### PR TITLE
APPS: Modify the way apps/cmp.c silences the UI_METHOD when -batch is given

### DIFF
--- a/apps/cmp.c
+++ b/apps/cmp.c
@@ -2697,12 +2697,8 @@ int cmp_main(int argc, char **argv)
         goto err;
     ret = 0;
 
-    if (opt_batch) {
-#ifndef OPENSSL_NO_UI_CONSOLE
-        UI_method_set_reader(UI_OpenSSL(), NULL);
-        /* can't change get_ui_method() here as load_key_certs_crls() uses it */
-#endif
-    }
+    if (opt_batch)
+        set_base_ui_method(UI_null());
 
     if (opt_engine != NULL)
         engine = setup_engine_methods(opt_engine, 0 /* not: ENGINE_METHOD_ALL */, 0);

--- a/apps/include/apps_ui.h
+++ b/apps/include/apps_ui.h
@@ -21,7 +21,8 @@ int password_callback(char *buf, int bufsiz, int verify, PW_CB_DATA *cb_data);
 
 int setup_ui_method(void);
 void destroy_ui_method(void);
-UI_METHOD *get_ui_method(void);
+int set_base_ui_method(const UI_METHOD *ui_method);
+const UI_METHOD *get_ui_method(void);
 
 extern BIO *bio_err;
 

--- a/apps/lib/apps_ui.c
+++ b/apps/lib/apps_ui.c
@@ -13,11 +13,11 @@
 #include "apps_ui.h"
 
 static UI_METHOD *ui_method = NULL;
-static const UI_METHOD *ui_fallback_method = NULL;
+static const UI_METHOD *ui_base_method = NULL;
 
 static int ui_open(UI *ui)
 {
-    int (*opener)(UI *ui) = UI_method_get_opener(ui_fallback_method);
+    int (*opener)(UI *ui) = UI_method_get_opener(ui_base_method);
 
     if (opener != NULL)
         return opener(ui);
@@ -51,7 +51,7 @@ static int ui_read(UI *ui, UI_STRING *uis)
         }
     }
 
-    reader = UI_method_get_reader(ui_fallback_method);
+    reader = UI_method_get_reader(ui_base_method);
     if (reader != NULL)
         return reader(ui, uis);
     /* Default to the empty password if we've got nothing better */
@@ -84,7 +84,7 @@ static int ui_write(UI *ui, UI_STRING *uis)
         }
     }
 
-    writer = UI_method_get_writer(ui_fallback_method);
+    writer = UI_method_get_writer(ui_base_method);
     if (writer != NULL)
         return writer(ui, uis);
     return 1;
@@ -92,7 +92,7 @@ static int ui_write(UI *ui, UI_STRING *uis)
 
 static int ui_close(UI *ui)
 {
-    int (*closer)(UI *ui) = UI_method_get_closer(ui_fallback_method);
+    int (*closer)(UI *ui) = UI_method_get_closer(ui_base_method);
 
     if (closer != NULL)
         return closer(ui);
@@ -112,11 +112,19 @@ static char *ui_prompt_construct(UI *ui, const char *phrase_desc,
     return UI_construct_prompt(NULL, phrase_desc, object_name);
 }
 
+int set_base_ui_method(const UI_METHOD *ui_meth)
+{
+    if (ui_meth == NULL)
+        ui_meth = UI_null();
+    ui_base_method = ui_meth;
+    return 1;
+}
+
 int setup_ui_method(void)
 {
-    ui_fallback_method = UI_null();
+    ui_base_method = UI_null();
 #ifndef OPENSSL_NO_UI_CONSOLE
-    ui_fallback_method = UI_OpenSSL();
+    ui_base_method = UI_OpenSSL();
 #endif
     ui_method = UI_create_method("OpenSSL application user interface");
     return ui_method != NULL
@@ -136,7 +144,7 @@ void destroy_ui_method(void)
     }
 }
 
-UI_METHOD *get_ui_method(void)
+const UI_METHOD *get_ui_method(void)
 {
     return ui_method;
 }


### PR DESCRIPTION
The apps UI method acts as a proxy that bases its activity on a base (was called fallback) UI_METHOD, which defaults to UI_OpenSSL() under normal circumstances.  Recent development has made it clear that apps may at times need to set that base UI method explicitly, for example to enable a `-batch` option that silences all prompts.

`set_base_ui_method()` is added to make that possible, and `apps/cmp.c` is modified to use it.

Fixes #13511