### PR TITLE
[WIP] APPS: Remove the format argument where it's not used

### DIFF
--- a/apps/ca.c
+++ b/apps/ca.c
@@ -591,7 +591,7 @@ end_of_options:
             && (certfile = lookup_conf(conf, section, ENV_CERTIFICATE)) == NULL)
             goto end;
 
-        x509 = load_cert_pass(certfile, certformat, passin, "CA certificate");
+        x509 = load_cert_pass(certfile, 1, passin, "CA certificate");
         if (x509 == NULL)
             goto end;
 
@@ -1269,7 +1269,7 @@ end_of_options:
         } else {
             X509 *revcert;
 
-            revcert = load_cert_pass(infile, certformat, passin,
+            revcert = load_cert_pass(infile, 1, passin,
                                      "certificate to be revoked");
             if (revcert == NULL)
                 goto end;
@@ -1404,7 +1404,8 @@ static int certify_cert(X509 **xret, const char *infile, int certformat,
     EVP_PKEY *pktmp = NULL;
     int ok = -1, i;
 
-    if ((template_cert = load_cert_pass(infile, certformat, passin, "template certificate")) == NULL)
+    if ((template_cert = load_cert_pass(infile, 1, passin,
+                                        "template certificate")) == NULL)
         goto end;
     if (verbose)
         X509_print(bio_err, template_cert);

--- a/apps/cms.c
+++ b/apps/cms.c
@@ -616,8 +616,7 @@ int cms_main(int argc, char **argv)
             if (operation == SMIME_ENCRYPT) {
                 if (encerts == NULL && (encerts = sk_X509_new_null()) == NULL)
                     goto end;
-                cert = load_cert(opt_arg(), FORMAT_UNDEF,
-                                 "recipient certificate file");
+                cert = load_cert(opt_arg(), "recipient certificate file");
                 if (cert == NULL)
                     goto end;
                 sk_X509_push(encerts, cert);
@@ -809,8 +808,7 @@ int cms_main(int argc, char **argv)
             if ((encerts = sk_X509_new_null()) == NULL)
                 goto end;
         while (*argv) {
-            if ((cert = load_cert(*argv, FORMAT_UNDEF,
-                                  "recipient certificate file")) == NULL)
+            if ((cert = load_cert(*argv, "recipient certificate file")) == NULL)
                 goto end;
             sk_X509_push(encerts, cert);
             cert = NULL;
@@ -826,7 +824,7 @@ int cms_main(int argc, char **argv)
     }
 
     if (recipfile != NULL && (operation == SMIME_DECRYPT)) {
-        if ((recip = load_cert(recipfile, FORMAT_UNDEF,
+        if ((recip = load_cert(recipfile,
                                "recipient certificate file")) == NULL) {
             ERR_print_errors(bio_err);
             goto end;
@@ -834,7 +832,7 @@ int cms_main(int argc, char **argv)
     }
 
     if (originatorfile != NULL) {
-        if ((originator = load_cert(originatorfile, FORMAT_UNDEF,
+        if ((originator = load_cert(originatorfile,
                                     "originator certificate file")) == NULL) {
              ERR_print_errors(bio_err);
              goto end;
@@ -842,7 +840,7 @@ int cms_main(int argc, char **argv)
     }
 
     if (operation == SMIME_SIGN_RECEIPT) {
-        if ((signer = load_cert(signerfile, FORMAT_UNDEF,
+        if ((signer = load_cert(signerfile,
                                 "receipt signer certificate file")) == NULL) {
             ERR_print_errors(bio_err);
             goto end;
@@ -1049,8 +1047,7 @@ int cms_main(int argc, char **argv)
             signerfile = sk_OPENSSL_STRING_value(sksigners, i);
             keyfile = sk_OPENSSL_STRING_value(skkeys, i);
 
-            signer = load_cert(signerfile, FORMAT_UNDEF,
-                               "signer certificate");
+            signer = load_cert(signerfile, "signer certificate");
             if (signer == NULL) {
                 ret = 2;
                 goto end;

--- a/apps/crl.c
+++ b/apps/crl.c
@@ -205,7 +205,7 @@ int crl_main(int argc, char **argv)
     if (argc != 0)
         goto opthelp;
 
-    x = load_crl(infile, informat, "CRL");
+    x = load_crl(infile, "CRL");
     if (x == NULL)
         goto end;
 
@@ -250,7 +250,7 @@ int crl_main(int argc, char **argv)
             BIO_puts(bio_err, "Missing CRL signing key\n");
             goto end;
         }
-        newcrl = load_crl(crldiff, informat, "other CRL");
+        newcrl = load_crl(crldiff, "other CRL");
         if (!newcrl)
             goto end;
         pkey = load_key(keyfile, keyformat, 0, NULL, NULL, "CRL signing key");

--- a/apps/include/apps.h
+++ b/apps/include/apps.h
@@ -107,9 +107,8 @@ int add_oid_section(CONF *conf);
 X509_REQ *load_csr(const char *file, int format, const char *desc);
 X509 *load_cert_pass(const char *uri, int maybe_stdin,
                      const char *pass, const char *desc);
-/* the format parameter is meanwhile not needed anymore and thus ignored */
-#define load_cert(uri, format, desc) load_cert_pass(uri, 0, NULL, desc)
-X509_CRL *load_crl(const char *uri, int format, const char *desc);
+#define load_cert(uri, desc) load_cert_pass(uri, 1, NULL, desc)
+X509_CRL *load_crl(const char *uri, const char *desc);
 void cleanse(char *str);
 void clear_free(char *str);
 EVP_PKEY *load_key(const char *uri, int format, int maybe_stdin,

--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -485,7 +485,7 @@ X509 *load_cert_pass(const char *uri, int maybe_stdin,
 }
 
 /* the format parameter is meanwhile not needed anymore and thus ignored */
-X509_CRL *load_crl(const char *uri, int format, const char *desc)
+X509_CRL *load_crl(const char *uri, const char *desc)
 {
     X509_CRL *crl = NULL;
 
@@ -1915,7 +1915,7 @@ static X509_CRL *load_crl_crldp(STACK_OF(DIST_POINT) *crldp)
         DIST_POINT *dp = sk_DIST_POINT_value(crldp, i);
         urlptr = get_dp_url(dp);
         if (urlptr)
-            return load_crl(urlptr, FORMAT_HTTP, "CRL via CDP");
+            return load_crl(urlptr, "CRL via CDP");
     }
     return NULL;
 }

--- a/apps/lib/s_cb.c
+++ b/apps/lib/s_cb.c
@@ -1041,8 +1041,7 @@ int load_excert(SSL_EXCERT **pexc)
             BIO_printf(bio_err, "Missing filename\n");
             return 0;
         }
-        exc->cert = load_cert(exc->certfile, exc->certform,
-                              "Server Certificate");
+        exc->cert = load_cert(exc->certfile, "Server Certificate");
         if (exc->cert == NULL)
             return 0;
         if (exc->keyfile != NULL) {

--- a/apps/ocsp.c
+++ b/apps/ocsp.c
@@ -405,8 +405,7 @@ int ocsp_main(int argc, char **argv)
             path = opt_arg();
             break;
         case OPT_ISSUER:
-            issuer = load_cert(opt_arg(), FORMAT_UNDEF,
-                               "issuer certificate");
+            issuer = load_cert(opt_arg(), "issuer certificate");
             if (issuer == NULL)
                 goto end;
             if (issuers == NULL) {
@@ -418,7 +417,7 @@ int ocsp_main(int argc, char **argv)
             break;
         case OPT_CERT:
             X509_free(cert);
-            cert = load_cert(opt_arg(), FORMAT_UNDEF, "certificate");
+            cert = load_cert(opt_arg(), "certificate");
             if (cert == NULL)
                 goto end;
             if (cert_id_md == NULL)
@@ -562,8 +561,7 @@ int ocsp_main(int argc, char **argv)
     if (rsignfile != NULL) {
         if (rkeyfile == NULL)
             rkeyfile = rsignfile;
-        rsigner = load_cert(rsignfile, FORMAT_UNDEF,
-                            "responder certificate");
+        rsigner = load_cert(rsignfile, "responder certificate");
         if (rsigner == NULL) {
             BIO_printf(bio_err, "Error loading responder certificate\n");
             goto end;
@@ -659,7 +657,7 @@ redo_accept:
     if (signfile != NULL) {
         if (keyfile == NULL)
             keyfile = signfile;
-        signer = load_cert(signfile, FORMAT_UNDEF, "signer certificate");
+        signer = load_cert(signfile, "signer certificate");
         if (signer == NULL) {
             BIO_printf(bio_err, "Error loading signer certificate\n");
             goto end;

--- a/apps/pkeyutl.c
+++ b/apps/pkeyutl.c
@@ -540,7 +540,7 @@ static EVP_PKEY_CTX *init_ctx(const char *kdfalg, int *pkeysize,
         break;
 
     case KEY_CERT:
-        x = load_cert(keyfile, FORMAT_UNDEF, "Certificate");
+        x = load_cert(keyfile, "Certificate");
         if (x) {
             pkey = X509_get_pubkey(x);
             X509_free(x);

--- a/apps/rsautl.c
+++ b/apps/rsautl.c
@@ -197,7 +197,7 @@ int rsautl_main(int argc, char **argv)
         break;
 
     case KEY_CERT:
-        x = load_cert(keyfile, FORMAT_UNDEF, "Certificate");
+        x = load_cert(keyfile, "Certificate");
         if (x) {
             pkey = X509_get_pubkey(x);
             X509_free(x);

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -1731,7 +1731,7 @@ int s_client_main(int argc, char **argv)
     }
 
     if (cert_file != NULL) {
-        cert = load_cert_pass(cert_file, cert_format, pass, "client certificate");
+        cert = load_cert_pass(cert_file, 1, pass, "client certificate");
         if (cert == NULL)
             goto end;
     }
@@ -1743,7 +1743,7 @@ int s_client_main(int argc, char **argv)
 
     if (crl_file != NULL) {
         X509_CRL *crl;
-        crl = load_crl(crl_file, crl_format, "CRL");
+        crl = load_crl(crl_file, "CRL");
         if (crl == NULL)
             goto end;
         crls = sk_X509_CRL_new_null();

--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -1744,8 +1744,7 @@ int s_server_main(int argc, char *argv[])
         if (s_key == NULL)
             goto end;
 
-        s_cert = load_cert_pass(s_cert_file, s_cert_format, pass,
-                           "server certificate");
+        s_cert = load_cert_pass(s_cert_file, 1, pass, "server certificate");
 
         if (s_cert == NULL)
             goto end;
@@ -1761,7 +1760,7 @@ int s_server_main(int argc, char *argv[])
             if (s_key2 == NULL)
                 goto end;
 
-            s_cert2 = load_cert_pass(s_cert_file2, s_cert_format, pass,
+            s_cert2 = load_cert_pass(s_cert_file2, 1, pass,
                                 "second server certificate");
 
             if (s_cert2 == NULL)
@@ -1784,7 +1783,7 @@ int s_server_main(int argc, char *argv[])
 
     if (crl_file != NULL) {
         X509_CRL *crl;
-        crl = load_crl(crl_file, crl_format, "CRL");
+        crl = load_crl(crl_file, "CRL");
         if (crl == NULL)
             goto end;
         crls = sk_X509_CRL_new_null();
@@ -1806,8 +1805,8 @@ int s_server_main(int argc, char *argv[])
         if (s_dkey == NULL)
             goto end;
 
-        s_dcert = load_cert_pass(s_dcert_file, s_dcert_format, dpass,
-                            "second server certificate");
+        s_dcert = load_cert_pass(s_dcert_file, 1, dpass,
+                                 "second server certificate");
 
         if (s_dcert == NULL) {
             ERR_print_errors(bio_err);

--- a/apps/smime.c
+++ b/apps/smime.c
@@ -435,8 +435,7 @@ int smime_main(int argc, char **argv)
         if (encerts == NULL)
             goto end;
         while (*argv != NULL) {
-            cert = load_cert(*argv, FORMAT_UNDEF,
-                             "recipient certificate file");
+            cert = load_cert(*argv, "recipient certificate file");
             if (cert == NULL)
                 goto end;
             sk_X509_push(encerts, cert);
@@ -453,7 +452,7 @@ int smime_main(int argc, char **argv)
     }
 
     if (recipfile != NULL && (operation == SMIME_DECRYPT)) {
-        if ((recip = load_cert(recipfile, FORMAT_UNDEF,
+        if ((recip = load_cert(recipfile,
                                "recipient certificate file")) == NULL) {
             ERR_print_errors(bio_err);
             goto end;
@@ -568,8 +567,7 @@ int smime_main(int argc, char **argv)
         for (i = 0; i < sk_OPENSSL_STRING_num(sksigners); i++) {
             signerfile = sk_OPENSSL_STRING_value(sksigners, i);
             keyfile = sk_OPENSSL_STRING_value(skkeys, i);
-            signer = load_cert(signerfile, FORMAT_UNDEF,
-                               "signer certificate");
+            signer = load_cert(signerfile, "signer certificate");
             if (signer == NULL)
                 goto end;
             key = load_key(keyfile, keyform, 0, passin, e, "signing key");

--- a/apps/verify.c
+++ b/apps/verify.c
@@ -250,7 +250,7 @@ static int check(X509_STORE *ctx, const char *file,
     STACK_OF(X509) *chain = NULL;
     int num_untrusted;
 
-    x = load_cert(file, FORMAT_UNDEF, "certificate file");
+    x = load_cert(file, "certificate file");
     if (x == NULL)
         goto end;
 

--- a/apps/x509.c
+++ b/apps/x509.c
@@ -629,7 +629,7 @@ int x509_main(int argc, char **argv)
         if (!X509_set_pubkey(x, fkey != NULL ? fkey : X509_REQ_get0_pubkey(req)))
             goto end;
     } else {
-        x = load_cert_pass(infile, FORMAT_UNDEF, passin, "certificate");
+        x = load_cert_pass(infile, 1, passin, "certificate");
         if (x == NULL)
             goto end;
         if (fkey != NULL && !X509_set_pubkey(x, fkey))
@@ -639,7 +639,7 @@ int x509_main(int argc, char **argv)
     }
 
     if (CA_flag) {
-        xca = load_cert_pass(CAfile, CAformat, passin, "CA certificate");
+        xca = load_cert_pass(CAfile, 1, passin, "CA certificate");
         if (xca == NULL)
             goto end;
     }


### PR DESCRIPTION
Also, restore a behaviour change, where load_cert() would look at
stdin when the input file name is NULL, and make sure to call
load_cert_pass() with a corresponding argument where load_cert() was
used in OpenSSL 1.1.1.

Fixes #13235
