### PR TITLE
Ensure that _GNU_SOURCE is defined for NI_MAXHOST and NI_MAXSERV

### DIFF
--- a/crypto/bio/b_addr.c
+++ b/crypto/bio/b_addr.c
@@ -7,6 +7,10 @@
  * https://www.openssl.org/source/license.html
  */
 
+#ifndef _GNU_SOURCE
+# define _GNU_SOURCE
+#endif
+
 #include <assert.h>
 #include <string.h>
 


### PR DESCRIPTION
This fixes (among others) the following error with gcc9:

.../crypto/bio/b_addr.c:198:19: error: ‘NI_MAXHOST’ undeclared

Since glibc 2.8, these defines like `NI_MAXHOST` are exposed only
if suitable feature test macros are defined, namely: _GNU_SOURCE,
_DEFAULT_SOURCE (since glibc 2.19), or _BSD_SOURCE or _SVID_SOURCE
(before glibc 2.19)

CLA: trivial
Fixes #13049
