### PR TITLE
rand: declare get_hardware_random_value() before use.

### DIFF
--- a/providers/implementations/rands/seeding/rand_cpu_x86.c
+++ b/providers/implementations/rands/seeding/rand_cpu_x86.c
@@ -16,11 +16,12 @@
 # if defined(OPENSSL_SYS_TANDEM) && defined(_TNS_X_TARGET)
 #  include <builtin.h> /* _rdrand64 */
 #  include <string.h> /* memcpy */
-static size_t get_hardware_random_value(unsigned char *buf, size_t len);
 # else
 size_t OPENSSL_ia32_rdseed_bytes(unsigned char *buf, size_t len);
 size_t OPENSSL_ia32_rdrand_bytes(unsigned char *buf, size_t len);
 # endif
+
+static size_t get_hardware_random_value(unsigned char *buf, size_t len);
 
 /*
  * Acquire entropy using Intel-specific cpu instructions


### PR DESCRIPTION
Introduced by #12923

Fixes #13004

