### PR TITLE
PEM: Add a more generic way to implement PEM _ex functions for libctx

### DIFF
--- a/crypto/pem/pem_local.h
+++ b/crypto/pem/pem_local.h
@@ -44,7 +44,7 @@
 
 /* Alternative IMPLEMENT macros for provided encoders */
 
-# define IMPLEMENT_PEM_provided_write_body_vars(type, asn1, libctx, pq) \
+# define IMPLEMENT_PEM_provided_write_body_vars(type, asn1, pq)         \
     int ret = 0;                                                        \
     OSSL_ENCODER_CTX *ctx =                                             \
         OSSL_ENCODER_CTX_new_by_##type(x, PEM_SELECTION_##asn1,         \
@@ -102,15 +102,14 @@
                                          OUTTYPE, outtype, writename)   \
     PEM_write_fnsig(name, type, OUTTYPE, writename)                     \
     {                                                                   \
-        IMPLEMENT_PEM_provided_write_body_vars(type, asn1, NULL, NULL); \
+        IMPLEMENT_PEM_provided_write_body_vars(type, asn1, NULL);       \
         IMPLEMENT_PEM_provided_write_body_main(type, outtype);          \
         IMPLEMENT_PEM_provided_write_body_fallback(str, asn1,           \
                                                    writename);          \
     }                                                                   \
     PEM_write_ex_fnsig(name, type, OUTTYPE, writename)                  \
     {                                                                   \
-        IMPLEMENT_PEM_provided_write_body_vars(type, asn1,              \
-                                               libctx, propq);          \
+        IMPLEMENT_PEM_provided_write_body_vars(type, asn1, propq);      \
         IMPLEMENT_PEM_provided_write_body_main(type, outtype);          \
         IMPLEMENT_PEM_provided_write_body_fallback(str, asn1,           \
                                                    writename);          \

--- a/crypto/pem/pem_local.h
+++ b/crypto/pem/pem_local.h
@@ -44,12 +44,12 @@
 
 /* Alternative IMPLEMENT macros for provided encoders */
 
-# define IMPLEMENT_PEM_provided_write_body_vars(type, asn1)             \
+# define IMPLEMENT_PEM_provided_write_body_vars(type, asn1, libctx, pq) \
     int ret = 0;                                                        \
     OSSL_ENCODER_CTX *ctx =                                             \
         OSSL_ENCODER_CTX_new_by_##type(x, PEM_SELECTION_##asn1,         \
                                        "PEM", PEM_STRUCTURE_##asn1,     \
-                                       NULL);                           \
+                                       (pq));                           \
                                                                         \
     if (OSSL_ENCODER_CTX_get_num_encoders(ctx) == 0) {                  \
         OSSL_ENCODER_CTX_free(ctx);                                     \
@@ -95,14 +95,22 @@
 # define IMPLEMENT_PEM_provided_write_body_fallback_cb(str, asn1,       \
                                                        writename)       \
     legacy:                                                             \
-    return PEM_ASN1_##writename((i2d_of_void *)i2d_##asn1, str, out,    \
-                                x, enc, kstr, klen, cb, u)
+    return PEM_ASN1_##writename##((i2d_of_void *)i2d_##asn1, str, out,  \
+                                  x, enc, kstr, klen, cb, u)
 
 # define IMPLEMENT_PEM_provided_write_to(name, type, str, asn1,         \
                                          OUTTYPE, outtype, writename)   \
     PEM_write_fnsig(name, type, OUTTYPE, writename)                     \
     {                                                                   \
-        IMPLEMENT_PEM_provided_write_body_vars(type, asn1);             \
+        IMPLEMENT_PEM_provided_write_body_vars(type, asn1, NULL, NULL); \
+        IMPLEMENT_PEM_provided_write_body_main(type, outtype);          \
+        IMPLEMENT_PEM_provided_write_body_fallback(str, asn1,           \
+                                                   writename);          \
+    }                                                                   \
+    PEM_write_ex_fnsig(name, type, OUTTYPE, writename)                  \
+    {                                                                   \
+        IMPLEMENT_PEM_provided_write_body_vars(type, asn1,              \
+                                               libctx, propq);          \
         IMPLEMENT_PEM_provided_write_body_main(type, outtype);          \
         IMPLEMENT_PEM_provided_write_body_fallback(str, asn1,           \
                                                    writename);          \
@@ -113,11 +121,19 @@
                                             OUTTYPE, outtype, writename) \
     PEM_write_cb_fnsig(name, type, OUTTYPE, writename)                  \
     {                                                                   \
-        IMPLEMENT_PEM_provided_write_body_vars(type, asn1);             \
+        IMPLEMENT_PEM_provided_write_body_vars(type, asn1, NULL);       \
         IMPLEMENT_PEM_provided_write_body_pass();                       \
         IMPLEMENT_PEM_provided_write_body_main(type, outtype);          \
         IMPLEMENT_PEM_provided_write_body_fallback_cb(str, asn1,        \
                                                       writename);       \
+    }                                                                   \
+    PEM_write_ex_cb_fnsig(name, type, OUTTYPE, writename)               \
+    {                                                                   \
+        IMPLEMENT_PEM_provided_write_body_vars(type, asn1, propq);      \
+        IMPLEMENT_PEM_provided_write_body_pass();                       \
+        IMPLEMENT_PEM_provided_write_body_main(type, outtype);          \
+        IMPLEMENT_PEM_provided_write_body_fallback(str, asn1,           \
+                                                   writename);          \
     }
 
 # ifdef OPENSSL_NO_STDIO

--- a/crypto/pem/pem_pkey.c
+++ b/crypto/pem/pem_pkey.c
@@ -153,7 +153,7 @@ EVP_PKEY *PEM_read_bio_PrivateKey(BIO *bp, EVP_PKEY **x, pem_password_cb *cb,
 
 PEM_write_cb_ex_fnsig(PrivateKey, EVP_PKEY, BIO, write_bio)
 {
-    IMPLEMENT_PEM_provided_write_body_vars(EVP_PKEY, PrivateKey, libctx, propq);
+    IMPLEMENT_PEM_provided_write_body_vars(EVP_PKEY, PrivateKey, propq);
 
     IMPLEMENT_PEM_provided_write_body_pass();
     IMPLEMENT_PEM_provided_write_body_main(EVP_PKEY, bio);
@@ -218,7 +218,8 @@ EVP_PKEY *PEM_read_bio_Parameters(BIO *bp, EVP_PKEY **x)
 PEM_write_fnsig(Parameters, EVP_PKEY, BIO, write_bio)
 {
     char pem_str[80];
-    IMPLEMENT_PEM_provided_write_body_vars(EVP_PKEY, Parameters, NULL, NULL);
+    IMPLEMENT_PEM_provided_write_body_vars(EVP_PKEY, Parameters, NULL);
+
     IMPLEMENT_PEM_provided_write_body_main(EVP_PKEY, bio);
 
  legacy:

--- a/crypto/pem/pem_pkey.c
+++ b/crypto/pem/pem_pkey.c
@@ -151,9 +151,9 @@ EVP_PKEY *PEM_read_bio_PrivateKey(BIO *bp, EVP_PKEY **x, pem_password_cb *cb,
     return PEM_read_bio_PrivateKey_ex(bp, x, cb, u, NULL, NULL);
 }
 
-PEM_write_cb_fnsig(PrivateKey, EVP_PKEY, BIO, write_bio)
+PEM_write_cb_ex_fnsig(PrivateKey, EVP_PKEY, BIO, write_bio)
 {
-    IMPLEMENT_PEM_provided_write_body_vars(EVP_PKEY, PrivateKey);
+    IMPLEMENT_PEM_provided_write_body_vars(EVP_PKEY, PrivateKey, libctx, propq);
 
     IMPLEMENT_PEM_provided_write_body_pass();
     IMPLEMENT_PEM_provided_write_body_main(EVP_PKEY, bio);
@@ -163,6 +163,12 @@ PEM_write_cb_fnsig(PrivateKey, EVP_PKEY, BIO, write_bio)
         return PEM_write_bio_PKCS8PrivateKey(out, x, enc,
                                              (const char *)kstr, klen, cb, u);
     return PEM_write_bio_PrivateKey_traditional(out, x, enc, kstr, klen, cb, u);
+}
+
+PEM_write_cb_fnsig(PrivateKey, EVP_PKEY, BIO, write_bio)
+{
+    return PEM_write_bio_PrivateKey_ex(out, x, enc, kstr, klen, cb, u,
+                                       NULL, NULL);
 }
 
 /*
@@ -212,8 +218,7 @@ EVP_PKEY *PEM_read_bio_Parameters(BIO *bp, EVP_PKEY **x)
 PEM_write_fnsig(Parameters, EVP_PKEY, BIO, write_bio)
 {
     char pem_str[80];
-    IMPLEMENT_PEM_provided_write_body_vars(EVP_PKEY, Parameters);
-
+    IMPLEMENT_PEM_provided_write_body_vars(EVP_PKEY, Parameters, NULL, NULL);
     IMPLEMENT_PEM_provided_write_body_main(EVP_PKEY, bio);
 
  legacy:
@@ -249,20 +254,23 @@ EVP_PKEY *PEM_read_PrivateKey(FILE *fp, EVP_PKEY **x, pem_password_cb *cb,
     return PEM_read_PrivateKey_ex(fp, x, cb, u, NULL, NULL);
 }
 
-int PEM_write_PrivateKey(FILE *fp, const EVP_PKEY *x, const EVP_CIPHER *enc,
-                         const unsigned char *kstr, int klen,
-                         pem_password_cb *cb, void *u)
+PEM_write_cb_ex_fnsig(PrivateKey, EVP_PKEY, FILE, write)
 {
     BIO *b;
     int ret;
 
-    if ((b = BIO_new_fp(fp, BIO_NOCLOSE)) == NULL) {
+    if ((b = BIO_new_fp(out, BIO_NOCLOSE)) == NULL) {
         ERR_raise(ERR_LIB_PEM, ERR_R_BUF_LIB);
         return 0;
     }
-    ret = PEM_write_bio_PrivateKey(b, x, enc, kstr, klen, cb, u);
+    ret = PEM_write_bio_PrivateKey_ex(b, x, enc, kstr, klen, cb, u,
+                                      libctx, propq);
     BIO_free(b);
     return ret;
 }
 
+PEM_write_cb_fnsig(PrivateKey, EVP_PKEY, FILE, write)
+{
+    return PEM_write_PrivateKey_ex(out, x, enc, kstr, klen, cb, u, NULL, NULL);
+}
 #endif

--- a/doc/man3/PEM_read_bio_PrivateKey.pod
+++ b/doc/man3/PEM_read_bio_PrivateKey.pod
@@ -3,13 +3,17 @@
 =head1 NAME
 
 pem_password_cb,
-PEM_read_bio_PrivateKey_ex, PEM_read_bio_PrivateKey, PEM_read_PrivateKey_ex,
-PEM_read_PrivateKey, PEM_write_bio_PrivateKey,
-PEM_write_bio_PrivateKey_traditional, PEM_write_PrivateKey,
+PEM_read_bio_PrivateKey_ex, PEM_read_bio_PrivateKey,
+PEM_read_PrivateKey_ex, PEM_read_PrivateKey,
+PEM_write_bio_PrivateKey_ex, PEM_write_bio_PrivateKey,
+PEM_write_bio_PrivateKey_traditional,
+PEM_write_PrivateKey_ex, PEM_write_PrivateKey,
 PEM_write_bio_PKCS8PrivateKey, PEM_write_PKCS8PrivateKey,
 PEM_write_bio_PKCS8PrivateKey_nid, PEM_write_PKCS8PrivateKey_nid,
-PEM_read_bio_PUBKEY_ex, PEM_read_bio_PUBKEY, PEM_read_PUBKEY_ex,
-PEM_read_PUBKEY, PEM_write_bio_PUBKEY, PEM_write_PUBKEY,
+PEM_read_bio_PUBKEY_ex, PEM_read_bio_PUBKEY,
+PEM_read_PUBKEY_ex, PEM_read_PUBKEY,
+PEM_write_bio_PUBKEY_ex, PEM_write_bio_PUBKEY,
+PEM_write_PUBKEY_ex, PEM_write_PUBKEY,
 PEM_read_bio_RSAPrivateKey, PEM_read_RSAPrivateKey,
 PEM_write_bio_RSAPrivateKey, PEM_write_RSAPrivateKey,
 PEM_read_bio_RSAPublicKey, PEM_read_RSAPublicKey, PEM_write_bio_RSAPublicKey,
@@ -35,9 +39,9 @@ PEM_write_bio_PKCS7, PEM_write_PKCS7 - PEM routines
 
  typedef int pem_password_cb(char *buf, int size, int rwflag, void *u);
 
- EVP_PKEY *PEM_read_bio_PrivateKey_ex(BIO *bp, EVP_PKEY **x, pem_password_cb *cb,
-                                      void *u, OSSL_LIB_CTX *libctx,
-                                      const char *propq);
+ EVP_PKEY *PEM_read_bio_PrivateKey_ex(BIO *bp, EVP_PKEY **x,
+                                      pem_password_cb *cb, void *u,
+                                      OSSL_LIB_CTX *libctx, const char *propq);
  EVP_PKEY *PEM_read_bio_PrivateKey(BIO *bp, EVP_PKEY **x,
                                    pem_password_cb *cb, void *u);
  EVP_PKEY *PEM_read_PrivateKey_ex(FILE *fp, EVP_PKEY **x, pem_password_cb *cb,
@@ -45,6 +49,11 @@ PEM_write_bio_PKCS7, PEM_write_PKCS7 - PEM routines
                                   const char *propq);
  EVP_PKEY *PEM_read_PrivateKey(FILE *fp, EVP_PKEY **x,
                                pem_password_cb *cb, void *u);
+ int PEM_write_bio_PrivateKey_ex(BIO *bp, const EVP_PKEY *x,
+                                 const EVP_CIPHER *enc,
+                                 unsigned char *kstr, int klen,
+                                 pem_password_cb *cb, void *u,
+                                 OSSL_LIB_CTX *libctx, const char *propq);
  int PEM_write_bio_PrivateKey(BIO *bp, const EVP_PKEY *x, const EVP_CIPHER *enc,
                               unsigned char *kstr, int klen,
                               pem_password_cb *cb, void *u);
@@ -52,6 +61,10 @@ PEM_write_bio_PKCS7, PEM_write_PKCS7 - PEM routines
                                           const EVP_CIPHER *enc,
                                           unsigned char *kstr, int klen,
                                           pem_password_cb *cb, void *u);
+ int PEM_write_PrivateKey_ex(FILE *fp, EVP_PKEY *x, const EVP_CIPHER *enc,
+                             unsigned char *kstr, int klen,
+                             pem_password_cb *cb, void *u,
+                             OSSL_LIB_CTX *libctx, const char *propq);
  int PEM_write_PrivateKey(FILE *fp, EVP_PKEY *x, const EVP_CIPHER *enc,
                           unsigned char *kstr, int klen,
                           pem_password_cb *cb, void *u);
@@ -78,7 +91,11 @@ PEM_write_bio_PKCS7, PEM_write_PKCS7 - PEM routines
                               OSSL_LIB_CTX *libctx, const char *propq);
  EVP_PKEY *PEM_read_PUBKEY(FILE *fp, EVP_PKEY **x,
                            pem_password_cb *cb, void *u);
+ int PEM_write_bio_PUBKEY_ex(BIO *bp, EVP_PKEY *x,
+                             OSSL_LIB_CTX *libctx, const char *propq);
  int PEM_write_bio_PUBKEY(BIO *bp, EVP_PKEY *x);
+ int PEM_write_PUBKEY_ex(FILE *fp, EVP_PKEY *x,
+                         OSSL_LIB_CTX *libctx, const char *propq);
  int PEM_write_PUBKEY(FILE *fp, EVP_PKEY *x);
 
  RSA *PEM_read_bio_RSAPrivateKey(BIO *bp, RSA **x,
@@ -187,9 +204,9 @@ B<PEM_write_bio_I<TYPE>>(), and B<PEM_write_I<TYPE>>() functions.
 Some operations have additional variants that take a library context I<libctx>
 and a property query string I<propq>.
 
-The B<PrivateKey> functions read or write a private key in PEM format using an
-EVP_PKEY structure. The write routines use PKCS#8 private key format and are
-equivalent to PEM_write_bio_PKCS8PrivateKey().The read functions transparently
+The B<PrivateKey> functions read or write a private key in PEM format using
+an EVP_PKEY structure. The write routines use PKCS#8 private key format and are
+equivalent to PEM_write_bio_PKCS8PrivateKey(). The read functions transparently
 handle traditional and PKCS#8 format encrypted and unencrypted keys.
 
 PEM_write_bio_PrivateKey_traditional() writes out a private key in the

--- a/include/openssl/pem.h
+++ b/include/openssl/pem.h
@@ -66,13 +66,33 @@ extern "C" {
  * IMPLEMENT_PEM_rw_cb(...)
  */
 
-# define PEM_write_fnsig(name, type, OUTTYPE, writename)        \
+# define PEM_read_cb_fnsig(name, type, INTYPE, readname)                \
+    type *PEM_##readname##_##name(INTYPE *out, type **x,                \
+                                 pem_password_cb *cb, void *u)
+# define PEM_read_cb_ex_fnsig(name, type, INTYPE, readname)             \
+    type *PEM_##readname##_##name##_ex(INTYPE *out, type **x,           \
+                                       pem_password_cb *cb, void *u,    \
+                                       OSSL_LIB_CTX *libctx,            \
+                                       const char *propq)
+
+# define PEM_write_fnsig(name, type, OUTTYPE, writename)                \
     int PEM_##writename##_##name(OUTTYPE *out, const type *x)
 # define PEM_write_cb_fnsig(name, type, OUTTYPE, writename)             \
     int PEM_##writename##_##name(OUTTYPE *out, const type *x,           \
                                  const EVP_CIPHER *enc,                 \
                                  const unsigned char *kstr, int klen,   \
                                  pem_password_cb *cb, void *u)
+# define PEM_write_ex_fnsig(name, type, OUTTYPE, writename)             \
+    int PEM_##writename##_##name##_ex(OUTTYPE *out, const type *x,      \
+                                      OSSL_LIB_CTX *libctx,             \
+                                      const char *propq)
+# define PEM_write_cb_ex_fnsig(name, type, OUTTYPE, writename)          \
+    int PEM_##writename##_##name##_ex(OUTTYPE *out, const type *x,      \
+                                      const EVP_CIPHER *enc,            \
+                                      const unsigned char *kstr, int klen, \
+                                      pem_password_cb *cb, void *u,     \
+                                      OSSL_LIB_CTX *libctx,             \
+                                      const char *propq)
 
 # ifdef OPENSSL_NO_STDIO
 
@@ -199,50 +219,70 @@ extern "C" {
 # if defined(OPENSSL_NO_STDIO)
 
 #  define DECLARE_PEM_read_fp_attr(attr, name, type) /**/
+#  define DECLARE_PEM_read_fp_ex_attr(attr, name, type) /**/
 #  define DECLARE_PEM_write_fp_attr(attr, name, type) /**/
-#  define DECLARE_PEM_write_fp_attr(attr, name, type) /**/
+#  define DECLARE_PEM_write_fp_ex_attr(attr, name, type) /**/
 #  ifndef OPENSSL_NO_DEPRECATED_3_0
 #   define DECLARE_PEM_write_fp_const_attr(attr, name, type) /**/
 #  endif
 #  define DECLARE_PEM_write_cb_fp_attr(attr, name, type) /**/
+#  define DECLARE_PEM_write_cb_fp_ex_attr(attr, name, type) /**/
 
 # else
 
 #  define DECLARE_PEM_read_fp_attr(attr, name, type)                        \
-    attr type *PEM_read_##name(FILE *fp, type **x,                          \
-                               pem_password_cb *cb, void *u);
+    attr PEM_read_cb_fnsig(name, type, FILE, read);
+#  define DECLARE_PEM_read_fp_ex_attr(attr, name, type)                     \
+    attr PEM_read_cb_fnsig(name, type, FILE, read);                         \
+    attr PEM_read_cb_ex_fnsig(name, type, FILE, read);
+
 #  define DECLARE_PEM_write_fp_attr(attr, name, type)                       \
     attr PEM_write_fnsig(name, type, FILE, write);
+#  define DECLARE_PEM_write_fp_ex_attr(attr, name, type)                    \
+    attr PEM_write_fnsig(name, type, FILE, write);                          \
+    attr PEM_write_ex_fnsig(name, type, FILE, write);
 #  ifndef OPENSSL_NO_DEPRECATED_3_0
 #   define DECLARE_PEM_write_fp_const_attr(attr, name, type)                \
     attr PEM_write_fnsig(name, type, FILE, write);
 #  endif
 #  define DECLARE_PEM_write_cb_fp_attr(attr, name, type)                    \
     attr PEM_write_cb_fnsig(name, type, FILE, write);
+#  define DECLARE_PEM_write_cb_fp_ex_attr(attr, name, type)                 \
+    attr PEM_write_cb_fnsig(name, type, FILE, write);                       \
+    attr PEM_write_cb_ex_fnsig(name, type, FILE, write);
 
 # endif
 
-# define DECLARE_PEM_read_fp(name, type)                                   \
+# define DECLARE_PEM_read_fp(name, type)                                    \
     DECLARE_PEM_read_fp_attr(extern, name, type)
-# define DECLARE_PEM_write_fp(name, type)                                  \
+# define DECLARE_PEM_write_fp(name, type)                                   \
     DECLARE_PEM_write_fp_attr(extern, name, type)
 # ifndef OPENSSL_NO_DEPRECATED_3_0
 #   define DECLARE_PEM_write_fp_const(name, type)                           \
     DECLARE_PEM_write_fp_const_attr(extern, name, type)
 # endif
-# define DECLARE_PEM_write_cb_fp(name, type)                               \
+# define DECLARE_PEM_write_cb_fp(name, type)                                \
     DECLARE_PEM_write_cb_fp_attr(extern, name, type)
 
-# define DECLARE_PEM_read_bio_attr(attr, name, type)                        \
-    attr type *PEM_read_bio_##name(BIO *bp, type **x,                       \
-                                   pem_password_cb *cb, void *u);
+#  define DECLARE_PEM_read_bio_attr(attr, name, type)                       \
+    attr PEM_read_cb_fnsig(name, type, BIO, read_bio);
+#  define DECLARE_PEM_read_bio_ex_attr(attr, name, type)                    \
+    attr PEM_read_cb_fnsig(name, type, BIO, read_bio);                      \
+    attr PEM_read_cb_ex_fnsig(name, type, BIO, read_bio);
 # define DECLARE_PEM_read_bio(name, type)                                   \
     DECLARE_PEM_read_bio_attr(extern, name, type)
+# define DECLARE_PEM_read_bio_ex(name, type)                                \
+    DECLARE_PEM_read_bio_ex_attr(extern, name, type)
 
 # define DECLARE_PEM_write_bio_attr(attr, name, type)                       \
     attr PEM_write_fnsig(name, type, BIO, write_bio);
+# define DECLARE_PEM_write_bio_ex_attr(attr, name, type)                    \
+    attr PEM_write_fnsig(name, type, BIO, write_bio);                       \
+    attr PEM_write_ex_fnsig(name, type, BIO, write_bio);
 # define DECLARE_PEM_write_bio(name, type)                                  \
     DECLARE_PEM_write_bio_attr(extern, name, type)
+# define DECLARE_PEM_write_bio_ex(name, type)                               \
+    DECLARE_PEM_write_bio_ex_attr(extern, name, type)
 
 # ifndef OPENSSL_NO_DEPRECATED_3_0
 #  define DECLARE_PEM_write_bio_const_attr(attr, name, type)                \
@@ -253,14 +293,24 @@ extern "C" {
 
 # define DECLARE_PEM_write_cb_bio_attr(attr, name, type)                    \
     attr PEM_write_cb_fnsig(name, type, BIO, write_bio);
+# define DECLARE_PEM_write_cb_bio_ex_attr(attr, name, type)                 \
+    attr PEM_write_cb_fnsig(name, type, BIO, write_bio);                    \
+    attr PEM_write_cb_ex_fnsig(name, type, BIO, write_bio);
 # define DECLARE_PEM_write_cb_bio(name, type)                               \
     DECLARE_PEM_write_cb_bio_attr(extern, name, type)
+# define DECLARE_PEM_write_cb_ex_bio(name, type)                            \
+    DECLARE_PEM_write_cb_bio_ex_attr(extern, name, type)
 
 # define DECLARE_PEM_write_attr(attr, name, type)                           \
     DECLARE_PEM_write_bio_attr(attr, name, type)                            \
     DECLARE_PEM_write_fp_attr(attr, name, type)
+# define DECLARE_PEM_write_ex_attr(attr, name, type)                        \
+    DECLARE_PEM_write_bio_ex_attr(attr, name, type)                         \
+    DECLARE_PEM_write_fp_ex_attr(attr, name, type)
 # define DECLARE_PEM_write(name, type) \
     DECLARE_PEM_write_attr(extern, name, type)
+# define DECLARE_PEM_write_ex(name, type) \
+    DECLARE_PEM_write_ex_attr(extern, name, type)
 # ifndef OPENSSL_NO_DEPRECATED_3_0
 #  define DECLARE_PEM_write_const_attr(attr, name, type)                    \
     DECLARE_PEM_write_bio_const_attr(attr, name, type)                      \
@@ -271,18 +321,33 @@ extern "C" {
 # define DECLARE_PEM_write_cb_attr(attr, name, type)                        \
     DECLARE_PEM_write_cb_bio_attr(attr, name, type)                         \
     DECLARE_PEM_write_cb_fp_attr(attr, name, type)
+# define DECLARE_PEM_write_cb_ex_attr(attr, name, type)                     \
+    DECLARE_PEM_write_cb_bio_ex_attr(attr, name, type)                      \
+    DECLARE_PEM_write_cb_fp_ex_attr(attr, name, type)
 # define DECLARE_PEM_write_cb(name, type)                                   \
     DECLARE_PEM_write_cb_attr(extern, name, type)
+# define DECLARE_PEM_write_cb_ex(name, type)                                \
+    DECLARE_PEM_write_cb_ex_attr(extern, name, type)
 # define DECLARE_PEM_read_attr(attr, name, type)                            \
     DECLARE_PEM_read_bio_attr(attr, name, type)                             \
     DECLARE_PEM_read_fp_attr(attr, name, type)
+# define DECLARE_PEM_read_ex_attr(attr, name, type)                         \
+    DECLARE_PEM_read_bio_ex_attr(attr, name, type)                          \
+    DECLARE_PEM_read_fp_ex_attr(attr, name, type)
 # define DECLARE_PEM_read(name, type)                                       \
     DECLARE_PEM_read_attr(extern, name, type)
+# define DECLARE_PEM_read_ex(name, type)                                    \
+    DECLARE_PEM_read_ex_attr(extern, name, type)
 # define DECLARE_PEM_rw_attr(attr, name, type)                              \
     DECLARE_PEM_read_attr(attr, name, type)                                 \
     DECLARE_PEM_write_attr(attr, name, type)
+# define DECLARE_PEM_rw_ex_attr(attr, name, type)                           \
+    DECLARE_PEM_read_ex_attr(attr, name, type)                              \
+    DECLARE_PEM_write_ex_attr(attr, name, type)
 # define DECLARE_PEM_rw(name, type) \
     DECLARE_PEM_rw_attr(extern, name, type)
+# define DECLARE_PEM_rw_ex(name, type) \
+    DECLARE_PEM_rw_ex_attr(extern, name, type)
 # ifndef OPENSSL_NO_DEPRECATED_3_0
 #  define DECLARE_PEM_rw_const_attr(attr, name, type)                       \
     DECLARE_PEM_read_attr(attr, name, type)                                 \
@@ -293,8 +358,13 @@ extern "C" {
 # define DECLARE_PEM_rw_cb_attr(attr, name, type)                           \
     DECLARE_PEM_read_attr(attr, name, type)                                 \
     DECLARE_PEM_write_cb_attr(attr, name, type)
+# define DECLARE_PEM_rw_cb_ex_attr(attr, name, type)                        \
+    DECLARE_PEM_read_ex_attr(attr, name, type)                              \
+    DECLARE_PEM_write_cb_ex_attr(attr, name, type)
 # define DECLARE_PEM_rw_cb(name, type) \
     DECLARE_PEM_rw_cb_attr(extern, name, type)
+# define DECLARE_PEM_rw_cb_ex(name, type) \
+    DECLARE_PEM_rw_cb_ex_attr(extern, name, type)
 
 int PEM_get_EVP_CIPHER_INFO(char *header, EVP_CIPHER_INFO *cipher);
 int PEM_do_header(EVP_CIPHER_INFO *cipher, unsigned char *data, long *len,
@@ -396,24 +466,8 @@ DECLARE_PEM_rw_attr(OSSL_DEPRECATEDIN_3_0, DHparams, DH)
 DECLARE_PEM_write_attr(OSSL_DEPRECATEDIN_3_0, DHxparams, DH)
 #  endif
 # endif
-DECLARE_PEM_rw_cb(PrivateKey, EVP_PKEY)
-EVP_PKEY *PEM_read_bio_PrivateKey_ex(BIO *bp, EVP_PKEY **x,
-                                     pem_password_cb *cb, void *u,
-                                     OSSL_LIB_CTX *libctx, const char *propq);
-# ifndef OPENSSL_NO_STDIO
-EVP_PKEY *PEM_read_PrivateKey_ex(FILE *fp, EVP_PKEY **x,
-                                 pem_password_cb *cb, void *u,
-                                 OSSL_LIB_CTX *libctx, const char *propq);
-# endif
-DECLARE_PEM_rw(PUBKEY, EVP_PKEY)
-EVP_PKEY *PEM_read_bio_PUBKEY_ex(BIO *bp, EVP_PKEY **x,
-                                 pem_password_cb *cb, void *u,
-                                 OSSL_LIB_CTX *libctx, const char *propq);
-# ifndef OPENSSL_NO_STDIO
-EVP_PKEY *PEM_read_PUBKEY_ex(FILE *fp, EVP_PKEY **x,
-                             pem_password_cb *cb, void *u,
-                             OSSL_LIB_CTX *libctx, const char *propq);
-# endif
+DECLARE_PEM_rw_cb_ex(PrivateKey, EVP_PKEY)
+DECLARE_PEM_rw_ex(PUBKEY, EVP_PKEY)
 
 int PEM_write_bio_PrivateKey_traditional(BIO *bp, const EVP_PKEY *x,
                                          const EVP_CIPHER *enc,

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5280,3 +5280,7 @@ OSSL_DECODER_CTX_set_input_structure    ?	3_0_0	EXIST::FUNCTION:
 OSSL_DECODER_INSTANCE_get_input_structure ?	3_0_0	EXIST::FUNCTION:
 OSSL_ENCODER_CTX_set_output_structure   ?	3_0_0	EXIST::FUNCTION:
 OSSL_ENCODER_INSTANCE_get_output_structure ?	3_0_0	EXIST::FUNCTION:
+PEM_write_PrivateKey_ex                 ?	3_0_0	EXIST::FUNCTION:STDIO
+PEM_write_bio_PrivateKey_ex             ?	3_0_0	EXIST::FUNCTION:
+PEM_write_PUBKEY_ex                     ?	3_0_0	EXIST::FUNCTION:STDIO
+PEM_write_bio_PUBKEY_ex                 ?	3_0_0	EXIST::FUNCTION:

--- a/util/perl/OpenSSL/ParseC.pm
+++ b/util/perl/OpenSSL/ParseC.pm
@@ -553,12 +553,38 @@ int PEM_write_bio_$1(void);
 EOF
       },
     },
+    { regexp   => qr/DECLARE_PEM(?|_rw|_rw_cb|_rw_const)_ex<<<\((.*?),.*\)>>>/,
+      massager => sub { return (<<"EOF");
+#ifndef OPENSSL_NO_STDIO
+int PEM_read_$1(void);
+int PEM_write_$1(void);
+int PEM_read_$1_ex(void);
+int PEM_write_$1_ex(void);
+#endif
+int PEM_read_bio_$1(void);
+int PEM_write_bio_$1(void);
+int PEM_read_bio_$1_ex(void);
+int PEM_write_bio_$1_ex(void);
+EOF
+      },
+    },
     { regexp   => qr/DECLARE_PEM(?|_write|_write_cb|_write_const)<<<\((.*?),.*\)>>>/,
       massager => sub { return (<<"EOF");
 #ifndef OPENSSL_NO_STDIO
 int PEM_write_$1(void);
 #endif
 int PEM_write_bio_$1(void);
+EOF
+      },
+    },
+    { regexp   => qr/DECLARE_PEM(?|_write|_write_cb|_write_const)_ex<<<\((.*?),.*\)>>>/,
+      massager => sub { return (<<"EOF");
+#ifndef OPENSSL_NO_STDIO
+int PEM_write_$1(void);
+int PEM_write_$1_ex(void);
+#endif
+int PEM_write_bio_$1(void);
+int PEM_write_bio_$1_ex(void);
 EOF
       },
     },
@@ -571,10 +597,22 @@ int PEM_read_bio_$1(void);
 EOF
       },
     },
+    { regexp   => qr/DECLARE_PEM(?|_read|_read_cb)_ex<<<\((.*?),.*\)>>>/,
+      massager => sub { return (<<"EOF");
+#ifndef OPENSSL_NO_STDIO
+int PEM_read_$1(void);
+int PEM_read_$1_ex(void);
+#endif
+int PEM_read_bio_$1(void);
+int PEM_read_bio_$1_ex(void);
+EOF
+      },
+    },
     # Universal translator of attributed PEM declarators
     { regexp   => qr/
           DECLARE_PEM
-          (_rw|_rw_cb|_rw_const|_write|_write_cb|_write_const|_read|_read_cb)
+          ((?:_rw|_rw_cb|_rw_const|_write|_write_cb|_write_const|_read|_read_cb)
+           (?:_ex)?)
           _attr
           <<<\(\s*OSSL_DEPRECATEDIN_(.*?)\s*,(.*?)\)>>>
       /x,


### PR DESCRIPTION
This also adds the following functions, for completeness:

PEM_write_PrivateKey_ex(), PEM_write_bio_PrivateKey_ex(),
PEM_write_PUBKEY_ex, PEM_write_bio_PUBKEY_ex

Fixes #13542
