### PR TITLE
Fix no-err

### DIFF
--- a/crypto/err/err_all_legacy.c
+++ b/crypto/err/err_all_legacy.c
@@ -12,95 +12,95 @@
 
 #ifndef OPENSSL_NO_DEPRECATED_3_0
 
-#include "crypto/err.h"
-#include "crypto/asn1err.h"
-#include "crypto/asyncerr.h"
-#include "crypto/bnerr.h"
-#include "crypto/buffererr.h"
-#include "crypto/bioerr.h"
-#include "crypto/cmserr.h"
-#include "crypto/comperr.h"
-#include "crypto/conferr.h"
-#include "crypto/cryptoerr.h"
-#include "crypto/cterr.h"
-#include "crypto/dherr.h"
-#include "crypto/dsaerr.h"
-#include "internal/dsoerr.h"
-#include "crypto/ecerr.h"
-#include "crypto/engineerr.h"
-#include "crypto/evperr.h"
-#include "crypto/httperr.h"
-#include "crypto/objectserr.h"
-#include "crypto/ocsperr.h"
-#include "crypto/pemerr.h"
-#include "crypto/pkcs12err.h"
-#include "crypto/pkcs7err.h"
-#include "crypto/randerr.h"
-#include "crypto/rsaerr.h"
-#include "crypto/storeerr.h"
-#include "crypto/tserr.h"
-#include "crypto/uierr.h"
-#include "crypto/x509err.h"
-#include "crypto/x509v3err.h"
+# include "crypto/err.h"
+# include "crypto/asn1err.h"
+# include "crypto/asyncerr.h"
+# include "crypto/bnerr.h"
+# include "crypto/buffererr.h"
+# include "crypto/bioerr.h"
+# include "crypto/cmserr.h"
+# include "crypto/comperr.h"
+# include "crypto/conferr.h"
+# include "crypto/cryptoerr.h"
+# include "crypto/cterr.h"
+# include "crypto/dherr.h"
+# include "crypto/dsaerr.h"
+# include "internal/dsoerr.h"
+# include "crypto/ecerr.h"
+# include "crypto/engineerr.h"
+# include "crypto/evperr.h"
+# include "crypto/httperr.h"
+# include "crypto/objectserr.h"
+# include "crypto/ocsperr.h"
+# include "crypto/pemerr.h"
+# include "crypto/pkcs12err.h"
+# include "crypto/pkcs7err.h"
+# include "crypto/randerr.h"
+# include "crypto/rsaerr.h"
+# include "crypto/storeerr.h"
+# include "crypto/tserr.h"
+# include "crypto/uierr.h"
+# include "crypto/x509err.h"
+# include "crypto/x509v3err.h"
 
-#ifdef OPENSSL_NO_ERR
-# define IMPLEMENT_LEGACY_ERR_LOAD(lib)         \
+# ifdef OPENSSL_NO_ERR
+#  define IMPLEMENT_LEGACY_ERR_LOAD(lib)         \
     int ERR_load_##lib##_strings(void)          \
     {                                           \
         return 1;                               \
     }
-#else
-# define IMPLEMENT_LEGACY_ERR_LOAD(lib)         \
+# else
+#  define IMPLEMENT_LEGACY_ERR_LOAD(lib)         \
     int ERR_load_##lib##_strings(void)          \
     {                                           \
         return err_load_##lib##_strings_int();  \
     }
-#endif
+# endif
 
 IMPLEMENT_LEGACY_ERR_LOAD(ASN1)
 IMPLEMENT_LEGACY_ERR_LOAD(ASYNC)
 IMPLEMENT_LEGACY_ERR_LOAD(BIO)
 IMPLEMENT_LEGACY_ERR_LOAD(BN)
 IMPLEMENT_LEGACY_ERR_LOAD(BUF)
-#  ifndef OPENSSL_NO_CMS
+# ifndef OPENSSL_NO_CMS
 IMPLEMENT_LEGACY_ERR_LOAD(CMS)
-#  endif
-#  ifndef OPENSSL_NO_COMP
+# endif
+# ifndef OPENSSL_NO_COMP
 IMPLEMENT_LEGACY_ERR_LOAD(COMP)
-#  endif
+# endif
 IMPLEMENT_LEGACY_ERR_LOAD(CONF)
 IMPLEMENT_LEGACY_ERR_LOAD(CRYPTO)
-#  ifndef OPENSSL_NO_CT
+# ifndef OPENSSL_NO_CT
 IMPLEMENT_LEGACY_ERR_LOAD(CT)
-#  endif
-#  ifndef OPENSSL_NO_DH
+# endif
+# ifndef OPENSSL_NO_DH
 IMPLEMENT_LEGACY_ERR_LOAD(DH)
-#  endif
-#  ifndef OPENSSL_NO_DSA
+# endif
+# ifndef OPENSSL_NO_DSA
 IMPLEMENT_LEGACY_ERR_LOAD(DSA)
-#  endif
-#  ifndef OPENSSL_NO_EC
+# endif
+# ifndef OPENSSL_NO_EC
 IMPLEMENT_LEGACY_ERR_LOAD(EC)
-#  endif
-#  ifndef OPENSSL_NO_ENGINE
+# endif
+# ifndef OPENSSL_NO_ENGINE
 IMPLEMENT_LEGACY_ERR_LOAD(ENGINE)
-#  endif
+# endif
 IMPLEMENT_LEGACY_ERR_LOAD(ERR)
 IMPLEMENT_LEGACY_ERR_LOAD(EVP)
 IMPLEMENT_LEGACY_ERR_LOAD(OBJ)
-#  ifndef OPENSSL_NO_OCSP
+# ifndef OPENSSL_NO_OCSP
 IMPLEMENT_LEGACY_ERR_LOAD(OCSP)
-#  endif
+# endif
 IMPLEMENT_LEGACY_ERR_LOAD(PEM)
 IMPLEMENT_LEGACY_ERR_LOAD(PKCS12)
 IMPLEMENT_LEGACY_ERR_LOAD(PKCS7)
 IMPLEMENT_LEGACY_ERR_LOAD(RAND)
 IMPLEMENT_LEGACY_ERR_LOAD(RSA)
 IMPLEMENT_LEGACY_ERR_LOAD(OSSL_STORE)
-#  ifndef OPENSSL_NO_TS
+# ifndef OPENSSL_NO_TS
 IMPLEMENT_LEGACY_ERR_LOAD(TS)
-#  endif
+# endif
 IMPLEMENT_LEGACY_ERR_LOAD(UI)
 IMPLEMENT_LEGACY_ERR_LOAD(X509)
 IMPLEMENT_LEGACY_ERR_LOAD(X509V3)
-# endif
+#endif /* OPENSSL_NO_DEPRECATED_3_0 */

--- a/crypto/err/err_all_legacy.c
+++ b/crypto/err/err_all_legacy.c
@@ -43,13 +43,20 @@
 #include "crypto/x509err.h"
 #include "crypto/x509v3err.h"
 
+#ifdef OPENSSL_NO_ERR
+# define IMPLEMENT_LEGACY_ERR_LOAD(lib)         \
+    int ERR_load_##lib##_strings(void)          \
+    {                                           \
+        return 1;                               \
+    }
+#else
 # define IMPLEMENT_LEGACY_ERR_LOAD(lib)         \
     int ERR_load_##lib##_strings(void)          \
     {                                           \
         return err_load_##lib##_strings_int();  \
     }
+#endif
 
-# ifndef OPENSSL_NO_ERR
 IMPLEMENT_LEGACY_ERR_LOAD(ASN1)
 IMPLEMENT_LEGACY_ERR_LOAD(ASYNC)
 IMPLEMENT_LEGACY_ERR_LOAD(BIO)
@@ -97,5 +104,3 @@ IMPLEMENT_LEGACY_ERR_LOAD(UI)
 IMPLEMENT_LEGACY_ERR_LOAD(X509)
 IMPLEMENT_LEGACY_ERR_LOAD(X509V3)
 # endif
-
-#endif


### PR DESCRIPTION
The ERR_load_*_strings() functions were not being defined in a no-err
build. This is an API break since in 1.1.1 they were still present in a
no-err build, but were no-ops. This was also causing a failure in
test_symbol_presence. We revert to the way things were done in 1.1.1,
i.e. in a no-err build the functions are still present but are no-ops.
