### PR TITLE
check-format.pl: Prevent two minor types of false positives, extend doc and tests

### DIFF
--- a/util/check-format-test-negatives.c
+++ b/util/check-format-test-negatives.c
@@ -282,10 +282,17 @@ static void *fun(void)
         /* comment */
         return NULL;
 
+label0:
+ label1: /* allow special indent 1 for label at outermost level in body */
     do {
+    label2:
         size_t available_len, data_len;
         const char *curr = txt, *next = txt;
         char *tmp;
+
+        {
+        label3:
+        }
     } while (1);
 
     char *intraline_string_with_comment_delimiters_and_dbl_space = "1  /*1";

--- a/util/check-format-test-negatives.c
+++ b/util/check-format-test-negatives.c
@@ -29,6 +29,13 @@ int f(void) /*
         /* entire-line comment may have same indent as normal code */
     }
 
+    for (;;)
+        ;
+    for (i = 0;;)
+        ;
+    for (i = 0; i < 1;)
+        ;
+
 #if X
     if (1) /* bad style: just part of control structure depends on #if */
 #else

--- a/util/check-format-test-positives.c
+++ b/util/check-format-test-positives.c
@@ -117,7 +117,9 @@ int f (int a,       /*@ space after fn before '(', reported unless sloppy-spc */
         do f(c, c); /*@ (non-brace) code after 'do' */
         while ( 2); /*@ space after '(', reported unless sloppy-spc */
     b; c;           /*@ more than one statement per line */
+  outer:            /*@ outer label special indent off by 1 */
     do{             /*@ no space before '{', reported unless sloppy-spc */
+     inner:         /*@ inner label normal indent off by 1 */
         f (3,       /*@ space after fn before '(', reported unless sloppy-spc */
            4);      /*@0 false negative: should report single stmt in braces */
     }               /*@0 'while' not on same line as preceding '}' */
@@ -127,7 +129,6 @@ int f (int a,       /*@ space after fn before '(', reported unless sloppy-spc */
     case(2):        /*@ no space after 'case', reported unless sloppy-spc */
     default: ;      /*@ code after 'default:' */
 }                   /*@ statement indent off by -4 */
-  label:            /*@ label special statement indent off by 1 */
     return(         /*@ no space after 'return', reported unless sloppy-spc */
            x); }    /*@ code before block-level '}' */
 /* Here the tool should stop complaining apart from the below issues at EOF */

--- a/util/check-format.pl
+++ b/util/check-format.pl
@@ -798,7 +798,7 @@ while (<>) { # loop over all lines of all input files
             $local_offset = -INDENT_LEVEL;
         } else {
             if (m/^([\s@]*)(\w+):/) { # (leading) label, cannot be "default"
-                $local_offset = -INDENT_LEVEL + 1 ;
+                $local_offset = -INDENT_LEVEL;
                 $has_label = 1;
             }
         }

--- a/util/check-format.pl
+++ b/util/check-format.pl
@@ -17,6 +17,10 @@
 #                   [-h|--sloppy-hang] [-1|--1-stmt]
 #                   <files>
 #
+# run self-tests:
+#   util/check-format.pl util/check-format-test-positives.c
+#   util/check-format.pl util/check-format-test-negatives.c
+#
 # checks adherence to the formatting rules of the OpenSSL coding guidelines
 # assuming that the input files contain syntactically correct C code.
 # This pragmatic tool is incomplete and yields some false positives.

--- a/util/check-format.pl
+++ b/util/check-format.pl
@@ -658,7 +658,8 @@ while (<>) { # loop over all lines of all input files
         # treat remaining blinded comments and string literal contents as (single) space during matching below
         $intra_line =~ s/@+/ /g;                     # note that double SPC has already been handled above
         $intra_line =~ s/\s+$//;                     # strip any (resulting) space at EOL
-        $intra_line =~ s/(for\s*\();;(\))/"$1$2"/eg; # strip ';;' in for (;;)
+        $intra_line =~ s/(for\s*\([^;]*);;(\))/"$1$2"/eg; # strip trailing ';;' in for (;;)
+        $intra_line =~ s/(for\s*\([^;]+;[^;]+);(\))/"$1$2"/eg; # strip trailing ';' in for (;;)
         $intra_line =~ s/(=\s*)\{ /"$1@ "/eg;        # do not report {SPC in initializers such as ' = { 0, };'
         $intra_line =~ s/, \};/, @;/g;               # do not report SPC} in initializers such as ' = { 0, };'
         report("SPC before '$1'") if $intra_line =~ m/[\w)\]]\s+(\+\+|--)/;  # postfix ++/-- with preceding space


### PR DESCRIPTION
This contains further minor improvements of `util/check-format.pl`:
* Document how to run positive and negative self-tests
* Extend exceptions for no SPC after trailing `;` in `for (...;)`
* Allow nested indentation of labels (not only at line position 1)

Nothing urgent.