### PR TITLE
Remove FLOSS from all OSS builds on NonStop except for SPT threading.

### DIFF
--- a/Configurations/50-nonstop.conf
+++ b/Configurations/50-nonstop.conf
@@ -194,8 +194,7 @@
         inherit_from     => [ 'nonstop-common',
                               'nonstop-archenv-x86_64-oss',
                               'nonstop-ilp32',
-                              'nonstop-efloat-x86_64',
-                              'nonstop-model-floss' ],
+                              'nonstop-efloat-x86_64' ],
         disable          => ['threads'],
     },
     'nonstop-nsx_put' => {
@@ -209,8 +208,7 @@
         inherit_from     => [ 'nonstop-common',
                               'nonstop-archenv-x86_64-oss',
                               'nonstop-lp64-x86_64',
-                              'nonstop-efloat-x86_64',
-                              'nonstop-model-floss' ],
+                              'nonstop-efloat-x86_64' ],
         disable          => ['threads'],
     },
     'nonstop-nsx_64_put' => {
@@ -232,7 +230,8 @@
                               'nonstop-archenv-x86_64-oss',
                               'nonstop-ilp32',
                               'nonstop-efloat-x86_64',
-                              'nonstop-model-floss', 'nonstop-model-spt'],
+                              'nonstop-model-floss',
+                              'nonstop-model-spt'],
     },
     'nonstop-nsx_g' => {
         inherit_from     => [ 'nonstop-common',
@@ -253,8 +252,7 @@
         inherit_from     => [ 'nonstop-common',
                               'nonstop-archenv-itanium-oss',
                               'nonstop-ilp32',
-                              'nonstop-efloat-itanium',
-                              'nonstop-model-floss' ],
+                              'nonstop-efloat-itanium' ],
         disable          => ['threads'],
     },
     'nonstop-nse_put' => {
@@ -268,8 +266,7 @@
         inherit_from     => [ 'nonstop-common',
                               'nonstop-archenv-itanium-oss',
                               'nonstop-lp64-itanium',
-                              'nonstop-efloat-itanium',
-                              'nonstop-model-floss' ],
+                              'nonstop-efloat-itanium' ],
         disable          => ['threads'],
     },
     'nonstop-nse_64_put' => {


### PR DESCRIPTION
The Standard POSIX Threads (SPT) implementation hangs in some test cases
if FLOSS is not used.

CLA: Permission is granted by the author to the OpenSSL team to use
these modifications.

Fixes #13277

Signed-off-by: Randall S. Becker <rsbecker@nexbridge.com>