### PR TITLE
Fix run-checker ubsan build

### DIFF
--- a/crypto/asn1/a_int.c
+++ b/crypto/asn1/a_int.c
@@ -79,8 +79,14 @@ static void twos_complement(unsigned char *dst, const unsigned char *src,
     unsigned int carry = pad & 1;
 
     /* Begin at the end of the encoding */
-    dst += len;
-    src += len;
+    if (len != 0) {
+        /*
+         * if len == 0 then src/dst could be NULL, and this would be undefined
+         * behaviour.
+         */
+        dst += len;
+        src += len;
+    }
     /* two's complement value: ~value + 1 */
     while (len-- != 0) {
         *(--dst) = (unsigned char)(carry += *(--src) ^ pad);

--- a/crypto/bio/bss_mem.c
+++ b/crypto/bio/bss_mem.c
@@ -299,7 +299,7 @@ static long mem_ctrl(BIO *b, int cmd, long num, void *ptr)
         ret = (long)bm->length;
         if (ptr != NULL) {
             pptr = (char **)ptr;
-            *pptr = (char *)&(bm->data[0]);
+            *pptr = (char *)(bm->data);
         }
         break;
     case BIO_C_SET_BUF_MEM:

--- a/crypto/pem/pem_lib.c
+++ b/crypto/pem/pem_lib.c
@@ -954,6 +954,11 @@ int PEM_read_bio_ex(BIO *bp, char **name_out, char **header,
     EVP_DecodeInit(ctx);
     BIO_get_mem_ptr(dataB, &buf_mem);
     len = buf_mem->length;
+
+    /* There was no data in the PEM file */
+    if (len == 0)
+        goto end;
+
     if (EVP_DecodeUpdate(ctx, (unsigned char*)buf_mem->data, &len,
                          (unsigned char*)buf_mem->data, len) < 0
             || EVP_DecodeFinal(ctx, (unsigned char*)&(buf_mem->data[len]),
@@ -964,9 +969,6 @@ int PEM_read_bio_ex(BIO *bp, char **name_out, char **header,
     len += taillen;
     buf_mem->length = len;
 
-    /* There was no data in the PEM file; avoid malloc(0). */
-    if (len == 0)
-        goto end;
     headerlen = BIO_get_mem_data(headerB, NULL);
     *header = pem_malloc(headerlen + 1, flags);
     *data = pem_malloc(len, flags);

--- a/crypto/pem/pem_lib.c
+++ b/crypto/pem/pem_lib.c
@@ -917,17 +917,12 @@ err:
 int PEM_read_bio_ex(BIO *bp, char **name_out, char **header,
                     unsigned char **data, long *len_out, unsigned int flags)
 {
-    EVP_ENCODE_CTX *ctx = EVP_ENCODE_CTX_new();
+    EVP_ENCODE_CTX *ctx = NULL;
     const BIO_METHOD *bmeth;
     BIO *headerB = NULL, *dataB = NULL;
     char *name = NULL;
     int len, taillen, headerlen, ret = 0;
     BUF_MEM * buf_mem;
-
-    if (ctx == NULL) {
-        ERR_raise(ERR_LIB_PEM, ERR_R_MALLOC_FAILURE);
-        return 0;
-    }
 
     *len_out = 0;
     *name_out = *header = NULL;
@@ -951,7 +946,6 @@ int PEM_read_bio_ex(BIO *bp, char **name_out, char **header,
     if (!get_header_and_data(bp, &headerB, &dataB, name, flags))
         goto end;
 
-    EVP_DecodeInit(ctx);
     BIO_get_mem_ptr(dataB, &buf_mem);
     len = buf_mem->length;
 
@@ -959,6 +953,13 @@ int PEM_read_bio_ex(BIO *bp, char **name_out, char **header,
     if (len == 0)
         goto end;
 
+    ctx = EVP_ENCODE_CTX_new();
+    if (ctx == NULL) {
+        ERR_raise(ERR_LIB_PEM, ERR_R_MALLOC_FAILURE);
+        goto end;
+    }
+
+    EVP_DecodeInit(ctx);
     if (EVP_DecodeUpdate(ctx, (unsigned char*)buf_mem->data, &len,
                          (unsigned char*)buf_mem->data, len) < 0
             || EVP_DecodeFinal(ctx, (unsigned char*)&(buf_mem->data[len]),

--- a/providers/implementations/ciphers/cipher_aes_ocb.c
+++ b/providers/implementations/ciphers/cipher_aes_ocb.c
@@ -177,7 +177,8 @@ static int aes_ocb_block_update_internal(PROV_AES_OCB_CTX *ctx,
         }
         *bufsz = 0;
         outlint = AES_BLOCK_SIZE;
-        out += AES_BLOCK_SIZE;
+        if (out != NULL)
+            out += AES_BLOCK_SIZE;
     }
     if (nextblocks > 0) {
         outlint += nextblocks;

--- a/providers/implementations/ciphers/cipher_chacha20_poly1305_hw.c
+++ b/providers/implementations/ciphers/cipher_chacha20_poly1305_hw.c
@@ -120,9 +120,6 @@ static int chacha20_poly1305_tls_cipher(PROV_CIPHER_CTX *bctx,
 
     DECLARE_IS_ENDIAN;
 
-    if (len != plen + POLY1305_BLOCK_SIZE)
-        return 0;
-
     buf = storage + ((0 - (size_t)storage) & 15);   /* align */
     ctr = buf + CHACHA_BLK_SIZE;
     tohash = buf + CHACHA_BLK_SIZE - POLY1305_BLOCK_SIZE;
@@ -274,11 +271,14 @@ static int chacha20_poly1305_aead_cipher(PROV_CIPHER_CTX *bctx,
     DECLARE_IS_ENDIAN;
 
     if (!ctx->mac_inited) {
-#if !defined(OPENSSL_SMALL_FOOTPRINT)
         if (plen != NO_TLS_PAYLOAD_LENGTH && out != NULL) {
+            if (inl != plen + POLY1305_BLOCK_SIZE)
+                return 0;
+#if !defined(OPENSSL_SMALL_FOOTPRINT)
             return chacha20_poly1305_tls_cipher(bctx, out, outl, in, inl);
-        }
 #endif
+        }
+
         ctx->chacha.counter[0] = 0;
         ChaCha20_ctr32(ctx->chacha.buf, zero, CHACHA_BLK_SIZE,
                        ctx->chacha.key.d, ctx->chacha.counter);
@@ -375,6 +375,8 @@ static int chacha20_poly1305_aead_cipher(PROV_CIPHER_CTX *bctx,
                     memset(out - plen, 0, plen);
                     goto err;
                 }
+                /* Strip the tag */
+                inl -= POLY1305_BLOCK_SIZE;
             }
         }
         else if (!bctx->enc) {

--- a/test/filterprov.c
+++ b/test/filterprov.c
@@ -167,7 +167,7 @@ int filter_provider_set_filter(int operation, const char *filterstr)
     if (globs->num_dispatch >= MAX_FILTERS)
         goto err;
 
-    for (name = filterstrtmp; !last; name = sep + 1) {
+    for (name = filterstrtmp; !last; name = (last ? NULL : sep + 1)) {
         sep = strstr(name, ":");
         if (sep != NULL)
             *sep = '\0';

--- a/test/filterprov.c
+++ b/test/filterprov.c
@@ -167,7 +167,7 @@ int filter_provider_set_filter(int operation, const char *filterstr)
     if (globs->num_dispatch >= MAX_FILTERS)
         goto err;
 
-    for (name = filterstrtmp; !last; name = (last ? NULL : sep + 1)) {
+    for (name = filterstrtmp; !last; name = (sep == NULL ? NULL : sep + 1)) {
         sep = strstr(name, ":");
         if (sep != NULL)
             *sep = '\0';

--- a/test/testutil/format_output.c
+++ b/test/testutil/format_output.c
@@ -108,8 +108,10 @@ static void test_fail_string_common(const char *prefix, const char *file,
             if (diff && i > 0)
                 test_printf_stderr("%4s    %s\n", "", bdiff);
         }
-        m1 += n1;
-        m2 += n2;
+        if (m1 != NULL)
+            m1 += n1;
+        if (m2 != NULL)
+            m2 += n2;
         l1 -= n1;
         l2 -= n2;
         cnt += width;
@@ -497,8 +499,10 @@ static void test_fail_memory_common(const char *prefix, const char *file,
             if (diff && i > 0)
                 test_printf_stderr("%4s  %s\n", "", bdiff);
         }
-        m1 += n1;
-        m2 += n2;
+        if (m1 != NULL)
+            m1 += n1;
+        if (m2 != NULL)
+            m2 += n2;
         l1 -= n1;
         l2 -= n2;
         cnt += bytes;


### PR DESCRIPTION
The ubsan run-checker build is configured as follows:

````
CC=clang ../openssl/config -d --strict-warnings enable-ubsan -DPEDANTIC -DOPENSSL_SMALL_FOOTPRINT -fno-sanitize=alignment
````
This PR contains 2 commits to address 2 different issues with the above config line:

1) The first commit addresses ubsan failures. Addition using the NULL pointer (even when adding 0) is undefined
behaviour. Recent versions of ubsan are now complaining about this, so we fix various instances.

2) The second commit address an OPENSSL_SMALL_FOOTPRINT issue. If OPENSSL_SMALL_FOOTPRINT was defined then the CHACHA20-POLY1305 implementation for TLS went down a different codepath that failed to adjust the payload length to remove the tag.

Thanks to @kroeckx for reporting the PEM ubsan issue.