### PR TITLE
Building: Fix the library file names for MSVC builds to include multilib

### DIFF
--- a/Configurations/platform/Windows/MSVC.pm
+++ b/Configurations/platform/Windows/MSVC.pm
@@ -14,6 +14,17 @@ use configdata;
 
 sub pdbext              { '.pdb' }
 
+# It's possible that this variant of |sharedname| should be in Windows.pm.
+# However, this variant was VC only in 1.1.1, so we maintain that here until
+# further notice.
+sub sharedname {
+    return platform::BASE::__concat(platform::BASE->sharedname($_[1]),
+                                    "-",
+                                    $_[0]->shlib_version_as_filename(),
+                                    ($target{multilib} // '' ),
+                                    ($_[0]->shlibvariant() // ''));
+}
+
 sub staticlibpdb {
     return platform::BASE::__concat($_[0]->staticname($_[1]), $_[0]->pdbext());
 }


### PR DESCRIPTION
In OpenSSL 1.1.1, VC-WIN64I and VC-WIN64A have a 'multilib' attribute
set, which affect the names of the produced libcrypto and libssl DLLs.
This restores that for OpenSSL 3.0.

Fixes #13659
