### PR TITLE
README: Move Travis link to .com from .org.

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,11 +207,11 @@ All rights reserved.
     "OpenSSL Logo"
 
 [travis badge]:
-    <https://travis-ci.org/openssl/openssl.svg?branch=master>
+    <https://travis-ci.com/openssl/openssl.svg?branch=master>
     "Travis Build Status"
 
 [travis jobs]:
-    <https://travis-ci.org/openssl/openssl>
+    <https://travis-ci.com/openssl/openssl>
     "Travis Jobs"
 
 [appveyor badge]:


### PR DESCRIPTION
The README still links to the old Travis site at [travis-ci.org](https://travis-ci.org), which leads to a page with the note below.
This short PR fixes that so it goes to the correct page. I believe this doesn't require a CLA as it is quite trivial.

![travis_org](https://user-images.githubusercontent.com/1296726/100395381-fb794100-3040-11eb-937f-fe0dca41056d.png)
