### PR TITLE
Disabled symbol_presence test on NonStop due to different nm format.

### DIFF
--- a/test/recipes/01-test_symbol_presence.t
+++ b/test/recipes/01-test_symbol_presence.t
@@ -14,6 +14,7 @@ use OpenSSL::Test::Utils;
 
 setup("test_symbol_presence");
 
+plan skip_all => "Test is disabled on NonStop" if config('target') =~ m|^nonstop|;
 plan skip_all => "Only useful when building shared libraries"
     if disabled("shared");
 


### PR DESCRIPTION
CLA: trivial
Fixes #12996

Signed-off-by: Randall S. Becker <rsbecker@nexbridge.com>
