### PR TITLE
Change markdown link style in README, INSTALL, SUPPORT and CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,13 +1,13 @@
 HOW TO CONTRIBUTE TO OpenSSL
 ============================
 
-Please visit our [Getting Started][gs] page for other ideas about how to contribute.
+Please visit our [Getting Started] page for other ideas about how to contribute.
 
-  [gs]: https://www.openssl.org/community/getting-started.html
+  [Getting Started]: <https://www.openssl.org/community/getting-started.html>
 
-Development is done on GitHub in the [openssl/openssl][gh] repository.
+Development is done on GitHub in the [openssl/openssl] repository.
 
-  [gh]: https://github.com/openssl/openssl
+  [openssl/openssl]: <https://github.com/openssl/openssl>
 
 To request new features or report bugs, please open an issue on GitHub
 
@@ -20,13 +20,13 @@ To make it easier to review and accept your pull request, please follow these
 guidelines:
 
  1. Anything other than a trivial contribution requires a [Contributor
-    License Agreement][CLA] (CLA), giving us permission to use your code.
+    License Agreement] (CLA), giving us permission to use your code.
     If your contribution is too small to require a CLA (e.g. fixing a spelling
     mistake), place the text "`CLA: trivial`" on a line by itself separated by
     an empty line from the rest of the commit message. It is not sufficient to
     only place the text in the GitHub pull request description.
 
-    [CLA]: https://www.openssl.org/policies/cla.html
+    [Contributor License Agreement]: <https://www.openssl.org/policies/cla.html>
 
     To amend a missing "`CLA: trivial`" line after submission, do the following:
 
@@ -53,7 +53,7 @@ guidelines:
     often. We do not accept merge commits, you will have to remove them
     (usually by rebasing) before it will be acceptable.
 
- 4. Patches should follow our [coding style][] and compile without warnings.
+ 4. Patches should follow our [coding style] and compile without warnings.
     Where `gcc` or `clang` is available you should use the
     `--strict-warnings` `Configure` option.  OpenSSL compiles on many varied
     platforms: try to ensure you only use portable features.  Clean builds

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1524,7 +1524,7 @@ directory, which you can supply to the `./Configure` command,
 possibly after some adjustment.
 
 The `Configurations/` directory contains a lot of examples of such targets.
-The main configuration file is [10-main.conf][], which contains all targets that
+The main configuration file is [10-main.conf], which contains all targets that
 are officially supported by the OpenSSL team. Other configuration files contain
 targets contributed by other OpenSSL users. The list of targets can be found in
 a Perl list `my %targets = ( ... )`.
@@ -1552,11 +1552,11 @@ design of the configuration files.
  - [Configurations/README.md](Configurations/README.md)
  - [Configurations/README-design.md](Configurations/README-design.md)
 
-If you need further help, try to search the [openssl-users][] mailing list
-or the [GitHub Issues][] for existing solutions. If you don't find anything,
-you can [raise an issue][] to ask a question yourself.
+If you need further help, try to search the [openssl-users] mailing list
+or the [GitHub Issues] for existing solutions. If you don't find anything,
+you can [raise an issue] to ask a question yourself.
 
-More about our support resources can be found in the [SUPPORT][] file.
+More about our support resources can be found in the [SUPPORT] file.
 
 ### Configuration Errors
 
@@ -1564,7 +1564,7 @@ If the `./Configure` or `./Configure` command fails with an error message,
 read the error message carefully and try to figure out whether you made
 a mistake (e.g., by providing a wrong option), or whether the script is
 working incorrectly. If you think you encountered a bug, please
-[raise an issue][] on GitHub to file a bug report.
+[raise an issue] on GitHub to file a bug report.
 
 Along with a short description of the bug, please provide the complete
 configure command line and the relevant output including the error message.
@@ -1603,9 +1603,9 @@ Assembler error messages can sometimes be sidestepped by using the
 Compiling parts of OpenSSL with gcc and others with the system compiler will
 result in unresolved symbols on some systems.
 
-If you are still having problems, try to search the [openssl-users][] mailing
-list or the [GitHub Issues][] for existing solutions. If you think you
-encountered an OpenSSL bug, please [raise an issue][] to file a bug report.
+If you are still having problems, try to search the [openssl-users] mailing
+list or the [GitHub Issues] for existing solutions. If you think you
+encountered an OpenSSL bug, please [raise an issue] to file a bug report.
 Please take the time to review the existing issues first; maybe the bug was
 already reported or has already been fixed.
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 Welcome to the OpenSSL Project
 ==============================
 
-[![openssl logo][]][www.openssl.org]
+[![openssl logo]][www.openssl.org]
 
-[![travis badge][]][travis jobs]
-[![appveyor badge][]][appveyor jobs]
+[![travis badge]][travis jobs]
+[![appveyor badge]][appveyor jobs]
 
 OpenSSL is a robust, commercial-grade, full-featured Open Source Toolkit
 for the Transport Layer Security (TLS) protocol formerly known as the
@@ -15,7 +15,7 @@ be used stand-alone.
 OpenSSL is descended from the SSLeay library developed by Eric A. Young
 and Tim J. Hudson.
 
-The official Home Page of the OpenSSL Project is [www.openssl.org][].
+The official Home Page of the OpenSSL Project is [www.openssl.org].
 
 Table of Contents
 =================
@@ -35,7 +35,7 @@ Overview
 The OpenSSL toolkit includes:
 
 - **libssl**
-  an implementation of all TLS protocol versions up to TLSv1.3 ([RFC 8446][]).
+  an implementation of all TLS protocol versions up to TLSv1.3 ([RFC 8446]).
 
 - **libcrypto**
   a full-strength general purpose cryptographic library. It constitutes the
@@ -75,8 +75,8 @@ the source tarballs, having a local copy of the git repository with
 the entire project history gives you much more insight into the
 code base.
 
-The official OpenSSL Git Repository is located at [git.openssl.org][].
-There is a GitHub mirror of the repository at [github.com/openssl/openssl][],
+The official OpenSSL Git Repository is located at [git.openssl.org].
+There is a GitHub mirror of the repository at [github.com/openssl/openssl],
 which is updated automatically from the former on every commit.
 
 A local copy of the Git Repository can be obtained by cloning it from
@@ -132,7 +132,7 @@ available online.
 Wiki
 ----
 
-There is a Wiki at [wiki.openssl.org][] which is currently not very active.
+There is a Wiki at [wiki.openssl.org] which is currently not very active.
 It contains a lot of useful information, not all of which is up to date.
 
 License

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -43,7 +43,7 @@ For more information, see <https://www.openssl.org/community/mailinglists.html>
 You have general questions about using OpenSSL
 ----------------------------------------------
 
-In this case the [openssl-users][] mailing list is the right place for you.
+In this case the [openssl-users] mailing list is the right place for you.
 The list is not only watched by the OpenSSL team members, but also by many
 other OpenSSL users. Here you will most likely get the answer to your questions.
 An overview over the [mailing lists](#mailing-lists) can be found below.
@@ -64,7 +64,7 @@ If you have any problems with OpenSSL then please take the following steps first
 Please keep in mind: Just because something doesn't work the way you expect
 does not mean it is necessarily a bug in OpenSSL. If you are not sure,
 consider searching the mail archives and posting a question to the
-[openssl-users][] mailing list first.
+[openssl-users] mailing list first.
 
 ### Open an Issue
 
@@ -94,18 +94,18 @@ like a grammatical or typographical error in the documentation.
 Mailing Lists
 =============
 
-The OpenSSL maintains a number of [mailing lists][] for various purposes.
+The OpenSSL maintains a number of [mailing lists] for various purposes.
 The most important lists are:
 
-- [openssl-users][] for general questions about using the OpenSSL software
-                    and discussions between OpenSSL users.
+- [openssl-users]    for general questions about using the OpenSSL software
+                     and discussions between OpenSSL users.
 
-- [openssl-announce][] for official announcements to the OpenSSL community.
+- [openssl-announce] for official announcements to the OpenSSL community.
 
-- [openssl-project][]  for discussion about the development roadmap
-                       and governance.
+- [openssl-project]  for discussion about the development roadmap
+                     and governance.
 
-- [openssl-dev][]      for discussion about development of OpenSSL.
+- [openssl-dev]      for discussion about development of OpenSSL.
 
 The openssl-dev list has been discontinued since development is now taking
 place in form of GitHub pull requests. Although not active anymore, the


### PR DESCRIPTION
Replace [collapsed reference links][] by [shortcut reference links],
in order to to improve the readability of the raw markdown text,
see also commit d8dc853825 (Change CVE link style in CHANGES and NEWS).

[collapsed reference links]:
  https://github.github.com/gfm/#collapsed-reference-link

[shortcut reference links]:
  https://github.github.com/gfm/#shortcut-reference-link
