### PR TITLE
Update README.md with link to Binaries wiki page

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ of the OpenSSL toolkit are available. In particular on Linux and other
 Unix operating systems it is normally recommended to link against the
 precompiled shared libraries provided by the distributor or vendor.
 
+Some people have offered to provide OpenSSL binary distributions for
+selected operating systems. See the OpenSSL wiki page at [wiki.openssl.org/index.php/Binaries](https://wiki.openssl.org/index.php/Binaries)
+for more information.
+
 For Testing and Development
 ---------------------------
 


### PR DESCRIPTION
Add a link to the OpenSSL *Binaries* wiki page (https://wiki.openssl.org/index.php/Binaries) for those people seeking binaries to install. This link helps avoid the otherwise needed treasure hunt on the internet to find (reasonably) trusted binaries to install.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated

