### PR TITLE
Fix bug in EDDSA speed test

### DIFF
--- a/apps/speed.c
+++ b/apps/speed.c
@@ -3426,6 +3426,7 @@ int speed_main(int argc, char **argv)
             }
 
             EVP_PKEY_free(ed_pkey);
+            ed_pkey = NULL;
         }
         if (st == 0) {
             BIO_printf(bio_err, "EdDSA failure.\n");


### PR DESCRIPTION
The pkey created in one loop was being fed into the keygen of the next loop - since it was not set to NULL after the
free. This meant that the 2 EVP_MD_CTX objects that still had ref counts to this key were getting confused.

All other tests clear the key after freeing the key if they loop (some do this by declaring/initing the pkey inside the loop).
The offending code is a recent addition to the speed app.
This was found using the -async_jobs option.
Similar code was tried for an RSA key using 111 which resulted in the same issue.

Found while trying to test issue #128867 (It is not known if this will fix that issue yet).

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
