### PR TITLE
DH: stop setting the private key length arbitrarily

### DIFF
--- a/crypto/dh/dh_backend.c
+++ b/crypto/dh/dh_backend.c
@@ -8,6 +8,7 @@
  */
 
 #include <openssl/core_names.h>
+#include "internal/param_build_set.h"
 #include "crypto/dh.h"
 
 /*
@@ -15,6 +16,41 @@
  * for legacy backends (EVP_PKEY_ASN1_METHOD and EVP_PKEY_METHOD) and provider
  * implementations alike.
  */
+
+static int dh_ffc_params_fromdata(DH *dh, const OSSL_PARAM params[])
+{
+    int ret;
+    FFC_PARAMS *ffc;
+
+    if (dh == NULL)
+        return 0;
+    ffc = dh_get0_params(dh);
+    if (ffc == NULL)
+        return 0;
+
+    ret = ossl_ffc_params_fromdata(ffc, params);
+    if (ret)
+        dh_cache_named_group(dh); /* This increments dh->dirt_cnt */
+    return ret;
+}
+
+int dh_params_fromdata(DH *dh, const OSSL_PARAM params[])
+{
+    const OSSL_PARAM *param_priv_len;
+    long priv_len;
+
+    if (!dh_ffc_params_fromdata(dh, params))
+        return 0;
+
+    param_priv_len =
+        OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_DH_PRIV_LEN);
+    if (param_priv_len != NULL
+        && (!OSSL_PARAM_get_long(param_priv_len, &priv_len)
+            || !DH_set_length(dh, priv_len)))
+        return 0;
+
+    return 1;
+}
 
 int dh_key_fromdata(DH *dh, const OSSL_PARAM params[])
 {
@@ -51,4 +87,34 @@ int dh_key_fromdata(DH *dh, const OSSL_PARAM params[])
     BN_clear_free(priv_key);
     BN_free(pub_key);
     return 0;
+}
+
+int dh_params_todata(DH *dh, OSSL_PARAM_BLD *bld, OSSL_PARAM params[])
+{
+    long l = DH_get_length(dh);
+
+    if (!ossl_ffc_params_todata(dh_get0_params(dh), bld, params))
+        return 0;
+    if (l > 0
+        && !ossl_param_build_set_long(bld, params, OSSL_PKEY_PARAM_DH_PRIV_LEN, l))
+        return 0;
+    return 1;
+}
+
+int dh_key_todata(DH *dh, OSSL_PARAM_BLD *bld, OSSL_PARAM params[])
+{
+    const BIGNUM *priv = NULL, *pub = NULL;
+
+    if (dh == NULL)
+        return 0;
+
+    DH_get0_key(dh, &pub, &priv);
+    if (priv != NULL
+        && !ossl_param_build_set_bn(bld, params, OSSL_PKEY_PARAM_PRIV_KEY, priv))
+        return 0;
+    if (pub != NULL
+        && !ossl_param_build_set_bn(bld, params, OSSL_PKEY_PARAM_PUB_KEY, pub))
+        return 0;
+
+    return 1;
 }

--- a/crypto/dh/dh_backend.c
+++ b/crypto/dh/dh_backend.c
@@ -30,7 +30,7 @@ static int dh_ffc_params_fromdata(DH *dh, const OSSL_PARAM params[])
 
     ret = ossl_ffc_params_fromdata(ffc, params);
     if (ret)
-        dh_cache_named_group(dh); /* This increments dh->dirt_cnt */
+        dh_cache_named_group(dh); /* This increments dh->dirty_cnt */
     return ret;
 }
 

--- a/crypto/dh/dh_key.c
+++ b/crypto/dh/dh_key.c
@@ -269,7 +269,10 @@ static int generate_key(DH *dh)
                 goto err;
 #else
             if (dh->params.q == NULL) {
-                /* secret exponent length */
+                /* secret exponent length, must satisfy 2^(l-1) <= p */
+                if (dh->length != 0
+                    && dh->length >= BN_num_bits(dh->params.p))
+                    goto err;
                 l = dh->length ? dh->length : BN_num_bits(dh->params.p) - 1;
                 if (!BN_priv_rand_ex(priv_key, l, BN_RAND_TOP_ONE,
                                      BN_RAND_BOTTOM_ANY, ctx))

--- a/crypto/dh/dh_key.c
+++ b/crypto/dh/dh_key.c
@@ -271,6 +271,7 @@ static int generate_key(DH *dh)
             if (dh->params.q == NULL) {
                 /* secret exponent length */
                 l = dh->length ? dh->length : BN_num_bits(dh->params.p) - 1;
+                /* TODO: should l be checked for validity here? */
                 if (!BN_priv_rand_ex(priv_key, l, BN_RAND_TOP_ONE,
                                      BN_RAND_BOTTOM_ANY, ctx))
                     goto err;

--- a/crypto/dh/dh_key.c
+++ b/crypto/dh/dh_key.c
@@ -271,7 +271,6 @@ static int generate_key(DH *dh)
             if (dh->params.q == NULL) {
                 /* secret exponent length */
                 l = dh->length ? dh->length : BN_num_bits(dh->params.p) - 1;
-                /* TODO: should l be checked for validity here? */
                 if (!BN_priv_rand_ex(priv_key, l, BN_RAND_TOP_ONE,
                                      BN_RAND_BOTTOM_ANY, ctx))
                     goto err;

--- a/crypto/dh/dh_lib.c
+++ b/crypto/dh/dh_lib.c
@@ -219,18 +219,6 @@ int DH_set0_pqg(DH *dh, BIGNUM *p, BIGNUM *q, BIGNUM *g)
 
     ossl_ffc_params_set0_pqg(&dh->params, p, q, g);
     dh_cache_named_group(dh);
-    if (q != NULL)
-        dh->length = BN_num_bits(q);
-    /*
-     * Check if this is a named group. If it finds a named group then the
-     * 'q' and 'length' value are either already set or are set by the
-     * call.
-     */
-    if (DH_get_nid(dh) == NID_undef) {
-        /* If its not a named group then set the 'length' if q is not NULL */
-        if (q != NULL)
-            dh->length = BN_num_bits(q);
-    }
     dh->dirty_cnt++;
     return 1;
 }
@@ -264,7 +252,6 @@ int DH_set0_key(DH *dh, BIGNUM *pub_key, BIGNUM *priv_key)
     if (priv_key != NULL) {
         BN_clear_free(dh->priv_key);
         dh->priv_key = priv_key;
-        dh->length = BN_num_bits(priv_key);
     }
 
     dh->dirty_cnt++;

--- a/crypto/dh/dh_lib.c
+++ b/crypto/dh/dh_lib.c
@@ -325,22 +325,3 @@ int dh_get0_nid(const DH *dh)
 {
     return dh->params.nid;
 }
-
-int dh_ffc_params_fromdata(DH *dh, const OSSL_PARAM params[])
-{
-    int ret;
-    FFC_PARAMS *ffc;
-
-    if (dh == NULL)
-        return 0;
-    ffc = dh_get0_params(dh);
-    if (ffc == NULL)
-        return 0;
-
-    ret = ossl_ffc_params_fromdata(ffc, params);
-    if (ret) {
-        dh_cache_named_group(dh);
-        dh->dirty_cnt++;
-    }
-    return ret;
-}

--- a/crypto/dh/dh_lib.c
+++ b/crypto/dh/dh_lib.c
@@ -243,6 +243,7 @@ long DH_get_length(const DH *dh)
 int DH_set_length(DH *dh, long length)
 {
     dh->length = length;
+    dh->dirty_cnt++;
     return 1;
 }
 

--- a/crypto/param_build_set.c
+++ b/crypto/param_build_set.c
@@ -30,6 +30,17 @@ int ossl_param_build_set_int(OSSL_PARAM_BLD *bld, OSSL_PARAM *p,
     return 1;
 }
 
+int ossl_param_build_set_long(OSSL_PARAM_BLD *bld, OSSL_PARAM *p,
+                              const char *key, long num)
+{
+    if (bld != NULL)
+        return OSSL_PARAM_BLD_push_long(bld, key, num);
+    p = OSSL_PARAM_locate(p, key);
+    if (p != NULL)
+        return OSSL_PARAM_set_long(p, num);
+    return 1;
+}
+
 int ossl_param_build_set_utf8_string(OSSL_PARAM_BLD *bld, OSSL_PARAM *p,
                                      const char *key, const char *buf)
 {

--- a/include/crypto/dh.h
+++ b/include/crypto/dh.h
@@ -8,6 +8,7 @@
  */
 
 #include <openssl/core.h>
+#include <openssl/params.h>
 #include <openssl/dh.h>
 #include "internal/ffc.h"
 
@@ -24,8 +25,10 @@ void dh_cache_named_group(DH *dh);
 
 FFC_PARAMS *dh_get0_params(DH *dh);
 int dh_get0_nid(const DH *dh);
-int dh_ffc_params_fromdata(DH *dh, const OSSL_PARAM params[]);
+int dh_params_fromdata(DH *dh, const OSSL_PARAM params[]);
 int dh_key_fromdata(DH *dh, const OSSL_PARAM params[]);
+int dh_params_todata(DH *dh, OSSL_PARAM_BLD *bld, OSSL_PARAM params[]);
+int dh_key_todata(DH *dh, OSSL_PARAM_BLD *bld, OSSL_PARAM params[]);
 
 int dh_check_pub_key_partial(const DH *dh, const BIGNUM *pub_key, int *ret);
 int dh_check_priv_key(const DH *dh, const BIGNUM *priv_key, int *ret);

--- a/include/internal/param_build_set.h
+++ b/include/internal/param_build_set.h
@@ -12,6 +12,8 @@
 
 int ossl_param_build_set_int(OSSL_PARAM_BLD *bld, OSSL_PARAM *p,
                              const char *key, int num);
+int ossl_param_build_set_long(OSSL_PARAM_BLD *bld, OSSL_PARAM *p,
+                              const char *key, long num);
 int ossl_param_build_set_utf8_string(OSSL_PARAM_BLD *bld, OSSL_PARAM *p,
                                      const char *key, const char *buf);
 int ossl_param_build_set_octet_string(OSSL_PARAM_BLD *bld, OSSL_PARAM *p,

--- a/test/evp_pkey_provided_test.c
+++ b/test/evp_pkey_provided_test.c
@@ -457,6 +457,7 @@ static int test_fromdata_dh_named_group(void)
         0xcf, 0x33, 0x42, 0x83, 0x42
     };
     static const char group_name[] = "ffdhe2048";
+    static const long priv_len = 224;
 
     if (!TEST_ptr(bld = OSSL_PARAM_BLD_new())
         || !TEST_ptr(pub = BN_bin2bn(pub_data, sizeof(pub_data), NULL))
@@ -464,6 +465,8 @@ static int test_fromdata_dh_named_group(void)
         || !TEST_true(OSSL_PARAM_BLD_push_utf8_string(bld,
                                                       OSSL_PKEY_PARAM_GROUP_NAME,
                                                       group_name, 0))
+        || !TEST_true(OSSL_PARAM_BLD_push_long(bld, OSSL_PKEY_PARAM_DH_PRIV_LEN,
+                                               priv_len))
         || !TEST_true(OSSL_PARAM_BLD_push_BN(bld, OSSL_PKEY_PARAM_PUB_KEY, pub))
         || !TEST_true(OSSL_PARAM_BLD_push_BN(bld, OSSL_PKEY_PARAM_PRIV_KEY, priv))
         || !TEST_ptr(fromdata_params = OSSL_PARAM_BLD_to_param(bld)))
@@ -597,6 +600,7 @@ static int test_fromdata_dh_fips186_4(void)
        0x33, 0x42, 0x83, 0x42
     };
     static const char group_name[] = "ffdhe2048";
+    static const long priv_len = 224;
 
 
     if (!TEST_ptr(bld = OSSL_PARAM_BLD_new())
@@ -605,6 +609,8 @@ static int test_fromdata_dh_fips186_4(void)
         || !TEST_true(OSSL_PARAM_BLD_push_utf8_string(bld,
                                                       OSSL_PKEY_PARAM_GROUP_NAME,
                                                       group_name, 0))
+        || !TEST_true(OSSL_PARAM_BLD_push_long(bld, OSSL_PKEY_PARAM_DH_PRIV_LEN,
+                                               priv_len))
         || !TEST_true(OSSL_PARAM_BLD_push_BN(bld, OSSL_PKEY_PARAM_PUB_KEY, pub))
         || !TEST_true(OSSL_PARAM_BLD_push_BN(bld, OSSL_PKEY_PARAM_PRIV_KEY, priv))
         || !TEST_ptr(fromdata_params = OSSL_PARAM_BLD_to_param(bld)))


### PR DESCRIPTION
The private key length is supposed to be a user settable parameter.
We do check if it's set or not, and if not, we do apply defaults.

Fixes #12071