### PR TITLE
ENCODER & DECODER: set params on all encoder/decoder instances, unconditionally

### DIFF
--- a/crypto/encode_decode/decoder_meth.c
+++ b/crypto/encode_decode/decoder_meth.c
@@ -493,6 +493,7 @@ OSSL_DECODER_CTX *OSSL_DECODER_CTX_new(void)
 int OSSL_DECODER_CTX_set_params(OSSL_DECODER_CTX *ctx,
                                 const OSSL_PARAM params[])
 {
+    int ok = 1;
     size_t i;
     size_t l;
 
@@ -516,9 +517,9 @@ int OSSL_DECODER_CTX_set_params(OSSL_DECODER_CTX *ctx,
         if (decoderctx == NULL || decoder->set_ctx_params == NULL)
             continue;
         if (!decoder->set_ctx_params(decoderctx, params))
-            return 0;
+            ok = 0;
     }
-    return 1;
+    return ok;
 }
 
 void OSSL_DECODER_CTX_free(OSSL_DECODER_CTX *ctx)

--- a/crypto/encode_decode/encoder_meth.c
+++ b/crypto/encode_decode/encoder_meth.c
@@ -503,6 +503,7 @@ OSSL_ENCODER_CTX *OSSL_ENCODER_CTX_new(void)
 int OSSL_ENCODER_CTX_set_params(OSSL_ENCODER_CTX *ctx,
                                 const OSSL_PARAM params[])
 {
+    int ok = 1;
     size_t i;
     size_t l;
 
@@ -524,9 +525,9 @@ int OSSL_ENCODER_CTX_set_params(OSSL_ENCODER_CTX *ctx,
         if (encoderctx == NULL || encoder->set_ctx_params == NULL)
             continue;
         if (!encoder->set_ctx_params(encoderctx, params))
-            return 0;
+            ok = 0;
     }
-    return 1;
+    return ok;
 }
 
 void OSSL_ENCODER_CTX_free(OSSL_ENCODER_CTX *ctx)


### PR DESCRIPTION
OSSL_DECODER_CTX_set_params() and OSSL_ENCODER_CTX_set_params() would
stop as soon as a decoder / encoder instance failed, which leaves the
rest of them with a possibly previous and different value.

Instead, these functions will now call them all, but will return 0 if
any of the instance calls failed.
