### PR TITLE
test: print OPENSSL_TEST_RAND_ORDER=x when a randomised test fails.

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -148,3 +148,23 @@ for `TAP::Harness` to know more.
 To run up to four tests in parallel at any given time:
 
     $ make HARNESS_JOBS=4 test
+
+Randomisation of Test Ordering
+------------------------------
+
+By default, the test harness will execute tests in the order they were added.
+By setting the `OPENSSL_TEST_RAND_ORDER` environment variable to zero, the
+test ordering will be randomised.  If a randomly ordered test fails, the
+seed value used will be reported.  Setting the `OPENSSL_TEST_RAND_ORDER`
+environment variable to this value will rerun the tests in the same
+order.  This assures repeatability of randomly ordered test runs.
+This repeatability is independent of the operating system, processor or
+platform used.
+
+To randomise the test ordering:
+
+    $ make OPENSSL_TEST_RAND_ORDER=0 test
+
+To run the tests using the order defined by the random seed `42`:
+
+    $ make OPENSSL_TEST_RAND_ORDER=42 test

--- a/test/testutil/driver.c
+++ b/test/testutil/driver.c
@@ -256,7 +256,7 @@ PRINTF_FORMAT(2, 3) static void test_verdict(int verdict,
     test_flush_stderr();
 
     if (verdict == 0 && seed != 0)
-        test_printf_tapout("# random seed: %d\n", seed);
+        test_printf_tapout("# OPENSSL_TEST_RAND_ORDER=%d\n", seed);
     test_printf_tapout("%s ", verdict != 0 ? "ok" : "not ok");
     va_start(ap, description);
     test_vprintf_tapout(description, ap);


### PR DESCRIPTION
The previous message "random seed x" is a lot less descriptive.

- [x] documentation is added or updated
- [x] tests are added or updated
