### PR TITLE
ENCODER: Don't pass libctx to OSSL_ENCODER_CTX_new_by_EVP_PKEY()

### DIFF
--- a/apps/dhparam.c
+++ b/apps/dhparam.c
@@ -325,7 +325,7 @@ int dhparam_main(int argc, char **argv)
                                              OSSL_KEYMGMT_SELECT_DOMAIN_PARAMETERS,
                                              outformat == FORMAT_ASN1
                                              ? "DER" : "PEM",
-                                             NULL, NULL, NULL);
+                                             NULL, NULL);
 
         if (ectx == NULL || !OSSL_ENCODER_to_bio(ectx, out)) {
             OSSL_ENCODER_CTX_free(ectx);

--- a/apps/rsa.c
+++ b/apps/rsa.c
@@ -323,7 +323,7 @@ int rsa_main(int argc, char **argv)
     /* Now, perform the encoding */
     ectx = OSSL_ENCODER_CTX_new_by_EVP_PKEY(pkey, selection,
                                             output_type, output_structure,
-                                            NULL, NULL);
+                                            NULL);
     if (OSSL_ENCODER_CTX_get_num_encoders(ectx) == 0) {
         BIO_printf(bio_err, "%s format not supported\n", output_type);
         goto end;

--- a/crypto/asn1/i2d_evp.c
+++ b/crypto/asn1/i2d_evp.c
@@ -42,8 +42,7 @@ static int i2d_provided(const EVP_PKEY *a, int selection,
         size_t len = INT_MAX;
 
         ctx = OSSL_ENCODER_CTX_new_by_EVP_PKEY(a, selection, "DER",
-                                               *output_structures,
-                                               NULL, NULL);
+                                               *output_structures, NULL);
         if (ctx == NULL)
             return -1;
         if (OSSL_ENCODER_to_data(ctx, pp, &len))

--- a/crypto/encode_decode/encoder_pkey.c
+++ b/crypto/encode_decode/encoder_pkey.c
@@ -213,14 +213,17 @@ static int ossl_encoder_ctx_setup_for_EVP_PKEY(OSSL_ENCODER_CTX *ctx,
                                                const char *propquery)
 {
     struct construct_data_st *data = NULL;
-    const OSSL_PROVIDER *prov = EVP_KEYMGMT_provider(pkey->keymgmt);
-    OSSL_LIB_CTX *libctx = ossl_provider_libctx(prov);
+    const OSSL_PROVIDER *prov = NULL;
+    OSSL_LIB_CTX *libctx = NULL;
     int ok = 0;
 
     if (!ossl_assert(ctx != NULL) || !ossl_assert(pkey != NULL)) {
         ERR_raise(ERR_LIB_OSSL_ENCODER, ERR_R_PASSED_NULL_PARAMETER);
         return 0;
     }
+
+    prov = EVP_KEYMGMT_provider(pkey->keymgmt);
+    libctx = ossl_provider_libctx(prov);
 
     if (pkey->keymgmt != NULL) {
         struct collected_encoder_st encoder_data;

--- a/crypto/encode_decode/encoder_pkey.c
+++ b/crypto/encode_decode/encoder_pkey.c
@@ -210,10 +210,11 @@ static void encoder_destruct_EVP_PKEY(void *arg)
 static int ossl_encoder_ctx_setup_for_EVP_PKEY(OSSL_ENCODER_CTX *ctx,
                                                const EVP_PKEY *pkey,
                                                int selection,
-                                               OSSL_LIB_CTX *libctx,
                                                const char *propquery)
 {
     struct construct_data_st *data = NULL;
+    const OSSL_PROVIDER *prov = EVP_KEYMGMT_provider(pkey->keymgmt);
+    OSSL_LIB_CTX *libctx = ossl_provider_libctx(prov);
     int ok = 0;
 
     if (!ossl_assert(ctx != NULL) || !ossl_assert(pkey != NULL)) {
@@ -280,10 +281,11 @@ OSSL_ENCODER_CTX *OSSL_ENCODER_CTX_new_by_EVP_PKEY(const EVP_PKEY *pkey,
                                                    int selection,
                                                    const char *output_type,
                                                    const char *output_struct,
-                                                   OSSL_LIB_CTX *libctx,
                                                    const char *propquery)
 {
     OSSL_ENCODER_CTX *ctx = NULL;
+    const OSSL_PROVIDER *prov = EVP_KEYMGMT_provider(pkey->keymgmt);
+    OSSL_LIB_CTX *libctx = ossl_provider_libctx(prov);
 
     if ((ctx = OSSL_ENCODER_CTX_new()) == NULL) {
         ERR_raise(ERR_LIB_OSSL_ENCODER, ERR_R_MALLOC_FAILURE);
@@ -302,8 +304,7 @@ OSSL_ENCODER_CTX *OSSL_ENCODER_CTX_new_by_EVP_PKEY(const EVP_PKEY *pkey,
         && (output_struct == NULL
             || OSSL_ENCODER_CTX_set_output_structure(ctx, output_struct))
         && OSSL_ENCODER_CTX_set_selection(ctx, selection)
-        && ossl_encoder_ctx_setup_for_EVP_PKEY(ctx, pkey, selection,
-                                               libctx, propquery)
+        && ossl_encoder_ctx_setup_for_EVP_PKEY(ctx, pkey, selection, propquery)
         && OSSL_ENCODER_CTX_add_extra(ctx, libctx, propquery)) {
         OSSL_TRACE_BEGIN(ENCODER) {
             BIO_printf(trc_out, "(ctx %p) Got %d encoders\n",

--- a/crypto/encode_decode/encoder_pkey.c
+++ b/crypto/encode_decode/encoder_pkey.c
@@ -284,12 +284,17 @@ OSSL_ENCODER_CTX *OSSL_ENCODER_CTX_new_by_EVP_PKEY(const EVP_PKEY *pkey,
                                                    const char *propquery)
 {
     OSSL_ENCODER_CTX *ctx = NULL;
-    const OSSL_PROVIDER *prov = EVP_KEYMGMT_provider(pkey->keymgmt);
-    OSSL_LIB_CTX *libctx = ossl_provider_libctx(prov);
+    OSSL_LIB_CTX *libctx = NULL;
 
     if ((ctx = OSSL_ENCODER_CTX_new()) == NULL) {
         ERR_raise(ERR_LIB_OSSL_ENCODER, ERR_R_MALLOC_FAILURE);
         return NULL;
+    }
+
+    if (pkey != NULL) {
+        const OSSL_PROVIDER *prov = EVP_KEYMGMT_provider(pkey->keymgmt);
+
+        libctx = ossl_provider_libctx(prov);
     }
 
     OSSL_TRACE_BEGIN(ENCODER) {

--- a/crypto/evp/evp_pkey.c
+++ b/crypto/evp/evp_pkey.c
@@ -81,15 +81,13 @@ PKCS8_PRIV_KEY_INFO *EVP_PKEY2PKCS8(const EVP_PKEY *pkey)
      */
     if (evp_pkey_is_provided(pkey)) {
         int selection = OSSL_KEYMGMT_SELECT_ALL;
-        const OSSL_PROVIDER *prov = EVP_KEYMGMT_provider(pkey->keymgmt);
-        OSSL_LIB_CTX *libctx = ossl_provider_libctx(prov);
         unsigned char *der = NULL;
         size_t derlen = 0;
         const unsigned char *pp;
 
         if ((ctx = OSSL_ENCODER_CTX_new_by_EVP_PKEY(pkey, selection,
                                                     "DER", "pkcs8",
-                                                    libctx, NULL)) == NULL
+                                                    NULL)) == NULL
             || !OSSL_ENCODER_to_data(ctx, &der, &derlen))
             goto error;
 

--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -1140,7 +1140,6 @@ static int unsup_alg(BIO *out, const EVP_PKEY *pkey, int indent,
 
 static int print_pkey(const EVP_PKEY *pkey, BIO *out, int indent,
                       int selection /* For provided encoding */,
-                      OSSL_LIB_CTX *libctx /* For provided encoding */,
                       const char *propquery /* For provided encoding */,
                       int (*legacy_print)(BIO *out, const EVP_PKEY *pkey,
                                           int indent, ASN1_PCTX *pctx),
@@ -1155,7 +1154,7 @@ static int print_pkey(const EVP_PKEY *pkey, BIO *out, int indent,
         return 0;
 
     ctx = OSSL_ENCODER_CTX_new_by_EVP_PKEY(pkey, selection, "TEXT", NULL,
-                                           libctx, propquery);
+                                           propquery);
     if (OSSL_ENCODER_CTX_get_num_encoders(ctx) != 0)
         ret = OSSL_ENCODER_to_bio(ctx, out);
     OSSL_ENCODER_CTX_free(ctx);
@@ -1177,7 +1176,7 @@ static int print_pkey(const EVP_PKEY *pkey, BIO *out, int indent,
 int EVP_PKEY_print_public(BIO *out, const EVP_PKEY *pkey,
                           int indent, ASN1_PCTX *pctx)
 {
-    return print_pkey(pkey, out, indent, EVP_PKEY_PUBLIC_KEY, NULL, NULL,
+    return print_pkey(pkey, out, indent, EVP_PKEY_PUBLIC_KEY, NULL,
                       (pkey->ameth != NULL ? pkey->ameth->pub_print : NULL),
                       pctx);
 }
@@ -1185,7 +1184,7 @@ int EVP_PKEY_print_public(BIO *out, const EVP_PKEY *pkey,
 int EVP_PKEY_print_private(BIO *out, const EVP_PKEY *pkey,
                            int indent, ASN1_PCTX *pctx)
 {
-    return print_pkey(pkey, out, indent, EVP_PKEY_KEYPAIR, NULL, NULL,
+    return print_pkey(pkey, out, indent, EVP_PKEY_KEYPAIR, NULL,
                       (pkey->ameth != NULL ? pkey->ameth->priv_print : NULL),
                       pctx);
 }
@@ -1193,7 +1192,7 @@ int EVP_PKEY_print_private(BIO *out, const EVP_PKEY *pkey,
 int EVP_PKEY_print_params(BIO *out, const EVP_PKEY *pkey,
                           int indent, ASN1_PCTX *pctx)
 {
-    return print_pkey(pkey, out, indent, EVP_PKEY_KEY_PARAMETERS, NULL, NULL,
+    return print_pkey(pkey, out, indent, EVP_PKEY_KEY_PARAMETERS, NULL,
                       (pkey->ameth != NULL ? pkey->ameth->param_print : NULL),
                       pctx);
 }

--- a/crypto/pem/pem_local.h
+++ b/crypto/pem/pem_local.h
@@ -49,7 +49,7 @@
     OSSL_ENCODER_CTX *ctx =                                             \
         OSSL_ENCODER_CTX_new_by_##type(x, PEM_SELECTION_##asn1,         \
                                        "PEM", PEM_STRUCTURE_##asn1,     \
-                                       NULL, NULL);                     \
+                                       NULL);                           \
                                                                         \
     if (OSSL_ENCODER_CTX_get_num_encoders(ctx) == 0) {                  \
         OSSL_ENCODER_CTX_free(ctx);                                     \

--- a/crypto/pem/pem_pk8.c
+++ b/crypto/pem/pem_pk8.c
@@ -22,14 +22,14 @@ static int do_pk8pkey(BIO *bp, const EVP_PKEY *x, int isder,
                       int nid, const EVP_CIPHER *enc,
                       const char *kstr, int klen,
                       pem_password_cb *cb, void *u,
-                      OSSL_LIB_CTX *libctx, const char *propq);
+                      const char *propq);
 
 #ifndef OPENSSL_NO_STDIO
 static int do_pk8pkey_fp(FILE *bp, const EVP_PKEY *x, int isder,
                          int nid, const EVP_CIPHER *enc,
                          const char *kstr, int klen,
                          pem_password_cb *cb, void *u,
-                         OSSL_LIB_CTX *libctx, const char *propq);
+                         const char *propq);
 #endif
 /*
  * These functions write a private key in PKCS#8 format: it is a "drop in"
@@ -42,40 +42,39 @@ int PEM_write_bio_PKCS8PrivateKey_nid(BIO *bp, const EVP_PKEY *x, int nid,
                                       const char *kstr, int klen,
                                       pem_password_cb *cb, void *u)
 {
-    return do_pk8pkey(bp, x, 0, nid, NULL, kstr, klen, cb, u, NULL, NULL);
+    return do_pk8pkey(bp, x, 0, nid, NULL, kstr, klen, cb, u, NULL);
 }
 
 int PEM_write_bio_PKCS8PrivateKey(BIO *bp, const EVP_PKEY *x, const EVP_CIPHER *enc,
                                   const char *kstr, int klen,
                                   pem_password_cb *cb, void *u)
 {
-    return do_pk8pkey(bp, x, 0, -1, enc, kstr, klen, cb, u, NULL, NULL);
+    return do_pk8pkey(bp, x, 0, -1, enc, kstr, klen, cb, u, NULL);
 }
 
 int i2d_PKCS8PrivateKey_bio(BIO *bp, const EVP_PKEY *x, const EVP_CIPHER *enc,
                             const char *kstr, int klen,
                             pem_password_cb *cb, void *u)
 {
-    return do_pk8pkey(bp, x, 1, -1, enc, kstr, klen, cb, u, NULL, NULL);
+    return do_pk8pkey(bp, x, 1, -1, enc, kstr, klen, cb, u, NULL);
 }
 
 int i2d_PKCS8PrivateKey_nid_bio(BIO *bp, const EVP_PKEY *x, int nid,
                                 const char *kstr, int klen,
                                 pem_password_cb *cb, void *u)
 {
-    return do_pk8pkey(bp, x, 1, nid, NULL, kstr, klen, cb, u, NULL, NULL);
+    return do_pk8pkey(bp, x, 1, nid, NULL, kstr, klen, cb, u, NULL);
 }
 
 static int do_pk8pkey(BIO *bp, const EVP_PKEY *x, int isder, int nid,
                       const EVP_CIPHER *enc, const char *kstr, int klen,
-                      pem_password_cb *cb, void *u,
-                      OSSL_LIB_CTX *libctx, const char *propq)
+                      pem_password_cb *cb, void *u, const char *propq)
 {
     int ret = 0;
     const char *outtype = isder ? "DER" : "PEM";
     OSSL_ENCODER_CTX *ctx =
         OSSL_ENCODER_CTX_new_by_EVP_PKEY(x, OSSL_KEYMGMT_SELECT_ALL,
-                                         outtype, "pkcs8", libctx, propq);
+                                         outtype, "pkcs8", propq);
 
     if (ctx == NULL)
         return 0;
@@ -203,34 +202,33 @@ int i2d_PKCS8PrivateKey_fp(FILE *fp, const EVP_PKEY *x, const EVP_CIPHER *enc,
                            const char *kstr, int klen,
                            pem_password_cb *cb, void *u)
 {
-    return do_pk8pkey_fp(fp, x, 1, -1, enc, kstr, klen, cb, u, NULL, NULL);
+    return do_pk8pkey_fp(fp, x, 1, -1, enc, kstr, klen, cb, u, NULL);
 }
 
 int i2d_PKCS8PrivateKey_nid_fp(FILE *fp, const EVP_PKEY *x, int nid,
                                const char *kstr, int klen,
                                pem_password_cb *cb, void *u)
 {
-    return do_pk8pkey_fp(fp, x, 1, nid, NULL, kstr, klen, cb, u, NULL, NULL);
+    return do_pk8pkey_fp(fp, x, 1, nid, NULL, kstr, klen, cb, u, NULL);
 }
 
 int PEM_write_PKCS8PrivateKey_nid(FILE *fp, const EVP_PKEY *x, int nid,
                                   const char *kstr, int klen,
                                   pem_password_cb *cb, void *u)
 {
-    return do_pk8pkey_fp(fp, x, 0, nid, NULL, kstr, klen, cb, u, NULL, NULL);
+    return do_pk8pkey_fp(fp, x, 0, nid, NULL, kstr, klen, cb, u, NULL);
 }
 
 int PEM_write_PKCS8PrivateKey(FILE *fp, const EVP_PKEY *x, const EVP_CIPHER *enc,
                               const char *kstr, int klen,
                               pem_password_cb *cb, void *u)
 {
-    return do_pk8pkey_fp(fp, x, 0, -1, enc, kstr, klen, cb, u, NULL, NULL);
+    return do_pk8pkey_fp(fp, x, 0, -1, enc, kstr, klen, cb, u, NULL);
 }
 
 static int do_pk8pkey_fp(FILE *fp, const EVP_PKEY *x, int isder, int nid,
                          const EVP_CIPHER *enc, const char *kstr, int klen,
-                         pem_password_cb *cb, void *u,
-                         OSSL_LIB_CTX *libctx, const char *propq)
+                         pem_password_cb *cb, void *u, const char *propq)
 {
     BIO *bp;
     int ret;
@@ -239,7 +237,7 @@ static int do_pk8pkey_fp(FILE *fp, const EVP_PKEY *x, int isder, int nid,
         ERR_raise(ERR_LIB_PEM, ERR_R_BUF_LIB);
         return 0;
     }
-    ret = do_pk8pkey(bp, x, isder, nid, enc, kstr, klen, cb, u, libctx, propq);
+    ret = do_pk8pkey(bp, x, isder, nid, enc, kstr, klen, cb, u, propq);
     BIO_free(bp);
     return ret;
 }

--- a/crypto/x509/x_pubkey.c
+++ b/crypto/x509/x_pubkey.c
@@ -98,14 +98,12 @@ int X509_PUBKEY_set(X509_PUBKEY **x, EVP_PKEY *pkey)
             goto error;
         }
     } else if (evp_pkey_is_provided(pkey)) {
-        const OSSL_PROVIDER *pkprov = EVP_KEYMGMT_provider(pkey->keymgmt);
-        OSSL_LIB_CTX *libctx = ossl_provider_libctx(pkprov);
         unsigned char *der = NULL;
         size_t derlen = 0;
         OSSL_ENCODER_CTX *ectx =
             OSSL_ENCODER_CTX_new_by_EVP_PKEY(pkey, EVP_PKEY_PUBLIC_KEY,
                                              "DER", "SubjectPublicKeyInfo",
-                                             libctx, NULL);
+                                             NULL);
 
         if (OSSL_ENCODER_to_data(ectx, &der, &derlen)) {
             const unsigned char *pder = der;
@@ -306,12 +304,10 @@ int i2d_PUBKEY(const EVP_PKEY *a, unsigned char **pp)
         }
         X509_PUBKEY_free(xpk);
     } else if (a->keymgmt != NULL) {
-        const OSSL_PROVIDER *pkprov = EVP_KEYMGMT_provider(a->keymgmt);
-        OSSL_LIB_CTX *libctx = ossl_provider_libctx(pkprov);
         OSSL_ENCODER_CTX *ctx =
             OSSL_ENCODER_CTX_new_by_EVP_PKEY(a, EVP_PKEY_PUBLIC_KEY,
                                              "DER", "SubjectPublicKeyInfo",
-                                             libctx, NULL);
+                                             NULL);
         BIO *out = BIO_new(BIO_s_mem());
         BUF_MEM *buf = NULL;
 

--- a/doc/man3/OSSL_ENCODER_CTX_new_by_EVP_PKEY.pod
+++ b/doc/man3/OSSL_ENCODER_CTX_new_by_EVP_PKEY.pod
@@ -18,7 +18,7 @@ OSSL_ENCODER_CTX_set_passphrase_ui
  OSSL_ENCODER_CTX_new_by_EVP_PKEY(const EVP_PKEY *pkey, int selection,
                                   const char *output_type,
                                   const char *output_structure,
-                                  OSSL_LIB_CTX *libctx, const char *propquery);
+                                  const char *propquery);
 
  int OSSL_ENCODER_CTX_set_cipher(OSSL_ENCODER_CTX *ctx,
                                  const char *cipher_name,
@@ -51,7 +51,7 @@ L<EVP_KEYMGMT(3)> implementation associated with I<pkey> to build a list of
 applicable encoder implementations that are used to process the I<pkey> into
 the encoding named by I<output_type>, with the outermost structure named by
 I<output_structure> if that's relevant.  All these implementations are
-implicitly fetched using I<libctx> and I<propquery>.
+implicitly fetched, with I<propquery> for finer selection.
 
 If no suitable encoder implementation is found,
 OSSL_ENCODER_CTX_new_by_EVP_PKEY() still creates a B<OSSL_ENCODER_CTX>, but

--- a/include/openssl/encoder.h
+++ b/include/openssl/encoder.h
@@ -117,7 +117,6 @@ OSSL_ENCODER_CTX *OSSL_ENCODER_CTX_new_by_EVP_PKEY(const EVP_PKEY *pkey,
                                                    int selection,
                                                    const char *output_type,
                                                    const char *output_struct,
-                                                   OSSL_LIB_CTX *libctx,
                                                    const char *propquery);
 
 # ifdef __cplusplus

--- a/test/endecode_test.c
+++ b/test/endecode_test.c
@@ -183,7 +183,7 @@ static int encode_EVP_PKEY_prov(void **encoded, long *encoded_len,
     if (!TEST_ptr(ectx = OSSL_ENCODER_CTX_new_by_EVP_PKEY(pkey, selection,
                                                           output_type,
                                                           output_structure,
-                                                          NULL, NULL))
+                                                          NULL))
         || !TEST_int_gt(OSSL_ENCODER_CTX_get_num_encoders(ectx), 0)
         || (pass != NULL
             && !TEST_true(OSSL_ENCODER_CTX_set_passphrase(ectx, upass,

--- a/test/endecoder_legacy_test.c
+++ b/test/endecoder_legacy_test.c
@@ -321,7 +321,7 @@ static int test_protected_PEM(const char *keytype, int evp_type,
     if (!TEST_ptr(ectx =
                   OSSL_ENCODER_CTX_new_by_EVP_PKEY(provided_pkey, selection,
                                                    "PEM", structure,
-                                                   NULL, NULL))
+                                                   NULL))
         || !TEST_true(OSSL_ENCODER_to_bio(ectx, membio_provided))
         || !TEST_true(pem_write_bio(membio_legacy, legacy_key,
                                    NULL, NULL, 0, NULL, NULL))
@@ -389,7 +389,7 @@ static int test_unprotected_PEM(const char *keytype, int evp_type,
     if (!TEST_ptr(ectx =
                   OSSL_ENCODER_CTX_new_by_EVP_PKEY(provided_pkey, selection,
                                                    "PEM", structure,
-                                                   NULL, NULL))
+                                                   NULL))
         || !TEST_true(OSSL_ENCODER_to_bio(ectx, membio_provided))
         || !TEST_true(pem_write_bio(membio_legacy, legacy_key))
         || !test_membio_str_eq(membio_provided, membio_legacy))
@@ -454,7 +454,7 @@ static int test_DER(const char *keytype, int evp_type,
     if (!TEST_ptr(ectx =
                  OSSL_ENCODER_CTX_new_by_EVP_PKEY(provided_pkey, selection,
                                                   "DER", structure,
-                                                  NULL, NULL))
+                                                  NULL))
         || !TEST_true(OSSL_ENCODER_to_data(ectx,
                                           &der_provided, &der_provided_len))
         || !TEST_size_t_gt(der_legacy_len = i2d(legacy_key, &der_legacy), 0)

--- a/test/evp_libctx_test.c
+++ b/test/evp_libctx_test.c
@@ -461,7 +461,7 @@ static int rsa_keygen(int bits, EVP_PKEY **pub, EVP_PKEY **priv)
                      OSSL_ENCODER_CTX_new_by_EVP_PKEY(*priv,
                                                       EVP_PKEY_PUBLIC_KEY,
                                                       "DER", "type-specific",
-                                                      libctx, NULL))
+                                                      NULL))
         || !TEST_true(OSSL_ENCODER_to_data(ectx, &pub_der, &len)))
         goto err;
     pp = pub_der;

--- a/test/evp_pkey_provided_test.c
+++ b/test/evp_pkey_provided_test.c
@@ -217,7 +217,7 @@ static int test_print_key_type_using_encoder(const char *alg, int type,
     if (!TEST_ptr(ctx = OSSL_ENCODER_CTX_new_by_EVP_PKEY(pk, selection,
                                                          output_type,
                                                          output_structure,
-                                                         NULL, NULL))
+                                                         NULL))
         /* Check that this operation is supported */
         || !TEST_int_ne(OSSL_ENCODER_CTX_get_num_encoders(ctx), 0))
         goto err;


### PR DESCRIPTION
The passed 'pkey' already contains a library context, and the encoder
implementations should be found within the same context, so passing an
explicit library context seems unnecessary, and potentially dangerous.

Fixes #13544