### PR TITLE
Fix crash in genpkey app when -pkeyopt digest:name is used for DH/DSA

### DIFF
--- a/providers/implementations/keymgmt/dh_kmgmt.c
+++ b/providers/implementations/keymgmt/dh_kmgmt.c
@@ -69,8 +69,8 @@ struct dh_gen_ctx {
     int hindex;
     int priv_len;
 
-    const char *mdname;
-    const char *mdprops;
+    char *mdname;
+    char *mdprops;
     OSSL_CALLBACK *cb;
     void *cbarg;
     int dh_type;
@@ -527,13 +527,19 @@ static int dh_gen_set_params(void *genctx, const OSSL_PARAM params[])
     if (p != NULL) {
         if (p->data_type != OSSL_PARAM_UTF8_STRING)
             return 0;
-        gctx->mdname = p->data;
+        OPENSSL_free(gctx->mdname);
+        gctx->mdname = OPENSSL_strdup(p->data);
+        if (gctx->mdname == NULL)
+            return 0;
     }
     p = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_FFC_DIGEST_PROPS);
     if (p != NULL) {
         if (p->data_type != OSSL_PARAM_UTF8_STRING)
             return 0;
-        gctx->mdprops = p->data;
+        OPENSSL_free(gctx->mdprops);
+        gctx->mdprops = OPENSSL_strdup(p->data);
+        if (gctx->mdprops == NULL)
+            return 0;
     }
     p = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_DH_PRIV_LEN);
     if (p != NULL && !OSSL_PARAM_get_int(p, &gctx->priv_len))
@@ -671,6 +677,8 @@ static void dh_gen_cleanup(void *genctx)
     if (gctx == NULL)
         return;
 
+    OPENSSL_free(gctx->mdname);
+    OPENSSL_free(gctx->mdprops);
     OPENSSL_clear_free(gctx->seed, gctx->seedlen);
     OPENSSL_free(gctx);
 }

--- a/providers/implementations/keymgmt/dsa_kmgmt.c
+++ b/providers/implementations/keymgmt/dsa_kmgmt.c
@@ -63,8 +63,8 @@ struct dsa_gen_ctx {
     int gen_type; /* DSA_PARAMGEN_TYPE_FIPS_186_2 or DSA_PARAMGEN_TYPE_FIPS_186_4 */
     int pcounter;
     int hindex;
-    const char *mdname;
-    const char *mdprops;
+    char *mdname;
+    char *mdprops;
     OSSL_CALLBACK *cb;
     void *cbarg;
 };
@@ -451,13 +451,19 @@ static int dsa_gen_set_params(void *genctx, const OSSL_PARAM params[])
     if (p != NULL) {
         if (p->data_type != OSSL_PARAM_UTF8_STRING)
             return 0;
-        gctx->mdname = p->data;
+        OPENSSL_free(gctx->mdname);
+        gctx->mdname = OPENSSL_strdup(p->data);
+        if (gctx->mdname == NULL)
+            return 0;
     }
     p = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_FFC_DIGEST_PROPS);
     if (p != NULL) {
         if (p->data_type != OSSL_PARAM_UTF8_STRING)
             return 0;
-        gctx->mdprops = p->data;
+        OPENSSL_free(gctx->mdprops);
+        gctx->mdprops = OPENSSL_strdup(p->data);
+        if (gctx->mdprops == NULL)
+            return 0;
     }
     return 1;
 }
@@ -564,6 +570,8 @@ static void dsa_gen_cleanup(void *genctx)
     if (gctx == NULL)
         return;
 
+    OPENSSL_free(gctx->mdname);
+    OPENSSL_free(gctx->mdprops);
     OPENSSL_clear_free(gctx->seed, gctx->seedlen);
     OPENSSL_free(gctx);
 }

--- a/test/recipes/15-test_gendh.t
+++ b/test/recipes/15-test_gendh.t
@@ -18,7 +18,7 @@ setup("test_gendh");
 
 plan skip_all => "This test is unsupported in a no-dh build" if disabled("dh");
 
-plan tests => 12;
+plan tests => 13;
 
 ok(run(app([ 'openssl', 'genpkey', '-genparam',
              '-algorithm', 'DH',
@@ -32,6 +32,14 @@ ok(run(app([ 'openssl', 'genpkey', '-genparam',
              '-pkeyopt', 'type:fips186_4',
              '-text'])),
    "genpkey DH params fips186_4 with unverifiable g");
+
+ok(run(app([ 'openssl', 'genpkey', '-genparam',
+             '-algorithm', 'DH',
+             '-pkeyopt', 'pbits:2048',
+             '-pkeyopt', 'qbits:224',
+             '-pkeyopt', 'digest:SHA512-224',
+             '-pkeyopt', 'type:fips186_4'])),
+   "genpkey DH params fips186_4 with truncated SHA");
 
 ok(run(app([ 'openssl', 'genpkey', '-genparam',
              '-algorithm', 'DH',

--- a/test/recipes/15-test_gendsa.t
+++ b/test/recipes/15-test_gendsa.t
@@ -19,7 +19,7 @@ setup("test_gendsa");
 plan skip_all => "This test is unsupported in a no-dsa build"
     if disabled("dsa");
 
-plan tests => 10;
+plan tests => 11;
 
 ok(run(app([ 'openssl', 'genpkey', '-genparam',
              '-algorithm', 'DSA',
@@ -33,6 +33,14 @@ ok(run(app([ 'openssl', 'genpkey', '-genparam',
              '-pkeyopt', 'type:fips186_4',
              '-text'])),
    "genpkey DSA params fips186_4 with unverifiable g");
+
+ok(run(app([ 'openssl', 'genpkey', '-genparam',
+             '-algorithm', 'DSA',
+             '-pkeyopt', 'pbits:2048',
+             '-pkeyopt', 'qbits:224',
+             '-pkeyopt', 'digest:SHA512-256',
+             '-pkeyopt', 'type:fips186_4'])),
+   "genpkey DSA params fips186_4 with truncated SHA");
 
 ok(run(app([ 'openssl', 'genpkey', '-genparam',
              '-algorithm', 'DSA',


### PR DESCRIPTION
By the time the keygen is called the references to strings inside the
gen ctx are floating pointers. A strdup solves this problem.

Found whilst checking that truncated SHA worked for keygen.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
