### PR TITLE
[WIP] Add new provider encoders implementations for more output standards

### DIFF
--- a/crypto/asn1/i2d_pr.c
+++ b/crypto/asn1/i2d_pr.c
@@ -40,20 +40,8 @@ int i2d_PrivateKey(const EVP_PKEY *a, unsigned char **pp)
         int ret = -1;
         OSSL_ENCODER_CTX *ctx;
 
-        /*
-         * The structure "rawkey" is expected to implements the same as
-         * a->ameth->old_priv_encode(), so we look for it first, and if not
-         * available, we use the "pkcs8" structure.  That implements the
-         * same encoding as the legacy code above.
-         */
         ctx = OSSL_ENCODER_CTX_new_by_EVP_PKEY(a, "DER", selection,
-                                               NULL, "structure=rawkey");
-        if (OSSL_ENCODER_CTX_get_num_encoders(ctx) == 0) {
-            OSSL_ENCODER_CTX_free(ctx);
-            ctx = OSSL_ENCODER_CTX_new_by_EVP_PKEY(a, "DER", selection,
-                                                   NULL, "structure=pkcs8");
-        }
-
+                                               NULL, "structure=ossl");
         if (OSSL_ENCODER_CTX_get_num_encoders(ctx) != 0
             && OSSL_ENCODER_to_data(ctx, pp, &length))
             ret = (int)length;

--- a/crypto/pem/pem_local.h
+++ b/crypto/pem/pem_local.h
@@ -39,7 +39,7 @@
  */
 # define PEM_STRUCTURE_PUBKEY "structure=SubjectPublicKeyInfo"
 # define PEM_STRUCTURE_PrivateKey "structure=pkcs8"
-# define PEM_STRUCTURE_Parameters "structure=raw"
+# define PEM_STRUCTURE_Parameters "structure=ossl"
 
 /* Alternative IMPLEMENT macros for provided encoders */
 

--- a/crypto/pem/pem_local.h
+++ b/crypto/pem/pem_local.h
@@ -34,13 +34,20 @@
     (OSSL_KEYMGMT_SELECT_ALL_PARAMETERS | OSSL_KEYMGMT_SELECT_KEYPAIR)
 # define PEM_SELECTION_Parameters OSSL_KEYMGMT_SELECT_ALL_PARAMETERS
 
+/*
+ * Properties, named according to the ASN.1 names used throughout libcrypto.
+ */
+# define PEM_STRUCTURE_PUBKEY "structure=SubjectPublicKeyInfo"
+# define PEM_STRUCTURE_PrivateKey "structure=pkcs8"
+# define PEM_STRUCTURE_Parameters "structure=raw"
+
 /* Alternative IMPLEMENT macros for provided encoders */
 
 # define IMPLEMENT_PEM_provided_write_body_vars(type, asn1)             \
     int ret = 0;                                                        \
     OSSL_ENCODER_CTX *ctx =                                             \
         OSSL_ENCODER_CTX_new_by_##type(x, "PEM", PEM_SELECTION_##asn1,  \
-                                       NULL, NULL);                     \
+                                       NULL, PEM_STRUCTURE_##asn1);     \
                                                                         \
     if (OSSL_ENCODER_CTX_get_num_encoders(ctx) == 0) {                  \
         OSSL_ENCODER_CTX_free(ctx);                                     \

--- a/crypto/pem/pem_pk8.c
+++ b/crypto/pem/pem_pk8.c
@@ -22,14 +22,14 @@ static int do_pk8pkey(BIO *bp, const EVP_PKEY *x, int isder,
                       int nid, const EVP_CIPHER *enc,
                       const char *kstr, int klen,
                       pem_password_cb *cb, void *u,
-                      OPENSSL_CTX *libctx, const char *propq);
+                      OPENSSL_CTX *libctx);
 
 #ifndef OPENSSL_NO_STDIO
 static int do_pk8pkey_fp(FILE *bp, const EVP_PKEY *x, int isder,
                          int nid, const EVP_CIPHER *enc,
                          const char *kstr, int klen,
                          pem_password_cb *cb, void *u,
-                         OPENSSL_CTX *libctx, const char *propq);
+                         OPENSSL_CTX *libctx);
 #endif
 /*
  * These functions write a private key in PKCS#8 format: it is a "drop in"
@@ -42,36 +42,37 @@ int PEM_write_bio_PKCS8PrivateKey_nid(BIO *bp, const EVP_PKEY *x, int nid,
                                       const char *kstr, int klen,
                                       pem_password_cb *cb, void *u)
 {
-    return do_pk8pkey(bp, x, 0, nid, NULL, kstr, klen, cb, u, NULL, NULL);
+    return do_pk8pkey(bp, x, 0, nid, NULL, kstr, klen, cb, u, NULL);
 }
 
 int PEM_write_bio_PKCS8PrivateKey(BIO *bp, const EVP_PKEY *x, const EVP_CIPHER *enc,
                                   const char *kstr, int klen,
                                   pem_password_cb *cb, void *u)
 {
-    return do_pk8pkey(bp, x, 0, -1, enc, kstr, klen, cb, u, NULL, NULL);
+    return do_pk8pkey(bp, x, 0, -1, enc, kstr, klen, cb, u, NULL);
 }
 
 int i2d_PKCS8PrivateKey_bio(BIO *bp, const EVP_PKEY *x, const EVP_CIPHER *enc,
                             const char *kstr, int klen,
                             pem_password_cb *cb, void *u)
 {
-    return do_pk8pkey(bp, x, 1, -1, enc, kstr, klen, cb, u, NULL, NULL);
+    return do_pk8pkey(bp, x, 1, -1, enc, kstr, klen, cb, u, NULL);
 }
 
 int i2d_PKCS8PrivateKey_nid_bio(BIO *bp, const EVP_PKEY *x, int nid,
                                 const char *kstr, int klen,
                                 pem_password_cb *cb, void *u)
 {
-    return do_pk8pkey(bp, x, 1, nid, NULL, kstr, klen, cb, u, NULL, NULL);
+    return do_pk8pkey(bp, x, 1, nid, NULL, kstr, klen, cb, u, NULL);
 }
 
 static int do_pk8pkey(BIO *bp, const EVP_PKEY *x, int isder, int nid,
                       const EVP_CIPHER *enc, const char *kstr, int klen,
                       pem_password_cb *cb, void *u,
-                      OPENSSL_CTX *libctx, const char *propq)
+                      OPENSSL_CTX *libctx)
 {
     int ret = 0;
+    const char *propq = "structure=pkcs8";
     const char *outtype = isder ? "DER" : "PEM";
     OSSL_ENCODER_CTX *ctx =
         OSSL_ENCODER_CTX_new_by_EVP_PKEY(x, outtype, OSSL_KEYMGMT_SELECT_ALL,
@@ -203,34 +204,33 @@ int i2d_PKCS8PrivateKey_fp(FILE *fp, const EVP_PKEY *x, const EVP_CIPHER *enc,
                            const char *kstr, int klen,
                            pem_password_cb *cb, void *u)
 {
-    return do_pk8pkey_fp(fp, x, 1, -1, enc, kstr, klen, cb, u, NULL, NULL);
+    return do_pk8pkey_fp(fp, x, 1, -1, enc, kstr, klen, cb, u, NULL);
 }
 
 int i2d_PKCS8PrivateKey_nid_fp(FILE *fp, const EVP_PKEY *x, int nid,
                                const char *kstr, int klen,
                                pem_password_cb *cb, void *u)
 {
-    return do_pk8pkey_fp(fp, x, 1, nid, NULL, kstr, klen, cb, u, NULL, NULL);
+    return do_pk8pkey_fp(fp, x, 1, nid, NULL, kstr, klen, cb, u, NULL);
 }
 
 int PEM_write_PKCS8PrivateKey_nid(FILE *fp, const EVP_PKEY *x, int nid,
                                   const char *kstr, int klen,
                                   pem_password_cb *cb, void *u)
 {
-    return do_pk8pkey_fp(fp, x, 0, nid, NULL, kstr, klen, cb, u, NULL, NULL);
+    return do_pk8pkey_fp(fp, x, 0, nid, NULL, kstr, klen, cb, u, NULL);
 }
 
 int PEM_write_PKCS8PrivateKey(FILE *fp, const EVP_PKEY *x, const EVP_CIPHER *enc,
                               const char *kstr, int klen,
                               pem_password_cb *cb, void *u)
 {
-    return do_pk8pkey_fp(fp, x, 0, -1, enc, kstr, klen, cb, u, NULL, NULL);
+    return do_pk8pkey_fp(fp, x, 0, -1, enc, kstr, klen, cb, u, NULL);
 }
 
 static int do_pk8pkey_fp(FILE *fp, const EVP_PKEY *x, int isder, int nid,
                          const EVP_CIPHER *enc, const char *kstr, int klen,
-                         pem_password_cb *cb, void *u,
-                         OPENSSL_CTX *libctx, const char *propq)
+                         pem_password_cb *cb, void *u, OPENSSL_CTX *libctx)
 {
     BIO *bp;
     int ret;
@@ -239,7 +239,7 @@ static int do_pk8pkey_fp(FILE *fp, const EVP_PKEY *x, int isder, int nid,
         PEMerr(PEM_F_DO_PK8PKEY_FP, ERR_R_BUF_LIB);
         return 0;
     }
-    ret = do_pk8pkey(bp, x, isder, nid, enc, kstr, klen, cb, u, libctx, propq);
+    ret = do_pk8pkey(bp, x, isder, nid, enc, kstr, klen, cb, u, libctx);
     BIO_free(bp);
     return ret;
 }

--- a/crypto/x509/x_pubkey.c
+++ b/crypto/x509/x_pubkey.c
@@ -103,11 +103,12 @@ int X509_PUBKEY_set(X509_PUBKEY **x, EVP_PKEY *pkey)
         OPENSSL_CTX *libctx = ossl_provider_library_context(pkprov);
         unsigned char *der = NULL;
         size_t derlen = 0;
+        const char *propq = "structure=SubjectPublicKeyInfo";
         int selection = (OSSL_KEYMGMT_SELECT_PUBLIC_KEY
                          | OSSL_KEYMGMT_SELECT_DOMAIN_PARAMETERS);
         OSSL_ENCODER_CTX *ectx =
             OSSL_ENCODER_CTX_new_by_EVP_PKEY(pkey, "DER", selection,
-                                             libctx, NULL);
+                                             libctx, propq);
 
         if (OSSL_ENCODER_to_data(ectx, &der, &derlen)) {
             const unsigned char *pder = der;

--- a/providers/baseprov.c
+++ b/providers/baseprov.c
@@ -69,15 +69,11 @@ static int base_get_params(void *provctx, OSSL_PARAM params[])
 }
 
 static const OSSL_ALGORITHM base_encoder[] = {
-#define ENCODER(name, _fips, _output, func_table)                           \
-    { name,                                                                 \
-      "provider=base,fips=" _fips ",output=" _output,                       \
-      (func_table) }
-
+#define ENCODER_PROVIDER "base"
 #include "encoders.inc"
     { NULL, NULL, NULL }
 };
-#undef ENCODER
+#undef ENCODER_PROVIDER
 
 static const OSSL_ALGORITHM base_decoder[] = {
 #define DECODER(name, _fips, _input, func_table)                            \

--- a/providers/defltprov.c
+++ b/providers/defltprov.c
@@ -433,15 +433,11 @@ static const OSSL_ALGORITHM deflt_keymgmt[] = {
 };
 
 static const OSSL_ALGORITHM deflt_encoder[] = {
-#define ENCODER(name, _fips, _output, func_table)                           \
-    { name,                                                                 \
-      "provider=default,fips=" _fips ",output=" _output,                    \
-      (func_table) }
-
+#define ENCODER_PROVIDER "default"
 #include "encoders.inc"
     { NULL, NULL, NULL }
 };
-#undef ENCODER
+#undef ENCODER_PROVIDER
 
 static const OSSL_ALGORITHM deflt_decoder[] = {
 #define DECODER(name, _fips, _input, func_table)                            \

--- a/providers/encoders.inc
+++ b/providers/encoders.inc
@@ -7,51 +7,192 @@
  * https://www.openssl.org/source/license.html
  */
 
-#ifndef ENCODER
-# error Macro ENCODER undefined
+#ifndef ENCODER_PROVIDER
+# error Macro ENCODER_PROVIDER undefined
 #endif
+#define ENCODER_TEXT(name, _fips, func_table)                               \
+    { name,                                                                 \
+      "provider=" ENCODER_PROVIDER ",fips=" _fips ",output=text",           \
+      (func_table) }
+#define ENCODER(name, _fips, _output, _structure, func_table)               \
+    { name,                                                                 \
+      "provider=" ENCODER_PROVIDER ",fips=" _fips ",output=" _output        \
+      ",structure=" _structure,                                             \
+      (func_table) }
 
-    ENCODER("RSA", "yes", "text", ossl_rsa_to_text_encoder_functions),
-    ENCODER("RSA", "yes", "der", ossl_rsa_to_der_encoder_functions),
-    ENCODER("RSA", "yes", "pem", ossl_rsa_to_pem_encoder_functions),
-    ENCODER("RSA-PSS", "yes", "text", ossl_rsapss_to_text_encoder_functions),
-    ENCODER("RSA-PSS", "yes", "der", ossl_rsapss_to_der_encoder_functions),
-    ENCODER("RSA-PSS", "yes", "pem", ossl_rsapss_to_pem_encoder_functions),
+    /*
+     * All key TYPEs that have i2d_TYPEPrivateKey, i2d_TYPEPublicKey and
+     * i2d_TYPEparams functions should have a corresponding "raw" entry
+     * here.  They implement the structure that is relevant for the key
+     * TYPE (RSA does PKCS#1, DH does PKCS#3, ...)
+     *
+     * All key types that have old_encode_priv implementation in the
+     * EVP_PKEY_ASN1_METHOD should have a corresponding "rawkey" entry
+     * here.
+     *
+     * All key types should have "pkcs8" and "SubjectPublicKeyInfo"
+     * entries here.
+     *
+     * There may be additional entries with other structure names for the
+     * convenience of the users.
+     */
+
+    ENCODER_TEXT("RSA", "yes", ossl_rsa_to_text_encoder_functions),
+    ENCODER("RSA", "yes", "der", "raw",
+            ossl_rsa_to_RAW_der_encoder_functions),
+    ENCODER("RSA", "yes", "pem", "raw",
+            ossl_rsa_to_RAW_pem_encoder_functions),
+    ENCODER("RSA", "yes", "der", "rawkey",
+            ossl_rsa_to_RAWKEY_der_encoder_functions),
+    ENCODER("RSA", "yes", "pem", "rawkey",
+            ossl_rsa_to_RAWKEY_pem_encoder_functions),
+    ENCODER("RSA", "yes", "der", "pkcs8",
+            ossl_rsa_to_PKCS8_der_encoder_functions),
+    ENCODER("RSA", "yes", "pem", "pkcs8",
+            ossl_rsa_to_PKCS8_pem_encoder_functions),
+    ENCODER("RSA", "yes", "der", "SubjectPublicKeyInfo",
+            ossl_rsa_to_SubjectPublicKeyInfo_der_encoder_functions),
+    ENCODER("RSA", "yes", "pem", "SubjectPublicKeyInfo",
+            ossl_rsa_to_SubjectPublicKeyInfo_pem_encoder_functions),
+    /* PKCS#1 is a well known for plain RSA keys, so we add that too */
+    ENCODER("RSA", "yes", "der", "pkcs1",
+            ossl_rsa_to_RAW_der_encoder_functions),
+    ENCODER("RSA", "yes", "pem", "pkcs1",
+            ossl_rsa_to_RAW_pem_encoder_functions),
+
+    /*
+     * RSA-PSS uses the same functions as RSA, except for RAW, PKCS#8
+     * and SubjectPublicKeyInfo
+     */
+    ENCODER_TEXT("RSA-PSS", "yes", ossl_rsapss_to_text_encoder_functions),
+    ENCODER("RSA-PSS", "yes", "der", "raw",
+            ossl_rsapss_to_RAW_der_encoder_functions),
+    ENCODER("RSA-PSS", "yes", "pem", "raw",
+            ossl_rsapss_to_RAW_pem_encoder_functions),
+    ENCODER("RSA-PSS", "yes", "der", "rawkey",
+            ossl_rsa_to_RAWKEY_der_encoder_functions),
+    ENCODER("RSA-PSS", "yes", "pem", "rawkey",
+            ossl_rsa_to_RAWKEY_pem_encoder_functions),
+    ENCODER("RSA-PSS", "yes", "der", "pkcs8",
+            ossl_rsapss_to_PKCS8_der_encoder_functions),
+    ENCODER("RSA-PSS", "yes", "pem", "pkcs8",
+            ossl_rsapss_to_PKCS8_pem_encoder_functions),
+    ENCODER("RSA-PSS", "yes", "der", "SubjectPublicKeyInfo",
+            ossl_rsapss_to_SubjectPublicKeyInfo_der_encoder_functions),
+    ENCODER("RSA-PSS", "yes", "pem", "SubjectPublicKeyInfo",
+            ossl_rsapss_to_SubjectPublicKeyInfo_pem_encoder_functions),
 
 #ifndef OPENSSL_NO_DH
-    ENCODER("DH", "yes", "text", ossl_dh_to_text_encoder_functions),
-    ENCODER("DH", "yes", "der", ossl_dh_to_der_encoder_functions),
-    ENCODER("DH", "yes", "pem", ossl_dh_to_pem_encoder_functions),
+    /*
+     * OpenSSL 1.1.1 DH EVP_PKEY_ASN1_METHOD doesn't implement old_priv_encode,
+     * So we provide no "rawkey" implementation.
+     */
+    ENCODER_TEXT("DH", "yes", ossl_dh_to_text_encoder_functions),
+    ENCODER("DH", "yes", "der", "raw",
+            ossl_dh_to_RAW_der_encoder_functions),
+    ENCODER("DH", "yes", "pem", "raw",
+            ossl_dh_to_RAW_pem_encoder_functions),
+    ENCODER("DH", "yes", "der", "pkcs8",
+            ossl_dh_to_PKCS8_der_encoder_functions),
+    ENCODER("DH", "yes", "pem", "pkcs8",
+            ossl_dh_to_PKCS8_pem_encoder_functions),
+    ENCODER("DH", "yes", "der", "SubjectPublicKeyInfo",
+            ossl_dh_to_SubjectPublicKeyInfo_der_encoder_functions),
+    ENCODER("DH", "yes", "pem", "SubjectPublicKeyInfo",
+            ossl_dh_to_SubjectPublicKeyInfo_pem_encoder_functions),
 
-    ENCODER("DHX", "yes", "text", ossl_dhx_to_text_encoder_functions),
-    ENCODER("DHX", "yes", "der", ossl_dhx_to_der_encoder_functions),
-    ENCODER("DHX", "yes", "pem", ossl_dhx_to_pem_encoder_functions),
+    ENCODER_TEXT("DHX", "yes", ossl_dhx_to_text_encoder_functions),
+    ENCODER("DHX", "yes", "der", "raw",
+            ossl_dhx_to_RAW_der_encoder_functions),
+    ENCODER("DHX", "yes", "pem", "raw",
+            ossl_dhx_to_RAW_pem_encoder_functions),
+    ENCODER("DHX", "yes", "der", "pkcs8",
+            ossl_dhx_to_PKCS8_der_encoder_functions),
+    ENCODER("DHX", "yes", "pem", "pkcs8",
+            ossl_dhx_to_PKCS8_pem_encoder_functions),
+    ENCODER("DHX", "yes", "der", "SubjectPublicKeyInfo",
+            ossl_dhx_to_SubjectPublicKeyInfo_der_encoder_functions),
+    ENCODER("DHX", "yes", "pem", "SubjectPublicKeyInfo",
+            ossl_dhx_to_SubjectPublicKeyInfo_pem_encoder_functions),
 #endif
 
 #ifndef OPENSSL_NO_DSA
-    ENCODER("DSA", "yes", "text", ossl_dsa_to_text_encoder_functions),
-    ENCODER("DSA", "yes", "der", ossl_dsa_to_der_encoder_functions),
-    ENCODER("DSA", "yes", "pem", ossl_dsa_to_pem_encoder_functions),
+    ENCODER_TEXT("DSA", "yes", ossl_dsa_to_text_encoder_functions),
+    ENCODER("DSA", "yes", "der", "raw",
+            ossl_dsa_to_RAW_der_encoder_functions),
+    ENCODER("DSA", "yes", "pem", "raw",
+            ossl_dsa_to_RAW_pem_encoder_functions),
+    ENCODER("DSA", "yes", "der", "rawkey",
+            ossl_dsa_to_RAWKEY_der_encoder_functions),
+    ENCODER("DSA", "yes", "pem", "rawkey",
+            ossl_dsa_to_RAWKEY_pem_encoder_functions),
+    ENCODER("DSA", "yes", "der", "pkcs8",
+            ossl_dsa_to_PKCS8_der_encoder_functions),
+    ENCODER("DSA", "yes", "pem", "pkcs8",
+            ossl_dsa_to_PKCS8_pem_encoder_functions),
+    ENCODER("DSA", "yes", "der", "SubjectPublicKeyInfo",
+            ossl_dsa_to_SubjectPublicKeyInfo_der_encoder_functions),
+    ENCODER("DSA", "yes", "pem", "SubjectPublicKeyInfo",
+            ossl_dsa_to_SubjectPublicKeyInfo_pem_encoder_functions),
 #endif
 
 #ifndef OPENSSL_NO_EC
-    ENCODER("X25519", "yes", "text", ossl_x25519_to_text_encoder_functions),
-    ENCODER("X25519", "yes", "der", ossl_x25519_to_der_encoder_functions),
-    ENCODER("X25519", "yes", "pem", ossl_x25519_to_pem_encoder_functions),
+    /* X25519, X448, ED25519 and ED448 only support PKCS#8 and SPKI */
+    ENCODER_TEXT("X25519", "yes", ossl_x25519_to_text_encoder_functions),
+    ENCODER("X25519", "yes", "der", "pkcs8",
+            ossl_x25519_to_PKCS8_der_encoder_functions),
+    ENCODER("X25519", "yes", "pem", "pkcs8",
+            ossl_x25519_to_PKCS8_pem_encoder_functions),
+    ENCODER("X25519", "yes", "der", "SubjectPublicKeyInfo",
+            ossl_x25519_to_SubjectPublicKeyInfo_der_encoder_functions),
+    ENCODER("X25519", "yes", "pem", "SubjectPublicKeyInfo",
+            ossl_x25519_to_SubjectPublicKeyInfo_pem_encoder_functions),
 
-    ENCODER("X448", "yes", "text", ossl_x448_to_text_encoder_functions),
-    ENCODER("X448", "yes", "der", ossl_x448_to_der_encoder_functions),
-    ENCODER("X448", "yes", "pem", ossl_x448_to_pem_encoder_functions),
+    ENCODER_TEXT("X448", "yes", ossl_x448_to_text_encoder_functions),
+    ENCODER("X448", "yes", "der", "pkcs8",
+            ossl_x448_to_PKCS8_der_encoder_functions),
+    ENCODER("X448", "yes", "pem", "pkcs8",
+            ossl_x448_to_PKCS8_pem_encoder_functions),
+    ENCODER("X448", "yes", "der", "SubjectPublicKeyInfo",
+            ossl_x448_to_SubjectPublicKeyInfo_der_encoder_functions),
+    ENCODER("X448", "yes", "pem", "SubjectPublicKeyInfo",
+            ossl_x448_to_SubjectPublicKeyInfo_pem_encoder_functions),
 
-    ENCODER("ED25519", "yes", "text", ossl_ed25519_to_text_encoder_functions),
-    ENCODER("ED25519", "yes", "der", ossl_ed25519_to_der_encoder_functions),
-    ENCODER("ED25519", "yes", "pem", ossl_ed25519_to_pem_encoder_functions),
+    ENCODER_TEXT("ED25519", "yes", ossl_ed25519_to_text_encoder_functions),
+    ENCODER("ED25519", "yes", "der", "pkcs8",
+            ossl_ed25519_to_PKCS8_der_encoder_functions),
+    ENCODER("ED25519", "yes", "pem", "pkcs8",
+            ossl_ed25519_to_PKCS8_pem_encoder_functions),
+    ENCODER("ED25519", "yes", "der", "SubjectPublicKeyInfo",
+            ossl_ed25519_to_SubjectPublicKeyInfo_der_encoder_functions),
+    ENCODER("ED25519", "yes", "pem", "SubjectPublicKeyInfo",
+            ossl_ed25519_to_SubjectPublicKeyInfo_pem_encoder_functions),
 
-    ENCODER("ED448", "yes", "text", ossl_ed448_to_text_encoder_functions),
-    ENCODER("ED448", "yes", "der", ossl_ed448_to_der_encoder_functions),
-    ENCODER("ED448", "yes", "pem", ossl_ed448_to_pem_encoder_functions),
+    ENCODER_TEXT("ED448", "yes", ossl_ed448_to_text_encoder_functions),
+    ENCODER("ED448", "yes", "der", "pkcs8",
+            ossl_ed448_to_PKCS8_der_encoder_functions),
+    ENCODER("ED448", "yes", "pem", "pkcs8",
+            ossl_ed448_to_PKCS8_pem_encoder_functions),
+    ENCODER("ED448", "yes", "der", "SubjectPublicKeyInfo",
+            ossl_ed448_to_SubjectPublicKeyInfo_der_encoder_functions),
+    ENCODER("ED448", "yes", "pem", "SubjectPublicKeyInfo",
+            ossl_ed448_to_SubjectPublicKeyInfo_pem_encoder_functions),
 
-    ENCODER("EC", "yes", "text", ossl_ec_to_text_encoder_functions),
-    ENCODER("EC", "yes", "der", ossl_ec_to_der_encoder_functions),
-    ENCODER("EC", "yes", "pem", ossl_ec_to_pem_encoder_functions),
+    ENCODER_TEXT("EC", "yes", ossl_ec_to_text_encoder_functions),
+    ENCODER("EC", "yes", "der", "raw",
+            ossl_ec_to_RAW_der_encoder_functions),
+    ENCODER("EC", "yes", "pem", "raw",
+            ossl_ec_to_RAW_pem_encoder_functions),
+    ENCODER("EC", "yes", "der", "rawkey",
+            ossl_ec_to_RAWKEY_der_encoder_functions),
+    ENCODER("EC", "yes", "pem", "rawkey",
+            ossl_ec_to_RAWKEY_pem_encoder_functions),
+    ENCODER("EC", "yes", "der", "pkcs8",
+            ossl_ec_to_PKCS8_der_encoder_functions),
+    ENCODER("EC", "yes", "pem", "pkcs8",
+            ossl_ec_to_PKCS8_pem_encoder_functions),
+    ENCODER("EC", "yes", "der", "SubjectPublicKeyInfo",
+            ossl_ec_to_SubjectPublicKeyInfo_der_encoder_functions),
+    ENCODER("EC", "yes", "pem", "SubjectPublicKeyInfo",
+            ossl_ec_to_SubjectPublicKeyInfo_pem_encoder_functions),
 #endif

--- a/providers/encoders.inc
+++ b/providers/encoders.inc
@@ -20,179 +20,207 @@
       ",structure=" _structure,                                             \
       (func_table) }
 
-    /*
-     * All key TYPEs that have i2d_TYPEPrivateKey, i2d_TYPEPublicKey and
-     * i2d_TYPEparams functions should have a corresponding "raw" entry
-     * here.  They implement the structure that is relevant for the key
-     * TYPE (RSA does PKCS#1, DH does PKCS#3, ...)
-     *
-     * All key types that have old_encode_priv implementation in the
-     * EVP_PKEY_ASN1_METHOD should have a corresponding "rawkey" entry
-     * here.
-     *
-     * All key types should have "pkcs8" and "SubjectPublicKeyInfo"
-     * entries here.
-     *
-     * There may be additional entries with other structure names for the
-     * convenience of the users.
-     */
+/*
+ * Entries for human text "encoders"
+ */
+ENCODER_TEXT("RSA", "yes", ossl_rsa_to_text_encoder_functions),
+ENCODER_TEXT("RSA-PSS", "yes", ossl_rsapss_to_text_encoder_functions),
+#ifndef OPENSSL_NO_DH
+ENCODER_TEXT("DH", "yes", ossl_dh_to_text_encoder_functions),
+ENCODER_TEXT("DHX", "yes", ossl_dhx_to_text_encoder_functions),
+#endif
+#ifndef OPENSSL_NO_DSA
+ENCODER_TEXT("DSA", "yes", ossl_dsa_to_text_encoder_functions),
+#endif
+#ifndef OPENSSL_NO_EC
+ENCODER_TEXT("EC", "yes", ossl_ec_to_text_encoder_functions),
+ENCODER_TEXT("ED25519", "yes", ossl_ed25519_to_text_encoder_functions),
+ENCODER_TEXT("ED448", "yes", ossl_ed448_to_text_encoder_functions),
+ENCODER_TEXT("X25519", "yes", ossl_x25519_to_text_encoder_functions),
+ENCODER_TEXT("X448", "yes", ossl_x448_to_text_encoder_functions),
+#endif
 
-    ENCODER_TEXT("RSA", "yes", ossl_rsa_to_text_encoder_functions),
-    ENCODER("RSA", "yes", "der", "raw",
-            ossl_rsa_to_RAW_der_encoder_functions),
-    ENCODER("RSA", "yes", "pem", "raw",
-            ossl_rsa_to_RAW_pem_encoder_functions),
-    ENCODER("RSA", "yes", "der", "rawkey",
-            ossl_rsa_to_RAWKEY_der_encoder_functions),
-    ENCODER("RSA", "yes", "pem", "rawkey",
-            ossl_rsa_to_RAWKEY_pem_encoder_functions),
-    ENCODER("RSA", "yes", "der", "pkcs8",
-            ossl_rsa_to_PKCS8_der_encoder_functions),
-    ENCODER("RSA", "yes", "pem", "pkcs8",
-            ossl_rsa_to_PKCS8_pem_encoder_functions),
-    ENCODER("RSA", "yes", "der", "SubjectPublicKeyInfo",
-            ossl_rsa_to_SubjectPublicKeyInfo_der_encoder_functions),
-    ENCODER("RSA", "yes", "pem", "SubjectPublicKeyInfo",
-            ossl_rsa_to_SubjectPublicKeyInfo_pem_encoder_functions),
-    /* PKCS#1 is a well known for plain RSA keys, so we add that too */
-    ENCODER("RSA", "yes", "der", "pkcs1",
-            ossl_rsa_to_RAW_der_encoder_functions),
-    ENCODER("RSA", "yes", "pem", "pkcs1",
-            ossl_rsa_to_RAW_pem_encoder_functions),
+/*
+ * Entries to support i2d_PrivateKey(), i2d_PublicKey() and i2d_KeyParams()
+ * They need a uniform structure name, we currently use "ossl".
+ */
+ENCODER("RSA", "yes", "der", "ossl",
+        ossl_rsa_to_OSSL_old_der_encoder_functions),
+ENCODER("RSA-PSS", "yes", "der", "ossl",
+        ossl_rsapss_to_OSSL_current_der_encoder_functions),
+#ifndef OPENSSL_NO_DH
+ENCODER("DH", "yes", "der", "ossl",
+        ossl_dh_to_OSSL_current_w_params_der_encoder_functions),
+#endif
+#ifndef OPENSSL_NO_DSA
+ENCODER("DSA", "yes", "der", "ossl",
+        ossl_dsa_to_OSSL_old_w_params_der_encoder_functions),
+#endif
+#ifndef OPENSSL_NO_EC
+ENCODER("EC", "yes", "der", "ossl",
+        ossl_ec_to_OSSL_old_w_params_der_encoder_functions),
+ENCODER("ED25519", "yes", "der", "ossl",
+        ossl_ed25519_to_OSSL_current_der_encoder_functions),
+ENCODER("ED448", "yes", "der", "ossl",
+        ossl_ed448_to_OSSL_current_der_encoder_functions),
+ENCODER("X25519", "yes", "der", "ossl",
+        ossl_x25519_to_OSSL_current_der_encoder_functions),
+ENCODER("X448", "yes", "der", "ossl",
+        ossl_x448_to_OSSL_current_der_encoder_functions),
+#endif
 
-    /*
-     * RSA-PSS uses the same functions as RSA, except for RAW, PKCS#8
-     * and SubjectPublicKeyInfo
-     */
-    ENCODER_TEXT("RSA-PSS", "yes", ossl_rsapss_to_text_encoder_functions),
-    ENCODER("RSA-PSS", "yes", "der", "raw",
-            ossl_rsapss_to_RAW_der_encoder_functions),
-    ENCODER("RSA-PSS", "yes", "pem", "raw",
-            ossl_rsapss_to_RAW_pem_encoder_functions),
-    ENCODER("RSA-PSS", "yes", "der", "rawkey",
-            ossl_rsa_to_RAWKEY_der_encoder_functions),
-    ENCODER("RSA-PSS", "yes", "pem", "rawkey",
-            ossl_rsa_to_RAWKEY_pem_encoder_functions),
-    ENCODER("RSA-PSS", "yes", "der", "pkcs8",
-            ossl_rsapss_to_PKCS8_der_encoder_functions),
-    ENCODER("RSA-PSS", "yes", "pem", "pkcs8",
-            ossl_rsapss_to_PKCS8_pem_encoder_functions),
-    ENCODER("RSA-PSS", "yes", "der", "SubjectPublicKeyInfo",
-            ossl_rsapss_to_SubjectPublicKeyInfo_der_encoder_functions),
-    ENCODER("RSA-PSS", "yes", "pem", "SubjectPublicKeyInfo",
-            ossl_rsapss_to_SubjectPublicKeyInfo_pem_encoder_functions),
+/*
+ * Entries to support PEM_write_bio_Parameters(), using the same uniform
+ * structure name "ossl".
+ */
+#ifndef OPENSSL_NO_DH
+ENCODER("DH", "yes", "pem", "ossl", ossl_dh_to_OSSL_params_pem_encoder_functions),
+#endif
+#ifndef OPENSSL_NO_DSA
+ENCODER("DSA", "yes", "pem", "ossl", ossl_dsa_to_OSSL_params_pem_encoder_functions),
+#endif
+#ifndef OPENSSL_NO_EC
+ENCODER("EC", "yes", "pem", "ossl", ossl_ec_to_OSSL_params_pem_encoder_functions),
+#endif
+
+/*
+ * Entries for PKCS#8 and SubjectPublicKeyInfo.  These are added convenience
+ * for any user that wants to use OSSL_ENCODER directly.  However, the "pem"
+ * ones also support PEM_write_bio_PrivateKey() and PEM_write_bio_PUBKEY().
+ */
+ENCODER("RSA", "yes", "der", "pkcs8", ossl_rsa_to_PKCS8_der_encoder_functions),
+ENCODER("RSA", "yes", "pem", "pkcs8", ossl_rsa_to_PKCS8_pem_encoder_functions),
+ENCODER("RSA", "yes", "der", "SubjectPublicKeyInfo",
+        ossl_rsa_to_SubjectPublicKeyInfo_der_encoder_functions),
+ENCODER("RSA", "yes", "pem", "SubjectPublicKeyInfo",
+        ossl_rsa_to_SubjectPublicKeyInfo_pem_encoder_functions),
+
+ENCODER("RSA-PSS", "yes", "der", "pkcs8", ossl_rsapss_to_PKCS8_der_encoder_functions),
+ENCODER("RSA-PSS", "yes", "pem", "pkcs8", ossl_rsapss_to_PKCS8_pem_encoder_functions),
+ENCODER("RSA-PSS", "yes", "der", "SubjectPublicKeyInfo",
+        ossl_rsapss_to_SubjectPublicKeyInfo_der_encoder_functions),
+ENCODER("RSA-PSS", "yes", "pem", "SubjectPublicKeyInfo",
+        ossl_rsapss_to_SubjectPublicKeyInfo_pem_encoder_functions),
 
 #ifndef OPENSSL_NO_DH
-    /*
-     * OpenSSL 1.1.1 DH EVP_PKEY_ASN1_METHOD doesn't implement old_priv_encode,
-     * So we provide no "rawkey" implementation.
-     */
-    ENCODER_TEXT("DH", "yes", ossl_dh_to_text_encoder_functions),
-    ENCODER("DH", "yes", "der", "raw",
-            ossl_dh_to_RAW_der_encoder_functions),
-    ENCODER("DH", "yes", "pem", "raw",
-            ossl_dh_to_RAW_pem_encoder_functions),
-    ENCODER("DH", "yes", "der", "pkcs8",
-            ossl_dh_to_PKCS8_der_encoder_functions),
-    ENCODER("DH", "yes", "pem", "pkcs8",
-            ossl_dh_to_PKCS8_pem_encoder_functions),
-    ENCODER("DH", "yes", "der", "SubjectPublicKeyInfo",
-            ossl_dh_to_SubjectPublicKeyInfo_der_encoder_functions),
-    ENCODER("DH", "yes", "pem", "SubjectPublicKeyInfo",
-            ossl_dh_to_SubjectPublicKeyInfo_pem_encoder_functions),
+ENCODER("DH", "yes", "der", "pkcs8", ossl_dh_to_PKCS8_der_encoder_functions),
+ENCODER("DH", "yes", "pem", "pkcs8", ossl_dh_to_PKCS8_pem_encoder_functions),
+ENCODER("DH", "yes", "der", "SubjectPublicKeyInfo",
+        ossl_dh_to_SubjectPublicKeyInfo_der_encoder_functions),
+ENCODER("DH", "yes", "pem", "SubjectPublicKeyInfo",
+        ossl_dh_to_SubjectPublicKeyInfo_pem_encoder_functions),
 
-    ENCODER_TEXT("DHX", "yes", ossl_dhx_to_text_encoder_functions),
-    ENCODER("DHX", "yes", "der", "raw",
-            ossl_dhx_to_RAW_der_encoder_functions),
-    ENCODER("DHX", "yes", "pem", "raw",
-            ossl_dhx_to_RAW_pem_encoder_functions),
-    ENCODER("DHX", "yes", "der", "pkcs8",
-            ossl_dhx_to_PKCS8_der_encoder_functions),
-    ENCODER("DHX", "yes", "pem", "pkcs8",
-            ossl_dhx_to_PKCS8_pem_encoder_functions),
-    ENCODER("DHX", "yes", "der", "SubjectPublicKeyInfo",
-            ossl_dhx_to_SubjectPublicKeyInfo_der_encoder_functions),
-    ENCODER("DHX", "yes", "pem", "SubjectPublicKeyInfo",
-            ossl_dhx_to_SubjectPublicKeyInfo_pem_encoder_functions),
+ENCODER("DHX", "yes", "der", "pkcs8", ossl_dhx_to_PKCS8_der_encoder_functions),
+ENCODER("DHX", "yes", "pem", "pkcs8", ossl_dhx_to_PKCS8_pem_encoder_functions),
+ENCODER("DHX", "yes", "der", "SubjectPublicKeyInfo",
+        ossl_dhx_to_SubjectPublicKeyInfo_der_encoder_functions),
+ENCODER("DHX", "yes", "pem", "SubjectPublicKeyInfo",
+        ossl_dhx_to_SubjectPublicKeyInfo_pem_encoder_functions),
 #endif
 
 #ifndef OPENSSL_NO_DSA
-    ENCODER_TEXT("DSA", "yes", ossl_dsa_to_text_encoder_functions),
-    ENCODER("DSA", "yes", "der", "raw",
-            ossl_dsa_to_RAW_der_encoder_functions),
-    ENCODER("DSA", "yes", "pem", "raw",
-            ossl_dsa_to_RAW_pem_encoder_functions),
-    ENCODER("DSA", "yes", "der", "rawkey",
-            ossl_dsa_to_RAWKEY_der_encoder_functions),
-    ENCODER("DSA", "yes", "pem", "rawkey",
-            ossl_dsa_to_RAWKEY_pem_encoder_functions),
-    ENCODER("DSA", "yes", "der", "pkcs8",
-            ossl_dsa_to_PKCS8_der_encoder_functions),
-    ENCODER("DSA", "yes", "pem", "pkcs8",
-            ossl_dsa_to_PKCS8_pem_encoder_functions),
-    ENCODER("DSA", "yes", "der", "SubjectPublicKeyInfo",
-            ossl_dsa_to_SubjectPublicKeyInfo_der_encoder_functions),
-    ENCODER("DSA", "yes", "pem", "SubjectPublicKeyInfo",
-            ossl_dsa_to_SubjectPublicKeyInfo_pem_encoder_functions),
+ENCODER("DSA", "yes", "der", "pkcs8", ossl_dsa_to_PKCS8_der_encoder_functions),
+ENCODER("DSA", "yes", "pem", "pkcs8", ossl_dsa_to_PKCS8_pem_encoder_functions),
+ENCODER("DSA", "yes", "der", "SubjectPublicKeyInfo",
+        ossl_dsa_to_SubjectPublicKeyInfo_der_encoder_functions),
+ENCODER("DSA", "yes", "pem", "SubjectPublicKeyInfo",
+        ossl_dsa_to_SubjectPublicKeyInfo_pem_encoder_functions),
 #endif
 
 #ifndef OPENSSL_NO_EC
-    /* X25519, X448, ED25519 and ED448 only support PKCS#8 and SPKI */
-    ENCODER_TEXT("X25519", "yes", ossl_x25519_to_text_encoder_functions),
-    ENCODER("X25519", "yes", "der", "pkcs8",
-            ossl_x25519_to_PKCS8_der_encoder_functions),
-    ENCODER("X25519", "yes", "pem", "pkcs8",
-            ossl_x25519_to_PKCS8_pem_encoder_functions),
-    ENCODER("X25519", "yes", "der", "SubjectPublicKeyInfo",
-            ossl_x25519_to_SubjectPublicKeyInfo_der_encoder_functions),
-    ENCODER("X25519", "yes", "pem", "SubjectPublicKeyInfo",
-            ossl_x25519_to_SubjectPublicKeyInfo_pem_encoder_functions),
+ENCODER("EC", "yes", "der", "pkcs8", ossl_ec_to_PKCS8_der_encoder_functions),
+ENCODER("EC", "yes", "pem", "pkcs8", ossl_ec_to_PKCS8_pem_encoder_functions),
+ENCODER("EC", "yes", "der", "SubjectPublicKeyInfo",
+        ossl_ec_to_SubjectPublicKeyInfo_der_encoder_functions),
+ENCODER("EC", "yes", "pem", "SubjectPublicKeyInfo",
+        ossl_ec_to_SubjectPublicKeyInfo_pem_encoder_functions),
 
-    ENCODER_TEXT("X448", "yes", ossl_x448_to_text_encoder_functions),
-    ENCODER("X448", "yes", "der", "pkcs8",
-            ossl_x448_to_PKCS8_der_encoder_functions),
-    ENCODER("X448", "yes", "pem", "pkcs8",
-            ossl_x448_to_PKCS8_pem_encoder_functions),
-    ENCODER("X448", "yes", "der", "SubjectPublicKeyInfo",
-            ossl_x448_to_SubjectPublicKeyInfo_der_encoder_functions),
-    ENCODER("X448", "yes", "pem", "SubjectPublicKeyInfo",
-            ossl_x448_to_SubjectPublicKeyInfo_pem_encoder_functions),
+ENCODER("X25519", "yes", "der", "pkcs8", ossl_x25519_to_PKCS8_der_encoder_functions),
+ENCODER("X25519", "yes", "pem", "pkcs8", ossl_x25519_to_PKCS8_pem_encoder_functions),
+ENCODER("X25519", "yes", "der", "SubjectPublicKeyInfo",
+        ossl_x25519_to_SubjectPublicKeyInfo_der_encoder_functions),
+ENCODER("X25519", "yes", "pem", "SubjectPublicKeyInfo",
+        ossl_x25519_to_SubjectPublicKeyInfo_pem_encoder_functions),
 
-    ENCODER_TEXT("ED25519", "yes", ossl_ed25519_to_text_encoder_functions),
-    ENCODER("ED25519", "yes", "der", "pkcs8",
-            ossl_ed25519_to_PKCS8_der_encoder_functions),
-    ENCODER("ED25519", "yes", "pem", "pkcs8",
-            ossl_ed25519_to_PKCS8_pem_encoder_functions),
-    ENCODER("ED25519", "yes", "der", "SubjectPublicKeyInfo",
-            ossl_ed25519_to_SubjectPublicKeyInfo_der_encoder_functions),
-    ENCODER("ED25519", "yes", "pem", "SubjectPublicKeyInfo",
-            ossl_ed25519_to_SubjectPublicKeyInfo_pem_encoder_functions),
+ENCODER("X448", "yes", "der", "pkcs8", ossl_x448_to_PKCS8_der_encoder_functions),
+ENCODER("X448", "yes", "pem", "pkcs8", ossl_x448_to_PKCS8_pem_encoder_functions),
+ENCODER("X448", "yes", "der", "SubjectPublicKeyInfo",
+        ossl_x448_to_SubjectPublicKeyInfo_der_encoder_functions),
+ENCODER("X448", "yes", "pem", "SubjectPublicKeyInfo",
+        ossl_x448_to_SubjectPublicKeyInfo_pem_encoder_functions),
 
-    ENCODER_TEXT("ED448", "yes", ossl_ed448_to_text_encoder_functions),
-    ENCODER("ED448", "yes", "der", "pkcs8",
-            ossl_ed448_to_PKCS8_der_encoder_functions),
-    ENCODER("ED448", "yes", "pem", "pkcs8",
-            ossl_ed448_to_PKCS8_pem_encoder_functions),
-    ENCODER("ED448", "yes", "der", "SubjectPublicKeyInfo",
-            ossl_ed448_to_SubjectPublicKeyInfo_der_encoder_functions),
-    ENCODER("ED448", "yes", "pem", "SubjectPublicKeyInfo",
-            ossl_ed448_to_SubjectPublicKeyInfo_pem_encoder_functions),
+ENCODER("ED25519", "yes", "der", "pkcs8", ossl_ed25519_to_PKCS8_der_encoder_functions),
+ENCODER("ED25519", "yes", "pem", "pkcs8", ossl_ed25519_to_PKCS8_pem_encoder_functions),
+ENCODER("ED25519", "yes", "der", "SubjectPublicKeyInfo",
+        ossl_ed25519_to_SubjectPublicKeyInfo_der_encoder_functions),
+ENCODER("ED25519", "yes", "pem", "SubjectPublicKeyInfo",
+        ossl_ed25519_to_SubjectPublicKeyInfo_pem_encoder_functions),
 
-    ENCODER_TEXT("EC", "yes", ossl_ec_to_text_encoder_functions),
-    ENCODER("EC", "yes", "der", "raw",
-            ossl_ec_to_RAW_der_encoder_functions),
-    ENCODER("EC", "yes", "pem", "raw",
-            ossl_ec_to_RAW_pem_encoder_functions),
-    ENCODER("EC", "yes", "der", "rawkey",
-            ossl_ec_to_RAWKEY_der_encoder_functions),
-    ENCODER("EC", "yes", "pem", "rawkey",
-            ossl_ec_to_RAWKEY_pem_encoder_functions),
-    ENCODER("EC", "yes", "der", "pkcs8",
-            ossl_ec_to_PKCS8_der_encoder_functions),
-    ENCODER("EC", "yes", "pem", "pkcs8",
-            ossl_ec_to_PKCS8_pem_encoder_functions),
-    ENCODER("EC", "yes", "der", "SubjectPublicKeyInfo",
-            ossl_ec_to_SubjectPublicKeyInfo_der_encoder_functions),
-    ENCODER("EC", "yes", "pem", "SubjectPublicKeyInfo",
-            ossl_ec_to_SubjectPublicKeyInfo_pem_encoder_functions),
+ENCODER("ED448", "yes", "der", "pkcs8", ossl_ed448_to_PKCS8_der_encoder_functions),
+ENCODER("ED448", "yes", "pem", "pkcs8", ossl_ed448_to_PKCS8_pem_encoder_functions),
+ENCODER("ED448", "yes", "der", "SubjectPublicKeyInfo",
+        ossl_ed448_to_SubjectPublicKeyInfo_der_encoder_functions),
+ENCODER("ED448", "yes", "pem", "SubjectPublicKeyInfo",
+        ossl_ed448_to_SubjectPublicKeyInfo_pem_encoder_functions),
+#endif
+
+/*
+ * Entries for key specific output formats.  The structure name on these
+ * is the same as the key type name.  This allows us to say something like:
+ *
+ * To replace i2d_{TYPE}PrivateKey(), i2d_{TYPE}PublicKey() and
+ * i2d_{TYPE}Params(), use OSSL_ENCODER functions with an OSSL_ENCODER_CTX
+ * created like this:
+ *
+ * OSSL_ENCODER_CTX *ctx =
+ *     OSSL_ENCODER_CTX_new_by_EVP_PKEY(pkey, "DER", selection, NULL,
+ *                                      "structure={type}");
+ *
+ * To replace PEM_write_bio_{TYPE}PrivateKey(), PEM_write_bio_{TYPE}PublicKey()
+ * and PEM_write_bio_{TYPE}Params(), use OSSL_ENCODER functions with an
+ * OSSL_ENCODER_CTX created like this:
+ *
+ * OSSL_ENCODER_CTX *ctx =
+ *     OSSL_ENCODER_CTX_new_by_EVP_PKEY(pkey, "PEM", selection, NULL,
+ *                                      "structure={type}");
+ *
+ * We only implement those for which there are current i2d_ and PEM_write_bio
+ * implementations.
+ */
+
+/* The RSA encoders only support private key and public key output */
+ENCODER("RSA", "yes", "der", "rsa", ossl_rsa_to_PKCS1_der_encoder_functions),
+ENCODER("RSA", "yes", "pem", "rsa", ossl_rsa_to_PKCS1_pem_encoder_functions),
+#ifndef OPENSSL_NO_DH
+/* DH and X9.42 DH only support key parameters output. */
+ENCODER("DH", "yes", "der", "dh", ossl_dh_to_PKCS3_der_encoder_functions),
+ENCODER("DH", "yes", "pem", "dh", ossl_dh_to_PKCS3_pem_encoder_functions),
+ENCODER("DHX", "yes", "der", "dhx", ossl_dhx_to_X9_42_der_encoder_functions),
+ENCODER("DHX", "yes", "pem", "dhx", ossl_dhx_to_X9_42_pem_encoder_functions),
+#endif
+#ifndef OPENSSL_NO_DSA
+ENCODER("DSA", "yes", "der", "dsa", ossl_dsa_to_RAW_w_params_der_encoder_functions),
+ENCODER("DSA", "yes", "pem", "dsa", ossl_dsa_to_RAW_w_params_pem_encoder_functions),
+#endif
+#ifndef OPENSSL_NO_EC
+ENCODER("EC", "yes", "der", "ec", ossl_ec_to_RAW_w_params_der_encoder_functions),
+ENCODER("EC", "yes", "pem", "ec", ossl_ec_to_RAW_w_params_pem_encoder_functions),
+#endif
+
+/*
+ * Additional entries with structure names being the standard name.
+ * This is entirely for the convenience of the user that wants to use
+ * OSSL_ENCODER directly with names they may fancy.  These do not impact
+ * on libcrypto functionality in any way.
+ */
+/* PKCS#1 is a well known for plain RSA keys, so we add that too */
+ENCODER("RSA", "yes", "der", "pkcs1", ossl_rsa_to_PKCS1_der_encoder_functions),
+ENCODER("RSA", "yes", "pem", "pkcs1", ossl_rsa_to_PKCS1_pem_encoder_functions),
+#ifndef OPENSSL_NO_DH
+/* PKCS#3 defines the format for DH parameters */
+ENCODER("DH", "yes", "der", "pkcs3", ossl_dh_to_PKCS3_der_encoder_functions),
+ENCODER("DH", "yes", "pem", "pkcs3", ossl_dh_to_PKCS3_pem_encoder_functions),
+/* X9.42 defines the format for DHX parameters */
+ENCODER("DHX", "yes", "der", "X9.42", ossl_dhx_to_X9_42_der_encoder_functions),
+ENCODER("DHX", "yes", "pem", "X9.42", ossl_dhx_to_X9_42_pem_encoder_functions),
 #endif

--- a/providers/implementations/include/prov/implementations.h
+++ b/providers/implementations/include/prov/implementations.h
@@ -315,44 +315,82 @@ extern const OSSL_DISPATCH sm2_asym_cipher_functions[];
 extern const OSSL_DISPATCH ossl_rsa_asym_kem_functions[];
 
 /* Encoders */
-extern const OSSL_DISPATCH ossl_rsa_to_der_encoder_functions[];
-extern const OSSL_DISPATCH ossl_rsa_to_pem_encoder_functions[];
+extern const OSSL_DISPATCH ossl_rsa_to_RAW_der_encoder_functions[];
+extern const OSSL_DISPATCH ossl_rsa_to_RAW_pem_encoder_functions[];
+extern const OSSL_DISPATCH ossl_rsa_to_RAWKEY_der_encoder_functions[];
+extern const OSSL_DISPATCH ossl_rsa_to_RAWKEY_pem_encoder_functions[];
+extern const OSSL_DISPATCH ossl_rsa_to_PKCS8_der_encoder_functions[];
+extern const OSSL_DISPATCH ossl_rsa_to_PKCS8_pem_encoder_functions[];
+extern const OSSL_DISPATCH ossl_rsa_to_SubjectPublicKeyInfo_der_encoder_functions[];
+extern const OSSL_DISPATCH ossl_rsa_to_SubjectPublicKeyInfo_pem_encoder_functions[];
 extern const OSSL_DISPATCH ossl_rsa_to_text_encoder_functions[];
 
-extern const OSSL_DISPATCH ossl_rsapss_to_der_encoder_functions[];
-extern const OSSL_DISPATCH ossl_rsapss_to_pem_encoder_functions[];
+extern const OSSL_DISPATCH ossl_rsapss_to_RAW_der_encoder_functions[];
+extern const OSSL_DISPATCH ossl_rsapss_to_RAW_pem_encoder_functions[];
+extern const OSSL_DISPATCH ossl_rsapss_to_PKCS8_der_encoder_functions[];
+extern const OSSL_DISPATCH ossl_rsapss_to_PKCS8_pem_encoder_functions[];
+extern const OSSL_DISPATCH ossl_rsapss_to_SubjectPublicKeyInfo_der_encoder_functions[];
+extern const OSSL_DISPATCH ossl_rsapss_to_SubjectPublicKeyInfo_pem_encoder_functions[];
 extern const OSSL_DISPATCH ossl_rsapss_to_text_encoder_functions[];
 
-extern const OSSL_DISPATCH ossl_dh_to_der_encoder_functions[];
-extern const OSSL_DISPATCH ossl_dh_to_pem_encoder_functions[];
+extern const OSSL_DISPATCH ossl_dh_to_RAW_der_encoder_functions[];
+extern const OSSL_DISPATCH ossl_dh_to_RAW_pem_encoder_functions[];
+extern const OSSL_DISPATCH ossl_dh_to_PKCS8_der_encoder_functions[];
+extern const OSSL_DISPATCH ossl_dh_to_PKCS8_pem_encoder_functions[];
+extern const OSSL_DISPATCH ossl_dh_to_SubjectPublicKeyInfo_der_encoder_functions[];
+extern const OSSL_DISPATCH ossl_dh_to_SubjectPublicKeyInfo_pem_encoder_functions[];
 extern const OSSL_DISPATCH ossl_dh_to_text_encoder_functions[];
 
-extern const OSSL_DISPATCH ossl_dhx_to_der_encoder_functions[];
-extern const OSSL_DISPATCH ossl_dhx_to_pem_encoder_functions[];
+extern const OSSL_DISPATCH ossl_dhx_to_RAW_der_encoder_functions[];
+extern const OSSL_DISPATCH ossl_dhx_to_RAW_pem_encoder_functions[];
+extern const OSSL_DISPATCH ossl_dhx_to_PKCS8_der_encoder_functions[];
+extern const OSSL_DISPATCH ossl_dhx_to_PKCS8_pem_encoder_functions[];
+extern const OSSL_DISPATCH ossl_dhx_to_SubjectPublicKeyInfo_der_encoder_functions[];
+extern const OSSL_DISPATCH ossl_dhx_to_SubjectPublicKeyInfo_pem_encoder_functions[];
 extern const OSSL_DISPATCH ossl_dhx_to_text_encoder_functions[];
 
-extern const OSSL_DISPATCH ossl_dsa_to_der_encoder_functions[];
-extern const OSSL_DISPATCH ossl_dsa_to_pem_encoder_functions[];
+extern const OSSL_DISPATCH ossl_dsa_to_RAW_der_encoder_functions[];
+extern const OSSL_DISPATCH ossl_dsa_to_RAW_pem_encoder_functions[];
+extern const OSSL_DISPATCH ossl_dsa_to_RAWKEY_der_encoder_functions[];
+extern const OSSL_DISPATCH ossl_dsa_to_RAWKEY_pem_encoder_functions[];
+extern const OSSL_DISPATCH ossl_dsa_to_PKCS8_der_encoder_functions[];
+extern const OSSL_DISPATCH ossl_dsa_to_PKCS8_pem_encoder_functions[];
+extern const OSSL_DISPATCH ossl_dsa_to_SubjectPublicKeyInfo_der_encoder_functions[];
+extern const OSSL_DISPATCH ossl_dsa_to_SubjectPublicKeyInfo_pem_encoder_functions[];
 extern const OSSL_DISPATCH ossl_dsa_to_text_encoder_functions[];
 
-extern const OSSL_DISPATCH ossl_x25519_to_der_encoder_functions[];
-extern const OSSL_DISPATCH ossl_x25519_to_pem_encoder_functions[];
+extern const OSSL_DISPATCH ossl_x25519_to_PKCS8_der_encoder_functions[];
+extern const OSSL_DISPATCH ossl_x25519_to_PKCS8_pem_encoder_functions[];
+extern const OSSL_DISPATCH ossl_x25519_to_SubjectPublicKeyInfo_der_encoder_functions[];
+extern const OSSL_DISPATCH ossl_x25519_to_SubjectPublicKeyInfo_pem_encoder_functions[];
 extern const OSSL_DISPATCH ossl_x25519_to_text_encoder_functions[];
 
-extern const OSSL_DISPATCH ossl_x448_to_der_encoder_functions[];
-extern const OSSL_DISPATCH ossl_x448_to_pem_encoder_functions[];
+extern const OSSL_DISPATCH ossl_x448_to_PKCS8_der_encoder_functions[];
+extern const OSSL_DISPATCH ossl_x448_to_PKCS8_pem_encoder_functions[];
+extern const OSSL_DISPATCH ossl_x448_to_SubjectPublicKeyInfo_der_encoder_functions[];
+extern const OSSL_DISPATCH ossl_x448_to_SubjectPublicKeyInfo_pem_encoder_functions[];
 extern const OSSL_DISPATCH ossl_x448_to_text_encoder_functions[];
 
-extern const OSSL_DISPATCH ossl_ed25519_to_der_encoder_functions[];
-extern const OSSL_DISPATCH ossl_ed25519_to_pem_encoder_functions[];
+extern const OSSL_DISPATCH ossl_ed25519_to_PKCS8_der_encoder_functions[];
+extern const OSSL_DISPATCH ossl_ed25519_to_PKCS8_pem_encoder_functions[];
+extern const OSSL_DISPATCH ossl_ed25519_to_SubjectPublicKeyInfo_der_encoder_functions[];
+extern const OSSL_DISPATCH ossl_ed25519_to_SubjectPublicKeyInfo_pem_encoder_functions[];
 extern const OSSL_DISPATCH ossl_ed25519_to_text_encoder_functions[];
 
-extern const OSSL_DISPATCH ossl_ed448_to_der_encoder_functions[];
-extern const OSSL_DISPATCH ossl_ed448_to_pem_encoder_functions[];
+extern const OSSL_DISPATCH ossl_ed448_to_PKCS8_der_encoder_functions[];
+extern const OSSL_DISPATCH ossl_ed448_to_PKCS8_pem_encoder_functions[];
+extern const OSSL_DISPATCH ossl_ed448_to_SubjectPublicKeyInfo_der_encoder_functions[];
+extern const OSSL_DISPATCH ossl_ed448_to_SubjectPublicKeyInfo_pem_encoder_functions[];
 extern const OSSL_DISPATCH ossl_ed448_to_text_encoder_functions[];
 
-extern const OSSL_DISPATCH ossl_ec_to_der_encoder_functions[];
-extern const OSSL_DISPATCH ossl_ec_to_pem_encoder_functions[];
+extern const OSSL_DISPATCH ossl_ec_to_RAW_der_encoder_functions[];
+extern const OSSL_DISPATCH ossl_ec_to_RAW_pem_encoder_functions[];
+extern const OSSL_DISPATCH ossl_ec_to_RAWKEY_der_encoder_functions[];
+extern const OSSL_DISPATCH ossl_ec_to_RAWKEY_pem_encoder_functions[];
+extern const OSSL_DISPATCH ossl_ec_to_PKCS8_der_encoder_functions[];
+extern const OSSL_DISPATCH ossl_ec_to_PKCS8_pem_encoder_functions[];
+extern const OSSL_DISPATCH ossl_ec_to_SubjectPublicKeyInfo_der_encoder_functions[];
+extern const OSSL_DISPATCH ossl_ec_to_SubjectPublicKeyInfo_pem_encoder_functions[];
 extern const OSSL_DISPATCH ossl_ec_to_text_encoder_functions[];
 
 /* Decoders */

--- a/providers/implementations/include/prov/implementations.h
+++ b/providers/implementations/include/prov/implementations.h
@@ -315,83 +315,89 @@ extern const OSSL_DISPATCH sm2_asym_cipher_functions[];
 extern const OSSL_DISPATCH ossl_rsa_asym_kem_functions[];
 
 /* Encoders */
-extern const OSSL_DISPATCH ossl_rsa_to_RAW_der_encoder_functions[];
-extern const OSSL_DISPATCH ossl_rsa_to_RAW_pem_encoder_functions[];
-extern const OSSL_DISPATCH ossl_rsa_to_RAWKEY_der_encoder_functions[];
-extern const OSSL_DISPATCH ossl_rsa_to_RAWKEY_pem_encoder_functions[];
+extern const OSSL_DISPATCH ossl_rsa_to_OSSL_old_der_encoder_functions[];
+extern const OSSL_DISPATCH ossl_rsa_to_PKCS1_der_encoder_functions[];
+extern const OSSL_DISPATCH ossl_rsa_to_PKCS1_pem_encoder_functions[];
 extern const OSSL_DISPATCH ossl_rsa_to_PKCS8_der_encoder_functions[];
 extern const OSSL_DISPATCH ossl_rsa_to_PKCS8_pem_encoder_functions[];
 extern const OSSL_DISPATCH ossl_rsa_to_SubjectPublicKeyInfo_der_encoder_functions[];
 extern const OSSL_DISPATCH ossl_rsa_to_SubjectPublicKeyInfo_pem_encoder_functions[];
 extern const OSSL_DISPATCH ossl_rsa_to_text_encoder_functions[];
 
-extern const OSSL_DISPATCH ossl_rsapss_to_RAW_der_encoder_functions[];
-extern const OSSL_DISPATCH ossl_rsapss_to_RAW_pem_encoder_functions[];
+extern const OSSL_DISPATCH ossl_rsapss_to_OSSL_current_der_encoder_functions[];
 extern const OSSL_DISPATCH ossl_rsapss_to_PKCS8_der_encoder_functions[];
 extern const OSSL_DISPATCH ossl_rsapss_to_PKCS8_pem_encoder_functions[];
 extern const OSSL_DISPATCH ossl_rsapss_to_SubjectPublicKeyInfo_der_encoder_functions[];
 extern const OSSL_DISPATCH ossl_rsapss_to_SubjectPublicKeyInfo_pem_encoder_functions[];
 extern const OSSL_DISPATCH ossl_rsapss_to_text_encoder_functions[];
 
-extern const OSSL_DISPATCH ossl_dh_to_RAW_der_encoder_functions[];
-extern const OSSL_DISPATCH ossl_dh_to_RAW_pem_encoder_functions[];
+extern const OSSL_DISPATCH ossl_dh_to_OSSL_current_w_params_der_encoder_functions[];
+extern const OSSL_DISPATCH ossl_dh_to_OSSL_params_pem_encoder_functions[];
+extern const OSSL_DISPATCH ossl_dh_to_PKCS3_der_encoder_functions[];
+extern const OSSL_DISPATCH ossl_dh_to_PKCS3_pem_encoder_functions[];
 extern const OSSL_DISPATCH ossl_dh_to_PKCS8_der_encoder_functions[];
 extern const OSSL_DISPATCH ossl_dh_to_PKCS8_pem_encoder_functions[];
 extern const OSSL_DISPATCH ossl_dh_to_SubjectPublicKeyInfo_der_encoder_functions[];
 extern const OSSL_DISPATCH ossl_dh_to_SubjectPublicKeyInfo_pem_encoder_functions[];
 extern const OSSL_DISPATCH ossl_dh_to_text_encoder_functions[];
 
-extern const OSSL_DISPATCH ossl_dhx_to_RAW_der_encoder_functions[];
-extern const OSSL_DISPATCH ossl_dhx_to_RAW_pem_encoder_functions[];
+extern const OSSL_DISPATCH ossl_dhx_to_OSSL_current_w_params_der_encoder_functions[];
+extern const OSSL_DISPATCH ossl_dhx_to_OSSL_params_pem_encoder_functions[];
+extern const OSSL_DISPATCH ossl_dhx_to_X9_42_der_encoder_functions[];
+extern const OSSL_DISPATCH ossl_dhx_to_X9_42_pem_encoder_functions[];
 extern const OSSL_DISPATCH ossl_dhx_to_PKCS8_der_encoder_functions[];
 extern const OSSL_DISPATCH ossl_dhx_to_PKCS8_pem_encoder_functions[];
 extern const OSSL_DISPATCH ossl_dhx_to_SubjectPublicKeyInfo_der_encoder_functions[];
 extern const OSSL_DISPATCH ossl_dhx_to_SubjectPublicKeyInfo_pem_encoder_functions[];
 extern const OSSL_DISPATCH ossl_dhx_to_text_encoder_functions[];
 
-extern const OSSL_DISPATCH ossl_dsa_to_RAW_der_encoder_functions[];
-extern const OSSL_DISPATCH ossl_dsa_to_RAW_pem_encoder_functions[];
-extern const OSSL_DISPATCH ossl_dsa_to_RAWKEY_der_encoder_functions[];
-extern const OSSL_DISPATCH ossl_dsa_to_RAWKEY_pem_encoder_functions[];
+extern const OSSL_DISPATCH ossl_dsa_to_OSSL_old_w_params_der_encoder_functions[];
+extern const OSSL_DISPATCH ossl_dsa_to_OSSL_params_pem_encoder_functions[];
 extern const OSSL_DISPATCH ossl_dsa_to_PKCS8_der_encoder_functions[];
 extern const OSSL_DISPATCH ossl_dsa_to_PKCS8_pem_encoder_functions[];
 extern const OSSL_DISPATCH ossl_dsa_to_SubjectPublicKeyInfo_der_encoder_functions[];
 extern const OSSL_DISPATCH ossl_dsa_to_SubjectPublicKeyInfo_pem_encoder_functions[];
+extern const OSSL_DISPATCH ossl_dsa_to_RAW_w_params_der_encoder_functions[];
+extern const OSSL_DISPATCH ossl_dsa_to_RAW_w_params_pem_encoder_functions[];
 extern const OSSL_DISPATCH ossl_dsa_to_text_encoder_functions[];
 
-extern const OSSL_DISPATCH ossl_x25519_to_PKCS8_der_encoder_functions[];
-extern const OSSL_DISPATCH ossl_x25519_to_PKCS8_pem_encoder_functions[];
-extern const OSSL_DISPATCH ossl_x25519_to_SubjectPublicKeyInfo_der_encoder_functions[];
-extern const OSSL_DISPATCH ossl_x25519_to_SubjectPublicKeyInfo_pem_encoder_functions[];
-extern const OSSL_DISPATCH ossl_x25519_to_text_encoder_functions[];
-
-extern const OSSL_DISPATCH ossl_x448_to_PKCS8_der_encoder_functions[];
-extern const OSSL_DISPATCH ossl_x448_to_PKCS8_pem_encoder_functions[];
-extern const OSSL_DISPATCH ossl_x448_to_SubjectPublicKeyInfo_der_encoder_functions[];
-extern const OSSL_DISPATCH ossl_x448_to_SubjectPublicKeyInfo_pem_encoder_functions[];
-extern const OSSL_DISPATCH ossl_x448_to_text_encoder_functions[];
+extern const OSSL_DISPATCH ossl_ec_to_OSSL_old_w_params_der_encoder_functions[];
+extern const OSSL_DISPATCH ossl_ec_to_OSSL_params_pem_encoder_functions[];
+extern const OSSL_DISPATCH ossl_ec_to_PKCS8_der_encoder_functions[];
+extern const OSSL_DISPATCH ossl_ec_to_PKCS8_pem_encoder_functions[];
+extern const OSSL_DISPATCH ossl_ec_to_SubjectPublicKeyInfo_der_encoder_functions[];
+extern const OSSL_DISPATCH ossl_ec_to_SubjectPublicKeyInfo_pem_encoder_functions[];
+extern const OSSL_DISPATCH ossl_ec_to_RAW_w_params_der_encoder_functions[];
+extern const OSSL_DISPATCH ossl_ec_to_RAW_w_params_pem_encoder_functions[];
+extern const OSSL_DISPATCH ossl_ec_to_text_encoder_functions[];
 
 extern const OSSL_DISPATCH ossl_ed25519_to_PKCS8_der_encoder_functions[];
 extern const OSSL_DISPATCH ossl_ed25519_to_PKCS8_pem_encoder_functions[];
 extern const OSSL_DISPATCH ossl_ed25519_to_SubjectPublicKeyInfo_der_encoder_functions[];
 extern const OSSL_DISPATCH ossl_ed25519_to_SubjectPublicKeyInfo_pem_encoder_functions[];
+extern const OSSL_DISPATCH ossl_ed25519_to_OSSL_current_der_encoder_functions[];
 extern const OSSL_DISPATCH ossl_ed25519_to_text_encoder_functions[];
 
 extern const OSSL_DISPATCH ossl_ed448_to_PKCS8_der_encoder_functions[];
 extern const OSSL_DISPATCH ossl_ed448_to_PKCS8_pem_encoder_functions[];
 extern const OSSL_DISPATCH ossl_ed448_to_SubjectPublicKeyInfo_der_encoder_functions[];
 extern const OSSL_DISPATCH ossl_ed448_to_SubjectPublicKeyInfo_pem_encoder_functions[];
+extern const OSSL_DISPATCH ossl_ed448_to_OSSL_current_der_encoder_functions[];
 extern const OSSL_DISPATCH ossl_ed448_to_text_encoder_functions[];
 
-extern const OSSL_DISPATCH ossl_ec_to_RAW_der_encoder_functions[];
-extern const OSSL_DISPATCH ossl_ec_to_RAW_pem_encoder_functions[];
-extern const OSSL_DISPATCH ossl_ec_to_RAWKEY_der_encoder_functions[];
-extern const OSSL_DISPATCH ossl_ec_to_RAWKEY_pem_encoder_functions[];
-extern const OSSL_DISPATCH ossl_ec_to_PKCS8_der_encoder_functions[];
-extern const OSSL_DISPATCH ossl_ec_to_PKCS8_pem_encoder_functions[];
-extern const OSSL_DISPATCH ossl_ec_to_SubjectPublicKeyInfo_der_encoder_functions[];
-extern const OSSL_DISPATCH ossl_ec_to_SubjectPublicKeyInfo_pem_encoder_functions[];
-extern const OSSL_DISPATCH ossl_ec_to_text_encoder_functions[];
+extern const OSSL_DISPATCH ossl_x25519_to_PKCS8_der_encoder_functions[];
+extern const OSSL_DISPATCH ossl_x25519_to_PKCS8_pem_encoder_functions[];
+extern const OSSL_DISPATCH ossl_x25519_to_SubjectPublicKeyInfo_der_encoder_functions[];
+extern const OSSL_DISPATCH ossl_x25519_to_SubjectPublicKeyInfo_pem_encoder_functions[];
+extern const OSSL_DISPATCH ossl_x25519_to_OSSL_current_der_encoder_functions[];
+extern const OSSL_DISPATCH ossl_x25519_to_text_encoder_functions[];
+
+extern const OSSL_DISPATCH ossl_x448_to_PKCS8_der_encoder_functions[];
+extern const OSSL_DISPATCH ossl_x448_to_PKCS8_pem_encoder_functions[];
+extern const OSSL_DISPATCH ossl_x448_to_SubjectPublicKeyInfo_der_encoder_functions[];
+extern const OSSL_DISPATCH ossl_x448_to_SubjectPublicKeyInfo_pem_encoder_functions[];
+extern const OSSL_DISPATCH ossl_x448_to_OSSL_current_der_encoder_functions[];
+extern const OSSL_DISPATCH ossl_x448_to_text_encoder_functions[];
 
 /* Decoders */
 extern const OSSL_DISPATCH ossl_der_to_dh_decoder_functions[];

--- a/test/endecode_test.c
+++ b/test/endecode_test.c
@@ -590,7 +590,10 @@ static int check_unprotected_legacy_PEM(const char *type,
 
 static int test_unprotected_via_legacy_PEM(const char *type, EVP_PKEY *key)
 {
-    return test_encode_decode(type, key, "structure=raw",
+    static char structure_propq[80];
+
+    return TEST_int_gt(BIO_snprintf(structure_propq, "structure=%s", type), 0)
+        && test_encode_decode(type, key, structure_propq,
                               "PEM", OSSL_KEYMGMT_SELECT_KEYPAIR
                               | OSSL_KEYMGMT_SELECT_DOMAIN_PARAMETERS,
                               NULL, NULL,
@@ -705,7 +708,10 @@ static int check_protected_legacy_PEM(const char *type,
 
 static int test_protected_via_legacy_PEM(const char *type, EVP_PKEY *key)
 {
-    return test_encode_decode(type, key, NULL,
+    static char structure_propq[80];
+
+    return TEST_int_gt(BIO_snprintf(structure_propq, "structure=%s", type), 0)
+        && test_encode_decode(type, key, structure_propq,
                               "PEM", OSSL_KEYMGMT_SELECT_KEYPAIR
                               | OSSL_KEYMGMT_SELECT_DOMAIN_PARAMETERS,
                               pass, pass_cipher,


### PR DESCRIPTION
The current encoder implementations only supported PKCS#8 output.
However, if we are to deprecate key type specific i2d_ and PEM_write_
functions in favor of using OSSL_ENCODER, the users need an easy
enough migration path to do what they've done so far.

The encoders are now enhanced to cover most of those cases, and are
classified like this (visible in the OSSL_DISPATCH array names):

-   RAW: this corresponds to what the type specific i2d_TYPEPrivateKey(),
    i2d_TYPEPublicKey(), PEM_write_bio_TYPEPrivateKey() and
    PEM_write_bio_TYPEPublicKey() produce.
-   RAWKEY: this corresponds to what the function old_priv_encode() in
    EVP_PKEY_ASN1_METHOD produces, and thus the "old" / "traditional"
    output of i2d_PrivateKey() and PEM_write_bio_PrivateKey_traditional().
-   PKCS8: this corresponds to what the function priv_encode() in
    EVP_PKEY_ASN1_METHOD produces, and thus the fallback (when there's
    no old_priv_encode() defined) output of i2d_PrivateKey(), as well
    as the output of PEM_write_bio_PrivateKey().
-   SubjectPublicKeyInfo: this corresponds to the what the function
    pub_encode() in EVP_PKEY_ASN1_METHOD produces, and thus the output
    of i2d_PUBKEY() and PEM_write_bio_PUBKEY().

In the OSSL_ALGORITHM tables, these diverse OSSL_DISPATCH arrays can
be re-used with different "structure={name}" properties for maximum
expressiveness if that's desirable.  There is an example where the
OSSL_DISPATCH arrays ossl_rsa_to_RAW_der_encoder_functions[] and
ossl_rsa_to_RAW_pem_encoder_functions[] are used twice, once with the
property "structure=raw" and once with the property "structure=pkcs1".

For our internal uses, "structure=raw", "structure=rawkey",
"structure=pkcs8" and "structure=SubjectPublicKeyInfo" will be used
uniformly.  That allows us to map deprecated functionality to the
corresponding OSSL_ENCODER calls without having to have special
knowledge of the more standardised structure names for each key type
in libcrypto.  Additional structure names are only added for the
convenience of the users that may wish to use OSSL_ENCODER directly
and use structure names that suit them better.