### PR TITLE
Rename internal functions so they begin with an ossl_ prefix.

### DIFF
--- a/crypto/evp/legacy_md5_sha1.c
+++ b/crypto/evp/legacy_md5_sha1.c
@@ -18,10 +18,10 @@
 #include "prov/md5_sha1.h"   /* diverse MD5_SHA1 macros */
 #include "legacy_meth.h"
 
-IMPLEMENT_LEGACY_EVP_MD_METH_LC(md5_sha1_int, md5_sha1)
+IMPLEMENT_LEGACY_EVP_MD_METH_LC(md5_sha1_int, ossl_md5_sha1)
 static int md5_sha1_int_ctrl(EVP_MD_CTX *ctx, int cmd, int mslen, void *ms)
 {
-    return md5_sha1_ctrl(EVP_MD_CTX_md_data(ctx), cmd, mslen, ms);
+    return ossl_md5_sha1_ctrl(EVP_MD_CTX_md_data(ctx), cmd, mslen, ms);
 }
 
 static const EVP_MD md5_sha1_md = {

--- a/crypto/evp/legacy_sha.c
+++ b/crypto/evp/legacy_sha.c
@@ -60,12 +60,13 @@ IMPLEMENT_LEGACY_EVP_MD_METH(sha384, SHA384)
 IMPLEMENT_LEGACY_EVP_MD_METH(sha512, SHA512)
 IMPLEMENT_LEGACY_EVP_MD_METH(sha512_224_int, sha512_224)
 IMPLEMENT_LEGACY_EVP_MD_METH(sha512_256_int, sha512_256)
-IMPLEMENT_LEGACY_EVP_MD_METH_SHA3(sha3_int, sha3, '\x06')
-IMPLEMENT_LEGACY_EVP_MD_METH_SHAKE(shake, sha3, '\x1f')
+IMPLEMENT_LEGACY_EVP_MD_METH_SHA3(sha3_int, ossl_sha3, '\x06')
+IMPLEMENT_LEGACY_EVP_MD_METH_SHAKE(shake, ossl_sha3, '\x1f')
 
 static int sha1_int_ctrl(EVP_MD_CTX *ctx, int cmd, int p1, void *p2)
 {
-    return sha1_ctrl(ctx != NULL ? EVP_MD_CTX_md_data(ctx) : NULL, cmd, p1, p2);
+    return ossl_sha1_ctrl(ctx != NULL ? EVP_MD_CTX_md_data(ctx) : NULL,
+                          cmd, p1, p2);
 }
 
 static int shake_ctrl(EVP_MD_CTX *evp_ctx, int cmd, int p1, void *p2)

--- a/crypto/md5/asm/md5-586.pl
+++ b/crypto/md5/asm/md5-586.pl
@@ -42,7 +42,7 @@ $X="esi";
  0, 7, 14, 5, 12, 3, 10, 1, 8, 15, 6, 13, 4, 11, 2, 9,	# R3
  );
 
-&md5_block("md5_block_asm_data_order");
+&md5_block("ossl_md5_block_asm_data_order");
 &asm_finish();
 
 close STDOUT or die "error closing STDOUT: $!";

--- a/crypto/md5/asm/md5-sparcv9.pl
+++ b/crypto/md5/asm/md5-sparcv9.pl
@@ -216,9 +216,9 @@ $code.=<<___;
 SPARC_PIC_THUNK(%g1)
 #endif
 
-.globl	md5_block_asm_data_order
+.globl	ossl_md5_block_asm_data_order
 .align	32
-md5_block_asm_data_order:
+ossl_md5_block_asm_data_order:
 	SPARC_LOAD_ADDRESS_LEAF(OPENSSL_sparcv9cap_P,%g1,%g5)
 	ld	[%g1+4],%g1		! OPENSSL_sparcv9cap_P[1]
 
@@ -371,8 +371,8 @@ $code.=<<___;
 	wr	%g0,$saved_asi,%asi
 	ret
 	restore
-.type	md5_block_asm_data_order,#function
-.size	md5_block_asm_data_order,(.-md5_block_asm_data_order)
+.type	ossl_md5_block_asm_data_order,#function
+.size	ossl_md5_block_asm_data_order,(.-ossl_md5_block_asm_data_order)
 
 .asciz	"MD5 block transform for SPARCv9, CRYPTOGAMS by <appro\@openssl.org>"
 .align	4

--- a/crypto/md5/asm/md5-x86_64.pl
+++ b/crypto/md5/asm/md5-x86_64.pl
@@ -139,9 +139,9 @@ $code .= <<EOF;
 .text
 .align 16
 
-.globl md5_block_asm_data_order
-.type md5_block_asm_data_order,\@function,3
-md5_block_asm_data_order:
+.globl ossl_md5_block_asm_data_order
+.type ossl_md5_block_asm_data_order,\@function,3
+ossl_md5_block_asm_data_order:
 .cfi_startproc
 	push	%rbp
 .cfi_push	%rbp
@@ -283,7 +283,7 @@ $code .= <<EOF;
 .Lepilogue:
 	ret
 .cfi_endproc
-.size md5_block_asm_data_order,.-md5_block_asm_data_order
+.size ossl_md5_block_asm_data_order,.-ossl_md5_block_asm_data_order
 EOF
 
 # EXCEPTION_DISPOSITION handler (EXCEPTION_RECORD *rec,ULONG64 frame,
@@ -378,13 +378,13 @@ se_handler:
 
 .section	.pdata
 .align	4
-	.rva	.LSEH_begin_md5_block_asm_data_order
-	.rva	.LSEH_end_md5_block_asm_data_order
-	.rva	.LSEH_info_md5_block_asm_data_order
+	.rva	.LSEH_begin_ossl_md5_block_asm_data_order
+	.rva	.LSEH_end_ossl_md5_block_asm_data_order
+	.rva	.LSEH_info_ossl_md5_block_asm_data_order
 
 .section	.xdata
 .align	8
-.LSEH_info_md5_block_asm_data_order:
+.LSEH_info_ossl_md5_block_asm_data_order:
 	.byte	9,0,0,0
 	.rva	se_handler
 ___

--- a/crypto/md5/md5_local.h
+++ b/crypto/md5/md5_local.h
@@ -15,11 +15,11 @@
 #ifdef MD5_ASM
 # if defined(__i386) || defined(__i386__) || defined(_M_IX86) || \
      defined(__x86_64) || defined(__x86_64__) || defined(_M_AMD64) || defined(_M_X64)
-#  define md5_block_data_order md5_block_asm_data_order
+#  define md5_block_data_order ossl_md5_block_asm_data_order
 # elif defined(__ia64) || defined(__ia64__) || defined(_M_IA64)
-#  define md5_block_data_order md5_block_asm_data_order
+#  define md5_block_data_order ossl_md5_block_asm_data_order
 # elif defined(__sparc) || defined(__sparc__)
-#  define md5_block_data_order md5_block_asm_data_order
+#  define md5_block_data_order ossl_md5_block_asm_data_order
 # endif
 #endif
 

--- a/crypto/md5/md5_sha1.c
+++ b/crypto/md5/md5_sha1.c
@@ -17,28 +17,28 @@
 #include "prov/md5_sha1.h"
 #include <openssl/evp.h>
 
-int md5_sha1_init(MD5_SHA1_CTX *mctx)
+int ossl_md5_sha1_init(MD5_SHA1_CTX *mctx)
 {
     if (!MD5_Init(&mctx->md5))
         return 0;
     return SHA1_Init(&mctx->sha1);
 }
 
-int md5_sha1_update(MD5_SHA1_CTX *mctx, const void *data, size_t count)
+int ossl_md5_sha1_update(MD5_SHA1_CTX *mctx, const void *data, size_t count)
 {
     if (!MD5_Update(&mctx->md5, data, count))
         return 0;
     return SHA1_Update(&mctx->sha1, data, count);
 }
 
-int md5_sha1_final(unsigned char *md, MD5_SHA1_CTX *mctx)
+int ossl_md5_sha1_final(unsigned char *md, MD5_SHA1_CTX *mctx)
 {
     if (!MD5_Final(md, &mctx->md5))
         return 0;
     return SHA1_Final(md + MD5_DIGEST_LENGTH, &mctx->sha1);
 }
 
-int md5_sha1_ctrl(MD5_SHA1_CTX *mctx, int cmd, int mslen, void *ms)
+int ossl_md5_sha1_ctrl(MD5_SHA1_CTX *mctx, int cmd, int mslen, void *ms)
 {
     unsigned char padtmp[48];
     unsigned char md5tmp[MD5_DIGEST_LENGTH];
@@ -58,7 +58,7 @@ int md5_sha1_ctrl(MD5_SHA1_CTX *mctx, int cmd, int mslen, void *ms)
      * with master secret and pad_1.
      */
 
-    if (md5_sha1_update(mctx, ms, mslen) <= 0)
+    if (ossl_md5_sha1_update(mctx, ms, mslen) <= 0)
         return 0;
 
     /* Set padtmp to pad_1 value */
@@ -78,10 +78,10 @@ int md5_sha1_ctrl(MD5_SHA1_CTX *mctx, int cmd, int mslen, void *ms)
 
     /* Reinitialise context */
 
-    if (!md5_sha1_init(mctx))
+    if (!ossl_md5_sha1_init(mctx))
         return 0;
 
-    if (md5_sha1_update(mctx, ms, mslen) <= 0)
+    if (ossl_md5_sha1_update(mctx, ms, mslen) <= 0)
         return 0;
 
     /* Set padtmp to pad_2 value */

--- a/crypto/rand/rand_lib.c
+++ b/crypto/rand/rand_lib.c
@@ -125,7 +125,7 @@ int RAND_poll(void)
         if (pool == NULL)
             return 0;
 
-        if (prov_pool_acquire_entropy(pool) == 0)
+        if (ossl_pool_acquire_entropy(pool) == 0)
             goto err;
 
         if (meth->add == NULL

--- a/crypto/rc4/asm/rc4-md5-x86_64.pl
+++ b/crypto/rc4/asm/rc4-md5-x86_64.pl
@@ -27,7 +27,7 @@
 # minimize register usage, which was used as "main thread" with RC4
 # weaved into it, one RC4 round per one MD5 round. In addition to the
 # stiched subroutine the script can generate standalone replacement
-# md5_block_asm_data_order and RC4. Below are performance numbers in
+# ossl_md5_block_asm_data_order and RC4. Below are performance numbers in
 # cycles per processed byte, less is better, for these the standalone
 # subroutines, sum of them, and stitched one:
 #
@@ -76,7 +76,7 @@ if ($rc4 && !$md5) {
   $func="RC4";				$nargs=4;
 } elsif ($md5 && !$rc4) {
   ($ctx,$inp,$len) = ("%rdi","%rsi","%rdx");
-  $func="md5_block_asm_data_order";	$nargs=3;
+  $func="ossl_md5_block_asm_data_order";	$nargs=3;
 } else {
   ($dat,$in0,$out,$ctx,$inp,$len) = ("%rdi","%rsi","%rdx","%rcx","%r8","%r9");
   $func="rc4_md5_enc";			$nargs=6;

--- a/crypto/sha/sha1dgst.c
+++ b/crypto/sha/sha1dgst.c
@@ -25,7 +25,7 @@
 #include "sha_local.h"
 #include "crypto/sha.h"
 
-int sha1_ctrl(SHA_CTX *sha1, int cmd, int mslen, void *ms)
+int ossl_sha1_ctrl(SHA_CTX *sha1, int cmd, int mslen, void *ms)
 {
     unsigned char padtmp[40];
     unsigned char sha1tmp[SHA_DIGEST_LENGTH];

--- a/crypto/sha/sha3.c
+++ b/crypto/sha/sha3.c
@@ -12,18 +12,18 @@
 
 void SHA3_squeeze(uint64_t A[5][5], unsigned char *out, size_t len, size_t r);
 
-void sha3_reset(KECCAK1600_CTX *ctx)
+void ossl_sha3_reset(KECCAK1600_CTX *ctx)
 {
     memset(ctx->A, 0, sizeof(ctx->A));
     ctx->bufsz = 0;
 }
 
-int sha3_init(KECCAK1600_CTX *ctx, unsigned char pad, size_t bitlen)
+int ossl_sha3_init(KECCAK1600_CTX *ctx, unsigned char pad, size_t bitlen)
 {
     size_t bsz = SHA3_BLOCKSIZE(bitlen);
 
     if (bsz <= sizeof(ctx->buf)) {
-        sha3_reset(ctx);
+        ossl_sha3_reset(ctx);
         ctx->block_size = bsz;
         ctx->md_size = bitlen / 8;
         ctx->pad = pad;
@@ -33,16 +33,16 @@ int sha3_init(KECCAK1600_CTX *ctx, unsigned char pad, size_t bitlen)
     return 0;
 }
 
-int keccak_kmac_init(KECCAK1600_CTX *ctx, unsigned char pad, size_t bitlen)
+int ossl_keccak_kmac_init(KECCAK1600_CTX *ctx, unsigned char pad, size_t bitlen)
 {
-    int ret = sha3_init(ctx, pad, bitlen);
+    int ret = ossl_sha3_init(ctx, pad, bitlen);
 
     if (ret)
         ctx->md_size *= 2;
     return ret;
 }
 
-int sha3_update(KECCAK1600_CTX *ctx, const void *_inp, size_t len)
+int ossl_sha3_update(KECCAK1600_CTX *ctx, const void *_inp, size_t len)
 {
     const unsigned char *inp = _inp;
     size_t bsz = ctx->block_size;
@@ -84,7 +84,7 @@ int sha3_update(KECCAK1600_CTX *ctx, const void *_inp, size_t len)
     return 1;
 }
 
-int sha3_final(unsigned char *md, KECCAK1600_CTX *ctx)
+int ossl_sha3_final(unsigned char *md, KECCAK1600_CTX *ctx)
 {
     size_t bsz = ctx->block_size;
     size_t num = ctx->bufsz;

--- a/include/crypto/sha.h
+++ b/include/crypto/sha.h
@@ -15,6 +15,6 @@
 
 int sha512_224_init(SHA512_CTX *);
 int sha512_256_init(SHA512_CTX *);
-int sha1_ctrl(SHA_CTX *ctx, int cmd, int mslen, void *ms);
+int ossl_sha1_ctrl(SHA_CTX *ctx, int cmd, int mslen, void *ms);
 
 #endif

--- a/include/internal/sha3.h
+++ b/include/internal/sha3.h
@@ -40,11 +40,12 @@ struct keccak_st {
     PROV_SHA3_METHOD meth;
 };
 
-void sha3_reset(KECCAK1600_CTX *ctx);
-int sha3_init(KECCAK1600_CTX *ctx, unsigned char pad, size_t bitlen);
-int keccak_kmac_init(KECCAK1600_CTX *ctx, unsigned char pad, size_t bitlen);
-int sha3_update(KECCAK1600_CTX *ctx, const void *_inp, size_t len);
-int sha3_final(unsigned char *md, KECCAK1600_CTX *ctx);
+void ossl_sha3_reset(KECCAK1600_CTX *ctx);
+int ossl_sha3_init(KECCAK1600_CTX *ctx, unsigned char pad, size_t bitlen);
+int ossl_keccak_kmac_init(KECCAK1600_CTX *ctx, unsigned char pad,
+                          size_t bitlen);
+int ossl_sha3_update(KECCAK1600_CTX *ctx, const void *_inp, size_t len);
+int ossl_sha3_final(unsigned char *md, KECCAK1600_CTX *ctx);
 
 size_t SHA3_absorb(uint64_t A[5][5], const unsigned char *inp, size_t len,
                    size_t r);

--- a/providers/implementations/digests/md5_sha1_prov.c
+++ b/providers/implementations/digests/md5_sha1_prov.c
@@ -44,8 +44,8 @@ static int md5_sha1_set_ctx_params(void *vctx, const OSSL_PARAM params[])
     if (ctx != NULL && params != NULL) {
         p = OSSL_PARAM_locate_const(params, OSSL_DIGEST_PARAM_SSL3_MS);
         if (p != NULL && p->data_type == OSSL_PARAM_OCTET_STRING)
-            return md5_sha1_ctrl(ctx, EVP_CTRL_SSL3_MASTER_SECRET, p->data_size,
-                                 p->data);
+            return ossl_md5_sha1_ctrl(ctx, EVP_CTRL_SSL3_MASTER_SECRET,
+                                      p->data_size, p->data);
     }
     return 0;
 }
@@ -53,5 +53,5 @@ static int md5_sha1_set_ctx_params(void *vctx, const OSSL_PARAM params[])
 /* ossl_md5_sha1_functions */
 IMPLEMENT_digest_functions_with_settable_ctx(
     md5_sha1, MD5_SHA1_CTX, MD5_SHA1_CBLOCK, MD5_SHA1_DIGEST_LENGTH, 0,
-    md5_sha1_init, md5_sha1_update, md5_sha1_final,
+    ossl_md5_sha1_init, ossl_md5_sha1_update, ossl_md5_sha1_final,
     md5_sha1_settable_ctx_params, md5_sha1_set_ctx_params)

--- a/providers/implementations/digests/sha2_prov.c
+++ b/providers/implementations/digests/sha2_prov.c
@@ -45,8 +45,8 @@ static int sha1_set_ctx_params(void *vctx, const OSSL_PARAM params[])
     if (ctx != NULL && params != NULL) {
         p = OSSL_PARAM_locate_const(params, OSSL_DIGEST_PARAM_SSL3_MS);
         if (p != NULL && p->data_type == OSSL_PARAM_OCTET_STRING)
-            return sha1_ctrl(ctx, EVP_CTRL_SSL3_MASTER_SECRET, p->data_size,
-                             p->data);
+            return ossl_sha1_ctrl(ctx, EVP_CTRL_SSL3_MASTER_SECRET,
+                                  p->data_size, p->data);
     }
     return 0;
 }

--- a/providers/implementations/digests/sha3_prov.c
+++ b/providers/implementations/digests/sha3_prov.c
@@ -50,7 +50,7 @@ static int keccak_init(void *vctx)
     if (!ossl_prov_is_running())
         return 0;
     /* The newctx() handles most of the ctx fixed setup. */
-    sha3_reset((KECCAK1600_CTX *)vctx);
+    ossl_sha3_reset((KECCAK1600_CTX *)vctx);
     return 1;
 }
 
@@ -118,7 +118,7 @@ static size_t generic_sha3_absorb(void *vctx, const void *inp, size_t len)
 
 static int generic_sha3_final(unsigned char *md, void *vctx)
 {
-    return sha3_final(md, (KECCAK1600_CTX *)vctx);
+    return ossl_sha3_final(md, (KECCAK1600_CTX *)vctx);
 }
 
 static PROV_SHA3_METHOD sha3_generic_md =
@@ -198,7 +198,7 @@ static void *name##_newctx(void *provctx)                                      \
                                                                                \
     if (ctx == NULL)                                                           \
         return NULL;                                                           \
-    sha3_init(ctx, pad, bitlen);                                               \
+    ossl_sha3_init(ctx, pad, bitlen);                                          \
     SHA3_SET_MD(uname, typ)                                                    \
     return ctx;                                                                \
 }
@@ -212,7 +212,7 @@ static void *uname##_newctx(void *provctx)                                     \
                                                                                \
     if (ctx == NULL)                                                           \
         return NULL;                                                           \
-    keccak_kmac_init(ctx, pad, bitlen);                                        \
+    ossl_keccak_kmac_init(ctx, pad, bitlen);                                   \
     ctx->meth = sha3_generic_md;                                               \
     return ctx;                                                                \
 }

--- a/providers/implementations/include/prov/macsignature.h
+++ b/providers/implementations/include/prov/macsignature.h
@@ -25,6 +25,6 @@ struct mac_key_st {
 
 typedef struct mac_key_st MAC_KEY;
 
-MAC_KEY *mac_key_new(OSSL_LIB_CTX *libctx, int cmac);
-void mac_key_free(MAC_KEY *mackey);
-int mac_key_up_ref(MAC_KEY *mackey);
+MAC_KEY *ossl_mac_key_new(OSSL_LIB_CTX *libctx, int cmac);
+void ossl_mac_key_free(MAC_KEY *mackey);
+int ossl_mac_key_up_ref(MAC_KEY *mackey);

--- a/providers/implementations/include/prov/md5_sha1.h
+++ b/providers/implementations/include/prov/md5_sha1.h
@@ -27,10 +27,10 @@ typedef struct md5_sha1_st {
     SHA_CTX sha1;
 } MD5_SHA1_CTX;
 
-int md5_sha1_init(MD5_SHA1_CTX *mctx);
-int md5_sha1_update(MD5_SHA1_CTX *mctx, const void *data, size_t count);
-int md5_sha1_final(unsigned char *md, MD5_SHA1_CTX *mctx);
-int md5_sha1_ctrl(MD5_SHA1_CTX *mctx, int cmd, int mslen, void *ms);
+int ossl_md5_sha1_init(MD5_SHA1_CTX *mctx);
+int ossl_md5_sha1_update(MD5_SHA1_CTX *mctx, const void *data, size_t count);
+int ossl_md5_sha1_final(unsigned char *md, MD5_SHA1_CTX *mctx);
+int ossl_md5_sha1_ctrl(MD5_SHA1_CTX *mctx, int cmd, int mslen, void *ms);
 
 # endif /* OPENSSL_NO_MD5 */
 

--- a/providers/implementations/include/prov/seeding.h
+++ b/providers/implementations/include/prov/seeding.h
@@ -18,8 +18,8 @@ size_t prov_drbg_get_additional_data(RAND_POOL *pool, unsigned char **pout);
 
 void prov_drbg_cleanup_additional_data(RAND_POOL *pool, unsigned char *out);
 
-size_t prov_pool_acquire_entropy(RAND_POOL *pool);
-int prov_pool_add_nonce_data(RAND_POOL *pool);
+size_t ossl_pool_acquire_entropy(RAND_POOL *pool);
+int ossl_pool_add_nonce_data(RAND_POOL *pool);
 
 /*
  * Add some platform specific additional data

--- a/providers/implementations/keymgmt/mac_legacy_kmgmt.c
+++ b/providers/implementations/keymgmt/mac_legacy_kmgmt.c
@@ -57,7 +57,7 @@ struct mac_gen_ctx {
     PROV_CIPHER cipher;
 };
 
-MAC_KEY *mac_key_new(OSSL_LIB_CTX *libctx, int cmac)
+MAC_KEY *ossl_mac_key_new(OSSL_LIB_CTX *libctx, int cmac)
 {
     MAC_KEY *mackey;
 
@@ -80,7 +80,7 @@ MAC_KEY *mac_key_new(OSSL_LIB_CTX *libctx, int cmac)
     return mackey;
 }
 
-void mac_key_free(MAC_KEY *mackey)
+void ossl_mac_key_free(MAC_KEY *mackey)
 {
     int ref = 0;
 
@@ -98,7 +98,7 @@ void mac_key_free(MAC_KEY *mackey)
     OPENSSL_free(mackey);
 }
 
-int mac_key_up_ref(MAC_KEY *mackey)
+int ossl_mac_key_up_ref(MAC_KEY *mackey)
 {
     int ref = 0;
 
@@ -118,17 +118,17 @@ int mac_key_up_ref(MAC_KEY *mackey)
 
 static void *mac_new(void *provctx)
 {
-    return mac_key_new(PROV_LIBCTX_OF(provctx), 0);
+    return ossl_mac_key_new(PROV_LIBCTX_OF(provctx), 0);
 }
 
 static void *mac_new_cmac(void *provctx)
 {
-    return mac_key_new(PROV_LIBCTX_OF(provctx), 1);
+    return ossl_mac_key_new(PROV_LIBCTX_OF(provctx), 1);
 }
 
 static void mac_free(void *mackey)
 {
-    mac_key_free(mackey);
+    ossl_mac_key_free(mackey);
 }
 
 static int mac_has(const void *keydata, int selection)
@@ -454,7 +454,7 @@ static void *mac_gen(void *genctx, OSSL_CALLBACK *cb, void *cbarg)
     if (!ossl_prov_is_running() || gctx == NULL)
         return NULL;
 
-    if ((key = mac_key_new(gctx->libctx, 0)) == NULL) {
+    if ((key = ossl_mac_key_new(gctx->libctx, 0)) == NULL) {
         ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
         return NULL;
     }
@@ -465,7 +465,7 @@ static void *mac_gen(void *genctx, OSSL_CALLBACK *cb, void *cbarg)
 
     if (gctx->priv_key == NULL) {
         ERR_raise(ERR_LIB_PROV, EVP_R_INVALID_KEY);
-        mac_key_free(key);
+        ossl_mac_key_free(key);
         return NULL;
     }
 

--- a/providers/implementations/rands/crngt.c
+++ b/providers/implementations/rands/crngt.c
@@ -41,7 +41,7 @@ static int crngt_get_entropy(OSSL_LIB_CTX *ctx, RAND_POOL *pool,
     if (pool == NULL)
         return 0;
 
-    n = prov_pool_acquire_entropy(pool);
+    n = ossl_pool_acquire_entropy(pool);
     if (n >= CRNGT_BUFSIZ) {
         fmd = EVP_MD_fetch(ctx, "SHA256", "");
         if (fmd == NULL)
@@ -104,7 +104,7 @@ static int prov_crngt_compare_previous(const unsigned char *prev,
     return res;
 }
 
-size_t prov_crngt_get_entropy(PROV_DRBG *drbg,
+size_t ossl_crngt_get_entropy(PROV_DRBG *drbg,
                               unsigned char **pout,
                               int entropy, size_t min_len, size_t max_len,
                               int prediction_resistance)
@@ -164,7 +164,7 @@ err:
     return r;
 }
 
-void prov_crngt_cleanup_entropy(PROV_DRBG *drbg,
+void ossl_crngt_cleanup_entropy(PROV_DRBG *drbg,
                                 unsigned char *out, size_t outlen)
 {
     OPENSSL_secure_clear_free(out, outlen);

--- a/providers/implementations/rands/drbg.c
+++ b/providers/implementations/rands/drbg.c
@@ -139,7 +139,7 @@ static unsigned int get_parent_reseed_count(PROV_DRBG *drbg)
  * is fetched using the parent's ossl_prov_drbg_generate().
  *
  * Otherwise, the entropy is polled from the system entropy sources
- * using prov_pool_acquire_entropy().
+ * using ossl_pool_acquire_entropy().
  *
  * If a random pool has been added to the DRBG using RAND_add(), then
  * its entropy will be used up first.
@@ -214,7 +214,7 @@ static size_t prov_drbg_get_entropy(PROV_DRBG *drbg, unsigned char **pout,
         }
     } else {
         /* Get entropy by polling system entropy sources. */
-        entropy_available = prov_pool_acquire_entropy(pool);
+        entropy_available = ossl_pool_acquire_entropy(pool);
     }
 
     if (entropy_available > 0) {
@@ -246,7 +246,7 @@ static size_t get_entropy(PROV_DRBG *drbg, unsigned char **pout, int entropy,
 {
 #ifdef FIPS_MODULE
     if (drbg->parent == NULL)
-        return prov_crngt_get_entropy(drbg, pout, entropy, min_len, max_len,
+        return ossl_crngt_get_entropy(drbg, pout, entropy, min_len, max_len,
                                       prediction_resistance);
 #endif
 
@@ -258,7 +258,7 @@ static void cleanup_entropy(PROV_DRBG *drbg, unsigned char *out, size_t outlen)
 {
 #ifdef FIPS_MODULE
     if (drbg->parent == NULL)
-        prov_crngt_cleanup_entropy(drbg, out, outlen);
+        ossl_crngt_cleanup_entropy(drbg, out, outlen);
     else
 #endif
         prov_drbg_cleanup_entropy(drbg, out, outlen);
@@ -353,7 +353,7 @@ static size_t prov_drbg_get_nonce(PROV_DRBG *drbg,
     if (pool == NULL)
         return 0;
 
-    if (prov_pool_add_nonce_data(pool) == 0)
+    if (ossl_pool_add_nonce_data(pool) == 0)
         goto err;
 
     data.instance = drbg;
@@ -807,7 +807,7 @@ int drbg_enable_locking(void *vctx)
  *
  * Returns a pointer to the new DRBG instance on success, NULL on failure.
  */
-PROV_DRBG *prov_rand_drbg_new
+PROV_DRBG *ossl_rand_drbg_new
     (void *provctx, void *parent, const OSSL_DISPATCH *p_dispatch,
      int (*dnew)(PROV_DRBG *ctx),
      int (*instantiate)(PROV_DRBG *drbg,
@@ -883,11 +883,11 @@ PROV_DRBG *prov_rand_drbg_new
     return drbg;
 
  err:
-    prov_rand_drbg_free(drbg);
+    ossl_rand_drbg_free(drbg);
     return NULL;
 }
 
-void prov_rand_drbg_free(PROV_DRBG *drbg)
+void ossl_rand_drbg_free(PROV_DRBG *drbg)
 {
     if (drbg == NULL)
         return;

--- a/providers/implementations/rands/drbg_ctr.c
+++ b/providers/implementations/rands/drbg_ctr.c
@@ -645,7 +645,7 @@ static int drbg_ctr_get_ctx_params(void *vdrbg, OSSL_PARAM params[])
             return 0;
     }
 
-    return drbg_get_ctx_params(drbg, params);
+    return ossl_drbg_get_ctx_params(drbg, params);
 }
 
 static const OSSL_PARAM *drbg_ctr_gettable_ctx_params(ossl_unused void *provctx)
@@ -713,7 +713,7 @@ static int drbg_ctr_set_ctx_params(void *vctx, const OSSL_PARAM params[])
     if (cipher_init && !drbg_ctr_init(ctx))
         return 0;
 
-    return drbg_set_ctx_params(ctx, params);
+    return ossl_drbg_set_ctx_params(ctx, params);
 }
 
 static const OSSL_PARAM *drbg_ctr_settable_ctx_params(ossl_unused void *provctx)
@@ -744,9 +744,9 @@ const OSSL_DISPATCH ossl_drbg_ctr_functions[] = {
       (void(*)(void))drbg_ctr_uninstantiate_wrapper },
     { OSSL_FUNC_RAND_GENERATE, (void(*)(void))drbg_ctr_generate_wrapper },
     { OSSL_FUNC_RAND_RESEED, (void(*)(void))drbg_ctr_reseed_wrapper },
-    { OSSL_FUNC_RAND_ENABLE_LOCKING, (void(*)(void))drbg_enable_locking },
-    { OSSL_FUNC_RAND_LOCK, (void(*)(void))drbg_lock },
-    { OSSL_FUNC_RAND_UNLOCK, (void(*)(void))drbg_unlock },
+    { OSSL_FUNC_RAND_ENABLE_LOCKING, (void(*)(void))ossl_drbg_enable_locking },
+    { OSSL_FUNC_RAND_LOCK, (void(*)(void))ossl_drbg_lock },
+    { OSSL_FUNC_RAND_UNLOCK, (void(*)(void))ossl_drbg_unlock },
     { OSSL_FUNC_RAND_SETTABLE_CTX_PARAMS,
       (void(*)(void))drbg_ctr_settable_ctx_params },
     { OSSL_FUNC_RAND_SET_CTX_PARAMS, (void(*)(void))drbg_ctr_set_ctx_params },

--- a/providers/implementations/rands/drbg_ctr.c
+++ b/providers/implementations/rands/drbg_ctr.c
@@ -606,7 +606,7 @@ static int drbg_ctr_new(PROV_DRBG *drbg)
 static void *drbg_ctr_new_wrapper(void *provctx, void *parent,
                                    const OSSL_DISPATCH *parent_dispatch)
 {
-    return prov_rand_drbg_new(provctx, parent, parent_dispatch, &drbg_ctr_new,
+    return ossl_rand_drbg_new(provctx, parent, parent_dispatch, &drbg_ctr_new,
                               &drbg_ctr_instantiate, &drbg_ctr_uninstantiate,
                               &drbg_ctr_reseed, &drbg_ctr_generate);
 }
@@ -625,7 +625,7 @@ static void drbg_ctr_free(void *vdrbg)
 
         OPENSSL_secure_clear_free(ctr, sizeof(*ctr));
     }
-    prov_rand_drbg_free(drbg);
+    ossl_rand_drbg_free(drbg);
 }
 
 static int drbg_ctr_get_ctx_params(void *vdrbg, OSSL_PARAM params[])

--- a/providers/implementations/rands/drbg_hash.c
+++ b/providers/implementations/rands/drbg_hash.c
@@ -407,7 +407,7 @@ static int drbg_hash_new(PROV_DRBG *ctx)
 static void *drbg_hash_new_wrapper(void *provctx, void *parent,
                                    const OSSL_DISPATCH *parent_dispatch)
 {
-    return prov_rand_drbg_new(provctx, parent, parent_dispatch, &drbg_hash_new,
+    return ossl_rand_drbg_new(provctx, parent, parent_dispatch, &drbg_hash_new,
                               &drbg_hash_instantiate, &drbg_hash_uninstantiate,
                               &drbg_hash_reseed, &drbg_hash_generate);
 }
@@ -422,7 +422,7 @@ static void drbg_hash_free(void *vdrbg)
         ossl_prov_digest_reset(&hash->digest);
         OPENSSL_secure_clear_free(hash, sizeof(*hash));
     }
-    prov_rand_drbg_free(drbg);
+    ossl_rand_drbg_free(drbg);
 }
 
 static int drbg_hash_get_ctx_params(void *vdrbg, OSSL_PARAM params[])

--- a/providers/implementations/rands/drbg_hash.c
+++ b/providers/implementations/rands/drbg_hash.c
@@ -439,7 +439,7 @@ static int drbg_hash_get_ctx_params(void *vdrbg, OSSL_PARAM params[])
             return 0;
     }
 
-    return drbg_get_ctx_params(drbg, params);
+    return ossl_drbg_get_ctx_params(drbg, params);
 }
 
 static const OSSL_PARAM *drbg_hash_gettable_ctx_params(ossl_unused void *p_ctx)
@@ -484,7 +484,7 @@ static int drbg_hash_set_ctx_params(void *vctx, const OSSL_PARAM params[])
         ctx->min_noncelen = ctx->min_entropylen / 2;
     }
 
-    return drbg_set_ctx_params(ctx, params);
+    return ossl_drbg_set_ctx_params(ctx, params);
 }
 
 static const OSSL_PARAM *drbg_hash_settable_ctx_params(ossl_unused void *p_ctx)
@@ -507,9 +507,9 @@ const OSSL_DISPATCH ossl_drbg_hash_functions[] = {
       (void(*)(void))drbg_hash_uninstantiate_wrapper },
     { OSSL_FUNC_RAND_GENERATE, (void(*)(void))drbg_hash_generate_wrapper },
     { OSSL_FUNC_RAND_RESEED, (void(*)(void))drbg_hash_reseed_wrapper },
-    { OSSL_FUNC_RAND_ENABLE_LOCKING, (void(*)(void))drbg_enable_locking },
-    { OSSL_FUNC_RAND_LOCK, (void(*)(void))drbg_lock },
-    { OSSL_FUNC_RAND_UNLOCK, (void(*)(void))drbg_unlock },
+    { OSSL_FUNC_RAND_ENABLE_LOCKING, (void(*)(void))ossl_drbg_enable_locking },
+    { OSSL_FUNC_RAND_LOCK, (void(*)(void))ossl_drbg_lock },
+    { OSSL_FUNC_RAND_UNLOCK, (void(*)(void))ossl_drbg_unlock },
     { OSSL_FUNC_RAND_SETTABLE_CTX_PARAMS,
       (void(*)(void))drbg_hash_settable_ctx_params },
     { OSSL_FUNC_RAND_SET_CTX_PARAMS, (void(*)(void))drbg_hash_set_ctx_params },

--- a/providers/implementations/rands/drbg_hmac.c
+++ b/providers/implementations/rands/drbg_hmac.c
@@ -304,7 +304,7 @@ static int drbg_hmac_new(PROV_DRBG *drbg)
 static void *drbg_hmac_new_wrapper(void *provctx, void *parent,
                                    const OSSL_DISPATCH *parent_dispatch)
 {
-    return prov_rand_drbg_new(provctx, parent, parent_dispatch, &drbg_hmac_new,
+    return ossl_rand_drbg_new(provctx, parent, parent_dispatch, &drbg_hmac_new,
                               &drbg_hmac_instantiate, &drbg_hmac_uninstantiate,
                               &drbg_hmac_reseed, &drbg_hmac_generate);
 }
@@ -319,7 +319,7 @@ static void drbg_hmac_free(void *vdrbg)
         ossl_prov_digest_reset(&hmac->digest);
         OPENSSL_secure_clear_free(hmac, sizeof(*hmac));
     }
-    prov_rand_drbg_free(drbg);
+    ossl_rand_drbg_free(drbg);
 }
 
 static int drbg_hmac_get_ctx_params(void *vdrbg, OSSL_PARAM params[])

--- a/providers/implementations/rands/drbg_hmac.c
+++ b/providers/implementations/rands/drbg_hmac.c
@@ -346,7 +346,7 @@ static int drbg_hmac_get_ctx_params(void *vdrbg, OSSL_PARAM params[])
             return 0;
     }
 
-    return drbg_get_ctx_params(drbg, params);
+    return ossl_drbg_get_ctx_params(drbg, params);
 }
 
 static const OSSL_PARAM *drbg_hmac_gettable_ctx_params(ossl_unused void *p_ctx)
@@ -397,7 +397,7 @@ static int drbg_hmac_set_ctx_params(void *vctx, const OSSL_PARAM params[])
         ctx->min_noncelen = ctx->min_entropylen / 2;
     }
 
-    return drbg_set_ctx_params(ctx, params);
+    return ossl_drbg_set_ctx_params(ctx, params);
 }
 
 static const OSSL_PARAM *drbg_hmac_settable_ctx_params(ossl_unused void *p_ctx)
@@ -421,9 +421,9 @@ const OSSL_DISPATCH ossl_drbg_ossl_hmac_functions[] = {
       (void(*)(void))drbg_hmac_uninstantiate_wrapper },
     { OSSL_FUNC_RAND_GENERATE, (void(*)(void))drbg_hmac_generate_wrapper },
     { OSSL_FUNC_RAND_RESEED, (void(*)(void))drbg_hmac_reseed_wrapper },
-    { OSSL_FUNC_RAND_ENABLE_LOCKING, (void(*)(void))drbg_enable_locking },
-    { OSSL_FUNC_RAND_LOCK, (void(*)(void))drbg_lock },
-    { OSSL_FUNC_RAND_UNLOCK, (void(*)(void))drbg_unlock },
+    { OSSL_FUNC_RAND_ENABLE_LOCKING, (void(*)(void))ossl_drbg_enable_locking },
+    { OSSL_FUNC_RAND_LOCK, (void(*)(void))ossl_drbg_lock },
+    { OSSL_FUNC_RAND_UNLOCK, (void(*)(void))ossl_drbg_unlock },
     { OSSL_FUNC_RAND_SETTABLE_CTX_PARAMS,
       (void(*)(void))drbg_hmac_settable_ctx_params },
     { OSSL_FUNC_RAND_SET_CTX_PARAMS, (void(*)(void))drbg_hmac_set_ctx_params },

--- a/providers/implementations/rands/drbg_local.h
+++ b/providers/implementations/rands/drbg_local.h
@@ -230,13 +230,13 @@ int ossl_prov_drbg_generate(PROV_DRBG *drbg, unsigned char *out, size_t outlen,
     }
 
 /* locking api */
-OSSL_FUNC_rand_enable_locking_fn drbg_enable_locking;
-OSSL_FUNC_rand_lock_fn drbg_lock;
-OSSL_FUNC_rand_unlock_fn drbg_unlock;
+OSSL_FUNC_rand_enable_locking_fn ossl_drbg_enable_locking;
+OSSL_FUNC_rand_lock_fn ossl_drbg_lock;
+OSSL_FUNC_rand_unlock_fn ossl_drbg_unlock;
 
 /* Common parameters for all of our DRBGs */
-int drbg_get_ctx_params(PROV_DRBG *drbg, OSSL_PARAM params[]);
-int drbg_set_ctx_params(PROV_DRBG *drbg, const OSSL_PARAM params[]);
+int ossl_drbg_get_ctx_params(PROV_DRBG *drbg, OSSL_PARAM params[]);
+int ossl_drbg_set_ctx_params(PROV_DRBG *drbg, const OSSL_PARAM params[]);
 
 #define OSSL_PARAM_DRBG_SETTABLE_CTX_COMMON                                      \
     OSSL_PARAM_uint(OSSL_DRBG_PARAM_RESEED_REQUESTS, NULL),             \

--- a/providers/implementations/rands/drbg_local.h
+++ b/providers/implementations/rands/drbg_local.h
@@ -191,7 +191,7 @@ struct prov_drbg_st {
     OSSL_CALLBACK *cleanup_nonce_fn;
 };
 
-PROV_DRBG *prov_rand_drbg_new
+PROV_DRBG *ossl_rand_drbg_new
     (void *provctx, void *parent, const OSSL_DISPATCH *parent_dispatch,
      int (*dnew)(PROV_DRBG *ctx),
      int (*instantiate)(PROV_DRBG *drbg,
@@ -203,7 +203,7 @@ PROV_DRBG *prov_rand_drbg_new
                    const unsigned char *adin, size_t adin_len),
      int (*generate)(PROV_DRBG *, unsigned char *out, size_t outlen,
                      const unsigned char *adin, size_t adin_len));
-void prov_rand_drbg_free(PROV_DRBG *drbg);
+void ossl_rand_drbg_free(PROV_DRBG *drbg);
 
 int ossl_prov_drbg_instantiate(PROV_DRBG *drbg, unsigned int strength,
                                int prediction_resistance,
@@ -258,11 +258,11 @@ int drbg_set_ctx_params(PROV_DRBG *drbg, const OSSL_PARAM params[]);
     OSSL_PARAM_uint64(OSSL_DRBG_PARAM_RESEED_TIME_INTERVAL, NULL)
 
 /* Continuous test "entropy" calls */
-size_t prov_crngt_get_entropy(PROV_DRBG *drbg,
+size_t ossl_crngt_get_entropy(PROV_DRBG *drbg,
                               unsigned char **pout,
                               int entropy, size_t min_len, size_t max_len,
                               int prediction_resistance);
-void prov_crngt_cleanup_entropy(PROV_DRBG *drbg,
+void ossl_crngt_cleanup_entropy(PROV_DRBG *drbg,
                                 unsigned char *out, size_t outlen);
 
 #endif

--- a/providers/implementations/rands/seeding/rand_unix.c
+++ b/providers/implementations/rands/seeding/rand_unix.c
@@ -165,7 +165,7 @@ static uint64_t get_timer_bits(void);
  *
  * As a precaution, we assume only 2 bits of entropy per byte.
  */
-size_t prov_pool_acquire_entropy(RAND_POOL *pool)
+size_t ossl_pool_acquire_entropy(RAND_POOL *pool)
 {
     short int code;
     int i, k;
@@ -649,7 +649,7 @@ void rand_pool_keep_random_devices_open(int keep)
  * of input from the different entropy sources (trust, quality,
  * possibility of blocking).
  */
-size_t prov_pool_acquire_entropy(RAND_POOL *pool)
+size_t ossl_pool_acquire_entropy(RAND_POOL *pool)
 {
 #  if defined(OPENSSL_RAND_SEED_NONE)
     return rand_pool_entropy_available(pool);
@@ -777,7 +777,7 @@ size_t prov_pool_acquire_entropy(RAND_POOL *pool)
 
 #if (defined(OPENSSL_SYS_UNIX) && !defined(OPENSSL_SYS_VXWORKS)) \
      || defined(__DJGPP__)
-int prov_pool_add_nonce_data(RAND_POOL *pool)
+int ossl_pool_add_nonce_data(RAND_POOL *pool)
 {
     struct {
         pid_t pid;

--- a/providers/implementations/rands/seeding/rand_vms.c
+++ b/providers/implementations/rands/seeding/rand_vms.c
@@ -474,7 +474,7 @@ size_t data_collect_method(RAND_POOL *pool)
     return rand_pool_entropy_available(pool);
 }
 
-int prov_pool_add_nonce_data(RAND_POOL *pool)
+int ossl_pool_add_nonce_data(RAND_POOL *pool)
 {
     struct {
         pid_t pid;
@@ -568,7 +568,7 @@ size_t get_entropy_method(RAND_POOL *pool)
  * These functions are called by the RAND / DRBG functions
  */
 
-size_t prov_pool_acquire_entropy(RAND_POOL *pool)
+size_t ossl_pool_acquire_entropy(RAND_POOL *pool)
 {
     if (init_get_entropy_address())
         return get_entropy_method(pool);

--- a/providers/implementations/rands/seeding/rand_vxworks.c
+++ b/providers/implementations/rands/seeding/rand_vxworks.c
@@ -96,7 +96,7 @@ int rand_pool_add_additional_data(RAND_POOL *pool)
     return rand_pool_add(pool, (unsigned char *)&data, sizeof(data), 0);
 }
 
-int prov_pool_add_nonce_data(RAND_POOL *pool)
+int ossl_pool_add_nonce_data(RAND_POOL *pool)
 {
     struct {
         pid_t pid;
@@ -118,7 +118,7 @@ int prov_pool_add_nonce_data(RAND_POOL *pool)
     return rand_pool_add(pool, (unsigned char *)&data, sizeof(data), 0);
 }
 
-size_t prov_pool_acquire_entropy(RAND_POOL *pool)
+size_t ossl_pool_acquire_entropy(RAND_POOL *pool)
 {
 #if defined(RAND_SEED_VXRANDLIB)
     /* vxRandLib based entropy method */

--- a/providers/implementations/rands/seeding/rand_win.c
+++ b/providers/implementations/rands/seeding/rand_win.c
@@ -42,7 +42,7 @@
 #  define INTEL_DEF_PROV L"Intel Hardware Cryptographic Service Provider"
 # endif
 
-size_t prov_pool_acquire_entropy(RAND_POOL *pool)
+size_t ossl_pool_acquire_entropy(RAND_POOL *pool)
 {
 # ifndef USE_BCRYPTGENRANDOM
     HCRYPTPROV hProvider;
@@ -122,7 +122,7 @@ size_t prov_pool_acquire_entropy(RAND_POOL *pool)
 }
 
 
-int prov_pool_add_nonce_data(RAND_POOL *pool)
+int ossl_pool_add_nonce_data(RAND_POOL *pool)
 {
     struct {
         DWORD pid;

--- a/providers/implementations/rands/test_rng.c
+++ b/providers/implementations/rands/test_rng.c
@@ -61,7 +61,7 @@ static void test_rng_free(void *vdrbg)
     OPENSSL_free(t->entropy);
     OPENSSL_free(t->nonce);
     OPENSSL_free(drbg->data);
-    prov_rand_drbg_free(drbg);
+    ossl_rand_drbg_free(drbg);
 }
 
 static int test_rng_instantiate(PROV_DRBG *drbg,
@@ -293,7 +293,7 @@ static int test_rng_verify_zeroization(void *vdrbg)
 static void *test_rng_new_wrapper(void *provctx, void *parent,
                                    const OSSL_DISPATCH *parent_dispatch)
 {
-    return prov_rand_drbg_new(provctx, parent, parent_dispatch,
+    return ossl_rand_drbg_new(provctx, parent, parent_dispatch,
                               &test_rng_new, &test_rng_instantiate,
                               &test_rng_uninstantiate, &test_rng_reseed,
                               &test_rng_generate);

--- a/providers/implementations/rands/test_rng.c
+++ b/providers/implementations/rands/test_rng.c
@@ -183,7 +183,7 @@ static int test_rng_get_ctx_params(void *vdrbg, OSSL_PARAM params[])
 {
     PROV_DRBG *drbg = (PROV_DRBG *)vdrbg;
 
-    return drbg_get_ctx_params(drbg, params);
+    return ossl_drbg_get_ctx_params(drbg, params);
 }
 
 static const OSSL_PARAM *test_rng_gettable_ctx_params(ossl_unused void *provctx)
@@ -261,7 +261,7 @@ static int test_rng_set_ctx_params(void *vdrbg, const OSSL_PARAM params[])
             || !set_size_t(params, OSSL_DRBG_PARAM_MAX_ADINLEN,
                            &drbg->max_adinlen))
         return 0;
-    return drbg_set_ctx_params(drbg, params);
+    return ossl_drbg_set_ctx_params(drbg, params);
 }
 
 static const OSSL_PARAM *test_rng_settable_ctx_params(ossl_unused void *provctx)
@@ -309,9 +309,9 @@ const OSSL_DISPATCH ossl_test_rng_functions[] = {
     { OSSL_FUNC_RAND_GENERATE, (void(*)(void))test_rng_generate_wrapper },
     { OSSL_FUNC_RAND_RESEED, (void(*)(void))test_rng_reseed_wrapper },
     { OSSL_FUNC_RAND_NONCE, (void(*)(void))test_rng_nonce },
-    { OSSL_FUNC_RAND_ENABLE_LOCKING, (void(*)(void))drbg_enable_locking },
-    { OSSL_FUNC_RAND_LOCK, (void(*)(void))drbg_lock },
-    { OSSL_FUNC_RAND_UNLOCK, (void(*)(void))drbg_unlock },
+    { OSSL_FUNC_RAND_ENABLE_LOCKING, (void(*)(void))ossl_drbg_enable_locking },
+    { OSSL_FUNC_RAND_LOCK, (void(*)(void))ossl_drbg_lock },
+    { OSSL_FUNC_RAND_UNLOCK, (void(*)(void))ossl_drbg_unlock },
     { OSSL_FUNC_RAND_SETTABLE_CTX_PARAMS,
       (void(*)(void))test_rng_settable_ctx_params },
     { OSSL_FUNC_RAND_SET_CTX_PARAMS, (void(*)(void))test_rng_set_ctx_params },

--- a/providers/implementations/signature/mac_legacy.c
+++ b/providers/implementations/signature/mac_legacy.c
@@ -98,10 +98,10 @@ static int mac_digest_sign_init(void *vpmacctx, const char *mdname, void *vkey)
     if (!ossl_prov_is_running()
             || pmacctx == NULL
             || vkey == NULL
-            || !mac_key_up_ref(vkey))
+            || !ossl_mac_key_up_ref(vkey))
         return 0;
 
-    mac_key_free(pmacctx->key);
+    ossl_mac_key_free(pmacctx->key);
     pmacctx->key = vkey;
 
     if (pmacctx->key->cipher.cipher != NULL)
@@ -154,7 +154,7 @@ static void mac_freectx(void *vpmacctx)
 
     OPENSSL_free(ctx->propq);
     EVP_MAC_CTX_free(ctx->macctx);
-    mac_key_free(ctx->key);
+    ossl_mac_key_free(ctx->key);
     OPENSSL_free(ctx);
 }
 
@@ -174,7 +174,7 @@ static void *mac_dupctx(void *vpmacctx)
     dstctx->key = NULL;
     dstctx->macctx = NULL;
 
-    if (srcctx->key != NULL && !mac_key_up_ref(srcctx->key))
+    if (srcctx->key != NULL && !ossl_mac_key_up_ref(srcctx->key))
         goto err;
     dstctx->key = srcctx->key;
 


### PR DESCRIPTION
Rename these functions:
```
keccak_kmac_init(), mac_key_free(), mac_key_new(), mac_key_up_ref(),
md5_block_asm_data_order(), md5_sha1_ctrl(), md5_sha1_final(),
md5_sha1_init(), md5_sha1_update(), prov_crngt_cleanup_entropy(),
prov_crngt_get_entropy(), prov_pool_acquire_entropy(),
prov_pool_add_nonce_data(), prov_rand_drbg_free(), prov_rand_drbg_new(),
sha1_ctrl(), sha3_final(), sha3_init(), sha3_reset() and sha3_update().
```
so that they begin with an ossl_ prefix.