### PR TITLE
Remove unused helper functions EVP_str2ctrl() & EVP_hex2ctrl().

### DIFF
--- a/crypto/evp/evp_lib.c
+++ b/crypto/evp/evp_lib.c
@@ -991,33 +991,6 @@ int EVP_CIPHER_CTX_test_flags(const EVP_CIPHER_CTX *ctx, int flags)
     return (ctx->flags & flags);
 }
 
-int EVP_str2ctrl(int (*cb)(void *ctx, int cmd, void *buf, size_t buflen),
-                 void *ctx, int cmd, const char *value)
-{
-    size_t len;
-
-    len = strlen(value);
-    if (len > INT_MAX)
-        return -1;
-    return cb(ctx, cmd, (void *)value, len);
-}
-
-int EVP_hex2ctrl(int (*cb)(void *ctx, int cmd, void *buf, size_t buflen),
-                 void *ctx, int cmd, const char *hex)
-{
-    unsigned char *bin;
-    long binlen;
-    int rv = -1;
-
-    bin = OPENSSL_hexstr2buf(hex, &binlen);
-    if (bin == NULL)
-        return 0;
-    if (binlen <= INT_MAX)
-        rv = cb(ctx, cmd, bin, binlen);
-    OPENSSL_free(bin);
-    return rv;
-}
-
 int EVP_PKEY_CTX_set_group_name(EVP_PKEY_CTX *ctx, const char *name)
 {
     OSSL_PARAM params[] = { OSSL_PARAM_END, OSSL_PARAM_END };

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -1978,15 +1978,6 @@ const OSSL_PARAM *EVP_KEYEXCH_settable_ctx_params(const EVP_KEYEXCH *keyexch);
 
 void EVP_add_alg_module(void);
 
-/*
- * Convenient helper functions to transfer string based controls.
- * The callback gets called with the parsed value.
- */
-int EVP_str2ctrl(int (*cb)(void *ctx, int cmd, void *buf, size_t buflen),
-                 void *ctx, int cmd, const char *value);
-int EVP_hex2ctrl(int (*cb)(void *ctx, int cmd, void *buf, size_t buflen),
-                 void *ctx, int cmd, const char *hex);
-
 int EVP_PKEY_CTX_set_group_name(EVP_PKEY_CTX *ctx, const char *name);
 int EVP_PKEY_CTX_get_group_name(EVP_PKEY_CTX *ctx, char *name, size_t namelen);
 

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4414,8 +4414,6 @@ EVP_MAC_CTX_get_mac_size                ?	3_0_0	EXIST::FUNCTION:
 EVP_MAC_init                            ?	3_0_0	EXIST::FUNCTION:
 EVP_MAC_update                          ?	3_0_0	EXIST::FUNCTION:
 EVP_MAC_final                           ?	3_0_0	EXIST::FUNCTION:
-EVP_str2ctrl                            ?	3_0_0	EXIST::FUNCTION:
-EVP_hex2ctrl                            ?	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_supports_digest_nid            ?	3_0_0	EXIST::FUNCTION:
 SRP_VBASE_add0_user                     ?	3_0_0	EXIST::FUNCTION:SRP
 SRP_user_pwd_new                        ?	3_0_0	EXIST::FUNCTION:SRP


### PR DESCRIPTION
These were added when the EVP_MAC work was being done.
I dont think these lightweight wrappers are required, and it seems better to remove them,
rather than adding documentation.

@levitte they haven't been used for 2 years now :)

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
