### PR TITLE
afalg: add a NULL pointer check

### DIFF
--- a/engines/e_afalg.c
+++ b/engines/e_afalg.c
@@ -681,6 +681,9 @@ static cbc_handles *get_cipher_handle(int nid)
 static const EVP_CIPHER *afalg_aes_cbc(int nid)
 {
     cbc_handles *cipher_handle = get_cipher_handle(nid);
+
+    if (cipher_handle == NULL)
+            return NULL;
     if (cipher_handle->_hidden == NULL
         && ((cipher_handle->_hidden =
          EVP_CIPHER_meth_new(nid,


### PR DESCRIPTION
Under the provider model, it is possible to not have AES CBC available and this will avoid a crash.

This was not a problem in earlier versions of OpenSSL, AES CBC was always available.
