### PR TITLE
EVP_DigestFinalXOF must not reset the EVP_MD_CTX

### DIFF
--- a/crypto/evp/digest.c
+++ b/crypto/evp/digest.c
@@ -455,7 +455,7 @@ int EVP_DigestFinalXOF(EVP_MD_CTX *ctx, unsigned char *md, size_t size)
 
     if (EVP_MD_CTX_set_params(ctx, params) > 0)
         ret = ctx->digest->dfinal(ctx->provctx, md, &size, size);
-    EVP_MD_CTX_reset(ctx);
+
     return ret;
 
 legacy:

--- a/crypto/evp/digest.c
+++ b/crypto/evp/digest.c
@@ -170,8 +170,15 @@ int EVP_DigestInit_ex(EVP_MD_CTX *ctx, const EVP_MD *type, ENGINE *impl)
         ctx->provctx = NULL;
     }
 
-    if (type != NULL)
+    if (type != NULL) {
         ctx->reqdigest = type;
+    } else {
+        if (ctx->digest == NULL) {
+            ERR_raise(ERR_LIB_EVP, EVP_R_NO_DIGEST_SET);
+            return 0;
+        }
+        type = ctx->digest;
+    }
 
     /* TODO(3.0): Legacy work around code below. Remove this */
 #if !defined(OPENSSL_NO_ENGINE) && !defined(FIPS_MODULE)
@@ -292,12 +299,6 @@ int EVP_DigestInit_ex(EVP_MD_CTX *ctx, const EVP_MD *type, ENGINE *impl)
             ctx->engine = impl;
         } else
             ctx->engine = NULL;
-    } else {
-        if (!ctx->digest) {
-            ERR_raise(ERR_LIB_EVP, EVP_R_NO_DIGEST_SET);
-            return 0;
-        }
-        type = ctx->digest;
     }
 #endif
     if (ctx->digest != type) {

--- a/doc/man3/EVP_DigestInit.pod
+++ b/doc/man3/EVP_DigestInit.pod
@@ -208,6 +208,10 @@ value explicitly fetched with EVP_MD_fetch().
 If I<impl> is non-NULL, its implementation of the digest I<type> is used if
 there is one, and if not, the default implementation is used.
 
+The I<type> parameter can be NULL if I<ctx> has been already initialized
+with another EVP_DigestInit_ex() call and has not been reset with
+EVP_MD_CTX_reset().
+
 =item EVP_DigestUpdate()
 
 Hashes I<cnt> bytes of data at I<d> into the digest context I<ctx>. This
@@ -239,12 +243,13 @@ few bytes.
 =item EVP_DigestInit()
 
 Behaves in the same way as EVP_DigestInit_ex() except it always uses the
-default digest implementation and calls EVP_MD_CTX_reset().
+default digest implementation and calls EVP_MD_CTX_reset() so it cannot
+be used with an I<type> of NULL.
 
 =item EVP_DigestFinal()
 
-Similar to EVP_DigestFinal_ex() except the digest context I<ctx> is
-automatically cleaned up.
+Similar to EVP_DigestFinal_ex() except after computing the digest
+the digest context I<ctx> is automatically cleaned up with EVP_MD_CTX_reset().
 
 =item EVP_MD_CTX_copy()
 


### PR DESCRIPTION
It does not do it in legacy path and 1.1.1 so that must not change.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
