### PR TITLE
REF_PRINT: cast pointer to void to avoid warnings

### DIFF
--- a/crypto/asn1/tasn_utl.c
+++ b/crypto/asn1/tasn_utl.c
@@ -97,7 +97,7 @@ int asn1_do_lock(ASN1_VALUE **pval, int op, const ASN1_ITEM *it)
         if (!CRYPTO_DOWN_REF(lck, &ret, *lock))
             return -1;  /* failed */
 #ifdef REF_PRINT
-        fprintf(stderr, "%p:%4d:%s\n", it, ret, it->sname);
+        fprintf(stderr, "%p:%4d:%s\n", (void*)it, ret, it->sname);
 #endif
         REF_ASSERT_ISNT(ret < 0);
         if (ret == 0) {

--- a/include/internal/refcount.h
+++ b/include/internal/refcount.h
@@ -166,7 +166,7 @@ typedef int CRYPTO_REF_COUNT;
 
 # ifdef REF_PRINT
 #  define REF_PRINT_COUNT(a, b) \
-        fprintf(stderr, "%p:%4d:%s\n", b, b->references, a)
+        fprintf(stderr, "%p:%4d:%s\n", (void*)b, b->references, a)
 # else
 #  define REF_PRINT_COUNT(a, b)
 # endif


### PR DESCRIPTION
Currently, when configuring OpenSSL and specifying the --strict-warnings
option there are failures like the following one:
```console
crypto/bio/bio_lib.c: In function 'BIO_up_ref':
include/internal/refcount.h:169:25: error: format '%p' expects argument of type 'void *', but argument 3 has type 'BIO *' {aka 'struct bio_st *'} [-Werror=format=]
  169 |         fprintf(stderr, "%p:%4d:%s\n", b, b->references, a)
      |                         ^~~~~~~~~~~~~
crypto/bio/bio_lib.c:185:5: note: in expansion of macro 'REF_PRINT_COUNT'
  185 |     REF_PRINT_COUNT("BIO", a);
      |     ^~~~~~~~~~~~~~~
include/internal/refcount.h:169:27: note: format string is defined here
  169 |         fprintf(stderr, "%p:%4d:%s\n", b, b->references, a)
      |                          ~^
      |                           |
      |                           void *
cc1: all warnings being treated as errors
```
This commit adds casts to avoid the warnings.
