### PR TITLE
ffc: add _ossl to exported but internal functions

### DIFF
--- a/crypto/dh/dh_ameth.c
+++ b/crypto/dh/dh_ameth.c
@@ -320,7 +320,7 @@ static int do_dh_print(BIO *bp, const DH *x, int indent, int ptype)
     if (!ASN1_bn_print(bp, "public-key:", pub_key, NULL, indent))
         goto err;
 
-    if (!ffc_params_print(bp, &x->params, indent))
+    if (!ossl_ffc_params_print(bp, &x->params, indent))
         goto err;
 
     if (x->length != 0) {
@@ -354,15 +354,15 @@ static int dh_security_bits(const EVP_PKEY *pkey)
 
 static int dh_cmp_parameters(const EVP_PKEY *a, const EVP_PKEY *b)
 {
-    return ffc_params_cmp(&a->pkey.dh->params, &a->pkey.dh->params,
-                          a->ameth != &dhx_asn1_meth);
+    return ossl_ffc_params_cmp(&a->pkey.dh->params, &a->pkey.dh->params,
+                               a->ameth != &dhx_asn1_meth);
 }
 
 static int int_dh_param_copy(DH *to, const DH *from, int is_x942)
 {
     if (is_x942 == -1)
         is_x942 = (from->params.q != NULL);
-    if (!ffc_params_copy(&to->params, &from->params))
+    if (!ossl_ffc_params_copy(&to->params, &from->params))
         return 0;
     if (!is_x942)
         to->length = from->length;

--- a/crypto/dh/dh_asn1.c
+++ b/crypto/dh/dh_asn1.c
@@ -108,13 +108,14 @@ DH *d2i_DHxparams(DH **a, const unsigned char **pp, long length)
 
     params = &dh->params;
     DH_set0_pqg(dh, dhx->p, dhx->q, dhx->g);
-    ffc_params_set0_j(params, dhx->j);
+    ossl_ffc_params_set0_j(params, dhx->j);
 
     if (dhx->vparams != NULL) {
         /* The counter has a maximum value of 4 * numbits(p) - 1 */
         size_t counter = (size_t)BN_get_word(dhx->vparams->counter);
-        ffc_params_set_validate_params(params, dhx->vparams->seed->data,
-                                       dhx->vparams->seed->length, counter);
+        ossl_ffc_params_set_validate_params(params, dhx->vparams->seed->data,
+                                            dhx->vparams->seed->length,
+                                            counter);
         ASN1_BIT_STRING_free(dhx->vparams->seed);
         BN_free(dhx->vparams->counter);
         OPENSSL_free(dhx->vparams);
@@ -135,10 +136,10 @@ int i2d_DHxparams(const DH *dh, unsigned char **pp)
     const FFC_PARAMS *params = &dh->params;
     int counter;
 
-    ffc_params_get0_pqg(params, (const BIGNUM **)&dhx.p,
-                        (const BIGNUM **)&dhx.q, (const BIGNUM **)&dhx.g);
+    ossl_ffc_params_get0_pqg(params, (const BIGNUM **)&dhx.p,
+                             (const BIGNUM **)&dhx.q, (const BIGNUM **)&dhx.g);
     dhx.j = params->j;
-    ffc_params_get_validate_params(params, &seed.data, &seedlen, &counter);
+    ossl_ffc_params_get_validate_params(params, &seed.data, &seedlen, &counter);
     seed.length = (int)seedlen;
 
     if (counter != -1 && seed.data != NULL && seed.length > 0) {

--- a/crypto/dh/dh_check.c
+++ b/crypto/dh/dh_check.c
@@ -62,8 +62,8 @@ int DH_check_params(const DH *dh, int *ret)
      * (2b) FFC domain params conform to FIPS-186-4 explicit domain param
      * validity tests.
      */
-    return ffc_params_FIPS186_4_validate(dh->libctx, &dh->params,
-                                         FFC_PARAM_TYPE_DH, ret, NULL);
+    return ossl_ffc_params_FIPS186_4_validate(dh->libctx, &dh->params,
+                                              FFC_PARAM_TYPE_DH, ret, NULL);
 }
 #else
 int DH_check_params(const DH *dh, int *ret)
@@ -235,7 +235,7 @@ int DH_check_pub_key_ex(const DH *dh, const BIGNUM *pub_key)
  */
 int DH_check_pub_key(const DH *dh, const BIGNUM *pub_key, int *ret)
 {
-    return ffc_validate_public_key(&dh->params, pub_key, ret);
+    return ossl_ffc_validate_public_key(&dh->params, pub_key, ret);
 }
 
 /*
@@ -245,7 +245,7 @@ int DH_check_pub_key(const DH *dh, const BIGNUM *pub_key, int *ret)
  */
 int dh_check_pub_key_partial(const DH *dh, const BIGNUM *pub_key, int *ret)
 {
-    return ffc_validate_public_key_partial(&dh->params, pub_key, ret);
+    return ossl_ffc_validate_public_key_partial(&dh->params, pub_key, ret);
 }
 
 int dh_check_priv_key(const DH *dh, const BIGNUM *priv_key, int *ret)
@@ -268,7 +268,7 @@ int dh_check_priv_key(const DH *dh, const BIGNUM *priv_key, int *ret)
         if (BN_cmp(two_powN, dh->params.q) < 0)
             upper = two_powN;
     }
-    if (!ffc_validate_private_key(upper, priv_key, ret))
+    if (!ossl_ffc_validate_private_key(upper, priv_key, ret))
         goto err;
 
     ok = 1;

--- a/crypto/dh/dh_ctrl.c
+++ b/crypto/dh/dh_ctrl.c
@@ -179,7 +179,7 @@ int EVP_PKEY_CTX_set_dh_rfc5114(EVP_PKEY_CTX *ctx, int gen)
     if (ctx->op.keymgmt.genctx == NULL)
         return EVP_PKEY_CTX_ctrl(ctx, EVP_PKEY_DHX, EVP_PKEY_OP_PARAMGEN,
                                  EVP_PKEY_CTRL_DH_RFC5114, gen, NULL);
-    name = ffc_named_group_from_uid(gen);
+    name = ossl_ffc_named_group_from_uid(gen);
     if (name == NULL)
         return 0;
 
@@ -208,7 +208,7 @@ int EVP_PKEY_CTX_set_dh_nid(EVP_PKEY_CTX *ctx, int nid)
         return EVP_PKEY_CTX_ctrl(ctx, EVP_PKEY_DH,
                                  EVP_PKEY_OP_PARAMGEN | EVP_PKEY_OP_KEYGEN,
                                  EVP_PKEY_CTRL_DH_NID, nid, NULL);
-    name = ffc_named_group_from_uid(nid);
+    name = ossl_ffc_named_group_from_uid(nid);
     if (name == NULL)
         return 0;
 

--- a/crypto/dh/dh_gen.c
+++ b/crypto/dh/dh_gen.c
@@ -42,14 +42,14 @@ int dh_generate_ffc_parameters(DH *dh, int type, int pbits, int qbits,
 
 #ifndef FIPS_MODULE
     if (type == DH_PARAMGEN_TYPE_FIPS_186_2)
-        ret = ffc_params_FIPS186_2_generate(dh->libctx, &dh->params,
-                                            FFC_PARAM_TYPE_DH,
-                                            pbits, qbits, &res, cb);
+        ret = ossl_ffc_params_FIPS186_2_generate(dh->libctx, &dh->params,
+                                                 FFC_PARAM_TYPE_DH,
+                                                 pbits, qbits, &res, cb);
     else
 #endif
-        ret = ffc_params_FIPS186_4_generate(dh->libctx, &dh->params,
-                                            FFC_PARAM_TYPE_DH,
-                                            pbits, qbits, &res, cb);
+        ret = ossl_ffc_params_FIPS186_4_generate(dh->libctx, &dh->params,
+                                                 FFC_PARAM_TYPE_DH,
+                                                 pbits, qbits, &res, cb);
     if (ret > 0)
         dh->dirty_cnt++;
     return ret;
@@ -102,7 +102,7 @@ static int dh_gen_named_group(OPENSSL_CTX *libctx, DH *ret, int prime_len)
 
     dh = dh_new_by_nid_ex(libctx, nid);
     if (dh != NULL
-        && ffc_params_copy(&ret->params, &dh->params)) {
+        && ossl_ffc_params_copy(&ret->params, &dh->params)) {
         ok = 1;
         ret->dirty_cnt++;
     }

--- a/crypto/dh/dh_group_params.c
+++ b/crypto/dh/dh_group_params.c
@@ -78,7 +78,7 @@ static const DH_NAMED_GROUP dh_named_groups[] = {
 #endif
 };
 
-int ffc_named_group_to_uid(const char *name)
+int ossl_ffc_named_group_to_uid(const char *name)
 {
     size_t i;
 
@@ -89,7 +89,7 @@ int ffc_named_group_to_uid(const char *name)
     return NID_undef;
 }
 
-const char *ffc_named_group_from_uid(int uid)
+const char *ossl_ffc_named_group_from_uid(int uid)
 {
     size_t i;
 
@@ -138,7 +138,7 @@ static DH *dh_new_by_group_name(OPENSSL_CTX *libctx, const char *name)
 
 DH *dh_new_by_nid_ex(OPENSSL_CTX *libctx, int nid)
 {
-    const char *name = ffc_named_group_from_uid(nid);
+    const char *name = ossl_ffc_named_group_from_uid(nid);
 
     return dh_new_by_group_name(libctx, name);
 }
@@ -148,7 +148,7 @@ DH *DH_new_by_nid(int nid)
     return dh_new_by_nid_ex(NULL, nid);
 }
 
-int ffc_set_group_pqg(FFC_PARAMS *ffc, const char *group_name)
+int ossl_ffc_set_group_pqg(FFC_PARAMS *ffc, const char *group_name)
 {
     int i;
     BIGNUM *q = NULL;
@@ -158,10 +158,10 @@ int ffc_set_group_pqg(FFC_PARAMS *ffc, const char *group_name)
 
     for (i = 0; i < (int)OSSL_NELEM(dh_named_groups); ++i) {
         if (strcasecmp(dh_named_groups[i].name, group_name) == 0) {
-            ffc_params_set0_pqg(ffc,
-                                (BIGNUM *)dh_named_groups[i].p,
-                                (BIGNUM *)dh_named_groups[i].q,
-                                (BIGNUM *)dh_named_groups[i].g);
+            ossl_ffc_params_set0_pqg(ffc,
+                                     (BIGNUM *)dh_named_groups[i].p,
+                                     (BIGNUM *)dh_named_groups[i].q,
+                                     (BIGNUM *)dh_named_groups[i].g);
             /* flush the cached nid, The DH layer is responsible for caching */
             ffc->nid = NID_undef;
             return 1;

--- a/crypto/dh/dh_key.c
+++ b/crypto/dh/dh_key.c
@@ -155,7 +155,7 @@ static int dh_bn_mod_exp(const DH *dh, BIGNUM *r,
 static int dh_init(DH *dh)
 {
     dh->flags |= DH_FLAG_CACHE_MONT_P;
-    ffc_params_init(&dh->params);
+    ossl_ffc_params_init(&dh->params);
     dh->dirty_cnt++;
     return 1;
 }
@@ -260,8 +260,8 @@ static int generate_key(DH *dh)
                 || dh->length > BN_num_bits(dh->params.q))
                 goto err;
             /* dh->length = maximum bit length of generated private key */
-            if (!ffc_generate_private_key(ctx, &dh->params, dh->length,
-                                          max_strength, priv_key))
+            if (!ossl_ffc_generate_private_key(ctx, &dh->params, dh->length,
+                                               max_strength, priv_key))
                 goto err;
         } else {
 #ifdef FIPS_MODULE
@@ -288,18 +288,18 @@ static int generate_key(DH *dh)
 #endif
             {
                 /* Do a partial check for invalid p, q, g */
-                if (!ffc_params_simple_validate(dh->libctx, &dh->params,
-                                                FFC_PARAM_TYPE_DH))
+                if (!ossl_ffc_params_simple_validate(dh->libctx, &dh->params,
+                                                     FFC_PARAM_TYPE_DH))
                     goto err;
                 /*
                  * For FFC FIPS 186-4 keygen
                  * security strength s = 112,
                  * Max Private key size N = len(q)
                  */
-                if (!ffc_generate_private_key(ctx, &dh->params,
-                                              BN_num_bits(dh->params.q),
-                                              MIN_STRENGTH,
-                                              priv_key))
+                if (!ossl_ffc_generate_private_key(ctx, &dh->params,
+                                                   BN_num_bits(dh->params.q),
+                                                   MIN_STRENGTH,
+                                                   priv_key))
                     goto err;
             }
         }

--- a/crypto/dh/dh_lib.c
+++ b/crypto/dh/dh_lib.c
@@ -149,7 +149,7 @@ void DH_free(DH *r)
 
     CRYPTO_THREAD_lock_free(r->lock);
 
-    ffc_params_cleanup(&r->params);
+    ossl_ffc_params_cleanup(&r->params);
     BN_clear_free(r->pub_key);
     BN_clear_free(r->priv_key);
     OPENSSL_free(r);
@@ -204,7 +204,7 @@ int DH_security_bits(const DH *dh)
 void DH_get0_pqg(const DH *dh,
                  const BIGNUM **p, const BIGNUM **q, const BIGNUM **g)
 {
-    ffc_params_get0_pqg(&dh->params, p, q, g);
+    ossl_ffc_params_get0_pqg(&dh->params, p, q, g);
 }
 
 int DH_set0_pqg(DH *dh, BIGNUM *p, BIGNUM *q, BIGNUM *g)
@@ -217,7 +217,7 @@ int DH_set0_pqg(DH *dh, BIGNUM *p, BIGNUM *q, BIGNUM *g)
         || (dh->params.g == NULL && g == NULL))
         return 0;
 
-    ffc_params_set0_pqg(&dh->params, p, q, g);
+    ossl_ffc_params_set0_pqg(&dh->params, p, q, g);
     dh_cache_named_group(dh);
     if (q != NULL)
         dh->length = BN_num_bits(q);
@@ -337,7 +337,7 @@ int dh_ffc_params_fromdata(DH *dh, const OSSL_PARAM params[])
     if (ffc == NULL)
         return 0;
 
-    ret = ffc_params_fromdata(ffc, params);
+    ret = ossl_ffc_params_fromdata(ffc, params);
     if (ret) {
         dh_cache_named_group(dh);
         dh->dirty_cnt++;

--- a/crypto/dh/dh_pmeth.c
+++ b/crypto/dh/dh_pmeth.c
@@ -297,20 +297,22 @@ static DH *ffc_params_generate(OPENSSL_CTX *libctx, DH_PKEY_CTX *dctx,
     }
 
     if (dctx->md != NULL)
-        ffc_set_digest(&ret->params, EVP_MD_name(dctx->md), NULL);
+        ossl_ffc_set_digest(&ret->params, EVP_MD_name(dctx->md), NULL);
 
 # ifndef FIPS_MODULE
     if (dctx->paramgen_type == DH_PARAMGEN_TYPE_FIPS_186_2)
-        rv = ffc_params_FIPS186_2_generate(libctx, &ret->params,
-                                           FFC_PARAM_TYPE_DH,
-                                           prime_len, subprime_len, &res, pcb);
+        rv = ossl_ffc_params_FIPS186_2_generate(libctx, &ret->params,
+                                                FFC_PARAM_TYPE_DH,
+                                                prime_len, subprime_len, &res,
+                                                pcb);
     else
 # endif
     /* For FIPS we always use the DH_PARAMGEN_TYPE_FIPS_186_4 generator */
     if (dctx->paramgen_type >= DH_PARAMGEN_TYPE_FIPS_186_2)
-        rv = ffc_params_FIPS186_4_generate(libctx, &ret->params,
-                                           FFC_PARAM_TYPE_DH,
-                                           prime_len, subprime_len, &res, pcb);
+        rv = ossl_ffc_params_FIPS186_4_generate(libctx, &ret->params,
+                                                FFC_PARAM_TYPE_DH,
+                                                prime_len, subprime_len, &res,
+                                                pcb);
     if (rv <= 0) {
         DH_free(ret);
         return NULL;

--- a/crypto/dsa/dsa_ameth.c
+++ b/crypto/dsa/dsa_ameth.c
@@ -300,7 +300,7 @@ static int dsa_copy_parameters(EVP_PKEY *to, const EVP_PKEY *from)
         if (to->pkey.dsa == NULL)
             return 0;
     }
-    if (!ffc_params_copy(&to->pkey.dsa->params, &from->pkey.dsa->params))
+    if (!ossl_ffc_params_copy(&to->pkey.dsa->params, &from->pkey.dsa->params))
         return 0;
 
     to->pkey.dsa->dirty_cnt++;
@@ -309,7 +309,7 @@ static int dsa_copy_parameters(EVP_PKEY *to, const EVP_PKEY *from)
 
 static int dsa_cmp_parameters(const EVP_PKEY *a, const EVP_PKEY *b)
 {
-    return ffc_params_cmp(&a->pkey.dsa->params, &b->pkey.dsa->params, 1);
+    return ossl_ffc_params_cmp(&a->pkey.dsa->params, &b->pkey.dsa->params, 1);
 }
 
 static int dsa_pub_cmp(const EVP_PKEY *a, const EVP_PKEY *b)
@@ -363,7 +363,7 @@ static int do_dsa_print(BIO *bp, const DSA *x, int off, int ptype)
         goto err;
     if (!ASN1_bn_print(bp, "pub: ", pub_key, NULL, off))
         goto err;
-    if (!ffc_params_print(bp, &x->params, off))
+    if (!ossl_ffc_params_print(bp, &x->params, off))
         goto err;
     ret = 1;
  err:

--- a/crypto/dsa/dsa_check.c
+++ b/crypto/dsa/dsa_check.c
@@ -19,8 +19,8 @@ int dsa_check_params(const DSA *dsa, int *ret)
      * (2b) FFC domain params conform to FIPS-186-4 explicit domain param
      * validity tests.
      */
-    return ffc_params_FIPS186_4_validate(dsa->libctx, &dsa->params,
-                                         FFC_PARAM_TYPE_DSA, ret, NULL);
+    return ossl_ffc_params_FIPS186_4_validate(dsa->libctx, &dsa->params,
+                                              FFC_PARAM_TYPE_DSA, ret, NULL);
 }
 
 /*
@@ -28,7 +28,7 @@ int dsa_check_params(const DSA *dsa, int *ret)
  */
 int dsa_check_pub_key(const DSA *dsa, const BIGNUM *pub_key, int *ret)
 {
-    return ffc_validate_public_key(&dsa->params, pub_key, ret);
+    return ossl_ffc_validate_public_key(&dsa->params, pub_key, ret);
 }
 
 /*
@@ -38,7 +38,7 @@ int dsa_check_pub_key(const DSA *dsa, const BIGNUM *pub_key, int *ret)
  */
 int dsa_check_pub_key_partial(const DSA *dsa, const BIGNUM *pub_key, int *ret)
 {
-    return ffc_validate_public_key_partial(&dsa->params, pub_key, ret);
+    return ossl_ffc_validate_public_key_partial(&dsa->params, pub_key, ret);
 }
 
 int dsa_check_priv_key(const DSA *dsa, const BIGNUM *priv_key, int *ret)
@@ -46,7 +46,7 @@ int dsa_check_priv_key(const DSA *dsa, const BIGNUM *priv_key, int *ret)
     *ret = 0;
 
     return (dsa->params.q != NULL
-            && ffc_validate_private_key(dsa->params.q, priv_key, ret));
+            && ossl_ffc_validate_private_key(dsa->params.q, priv_key, ret));
 }
 
 /*

--- a/crypto/dsa/dsa_gen.c
+++ b/crypto/dsa/dsa_gen.c
@@ -30,14 +30,14 @@ int dsa_generate_ffc_parameters(DSA *dsa, int type, int pbits, int qbits,
 
 #ifndef FIPS_MODULE
     if (type == DSA_PARAMGEN_TYPE_FIPS_186_2)
-        ret = ffc_params_FIPS186_2_generate(dsa->libctx, &dsa->params,
-                                            FFC_PARAM_TYPE_DSA,
-                                            pbits, qbits, &res, cb);
+        ret = ossl_ffc_params_FIPS186_2_generate(dsa->libctx, &dsa->params,
+                                                 FFC_PARAM_TYPE_DSA,
+                                                 pbits, qbits, &res, cb);
     else
 #endif
-        ret = ffc_params_FIPS186_4_generate(dsa->libctx, &dsa->params,
-                                            FFC_PARAM_TYPE_DSA,
-                                            pbits, qbits, &res, cb);
+        ret = ossl_ffc_params_FIPS186_4_generate(dsa->libctx, &dsa->params,
+                                                 FFC_PARAM_TYPE_DSA,
+                                                 pbits, qbits, &res, cb);
     if (ret > 0)
         dsa->dirty_cnt++;
     return ret;
@@ -53,7 +53,8 @@ int DSA_generate_parameters_ex(DSA *dsa, int bits,
         return dsa->meth->dsa_paramgen(dsa, bits, seed_in, seed_len,
                                        counter_ret, h_ret, cb);
     if (seed_in != NULL
-        && !ffc_params_set_validate_params(&dsa->params, seed_in, seed_len, -1))
+        && !ossl_ffc_params_set_validate_params(&dsa->params, seed_in, seed_len,
+                                                -1))
         return 0;
 
     /* The old code used FIPS 186-2 DSA Parameter generation */

--- a/crypto/dsa/dsa_key.c
+++ b/crypto/dsa/dsa_key.c
@@ -76,8 +76,8 @@ static int dsa_keygen(DSA *dsa, int pairwise_test)
     }
 
     /* Do a partial check for invalid p, q, g */
-    if (!ffc_params_simple_validate(dsa->libctx, &dsa->params,
-                                    FFC_PARAM_TYPE_DSA))
+    if (!ossl_ffc_params_simple_validate(dsa->libctx, &dsa->params,
+                                         FFC_PARAM_TYPE_DSA))
         goto err;
 
     /*
@@ -85,8 +85,9 @@ static int dsa_keygen(DSA *dsa, int pairwise_test)
      * security strength s = 112,
      * Max Private key size N = len(q)
      */
-    if (!ffc_generate_private_key(ctx, &dsa->params, BN_num_bits(dsa->params.q),
-                                  MIN_STRENGTH, priv_key))
+    if (!ossl_ffc_generate_private_key(ctx, &dsa->params,
+                                       BN_num_bits(dsa->params.q),
+                                       MIN_STRENGTH, priv_key))
         goto err;
 
     if (dsa->pub_key == NULL) {

--- a/crypto/dsa/dsa_lib.c
+++ b/crypto/dsa/dsa_lib.c
@@ -56,7 +56,7 @@ DH *DSA_dup_DH(const DSA *r)
     if (ret == NULL)
         goto err;
 
-    if (!ffc_params_copy(dh_get0_params(ret), &r->params))
+    if (!ossl_ffc_params_copy(dh_get0_params(ret), &r->params))
         goto err;
 
     if (r->pub_key != NULL) {
@@ -231,7 +231,7 @@ void DSA_free(DSA *r)
 
     CRYPTO_THREAD_lock_free(r->lock);
 
-    ffc_params_cleanup(&r->params);
+    ossl_ffc_params_cleanup(&r->params);
     BN_clear_free(r->pub_key);
     BN_clear_free(r->priv_key);
     OPENSSL_free(r);
@@ -252,7 +252,7 @@ int DSA_up_ref(DSA *r)
 void DSA_get0_pqg(const DSA *d,
                   const BIGNUM **p, const BIGNUM **q, const BIGNUM **g)
 {
-    ffc_params_get0_pqg(&d->params, p, q, g);
+    ossl_ffc_params_get0_pqg(&d->params, p, q, g);
 }
 
 int DSA_set0_pqg(DSA *d, BIGNUM *p, BIGNUM *q, BIGNUM *g)
@@ -265,7 +265,7 @@ int DSA_set0_pqg(DSA *d, BIGNUM *p, BIGNUM *q, BIGNUM *g)
         || (d->params.g == NULL && g == NULL))
         return 0;
 
-    ffc_params_set0_pqg(&d->params, p, q, g);
+    ossl_ffc_params_set0_pqg(&d->params, p, q, g);
     d->dirty_cnt++;
 
     return 1;
@@ -356,7 +356,7 @@ int dsa_ffc_params_fromdata(DSA *dsa, const OSSL_PARAM params[])
     if (ffc == NULL)
         return 0;
 
-    ret = ffc_params_fromdata(ffc, params);
+    ret = ossl_ffc_params_fromdata(ffc, params);
     if (ret)
         dsa->dirty_cnt++;
     return ret;

--- a/crypto/dsa/dsa_ossl.c
+++ b/crypto/dsa/dsa_ossl.c
@@ -426,7 +426,7 @@ static int dsa_do_verify(const unsigned char *dgst, int dgst_len,
 static int dsa_init(DSA *dsa)
 {
     dsa->flags |= DSA_FLAG_CACHE_MONT_P;
-    ffc_params_init(&dsa->params);
+    ossl_ffc_params_init(&dsa->params);
     dsa->dirty_cnt++;
     return 1;
 }

--- a/crypto/dsa/dsa_pmeth.c
+++ b/crypto/dsa/dsa_pmeth.c
@@ -218,10 +218,11 @@ static int pkey_dsa_paramgen(EVP_PKEY_CTX *ctx, EVP_PKEY *pkey)
         return 0;
     }
     if (dctx->md != NULL)
-        ffc_set_digest(&dsa->params, EVP_MD_name(dctx->md), NULL);
+        ossl_ffc_set_digest(&dsa->params, EVP_MD_name(dctx->md), NULL);
 
-    ret = ffc_params_FIPS186_4_generate(NULL, &dsa->params, FFC_PARAM_TYPE_DSA,
-                                        dctx->nbits, dctx->qbits, &res, pcb);
+    ret = ossl_ffc_params_FIPS186_4_generate(NULL, &dsa->params,
+                                             FFC_PARAM_TYPE_DSA, dctx->nbits,
+                                             dctx->qbits, &res, pcb);
     BN_GENCB_free(pcb);
     if (ret > 0)
         EVP_PKEY_assign_DSA(pkey, dsa);

--- a/crypto/evp/pmeth_lib.c
+++ b/crypto/evp/pmeth_lib.c
@@ -1569,7 +1569,7 @@ static int legacy_ctrl_str_to_param(EVP_PKEY_CTX *ctx, const char *name,
         name = OSSL_PKEY_PARAM_GROUP_NAME;
     else if (strcmp(name, "dh_rfc5114") == 0) {
         name = OSSL_PKEY_PARAM_GROUP_NAME;
-        value = ffc_named_group_from_uid(atoi(value));
+        value = ossl_ffc_named_group_from_uid(atoi(value));
     } else if (strcmp(name, "dh_pad") == 0)
         name = OSSL_EXCHANGE_PARAM_PAD;
 # endif

--- a/crypto/ffc/ffc_backend.c
+++ b/crypto/ffc/ffc_backend.c
@@ -17,7 +17,7 @@
  * implementations alike.
  */
 
-int ffc_params_fromdata(FFC_PARAMS *ffc, const OSSL_PARAM params[])
+int ossl_ffc_params_fromdata(FFC_PARAMS *ffc, const OSSL_PARAM params[])
 {
     const OSSL_PARAM *prm;
     const OSSL_PARAM *param_p, *param_q, *param_g;
@@ -36,7 +36,7 @@ int ffc_params_fromdata(FFC_PARAMS *ffc, const OSSL_PARAM params[])
          * In a no-dh build we just go straight to err because we have no
          * support for this.
          */
-        if (!ffc_set_group_pqg(ffc, prm->data))
+        if (!ossl_ffc_set_group_pqg(ffc, prm->data))
 #endif
             goto err;
     }
@@ -75,14 +75,14 @@ int ffc_params_fromdata(FFC_PARAMS *ffc, const OSSL_PARAM params[])
     if (prm != NULL) {
         if (prm->data_type != OSSL_PARAM_OCTET_STRING)
             goto err;
-        if (!ffc_params_set_seed(ffc, prm->data, prm->data_size))
+        if (!ossl_ffc_params_set_seed(ffc, prm->data, prm->data_size))
             goto err;
     }
     prm  = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_FFC_VALIDATE_TYPE);
     if (prm != NULL) {
         if (prm->data_type != OSSL_PARAM_UTF8_STRING)
             goto err;
-        ffc_params_set_flags(ffc, ffc_params_flags_from_name(prm->data));
+        ossl_ffc_params_set_flags(ffc, ossl_ffc_params_flags_from_name(prm->data));
     }
     prm = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_FFC_DIGEST);
     if (prm != NULL) {
@@ -96,12 +96,12 @@ int ffc_params_fromdata(FFC_PARAMS *ffc, const OSSL_PARAM params[])
             if (p1->data_type != OSSL_PARAM_UTF8_STRING)
                 goto err;
         }
-        if (!ffc_set_digest(ffc, prm->data, props))
+        if (!ossl_ffc_set_digest(ffc, prm->data, props))
             goto err;
     }
 
-    ffc_params_set0_pqg(ffc, p, q, g);
-    ffc_params_set0_j(ffc, j);
+    ossl_ffc_params_set0_pqg(ffc, p, q, g);
+    ossl_ffc_params_set0_j(ffc, j);
     return 1;
 
  err:

--- a/crypto/ffc/ffc_key_generate.c
+++ b/crypto/ffc/ffc_key_generate.c
@@ -19,8 +19,8 @@
  * s is the security strength.
  * priv_key is the returned private key,
  */
-int ffc_generate_private_key(BN_CTX *ctx, const FFC_PARAMS *params,
-                             int N, int s, BIGNUM *priv)
+int ossl_ffc_generate_private_key(BN_CTX *ctx, const FFC_PARAMS *params,
+                                  int N, int s, BIGNUM *priv)
 {
     int ret = 0, qbits = BN_num_bits(params->q);
     BIGNUM *m, *two_powN = NULL;

--- a/crypto/ffc/ffc_key_validate.c
+++ b/crypto/ffc/ffc_key_validate.c
@@ -16,8 +16,8 @@
  *
  * ret contains 0 on success, or error flags (see FFC_ERROR_PUBKEY_TOO_SMALL)
  */
-int ffc_validate_public_key_partial(const FFC_PARAMS *params,
-                                    const BIGNUM *pub_key, int *ret)
+int ossl_ffc_validate_public_key_partial(const FFC_PARAMS *params,
+                                         const BIGNUM *pub_key, int *ret)
 {
     int ok = 0;
     BIGNUM *tmp = NULL;
@@ -58,14 +58,14 @@ int ffc_validate_public_key_partial(const FFC_PARAMS *params,
 /*
  * See SP800-56Ar3 Section 5.6.2.3.1 : FFC Full public key validation.
  */
-int ffc_validate_public_key(const FFC_PARAMS *params, const BIGNUM *pub_key,
-                            int *ret)
+int ossl_ffc_validate_public_key(const FFC_PARAMS *params,
+                                 const BIGNUM *pub_key, int *ret)
 {
     int ok = 0;
     BIGNUM *tmp = NULL;
     BN_CTX *ctx = NULL;
 
-    if (!ffc_validate_public_key_partial(params, pub_key, ret))
+    if (!ossl_ffc_validate_public_key_partial(params, pub_key, ret))
         return 0;
 
     if (params->q != NULL) {
@@ -100,7 +100,8 @@ int ffc_validate_public_key(const FFC_PARAMS *params, const BIGNUM *pub_key,
  * is normally params->q but can be 2^N for approved safe prime groups.
  * Note: This assumes that the domain parameters are valid.
  */
-int ffc_validate_private_key(const BIGNUM *upper, const BIGNUM *priv, int *ret)
+int ossl_ffc_validate_private_key(const BIGNUM *upper, const BIGNUM *priv,
+                                  int *ret)
 {
     int ok = 0;
 

--- a/crypto/ffc/ffc_params.c
+++ b/crypto/ffc/ffc_params.c
@@ -15,10 +15,10 @@
 #include "e_os.h" /* strcasecmp */
 
 #ifndef FIPS_MODULE
-# include <openssl/asn1.h> /* ffc_params_print */
+# include <openssl/asn1.h> /* ossl_ffc_params_print */
 #endif
 
-void ffc_params_init(FFC_PARAMS *params)
+void ossl_ffc_params_init(FFC_PARAMS *params)
 {
     memset(params, 0, sizeof(*params));
     params->pcounter = -1;
@@ -26,17 +26,17 @@ void ffc_params_init(FFC_PARAMS *params)
     params->flags = FFC_PARAM_FLAG_VALIDATE_ALL;
 }
 
-void ffc_params_cleanup(FFC_PARAMS *params)
+void ossl_ffc_params_cleanup(FFC_PARAMS *params)
 {
     BN_free(params->p);
     BN_free(params->q);
     BN_free(params->g);
     BN_free(params->j);
     OPENSSL_free(params->seed);
-    ffc_params_init(params);
+    ossl_ffc_params_init(params);
 }
 
-void ffc_params_set0_pqg(FFC_PARAMS *d, BIGNUM *p, BIGNUM *q, BIGNUM *g)
+void ossl_ffc_params_set0_pqg(FFC_PARAMS *d, BIGNUM *p, BIGNUM *q, BIGNUM *g)
 {
     if (p != NULL && p != d->p) {
         BN_free(d->p);
@@ -52,8 +52,8 @@ void ffc_params_set0_pqg(FFC_PARAMS *d, BIGNUM *p, BIGNUM *q, BIGNUM *g)
     }
 }
 
-void ffc_params_get0_pqg(const FFC_PARAMS *d, const BIGNUM **p,
-                         const BIGNUM **q, const BIGNUM **g)
+void ossl_ffc_params_get0_pqg(const FFC_PARAMS *d, const BIGNUM **p,
+                              const BIGNUM **q, const BIGNUM **g)
 {
     if (p != NULL)
         *p = d->p;
@@ -65,7 +65,7 @@ void ffc_params_get0_pqg(const FFC_PARAMS *d, const BIGNUM **p,
 
 
 /* j is the 'cofactor' that is optionally output for ASN1. */
-void ffc_params_set0_j(FFC_PARAMS *d, BIGNUM *j)
+void ossl_ffc_params_set0_j(FFC_PARAMS *d, BIGNUM *j)
 {
     BN_free(d->j);
     d->j = NULL;
@@ -73,8 +73,8 @@ void ffc_params_set0_j(FFC_PARAMS *d, BIGNUM *j)
         d->j = j;
 }
 
-int ffc_params_set_seed(FFC_PARAMS *params,
-                        const unsigned char *seed, size_t seedlen)
+int ossl_ffc_params_set_seed(FFC_PARAMS *params,
+                             const unsigned char *seed, size_t seedlen)
 {
     if (params == NULL)
         return 0;
@@ -97,27 +97,28 @@ int ffc_params_set_seed(FFC_PARAMS *params,
     return 1;
 }
 
-void ffc_params_set_gindex(FFC_PARAMS *params, int index)
+void ossl_ffc_params_set_gindex(FFC_PARAMS *params, int index)
 {
     params->gindex = index;
 }
 
-void ffc_params_set_pcounter(FFC_PARAMS *params, int index)
+void ossl_ffc_params_set_pcounter(FFC_PARAMS *params, int index)
 {
     params->pcounter = index;
 }
 
-void ffc_params_set_h(FFC_PARAMS *params, int index)
+void ossl_ffc_params_set_h(FFC_PARAMS *params, int index)
 {
     params->h = index;
 }
 
-void ffc_params_set_flags(FFC_PARAMS *params, unsigned int flags)
+void ossl_ffc_params_set_flags(FFC_PARAMS *params, unsigned int flags)
 {
     params->flags = flags;
 }
 
-void ffc_params_enable_flags(FFC_PARAMS *params, unsigned int flags, int enable)
+void ossl_ffc_params_enable_flags(FFC_PARAMS *params, unsigned int flags,
+                                  int enable)
 {
     if (enable)
         params->flags |= flags;
@@ -125,26 +126,26 @@ void ffc_params_enable_flags(FFC_PARAMS *params, unsigned int flags, int enable)
         params->flags &= ~flags;
 }
 
-int ffc_set_digest(FFC_PARAMS *params, const char *alg, const char *props)
+int ossl_ffc_set_digest(FFC_PARAMS *params, const char *alg, const char *props)
 {
     params->mdname = alg;
     params->mdprops = props;
     return 1;
 }
 
-int ffc_params_set_validate_params(FFC_PARAMS *params,
-                                   const unsigned char *seed, size_t seedlen,
-                                   int counter)
+int ossl_ffc_params_set_validate_params(FFC_PARAMS *params,
+                                        const unsigned char *seed,
+                                        size_t seedlen, int counter)
 {
-    if (!ffc_params_set_seed(params, seed, seedlen))
+    if (!ossl_ffc_params_set_seed(params, seed, seedlen))
         return 0;
     params->pcounter = counter;
     return 1;
 }
 
-void ffc_params_get_validate_params(const FFC_PARAMS *params,
-                                    unsigned char **seed, size_t *seedlen,
-                                    int *pcounter)
+void ossl_ffc_params_get_validate_params(const FFC_PARAMS *params,
+                                         unsigned char **seed, size_t *seedlen,
+                                         int *pcounter)
 {
     if (seed != NULL)
         *seed = params->seed;
@@ -174,7 +175,7 @@ static int ffc_bn_cpy(BIGNUM **dst, const BIGNUM *src)
     return 1;
 }
 
-int ffc_params_copy(FFC_PARAMS *dst, const FFC_PARAMS *src)
+int ossl_ffc_params_copy(FFC_PARAMS *dst, const FFC_PARAMS *src)
 {
     if (!ffc_bn_cpy(&dst->p, src->p)
         || !ffc_bn_cpy(&dst->g, src->g)
@@ -198,7 +199,7 @@ int ffc_params_copy(FFC_PARAMS *dst, const FFC_PARAMS *src)
     return 1;
 }
 
-int ffc_params_cmp(const FFC_PARAMS *a, const FFC_PARAMS *b, int ignore_q)
+int ossl_ffc_params_cmp(const FFC_PARAMS *a, const FFC_PARAMS *b, int ignore_q)
 {
     return BN_cmp(a->p, b->p) == 0
            && BN_cmp(a->g, b->g) == 0
@@ -212,7 +213,7 @@ static const OSSL_ITEM flag_map[] = {
     { 0, "" }
 };
 
-int ffc_params_flags_from_name(const char *name)
+int ossl_ffc_params_flags_from_name(const char *name)
 {
     size_t i;
 
@@ -223,7 +224,7 @@ int ffc_params_flags_from_name(const char *name)
     return NID_undef;
 }
 
-const char *ffc_params_flags_to_name(int flags)
+const char *ossl_ffc_params_flags_to_name(int flags)
 {
     size_t i;
 
@@ -235,7 +236,7 @@ const char *ffc_params_flags_to_name(int flags)
     return "";
 }
 
-int ffc_params_todata(const FFC_PARAMS *ffc, OSSL_PARAM_BLD *bld,
+int ossl_ffc_params_todata(const FFC_PARAMS *ffc, OSSL_PARAM_BLD *bld,
                       OSSL_PARAM params[])
 {
     if (ffc == NULL)
@@ -269,7 +270,7 @@ int ffc_params_todata(const FFC_PARAMS *ffc, OSSL_PARAM_BLD *bld,
         return 0;
     if (ffc->nid != NID_undef) {
 #ifndef OPENSSL_NO_DH
-        const char *name = ffc_named_group_from_uid(ffc->nid);
+        const char *name = ossl_ffc_named_group_from_uid(ffc->nid);
 
         if (name == NULL
             || !ossl_param_build_set_utf8_string(bld, params,
@@ -283,7 +284,7 @@ int ffc_params_todata(const FFC_PARAMS *ffc, OSSL_PARAM_BLD *bld,
     }
     if (!ossl_param_build_set_utf8_string(bld, params,
                                           OSSL_PKEY_PARAM_FFC_VALIDATE_TYPE,
-                                          ffc_params_flags_to_name(ffc->flags)))
+                                          ossl_ffc_params_flags_to_name(ffc->flags)))
         return 0;
     if (ffc->mdname != NULL
         && !ossl_param_build_set_utf8_string(bld, params,
@@ -299,7 +300,7 @@ int ffc_params_todata(const FFC_PARAMS *ffc, OSSL_PARAM_BLD *bld,
 }
 
 #ifndef FIPS_MODULE
-int ffc_params_print(BIO *bp, const FFC_PARAMS *ffc, int indent)
+int ossl_ffc_params_print(BIO *bp, const FFC_PARAMS *ffc, int indent)
 {
     if (!ASN1_bn_print(bp, "prime P:", ffc->p, NULL, indent))
         goto err;

--- a/crypto/ffc/ffc_params_generate.c
+++ b/crypto/ffc/ffc_params_generate.c
@@ -510,9 +510,10 @@ static const char *default_mdname(size_t N)
  *   - FFC_PARAM_RET_STATUS_UNVERIFIABLE_G if the validation of G succeeded,
  *     but G is unverifiable.
  */
-int ffc_params_FIPS186_4_gen_verify(OPENSSL_CTX *libctx, FFC_PARAMS *params,
-                                    int mode, int type, size_t L, size_t N,
-                                    int *res, BN_GENCB *cb)
+int ossl_ffc_params_FIPS186_4_gen_verify(OPENSSL_CTX *libctx,
+                                         FFC_PARAMS *params, int mode, int type,
+                                         size_t L, size_t N, int *res,
+                                         BN_GENCB *cb)
 {
     int ok = FFC_PARAM_RET_STATUS_FAILED;
     unsigned char *seed = NULL, *seed_tmp = NULL;
@@ -728,8 +729,8 @@ g_only:
         goto err;
 
     if (((flags & FFC_PARAM_FLAG_VALIDATE_G) != 0)
-        && !ffc_params_validate_unverifiable_g(ctx, mont, p, q, params->g,
-                                               tmp, res))
+        && !ossl_ffc_params_validate_unverifiable_g(ctx, mont, p, q, params->g,
+                                                    tmp, res))
         goto err;
 
     /*
@@ -777,7 +778,8 @@ g_only:
         }
         if (params->p == NULL || params->q == NULL || params->g == NULL)
             goto err;
-        if (!ffc_params_set_validate_params(params, seed, seedlen, pcounter))
+        if (!ossl_ffc_params_set_validate_params(params, seed, seedlen,
+                                                 pcounter))
             goto err;
         params->h = hret;
     }
@@ -801,9 +803,10 @@ err:
 }
 
 /* Note this function is only used for verification in fips mode */
-int ffc_params_FIPS186_2_gen_verify(OPENSSL_CTX *libctx, FFC_PARAMS *params,
-                                    int mode, int type, size_t L, size_t N,
-                                    int *res, BN_GENCB *cb)
+int ossl_ffc_params_FIPS186_2_gen_verify(OPENSSL_CTX *libctx,
+                                         FFC_PARAMS *params, int mode, int type,
+                                         size_t L, size_t N, int *res,
+                                         BN_GENCB *cb)
 {
     int ok = FFC_PARAM_RET_STATUS_FAILED;
     unsigned char seed[SHA256_DIGEST_LENGTH];
@@ -988,8 +991,9 @@ g_only:
         if (!generate_unverifiable_g(ctx, mont, g, tmp, p, r0, test, &hret))
             goto err;
     } else if (((flags & FFC_PARAM_FLAG_VALIDATE_G) != 0)
-               && !ffc_params_validate_unverifiable_g(ctx, mont, p, q,
-                                                      params->g, tmp, res)) {
+               && !ossl_ffc_params_validate_unverifiable_g(ctx, mont, p, q,
+                                                           params->g, tmp,
+                                                           res)) {
         goto err;
     }
 
@@ -1011,7 +1015,7 @@ g_only:
         }
         if (params->p == NULL || params->q == NULL || params->g == NULL)
             goto err;
-        if (!ffc_params_set_validate_params(params, seed, qsize, pcounter))
+        if (!ossl_ffc_params_set_validate_params(params, seed, qsize, pcounter))
             goto err;
         params->h = hret;
     }
@@ -1029,21 +1033,21 @@ err:
     return ok;
 }
 
-int ffc_params_FIPS186_4_generate(OPENSSL_CTX *libctx, FFC_PARAMS *params,
-                                  int type, size_t L, size_t N,
-                                  int *res, BN_GENCB *cb)
+int ossl_ffc_params_FIPS186_4_generate(OPENSSL_CTX *libctx, FFC_PARAMS *params,
+                                       int type, size_t L, size_t N,
+                                       int *res, BN_GENCB *cb)
 {
-    return ffc_params_FIPS186_4_gen_verify(libctx, params,
-                                           FFC_PARAM_MODE_GENERATE,
-                                           type, L, N, res, cb);
+    return ossl_ffc_params_FIPS186_4_gen_verify(libctx, params,
+                                                FFC_PARAM_MODE_GENERATE,
+                                                type, L, N, res, cb);
 }
 
 /* This should no longer be used in FIPS mode */
-int ffc_params_FIPS186_2_generate(OPENSSL_CTX *libctx, FFC_PARAMS *params,
-                                  int type, size_t L, size_t N,
-                                  int *res, BN_GENCB *cb)
+int ossl_ffc_params_FIPS186_2_generate(OPENSSL_CTX *libctx, FFC_PARAMS *params,
+                                       int type, size_t L, size_t N,
+                                       int *res, BN_GENCB *cb)
 {
-    return ffc_params_FIPS186_2_gen_verify(libctx, params,
-                                           FFC_PARAM_MODE_GENERATE,
-                                           type, L, N, res, cb);
+    return ossl_ffc_params_FIPS186_2_gen_verify(libctx, params,
+                                                FFC_PARAM_MODE_GENERATE,
+                                                type, L, N, res, cb);
 }

--- a/crypto/ffc/ffc_params_validate.c
+++ b/crypto/ffc/ffc_params_validate.c
@@ -16,9 +16,10 @@
 #include "internal/ffc.h"
 
 /* FIPS186-4 A.2.2 Unverifiable partial validation of Generator g */
-int ffc_params_validate_unverifiable_g(BN_CTX *ctx, BN_MONT_CTX *mont,
-                                       const BIGNUM *p, const BIGNUM *q,
-                                       const BIGNUM *g, BIGNUM *tmp, int *ret)
+int ossl_ffc_params_validate_unverifiable_g(BN_CTX *ctx, BN_MONT_CTX *mont,
+                                            const BIGNUM *p, const BIGNUM *q,
+                                            const BIGNUM *g, BIGNUM *tmp,
+                                            int *ret)
 {
     /*
      * A.2.2 Step (1) AND
@@ -44,8 +45,9 @@ int ffc_params_validate_unverifiable_g(BN_CTX *ctx, BN_MONT_CTX *mont,
     return 1;
 }
 
-int ffc_params_FIPS186_4_validate(OPENSSL_CTX *libctx, const FFC_PARAMS *params,
-                                  int type, int *res, BN_GENCB *cb)
+int ossl_ffc_params_FIPS186_4_validate(OPENSSL_CTX *libctx,
+                                       const FFC_PARAMS *params, int type,
+                                       int *res, BN_GENCB *cb)
 {
     size_t L, N;
 
@@ -55,14 +57,15 @@ int ffc_params_FIPS186_4_validate(OPENSSL_CTX *libctx, const FFC_PARAMS *params,
     /* A.1.1.3 Step (1..2) : L = len(p), N = len(q) */
     L = BN_num_bits(params->p);
     N = BN_num_bits(params->q);
-    return ffc_params_FIPS186_4_gen_verify(libctx, (FFC_PARAMS *)params,
-                                           FFC_PARAM_MODE_VERIFY, type,
-                                           L, N, res, cb);
+    return ossl_ffc_params_FIPS186_4_gen_verify(libctx, (FFC_PARAMS *)params,
+                                                FFC_PARAM_MODE_VERIFY, type,
+                                                L, N, res, cb);
 }
 
 /* This may be used in FIPS mode to validate deprecated FIPS-186-2 Params */
-int ffc_params_FIPS186_2_validate(OPENSSL_CTX *libctx, const FFC_PARAMS *params,
-                                  int type, int *res, BN_GENCB *cb)
+int ossl_ffc_params_FIPS186_2_validate(OPENSSL_CTX *libctx,
+                                       const FFC_PARAMS *params, int type,
+                                       int *res, BN_GENCB *cb)
 {
     size_t L, N;
 
@@ -74,9 +77,9 @@ int ffc_params_FIPS186_2_validate(OPENSSL_CTX *libctx, const FFC_PARAMS *params,
     /* A.1.1.3 Step (1..2) : L = len(p), N = len(q) */
     L = BN_num_bits(params->p);
     N = BN_num_bits(params->q);
-    return ffc_params_FIPS186_2_gen_verify(libctx, (FFC_PARAMS *)params,
-                                           FFC_PARAM_MODE_VERIFY, type,
-                                           L, N, res, cb);
+    return ossl_ffc_params_FIPS186_2_gen_verify(libctx, (FFC_PARAMS *)params,
+                                                FFC_PARAM_MODE_VERIFY, type,
+                                                L, N, res, cb);
 }
 
 /*
@@ -85,7 +88,8 @@ int ffc_params_FIPS186_2_validate(OPENSSL_CTX *libctx, const FFC_PARAMS *params,
  * extra parameters such as the digest and seed, which may not be available for
  * this test.
  */
-int ffc_params_simple_validate(OPENSSL_CTX *libctx, FFC_PARAMS *params, int type)
+int ossl_ffc_params_simple_validate(OPENSSL_CTX *libctx, FFC_PARAMS *params,
+                                    int type)
 {
     int ret, res = 0;
     int save_gindex;
@@ -101,10 +105,12 @@ int ffc_params_simple_validate(OPENSSL_CTX *libctx, FFC_PARAMS *params, int type
 
 #ifndef FIPS_MODULE
     if (save_flags & FFC_PARAM_FLAG_VALIDATE_LEGACY)
-        ret = ffc_params_FIPS186_2_validate(libctx, params, type, &res, NULL);
+        ret = ossl_ffc_params_FIPS186_2_validate(libctx, params, type, &res,
+                                                 NULL);
     else
 #endif
-        ret = ffc_params_FIPS186_4_validate(libctx, params, type, &res, NULL);
+        ret = ossl_ffc_params_FIPS186_4_validate(libctx, params, type, &res,
+                                                 NULL);
     params->flags = save_flags;
     params->gindex = save_gindex;
     return ret != FFC_PARAM_RET_STATUS_FAILED;

--- a/include/internal/ffc.h
+++ b/include/internal/ffc.h
@@ -27,7 +27,7 @@
 
 /*
  * The mode used by functions that share code for both generation and
- * verification. See ffc_params_FIPS186_4_gen_verify().
+ * verification. See ossl_ffc_params_FIPS186_4_gen_verify().
  */
 #define FFC_PARAM_MODE_VERIFY   0
 #define FFC_PARAM_MODE_GENERATE 1
@@ -113,78 +113,86 @@ typedef struct ffc_params_st {
     const char *mdprops;
 } FFC_PARAMS;
 
-void ffc_params_init(FFC_PARAMS *params);
-void ffc_params_cleanup(FFC_PARAMS *params);
-void ffc_params_set0_pqg(FFC_PARAMS *params, BIGNUM *p, BIGNUM *q, BIGNUM *g);
-void ffc_params_get0_pqg(const FFC_PARAMS *params, const BIGNUM **p,
-                         const BIGNUM **q, const BIGNUM **g);
-void ffc_params_set0_j(FFC_PARAMS *d, BIGNUM *j);
-int ffc_params_set_seed(FFC_PARAMS *params,
-                        const unsigned char *seed, size_t seedlen);
-void ffc_params_set_gindex(FFC_PARAMS *params, int index);
-void ffc_params_set_pcounter(FFC_PARAMS *params, int index);
-void ffc_params_set_h(FFC_PARAMS *params, int index);
-void ffc_params_set_flags(FFC_PARAMS *params, unsigned int flags);
-void ffc_params_enable_flags(FFC_PARAMS *params, unsigned int flags, int enable);
-int ffc_set_digest(FFC_PARAMS *params, const char *alg, const char *props);
+void ossl_ffc_params_init(FFC_PARAMS *params);
+void ossl_ffc_params_cleanup(FFC_PARAMS *params);
+void ossl_ffc_params_set0_pqg(FFC_PARAMS *params, BIGNUM *p, BIGNUM *q,
+                              BIGNUM *g);
+void ossl_ffc_params_get0_pqg(const FFC_PARAMS *params, const BIGNUM **p,
+                              const BIGNUM **q, const BIGNUM **g);
+void ossl_ffc_params_set0_j(FFC_PARAMS *d, BIGNUM *j);
+int ossl_ffc_params_set_seed(FFC_PARAMS *params,
+                             const unsigned char *seed, size_t seedlen);
+void ossl_ffc_params_set_gindex(FFC_PARAMS *params, int index);
+void ossl_ffc_params_set_pcounter(FFC_PARAMS *params, int index);
+void ossl_ffc_params_set_h(FFC_PARAMS *params, int index);
+void ossl_ffc_params_set_flags(FFC_PARAMS *params, unsigned int flags);
+void ossl_ffc_params_enable_flags(FFC_PARAMS *params, unsigned int flags,
+                                  int enable);
+int ossl_ffc_set_digest(FFC_PARAMS *params, const char *alg, const char *props);
 
-int ffc_params_set_validate_params(FFC_PARAMS *params,
-                                   const unsigned char *seed, size_t seedlen,
-                                   int counter);
-void ffc_params_get_validate_params(const FFC_PARAMS *params,
-                                    unsigned char **seed, size_t *seedlen,
-                                    int *pcounter);
+int ossl_ffc_params_set_validate_params(FFC_PARAMS *params,
+                                        const unsigned char *seed,
+                                        size_t seedlen, int counter);
+void ossl_ffc_params_get_validate_params(const FFC_PARAMS *params,
+                                         unsigned char **seed, size_t *seedlen,
+                                         int *pcounter);
 
-int ffc_params_copy(FFC_PARAMS *dst, const FFC_PARAMS *src);
-int ffc_params_cmp(const FFC_PARAMS *a, const FFC_PARAMS *b, int ignore_q);
+int ossl_ffc_params_copy(FFC_PARAMS *dst, const FFC_PARAMS *src);
+int ossl_ffc_params_cmp(const FFC_PARAMS *a, const FFC_PARAMS *b, int ignore_q);
 
 #ifndef FIPS_MODULE
-int ffc_params_print(BIO *bp, const FFC_PARAMS *ffc, int indent);
+int ossl_ffc_params_print(BIO *bp, const FFC_PARAMS *ffc, int indent);
 #endif /* FIPS_MODULE */
 
 
-int ffc_params_FIPS186_4_generate(OPENSSL_CTX *libctx, FFC_PARAMS *params,
-                                  int type, size_t L, size_t N,
-                                  int *res, BN_GENCB *cb);
-int ffc_params_FIPS186_2_generate(OPENSSL_CTX *libctx, FFC_PARAMS *params,
-                                  int type, size_t L, size_t N,
-                                  int *res, BN_GENCB *cb);
+int ossl_ffc_params_FIPS186_4_generate(OPENSSL_CTX *libctx, FFC_PARAMS *params,
+                                       int type, size_t L, size_t N,
+                                       int *res, BN_GENCB *cb);
+int ossl_ffc_params_FIPS186_2_generate(OPENSSL_CTX *libctx, FFC_PARAMS *params,
+                                       int type, size_t L, size_t N,
+                                       int *res, BN_GENCB *cb);
 
-int ffc_params_FIPS186_4_gen_verify(OPENSSL_CTX *libctx, FFC_PARAMS *params,
-                                    int mode, int type, size_t L, size_t N,
-                                    int *res, BN_GENCB *cb);
-int ffc_params_FIPS186_2_gen_verify(OPENSSL_CTX *libctx, FFC_PARAMS *params,
-                                    int mode, int type, size_t L, size_t N,
-                                    int *res, BN_GENCB *cb);
+int ossl_ffc_params_FIPS186_4_gen_verify(OPENSSL_CTX *libctx,
+                                         FFC_PARAMS *params, int mode, int type,
+                                         size_t L, size_t N, int *res,
+                                         BN_GENCB *cb);
+int ossl_ffc_params_FIPS186_2_gen_verify(OPENSSL_CTX *libctx,
+                                         FFC_PARAMS *params, int mode, int type,
+                                         size_t L, size_t N, int *res,
+                                         BN_GENCB *cb);
 
-int ffc_params_simple_validate(OPENSSL_CTX *libctx, FFC_PARAMS *params, int type);
-int ffc_params_FIPS186_4_validate(OPENSSL_CTX *libctx, const FFC_PARAMS *params,
-                                  int type, int *res, BN_GENCB *cb);
-int ffc_params_FIPS186_2_validate(OPENSSL_CTX *libctx, const FFC_PARAMS *params,
-                                  int type, int *res, BN_GENCB *cb);
+int ossl_ffc_params_simple_validate(OPENSSL_CTX *libctx, FFC_PARAMS *params,
+                                    int type);
+int ossl_ffc_params_FIPS186_4_validate(OPENSSL_CTX *libctx,
+                                       const FFC_PARAMS *params,
+                                       int type, int *res, BN_GENCB *cb);
+int ossl_ffc_params_FIPS186_2_validate(OPENSSL_CTX *libctx,
+                                       const FFC_PARAMS *params,
+                                       int type, int *res, BN_GENCB *cb);
 
-int ffc_generate_private_key(BN_CTX *ctx, const FFC_PARAMS *params,
-                             int N, int s, BIGNUM *priv);
+int ossl_ffc_generate_private_key(BN_CTX *ctx, const FFC_PARAMS *params,
+                                  int N, int s, BIGNUM *priv);
 
-int ffc_params_validate_unverifiable_g(BN_CTX *ctx, BN_MONT_CTX *mont,
-                                       const BIGNUM *p, const BIGNUM *q,
-                                       const BIGNUM *g, BIGNUM *tmp, int *ret);
+int ossl_ffc_params_validate_unverifiable_g(BN_CTX *ctx, BN_MONT_CTX *mont,
+                                            const BIGNUM *p, const BIGNUM *q,
+                                            const BIGNUM *g, BIGNUM *tmp,
+                                            int *ret);
 
-int ffc_validate_public_key(const FFC_PARAMS *params, const BIGNUM *pub_key,
-                            int *ret);
-int ffc_validate_public_key_partial(const FFC_PARAMS *params,
-                                    const BIGNUM *pub_key, int *ret);
-int ffc_validate_private_key(const BIGNUM *upper, const BIGNUM *priv_key,
-                             int *ret);
+int ossl_ffc_validate_public_key(const FFC_PARAMS *params,
+                                 const BIGNUM *pub_key, int *ret);
+int ossl_ffc_validate_public_key_partial(const FFC_PARAMS *params,
+                                         const BIGNUM *pub_key, int *ret);
+int ossl_ffc_validate_private_key(const BIGNUM *upper, const BIGNUM *priv_key,
+                                 int *ret);
 
-int ffc_params_todata(const FFC_PARAMS *ffc, OSSL_PARAM_BLD *tmpl,
-                      OSSL_PARAM params[]);
-int ffc_params_fromdata(FFC_PARAMS *ffc, const OSSL_PARAM params[]);
-int ffc_set_group_pqg(FFC_PARAMS *ffc, const char *group_name);
-int ffc_named_group_to_uid(const char *name);
-const char *ffc_named_group_from_uid(int nid);
-int ffc_set_group_pqg(FFC_PARAMS *ffc, const char *group_name);
-const char *ffc_params_flags_to_name(int flags);
-int ffc_params_flags_from_name(const char *name);
+int ossl_ffc_params_todata(const FFC_PARAMS *ffc, OSSL_PARAM_BLD *tmpl,
+                           OSSL_PARAM params[]);
+int ossl_ffc_params_fromdata(FFC_PARAMS *ffc, const OSSL_PARAM params[]);
+int ossl_ffc_set_group_pqg(FFC_PARAMS *ffc, const char *group_name);
+int ossl_ffc_named_group_to_uid(const char *name);
+const char *ossl_ffc_named_group_from_uid(int nid);
+int ossl_ffc_set_group_pqg(FFC_PARAMS *ffc, const char *group_name);
+const char *ossl_ffc_params_flags_to_name(int flags);
+int ossl_ffc_params_flags_from_name(const char *name);
 
 #endif /* OSSL_INTERNAL_FFC_H */

--- a/providers/implementations/encode_decode/encode_key2text.c
+++ b/providers/implementations/encode_decode/encode_key2text.c
@@ -157,7 +157,7 @@ static int ffc_params_to_text(BIO *out, const FFC_PARAMS *ffc)
 {
     if (ffc->nid != NID_undef) {
 #ifndef OPENSSL_NO_DH
-        const char *name = ffc_named_group_from_uid(ffc->nid);
+        const char *name = ossl_ffc_named_group_from_uid(ffc->nid);
 
         if (name == NULL)
             goto err;

--- a/providers/implementations/keymgmt/dh_kmgmt.c
+++ b/providers/implementations/keymgmt/dh_kmgmt.c
@@ -198,7 +198,7 @@ static int dh_match(const void *keydata1, const void *keydata2, int selection)
         FFC_PARAMS *dhparams1 = dh_get0_params((DH *)dh1);
         FFC_PARAMS *dhparams2 = dh_get0_params((DH *)dh2);
 
-        ok = ok && ffc_params_cmp(dhparams1, dhparams2, 1);
+        ok = ok && ossl_ffc_params_cmp(dhparams1, dhparams2, 1);
     }
     return ok;
 }
@@ -239,7 +239,7 @@ static int dh_export(void *keydata, int selection, OSSL_CALLBACK *param_cb,
         return 0;
 
     if ((selection & OSSL_KEYMGMT_SELECT_ALL_PARAMETERS) != 0)
-        ok = ok && ffc_params_todata(dh_get0_params(dh), tmpl, NULL);
+        ok = ok && ossl_ffc_params_todata(dh_get0_params(dh), tmpl, NULL);
     if ((selection & OSSL_KEYMGMT_SELECT_KEYPAIR) != 0)
         ok = ok && dh_key_todata(dh, tmpl, NULL);
 
@@ -337,7 +337,7 @@ static ossl_inline int dh_get_params(void *key, OSSL_PARAM params[])
             return 0;
     }
 
-    return ffc_params_todata(dh_get0_params(dh), NULL, params)
+    return ossl_ffc_params_todata(dh_get0_params(dh), NULL, params)
            && dh_key_todata(dh, NULL, params);
 }
 
@@ -511,7 +511,7 @@ static int dh_gen_set_params(void *genctx, const OSSL_PARAM params[])
     p = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_GROUP_NAME);
     if (p != NULL) {
         if (p->data_type != OSSL_PARAM_UTF8_STRING
-           || ((gctx->group_nid = ffc_named_group_to_uid(p->data)) == NID_undef)) {
+           || ((gctx->group_nid = ossl_ffc_named_group_to_uid(p->data)) == NID_undef)) {
             ERR_raise(ERR_LIB_PROV, ERR_R_PASSED_INVALID_ARGUMENT);
             return 0;
         }
@@ -620,20 +620,20 @@ static void *dh_gen(void *genctx, OSSL_CALLBACK *osslcb, void *cbarg)
 
         /* Copy the template value if one was passed */
         if (gctx->ffc_params != NULL
-            && !ffc_params_copy(ffc, gctx->ffc_params))
+            && !ossl_ffc_params_copy(ffc, gctx->ffc_params))
             goto end;
 
-        if (!ffc_params_set_seed(ffc, gctx->seed, gctx->seedlen))
+        if (!ossl_ffc_params_set_seed(ffc, gctx->seed, gctx->seedlen))
             goto end;
         if (gctx->gindex != -1) {
-            ffc_params_set_gindex(ffc, gctx->gindex);
+            ossl_ffc_params_set_gindex(ffc, gctx->gindex);
             if (gctx->pcounter != -1)
-                ffc_params_set_pcounter(ffc, gctx->pcounter);
+                ossl_ffc_params_set_pcounter(ffc, gctx->pcounter);
         } else if (gctx->hindex != 0) {
-            ffc_params_set_h(ffc, gctx->hindex);
+            ossl_ffc_params_set_h(ffc, gctx->hindex);
         }
         if (gctx->mdname != NULL) {
-            if (!ffc_set_digest(ffc, gctx->mdname, gctx->mdprops))
+            if (!ossl_ffc_set_digest(ffc, gctx->mdname, gctx->mdprops))
                 goto end;
         }
         gctx->cb = osslcb;
@@ -664,8 +664,8 @@ static void *dh_gen(void *genctx, OSSL_CALLBACK *osslcb, void *cbarg)
             goto end;
         if (gctx->priv_len > 0)
             DH_set_length(dh, (long)gctx->priv_len);
-        ffc_params_enable_flags(ffc, FFC_PARAM_FLAG_VALIDATE_LEGACY,
-                                gctx->gen_type == DH_PARAMGEN_TYPE_FIPS_186_2);
+        ossl_ffc_params_enable_flags(ffc, FFC_PARAM_FLAG_VALIDATE_LEGACY,
+                                     gctx->gen_type == DH_PARAMGEN_TYPE_FIPS_186_2);
         if (DH_generate_key(dh) <= 0)
             goto end;
     }

--- a/providers/implementations/keymgmt/dsa_kmgmt.c
+++ b/providers/implementations/keymgmt/dsa_kmgmt.c
@@ -159,7 +159,7 @@ static int dsa_match(const void *keydata1, const void *keydata2, int selection)
         FFC_PARAMS *dsaparams1 = dsa_get0_params((DSA *)dsa1);
         FFC_PARAMS *dsaparams2 = dsa_get0_params((DSA *)dsa2);
 
-        ok = ok && ffc_params_cmp(dsaparams1, dsaparams2, 1);
+        ok = ok && ossl_ffc_params_cmp(dsaparams1, dsaparams2, 1);
     }
     return ok;
 }
@@ -195,7 +195,7 @@ static int dsa_export(void *keydata, int selection, OSSL_CALLBACK *param_cb,
         goto err;
 
     if ((selection & OSSL_KEYMGMT_SELECT_ALL_PARAMETERS) != 0)
-        ok = ok && ffc_params_todata(dsa_get0_params(dsa), tmpl, NULL);
+        ok = ok && ossl_ffc_params_todata(dsa_get0_params(dsa), tmpl, NULL);
     if ((selection & OSSL_KEYMGMT_SELECT_KEYPAIR) != 0)
         ok = ok && dsa_key_todata(dsa, tmpl, NULL);
 
@@ -285,7 +285,7 @@ static ossl_inline int dsa_get_params(void *key, OSSL_PARAM params[])
     if ((p = OSSL_PARAM_locate(params, OSSL_PKEY_PARAM_DEFAULT_DIGEST)) != NULL
         && !OSSL_PARAM_set_utf8_string(p, DSA_DEFAULT_MD))
         return 0;
-    return ffc_params_todata(dsa_get0_params(dsa), NULL, params)
+    return ossl_ffc_params_todata(dsa_get0_params(dsa), NULL, params)
            && dsa_key_todata(dsa, NULL, params);
 }
 
@@ -513,21 +513,21 @@ static void *dsa_gen(void *genctx, OSSL_CALLBACK *osslcb, void *cbarg)
     ffc = dsa_get0_params(dsa);
     /* Copy the template value if one was passed */
     if (gctx->ffc_params != NULL
-        && !ffc_params_copy(ffc, gctx->ffc_params))
+        && !ossl_ffc_params_copy(ffc, gctx->ffc_params))
         goto end;
 
     if (gctx->seed != NULL
-        && !ffc_params_set_seed(ffc, gctx->seed, gctx->seedlen))
+        && !ossl_ffc_params_set_seed(ffc, gctx->seed, gctx->seedlen))
         goto end;
     if (gctx->gindex != -1) {
-        ffc_params_set_gindex(ffc, gctx->gindex);
+        ossl_ffc_params_set_gindex(ffc, gctx->gindex);
         if (gctx->pcounter != -1)
-            ffc_params_set_pcounter(ffc, gctx->pcounter);
+            ossl_ffc_params_set_pcounter(ffc, gctx->pcounter);
     } else if (gctx->hindex != 0) {
-        ffc_params_set_h(ffc, gctx->hindex);
+        ossl_ffc_params_set_h(ffc, gctx->hindex);
     }
     if (gctx->mdname != NULL) {
-        if (!ffc_set_digest(ffc, gctx->mdname, gctx->mdprops))
+        if (!ossl_ffc_set_digest(ffc, gctx->mdname, gctx->mdprops))
             goto end;
     }
     if ((gctx->selection & OSSL_KEYMGMT_SELECT_DOMAIN_PARAMETERS) != 0) {
@@ -537,8 +537,8 @@ static void *dsa_gen(void *genctx, OSSL_CALLBACK *osslcb, void *cbarg)
                                          gencb) <= 0)
              goto end;
     }
-    ffc_params_enable_flags(ffc, FFC_PARAM_FLAG_VALIDATE_LEGACY,
-                            gctx->gen_type == DSA_PARAMGEN_TYPE_FIPS_186_2);
+    ossl_ffc_params_enable_flags(ffc, FFC_PARAM_FLAG_VALIDATE_LEGACY,
+                                 gctx->gen_type == DSA_PARAMGEN_TYPE_FIPS_186_2);
     if ((gctx->selection & OSSL_KEYMGMT_SELECT_KEYPAIR) != 0) {
         if (ffc->p == NULL
             || ffc->q == NULL

--- a/test/ffc_internal_test.c
+++ b/test/ffc_internal_test.c
@@ -171,7 +171,7 @@ static int ffc_params_validate_g_unverified_test(void)
     BIGNUM *p = NULL, *q = NULL, *g = NULL;
     BIGNUM *p1 = NULL, *g1 = NULL;
 
-    ffc_params_init(&params);
+    ossl_ffc_params_init(&params);
 
     if (!TEST_ptr(p = BN_bin2bn(dsa_2048_224_sha256_p,
                                 sizeof(dsa_2048_224_sha256_p), NULL)))
@@ -186,48 +186,48 @@ static int ffc_params_validate_g_unverified_test(void)
     g1 = g;
 
     /* Fail if g is NULL */
-    ffc_params_set0_pqg(&params, p, q, NULL);
+    ossl_ffc_params_set0_pqg(&params, p, q, NULL);
     p = NULL;
     q = NULL;
-    ffc_params_set_flags(&params, FFC_PARAM_FLAG_VALIDATE_G);
-    ffc_set_digest(&params, "SHA256", NULL);
+    ossl_ffc_params_set_flags(&params, FFC_PARAM_FLAG_VALIDATE_G);
+    ossl_ffc_set_digest(&params, "SHA256", NULL);
 
-    if (!TEST_false(ffc_params_FIPS186_4_validate(NULL, &params,
-                                                  FFC_PARAM_TYPE_DSA,
-                                                  &res, NULL)))
+    if (!TEST_false(ossl_ffc_params_FIPS186_4_validate(NULL, &params,
+                                                       FFC_PARAM_TYPE_DSA,
+                                                       &res, NULL)))
         goto err;
 
-    ffc_params_set0_pqg(&params, p, q, g);
+    ossl_ffc_params_set0_pqg(&params, p, q, g);
     g = NULL;
-    if (!TEST_true(ffc_params_FIPS186_4_validate(NULL, &params,
-                                                 FFC_PARAM_TYPE_DSA,
-                                                 &res, NULL)))
+    if (!TEST_true(ossl_ffc_params_FIPS186_4_validate(NULL, &params,
+                                                      FFC_PARAM_TYPE_DSA,
+                                                      &res, NULL)))
         goto err;
 
     /* incorrect g */
     BN_add_word(g1, 1);
-    if (!TEST_false(ffc_params_FIPS186_4_validate(NULL, &params,
-                                                  FFC_PARAM_TYPE_DSA,
-                                                  &res, NULL)))
+    if (!TEST_false(ossl_ffc_params_FIPS186_4_validate(NULL, &params,
+                                                       FFC_PARAM_TYPE_DSA,
+                                                       &res, NULL)))
         goto err;
 
     /* fail if g < 2 */
     BN_set_word(g1, 1);
-    if (!TEST_false(ffc_params_FIPS186_4_validate(NULL, &params,
-                                                  FFC_PARAM_TYPE_DSA,
-                                                  &res, NULL)))
+    if (!TEST_false(ossl_ffc_params_FIPS186_4_validate(NULL, &params,
+                                                       FFC_PARAM_TYPE_DSA,
+                                                       &res, NULL)))
         goto err;
 
     BN_copy(g1, p1);
     /* Fail if g >= p */
-    if (!TEST_false(ffc_params_FIPS186_4_validate(NULL, &params,
-                                                  FFC_PARAM_TYPE_DSA,
-                                                  &res, NULL)))
+    if (!TEST_false(ossl_ffc_params_FIPS186_4_validate(NULL, &params,
+                                                       FFC_PARAM_TYPE_DSA,
+                                                       &res, NULL)))
         goto err;
 
     ret = 1;
 err:
-    ffc_params_cleanup(&params);
+    ossl_ffc_params_cleanup(&params);
     BN_free(p);
     BN_free(q);
     BN_free(g);
@@ -240,7 +240,7 @@ static int ffc_params_validate_pq_test(void)
     FFC_PARAMS params;
     BIGNUM *p = NULL, *q = NULL;
 
-    ffc_params_init(&params);
+    ossl_ffc_params_init(&params);
     if (!TEST_ptr(p = BN_bin2bn(dsa_2048_224_sha224_p,
                                    sizeof(dsa_2048_224_sha224_p),
                                    NULL)))
@@ -251,52 +251,52 @@ static int ffc_params_validate_pq_test(void)
         goto err;
 
     /* No p */
-    ffc_params_set0_pqg(&params, NULL, q, NULL);
+    ossl_ffc_params_set0_pqg(&params, NULL, q, NULL);
     q = NULL;
-    ffc_params_set_flags(&params, FFC_PARAM_FLAG_VALIDATE_PQ);
-    ffc_set_digest(&params, "SHA224", NULL);
+    ossl_ffc_params_set_flags(&params, FFC_PARAM_FLAG_VALIDATE_PQ);
+    ossl_ffc_set_digest(&params, "SHA224", NULL);
 
-    if (!TEST_false(ffc_params_FIPS186_4_validate(NULL, &params,
-                                                  FFC_PARAM_TYPE_DSA,
-                                                  &res, NULL)))
+    if (!TEST_false(ossl_ffc_params_FIPS186_4_validate(NULL, &params,
+                                                       FFC_PARAM_TYPE_DSA,
+                                                       &res, NULL)))
         goto err;
 
     /* Test valid case */
-    ffc_params_set0_pqg(&params, p, NULL, NULL);
+    ossl_ffc_params_set0_pqg(&params, p, NULL, NULL);
     p = NULL;
-    ffc_params_set_validate_params(&params, dsa_2048_224_sha224_seed,
-                                   sizeof(dsa_2048_224_sha224_seed),
-                                   dsa_2048_224_sha224_counter);
-    if (!TEST_true(ffc_params_FIPS186_4_validate(NULL, &params,
-                                                 FFC_PARAM_TYPE_DSA,
-                                                 &res, NULL)))
+    ossl_ffc_params_set_validate_params(&params, dsa_2048_224_sha224_seed,
+                                        sizeof(dsa_2048_224_sha224_seed),
+                                        dsa_2048_224_sha224_counter);
+    if (!TEST_true(ossl_ffc_params_FIPS186_4_validate(NULL, &params,
+                                                      FFC_PARAM_TYPE_DSA,
+                                                      &res, NULL)))
         goto err;
 
     /* Bad counter - so p is not prime */
-    ffc_params_set_validate_params(&params, dsa_2048_224_sha224_seed,
-                                   sizeof(dsa_2048_224_sha224_seed),
-                                   1);
-    if (!TEST_false(ffc_params_FIPS186_4_validate(NULL, &params,
-                                                  FFC_PARAM_TYPE_DSA,
-                                                  &res, NULL)))
+    ossl_ffc_params_set_validate_params(&params, dsa_2048_224_sha224_seed,
+                                        sizeof(dsa_2048_224_sha224_seed),
+                                        1);
+    if (!TEST_false(ossl_ffc_params_FIPS186_4_validate(NULL, &params,
+                                                       FFC_PARAM_TYPE_DSA,
+                                                       &res, NULL)))
         goto err;
 
     /* seedlen smaller than N */
-    ffc_params_set_validate_params(&params, dsa_2048_224_sha224_seed,
-                                   sizeof(dsa_2048_224_sha224_seed)-1,
-                                   dsa_2048_224_sha224_counter);
-    if (!TEST_false(ffc_params_FIPS186_4_validate(NULL, &params,
-                                                  FFC_PARAM_TYPE_DSA,
-                                                  &res, NULL)))
+    ossl_ffc_params_set_validate_params(&params, dsa_2048_224_sha224_seed,
+                                        sizeof(dsa_2048_224_sha224_seed)-1,
+                                        dsa_2048_224_sha224_counter);
+    if (!TEST_false(ossl_ffc_params_FIPS186_4_validate(NULL, &params,
+                                                       FFC_PARAM_TYPE_DSA,
+                                                       &res, NULL)))
         goto err;
 
     /* Provided seed doesnt produce a valid prime q */
-    ffc_params_set_validate_params(&params, dsa_2048_224_sha224_bad_seed,
-                                   sizeof(dsa_2048_224_sha224_bad_seed),
-                                   dsa_2048_224_sha224_counter);
-    if (!TEST_false(ffc_params_FIPS186_4_validate(NULL, &params,
-                                                  FFC_PARAM_TYPE_DSA,
-                                                  &res, NULL)))
+    ossl_ffc_params_set_validate_params(&params, dsa_2048_224_sha224_bad_seed,
+                                        sizeof(dsa_2048_224_sha224_bad_seed),
+                                        dsa_2048_224_sha224_counter);
+    if (!TEST_false(ossl_ffc_params_FIPS186_4_validate(NULL, &params,
+                                                       FFC_PARAM_TYPE_DSA,
+                                                       &res, NULL)))
         goto err;
 
     if (!TEST_ptr(p = BN_bin2bn(dsa_3072_256_sha512_p,
@@ -308,27 +308,27 @@ static int ffc_params_validate_pq_test(void)
         goto err;
 
 
-    ffc_params_set0_pqg(&params, p, q, NULL);
+    ossl_ffc_params_set0_pqg(&params, p, q, NULL);
     p = q  = NULL;
-    ffc_set_digest(&params, "SHA512", NULL);
-    ffc_params_set_validate_params(&params, dsa_3072_256_sha512_seed,
-                                   sizeof(dsa_3072_256_sha512_seed),
-                                   dsa_3072_256_sha512_counter);
+    ossl_ffc_set_digest(&params, "SHA512", NULL);
+    ossl_ffc_params_set_validate_params(&params, dsa_3072_256_sha512_seed,
+                                        sizeof(dsa_3072_256_sha512_seed),
+                                        dsa_3072_256_sha512_counter);
     /* Q doesn't div P-1 */
-    if (!TEST_false(ffc_params_FIPS186_4_validate(NULL, &params,
-                                                  FFC_PARAM_TYPE_DSA,
-                                                  &res, NULL)))
+    if (!TEST_false(ossl_ffc_params_FIPS186_4_validate(NULL, &params,
+                                                       FFC_PARAM_TYPE_DSA,
+                                                       &res, NULL)))
         goto err;
 
     /* Bad L/N for FIPS DH */
-    if (!TEST_false(ffc_params_FIPS186_4_validate(NULL, &params,
-                                                  FFC_PARAM_TYPE_DH,
-                                                  &res, NULL)))
+    if (!TEST_false(ossl_ffc_params_FIPS186_4_validate(NULL, &params,
+                                                       FFC_PARAM_TYPE_DH,
+                                                       &res, NULL)))
         goto err;
 
     ret = 1;
 err:
-    ffc_params_cleanup(&params);
+    ossl_ffc_params_cleanup(&params);
     BN_free(p);
     BN_free(q);
     return ret;
@@ -341,19 +341,19 @@ static int ffc_params_gen_test(void)
     int ret = 0, res = -1;
     FFC_PARAMS params;
 
-    ffc_params_init(&params);
-    if (!TEST_true(ffc_params_FIPS186_4_generate(NULL, &params,
-                                                 FFC_PARAM_TYPE_DH,
-                                                 2048, 256, &res, NULL)))
+    ossl_ffc_params_init(&params);
+    if (!TEST_true(ossl_ffc_params_FIPS186_4_generate(NULL, &params,
+                                                      FFC_PARAM_TYPE_DH,
+                                                      2048, 256, &res, NULL)))
         goto err;
-    if (!TEST_true(ffc_params_FIPS186_4_validate(NULL, &params,
-                                                 FFC_PARAM_TYPE_DH,
-                                                 &res, NULL)))
+    if (!TEST_true(ossl_ffc_params_FIPS186_4_validate(NULL, &params,
+                                                      FFC_PARAM_TYPE_DH,
+                                                      &res, NULL)))
         goto err;
 
     ret = 1;
 err:
-    ffc_params_cleanup(&params);
+    ossl_ffc_params_cleanup(&params);
     return ret;
 }
 
@@ -362,23 +362,23 @@ static int ffc_params_gen_canonicalg_test(void)
     int ret = 0, res = -1;
     FFC_PARAMS params;
 
-    ffc_params_init(&params);
+    ossl_ffc_params_init(&params);
     params.gindex = 1;
-    if (!TEST_true(ffc_params_FIPS186_4_generate(NULL, &params,
-                                                 FFC_PARAM_TYPE_DH,
-                                                 2048, 256, &res, NULL)))
+    if (!TEST_true(ossl_ffc_params_FIPS186_4_generate(NULL, &params,
+                                                      FFC_PARAM_TYPE_DH,
+                                                      2048, 256, &res, NULL)))
         goto err;
-    if (!TEST_true(ffc_params_FIPS186_4_validate(NULL, &params,
-                                                 FFC_PARAM_TYPE_DH,
-                                                 &res, NULL)))
+    if (!TEST_true(ossl_ffc_params_FIPS186_4_validate(NULL, &params,
+                                                      FFC_PARAM_TYPE_DH,
+                                                      &res, NULL)))
         goto err;
 
-    if (!TEST_true(ffc_params_print(bio_out, &params, 4)))
+    if (!TEST_true(ossl_ffc_params_print(bio_out, &params, 4)))
         goto err;
 
     ret = 1;
 err:
-    ffc_params_cleanup(&params);
+    ossl_ffc_params_cleanup(&params);
     return ret;
 }
 
@@ -388,44 +388,44 @@ static int ffc_params_fips186_2_gen_validate_test(void)
     FFC_PARAMS params;
     BIGNUM *bn = NULL;
 
-    ffc_params_init(&params);
+    ossl_ffc_params_init(&params);
     if (!TEST_ptr(bn = BN_new()))
         goto err;
-    if (!TEST_true(ffc_params_FIPS186_2_generate(NULL, &params,
-                                                 FFC_PARAM_TYPE_DH,
-                                                 1024, 160, &res, NULL)))
+    if (!TEST_true(ossl_ffc_params_FIPS186_2_generate(NULL, &params,
+                                                      FFC_PARAM_TYPE_DH,
+                                                      1024, 160, &res, NULL)))
         goto err;
-    if (!TEST_true(ffc_params_FIPS186_2_validate(NULL, &params,
-                                                 FFC_PARAM_TYPE_DH,
-                                                 &res, NULL)))
+    if (!TEST_true(ossl_ffc_params_FIPS186_2_validate(NULL, &params,
+                                                      FFC_PARAM_TYPE_DH,
+                                                      &res, NULL)))
         goto err;
 
     /*
      * The fips186-2 generation should produce a different q compared to
      * fips 186-4 given the same seed value. So validation of q will fail.
      */
-    if (!TEST_false(ffc_params_FIPS186_4_validate(NULL, &params,
-                                                  FFC_PARAM_TYPE_DSA,
-                                                  &res, NULL)))
+    if (!TEST_false(ossl_ffc_params_FIPS186_4_validate(NULL, &params,
+                                                       FFC_PARAM_TYPE_DSA,
+                                                       &res, NULL)))
         goto err;
     /* As the params are randomly generated the error is one of the following */
     if (!TEST_true(res == FFC_CHECK_Q_MISMATCH || res == FFC_CHECK_Q_NOT_PRIME))
         goto err;
 
-    ffc_params_set_flags(&params, FFC_PARAM_FLAG_VALIDATE_G);
+    ossl_ffc_params_set_flags(&params, FFC_PARAM_FLAG_VALIDATE_G);
     /* Partially valid g test will still pass */
-    if (!TEST_int_eq(ffc_params_FIPS186_4_validate(NULL, &params,
-                                                   FFC_PARAM_TYPE_DSA,
-                                                   &res, NULL), 2))
+    if (!TEST_int_eq(ossl_ffc_params_FIPS186_4_validate(NULL, &params,
+                                                        FFC_PARAM_TYPE_DSA,
+                                                        &res, NULL), 2))
         goto err;
 
-    if (!TEST_true(ffc_params_print(bio_out, &params, 4)))
+    if (!TEST_true(ossl_ffc_params_print(bio_out, &params, 4)))
         goto err;
 
     ret = 1;
 err:
     BN_free(bn);
-    ffc_params_cleanup(&params);
+    ossl_ffc_params_cleanup(&params);
     return ret;
 }
 
@@ -449,7 +449,7 @@ static int ffc_public_validate_test(void)
         goto err;
     BN_set_negative(pub, 1);
     /* Fail if public key is negative */
-    if (!TEST_false(ffc_validate_public_key(params, pub, &res)))
+    if (!TEST_false(ossl_ffc_validate_public_key(params, pub, &res)))
         goto err;
     if (!TEST_int_eq(FFC_ERROR_PUBKEY_TOO_SMALL, res))
         goto err;
@@ -458,25 +458,25 @@ static int ffc_public_validate_test(void)
     if (!TEST_int_eq(FFC_ERROR_PUBKEY_TOO_SMALL, res))
         goto err;
     /* Fail if public key is zero */
-    if (!TEST_false(ffc_validate_public_key(params, pub, &res)))
+    if (!TEST_false(ossl_ffc_validate_public_key(params, pub, &res)))
         goto err;
     if (!TEST_int_eq(FFC_ERROR_PUBKEY_TOO_SMALL, res))
         goto err;
     /* Fail if public key is 1 */
-    if (!TEST_false(ffc_validate_public_key(params, BN_value_one(), &res)))
+    if (!TEST_false(ossl_ffc_validate_public_key(params, BN_value_one(), &res)))
         goto err;
     if (!TEST_int_eq(FFC_ERROR_PUBKEY_TOO_SMALL, res))
         goto err;
     if (!TEST_true(BN_add_word(pub, 2)))
         goto err;
     /* Pass if public key >= 2 */
-    if (!TEST_true(ffc_validate_public_key(params, pub, &res)))
+    if (!TEST_true(ossl_ffc_validate_public_key(params, pub, &res)))
         goto err;
 
     if (!TEST_ptr(BN_copy(pub, params->p)))
         goto err;
     /* Fail if public key = p */
-    if (!TEST_false(ffc_validate_public_key(params, pub, &res)))
+    if (!TEST_false(ossl_ffc_validate_public_key(params, pub, &res)))
         goto err;
     if (!TEST_int_eq(FFC_ERROR_PUBKEY_TOO_LARGE, res))
         goto err;
@@ -484,7 +484,7 @@ static int ffc_public_validate_test(void)
     if (!TEST_true(BN_sub_word(pub, 1)))
         goto err;
     /* Fail if public key = p - 1 */
-    if (!TEST_false(ffc_validate_public_key(params, pub, &res)))
+    if (!TEST_false(ossl_ffc_validate_public_key(params, pub, &res)))
         goto err;
     if (!TEST_int_eq(FFC_ERROR_PUBKEY_TOO_LARGE, res))
         goto err;
@@ -492,7 +492,7 @@ static int ffc_public_validate_test(void)
     if (!TEST_true(BN_sub_word(pub, 1)))
         goto err;
     /* Fail if public key is not related to p & q */
-    if (!TEST_false(ffc_validate_public_key(params, pub, &res)))
+    if (!TEST_false(ossl_ffc_validate_public_key(params, pub, &res)))
         goto err;
     if (!TEST_int_eq(FFC_ERROR_PUBKEY_INVALID, res))
         goto err;
@@ -500,7 +500,7 @@ static int ffc_public_validate_test(void)
     if (!TEST_true(BN_sub_word(pub, 5)))
         goto err;
     /* Pass if public key is valid */
-    if (!TEST_true(ffc_validate_public_key(params, pub, &res)))
+    if (!TEST_true(ossl_ffc_validate_public_key(params, pub, &res)))
         goto err;
 
     ret = 1;
@@ -528,7 +528,7 @@ static int ffc_private_validate_test(void)
         goto err;
     BN_set_negative(priv, 1);
     /* Fail if priv key is negative */
-    if (!TEST_false(ffc_validate_private_key(params->q, priv, &res)))
+    if (!TEST_false(ossl_ffc_validate_private_key(params->q, priv, &res)))
         goto err;
     if (!TEST_int_eq(FFC_ERROR_PRIVKEY_TOO_SMALL, res))
         goto err;
@@ -536,19 +536,20 @@ static int ffc_private_validate_test(void)
     if (!TEST_true(BN_set_word(priv, 0)))
         goto err;
     /* Fail if priv key is zero */
-    if (!TEST_false(ffc_validate_private_key(params->q, priv, &res)))
+    if (!TEST_false(ossl_ffc_validate_private_key(params->q, priv, &res)))
         goto err;
     if (!TEST_int_eq(FFC_ERROR_PRIVKEY_TOO_SMALL, res))
         goto err;
 
     /* Pass if priv key >= 1 */
-    if (!TEST_true(ffc_validate_private_key(params->q, BN_value_one(), &res)))
+    if (!TEST_true(ossl_ffc_validate_private_key(params->q, BN_value_one(),
+                                                 &res)))
         goto err;
 
     if (!TEST_ptr(BN_copy(priv, params->q)))
         goto err;
     /* Fail if priv key = upper */
-    if (!TEST_false(ffc_validate_private_key(params->q, priv, &res)))
+    if (!TEST_false(ossl_ffc_validate_private_key(params->q, priv, &res)))
         goto err;
     if (!TEST_int_eq(FFC_ERROR_PRIVKEY_TOO_LARGE, res))
         goto err;
@@ -556,7 +557,7 @@ static int ffc_private_validate_test(void)
     if (!TEST_true(BN_sub_word(priv, 1)))
         goto err;
     /* Pass if priv key <= upper - 1 */
-    if (!TEST_true(ffc_validate_private_key(params->q, priv, &res)))
+    if (!TEST_true(ossl_ffc_validate_private_key(params->q, priv, &res)))
         goto err;
 
     ret = 1;
@@ -586,27 +587,27 @@ static int ffc_private_gen_test(int index)
 
     N = BN_num_bits(params->q);
     /* Fail since N < 2*s - where s = 112*/
-    if (!TEST_false(ffc_generate_private_key(ctx, params, 220, 112, priv)))
+    if (!TEST_false(ossl_ffc_generate_private_key(ctx, params, 220, 112, priv)))
         goto err;
     /* fail since N > len(q) */
-    if (!TEST_false(ffc_generate_private_key(ctx, params, N + 1, 112, priv)))
+    if (!TEST_false(ossl_ffc_generate_private_key(ctx, params, N + 1, 112, priv)))
         goto err;
     /* pass since 2s <= N <= len(q) */
-    if (!TEST_true(ffc_generate_private_key(ctx, params, N, 112, priv)))
+    if (!TEST_true(ossl_ffc_generate_private_key(ctx, params, N, 112, priv)))
         goto err;
     /* pass since N = len(q) */
-    if (!TEST_true(ffc_validate_private_key(params->q, priv, &res)))
+    if (!TEST_true(ossl_ffc_validate_private_key(params->q, priv, &res)))
         goto err;
     /* pass since 2s <= N < len(q) */
-    if (!TEST_true(ffc_generate_private_key(ctx, params, N / 2, 112, priv)))
+    if (!TEST_true(ossl_ffc_generate_private_key(ctx, params, N / 2, 112, priv)))
         goto err;
-    if (!TEST_true(ffc_validate_private_key(params->q, priv, &res)))
+    if (!TEST_true(ossl_ffc_validate_private_key(params->q, priv, &res)))
         goto err;
 
     /* N and s are ignored in this case */
-    if (!TEST_true(ffc_generate_private_key(ctx, params, 0, 0, priv)))
+    if (!TEST_true(ossl_ffc_generate_private_key(ctx, params, 0, 0, priv)))
         goto err;
-    if (!TEST_true(ffc_validate_private_key(params->q, priv, &res)))
+    if (!TEST_true(ossl_ffc_validate_private_key(params->q, priv, &res)))
         goto err;
 
     ret = 1;


### PR DESCRIPTION
The functions updated are:
```
ffc_generate_private_key, ffc_named_group_from_uid, ffc_named_group_to_uid, ffc_params_FIPS186_2_gen_verify,
ffc_params_FIPS186_2_generate, ffc_params_FIPS186_2_validate, ffc_params_FIPS186_4_gen_verify, ffc_params_FIPS186_4_generate,
ffc_params_FIPS186_4_validate, ffc_params_cleanup, ffc_params_cmp, ffc_params_copy, ffc_params_enable_flags,
ffc_params_flags_from_name, ffc_params_flags_to_name, ffc_params_fromdata, ffc_params_get0_pqg, ffc_params_get_validate_params,
ffc_params_init, ffc_params_print, ffc_params_set0_j, ffc_params_set0_pqg, ffc_params_set_flags, ffc_params_set_gindex,
ffc_params_set_h, ffc_params_set_pcounter, ffc_params_set_seed, ffc_params_set_validate_params, ffc_params_simple_validate,
ffc_params_todata, ffc_params_validate_unverifiable_g, ffc_set_digest, ffc_set_group_pqg, ffc_validate_private_key,
ffc_validate_public_key and ffc_validate_public_key_partial.
```

- [x] tests are added or updated
