### PR TITLE
Add info on terminating arrays to OSSL_PARAM documentation

### DIFF
--- a/doc/man3/OSSL_PARAM.pod
+++ b/doc/man3/OSSL_PARAM.pod
@@ -203,6 +203,10 @@ used for data that remains constant and in a constant location for a
 long enough duration (such as the life-time of the entity that
 offers these parameters).
 
+=item B<OSSL_PARAM_END>
+
+This must be used to terminate any B<OSSL_PARAM> array. 
+
 =back
 
 =head1 NOTES
@@ -259,6 +263,10 @@ must fill all I<data_size> bytes and ensure correct padding for the
 native endianness, and set I<return_size> to the same value as
 I<data_size>.
 
+=item *
+
+The array must be terminated by B<OSSL_PARAM_END>.
+
 =back
 
 =begin comment RETURN VALUES doesn't make sense for a manual that only
@@ -288,7 +296,7 @@ This example is for setting parameters on some object:
     OSSL_PARAM set[] = {
         { "foo", OSSL_PARAM_UTF8_STRING_PTR, &foo, foo_l, 0 },
         { "bar", OSSL_PARAM_UTF8_STRING, &bar, sizeof(bar), 0 },
-        { NULL, 0, NULL, 0, NULL }
+        OSSL_PARAM_END
     };
 
 =head3 Example 2
@@ -302,7 +310,7 @@ This example is for requesting parameters on some object:
     OSSL_PARAM request[] = {
         { "foo", OSSL_PARAM_UTF8_STRING_PTR, &foo, 0 /*irrelevant*/, 0 },
         { "bar", OSSL_PARAM_UTF8_STRING, &bar, sizeof(bar), 0 },
-        { NULL, 0, NULL, 0, NULL }
+        OSSL_PARAM_END
     };
 
 A I<responder> that receives this array (as I<params> in this example)


### PR DESCRIPTION
Examples in the docs were not up-to-date with recommended style and the need for terminating values was not emphasized.
Documentation overlaps somewhat with the constructors in [OSSL_PARAM_int](https://www.openssl.org/docs/manmaster/man3/OSSL_PARAM_int.html). That documentation was left as a more comprehensive explanation, but as pointed out in the ticket this terminator is unexplained and relevant within this doc as well.

Fixes #11280

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
