### PR TITLE
RSA: Fix guard mixup

### DIFF
--- a/include/openssl/rsa.h
+++ b/include/openssl/rsa.h
@@ -246,13 +246,17 @@ OSSL_DEPRECATEDIN_3_0 int RSA_test_flags(const RSA *r, int flags);
 OSSL_DEPRECATEDIN_3_0 void RSA_set_flags(RSA *r, int flags);
 OSSL_DEPRECATEDIN_3_0 int RSA_get_version(RSA *r);
 OSSL_DEPRECATEDIN_3_0 ENGINE *RSA_get0_engine(const RSA *r);
+#  endif  /* !OPENSSL_NO_DEPRECATED_3_0 */
 
 /* Deprecated version */
+#  ifndef OPENSSL_NO_DEPRECATED_0_9_8
 OSSL_DEPRECATEDIN_0_9_8 RSA *RSA_generate_key(int bits, unsigned long e, void
                                               (*callback) (int, int, void *),
                                               void *cb_arg);
+#  endif
 
 /* New version */
+#  ifndef OPENSSL_NO_DEPRECATED_3_0
 OSSL_DEPRECATEDIN_3_0 int RSA_generate_key_ex(RSA *rsa, int bits, BIGNUM *e,
                                               BN_GENCB *cb);
 /* Multi-prime version */

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -3200,7 +3200,7 @@ d2i_ASN1_OCTET_STRING                   3265	3_0_0	EXIST::FUNCTION:
 ENGINE_set_load_pubkey_function         3266	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,ENGINE
 BIO_vprintf                             3267	3_0_0	EXIST::FUNCTION:
 CMS_RecipientInfo_decrypt               3268	3_0_0	EXIST::FUNCTION:CMS
-RSA_generate_key                        3269	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,RSA
+RSA_generate_key                        3269	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_0_9_8,RSA
 PKCS7_set0_type_other                   3270	3_0_0	EXIST::FUNCTION:
 OCSP_REQUEST_new                        3271	3_0_0	EXIST::FUNCTION:OCSP
 BIO_lookup                              3272	3_0_0	EXIST::FUNCTION:SOCK


### PR DESCRIPTION
A OSSL_DEPRECATEDIN_0_9_8 function was surrounded by a
OPENSSL_NO_DEPRECATED_3_0 guard.
