### PR TITLE
Fix Solaris Sparc build issues

### DIFF
--- a/include/openssl/lhash.h
+++ b/include/openssl/lhash.h
@@ -256,6 +256,32 @@ DEFINE_LHASH_OF(OPENSSL_CSTRING);
 #  pragma warning (pop)
 # endif
 
+/*	
+ * If called without higher optimization (min. -xO3) the Oracle Developer	
+ * Studio compiler generates code for the defined (static inline) functions	
+ * above.	
+ * This would later lead to the linker complaining about missing symbols when	
+ * this header file is included but the resulting object is not linked against	
+ * the Crypto library (openssl#6912).	
+ */	
+# ifdef __SUNPRO_C	
+#  pragma weak OPENSSL_LH_new	
+#  pragma weak OPENSSL_LH_flush	
+#  pragma weak OPENSSL_LH_free	
+#  pragma weak OPENSSL_LH_insert	
+#  pragma weak OPENSSL_LH_delete	
+#  pragma weak OPENSSL_LH_retrieve	
+#  pragma weak OPENSSL_LH_error	
+#  pragma weak OPENSSL_LH_num_items	
+#  pragma weak OPENSSL_LH_node_stats_bio	
+#  pragma weak OPENSSL_LH_node_usage_stats_bio	
+#  pragma weak OPENSSL_LH_stats_bio	
+#  pragma weak OPENSSL_LH_get_down_load	
+#  pragma weak OPENSSL_LH_set_down_load	
+#  pragma weak OPENSSL_LH_doall	
+#  pragma weak OPENSSL_LH_doall_arg	
+# endif /* __SUNPRO_C */	
+
 #ifdef  __cplusplus
 }
 #endif

--- a/providers/implementations/ciphers/cipher_aes_hw_t4.inc
+++ b/providers/implementations/ciphers/cipher_aes_hw_t4.inc
@@ -19,7 +19,7 @@ static int cipher_hw_aes_t4_initkey(PROV_CIPHER_CTX *dat,
     PROV_AES_CTX *adat = (PROV_AES_CTX *)dat;
     AES_KEY *ks = &adat->ks.ks;
 
-    dat->ks = (const void *)ks; /* used by cipher_hw_generic_XXX */
+    dat->ks = (const void *)ks; /* used by ossl_cipher_hw_generic_XXX */
 
     bits = keylen * 8;
     if ((dat->mode == EVP_CIPH_ECB_MODE || dat->mode == EVP_CIPH_CBC_MODE)


### PR DESCRIPTION
The first of these appears to have been merged recently in #13213 , but the other is caused by https://github.com/openssl/openssl/commit/028b31b32da97ada44140120297511eae518ed42

The build fails with Oracle Studio 12.6 due to unresolved symbols:

```
-bash-4.4$ make 
make depend && make _build_sw 
cc  -Iinclude -Iapps/include  -xarch=v9 -xstrconst -Xa -g -D_REENTRANT -DOPENSSL_BUILDING_OPENSSL   -c -o test/shlibloadtest-bin-shlibloadtest.o test/shlibloadtest.c 
cc: Warning: -xarch=v9 is deprecated, use -m64 -xarch=sparc instead 
rm -f test/shlibloadtest 
${LDCMD:-cc} -xarch=v9 -xstrconst -Xa -g -mt  \ 
       -o test/shlibloadtest \ 
       test/shlibloadtest-bin-shlibloadtest.o \ 
       -lsocket -lnsl -ldl -lpthread  
cc: Warning: -xarch=v9 is deprecated, use -m64 -xarch=sparc instead 
Undefined                       first referenced 
symbol                             in file 
OPENSSL_LH_stats_bio                test/shlibloadtest-bin-shlibloadtest.o 
OPENSSL_LH_get_down_load            test/shlibloadtest-bin-shlibloadtest.o 
OPENSSL_LH_set_down_load            test/shlibloadtest-bin-shlibloadtest.o 
OPENSSL_LH_new                      test/shlibloadtest-bin-shlibloadtest.o 
OPENSSL_LH_retrieve                 test/shlibloadtest-bin-shlibloadtest.o 
OPENSSL_LH_free                     test/shlibloadtest-bin-shlibloadtest.o 
OPENSSL_LH_node_stats_bio           test/shlibloadtest-bin-shlibloadtest.o 
OPENSSL_LH_num_items                test/shlibloadtest-bin-shlibloadtest.o 
OPENSSL_LH_node_usage_stats_bio     test/shlibloadtest-bin-shlibloadtest.o 
OPENSSL_LH_delete                   test/shlibloadtest-bin-shlibloadtest.o 
OPENSSL_LH_insert                   test/shlibloadtest-bin-shlibloadtest.o 
OPENSSL_LH_doall                    test/shlibloadtest-bin-shlibloadtest.o 
OPENSSL_LH_error                    test/shlibloadtest-bin-shlibloadtest.o 
OPENSSL_LH_flush                    test/shlibloadtest-bin-shlibloadtest.o 
ld: fatal: symbol referencing errors 
*** Error code 2 
make: Fatal error: Command failed for target `test/shlibloadtest' 
Current working directory /scratch/jspillet/jaffa/openssl-cmphang 
*** Error code 1 
make: Fatal error: Command failed for target `build_sw' 
-bash-4.4$ 
```

This PR reverses the change.
