### PR TITLE
appveyor.yml: clarify conditions for building the plain configuration

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,8 @@ for:
             EXTENDED_TESTS: yes
     -
         branches:
-            only: master
+            only:
+                - master
         configuration:
             - shared
             - plain

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,8 +12,27 @@ environment:
 
 configuration:
     - shared
-    - plain
     - minimal
+
+for:
+    -
+        only_commits:
+            message: /\[extended tests\]/
+        configuration:
+            - shared
+            - plain
+            - minimal
+        environment:
+            EXTENDED_TESTS: yes
+    -
+        branches:
+            only: master
+        configuration:
+            - shared
+            - plain
+            - minimal
+        environment:
+            EXTENDED_TESTS: yes
 
 before_build:
     - ps: >-
@@ -43,12 +62,6 @@ before_build:
     - perl configdata.pm --dump
     - cd ..
     - ps: >-
-        If (-not $env:APPVEYOR_PULL_REQUEST_NUMBER`
-            -or (&git log -1 $env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT |
-                 Select-String "\[extended tests\]") ) {
-            $env:EXTENDED_TESTS="yes"
-        }
-    - ps: >-
         If ($env:BUILDONLY -or $env:MAKEVERBOSE) {
             $env:NMAKE="nmake"
         } Else {
@@ -59,24 +72,17 @@ before_build:
 
 build_script:
     - cd _build
-    - ps: >-
-        If ($env:Configuration -Match "shared" -or $env:EXTENDED_TESTS) {
-            cmd /c "%NMAKE% build_all_generated 2>&1"
-            # Unfortunately, CL=/MP would not have parallelizing effect
-            cmd /c "%NMAKE% PERL=no-perl 2>&1"
-        }
+    - %NMAKE% build_all_generated
+    - %NMAKE% PERL=no-perl
     - cd ..
 
 test_script:
     - cd _build
     - ps: >-
-        If ($env:Configuration -Match "shared" -or $env:EXTENDED_TESTS) {
-            # Unfortunately, HARNESS_JOBS=4 would not have parallelizing effect
-            if ($env:EXTENDED_TESTS) {
-                cmd /c "%NMAKE% test HARNESS_VERBOSE_FAILURE=yes 2>&1"
-            } Else {
-                cmd /c "%NMAKE% test HARNESS_VERBOSE_FAILURE=yes TESTS=-test_fuzz 2>&1"
-            }
+        if ($env:EXTENDED_TESTS) {
+            cmd /c "%NMAKE% test VERBOSE_FAILURE=yes 2>&1"
+        } Else {
+            cmd /c "%NMAKE% test VERBOSE_FAILURE=yes TESTS=-test_fuzz 2>&1"
         }
     - ps: >-
         if ($env:EXTENDED_TESTS) {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -71,7 +71,6 @@ before_build:
     - ps: >-
         gci env:* | sort-object name
 
-# The two 'cmd /c' lines are due to "interesting"
 build_script:
     - cd _build
     - "%NMAKE% build_all_generated"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -73,8 +73,8 @@ before_build:
 
 build_script:
     - cd _build
-    - %NMAKE% build_all_generated
-    - %NMAKE% PERL=no-perl
+    - "%NMAKE%" build_all_generated
+    - "%NMAKE%" PERL=no-perl
     - cd ..
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -71,10 +71,11 @@ before_build:
     - ps: >-
         gci env:* | sort-object name
 
+# The two 'cmd /c' lines are due to "interesting"
 build_script:
     - cd _build
-    - "%NMAKE%" build_all_generated
-    - "%NMAKE%" PERL=no-perl
+    - "%NMAKE% build_all_generated"
+    - "%NMAKE% PERL=no-perl"
     - cd ..
 
 test_script:


### PR DESCRIPTION
The "plain" configuration is only meant to be built for an '[extended tests]'
commit, or on the master branch.  This isn't at all clear from the
scripts, and furthermore, we "skip" the plain configuration by running
the OpenSSL configuration script...  and then nothing more.

Instead, we use AppVeyor configuration issues to specify when and when
not to build the "plain" configuration, and leave it to the scripts to
do the right thing using only $env:EXTENDED_TESTS.

Fixes #7958
