### PR TITLE
v3nametest: Make the gennames array static

### DIFF
--- a/test/v3nametest.c
+++ b/test/v3nametest.c
@@ -359,7 +359,7 @@ static int call_run_cert(int i)
     return failed == 0;
 }
 
-struct gennamedata {
+static struct gennamedata {
     const unsigned char der[22];
     size_t derlen;
 } gennames[] = {


### PR DESCRIPTION
As this breaks one of the CI builds it is kind of urgent.
