### PR TITLE
Fix no-dh

### DIFF
--- a/crypto/dsa/dsa_ameth.c
+++ b/crypto/dsa/dsa_ameth.c
@@ -374,10 +374,9 @@ static int dsa_param_decode(EVP_PKEY *pkey,
 {
     DSA *dsa;
 
-    if ((dsa = d2i_DSAparams(NULL, pder, derlen)) == NULL) {
-        DSAerr(DSA_F_DSA_PARAM_DECODE, ERR_R_DSA_LIB);
+    if ((dsa = d2i_DSAparams(NULL, pder, derlen)) == NULL)
         return 0;
-    }
+
     dsa->dirty_cnt++;
     EVP_PKEY_assign_DSA(pkey, dsa);
     return 1;


### PR DESCRIPTION
One of the x509 tests checks to make sure spurious errors don't appear on
the stack. The x509 app uses the OSSL_STORE code to load things. The
OSSL_STORE code will try various different formats - which results in
lots of failures. However those failures are typically suppressed by
OSSL_STORE unless they are interesting. OSSL_STORE thinks it know what
kind of errors are uninteresting (ASN.1 errors) but gets confused if
upper levels of code add additional errors to the stack. This was
happening in the DSA code which confused OSSL_STORE and meant the errors
were not being suppressed propery - and hence the x509 test failed.

Interestingly this only impacts a no-dh build, because in a no-dh build
the DSA param decoder suddenly becomes the last to be tried. If it
happens earlier in the list the errors end up getting suppressed anyway.

The simplest solution is to just to remove the error from the DSA param
decoder code. Its not adding any useful information anyway.
