### PR TITLE
DOC: Fixup the description of the -x509_strict option

### DIFF
--- a/doc/man1/openssl.pod
+++ b/doc/man1/openssl.pod
@@ -887,22 +887,54 @@ Thus errors are thrown on certificates not compliant with RFC 5280.
 When this option is set,
 among others, the following certificate well-formedness conditions are checked:
 
-=over 8
+=over 4
 
-=item The basicConstraints of CA certificates must be marked critical.
-=item CA certificates must explicitly include the keyUsage extension.
-=item If a pathlenConstraint is given the key usage keyCertSign must be allowed.
-=item The pathlenConstraint must not be given for non-CA certificates.
-=item The issuer name of any certificate must not be empty.
-=item The subject name of CA certs, certs with keyUsage crlSign,
-      and certs without subjectAlternativeName must not be empty.
-=item If a subjectAlternativeName extension is given it must not be empty.
-=item The signatureAlgorithm field and the cert signature must be consistent.
-=item Any given authorityKeyIdentifier and any given subjectKeyIdentifier
-      must not be marked critical.
-=item The authorityKeyIdentifier must be given for X.509v3 certs
-      unless they are self-signed.
-=item The subjectKeyIdentifier must be given for all X.509v3 CA certs.
+=item -
+
+The basicConstraints of CA certificates must be marked critical.
+
+=item -
+
+CA certificates must explicitly include the keyUsage extension.
+
+=item -
+
+If a pathlenConstraint is given the key usage keyCertSign must be allowed.
+
+=item -
+
+The pathlenConstraint must not be given for non-CA certificates.
+
+=item -
+
+The issuer name of any certificate must not be empty.
+
+=item -
+
+The subject name of CA certs, certs with keyUsage crlSign, and certs
+without subjectAlternativeName must not be empty.
+
+=item -
+
+If a subjectAlternativeName extension is given it must not be empty.
+
+=item -
+
+The signatureAlgorithm field and the cert signature must be consistent.
+
+=item -
+
+Any given authorityKeyIdentifier and any given subjectKeyIdentifier
+must not be marked critical.
+
+=item -
+
+The authorityKeyIdentifier must be given for X.509v3 certs unless they
+are self-signed.
+
+=item -
+
+The subjectKeyIdentifier must be given for all X.509v3 CA certs.
 
 =back
 


### PR DESCRIPTION
POD commands must always be surrounded by blank lines

POD transformers read everything in paragraph mode.  The following
lines become *one* command, where the second line becomes part of the
text of the first, including the command itself.  In other words,
this:

    =item something
    =item something else

Translates to this in a man-page:

    something =item something else
