### PR TITLE
[WIP] Support calling SHA3_squeeze multiple times

### DIFF
--- a/crypto/evp/digest.c
+++ b/crypto/evp/digest.c
@@ -455,7 +455,7 @@ int EVP_DigestFinalXOF(EVP_MD_CTX *ctx, unsigned char *md, size_t size)
 
     if (EVP_MD_CTX_set_params(ctx, params) > 0)
         ret = ctx->digest->dfinal(ctx->provctx, md, &size, size);
-    EVP_MD_CTX_reset(ctx);
+
     return ret;
 
 legacy:

--- a/include/internal/sha3.h
+++ b/include/internal/sha3.h
@@ -38,6 +38,8 @@ struct keccak_st {
     unsigned char buf[KECCAK1600_WIDTH / 8 - 32];
     unsigned char pad;
     PROV_SHA3_METHOD meth;
+    size_t last_byte;
+    int final_done;
 };
 
 void ossl_sha3_reset(KECCAK1600_CTX *ctx);

--- a/test/evp_test.c
+++ b/test/evp_test.c
@@ -452,7 +452,11 @@ static int digest_test_run(EVP_TEST *t)
         EVP_MD_CTX_free(mctx_cpy);
 
         got_len = expected->output_len;
-        if (!EVP_DigestFinalXOF(mctx, got, got_len)) {
+        if (!EVP_DigestFinalXOF(mctx, got, got_len/2)) {
+            t->err = "DIGESTFINALXOF_ERROR";
+            goto err;
+        }
+        if (!EVP_DigestFinalXOF(mctx, got+got_len/2, got_len-got_len/2)) {
             t->err = "DIGESTFINALXOF_ERROR";
             goto err;
         }


### PR DESCRIPTION
This allows to call EVP_DigestFinalXOF multiple times.

This is WIP because all the assembler versions of SHA3_squeeze need to be modified.

It contains a commit from #13402.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
