### PR TITLE
darwin64-arm64 and darwin64-ub : Apple Silicon

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1615,15 +1615,25 @@ my %targets = (
         asm_arch         => 'x86_64',
         perlasm_scheme   => "macosx",
     },
-    "darwin64-arm64-cc" => { inherit_from => [ "darwin64-arm64" ] }, # "Historic" alias
+    "darwin64-arm64-cc" => { inherit_from => [ "darwin64-arm64" ] }, # Historic alias
     "darwin64-arm64" => {
-        inherit_from     => [ "darwin-common" ],
+        inherit_from     => [ "darwin-common", asm("aarch64_asm") ],
         CFLAGS           => add("-Wall"),
         cflags           => add("-arch arm64"),
         lib_cppflags     => add("-DL_ENDIAN"),
         bn_ops           => "SIXTY_FOUR_BIT_LONG",
-        asm_arch         => 'aarch64_asm',
-        perlasm_scheme   => "ios64",
+        perlasm_scheme   => "macosx",
+    },
+    # As the target modifies the project before the build, better use a ub target than lipo build from different projects
+    "darwin64-ub-cc" => { inherit_from => [ "darwin64-x86_64" ] },
+    "darwin64-ub" => {
+        inherit_from     => [ "darwin-common", asm("aarch64_asm") ],
+        inherit_from     => [ "darwin-common", asm("x86_64_asm") ],
+        CFLAGS           => add("-Wall"),
+        cflags           => add("-arch arm64 -arch x86_64"),
+        lib_cppflags     => add("-DL_ENDIAN"),
+        bn_ops           => "SIXTY_FOUR_BIT_LONG",
+        perlasm_scheme   => "macosx",
     },
 
 ##### GNU Hurd


### PR DESCRIPTION
In arm64 build, changed iphoneos to macosx
Added ub target because the configure modifies the project before the build.
I don't like to lipo build from different projects that may use different options.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
