### PR TITLE
defltprov: remove duplicate algorithm names.

### DIFF
--- a/providers/defltprov.c
+++ b/providers/defltprov.c
@@ -373,8 +373,8 @@ static const OSSL_ALGORITHM deflt_signature[] = {
 #endif
     { "RSA:rsaEncryption", "provider=default", ossl_rsa_signature_functions },
 #ifndef OPENSSL_NO_EC
-    { "ED25519:Ed25519", "provider=default", ossl_ed25519_signature_functions },
-    { "ED448:Ed448", "provider=default", ossl_ed448_signature_functions },
+    { "ED25519", "provider=default", ossl_ed25519_signature_functions },
+    { "ED448", "provider=default", ossl_ed448_signature_functions },
     { "ECDSA", "provider=default", ecossl_dsa_signature_functions },
 # ifndef OPENSSL_NO_SM2
     { "SM2", "provider=default", sm2_signature_functions },


### PR DESCRIPTION
Ed25519 and Ed448 contained aliases that were the same as the primary name.
This removes the aliases leaving ED25519 and ED448 as the canonical names.

Matching is case insensitive, so no functionality is lost.  The FIPS provider
didn't include the duplicates.
