### PR TITLE
UAF avoidance in init_thread_deregister()

### DIFF
--- a/crypto/initthread.c
+++ b/crypto/initthread.c
@@ -389,6 +389,8 @@ static int init_thread_deregister(void *index, int all)
         return 0;
     if (!all)
         CRYPTO_THREAD_write_lock(gtr->lock);
+    else
+        glob_tevent_reg = NULL;
     for (i = 0; i < sk_THREAD_EVENT_HANDLER_PTR_num(gtr->skhands); i++) {
         THREAD_EVENT_HANDLER **hands
             = sk_THREAD_EVENT_HANDLER_PTR_value(gtr->skhands, i);


### PR DESCRIPTION
I discovered the potential for use-after-free on glob_tevent_reg & its members in this function as a consequence of some static (de-)initialization fiasco in C++ client code.

Long story short, an EVP_PKEY_free() was happening after OPENSSL_cleanup(). Aside from being freed the EVP_PKEY object wasn't actually being used after cleanup, it was basically just an ordering issue.

Obviously the application behavior here is somewhat suspect, but IMO is basically benign. Crashing (most typical outcome of a UAF) doesn't seem the optimal response.

At any rate, the issue can be avoided (at least with regard to this function) by simply updating the pointer to NULL rather than leaving it pointing to the freed memory, as is the typical practice.