### PR TITLE
Fix dsa securitycheck for fips.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -137,7 +137,7 @@ jobs:
           script: true
         - os: linux
           compiler: gcc
-          env: CONFIGURE_TARGET="linux-generic32" MARKDOWNLINT="yes" CONFIG_OPTS="--strict-warnings no-shared no-dso no-pic no-aria no-async no-autoload-config no-blake2 no-bf no-camellia no-cast no-chacha no-cmac no-cms no-cmp no-comp no-ct no-des no-dgram no-dh no-dsa no-dtls no-ec2m no-engine no-filenames no-gost no-idea no-ktls no-mdc2 no-md4 no-multiblock no-nextprotoneg no-ocsp no-ocb no-poly1305 no-psk no-rc2 no-rc4 no-rmd160 no-seed no-siphash no-siv no-sm2 no-sm3 no-sm4 no-srp no-srtp no-ssl3 no-ssl3-method no-ts no-ui-console no-whirlpool no-asm -DOPENSSL_NO_SECURE_MEMORY -DOPENSSL_SMALL_FOOTPRINT"
+          env: CONFIGURE_TARGET="linux-generic32" MARKDOWNLINT="yes" CONFIG_OPTS="--strict-warnings no-shared no-dso no-pic no-aria no-async no-autoload-config no-blake2 no-bf no-camellia no-cast no-chacha no-cmac no-cms no-cmp no-comp no-ct no-des no-dgram no-dh no-dsa no-dtls no-ec2m no-engine no-filenames no-gost no-idea no-ktls no-mdc2 no-md4 no-multiblock no-nextprotoneg no-ocsp no-ocb no-poly1305 no-psk no-rc2 no-rc4 no-rmd160 no-seed no-siphash no-siv no-sm2 no-sm3 no-sm4 no-srp no-srtp no-ssl3 no-ssl3-method no-ts no-ui-console no-whirlpool no-fips-securitychecks no-asm -DOPENSSL_NO_SECURE_MEMORY -DOPENSSL_SMALL_FOOTPRINT"
 
 
 before_script:

--- a/providers/common/securitycheck.c
+++ b/providers/common/securitycheck.c
@@ -129,12 +129,13 @@ int dsa_check_key(const DSA *dsa, int sign)
         N = BN_num_bits(q);
 
         /*
-         * Valid sizes or verification - Note this could be a fips186-2 type
-         * key - so we allow 512 also. When this is no longer suppported the
-         * lower bound should be increased to 1024.
+         * For Digital signature verification DSA keys with < 112 bits of
+         * security strength (i.e L < 2048 bits), are still allowed for legacy
+         * use. The bounds given in SP800 131Ar2 - Table 2 are
+         * (512 <= L < 2048 and 160 <= N < 224)
          */
-        if (!sign)
-            return (L >= 512 && N >= 160);
+        if (!sign && L < 2048)
+            return (L >= 512 && N >= 160 && N < 224);
 
          /* Valid sizes for both sign and verify */
         if (L == 2048 && (N == 224 || N == 256))

--- a/test/evp_test.c
+++ b/test/evp_test.c
@@ -3284,6 +3284,7 @@ static char *take_value(PAIR *pp)
     return p;
 }
 
+#if !defined(OPENSSL_NO_FIPS_SECURITYCHECKS)
 static int securitycheck_enabled(void)
 {
     static int enabled = -1;
@@ -3310,6 +3311,7 @@ static int securitycheck_enabled(void)
     }
     return enabled;
 }
+#endif
 
 /*
  * Return 1 if one of the providers named in the string is available.

--- a/test/recipes/20-test_cli_fips.t
+++ b/test/recipes/20-test_cli_fips.t
@@ -23,7 +23,9 @@ use lib srctop_dir('Configurations');
 use lib bldtop_dir('.');
 use platform;
 
-plan skip_all => "Test only supported in a fips build" if disabled("fips");
+my $no_check = disabled('fips-securitychecks');
+plan skip_all => "Test only supported in a fips build with security checks"
+    if disabled("fips") || disabled("fips-securitychecks");
 plan tests => 13;
 
 my $fipsmodule = bldtop_file('providers', platform->dso('fips'));
@@ -235,10 +237,7 @@ SKIP: {
                      '-out', $testtext_prefix.'.fail.priv.pem'])),
            $testtext);
 
-        TODO : {
-             local $TODO = "see issue #12629";
-             tsignverify($testtext_prefix, $fips_key, $nonfips_key);
-        }
+        tsignverify($testtext_prefix, $fips_key, $nonfips_key);
     };
 }
 
@@ -315,9 +314,6 @@ SKIP : {
                      '-out', $testtext_prefix.'.fail.priv.pem'])),
            $testtext);
 
-       TODO : {
-            local $TODO = "see issues #12626, #12627";
-            tsignverify($testtext_prefix, $fips_key, $nonfips_key);
-       }
+        tsignverify($testtext_prefix, $fips_key, $nonfips_key);
     };
 }


### PR DESCRIPTION
Fixes #12627

Changed security check for DSA verification to match SP800-131Ar2 when
the security strength is < 112.
Fixed compilation error when using config opt 'no-fips-securitychecks'
Removed TODO's from 20-test_cli_fips.t - there is no longer an TODO error.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
