### PR TITLE
Modify util/mknum.pl to drop new symbols that don't exist any more

### DIFF
--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4430,17 +4430,6 @@ OPENSSL_version_build_metadata          ?	3_0_0	EXIST::FUNCTION:
 EVP_aes_128_siv                         ?	3_0_0	EXIST::FUNCTION:SIV
 EVP_aes_192_siv                         ?	3_0_0	EXIST::FUNCTION:SIV
 EVP_aes_256_siv                         ?	3_0_0	EXIST::FUNCTION:SIV
-CRYPTO_siv128_new                       ?	3_0_0	NOEXIST::FUNCTION:SIV
-CRYPTO_siv128_init                      ?	3_0_0	NOEXIST::FUNCTION:SIV
-CRYPTO_siv128_copy_ctx                  ?	3_0_0	NOEXIST::FUNCTION:SIV
-CRYPTO_siv128_aad                       ?	3_0_0	NOEXIST::FUNCTION:SIV
-CRYPTO_siv128_encrypt                   ?	3_0_0	NOEXIST::FUNCTION:SIV
-CRYPTO_siv128_decrypt                   ?	3_0_0	NOEXIST::FUNCTION:SIV
-CRYPTO_siv128_finish                    ?	3_0_0	NOEXIST::FUNCTION:SIV
-CRYPTO_siv128_set_tag                   ?	3_0_0	NOEXIST::FUNCTION:SIV
-CRYPTO_siv128_get_tag                   ?	3_0_0	NOEXIST::FUNCTION:SIV
-CRYPTO_siv128_cleanup                   ?	3_0_0	NOEXIST::FUNCTION:SIV
-CRYPTO_siv128_speed                     ?	3_0_0	NOEXIST::FUNCTION:SIV
 OPENSSL_INIT_set_config_filename        ?	3_0_0	EXIST::FUNCTION:STDIO
 OPENSSL_INIT_set_config_file_flags      ?	3_0_0	EXIST::FUNCTION:STDIO
 ASYNC_WAIT_CTX_get_callback             ?	3_0_0	EXIST::FUNCTION:
@@ -4626,9 +4615,6 @@ OSSL_CMP_MSG_free                       ?	3_0_0	EXIST::FUNCTION:CMP
 ERR_load_CMP_strings                    ?	3_0_0	EXIST::FUNCTION:CMP
 EVP_MD_CTX_set_params                   ?	3_0_0	EXIST::FUNCTION:
 EVP_MD_CTX_get_params                   ?	3_0_0	EXIST::FUNCTION:
-OPENSSL_CTX_get0_primary_drbg           ?	3_0_0	NOEXIST::FUNCTION:
-OPENSSL_CTX_get0_public_drbg            ?	3_0_0	NOEXIST::FUNCTION:
-OPENSSL_CTX_get0_private_drbg           ?	3_0_0	NOEXIST::FUNCTION:
 BN_CTX_new_ex                           ?	3_0_0	EXIST::FUNCTION:
 BN_CTX_secure_new_ex                    ?	3_0_0	EXIST::FUNCTION:
 OPENSSL_thread_stop_ex                  ?	3_0_0	EXIST::FUNCTION:
@@ -4666,9 +4652,6 @@ ERR_vset_error                          ?	3_0_0	EXIST::FUNCTION:
 X509_get0_authority_issuer              ?	3_0_0	EXIST::FUNCTION:
 X509_get0_authority_serial              ?	3_0_0	EXIST::FUNCTION:
 X509_self_signed                        ?	3_0_0	EXIST::FUNCTION:
-EC_GROUP_new_by_curve_name_ex           ?	3_0_0	NOEXIST::FUNCTION:EC
-EC_KEY_new_ex                           ?	3_0_0	NOEXIST::FUNCTION:EC
-EC_KEY_new_by_curve_name_ex             ?	3_0_0	NOEXIST::FUNCTION:EC
 OPENSSL_hexstr2buf_ex                   ?	3_0_0	EXIST::FUNCTION:
 OPENSSL_buf2hexstr_ex                   ?	3_0_0	EXIST::FUNCTION:
 OSSL_PARAM_allocate_from_text           ?	3_0_0	EXIST::FUNCTION:
@@ -4792,9 +4775,7 @@ OSSL_CMP_print_to_bio                   ?	3_0_0	EXIST::FUNCTION:CMP
 OSSL_CMP_print_errors_cb                ?	3_0_0	EXIST::FUNCTION:CMP
 OSSL_CRMF_CERTID_get0_issuer            ?	3_0_0	EXIST::FUNCTION:CRMF
 OSSL_CRMF_CERTID_get0_serialNumber      ?	3_0_0	EXIST::FUNCTION:CRMF
-EVP_DigestSignInit_ex                   ?	3_0_0	NOEXIST::FUNCTION:
 EVP_DigestSignUpdate                    ?	3_0_0	EXIST::FUNCTION:
-EVP_DigestVerifyInit_ex                 ?	3_0_0	NOEXIST::FUNCTION:
 EVP_DigestVerifyUpdate                  ?	3_0_0	EXIST::FUNCTION:
 BN_check_prime                          ?	3_0_0	EXIST::FUNCTION:
 EVP_KEYMGMT_is_a                        ?	3_0_0	EXIST::FUNCTION:
@@ -5019,7 +5000,6 @@ SRP_Calc_B_ex                           ?	3_0_0	EXIST::FUNCTION:SRP
 SRP_Calc_u_ex                           ?	3_0_0	EXIST::FUNCTION:SRP
 SRP_Calc_x_ex                           ?	3_0_0	EXIST::FUNCTION:SRP
 SRP_Calc_client_key_ex                  ?	3_0_0	EXIST::FUNCTION:SRP
-X509v3_cache_extensions                 ?	3_0_0	NOEXIST::FUNCTION:
 EVP_PKEY_gettable_params                ?	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_get_int_param                  ?	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_get_size_t_param               ?	3_0_0	EXIST::FUNCTION:
@@ -5064,8 +5044,6 @@ EVP_PKEY_CTX_set_dhx_rfc5114            ?	3_0_0	EXIST::FUNCTION:DH
 X509_VERIFY_PARAM_get0_host             ?	3_0_0	EXIST::FUNCTION:
 X509_VERIFY_PARAM_get0_email            ?	3_0_0	EXIST::FUNCTION:
 X509_VERIFY_PARAM_get1_ip_asc           ?	3_0_0	EXIST::FUNCTION:
-X509_verify_ex                          ?	3_0_0	NOEXIST::FUNCTION:
-X509_REQ_verify_ex                      ?	3_0_0	NOEXIST::FUNCTION:
 X509_ALGOR_copy                         ?	3_0_0	EXIST::FUNCTION:
 X509_REQ_set0_signature                 ?	3_0_0	EXIST::FUNCTION:
 X509_REQ_set1_signature_algo            ?	3_0_0	EXIST::FUNCTION:
@@ -5094,7 +5072,6 @@ EVP_RAND_uninstantiate                  ?	3_0_0	EXIST::FUNCTION:
 EVP_RAND_generate                       ?	3_0_0	EXIST::FUNCTION:
 EVP_RAND_reseed                         ?	3_0_0	EXIST::FUNCTION:
 EVP_RAND_nonce                          ?	3_0_0	EXIST::FUNCTION:
-EVP_RAND_set_callbacks                  ?	3_0_0	NOEXIST::FUNCTION:
 EVP_RAND_enable_locking                 ?	3_0_0	EXIST::FUNCTION:
 EVP_RAND_verify_zeroization             ?	3_0_0	EXIST::FUNCTION:
 EVP_RAND_strength                       ?	3_0_0	EXIST::FUNCTION:

--- a/util/mknum.pl
+++ b/util/mknum.pl
@@ -118,7 +118,15 @@ if ($checkexist) {
         }
     }
 } else {
-    $ordinals->rewrite();
+    my $dropped = 0;
+    my $unassigned;
+    my $filter = sub {
+        my $item = shift;
+        my $result = $item->number() ne '?' || $item->exists();
+        $dropped++ unless $result;
+        return $result;
+    };
+    $ordinals->rewrite(filter => $filter);
     my %stats = $ordinals->stats();
     print STDERR
         "${ordinals_file}: $stats{modified} old symbols have updated info\n"
@@ -128,9 +136,13 @@ if ($checkexist) {
     } else {
         print STDERR "${ordinals_file}: No new symbols added\n";
     }
-    if ($stats{unassigned}) {
-        my $symbol = $stats{unassigned} == 1 ? "symbol" : "symbols";
-        my $is = $stats{unassigned} == 1 ? "is" : "are";
-        print STDERR "${ordinals_file}: $stats{unassigned} $symbol $is without ordinal number\n";
+    if ($dropped) {
+        print STDERR "${ordinals_file}: Dropped $dropped new symbols\n";
+    }
+    $unassigned = $stats{unassigned} - $dropped;
+    if ($unassigned) {
+        my $symbol = $unassigned == 1 ? "symbol" : "symbols";
+        my $is = $unassigned == 1 ? "is" : "are";
+        print STDERR "${ordinals_file}: $unassigned $symbol $is without ordinal number\n";
     }
 }

--- a/util/perl/OpenSSL/Ordinals.pm
+++ b/util/perl/OpenSSL/Ordinals.pm
@@ -179,7 +179,7 @@ sub renumber {
     my $self = shift;
 
     my $max_assigned = 0;
-    foreach ($self->items(by => by_number())) {
+    foreach ($self->items(sort => by_number())) {
         $_->number($_->intnum()) if $_->number() =~ m|^\?|;
         if ($max_assigned < $_->number()) {
             $max_assigned = $_->number();
@@ -190,34 +190,49 @@ sub renumber {
 
 =item B<< $ordinals->rewrite >>
 
+=item B<< $ordinals->rewrite >>, I<%options>
+
 If an ordinals file has been loaded, it gets rewritten with the data from
 the current work database.
+
+If there are more arguments, they are used as I<%options> with the
+same semantics as for B<< $ordinals->items >> described below, apart
+from B<sort>, which is forbidden here.
 
 =cut
 
 sub rewrite {
     my $self = shift;
+    my %opts = @_;
 
-    $self->write($self->{filename});
+    $self->write($self->{filename}, %opts);
 }
 
 =item B<< $ordinals->write FILENAME >>
 
+=item B<< $ordinals->write FILENAME >>, I<%options>
+
 Writes the current work database data to the ordinals file FILENAME.
 This also validates the data, see B<< $ordinals->validate >> below.
+
+If there are more arguments, they are used as I<%options> with the
+same semantics as for B<< $ordinals->items >> described next, apart
+from B<sort>, which is forbidden here.
 
 =cut
 
 sub write {
     my $self = shift;
     my $filename = shift;
+    my %opts = @_;
 
     croak "Undefined filename" unless defined($filename);
+    croak "The 'sort' option is not allowed" if $opts{sort};
 
     $self->validate();
 
     open F, '>', $filename or croak "Unable to open $filename";
-    foreach ($self->items(by => by_number())) {
+    foreach ($self->items(%opts, sort => by_number())) {
         print F $_->to_string(),"\n";
     }
     close F;


### PR DESCRIPTION
This makes use of writer filters in OpenSSL::Ordinals, also added in this PR.

Fixes #10395