### PR TITLE
Correct system guessing for solaris64-x86_64-* targets 

### DIFF
--- a/util/perl/OpenSSL/config.pm
+++ b/util/perl/OpenSSL/config.pm
@@ -202,7 +202,7 @@ sub is_sco_uname {
     }
     close UNAME;
     return "" if $line eq '';
-    my @fields = split('\s+', $line);
+    my @fields = split(/\s+/, $line);
     return $fields[2] // '';
 }
 

--- a/util/perl/OpenSSL/config.pm
+++ b/util/perl/OpenSSL/config.pm
@@ -202,8 +202,8 @@ sub is_sco_uname {
     }
     close UNAME;
     return "" if $line eq '';
-    my @fields = split($line);
-    return $fields[2];
+    my @fields = split('\s+', $line);
+    return $fields[2] // '';
 }
 
 sub get_sco_type {

--- a/util/perl/OpenSSL/config.pm
+++ b/util/perl/OpenSSL/config.pm
@@ -704,13 +704,16 @@ EOF
             my $KERNEL_BITS = $ENV{KERNEL_BITS};
             my $ISA64 = `isainfo 2>/dev/null | grep amd64`;
             my $KB = $KERNEL_BITS // '64';
-            return { target => "solaris64-x86_64" }
-                if $ISA64 ne "" && $KB eq '64';
+            if ($ISA64 ne "" && $KB eq '64') {
+                return { target => "solaris64-x86_64-gcc" } if $CCVENDOR eq "gnu";
+                return { target => "solaris64-x86_64-cc" };
+            }
             my $REL = uname('-r');
             $REL =~ s/5\.//;
             my @tmp_disable = ();
             push @tmp_disable, 'sse2' if int($REL) < 10;
-            return { target => "solaris-x86",
+            #There is no solaris-x86-cc target
+            return { target => "solaris-x86-gcc",
                      disable => [ @tmp_disable ] };
         }
       ],


### PR DESCRIPTION
Previously the system guessing script was choosing a target that did not
exist for these platforms.

Fixes #13323

Also fixed is an issue where, If the system understands `uname -X`, then the Configure script will attempt
to use uninitialized values.