### PR TITLE
Undeprecate the -dsaparam option in the dhparam app

### DIFF
--- a/apps/dhparam.c
+++ b/apps/dhparam.c
@@ -124,11 +124,7 @@ int dhparam_main(int argc, char **argv)
             text = 1;
             break;
         case OPT_DSAPARAM:
-# ifdef OPENSSL_NO_DEPRECATED_3_0
-            BIO_printf(bio_err, "The dsaparam option is deprecated.\n");
-# else
             dsaparam = 1;
-# endif
             break;
         case OPT_2:
             g = 2;

--- a/doc/man1/openssl-dhparam.pod.in
+++ b/doc/man1/openssl-dhparam.pod.in
@@ -57,8 +57,6 @@ as the input filename.
 
 =item B<-dsaparam>
 
-This option is deprecated.
-
 If this option is used, DSA rather than DH parameters are read or created;
 they are converted to DH format.  Otherwise, "strong" primes (such
 that (p-1)/2 is also prime) will be used for DH parameter generation.

--- a/doc/man1/openssl-dhparam.pod.in
+++ b/doc/man1/openssl-dhparam.pod.in
@@ -126,7 +126,7 @@ L<openssl-dsaparam(1)>
 
 =head1 HISTORY
 
-The B<-dsaparam> and B<-engine> options were deprecated in OpenSSL 3.0.
+The B<-engine> option was deprecated in OpenSSL 3.0.
 
 The B<-C> option was removed in OpenSSL 3.0.
 


### PR DESCRIPTION
The -dsaparam option was deprecated because it was previously using
deprecated functions in order to operate. This is no longer the case
and therefore does not need to be deprecated.