### PR TITLE
Expose PKCS7_get_octet_string and PKCS7_type_is_other

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,11 @@ OpenSSL 3.0
 
 ### Changes between 1.1.1 and 3.0 [xx XXX xxxx]
 
+ * Add PKCS7_get_octet_string() and PKCS7_type_is_other() to the public
+   interface. Their functionality remains unchanged.
+
+   *Jordan Montgomery*
+
  * Deprecated EVP_PKEY_set_alias_type().  This function was previously
    needed as a workaround to recognise SM2 keys.  With OpenSSL 3.0, this key
    type is internally recognised so the workaround is no longer needed.

--- a/crypto/pkcs7/pk7_doit.c
+++ b/crypto/pkcs7/pk7_doit.c
@@ -20,7 +20,7 @@ static int add_attribute(STACK_OF(X509_ATTRIBUTE) **sk, int nid, int atrtype,
                          void *value);
 static ASN1_TYPE *get_attribute(STACK_OF(X509_ATTRIBUTE) *sk, int nid);
 
-static int PKCS7_type_is_other(PKCS7 *p7)
+int PKCS7_type_is_other(PKCS7 *p7)
 {
     int isOther = 1;
 
@@ -43,7 +43,7 @@ static int PKCS7_type_is_other(PKCS7 *p7)
 
 }
 
-static ASN1_OCTET_STRING *PKCS7_get_octet_string(PKCS7 *p7)
+ASN1_OCTET_STRING *PKCS7_get_octet_string(PKCS7 *p7)
 {
     if (PKCS7_type_is_data(p7))
         return p7->d.data;

--- a/doc/man3/PKCS7_get_octet_string.pod
+++ b/doc/man3/PKCS7_get_octet_string.pod
@@ -1,0 +1,40 @@
+=pod
+
+=head1 NAME
+
+PKCS7_get_octet_string - return octet string from a PKCS#7 envelopedData structure
+
+=head1 SYNOPSIS
+
+ #include <openssl/pkcs7.h>
+
+ ASN1_OCTET_STRING *PKCS7_get_octet_string(PKCS7 *p7);
+
+=head1 DESCRIPTION
+
+PKCS7_get_octet_string() returns a pointer to an ASN1 octet string from a
+PKCS#7 envelopedData structure or B<NULL> if the structure cannot be parsed.
+
+=head1 NOTES
+
+As the B<0> implies, PKCS7_get_octet_string() returns internal pointers which
+should not be freed by the caller.
+
+=head1 RETURN VALUES
+
+PKCS7_get_octet_string() returns an ASN1_OCTET_STRING pointer.
+
+=head1 SEE ALSO
+
+L<PKCS7_type_is_data(3)>
+
+=head1 COPYRIGHT
+
+Copyright 2002-2020 The OpenSSL Project Authors. All Rights Reserved.
+
+Licensed under the Apache License 2.0 (the "License").  You may not use
+this file except in compliance with the License.  You can obtain a copy
+in the file LICENSE in the source distribution or at
+L<https://www.openssl.org/source/license.html>.
+
+=cut

--- a/doc/man3/PKCS7_type_is_other.pod
+++ b/doc/man3/PKCS7_type_is_other.pod
@@ -1,0 +1,42 @@
+=pod
+
+=head1 NAME
+
+PKCS7_type_is_other - determine content type of PKCS#7 envelopedData structure
+
+=head1 SYNOPSIS
+
+ #include <openssl/pkcs7.h>
+
+ int PKCS7_type_is_other(PKCS7 *p7);
+
+=head1 DESCRIPTION
+
+PKCS7_type_is_other() returns the whether the content type of a PKCS#7 envelopedData
+structure is one of the following content types:
+
+NID_pkcs7_data
+NID_pkcs7_signed
+NID_pkcs7_enveloped
+NID_pkcs7_signedAndEnveloped
+NID_pkcs7_digest
+NID_pkcs7_encrypted
+
+=head1 RETURN VALUES
+
+PKCS7_type_is_other() returns either 0 if the content type is matched or 1 otherwise.
+
+=head1 SEE ALSO
+
+L<PKCS7_type_is_data(3)>, L<PKCS7_get_octet_string(3)>
+
+=head1 COPYRIGHT
+
+Copyright 2002-2020 The OpenSSL Project Authors. All Rights Reserved.
+
+Licensed under the Apache License 2.0 (the "License").  You may not use
+this file except in compliance with the License.  You can obtain a copy
+in the file LICENSE in the source distribution or at
+L<https://www.openssl.org/source/license.html>.
+
+=cut

--- a/include/openssl/pkcs7.h.in
+++ b/include/openssl/pkcs7.h.in
@@ -262,6 +262,7 @@ DECLARE_ASN1_PRINT_FUNCTION(PKCS7)
 
 long PKCS7_ctrl(PKCS7 *p7, int cmd, long larg, char *parg);
 
+int PKCS7_type_is_other(PKCS7 *p7);
 int PKCS7_set_type(PKCS7 *p7, int type);
 int PKCS7_set0_type_other(PKCS7 *p7, int type, ASN1_TYPE *other);
 int PKCS7_set_content(PKCS7 *p7, PKCS7 *p7_data);
@@ -297,6 +298,7 @@ int PKCS7_set_cipher(PKCS7 *p7, const EVP_CIPHER *cipher);
 int PKCS7_stream(unsigned char ***boundary, PKCS7 *p7);
 
 PKCS7_ISSUER_AND_SERIAL *PKCS7_get_issuer_and_serial(PKCS7 *p7, int idx);
+ASN1_OCTET_STRING *PKCS7_get_octet_string(PKCS7 *p7);
 ASN1_OCTET_STRING *PKCS7_digest_from_attributes(STACK_OF(X509_ATTRIBUTE) *sk);
 int PKCS7_add_signed_attribute(PKCS7_SIGNER_INFO *p7si, int nid, int type,
                                void *data);

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5307,3 +5307,5 @@ EVP_ASYM_CIPHER_gettable_ctx_params     ?	3_0_0	EXIST::FUNCTION:
 EVP_ASYM_CIPHER_settable_ctx_params     ?	3_0_0	EXIST::FUNCTION:
 EVP_KEM_gettable_ctx_params             ?	3_0_0	EXIST::FUNCTION:
 EVP_KEM_settable_ctx_params             ?	3_0_0	EXIST::FUNCTION:
+PKCS7_type_is_other                     ?	3_0_0	EXIST::FUNCTION:
+PKCS7_get_octet_string                  ?	3_0_0	EXIST::FUNCTION:


### PR DESCRIPTION
Add PKCS7_get_octet_string() and PKCS7_type_is_other() to the public interface.
Fixes #11139

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
