### PR TITLE
CRYPTO_secure_malloc_init: BSD support improvements.

### DIFF
--- a/crypto/mem_sec.c
+++ b/crypto/mem_sec.c
@@ -34,6 +34,12 @@
 #   include <errno.h>
 #  endif
 # endif
+# if defined(__FreeBSD__)
+#  define MADV_DONTDUMP MADV_NOCORE
+# endif
+# if !defined(MAP_CONCEAL)
+#  define MAP_CONCEAL 0
+# endif
 # include <sys/param.h>
 # include <sys/stat.h>
 # include <fcntl.h>
@@ -442,7 +448,7 @@ static int sh_init(size_t size, int minsize)
     if (1) {
 #ifdef MAP_ANON
         sh.map_result = mmap(NULL, sh.map_size,
-                             PROT_READ|PROT_WRITE, MAP_ANON|MAP_PRIVATE, -1, 0);
+                             PROT_READ|PROT_WRITE, MAP_ANON|MAP_PRIVATE|MAP_CONCEAL, -1, 0);
     } else {
 #endif
         int fd;


### PR DESCRIPTION
Backport of #13394