### PR TITLE
ktls: Initial support for ChaCha20-Poly1305

### DIFF
--- a/include/internal/ktls.h
+++ b/include/internal/ktls.h
@@ -222,6 +222,11 @@ static ossl_inline ossl_ssize_t ktls_sendfile(int s, int fd, off_t off,
 #    define OPENSSL_KTLS_TLS13
 #    if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 2, 0)
 #     define OPENSSL_KTLS_AES_CCM_128
+#     if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 11, 0)
+#      ifndef OPENSSL_NO_CHACHA
+#       define OPENSSL_KTLS_CHACHA20_POLY1305
+#      endif
+#     endif
 #    endif
 #   endif
 
@@ -254,6 +259,9 @@ struct tls_crypto_info_all {
 #   endif
 #   ifdef OPENSSL_KTLS_AES_CCM_128
         struct tls12_crypto_info_aes_ccm_128 ccm128;
+#   endif
+#   ifdef OPENSSL_KTLS_CHACHA20_POLY1305
+        struct tls12_crypto_info_chacha20_poly1305 chacha20poly1305;
 #   endif
     };
     size_t tls_crypto_info_len;

--- a/ssl/ktls.c
+++ b/ssl/ktls.c
@@ -126,7 +126,9 @@ int ktls_check_supported_cipher(const SSL *s, const EVP_CIPHER *c,
         return 0;
     }
 
-    /* check that cipher is AES_GCM_128, AES_GCM_256, AES_CCM_128 */
+    /* check that cipher is AES_GCM_128, AES_GCM_256, AES_CCM_128 
+     * or Chacha20-Poly1305
+     */
     switch (EVP_CIPHER_nid(c))
     {
 # ifdef OPENSSL_KTLS_AES_CCM_128
@@ -139,6 +141,9 @@ int ktls_check_supported_cipher(const SSL *s, const EVP_CIPHER *c,
 # endif
 # ifdef OPENSSL_KTLS_AES_GCM_256
     case NID_aes_256_gcm:
+# endif
+# ifdef OPENSSL_KTLS_CHACHA20_POLY1305
+    case NID_chacha20_poly1305:
 # endif
         return 1;
     default:
@@ -211,6 +216,20 @@ int ktls_configure_crypto(const SSL *s, const EVP_CIPHER *c, EVP_CIPHER_CTX *dd,
                 TLS_CIPHER_AES_CCM_128_REC_SEQ_SIZE);
         if (rec_seq != NULL)
             *rec_seq = crypto_info->ccm128.rec_seq;
+        return 1;
+# endif
+# ifdef OPENSSL_KTLS_CHACHA20_POLY1305
+    case NID_chacha20_poly1305:
+        crypto_info->chacha20poly1305.info.cipher_type = TLS_CIPHER_CHACHA20_POLY1305;
+        crypto_info->chacha20poly1305.info.version = s->version;
+        crypto_info->tls_crypto_info_len = sizeof(crypto_info->chacha20poly1305);
+        memcpy(crypto_info->chacha20poly1305.iv, iiv,
+		TLS_CIPHER_CHACHA20_POLY1305_IV_SIZE);
+        memcpy(crypto_info->chacha20poly1305.key, key, EVP_CIPHER_key_length(c));
+        memcpy(crypto_info->chacha20poly1305.rec_seq, rl_sequence,
+                TLS_CIPHER_CHACHA20_POLY1305_REC_SEQ_SIZE);
+        if (rec_seq != NULL)
+            *rec_seq = crypto_info->chacha20poly1305.rec_seq;
         return 1;
 # endif
     default:


### PR DESCRIPTION
Linux kernel is going to support ChaCha20-Poly1305 in TLS offload.
Add support for this cipher.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
