### PR TITLE
Add darwin64-arm64-cc build target for OpenSSL 1.1.1

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,9 @@
 
  Changes between 1.1.1h and 1.1.1i [xx XXX xxxx]
 
+  *) Add support for Apple Silicon M1 Macs with the darwin64-arm64-cc target.
+     [Felix Buenemann]
+
   *) The security callback, which can be customised by application code, supports
      the security operation SSL_SECOP_TMP_DH. This is defined to take an EVP_PKEY
      in the "other" parameter. In most places this is what is passed. All these

--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1557,6 +1557,14 @@ my %targets = (
         bn_ops           => "SIXTY_FOUR_BIT_LONG",
         perlasm_scheme   => "macosx",
     },
+    "darwin64-arm64-cc" => {
+        inherit_from     => [ "darwin-common", asm("aarch64_asm") ],
+        CFLAGS           => add("-Wall"),
+        cflags           => add("-arch arm64"),
+        lib_cppflags     => add("-DL_ENDIAN"),
+        bn_ops           => "SIXTY_FOUR_BIT_LONG",
+        perlasm_scheme   => "ios64",
+    },
 
 ##### GNU Hurd
     "hurd-x86" => {


### PR DESCRIPTION
This adds support for the Apple Silicon M1 hardware to OpenSSL 1.1.1 on macOS Big Sur and enables aarch64 assembly.

The changes have been adapted from master and were verified using an Apple MacBook Air (2020, M1) running macOS 11.1 Beta (20C5048l) and have been compiled with Xcode 12.3 beta (12C5020f).

The test suite passes and benchmarks show the expected speed-ups.

Related #12591 Fixes #12254 Duplicate of #12369