### PR TITLE
prov: prefix all OSSL_DISPATCH tables names with ossl_

### DIFF
--- a/providers/decoders.inc
+++ b/providers/decoders.inc
@@ -12,31 +12,31 @@
 #endif
 
 #ifndef OPENSSL_NO_DH
-    DECODER("DH", "yes", "der", der_to_dh_decoder_functions),
-    DECODER("DHX", "yes", "der", der_to_dhx_decoder_functions),
+    DECODER("DH", "yes", "der", ossl_der_to_dh_decoder_functions),
+    DECODER("DHX", "yes", "der", ossl_der_to_dhx_decoder_functions),
 #endif
 #ifndef OPENSSL_NO_DSA
-    DECODER("DSA", "yes", "der", der_to_dsa_decoder_functions),
-    DECODER("DSA", "yes", "mblob", msblob_to_dsa_decoder_functions),
+    DECODER("DSA", "yes", "der", ossl_der_to_dsa_decoder_functions),
+    DECODER("DSA", "yes", "mblob", ossl_msblob_to_dsa_decoder_functions),
 # ifndef OPENSSL_NO_RC4
-    DECODER("DSA", "yes", "pvk", pvk_to_dsa_decoder_functions),
+    DECODER("DSA", "yes", "pvk", ossl_pvk_to_dsa_decoder_functions),
 # endif
 #endif
 #ifndef OPENSSL_NO_EC
-    DECODER("EC", "yes", "der", der_to_ec_decoder_functions),
-    DECODER("ED25519", "yes", "der", der_to_ed25519_decoder_functions),
-    DECODER("ED448", "yes", "der", der_to_ed448_decoder_functions),
-    DECODER("X25519", "yes", "der", der_to_x25519_decoder_functions),
-    DECODER("X448", "yes", "der", der_to_x448_decoder_functions),
+    DECODER("EC", "yes", "der", ossl_der_to_ec_decoder_functions),
+    DECODER("ED25519", "yes", "der", ossl_der_to_ed25519_decoder_functions),
+    DECODER("ED448", "yes", "der", ossl_der_to_ed448_decoder_functions),
+    DECODER("X25519", "yes", "der", ossl_der_to_x25519_decoder_functions),
+    DECODER("X448", "yes", "der", ossl_der_to_x448_decoder_functions),
 #endif
-    DECODER("RSA", "yes", "der", der_to_rsa_decoder_functions),
-    DECODER("RSA-PSS", "yes", "der", der_to_rsapss_decoder_functions),
+    DECODER("RSA", "yes", "der", ossl_der_to_rsa_decoder_functions),
+    DECODER("RSA-PSS", "yes", "der", ossl_der_to_rsapss_decoder_functions),
 #ifndef OPENSSL_NO_DSA
-    DECODER("RSA", "yes", "mblob", msblob_to_rsa_decoder_functions),
+    DECODER("RSA", "yes", "mblob", ossl_msblob_to_rsa_decoder_functions),
 # ifndef OPENSSL_NO_RC4
-    DECODER("RSA", "yes", "pvk", pvk_to_rsa_decoder_functions),
+    DECODER("RSA", "yes", "pvk", ossl_pvk_to_rsa_decoder_functions),
 # endif
 #endif
 
-    DECODER("DER", "yes", "pem", pem_to_der_decoder_functions),
+    DECODER("DER", "yes", "pem", ossl_pem_to_der_decoder_functions),
 

--- a/providers/defltprov.c
+++ b/providers/defltprov.c
@@ -98,32 +98,34 @@ static int deflt_get_params(void *provctx, OSSL_PARAM params[])
  */
 static const OSSL_ALGORITHM deflt_digests[] = {
     /* Our primary name:NIST name[:our older names] */
-    { "SHA1:SHA-1:SSL3-SHA1", "provider=default", sha1_functions },
-    { "SHA2-224:SHA-224:SHA224", "provider=default", sha224_functions },
-    { "SHA2-256:SHA-256:SHA256", "provider=default", sha256_functions },
-    { "SHA2-384:SHA-384:SHA384", "provider=default", sha384_functions },
-    { "SHA2-512:SHA-512:SHA512", "provider=default", sha512_functions },
+    { "SHA1:SHA-1:SSL3-SHA1", "provider=default", ossl_sha1_functions },
+    { "SHA2-224:SHA-224:SHA224", "provider=default", ossl_sha224_functions },
+    { "SHA2-256:SHA-256:SHA256", "provider=default", ossl_sha256_functions },
+    { "SHA2-384:SHA-384:SHA384", "provider=default", ossl_sha384_functions },
+    { "SHA2-512:SHA-512:SHA512", "provider=default", ossl_sha512_functions },
     { "SHA2-512/224:SHA-512/224:SHA512-224", "provider=default",
-      sha512_224_functions },
+      ossl_sha512_224_functions },
     { "SHA2-512/256:SHA-512/256:SHA512-256", "provider=default",
-      sha512_256_functions },
+      ossl_sha512_256_functions },
 
     /* We agree with NIST here, so one name only */
-    { "SHA3-224", "provider=default", sha3_224_functions },
-    { "SHA3-256", "provider=default", sha3_256_functions },
-    { "SHA3-384", "provider=default", sha3_384_functions },
-    { "SHA3-512", "provider=default", sha3_512_functions },
+    { "SHA3-224", "provider=default", ossl_sha3_224_functions },
+    { "SHA3-256", "provider=default", ossl_sha3_256_functions },
+    { "SHA3-384", "provider=default", ossl_sha3_384_functions },
+    { "SHA3-512", "provider=default", ossl_sha3_512_functions },
 
     /*
      * KECCAK-KMAC-128 and KECCAK-KMAC-256 as hashes are mostly useful for
      * the KMAC-128 and KMAC-256.
      */
-    { "KECCAK-KMAC-128:KECCAK-KMAC128", "provider=default", keccak_kmac_128_functions },
-    { "KECCAK-KMAC-256:KECCAK-KMAC256", "provider=default", keccak_kmac_256_functions },
+    { "KECCAK-KMAC-128:KECCAK-KMAC128", "provider=default",
+      ossl_keccak_kmac_128_functions },
+    { "KECCAK-KMAC-256:KECCAK-KMAC256", "provider=default",
+      ossl_keccak_kmac_256_functions },
 
     /* Our primary name:NIST name */
-    { "SHAKE-128:SHAKE128", "provider=default", shake_128_functions },
-    { "SHAKE-256:SHAKE256", "provider=default", shake_256_functions },
+    { "SHAKE-128:SHAKE128", "provider=default", ossl_shake_128_functions },
+    { "SHAKE-256:SHAKE256", "provider=default", ossl_shake_256_functions },
 
 #ifndef OPENSSL_NO_BLAKE2
     /*
@@ -133,159 +135,159 @@ static const OSSL_ALGORITHM deflt_digests[] = {
      * If we assume that "2b" and "2s" are versions, that pattern
      * fits with ours.  We also add our historical names.
      */
-    { "BLAKE2S-256:BLAKE2s256", "provider=default", blake2s256_functions },
-    { "BLAKE2B-512:BLAKE2b512", "provider=default", blake2b512_functions },
+    { "BLAKE2S-256:BLAKE2s256", "provider=default", ossl_blake2s256_functions },
+    { "BLAKE2B-512:BLAKE2b512", "provider=default", ossl_blake2b512_functions },
 #endif /* OPENSSL_NO_BLAKE2 */
 
 #ifndef OPENSSL_NO_SM3
-    { "SM3", "provider=default", sm3_functions },
+    { "SM3", "provider=default", ossl_sm3_functions },
 #endif /* OPENSSL_NO_SM3 */
 
 #ifndef OPENSSL_NO_MD5
-    { "MD5:SSL3-MD5", "provider=default", md5_functions },
-    { "MD5-SHA1", "provider=default", md5_sha1_functions },
+    { "MD5:SSL3-MD5", "provider=default", ossl_md5_functions },
+    { "MD5-SHA1", "provider=default", ossl_md5_sha1_functions },
 #endif /* OPENSSL_NO_MD5 */
 
     { NULL, NULL, NULL }
 };
 
 static const OSSL_ALGORITHM_CAPABLE deflt_ciphers[] = {
-    ALG("NULL", null_functions),
-    ALG("AES-256-ECB", aes256ecb_functions),
-    ALG("AES-192-ECB", aes192ecb_functions),
-    ALG("AES-128-ECB", aes128ecb_functions),
-    ALG("AES-256-CBC:AES256", aes256cbc_functions),
-    ALG("AES-192-CBC:AES192", aes192cbc_functions),
-    ALG("AES-128-CBC:AES128", aes128cbc_functions),
-    ALG("AES-128-CBC-CTS", aes128cbc_cts_functions),
-    ALG("AES-192-CBC-CTS", aes192cbc_cts_functions),
-    ALG("AES-256-CBC-CTS", aes256cbc_cts_functions),
-    ALG("AES-256-OFB", aes256ofb_functions),
-    ALG("AES-192-OFB", aes192ofb_functions),
-    ALG("AES-128-OFB", aes128ofb_functions),
-    ALG("AES-256-CFB", aes256cfb_functions),
-    ALG("AES-192-CFB", aes192cfb_functions),
-    ALG("AES-128-CFB", aes128cfb_functions),
-    ALG("AES-256-CFB1", aes256cfb1_functions),
-    ALG("AES-192-CFB1", aes192cfb1_functions),
-    ALG("AES-128-CFB1", aes128cfb1_functions),
-    ALG("AES-256-CFB8", aes256cfb8_functions),
-    ALG("AES-192-CFB8", aes192cfb8_functions),
-    ALG("AES-128-CFB8", aes128cfb8_functions),
-    ALG("AES-256-CTR", aes256ctr_functions),
-    ALG("AES-192-CTR", aes192ctr_functions),
-    ALG("AES-128-CTR", aes128ctr_functions),
-    ALG("AES-256-XTS", aes256xts_functions),
-    ALG("AES-128-XTS", aes128xts_functions),
+    ALG("NULL", ossl_null_functions),
+    ALG("AES-256-ECB", ossl_aes256ecb_functions),
+    ALG("AES-192-ECB", ossl_aes192ecb_functions),
+    ALG("AES-128-ECB", ossl_aes128ecb_functions),
+    ALG("AES-256-CBC:AES256", ossl_aes256cbc_functions),
+    ALG("AES-192-CBC:AES192", ossl_aes192cbc_functions),
+    ALG("AES-128-CBC:AES128", ossl_aes128cbc_functions),
+    ALG("AES-128-CBC-CTS", ossl_aes128cbc_cts_functions),
+    ALG("AES-192-CBC-CTS", ossl_aes192cbc_cts_functions),
+    ALG("AES-256-CBC-CTS", ossl_aes256cbc_cts_functions),
+    ALG("AES-256-OFB", ossl_aes256ofb_functions),
+    ALG("AES-192-OFB", ossl_aes192ofb_functions),
+    ALG("AES-128-OFB", ossl_aes128ofb_functions),
+    ALG("AES-256-CFB", ossl_aes256cfb_functions),
+    ALG("AES-192-CFB", ossl_aes192cfb_functions),
+    ALG("AES-128-CFB", ossl_aes128cfb_functions),
+    ALG("AES-256-CFB1", ossl_aes256cfb1_functions),
+    ALG("AES-192-CFB1", ossl_aes192cfb1_functions),
+    ALG("AES-128-CFB1", ossl_aes128cfb1_functions),
+    ALG("AES-256-CFB8", ossl_aes256cfb8_functions),
+    ALG("AES-192-CFB8", ossl_aes192cfb8_functions),
+    ALG("AES-128-CFB8", ossl_aes128cfb8_functions),
+    ALG("AES-256-CTR", ossl_aes256ctr_functions),
+    ALG("AES-192-CTR", ossl_aes192ctr_functions),
+    ALG("AES-128-CTR", ossl_aes128ctr_functions),
+    ALG("AES-256-XTS", ossl_aes256xts_functions),
+    ALG("AES-128-XTS", ossl_aes128xts_functions),
 #ifndef OPENSSL_NO_OCB
-    ALG("AES-256-OCB", aes256ocb_functions),
-    ALG("AES-192-OCB", aes192ocb_functions),
-    ALG("AES-128-OCB", aes128ocb_functions),
+    ALG("AES-256-OCB", ossl_aes256ocb_functions),
+    ALG("AES-192-OCB", ossl_aes192ocb_functions),
+    ALG("AES-128-OCB", ossl_aes128ocb_functions),
 #endif /* OPENSSL_NO_OCB */
 #ifndef OPENSSL_NO_SIV
-    ALG("AES-128-SIV", aes128siv_functions),
-    ALG("AES-192-SIV", aes192siv_functions),
-    ALG("AES-256-SIV", aes256siv_functions),
+    ALG("AES-128-SIV", ossl_aes128siv_functions),
+    ALG("AES-192-SIV", ossl_aes192siv_functions),
+    ALG("AES-256-SIV", ossl_aes256siv_functions),
 #endif /* OPENSSL_NO_SIV */
-    ALG("AES-256-GCM:id-aes256-GCM", aes256gcm_functions),
-    ALG("AES-192-GCM:id-aes192-GCM", aes192gcm_functions),
-    ALG("AES-128-GCM:id-aes128-GCM", aes128gcm_functions),
-    ALG("AES-256-CCM:id-aes256-CCM", aes256ccm_functions),
-    ALG("AES-192-CCM:id-aes192-CCM", aes192ccm_functions),
-    ALG("AES-128-CCM:id-aes128-CCM", aes128ccm_functions),
-    ALG("AES-256-WRAP:id-aes256-wrap:AES256-WRAP", aes256wrap_functions),
-    ALG("AES-192-WRAP:id-aes192-wrap:AES192-WRAP", aes192wrap_functions),
-    ALG("AES-128-WRAP:id-aes128-wrap:AES128-WRAP", aes128wrap_functions),
+    ALG("AES-256-GCM:id-aes256-GCM", ossl_aes256gcm_functions),
+    ALG("AES-192-GCM:id-aes192-GCM", ossl_aes192gcm_functions),
+    ALG("AES-128-GCM:id-aes128-GCM", ossl_aes128gcm_functions),
+    ALG("AES-256-CCM:id-aes256-CCM", ossl_aes256ccm_functions),
+    ALG("AES-192-CCM:id-aes192-CCM", ossl_aes192ccm_functions),
+    ALG("AES-128-CCM:id-aes128-CCM", ossl_aes128ccm_functions),
+    ALG("AES-256-WRAP:id-aes256-wrap:AES256-WRAP", ossl_aes256wrap_functions),
+    ALG("AES-192-WRAP:id-aes192-wrap:AES192-WRAP", ossl_aes192wrap_functions),
+    ALG("AES-128-WRAP:id-aes128-wrap:AES128-WRAP", ossl_aes128wrap_functions),
     ALG("AES-256-WRAP-PAD:id-aes256-wrap-pad:AES256-WRAP-PAD",
-        aes256wrappad_functions),
+        ossl_aes256wrappad_functions),
     ALG("AES-192-WRAP-PAD:id-aes192-wrap-pad:AES192-WRAP-PAD",
-        aes192wrappad_functions),
+        ossl_aes192wrappad_functions),
     ALG("AES-128-WRAP-PAD:id-aes128-wrap-pad:AES128-WRAP-PAD",
-        aes128wrappad_functions),
-    ALGC("AES-128-CBC-HMAC-SHA1", aes128cbc_hmac_sha1_functions,
+        ossl_aes128wrappad_functions),
+    ALGC("AES-128-CBC-HMAC-SHA1", ossl_aes128cbc_hmac_sha1_functions,
          cipher_capable_aes_cbc_hmac_sha1),
-    ALGC("AES-256-CBC-HMAC-SHA1", aes256cbc_hmac_sha1_functions,
+    ALGC("AES-256-CBC-HMAC-SHA1", ossl_aes256cbc_hmac_sha1_functions,
          cipher_capable_aes_cbc_hmac_sha1),
-    ALGC("AES-128-CBC-HMAC-SHA256", aes128cbc_hmac_sha256_functions,
+    ALGC("AES-128-CBC-HMAC-SHA256", ossl_aes128cbc_hmac_sha256_functions,
         cipher_capable_aes_cbc_hmac_sha256),
-    ALGC("AES-256-CBC-HMAC-SHA256", aes256cbc_hmac_sha256_functions,
+    ALGC("AES-256-CBC-HMAC-SHA256", ossl_aes256cbc_hmac_sha256_functions,
          cipher_capable_aes_cbc_hmac_sha256),
 #ifndef OPENSSL_NO_ARIA
-    ALG("ARIA-256-GCM", aria256gcm_functions),
-    ALG("ARIA-192-GCM", aria192gcm_functions),
-    ALG("ARIA-128-GCM", aria128gcm_functions),
-    ALG("ARIA-256-CCM", aria256ccm_functions),
-    ALG("ARIA-192-CCM", aria192ccm_functions),
-    ALG("ARIA-128-CCM", aria128ccm_functions),
-    ALG("ARIA-256-ECB", aria256ecb_functions),
-    ALG("ARIA-192-ECB", aria192ecb_functions),
-    ALG("ARIA-128-ECB", aria128ecb_functions),
-    ALG("ARIA-256-CBC:ARIA256", aria256cbc_functions),
-    ALG("ARIA-192-CBC:ARIA192", aria192cbc_functions),
-    ALG("ARIA-128-CBC:ARIA128", aria128cbc_functions),
-    ALG("ARIA-256-OFB", aria256ofb_functions),
-    ALG("ARIA-192-OFB", aria192ofb_functions),
-    ALG("ARIA-128-OFB", aria128ofb_functions),
-    ALG("ARIA-256-CFB", aria256cfb_functions),
-    ALG("ARIA-192-CFB", aria192cfb_functions),
-    ALG("ARIA-128-CFB", aria128cfb_functions),
-    ALG("ARIA-256-CFB1", aria256cfb1_functions),
-    ALG("ARIA-192-CFB1", aria192cfb1_functions),
-    ALG("ARIA-128-CFB1", aria128cfb1_functions),
-    ALG("ARIA-256-CFB8", aria256cfb8_functions),
-    ALG("ARIA-192-CFB8", aria192cfb8_functions),
-    ALG("ARIA-128-CFB8", aria128cfb8_functions),
-    ALG("ARIA-256-CTR", aria256ctr_functions),
-    ALG("ARIA-192-CTR", aria192ctr_functions),
-    ALG("ARIA-128-CTR", aria128ctr_functions),
+    ALG("ARIA-256-GCM", ossl_aria256gcm_functions),
+    ALG("ARIA-192-GCM", ossl_aria192gcm_functions),
+    ALG("ARIA-128-GCM", ossl_aria128gcm_functions),
+    ALG("ARIA-256-CCM", ossl_aria256ccm_functions),
+    ALG("ARIA-192-CCM", ossl_aria192ccm_functions),
+    ALG("ARIA-128-CCM", ossl_aria128ccm_functions),
+    ALG("ARIA-256-ECB", ossl_aria256ecb_functions),
+    ALG("ARIA-192-ECB", ossl_aria192ecb_functions),
+    ALG("ARIA-128-ECB", ossl_aria128ecb_functions),
+    ALG("ARIA-256-CBC:ARIA256", ossl_aria256cbc_functions),
+    ALG("ARIA-192-CBC:ARIA192", ossl_aria192cbc_functions),
+    ALG("ARIA-128-CBC:ARIA128", ossl_aria128cbc_functions),
+    ALG("ARIA-256-OFB", ossl_aria256ofb_functions),
+    ALG("ARIA-192-OFB", ossl_aria192ofb_functions),
+    ALG("ARIA-128-OFB", ossl_aria128ofb_functions),
+    ALG("ARIA-256-CFB", ossl_aria256cfb_functions),
+    ALG("ARIA-192-CFB", ossl_aria192cfb_functions),
+    ALG("ARIA-128-CFB", ossl_aria128cfb_functions),
+    ALG("ARIA-256-CFB1", ossl_aria256cfb1_functions),
+    ALG("ARIA-192-CFB1", ossl_aria192cfb1_functions),
+    ALG("ARIA-128-CFB1", ossl_aria128cfb1_functions),
+    ALG("ARIA-256-CFB8", ossl_aria256cfb8_functions),
+    ALG("ARIA-192-CFB8", ossl_aria192cfb8_functions),
+    ALG("ARIA-128-CFB8", ossl_aria128cfb8_functions),
+    ALG("ARIA-256-CTR", ossl_aria256ctr_functions),
+    ALG("ARIA-192-CTR", ossl_aria192ctr_functions),
+    ALG("ARIA-128-CTR", ossl_aria128ctr_functions),
 #endif /* OPENSSL_NO_ARIA */
 #ifndef OPENSSL_NO_CAMELLIA
-    ALG("CAMELLIA-256-ECB", camellia256ecb_functions),
-    ALG("CAMELLIA-192-ECB", camellia192ecb_functions),
-    ALG("CAMELLIA-128-ECB", camellia128ecb_functions),
-    ALG("CAMELLIA-256-CBC:CAMELLIA256", camellia256cbc_functions),
-    ALG("CAMELLIA-192-CBC:CAMELLIA192", camellia192cbc_functions),
-    ALG("CAMELLIA-128-CBC:CAMELLIA128", camellia128cbc_functions),
-    ALG("CAMELLIA-256-OFB", camellia256ofb_functions),
-    ALG("CAMELLIA-192-OFB", camellia192ofb_functions),
-    ALG("CAMELLIA-128-OFB", camellia128ofb_functions),
-    ALG("CAMELLIA-256-CFB", camellia256cfb_functions),
-    ALG("CAMELLIA-192-CFB", camellia192cfb_functions),
-    ALG("CAMELLIA-128-CFB", camellia128cfb_functions),
-    ALG("CAMELLIA-256-CFB1", camellia256cfb1_functions),
-    ALG("CAMELLIA-192-CFB1", camellia192cfb1_functions),
-    ALG("CAMELLIA-128-CFB1", camellia128cfb1_functions),
-    ALG("CAMELLIA-256-CFB8", camellia256cfb8_functions),
-    ALG("CAMELLIA-192-CFB8", camellia192cfb8_functions),
-    ALG("CAMELLIA-128-CFB8", camellia128cfb8_functions),
-    ALG("CAMELLIA-256-CTR", camellia256ctr_functions),
-    ALG("CAMELLIA-192-CTR", camellia192ctr_functions),
-    ALG("CAMELLIA-128-CTR", camellia128ctr_functions),
+    ALG("CAMELLIA-256-ECB", ossl_camellia256ecb_functions),
+    ALG("CAMELLIA-192-ECB", ossl_camellia192ecb_functions),
+    ALG("CAMELLIA-128-ECB", ossl_camellia128ecb_functions),
+    ALG("CAMELLIA-256-CBC:CAMELLIA256", ossl_camellia256cbc_functions),
+    ALG("CAMELLIA-192-CBC:CAMELLIA192", ossl_camellia192cbc_functions),
+    ALG("CAMELLIA-128-CBC:CAMELLIA128", ossl_camellia128cbc_functions),
+    ALG("CAMELLIA-256-OFB", ossl_camellia256ofb_functions),
+    ALG("CAMELLIA-192-OFB", ossl_camellia192ofb_functions),
+    ALG("CAMELLIA-128-OFB", ossl_camellia128ofb_functions),
+    ALG("CAMELLIA-256-CFB", ossl_camellia256cfb_functions),
+    ALG("CAMELLIA-192-CFB", ossl_camellia192cfb_functions),
+    ALG("CAMELLIA-128-CFB", ossl_camellia128cfb_functions),
+    ALG("CAMELLIA-256-CFB1", ossl_camellia256cfb1_functions),
+    ALG("CAMELLIA-192-CFB1", ossl_camellia192cfb1_functions),
+    ALG("CAMELLIA-128-CFB1", ossl_camellia128cfb1_functions),
+    ALG("CAMELLIA-256-CFB8", ossl_camellia256cfb8_functions),
+    ALG("CAMELLIA-192-CFB8", ossl_camellia192cfb8_functions),
+    ALG("CAMELLIA-128-CFB8", ossl_camellia128cfb8_functions),
+    ALG("CAMELLIA-256-CTR", ossl_camellia256ctr_functions),
+    ALG("CAMELLIA-192-CTR", ossl_camellia192ctr_functions),
+    ALG("CAMELLIA-128-CTR", ossl_camellia128ctr_functions),
 #endif /* OPENSSL_NO_CAMELLIA */
 #ifndef OPENSSL_NO_DES
-    ALG("DES-EDE3-ECB:DES-EDE3", tdes_ede3_ecb_functions),
-    ALG("DES-EDE3-CBC:DES3", tdes_ede3_cbc_functions),
-    ALG("DES-EDE3-OFB", tdes_ede3_ofb_functions),
-    ALG("DES-EDE3-CFB", tdes_ede3_cfb_functions),
-    ALG("DES-EDE3-CFB8", tdes_ede3_cfb8_functions),
-    ALG("DES-EDE3-CFB1", tdes_ede3_cfb1_functions),
-    ALG("DES3-WRAP:id-smime-alg-CMS3DESwrap", tdes_wrap_cbc_functions),
-    ALG("DES-EDE-ECB:DES-EDE", tdes_ede2_ecb_functions),
-    ALG("DES-EDE-CBC", tdes_ede2_cbc_functions),
-    ALG("DES-EDE-OFB", tdes_ede2_ofb_functions),
-    ALG("DES-EDE-CFB", tdes_ede2_cfb_functions),
+    ALG("DES-EDE3-ECB:DES-EDE3", ossl_tdes_ede3_ecb_functions),
+    ALG("DES-EDE3-CBC:DES3", ossl_tdes_ede3_cbc_functions),
+    ALG("DES-EDE3-OFB", ossl_tdes_ede3_ofb_functions),
+    ALG("DES-EDE3-CFB", ossl_tdes_ede3_cfb_functions),
+    ALG("DES-EDE3-CFB8", ossl_tdes_ede3_cfb8_functions),
+    ALG("DES-EDE3-CFB1", ossl_tdes_ede3_cfb1_functions),
+    ALG("DES3-WRAP:id-smime-alg-CMS3DESwrap", ossl_tdes_wrap_cbc_functions),
+    ALG("DES-EDE-ECB:DES-EDE", ossl_tdes_ede2_ecb_functions),
+    ALG("DES-EDE-CBC", ossl_tdes_ede2_cbc_functions),
+    ALG("DES-EDE-OFB", ossl_tdes_ede2_ofb_functions),
+    ALG("DES-EDE-CFB", ossl_tdes_ede2_cfb_functions),
 #endif /* OPENSSL_NO_DES */
 #ifndef OPENSSL_NO_SM4
-    ALG("SM4-ECB", sm4128ecb_functions),
-    ALG("SM4-CBC:SM4", sm4128cbc_functions),
-    ALG("SM4-CTR", sm4128ctr_functions),
-    ALG("SM4-OFB:SM4-OFB128", sm4128ofb128_functions),
-    ALG("SM4-CFB:SM4-CFB128", sm4128cfb128_functions),
+    ALG("SM4-ECB", ossl_sm4128ecb_functions),
+    ALG("SM4-CBC:SM4", ossl_sm4128cbc_functions),
+    ALG("SM4-CTR", ossl_sm4128ctr_functions),
+    ALG("SM4-OFB:SM4-OFB128", ossl_sm4128ofb128_functions),
+    ALG("SM4-CFB:SM4-CFB128", ossl_sm4128cfb128_functions),
 #endif /* OPENSSL_NO_SM4 */
 #ifndef OPENSSL_NO_CHACHA
-    ALG("ChaCha20", chacha20_functions),
+    ALG("ChaCha20", ossl_chacha20_functions),
 # ifndef OPENSSL_NO_POLY1305
-    ALG("ChaCha20-Poly1305", chacha20_poly1305_functions),
+    ALG("ChaCha20-Poly1305", ossl_chacha20_ossl_poly1305_functions),
 # endif /* OPENSSL_NO_POLY1305 */
 #endif /* OPENSSL_NO_CHACHA */
     { { NULL, NULL, NULL }, NULL }
@@ -294,93 +296,96 @@ static OSSL_ALGORITHM exported_ciphers[OSSL_NELEM(deflt_ciphers)];
 
 static const OSSL_ALGORITHM deflt_macs[] = {
 #ifndef OPENSSL_NO_BLAKE2
-    { "BLAKE2BMAC", "provider=default", blake2bmac_functions },
-    { "BLAKE2SMAC", "provider=default", blake2smac_functions },
+    { "BLAKE2BMAC", "provider=default", ossl_blake2bmac_functions },
+    { "BLAKE2SMAC", "provider=default", ossl_blake2smac_functions },
 #endif
 #ifndef OPENSSL_NO_CMAC
-    { "CMAC", "provider=default", cmac_functions },
+    { "CMAC", "provider=default", ossl_cmac_functions },
 #endif
-    { "GMAC", "provider=default", gmac_functions },
-    { "HMAC", "provider=default", hmac_functions },
-    { "KMAC-128:KMAC128", "provider=default", kmac128_functions },
-    { "KMAC-256:KMAC256", "provider=default", kmac256_functions },
+    { "GMAC", "provider=default", ossl_gmac_functions },
+    { "HMAC", "provider=default", ossl_hmac_functions },
+    { "KMAC-128:KMAC128", "provider=default", ossl_kmac128_functions },
+    { "KMAC-256:KMAC256", "provider=default", ossl_kmac256_functions },
 #ifndef OPENSSL_NO_SIPHASH
-    { "SIPHASH", "provider=default", siphash_functions },
+    { "SIPHASH", "provider=default", ossl_siphash_functions },
 #endif
 #ifndef OPENSSL_NO_POLY1305
-    { "POLY1305", "provider=default", poly1305_functions },
+    { "POLY1305", "provider=default", ossl_poly1305_functions },
 #endif
     { NULL, NULL, NULL }
 };
 
 static const OSSL_ALGORITHM deflt_kdfs[] = {
-    { "HKDF", "provider=default", kdf_hkdf_functions },
-    { "SSKDF", "provider=default", kdf_sskdf_functions },
-    { "PBKDF2", "provider=default", kdf_pbkdf2_functions },
-    { "PKCS12KDF", "provider=default", kdf_pkcs12_functions },
-    { "SSHKDF", "provider=default", kdf_sshkdf_functions },
-    { "X963KDF", "provider=default", kdf_x963_kdf_functions },
-    { "TLS1-PRF", "provider=default", kdf_tls1_prf_functions },
-    { "KBKDF", "provider=default", kdf_kbkdf_functions },
+    { "HKDF", "provider=default", ossl_kdf_hkdf_functions },
+    { "SSKDF", "provider=default", ossl_kdf_sskdf_functions },
+    { "PBKDF2", "provider=default", ossl_kdf_pbkdf2_functions },
+    { "PKCS12KDF", "provider=default", ossl_kdf_pkcs12_functions },
+    { "SSHKDF", "provider=default", ossl_kdf_sshkdf_functions },
+    { "X963KDF", "provider=default", ossl_kdf_x963_kdf_functions },
+    { "TLS1-PRF", "provider=default", ossl_kdf_tls1_prf_functions },
+    { "KBKDF", "provider=default", ossl_kdf_kbkdf_functions },
 #ifndef OPENSSL_NO_CMS
-    { "X942KDF", "provider=default", kdf_x942_kdf_functions },
+    { "X942KDF", "provider=default", ossl_kdf_x942_kdf_functions },
 #endif
 #ifndef OPENSSL_NO_SCRYPT
-    { "SCRYPT:id-scrypt", "provider=default", kdf_scrypt_functions },
+    { "SCRYPT:id-scrypt", "provider=default", ossl_kdf_scrypt_functions },
 #endif
-    { "KRB5KDF", "provider=default", kdf_krb5kdf_functions },
+    { "KRB5KDF", "provider=default", ossl_kdf_krb5kdf_functions },
     { NULL, NULL, NULL }
 };
 
 static const OSSL_ALGORITHM deflt_keyexch[] = {
 #ifndef OPENSSL_NO_DH
-    { "DH:dhKeyAgreement", "provider=default", dh_keyexch_functions },
+    { "DH:dhKeyAgreement", "provider=default", ossl_dh_keyexch_functions },
 #endif
 #ifndef OPENSSL_NO_EC
-    { "ECDH", "provider=default", ecdh_keyexch_functions },
-    { "X25519", "provider=default", x25519_keyexch_functions },
-    { "X448", "provider=default", x448_keyexch_functions },
+    { "ECDH", "provider=default", ecossl_dh_keyexch_functions },
+    { "X25519", "provider=default", ossl_x25519_keyexch_functions },
+    { "X448", "provider=default", ossl_x448_keyexch_functions },
 #endif
-    { "TLS1-PRF", "provider=default", kdf_tls1_prf_keyexch_functions },
-    { "HKDF", "provider=default", kdf_hkdf_keyexch_functions },
-    { "SCRYPT:id-scrypt", "provider=default", kdf_scrypt_keyexch_functions },
+    { "TLS1-PRF", "provider=default", ossl_kdf_tls1_prf_keyexch_functions },
+    { "HKDF", "provider=default", ossl_kdf_hkdf_keyexch_functions },
+    { "SCRYPT:id-scrypt", "provider=default",
+      ossl_kdf_scrypt_keyexch_functions },
     { NULL, NULL, NULL }
 };
 
 static const OSSL_ALGORITHM deflt_rands[] = {
-    { "CTR-DRBG", "provider=default", drbg_ctr_functions },
-    { "HASH-DRBG", "provider=default", drbg_hash_functions },
-    { "HMAC-DRBG", "provider=default", drbg_hmac_functions },
-    { "TEST-RAND", "provider=default", test_rng_functions },
+    { "CTR-DRBG", "provider=default", ossl_drbg_ctr_functions },
+    { "HASH-DRBG", "provider=default", ossl_drbg_hash_functions },
+    { "HMAC-DRBG", "provider=default", ossl_drbg_ossl_hmac_functions },
+    { "TEST-RAND", "provider=default", ossl_test_rng_functions },
     { NULL, NULL, NULL }
 };
 
 static const OSSL_ALGORITHM deflt_signature[] = {
 #ifndef OPENSSL_NO_DSA
-    { "DSA:dsaEncryption", "provider=default", dsa_signature_functions },
+    { "DSA:dsaEncryption", "provider=default", ossl_dsa_signature_functions },
 #endif
-    { "RSA:rsaEncryption", "provider=default", rsa_signature_functions },
+    { "RSA:rsaEncryption", "provider=default", ossl_rsa_signature_functions },
 #ifndef OPENSSL_NO_EC
-    { "ED25519:Ed25519", "provider=default", ed25519_signature_functions },
-    { "ED448:Ed448", "provider=default", ed448_signature_functions },
-    { "ECDSA", "provider=default", ecdsa_signature_functions },
+    { "ED25519:Ed25519", "provider=default", ossl_ed25519_signature_functions },
+    { "ED448:Ed448", "provider=default", ossl_ed448_signature_functions },
+    { "ECDSA", "provider=default", ecossl_dsa_signature_functions },
 # ifndef OPENSSL_NO_SM2
     { "SM2", "provider=default", sm2_signature_functions },
 # endif
 #endif
-    { "HMAC", "provider=default", mac_legacy_hmac_signature_functions },
-    { "SIPHASH", "provider=default", mac_legacy_siphash_signature_functions },
+    { "HMAC", "provider=default", ossl_mac_legacy_hmac_signature_functions },
+    { "SIPHASH", "provider=default",
+      ossl_mac_legacy_siphash_signature_functions },
 #ifndef OPENSSL_NO_POLY1305
-    { "POLY1305", "provider=default", mac_legacy_poly1305_signature_functions },
+    { "POLY1305", "provider=default",
+      ossl_mac_legacy_poly1305_signature_functions },
 #endif
 #ifndef OPENSSL_NO_CMAC
-    { "CMAC", "provider=default", mac_legacy_cmac_signature_functions },
+    { "CMAC", "provider=default", ossl_mac_legacy_cmac_signature_functions },
 #endif
     { NULL, NULL, NULL }
 };
 
 static const OSSL_ALGORITHM deflt_asym_cipher[] = {
-    { "RSA:rsaEncryption", "provider=default", rsa_asym_cipher_functions },
+    { "RSA:rsaEncryption", "provider=default", ossl_rsa_asym_cipher_functions },
 #ifndef OPENSSL_NO_SM2
     { "SM2", "provider=default", sm2_asym_cipher_functions },
 #endif
@@ -388,37 +393,38 @@ static const OSSL_ALGORITHM deflt_asym_cipher[] = {
 };
 
 static const OSSL_ALGORITHM deflt_asym_kem[] = {
-    { "RSA", "provider=default", rsa_asym_kem_functions },
+    { "RSA", "provider=default", ossl_rsa_asym_kem_functions },
     { NULL, NULL, NULL }
 };
 
 static const OSSL_ALGORITHM deflt_keymgmt[] = {
 #ifndef OPENSSL_NO_DH
-    { "DH:dhKeyAgreement", "provider=default", dh_keymgmt_functions },
-    { "DHX:X9.42 DH:dhpublicnumber", "provider=default", dhx_keymgmt_functions },
+    { "DH:dhKeyAgreement", "provider=default", ossl_dh_keymgmt_functions },
+    { "DHX:X9.42 DH:dhpublicnumber", "provider=default",
+      ossl_dhx_keymgmt_functions },
 #endif
 #ifndef OPENSSL_NO_DSA
-    { "DSA:dsaEncryption", "provider=default", dsa_keymgmt_functions },
+    { "DSA:dsaEncryption", "provider=default", ossl_dsa_keymgmt_functions },
 #endif
-    { "RSA:rsaEncryption", "provider=default", rsa_keymgmt_functions },
-    { "RSA-PSS:RSASSA-PSS", "provider=default", rsapss_keymgmt_functions },
+    { "RSA:rsaEncryption", "provider=default", ossl_rsa_keymgmt_functions },
+    { "RSA-PSS:RSASSA-PSS", "provider=default", ossl_rsapss_keymgmt_functions },
 #ifndef OPENSSL_NO_EC
-    { "EC:id-ecPublicKey", "provider=default", ec_keymgmt_functions },
-    { "X25519", "provider=default", x25519_keymgmt_functions },
-    { "X448", "provider=default", x448_keymgmt_functions },
-    { "ED25519", "provider=default", ed25519_keymgmt_functions },
-    { "ED448", "provider=default", ed448_keymgmt_functions },
+    { "EC:id-ecPublicKey", "provider=default", ossl_ec_keymgmt_functions },
+    { "X25519", "provider=default", ossl_x25519_keymgmt_functions },
+    { "X448", "provider=default", ossl_x448_keymgmt_functions },
+    { "ED25519", "provider=default", ossl_ed25519_keymgmt_functions },
+    { "ED448", "provider=default", ossl_ed448_keymgmt_functions },
 #endif
-    { "TLS1-PRF", "provider=default", kdf_keymgmt_functions },
-    { "HKDF", "provider=default", kdf_keymgmt_functions },
-    { "SCRYPT:id-scrypt", "provider=default", kdf_keymgmt_functions },
-    { "HMAC", "provider=default", mac_legacy_keymgmt_functions },
-    { "SIPHASH", "provider=default", mac_legacy_keymgmt_functions },
+    { "TLS1-PRF", "provider=default", ossl_kdf_keymgmt_functions },
+    { "HKDF", "provider=default", ossl_kdf_keymgmt_functions },
+    { "SCRYPT:id-scrypt", "provider=default", ossl_kdf_keymgmt_functions },
+    { "HMAC", "provider=default", ossl_mac_legacy_keymgmt_functions },
+    { "SIPHASH", "provider=default", ossl_mac_legacy_keymgmt_functions },
 #ifndef OPENSSL_NO_POLY1305
-    { "POLY1305", "provider=default", mac_legacy_keymgmt_functions },
+    { "POLY1305", "provider=default", ossl_mac_legacy_keymgmt_functions },
 #endif
 #ifndef OPENSSL_NO_CMAC
-    { "CMAC", "provider=default", cmac_legacy_keymgmt_functions },
+    { "CMAC", "provider=default", ossl_cossl_mac_legacy_keymgmt_functions },
 #endif
 #ifndef OPENSSL_NO_SM2
     { "SM2", "provider=default", sm2_keymgmt_functions },

--- a/providers/encoders.inc
+++ b/providers/encoders.inc
@@ -11,47 +11,47 @@
 # error Macro ENCODER undefined
 #endif
 
-    ENCODER("RSA", "yes", "text", rsa_to_text_encoder_functions),
-    ENCODER("RSA", "yes", "der", rsa_to_der_encoder_functions),
-    ENCODER("RSA", "yes", "pem", rsa_to_pem_encoder_functions),
-    ENCODER("RSA-PSS", "yes", "text", rsapss_to_text_encoder_functions),
-    ENCODER("RSA-PSS", "yes", "der", rsapss_to_der_encoder_functions),
-    ENCODER("RSA-PSS", "yes", "pem", rsapss_to_pem_encoder_functions),
+    ENCODER("RSA", "yes", "text", ossl_rsa_to_text_encoder_functions),
+    ENCODER("RSA", "yes", "der", ossl_rsa_to_der_encoder_functions),
+    ENCODER("RSA", "yes", "pem", ossl_rsa_to_pem_encoder_functions),
+    ENCODER("RSA-PSS", "yes", "text", ossl_rsapss_to_text_encoder_functions),
+    ENCODER("RSA-PSS", "yes", "der", ossl_rsapss_to_der_encoder_functions),
+    ENCODER("RSA-PSS", "yes", "pem", ossl_rsapss_to_pem_encoder_functions),
 
 #ifndef OPENSSL_NO_DH
-    ENCODER("DH", "yes", "text", dh_to_text_encoder_functions),
-    ENCODER("DH", "yes", "der", dh_to_der_encoder_functions),
-    ENCODER("DH", "yes", "pem", dh_to_pem_encoder_functions),
+    ENCODER("DH", "yes", "text", ossl_dh_to_text_encoder_functions),
+    ENCODER("DH", "yes", "der", ossl_dh_to_der_encoder_functions),
+    ENCODER("DH", "yes", "pem", ossl_dh_to_pem_encoder_functions),
 
-    ENCODER("DHX", "yes", "text", dhx_to_text_encoder_functions),
-    ENCODER("DHX", "yes", "der", dhx_to_der_encoder_functions),
-    ENCODER("DHX", "yes", "pem", dhx_to_pem_encoder_functions),
+    ENCODER("DHX", "yes", "text", ossl_dhx_to_text_encoder_functions),
+    ENCODER("DHX", "yes", "der", ossl_dhx_to_der_encoder_functions),
+    ENCODER("DHX", "yes", "pem", ossl_dhx_to_pem_encoder_functions),
 #endif
 
 #ifndef OPENSSL_NO_DSA
-    ENCODER("DSA", "yes", "text", dsa_to_text_encoder_functions),
-    ENCODER("DSA", "yes", "der", dsa_to_der_encoder_functions),
-    ENCODER("DSA", "yes", "pem", dsa_to_pem_encoder_functions),
+    ENCODER("DSA", "yes", "text", ossl_dsa_to_text_encoder_functions),
+    ENCODER("DSA", "yes", "der", ossl_dsa_to_der_encoder_functions),
+    ENCODER("DSA", "yes", "pem", ossl_dsa_to_pem_encoder_functions),
 #endif
 
 #ifndef OPENSSL_NO_EC
-    ENCODER("X25519", "yes", "text", x25519_to_text_encoder_functions),
-    ENCODER("X25519", "yes", "der", x25519_to_der_encoder_functions),
-    ENCODER("X25519", "yes", "pem", x25519_to_pem_encoder_functions),
+    ENCODER("X25519", "yes", "text", ossl_x25519_to_text_encoder_functions),
+    ENCODER("X25519", "yes", "der", ossl_x25519_to_der_encoder_functions),
+    ENCODER("X25519", "yes", "pem", ossl_x25519_to_pem_encoder_functions),
 
-    ENCODER("X448", "yes", "text", x448_to_text_encoder_functions),
-    ENCODER("X448", "yes", "der", x448_to_der_encoder_functions),
-    ENCODER("X448", "yes", "pem", x448_to_pem_encoder_functions),
+    ENCODER("X448", "yes", "text", ossl_x448_to_text_encoder_functions),
+    ENCODER("X448", "yes", "der", ossl_x448_to_der_encoder_functions),
+    ENCODER("X448", "yes", "pem", ossl_x448_to_pem_encoder_functions),
 
-    ENCODER("ED25519", "yes", "text", ed25519_to_text_encoder_functions),
-    ENCODER("ED25519", "yes", "der", ed25519_to_der_encoder_functions),
-    ENCODER("ED25519", "yes", "pem", ed25519_to_pem_encoder_functions),
+    ENCODER("ED25519", "yes", "text", ossl_ed25519_to_text_encoder_functions),
+    ENCODER("ED25519", "yes", "der", ossl_ed25519_to_der_encoder_functions),
+    ENCODER("ED25519", "yes", "pem", ossl_ed25519_to_pem_encoder_functions),
 
-    ENCODER("ED448", "yes", "text", ed448_to_text_encoder_functions),
-    ENCODER("ED448", "yes", "der", ed448_to_der_encoder_functions),
-    ENCODER("ED448", "yes", "pem", ed448_to_pem_encoder_functions),
+    ENCODER("ED448", "yes", "text", ossl_ed448_to_text_encoder_functions),
+    ENCODER("ED448", "yes", "der", ossl_ed448_to_der_encoder_functions),
+    ENCODER("ED448", "yes", "pem", ossl_ed448_to_pem_encoder_functions),
 
-    ENCODER("EC", "yes", "text", ec_to_text_encoder_functions),
-    ENCODER("EC", "yes", "der", ec_to_der_encoder_functions),
-    ENCODER("EC", "yes", "pem", ec_to_pem_encoder_functions),
+    ENCODER("EC", "yes", "text", ossl_ec_to_text_encoder_functions),
+    ENCODER("EC", "yes", "der", ossl_ec_to_der_encoder_functions),
+    ENCODER("EC", "yes", "pem", ossl_ec_to_pem_encoder_functions),
 #endif

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -307,90 +307,94 @@ const char *ossl_prov_util_nid_to_name(int nid)
  */
 static const OSSL_ALGORITHM fips_digests[] = {
     /* Our primary name:NiST name[:our older names] */
-    { "SHA1:SHA-1:SSL3-SHA1", FIPS_DEFAULT_PROPERTIES, sha1_functions },
-    { "SHA2-224:SHA-224:SHA224", FIPS_DEFAULT_PROPERTIES, sha224_functions },
-    { "SHA2-256:SHA-256:SHA256", FIPS_DEFAULT_PROPERTIES, sha256_functions },
-    { "SHA2-384:SHA-384:SHA384", FIPS_DEFAULT_PROPERTIES, sha384_functions },
-    { "SHA2-512:SHA-512:SHA512", FIPS_DEFAULT_PROPERTIES, sha512_functions },
+    { "SHA1:SHA-1:SSL3-SHA1", FIPS_DEFAULT_PROPERTIES, ossl_sha1_functions },
+    { "SHA2-224:SHA-224:SHA224", FIPS_DEFAULT_PROPERTIES,
+      ossl_sha224_functions },
+    { "SHA2-256:SHA-256:SHA256", FIPS_DEFAULT_PROPERTIES,
+      ossl_sha256_functions },
+    { "SHA2-384:SHA-384:SHA384", FIPS_DEFAULT_PROPERTIES,
+      ossl_sha384_functions },
+    { "SHA2-512:SHA-512:SHA512", FIPS_DEFAULT_PROPERTIES,
+      ossl_sha512_functions },
     { "SHA2-512/224:SHA-512/224:SHA512-224", FIPS_DEFAULT_PROPERTIES,
-      sha512_224_functions },
+      ossl_sha512_224_functions },
     { "SHA2-512/256:SHA-512/256:SHA512-256", FIPS_DEFAULT_PROPERTIES,
-      sha512_256_functions },
+      ossl_sha512_256_functions },
 
     /* We agree with NIST here, so one name only */
-    { "SHA3-224", FIPS_DEFAULT_PROPERTIES, sha3_224_functions },
-    { "SHA3-256", FIPS_DEFAULT_PROPERTIES, sha3_256_functions },
-    { "SHA3-384", FIPS_DEFAULT_PROPERTIES, sha3_384_functions },
-    { "SHA3-512", FIPS_DEFAULT_PROPERTIES, sha3_512_functions },
+    { "SHA3-224", FIPS_DEFAULT_PROPERTIES, ossl_sha3_224_functions },
+    { "SHA3-256", FIPS_DEFAULT_PROPERTIES, ossl_sha3_256_functions },
+    { "SHA3-384", FIPS_DEFAULT_PROPERTIES, ossl_sha3_384_functions },
+    { "SHA3-512", FIPS_DEFAULT_PROPERTIES, ossl_sha3_512_functions },
 
-    { "SHAKE-128:SHAKE128", FIPS_DEFAULT_PROPERTIES, shake_128_functions },
-    { "SHAKE-256:SHAKE256", FIPS_DEFAULT_PROPERTIES, shake_256_functions },
+    { "SHAKE-128:SHAKE128", FIPS_DEFAULT_PROPERTIES, ossl_shake_128_functions },
+    { "SHAKE-256:SHAKE256", FIPS_DEFAULT_PROPERTIES, ossl_shake_256_functions },
 
     /*
      * KECCAK-KMAC-128 and KECCAK-KMAC-256 as hashes are mostly useful for
      * KMAC128 and KMAC256.
      */
     { "KECCAK-KMAC-128:KECCAK-KMAC128", FIPS_DEFAULT_PROPERTIES,
-      keccak_kmac_128_functions },
+      ossl_keccak_kmac_128_functions },
     { "KECCAK-KMAC-256:KECCAK-KMAC256", FIPS_DEFAULT_PROPERTIES,
-      keccak_kmac_256_functions },
+      ossl_keccak_kmac_256_functions },
     { NULL, NULL, NULL }
 };
 
 static const OSSL_ALGORITHM_CAPABLE fips_ciphers[] = {
     /* Our primary name[:ASN.1 OID name][:our older names] */
-    ALG("AES-256-ECB", aes256ecb_functions),
-    ALG("AES-192-ECB", aes192ecb_functions),
-    ALG("AES-128-ECB", aes128ecb_functions),
-    ALG("AES-256-CBC:AES256", aes256cbc_functions),
-    ALG("AES-192-CBC:AES192", aes192cbc_functions),
-    ALG("AES-128-CBC:AES128", aes128cbc_functions),
-    ALG("AES-256-CBC-CTS", aes256cbc_cts_functions),
-    ALG("AES-192-CBC-CTS", aes192cbc_cts_functions),
-    ALG("AES-128-CBC-CTS", aes128cbc_cts_functions),
-    ALG("AES-256-OFB", aes256ofb_functions),
-    ALG("AES-192-OFB", aes192ofb_functions),
-    ALG("AES-128-OFB", aes128ofb_functions),
-    ALG("AES-256-CFB", aes256cfb_functions),
-    ALG("AES-192-CFB", aes192cfb_functions),
-    ALG("AES-128-CFB", aes128cfb_functions),
-    ALG("AES-256-CFB1", aes256cfb1_functions),
-    ALG("AES-192-CFB1", aes192cfb1_functions),
-    ALG("AES-128-CFB1", aes128cfb1_functions),
-    ALG("AES-256-CFB8", aes256cfb8_functions),
-    ALG("AES-192-CFB8", aes192cfb8_functions),
-    ALG("AES-128-CFB8", aes128cfb8_functions),
-    ALG("AES-256-CTR", aes256ctr_functions),
-    ALG("AES-192-CTR", aes192ctr_functions),
-    ALG("AES-128-CTR", aes128ctr_functions),
-    ALG("AES-256-XTS", aes256xts_functions),
-    ALG("AES-128-XTS", aes128xts_functions),
-    ALG("AES-256-GCM:id-aes256-GCM", aes256gcm_functions),
-    ALG("AES-192-GCM:id-aes192-GCM", aes192gcm_functions),
-    ALG("AES-128-GCM:id-aes128-GCM", aes128gcm_functions),
-    ALG("AES-256-CCM:id-aes256-CCM", aes256ccm_functions),
-    ALG("AES-192-CCM:id-aes192-CCM", aes192ccm_functions),
-    ALG("AES-128-CCM:id-aes128-CCM", aes128ccm_functions),
-    ALG("AES-256-WRAP:id-aes256-wrap:AES256-WRAP", aes256wrap_functions),
-    ALG("AES-192-WRAP:id-aes192-wrap:AES192-WRAP", aes192wrap_functions),
-    ALG("AES-128-WRAP:id-aes128-wrap:AES128-WRAP", aes128wrap_functions),
+    ALG("AES-256-ECB", ossl_aes256ecb_functions),
+    ALG("AES-192-ECB", ossl_aes192ecb_functions),
+    ALG("AES-128-ECB", ossl_aes128ecb_functions),
+    ALG("AES-256-CBC:AES256", ossl_aes256cbc_functions),
+    ALG("AES-192-CBC:AES192", ossl_aes192cbc_functions),
+    ALG("AES-128-CBC:AES128", ossl_aes128cbc_functions),
+    ALG("AES-256-CBC-CTS", ossl_aes256cbc_cts_functions),
+    ALG("AES-192-CBC-CTS", ossl_aes192cbc_cts_functions),
+    ALG("AES-128-CBC-CTS", ossl_aes128cbc_cts_functions),
+    ALG("AES-256-OFB", ossl_aes256ofb_functions),
+    ALG("AES-192-OFB", ossl_aes192ofb_functions),
+    ALG("AES-128-OFB", ossl_aes128ofb_functions),
+    ALG("AES-256-CFB", ossl_aes256cfb_functions),
+    ALG("AES-192-CFB", ossl_aes192cfb_functions),
+    ALG("AES-128-CFB", ossl_aes128cfb_functions),
+    ALG("AES-256-CFB1", ossl_aes256cfb1_functions),
+    ALG("AES-192-CFB1", ossl_aes192cfb1_functions),
+    ALG("AES-128-CFB1", ossl_aes128cfb1_functions),
+    ALG("AES-256-CFB8", ossl_aes256cfb8_functions),
+    ALG("AES-192-CFB8", ossl_aes192cfb8_functions),
+    ALG("AES-128-CFB8", ossl_aes128cfb8_functions),
+    ALG("AES-256-CTR", ossl_aes256ctr_functions),
+    ALG("AES-192-CTR", ossl_aes192ctr_functions),
+    ALG("AES-128-CTR", ossl_aes128ctr_functions),
+    ALG("AES-256-XTS", ossl_aes256xts_functions),
+    ALG("AES-128-XTS", ossl_aes128xts_functions),
+    ALG("AES-256-GCM:id-aes256-GCM", ossl_aes256gcm_functions),
+    ALG("AES-192-GCM:id-aes192-GCM", ossl_aes192gcm_functions),
+    ALG("AES-128-GCM:id-aes128-GCM", ossl_aes128gcm_functions),
+    ALG("AES-256-CCM:id-aes256-CCM", ossl_aes256ccm_functions),
+    ALG("AES-192-CCM:id-aes192-CCM", ossl_aes192ccm_functions),
+    ALG("AES-128-CCM:id-aes128-CCM", ossl_aes128ccm_functions),
+    ALG("AES-256-WRAP:id-aes256-wrap:AES256-WRAP", ossl_aes256wrap_functions),
+    ALG("AES-192-WRAP:id-aes192-wrap:AES192-WRAP", ossl_aes192wrap_functions),
+    ALG("AES-128-WRAP:id-aes128-wrap:AES128-WRAP", ossl_aes128wrap_functions),
     ALG("AES-256-WRAP-PAD:id-aes256-wrap-pad:AES256-WRAP-PAD",
-        aes256wrappad_functions),
+        ossl_aes256wrappad_functions),
     ALG("AES-192-WRAP-PAD:id-aes192-wrap-pad:AES192-WRAP-PAD",
-        aes192wrappad_functions),
+        ossl_aes192wrappad_functions),
     ALG("AES-128-WRAP-PAD:id-aes128-wrap-pad:AES128-WRAP-PAD",
-        aes128wrappad_functions),
-    ALGC("AES-128-CBC-HMAC-SHA1", aes128cbc_hmac_sha1_functions,
+        ossl_aes128wrappad_functions),
+    ALGC("AES-128-CBC-HMAC-SHA1", ossl_aes128cbc_hmac_sha1_functions,
          cipher_capable_aes_cbc_hmac_sha1),
-    ALGC("AES-256-CBC-HMAC-SHA1", aes256cbc_hmac_sha1_functions,
+    ALGC("AES-256-CBC-HMAC-SHA1", ossl_aes256cbc_hmac_sha1_functions,
          cipher_capable_aes_cbc_hmac_sha1),
-    ALGC("AES-128-CBC-HMAC-SHA256", aes128cbc_hmac_sha256_functions,
+    ALGC("AES-128-CBC-HMAC-SHA256", ossl_aes128cbc_hmac_sha256_functions,
          cipher_capable_aes_cbc_hmac_sha256),
-    ALGC("AES-256-CBC-HMAC-SHA256", aes256cbc_hmac_sha256_functions,
+    ALGC("AES-256-CBC-HMAC-SHA256", ossl_aes256cbc_hmac_sha256_functions,
          cipher_capable_aes_cbc_hmac_sha256),
 #ifndef OPENSSL_NO_DES
-    ALG("DES-EDE3-ECB:DES-EDE3", tdes_ede3_ecb_functions),
-    ALG("DES-EDE3-CBC:DES3", tdes_ede3_cbc_functions),
+    ALG("DES-EDE3-ECB:DES-EDE3", ossl_tdes_ede3_ecb_functions),
+    ALG("DES-EDE3-CBC:DES3", ossl_tdes_ede3_cbc_functions),
 #endif  /* OPENSSL_NO_DES */
     { { NULL, NULL, NULL }, NULL }
 };
@@ -398,98 +402,107 @@ static OSSL_ALGORITHM exported_fips_ciphers[OSSL_NELEM(fips_ciphers)];
 
 static const OSSL_ALGORITHM fips_macs[] = {
 #ifndef OPENSSL_NO_CMAC
-    { "CMAC", FIPS_DEFAULT_PROPERTIES, cmac_functions },
+    { "CMAC", FIPS_DEFAULT_PROPERTIES, ossl_cmac_functions },
 #endif
-    { "GMAC", FIPS_DEFAULT_PROPERTIES, gmac_functions },
-    { "HMAC", FIPS_DEFAULT_PROPERTIES, hmac_functions },
-    { "KMAC-128:KMAC128", FIPS_DEFAULT_PROPERTIES, kmac128_functions },
-    { "KMAC-256:KMAC256", FIPS_DEFAULT_PROPERTIES, kmac256_functions },
+    { "GMAC", FIPS_DEFAULT_PROPERTIES, ossl_gmac_functions },
+    { "HMAC", FIPS_DEFAULT_PROPERTIES, ossl_hmac_functions },
+    { "KMAC-128:KMAC128", FIPS_DEFAULT_PROPERTIES, ossl_kmac128_functions },
+    { "KMAC-256:KMAC256", FIPS_DEFAULT_PROPERTIES, ossl_kmac256_functions },
     { NULL, NULL, NULL }
 };
 
 static const OSSL_ALGORITHM fips_kdfs[] = {
-    { "HKDF", FIPS_DEFAULT_PROPERTIES, kdf_hkdf_functions },
-    { "SSKDF", FIPS_DEFAULT_PROPERTIES, kdf_sskdf_functions },
-    { "PBKDF2", FIPS_DEFAULT_PROPERTIES, kdf_pbkdf2_functions },
-    { "SSHKDF", FIPS_DEFAULT_PROPERTIES, kdf_sshkdf_functions },
-    { "X963KDF", FIPS_DEFAULT_PROPERTIES, kdf_x963_kdf_functions },
-    { "TLS1-PRF", FIPS_DEFAULT_PROPERTIES, kdf_tls1_prf_functions },
-    { "KBKDF", FIPS_DEFAULT_PROPERTIES, kdf_kbkdf_functions },
+    { "HKDF", FIPS_DEFAULT_PROPERTIES, ossl_kdf_hkdf_functions },
+    { "SSKDF", FIPS_DEFAULT_PROPERTIES, ossl_kdf_sskdf_functions },
+    { "PBKDF2", FIPS_DEFAULT_PROPERTIES, ossl_kdf_pbkdf2_functions },
+    { "SSHKDF", FIPS_DEFAULT_PROPERTIES, ossl_kdf_sshkdf_functions },
+    { "X963KDF", FIPS_DEFAULT_PROPERTIES, ossl_kdf_x963_kdf_functions },
+    { "TLS1-PRF", FIPS_DEFAULT_PROPERTIES, ossl_kdf_tls1_prf_functions },
+    { "KBKDF", FIPS_DEFAULT_PROPERTIES, ossl_kdf_kbkdf_functions },
     { NULL, NULL, NULL }
 };
 
 static const OSSL_ALGORITHM fips_rands[] = {
-    { "CTR-DRBG", FIPS_DEFAULT_PROPERTIES, drbg_ctr_functions },
-    { "HASH-DRBG", FIPS_DEFAULT_PROPERTIES, drbg_hash_functions },
-    { "HMAC-DRBG", FIPS_DEFAULT_PROPERTIES, drbg_hmac_functions },
-    { "TEST-RAND", FIPS_UNAPPROVED_PROPERTIES, test_rng_functions },
+    { "CTR-DRBG", FIPS_DEFAULT_PROPERTIES, ossl_drbg_ctr_functions },
+    { "HASH-DRBG", FIPS_DEFAULT_PROPERTIES, ossl_drbg_hash_functions },
+    { "HMAC-DRBG", FIPS_DEFAULT_PROPERTIES, ossl_drbg_ossl_hmac_functions },
+    { "TEST-RAND", FIPS_UNAPPROVED_PROPERTIES, ossl_test_rng_functions },
     { NULL, NULL, NULL }
 };
 
 static const OSSL_ALGORITHM fips_keyexch[] = {
 #ifndef OPENSSL_NO_DH
-    { "DH:dhKeyAgreement", FIPS_DEFAULT_PROPERTIES, dh_keyexch_functions },
+    { "DH:dhKeyAgreement", FIPS_DEFAULT_PROPERTIES, ossl_dh_keyexch_functions },
 #endif
 #ifndef OPENSSL_NO_EC
-    { "ECDH", FIPS_DEFAULT_PROPERTIES, ecdh_keyexch_functions },
-    { "X25519", FIPS_DEFAULT_PROPERTIES, x25519_keyexch_functions },
-    { "X448", FIPS_DEFAULT_PROPERTIES, x448_keyexch_functions },
+    { "ECDH", FIPS_DEFAULT_PROPERTIES, ecossl_dh_keyexch_functions },
+    { "X25519", FIPS_DEFAULT_PROPERTIES, ossl_x25519_keyexch_functions },
+    { "X448", FIPS_DEFAULT_PROPERTIES, ossl_x448_keyexch_functions },
 #endif
-    { "TLS1-PRF", FIPS_DEFAULT_PROPERTIES, kdf_tls1_prf_keyexch_functions },
-    { "HKDF", FIPS_DEFAULT_PROPERTIES, kdf_hkdf_keyexch_functions },
+    { "TLS1-PRF", FIPS_DEFAULT_PROPERTIES,
+      ossl_kdf_tls1_prf_keyexch_functions },
+    { "HKDF", FIPS_DEFAULT_PROPERTIES, ossl_kdf_hkdf_keyexch_functions },
     { NULL, NULL, NULL }
 };
 
 static const OSSL_ALGORITHM fips_signature[] = {
 #ifndef OPENSSL_NO_DSA
-    { "DSA:dsaEncryption", FIPS_DEFAULT_PROPERTIES, dsa_signature_functions },
+    { "DSA:dsaEncryption", FIPS_DEFAULT_PROPERTIES,
+      ossl_dsa_signature_functions },
 #endif
-    { "RSA:rsaEncryption", FIPS_DEFAULT_PROPERTIES, rsa_signature_functions },
+    { "RSA:rsaEncryption", FIPS_DEFAULT_PROPERTIES,
+      ossl_rsa_signature_functions },
 #ifndef OPENSSL_NO_EC
-    { "ED25519", FIPS_DEFAULT_PROPERTIES, ed25519_signature_functions },
-    { "ED448", FIPS_DEFAULT_PROPERTIES, ed448_signature_functions },
-    { "ECDSA", FIPS_DEFAULT_PROPERTIES, ecdsa_signature_functions },
+    { "ED25519", FIPS_DEFAULT_PROPERTIES, ossl_ed25519_signature_functions },
+    { "ED448", FIPS_DEFAULT_PROPERTIES, ossl_ed448_signature_functions },
+    { "ECDSA", FIPS_DEFAULT_PROPERTIES, ecossl_dsa_signature_functions },
 #endif
-    { "HMAC", FIPS_DEFAULT_PROPERTIES, mac_legacy_hmac_signature_functions },
+    { "HMAC", FIPS_DEFAULT_PROPERTIES,
+      ossl_mac_legacy_hmac_signature_functions },
 #ifndef OPENSSL_NO_CMAC
-    { "CMAC", FIPS_DEFAULT_PROPERTIES, mac_legacy_cmac_signature_functions },
+    { "CMAC", FIPS_DEFAULT_PROPERTIES,
+      ossl_mac_legacy_cmac_signature_functions },
 #endif
     { NULL, NULL, NULL }
 };
 
 static const OSSL_ALGORITHM fips_asym_cipher[] = {
-    { "RSA:rsaEncryption", FIPS_DEFAULT_PROPERTIES, rsa_asym_cipher_functions },
+    { "RSA:rsaEncryption", FIPS_DEFAULT_PROPERTIES,
+      ossl_rsa_asym_cipher_functions },
     { NULL, NULL, NULL }
 };
 
 static const OSSL_ALGORITHM fips_asym_kem[] = {
-    { "RSA", FIPS_DEFAULT_PROPERTIES, rsa_asym_kem_functions },
+    { "RSA", FIPS_DEFAULT_PROPERTIES, ossl_rsa_asym_kem_functions },
     { NULL, NULL, NULL }
 };
 
 static const OSSL_ALGORITHM fips_keymgmt[] = {
 #ifndef OPENSSL_NO_DH
-    { "DH:dhKeyAgreement", FIPS_DEFAULT_PROPERTIES, dh_keymgmt_functions },
-    { "DHX:X9.42 DH:dhpublicnumber", FIPS_DEFAULT_PROPERTIES, dhx_keymgmt_functions },
+    { "DH:dhKeyAgreement", FIPS_DEFAULT_PROPERTIES, ossl_dh_keymgmt_functions },
+    { "DHX:X9.42 DH:dhpublicnumber", FIPS_DEFAULT_PROPERTIES,
+      ossl_dhx_keymgmt_functions },
 #endif
 #ifndef OPENSSL_NO_DSA
-    { "DSA", FIPS_DEFAULT_PROPERTIES, dsa_keymgmt_functions },
+    { "DSA", FIPS_DEFAULT_PROPERTIES, ossl_dsa_keymgmt_functions },
 #endif
-    { "RSA:rsaEncryption", FIPS_DEFAULT_PROPERTIES, rsa_keymgmt_functions },
+    { "RSA:rsaEncryption", FIPS_DEFAULT_PROPERTIES,
+      ossl_rsa_keymgmt_functions },
     { "RSA-PSS:RSASSA-PSS", FIPS_DEFAULT_PROPERTIES,
-      rsapss_keymgmt_functions },
+      ossl_rsapss_keymgmt_functions },
 #ifndef OPENSSL_NO_EC
-    { "EC:id-ecPublicKey", FIPS_DEFAULT_PROPERTIES, ec_keymgmt_functions },
-    { "X25519", FIPS_DEFAULT_PROPERTIES, x25519_keymgmt_functions },
-    { "X448", FIPS_DEFAULT_PROPERTIES, x448_keymgmt_functions },
-    { "ED25519", FIPS_DEFAULT_PROPERTIES, ed25519_keymgmt_functions },
-    { "ED448", FIPS_DEFAULT_PROPERTIES, ed448_keymgmt_functions },
+    { "EC:id-ecPublicKey", FIPS_DEFAULT_PROPERTIES, ossl_ec_keymgmt_functions },
+    { "X25519", FIPS_DEFAULT_PROPERTIES, ossl_x25519_keymgmt_functions },
+    { "X448", FIPS_DEFAULT_PROPERTIES, ossl_x448_keymgmt_functions },
+    { "ED25519", FIPS_DEFAULT_PROPERTIES, ossl_ed25519_keymgmt_functions },
+    { "ED448", FIPS_DEFAULT_PROPERTIES, ossl_ed448_keymgmt_functions },
 #endif
-    { "TLS1-PRF", FIPS_DEFAULT_PROPERTIES, kdf_keymgmt_functions },
-    { "HKDF", FIPS_DEFAULT_PROPERTIES, kdf_keymgmt_functions },
-    { "HMAC", FIPS_DEFAULT_PROPERTIES, mac_legacy_keymgmt_functions },
+    { "TLS1-PRF", FIPS_DEFAULT_PROPERTIES, ossl_kdf_keymgmt_functions },
+    { "HKDF", FIPS_DEFAULT_PROPERTIES, ossl_kdf_keymgmt_functions },
+    { "HMAC", FIPS_DEFAULT_PROPERTIES, ossl_mac_legacy_keymgmt_functions },
 #ifndef OPENSSL_NO_CMAC
-    { "CMAC", FIPS_DEFAULT_PROPERTIES, cmac_legacy_keymgmt_functions },
+    { "CMAC", FIPS_DEFAULT_PROPERTIES,
+      ossl_cossl_mac_legacy_keymgmt_functions },
 #endif
     { NULL, NULL, NULL }
 };

--- a/providers/implementations/asymciphers/rsa_enc.c
+++ b/providers/implementations/asymciphers/rsa_enc.c
@@ -563,7 +563,7 @@ static const OSSL_PARAM *rsa_settable_ctx_params(ossl_unused void *provctx)
     return known_settable_ctx_params;
 }
 
-const OSSL_DISPATCH rsa_asym_cipher_functions[] = {
+const OSSL_DISPATCH ossl_rsa_asym_cipher_functions[] = {
     { OSSL_FUNC_ASYM_CIPHER_NEWCTX, (void (*)(void))rsa_newctx },
     { OSSL_FUNC_ASYM_CIPHER_ENCRYPT_INIT, (void (*)(void))rsa_encrypt_init },
     { OSSL_FUNC_ASYM_CIPHER_ENCRYPT, (void (*)(void))rsa_encrypt },

--- a/providers/implementations/ciphers/cipher_aes.c
+++ b/providers/implementations/ciphers/cipher_aes.c
@@ -49,47 +49,47 @@ static void *aes_dupctx(void *ctx)
     return ret;
 }
 
-/* aes256ecb_functions */
+/* ossl_aes256ecb_functions */
 IMPLEMENT_generic_cipher(aes, AES, ecb, ECB, 0, 256, 128, 0, block)
-/* aes192ecb_functions */
+/* ossl_aes192ecb_functions */
 IMPLEMENT_generic_cipher(aes, AES, ecb, ECB, 0, 192, 128, 0, block)
-/* aes128ecb_functions */
+/* ossl_aes128ecb_functions */
 IMPLEMENT_generic_cipher(aes, AES, ecb, ECB, 0, 128, 128, 0, block)
-/* aes256cbc_functions */
+/* ossl_aes256cbc_functions */
 IMPLEMENT_generic_cipher(aes, AES, cbc, CBC, 0, 256, 128, 128, block)
-/* aes192cbc_functions */
+/* ossl_aes192cbc_functions */
 IMPLEMENT_generic_cipher(aes, AES, cbc, CBC, 0, 192, 128, 128, block)
-/* aes128cbc_functions */
+/* ossl_aes128cbc_functions */
 IMPLEMENT_generic_cipher(aes, AES, cbc, CBC, 0, 128, 128, 128, block)
-/* aes256ofb_functions */
+/* ossl_aes256ofb_functions */
 IMPLEMENT_generic_cipher(aes, AES, ofb, OFB, 0, 256, 8, 128, stream)
-/* aes192ofb_functions */
+/* ossl_aes192ofb_functions */
 IMPLEMENT_generic_cipher(aes, AES, ofb, OFB, 0, 192, 8, 128, stream)
-/* aes128ofb_functions */
+/* ossl_aes128ofb_functions */
 IMPLEMENT_generic_cipher(aes, AES, ofb, OFB, 0, 128, 8, 128, stream)
-/* aes256cfb_functions */
+/* ossl_aes256cfb_functions */
 IMPLEMENT_generic_cipher(aes, AES, cfb,  CFB, 0, 256, 8, 128, stream)
-/* aes192cfb_functions */
+/* ossl_aes192cfb_functions */
 IMPLEMENT_generic_cipher(aes, AES, cfb,  CFB, 0, 192, 8, 128, stream)
-/* aes128cfb_functions */
+/* ossl_aes128cfb_functions */
 IMPLEMENT_generic_cipher(aes, AES, cfb,  CFB, 0, 128, 8, 128, stream)
-/* aes256cfb1_functions */
+/* ossl_aes256cfb1_functions */
 IMPLEMENT_generic_cipher(aes, AES, cfb1, CFB, 0, 256, 8, 128, stream)
-/* aes192cfb1_functions */
+/* ossl_aes192cfb1_functions */
 IMPLEMENT_generic_cipher(aes, AES, cfb1, CFB, 0, 192, 8, 128, stream)
-/* aes128cfb1_functions */
+/* ossl_aes128cfb1_functions */
 IMPLEMENT_generic_cipher(aes, AES, cfb1, CFB, 0, 128, 8, 128, stream)
-/* aes256cfb8_functions */
+/* ossl_aes256cfb8_functions */
 IMPLEMENT_generic_cipher(aes, AES, cfb8, CFB, 0, 256, 8, 128, stream)
-/* aes192cfb8_functions */
+/* ossl_aes192cfb8_functions */
 IMPLEMENT_generic_cipher(aes, AES, cfb8, CFB, 0, 192, 8, 128, stream)
-/* aes128cfb8_functions */
+/* ossl_aes128cfb8_functions */
 IMPLEMENT_generic_cipher(aes, AES, cfb8, CFB, 0, 128, 8, 128, stream)
-/* aes256ctr_functions */
+/* ossl_aes256ctr_functions */
 IMPLEMENT_generic_cipher(aes, AES, ctr, CTR, 0, 256, 8, 128, stream)
-/* aes192ctr_functions */
+/* ossl_aes192ctr_functions */
 IMPLEMENT_generic_cipher(aes, AES, ctr, CTR, 0, 192, 8, 128, stream)
-/* aes128ctr_functions */
+/* ossl_aes128ctr_functions */
 IMPLEMENT_generic_cipher(aes, AES, ctr, CTR, 0, 128, 8, 128, stream)
 
 #include "cipher_aes_cts.inc"

--- a/providers/implementations/ciphers/cipher_aes_cbc_hmac_sha.c
+++ b/providers/implementations/ciphers/cipher_aes_cbc_hmac_sha.c
@@ -24,7 +24,7 @@
 
 #ifndef AES_CBC_HMAC_SHA_CAPABLE
 # define IMPLEMENT_CIPHER(nm, sub, kbits, blkbits, ivbits, flags)              \
-const OSSL_DISPATCH nm##kbits##sub##_functions[] = {                           \
+const OSSL_DISPATCH ossl_##nm##kbits##sub##_functions[] = {                    \
     { 0, NULL }                                                                \
 };
 #else
@@ -362,7 +362,7 @@ static int nm##_##kbits##_##sub##_get_params(OSSL_PARAM params[])              \
     return cipher_generic_get_params(params, EVP_CIPH_CBC_MODE,                \
                                      flags, kbits, blkbits, ivbits);           \
 }                                                                              \
-const OSSL_DISPATCH nm##kbits##sub##_functions[] = {                           \
+const OSSL_DISPATCH ossl_##nm##kbits##sub##_functions[] = {                    \
     { OSSL_FUNC_CIPHER_NEWCTX, (void (*)(void))nm##_##kbits##_##sub##_newctx },\
     { OSSL_FUNC_CIPHER_FREECTX, (void (*)(void))nm##_##sub##_freectx },        \
     { OSSL_FUNC_CIPHER_ENCRYPT_INIT, (void (*)(void))nm##_einit },             \
@@ -387,11 +387,11 @@ const OSSL_DISPATCH nm##kbits##sub##_functions[] = {                           \
 
 #endif /* AES_CBC_HMAC_SHA_CAPABLE */
 
-/* aes128cbc_hmac_sha1_functions */
+/* ossl_aes128cbc_hmac_sha1_functions */
 IMPLEMENT_CIPHER(aes, cbc_hmac_sha1, 128, 128, 128, AES_CBC_HMAC_SHA_FLAGS)
-/* aes256cbc_hmac_sha1_functions */
+/* ossl_aes256cbc_hmac_sha1_functions */
 IMPLEMENT_CIPHER(aes, cbc_hmac_sha1, 256, 128, 128, AES_CBC_HMAC_SHA_FLAGS)
-/* aes128cbc_hmac_sha256_functions */
+/* ossl_aes128cbc_hmac_sha256_functions */
 IMPLEMENT_CIPHER(aes, cbc_hmac_sha256, 128, 128, 128, AES_CBC_HMAC_SHA_FLAGS)
-/* aes256cbc_hmac_sha256_functions */
+/* ossl_aes256cbc_hmac_sha256_functions */
 IMPLEMENT_CIPHER(aes, cbc_hmac_sha256, 256, 128, 128, AES_CBC_HMAC_SHA_FLAGS)

--- a/providers/implementations/ciphers/cipher_aes_ccm.c
+++ b/providers/implementations/ciphers/cipher_aes_ccm.c
@@ -41,9 +41,9 @@ static void aes_ccm_freectx(void *vctx)
     OPENSSL_clear_free(ctx,  sizeof(*ctx));
 }
 
-/* aes128ccm_functions */
+/* ossl_aes128ccm_functions */
 IMPLEMENT_aead_cipher(aes, ccm, CCM, AEAD_FLAGS, 128, 8, 96);
-/* aes192ccm_functions */
+/* ossl_aes192ccm_functions */
 IMPLEMENT_aead_cipher(aes, ccm, CCM, AEAD_FLAGS, 192, 8, 96);
-/* aes256ccm_functions */
+/* ossl_aes256ccm_functions */
 IMPLEMENT_aead_cipher(aes, ccm, CCM, AEAD_FLAGS, 256, 8, 96);

--- a/providers/implementations/ciphers/cipher_aes_cts.inc
+++ b/providers/implementations/ciphers/cipher_aes_cts.inc
@@ -73,7 +73,7 @@ static int alg##_cts_##kbits##_##lcmode##_get_params(OSSL_PARAM params[])      \
     return cipher_generic_get_params(params, EVP_CIPH_##UCMODE##_MODE, flags,  \
                                      kbits, blkbits, ivbits);                  \
 }                                                                              \
-const OSSL_DISPATCH alg##kbits##lcmode##_cts_functions[] = {                   \
+const OSSL_DISPATCH ossl_##alg##kbits##lcmode##_cts_functions[] = {            \
     { OSSL_FUNC_CIPHER_NEWCTX,                                                 \
       (void (*)(void)) alg##_##kbits##_##lcmode##_newctx },                    \
     { OSSL_FUNC_CIPHER_FREECTX, (void (*)(void)) alg##_freectx },              \
@@ -100,9 +100,9 @@ const OSSL_DISPATCH alg##kbits##lcmode##_cts_functions[] = {                   \
     { 0, NULL }                                                                \
 };
 
-/* aes256cbc_cts_functions */
+/* ossl_aes256cbc_cts_functions */
 IMPLEMENT_cts_cipher(aes, AES, cbc, CBC, EVP_CIPH_FLAG_CTS, 256, 128, 128, block)
-/* aes192cbc_cts_functions */
+/* ossl_aes192cbc_cts_functions */
 IMPLEMENT_cts_cipher(aes, AES, cbc, CBC, EVP_CIPH_FLAG_CTS, 192, 128, 128, block)
-/* aes128cbc_cts_functions */
+/* ossl_aes128cbc_cts_functions */
 IMPLEMENT_cts_cipher(aes, AES, cbc, CBC, EVP_CIPH_FLAG_CTS, 128, 128, 128, block)

--- a/providers/implementations/ciphers/cipher_aes_gcm.c
+++ b/providers/implementations/ciphers/cipher_aes_gcm.c
@@ -45,9 +45,9 @@ static void aes_gcm_freectx(void *vctx)
     OPENSSL_clear_free(ctx,  sizeof(*ctx));
 }
 
-/* aes128gcm_functions */
+/* ossl_aes128gcm_functions */
 IMPLEMENT_aead_cipher(aes, gcm, GCM, AEAD_FLAGS, 128, 8, 96);
-/* aes192gcm_functions */
+/* ossl_aes192gcm_functions */
 IMPLEMENT_aead_cipher(aes, gcm, GCM, AEAD_FLAGS, 192, 8, 96);
-/* aes256gcm_functions */
+/* ossl_aes256gcm_functions */
 IMPLEMENT_aead_cipher(aes, gcm, GCM, AEAD_FLAGS, 256, 8, 96);

--- a/providers/implementations/ciphers/cipher_aes_ocb.c
+++ b/providers/implementations/ciphers/cipher_aes_ocb.c
@@ -518,7 +518,7 @@ static void *aes_##kbits##_##mode##_newctx(void *provctx)                      \
     return aes_##mode##_newctx(provctx, kbits, blkbits, ivbits,                \
                                EVP_CIPH_##UCMODE##_MODE, flags);               \
 }                                                                              \
-const OSSL_DISPATCH aes##kbits##mode##_functions[] = {                         \
+const OSSL_DISPATCH ossl_##aes##kbits##mode##_functions[] = {                  \
     { OSSL_FUNC_CIPHER_NEWCTX,                                                 \
         (void (*)(void))aes_##kbits##_##mode##_newctx },                       \
     { OSSL_FUNC_CIPHER_ENCRYPT_INIT, (void (*)(void))aes_##mode##_einit },     \

--- a/providers/implementations/ciphers/cipher_aes_siv.c
+++ b/providers/implementations/ciphers/cipher_aes_siv.c
@@ -266,7 +266,7 @@ static void * alg##kbits##lc##_newctx(void *provctx)                           \
     return alg##_##lc##_newctx(provctx, 2*kbits, EVP_CIPH_##UCMODE##_MODE,     \
                                flags);                                         \
 }                                                                              \
-const OSSL_DISPATCH alg##kbits##lc##_functions[] = {                           \
+const OSSL_DISPATCH ossl_##alg##kbits##lc##_functions[] = {                    \
     { OSSL_FUNC_CIPHER_NEWCTX, (void (*)(void))alg##kbits##lc##_newctx },      \
     { OSSL_FUNC_CIPHER_FREECTX, (void (*)(void))alg##_##lc##_freectx },        \
     { OSSL_FUNC_CIPHER_DUPCTX, (void (*)(void)) lc##_dupctx },                 \

--- a/providers/implementations/ciphers/cipher_aes_wrp.c
+++ b/providers/implementations/ciphers/cipher_aes_wrp.c
@@ -237,7 +237,7 @@ static int aes_wrap_set_ctx_params(void *vctx, const OSSL_PARAM params[])
         return aes_##mode##_newctx(kbits, blkbits, ivbits,                     \
                                    EVP_CIPH_##UCMODE##_MODE, flags);           \
     }                                                                          \
-    const OSSL_DISPATCH aes##kbits##fname##_functions[] = {                    \
+    const OSSL_DISPATCH ossl_##aes##kbits##fname##_functions[] = {             \
         { OSSL_FUNC_CIPHER_NEWCTX,                                             \
             (void (*)(void))aes_##kbits##fname##_newctx },                     \
         { OSSL_FUNC_CIPHER_ENCRYPT_INIT, (void (*)(void))aes_##mode##_einit }, \

--- a/providers/implementations/ciphers/cipher_aes_xts.c
+++ b/providers/implementations/ciphers/cipher_aes_xts.c
@@ -1,3 +1,4 @@
+
 /*
  * Copyright 2019-2020 The OpenSSL Project Authors. All Rights Reserved.
  *
@@ -265,7 +266,7 @@ static void *aes_##kbits##_xts_newctx(void *provctx)                           \
     return aes_xts_newctx(provctx, EVP_CIPH_##UCMODE##_MODE, flags, 2 * kbits, \
                           AES_XTS_BLOCK_BITS, AES_XTS_IV_BITS);                \
 }                                                                              \
-const OSSL_DISPATCH aes##kbits##xts_functions[] = {                            \
+const OSSL_DISPATCH ossl_aes##kbits##xts_functions[] = {                       \
     { OSSL_FUNC_CIPHER_NEWCTX, (void (*)(void))aes_##kbits##_xts_newctx },     \
     { OSSL_FUNC_CIPHER_ENCRYPT_INIT, (void (*)(void))aes_xts_einit },          \
     { OSSL_FUNC_CIPHER_DECRYPT_INIT, (void (*)(void))aes_xts_dinit },          \

--- a/providers/implementations/ciphers/cipher_aria.c
+++ b/providers/implementations/ciphers/cipher_aria.c
@@ -42,45 +42,45 @@ static void *aria_dupctx(void *ctx)
     return ret;
 }
 
-/* aria256ecb_functions */
+/* ossl_aria256ecb_functions */
 IMPLEMENT_generic_cipher(aria, ARIA, ecb, ECB, 0, 256, 128, 0, block)
-/* aria192ecb_functions */
+/* ossl_aria192ecb_functions */
 IMPLEMENT_generic_cipher(aria, ARIA, ecb, ECB, 0, 192, 128, 0, block)
-/* aria128ecb_functions */
+/* ossl_aria128ecb_functions */
 IMPLEMENT_generic_cipher(aria, ARIA, ecb, ECB, 0, 128, 128, 0, block)
-/* aria256cbc_functions */
+/* ossl_aria256cbc_functions */
 IMPLEMENT_generic_cipher(aria, ARIA, cbc, CBC, 0, 256, 128, 128, block)
-/* aria192cbc_functions */
+/* ossl_aria192cbc_functions */
 IMPLEMENT_generic_cipher(aria, ARIA, cbc, CBC, 0, 192, 128, 128, block)
-/* aria128cbc_functions */
+/* ossl_aria128cbc_functions */
 IMPLEMENT_generic_cipher(aria, ARIA, cbc, CBC, 0, 128, 128, 128, block)
-/* aria256ofb_functions */
+/* ossl_aria256ofb_functions */
 IMPLEMENT_generic_cipher(aria, ARIA, ofb, OFB, 0, 256, 8, 128, stream)
-/* aria192ofb_functions */
+/* ossl_aria192ofb_functions */
 IMPLEMENT_generic_cipher(aria, ARIA, ofb, OFB, 0, 192, 8, 128, stream)
-/* aria128ofb_functions */
+/* ossl_aria128ofb_functions */
 IMPLEMENT_generic_cipher(aria, ARIA, ofb, OFB, 0, 128, 8, 128, stream)
-/* aria256cfb_functions */
+/* ossl_aria256cfb_functions */
 IMPLEMENT_generic_cipher(aria, ARIA, cfb,  CFB, 0, 256, 8, 128, stream)
-/* aria192cfb_functions */
+/* ossl_aria192cfb_functions */
 IMPLEMENT_generic_cipher(aria, ARIA, cfb,  CFB, 0, 192, 8, 128, stream)
-/* aria128cfb_functions */
+/* ossl_aria128cfb_functions */
 IMPLEMENT_generic_cipher(aria, ARIA, cfb,  CFB, 0, 128, 8, 128, stream)
-/* aria256cfb1_functions */
+/* ossl_aria256cfb1_functions */
 IMPLEMENT_generic_cipher(aria, ARIA, cfb1, CFB, 0, 256, 8, 128, stream)
-/* aria192cfb1_functions */
+/* ossl_aria192cfb1_functions */
 IMPLEMENT_generic_cipher(aria, ARIA, cfb1, CFB, 0, 192, 8, 128, stream)
-/* aria128cfb1_functions */
+/* ossl_aria128cfb1_functions */
 IMPLEMENT_generic_cipher(aria, ARIA, cfb1, CFB, 0, 128, 8, 128, stream)
-/* aria256cfb8_functions */
+/* ossl_aria256cfb8_functions */
 IMPLEMENT_generic_cipher(aria, ARIA, cfb8, CFB, 0, 256, 8, 128, stream)
-/* aria192cfb8_functions */
+/* ossl_aria192cfb8_functions */
 IMPLEMENT_generic_cipher(aria, ARIA, cfb8, CFB, 0, 192, 8, 128, stream)
-/* aria128cfb8_functions */
+/* ossl_aria128cfb8_functions */
 IMPLEMENT_generic_cipher(aria, ARIA, cfb8, CFB, 0, 128, 8, 128, stream)
-/* aria256ctr_functions */
+/* ossl_aria256ctr_functions */
 IMPLEMENT_generic_cipher(aria, ARIA, ctr, CTR, 0, 256, 8, 128, stream)
-/* aria192ctr_functions */
+/* ossl_aria192ctr_functions */
 IMPLEMENT_generic_cipher(aria, ARIA, ctr, CTR, 0, 192, 8, 128, stream)
-/* aria128ctr_functions */
+/* ossl_aria128ctr_functions */
 IMPLEMENT_generic_cipher(aria, ARIA, ctr, CTR, 0, 128, 8, 128, stream)

--- a/providers/implementations/ciphers/cipher_aria_gcm.c
+++ b/providers/implementations/ciphers/cipher_aria_gcm.c
@@ -37,10 +37,10 @@ static void aria_gcm_freectx(void *vctx)
     OPENSSL_clear_free(ctx,  sizeof(*ctx));
 }
 
-/* aria128gcm_functions */
+/* ossl_aria128gcm_functions */
 IMPLEMENT_aead_cipher(aria, gcm, GCM, AEAD_FLAGS, 128, 8, 96);
-/* aria192gcm_functions */
+/* ossl_aria192gcm_functions */
 IMPLEMENT_aead_cipher(aria, gcm, GCM, AEAD_FLAGS, 192, 8, 96);
-/* aria256gcm_functions */
+/* ossl_aria256gcm_functions */
 IMPLEMENT_aead_cipher(aria, gcm, GCM, AEAD_FLAGS, 256, 8, 96);
 

--- a/providers/implementations/ciphers/cipher_camellia.c
+++ b/providers/implementations/ciphers/cipher_camellia.c
@@ -48,46 +48,46 @@ static void *camellia_dupctx(void *ctx)
     return ret;
 }
 
-/* camellia256ecb_functions */
+/* ossl_camellia256ecb_functions */
 IMPLEMENT_generic_cipher(camellia, CAMELLIA, ecb, ECB, 0, 256, 128, 0, block)
-/* camellia192ecb_functions */
+/* ossl_camellia192ecb_functions */
 IMPLEMENT_generic_cipher(camellia, CAMELLIA, ecb, ECB, 0, 192, 128, 0, block)
-/* camellia128ecb_functions */
+/* ossl_camellia128ecb_functions */
 IMPLEMENT_generic_cipher(camellia, CAMELLIA, ecb, ECB, 0, 128, 128, 0, block)
-/* camellia256cbc_functions */
+/* ossl_camellia256cbc_functions */
 IMPLEMENT_generic_cipher(camellia, CAMELLIA, cbc, CBC, 0, 256, 128, 128, block)
-/* camellia192cbc_functions */
+/* ossl_camellia192cbc_functions */
 IMPLEMENT_generic_cipher(camellia, CAMELLIA, cbc, CBC, 0, 192, 128, 128, block)
-/* camellia128cbc_functions */
+/* ossl_camellia128cbc_functions */
 IMPLEMENT_generic_cipher(camellia, CAMELLIA, cbc, CBC, 0, 128, 128, 128, block)
-/* camellia256ofb_functions */
+/* ossl_camellia256ofb_functions */
 IMPLEMENT_generic_cipher(camellia, CAMELLIA, ofb, OFB, 0, 256, 8, 128, stream)
-/* camellia192ofb_functions */
+/* ossl_camellia192ofb_functions */
 IMPLEMENT_generic_cipher(camellia, CAMELLIA, ofb, OFB, 0, 192, 8, 128, stream)
-/* camellia128ofb_functions */
+/* ossl_camellia128ofb_functions */
 IMPLEMENT_generic_cipher(camellia, CAMELLIA, ofb, OFB, 0, 128, 8, 128, stream)
-/* camellia256cfb_functions */
+/* ossl_camellia256cfb_functions */
 IMPLEMENT_generic_cipher(camellia, CAMELLIA, cfb,  CFB, 0, 256, 8, 128, stream)
-/* camellia192cfb_functions */
+/* ossl_camellia192cfb_functions */
 IMPLEMENT_generic_cipher(camellia, CAMELLIA, cfb,  CFB, 0, 192, 8, 128, stream)
-/* camellia128cfb_functions */
+/* ossl_camellia128cfb_functions */
 IMPLEMENT_generic_cipher(camellia, CAMELLIA, cfb,  CFB, 0, 128, 8, 128, stream)
-/* camellia256cfb1_functions */
+/* ossl_camellia256cfb1_functions */
 IMPLEMENT_generic_cipher(camellia, CAMELLIA, cfb1, CFB, 0, 256, 8, 128, stream)
-/* camellia192cfb1_functions */
+/* ossl_camellia192cfb1_functions */
 IMPLEMENT_generic_cipher(camellia, CAMELLIA, cfb1, CFB, 0, 192, 8, 128, stream)
-/* camellia128cfb1_functions */
+/* ossl_camellia128cfb1_functions */
 IMPLEMENT_generic_cipher(camellia, CAMELLIA, cfb1, CFB, 0, 128, 8, 128, stream)
-/* camellia256cfb8_functions */
+/* ossl_camellia256cfb8_functions */
 IMPLEMENT_generic_cipher(camellia, CAMELLIA, cfb8, CFB, 0, 256, 8, 128, stream)
-/* camellia192cfb8_functions */
+/* ossl_camellia192cfb8_functions */
 IMPLEMENT_generic_cipher(camellia, CAMELLIA, cfb8, CFB, 0, 192, 8, 128, stream)
-/* camellia128cfb8_functions */
+/* ossl_camellia128cfb8_functions */
 IMPLEMENT_generic_cipher(camellia, CAMELLIA, cfb8, CFB, 0, 128, 8, 128, stream)
-/* camellia256ctr_functions */
+/* ossl_camellia256ctr_functions */
 IMPLEMENT_generic_cipher(camellia, CAMELLIA, ctr, CTR, 0, 256, 8, 128, stream)
-/* camellia192ctr_functions */
+/* ossl_camellia192ctr_functions */
 IMPLEMENT_generic_cipher(camellia, CAMELLIA, ctr, CTR, 0, 192, 8, 128, stream)
-/* camellia128ctr_functions */
+/* ossl_camellia128ctr_functions */
 IMPLEMENT_generic_cipher(camellia, CAMELLIA, ctr, CTR, 0, 128, 8, 128, stream)
 

--- a/providers/implementations/ciphers/cipher_cast5.c
+++ b/providers/implementations/ciphers/cipher_cast5.c
@@ -51,11 +51,11 @@ static void *cast5_dupctx(void *ctx)
     return ret;
 }
 
-/* cast5128ecb_functions */
+/* ossl_cast5128ecb_functions */
 IMPLEMENT_var_keylen_cipher(cast5, CAST, ecb, ECB, CAST5_FLAGS, 128, 64, 0, block)
-/* cast5128cbc_functions */
+/* ossl_cast5128cbc_functions */
 IMPLEMENT_var_keylen_cipher(cast5, CAST, cbc, CBC, CAST5_FLAGS, 128, 64, 64, block)
-/* cast5128ofb64_functions */
+/* ossl_cast5128ofb64_functions */
 IMPLEMENT_var_keylen_cipher(cast5, CAST, ofb64, OFB, CAST5_FLAGS, 128, 8, 64, stream)
-/* cast5128cfb64_functions */
+/* ossl_cast5128cfb64_functions */
 IMPLEMENT_var_keylen_cipher(cast5, CAST, cfb64,  CFB, CAST5_FLAGS, 128, 8, 64, stream)

--- a/providers/implementations/ciphers/cipher_chacha20.c
+++ b/providers/implementations/ciphers/cipher_chacha20.c
@@ -173,8 +173,8 @@ int chacha20_dinit(void *vctx, const unsigned char *key, size_t keylen,
     return ret;
 }
 
-/* chacha20_functions */
-const OSSL_DISPATCH chacha20_functions[] = {
+/* ossl_chacha20_functions */
+const OSSL_DISPATCH ossl_chacha20_functions[] = {
     { OSSL_FUNC_CIPHER_NEWCTX, (void (*)(void))chacha20_newctx },
     { OSSL_FUNC_CIPHER_FREECTX, (void (*)(void))chacha20_freectx },
     { OSSL_FUNC_CIPHER_ENCRYPT_INIT, (void (*)(void))chacha20_einit },

--- a/providers/implementations/ciphers/cipher_chacha20_poly1305.c
+++ b/providers/implementations/ciphers/cipher_chacha20_poly1305.c
@@ -308,8 +308,8 @@ static int chacha20_poly1305_final(void *vctx, unsigned char *out, size_t *outl,
     return 1;
 }
 
-/* chacha20_poly1305_functions */
-const OSSL_DISPATCH chacha20_poly1305_functions[] = {
+/* ossl_chacha20_ossl_poly1305_functions */
+const OSSL_DISPATCH ossl_chacha20_ossl_poly1305_functions[] = {
     { OSSL_FUNC_CIPHER_NEWCTX, (void (*)(void))chacha20_poly1305_newctx },
     { OSSL_FUNC_CIPHER_FREECTX, (void (*)(void))chacha20_poly1305_freectx },
     { OSSL_FUNC_CIPHER_ENCRYPT_INIT, (void (*)(void))chacha20_poly1305_einit },

--- a/providers/implementations/ciphers/cipher_des.c
+++ b/providers/implementations/ciphers/cipher_des.c
@@ -157,7 +157,7 @@ static int des_##lcmode##_get_params(OSSL_PARAM params[])                      \
     return cipher_generic_get_params(params, EVP_CIPH_##UCMODE##_MODE, flags,  \
                                      kbits, blkbits, ivbits);                  \
 }                                                                              \
-const OSSL_DISPATCH des_##lcmode##_functions[] = {                             \
+const OSSL_DISPATCH ossl_##des_##lcmode##_functions[] = {                      \
     { OSSL_FUNC_CIPHER_ENCRYPT_INIT, (void (*)(void))des_einit },              \
     { OSSL_FUNC_CIPHER_DECRYPT_INIT, (void (*)(void))des_dinit },              \
     { OSSL_FUNC_CIPHER_UPDATE,                                                 \
@@ -182,15 +182,15 @@ const OSSL_DISPATCH des_##lcmode##_functions[] = {                             \
     { 0, NULL }                                                                \
 }
 
-/* des_ecb_functions */
+/* ossl_des_ecb_functions */
 IMPLEMENT_des_cipher(des, ecb, ECB, DES_FLAGS, 64, 64, 0, block);
-/* des_cbc_functions */
+/* ossl_des_cbc_functions */
 IMPLEMENT_des_cipher(des, cbc, CBC, DES_FLAGS, 64, 64, 64, block);
-/* des_ofb64_functions */
+/* ossl_des_ofb64_functions */
 IMPLEMENT_des_cipher(des, ofb64, OFB, DES_FLAGS, 64, 8, 64, stream);
-/* des_cfb64_functions */
+/* ossl_des_cfb64_functions */
 IMPLEMENT_des_cipher(des, cfb64, CFB, DES_FLAGS, 64, 8, 64, stream);
-/* des_cfb1_functions */
+/* ossl_des_cfb1_functions */
 IMPLEMENT_des_cipher(des, cfb1, CFB, DES_FLAGS, 64, 8, 64, stream);
-/* des_cfb8_functions */
+/* ossl_des_cfb8_functions */
 IMPLEMENT_des_cipher(des, cfb8, CFB, DES_FLAGS, 64, 8, 64, stream);

--- a/providers/implementations/ciphers/cipher_idea.c
+++ b/providers/implementations/ciphers/cipher_idea.c
@@ -49,11 +49,11 @@ static void *idea_dupctx(void *ctx)
     return ret;
 }
 
-/* idea128ecb_functions */
+/* ossl_idea128ecb_functions */
 IMPLEMENT_generic_cipher(idea, IDEA, ecb, ECB, 0, 128, 64, 0, block)
-/* idea128cbc_functions */
+/* ossl_idea128cbc_functions */
 IMPLEMENT_generic_cipher(idea, IDEA, cbc, CBC, 0, 128, 64, 64, block)
-/* idea128ofb64_functions */
+/* ossl_idea128ofb64_functions */
 IMPLEMENT_generic_cipher(idea, IDEA, ofb64, OFB, 0, 128, 8, 64, stream)
-/* idea128cfb64_functions */
+/* ossl_idea128cfb64_functions */
 IMPLEMENT_generic_cipher(idea, IDEA, cfb64,  CFB, 0, 128, 8, 64, stream)

--- a/providers/implementations/ciphers/cipher_null.c
+++ b/providers/implementations/ciphers/cipher_null.c
@@ -170,7 +170,7 @@ static int null_set_ctx_params(void *vctx, const OSSL_PARAM params[])
     return 1;
 }
 
-const OSSL_DISPATCH null_functions[] = {
+const OSSL_DISPATCH ossl_null_functions[] = {
     { OSSL_FUNC_CIPHER_NEWCTX,
       (void (*)(void)) null_newctx },
     { OSSL_FUNC_CIPHER_FREECTX, (void (*)(void)) null_freectx },

--- a/providers/implementations/ciphers/cipher_rc2.c
+++ b/providers/implementations/ciphers/cipher_rc2.c
@@ -215,7 +215,7 @@ static void * alg##_##kbits##_##lcmode##_newctx(void *provctx)                 \
      }                                                                         \
      return ctx;                                                               \
 }                                                                              \
-const OSSL_DISPATCH alg##kbits##lcmode##_functions[] = {                       \
+const OSSL_DISPATCH ossl_##alg##kbits##lcmode##_functions[] = {                \
     { OSSL_FUNC_CIPHER_NEWCTX,                                                 \
       (void (*)(void)) alg##_##kbits##_##lcmode##_newctx },                    \
     { OSSL_FUNC_CIPHER_FREECTX, (void (*)(void)) alg##_freectx },              \
@@ -240,16 +240,16 @@ const OSSL_DISPATCH alg##kbits##lcmode##_functions[] = {                       \
     { 0, NULL }                                                                \
 };
 
-/* rc2128ecb_functions */
+/* ossl_rc2128ecb_functions */
 IMPLEMENT_cipher(rc2, RC2, ecb, ECB, EVP_CIPH_VARIABLE_LENGTH, 128, 64, 0, block)
-/* rc2128cbc_functions */
+/* ossl_rc2128cbc_functions */
 IMPLEMENT_cipher(rc2, RC2, cbc, CBC, EVP_CIPH_VARIABLE_LENGTH, 128, 64, 64, block)
-/* rc240cbc_functions */
+/* ossl_rc240cbc_functions */
 IMPLEMENT_cipher(rc2, RC2, cbc, CBC, EVP_CIPH_VARIABLE_LENGTH, 40, 64, 64, block)
-/* rc264cbc_functions */
+/* ossl_rc264cbc_functions */
 IMPLEMENT_cipher(rc2, RC2, cbc, CBC, EVP_CIPH_VARIABLE_LENGTH, 64, 64, 64, block)
 
-/* rc2128ofb128_functions */
+/* ossl_rc2128ofb128_functions */
 IMPLEMENT_cipher(rc2, RC2, ofb128, OFB, EVP_CIPH_VARIABLE_LENGTH, 128, 8, 64, stream)
-/* rc2128cfb128_functions */
+/* ossl_rc2128cfb128_functions */
 IMPLEMENT_cipher(rc2, RC2, cfb128, CFB, EVP_CIPH_VARIABLE_LENGTH, 128, 8, 64, stream)

--- a/providers/implementations/ciphers/cipher_rc4.c
+++ b/providers/implementations/ciphers/cipher_rc4.c
@@ -71,7 +71,7 @@ static void * alg##_##kbits##_newctx(void *provctx)                            \
      }                                                                         \
      return ctx;                                                               \
 }                                                                              \
-const OSSL_DISPATCH alg##kbits##_functions[] = {                               \
+const OSSL_DISPATCH ossl_##alg##kbits##_functions[] = {                        \
     { OSSL_FUNC_CIPHER_NEWCTX,                                                 \
       (void (*)(void)) alg##_##kbits##_newctx },                               \
     { OSSL_FUNC_CIPHER_FREECTX, (void (*)(void)) alg##_freectx },              \
@@ -96,7 +96,7 @@ const OSSL_DISPATCH alg##kbits##_functions[] = {                               \
     { 0, NULL }                                                                \
 };
 
-/* rc440_functions */
+/* ossl_rc440_functions */
 IMPLEMENT_cipher(rc4, RC4, EVP_CIPH_VARIABLE_LENGTH, 40, 8, 0, stream)
-/* rc4128_functions */
+/* ossl_rc4128_functions */
 IMPLEMENT_cipher(rc4, RC4, EVP_CIPH_VARIABLE_LENGTH, 128, 8, 0, stream)

--- a/providers/implementations/ciphers/cipher_rc4_hmac_md5.c
+++ b/providers/implementations/ciphers/cipher_rc4_hmac_md5.c
@@ -180,7 +180,7 @@ static int rc4_hmac_md5_get_params(OSSL_PARAM params[])
                                      RC4_HMAC_MD5_IV_BITS);
 }
 
-const OSSL_DISPATCH rc4_hmac_md5_functions[] = {
+const OSSL_DISPATCH ossl_rc4_hmac_ossl_md5_functions[] = {
     { OSSL_FUNC_CIPHER_NEWCTX, (void (*)(void))rc4_hmac_md5_newctx },
     { OSSL_FUNC_CIPHER_FREECTX, (void (*)(void))rc4_hmac_md5_freectx },
     { OSSL_FUNC_CIPHER_ENCRYPT_INIT, (void (*)(void))rc4_hmac_md5_einit },

--- a/providers/implementations/ciphers/cipher_rc5.c
+++ b/providers/implementations/ciphers/cipher_rc5.c
@@ -126,7 +126,7 @@ static void * alg##_##kbits##_##lcmode##_newctx(void *provctx)                 \
      }                                                                         \
      return ctx;                                                               \
 }                                                                              \
-const OSSL_DISPATCH alg##kbits##lcmode##_functions[] = {                       \
+const OSSL_DISPATCH ossl_##alg##kbits##lcmode##_functions[] = {                \
     { OSSL_FUNC_CIPHER_NEWCTX,                                                 \
       (void (*)(void)) alg##_##kbits##_##lcmode##_newctx },                    \
     { OSSL_FUNC_CIPHER_FREECTX, (void (*)(void)) alg##_freectx },              \
@@ -151,11 +151,11 @@ const OSSL_DISPATCH alg##kbits##lcmode##_functions[] = {                       \
     { 0, NULL }                                                                \
 };
 
-/* rc5128ecb_functions */
+/* ossl_rc5128ecb_functions */
 IMPLEMENT_cipher(rc5, RC5, ecb, ECB, EVP_CIPH_VARIABLE_LENGTH, 128, 64, 0, block)
-/* rc5128cbc_functions */
+/* ossl_rc5128cbc_functions */
 IMPLEMENT_cipher(rc5, RC5, cbc, CBC, EVP_CIPH_VARIABLE_LENGTH, 128, 64, 64, block)
-/* rc5128ofb64_functions */
+/* ossl_rc5128ofb64_functions */
 IMPLEMENT_cipher(rc5, RC5, ofb64, OFB, EVP_CIPH_VARIABLE_LENGTH, 128, 8, 64, stream)
-/* rc5128cfb64_functions */
+/* ossl_rc5128cfb64_functions */
 IMPLEMENT_cipher(rc5, RC5, cfb64,  CFB, EVP_CIPH_VARIABLE_LENGTH, 128, 8, 64, stream)

--- a/providers/implementations/ciphers/cipher_seed.c
+++ b/providers/implementations/ciphers/cipher_seed.c
@@ -48,11 +48,11 @@ static void *seed_dupctx(void *ctx)
     return ret;
 }
 
-/* seed128ecb_functions */
+/* ossl_seed128ecb_functions */
 IMPLEMENT_generic_cipher(seed, SEED, ecb, ECB, 0, 128, 128, 0, block)
-/* seed128cbc_functions */
+/* ossl_seed128cbc_functions */
 IMPLEMENT_generic_cipher(seed, SEED, cbc, CBC, 0, 128, 128, 128, block)
-/* seed128ofb128_functions */
+/* ossl_seed128ofb128_functions */
 IMPLEMENT_generic_cipher(seed, SEED, ofb128, OFB, 0, 128, 8, 128, stream)
-/* seed128cfb128_functions */
+/* ossl_seed128cfb128_functions */
 IMPLEMENT_generic_cipher(seed, SEED, cfb128,  CFB, 0, 128, 8, 128, stream)

--- a/providers/implementations/ciphers/cipher_sm4.c
+++ b/providers/implementations/ciphers/cipher_sm4.c
@@ -42,13 +42,13 @@ static void *sm4_dupctx(void *ctx)
     return ret;
 }
 
-/* sm4128ecb_functions */
+/* ossl_sm4128ecb_functions */
 IMPLEMENT_generic_cipher(sm4, SM4, ecb, ECB, 0, 128, 128, 0, block)
-/* sm4128cbc_functions */
+/* ossl_sm4128cbc_functions */
 IMPLEMENT_generic_cipher(sm4, SM4, cbc, CBC, 0, 128, 128, 128, block)
-/* sm4128ctr_functions */
+/* ossl_sm4128ctr_functions */
 IMPLEMENT_generic_cipher(sm4, SM4, ctr, CTR, 0, 128, 8, 128, stream)
-/* sm4128ofb128_functions */
+/* ossl_sm4128ofb128_functions */
 IMPLEMENT_generic_cipher(sm4, SM4, ofb128, OFB, 0, 128, 8, 128, stream)
-/* sm4128cfb128_functions */
+/* ossl_sm4128cfb128_functions */
 IMPLEMENT_generic_cipher(sm4, SM4, cfb128,  CFB, 0, 128, 8, 128, stream)

--- a/providers/implementations/ciphers/cipher_tdes.c
+++ b/providers/implementations/ciphers/cipher_tdes.c
@@ -23,7 +23,7 @@
  * TODO(3.0) - ECB mode does not use an IV - but existing test code is setting
  * an IV. Fixing this could potentially make applications break.
  */
-/* tdes_ede3_ecb_functions */
+/* ossl_tdes_ede3_ecb_functions */
 IMPLEMENT_tdes_cipher(ede3, EDE3, ecb, ECB, TDES_FLAGS, 64*3, 64, 64, block);
-/* tdes_ede3_cbc_functions */
+/* ossl_tdes_ede3_cbc_functions */
 IMPLEMENT_tdes_cipher(ede3, EDE3, cbc, CBC, TDES_FLAGS, 64*3, 64, 64, block);

--- a/providers/implementations/ciphers/cipher_tdes.h
+++ b/providers/implementations/ciphers/cipher_tdes.h
@@ -44,7 +44,7 @@ static int tdes_##type##_##lcmode##_get_params(OSSL_PARAM params[])            \
     return cipher_generic_get_params(params, EVP_CIPH_##UCMODE##_MODE, flags,  \
                                      kbits, blkbits, ivbits);                  \
 }                                                                              \
-const OSSL_DISPATCH tdes_##type##_##lcmode##_functions[] = {                   \
+const OSSL_DISPATCH ossl_tdes_##type##_##lcmode##_functions[] = {              \
     { OSSL_FUNC_CIPHER_ENCRYPT_INIT, (void (*)(void))tdes_einit },             \
     { OSSL_FUNC_CIPHER_DECRYPT_INIT, (void (*)(void))tdes_dinit },             \
     { OSSL_FUNC_CIPHER_UPDATE,                                                 \

--- a/providers/implementations/ciphers/cipher_tdes_default.c
+++ b/providers/implementations/ciphers/cipher_tdes_default.c
@@ -16,20 +16,20 @@
 #include "cipher_tdes_default.h"
 #include "prov/implementations.h"
 
-/* tdes_ede3_ofb_functions */
+/* ossl_tdes_ede3_ofb_functions */
 IMPLEMENT_tdes_cipher(ede3, EDE3,  ofb, OFB, TDES_FLAGS, 64*3,  8, 64, stream);
-/* tdes_ede3_cfb_functions */
+/* ossl_tdes_ede3_cfb_functions */
 IMPLEMENT_tdes_cipher(ede3, EDE3,  cfb, CFB, TDES_FLAGS, 64*3,  8, 64, stream);
-/* tdes_ede3_cfb1_functions */
+/* ossl_tdes_ede3_cfb1_functions */
 IMPLEMENT_tdes_cipher(ede3, EDE3, cfb1, CFB, TDES_FLAGS, 64*3,  8, 64, stream);
-/* tdes_ede3_cfb8_functions */
+/* ossl_tdes_ede3_cfb8_functions */
 IMPLEMENT_tdes_cipher(ede3, EDE3, cfb8, CFB, TDES_FLAGS, 64*3,  8, 64, stream);
 
-/* tdes_ede2_ecb_functions */
+/* ossl_tdes_ede2_ecb_functions */
 IMPLEMENT_tdes_cipher(ede2, EDE2, ecb, ECB, TDES_FLAGS, 64*2, 64, 64, block);
-/* tdes_ede2_cbc_functions */
+/* ossl_tdes_ede2_cbc_functions */
 IMPLEMENT_tdes_cipher(ede2, EDE2, cbc, CBC, TDES_FLAGS, 64*2, 64, 64, block);
-/* tdes_ede2_ofb_functions */
+/* ossl_tdes_ede2_ofb_functions */
 IMPLEMENT_tdes_cipher(ede2, EDE2, ofb, OFB, TDES_FLAGS, 64*2,  8, 64, stream);
-/* tdes_ede2_cfb_functions */
+/* ossl_tdes_ede2_cfb_functions */
 IMPLEMENT_tdes_cipher(ede2, EDE2, cfb, CFB, TDES_FLAGS, 64*2,  8, 64, stream);

--- a/providers/implementations/ciphers/cipher_tdes_wrap.c
+++ b/providers/implementations/ciphers/cipher_tdes_wrap.c
@@ -183,7 +183,7 @@ static int tdes_wrap_get_params(OSSL_PARAM params[])                           \
     return cipher_generic_get_params(params, EVP_CIPH_WRAP_MODE, flags,        \
                                      kbits, blkbits, ivbits);                  \
 }                                                                              \
-const OSSL_DISPATCH tdes_wrap_cbc_functions[] =                                \
+const OSSL_DISPATCH ossl_tdes_wrap_cbc_functions[] =                           \
 {                                                                              \
     { OSSL_FUNC_CIPHER_ENCRYPT_INIT, (void (*)(void)) tdes_einit },            \
     { OSSL_FUNC_CIPHER_DECRYPT_INIT, (void (*)(void)) tdes_dinit },            \
@@ -205,5 +205,5 @@ const OSSL_DISPATCH tdes_wrap_cbc_functions[] =                                \
     { 0, NULL }                                                                \
 }
 
-/* tdes_wrap_cbc_functions */
+/* ossl_tdes_wrap_cbc_functions */
 IMPLEMENT_WRAP_CIPHER(TDES_WRAP_FLAGS, 64*3, 64, 0);

--- a/providers/implementations/digests/blake2_prov.c
+++ b/providers/implementations/digests/blake2_prov.c
@@ -31,12 +31,12 @@ int blake2b512_init(void *ctx)
     return blake2b_init((BLAKE2B_CTX *)ctx, &P);
 }
 
-/* blake2s256_functions */
+/* ossl_blake2s256_functions */
 IMPLEMENT_digest_functions(blake2s256, BLAKE2S_CTX,
                            BLAKE2S_BLOCKBYTES, BLAKE2S_DIGEST_LENGTH, 0,
                            blake2s256_init, blake2s_update, blake2s_final)
 
-/* blake2b512_functions */
+/* ossl_blake2b512_functions */
 IMPLEMENT_digest_functions(blake2b512, BLAKE2B_CTX,
                            BLAKE2B_BLOCKBYTES, BLAKE2B_DIGEST_LENGTH, 0,
                            blake2b512_init, blake2b_update, blake2b_final)

--- a/providers/implementations/digests/md2_prov.c
+++ b/providers/implementations/digests/md2_prov.c
@@ -18,7 +18,7 @@
 #include "prov/digestcommon.h"
 #include "prov/implementations.h"
 
-/* md2_functions */
+/* ossl_md2_functions */
 IMPLEMENT_digest_functions(md2, MD2_CTX,
                            MD2_BLOCK, MD2_DIGEST_LENGTH, 0,
                            MD2_Init, MD2_Update, MD2_Final)

--- a/providers/implementations/digests/md4_prov.c
+++ b/providers/implementations/digests/md4_prov.c
@@ -18,7 +18,7 @@
 #include "prov/digestcommon.h"
 #include "prov/implementations.h"
 
-/* md4_functions */
+/* ossl_md4_functions */
 IMPLEMENT_digest_functions(md4, MD4_CTX,
                            MD4_CBLOCK, MD4_DIGEST_LENGTH, 0,
                            MD4_Init, MD4_Update, MD4_Final)

--- a/providers/implementations/digests/md5_prov.c
+++ b/providers/implementations/digests/md5_prov.c
@@ -18,7 +18,7 @@
 #include "prov/digestcommon.h"
 #include "prov/implementations.h"
 
-/* md5_functions */
+/* ossl_md5_functions */
 IMPLEMENT_digest_functions(md5, MD5_CTX,
                            MD5_CBLOCK, MD5_DIGEST_LENGTH, 0,
                            MD5_Init, MD5_Update, MD5_Final)

--- a/providers/implementations/digests/md5_sha1_prov.c
+++ b/providers/implementations/digests/md5_sha1_prov.c
@@ -50,7 +50,7 @@ static int md5_sha1_set_ctx_params(void *vctx, const OSSL_PARAM params[])
     return 0;
 }
 
-/* md5_sha1_functions */
+/* ossl_md5_sha1_functions */
 IMPLEMENT_digest_functions_with_settable_ctx(
     md5_sha1, MD5_SHA1_CTX, MD5_SHA1_CBLOCK, MD5_SHA1_DIGEST_LENGTH, 0,
     md5_sha1_init, md5_sha1_update, md5_sha1_final,

--- a/providers/implementations/digests/mdc2_prov.c
+++ b/providers/implementations/digests/mdc2_prov.c
@@ -51,7 +51,7 @@ static int mdc2_set_ctx_params(void *vctx, const OSSL_PARAM params[])
     return 0; /* Null Parameter */
 }
 
-/* mdc2_functions */
+/* ossl_mdc2_functions */
 IMPLEMENT_digest_functions_with_settable_ctx(
     mdc2, MDC2_CTX, MDC2_BLOCK, MDC2_DIGEST_LENGTH, 0,
     MDC2_Init, MDC2_Update, MDC2_Final,

--- a/providers/implementations/digests/ripemd_prov.c
+++ b/providers/implementations/digests/ripemd_prov.c
@@ -18,7 +18,7 @@
 #include "prov/digestcommon.h"
 #include "prov/implementations.h"
 
-/* ripemd160_functions */
+/* ossl_ripemd160_functions */
 IMPLEMENT_digest_functions(ripemd160, RIPEMD160_CTX,
                            RIPEMD160_CBLOCK, RIPEMD160_DIGEST_LENGTH, 0,
                            RIPEMD160_Init, RIPEMD160_Update, RIPEMD160_Final)

--- a/providers/implementations/digests/sha2_prov.c
+++ b/providers/implementations/digests/sha2_prov.c
@@ -51,43 +51,43 @@ static int sha1_set_ctx_params(void *vctx, const OSSL_PARAM params[])
     return 0;
 }
 
-/* sha1_functions */
+/* ossl_sha1_functions */
 IMPLEMENT_digest_functions_with_settable_ctx(
     sha1, SHA_CTX, SHA_CBLOCK, SHA_DIGEST_LENGTH, EVP_MD_FLAG_DIGALGID_ABSENT,
     SHA1_Init, SHA1_Update, SHA1_Final,
     sha1_settable_ctx_params, sha1_set_ctx_params)
 
-/* sha224_functions */
+/* ossl_sha224_functions */
 IMPLEMENT_digest_functions(sha224, SHA256_CTX,
                            SHA256_CBLOCK, SHA224_DIGEST_LENGTH,
                            EVP_MD_FLAG_DIGALGID_ABSENT,
                            SHA224_Init, SHA224_Update, SHA224_Final)
 
-/* sha256_functions */
+/* ossl_sha256_functions */
 IMPLEMENT_digest_functions(sha256, SHA256_CTX,
                            SHA256_CBLOCK, SHA256_DIGEST_LENGTH,
                            EVP_MD_FLAG_DIGALGID_ABSENT,
                            SHA256_Init, SHA256_Update, SHA256_Final)
 
-/* sha384_functions */
+/* ossl_sha384_functions */
 IMPLEMENT_digest_functions(sha384, SHA512_CTX,
                            SHA512_CBLOCK, SHA384_DIGEST_LENGTH,
                            EVP_MD_FLAG_DIGALGID_ABSENT,
                            SHA384_Init, SHA384_Update, SHA384_Final)
 
-/* sha512_functions */
+/* ossl_sha512_functions */
 IMPLEMENT_digest_functions(sha512, SHA512_CTX,
                            SHA512_CBLOCK, SHA512_DIGEST_LENGTH,
                            EVP_MD_FLAG_DIGALGID_ABSENT,
                            SHA512_Init, SHA512_Update, SHA512_Final)
 
-/* sha512_224_functions */
+/* ossl_sha512_224_functions */
 IMPLEMENT_digest_functions(sha512_224, SHA512_CTX,
                            SHA512_CBLOCK, SHA224_DIGEST_LENGTH,
                            EVP_MD_FLAG_DIGALGID_ABSENT,
                            sha512_224_init, SHA512_Update, SHA512_Final)
 
-/* sha512_256_functions */
+/* ossl_sha512_256_functions */
 IMPLEMENT_digest_functions(sha512_256, SHA512_CTX,
                            SHA512_CBLOCK, SHA256_DIGEST_LENGTH,
                            EVP_MD_FLAG_DIGALGID_ABSENT,

--- a/providers/implementations/digests/sha3_prov.c
+++ b/providers/implementations/digests/sha3_prov.c
@@ -219,7 +219,7 @@ static void *uname##_newctx(void *provctx)                                     \
 
 #define PROV_FUNC_SHA3_DIGEST_COMMON(name, bitlen, blksize, dgstsize, flags)   \
 PROV_FUNC_DIGEST_GET_PARAM(name, blksize, dgstsize, flags)                     \
-const OSSL_DISPATCH name##_functions[] = {                                     \
+const OSSL_DISPATCH ossl_##name##_functions[] = {                              \
     { OSSL_FUNC_DIGEST_NEWCTX, (void (*)(void))name##_newctx },                \
     { OSSL_FUNC_DIGEST_INIT, (void (*)(void))keccak_init },                    \
     { OSSL_FUNC_DIGEST_UPDATE, (void (*)(void))keccak_update },                \
@@ -299,19 +299,19 @@ static int shake_set_ctx_params(void *vctx, const OSSL_PARAM params[])
                            SHA3_BLOCKSIZE(bitlen), KMAC_MDSIZE(bitlen),        \
                            EVP_MD_FLAG_XOF)
 
-/* sha3_224_functions */
+/* ossl_sha3_224_functions */
 IMPLEMENT_SHA3_functions(224)
-/* sha3_256_functions */
+/* ossl_sha3_256_functions */
 IMPLEMENT_SHA3_functions(256)
-/* sha3_384_functions */
+/* ossl_sha3_384_functions */
 IMPLEMENT_SHA3_functions(384)
-/* sha3_512_functions */
+/* ossl_sha3_512_functions */
 IMPLEMENT_SHA3_functions(512)
-/* shake_128_functions */
+/* ossl_shake_128_functions */
 IMPLEMENT_SHAKE_functions(128)
-/* shake_256_functions */
+/* ossl_shake_256_functions */
 IMPLEMENT_SHAKE_functions(256)
-/* keccak_kmac_128_functions */
+/* ossl_keccak_kmac_128_functions */
 IMPLEMENT_KMAC_functions(128)
-/* keccak_kmac_256_functions */
+/* ossl_keccak_kmac_256_functions */
 IMPLEMENT_KMAC_functions(256)

--- a/providers/implementations/digests/sm3_prov.c
+++ b/providers/implementations/digests/sm3_prov.c
@@ -12,7 +12,7 @@
 #include "prov/digestcommon.h"
 #include "prov/implementations.h"
 
-/* sm3_functions */
+/* ossl_sm3_functions */
 IMPLEMENT_digest_functions(sm3, SM3_CTX,
                            SM3_CBLOCK, SM3_DIGEST_LENGTH, 0,
                            sm3_init, sm3_update, sm3_final)

--- a/providers/implementations/digests/wp_prov.c
+++ b/providers/implementations/digests/wp_prov.c
@@ -18,7 +18,7 @@
 #include "prov/digestcommon.h"
 #include "prov/implementations.h"
 
-/* wp_functions */
+/* ossl_wp_functions */
 IMPLEMENT_digest_functions(wp, WHIRLPOOL_CTX,
                            WHIRLPOOL_BBLOCK / 8, WHIRLPOOL_DIGEST_LENGTH, 0,
                            WHIRLPOOL_Init, WHIRLPOOL_Update, WHIRLPOOL_Final)

--- a/providers/implementations/encode_decode/decode_der2key.c
+++ b/providers/implementations/encode_decode/decode_der2key.c
@@ -270,7 +270,8 @@ static int der2key_export_object(void *vctx,
 
 #define IMPLEMENT_NEWCTX(KEYTYPEstr, KEYTYPE, keytype, extract, free)   \
     static const struct keytype_desc_st keytype##_desc =                \
-        { EVP_PKEY_##KEYTYPE, KEYTYPEstr, keytype##_keymgmt_functions,  \
+        { EVP_PKEY_##KEYTYPE, KEYTYPEstr,                               \
+          ossl_##keytype##_keymgmt_functions,                           \
           (extract_key_fn *)extract,                                    \
           (free_key_fn *)free };                                        \
     static OSSL_FUNC_decoder_newctx_fn der2##keytype##_newctx;          \
@@ -278,7 +279,7 @@ static int der2key_export_object(void *vctx,
     {                                                                   \
         return der2key_newctx(provctx, &keytype##_desc);                \
     }                                                                   \
-    const OSSL_DISPATCH der_to_##keytype##_decoder_functions[] = {      \
+    const OSSL_DISPATCH ossl_der_to_##keytype##_decoder_functions[] = { \
         { OSSL_FUNC_DECODER_NEWCTX,                                     \
           (void (*)(void))der2##keytype##_newctx },                     \
         { OSSL_FUNC_DECODER_FREECTX,                                    \

--- a/providers/implementations/encode_decode/decode_ms2key.c
+++ b/providers/implementations/encode_decode/decode_ms2key.c
@@ -242,13 +242,14 @@ static int ms2key_export_object(void *vctx,
         return ms2key_newctx(provctx, &keytype##_desc);                 \
     }                                                                   \
     static const struct keytype_desc_st keytype##_desc =                \
-        { EVP_PKEY_##KEYTYPE, KEYTYPEstr, keytype##_keymgmt_functions,  \
+        { EVP_PKEY_##KEYTYPE, KEYTYPEstr,                               \
+          ossl_##keytype##_keymgmt_functions,                           \
           (extract_key_fn *)extract,                                    \
           (free_key_fn *)free }
 
 #define IMPLEMENT_MS(mstype, keytype)                                   \
     const OSSL_DISPATCH                                                 \
-        mstype##_to_##keytype##_decoder_functions[] = {                 \
+        ossl_##mstype##_to_##keytype##_decoder_functions[] = {          \
         { OSSL_FUNC_DECODER_NEWCTX,                                     \
           (void (*)(void))ms2##keytype##_newctx },                      \
         { OSSL_FUNC_DECODER_FREECTX,                                    \

--- a/providers/implementations/encode_decode/decode_pem2der.c
+++ b/providers/implementations/encode_decode/decode_pem2der.c
@@ -158,7 +158,7 @@ static int pem2der_decode(void *vctx, OSSL_CORE_BIO *cin,
     return ok;
 }
 
-const OSSL_DISPATCH pem_to_der_decoder_functions[] = {
+const OSSL_DISPATCH ossl_pem_to_der_decoder_functions[] = {
     { OSSL_FUNC_DECODER_NEWCTX, (void (*)(void))pem2der_newctx },
     { OSSL_FUNC_DECODER_FREECTX, (void (*)(void))pem2der_freectx },
     { OSSL_FUNC_DECODER_GETTABLE_PARAMS,

--- a/providers/implementations/encode_decode/encode_key2any.c
+++ b/providers/implementations/encode_decode/encode_key2any.c
@@ -873,12 +873,12 @@ static int key2any_encode_params(struct key2any_ctx_st *ctx,
                                     const OSSL_PARAM params[])              \
     {                                                                       \
         struct key2any_ctx_st *ctx = vctx;                                  \
-        return ossl_prov_import_key(impl##_keymgmt_functions,               \
+        return ossl_prov_import_key(ossl_##impl##_keymgmt_functions,        \
                                     ctx->provctx, selection, params);       \
     }                                                                       \
     static void impl##2##output##_free_object(void *key)                    \
     {                                                                       \
-        ossl_prov_free_key(impl##_keymgmt_functions, key);                  \
+        ossl_prov_free_key(ossl_##impl##_keymgmt_functions, key);           \
     }                                                                       \
     static int                                                              \
     impl##2##output##_encode(void *ctx, OSSL_CORE_BIO *cout,                \
@@ -915,7 +915,7 @@ static int key2any_encode_params(struct key2any_ctx_st *ctx,
         ERR_raise(ERR_LIB_PROV, ERR_R_PASSED_INVALID_ARGUMENT);             \
         return 0;                                                           \
     }                                                                       \
-    const OSSL_DISPATCH impl##_to_##output##_encoder_functions[] = {        \
+    const OSSL_DISPATCH ossl_##impl##_to_##output##_encoder_functions[] = { \
         { OSSL_FUNC_ENCODER_NEWCTX,                                         \
           (void (*)(void))key2any_newctx },                                 \
         { OSSL_FUNC_ENCODER_FREECTX,                                        \

--- a/providers/implementations/encode_decode/encode_key2text.c
+++ b/providers/implementations/encode_decode/encode_key2text.c
@@ -841,17 +841,17 @@ static int key2text_encode(void *vctx, const void *key, int selection,
                                                                         \
     static int impl##2text_get_params(OSSL_PARAM params[])              \
     {                                                                   \
-        return key2text_get_params(params, impl##_input_type);           \
+        return key2text_get_params(params, impl##_input_type);          \
     }                                                                   \
     static void *impl##2text_import_object(void *ctx, int selection,    \
                                            const OSSL_PARAM params[])   \
     {                                                                   \
-        return ossl_prov_import_key(impl##_keymgmt_functions,           \
+        return ossl_prov_import_key(ossl_##impl##_keymgmt_functions,    \
                                     ctx, selection, params);            \
     }                                                                   \
     static void impl##2text_free_object(void *key)                      \
     {                                                                   \
-        ossl_prov_free_key(impl##_keymgmt_functions, key);              \
+        ossl_prov_free_key(ossl_##impl##_keymgmt_functions, key);       \
     }                                                                   \
     static int impl##2text_encode(void *vctx, OSSL_CORE_BIO *cout,      \
                                   const void *key,                      \
@@ -868,7 +868,7 @@ static int key2text_encode(void *vctx, const void *key, int selection,
         return key2text_encode(vctx, key, selection, cout,              \
                                type##_to_text, cb, cbarg);              \
     }                                                                   \
-    const OSSL_DISPATCH impl##_to_text_encoder_functions[] = {          \
+    const OSSL_DISPATCH ossl_##impl##_to_text_encoder_functions[] = {   \
         { OSSL_FUNC_ENCODER_NEWCTX,                                     \
           (void (*)(void))key2text_newctx },                            \
         { OSSL_FUNC_ENCODER_FREECTX,                                    \

--- a/providers/implementations/exchange/dh_exch.c
+++ b/providers/implementations/exchange/dh_exch.c
@@ -460,7 +460,7 @@ static int dh_get_ctx_params(void *vpdhctx, OSSL_PARAM params[])
     return 1;
 }
 
-const OSSL_DISPATCH dh_keyexch_functions[] = {
+const OSSL_DISPATCH ossl_dh_keyexch_functions[] = {
     { OSSL_FUNC_KEYEXCH_NEWCTX, (void (*)(void))dh_newctx },
     { OSSL_FUNC_KEYEXCH_INIT, (void (*)(void))dh_init },
     { OSSL_FUNC_KEYEXCH_DERIVE, (void (*)(void))dh_derive },

--- a/providers/implementations/exchange/ecdh_exch.c
+++ b/providers/implementations/exchange/ecdh_exch.c
@@ -534,7 +534,7 @@ int ecdh_derive(void *vpecdhctx, unsigned char *secret,
     return 0;
 }
 
-const OSSL_DISPATCH ecdh_keyexch_functions[] = {
+const OSSL_DISPATCH ecossl_dh_keyexch_functions[] = {
     { OSSL_FUNC_KEYEXCH_NEWCTX, (void (*)(void))ecdh_newctx },
     { OSSL_FUNC_KEYEXCH_INIT, (void (*)(void))ecdh_init },
     { OSSL_FUNC_KEYEXCH_DERIVE, (void (*)(void))ecdh_derive },

--- a/providers/implementations/exchange/ecx_exch.c
+++ b/providers/implementations/exchange/ecx_exch.c
@@ -219,7 +219,7 @@ static void *ecx_dupctx(void *vecxctx)
     return dstctx;
 }
 
-const OSSL_DISPATCH x25519_keyexch_functions[] = {
+const OSSL_DISPATCH ossl_x25519_keyexch_functions[] = {
     { OSSL_FUNC_KEYEXCH_NEWCTX, (void (*)(void))x25519_newctx },
     { OSSL_FUNC_KEYEXCH_INIT, (void (*)(void))ecx_init },
     { OSSL_FUNC_KEYEXCH_DERIVE, (void (*)(void))ecx_derive },
@@ -229,7 +229,7 @@ const OSSL_DISPATCH x25519_keyexch_functions[] = {
     { 0, NULL }
 };
 
-const OSSL_DISPATCH x448_keyexch_functions[] = {
+const OSSL_DISPATCH ossl_x448_keyexch_functions[] = {
     { OSSL_FUNC_KEYEXCH_NEWCTX, (void (*)(void))x448_newctx },
     { OSSL_FUNC_KEYEXCH_INIT, (void (*)(void))ecx_init },
     { OSSL_FUNC_KEYEXCH_DERIVE, (void (*)(void))ecx_derive },

--- a/providers/implementations/exchange/kdf_exch.c
+++ b/providers/implementations/exchange/kdf_exch.c
@@ -170,7 +170,7 @@ KDF_SETTABLE_CTX_PARAMS(hkdf, "HKDF")
 KDF_SETTABLE_CTX_PARAMS(scrypt, "SCRYPT")
 
 #define KDF_KEYEXCH_FUNCTIONS(funcname) \
-    const OSSL_DISPATCH kdf_##funcname##_keyexch_functions[] = { \
+    const OSSL_DISPATCH ossl_kdf_##funcname##_keyexch_functions[] = { \
         { OSSL_FUNC_KEYEXCH_NEWCTX, (void (*)(void))kdf_##funcname##_newctx }, \
         { OSSL_FUNC_KEYEXCH_INIT, (void (*)(void))kdf_init }, \
         { OSSL_FUNC_KEYEXCH_DERIVE, (void (*)(void))kdf_derive }, \

--- a/providers/implementations/include/prov/ciphercommon.h
+++ b/providers/implementations/include/prov/ciphercommon.h
@@ -117,7 +117,7 @@ void cipher_generic_initkey(void *vctx, size_t kbits, size_t blkbits,
 
 #define IMPLEMENT_generic_cipher_func(alg, UCALG, lcmode, UCMODE, flags, kbits,\
                                       blkbits, ivbits, typ)                    \
-const OSSL_DISPATCH alg##kbits##lcmode##_functions[] = {                       \
+const OSSL_DISPATCH ossl_##alg##kbits##lcmode##_functions[] = {                \
     { OSSL_FUNC_CIPHER_NEWCTX,                                                 \
       (void (*)(void)) alg##_##kbits##_##lcmode##_newctx },                    \
     { OSSL_FUNC_CIPHER_FREECTX, (void (*)(void)) alg##_freectx },              \
@@ -144,7 +144,7 @@ const OSSL_DISPATCH alg##kbits##lcmode##_functions[] = {                       \
 
 #define IMPLEMENT_var_keylen_cipher_func(alg, UCALG, lcmode, UCMODE, flags,    \
                                          kbits, blkbits, ivbits, typ)          \
-const OSSL_DISPATCH alg##kbits##lcmode##_functions[] = {                       \
+const OSSL_DISPATCH ossl_##alg##kbits##lcmode##_functions[] = {                \
     { OSSL_FUNC_CIPHER_NEWCTX,                                                 \
       (void (*)(void)) alg##_##kbits##_##lcmode##_newctx },                    \
     { OSSL_FUNC_CIPHER_FREECTX, (void (*)(void)) alg##_freectx },              \

--- a/providers/implementations/include/prov/ciphercommon_aead.h
+++ b/providers/implementations/include/prov/ciphercommon_aead.h
@@ -28,7 +28,7 @@ static void * alg##kbits##lc##_newctx(void *provctx)                           \
 {                                                                              \
     return alg##_##lc##_newctx(provctx, kbits);                                \
 }                                                                              \
-const OSSL_DISPATCH alg##kbits##lc##_functions[] = {                           \
+const OSSL_DISPATCH ossl_##alg##kbits##lc##_functions[] = {                    \
     { OSSL_FUNC_CIPHER_NEWCTX, (void (*)(void))alg##kbits##lc##_newctx },      \
     { OSSL_FUNC_CIPHER_FREECTX, (void (*)(void))alg##_##lc##_freectx },        \
     { OSSL_FUNC_CIPHER_ENCRYPT_INIT, (void (*)(void)) lc##_einit },            \

--- a/providers/implementations/include/prov/digestcommon.h
+++ b/providers/implementations/include/prov/digestcommon.h
@@ -70,7 +70,7 @@ static int name##_internal_final(void *ctx, unsigned char *out, size_t *outl,  \
     return 0;                                                                  \
 }                                                                              \
 PROV_FUNC_DIGEST_GET_PARAM(name, blksize, dgstsize, flags)                     \
-const OSSL_DISPATCH name##_functions[] = {                                     \
+const OSSL_DISPATCH ossl_##name##_functions[] = {                              \
     { OSSL_FUNC_DIGEST_NEWCTX, (void (*)(void))name##_newctx },                \
     { OSSL_FUNC_DIGEST_INIT, (void (*)(void))name##_internal_init },           \
     { OSSL_FUNC_DIGEST_UPDATE, (void (*)(void))upd },                          \

--- a/providers/implementations/include/prov/implementations.h
+++ b/providers/implementations/include/prov/implementations.h
@@ -11,365 +11,365 @@
 #include <openssl/types.h>
 
 /* Digests */
-extern const OSSL_DISPATCH sha1_functions[];
-extern const OSSL_DISPATCH sha224_functions[];
-extern const OSSL_DISPATCH sha256_functions[];
-extern const OSSL_DISPATCH sha384_functions[];
-extern const OSSL_DISPATCH sha512_functions[];
-extern const OSSL_DISPATCH sha512_224_functions[];
-extern const OSSL_DISPATCH sha512_256_functions[];
-extern const OSSL_DISPATCH sha3_224_functions[];
-extern const OSSL_DISPATCH sha3_256_functions[];
-extern const OSSL_DISPATCH sha3_384_functions[];
-extern const OSSL_DISPATCH sha3_512_functions[];
-extern const OSSL_DISPATCH keccak_kmac_128_functions[];
-extern const OSSL_DISPATCH keccak_kmac_256_functions[];
-extern const OSSL_DISPATCH shake_128_functions[];
-extern const OSSL_DISPATCH shake_256_functions[];
-extern const OSSL_DISPATCH blake2s256_functions[];
-extern const OSSL_DISPATCH blake2b512_functions[];
-extern const OSSL_DISPATCH md5_functions[];
-extern const OSSL_DISPATCH md5_sha1_functions[];
-extern const OSSL_DISPATCH sm3_functions[];
-extern const OSSL_DISPATCH md2_functions[];
-extern const OSSL_DISPATCH md4_functions[];
-extern const OSSL_DISPATCH mdc2_functions[];
-extern const OSSL_DISPATCH wp_functions[];
-extern const OSSL_DISPATCH ripemd160_functions[];
+extern const OSSL_DISPATCH ossl_sha1_functions[];
+extern const OSSL_DISPATCH ossl_sha224_functions[];
+extern const OSSL_DISPATCH ossl_sha256_functions[];
+extern const OSSL_DISPATCH ossl_sha384_functions[];
+extern const OSSL_DISPATCH ossl_sha512_functions[];
+extern const OSSL_DISPATCH ossl_sha512_224_functions[];
+extern const OSSL_DISPATCH ossl_sha512_256_functions[];
+extern const OSSL_DISPATCH ossl_sha3_224_functions[];
+extern const OSSL_DISPATCH ossl_sha3_256_functions[];
+extern const OSSL_DISPATCH ossl_sha3_384_functions[];
+extern const OSSL_DISPATCH ossl_sha3_512_functions[];
+extern const OSSL_DISPATCH ossl_keccak_kmac_128_functions[];
+extern const OSSL_DISPATCH ossl_keccak_kmac_256_functions[];
+extern const OSSL_DISPATCH ossl_shake_128_functions[];
+extern const OSSL_DISPATCH ossl_shake_256_functions[];
+extern const OSSL_DISPATCH ossl_blake2s256_functions[];
+extern const OSSL_DISPATCH ossl_blake2b512_functions[];
+extern const OSSL_DISPATCH ossl_md5_functions[];
+extern const OSSL_DISPATCH ossl_md5_sha1_functions[];
+extern const OSSL_DISPATCH ossl_sm3_functions[];
+extern const OSSL_DISPATCH ossl_md2_functions[];
+extern const OSSL_DISPATCH ossl_md4_functions[];
+extern const OSSL_DISPATCH ossl_mdc2_functions[];
+extern const OSSL_DISPATCH ossl_wp_functions[];
+extern const OSSL_DISPATCH ossl_ripemd160_functions[];
 
 /* Ciphers */
-extern const OSSL_DISPATCH null_functions[];
-extern const OSSL_DISPATCH aes256ecb_functions[];
-extern const OSSL_DISPATCH aes192ecb_functions[];
-extern const OSSL_DISPATCH aes128ecb_functions[];
-extern const OSSL_DISPATCH aes256cbc_functions[];
-extern const OSSL_DISPATCH aes192cbc_functions[];
-extern const OSSL_DISPATCH aes128cbc_functions[];
-extern const OSSL_DISPATCH aes256cbc_cts_functions[];
-extern const OSSL_DISPATCH aes192cbc_cts_functions[];
-extern const OSSL_DISPATCH aes128cbc_cts_functions[];
-extern const OSSL_DISPATCH aes256ofb_functions[];
-extern const OSSL_DISPATCH aes192ofb_functions[];
-extern const OSSL_DISPATCH aes128ofb_functions[];
-extern const OSSL_DISPATCH aes256cfb_functions[];
-extern const OSSL_DISPATCH aes192cfb_functions[];
-extern const OSSL_DISPATCH aes128cfb_functions[];
-extern const OSSL_DISPATCH aes256cfb1_functions[];
-extern const OSSL_DISPATCH aes192cfb1_functions[];
-extern const OSSL_DISPATCH aes128cfb1_functions[];
-extern const OSSL_DISPATCH aes256cfb8_functions[];
-extern const OSSL_DISPATCH aes192cfb8_functions[];
-extern const OSSL_DISPATCH aes128cfb8_functions[];
-extern const OSSL_DISPATCH aes256ctr_functions[];
-extern const OSSL_DISPATCH aes192ctr_functions[];
-extern const OSSL_DISPATCH aes128ctr_functions[];
-extern const OSSL_DISPATCH aes256xts_functions[];
-extern const OSSL_DISPATCH aes128xts_functions[];
+extern const OSSL_DISPATCH ossl_null_functions[];
+extern const OSSL_DISPATCH ossl_aes256ecb_functions[];
+extern const OSSL_DISPATCH ossl_aes192ecb_functions[];
+extern const OSSL_DISPATCH ossl_aes128ecb_functions[];
+extern const OSSL_DISPATCH ossl_aes256cbc_functions[];
+extern const OSSL_DISPATCH ossl_aes192cbc_functions[];
+extern const OSSL_DISPATCH ossl_aes128cbc_functions[];
+extern const OSSL_DISPATCH ossl_aes256cbc_cts_functions[];
+extern const OSSL_DISPATCH ossl_aes192cbc_cts_functions[];
+extern const OSSL_DISPATCH ossl_aes128cbc_cts_functions[];
+extern const OSSL_DISPATCH ossl_aes256ofb_functions[];
+extern const OSSL_DISPATCH ossl_aes192ofb_functions[];
+extern const OSSL_DISPATCH ossl_aes128ofb_functions[];
+extern const OSSL_DISPATCH ossl_aes256cfb_functions[];
+extern const OSSL_DISPATCH ossl_aes192cfb_functions[];
+extern const OSSL_DISPATCH ossl_aes128cfb_functions[];
+extern const OSSL_DISPATCH ossl_aes256cfb1_functions[];
+extern const OSSL_DISPATCH ossl_aes192cfb1_functions[];
+extern const OSSL_DISPATCH ossl_aes128cfb1_functions[];
+extern const OSSL_DISPATCH ossl_aes256cfb8_functions[];
+extern const OSSL_DISPATCH ossl_aes192cfb8_functions[];
+extern const OSSL_DISPATCH ossl_aes128cfb8_functions[];
+extern const OSSL_DISPATCH ossl_aes256ctr_functions[];
+extern const OSSL_DISPATCH ossl_aes192ctr_functions[];
+extern const OSSL_DISPATCH ossl_aes128ctr_functions[];
+extern const OSSL_DISPATCH ossl_aes256xts_functions[];
+extern const OSSL_DISPATCH ossl_aes128xts_functions[];
 #ifndef OPENSSL_NO_OCB
-extern const OSSL_DISPATCH aes256ocb_functions[];
-extern const OSSL_DISPATCH aes192ocb_functions[];
-extern const OSSL_DISPATCH aes128ocb_functions[];
+extern const OSSL_DISPATCH ossl_aes256ocb_functions[];
+extern const OSSL_DISPATCH ossl_aes192ocb_functions[];
+extern const OSSL_DISPATCH ossl_aes128ocb_functions[];
 #endif /* OPENSSL_NO_OCB */
-extern const OSSL_DISPATCH aes256gcm_functions[];
-extern const OSSL_DISPATCH aes192gcm_functions[];
-extern const OSSL_DISPATCH aes128gcm_functions[];
-extern const OSSL_DISPATCH aes256ccm_functions[];
-extern const OSSL_DISPATCH aes192ccm_functions[];
-extern const OSSL_DISPATCH aes128ccm_functions[];
-extern const OSSL_DISPATCH aes256wrap_functions[];
-extern const OSSL_DISPATCH aes192wrap_functions[];
-extern const OSSL_DISPATCH aes128wrap_functions[];
-extern const OSSL_DISPATCH aes256wrappad_functions[];
-extern const OSSL_DISPATCH aes192wrappad_functions[];
-extern const OSSL_DISPATCH aes128wrappad_functions[];
-extern const OSSL_DISPATCH aes256cbc_hmac_sha1_functions[];
-extern const OSSL_DISPATCH aes128cbc_hmac_sha1_functions[];
-extern const OSSL_DISPATCH aes256cbc_hmac_sha256_functions[];
-extern const OSSL_DISPATCH aes128cbc_hmac_sha256_functions[];
+extern const OSSL_DISPATCH ossl_aes256gcm_functions[];
+extern const OSSL_DISPATCH ossl_aes192gcm_functions[];
+extern const OSSL_DISPATCH ossl_aes128gcm_functions[];
+extern const OSSL_DISPATCH ossl_aes256ccm_functions[];
+extern const OSSL_DISPATCH ossl_aes192ccm_functions[];
+extern const OSSL_DISPATCH ossl_aes128ccm_functions[];
+extern const OSSL_DISPATCH ossl_aes256wrap_functions[];
+extern const OSSL_DISPATCH ossl_aes192wrap_functions[];
+extern const OSSL_DISPATCH ossl_aes128wrap_functions[];
+extern const OSSL_DISPATCH ossl_aes256wrappad_functions[];
+extern const OSSL_DISPATCH ossl_aes192wrappad_functions[];
+extern const OSSL_DISPATCH ossl_aes128wrappad_functions[];
+extern const OSSL_DISPATCH ossl_aes256cbc_hmac_sha1_functions[];
+extern const OSSL_DISPATCH ossl_aes128cbc_hmac_sha1_functions[];
+extern const OSSL_DISPATCH ossl_aes256cbc_hmac_sha256_functions[];
+extern const OSSL_DISPATCH ossl_aes128cbc_hmac_sha256_functions[];
 
 #ifndef OPENSSL_NO_ARIA
-extern const OSSL_DISPATCH aria256gcm_functions[];
-extern const OSSL_DISPATCH aria192gcm_functions[];
-extern const OSSL_DISPATCH aria128gcm_functions[];
-extern const OSSL_DISPATCH aria256ccm_functions[];
-extern const OSSL_DISPATCH aria192ccm_functions[];
-extern const OSSL_DISPATCH aria128ccm_functions[];
-extern const OSSL_DISPATCH aria256ecb_functions[];
-extern const OSSL_DISPATCH aria192ecb_functions[];
-extern const OSSL_DISPATCH aria128ecb_functions[];
-extern const OSSL_DISPATCH aria256cbc_functions[];
-extern const OSSL_DISPATCH aria192cbc_functions[];
-extern const OSSL_DISPATCH aria128cbc_functions[];
-extern const OSSL_DISPATCH aria256ofb_functions[];
-extern const OSSL_DISPATCH aria192ofb_functions[];
-extern const OSSL_DISPATCH aria128ofb_functions[];
-extern const OSSL_DISPATCH aria256cfb_functions[];
-extern const OSSL_DISPATCH aria192cfb_functions[];
-extern const OSSL_DISPATCH aria128cfb_functions[];
-extern const OSSL_DISPATCH aria256cfb1_functions[];
-extern const OSSL_DISPATCH aria192cfb1_functions[];
-extern const OSSL_DISPATCH aria128cfb1_functions[];
-extern const OSSL_DISPATCH aria256cfb8_functions[];
-extern const OSSL_DISPATCH aria192cfb8_functions[];
-extern const OSSL_DISPATCH aria128cfb8_functions[];
-extern const OSSL_DISPATCH aria256ctr_functions[];
-extern const OSSL_DISPATCH aria192ctr_functions[];
-extern const OSSL_DISPATCH aria128ctr_functions[];
+extern const OSSL_DISPATCH ossl_aria256gcm_functions[];
+extern const OSSL_DISPATCH ossl_aria192gcm_functions[];
+extern const OSSL_DISPATCH ossl_aria128gcm_functions[];
+extern const OSSL_DISPATCH ossl_aria256ccm_functions[];
+extern const OSSL_DISPATCH ossl_aria192ccm_functions[];
+extern const OSSL_DISPATCH ossl_aria128ccm_functions[];
+extern const OSSL_DISPATCH ossl_aria256ecb_functions[];
+extern const OSSL_DISPATCH ossl_aria192ecb_functions[];
+extern const OSSL_DISPATCH ossl_aria128ecb_functions[];
+extern const OSSL_DISPATCH ossl_aria256cbc_functions[];
+extern const OSSL_DISPATCH ossl_aria192cbc_functions[];
+extern const OSSL_DISPATCH ossl_aria128cbc_functions[];
+extern const OSSL_DISPATCH ossl_aria256ofb_functions[];
+extern const OSSL_DISPATCH ossl_aria192ofb_functions[];
+extern const OSSL_DISPATCH ossl_aria128ofb_functions[];
+extern const OSSL_DISPATCH ossl_aria256cfb_functions[];
+extern const OSSL_DISPATCH ossl_aria192cfb_functions[];
+extern const OSSL_DISPATCH ossl_aria128cfb_functions[];
+extern const OSSL_DISPATCH ossl_aria256cfb1_functions[];
+extern const OSSL_DISPATCH ossl_aria192cfb1_functions[];
+extern const OSSL_DISPATCH ossl_aria128cfb1_functions[];
+extern const OSSL_DISPATCH ossl_aria256cfb8_functions[];
+extern const OSSL_DISPATCH ossl_aria192cfb8_functions[];
+extern const OSSL_DISPATCH ossl_aria128cfb8_functions[];
+extern const OSSL_DISPATCH ossl_aria256ctr_functions[];
+extern const OSSL_DISPATCH ossl_aria192ctr_functions[];
+extern const OSSL_DISPATCH ossl_aria128ctr_functions[];
 #endif /* OPENSSL_NO_ARIA */
 #ifndef OPENSSL_NO_CAMELLIA
-extern const OSSL_DISPATCH camellia256ecb_functions[];
-extern const OSSL_DISPATCH camellia192ecb_functions[];
-extern const OSSL_DISPATCH camellia128ecb_functions[];
-extern const OSSL_DISPATCH camellia256cbc_functions[];
-extern const OSSL_DISPATCH camellia192cbc_functions[];
-extern const OSSL_DISPATCH camellia128cbc_functions[];
-extern const OSSL_DISPATCH camellia256ofb_functions[];
-extern const OSSL_DISPATCH camellia192ofb_functions[];
-extern const OSSL_DISPATCH camellia128ofb_functions[];
-extern const OSSL_DISPATCH camellia256cfb_functions[];
-extern const OSSL_DISPATCH camellia192cfb_functions[];
-extern const OSSL_DISPATCH camellia128cfb_functions[];
-extern const OSSL_DISPATCH camellia256cfb1_functions[];
-extern const OSSL_DISPATCH camellia192cfb1_functions[];
-extern const OSSL_DISPATCH camellia128cfb1_functions[];
-extern const OSSL_DISPATCH camellia256cfb8_functions[];
-extern const OSSL_DISPATCH camellia192cfb8_functions[];
-extern const OSSL_DISPATCH camellia128cfb8_functions[];
-extern const OSSL_DISPATCH camellia256ctr_functions[];
-extern const OSSL_DISPATCH camellia192ctr_functions[];
-extern const OSSL_DISPATCH camellia128ctr_functions[];
+extern const OSSL_DISPATCH ossl_camellia256ecb_functions[];
+extern const OSSL_DISPATCH ossl_camellia192ecb_functions[];
+extern const OSSL_DISPATCH ossl_camellia128ecb_functions[];
+extern const OSSL_DISPATCH ossl_camellia256cbc_functions[];
+extern const OSSL_DISPATCH ossl_camellia192cbc_functions[];
+extern const OSSL_DISPATCH ossl_camellia128cbc_functions[];
+extern const OSSL_DISPATCH ossl_camellia256ofb_functions[];
+extern const OSSL_DISPATCH ossl_camellia192ofb_functions[];
+extern const OSSL_DISPATCH ossl_camellia128ofb_functions[];
+extern const OSSL_DISPATCH ossl_camellia256cfb_functions[];
+extern const OSSL_DISPATCH ossl_camellia192cfb_functions[];
+extern const OSSL_DISPATCH ossl_camellia128cfb_functions[];
+extern const OSSL_DISPATCH ossl_camellia256cfb1_functions[];
+extern const OSSL_DISPATCH ossl_camellia192cfb1_functions[];
+extern const OSSL_DISPATCH ossl_camellia128cfb1_functions[];
+extern const OSSL_DISPATCH ossl_camellia256cfb8_functions[];
+extern const OSSL_DISPATCH ossl_camellia192cfb8_functions[];
+extern const OSSL_DISPATCH ossl_camellia128cfb8_functions[];
+extern const OSSL_DISPATCH ossl_camellia256ctr_functions[];
+extern const OSSL_DISPATCH ossl_camellia192ctr_functions[];
+extern const OSSL_DISPATCH ossl_camellia128ctr_functions[];
 #endif /* OPENSSL_NO_CAMELLIA */
 #ifndef OPENSSL_NO_BF
-extern const OSSL_DISPATCH blowfish128ecb_functions[];
-extern const OSSL_DISPATCH blowfish128cbc_functions[];
-extern const OSSL_DISPATCH blowfish64ofb64_functions[];
-extern const OSSL_DISPATCH blowfish64cfb64_functions[];
+extern const OSSL_DISPATCH ossl_blowfish128ecb_functions[];
+extern const OSSL_DISPATCH ossl_blowfish128cbc_functions[];
+extern const OSSL_DISPATCH ossl_blowfish64ofb64_functions[];
+extern const OSSL_DISPATCH ossl_blowfish64cfb64_functions[];
 #endif /* OPENSSL_NO_BF */
 #ifndef OPENSSL_NO_IDEA
-extern const OSSL_DISPATCH idea128ecb_functions[];
-extern const OSSL_DISPATCH idea128cbc_functions[];
-extern const OSSL_DISPATCH idea128ofb64_functions[];
-extern const OSSL_DISPATCH idea128cfb64_functions[];
+extern const OSSL_DISPATCH ossl_idea128ecb_functions[];
+extern const OSSL_DISPATCH ossl_idea128cbc_functions[];
+extern const OSSL_DISPATCH ossl_idea128ofb64_functions[];
+extern const OSSL_DISPATCH ossl_idea128cfb64_functions[];
 #endif /* OPENSSL_NO_IDEA */
 #ifndef OPENSSL_NO_CAST
-extern const OSSL_DISPATCH cast5128ecb_functions[];
-extern const OSSL_DISPATCH cast5128cbc_functions[];
-extern const OSSL_DISPATCH cast5128ofb64_functions[];
-extern const OSSL_DISPATCH cast5128cfb64_functions[];
+extern const OSSL_DISPATCH ossl_cast5128ecb_functions[];
+extern const OSSL_DISPATCH ossl_cast5128cbc_functions[];
+extern const OSSL_DISPATCH ossl_cast5128ofb64_functions[];
+extern const OSSL_DISPATCH ossl_cast5128cfb64_functions[];
 #endif /* OPENSSL_NO_CAST */
 #ifndef OPENSSL_NO_SEED
-extern const OSSL_DISPATCH seed128ecb_functions[];
-extern const OSSL_DISPATCH seed128cbc_functions[];
-extern const OSSL_DISPATCH seed128ofb128_functions[];
-extern const OSSL_DISPATCH seed128cfb128_functions[];
+extern const OSSL_DISPATCH ossl_seed128ecb_functions[];
+extern const OSSL_DISPATCH ossl_seed128cbc_functions[];
+extern const OSSL_DISPATCH ossl_seed128ofb128_functions[];
+extern const OSSL_DISPATCH ossl_seed128cfb128_functions[];
 #endif /* OPENSSL_NO_SEED */
 #ifndef OPENSSL_NO_SM4
-extern const OSSL_DISPATCH sm4128ecb_functions[];
-extern const OSSL_DISPATCH sm4128cbc_functions[];
-extern const OSSL_DISPATCH sm4128ctr_functions[];
-extern const OSSL_DISPATCH sm4128ofb128_functions[];
-extern const OSSL_DISPATCH sm4128cfb128_functions[];
+extern const OSSL_DISPATCH ossl_sm4128ecb_functions[];
+extern const OSSL_DISPATCH ossl_sm4128cbc_functions[];
+extern const OSSL_DISPATCH ossl_sm4128ctr_functions[];
+extern const OSSL_DISPATCH ossl_sm4128ofb128_functions[];
+extern const OSSL_DISPATCH ossl_sm4128cfb128_functions[];
 #endif /* OPENSSL_NO_SM4 */
 #ifndef OPENSSL_NO_RC5
-extern const OSSL_DISPATCH rc5128ecb_functions[];
-extern const OSSL_DISPATCH rc5128cbc_functions[];
-extern const OSSL_DISPATCH rc5128ofb64_functions[];
-extern const OSSL_DISPATCH rc5128cfb64_functions[];
+extern const OSSL_DISPATCH ossl_rc5128ecb_functions[];
+extern const OSSL_DISPATCH ossl_rc5128cbc_functions[];
+extern const OSSL_DISPATCH ossl_rc5128ofb64_functions[];
+extern const OSSL_DISPATCH ossl_rc5128cfb64_functions[];
 #endif /* OPENSSL_NO_RC5 */
 #ifndef OPENSSL_NO_RC2
-extern const OSSL_DISPATCH rc2128ecb_functions[];
-extern const OSSL_DISPATCH rc2128cbc_functions[];
-extern const OSSL_DISPATCH rc240cbc_functions[];
-extern const OSSL_DISPATCH rc264cbc_functions[];
-extern const OSSL_DISPATCH rc2128cfb128_functions[];
-extern const OSSL_DISPATCH rc2128ofb128_functions[];
+extern const OSSL_DISPATCH ossl_rc2128ecb_functions[];
+extern const OSSL_DISPATCH ossl_rc2128cbc_functions[];
+extern const OSSL_DISPATCH ossl_rc240cbc_functions[];
+extern const OSSL_DISPATCH ossl_rc264cbc_functions[];
+extern const OSSL_DISPATCH ossl_rc2128cfb128_functions[];
+extern const OSSL_DISPATCH ossl_rc2128ofb128_functions[];
 #endif /* OPENSSL_NO_RC2 */
 #ifndef OPENSSL_NO_DES
-extern const OSSL_DISPATCH tdes_ede3_ecb_functions[];
-extern const OSSL_DISPATCH tdes_ede3_cbc_functions[];
+extern const OSSL_DISPATCH ossl_tdes_ede3_ecb_functions[];
+extern const OSSL_DISPATCH ossl_tdes_ede3_cbc_functions[];
 # ifndef FIPS_MODULE
-extern const OSSL_DISPATCH tdes_ede3_ofb_functions[];
-extern const OSSL_DISPATCH tdes_ede3_cfb_functions[];
-extern const OSSL_DISPATCH tdes_ede3_cfb8_functions[];
-extern const OSSL_DISPATCH tdes_ede3_cfb1_functions[];
+extern const OSSL_DISPATCH ossl_tdes_ede3_ofb_functions[];
+extern const OSSL_DISPATCH ossl_tdes_ede3_cfb_functions[];
+extern const OSSL_DISPATCH ossl_tdes_ede3_cfb8_functions[];
+extern const OSSL_DISPATCH ossl_tdes_ede3_cfb1_functions[];
 
-extern const OSSL_DISPATCH tdes_ede2_ecb_functions[];
-extern const OSSL_DISPATCH tdes_ede2_cbc_functions[];
-extern const OSSL_DISPATCH tdes_ede2_ofb_functions[];
-extern const OSSL_DISPATCH tdes_ede2_cfb_functions[];
+extern const OSSL_DISPATCH ossl_tdes_ede2_ecb_functions[];
+extern const OSSL_DISPATCH ossl_tdes_ede2_cbc_functions[];
+extern const OSSL_DISPATCH ossl_tdes_ede2_ofb_functions[];
+extern const OSSL_DISPATCH ossl_tdes_ede2_cfb_functions[];
 
-extern const OSSL_DISPATCH tdes_desx_cbc_functions[];
-extern const OSSL_DISPATCH tdes_wrap_cbc_functions[];
+extern const OSSL_DISPATCH ossl_tdes_desx_cbc_functions[];
+extern const OSSL_DISPATCH ossl_tdes_wrap_cbc_functions[];
 
-extern const OSSL_DISPATCH des_ecb_functions[];
-extern const OSSL_DISPATCH des_cbc_functions[];
-extern const OSSL_DISPATCH des_ofb64_functions[];
-extern const OSSL_DISPATCH des_cfb64_functions[];
-extern const OSSL_DISPATCH des_cfb1_functions[];
-extern const OSSL_DISPATCH des_cfb8_functions[];
+extern const OSSL_DISPATCH ossl_des_ecb_functions[];
+extern const OSSL_DISPATCH ossl_des_cbc_functions[];
+extern const OSSL_DISPATCH ossl_des_ofb64_functions[];
+extern const OSSL_DISPATCH ossl_des_cfb64_functions[];
+extern const OSSL_DISPATCH ossl_des_cfb1_functions[];
+extern const OSSL_DISPATCH ossl_des_cfb8_functions[];
 # endif /* FIPS_MODULE */
 #endif /* OPENSSL_NO_DES */
 
 #ifndef OPENSSL_NO_RC4
-extern const OSSL_DISPATCH rc440_functions[];
-extern const OSSL_DISPATCH rc4128_functions[];
+extern const OSSL_DISPATCH ossl_rc440_functions[];
+extern const OSSL_DISPATCH ossl_rc4128_functions[];
 # ifndef OPENSSL_NO_MD5
-extern const OSSL_DISPATCH rc4_hmac_md5_functions[];
+extern const OSSL_DISPATCH ossl_rc4_hmac_ossl_md5_functions[];
 # endif /* OPENSSL_NO_MD5 */
 #endif /* OPENSSL_NO_RC4 */
 #ifndef OPENSSL_NO_CHACHA
-extern const OSSL_DISPATCH chacha20_functions[];
+extern const OSSL_DISPATCH ossl_chacha20_functions[];
 # ifndef OPENSSL_NO_POLY1305
-extern const OSSL_DISPATCH chacha20_poly1305_functions[];
+extern const OSSL_DISPATCH ossl_chacha20_ossl_poly1305_functions[];
 # endif /* OPENSSL_NO_POLY1305 */
 #endif /* OPENSSL_NO_CHACHA */
 
 
 #ifndef OPENSSL_NO_SIV
-extern const OSSL_DISPATCH aes128siv_functions[];
-extern const OSSL_DISPATCH aes192siv_functions[];
-extern const OSSL_DISPATCH aes256siv_functions[];
+extern const OSSL_DISPATCH ossl_aes128siv_functions[];
+extern const OSSL_DISPATCH ossl_aes192siv_functions[];
+extern const OSSL_DISPATCH ossl_aes256siv_functions[];
 #endif /* OPENSSL_NO_SIV */
 
 /* MACs */
-extern const OSSL_DISPATCH blake2bmac_functions[];
-extern const OSSL_DISPATCH blake2smac_functions[];
-extern const OSSL_DISPATCH cmac_functions[];
-extern const OSSL_DISPATCH gmac_functions[];
-extern const OSSL_DISPATCH hmac_functions[];
-extern const OSSL_DISPATCH kmac128_functions[];
-extern const OSSL_DISPATCH kmac256_functions[];
-extern const OSSL_DISPATCH siphash_functions[];
-extern const OSSL_DISPATCH poly1305_functions[];
+extern const OSSL_DISPATCH ossl_blake2bmac_functions[];
+extern const OSSL_DISPATCH ossl_blake2smac_functions[];
+extern const OSSL_DISPATCH ossl_cmac_functions[];
+extern const OSSL_DISPATCH ossl_gmac_functions[];
+extern const OSSL_DISPATCH ossl_hmac_functions[];
+extern const OSSL_DISPATCH ossl_kmac128_functions[];
+extern const OSSL_DISPATCH ossl_kmac256_functions[];
+extern const OSSL_DISPATCH ossl_siphash_functions[];
+extern const OSSL_DISPATCH ossl_poly1305_functions[];
 
 /* KDFs / PRFs */
-extern const OSSL_DISPATCH kdf_pbkdf2_functions[];
-extern const OSSL_DISPATCH kdf_pkcs12_functions[];
+extern const OSSL_DISPATCH ossl_kdf_pbkdf2_functions[];
+extern const OSSL_DISPATCH ossl_kdf_pkcs12_functions[];
 #ifndef OPENSSL_NO_SCRYPT
-extern const OSSL_DISPATCH kdf_scrypt_functions[];
+extern const OSSL_DISPATCH ossl_kdf_scrypt_functions[];
 #endif
-extern const OSSL_DISPATCH kdf_tls1_prf_functions[];
-extern const OSSL_DISPATCH kdf_hkdf_functions[];
-extern const OSSL_DISPATCH kdf_sshkdf_functions[];
-extern const OSSL_DISPATCH kdf_sskdf_functions[];
-extern const OSSL_DISPATCH kdf_x963_kdf_functions[];
-extern const OSSL_DISPATCH kdf_kbkdf_functions[];
+extern const OSSL_DISPATCH ossl_kdf_tls1_prf_functions[];
+extern const OSSL_DISPATCH ossl_kdf_hkdf_functions[];
+extern const OSSL_DISPATCH ossl_kdf_sshkdf_functions[];
+extern const OSSL_DISPATCH ossl_kdf_sskdf_functions[];
+extern const OSSL_DISPATCH ossl_kdf_x963_kdf_functions[];
+extern const OSSL_DISPATCH ossl_kdf_kbkdf_functions[];
 #ifndef OPENSSL_NO_CMS
-extern const OSSL_DISPATCH kdf_x942_kdf_functions[];
+extern const OSSL_DISPATCH ossl_kdf_x942_kdf_functions[];
 #endif
-extern const OSSL_DISPATCH kdf_krb5kdf_functions[];
+extern const OSSL_DISPATCH ossl_kdf_krb5kdf_functions[];
 
 /* RNGs */
-extern const OSSL_DISPATCH test_rng_functions[];
-extern const OSSL_DISPATCH drbg_hash_functions[];
-extern const OSSL_DISPATCH drbg_hmac_functions[];
-extern const OSSL_DISPATCH drbg_ctr_functions[];
+extern const OSSL_DISPATCH ossl_test_rng_functions[];
+extern const OSSL_DISPATCH ossl_drbg_hash_functions[];
+extern const OSSL_DISPATCH ossl_drbg_ossl_hmac_functions[];
+extern const OSSL_DISPATCH ossl_drbg_ctr_functions[];
 extern const OSSL_DISPATCH crngt_functions[];
 
 /* Key management */
-extern const OSSL_DISPATCH dh_keymgmt_functions[];
-extern const OSSL_DISPATCH dhx_keymgmt_functions[];
-extern const OSSL_DISPATCH dsa_keymgmt_functions[];
-extern const OSSL_DISPATCH rsa_keymgmt_functions[];
-extern const OSSL_DISPATCH rsapss_keymgmt_functions[];
-extern const OSSL_DISPATCH x25519_keymgmt_functions[];
-extern const OSSL_DISPATCH x448_keymgmt_functions[];
-extern const OSSL_DISPATCH ed25519_keymgmt_functions[];
-extern const OSSL_DISPATCH ed448_keymgmt_functions[];
-extern const OSSL_DISPATCH ec_keymgmt_functions[];
-extern const OSSL_DISPATCH kdf_keymgmt_functions[];
-extern const OSSL_DISPATCH mac_legacy_keymgmt_functions[];
-extern const OSSL_DISPATCH cmac_legacy_keymgmt_functions[];
+extern const OSSL_DISPATCH ossl_dh_keymgmt_functions[];
+extern const OSSL_DISPATCH ossl_dhx_keymgmt_functions[];
+extern const OSSL_DISPATCH ossl_dsa_keymgmt_functions[];
+extern const OSSL_DISPATCH ossl_rsa_keymgmt_functions[];
+extern const OSSL_DISPATCH ossl_rsapss_keymgmt_functions[];
+extern const OSSL_DISPATCH ossl_x25519_keymgmt_functions[];
+extern const OSSL_DISPATCH ossl_x448_keymgmt_functions[];
+extern const OSSL_DISPATCH ossl_ed25519_keymgmt_functions[];
+extern const OSSL_DISPATCH ossl_ed448_keymgmt_functions[];
+extern const OSSL_DISPATCH ossl_ec_keymgmt_functions[];
+extern const OSSL_DISPATCH ossl_kdf_keymgmt_functions[];
+extern const OSSL_DISPATCH ossl_mac_legacy_keymgmt_functions[];
+extern const OSSL_DISPATCH ossl_cossl_mac_legacy_keymgmt_functions[];
 #ifndef OPENSSL_NO_SM2
 extern const OSSL_DISPATCH sm2_keymgmt_functions[];
 #endif
 
 /* Key Exchange */
-extern const OSSL_DISPATCH dh_keyexch_functions[];
-extern const OSSL_DISPATCH x25519_keyexch_functions[];
-extern const OSSL_DISPATCH x448_keyexch_functions[];
-extern const OSSL_DISPATCH ecdh_keyexch_functions[];
-extern const OSSL_DISPATCH kdf_tls1_prf_keyexch_functions[];
-extern const OSSL_DISPATCH kdf_hkdf_keyexch_functions[];
-extern const OSSL_DISPATCH kdf_scrypt_keyexch_functions[];
+extern const OSSL_DISPATCH ossl_dh_keyexch_functions[];
+extern const OSSL_DISPATCH ossl_x25519_keyexch_functions[];
+extern const OSSL_DISPATCH ossl_x448_keyexch_functions[];
+extern const OSSL_DISPATCH ecossl_dh_keyexch_functions[];
+extern const OSSL_DISPATCH ossl_kdf_tls1_prf_keyexch_functions[];
+extern const OSSL_DISPATCH ossl_kdf_hkdf_keyexch_functions[];
+extern const OSSL_DISPATCH ossl_kdf_scrypt_keyexch_functions[];
 
 /* Signature */
-extern const OSSL_DISPATCH dsa_signature_functions[];
-extern const OSSL_DISPATCH rsa_signature_functions[];
-extern const OSSL_DISPATCH ed25519_signature_functions[];
-extern const OSSL_DISPATCH ed448_signature_functions[];
-extern const OSSL_DISPATCH ecdsa_signature_functions[];
-extern const OSSL_DISPATCH mac_legacy_hmac_signature_functions[];
-extern const OSSL_DISPATCH mac_legacy_siphash_signature_functions[];
-extern const OSSL_DISPATCH mac_legacy_poly1305_signature_functions[];
-extern const OSSL_DISPATCH mac_legacy_cmac_signature_functions[];
+extern const OSSL_DISPATCH ossl_dsa_signature_functions[];
+extern const OSSL_DISPATCH ossl_rsa_signature_functions[];
+extern const OSSL_DISPATCH ossl_ed25519_signature_functions[];
+extern const OSSL_DISPATCH ossl_ed448_signature_functions[];
+extern const OSSL_DISPATCH ecossl_dsa_signature_functions[];
+extern const OSSL_DISPATCH ossl_mac_legacy_hmac_signature_functions[];
+extern const OSSL_DISPATCH ossl_mac_legacy_siphash_signature_functions[];
+extern const OSSL_DISPATCH ossl_mac_legacy_poly1305_signature_functions[];
+extern const OSSL_DISPATCH ossl_mac_legacy_cmac_signature_functions[];
 extern const OSSL_DISPATCH sm2_signature_functions[];
 
 /* Asym Cipher */
-extern const OSSL_DISPATCH rsa_asym_cipher_functions[];
+extern const OSSL_DISPATCH ossl_rsa_asym_cipher_functions[];
 #ifndef OPENSSL_NO_SM2
 extern const OSSL_DISPATCH sm2_asym_cipher_functions[];
 #endif
 
 /* Asym Key encapsulation  */
-extern const OSSL_DISPATCH rsa_asym_kem_functions[];
+extern const OSSL_DISPATCH ossl_rsa_asym_kem_functions[];
 
 /* Encoders */
-extern const OSSL_DISPATCH rsa_to_der_encoder_functions[];
-extern const OSSL_DISPATCH rsa_to_pem_encoder_functions[];
-extern const OSSL_DISPATCH rsa_to_text_encoder_functions[];
+extern const OSSL_DISPATCH ossl_rsa_to_der_encoder_functions[];
+extern const OSSL_DISPATCH ossl_rsa_to_pem_encoder_functions[];
+extern const OSSL_DISPATCH ossl_rsa_to_text_encoder_functions[];
 
-extern const OSSL_DISPATCH rsapss_to_der_encoder_functions[];
-extern const OSSL_DISPATCH rsapss_to_pem_encoder_functions[];
-extern const OSSL_DISPATCH rsapss_to_text_encoder_functions[];
+extern const OSSL_DISPATCH ossl_rsapss_to_der_encoder_functions[];
+extern const OSSL_DISPATCH ossl_rsapss_to_pem_encoder_functions[];
+extern const OSSL_DISPATCH ossl_rsapss_to_text_encoder_functions[];
 
-extern const OSSL_DISPATCH dh_to_der_encoder_functions[];
-extern const OSSL_DISPATCH dh_to_pem_encoder_functions[];
-extern const OSSL_DISPATCH dh_to_text_encoder_functions[];
+extern const OSSL_DISPATCH ossl_dh_to_der_encoder_functions[];
+extern const OSSL_DISPATCH ossl_dh_to_pem_encoder_functions[];
+extern const OSSL_DISPATCH ossl_dh_to_text_encoder_functions[];
 
-extern const OSSL_DISPATCH dhx_to_der_encoder_functions[];
-extern const OSSL_DISPATCH dhx_to_pem_encoder_functions[];
-extern const OSSL_DISPATCH dhx_to_text_encoder_functions[];
+extern const OSSL_DISPATCH ossl_dhx_to_der_encoder_functions[];
+extern const OSSL_DISPATCH ossl_dhx_to_pem_encoder_functions[];
+extern const OSSL_DISPATCH ossl_dhx_to_text_encoder_functions[];
 
-extern const OSSL_DISPATCH dsa_to_der_encoder_functions[];
-extern const OSSL_DISPATCH dsa_to_pem_encoder_functions[];
-extern const OSSL_DISPATCH dsa_to_text_encoder_functions[];
+extern const OSSL_DISPATCH ossl_dsa_to_der_encoder_functions[];
+extern const OSSL_DISPATCH ossl_dsa_to_pem_encoder_functions[];
+extern const OSSL_DISPATCH ossl_dsa_to_text_encoder_functions[];
 
-extern const OSSL_DISPATCH x25519_to_der_encoder_functions[];
-extern const OSSL_DISPATCH x25519_to_pem_encoder_functions[];
-extern const OSSL_DISPATCH x25519_to_text_encoder_functions[];
+extern const OSSL_DISPATCH ossl_x25519_to_der_encoder_functions[];
+extern const OSSL_DISPATCH ossl_x25519_to_pem_encoder_functions[];
+extern const OSSL_DISPATCH ossl_x25519_to_text_encoder_functions[];
 
-extern const OSSL_DISPATCH x448_to_der_encoder_functions[];
-extern const OSSL_DISPATCH x448_to_pem_encoder_functions[];
-extern const OSSL_DISPATCH x448_to_text_encoder_functions[];
+extern const OSSL_DISPATCH ossl_x448_to_der_encoder_functions[];
+extern const OSSL_DISPATCH ossl_x448_to_pem_encoder_functions[];
+extern const OSSL_DISPATCH ossl_x448_to_text_encoder_functions[];
 
-extern const OSSL_DISPATCH ed25519_to_der_encoder_functions[];
-extern const OSSL_DISPATCH ed25519_to_pem_encoder_functions[];
-extern const OSSL_DISPATCH ed25519_to_text_encoder_functions[];
+extern const OSSL_DISPATCH ossl_ed25519_to_der_encoder_functions[];
+extern const OSSL_DISPATCH ossl_ed25519_to_pem_encoder_functions[];
+extern const OSSL_DISPATCH ossl_ed25519_to_text_encoder_functions[];
 
-extern const OSSL_DISPATCH ed448_to_der_encoder_functions[];
-extern const OSSL_DISPATCH ed448_to_pem_encoder_functions[];
-extern const OSSL_DISPATCH ed448_to_text_encoder_functions[];
+extern const OSSL_DISPATCH ossl_ed448_to_der_encoder_functions[];
+extern const OSSL_DISPATCH ossl_ed448_to_pem_encoder_functions[];
+extern const OSSL_DISPATCH ossl_ed448_to_text_encoder_functions[];
 
-extern const OSSL_DISPATCH ec_to_der_encoder_functions[];
-extern const OSSL_DISPATCH ec_to_pem_encoder_functions[];
-extern const OSSL_DISPATCH ec_to_text_encoder_functions[];
+extern const OSSL_DISPATCH ossl_ec_to_der_encoder_functions[];
+extern const OSSL_DISPATCH ossl_ec_to_pem_encoder_functions[];
+extern const OSSL_DISPATCH ossl_ec_to_text_encoder_functions[];
 
 /* Decoders */
-extern const OSSL_DISPATCH der_to_dh_decoder_functions[];
-extern const OSSL_DISPATCH der_to_dhx_decoder_functions[];
-extern const OSSL_DISPATCH der_to_dsa_decoder_functions[];
-extern const OSSL_DISPATCH msblob_to_dsa_decoder_functions[];
-extern const OSSL_DISPATCH pvk_to_dsa_decoder_functions[];
-extern const OSSL_DISPATCH der_to_ec_decoder_functions[];
-extern const OSSL_DISPATCH der_to_x25519_decoder_functions[];
-extern const OSSL_DISPATCH der_to_x448_decoder_functions[];
-extern const OSSL_DISPATCH der_to_ed25519_decoder_functions[];
-extern const OSSL_DISPATCH der_to_ed448_decoder_functions[];
-extern const OSSL_DISPATCH der_to_rsa_decoder_functions[];
-extern const OSSL_DISPATCH der_to_rsapss_decoder_functions[];
-extern const OSSL_DISPATCH msblob_to_rsa_decoder_functions[];
-extern const OSSL_DISPATCH pvk_to_rsa_decoder_functions[];
-extern const OSSL_DISPATCH pem_to_der_decoder_functions[];
+extern const OSSL_DISPATCH ossl_der_to_dh_decoder_functions[];
+extern const OSSL_DISPATCH ossl_der_to_dhx_decoder_functions[];
+extern const OSSL_DISPATCH ossl_der_to_dsa_decoder_functions[];
+extern const OSSL_DISPATCH ossl_msblob_to_dsa_decoder_functions[];
+extern const OSSL_DISPATCH ossl_pvk_to_dsa_decoder_functions[];
+extern const OSSL_DISPATCH ossl_der_to_ec_decoder_functions[];
+extern const OSSL_DISPATCH ossl_der_to_x25519_decoder_functions[];
+extern const OSSL_DISPATCH ossl_der_to_x448_decoder_functions[];
+extern const OSSL_DISPATCH ossl_der_to_ed25519_decoder_functions[];
+extern const OSSL_DISPATCH ossl_der_to_ed448_decoder_functions[];
+extern const OSSL_DISPATCH ossl_der_to_rsa_decoder_functions[];
+extern const OSSL_DISPATCH ossl_der_to_rsapss_decoder_functions[];
+extern const OSSL_DISPATCH ossl_msblob_to_rsa_decoder_functions[];
+extern const OSSL_DISPATCH ossl_pvk_to_rsa_decoder_functions[];
+extern const OSSL_DISPATCH ossl_pem_to_der_decoder_functions[];
 
-extern const OSSL_DISPATCH file_store_functions[];
+extern const OSSL_DISPATCH ossl_file_store_functions[];

--- a/providers/implementations/kdfs/hkdf.c
+++ b/providers/implementations/kdfs/hkdf.c
@@ -271,7 +271,7 @@ static const OSSL_PARAM *kdf_hkdf_gettable_ctx_params(ossl_unused void *provctx)
     return known_gettable_ctx_params;
 }
 
-const OSSL_DISPATCH kdf_hkdf_functions[] = {
+const OSSL_DISPATCH ossl_kdf_hkdf_functions[] = {
     { OSSL_FUNC_KDF_NEWCTX, (void(*)(void))kdf_hkdf_new },
     { OSSL_FUNC_KDF_FREECTX, (void(*)(void))kdf_hkdf_free },
     { OSSL_FUNC_KDF_RESET, (void(*)(void))kdf_hkdf_reset },

--- a/providers/implementations/kdfs/kbkdf.c
+++ b/providers/implementations/kdfs/kbkdf.c
@@ -348,7 +348,7 @@ static const OSSL_PARAM *kbkdf_gettable_ctx_params(ossl_unused void *provctx)
     return known_gettable_ctx_params;
 }
 
-const OSSL_DISPATCH kdf_kbkdf_functions[] = {
+const OSSL_DISPATCH ossl_kdf_kbkdf_functions[] = {
     { OSSL_FUNC_KDF_NEWCTX, (void(*)(void))kbkdf_new },
     { OSSL_FUNC_KDF_FREECTX, (void(*)(void))kbkdf_free },
     { OSSL_FUNC_KDF_RESET, (void(*)(void))kbkdf_reset },

--- a/providers/implementations/kdfs/krb5kdf.c
+++ b/providers/implementations/kdfs/krb5kdf.c
@@ -188,7 +188,7 @@ static const OSSL_PARAM *krb5kdf_gettable_ctx_params(ossl_unused void *provctx)
     return known_gettable_ctx_params;
 }
 
-const OSSL_DISPATCH kdf_krb5kdf_functions[] = {
+const OSSL_DISPATCH ossl_kdf_krb5kdf_functions[] = {
     { OSSL_FUNC_KDF_NEWCTX, (void(*)(void))krb5kdf_new },
     { OSSL_FUNC_KDF_FREECTX, (void(*)(void))krb5kdf_free },
     { OSSL_FUNC_KDF_RESET, (void(*)(void))krb5kdf_reset },

--- a/providers/implementations/kdfs/pbkdf2.c
+++ b/providers/implementations/kdfs/pbkdf2.c
@@ -240,7 +240,7 @@ static const OSSL_PARAM *kdf_pbkdf2_gettable_ctx_params(ossl_unused void *p_ctx)
     return known_gettable_ctx_params;
 }
 
-const OSSL_DISPATCH kdf_pbkdf2_functions[] = {
+const OSSL_DISPATCH ossl_kdf_pbkdf2_functions[] = {
     { OSSL_FUNC_KDF_NEWCTX, (void(*)(void))kdf_pbkdf2_new },
     { OSSL_FUNC_KDF_FREECTX, (void(*)(void))kdf_pbkdf2_free },
     { OSSL_FUNC_KDF_RESET, (void(*)(void))kdf_pbkdf2_reset },

--- a/providers/implementations/kdfs/pkcs12kdf.c
+++ b/providers/implementations/kdfs/pkcs12kdf.c
@@ -278,7 +278,7 @@ static const OSSL_PARAM *kdf_pkcs12_gettable_ctx_params(ossl_unused void *provct
     return known_gettable_ctx_params;
 }
 
-const OSSL_DISPATCH kdf_pkcs12_functions[] = {
+const OSSL_DISPATCH ossl_kdf_pkcs12_functions[] = {
     { OSSL_FUNC_KDF_NEWCTX, (void(*)(void))kdf_pkcs12_new },
     { OSSL_FUNC_KDF_FREECTX, (void(*)(void))kdf_pkcs12_free },
     { OSSL_FUNC_KDF_RESET, (void(*)(void))kdf_pkcs12_reset },

--- a/providers/implementations/kdfs/scrypt.c
+++ b/providers/implementations/kdfs/scrypt.c
@@ -266,7 +266,7 @@ static const OSSL_PARAM *kdf_scrypt_gettable_ctx_params(ossl_unused void *p_ctx)
     return known_gettable_ctx_params;
 }
 
-const OSSL_DISPATCH kdf_scrypt_functions[] = {
+const OSSL_DISPATCH ossl_kdf_scrypt_functions[] = {
     { OSSL_FUNC_KDF_NEWCTX, (void(*)(void))kdf_scrypt_new },
     { OSSL_FUNC_KDF_FREECTX, (void(*)(void))kdf_scrypt_free },
     { OSSL_FUNC_KDF_RESET, (void(*)(void))kdf_scrypt_reset },

--- a/providers/implementations/kdfs/sshkdf.c
+++ b/providers/implementations/kdfs/sshkdf.c
@@ -200,7 +200,7 @@ static const OSSL_PARAM *kdf_sshkdf_gettable_ctx_params(ossl_unused void *p_ctx)
     return known_gettable_ctx_params;
 }
 
-const OSSL_DISPATCH kdf_sshkdf_functions[] = {
+const OSSL_DISPATCH ossl_kdf_sshkdf_functions[] = {
     { OSSL_FUNC_KDF_NEWCTX, (void(*)(void))kdf_sshkdf_new },
     { OSSL_FUNC_KDF_FREECTX, (void(*)(void))kdf_sshkdf_free },
     { OSSL_FUNC_KDF_RESET, (void(*)(void))kdf_sshkdf_reset },

--- a/providers/implementations/kdfs/sskdf.c
+++ b/providers/implementations/kdfs/sskdf.c
@@ -524,7 +524,7 @@ static const OSSL_PARAM *sskdf_gettable_ctx_params(ossl_unused void *provctx)
     return known_gettable_ctx_params;
 }
 
-const OSSL_DISPATCH kdf_sskdf_functions[] = {
+const OSSL_DISPATCH ossl_kdf_sskdf_functions[] = {
     { OSSL_FUNC_KDF_NEWCTX, (void(*)(void))sskdf_new },
     { OSSL_FUNC_KDF_FREECTX, (void(*)(void))sskdf_free },
     { OSSL_FUNC_KDF_RESET, (void(*)(void))sskdf_reset },
@@ -538,7 +538,7 @@ const OSSL_DISPATCH kdf_sskdf_functions[] = {
     { 0, NULL }
 };
 
-const OSSL_DISPATCH kdf_x963_kdf_functions[] = {
+const OSSL_DISPATCH ossl_kdf_x963_kdf_functions[] = {
     { OSSL_FUNC_KDF_NEWCTX, (void(*)(void))sskdf_new },
     { OSSL_FUNC_KDF_FREECTX, (void(*)(void))sskdf_free },
     { OSSL_FUNC_KDF_RESET, (void(*)(void))sskdf_reset },

--- a/providers/implementations/kdfs/tls1_prf.c
+++ b/providers/implementations/kdfs/tls1_prf.c
@@ -241,7 +241,7 @@ static const OSSL_PARAM *kdf_tls1_prf_gettable_ctx_params(ossl_unused void *ctx)
     return known_gettable_ctx_params;
 }
 
-const OSSL_DISPATCH kdf_tls1_prf_functions[] = {
+const OSSL_DISPATCH ossl_kdf_tls1_prf_functions[] = {
     { OSSL_FUNC_KDF_NEWCTX, (void(*)(void))kdf_tls1_prf_new },
     { OSSL_FUNC_KDF_FREECTX, (void(*)(void))kdf_tls1_prf_free },
     { OSSL_FUNC_KDF_RESET, (void(*)(void))kdf_tls1_prf_reset },

--- a/providers/implementations/kdfs/x942kdf.c
+++ b/providers/implementations/kdfs/x942kdf.c
@@ -452,7 +452,7 @@ static const OSSL_PARAM *x942kdf_gettable_ctx_params(ossl_unused void *provctx)
     return known_gettable_ctx_params;
 }
 
-const OSSL_DISPATCH kdf_x942_kdf_functions[] = {
+const OSSL_DISPATCH ossl_kdf_x942_kdf_functions[] = {
     { OSSL_FUNC_KDF_NEWCTX, (void(*)(void))x942kdf_new },
     { OSSL_FUNC_KDF_FREECTX, (void(*)(void))x942kdf_free },
     { OSSL_FUNC_KDF_RESET, (void(*)(void))x942kdf_reset },

--- a/providers/implementations/kem/rsa_kem.c
+++ b/providers/implementations/kem/rsa_kem.c
@@ -334,7 +334,7 @@ static int rsakem_recover(void *vprsactx, unsigned char *out, size_t *outlen,
     }
 }
 
-const OSSL_DISPATCH rsa_asym_kem_functions[] = {
+const OSSL_DISPATCH ossl_rsa_asym_kem_functions[] = {
     { OSSL_FUNC_KEM_NEWCTX, (void (*)(void))rsakem_newctx },
     { OSSL_FUNC_KEM_ENCAPSULATE_INIT,
       (void (*)(void))rsakem_encapsulate_init },

--- a/providers/implementations/keymgmt/dh_kmgmt.c
+++ b/providers/implementations/keymgmt/dh_kmgmt.c
@@ -707,7 +707,7 @@ void *dh_load(const void *reference, size_t reference_sz)
     return NULL;
 }
 
-const OSSL_DISPATCH dh_keymgmt_functions[] = {
+const OSSL_DISPATCH ossl_dh_keymgmt_functions[] = {
     { OSSL_FUNC_KEYMGMT_NEW, (void (*)(void))dh_newdata },
     { OSSL_FUNC_KEYMGMT_GEN_INIT, (void (*)(void))dh_gen_init },
     { OSSL_FUNC_KEYMGMT_GEN_SET_TEMPLATE, (void (*)(void))dh_gen_set_template },
@@ -738,7 +738,7 @@ static const char *dhx_query_operation_name(int operation_id)
     return "DH";
 }
 
-const OSSL_DISPATCH dhx_keymgmt_functions[] = {
+const OSSL_DISPATCH ossl_dhx_keymgmt_functions[] = {
     { OSSL_FUNC_KEYMGMT_NEW, (void (*)(void))dhx_newdata },
     { OSSL_FUNC_KEYMGMT_GEN_INIT, (void (*)(void))dhx_gen_init },
     { OSSL_FUNC_KEYMGMT_GEN_SET_TEMPLATE, (void (*)(void))dh_gen_set_template },

--- a/providers/implementations/keymgmt/dsa_kmgmt.c
+++ b/providers/implementations/keymgmt/dsa_kmgmt.c
@@ -582,7 +582,7 @@ void *dsa_load(const void *reference, size_t reference_sz)
     return NULL;
 }
 
-const OSSL_DISPATCH dsa_keymgmt_functions[] = {
+const OSSL_DISPATCH ossl_dsa_keymgmt_functions[] = {
     { OSSL_FUNC_KEYMGMT_NEW, (void (*)(void))dsa_newdata },
     { OSSL_FUNC_KEYMGMT_GEN_INIT, (void (*)(void))dsa_gen_init },
     { OSSL_FUNC_KEYMGMT_GEN_SET_TEMPLATE, (void (*)(void))dsa_gen_set_template },

--- a/providers/implementations/keymgmt/ec_kmgmt.c
+++ b/providers/implementations/keymgmt/ec_kmgmt.c
@@ -1166,7 +1166,7 @@ void *ec_load(const void *reference, size_t reference_sz)
     return NULL;
 }
 
-const OSSL_DISPATCH ec_keymgmt_functions[] = {
+const OSSL_DISPATCH ossl_ec_keymgmt_functions[] = {
     { OSSL_FUNC_KEYMGMT_NEW, (void (*)(void))ec_newdata },
     { OSSL_FUNC_KEYMGMT_GEN_INIT, (void (*)(void))ec_gen_init },
     { OSSL_FUNC_KEYMGMT_GEN_SET_TEMPLATE,

--- a/providers/implementations/keymgmt/ecx_kmgmt.c
+++ b/providers/implementations/keymgmt/ecx_kmgmt.c
@@ -671,7 +671,7 @@ void *ecx_load(const void *reference, size_t reference_sz)
 }
 
 #define MAKE_KEYMGMT_FUNCTIONS(alg) \
-    const OSSL_DISPATCH alg##_keymgmt_functions[] = { \
+    const OSSL_DISPATCH ossl_##alg##_keymgmt_functions[] = { \
         { OSSL_FUNC_KEYMGMT_NEW, (void (*)(void))alg##_new_key }, \
         { OSSL_FUNC_KEYMGMT_FREE, (void (*)(void))ecx_key_free }, \
         { OSSL_FUNC_KEYMGMT_GET_PARAMS, (void (*) (void))alg##_get_params }, \

--- a/providers/implementations/keymgmt/kdf_legacy_kmgmt.c
+++ b/providers/implementations/keymgmt/kdf_legacy_kmgmt.c
@@ -96,7 +96,7 @@ static int kdf_has(void *keydata, int selection)
     return 0;
 }
 
-const OSSL_DISPATCH kdf_keymgmt_functions[] = {
+const OSSL_DISPATCH ossl_kdf_keymgmt_functions[] = {
     { OSSL_FUNC_KEYMGMT_NEW, (void (*)(void))kdf_newdata },
     { OSSL_FUNC_KEYMGMT_FREE, (void (*)(void))kdf_freedata },
     { OSSL_FUNC_KEYMGMT_HAS, (void (*)(void))kdf_has },

--- a/providers/implementations/keymgmt/mac_legacy_kmgmt.c
+++ b/providers/implementations/keymgmt/mac_legacy_kmgmt.c
@@ -497,7 +497,7 @@ static void mac_gen_cleanup(void *genctx)
     OPENSSL_free(gctx);
 }
 
-const OSSL_DISPATCH mac_legacy_keymgmt_functions[] = {
+const OSSL_DISPATCH ossl_mac_legacy_keymgmt_functions[] = {
     { OSSL_FUNC_KEYMGMT_NEW, (void (*)(void))mac_new },
     { OSSL_FUNC_KEYMGMT_FREE, (void (*)(void))mac_free },
     { OSSL_FUNC_KEYMGMT_GET_PARAMS, (void (*) (void))mac_get_params },
@@ -519,7 +519,7 @@ const OSSL_DISPATCH mac_legacy_keymgmt_functions[] = {
     { 0, NULL }
 };
 
-const OSSL_DISPATCH cmac_legacy_keymgmt_functions[] = {
+const OSSL_DISPATCH ossl_cossl_mac_legacy_keymgmt_functions[] = {
     { OSSL_FUNC_KEYMGMT_NEW, (void (*)(void))mac_new_cmac },
     { OSSL_FUNC_KEYMGMT_FREE, (void (*)(void))mac_free },
     { OSSL_FUNC_KEYMGMT_GET_PARAMS, (void (*) (void))mac_get_params },

--- a/providers/implementations/keymgmt/rsa_kmgmt.c
+++ b/providers/implementations/keymgmt/rsa_kmgmt.c
@@ -616,7 +616,7 @@ static const char *rsa_query_operation_name(int operation_id)
     return "RSA";
 }
 
-const OSSL_DISPATCH rsa_keymgmt_functions[] = {
+const OSSL_DISPATCH ossl_rsa_keymgmt_functions[] = {
     { OSSL_FUNC_KEYMGMT_NEW, (void (*)(void))rsa_newdata },
     { OSSL_FUNC_KEYMGMT_GEN_INIT, (void (*)(void))rsa_gen_init },
     { OSSL_FUNC_KEYMGMT_GEN_SET_PARAMS,
@@ -639,7 +639,7 @@ const OSSL_DISPATCH rsa_keymgmt_functions[] = {
     { 0, NULL }
 };
 
-const OSSL_DISPATCH rsapss_keymgmt_functions[] = {
+const OSSL_DISPATCH ossl_rsapss_keymgmt_functions[] = {
     { OSSL_FUNC_KEYMGMT_NEW, (void (*)(void))rsapss_newdata },
     { OSSL_FUNC_KEYMGMT_GEN_INIT, (void (*)(void))rsapss_gen_init },
     { OSSL_FUNC_KEYMGMT_GEN_SET_PARAMS, (void (*)(void))rsa_gen_set_params },

--- a/providers/implementations/macs/blake2b_mac.c
+++ b/providers/implementations/macs/blake2b_mac.c
@@ -26,7 +26,7 @@
 #define BLAKE2_PARAM_SET_SALT blake2b_param_set_salt
 
 /* OSSL_DISPATCH symbol */
-#define BLAKE2_FUNCTIONS blake2bmac_functions
+#define BLAKE2_FUNCTIONS ossl_blake2bmac_functions
 
 #include "blake2_mac_impl.c"
 

--- a/providers/implementations/macs/blake2s_mac.c
+++ b/providers/implementations/macs/blake2s_mac.c
@@ -26,6 +26,6 @@
 #define BLAKE2_PARAM_SET_SALT blake2s_param_set_salt
 
 /* OSSL_DISPATCH symbol */
-#define BLAKE2_FUNCTIONS blake2smac_functions
+#define BLAKE2_FUNCTIONS ossl_blake2smac_functions
 
 #include "blake2_mac_impl.c"

--- a/providers/implementations/macs/cmac_prov.c
+++ b/providers/implementations/macs/cmac_prov.c
@@ -193,7 +193,7 @@ static int cmac_set_ctx_params(void *vmacctx, const OSSL_PARAM params[])
     return 1;
 }
 
-const OSSL_DISPATCH cmac_functions[] = {
+const OSSL_DISPATCH ossl_cmac_functions[] = {
     { OSSL_FUNC_MAC_NEWCTX, (void (*)(void))cmac_new },
     { OSSL_FUNC_MAC_DUPCTX, (void (*)(void))cmac_dup },
     { OSSL_FUNC_MAC_FREECTX, (void (*)(void))cmac_free },

--- a/providers/implementations/macs/gmac_prov.c
+++ b/providers/implementations/macs/gmac_prov.c
@@ -224,7 +224,7 @@ static int gmac_set_ctx_params(void *vmacctx, const OSSL_PARAM params[])
     return 1;
 }
 
-const OSSL_DISPATCH gmac_functions[] = {
+const OSSL_DISPATCH ossl_gmac_functions[] = {
     { OSSL_FUNC_MAC_NEWCTX, (void (*)(void))gmac_new },
     { OSSL_FUNC_MAC_DUPCTX, (void (*)(void))gmac_dup },
     { OSSL_FUNC_MAC_FREECTX, (void (*)(void))gmac_free },

--- a/providers/implementations/macs/hmac_prov.c
+++ b/providers/implementations/macs/hmac_prov.c
@@ -298,7 +298,7 @@ static int hmac_set_ctx_params(void *vmacctx, const OSSL_PARAM params[])
     return 1;
 }
 
-const OSSL_DISPATCH hmac_functions[] = {
+const OSSL_DISPATCH ossl_hmac_functions[] = {
     { OSSL_FUNC_MAC_NEWCTX, (void (*)(void))hmac_new },
     { OSSL_FUNC_MAC_DUPCTX, (void (*)(void))hmac_dup },
     { OSSL_FUNC_MAC_FREECTX, (void (*)(void))hmac_free },

--- a/providers/implementations/macs/kmac_prov.c
+++ b/providers/implementations/macs/kmac_prov.c
@@ -524,7 +524,7 @@ static int kmac_bytepad_encode_key(unsigned char *out, int *out_len,
     return bytepad(out, out_len, tmp, tmp_len, NULL, 0, w);
 }
 
-const OSSL_DISPATCH kmac128_functions[] = {
+const OSSL_DISPATCH ossl_kmac128_functions[] = {
     { OSSL_FUNC_MAC_NEWCTX, (void (*)(void))kmac128_new },
     { OSSL_FUNC_MAC_DUPCTX, (void (*)(void))kmac_dup },
     { OSSL_FUNC_MAC_FREECTX, (void (*)(void))kmac_free },
@@ -540,7 +540,7 @@ const OSSL_DISPATCH kmac128_functions[] = {
     { 0, NULL }
 };
 
-const OSSL_DISPATCH kmac256_functions[] = {
+const OSSL_DISPATCH ossl_kmac256_functions[] = {
     { OSSL_FUNC_MAC_NEWCTX, (void (*)(void))kmac256_new },
     { OSSL_FUNC_MAC_DUPCTX, (void (*)(void))kmac_dup },
     { OSSL_FUNC_MAC_FREECTX, (void (*)(void))kmac_free },

--- a/providers/implementations/macs/poly1305_prov.c
+++ b/providers/implementations/macs/poly1305_prov.c
@@ -154,7 +154,7 @@ static int poly1305_set_ctx_params(void *vmacctx, const OSSL_PARAM *params)
     return 1;
 }
 
-const OSSL_DISPATCH poly1305_functions[] = {
+const OSSL_DISPATCH ossl_poly1305_functions[] = {
     { OSSL_FUNC_MAC_NEWCTX, (void (*)(void))poly1305_new },
     { OSSL_FUNC_MAC_DUPCTX, (void (*)(void))poly1305_dup },
     { OSSL_FUNC_MAC_FREECTX, (void (*)(void))poly1305_free },

--- a/providers/implementations/macs/siphash_prov.c
+++ b/providers/implementations/macs/siphash_prov.c
@@ -167,7 +167,7 @@ static int siphash_set_params(void *vmacctx, const OSSL_PARAM *params)
     return 1;
 }
 
-const OSSL_DISPATCH siphash_functions[] = {
+const OSSL_DISPATCH ossl_siphash_functions[] = {
     { OSSL_FUNC_MAC_NEWCTX, (void (*)(void))siphash_new },
     { OSSL_FUNC_MAC_DUPCTX, (void (*)(void))siphash_dup },
     { OSSL_FUNC_MAC_FREECTX, (void (*)(void))siphash_free },

--- a/providers/implementations/rands/drbg_ctr.c
+++ b/providers/implementations/rands/drbg_ctr.c
@@ -735,7 +735,7 @@ static const OSSL_PARAM *drbg_ctr_settable_ctx_params(ossl_unused void *provctx)
     return known_settable_ctx_params;
 }
 
-const OSSL_DISPATCH drbg_ctr_functions[] = {
+const OSSL_DISPATCH ossl_drbg_ctr_functions[] = {
     { OSSL_FUNC_RAND_NEWCTX, (void(*)(void))drbg_ctr_new_wrapper },
     { OSSL_FUNC_RAND_FREECTX, (void(*)(void))drbg_ctr_free },
     { OSSL_FUNC_RAND_INSTANTIATE,

--- a/providers/implementations/rands/drbg_hash.c
+++ b/providers/implementations/rands/drbg_hash.c
@@ -498,7 +498,7 @@ static const OSSL_PARAM *drbg_hash_settable_ctx_params(ossl_unused void *p_ctx)
     return known_settable_ctx_params;
 }
 
-const OSSL_DISPATCH drbg_hash_functions[] = {
+const OSSL_DISPATCH ossl_drbg_hash_functions[] = {
     { OSSL_FUNC_RAND_NEWCTX, (void(*)(void))drbg_hash_new_wrapper },
     { OSSL_FUNC_RAND_FREECTX, (void(*)(void))drbg_hash_free },
     { OSSL_FUNC_RAND_INSTANTIATE,

--- a/providers/implementations/rands/drbg_hmac.c
+++ b/providers/implementations/rands/drbg_hmac.c
@@ -412,7 +412,7 @@ static const OSSL_PARAM *drbg_hmac_settable_ctx_params(ossl_unused void *p_ctx)
     return known_settable_ctx_params;
 }
 
-const OSSL_DISPATCH drbg_hmac_functions[] = {
+const OSSL_DISPATCH ossl_drbg_ossl_hmac_functions[] = {
     { OSSL_FUNC_RAND_NEWCTX, (void(*)(void))drbg_hmac_new_wrapper },
     { OSSL_FUNC_RAND_FREECTX, (void(*)(void))drbg_hmac_free },
     { OSSL_FUNC_RAND_INSTANTIATE,

--- a/providers/implementations/rands/test_rng.c
+++ b/providers/implementations/rands/test_rng.c
@@ -299,7 +299,7 @@ static void *test_rng_new_wrapper(void *provctx, void *parent,
                               &test_rng_generate);
 }
 
-const OSSL_DISPATCH test_rng_functions[] = {
+const OSSL_DISPATCH ossl_test_rng_functions[] = {
     { OSSL_FUNC_RAND_NEWCTX, (void(*)(void))test_rng_new_wrapper },
     { OSSL_FUNC_RAND_FREECTX, (void(*)(void))test_rng_free },
     { OSSL_FUNC_RAND_INSTANTIATE,

--- a/providers/implementations/signature/dsa.c
+++ b/providers/implementations/signature/dsa.c
@@ -529,7 +529,7 @@ static const OSSL_PARAM *dsa_settable_ctx_md_params(void *vpdsactx)
     return EVP_MD_settable_ctx_params(pdsactx->md);
 }
 
-const OSSL_DISPATCH dsa_signature_functions[] = {
+const OSSL_DISPATCH ossl_dsa_signature_functions[] = {
     { OSSL_FUNC_SIGNATURE_NEWCTX, (void (*)(void))dsa_newctx },
     { OSSL_FUNC_SIGNATURE_SIGN_INIT, (void (*)(void))dsa_sign_init },
     { OSSL_FUNC_SIGNATURE_SIGN, (void (*)(void))dsa_sign },

--- a/providers/implementations/signature/ecdsa.c
+++ b/providers/implementations/signature/ecdsa.c
@@ -504,7 +504,7 @@ static const OSSL_PARAM *ecdsa_settable_ctx_md_params(void *vctx)
     return EVP_MD_settable_ctx_params(ctx->md);
 }
 
-const OSSL_DISPATCH ecdsa_signature_functions[] = {
+const OSSL_DISPATCH ecossl_dsa_signature_functions[] = {
     { OSSL_FUNC_SIGNATURE_NEWCTX, (void (*)(void))ecdsa_newctx },
     { OSSL_FUNC_SIGNATURE_SIGN_INIT, (void (*)(void))ecdsa_sign_init },
     { OSSL_FUNC_SIGNATURE_SIGN, (void (*)(void))ecdsa_sign },

--- a/providers/implementations/signature/eddsa.c
+++ b/providers/implementations/signature/eddsa.c
@@ -261,7 +261,7 @@ static const OSSL_PARAM *eddsa_gettable_ctx_params(ossl_unused void *provctx)
     return known_gettable_ctx_params;
 }
 
-const OSSL_DISPATCH ed25519_signature_functions[] = {
+const OSSL_DISPATCH ossl_ed25519_signature_functions[] = {
     { OSSL_FUNC_SIGNATURE_NEWCTX, (void (*)(void))eddsa_newctx },
     { OSSL_FUNC_SIGNATURE_DIGEST_SIGN_INIT,
       (void (*)(void))eddsa_digest_signverify_init },
@@ -279,7 +279,7 @@ const OSSL_DISPATCH ed25519_signature_functions[] = {
     { 0, NULL }
 };
 
-const OSSL_DISPATCH ed448_signature_functions[] = {
+const OSSL_DISPATCH ossl_ed448_signature_functions[] = {
     { OSSL_FUNC_SIGNATURE_NEWCTX, (void (*)(void))eddsa_newctx },
     { OSSL_FUNC_SIGNATURE_DIGEST_SIGN_INIT,
       (void (*)(void))eddsa_digest_signverify_init },

--- a/providers/implementations/signature/mac_legacy.c
+++ b/providers/implementations/signature/mac_legacy.c
@@ -225,7 +225,7 @@ MAC_SETTABLE_CTX_PARAMS(poly1305, "POLY1305")
 MAC_SETTABLE_CTX_PARAMS(cmac, "CMAC")
 
 #define MAC_SIGNATURE_FUNCTIONS(funcname) \
-    const OSSL_DISPATCH mac_legacy_##funcname##_signature_functions[] = { \
+    const OSSL_DISPATCH ossl_mac_legacy_##funcname##_signature_functions[] = { \
         { OSSL_FUNC_SIGNATURE_NEWCTX, (void (*)(void))mac_##funcname##_newctx }, \
         { OSSL_FUNC_SIGNATURE_DIGEST_SIGN_INIT, \
         (void (*)(void))mac_digest_sign_init }, \

--- a/providers/implementations/signature/rsa.c
+++ b/providers/implementations/signature/rsa.c
@@ -1295,7 +1295,7 @@ static const OSSL_PARAM *rsa_settable_ctx_md_params(void *vprsactx)
     return EVP_MD_settable_ctx_params(prsactx->md);
 }
 
-const OSSL_DISPATCH rsa_signature_functions[] = {
+const OSSL_DISPATCH ossl_rsa_signature_functions[] = {
     { OSSL_FUNC_SIGNATURE_NEWCTX, (void (*)(void))rsa_newctx },
     { OSSL_FUNC_SIGNATURE_SIGN_INIT, (void (*)(void))rsa_sign_init },
     { OSSL_FUNC_SIGNATURE_SIGN, (void (*)(void))rsa_sign },

--- a/providers/implementations/storemgmt/file_store.c
+++ b/providers/implementations/storemgmt/file_store.c
@@ -906,7 +906,7 @@ static int file_close(void *loaderctx)
     return 1;
 }
 
-const OSSL_DISPATCH file_store_functions[] = {
+const OSSL_DISPATCH ossl_file_store_functions[] = {
     { OSSL_FUNC_STORE_OPEN, (void (*)(void))file_open },
     { OSSL_FUNC_STORE_ATTACH, (void (*)(void))file_attach },
     { OSSL_FUNC_STORE_SETTABLE_CTX_PARAMS,

--- a/providers/legacyprov.c
+++ b/providers/legacyprov.c
@@ -71,77 +71,77 @@ static int legacy_get_params(void *provctx, OSSL_PARAM params[])
 
 static const OSSL_ALGORITHM legacy_digests[] = {
 #ifndef OPENSSL_NO_MD2
-    ALG("MD2", md2_functions),
+    ALG("MD2", ossl_md2_functions),
 #endif
 #ifndef OPENSSL_NO_MD4
-    ALG("MD4", md4_functions),
+    ALG("MD4", ossl_md4_functions),
 #endif
 #ifndef OPENSSL_NO_MDC2
-    ALG("MDC2", mdc2_functions),
+    ALG("MDC2", ossl_mdc2_functions),
 #endif /* OPENSSL_NO_MDC2 */
 #ifndef OPENSSL_NO_WHIRLPOOL
-    ALG("WHIRLPOOL", wp_functions),
+    ALG("WHIRLPOOL", ossl_wp_functions),
 #endif /* OPENSSL_NO_WHIRLPOOL */
 #ifndef OPENSSL_NO_RMD160
-    ALG("RIPEMD-160:RIPEMD160:RIPEMD:RMD160", ripemd160_functions),
+    ALG("RIPEMD-160:RIPEMD160:RIPEMD:RMD160", ossl_ripemd160_functions),
 #endif /* OPENSSL_NO_RMD160 */
     { NULL, NULL, NULL }
 };
 
 static const OSSL_ALGORITHM legacy_ciphers[] = {
 #ifndef OPENSSL_NO_CAST
-    ALG("CAST5-ECB", cast5128ecb_functions),
-    ALG("CAST5-CBC:CAST-CBC:CAST", cast5128cbc_functions),
-    ALG("CAST5-OFB", cast5128ofb64_functions),
-    ALG("CAST5-CFB", cast5128cfb64_functions),
+    ALG("CAST5-ECB", ossl_cast5128ecb_functions),
+    ALG("CAST5-CBC:CAST-CBC:CAST", ossl_cast5128cbc_functions),
+    ALG("CAST5-OFB", ossl_cast5128ofb64_functions),
+    ALG("CAST5-CFB", ossl_cast5128cfb64_functions),
 #endif /* OPENSSL_NO_CAST */
 #ifndef OPENSSL_NO_BF
-    ALG("BF-ECB", blowfish128ecb_functions),
-    ALG("BF-CBC:BF:BLOWFISH", blowfish128cbc_functions),
-    ALG("BF-OFB", blowfish64ofb64_functions),
-    ALG("BF-CFB", blowfish64cfb64_functions),
+    ALG("BF-ECB", ossl_blowfish128ecb_functions),
+    ALG("BF-CBC:BF:BLOWFISH", ossl_blowfish128cbc_functions),
+    ALG("BF-OFB", ossl_blowfish64ofb64_functions),
+    ALG("BF-CFB", ossl_blowfish64cfb64_functions),
 #endif /* OPENSSL_NO_BF */
 #ifndef OPENSSL_NO_IDEA
-    ALG("IDEA-ECB", idea128ecb_functions),
-    ALG("IDEA-CBC:IDEA", idea128cbc_functions),
-    ALG("IDEA-OFB:IDEA-OFB64", idea128ofb64_functions),
-    ALG("IDEA-CFB:IDEA-CFB64", idea128cfb64_functions),
+    ALG("IDEA-ECB", ossl_idea128ecb_functions),
+    ALG("IDEA-CBC:IDEA", ossl_idea128cbc_functions),
+    ALG("IDEA-OFB:IDEA-OFB64", ossl_idea128ofb64_functions),
+    ALG("IDEA-CFB:IDEA-CFB64", ossl_idea128cfb64_functions),
 #endif /* OPENSSL_NO_IDEA */
 #ifndef OPENSSL_NO_SEED
-    ALG("SEED-ECB", seed128ecb_functions),
-    ALG("SEED-CBC:SEED", seed128cbc_functions),
-    ALG("SEED-OFB:SEED-OFB128", seed128ofb128_functions),
-    ALG("SEED-CFB:SEED-CFB128", seed128cfb128_functions),
+    ALG("SEED-ECB", ossl_seed128ecb_functions),
+    ALG("SEED-CBC:SEED", ossl_seed128cbc_functions),
+    ALG("SEED-OFB:SEED-OFB128", ossl_seed128ofb128_functions),
+    ALG("SEED-CFB:SEED-CFB128", ossl_seed128cfb128_functions),
 #endif /* OPENSSL_NO_SEED */
 #ifndef OPENSSL_NO_RC2
-    ALG("RC2-ECB", rc2128ecb_functions),
-    ALG("RC2-CBC:RC2:RC2-128", rc2128cbc_functions),
-    ALG("RC2-40-CBC:RC2-40", rc240cbc_functions),
-    ALG("RC2-64-CBC:RC2-64", rc264cbc_functions),
-    ALG("RC2-CFB", rc2128cfb128_functions),
-    ALG("RC2-OFB", rc2128ofb128_functions),
+    ALG("RC2-ECB", ossl_rc2128ecb_functions),
+    ALG("RC2-CBC:RC2:RC2-128", ossl_rc2128cbc_functions),
+    ALG("RC2-40-CBC:RC2-40", ossl_rc240cbc_functions),
+    ALG("RC2-64-CBC:RC2-64", ossl_rc264cbc_functions),
+    ALG("RC2-CFB", ossl_rc2128cfb128_functions),
+    ALG("RC2-OFB", ossl_rc2128ofb128_functions),
 #endif /* OPENSSL_NO_RC2 */
 #ifndef OPENSSL_NO_RC4
-    ALG("RC4", rc4128_functions),
-    ALG("RC4-40", rc440_functions),
+    ALG("RC4", ossl_rc4128_functions),
+    ALG("RC4-40", ossl_rc440_functions),
 # ifndef OPENSSL_NO_MD5
-    ALG("RC4-HMAC-MD5", rc4_hmac_md5_functions),
+    ALG("RC4-HMAC-MD5", ossl_rc4_hmac_ossl_md5_functions),
 # endif /* OPENSSL_NO_MD5 */
 #endif /* OPENSSL_NO_RC4 */
 #ifndef OPENSSL_NO_RC5
-    ALG("RC5-ECB", rc5128ecb_functions),
-    ALG("RC5-CBC:RC5", rc5128cbc_functions),
-    ALG("RC5-OFB", rc5128ofb64_functions),
-    ALG("RC5-CFB", rc5128cfb64_functions),
+    ALG("RC5-ECB", ossl_rc5128ecb_functions),
+    ALG("RC5-CBC:RC5", ossl_rc5128cbc_functions),
+    ALG("RC5-OFB", ossl_rc5128ofb64_functions),
+    ALG("RC5-CFB", ossl_rc5128cfb64_functions),
 #endif /* OPENSSL_NO_RC5 */
 #ifndef OPENSSL_NO_DES
-    ALG("DESX-CBC:DESX", tdes_desx_cbc_functions),
-    ALG("DES-ECB", des_ecb_functions),
-    ALG("DES-CBC:DES", des_cbc_functions),
-    ALG("DES-OFB", des_ofb64_functions),
-    ALG("DES-CFB", des_cfb64_functions),
-    ALG("DES-CFB1", des_cfb1_functions),
-    ALG("DES-CFB8", des_cfb8_functions),
+    ALG("DESX-CBC:DESX", ossl_tdes_desx_cbc_functions),
+    ALG("DES-ECB", ossl_des_ecb_functions),
+    ALG("DES-CBC:DES", ossl_des_cbc_functions),
+    ALG("DES-OFB", ossl_des_ofb64_functions),
+    ALG("DES-CFB", ossl_des_cfb64_functions),
+    ALG("DES-CFB1", ossl_des_cfb1_functions),
+    ALG("DES-CFB8", ossl_des_cfb8_functions),
 #endif /* OPENSSL_NO_DES */
     { NULL, NULL, NULL }
 };

--- a/providers/stores.inc
+++ b/providers/stores.inc
@@ -11,4 +11,4 @@
 # error Macro STORE undefined
 #endif
 
-STORE("file", "yes", file_store_functions)
+STORE("file", "yes", ossl_file_store_functions)


### PR DESCRIPTION
This stops them leaking into other namespaces in a static build.
They remain internal.
