### PR TITLE
resolve defects - resource leak - the return value of function dup

### DIFF
--- a/apps/speed.c
+++ b/apps/speed.c
@@ -3467,6 +3467,7 @@ static int do_multi(int multi, int size_num)
     int n;
     int fd[2];
     int *fds;
+    int dup_fd;
     static char sep[] = ":";
 
     fds = app_malloc(sizeof(*fds) * multi, "fd buffer for do_multi");
@@ -3483,10 +3484,11 @@ static int do_multi(int multi, int size_num)
         } else {
             close(fd[0]);
             close(1);
-            if (dup(fd[1]) == -1) {
+            if ((dup_fd = dup(fd[1])) == -1) {
                 BIO_printf(bio_err, "dup failed\n");
                 exit(1);
             }
+            close(dup_fd)
             close(fd[1]);
             mr = 1;
             usertime = 0;

--- a/apps/speed.c
+++ b/apps/speed.c
@@ -3488,7 +3488,7 @@ static int do_multi(int multi, int size_num)
                 BIO_printf(bio_err, "dup failed\n");
                 exit(1);
             }
-            close(dup_fd)
+            close(dup_fd);
             close(fd[1]);
             mr = 1;
             usertime = 0;


### PR DESCRIPTION
the return value of function `dup` in func `do_multi` is not kept and closed properly which can result in resource leak. The PR tries to resolve the defects.