### PR TITLE
Constify OSSL_FUNC_keymgmt_has()

### DIFF
--- a/doc/man7/provider-keymgmt.pod
+++ b/doc/man7/provider-keymgmt.pod
@@ -36,7 +36,7 @@ provider-keymgmt - The KEYMGMT library E<lt>-E<gt> provider functions
  const OSSL_PARAM *OSSL_FUNC_keymgmt_settable_params(void *provctx);
 
  /* Key object content checks */
- int OSSL_FUNC_keymgmt_has(void *keydata, int selection);
+ int OSSL_FUNC_keymgmt_has(const void *keydata, int selection);
  int OSSL_FUNC_keymgmt_match(const void *keydata1, const void *keydata2,
                              int selection);
 

--- a/include/openssl/core_dispatch.h
+++ b/include/openssl/core_dispatch.h
@@ -530,7 +530,7 @@ OSSL_CORE_MAKE_FUNC(const char *, keymgmt_query_operation_name,
 
 /* Key checks - key data content checks */
 # define OSSL_FUNC_KEYMGMT_HAS                        21
-OSSL_CORE_MAKE_FUNC(int, keymgmt_has, (void *keydata, int selection))
+OSSL_CORE_MAKE_FUNC(int, keymgmt_has, (const void *keydata, int selection))
 
 /* Key checks - validation */
 # define OSSL_FUNC_KEYMGMT_VALIDATE                   22

--- a/providers/implementations/keymgmt/dh_kmgmt.c
+++ b/providers/implementations/keymgmt/dh_kmgmt.c
@@ -143,9 +143,9 @@ static void dh_freedata(void *keydata)
     DH_free(keydata);
 }
 
-static int dh_has(void *keydata, int selection)
+static int dh_has(const void *keydata, int selection)
 {
-    DH *dh = keydata;
+    const DH *dh = keydata;
     int ok = 0;
 
     if (ossl_prov_is_running() && dh != NULL) {

--- a/providers/implementations/keymgmt/dsa_kmgmt.c
+++ b/providers/implementations/keymgmt/dsa_kmgmt.c
@@ -121,9 +121,9 @@ static void dsa_freedata(void *keydata)
     DSA_free(keydata);
 }
 
-static int dsa_has(void *keydata, int selection)
+static int dsa_has(const void *keydata, int selection)
 {
-    DSA *dsa = keydata;
+    const DSA *dsa = keydata;
     int ok = 0;
 
     if (ossl_prov_is_running() && dsa != NULL) {

--- a/providers/implementations/keymgmt/ec_kmgmt.c
+++ b/providers/implementations/keymgmt/ec_kmgmt.c
@@ -246,9 +246,9 @@ void ec_freedata(void *keydata)
 }
 
 static
-int ec_has(void *keydata, int selection)
+int ec_has(const void *keydata, int selection)
 {
-    EC_KEY *ec = keydata;
+    const EC_KEY *ec = keydata;
     int ok = 0;
 
     if (ossl_prov_is_running() && ec != NULL) {

--- a/providers/implementations/keymgmt/ecx_kmgmt.c
+++ b/providers/implementations/keymgmt/ecx_kmgmt.c
@@ -113,9 +113,9 @@ static void *ed448_new_key(void *provctx)
                        NULL);
 }
 
-static int ecx_has(void *keydata, int selection)
+static int ecx_has(const void *keydata, int selection)
 {
-    ECX_KEY *key = keydata;
+    const ECX_KEY *key = keydata;
     int ok = 0;
 
     if (ossl_prov_is_running() && key != NULL) {

--- a/providers/implementations/keymgmt/kdf_legacy_kmgmt.c
+++ b/providers/implementations/keymgmt/kdf_legacy_kmgmt.c
@@ -91,7 +91,7 @@ static void kdf_freedata(void *kdfdata)
     kdf_data_free(kdfdata);
 }
 
-static int kdf_has(void *keydata, int selection)
+static int kdf_has(const void *keydata, int selection)
 {
     return 0;
 }

--- a/providers/implementations/keymgmt/mac_legacy_kmgmt.c
+++ b/providers/implementations/keymgmt/mac_legacy_kmgmt.c
@@ -131,9 +131,9 @@ static void mac_free(void *mackey)
     mac_key_free(mackey);
 }
 
-static int mac_has(void *keydata, int selection)
+static int mac_has(const void *keydata, int selection)
 {
-    MAC_KEY *key = keydata;
+    const MAC_KEY *key = keydata;
     int ok = 0;
 
     if (ossl_prov_is_running() && key != NULL) {

--- a/providers/implementations/keymgmt/rsa_kmgmt.c
+++ b/providers/implementations/keymgmt/rsa_kmgmt.c
@@ -108,9 +108,9 @@ static void rsa_freedata(void *keydata)
     RSA_free(keydata);
 }
 
-static int rsa_has(void *keydata, int selection)
+static int rsa_has(const void *keydata, int selection)
 {
-    RSA *rsa = keydata;
+    const RSA *rsa = keydata;
     int ok = 0;
 
     if (rsa != NULL && ossl_prov_is_running()) {

--- a/test/tls-provider.c
+++ b/test/tls-provider.c
@@ -418,9 +418,9 @@ static void xor_freedata(void *keydata)
     OPENSSL_free(keydata);
 }
 
-static int xor_has(void *vkey, int selection)
+static int xor_has(const void *vkey, int selection)
 {
-    XORKEY *key = vkey;
+    const XORKEY *key = vkey;
     int ok = 0;
 
     if (key != NULL) {


### PR DESCRIPTION
The keydata argument of `OSSL_FUNC_keymgmt_has()` should be read-only.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
