### PR TITLE
Remove TODO on OCSP_REQ_CTX_i2d deprecation

### DIFF
--- a/crypto/ocsp/ocsp_http.c
+++ b/crypto/ocsp/ocsp_http.c
@@ -13,6 +13,7 @@
 
 #ifndef OPENSSL_NO_OCSP
 
+/* Could deprecate this, once OCSP_REQ_CTX_i2d is documented. */
 int OCSP_REQ_CTX_set1_req(OCSP_REQ_CTX *rctx, const OCSP_REQUEST *req)
 {
     return OCSP_REQ_CTX_i2d(rctx, "application/ocsp-request",

--- a/include/openssl/ocsp.h.in
+++ b/include/openssl/ocsp.h.in
@@ -198,7 +198,6 @@ OCSP_REQ_CTX *OCSP_sendreq_new(BIO *io, const char *path, OCSP_REQUEST *req,
                                int maxline);
 int OCSP_sendreq_nbio(OCSP_RESPONSE **presp, OCSP_REQ_CTX *rctx);
 
-/* TODO: remove this (documented but) meanwhile obsolete function? */
 int OCSP_REQ_CTX_set1_req(OCSP_REQ_CTX *rctx, const OCSP_REQUEST *req);
 
 OCSP_CERTID *OCSP_cert_to_id(const EVP_MD *dgst, const X509 *subject,


### PR DESCRIPTION
Alternate way to address #12980; just remove the TODO comment from the header file.
See comment thread in #13620 for more background.
