### PR TITLE
INSTALL.md: Drop trailing spaces on a line

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1470,7 +1470,7 @@ described here.  Examine the Makefiles themselves for the full list.
 
     install_html_docs
                    Only install the OpenSSL HTML documentation.
-                   
+
     install_fips
                    Install the FIPS provider module configuration file.
 


### PR DESCRIPTION
Trivial and urgent because it breaks build.
