### PR TITLE
Permit writes of zero byte records.

### DIFF
--- a/ssl/record/rec_layer_s3.c
+++ b/ssl/record/rec_layer_s3.c
@@ -1231,7 +1231,15 @@ int ssl3_write_pending(SSL *s, int type, const unsigned char *buf, size_t len,
                      SSL_R_BIO_NOT_SET);
             i = -1;
         }
-        if (i > 0 && tmpwrit == SSL3_BUFFER_get_left(&wb[currbuf])) {
+
+	/*
+	 * When an empty fragment is sent on a connection using KTLS,
+	 * it is sent as a write of zero bytes.  If this zero byte
+	 * write succeeds, i will be 0 rather than a non-zero value.
+	 * Treat i == 0 as success rather than an error for zero byte
+	 * writes to permit this case.
+	 */
+        if (i >= 0 && tmpwrit == SSL3_BUFFER_get_left(&wb[currbuf])) {
             SSL3_BUFFER_set_left(&wb[currbuf], 0);
             SSL3_BUFFER_add_offset(&wb[currbuf], tmpwrit);
             if (currbuf + 1 < s->rlayer.numwpipes)

--- a/ssl/record/rec_layer_s3.c
+++ b/ssl/record/rec_layer_s3.c
@@ -1213,10 +1213,6 @@ int ssl3_write_pending(SSL *s, int type, const unsigned char *buf, size_t len,
                 i = BIO_flush(s->wbio);
                 if (i <= 0)
                     return i;
-            }
-
-            if (BIO_get_ktls_send(s->wbio)
-                && type != SSL3_RT_APPLICATION_DATA) {
                 BIO_set_ktls_ctrl_msg(s->wbio, type);
             }
             /* TODO(size_t): Convert this call */


### PR DESCRIPTION
When using KTLS, empty fragments sent as a mitigation for known-IV
weakenesses in TLS 1.0 are sent as writes of 0 bytes.  The TLS header
and trailer are added to the empty fragment by the kernel.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
