### PR TITLE
Fix sparc t4 build error 'undefined symbol: cipher_hw_generic_cbc'

### DIFF
--- a/providers/implementations/ciphers/cipher_aes_hw_t4.inc
+++ b/providers/implementations/ciphers/cipher_aes_hw_t4.inc
@@ -88,7 +88,7 @@ static int cipher_hw_aes_t4_initkey(PROV_CIPHER_CTX *dat,
 #define PROV_CIPHER_HW_declare(mode)                                           \
 static const PROV_CIPHER_HW aes_t4_##mode = {                                  \
     cipher_hw_aes_t4_initkey,                                                  \
-    cipher_hw_generic_##mode,                                                  \
+    ossl_cipher_hw_generic_##mode,                                             \
     cipher_hw_aes_copyctx                                                      \
 };
 #define PROV_CIPHER_HW_select(mode)                                            \

--- a/providers/implementations/ciphers/cipher_camellia_hw_t4.inc
+++ b/providers/implementations/ciphers/cipher_camellia_hw_t4.inc
@@ -76,7 +76,7 @@ static int cipher_hw_camellia_t4_initkey(PROV_CIPHER_CTX *dat,
 #define PROV_CIPHER_HW_declare(mode)                                           \
 static const PROV_CIPHER_HW t4_camellia_##mode = {                             \
     cipher_hw_camellia_t4_initkey,                                             \
-    cipher_hw_generic_##mode,                                                  \
+    ossl_cipher_hw_generic_##mode,                                             \
     cipher_hw_camellia_copyctx                                                 \
 };
 #define PROV_CIPHER_HW_select(mode)                                            \


### PR DESCRIPTION
cipher_hw_generic_##mode has been renamed to ossl_cipher_hw_generic_##mode.
There were a few missing renames for t4 in .inc files.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
