### PR TITLE
Fix AES-GCM bug on aarch64 BigEndian

### DIFF
--- a/crypto/aes/asm/aesv8-armx.pl
+++ b/crypto/aes/asm/aesv8-armx.pl
@@ -183,7 +183,12 @@ $code.=<<___;
 .Loop192:
 	vtbl.8	$key,{$in1},$mask
 	vext.8	$tmp,$zero,$in0,#12
+#ifdef __ARMEB__
+	vst1.32	{$in1},[$out],#16
+	sub	$out,$out,#8
+#else
 	vst1.32	{$in1},[$out],#8
+#endif
 	aese	$key,$zero
 	subs	$bits,$bits,#1
 
@@ -715,8 +720,11 @@ $code.=<<___;
 	ldr		$rounds,[$key,#240]
 
 	ldr		$ctr, [$ivp, #12]
+#ifdef __ARMEB__
+	vld1.8		{$dat0},[$ivp]
+#else
 	vld1.32		{$dat0},[$ivp]
-
+#endif
 	vld1.32		{q8-q9},[$key]		// load key schedule...
 	sub		$rounds,$rounds,#4
 	mov		$step,#16

--- a/crypto/modes/modes_local.h
+++ b/crypto/modes/modes_local.h
@@ -63,12 +63,15 @@ typedef u32 u32_a1;
                         asm ("bswapl %0"                \
                         : "+r"(ret_));   ret_;          })
 #  elif defined(__aarch64__)
-#   define BSWAP8(x) ({ u64 ret_;                       \
+#   if defined(__BYTE_ORDER__) && defined(__ORDER_LITTLE_ENDIAN__) && \
+       __BYTE_ORDER__==__ORDER_LITTLE_ENDIAN__
+#    define BSWAP8(x) ({ u64 ret_;                       \
                         asm ("rev %0,%1"                \
                         : "=r"(ret_) : "r"(x)); ret_;   })
-#   define BSWAP4(x) ({ u32 ret_;                       \
+#    define BSWAP4(x) ({ u32 ret_;                       \
                         asm ("rev %w0,%w1"              \
                         : "=r"(ret_) : "r"(x)); ret_;   })
+#   endif
 #  elif (defined(__arm__) || defined(__arm)) && !defined(STRICT_ALIGNMENT)
 #   define BSWAP8(x) ({ u32 lo_=(u64)(x)>>32,hi_=(x);   \
                         asm ("rev %0,%0; rev %1,%1"     \


### PR DESCRIPTION
Fixes #10638
Fixes #13188

Fixes a bug for aarch64 bigendian with instructions 'st1' and 'ld1' on AES-GCM mode.

CLA: trivial

(cherry picked from commit bc8b648f744566031ce84d77333dbbcb9689e975)
