### PR TITLE
add a NULL check for function EVP_MAC_CTX_new

### DIFF
--- a/test/bad_dtls_test.c
+++ b/test/bad_dtls_test.c
@@ -307,6 +307,8 @@ static int send_record(BIO *rbio, unsigned char type, uint64_t seqnr,
     hmac = EVP_MAC_fetch(NULL, "HMAC", NULL);
     ctx = EVP_MAC_CTX_new(hmac);
     if(ctx == NULL){
+        OPENSSL_free(enc);
+        EVP_MAC_free(hmac);
         return 0;
     }
     EVP_MAC_free(hmac);

--- a/test/bad_dtls_test.c
+++ b/test/bad_dtls_test.c
@@ -306,6 +306,9 @@ static int send_record(BIO *rbio, unsigned char type, uint64_t seqnr,
     /* Append HMAC to data */
     hmac = EVP_MAC_fetch(NULL, "HMAC", NULL);
     ctx = EVP_MAC_CTX_new(hmac);
+    if(ctx == NULL){
+        return 0;
+    }
     EVP_MAC_free(hmac);
     params[0] = OSSL_PARAM_construct_utf8_string(OSSL_MAC_PARAM_DIGEST,
                                                  "SHA1", 0);


### PR DESCRIPTION
in file `openssl/test/bad_dtls_test.c`, if function `VP_MAC_CTX_new` return NULL, then the use of ctx in EVP_MAC_CTX_set_params `if (ctx->meth->set_ctx_params != NULL)`will be wrong

```
int EVP_MAC_CTX_set_params(EVP_MAC_CTX *ctx, const OSSL_PARAM params[])
{
    if (ctx->meth->set_ctx_params != NULL)
        return ctx->meth->set_ctx_params(ctx->data, params);
    return 1;
}
```
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
