### PR TITLE
apps/pkcs12.c: Improve user guidance, re-ordering no-export vs. export options

### DIFF
--- a/doc/man1/openssl-pkcs12.pod.in
+++ b/doc/man1/openssl-pkcs12.pod.in
@@ -9,26 +9,25 @@ openssl-pkcs12 - PKCS#12 file command
 
 B<openssl> B<pkcs12>
 [B<-help>]
-[B<-export>]
-[B<-chain>]
-[B<-untrusted> I<filename>]
-[B<-inkey> I<filename>|I<uri>]
-[B<-certfile> I<filename>]
-[B<-passcerts> I<arg>]
-[B<-name> I<name>]
-[B<-caname> I<name>]
+[B<-passin> I<arg>]
+[B<-passout> I<arg>]
+[B<-password> I<arg>]
+[B<-twopass>]
 [B<-in> I<filename>|I<uri>]
 [B<-out> I<filename>]
-[B<-noout>]
-[B<-nomacver>]
+[B<-nokeys>]
 [B<-nocerts>]
+[B<-noout>]
+[B<-legacy>]
+{- $OpenSSL::safe::opt_engine_synopsis -}{- $OpenSSL::safe::opt_provider_synopsis -}
+{- $OpenSSL::safe::opt_r_synopsis -}
+
+PKCS#12 input (parsing) options:
+[B<-info>]
+[B<-nomacver>]
 [B<-clcerts>]
 [B<-cacerts>]
-[B<-nokeys>]
-[B<-info>]
-[B<-des>]
-[B<-des3>]
-[B<-idea>]
+
 [B<-aes128>]
 [B<-aes192>]
 [B<-aes256>]
@@ -38,29 +37,36 @@ B<openssl> B<pkcs12>
 [B<-camellia128>]
 [B<-camellia192>]
 [B<-camellia256>]
+[B<-des>]
+[B<-des3>]
+[B<-idea>]
 [B<-noenc>]
 [B<-nodes>]
+
+PKCS#12 output (export) options:
+
+[B<-export>]
+[B<-inkey> I<filename>|I<uri>]
+[B<-certfile> I<filename>]
+[B<-passcerts> I<arg>]
+[B<-chain>]
+[B<-untrusted> I<filename>]
+{- $OpenSSL::safe::opt_trust_synopsis -}
+[B<-name> I<name>]
+[B<-caname> I<name>]
+[B<-CSP> I<name>]
+[B<-LMK>]
+[B<-keyex>]
+[B<-keysig>]
+[B<-keypbe> I<cipher>]
+[B<-certpbe> I<cipher>]
+[B<-descert>]
+[B<-macalg> I<digest>]
 [B<-iter> I<count>]
 [B<-noiter>]
 [B<-nomaciter>]
 [B<-maciter>]
 [B<-nomac>]
-[B<-twopass>]
-[B<-legacy>]
-[B<-descert>]
-[B<-certpbe> I<cipher>]
-[B<-keypbe> I<cipher>]
-[B<-macalg> I<digest>]
-[B<-keyex>]
-[B<-keysig>]
-[B<-password> I<arg>]
-[B<-passin> I<arg>]
-[B<-passout> I<arg>]
-[B<-LMK>]
-[B<-CSP> I<name>]
-{- $OpenSSL::safe::opt_trust_synopsis -}
-{- $OpenSSL::safe::opt_r_synopsis -}
-{- $OpenSSL::safe::opt_engine_synopsis -}{- $OpenSSL::safe::opt_provider_synopsis -}
 
 =for openssl ifdef engine
 
@@ -75,10 +81,11 @@ programs including Netscape, MSIE and MS Outlook.
 There are a lot of options the meaning of some depends of whether a PKCS#12 file
 is being created or parsed. By default a PKCS#12 file is parsed.
 A PKCS#12 file can be created by using the B<-export> option (see below).
-Many further options such as B<-chain> make sense only with B<-export>.
+The PKCS#12 export encryption and MAC options such as B<-certpbe> and B<-iter>
+and many further options such as B<-chain> are relevant only with B<-export>.
+Conversely, the options regarding encryption of private keys when outputting
+PKCS#12 input are relevant only when the B<-export> option is not given.
 The default encryption algorithm is AES-256-CBC with PBKDF2 for key derivation.
-
-=head1 PARSING OPTIONS
 
 =over 4
 
@@ -86,28 +93,84 @@ The default encryption algorithm is AES-256-CBC with PBKDF2 for key derivation.
 
 Print out a usage message.
 
-=item B<-in> I<filename>|I<uri>
+=item B<-passin> I<arg>
 
-This specifies the input filename or URI.
-Standard input is used by default.
-Without the B<-export> option this is a PKCS#12 file to be parsed.
-With the B<-export> option this is a file with certificates and possibly a key,
-or a URI that refers to a key accessed via an engine.
+The password source for input files.
+For more information about the format of B<arg>
+see L<openssl(1)/Pass Phrase Options>.
 
-=item B<-out> I<filename>
+=item B<-passout> I<arg>
 
-The filename to write certificates and private keys to, standard output by
-default.  They are all written in PEM format.
+The password source for output files.
 
 =item B<-password> I<arg>
 
 With B<-export>, B<-password> is equivalent to B<-passout>,
 otherwise it is equivalent to B<-passin>.
 
+=item B<-twopass>
+
+Prompt for separate integrity and encryption passwords: most software
+always assumes these are the same so this option will render such
+PKCS#12 files unreadable. Cannot be used in combination with the options
+B<-password>, B<-passin> if importing from PKCS#12, or B<-passout> if exporting.
+
+=item B<-nokeys>
+
+No private keys will be output.
+
+=item B<-nocerts>
+
+No certificates will be output.
+
 =item B<-noout>
 
-This option inhibits credentials output,
-and so the PKCS#12 input is just verified.
+This option inhibits all credentials output,
+and so the input is just verified.
+
+=item B<-legacy>
+
+Use legacy mode of operation and automatically load the legacy provider.
+In the legacy mode, the default algorithm for certificate encryption
+is RC2_CBC or 3DES_CBC depending on whether the RC2 cipher is enabled
+in the build. The default algorithm for private key encryption is 3DES_CBC.
+If the legacy option is not specified, then the legacy provider is not loaded
+and the default encryption algorithm for both certificates and private keys is
+AES_256_CBC with PBKDF2 for key derivation.
+
+{- $OpenSSL::safe::opt_engine_item -}
+
+{- $OpenSSL::safe::opt_provider_item -}
+
+{- $OpenSSL::safe::opt_r_item -}
+
+=back
+
+=head2 PKCS#12 input (parsing) options
+
+=over 4
+
+=item B<-in> I<filename>|I<uri>
+
+This specifies the input filename or URI.
+Standard input is used by default.
+Without the B<-export> option this must be PKCS#12 file to be parsed.
+For use with the B<-export> option
+see the L</PKCS#12 output (export) options> section.
+
+=item B<-out> I<filename>
+
+The filename to write certificates and private keys to, standard output by
+default.  They are all written in PEM format.
+
+=item B<-info>
+
+Output additional information about the PKCS#12 file structure, algorithms
+used and iteration counts.
+
+=item B<-nomacver>
+
+Don't attempt to verify the integrity MAC.
 
 =item B<-clcerts>
 
@@ -116,31 +179,6 @@ Only output client certificates (not CA certificates).
 =item B<-cacerts>
 
 Only output CA certificates (not client certificates).
-
-=item B<-nocerts>
-
-No certificates at all will be output.
-
-=item B<-nokeys>
-
-No private keys will be output.
-
-=item B<-info>
-
-Output additional information about the PKCS#12 file structure, algorithms
-used and iteration counts.
-
-=item B<-des>
-
-Use DES to encrypt private keys before outputting.
-
-=item B<-des3>
-
-Use triple DES to encrypt private keys before outputting.
-
-=item B<-idea>
-
-Use IDEA to encrypt private keys before outputting.
 
 =item B<-aes128>, B<-aes192>, B<-aes256>
 
@@ -154,38 +192,29 @@ Use ARIA to encrypt private keys before outputting.
 
 Use Camellia to encrypt private keys before outputting.
 
+=item B<-des>
+
+Use DES to encrypt private keys before outputting.
+
+=item B<-des3>
+
+Use triple DES to encrypt private keys before outputting.
+
+=item B<-idea>
+
+Use IDEA to encrypt private keys before outputting.
+
 =item B<-noenc>
 
-Don't encrypt the private keys at all.
+Don't encrypt private keys at all.
 
 =item B<-nodes>
 
 This option is deprecated since OpenSSL 3.0; use B<-noenc> instead.
 
-=item B<-nomacver>
-
-Don't attempt to verify the integrity MAC before reading the file.
-
-=item B<-twopass>
-
-Prompt for separate integrity and encryption passwords: most software
-always assumes these are the same so this option will render such
-PKCS#12 files unreadable. Cannot be used in combination with the options
-B<-password>, B<-passin> if importing, or B<-passout> if exporting.
-
-=item B<-legacy>
-
-Use legacy mode of operation and automatically load the legacy provider.
-In the legacy mode, the default algorithm for certificate encryption
-is RC2_CBC or 3DES_CBC depending on whether the RC2 cipher is enabled
-in the build. The default algorithm for private key encryption is 3DES_CBC.
-If the legacy option is not specified, then the legacy provider is not loaded
-and the default encryption algorithm for both certificates and private keys is
-AES_256_CBC with PBKDF2 for key derivation by default.
-
 =back
 
-=head1 FILE CREATION OPTIONS
+=head2 PKCS#12 output (export) options
 
 =over 4
 
@@ -199,38 +228,29 @@ parsed.
 This specifies filename to write the PKCS#12 file to. Standard output is used
 by default.
 
-=item B<-in> I<filename>
+=item B<-in> I<filename>|I<uri>
 
-The filename or URI to read certificates and private keys from, standard input
-by default. They can be in PEM, DER, or PKCS#12 format.
-The order doesn't matter but one private key and
+This specifies the input filename or URI.
+Standard input is used by default.
+With the B<-export> option this is a file with certificates and a key,
+or a URI that refers to a key accessed via an engine.
+The order of credentials in a file doesn't matter but one private key and
 its corresponding certificate should be present. If additional
-certificates are present they will also be included in the PKCS#12 file.
+certificates are present they will also be included in the PKCS#12 output file.
 
 =item B<-inkey> I<filename>|I<uri>
 
-The private key input for PKCS12 output. If this option is not specified then
-the input file (B<-in> argument) must contain a private key.
-If no engine is used, the argument is taken as a file;
-if the B<-engine> option is used or the URI has prefix C<org.openssl.engine:>
+The private key input for PKCS12 output.
+If this option is not specified then the input file (B<-in> argument) must
+contain a private key.
+If no engine is used, the argument is taken as a file.
+If the B<-engine> option is used or the URI has prefix C<org.openssl.engine:>
 then the rest of the URI is taken as key identifier for the given engine.
-
-=item B<-name> I<friendlyname>
-
-This specifies the "friendly name" for the certificate and private key. This
-name is typically displayed in list boxes by software importing the file.
 
 =item B<-certfile> I<filename>
 
-An input file with extra certificates to be added to the PKCS12 output
+An input file with extra certificates to be added to the PKCS#12 output
 if the B<-export> option is given.
-
-=item B<-untrusted> I<filename>
-
-An input file of untrusted certificates that may be used
-for chain building, which is relevant only when a PKCS#12 file is created
-with the B<-export> option and the B<-chain> option is given as well.
-Any certificates that are actually part of the chain are added to the output.
 
 =item B<-passcerts> I<arg>
 
@@ -238,20 +258,6 @@ The password source for certificate input such as B<-certfile>
 and B<-untrusted>.
 For more information about the format of B<arg>
 see the B<PASS PHRASE ARGUMENTS> section in L<openssl(1)>.
-
-=item B<-caname> I<friendlyname>
-
-This specifies the "friendly name" for other certificates. This option may be
-used multiple times to specify names for all certificates in the order they
-appear. Netscape ignores friendly names on other certificates whereas MSIE
-displays them.
-
-=item B<-passin> I<arg>, B<-passout> I<arg>
-
-The password source for the input, and for encrypting any private keys that
-are output.
-For more information about the format of B<arg>
-see L<openssl(1)/Pass Phrase Options>.
 
 =item B<-chain>
 
@@ -262,24 +268,34 @@ if no key is given, else the first certificate matching the given key.
 The standard CA trust store is used for chain building,
 as well as any untrusted CA certificates given with the B<-untrusted> option.
 
-=item B<-descert>
+=item B<-untrusted> I<filename>
 
-Encrypt the certificate using triple DES, this may render the PKCS#12
-file unreadable by some "export grade" software. By default the private
-key and the certificates are encrypted using AES-256-CBC unless
-the '-legacy' option is used. If '-descert' is used with the '-legacy'
-then both, the private key and the certificate are encrypted using triple DES.
+An input file of untrusted certificates that may be used
+for chain building, which is relevant only when a PKCS#12 file is created
+with the B<-export> option and the B<-chain> option is given as well.
+Any certificates that are actually part of the chain are added to the output.
 
-=item B<-keypbe> I<alg>, B<-certpbe> I<alg>
+{- $OpenSSL::safe::opt_trust_item -}
 
-These options allow the algorithm used to encrypt the private key and
-certificates to be selected. Any PKCS#5 v1.5 or PKCS#12 PBE algorithm name
-can be used (see L</NOTES> section for more information). If a cipher name
-(as output by C<openssl list -cipher-algorithms>) is specified then it
-is used with PKCS#5 v2.0. For interoperability reasons it is advisable to only
-use PKCS#12 algorithms.
+=item B<-name> I<friendlyname>
 
-Special value C<NONE> disables encryption of the private key and certificate.
+This specifies the "friendly name" for the certificates and private key. This
+name is typically displayed in list boxes by software importing the file.
+
+=item B<-caname> I<friendlyname>
+
+This specifies the "friendly name" for other certificates. This option may be
+used multiple times to specify names for all certificates in the order they
+appear. Netscape ignores friendly names on other certificates whereas MSIE
+displays them.
+
+=item B<-CSP> I<name>
+
+Write I<name> as a Microsoft CSP name.
+
+=item B<-LMK>
+
+Add the "Local Key Set" identifier to the attributes.
 
 =item B<-keyex>|B<-keysig>
 
@@ -291,6 +307,24 @@ option marks the key for signing only. Signing only keys can be used for
 S/MIME signing, authenticode (ActiveX control signing)  and SSL client
 authentication, however, due to a bug only MSIE 5.0 and later support
 the use of signing only keys for SSL client authentication.
+
+=item B<-keypbe> I<alg>, B<-certpbe> I<alg>
+
+These options allow the algorithm used to encrypt the private key and
+certificates to be selected. Any PKCS#5 v1.5 or PKCS#12 PBE algorithm name
+can be used (see L</NOTES> section for more information). If a cipher name
+(as output by C<openssl list -cipher-algorithms>) is specified then it
+is used with PKCS#5 v2.0. For interoperability reasons it is advisable to only
+use PKCS#12 algorithms.
+
+Special value C<NONE> disables encryption of the private key and certificates.
+
+=item B<-descert>
+
+Encrypt the certificates using triple DES. By default the private
+key and the certificates are encrypted using AES-256-CBC unless
+the '-legacy' option is used. If '-descert' is used with the '-legacy'
+then both, the private key and the certificates are encrypted using triple DES.
 
 =item B<-macalg> I<digest>
 
@@ -307,12 +341,12 @@ to it: this causes a certain part of the algorithm to be repeated and slows it
 down. The MAC is used to check the file integrity but since it will normally
 have the same password as the keys and certificates it could also be attacked.
 
-=item B<-nomaciter>, B<-noiter>
+=item B<-noiter>, B<-nomaciter>
 
-By default both MAC and encryption iteration counts are set to 2048, using
+By default both encryption and MAC iteration counts are set to 2048, using
 these options the MAC and encryption iteration counts can be set to 1, since
 this reduces the file security you should not use these options unless you
-really have to. Most software supports both MAC and key iteration counts.
+really have to. Most software supports both MAC and encryption iteration counts.
 MSIE 4.0 doesn't support MAC iteration counts so it needs the B<-nomaciter>
 option.
 
@@ -325,22 +359,6 @@ to be needed to use MAC iterations counts but they are now used by default.
 
 Don't attempt to provide the MAC integrity.
 
-=item B<-LMK>
-
-Add the "Local Key Set" identifier to the attributes.
-
-=item B<-CSP> I<name>
-
-Write I<name> as a Microsoft CSP name.
-
-{- $OpenSSL::safe::opt_trust_item -}
-
-{- $OpenSSL::safe::opt_r_item -}
-
-{- $OpenSSL::safe::opt_engine_item -}
-
-{- $OpenSSL::safe::opt_provider_item -}
-
 =back
 
 =head1 NOTES
@@ -352,10 +370,11 @@ for PKCS#12 file creation B<-export> and B<-name> are also used.
 If none of the B<-clcerts>, B<-cacerts> or B<-nocerts> options are present
 then all certificates will be output in the order they appear in the input
 PKCS#12 files. There is no guarantee that the first certificate present is
-the one corresponding to the private key. Certain software which requires
-a private key and certificate and assumes the first certificate in the
-file is the one corresponding to the private key: this may not always
-be the case. Using the B<-clcerts> option will solve this problem by only
+the one corresponding to the private key.
+Certain software which tries to get a private key and the corresponding
+certificate might assume that the first certificate in the file is the one
+corresponding to the private key, but that may not always be the case.
+Using the B<-clcerts> option will solve this problem by only
 outputting the certificate corresponding to the private key. If the CA
 certificates are required then they can be output to a separate file using
 the B<-nokeys> B<-cacerts> options to just output CA certificates.
@@ -379,7 +398,7 @@ command.
 
 =head1 EXAMPLES
 
-Parse a PKCS#12 file and output it to a file:
+Parse a PKCS#12 file and output it to a PEM file:
 
  openssl pkcs12 -in file.p12 -out file.pem
 
@@ -399,16 +418,17 @@ Print some info about a PKCS#12 file in legacy mode:
 
  openssl pkcs12 -in file.p12 -info -noout -legacy
 
-Create a PKCS#12 file:
+Create a PKCS#12 file from a PEM file that may contain a key and certificates:
 
- openssl pkcs12 -export -in file.pem -out file.p12 -name "My Certificate"
+ openssl pkcs12 -export -in file.pem -out file.p12 -name "My PSE"
 
 Include some extra certificates:
 
- openssl pkcs12 -export -in file.pem -out file.p12 -name "My Certificate" \
+ openssl pkcs12 -export -in file.pem -out file.p12 -name "My PSE" \
   -certfile othercerts.pem
 
-Export a PKCS#12 file with default algorithms as in the legacy provider:
+Export a PKCS#12 file with data from a certificate PEM file and from a further
+PEM file containing a key, with default algorithms as in the legacy provider:
 
  openssl pkcs12 -export -in cert.pem -inkey key.pem -out file.p12 -legacy
 


### PR DESCRIPTION
Make the option order consistent in the help output and in the POD file.
Give warnings when an option is ignored because` -export` is given or missing.

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated

