### PR TITLE
Allow empty deprecation macros to be passed as macro arguments

### DIFF
--- a/include/openssl/macros.h
+++ b/include/openssl/macros.h
@@ -69,7 +69,10 @@
 #  endif
 # endif
 
-/* Still not defined?  Then define no-op macros */
+/*
+ * Still not defined?  Then define no-op macros. This means these macros
+ * are unsuitable for use in a typedef.
+ */
 # ifndef OSSL_DEPRECATED
 #  define OSSL_DEPRECATED(since)                extern
 #  define OSSL_DEPRECATED_FOR(since, message)   extern

--- a/include/openssl/macros.h
+++ b/include/openssl/macros.h
@@ -69,10 +69,10 @@
 #  endif
 # endif
 
-/* Still not defined?  Then define empty macros */
+/* Still not defined?  Then define no-op macros */
 # ifndef OSSL_DEPRECATED
-#  define OSSL_DEPRECATED(since)
-#  define OSSL_DEPRECATED_FOR(since, message)
+#  define OSSL_DEPRECATED(since)                extern
+#  define OSSL_DEPRECATED_FOR(since, message)   extern
 # endif
 
 /*


### PR DESCRIPTION
The OSSL_DEPRECATEDIN_3_0 macro introduced in PR #13074 is intended to
be passed as a parameter to the various PEM declaration macros. However,
in some cases OSSL_DEPRECATEDIN_3_0 is defined to be empty, and it is
not allowed to pass empty macro arguments in C90. Therefore we ensure
these macros are always defined. In the case where they were empty
previously we use a no-op value instead.
