### PR TITLE
optimise ssl3_get_cipher_by_std_name()

### DIFF
--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -4132,8 +4132,7 @@ const SSL_CIPHER *ssl3_get_cipher_by_std_name(const char *stdname)
             if (tbl->stdname == NULL)
                 continue;
             if (strcmp(stdname, tbl->stdname) == 0) {
-                c = tbl;
-                break;
+                return tbl;
             }
         }
     }


### PR DESCRIPTION
Return immediately on matched cipher. Without this patch the code only breaks out of the inner for loop, meaning for a matched TLS13 cipher the code will still loop through 160ish SSL3 ciphers.

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
