### PR TITLE
 ERR: Restore the similarity of ERR_print_error_cb() and ERR_error_string_n()

### DIFF
--- a/crypto/err/err.c
+++ b/crypto/err/err.c
@@ -489,11 +489,12 @@ static unsigned long get_error_values(ERR_GET_ACTION g,
     return ret;
 }
 
-void ERR_error_string_n(unsigned long e, char *buf, size_t len)
+void ossl_err_string_int(unsigned long e, const char *func,
+                         char *buf, size_t len)
 {
     char lsbuf[64], rsbuf[256];
     const char *ls, *rs = NULL;
-    unsigned long f = 0, l, r;
+    unsigned long l, r;
 
     if (len == 0)
         return;
@@ -512,22 +513,30 @@ void ERR_error_string_n(unsigned long e, char *buf, size_t len)
      * directly instead.
      */
     r = ERR_GET_REASON(e);
+#ifndef OPENSSL_NO_ERR
     if (ERR_SYSTEM_ERROR(e)) {
         if (openssl_strerror_r(r, rsbuf, sizeof(rsbuf)))
             rs = rsbuf;
     } else {
         rs = ERR_reason_error_string(e);
     }
+#endif
     if (rs == NULL) {
         BIO_snprintf(rsbuf, sizeof(rsbuf), "reason(%lu)", r);
         rs = rsbuf;
     }
 
-    BIO_snprintf(buf, len, "error:%08lX:%s:%s:%s", e, ls, "", rs);
+    BIO_snprintf(buf, len, "error:%08lX:%s:%s:%s", e, ls, func, rs);
     if (strlen(buf) == len - 1) {
         /* Didn't fit; use a minimal format. */
-        BIO_snprintf(buf, len, "err:%lx:%lx:%lx:%lx", e, l, f, r);
+        BIO_snprintf(buf, len, "err:%lx:%lx:%lx:%lx", e, l, 0L, r);
     }
+}
+
+
+void ERR_error_string_n(unsigned long e, char *buf, size_t len)
+{
+    ossl_err_string_int(e, "", buf, len);
 }
 
 /*

--- a/crypto/err/err_local.h
+++ b/crypto/err/err_local.h
@@ -72,3 +72,5 @@ static ossl_inline void err_clear(ERR_STATE *es, size_t i, int deall)
 }
 
 ERR_STATE *err_get_state_int(void);
+void ossl_err_string_int(unsigned long e, const char *func,
+                         char *buf, size_t len);

--- a/crypto/err/err_prn.c
+++ b/crypto/err/err_prn.c
@@ -27,39 +27,21 @@ void ERR_print_errors_cb(int (*cb) (const char *str, size_t len, void *u),
     int line, flags;
 
     while ((l = ERR_get_error_all(&file, &line, &func, &data, &flags)) != 0) {
-        char buf[ERR_PRINT_BUF_SIZE], *hex;
-        const char *lib, *reason = NULL;
-        char rsbuf[256];
-        unsigned long r = ERR_GET_REASON(l);
+        char buf[ERR_PRINT_BUF_SIZE] = "";
+        char *hex = NULL;
+        int offset;
 
-        lib = ERR_lib_error_string(l);
-
-        /*
-         * ERR_reason_error_string() can't safely return system error strings,
-         * since it would call openssl_strerror_r(), which needs a buffer for
-         * thread safety.  So for system errors, we call openssl_strerror_r()
-         * directly instead.
-         */
-        if (ERR_SYSTEM_ERROR(l)) {
-            if (openssl_strerror_r(r, rsbuf, sizeof(rsbuf)))
-                reason = rsbuf;
-        } else {
-            reason = ERR_reason_error_string(l);
-        }
-
-        if (func == NULL)
-            func = "unknown function";
-        if (reason == NULL) {
-            BIO_snprintf(rsbuf, sizeof(rsbuf), "reason(%lu)", r);
-            reason = rsbuf;
-        }
         if ((flags & ERR_TXT_STRING) == 0)
             data = "";
+
         hex = openssl_buf2hexstr_sep((const unsigned char *)&tid, sizeof(tid),
                                      '\0');
-        BIO_snprintf(buf, sizeof(buf), "%s:error::%s:%s:%s:%s:%d:%s\n",
-                     hex == NULL ? "<null>" : hex, lib, func, reason, file,
-                     line, data);
+        BIO_snprintf(buf, sizeof(buf), "%s:", hex == NULL ? "<null>" : hex);
+        offset = strlen(buf);
+        ossl_err_string_int(l, func, buf + offset, sizeof(buf) - offset);
+        offset += strlen(buf + offset);
+        BIO_snprintf(buf + offset, sizeof(buf) - offset, ":%s:%d:%s\n",
+                     file, line, data);
         OPENSSL_free(hex);
         if (cb(buf, strlen(buf), u) <= 0)
             break;              /* abort outputting the error report */

--- a/test/errtest.c
+++ b/test/errtest.c
@@ -26,7 +26,10 @@
 static int test_print_error_format(void)
 {
     /* Variables used to construct an error line */
+    char *lib;
     const char *func = OPENSSL_FUNC;
+    char reasonbuf[255];
+    char *reason;
 # ifndef OPENSSL_NO_FILENAMES
     const char *file = OPENSSL_FILE;
     const int line = OPENSSL_LINE;
@@ -35,13 +38,14 @@ static int test_print_error_format(void)
     const int line = 0;
 # endif
     /* The format for OpenSSL error lines */
-    const char *expected_format = ":error::system library:%s:%s:%s:%d";
+    const char *expected_format = ":error:%08lX:%s:%s:%s:%s:%d";
     /*-
-     *                                                    ^^ ^^ ^^ ^^
-     * function name -------------------------------------++ || || ||
-     * reason string (system error string) ------------------++ || ||
-     * file name -----------------------------------------------++ ||
-     * line number ------------------------------------------------++
+     *                                          ^^ ^^ ^^ ^^ ^^
+     * "library" name --------------------------++ || || || ||
+     * function name ------------------------------++ || || ||
+     * reason string (system error string) -----------++ || ||
+     * file name ----------------------------------------++ ||
+     * line number -----------------------------------------++
      */
     char expected[512];
 
@@ -49,7 +53,8 @@ static int test_print_error_format(void)
     int ret = 0, len;
     BIO *bio = NULL;
     const int syserr = EPERM;
-    int reasoncode;
+    unsigned long errorcode;
+    unsigned long reasoncode;
 
     /*
      * We set a mark here so we can clear the system error that we generate
@@ -59,15 +64,25 @@ static int test_print_error_format(void)
     ERR_set_mark();
 
     ERR_PUT_error(ERR_LIB_SYS, 0, syserr, file, line);
-    reasoncode = ERR_GET_REASON(ERR_peek_error());
+    errorcode = ERR_peek_error();
+    reasoncode = ERR_GET_REASON(errorcode);
 
     if (!TEST_int_eq(reasoncode, syserr)) {
         ERR_pop_to_mark();
         goto err;
     }
 
+# ifndef OPENSSL_NO_ERR
+    lib = "system library";
+    reason = strerror(syserr);
+# else
+    lib = "lib(2)";
+    BIO_snprintf(reasonbuf, sizeof(reasonbuf), "reason(%lu)", reasoncode);
+    reason = reasonbuf;
+# endif
+
     BIO_snprintf(expected, sizeof(expected), expected_format,
-                 func, strerror(syserr), file, line);
+                 errorcode, lib, func, reason, file, line);
 
     if (!TEST_ptr(bio = BIO_new(BIO_s_mem())))
         goto err;

--- a/test/errtest.c
+++ b/test/errtest.c
@@ -28,8 +28,10 @@ static int test_print_error_format(void)
     /* Variables used to construct an error line */
     char *lib;
     const char *func = OPENSSL_FUNC;
-    char reasonbuf[255];
     char *reason;
+# ifdef OPENSSL_NO_ERR
+    char reasonbuf[255];
+# endif
 # ifndef OPENSSL_NO_FILENAMES
     const char *file = OPENSSL_FILE;
     const int line = OPENSSL_LINE;


### PR DESCRIPTION
Their output has diverged, time to make the consistent with each other.