### PR TITLE
Constify OSSL_FUNC_keymgmt_validate()

### DIFF
--- a/crypto/dh/dh_check.c
+++ b/crypto/dh/dh_check.c
@@ -281,7 +281,7 @@ err:
  * FFC pairwise check from SP800-56A R3.
  *    Section 5.6.2.1.4 Owner Assurance of Pair-wise Consistency
  */
-int dh_check_pairwise(DH *dh)
+int dh_check_pairwise(const DH *dh)
 {
     int ret = 0;
     BN_CTX *ctx = NULL;

--- a/crypto/dh/dh_key.c
+++ b/crypto/dh/dh_key.c
@@ -182,7 +182,7 @@ int DH_generate_key(DH *dh)
 #endif
 }
 
-int dh_generate_public_key(BN_CTX *ctx, DH *dh, const BIGNUM *priv_key,
+int dh_generate_public_key(BN_CTX *ctx, const DH *dh, const BIGNUM *priv_key,
                            BIGNUM *pub_key)
 {
     int ret = 0;
@@ -193,8 +193,16 @@ int dh_generate_public_key(BN_CTX *ctx, DH *dh, const BIGNUM *priv_key,
         return 0;
 
     if (dh->flags & DH_FLAG_CACHE_MONT_P) {
-        mont = BN_MONT_CTX_set_locked(&dh->method_mont_p,
-                                      dh->lock, dh->params.p, ctx);
+        /*
+         * We take the input DH as const, but we lie, because in some cases we
+         * want to get a hold of its Montgomery context.
+         *
+         * We cast to remove the const qualifier in this case, it should be
+         * fine...
+         */
+        BN_MONT_CTX **pmont = (BN_MONT_CTX **)&dh->method_mont_p;
+
+        mont = BN_MONT_CTX_set_locked(pmont, dh->lock, dh->params.p, ctx);
         if (mont == NULL)
             goto err;
     }

--- a/doc/man7/provider-keymgmt.pod
+++ b/doc/man7/provider-keymgmt.pod
@@ -54,7 +54,7 @@ provider-keymgmt - The KEYMGMT library E<lt>-E<gt> provider functions
  int OSSL_FUNC_keymgmt_copy(void *keydata_to, const void *keydata_from, int selection);
 
  /* Key object validation */
- int OSSL_FUNC_keymgmt_validate(void *keydata, int selection);
+ int OSSL_FUNC_keymgmt_validate(const void *keydata, int selection);
 
 =head1 DESCRIPTION
 

--- a/include/crypto/dh.h
+++ b/include/crypto/dh.h
@@ -17,7 +17,7 @@ DH *dh_new_ex(OSSL_LIB_CTX *libctx);
 
 int dh_generate_ffc_parameters(DH *dh, int type, int pbits, int qbits,
                                BN_GENCB *cb);
-int dh_generate_public_key(BN_CTX *ctx, DH *dh, const BIGNUM *priv_key,
+int dh_generate_public_key(BN_CTX *ctx, const DH *dh, const BIGNUM *priv_key,
                            BIGNUM *pub_key);
 int dh_get_named_group_uid_from_size(int pbits);
 const char *dh_gen_type_id2name(int id);
@@ -32,7 +32,7 @@ int dh_key_todata(DH *dh, OSSL_PARAM_BLD *bld, OSSL_PARAM params[]);
 
 int dh_check_pub_key_partial(const DH *dh, const BIGNUM *pub_key, int *ret);
 int dh_check_priv_key(const DH *dh, const BIGNUM *priv_key, int *ret);
-int dh_check_pairwise(DH *dh);
+int dh_check_pairwise(const DH *dh);
 
 const DH_METHOD *dh_get_method(const DH *dh);
 

--- a/include/openssl/core_dispatch.h
+++ b/include/openssl/core_dispatch.h
@@ -534,7 +534,7 @@ OSSL_CORE_MAKE_FUNC(int, keymgmt_has, (void *keydata, int selection))
 
 /* Key checks - validation */
 # define OSSL_FUNC_KEYMGMT_VALIDATE                   22
-OSSL_CORE_MAKE_FUNC(int, keymgmt_validate, (void *keydata, int selection))
+OSSL_CORE_MAKE_FUNC(int, keymgmt_validate, (const void *keydata, int selection))
 
 /* Key checks - matching */
 # define OSSL_FUNC_KEYMGMT_MATCH                      23

--- a/providers/implementations/keymgmt/dh_kmgmt.c
+++ b/providers/implementations/keymgmt/dh_kmgmt.c
@@ -363,7 +363,7 @@ static int dh_set_params(void *key, const OSSL_PARAM params[])
     return 1;
 }
 
-static int dh_validate_public(DH *dh)
+static int dh_validate_public(const DH *dh)
 {
     const BIGNUM *pub_key = NULL;
 
@@ -373,7 +373,7 @@ static int dh_validate_public(DH *dh)
     return DH_check_pub_key_ex(dh, pub_key);
 }
 
-static int dh_validate_private(DH *dh)
+static int dh_validate_private(const DH *dh)
 {
     int status = 0;
     const BIGNUM *priv_key = NULL;
@@ -384,9 +384,9 @@ static int dh_validate_private(DH *dh)
     return dh_check_priv_key(dh, priv_key, &status);;
 }
 
-static int dh_validate(void *keydata, int selection)
+static int dh_validate(const void *keydata, int selection)
 {
-    DH *dh = keydata;
+    const DH *dh = keydata;
     int ok = 0;
 
     if (!ossl_prov_is_running())

--- a/providers/implementations/keymgmt/dsa_kmgmt.c
+++ b/providers/implementations/keymgmt/dsa_kmgmt.c
@@ -305,14 +305,14 @@ static const OSSL_PARAM *dsa_gettable_params(void *provctx)
     return dsa_params;
 }
 
-static int dsa_validate_domparams(DSA *dsa)
+static int dsa_validate_domparams(const DSA *dsa)
 {
     int status = 0;
 
     return dsa_check_params(dsa, &status);
 }
 
-static int dsa_validate_public(DSA *dsa)
+static int dsa_validate_public(const DSA *dsa)
 {
     int status = 0;
     const BIGNUM *pub_key = NULL;
@@ -323,7 +323,7 @@ static int dsa_validate_public(DSA *dsa)
     return dsa_check_pub_key(dsa, pub_key, &status);
 }
 
-static int dsa_validate_private(DSA *dsa)
+static int dsa_validate_private(const DSA *dsa)
 {
     int status = 0;
     const BIGNUM *priv_key = NULL;
@@ -334,9 +334,9 @@ static int dsa_validate_private(DSA *dsa)
     return dsa_check_priv_key(dsa, priv_key, &status);
 }
 
-static int dsa_validate(void *keydata, int selection)
+static int dsa_validate(const void *keydata, int selection)
 {
-    DSA *dsa = keydata;
+    const DSA *dsa = keydata;
     int ok = 0;
 
     if (!ossl_prov_is_running())

--- a/providers/implementations/keymgmt/ec_kmgmt.c
+++ b/providers/implementations/keymgmt/ec_kmgmt.c
@@ -785,9 +785,9 @@ const OSSL_PARAM *sm2_settable_params(ossl_unused void *provctx)
 #endif
 
 static
-int ec_validate(void *keydata, int selection)
+int ec_validate(const void *keydata, int selection)
 {
-    EC_KEY *eck = keydata;
+    const EC_KEY *eck = keydata;
     int ok = 0;
     BN_CTX *ctx = NULL;
 

--- a/providers/implementations/keymgmt/rsa_kmgmt.c
+++ b/providers/implementations/keymgmt/rsa_kmgmt.c
@@ -357,9 +357,9 @@ static const OSSL_PARAM *rsa_gettable_params(void *provctx)
     return rsa_params;
 }
 
-static int rsa_validate(void *keydata, int selection)
+static int rsa_validate(const void *keydata, int selection)
 {
-    RSA *rsa = keydata;
+    const RSA *rsa = keydata;
     int ok = 0;
 
     if (!ossl_prov_is_running())


### PR DESCRIPTION
The keydata argument of `OSSL_FUNC_keymgmt_validate()` should be read-only.

Followup from #13200 , but this is more involved because with `DH` keys we lie a bit and we need to cast and discard the qualifier when grabbing the inner Montgomery context.

Operating on the Montgomery context should not alter the contents of the `DH` key, so I believe it is appropriate to lie here and cast away the `const` for that struct field.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
