### PR TITLE
provider: add a query free function

### DIFF
--- a/crypto/core_algorithm.c
+++ b/crypto/core_algorithm.c
@@ -65,6 +65,7 @@ static int algorithm_do_this(OSSL_PROVIDER *provider, void *cbdata)
                 data->fn(provider, thismap, no_store, data->data);
             }
         }
+        ossl_provider_unquery_operation(provider, cur_operation, map);
 
         /* Do we fulfill post-conditions? */
         if (data->post == NULL) {

--- a/crypto/provider.c
+++ b/crypto/provider.c
@@ -75,6 +75,13 @@ const OSSL_ALGORITHM *OSSL_PROVIDER_query_operation(const OSSL_PROVIDER *prov,
     return ossl_provider_query_operation(prov, operation_id, no_cache);
 }
 
+void OSSL_PROVIDER_unquery_operation(const OSSL_PROVIDER *prov,
+                                     int operation_id,
+                                     const OSSL_ALGORITHM *algs)
+{
+    ossl_provider_unquery_operation(prov, operation_id, algs);
+}
+
 void *OSSL_PROVIDER_get0_provider_ctx(const OSSL_PROVIDER *prov)
 {
     return ossl_provider_prov_ctx(prov);

--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -78,6 +78,7 @@ struct ossl_provider_st {
     OSSL_FUNC_provider_get_capabilities_fn *get_capabilities;
     OSSL_FUNC_provider_self_test_fn *self_test;
     OSSL_FUNC_provider_query_operation_fn *query_operation;
+    OSSL_FUNC_provider_unquery_operation_fn *unquery_operation;
 
     /*
      * Cache of bit to indicate of query_operation() has been called on
@@ -571,6 +572,10 @@ static int provider_init(OSSL_PROVIDER *prov)
             prov->query_operation =
                 OSSL_FUNC_provider_query_operation(provider_dispatch);
             break;
+        case OSSL_FUNC_PROVIDER_UNQUERY_OPERATION:
+            prov->unquery_operation =
+                OSSL_FUNC_provider_unquery_operation(provider_dispatch);
+            break;
 #ifndef OPENSSL_NO_ERR
 # ifndef FIPS_MODULE
         case OSSL_FUNC_PROVIDER_GET_REASON_STRINGS:
@@ -925,6 +930,14 @@ const OSSL_ALGORITHM *ossl_provider_query_operation(const OSSL_PROVIDER *prov,
         *no_cache = 1;
 #endif
     return res;
+}
+
+void ossl_provider_unquery_operation(const OSSL_PROVIDER *prov,
+                                     int operation_id,
+                                     const OSSL_ALGORITHM *algs)
+{
+    if (prov->unquery_operation != NULL)
+        prov->unquery_operation(prov->provctx, operation_id, algs);
 }
 
 int ossl_provider_set_operation_bit(OSSL_PROVIDER *provider, size_t bitnum)

--- a/doc/internal/man3/ossl_provider_new.pod
+++ b/doc/internal/man3/ossl_provider_new.pod
@@ -75,7 +75,7 @@ ossl_provider_get_capabilities
                                                      int *no_cache);
  void ossl_provider_unquery_operation(const OSSL_PROVIDER *prov,
                                       int operation_id,
-                                      const OSSL_ALGORITHM * algs);
+                                      const OSSL_ALGORITHM *algs);
 
  int ossl_provider_set_operation_bit(OSSL_PROVIDER *provider, size_t bitnum);
  int ossl_provider_test_operation_bit(OSSL_PROVIDER *provider, size_t bitnum,

--- a/doc/internal/man3/ossl_provider_new.pod
+++ b/doc/internal/man3/ossl_provider_new.pod
@@ -13,7 +13,8 @@ ossl_provider_name, ossl_provider_dso,
 ossl_provider_module_name, ossl_provider_module_path,
 ossl_provider_libctx,
 ossl_provider_teardown, ossl_provider_gettable_params,
-ossl_provider_get_params, ossl_provider_query_operation,
+ossl_provider_get_params,
+ossl_provider_query_operation, ossl_provider_unquery_operation,
 ossl_provider_set_operation_bit, ossl_provider_test_operation_bit,
 ossl_provider_get_capabilities
 - internal provider routines
@@ -72,6 +73,9 @@ ossl_provider_get_capabilities
  const OSSL_ALGORITHM *ossl_provider_query_operation(const OSSL_PROVIDER *prov,
                                                      int operation_id,
                                                      int *no_cache);
+ void ossl_provider_unquery_operation(const OSSL_PROVIDER *prov,
+                                      int operation_id,
+                                      const OSSL_ALGORITHM * algs);
 
  int ossl_provider_set_operation_bit(OSSL_PROVIDER *provider, size_t bitnum);
  int ossl_provider_test_operation_bit(OSSL_PROVIDER *provider, size_t bitnum,
@@ -230,6 +234,10 @@ ossl_provider_query_operation() calls the provider's
 I<query_operation> function, if the provider has one.
 It should return an array of I<OSSL_ALGORITHM> for the given
 I<operation_id>.
+
+ossl_provider_unquery_operation() informs the provider that the result of
+ossl_provider_query_operation() is no longer going to be directly accessed and
+that all relevant information has been copied.
 
 ossl_provider_set_operation_bit() registers a 1 for operation I<bitnum>
 in a bitstring that's internal to I<provider>.

--- a/doc/man3/OSSL_PROVIDER.pod
+++ b/doc/man3/OSSL_PROVIDER.pod
@@ -6,8 +6,8 @@ OSSL_PROVIDER_set_default_search_path,
 OSSL_PROVIDER, OSSL_PROVIDER_load, OSSL_PROVIDER_try_load, OSSL_PROVIDER_unload,
 OSSL_PROVIDER_available, OSSL_PROVIDER_do_all,
 OSSL_PROVIDER_gettable_params, OSSL_PROVIDER_get_params,
-OSSL_PROVIDER_query_operation, OSSL_PROVIDER_get0_provider_ctx,
-OSSL_PROVIDER_add_builtin, OSSL_PROVIDER_name,
+OSSL_PROVIDER_query_operation, OSSL_PROVIDER_unquery_operation,
+OSSL_PROVIDER_get0_provider_ctx, OSSL_PROVIDER_add_builtin, OSSL_PROVIDER_name,
 OSSL_PROVIDER_get_capabilities, OSSL_PROVIDER_self_test
 - provider routines
 
@@ -34,6 +34,9 @@ OSSL_PROVIDER_get_capabilities, OSSL_PROVIDER_self_test
  const OSSL_ALGORITHM *OSSL_PROVIDER_query_operation(const OSSL_PROVIDER *prov,
                                                      int operation_id,
                                                      int *no_cache);
+ void OSSL_PROVIDER_unquery_operation(const OSSL_PROVIDER *prov,
+                                      int operation_id,
+                                      const OSSL_ALGORITHM *algs);
  void *OSSL_PROVIDER_get0_provider_ctx(const OSSL_PROVIDER *prov);
 
  int OSSL_PROVIDER_add_builtin(OSSL_LIB_CTX *libctx, const char *name,
@@ -117,6 +120,10 @@ function (see L<provider(7)>), if the provider has one. It returns an
 array of I<OSSL_ALGORITHM> for the given I<operation_id> terminated by an all
 NULL OSSL_ALGORITHM entry. This is considered a low-level function that most
 applications should not need to call.
+
+OSSL_PROVIDER_unquery_operation() calls the provider's I<unquery_operation>
+function (see L<provider(7)>), if the provider has one.  This is considered a
+low-level function that most applications should not need to call.
 
 OSSL_PROVIDER_get0_provider_ctx() returns the provider context for the given
 provider. The provider context is an opaque handle set by the provider itself

--- a/doc/man7/provider-base.pod
+++ b/doc/man7/provider-base.pod
@@ -86,6 +86,8 @@ provider-base
  const OSSL_ALGORITHM *provider_query_operation(void *provctx,
                                                 int operation_id,
                                                 const int *no_store);
+ void provider_unquery_operation(void *provctx, int operation_id,
+                                 const OSSL_ALGORITHM *algs);
  const OSSL_ITEM *provider_get_reason_strings(void *provctx);
  int provider_get_capabilities(void *provctx, const char *capability,
                                OSSL_CALLBACK *cb, void *arg);
@@ -154,6 +156,7 @@ F<libcrypto>):
  provider_gettable_params       OSSL_FUNC_PROVIDER_GETTABLE_PARAMS
  provider_get_params            OSSL_FUNC_PROVIDER_GET_PARAMS
  provider_query_operation       OSSL_FUNC_PROVIDER_QUERY_OPERATION
+ provider_unquery_operation     OSSL_FUNC_PROVIDER_UNQUERY_OPERATION
  provider_get_reason_strings    OSSL_FUNC_PROVIDER_GET_REASON_STRINGS
  provider_get_capabilities      OSSL_FUNC_PROVIDER_GET_CAPABILITIES
  provider_self_test             OSSL_FUNC_PROVIDER_SELF_TEST
@@ -273,6 +276,11 @@ that corresponds to the given I<operation_id>.
 It should indicate if the core may store a reference to this array by
 setting I<*no_store> to 0 (core may store a reference) or 1 (core may
 not store a reference).
+
+provider_unquery_operation() informs the provider that the result of a
+provider_query_operation() is no longer directly required and that the function
+pointers have been copied.  The I<operation_id> should match that passed to
+provider_query_operation() and I<algs> should be it return value.
 
 provider_get_reason_strings() should return a constant B<OSSL_ITEM>
 array that provides reason strings for reason codes the provider may

--- a/doc/man7/provider-base.pod
+++ b/doc/man7/provider-base.pod
@@ -280,7 +280,7 @@ not store a reference).
 provider_unquery_operation() informs the provider that the result of a
 provider_query_operation() is no longer directly required and that the function
 pointers have been copied.  The I<operation_id> should match that passed to
-provider_query_operation() and I<algs> should be it return value.
+provider_query_operation() and I<algs> should be its return value.
 
 provider_get_reason_strings() should return a constant B<OSSL_ITEM>
 array that provides reason strings for reason codes the provider may

--- a/include/internal/provider.h
+++ b/include/internal/provider.h
@@ -83,6 +83,9 @@ int ossl_provider_self_test(const OSSL_PROVIDER *prov);
 const OSSL_ALGORITHM *ossl_provider_query_operation(const OSSL_PROVIDER *prov,
                                                     int operation_id,
                                                     int *no_cache);
+void ossl_provider_unquery_operation(const OSSL_PROVIDER *prov,
+                                     int operation_id,
+                                     const OSSL_ALGORITHM *algs);
 
 /* Cache of bits to see if we already queried an operation */
 int ossl_provider_set_operation_bit(OSSL_PROVIDER *provider, size_t bitnum);

--- a/include/openssl/core_dispatch.h
+++ b/include/openssl/core_dispatch.h
@@ -191,13 +191,16 @@ OSSL_CORE_MAKE_FUNC(int,provider_get_params,(void *provctx,
 # define OSSL_FUNC_PROVIDER_QUERY_OPERATION    1027
 OSSL_CORE_MAKE_FUNC(const OSSL_ALGORITHM *,provider_query_operation,
                     (void *provctx, int operation_id, int *no_store))
-# define OSSL_FUNC_PROVIDER_GET_REASON_STRINGS 1028
+# define OSSL_FUNC_PROVIDER_UNQUERY_OPERATION  1028
+OSSL_CORE_MAKE_FUNC(void, provider_unquery_operation,
+                    (void *provctx, int operation_id, const OSSL_ALGORITHM *))
+# define OSSL_FUNC_PROVIDER_GET_REASON_STRINGS 1029
 OSSL_CORE_MAKE_FUNC(const OSSL_ITEM *,provider_get_reason_strings,
                     (void *provctx))
-# define OSSL_FUNC_PROVIDER_GET_CAPABILITIES   1029
+# define OSSL_FUNC_PROVIDER_GET_CAPABILITIES   1030
 OSSL_CORE_MAKE_FUNC(int, provider_get_capabilities, (void *provctx,
                     const char *capability, OSSL_CALLBACK *cb, void *arg))
-# define OSSL_FUNC_PROVIDER_SELF_TEST          1030
+# define OSSL_FUNC_PROVIDER_SELF_TEST          1031
 OSSL_CORE_MAKE_FUNC(int, provider_self_test, (void *provctx))
 
 /* Operations */

--- a/include/openssl/provider.h
+++ b/include/openssl/provider.h
@@ -40,6 +40,8 @@ int OSSL_PROVIDER_get_capabilities(const OSSL_PROVIDER *prov,
 const OSSL_ALGORITHM *OSSL_PROVIDER_query_operation(const OSSL_PROVIDER *prov,
                                                     int operation_id,
                                                     int *no_cache);
+void OSSL_PROVIDER_unquery_operation(const OSSL_PROVIDER *prov,
+                                     int operation_id, const OSSL_ALGORITHM *algs);
 void *OSSL_PROVIDER_get0_provider_ctx(const OSSL_PROVIDER *prov);
 
 /* Add a built in providers */

--- a/test/filterprov.h
+++ b/test/filterprov.h
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2021 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <openssl/core_dispatch.h>
+
+OSSL_provider_init_fn filter_provider_init;
+int filter_provider_set_filter(int operation, const char *name);
+int filter_provider_check_clean_finish(void);

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -38,6 +38,7 @@
 #include "internal/nelem.h"
 #include "internal/ktls.h"
 #include "../ssl/ssl_local.h"
+#include "filterprov.h"
 
 #undef OSSL_NO_USABLE_TLS1_3
 #if defined(OPENSSL_NO_TLS1_3) \
@@ -48,10 +49,6 @@
  */
 # define OSSL_NO_USABLE_TLS1_3
 #endif
-
-/* Defined in filterprov.c */
-OSSL_provider_init_fn filter_provider_init;
-int filter_provider_set_filter(int operation, const char *name);
 
 /* Defined in tls-provider.c */
 int tls_provider_init(const OSSL_CORE_HANDLE *handle,
@@ -8058,7 +8055,7 @@ static int test_sigalgs_available(int idx)
                                                  : NID_rsassaPss))
         goto end;
 
-    testresult = 1;
+    testresult = filter_provider_check_clean_finish();
 
  end:
     SSL_free(serverssl);

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5078,6 +5078,7 @@ X509_PUBKEY_eq                          ?	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_eq                             ?	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_parameters_eq                  ?	3_0_0	EXIST::FUNCTION:
 OSSL_PROVIDER_query_operation           ?	3_0_0	EXIST::FUNCTION:
+OSSL_PROVIDER_unquery_operation         ?	3_0_0	EXIST::FUNCTION:
 OSSL_PROVIDER_get0_provider_ctx         ?	3_0_0	EXIST::FUNCTION:
 OSSL_PROVIDER_get_capabilities          ?	3_0_0	EXIST::FUNCTION:
 EC_GROUP_new_by_curve_name_ex           ?	3_0_0	EXIST::FUNCTION:EC


### PR DESCRIPTION
Providers are allowed to return non-cached OSSL_DISPATCH tables.  These can be dynamically allocated.  There is no way for a provider to know when an application has finished with these.  Adding a free function allows an application to inform the provider that it is done with the table.

- [x] documentation is added or updated
- [x] tests are added or updated

Fixes #11771
