### PR TITLE
DECODER: Allow precise result type for OSSL_DECODER_CTX_new_by_EVP_PKEY()

### DIFF
--- a/crypto/store/store_result.c
+++ b/crypto/store/store_result.c
@@ -257,7 +257,8 @@ static EVP_PKEY *try_key_value(struct extracted_param_data_st *data,
     if (membio == NULL)
         return 0;
 
-    decoderctx = OSSL_DECODER_CTX_new_by_EVP_PKEY(&pk, "DER", libctx, propq);
+    decoderctx =
+        OSSL_DECODER_CTX_new_by_EVP_PKEY(&pk, "DER", NULL, libctx, propq);
     (void)OSSL_DECODER_CTX_set_passphrase_cb(decoderctx, cb, cbarg);
 
     /* No error if this couldn't be decoded */

--- a/doc/man3/OSSL_DECODER_CTX_new_by_EVP_PKEY.pod
+++ b/doc/man3/OSSL_DECODER_CTX_new_by_EVP_PKEY.pod
@@ -14,7 +14,8 @@ OSSL_DECODER_CTX_set_passphrase_cb
  #include <openssl/decoder.h>
 
  OSSL_DECODER_CTX *
- OSSL_DECODER_CTX_new_by_EVP_PKEY(const EVP_PKEY *pkey, const char *input_type,
+ OSSL_DECODER_CTX_new_by_EVP_PKEY(const EVP_PKEY *pkey,
+                                  const char *input_type, const char *keytype,
                                   OPENSSL_CTX *libctx, const char *propquery);
 
  int OSSL_DECODER_CTX_set_passphrase(OSSL_DECODER_CTX *ctx,
@@ -44,8 +45,14 @@ data suitable for B<EVP_PKEY>s.  All these implementations are implicitly
 fetched using I<libctx> and I<propquery>.
 
 The search of decoder implementations can be limited with I<input_type>,
-which specifies a starting input type.  This is further explained in
-L<OSSL_DECODER_CTX_set_input_type(3)>.
+which specifies a starting input type.  NULL is valid input and signifies
+that the decoder implementations will find out the input type on their own.
+This is further explained in L<OSSL_DECODER_CTX_set_input_type(3)>.
+
+The search of decoder implementations can also be limited with I<keytype>,
+which specifies the expected resulting keytype.  NULL is valid input and
+signifies that the decoder implementations will find out the keytype on
+their own from the input they get.
 
 If no suitable decoder implementation is found,
 OSSL_DECODER_CTX_new_by_EVP_PKEY() still creates a B<OSSL_DECODER_CTX>, but

--- a/include/crypto/decoder.h
+++ b/include/crypto/decoder.h
@@ -32,7 +32,7 @@ int ossl_decoder_ctx_add_decoder_inst(OSSL_DECODER_CTX *ctx,
                                       OSSL_DECODER_INSTANCE *di);
 
 int ossl_decoder_ctx_setup_for_EVP_PKEY(OSSL_DECODER_CTX *ctx,
-                                        EVP_PKEY **pkey,
+                                        EVP_PKEY **pkey, const char *keytype,
                                         OPENSSL_CTX *libctx,
                                         const char *propquery);
 

--- a/include/openssl/decoder.h
+++ b/include/openssl/decoder.h
@@ -112,7 +112,8 @@ int OSSL_DECODER_from_fp(OSSL_DECODER_CTX *ctx, FILE *in);
  * an implicit OSSL_DECODER_fetch(), suitable for the object of that type.
  */
 OSSL_DECODER_CTX *
-OSSL_DECODER_CTX_new_by_EVP_PKEY(EVP_PKEY **pkey, const char *input_type,
+OSSL_DECODER_CTX_new_by_EVP_PKEY(EVP_PKEY **pkey,
+                                 const char *input_type, const char *keytype,
                                  OPENSSL_CTX *libctx, const char *propquery);
 
 # ifdef __cplusplus

--- a/providers/implementations/storemgmt/file_store.c
+++ b/providers/implementations/storemgmt/file_store.c
@@ -582,7 +582,8 @@ static int file_setup_decoders(struct file_ctx_st *ctx)
          * Since we're setting up our own constructor, we don't need to care
          * more than that...
          */
-        if (!ossl_decoder_ctx_setup_for_EVP_PKEY(ctx->_.file.decoderctx, &dummy,
+        if (!ossl_decoder_ctx_setup_for_EVP_PKEY(ctx->_.file.decoderctx,
+                                                 &dummy, NULL,
                                                  libctx, ctx->_.file.propq)
             || !OSSL_DECODER_CTX_add_extra(ctx->_.file.decoderctx,
                                            libctx, ctx->_.file.propq)) {

--- a/test/endecode_test.c
+++ b/test/endecode_test.c
@@ -201,7 +201,7 @@ static int decode_EVP_PKEY_prov(void **object, void *encoded, long encoded_len,
     const unsigned char *upass = (const unsigned char *)pass;
     int ok = 0;
 
-    if (!TEST_ptr(dctx = OSSL_DECODER_CTX_new_by_EVP_PKEY(&pkey, NULL,
+    if (!TEST_ptr(dctx = OSSL_DECODER_CTX_new_by_EVP_PKEY(&pkey, NULL, NULL,
                                                           NULL, NULL))
         || (pass != NULL
             && !OSSL_DECODER_CTX_set_passphrase(dctx, upass, strlen(pass)))


### PR DESCRIPTION
There is some data that is very difficult to guess.  For example, DSA
parameters and X9.42 DH parameters look exactly the same, a SEQUENCE
of 3 INTEGER.  Therefore, callers may need the possibility to select
the exact keytype that they expect to get.

This will also allow use to translate d2i_TYPEPrivateKey(),
d2i_TYPEPublicKey() and d2i_TYPEParams() into OSSL_DECODER terms much
more smoothly.
