### PR TITLE
EVP: don't call memset for evp_pkey_downgrade

### DIFF
--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -1354,40 +1354,18 @@ static int evp_pkey_reset_unlocked(EVP_PKEY *pk)
     if (pk == NULL)
         return 0;
 
+    if (pk->lock) {
+      const size_t offset = (unsigned char *)&pk->lock - (unsigned char *)pk;
+      memset(pk, 0, offset);
+      memset(&pk->lock + 1, 0, sizeof(*pk) - offset - sizeof(pk->lock));
+    } else {
+      memset(pk, 0, sizeof(*pk));
+    }
+
     pk->type = EVP_PKEY_NONE;
     pk->save_type = EVP_PKEY_NONE;
-#ifndef FIPS_MODULE
-    pk->ameth = NULL;
-    pk->engine = NULL;
-    pk->pmeth_engine = NULL;
-    pk->pkey.ptr = NULL;
-#  ifndef OPENSSL_NO_RSA
-    pk->pkey.rsa = NULL;
-#  endif
-#  ifndef OPENSSL_NO_DSA
-    pk->pkey.dsa = NULL;
-#  endif
-#  ifndef OPENSSL_NO_DH
-    pk->pkey.dh = NULL;
-#  endif
-#  ifndef OPENSSL_NO_EC
-    pk->pkey.ec = NULL;
-    pk->pkey.ecx = NULL;
-#  endif
-#endif
     pk->references = 1;
-    /* pk->lock is intentionally left out */
-    pk->attributes = NULL;
     pk->save_parameters = 1;
-#ifndef FIPS_MODULE
-    memset(&pk->ex_data, 0, sizeof(CRYPTO_EX_DATA));
-#endif
-    pk->keymgmt = NULL;
-    pk->keydata = NULL;
-    pk->dirty_cnt = 0;
-    memset(&pk->operation_cache, 0, sizeof(pk->operation_cache));
-    pk->dirty_cnt_copy = 0;
-    memset(&pk->cache, 0, sizeof(pk->cache));
 
     return 1;
 }

--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -1362,7 +1362,7 @@ static int evp_pkey_reset_unlocked(EVP_PKEY *pk)
              0,
              sizeof(*pk) - offset - sizeof(pk->lock));
     }
-    /* EVP_PKEY_new will have zalloced the memory so no need to call memset */
+    /* EVP_PKEY_new uses zalloc so no need to call memset if pk->lock is NULL */
 
     pk->type = EVP_PKEY_NONE;
     pk->save_type = EVP_PKEY_NONE;

--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -1361,9 +1361,8 @@ static int evp_pkey_reset_unlocked(EVP_PKEY *pk)
       memset((unsigned char *)pk + offset + sizeof(pk->lock),
              0,
              sizeof(*pk) - offset - sizeof(pk->lock));
-    } else {
-      memset(pk, 0, sizeof(*pk));
     }
+    /* EVP_PKEY_new will have zalloced the memory so no need to call memset */
 
     pk->type = EVP_PKEY_NONE;
     pk->save_type = EVP_PKEY_NONE;

--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -1354,8 +1354,9 @@ static int evp_pkey_reset_unlocked(EVP_PKEY *pk)
     if (pk == NULL)
         return 0;
 
-    if (pk->lock) {
+    if (pk->lock != NULL) {
       const size_t offset = (unsigned char *)&pk->lock - (unsigned char *)pk;
+
       memset(pk, 0, offset);
       memset(&pk->lock + 1, 0, sizeof(*pk) - offset - sizeof(pk->lock));
     } else {

--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -1358,7 +1358,9 @@ static int evp_pkey_reset_unlocked(EVP_PKEY *pk)
       const size_t offset = (unsigned char *)&pk->lock - (unsigned char *)pk;
 
       memset(pk, 0, offset);
-      memset(&pk->lock + 1, 0, sizeof(*pk) - offset - sizeof(pk->lock));
+      memset((unsigned char *)pk + offset + sizeof(pk->lock),
+             0,
+             sizeof(*pk) - offset - sizeof(pk->lock));
     } else {
       memset(pk, 0, sizeof(*pk));
     }

--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -1386,7 +1386,7 @@ EVP_PKEY *EVP_PKEY_new(void)
 
     ret->lock = CRYPTO_THREAD_lock_new();
     if (ret->lock == NULL) {
-        EVPerr(0, ERR_R_MALLOC_FAILURE);
+        EVPerr(ERR_LIB_EVP, ERR_R_MALLOC_FAILURE);
         goto err;
     }
 
@@ -1952,7 +1952,7 @@ int evp_pkey_downgrade(EVP_PKEY *pk)
         rv = 1;
     } else {
         /* Restore the original key */
-        *pk = tmp_copy;          /* |pk| now owns THE lock */
+        *pk = tmp_copy;
     }
 
  end:


### PR DESCRIPTION
This commit tries to address a locking issue in `evp_pkey_reset_unlocked`
which can occur when it is called from `evp_pkey_downgrade`.

`evp_pkey_downgrade` will acquire a lock for `pk->lock` and if successful
then call `evp_pkey_reset_unlocked`. `evp_pkey_reset_unlocked` will call
`memset` on `pk`, and then create a new lock and set `pk->lock` to point to
that new lock. I believe there are two problems with this.

The first is that after the call to `memset`, another thread would try to
acquire a lock for `NULL` as that is what the value of `pk->lock` would be
at that point.

The second issue is that after the new lock has been assigned to
`pk->lock`, that lock is different from the one currently locked so
another thread trying to acquire the lock will succeed which can lead to
strange behaviour. More details and a reproducer can be found in the
Refs link below.

This commit introduces a new function that is only called by
`evp_pkey_downgrade` which does not use `memset` but instead
"manually" sets the `EVP_PKEY` values to their default values, but does
not modify `pk->lock`. This could perhaps be updated to go back to only
having one function that is called for both `evp_pkey_downgrade` and
`EVP_PKEY_new` and only create a new lock if one does not already exist.

Refs:
https://github.com/danbev/learning-libcrypto/blob/master/notes/issues.md#openssl-investigationtroubleshooting  
https://github.com/nodejs/node/issues/29817
