### PR TITLE
Disable ubsan in the Github CIs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,12 +38,12 @@ jobs:
     - name: make test
       run: make test
 
-  sanitizers:
+  asan:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - name: config
-      run: ./config --debug no-asm enable-asan enable-ubsan enable-rc5 enable-md2 enable-ec_nistp_64_gcc_128
+      run: ./config --debug no-asm enable-asan enable-rc5 enable-md2 enable-ec_nistp_64_gcc_128
     - name: make
       run: make
     - name: make test


### PR DESCRIPTION
ubsan runs extremely slowly, and is already covered by a separate
run-checker job. Therefore we disable ubsan in the CIs.
