### PR TITLE
Optimize chacha20 for aarch64.

### DIFF
--- a/crypto/arm_arch.h
+++ b/crypto/arm_arch.h
@@ -72,6 +72,7 @@
 # ifndef __ASSEMBLER__
 extern unsigned int OPENSSL_armcap_P;
 extern unsigned int OPENSSL_arm_midr;
+extern unsigned int OPENSSL_arm_chacha_choose;
 # endif
 
 # define ARMV7_NEON      (1<<0)
@@ -95,6 +96,9 @@ extern unsigned int OPENSSL_arm_midr;
 
 # define ARM_CPU_IMP_ARM           0x41
 
+# define ARM_CPU_PART_CORTEX_A53   0xD03
+# define ARM_CPU_PART_CORTEX_A55   0xD05
+# define ARM_CPU_PART_CORTEX_A57   0xD07
 # define ARM_CPU_PART_CORTEX_A72   0xD08
 # define ARM_CPU_PART_N1           0xD0C
 

--- a/crypto/armcap.c
+++ b/crypto/armcap.c
@@ -19,6 +19,7 @@
 
 unsigned int OPENSSL_armcap_P = 0;
 unsigned int OPENSSL_arm_midr = 0;
+unsigned int OPENSSL_arm_chacha_choose = 0;
 
 #if __ARM_MAX_ARCH__<7
 void OPENSSL_cpuid_setup(void)
@@ -220,6 +221,13 @@ void OPENSSL_cpuid_setup(void)
 # ifdef __aarch64__
     if (OPENSSL_armcap_P & ARMV8_CPUID)
         OPENSSL_arm_midr = _armv8_cpuid_probe();
+
+    if (MIDR_IS_CPU_MODEL(OPENSSL_arm_midr, ARM_CPU_IMP_ARM, ARM_CPU_PART_CORTEX_A53)
+        || MIDR_IS_CPU_MODEL(OPENSSL_arm_midr, ARM_CPU_IMP_ARM, ARM_CPU_PART_CORTEX_A55)
+        || MIDR_IS_CPU_MODEL(OPENSSL_arm_midr, ARM_CPU_IMP_ARM, ARM_CPU_PART_CORTEX_A57)
+        || MIDR_IS_CPU_MODEL(OPENSSL_arm_midr, ARM_CPU_IMP_ARM, ARM_CPU_PART_CORTEX_A72)) {
+        OPENSSL_arm_chacha_choose = 1;
+    }
 # endif
 }
 #endif


### PR DESCRIPTION
Previous 6 * NEON + 2 * ALU code path is optimized for thunderx2, and
is suboptimal on most other platforms. Detecting micro architecture
at runtime and choosing suitable code path can help achieve best
performance.

This PR changes code path into 4 * NEON + 1 * ALU for A53, A55, A57
and A72(which is also commonly used in arm servers) cores.
Then chacha20_neon processes 320 bytes data at a time, and has
better overall performance.

Use MIDR_EL1 system register to determine cpu core at runtime.
Based on PR #11744.

Peformance changes after applying optimization:
                          A55     A53    A57    A72
chacha20@8192             +10.2%  +9.1%  +5.8%  +4.3%
chacha20@16384            +10.4%  +9.2%  +5.7%  +4.3%
chacha20-poly1305@8192    +7.4%   +6.7%  +4.6%  +3.3%
chacha20-poly1305@16384   +7.5%   +6.9%  +4.8%  +3.6%

Other cores don't change code path, and performance remains the
same(tested on Qualcomm SDA845).

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
