### PR TITLE
Fix 'no-deprecated'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,17 @@ jobs:
     - name: make test
       run: make test HARNESS_JOBS=${HARNESS_JOBS:-4}
 
+  no-deprecated:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: config
+      run: ./config --strict-warnings no-deprecated && perl configdata.pm --dump
+    - name: make
+      run: make -s -j4
+    - name: make test
+      run: make test HARNESS_JOBS=${HARNESS_JOBS:-4}
+
   sanitizers:
     runs-on: ubuntu-latest
     steps:

--- a/Configure
+++ b/Configure
@@ -540,7 +540,7 @@ our %disabled = ( # "what"         => "comment"
 # Note: => pair form used for aesthetics, not to truly make a hash table
 my @disable_cascades = (
     # "what"            => [ "cascade", ... ]
-    "bulk"              => [ "deprecated", "shared", "dso",
+    "bulk"              => [ "shared", "dso",
                              "aria", "async", "autoload-config",
                              "blake2", "bf", "camellia", "cast", "chacha",
                              "cmac", "cms", "cmp", "comp", "ct",

--- a/crypto/asn1/i2d_evp.c
+++ b/crypto/asn1/i2d_evp.c
@@ -7,8 +7,11 @@
  * https://www.openssl.org/source/license.html
  */
 
-/* We need to use some deprecated APIs to support the legacy bits */
-#define OPENSSL_SUPPRESS_DEPRECATED
+/*
+ * Low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
 
 #include <stdio.h>
 #include "internal/cryptlib.h"
@@ -16,9 +19,7 @@
 #include <openssl/encoder.h>
 #include <openssl/buffer.h>
 #include <openssl/x509.h>
-#ifndef OPENSSL_NO_DEPRECATED_3_0
-# include <openssl/rsa.h>        /* For i2d_RSAPublicKey */
-#endif
+#include <openssl/rsa.h>         /* For i2d_RSAPublicKey */
 #include <openssl/dsa.h>         /* For i2d_DSAPublicKey */
 #include <openssl/ec.h>          /* For i2o_ECPublicKey */
 #include "crypto/asn1.h"
@@ -106,11 +107,9 @@ int i2d_PublicKey(const EVP_PKEY *a, unsigned char **pp)
         return i2d_provided(a, EVP_PKEY_PUBLIC_KEY, output_structures, pp);
     }
     switch (EVP_PKEY_id(a)) {
-#ifndef OPENSSL_NO_DEPRECATED_3_0
-# ifndef OPENSSL_NO_RSA
+#ifndef OPENSSL_NO_RSA
     case EVP_PKEY_RSA:
         return i2d_RSAPublicKey(EVP_PKEY_get0_RSA(a), pp);
-# endif
 #endif
 #ifndef OPENSSL_NO_DSA
     case EVP_PKEY_DSA:

--- a/fuzz/server.c
+++ b/fuzz/server.c
@@ -512,8 +512,8 @@ int FuzzerTestOneInput(const uint8_t *buf, size_t len)
     SSL *server;
     BIO *in;
     BIO *out;
-#if !defined(OPENSSL_NO_EC) || !defined(OPENSSL_NO_DSA) \
-    || !defined(OPENSSL_NO_DEPRECATED_3_0)
+#if !defined(OPENSSL_NO_EC)                     \
+    || (!defined(OPENSSL_NO_DSA) && !defined(OPENSSL_NO_DEPRECATED_3_0))
     BIO *bio_buf;
 #endif
     SSL_CTX *ctx;
@@ -522,7 +522,8 @@ int FuzzerTestOneInput(const uint8_t *buf, size_t len)
     RSA *privkey;
 #endif
     const uint8_t *bufp;
-#if (!defined(OPENSSL_NO_DSA) && !defined(OPENSSL_NO_DEPRECATED_3_0)) \
+#if !defined(OPENSSL_NO_DEPRECATED_3_0)         \
+    || !defined(OPENSSL_NO_DSA)                 \
     || !defined(OPENSSL_NO_EC)
     EVP_PKEY *pkey;
 #endif

--- a/fuzz/server.c
+++ b/fuzz/server.c
@@ -292,7 +292,7 @@ static const char ECDSACertPEM[] = {
 };
 #endif
 
-#if !defined(OPENSSL_NO_DSA) || !defined(OPENSSL_NO_DEPRECATED_3_0)
+#if !defined(OPENSSL_NO_DSA) && !defined(OPENSSL_NO_DEPRECATED_3_0)
 /*
  * -----BEGIN DSA PRIVATE KEY-----
  * MIIBuwIBAAKBgQDdkFKzNABLOha7Eqj7004+p5fhtR6bxpujToMmSZTYi8igVVXP
@@ -522,15 +522,15 @@ int FuzzerTestOneInput(const uint8_t *buf, size_t len)
     RSA *privkey;
 #endif
     const uint8_t *bufp;
-#if !defined(OPENSSL_NO_DSA) || !defined(OPENSSL_NO_EC) \
-    || !defined(OPENSSL_NO_DEPRECATED_3_0)
+#if (!defined(OPENSSL_NO_DSA) && !defined(OPENSSL_NO_DEPRECATED_3_0)) \
+    || !defined(OPENSSL_NO_EC)
     EVP_PKEY *pkey;
 #endif
     X509 *cert;
 #ifndef OPENSSL_NO_EC
     EC_KEY *ecdsakey = NULL;
 #endif
-#if !defined(OPENSSL_NO_DSA) || !defined(OPENSSL_NO_DEPRECATED_3_0)
+#if !defined(OPENSSL_NO_DSA) && !defined(OPENSSL_NO_DEPRECATED_3_0)
     DSA *dsakey = NULL;
 #endif
     uint8_t opt;
@@ -593,7 +593,7 @@ int FuzzerTestOneInput(const uint8_t *buf, size_t len)
     X509_free(cert);
 #endif
 
-#if !defined(OPENSSL_NO_DSA) || !defined(OPENSSL_NO_DEPRECATED_3_0)
+#if !defined(OPENSSL_NO_DSA) && !defined(OPENSSL_NO_DEPRECATED_3_0)
     /* DSA */
     bio_buf = BIO_new(BIO_s_mem());
     OPENSSL_assert((size_t)BIO_write(bio_buf, DSAPrivateKeyPEM, sizeof(DSAPrivateKeyPEM)) == sizeof(DSAPrivateKeyPEM));


### PR DESCRIPTION
Some of the handling of no-deprecated stuff wasn't quite complete, or
even plain wrong.

This restores i2d_PublicKey() to be able to handle EVP_PKEYs with
legacy internal keys.

This also refactors the DSA key tests in test/evp_extra_test.c to use
EVP functionality entirely.
