### PR TITLE
resolve defects - reverse_inull - row[DB_exp_date] referenced before ch…

### DIFF
--- a/apps/ca.c
+++ b/apps/ca.c
@@ -1862,8 +1862,8 @@ static int do_body(X509 **xret, EVP_PKEY *pkey, X509 *x509,
     row[DB_exp_date][tm->length] = '\0';
     row[DB_rev_date] = NULL;
     row[DB_file] = OPENSSL_strdup("unknown");
-    if ((row[DB_type] == NULL) || (row[DB_exp_date] == NULL) ||
-        (row[DB_file] == NULL) || (row[DB_name] == NULL)) {
+    if ((row[DB_type] == NULL) || (row[DB_file] == NULL)
+        || (row[DB_name] == NULL)) {
         BIO_printf(bio_err, "Memory allocation failure\n");
         goto end;
     }


### PR DESCRIPTION
`row[DB_exp_date]` is referenced before being checked. And `row[DB_exp_date]` is created by function `app_malloc`  which ensures either memory is allocated or program exits. So, the PR removes the check of `row[DB_exp_date]`