### PR TITLE
Fix no-sock and no-dtls

### DIFF
--- a/include/openssl/bio.h.in
+++ b/include/openssl/bio.h.in
@@ -443,11 +443,10 @@ struct bio_dgram_sctp_prinfo {
 #  define BIO_BIND_REUSEADDR_IF_UNUSED    BIO_SOCK_REUSEADDR
 #  define BIO_set_bind_mode(b,mode) BIO_ctrl(b,BIO_C_SET_BIND_MODE,mode,NULL)
 #  define BIO_get_bind_mode(b)    BIO_ctrl(b,BIO_C_GET_BIND_MODE,0,NULL)
-
-/* BIO_s_accept() and BIO_s_connect() */
-#  define BIO_do_connect(b)       BIO_do_handshake(b)
-#  define BIO_do_accept(b)        BIO_do_handshake(b)
 # endif /* OPENSSL_NO_SOCK */
+
+# define BIO_do_connect(b)       BIO_do_handshake(b)
+# define BIO_do_accept(b)        BIO_do_handshake(b)
 
 # define BIO_do_handshake(b)     BIO_ctrl(b,BIO_C_DO_STATE_MACHINE,0,NULL)
 

--- a/test/ssl-tests/04-client_auth.cnf.in
+++ b/test/ssl-tests/04-client_auth.cnf.in
@@ -15,13 +15,14 @@ our $fips_mode;
 
 my @protocols;
 my @is_disabled = (0);
-push @is_disabled, anydisabled("ssl3", "tls1", "tls1_1", "tls1_2", "dtls1", "dtls1_2");
 
 # We test version-flexible negotiation (undef) and each protocol version.
 if ($fips_mode) {
     @protocols = (undef, "TLSv1.2", "DTLSv1.2");
+    push @is_disabled, anydisabled("tls1_2", "dtls1_2");
 } else {
     @protocols = (undef, "SSLv3", "TLSv1", "TLSv1.1", "TLSv1.2", "DTLSv1", "DTLSv1.2");
+    push @is_disabled, anydisabled("ssl3", "tls1", "tls1_1", "tls1_2", "dtls1", "dtls1_2");
 }
 
 our @tests = ();


### PR DESCRIPTION
BIO_do_connect() can work even in no-sock builds (non socket based BIOs
have the right ctrls). Therefore we move the macro outside of the
OPENSSL_NO_SOCK guards

no-sock implies no-dtls, which was also broken, so we fix that too.

Fixes #12207