### PR TITLE
Ensure we raise SSLfatal on error (1.1.1)

### DIFF
--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -2577,7 +2577,7 @@ int tls_construct_server_key_exchange(SSL *s, WPACKET *pkt)
 
         s->s3->tmp.pkey = ssl_generate_pkey(pkdhp);
         if (s->s3->tmp.pkey == NULL) {
-            /* SSLfatal() already called */
+            SSLfatal(s, SSL_AD_INTERNAL_ERROR, 0, ERR_R_INTERNAL_ERROR);
             goto err;
         }
 


### PR DESCRIPTION
We were missing a call to SSLfatal. A comment claimed that we had already
called it - but that is incorrect.

This is a backport of #13229 to the 1.1.1 branch.
