### PR TITLE
Make enable/disable Configure parser more robust

### DIFF
--- a/Configure
+++ b/Configure
@@ -762,7 +762,7 @@ while (@argvcopy)
         s /^zlib$/enable-zlib/;
         s /^zlib-dynamic$/enable-zlib-dynamic/;
 
-        if (/^(no|disable|enable)-(.+)$/)
+        if (/^-?(no|disable|enable)-(.+)$/)
                 {
                 my $word = $2;
                 if ($word !~ m|hw(?:-.+)| # special treatment for hw regexp opt
@@ -773,7 +773,7 @@ while (@argvcopy)
                         next;
                         }
                 }
-        if (/^no-(.+)$/ || /^disable-(.+)$/)
+        if (/^-?no-(.+)$/ || /^-?disable-(.+)$/)
                 {
                 foreach my $proto ((@tls, @dtls))
                         {
@@ -832,7 +832,7 @@ while (@argvcopy)
                 # No longer an automatic choice
                 $auto_threads = 0 if ($1 eq "threads");
                 }
-        elsif (/^enable-(.+)$/)
+        elsif (/^-?enable-(.+)$/)
                 {
                 if ($1 eq "static-engine")
                         {


### PR DESCRIPTION
When leading - is specified for enable/disable-openssl-xxx, just cut it off.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
