### PR TITLE
STORE: Clear a couple of TODOs that were there for the sake of SM2

### DIFF
--- a/crypto/store/store_result.c
+++ b/crypto/store/store_result.c
@@ -337,20 +337,6 @@ static EVP_PKEY *try_key_value_legacy(struct extracted_param_data_st *data,
                 pk = EVP_PKCS82PKEY_with_libctx(p8info, libctx, propq);
                 PKCS8_PRIV_KEY_INFO_free(p8info);
             }
-
-            /*
-             * It wasn't PKCS#8, so we must try the hard way.
-             * However, we can cheat a little bit, because we know
-             * what's not yet fully supported in out decoders.
-             * TODO(3.0) Eliminate these when we have decoder support.
-             */
-            if (pk == NULL) {
-                derp = der;
-                pk = d2i_PrivateKey_ex(EVP_PKEY_SM2, NULL,
-                                       &derp, der_len,
-                                       libctx, NULL);
-                RESET_ERR_MARK();
-            }
         }
 
         if (pk != NULL)
@@ -359,19 +345,6 @@ static EVP_PKEY *try_key_value_legacy(struct extracted_param_data_st *data,
         OPENSSL_free(new_der);
         der = data->octet_data;
         der_len = (long)data->octet_data_size;
-    }
-
-    /*
-     * Last, we try parameters.  We cheat the same way we do for
-     * private keys above.
-     * TODO(3.0) Eliminate these when we have decoder support.
-     */
-    if (pk == NULL) {
-        derp = der;
-        pk = d2i_KeyParams(EVP_PKEY_SM2, NULL, &derp, der_len);
-        RESET_ERR_MARK();
-        if (pk != NULL)
-            *store_info_new = OSSL_STORE_INFO_new_PARAMS;
     }
     CLEAR_ERR_MARK();
 


### PR DESCRIPTION
We now have decoder support for SM2, so the cheats that were in place
for the sake of lacking decoders aren't needed any more.

Fixes #12982
