### PR TITLE
APPS: Reduce deprecation warning suppression - ENGINE

### DIFF
--- a/apps/include/apps.h
+++ b/apps/include/apps.h
@@ -151,6 +151,12 @@ __owur int ctx_set_ctlog_list_file(SSL_CTX *ctx, const char *path);
 ENGINE *setup_engine_methods(const char *id, unsigned int methods, int debug);
 # define setup_engine(e, debug) setup_engine_methods(e, (unsigned int)-1, debug)
 void release_engine(ENGINE *e);
+int init_engine(ENGINE *e);
+int finish_engine(ENGINE *e);
+EVP_PKEY *load_engine_private_key(ENGINE *e, const char *keyid,
+                                  const char *pass, const char *desc);
+EVP_PKEY *load_engine_public_key(ENGINE *e, const char *keyid,
+                                 const char *pass, const char *desc);
 
 # ifndef OPENSSL_NO_OCSP
 OCSP_RESPONSE *process_responder(OCSP_REQUEST *req,

--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -581,7 +581,7 @@ EVP_PKEY *load_pubkey(const char *uri, int format, int maybe_stdin,
         if (e == NULL) {
             BIO_printf(bio_err, "No engine specified for loading %s\n", desc);
         } else {
-            pkey = load_engine_private_key(e, uri, pass, desc);
+            pkey = load_engine_public_key(e, uri, pass, desc);
             if (pkey == NULL) {
                 BIO_printf(bio_err, "Cannot load %s from engine\n", desc);
                 ERR_print_errors(bio_err);

--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -7,9 +7,6 @@
  * https://www.openssl.org/source/license.html
  */
 
-/* We need to use some engine deprecated APIs */
-#define OPENSSL_SUPPRESS_DEPRECATED
-
 #if !defined(_POSIX_C_SOURCE) && defined(OPENSSL_SYS_VMS)
 /*
  * On VMS, you need to define this to get the declaration of fileno().  The
@@ -36,9 +33,6 @@
 #include <openssl/pkcs12.h>
 #include <openssl/ui.h>
 #include <openssl/safestack.h>
-#ifndef OPENSSL_NO_ENGINE
-# include <openssl/engine.h>
-#endif
 #ifndef OPENSSL_NO_RSA
 # include <openssl/rsa.h>
 #endif
@@ -557,24 +551,11 @@ EVP_PKEY *load_key(const char *uri, int format, int may_stdin,
         if (e == NULL) {
             BIO_printf(bio_err, "No engine specified for loading %s\n", desc);
         } else {
-#ifndef OPENSSL_NO_ENGINE
-            PW_CB_DATA cb_data;
-
-            cb_data.password = pass;
-            cb_data.prompt_info = uri;
-            if (ENGINE_init(e)) {
-                pkey = ENGINE_load_private_key(e, uri,
-                                               (UI_METHOD *)get_ui_method(),
-                                               &cb_data);
-                ENGINE_finish(e);
-            }
+            pkey = load_engine_private_key(e, uri, pass, desc);
             if (pkey == NULL) {
                 BIO_printf(bio_err, "Cannot load %s from engine\n", desc);
                 ERR_print_errors(bio_err);
             }
-#else
-            BIO_printf(bio_err, "Engines not supported for loading %s\n", desc);
-#endif
         }
     } else {
         (void)load_key_certs_crls(uri, may_stdin, pass, desc,
@@ -600,20 +581,11 @@ EVP_PKEY *load_pubkey(const char *uri, int format, int maybe_stdin,
         if (e == NULL) {
             BIO_printf(bio_err, "No engine specified for loading %s\n", desc);
         } else {
-#ifndef OPENSSL_NO_ENGINE
-            PW_CB_DATA cb_data;
-
-            cb_data.password = pass;
-            cb_data.prompt_info = uri;
-            pkey = ENGINE_load_public_key(e, uri, (UI_METHOD *)get_ui_method(),
-                                          &cb_data);
+            pkey = load_engine_private_key(e, uri, pass, desc);
             if (pkey == NULL) {
                 BIO_printf(bio_err, "Cannot load %s from engine\n", desc);
                 ERR_print_errors(bio_err);
             }
-#else
-            BIO_printf(bio_err, "Engines not supported for loading %s\n", desc);
-#endif
         }
     } else {
         (void)load_key_certs_crls(uri, maybe_stdin, pass, desc,
@@ -1160,64 +1132,6 @@ X509_STORE *setup_verify(const char *CAfile, int noCAfile,
     ERR_print_errors(bio_err);
     X509_STORE_free(store);
     return NULL;
-}
-
-#ifndef OPENSSL_NO_ENGINE
-/* Try to load an engine in a shareable library */
-static ENGINE *try_load_engine(const char *engine)
-{
-    ENGINE *e = ENGINE_by_id("dynamic");
-    if (e) {
-        if (!ENGINE_ctrl_cmd_string(e, "SO_PATH", engine, 0)
-            || !ENGINE_ctrl_cmd_string(e, "LOAD", NULL, 0)) {
-            ENGINE_free(e);
-            e = NULL;
-        }
-    }
-    return e;
-}
-#endif
-
-ENGINE *setup_engine_methods(const char *id, unsigned int methods, int debug)
-{
-    ENGINE *e = NULL;
-
-#ifndef OPENSSL_NO_ENGINE
-    if (id != NULL) {
-        if (strcmp(id, "auto") == 0) {
-            BIO_printf(bio_err, "Enabling auto ENGINE support\n");
-            ENGINE_register_all_complete();
-            return NULL;
-        }
-        if ((e = ENGINE_by_id(id)) == NULL
-            && (e = try_load_engine(id)) == NULL) {
-            BIO_printf(bio_err, "Invalid engine \"%s\"\n", id);
-            ERR_print_errors(bio_err);
-            return NULL;
-        }
-        if (debug)
-            (void)ENGINE_ctrl(e, ENGINE_CTRL_SET_LOGSTREAM, 0, bio_err, 0);
-        if (!ENGINE_ctrl_cmd(e, "SET_USER_INTERFACE", 0,
-                             (void *)get_ui_method(), 0, 1)
-                || !ENGINE_set_default(e, methods)) {
-            BIO_printf(bio_err, "Cannot use engine \"%s\"\n", ENGINE_get_id(e));
-            ERR_print_errors(bio_err);
-            ENGINE_free(e);
-            return NULL;
-        }
-
-        BIO_printf(bio_err, "Engine \"%s\" set.\n", ENGINE_get_id(e));
-    }
-#endif
-    return e;
-}
-
-void release_engine(ENGINE *e)
-{
-#ifndef OPENSSL_NO_ENGINE
-    /* Free our "structural" reference. */
-    ENGINE_free(e);
-#endif
 }
 
 static unsigned long index_serial_hash(const OPENSSL_CSTRING *a)

--- a/apps/lib/build.info
+++ b/apps/lib/build.info
@@ -9,7 +9,8 @@ ENDIF
 
 # Source for libapps
 $LIBAPPSSRC=apps.c apps_ui.c opt.c fmt.c s_cb.c s_socket.c app_rand.c \
-        columns.c app_params.c names.c app_provider.c app_x509.c http_server.c
+        columns.c app_params.c names.c app_provider.c app_x509.c http_server.c \
+        engine.c
 
 IF[{- !$disabled{apps} -}]
   LIBS{noinst}=../libapps.a

--- a/apps/lib/engine.c
+++ b/apps/lib/engine.c
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2020 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+/*
+ * Here is a set of wrappers for the ENGINE API, which are no-ops when the
+ * ENGINE API is disabled / removed.
+ * We need to suppress deprecation warnings to make this work.
+ */
+#define OPENSSL_SUPPRESS_DEPRECATED
+
+#include <openssl/types.h> /* Ensure we have the ENGINE type, regardless */
+#ifndef OPENSSL_NO_ENGINE
+# include <openssl/engine.h>
+#endif
+#include "apps.h"
+
+#ifndef OPENSSL_NO_ENGINE
+/* Try to load an engine in a shareable library */
+static ENGINE *try_load_engine(const char *engine)
+{
+    ENGINE *e = NULL;
+
+    if ((e = ENGINE_by_id("dynamic")) != NULL) {
+        if (!ENGINE_ctrl_cmd_string(e, "SO_PATH", engine, 0)
+            || !ENGINE_ctrl_cmd_string(e, "LOAD", NULL, 0)) {
+            ENGINE_free(e);
+            e = NULL;
+        }
+    }
+    return e;
+}
+#endif
+
+ENGINE *setup_engine_methods(const char *id, unsigned int methods, int debug)
+{
+    ENGINE *e = NULL;
+
+#ifndef OPENSSL_NO_ENGINE
+    if (id != NULL) {
+        if (strcmp(id, "auto") == 0) {
+            BIO_printf(bio_err, "Enabling auto ENGINE support\n");
+            ENGINE_register_all_complete();
+            return NULL;
+        }
+        if ((e = ENGINE_by_id(id)) == NULL
+            && (e = try_load_engine(id)) == NULL) {
+            BIO_printf(bio_err, "Invalid engine \"%s\"\n", id);
+            ERR_print_errors(bio_err);
+            return NULL;
+        }
+        if (debug)
+            (void)ENGINE_ctrl(e, ENGINE_CTRL_SET_LOGSTREAM, 0, bio_err, 0);
+        if (!ENGINE_ctrl_cmd(e, "SET_USER_INTERFACE", 0,
+                             (void *)get_ui_method(), 0, 1)
+                || !ENGINE_set_default(e, methods)) {
+            BIO_printf(bio_err, "Cannot use engine \"%s\"\n", ENGINE_get_id(e));
+            ERR_print_errors(bio_err);
+            ENGINE_free(e);
+            return NULL;
+        }
+
+        BIO_printf(bio_err, "Engine \"%s\" set.\n", ENGINE_get_id(e));
+    }
+#endif
+    return e;
+}
+
+void release_engine(ENGINE *e)
+{
+#ifndef OPENSSL_NO_ENGINE
+    /* Free our "structural" reference. */
+    ENGINE_free(e);
+#endif
+}
+
+int init_engine(ENGINE *e)
+{
+    int rv = 1;
+
+#ifndef OPENSSL_NO_ENGINE
+    rv = ENGINE_init(e);
+#endif
+    return rv;
+}
+
+int finish_engine(ENGINE *e)
+{
+    int rv = 1;
+
+#ifndef OPENSSL_NO_ENGINE
+    rv = ENGINE_finish(e);
+#endif
+    return rv;
+}
+
+EVP_PKEY *load_engine_private_key(ENGINE *e, const char *keyid,
+                                  const char *pass, const char *desc)
+{
+    EVP_PKEY *rv = NULL;
+
+#ifndef OPENSSL_NO_ENGINE
+    if (init_engine(e)) {
+        PW_CB_DATA cb_data;
+
+        cb_data.password = pass;
+        cb_data.prompt_info = keyid;
+
+        rv = ENGINE_load_private_key(e, keyid,
+                                     (UI_METHOD *)get_ui_method(), &cb_data);
+        finish_engine(e);
+    }
+#else
+    BIO_printf(bio_err, "Engines not supported for loading %s\n", desc);
+#endif
+    return rv;
+}
+
+EVP_PKEY *load_engine_public_key(ENGINE *e, const char *keyid,
+                                 const char *pass, const char *desc)
+{
+    EVP_PKEY *rv = NULL;
+
+#ifndef OPENSSL_NO_ENGINE
+    if (init_engine(e)) {
+        PW_CB_DATA cb_data;
+
+        cb_data.password = pass;
+        cb_data.prompt_info = keyid;
+
+        rv = ENGINE_load_public_key(e, keyid,
+                                    (UI_METHOD *)get_ui_method(), &cb_data);
+        finish_engine(e);
+    }
+#else
+    BIO_printf(bio_err, "Engines not supported for loading %s\n", desc);
+#endif
+    return rv;
+}
+

--- a/apps/req.c
+++ b/apps/req.c
@@ -284,11 +284,13 @@ int req_main(int argc, char **argv)
             e = setup_engine(opt_arg(), 0);
             break;
         case OPT_KEYGEN_ENGINE:
+#ifndef OPENSSL_NO_ENGINE
             gen_eng = setup_engine(opt_arg(), 0);
             if (gen_eng == NULL) {
                 BIO_printf(bio_err, "Can't find keygen engine %s\n", *argv);
                 goto opthelp;
             }
+#endif
             break;
         case OPT_KEY:
             keyfile = opt_arg();

--- a/apps/req.c
+++ b/apps/req.c
@@ -7,9 +7,6 @@
  * https://www.openssl.org/source/license.html
  */
 
-/* We need to use some engine deprecated APIs */
-#define OPENSSL_SUPPRESS_DEPRECATED
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
@@ -287,13 +284,11 @@ int req_main(int argc, char **argv)
             e = setup_engine(opt_arg(), 0);
             break;
         case OPT_KEYGEN_ENGINE:
-#ifndef OPENSSL_NO_ENGINE
-            gen_eng = ENGINE_by_id(opt_arg());
+            gen_eng = setup_engine(opt_arg(), 0);
             if (gen_eng == NULL) {
                 BIO_printf(bio_err, "Can't find keygen engine %s\n", *argv);
                 goto opthelp;
             }
-#endif
             break;
         case OPT_KEY:
             keyfile = opt_arg();
@@ -992,7 +987,7 @@ int req_main(int argc, char **argv)
     lh_OPENSSL_STRING_doall(addexts, exts_cleanup);
     lh_OPENSSL_STRING_free(addexts);
 #ifndef OPENSSL_NO_ENGINE
-    ENGINE_free(gen_eng);
+    release_engine(gen_eng);
 #endif
     OPENSSL_free(keyalgstr);
     X509_REQ_free(req);
@@ -1511,7 +1506,7 @@ static EVP_PKEY_CTX *set_keygen_ctx(const char *gstr,
 
         EVP_PKEY_asn1_get0_info(NULL, pkey_type, NULL, NULL, NULL, ameth);
 #ifndef OPENSSL_NO_ENGINE
-        ENGINE_finish(tmpeng);
+        finish_engine(tmpeng);
 #endif
         if (*pkey_type == EVP_PKEY_RSA) {
             if (p != NULL) {
@@ -1572,7 +1567,7 @@ static EVP_PKEY_CTX *set_keygen_ctx(const char *gstr,
         EVP_PKEY_asn1_get0_info(NULL, NULL, NULL, NULL, &anam, ameth);
         *palgnam = OPENSSL_strdup(anam);
 #ifndef OPENSSL_NO_ENGINE
-        ENGINE_finish(tmpeng);
+        finish_engine(tmpeng);
 #endif
     }
 

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -8,9 +8,6 @@
  * https://www.openssl.org/source/license.html
  */
 
-/* We need to use some engine deprecated APIs */
-#define OPENSSL_SUPPRESS_DEPRECATED
-
 #include "e_os.h"
 #include <ctype.h>
 #include <stdio.h>
@@ -1203,13 +1200,11 @@ int s_client_main(int argc, char **argv)
             e = setup_engine(opt_arg(), 1);
             break;
         case OPT_SSL_CLIENT_ENGINE:
-#ifndef OPENSSL_NO_ENGINE
-            ssl_client_engine = ENGINE_by_id(opt_arg());
+            ssl_client_engine = setup_engine(opt_arg(), 0);
             if (ssl_client_engine == NULL) {
                 BIO_printf(bio_err, "Error getting client auth engine\n");
                 goto opthelp;
             }
-#endif
             break;
         case OPT_R_CASES:
             if (!opt_rand(o))
@@ -1881,10 +1876,10 @@ int s_client_main(int argc, char **argv)
         if (!SSL_CTX_set_client_cert_engine(ctx, ssl_client_engine)) {
             BIO_puts(bio_err, "Error setting client auth engine\n");
             ERR_print_errors(bio_err);
-            ENGINE_free(ssl_client_engine);
+            release_engine(ssl_client_engine);
             goto end;
         }
-        ENGINE_free(ssl_client_engine);
+        release_engine(ssl_client_engine);
     }
 #endif
 

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -1200,11 +1200,13 @@ int s_client_main(int argc, char **argv)
             e = setup_engine(opt_arg(), 1);
             break;
         case OPT_SSL_CLIENT_ENGINE:
+#ifndef OPENSSL_NO_ENGINE
             ssl_client_engine = setup_engine(opt_arg(), 0);
             if (ssl_client_engine == NULL) {
                 BIO_printf(bio_err, "Error getting client auth engine\n");
                 goto opthelp;
             }
+#endif
             break;
         case OPT_R_CASES:
             if (!opt_rand(o))


### PR DESCRIPTION
Some of our apps turn off deprecation warnings solely for the sake of
ENGINE, and thereby shadowing other deprecations that we should take
better care of.

To solve this, all apps ENGINE functionality is move to one file,
where deprecation warning suppression is activate, and the same
suppression can then easily be removed in at least some of the apps.
Any remaining suppression that we still need to deal with should
happen as separate efforts.
