### PR TITLE
Make minimal config in {.travis,ci,appveyor}.yml consistent and add no-deprecated no-ec no-ktls no-siv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: config
-      run: ./config --strict-warnings no-shared no-dso no-pic no-aria no-async no-autoload-config no-blake2 no-bf no-camellia no-cast no-chacha no-cmac no-cms no-comp no-ct no-des no-dgram no-dh no-dsa no-dtls no-ec2m no-engine no-filenames no-gost no-idea no-mdc2 no-md4 no-multiblock no-nextprotoneg no-ocsp no-ocb no-poly1305 no-psk no-rc2 no-rc4 no-rmd160 no-seed no-siphash no-sm2 no-sm3 no-sm4 no-srp no-srtp no-ssl3 no-ssl3-method no-ts no-ui-console no-whirlpool no-asm -DOPENSSL_NO_SECURE_MEMORY -DOPENSSL_SMALL_FOOTPRINT && perl configdata.pm --dump
+      run: ./config --strict-warnings no-bulk no-pic no-asm -DOPENSSL_NO_SECURE_MEMORY -DOPENSSL_SMALL_FOOTPRINT && perl configdata.pm --dump
     - name: make
       run: make -s -j4
     - name: make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -137,8 +137,7 @@ jobs:
           script: true
         - os: linux
           compiler: gcc
-          env: CONFIGURE_TARGET="linux-generic32" MARKDOWNLINT="yes" CONFIG_OPTS="--strict-warnings no-shared no-dso no-pic no-aria no-async no-autoload-config no-blake2 no-bf no-camellia no-cast no-chacha no-cmac no-cms no-cmp no-comp no-ct no-des no-dgram no-dh no-dsa no-dtls no-ec2m no-engine no-filenames no-gost no-idea no-ktls no-mdc2 no-md4 no-multiblock no-nextprotoneg no-ocsp no-ocb no-poly1305 no-psk no-rc2 no-rc4 no-rmd160 no-seed no-siphash no-siv no-sm2 no-sm3 no-sm4 no-srp no-srtp no-ssl3 no-ssl3-method no-ts no-ui-console no-whirlpool no-fips-securitychecks no-asm -DOPENSSL_NO_SECURE_MEMORY -DOPENSSL_SMALL_FOOTPRINT"
-
+          env: CONFIGURE_TARGET="linux-generic32" MARKDOWNLINT="yes" CONFIG_OPTS="no-bulk no-pic no-asm -DOPENSSL_SMALL_FOOTPRINT --strict-warnings no-pic -DOPENSSL_NO_SECURE_MEMORY"
 
 before_script:
     - env

--- a/Configure
+++ b/Configure
@@ -391,6 +391,7 @@ my @disablables = (
     "bf",
     "blake2",
     "buildtest-c++",
+    "bulk",
     "camellia",
     "capieng",
     "cast",
@@ -539,13 +540,29 @@ our %disabled = ( # "what"         => "comment"
 # Note: => pair form used for aesthetics, not to truly make a hash table
 my @disable_cascades = (
     # "what"            => [ "cascade", ... ]
+    "bulk"              => [ "deprecated", "shared", "dso",
+                             "aria", "async", "autoload-config",
+                             "blake2", "bf", "camellia", "cast", "chacha",
+                             "cmac", "cms", "cmp", "comp", "ct",
+                             "des", "dgram", "dh", "dsa",
+                             "ec", "engine",
+                             "filenames",
+                             "idea", "ktls",
+                             "md4", "multiblock", "nextprotoneg",
+                             "ocsp", "ocb", "poly1305", "psk",
+                             "rc2", "rc4", "rmd160",
+                             "seed", "siphash", "siv",
+                             "sm3", "sm4", "srp",
+                             "srtp", "ssl3-method",
+                             "ts", "ui-console", "whirlpool",
+                             "fips-securitychecks" ],
     sub { $config{processor} eq "386" }
                         => [ "sse2" ],
     "ssl"               => [ "ssl3" ],
     "ssl3-method"       => [ "ssl3" ],
     "zlib"              => [ "zlib-dynamic" ],
     "des"               => [ "mdc2" ],
-    "ec"                => [ "ecdsa", "ecdh", "sm2", "gost" ],
+    "ec"                => [ "ec2m", "ecdsa", "ecdh", "sm2", "gost" ],
     sub { $disabled{"ec"} && $disabled{"dh"} }
                         => [ "tls1_3" ],
     "dgram"             => [ "dtls", "sctp" ],

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -577,6 +577,11 @@ as configuration option, you must ensure that it's valid for both the C and
 the C++ compiler.  If not, the C++ build test will most likely break.  As an
 alternative, you can use the language specific variables, `CFLAGS` and `CXXFLAGS`.
 
+### no-bulk
+
+Build only some minimal set of features.
+This is a developer option used internally for CI build tests of the project.
+
 ### no-capieng
 
 Don't build the CAPI engine.

--- a/apps/speed.c
+++ b/apps/speed.c
@@ -1516,7 +1516,7 @@ int speed_main(int argc, char **argv)
 #if (!defined(OPENSSL_NO_RSA) && !defined(OPENSSL_NO_DEPRECATED_3_0)) \
     || (!defined(OPENSSL_NO_DSA) && !defined(OPENSSL_NO_DEPRECATED_3_0)) \
     || !defined(OPENSSL_NO_EC) || !defined(OPENSSL_NO_DH)
-     long rsa_count = 1;
+     long op_count = 1;
 #endif
     openssl_speed_sec_t seconds = { SECONDS, RSA_SECONDS, DSA_SECONDS,
                                     ECDSA_SECONDS, ECDH_SECONDS,
@@ -3025,7 +3025,7 @@ int speed_main(int argc, char **argv)
             BIO_printf(bio_err,
                        "RSA sign failure.  No RSA sign will be done.\n");
             ERR_print_errors(bio_err);
-            rsa_count = 1;
+            op_count = 1;
         } else {
             pkey_print_message("private", "rsa",
                                rsa_c[testnum][0], rsa_keys[testnum].bits,
@@ -3039,7 +3039,7 @@ int speed_main(int argc, char **argv)
                        : "%ld %u bits private RSA's in %.2fs\n",
                        count, rsa_keys[testnum].bits, d);
             rsa_results[testnum][0] = (double)count / d;
-            rsa_count = count;
+            op_count = count;
         }
 
         for (i = 0; i < loopargs_len; i++) {
@@ -3067,7 +3067,7 @@ int speed_main(int argc, char **argv)
             rsa_results[testnum][1] = (double)count / d;
         }
 
-        if (rsa_count <= 1) {
+        if (op_count <= 1) {
             /* if longer than 10s, don't do any more */
             stop_it(rsa_doit, testnum);
         }
@@ -3096,7 +3096,7 @@ int speed_main(int argc, char **argv)
             BIO_printf(bio_err,
                        "DSA sign failure.  No DSA sign will be done.\n");
             ERR_print_errors(bio_err);
-            rsa_count = 1;
+            op_count = 1;
         } else {
             pkey_print_message("sign", "dsa",
                                dsa_c[testnum][0], dsa_bits[testnum],
@@ -3109,7 +3109,7 @@ int speed_main(int argc, char **argv)
                        : "%ld %u bits DSA signs in %.2fs\n",
                        count, dsa_bits[testnum], d);
             dsa_results[testnum][0] = (double)count / d;
-            rsa_count = count;
+            op_count = count;
         }
 
         for (i = 0; i < loopargs_len; i++) {
@@ -3137,7 +3137,7 @@ int speed_main(int argc, char **argv)
             dsa_results[testnum][1] = (double)count / d;
         }
 
-        if (rsa_count <= 1) {
+        if (op_count <= 1) {
             /* if longer than 10s, don't do any more */
             stop_it(dsa_doit, testnum);
         }
@@ -3162,7 +3162,7 @@ int speed_main(int argc, char **argv)
         if (st == 0) {
             BIO_printf(bio_err, "ECDSA failure.\n");
             ERR_print_errors(bio_err);
-            rsa_count = 1;
+            op_count = 1;
         } else {
             for (i = 0; i < loopargs_len; i++) {
                 /* Perform ECDSA signature test */
@@ -3177,7 +3177,7 @@ int speed_main(int argc, char **argv)
                 BIO_printf(bio_err,
                            "ECDSA sign failure.  No ECDSA sign will be done.\n");
                 ERR_print_errors(bio_err);
-                rsa_count = 1;
+                op_count = 1;
             } else {
                 pkey_print_message("sign", "ecdsa",
                                    ecdsa_c[testnum][0],
@@ -3191,7 +3191,7 @@ int speed_main(int argc, char **argv)
                            "%ld %u bits ECDSA signs in %.2fs \n",
                            count, ec_curves[testnum].bits, d);
                 ecdsa_results[testnum][0] = (double)count / d;
-                rsa_count = count;
+                op_count = count;
             }
 
             /* Perform ECDSA verification test */
@@ -3221,7 +3221,7 @@ int speed_main(int argc, char **argv)
                 ecdsa_results[testnum][1] = (double)count / d;
             }
 
-            if (rsa_count <= 1) {
+            if (op_count <= 1) {
                 /* if longer than 10s, don't do any more */
                 stop_it(ecdsa_doit, testnum);
             }
@@ -3276,7 +3276,7 @@ int speed_main(int argc, char **argv)
                     BIO_printf(bio_err,
                                "Unhandled error in the error queue during ECDH init.\n");
                     ERR_print_errors(bio_err);
-                    rsa_count = 1;
+                    op_count = 1;
                     break;
                 }
 
@@ -3293,7 +3293,7 @@ int speed_main(int argc, char **argv)
                     ecdh_checks = 0;
                     BIO_printf(bio_err, "ECDH EC params init failure.\n");
                     ERR_print_errors(bio_err);
-                    rsa_count = 1;
+                    op_count = 1;
                     break;
                 }
                 /* Create the context for the key generation */
@@ -3309,7 +3309,7 @@ int speed_main(int argc, char **argv)
                 ecdh_checks = 0;
                 BIO_printf(bio_err, "ECDH keygen failure.\n");
                 ERR_print_errors(bio_err);
-                rsa_count = 1;
+                op_count = 1;
                 break;
             }
 
@@ -3324,7 +3324,7 @@ int speed_main(int argc, char **argv)
                 ecdh_checks = 0;
                 BIO_printf(bio_err, "ECDH key generation failure.\n");
                 ERR_print_errors(bio_err);
-                rsa_count = 1;
+                op_count = 1;
                 break;
             }
 
@@ -3342,7 +3342,7 @@ int speed_main(int argc, char **argv)
                 ecdh_checks = 0;
                 BIO_printf(bio_err, "ECDH computation failure.\n");
                 ERR_print_errors(bio_err);
-                rsa_count = 1;
+                op_count = 1;
                 break;
             }
 
@@ -3352,7 +3352,7 @@ int speed_main(int argc, char **argv)
                 ecdh_checks = 0;
                 BIO_printf(bio_err, "ECDH computations don't match.\n");
                 ERR_print_errors(bio_err);
-                rsa_count = 1;
+                op_count = 1;
                 break;
             }
 
@@ -3379,10 +3379,10 @@ int speed_main(int argc, char **argv)
                        "%ld %u-bits ECDH ops in %.2fs\n", count,
                        ec_curves[testnum].bits, d);
             ecdh_results[testnum][0] = (double)count / d;
-            rsa_count = count;
+            op_count = count;
         }
 
-        if (rsa_count <= 1) {
+        if (op_count <= 1) {
             /* if longer than 10s, don't do any more */
             stop_it(ecdh_doit, testnum);
         }
@@ -3436,7 +3436,7 @@ int speed_main(int argc, char **argv)
         if (st == 0) {
             BIO_printf(bio_err, "EdDSA failure.\n");
             ERR_print_errors(bio_err);
-            rsa_count = 1;
+            op_count = 1;
         } else {
             for (i = 0; i < loopargs_len; i++) {
                 /* Perform EdDSA signature test */
@@ -3451,7 +3451,7 @@ int speed_main(int argc, char **argv)
                 BIO_printf(bio_err,
                            "EdDSA sign failure.  No EdDSA sign will be done.\n");
                 ERR_print_errors(bio_err);
-                rsa_count = 1;
+                op_count = 1;
             } else {
                 pkey_print_message("sign", ed_curves[testnum].name,
                                    eddsa_c[testnum][0],
@@ -3466,7 +3466,7 @@ int speed_main(int argc, char **argv)
                            count, ed_curves[testnum].bits,
                            ed_curves[testnum].name, d);
                 eddsa_results[testnum][0] = (double)count / d;
-                rsa_count = count;
+                op_count = count;
             }
             /* Perform EdDSA verification test */
             for (i = 0; i < loopargs_len; i++) {
@@ -3496,7 +3496,7 @@ int speed_main(int argc, char **argv)
                 eddsa_results[testnum][1] = (double)count / d;
             }
 
-            if (rsa_count <= 1) {
+            if (op_count <= 1) {
                 /* if longer than 10s, don't do any more */
                 stop_it(eddsa_doit, testnum);
             }
@@ -3568,7 +3568,7 @@ int speed_main(int argc, char **argv)
         if (st == 0) {
             BIO_printf(bio_err, "SM2 init failure.\n");
             ERR_print_errors(bio_err);
-            rsa_count = 1;
+            op_count = 1;
         } else {
             for (i = 0; i < loopargs_len; i++) {
                 size_t sm2_sigsize = loopargs[i].sigsize;
@@ -3584,7 +3584,7 @@ int speed_main(int argc, char **argv)
                 BIO_printf(bio_err,
                            "SM2 sign failure.  No SM2 sign will be done.\n");
                 ERR_print_errors(bio_err);
-                rsa_count = 1;
+                op_count = 1;
             } else {
                 pkey_print_message("sign", sm2_curves[testnum].name,
                                    sm2_c[testnum][0],
@@ -3599,7 +3599,7 @@ int speed_main(int argc, char **argv)
                            count, sm2_curves[testnum].bits,
                            sm2_curves[testnum].name, d);
                 sm2_results[testnum][0] = (double)count / d;
-                rsa_count = count;
+                op_count = count;
             }
 
             /* Perform SM2 verification test */
@@ -3630,7 +3630,7 @@ int speed_main(int argc, char **argv)
                 sm2_results[testnum][1] = (double)count / d;
             }
 
-            if (rsa_count <= 1) {
+            if (op_count <= 1) {
                 /* if longer than 10s, don't do any more */
                 for (testnum++; testnum < SM2_NUM; testnum++)
                     sm2_doit[testnum] = 0;
@@ -3666,7 +3666,7 @@ int speed_main(int argc, char **argv)
             if (!pkey_A) {
                 BIO_printf(bio_err, "Error while initialising EVP_PKEY (out of memory?).\n");
                 ERR_print_errors(bio_err);
-                rsa_count = 1;
+                op_count = 1;
                 ffdh_checks = 0;
                 break;
             }
@@ -3674,7 +3674,7 @@ int speed_main(int argc, char **argv)
             if (!pkey_B) {
                 BIO_printf(bio_err, "Error while initialising EVP_PKEY (out of memory?).\n");
                 ERR_print_errors(bio_err);
-                rsa_count = 1;
+                op_count = 1;
                 ffdh_checks = 0;
                 break;
             }
@@ -3683,7 +3683,7 @@ int speed_main(int argc, char **argv)
             if (!ffdh_ctx) {
                 BIO_printf(bio_err, "Error while allocating EVP_PKEY_CTX.\n");
                 ERR_print_errors(bio_err);
-                rsa_count = 1;
+                op_count = 1;
                 ffdh_checks = 0;
                 break;
             }
@@ -3691,14 +3691,14 @@ int speed_main(int argc, char **argv)
             if (EVP_PKEY_keygen_init(ffdh_ctx) <= 0) {
                 BIO_printf(bio_err, "Error while initialising EVP_PKEY_CTX.\n");
                 ERR_print_errors(bio_err);
-                rsa_count = 1;
+                op_count = 1;
                 ffdh_checks = 0;
                 break;
             }
             if (EVP_PKEY_CTX_set_dh_nid(ffdh_ctx, ffdh_params[testnum].nid) <= 0) {
                 BIO_printf(bio_err, "Error setting DH key size for keygen.\n");
                 ERR_print_errors(bio_err);
-                rsa_count = 1;
+                op_count = 1;
                 ffdh_checks = 0;
                 break;
             }
@@ -3707,7 +3707,7 @@ int speed_main(int argc, char **argv)
                 EVP_PKEY_keygen(ffdh_ctx, &pkey_B) <= 0) {
                 BIO_printf(bio_err, "FFDH key generation failure.\n");
                 ERR_print_errors(bio_err);
-                rsa_count = 1;
+                op_count = 1;
                 ffdh_checks = 0;
                 break;
             }
@@ -3721,34 +3721,34 @@ int speed_main(int argc, char **argv)
             if (!ffdh_ctx) {
                 BIO_printf(bio_err, "Error while allocating EVP_PKEY_CTX.\n");
                 ERR_print_errors(bio_err);
-                rsa_count = 1;
+                op_count = 1;
                 ffdh_checks = 0;
                 break;
             }
             if (EVP_PKEY_derive_init(ffdh_ctx) <= 0) {
                 BIO_printf(bio_err, "FFDH derivation context init failure.\n");
                 ERR_print_errors(bio_err);
-                rsa_count = 1;
+                op_count = 1;
                 ffdh_checks = 0;
                 break;
             }
             if (EVP_PKEY_derive_set_peer(ffdh_ctx, pkey_B) <= 0) {
                 BIO_printf(bio_err, "Assigning peer key for derivation failed.\n");
                 ERR_print_errors(bio_err);
-                rsa_count = 1;
+                op_count = 1;
                 ffdh_checks = 0;
                 break;
             }
             if (EVP_PKEY_derive(ffdh_ctx, NULL, &secret_size) <= 0) {
                 BIO_printf(bio_err, "Checking size of shared secret failed.\n");
                 ERR_print_errors(bio_err);
-                rsa_count = 1;
+                op_count = 1;
                 ffdh_checks = 0;
                 break;
             }
             if (secret_size > MAX_FFDH_SIZE) {
                 BIO_printf(bio_err, "Assertion failure: shared secret too large.\n");
-                rsa_count = 1;
+                op_count = 1;
                 ffdh_checks = 0;
                 break;
             }
@@ -3757,7 +3757,7 @@ int speed_main(int argc, char **argv)
                                 &secret_size) <= 0) {
                 BIO_printf(bio_err, "Shared secret derive failure.\n");
                 ERR_print_errors(bio_err);
-                rsa_count = 1;
+                op_count = 1;
                 ffdh_checks = 0;
                 break;
             }
@@ -3766,7 +3766,7 @@ int speed_main(int argc, char **argv)
             if (!test_ctx) {
                 BIO_printf(bio_err, "Error while allocating EVP_PKEY_CTX.\n");
                 ERR_print_errors(bio_err);
-                rsa_count = 1;
+                op_count = 1;
                 ffdh_checks = 0;
                 break;
             }
@@ -3776,7 +3776,7 @@ int speed_main(int argc, char **argv)
                 !EVP_PKEY_derive(test_ctx, loopargs[i].secret_ff_b, &test_out) ||
                 test_out != secret_size) {
                 BIO_printf(bio_err, "FFDH computation failure.\n");
-                rsa_count = 1;
+                op_count = 1;
                 ffdh_checks = 0;
                 break;
             }
@@ -3786,7 +3786,7 @@ int speed_main(int argc, char **argv)
                               loopargs[i].secret_ff_b, secret_size)) {
                 BIO_printf(bio_err, "FFDH computations don't match.\n");
                 ERR_print_errors(bio_err);
-                rsa_count = 1;
+                op_count = 1;
                 ffdh_checks = 0;
                 break;
             }
@@ -3812,9 +3812,9 @@ int speed_main(int argc, char **argv)
                        "%ld %u-bits FFDH ops in %.2fs\n", count,
                        ffdh_params[testnum].bits, d);
             ffdh_results[testnum][0] = (double)count / d;
-            rsa_count = count;
+            op_count = count;
         };
-        if (rsa_count <= 1) {
+        if (op_count <= 1) {
             /* if longer than 10s, don't do any more */
             stop_it(ffdh_doit, testnum);
         }

--- a/apps/speed.c
+++ b/apps/speed.c
@@ -155,8 +155,12 @@ static int usertime = 1;
 
 static double Time_F(int s);
 static void print_message(const char *s, long num, int length, int tm);
+#if (!defined(OPENSSL_NO_RSA) && !defined(OPENSSL_NO_DEPRECATED_3_0)) \
+    || (!defined(OPENSSL_NO_DSA) && !defined(OPENSSL_NO_DEPRECATED_3_0)) \
+    || !defined(OPENSSL_NO_EC) || !defined(OPENSSL_NO_DH)
 static void pkey_print_message(const char *str, const char *str2,
                                long num, unsigned int bits, int sec);
+#endif
 static void print_result(int alg, int run_no, int count, double time_used);
 #ifndef NO_FORK
 static int do_multi(int multi, int size_num);
@@ -1509,9 +1513,10 @@ int speed_main(int argc, char **argv)
 #ifndef NO_FORK
     int multi = 0;
 #endif
-#if !defined(OPENSSL_NO_RSA) || !defined(OPENSSL_NO_DSA) \
-    || !defined(OPENSSL_NO_EC)
-    long rsa_count = 1;
+#if (!defined(OPENSSL_NO_RSA) && !defined(OPENSSL_NO_DEPRECATED_3_0)) \
+    || (!defined(OPENSSL_NO_DSA) && !defined(OPENSSL_NO_DEPRECATED_3_0)) \
+    || !defined(OPENSSL_NO_EC) || !defined(OPENSSL_NO_DH)
+     long rsa_count = 1;
 #endif
     openssl_speed_sec_t seconds = { SECONDS, RSA_SECONDS, DSA_SECONDS,
                                     ECDSA_SECONDS, ECDH_SECONDS,
@@ -3222,7 +3227,7 @@ int speed_main(int argc, char **argv)
             }
         }
     }
-# endif
+# endif /* OPENSSL_NO_DEPRECATED_3_0 */
 
     for (testnum = 0; testnum < EC_NUM; testnum++) {
         int ecdh_checks = 1;
@@ -4103,23 +4108,27 @@ static void print_message(const char *s, long num, int length, int tm)
 #endif
 }
 
+#if (!defined(OPENSSL_NO_RSA) && !defined(OPENSSL_NO_DEPRECATED_3_0)) \
+    || (!defined(OPENSSL_NO_DSA) && !defined(OPENSSL_NO_DEPRECATED_3_0)) \
+    || !defined(OPENSSL_NO_EC) || !defined(OPENSSL_NO_DH)
 static void pkey_print_message(const char *str, const char *str2, long num,
                                unsigned int bits, int tm)
 {
-#ifdef SIGALRM
+# ifdef SIGALRM
     BIO_printf(bio_err,
                mr ? "+DTP:%d:%s:%s:%d\n"
                : "Doing %u bits %s %s's for %ds: ", bits, str, str2, tm);
     (void)BIO_flush(bio_err);
     run = 1;
     alarm(tm);
-#else
+# else
     BIO_printf(bio_err,
                mr ? "+DNP:%ld:%d:%s:%s\n"
                : "Doing %ld %u bits %s %s's: ", num, bits, str, str2);
     (void)BIO_flush(bio_err);
-#endif
+# endif
 }
+#endif
 
 static void print_result(int alg, int run_no, int count, double time_used)
 {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,16 +30,16 @@ before_build:
         }
     - ps: >-
         If ($env:Configuration -Match "shared") {
-            $env:SHARED="no-makedepend"
+            $env:CONFIG_OPTS=""
         } ElseIf ($env:Configuration -Match "minimal") {
-            $env:SHARED="no-shared no-dso no-makedepend no-aria no-async no-autoload-config no-blake2 no-bf no-camellia no-cast no-chacha no-cmac no-cms no-cmp no-comp no-ct no-des no-dgram no-dh no-dsa no-ec no-ec2m no-engine no-filenames no-idea no-ktls no-md4 no-multiblock no-nextprotoneg no-ocsp no-ocb no-poly1305 no-psk no-rc2 no-rc4 no-rmd160 no-seed no-siphash no-siv no-sm3 no-sm4 no-srp no-srtp no-ssl3-method no-ts no-ui-console no-whirlpool no-asm -DOPENSSL_SMALL_FOOTPRINT"
+            $env:CONFIG_OPTS="no-bulk no-asm -DOPENSSL_SMALL_FOOTPRINT"
         } Else {
-            $env:SHARED="no-shared no-makedepend"
+            $env:CONFIG_OPTS="no-shared"
         }
     - call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" %VCVARS_PLATFORM%
     - mkdir _build
     - cd _build
-    - perl ..\Configure %TARGET% %SHARED%
+    - perl ..\Configure %TARGET% no-makedepend %CONFIG_OPTS%
     - perl configdata.pm --dump
     - cd ..
     - ps: >-

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,8 +21,6 @@ before_build:
     - ps: >-
         Get-VSSetupInstance -All
     - ps: >-
-        gci env:* | sort-object name
-    - ps: >-
         If ($env:Platform -Match "x86") {
             $env:VCVARS_PLATFORM="x86"
             $env:TARGET="VC-WIN32 no-asm --strict-warnings"
@@ -45,7 +43,7 @@ before_build:
     - perl configdata.pm --dump
     - cd ..
     - ps: >-
-        if (-not $env:APPVEYOR_PULL_REQUEST_NUMBER`
+        If (-not $env:APPVEYOR_PULL_REQUEST_NUMBER`
             -or (&git log -1 $env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT |
                  Select-String "\[extended tests\]") ) {
             $env:EXTENDED_TESTS="yes"
@@ -56,6 +54,8 @@ before_build:
         } Else {
             $env:NMAKE="nmake /S"
         }
+    - ps: >-
+        gci env:* | sort-object name
 
 build_script:
     - cd _build

--- a/fuzz/server.c
+++ b/fuzz/server.c
@@ -521,7 +521,10 @@ int FuzzerTestOneInput(const uint8_t *buf, size_t len)
     RSA *privkey;
 #endif
     const uint8_t *bufp;
+#if !defined(OPENSSL_NO_DSA) || !defined(OPENSSL_NO_EC) \
+    || !defined(OPENSSL_NO_DEPRECATED_3_0)
     EVP_PKEY *pkey;
+#endif
     X509 *cert;
 #ifndef OPENSSL_NO_EC
     EC_KEY *ecdsakey = NULL;

--- a/providers/implementations/encode_decode/encode_key2any.c
+++ b/providers/implementations/encode_decode/encode_key2any.c
@@ -330,6 +330,8 @@ static int key_to_type_specific_pem_pub_bio(BIO *out, const void *key,
                                            p2s, k2d, ctx, NULL, NULL);
 }
 
+#if !defined(OPENSSL_NO_DH) || !defined(OPENSSL_NO_DSA) \
+    || !defined(OPENSSL_NO_EC)
 static int key_to_type_specific_pem_param_bio(BIO *out, const void *key,
                                               int key_nid, const char *pemname,
                                               key_to_paramstring_fn *p2s,
@@ -339,6 +341,7 @@ static int key_to_type_specific_pem_param_bio(BIO *out, const void *key,
     return key_to_type_specific_pem_bio_cb(out, key, key_nid, pemname,
                                            p2s, k2d, ctx, NULL, NULL);
 }
+#endif
 
 #define der_output_type         "DER"
 #define pem_output_type         "PEM"

--- a/providers/implementations/encode_decode/encode_key2text.c
+++ b/providers/implementations/encode_decode/encode_key2text.c
@@ -126,6 +126,7 @@ err:
 /* Number of octets per line */
 #define LABELED_BUF_PRINT_WIDTH    15
 
+#if !defined(OPENSSL_NO_DH) || !defined(OPENSSL_NO_DSA) || !defined(OPENSSL_NO_EC)
 static int print_labeled_buf(BIO *out, const char *label,
                              const unsigned char *buf, size_t buflen)
 {
@@ -151,6 +152,7 @@ static int print_labeled_buf(BIO *out, const char *label,
 
     return 1;
 }
+#endif
 
 #if !defined(OPENSSL_NO_DH) || !defined(OPENSSL_NO_DSA)
 static int ffc_params_to_text(BIO *out, const FFC_PARAMS *ffc)

--- a/test/endecode_test.c
+++ b/test/endecode_test.c
@@ -40,12 +40,14 @@ static OSSL_PARAM *ec_explicit_tri_params_explicit = NULL;
 # endif
 #endif
 
+#if !defined(OPENSSL_NO_DH) || !defined(OPENSSL_NO_DSA) \
+    || !defined(OPENSSL_NO_EC)
 static EVP_PKEY *make_template(const char *type, OSSL_PARAM *genparams)
 {
     EVP_PKEY *pkey = NULL;
     EVP_PKEY_CTX *ctx = NULL;
 
-#ifndef OPENSSL_NO_DH
+# ifndef OPENSSL_NO_DH
     /*
      * Use 512-bit DH(X) keys with predetermined parameters for efficiency,
      * for testing only. Use a minimum key size of 2048 for security purposes.
@@ -54,7 +56,7 @@ static EVP_PKEY *make_template(const char *type, OSSL_PARAM *genparams)
         return get_dh512(NULL);
     if (strcmp(type, "X9.42 DH") == 0)
         return get_dhx512(NULL);
-#endif
+# endif
 
     /*
      * No real need to check the errors other than for the cascade
@@ -69,6 +71,7 @@ static EVP_PKEY *make_template(const char *type, OSSL_PARAM *genparams)
 
     return pkey;
 }
+#endif
 
 static EVP_PKEY *make_key(const char *type, EVP_PKEY *template,
                           OSSL_PARAM *genparams)
@@ -514,6 +517,8 @@ static int test_unprotected_via_PEM(const char *type, EVP_PKEY *key)
                               dump_pem, 0);
 }
 
+#if !defined(OPENSSL_NO_DH) || !defined(OPENSSL_NO_DSA) \
+    || !defined(OPENSSL_NO_EC)
 static int check_params_DER(const char *type, const void *data, size_t data_len)
 {
     const unsigned char *datap = data;
@@ -568,6 +573,7 @@ static int test_params_via_PEM(const char *type, EVP_PKEY *key)
                               test_text, check_params_PEM,
                               dump_pem, 0);
 }
+#endif /* ndef(OPENSSL_NO_DH) || ndef(OPENSSL_NO_DSA) || ndef(OPENSSL_NO_EC) */
 
 static int check_unprotected_legacy_PEM(const char *type,
                                         const void *data, size_t data_len)

--- a/test/evp_pkey_dparams_test.c
+++ b/test/evp_pkey_dparams_test.c
@@ -89,6 +89,7 @@ static const unsigned char ecparam_bin[] = {
 };
 #endif
 
+#if !defined(OPENSSL_NO_DH) || !defined(OPENSSL_NO_DSA) || !defined(OPENSSL_NO_EC)
 static const struct {
     int type;
     const unsigned char *param_bin;
@@ -105,7 +106,6 @@ static const struct {
 #endif
 };
 
-#if !defined(OPENSSL_NO_DH) || !defined(OPENSSL_NO_DSA) || !defined(OPENSSL_NO_EC)
 static int params_bio_test(int id)
 {
     int ret, out_len;


### PR DESCRIPTION
* Introduce an environment variable `MINIMAL_CONFIG` that can easily be kept in sync between `.travis.yml` and `appveyor.yml`
* Make the exclusions in `.travis.yml` consistent with improvements to  `appveyor.yml`  done in commit e6a2596cdcb0137e268517f4ce01254b3cba8017
 (adding `no-ec` and pruning cascaded (`no-*`)
* Add `no-deprecated` and `no-legacy` (in both minimal configurations, of course)
* ~appveyor.yml: Add `MAKEVERBOSE` option, defaulting to 'no'~ - superseded by #13580
* ~appveyor.yml: Add a warning when build and test are skipped due to `no-shared` and `[extended tests]` not being present.
    Also move printing of env variables such that locally defined ones are shown as well.~ - superseded by #13537
* Correct various bugs that make `no-legcay` `no-deprecated` builds fail.