### PR TITLE
EVP: use evp_pkey_ctx_is_legacy() to find what implementation to use

### DIFF
--- a/crypto/evp/asymcipher.c
+++ b/crypto/evp/asymcipher.c
@@ -38,7 +38,7 @@ static int evp_pkey_asym_cipher_init(EVP_PKEY_CTX *ctx, int operation)
      */
     ERR_set_mark();
 
-    if (ctx->engine != NULL || ctx->keytype == NULL)
+    if (evp_pkey_ctx_is_legacy(ctx))
         goto legacy;
 
     /*

--- a/crypto/evp/exchange.c
+++ b/crypto/evp/exchange.c
@@ -197,7 +197,7 @@ int EVP_PKEY_derive_init(EVP_PKEY_CTX *ctx)
      */
     ERR_set_mark();
 
-    if (ctx->keymgmt == NULL)
+    if (evp_pkey_ctx_is_legacy(ctx))
         goto legacy;
 
     /*

--- a/crypto/evp/m_sigver.c
+++ b/crypto/evp/m_sigver.c
@@ -80,7 +80,7 @@ static int do_sigver_init(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx,
      */
     ERR_set_mark();
 
-    if (locpctx->engine != NULL || locpctx->keytype == NULL)
+    if (evp_pkey_ctx_is_legacy(locpctx))
         goto legacy;
 
     /*

--- a/crypto/evp/signature.c
+++ b/crypto/evp/signature.c
@@ -381,7 +381,7 @@ static int evp_pkey_signature_init(EVP_PKEY_CTX *ctx, int operation)
      */
     ERR_set_mark();
 
-    if (ctx->keymgmt == NULL)
+    if (evp_pkey_ctx_is_legacy(ctx))
         goto legacy;
 
     /*

--- a/include/crypto/evp.h
+++ b/include/crypto/evp.h
@@ -18,6 +18,22 @@
  */
 #define EVP_MD_CTX_FLAG_KEEP_PKEY_CTX   0x0400
 
+/*
+ * An EVP_PKEY can have the following support states:
+ *
+ * Supports legacy implementations only:
+ *
+ *      engine != NULL || keytype == NULL
+ *
+ * Supports provided implementations:
+ *
+ *      engine == NULL && keytype != NULL
+ */
+#define evp_pkey_ctx_is_legacy(ctx)                             \
+    ((ctx)->engine != NULL || (ctx)->keytype == NULL)
+#define evp_pkey_ctx_is_provided(ctx)                           \
+    (!evp_pkey_ctx_is_legacy(ctx))
+
 struct evp_pkey_ctx_st {
     /* Actual operation */
     int operation;


### PR DESCRIPTION
We've had explicit checks for when to fall back to legacy code for
operations that use an EVP_PKEY.  Unfortunately, the checks were
radically different in different spots, so we refactor that into a
macro that gets used everywhere.
