### PR TITLE
Ensure DTLS free functions can handle NULL

### DIFF
--- a/ssl/d1_lib.c
+++ b/ssl/d1_lib.c
@@ -142,10 +142,11 @@ void dtls1_free(SSL *s)
 
     ssl3_free(s);
 
-    dtls1_clear_queues(s);
-
-    pqueue_free(s->d1->buffered_messages);
-    pqueue_free(s->d1->sent_messages);
+    if (s->d1 != NULL) {
+        dtls1_clear_queues(s);
+        pqueue_free(s->d1->buffered_messages);
+        pqueue_free(s->d1->sent_messages);
+    }
 
     OPENSSL_free(s->d1);
     s->d1 = NULL;

--- a/ssl/record/rec_layer_d1.c
+++ b/ssl/record/rec_layer_d1.c
@@ -46,6 +46,9 @@ int DTLS_RECORD_LAYER_new(RECORD_LAYER *rl)
 
 void DTLS_RECORD_LAYER_free(RECORD_LAYER *rl)
 {
+    if (rl->d == NULL)
+        return;
+
     DTLS_RECORD_LAYER_clear(rl);
     pqueue_free(rl->d->unprocessed_rcds.q);
     pqueue_free(rl->d->processed_rcds.q);


### PR DESCRIPTION
Our free functions should be able to deal with the case where the object
being freed is NULL. This turns out to not be quite the case for DTLS
related objects.

Fixes #13649
