### PR TITLE
NetBSD build fix.

### DIFF
--- a/providers/implementations/rands/seeding/rand_unix.c
+++ b/providers/implementations/rands/seeding/rand_unix.c
@@ -383,7 +383,7 @@ static ssize_t syscall_random(void *buf, size_t buflen)
      * Note: Sometimes getentropy() can be provided but not implemented
      * internally. So we need to check errno for ENOSYS
      */
-#  if !defined(__DragonFly__)
+#  if !defined(__DragonFly__) && !defined(__NetBSD__)
 #    if defined(__GNUC__) && __GNUC__>=2 && defined(__ELF__) && !defined(__hpux)
     extern int getentropy(void *buffer, size_t length) __attribute__((weak));
 
@@ -416,7 +416,8 @@ static ssize_t syscall_random(void *buf, size_t buflen)
     return syscall(__NR_getrandom, buf, buflen, 0);
 #  elif (defined(__FreeBSD__) || defined(__NetBSD__)) && defined(KERN_ARND)
     return sysctl_random(buf, buflen);
-#  elif (defined(__DragonFly__)  && __DragonFly_version >= 500700)
+#  elif (defined(__DragonFly__)  && __DragonFly_version >= 500700) \
+     || (defined(__NetBSD__) && __NetBSD_Version >= 1000000000)
     return getrandom(buf, buflen, 0);
 #  else
     errno = ENOSYS;


### PR DESCRIPTION
getentropy shows up wrongly as weak symbol whereas there is no support.

However NetBSD 10.0 will support getrandom.