### PR TITLE
Fix REF_PRINT_COUNT argument in ecx_key_free

### DIFF
--- a/crypto/ec/ecx_key.c
+++ b/crypto/ec/ecx_key.c
@@ -62,7 +62,7 @@ void ecx_key_free(ECX_KEY *key)
         return;
 
     CRYPTO_DOWN_REF(&key->references, &i, key->lock);
-    REF_PRINT_COUNT("ECX_KEY", r);
+    REF_PRINT_COUNT("ECX_KEY", key);
     if (i > 0)
         return;
     REF_ASSERT_ISNT(i < 0);


### PR DESCRIPTION
Currently, when configuring OpenSSL using `-DREF_PRINT` the following
compilation error is generated:
```console
In file included from include/crypto/ecx.h:21,
                 from crypto/ec/ecx_key.c:11:
crypto/ec/ecx_key.c: In function 'ecx_key_free':
crypto/ec/ecx_key.c:65:32: error: 'r' undeclared
(first use in this function)
   65 |     REF_PRINT_COUNT("ECX_KEY", r);
      |                                ^
include/internal/refcount.h:169:40: note: in definition of macro
'REF_PRINT_COUNT'
  169 |         fprintf(stderr, "%p:%4d:%s\n", b, b->references, a)
      |                                        ^
crypto/ec/ecx_key.c:65:32: note: each undeclared identifier is reported
only once for each function it appears in
   65 |     REF_PRINT_COUNT("ECX_KEY", r);
      |                                ^
include/internal/refcount.h:169:40: note: in definition of macro
'REF_PRINT_COUNT'
  169 |         fprintf(stderr, "%p:%4d:%s\n", b, b->references, a)
      |                                        ^
make[1]: *** [Makefile:14929: crypto/ec/libcrypto-lib-ecx_key.o] Error 1
```
This commit updates the argument passed in to be the ECX_KEY* key.
