### PR TITLE
CMS: resolve the libctx if passed NULL

### DIFF
--- a/crypto/cms/cms_io.c
+++ b/crypto/cms/cms_io.c
@@ -38,7 +38,7 @@ CMS_ContentInfo *d2i_CMS_bio(BIO *bp, CMS_ContentInfo **cms)
     CMS_ContentInfo *ci;
 
     ci = ASN1_item_d2i_bio(ASN1_ITEM_rptr(CMS_ContentInfo), bp, cms);
-    if (ci != NULL && cms != NULL)
+    if (ci != NULL)
         cms_resolve_libctx(ci);
     return ci;
 }
@@ -97,7 +97,7 @@ CMS_ContentInfo *SMIME_read_CMS_ex(BIO *bio, BIO **bcont, CMS_ContentInfo **cms)
     ci = (CMS_ContentInfo *)SMIME_read_ASN1_ex(bio, bcont,
                                                ASN1_ITEM_rptr(CMS_ContentInfo),
                                                (ASN1_VALUE **)cms);
-    if (ci != NULL && cms != NULL)
+    if (ci != NULL)
         cms_resolve_libctx(ci);
     return ci;
 }

--- a/crypto/cms/cms_lib.c
+++ b/crypto/cms/cms_lib.c
@@ -30,7 +30,7 @@ CMS_ContentInfo *d2i_CMS_ContentInfo(CMS_ContentInfo **a,
 
     ci = (CMS_ContentInfo *)ASN1_item_d2i((ASN1_VALUE **)a, in, len,
                                           (CMS_ContentInfo_it()));
-    if (ci != NULL && a != NULL)
+    if (ci != NULL)
         cms_resolve_libctx(ci);
     return ci;
 }


### PR DESCRIPTION
d2i_CMS_bio(), d2i_CMS_ContentInfo() and SMIME_read_CMS_ex() would
behave differently if passed a cms == NULL or if *cms == NULL although
the API is such that both calls are effectively equivalent. Drop an
incorrect NULL check and resolve the libcontexts in both cases.
This could lead to a NULL pointer dereference in CMS_SignerInfo_verify()
via CMS_verify().

Fixes: #13624
CLA: trivial