### PR TITLE
der: _ossl prefix DER functions

### DIFF
--- a/crypto/asn1_dsa.c
+++ b/crypto/asn1_dsa.c
@@ -152,7 +152,7 @@ int encode_der_dsa_sig(WPACKET *pkt, const BIGNUM *r, const BIGNUM *s)
  *
  * Returns 1 on success or 0 on failure.
  */
-int decode_der_length(PACKET *pkt, PACKET *subpkt)
+int ossl_decode_der_length(PACKET *pkt, PACKET *subpkt)
 {
     unsigned int byte;
 
@@ -184,7 +184,7 @@ int decode_der_length(PACKET *pkt, PACKET *subpkt)
  * trailing garbage then it is up to the caller to verify that all bytes
  * were consumed.
  */
-int decode_der_integer(PACKET *pkt, BIGNUM *n)
+int ossl_decode_der_integer(PACKET *pkt, BIGNUM *n)
 {
     PACKET contpkt, tmppkt;
     unsigned int tag, tmp;
@@ -192,7 +192,7 @@ int decode_der_integer(PACKET *pkt, BIGNUM *n)
     /* Check we have an integer and get the content bytes */
     if (!PACKET_get_1(pkt, &tag)
             || tag != ID_INTEGER
-            || !decode_der_length(pkt, &contpkt))
+            || !ossl_decode_der_length(pkt, &contpkt))
         return 0;
 
     /* Peek ahead at the first bytes to check for proper encoding */
@@ -230,8 +230,8 @@ int decode_der_integer(PACKET *pkt, BIGNUM *n)
  * trailing garbage then it is up to the caller to verify that all bytes
  * were consumed.
  */
-size_t decode_der_dsa_sig(BIGNUM *r, BIGNUM *s, const unsigned char **ppin,
-                          size_t len)
+size_t ossl_decode_der_dsa_sig(BIGNUM *r, BIGNUM *s,
+                               const unsigned char **ppin, size_t len)
 {
     size_t consumed;
     PACKET pkt, contpkt;
@@ -240,9 +240,9 @@ size_t decode_der_dsa_sig(BIGNUM *r, BIGNUM *s, const unsigned char **ppin,
     if (!PACKET_buf_init(&pkt, *ppin, len)
             || !PACKET_get_1(&pkt, &tag)
             || tag != ID_SEQUENCE
-            || !decode_der_length(&pkt, &contpkt)
-            || !decode_der_integer(&contpkt, r)
-            || !decode_der_integer(&contpkt, s)
+            || !ossl_decode_der_length(&pkt, &contpkt)
+            || !ossl_decode_der_integer(&contpkt, r)
+            || !ossl_decode_der_integer(&contpkt, s)
             || PACKET_remaining(&contpkt) != 0)
         return 0;
 

--- a/crypto/der_writer.c
+++ b/crypto/der_writer.c
@@ -48,15 +48,16 @@ static int int_end_context(WPACKET *pkt, int tag)
         && (size1 == size2 || WPACKET_put_bytes_u8(pkt, tag));
 }
 
-int DER_w_precompiled(WPACKET *pkt, int tag,
-                      const unsigned char *precompiled, size_t precompiled_n)
+int ossl_DER_w_precompiled(WPACKET *pkt, int tag,
+                           const unsigned char *precompiled,
+                           size_t precompiled_n)
 {
     return int_start_context(pkt, tag)
         && WPACKET_memcpy(pkt, precompiled, precompiled_n)
         && int_end_context(pkt, tag);
 }
 
-int DER_w_boolean(WPACKET *pkt, int tag, int b)
+int ossl_DER_w_boolean(WPACKET *pkt, int tag, int b)
 {
     return int_start_context(pkt, tag)
         && WPACKET_start_sub_packet(pkt)
@@ -66,8 +67,8 @@ int DER_w_boolean(WPACKET *pkt, int tag, int b)
         && int_end_context(pkt, tag);
 }
 
-int DER_w_octet_string(WPACKET *pkt, int tag,
-                       const unsigned char *data, size_t data_n)
+int ossl_DER_w_octet_string(WPACKET *pkt, int tag,
+                            const unsigned char *data, size_t data_n)
 {
     return int_start_context(pkt, tag)
         && WPACKET_start_sub_packet(pkt)
@@ -77,7 +78,7 @@ int DER_w_octet_string(WPACKET *pkt, int tag,
         && int_end_context(pkt, tag);
 }
 
-int DER_w_octet_string_uint32(WPACKET *pkt, int tag, uint32_t value)
+int ossl_DER_w_octet_string_uint32(WPACKET *pkt, int tag, uint32_t value)
 {
     unsigned char tmp[4] = { 0, 0, 0, 0 };
     unsigned char *pbuf = tmp + (sizeof(tmp) - 1);
@@ -86,7 +87,7 @@ int DER_w_octet_string_uint32(WPACKET *pkt, int tag, uint32_t value)
         *pbuf-- = (value & 0xFF);
         value >>= 8;
     }
-    return DER_w_octet_string(pkt, tag, tmp, sizeof(tmp));
+    return ossl_DER_w_octet_string(pkt, tag, tmp, sizeof(tmp));
 }
 
 static int int_der_w_integer(WPACKET *pkt, int tag,
@@ -124,7 +125,7 @@ static int int_put_bytes_ulong(WPACKET *pkt, const void *v,
 }
 
 /* For integers, we only support unsigned values for now */
-int DER_w_ulong(WPACKET *pkt, int tag, unsigned long v)
+int ossl_DER_w_ulong(WPACKET *pkt, int tag, unsigned long v)
 {
     return int_der_w_integer(pkt, tag, int_put_bytes_ulong, &v);
 }
@@ -147,17 +148,17 @@ static int int_put_bytes_bn(WPACKET *pkt, const void *v,
     return 1;
 }
 
-int DER_w_bn(WPACKET *pkt, int tag, const BIGNUM *v)
+int ossl_DER_w_bn(WPACKET *pkt, int tag, const BIGNUM *v)
 {
     if (v == NULL || BN_is_negative(v))
         return 0;
     if (BN_is_zero(v))
-        return DER_w_ulong(pkt, tag, 0);
+        return ossl_DER_w_ulong(pkt, tag, 0);
 
     return int_der_w_integer(pkt, tag, int_put_bytes_bn, v);
 }
 
-int DER_w_null(WPACKET *pkt, int tag)
+int ossl_DER_w_null(WPACKET *pkt, int tag)
 {
     return int_start_context(pkt, tag)
         && WPACKET_start_sub_packet(pkt)
@@ -167,13 +168,13 @@ int DER_w_null(WPACKET *pkt, int tag)
 }
 
 /* Constructed things need a start and an end */
-int DER_w_begin_sequence(WPACKET *pkt, int tag)
+int ossl_DER_w_begin_sequence(WPACKET *pkt, int tag)
 {
     return int_start_context(pkt, tag)
         && WPACKET_start_sub_packet(pkt);
 }
 
-int DER_w_end_sequence(WPACKET *pkt, int tag)
+int ossl_DER_w_end_sequence(WPACKET *pkt, int tag)
 {
     /*
      * If someone set the flag WPACKET_FLAGS_ABANDON_ON_ZERO_LENGTH on this

--- a/crypto/dsa/dsa_sign.c
+++ b/crypto/dsa/dsa_sign.c
@@ -65,7 +65,7 @@ DSA_SIG *d2i_DSA_SIG(DSA_SIG **psig, const unsigned char **ppin, long len)
         sig->r = BN_new();
     if (sig->s == NULL)
         sig->s = BN_new();
-    if (decode_der_dsa_sig(sig->r, sig->s, ppin, (size_t)len) == 0) {
+    if (ossl_decode_der_dsa_sig(sig->r, sig->s, ppin, (size_t)len) == 0) {
         if (psig == NULL || *psig == NULL)
             DSA_SIG_free(sig);
         return NULL;

--- a/crypto/ec/ec_asn1.c
+++ b/crypto/ec/ec_asn1.c
@@ -1218,7 +1218,7 @@ ECDSA_SIG *d2i_ECDSA_SIG(ECDSA_SIG **psig, const unsigned char **ppin, long len)
         sig->r = BN_new();
     if (sig->s == NULL)
         sig->s = BN_new();
-    if (decode_der_dsa_sig(sig->r, sig->s, ppin, (size_t)len) == 0) {
+    if (ossl_decode_der_dsa_sig(sig->r, sig->s, ppin, (size_t)len) == 0) {
         if (psig == NULL || *psig == NULL)
             ECDSA_SIG_free(sig);
         return NULL;

--- a/doc/internal/man3/ossl_DER_w_begin_sequence.pod
+++ b/doc/internal/man3/ossl_DER_w_begin_sequence.pod
@@ -2,15 +2,15 @@
 
 =head1 NAME
 
-DER_w_begin_sequence, DER_w_end_sequence
+ossl_DER_w_begin_sequence, ossl_DER_w_end_sequence
 - internal DER writers for DER constructed elements
 
 =head1 SYNOPSIS
 
  #include "internal/der.h"
 
- int DER_w_begin_sequence(WPACKET *pkt, int tag);
- int DER_w_end_sequence(WPACKET *pkt, int tag);
+ int ossl_DER_w_begin_sequence(WPACKET *pkt, int tag);
+ int ossl_DER_w_end_sequence(WPACKET *pkt, int tag);
 
 =head1 DESCRIPTION
 
@@ -22,7 +22,7 @@ and B<end>.
 When using these, special care must be taken to ensure that the ASN.1 tag
 value I<tag> is the same in the matching C<begin> and C<end> function calls.
 
-DER_w_begin_sequence() and DER_w_end_sequence() begins and ends a
+ossl_DER_w_begin_sequence() and ossl_DER_w_end_sequence() begins and ends a
 SEQUENCE.
 
 =head1 RETURN VALUES

--- a/doc/internal/man3/ossl_DER_w_bn.pod
+++ b/doc/internal/man3/ossl_DER_w_bn.pod
@@ -2,21 +2,21 @@
 
 =head1 NAME
 
-DER_w_boolean, DER_w_ulong, DER_w_bn, DER_w_null,
-DER_w_octet_string, DER_w_octet_string_uint32
+ossl_DER_w_boolean, ossl_DER_w_ulong, ossl_DER_w_bn, ossl_DER_w_null,
+ossl_DER_w_octet_string, ossl_DER_w_octet_string_uint32
 - internal DER writers for DER primitives
 
 =head1 SYNOPSIS
 
  #include "internal/der.h"
 
- int DER_w_boolean(WPACKET *pkt, int tag, int b);
- int DER_w_ulong(WPACKET *pkt, int tag, unsigned long v);
- int DER_w_bn(WPACKET *pkt, int tag, const BIGNUM *v);
- int DER_w_null(WPACKET *pkt, int tag);
- int DER_w_octet_string(WPACKET *pkt, int tag,
-                        const unsigned char *data, size_t data_n);
- int DER_w_octet_string_uint32(WPACKET *pkt, int tag, uint32_t value);
+ int ossl_DER_w_boolean(WPACKET *pkt, int tag, int b);
+ int ossl_DER_w_ulong(WPACKET *pkt, int tag, unsigned long v);
+ int ossl_DER_w_bn(WPACKET *pkt, int tag, const BIGNUM *v);
+ int ossl_DER_w_null(WPACKET *pkt, int tag);
+ int ossl_DER_w_octet_string(WPACKET *pkt, int tag,
+                             const unsigned char *data, size_t data_n);
+ int ossl_DER_w_octet_string_uint32(WPACKET *pkt, int tag, uint32_t value);
 
 =head1 DESCRIPTION
 
@@ -25,23 +25,23 @@ All functions described here behave the same way, they prepend
 their respective value to the already written output buffer held by
 I<pkt>.
 
-DER_w_boolean() writes the primitive BOOLEAN using the value I<b>.
+ossl_DER_w_boolean() writes the primitive BOOLEAN using the value I<b>.
 Any value that evaluates as true will render a B<true> BOOLEAN,
 otherwise a B<false> BOOLEAN.
 
-DER_w_ulong() and DER_w_bn() both write the primitive INTEGER using
+ossl_DER_w_ulong() and ossl_DER_w_bn() both write the primitive INTEGER using
 the value I<v>.
 
 =for comment Other similar functions for diverse C integers should be
 added.
 
-DER_w_null() writes the primitive NULL.
+ossl_DER_w_null() writes the primitive NULL.
 
-DER_w_octet_string() writes the primitive OCTET STRING using the bytes from
-I<data> with a length of I<data_n>.
+ossl_DER_w_octet_string() writes the primitive OCTET STRING using the bytes
+from I<data> with a length of I<data_n>.
 
-DER_w_octet_string_uint32() writes the primitive OCTET STRING using a 32 bit
-value in I<value>.
+ossl_DER_w_octet_string_uint32() writes the primitive OCTET STRING using a
+32 bit value in I<value>.
 
 =head1 RETURN VALUES
 

--- a/doc/internal/man3/ossl_DER_w_precompiled.pod
+++ b/doc/internal/man3/ossl_DER_w_precompiled.pod
@@ -2,16 +2,16 @@
 
 =head1 NAME
 
-DER_w_precompiled
+ossl_DER_w_precompiled
 - internal DER writers for precompiled DER blobs
 
 =head1 SYNOPSIS
 
  #include "internal/der.h"
 
- int DER_w_precompiled(WPACKET *pkt, int tag,
-                       const unsigned char *precompiled,
-                       size_t precompiled_n);
+ int ossl_DER_w_precompiled(WPACKET *pkt, int tag,
+                            const unsigned char *precompiled,
+                            size_t precompiled_n);
 
 =head1 DESCRIPTION
 
@@ -19,15 +19,15 @@ There may be already existing DER blobs that can simply be copied to
 the buffer held by I<pkt>.  For example, precompiled values, such as
 OIDs (for example, C<id-sha256>) or complete AlgorithmIdentifiers
 (for example, C<sha256Identifier>).  To add those as an element in a
-structure being DER encoded, use DER_w_precompiled().
+structure being DER encoded, use ossl_DER_w_precompiled().
 
-DER_w_precompiled() will simply take the DER encoded blob given as
+ossl_DER_w_precompiled() will simply take the DER encoded blob given as
 I<precompiled> with length I<precompiled_n> and add it to the buffer
 held by I<pkt>.
 
 =head1 RETURN VALUES
 
-DER_w_precompiled() returns 1 on success and 0 on failure.  Failure
+ossl_DER_w_precompiled() returns 1 on success and 0 on failure.  Failure
 may mean that the buffer held by the I<pkt> is too small, but may also
 mean that the values given to the functions are invalid, such as the provided
 I<tag> value being too large for the implementation.

--- a/doc/internal/man7/DERlib.pod
+++ b/doc/internal/man7/DERlib.pod
@@ -50,10 +50,10 @@ which is defined like this in ASN.1 terms:
 With the DER library, this is the corresponding code, given two OpenSSL
 B<BIGNUM>s I<r> and I<s>:
 
-    int ok = DER_w_begin_sequence(pkt, -1)
-          && DER_w_bn(pkg, -1, s)
-          && DER_w_bn(pkg, -1, r)
-          && DER_w_end_sequence(pkt, -1);
+    int ok = ossl_DER_w_begin_sequence(pkt, -1)
+          && ossl_DER_w_bn(pkg, -1, s)
+          && ossl_DER_w_bn(pkg, -1, r)
+          && ossl_DER_w_end_sequence(pkt, -1);
 
 As an example of the use of I<tag>, an ASN.1 element like this:
 
@@ -61,7 +61,7 @@ As an example of the use of I<tag>, an ASN.1 element like this:
 
 Would be encoded like this:
 
-    DER_w_bn(pkt, 1, v)
+    ossl_DER_w_bn(pkt, 1, v)
 
 =begin comment
 
@@ -116,25 +116,26 @@ value:
                                                      int tag,
                                                      RSA *rsa)
     {
-        return DER_w_begin_sequence(pkt, tag)
-            && (DER_w_begin_sequence(pkt, DER_NO_CONTEXT)
-                && DER_w_ulong(pkt, 2, 20)
-                && DER_w_precompiled(pkt, 1,
-                                     der_mgf1SHA256Identifier,
-                                     sizeof(der_mgf1SHA256Identifier))
-                && DER_w_precompiled(pkt, 0,
-                                     der_sha256Identifier,
-                                     sizeof(der_sha256Identifier))
-                && DER_w_end_sequence(pkt, DER_NO_CONTEXT))
-            && DER_w_precompiled(pkt, DER_NO_CONTEXT,
-                                 der_id_RSASSA_PSS,
-                                 sizeof(der_id_RSASSA_PSS))
-            && DER_w_end_sequence(pkt, tag);
+        return ossl_DER_w_begin_sequence(pkt, tag)
+            && (ossl_DER_w_begin_sequence(pkt, DER_NO_CONTEXT)
+                && ossl_DER_w_ulong(pkt, 2, 20)
+                && ossl_DER_w_precompiled(pkt, 1,
+                                          der_mgf1SHA256Identifier,
+                                          sizeof(der_mgf1SHA256Identifier))
+                && ossl_DER_w_precompiled(pkt, 0,
+                                          der_sha256Identifier,
+                                          sizeof(der_sha256Identifier))
+                && ossl_DER_w_end_sequence(pkt, DER_NO_CONTEXT))
+            && ossl_DER_w_precompiled(pkt, DER_NO_CONTEXT,
+                                      der_id_RSASSA_PSS,
+                                      sizeof(der_id_RSASSA_PSS))
+            && ossl_DER_w_end_sequence(pkt, tag);
     }
 
 =head1 SEE ALSO
 
-L<DER_w_bn(3)>, L<DER_w_begin_sequence(3)>, L<DER_w_precompiled(3)>
+L<ossl_DER_w_bn(3)>, L<ossl_DER_w_begin_sequence(3)>,
+L<ossl_DER_w_precompiled(3)>
 
 =head1 COPYRIGHT
 

--- a/include/crypto/asn1_dsa.h
+++ b/include/crypto/asn1_dsa.h
@@ -15,9 +15,9 @@
 int encode_der_length(WPACKET *pkt, size_t cont_len);
 int encode_der_integer(WPACKET *pkt, const BIGNUM *n);
 int encode_der_dsa_sig(WPACKET *pkt, const BIGNUM *r, const BIGNUM *s);
-int decode_der_length(PACKET *pkt, PACKET *subpkt);
-int decode_der_integer(PACKET *pkt, BIGNUM *n);
-size_t decode_der_dsa_sig(BIGNUM *r, BIGNUM *s, const unsigned char **ppin,
-                          size_t len);
+int ossl_decode_der_length(PACKET *pkt, PACKET *subpkt);
+int ossl_decode_der_integer(PACKET *pkt, BIGNUM *n);
+size_t ossl_decode_der_dsa_sig(BIGNUM *r, BIGNUM *s, const unsigned char **ppin,
+                               size_t len);
 
 #endif

--- a/include/internal/der.h
+++ b/include/internal/der.h
@@ -69,19 +69,20 @@
 /* This can be used for all items that don't have a context */
 #define DER_NO_CONTEXT  -1
 
-int DER_w_precompiled(WPACKET *pkt, int tag,
-                      const unsigned char *precompiled, size_t precompiled_n);
+int ossl_DER_w_precompiled(WPACKET *pkt, int tag,
+                           const unsigned char *precompiled,
+                           size_t precompiled_n);
 
-int DER_w_boolean(WPACKET *pkt, int tag, int b);
-int DER_w_ulong(WPACKET *pkt, int tag, unsigned long v);
-int DER_w_bn(WPACKET *pkt, int tag, const BIGNUM *v);
-int DER_w_null(WPACKET *pkt, int tag);
-int DER_w_octet_string(WPACKET *pkt, int tag,
-                       const unsigned char *data, size_t data_n);
-int DER_w_octet_string_uint32(WPACKET *pkt, int tag, uint32_t value);
+int ossl_DER_w_boolean(WPACKET *pkt, int tag, int b);
+int ossl_DER_w_ulong(WPACKET *pkt, int tag, unsigned long v);
+int ossl_DER_w_bn(WPACKET *pkt, int tag, const BIGNUM *v);
+int ossl_DER_w_null(WPACKET *pkt, int tag);
+int ossl_DER_w_octet_string(WPACKET *pkt, int tag,
+                            const unsigned char *data, size_t data_n);
+int ossl_DER_w_octet_string_uint32(WPACKET *pkt, int tag, uint32_t value);
 
 /*
  * All constructors for constructed elements have a begin and a end function
  */
-int DER_w_begin_sequence(WPACKET *pkt, int tag);
-int DER_w_end_sequence(WPACKET *pkt, int tag);
+int ossl_DER_w_begin_sequence(WPACKET *pkt, int tag);
+int ossl_DER_w_end_sequence(WPACKET *pkt, int tag);

--- a/providers/common/der/der_dsa.h.in
+++ b/providers/common/der/der_dsa.h.in
@@ -17,7 +17,7 @@
 -}
 
 /* Subject Public Key Info */
-int DER_w_algorithmIdentifier_DSA(WPACKET *pkt, int tag, DSA *dsa);
+int ossl_DER_w_algorithmIdentifier_DSA(WPACKET *pkt, int tag, DSA *dsa);
 /* Signature */
-int DER_w_algorithmIdentifier_DSA_with_MD(WPACKET *pkt, int tag,
-                                        DSA *dsa, int mdnid);
+int ossl_DER_w_algorithmIdentifier_DSA_with_MD(WPACKET *pkt, int tag,
+                                               DSA *dsa, int mdnid);

--- a/providers/common/der/der_dsa_key.c
+++ b/providers/common/der/der_dsa_key.c
@@ -15,7 +15,7 @@ int ossl_DER_w_algorithmIdentifier_DSA(WPACKET *pkt, int tag, DSA *dsa)
 {
     return ossl_DER_w_begin_sequence(pkt, tag)
         /* No parameters (yet?) */
-        && ossl_DER_w_precompiled(pkt, -1, der_oid_id_dsa,
-                                  sizeof(der_oid_id_dsa))
+        && ossl_DER_w_precompiled(pkt, -1, ossl_der_oid_id_dsa,
+                                  sizeof(ossl_der_oid_id_dsa))
         && ossl_DER_w_end_sequence(pkt, tag);
 }

--- a/providers/common/der/der_dsa_key.c
+++ b/providers/common/der/der_dsa_key.c
@@ -11,10 +11,11 @@
 #include "internal/packet.h"
 #include "prov/der_dsa.h"
 
-int DER_w_algorithmIdentifier_DSA(WPACKET *pkt, int tag, DSA *dsa)
+int ossl_DER_w_algorithmIdentifier_DSA(WPACKET *pkt, int tag, DSA *dsa)
 {
-    return DER_w_begin_sequence(pkt, tag)
+    return ossl_DER_w_begin_sequence(pkt, tag)
         /* No parameters (yet?) */
-        && DER_w_precompiled(pkt, -1, der_oid_id_dsa, sizeof(der_oid_id_dsa))
-        && DER_w_end_sequence(pkt, tag);
+        && ossl_DER_w_precompiled(pkt, -1, der_oid_id_dsa,
+                                  sizeof(der_oid_id_dsa))
+        && ossl_DER_w_end_sequence(pkt, tag);
 }

--- a/providers/common/der/der_dsa_sig.c
+++ b/providers/common/der/der_dsa_sig.c
@@ -13,8 +13,8 @@
 
 #define MD_CASE(name)                                                   \
     case NID_##name:                                                    \
-        precompiled = der_oid_id_dsa_with_##name;                \
-        precompiled_sz = sizeof(der_oid_id_dsa_with_##name);     \
+        precompiled = ossl_der_oid_id_dsa_with_##name;                  \
+        precompiled_sz = sizeof(ossl_der_oid_id_dsa_with_##name);       \
         break;
 
 int ossl_DER_w_algorithmIdentifier_DSA_with_MD(WPACKET *pkt, int tag,

--- a/providers/common/der/der_dsa_sig.c
+++ b/providers/common/der/der_dsa_sig.c
@@ -17,8 +17,8 @@
         precompiled_sz = sizeof(der_oid_id_dsa_with_##name);     \
         break;
 
-int DER_w_algorithmIdentifier_DSA_with_MD(WPACKET *pkt, int tag,
-                                          DSA *dsa, int mdnid)
+int ossl_DER_w_algorithmIdentifier_DSA_with_MD(WPACKET *pkt, int tag,
+                                               DSA *dsa, int mdnid)
 {
     const unsigned char *precompiled = NULL;
     size_t precompiled_sz = 0;
@@ -37,8 +37,8 @@ int DER_w_algorithmIdentifier_DSA_with_MD(WPACKET *pkt, int tag,
         return 0;
     }
 
-    return DER_w_begin_sequence(pkt, tag)
+    return ossl_DER_w_begin_sequence(pkt, tag)
         /* No parameters (yet?) */
-        && DER_w_precompiled(pkt, -1, precompiled, precompiled_sz)
-        && DER_w_end_sequence(pkt, tag);
+        && ossl_DER_w_precompiled(pkt, -1, precompiled, precompiled_sz)
+        && ossl_DER_w_end_sequence(pkt, tag);
 }

--- a/providers/common/der/der_ec.h.in
+++ b/providers/common/der/der_ec.h.in
@@ -17,7 +17,7 @@
 -}
 
 /* Subject Public Key Info */
-int DER_w_algorithmIdentifier_EC(WPACKET *pkt, int cont, EC_KEY *ec);
+int ossl_DER_w_algorithmIdentifier_EC(WPACKET *pkt, int cont, EC_KEY *ec);
 /* Signature */
-int DER_w_algorithmIdentifier_ECDSA_with_MD(WPACKET *pkt, int cont,
-                                            EC_KEY *ec, int mdnid);
+int ossl_DER_w_algorithmIdentifier_ECDSA_with_MD(WPACKET *pkt, int cont,
+                                                 EC_KEY *ec, int mdnid);

--- a/providers/common/der/der_ec_key.c
+++ b/providers/common/der/der_ec_key.c
@@ -11,11 +11,11 @@
 #include "internal/packet.h"
 #include "prov/der_ec.h"
 
-int DER_w_algorithmIdentifier_EC(WPACKET *pkt, int cont, EC_KEY *ec)
+int ossl_DER_w_algorithmIdentifier_EC(WPACKET *pkt, int cont, EC_KEY *ec)
 {
-    return DER_w_begin_sequence(pkt, cont)
+    return ossl_DER_w_begin_sequence(pkt, cont)
         /* No parameters (yet?) */
-        && DER_w_precompiled(pkt, -1, der_oid_id_ecPublicKey,
-                             sizeof(der_oid_id_ecPublicKey))
-        && DER_w_end_sequence(pkt, cont);
+        && ossl_DER_w_precompiled(pkt, -1, der_oid_id_ecPublicKey,
+                                  sizeof(der_oid_id_ecPublicKey))
+        && ossl_DER_w_end_sequence(pkt, cont);
 }

--- a/providers/common/der/der_ec_key.c
+++ b/providers/common/der/der_ec_key.c
@@ -15,7 +15,7 @@ int ossl_DER_w_algorithmIdentifier_EC(WPACKET *pkt, int cont, EC_KEY *ec)
 {
     return ossl_DER_w_begin_sequence(pkt, cont)
         /* No parameters (yet?) */
-        && ossl_DER_w_precompiled(pkt, -1, der_oid_id_ecPublicKey,
-                                  sizeof(der_oid_id_ecPublicKey))
+        && ossl_DER_w_precompiled(pkt, -1, ossl_der_oid_id_ecPublicKey,
+                                  sizeof(ossl_der_oid_id_ecPublicKey))
         && ossl_DER_w_end_sequence(pkt, cont);
 }

--- a/providers/common/der/der_ec_sig.c
+++ b/providers/common/der/der_ec_sig.c
@@ -24,8 +24,8 @@
         precompiled_sz = sizeof(der_oid_id_ecdsa_with_##name);          \
         break;
 
-int DER_w_algorithmIdentifier_ECDSA_with_MD(WPACKET *pkt, int cont,
-                                            EC_KEY *ec, int mdnid)
+int ossl_DER_w_algorithmIdentifier_ECDSA_with_MD(WPACKET *pkt, int cont,
+                                                 EC_KEY *ec, int mdnid)
 {
     const unsigned char *precompiled = NULL;
     size_t precompiled_sz = 0;
@@ -44,8 +44,8 @@ int DER_w_algorithmIdentifier_ECDSA_with_MD(WPACKET *pkt, int cont,
         return 0;
     }
 
-    return DER_w_begin_sequence(pkt, cont)
+    return ossl_DER_w_begin_sequence(pkt, cont)
         /* No parameters (yet?) */
-        && DER_w_precompiled(pkt, -1, precompiled, precompiled_sz)
-        && DER_w_end_sequence(pkt, cont);
+        && ossl_DER_w_precompiled(pkt, -1, precompiled, precompiled_sz)
+        && ossl_DER_w_end_sequence(pkt, cont);
 }

--- a/providers/common/der/der_ec_sig.c
+++ b/providers/common/der/der_ec_sig.c
@@ -12,16 +12,16 @@
 #include "prov/der_ec.h"
 
 /* Aliases so we can have a uniform MD_CASE */
-#define der_oid_id_ecdsa_with_sha1   der_oid_ecdsa_with_SHA1
-#define der_oid_id_ecdsa_with_sha224 der_oid_ecdsa_with_SHA224
-#define der_oid_id_ecdsa_with_sha256 der_oid_ecdsa_with_SHA256
-#define der_oid_id_ecdsa_with_sha384 der_oid_ecdsa_with_SHA384
-#define der_oid_id_ecdsa_with_sha512 der_oid_ecdsa_with_SHA512
+#define ossl_der_oid_id_ecdsa_with_sha1   ossl_der_oid_ecdsa_with_SHA1
+#define ossl_der_oid_id_ecdsa_with_sha224 ossl_der_oid_ecdsa_with_SHA224
+#define ossl_der_oid_id_ecdsa_with_sha256 ossl_der_oid_ecdsa_with_SHA256
+#define ossl_der_oid_id_ecdsa_with_sha384 ossl_der_oid_ecdsa_with_SHA384
+#define ossl_der_oid_id_ecdsa_with_sha512 ossl_der_oid_ecdsa_with_SHA512
 
 #define MD_CASE(name)                                                   \
     case NID_##name:                                                    \
-        precompiled = der_oid_id_ecdsa_with_##name;                     \
-        precompiled_sz = sizeof(der_oid_id_ecdsa_with_##name);          \
+        precompiled = ossl_der_oid_id_ecdsa_with_##name;                \
+        precompiled_sz = sizeof(ossl_der_oid_id_ecdsa_with_##name);     \
         break;
 
 int ossl_DER_w_algorithmIdentifier_ECDSA_with_MD(WPACKET *pkt, int cont,

--- a/providers/common/der/der_ecx.h.in
+++ b/providers/common/der/der_ecx.h.in
@@ -17,7 +17,7 @@
                                        filter => \&oids_to_c::filter_to_H });
 -}
 
-int DER_w_algorithmIdentifier_ED25519(WPACKET *pkt, int cont, ECX_KEY *ec);
-int DER_w_algorithmIdentifier_ED448(WPACKET *pkt, int cont, ECX_KEY *ec);
-int DER_w_algorithmIdentifier_X25519(WPACKET *pkt, int cont, ECX_KEY *ec);
-int DER_w_algorithmIdentifier_X448(WPACKET *pkt, int cont, ECX_KEY *ec);
+int ossl_DER_w_algorithmIdentifier_ED25519(WPACKET *pkt, int cont, ECX_KEY *ec);
+int ossl_DER_w_algorithmIdentifier_ED448(WPACKET *pkt, int cont, ECX_KEY *ec);
+int ossl_DER_w_algorithmIdentifier_X25519(WPACKET *pkt, int cont, ECX_KEY *ec);
+int ossl_DER_w_algorithmIdentifier_X448(WPACKET *pkt, int cont, ECX_KEY *ec);

--- a/providers/common/der/der_ecx_key.c
+++ b/providers/common/der/der_ecx_key.c
@@ -11,38 +11,38 @@
 #include "internal/packet.h"
 #include "prov/der_ecx.h"
 
-int DER_w_algorithmIdentifier_X25519(WPACKET *pkt, int cont, ECX_KEY *ec)
+int ossl_DER_w_algorithmIdentifier_X25519(WPACKET *pkt, int cont, ECX_KEY *ec)
 {
-    return DER_w_begin_sequence(pkt, cont)
+    return ossl_DER_w_begin_sequence(pkt, cont)
         /* No parameters (yet?) */
-        && DER_w_precompiled(pkt, -1, der_oid_id_X25519,
-                             sizeof(der_oid_id_X25519))
-        && DER_w_end_sequence(pkt, cont);
+        && ossl_DER_w_precompiled(pkt, -1, der_oid_id_X25519,
+                                  sizeof(der_oid_id_X25519))
+        && ossl_DER_w_end_sequence(pkt, cont);
 }
 
-int DER_w_algorithmIdentifier_X448(WPACKET *pkt, int cont, ECX_KEY *ec)
+int ossl_DER_w_algorithmIdentifier_X448(WPACKET *pkt, int cont, ECX_KEY *ec)
 {
-    return DER_w_begin_sequence(pkt, cont)
+    return ossl_DER_w_begin_sequence(pkt, cont)
         /* No parameters (yet?) */
-        && DER_w_precompiled(pkt, -1, der_oid_id_X448,
-                             sizeof(der_oid_id_X448))
-        && DER_w_end_sequence(pkt, cont);
+        && ossl_DER_w_precompiled(pkt, -1, der_oid_id_X448,
+                                  sizeof(der_oid_id_X448))
+        && ossl_DER_w_end_sequence(pkt, cont);
 }
 
-int DER_w_algorithmIdentifier_ED25519(WPACKET *pkt, int cont, ECX_KEY *ec)
+int ossl_DER_w_algorithmIdentifier_ED25519(WPACKET *pkt, int cont, ECX_KEY *ec)
 {
-    return DER_w_begin_sequence(pkt, cont)
+    return ossl_DER_w_begin_sequence(pkt, cont)
         /* No parameters (yet?) */
-        && DER_w_precompiled(pkt, -1, der_oid_id_Ed25519,
-                             sizeof(der_oid_id_Ed25519))
-        && DER_w_end_sequence(pkt, cont);
+        && ossl_DER_w_precompiled(pkt, -1, der_oid_id_Ed25519,
+                                  sizeof(der_oid_id_Ed25519))
+        && ossl_DER_w_end_sequence(pkt, cont);
 }
 
-int DER_w_algorithmIdentifier_ED448(WPACKET *pkt, int cont, ECX_KEY *ec)
+int ossl_DER_w_algorithmIdentifier_ED448(WPACKET *pkt, int cont, ECX_KEY *ec)
 {
-    return DER_w_begin_sequence(pkt, cont)
+    return ossl_DER_w_begin_sequence(pkt, cont)
         /* No parameters (yet?) */
-        && DER_w_precompiled(pkt, -1, der_oid_id_Ed448,
-                             sizeof(der_oid_id_Ed448))
-        && DER_w_end_sequence(pkt, cont);
+        && ossl_DER_w_precompiled(pkt, -1, der_oid_id_Ed448,
+                                  sizeof(der_oid_id_Ed448))
+        && ossl_DER_w_end_sequence(pkt, cont);
 }

--- a/providers/common/der/der_ecx_key.c
+++ b/providers/common/der/der_ecx_key.c
@@ -15,8 +15,8 @@ int ossl_DER_w_algorithmIdentifier_X25519(WPACKET *pkt, int cont, ECX_KEY *ec)
 {
     return ossl_DER_w_begin_sequence(pkt, cont)
         /* No parameters (yet?) */
-        && ossl_DER_w_precompiled(pkt, -1, der_oid_id_X25519,
-                                  sizeof(der_oid_id_X25519))
+        && ossl_DER_w_precompiled(pkt, -1, ossl_der_oid_id_X25519,
+                                  sizeof(ossl_der_oid_id_X25519))
         && ossl_DER_w_end_sequence(pkt, cont);
 }
 
@@ -24,8 +24,8 @@ int ossl_DER_w_algorithmIdentifier_X448(WPACKET *pkt, int cont, ECX_KEY *ec)
 {
     return ossl_DER_w_begin_sequence(pkt, cont)
         /* No parameters (yet?) */
-        && ossl_DER_w_precompiled(pkt, -1, der_oid_id_X448,
-                                  sizeof(der_oid_id_X448))
+        && ossl_DER_w_precompiled(pkt, -1, ossl_der_oid_id_X448,
+                                  sizeof(ossl_der_oid_id_X448))
         && ossl_DER_w_end_sequence(pkt, cont);
 }
 
@@ -33,8 +33,8 @@ int ossl_DER_w_algorithmIdentifier_ED25519(WPACKET *pkt, int cont, ECX_KEY *ec)
 {
     return ossl_DER_w_begin_sequence(pkt, cont)
         /* No parameters (yet?) */
-        && ossl_DER_w_precompiled(pkt, -1, der_oid_id_Ed25519,
-                                  sizeof(der_oid_id_Ed25519))
+        && ossl_DER_w_precompiled(pkt, -1, ossl_der_oid_id_Ed25519,
+                                  sizeof(ossl_der_oid_id_Ed25519))
         && ossl_DER_w_end_sequence(pkt, cont);
 }
 
@@ -42,7 +42,7 @@ int ossl_DER_w_algorithmIdentifier_ED448(WPACKET *pkt, int cont, ECX_KEY *ec)
 {
     return ossl_DER_w_begin_sequence(pkt, cont)
         /* No parameters (yet?) */
-        && ossl_DER_w_precompiled(pkt, -1, der_oid_id_Ed448,
-                                  sizeof(der_oid_id_Ed448))
+        && ossl_DER_w_precompiled(pkt, -1, ossl_der_oid_id_Ed448,
+                                  sizeof(ossl_der_oid_id_Ed448))
         && ossl_DER_w_end_sequence(pkt, cont);
 }

--- a/providers/common/der/der_rsa.h.in
+++ b/providers/common/der/der_rsa.h.in
@@ -19,10 +19,10 @@
 -}
 
 /* PSS parameters */
-int DER_w_RSASSA_PSS_params(WPACKET *pkt, int tag,
-                            const RSA_PSS_PARAMS_30 *pss);
+int ossl_DER_w_RSASSA_PSS_params(WPACKET *pkt, int tag,
+                                 const RSA_PSS_PARAMS_30 *pss);
 /* Subject Public Key Info */
-int DER_w_algorithmIdentifier_RSA(WPACKET *pkt, int tag, RSA *rsa);
+int ossl_DER_w_algorithmIdentifier_RSA(WPACKET *pkt, int tag, RSA *rsa);
 /* Signature */
-int DER_w_algorithmIdentifier_MDWithRSAEncryption(WPACKET *pkt, int tag,
-                                                  RSA *rsa, int mdnid);
+int ossl_DER_w_algorithmIdentifier_MDWithRSAEncryption(WPACKET *pkt, int tag,
+                                                       RSA *rsa, int mdnid);

--- a/providers/common/der/der_rsa_key.c
+++ b/providers/common/der/der_rsa_key.c
@@ -64,66 +64,66 @@ const unsigned char der_aid_sha1Identifier[] = {
         DER_OID_SZ_id_sha224 + DER_SZ_NULL,                             \
         DER_OID_V_id_sha224,                                            \
         DER_V_NULL
-extern const unsigned char der_aid_sha224Identifier[];
-const unsigned char der_aid_sha224Identifier[] = {
+extern const unsigned char ossl_der_aid_sha224Identifier[];
+const unsigned char ossl_der_aid_sha224Identifier[] = {
     DER_AID_V_sha224Identifier
 };
-#define DER_AID_SZ_sha224Identifier sizeof(der_aid_sha224Identifier)
+#define DER_AID_SZ_sha224Identifier sizeof(ossl_der_aid_sha224Identifier)
 
 #define DER_AID_V_sha256Identifier                                      \
     DER_P_SEQUENCE|DER_F_CONSTRUCTED,                                   \
         DER_OID_SZ_id_sha256 + DER_SZ_NULL,                             \
         DER_OID_V_id_sha256,                                            \
         DER_V_NULL
-extern const unsigned char der_aid_sha256Identifier[];
-const unsigned char der_aid_sha256Identifier[] = {
+extern const unsigned char ossl_der_aid_sha256Identifier[];
+const unsigned char ossl_der_aid_sha256Identifier[] = {
     DER_AID_V_sha256Identifier
 };
-#define DER_AID_SZ_sha256Identifier sizeof(der_aid_sha256Identifier)
+#define DER_AID_SZ_sha256Identifier sizeof(ossl_der_aid_sha256Identifier)
 
 #define DER_AID_V_sha384Identifier                                      \
     DER_P_SEQUENCE|DER_F_CONSTRUCTED,                                   \
         DER_OID_SZ_id_sha384 + DER_SZ_NULL,                             \
         DER_OID_V_id_sha384,                                            \
         DER_V_NULL
-extern const unsigned char der_aid_sha384Identifier[];
-const unsigned char der_aid_sha384Identifier[] = {
+extern const unsigned char ossl_der_aid_sha384Identifier[];
+const unsigned char ossl_der_aid_sha384Identifier[] = {
     DER_AID_V_sha384Identifier
 };
-#define DER_AID_SZ_sha384Identifier sizeof(der_aid_sha384Identifier)
+#define DER_AID_SZ_sha384Identifier sizeof(ossl_der_aid_sha384Identifier)
 
 #define DER_AID_V_sha512Identifier                                      \
     DER_P_SEQUENCE|DER_F_CONSTRUCTED,                                   \
         DER_OID_SZ_id_sha512 + DER_SZ_NULL,                             \
         DER_OID_V_id_sha512,                                            \
         DER_V_NULL
-extern const unsigned char der_aid_sha512Identifier[];
-const unsigned char der_aid_sha512Identifier[] = {
+extern const unsigned char ossl_der_aid_sha512Identifier[];
+const unsigned char ossl_der_aid_sha512Identifier[] = {
     DER_AID_V_sha512Identifier
 };
-#define DER_AID_SZ_sha512Identifier sizeof(der_aid_sha512Identifier)
+#define DER_AID_SZ_sha512Identifier sizeof(ossl_der_aid_sha512Identifier)
 
 #define DER_AID_V_sha512_224Identifier                                  \
     DER_P_SEQUENCE|DER_F_CONSTRUCTED,                                   \
         DER_OID_SZ_id_sha512_224 + DER_SZ_NULL,                         \
         DER_OID_V_id_sha512_224,                                        \
         DER_V_NULL
-extern const unsigned char der_aid_sha512_224Identifier[];
-const unsigned char der_aid_sha512_224Identifier[] = {
+extern const unsigned char ossl_der_aid_sha512_224Identifier[];
+const unsigned char ossl_der_aid_sha512_224Identifier[] = {
     DER_AID_V_sha512_224Identifier
 };
-#define DER_AID_SZ_sha512_224Identifier sizeof(der_aid_sha512_224Identifier)
+#define DER_AID_SZ_sha512_224Identifier sizeof(ossl_der_aid_sha512_224Identifier)
 
 #define DER_AID_V_sha512_256Identifier                                  \
     DER_P_SEQUENCE|DER_F_CONSTRUCTED,                                   \
         DER_OID_SZ_id_sha512_256 + DER_SZ_NULL,                         \
         DER_OID_V_id_sha512_256,                                        \
         DER_V_NULL
-extern const unsigned char der_aid_sha512_256Identifier[];
-const unsigned char der_aid_sha512_256Identifier[] = {
+extern const unsigned char ossl_der_aid_sha512_256Identifier[];
+const unsigned char ossl_der_aid_sha512_256Identifier[] = {
     DER_AID_V_sha512_256Identifier
 };
-#define DER_AID_SZ_sha512_256Identifier sizeof(der_aid_sha512_256Identifier)
+#define DER_AID_SZ_sha512_256Identifier sizeof(ossl_der_aid_sha512_256Identifier)
 
 /*-
  * From https://tools.ietf.org/html/rfc8017#appendix-A.2.1
@@ -271,8 +271,8 @@ static int DER_w_MaskGenAlgorithm(WPACKET *pkt, int tag,
 
 #define OAEP_PSS_MD_CASE(name, var)                                     \
     case NID_##name:                                                    \
-        var = der_oid_id_##name;                                        \
-        var##_sz = sizeof(der_oid_id_##name);                           \
+        var = ossl_der_oid_id_##name;                                   \
+        var##_sz = sizeof(ossl_der_oid_id_##name);                      \
         break;
 
 int ossl_DER_w_RSASSA_PSS_params(WPACKET *pkt, int tag,
@@ -341,12 +341,12 @@ int ossl_DER_w_RSASSA_PSS_params(WPACKET *pkt, int tag,
 }
 
 /* Aliases so we can have a uniform RSA_CASE */
-#define der_oid_rsassaPss der_oid_id_RSASSA_PSS
+#define ossl_der_oid_rsassaPss ossl_der_oid_id_RSASSA_PSS
 
 #define RSA_CASE(name, var)                                             \
     var##_nid = NID_##name;                                             \
-    var##_oid = der_oid_##name;                                         \
-    var##_oid_sz = sizeof(der_oid_##name);                              \
+    var##_oid = ossl_der_oid_##name;                                    \
+    var##_oid_sz = sizeof(ossl_der_oid_##name);                         \
     break;
 
 int ossl_DER_w_algorithmIdentifier_RSA(WPACKET *pkt, int tag, RSA *rsa)

--- a/providers/common/der/der_rsa_key.c
+++ b/providers/common/der/der_rsa_key.c
@@ -264,7 +264,7 @@ static int DER_w_MaskGenAlgorithm(WPACKET *pkt, int tag,
         if (maskgenalg == NULL)
             return 1;
 
-        return DER_w_precompiled(pkt, tag, maskgenalg, maskgenalg_sz);
+        return ossl_DER_w_precompiled(pkt, tag, maskgenalg, maskgenalg_sz);
     }
     return 0;
 }
@@ -275,7 +275,8 @@ static int DER_w_MaskGenAlgorithm(WPACKET *pkt, int tag,
         var##_sz = sizeof(der_oid_id_##name);                           \
         break;
 
-int DER_w_RSASSA_PSS_params(WPACKET *pkt, int tag, const RSA_PSS_PARAMS_30 *pss)
+int ossl_DER_w_RSASSA_PSS_params(WPACKET *pkt, int tag,
+                                 const RSA_PSS_PARAMS_30 *pss)
 {
     int hashalg_nid, default_hashalg_nid;
     int saltlen, default_saltlen;
@@ -329,14 +330,14 @@ int DER_w_RSASSA_PSS_params(WPACKET *pkt, int tag, const RSA_PSS_PARAMS_30 *pss)
         return 0;
     }
 
-    return DER_w_begin_sequence(pkt, tag)
+    return ossl_DER_w_begin_sequence(pkt, tag)
         && (trailerfield == default_trailerfield
-            || DER_w_ulong(pkt, 3, trailerfield))
-        && (saltlen == default_saltlen || DER_w_ulong(pkt, 2, saltlen))
+            || ossl_DER_w_ulong(pkt, 3, trailerfield))
+        && (saltlen == default_saltlen || ossl_DER_w_ulong(pkt, 2, saltlen))
         && DER_w_MaskGenAlgorithm(pkt, 1, pss)
         && (hashalg_nid == default_hashalg_nid
-            || DER_w_precompiled(pkt, 0, hashalg, hashalg_sz))
-        && DER_w_end_sequence(pkt, tag);
+            || ossl_DER_w_precompiled(pkt, 0, hashalg, hashalg_sz))
+        && ossl_DER_w_end_sequence(pkt, tag);
 }
 
 /* Aliases so we can have a uniform RSA_CASE */
@@ -348,7 +349,7 @@ int DER_w_RSASSA_PSS_params(WPACKET *pkt, int tag, const RSA_PSS_PARAMS_30 *pss)
     var##_oid_sz = sizeof(der_oid_##name);                              \
     break;
 
-int DER_w_algorithmIdentifier_RSA(WPACKET *pkt, int tag, RSA *rsa)
+int ossl_DER_w_algorithmIdentifier_RSA(WPACKET *pkt, int tag, RSA *rsa)
 {
     int rsa_nid = NID_undef;
     const unsigned char *rsa_oid = NULL;
@@ -365,10 +366,10 @@ int DER_w_algorithmIdentifier_RSA(WPACKET *pkt, int tag, RSA *rsa)
     if (rsa_oid == NULL)
         return 0;
 
-    return DER_w_begin_sequence(pkt, tag)
+    return ossl_DER_w_begin_sequence(pkt, tag)
         && (rsa_nid != NID_rsassaPss
             || rsa_pss_params_30_is_unrestricted(pss_params)
-            || DER_w_RSASSA_PSS_params(pkt, -1, pss_params))
-        && DER_w_precompiled(pkt, -1, rsa_oid, rsa_oid_sz)
-        && DER_w_end_sequence(pkt, tag);
+            || ossl_DER_w_RSASSA_PSS_params(pkt, -1, pss_params))
+        && ossl_DER_w_precompiled(pkt, -1, rsa_oid, rsa_oid_sz)
+        && ossl_DER_w_end_sequence(pkt, tag);
 }

--- a/providers/common/der/der_rsa_sig.c
+++ b/providers/common/der/der_rsa_sig.c
@@ -28,8 +28,8 @@
         var##_sz = sizeof(der_oid_##name##WithRSAEncryption);           \
         break;
 
-int DER_w_algorithmIdentifier_MDWithRSAEncryption(WPACKET *pkt, int tag,
-                                                  RSA *rsa, int mdnid)
+int ossl_DER_w_algorithmIdentifier_MDWithRSAEncryption(WPACKET *pkt, int tag,
+                                                       RSA *rsa, int mdnid)
 {
     const unsigned char *precompiled = NULL;
     size_t precompiled_sz = 0;
@@ -57,8 +57,8 @@ int DER_w_algorithmIdentifier_MDWithRSAEncryption(WPACKET *pkt, int tag,
         return 0;
     }
 
-    return DER_w_begin_sequence(pkt, tag)
+    return ossl_DER_w_begin_sequence(pkt, tag)
         /* No parameters (yet?) */
-        && DER_w_precompiled(pkt, -1, precompiled, precompiled_sz)
-        && DER_w_end_sequence(pkt, tag);
+        && ossl_DER_w_precompiled(pkt, -1, precompiled, precompiled_sz)
+        && ossl_DER_w_end_sequence(pkt, tag);
 }

--- a/providers/common/der/der_rsa_sig.c
+++ b/providers/common/der/der_rsa_sig.c
@@ -13,19 +13,19 @@
 #include "prov/der_digests.h"
 
 /* Aliases so we can have a uniform MD_with_RSA_CASE */
-#define der_oid_sha3_224WithRSAEncryption \
-    der_oid_id_rsassa_pkcs1_v1_5_with_sha3_224
-#define der_oid_sha3_256WithRSAEncryption \
-    der_oid_id_rsassa_pkcs1_v1_5_with_sha3_256
-#define der_oid_sha3_384WithRSAEncryption \
-    der_oid_id_rsassa_pkcs1_v1_5_with_sha3_384
-#define der_oid_sha3_512WithRSAEncryption \
-    der_oid_id_rsassa_pkcs1_v1_5_with_sha3_512
+#define ossl_der_oid_sha3_224WithRSAEncryption \
+    ossl_der_oid_id_rsassa_pkcs1_v1_5_with_sha3_224
+#define ossl_der_oid_sha3_256WithRSAEncryption \
+    ossl_der_oid_id_rsassa_pkcs1_v1_5_with_sha3_256
+#define ossl_der_oid_sha3_384WithRSAEncryption \
+    ossl_der_oid_id_rsassa_pkcs1_v1_5_with_sha3_384
+#define ossl_der_oid_sha3_512WithRSAEncryption \
+    ossl_der_oid_id_rsassa_pkcs1_v1_5_with_sha3_512
 
 #define MD_with_RSA_CASE(name, var)                                     \
     case NID_##name:                                                    \
-        var = der_oid_##name##WithRSAEncryption;                        \
-        var##_sz = sizeof(der_oid_##name##WithRSAEncryption);           \
+        var = ossl_der_oid_##name##WithRSAEncryption;                   \
+        var##_sz = sizeof(ossl_der_oid_##name##WithRSAEncryption);      \
         break;
 
 int ossl_DER_w_algorithmIdentifier_MDWithRSAEncryption(WPACKET *pkt, int tag,

--- a/providers/common/der/der_sm2_key.c
+++ b/providers/common/der/der_sm2_key.c
@@ -14,10 +14,10 @@
 
 int DER_w_algorithmIdentifier_SM2(WPACKET *pkt, int cont, EC_KEY *ec)
 {
-    return DER_w_begin_sequence(pkt, cont)
+    return ossl_DER_w_begin_sequence(pkt, cont)
         /* No parameters (yet?) */
         /* It seems SM2 identifier is the same as id_ecPublidKey */
-        && DER_w_precompiled(pkt, -1, der_oid_id_ecPublicKey,
-                             sizeof(der_oid_id_ecPublicKey))
-        && DER_w_end_sequence(pkt, cont);
+        && ossl_DER_w_precompiled(pkt, -1, der_oid_id_ecPublicKey,
+                                  sizeof(der_oid_id_ecPublicKey))
+        && ossl_DER_w_end_sequence(pkt, cont);
 }

--- a/providers/common/der/der_sm2_key.c
+++ b/providers/common/der/der_sm2_key.c
@@ -17,7 +17,7 @@ int DER_w_algorithmIdentifier_SM2(WPACKET *pkt, int cont, EC_KEY *ec)
     return ossl_DER_w_begin_sequence(pkt, cont)
         /* No parameters (yet?) */
         /* It seems SM2 identifier is the same as id_ecPublidKey */
-        && ossl_DER_w_precompiled(pkt, -1, der_oid_id_ecPublicKey,
-                                  sizeof(der_oid_id_ecPublicKey))
+        && ossl_DER_w_precompiled(pkt, -1, ossl_der_oid_id_ecPublicKey,
+                                  sizeof(ossl_der_oid_id_ecPublicKey))
         && ossl_DER_w_end_sequence(pkt, cont);
 }

--- a/providers/common/der/der_sm2_sig.c
+++ b/providers/common/der/der_sm2_sig.c
@@ -32,8 +32,8 @@ int DER_w_algorithmIdentifier_SM2_with_MD(WPACKET *pkt, int cont,
         return 0;
     }
 
-    return DER_w_begin_sequence(pkt, cont)
+    return ossl_DER_w_begin_sequence(pkt, cont)
         /* No parameters (yet?) */
-        && DER_w_precompiled(pkt, -1, precompiled, precompiled_sz)
-        && DER_w_end_sequence(pkt, cont);
+        && ossl_DER_w_precompiled(pkt, -1, precompiled, precompiled_sz)
+        && ossl_DER_w_end_sequence(pkt, cont);
 }

--- a/providers/common/der/der_sm2_sig.c
+++ b/providers/common/der/der_sm2_sig.c
@@ -12,12 +12,12 @@
 #include "prov/der_sm2.h"
 
 /* Aliases so we can have a uniform MD_CASE */
-#define der_oid_id_sm2_with_sm3   der_oid_sm2_with_SM3
+#define ossl_der_oid_id_sm2_with_sm3   ossl_der_oid_sm2_with_SM3
 
 #define MD_CASE(name)                                                   \
     case NID_##name:                                                    \
-        precompiled = der_oid_id_sm2_with_##name;                     \
-        precompiled_sz = sizeof(der_oid_id_sm2_with_##name);          \
+        precompiled = ossl_der_oid_id_sm2_with_##name;                  \
+        precompiled_sz = sizeof(ossl_der_oid_id_sm2_with_##name);       \
         break;
 
 int DER_w_algorithmIdentifier_SM2_with_MD(WPACKET *pkt, int cont,

--- a/providers/common/der/oids_to_c.pm
+++ b/providers/common/der/oids_to_c.pm
@@ -40,7 +40,7 @@ sub filter_to_H {
 $C_comment
 #define DER_OID_V_${C_name} DER_P_OBJECT, $oid_size, ${C_bytes}
 #define DER_OID_SZ_${C_name} ${C_bytes_size}
-extern const unsigned char der_oid_${C_name}[DER_OID_SZ_${C_name}];
+extern const unsigned char ossl_der_oid_${C_name}[DER_OID_SZ_${C_name}];
 _____
 }
 
@@ -58,7 +58,7 @@ sub filter_to_C {
 
     return <<"_____";
 $C_comment
-const unsigned char der_oid_${C_name}[DER_OID_SZ_${C_name}] = {
+const unsigned char ossl_der_oid_${C_name}[DER_OID_SZ_${C_name}] = {
     DER_OID_V_${C_name}
 };
 _____

--- a/providers/implementations/encode_decode/encode_key2any.c
+++ b/providers/implementations/encode_decode/encode_key2any.c
@@ -657,7 +657,7 @@ static int prepare_rsa_params(const void *rsa, int nid,
                     }
                     break;
                 }
-                if (!DER_w_RSASSA_PSS_params(&pkt, -1, pss)
+                if (!ossl_DER_w_RSASSA_PSS_params(&pkt, -1, pss)
                     || !WPACKET_finish(&pkt)
                     || !WPACKET_get_total_written(&pkt, &str_sz))
                     goto err;

--- a/providers/implementations/kdfs/x942kdf.c
+++ b/providers/implementations/kdfs/x942kdf.c
@@ -94,14 +94,14 @@ static int DER_w_keyinfo(WPACKET *pkt,
                          const unsigned char *der_oid, size_t der_oidlen,
                          unsigned char **pcounter)
 {
-    return DER_w_begin_sequence(pkt, -1)
+    return ossl_DER_w_begin_sequence(pkt, -1)
            /* Store the initial value of 1 into the counter */
-           && DER_w_octet_string_uint32(pkt, -1, 1)
+           && ossl_DER_w_octet_string_uint32(pkt, -1, 1)
            /* Remember where we stored the counter in the buffer */
            && (pcounter == NULL
                || (*pcounter = WPACKET_get_curr(pkt)) != NULL)
-           && DER_w_precompiled(pkt, -1, der_oid, der_oidlen)
-           && DER_w_end_sequence(pkt, -1);
+           && ossl_DER_w_precompiled(pkt, -1, der_oid, der_oidlen)
+           && ossl_DER_w_end_sequence(pkt, -1);
 }
 
 static int der_encode_sharedinfo(WPACKET *pkt, unsigned char *buf, size_t buflen,
@@ -111,11 +111,11 @@ static int der_encode_sharedinfo(WPACKET *pkt, unsigned char *buf, size_t buflen
 {
     return (buf != NULL ? WPACKET_init_der(pkt, buf, buflen) :
                           WPACKET_init_null_der(pkt))
-           && DER_w_begin_sequence(pkt, -1)
-           && DER_w_octet_string_uint32(pkt, 2, keylen_bits)
-           && (ukm == NULL || DER_w_octet_string(pkt, 0, ukm, ukmlen))
+           && ossl_DER_w_begin_sequence(pkt, -1)
+           && ossl_DER_w_octet_string_uint32(pkt, 2, keylen_bits)
+           && (ukm == NULL || ossl_DER_w_octet_string(pkt, 0, ukm, ukmlen))
            && DER_w_keyinfo(pkt, der_oid, der_oidlen, pcounter)
-           && DER_w_end_sequence(pkt, -1)
+           && ossl_DER_w_end_sequence(pkt, -1)
            && WPACKET_finish(pkt);
 }
 

--- a/providers/implementations/kdfs/x942kdf.c
+++ b/providers/implementations/kdfs/x942kdf.c
@@ -58,12 +58,15 @@ static const struct {
     size_t oid_len;
     size_t keklen; /* size in bytes */
 } kek_algs[] = {
-    { "AES-128-WRAP", der_oid_id_aes128_wrap, DER_OID_SZ_id_aes128_wrap, 16 },
-    { "AES-192-WRAP", der_oid_id_aes192_wrap, DER_OID_SZ_id_aes192_wrap, 24 },
-    { "AES-256-WRAP", der_oid_id_aes256_wrap, DER_OID_SZ_id_aes256_wrap, 32 },
-#ifndef FIPS_MODULE
-    { "DES3-WRAP", der_oid_id_alg_CMS3DESwrap, DER_OID_SZ_id_alg_CMS3DESwrap,
+    { "AES-128-WRAP", ossl_der_oid_id_aes128_wrap, DER_OID_SZ_id_aes128_wrap,
+      16 },
+    { "AES-192-WRAP", ossl_der_oid_id_aes192_wrap, DER_OID_SZ_id_aes192_wrap,
       24 },
+    { "AES-256-WRAP", ossl_der_oid_id_aes256_wrap, DER_OID_SZ_id_aes256_wrap,
+      32 },
+#ifndef FIPS_MODULE
+    { "DES3-WRAP", ossl_der_oid_id_alg_CMS3DESwrap,
+      DER_OID_SZ_id_alg_CMS3DESwrap, 24 },
 #endif
 };
 

--- a/providers/implementations/signature/dsa.c
+++ b/providers/implementations/signature/dsa.c
@@ -157,8 +157,8 @@ static int dsa_setup_md(PROV_DSA_CTX *ctx,
          */
         ctx->aid_len = 0;
         if (WPACKET_init_der(&pkt, ctx->aid_buf, sizeof(ctx->aid_buf))
-            && DER_w_algorithmIdentifier_DSA_with_MD(&pkt, -1, ctx->dsa,
-                                                     md_nid)
+            && ossl_DER_w_algorithmIdentifier_DSA_with_MD(&pkt, -1, ctx->dsa,
+                                                          md_nid)
             && WPACKET_finish(&pkt)) {
             WPACKET_get_total_written(&pkt, &ctx->aid_len);
             ctx->aid = WPACKET_get_curr(&pkt);

--- a/providers/implementations/signature/ecdsa.c
+++ b/providers/implementations/signature/ecdsa.c
@@ -233,7 +233,8 @@ static int ecdsa_digest_signverify_init(void *vctx, const char *mdname,
      */
     ctx->aid_len = 0;
     if (WPACKET_init_der(&pkt, ctx->aid_buf, sizeof(ctx->aid_buf))
-        && DER_w_algorithmIdentifier_ECDSA_with_MD(&pkt, -1, ctx->ec, md_nid)
+        && ossl_DER_w_algorithmIdentifier_ECDSA_with_MD(&pkt, -1, ctx->ec,
+                                                        md_nid)
         && WPACKET_finish(&pkt)) {
         WPACKET_get_total_written(&pkt, &ctx->aid_len);
         ctx->aid = WPACKET_get_curr(&pkt);

--- a/providers/implementations/signature/eddsa.c
+++ b/providers/implementations/signature/eddsa.c
@@ -94,10 +94,10 @@ static int eddsa_digest_signverify_init(void *vpeddsactx, const char *mdname,
     ret = WPACKET_init_der(&pkt, peddsactx->aid_buf, sizeof(peddsactx->aid_buf));
     switch (edkey->type) {
     case ECX_KEY_TYPE_ED25519:
-        ret = ret && DER_w_algorithmIdentifier_ED25519(&pkt, -1, edkey);
+        ret = ret && ossl_DER_w_algorithmIdentifier_ED25519(&pkt, -1, edkey);
         break;
     case ECX_KEY_TYPE_ED448:
-        ret = ret && DER_w_algorithmIdentifier_ED448(&pkt, -1, edkey);
+        ret = ret && ossl_DER_w_algorithmIdentifier_ED448(&pkt, -1, edkey);
         break;
     default:
         /* Should never happen */

--- a/providers/implementations/signature/rsa.c
+++ b/providers/implementations/signature/rsa.c
@@ -221,8 +221,9 @@ static int rsa_setup_md(PROV_RSA_CTX *ctx, const char *mdname,
          */
         ctx->aid_len = 0;
         if (WPACKET_init_der(&pkt, ctx->aid_buf, sizeof(ctx->aid_buf))
-            && DER_w_algorithmIdentifier_MDWithRSAEncryption(&pkt, -1, ctx->rsa,
-                                                             md_nid)
+            && ossl_DER_w_algorithmIdentifier_MDWithRSAEncryption(&pkt, -1,
+                                                                  ctx->rsa,
+                                                                  md_nid)
             && WPACKET_finish(&pkt)) {
             WPACKET_get_total_written(&pkt, &ctx->aid_len);
             ctx->aid = WPACKET_get_curr(&pkt);

--- a/providers/implementations/storemgmt/file_store.c
+++ b/providers/implementations/storemgmt/file_store.c
@@ -557,7 +557,8 @@ static int file_setup_decoders(struct file_ctx_st *ctx)
          * The decoder doesn't need any identification or to be attached to
          * any provider, since it's only used locally.
          */
-        to_obj = ossl_decoder_from_dispatch(0, &der_to_obj_algorithm, NULL);
+        to_obj = ossl_decoder_from_dispatch(0, &ossl_der_to_obj_algorithm,
+                                            NULL);
         if (to_obj == NULL)
             goto err;
         to_obj_inst = ossl_decoder_instance_new(to_obj, ctx->provctx);

--- a/providers/implementations/storemgmt/file_store_der2obj.c
+++ b/providers/implementations/storemgmt/file_store_der2obj.c
@@ -130,5 +130,5 @@ static const OSSL_DISPATCH der_to_obj_decoder_functions[] = {
     { 0, NULL }
 };
 
-const OSSL_ALGORITHM der_to_obj_algorithm =
+const OSSL_ALGORITHM ossl_der_to_obj_algorithm =
     { "obj", NULL, der_to_obj_decoder_functions };

--- a/providers/implementations/storemgmt/file_store_local.h
+++ b/providers/implementations/storemgmt/file_store_local.h
@@ -7,5 +7,5 @@
  * https://www.openssl.org/source/license.html
  */
 
-extern const OSSL_ALGORITHM der_to_obj_algorithm;
+extern const OSSL_ALGORITHM ossl_der_to_obj_algorithm;
 

--- a/test/asn1_dsa_internal_test.c
+++ b/test/asn1_dsa_internal_test.c
@@ -93,7 +93,7 @@ static int test_decode(void)
 
     /* Positive tests */
     pder = t_dsa_sig;
-    if (decode_der_dsa_sig(r, s, &pder, sizeof(t_dsa_sig)) == 0
+    if (ossl_decode_der_dsa_sig(r, s, &pder, sizeof(t_dsa_sig)) == 0
             || !TEST_ptr_eq(pder, (t_dsa_sig + sizeof(t_dsa_sig)))
             || !TEST_BN_eq_word(r, 1) || !TEST_BN_eq_word(s, 2)) {
         TEST_info("asn1_dsa test_decode: t_dsa_sig failed");
@@ -103,7 +103,7 @@ static int test_decode(void)
     BN_clear(r);
     BN_clear(s);
     pder = t_dsa_sig_extra;
-    if (decode_der_dsa_sig(r, s, &pder, sizeof(t_dsa_sig_extra)) == 0
+    if (ossl_decode_der_dsa_sig(r, s, &pder, sizeof(t_dsa_sig_extra)) == 0
             || !TEST_ptr_eq(pder,
                             (t_dsa_sig_extra + sizeof(t_dsa_sig_extra) - 2))
             || !TEST_BN_eq_word(r, 1) || !TEST_BN_eq_word(s, 2)) {
@@ -114,7 +114,7 @@ static int test_decode(void)
     BN_clear(r);
     BN_clear(s);
     pder = t_dsa_sig_msb;
-    if (decode_der_dsa_sig(r, s, &pder, sizeof(t_dsa_sig_msb)) == 0
+    if (ossl_decode_der_dsa_sig(r, s, &pder, sizeof(t_dsa_sig_msb)) == 0
             || !TEST_ptr_eq(pder, (t_dsa_sig_msb + sizeof(t_dsa_sig_msb)))
             || !TEST_BN_eq_word(r, 0x81) || !TEST_BN_eq_word(s, 0x82)) {
         TEST_info("asn1_dsa test_decode: t_dsa_sig_msb failed");
@@ -124,7 +124,7 @@ static int test_decode(void)
     BN_clear(r);
     BN_clear(s);
     pder = t_dsa_sig_two;
-    if (decode_der_dsa_sig(r, s, &pder, sizeof(t_dsa_sig_two)) == 0
+    if (ossl_decode_der_dsa_sig(r, s, &pder, sizeof(t_dsa_sig_two)) == 0
             || !TEST_ptr_eq(pder, (t_dsa_sig_two + sizeof(t_dsa_sig_two)))
             || !TEST_BN_eq_word(r, 0x100) || !TEST_BN_eq_word(s, 0x200)) {
         TEST_info("asn1_dsa test_decode: t_dsa_sig_two failed");
@@ -133,7 +133,7 @@ static int test_decode(void)
 
     /* Negative tests */
     pder = t_invalid_int_zero;
-    if (decode_der_dsa_sig(r, s, &pder, sizeof(t_invalid_int_zero)) != 0) {
+    if (ossl_decode_der_dsa_sig(r, s, &pder, sizeof(t_invalid_int_zero)) != 0) {
         TEST_info("asn1_dsa test_decode: Expected t_invalid_int_zero to fail");
         goto fail;
     }
@@ -141,7 +141,7 @@ static int test_decode(void)
     BN_clear(r);
     BN_clear(s);
     pder = t_invalid_int;
-    if (decode_der_dsa_sig(r, s, &pder, sizeof(t_invalid_int)) != 0) {
+    if (ossl_decode_der_dsa_sig(r, s, &pder, sizeof(t_invalid_int)) != 0) {
         TEST_info("asn1_dsa test_decode: Expected t_invalid_int to fail");
         goto fail;
     }
@@ -149,7 +149,7 @@ static int test_decode(void)
     BN_clear(r);
     BN_clear(s);
     pder = t_neg_int;
-    if (decode_der_dsa_sig(r, s, &pder, sizeof(t_neg_int)) != 0) {
+    if (ossl_decode_der_dsa_sig(r, s, &pder, sizeof(t_neg_int)) != 0) {
         TEST_info("asn1_dsa test_decode: Expected t_neg_int to fail");
         goto fail;
     }
@@ -157,7 +157,7 @@ static int test_decode(void)
     BN_clear(r);
     BN_clear(s);
     pder = t_trunc_der;
-    if (decode_der_dsa_sig(r, s, &pder, sizeof(t_trunc_der)) != 0) {
+    if (ossl_decode_der_dsa_sig(r, s, &pder, sizeof(t_trunc_der)) != 0) {
         TEST_info("asn1_dsa test_decode: Expected fail t_trunc_der");
         goto fail;
     }
@@ -165,7 +165,7 @@ static int test_decode(void)
     BN_clear(r);
     BN_clear(s);
     pder = t_trunc_seq;
-    if (decode_der_dsa_sig(r, s, &pder, sizeof(t_trunc_seq)) != 0) {
+    if (ossl_decode_der_dsa_sig(r, s, &pder, sizeof(t_trunc_seq)) != 0) {
         TEST_info("asn1_dsa test_decode: Expected fail t_trunc_seq");
         goto fail;
     }


### PR DESCRIPTION
Functions renamed are:
```
der_aid_sha224Identifier, der_aid_sha256Identifier, der_aid_sha384Identifier, der_aid_sha512Identifier,
der_aid_sha512_224Identifier, der_aid_sha512_256Identifier, der_oid_c2onb191v4, der_oid_c2onb191v5, der_oid_c2onb239v4,
der_oid_c2onb239v5, der_oid_c2pnb163v1, der_oid_c2pnb163v2, der_oid_c2pnb163v3, der_oid_c2pnb176w1, der_oid_c2pnb208w1,
der_oid_c2pnb272w1, der_oid_c2pnb304w1, der_oid_c2pnb368w1, der_oid_c2tnb191v1, der_oid_c2tnb191v2, der_oid_c2tnb191v3,
der_oid_c2tnb239v1, der_oid_c2tnb239v2, der_oid_c2tnb239v3, der_oid_c2tnb359v1, der_oid_c2tnb431r1, der_oid_hashAlgs,
der_oid_id_Ed25519, der_oid_id_Ed448, der_oid_id_KMACWithSHAKE128, der_oid_id_KMACWithSHAKE256, der_oid_id_RSAES_OAEP,
der_oid_id_RSASSA_PSS, der_oid_id_X25519, der_oid_id_X448, der_oid_id_aes128_wrap, der_oid_id_aes192_wrap, der_oid_id_aes256_wrap,
der_oid_id_alg_CMS3DESwrap, der_oid_id_dsa, der_oid_id_dsa_with_sha1, der_oid_id_dsa_with_sha224, der_oid_id_dsa_with_sha256,
der_oid_id_dsa_with_sha384, der_oid_id_dsa_with_sha3_224, der_oid_id_dsa_with_sha3_256, der_oid_id_dsa_with_sha3_384,
der_oid_id_dsa_with_sha3_512, der_oid_id_dsa_with_sha512, der_oid_id_ecPublicKey, der_oid_id_ecdsa_with_sha3_224,
der_oid_id_ecdsa_with_sha3_256, der_oid_id_ecdsa_with_sha3_384, der_oid_id_ecdsa_with_sha3_512, der_oid_id_md2, der_oid_id_md5,
der_oid_id_mgf1, der_oid_id_pSpecified, der_oid_id_rsassa_pkcs1_v1_5_with_sha3_224, der_oid_id_rsassa_pkcs1_v1_5_with_sha3_256,
der_oid_id_rsassa_pkcs1_v1_5_with_sha3_384, der_oid_id_rsassa_pkcs1_v1_5_with_sha3_512, der_oid_id_sha1, der_oid_id_sha224,
der_oid_id_sha256, der_oid_id_sha384, der_oid_id_sha3_224, der_oid_id_sha3_256, der_oid_id_sha3_384, der_oid_id_sha3_512,
der_oid_id_sha512, der_oid_id_sha512_224, der_oid_id_sha512_256, der_oid_id_shake128, der_oid_id_shake128_len,
der_oid_id_shake256, der_oid_id_shake256_len, der_oid_md2WithRSAEncryption, der_oid_md4WithRSAEncryption,
der_oid_md5WithRSAEncryption, der_oid_prime192v1, der_oid_prime192v2, der_oid_prime192v3, der_oid_prime239v1,
der_oid_prime239v2, der_oid_prime239v3, der_oid_prime256v1, der_oid_ripemd160WithRSAEncryption, der_oid_rsaEncryption,
der_oid_sha1WithRSAEncryption, der_oid_sha224WithRSAEncryption, der_oid_sha256WithRSAEncryption, der_oid_sha384WithRSAEncryption,
der_oid_sha512WithRSAEncryption, der_oid_sha512_224WithRSAEncryption, der_oid_sha512_256WithRSAEncryption, der_oid_sigAlgs,
der_to_obj_algorithm, decode_der_dsa_sig, decode_der_integer, decode_der_length, DER_w_RSASSA_PSS_params,
DER_w_algorithmIdentifier_DSA, DER_w_algorithmIdentifier_DSA_with_MD, DER_w_algorithmIdentifier_EC,
DER_w_algorithmIdentifier_ECDSA_with_MD, DER_w_algorithmIdentifier_ED25519, DER_w_algorithmIdentifier_ED448,
DER_w_algorithmIdentifier_MDWithRSAEncryption, DER_w_algorithmIdentifier_RSA, DER_w_algorithmIdentifier_X25519,
DER_w_algorithmIdentifier_X448, DER_w_begin_sequence, DER_w_bn, DER_w_boolean, DER_w_end_sequence, DER_w_null, DER_w_octet_string,
DER_w_octet_string_uint32, DER_w_precompiled and DER_w_ulong.

```
- [x] documentation is added or updated
- [x] tests are added or updated
