### PR TITLE
cmp_msg.c: Use issuer of reference cert as default issuer entry in certTemplate

### DIFF
--- a/crypto/cmp/cmp_msg.c
+++ b/crypto/cmp/cmp_msg.c
@@ -434,7 +434,7 @@ OSSL_CMP_MSG *ossl_cmp_certrep_new(OSSL_CMP_CTX *ctx, int bodytype,
         if (msg->extraCerts == NULL
                 || !X509_add_certs(msg->extraCerts, chain,
                                    X509_ADD_FLAG_UP_REF | X509_ADD_FLAG_NO_DUP))
-        goto err;
+            goto err;
     }
 
     if (!unprotectedErrors

--- a/crypto/cmp/cmp_msg.c
+++ b/crypto/cmp/cmp_msg.c
@@ -209,6 +209,8 @@ OSSL_CRMF_MSG *OSSL_CMP_CTX_setup_CRM(OSSL_CMP_CTX *ctx, int for_KUR, int rid)
     EVP_PKEY *rkey = OSSL_CMP_CTX_get0_newPkey(ctx, 0);
     STACK_OF(GENERAL_NAME) *default_sans = NULL;
     const X509_NAME *subject = determine_subj(ctx, refcert, for_KUR);
+    const X509_NAME *issuer = ctx->issuer != NULL || refcert == NULL
+        ? ctx->issuer : X509_get_issuer_name(refcert);
     int crit = ctx->setSubjectAltNameCritical || subject == NULL;
     /* RFC5280: subjectAltName MUST be critical if subject is null */
     X509_EXTENSIONS *exts = NULL;
@@ -234,8 +236,7 @@ OSSL_CRMF_MSG *OSSL_CMP_CTX_setup_CRM(OSSL_CMP_CTX *ctx, int for_KUR, int rid)
              * it could be NULL if centralized key creation was supported
              */
             || !OSSL_CRMF_CERTTEMPLATE_fill(OSSL_CRMF_MSG_get0_tmpl(crm), rkey,
-                                            subject, ctx->issuer,
-                                            NULL /* serial */))
+                                            subject, issuer, NULL /* serial */))
         goto err;
     if (ctx->days != 0) {
         time_t now = time(NULL);

--- a/doc/man1/openssl-cmp.pod.in
+++ b/doc/man1/openssl-cmp.pod.in
@@ -631,7 +631,7 @@ Requires the corresponding key to be given with B<-key>.
 The subject of this certificate will be used as sender of outgoing CMP messages,
 while the subject of B<-oldcert> or B<-subjectName> may provide fallback values.
 The issuer of this certificate is used as one of the recipient fallback values
-and as fallback issuer entry in the certificate template of IR, CR, and KUR.
+and as fallback issuer entry in the certificate template of IR/CR/KUR.
 When using signature-based message protection, this "protection certificate"
 will be included first in the extraCerts field of outgoing messages
 and the signature is done with the corresponding key.

--- a/doc/man1/openssl-cmp.pod.in
+++ b/doc/man1/openssl-cmp.pod.in
@@ -403,7 +403,8 @@ The certificate to be updated (i.e., renewed or re-keyed) in Key Update Request
 It must be given for RR, while for KUR it defaults to B<-cert>.
 
 The reference certificate determined in this way, if any, is also used for
-deriving default subject DN and Subject Alternative Names for IR, CR, and KUR.
+deriving default subject DN and Subject Alternative Names and the
+default issuer entry in the requested certificate template of IR/CR/KUR.
 Its subject is used as sender of outgoing messages if B<-cert> is not given.
 Its issuer is used as default recipient in CMP message headers
 if neither B<-recipient>, B<-srvcert>, nor B<-issuer> is given.
@@ -629,7 +630,8 @@ The client's current CMP signer certificate.
 Requires the corresponding key to be given with B<-key>.
 The subject of this certificate will be used as sender of outgoing CMP messages,
 while the subject of B<-oldcert> or B<-subjectName> may provide fallback values.
-The issuer of this certificate is used as one of the recipient fallback values.
+The issuer of this certificate is used as one of the recipient fallback values
+and as fallback issuer entry in the certificate template of IR, CR, and KUR.
 When using signature-based message protection, this "protection certificate"
 will be included first in the extraCerts field of outgoing messages
 and the signature is done with the corresponding key.

--- a/doc/man3/OSSL_CMP_CTX_new.pod
+++ b/doc/man3/OSSL_CMP_CTX_new.pod
@@ -437,9 +437,11 @@ Therefore the public key of this I<cert> must correspond to
 the private key set before or thereafter via OSSL_CMP_CTX_set1_pkey().
 When using signature-based protection of CMP request messages
 this CMP signer certificate will be included first in the extraCerts field.
+It serves as fallback reference certificate, see OSSL_CMP_CTX_set1_oldCert().
 The subject of this I<cert> will be used as the sender field of outgoing
 messages, while the subject of any cert set via OSSL_CMP_CTX_set1_oldCert()
 and any value set via OSSL_CMP_CTX_set1_subjectName() are used as fallback.
+
 The I<cert> argument may be NULL to clear the entry.
 
 OSSL_CMP_CTX_build_cert_chain() builds a certificate chain for the CMP signer
@@ -548,7 +550,8 @@ OSSL_CMP_CTX_set1_oldCert() sets the old certificate to be updated in
 Key Update Requests (KUR) or to be revoked in Revocation Requests (RR).
 It must be given for RR, else it defaults to the CMP signer certificate.
 The reference certificate determined in this way, if any, is also used for
-deriving default subject DN and Subject Alternative Names for IR, CR, and KUR.
+deriving default subject DN and Subject Alternative Names and the
+default issuer entry in the requested certificate template of IR, CR, and KUR.
 The subject of the reference certificate is used as the sender field value
 in CMP message headers.
 Its issuer is used as default recipient in CMP message headers.

--- a/doc/man3/OSSL_CMP_CTX_new.pod
+++ b/doc/man3/OSSL_CMP_CTX_new.pod
@@ -551,7 +551,7 @@ Key Update Requests (KUR) or to be revoked in Revocation Requests (RR).
 It must be given for RR, else it defaults to the CMP signer certificate.
 The reference certificate determined in this way, if any, is also used for
 deriving default subject DN and Subject Alternative Names and the
-default issuer entry in the requested certificate template of IR, CR, and KUR.
+default issuer entry in the requested certificate template of IR/CR/KUR.
 The subject of the reference certificate is used as the sender field value
 in CMP message headers.
 Its issuer is used as default recipient in CMP message headers.


### PR DESCRIPTION
This fixes an issue found by a customer with the fallback issuer entry in certificate templates.
Documentation is updated accordingly.