### PR TITLE
Fix some missed usage of DEFINE_LHASH_OF()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@
 /include/openssl/err.h
 /include/openssl/ess.h
 /include/openssl/fipskey.h
+/include/openssl/lhash.h
 /include/openssl/ocsp.h
 /include/openssl/opensslv.h
 /include/openssl/pkcs12.h

--- a/build.info
+++ b/build.info
@@ -26,6 +26,7 @@ DEPEND[]=include/openssl/asn1.h \
          include/openssl/err.h \
          include/openssl/ess.h \
          include/openssl/fipskey.h \
+         include/openssl/lhash.h \
          include/openssl/opensslv.h \
          include/openssl/ocsp.h \
          include/openssl/pkcs12.h \
@@ -53,6 +54,7 @@ GENERATE[include/openssl/ct.h]=include/openssl/ct.h.in
 GENERATE[include/openssl/err.h]=include/openssl/err.h.in
 GENERATE[include/openssl/ess.h]=include/openssl/ess.h.in
 GENERATE[include/openssl/fipskey.h]=include/openssl/fipskey.h.in
+GENERATE[include/openssl/lhash.h]=include/openssl/lhash.h.in
 GENERATE[include/openssl/ocsp.h]=include/openssl/ocsp.h.in
 GENERATE[include/openssl/opensslv.h]=include/openssl/opensslv.h.in
 GENERATE[include/openssl/pkcs12.h]=include/openssl/pkcs12.h.in

--- a/include/openssl/lhash.h.in
+++ b/include/openssl/lhash.h.in
@@ -7,6 +7,10 @@
  * https://www.openssl.org/source/license.html
  */
 
+{-
+use OpenSSL::stackhash qw(generate_lhash_macros);
+-}
+
 /*
  * Header for dynamic hash table routines Author - Eric Young
  */
@@ -240,21 +244,10 @@ void OPENSSL_LH_node_usage_stats_bio(const OPENSSL_LHASH *lh, BIO *out);
     } \
     LHASH_OF(type)
 
-DEFINE_LHASH_OF(OPENSSL_STRING);
-# ifdef _MSC_VER
-/*
- * push and pop this warning:
- *   warning C4090: 'function': different 'const' qualifiers
- */
-#  pragma warning (push)
-#  pragma warning (disable: 4090)
-# endif
-
-DEFINE_LHASH_OF(OPENSSL_CSTRING);
-
-# ifdef _MSC_VER
-#  pragma warning (pop)
-# endif
+{-
+    generate_lhash_macros("OPENSSL_STRING")
+    .generate_lhash_macros("OPENSSL_CSTRING");
+-}
 
 #ifdef  __cplusplus
 }


### PR DESCRIPTION
PR #12860 fixed issues with the Lhash code. It replaced usage of
DEFINE_LHASH_OF() in the public headers. Unfortunately it missed a couple
of instances.
