### PR TITLE
util/find-doc-nits: check podchecker() return value

### DIFF
--- a/util/find-doc-nits
+++ b/util/find-doc-nits
@@ -778,7 +778,8 @@ sub check {
 
     open my $OUT, '>', $temp
         or die "Can't open $temp, $!";
-    podchecker($filename, $OUT);
+    err($id, "POD errors")
+        if podchecker($filename, $OUT) != 0;
     close $OUT;
     open $OUT, '<', $temp
         or die "Can't read $temp, $!";


### PR DESCRIPTION
From the Pod::Checker manual:

> RETURN VALUE
>        podchecker returns the number of POD syntax errors found or
>        -1 if there were no POD commands at all found in the file.
