### PR TITLE
Implement OpenSSL secure memory for Windows on 1.1.1

### DIFF
--- a/crypto/mem_sec.c
+++ b/crypto/mem_sec.c
@@ -479,8 +479,6 @@ static int sh_init(size_t size, int minsize)
 
     if (sh.map_result == NULL)
             goto err;
-
-    memset(sh.map_result, 0, sh.map_size);
 #endif
 
     sh.arena = (char *)(sh.map_result + pgsize);

--- a/crypto/mem_sec.c
+++ b/crypto/mem_sec.c
@@ -28,11 +28,11 @@
 # include <stdlib.h>
 # include <assert.h>
 # if defined(OPENSSL_SYS_UNIX)
-# include <unistd.h>
+#  include <unistd.h>
 # endif
 # include <sys/types.h>
 # if defined(OPENSSL_SYS_UNIX)
-# include <sys/mman.h>
+#  include <sys/mman.h>
 # endif
 # if defined(OPENSSL_SYS_LINUX)
 #  include <sys/syscall.h>
@@ -42,7 +42,7 @@
 #  endif
 # endif
 # if defined(OPENSSL_SYS_UNIX)
-# include <sys/param.h>
+#  include <sys/param.h>
 # endif
 # include <sys/stat.h>
 # include <fcntl.h>

--- a/crypto/mem_sec.c
+++ b/crypto/mem_sec.c
@@ -22,11 +22,18 @@
 
 /* e_os.h defines OPENSSL_SECURE_MEMORY if secure memory can be implemented */
 #ifdef OPENSSL_SECURE_MEMORY
+# if defined(_WIN32)
+#  include <windows.h>
+# endif
 # include <stdlib.h>
 # include <assert.h>
+# if defined(OPENSSL_SYS_UNIX)
 # include <unistd.h>
+# endif
 # include <sys/types.h>
+# if defined(OPENSSL_SYS_UNIX)
 # include <sys/mman.h>
+# endif
 # if defined(OPENSSL_SYS_LINUX)
 #  include <sys/syscall.h>
 #  if defined(SYS_mlock2)
@@ -34,7 +41,9 @@
 #   include <errno.h>
 #  endif
 # endif
+# if defined(OPENSSL_SYS_UNIX)
 # include <sys/param.h>
+# endif
 # include <sys/stat.h>
 # include <fcntl.h>
 #endif
@@ -379,6 +388,10 @@ static int sh_init(size_t size, int minsize)
     size_t i;
     size_t pgsize;
     size_t aligned;
+#if defined(_WIN32)
+    DWORD flOldProtect;
+    SYSTEM_INFO systemInfo;
+#endif
 
     memset(&sh, 0, sizeof(sh));
 
@@ -435,16 +448,20 @@ static int sh_init(size_t size, int minsize)
         else
             pgsize = (size_t)tmppgsize;
     }
+#elif defined(_WIN32)
+    GetSystemInfo(&systemInfo);
+    pgsize = (size_t)systemInfo.dwPageSize;
 #else
     pgsize = PAGE_SIZE;
 #endif
     sh.map_size = pgsize + sh.arena_size + pgsize;
+#if !defined(_WIN32)
     if (1) {
-#ifdef MAP_ANON
+# ifdef MAP_ANON
         sh.map_result = mmap(NULL, sh.map_size,
                              PROT_READ|PROT_WRITE, MAP_ANON|MAP_PRIVATE, -1, 0);
     } else {
-#endif
+# endif
         int fd;
 
         sh.map_result = MAP_FAILED;
@@ -454,8 +471,18 @@ static int sh_init(size_t size, int minsize)
             close(fd);
         }
     }
+
     if (sh.map_result == MAP_FAILED)
         goto err;
+#else
+    sh.map_result = VirtualAlloc(NULL, sh.map_size, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
+
+    if (sh.map_result == NULL)
+            goto err;
+
+    memset(sh.map_result, 0, sh.map_size);
+#endif
+
     sh.arena = (char *)(sh.map_result + pgsize);
     sh_setbit(sh.arena, 0, sh.bittable);
     sh_add_to_list(&sh.freelist[0], sh.arena);
@@ -463,14 +490,24 @@ static int sh_init(size_t size, int minsize)
     /* Now try to add guard pages and lock into memory. */
     ret = 1;
 
+#if !defined(_WIN32)
     /* Starting guard is already aligned from mmap. */
     if (mprotect(sh.map_result, pgsize, PROT_NONE) < 0)
         ret = 2;
+#else
+    if (VirtualProtect(sh.map_result, pgsize, PAGE_NOACCESS, &flOldProtect) == FALSE)
+        ret = 2;
+#endif
 
     /* Ending guard page - need to round up to page boundary */
     aligned = (pgsize + sh.arena_size + (pgsize - 1)) & ~(pgsize - 1);
+#if !defined(_WIN32)
     if (mprotect(sh.map_result + aligned, pgsize, PROT_NONE) < 0)
         ret = 2;
+#else
+    if (VirtualProtect(sh.map_result + aligned, pgsize, PAGE_NOACCESS, &flOldProtect) == FALSE)
+        ret = 2;
+#endif
 
 #if defined(OPENSSL_SYS_LINUX) && defined(MLOCK_ONFAULT) && defined(SYS_mlock2)
     if (syscall(SYS_mlock2, sh.arena, sh.arena_size, MLOCK_ONFAULT) < 0) {
@@ -481,6 +518,9 @@ static int sh_init(size_t size, int minsize)
             ret = 2;
         }
     }
+#elif defined(_WIN32)
+    if (VirtualLock(sh.arena, sh.arena_size) == FALSE)
+        ret = 2;
 #else
     if (mlock(sh.arena, sh.arena_size) < 0)
         ret = 2;
@@ -502,8 +542,13 @@ static void sh_done(void)
     OPENSSL_free(sh.freelist);
     OPENSSL_free(sh.bittable);
     OPENSSL_free(sh.bitmalloc);
+#if !defined(_WIN32)
     if (sh.map_result != MAP_FAILED && sh.map_size)
         munmap(sh.map_result, sh.map_size);
+#else
+    if (sh.map_result != NULL && sh.map_size)
+        VirtualFree(sh.map_result, 0, MEM_RELEASE);
+#endif
     memset(&sh, 0, sizeof(sh));
 }
 

--- a/e_os.h
+++ b/e_os.h
@@ -350,10 +350,10 @@ struct servent *getservbyname(const char *name, const char *proto);
 # endif
 
 /* unistd.h defines _POSIX_VERSION */
-# if !defined(OPENSSL_NO_SECURE_MEMORY) && defined(OPENSSL_SYS_UNIX) \
+# if !defined(OPENSSL_NO_SECURE_MEMORY) && ( ( defined(OPENSSL_SYS_UNIX) \
      && ( (defined(_POSIX_VERSION) && _POSIX_VERSION >= 200112L)      \
           || defined(__sun) || defined(__hpux) || defined(__sgi)      \
-          || defined(__osf__) )
+          || defined(__osf__) ) ) || defined(_WIN32) )
 #  define OPENSSL_SECURE_MEMORY  /* secure memory is implemented */
 # endif
 #endif


### PR DESCRIPTION
NOTE: This is a backport of #13172 to 1.1.1.  I'm not sure if this is a candidate for backport, but if it is I'd like to submit it.

Hello, please review this pull request implementing CRYPTO_secure_malloc and the associated functions for the Windows platform using equivalent functions such as VirtualAlloc for mmap, etc. Thank you.

Checklist
Documentation for CRYPTO_secure_malloc(3) doesn't seem to mention which platforms are and are not supported, so I do not believe any update is required.

Existing secmemtest should cover Windows implementation