### PR TITLE
Fix no-deprecated configuration

### DIFF
--- a/test/build.info
+++ b/test/build.info
@@ -57,8 +57,7 @@ IF[{- !$disabled{tests} -}]
           http_test servername_test ocspapitest fatalerrtest tls13ccstest \
           sysdefaulttest errtest ssl_ctx_test gosttest \
           context_internal_test aesgcmtest params_test evp_pkey_dparams_test \
-          keymgmt_internal_test hexstr_test provider_status_test defltfips_test \
-          pem_read_depr_test
+          keymgmt_internal_test hexstr_test provider_status_test defltfips_test
 
   IF[{- !$disabled{'deprecated-3.0'} -}]
     PROGRAMS{noinst}=enginetest
@@ -810,6 +809,7 @@ IF[{- !$disabled{tests} -}]
   DEPEND[bio_prefix_text]=../libcrypto
 
   IF[{- !$disabled{'deprecated-3.0'} -}]
+    PROGRAMS{noinst}=pem_read_depr_test
     SOURCE[pem_read_depr_test]=pem_read_depr_test.c
     INCLUDE[pem_read_depr_test]=../include ../apps/include
     DEPEND[pem_read_depr_test]=../libcrypto libtestutil.a


### PR DESCRIPTION
pem_read_depr_test needed to be setup in build info so that it only
exists inside an IF[{- !$disabled{'deprecated-3.0'} -}] block.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
