### PR TITLE
Fix extended tests before beta1

### DIFF
--- a/dev/.FORCE_EXTENDED_TESTS
+++ b/dev/.FORCE_EXTENDED_TESTS
@@ -1,0 +1,10 @@
+This file accomplishes nothing, other than ensuring this commit is not empty and
+CI steps over it.
+
+To trigger extended tests the important bit is including the line
+
+~~~
+[extended tests]
+~~~
+
+in the body of a commit message.


### PR DESCRIPTION
As part of ongoing OTC discussions, one item that nobody ever opposed is that builds shouldn't be failing for some period of time before the release.

This PR is to track the state of our builds in combination with the `[extended tests]` tag.

Any Committer should feel free to rebase this PR on latest `master` and push to my branch to update this PR.

This PR is tracking the **issues** not the solutions: feel free to spawn separate PRs to address the issues detected by the CI in the builds of this PR, and link to them in a comment: it would be nice if after a PR fixing one of the problems is merged to `master` you could also rebase this PR and force-push, so we can keep track of other potentially undetected issues unlocked by the fix.

Ideally this PR will be closed the day `beta1` is released after ensuring everything passes, it is not meant to be merged.