### PR TITLE
Cleanup error reporting providers

### DIFF
--- a/providers/implementations/asymciphers/rsa_enc.c
+++ b/providers/implementations/asymciphers/rsa_enc.c
@@ -155,13 +155,13 @@ static int rsa_encrypt(void *vprsactx, unsigned char *out, size_t *outlen,
         unsigned char *tbuf;
 
         if ((tbuf = OPENSSL_malloc(rsasize)) == NULL) {
-            PROVerr(0, ERR_R_MALLOC_FAILURE);
+            ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
             return 0;
         }
         if (prsactx->oaep_md == NULL) {
             OPENSSL_free(tbuf);
             prsactx->oaep_md = EVP_MD_fetch(prsactx->libctx, "SHA-1", NULL);
-            PROVerr(0, ERR_R_INTERNAL_ERROR);
+            ERR_raise(ERR_LIB_PROV, ERR_R_INTERNAL_ERROR);
             return 0;
         }
         ret =
@@ -230,7 +230,7 @@ static int rsa_decrypt(void *vprsactx, unsigned char *out, size_t *outlen,
         unsigned char *tbuf;
 
         if ((tbuf = OPENSSL_malloc(len)) == NULL) {
-            PROVerr(0, ERR_R_MALLOC_FAILURE);
+            ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
             return 0;
         }
         ret = RSA_private_decrypt(inlen, in, tbuf, prsactx->rsa,
@@ -248,7 +248,7 @@ static int rsa_decrypt(void *vprsactx, unsigned char *out, size_t *outlen,
             if (prsactx->oaep_md == NULL) {
                 prsactx->oaep_md = EVP_MD_fetch(prsactx->libctx, "SHA-1", NULL);
                 if (prsactx->oaep_md == NULL) {
-                    PROVerr(0, ERR_R_INTERNAL_ERROR);
+                    ERR_raise(ERR_LIB_PROV, ERR_R_INTERNAL_ERROR);
                     return 0;
                 }
             }

--- a/providers/implementations/ciphers/cipher_tdes_wrap.c
+++ b/providers/implementations/ciphers/cipher_tdes_wrap.c
@@ -138,7 +138,7 @@ static int tdes_wrap_cipher(void *vctx,
         return 0;
 
     if (outsize < inl) {
-        PROVerr(0, PROV_R_OUTPUT_BUFFER_TOO_SMALL);
+        ERR_raise(ERR_LIB_PROV, PROV_R_OUTPUT_BUFFER_TOO_SMALL);
         return 0;
     }
 
@@ -158,12 +158,12 @@ static int tdes_wrap_update(void *vctx, unsigned char *out, size_t *outl,
     if (inl == 0)
         return 1;
     if (outsize < inl) {
-        PROVerr(0, PROV_R_OUTPUT_BUFFER_TOO_SMALL);
+        ERR_raise(ERR_LIB_PROV, PROV_R_OUTPUT_BUFFER_TOO_SMALL);
         return 0;
     }
 
     if (!tdes_wrap_cipher(vctx, out, outl, outsize, in, inl)) {
-        PROVerr(0, PROV_R_CIPHER_OPERATION_FAILED);
+        ERR_raise(ERR_LIB_PROV, PROV_R_CIPHER_OPERATION_FAILED);
         return 0;
     }
     return 1;

--- a/providers/implementations/kdfs/scrypt.c
+++ b/providers/implementations/kdfs/scrypt.c
@@ -417,7 +417,7 @@ static int scrypt_alg(const char *pass, size_t passlen,
         return 0;
     /* Check p * r < SCRYPT_PR_MAX avoiding overflow */
     if (p > SCRYPT_PR_MAX / r) {
-        EVPerr(EVP_F_SCRYPT_ALG, EVP_R_MEMORY_LIMIT_EXCEEDED);
+        ERR_raise(ERR_LIB_EVP, EVP_R_MEMORY_LIMIT_EXCEEDED);
         return 0;
     }
 
@@ -428,7 +428,7 @@ static int scrypt_alg(const char *pass, size_t passlen,
 
     if (16 * r <= LOG2_UINT64_MAX) {
         if (N >= (((uint64_t)1) << (16 * r))) {
-            EVPerr(EVP_F_SCRYPT_ALG, EVP_R_MEMORY_LIMIT_EXCEEDED);
+            ERR_raise(ERR_LIB_EVP, EVP_R_MEMORY_LIMIT_EXCEEDED);
             return 0;
         }
     }
@@ -446,7 +446,7 @@ static int scrypt_alg(const char *pass, size_t passlen,
      * have to be revised when/if PKCS5_PBKDF2_HMAC accepts size_t.]
      */
     if (Blen > INT_MAX) {
-        EVPerr(EVP_F_SCRYPT_ALG, EVP_R_MEMORY_LIMIT_EXCEEDED);
+        ERR_raise(ERR_LIB_EVP, EVP_R_MEMORY_LIMIT_EXCEEDED);
         return 0;
     }
 
@@ -456,14 +456,14 @@ static int scrypt_alg(const char *pass, size_t passlen,
      */
     i = UINT64_MAX / (32 * sizeof(uint32_t));
     if (N + 2 > i / r) {
-        EVPerr(EVP_F_SCRYPT_ALG, EVP_R_MEMORY_LIMIT_EXCEEDED);
+        ERR_raise(ERR_LIB_EVP, EVP_R_MEMORY_LIMIT_EXCEEDED);
         return 0;
     }
     Vlen = 32 * r * (N + 2) * sizeof(uint32_t);
 
     /* check total allocated size fits in uint64_t */
     if (Blen > UINT64_MAX - Vlen) {
-        EVPerr(EVP_F_SCRYPT_ALG, EVP_R_MEMORY_LIMIT_EXCEEDED);
+        ERR_raise(ERR_LIB_EVP, EVP_R_MEMORY_LIMIT_EXCEEDED);
         return 0;
     }
 
@@ -472,7 +472,7 @@ static int scrypt_alg(const char *pass, size_t passlen,
         maxmem = SIZE_MAX;
 
     if (Blen + Vlen > maxmem) {
-        EVPerr(EVP_F_SCRYPT_ALG, EVP_R_MEMORY_LIMIT_EXCEEDED);
+        ERR_raise(ERR_LIB_EVP, EVP_R_MEMORY_LIMIT_EXCEEDED);
         return 0;
     }
 
@@ -482,7 +482,7 @@ static int scrypt_alg(const char *pass, size_t passlen,
 
     B = OPENSSL_malloc((size_t)(Blen + Vlen));
     if (B == NULL) {
-        EVPerr(EVP_F_SCRYPT_ALG, ERR_R_MALLOC_FAILURE);
+        ERR_raise(ERR_LIB_EVP, ERR_R_MALLOC_FAILURE);
         return 0;
     }
     X = (uint32_t *)(B + Blen);
@@ -501,7 +501,7 @@ static int scrypt_alg(const char *pass, size_t passlen,
     rv = 1;
  err:
     if (rv == 0)
-        EVPerr(EVP_F_SCRYPT_ALG, EVP_R_PBKDF2_ERROR);
+        ERR_raise(ERR_LIB_EVP, EVP_R_PBKDF2_ERROR);
 
     OPENSSL_clear_free(B, (size_t)(Blen + Vlen));
     return rv;

--- a/providers/implementations/macs/kmac_prov.c
+++ b/providers/implementations/macs/kmac_prov.c
@@ -252,7 +252,7 @@ static int kmac_init(void *vmacctx)
 
     /* Check key has been set */
     if (kctx->key_len == 0) {
-        EVPerr(EVP_F_KMAC_INIT, EVP_R_NO_KEY_SET);
+        ERR_raise(ERR_LIB_EVP, EVP_R_NO_KEY_SET);
         return 0;
     }
     if (!EVP_DigestInit_ex(kctx->ctx, ossl_prov_digest_md(&kctx->digest),

--- a/providers/implementations/rands/drbg_ctr.c
+++ b/providers/implementations/rands/drbg_ctr.c
@@ -494,7 +494,7 @@ static int drbg_ctr_init_lengths(PROV_DRBG *drbg)
 
 #ifdef FIPS_MODULE
     if (!ctr->use_df) {
-        PROVerr(0, RAND_R_DERIVATION_FUNCTION_MANDATORY_FOR_FIPS);
+        ERR_raise(ERR_LIB_PROV, RAND_R_DERIVATION_FUNCTION_MANDATORY_FOR_FIPS);
         ctr->use_df = 1;
         res = 0;
     }

--- a/providers/implementations/rands/rand_pool.c
+++ b/providers/implementations/rands/rand_pool.c
@@ -26,7 +26,7 @@ RAND_POOL *rand_pool_new(int entropy_requested, int secure,
     size_t min_alloc_size = RAND_POOL_MIN_ALLOCATION(secure);
 
     if (pool == NULL) {
-        RANDerr(RAND_F_RAND_POOL_NEW, ERR_R_MALLOC_FAILURE);
+        ERR_raise(ERR_LIB_RAND, ERR_R_MALLOC_FAILURE);
         return NULL;
     }
 
@@ -43,7 +43,7 @@ RAND_POOL *rand_pool_new(int entropy_requested, int secure,
         pool->buffer = OPENSSL_zalloc(pool->alloc_len);
 
     if (pool->buffer == NULL) {
-        RANDerr(RAND_F_RAND_POOL_NEW, ERR_R_MALLOC_FAILURE);
+        ERR_raise(ERR_LIB_RAND, ERR_R_MALLOC_FAILURE);
         goto err;
     }
 
@@ -68,7 +68,7 @@ RAND_POOL *rand_pool_attach(const unsigned char *buffer, size_t len,
     RAND_POOL *pool = OPENSSL_zalloc(sizeof(*pool));
 
     if (pool == NULL) {
-        RANDerr(RAND_F_RAND_POOL_ATTACH, ERR_R_MALLOC_FAILURE);
+        ERR_raise(ERR_LIB_RAND, ERR_R_MALLOC_FAILURE);
         return NULL;
     }
 
@@ -210,7 +210,7 @@ static int rand_pool_grow(RAND_POOL *pool, size_t len)
         size_t newlen = pool->alloc_len;
 
         if (pool->attached || len > pool->max_len - pool->len) {
-            RANDerr(RAND_F_RAND_POOL_GROW, ERR_R_INTERNAL_ERROR);
+            ERR_raise(ERR_LIB_RAND, ERR_R_INTERNAL_ERROR);
             return 0;
         }
 
@@ -223,7 +223,7 @@ static int rand_pool_grow(RAND_POOL *pool, size_t len)
         else
             p = OPENSSL_zalloc(newlen);
         if (p == NULL) {
-            RANDerr(RAND_F_RAND_POOL_GROW, ERR_R_MALLOC_FAILURE);
+            ERR_raise(ERR_LIB_RAND, ERR_R_MALLOC_FAILURE);
             return 0;
         }
         memcpy(p, pool->buffer, pool->len);
@@ -249,7 +249,7 @@ size_t rand_pool_bytes_needed(RAND_POOL *pool, unsigned int entropy_factor)
     size_t entropy_needed = rand_pool_entropy_needed(pool);
 
     if (entropy_factor < 1) {
-        RANDerr(RAND_F_RAND_POOL_BYTES_NEEDED, RAND_R_ARGUMENT_OUT_OF_RANGE);
+        ERR_raise(ERR_LIB_RAND, RAND_R_ARGUMENT_OUT_OF_RANGE);
         return 0;
     }
 
@@ -257,7 +257,7 @@ size_t rand_pool_bytes_needed(RAND_POOL *pool, unsigned int entropy_factor)
 
     if (bytes_needed > pool->max_len - pool->len) {
         /* not enough space left */
-        RANDerr(RAND_F_RAND_POOL_BYTES_NEEDED, RAND_R_RANDOM_POOL_OVERFLOW);
+        ERR_raise(ERR_LIB_RAND, RAND_R_RANDOM_POOL_OVERFLOW);
         return 0;
     }
 
@@ -306,12 +306,12 @@ int rand_pool_add(RAND_POOL *pool,
                   const unsigned char *buffer, size_t len, size_t entropy)
 {
     if (len > pool->max_len - pool->len) {
-        RANDerr(RAND_F_RAND_POOL_ADD, RAND_R_ENTROPY_INPUT_TOO_LONG);
+        ERR_raise(ERR_LIB_RAND, RAND_R_ENTROPY_INPUT_TOO_LONG);
         return 0;
     }
 
     if (pool->buffer == NULL) {
-        RANDerr(RAND_F_RAND_POOL_ADD, ERR_R_INTERNAL_ERROR);
+        ERR_raise(ERR_LIB_RAND, ERR_R_INTERNAL_ERROR);
         return 0;
     }
 
@@ -325,7 +325,7 @@ int rand_pool_add(RAND_POOL *pool,
          * indeterminate result.
          */
         if (pool->alloc_len > pool->len && pool->buffer + pool->len == buffer) {
-            RANDerr(RAND_F_RAND_POOL_ADD, ERR_R_INTERNAL_ERROR);
+            ERR_raise(ERR_LIB_RAND, ERR_R_INTERNAL_ERROR);
             return 0;
         }
         /*
@@ -363,12 +363,12 @@ unsigned char *rand_pool_add_begin(RAND_POOL *pool, size_t len)
         return NULL;
 
     if (len > pool->max_len - pool->len) {
-        RANDerr(RAND_F_RAND_POOL_ADD_BEGIN, RAND_R_RANDOM_POOL_OVERFLOW);
+        ERR_raise(ERR_LIB_RAND, RAND_R_RANDOM_POOL_OVERFLOW);
         return NULL;
     }
 
     if (pool->buffer == NULL) {
-        RANDerr(RAND_F_RAND_POOL_ADD_BEGIN, ERR_R_INTERNAL_ERROR);
+        ERR_raise(ERR_LIB_RAND, ERR_R_INTERNAL_ERROR);
         return NULL;
     }
 
@@ -399,7 +399,7 @@ unsigned char *rand_pool_add_begin(RAND_POOL *pool, size_t len)
 int rand_pool_add_end(RAND_POOL *pool, size_t len, size_t entropy)
 {
     if (len > pool->alloc_len - pool->len) {
-        RANDerr(RAND_F_RAND_POOL_ADD_END, RAND_R_RANDOM_POOL_OVERFLOW);
+        ERR_raise(ERR_LIB_RAND, RAND_R_RANDOM_POOL_OVERFLOW);
         return 0;
     }
 

--- a/providers/implementations/signature/eddsa.c
+++ b/providers/implementations/signature/eddsa.c
@@ -53,7 +53,7 @@ static void *eddsa_newctx(void *provctx, const char *propq_unused)
 
     peddsactx = OPENSSL_zalloc(sizeof(PROV_EDDSA_CTX));
     if (peddsactx == NULL) {
-        PROVerr(0, ERR_R_MALLOC_FAILURE);
+        ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
         return NULL;
     }
 
@@ -74,12 +74,12 @@ static int eddsa_digest_signverify_init(void *vpeddsactx, const char *mdname,
         return 0;
 
     if (mdname != NULL && mdname[0] != '\0') {
-        PROVerr(0, PROV_R_INVALID_DIGEST);
+        ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_DIGEST);
         return 0;
     }
 
     if (!ecx_key_up_ref(edkey)) {
-        PROVerr(0, ERR_R_INTERNAL_ERROR);
+        ERR_raise(ERR_LIB_PROV, ERR_R_INTERNAL_ERROR);
         return 0;
     }
 
@@ -101,7 +101,7 @@ static int eddsa_digest_signverify_init(void *vpeddsactx, const char *mdname,
         break;
     default:
         /* Should never happen */
-        PROVerr(0, ERR_R_INTERNAL_ERROR);
+        ERR_raise(ERR_LIB_PROV, ERR_R_INTERNAL_ERROR);
         return 0;
     }
     if (ret && WPACKET_finish(&pkt)) {
@@ -130,13 +130,13 @@ int ed25519_digest_sign(void *vpeddsactx, unsigned char *sigret,
         return 1;
     }
     if (sigsize < ED25519_SIGSIZE) {
-        PROVerr(0, PROV_R_OUTPUT_BUFFER_TOO_SMALL);
+        ERR_raise(ERR_LIB_PROV, PROV_R_OUTPUT_BUFFER_TOO_SMALL);
         return 0;
     }
 
     if (ED25519_sign(sigret, tbs, tbslen, edkey->pubkey, edkey->privkey,
                      peddsactx->libctx, NULL) == 0) {
-        PROVerr(0, PROV_R_FAILED_TO_SIGN);
+        ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SIGN);
         return 0;
     }
     *siglen = ED25519_SIGSIZE;
@@ -158,13 +158,13 @@ int ed448_digest_sign(void *vpeddsactx, unsigned char *sigret,
         return 1;
     }
     if (sigsize < ED448_SIGSIZE) {
-        PROVerr(0, PROV_R_OUTPUT_BUFFER_TOO_SMALL);
+        ERR_raise(ERR_LIB_PROV, PROV_R_OUTPUT_BUFFER_TOO_SMALL);
         return 0;
     }
 
     if (ED448_sign(peddsactx->libctx, sigret, tbs, tbslen, edkey->pubkey,
                    edkey->privkey, NULL, 0, edkey->propq) == 0) {
-        PROVerr(0, PROV_R_FAILED_TO_SIGN);
+        ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SIGN);
         return 0;
     }
     *siglen = ED448_SIGSIZE;
@@ -224,7 +224,7 @@ static void *eddsa_dupctx(void *vpeddsactx)
     dstctx->key = NULL;
 
     if (srcctx->key != NULL && !ecx_key_up_ref(srcctx->key)) {
-        PROVerr(0, ERR_R_INTERNAL_ERROR);
+        ERR_raise(ERR_LIB_PROV, ERR_R_INTERNAL_ERROR);
         goto err;
     }
     dstctx->key = srcctx->key;


### PR DESCRIPTION
Error reporting in `providers/` is changed to make better use of the newer ERR building blocks, and to drop the old function codes everywhere.