### PR TITLE
Fix no-threads

### DIFF
--- a/crypto/build.info
+++ b/crypto/build.info
@@ -71,7 +71,7 @@ $UTIL_COMMON=\
         cryptlib.c params.c params_from_text.c bsearch.c ex_data.c o_str.c \
         ctype.c threads_pthread.c threads_win.c threads_none.c initthread.c \
         context.c sparse_array.c asn1_dsa.c packet.c param_build.c $CPUIDASM \
-        param_build_set.c der_writer.c passphrase.c
+        param_build_set.c der_writer.c passphrase.c threads_lib.c
 $UTIL_DEFINE=$CPUIDDEF
 
 SOURCE[../libcrypto]=$UTIL_COMMON \

--- a/crypto/threads_lib.c
+++ b/crypto/threads_lib.c
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2020 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+#include <openssl/crypto.h>
+
+#ifndef OPENSSL_NO_DEPRECATED_3_0
+
+void OPENSSL_fork_prepare(void)
+{
+}
+
+void OPENSSL_fork_parent(void)
+{
+}
+
+void OPENSSL_fork_child(void)
+{
+}
+
+#endif

--- a/crypto/threads_pthread.c
+++ b/crypto/threads_pthread.c
@@ -200,21 +200,6 @@ int CRYPTO_atomic_add(int *val, int amount, int *ret, CRYPTO_RWLOCK *lock)
 # ifndef FIPS_MODULE
 #  ifdef OPENSSL_SYS_UNIX
 
-#   ifndef OPENSSL_NO_DEPRECATED_3_0
-
-void OPENSSL_fork_prepare(void)
-{
-}
-
-void OPENSSL_fork_parent(void)
-{
-}
-
-void OPENSSL_fork_child(void)
-{
-}
-
-#   endif
 static pthread_once_t fork_once_control = PTHREAD_ONCE_INIT;
 
 static void fork_once_func(void)


### PR DESCRIPTION
Make OPENSSL_fork_prepare() et al always available even in a no-threads
build. These functions are no-ops anyway so this shouldn't make any
difference.

This fixes an issue where the symbol_presence test fails in a no-threads
build. This is because these functions have not been marked in
libcrypto.num as being dependent on thread support. Enclosing the
declarations of the functions in the header with an appropriate guard
does not help because we never define OPENSSL_NO_THREADS (we define the
opposite OPENSSL_THREADS). This confuses the scripts which only consider
OPENSSL_NO_* guards. The simplest solution is to just make them always
available.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
