### PR TITLE
Remove some redundant error messages in the apps

### DIFF
--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -562,10 +562,6 @@ EVP_PKEY *load_key(const char *uri, int format, int may_stdin,
                                   &pkey, NULL, NULL, NULL, NULL, NULL, NULL);
     }
 
-    if (pkey == NULL) {
-        BIO_printf(bio_err, "Unable to load %s\n", desc);
-        ERR_print_errors(bio_err);
-    }
     return pkey;
 }
 
@@ -591,10 +587,7 @@ EVP_PKEY *load_pubkey(const char *uri, int format, int maybe_stdin,
         (void)load_key_certs_crls(uri, maybe_stdin, pass, desc,
                                   NULL, &pkey, NULL, NULL, NULL, NULL, NULL);
     }
-    if (pkey == NULL) {
-        BIO_printf(bio_err, "Unable to load %s\n", desc);
-        ERR_print_errors(bio_err);
-    }
+
     return pkey;
 }
 


### PR DESCRIPTION
We change the load_key() and load_pubkey() functions to make them more
consistent with the load_keyparams() function modified as a result of
PR #13317.

The error message on a NULL key is removed, because an error message has
already been displayed by load_key_certs_crls().
