### PR TITLE
crypto/init.c: Fix a locking issue in OPENSSL_init_crypto()

### DIFF
--- a/crypto/init.c
+++ b/crypto/init.c
@@ -61,11 +61,6 @@ DEFINE_RUN_ONCE_STATIC(ossl_init_base)
 
     base_inited = 1;
     return 1;
-
-err:
-    OSSL_TRACE(INIT, "ossl_init_base failed!\n");
-
-    return 0;
 }
 
 static CRYPTO_ONCE register_atexit = CRYPTO_ONCE_STATIC_INIT;


### PR DESCRIPTION
OPENSSL_init_crypto() passes its `settings` argument to
`ossl_init_config()` through a static variable called
`conf_settings`, because ossl_init_config() is a
run-once function which can't take any parameters.

This workaround is thread-safe, because passing a non-null
`settings` argument is well defined and allowed only during
early initialization in single-threaded mode.

Nevertheless, the 'init_lock' was added in commit bf24111bb2
(Avoid a race condition in loading config settings, 2016-02-09)
to protect this workaround. This probably happened to fix a
thread sanitizer warning. I believe it was a ~~false~~ false
positive caused by unnecessary writes of null values to the
`conf_settings` variable.

Since commit e6c54619d1 (Load the default config file before
working with default properties, 2020-07-31) the unnecessary
lock is causing a lock-order-inversion, so it needs to be
removed. Instead, we prevent concurrency warnings by avoiding
to update `conf_settings` unnecessarily.

Fixes #12869

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
