### PR TITLE
Change the default key generation type for DH and DSA

### DIFF
--- a/doc/man3/EVP_PKEY_CTX_ctrl.pod
+++ b/doc/man3/EVP_PKEY_CTX_ctrl.pod
@@ -457,8 +457,8 @@ Uses a safe prime generator g (PKCS#3 format).
 
 The default in the default provider is B<DH_PARAMGEN_TYPE_GENERATOR> for the
 "DH" keytype, and B<DH_PARAMGEN_TYPE_FIPS_186_2> for the "DHX" keytype. In the
-FIPS provider the default value is B<DH_PARAMGEN_TYPE_FIPS_186_4> for both key
-types.
+FIPS provider the default value is B<DH_PARAMGEN_TYPE_GROUP> for the "DH"
+keytype and <B<DH_PARAMGEN_TYPE_FIPS_186_4> for the "DHX" keytype.
 
 EVP_PKEY_CTX_set_dh_paramgen_gindex() sets the I<gindex> used by the generator G.
 The default value is -1 which uses unverifiable g, otherwise a positive value

--- a/doc/man3/EVP_PKEY_CTX_ctrl.pod
+++ b/doc/man3/EVP_PKEY_CTX_ctrl.pod
@@ -455,9 +455,10 @@ Uses a safe prime generator g (PKCS#3 format).
 
 =back
 
-The default is B<DH_PARAMGEN_TYPE_GENERATOR> in the default provider for the
-"DH" keytype, and B<DH_PARAMGEN_TYPE_FIPS_186_4> in the FIPS provider and for
-the "DHX" keytype in the default provider.
+The default in the default provider is B<DH_PARAMGEN_TYPE_GENERATOR> for the
+"DH" keytype, and B<DH_PARAMGEN_TYPE_FIPS_186_2> for the "DHX" keytype. In the
+FIPS provider the default value is B<DH_PARAMGEN_TYPE_FIPS_186_4> for both key
+types.
 
 EVP_PKEY_CTX_set_dh_paramgen_gindex() sets the I<gindex> used by the generator G.
 The default value is -1 which uses unverifiable g, otherwise a positive value

--- a/doc/man3/EVP_PKEY_CTX_ctrl.pod
+++ b/doc/man3/EVP_PKEY_CTX_ctrl.pod
@@ -414,7 +414,8 @@ p, q, and verifiable g are required, since it is not part of a persisted key.
 
 EVP_PKEY_CTX_set_dsa_paramgen_type() sets the generation type to use FIPS186-4
 generation if I<name> is "fips186_4", or FIPS186-2 generation if I<name> is
-"fips186_2". The default value is "fips186_4".
+"fips186_2". The default value for the default provider is "fips186_2". The
+default value for the FIPS provider is "fips186_4".
 
 =head2 DH parameters
 
@@ -454,7 +455,9 @@ Uses a safe prime generator g (PKCS#3 format).
 
 =back
 
-The default is B<DH_PARAMGEN_TYPE_GENERATOR>.
+The default is B<DH_PARAMGEN_TYPE_GENERATOR> in the default provider for the
+"DH" keytype, and B<DH_PARAMGEN_TYPE_FIPS_186_4> in the FIPS provider and for
+the "DHX" keytype in the default provider.
 
 EVP_PKEY_CTX_set_dh_paramgen_gindex() sets the I<gindex> used by the generator G.
 The default value is -1 which uses unverifiable g, otherwise a positive value

--- a/providers/implementations/keymgmt/build.info
+++ b/providers/implementations/keymgmt/build.info
@@ -1,14 +1,14 @@
 # We make separate GOAL variables for each algorithm, to make it easy to
 # switch each to the Legacy provider when needed.
 
-$DH_GOAL=../../libimplementations.a
 $DSA_GOAL=../../libimplementations.a
 $EC_GOAL=../../libimplementations.a
 $ECX_GOAL=../../libimplementations.a
 $KDF_GOAL=../../libimplementations.a
 
 IF[{- !$disabled{dh} -}]
-  SOURCE[$DH_GOAL]=dh_kmgmt.c
+  SOURCE[../../libfips.a]=dh_kmgmt.c
+  SOURCE[../../libnonfips.a]=dh_kmgmt.c
 ENDIF
 IF[{- !$disabled{dsa} -}]
   SOURCE[$DSA_GOAL]=dsa_kmgmt.c

--- a/providers/implementations/keymgmt/build.info
+++ b/providers/implementations/keymgmt/build.info
@@ -1,7 +1,6 @@
 # We make separate GOAL variables for each algorithm, to make it easy to
 # switch each to the Legacy provider when needed.
 
-$DSA_GOAL=../../libimplementations.a
 $EC_GOAL=../../libimplementations.a
 $ECX_GOAL=../../libimplementations.a
 $KDF_GOAL=../../libimplementations.a
@@ -11,7 +10,8 @@ IF[{- !$disabled{dh} -}]
   SOURCE[../../libnonfips.a]=dh_kmgmt.c
 ENDIF
 IF[{- !$disabled{dsa} -}]
-  SOURCE[$DSA_GOAL]=dsa_kmgmt.c
+  SOURCE[../../libfips.a]=dsa_kmgmt.c
+  SOURCE[../../libnonfips.a]=dsa_kmgmt.c
 ENDIF
 IF[{- !$disabled{ec} -}]
   SOURCE[$EC_GOAL]=ec_kmgmt.c

--- a/providers/implementations/keymgmt/dh_kmgmt.c
+++ b/providers/implementations/keymgmt/dh_kmgmt.c
@@ -106,13 +106,13 @@ static int dh_gen_type_name2id(const char *name, int type)
 
     if (strcmp(name, "default") == 0) {
 #ifdef FIPS_MODULE
-        if (type == DH_FLAG_TYPE_DHX)
-            return DH_PARAMGEN_TYPE_FIPS_186_4;
+        return DH_PARAMGEN_TYPE_FIPS_186_4;
 #else
         if (type == DH_FLAG_TYPE_DHX)
             return DH_PARAMGEN_TYPE_FIPS_186_2;
-#endif
+
         return DH_PARAMGEN_TYPE_GENERATOR;
+#endif
     }
 
     for (i = 0; i < OSSL_NELEM(dhtype2id); ++i) {

--- a/providers/implementations/keymgmt/dsa_kmgmt.c
+++ b/providers/implementations/keymgmt/dsa_kmgmt.c
@@ -75,7 +75,11 @@ typedef struct dh_name2id_st{
 
 static const DSA_GENTYPE_NAME2ID dsatype2id[]=
 {
+#ifdef FIPS_MODULE
     { "default", DSA_PARAMGEN_TYPE_FIPS_186_4 },
+#else
+    { "default", DSA_PARAMGEN_TYPE_FIPS_186_2 },
+#endif
     { "fips186_4", DSA_PARAMGEN_TYPE_FIPS_186_4 },
     { "fips186_2", DSA_PARAMGEN_TYPE_FIPS_186_2 },
 };
@@ -374,7 +378,11 @@ static void *dsa_gen_init(void *provctx, int selection)
         gctx->libctx = libctx;
         gctx->pbits = 2048;
         gctx->qbits = 224;
+#ifdef FIPS_MODULE
         gctx->gen_type = DSA_PARAMGEN_TYPE_FIPS_186_4;
+#else
+        gctx->gen_type = DSA_PARAMGEN_TYPE_FIPS_186_2;
+#endif
         gctx->gindex = -1;
         gctx->pcounter = -1;
         gctx->hindex = 0;

--- a/test/dsatest.c
+++ b/test/dsatest.c
@@ -249,6 +249,7 @@ static int dsa_keygen_test(void)
         || !TEST_ptr(settables = EVP_PKEY_CTX_settable_params(pg_ctx))
         || !TEST_ptr(OSSL_PARAM_locate_const(settables,
                                              OSSL_PKEY_PARAM_FFC_PBITS))
+        || !TEST_true(EVP_PKEY_CTX_set_dsa_paramgen_type(pg_ctx, "fips186_4"))
         || !TEST_true(EVP_PKEY_CTX_set_dsa_paramgen_bits(pg_ctx, 2048))
         || !TEST_true(EVP_PKEY_CTX_set_dsa_paramgen_q_bits(pg_ctx, 224))
         || !TEST_true(EVP_PKEY_CTX_set_dsa_paramgen_seed(pg_ctx, seed_data,

--- a/test/recipes/15-test_gendsa.t
+++ b/test/recipes/15-test_gendsa.t
@@ -79,6 +79,7 @@ ok(run(app([ 'openssl', 'genpkey',
 # Just put some dummy ones in to show it works.
 ok(run(app([ 'openssl', 'genpkey',
              '-paramfile', 'dsagen.der',
+             '-pkeyopt', 'type:fips186_4',
              '-pkeyopt', 'gindex:1',
              '-pkeyopt', 'hexseed:0102030405060708090A0B0C0D0E0F1011121314',
              '-pkeyopt', 'pcounter:25',


### PR DESCRIPTION
Previously both DH and DSA were using FIPS186-4 for all key generation for DH and DSA in both the default and FIPS providers.

This is a little too restrictive for general purpose use and is a significant breaking change (for example it introduces restrictions on the sizes keys can be). AFAIK there was no OTC/OMC decision to make this breaking change.

This PR changes things so that by default in the default provider, DH keys swap to DH_PARAMGEN_TYPE_GENERATOR (i.e. PKCS3) and DHX keys swap to DH_PARAMGEN_TYPE_FIPS_186_2.

For DSA we swap to DSA_PARAMGEN_TYPE_FIPS_186_2 in the default provider.

The defaults are unchanged for the FIPS provider.

This was discovered by the tests being introduced in #13138 and is required for those tests to pass.