### PR TITLE
Avoid potential doublefree on dh object assigned to EVP_PKEY

### DIFF
--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -2150,6 +2150,7 @@ static int tls_process_ske_dhe(SSL *s, PACKET *pkt, EVP_PKEY **pkey)
                  ERR_R_EVP_LIB);
         goto err;
     }
+    dh = NULL;
 
     if (!ssl_security(s, SSL_SECOP_TMP_DH, EVP_PKEY_security_bits(peer_tmp),
                       0, peer_tmp)) {


### PR DESCRIPTION
Fixes regression from 7844f3c784bfc93c9b94ae5a4082f9d01e82e0af
