### PR TITLE
Modify is_tls13_capable() to take account of the servername cb (1.1.1)

### DIFF
--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -1504,8 +1504,8 @@ static int ssl_method_error(const SSL *s, const SSL_METHOD *method)
 
 /*
  * Only called by servers. Returns 1 if the server has a TLSv1.3 capable
- * certificate type, or has PSK or a certificate callback configured. Otherwise
- * returns 0.
+ * certificate type, or has PSK or a certificate callback configured, or has
+ * a servername callback configure. Otherwise returns 0.
  */
 static int is_tls13_capable(const SSL *s)
 {
@@ -1514,6 +1514,17 @@ static int is_tls13_capable(const SSL *s)
     int curve;
     EC_KEY *eckey;
 #endif
+
+    if (!ossl_assert(s->ctx != NULL) || !ossl_assert(s->session_ctx != NULL))
+        return 0;
+
+    /*
+     * A servername callback can change the available certs, so if a servername
+     * cb is set then we just assume TLSv1.3 will be ok
+     */
+    if (s->ctx->ext.servername_cb != NULL
+            || s->session_ctx->ext.servername_cb != NULL)
+        return 1;
 
 #ifndef OPENSSL_NO_PSK
     if (s->psk_server_callback != NULL)


### PR DESCRIPTION
A servername cb may change the available certificates, so if we have one
set then we cannot rely on the configured certificates to determine if we
are capable of negotiating TLSv1.3 or not.

Fixes #13291