### PR TITLE
Moved OPENSSL_fork_prepare,_parent,_child from init.c to threads_pthread.c

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1237,6 +1237,15 @@ OpenSSL 3.0
 
    *David von Oheimb*
 
+ * Deprecated pthread fork support methods. These were unused so no
+   replacement is required.
+
+   - OPENSSL_fork_prepare()
+   - OPENSSL_fork_parent()
+   - OPENSSL_fork_child()
+
+   *Randall S. Becker*
+
 OpenSSL 1.1.1
 -------------
 

--- a/crypto/init.c
+++ b/crypto/init.c
@@ -666,28 +666,3 @@ int OPENSSL_atexit(void (*handler)(void))
     return 1;
 }
 
-#ifdef OPENSSL_SYS_UNIX
-/*
- * The following three functions are for OpenSSL developers.  This is
- * where we set/reset state across fork (called via pthread_atfork when
- * it exists, or manually by the application when it doesn't).
- *
- * WARNING!  If you put code in either OPENSSL_fork_parent or
- * OPENSSL_fork_child, you MUST MAKE SURE that they are async-signal-
- * safe.  See this link, for example:
- *      http://man7.org/linux/man-pages/man7/signal-safety.7.html
- */
-
-void OPENSSL_fork_prepare(void)
-{
-}
-
-void OPENSSL_fork_parent(void)
-{
-}
-
-void OPENSSL_fork_child(void)
-{
-    /* TODO(3.0): Inform all providers about a fork event */
-}
-#endif

--- a/crypto/threads_pthread.c
+++ b/crypto/threads_pthread.c
@@ -7,6 +7,9 @@
  * https://www.openssl.org/source/license.html
  */
 
+/* We need to use the OPENSSL_fork_*() deprecated APIs */
+#define OPENSSL_SUPPRESS_DEPRECATED
+
 #include <openssl/crypto.h>
 #include "internal/cryptlib.h"
 
@@ -196,12 +199,30 @@ int CRYPTO_atomic_add(int *val, int amount, int *ret, CRYPTO_RWLOCK *lock)
 
 # ifndef FIPS_MODULE
 #  ifdef OPENSSL_SYS_UNIX
+
+#   ifndef OPENSSL_NO_DEPRECATED_3_0
+
+void OPENSSL_fork_prepare(void)
+{
+}
+
+void OPENSSL_fork_parent(void)
+{
+}
+
+void OPENSSL_fork_child(void)
+{
+}
+
+#   endif
 static pthread_once_t fork_once_control = PTHREAD_ONCE_INIT;
 
 static void fork_once_func(void)
 {
+#   ifndef OPENSSL_NO_DEPRECATED_3_0
     pthread_atfork(OPENSSL_fork_prepare,
                    OPENSSL_fork_parent, OPENSSL_fork_child);
+#   endif
 }
 #  endif
 

--- a/doc/man3/OPENSSL_fork_prepare.pod
+++ b/doc/man3/OPENSSL_fork_prepare.pod
@@ -11,12 +11,19 @@ OPENSSL_fork_child
 
  #include <openssl/crypto.h>
 
+Deprecated since OpenSSL 3.0.0, can be hidden entirely by defining
+B<OPENSSL_API_COMPAT> with a suitable version value, see
+L<openssl_user_macros(7)>:
+
  void OPENSSL_fork_prepare(void);
  void OPENSSL_fork_parent(void);
  void OPENSSL_fork_child(void);
 
 =head1 DESCRIPTION
 
+These methods are currently unused, and as such, no replacement methods are
+required or planned.
+   
 OpenSSL has state that should be reset when a process forks. For example,
 the entropy pool used to generate random numbers (and therefore encryption
 keys) should not be shared across multiple programs.
@@ -53,7 +60,7 @@ These functions were added in OpenSSL 1.1.1.
 
 =head1 COPYRIGHT
 
-Copyright 2017-2018 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2017-2020 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/include/openssl/crypto.h.in
+++ b/include/openssl/crypto.h.in
@@ -389,9 +389,11 @@ int OPENSSL_isservice(void);
 
 void OPENSSL_init(void);
 # ifdef OPENSSL_SYS_UNIX
-void OPENSSL_fork_prepare(void);
-void OPENSSL_fork_parent(void);
-void OPENSSL_fork_child(void);
+#  ifndef OPENSSL_NO_DEPRECATED_3_0
+OSSL_DEPRECATEDIN_3_0 void OPENSSL_fork_prepare(void);
+OSSL_DEPRECATEDIN_3_0 void OPENSSL_fork_parent(void);
+OSSL_DEPRECATEDIN_3_0 void OPENSSL_fork_child(void);
+#  endif
 # endif
 
 struct tm *OPENSSL_gmtime(const time_t *timer, struct tm *result);

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4195,9 +4195,9 @@ OSSL_STORE_INFO_set0_NAME_description   4284	3_0_0	EXIST::FUNCTION:
 OSSL_STORE_INFO_get1_NAME_description   4285	3_0_0	EXIST::FUNCTION:
 OSSL_STORE_do_all_loaders               4286	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
 OSSL_STORE_LOADER_get0_engine           4287	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
-OPENSSL_fork_prepare                    4288	3_0_0	EXIST:UNIX:FUNCTION:
-OPENSSL_fork_parent                     4289	3_0_0	EXIST:UNIX:FUNCTION:
-OPENSSL_fork_child                      4290	3_0_0	EXIST:UNIX:FUNCTION:
+OPENSSL_fork_prepare                    4288	3_0_0	EXIST:UNIX:FUNCTION:DEPRECATEDIN_3_0
+OPENSSL_fork_parent                     4289	3_0_0	EXIST:UNIX:FUNCTION:DEPRECATEDIN_3_0
+OPENSSL_fork_child                      4290	3_0_0	EXIST:UNIX:FUNCTION:DEPRECATEDIN_3_0
 EVP_sha3_224                            4304	3_0_0	EXIST::FUNCTION:
 EVP_sha3_256                            4305	3_0_0	EXIST::FUNCTION:
 EVP_sha3_384                            4306	3_0_0	EXIST::FUNCTION:


### PR DESCRIPTION
These methods have been deprecated. The move is to insulate non-UNIX platforms from these undefined symbols.

CLA: Permission is granted by the author to the OpenSSL team to use these modifications.

Fixes #13273

Signed-off-by: Randall S. Becker <rsbecker@nexbridge.com>