### PR TITLE
25-test_x509.t: Re-add and improve a test on non-existence of ASN.1parse errors

### DIFF
--- a/test/recipes/25-test_x509.t
+++ b/test/recipes/25-test_x509.t
@@ -16,7 +16,7 @@ use OpenSSL::Test qw/:DEFAULT srctop_file/;
 
 setup("test_x509");
 
-plan tests => 14;
+plan tests => 15;
 
 require_ok(srctop_file('test','recipes','tconversion.pl'));
 
@@ -124,8 +124,12 @@ sub test_errors { # actually tests diagnostics of OSSL_STORE
     return $res && $found;
 }
 
+# 3 tests for non-existence of spurious OSSL_STORE ASN.1 parse error output.
+# This requires provoking somehow a non-successful late exit of the app.
+ok(test_errors("bad output format", "root-cert.pem", '-outform', 'http'),
+   "load root-cert errors");
 ok(test_errors("RC2-40-CBC", "v3-certs-RC2.p12", '-passin', 'pass:v3-certs'),
-   "load v3-certs-RC2 no asn1 errors");
+   "load v3-certs-RC2 no asn1 errors"); # error msg should mention "RC2-40-CBC"
 SKIP: {
     skip "sm2 not disabled", 1 if !disabled("sm2");
 

--- a/test/recipes/25-test_x509.t
+++ b/test/recipes/25-test_x509.t
@@ -125,7 +125,7 @@ sub test_errors { # actually tests diagnostics of OSSL_STORE
 }
 
 # 3 tests for non-existence of spurious OSSL_STORE ASN.1 parse error output.
-# This requires provoking somehow a non-successful late exit of the app.
+# This requires provoking a failure exit of the app after reading input files.
 ok(test_errors("bad output format", "root-cert.pem", '-outform', 'http'),
    "load root-cert errors");
 ok(test_errors("RC2-40-CBC", "v3-certs-RC2.p12", '-passin', 'pass:v3-certs'),


### PR DESCRIPTION
This corrects the 'fix' done in #13309 and makes more clear what the test is about and how it works.