### PR TITLE
Small passphrase reading fixes

### DIFF
--- a/crypto/pem/pem_pkey.c
+++ b/crypto/pem/pem_pkey.c
@@ -48,12 +48,9 @@ static EVP_PKEY *pem_read_bio_key(BIO *bp, EVP_PKEY **x,
         return NULL;
     }
 
-    if (u != NULL && cb == NULL)
-        cb = PEM_def_callback;
     if (cb == NULL)
-        ui_method = UI_null();
-    else
-        ui_method = allocated_ui_method = UI_UTIL_wrap_read_pem_callback(cb, 0);
+        cb = PEM_def_callback;
+    ui_method = allocated_ui_method = UI_UTIL_wrap_read_pem_callback(cb, 0);
     if (ui_method == NULL)
         return NULL;
 

--- a/crypto/ui/ui_lib.c
+++ b/crypto/ui/ui_lib.c
@@ -106,7 +106,7 @@ static UI_STRING *general_allocate_prompt(UI *ui, const char *prompt,
     } else if ((type == UIT_PROMPT || type == UIT_VERIFY
                 || type == UIT_BOOLEAN) && result_buf == NULL) {
         UIerr(UI_F_GENERAL_ALLOCATE_PROMPT, UI_R_NO_RESULT_BUFFER);
-    } else if ((ret = OPENSSL_malloc(sizeof(*ret))) != NULL) {
+    } else if ((ret = OPENSSL_zalloc(sizeof(*ret))) != NULL) {
         ret->out_string = prompt;
         ret->flags = prompt_freeable ? OUT_STRING_FREEABLE : 0;
         ret->input_flags = input_flags;


### PR DESCRIPTION
## UI: Use OPENSSL_zalloc() in general_allocate_prompt()

This is to ensure that fields we don't set explicitly are always zero.

Fixes #13340

## PEM: Always use PEM_def_callback() when cb == NULL in pem_read_bio_key()

Too many other functions depend on this being done.

Fixes #13340