### PR TITLE
Pass an EVP_PKEY for SSL_SECOP_TMP_DH in the security callback (1.1.1)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,7 +9,15 @@
 
  Changes between 1.1.1h and 1.1.1i [xx XXX xxxx]
 
-  *)
+  *) The security callback, which can be customised by application code, supports
+     the security operation SSL_SECOP_TMP_DH. This is defined to take an EVP_PKEY
+     in the "other" parameter. In most places this is what is passed. All these
+     places occur server side. However there was one client side call of this
+     security operation and it passed a DH object instead. This is incorrect
+     according to the definition of SSL_SECOP_TMP_DH, and is inconsistent with all
+     of the other locations. Therefore this client side call has been changed to
+     pass an EVP_PKEY instead.
+     [Matt Caswell]
 
  Changes between 1.1.1g and 1.1.1h [22 Sep 2020]
 

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -2145,15 +2145,16 @@ static int tls_process_ske_dhe(SSL *s, PACKET *pkt, EVP_PKEY **pkey)
     }
     bnpub_key = NULL;
 
-    if (!ssl_security(s, SSL_SECOP_TMP_DH, DH_security_bits(dh), 0, dh)) {
-        SSLfatal(s, SSL_AD_HANDSHAKE_FAILURE, SSL_F_TLS_PROCESS_SKE_DHE,
-                 SSL_R_DH_KEY_TOO_SMALL);
-        goto err;
-    }
-
     if (EVP_PKEY_assign_DH(peer_tmp, dh) == 0) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS_PROCESS_SKE_DHE,
                  ERR_R_EVP_LIB);
+        goto err;
+    }
+
+    if (!ssl_security(s, SSL_SECOP_TMP_DH, EVP_PKEY_security_bits(peer_tmp),
+                      0, peer_tmp)) {
+        SSLfatal(s, SSL_AD_HANDSHAKE_FAILURE, SSL_F_TLS_PROCESS_SKE_DHE,
+                 SSL_R_DH_KEY_TOO_SMALL);
         goto err;
     }
 


### PR DESCRIPTION
The security operation SSL_SECOP_TMP_DH is defined to take an EVP_PKEY
in the "other" parameter:

````
 /* Temporary DH key */
 # define SSL_SECOP_TMP_DH                (7 | SSL_SECOP_OTHER_PKEY)
````

In most places this is what is passed. All these places occur server side.
However there is one client side call of this security operation and it
passes a DH object instead. This is incorrect according to the
definition of SSL_SECOP_TMP_DH, and is inconsistent with all of the other
locations.

Our own default security callback, and the debug callback in the apps,
never look at this value and therefore this issue was never noticed
previously. In theory a client side application could be relying on this
behaviour and could be broken by this change. This is probably fairly
unlikely but can't be ruled out.

This is a 1.1.1 backport of #13136