### PR TITLE
Fix missing include of string.h in apps/lib/engine.c for strcmp.

### DIFF
--- a/apps/lib/engine.c
+++ b/apps/lib/engine.c
@@ -14,6 +14,8 @@
  */
 #define OPENSSL_SUPPRESS_DEPRECATED
 
+#include <string.h> /* strcmp */
+
 #include <openssl/types.h> /* Ensure we have the ENGINE type, regardless */
 #ifndef OPENSSL_NO_ENGINE
 # include <openssl/engine.h>


### PR DESCRIPTION
This include is required for c99 on the NonStop TNS/X platform.

CLA: trivial

Fixes #13102

Signed-off-by: Randall S. Becker <rsbecker@nexbridge.com>