### PR TITLE
30-test_evp.t: disable tests not supported by the given build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,7 +34,7 @@ before_build:
         If ($env:Configuration -Match "shared") {
             $env:SHARED="no-makedepend"
         } ElseIf ($env:Configuration -Match "minimal") {
-            $env:SHARED="no-shared no-dso no-makedepend no-aria no-async no-autoload-config no-blake2 no-bf no-camellia no-cast no-chacha no-cmac no-cms no-cmp no-comp no-ct no-des no-dgram no-dh no-dsa no-dtls no-ec2m no-engine no-filenames no-gost no-idea no-ktls no-mdc2 no-md4 no-multiblock no-nextprotoneg no-ocsp no-ocb no-poly1305 no-psk no-rc2 no-rc4 no-rmd160 no-seed no-siphash no-siv no-sm2 no-sm3 no-sm4 no-srp no-srtp no-ssl3 no-ssl3-method no-ts no-ui-console no-whirlpool no-asm -DOPENSSL_SMALL_FOOTPRINT"
+            $env:SHARED="no-shared no-dso no-makedepend no-aria no-async no-autoload-config no-blake2 no-bf no-camellia no-cast no-chacha no-cmac no-cms no-cmp no-comp no-ct no-des no-dgram no-dh no-dsa no-ec no-ec2m no-engine no-filenames no-idea no-ktls no-md4 no-multiblock no-nextprotoneg no-ocsp no-ocb no-poly1305 no-psk no-rc2 no-rc4 no-rmd160 no-seed no-siphash no-siv no-sm3 no-sm4 no-srp no-srtp no-ssl3-method no-ts no-ui-console no-whirlpool no-asm -DOPENSSL_SMALL_FOOTPRINT"
         } Else {
             $env:SHARED="no-shared no-makedepend"
         }

--- a/test/recipes/30-test_evp.t
+++ b/test/recipes/30-test_evp.t
@@ -23,6 +23,11 @@ use platform;
 
 my $no_fips = disabled('fips') || ($ENV{NO_FIPS} // 0);
 my $no_legacy = disabled('legacy') || ($ENV{NO_LEGACY} // 0);
+my $no_dh = disabled("dh");
+my $no_dsa = disabled("dsa");
+my $no_ec = disabled("ec");
+my $no_gost = disabled("gost");
+my $no_sm2 = disabled("sm2");
 
 # Default config depends on if the legacy module is built or not
 my $defaultcnf = $no_legacy ? 'default.cnf' : 'default-and-legacy.cnf';
@@ -46,18 +51,20 @@ my @files = qw(
                 evpmac_common.txt
                 evpmd_sha.txt
                 evppbe_pbkdf2.txt
-                evppkey_dsa.txt 
-                evppkey_ecc.txt
-                evppkey_ecdh.txt
-                evppkey_ecdsa.txt
-                evppkey_ecx.txt
-                evppkey_ffdhe.txt
-                evppkey_kas.txt
                 evppkey_kdf_hkdf.txt
-                evppkey_mismatch.txt
                 evppkey_rsa_common.txt
                 evprand.txt
               );
+push @files, qw(evppkey_ffdhe.txt) unless $no_dh;
+push @files, qw(evppkey_dsa.txt) unless $no_dsa;
+push @files, qw(evppkey_ecx.txt) unless $no_ec;
+push @files, qw(
+                evppkey_ecc.txt
+                evppkey_ecdh.txt
+                evppkey_ecdsa.txt
+                evppkey_kas.txt
+                evppkey_mismatch.txt
+              ) unless $no_ec || $no_gost;
 
 # A list of tests that only run with the default provider
 # (i.e. The algorithms are not present in the fips provider)
@@ -93,12 +100,12 @@ my @defltfiles = qw(
                      evpmd_whirlpool.txt
                      evppbe_scrypt.txt
                      evppbe_pkcs12.txt
-                     evppkey_brainpool.txt
                      evppkey_kdf_scrypt.txt
                      evppkey_kdf_tls1_prf.txt
                      evppkey_rsa.txt
-                     evppkey_sm2.txt
                     );
+push @defltfiles, qw(evppkey_brainpool.txt) unless $no_ec;
+push @defltfiles, qw(evppkey_sm2.txt) unless $no_sm2;
 
 plan tests =>
     ($no_fips ? 0 : 1)          # FIPS install test


### PR DESCRIPTION
This fixes a further (unrelated) issue I found during testing #13003.

For some reason, `30-test_evp.t` so far did not disable various tests that require EC support 
for configurations with `no-ec` and so far for some strange reason this apparently went undetected.

- [x] tests are added or updated
