### PR TITLE
ERR: Drop or deprecate dangerous or overly confusing functions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,16 +23,6 @@ OpenSSL 3.0
 
 ### Changes between 1.1.1 and 3.0 [xx XXX xxxx]
 
- * Deprecated ERR_get_error_line(), as it's considered incomplete and confusing.
-   Dropped the new functions ERR_get_error_func() and ERR_get_error_data() for
-   the same reason, and because they were new in 3.0.0.
-
-   Users are recommended to use ERR_get_error_all(), or to pick information
-   with ERR_peek functions and finish off with getting the error code by using
-   ERR_get_error().
-
-   *Richard Levitte*
-
  * Deprecated all the libcrypto and libssl error string loading
    functions: ERR_load_ASN1_strings(), ERR_load_ASYNC_strings(),
    ERR_load_BIO_strings(), ERR_load_BN_strings(), ERR_load_BUF_strings(),
@@ -862,14 +852,17 @@ OpenSSL 3.0
  * Added ERR functionality to give callers access to the stored function
    names that have replaced the older function code based functions.
 
-   New functions are ERR_get_error_func(), ERR_peek_error_func(),
-   ERR_peek_last_error_func(), ERR_get_error_data(), ERR_peek_error_data(),
-   ERR_peek_last_error_data(), ERR_get_error_all(), ERR_peek_error_all()
-   and ERR_peek_last_error_all().
+   New functions are ERR_peek_error_func(), ERR_peek_last_error_func(),
+   ERR_peek_error_data(), ERR_peek_last_error_data(), ERR_get_error_all(),
+   ERR_peek_error_all() and ERR_peek_last_error_all().
 
-   These functions have become deprecated: ERR_get_error_line_data(),
-   ERR_peek_error_line_data(), ERR_peek_last_error_line_data() and
-   ERR_func_error_string().
+   These functions have become deprecated: ERR_get_error_line(),
+   ERR_get_error_line_data(), ERR_peek_error_line_data(),
+   ERR_peek_last_error_line_data() and ERR_func_error_string().
+
+   Users are recommended to use ERR_get_error_all(), or to pick information
+   with ERR_peek functions and finish off with getting the error code by using
+   ERR_get_error().
 
    *Richard Levitte*
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,16 @@ OpenSSL 3.0
 
 ### Changes between 1.1.1 and 3.0 [xx XXX xxxx]
 
+ * Deprecated ERR_get_error_line(), as it's considered incomplete and confusing.
+   Dropped the new functions ERR_get_error_func() and ERR_get_error_data() for
+   the same reason, and because they were new in 3.0.0.
+
+   Users are recommended to use ERR_get_error_all(), or to pick information
+   with ERR_peek functions and finish off with getting the error code by using
+   ERR_get_error().
+
+   *Richard Levitte*
+
  * Deprecated all the libcrypto and libssl error string loading
    functions: ERR_load_ASN1_strings(), ERR_load_ASYNC_strings(),
    ERR_load_BIO_strings(), ERR_load_BN_strings(), ERR_load_BUF_strings(),

--- a/NEWS.md
+++ b/NEWS.md
@@ -20,9 +20,6 @@ OpenSSL 3.0
 
 ### Major changes between OpenSSL 1.1.1 and OpenSSL 3.0 [under development]
 
-  * Deprecated ERR_get_error_line(), ERR_get_error_line_data(),
-    ERR_peek_error_line_data(), ERR_peek_last_error_line_data() and
-    ERR_func_error_string().
   * Deprecated the `ERR_load_` functions.
   * Remove the `RAND_DRBG` API.
   * Deprecated the `ENGINE` API.
@@ -50,7 +47,9 @@ OpenSSL 3.0
   * Added OSSL_ENCODER, a generic encoder API.
   * Added OSSL_PARAM_BLD, an easier to use API to OSSL_PARAM.
   * Added error raising macros, ERR_raise() and ERR_raise_data().
-  * Deprecated ERR_put_error().
+  * Deprecated ERR_put_error(), ERR_get_error_line(), ERR_get_error_line_data(),
+    ERR_peek_error_line_data(), ERR_peek_last_error_line_data() and
+    ERR_func_error_string().
   * Added OSSL_PROVIDER_available(), to check provider availibility.
   * Added 'openssl mac' that uses the EVP_MAC API.
   * Added 'openssl kdf' that uses the EVP_KDF API.

--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,9 @@ OpenSSL 3.0
 
 ### Major changes between OpenSSL 1.1.1 and OpenSSL 3.0 [under development]
 
+  * Deprecated ERR_get_error_line(), ERR_get_error_line_data(),
+    ERR_peek_error_line_data(), ERR_peek_last_error_line_data() and
+    ERR_func_error_string().
   * Deprecated the `ERR_load_` functions.
   * Remove the `RAND_DRBG` API.
   * Deprecated the `ENGINE` API.

--- a/crypto/err/err.c
+++ b/crypto/err/err.c
@@ -312,21 +312,6 @@ unsigned long ERR_get_error(void)
     return get_error_values(EV_POP, NULL, NULL, NULL, NULL, NULL);
 }
 
-unsigned long ERR_get_error_line(const char **file, int *line)
-{
-    return get_error_values(EV_POP, file, line, NULL, NULL, NULL);
-}
-
-unsigned long ERR_get_error_func(const char **func)
-{
-    return get_error_values(EV_POP, NULL, NULL, func, NULL, NULL);
-}
-
-unsigned long ERR_get_error_data(const char **data, int *flags)
-{
-    return get_error_values(EV_POP, NULL, NULL, NULL, data, flags);
-}
-
 unsigned long ERR_get_error_all(const char **file, int *line,
                                 const char **func,
                                 const char **data, int *flags)
@@ -335,6 +320,11 @@ unsigned long ERR_get_error_all(const char **file, int *line,
 }
 
 #ifndef OPENSSL_NO_DEPRECATED_3_0
+unsigned long ERR_get_error_line(const char **file, int *line)
+{
+    return get_error_values(EV_POP, file, line, NULL, NULL, NULL);
+}
+
 unsigned long ERR_get_error_line_data(const char **file, int *line,
                                       const char **data, int *flags)
 {

--- a/crypto/err/err.c
+++ b/crypto/err/err.c
@@ -584,8 +584,7 @@ const char *ERR_reason_error_string(unsigned long e)
     return ((p == NULL) ? NULL : p->string);
 }
 
-/* TODO(3.0): arg ignored for now */
-static void err_delete_thread_state(void *arg)
+static void err_delete_thread_state(void *unused)
 {
     ERR_STATE *state = CRYPTO_THREAD_get_local(&err_thread_local);
     if (state == NULL)

--- a/doc/man3/ERR_get_error.pod
+++ b/doc/man3/ERR_get_error.pod
@@ -102,7 +102,7 @@ of the above.
 ERR_get_error_line(), ERR_get_error_line_data(), ERR_peek_error_line_data()
 and ERR_peek_last_error_line_data() are older variants of ERR_get_error_all(),
 ERR_peek_error_all() and ERR_peek_last_error_all(), and may give confusing
-results.  They should no longer be used.
+results.  They should no longer be used and are therefore deprecated.
 
 An application B<MUST NOT> free the *I<data> pointer (or any other pointers
 returned by these functions) with OPENSSL_free() as freeing is handled

--- a/doc/man3/ERR_get_error.pod
+++ b/doc/man3/ERR_get_error.pod
@@ -4,8 +4,8 @@
 
 ERR_get_error, ERR_peek_error, ERR_peek_last_error,
 ERR_get_error_line, ERR_peek_error_line, ERR_peek_last_error_line,
-ERR_get_error_func, ERR_peek_error_func, ERR_peek_last_error_func,
-ERR_get_error_data, ERR_peek_error_data, ERR_peek_last_error_data,
+ERR_peek_error_func, ERR_peek_last_error_func,
+ERR_peek_error_data, ERR_peek_last_error_data,
 ERR_get_error_all, ERR_peek_error_all, ERR_peek_last_error_all,
 ERR_get_error_line_data, ERR_peek_error_line_data, ERR_peek_last_error_line_data
 - obtain error code and data

--- a/doc/man3/ERR_get_error.pod
+++ b/doc/man3/ERR_get_error.pod
@@ -18,20 +18,17 @@ ERR_get_error_line_data, ERR_peek_error_line_data, ERR_peek_last_error_line_data
  unsigned long ERR_peek_error(void);
  unsigned long ERR_peek_last_error(void);
 
- unsigned long ERR_get_error_line(const char **file, int *line);
  unsigned long ERR_peek_error_line(const char **file, int *line);
  unsigned long ERR_peek_last_error_line(const char **file, int *line);
 
- unsigned long ERR_get_error_func(const char **func);
  unsigned long ERR_peek_error_func(const char **func);
  unsigned long ERR_peek_last_error_func(const char **func);
 
- unsigned long ERR_get_error_data(const char **data, int *flags);
  unsigned long ERR_peek_error_data(const char **data, int *flags);
  unsigned long ERR_peek_last_error_data(const char **data, int *flags);
 
  unsigned long ERR_get_error_all(const char **file, int *line,
-                                 const char *func,
+                                 const char **func,
                                  const char **data, int *flags);
  unsigned long ERR_peek_error_all(const char **file, int *line,
                                   const char *func,
@@ -42,6 +39,7 @@ ERR_get_error_line_data, ERR_peek_error_line_data, ERR_peek_last_error_line_data
 
 Deprecated since OpenSSL 3.0:
 
+ unsigned long ERR_get_error_line(const char **file, int *line);
  unsigned long ERR_get_error_line_data(const char **file, int *line,
                                        const char **data, int *flags);
  unsigned long ERR_peek_error_line_data(const char **file, int *line,
@@ -52,7 +50,7 @@ Deprecated since OpenSSL 3.0:
 =head1 DESCRIPTION
 
 ERR_get_error() returns the earliest error code from the thread's error
-queue and removes the entry. This function can be called repeatedly
+queue and removes the entry.  This function can be called repeatedly
 until there are no more error codes to return.
 
 ERR_peek_error() returns the earliest error code from the thread's
@@ -65,42 +63,48 @@ See L<ERR_GET_LIB(3)> for obtaining further specific information
 such as the reason of the error,
 and L<ERR_error_string(3)> for human-readable error messages.
 
-ERR_get_error_line(), ERR_peek_error_line() and
-ERR_peek_last_error_line() are the same as ERR_get_error(),
-ERR_peek_error() and ERR_peek_last_error(), but on success they
-additionally store the filename and line number where
-the error occurred in *B<file> and *B<line>, as far as they are not B<NULL>.
-An unset filename is indicated as B<"">, i.e., an empty string.
-An unset line number is indicated as B<0>.
+ERR_get_error_all() is the same as ERR_get_error(), but on success it
+additionally stores the filename, line number and function where the error
+occurred in *I<file>, *I<line> and *I<func>, and also extra text and flags
+in *I<data>, *I<flags>.  If any of those parameters are NULL, it will not
+be changed.
+An unset filename is indicated as "", i.e. an empty string.
+An unset line number is indicated as 0.
+An unset function name is indicated as "", i.e. an empty string.
 
 A pointer returned this way by these functions and the ones below
-is valid until the respective entry is removed from the error queue.
+is valid until the respective entry is overwritten in the error queue.
 
-ERR_get_error_func(), ERR_peek_error_func() and
-ERR_peek_last_error_func() are the same as ERR_get_error(),
-ERR_peek_error() and ERR_peek_last_error(), but on success they
-additionally store the name of the function where the error occurred
-in *B<func>, unless it is B<NULL>.
-An unset function name is indicated as B<"">.
+ERR_peek_error_line() and ERR_peek_last_error_line() are the same as
+ERR_peek_error() and ERR_peek_last_error(), but on success they additionally
+store the filename and line number where the error occurred in *I<file> and
+*I<line>, as far as they are not NULL. 
+An unset filename is indicated as "", i.e., an empty string.
+An unset line number is indicated as 0.
 
-ERR_get_error_data(), ERR_peek_error_data() and
-ERR_peek_last_error_data() are the same as ERR_get_error(),
-ERR_peek_error() and ERR_peek_last_error(), but on success they
-additionally store additional data and flags associated with the error
-code in *B<data> and *B<flags>, as far as they are not B<NULL>.
-Unset data is indicated as B<"">.
-In this case the value given for the flag is irrelevant (and equals B<0>).
-*B<data> contains a string if *B<flags>&B<ERR_TXT_STRING> is true.
+ERR_peek_error_func() and ERR_peek_last_error_func() are the same as
+ERR_peek_error() and ERR_peek_last_error(), but on success they additionally
+store the name of the function where the error occurred in *I<func>, unless
+it is NULL. 
+An unset function name is indicated as "".
 
-ERR_get_error_all(), ERR_peek_error_all() and
-ERR_peek_last_error_all() are combinations of all of the above.
+ERR_peek_error_data() and ERR_peek_last_error_data() are the same as
+ERR_peek_error() and ERR_peek_last_error(), but on success they additionally
+store additional data and flags associated with the error code in *I<data>
+and *I<flags>, as far as they are not NULL.
+Unset data is indicated as "".
+In this case the value given for the flag is irrelevant (and equals 0).
+*I<data> contains a string if *I<flags>&B<ERR_TXT_STRING> is true.
 
-ERR_get_error_line_data(), ERR_peek_error_line_data() and
-ERR_peek_last_error_line_data() are older variants of ERR_get_error_all(),
-ERR_peek_error_all() and ERR_peek_last_error_all(), and should no longer
-be used.
+ERR_peek_error_all() and ERR_peek_last_error_all() are combinations of all
+of the above.
 
-An application B<MUST NOT> free the *B<data> pointer (or any other pointers
+ERR_get_error_line(), ERR_get_error_line_data(), ERR_peek_error_line_data()
+and ERR_peek_last_error_line_data() are older variants of ERR_get_error_all(),
+ERR_peek_error_all() and ERR_peek_last_error_all(), and may give confusing
+results.  They should no longer be used.
+
+An application B<MUST NOT> free the *I<data> pointer (or any other pointers
 returned by these functions) with OPENSSL_free() as freeing is handled
 automatically by the error library.
 
@@ -115,18 +119,18 @@ L<ERR_GET_LIB(3)>
 
 =head1 HISTORY
 
-ERR_get_error_func(), ERR_peek_error_func(), ERR_peek_last_error_func(),
-ERR_get_error_data(), ERR_peek_error_data(), ERR_peek_last_error_data(),
-ERR_get_error_all(), ERR_peek_error_all() and ERR_peek_last_error_all()
+ERR_peek_error_func(), ERR_peek_last_error_func(),
+ERR_peek_error_data(), ERR_peek_last_error_data(),
+ERR_peek_error_all() and ERR_peek_last_error_all()
 were added in OpenSSL 3.0.
 
-ERR_get_error_line_data(), ERR_peek_error_line_data() and
-ERR_peek_last_error_line_data() became deprecated in OpenSSL 3.0.
+ERR_get_error_line(), ERR_get_error_line_data(), ERR_peek_error_line_data()
+and ERR_peek_last_error_line_data() became deprecated in OpenSSL 3.0.
 
 
 =head1 COPYRIGHT
 
-Copyright 2000-2017 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2000-2020 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/include/openssl/err.h.in
+++ b/include/openssl/err.h.in
@@ -392,23 +392,16 @@ void ERR_vset_error(int lib, int reason, const char *fmt, va_list args);
 void ERR_set_error_data(char *data, int flags);
 
 unsigned long ERR_get_error(void);
-/*
- * TODO(3.0) consider if the following three functions should be deprecated.
- * They all drop the error record from the error queue, so regardless of which
- * one is used, the rest of the information is lost, making them not so useful.
- * The recommendation should be to use the peek functions to extract all the
- * additional data.
- */
-unsigned long ERR_get_error_line(const char **file, int *line);
-unsigned long ERR_get_error_func(const char **func);
-unsigned long ERR_get_error_data(const char **data, int *flags);
 unsigned long ERR_get_error_all(const char **file, int *line,
                                 const char **func,
                                 const char **data, int *flags);
-DEPRECATEDIN_3_0(unsigned long ERR_get_error_line_data(const char **file,
-                                                     int *line,
-                                                     const char **data,
-                                                     int *flags))
+# ifndef OPENSSL_NO_DEPRECATED_3_0
+OSSL_DEPRECATEDIN_3_0
+unsigned long ERR_get_error_line(const char **file, int *line);
+OSSL_DEPRECATEDIN_3_0
+unsigned long ERR_get_error_line_data(const char **file, int *line,
+                                      const char **data, int *flags);
+#endif
 unsigned long ERR_peek_error(void);
 unsigned long ERR_peek_error_line(const char **file, int *line);
 unsigned long ERR_peek_error_func(const char **func);
@@ -416,10 +409,11 @@ unsigned long ERR_peek_error_data(const char **data, int *flags);
 unsigned long ERR_peek_error_all(const char **file, int *line,
                                  const char **func,
                                  const char **data, int *flags);
-DEPRECATEDIN_3_0(unsigned long ERR_peek_error_line_data(const char **file,
-                                                      int *line,
-                                                      const char **data,
-                                                      int *flags))
+# ifndef OPENSSL_NO_DEPRECATED_3_0
+OSSL_DEPRECATEDIN_3_0
+unsigned long ERR_peek_error_line_data(const char **file, int *line,
+                                       const char **data, int *flags);
+# endif
 unsigned long ERR_peek_last_error(void);
 unsigned long ERR_peek_last_error_line(const char **file, int *line);
 unsigned long ERR_peek_last_error_func(const char **func);
@@ -427,10 +421,11 @@ unsigned long ERR_peek_last_error_data(const char **data, int *flags);
 unsigned long ERR_peek_last_error_all(const char **file, int *line,
                                       const char **func,
                                       const char **data, int *flags);
-DEPRECATEDIN_3_0(unsigned long ERR_peek_last_error_line_data(const char **file,
-                                                           int *line,
-                                                           const char **data,
-                                                           int *flags))
+# ifndef OPENSSL_NO_DEPRECATED_3_0
+OSSL_DEPRECATEDIN_3_0
+unsigned long ERR_peek_last_error_line_data(const char **file, int *line,
+                                            const char **data, int *flags);
+# endif
 
 void ERR_clear_error(void);
 

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -3176,7 +3176,7 @@ ERR_load_EVP_strings                    3241	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_
 X509_ATTRIBUTE_set1_data                3242	3_0_0	EXIST::FUNCTION:
 d2i_X509_fp                             3243	3_0_0	EXIST::FUNCTION:STDIO
 MD2_Init                                3244	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,MD2
-ERR_get_error_line                      3245	3_0_0	EXIST::FUNCTION:
+ERR_get_error_line                      3245	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
 X509_CRL_get_ext_by_NID                 3246	3_0_0	EXIST::FUNCTION:
 OPENSSL_INIT_free                       3247	3_0_0	EXIST::FUNCTION:
 PBE2PARAM_free                          3248	3_0_0	EXIST::FUNCTION:
@@ -4693,8 +4693,6 @@ EVP_PKEY_CTX_get_params                 ?	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_CTX_gettable_params            ?	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_CTX_settable_params            ?	3_0_0	EXIST::FUNCTION:
 EVP_CIPHER_CTX_tag_length               ?	3_0_0	EXIST::FUNCTION:
-ERR_get_error_func                      ?	3_0_0	EXIST::FUNCTION:
-ERR_get_error_data                      ?	3_0_0	EXIST::FUNCTION:
 ERR_get_error_all                       ?	3_0_0	EXIST::FUNCTION:
 ERR_peek_error_func                     ?	3_0_0	EXIST::FUNCTION:
 ERR_peek_error_data                     ?	3_0_0	EXIST::FUNCTION:


### PR DESCRIPTION
ERR_get_error_line() is deprecated, and ERR_get_error_func() and
ERR_get_error_data() are removed in favor of ERR_get_error_all(),
since they pop the error record, leaving the caller with only partial
error record data and no way to get the rest if the wish.

If it's desirable to retrieve data piecemeal, the caller should
consider using the diverse ERR_peek functions and finish off with
ERR_get_error().
