### PR TITLE
TLS AEAD ciphers: more bytes for key_block than needed

### DIFF
--- a/ssl/t1_enc.c
+++ b/ssl/t1_enc.c
@@ -175,6 +175,18 @@ int tls_provider_set_tls_params(SSL *s, EVP_CIPHER_CTX *ctx,
     return 1;
 }
 
+
+static int tls_iv_length_within_key_block(const EVP_CIPHER *c)
+{
+    /* If GCM/CCM mode only part of IV comes from PRF */
+    if (EVP_CIPHER_mode(c) == EVP_CIPH_GCM_MODE)
+        return EVP_GCM_TLS_FIXED_IV_LEN;
+    else if (EVP_CIPHER_mode(c) == EVP_CIPH_CCM_MODE)
+        return EVP_CCM_TLS_FIXED_IV_LEN;
+    else
+        return EVP_CIPHER_iv_length(c);
+}
+
 int tls1_change_cipher_state(SSL *s, int which)
 {
     unsigned char *p, *mac_secret;
@@ -337,14 +349,7 @@ int tls1_change_cipher_state(SSL *s, int which)
     /* TODO(size_t): convert me */
     cl = EVP_CIPHER_key_length(c);
     j = cl;
-    /* Was j=(exp)?5:EVP_CIPHER_key_length(c); */
-    /* If GCM/CCM mode only part of IV comes from PRF */
-    if (EVP_CIPHER_mode(c) == EVP_CIPH_GCM_MODE)
-        k = EVP_GCM_TLS_FIXED_IV_LEN;
-    else if (EVP_CIPHER_mode(c) == EVP_CIPH_CCM_MODE)
-        k = EVP_CCM_TLS_FIXED_IV_LEN;
-    else
-        k = EVP_CIPHER_iv_length(c);
+    k = tls_iv_length_within_key_block(c);
     if ((which == SSL3_CHANGE_CIPHER_CLIENT_WRITE) ||
         (which == SSL3_CHANGE_CIPHER_SERVER_READ)) {
         ms = &(p[0]);
@@ -568,7 +573,7 @@ int tls1_setup_key_block(SSL *s)
     s->s3.tmp.new_hash = hash;
     s->s3.tmp.new_mac_pkey_type = mac_type;
     s->s3.tmp.new_mac_secret_size = mac_secret_size;
-    num = EVP_CIPHER_key_length(c) + mac_secret_size + EVP_CIPHER_iv_length(c);
+    num = mac_secret_size + EVP_CIPHER_key_length(c) + tls_iv_length_within_key_block(c);
     num *= 2;
 
     ssl3_cleanup_key_block(s);
@@ -583,6 +588,7 @@ int tls1_setup_key_block(SSL *s)
     s->s3.tmp.key_block = p;
 
     OSSL_TRACE_BEGIN(TLS) {
+        BIO_printf(trc_out, "key block length: %ld\n", num);
         BIO_printf(trc_out, "client random\n");
         BIO_dump_indent(trc_out, s->s3.client_random, SSL3_RANDOM_SIZE, 4);
         BIO_printf(trc_out, "server random\n");


### PR DESCRIPTION
TLS AEAD ciphers: more bytes for key_block than needed.

This pull request fixes the issue "More bytes are generated for key_block than needed for AEAD ciphers". In doing the fix, I have reused existing code that was already calculating IV length within the key block. See the discussion at #12007 for more details. It was the idea of @jwalch to use the existing code. I have taken existing code using the so-called "extract function" refactoring pattern. After that, @richsalz has proposed to optimize the code that by removing "k", and just replacing the assignments with return statements, then removing the "else".

This pull request is basically about the two things:

(1) Enables tracing of the key block length to show the bug by adding 'BIO_printf(trc_out, "key block length: %ld\n", num);'
(2) Fixes the bug by creating a function 'tls_iv_length_within_key_block' from existing code and calling it from that old place and from a second (new) place where IV length was taking regardless its context within the key_block.

I have also changed the order of addendums to correspond to one given in the RFC. The old order was somewhat counter-intuitive.

Old:

    num = EVP_CIPHER_key_length(c) + mac_secret_size + EVP_CIPHER_iv_length(c);

New:

    num = mac_secret_size + EVP_CIPHER_key_length(c) + tls_iv_length_within_key_block(c);

Here is the order in the RFC:

    client_write_MAC_key[SecurityParameters.mac_key_length]
    server_write_MAC_key[SecurityParameters.mac_key_length]
    client_write_key[SecurityParameters.enc_key_length]
    server_write_key[SecurityParameters.enc_key_length]
    client_write_IV[SecurityParameters.fixed_iv_length]
    server_write_IV[SecurityParameters.fixed_iv_length]

So, MAC_key comes first, then come cipher key and then the IV. That's why I put "mac_secret_size" first.

@mattcaswell - please review.

Fixes #12007