### PR TITLE
ENCODER / DECODER: Add functions to encode/decode to/from a buffer

### DIFF
--- a/crypto/asn1/i2d_pr.c
+++ b/crypto/asn1/i2d_pr.c
@@ -30,35 +30,19 @@ int i2d_PrivateKey(const EVP_PKEY *a, unsigned char **pp)
         }
         return ret;
     }
-    if (a->keymgmt != NULL) {
+    if (evp_pkey_is_provided(a)) {
         /* The private key includes everything */
+        OSSL_ENCODER_CTX *ctx;
         int selection =
             OSSL_KEYMGMT_SELECT_ALL_PARAMETERS | OSSL_KEYMGMT_SELECT_KEYPAIR;
-        OSSL_ENCODER_CTX *ctx =
-            OSSL_ENCODER_CTX_new_by_EVP_PKEY(a, "DER", selection, NULL, NULL);
-        BIO *out = BIO_new(BIO_s_mem());
-        BUF_MEM *buf = NULL;
+        size_t length;
         int ret = -1;
 
-        if (ctx != NULL
-            && out != NULL
+        if ((ctx = OSSL_ENCODER_CTX_new_by_EVP_PKEY(a, "DER", selection,
+                                                    NULL, NULL)) != NULL
             && OSSL_ENCODER_CTX_get_num_encoders(ctx) != 0
-            && OSSL_ENCODER_to_bio(ctx, out)
-            && BIO_get_mem_ptr(out, &buf) > 0) {
-            ret = buf->length;
-
-            if (pp != NULL) {
-                if (*pp == NULL) {
-                    *pp = (unsigned char *)buf->data;
-                    buf->length = 0;
-                    buf->data = NULL;
-                } else {
-                    memcpy(*pp, buf->data, ret);
-                    *pp += ret;
-                }
-            }
-        }
-        BIO_free(out);
+            && OSSL_ENCODER_to_data(ctx, pp, &length))
+            ret = (int)length;
         OSSL_ENCODER_CTX_free(ctx);
         return ret;
     }

--- a/crypto/asn1/i2d_pr.c
+++ b/crypto/asn1/i2d_pr.c
@@ -8,6 +8,7 @@
  */
 
 #include <stdio.h>
+#include <limits.h>
 #include "internal/cryptlib.h"
 #include <openssl/evp.h>
 #include <openssl/encoder.h>
@@ -31,12 +32,16 @@ int i2d_PrivateKey(const EVP_PKEY *a, unsigned char **pp)
         return ret;
     }
     if (evp_pkey_is_provided(a)) {
+        /*
+         * This is horribly much, but then again, |*pp| is unbounded, and
+         * we really can't know better.
+         */
+        size_t length = INT_MAX;
         /* The private key includes everything */
-        OSSL_ENCODER_CTX *ctx;
         int selection =
             OSSL_KEYMGMT_SELECT_ALL_PARAMETERS | OSSL_KEYMGMT_SELECT_KEYPAIR;
-        size_t length;
         int ret = -1;
+        OSSL_ENCODER_CTX *ctx;
 
         if ((ctx = OSSL_ENCODER_CTX_new_by_EVP_PKEY(a, "DER", selection,
                                                     NULL, NULL)) != NULL

--- a/crypto/asn1/i2d_pr.c
+++ b/crypto/asn1/i2d_pr.c
@@ -32,10 +32,7 @@ int i2d_PrivateKey(const EVP_PKEY *a, unsigned char **pp)
         return ret;
     }
     if (evp_pkey_is_provided(a)) {
-        /*
-         * This is horribly much, but then again, |*pp| is unbounded, and
-         * we really can't know better.
-         */
+        /* |*pp| is unbounded, so we need an upper limit */
         size_t length = INT_MAX;
         /* The private key includes everything */
         int selection =

--- a/crypto/encode_decode/decoder_lib.c
+++ b/crypto/encode_decode/decoder_lib.c
@@ -77,6 +77,27 @@ int OSSL_DECODER_from_fp(OSSL_DECODER_CTX *ctx, FILE *fp)
 }
 #endif
 
+int OSSL_DECODER_from_data(OSSL_DECODER_CTX *ctx, const unsigned char **pdata,
+                           size_t *pdata_len)
+{
+    BIO *membio;
+    int ret = 0;
+
+    if (pdata == NULL || *pdata == NULL || pdata_len == NULL) {
+        ERR_raise(ERR_LIB_OSSL_DECODER, ERR_R_PASSED_NULL_PARAMETER);
+        return 0;
+    }
+
+    membio = BIO_new_mem_buf(*pdata, (int)*pdata_len);
+    if (OSSL_DECODER_from_bio(ctx, membio)) {
+        *pdata_len = (size_t)BIO_get_mem_data(membio, pdata);
+        ret = 1;
+    }
+    BIO_free(membio);
+
+    return ret;
+}
+
 int OSSL_DECODER_CTX_set_input_type(OSSL_DECODER_CTX *ctx,
                                     const char *input_type)
 {

--- a/crypto/encode_decode/encoder_lib.c
+++ b/crypto/encode_decode/encoder_lib.c
@@ -67,6 +67,11 @@ int OSSL_ENCODER_to_data(OSSL_ENCODER_CTX *ctx, unsigned char **pdata,
 
         if (pdata != NULL && *pdata != NULL) {
             if (*pdata_len < buf->length)
+                /*
+                 * It's tempting to do |*pdata_len = (size_t)buf->length|
+                 * However, it's believed to be confusing more than helpful,
+                 * so we don't.
+                 */
                 ret = 0;
             else
                 *pdata_len -= buf->length;

--- a/crypto/store/store_result.c
+++ b/crypto/store/store_result.c
@@ -251,21 +251,17 @@ static EVP_PKEY *try_key_value(struct extracted_param_data_st *data,
 {
     EVP_PKEY *pk = NULL;
     OSSL_DECODER_CTX *decoderctx = NULL;
-    BIO *membio =
-        BIO_new_mem_buf(data->octet_data, (int)data->octet_data_size);
-
-    if (membio == NULL)
-        return 0;
+    const unsigned char *pdata = data->octet_data;
+    size_t pdatalen = data->octet_data_size;
 
     decoderctx =
         OSSL_DECODER_CTX_new_by_EVP_PKEY(&pk, "DER", NULL, libctx, propq);
     (void)OSSL_DECODER_CTX_set_passphrase_cb(decoderctx, cb, cbarg);
 
     /* No error if this couldn't be decoded */
-    (void)OSSL_DECODER_from_bio(decoderctx, membio);
+    (void)OSSL_DECODER_from_data(decoderctx, &pdata, &pdatalen);
 
     OSSL_DECODER_CTX_free(decoderctx);
-    BIO_free(membio);
 
     return pk;
 }

--- a/doc/man3/OSSL_DECODER_from_bio.pod
+++ b/doc/man3/OSSL_DECODER_from_bio.pod
@@ -14,7 +14,7 @@ OSSL_DECODER_from_fp
  int OSSL_DECODER_from_bio(OSSL_DECODER_CTX *ctx, BIO *in);
  int OSSL_DECODER_from_fp(OSSL_DECODER_CTX *ctx, FILE *fp);
  int OSSL_DECODER_from_data(OSSL_DECODER_CTX *ctx, const unsigned char **pdata,
-                            size_t data_len);
+                            size_t *pdata_len);
 
 Feature availability macros:
 

--- a/doc/man3/OSSL_DECODER_from_bio.pod
+++ b/doc/man3/OSSL_DECODER_from_bio.pod
@@ -2,6 +2,7 @@
 
 =head1 NAME
 
+OSSL_DECODER_from_data,
 OSSL_DECODER_from_bio,
 OSSL_DECODER_from_fp
 - Routines to perform a decoding
@@ -12,6 +13,8 @@ OSSL_DECODER_from_fp
 
  int OSSL_DECODER_from_bio(OSSL_DECODER_CTX *ctx, BIO *in);
  int OSSL_DECODER_from_fp(OSSL_DECODER_CTX *ctx, FILE *fp);
+ int OSSL_DECODER_from_data(OSSL_DECODER_CTX *ctx, const unsigned char **pdata,
+                            size_t data_len);
 
 Feature availability macros:
 
@@ -23,6 +26,12 @@ is undefined.
 =back
 
 =head1 DESCRIPTION
+
+OSSL_DECODER_from_data() runs the decoding process for the context I<ctx>,
+with input coming from I<*pdata>, I<*pdata_len> bytes long.  Both I<*pdata>
+and I<*pdata_len> must be non-NULL.  When OSSL_DECODER_from_data() returns,
+I<*pdata> is updated to point at the location after what has been decoded,
+and I<*pdata_len> to have the number of remaining bytes.
 
 OSSL_DECODER_from_bio() runs the decoding process for the context I<ctx>,
 with the input coming from the B<BIO> I<in>.  Should it make a difference,

--- a/doc/man3/OSSL_ENCODER_to_bio.pod
+++ b/doc/man3/OSSL_ENCODER_to_bio.pod
@@ -41,8 +41,8 @@ remaining bytes.
 OSSL_ENCODER_to_bio() runs the encoding process for the context I<ctx>, with
 the output going to the B<BIO> I<out>.
 
-OSSL_ENCODER_to_fp() does the same thing as OSSL_ENCODER_to_bio(),
-except that the output is going to the B<FILE> I<fp>.
+OSSL_ENCODER_to_fp() does the same thing as OSSL_ENCODER_to_bio(), except
+that the output is going to the B<FILE> I<fp>.
 
 =for comment Know your encoder!
 
@@ -52,8 +52,8 @@ it in text or binary mode as is appropriate for the encoder output type.
 
 =head1 RETURN VALUES
 
-OSSL_ENCODER_to_bio() and OSSL_ENCODER_to_fp() return 1 on success, or 0 on
-failure.
+OSSL_ENCODER_to_bio(), OSSL_ENCODER_to_fp() and OSSL_ENCODER_to_data()
+return 1 on success, or 0 on failure.
 
 =begin comment TODO(3.0) Add examples!
 

--- a/doc/man3/OSSL_ENCODER_to_bio.pod
+++ b/doc/man3/OSSL_ENCODER_to_bio.pod
@@ -38,10 +38,6 @@ is assumed to have its size.  In this case, I<*pdata> will be set to point
 after the encoded bytes, and I<*pdata_len> will be assigned the number of
 remaining bytes.
 
-The application is required to set
-up the B<BIO> properly, for example to have it in text or binary mode if
-that's appropriate.
-
 OSSL_ENCODER_to_bio() runs the encoding process for the context I<ctx>, with
 the output going to the B<BIO> I<out>.  The application is required to set
 up the B<BIO> properly, for example to have it in text or binary mode if
@@ -51,6 +47,10 @@ that's appropriate.
 
 OSSL_ENCODER_to_fp() does the same thing as OSSL_ENCODER_to_bio(),
 except that the output is going to the B<FILE> I<fp>.
+
+For OSSL_ENCODER_to_bio() and OSSL_ENCODER_to_fp(), the application is
+required to set up the B<BIO> properly, for example to have it in text
+or binary mode as is appropriate for the output type.
 
 =head1 RETURN VALUES
 

--- a/doc/man3/OSSL_ENCODER_to_bio.pod
+++ b/doc/man3/OSSL_ENCODER_to_bio.pod
@@ -2,6 +2,7 @@
 
 =head1 NAME
 
+OSSL_ENCODER_to_data,
 OSSL_ENCODER_to_bio,
 OSSL_ENCODER_to_fp
 - Routines to perform an encoding
@@ -10,6 +11,8 @@ OSSL_ENCODER_to_fp
 
  #include <openssl/encoder.h>
 
+ int OSSL_ENCODER_to_data(OSSL_ENCODER_CTX *ctx, unsigned char **pdata,
+                          size_t *pdata_len);
  int OSSL_ENCODER_to_bio(OSSL_ENCODER_CTX *ctx, BIO *out);
  int OSSL_ENCODER_to_fp(OSSL_ENCODER_CTX *ctx, FILE *fp);
 
@@ -23,6 +26,21 @@ is undefined.
 =back
 
 =head1 DESCRIPTION
+
+OSSL_ENCODER_to_data() runs the encoding process for the context I<ctx>,
+with the output going to the I<*pdata> and I<*pdata_len>.
+If I<*pdata> is NULL when OSSL_ENCODER_to_data() is called, a buffer will be
+allocated using L<OPENSSL_zalloc(3)>, and I<*pdata> will be set to point at
+the start of that buffer, and I<*pdata_len> will be assigned its length when
+OSSL_ENCODER_to_data() returns.
+If I<*pdata> is non-NULL when OSSL_ENCODER_to_data() is called, I<*pdata_len>
+is assumed to have its size.  In this case, I<*pdata> will be set to point
+after the encoded bytes, and I<*pdata_len> will be assigned the number of
+remaining bytes.
+
+The application is required to set
+up the B<BIO> properly, for example to have it in text or binary mode if
+that's appropriate.
 
 OSSL_ENCODER_to_bio() runs the encoding process for the context I<ctx>, with
 the output going to the B<BIO> I<out>.  The application is required to set

--- a/doc/man3/OSSL_ENCODER_to_bio.pod
+++ b/doc/man3/OSSL_ENCODER_to_bio.pod
@@ -39,18 +39,16 @@ after the encoded bytes, and I<*pdata_len> will be assigned the number of
 remaining bytes.
 
 OSSL_ENCODER_to_bio() runs the encoding process for the context I<ctx>, with
-the output going to the B<BIO> I<out>.  The application is required to set
-up the B<BIO> properly, for example to have it in text or binary mode if
-that's appropriate.
-
-=for comment Know your encoder!
+the output going to the B<BIO> I<out>.
 
 OSSL_ENCODER_to_fp() does the same thing as OSSL_ENCODER_to_bio(),
 except that the output is going to the B<FILE> I<fp>.
 
+=for comment Know your encoder!
+
 For OSSL_ENCODER_to_bio() and OSSL_ENCODER_to_fp(), the application is
 required to set up the B<BIO> properly, for example to have it in text
-or binary mode as is appropriate for the output type.
+or binary mode as is appropriate for the encoder output type.
 
 =head1 RETURN VALUES
 

--- a/doc/man3/OSSL_ENCODER_to_bio.pod
+++ b/doc/man3/OSSL_ENCODER_to_bio.pod
@@ -47,8 +47,8 @@ except that the output is going to the B<FILE> I<fp>.
 =for comment Know your encoder!
 
 For OSSL_ENCODER_to_bio() and OSSL_ENCODER_to_fp(), the application is
-required to set up the B<BIO> properly, for example to have it in text
-or binary mode as is appropriate for the encoder output type.
+required to set up the B<BIO> or B<FILE> properly, for example to have
+it in text or binary mode as is appropriate for the encoder output type.
 
 =head1 RETURN VALUES
 

--- a/include/openssl/decoder.h
+++ b/include/openssl/decoder.h
@@ -106,6 +106,8 @@ int OSSL_DECODER_from_bio(OSSL_DECODER_CTX *ctx, BIO *in);
 #ifndef OPENSSL_NO_STDIO
 int OSSL_DECODER_from_fp(OSSL_DECODER_CTX *ctx, FILE *in);
 #endif
+int OSSL_DECODER_from_data(OSSL_DECODER_CTX *ctx, const unsigned char **pdata,
+                           size_t *pdata_len);
 
 /*
  * Create the OSSL_DECODER_CTX with an associated type.  This will perform

--- a/include/openssl/encoder.h
+++ b/include/openssl/encoder.h
@@ -101,6 +101,8 @@ int OSSL_ENCODER_to_bio(OSSL_ENCODER_CTX *ctx, BIO *out);
 #ifndef OPENSSL_NO_STDIO
 int OSSL_ENCODER_to_fp(OSSL_ENCODER_CTX *ctx, FILE *fp);
 #endif
+int OSSL_ENCODER_to_data(OSSL_ENCODER_CTX *ctx, unsigned char **pdata,
+                         size_t *pdata_len);
 
 /*
  * Create the OSSL_ENCODER_CTX with an associated type.  This will perform

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5309,3 +5309,5 @@ EVP_KEM_gettable_ctx_params             ?	3_0_0	EXIST::FUNCTION:
 EVP_KEM_settable_ctx_params             ?	3_0_0	EXIST::FUNCTION:
 PKCS7_type_is_other                     ?	3_0_0	EXIST::FUNCTION:
 PKCS7_get_octet_string                  ?	3_0_0	EXIST::FUNCTION:
+OSSL_DECODER_from_data                  ?	3_0_0	EXIST::FUNCTION:
+OSSL_ENCODER_to_data                    ?	3_0_0	EXIST::FUNCTION:


### PR DESCRIPTION
This adds OSSL_ENCODER_to_data() and OSSL_DECODER_from_data().  These
functions allow fairly simple rewrites of type-specific i2d and d2i
calls.