### PR TITLE
SSL_load_client_CA_file unable to load "TRUSTED CERTIFICATE"

### DIFF
--- a/ssl/ssl_cert.c
+++ b/ssl/ssl_cert.c
@@ -680,7 +680,7 @@ int SSL_add_file_cert_subjects_to_stack(STACK_OF(X509_NAME) *stack,
         goto err;
 
     for (;;) {
-        if (PEM_read_bio_X509(in, &x, NULL, NULL) == NULL)
+        if (PEM_read_bio_X509_AUX(in, &x, NULL, NULL) == NULL)
             break;
         if ((xn = X509_get_subject_name(x)) == NULL)
             goto err;


### PR DESCRIPTION
Make SSL_load_client_CA_file api (https://www.openssl.org/docs/man1.1.1/man3/SSL_load_client_CA_file.html) load 'TRUSTED CERTIFICATE' created using https://www.openssl.org/docs/man1.1.1/man1/x509.html with -trustout option.

CLA: trivial

