### PR TITLE
Remove deprecation warning suppression from genpkey

### DIFF
--- a/apps/include/apps.h
+++ b/apps/include/apps.h
@@ -160,6 +160,8 @@ EVP_PKEY *load_engine_private_key(ENGINE *e, const char *keyid,
 EVP_PKEY *load_engine_public_key(ENGINE *e, const char *keyid,
                                  const char *pass, const char *desc);
 
+int get_legacy_pkey_id(OSSL_LIB_CTX *libctx, const char *algname, ENGINE *e);
+
 # ifndef OPENSSL_NO_OCSP
 OCSP_RESPONSE *process_responder(OCSP_REQUEST *req,
                                  const char *host, const char *path,

--- a/apps/lib/engine.c
+++ b/apps/lib/engine.c
@@ -17,6 +17,7 @@
 #include <string.h> /* strcmp */
 
 #include <openssl/types.h> /* Ensure we have the ENGINE type, regardless */
+#include <openssl/err.h>
 #ifndef OPENSSL_NO_ENGINE
 # include <openssl/engine.h>
 #endif

--- a/apps/lib/engine.c
+++ b/apps/lib/engine.c
@@ -145,3 +145,31 @@ EVP_PKEY *load_engine_public_key(ENGINE *e, const char *keyid,
     return rv;
 }
 
+int get_legacy_pkey_id(OSSL_LIB_CTX *libctx, const char *algname, ENGINE *e)
+{
+    const EVP_PKEY_ASN1_METHOD *ameth;
+    ENGINE *tmpeng = NULL;
+    int pkey_id = NID_undef;
+
+    ERR_set_mark();
+    ameth = EVP_PKEY_asn1_find_str(&tmpeng, algname, -1);
+
+#if !defined(OPENSSL_NO_ENGINE)
+    ENGINE_finish(tmpeng);
+
+    if (ameth == NULL && e != NULL)
+        ameth = ENGINE_get_pkey_asn1_meth_str(e, algname, -1);
+    else
+#endif
+    /* We're only interested if it comes from an ENGINE */
+    if (tmpeng == NULL)
+        ameth = NULL;
+
+    ERR_pop_to_mark();
+    if (ameth == NULL)
+        return NID_undef;
+
+    EVP_PKEY_asn1_get0_info(&pkey_id, NULL, NULL, NULL, NULL, ameth);
+
+    return pkey_id;
+}


### PR DESCRIPTION
genpkey was supressing deprecation warnings in order to support ENGINE
functionality. We move all of that into a separate file so that we don't
need to suppress the warnings anymore.

Fixes #13118

