### PR TITLE
Do not export the submodules gost-engine

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,3 +11,4 @@ boringssl                               export-ignore
 krb5                                    export-ignore
 pyca-cryptography                       export-ignore
 dev                                     export-ignore
+gost-engine                             export-ignore


### PR DESCRIPTION
Remove gost-engine from the distribution tarball.

Signed-off-by: Hu Keping <hukeping@huawei.com>