### PR TITLE
OPENSSL_cpuid_setup FreeBSD arm update.

### DIFF
--- a/crypto/armcap.c
+++ b/crypto/armcap.c
@@ -71,6 +71,23 @@ void OPENSSL_cpuid_setup(void) __attribute__ ((constructor));
 #   define OSSL_IMPLEMENT_GETAUXVAL
 #  endif
 # endif
+# if defined(__FreeBSD__)
+#  include <sys/param.h>
+#  if __FreeBSD_version >= 1200000
+#   include <sys/auxv.h>
+#   define OSSL_IMPLEMENT_GETAUXVAL
+
+static unsigned long getauxval(unsigned long key)
+{
+  unsigned long val = 0ul;
+
+  if (elf_aux_info((int)key, &val, sizeof(val)) != 0)
+    return 0ul;
+
+  return val;
+}
+#  endif
+# endif
 
 /*
  * ARM puts the feature bits for Crypto Extensions in AT_HWCAP2, whereas


### PR DESCRIPTION
when possible using the getauxval equivalent which has similar ids as Linux, instead of bad instructions catch approach.