### PR TITLE
Verification zero-length content in S/MIME format

### DIFF
--- a/crypto/cms/cms_smime.c
+++ b/crypto/cms/cms_smime.c
@@ -401,7 +401,7 @@ int CMS_verify(CMS_ContentInfo *cms, STACK_OF(X509) *certs,
         long len;
 
         len = BIO_get_mem_data(dcont, &ptr);
-        tmpin = BIO_new_mem_buf(ptr, len);
+        tmpin = (len == 0) ? dcont : BIO_new_mem_buf(ptr, len);
         if (tmpin == NULL) {
             CMSerr(CMS_F_CMS_VERIFY, ERR_R_MALLOC_FAILURE);
             goto err2;

--- a/crypto/pkcs7/pk7_smime.c
+++ b/crypto/pkcs7/pk7_smime.c
@@ -311,7 +311,7 @@ int PKCS7_verify(PKCS7 *p7, STACK_OF(X509) *certs, X509_STORE *store,
         char *ptr;
         long len;
         len = BIO_get_mem_data(indata, &ptr);
-        tmpin = BIO_new_mem_buf(ptr, len);
+        tmpin = (len == 0) ? indata : BIO_new_mem_buf(ptr, len);
         if (tmpin == NULL) {
             PKCS7err(0, ERR_R_MALLOC_FAILURE);
             goto err;


### PR DESCRIPTION
There was an error when verifying S/MIME messages with zero-length content.

Allocation of 0 bytes returns a NULL pointer causing misleading diagnostics about malloc failure.

- [ ] documentation is added or updated
- [x] tests are added or updated
