### PR TITLE
bio_dgram: FreeBSD removal of IN6_IS_ADDR_V4MAPPED redefinition.

### DIFF
--- a/crypto/bio/bss_dgram.c
+++ b/crypto/bio/bss_dgram.c
@@ -28,16 +28,6 @@
 #  define IPPROTO_IPV6 41       /* windows is lame */
 # endif
 
-# if defined(__FreeBSD__) && defined(IN6_IS_ADDR_V4MAPPED)
-/* Standard definition causes type-punning problems. */
-#  undef IN6_IS_ADDR_V4MAPPED
-#  define s6_addr32 __u6_addr.__u6_addr32
-#  define IN6_IS_ADDR_V4MAPPED(a)               \
-        (((a)->s6_addr32[0] == 0) &&          \
-         ((a)->s6_addr32[1] == 0) &&          \
-         ((a)->s6_addr32[2] == htonl(0x0000ffff)))
-# endif
-
 static int dgram_write(BIO *h, const char *buf, int num);
 static int dgram_read(BIO *h, char *buf, int size);
 static int dgram_puts(BIO *h, const char *str);


### PR DESCRIPTION
Fixed since FreeBSD 9.2 (EOL since 2013), as before it used casts within the macro indeed but had been updated since.