### PR TITLE
Correct and simplify use of ERR_clear_error() etc. for loading DSO libs

### DIFF
--- a/apps/cmp.c
+++ b/apps/cmp.c
@@ -2626,7 +2626,6 @@ int cmp_main(int argc, char **argv)
     char mock_server[] = "mock server:1";
     int ret = 0; /* default: failure */
 
-    ERR_clear_error(); /* clear leftover errors on loading libengines.so etc. */
     if (argc <= 1) {
         opt_help(cmp_options);
         goto err;

--- a/crypto/conf/conf_lib.c
+++ b/crypto/conf/conf_lib.c
@@ -101,6 +101,7 @@ STACK_OF(CONF_VALUE) *CONF_get_section(LHASH_OF(CONF_VALUE) *conf,
         return NULL;
     } else {
         CONF ctmp;
+
         CONF_set_nconf(&ctmp, conf);
         return NCONF_get_section(&ctmp, section);
     }
@@ -113,6 +114,7 @@ char *CONF_get_string(LHASH_OF(CONF_VALUE) *conf, const char *group,
         return NCONF_get_string(NULL, group, name);
     } else {
         CONF ctmp;
+
         CONF_set_nconf(&ctmp, conf);
         return NCONF_get_string(&ctmp, group, name);
     }
@@ -129,6 +131,7 @@ long CONF_get_number(LHASH_OF(CONF_VALUE) *conf, const char *group,
         status = NCONF_get_number_e(NULL, group, name, &result);
     } else {
         CONF ctmp;
+
         CONF_set_nconf(&ctmp, conf);
         status = NCONF_get_number_e(&ctmp, group, name, &result);
     }
@@ -162,6 +165,7 @@ int CONF_dump_fp(LHASH_OF(CONF_VALUE) *conf, FILE *out)
 int CONF_dump_bio(LHASH_OF(CONF_VALUE) *conf, BIO *out)
 {
     CONF ctmp;
+
     CONF_set_nconf(&ctmp, conf);
     return NCONF_dump_bio(&ctmp, out);
 }
@@ -327,6 +331,18 @@ int NCONF_get_number_e(const CONF *conf, const char *group, const char *name,
 
     *result = res;
     return 1;
+}
+
+long _CONF_get_number(const CONF *conf, const char *section,
+                      const char *name)
+{
+    int status;
+    long result = 0;
+
+    ERR_set_mark();
+    status = NCONF_get_number_e(conf, section, name, &result);
+    ERR_pop_to_mark();
+    return status == 0 ? 0L : result;
 }
 
 #ifndef OPENSSL_NO_STDIO

--- a/crypto/conf/conf_mod.c
+++ b/crypto/conf/conf_mod.c
@@ -15,6 +15,7 @@
 #include <ctype.h>
 #include <openssl/crypto.h>
 #include "internal/conf.h"
+#include "openssl/conf_api.h"
 #include "internal/dso.h"
 #include "internal/thread_once.h"
 #include <openssl/x509.h>
@@ -80,14 +81,7 @@ static CONF_MODULE *module_load_dso(const CONF *cnf, const char *name,
 
 static int conf_diagnostics(const CONF *cnf)
 {
-    long int lflag = 0;
-    int res;
-
-    ERR_set_mark();
-    res = NCONF_get_number(cnf, NULL, "config_diagnostics", &lflag)
-          && lflag != 0;
-    ERR_pop_to_mark();
-    return res;
+    return _CONF_get_number(cnf, NULL, "config_diagnostics") != 0;
 }
 
 /* Main function: load modules from a CONF structure */
@@ -109,6 +103,7 @@ int CONF_modules_load(const CONF *cnf, const char *appname,
                    | CONF_MFLAGS_SILENT
                    | CONF_MFLAGS_IGNORE_MISSING_FILE);
 
+    ERR_set_mark();
     if (appname)
         vsection = NCONF_get_string(cnf, NULL, appname);
 
@@ -116,7 +111,7 @@ int CONF_modules_load(const CONF *cnf, const char *appname,
         vsection = NCONF_get_string(cnf, NULL, "openssl_conf");
 
     if (!vsection) {
-        ERR_clear_error();
+        ERR_pop_to_mark();
         return 1;
     }
 
@@ -125,20 +120,28 @@ int CONF_modules_load(const CONF *cnf, const char *appname,
 
     if (values == NULL) {
         if (!(flags & CONF_MFLAGS_SILENT)) {
+            ERR_clear_last_mark();
             CONFerr(0, CONF_R_OPENSSL_CONF_REFERENCES_MISSING_SECTION);
             ERR_add_error_data(2, "openssl_conf=", vsection);
+        } else {
+            ERR_pop_to_mark();
         }
         return 0;
     }
+    ERR_pop_to_mark();
 
     for (i = 0; i < sk_CONF_VALUE_num(values); i++) {
         vl = sk_CONF_VALUE_value(values, i);
+        ERR_set_mark();
         ret = module_run(cnf, vl->name, vl->value, flags);
         OSSL_TRACE3(CONF, "Running module %s (%s) returned %d\n",
                     vl->name, vl->value, ret);
         if (ret <= 0)
-            if (!(flags & CONF_MFLAGS_IGNORE_ERRORS))
+            if (!(flags & CONF_MFLAGS_IGNORE_ERRORS)) {
+                ERR_clear_last_mark();
                 return ret;
+            }
+        ERR_pop_to_mark();
     }
 
     return 1;
@@ -152,6 +155,7 @@ int CONF_modules_load_file_ex(OPENSSL_CTX *libctx, const char *filename,
     CONF *conf = NULL;
     int ret = 0, diagnostics = 0;
 
+    ERR_set_mark();
     conf = NCONF_new_ex(libctx, NULL);
     if (conf == NULL)
         goto err;
@@ -167,11 +171,11 @@ int CONF_modules_load_file_ex(OPENSSL_CTX *libctx, const char *filename,
     if (NCONF_load(conf, file, NULL) <= 0) {
         if ((flags & CONF_MFLAGS_IGNORE_MISSING_FILE) &&
             (ERR_GET_REASON(ERR_peek_last_error()) == CONF_R_NO_SUCH_FILE)) {
-            ERR_clear_error();
             ret = 1;
         }
         goto err;
     }
+    ERR_pop_to_mark();
 
     ret = CONF_modules_load(conf, appname, flags);
     diagnostics = conf_diagnostics(conf);
@@ -182,8 +186,12 @@ int CONF_modules_load_file_ex(OPENSSL_CTX *libctx, const char *filename,
     NCONF_free(conf);
 
     if ((flags & CONF_MFLAGS_IGNORE_RETURN_CODES) != 0 && !diagnostics)
-        return 1;
+        ret = 1;
 
+    if (ret)
+        ERR_pop_to_mark();
+    else
+        ERR_clear_last_mark();
     return ret;
 }
 
@@ -255,9 +263,8 @@ static CONF_MODULE *module_load_dso(const CONF *cnf,
     CONF_MODULE *md;
 
     /* Look for alternative path in module section */
-    path = NCONF_get_string(cnf, value, "path");
+    path = _CONF_get_string(cnf, value, "path");
     if (path == NULL) {
-        ERR_clear_error();
         path = name;
     }
     dso = DSO_load(NULL, path, NULL, 0);

--- a/crypto/conf/conf_mod.c
+++ b/crypto/conf/conf_mod.c
@@ -175,7 +175,6 @@ int CONF_modules_load_file_ex(OPENSSL_CTX *libctx, const char *filename,
         }
         goto err;
     }
-    ERR_pop_to_mark();
 
     ret = CONF_modules_load(conf, appname, flags);
     diagnostics = conf_diagnostics(conf);

--- a/crypto/ts/ts_conf.c
+++ b/crypto/ts/ts_conf.c
@@ -17,6 +17,7 @@
 #include <openssl/pem.h>
 #include <openssl/engine.h>
 #include <openssl/ts.h>
+#include <openssl/conf_api.h>
 
 /* Macro definitions for the configuration file. */
 #define BASE_SECTION                    "tsa"
@@ -418,7 +419,7 @@ int TS_CONF_set_accuracy(CONF *conf, const char *section, TS_RESP_CTX *ctx)
     return ret;
 }
 
-int TS_CONF_set_clock_precision_digits(CONF *conf, const char *section,
+int TS_CONF_set_clock_precision_digits(const CONF *conf, const char *section,
                                        TS_RESP_CTX *ctx)
 {
     int ret = 0;
@@ -427,9 +428,7 @@ int TS_CONF_set_clock_precision_digits(CONF *conf, const char *section,
     /*
      * If not specified, set the default value to 0, i.e. sec precision
      */
-    if (!NCONF_get_number_e(conf, section, ENV_CLOCK_PRECISION_DIGITS,
-                            &digits))
-        digits = 0;
+    digits = _CONF_get_number(conf, section, ENV_CLOCK_PRECISION_DIGITS);
     if (digits < 0 || digits > TS_MAX_CLOCK_PRECISION_DIGITS) {
         ts_CONF_invalid(section, ENV_CLOCK_PRECISION_DIGITS);
         goto err;

--- a/include/openssl/ts.h
+++ b/include/openssl/ts.h
@@ -486,7 +486,7 @@ int TS_CONF_set_def_policy(CONF *conf, const char *section,
 int TS_CONF_set_policies(CONF *conf, const char *section, TS_RESP_CTX *ctx);
 int TS_CONF_set_digests(CONF *conf, const char *section, TS_RESP_CTX *ctx);
 int TS_CONF_set_accuracy(CONF *conf, const char *section, TS_RESP_CTX *ctx);
-int TS_CONF_set_clock_precision_digits(CONF *conf, const char *section,
+int TS_CONF_set_clock_precision_digits(const CONF *conf, const char *section,
                                        TS_RESP_CTX *ctx);
 int TS_CONF_set_ordering(CONF *conf, const char *section, TS_RESP_CTX *ctx);
 int TS_CONF_set_tsa_name(CONF *conf, const char *section, TS_RESP_CTX *ctx);


### PR DESCRIPTION
After app startup, depending on config file entries regarding engines, sometimes spurious error messages show up such as
```
C0A7DE58037F0000:error::DSO support routines:(unknown function):could not load the shared library:crypto/dso/dso_lib.c:162:
C0A7DE58037F0000:error::configuration file routines:(unknown function):error loading dso:crypto/conf/conf_mod.c:285:module=engines, path=engines
C0A7DE58037F0000:error::configuration file routines:(unknown function):unknown module name:crypto/conf/conf_mod.c:225:module=engines
```
This is cleaned up by this PR, also correcting and simplifying related types of error queue resets.