### PR TITLE
Added OpenSSL GitHub URL to release and pre-release anouncement template

### DIFF
--- a/dev/release-aux/openssl-announce-pre-release.tmpl
+++ b/dev/release-aux/openssl-announce-pre-release.tmpl
@@ -42,8 +42,9 @@
     https://github.com/openssl/openssl/issues
 
    Please check the release notes and mailing lists to avoid duplicate
-   reports of known issues. (Of course, the source is also available
-   on GitHub.)
+   reports of known issues. The source is also available on GitHub at:
+
+    https://github.com/openssl/openssl.git
 
    Yours,
 

--- a/dev/release-aux/openssl-announce-release.tmpl
+++ b/dev/release-aux/openssl-announce-release.tmpl
@@ -35,6 +35,10 @@
     openssl sha1 $tarfile
     openssl sha256 $tarfile
 
+   The source is also available on GitHub at:
+
+    https://github.com/openssl/openssl.git
+
    Yours,
 
    The OpenSSL Project Team.


### PR DESCRIPTION

Fixes #13328

CLA: Trivial

Signed-off-by: Randall S. Becker <rsbecker@nexbridge.com>
