### PR TITLE
Fix no-posix-io

### DIFF
--- a/apps/lib/http_server.c
+++ b/apps/lib/http_server.c
@@ -30,13 +30,10 @@
 # endif
 #endif
 
+#ifdef HTTP_DAEMON
 int multi = 0; /* run multiple responder processes */
-
-#ifdef HTTP_DAEMON
 int acfd = (int) INVALID_SOCKET;
-#endif
 
-#ifdef HTTP_DAEMON
 static int print_syslog(const char *str, size_t len, void *levPtr)
 {
     int level = *(int *)levPtr;
@@ -61,9 +58,9 @@ void log_message(const char *prog, int level, const char *fmt, ...)
             syslog(level, "%s", buf);
         if (level >= LOG_ERR)
             ERR_print_errors_cb(print_syslog, &level);
-    }
+    } else
 #endif
-    if (!multi) {
+    {
         BIO_printf(bio_err, "%s: ", prog);
         BIO_vprintf(bio_err, fmt, ap);
         BIO_printf(bio_err, "\n");


### PR DESCRIPTION
The "multi" variable should only be used within HTTP_DAEMON guards.
However there were a few spots where this was not the case, which
causes no-posix-io builds to fail.
