### PR TITLE
Improve assert message handling, particularly on macOS

### DIFF
--- a/crypto/cryptlib.c
+++ b/crypto/cryptlib.c
@@ -396,15 +396,31 @@ void OPENSSL_showfatal(const char *fmta, ...)
 # endif
 }
 #else
+
+# ifdef __APPLE__
+extern void _os_crash(const char *) __attribute__((weak_import));
+# endif
+
 void OPENSSL_showfatal(const char *fmta, ...)
 {
-#ifndef OPENSSL_NO_STDIO
     va_list ap;
 
     va_start(ap, fmta);
+
+# ifdef __APPLE__
+    if (_os_crash != NULL) {
+        char *msg;
+        va_list ap2;
+        va_copy(ap2, ap);
+        if (vasprintf(&msg, fmta, ap2) > 0)
+            _os_crash(msg);
+    }
+# endif
+
+# ifndef OPENSSL_NO_STDIO
     vfprintf(stderr, fmta, ap);
+# endif
     va_end(ap);
-#endif
 }
 
 int OPENSSL_isservice(void)

--- a/crypto/cryptlib.c
+++ b/crypto/cryptlib.c
@@ -413,10 +413,13 @@ int OPENSSL_isservice(void)
 }
 #endif
 
-void OPENSSL_die(const char *message, const char *file, int line)
+void OPENSSL_die2(const char *message, const char *file, int line, const char *func)
 {
-    OPENSSL_showfatal("%s:%d: OpenSSL internal error: %s\n",
-                      file, line, message);
+    if (func == NULL)
+        OPENSSL_die(message, file, line);
+
+    OPENSSL_showfatal("%s:%d: Function %s: OpenSSL internal error: %s\n",
+                      file, line, func, message);
 #if !defined(_WIN32)
     abort();
 #else
@@ -428,6 +431,11 @@ void OPENSSL_die(const char *message, const char *file, int line)
 # endif
     _exit(3);
 #endif
+}
+
+void OPENSSL_die(const char *message, const char *file, int line)
+{
+    OPENSSL_die2(message, file, line, "(unknown function)");
 }
 
 #if !defined(OPENSSL_CPUID_OBJ)

--- a/include/openssl/crypto.h.in
+++ b/include/openssl/crypto.h.in
@@ -379,11 +379,12 @@ DEPRECATEDIN_3_0(int CRYPTO_mem_leaks(BIO *bio))
 
 /* die if we have to */
 ossl_noreturn void OPENSSL_die(const char *assertion, const char *file, int line);
+ossl_noreturn void OPENSSL_die2(const char *assertion, const char *file, int line, const char *func);
 # ifndef OPENSSL_NO_DEPRECATED_1_1_0
 #  define OpenSSLDie(f,l,a) OPENSSL_die((a),(f),(l))
 # endif
 # define OPENSSL_assert(e) \
-    (void)((e) ? 0 : (OPENSSL_die("assertion failed: " #e, OPENSSL_FILE, OPENSSL_LINE), 1))
+    (void)((e) ? 0 : (OPENSSL_die2("assertion failed: " #e, OPENSSL_FILE, OPENSSL_LINE, OPENSSL_FUNC), 1))
 
 int OPENSSL_isservice(void);
 

--- a/test/asserttest.c
+++ b/test/asserttest.c
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2016 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <openssl/crypto.h>
+
+int main(int argc, char **argv)
+{
+    OPENSSL_assert(!"Voluntary assertion failure");
+    return 0;
+}

--- a/test/build.info
+++ b/test/build.info
@@ -30,7 +30,7 @@ IF[{- !$disabled{tests} -}]
   PROGRAMS{noinst}= \
           confdump \
           versions \
-          aborttest test_test pkcs12_format_test \
+          aborttest asserttest test_test pkcs12_format_test \
           sanitytest rsa_complex exdatatest bntest \
           ectest ecstresstest gmdifftest pbelutest \
           destest mdc2test \
@@ -74,6 +74,10 @@ IF[{- !$disabled{tests} -}]
   SOURCE[aborttest]=aborttest.c
   INCLUDE[aborttest]=../include ../apps/include
   DEPEND[aborttest]=../libcrypto
+
+  SOURCE[asserttest]=asserttest.c
+  INCLUDE[asserttest]=../include ../apps/include
+  DEPEND[asserttest]=../libcrypto
 
   SOURCE[sanitytest]=sanitytest.c
   INCLUDE[sanitytest]=../include ../apps/include

--- a/test/recipes/01-test_assert.t
+++ b/test/recipes/01-test_assert.t
@@ -1,0 +1,16 @@
+#! /usr/bin/env perl
+# Copyright 2020 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+
+use OpenSSL::Test;
+
+setup("test_assert");
+
+plan tests => 1;
+
+is(run(test(["asserttest"])), 0, "Testing that assertion failure is caught correctly");


### PR DESCRIPTION
- Add a test case for assertion failures (separate from the direct OPENSSL_die call in the existing abort test)
- Add the asserting function's name to assertion-failure error messages
- Add the assertion-failure error message to crash dumps on macOS and iOS

This improves debug output on assertion failures, particularly when an Apple crash dump is available but stderr is not.

##### Checklist
- [X] tests are added or updated
