### PR TITLE
Fix regression with absolute path includes when OPENSSL_CONF_INCLUDE is set

### DIFF
--- a/doc/internal/man3/ossl_ends_with_dirsep.pod
+++ b/doc/internal/man3/ossl_ends_with_dirsep.pod
@@ -2,8 +2,8 @@
 
 =head1 NAME
 
-ossl_ends_with_dirsep - internal function to detect whether a path
-ends with directory separator
+ossl_ends_with_dirsep, ossl_is_absolute_path
+- internal functions to work with paths
 
 =head1 SYNOPSIS
 
@@ -11,19 +11,26 @@ ends with directory separator
 
   int ossl_ends_with_dirsep(const char *path);
 
+  int ossl_is_absolute_path(const char *path);
+
 =head1 DESCRIPTION
 
 ossl_ends_with_dirsep() detects whether the I<path> ends with a directory
 separator in platform agnostic way.
+
+ossl_is_absolute_path() detects whether the I<path> is absolute path in
+platform agnostic way.
 
 =head1 RETURN VALUES
 
 ossl_ends_with_dirsep() returns 1 if the I<path> ends with a directory
 separator, 0 otherwise.
 
+ossl_is_absolute_path() returns 1 if the I<path> is absolute, 0 otherwise.
+
 =head1 HISTORY
 
-The function described here was added in OpenSSL 3.0.
+The functions described here were added in OpenSSL 3.0.
 
 =head1 COPYRIGHT
 

--- a/doc/internal/man3/ossl_ends_with_dirsep.pod
+++ b/doc/internal/man3/ossl_ends_with_dirsep.pod
@@ -1,0 +1,38 @@
+=pod
+
+=head1 NAME
+
+ossl_ends_with_dirsep - internal function to detect whether a path
+ends with directory separator
+
+=head1 SYNOPSIS
+
+  #include "internal/cryptlib.h"
+
+  int ossl_ends_with_dirsep(const char *path);
+
+=head1 DESCRIPTION
+
+ossl_ends_with_dirsep() detects whether the I<path> ends with a directory
+separator in platform agnostic way.
+
+=head1 RETURN VALUES
+
+ossl_ends_with_dirsep() returns 1 if the I<path> ends with a directory
+separator, 0 otherwise.
+
+=head1 HISTORY
+
+The function described here was added in OpenSSL 3.0.
+
+=head1 COPYRIGHT
+
+Copyright 2019-2020 The OpenSSL Project Authors. All Rights Reserved.
+
+Licensed under the Apache License 2.0 (the "License").  You may not use
+this file except in compliance with the License.  You can obtain a copy
+in the file LICENSE in the source distribution or at
+L<https://www.openssl.org/source/license.html>.
+
+=cut
+

--- a/doc/internal/man3/ossl_ends_with_dirsep.pod
+++ b/doc/internal/man3/ossl_ends_with_dirsep.pod
@@ -16,10 +16,10 @@ ossl_ends_with_dirsep, ossl_is_absolute_path
 =head1 DESCRIPTION
 
 ossl_ends_with_dirsep() detects whether the I<path> ends with a directory
-separator in platform agnostic way.
+separator in a platform agnostic way.
 
 ossl_is_absolute_path() detects whether the I<path> is absolute path in
-platform agnostic way.
+a platform agnostic way.
 
 =head1 RETURN VALUES
 

--- a/engines/e_loader_attic.c
+++ b/engines/e_loader_attic.c
@@ -1424,27 +1424,13 @@ static int file_read_asn1(BIO *bp, unsigned char **data, long *len)
     return 1;
 }
 
-static int ends_with_dirsep(const char *uri)
-{
-    if (*uri != '\0')
-        uri += strlen(uri) - 1;
-#if defined(__VMS)
-    if (*uri == ']' || *uri == '>' || *uri == ':')
-        return 1;
-#elif defined(_WIN32)
-    if (*uri == '\\')
-        return 1;
-#endif
-    return *uri == '/';
-}
-
 static int file_name_to_uri(OSSL_STORE_LOADER_CTX *ctx, const char *name,
                             char **data)
 {
     assert(name != NULL);
     assert(data != NULL);
     {
-        const char *pathsep = ends_with_dirsep(ctx->uri) ? "" : "/";
+        const char *pathsep = ossl_ends_with_dirsep(ctx->uri) ? "" : "/";
         long calculated_length = strlen(ctx->uri) + strlen(pathsep)
             + strlen(name) + 1 /* \0 */;
 

--- a/include/internal/cryptlib.h
+++ b/include/internal/cryptlib.h
@@ -267,4 +267,17 @@ static ossl_inline int ossl_ends_with_dirsep(const char *path)
     return *path == '/';
 }
 
+static ossl_inline int ossl_is_absolute_path(const char *path)
+{
+# if defined __VMS
+    if (strchr(path, ':') != NULL)
+        return 1;
+# elif defined _WIN32
+    if (path[0] == '\\'
+        || (path[0] != '\0' && path[1] == ':'))
+        return 1;
+# endif
+    return path[0] == '/';
+}
+
 #endif

--- a/include/internal/cryptlib.h
+++ b/include/internal/cryptlib.h
@@ -253,4 +253,18 @@ char *openssl_buf2hexstr_sep(const unsigned char *buf, long buflen, char sep);
 unsigned char *openssl_hexstr2buf_sep(const char *str, long *buflen,
                                       const char sep);
 
+static ossl_inline int ossl_ends_with_dirsep(const char *path)
+{
+    if (*path != '\0')
+        path += strlen(path) - 1;
+# if defined __VMS
+    if (*path == ']' || *path == '>' || *path == ':')
+        return 1;
+# elif defined _WIN32
+    if (*path == '\\')
+        return 1;
+# endif
+    return *path == '/';
+}
+
 #endif

--- a/include/internal/cryptlib.h
+++ b/include/internal/cryptlib.h
@@ -270,7 +270,10 @@ static ossl_inline int ossl_ends_with_dirsep(const char *path)
 static ossl_inline int ossl_is_absolute_path(const char *path)
 {
 # if defined __VMS
-    if (strchr(path, ':') != NULL)
+    if (strchr(path, ':') != NULL
+        || ((path[0] == '[' || path[0] == '<')
+            && path[1] != '.' && path[1] != '-'
+            && path[1] != ']' && path[1] != '>'))
         return 1;
 # elif defined _WIN32
     if (path[0] == '\\'

--- a/providers/implementations/storemgmt/file_store.c
+++ b/providers/implementations/storemgmt/file_store.c
@@ -24,6 +24,7 @@
 #include <openssl/params.h>
 #include <openssl/decoder.h>
 #include <openssl/store.h>       /* The OSSL_STORE_INFO type numbers */
+#include "internal/cryptlib.h"
 #include "internal/o_dir.h"
 #include "crypto/pem.h"          /* For PVK and "blob" PEM headers */
 #include "crypto/decoder.h"
@@ -647,27 +648,13 @@ static int file_load_file(struct file_ctx_st *ctx,
  *  --------------------------------------
  */
 
-static int ends_with_dirsep(const char *uri)
-{
-    if (*uri != '\0')
-        uri += strlen(uri) - 1;
-#if defined(__VMS)
-    if (*uri == ']' || *uri == '>' || *uri == ':')
-        return 1;
-#elif defined(_WIN32)
-    if (*uri == '\\')
-        return 1;
-#endif
-    return *uri == '/';
-}
-
 static char *file_name_to_uri(struct file_ctx_st *ctx, const char *name)
 {
     char *data = NULL;
 
     assert(name != NULL);
     {
-        const char *pathsep = ends_with_dirsep(ctx->uri) ? "" : "/";
+        const char *pathsep = ossl_ends_with_dirsep(ctx->uri) ? "" : "/";
         long calculated_length = strlen(ctx->uri) + strlen(pathsep)
             + strlen(name) + 1 /* \0 */;
 


### PR DESCRIPTION
Do not prepend $OPENSSL_CONF_INCLUDE to absolute include paths
    
Also check for malloc failure and do not add '/' when
$OPENSSL_CONF_INCLUDE already ends with directory separator.

Fixes #13302 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
