### PR TITLE
Add support for making all of KBKDF FixedInput fields optional.

### DIFF
--- a/doc/man7/EVP_KDF-KB.pod
+++ b/doc/man7/EVP_KDF-KB.pod
@@ -21,15 +21,21 @@ The supported parameters are:
 
 =over 4
 
-=item "properties" (B<OSSL_KDF_PARAM_PROPERTIES>) <UTF8 string>
-
 =item "mode" (B<OSSL_KDF_PARAM_MODE>) <UTF8 string>
+
+The mode parameter determines which flavor of KBKDF to use - currently the
+choices are "counter" and "feedback". "counter" is the default, and will be
+used if unspecified.
 
 =item "mac" (B<OSSL_KDF_PARAM_MAC>) <UTF8 string>
 
+The value is either CMAC or HMAC.
+
 =item "digest" (B<OSSL_KDF_PARAM_DIGEST>) <UTF8 string>
 
-=item "cipher" (B<OSSL_KDF_PARAM_DIGEST>) <UTF8 string>
+=item "cipher" (B<OSSL_KDF_PARAM_CIPHER>) <UTF8 string>
+
+=item "properties" (B<OSSL_KDF_PARAM_PROPERTIES>) <UTF8 string>
 
 =item "key" (B<OSSL_KDF_PARAM_KEY>) <octet string>
 
@@ -39,18 +45,30 @@ The supported parameters are:
 
 =item "seed" (B<OSSL_KDF_PARAM_SEED>) <octet string>
 
+The seed parameter is unused in counter mode.
+
+=item "use-l" (B<OSSL_KDF_PARAM_KBKDF_USE_L>) <int>
+
+Set to B<0> to disable use of the optional Fixed Input data 'L' (see SP800-108).
+The default value of B<1> will be used if unspecified.
+
+=item "use-separator" (B<OSSL_KDF_PARAM_KBKDF_USE_SEPARATOR>) <int>
+
+Set to B<0> to disable use of the optional Fixed Input data 'zero separator'
+(see SP800-108) that is placed between the Label and Context.
+The default value of B<1> will be used if unspecified.
+
 =back
 
-The mode parameter determines which flavor of KBKDF to use - currently the
-choices are "counter" and "feedback".  Counter is the default, and will be
-used if unspecified.  The seed parameter is unused in counter mode.
+Depending on whether mac is CMAC or HMAC, either digest or cipher is required
+(respectively) and the other is unused.
 
 The parameters key, salt, info, and seed correspond to KI, Label, Context, and
 IV (respectively) in SP800-108.  As in that document, salt, info, and seed are
 optional and may be omitted.
 
-Depending on whether mac is CMAC or HMAC, either digest or cipher is required
-(respectively) and the other is unused.
+"mac", "digest", cipher" and "properties" are described in
+L<EVP_KDF(3)/PARAMETERS>.
 
 =head1 NOTES
 

--- a/include/openssl/core_names.h
+++ b/include/openssl/core_names.h
@@ -200,6 +200,8 @@ extern "C" {
 #define OSSL_KDF_PARAM_CIPHER       OSSL_ALG_PARAM_CIPHER     /* utf8 string */
 #define OSSL_KDF_PARAM_CONSTANT     "constant"  /* octet string */
 #define OSSL_KDF_PARAM_PKCS12_ID    "id"        /* int */
+#define OSSL_KDF_PARAM_KBKDF_USE_L  "use-l"             /* int */
+#define OSSL_KDF_PARAM_KBKDF_USE_SEPARATOR  "use-separator"     /* int */
 
 /* Known KDF names */
 #define OSSL_KDF_NAME_HKDF          "HKDF"


### PR DESCRIPTION
Added settable integer parameters OSSL_KDF_PARAM_KBKDF_USE_L, OSSL_KDF_PARAM_KBKDF_USE_SEPARATOR.
This is required for CAVS tests that only use a combined blob of
inputdata. A test showing this use case has been added.

Reported by Mark Powers (Acumen)

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
