### PR TITLE
Implement OpenSSL secure memory for Windows

### DIFF
--- a/crypto/mem_sec.c
+++ b/crypto/mem_sec.c
@@ -21,11 +21,18 @@
 #include <string.h>
 
 #ifndef OPENSSL_NO_SECURE_MEMORY
+# if defined(_WIN32)
+#  include <windows.h>
+# endif
 # include <stdlib.h>
 # include <assert.h>
+# if defined(OPENSSL_SYS_UNIX)
 # include <unistd.h>
+# endif
 # include <sys/types.h>
+# if defined(OPENSSL_SYS_UNIX)
 # include <sys/mman.h>
+# endif
 # if defined(OPENSSL_SYS_LINUX)
 #  include <sys/syscall.h>
 #  if defined(SYS_mlock2)
@@ -375,6 +382,10 @@ static int sh_init(size_t size, size_t minsize)
     size_t i;
     size_t pgsize;
     size_t aligned;
+#if defined(_WIN32)
+    DWORD flOldProtect;
+    SYSTEM_INFO systemInfo;
+#endif
 
     memset(&sh, 0, sizeof(sh));
 
@@ -446,15 +457,19 @@ static int sh_init(size_t size, size_t minsize)
         else
             pgsize = (size_t)tmppgsize;
     }
+#elif defined(_WIN32)
+    GetSystemInfo(&systemInfo);
+    pgsize = (size_t)systemInfo.dwPageSize;
 #else
     pgsize = PAGE_SIZE;
 #endif
     sh.map_size = pgsize + sh.arena_size + pgsize;
 
-#ifdef MAP_ANON
+#if !defined(_WIN32)
+# ifdef MAP_ANON
     sh.map_result = mmap(NULL, sh.map_size,
                          PROT_READ|PROT_WRITE, MAP_ANON|MAP_PRIVATE, -1, 0);
-#else
+# else
     {
         int fd;
 
@@ -465,9 +480,18 @@ static int sh_init(size_t size, size_t minsize)
             close(fd);
         }
     }
-#endif
+# endif
     if (sh.map_result == MAP_FAILED)
         goto err;
+#else
+    sh.map_result = VirtualAlloc(NULL, sh.map_size, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
+
+    if (sh.map_result == NULL)
+            goto err;
+
+    memset(sh.map_result, 0, sh.map_size);
+#endif
+
     sh.arena = (char *)(sh.map_result + pgsize);
     sh_setbit(sh.arena, 0, sh.bittable);
     sh_add_to_list(&sh.freelist[0], sh.arena);
@@ -475,14 +499,24 @@ static int sh_init(size_t size, size_t minsize)
     /* Now try to add guard pages and lock into memory. */
     ret = 1;
 
+#if !defined(_WIN32)
     /* Starting guard is already aligned from mmap. */
     if (mprotect(sh.map_result, pgsize, PROT_NONE) < 0)
         ret = 2;
+#else
+    if (VirtualProtect(sh.map_result, pgsize, PAGE_NOACCESS, &flOldProtect) == FALSE)
+        ret = 2;
+#endif
 
     /* Ending guard page - need to round up to page boundary */
     aligned = (pgsize + sh.arena_size + (pgsize - 1)) & ~(pgsize - 1);
+#if !defined(_WIN32)
     if (mprotect(sh.map_result + aligned, pgsize, PROT_NONE) < 0)
         ret = 2;
+#else
+    if (VirtualProtect(sh.map_result + aligned, pgsize, PAGE_NOACCESS, &flOldProtect) == FALSE)
+        ret = 2;
+#endif
 
 #if defined(OPENSSL_SYS_LINUX) && defined(MLOCK_ONFAULT) && defined(SYS_mlock2)
     if (syscall(SYS_mlock2, sh.arena, sh.arena_size, MLOCK_ONFAULT) < 0) {
@@ -493,6 +527,9 @@ static int sh_init(size_t size, size_t minsize)
             ret = 2;
         }
     }
+#elif defined(_WIN32)
+    if (VirtualLock(sh.arena, sh.arena_size) == FALSE)
+        ret = 2;
 #else
     if (mlock(sh.arena, sh.arena_size) < 0)
         ret = 2;
@@ -514,8 +551,13 @@ static void sh_done(void)
     OPENSSL_free(sh.freelist);
     OPENSSL_free(sh.bittable);
     OPENSSL_free(sh.bitmalloc);
+#if !defined(_WIN32)
     if (sh.map_result != MAP_FAILED && sh.map_size)
         munmap(sh.map_result, sh.map_size);
+#else
+    if (sh.map_result != NULL && sh.map_size)
+        VirtualFree(sh.map_result, 0, MEM_RELEASE);
+#endif
     memset(&sh, 0, sizeof(sh));
 }
 

--- a/crypto/mem_sec.c
+++ b/crypto/mem_sec.c
@@ -488,8 +488,6 @@ static int sh_init(size_t size, size_t minsize)
 
     if (sh.map_result == NULL)
             goto err;
-
-    memset(sh.map_result, 0, sh.map_size);
 #endif
 
     sh.arena = (char *)(sh.map_result + pgsize);

--- a/crypto/mem_sec.c
+++ b/crypto/mem_sec.c
@@ -27,11 +27,11 @@
 # include <stdlib.h>
 # include <assert.h>
 # if defined(OPENSSL_SYS_UNIX)
-# include <unistd.h>
+#  include <unistd.h>
 # endif
 # include <sys/types.h>
 # if defined(OPENSSL_SYS_UNIX)
-# include <sys/mman.h>
+#  include <sys/mman.h>
 # endif
 # if defined(OPENSSL_SYS_LINUX)
 #  include <sys/syscall.h>

--- a/e_os.h
+++ b/e_os.h
@@ -360,9 +360,9 @@ inline int nssgetpid();
 # ifndef OPENSSL_NO_SECURE_MEMORY
    /* unistd.h defines _POSIX_VERSION */
 #  if (defined(OPENSSL_SYS_UNIX) \
-      && ( (defined(_POSIX_VERSION) && _POSIX_VERSION >= 200112L)      \
+        && ( (defined(_POSIX_VERSION) && _POSIX_VERSION >= 200112L)      \
              || defined(__sun) || defined(__hpux) || defined(__sgi)      \
-             || defined(__osf__) ))
+             || defined(__osf__) )) \
       || defined(_WIN32)
       /* secure memory is implemented */
 #   else

--- a/e_os.h
+++ b/e_os.h
@@ -359,10 +359,10 @@ inline int nssgetpid();
 
 # ifndef OPENSSL_NO_SECURE_MEMORY
    /* unistd.h defines _POSIX_VERSION */
-#  if defined(OPENSSL_SYS_UNIX) \
+#  if (defined(OPENSSL_SYS_UNIX) \
       && ( (defined(_POSIX_VERSION) && _POSIX_VERSION >= 200112L)      \
            || defined(__sun) || defined(__hpux) || defined(__sgi)      \
-           || defined(__osf__) )
+           || defined(__osf__) )) || defined(_WIN32)
       /* secure memory is implemented */
 #   else
 #     define OPENSSL_NO_SECURE_MEMORY

--- a/e_os.h
+++ b/e_os.h
@@ -361,8 +361,9 @@ inline int nssgetpid();
    /* unistd.h defines _POSIX_VERSION */
 #  if (defined(OPENSSL_SYS_UNIX) \
       && ( (defined(_POSIX_VERSION) && _POSIX_VERSION >= 200112L)      \
-           || defined(__sun) || defined(__hpux) || defined(__sgi)      \
-           || defined(__osf__) )) || defined(_WIN32)
+             || defined(__sun) || defined(__hpux) || defined(__sgi)      \
+             || defined(__osf__) ))
+      || defined(_WIN32)
       /* secure memory is implemented */
 #   else
 #     define OPENSSL_NO_SECURE_MEMORY


### PR DESCRIPTION
Hello, please review this pull request implementing CRYPTO_secure_malloc and the associated functions for the Windows platform using equivalent functions such as VirtualAlloc for mmap, etc.  Thank you.

##### Checklist

Documentation for CRYPTO_secure_malloc(3) doesn't seem to mention which platforms are and are not supported, so I do not believe any update is required.

Existing secmemtest should cover Windows implementation
