### PR TITLE
Remove test that breaks on AIX.

### DIFF
--- a/test/recipes/25-test_x509.t
+++ b/test/recipes/25-test_x509.t
@@ -16,7 +16,7 @@ use OpenSSL::Test qw/:DEFAULT srctop_file/;
 
 setup("test_x509");
 
-plan tests => 15;
+plan tests => 14;
 
 require_ok(srctop_file('test','recipes','tconversion.pl'));
 
@@ -124,8 +124,6 @@ sub test_errors { # actually tests diagnostics of OSSL_STORE
     return $res && $found;
 }
 
-ok(test_errors("Can't open any-dir/", "root-cert.pem", '-out', 'any-dir/'),
-   "load root-cert errors");
 ok(test_errors("RC2-40-CBC", "v3-certs-RC2.p12", '-passin', 'pass:v3-certs'),
    "load v3-certs-RC2 no asn1 errors");
 SKIP: {


### PR DESCRIPTION
The offending test checks that fopen("anydir/") fails. This looks fairly platform
specific. For the test involved this creates a file called
"anydir" on an AIX test machine.

This change was introduced on (Sept 24)
https://github.com/openssl/openssl/commit/29844ea5b3d2b7240d99b043a0d82cb177f0762d

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
