### PR TITLE
APPS: Implement load_keyparams() to load key parameters

### DIFF
--- a/apps/cmp.c
+++ b/apps/cmp.c
@@ -724,7 +724,7 @@ static int load_cert_certs(const char *uri,
         return ret;
     }
     pass_string = get_passwd(pass, desc);
-    ret = load_key_certs_crls(uri, 0, pass_string, desc, NULL, NULL,
+    ret = load_key_certs_crls(uri, 0, pass_string, desc, NULL, NULL, NULL,
                               pcert, pcerts, NULL, NULL);
     clear_free(pass_string);
 

--- a/apps/include/apps.h
+++ b/apps/include/apps.h
@@ -116,6 +116,7 @@ EVP_PKEY *load_key(const char *uri, int format, int maybe_stdin,
                    const char *pass, ENGINE *e, const char *desc);
 EVP_PKEY *load_pubkey(const char *uri, int format, int maybe_stdin,
                       const char *pass, ENGINE *e, const char *desc);
+EVP_PKEY *load_keyparams(const char *uri, int maybe_stdin, const char *desc);
 int load_certs(const char *uri, STACK_OF(X509) **certs,
                const char *pass, const char *desc);
 int load_crls(const char *uri, STACK_OF(X509_CRL) **crls,
@@ -123,6 +124,7 @@ int load_crls(const char *uri, STACK_OF(X509_CRL) **crls,
 int load_key_certs_crls(const char *uri, int maybe_stdin,
                         const char *pass, const char *desc,
                         EVP_PKEY **ppkey, EVP_PKEY **ppubkey,
+                        EVP_PKEY **pparams,
                         X509 **pcert, STACK_OF(X509) **pcerts,
                         X509_CRL **pcrl, STACK_OF(X509_CRL) **pcrls);
 int load_key_cert_crl(const char *uri, int maybe_stdin,

--- a/doc/man1/openssl-dsaparam.pod.in
+++ b/doc/man1/openssl-dsaparam.pod.in
@@ -40,7 +40,7 @@ Print out a usage message.
 
 =item B<-inform> B<DER>|B<PEM>, B<-outform> B<DER>|B<PEM>
 
-The input and formats; the default is B<PEM>.
+This option has become obsolete.
 See L<openssl(1)/Format Options> for details.
 
 Parameters are a sequence of B<ASN.1 INTEGER>s: B<p>, B<q>, and B<g>.


### PR DESCRIPTION
'openssl dsaparam' is affected as an obvious usage example.
