### PR TITLE
X509 app: major cleanup of user guidance, documentation, and code structure

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -914,19 +914,25 @@ OpenSSL 3.0
 
    *Richard Levitte*
 
- * Added the `<-copy_extensions` option to the `req` command for use with `-x509`.
-   When given with the `copy` or `copyall` argument,
-   any extensions present in the certification request are copied to the certificate.
+ * Added the `-copy_extensions` option to the `x509` command for use with
+   `-req` and `-x509toreq`. When given with the `copy` or `copyall` argument,
+   all extensions in the request are copied to the certificate or vice versa.
+
+   *David von Oheimb*, *Kirill Stefanenkov <kirill_stefanenkov@rambler.ru>*
+
+ * Added the `-copy_extensions` option to the `req` command for use with
+   `-x509`. When given with the `copy` or `copyall` argument,
+   all extensions in the certification request are copied to the certificate.
 
    *David von Oheimb*
 
- * The `x509`, `req`, and `ca` commands now make sure that certificates they
-   generate are RFC 5280 compliant by default: For X.509 version 3 certs they ensure that
-   a subjectKeyIdentifier extension is included containing a hash value of the public key
-   and an authorityKeyIdentifier extension is included for not self-signed certs
-   containing a keyIdentifier field with the hash value identifying the signing key.
+ * The `x509`, `req`, and `ca` commands now make sure that X.509v3 certificates
+   they generate are by default RFC 5280 compliant in the following sense:
+   There is a subjectKeyIdentifier extension with a hash value of the public key
+   and for not self-signed certs there is an authorityKeyIdentifier extension
+   with a keyIdentifier field or issuer information identifying the signing key.
    This is done unless some configuration overrides the new default behavior,
-   e.g. `authorityKeyIdentifier = none`.
+   such as `subjectKeyIdentifier = none` and `authorityKeyIdentifier = none`.
 
    *David von Oheimb*
 

--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -989,10 +989,7 @@ int copy_extensions(X509 *x, X509_REQ *req, int copy_type)
                 continue;
             /* Delete all extensions of same type */
             do {
-                X509_EXTENSION *tmpext = X509_get_ext(x, idx);
-
-                X509_delete_ext(x, idx);
-                X509_EXTENSION_free(tmpext);
+                X509_EXTENSION_free(X509_delete_ext(x, idx));
                 idx = X509_get_ext_by_OBJ(x, obj, -1);
             } while (idx != -1);
         }

--- a/crypto/ct/ct_sct_ctx.c
+++ b/crypto/ct/ct_sct_ctx.c
@@ -168,15 +168,12 @@ int SCT_CTX_set1_cert(SCT_CTX *sctx, X509 *cert, X509 *presigner)
      * SCT.
      */
     if (idx >= 0) {
-        X509_EXTENSION *ext;
-
         /* Take a copy of certificate so we don't modify passed version */
         pretmp = X509_dup(cert);
         if (pretmp == NULL)
             goto err;
 
-        ext = X509_delete_ext(pretmp, idx);
-        X509_EXTENSION_free(ext);
+        X509_EXTENSION_free(X509_delete_ext(pretmp, idx));
 
         if (!ct_x509_cert_fixup(pretmp, presigner))
             goto err;

--- a/crypto/x509/t_req.c
+++ b/crypto/x509/t_req.c
@@ -108,7 +108,7 @@ int X509_REQ_print_ex(BIO *bp, X509_REQ *x, unsigned long nmflags,
             goto err;
 
         if (X509_REQ_get_attr_count(x) == 0) {
-            if (BIO_printf(bp, "%12sa0:00\n", "") <= 0)
+            if (BIO_printf(bp, "%12s(none)\n", "") <= 0)
                 goto err;
         } else {
             for (i = 0; i < X509_REQ_get_attr_count(x); i++) {

--- a/crypto/x509/t_req.c
+++ b/crypto/x509/t_req.c
@@ -166,14 +166,14 @@ int X509_REQ_print_ex(BIO *bp, X509_REQ *x, unsigned long nmflags,
     if (!(cflag & X509_FLAG_NO_EXTENSIONS)) {
         exts = X509_REQ_get_extensions(x);
         if (exts) {
-            if (BIO_printf(bp, "%8sRequested Extensions:\n", "") <= 0)
+            if (BIO_printf(bp, "%12sRequested Extensions:\n", "") <= 0)
                 goto err;
             for (i = 0; i < sk_X509_EXTENSION_num(exts); i++) {
                 ASN1_OBJECT *obj;
                 X509_EXTENSION *ex;
                 int critical;
                 ex = sk_X509_EXTENSION_value(exts, i);
-                if (BIO_printf(bp, "%12s", "") <= 0)
+                if (BIO_printf(bp, "%16s", "") <= 0)
                     goto err;
                 obj = X509_EXTENSION_get_object(ex);
                 if (i2a_ASN1_OBJECT(bp, obj) <= 0)
@@ -181,8 +181,8 @@ int X509_REQ_print_ex(BIO *bp, X509_REQ *x, unsigned long nmflags,
                 critical = X509_EXTENSION_get_critical(ex);
                 if (BIO_printf(bp, ": %s\n", critical ? "critical" : "") <= 0)
                     goto err;
-                if (!X509V3_EXT_print(bp, ex, cflag, 16)) {
-                    if (BIO_printf(bp, "%16s", "") <= 0
+                if (!X509V3_EXT_print(bp, ex, cflag, 20)) {
+                    if (BIO_printf(bp, "%20s", "") <= 0
                         || ASN1_STRING_print(bp,
                                              X509_EXTENSION_get_data(ex)) <= 0)
                         goto err;

--- a/crypto/x509/v3_conf.c
+++ b/crypto/x509/v3_conf.c
@@ -295,12 +295,8 @@ static void delete_ext(STACK_OF(X509_EXTENSION) *sk, X509_EXTENSION *dext)
     ASN1_OBJECT *obj;
 
     obj = X509_EXTENSION_get_object(dext);
-    while ((idx = X509v3_get_ext_by_OBJ(sk, obj, -1)) >= 0) {
-        X509_EXTENSION *tmpext = X509v3_get_ext(sk, idx);
-
-        X509v3_delete_ext(sk, idx);
-        X509_EXTENSION_free(tmpext);
-    }
+    while ((idx = X509v3_get_ext_by_OBJ(sk, obj, -1)) >= 0)
+        X509_EXTENSION_free(X509v3_delete_ext(sk, idx));
 }
 
 /*

--- a/crypto/x509/x509_req.c
+++ b/crypto/x509/x509_req.c
@@ -164,15 +164,15 @@ STACK_OF(X509_EXTENSION) *X509_REQ_get_extensions(X509_REQ *req)
  * Add a STACK_OF extensions to a certificate request: allow alternative OIDs
  * in case we want to create a non standard one.
  */
-
-int X509_REQ_add_extensions_nid(X509_REQ *req, STACK_OF(X509_EXTENSION) *exts,
-                                int nid)
+int X509_REQ_add_extensions_nid(X509_REQ *req,
+                                const STACK_OF(X509_EXTENSION) *exts, int nid)
 {
     int extlen;
     int rv = 0;
     unsigned char *ext = NULL;
+
     /* Generate encoding of extensions */
-    extlen = ASN1_item_i2d((ASN1_VALUE *)exts, &ext,
+    extlen = ASN1_item_i2d((const ASN1_VALUE *)exts, &ext,
                            ASN1_ITEM_rptr(X509_EXTENSIONS));
     if (extlen <= 0)
         return 0;
@@ -182,7 +182,7 @@ int X509_REQ_add_extensions_nid(X509_REQ *req, STACK_OF(X509_EXTENSION) *exts,
 }
 
 /* This is the normal usage: use the "official" OID */
-int X509_REQ_add_extensions(X509_REQ *req, STACK_OF(X509_EXTENSION) *exts)
+int X509_REQ_add_extensions(X509_REQ *req, const STACK_OF(X509_EXTENSION) *exts)
 {
     return X509_REQ_add_extensions_nid(req, exts, NID_ext_req);
 }

--- a/doc/man1/openssl-x509.pod.in
+++ b/doc/man1/openssl-x509.pod.in
@@ -145,7 +145,11 @@ Determines how to handle X.509 extensions
 when converting from a certificate to a request using the B<-x509toreq> option
 or converting from a request to a certificate using the B<-req> option.
 If I<arg> is B<none> or this option is not present then extensions are ignored.
-If I<arg> is B<copy> or B<copyall> then all extensions are copied.
+If I<arg> is B<copy> or B<copyall> then all extensions are copied,
+except that subject identifier and authority key identifier extensions
+are not taken over when producing a certificate request.
+
+The B<-ext> option can be used to further restrict which extensions to copy.
 
 =item B<-inform> B<DER>|B<PEM>
 
@@ -283,7 +287,9 @@ as used by OpenSSL before version 1.0.0.
 
 =item B<-ext> I<extensions>
 
-Prints out the certificate extensions in text form. Extensions are specified
+Prints out the certificate extensions in text form.
+Can also be used to restrict which extensions to copy.
+Extensions are specified
 with a comma separated string, e.g., "subjectAltName,subjectKeyIdentifier".
 See the L<x509v3_config(5)> manual page for the extension names.
 
@@ -395,22 +401,21 @@ generate a certificate containing any desired public key.
 
 =item B<-clrext>
 
-When a transforming a certificate to a new certificate
-(for example with the B<-signkey> or B<-CA> option)
-by default all certificate extensions are retained
-except for any subject identifier and authority key identifier.
-For those, new values are generated unless prohibited by configuration.
+When transforming a certificate to a new certificate
+by default all certificate extensions are retained.
 
-When producing a certificate with the B<-clrext> option,
-any extensions are deleted.
+When transforming a certificate or certificate request,
+the B<-clrext> option prevents taking over any extensions from the source.
+In any case, when producing a certificate request,
+neither subject identifier nor authority key identifier extensions are included.
 
 =item B<-extfile> I<filename>
 
-Configuration file containing certificate extensions to add.
+Configuration file containing certificate and request X.509 extensions to add.
 
 =item B<-extensions> I<section>
 
-The section in the extfile to add certificate extensions from.
+The section in the extfile to add X.509 extensions from.
 If this option is not
 specified then the extensions should either be contained in the unnamed
 (default) section or the default section should contain a variable called
@@ -421,7 +426,8 @@ extension section format.
 =item B<-sigopt> I<nm>:I<v>
 
 Pass options to the signature algorithm during sign operations.
-Names and values of these options are algorithm-specific.
+This option may be given multiple times.
+Names and values provided using this option are algorithm-specific.
 
 =item B<-badsig>
 

--- a/doc/man1/openssl-x509.pod.in
+++ b/doc/man1/openssl-x509.pod.in
@@ -488,7 +488,10 @@ extension section format.
 
 Generate a certificate from scratch, not using an input certificate
 or certificate request. So the B<-in> option must not be used in this case.
-Instead, the B<-subj> and <-force_pubkey> options need to be given.
+Instead, the B<-subj> option needs to be given.
+The public key to include defaults to the key given with the B<-signkey> option,
+which implies self-signature.
+It may also be given explicity using the B<-force_pubkey> option.
 
 =item B<-next_serial>
 

--- a/doc/man1/openssl-x509.pod.in
+++ b/doc/man1/openssl-x509.pod.in
@@ -9,70 +9,70 @@ openssl-x509 - Certificate display and signing command
 
 B<openssl> B<x509>
 [B<-help>]
+[B<-in> I<filename>|I<uri>]
+[B<-passin> I<arg>]
+[B<-new>]
+[B<-x509toreq>]
+[B<-req>]
 [B<-inform> B<DER>|B<PEM>]
-[B<-outform> B<DER>|B<PEM>]
+[B<-vfyopt> I<nm>:I<v>]
+[B<-signkey> I<filename>|I<uri>]
 [B<-keyform> B<DER>|B<PEM>|B<P12>|B<ENGINE>]
-[B<-CAform> B<DER>|B<PEM>|B<P12>]
-[B<-CAkeyform> B<DER>|B<PEM>|B<P12>|B<ENGINE>]
-[B<-in> I<filename>]
 [B<-out> I<filename>]
+[B<-outform> B<DER>|B<PEM>]
+[B<-nocert>]
+[B<-noout>]
+[B<-text>]
+[B<-certopt> I<option>]
+[B<-fingerprint>]
+[B<-alias>]
 [B<-serial>]
+[B<-startdate>]
+[B<-enddate>]
+[B<-dates>]
+[B<-subject>]
+[B<-issuer>]
+{- $OpenSSL::safe::opt_name_synopsis -}
+[B<-email>]
 [B<-hash>]
 [B<-subject_hash>]
 [B<-subject_hash_old>]
 [B<-issuer_hash>]
 [B<-issuer_hash_old>]
-[B<-ocspid>]
-[B<-subject>]
-[B<-issuer>]
-[B<-email>]
-[B<-ocsp_uri>]
-[B<-startdate>]
-[B<-enddate>]
-[B<-purpose>]
-[B<-dates>]
-[B<-checkend> I<num>]
-[B<-modulus>]
-[B<-pubkey>]
-[B<-fingerprint>]
-[B<-alias>]
-[B<-noout>]
-[B<-trustout>]
-[B<-clrtrust>]
-[B<-clrreject>]
-[B<-addtrust> I<arg>]
-[B<-addreject> I<arg>]
-[B<-setalias> I<arg>]
-[B<-days> I<arg>]
-[B<-set_serial> I<n>]
-[B<-signkey> I<filename>|I<uri>]
-[B<-badsig>]
-[B<-passin> I<arg>]
-[B<-x509toreq>]
-[B<-req>]
-[B<-CA> I<filename>]
-[B<-CAkey> I<filename>|I<uri>]
-[B<-CAcreateserial>]
-[B<-CAserial> I<filename>]
-[B<-new>]
-[B<-next_serial>]
-[B<-nocert>]
-[B<-force_pubkey> I<filename>]
-[B<-subj> I<arg>]
-[B<-text>]
 [B<-ext> I<extensions>]
-[B<-certopt> I<option>]
+[B<-ocspid>]
+[B<-ocsp_uri>]
+[B<-purpose>]
+[B<-pubkey>]
+[B<-modulus>]
+[B<-checkend> I<num>]
 [B<-checkhost> I<host>]
 [B<-checkemail> I<host>]
 [B<-checkip> I<ipaddr>]
-[B<-I<digest>>]
+[B<-set_serial> I<n>]
+[B<-next_serial>]
+[B<-days> I<arg>]
+[B<-preserve_dates>]
+[B<-subj> I<arg>]
+[B<-force_pubkey> I<filename>]
 [B<-clrext>]
 [B<-extfile> I<filename>]
 [B<-extensions> I<section>]
 [B<-sigopt> I<nm>:I<v>]
-[B<-vfyopt> I<nm>:I<v>]
-[B<-preserve_dates>]
-{- $OpenSSL::safe::opt_name_synopsis -}
+[B<-badsig>]
+[B<-I<digest>>]
+[B<-CA> I<filename>|I<uri>]
+[B<-CAform> B<DER>|B<PEM>|B<P12>]
+[B<-CAkey> I<filename>|I<uri>]
+[B<-CAkeyform> B<DER>|B<PEM>|B<P12>|B<ENGINE>]
+[B<-CAserial> I<filename>]
+[B<-CAcreateserial>]
+[B<-trustout>]
+[B<-setalias> I<arg>]
+[B<-clrtrust>]
+[B<-addtrust> I<arg>]
+[B<-clrreject>]
+[B<-addreject> I<arg>]
 {- $OpenSSL::safe::opt_r_synopsis -}
 {- $OpenSSL::safe::opt_engine_synopsis -}{- $OpenSSL::safe::opt_provider_synopsis -}
 
@@ -80,10 +80,11 @@ B<openssl> B<x509>
 
 =head1 DESCRIPTION
 
-This command is a multi-purposes certificate command. It can
-be used to display certificate information, convert certificates to
-various forms, sign certificate requests like a "mini CA" or edit
-certificate trust settings.
+This command is a multi-purposes certificate handling command.
+It can be used to print certificate information,
+convert certificates to various forms, edit certificate trust settings,
+generate certificates from scratch or from certificating requests
+and then self-signing them or signing them like a "micro CA".
 
 Since there are a large number of options they will split up into
 various sections.
@@ -98,152 +99,131 @@ various sections.
 
 Print out a usage message.
 
+=item B<-in> I<filename>|I<uri>
+
+If the B<-req> option is not used this specifies the input
+to read a certificate from or standard input if this option is not specified.
+With the B<-req> option this specifies a certificate request file.
+
+=item B<-passin> I<arg>
+
+The key and certificate file password source.
+For more information about the format of I<arg>
+see L<openssl-passphrase-options(1)>.
+
+=item B<-new>
+
+Generate a certificate from scratch, not using an input certificate
+or certificate request. So the B<-in> option must not be used in this case.
+Instead, the B<-subj> option needs to be given.
+The public key to include can be given with the B<-force_pubkey> option
+and defaults to the key given with the B<-signkey> option,
+which implies self-signature.
+
+=item B<-x509toreq>
+
+Output a certificate request (rather than a certificate).
+The B<-signkey> option must be used to provide the private key for self-signing;
+the corresponding public key is placed in the subjectPKInfo field.
+
+Any X.509 extensions included in an input file are ignored.
+X.509 extensions to be added can be specified using the B<-extfile> option.
+
+=item B<-req>
+
+By default a certificate is expected on input.
+With this option a certificate request is expected instead,
+which is transformed into a certificate.
+
+Any X.509 extensions included in the request file are ignored.
+X.509 extensions to be added can be specified using the B<-extfile> option.
+
 =item B<-inform> B<DER>|B<PEM>
 
-The CSR input format; the default is B<PEM>.
+The CSR input file format; the default is B<PEM>.
 See L<openssl-format-options(1)> for details.
 
-The input is normally an X.509 certificate file of any format,
-but this can change if other options such as B<-req> are used.
+=item B<-vfyopt> I<nm>:I<v>
 
-B<-outform> B<DER>|B<PEM>
+Pass options to the signature algorithm during verify operations.
+Names and values of these options are algorithm-specific.
+
+=item B<-signkey> I<filename>|I<uri>
+
+This option causes the new certificate or certificate request
+to be self-signed using the supplied private key.
+This cannot be used in conjunction with the B<-CA> option.
+
+It sets the issuer name to the subject name (i.e., makes it self-issued)
+and changes the public key to the supplied value (unless overridden
+by B<-force_pubkey>).
+Unless the B<-preserve_dates> option is supplied,
+it sets the validity start date to the current time
+and the end date to a value determined by the B<-days> option.
+Unless the B<-clrext> option is supplied, it retains all certificate extensions
+except for any subject identifier and authority key identifier.
+For those, new values are generated unless prohibited by configuration.
+
+=item B<-keyform> B<DER>|B<PEM>|B<P12>|B<ENGINE>
+
+The key input format; the default is B<PEM>.
+The only value with effect is B<ENGINE>; all others have become obsolete.
+See L<openssl-format-options(1)> for details.
+
+=item B<-out> I<filename>
+
+This specifies the output filename to write to or standard output by default.
+
+=item B<-outform> B<DER>|B<PEM>
 
 The output format; the default is B<PEM>.
 See L<openssl-format-options(1)> for details.
 
-=item B<-in> I<filename>
+=item B<-nocert>
 
-This specifies the input filename to read a certificate from or standard input
-if this option is not specified.
+Do not output a certificate (except for printing as requested by below options).
 
-=item B<-out> I<filename>
+=item B<-noout>
 
-This specifies the output filename to write to or standard output by
-default.
-
-=item B<-I<digest>>
-
-The digest to use.
-This affects any signing or display option that uses a message
-digest, such as the B<-fingerprint>, B<-signkey> and B<-CA> options.
-Any digest supported by the L<openssl-dgst(1)> command can be used.
-If not specified then SHA1 is used with B<-fingerprint> or
-the default digest for the signing algorithm is used, typically SHA256.
-
-=item B<-preserve_dates>
-
-When signing a certificate, preserve the "notBefore" and "notAfter" dates
-instead of adjusting them to current time and duration.
-Cannot be used with the B<-days> option.
-
-{- $OpenSSL::safe::opt_r_synopsis -}
-
-{- $OpenSSL::safe::opt_engine_item -}
-
-{- $OpenSSL::safe::opt_provider_item -}
+This option prevents output except for printing as requested by below options.
 
 =back
 
-=head2 Display Options
+=head2 Certificate Printing Options
 
-Note: the B<-alias> and B<-purpose> options are also display options
+Note: the B<-alias> and B<-purpose> options are also printing options
 but are described in the L</Trust Settings> section.
 
 =over 4
 
 =item B<-text>
 
-Prints out the certificate in text form. Full details are output including the
+Prints out the certificate in text form. Full details are printed including the
 public key, signature algorithms, issuer and subject names, serial number
 any extensions present and any trust settings.
 
-=item B<-ext> I<extensions>
-
-Prints out the certificate extensions in text form. Extensions are specified
-with a comma separated string, e.g., "subjectAltName,subjectKeyIdentifier".
-See the L<x509v3_config(5)> manual page for the extension names.
-
 =item B<-certopt> I<option>
 
-Customise the output format used with B<-text>. The I<option> argument
-can be a single option or multiple options separated by commas. The
-B<-certopt> switch may be also be used more than once to set multiple
-options. See the L</Text Options> section for more information.
+Customise the print format used with B<-text>. The I<option> argument
+can be a single option or multiple options separated by commas.
+The B<-certopt> switch may be also be used more than once to set multiple
+options. See the L</Text Printing Flags> section for more information.
 
-=item B<-checkhost> I<host>
+=item B<-fingerprint>
 
-Check that the certificate matches the specified host.
+Calculates and prints the digest of the DER encoded version of the entire
+certificate (see digest options).
+This is commonly called a "fingerprint". Because of the nature of message
+digests, the fingerprint of a certificate is unique to that certificate and
+two certificates with the same fingerprint can be considered to be the same.
 
-=item B<-checkemail> I<email>
+=item B<-alias>
 
-Check that the certificate matches the specified email address.
-
-=item B<-checkip> I<ipaddr>
-
-Check that the certificate matches the specified IP address.
-
-=item B<-noout>
-
-This option prevents output of the encoded version of the certificate.
-
-=item B<-pubkey>
-
-Outputs the certificate's SubjectPublicKeyInfo block in PEM format.
-
-=item B<-modulus>
-
-This option prints out the value of the modulus of the public key
-contained in the certificate.
+Prints the certificate "alias" (nickname), if any.
 
 =item B<-serial>
 
-Outputs the certificate serial number.
-
-=item B<-subject_hash>
-
-Outputs the "hash" of the certificate subject name. This is used in OpenSSL to
-form an index to allow certificates in a directory to be looked up by subject
-name.
-
-=item B<-issuer_hash>
-
-Outputs the "hash" of the certificate issuer name.
-
-=item B<-ocspid>
-
-Outputs the OCSP hash values for the subject name and public key.
-
-=item B<-hash>
-
-Synonym for "-subject_hash" for backward compatibility reasons.
-
-=item B<-subject_hash_old>
-
-Outputs the "hash" of the certificate subject name using the older algorithm
-as used by OpenSSL before version 1.0.0.
-
-=item B<-issuer_hash_old>
-
-Outputs the "hash" of the certificate issuer name using the older algorithm
-as used by OpenSSL before version 1.0.0.
-
-=item B<-subject>
-
-Outputs the subject name.
-
-=item B<-issuer>
-
-Outputs the issuer name.
-
-{- $OpenSSL::safe::opt_name_item -}
-
-=item B<-email>
-
-Outputs the email address(es) if any.
-
-=item B<-ocsp_uri>
-
-Outputs the OCSP responder address(es) if any.
+Prints the certificate serial number.
 
 =item B<-startdate>
 
@@ -257,196 +237,230 @@ Prints out the expiry date of the certificate, that is the notAfter date.
 
 Prints out the start and expiry dates of a certificate.
 
+=item B<-subject>
+
+Prints the subject name.
+
+=item B<-issuer>
+
+Prints the issuer name.
+
+{- $OpenSSL::safe::opt_name_item -}
+
+=item B<-email>
+
+Prints the email address(es) if any.
+
+=item B<-hash>
+
+Synonym for "-subject_hash" for backward compatibility reasons.
+
+=item B<-subject_hash>
+
+Prints the "hash" of the certificate subject name. This is used in OpenSSL to
+form an index to allow certificates in a directory to be looked up by subject
+name.
+
+=item B<-subject_hash_old>
+
+Prints the "hash" of the certificate subject name using the older algorithm
+as used by OpenSSL before version 1.0.0.
+
+=item B<-issuer_hash>
+
+Prints the "hash" of the certificate issuer name.
+
+=item B<-issuer_hash_old>
+
+Prints the "hash" of the certificate issuer name using the older algorithm
+as used by OpenSSL before version 1.0.0.
+
+=item B<-ext> I<extensions>
+
+Prints out the certificate extensions in text form. Extensions are specified
+with a comma separated string, e.g., "subjectAltName,subjectKeyIdentifier".
+See the L<x509v3_config(5)> manual page for the extension names.
+
+=item B<-ocspid>
+
+Prints the OCSP hash values for the subject name and public key.
+
+=item B<-ocsp_uri>
+
+Prints the OCSP responder address(es) if any.
+
+=item B<-purpose>
+
+This option performs tests on the certificate extensions and prints
+the results. For a more complete description see the
+L</CERTIFICATE EXTENSIONS> section.
+
+=item B<-pubkey>
+
+Prints the certificate's SubjectPublicKeyInfo block in PEM format.
+
+=item B<-modulus>
+
+This option prints out the value of the modulus of the public key
+contained in the certificate.
+
+=back
+
+=head2 Certificate Checking Options
+
+=over 4
+
 =item B<-checkend> I<arg>
 
 Checks if the certificate expires within the next I<arg> seconds and exits
 nonzero if yes it will expire or zero if not.
 
-=item B<-fingerprint>
+=item B<-checkhost> I<host>
 
-Calculates and outputs the digest of the DER encoded version of the entire
-certificate (see digest options).
-This is commonly called a "fingerprint". Because of the nature of message
-digests, the fingerprint of a certificate is unique to that certificate and
-two certificates with the same fingerprint can be considered to be the same.
+Check that the certificate matches the specified host.
 
-=back
+=item B<-checkemail> I<email>
 
-=head2 Trust Settings
+Check that the certificate matches the specified email address.
 
-A B<trusted certificate> is an ordinary certificate which has several
-additional pieces of information attached to it such as the permitted
-and prohibited uses of the certificate and an "alias".
+=item B<-checkip> I<ipaddr>
 
-Normally when a certificate is being verified at least one certificate
-must be "trusted". By default a trusted certificate must be stored
-locally and must be a root CA: any certificate chain ending in this CA
-is then usable for any purpose.
-
-Trust settings currently are only used with a root CA. They allow a finer
-control over the purposes the root CA can be used for. For example a CA
-may be trusted for SSL client but not SSL server use.
-
-See the description in L<openssl-verify(1)> for more information
-on the meaning of trust settings.
-
-Future versions of OpenSSL will recognize trust settings on any
-certificate: not just root CAs.
-
-
-=over 4
-
-=item B<-trustout>
-
-Output a B<trusted> certificate rather than an ordinary. An ordinary
-or trusted certificate can be input but by default an ordinary
-certificate is output and any trust settings are discarded. With the
-B<-trustout> option a trusted certificate is output. A trusted
-certificate is automatically output if any trust settings are modified.
-
-=item B<-setalias> I<arg>
-
-Sets the alias of the certificate. This will allow the certificate
-to be referred to using a nickname for example "Steve's Certificate".
-
-=item B<-alias>
-
-Outputs the certificate alias, if any.
-
-=item B<-clrtrust>
-
-Clears all the permitted or trusted uses of the certificate.
-
-=item B<-clrreject>
-
-Clears all the prohibited or rejected uses of the certificate.
-
-=item B<-addtrust> I<arg>
-
-Adds a trusted certificate use.
-Any object name can be used here but currently only B<clientAuth> (SSL client
-use), B<serverAuth> (SSL server use), B<emailProtection> (S/MIME email) and
-B<anyExtendedKeyUsage> are used.
-As of OpenSSL 1.1.0, the last of these blocks all purposes when rejected or
-enables all purposes when trusted.
-Other OpenSSL applications may define additional uses.
-
-=item B<-addreject> I<arg>
-
-Adds a prohibited use. It accepts the same values as the B<-addtrust>
-option.
-
-=item B<-purpose>
-
-This option performs tests on the certificate extensions and outputs
-the results. For a more complete description see the
-L</CERTIFICATE EXTENSIONS> section.
+Check that the certificate matches the specified IP address.
 
 =back
 
-=head2 Signing Options
-
-This command can be used to sign certificates and requests: it
-can thus behave like a "mini CA".
+=head2 Certificate Output Options
 
 =over 4
 
-=item B<-signkey> I<filename>|I<uri>
+=item B<-set_serial> I<n>
 
-This option causes the input file to be self signed using the supplied
-private key.
+Specifies the serial number to use. This option can be used with either
+the B<-signkey> or B<-CA> options. If used in conjunction with the B<-CA> option
+the serial number file (as specified by the B<-CAserial> option) is not used.
 
-It sets the issuer name to the subject name (i.e., makes it self-issued)
-and changes the public key to the supplied value (unless overridden by
-B<-force_pubkey>). It sets the validity start date to the current time
-and the end date to a value determined by the B<-days> option.
-It retains any certificate extensions unless the B<-clrext> option is supplied;
-this includes, for example, any existing key identifier extensions.
+The serial number can be decimal or hex (if preceded by C<0x>).
 
-=item B<-badsig>
+=item B<-next_serial>
 
-Corrupt the signature before writing it; this can be useful
-for testing.
+Set the serial to be one more than the number in the certificate.
+
+=item B<-days> I<arg>
+
+Specifies the number of days until a newly generated certificate expires.
+The default is 30.
+Cannot be used together with the B<-preserve_dates> option.
+
+=item B<-preserve_dates>
+
+When signing a certificate, preserve "notBefore" and "notAfter" dates of any
+input certificate instead of adjusting them to current time and duration.
+Cannot be used together with the B<-days> option.
+
+=item B<-subj> I<arg>
+
+When a certificate is created set its subject name to the given value.
+When the certificate is self-signed the issuer name is set to the same value.
+
+The arg must be formatted as C</type0=value0/type1=value1/type2=...>.
+Special characters may be escaped by C<\> (backslash), whitespace is retained.
+Empty values are permitted, but the corresponding type will not be included
+in the certificate.
+Giving a single C</> will lead to an empty sequence of RDNs (a NULL-DN).
+Multi-valued RDNs can be formed by placing a C<+> character instead of a C</>
+between the AttributeValueAssertions (AVAs) that specify the members of the set.
+Example:
+
+C</DC=org/DC=OpenSSL/DC=users/UID=123456+CN=John Doe>
+
+This option can be used in conjunction with the B<-force_pubkey> option
+to create a certificate even without providing an input certificate
+or certificate request.
+
+=item B<-force_pubkey> I<filename>
+
+When a certificate is created set its public key to the key in I<filename>
+instead of the key contained in the input or given with the B<-signkey> option.
+
+This option is useful for creating self-issued certificates that are not
+self-signed, for instance when the key cannot be used for signing, such as DH.
+It can also be used in conjunction with b<-new> and B<-subj> to directly
+generate a certificate containing any desired public key.
+
+=item B<-clrext>
+
+Delete any extensions from a certificate. This option is used when a
+certificate is being created from another certificate (for example with
+either the B<-signkey> or the B<-CA> option).
+Normally all extensions are retained.
+
+=item B<-extfile> I<filename>
+
+Configuration file containing certificate extensions to add.
+
+=item B<-extensions> I<section>
+
+The section in the extfile to add certificate extensions from.
+If this option is not
+specified then the extensions should either be contained in the unnamed
+(default) section or the default section should contain a variable called
+"extensions" which contains the section to use.
+See the L<x509v3_config(5)> manual page for details of the
+extension section format.
 
 =item B<-sigopt> I<nm>:I<v>
 
 Pass options to the signature algorithm during sign operations.
 Names and values of these options are algorithm-specific.
 
-=item B<-vfyopt> I<nm>:I<v>
+=item B<-badsig>
 
-Pass options to the signature algorithm during verify operations.
-Names and values of these options are algorithm-specific.
+Corrupt the signature before writing it; this can be useful
+for testing.
 
-=item B<-passin> I<arg>
+=item B<-I<digest>>
 
-The key and certificate file password source.
-For more information about the format of I<arg>
-see L<openssl-passphrase-options(1)>.
+The digest to use.
+This affects any signing or printing option that uses a message
+digest, such as the B<-fingerprint>, B<-signkey> and B<-CA> options.
+Any digest supported by the L<openssl-dgst(1)> command can be used.
+If not specified then SHA1 is used with B<-fingerprint> or
+the default digest for the signing algorithm is used, typically SHA256.
 
-=item B<-clrext>
+=back
 
-Delete any extensions from a certificate. This option is used when a
-certificate is being created from another certificate (for example with
-the B<-signkey> or the B<-CA> options). Normally all extensions are
-retained.
+=head2 Micro-CA Options
 
-=item B<-keyform> B<DER>|B<PEM>|B<P12>|B<ENGINE>
+=over 4
 
-The key format; the default is B<PEM>.
-The only value with effect is B<ENGINE>; all others have become obsolete.
-See L<openssl-format-options(1)> for details.
+=item B<-CA> I<filename>|I<uri>
+
+Specifies the "CA" certificate to be used for signing.
+When present, this behaves like a "micro CA" as follows:
+The subject name of the "CA" certificate is placed as issuer name in the new
+certificate, which is then signed using the "CA" key given as detailed below.
+
+This option cannot be used in conjunction with the B<-signkey> option.
+This option is normally combined with the B<-req> option referencing a CSR.
+Without the B<-req> option the input must be a self-signed certificate
+unless the B<-new> option is given, which generates a certificate from scratch.
 
 =item B<-CAform> B<DER>|B<PEM>|B<P12>,
 
 The format for the CA certificate.
 This option has no effect and is retained for backward compatibility.
 
+=item B<-CAkey> I<filename>|I<uri>
+
+Sets the CA private key to sign a certificate with.
+The private key must match the public key of the certificate given with B<-CA>.
+If this option is not provided then the key must be present in the B<-CA> input.
+
 =item B<-CAkeyform> B<DER>|B<PEM>|B<P12>|B<ENGINE>
 
 The format for the CA key; the default is B<PEM>.
 The only value with effect is B<ENGINE>; all others have become obsolete.
 See L<openssl-format-options(1)> for details.
-
-=item B<-days> I<arg>
-
-Specifies the number of days to make a certificate valid for. The default
-is 30 days. Cannot be used with the B<-preserve_dates> option.
-
-=item B<-x509toreq>
-
-Converts a certificate into a certificate request. The B<-signkey> option
-is used to pass the required private key.
-
-=item B<-req>
-
-By default a certificate is expected on input. With this option a
-certificate request is expected instead.
-
-=item B<-set_serial> I<n>
-
-Specifies the serial number to use. This option can be used with either
-the B<-signkey> or B<-CA> options. If used in conjunction with the B<-CA>
-option the serial number file (as specified by the B<-CAserial> or
-B<-CAcreateserial> options) is not used.
-
-The serial number can be decimal or hex (if preceded by C<0x>).
-
-=item B<-CA> I<filename>
-
-Specifies the CA certificate to be used for signing. When this option is
-present, this command behaves like a "mini CA". The input file is signed by
-this CA using this option: that is its issuer name is set to the subject name
-of the CA and it is digitally signed using the CAs private key.
-
-This option is normally combined with the B<-req> option. Without the
-B<-req> option the input is a certificate which must be self signed.
-
-=item B<-CAkey> I<filename>|I<uri>
-
-Sets the CA private key to sign a certificate with. If this option is
-not specified then it is assumed that the CA private key is present in
-the CA certificate file.
 
 =item B<-CAserial> I<filename>
 
@@ -470,81 +484,92 @@ have the 1 as its serial number. If the B<-CA> option is specified
 and the serial number file does not exist a random number is generated;
 this is the recommended practice.
 
-=item B<-extfile> I<filename>
+=back
 
-File containing certificate extensions to use. If not specified then
-no extensions are added to the certificate.
+=head2 Trust Settings
 
-=item B<-extensions> I<section>
+A B<trusted certificate> is an ordinary certificate which has several
+additional pieces of information attached to it such as the permitted
+and prohibited uses of the certificate and possibly an "alias" (nickname).
 
-The section to add certificate extensions from. If this option is not
-specified then the extensions should either be contained in the unnamed
-(default) section or the default section should contain a variable called
-"extensions" which contains the section to use. See the
-L<x509v3_config(5)> manual page for details of the
-extension section format.
+Normally when a certificate is being verified at least one certificate
+must be "trusted". By default a trusted certificate must be stored
+locally and must be a root CA: any certificate chain ending in this CA
+is then usable for any purpose.
 
-=item B<-new>
+Trust settings currently are only used with a root CA.
+They allow a finer control over the purposes the root CA can be used for.
+For example, a CA may be trusted for SSL client but not SSL server use.
 
-Generate a certificate from scratch, not using an input certificate
-or certificate request. So the B<-in> option must not be used in this case.
-Instead, the B<-subj> option needs to be given.
-The public key to include defaults to the key given with the B<-signkey> option,
-which implies self-signature.
-It may also be given explicity using the B<-force_pubkey> option.
+See the description in L<openssl-verify(1)> for more information
+on the meaning of trust settings.
 
-=item B<-next_serial>
+Future versions of OpenSSL will recognize trust settings on any
+certificate: not just root CAs.
 
-Set the serial to be one more than the number in the certificate.
+=over 4
 
-=item B<-nocert>
+=item B<-trustout>
 
-Do not generate or output a certificate.
+Mark any certificate PEM output as <trusted> certificate rather than ordinary.
+An ordinary or trusted certificate can be input but by default an ordinary
+certificate is output and any trust settings are discarded.
+With the B<-trustout> option a trusted certificate is output. A trusted
+certificate is automatically output if any trust settings are modified.
 
-=item B<-force_pubkey> I<filename>
+=item B<-setalias> I<arg>
 
-When a certificate is created set its public key to the key in I<filename>
-instead of the key contained in the input or given with the B<-signkey> option.
+Sets the "alias" of the certificate. This will allow the certificate
+to be referred to using a nickname for example "Steve's Certificate".
 
-This option is useful for creating self-issued certificates that are not
-self-signed, for instance when the key cannot be used for signing, such as DH.
-It can also be used in conjunction with b<-new> and B<-subj> to directly
-generate a certificate containing any desired public key.
+=item B<-clrtrust>
 
-=item B<-subj> I<arg>
+Clears all the permitted or trusted uses of the certificate.
 
-When a certificate is created set its subject name to the given value.
+=item B<-addtrust> I<arg>
 
-The arg must be formatted as C</type0=value0/type1=value1/type2=...>.
-Special characters may be escaped by C<\> (backslash), whitespace is retained.
-Empty values are permitted, but the corresponding type will not be included
-in the certificate.
-Giving a single C</> will lead to an empty sequence of RDNs (a NULL-DN).
-Multi-valued RDNs can be formed by placing a C<+> character instead of a C</>
-between the AttributeValueAssertions (AVAs) that specify the members of the set.
-Example:
+Adds a trusted certificate use.
+Any object name can be used here but currently only B<clientAuth> (SSL client
+use), B<serverAuth> (SSL server use), B<emailProtection> (S/MIME email)
+and B<anyExtendedKeyUsage> are used.
+As of OpenSSL 1.1.0, the last of these blocks all purposes when rejected or
+enables all purposes when trusted.
+Other OpenSSL applications may define additional uses.
 
-C</DC=org/DC=OpenSSL/DC=users/UID=123456+CN=John Doe>
+=item B<-clrreject>
 
-Unless the B<-CA> option is given the issuer is set to the same value.
+Clears all the prohibited or rejected uses of the certificate.
 
-This option can be used in conjunction with the B<-force_pubkey> option
-to create a certificate even without providing an input certificate
-or certificate request.
+=item B<-addreject> I<arg>
+
+Adds a prohibited use.
+It accepts the same values as the B<-addtrust> option.
 
 =back
 
-=head2 Text Options
+=head2 Generic options
 
-As well as customising the name output format, it is also possible to
-customise the actual fields printed using the B<certopt> options when
+=over 4
+
+{- $OpenSSL::safe::opt_r_item -}
+
+{- $OpenSSL::safe::opt_engine_item -}
+
+{- $OpenSSL::safe::opt_provider_item -}
+
+=back
+
+=head2 Text Printing Flags
+
+As well as customising the name printing format, it is also possible to
+customise the actual fields printed using the B<certopt> option when
 the B<text> option is present. The default behaviour is to print all fields.
 
 =over 4
 
 =item B<compatible>
 
-Use the old format. This is equivalent to specifying no output options at all.
+Use the old format. This is equivalent to specifying no printing options at all.
 
 =item B<no_header>
 
@@ -620,36 +645,36 @@ B<no_header>, and B<no_version>.
 Note: in these examples the '\' means the example should be all on one
 line.
 
-Display the contents of a certificate:
+Print the contents of a certificate:
 
  openssl x509 -in cert.pem -noout -text
 
-Display the "Subject Alternative Name" extension of a certificate:
+Print the "Subject Alternative Name" extension of a certificate:
 
  openssl x509 -in cert.pem -noout -ext subjectAltName
 
-Display more extensions of a certificate:
+Print more extensions of a certificate:
 
  openssl x509 -in cert.pem -noout -ext subjectAltName,nsCertType
 
-Display the certificate serial number:
+Print the certificate serial number:
 
  openssl x509 -in cert.pem -noout -serial
 
-Display the certificate subject name:
+Print the certificate subject name:
 
  openssl x509 -in cert.pem -noout -subject
 
-Display the certificate subject name in RFC2253 form:
+Print the certificate subject name in RFC2253 form:
 
  openssl x509 -in cert.pem -noout -subject -nameopt RFC2253
 
-Display the certificate subject name in oneline form on a terminal
+Print the certificate subject name in oneline form on a terminal
 supporting UTF8:
 
  openssl x509 -in cert.pem -noout -subject -nameopt oneline,-esc_msb
 
-Display the certificate SHA1 fingerprint:
+Print the certificate SHA1 fingerprint:
 
  openssl x509 -sha1 -in cert.pem -noout -fingerprint
 
@@ -661,7 +686,7 @@ Convert a certificate to a certificate request:
 
  openssl x509 -x509toreq -in cert.pem -out req.pem -signkey key.pem
 
-Convert a certificate request into a self signed certificate using
+Convert a certificate request into a self-signed certificate using
 extensions for a CA:
 
  openssl x509 -req -in careq.pem -extfile openssl.cnf -extensions v3_ca \
@@ -672,7 +697,6 @@ certificate extensions:
 
  openssl x509 -req -in req.pem -extfile openssl.cnf -extensions v3_usr \
         -CA cacert.pem -CAkey key.pem -CAcreateserial
-
 
 Set a certificate to be trusted for SSL client use and change set its alias to
 "Steve's Class 1 CA"
@@ -685,7 +709,7 @@ Set a certificate to be trusted for SSL client use and change set its alias to
 The conversion to UTF8 format used with the name options assumes that
 T61Strings use the ISO8859-1 character set. This is wrong but Netscape
 and MSIE do this as do many certificates. So although this is incorrect
-it is more likely to display the majority of certificates correctly.
+it is more likely to print the majority of certificates correctly.
 
 The B<-email> option searches the subject name and the subject alternative
 name extension. Only unique email addresses will be printed out: it will
@@ -713,9 +737,9 @@ because the certificate should really not be regarded as a CA: however
 it is allowed to be a CA to work around some broken software.
 
 If the certificate is a V1 certificate (and thus has no extensions) and
-it is self signed it is also assumed to be a CA but a warning is again
+it is self-signed it is also assumed to be a CA but a warning is again
 given: this is to work around the problem of Verisign roots which are V1
-self signed certificates.
+self-signed certificates.
 
 If the keyUsage extension is present then additional restraints are
 made on the uses of the certificate. A CA certificate B<must> have the

--- a/doc/man1/openssl-x509.pod.in
+++ b/doc/man1/openssl-x509.pod.in
@@ -14,6 +14,7 @@ B<openssl> B<x509>
 [B<-new>]
 [B<-x509toreq>]
 [B<-req>]
+[B<-copy_extensions> I<arg>]
 [B<-inform> B<DER>|B<PEM>]
 [B<-vfyopt> I<nm>:I<v>]
 [B<-signkey> I<filename>|I<uri>]
@@ -122,21 +123,29 @@ which implies self-signature.
 
 =item B<-x509toreq>
 
-Output a certificate request (rather than a certificate).
+Output a PKCS#10 certificate request (rather than a certificate).
 The B<-signkey> option must be used to provide the private key for self-signing;
 the corresponding public key is placed in the subjectPKInfo field.
 
-Any X.509 extensions included in an input file are ignored.
+X.509 extensions included in a certificate input are not copied by default.
 X.509 extensions to be added can be specified using the B<-extfile> option.
 
 =item B<-req>
 
 By default a certificate is expected on input.
-With this option a certificate request is expected instead,
-which is transformed into a certificate.
+With this option a PKCS#10 certificate request is expected instead,
+which must be correctly self-signed.
 
-Any X.509 extensions included in the request file are ignored.
+X.509 extensions included in the request are not copied by default.
 X.509 extensions to be added can be specified using the B<-extfile> option.
+
+=item B<-copy_extensions> I<arg>
+
+Determines how to handle X.509 extensions
+when converting from a certificate to a request using the B<-x509toreq> option
+or converting from a request to a certificate using the B<-req> option.
+If I<arg> is B<none> or this option is not present then extensions are ignored.
+If I<arg> is B<copy> or B<copyall> then all extensions are copied.
 
 =item B<-inform> B<DER>|B<PEM>
 
@@ -160,9 +169,6 @@ by B<-force_pubkey>).
 Unless the B<-preserve_dates> option is supplied,
 it sets the validity start date to the current time
 and the end date to a value determined by the B<-days> option.
-Unless the B<-clrext> option is supplied, it retains all certificate extensions
-except for any subject identifier and authority key identifier.
-For those, new values are generated unless prohibited by configuration.
 
 =item B<-keyform> B<DER>|B<PEM>|B<P12>|B<ENGINE>
 
@@ -389,10 +395,14 @@ generate a certificate containing any desired public key.
 
 =item B<-clrext>
 
-Delete any extensions from a certificate. This option is used when a
-certificate is being created from another certificate (for example with
-either the B<-signkey> or the B<-CA> option).
-Normally all extensions are retained.
+When a transforming a certificate to a new certificate
+(for example with the B<-signkey> or B<-CA> option)
+by default all certificate extensions are retained
+except for any subject identifier and authority key identifier.
+For those, new values are generated unless prohibited by configuration.
+
+When producing a certificate with the B<-clrext> option,
+any extensions are deleted.
 
 =item B<-extfile> I<filename>
 
@@ -830,12 +840,9 @@ must be present.
 
 =head1 BUGS
 
-Extensions in certificates are not transferred to certificate requests and
-vice versa.
-
 It is possible to produce invalid certificates or requests by specifying the
-wrong private key or using inconsistent options in some cases: these should
-be checked.
+wrong private key, using unsuitable X.509 extensions,
+or using inconsistent options in some cases: these should be checked.
 
 There should be options to explicitly set such things as start and end
 dates rather than an offset from the current time.

--- a/doc/man3/X509v3_get_ext_by_NID.pod
+++ b/doc/man3/X509v3_get_ext_by_NID.pod
@@ -74,9 +74,9 @@ looks for an extension of criticality B<crit>. A zero value for B<crit>
 looks for a non-critical extension a nonzero value looks for a critical
 extension.
 
-X509v3_delete_ext() deletes the extension with index B<loc> from B<x>. The
-deleted extension is returned and must be freed by the caller. If B<loc>
-is in invalid index value B<NULL> is returned.
+X509v3_delete_ext() deletes the extension with index B<loc> from B<x>.
+The deleted extension is returned and must be freed by the caller.
+If B<loc> is in invalid index value B<NULL> is returned.
 
 X509v3_add_ext() adds extension B<ex> to stack B<*x> at position B<loc>. If
 B<loc> is B<-1> the new extension is added to the end. If B<*x> is B<NULL>
@@ -110,6 +110,11 @@ Extension indices start from zero, so a zero index return value is B<not> an
 error. These search functions start from the extension B<after> the B<lastpos>
 parameter so it should initially be set to B<-1>, if it is set to zero the
 initial extension will not be checked.
+
+=head1 BUGS
+
+X509v3_delete_ext() and its variants are a bit counter-intuitive
+because these functions do not free the extension they delete.
 
 =head1 RETURN VALUES
 

--- a/include/openssl/x509.h.in
+++ b/include/openssl/x509.h.in
@@ -734,9 +734,9 @@ int X509_REQ_extension_nid(int nid);
 int *X509_REQ_get_extension_nids(void);
 void X509_REQ_set_extension_nids(int *nids);
 STACK_OF(X509_EXTENSION) *X509_REQ_get_extensions(X509_REQ *req);
-int X509_REQ_add_extensions_nid(X509_REQ *req, STACK_OF(X509_EXTENSION) *exts,
-                                int nid);
-int X509_REQ_add_extensions(X509_REQ *req, STACK_OF(X509_EXTENSION) *exts);
+int X509_REQ_add_extensions_nid(X509_REQ *req,
+                                const STACK_OF(X509_EXTENSION) *exts, int nid);
+int X509_REQ_add_extensions(X509_REQ *req, const STACK_OF(X509_EXTENSION) *ext);
 int X509_REQ_get_attr_count(const X509_REQ *req);
 int X509_REQ_get_attr_by_NID(const X509_REQ *req, int nid, int lastpos);
 int X509_REQ_get_attr_by_OBJ(const X509_REQ *req, const ASN1_OBJECT *obj,

--- a/test/recipes/25-test_x509.t
+++ b/test/recipes/25-test_x509.t
@@ -30,11 +30,11 @@ my $utf = srctop_file(@certs, "cyrillic.utf8");
 ok(run(app(["openssl", "x509", "-text", "-in", $pem, "-out", $out_msb,
             "-nameopt", "esc_msb"])));
 is(cmp_text($out_msb, srctop_file(@certs, "cyrillic.msb")),
-   0, 'Comparing esc_msb output');
+   0, 'Comparing esc_msb output with cyrillic.msb');
 ok(run(app(["openssl", "x509", "-text", "-in", $pem, "-out", $out_utf8,
             "-nameopt", "utf8"])));
 is(cmp_text($out_utf8, srctop_file(@certs, "cyrillic.utf8")),
-   0, 'Comparing utf8 output');
+   0, 'Comparing utf8 output with cyrillic.utf8');
 
  SKIP: {
     skip "DES disabled", 1 if disabled("des");

--- a/test/recipes/25-test_x509.t
+++ b/test/recipes/25-test_x509.t
@@ -44,7 +44,7 @@ is(cmp_text($out_utf8, srctop_file("test/certs", "cyrillic.utf8")),
     my $out_pem = "out.pem";
     ok(run(app(["openssl", "x509", "-text", "-in", $p12, "-out", $out_pem,
                 "-passin", "pass:$p12pass"])));
-    unlink $out_pem;
+    # not unlinking $out_pem
 }
 
 SKIP: {
@@ -68,8 +68,8 @@ SKIP: {
        &&
        run(app(["openssl", "verify", "-no_check_time",
                 "-trusted", $selfout, "-partial_chain", $testcert])));
-    unlink $pubkey;
-    unlink $selfout;
+    # not unlinking $pubkey
+    # not unlinking $selfout
 }
 
 subtest 'x509 -- x.509 v1 certificate' => sub {

--- a/test/recipes/25-test_x509.t
+++ b/test/recipes/25-test_x509.t
@@ -47,29 +47,23 @@ is(cmp_text($out_utf8, srctop_file(@certs, "cyrillic.utf8")),
     # not unlinking $out_pem
 }
 
-SKIP: {
-    skip "EC disabled", 1 if disabled("ec");
-
-    # producing and checking self-issued (but not self-signed) cert
-    my $subj = "/CN=CA"; # using same DN as in issuer of ee-cert.pem
-    my $extfile = srctop_file("test", "v3_ca_exts.cnf");
-    my $pkey = srctop_file(@certs, "ca-key.pem"); #  issuer private key
-    my $pubkey = "ca-pubkey.pem"; # the corresponding issuer public key
-    # use any (different) key for signing our self-issued cert:
-    my $signkey = srctop_file(@certs, "ee-ecdsa-key.pem");
-    my $selfout = "self-issued.out";
-    my $testcert = srctop_file(@certs, "ee-cert.pem");
-    ok(run(app(["openssl", "pkey", "-in", $pkey, "-pubout", "-out", $pubkey]))
-       &&
-       run(app(["openssl", "x509", "-new", "-force_pubkey", $pubkey,
-                "-subj", $subj, "-extfile", $extfile,
-                "-signkey", $signkey, "-out", $selfout]))
-       &&
-       run(app(["openssl", "verify", "-no_check_time",
-                "-trusted", $selfout, "-partial_chain", $testcert])));
-    # not unlinking $pubkey
-    # not unlinking $selfout
-}
+# producing and checking self-issued (but not self-signed) cert
+my $subj = "/CN=CA"; # using same DN as in issuer of ee-cert.pem
+my $extfile = srctop_file("test", "v3_ca_exts.cnf");
+my $pkey = srctop_file(@certs, "ca-key.pem"); # issuer private key
+my $pubkey = "ca-pubkey.pem"; # the corresponding issuer public key
+# use any (different) key for signing our self-issued cert:
+my $signkey = srctop_file(@certs, "serverkey.pem");
+my $selfout = "self-issued.out";
+my $testcert = srctop_file(@certs, "ee-cert.pem");
+ok(run(app(["openssl", "pkey", "-in", $pkey, "-pubout", "-out", $pubkey]))
+&& run(app(["openssl", "x509", "-new", "-force_pubkey", $pubkey,
+            "-subj", $subj, "-extfile", $extfile,
+            "-signkey", $signkey, "-out", $selfout]))
+&& run(app(["openssl", "verify", "-no_check_time",
+            "-trusted", $selfout, "-partial_chain", $testcert])));
+# not unlinking $pubkey
+# not unlinking $selfout
 
 subtest 'x509 -- x.509 v1 certificate' => sub {
     tconversion( -type => 'x509', -prefix => 'x509v1',

--- a/test/recipes/25-test_x509.t
+++ b/test/recipes/25-test_x509.t
@@ -18,22 +18,22 @@ setup("test_x509");
 
 plan tests => 15;
 
-require_ok(srctop_file('test','recipes','tconversion.pl'));
+require_ok(srctop_file("test", "recipes", "tconversion.pl"));
 
 my @certs = qw(test certs);
-my $pem = srctop_file("test/certs", "cyrillic.pem");
+my $pem = srctop_file(@certs, "cyrillic.pem");
 my $out_msb = "out-cyrillic.msb";
 my $out_utf8 = "out-cyrillic.utf8";
-my $msb = srctop_file("test/certs", "cyrillic.msb");
-my $utf = srctop_file("test/certs", "cyrillic.utf8");
+my $msb = srctop_file(@certs, "cyrillic.msb");
+my $utf = srctop_file(@certs, "cyrillic.utf8");
 
 ok(run(app(["openssl", "x509", "-text", "-in", $pem, "-out", $out_msb,
             "-nameopt", "esc_msb"])));
-is(cmp_text($out_msb, srctop_file("test/certs", "cyrillic.msb")),
+is(cmp_text($out_msb, srctop_file(@certs, "cyrillic.msb")),
    0, 'Comparing esc_msb output');
 ok(run(app(["openssl", "x509", "-text", "-in", $pem, "-out", $out_utf8,
             "-nameopt", "utf8"])));
-is(cmp_text($out_utf8, srctop_file("test/certs", "cyrillic.utf8")),
+is(cmp_text($out_utf8, srctop_file(@certs, "cyrillic.utf8")),
    0, 'Comparing utf8 output');
 
  SKIP: {
@@ -51,15 +51,14 @@ SKIP: {
     skip "EC disabled", 1 if disabled("ec");
 
     # producing and checking self-issued (but not self-signed) cert
-    my @path = qw(test certs);
     my $subj = "/CN=CA"; # using same DN as in issuer of ee-cert.pem
     my $extfile = srctop_file("test", "v3_ca_exts.cnf");
-    my $pkey = srctop_file(@path, "ca-key.pem"); #  issuer private key
+    my $pkey = srctop_file(@certs, "ca-key.pem"); #  issuer private key
     my $pubkey = "ca-pubkey.pem"; # the corresponding issuer public key
     # use any (different) key for signing our self-issued cert:
-    my $signkey = srctop_file(@path, "ee-ecdsa-key.pem");
+    my $signkey = srctop_file(@certs, "ee-ecdsa-key.pem");
     my $selfout = "self-issued.out";
-    my $testcert = srctop_file(@path, "ee-cert.pem");
+    my $testcert = srctop_file(@certs, "ee-cert.pem");
     ok(run(app(["openssl", "pkey", "-in", $pkey, "-pubout", "-out", $pubkey]))
        &&
        run(app(["openssl", "x509", "-new", "-force_pubkey", $pubkey,
@@ -74,19 +73,19 @@ SKIP: {
 
 subtest 'x509 -- x.509 v1 certificate' => sub {
     tconversion( -type => 'x509', -prefix => 'x509v1',
-                 -in => srctop_file("test","testx509.pem") );
+                 -in => srctop_file("test", "testx509.pem") );
 };
 subtest 'x509 -- first x.509 v3 certificate' => sub {
     tconversion( -type => 'x509', -prefix => 'x509v3-1',
-                 -in => srctop_file("test","v3-cert1.pem") );
+                 -in => srctop_file("test", "v3-cert1.pem") );
 };
 subtest 'x509 -- second x.509 v3 certificate' => sub {
     tconversion( -type => 'x509', -prefix => 'x509v3-2',
-                 -in => srctop_file("test","v3-cert2.pem") );
+                 -in => srctop_file("test", "v3-cert2.pem") );
 };
 
 subtest 'x509 -- pathlen' => sub {
-    ok(run(test(["v3ext", srctop_file("test/certs", "pathlen.pem")])));
+    ok(run(test(["v3ext", srctop_file(@certs, "pathlen.pem")])));
 };
 
 cert_contains(srctop_file(@certs, "fake-gp.pem"),
@@ -95,7 +94,7 @@ cert_contains(srctop_file(@certs, "fake-gp.pem"),
 
 sub test_errors { # actually tests diagnostics of OSSL_STORE
     my ($expected, $cert, @opts) = @_;
-    my $infile = srctop_file('test', 'certs', $cert);
+    my $infile = srctop_file(@certs, $cert);
     my @args = qw(openssl x509 -in);
     push(@args, $infile, @opts);
     my $tmpfile = 'out.txt';

--- a/test/recipes/80-test_ssl_old.t
+++ b/test/recipes/80-test_ssl_old.t
@@ -17,7 +17,7 @@ use OpenSSL::Test qw/:DEFAULT with bldtop_file bldtop_dir srctop_file srctop_dir
 use OpenSSL::Test::Utils;
 
 BEGIN {
-setup("test_ssl");
+setup("test_ssl_old");
 }
 
 use lib srctop_dir('Configurations');
@@ -103,15 +103,15 @@ subtest 'test_ss' => sub {
     }
 };
 
-note('test_ssl -- key U');
+note('test_ssl_old -- key U');
 my $configfile = srctop_file("test","default-and-legacy.cnf");
 if (disabled("legacy")) {
     $configfile = srctop_file("test","default.cnf");
 }
 
-testssl("keyU.ss", $Ucert, $CAcert, "default", $configfile);
+testssl($Ukey, $Ucert, $CAcert, "default", $configfile);
 unless ($no_fips) {
-    testssl("keyU.ss", $Ucert, $CAcert, "fips",
+    testssl($Ukey, $Ucert, $CAcert, "fips",
             srctop_file("test","fips-and-base.cnf"));
 }
 


### PR DESCRIPTION
While adding tests to #13658 I came across various shortcomings in the user guidance of the `x509` app.
Like with several other apps, there are meanwhile a lot of options and their presentation to users has become a mess.
This is likely due to various incremental additions of options having grown wild without intermediate cleanup.

I spent quite some effort getting the presentation of the options in the help output and the documentation into a logical order
and fixing descriptions where they were outdated or unclear.
During this process I inevitably found a couple of minor bugs and fixed them, 
in particular regarding unexpected combinations of options and memory leaks of the `-clrext` option.

~I've also renamed the new `-force_pubkey` option to the more consistent and less 'aggressive' name `-set_pubkey`~
and did some minor improvements to the related tests.

~I've renamed the `-signkey` option to `-key` for consistency with the `req` app
and because this better reflects that usually also the public portion is used,
retaining the old `-signkey` option for backward compatibility.~

Moreover, this adds the `-copy_extensions` option, used when transforming x509 <-> req.
Fixes #3638
Fixes #6481
Fixes #10458
Partly fixes #13708
Supersedes #9449

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
