### PR TITLE
Fix DHX parameter encoding

### DIFF
--- a/crypto/encode_decode/decoder_lib.c
+++ b/crypto/encode_decode/decoder_lib.c
@@ -259,7 +259,7 @@ int OSSL_DECODER_CTX_add_extra(OSSL_DECODER_CTX *ctx,
              * on top of this one, so we don't.
              */
             if (ctx->start_input_type != NULL
-                && strcasecmp(ctx->start_input_type, input_type) != 0)
+                && strcasecmp(ctx->start_input_type, input_type) == 0)
                 continue;
 
             ERR_set_mark();

--- a/providers/implementations/encode_decode/encode_key2any.c
+++ b/providers/implementations/encode_decode/encode_key2any.c
@@ -319,12 +319,23 @@ static int dh_priv_to_der(const void *dh, unsigned char **pder)
 
 static int dh_params_to_der_bio(BIO *out, const void *key)
 {
-    return i2d_DHparams_bio(out, key);
+    int type =
+        DH_test_flags(key, DH_FLAG_TYPE_DHX) ? EVP_PKEY_DHX : EVP_PKEY_DH;
+
+    if (type == EVP_PKEY_DH)
+        return i2d_DHparams_bio(out, key);
+    return i2d_DHxparams_bio(out, key);
 }
 
 static int dh_params_to_pem_bio(BIO *out, const void *key)
 {
-    return PEM_write_bio_DHparams(out, key);
+    int type =
+        DH_test_flags(key, DH_FLAG_TYPE_DHX) ? EVP_PKEY_DHX : EVP_PKEY_DH;
+
+    if (type == EVP_PKEY_DH)
+        return PEM_write_bio_DHparams(out, key);
+
+    return PEM_write_bio_DHxparams(out, key);
 }
 
 static int dh_check_key_type(const void *key, int expected_type)
@@ -940,8 +951,8 @@ static int key2any_encode_params(struct key2any_ctx_st *ctx,
 #ifndef OPENSSL_NO_DH
 MAKE_ENCODER(dh, dh, EVP_PKEY_DH, der);
 MAKE_ENCODER(dh, dh, EVP_PKEY_DH, pem);
-MAKE_ENCODER(dhx, dh, EVP_PKEY_DH, der);
-MAKE_ENCODER(dhx, dh, EVP_PKEY_DH, pem);
+MAKE_ENCODER(dhx, dh, EVP_PKEY_DHX, der);
+MAKE_ENCODER(dhx, dh, EVP_PKEY_DHX, pem);
 #endif
 #ifndef OPENSSL_NO_DSA
 MAKE_ENCODER(dsa, dsa, EVP_PKEY_DSA, der);


### PR DESCRIPTION
DHX parameters were incorrectly being encoded as PKCS3 DH parameters files instead of X9.42 DH parameters files.

We also extended the encode_decode test to include encoding and decoding of parameters files.

This is WIP because the test currently fails due to an unrelated bug in DHX parameter *decoding*. DHX parameters are incorrectly identified as and decoded as DSA parameters.

I'm not sure how to fix this last issue - so ping @levitte.