### PR TITLE
PROV: Add MSBLOB and PVK encoders 

### DIFF
--- a/apps/rsa.c
+++ b/apps/rsa.c
@@ -308,9 +308,9 @@ int rsa_main(int argc, char **argv)
     if (outformat == FORMAT_ASN1 || outformat == FORMAT_PEM) {
         if (pubout || pubin) {
             if (pubout == 2)
-                output_structure = "SubjectPublicKeyInfo";
-            else
                 output_structure = "pkcs1"; /* "type-specific" would work too */
+            else
+                output_structure = "SubjectPublicKeyInfo";
         } else {
             assert(private);
             if (traditional)

--- a/include/openssl/core_names.h
+++ b/include/openssl/core_names.h
@@ -464,6 +464,8 @@ extern "C" {
 #define OSSL_ENCODER_PARAM_INPUT_TYPE       "input-type"
 #define OSSL_ENCODER_PARAM_OUTPUT_TYPE      "output-type"
 #define OSSL_ENCODER_PARAM_OUTPUT_STRUCTURE "output-structure"
+/* Currently PVK only, but reusable for others as needed */
+#define OSSL_ENCODER_PARAM_ENCRYPT_LEVEL    "encrypt-level"
 
 #define OSSL_DECODER_PARAM_PROPERTIES       OSSL_ALG_PARAM_PROPERTIES
 #define OSSL_DECODER_PARAM_INPUT_TYPE       "input-type"

--- a/providers/encoders.inc
+++ b/providers/encoders.inc
@@ -32,7 +32,11 @@
     { _name,                                                            \
       "provider=" ENCODER_PROVIDER ",fips=" #_fips ",output=text",      \
       (ossl_##_sym##_to_text_encoder_functions) }
-#define ENCODER(_name, _sym, _fips, _output, _structure)                \
+#define ENCODER(_name, _sym, _fips, _output)                            \
+    { _name,                                                            \
+      "provider=" ENCODER_PROVIDER ",fips=" #_fips ",output=" #_output, \
+      (ossl_##_sym##_to_##_output##_encoder_functions) }
+#define ENCODER_w_structure(_name, _sym, _fips, _output, _structure)    \
     { _name,                                                            \
       "provider=" ENCODER_PROVIDER ",fips=" #_fips ",output=" #_output  \
       ",structure=" ENCODER_STRUCTURE_##_structure,                     \
@@ -83,23 +87,37 @@ ENCODER_TEXT("X448", x448, yes),
  */
 
 /* The RSA encoders only support private key and public key output */
-ENCODER("RSA", rsa, yes, der, type_specific_keypair),
-ENCODER("RSA", rsa, yes, pem, type_specific_keypair),
+ENCODER_w_structure("RSA", rsa, yes, der, type_specific_keypair),
+ENCODER_w_structure("RSA", rsa, yes, pem, type_specific_keypair),
 #ifndef OPENSSL_NO_DH
 /* DH and X9.42 DH only support key parameters output. */
-ENCODER("DH", dh, yes, der, type_specific_params),
-ENCODER("DH", dh, yes, pem, type_specific_params),
-ENCODER("DHX", dhx, yes, der, type_specific_params),
-ENCODER("DHX", dhx, yes, pem, type_specific_params),
+ENCODER_w_structure("DH", dh, yes, der, type_specific_params),
+ENCODER_w_structure("DH", dh, yes, pem, type_specific_params),
+ENCODER_w_structure("DHX", dhx, yes, der, type_specific_params),
+ENCODER_w_structure("DHX", dhx, yes, pem, type_specific_params),
 #endif
 #ifndef OPENSSL_NO_DSA
-ENCODER("DSA", dsa, yes, der, type_specific),
-ENCODER("DSA", dsa, yes, pem, type_specific),
+ENCODER_w_structure("DSA", dsa, yes, der, type_specific),
+ENCODER_w_structure("DSA", dsa, yes, pem, type_specific),
 #endif
 #ifndef OPENSSL_NO_EC
 /* EC only supports keypair and parameters output. */
-ENCODER("EC", ec, yes, der, type_specific_no_pub),
-ENCODER("EC", ec, yes, pem, type_specific_no_pub),
+ENCODER_w_structure("EC", ec, yes, der, type_specific_no_pub),
+ENCODER_w_structure("EC", ec, yes, pem, type_specific_no_pub),
+#endif
+
+/*
+ * Entries for the output formats MSBLOB and PVK
+ */
+ENCODER("RSA", rsa, yes, msblob),
+#ifndef OPENSSL_NO_RC4
+ENCODER("RSA", rsa, yes, pvk),
+#endif
+#ifndef OPENSSL_NO_DSA
+ENCODER("DSA", dsa, yes, msblob),
+# ifndef OPENSSL_NO_RC4
+ENCODER("DSA", dsa, yes, pvk),
+# endif
 #endif
 
 /*
@@ -109,60 +127,60 @@ ENCODER("EC", ec, yes, pem, type_specific_no_pub),
  * The "pem" ones also support PEM_write_bio_PrivateKey() and
  * PEM_write_bio_PUBKEY().
  */
-ENCODER("RSA", rsa, yes, der, PKCS8),
-ENCODER("RSA", rsa, yes, pem, PKCS8),
-ENCODER("RSA", rsa, yes, der, SubjectPublicKeyInfo),
-ENCODER("RSA", rsa, yes, pem, SubjectPublicKeyInfo),
+ENCODER_w_structure("RSA", rsa, yes, der, PKCS8),
+ENCODER_w_structure("RSA", rsa, yes, pem, PKCS8),
+ENCODER_w_structure("RSA", rsa, yes, der, SubjectPublicKeyInfo),
+ENCODER_w_structure("RSA", rsa, yes, pem, SubjectPublicKeyInfo),
 
-ENCODER("RSA-PSS", rsapss, yes, der, PKCS8),
-ENCODER("RSA-PSS", rsapss, yes, pem, PKCS8),
-ENCODER("RSA-PSS", rsapss, yes, der, SubjectPublicKeyInfo),
-ENCODER("RSA-PSS", rsapss, yes, pem, SubjectPublicKeyInfo),
+ENCODER_w_structure("RSA-PSS", rsapss, yes, der, PKCS8),
+ENCODER_w_structure("RSA-PSS", rsapss, yes, pem, PKCS8),
+ENCODER_w_structure("RSA-PSS", rsapss, yes, der, SubjectPublicKeyInfo),
+ENCODER_w_structure("RSA-PSS", rsapss, yes, pem, SubjectPublicKeyInfo),
 
 #ifndef OPENSSL_NO_DH
-ENCODER("DH", dh, yes, der, PKCS8),
-ENCODER("DH", dh, yes, pem, PKCS8),
-ENCODER("DH", dh, yes, der, SubjectPublicKeyInfo),
-ENCODER("DH", dh, yes, pem, SubjectPublicKeyInfo),
+ENCODER_w_structure("DH", dh, yes, der, PKCS8),
+ENCODER_w_structure("DH", dh, yes, pem, PKCS8),
+ENCODER_w_structure("DH", dh, yes, der, SubjectPublicKeyInfo),
+ENCODER_w_structure("DH", dh, yes, pem, SubjectPublicKeyInfo),
 
-ENCODER("DHX", dhx, yes, der, PKCS8),
-ENCODER("DHX", dhx, yes, pem, PKCS8),
-ENCODER("DHX", dhx, yes, der, SubjectPublicKeyInfo),
-ENCODER("DHX", dhx, yes, pem, SubjectPublicKeyInfo),
+ENCODER_w_structure("DHX", dhx, yes, der, PKCS8),
+ENCODER_w_structure("DHX", dhx, yes, pem, PKCS8),
+ENCODER_w_structure("DHX", dhx, yes, der, SubjectPublicKeyInfo),
+ENCODER_w_structure("DHX", dhx, yes, pem, SubjectPublicKeyInfo),
 #endif
 
 #ifndef OPENSSL_NO_DSA
-ENCODER("DSA", dsa, yes, der, PKCS8),
-ENCODER("DSA", dsa, yes, pem, PKCS8),
-ENCODER("DSA", dsa, yes, der, SubjectPublicKeyInfo),
-ENCODER("DSA", dsa, yes, pem, SubjectPublicKeyInfo),
+ENCODER_w_structure("DSA", dsa, yes, der, PKCS8),
+ENCODER_w_structure("DSA", dsa, yes, pem, PKCS8),
+ENCODER_w_structure("DSA", dsa, yes, der, SubjectPublicKeyInfo),
+ENCODER_w_structure("DSA", dsa, yes, pem, SubjectPublicKeyInfo),
 #endif
 
 #ifndef OPENSSL_NO_EC
-ENCODER("EC", ec, yes, der, PKCS8),
-ENCODER("EC", ec, yes, pem, PKCS8),
-ENCODER("EC", ec, yes, der, SubjectPublicKeyInfo),
-ENCODER("EC", ec, yes, pem, SubjectPublicKeyInfo),
+ENCODER_w_structure("EC", ec, yes, der, PKCS8),
+ENCODER_w_structure("EC", ec, yes, pem, PKCS8),
+ENCODER_w_structure("EC", ec, yes, der, SubjectPublicKeyInfo),
+ENCODER_w_structure("EC", ec, yes, pem, SubjectPublicKeyInfo),
 
-ENCODER("X25519", x25519, yes, der, PKCS8),
-ENCODER("X25519", x25519, yes, pem, PKCS8),
-ENCODER("X25519", x25519, yes, der, SubjectPublicKeyInfo),
-ENCODER("X25519", x25519, yes, pem, SubjectPublicKeyInfo),
+ENCODER_w_structure("X25519", x25519, yes, der, PKCS8),
+ENCODER_w_structure("X25519", x25519, yes, pem, PKCS8),
+ENCODER_w_structure("X25519", x25519, yes, der, SubjectPublicKeyInfo),
+ENCODER_w_structure("X25519", x25519, yes, pem, SubjectPublicKeyInfo),
 
-ENCODER("X448", x448, yes, der, PKCS8),
-ENCODER("X448", x448, yes, pem, PKCS8),
-ENCODER("X448", x448, yes, der, SubjectPublicKeyInfo),
-ENCODER("X448", x448, yes, pem, SubjectPublicKeyInfo),
+ENCODER_w_structure("X448", x448, yes, der, PKCS8),
+ENCODER_w_structure("X448", x448, yes, pem, PKCS8),
+ENCODER_w_structure("X448", x448, yes, der, SubjectPublicKeyInfo),
+ENCODER_w_structure("X448", x448, yes, pem, SubjectPublicKeyInfo),
 
-ENCODER("ED25519", ed25519, yes, der, PKCS8),
-ENCODER("ED25519", ed25519, yes, pem, PKCS8),
-ENCODER("ED25519", ed25519, yes, der, SubjectPublicKeyInfo),
-ENCODER("ED25519", ed25519, yes, pem, SubjectPublicKeyInfo),
+ENCODER_w_structure("ED25519", ed25519, yes, der, PKCS8),
+ENCODER_w_structure("ED25519", ed25519, yes, pem, PKCS8),
+ENCODER_w_structure("ED25519", ed25519, yes, der, SubjectPublicKeyInfo),
+ENCODER_w_structure("ED25519", ed25519, yes, pem, SubjectPublicKeyInfo),
 
-ENCODER("ED448", ed448, yes, der, PKCS8),
-ENCODER("ED448", ed448, yes, pem, PKCS8),
-ENCODER("ED448", ed448, yes, der, SubjectPublicKeyInfo),
-ENCODER("ED448", ed448, yes, pem, SubjectPublicKeyInfo),
+ENCODER_w_structure("ED448", ed448, yes, der, PKCS8),
+ENCODER_w_structure("ED448", ed448, yes, pem, PKCS8),
+ENCODER_w_structure("ED448", ed448, yes, der, SubjectPublicKeyInfo),
+ENCODER_w_structure("ED448", ed448, yes, pem, SubjectPublicKeyInfo),
 #endif
 
 /*
@@ -173,22 +191,22 @@ ENCODER("ED448", ed448, yes, pem, SubjectPublicKeyInfo),
  */
 
 /* The RSA encoders only support private key and public key output */
-ENCODER("RSA", rsa, yes, der, RSA),
-ENCODER("RSA", rsa, yes, pem, RSA),
+ENCODER_w_structure("RSA", rsa, yes, der, RSA),
+ENCODER_w_structure("RSA", rsa, yes, pem, RSA),
 #ifndef OPENSSL_NO_DH
 /* DH and X9.42 DH only support key parameters output. */
-ENCODER("DH", dh, yes, der, DH),
-ENCODER("DH", dh, yes, pem, DH),
-ENCODER("DHX", dhx, yes, der, DHX),
-ENCODER("DHX", dhx, yes, pem, DHX),
+ENCODER_w_structure("DH", dh, yes, der, DH),
+ENCODER_w_structure("DH", dh, yes, pem, DH),
+ENCODER_w_structure("DHX", dhx, yes, der, DHX),
+ENCODER_w_structure("DHX", dhx, yes, pem, DHX),
 #endif
 #ifndef OPENSSL_NO_DSA
-ENCODER("DSA", dsa, yes, der, DSA),
-ENCODER("DSA", dsa, yes, pem, DSA),
+ENCODER_w_structure("DSA", dsa, yes, der, DSA),
+ENCODER_w_structure("DSA", dsa, yes, pem, DSA),
 #endif
 #ifndef OPENSSL_NO_EC
-ENCODER("EC", ec, yes, der, EC),
-ENCODER("EC", ec, yes, pem, EC),
+ENCODER_w_structure("EC", ec, yes, der, EC),
+ENCODER_w_structure("EC", ec, yes, pem, EC),
 #endif
 
 /*
@@ -198,20 +216,20 @@ ENCODER("EC", ec, yes, pem, EC),
  * on libcrypto functionality in any way.
  */
 /* PKCS#1 is a well known for plain RSA keys, so we add that too */
-ENCODER("RSA", rsa, yes, der, PKCS1),
-ENCODER("RSA", rsa, yes, pem, PKCS1),
-ENCODER("RSA-PSS", rsapss, yes, der, PKCS1),
-ENCODER("RSA-PSS", rsapss, yes, pem, PKCS1),
+ENCODER_w_structure("RSA", rsa, yes, der, PKCS1),
+ENCODER_w_structure("RSA", rsa, yes, pem, PKCS1),
+ENCODER_w_structure("RSA-PSS", rsapss, yes, der, PKCS1),
+ENCODER_w_structure("RSA-PSS", rsapss, yes, pem, PKCS1),
 #ifndef OPENSSL_NO_DH
 /* PKCS#3 defines the format for DH parameters */
-ENCODER("DH", dh, yes, der, PKCS3),
-ENCODER("DH", dh, yes, pem, PKCS3),
+ENCODER_w_structure("DH", dh, yes, der, PKCS3),
+ENCODER_w_structure("DH", dh, yes, pem, PKCS3),
 /* X9.42 defines the format for DHX parameters */
-ENCODER("DHX", dhx, yes, der, X9_42),
-ENCODER("DHX", dhx, yes, pem, X9_42),
+ENCODER_w_structure("DHX", dhx, yes, der, X9_42),
+ENCODER_w_structure("DHX", dhx, yes, pem, X9_42),
 #endif
 #ifndef OPENSSL_NO_EC
 /* RFC 5915 defines the format for EC keys and parameters */
-ENCODER("EC", ec, yes, der, X9_62),
-ENCODER("EC", ec, yes, pem, X9_62),
+ENCODER_w_structure("EC", ec, yes, der, X9_62),
+ENCODER_w_structure("EC", ec, yes, pem, X9_62),
 #endif

--- a/providers/encoders.inc
+++ b/providers/encoders.inc
@@ -110,14 +110,10 @@ ENCODER_w_structure("EC", ec, yes, pem, type_specific_no_pub),
  * Entries for the output formats MSBLOB and PVK
  */
 ENCODER("RSA", rsa, yes, msblob),
-#ifndef OPENSSL_NO_RC4
 ENCODER("RSA", rsa, yes, pvk),
-#endif
 #ifndef OPENSSL_NO_DSA
 ENCODER("DSA", dsa, yes, msblob),
-# ifndef OPENSSL_NO_RC4
 ENCODER("DSA", dsa, yes, pvk),
-# endif
 #endif
 
 /*

--- a/providers/implementations/encode_decode/build.info
+++ b/providers/implementations/encode_decode/build.info
@@ -14,8 +14,5 @@ SOURCE[$ENCODER_GOAL]=endecoder_common.c
 
 SOURCE[$DECODER_GOAL]=decode_der2key.c decode_pem2der.c decode_ms2key.c
 
-SOURCE[$ENCODER_GOAL]=encode_key2any.c encode_key2text.c
+SOURCE[$ENCODER_GOAL]=encode_key2any.c encode_key2text.c encode_key2ms.c
 DEPEND[encode_key2any.o]=../../common/include/prov/der_rsa.h
-IF[{- !$disabled{dsa} -}]
-  SOURCE[$ENCODER_GOAL]=encode_key2ms.c
-ENDIF

--- a/providers/implementations/encode_decode/build.info
+++ b/providers/implementations/encode_decode/build.info
@@ -14,5 +14,8 @@ SOURCE[$ENCODER_GOAL]=endecoder_common.c
 
 SOURCE[$DECODER_GOAL]=decode_der2key.c decode_pem2der.c decode_ms2key.c
 
-SOURCE[$DECODER_GOAL]=encode_key2any.c encode_key2text.c
+SOURCE[$ENCODER_GOAL]=encode_key2any.c encode_key2text.c
 DEPEND[encode_key2any.o]=../../common/include/prov/der_rsa.h
+IF[{- !$disabled{dsa} -}]
+  SOURCE[$ENCODER_GOAL]=encode_key2ms.c
+ENDIF

--- a/providers/implementations/encode_decode/encode_key2ms.c
+++ b/providers/implementations/encode_decode/encode_key2ms.c
@@ -35,7 +35,6 @@ struct key2ms_ctx_st {
     struct ossl_passphrase_data_st pwdata;
 };
 
-#ifndef OPENSSL_NO_DSA
 static int write_msblob(struct key2ms_ctx_st *ctx, OSSL_CORE_BIO *cout,
                         EVP_PKEY *pkey, int ispub)
 {
@@ -47,7 +46,6 @@ static int write_msblob(struct key2ms_ctx_st *ctx, OSSL_CORE_BIO *cout,
     return ret;
 }
 
-# ifndef OPENSSL_NO_RC4
 static int write_pvk(struct key2ms_ctx_st *ctx, OSSL_CORE_BIO *cout,
                      EVP_PKEY *pkey,
                      OSSL_PASSPHRASE_CALLBACK *pw_cb, void *pw_cbarg)
@@ -62,8 +60,6 @@ static int write_pvk(struct key2ms_ctx_st *ctx, OSSL_CORE_BIO *cout,
 
     return ret;
 }
-# endif
-#endif
 
 static OSSL_FUNC_encoder_freectx_fn key2ms_freectx;
 static OSSL_FUNC_encoder_gettable_params_fn key2ms_gettable_params;
@@ -109,7 +105,6 @@ static int key2msblob_get_params(OSSL_PARAM params[])
     return 1;
 }
 
-#ifndef OPENSSL_NO_RC4
 static int key2pvk_get_params(OSSL_PARAM params[])
 {
     OSSL_PARAM *p;
@@ -120,7 +115,6 @@ static int key2pvk_get_params(OSSL_PARAM params[])
 
     return 1;
 }
-#endif
 
 static const OSSL_PARAM *key2pvk_settable_ctx_params(ossl_unused void *provctx)
 {
@@ -181,7 +175,6 @@ static int key2msblob_encode(void *vctx, const void *key, int selection,
     return ok;
 }
 
-#ifndef OPENSSL_NO_RC4
 static int key2pvk_encode(void *vctx, const void *key, int selection,
                           OSSL_CORE_BIO *cout, evp_pkey_set1_fn *set1_key,
                           OSSL_PASSPHRASE_CALLBACK *pw_cb, void *pw_cbarg)
@@ -198,7 +191,6 @@ static int key2pvk_encode(void *vctx, const void *key, int selection,
     EVP_PKEY_free(pkey);
     return ok;
 }
-#endif
 
 #define dsa_set1        (evp_pkey_set1_fn *)EVP_PKEY_set1_DSA
 #define rsa_set1        (evp_pkey_set1_fn *)EVP_PKEY_set1_RSA
@@ -264,13 +256,9 @@ static int key2pvk_encode(void *vctx, const void *key, int selection,
     }
 
 #ifndef OPENSSL_NO_DSA
-# ifndef OPENSSL_NO_RC4
 MAKE_MS_ENCODER(dsa, pvk, dsa);
-# endif
 MAKE_MS_ENCODER(dsa, msblob, dsa);
 #endif
 
-#ifndef OPENSSL_NO_RC4
 MAKE_MS_ENCODER(rsa, pvk, rsa);
-#endif
 MAKE_MS_ENCODER(rsa, msblob, rsa);

--- a/providers/implementations/encode_decode/encode_key2ms.c
+++ b/providers/implementations/encode_decode/encode_key2ms.c
@@ -1,0 +1,276 @@
+/*
+ * Copyright 2020 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+/*
+ * Low level APIs are deprecated for public use, but still ok for internal use.
+ */
+#include "internal/deprecated.h"
+
+#include <string.h>
+#include <openssl/core.h>
+#include <openssl/core_dispatch.h>
+#include <openssl/core_names.h>
+#include <openssl/params.h>
+#include <openssl/err.h>
+#include <openssl/pem.h>         /* Functions for writing MSBLOB and PVK */
+#include <openssl/dsa.h>
+#include "internal/passphrase.h"
+#include "crypto/rsa.h"
+#include "prov/implementations.h"
+#include "prov/bio.h"
+#include "prov/provider_ctx.h"
+#include "endecoder_local.h"
+
+struct key2ms_ctx_st {
+    PROV_CTX *provctx;
+
+    int pvk_encr_level;
+
+    struct ossl_passphrase_data_st pwdata;
+};
+
+#ifndef OPENSSL_NO_DSA
+static int write_msblob(struct key2ms_ctx_st *ctx, OSSL_CORE_BIO *cout,
+                        EVP_PKEY *pkey, int ispub)
+{
+    BIO *out = bio_new_from_core_bio(ctx->provctx, cout);
+    int ret =
+        ispub ? i2b_PublicKey_bio(out, pkey) : i2b_PrivateKey_bio(out, pkey);
+
+    BIO_free(out);
+    return ret;
+}
+
+# ifndef OPENSSL_NO_RC4
+static int write_pvk(struct key2ms_ctx_st *ctx, OSSL_CORE_BIO *cout,
+                     EVP_PKEY *pkey,
+                     OSSL_PASSPHRASE_CALLBACK *pw_cb, void *pw_cbarg)
+{
+    BIO *out = NULL;
+    int ret = 0;
+
+    out = bio_new_from_core_bio(ctx->provctx, cout);
+    ret = i2b_PVK_bio(out, pkey, ctx->pvk_encr_level,
+                      ossl_pw_pem_password, &ctx->pwdata);
+    BIO_free(out);
+
+    return ret;
+}
+# endif
+#endif
+
+static OSSL_FUNC_encoder_freectx_fn key2ms_freectx;
+static OSSL_FUNC_encoder_gettable_params_fn key2ms_gettable_params;
+static OSSL_FUNC_encoder_does_selection_fn key2ms_does_selection;
+
+static struct key2ms_ctx_st *key2ms_newctx(void *provctx)
+{
+    struct key2ms_ctx_st *ctx = OPENSSL_zalloc(sizeof(*ctx));
+
+    if (ctx != NULL) {
+        ctx->provctx = provctx;
+        /* This is the strongest encryption level */
+        ctx->pvk_encr_level = 2;
+    }
+    return ctx;
+}
+
+static void key2ms_freectx(void *vctx)
+{
+    struct key2ms_ctx_st *ctx = vctx;
+
+    OPENSSL_free(ctx);
+}
+
+static const OSSL_PARAM *key2ms_gettable_params(ossl_unused void *provctx)
+{
+    static const OSSL_PARAM gettables[] = {
+        { OSSL_ENCODER_PARAM_OUTPUT_TYPE, OSSL_PARAM_UTF8_PTR, NULL, 0, 0 },
+        OSSL_PARAM_END,
+    };
+
+    return gettables;
+}
+
+static int key2msblob_get_params(OSSL_PARAM params[])
+{
+    OSSL_PARAM *p;
+
+    p = OSSL_PARAM_locate(params, OSSL_ENCODER_PARAM_OUTPUT_TYPE);
+    if (p != NULL && !OSSL_PARAM_set_utf8_ptr(p, "MSBLOB"))
+        return 0;
+
+    return 1;
+}
+
+#ifndef OPENSSL_NO_RC4
+static int key2pvk_get_params(OSSL_PARAM params[])
+{
+    OSSL_PARAM *p;
+
+    p = OSSL_PARAM_locate(params, OSSL_ENCODER_PARAM_OUTPUT_TYPE);
+    if (p != NULL && !OSSL_PARAM_set_utf8_ptr(p, "PVK"))
+        return 0;
+
+    return 1;
+}
+#endif
+
+static const OSSL_PARAM *key2pvk_settable_ctx_params(ossl_unused void *provctx)
+{
+    static const OSSL_PARAM settables[] = {
+        OSSL_PARAM_int(OSSL_ENCODER_PARAM_ENCRYPT_LEVEL, NULL),
+        OSSL_PARAM_END,
+    };
+
+    return settables;
+}
+
+static int key2pvk_set_ctx_params(void *vctx, const OSSL_PARAM params[])
+{
+    struct key2ms_ctx_st *ctx = vctx;
+    const OSSL_PARAM *p;
+
+    p = OSSL_PARAM_locate_const(params, OSSL_ENCODER_PARAM_ENCRYPT_LEVEL);
+    if (p != NULL && !OSSL_PARAM_get_int(p, &ctx->pvk_encr_level))
+        return 0;
+    return 1;
+}
+
+static int key2ms_does_selection(void *vctx, int selection)
+{
+    return (selection & OSSL_KEYMGMT_SELECT_KEYPAIR) != 0;
+}
+
+/*
+ * The real EVP_PKEY_set1_TYPE() functions take a non-const key, while the key
+ * pointer in the encode function is a const pointer.  We violate the constness
+ * knowingly, since we know that the key comes from the same provider, is never
+ * actually const, and the implied reference count change is safe.
+ *
+ * EVP_PKEY_assign() can't be used, because there's no way to clear the internal
+ * key using that function without freeing the existing internal key.
+ */
+typedef int evp_pkey_set1_fn(EVP_PKEY *, const void *key);
+
+static int key2msblob_encode(void *vctx, const void *key, int selection,
+                             OSSL_CORE_BIO *cout, evp_pkey_set1_fn *set1_key,
+                             OSSL_PASSPHRASE_CALLBACK *pw_cb, void *pw_cbarg)
+{
+    struct key2ms_ctx_st *ctx = vctx;
+    int ispub = -1;
+    EVP_PKEY *pkey = NULL;
+    int ok = 0;
+
+    if ((selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) != 0)
+        ispub = 0;
+    else if ((selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY) != 0)
+        ispub = 1;
+    else
+        return 0;                /* Error */
+
+    if ((pkey = EVP_PKEY_new()) != NULL && set1_key(pkey, key))
+        ok = write_msblob(ctx, cout, pkey, ispub);
+    EVP_PKEY_free(pkey);
+    return ok;
+}
+
+#ifndef OPENSSL_NO_RC4
+static int key2pvk_encode(void *vctx, const void *key, int selection,
+                          OSSL_CORE_BIO *cout, evp_pkey_set1_fn *set1_key,
+                          OSSL_PASSPHRASE_CALLBACK *pw_cb, void *pw_cbarg)
+{
+    struct key2ms_ctx_st *ctx = vctx;
+    EVP_PKEY *pkey = NULL;
+    int ok = 0;
+
+    if ((selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) == 0)
+        return 0;                /* Error */
+
+    if ((pkey = EVP_PKEY_new()) != NULL && set1_key(pkey, key))
+        ok = write_pvk(ctx, cout, pkey, pw_cb, pw_cbarg);
+    EVP_PKEY_free(pkey);
+    return ok;
+}
+#endif
+
+#define dsa_set1        (evp_pkey_set1_fn *)EVP_PKEY_set1_DSA
+#define rsa_set1        (evp_pkey_set1_fn *)EVP_PKEY_set1_RSA
+
+#define msblob_set_params
+#define pvk_set_params                                                        \
+        { OSSL_FUNC_ENCODER_SETTABLE_CTX_PARAMS,                              \
+          (void (*)(void))key2pvk_settable_ctx_params },                      \
+        { OSSL_FUNC_ENCODER_SET_CTX_PARAMS,                                   \
+          (void (*)(void))key2pvk_set_ctx_params },
+
+#define MAKE_MS_ENCODER(impl, output, type)                                   \
+    static OSSL_FUNC_encoder_import_object_fn                                 \
+    impl##2##output##_import_object;                                          \
+    static OSSL_FUNC_encoder_free_object_fn impl##2##output##_free_object;    \
+    static OSSL_FUNC_encoder_encode_fn impl##2##output##_encode;              \
+                                                                              \
+    static void *                                                             \
+    impl##2##output##_import_object(void *ctx, int selection,                 \
+                                    const OSSL_PARAM params[])                \
+    {                                                                         \
+        return ossl_prov_import_key(ossl_##impl##_keymgmt_functions,          \
+                                    ctx, selection, params);                  \
+    }                                                                         \
+    static void impl##2##output##_free_object(void *key)                      \
+    {                                                                         \
+        ossl_prov_free_key(ossl_##impl##_keymgmt_functions, key);             \
+    }                                                                         \
+    static int impl##2##output##_encode(void *vctx, OSSL_CORE_BIO *cout,      \
+                                        const void *key,                      \
+                                        const OSSL_PARAM key_abstract[],      \
+                                        int selection,                        \
+                                        OSSL_PASSPHRASE_CALLBACK *cb,         \
+                                        void *cbarg)                          \
+    {                                                                         \
+        /* We don't deal with abstract objects */                             \
+        if (key_abstract != NULL) {                                           \
+            ERR_raise(ERR_LIB_PROV, ERR_R_PASSED_INVALID_ARGUMENT);           \
+            return 0;                                                         \
+        }                                                                     \
+        return key2##output##_encode(vctx, key, selection, cout, type##_set1, \
+                                     cb, cbarg);                              \
+    }                                                                         \
+    const OSSL_DISPATCH ossl_##impl##_to_##output##_encoder_functions[] = {   \
+        { OSSL_FUNC_ENCODER_NEWCTX,                                           \
+          (void (*)(void))key2ms_newctx },                                    \
+        { OSSL_FUNC_ENCODER_FREECTX,                                          \
+          (void (*)(void))key2ms_freectx },                                   \
+        { OSSL_FUNC_ENCODER_GETTABLE_PARAMS,                                  \
+          (void (*)(void))key2ms_gettable_params },                           \
+        { OSSL_FUNC_ENCODER_GET_PARAMS,                                       \
+          (void (*)(void))key2##output##_get_params },                        \
+        output##_set_params                                                   \
+        { OSSL_FUNC_ENCODER_DOES_SELECTION,                                   \
+          (void (*)(void))key2ms_does_selection },                            \
+        { OSSL_FUNC_ENCODER_IMPORT_OBJECT,                                    \
+          (void (*)(void))impl##2##output##_import_object },                  \
+        { OSSL_FUNC_ENCODER_FREE_OBJECT,                                      \
+          (void (*)(void))impl##2##output##_free_object },                    \
+        { OSSL_FUNC_ENCODER_ENCODE,                                           \
+          (void (*)(void))impl##2##output##_encode },                         \
+        { 0, NULL }                                                           \
+    }
+
+#ifndef OPENSSL_NO_DSA
+# ifndef OPENSSL_NO_RC4
+MAKE_MS_ENCODER(dsa, pvk, dsa);
+# endif
+MAKE_MS_ENCODER(dsa, msblob, dsa);
+#endif
+
+#ifndef OPENSSL_NO_RC4
+MAKE_MS_ENCODER(rsa, pvk, rsa);
+#endif
+MAKE_MS_ENCODER(rsa, msblob, rsa);

--- a/providers/implementations/include/prov/implementations.h
+++ b/providers/implementations/include/prov/implementations.h
@@ -328,6 +328,8 @@ extern const OSSL_DISPATCH ossl_rsa_to_RSA_der_encoder_functions[];
 extern const OSSL_DISPATCH ossl_rsa_to_RSA_pem_encoder_functions[];
 extern const OSSL_DISPATCH ossl_rsa_to_SubjectPublicKeyInfo_der_encoder_functions[];
 extern const OSSL_DISPATCH ossl_rsa_to_SubjectPublicKeyInfo_pem_encoder_functions[];
+extern const OSSL_DISPATCH ossl_rsa_to_msblob_encoder_functions[];
+extern const OSSL_DISPATCH ossl_rsa_to_pvk_encoder_functions[];
 extern const OSSL_DISPATCH ossl_rsa_to_text_encoder_functions[];
 extern const OSSL_DISPATCH ossl_rsa_to_type_specific_keypair_der_encoder_functions[];
 extern const OSSL_DISPATCH ossl_rsa_to_type_specific_keypair_pem_encoder_functions[];
@@ -372,6 +374,8 @@ extern const OSSL_DISPATCH ossl_dsa_to_SubjectPublicKeyInfo_der_encoder_function
 extern const OSSL_DISPATCH ossl_dsa_to_SubjectPublicKeyInfo_pem_encoder_functions[];
 extern const OSSL_DISPATCH ossl_dsa_to_type_specific_pem_encoder_functions[];
 extern const OSSL_DISPATCH ossl_dsa_to_type_specific_der_encoder_functions[];
+extern const OSSL_DISPATCH ossl_dsa_to_msblob_encoder_functions[];
+extern const OSSL_DISPATCH ossl_dsa_to_pvk_encoder_functions[];
 extern const OSSL_DISPATCH ossl_dsa_to_text_encoder_functions[];
 
 extern const OSSL_DISPATCH ossl_ec_to_EC_der_encoder_functions[];

--- a/test/recipes/15-test_rsa.t
+++ b/test/recipes/15-test_rsa.t
@@ -49,7 +49,7 @@ sub run_rsa_tests {
 
      SKIP: {
          skip "Skipping msblob conversion test", 1
-	     if disabled($cmd) || disabled("dsa") || $cmd eq 'pkey';
+	     if disabled($cmd) || $cmd eq 'pkey';
 
          subtest "$cmd conversions -- public key" => sub {
 	     tconversion( -type => 'msb', -prefix => "$cmd-msb-pub",

--- a/test/recipes/15-test_rsa.t
+++ b/test/recipes/15-test_rsa.t
@@ -49,7 +49,7 @@ sub run_rsa_tests {
 
      SKIP: {
          skip "Skipping msblob conversion test", 1
-	     if disabled($cmd) || disabled("dsa") || $cmd == 'pkey';
+	     if disabled($cmd) || disabled("dsa") || $cmd eq 'pkey';
 
          subtest "$cmd conversions -- public key" => sub {
 	     tconversion( -type => 'msb', -prefix => "$cmd-msb-pub",


### PR DESCRIPTION
This allows 15-test_rsa.t to succeed, and provides the same OSSL_ENCODER
support for these formats as for all other formats supported in OpenSSL.

Fixes #13379