### PR TITLE
apps/openssl: add -propquery command line option

### DIFF
--- a/apps/genpkey.c
+++ b/apps/genpkey.c
@@ -68,7 +68,6 @@ int genpkey_main(int argc, char **argv)
     int outformat = FORMAT_PEM, text = 0, ret = 1, rv, do_param = 0;
     int private = 0;
     OSSL_LIB_CTX *libctx = app_get0_libctx();
-    const char *propq = app_get0_propq();
 
     prog = opt_init(argc, argv, genpkey_options);
     while ((o = opt_next()) != OPT_EOF) {
@@ -98,11 +97,11 @@ int genpkey_main(int argc, char **argv)
         case OPT_PARAMFILE:
             if (do_param == 1)
                 goto opthelp;
-            if (!init_keygen_file(&ctx, opt_arg(), e, libctx, propq))
+            if (!init_keygen_file(&ctx, opt_arg(), e, libctx, app_get0_propq()))
                 goto end;
             break;
         case OPT_ALGORITHM:
-            if (!init_gen_str(&ctx, opt_arg(), e, do_param, libctx, propq))
+            if (!init_gen_str(&ctx, opt_arg(), e, do_param, libctx, app_get0_propq()))
                 goto end;
             break;
         case OPT_PKEYOPT:

--- a/apps/include/apps.h
+++ b/apps/include/apps.h
@@ -323,6 +323,7 @@ int app_provider_load(OSSL_LIB_CTX *libctx, const char *provider_name);
 void app_providers_cleanup(void);
 
 OSSL_LIB_CTX *app_get0_libctx(void);
+int app_set_propq(const char *arg);
 const char *app_get0_propq(void);
 
 #endif

--- a/apps/include/opt.h
+++ b/apps/include/opt.h
@@ -270,7 +270,7 @@
  */
 # define OPT_PROV_ENUM \
         OPT_PROV__FIRST=1600, \
-        OPT_PROV_PROVIDER, OPT_PROV_PROVIDER_PATH, \
+        OPT_PROV_PROVIDER, OPT_PROV_PROVIDER_PATH, OPT_PROV_PROPQUERY, \
         OPT_PROV__LAST
 
 # define OPT_CONFIG_OPTION \
@@ -279,12 +279,14 @@
 # define OPT_PROV_OPTIONS \
         OPT_SECTION("Provider"), \
         { "provider-path", OPT_PROV_PROVIDER_PATH, 's', "Provider load path (must be before 'provider' argument if required)" }, \
-        { "provider", OPT_PROV_PROVIDER, 's', "Provider to load (can be specified multiple times)" }
+        { "provider", OPT_PROV_PROVIDER, 's', "Provider to load (can be specified multiple times)" }, \
+        { "propquery", OPT_PROV_PROPQUERY, 's', "Property query used when fetching algorithms" }
 
 # define OPT_PROV_CASES \
         OPT_PROV__FIRST: case OPT_PROV__LAST: break; \
         case OPT_PROV_PROVIDER: \
-        case OPT_PROV_PROVIDER_PATH
+        case OPT_PROV_PROVIDER_PATH: \
+        case OPT_PROV_PROPQUERY
 
 /*
  * Option parsing.

--- a/apps/lib/app_provider.c
+++ b/apps/lib/app_provider.c
@@ -70,6 +70,8 @@ int opt_provider(int opt)
         return app_provider_load(app_get0_libctx(), opt_arg());
     case OPT_PROV_PROVIDER_PATH:
         return opt_provider_path(opt_arg());
+    case OPT_PROV_PROPQUERY:
+        return app_set_propq(opt_arg());
     }
     return 0;
 }

--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -331,10 +331,17 @@ OSSL_LIB_CTX *app_get0_libctx(void)
     return app_libctx;
 }
 
-/* TODO(3.0): Make this an environment variable if required */
+static const char *app_propq = NULL;
+
+int app_set_propq(const char *arg)
+{
+    app_propq = arg;
+    return 1;
+}
+
 const char *app_get0_propq(void)
 {
-    return NULL;
+    return app_propq;
 }
 
 OSSL_LIB_CTX *app_create_libctx(void)

--- a/apps/mac.c
+++ b/apps/mac.c
@@ -105,7 +105,7 @@ opthelp:
     if (argc != 1)
         goto opthelp;
 
-    mac = EVP_MAC_fetch(NULL, argv[0], NULL);
+    mac = EVP_MAC_fetch(app_get0_libctx(), argv[0], app_get0_propq());
     if (mac == NULL) {
         BIO_printf(bio_err, "Invalid MAC name %s\n", argv[0]);
         goto opthelp;

--- a/apps/pkcs7.c
+++ b/apps/pkcs7.c
@@ -61,7 +61,6 @@ int pkcs7_main(int argc, char **argv)
     int i, print_certs = 0, text = 0, noout = 0, p7_print = 0, ret = 1;
     OPTION_CHOICE o;
     OSSL_LIB_CTX *libctx = app_get0_libctx();
-    const char *propq = app_get0_propq();
 
     prog = opt_init(argc, argv, pkcs7_options);
     while ((o = opt_next()) != OPT_EOF) {
@@ -120,7 +119,7 @@ int pkcs7_main(int argc, char **argv)
     if (in == NULL)
         goto end;
 
-    p7 = PKCS7_new_ex(libctx, propq);
+    p7 = PKCS7_new_ex(libctx, app_get0_propq());
     if (p7 == NULL) {
         BIO_printf(bio_err, "unable to allocate PKCS7 object\n");
         ERR_print_errors(bio_err);

--- a/apps/pkeyutl.c
+++ b/apps/pkeyutl.c
@@ -24,7 +24,7 @@ static EVP_PKEY_CTX *init_ctx(const char *kdfalg, int *pkeysize,
                               const char *keyfile, int keyform, int key_type,
                               char *passinarg, int pkey_op, ENGINE *e,
                               const int impl, int rawin, EVP_PKEY **ppkey,
-                              OSSL_LIB_CTX *libctx, const char *propq);
+                              OSSL_LIB_CTX *libctx);
 
 static int setup_peer(EVP_PKEY_CTX *ctx, int peerform, const char *file,
                       ENGINE *e);
@@ -125,7 +125,6 @@ int pkeyutl_main(int argc, char **argv)
     const EVP_MD *md = NULL;
     int filesize = -1;
     OSSL_LIB_CTX *libctx = app_get0_libctx();
-    const char *propq = NULL;
 
     prog = opt_init(argc, argv, pkeyutl_options);
     while ((o = opt_next()) != OPT_EOF) {
@@ -293,7 +292,7 @@ int pkeyutl_main(int argc, char **argv)
     }
     ctx = init_ctx(kdfalg, &keysize, inkey, keyform, key_type,
                    passinarg, pkey_op, e, engine_impl, rawin, &pkey,
-                   libctx, propq);
+                   libctx);
     if (ctx == NULL) {
         BIO_printf(bio_err, "%s: Error initializing context\n", prog);
         ERR_print_errors(bio_err);
@@ -514,7 +513,7 @@ static EVP_PKEY_CTX *init_ctx(const char *kdfalg, int *pkeysize,
                               char *passinarg, int pkey_op, ENGINE *e,
                               const int engine_impl, int rawin,
                               EVP_PKEY **ppkey,
-                              OSSL_LIB_CTX *libctx, const char *propq)
+                              OSSL_LIB_CTX *libctx)
 {
     EVP_PKEY *pkey = NULL;
     EVP_PKEY_CTX *ctx = NULL;
@@ -522,6 +521,7 @@ static EVP_PKEY_CTX *init_ctx(const char *kdfalg, int *pkeysize,
     char *passin = NULL;
     int rv = -1;
     X509 *x;
+
     if (((pkey_op == EVP_PKEY_OP_SIGN) || (pkey_op == EVP_PKEY_OP_DECRYPT)
          || (pkey_op == EVP_PKEY_OP_DERIVE))
         && (key_type != KEY_PRIVKEY && kdfalg == NULL)) {
@@ -573,7 +573,7 @@ static EVP_PKEY_CTX *init_ctx(const char *kdfalg, int *pkeysize,
         if (impl != NULL)
             ctx = EVP_PKEY_CTX_new_id(kdfnid, impl);
         else
-            ctx = EVP_PKEY_CTX_new_from_name(libctx, kdfalg, propq);
+            ctx = EVP_PKEY_CTX_new_from_name(libctx, kdfalg, app_get0_propq());
     } else {
         if (pkey == NULL)
             goto end;
@@ -582,7 +582,7 @@ static EVP_PKEY_CTX *init_ctx(const char *kdfalg, int *pkeysize,
         if (impl != NULL)
             ctx = EVP_PKEY_CTX_new(pkey, impl);
         else
-            ctx = EVP_PKEY_CTX_new_from_pkey(libctx, pkey, propq);
+            ctx = EVP_PKEY_CTX_new_from_pkey(libctx, pkey, app_get0_propq());
         if (ppkey != NULL)
             *ppkey = pkey;
         EVP_PKEY_free(pkey);

--- a/apps/smime.c
+++ b/apps/smime.c
@@ -155,7 +155,6 @@ int smime_main(int argc, char **argv)
     ENGINE *e = NULL;
     const char *mime_eol = "\n";
     OSSL_LIB_CTX *libctx = app_get0_libctx();
-    const char *propq = app_get0_propq();
 
     if ((vpm = X509_VERIFY_PARAM_new()) == NULL)
         return 1;
@@ -495,7 +494,7 @@ int smime_main(int argc, char **argv)
     if (operation & SMIME_IP) {
         PKCS7 *p7_in = NULL;
 
-        p7 = PKCS7_new_ex(libctx, propq);
+        p7 = PKCS7_new_ex(libctx, app_get0_propq());
         if (p7 == NULL) {
             BIO_printf(bio_err, "Error allocating PKCS7 object\n");
             goto end;
@@ -542,7 +541,7 @@ int smime_main(int argc, char **argv)
     if (operation == SMIME_ENCRYPT) {
         if (indef)
             flags |= PKCS7_STREAM;
-        p7 = PKCS7_encrypt_ex(encerts, in, cipher, flags, libctx, propq);
+        p7 = PKCS7_encrypt_ex(encerts, in, cipher, flags, libctx, app_get0_propq());
     } else if (operation & SMIME_SIGNERS) {
         int i;
         /*
@@ -557,7 +556,7 @@ int smime_main(int argc, char **argv)
                 flags |= PKCS7_STREAM;
             }
             flags |= PKCS7_PARTIAL;
-            p7 = PKCS7_sign_ex(NULL, NULL, other, in, flags, libctx, propq);
+            p7 = PKCS7_sign_ex(NULL, NULL, other, in, flags, libctx, app_get0_propq());
             if (p7 == NULL)
                 goto end;
             if (flags & PKCS7_NOCERTS) {

--- a/apps/storeutl.c
+++ b/apps/storeutl.c
@@ -19,7 +19,7 @@
 static int process(const char *uri, const UI_METHOD *uimeth, PW_CB_DATA *uidata,
                    int expected, int criterion, OSSL_STORE_SEARCH *search,
                    int text, int noout, int recursive, int indent, BIO *out,
-                   const char *prog, OSSL_LIB_CTX *libctx, const char *propq);
+                   const char *prog, OSSL_LIB_CTX *libctx);
 
 typedef enum OPTION_choice {
     OPT_ERR = -1, OPT_EOF = 0, OPT_HELP, OPT_ENGINE, OPT_OUT, OPT_PASSIN,
@@ -85,7 +85,6 @@ int storeutl_main(int argc, char *argv[])
     OSSL_STORE_SEARCH *search = NULL;
     const EVP_MD *digest = NULL;
     OSSL_LIB_CTX *libctx = app_get0_libctx();
-    const char *propq = app_get0_propq();
 
     while ((o = opt_next()) != OPT_EOF) {
         switch (o) {
@@ -315,7 +314,7 @@ int storeutl_main(int argc, char *argv[])
 
     ret = process(argv[0], get_ui_method(), &pw_cb_data,
                   expected, criterion, search,
-                  text, noout, recursive, 0, out, prog, libctx, propq);
+                  text, noout, recursive, 0, out, prog, libctx);
 
  end:
     OPENSSL_free(fingerprint);
@@ -346,12 +345,12 @@ static int indent_printf(int indent, BIO *bio, const char *format, ...)
 static int process(const char *uri, const UI_METHOD *uimeth, PW_CB_DATA *uidata,
                    int expected, int criterion, OSSL_STORE_SEARCH *search,
                    int text, int noout, int recursive, int indent, BIO *out,
-                   const char *prog, OSSL_LIB_CTX *libctx, const char *propq)
+                   const char *prog, OSSL_LIB_CTX *libctx)
 {
     OSSL_STORE_CTX *store_ctx = NULL;
     int ret = 1, items = 0;
 
-    if ((store_ctx = OSSL_STORE_open_ex(uri, libctx, propq, uimeth, uidata,
+    if ((store_ctx = OSSL_STORE_open_ex(uri, libctx, app_get0_propq(), uimeth, uidata,
                                         NULL, NULL))
         == NULL) {
         BIO_printf(bio_err, "Couldn't open file or uri %s\n", uri);
@@ -436,7 +435,7 @@ static int process(const char *uri, const UI_METHOD *uimeth, PW_CB_DATA *uidata,
                 ret += process(suburi, uimeth, uidata,
                                expected, criterion, search,
                                text, noout, recursive, indent + 2, out, prog,
-                               libctx, propq);
+                               libctx);
             }
             break;
         case OSSL_STORE_INFO_PARAMS:

--- a/doc/man1/openssl.pod
+++ b/doc/man1/openssl.pod
@@ -639,6 +639,26 @@ the PKCS#11 URI as defined in RFC 7512 should be possible to use directly:
 
     -key pkcs11:object=some-private-key;pin-value=1234
 
+=head2 Provider Options
+
+=over 4
+
+=item B<-provider> I<name>
+
+Load and initialize the provider identified by I<name>.
+
+=item B<-provider-path> I<path>
+
+Specifies the search path that is to be used for looking for providers.
+
+=item B<-propquery> I<propq>
+
+Specifies the I<property query clause> to be used when fetching algorithms
+from the loaded providers.
+See L<property(7)> for a more detailed description.
+
+=back
+
 =head1 ENVIRONMENT
 
 The OpenSSL library can be take some configuration parameters from the

--- a/doc/perlvars.pm
+++ b/doc/perlvars.pm
@@ -93,11 +93,14 @@ $OpenSSL::safe::opt_r_item = ""
 # Provider options
 $OpenSSL::safe::opt_provider_synopsis = ""
 . "[B<-provider> I<name>]\n"
-. "[B<-provider-path> I<path>]";
+. "[B<-provider-path> I<path>]\n"
+. "[B<-propquery> I<propq>]";
 $OpenSSL::safe::opt_provider_item = ""
 . "=item B<-provider> I<name>\n"
 . "\n"
 . "=item B<-provider-path> I<path>\n"
+. "\n"
+. "=item B<-propquery> I<propq>\n"
 . "\n"
 . "See L<openssl(1)/Provider Options>.";
 

--- a/test/recipes/15-test_genrsa.t
+++ b/test/recipes/15-test_genrsa.t
@@ -26,7 +26,7 @@ my $no_fips = disabled('fips') || ($ENV{NO_FIPS} // 0);
 
 plan tests =>
     ($no_fips ? 0 : 2)          # FIPS install test + fips related test
-    + 12;
+    + 13;
 
 # We want to know that an absurdly small number of bits isn't support
 if (disabled("deprecated-3.0")) {
@@ -101,6 +101,9 @@ ok(!run(app([ 'openssl', 'genpkey', '-algorithm', 'RSA',
              '-pkeyopt', 'e:65538',
              '-out', 'genrsatest.pem' ])),
    "genpkey with a even public exponent should fail");
+ok(!run(app([ 'openssl', 'genpkey', '-propquery', 'unknown',
+             '-algorithm', 'RSA' ])),
+   "genpkey requesting unknown=yes property should fail");
 
 
  SKIP: {

--- a/test/recipes/20-test_mac.t
+++ b/test/recipes/20-test_mac.t
@@ -78,6 +78,11 @@ my @mac_fail_tests = (
       input => '00',
       err => 'EVP_MAC_Init',
       desc => 'KMAC128 Fail no key' },
+    { cmd => [qw{openssl mac -propquery unknown -macopt hexkey:404142434445464748494A4B4C4D4E4F505152535455565758595A5B5C5D5E5F}],
+      type => 'KMAC128',
+      input => '00',
+      err => 'Invalid MAC name KMAC128',
+      desc => 'KMAC128 Fail unknown property' },
 );
 
 my @siphash_fail_tests = (


### PR DESCRIPTION
Fixes #13656. Right now all openssl commands use a NULL propq. This patch adds a possibility to specify a custom propq in a command line option. The implementation follows the example of set_nameopt/get_nameopt.

Also, the `app_get0_propq()` needs to be called after the command line arguments have been processed. I see no point in loading a global variable into a local variable here, so the app_get0_propq() is called everytime a propq is needed. The `apps/pkcs12.c` has already been using this approach.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [X] tests are added or updated
