### PR TITLE
OSSL_STORE: restore diagnostics on decrypt error; provide password hints

### DIFF
--- a/crypto/pkcs12/p12_decr.c
+++ b/crypto/pkcs12/p12_decr.c
@@ -81,7 +81,9 @@ unsigned char *PKCS12_pbe_crypt(const X509_ALGOR *algor,
     if (!EVP_CipherFinal_ex(ctx, out + i, &i)) {
         OPENSSL_free(out);
         out = NULL;
-        ERR_raise(ERR_LIB_PKCS12, PKCS12_R_PKCS12_CIPHERFINAL_ERROR);
+        ERR_raise_data(ERR_LIB_PKCS12, PKCS12_R_PKCS12_CIPHERFINAL_ERROR,
+                       passlen == 0 ? "empty password"
+                       : "maybe wrong password");
         goto err;
     }
     outlen += i;

--- a/crypto/store/store_result.c
+++ b/crypto/store/store_result.c
@@ -564,8 +564,10 @@ static int try_pkcs12(struct extracted_param_data_st *data, OSSL_STORE_INFO **v,
                 }
                 pass = tpass;
                 if (!PKCS12_verify_mac(p12, pass, strlen(pass))) {
-                    ERR_raise(ERR_LIB_OSSL_STORE,
-                              OSSL_STORE_R_ERROR_VERIFYING_PKCS12_MAC);
+                    ERR_raise_data(ERR_LIB_OSSL_STORE,
+                                   OSSL_STORE_R_ERROR_VERIFYING_PKCS12_MAC,
+                                   strlen(pass) == 0 ? "empty password" :
+                                   "maybe wrong password");
                     goto p12_end;
                 }
             }

--- a/providers/implementations/encode_decode/decode_der2key.c
+++ b/providers/implementations/encode_decode/decode_der2key.c
@@ -260,6 +260,7 @@ static int der2key_decode(void *vctx, OSSL_CORE_BIO *cin, int selection,
     EVP_PKEY *pkey = NULL;
     void *key = NULL;
     int orig_selection = selection;
+    int dec_err;
     int ok = 0;
 
     /*
@@ -319,8 +320,13 @@ static int der2key_decode(void *vctx, OSSL_CORE_BIO *cin, int selection,
             der = new_der;
             der_len = new_der_len;
         }
-        RESET_ERR_MARK();
+        /* decryption errors are fatal and should be reported */
+        dec_err = ERR_peek_last_error();
+        if (ERR_GET_LIB(dec_err) == ERR_LIB_PROV
+                && ERR_GET_REASON(dec_err) == PROV_R_BAD_DECRYPT)
+            goto end;
 
+        RESET_ERR_MARK();
         if ((selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) != 0) {
             derp = der;
             pkey = evp_privatekey_from_binary(ctx->desc->evp_type, NULL,


### PR DESCRIPTION
The error output on attempting to load encrypted private keys from files with missing/wrong passwords so far has been pretty poor.

For PKCS#12 input the message was just 
```
error:STORE routines:error verifying pkcs12 mac:crypto/store/store_result.c:563:
```
from which it's hard for inexperienced users to deduce that this was likely due to an unsuitable or missing password.

For PEM input currently no error is reported at all in such cases, while with previous OpenSSL versions the output was, e.g.:
```
error:06065064:digital envelope routines:EVP_DecryptFinal_ex:bad decrypt:../crypto/evp/evp_enc.c:570:
error:23077074:PKCS12 routines:PKCS12_pbe_crypt:pkcs12 cipherfinal error:../crypto/pkcs12/p12_decr.c:63:
error:2306A075:PKCS12 routines:PKCS12_item_decrypt_d2i:pkcs12 pbe crypt error:../crypto/pkcs12/p12_decr.c:94:
error:0907B00D:PEM routines:PEM_read_bio_PrivateKey:ASN1 lib:../crypto/pem/pem_pkey.c:88:
```

This PR restores the output of a suitable error output for the PEM case, giving exactly one queue entry:
```
error::Provider routines:bad decrypt:providers/implementations/ciphers/ciphercommon_block.c:123:
```
and for both PKCS#12 and PEM input adds a hint "maybe wrong password" when a non-empty unsuitable password was provided and "empty password" otherwise, for instance:

```
error:STORE routines:error verifying pkcs12 mac:crypto/store/store_result.c:563:maybe wrong password
```
```
error:Provider routines:bad decrypt:providers/implementations/ciphers/ciphercommon_block.c:123:empty password
```