### PR TITLE
x509_vfy.c: Remove superfluous assignment to 'ret' in check_chain()

### DIFF
--- a/crypto/x509/x509_vfy.c
+++ b/crypto/x509/x509_vfy.c
@@ -484,11 +484,9 @@ static int check_chain(X509_STORE_CTX *ctx)
             CHECK_CB((ctx->param->flags & X509_V_FLAG_X509_STRICT) != 0
                          && ret != 1 && ret != 0,
                      ctx, x, i, X509_V_ERR_INVALID_CA);
-            ret = 1;
             break;
         case 0:
             CHECK_CB(ret != 0,  ctx, x, i, X509_V_ERR_INVALID_NON_CA);
-            ret = 1;
             break;
         default:
             /* X509_V_FLAG_X509_STRICT is implicit for intermediate CAs */
@@ -496,7 +494,6 @@ static int check_chain(X509_STORE_CTX *ctx)
                      || ((i + 1 < num
                           || ctx->param->flags & X509_V_FLAG_X509_STRICT)
                          && ret != 1), ctx, x, i, X509_V_ERR_INVALID_CA);
-            ret = 1;
             break;
         }
         if (num > 1) {

--- a/crypto/x509/x509_vfy.c
+++ b/crypto/x509/x509_vfy.c
@@ -486,7 +486,7 @@ static int check_chain(X509_STORE_CTX *ctx)
                      ctx, x, i, X509_V_ERR_INVALID_CA);
             break;
         case 0:
-            CHECK_CB(ret != 0,  ctx, x, i, X509_V_ERR_INVALID_NON_CA);
+            CHECK_CB(ret != 0, ctx, x, i, X509_V_ERR_INVALID_NON_CA);
             break;
         default:
             /* X509_V_FLAG_X509_STRICT is implicit for intermediate CAs */


### PR DESCRIPTION
This fixes #13354 referring to Coverity CID 1469104.

Three superfluous assignments to `ret` in `check_chain()` removed.

On this occasion we also fix a whitespace nit in `check_chain()`.