### PR TITLE
Update CHANGES and NEWS for 1.1.1h release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1191,7 +1191,79 @@ OpenSSL 3.0
 OpenSSL 1.1.1
 -------------
 
-### Changes between 1.1.1e and 1.1.1f [xx XXX xxxx]
+### Changes between 1.1.1h and 1.1.1i [xx XXX xxxx]
+
+ *
+
+### Changes between 1.1.1g and 1.1.1h [22 Sep 2020]
+
+ * Certificates with explicit curve parameters are now disallowed in
+   verification chains if the X509_V_FLAG_X509_STRICT flag is used.
+   [Tomas Mraz]
+
+ * The 'MinProtocol' and 'MaxProtocol' configuration commands now silently
+   ignore TLS protocol version bounds when configuring DTLS-based contexts, and
+   conversely, silently ignore DTLS protocol version bounds when configuring
+   TLS-based contexts.  The commands can be repeated to set bounds of both
+   types.  The same applies with the corresponding "min_protocol" and
+   "max_protocol" command-line switches, in case some application uses both TLS
+   and DTLS.
+
+   SSL_CTX instances that are created for a fixed protocol version (e.g.
+   TLSv1_server_method()) also silently ignore version bounds.  Previously
+   attempts to apply bounds to these protocol versions would result in an
+   error.  Now only the "version-flexible" SSL_CTX instances are subject to
+   limits in configuration files in command-line options.
+   [Viktor Dukhovni]
+
+ * Handshake now fails if Extended Master Secret extension is dropped
+   on renegotiation.
+   *Tomas Mraz*
+
+ * The Oracle Developer Studio compiler will start reporting deprecated APIs
+
+### Changes between 1.1.1f and 1.1.1g [21 Apr 2020]
+
+ * Fixed segmentation fault in SSL_check_chain()
+   Server or client applications that call the SSL_check_chain() function
+   during or after a TLS 1.3 handshake may crash due to a NULL pointer
+   dereference as a result of incorrect handling of the
+   "signature_algorithms_cert" TLS extension. The crash occurs if an invalid
+   or unrecognised signature algorithm is received from the peer. This could
+   be exploited by a malicious peer in a Denial of Service attack.
+   [CVE-2020-1967][]
+
+   *Benjamin Kaduk*
+
+ * Added AES consttime code for no-asm configurations
+   an optional constant time support for AES was added
+   when building openssl for no-asm.
+   Enable with: ./config no-asm -DOPENSSL_AES_CONST_TIME
+   Disable with: ./config no-asm -DOPENSSL_NO_AES_CONST_TIME
+   At this time this feature is by default disabled.
+   It will be enabled by default in 3.0.
+
+   *Bernd Edlinger*
+
+### Changes between 1.1.1e and 1.1.1f [31 Mar 2020]
+
+ * Revert the change of EOF detection while reading in libssl to avoid
+   regressions in applications depending on the current way of reporting
+   the EOF. As the existing method is not fully accurate the change to
+   reporting the EOF via SSL_ERROR_SSL is kept on the current development
+   branch and will be present in the 3.0 release.
+
+   *Tomas Mraz*
+
+ * Revised BN_generate_prime_ex to not avoid factors 3..17863 in p-1
+   when primes for RSA keys are computed.
+   Since we previously always generated primes == 2 (mod 3) for RSA keys,
+   the 2-prime and 3-prime RSA modules were easy to distinguish, since
+   N = p*q = 1 (mod 3), but N = p*q*r = 2 (mod 3). Therefore fingerprinting
+   2-prime vs. 3-prime RSA keys was possible by computing N mod 3.
+   This avoids possible fingerprinting of newly generated RSA modules.
+
+   *Bernd Edlinger*
 
 ### Changes between 1.1.1d and 1.1.1e [17 Mar 2020]
 
@@ -18441,6 +18513,7 @@ ndif
 
 <!-- Links -->
 
+[CVE-2020-1967]: https://www.openssl.org/news/vulnerabilities.html#CVE-2020-1967
 [CVE-2019-1563]: https://www.openssl.org/news/vulnerabilities.html#CVE-2019-1563
 [CVE-2019-1559]: https://www.openssl.org/news/vulnerabilities.html#CVE-2019-1559
 [CVE-2019-1552]: https://www.openssl.org/news/vulnerabilities.html#CVE-2019-1552

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -604,7 +604,7 @@ OpenSSL 3.0
    have to re-use the DH512 private key, which is not recommended anyway.
    Also applications directly using the low level API BN_mod_exp may be
    affected if they use BN_FLG_CONSTTIME.
-   [CVE-2019-1551][]
+   ([CVE-2019-1551])
 
    *Andy Polyakov*
 
@@ -789,7 +789,7 @@ OpenSSL 3.0
    this change, EC_GROUP_set_generator would accept order and/or cofactor as
    NULL. After this change, only the cofactor parameter can be NULL. It also
    does some minimal sanity checks on the passed order.
-   [CVE-2019-1547][]
+   ([CVE-2019-1547])
 
    *Billy Bob Brumley*
 
@@ -1231,7 +1231,7 @@ OpenSSL 1.1.1
    "signature_algorithms_cert" TLS extension. The crash occurs if an invalid
    or unrecognised signature algorithm is received from the peer. This could
    be exploited by a malicious peer in a Denial of Service attack.
-   [CVE-2020-1967][]
+   ([CVE-2020-1967])
 
    *Benjamin Kaduk*
 
@@ -1333,7 +1333,7 @@ OpenSSL 1.1.1
 
    If an application already calls OPENSSL_init_crypto() explicitly using
    OPENSSL_INIT_ATFORK then this problem does not occur at all.
-   [CVE-2019-1549][]
+   ([CVE-2019-1549])
 
    *Matthias St. Pierre*
 
@@ -1353,7 +1353,7 @@ OpenSSL 1.1.1
    this change, EC_GROUP_set_generator would accept order and/or cofactor as
    NULL. After this change, only the cofactor parameter can be NULL. It also
    does some minimal sanity checks on the passed order.
-   [CVE-2019-1547][]
+   ([CVE-2019-1547])
 
    *Billy Bob Brumley*
 
@@ -1369,7 +1369,7 @@ OpenSSL 1.1.1
    certifiate is not given and all recipientInfo are tried out.
    The old behaviour can be re-enabled in the CMS code by setting the
    CMS_DEBUG_DECRYPT flag.
-   [CVE-2019-1563][]
+   ([CVE-2019-1563])
 
    *Bernd Edlinger*
 
@@ -1395,7 +1395,7 @@ OpenSSL 1.1.1
 
    Mingw isn't a POSIX environment per se, which means that Windows
    paths should be used for installation.
-   [CVE-2019-1552][]
+   ([CVE-2019-1552])
 
    *Richard Levitte*
 
@@ -1497,7 +1497,7 @@ OpenSSL 1.1.1
 
    This issue was reported to OpenSSL on 16th of March 2019 by Joran Dirk
    Greef of Ronomon.
-   [CVE-2019-1543][]
+   ([CVE-2019-1543])
 
    *Matt Caswell*
 
@@ -1538,7 +1538,7 @@ OpenSSL 1.1.1
    algorithm to recover the private key.
 
    This issue was reported to OpenSSL on 16th October 2018 by Samuel Weiser.
-   [CVE-2018-0734][]
+   ([CVE-2018-0734])
 
    *Paul Dale*
 
@@ -1549,7 +1549,7 @@ OpenSSL 1.1.1
    algorithm to recover the private key.
 
    This issue was reported to OpenSSL on 25th October 2018 by Samuel Weiser.
-   [CVE-2018-0735][]
+   ([CVE-2018-0735])
 
    *Paul Dale*
 
@@ -2123,7 +2123,7 @@ OpenSSL 1.1.0
    this change, EC_GROUP_set_generator would accept order and/or cofactor as
    NULL. After this change, only the cofactor parameter can be NULL. It also
    does some minimal sanity checks on the passed order.
-   [CVE-2019-1547][]
+   ([CVE-2019-1547])
 
    *Billy Bob Brumley*
 
@@ -2139,7 +2139,7 @@ OpenSSL 1.1.0
    certifiate is not given and all recipientInfo are tried out.
    The old behaviour can be re-enabled in the CMS code by setting the
    CMS_DEBUG_DECRYPT flag.
-   [CVE-2019-1563][]
+   ([CVE-2019-1563])
 
    *Bernd Edlinger*
 
@@ -2147,7 +2147,7 @@ OpenSSL 1.1.0
 
    Mingw isn't a POSIX environment per se, which means that Windows
    paths should be used for installation.
-   [CVE-2019-1552][]
+   ([CVE-2019-1552])
 
    *Richard Levitte*
 
@@ -2188,7 +2188,7 @@ OpenSSL 1.1.0
 
    This issue was reported to OpenSSL on 16th of March 2019 by Joran Dirk
    Greef of Ronomon.
-   [CVE-2019-1543][]
+   ([CVE-2019-1543])
 
    *Matt Caswell*
 
@@ -2223,7 +2223,7 @@ OpenSSL 1.1.0
    algorithm to recover the private key.
 
    This issue was reported to OpenSSL on 16th October 2018 by Samuel Weiser.
-   [CVE-2018-0734][]
+   ([CVE-2018-0734])
 
    *Paul Dale*
 
@@ -2234,7 +2234,7 @@ OpenSSL 1.1.0
    algorithm to recover the private key.
 
    This issue was reported to OpenSSL on 25th October 2018 by Samuel Weiser.
-   [CVE-2018-0735][]
+   ([CVE-2018-0735])
 
    *Paul Dale*
 
@@ -2255,7 +2255,7 @@ OpenSSL 1.1.0
    could be exploited in a Denial Of Service attack.
 
    This issue was reported to OpenSSL on 5th June 2018 by Guido Vranken
-   [CVE-2018-0732][]
+   ([CVE-2018-0732])
 
    *Guido Vranken*
 
@@ -2268,7 +2268,7 @@ OpenSSL 1.1.0
 
    This issue was reported to OpenSSL on 4th April 2018 by Alejandro Cabrera
    Aldaya, Billy Brumley, Cesar Pereida Garcia and Luis Manuel Alvarez Tapia.
-   [CVE-2018-0737][]
+   ([CVE-2018-0737])
 
    *Billy Brumley*
 
@@ -2341,7 +2341,7 @@ OpenSSL 1.1.0
 
    This issue was reported to OpenSSL on 4th January 2018 by the OSS-fuzz
    project.
-   [CVE-2018-0739][]
+   ([CVE-2018-0739])
 
    *Matt Caswell*
 
@@ -2356,7 +2356,7 @@ OpenSSL 1.1.0
 
    This issue was reported to OpenSSL on 2nd March 2018 by Peter Waltenberg
    (IBM).
-   [CVE-2018-0733][]
+   ([CVE-2018-0733])
 
    *Andy Polyakov*
 
@@ -2404,7 +2404,7 @@ OpenSSL 1.1.0
 
    This issue was reported to OpenSSL by David Benjamin (Google). The issue
    was originally found via the OSS-Fuzz project.
-   [CVE-2017-3738][]
+   ([CVE-2017-3738])
 
    *Andy Polyakov*
 
@@ -2428,7 +2428,7 @@ OpenSSL 1.1.0
    like Intel Broadwell (5th generation) and later or AMD Ryzen.
 
    This issue was reported to OpenSSL by the OSS-Fuzz project.
-   [CVE-2017-3736][]
+   ([CVE-2017-3736])
 
    *Andy Polyakov*
 
@@ -2439,7 +2439,7 @@ OpenSSL 1.1.0
    would be an erroneous display of the certificate in text format.
 
    This issue was reported to OpenSSL by the OSS-Fuzz project.
-   [CVE-2017-3735][]
+   ([CVE-2017-3735])
 
    *Rich Salz*
 
@@ -2466,7 +2466,7 @@ OpenSSL 1.1.0
    and servers are affected.
 
    This issue was reported to OpenSSL by Joe Orton (Red Hat).
-   [CVE-2017-3733][]
+   ([CVE-2017-3733])
 
    *Matt Caswell*
 
@@ -2479,7 +2479,7 @@ OpenSSL 1.1.0
    perform an out-of-bounds read, usually resulting in a crash.
 
    This issue was reported to OpenSSL by Robert Święcki of Google.
-   [CVE-2017-3731][]
+   ([CVE-2017-3731])
 
    *Andy Polyakov*
 
@@ -2491,7 +2491,7 @@ OpenSSL 1.1.0
    of Service attack.
 
    This issue was reported to OpenSSL by Guido Vranken.
-   [CVE-2017-3730][]
+   ([CVE-2017-3730])
 
    *Matt Caswell*
 
@@ -2512,7 +2512,7 @@ OpenSSL 1.1.0
    similar to CVE-2015-3193 but must be treated as a separate problem.
 
    This issue was reported to OpenSSL by the OSS-Fuzz project.
-   [CVE-2017-3732][]
+   ([CVE-2017-3732])
 
    *Andy Polyakov*
 
@@ -2525,7 +2525,7 @@ OpenSSL 1.1.0
    crash. This issue is not considered to be exploitable beyond a DoS.
 
    This issue was reported to OpenSSL by Robert Święcki (Google Security Team)
-   [CVE-2016-7054][]
+   ([CVE-2016-7054])
 
    *Richard Levitte*
 
@@ -2539,7 +2539,7 @@ OpenSSL 1.1.0
    affected.
 
    This issue was reported to OpenSSL by Tyler Nighswander of ForAllSecure.
-   [CVE-2016-7053][]
+   ([CVE-2016-7053])
 
    *Stephen Henson*
 
@@ -2563,7 +2563,7 @@ OpenSSL 1.1.0
    This issue was publicly reported as transient failures and was not
    initially recognized as a security issue. Thanks to Richard Morgan for
    providing reproducible case.
-   [CVE-2016-7055][]
+   ([CVE-2016-7055])
 
    *Andy Polyakov*
 
@@ -2586,7 +2586,7 @@ OpenSSL 1.1.0
    This issue only affects OpenSSL 1.1.0a.
 
    This issue was reported to OpenSSL by Robert Święcki.
-   [CVE-2016-6309][]
+   ([CVE-2016-6309])
 
    *Matt Caswell*
 
@@ -2603,7 +2603,7 @@ OpenSSL 1.1.0
    the "no-ocsp" build time option are not affected.
 
    This issue was reported to OpenSSL by Shi Lei (Gear Team, Qihoo 360 Inc.)
-   [CVE-2016-6304][]
+   ([CVE-2016-6304])
 
    *Matt Caswell*
 
@@ -2614,7 +2614,7 @@ OpenSSL 1.1.0
    Denial Of Service attack.
 
    This issue was reported to OpenSSL by Alex Gaynor.
-   [CVE-2016-6305][]
+   ([CVE-2016-6305])
 
    *Matt Caswell*
 
@@ -2680,7 +2680,7 @@ OpenSSL 1.1.0
 
    *Andy Polyakov*
 
- * To mitigate the SWEET32 attack [CVE-2016-2183][], 3DES cipher suites
+ * To mitigate the SWEET32 attack ([CVE-2016-2183]), 3DES cipher suites
    have been disabled by default and removed from DEFAULT, just like RC4.
    See the RC4 item below to re-enable both.
 
@@ -2931,7 +2931,7 @@ OpenSSL 1.1.0
 
  * Deprecate SRP_VBASE_get_by_user.
    SRP_VBASE_get_by_user had inconsistent memory management behaviour.
-   In order to fix an unavoidable memory leak [CVE-2016-0798][],
+   In order to fix an unavoidable memory leak ([CVE-2016-0798]),
    SRP_VBASE_get_by_user was changed to ignore the "fake user" SRP
    seed, even if the seed is configured.
 
@@ -3573,7 +3573,7 @@ OpenSSL 1.1.0
 
    Thanks for Neel Mehta of Google Security for discovering this bug and to
    Adam Langley <agl@chromium.org> and Bodo Moeller <bmoeller@acm.org> for
-   preparing the fix [CVE-2014-0160][]
+   preparing the fix ([CVE-2014-0160])
 
    *Adam Langley, Bodo Moeller*
 
@@ -3583,7 +3583,7 @@ OpenSSL 1.1.0
    <http://eprint.iacr.org/2014/140>
 
    Thanks to Yuval Yarom and Naomi Benger for discovering this
-   flaw and to Yuval Yarom for supplying a fix [CVE-2014-0076][]
+   flaw and to Yuval Yarom for supplying a fix ([CVE-2014-0076])
 
    *Yuval Yarom and Naomi Benger*
 
@@ -3920,7 +3920,7 @@ OpenSSL 1.0.2
    this change, EC_GROUP_set_generator would accept order and/or cofactor as
    NULL. After this change, only the cofactor parameter can be NULL. It also
    does some minimal sanity checks on the passed order.
-   [CVE-2019-1547][]
+   ([CVE-2019-1547])
 
    *Billy Bob Brumley*
 
@@ -3936,7 +3936,7 @@ OpenSSL 1.0.2
    certifiate is not given and all recipientInfo are tried out.
    The old behaviour can be re-enabled in the CMS code by setting the
    CMS_DEBUG_DECRYPT flag.
-   [CVE-2019-1563][]
+   ([CVE-2019-1563])
 
    *Bernd Edlinger*
 
@@ -3944,7 +3944,7 @@ OpenSSL 1.0.2
 
    '/usr/local/ssl' is an unsafe prefix for location to install OpenSSL
    binaries and run-time config file.
-   [CVE-2019-1552][]
+   ([CVE-2019-1552])
 
    *Richard Levitte*
 
@@ -3988,7 +3988,7 @@ OpenSSL 1.0.2
    This issue was discovered by Juraj Somorovsky, Robert Merget and Nimrod
    Aviram, with additional investigation by Steven Collison and Andrew
    Hourselt. It was reported to OpenSSL on 10th December 2018.
-   [CVE-2019-1559][]
+   ([CVE-2019-1559])
 
    *Matt Caswell*
 
@@ -4008,7 +4008,7 @@ OpenSSL 1.0.2
    This issue was reported to OpenSSL on 26th October 2018 by Alejandro
    Cabrera Aldaya, Billy Brumley, Sohaib ul Hassan, Cesar Pereida Garcia and
    Nicola Tuveri.
-   [CVE-2018-5407][]
+   ([CVE-2018-5407])
 
    *Billy Brumley*
 
@@ -4019,7 +4019,7 @@ OpenSSL 1.0.2
    algorithm to recover the private key.
 
    This issue was reported to OpenSSL on 16th October 2018 by Samuel Weiser.
-   [CVE-2018-0734][]
+   ([CVE-2018-0734])
 
    *Paul Dale*
 
@@ -4040,7 +4040,7 @@ OpenSSL 1.0.2
    could be exploited in a Denial Of Service attack.
 
    This issue was reported to OpenSSL on 5th June 2018 by Guido Vranken
-   [CVE-2018-0732][]
+   ([CVE-2018-0732])
 
    *Guido Vranken*
 
@@ -4053,7 +4053,7 @@ OpenSSL 1.0.2
 
    This issue was reported to OpenSSL on 4th April 2018 by Alejandro Cabrera
    Aldaya, Billy Brumley, Cesar Pereida Garcia and Luis Manuel Alvarez Tapia.
-   [CVE-2018-0737][]
+   ([CVE-2018-0737])
 
    *Billy Brumley*
 
@@ -4108,7 +4108,7 @@ OpenSSL 1.0.2
 
    This issue was reported to OpenSSL on 4th January 2018 by the OSS-fuzz
    project.
-   [CVE-2018-0739][]
+   ([CVE-2018-0739])
 
    *Matt Caswell*
 
@@ -4133,7 +4133,7 @@ OpenSSL 1.0.2
    already received a fatal error.
 
    This issue was reported to OpenSSL by David Benjamin (Google).
-   [CVE-2017-3737][]
+   ([CVE-2017-3737])
 
    *Matt Caswell*
 
@@ -4155,7 +4155,7 @@ OpenSSL 1.0.2
 
    This issue was reported to OpenSSL by David Benjamin (Google). The issue
    was originally found via the OSS-Fuzz project.
-   [CVE-2017-3738][]
+   ([CVE-2017-3738])
 
    *Andy Polyakov*
 
@@ -4179,7 +4179,7 @@ OpenSSL 1.0.2
    like Intel Broadwell (5th generation) and later or AMD Ryzen.
 
    This issue was reported to OpenSSL by the OSS-Fuzz project.
-   [CVE-2017-3736][]
+   ([CVE-2017-3736])
 
    *Andy Polyakov*
 
@@ -4190,7 +4190,7 @@ OpenSSL 1.0.2
    would be an erroneous display of the certificate in text format.
 
    This issue was reported to OpenSSL by the OSS-Fuzz project.
-   [CVE-2017-3735][]
+   ([CVE-2017-3735])
 
    *Rich Salz*
 
@@ -4210,7 +4210,7 @@ OpenSSL 1.0.2
    perform an out-of-bounds read, usually resulting in a crash.
 
    This issue was reported to OpenSSL by Robert Święcki of Google.
-   [CVE-2017-3731][]
+   ([CVE-2017-3731])
 
    *Andy Polyakov*
 
@@ -4231,7 +4231,7 @@ OpenSSL 1.0.2
    similar to CVE-2015-3193 but must be treated as a separate problem.
 
    This issue was reported to OpenSSL by the OSS-Fuzz project.
-   [CVE-2017-3732][]
+   ([CVE-2017-3732])
 
    *Andy Polyakov*
 
@@ -4255,7 +4255,7 @@ OpenSSL 1.0.2
    This issue was publicly reported as transient failures and was not
    initially recognized as a security issue. Thanks to Richard Morgan for
    providing reproducible case.
-   [CVE-2016-7055][]
+   ([CVE-2016-7055])
 
    *Andy Polyakov*
 
@@ -4275,7 +4275,7 @@ OpenSSL 1.0.2
    CRLs in OpenSSL 1.0.2i will crash with a null pointer exception.
 
    This issue only affects the OpenSSL 1.0.2i
-   [CVE-2016-7052][]
+   ([CVE-2016-7052])
 
    *Matt Caswell*
 
@@ -4292,7 +4292,7 @@ OpenSSL 1.0.2
    the "no-ocsp" build time option are not affected.
 
    This issue was reported to OpenSSL by Shi Lei (Gear Team, Qihoo 360 Inc.)
-   [CVE-2016-6304][]
+   ([CVE-2016-6304])
 
    *Matt Caswell*
 
@@ -4301,7 +4301,7 @@ OpenSSL 1.0.2
 
    This issue was reported to OpenSSL Karthikeyan Bhargavan and Gaetan
    Leurent (INRIA)
-   [CVE-2016-2183][]
+   ([CVE-2016-2183])
 
    *Rich Salz*
 
@@ -4317,7 +4317,7 @@ OpenSSL 1.0.2
    on most platforms.
 
    This issue was reported to OpenSSL by Shi Lei (Gear Team, Qihoo 360 Inc.)
-   [CVE-2016-6303][]
+   ([CVE-2016-6303])
 
    *Stephen Henson*
 
@@ -4331,7 +4331,7 @@ OpenSSL 1.0.2
    a custom server callback and ticket lookup mechanism.
 
    This issue was reported to OpenSSL by Shi Lei (Gear Team, Qihoo 360 Inc.)
-   [CVE-2016-6302][]
+   ([CVE-2016-6302])
 
    *Stephen Henson*
 
@@ -4344,7 +4344,7 @@ OpenSSL 1.0.2
    record limits will reject an oversized certificate before it is parsed.
 
    This issue was reported to OpenSSL by Shi Lei (Gear Team, Qihoo 360 Inc.)
-   [CVE-2016-2182][]
+   ([CVE-2016-2182])
 
    *Stephen Henson*
 
@@ -4356,7 +4356,7 @@ OpenSSL 1.0.2
    presented.
 
    This issue was reported to OpenSSL by Shi Lei (Gear Team, Qihoo 360 Inc.)
-   [CVE-2016-2180][]
+   ([CVE-2016-2180])
 
    *Stephen Henson*
 
@@ -4382,7 +4382,7 @@ OpenSSL 1.0.2
    values of len that are too big and therefore p + len < limit.
 
    This issue was reported to OpenSSL by Guido Vranken
-   [CVE-2016-2177][]
+   ([CVE-2016-2177])
 
    *Matt Caswell*
 
@@ -4397,7 +4397,7 @@ OpenSSL 1.0.2
    This issue was reported by César Pereida (Aalto University), Billy Brumley
    (Tampere University of Technology), and Yuval Yarom (The University of
    Adelaide and NICTA).
-   [CVE-2016-2178][]
+   ([CVE-2016-2178])
 
    *César Pereida*
 
@@ -4415,7 +4415,7 @@ OpenSSL 1.0.2
    attacker could cause a DoS attack through memory exhaustion.
 
    This issue was reported to OpenSSL by Quan Luo.
-   [CVE-2016-2179][]
+   ([CVE-2016-2179])
 
    *Matt Caswell*
 
@@ -4430,7 +4430,7 @@ OpenSSL 1.0.2
    service for a specific DTLS connection.
 
    This issue was reported to OpenSSL by the OCAP audit team.
-   [CVE-2016-2181][]
+   ([CVE-2016-2181])
 
    *Matt Caswell*
 
@@ -4446,7 +4446,7 @@ OpenSSL 1.0.2
    against a client or a server which enables client authentication.
 
    This issue was reported to OpenSSL by Shi Lei (Gear Team, Qihoo 360 Inc.)
-   [CVE-2016-6306][]
+   ([CVE-2016-6306])
 
    *Stephen Henson*
 
@@ -4459,14 +4459,14 @@ OpenSSL 1.0.2
    AES-NI.
 
    This issue was introduced as part of the fix for Lucky 13 padding
-   attack [CVE-2013-0169][]. The padding check was rewritten to be in
+   attack ([CVE-2013-0169]). The padding check was rewritten to be in
    constant time by making sure that always the same bytes are read and
    compared against either the MAC or padding bytes. But it no longer
    checked that there was enough data to have both the MAC and padding
    bytes.
 
    This issue was reported by Juraj Somorovsky using TLS-Attacker.
-   [CVE-2016-2107][]
+   ([CVE-2016-2107])
 
    *Kurt Roeckx*
 
@@ -4485,7 +4485,7 @@ OpenSSL 1.0.2
    with large amounts of untrusted data may also be vulnerable.
 
    This issue was reported by Guido Vranken.
-   [CVE-2016-2105][]
+   ([CVE-2016-2105])
 
    *Matt Caswell*
 
@@ -4509,7 +4509,7 @@ OpenSSL 1.0.2
    instances in internal usage where an overflow could occur.
 
    This issue was reported by Guido Vranken.
-   [CVE-2016-2106][]
+   ([CVE-2016-2106])
 
    *Matt Caswell*
 
@@ -4525,7 +4525,7 @@ OpenSSL 1.0.2
    applications are not affected.
 
    This issue was reported by Brian Carpenter.
-   [CVE-2016-2109][]
+   ([CVE-2016-2109])
 
    *Stephen Henson*
 
@@ -4536,7 +4536,7 @@ OpenSSL 1.0.2
    in arbitrary stack data being returned in the buffer.
 
    This issue was reported by Guido Vranken.
-   [CVE-2016-2176][]
+   ([CVE-2016-2176])
 
    *Matt Caswell*
 
@@ -4578,7 +4578,7 @@ OpenSSL 1.0.2
   server variants, SSLv2 ciphers vulnerable to exhaustive search key
   recovery have been removed.  Specifically, the SSLv2 40-bit EXPORT
   ciphers, and SSLv2 56-bit DES are no longer available.
-  [CVE-2016-0800][]
+  ([CVE-2016-0800])
 
    *Viktor Dukhovni*
 
@@ -4591,7 +4591,7 @@ OpenSSL 1.0.2
 
    This issue was reported to OpenSSL by Adam Langley(Google/BoringSSL) using
    libFuzzer.
-   [CVE-2016-0705][]
+   ([CVE-2016-0705])
 
    *Stephen Henson*
 
@@ -4611,7 +4611,7 @@ OpenSSL 1.0.2
    credentials, this behaviour is not constant time and no strong
    guarantees are made that the handshake is indistinguishable from
    that of a valid user.
-   [CVE-2016-0798][]
+   ([CVE-2016-0798])
 
    *Emilia Käsper*
 
@@ -4636,7 +4636,7 @@ OpenSSL 1.0.2
    consequences. This is also anticipated to be rare.
 
    This issue was reported to OpenSSL by Guido Vranken.
-   [CVE-2016-0797][]
+   ([CVE-2016-0797])
 
    *Matt Caswell*
 
@@ -4668,7 +4668,7 @@ OpenSSL 1.0.2
    trigger these issues because of message size limits enforced within libssl.
 
    This issue was reported to OpenSSL Guido Vranken.
-   [CVE-2016-0799][]
+   ([CVE-2016-0799])
 
    *Matt Caswell*
 
@@ -4684,7 +4684,7 @@ OpenSSL 1.0.2
    Adelaide and NICTA, Daniel Genkin, Technion and Tel Aviv University, and
    Nadia Heninger, University of Pennsylvania with more information at
    <http://cachebleed.info>.
-   [CVE-2016-0702][]
+   ([CVE-2016-0702])
 
    *Andy Polyakov*
 
@@ -4725,7 +4725,7 @@ OpenSSL 1.0.2
    default and cannot be disabled. This could have some performance impact.
 
    This issue was reported to OpenSSL by Antonio Sanso (Adobe).
-   [CVE-2016-0701][]
+   ([CVE-2016-0701])
 
    *Matt Caswell*
 
@@ -4738,7 +4738,7 @@ OpenSSL 1.0.2
 
    This issue was reported to OpenSSL on 26th December 2015 by Nimrod Aviram
    and Sebastian Schinzel.
-   [CVE-2015-3197][]
+   ([CVE-2015-3197])
 
    *Viktor Dukhovni*
 
@@ -4760,7 +4760,7 @@ OpenSSL 1.0.2
    default in OpenSSL DHE based SSL/TLS ciphersuites.
 
    This issue was reported to OpenSSL by Hanno Böck.
-   [CVE-2015-3193][]
+   ([CVE-2015-3193])
 
    *Andy Polyakov*
 
@@ -4776,7 +4776,7 @@ OpenSSL 1.0.2
    authentication.
 
    This issue was reported to OpenSSL by Loïc Jonas Etienne (Qnective AG).
-   [CVE-2015-3194][]
+   ([CVE-2015-3194])
 
    *Stephen Henson*
 
@@ -4789,7 +4789,7 @@ OpenSSL 1.0.2
 
    This issue was reported to OpenSSL by Adam Langley (Google/BoringSSL) using
    libFuzzer.
-   [CVE-2015-3195][]
+   ([CVE-2015-3195])
 
    *Stephen Henson*
 
@@ -4843,7 +4843,7 @@ OpenSSL 1.0.2
    client authentication enabled.
 
    This issue was reported to OpenSSL by Joseph Barr-Pixton.
-   [CVE-2015-1788][]
+   ([CVE-2015-1788])
 
    *Andy Polyakov*
 
@@ -4863,7 +4863,7 @@ OpenSSL 1.0.2
 
    This issue was reported to OpenSSL by Robert Swiecki (Google), and
    independently by Hanno Böck.
-   [CVE-2015-1789][]
+   ([CVE-2015-1789])
 
    *Emilia Käsper*
 
@@ -4878,7 +4878,7 @@ OpenSSL 1.0.2
    servers are not affected.
 
    This issue was reported to OpenSSL by Michal Zalewski (Google).
-   [CVE-2015-1790][]
+   ([CVE-2015-1790])
 
    *Emilia Käsper*
 
@@ -4889,7 +4889,7 @@ OpenSSL 1.0.2
    denial of service against any system which verifies signedData messages using
    the CMS code.
    This issue was reported to OpenSSL by Johannes Bauer.
-   [CVE-2015-1792][]
+   ([CVE-2015-1792])
 
    *Stephen Henson*
 
@@ -4898,7 +4898,7 @@ OpenSSL 1.0.2
    If a NewSessionTicket is received by a multi-threaded client when attempting to
    reuse a previous ticket then a race condition can occur potentially leading to
    a double free of the ticket data.
-   [CVE-2015-1791][]
+   ([CVE-2015-1791])
 
    *Matt Caswell*
 
@@ -4918,7 +4918,7 @@ OpenSSL 1.0.2
 
    This issue was was reported to OpenSSL by David Ramos of Stanford
    University.
-   [CVE-2015-0291][]
+   ([CVE-2015-0291])
 
    *Stephen Henson and Matt Caswell*
 
@@ -4934,7 +4934,7 @@ OpenSSL 1.0.2
    fault will be triggered, thus enabling a potential DoS attack.
 
    This issue was reported to OpenSSL by Daniel Danner and Rainer Mueller.
-   [CVE-2015-0290][]
+   ([CVE-2015-0290])
 
    *Matt Caswell*
 
@@ -4951,7 +4951,7 @@ OpenSSL 1.0.2
    server.
 
    This issue was reported to OpenSSL by Per Allansson.
-   [CVE-2015-0207][]
+   ([CVE-2015-0207])
 
    *Matt Caswell*
 
@@ -4963,7 +4963,7 @@ OpenSSL 1.0.2
    certificate verification operation and exploited in a DoS attack. Any
    application which performs certificate verification is vulnerable including
    OpenSSL clients and servers which enable client authentication.
-   [CVE-2015-0286][]
+   ([CVE-2015-0286])
 
    *Stephen Henson*
 
@@ -4978,7 +4978,7 @@ OpenSSL 1.0.2
    OpenSSL clients and servers which enable client authentication.
 
    This issue was was reported to OpenSSL by Brian Carpenter.
-   [CVE-2015-0208][]
+   ([CVE-2015-0208])
 
    *Stephen Henson*
 
@@ -4992,7 +4992,7 @@ OpenSSL 1.0.2
    components may be affected. Certificate parsing (d2i_X509 and related
    functions) are however not affected. OpenSSL clients and servers are
    not affected.
-   [CVE-2015-0287][]
+   ([CVE-2015-0287])
 
    *Stephen Henson*
 
@@ -5007,7 +5007,7 @@ OpenSSL 1.0.2
    affected. OpenSSL clients and servers are not affected.
 
    This issue was reported to OpenSSL by Michal Zalewski (Google).
-   [CVE-2015-0289][]
+   ([CVE-2015-0289])
 
    *Emilia Käsper*
 
@@ -5019,7 +5019,7 @@ OpenSSL 1.0.2
 
    This issue was discovered by Sean Burford (Google) and Emilia Käsper
    (OpenSSL development team).
-   [CVE-2015-0293][]
+   ([CVE-2015-0293])
 
    *Emilia Käsper*
 
@@ -5028,7 +5028,7 @@ OpenSSL 1.0.2
    If client auth is used then a server can seg fault in the event of a DHE
    ciphersuite being selected and a zero length ClientKeyExchange message
    being sent by the client. This could be exploited in a DoS attack.
-   [CVE-2015-1787][]
+   ([CVE-2015-1787])
 
    *Matt Caswell*
 
@@ -5051,7 +5051,7 @@ OpenSSL 1.0.2
    succeed on an unpatched platform:
 
    openssl s_client -psk 1a2b3c4d -tls1_2 -cipher PSK-RC4-SHA
-   [CVE-2015-0285][]
+   ([CVE-2015-0285])
 
    *Matt Caswell*
 
@@ -5066,7 +5066,7 @@ OpenSSL 1.0.2
 
    This issue was discovered by the BoringSSL project and fixed in their
    commit 517073cd4b.
-   [CVE-2015-0209][]
+   ([CVE-2015-0209])
 
    *Matt Caswell*
 
@@ -5076,7 +5076,7 @@ OpenSSL 1.0.2
    the certificate key is invalid. This function is rarely used in practice.
 
    This issue was discovered by Brian Carpenter.
-   [CVE-2015-0288][]
+   ([CVE-2015-0288])
 
    *Stephen Henson*
 
@@ -5494,7 +5494,7 @@ OpenSSL 1.0.1
    the "no-ocsp" build time option are not affected.
 
    This issue was reported to OpenSSL by Shi Lei (Gear Team, Qihoo 360 Inc.)
-   [CVE-2016-6304][]
+   ([CVE-2016-6304])
 
    *Matt Caswell*
 
@@ -5503,7 +5503,7 @@ OpenSSL 1.0.1
 
    This issue was reported to OpenSSL Karthikeyan Bhargavan and Gaetan
    Leurent (INRIA)
-   [CVE-2016-2183][]
+   ([CVE-2016-2183])
 
    *Rich Salz*
 
@@ -5519,7 +5519,7 @@ OpenSSL 1.0.1
    on most platforms.
 
    This issue was reported to OpenSSL by Shi Lei (Gear Team, Qihoo 360 Inc.)
-   [CVE-2016-6303][]
+   ([CVE-2016-6303])
 
    *Stephen Henson*
 
@@ -5533,7 +5533,7 @@ OpenSSL 1.0.1
    a custom server callback and ticket lookup mechanism.
 
    This issue was reported to OpenSSL by Shi Lei (Gear Team, Qihoo 360 Inc.)
-   [CVE-2016-6302][]
+   ([CVE-2016-6302])
 
    *Stephen Henson*
 
@@ -5546,7 +5546,7 @@ OpenSSL 1.0.1
    record limits will reject an oversized certificate before it is parsed.
 
    This issue was reported to OpenSSL by Shi Lei (Gear Team, Qihoo 360 Inc.)
-   [CVE-2016-2182][]
+   ([CVE-2016-2182])
 
    *Stephen Henson*
 
@@ -5558,7 +5558,7 @@ OpenSSL 1.0.1
    presented.
 
    This issue was reported to OpenSSL by Shi Lei (Gear Team, Qihoo 360 Inc.)
-   [CVE-2016-2180][]
+   ([CVE-2016-2180])
 
    *Stephen Henson*
 
@@ -5584,7 +5584,7 @@ OpenSSL 1.0.1
    values of len that are too big and therefore p + len < limit.
 
    This issue was reported to OpenSSL by Guido Vranken
-   [CVE-2016-2177][]
+   ([CVE-2016-2177])
 
    *Matt Caswell*
 
@@ -5599,7 +5599,7 @@ OpenSSL 1.0.1
    This issue was reported by César Pereida (Aalto University), Billy Brumley
    (Tampere University of Technology), and Yuval Yarom (The University of
    Adelaide and NICTA).
-   [CVE-2016-2178][]
+   ([CVE-2016-2178])
 
    *César Pereida*
 
@@ -5617,7 +5617,7 @@ OpenSSL 1.0.1
    attacker could cause a DoS attack through memory exhaustion.
 
    This issue was reported to OpenSSL by Quan Luo.
-   [CVE-2016-2179][]
+   ([CVE-2016-2179])
 
    *Matt Caswell*
 
@@ -5632,7 +5632,7 @@ OpenSSL 1.0.1
    service for a specific DTLS connection.
 
    This issue was reported to OpenSSL by the OCAP audit team.
-   [CVE-2016-2181][]
+   ([CVE-2016-2181])
 
    *Matt Caswell*
 
@@ -5648,7 +5648,7 @@ OpenSSL 1.0.1
    against a client or a server which enables client authentication.
 
    This issue was reported to OpenSSL by Shi Lei (Gear Team, Qihoo 360 Inc.)
-   [CVE-2016-6306][]
+   ([CVE-2016-6306])
 
    *Stephen Henson*
 
@@ -5661,14 +5661,14 @@ OpenSSL 1.0.1
    AES-NI.
 
    This issue was introduced as part of the fix for Lucky 13 padding
-   attack [CVE-2013-0169][]. The padding check was rewritten to be in
+   attack ([CVE-2013-0169]). The padding check was rewritten to be in
    constant time by making sure that always the same bytes are read and
    compared against either the MAC or padding bytes. But it no longer
    checked that there was enough data to have both the MAC and padding
    bytes.
 
    This issue was reported by Juraj Somorovsky using TLS-Attacker.
-   [CVE-2016-2107][]
+   ([CVE-2016-2107])
 
    *Kurt Roeckx*
 
@@ -5687,7 +5687,7 @@ OpenSSL 1.0.1
    with large amounts of untrusted data may also be vulnerable.
 
    This issue was reported by Guido Vranken.
-   [CVE-2016-2105][]
+   ([CVE-2016-2105])
 
    *Matt Caswell*
 
@@ -5711,7 +5711,7 @@ OpenSSL 1.0.1
    instances in internal usage where an overflow could occur.
 
    This issue was reported by Guido Vranken.
-   [CVE-2016-2106][]
+   ([CVE-2016-2106])
 
    *Matt Caswell*
 
@@ -5727,7 +5727,7 @@ OpenSSL 1.0.1
    applications are not affected.
 
    This issue was reported by Brian Carpenter.
-   [CVE-2016-2109][]
+   ([CVE-2016-2109])
 
    *Stephen Henson*
 
@@ -5738,7 +5738,7 @@ OpenSSL 1.0.1
    in arbitrary stack data being returned in the buffer.
 
    This issue was reported by Guido Vranken.
-   [CVE-2016-2176][]
+   ([CVE-2016-2176])
 
    *Matt Caswell*
 
@@ -5780,7 +5780,7 @@ OpenSSL 1.0.1
   server variants, SSLv2 ciphers vulnerable to exhaustive search key
   recovery have been removed.  Specifically, the SSLv2 40-bit EXPORT
   ciphers, and SSLv2 56-bit DES are no longer available.
-  [CVE-2016-0800][]
+  ([CVE-2016-0800])
 
   *Viktor Dukhovni*
 
@@ -5793,7 +5793,7 @@ OpenSSL 1.0.1
 
    This issue was reported to OpenSSL by Adam Langley(Google/BoringSSL) using
    libFuzzer.
-   [CVE-2016-0705][]
+   ([CVE-2016-0705])
 
    *Stephen Henson*
 
@@ -5813,7 +5813,7 @@ OpenSSL 1.0.1
    credentials, this behaviour is not constant time and no strong
    guarantees are made that the handshake is indistinguishable from
    that of a valid user.
-   [CVE-2016-0798][]
+   ([CVE-2016-0798])
 
    *Emilia Käsper*
 
@@ -5838,7 +5838,7 @@ OpenSSL 1.0.1
    consequences. This is also anticipated to be rare.
 
    This issue was reported to OpenSSL by Guido Vranken.
-   [CVE-2016-0797][]
+   ([CVE-2016-0797])
 
    *Matt Caswell*
 
@@ -5870,7 +5870,7 @@ OpenSSL 1.0.1
    trigger these issues because of message size limits enforced within libssl.
 
    This issue was reported to OpenSSL Guido Vranken.
-   [CVE-2016-0799][]
+   ([CVE-2016-0799])
 
    *Matt Caswell*
 
@@ -5886,7 +5886,7 @@ OpenSSL 1.0.1
    Adelaide and NICTA, Daniel Genkin, Technion and Tel Aviv University, and
    Nadia Heninger, University of Pennsylvania with more information at
    <http://cachebleed.info>.
-   [CVE-2016-0702][]
+   ([CVE-2016-0702])
 
    *Andy Polyakov*
 
@@ -5916,7 +5916,7 @@ OpenSSL 1.0.1
 
    This issue was reported to OpenSSL on 26th December 2015 by Nimrod Aviram
    and Sebastian Schinzel.
-   [CVE-2015-3197][]
+   ([CVE-2015-3197])
 
    *Viktor Dukhovni*
 
@@ -5938,7 +5938,7 @@ OpenSSL 1.0.1
    authentication.
 
    This issue was reported to OpenSSL by Loïc Jonas Etienne (Qnective AG).
-   [CVE-2015-3194][]
+   ([CVE-2015-3194])
 
    *Stephen Henson*
 
@@ -5951,7 +5951,7 @@ OpenSSL 1.0.1
 
    This issue was reported to OpenSSL by Adam Langley (Google/BoringSSL) using
    libFuzzer.
-   [CVE-2015-3195][]
+   ([CVE-2015-3195])
 
    *Stephen Henson*
 
@@ -5980,7 +5980,7 @@ OpenSSL 1.0.1
 
    This issue was reported to OpenSSL by Adam Langley/David Benjamin
    (Google/BoringSSL).
-   [CVE-2015-1793][]
+   ([CVE-2015-1793])
 
    *Matt Caswell*
 
@@ -5990,7 +5990,7 @@ OpenSSL 1.0.1
    the values are wrongly updated in the parent SSL_CTX structure. This can
    result in a race condition potentially leading to a double free of the
    identify hint data.
-   [CVE-2015-3196][]
+   ([CVE-2015-3196])
 
    *Stephen Henson*
 
@@ -6014,7 +6014,7 @@ OpenSSL 1.0.1
    client authentication enabled.
 
    This issue was reported to OpenSSL by Joseph Barr-Pixton.
-   [CVE-2015-1788][]
+   ([CVE-2015-1788])
 
    *Andy Polyakov*
 
@@ -6034,7 +6034,7 @@ OpenSSL 1.0.1
 
    This issue was reported to OpenSSL by Robert Swiecki (Google), and
    independently by Hanno Böck.
-   [CVE-2015-1789][]
+   ([CVE-2015-1789])
 
    *Emilia Käsper*
 
@@ -6049,7 +6049,7 @@ OpenSSL 1.0.1
    servers are not affected.
 
    This issue was reported to OpenSSL by Michal Zalewski (Google).
-   [CVE-2015-1790][]
+   ([CVE-2015-1790])
 
    *Emilia Käsper*
 
@@ -6060,7 +6060,7 @@ OpenSSL 1.0.1
    denial of service against any system which verifies signedData messages using
    the CMS code.
    This issue was reported to OpenSSL by Johannes Bauer.
-   [CVE-2015-1792][]
+   ([CVE-2015-1792])
 
    *Stephen Henson*
 
@@ -6069,7 +6069,7 @@ OpenSSL 1.0.1
    If a NewSessionTicket is received by a multi-threaded client when attempting to
    reuse a previous ticket then a race condition can occur potentially leading to
    a double free of the ticket data.
-   [CVE-2015-1791][]
+   ([CVE-2015-1791])
 
    *Matt Caswell*
 
@@ -6091,7 +6091,7 @@ OpenSSL 1.0.1
    certificate verification operation and exploited in a DoS attack. Any
    application which performs certificate verification is vulnerable including
    OpenSSL clients and servers which enable client authentication.
-   [CVE-2015-0286][]
+   ([CVE-2015-0286])
 
    *Stephen Henson*
 
@@ -6105,7 +6105,7 @@ OpenSSL 1.0.1
    components may be affected. Certificate parsing (d2i_X509 and related
    functions) are however not affected. OpenSSL clients and servers are
    not affected.
-   [CVE-2015-0287][]
+   ([CVE-2015-0287])
 
    *Stephen Henson*
 
@@ -6120,7 +6120,7 @@ OpenSSL 1.0.1
    affected. OpenSSL clients and servers are not affected.
 
    This issue was reported to OpenSSL by Michal Zalewski (Google).
-   [CVE-2015-0289][]
+   ([CVE-2015-0289])
 
    *Emilia Käsper*
 
@@ -6132,7 +6132,7 @@ OpenSSL 1.0.1
 
    This issue was discovered by Sean Burford (Google) and Emilia Käsper
    (OpenSSL development team).
-   [CVE-2015-0293][]
+   ([CVE-2015-0293])
 
    *Emilia Käsper*
 
@@ -6147,7 +6147,7 @@ OpenSSL 1.0.1
 
    This issue was discovered by the BoringSSL project and fixed in their
    commit 517073cd4b.
-   [CVE-2015-0209][]
+   ([CVE-2015-0209])
 
    *Matt Caswell*
 
@@ -6157,7 +6157,7 @@ OpenSSL 1.0.1
    the certificate key is invalid. This function is rarely used in practice.
 
    This issue was discovered by Brian Carpenter.
-   [CVE-2015-0288][]
+   ([CVE-2015-0288])
 
    *Stephen Henson*
 
@@ -6177,7 +6177,7 @@ OpenSSL 1.0.1
    message can cause a segmentation fault in OpenSSL due to a NULL pointer
    dereference. This could lead to a Denial Of Service attack. Thanks to
    Markus Stenberg of Cisco Systems, Inc. for reporting this issue.
-   [CVE-2014-3571][]
+   ([CVE-2014-3571])
 
    *Steve Henson*
 
@@ -6187,7 +6187,7 @@ OpenSSL 1.0.1
    sequence number but for the next epoch. The memory leak could be exploited
    by an attacker in a Denial of Service attack through memory exhaustion.
    Thanks to Chris Mueller for reporting this issue.
-   [CVE-2015-0206][]
+   ([CVE-2015-0206])
 
    *Matt Caswell*
 
@@ -6195,7 +6195,7 @@ OpenSSL 1.0.1
    built with the no-ssl3 option and a SSL v3 ClientHello is received the ssl
    method would be set to NULL which could later result in a NULL pointer
    dereference. Thanks to Frank Schmirler for reporting this issue.
-   [CVE-2014-3569][]
+   ([CVE-2014-3569])
 
    *Kurt Roeckx*
 
@@ -6204,7 +6204,7 @@ OpenSSL 1.0.1
 
    Thanks to Karthikeyan Bhargavan of the PROSECCO team at INRIA for
    reporting this issue.
-   [CVE-2014-3572][]
+   ([CVE-2014-3572])
 
    *Steve Henson*
 
@@ -6214,7 +6214,7 @@ OpenSSL 1.0.1
    downgrade the RSA key length used to a value smaller than the server
    certificate. Thanks for Karthikeyan Bhargavan of the PROSECCO team at
    INRIA or reporting this issue.
-   [CVE-2015-0204][]
+   ([CVE-2015-0204])
 
    *Steve Henson*
 
@@ -6226,7 +6226,7 @@ OpenSSL 1.0.1
    containing DH keys: these are extremely rare and hardly ever encountered.
    Thanks for Karthikeyan Bhargavan of the PROSECCO team at INRIA or reporting
    this issue.
-   [CVE-2015-0205][]
+   ([CVE-2015-0205])
 
    *Steve Henson*
 
@@ -6272,7 +6272,7 @@ OpenSSL 1.0.1
    Further analysis was conducted and fixes were developed by Stephen Henson
    of the OpenSSL core team.
 
-   [CVE-2014-8275][]
+   ([CVE-2014-8275])
 
    *Steve Henson*
 
@@ -6284,7 +6284,7 @@ OpenSSL 1.0.1
    fix. Further analysis was conducted by the OpenSSL development team and
    Adam Langley of Google. The final fix was developed by Andy Polyakov of
    the OpenSSL core team.
-   [CVE-2014-3570][]
+   ([CVE-2014-3570])
 
    *Andy Polyakov*
 
@@ -6326,7 +6326,7 @@ OpenSSL 1.0.1
    have been compiled with OPENSSL_NO_SRTP defined are not affected.
 
    The fix was developed by the OpenSSL team.
-   [CVE-2014-3513][]
+   ([CVE-2014-3513])
 
    *OpenSSL team*
 
@@ -6338,7 +6338,7 @@ OpenSSL 1.0.1
    causing a memory leak. By sending a large number of invalid session
    tickets an attacker could exploit this issue in a Denial Of Service
    attack.
-   [CVE-2014-3567][]
+   ([CVE-2014-3567])
 
    *Steve Henson*
 
@@ -6347,14 +6347,14 @@ OpenSSL 1.0.1
    When OpenSSL is configured with "no-ssl3" as a build option, servers
    could accept and complete a SSL 3.0 handshake, and clients could be
    configured to send them.
-   [CVE-2014-3568][]
+   ([CVE-2014-3568])
 
    *Akamai and the OpenSSL team*
 
  * Add support for TLS_FALLBACK_SCSV.
    Client applications doing fallback retries should call
    SSL_set_mode(s, SSL_MODE_SEND_FALLBACK_SCSV).
-   [CVE-2014-3566][]
+   ([CVE-2014-3566])
 
    *Adam Langley, Bodo Moeller*
 
@@ -6376,7 +6376,7 @@ OpenSSL 1.0.1
 
    Thanks to Sean Devlin and Watson Ladd of Cryptography Services, NCC
    Group for discovering this issue.
-   [CVE-2014-3512][]
+   ([CVE-2014-3512])
 
    *Steve Henson*
 
@@ -6388,7 +6388,7 @@ OpenSSL 1.0.1
 
    Thanks to David Benjamin and Adam Langley (Google) for discovering and
    researching this issue.
-   [CVE-2014-3511][]
+   ([CVE-2014-3511])
 
    *David Benjamin*
 
@@ -6399,14 +6399,14 @@ OpenSSL 1.0.1
 
    Thanks to Felix Gröbert (Google) for discovering and researching this
    issue.
-   [CVE-2014-3510][]
+   ([CVE-2014-3510])
 
    *Emilia Käsper*
 
  * By sending carefully crafted DTLS packets an attacker could cause openssl
    to leak memory. This can be exploited through a Denial of Service attack.
    Thanks to Adam Langley for discovering and researching this issue.
-   [CVE-2014-3507][]
+   ([CVE-2014-3507])
 
    *Adam Langley*
 
@@ -6414,7 +6414,7 @@ OpenSSL 1.0.1
    processing DTLS handshake messages. This can be exploited through a
    Denial of Service attack.
    Thanks to Adam Langley for discovering and researching this issue.
-   [CVE-2014-3506][]
+   ([CVE-2014-3506])
 
    *Adam Langley*
 
@@ -6423,7 +6423,7 @@ OpenSSL 1.0.1
    can be exploited through a Denial of Service attack.
    Thanks to Adam Langley and Wan-Teh Chang for discovering and researching
    this issue.
-   [CVE-2014-3505][]
+   ([CVE-2014-3505])
 
    *Adam Langley*
 
@@ -6433,7 +6433,7 @@ OpenSSL 1.0.1
 
    Thanks to Gabor Tyukasz (LogMeIn Inc) for discovering and researching this
    issue.
-   [CVE-2014-3509][]
+   ([CVE-2014-3509])
 
    *Gabor Tyukasz*
 
@@ -6444,7 +6444,7 @@ OpenSSL 1.0.1
 
    Thanks to Joonas Kuorilehto and Riku Hietamäki (Codenomicon) for
    discovering and researching this issue.
-   [CVE-2014-5139][]
+   ([CVE-2014-5139])
 
    *Steve Henson*
 
@@ -6454,7 +6454,7 @@ OpenSSL 1.0.1
    output to the attacker.
 
    Thanks to Ivan Fratric (Google) for discovering this issue.
-   [CVE-2014-3508][]
+   ([CVE-2014-3508])
 
    *Emilia Käsper, and Steve Henson*
 
@@ -6471,7 +6471,7 @@ OpenSSL 1.0.1
    SSL/TLS clients and servers.
 
    Thanks to KIKUCHI Masashi (Lepidum Co. Ltd.) for discovering and
-   researching this issue. [CVE-2014-0224][]
+   researching this issue. ([CVE-2014-0224])
 
    *KIKUCHI Masashi, Steve Henson*
 
@@ -6480,7 +6480,7 @@ OpenSSL 1.0.1
    in a DoS attack.
 
    Thanks to Imre Rad (Search-Lab Ltd.) for discovering this issue.
-   [CVE-2014-0221][]
+   ([CVE-2014-0221])
 
    *Imre Rad, Steve Henson*
 
@@ -6489,7 +6489,7 @@ OpenSSL 1.0.1
    client or server. This is potentially exploitable to run arbitrary
    code on a vulnerable client or server.
 
-   Thanks to Jüri Aedla for reporting this issue. [CVE-2014-0195][]
+   Thanks to Jüri Aedla for reporting this issue. ([CVE-2014-0195])
 
    *Jüri Aedla, Steve Henson*
 
@@ -6497,7 +6497,7 @@ OpenSSL 1.0.1
    are subject to a denial of service attack.
 
    Thanks to Felix Gröbert and Ivan Fratric at Google for discovering
-   this issue. [CVE-2014-3470][]
+   this issue. ([CVE-2014-3470])
 
    *Felix Gröbert, Ivan Fratric, Steve Henson*
 
@@ -6523,7 +6523,7 @@ OpenSSL 1.0.1
 
    Thanks for Neel Mehta of Google Security for discovering this bug and to
    Adam Langley <agl@chromium.org> and Bodo Moeller <bmoeller@acm.org> for
-   preparing the fix [CVE-2014-0160][]
+   preparing the fix ([CVE-2014-0160])
 
    *Adam Langley, Bodo Moeller*
 
@@ -6533,7 +6533,7 @@ OpenSSL 1.0.1
    <http://eprint.iacr.org/2014/140>
 
    Thanks to Yuval Yarom and Naomi Benger for discovering this
-   flaw and to Yuval Yarom for supplying a fix [CVE-2014-0076][]
+   flaw and to Yuval Yarom for supplying a fix ([CVE-2014-0076])
 
    *Yuval Yarom and Naomi Benger*
 
@@ -6551,11 +6551,11 @@ OpenSSL 1.0.1
  * Fix for TLS record tampering bug. A carefully crafted invalid
    handshake could crash OpenSSL with a NULL pointer exception.
    Thanks to Anton Johansson for reporting this issues.
-   [CVE-2013-4353][]
+   ([CVE-2013-4353])
 
  * Keep original DTLS digest and encryption contexts in retransmission
    structures so we can use the previous session parameters if they need
-   to be resent. [CVE-2013-6450][]
+   to be resent. ([CVE-2013-6450])
 
    *Steve Henson*
 
@@ -6587,7 +6587,7 @@ OpenSSL 1.0.1
    Security Group at Royal Holloway, University of London
    (www.isg.rhul.ac.uk) for discovering this flaw and Adam Langley and
    Emilia Käsper for the initial patch.
-   [CVE-2013-0169][]
+   ([CVE-2013-0169])
 
    *Emilia Käsper, Adam Langley, Ben Laurie, Andy Polyakov, Steve Henson*
 
@@ -6596,12 +6596,12 @@ OpenSSL 1.0.1
    Thanks go to and to Adam Langley <agl@chromium.org> for discovering
    and detecting this bug and to Wolfgang Ettlinger
    <wolfgang.ettlinger@gmail.com> for independently discovering this issue.
-   [CVE-2012-2686][]
+   ([CVE-2012-2686])
 
    *Adam Langley*
 
  * Return an error when checking OCSP signatures when key is NULL.
-   This fixes a DoS attack. [CVE-2013-0166][]
+   This fixes a DoS attack. ([CVE-2013-0166])
 
    *Steve Henson*
 
@@ -6632,7 +6632,7 @@ OpenSSL 1.0.1
 
    Thanks to Codenomicon for discovering this issue using Fuzz-o-Matic
    fuzzing as a service testing platform.
-   [CVE-2012-2333][]
+   ([CVE-2012-2333])
 
    *Steve Henson*
 
@@ -6679,7 +6679,7 @@ OpenSSL 1.0.1
 
    Thanks to Tavis Ormandy, Google Security Team, for discovering this
    issue and to Adam Langley <agl@chromium.org> for fixing it.
-   [CVE-2012-2110][]
+   ([CVE-2012-2110])
 
    *Adam Langley (Google), Tavis Ormandy, Google Security Team*
 
@@ -7059,7 +7059,7 @@ OpenSSL 1.0.0
 
    This issue was reported to OpenSSL by Adam Langley (Google/BoringSSL) using
    libFuzzer.
-   [CVE-2015-3195][]
+   ([CVE-2015-3195])
 
    *Stephen Henson*
 
@@ -7069,7 +7069,7 @@ OpenSSL 1.0.0
    the values are wrongly updated in the parent SSL_CTX structure. This can
    result in a race condition potentially leading to a double free of the
    identify hint data.
-   [CVE-2015-3196][]
+   ([CVE-2015-3196])
 
    *Stephen Henson*
 
@@ -7087,7 +7087,7 @@ OpenSSL 1.0.0
    client authentication enabled.
 
    This issue was reported to OpenSSL by Joseph Barr-Pixton.
-   [CVE-2015-1788][]
+   ([CVE-2015-1788])
 
    *Andy Polyakov*
 
@@ -7107,7 +7107,7 @@ OpenSSL 1.0.0
 
    This issue was reported to OpenSSL by Robert Swiecki (Google), and
    independently by Hanno Böck.
-   [CVE-2015-1789][]
+   ([CVE-2015-1789])
 
    *Emilia Käsper*
 
@@ -7122,7 +7122,7 @@ OpenSSL 1.0.0
    servers are not affected.
 
    This issue was reported to OpenSSL by Michal Zalewski (Google).
-   [CVE-2015-1790][]
+   ([CVE-2015-1790])
 
    *Emilia Käsper*
 
@@ -7133,7 +7133,7 @@ OpenSSL 1.0.0
    denial of service against any system which verifies signedData messages using
    the CMS code.
    This issue was reported to OpenSSL by Johannes Bauer.
-   [CVE-2015-1792][]
+   ([CVE-2015-1792])
 
    *Stephen Henson*
 
@@ -7142,7 +7142,7 @@ OpenSSL 1.0.0
    If a NewSessionTicket is received by a multi-threaded client when attempting to
    reuse a previous ticket then a race condition can occur potentially leading to
    a double free of the ticket data.
-   [CVE-2015-1791][]
+   ([CVE-2015-1791])
 
    *Matt Caswell*
 
@@ -7156,7 +7156,7 @@ OpenSSL 1.0.0
    certificate verification operation and exploited in a DoS attack. Any
    application which performs certificate verification is vulnerable including
    OpenSSL clients and servers which enable client authentication.
-   [CVE-2015-0286][]
+   ([CVE-2015-0286])
 
    *Stephen Henson*
 
@@ -7170,7 +7170,7 @@ OpenSSL 1.0.0
    components may be affected. Certificate parsing (d2i_X509 and related
    functions) are however not affected. OpenSSL clients and servers are
    not affected.
-   [CVE-2015-0287][]
+   ([CVE-2015-0287])
 
    *Stephen Henson*
 
@@ -7185,7 +7185,7 @@ OpenSSL 1.0.0
    affected. OpenSSL clients and servers are not affected.
 
    This issue was reported to OpenSSL by Michal Zalewski (Google).
-   [CVE-2015-0289][]
+   ([CVE-2015-0289])
 
    *Emilia Käsper*
 
@@ -7197,7 +7197,7 @@ OpenSSL 1.0.0
 
    This issue was discovered by Sean Burford (Google) and Emilia Käsper
    (OpenSSL development team).
-   [CVE-2015-0293][]
+   ([CVE-2015-0293])
 
    *Emilia Käsper*
 
@@ -7212,7 +7212,7 @@ OpenSSL 1.0.0
 
    This issue was discovered by the BoringSSL project and fixed in their
    commit 517073cd4b.
-   [CVE-2015-0209][]
+   ([CVE-2015-0209])
 
    *Matt Caswell*
 
@@ -7222,7 +7222,7 @@ OpenSSL 1.0.0
    the certificate key is invalid. This function is rarely used in practice.
 
    This issue was discovered by Brian Carpenter.
-   [CVE-2015-0288][]
+   ([CVE-2015-0288])
 
    *Stephen Henson*
 
@@ -7242,7 +7242,7 @@ OpenSSL 1.0.0
    message can cause a segmentation fault in OpenSSL due to a NULL pointer
    dereference. This could lead to a Denial Of Service attack. Thanks to
    Markus Stenberg of Cisco Systems, Inc. for reporting this issue.
-   [CVE-2014-3571][]
+   ([CVE-2014-3571])
 
    *Steve Henson*
 
@@ -7252,7 +7252,7 @@ OpenSSL 1.0.0
    sequence number but for the next epoch. The memory leak could be exploited
    by an attacker in a Denial of Service attack through memory exhaustion.
    Thanks to Chris Mueller for reporting this issue.
-   [CVE-2015-0206][]
+   ([CVE-2015-0206])
 
    *Matt Caswell*
 
@@ -7260,7 +7260,7 @@ OpenSSL 1.0.0
    built with the no-ssl3 option and a SSL v3 ClientHello is received the ssl
    method would be set to NULL which could later result in a NULL pointer
    dereference. Thanks to Frank Schmirler for reporting this issue.
-   [CVE-2014-3569][]
+   ([CVE-2014-3569])
 
    *Kurt Roeckx*
 
@@ -7269,7 +7269,7 @@ OpenSSL 1.0.0
 
    Thanks to Karthikeyan Bhargavan of the PROSECCO team at INRIA for
    reporting this issue.
-   [CVE-2014-3572][]
+   ([CVE-2014-3572])
 
    *Steve Henson*
 
@@ -7279,7 +7279,7 @@ OpenSSL 1.0.0
    downgrade the RSA key length used to a value smaller than the server
    certificate. Thanks for Karthikeyan Bhargavan of the PROSECCO team at
    INRIA or reporting this issue.
-   [CVE-2015-0204][]
+   ([CVE-2015-0204])
 
    *Steve Henson*
 
@@ -7291,7 +7291,7 @@ OpenSSL 1.0.0
    containing DH keys: these are extremely rare and hardly ever encountered.
    Thanks for Karthikeyan Bhargavan of the PROSECCO team at INRIA or reporting
    this issue.
-   [CVE-2015-0205][]
+   ([CVE-2015-0205])
 
    *Steve Henson*
 
@@ -7303,7 +7303,7 @@ OpenSSL 1.0.0
    fix. Further analysis was conducted by the OpenSSL development team and
    Adam Langley of Google. The final fix was developed by Andy Polyakov of
    the OpenSSL core team.
-   [CVE-2014-3570][]
+   ([CVE-2014-3570])
 
    *Andy Polyakov*
 
@@ -7341,7 +7341,7 @@ OpenSSL 1.0.0
    Further analysis was conducted and fixes were developed by Stephen Henson
    of the OpenSSL core team.
 
-   [CVE-2014-8275][]
+   ([CVE-2014-8275])
 
    *Steve Henson*
 
@@ -7355,7 +7355,7 @@ OpenSSL 1.0.0
    causing a memory leak. By sending a large number of invalid session
    tickets an attacker could exploit this issue in a Denial Of Service
    attack.
-   [CVE-2014-3567][]
+   ([CVE-2014-3567])
 
    *Steve Henson*
 
@@ -7364,14 +7364,14 @@ OpenSSL 1.0.0
    When OpenSSL is configured with "no-ssl3" as a build option, servers
    could accept and complete a SSL 3.0 handshake, and clients could be
    configured to send them.
-   [CVE-2014-3568][]
+   ([CVE-2014-3568])
 
    *Akamai and the OpenSSL team*
 
  * Add support for TLS_FALLBACK_SCSV.
    Client applications doing fallback retries should call
    SSL_set_mode(s, SSL_MODE_SEND_FALLBACK_SCSV).
-   [CVE-2014-3566][]
+   ([CVE-2014-3566])
 
    *Adam Langley, Bodo Moeller*
 
@@ -7394,14 +7394,14 @@ OpenSSL 1.0.0
 
    Thanks to Felix Gröbert (Google) for discovering and researching this
    issue.
-   [CVE-2014-3510][]
+   ([CVE-2014-3510])
 
    *Emilia Käsper*
 
  * By sending carefully crafted DTLS packets an attacker could cause openssl
    to leak memory. This can be exploited through a Denial of Service attack.
    Thanks to Adam Langley for discovering and researching this issue.
-   [CVE-2014-3507][]
+   ([CVE-2014-3507])
 
    *Adam Langley*
 
@@ -7409,7 +7409,7 @@ OpenSSL 1.0.0
    processing DTLS handshake messages. This can be exploited through a
    Denial of Service attack.
    Thanks to Adam Langley for discovering and researching this issue.
-   [CVE-2014-3506][]
+   ([CVE-2014-3506])
 
    *Adam Langley*
 
@@ -7418,7 +7418,7 @@ OpenSSL 1.0.0
    can be exploited through a Denial of Service attack.
    Thanks to Adam Langley and Wan-Teh Chang for discovering and researching
    this issue.
-   [CVE-2014-3505][]
+   ([CVE-2014-3505])
 
    *Adam Langley*
 
@@ -7428,7 +7428,7 @@ OpenSSL 1.0.0
 
    Thanks to Gabor Tyukasz (LogMeIn Inc) for discovering and researching this
    issue.
-   [CVE-2014-3509][]
+   ([CVE-2014-3509])
 
    *Gabor Tyukasz*
 
@@ -7438,7 +7438,7 @@ OpenSSL 1.0.0
    output to the attacker.
 
    Thanks to Ivan Fratric (Google) for discovering this issue.
-   [CVE-2014-3508][]
+   ([CVE-2014-3508])
 
    *Emilia Käsper, and Steve Henson*
 
@@ -7455,7 +7455,7 @@ OpenSSL 1.0.0
    SSL/TLS clients and servers.
 
    Thanks to KIKUCHI Masashi (Lepidum Co. Ltd.) for discovering and
-   researching this issue. [CVE-2014-0224][]
+   researching this issue. ([CVE-2014-0224])
 
    *KIKUCHI Masashi, Steve Henson*
 
@@ -7464,7 +7464,7 @@ OpenSSL 1.0.0
    in a DoS attack.
 
    Thanks to Imre Rad (Search-Lab Ltd.) for discovering this issue.
-   [CVE-2014-0221][]
+   ([CVE-2014-0221])
 
    *Imre Rad, Steve Henson*
 
@@ -7473,7 +7473,7 @@ OpenSSL 1.0.0
    client or server. This is potentially exploitable to run arbitrary
    code on a vulnerable client or server.
 
-   Thanks to Jüri Aedla for reporting this issue. [CVE-2014-0195][]
+   Thanks to Jüri Aedla for reporting this issue. ([CVE-2014-0195])
 
    *Jüri Aedla, Steve Henson*
 
@@ -7481,7 +7481,7 @@ OpenSSL 1.0.0
    are subject to a denial of service attack.
 
    Thanks to Felix Gröbert and Ivan Fratric at Google for discovering
-   this issue. [CVE-2014-3470][]
+   this issue. ([CVE-2014-3470])
 
    *Felix Gröbert, Ivan Fratric, Steve Henson*
 
@@ -7505,7 +7505,7 @@ OpenSSL 1.0.0
    <http://eprint.iacr.org/2014/140>
 
    Thanks to Yuval Yarom and Naomi Benger for discovering this
-   flaw and to Yuval Yarom for supplying a fix [CVE-2014-0076][]
+   flaw and to Yuval Yarom for supplying a fix ([CVE-2014-0076])
 
    *Yuval Yarom and Naomi Benger*
 
@@ -7513,7 +7513,7 @@ OpenSSL 1.0.0
 
  * Keep original DTLS digest and encryption contexts in retransmission
    structures so we can use the previous session parameters if they need
-   to be resent. [CVE-2013-6450][]
+   to be resent. ([CVE-2013-6450])
 
    *Steve Henson*
 
@@ -7538,12 +7538,12 @@ OpenSSL 1.0.0
    Security Group at Royal Holloway, University of London
    (www.isg.rhul.ac.uk) for discovering this flaw and Adam Langley and
    Emilia Käsper for the initial patch.
-   [CVE-2013-0169][]
+   ([CVE-2013-0169])
 
    *Emilia Käsper, Adam Langley, Ben Laurie, Andy Polyakov, Steve Henson*
 
  * Return an error when checking OCSP signatures when key is NULL.
-   This fixes a DoS attack. [CVE-2013-0166][]
+   This fixes a DoS attack. ([CVE-2013-0166])
 
    *Steve Henson*
 
@@ -7569,7 +7569,7 @@ OpenSSL 1.0.1.]
 
    Thanks to Codenomicon for discovering this issue using Fuzz-o-Matic
    fuzzing as a service testing platform.
-   [CVE-2012-2333][]
+   ([CVE-2012-2333])
 
    *Steve Henson*
 
@@ -7586,7 +7586,7 @@ OpenSSL 1.0.1.]
 
    Thanks to Tavis Ormandy, Google Security Team, for discovering this
    issue and to Adam Langley <agl@chromium.org> for fixing it.
-   [CVE-2012-2110][]
+   ([CVE-2012-2110])
 
    *Adam Langley (Google), Tavis Ormandy, Google Security Team*
 
@@ -7600,7 +7600,7 @@ OpenSSL 1.0.1.]
    CMS_DEBUG_DECRYPT flag: this is useful for debugging and testing where
    an MMA defence is not necessary.
    Thanks to Ivan Nestlerode <inestlerode@us.ibm.com> for discovering
-   this issue. [CVE-2012-0884][]
+   this issue. ([CVE-2012-0884])
 
    *Steve Henson*
 
@@ -7615,7 +7615,7 @@ OpenSSL 1.0.1.]
  * Fix for DTLS DoS issue introduced by fix for CVE-2011-4109.
    Thanks to Antonio Martin, Enterprise Secure Access Research and
    Development, Cisco Systems, Inc. for discovering this bug and
-   preparing a fix. [CVE-2012-0050][]
+   preparing a fix. ([CVE-2012-0050])
 
    *Antonio Martin*
 
@@ -7632,28 +7632,28 @@ OpenSSL 1.0.1.]
    Security Group at Royal Holloway, University of London
    (www.isg.rhul.ac.uk) for discovering this flaw and to Robin Seggelmann
    <seggelmann@fh-muenster.de> and Michael Tuexen <tuexen@fh-muenster.de>
-   for preparing the fix. [CVE-2011-4108][]
+   for preparing the fix. ([CVE-2011-4108])
 
    *Robin Seggelmann, Michael Tuexen*
 
  * Clear bytes used for block padding of SSL 3.0 records.
-   [CVE-2011-4576][]
+   ([CVE-2011-4576])
 
    *Adam Langley (Google)*
 
  * Only allow one SGC handshake restart for SSL/TLS. Thanks to George
    Kadianakis <desnacked@gmail.com> for discovering this issue and
-   Adam Langley for preparing the fix. [CVE-2011-4619][]
+   Adam Langley for preparing the fix. ([CVE-2011-4619])
 
    *Adam Langley (Google)*
 
- * Check parameters are not NULL in GOST ENGINE. [CVE-2012-0027][]
+ * Check parameters are not NULL in GOST ENGINE. ([CVE-2012-0027])
 
    *Andrey Kulikov <amdeich@gmail.com>*
 
  * Prevent malformed RFC3779 data triggering an assertion failure.
    Thanks to Andrew Chi, BBN Technologies, for discovering the flaw
-   and Rob Austein <sra@hactrn.net> for fixing it. [CVE-2011-4577][]
+   and Rob Austein <sra@hactrn.net> for fixing it. ([CVE-2011-4577])
 
    *Rob Austein <sra@hactrn.net>*
 
@@ -7692,12 +7692,12 @@ OpenSSL 1.0.1.]
 ### Changes between 1.0.0d and 1.0.0e [6 Sep 2011]
 
  * Fix bug where CRLs with nextUpdate in the past are sometimes accepted
-   by initialising X509_STORE_CTX properly. [CVE-2011-3207][]
+   by initialising X509_STORE_CTX properly. ([CVE-2011-3207])
 
    *Kaspar Brand <ossl@velox.ch>*
 
  * Fix SSL memory handling for (EC)DH ciphersuites, in particular
-   for multi-threaded use of ECDH. [CVE-2011-3210][]
+   for multi-threaded use of ECDH. ([CVE-2011-3210])
 
    *Adam Langley (Google)*
 
@@ -7759,7 +7759,7 @@ OpenSSL 1.0.1.]
 ### Changes between 1.0.0 and 1.0.0a  [01 Jun 2010]
 
  * Check return value of int_rsa_verify in pkey_rsa_verifyrecover
-   [CVE-2010-1633][]
+   ([CVE-2010-1633])
 
    *Steve Henson, Peter-Michael Hager <hager@dortmund.net>*
 
@@ -8733,7 +8733,7 @@ OpenSSL 0.9.x
    - OpenSSL 0.9.8f if 'short' is longer than 16 bits,
    the previous behavior could result in a read attempt at NULL when
    receiving specific incorrect SSL/TLS records once record payload
-   protection is active.  [CVE-2010-0740][]
+   protection is active.  ([CVE-2010-0740])
 
    *Bodo Moeller, Adam Langley <agl@chromium.org>*
 
@@ -8744,7 +8744,7 @@ OpenSSL 0.9.x
 
 ### Changes between 0.9.8l and 0.9.8m [25 Feb 2010]
 
- * Always check bn_wexpand() return values for failure.  [CVE-2009-3245][]
+ * Always check bn_wexpand() return values for failure.  ([CVE-2009-3245])
 
    *Martin Olsson, Neel Mehta*
 
@@ -8903,7 +8903,7 @@ OpenSSL 0.9.x
    left. Additionally every future message was buffered, even if the
    sequence number made no sense and would be part of another handshake.
    So only messages with sequence numbers less than 10 in advance will be
-   buffered.  [CVE-2009-1378][]
+   buffered.  ([CVE-2009-1378])
 
    *Robin Seggelmann, discovered by Daniel Mentz*
 
@@ -8913,12 +8913,12 @@ OpenSSL 0.9.x
    a DOS attack with sending records with future epochs until there is no
    memory left. This patch adds the pqueue_size() function to determine
    the size of a buffer and limits the record buffer to 100 entries.
-   [CVE-2009-1377][]
+   ([CVE-2009-1377])
 
    *Robin Seggelmann, discovered by Daniel Mentz*
 
  * Keep a copy of frag->msg_header.frag_len so it can be used after the
-   parent structure is freed.  [CVE-2009-1379][]
+   parent structure is freed.  ([CVE-2009-1379])
 
    *Daniel Mentz*
 
@@ -8933,7 +8933,7 @@ OpenSSL 0.9.x
 ### Changes between 0.9.8k and 0.9.8l  [5 Nov 2009]
 
  * Disable renegotiation completely - this fixes a severe security
-   problem [CVE-2009-3555][] at the cost of breaking all
+   problem ([CVE-2009-3555]) at the cost of breaking all
    renegotiation. Renegotiation can be re-enabled by setting
    SSL3_FLAGS_ALLOW_UNSAFE_LEGACY_RENEGOTIATION in s3->flags at
    run-time. This is really not recommended unless you know what
@@ -8945,19 +8945,19 @@ OpenSSL 0.9.x
 
  * Don't set val to NULL when freeing up structures, it is freed up by
    underlying code. If `sizeof(void *) > sizeof(long)` this can result in
-   zeroing past the valid field. [CVE-2009-0789][]
+   zeroing past the valid field. ([CVE-2009-0789])
 
    *Paolo Ganci <Paolo.Ganci@AdNovum.CH>*
 
  * Fix bug where return value of CMS_SignerInfo_verify_content() was not
    checked correctly. This would allow some invalid signed attributes to
-   appear to verify correctly. [CVE-2009-0591][]
+   appear to verify correctly. ([CVE-2009-0591])
 
    *Ivan Nestlerode <inestlerode@us.ibm.com>*
 
  * Reject UniversalString and BMPString types with invalid lengths. This
    prevents a crash in ASN1_STRING_print_ex() which assumes the strings have
-   a legal length. [CVE-2009-0590][]
+   a legal length. ([CVE-2009-0590])
 
    *Steve Henson*
 
@@ -8998,7 +8998,7 @@ OpenSSL 0.9.x
 ### Changes between 0.9.8i and 0.9.8j  [07 Jan 2009]
 
  * Properly check EVP_VerifyFinal() and similar return values
-   [CVE-2008-5077][].
+   ([CVE-2008-5077]).
 
    *Ben Laurie, Bodo Moeller, Google Security Team*
 
@@ -9045,7 +9045,7 @@ OpenSSL 0.9.x
 ### Changes between 0.9.8h and 0.9.8i  [15 Sep 2008]
 
  * Fix NULL pointer dereference if a DTLS server received
-   ChangeCipherSpec as first record [CVE-2009-1386][].
+   ChangeCipherSpec as first record ([CVE-2009-1386]).
 
    *PR #1679*
 
@@ -9118,12 +9118,12 @@ OpenSSL 0.9.x
 
  * Fix flaw if 'Server Key exchange message' is omitted from a TLS
    handshake which could lead to a client crash as found using the
-   Codenomicon TLS test suite [CVE-2008-1672][]
+   Codenomicon TLS test suite ([CVE-2008-1672])
 
    *Steve Henson, Mark Cox*
 
  * Fix double free in TLS server name extensions which could lead to
-   a remote crash found by Codenomicon TLS test suite [CVE-2008-0891][]
+   a remote crash found by Codenomicon TLS test suite ([CVE-2008-0891])
 
    *Joe Orton*
 
@@ -9443,7 +9443,7 @@ OpenSSL 0.9.x
 
  * Update the SSL_get_shared_ciphers() fix CVE-2006-3738 which was
    not complete and could lead to a possible single byte overflow
-   [CVE-2007-5135][] [Ben Laurie]
+   ([CVE-2007-5135]) [Ben Laurie]
 
 ### Changes between 0.9.8d and 0.9.8e  [23 Feb 2007]
 
@@ -9490,18 +9490,18 @@ OpenSSL 0.9.x
 ### Changes between 0.9.8c and 0.9.8d  [28 Sep 2006]
 
  * Introduce limits to prevent malicious keys being able to
-   cause a denial of service.  [CVE-2006-2940][]
+   cause a denial of service.  ([CVE-2006-2940])
 
    *Steve Henson, Bodo Moeller*
 
  * Fix ASN.1 parsing of certain invalid structures that can result
-   in a denial of service.  [CVE-2006-2937][]  [Steve Henson]
+   in a denial of service.  ([CVE-2006-2937])  [Steve Henson]
 
  * Fix buffer overflow in SSL_get_shared_ciphers() function.
-   [CVE-2006-3738][] [Tavis Ormandy and Will Drewry, Google Security Team]
+   ([CVE-2006-3738]) [Tavis Ormandy and Will Drewry, Google Security Team]
 
  * Fix SSL client code which could crash if connecting to a
-   malicious SSLv2 server.  [CVE-2006-4343][]
+   malicious SSLv2 server.  ([CVE-2006-4343])
 
    *Tavis Ormandy and Will Drewry, Google Security Team*
 
@@ -9535,7 +9535,7 @@ OpenSSL 0.9.x
 ### Changes between 0.9.8b and 0.9.8c  [05 Sep 2006]
 
  * Avoid PKCS #1 v1.5 signature attack discovered by Daniel Bleichenbacher
-   [CVE-2006-4339][]  [Ben Laurie and Google Security Team]
+   ([CVE-2006-4339])  [Ben Laurie and Google Security Team]
 
  * Add AES IGE and biIGE modes.
 
@@ -9655,7 +9655,7 @@ OpenSSL 0.9.x
    (part of SSL_OP_ALL).  This option used to disable the
    countermeasure against man-in-the-middle protocol-version
    rollback in the SSL 2.0 server implementation, which is a bad
-   idea.  [CVE-2005-2969][]
+   idea.  ([CVE-2005-2969])
 
    *Bodo Moeller; problem pointed out by Yutaka Oiwa (Research Center
    for Information Security, National Institute of Advanced Industrial
@@ -10663,18 +10663,18 @@ OpenSSL 0.9.8.]
 ### Changes between 0.9.7k and 0.9.7l  [28 Sep 2006]
 
  * Introduce limits to prevent malicious keys being able to
-   cause a denial of service.  [CVE-2006-2940][]
+   cause a denial of service.  ([CVE-2006-2940])
 
    *Steve Henson, Bodo Moeller*
 
  * Fix ASN.1 parsing of certain invalid structures that can result
-   in a denial of service.  [CVE-2006-2937][]  [Steve Henson]
+   in a denial of service.  ([CVE-2006-2937])  [Steve Henson]
 
  * Fix buffer overflow in SSL_get_shared_ciphers() function.
-   [CVE-2006-3738][] [Tavis Ormandy and Will Drewry, Google Security Team]
+   ([CVE-2006-3738]) [Tavis Ormandy and Will Drewry, Google Security Team]
 
  * Fix SSL client code which could crash if connecting to a
-   malicious SSLv2 server.  [CVE-2006-4343][]
+   malicious SSLv2 server.  ([CVE-2006-4343])
 
    *Tavis Ormandy and Will Drewry, Google Security Team*
 
@@ -10691,7 +10691,7 @@ OpenSSL 0.9.8.]
 ### Changes between 0.9.7j and 0.9.7k  [05 Sep 2006]
 
  * Avoid PKCS #1 v1.5 signature attack discovered by Daniel Bleichenbacher
-   [CVE-2006-4339][]  [Ben Laurie and Google Security Team]
+   ([CVE-2006-4339])  [Ben Laurie and Google Security Team]
 
  * Change the Unix randomness entropy gathering to use poll() when
    possible instead of select(), since the latter has some
@@ -10754,7 +10754,7 @@ OpenSSL 0.9.8.]
    (part of SSL_OP_ALL).  This option used to disable the
    countermeasure against man-in-the-middle protocol-version
    rollback in the SSL 2.0 server implementation, which is a bad
-   idea.  [CVE-2005-2969][]
+   idea.  ([CVE-2005-2969])
 
    *Bodo Moeller; problem pointed out by Yutaka Oiwa (Research Center
    for Information Security, National Institute of Advanced Industrial
@@ -10940,12 +10940,12 @@ OpenSSL 0.9.8.]
 ### Changes between 0.9.7c and 0.9.7d  [17 Mar 2004]
 
  * Fix null-pointer assignment in do_change_cipher_spec() revealed
-   by using the Codenomicon TLS Test Tool [CVE-2004-0079][]
+   by using the Codenomicon TLS Test Tool ([CVE-2004-0079])
 
    *Joe Orton, Steve Henson*
 
  * Fix flaw in SSL/TLS handshaking when using Kerberos ciphersuites
-   [CVE-2004-0112][]
+   ([CVE-2004-0112])
 
    *Joe Orton, Steve Henson*
 
@@ -10997,7 +10997,7 @@ OpenSSL 0.9.8.]
    Stop out of bounds reads in the ASN1 code when presented with
    invalid tags (CVE-2003-0543 and CVE-2003-0544).
 
-   Free up ASN1_TYPE correctly if ANY type is invalid [CVE-2003-0545][].
+   Free up ASN1_TYPE correctly if ANY type is invalid ([CVE-2003-0545]).
 
    If verify callback ignores invalid public key errors don't try to check
    certificate signature with the NULL public key.
@@ -11094,7 +11094,7 @@ OpenSSL 0.9.8.]
    via timing by performing a MAC computation even if incorrect
    block cipher padding has been found.  This is a countermeasure
    against active attacks where the attacker has to distinguish
-   between bad padding and a MAC verification error. [CVE-2003-0078][]
+   between bad padding and a MAC verification error. ([CVE-2003-0078])
 
    *Bodo Moeller; problem pointed out by Brice Canvel (EPFL),
    Alain Hiltgen (UBS), Serge Vaudenay (EPFL), and
@@ -11352,7 +11352,7 @@ OpenSSL 0.9.7.]
 
    Remote buffer overflow in SSL3 protocol - an attacker could
    supply an oversized master key in Kerberos-enabled versions.
-   [CVE-2002-0657][]
+   ([CVE-2002-0657])
 
    *Ben Laurie (CHATS)*
 
@@ -13263,7 +13263,7 @@ s-cbc           3624.96k     5258.21k     5530.91k     5624.30k     5628.26k
 ### Changes between 0.9.6l and 0.9.6m  [17 Mar 2004]
 
  * Fix null-pointer assignment in do_change_cipher_spec() revealed
-   by using the Codenomicon TLS Test Tool [CVE-2004-0079][]
+   by using the Codenomicon TLS Test Tool ([CVE-2004-0079])
 
    *Joe Orton, Steve Henson*
 
@@ -13272,7 +13272,7 @@ s-cbc           3624.96k     5258.21k     5530.91k     5624.30k     5628.26k
  * Fix additional bug revealed by the NISCC test suite:
 
    Stop bug triggering large recursion when presented with
-   certain ASN.1 tags [CVE-2003-0851][]
+   certain ASN.1 tags ([CVE-2003-0851])
 
    *Steve Henson*
 
@@ -13339,7 +13339,7 @@ s-cbc           3624.96k     5258.21k     5530.91k     5624.30k     5628.26k
    via timing by performing a MAC computation even if incorrect
    block cipher padding has been found.  This is a countermeasure
    against active attacks where the attacker has to distinguish
-   between bad padding and a MAC verification error. [CVE-2003-0078][]
+   between bad padding and a MAC verification error. ([CVE-2003-0078])
 
    *Bodo Moeller; problem pointed out by Brice Canvel (EPFL),
    Alain Hiltgen (UBS), Serge Vaudenay (EPFL), and
@@ -13488,7 +13488,7 @@ s-cbc           3624.96k     5258.21k     5530.91k     5624.30k     5628.26k
  * Add various sanity checks to asn1_get_length() to reject
    the ASN1 length bytes if they exceed sizeof(long), will appear
    negative or the content length exceeds the length of the
-   supplied buffer. [CVE-2002-0659][]
+   supplied buffer. ([CVE-2002-0659])
 
    *Steve Henson, Adi Stav <stav@mercury.co.il>, James Yonan <jim@ntlp.com>*
 
@@ -13498,16 +13498,16 @@ s-cbc           3624.96k     5258.21k     5530.91k     5624.30k     5628.26k
    *Ben Laurie (CHATS)*
 
  * Various temporary buffers to hold ASCII versions of integers were
-   too small for 64 bit platforms. [CVE-2002-0655][]
+   too small for 64 bit platforms. ([CVE-2002-0655])
    *Matthew Byng-Maddick <mbm@aldigital.co.uk> and Ben Laurie (CHATS)>*
 
  * Remote buffer overflow in SSL3 protocol - an attacker could
-   supply an oversized session ID to a client. [CVE-2002-0656][]
+   supply an oversized session ID to a client. ([CVE-2002-0656])
 
    *Ben Laurie (CHATS)*
 
  * Remote buffer overflow in SSL2 protocol - an attacker could
-   supply an oversized client master key. [CVE-2002-0656][]
+   supply an oversized client master key. ([CVE-2002-0656])
 
    *Ben Laurie (CHATS)*
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1199,7 +1199,8 @@ OpenSSL 1.1.1
 
  * Certificates with explicit curve parameters are now disallowed in
    verification chains if the X509_V_FLAG_X509_STRICT flag is used.
-   [Tomas Mraz]
+
+   *Tomas Mraz*
 
  * The 'MinProtocol' and 'MaxProtocol' configuration commands now silently
    ignore TLS protocol version bounds when configuring DTLS-based contexts, and
@@ -1214,10 +1215,12 @@ OpenSSL 1.1.1
    attempts to apply bounds to these protocol versions would result in an
    error.  Now only the "version-flexible" SSL_CTX instances are subject to
    limits in configuration files in command-line options.
-   [Viktor Dukhovni]
+
+   *Viktor Dukhovni*
 
  * Handshake now fails if Extended Master Secret extension is dropped
    on renegotiation.
+
    *Tomas Mraz*
 
  * The Oracle Developer Studio compiler will start reporting deprecated APIs

--- a/NEWS.md
+++ b/NEWS.md
@@ -72,9 +72,25 @@ OpenSSL 3.0
 OpenSSL 1.1.1
 -------------
 
-### Major changes between OpenSSL 1.1.1e and OpenSSL 1.1.1f [under development]
+### Major changes between OpenSSL 1.1.1h and OpenSSL 1.1.1i [under development]
 
   *
+
+### Major changes between OpenSSL 1.1.1g and OpenSSL 1.1.1h [22 Sep 2020]
+
+  * Disallow explicit curve parameters in verifications chains when
+    X509_V_FLAG_X509_STRICT is used
+  * Enable 'MinProtocol' and 'MaxProtocol' to configure both TLS and DTLS
+    contexts
+  * Oracle Developer Studio will start reporting deprecation warnings
+
+### Major changes between OpenSSL 1.1.1f and OpenSSL 1.1.1g [21 Apr 2020]
+
+  * Fixed segmentation fault in SSL_check_chain() ([CVE-2020-1967][])
+
+### Major changes between OpenSSL 1.1.1e and OpenSSL 1.1.1f [31 Mar 2020]
+
+  * Revert the unexpected EOF reporting via SSL_ERROR_SSL
 
 ### Major changes between OpenSSL 1.1.1d and OpenSSL 1.1.1e [17 Mar 2020]
 
@@ -1309,6 +1325,7 @@ OpenSSL 0.9.x
 
 <!-- Links -->
 
+[CVE-2020-1967]: https://www.openssl.org/news/vulnerabilities.html#CVE-2020-1967
 [CVE-2019-1563]: https://www.openssl.org/news/vulnerabilities.html#CVE-2019-1563
 [CVE-2019-1559]: https://www.openssl.org/news/vulnerabilities.html#CVE-2019-1559
 [CVE-2019-1552]: https://www.openssl.org/news/vulnerabilities.html#CVE-2019-1552

--- a/NEWS.md
+++ b/NEWS.md
@@ -830,7 +830,7 @@ OpenSSL 0.9.x
 ### Major changes between OpenSSL 0.9.8j and OpenSSL 0.9.8k [25 Mar 2009]
 
   * Fix various build issues.
-  * Fix security issues [CVE-2009-0590], [CVE-2009-0591][], [CVE-2009-0789]
+  * Fix security issues [CVE-2009-0590], [CVE-2009-0591], [CVE-2009-0789]
 
 ### Major changes between OpenSSL 0.9.8i and OpenSSL 0.9.8j [7 Jan 2009]
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -86,7 +86,7 @@ OpenSSL 1.1.1
 
 ### Major changes between OpenSSL 1.1.1f and OpenSSL 1.1.1g [21 Apr 2020]
 
-  * Fixed segmentation fault in SSL_check_chain() ([CVE-2020-1967][])
+  * Fixed segmentation fault in SSL_check_chain() ([CVE-2020-1967])
 
 ### Major changes between OpenSSL 1.1.1e and OpenSSL 1.1.1f [31 Mar 2020]
 
@@ -95,28 +95,28 @@ OpenSSL 1.1.1
 ### Major changes between OpenSSL 1.1.1d and OpenSSL 1.1.1e [17 Mar 2020]
 
   * Fixed an overflow bug in the x64_64 Montgomery squaring procedure
-    used in exponentiation with 512-bit moduli ([CVE-2019-1551][])
+    used in exponentiation with 512-bit moduli ([CVE-2019-1551])
 
 ### Major changes between OpenSSL 1.1.1c and OpenSSL 1.1.1d [10 Sep 2019]
 
-  * Fixed a fork protection issue ([CVE-2019-1549][])
+  * Fixed a fork protection issue ([CVE-2019-1549])
   * Fixed a padding oracle in PKCS7_dataDecode and CMS_decrypt_set1_pkey
-    ([CVE-2019-1563][])
+    ([CVE-2019-1563])
   * For built-in EC curves, ensure an EC_GROUP built from the curve name is
     used even when parsing explicit parameters
   * Compute ECC cofactors if not provided during EC_GROUP construction
-    ([CVE-2019-1547][])
+    ([CVE-2019-1547])
   * Early start up entropy quality from the DEVRANDOM seed source has been
     improved for older Linux systems
   * Correct the extended master secret constant on EBCDIC systems
-  * Use Windows installation paths in the mingw builds ([CVE-2019-1552][])
+  * Use Windows installation paths in the mingw builds ([CVE-2019-1552])
   * Changed DH_check to accept parameters with order q and 2q subgroups
   * Significantly reduce secure memory usage by the randomness pools
   * Revert the DEVRANDOM_WAIT feature for Linux systems
 
 ### Major changes between OpenSSL 1.1.1b and OpenSSL 1.1.1c [28 May 2019]
 
-  * Prevent over long nonces in ChaCha20-Poly1305 ([CVE-2019-1543][])
+  * Prevent over long nonces in ChaCha20-Poly1305 ([CVE-2019-1543])
 
 ### Major changes between OpenSSL 1.1.1a and OpenSSL 1.1.1b [26 Feb 2019]
 
@@ -127,8 +127,8 @@ OpenSSL 1.1.1
 
 ### Major changes between OpenSSL 1.1.1 and OpenSSL 1.1.1a [20 Nov 2018]
 
-  * Timing vulnerability in DSA signature generation ([CVE-2018-0734][])
-  * Timing vulnerability in ECDSA signature generation ([CVE-2018-0735][])
+  * Timing vulnerability in DSA signature generation ([CVE-2018-0734])
+  * Timing vulnerability in ECDSA signature generation ([CVE-2018-0735])
 
 ### Major changes between OpenSSL 1.1.0i and OpenSSL 1.1.1 [11 Sep 2018]
 
@@ -186,38 +186,38 @@ OpenSSL 1.1.0
 ### Major changes between OpenSSL 1.1.0k and OpenSSL 1.1.0l [10 Sep 2019]
 
   * Fixed a padding oracle in PKCS7_dataDecode and CMS_decrypt_set1_pkey
-    ([CVE-2019-1563][])
+    ([CVE-2019-1563])
   * For built-in EC curves, ensure an EC_GROUP built from the curve name is
     used even when parsing explicit parameters
   * Compute ECC cofactors if not provided during EC_GROUP construction
-    ([CVE-2019-1547][])
-  * Use Windows installation paths in the mingw builds ([CVE-2019-1552][])
+    ([CVE-2019-1547])
+  * Use Windows installation paths in the mingw builds ([CVE-2019-1552])
 
 ### Major changes between OpenSSL 1.1.0j and OpenSSL 1.1.0k [28 May 2019]
 
-  * Prevent over long nonces in ChaCha20-Poly1305 ([CVE-2019-1543][])
+  * Prevent over long nonces in ChaCha20-Poly1305 ([CVE-2019-1543])
 
 ### Major changes between OpenSSL 1.1.0i and OpenSSL 1.1.0j [20 Nov 2018]
 
-  * Timing vulnerability in DSA signature generation ([CVE-2018-0734][])
-  * Timing vulnerability in ECDSA signature generation ([CVE-2018-0735][])
+  * Timing vulnerability in DSA signature generation ([CVE-2018-0734])
+  * Timing vulnerability in ECDSA signature generation ([CVE-2018-0735])
 
 ### Major changes between OpenSSL 1.1.0h and OpenSSL 1.1.0i [14 Aug 2018]
 
-  * Client DoS due to large DH parameter ([CVE-2018-0732][])
-  * Cache timing vulnerability in RSA Key Generation ([CVE-2018-0737][])
+  * Client DoS due to large DH parameter ([CVE-2018-0732])
+  * Cache timing vulnerability in RSA Key Generation ([CVE-2018-0737])
 
 ### Major changes between OpenSSL 1.1.0g and OpenSSL 1.1.0h [27 Mar 2018]
 
   * Constructed ASN.1 types with a recursive definition could exceed the
-    stack ([CVE-2018-0739][])
-  * Incorrect CRYPTO_memcmp on HP-UX PA-RISC ([CVE-2018-0733][])
-  * rsaz_1024_mul_avx2 overflow bug on x86_64 ([CVE-2017-3738][])
+    stack ([CVE-2018-0739])
+  * Incorrect CRYPTO_memcmp on HP-UX PA-RISC ([CVE-2018-0733])
+  * rsaz_1024_mul_avx2 overflow bug on x86_64 ([CVE-2017-3738])
 
 ### Major changes between OpenSSL 1.1.0f and OpenSSL 1.1.0g [2 Nov 2017]
 
-  * bn_sqrx8x_internal carry bug on x86_64 ([CVE-2017-3736][])
-  * Malformed X.509 IPAddressFamily could cause OOB read ([CVE-2017-3735][])
+  * bn_sqrx8x_internal carry bug on x86_64 ([CVE-2017-3736])
+  * Malformed X.509 IPAddressFamily could cause OOB read ([CVE-2017-3735])
 
 ### Major changes between OpenSSL 1.1.0e and OpenSSL 1.1.0f [25 May 2017]
 
@@ -225,32 +225,32 @@ OpenSSL 1.1.0
 
 ### Major changes between OpenSSL 1.1.0d and OpenSSL 1.1.0e [16 Feb 2017]
 
-  * Encrypt-Then-Mac renegotiation crash ([CVE-2017-3733][])
+  * Encrypt-Then-Mac renegotiation crash ([CVE-2017-3733])
 
 ### Major changes between OpenSSL 1.1.0c and OpenSSL 1.1.0d [26 Jan 2017]
 
-  * Truncated packet could crash via OOB read ([CVE-2017-3731][])
-  * Bad (EC)DHE parameters cause a client crash ([CVE-2017-3730][])
-  * BN_mod_exp may produce incorrect results on x86_64 ([CVE-2017-3732][])
+  * Truncated packet could crash via OOB read ([CVE-2017-3731])
+  * Bad (EC)DHE parameters cause a client crash ([CVE-2017-3730])
+  * BN_mod_exp may produce incorrect results on x86_64 ([CVE-2017-3732])
 
 ### Major changes between OpenSSL 1.1.0b and OpenSSL 1.1.0c [10 Nov 2016]
 
-  * ChaCha20/Poly1305 heap-buffer-overflow ([CVE-2016-7054][])
-  * CMS Null dereference ([CVE-2016-7053][])
-  * Montgomery multiplication may produce incorrect results ([CVE-2016-7055][])
+  * ChaCha20/Poly1305 heap-buffer-overflow ([CVE-2016-7054])
+  * CMS Null dereference ([CVE-2016-7053])
+  * Montgomery multiplication may produce incorrect results ([CVE-2016-7055])
 
 ### Major changes between OpenSSL 1.1.0a and OpenSSL 1.1.0b [26 Sep 2016]
 
-  * Fix Use After Free for large message sizes ([CVE-2016-6309][])
+  * Fix Use After Free for large message sizes ([CVE-2016-6309])
 
 ### Major changes between OpenSSL 1.1.0 and OpenSSL 1.1.0a [22 Sep 2016]
 
-  * OCSP Status Request extension unbounded memory growth ([CVE-2016-6304][])
-  * SSL_peek() hang on empty record ([CVE-2016-6305][])
+  * OCSP Status Request extension unbounded memory growth ([CVE-2016-6304])
+  * SSL_peek() hang on empty record ([CVE-2016-6305])
   * Excessive allocation of memory in tls_get_message_header()
-    ([CVE-2016-6307][])
+    ([CVE-2016-6307])
   * Excessive allocation of memory in dtls1_preprocess_fragment()
-    ([CVE-2016-6308][])
+    ([CVE-2016-6308])
 
 ### Major changes between OpenSSL 1.0.2h and OpenSSL 1.1.0 [25 Aug 2016]
 
@@ -306,13 +306,13 @@ OpenSSL 1.0.2
 ### Major changes between OpenSSL 1.0.2s and OpenSSL 1.0.2t [10 Sep 2019]
 
   * Fixed a padding oracle in PKCS7_dataDecode and CMS_decrypt_set1_pkey
-    ([CVE-2019-1563][])
+    ([CVE-2019-1563])
   * For built-in EC curves, ensure an EC_GROUP built from the curve name is
     used even when parsing explicit parameters
   * Compute ECC cofactors if not provided during EC_GROUP construction
-    ([CVE-2019-1547][])
+    ([CVE-2019-1547])
   * Document issue with installation paths in diverse Windows builds
-    ([CVE-2019-1552][])
+    ([CVE-2019-1552])
 
 ### Major changes between OpenSSL 1.0.2r and OpenSSL 1.0.2s [28 May 2019]
 
@@ -320,32 +320,32 @@ OpenSSL 1.0.2
 
 ### Major changes between OpenSSL 1.0.2q and OpenSSL 1.0.2r [26 Feb 2019]
 
-  * 0-byte record padding oracle ([CVE-2019-1559][])
+  * 0-byte record padding oracle ([CVE-2019-1559])
 
 ### Major changes between OpenSSL 1.0.2p and OpenSSL 1.0.2q [20 Nov 2018]
 
-  * Microarchitecture timing vulnerability in ECC scalar multiplication ([CVE-2018-5407][])
-  * Timing vulnerability in DSA signature generation ([CVE-2018-0734][])
+  * Microarchitecture timing vulnerability in ECC scalar multiplication ([CVE-2018-5407])
+  * Timing vulnerability in DSA signature generation ([CVE-2018-0734])
 
 ### Major changes between OpenSSL 1.0.2o and OpenSSL 1.0.2p [14 Aug 2018]
 
-  * Client DoS due to large DH parameter ([CVE-2018-0732][])
-  * Cache timing vulnerability in RSA Key Generation ([CVE-2018-0737][])
+  * Client DoS due to large DH parameter ([CVE-2018-0732])
+  * Cache timing vulnerability in RSA Key Generation ([CVE-2018-0737])
 
 ### Major changes between OpenSSL 1.0.2n and OpenSSL 1.0.2o [27 Mar 2018]
 
   * Constructed ASN.1 types with a recursive definition could exceed the
-    stack ([CVE-2018-0739][])
+    stack ([CVE-2018-0739])
 
 ### Major changes between OpenSSL 1.0.2m and OpenSSL 1.0.2n [7 Dec 2017]
 
-  * Read/write after SSL object in error state ([CVE-2017-3737][])
-  * rsaz_1024_mul_avx2 overflow bug on x86_64 ([CVE-2017-3738][])
+  * Read/write after SSL object in error state ([CVE-2017-3737])
+  * rsaz_1024_mul_avx2 overflow bug on x86_64 ([CVE-2017-3738])
 
 ### Major changes between OpenSSL 1.0.2l and OpenSSL 1.0.2m [2 Nov 2017]
 
-  * bn_sqrx8x_internal carry bug on x86_64 ([CVE-2017-3736][])
-  * Malformed X.509 IPAddressFamily could cause OOB read ([CVE-2017-3735][])
+  * bn_sqrx8x_internal carry bug on x86_64 ([CVE-2017-3736])
+  * Malformed X.509 IPAddressFamily could cause OOB read ([CVE-2017-3735])
 
 ### Major changes between OpenSSL 1.0.2k and OpenSSL 1.0.2l [25 May 2017]
 
@@ -353,35 +353,35 @@ OpenSSL 1.0.2
 
 ### Major changes between OpenSSL 1.0.2j and OpenSSL 1.0.2k [26 Jan 2017]
 
-  * Truncated packet could crash via OOB read ([CVE-2017-3731][])
-  * BN_mod_exp may produce incorrect results on x86_64 ([CVE-2017-3732][])
-  * Montgomery multiplication may produce incorrect results ([CVE-2016-7055][])
+  * Truncated packet could crash via OOB read ([CVE-2017-3731])
+  * BN_mod_exp may produce incorrect results on x86_64 ([CVE-2017-3732])
+  * Montgomery multiplication may produce incorrect results ([CVE-2016-7055])
 
 ### Major changes between OpenSSL 1.0.2i and OpenSSL 1.0.2j [26 Sep 2016]
 
-  * Missing CRL sanity check ([CVE-2016-7052][])
+  * Missing CRL sanity check ([CVE-2016-7052])
 
 ### Major changes between OpenSSL 1.0.2h and OpenSSL 1.0.2i [22 Sep 2016]
 
-  * OCSP Status Request extension unbounded memory growth ([CVE-2016-6304][])
-  * SWEET32 Mitigation ([CVE-2016-2183][])
-  * OOB write in MDC2_Update() ([CVE-2016-6303][])
-  * Malformed SHA512 ticket DoS ([CVE-2016-6302][])
-  * OOB write in BN_bn2dec() ([CVE-2016-2182][])
-  * OOB read in TS_OBJ_print_bio() ([CVE-2016-2180][])
-  * Pointer arithmetic undefined behaviour ([CVE-2016-2177][])
-  * Constant time flag not preserved in DSA signing ([CVE-2016-2178][])
-  * DTLS buffered message DoS ([CVE-2016-2179][])
-  * DTLS replay protection DoS ([CVE-2016-2181][])
-  * Certificate message OOB reads ([CVE-2016-6306][])
+  * OCSP Status Request extension unbounded memory growth ([CVE-2016-6304])
+  * SWEET32 Mitigation ([CVE-2016-2183])
+  * OOB write in MDC2_Update() ([CVE-2016-6303])
+  * Malformed SHA512 ticket DoS ([CVE-2016-6302])
+  * OOB write in BN_bn2dec() ([CVE-2016-2182])
+  * OOB read in TS_OBJ_print_bio() ([CVE-2016-2180])
+  * Pointer arithmetic undefined behaviour ([CVE-2016-2177])
+  * Constant time flag not preserved in DSA signing ([CVE-2016-2178])
+  * DTLS buffered message DoS ([CVE-2016-2179])
+  * DTLS replay protection DoS ([CVE-2016-2181])
+  * Certificate message OOB reads ([CVE-2016-6306])
 
 ### Major changes between OpenSSL 1.0.2g and OpenSSL 1.0.2h [3 May 2016]
 
-  * Prevent padding oracle in AES-NI CBC MAC check ([CVE-2016-2107][])
-  * Fix EVP_EncodeUpdate overflow ([CVE-2016-2105][])
-  * Fix EVP_EncryptUpdate overflow ([CVE-2016-2106][])
-  * Prevent ASN.1 BIO excessive memory allocation ([CVE-2016-2109][])
-  * EBCDIC overread ([CVE-2016-2176][])
+  * Prevent padding oracle in AES-NI CBC MAC check ([CVE-2016-2107])
+  * Fix EVP_EncodeUpdate overflow ([CVE-2016-2105])
+  * Fix EVP_EncryptUpdate overflow ([CVE-2016-2106])
+  * Prevent ASN.1 BIO excessive memory allocation ([CVE-2016-2109])
+  * EBCDIC overread ([CVE-2016-2176])
   * Modify behavior of ALPN to invoke callback after SNI/servername
     callback, such that updates to the SSL_CTX affect ALPN.
   * Remove LOW from the DEFAULT cipher list.  This removes singles DES from
@@ -392,33 +392,33 @@ OpenSSL 1.0.2
 
   * Disable weak ciphers in SSLv3 and up in default builds of OpenSSL.
   * Disable SSLv2 default build, default negotiation and weak ciphers
-    ([CVE-2016-0800][])
-  * Fix a double-free in DSA code ([CVE-2016-0705][])
+    ([CVE-2016-0800])
+  * Fix a double-free in DSA code ([CVE-2016-0705])
   * Disable SRP fake user seed to address a server memory leak
-    ([CVE-2016-0798][])
+    ([CVE-2016-0798])
   * Fix BN_hex2bn/BN_dec2bn NULL pointer deref/heap corruption
-    ([CVE-2016-0797][])
-  * Fix memory issues in BIO_*printf functions ([CVE-2016-0799][])
-  * Fix side channel attack on modular exponentiation ([CVE-2016-0702][])
+    ([CVE-2016-0797])
+  * Fix memory issues in BIO_*printf functions ([CVE-2016-0799])
+  * Fix side channel attack on modular exponentiation ([CVE-2016-0702])
 
 ### Major changes between OpenSSL 1.0.2e and OpenSSL 1.0.2f [28 Jan 2016]
 
-  * DH small subgroups ([CVE-2016-0701][])
-  * SSLv2 doesn't block disabled ciphers ([CVE-2015-3197][])
+  * DH small subgroups ([CVE-2016-0701])
+  * SSLv2 doesn't block disabled ciphers ([CVE-2015-3197])
 
 ### Major changes between OpenSSL 1.0.2d and OpenSSL 1.0.2e [3 Dec 2015]
 
-  * BN_mod_exp may produce incorrect results on x86_64 ([CVE-2015-3193][])
-  * Certificate verify crash with missing PSS parameter ([CVE-2015-3194][])
-  * X509_ATTRIBUTE memory leak ([CVE-2015-3195][])
+  * BN_mod_exp may produce incorrect results on x86_64 ([CVE-2015-3193])
+  * Certificate verify crash with missing PSS parameter ([CVE-2015-3194])
+  * X509_ATTRIBUTE memory leak ([CVE-2015-3195])
   * Rewrite EVP_DecodeUpdate (base64 decoding) to fix several bugs
   * In DSA_generate_parameters_ex, if the provided seed is too short,
     return an error
 
 ### Major changes between OpenSSL 1.0.2c and OpenSSL 1.0.2d [9 Jul 2015]
 
-  * Alternate chains certificate forgery ([CVE-2015-1793][])
-  * Race condition handling PSK identify hint ([CVE-2015-3196][])
+  * Alternate chains certificate forgery ([CVE-2015-1793])
+  * Race condition handling PSK identify hint ([CVE-2015-3196])
 
 ### Major changes between OpenSSL 1.0.2b and OpenSSL 1.0.2c [12 Jun 2015]
 
@@ -426,26 +426,26 @@ OpenSSL 1.0.2
 
 ### Major changes between OpenSSL 1.0.2a and OpenSSL 1.0.2b [11 Jun 2015]
 
-  * Malformed ECParameters causes infinite loop ([CVE-2015-1788][])
-  * Exploitable out-of-bounds read in X509_cmp_time ([CVE-2015-1789][])
-  * PKCS7 crash with missing EnvelopedContent ([CVE-2015-1790][])
-  * CMS verify infinite loop with unknown hash function ([CVE-2015-1792][])
-  * Race condition handling NewSessionTicket ([CVE-2015-1791][])
+  * Malformed ECParameters causes infinite loop ([CVE-2015-1788])
+  * Exploitable out-of-bounds read in X509_cmp_time ([CVE-2015-1789])
+  * PKCS7 crash with missing EnvelopedContent ([CVE-2015-1790])
+  * CMS verify infinite loop with unknown hash function ([CVE-2015-1792])
+  * Race condition handling NewSessionTicket ([CVE-2015-1791])
 
 ### Major changes between OpenSSL 1.0.2 and OpenSSL 1.0.2a [19 Mar 2015]
 
-  * OpenSSL 1.0.2 ClientHello sigalgs DoS fix ([CVE-2015-0291][])
-  * Multiblock corrupted pointer fix ([CVE-2015-0290][])
-  * Segmentation fault in DTLSv1_listen fix ([CVE-2015-0207][])
-  * Segmentation fault in ASN1_TYPE_cmp fix ([CVE-2015-0286][])
-  * Segmentation fault for invalid PSS parameters fix ([CVE-2015-0208][])
-  * ASN.1 structure reuse memory corruption fix ([CVE-2015-0287][])
-  * PKCS7 NULL pointer dereferences fix ([CVE-2015-0289][])
-  * DoS via reachable assert in SSLv2 servers fix ([CVE-2015-0293][])
-  * Empty CKE with client auth and DHE fix ([CVE-2015-1787][])
-  * Handshake with unseeded PRNG fix ([CVE-2015-0285][])
-  * Use After Free following d2i_ECPrivatekey error fix ([CVE-2015-0209][])
-  * X509_to_X509_REQ NULL pointer deref fix ([CVE-2015-0288][])
+  * OpenSSL 1.0.2 ClientHello sigalgs DoS fix ([CVE-2015-0291])
+  * Multiblock corrupted pointer fix ([CVE-2015-0290])
+  * Segmentation fault in DTLSv1_listen fix ([CVE-2015-0207])
+  * Segmentation fault in ASN1_TYPE_cmp fix ([CVE-2015-0286])
+  * Segmentation fault for invalid PSS parameters fix ([CVE-2015-0208])
+  * ASN.1 structure reuse memory corruption fix ([CVE-2015-0287])
+  * PKCS7 NULL pointer dereferences fix ([CVE-2015-0289])
+  * DoS via reachable assert in SSLv2 servers fix ([CVE-2015-0293])
+  * Empty CKE with client auth and DHE fix ([CVE-2015-1787])
+  * Handshake with unseeded PRNG fix ([CVE-2015-0285])
+  * Use After Free following d2i_ECPrivatekey error fix ([CVE-2015-0209])
+  * X509_to_X509_REQ NULL pointer deref fix ([CVE-2015-0288])
   * Removed the export ciphers from the DEFAULT ciphers
 
 ### Major changes between OpenSSL 1.0.1l and OpenSSL 1.0.2 [22 Jan 2015]
@@ -464,25 +464,25 @@ OpenSSL 1.0.1
 
 ### Major changes between OpenSSL 1.0.1t and OpenSSL 1.0.1u [22 Sep 2016]
 
-  * OCSP Status Request extension unbounded memory growth ([CVE-2016-6304][])
-  * SWEET32 Mitigation ([CVE-2016-2183][])
-  * OOB write in MDC2_Update() ([CVE-2016-6303][])
-  * Malformed SHA512 ticket DoS ([CVE-2016-6302][])
-  * OOB write in BN_bn2dec() ([CVE-2016-2182][])
-  * OOB read in TS_OBJ_print_bio() ([CVE-2016-2180][])
-  * Pointer arithmetic undefined behaviour ([CVE-2016-2177][])
-  * Constant time flag not preserved in DSA signing ([CVE-2016-2178][])
-  * DTLS buffered message DoS ([CVE-2016-2179][])
-  * DTLS replay protection DoS ([CVE-2016-2181][])
-  * Certificate message OOB reads ([CVE-2016-6306][])
+  * OCSP Status Request extension unbounded memory growth ([CVE-2016-6304])
+  * SWEET32 Mitigation ([CVE-2016-2183])
+  * OOB write in MDC2_Update() ([CVE-2016-6303])
+  * Malformed SHA512 ticket DoS ([CVE-2016-6302])
+  * OOB write in BN_bn2dec() ([CVE-2016-2182])
+  * OOB read in TS_OBJ_print_bio() ([CVE-2016-2180])
+  * Pointer arithmetic undefined behaviour ([CVE-2016-2177])
+  * Constant time flag not preserved in DSA signing ([CVE-2016-2178])
+  * DTLS buffered message DoS ([CVE-2016-2179])
+  * DTLS replay protection DoS ([CVE-2016-2181])
+  * Certificate message OOB reads ([CVE-2016-6306])
 
 ### Major changes between OpenSSL 1.0.1s and OpenSSL 1.0.1t [3 May 2016]
 
-  * Prevent padding oracle in AES-NI CBC MAC check ([CVE-2016-2107][])
-  * Fix EVP_EncodeUpdate overflow ([CVE-2016-2105][])
-  * Fix EVP_EncryptUpdate overflow ([CVE-2016-2106][])
-  * Prevent ASN.1 BIO excessive memory allocation ([CVE-2016-2109][])
-  * EBCDIC overread ([CVE-2016-2176][])
+  * Prevent padding oracle in AES-NI CBC MAC check ([CVE-2016-2107])
+  * Fix EVP_EncodeUpdate overflow ([CVE-2016-2105])
+  * Fix EVP_EncryptUpdate overflow ([CVE-2016-2106])
+  * Prevent ASN.1 BIO excessive memory allocation ([CVE-2016-2109])
+  * EBCDIC overread ([CVE-2016-2176])
   * Modify behavior of ALPN to invoke callback after SNI/servername
     callback, such that updates to the SSL_CTX affect ALPN.
   * Remove LOW from the DEFAULT cipher list.  This removes singles DES from
@@ -493,32 +493,32 @@ OpenSSL 1.0.1
 
   * Disable weak ciphers in SSLv3 and up in default builds of OpenSSL.
   * Disable SSLv2 default build, default negotiation and weak ciphers
-    ([CVE-2016-0800][])
-  * Fix a double-free in DSA code ([CVE-2016-0705][])
+    ([CVE-2016-0800])
+  * Fix a double-free in DSA code ([CVE-2016-0705])
   * Disable SRP fake user seed to address a server memory leak
-    ([CVE-2016-0798][])
+    ([CVE-2016-0798])
   * Fix BN_hex2bn/BN_dec2bn NULL pointer deref/heap corruption
-    ([CVE-2016-0797][])
-  * Fix memory issues in BIO_*printf functions ([CVE-2016-0799][])
-  * Fix side channel attack on modular exponentiation ([CVE-2016-0702][])
+    ([CVE-2016-0797])
+  * Fix memory issues in BIO_*printf functions ([CVE-2016-0799])
+  * Fix side channel attack on modular exponentiation ([CVE-2016-0702])
 
 ### Major changes between OpenSSL 1.0.1q and OpenSSL 1.0.1r [28 Jan 2016]
 
   * Protection for DH small subgroup attacks
-  * SSLv2 doesn't block disabled ciphers ([CVE-2015-3197][])
+  * SSLv2 doesn't block disabled ciphers ([CVE-2015-3197])
 
 ### Major changes between OpenSSL 1.0.1p and OpenSSL 1.0.1q [3 Dec 2015]
 
-  * Certificate verify crash with missing PSS parameter ([CVE-2015-3194][])
-  * X509_ATTRIBUTE memory leak ([CVE-2015-3195][])
+  * Certificate verify crash with missing PSS parameter ([CVE-2015-3194])
+  * X509_ATTRIBUTE memory leak ([CVE-2015-3195])
   * Rewrite EVP_DecodeUpdate (base64 decoding) to fix several bugs
   * In DSA_generate_parameters_ex, if the provided seed is too short,
     return an error
 
 ### Major changes between OpenSSL 1.0.1o and OpenSSL 1.0.1p [9 Jul 2015]
 
-  * Alternate chains certificate forgery ([CVE-2015-1793][])
-  * Race condition handling PSK identify hint ([CVE-2015-3196][])
+  * Alternate chains certificate forgery ([CVE-2015-1793])
+  * Race condition handling PSK identify hint ([CVE-2015-3196])
 
 ### Major changes between OpenSSL 1.0.1n and OpenSSL 1.0.1o [12 Jun 2015]
 
@@ -526,20 +526,20 @@ OpenSSL 1.0.1
 
 ### Major changes between OpenSSL 1.0.1m and OpenSSL 1.0.1n [11 Jun 2015]
 
-  * Malformed ECParameters causes infinite loop ([CVE-2015-1788][])
-  * Exploitable out-of-bounds read in X509_cmp_time ([CVE-2015-1789][])
-  * PKCS7 crash with missing EnvelopedContent ([CVE-2015-1790][])
-  * CMS verify infinite loop with unknown hash function ([CVE-2015-1792][])
-  * Race condition handling NewSessionTicket ([CVE-2015-1791][])
+  * Malformed ECParameters causes infinite loop ([CVE-2015-1788])
+  * Exploitable out-of-bounds read in X509_cmp_time ([CVE-2015-1789])
+  * PKCS7 crash with missing EnvelopedContent ([CVE-2015-1790])
+  * CMS verify infinite loop with unknown hash function ([CVE-2015-1792])
+  * Race condition handling NewSessionTicket ([CVE-2015-1791])
 
 ### Major changes between OpenSSL 1.0.1l and OpenSSL 1.0.1m [19 Mar 2015]
 
-  * Segmentation fault in ASN1_TYPE_cmp fix ([CVE-2015-0286][])
-  * ASN.1 structure reuse memory corruption fix ([CVE-2015-0287][])
-  * PKCS7 NULL pointer dereferences fix ([CVE-2015-0289][])
-  * DoS via reachable assert in SSLv2 servers fix ([CVE-2015-0293][])
-  * Use After Free following d2i_ECPrivatekey error fix ([CVE-2015-0209][])
-  * X509_to_X509_REQ NULL pointer deref fix ([CVE-2015-0288][])
+  * Segmentation fault in ASN1_TYPE_cmp fix ([CVE-2015-0286])
+  * ASN.1 structure reuse memory corruption fix ([CVE-2015-0287])
+  * PKCS7 NULL pointer dereferences fix ([CVE-2015-0289])
+  * DoS via reachable assert in SSLv2 servers fix ([CVE-2015-0293])
+  * Use After Free following d2i_ECPrivatekey error fix ([CVE-2015-0209])
+  * X509_to_X509_REQ NULL pointer deref fix ([CVE-2015-0288])
   * Removed the export ciphers from the DEFAULT ciphers
 
 ### Major changes between OpenSSL 1.0.1k and OpenSSL 1.0.1l [15 Jan 2015]
@@ -548,71 +548,71 @@ OpenSSL 1.0.1
 
 ### Major changes between OpenSSL 1.0.1j and OpenSSL 1.0.1k [8 Jan 2015]
 
-  * Fix for [CVE-2014-3571][]
-  * Fix for [CVE-2015-0206][]
-  * Fix for [CVE-2014-3569][]
-  * Fix for [CVE-2014-3572][]
-  * Fix for [CVE-2015-0204][]
-  * Fix for [CVE-2015-0205][]
-  * Fix for [CVE-2014-8275][]
-  * Fix for [CVE-2014-3570][]
+  * Fix for [CVE-2014-3571]
+  * Fix for [CVE-2015-0206]
+  * Fix for [CVE-2014-3569]
+  * Fix for [CVE-2014-3572]
+  * Fix for [CVE-2015-0204]
+  * Fix for [CVE-2015-0205]
+  * Fix for [CVE-2014-8275]
+  * Fix for [CVE-2014-3570]
 
 ### Major changes between OpenSSL 1.0.1i and OpenSSL 1.0.1j [15 Oct 2014]
 
-  * Fix for [CVE-2014-3513][]
-  * Fix for [CVE-2014-3567][]
-  * Mitigation for [CVE-2014-3566][] (SSL protocol vulnerability)
-  * Fix for [CVE-2014-3568][]
+  * Fix for [CVE-2014-3513]
+  * Fix for [CVE-2014-3567]
+  * Mitigation for [CVE-2014-3566] (SSL protocol vulnerability)
+  * Fix for [CVE-2014-3568]
 
 ### Major changes between OpenSSL 1.0.1h and OpenSSL 1.0.1i [6 Aug 2014]
 
-  * Fix for [CVE-2014-3512][]
-  * Fix for [CVE-2014-3511][]
-  * Fix for [CVE-2014-3510][]
-  * Fix for [CVE-2014-3507][]
-  * Fix for [CVE-2014-3506][]
-  * Fix for [CVE-2014-3505][]
-  * Fix for [CVE-2014-3509][]
-  * Fix for [CVE-2014-5139][]
-  * Fix for [CVE-2014-3508][]
+  * Fix for [CVE-2014-3512]
+  * Fix for [CVE-2014-3511]
+  * Fix for [CVE-2014-3510]
+  * Fix for [CVE-2014-3507]
+  * Fix for [CVE-2014-3506]
+  * Fix for [CVE-2014-3505]
+  * Fix for [CVE-2014-3509]
+  * Fix for [CVE-2014-5139]
+  * Fix for [CVE-2014-3508]
 
 ### Major changes between OpenSSL 1.0.1g and OpenSSL 1.0.1h [5 Jun 2014]
 
-  * Fix for [CVE-2014-0224][]
-  * Fix for [CVE-2014-0221][]
-  * Fix for [CVE-2014-0198][]
-  * Fix for [CVE-2014-0195][]
-  * Fix for [CVE-2014-3470][]
-  * Fix for [CVE-2010-5298][]
+  * Fix for [CVE-2014-0224]
+  * Fix for [CVE-2014-0221]
+  * Fix for [CVE-2014-0198]
+  * Fix for [CVE-2014-0195]
+  * Fix for [CVE-2014-3470]
+  * Fix for [CVE-2010-5298]
 
 ### Major changes between OpenSSL 1.0.1f and OpenSSL 1.0.1g [7 Apr 2014]
 
-  * Fix for [CVE-2014-0160][]
+  * Fix for [CVE-2014-0160]
   * Add TLS padding extension workaround for broken servers.
-  * Fix for [CVE-2014-0076][]
+  * Fix for [CVE-2014-0076]
 
 ### Major changes between OpenSSL 1.0.1e and OpenSSL 1.0.1f [6 Jan 2014]
 
   * Don't include gmt_unix_time in TLS server and client random values
-  * Fix for TLS record tampering bug [CVE-2013-4353][]
-  * Fix for TLS version checking bug [CVE-2013-6449][]
-  * Fix for DTLS retransmission bug [CVE-2013-6450][]
+  * Fix for TLS record tampering bug ([CVE-2013-4353])
+  * Fix for TLS version checking bug ([CVE-2013-6449])
+  * Fix for DTLS retransmission bug ([CVE-2013-6450])
 
 ### Major changes between OpenSSL 1.0.1d and OpenSSL 1.0.1e [11 Feb 2013]
 
-  * Corrected fix for [CVE-2013-0169][]
+  * Corrected fix for ([CVE-2013-0169])
 
 ### Major changes between OpenSSL 1.0.1c and OpenSSL 1.0.1d [4 Feb 2013]
 
   * Fix renegotiation in TLS 1.1, 1.2 by using the correct TLS version.
   * Include the fips configuration module.
-  * Fix OCSP bad key DoS attack [CVE-2013-0166][]
-  * Fix for SSL/TLS/DTLS CBC plaintext recovery attack [CVE-2013-0169][]
-  * Fix for TLS AESNI record handling flaw [CVE-2012-2686][]
+  * Fix OCSP bad key DoS attack ([CVE-2013-0166])
+  * Fix for SSL/TLS/DTLS CBC plaintext recovery attack ([CVE-2013-0169])
+  * Fix for TLS AESNI record handling flaw ([CVE-2012-2686])
 
 ### Major changes between OpenSSL 1.0.1b and OpenSSL 1.0.1c [10 May 2012]
 
-  * Fix TLS/DTLS record length checking bug [CVE-2012-2333][]
+  * Fix TLS/DTLS record length checking bug ([CVE-2012-2333])
   * Don't attempt to use non-FIPS composite ciphers in FIPS mode.
 
 ### Major changes between OpenSSL 1.0.1a and OpenSSL 1.0.1b [26 Apr 2012]
@@ -623,7 +623,7 @@ OpenSSL 1.0.1
 
 ### Major changes between OpenSSL 1.0.1 and OpenSSL 1.0.1a [19 Apr 2012]
 
-  * Fix for ASN1 overflow bug [CVE-2012-2110][]
+  * Fix for ASN1 overflow bug ([CVE-2012-2110])
   * Workarounds for some servers that hang on long client hellos.
   * Fix SEGV in AES code.
 
@@ -645,25 +645,25 @@ OpenSSL 1.0.0
 
 ### Major changes between OpenSSL 1.0.0s and OpenSSL 1.0.0t [3 Dec 2015]
 
-  * X509_ATTRIBUTE memory leak ([CVE-2015-3195][])
-  * Race condition handling PSK identify hint ([CVE-2015-3196][])
+  * X509_ATTRIBUTE memory leak (([CVE-2015-3195]))
+  * Race condition handling PSK identify hint ([CVE-2015-3196])
 
 ### Major changes between OpenSSL 1.0.0r and OpenSSL 1.0.0s [11 Jun 2015]
 
-  * Malformed ECParameters causes infinite loop ([CVE-2015-1788][])
-  * Exploitable out-of-bounds read in X509_cmp_time ([CVE-2015-1789][])
-  * PKCS7 crash with missing EnvelopedContent ([CVE-2015-1790][])
-  * CMS verify infinite loop with unknown hash function ([CVE-2015-1792][])
-  * Race condition handling NewSessionTicket ([CVE-2015-1791][])
+  * Malformed ECParameters causes infinite loop ([CVE-2015-1788])
+  * Exploitable out-of-bounds read in X509_cmp_time ([CVE-2015-1789])
+  * PKCS7 crash with missing EnvelopedContent ([CVE-2015-1790])
+  * CMS verify infinite loop with unknown hash function ([CVE-2015-1792])
+  * Race condition handling NewSessionTicket ([CVE-2015-1791])
 
 ### Major changes between OpenSSL 1.0.0q and OpenSSL 1.0.0r [19 Mar 2015]
 
-  * Segmentation fault in ASN1_TYPE_cmp fix ([CVE-2015-0286][])
-  * ASN.1 structure reuse memory corruption fix ([CVE-2015-0287][])
-  * PKCS7 NULL pointer dereferences fix ([CVE-2015-0289][])
-  * DoS via reachable assert in SSLv2 servers fix ([CVE-2015-0293][])
-  * Use After Free following d2i_ECPrivatekey error fix ([CVE-2015-0209][])
-  * X509_to_X509_REQ NULL pointer deref fix ([CVE-2015-0288][])
+  * Segmentation fault in ASN1_TYPE_cmp fix ([CVE-2015-0286])
+  * ASN.1 structure reuse memory corruption fix ([CVE-2015-0287])
+  * PKCS7 NULL pointer dereferences fix ([CVE-2015-0289])
+  * DoS via reachable assert in SSLv2 servers fix ([CVE-2015-0293])
+  * Use After Free following d2i_ECPrivatekey error fix ([CVE-2015-0209])
+  * X509_to_X509_REQ NULL pointer deref fix ([CVE-2015-0288])
   * Removed the export ciphers from the DEFAULT ciphers
 
 ### Major changes between OpenSSL 1.0.0p and OpenSSL 1.0.0q [15 Jan 2015]
@@ -672,30 +672,30 @@ OpenSSL 1.0.0
 
 ### Major changes between OpenSSL 1.0.0o and OpenSSL 1.0.0p [8 Jan 2015]
 
-  * Fix for [CVE-2014-3571][]
-  * Fix for [CVE-2015-0206][]
-  * Fix for [CVE-2014-3569][]
-  * Fix for [CVE-2014-3572][]
-  * Fix for [CVE-2015-0204][]
-  * Fix for [CVE-2015-0205][]
-  * Fix for [CVE-2014-8275][]
-  * Fix for [CVE-2014-3570][]
+  * Fix for [CVE-2014-3571]
+  * Fix for [CVE-2015-0206]
+  * Fix for [CVE-2014-3569]
+  * Fix for [CVE-2014-3572]
+  * Fix for [CVE-2015-0204]
+  * Fix for [CVE-2015-0205]
+  * Fix for [CVE-2014-8275]
+  * Fix for [CVE-2014-3570]
 
 ### Major changes between OpenSSL 1.0.0n and OpenSSL 1.0.0o [15 Oct 2014]
 
-  * Fix for [CVE-2014-3513][]
-  * Fix for [CVE-2014-3567][]
-  * Mitigation for [CVE-2014-3566][] (SSL protocol vulnerability)
-  * Fix for [CVE-2014-3568][]
+  * Fix for [CVE-2014-3513]
+  * Fix for [CVE-2014-3567]
+  * Mitigation for [CVE-2014-3566] (SSL protocol vulnerability)
+  * Fix for [CVE-2014-3568]
 
 ### Major changes between OpenSSL 1.0.0m and OpenSSL 1.0.0n [6 Aug 2014]
 
-  * Fix for [CVE-2014-3510][]
-  * Fix for [CVE-2014-3507][]
-  * Fix for [CVE-2014-3506][]
-  * Fix for [CVE-2014-3505][]
-  * Fix for [CVE-2014-3509][]
-  * Fix for [CVE-2014-3508][]
+  * Fix for [CVE-2014-3510]
+  * Fix for [CVE-2014-3507]
+  * Fix for [CVE-2014-3506]
+  * Fix for [CVE-2014-3505]
+  * Fix for [CVE-2014-3509]
+  * Fix for [CVE-2014-3508]
 
   Known issues in OpenSSL 1.0.0m:
 
@@ -706,78 +706,78 @@ OpenSSL 1.0.0
 
 ### Major changes between OpenSSL 1.0.0l and OpenSSL 1.0.0m [5 Jun 2014]
 
-  * Fix for [CVE-2014-0224][]
-  * Fix for [CVE-2014-0221][]
-  * Fix for [CVE-2014-0198][]
-  * Fix for [CVE-2014-0195][]
-  * Fix for [CVE-2014-3470][]
-  * Fix for [CVE-2014-0076][]
-  * Fix for [CVE-2010-5298][]
+  * Fix for [CVE-2014-0224]
+  * Fix for [CVE-2014-0221]
+  * Fix for [CVE-2014-0198]
+  * Fix for [CVE-2014-0195]
+  * Fix for [CVE-2014-3470]
+  * Fix for [CVE-2014-0076]
+  * Fix for [CVE-2010-5298]
 
 ### Major changes between OpenSSL 1.0.0k and OpenSSL 1.0.0l [6 Jan 2014]
 
-  * Fix for DTLS retransmission bug [CVE-2013-6450][]
+  * Fix for DTLS retransmission bug ([CVE-2013-6450])
 
 ### Major changes between OpenSSL 1.0.0j and OpenSSL 1.0.0k [5 Feb 2013]
 
-  * Fix for SSL/TLS/DTLS CBC plaintext recovery attack [CVE-2013-0169][]
-  * Fix OCSP bad key DoS attack [CVE-2013-0166][]
+  * Fix for SSL/TLS/DTLS CBC plaintext recovery attack ([CVE-2013-0169])
+  * Fix OCSP bad key DoS attack ([CVE-2013-0166])
 
 ### Major changes between OpenSSL 1.0.0i and OpenSSL 1.0.0j [10 May 2012]
 
-  * Fix DTLS record length checking bug [CVE-2012-2333][]
+  * Fix DTLS record length checking bug ([CVE-2012-2333])
 
 ### Major changes between OpenSSL 1.0.0h and OpenSSL 1.0.0i [19 Apr 2012]
 
-  * Fix for ASN1 overflow bug [CVE-2012-2110][]
+  * Fix for ASN1 overflow bug ([CVE-2012-2110])
 
 ### Major changes between OpenSSL 1.0.0g and OpenSSL 1.0.0h [12 Mar 2012]
 
-  * Fix for CMS/PKCS#7 MMA [CVE-2012-0884][]
-  * Corrected fix for [CVE-2011-4619][]
+  * Fix for CMS/PKCS#7 MMA ([CVE-2012-0884])
+  * Corrected fix for ([CVE-2011-4619])
   * Various DTLS fixes.
 
 ### Major changes between OpenSSL 1.0.0f and OpenSSL 1.0.0g [18 Jan 2012]
 
-  * Fix for DTLS DoS issue [CVE-2012-0050][]
+  * Fix for DTLS DoS issue ([CVE-2012-0050])
 
 ### Major changes between OpenSSL 1.0.0e and OpenSSL 1.0.0f [4 Jan 2012]
 
-  * Fix for DTLS plaintext recovery attack [CVE-2011-4108][]
-  * Clear block padding bytes of SSL 3.0 records [CVE-2011-4576][]
-  * Only allow one SGC handshake restart for SSL/TLS [CVE-2011-4619][]
-  * Check parameters are not NULL in GOST ENGINE [CVE-2012-0027][]
-  * Check for malformed RFC3779 data [CVE-2011-4577][]
+  * Fix for DTLS plaintext recovery attack ([CVE-2011-4108])
+  * Clear block padding bytes of SSL 3.0 records ([CVE-2011-4576])
+  * Only allow one SGC handshake restart for SSL/TLS ([CVE-2011-4619])
+  * Check parameters are not NULL in GOST ENGINE ([CVE-2012-0027])
+  * Check for malformed RFC3779 data ([CVE-2011-4577])
 
 ### Major changes between OpenSSL 1.0.0d and OpenSSL 1.0.0e [6 Sep 2011]
 
-  * Fix for CRL vulnerability issue [CVE-2011-3207][]
-  * Fix for ECDH crashes [CVE-2011-3210][]
+  * Fix for CRL vulnerability issue ([CVE-2011-3207])
+  * Fix for ECDH crashes ([CVE-2011-3210])
   * Protection against EC timing attacks.
   * Support ECDH ciphersuites for certificates using SHA2 algorithms.
   * Various DTLS fixes.
 
 ### Major changes between OpenSSL 1.0.0c and OpenSSL 1.0.0d [8 Feb 2011]
 
-  * Fix for security issue [CVE-2011-0014][]
+  * Fix for security issue ([CVE-2011-0014])
 
 ### Major changes between OpenSSL 1.0.0b and OpenSSL 1.0.0c [2 Dec 2010]
 
-  * Fix for security issue [CVE-2010-4180][]
-  * Fix for [CVE-2010-4252][]
+  * Fix for security issue ([CVE-2010-4180])
+  * Fix for ([CVE-2010-4252])
   * Fix mishandling of absent EC point format extension.
   * Fix various platform compilation issues.
-  * Corrected fix for security issue [CVE-2010-3864][].
+  * Corrected fix for security issue ([CVE-2010-3864]).
 
 ### Major changes between OpenSSL 1.0.0a and OpenSSL 1.0.0b [16 Nov 2010]
 
-  * Fix for security issue [CVE-2010-3864][].
-  * Fix for [CVE-2010-2939][]
+  * Fix for security issue ([CVE-2010-3864]).
+  * Fix for ([CVE-2010-2939])
   * Fix WIN32 build system for GOST ENGINE.
 
 ### Major changes between OpenSSL 1.0.0 and OpenSSL 1.0.0a [1 Jun 2010]
 
-  * Fix for security issue [CVE-2010-1633][].
+  * Fix for security issue ([CVE-2010-1633]).
   * GOST MAC and CFB fixes.
 
 ### Major changes between OpenSSL 0.9.8n and OpenSSL 1.0.0 [29 Mar 2010]
@@ -809,7 +809,7 @@ OpenSSL 0.9.x
 ### Major changes between OpenSSL 0.9.8m and OpenSSL 0.9.8n [24 Mar 2010]
 
   * CFB cipher definition fixes.
-  * Fix security issues [CVE-2010-0740][] and [CVE-2010-0433][].
+  * Fix security issues [CVE-2010-0740] and [CVE-2010-0433].
 
 ### Major changes between OpenSSL 0.9.8l and OpenSSL 0.9.8m [25 Feb 2010]
 
@@ -825,16 +825,16 @@ OpenSSL 0.9.x
 
 ### Major changes between OpenSSL 0.9.8k and OpenSSL 0.9.8l [5 Nov 2009]
 
-  * Temporary work around for [CVE-2009-3555][]: disable renegotiation.
+  * Temporary work around for [CVE-2009-3555]: disable renegotiation.
 
 ### Major changes between OpenSSL 0.9.8j and OpenSSL 0.9.8k [25 Mar 2009]
 
   * Fix various build issues.
-  * Fix security issues ([CVE-2009-0590][], [CVE-2009-0591][], [CVE-2009-0789][])
+  * Fix security issues [CVE-2009-0590], [CVE-2009-0591][], [CVE-2009-0789]
 
 ### Major changes between OpenSSL 0.9.8i and OpenSSL 0.9.8j [7 Jan 2009]
 
-  * Fix security issue ([CVE-2008-5077][])
+  * Fix security issue ([CVE-2008-5077])
   * Merge FIPS 140-2 branch code.
 
 ### Major changes between OpenSSL 0.9.8g and OpenSSL 0.9.8h [28 May 2008]
@@ -867,13 +867,13 @@ OpenSSL 0.9.x
 
 ### Major changes between OpenSSL 0.9.8c and OpenSSL 0.9.8d [28 Sep 2006]
 
-  * Introduce limits to prevent malicious key DoS  ([CVE-2006-2940][])
-  * Fix security issues ([CVE-2006-2937][], [CVE-2006-3737][], [CVE-2006-4343][])
+  * Introduce limits to prevent malicious key DoS  ([CVE-2006-2940])
+  * Fix security issues [CVE-2006-2937], [CVE-2006-3737], [CVE-2006-4343]
   * Changes to ciphersuite selection algorithm
 
 ### Major changes between OpenSSL 0.9.8b and OpenSSL 0.9.8c [5 Sep 2006]
 
-  * Fix Daniel Bleichenbacher forged signature attack, [CVE-2006-4339][]
+  * Fix Daniel Bleichenbacher forged signature attack, [CVE-2006-4339]
   * New cipher Camellia
 
 ### Major changes between OpenSSL 0.9.8a and OpenSSL 0.9.8b [4 May 2006]
@@ -888,7 +888,7 @@ OpenSSL 0.9.x
 
 ### Major changes between OpenSSL 0.9.8 and OpenSSL 0.9.8a [11 Oct 2005]
 
-  * Fix potential SSL 2.0 rollback, [CVE-2005-2969][]
+  * Fix potential SSL 2.0 rollback ([CVE-2005-2969])
   * Extended Windows CE support
 
 ### Major changes between OpenSSL 0.9.7g and OpenSSL 0.9.8 [5 Jul 2005]
@@ -972,12 +972,12 @@ OpenSSL 0.9.x
 
 ### Major changes between OpenSSL 0.9.7k and OpenSSL 0.9.7l [28 Sep 2006]
 
-  * Introduce limits to prevent malicious key DoS  ([CVE-2006-2940][])
-  * Fix security issues ([CVE-2006-2937][], [CVE-2006-3737][], [CVE-2006-4343][])
+  * Introduce limits to prevent malicious key DoS  ([CVE-2006-2940])
+  * Fix security issues [CVE-2006-2937], [CVE-2006-3737], [CVE-2006-4343]
 
 ### Major changes between OpenSSL 0.9.7j and OpenSSL 0.9.7k [5 Sep 2006]
 
-  * Fix Daniel Bleichenbacher forged signature attack, [CVE-2006-4339][]
+  * Fix Daniel Bleichenbacher forged signature attack, [CVE-2006-4339]
 
 ### Major changes between OpenSSL 0.9.7i and OpenSSL 0.9.7j [4 May 2006]
 
@@ -990,7 +990,7 @@ OpenSSL 0.9.x
 
 ### Major changes between OpenSSL 0.9.7g and OpenSSL 0.9.7h [11 Oct 2005]
 
-  * Fix SSL 2.0 Rollback, [CVE-2005-2969][]
+  * Fix SSL 2.0 Rollback ([CVE-2005-2969])
   * Allow use of fixed-length exponent on DSA signing
   * Default fixed-window RSA, DSA, DH private-key operations
 


### PR DESCRIPTION
Citing pull request #11346:

> Since the grand markdown revamping in #10545, the CHANGES and NEWS files contain notes for _all_ releases, so they need to be updated, too.
> 
> As long as there is only one stable branch, I can take care of it every time a release has happened.
> 
> _Note: For 3.0 and beyond, the ideal solution would be to update the CHANGES and NEWS files on master only, and backport the relevant sections to the respecitve stable branches using a script when creating the release. But that's a task for a separate pull request in the future..._
> 
> cc @mattcaswell

Since then, the markdown versions on the master branch haven't been updated, which was reported by Michael Wojcik on [openssl-users](https://mta.openssl.org/pipermail/openssl-users/2020-September/012984.html). This is fixed by the first commit.


> Author: Dr. Matthias St. Pierre <matthias.st.pierre@ncp-e.com>
> Date:   Thu Sep 24 07:58:52 2020 +0200
> 
>     Update CHANGES and NEWS for 1.1.1h release


While working on it, I adjusted the CVE link style, see second commit.

> Author: Dr. Matthias St. Pierre <matthias.st.pierre@ncp-e.com>
> Date:   Thu Sep 24 08:11:00 2020 +0200
> 
>     Change CVE link style in CHANGES and NEWS
>     
>     Replace [collapsed reference links][] for the CVEs by
>     [shortcut reference links], in order to to improve the
>     readability of the raw markdown text.
>     
>     Consistently add parentheses around the CVE links at the
>     end of the CVE descriptions. (The NEWS file already had
>     the parentheses, in the CHANGES file they where missing.)
>     
>     [collapsed reference links]:
>       https://github.github.com/gfm/#collapsed-reference-link
>     
>     [shortcut reference links]:
>       https://github.github.com/gfm/#shortcut-reference-link



