### PR TITLE
Appveyor: more quickly skip non-shared configurations without extended tests

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,6 +17,15 @@ configuration:
 
 before_build:
     - ps: >-
+        if (-not $env:APPVEYOR_PULL_REQUEST_NUMBER`
+            -or (&git log -1 $env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT |
+                 Select-String "\[extended tests\]") ) {
+            $env:EXTENDED_TESTS="yes"
+        } ElseIf (-not $env:Configuration -Match "shared") {
+            echo "Skipping non-shared build since [extended tests] is not set"
+            Exit-AppVeyorBuild
+        }
+    - ps: >-
         Install-Module VSSetup -Scope CurrentUser
     - ps: >-
         Get-VSSetupInstance -All
@@ -44,12 +53,6 @@ before_build:
     - perl ..\Configure %TARGET% %SHARED%
     - perl configdata.pm --dump
     - cd ..
-    - ps: >-
-        if (-not $env:APPVEYOR_PULL_REQUEST_NUMBER`
-            -or (&git log -1 $env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT |
-                 Select-String "\[extended tests\]") ) {
-            $env:EXTENDED_TESTS="yes"
-        }
 
 build_script:
     - cd _build
@@ -64,11 +67,9 @@ test_script:
     - cd _build
     - ps: >-
         If ($env:Configuration -Match "shared" -or $env:EXTENDED_TESTS) {
-            if ($env:EXTENDED_TESTS) {
                 cmd /c "nmake test HARNESS_VERBOSE_FAILURE=yes 2>&1"
-            } Else {
+        } Else {
                 cmd /c "nmake test HARNESS_VERBOSE_FAILURE=yes TESTS=-test_fuzz 2>&1"
-            }
         }
     - ps: >-
         if ($env:EXTENDED_TESTS) {

--- a/test/run_tests.pl
+++ b/test/run_tests.pl
@@ -47,6 +47,7 @@ my %tapargs =
     );
 
 $tapargs{jobs} = $jobs if $jobs > 1;
+print "Using HARNESS_JOBS=$jobs\n" if $jobs > 1;
 
 # Additional OpenSSL special TAP arguments.  Because we can't pass them via
 # TAP::Harness->new(), they will be accessed directly, see the
@@ -57,7 +58,7 @@ $openssl_args{'failure_verbosity'} = $ENV{HARNESS_VERBOSE} ? 0 :
     $ENV{HARNESS_VERBOSE_FAILURE_PROGRESS} ? 2 :
     1; # $ENV{HARNESS_VERBOSE_FAILURE}
 print "Warning: HARNESS_JOBS > 1 overrides HARNESS_VERBOSE\n"
-    if $jobs > 1;
+    if $jobs > 1 && $ENV{HARNESS_VERBOSE};
 print "Warning: HARNESS_VERBOSE overrides HARNESS_VERBOSE_FAILURE*\n"
     if ($ENV{HARNESS_VERBOSE} && ($ENV{HARNESS_VERBOSE_FAILURE}
                                   || $ENV{HARNESS_VERBOSE_FAILURE_PROGRESS}));
@@ -76,7 +77,7 @@ sub reorder {
     my $key = pop;
 
     # for parallel test runs, do slow tests first
-    if (defined $jobs && $jobs > 1 && $key =~ m/test_ssl_new|test_fuzz/) {
+    if ($jobs > 1 && $key =~ m/test_ssl_new|test_fuzz/) {
         $key =~ s/(\d+)-/00-/;
     }
     return $key;


### PR DESCRIPTION
This aims at short-cutting around one minute of needless build time per skipped AppVeyor job, mentioned in https://github.com/openssl/openssl/pull/13580#issuecomment-737027143.

This PR also includes a tweak to `run_tests.pl`: Improve diagnostics on the use of `HARNESS_JOBS`


