### PR TITLE
Check non-option arguments

### DIFF
--- a/apps/asn1pars.c
+++ b/apps/asn1pars.c
@@ -157,6 +157,8 @@ int asn1parse_main(int argc, char **argv)
             break;
         }
     }
+
+    /* No extra args. */
     argc = opt_num_rest();
     if (argc != 0)
         goto opthelp;

--- a/apps/ca.c
+++ b/apps/ca.c
@@ -488,7 +488,9 @@ opthelp:
             break;
         }
     }
+
 end_of_options:
+    /* Remaining args are files to certify. */
     argc = opt_num_rest();
     argv = opt_rest();
 

--- a/apps/ciphers.c
+++ b/apps/ciphers.c
@@ -176,11 +176,12 @@ int ciphers_main(int argc, char **argv)
             break;
         }
     }
+
+    /* Optional arg is cipher name. */
     argv = opt_rest();
     argc = opt_num_rest();
-
     if (argc == 1)
-        ciphers = *argv;
+        ciphers = argv[0];
     else if (argc != 0)
         goto opthelp;
 

--- a/apps/cmp.c
+++ b/apps/cmp.c
@@ -2293,7 +2293,7 @@ static int get_opts(int argc, char **argv)
         switch (o) {
         case OPT_EOF:
         case OPT_ERR:
-            goto opt_err;
+            goto opthelp;
         case OPT_HELP:
             opt_help(cmp_options);
             return -1;
@@ -2315,11 +2315,11 @@ static int get_opts(int argc, char **argv)
             break;
         case OPT_MSG_TIMEOUT:
             if ((opt_msg_timeout = opt_nat()) < 0)
-                goto opt_err;
+                goto opthelp;
             break;
         case OPT_TOTAL_TIMEOUT:
             if ((opt_total_timeout = opt_nat()) < 0)
-                goto opt_err;
+                goto opthelp;
             break;
         case OPT_TLS_USED:
             opt_tls_used = 1;
@@ -2403,7 +2403,7 @@ static int get_opts(int argc, char **argv)
 
         case OPT_V_CASES:
             if (!opt_verify(o, vpm))
-                goto opt_err;
+                goto opthelp;
             break;
         case OPT_CMD:
             opt_cmd_s = opt_str("cmd");
@@ -2429,7 +2429,7 @@ static int get_opts(int argc, char **argv)
             break;
         case OPT_DAYS:
             if ((opt_days = opt_nat()) < 0)
-                goto opt_err;
+                goto opthelp;
             break;
         case OPT_REQEXTS:
             opt_reqexts = opt_str("reqexts");
@@ -2454,7 +2454,7 @@ static int get_opts(int argc, char **argv)
                     || opt_popo < OSSL_CRMF_POPO_NONE
                     || opt_popo > OSSL_CRMF_POPO_KEYENC) {
                 CMP_err("invalid popo spec. Valid values are -1 .. 2");
-                goto opt_err;
+                goto opthelp;
             }
             break;
         case OPT_CSR:
@@ -2484,7 +2484,7 @@ static int get_opts(int argc, char **argv)
                     || opt_revreason > CRL_REASON_AA_COMPROMISE
                     || opt_revreason == 7) {
                 CMP_err("invalid revreason. Valid values are -1 .. 6, 8 .. 10");
-                goto opt_err;
+                goto opthelp;
             }
             break;
         case OPT_CERTFORM:
@@ -2503,7 +2503,7 @@ static int get_opts(int argc, char **argv)
 #endif
         case OPT_PROV_CASES:
             if (!opt_provider(o))
-                goto opt_err;
+                goto opthelp;
             break;
 
         case OPT_BATCH:
@@ -2535,7 +2535,7 @@ static int get_opts(int argc, char **argv)
             break;
         case OPT_MAX_MSGS:
             if ((opt_max_msgs = opt_nat()) < 0)
-                goto opt_err;
+                goto opthelp;
             break;
         case OPT_SRV_REF:
             opt_srv_ref = opt_str("srv_ref");
@@ -2608,15 +2608,15 @@ static int get_opts(int argc, char **argv)
             break;
         }
     }
+
+    /* No extra args. */
     argc = opt_num_rest();
     argv = opt_rest();
-    if (argc != 0) {
-        CMP_err1("unknown parameter %s", argv[0]);
-        goto opt_err;
-    }
-    return 1;
+    if (argc == 0)
+        return 1;
 
- opt_err:
+    CMP_err1("unknown parameter %s", argv[0]);
+ opthelp:
     CMP_err1("use -help for summary of '%s' options", prog);
     return 0;
 }

--- a/apps/cmp.c
+++ b/apps/cmp.c
@@ -2293,7 +2293,9 @@ static int get_opts(int argc, char **argv)
         switch (o) {
         case OPT_EOF:
         case OPT_ERR:
-            goto opthelp;
+ opthelp:
+            BIO_printf(bio_err, "%s: Use -help for summary.\n", prog);
+            return 0;
         case OPT_HELP:
             opt_help(cmp_options);
             return -1;
@@ -2612,13 +2614,9 @@ static int get_opts(int argc, char **argv)
     /* No extra args. */
     argc = opt_num_rest();
     argv = opt_rest();
-    if (argc == 0)
-        return 1;
-
-    CMP_err1("unknown parameter %s", argv[0]);
- opthelp:
-    CMP_err1("use -help for summary of '%s' options", prog);
-    return 0;
+    if (argc != 0)
+        goto opthelp;
+    return 1;
 }
 
 int cmp_main(int argc, char **argv)

--- a/apps/cms.c
+++ b/apps/cms.c
@@ -699,6 +699,8 @@ int cms_main(int argc, char **argv)
             break;
         }
     }
+
+    /* Remaining args are files to process. */
     argc = opt_num_rest();
     argv = opt_rest();
 

--- a/apps/crl.c
+++ b/apps/crl.c
@@ -201,6 +201,8 @@ int crl_main(int argc, char **argv)
             break;
         }
     }
+
+    /* No remaining args. */
     argc = opt_num_rest();
     if (argc != 0)
         goto opthelp;

--- a/apps/crl2p7.c
+++ b/apps/crl2p7.c
@@ -102,6 +102,8 @@ int crl2pkcs7_main(int argc, char **argv)
             break;
         }
     }
+
+    /* No remaining args. */
     argc = opt_num_rest();
     if (argc != 0)
         goto opthelp;

--- a/apps/dgst.c
+++ b/apps/dgst.c
@@ -215,6 +215,8 @@ int dgst_main(int argc, char **argv)
             break;
         }
     }
+
+    /* Remaining args are files to digest. */
     argc = opt_num_rest();
     argv = opt_rest();
     if (keyfile != NULL && argc > 1) {

--- a/apps/dhparam.c
+++ b/apps/dhparam.c
@@ -148,11 +148,17 @@ int dhparam_main(int argc, char **argv)
             break;
         }
     }
+
+    /* One optional argument, bitsize to generate. */
     argc = opt_num_rest();
     argv = opt_rest();
+    if (argc == 1) {
+        if (!opt_int(argv[0], &num) || num <= 0)
+            goto opthelp;
+    } else if (argc != 0) {
+        goto opthelp;
+    }
 
-    if (argv[0] != NULL && (!opt_int(argv[0], &num) || num <= 0))
-        goto end;
 
     if (g && !num)
         num = DEFBITS;

--- a/apps/dsa.c
+++ b/apps/dsa.c
@@ -150,6 +150,8 @@ int dsa_main(int argc, char **argv)
             break;
         }
     }
+
+    /* No extra args. */
     argc = opt_num_rest();
     if (argc != 0)
         goto opthelp;

--- a/apps/dsaparam.c
+++ b/apps/dsaparam.c
@@ -125,15 +125,19 @@ int dsaparam_main(int argc, char **argv)
             break;
         }
     }
+
+    /* Optional arg is bitsize. */
     argc = opt_num_rest();
     argv = opt_rest();
-
     if (argc == 1) {
         if (!opt_int(argv[0], &num) || num < 0)
-            goto end;
-        /* generate a key */
-        numbits = num;
+            goto opthelp;
+    } else if (argc != 0) {
+        goto opthelp;
     }
+
+    /* generate a key */
+    numbits = num;
     private = genkey ? 1 : 0;
 
     out = bio_open_owner(outfile, outformat, private);

--- a/apps/ec.c
+++ b/apps/ec.c
@@ -166,6 +166,8 @@ int ec_main(int argc, char **argv)
             break;
         }
     }
+
+    /* No extra arguments. */
     argc = opt_num_rest();
     if (argc != 0)
         goto opthelp;

--- a/apps/ecparam.c
+++ b/apps/ecparam.c
@@ -172,6 +172,8 @@ int ecparam_main(int argc, char **argv)
             break;
         }
     }
+
+    /* No extra args. */
     argc = opt_num_rest();
     if (argc != 0)
         goto opthelp;

--- a/apps/enc.c
+++ b/apps/enc.c
@@ -295,10 +295,11 @@ int enc_main(int argc, char **argv)
             break;
         }
     }
-    if (opt_num_rest() != 0) {
-        BIO_printf(bio_err, "Extra arguments given.\n");
+
+    /* No extra arguments. */
+    argc = opt_num_rest();
+    if (argc != 0)
         goto opthelp;
-    }
 
     if (cipher && EVP_CIPHER_flags(cipher) & EVP_CIPH_FLAG_AEAD_CIPHER) {
         BIO_printf(bio_err, "%s: AEAD ciphers not supported\n", prog);

--- a/apps/engine.c
+++ b/apps/engine.c
@@ -360,7 +360,7 @@ int engine_main(int argc, char **argv)
         }
     }
 
-    /* Allow any trailing parameters as engine names. */
+    /* Any remaining arguments are engine names. */
     argc = opt_num_rest();
     argv = opt_rest();
     for ( ; *argv; argv++) {

--- a/apps/errstr.c
+++ b/apps/errstr.c
@@ -57,7 +57,7 @@ int errstr_main(int argc, char **argv)
      * we're still interested in SSL error strings
      */
     OPENSSL_init_ssl(OPENSSL_INIT_LOAD_SSL_STRINGS
-            | OPENSSL_INIT_LOAD_CRYPTO_STRINGS, NULL);
+                    | OPENSSL_INIT_LOAD_CRYPTO_STRINGS, NULL);
 
     /* All remaining arg are error code. */
     ret = 0;

--- a/apps/errstr.c
+++ b/apps/errstr.c
@@ -52,16 +52,19 @@ int errstr_main(int argc, char **argv)
         }
     }
 
+    /*
+     * We're not really an SSL application so this won't auto-init, but
+     * we're still interested in SSL error strings
+     */
+    OPENSSL_init_ssl(OPENSSL_INIT_LOAD_SSL_STRINGS
+            | OPENSSL_INIT_LOAD_CRYPTO_STRINGS, NULL);
+
+    /* All remaining arg are error code. */
     ret = 0;
-    for (argv = opt_rest(); *argv; argv++) {
+    for (argv = opt_rest(); *argv != NULL; argv++) {
         if (sscanf(*argv, "%lx", &l) == 0) {
             ret++;
         } else {
-            /* We're not really an SSL application so this won't auto-init, but
-             * we're still interested in SSL error strings
-             */
-            OPENSSL_init_ssl(OPENSSL_INIT_LOAD_SSL_STRINGS
-                             | OPENSSL_INIT_LOAD_CRYPTO_STRINGS, NULL);
             ERR_error_string_n(l, buf, sizeof(buf));
             BIO_printf(bio_out, "%s\n", buf);
         }

--- a/apps/fipsinstall.c
+++ b/apps/fipsinstall.c
@@ -373,7 +373,11 @@ opthelp:
             break;
         }
     }
+
+    /* No extra arguments. */
     argc = opt_num_rest();
+    if (argc != 0)
+        goto opthelp;
 
     if (parent_config != NULL) {
         /* Test that a parent config can load the module */
@@ -386,9 +390,8 @@ opthelp:
         goto end;
     }
     if (module_fname == NULL
-        || (verify && in_fname == NULL)
-        || (!verify && out_fname == NULL)
-        || argc != 0)
+            || (verify && in_fname == NULL)
+            || (!verify && out_fname == NULL))
         goto opthelp;
 
     tail = opt_path_end(module_fname);

--- a/apps/gendsa.c
+++ b/apps/gendsa.c
@@ -102,13 +102,15 @@ int gendsa_main(int argc, char **argv)
             break;
         }
     }
+
+    /* One argument, the params file. */
     argc = opt_num_rest();
     argv = opt_rest();
-    private = 1;
-
     if (argc != 1)
         goto opthelp;
-    dsaparams = *argv;
+
+    dsaparams = argv[0];
+    private = 1;
 
     if (!app_passwd(NULL, passoutarg, NULL, &passout)) {
         BIO_printf(bio_err, "Error getting password\n");

--- a/apps/genpkey.c
+++ b/apps/genpkey.c
@@ -153,6 +153,8 @@ int genpkey_main(int argc, char **argv)
             break;
         }
     }
+
+    /* No extra arguments. */
     argc = opt_num_rest();
     if (argc != 0)
         goto opthelp;

--- a/apps/genrsa.c
+++ b/apps/genrsa.c
@@ -146,6 +146,8 @@ opthelp:
             break;
         }
     }
+
+    /* One optional argument, the bitsize. */
     argc = opt_num_rest();
     argv = opt_rest();
 

--- a/apps/info.c
+++ b/apps/info.c
@@ -86,10 +86,8 @@ opthelp:
             break;
         }
     }
-    if (opt_num_rest() != 0) {
-        BIO_printf(bio_err, "%s: Extra parameters given.\n", prog);
+    if (opt_num_rest() != 0)
         goto opthelp;
-    }
     if (dirty > 1) {
         BIO_printf(bio_err, "%s: Only one item allowed\n", prog);
         goto opthelp;

--- a/apps/kdf.c
+++ b/apps/kdf.c
@@ -89,13 +89,12 @@ opthelp:
             break;
         }
     }
+
+    /* One argument, the KDF name. */
     argc = opt_num_rest();
     argv = opt_rest();
-
-    if (argc != 1) {
-        BIO_printf(bio_err, "Invalid number of extra arguments\n");
+    if (argc != 1)
         goto opthelp;
-    }
 
     if ((kdf = EVP_KDF_fetch(NULL, argv[0], NULL)) == NULL) {
         BIO_printf(bio_err, "Invalid KDF name %s\n", argv[0]);

--- a/apps/list.c
+++ b/apps/list.c
@@ -1480,10 +1480,10 @@ opthelp:
         }
         done = 1;
     }
-    if (opt_num_rest() != 0) {
-        BIO_printf(bio_err, "Extra arguments given.\n");
+
+    /* No extra arguments. */
+    if (opt_num_rest() != 0)
         goto opthelp;
-    }
 
     if (todo.commands)
         list_type(FT_general, one);

--- a/apps/mac.c
+++ b/apps/mac.c
@@ -98,13 +98,12 @@ opthelp:
             break;
         }
     }
+
+    /* One argument, the MAC name. */
     argc = opt_num_rest();
     argv = opt_rest();
-
-    if (argc != 1) {
-        BIO_printf(bio_err, "Invalid number of extra arguments\n");
+    if (argc != 1)
         goto opthelp;
-    }
 
     mac = EVP_MAC_fetch(NULL, argv[0], NULL);
     if (mac == NULL) {

--- a/apps/nseq.c
+++ b/apps/nseq.c
@@ -71,6 +71,8 @@ int nseq_main(int argc, char **argv)
             break;
         }
     }
+
+    /* No extra arguments. */
     argc = opt_num_rest();
     if (argc != 0)
         goto opthelp;

--- a/apps/ocsp.c
+++ b/apps/ocsp.c
@@ -514,14 +514,17 @@ int ocsp_main(int argc, char **argv)
             break;
         }
     }
+
+    /* No extra arguments. */
+    argc = opt_num_rest();
+    if (argc != 0)
+        goto opthelp;
+
     if (trailing_md) {
         BIO_printf(bio_err, "%s: Digest must be before -cert or -serial\n",
                    prog);
         goto opthelp;
     }
-    argc = opt_num_rest();
-    if (argc != 0)
-        goto opthelp;
 
     /* Have we anything to do? */
     if (req == NULL && reqin == NULL

--- a/apps/openssl.c
+++ b/apps/openssl.c
@@ -345,6 +345,7 @@ int help_main(int argc, char **argv)
         }
     }
 
+    /* One optional argument, the command to get help for. */
     if (opt_num_rest() == 1) {
         new_argv[0] = opt_rest()[0];
         new_argv[1] = "--help";

--- a/apps/passwd.c
+++ b/apps/passwd.c
@@ -185,7 +185,7 @@ int passwd_main(int argc, char **argv)
         }
     }
 
-    /* All optional arguments, are the password text. */
+    /* All remaining arguments are the password text */
     argc = opt_num_rest();
     argv = opt_rest();
     if (*argv != NULL) {

--- a/apps/passwd.c
+++ b/apps/passwd.c
@@ -184,9 +184,10 @@ int passwd_main(int argc, char **argv)
             break;
         }
     }
+
+    /* All optional arguments, are the password text. */
     argc = opt_num_rest();
     argv = opt_rest();
-
     if (*argv != NULL) {
         if (pw_source_defined)
             goto opthelp;

--- a/apps/pkcs12.c
+++ b/apps/pkcs12.c
@@ -331,7 +331,11 @@ int pkcs12_main(int argc, char **argv)
             break;
         }
     }
+
+    /* No extra arguments. */
     argc = opt_num_rest();
+    if (argc != 0)
+        goto opthelp;
 
     if (!export_cert) {
         if (chain)
@@ -386,8 +390,6 @@ int pkcs12_main(int argc, char **argv)
         enc = EVP_des_ede3_cbc();
     }
 
-    if (argc != 0)
-        goto opthelp;
 
     private = 1;
 

--- a/apps/pkcs7.c
+++ b/apps/pkcs7.c
@@ -110,6 +110,8 @@ int pkcs7_main(int argc, char **argv)
             break;
         }
     }
+
+    /* No extra arguments. */
     argc = opt_num_rest();
     if (argc != 0)
         goto opthelp;

--- a/apps/pkcs8.c
+++ b/apps/pkcs8.c
@@ -193,6 +193,8 @@ int pkcs8_main(int argc, char **argv)
 #endif
         }
     }
+
+    /* No extra arguments. */
     argc = opt_num_rest();
     if (argc != 0)
         goto opthelp;

--- a/apps/pkey.c
+++ b/apps/pkey.c
@@ -185,6 +185,8 @@ int pkey_main(int argc, char **argv)
             break;
         }
     }
+
+    /* No extra arguments. */
     argc = opt_num_rest();
     if (argc != 0)
         goto opthelp;

--- a/apps/pkeyparam.c
+++ b/apps/pkeyparam.c
@@ -90,6 +90,8 @@ int pkeyparam_main(int argc, char **argv)
             break;
         }
     }
+
+    /* No extra arguments. */
     argc = opt_num_rest();
     if (argc != 0)
         goto opthelp;

--- a/apps/pkeyutl.c
+++ b/apps/pkeyutl.c
@@ -250,6 +250,8 @@ int pkeyutl_main(int argc, char **argv)
             break;
         }
     }
+
+    /* No extra arguments. */
     argc = opt_num_rest();
     if (argc != 0)
         goto opthelp;

--- a/apps/prime.c
+++ b/apps/prime.c
@@ -81,16 +81,14 @@ opthelp:
             break;
         }
     }
+
+    /* Optional arguments are numbers to check. */
     argc = opt_num_rest();
     argv = opt_rest();
-
     if (generate) {
-        if (argc != 0) {
-            BIO_printf(bio_err, "Extra arguments given.\n");
+        if (argc != 0)
             goto opthelp;
-        }
     } else if (argc == 0) {
-        BIO_printf(bio_err, "%s: No prime specified\n", prog);
         goto opthelp;
     }
 

--- a/apps/rand.c
+++ b/apps/rand.c
@@ -88,13 +88,14 @@ int rand_main(int argc, char **argv)
             break;
         }
     }
+
+    /* Optional argument is number of bytes to generate. */
     argc = opt_num_rest();
     argv = opt_rest();
     if (argc == 1) {
         if (!opt_int(argv[0], &num) || num <= 0)
-            goto end;
-    } else if (argc > 0) {
-        BIO_printf(bio_err, "Extra arguments given.\n");
+            goto opthelp;
+    } else if (argc != 0) {
         goto opthelp;
     }
 

--- a/apps/rehash.c
+++ b/apps/rehash.c
@@ -515,6 +515,8 @@ int rehash_main(int argc, char **argv)
             break;
         }
     }
+
+    /* Optional arguments are directories to scan. */
     argc = opt_num_rest();
     argv = opt_rest();
 

--- a/apps/req.c
+++ b/apps/req.c
@@ -447,6 +447,8 @@ int req_main(int argc, char **argv)
             break;
         }
     }
+
+    /* No extra arguments. */
     argc = opt_num_rest();
     if (argc != 0)
         goto opthelp;

--- a/apps/rsa.c
+++ b/apps/rsa.c
@@ -175,6 +175,8 @@ int rsa_main(int argc, char **argv)
             break;
         }
     }
+
+    /* No extra arguments. */
     argc = opt_num_rest();
     if (argc != 0)
         goto opthelp;

--- a/apps/rsautl.c
+++ b/apps/rsautl.c
@@ -171,6 +171,8 @@ int rsautl_main(int argc, char **argv)
             break;
         }
     }
+
+    /* No extra arguments. */
     argc = opt_num_rest();
     if (argc != 0)
         goto opthelp;

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -1572,6 +1572,24 @@ int s_client_main(int argc, char **argv)
         }
     }
 
+    /* Optional argument is connect string if -connect not used. */
+    argc = opt_num_rest();
+    if (argc == 1) {
+        /*
+         * Don't allow -connect and a separate argument.
+         */
+        if (connectstr != NULL) {
+            BIO_printf(bio_err,
+                       "%s: cannot provide both -connect option and target parameter\n",
+                       prog);
+            goto opthelp;
+        }
+        connect_type = use_inet;
+        freeandcopy(&connectstr, *opt_rest());
+    } else if (argc != 0) {
+        goto opthelp;
+    }
+
     if (count4or6 >= 2) {
         BIO_printf(bio_err, "%s: Can't use both -4 and -6\n", prog);
         goto opthelp;
@@ -1589,23 +1607,6 @@ int s_client_main(int argc, char **argv)
                prog);
             goto opthelp;
         }
-    }
-    argc = opt_num_rest();
-    if (argc == 1) {
-        /* If there's a positional argument, it's the equivalent of
-         * OPT_CONNECT.
-         * Don't allow -connect and a separate argument.
-         */
-        if (connectstr != NULL) {
-            BIO_printf(bio_err,
-                       "%s: must not provide both -connect option and target parameter\n",
-                       prog);
-            goto opthelp;
-        }
-        connect_type = use_inet;
-        freeandcopy(&connectstr, *opt_rest());
-    } else if (argc != 0) {
-        goto opthelp;
     }
 
 #ifndef OPENSSL_NO_NEXTPROTONEG

--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -1660,8 +1660,11 @@ int s_server_main(int argc, char *argv[])
             break;
         }
     }
+
+    /* No extra arguments. */
     argc = opt_num_rest();
-    argv = opt_rest();
+    if (argc != 0)
+        goto opthelp;
 
 #ifndef OPENSSL_NO_NEXTPROTONEG
     if (min_version == TLS1_3_VERSION && next_proto_neg_in != NULL) {

--- a/apps/s_time.c
+++ b/apps/s_time.c
@@ -234,6 +234,8 @@ int s_time_main(int argc, char **argv)
             break;
         }
     }
+
+    /* No extra arguments. */
     argc = opt_num_rest();
     if (argc != 0)
         goto opthelp;

--- a/apps/sess_id.c
+++ b/apps/sess_id.c
@@ -96,6 +96,8 @@ int sess_id_main(int argc, char **argv)
             break;
         }
     }
+
+    /* No extra arguments. */
     argc = opt_num_rest();
     if (argc != 0)
         goto opthelp;

--- a/apps/smime.c
+++ b/apps/smime.c
@@ -357,12 +357,17 @@ int smime_main(int argc, char **argv)
         }
     }
 
-    /* Extra arguements are files with recipient keys. */
+    /* Extra arguments are files with recipient keys. */
     argc = opt_num_rest();
     argv = opt_rest();
 
     if (!(operation & SMIME_SIGNERS) && (skkeys != NULL || sksigners != NULL)) {
         BIO_puts(bio_err, "Multiple signers or keys not allowed\n");
+        goto opthelp;
+    }
+    if (!operation) {
+        BIO_puts(bio_err,
+                "No operation (-encrypt|-sign|...) specified\n");
         goto opthelp;
     }
 
@@ -400,8 +405,6 @@ int smime_main(int argc, char **argv)
             BIO_printf(bio_err, "No recipient(s) certificate(s) specified\n");
             goto opthelp;
         }
-    } else if (!operation) {
-        goto opthelp;
     }
 
     if (!app_passwd(passinarg, NULL, &passin, NULL)) {

--- a/apps/smime.c
+++ b/apps/smime.c
@@ -356,6 +356,8 @@ int smime_main(int argc, char **argv)
             break;
         }
     }
+
+    /* Extra arguements are files with recipient keys. */
     argc = opt_num_rest();
     argv = opt_rest();
 

--- a/apps/speed.c
+++ b/apps/speed.c
@@ -1802,10 +1802,11 @@ int speed_main(int argc, char **argv)
             break;
         }
     }
+
+    /* Remaining arguments are algorithms. */
     argc = opt_num_rest();
     argv = opt_rest();
 
-    /* Remaining arguments are algorithms. */
     for (; *argv; argv++) {
         const char *algo = *argv;
 

--- a/apps/spkac.c
+++ b/apps/spkac.c
@@ -125,6 +125,8 @@ int spkac_main(int argc, char **argv)
             break;
         }
     }
+
+    /* No extra arguments. */
     argc = opt_num_rest();
     if (argc != 0)
         goto opthelp;

--- a/apps/srp.c
+++ b/apps/srp.c
@@ -301,6 +301,8 @@ int srp_main(int argc, char **argv)
             break;
         }
     }
+
+    /* Optional parameters are usernames. */
     argc = opt_num_rest();
     argv = opt_rest();
 

--- a/apps/storeutl.c
+++ b/apps/storeutl.c
@@ -256,17 +256,12 @@ int storeutl_main(int argc, char *argv[])
             break;
         }
     }
+
+    /* One argument, the URI */
     argc = opt_num_rest();
     argv = opt_rest();
-
-    if (argc == 0) {
-        BIO_printf(bio_err, "%s: No URI given, nothing to do...\n", prog);
+    if (argc != 1)
         goto opthelp;
-    }
-    if (argc > 1) {
-        BIO_printf(bio_err, "%s: Unknown extra parameters after URI\n", prog);
-        goto opthelp;
-    }
 
     if (criterion != 0) {
         switch (criterion) {

--- a/apps/ts.c
+++ b/apps/ts.c
@@ -286,7 +286,10 @@ int ts_main(int argc, char **argv)
             break;
         }
     }
-    if (mode == OPT_ERR || opt_num_rest() != 0)
+
+    /* No extra arguments. */
+    argc = opt_num_rest();
+    if (argc != 0 || mode == OPT_ERR)
         goto opthelp;
 
     if (mode == OPT_REPLY && passin &&

--- a/apps/verify.c
+++ b/apps/verify.c
@@ -193,8 +193,11 @@ int verify_main(int argc, char **argv)
             break;
         }
     }
+
+    /* Extra arguments are certificates to verify. */
     argc = opt_num_rest();
     argv = opt_rest();
+
     if (trusted != NULL
         && (CAfile != NULL || CApath != NULL || CAstore != NULL)) {
         BIO_printf(bio_err,

--- a/apps/version.c
+++ b/apps/version.c
@@ -97,10 +97,12 @@ opthelp:
             break;
         }
     }
-    if (opt_num_rest() != 0) {
-        BIO_printf(bio_err, "Extra parameters given.\n");
+
+    /* No extra arguments. */
+    argc = opt_num_rest();
+    if (argc != 0)
         goto opthelp;
-    }
+
     if (!dirty)
         version = 1;
 

--- a/apps/x509.c
+++ b/apps/x509.c
@@ -490,12 +490,11 @@ int x509_main(int argc, char **argv)
                 goto opthelp;
         }
     }
+
+    /* No extra arguments. */
     argc = opt_num_rest();
-    argv = opt_rest();
-    if (argc != 0) {
-        BIO_printf(bio_err, "%s: Unknown parameter %s\n", prog, argv[0]);
+    if (argc != 0)
         goto opthelp;
-    }
 
     if (!app_passwd(passinarg, NULL, &passin, NULL)) {
         BIO_printf(bio_err, "Error getting password\n");


### PR DESCRIPTION
Make sure all commands check to see if there are any "extra" arguments
after the options, and print an error if so.

Made all error messages consistent (which is to say, minimal).

Fixes: #13527
