### PR TITLE
Github CI: run also on repository pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: GitHub CI
 
-on: [pull_request]
+on: [pull_request, push]
 
 # for some reason, this does not work:
 # variables:


### PR DESCRIPTION
This is useful to have a history of builds to track regressions.
