### PR TITLE
Configuration: add initial NonStop values in OpenSSL::config

### DIFF
--- a/util/perl/OpenSSL/config.pm
+++ b/util/perl/OpenSSL/config.pm
@@ -872,8 +872,11 @@ EOF
       # model (PUT, SPT or nothing), target execution environment (OSS or
       # GUARDIAN).  And still, there must be some kind of default when
       # nothing else is said.
+      #
+      # nsv is a virtual x86 environment, equivalent to nsx, so we enforce
+      # the latter.
       [ 'nse-tandem-nsk.*',       { target => 'nonstop-nse' } ],
-      [ 'nsv-tandem-nsk.*',       { target => 'nonstop-nsv' } ],
+      [ 'nsv-tandem-nsk.*',       { target => 'nonstop-nsx' } ],
       [ 'nsx-tandem-nsk.*',       { target => 'nonstop-nsx' } ],
 
     ];

--- a/util/perl/OpenSSL/config.pm
+++ b/util/perl/OpenSSL/config.pm
@@ -161,9 +161,9 @@ my $guess_patterns = [
     [ 'vxworks.*',                  '${MACHINE}-whatever-vxworks' ],
 
     # Note: there's also NEO and NSR, but they are old and unsupported
-    [ 'NSE-.*?:NONSTOP_KERNEL:.*',  'nse-tandem-nsk${RELEASE}' ],
-    [ 'NSV-.*?:NONSTOP_KERNEL:.*',  'nsv-tandem-nsk${RELEASE}' ],
-    [ 'NSX-.*?:NONSTOP_KERNEL:.*',  'nsx-tandem-nsk${RELEASE}' ],
+    [ 'NONSTOP_KERNEL:.*:NSE-.*?',  'nse-tandem-nsk${RELEASE}' ],
+    [ 'NONSTOP_KERNEL:.*:NSV-.*?',  'nsv-tandem-nsk${RELEASE}' ],
+    [ 'NONSTOP_KERNEL:.*:NSX-.*?',  'nsx-tandem-nsk${RELEASE}' ],
 
     [ sub { -d '/usr/apollo' },     'whatever-apollo-whatever' ],
 ];

--- a/util/perl/OpenSSL/config.pm
+++ b/util/perl/OpenSSL/config.pm
@@ -160,6 +160,11 @@ my $guess_patterns = [
     [ 'CYGWIN.*',                   '${MACHINE}-pc-cygwin' ],
     [ 'vxworks.*',                  '${MACHINE}-whatever-vxworks' ],
 
+    # Note: there's also NEO and NSR, but they are old and unsupported
+    [ 'NSE-.*?:NONSTOP_KERNEL:.*',  'nse-tandem-nsk${RELEASE}' ],
+    [ 'NSV-.*?:NONSTOP_KERNEL:.*',  'nsv-tandem-nsk${RELEASE}' ],
+    [ 'NSX-.*?:NONSTOP_KERNEL:.*',  'nsx-tandem-nsk${RELEASE}' ],
+
     [ sub { -d '/usr/apollo' },     'whatever-apollo-whatever' ],
 ];
 
@@ -859,6 +864,17 @@ EOF
       # we'll get in the upcoming x86_64 port...
       [ '.*Alpha.*?-.*?-OpenVMS', { target => 'vms-alpha' } ],
       [ '.*?-.*?-OpenVMS',        { target => 'vms-ia64'  } ],
+
+      # TODO: There are a few more choices among OpenSSL config targets, but
+      # reaching them involves a bit more than just a host tripet.  Select
+      # environment variables could do the job to cover for more granular
+      # build options such as data model (ILP32 or LP64), thread support
+      # model (PUT, SPT or nothing), target execution environment (OSS or
+      # GUARDIAN).  And still, there must be some kind of default when
+      # nothing else is said.
+      [ 'nse-tandem-nsk.*',       { target => 'nonstop-nse' } ],
+      [ 'nsv-tandem-nsk.*',       { target => 'nonstop-nsv' } ],
+      [ 'nsx-tandem-nsk.*',       { target => 'nonstop-nsx' } ],
 
     ];
 


### PR DESCRIPTION
This makes Configure work it's automatic config detection, at least for
the simple straightfoward cases.

Fixes #12972
