### PR TITLE
TEST: Add a simple module loader, and test the FIPS module with it

### DIFF
--- a/test/build.info
+++ b/test/build.info
@@ -435,6 +435,10 @@ IF[{- !$disabled{tests} -}]
     PROGRAMS{noinst}=shlibloadtest
     SOURCE[shlibloadtest]=shlibloadtest.c simpledynamic.c
     INCLUDE[shlibloadtest]=../include ../apps/include
+
+    PROGRAMS{noinst}=moduleloadtest
+    SOURCE[moduleloadtest]=moduleloadtest.c simpledynamic.c
+    INCLUDE[moduleloadtest]=../include ../apps/include
   ENDIF
 
   # cipher_overhead_test uses internal symbols, so it must be linked with

--- a/test/build.info
+++ b/test/build.info
@@ -433,7 +433,7 @@ IF[{- !$disabled{tests} -}]
 
   IF[{- !$disabled{shared} -}]
     PROGRAMS{noinst}=shlibloadtest
-    SOURCE[shlibloadtest]=shlibloadtest.c
+    SOURCE[shlibloadtest]=shlibloadtest.c simpledynamic.c
     INCLUDE[shlibloadtest]=../include ../apps/include
   ENDIF
 

--- a/test/moduleloadtest.c
+++ b/test/moduleloadtest.c
@@ -36,6 +36,7 @@ static int test_load(const char *path, const char *symbol)
 int main(int argc, char *argv[])
 {
     const char *m, *s;
+    int ok;
 
     if (argc != 2 && argc != 3) {
         fprintf(stderr, "Usage: %s sharedobject [ entrypoint ]\n", argv[0]);
@@ -45,5 +46,8 @@ int main(int argc, char *argv[])
     m = argv[1];
     s = argc == 3 ? argv[2] : NULL;
 
-    return test_load(m, s) ? 0 : 1;
+    ok = test_load(m, s);
+    if (!ok)
+        fprintf(stderr, "ERROR: %s\n", sd_error());
+    return ok ? 0 : 1;
 }

--- a/test/moduleloadtest.c
+++ b/test/moduleloadtest.c
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+/*
+ * Extremely simple dynamic loader, must never be linked with anything other
+ * than the standard C library.  Its purpose is to try to load a dynamic module
+ * and verify the presence of one symbol, if that's given.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <openssl/core.h>
+#include "simpledynamic.h"
+
+static int test_load(const char *path, const char *symbol)
+{
+#ifdef SD_INIT
+    SD sd = SD_INIT;
+    SD_SYM sym;
+
+    return sd_load(path, &sd)
+        && (symbol == NULL || sd_sym(sd, symbol, &sym))
+        && sd_close(sd);
+#else
+    fprintf(stderr, "No dynamic loader\n");
+    return 0;
+#endif
+}
+
+int main(int argc, char *argv[])
+{
+    const char *m, *s;
+
+    if (argc != 3) {
+        fprintf(stderr, "Incorrect number of arguments\n");
+        return 1;
+    }
+
+    m = argv[1];
+    s = argv[2];
+
+    return test_load(m, s) ? 0 : 1;
+}

--- a/test/moduleloadtest.c
+++ b/test/moduleloadtest.c
@@ -37,13 +37,13 @@ int main(int argc, char *argv[])
 {
     const char *m, *s;
 
-    if (argc != 3) {
-        fprintf(stderr, "Incorrect number of arguments\n");
+    if (argc != 2 && argc != 3) {
+        fprintf(stderr, "Usage: %s sharedobject [ entrypoint ]\n", argv[0]);
         return 1;
     }
 
     m = argv[1];
-    s = argv[2];
+    s = argc == 3 ? argv[2] : NULL;
 
     return test_load(m, s) ? 0 : 1;
 }

--- a/test/moduleloadtest.c
+++ b/test/moduleloadtest.c
@@ -24,7 +24,7 @@ static int test_load(const char *path, const char *symbol)
     SD sd = SD_INIT;
     SD_SYM sym;
 
-    return sd_load(path, &sd)
+    return sd_load(path, &sd, SD_MODULE)
         && (symbol == NULL || sd_sym(sd, symbol, &sym))
         && sd_close(sd);
 #else

--- a/test/recipes/90-test_fipsload.t
+++ b/test/recipes/90-test_fipsload.t
@@ -1,0 +1,30 @@
+#! /usr/bin/env perl
+# Copyright 2020 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+use OpenSSL::Test qw/:DEFAULT srctop_dir bldtop_dir/;
+use OpenSSL::Test::Utils;
+
+BEGIN {
+    setup('test_shlibload');
+}
+use lib srctop_dir('Configurations');
+use lib bldtop_dir('.');
+use platform;
+
+plan skip_all => 'Test only supported in a shared build' if disabled('shared');
+plan skip_all => 'Test is disabled on AIX' if config('target') =~ m|^aix|;
+plan skip_all => 'Test is disabled on NonStop' if config('target') =~ m|^nonstop|;
+plan skip_all => 'Test only supported in a dso build' if disabled('dso');
+plan skip_all => 'Test is disabled in an address sanitizer build' unless disabled('asan');
+
+plan tests => 1;
+
+my $fips = bldtop_dir('providers', platform->dso('fips'));
+
+ok(run(test(['moduleloadtest', $fips, 'OSSL_provider_init'])),
+   "trying to load $fips in its own");

--- a/test/shlibloadtest.c
+++ b/test/shlibloadtest.c
@@ -13,7 +13,7 @@
 #include <openssl/opensslv.h>
 #include <openssl/ssl.h>
 #include <openssl/types.h>
-#include "crypto/dso_conf.h"
+#include "simpledynamic.h"
 
 typedef void DSO;
 
@@ -42,67 +42,7 @@ static const char *path_crypto;
 static const char *path_ssl;
 static const char *path_atexit;
 
-#ifdef DSO_DLFCN
-
-# include <dlfcn.h>
-
-# define SHLIB_INIT NULL
-
-typedef void *SHLIB;
-typedef void *SHLIB_SYM;
-
-static int shlib_load(const char *filename, SHLIB *lib)
-{
-    int dl_flags = (RTLD_GLOBAL|RTLD_LAZY);
-#ifdef _AIX
-    if (filename[strlen(filename) - 1] == ')')
-        dl_flags |= RTLD_MEMBER;
-#endif
-    *lib = dlopen(filename, dl_flags);
-    return *lib == NULL ? 0 : 1;
-}
-
-static int shlib_sym(SHLIB lib, const char *symname, SHLIB_SYM *sym)
-{
-    *sym = dlsym(lib, symname);
-    return *sym != NULL;
-}
-
-static int shlib_close(SHLIB lib)
-{
-    return dlclose(lib) != 0 ? 0 : 1;
-}
-#endif
-
-#ifdef DSO_WIN32
-
-# include <windows.h>
-
-# define SHLIB_INIT 0
-
-typedef HINSTANCE SHLIB;
-typedef void *SHLIB_SYM;
-
-static int shlib_load(const char *filename, SHLIB *lib)
-{
-    *lib = LoadLibraryA(filename);
-    return *lib == NULL ? 0 : 1;
-}
-
-static int shlib_sym(SHLIB lib, const char *symname, SHLIB_SYM *sym)
-{
-    *sym = (SHLIB_SYM)GetProcAddress(lib, symname);
-    return *sym != NULL;
-}
-
-static int shlib_close(SHLIB lib)
-{
-    return FreeLibrary(lib) == 0 ? 0 : 1;
-}
-#endif
-
-
-#if defined(DSO_DLFCN) || defined(DSO_WIN32)
+#ifdef SD_INIT
 
 static int atexit_handler_done = 0;
 
@@ -120,12 +60,12 @@ static void atexit_handler(void)
 
 static int test_lib(void)
 {
-    SHLIB ssllib = SHLIB_INIT;
-    SHLIB cryptolib = SHLIB_INIT;
+    SD ssllib = SD_INIT;
+    SD cryptolib = SD_INIT;
     SSL_CTX *ctx;
     union {
         void (*func)(void);
-        SHLIB_SYM sym;
+        SD_SYM sym;
     } symbols[5];
     TLS_method_t myTLS_method;
     SSL_CTX_new_t mySSL_CTX_new;
@@ -142,7 +82,7 @@ static int test_lib(void)
     case DSO_REFTEST:
     case NO_ATEXIT:
     case CRYPTO_FIRST:
-        if (!shlib_load(path_crypto, &cryptolib)) {
+        if (!sd_load(path_crypto, &cryptolib)) {
             fprintf(stderr, "Failed to load libcrypto\n");
             goto end;
         }
@@ -151,13 +91,13 @@ static int test_lib(void)
         /* Fall through */
 
     case SSL_FIRST:
-        if (!shlib_load(path_ssl, &ssllib)) {
+        if (!sd_load(path_ssl, &ssllib)) {
             fprintf(stderr, "Failed to load libssl\n");
             goto end;
         }
         if (test_type != SSL_FIRST)
             break;
-        if (!shlib_load(path_crypto, &cryptolib)) {
+        if (!sd_load(path_crypto, &cryptolib)) {
             fprintf(stderr, "Failed to load libcrypto\n");
             goto end;
         }
@@ -167,7 +107,7 @@ static int test_lib(void)
     if (test_type == NO_ATEXIT) {
         OPENSSL_init_crypto_t myOPENSSL_init_crypto;
 
-        if (!shlib_sym(cryptolib, "OPENSSL_init_crypto", &symbols[0].sym)) {
+        if (!sd_sym(cryptolib, "OPENSSL_init_crypto", &symbols[0].sym)) {
             fprintf(stderr, "Failed to load OPENSSL_init_crypto symbol\n");
             goto end;
         }
@@ -181,9 +121,9 @@ static int test_lib(void)
     if (test_type != JUST_CRYPTO
             && test_type != DSO_REFTEST
             && test_type != NO_ATEXIT) {
-        if (!shlib_sym(ssllib, "TLS_method", &symbols[0].sym)
-                || !shlib_sym(ssllib, "SSL_CTX_new", &symbols[1].sym)
-                || !shlib_sym(ssllib, "SSL_CTX_free", &symbols[2].sym)) {
+        if (!sd_sym(ssllib, "TLS_method", &symbols[0].sym)
+                || !sd_sym(ssllib, "SSL_CTX_new", &symbols[1].sym)
+                || !sd_sym(ssllib, "SSL_CTX_free", &symbols[2].sym)) {
             fprintf(stderr, "Failed to load libssl symbols\n");
             goto end;
         }
@@ -198,11 +138,11 @@ static int test_lib(void)
         mySSL_CTX_free(ctx);
     }
 
-    if (!shlib_sym(cryptolib, "ERR_get_error", &symbols[0].sym)
-           || !shlib_sym(cryptolib, "OPENSSL_version_major", &symbols[1].sym)
-           || !shlib_sym(cryptolib, "OPENSSL_version_minor", &symbols[2].sym)
-           || !shlib_sym(cryptolib, "OPENSSL_version_patch", &symbols[3].sym)
-           || !shlib_sym(cryptolib, "OPENSSL_atexit", &symbols[4].sym)) {
+    if (!sd_sym(cryptolib, "ERR_get_error", &symbols[0].sym)
+           || !sd_sym(cryptolib, "OPENSSL_version_major", &symbols[1].sym)
+           || !sd_sym(cryptolib, "OPENSSL_version_minor", &symbols[2].sym)
+           || !sd_sym(cryptolib, "OPENSSL_version_patch", &symbols[3].sym)
+           || !sd_sym(cryptolib, "OPENSSL_atexit", &symbols[4].sym)) {
         fprintf(stderr, "Failed to load libcrypto symbols\n");
         goto end;
     }
@@ -242,8 +182,8 @@ static int test_lib(void)
          * will always return an error, because DSO_pathbyaddr() is not
          * implemented there.
          */
-        if (!shlib_sym(cryptolib, "DSO_dsobyaddr", &symbols[0].sym)
-                || !shlib_sym(cryptolib, "DSO_free", &symbols[1].sym)) {
+        if (!sd_sym(cryptolib, "DSO_dsobyaddr", &symbols[0].sym)
+                || !sd_sym(cryptolib, "DSO_free", &symbols[1].sym)) {
             fprintf(stderr, "Unable to load DSO symbols\n");
             goto end;
         }
@@ -264,13 +204,13 @@ static int test_lib(void)
 # endif /* DSO_DLFCN */
     }
 
-    if (!shlib_close(cryptolib)) {
+    if (!sd_close(cryptolib)) {
         fprintf(stderr, "Failed to close libcrypto\n");
         goto end;
     }
 
     if (test_type == CRYPTO_FIRST || test_type == SSL_FIRST) {
-        if (!shlib_close(ssllib)) {
+        if (!sd_close(ssllib)) {
             fprintf(stderr, "Failed to close libssl\n");
             goto end;
         }
@@ -338,7 +278,7 @@ int main(int argc, char *argv[])
         return 1;
     }
 
-#if defined(DSO_DLFCN) || defined(DSO_WIN32)
+#ifdef SD_INIT
     if (!test_lib())
         return 1;
 #endif

--- a/test/shlibloadtest.c
+++ b/test/shlibloadtest.c
@@ -82,7 +82,7 @@ static int test_lib(void)
     case DSO_REFTEST:
     case NO_ATEXIT:
     case CRYPTO_FIRST:
-        if (!sd_load(path_crypto, &cryptolib)) {
+        if (!sd_load(path_crypto, &cryptolib, SD_SHLIB)) {
             fprintf(stderr, "Failed to load libcrypto\n");
             goto end;
         }
@@ -91,13 +91,13 @@ static int test_lib(void)
         /* Fall through */
 
     case SSL_FIRST:
-        if (!sd_load(path_ssl, &ssllib)) {
+        if (!sd_load(path_ssl, &ssllib, SD_SHLIB)) {
             fprintf(stderr, "Failed to load libssl\n");
             goto end;
         }
         if (test_type != SSL_FIRST)
             break;
-        if (!sd_load(path_crypto, &cryptolib)) {
+        if (!sd_load(path_crypto, &cryptolib, SD_SHLIB)) {
             fprintf(stderr, "Failed to load libcrypto\n");
             goto end;
         }

--- a/test/simpledynamic.c
+++ b/test/simpledynamic.c
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2016-2020 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <stdlib.h>              /* For NULL */
+#include <openssl/macros.h>      /* For NON_EMPTY_TRANSLATION_UNIT */
+#include "simpledynamic.h"
+
+#if defined(DSO_DLFCN)
+
+int sd_load(const char *filename, SD *lib)
+{
+    int dl_flags = (RTLD_GLOBAL|RTLD_LAZY);
+#ifdef _AIX
+    if (filename[strlen(filename) - 1] == ')')
+        dl_flags |= RTLD_MEMBER;
+#endif
+    *lib = dlopen(filename, dl_flags);
+    return *lib == NULL ? 0 : 1;
+}
+
+int sd_sym(SD lib, const char *symname, SD_SYM *sym)
+{
+    *sym = dlsym(lib, symname);
+    return *sym != NULL;
+}
+
+int sd_close(SD lib)
+{
+    return dlclose(lib) != 0 ? 0 : 1;
+}
+
+#elif defined(DSO_WIN32)
+
+nt sd_load(const char *filename, SD *lib)
+{
+    *lib = LoadLibraryA(filename);
+    return *lib == NULL ? 0 : 1;
+}
+
+int sd_sym(SD lib, const char *symname, SD_SYM *sym)
+{
+    *sym = (SD_SYM)GetProcAddress(lib, symname);
+    return *sym != NULL;
+}
+
+int sd_close(SD lib)
+{
+    return FreeLibrary(lib) == 0 ? 0 : 1;
+}
+
+#else
+
+NON_EMPTY_TRANSLATION_UNIT
+
+#endif

--- a/test/simpledynamic.c
+++ b/test/simpledynamic.c
@@ -13,9 +13,9 @@
 
 #if defined(DSO_DLFCN)
 
-int sd_load(const char *filename, SD *lib)
+int sd_load(const char *filename, SD *lib, int type)
 {
-    int dl_flags = (RTLD_GLOBAL|RTLD_LAZY);
+    int dl_flags = type;
 #ifdef _AIX
     if (filename[strlen(filename) - 1] == ')')
         dl_flags |= RTLD_MEMBER;
@@ -37,7 +37,7 @@ int sd_close(SD lib)
 
 #elif defined(DSO_WIN32)
 
-nt sd_load(const char *filename, SD *lib)
+nt sd_load(const char *filename, SD *lib, ossl_unused int type)
 {
     *lib = LoadLibraryA(filename);
     return *lib == NULL ? 0 : 1;

--- a/test/simpledynamic.c
+++ b/test/simpledynamic.c
@@ -35,6 +35,11 @@ int sd_close(SD lib)
     return dlclose(lib) != 0 ? 0 : 1;
 }
 
+const char *sd_error(void)
+{
+    return dlerror();
+}
+
 #elif defined(DSO_WIN32)
 
 nt sd_load(const char *filename, SD *lib, ossl_unused int type)
@@ -52,6 +57,16 @@ int sd_sym(SD lib, const char *symname, SD_SYM *sym)
 int sd_close(SD lib)
 {
     return FreeLibrary(lib) == 0 ? 0 : 1;
+}
+
+const char *sd_error(void)
+{
+    static char buffer[255];
+
+    buffer[0] = '\0';
+    FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM, NULL, GetLastError(), 0,
+                   buffer, sizeof(buffer), NULL);
+    return buffer;
 }
 
 #else

--- a/test/simpledynamic.h
+++ b/test/simpledynamic.h
@@ -39,5 +39,6 @@ typedef void *SD_SYM;
 int sd_load(const char *filename, SD *sd, int type);
 int sd_sym(SD sd, const char *symname, SD_SYM *sym);
 int sd_close(SD lib);
+const char *sd_error(void);
 
 #endif

--- a/test/simpledynamic.h
+++ b/test/simpledynamic.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2016-2018 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#ifndef OSSL_TEST_SIMPLEDYNAMIC_H
+# define OSSL_TEST_SIMPLEDYNAMIC_H
+
+# include "crypto/dso_conf.h"
+
+# if defined(DSO_DLFCN)
+
+#  include <dlfcn.h>
+
+#  define SD_INIT NULL
+
+typedef void *SD;
+typedef void *SD_SYM;
+
+# elif defined(DSO_WIN32)
+
+#  include <windows.h>
+
+#  define SD_INIT 0
+
+typedef HINSTANCE SD;
+typedef void *SD_SYM;
+
+# endif
+
+int sd_load(const char *filename, SD *sd);
+int sd_sym(SD sd, const char *symname, SD_SYM *sym);
+int sd_close(SD lib);
+
+#endif

--- a/test/simpledynamic.h
+++ b/test/simpledynamic.h
@@ -16,7 +16,9 @@
 
 #  include <dlfcn.h>
 
-#  define SD_INIT NULL
+#  define SD_INIT       NULL
+#  define SD_SHLIB      (RTLD_GLOBAL|RTLD_LAZY)
+#  define SD_MODULE     (RTLD_LOCAL|RTLD_NOW)
 
 typedef void *SD;
 typedef void *SD_SYM;
@@ -25,14 +27,16 @@ typedef void *SD_SYM;
 
 #  include <windows.h>
 
-#  define SD_INIT 0
+#  define SD_INIT       0
+#  define SD_SHLIB      0
+#  define SD_MODULE     0
 
 typedef HINSTANCE SD;
 typedef void *SD_SYM;
 
 # endif
 
-int sd_load(const char *filename, SD *sd);
+int sd_load(const char *filename, SD *sd, int type);
 int sd_sym(SD sd, const char *symname, SD_SYM *sym);
 int sd_close(SD lib);
 


### PR DESCRIPTION
This very simple module loader is only linked with the standard C
library, so cannot and should not provide any other symbol to the
module it tries to load.  It can thereby be used to verify that the
module it tries to load doesn't have any surprising dependencies when
it's supposed to be self contained.

A test recipe is added to verify the FIPS module with this loader.

Fixes #11020