### PR TITLE
Improve output from conf_diagnostics

### DIFF
--- a/crypto/conf/conf_mod.c
+++ b/crypto/conf/conf_mod.c
@@ -187,10 +187,11 @@ int CONF_modules_load_file_ex(OSSL_LIB_CTX *libctx, const char *filename,
     if ((flags & CONF_MFLAGS_IGNORE_RETURN_CODES) != 0 && !diagnostics)
         ret = 1;
 
-    if (ret)
+    if (ret > 0)
         ERR_pop_to_mark();
     else
         ERR_clear_last_mark();
+
     return ret;
 }
 

--- a/crypto/conf/conf_mod.c
+++ b/crypto/conf/conf_mod.c
@@ -208,7 +208,6 @@ DEFINE_RUN_ONCE_STATIC(do_load_builtin_modules)
     /* Need to load ENGINEs */
     ENGINE_load_builtin_engines();
 #endif
-    ERR_clear_error();
     return 1;
 }
 

--- a/crypto/engine/eng_dyn.c
+++ b/crypto/engine/eng_dyn.c
@@ -257,6 +257,8 @@ void engine_load_dynamic_int(void)
     ENGINE *toadd = engine_dynamic();
     if (!toadd)
         return;
+
+    ERR_set_mark();
     ENGINE_add(toadd);
     /*
      * If the "add" worked, it gets a structural reference. So either way, we
@@ -268,7 +270,7 @@ void engine_load_dynamic_int(void)
      * already added (eg. someone calling ENGINE_load_blah then calling
      * ENGINE_load_builtin_engines() perhaps).
      */
-    ERR_clear_error();
+    ERR_pop_to_mark();
 }
 
 static int dynamic_init(ENGINE *e)

--- a/crypto/engine/eng_openssl.c
+++ b/crypto/engine/eng_openssl.c
@@ -152,13 +152,20 @@ void engine_load_openssl_int(void)
     ENGINE *toadd = engine_openssl();
     if (!toadd)
         return;
+
+    ERR_set_mark();
     ENGINE_add(toadd);
     /*
      * If the "add" worked, it gets a structural reference. So either way, we
      * release our just-created reference.
      */
     ENGINE_free(toadd);
-    ERR_clear_error();
+    /*
+     * If the "add" didn't work, it was probably a conflict because it was
+     * already added (eg. someone calling ENGINE_load_blah then calling
+     * ENGINE_load_builtin_engines() perhaps).
+     */
+    ERR_pop_to_mark();
 }
 
 /*

--- a/crypto/engine/eng_rdrand.c
+++ b/crypto/engine/eng_rdrand.c
@@ -87,9 +87,19 @@ void engine_load_rdrand_int(void)
         ENGINE *toadd = ENGINE_rdrand();
         if (!toadd)
             return;
+        ERR_set_mark();
         ENGINE_add(toadd);
+        /*
+        * If the "add" worked, it gets a structural reference. So either way, we
+        * release our just-created reference.
+        */
         ENGINE_free(toadd);
-        ERR_clear_error();
+        /*
+        * If the "add" didn't work, it was probably a conflict because it was
+        * already added (eg. someone calling ENGINE_load_blah then calling
+        * ENGINE_load_builtin_engines() perhaps).
+        */
+        ERR_pop_to_mark();
     }
 }
 #else

--- a/engines/e_afalg.c
+++ b/engines/e_afalg.c
@@ -851,9 +851,19 @@ void engine_load_afalg_int(void)
     toadd = engine_afalg();
     if (toadd == NULL)
         return;
+    ERR_set_mark();
     ENGINE_add(toadd);
+    /*
+     * If the "add" worked, it gets a structural reference. So either way, we
+     * release our just-created reference.
+     */
     ENGINE_free(toadd);
-    ERR_clear_error();
+    /*
+     * If the "add" didn't work, it was probably a conflict because it was
+     * already added (eg. someone calling ENGINE_load_blah then calling
+     * ENGINE_load_builtin_engines() perhaps).
+     */
+    ERR_pop_to_mark();
 }
 # endif
 

--- a/engines/e_capi.c
+++ b/engines/e_capi.c
@@ -600,9 +600,19 @@ void engine_load_capi_int(void)
     ENGINE *toadd = engine_capi();
     if (!toadd)
         return;
+    ERR_set_mark();
     ENGINE_add(toadd);
+    /*
+     * If the "add" worked, it gets a structural reference. So either way, we
+     * release our just-created reference.
+     */
     ENGINE_free(toadd);
-    ERR_clear_error();
+    /*
+     * If the "add" didn't work, it was probably a conflict because it was
+     * already added (eg. someone calling ENGINE_load_blah then calling
+     * ENGINE_load_builtin_engines() perhaps).
+     */
+    ERR_pop_to_mark();
 }
 # endif
 

--- a/engines/e_dasync.c
+++ b/engines/e_dasync.c
@@ -348,9 +348,19 @@ void engine_load_dasync_int(void)
     ENGINE *toadd = engine_dasync();
     if (!toadd)
         return;
+    ERR_set_mark();
     ENGINE_add(toadd);
+    /*
+     * If the "add" worked, it gets a structural reference. So either way, we
+     * release our just-created reference.
+     */
     ENGINE_free(toadd);
-    ERR_clear_error();
+    /*
+     * If the "add" didn't work, it was probably a conflict because it was
+     * already added (eg. someone calling ENGINE_load_blah then calling
+     * ENGINE_load_builtin_engines() perhaps).
+     */
+    ERR_pop_to_mark();
 }
 
 static int dasync_init(ENGINE *e)

--- a/engines/e_devcrypto.c
+++ b/engines/e_devcrypto.c
@@ -1287,9 +1287,20 @@ void engine_load_devcrypto_int(void)
         return;
     }
 
+    ERR_set_mark();
     ENGINE_add(e);
+    /*
+     * If the "add" worked, it gets a structural reference. So either way, we
+     * release our just-created reference.
+     */
     ENGINE_free(e);          /* Loose our local reference */
-    ERR_clear_error();
+    /*
+     * If the "add" didn't work, it was probably a conflict because it was
+     * already added (eg. someone calling ENGINE_load_blah then calling
+     * ENGINE_load_builtin_engines() perhaps).
+     */
+    ERR_pop_to_mark();
+}
 }
 
 #else

--- a/engines/e_padlock.c
+++ b/engines/e_padlock.c
@@ -49,9 +49,19 @@ void engine_load_padlock_int(void)
     ENGINE *toadd = ENGINE_padlock();
     if (!toadd)
         return;
+    ERR_set_mark();
     ENGINE_add(toadd);
+    /*
+     * If the "add" worked, it gets a structural reference. So either way, we
+     * release our just-created reference.
+     */
     ENGINE_free(toadd);
-    ERR_clear_error();
+    /*
+     * If the "add" didn't work, it was probably a conflict because it was
+     * already added (eg. someone calling ENGINE_load_blah then calling
+     * ENGINE_load_builtin_engines() perhaps).
+     */
+    ERR_pop_to_mark();
 #  endif
 }
 


### PR DESCRIPTION
The "conf_diagnostics" facility in config files is useful for diagnosing config file problems. However 2 issues obscure problems:

1) A bug in CONF_modules_load_file_ex() meant that a call to CONF_modules_load() was treated as success and errors removed from the stack, even when it had actually failed

2) ".include" files get processed early, and we carry on regardless even if we can't locate the included file. However we still add errors to the stack to inform the user about this. However, later processing of ENGINES was unconditionally removing all errors from the stack and hence the ".include" errors were lost.