### PR TITLE
Configure: handle undefined shared_target.

### DIFF
--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -733,9 +733,6 @@ uninstall_engines:
 	@set -e; for e in dummy $(INSTALL_ENGINES); do \
 		if [ "$$e" = "dummy" ]; then continue; fi; \
 		fn=`basename $$e`; \
-		if [ "$$fn" = '{- platform->dso("ossltest") -}' ]; then \
-			continue; \
-		fi; \
 		$(ECHO) "$(RM) $(DESTDIR)$(ENGINESDIR)/$$fn"; \
 		$(RM) $(DESTDIR)$(ENGINESDIR)/$$fn; \
 	done
@@ -760,9 +757,6 @@ uninstall_modules:
 	@set -e; for e in dummy $(INSTALL_MODULES); do \
 		if [ "$$e" = "dummy" ]; then continue; fi; \
 		fn=`basename $$e`; \
-		if [ "$$fn" = '{- platform->dso("ossltest") -}' ]; then \
-			continue; \
-		fi; \
 		$(ECHO) "$(RM) $(DESTDIR)$(MODULESDIR)/$$fn"; \
 		$(RM) $(DESTDIR)$(MODULESDIR)/$$fn; \
 	done

--- a/Configure
+++ b/Configure
@@ -579,7 +579,7 @@ my @disable_cascades = (
     # or modules.
     "pic"               => [ "shared", "module" ],
 
-    "module"            => [ "fips" ],
+    "module"            => [ "fips", "dso" ],
 
     "engine"            => [ grep /eng$/, @disablables ],
     "hw"                => [ "padlockeng" ],
@@ -1444,7 +1444,7 @@ unless($disabled{threads}) {
 }
 
 my $no_shared_warn=0;
-if ($target{shared_target} eq "")
+if (($target{shared_target} // '') eq "")
         {
         $no_shared_warn = 1
             if (!$disabled{shared} || !$disabled{"dynamic-engine"});


### PR DESCRIPTION
Some very basic config targets don't defined the 'shared_target'
attribute at all.  This wasn't handled well enough in Configure.
This also cleans away an explicit reference to the ossltest engine in
Configurations/unix-Makefile.tmpl, which isn't necessary since the
build.info attributes were added.

Fixes openssl/web#197
