### PR TITLE
ocsp.h: Fix backward compatibility definition of OCSP_parse_url()

### DIFF
--- a/include/openssl/ocsp.h.in
+++ b/include/openssl/ocsp.h.in
@@ -261,7 +261,8 @@ int OCSP_check_validity(ASN1_GENERALIZEDTIME *thisupd,
 int OCSP_request_verify(OCSP_REQUEST *req, STACK_OF(X509) *certs,
                         X509_STORE *store, unsigned long flags);
 
-#  define OCSP_parse_url OSSL_HTTP_parse_url /* for backward compatibility */
+#  define OCSP_parse_url(url, host, port, path, ssl) \
+    OSSL_HTTP_parse_url(url, host, port, NULL, path, ssl) /* backward compat */
 
 int OCSP_id_issuer_cmp(const OCSP_CERTID *a, const OCSP_CERTID *b);
 int OCSP_id_cmp(const OCSP_CERTID *a, const OCSP_CERTID *b);


### PR DESCRIPTION
Restore API w.r.t. public undocumented legacy function `OCSP_parse_url()`,
fixing issue reported by @mtrojnar: https://github.com/openssl/openssl/pull/12786#issuecomment-703873448