### PR TITLE
Fix segfault on missing provider_query_operation()

### DIFF
--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -866,7 +866,8 @@ const OSSL_ALGORITHM *ossl_provider_query_operation(const OSSL_PROVIDER *prov,
                                                     int operation_id,
                                                     int *no_cache)
 {
-    return prov->query_operation(prov->provctx, operation_id, no_cache);
+    return prov->query_operation == NULL
+        ? NULL : prov->query_operation(prov->provctx, operation_id, no_cache);
 }
 
 int ossl_provider_set_operation_bit(OSSL_PROVIDER *provider, size_t bitnum)


### PR DESCRIPTION
A provider without `provider_query_operation()` is admittedly quite useless, yet technically the base provider functions are not mandatory according to our documentation.

Adding a test for this would require to instantiate a dummy provider, ideally one for each of the `provider-base(7)` _Provider functions_: it's not impossible, but I am not sure it is worth putting the effort.

I'll let the reviewer decide if I should add such a test case.

##### Checklist

- [ ] tests are added or updated
