### PR TITLE
Fix builds that specify both no-dh and no-ec

### DIFF
--- a/providers/common/capabilities.c
+++ b/providers/common/capabilities.c
@@ -19,6 +19,8 @@
 #include "prov/providercommon.h"
 #include "e_os.h"
 
+/* If neither ec or dh is available then we have no TLS-GROUP capabilities */
+#if !defined(OPENSSL_NO_EC) || !defined(OPENSSL_NO_DH)
 typedef struct tls_group_constants_st {
     unsigned int group_id;   /* Group ID */
     unsigned int secbits;    /* Bits of security */
@@ -97,83 +99,87 @@ static const TLS_GROUP_CONSTANTS group_list[35] = {
     }
 
 static const OSSL_PARAM param_group_list[][10] = {
-#ifndef OPENSSL_NO_EC
-# ifndef OPENSSL_NO_EC2M
+# ifndef OPENSSL_NO_EC
+#  ifndef OPENSSL_NO_EC2M
     TLS_GROUP_ENTRY("sect163k1", "sect163k1", "EC", 0),
-# endif
-# ifndef FIPS_MODULE
+#  endif
+#  ifndef FIPS_MODULE
     TLS_GROUP_ENTRY("sect163r1", "sect163r1", "EC", 1),
-# endif
-# ifndef OPENSSL_NO_EC2M
+#  endif
+#  ifndef OPENSSL_NO_EC2M
     TLS_GROUP_ENTRY("sect163r2", "sect163r2", "EC", 2),
-# endif
-# ifndef FIPS_MODULE
+#  endif
+#  ifndef FIPS_MODULE
     TLS_GROUP_ENTRY("sect193r1", "sect193r1", "EC", 3),
     TLS_GROUP_ENTRY("sect193r2", "sect193r2", "EC", 4),
-# endif
-# ifndef OPENSSL_NO_EC2M
+#  endif
+#  ifndef OPENSSL_NO_EC2M
     TLS_GROUP_ENTRY("sect233k1", "sect233k1", "EC", 5),
     TLS_GROUP_ENTRY("sect233r1", "sect233r1", "EC", 6),
-# endif
-# ifndef FIPS_MODULE
+#  endif
+#  ifndef FIPS_MODULE
     TLS_GROUP_ENTRY("sect239k1", "sect239k1", "EC", 7),
-# endif
-# ifndef OPENSSL_NO_EC2M
+#  endif
+#  ifndef OPENSSL_NO_EC2M
     TLS_GROUP_ENTRY("sect283k1", "sect283k1", "EC", 8),
     TLS_GROUP_ENTRY("sect283r1", "sect283r1", "EC", 9),
     TLS_GROUP_ENTRY("sect409k1", "sect409k1", "EC", 10),
     TLS_GROUP_ENTRY("sect409r1", "sect409r1", "EC", 11),
     TLS_GROUP_ENTRY("sect571k1", "sect571k1", "EC", 12),
     TLS_GROUP_ENTRY("sect571r1", "sect571r1", "EC", 13),
-# endif
-# ifndef FIPS_MODULE
+#  endif
+#  ifndef FIPS_MODULE
     TLS_GROUP_ENTRY("secp160k1", "secp160k1", "EC", 14),
     TLS_GROUP_ENTRY("secp160r1", "secp160r1", "EC", 15),
     TLS_GROUP_ENTRY("secp160r2", "secp160r2", "EC", 16),
     TLS_GROUP_ENTRY("secp192k1", "secp192k1", "EC", 17),
-# endif
+#  endif
     TLS_GROUP_ENTRY("secp192r1", "prime192v1", "EC", 18),
-# ifndef FIPS_MODULE
+#  ifndef FIPS_MODULE
     TLS_GROUP_ENTRY("secp224k1", "secp224k1", "EC", 19),
-# endif
+#  endif
     TLS_GROUP_ENTRY("secp224r1", "secp224r1", "EC", 20),
-# ifndef FIPS_MODULE
+#  ifndef FIPS_MODULE
     TLS_GROUP_ENTRY("secp256k1", "secp256k1", "EC", 21),
-# endif
+#  endif
     TLS_GROUP_ENTRY("secp256r1", "prime256v1", "EC", 22),
     TLS_GROUP_ENTRY("secp384r1", "secp384r1", "EC", 23),
     TLS_GROUP_ENTRY("secp521r1", "secp521r1", "EC", 24),
-# ifndef FIPS_MODULE
+#  ifndef FIPS_MODULE
     TLS_GROUP_ENTRY("brainpoolP256r1", "brainpoolP256r1", "EC", 25),
     TLS_GROUP_ENTRY("brainpoolP384r1", "brainpoolP384r1", "EC", 26),
     TLS_GROUP_ENTRY("brainpoolP512r1", "brainpoolP512r1", "EC", 27),
-# endif
+#  endif
     TLS_GROUP_ENTRY("x25519", "x25519", "X25519", 28),
     TLS_GROUP_ENTRY("x448", "x448", "X448", 29),
-#endif /* OPENSSL_NO_EC */
-#ifndef OPENSSL_NO_DH
+# endif /* OPENSSL_NO_EC */
+# ifndef OPENSSL_NO_DH
     /* Security bit values for FFDHE groups are as per RFC 7919 */
     TLS_GROUP_ENTRY("ffdhe2048", "ffdhe2048", "DH", 30),
     TLS_GROUP_ENTRY("ffdhe3072", "ffdhe3072", "DH", 31),
     TLS_GROUP_ENTRY("ffdhe4096", "ffdhe4096", "DH", 32),
     TLS_GROUP_ENTRY("ffdhe6144", "ffdhe6144", "DH", 33),
     TLS_GROUP_ENTRY("ffdhe8192", "ffdhe8192", "DH", 34),
-#endif
+# endif
 };
+#endif /* !defined(OPENSSL_NO_EC) || !defined(OPENSSL_NO_DH) */
 
 static int tls_group_capability(OSSL_CALLBACK *cb, void *arg)
 {
+#if !defined(OPENSSL_NO_EC) || !defined(OPENSSL_NO_DH)
     size_t i;
 
-#if !defined(OPENSSL_NO_EC) \
+# if !defined(OPENSSL_NO_EC) \
     && !defined(OPENSSL_NO_EC2M) \
     && !defined(OPENSSL_NO_DH) \
     && !defined(FIPS_MODULE)
     assert(OSSL_NELEM(param_group_list) == OSSL_NELEM(group_list));
-#endif
+# endif
+
     for (i = 0; i < OSSL_NELEM(param_group_list); i++)
         if (!cb(param_group_list[i], arg))
             return 0;
+#endif
 
     return 1;
 }

--- a/providers/fips/self_test_data.inc
+++ b/providers/fips/self_test_data.inc
@@ -769,9 +769,10 @@ static const unsigned char ecdh_secret_expected[] = {
 };
 #endif /* OPENSSL_NO_EC */
 
+#if !defined(OPENSSL_NO_DH) || !defined(OPENSSL_NO_EC)
 static const ST_KAT_KAS st_kat_kas_tests[] =
 {
-#ifndef OPENSSL_NO_DH
+# ifndef OPENSSL_NO_DH
     {
         OSSL_SELF_TEST_DESC_KA_DH,
         "DH",
@@ -780,8 +781,8 @@ static const ST_KAT_KAS st_kat_kas_tests[] =
         dh_peer_key,
         ITM(dh_secret_expected)
     },
-#endif /* OPENSSL_NO_DH */
-#ifndef OPENSSL_NO_EC
+# endif /* OPENSSL_NO_DH */
+# ifndef OPENSSL_NO_EC
     {
         OSSL_SELF_TEST_DESC_KA_ECDH,
         "EC",
@@ -790,8 +791,9 @@ static const ST_KAT_KAS st_kat_kas_tests[] =
         ecdh_peer_key,
         ITM(ecdh_secret_expected)
     },
-#endif /* OPENSSL_NO_EC */
+# endif /* OPENSSL_NO_EC */
 };
+#endif /* !defined(OPENSSL_NO_DH) || !defined(OPENSSL_NO_EC) */
 
 #if !defined(OPENSSL_NO_RSA)
 /* RSA key data */

--- a/providers/fips/self_test_kats.c
+++ b/providers/fips/self_test_kats.c
@@ -346,6 +346,7 @@ err:
     return ret;
 }
 
+#if !defined(OPENSSL_NO_DH) || !defined(OPENSSL_NO_EC)
 static int self_test_ka(const ST_KAT_KAS *t,
                         OSSL_SELF_TEST *st, OSSL_LIB_CTX *libctx)
 {
@@ -421,6 +422,7 @@ err:
     OSSL_SELF_TEST_onend(st, ret);
     return ret;
 }
+#endif /* !defined(OPENSSL_NO_DH) || !defined(OPENSSL_NO_EC) */
 
 static int self_test_sign(const ST_KAT_SIGN *t,
                          OSSL_SELF_TEST *st, OSSL_LIB_CTX *libctx)
@@ -655,12 +657,16 @@ static int self_test_drbgs(OSSL_SELF_TEST *st, OSSL_LIB_CTX *libctx)
 
 static int self_test_kas(OSSL_SELF_TEST *st, OSSL_LIB_CTX *libctx)
 {
-    int i, ret = 1;
+    int ret = 1;
+#if !defined(OPENSSL_NO_DH) || !defined(OPENSSL_NO_EC)
+    int i;
 
     for (i = 0; i < (int)OSSL_NELEM(st_kat_kas_tests); ++i) {
         if (!self_test_ka(&st_kat_kas_tests[i], st, libctx))
             ret = 0;
     }
+#endif
+
     return ret;
 }
 

--- a/ssl/ssl_local.h
+++ b/ssl/ssl_local.h
@@ -1301,9 +1301,7 @@ struct ssl_st {
             int message_type;
             /* used to hold the new cipher we are going to use */
             const SSL_CIPHER *new_cipher;
-# if !defined(OPENSSL_NO_EC) || !defined(OPENSSL_NO_DH)
-            EVP_PKEY *pkey;         /* holds short lived DH/ECDH key */
-# endif
+            EVP_PKEY *pkey;         /* holds short lived key exchange key */
             /* used for certificate requests */
             int cert_req;
             /* Certificate types in certificate request message. */
@@ -1415,11 +1413,9 @@ struct ssl_st {
 # endif                         /* !OPENSSL_NO_EC */
 
         /* For clients: peer temporary key */
-# if !defined(OPENSSL_NO_EC) || !defined(OPENSSL_NO_DH)
-        /* The group_id for the DH/ECDH key */
+        /* The group_id for the key exchange key */
         uint16_t group_id;
         EVP_PKEY *peer_tmp;
-# endif
 
     } s3;
 

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -136,7 +136,6 @@ int tls1_clear(SSL *s)
     return 1;
 }
 
-#if !defined(OPENSSL_NO_DH) || !defined(OPENSSL_NO_EC)
 /* Legacy NID to group_id mapping. Only works for groups we know about */
 static struct {
     int nid;
@@ -185,7 +184,6 @@ static struct {
     {NID_ffdhe6144, OSSL_TLS_GROUP_ID_ffdhe6144},
     {NID_ffdhe8192, OSSL_TLS_GROUP_ID_ffdhe8192}
 };
-#endif
 
 #ifndef OPENSSL_NO_EC
 static const unsigned char ecformats_default[] = {
@@ -421,7 +419,8 @@ static uint16_t tls1_group_name2id(SSL_CTX *ctx, const char *name)
         if (strcmp(ctx->group_list[i].tlsname, name) == 0
                 || (nid != NID_undef
                     && nid == tls1_group_id2nid(ctx->group_list[i].group_id,
-                                                0)))
+                                                0))
+           )
             return ctx->group_list[i].group_id;
     }
 
@@ -440,7 +439,6 @@ const TLS_GROUP_INFO *tls1_group_id_lookup(SSL_CTX *ctx, uint16_t group_id)
     return NULL;
 }
 
-#if !defined(OPENSSL_NO_DH) || !defined(OPENSSL_NO_EC)
 int tls1_group_id2nid(uint16_t group_id, int include_unknown)
 {
     size_t i;
@@ -478,7 +476,6 @@ static uint16_t tls1_nid2group_id(int nid)
 
     return 0;
 }
-#endif /* !defined(OPENSSL_NO_EC) || !defined(OPENSSL_NO_DH) */
 
 /*
  * Set *pgroups to the supported groups list and *pgroupslen to
@@ -644,7 +641,6 @@ uint16_t tls1_shared_group(SSL *s, int nmatch)
 int tls1_set_groups(uint16_t **pext, size_t *pextlen,
                     int *groups, size_t ngroups)
 {
-#if !defined(OPENSSL_NO_EC) || !defined(OPENSSL_NO_DH)
     uint16_t *glist;
     size_t i;
     /*
@@ -683,9 +679,6 @@ int tls1_set_groups(uint16_t **pext, size_t *pextlen,
 err:
     OPENSSL_free(glist);
     return 0;
-#else
-    return 0;
-#endif /* !defined(OPENSSL_NO_EC) || !defined(OPENSSL_NO_DH) */
 }
 
 /* TODO(3.0): An arbitrary amount for now. Take another look at this */

--- a/test/dtlstest.c
+++ b/test/dtlstest.c
@@ -146,6 +146,11 @@ static int test_dtls_unprocessed(int testidx)
 
 #define TOTAL_RECORDS (TOTAL_FULL_HAND_RECORDS + TOTAL_RESUME_HAND_RECORDS)
 
+/*
+ * We are assuming a ServerKeyExchange message is sent in this test. If we don't
+ * have either DH or EC, then it won't be
+ */
+#if !defined(OPENSSL_NO_DH) || !defined(OPENSSL_NO_EC)
 static int test_dtls_drop_records(int idx)
 {
     SSL_CTX *sctx = NULL, *cctx = NULL;
@@ -247,6 +252,7 @@ static int test_dtls_drop_records(int idx)
 
     return testresult;
 }
+#endif /* !defined(OPENSSL_NO_DH) || !defined(OPENSSL_NO_EC) */
 
 static const char dummy_cookie[] = "0123456";
 
@@ -345,7 +351,9 @@ int setup_tests(void)
         return 0;
 
     ADD_ALL_TESTS(test_dtls_unprocessed, NUM_TESTS);
+#if !defined(OPENSSL_NO_DH) || !defined(OPENSSL_NO_EC)
     ADD_ALL_TESTS(test_dtls_drop_records, TOTAL_RECORDS);
+#endif
     ADD_TEST(test_cookie);
     ADD_TEST(test_dtls_duplicate_records);
 


### PR DESCRIPTION
Various sections of code assumed that at least one of dh or ec would be
available. We also now also need to handle cases where a provider has
a key exchange algorithm and TLS-GROUP that we don't know about.

Fixes #13536
