### PR TITLE
Use send(,,,MSG_NOSIGNAL) where available

### DIFF
--- a/include/internal/sockets.h
+++ b/include/internal/sockets.h
@@ -160,7 +160,11 @@ struct servent *PASCAL getservbyname(const char *, const char *);
 #  define ioctlsocket(a,b,c)      ioctl(a,b,c)
 #  define closesocket(s)          close(s)
 #  define readsocket(s,b,n)       read((s),(b),(n))
-#  define writesocket(s,b,n)      write((s),(b),(n))
+#  if defined(MSG_NOSIGNAL)
+#   define writesocket(s,b,n)     send((s),(b),(n),MSG_NOSIGNAL)
+#  else
+#   define writesocket(s,b,n)     write((s),(b),(n))
+#  endif
 # endif
 
 /* also in apps/include/apps.h */


### PR DESCRIPTION
Where `MSG_NOSIGNAL` is available, use `send(,,,MSG_NOSIGNAL)` in preference
to `write()` when writing to sockets, to avoid `SIGPIPE`.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
