### PR TITLE
Ensure that _GNU_SOURCE is defined to prevent compile errors with gcc…

### DIFF
--- a/crypto/bio/b_addr.c
+++ b/crypto/bio/b_addr.c
@@ -7,6 +7,10 @@
  * https://www.openssl.org/source/license.html
  */
 
+#ifndef _GNU_SOURCE
+# define _GNU_SOURCE
+#endif
+
 #include <assert.h>
 #include <string.h>
 


### PR DESCRIPTION
CLA: trivial

Fixes #13049

Ensure that _GNU_SOURCE is defined to prevent compile errors with gcc 9 when _POSIX_C_SOURCE=200809L is defined

