### PR TITLE
Fix BoringSSL tests

### DIFF
--- a/ssl/record/ssl3_record.c
+++ b/ssl/record/ssl3_record.c
@@ -1615,6 +1615,7 @@ int dtls1_process_record(SSL *s, DTLS1_BITMAP *bitmap)
         mac_size = 0;
     }
 
+    ERR_set_mark();
     enc_err = s->method->ssl3_enc->enc(s, rr, 1, 0, &macbuf, mac_size);
 
     /*-
@@ -1624,6 +1625,7 @@ int dtls1_process_record(SSL *s, DTLS1_BITMAP *bitmap)
      *    1: Success or MTE decryption failed (MAC will be randomised)
      */
     if (enc_err == 0) {
+        ERR_pop_to_mark();
         if (ossl_statem_in_error(s)) {
             /* SSLfatal() got called */
             goto end;
@@ -1633,6 +1635,7 @@ int dtls1_process_record(SSL *s, DTLS1_BITMAP *bitmap)
         RECORD_LAYER_reset_packet_length(&s->rlayer);
         goto end;
     }
+    ERR_clear_last_mark();
     OSSL_TRACE_BEGIN(TLS) {
         BIO_printf(trc_out, "dec %zd\n", rr->length);
         BIO_dump_indent(trc_out, rr->data, rr->length, 4);

--- a/ssl/record/ssl3_record.c
+++ b/ssl/record/ssl3_record.c
@@ -1615,6 +1615,11 @@ int dtls1_process_record(SSL *s, DTLS1_BITMAP *bitmap)
         mac_size = 0;
     }
 
+    /*
+     * Set a mark around the packet decryption attempt.  This is DTLS, so
+     * bad packets are just ignored, and we don't want to leave stray
+     * errors in the queue from processing bogus junk that we ignored.
+     */
     ERR_set_mark();
     enc_err = s->method->ssl3_enc->enc(s, rr, 1, 0, &macbuf, mac_size);
 

--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -101,8 +101,8 @@ int tls_setup_handshake(SSL *s)
     memset(s->ext.extflags, 0, sizeof(s->ext.extflags));
 
     if (ssl_get_min_max_version(s, &ver_min, &ver_max, NULL) != 0) {
-        SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS_SETUP_HANDSHAKE,
-                    ERR_R_INTERNAL_ERROR);
+        SSLfatal(s, SSL_AD_PROTOCOL_VERSION, SSL_F_TLS_SETUP_HANDSHAKE,
+                    SSL_R_NO_PROTOCOLS_AVAILABLE);
         return 0;
     }
 

--- a/test/ossl_shim/ossl_shim.cc
+++ b/test/ossl_shim/ossl_shim.cc
@@ -1085,6 +1085,7 @@ static bool DoExchange(bssl::UniquePtr<SSL_SESSION> *out_session,
     } while (config->async && RetryAsync(ssl.get(), ret));
     if (ret != 1 ||
         !CheckHandshakeProperties(ssl.get(), is_resume)) {
+      fprintf(stderr, "resumption check failed\n");
       return false;
     }
 
@@ -1105,6 +1106,7 @@ static bool DoExchange(bssl::UniquePtr<SSL_SESSION> *out_session,
       return false;
     }
     if (WriteAll(ssl.get(), result.data(), result.size()) < 0) {
+      fprintf(stderr, "writing exported key material failed\n");
       return false;
     }
   }
@@ -1135,6 +1137,7 @@ static bool DoExchange(bssl::UniquePtr<SSL_SESSION> *out_session,
     if (config->shim_writes_first) {
       if (WriteAll(ssl.get(), reinterpret_cast<const uint8_t *>("hello"),
                    5) < 0) {
+        fprintf(stderr, "shim_writes_first write failed\n");
         return false;
       }
     }
@@ -1160,6 +1163,7 @@ static bool DoExchange(bssl::UniquePtr<SSL_SESSION> *out_session,
             fprintf(stderr, "Invalid SSL_get_error output\n");
             return false;
           }
+          fprintf(stderr, "Unexpected entry in error queue\n");
           return false;
         }
         // Successfully read data.
@@ -1179,6 +1183,7 @@ static bool DoExchange(bssl::UniquePtr<SSL_SESSION> *out_session,
           buf[i] ^= 0xff;
         }
         if (WriteAll(ssl.get(), buf.get(), n) < 0) {
+          fprintf(stderr, "write of inverted bitstream failed\n");
           return false;
         }
       }


### PR DESCRIPTION
As noted in the initial triage (#13207), one of the issues related to the reason code we used (for when no TLS versions were available at all).  For expediency I just changed it to be what the test expected, but have no particular attachment to doing it that way.

The other issues were due to a stray error-queue entry in DTLS processing -- the test runner looks at the `SSL_get_error()` output and fails if there's anything there (other than a very specific case or two).

In tracking down the latter I added some more diagnostics to `ossl_shim`, which seem like they are probably worth having in the tree for future use, but again I'm not tied to that.