### PR TITLE
Don't use no-asm in the Github CIs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: config
-      run: ./config --debug no-asm enable-asan enable-ubsan enable-rc5 enable-md2 enable-ec_nistp_64_gcc_128 && perl configdata.pm --dump
+      run: ./config --debug enable-asan enable-ubsan enable-rc5 enable-md2 enable-ec_nistp_64_gcc_128 && perl configdata.pm --dump
     - name: make
       run: make -s -j4
     - name: make test
@@ -69,12 +69,12 @@ jobs:
     - name: make test
       run: make test HARNESS_JOBS=${HARNESS_JOBS:-4}
 
-  legacy_and_no-asm:
+  legacy:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - name: config
-      run: ./config no-asm -Werror --debug no-afalgeng no-shared enable-crypto-mdebug enable-rc5 enable-md2 && perl configdata.pm --dump
+      run: ./config -Werror --debug no-afalgeng no-shared enable-crypto-mdebug enable-rc5 enable-md2 && perl configdata.pm --dump
     - name: make
       run: make -s -j4
     - name: make test
@@ -85,7 +85,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: config
-      run: ./config no-asm no-makedepend enable-buildtest-c++ --strict-warnings -D_DEFAULT_SOURCE && perl configdata.pm --dump
+      run: ./config no-makedepend enable-buildtest-c++ --strict-warnings -D_DEFAULT_SOURCE && perl configdata.pm --dump
     - name: make
       run: make -s -j4
     - name: make test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: config
-      run: ./config no-makedepend enable-buildtest-c++ --strict-warnings -D_DEFAULT_SOURCE && perl configdata.pm --dump
+      run: ./config no-asm no-makedepend enable-buildtest-c++ --strict-warnings -D_DEFAULT_SOURCE && perl configdata.pm --dump
     - name: make
       run: make -s -j4
     - name: make test


### PR DESCRIPTION
no-asm has proven to be too slow, therefore we don't use it in the Github
CI builds and instead rely on it being covered by run-checker.

I've left no-asm in the "minimal" build only to avoid a conflict with #13110 which is refactoring that build line and also removes no-asm
