### PR TITLE
Fix memory leak in req_cb() of x_req.c

### DIFF
--- a/crypto/x509/x_req.c
+++ b/crypto/x509/x_req.c
@@ -48,7 +48,6 @@ static int rinf_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
 static int req_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
                   void *exarg)
 {
-#ifndef OPENSSL_NO_SM2
     X509_REQ *ret = (X509_REQ *)*pval;
 
     switch (operation) {
@@ -63,7 +62,6 @@ static int req_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
         ASN1_OCTET_STRING_free(ret->distinguishing_id);
         break;
     }
-#endif
 
     return 1;
 }


### PR DESCRIPTION
This fixes an (unrelated) issue I found during testing #13003.

It turns out that `req_cb()` used by `X509_REQ_free()` needs to handle `distinguishing_id` also in case `OPENSSL_NO_SM2`.