### PR TITLE
PEM: Unlock MSBLOB and PVK functions from 'no-dsa' and 'no-rc4'

### DIFF
--- a/crypto/pem/pvkfmt.c
+++ b/crypto/pem/pvkfmt.c
@@ -873,6 +873,7 @@ static int i2b_PVK(unsigned char **out, const EVP_PKEY *pk, int enclevel,
     }
     do_i2b(&p, pk, 0);
     if (enclevel != 0) {
+#ifndef OPENSSL_NO_RC4
         char psbuf[PEM_BUFSIZE];
         unsigned char keybuf[20];
         int enctmplen, inlen;
@@ -897,6 +898,10 @@ static int i2b_PVK(unsigned char **out, const EVP_PKEY *pk, int enclevel,
             goto error;
         if (!EVP_EncryptFinal_ex(cctx, p + enctmplen, &enctmplen))
             goto error;
+#else
+        ERR_raise(ERR_LIB_PEM, PEM_R_UNSUPPORTED_CIPHER);
+        goto error;
+#endif
     }
 
     EVP_CIPHER_CTX_free(cctx);

--- a/crypto/pem/pvkfmt.c
+++ b/crypto/pem/pvkfmt.c
@@ -723,6 +723,7 @@ static EVP_PKEY *do_PVK_body(const unsigned char **in,
 
     EVP_CIPHER_CTX *cctx = EVP_CIPHER_CTX_new();
     if (saltlen) {
+#ifndef OPENSSL_NO_RC4
         char psbuf[PEM_BUFSIZE];
         int enctmplen, inlen;
         if (cb)
@@ -774,6 +775,10 @@ static EVP_PKEY *do_PVK_body(const unsigned char **in,
             }
         }
         p = enctmp;
+#else
+        ERR_raise(ERR_LIB_PEM, PEM_R_UNSUPPORTED_CIPHER);
+        goto err;
+#endif
     }
 
     ret = b2i_PrivateKey(&p, keylen);

--- a/crypto/pem/pvkfmt.c
+++ b/crypto/pem/pvkfmt.c
@@ -460,7 +460,7 @@ static void write_dsa(unsigned char **out, DSA *dsa, int ispub);
 static int do_i2b(unsigned char **out, const EVP_PKEY *pk, int ispub)
 {
     unsigned char *p;
-    unsigned int bitlen = 0, magic = 0, keyalg;
+    unsigned int bitlen = 0, magic = 0, keyalg = 0;
     int outlen, noinc = 0;
     int pktype = EVP_PKEY_id(pk);
 

--- a/crypto/pem/pvkfmt.c
+++ b/crypto/pem/pvkfmt.c
@@ -254,7 +254,8 @@ EVP_PKEY *ossl_b2i_bio(BIO *in, int *ispub)
     else
         ret = b2i_dss(&p, bitlen, *ispub);
 #endif
-    else
+
+    if (ret == NULL)
         ERR_raise(ERR_LIB_PEM, PEM_R_UNSUPPORTED_PUBLIC_KEY_TYPE);
 
  err:

--- a/crypto/pem/pvkfmt.c
+++ b/crypto/pem/pvkfmt.c
@@ -717,15 +717,16 @@ static EVP_PKEY *do_PVK_body(const unsigned char **in,
 {
     EVP_PKEY *ret = NULL;
     const unsigned char *p = *in;
-    unsigned int magic;
     unsigned char *enctmp = NULL, *q;
     unsigned char keybuf[20];
 
     EVP_CIPHER_CTX *cctx = EVP_CIPHER_CTX_new();
     if (saltlen) {
 #ifndef OPENSSL_NO_RC4
+        unsigned int magic;
         char psbuf[PEM_BUFSIZE];
         int enctmplen, inlen;
+
         if (cb)
             inlen = cb(psbuf, PEM_BUFSIZE, 0, u);
         else

--- a/engines/e_loader_attic.c
+++ b/engines/e_loader_attic.c
@@ -1338,9 +1338,6 @@ static int file_read_pem(BIO *bp, char **pem_name, char **pem_header,
 
 static OSSL_STORE_INFO *file_try_read_msblob(BIO *bp, int *matchcount)
 {
-#ifdef OPENSSL_NO_DSA
-    return NULL;
-#else
     OSSL_STORE_INFO *result = NULL;
     int ispub = -1;
 
@@ -1372,16 +1369,12 @@ static OSSL_STORE_INFO *file_try_read_msblob(BIO *bp, int *matchcount)
     }
 
     return result;
-#endif
 }
 
 static OSSL_STORE_INFO *file_try_read_PVK(BIO *bp, const UI_METHOD *ui_method,
                                           void *ui_data, const char *uri,
                                           int *matchcount)
 {
-#if defined(OPENSSL_NO_DSA) || defined(OPENSSL_NO_RC4)
-    return NULL;
-#else
     OSSL_STORE_INFO *result = NULL;
 
     {
@@ -1411,7 +1404,6 @@ static OSSL_STORE_INFO *file_try_read_PVK(BIO *bp, const UI_METHOD *ui_method,
     }
 
     return result;
-#endif
 }
 
 static int file_read_asn1(BIO *bp, unsigned char **data, long *len)

--- a/include/crypto/pem.h
+++ b/include/crypto/pem.h
@@ -12,20 +12,14 @@
 
 # include <openssl/pem.h>
 
-# ifndef OPENSSL_NO_DSA
 /* Found in crypto/pem/pvkfmt.c */
 int ossl_do_blob_header(const unsigned char **in, unsigned int length,
                         unsigned int *pmagic, unsigned int *pbitlen,
                         int *pisdss, int *pispub);
-#  ifndef OPENSSL_NO_RC4
 int ossl_do_PVK_header(const unsigned char **in, unsigned int length,
                        int skip_magic,
                        unsigned int *psaltlen, unsigned int *pkeylen);
-#  endif
-
 EVP_PKEY *ossl_b2i(const unsigned char **in, unsigned int length, int *ispub);
 EVP_PKEY *ossl_b2i_bio(BIO *in, int *ispub);
-
-# endif
 
 #endif

--- a/include/openssl/pem.h
+++ b/include/openssl/pem.h
@@ -513,19 +513,15 @@ EVP_PKEY *PEM_read_bio_Parameters_ex(BIO *bp, EVP_PKEY **x,
 EVP_PKEY *PEM_read_bio_Parameters(BIO *bp, EVP_PKEY **x);
 int PEM_write_bio_Parameters(BIO *bp, const EVP_PKEY *x);
 
-# ifndef OPENSSL_NO_DSA
 EVP_PKEY *b2i_PrivateKey(const unsigned char **in, long length);
 EVP_PKEY *b2i_PublicKey(const unsigned char **in, long length);
 EVP_PKEY *b2i_PrivateKey_bio(BIO *in);
 EVP_PKEY *b2i_PublicKey_bio(BIO *in);
 int i2b_PrivateKey_bio(BIO *out, const EVP_PKEY *pk);
 int i2b_PublicKey_bio(BIO *out, const EVP_PKEY *pk);
-#  ifndef OPENSSL_NO_RC4
 EVP_PKEY *b2i_PVK_bio(BIO *in, pem_password_cb *cb, void *u);
 int i2b_PVK_bio(BIO *out, const EVP_PKEY *pk, int enclevel,
                 pem_password_cb *cb, void *u);
-#  endif
-# endif
 
 # ifdef  __cplusplus
 }

--- a/providers/decoders.inc
+++ b/providers/decoders.inc
@@ -50,9 +50,7 @@ DECODER_w_structure("DSA", der, SubjectPublicKeyInfo, dsa, yes),
 DECODER_w_structure("DSA", der, type_specific, dsa, yes),
 DECODER_w_structure("DSA", der, DSA, dsa, yes),
 DECODER("DSA", msblob, dsa, yes),
-# ifndef OPENSSL_NO_RC4
 DECODER("DSA", pvk, dsa, yes),
-# endif
 #endif
 #ifndef OPENSSL_NO_EC
 DECODER_w_structure("EC", der, PKCS8, ec, yes),
@@ -74,11 +72,7 @@ DECODER_w_structure("RSA", der, type_specific_keypair, rsa, yes),
 DECODER_w_structure("RSA", der, RSA, rsa, yes),
 DECODER_w_structure("RSA-PSS", der, PKCS8, rsapss, yes),
 DECODER_w_structure("RSA-PSS", der, SubjectPublicKeyInfo, rsapss, yes),
-#ifndef OPENSSL_NO_DSA
 DECODER("RSA", msblob, rsa, yes),
-# ifndef OPENSSL_NO_RC4
 DECODER("RSA", pvk, rsa, yes),
-# endif
-#endif
 
 DECODER("DER", pem, der, yes),

--- a/providers/implementations/encode_decode/build.info
+++ b/providers/implementations/encode_decode/build.info
@@ -12,10 +12,7 @@ $EC_GOAL=../../libimplementations.a
 
 SOURCE[$ENCODER_GOAL]=endecoder_common.c
 
-SOURCE[$DECODER_GOAL]=decode_der2key.c decode_pem2der.c
-IF[{- !$disabled{dsa} -}]
-  SOURCE[$DECODER_GOAL]=decode_ms2key.c
-ENDIF
+SOURCE[$DECODER_GOAL]=decode_der2key.c decode_pem2der.c decode_ms2key.c
 
 SOURCE[$DECODER_GOAL]=encode_key2any.c encode_key2text.c
 DEPEND[encode_key2any.o]=../../common/include/prov/der_rsa.h

--- a/providers/implementations/encode_decode/decode_ms2key.c
+++ b/providers/implementations/encode_decode/decode_ms2key.c
@@ -28,7 +28,6 @@
 #include "prov/implementations.h"
 #include "endecoder_local.h"
 
-#ifndef OPENSSL_NO_DSA
 static EVP_PKEY *read_msblob(PROV_CTX *provctx, OSSL_CORE_BIO *cin, int *ispub)
 {
     BIO *in = bio_new_from_core_bio(provctx, cin);
@@ -38,7 +37,6 @@ static EVP_PKEY *read_msblob(PROV_CTX *provctx, OSSL_CORE_BIO *cin, int *ispub)
     return pkey;
 }
 
-# ifndef OPENSSL_NO_RC4
 static EVP_PKEY *read_pvk(PROV_CTX *provctx, OSSL_CORE_BIO *cin,
                           OSSL_PASSPHRASE_CALLBACK *pw_cb, void *pw_cbarg)
 {
@@ -56,19 +54,13 @@ static EVP_PKEY *read_pvk(PROV_CTX *provctx, OSSL_CORE_BIO *cin,
 
     return pkey;
 }
-# endif
-#endif
 
 static OSSL_FUNC_decoder_freectx_fn ms2key_freectx;
 static OSSL_FUNC_decoder_gettable_params_fn ms2key_gettable_params;
 static OSSL_FUNC_decoder_get_params_fn msblob2key_get_params;
-#ifndef OPENSSL_NO_RC4
 static OSSL_FUNC_decoder_get_params_fn pvk2key_get_params;
-#endif
 static OSSL_FUNC_decoder_decode_fn msblob2key_decode;
-#ifndef OPENSSL_NO_RC4
 static OSSL_FUNC_decoder_decode_fn pvk2key_decode;
-#endif
 static OSSL_FUNC_decoder_export_object_fn ms2key_export_object;
 
 typedef void *(extract_key_fn)(EVP_PKEY *);
@@ -134,7 +126,6 @@ static int msblob2key_get_params(OSSL_PARAM params[])
     return 1;
 }
 
-#ifndef OPENSSL_NO_RC4
 static int pvk2key_get_params(OSSL_PARAM params[])
 {
     OSSL_PARAM *p;
@@ -145,7 +136,6 @@ static int pvk2key_get_params(OSSL_PARAM params[])
 
     return 1;
 }
-#endif
 
 static int ms2key_post(struct ms2key_ctx_st *ctx, EVP_PKEY *pkey,
                        OSSL_CALLBACK *data_cb, void *data_cbarg)
@@ -207,7 +197,6 @@ static int msblob2key_decode(void *vctx, OSSL_CORE_BIO *cin, int selection,
     return ok;
 }
 
-#ifndef OPENSSL_NO_RC4
 static int pvk2key_decode(void *vctx, OSSL_CORE_BIO *cin, int selection,
                           OSSL_CALLBACK *data_cb, void *data_cbarg,
                           OSSL_PASSPHRASE_CALLBACK *pw_cb, void *pw_cbarg)
@@ -223,7 +212,6 @@ static int pvk2key_decode(void *vctx, OSSL_CORE_BIO *cin, int selection,
     EVP_PKEY_free(pkey);
     return ok;
 }
-#endif
 
 static int ms2key_export_object(void *vctx,
                                 const void *reference, size_t reference_sz,
@@ -278,12 +266,8 @@ static int ms2key_export_object(void *vctx,
 #ifndef OPENSSL_NO_DSA
 IMPLEMENT_TYPE("DSA", DSA, dsa, EVP_PKEY_get1_DSA, DSA_free);
 IMPLEMENT_MS(msblob, dsa);
-# ifndef OPENSSL_NO_RC4
 IMPLEMENT_MS(pvk, dsa);
-# endif
 #endif
 IMPLEMENT_TYPE("RSA", RSA, rsa, EVP_PKEY_get1_RSA, RSA_free);
 IMPLEMENT_MS(msblob, rsa);
-#ifndef OPENSSL_NO_RC4
 IMPLEMENT_MS(pvk, rsa);
-#endif

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -1,5 +1,5 @@
 d2i_EC_PUBKEY                           1	3_0_0	EXIST::FUNCTION:EC
-b2i_PVK_bio                             2	3_0_0	EXIST::FUNCTION:DSA,RC4
+b2i_PVK_bio                             2	3_0_0	EXIST::FUNCTION:
 PEM_read_bio_NETSCAPE_CERT_SEQUENCE     3	3_0_0	EXIST::FUNCTION:
 X509_STORE_CTX_get0_chain               4	3_0_0	EXIST::FUNCTION:
 COMP_expand_block                       5	3_0_0	EXIST::FUNCTION:COMP
@@ -209,7 +209,7 @@ RSA_X931_hash_id                        212	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3
 EC_KEY_set_method                       213	3_0_0	EXIST::FUNCTION:EC
 PEM_write_PKCS8_PRIV_KEY_INFO           214	3_0_0	EXIST::FUNCTION:STDIO
 X509at_get0_data_by_OBJ                 215	3_0_0	EXIST::FUNCTION:
-b2i_PublicKey_bio                       216	3_0_0	EXIST::FUNCTION:DSA
+b2i_PublicKey_bio                       216	3_0_0	EXIST::FUNCTION:
 s2i_ASN1_OCTET_STRING                   217	3_0_0	EXIST::FUNCTION:
 POLICYINFO_it                           218	3_0_0	EXIST::FUNCTION:
 OBJ_create                              219	3_0_0	EXIST::FUNCTION:
@@ -228,7 +228,7 @@ DIST_POINT_NAME_new                     231	3_0_0	EXIST::FUNCTION:
 X509_LOOKUP_file                        232	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_meth_set_decrypt               233	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
 EVP_rc2_ecb                             234	3_0_0	EXIST::FUNCTION:RC2
-i2b_PublicKey_bio                       235	3_0_0	EXIST::FUNCTION:DSA
+i2b_PublicKey_bio                       235	3_0_0	EXIST::FUNCTION:
 d2i_ASN1_SET_ANY                        236	3_0_0	EXIST::FUNCTION:
 ASN1_item_i2d                           238	3_0_0	EXIST::FUNCTION:
 OCSP_copy_nonce                         239	3_0_0	EXIST::FUNCTION:OCSP
@@ -1290,7 +1290,7 @@ RAND_event                              1318	3_0_0	EXIST:_WIN32:FUNCTION:DEPRECA
 i2d_PKCS12_fp                           1319	3_0_0	EXIST::FUNCTION:STDIO
 EVP_PKEY_meth_get_init                  1320	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
 X509_check_trust                        1321	3_0_0	EXIST::FUNCTION:
-b2i_PrivateKey                          1322	3_0_0	EXIST::FUNCTION:DSA
+b2i_PrivateKey                          1322	3_0_0	EXIST::FUNCTION:
 HMAC_Init_ex                            1323	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
 SMIME_read_CMS                          1324	3_0_0	EXIST::FUNCTION:CMS
 X509_subject_name_cmp                   1325	3_0_0	EXIST::FUNCTION:
@@ -1658,7 +1658,7 @@ ENGINE_ctrl_cmd                         1695	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_
 PKCS12_SAFEBAG_get_bag_nid              1696	3_0_0	EXIST::FUNCTION:
 TS_CONF_set_digests                     1697	3_0_0	EXIST::FUNCTION:TS
 PKCS7_SIGNED_it                         1698	3_0_0	EXIST::FUNCTION:
-b2i_PublicKey                           1699	3_0_0	EXIST::FUNCTION:DSA
+b2i_PublicKey                           1699	3_0_0	EXIST::FUNCTION:
 X509_PURPOSE_cleanup                    1700	3_0_0	EXIST::FUNCTION:
 ESS_SIGNING_CERT_dup                    1701	3_0_0	EXIST::FUNCTION:
 ENGINE_set_default_DSA                  1702	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,ENGINE
@@ -1812,7 +1812,7 @@ UI_method_set_reader                    1854	3_0_0	EXIST::FUNCTION:
 BIO_next                                1855	3_0_0	EXIST::FUNCTION:
 ASN1_STRING_set_default_mask_asc        1856	3_0_0	EXIST::FUNCTION:
 X509_CRL_new                            1857	3_0_0	EXIST::FUNCTION:
-i2b_PrivateKey_bio                      1858	3_0_0	EXIST::FUNCTION:DSA
+i2b_PrivateKey_bio                      1858	3_0_0	EXIST::FUNCTION:
 ASN1_STRING_length_set                  1859	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
 PEM_write_PKCS8                         1860	3_0_0	EXIST::FUNCTION:STDIO
 PKCS7_digest_from_attributes            1861	3_0_0	EXIST::FUNCTION:
@@ -2750,7 +2750,7 @@ ENGINE_register_all_DH                  2809	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_
 ERR_clear_error                         2810	3_0_0	EXIST::FUNCTION:
 EC_KEY_dup                              2811	3_0_0	EXIST::FUNCTION:EC
 X509_LOOKUP_init                        2812	3_0_0	EXIST::FUNCTION:
-i2b_PVK_bio                             2813	3_0_0	EXIST::FUNCTION:DSA,RC4
+i2b_PVK_bio                             2813	3_0_0	EXIST::FUNCTION:
 OCSP_ONEREQ_free                        2814	3_0_0	EXIST::FUNCTION:OCSP
 X509V3_EXT_print_fp                     2815	3_0_0	EXIST::FUNCTION:STDIO
 OBJ_bsearch_ex_                         2816	3_0_0	EXIST::FUNCTION:
@@ -3112,7 +3112,7 @@ i2d_PKCS7_bio_stream                    3176	3_0_0	EXIST::FUNCTION:
 i2a_ACCESS_DESCRIPTION                  3178	3_0_0	EXIST::FUNCTION:
 EC_KEY_set_enc_flags                    3179	3_0_0	EXIST::FUNCTION:EC
 i2d_PUBKEY_fp                           3180	3_0_0	EXIST::FUNCTION:STDIO
-b2i_PrivateKey_bio                      3181	3_0_0	EXIST::FUNCTION:DSA
+b2i_PrivateKey_bio                      3181	3_0_0	EXIST::FUNCTION:
 OCSP_REQUEST_add_ext                    3182	3_0_0	EXIST::FUNCTION:OCSP
 SXNET_add_id_INTEGER                    3183	3_0_0	EXIST::FUNCTION:
 CTLOG_get0_public_key                   3184	3_0_0	EXIST::FUNCTION:CT


### PR DESCRIPTION
All these functions are usable with RSA keys, there's no reason why
they should be unaccessible when DSA or RC4 are disabled.

When DSA is disabled, it's not possible to use these functions for
DSA EVP_PKEYs.  That's fine, and supported.

When RC4 is disabled, it's not possible to use these functions to
write encrypted PVK output.  That doesn't even depend on the
definition of OPENSSL_NO_RC4, but if the RC4 algorithm is accessible
via EVP, something that isn't known when building libcrypto.