### PR TITLE
x448: Add 64-bit implementation for ppc64(le)

### DIFF
--- a/crypto/ec/build.info
+++ b/crypto/ec/build.info
@@ -6,9 +6,15 @@ SOURCE[../../libcrypto]=\
         ecp_nistp224.c ecp_nistp256.c ecp_nistp521.c ecp_nistputil.c \
         ecp_oct.c ec2_oct.c ec_oct.c ec_kmeth.c ecdh_ossl.c ecdh_kdf.c \
         ecdsa_ossl.c ecdsa_sign.c ecdsa_vrf.c curve25519.c ecx_meth.c \
-        curve448/arch_32/f_impl.c curve448/f_generic.c curve448/scalar.c \
+        curve448/f_generic.c curve448/scalar.c \
         curve448/curve448_tables.c curve448/eddsa.c curve448/curve448.c \
         {- $target{ec_asm_src} -}
+
+IF[{- $config{target} =~ /ppc64/ -}]
+ SOURCE[../../libcrypto]=curve448/arch_64/f_impl.c
+ELSE
+ SOURCE[../../libcrypto]=curve448/arch_32/f_impl.c
+ENDIF
 
 GENERATE[ecp_nistz256-x86.s]=asm/ecp_nistz256-x86.pl \
         $(PERLASM_SCHEME) $(LIB_CFLAGS) $(LIB_CPPFLAGS) $(PROCESSOR)
@@ -34,9 +40,18 @@ BEGINRAW[Makefile]
 	CC="$(CC)" $(PERL) $< $(PERLASM_SCHEME) $@
 ENDRAW[Makefile]
 
-INCLUDE[curve448/arch_32/f_impl.o]=curve448/arch_32 curve448
-INCLUDE[curve448/f_generic.o]=curve448/arch_32 curve448
-INCLUDE[curve448/scalar.o]=curve448/arch_32 curve448
-INCLUDE[curve448/curve448_tables.o]=curve448/arch_32 curve448
-INCLUDE[curve448/eddsa.o]=curve448/arch_32 curve448
-INCLUDE[curve448/curve448.o]=curve448/arch_32 curve448
+IF[{- $config{target} =~ /ppc64/ -}]
+ INCLUDE[curve448/arch_64/f_impl.o]=curve448/arch_64 curve448
+ INCLUDE[curve448/f_generic.o]=curve448/arch_64 curve448
+ INCLUDE[curve448/scalar.o]=curve448/arch_64 curve448
+ INCLUDE[curve448/curve448_tables.o]=curve448/arch_64 curve448
+ INCLUDE[curve448/eddsa.o]=curve448/arch_64 curve448
+ INCLUDE[curve448/curve448.o]=curve448/arch_64 curve448
+ELSE
+ INCLUDE[curve448/arch_32/f_impl.o]=curve448/arch_32 curve448
+ INCLUDE[curve448/f_generic.o]=curve448/arch_32 curve448
+ INCLUDE[curve448/scalar.o]=curve448/arch_32 curve448
+ INCLUDE[curve448/curve448_tables.o]=curve448/arch_32 curve448
+ INCLUDE[curve448/eddsa.o]=curve448/arch_32 curve448
+ INCLUDE[curve448/curve448.o]=curve448/arch_32 curve448
+ENDIF

--- a/crypto/ec/curve448/arch_64/arch_intrinsics.h
+++ b/crypto/ec/curve448/arch_64/arch_intrinsics.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2016 Cryptography Research, Inc.
+ *
+ * Licensed under the OpenSSL license (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ *
+ * Originally written by Mike Hamburg
+ */
+
+#ifndef OSSL_CRYPTO_EC_CURVE448_ARCH_64_INTRINSICS_H
+# define OSSL_CRYPTO_EC_CURVE448_ARCH_64_INTRINSICS_H
+
+#include "internal/constant_time.h"
+
+# define ARCH_WORD_BITS 64
+
+#define word_is_zero(a)     constant_time_msb_64(~(a) & ((a)-1))
+
+static ossl_inline __uint128_t widemul(uint64_t a, uint64_t b)
+{
+    return ((__uint128_t)a) * b;
+}
+
+#endif                          /* OSSL_CRYPTO_EC_CURVE448_ARCH_64_INTRINSICS_H */

--- a/crypto/ec/curve448/arch_64/f_impl.c
+++ b/crypto/ec/curve448/arch_64/f_impl.c
@@ -1,0 +1,280 @@
+/*
+ * Copyright 2020 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2014 Cryptography Research, Inc.
+ *
+ * Licensed under the OpenSSL license (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ *
+ * Originally written by Mike Hamburg
+ */
+
+#include "field.h"
+
+void gf_mul (gf_s *__restrict__ cs, const gf as, const gf bs)
+{
+    const uint64_t *a = as->limb, *b = bs->limb;
+    uint64_t *c = cs->limb;
+
+    __uint128_t accum0 = 0, accum1 = 0, accum2;
+    uint64_t mask = (1ull<<56) - 1;
+
+    uint64_t aa[4], bb[4], bbb[4];
+
+    unsigned int i;
+    for (i=0; i<4; i++) {
+        aa[i]  = a[i] + a[i+4];
+        bb[i]  = b[i] + b[i+4];
+        bbb[i] = bb[i] + b[i+4];
+    }
+
+    accum2  = widemul(a[0],  b[0]);
+    accum1 += widemul(aa[0], bb[0]);
+    accum0 += widemul(a[4],  b[4]);
+
+    accum2 += widemul(a[1],  b[7]);
+    accum1 += widemul(aa[1], bbb[3]);
+    accum0 += widemul(a[5],  bb[3]);
+
+    accum2 += widemul(a[2],  b[6]);
+    accum1 += widemul(aa[2], bbb[2]);
+    accum0 += widemul(a[6],  bb[2]);
+
+    accum2 += widemul(a[3],  b[5]);
+    accum1 += widemul(aa[3], bbb[1]);
+    accum0 += widemul(a[7],  bb[1]);
+
+    accum1 -= accum2;
+    accum0 += accum2;
+
+    c[0] = ((uint64_t)(accum0)) & mask;
+    c[4] = ((uint64_t)(accum1)) & mask;
+
+    accum0 >>= 56;
+    accum1 >>= 56;
+
+    accum2  = widemul(a[0],  b[1]);
+    accum1 += widemul(aa[0], bb[1]);
+    accum0 += widemul(a[4],  b[5]);
+
+    accum2 += widemul(a[1],  b[0]);
+    accum1 += widemul(aa[1], bb[0]);
+    accum0 += widemul(a[5],  b[4]);
+
+    accum2 += widemul(a[2],  b[7]);
+    accum1 += widemul(aa[2], bbb[3]);
+    accum0 += widemul(a[6],  bb[3]);
+
+    accum2 += widemul(a[3],  b[6]);
+    accum1 += widemul(aa[3], bbb[2]);
+    accum0 += widemul(a[7],  bb[2]);
+
+    accum1 -= accum2;
+    accum0 += accum2;
+
+    c[1] = ((uint64_t)(accum0)) & mask;
+    c[5] = ((uint64_t)(accum1)) & mask;
+
+    accum0 >>= 56;
+    accum1 >>= 56;
+
+    accum2  = widemul(a[0],  b[2]);
+    accum1 += widemul(aa[0], bb[2]);
+    accum0 += widemul(a[4],  b[6]);
+
+    accum2 += widemul(a[1],  b[1]);
+    accum1 += widemul(aa[1], bb[1]);
+    accum0 += widemul(a[5],  b[5]);
+
+    accum2 += widemul(a[2],  b[0]);
+    accum1 += widemul(aa[2], bb[0]);
+    accum0 += widemul(a[6],  b[4]);
+
+    accum2 += widemul(a[3],  b[7]);
+    accum1 += widemul(aa[3], bbb[3]);
+    accum0 += widemul(a[7],  bb[3]);
+
+    accum1 -= accum2;
+    accum0 += accum2;
+
+    c[2] = ((uint64_t)(accum0)) & mask;
+    c[6] = ((uint64_t)(accum1)) & mask;
+
+    accum0 >>= 56;
+    accum1 >>= 56;
+
+    accum2  = widemul(a[0],  b[3]);
+    accum1 += widemul(aa[0], bb[3]);
+    accum0 += widemul(a[4],  b[7]);
+
+    accum2 += widemul(a[1],  b[2]);
+    accum1 += widemul(aa[1], bb[2]);
+    accum0 += widemul(a[5],  b[6]);
+
+    accum2 += widemul(a[2],  b[1]);
+    accum1 += widemul(aa[2], bb[1]);
+    accum0 += widemul(a[6],  b[5]);
+
+    accum2 += widemul(a[3],  b[0]);
+    accum1 += widemul(aa[3], bb[0]);
+    accum0 += widemul(a[7],  b[4]);
+
+    accum1 -= accum2;
+    accum0 += accum2;
+
+    c[3] = ((uint64_t)(accum0)) & mask;
+    c[7] = ((uint64_t)(accum1)) & mask;
+
+    accum0 >>= 56;
+    accum1 >>= 56;
+
+    accum0 += accum1;
+    accum0 += c[4];
+    accum1 += c[0];
+    c[4] = ((uint64_t)(accum0)) & mask;
+    c[0] = ((uint64_t)(accum1)) & mask;
+
+    accum0 >>= 56;
+    accum1 >>= 56;
+
+    c[5] += ((uint64_t)(accum0));
+    c[1] += ((uint64_t)(accum1));
+}
+
+void gf_mulw_unsigned (gf_s *__restrict__ cs, const gf as, uint32_t b)
+{
+    const uint64_t *a = as->limb;
+    uint64_t *c = cs->limb;
+
+    __uint128_t accum0 = 0, accum4 = 0;
+    uint64_t mask = (1ull<<56) - 1;
+
+    int i;
+    for (i=0; i<4; i++) {
+        accum0 += widemul(b, a[i]);
+        accum4 += widemul(b, a[i+4]);
+        c[i]   = accum0 & mask; accum0 >>= 56;
+        c[i+4] = accum4 & mask; accum4 >>= 56;
+    }
+
+    accum0 += accum4 + c[4];
+    c[4] = accum0 & mask;
+    c[5] += accum0 >> 56;
+
+    accum4 += c[0];
+    c[0] = accum4 & mask;
+    c[1] += accum4 >> 56;
+}
+
+void gf_sqr (gf_s *__restrict__ cs, const gf as)
+{
+    const uint64_t *a = as->limb;
+    uint64_t *c = cs->limb;
+
+    __uint128_t accum0 = 0, accum1 = 0, accum2;
+    uint64_t mask = (1ull<<56) - 1;
+
+    uint64_t aa[4];
+
+    /* For some reason clang doesn't vectorize this without prompting? */
+    unsigned int i;
+    for (i=0; i<4; i++) {
+        aa[i] = a[i] + a[i+4];
+    }
+
+    accum2  = widemul(a[0],a[3]);
+    accum0  = widemul(aa[0],aa[3]);
+    accum1  = widemul(a[4],a[7]);
+
+    accum2 += widemul(a[1], a[2]);
+    accum0 += widemul(aa[1], aa[2]);
+    accum1 += widemul(a[5], a[6]);
+
+    accum0 -= accum2;
+    accum1 += accum2;
+
+    c[3] = ((uint64_t)(accum1))<<1 & mask;
+    c[7] = ((uint64_t)(accum0))<<1 & mask;
+
+    accum0 >>= 55;
+    accum1 >>= 55;
+
+    accum0 += widemul(2*aa[1],aa[3]);
+    accum1 += widemul(2*a[5], a[7]);
+    accum0 += widemul(aa[2], aa[2]);
+    accum1 += accum0;
+
+    accum0 -= widemul(2*a[1], a[3]);
+    accum1 += widemul(a[6], a[6]);
+
+    accum2 = widemul(a[0],a[0]);
+    accum1 -= accum2;
+    accum0 += accum2;
+
+    accum0 -= widemul(a[2], a[2]);
+    accum1 += widemul(aa[0], aa[0]);
+    accum0 += widemul(a[4], a[4]);
+
+    c[0] = ((uint64_t)(accum0)) & mask;
+    c[4] = ((uint64_t)(accum1)) & mask;
+
+    accum0 >>= 56;
+    accum1 >>= 56;
+
+    accum2  = widemul(2*aa[2],aa[3]);
+    accum0 -= widemul(2*a[2], a[3]);
+    accum1 += widemul(2*a[6], a[7]);
+
+    accum1 += accum2;
+    accum0 += accum2;
+
+    accum2  = widemul(2*a[0],a[1]);
+    accum1 += widemul(2*aa[0], aa[1]);
+    accum0 += widemul(2*a[4], a[5]);
+
+    accum1 -= accum2;
+    accum0 += accum2;
+
+    c[1] = ((uint64_t)(accum0)) & mask;
+    c[5] = ((uint64_t)(accum1)) & mask;
+
+    accum0 >>= 56;
+    accum1 >>= 56;
+
+    accum2  = widemul(aa[3],aa[3]);
+    accum0 -= widemul(a[3], a[3]);
+    accum1 += widemul(a[7], a[7]);
+
+    accum1 += accum2;
+    accum0 += accum2;
+
+    accum2  = widemul(2*a[0],a[2]);
+    accum1 += widemul(2*aa[0], aa[2]);
+    accum0 += widemul(2*a[4], a[6]);
+
+    accum2 += widemul(a[1], a[1]);
+    accum1 += widemul(aa[1], aa[1]);
+    accum0 += widemul(a[5], a[5]);
+
+    accum1 -= accum2;
+    accum0 += accum2;
+
+    c[2] = ((uint64_t)(accum0)) & mask;
+    c[6] = ((uint64_t)(accum1)) & mask;
+
+    accum0 >>= 56;
+    accum1 >>= 56;
+
+    accum0 += c[3];
+    accum1 += c[7];
+    c[3] = ((uint64_t)(accum0)) & mask;
+    c[7] = ((uint64_t)(accum1)) & mask;
+
+    /* we could almost stop here, but it wouldn't be stable, so... */
+
+    accum0 >>= 56;
+    accum1 >>= 56;
+    c[4] += ((uint64_t)(accum0)) + ((uint64_t)(accum1));
+    c[0] += ((uint64_t)(accum1));
+}

--- a/crypto/ec/curve448/arch_64/f_impl.h
+++ b/crypto/ec/curve448/arch_64/f_impl.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2020 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2014 Cryptography Research, Inc.
+ *
+ * Licensed under the OpenSSL license (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ *
+ * Originally written by Mike Hamburg
+ */
+
+#ifndef OSSL_CRYPTO_EC_CURVE448_ARCH_64_F_IMPL_H
+# define OSSL_CRYPTO_EC_CURVE448_ARCH_64_F_IMPL_H
+
+#define GF_HEADROOM 9999 /* Everything is reduced anyway */
+#define FIELD_LITERAL(a,b,c,d,e,f,g,h) {{a,b,c,d,e,f,g,h}}
+
+#define LIMB_PLACE_VALUE(i) 56
+
+void gf_add_RAW (gf out, const gf a, const gf b)
+{
+    unsigned int i;
+
+    for (i = 0; i < NLIMBS; i++)
+        out->limb[i] = a->limb[i] + b->limb[i];
+
+    gf_weak_reduce(out);
+}
+
+void gf_sub_RAW (gf out, const gf a, const gf b)
+{
+    uint64_t co1 = ((1ull << 56) - 1) * 2, co2 = co1 - 2;
+    unsigned int i;
+
+    for (i = 0; i < NLIMBS; i++)
+        out->limb[i] = a->limb[i] - b->limb[i] + ((i == 4) ? co2 : co1);
+
+    gf_weak_reduce(out);
+}
+
+void gf_bias (gf a, int amt)
+{
+}
+
+void gf_weak_reduce (gf a)
+{
+    uint64_t mask = (1ull << 56) - 1;
+    uint64_t tmp = a->limb[NLIMBS - 1] >> 56;
+    unsigned int i;
+
+    a->limb[4] += tmp;
+    for (i = NLIMBS - 1; i > 0; i--)
+        a->limb[i] = (a->limb[i] & mask) + (a->limb[i-1] >> 56);
+
+    a->limb[0] = (a->limb[0] & mask) + tmp;
+}
+
+#endif                  /* OSSL_CRYPTO_EC_CURVE448_ARCH_64_F_IMPL_H */

--- a/crypto/ec/curve448/field.h
+++ b/crypto/ec/curve448/field.h
@@ -69,7 +69,11 @@ mask_t gf_deserialize(gf x, const uint8_t serial[SER_BYTES], int with_hibit,
 # include "f_impl.h"            /* Bring in the inline implementations */
 
 # define LIMBPERM(i) (i)
-# define LIMB_MASK(i) (((1)<<LIMB_PLACE_VALUE(i))-1)
+# if (ARCH_WORD_BITS == 32)
+#  define LIMB_MASK(i) (((1)<<LIMB_PLACE_VALUE(i))-1)
+# elif (ARCH_WORD_BITS == 64)
+#  define LIMB_MASK(i) (((1ull)<<LIMB_PLACE_VALUE(i))-1)
+# endif
 
 static const gf ZERO = {{{0}}}, ONE = {{{1}}};
 


### PR DESCRIPTION
The 64-bit implementation is taken from Ed448-Goldilocks repository
git://git.code.sf.net/p/ed448goldilocks/code.

  src/p448/arch_ref64/f_impl.[ch]

On POWER9 "openssl speed ecdhx448" performance improves from 1621 op/s
to 5611 op/s.

Signed-off-by: Amitay Isaacs <amitay@ozlabs.org>
