### PR TITLE
openssl dgst: add option to specify output length for XOF

### DIFF
--- a/doc/man1/openssl-dgst.pod.in
+++ b/doc/man1/openssl-dgst.pod.in
@@ -16,6 +16,7 @@ B<openssl> B<dgst>|I<digest>
 [B<-list>]
 [B<-hex>]
 [B<-binary>]
+[B<-xoflen> I<length>]
 [B<-r>]
 [B<-out> I<filename>]
 [B<-sign> I<filename>]
@@ -83,6 +84,10 @@ signatures using B<-hex>.
 =item B<-binary>
 
 Output the digest or signature in binary form.
+
+=item B<-xoflen> I<length>
+
+Set the output length for XOF algorithms, such as B<shake128>.
 
 =item B<-r>
 

--- a/test/recipes/20-test_dgst.t
+++ b/test/recipes/20-test_dgst.t
@@ -17,7 +17,7 @@ use OpenSSL::Test::Utils;
 
 setup("test_dgst");
 
-plan tests => 6;
+plan tests => 7;
 
 sub tsignverify {
     my $testtext = shift;
@@ -111,8 +111,22 @@ subtest "HMAC generation with `dgst` CLI" => sub {
     my @hmacdata = run(app(['openssl', 'dgst', '-sha256', '-hmac', '123456',
                             $testdata, $testdata]), capture => 1);
     chomp(@hmacdata);
-    my $expected = qr/HMAC-SHA256\([^\)]*data.bin\)= 6f12484129c4a761747f13d8234a1ff0e074adb34e9e9bf3a155c391b97b9a7c/;
+    my $expected = qr/HMAC-SHA256\(\Q$testdata\E\)= 6f12484129c4a761747f13d8234a1ff0e074adb34e9e9bf3a155c391b97b9a7c/;
     ok($hmacdata[0] =~ $expected, "HMAC: Check HMAC value is as expected ($hmacdata[0]) vs ($expected)");
     ok($hmacdata[1] =~ $expected,
        "HMAC: Check second HMAC value is consistent with the first ($hmacdata[1]) vs ($expected)");
+};
+
+subtest "Custom length XOF digest generation with `dgst` CLI" => sub {
+    plan tests => 2;
+
+    my $testdata = srctop_file('test', 'data.bin');
+    #Digest the data twice to check consistency
+    my @xofdata = run(app(['openssl', 'dgst', '-shake128', '-xoflen', '64',
+                           $testdata, $testdata]), capture => 1);
+    chomp(@xofdata);
+    my $expected = qr/SHAKE128\(\Q$testdata\E\)= bb565dac72640109e1c926ef441d3fa64ffd0b3e2bf8cd73d5182dfba19b6a8a2eab96d2df854b647b3795ef090582abe41ba4e0717dc4df40bc4e17d88e4677/;
+    ok($xofdata[0] =~ $expected, "XOF: Check digest value is as expected ($xofdata[0]) vs ($expected)");
+    ok($xofdata[1] =~ $expected,
+       "XOF: Check second digest value is consistent with the first ($xofdata[1]) vs ($expected)");
 };


### PR DESCRIPTION
This adds the `-xoflen` option to control the output length of the XOF algorithms, such as SHAKE128 and SHAKE256.

I initially thought that this can be implemented as a more generic option (say `-mdopt xoflen:100`) that allows to specify the "xoflen" param with `EVP_MD_CTX_set_params`. However, in the end I realized that it nevertheless requires a special case for XOF for the following reasons:
- `dgst` makes use of `BIO` and the underlying `gets` method truncates the output
- in the default provider, the value of "xoflen" is looked up with `OSSL_PARAM_get_size_t` which only works on a parameter values stored with `OSSL_PARAM_construct_size_t`, not the one returned from `app_params_new_from_opts`

I'd like to hear any suggestions.

Fixes: #11964

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
