### PR TITLE
Fix the reading of DSA parameters files using the dsaparam app

### DIFF
--- a/apps/dsaparam.c
+++ b/apps/dsaparam.c
@@ -179,14 +179,10 @@ int dsaparam_main(int argc, char **argv)
             goto end;
         }
     } else {
-        params = load_keyparams(infile, 1, "DSA parameters");
-        if (!EVP_PKEY_is_a(params, "DSA")) {
-            EVP_PKEY_free(params);
-            params = NULL;
-        }
+        params = load_keyparams(infile, 1, "DSA", "DSA parameters");
     }
     if (params == NULL) {
-        BIO_printf(bio_err, "Error, unable to load DSA parameters\n");
+        /* Error message should already have been displayed */
         goto end;
     }
 

--- a/apps/include/apps.h
+++ b/apps/include/apps.h
@@ -115,7 +115,8 @@ EVP_PKEY *load_key(const char *uri, int format, int maybe_stdin,
                    const char *pass, ENGINE *e, const char *desc);
 EVP_PKEY *load_pubkey(const char *uri, int format, int maybe_stdin,
                       const char *pass, ENGINE *e, const char *desc);
-EVP_PKEY *load_keyparams(const char *uri, int maybe_stdin, const char *desc);
+EVP_PKEY *load_keyparams(const char *uri, int maybe_stdin, const char *keytype,
+                         const char *desc);
 int load_certs(const char *uri, STACK_OF(X509) **certs,
                const char *pass, const char *desc);
 int load_crls(const char *uri, STACK_OF(X509_CRL) **crls,

--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -610,7 +610,7 @@ EVP_PKEY *load_keyparams(const char *uri, int maybe_stdin, const char *keytype,
                               NULL, NULL, &params, NULL, NULL, NULL, NULL);
     if (params != NULL && keytype != NULL && !EVP_PKEY_is_a(params, keytype)) {
         BIO_printf(bio_err,
-                   "Unable to load %s from %s (unexpected paraeters type)\n",
+                   "Unable to load %s from %s (unexpected parameters type)\n",
                    desc, uri);
         ERR_print_errors(bio_err);
         EVP_PKEY_free(params);

--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -609,7 +609,9 @@ EVP_PKEY *load_keyparams(const char *uri, int maybe_stdin, const char *keytype,
     (void)load_key_certs_crls(uri, maybe_stdin, NULL, desc,
                               NULL, NULL, &params, NULL, NULL, NULL, NULL);
     if (params != NULL && keytype != NULL && !EVP_PKEY_is_a(params, keytype)) {
-        BIO_printf(bio_err, "Unable to load %s from %s\n", desc, uri);
+        BIO_printf(bio_err,
+                   "Unable to load %s from %s (unexpected paraeters type)\n",
+                   desc, uri);
         ERR_print_errors(bio_err);
         EVP_PKEY_free(params);
         params = NULL;


### PR DESCRIPTION
DSA parameters files were failing to load correctly. We also fix a number
of follow on issues which resulted in multiple similar errors messages
being displayed for the same problem, as well as a seg-fault.
