### PR TITLE
Fix no-engine

### DIFF
--- a/Configure
+++ b/Configure
@@ -581,7 +581,7 @@ my @disable_cascades = (
 
     "module"            => [ "fips", "dso" ],
 
-    "engine"            => [ grep /eng$/, @disablables ],
+    "engine"            => [ grep /(eng$|dynamic-engine)/, @disablables ],
     "hw"                => [ "padlockeng" ],
 
     # no-autoalginit is only useful when building non-shared

--- a/Configure
+++ b/Configure
@@ -581,7 +581,7 @@ my @disable_cascades = (
 
     "module"            => [ "fips", "dso" ],
 
-    "engine"            => [ grep /(eng$|dynamic-engine)/, @disablables ],
+    "engine"            => [ "dynamic-engine", grep(/eng$/, @disablables) ],
     "hw"                => [ "padlockeng" ],
 
     # no-autoalginit is only useful when building non-shared


### PR DESCRIPTION
If we specify no-engine then this should cascade to also mean
no-dynamic-engine. The store test was only checking whether
dynamic-engine was disabled, meaning that some tests were failing
in a no-engine build.
