### PR TITLE
fix invalid unsigned arithmetic.

### DIFF
--- a/crypto/evp/bio_ok.c
+++ b/crypto/evp/bio_ok.c
@@ -204,7 +204,7 @@ static int ok_read(BIO *b, char *out, int outl)
                 /*
                  * copy start of the next block into proper place
                  */
-                if (ctx->buf_len_save - ctx->buf_off_save > 0) {
+                if (ctx->buf_len_save > ctx->buf_off_save) {
                     ctx->buf_len = ctx->buf_len_save - ctx->buf_off_save;
                     memmove(ctx->buf, &(ctx->buf[ctx->buf_off_save]),
                             ctx->buf_len);


### PR DESCRIPTION
CLA: trivial
your check is incorrect. since the variables are unsigned, it is equivalent to ctx-> buf_len_save! = ctx-> buf_off_save.
so I suggest a simple fix for the error.