### PR TITLE
Fix EVP_CIPHER_CTX_set_padding for legacy path

### DIFF
--- a/crypto/evp/evp_enc.c
+++ b/crypto/evp/evp_enc.c
@@ -948,7 +948,7 @@ int EVP_CIPHER_CTX_set_padding(EVP_CIPHER_CTX *ctx, int pad)
     else
         ctx->flags |= EVP_CIPH_NO_PADDING;
 
-    if (ctx->cipher != NULL &&  ctx->cipher->prov == NULL)
+    if (ctx->cipher != NULL && ctx->cipher->prov == NULL)
         return 1;
     params[0] = OSSL_PARAM_construct_uint(OSSL_CIPHER_PARAM_PADDING, &pd);
     ok = evp_do_ciph_ctx_setparams(ctx->cipher, ctx->provctx, params);

--- a/crypto/evp/evp_enc.c
+++ b/crypto/evp/evp_enc.c
@@ -948,6 +948,8 @@ int EVP_CIPHER_CTX_set_padding(EVP_CIPHER_CTX *ctx, int pad)
     else
         ctx->flags |= EVP_CIPH_NO_PADDING;
 
+    if (ctx->cipher != NULL &&  ctx->cipher->prov == NULL)
+        return 1;
     params[0] = OSSL_PARAM_construct_uint(OSSL_CIPHER_PARAM_PADDING, &pd);
     ok = evp_do_ciph_ctx_setparams(ctx->cipher, ctx->provctx, params);
 


### PR DESCRIPTION
Fixes #13057

When using an engine, there is no cipher->prov so a call to
EVP_CIPHER_CTX_set_padding() returns an error when
evp_do_ciph_ctx_setparams() is called. For the legacy path it needs to
avoid doing the call and just return 1.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
