### PR TITLE
WIP Deprecate RAND_METHOD_ functions.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -91,6 +91,13 @@ OpenSSL 3.0
 
    *Paul Dale and Matthias St. Pierre*
 
+ * Deprecate ability to set/get RAND_METHOD.  The functions RAND_set_method()
+   and RAND_get_method() have been deprecated, along with the ability to
+   have ENGINE's provide random bytes. Third-parties that want to provide
+   their own random numbers must do so as a provider.
+
+   *Rich Salz*
+
  * Allow SSL_set1_host() and SSL_add1_host() to take IP literal addresses
    as well as actual hostnames.
 

--- a/crypto/engine/build.info
+++ b/crypto/engine/build.info
@@ -2,7 +2,10 @@ LIBS=../../libcrypto
 SOURCE[../../libcrypto]=\
         eng_err.c eng_lib.c eng_list.c eng_init.c eng_ctrl.c \
         eng_table.c eng_pkey.c eng_fat.c eng_all.c \
-        tb_rsa.c tb_dsa.c tb_dh.c tb_rand.c \
+        tb_rsa.c tb_dsa.c tb_dh.c \
         tb_cipher.c tb_digest.c tb_pkmeth.c tb_asnmth.c tb_eckey.c \
-        eng_openssl.c eng_cnf.c eng_dyn.c \
-        eng_rdrand.c
+        eng_openssl.c eng_cnf.c eng_dyn.c
+
+IF[{- !$disabled{'deprecated-3.0'} -}]
+  SOURCE[../../libcrypto]=eng_rdrand.c tb_rand.c
+ENDIF

--- a/crypto/engine/eng_local.h
+++ b/crypto/engine/eng_local.h
@@ -112,7 +112,12 @@ struct engine_st {
     const DSA_METHOD *dsa_meth;
     const DH_METHOD *dh_meth;
     const EC_KEY_METHOD *ec_meth;
+# ifndef OPENSSL_NO_DEPRECATED_3_0
     const RAND_METHOD *rand_meth;
+#else
+    /* Keep for binary compatibility? */
+    const void *rand_meth;
+#endif
     /* Cipher handling is via this callback */
     ENGINE_CIPHERS_PTR ciphers;
     /* Digest handling is via this callback */

--- a/crypto/evp/evp_local.h
+++ b/crypto/evp/evp_local.h
@@ -10,7 +10,7 @@
 /* EVP_MD_CTX related stuff */
 
 #include <openssl/core_dispatch.h>
-#include "internal/refcount.h"
+#include "crypto/rand.h"
 
 #define EVP_CTRL_RET_UNSUPPORTED -1
 
@@ -65,14 +65,6 @@ struct evp_kdf_ctx_st {
     EVP_KDF *meth;              /* Method structure */
     void *data;                 /* Algorithm-specific data */
 } /* EVP_KDF_CTX */ ;
-
-struct evp_rand_ctx_st {
-    EVP_RAND *meth;             /* Method structure */
-    void *data;                 /* Algorithm-specific data */
-    EVP_RAND_CTX *parent;       /* Parent EVP_RAND or NULL if none */
-    CRYPTO_REF_COUNT refcnt;    /* Context reference count */
-    CRYPTO_RWLOCK *refcnt_lock;
-} /* EVP_RAND_CTX */ ;
 
 struct evp_keymgmt_st {
     int id;                      /* libcrypto internal */

--- a/crypto/evp/evp_rand.c
+++ b/crypto/evp/evp_rand.c
@@ -25,32 +25,6 @@
 #include "internal/provider.h"
 #include "evp_local.h"
 
-struct evp_rand_st {
-    OSSL_PROVIDER *prov;
-    int name_id;
-    CRYPTO_REF_COUNT refcnt;
-    CRYPTO_RWLOCK *refcnt_lock;
-
-    const OSSL_DISPATCH *dispatch;
-    OSSL_FUNC_rand_newctx_fn *newctx;
-    OSSL_FUNC_rand_freectx_fn *freectx;
-    OSSL_FUNC_rand_instantiate_fn *instantiate;
-    OSSL_FUNC_rand_uninstantiate_fn *uninstantiate;
-    OSSL_FUNC_rand_generate_fn *generate;
-    OSSL_FUNC_rand_reseed_fn *reseed;
-    OSSL_FUNC_rand_nonce_fn *nonce;
-    OSSL_FUNC_rand_enable_locking_fn *enable_locking;
-    OSSL_FUNC_rand_lock_fn *lock;
-    OSSL_FUNC_rand_unlock_fn *unlock;
-    OSSL_FUNC_rand_gettable_params_fn *gettable_params;
-    OSSL_FUNC_rand_gettable_ctx_params_fn *gettable_ctx_params;
-    OSSL_FUNC_rand_settable_ctx_params_fn *settable_ctx_params;
-    OSSL_FUNC_rand_get_params_fn *get_params;
-    OSSL_FUNC_rand_get_ctx_params_fn *get_ctx_params;
-    OSSL_FUNC_rand_set_ctx_params_fn *set_ctx_params;
-    OSSL_FUNC_rand_verify_zeroization_fn *verify_zeroization;
-} /* EVP_RAND */ ;
-
 static int evp_rand_up_ref(void *vrand)
 {
     EVP_RAND *rand = (EVP_RAND *)vrand;

--- a/crypto/rand/build.info
+++ b/crypto/rand/build.info
@@ -1,8 +1,11 @@
 LIBS=../../libcrypto
 
-$COMMON=rand_lib.c rand_meth.c
-$CRYPTO=randfile.c rand_err.c rand_deprecated.c
+$COMMON=rand_lib.c
+IF[{- !$disabled{'deprecated-3.0'} -}]
+  $COMMON=$COMMON rand_meth.c
+ENDIF
 
+$CRYPTO=randfile.c rand_err.c rand_deprecated.c
 IF[{- !$disabled{'egd'} -}]
   $CRYPTO=$CRYPTO rand_egd.c
 ENDIF

--- a/crypto/rand/rand_local.h
+++ b/crypto/rand/rand_local.h
@@ -25,7 +25,9 @@
 # define PRIMARY_RESEED_TIME_INTERVAL            (60 * 60) /* 1 hour */
 # define SECONDARY_RESEED_TIME_INTERVAL          (7 * 60)  /* 7 minutes */
 
+# ifndef OPENSSL_NO_DEPRECATED_3_0
 /* The global RAND method, and the global buffer and DRBG instance. */
 extern RAND_METHOD rand_meth;
+# endif
 
 #endif

--- a/doc/man3/RAND_set_rand_method.pod
+++ b/doc/man3/RAND_set_rand_method.pod
@@ -8,10 +8,12 @@ RAND_set_rand_method, RAND_get_rand_method, RAND_OpenSSL - select RAND method
 
  #include <openssl/rand.h>
 
+Deprecated since OpenSSL 3.0, can be hidden entirely by defining
+B<OPENSSL_API_COMPAT> with a suitable version value, see
+L<openssl_user_macros(7)>:
+
  RAND_METHOD *RAND_OpenSSL(void);
-
  int RAND_set_rand_method(const RAND_METHOD *meth);
-
  const RAND_METHOD *RAND_get_rand_method(void);
 
 =head1 DESCRIPTION

--- a/doc/man7/RAND.pod
+++ b/doc/man7/RAND.pod
@@ -47,7 +47,7 @@ CSPRNG instance will not affect the secrecy of these private values.
 
 In the rare case where the default implementation does not satisfy your special
 requirements, the default RAND method can be replaced by your own RAND
-method using L<RAND_set_rand_method(3)>.
+method in a provider.
 
 Changing the default random generator should be necessary
 only in exceptional cases and is not recommended, unless you have a profound

--- a/fuzz/asn1.c
+++ b/fuzz/asn1.c
@@ -39,7 +39,6 @@
 #include <openssl/ssl.h>
 #include <internal/nelem.h>
 #include "fuzzer.h"
-
 #include "rand.inc"
 
 static ASN1_ITEM_EXP *item_type[] = {

--- a/fuzz/asn1.c
+++ b/fuzz/asn1.c
@@ -289,9 +289,7 @@ int FuzzerInitialize(int *argc, char ***argv)
     OPENSSL_init_ssl(OPENSSL_INIT_LOAD_SSL_STRINGS, NULL);
     ERR_clear_error();
     CRYPTO_free_ex_index(0, -1);
-    FuzzerSetRand();
-
-    return 1;
+    return FuzzerSetRand();
 }
 
 int FuzzerTestOneInput(const uint8_t *buf, size_t len)

--- a/fuzz/build.info
+++ b/fuzz/build.info
@@ -89,7 +89,7 @@ IF[{- !$disabled{tests} -}]
 
   SOURCE[asn1-test]=asn1.c test-corpus.c
   INCLUDE[asn1-test]=../include
-  DEPEND[asn1-test]=../libcrypto ../libssl
+  DEPEND[asn1-test]=../providers/libnonfips.a ../libcrypto.a ../libssl.a
 
   SOURCE[asn1parse-test]=asn1parse.c test-corpus.c
   INCLUDE[asn1parse-test]=../include
@@ -105,11 +105,11 @@ IF[{- !$disabled{tests} -}]
 
   SOURCE[client-test]=client.c test-corpus.c
   INCLUDE[client-test]=../include
-  DEPEND[client-test]=../libcrypto ../libssl
+  DEPEND[client-test]=../providers/libnonfips.a ../libcrypto.a ../libssl.a
 
   SOURCE[cmp-test]=cmp.c test-corpus.c
   INCLUDE[cmp-test]=../include
-  DEPEND[cmp-test]=../libcrypto.a
+  DEPEND[cmp-test]=../providers/libnonfips.a ../libcrypto.a
   # referring to static lib allows using non-exported functions
 
   SOURCE[cms-test]=cms.c test-corpus.c
@@ -130,9 +130,9 @@ IF[{- !$disabled{tests} -}]
 
   SOURCE[server-test]=server.c test-corpus.c
   INCLUDE[server-test]=../include
-  DEPEND[server-test]=../libcrypto ../libssl
+  DEPEND[server-test]=../providers/libnonfips.a ../libcrypto.a ../libssl.a
 
   SOURCE[x509-test]=x509.c test-corpus.c
   INCLUDE[x509-test]=../include
-  DEPEND[x509-test]=../libcrypto
+  DEPEND[x509-test]=../providers/libnonfips.a ../libcrypto.a
 ENDIF

--- a/fuzz/client.c
+++ b/fuzz/client.c
@@ -47,12 +47,11 @@ int FuzzerInitialize(int *argc, char ***argv)
     ERR_clear_error();
     CRYPTO_free_ex_index(0, -1);
     idx = SSL_get_ex_data_X509_STORE_CTX_idx();
-    FuzzerSetRand();
     comp_methods = SSL_COMP_get_compression_methods();
     if (comp_methods != NULL)
         sk_SSL_COMP_sort(comp_methods);
 
-    return 1;
+    return FuzzerSetRand();
 }
 
 int FuzzerTestOneInput(const uint8_t *buf, size_t len)

--- a/fuzz/client.c
+++ b/fuzz/client.c
@@ -17,7 +17,6 @@
 #include <openssl/dh.h>
 #include <openssl/err.h>
 #include "fuzzer.h"
-
 #include "rand.inc"
 
 /* unused, to avoid warning. */

--- a/fuzz/cmp.c
+++ b/fuzz/cmp.c
@@ -23,8 +23,7 @@ int FuzzerInitialize(int *argc, char ***argv)
     OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CRYPTO_STRINGS, NULL);
     ERR_clear_error();
     CRYPTO_free_ex_index(0, -1);
-    FuzzerSetRand();
-    return 1;
+    return FuzzerSetRand();
 }
 
 static int num_responses;

--- a/fuzz/fuzzer.h
+++ b/fuzz/fuzzer.h
@@ -11,4 +11,4 @@
 int FuzzerTestOneInput(const uint8_t *buf, size_t len);
 int FuzzerInitialize(int *argc, char ***argv);
 void FuzzerCleanup(void);
-void FuzzerSetRand(void);
+int FuzzerSetRand(void);

--- a/fuzz/rand.inc
+++ b/fuzz/rand.inc
@@ -7,50 +7,14 @@
  * https://www.openssl.org/source/license.html
  * or in the file LICENSE in the source distribution.
  */
-#include <openssl/rand.h>
+#include <crypto/rand.h>
 
 int FuzzerSetRand(void)
 {
-    return 0;
-}
-#if 0
-static int rand_test_init(EVP_TEST *t, const char *name)
-{
-    RAND_DATA *rdata;
-    EVP_RAND *rand;
-    OSSL_PARAM params[2] = { OSSL_PARAM_END, OSSL_PARAM_END };
-    unsigned int strength = 256;
+    EVP_RAND_CTX *rfake = RAND_make_fake(NULL);
 
-    if (!TEST_ptr(rdata = OPENSSL_zalloc(sizeof(*rdata))))
-        return 0;
-
-    /* TEST-RAND is available in the FIPS provider but not with "fips=yes" */
-    rand = EVP_RAND_fetch(libctx, "TEST-RAND", "-fips");
-    if (rand == NULL)
-        goto err;
-    rdata->parent = EVP_RAND_CTX_new(rand, NULL);
-    EVP_RAND_free(rand);
-    if (rdata->parent == NULL)
-        goto err;
-
-    *params = OSSL_PARAM_construct_uint(OSSL_RAND_PARAM_STRENGTH, &strength);
-    if (!EVP_RAND_set_ctx_params(rdata->parent, params))
-        goto err;
-
-    rand = EVP_RAND_fetch(libctx, name, NULL);
-    if (rand == NULL)
-        goto err;
-    rdata->ctx = EVP_RAND_CTX_new(rand, rdata->parent);
-    EVP_RAND_free(rand);
-    if (rdata->ctx == NULL)
-        goto err;
-
-    rdata->n = -1;
-    t->data = rdata;
+    RAND_swap_primary(NULL, rfake);
+    RAND_swap_public(NULL, rfake);
+    RAND_swap_private(NULL, rfake);
     return 1;
- err:
-    EVP_RAND_CTX_free(rdata->parent);
-    OPENSSL_free(rdata);
-    return 0;
 }
-#endif

--- a/fuzz/rand.inc
+++ b/fuzz/rand.inc
@@ -9,32 +9,48 @@
  */
 #include <openssl/rand.h>
 
-static int fuzz_bytes(unsigned char *buf, int num)
+int FuzzerSetRand(void)
 {
-    unsigned char val = 1;
+    return 0;
+}
+#if 0
+static int rand_test_init(EVP_TEST *t, const char *name)
+{
+    RAND_DATA *rdata;
+    EVP_RAND *rand;
+    OSSL_PARAM params[2] = { OSSL_PARAM_END, OSSL_PARAM_END };
+    unsigned int strength = 256;
 
-    while (--num >= 0)
-        *buf++ = val++;
+    if (!TEST_ptr(rdata = OPENSSL_zalloc(sizeof(*rdata))))
+        return 0;
+
+    /* TEST-RAND is available in the FIPS provider but not with "fips=yes" */
+    rand = EVP_RAND_fetch(libctx, "TEST-RAND", "-fips");
+    if (rand == NULL)
+        goto err;
+    rdata->parent = EVP_RAND_CTX_new(rand, NULL);
+    EVP_RAND_free(rand);
+    if (rdata->parent == NULL)
+        goto err;
+
+    *params = OSSL_PARAM_construct_uint(OSSL_RAND_PARAM_STRENGTH, &strength);
+    if (!EVP_RAND_set_ctx_params(rdata->parent, params))
+        goto err;
+
+    rand = EVP_RAND_fetch(libctx, name, NULL);
+    if (rand == NULL)
+        goto err;
+    rdata->ctx = EVP_RAND_CTX_new(rand, rdata->parent);
+    EVP_RAND_free(rand);
+    if (rdata->ctx == NULL)
+        goto err;
+
+    rdata->n = -1;
+    t->data = rdata;
     return 1;
+ err:
+    EVP_RAND_CTX_free(rdata->parent);
+    OPENSSL_free(rdata);
+    return 0;
 }
-
-static int fuzz_status(void)
-{
-    return 1;
-}
-
-static RAND_METHOD fuzz_rand_method = {
-    NULL,
-    fuzz_bytes,
-    NULL,
-    NULL,
-    fuzz_bytes,
-    fuzz_status
-};
-
-void FuzzerSetRand(void)
-{
-    RAND_set_rand_method(&fuzz_rand_method);
-}
-
-
+#endif

--- a/fuzz/server.c
+++ b/fuzz/server.c
@@ -21,7 +21,6 @@
 #include <openssl/dh.h>
 #include <openssl/err.h>
 #include "fuzzer.h"
-
 #include "rand.inc"
 
 static const uint8_t kCertificateDER[] = {

--- a/fuzz/server.c
+++ b/fuzz/server.c
@@ -494,12 +494,11 @@ int FuzzerInitialize(int *argc, char ***argv)
     ERR_clear_error();
     CRYPTO_free_ex_index(0, -1);
     idx = SSL_get_ex_data_X509_STORE_CTX_idx();
-    FuzzerSetRand();
     comp_methods = SSL_COMP_get_compression_methods();
     if (comp_methods != NULL)
         sk_SSL_COMP_sort(comp_methods);
 
-    return 1;
+    return FuzzerSetRand();
 }
 
 int FuzzerTestOneInput(const uint8_t *buf, size_t len)

--- a/fuzz/x509.c
+++ b/fuzz/x509.c
@@ -21,8 +21,7 @@ int FuzzerInitialize(int *argc, char ***argv)
     OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CRYPTO_STRINGS, NULL);
     ERR_clear_error();
     CRYPTO_free_ex_index(0, -1);
-    FuzzerSetRand();
-    return 1;
+    return FuzzerSetRand();
 }
 
 int FuzzerTestOneInput(const uint8_t *buf, size_t len)

--- a/fuzz/x509.c
+++ b/fuzz/x509.c
@@ -13,7 +13,6 @@
 #include <openssl/err.h>
 #include <openssl/rand.h>
 #include "fuzzer.h"
-
 #include "rand.inc"
 
 int FuzzerInitialize(int *argc, char ***argv)

--- a/include/crypto/rand.h
+++ b/include/crypto/rand.h
@@ -7,18 +7,46 @@
  * https://www.openssl.org/source/license.html
  */
 
-/*
- * Licensed under the Apache License 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- * https://www.openssl.org/source/license.html
- * or in the file LICENSE in the source distribution.
- */
-
 #ifndef OSSL_CRYPTO_RAND_H
 # define OSSL_CRYPTO_RAND_H
 
 # include <openssl/rand.h>
+#include <openssl/core_dispatch.h>
+#include "internal/refcount.h"
+
+struct evp_rand_st {
+    OSSL_PROVIDER *prov;
+    int name_id;
+    CRYPTO_REF_COUNT refcnt;
+    CRYPTO_RWLOCK *refcnt_lock;
+
+    const OSSL_DISPATCH *dispatch;
+    OSSL_FUNC_rand_newctx_fn *newctx;
+    OSSL_FUNC_rand_freectx_fn *freectx;
+    OSSL_FUNC_rand_instantiate_fn *instantiate;
+    OSSL_FUNC_rand_uninstantiate_fn *uninstantiate;
+    OSSL_FUNC_rand_generate_fn *generate;
+    OSSL_FUNC_rand_reseed_fn *reseed;
+    OSSL_FUNC_rand_nonce_fn *nonce;
+    OSSL_FUNC_rand_enable_locking_fn *enable_locking;
+    OSSL_FUNC_rand_lock_fn *lock;
+    OSSL_FUNC_rand_unlock_fn *unlock;
+    OSSL_FUNC_rand_gettable_params_fn *gettable_params;
+    OSSL_FUNC_rand_gettable_ctx_params_fn *gettable_ctx_params;
+    OSSL_FUNC_rand_settable_ctx_params_fn *settable_ctx_params;
+    OSSL_FUNC_rand_get_params_fn *get_params;
+    OSSL_FUNC_rand_get_ctx_params_fn *get_ctx_params;
+    OSSL_FUNC_rand_set_ctx_params_fn *set_ctx_params;
+    OSSL_FUNC_rand_verify_zeroization_fn *verify_zeroization;
+};
+
+struct evp_rand_ctx_st {
+    EVP_RAND *meth;             /* Method structure */
+    void *data;                 /* Algorithm-specific data */
+    EVP_RAND_CTX *parent;       /* Parent EVP_RAND or NULL if none */
+    CRYPTO_REF_COUNT refcnt;    /* Context reference count */
+    CRYPTO_RWLOCK *refcnt_lock;
+};
 
 /*
  * Defines related to seed sources
@@ -92,5 +120,13 @@ void rand_pool_keep_random_devices_open(int keep);
  * Configuration
  */
 void ossl_random_add_conf_module(void);
+
+/*
+ * Swapping DRBG implementations; only to be used for testing.
+ */
+EVP_RAND_CTX *RAND_make_fake(const char *values);
+EVP_RAND_CTX *RAND_swap_primary(OSSL_LIB_CTX *ctx, EVP_RAND_CTX *prim);
+EVP_RAND_CTX *RAND_swap_public(OSSL_LIB_CTX *ctx, EVP_RAND_CTX *pub);
+EVP_RAND_CTX *RAND_swap_private(OSSL_LIB_CTX *ctx, EVP_RAND_CTX *priv);
 
 #endif

--- a/include/openssl/rand.h
+++ b/include/openssl/rand.h
@@ -36,6 +36,7 @@ extern "C" {
  */
 # define RAND_DRBG_STRENGTH             256
 
+# ifndef OPENSSL_NO_DEPRECATED_3_0
 struct rand_meth_st {
     int (*seed) (const void *buf, int num);
     int (*bytes) (unsigned char *buf, int num);
@@ -45,13 +46,13 @@ struct rand_meth_st {
     int (*status) (void);
 };
 
-int RAND_set_rand_method(const RAND_METHOD *meth);
-const RAND_METHOD *RAND_get_rand_method(void);
+OSSL_DEPRECATEDIN_3_0 int RAND_set_rand_method(const RAND_METHOD *meth);
+OSSL_DEPRECATEDIN_3_0 const RAND_METHOD *RAND_get_rand_method(void);
+OSSL_DEPRECATEDIN_3_0 RAND_METHOD *RAND_OpenSSL(void);
 # ifndef OPENSSL_NO_ENGINE
-int RAND_set_rand_engine(ENGINE *engine);
+OSSL_DEPRECATEDIN_3_0 int RAND_set_rand_engine(ENGINE *engine);
 # endif
-
-RAND_METHOD *RAND_OpenSSL(void);
+#endif
 
 # ifndef OPENSSL_NO_DEPRECATED_1_1_0
 #   define RAND_cleanup() while(0) continue

--- a/providers/implementations/rands/build.info
+++ b/providers/implementations/rands/build.info
@@ -3,4 +3,4 @@ SUBDIRS=seeding
 $COMMON=drbg.c test_rng.c drbg_ctr.c drbg_hash.c drbg_hmac.c crngt.c rand_pool.c
 
 SOURCE[../../libfips.a]=$COMMON
-SOURCE[../../libnonfips.a]=$COMMON
+SOURCE[../../libnonfips.a]=$COMMON fake.c

--- a/providers/implementations/rands/fake.c
+++ b/providers/implementations/rands/fake.c
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2020 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+/*
+ * A simple fake RNG for use in testing.  Not thread-safe.
+ */
+
+#include <string.h>
+#include <openssl/core_names.h>
+#include <crypto/rand.h>
+#include <crypto/rand.h>
+#include "drbg_local.h"
+
+typedef struct fake_rand_state_st {
+    const char *values;
+    int size;
+    int curr;
+} FAKE_RAND_STATE;
+
+static int get_ctx_params(void *ctx, OSSL_PARAM params[])
+{
+    OSSL_PARAM *p;
+
+    p = OSSL_PARAM_locate(params, OSSL_DRBG_PARAM_MAX_REQUEST);
+    if (p != NULL && !OSSL_PARAM_set_size_t(p, 255))
+        return 0;
+
+    return 1;
+}
+
+static int generate(void *vctx, unsigned char *out, size_t outlen,
+        unsigned int strength, int prediction_resistance,
+        const unsigned char *addin, size_t addin_len)
+{
+    FAKE_RAND_STATE *s = vctx;
+
+    if (s->values == NULL) {
+        unsigned char val = 1;
+
+        for (; outlen != 0; --outlen)
+            *out++ = val++;
+    } else {
+        for ( ; outlen != 0; --outlen) {
+            if (s->curr >= s->size)
+                s->curr = 0;
+            *out++ = s->values[s->curr++];
+        }
+    }
+    return 1;
+}
+
+static void freectx(void *vdrbg)
+{
+}
+
+EVP_RAND_CTX *RAND_make_fake(const char *values)
+{
+    static FAKE_RAND_STATE state;
+    static EVP_RAND method;
+    static EVP_RAND_CTX simple;
+
+    method.get_ctx_params = get_ctx_params;
+    method.freectx = freectx;
+    method.generate = generate;
+    state.values = values;
+    state.size = state.curr = 0;
+    if (values != NULL)
+        state.size = (int)strlen(values);
+    simple.meth = &method;
+    simple.data = &state;
+    simple.refcnt = 10; /* arbitrarily big */
+
+    return &simple;
+}

--- a/test/drbgtest.c
+++ b/test/drbgtest.c
@@ -7,6 +7,10 @@
  * https://www.openssl.org/source/license.html
  */
 
+#ifndef OPENSSL_NO_DEPRECATED_3_0
+# define OPENSSL_SUPPRESS_DEPRECATED
+#endif
+
 #include <string.h>
 #include "internal/nelem.h"
 #include <openssl/crypto.h>
@@ -45,6 +49,7 @@
  */
 static int gen_bytes(EVP_RAND_CTX *drbg, unsigned char *buf, int num)
 {
+#ifndef OPENSSL_NO_DEPRECATED_3_0
     const RAND_METHOD *meth = RAND_get_rand_method();
 
     if (meth != NULL && meth != RAND_OpenSSL()) {
@@ -52,6 +57,7 @@ static int gen_bytes(EVP_RAND_CTX *drbg, unsigned char *buf, int num)
             return meth->bytes(buf, num);
         return -1;
     }
+#endif
 
     if (drbg != NULL)
         return EVP_RAND_generate(drbg, buf, num, 0, 0, NULL, 0);
@@ -550,8 +556,10 @@ static int test_rand_reseed(void)
         return TEST_skip("CRNGT cannot be disabled");
 
     /* Check whether RAND_OpenSSL() is the default method */
+#ifndef OPENSSL_NO_DEPRECATED_3_0
     if (!TEST_ptr_eq(RAND_get_rand_method(), RAND_OpenSSL()))
         return 0;
+#endif
 
     /* All three DRBGs should be non-null */
     if (!TEST_ptr(primary = RAND_get0_primary(NULL))

--- a/test/ecdsatest.c
+++ b/test/ecdsatest.c
@@ -11,6 +11,8 @@
 /*
  * Low level APIs are deprecated for public use, but still ok for internal use.
  */
+#define OPENSSL_SUPPRESS_DEPRECATED
+#include <openssl/macros.h>
 #include "internal/deprecated.h"
 
 #include <openssl/opensslconf.h> /* To see if OPENSSL_NO_EC is defined */
@@ -25,11 +27,13 @@
 # include "internal/nelem.h"
 # include "ecdsatest.h"
 
+#ifndef OPENSSL_NO_DEPRECATED_3_0
 /* functions to change the RAND_METHOD */
 static int fbytes(unsigned char *buf, int num);
 
 static RAND_METHOD fake_rand;
 static const RAND_METHOD *old_rand;
+#endif
 static int use_fake = 0;
 static const char *numbers[2];
 static size_t crv_len = 0;
@@ -37,6 +41,7 @@ static EC_builtin_curve *curves = NULL;
 
 static int change_rand(void)
 {
+#ifndef OPENSSL_NO_DEPRECATED_3_0
     /* save old rand method */
     if (!TEST_ptr(old_rand = RAND_get_rand_method()))
         return 0;
@@ -47,16 +52,20 @@ static int change_rand(void)
     /* set new RAND_METHOD */
     if (!TEST_true(RAND_set_rand_method(&fake_rand)))
         return 0;
+#endif
     return 1;
 }
 
 static int restore_rand(void)
 {
+#ifndef OPENSSL_NO_DEPRECATED_3_0
     if (!TEST_true(RAND_set_rand_method(old_rand)))
         return 0;
+#endif
     return 1;
 }
 
+#ifndef OPENSSL_NO_DEPRECATED_3_0
 static int fbytes(unsigned char *buf, int num)
 {
     int ret = 0;
@@ -82,6 +91,7 @@ static int fbytes(unsigned char *buf, int num)
     BN_free(tmp);
     return ret;
 }
+#endif
 
 /*-
  * This function hijacks the RNG to feed it the chosen ECDSA key and nonce.

--- a/test/sm2_internal_test.c
+++ b/test/sm2_internal_test.c
@@ -10,6 +10,8 @@
 /*
  * Low level APIs are deprecated for public use, but still ok for internal use.
  */
+#define OPENSSL_SUPPRESS_DEPRECATED
+#include <openssl/macros.h>
 #include "internal/deprecated.h"
 
 #include <stdio.h>
@@ -28,8 +30,10 @@
 
 # include "crypto/sm2.h"
 
+# ifndef OPENSSL_NO_DEPRECATED_3_0
 static RAND_METHOD fake_rand;
 static const RAND_METHOD *saved_rand;
+#endif
 
 static uint8_t *fake_rand_bytes = NULL;
 static size_t fake_rand_bytes_offset = 0;

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -73,7 +73,7 @@ NETSCAPE_SPKI_print                     74	3_0_0	EXIST::FUNCTION:
 X509_set_pubkey                         75	3_0_0	EXIST::FUNCTION:
 ASN1_item_print                         76	3_0_0	EXIST::FUNCTION:
 CONF_set_nconf                          77	3_0_0	EXIST::FUNCTION:
-RAND_set_rand_method                    78	3_0_0	EXIST::FUNCTION:
+RAND_set_rand_method                    78	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
 BN_GF2m_mod_mul                         79	3_0_0	EXIST::FUNCTION:EC2M
 UI_add_input_boolean                    80	3_0_0	EXIST::FUNCTION:
 ASN1_TIME_adj                           81	3_0_0	EXIST::FUNCTION:
@@ -167,7 +167,7 @@ EVP_MD_type                             170	3_0_0	EXIST::FUNCTION:
 EVP_PKCS82PKEY                          171	3_0_0	EXIST::FUNCTION:
 BN_generate_prime_ex                    172	3_0_0	EXIST::FUNCTION:
 EVP_EncryptInit                         173	3_0_0	EXIST::FUNCTION:
-RAND_OpenSSL                            174	3_0_0	EXIST::FUNCTION:
+RAND_OpenSSL                            174	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
 BN_uadd                                 175	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_derive_init                    176	3_0_0	EXIST::FUNCTION:
 PEM_write_bio_ASN1_stream               177	3_0_0	EXIST::FUNCTION:
@@ -1397,7 +1397,7 @@ OCSP_RESPBYTES_it                       1429	3_0_0	EXIST::FUNCTION:OCSP
 EVP_aes_192_wrap                        1430	3_0_0	EXIST::FUNCTION:
 OCSP_CERTID_it                          1431	3_0_0	EXIST::FUNCTION:OCSP
 ENGINE_get_RSA                          1432	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,ENGINE
-RAND_get_rand_method                    1433	3_0_0	EXIST::FUNCTION:
+RAND_get_rand_method                    1433	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
 ERR_load_DSA_strings                    1434	3_0_0	EXIST::FUNCTION:DSA
 ASN1_check_infinite_end                 1435	3_0_0	EXIST::FUNCTION:
 i2d_PKCS7_DIGEST                        1436	3_0_0	EXIST::FUNCTION:
@@ -1746,7 +1746,7 @@ NAME_CONSTRAINTS_check                  1786	3_0_0	EXIST::FUNCTION:
 X509_CERT_AUX_it                        1787	3_0_0	EXIST::FUNCTION:
 X509_get_X509_PUBKEY                    1789	3_0_0	EXIST::FUNCTION:
 TXT_DB_create_index                     1790	3_0_0	EXIST::FUNCTION:
-RAND_set_rand_engine                    1791	3_0_0	EXIST::FUNCTION:ENGINE
+RAND_set_rand_engine                    1791	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,ENGINE
 X509_set_serialNumber                   1792	3_0_0	EXIST::FUNCTION:
 BN_mod_exp_mont_consttime               1793	3_0_0	EXIST::FUNCTION:
 X509V3_parse_list                       1794	3_0_0	EXIST::FUNCTION:


### PR DESCRIPTION
Fixes: 13126

@slontis, can you point me to what needs to be done to fix ```fuzz/rand.inc```, the way you did for some other tests?