### PR TITLE
Fix comment in do_dtls1_write()

### DIFF
--- a/ssl/record/rec_layer_d1.c
+++ b/ssl/record/rec_layer_d1.c
@@ -800,8 +800,8 @@ int do_dtls1_write(SSL *s, int type, const unsigned char *buf,
     wb = &s->rlayer.wbuf[0];
 
     /*
-     * first check if there is a SSL3_BUFFER still being written out.  This
-     * will happen with non blocking IO
+     * DTLS writes whole datagrams, so there can't be anything left in
+     * the buffer.
      */
     if (!ossl_assert(SSL3_BUFFER_get_left(wb) == 0)) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);


### PR DESCRIPTION
This code started off as a copy of ssl3_write_bytes(), and the comment
was not updated with the implementation.

Reported by yangyangtiantianlonglong in #13518

