### PR TITLE
Major improvemens of pkey app and bugfix on IS_HTTP(S) macros

### DIFF
--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -469,10 +469,10 @@ CONF *app_load_config_modules(const char *configfile)
     return conf;
 }
 
-#define IS_HTTP(uri) \
-    (strncmp(uri, OSSL_HTTP_PREFIX, strlen(OSSL_HTTP_PREFIX)) == 0)
-#define IS_HTTPS(uri) \
-    (strncmp(uri, OSSL_HTTPS_PREFIX, strlen(OSSL_HTTPS_PREFIX)) == 0)
+#define IS_HTTP(uri) ((uri) != NULL \
+        && strncmp(uri, OSSL_HTTP_PREFIX, strlen(OSSL_HTTP_PREFIX)) == 0)
+#define IS_HTTPS(uri) ((uri) != NULL \
+        && strncmp(uri, OSSL_HTTPS_PREFIX, strlen(OSSL_HTTPS_PREFIX)) == 0)
 
 X509 *load_cert_pass(const char *uri, int maybe_stdin,
                      const char *pass, const char *desc)

--- a/apps/pkey.c
+++ b/apps/pkey.c
@@ -58,24 +58,24 @@ const OPTIONS pkey_options[] = {
      "Key input format (ENGINE, other values ignored)"},
     {"passin", OPT_PASSIN, 's', "Key input pass phrase source"},
     {"pubin", OPT_PUBIN, '-',
-     "Read public key from input (default is private key)"},
+     "Read only public components from key input"},
 
     OPT_SECTION("Output"),
-    {"out", OPT_OUT, '>', "Output file"},
-    {"outform", OPT_OUTFORM, 'F', "Output format (DER or PEM)"},
+    {"out", OPT_OUT, '>', "Output file for encoded and/or text output"},
+    {"outform", OPT_OUTFORM, 'F', "Output encoding format (DER or PEM)"},
     {"", OPT_CIPHER, '-', "Any supported cipher to be used for encryption"},
     {"passout", OPT_PASSOUT, 's', "Output PEM file pass phrase source"},
     {"traditional", OPT_TRADITIONAL, '-',
      "Use traditional format for private key PEM output"},
-    {"pubout", OPT_PUBOUT, '-', "Output public key components only"},
-    {"noout", OPT_NOOUT, '-', "Don't output the key"},
+    {"pubout", OPT_PUBOUT, '-', "Restrict encoded output to public components"},
+    {"noout", OPT_NOOUT, '-', "Do not output the key in encoded form"},
+    {"text", OPT_TEXT, '-', "Output key components in plaintext"},
     {"text_pub", OPT_TEXT_PUB, '-',
-     "Output public key components in text form"},
-    {"text", OPT_TEXT, '-', "Output private components in plaintext as well"},
+     "Output only public key components in text form"},
     {"ec_conv_form", OPT_EC_CONV_FORM, 's',
-     "Specifies the point conversion form "},
+     "Specifies the EC point conversion form in the encoding"},
     {"ec_param_enc", OPT_EC_PARAM_ENC, 's',
-     "Specifies the way the ec parameters are encoded"},
+     "Specifies the way the EC parameters are encoded"},
 
     {NULL}
 };
@@ -90,7 +90,7 @@ int pkey_main(int argc, char **argv)
     char *passinarg = NULL, *passoutarg = NULL, *prog;
     OPTION_CHOICE o;
     int informat = FORMAT_PEM, outformat = FORMAT_PEM;
-    int pubin = 0, pubout = 0, pubtext = 0, text = 0, noout = 0, ret = 1;
+    int pubin = 0, pubout = 0, text_pub = 0, text = 0, noout = 0, ret = 1;
     int private = 0, traditional = 0, check = 0, pub_check = 0;
 #ifndef OPENSSL_NO_EC
     EC_KEY *eckey;
@@ -135,13 +135,13 @@ int pkey_main(int argc, char **argv)
             outfile = opt_arg();
             break;
         case OPT_PUBIN:
-            pubin = pubout = pubtext = 1;
+            pubin = pubout = 1;
             break;
         case OPT_PUBOUT:
             pubout = 1;
             break;
         case OPT_TEXT_PUB:
-            pubtext = text = 1;
+            text_pub = 1;
             break;
         case OPT_TEXT:
             text = 1;
@@ -194,15 +194,28 @@ int pkey_main(int argc, char **argv)
     if (argc != 0)
         goto opthelp;
 
-    private = !noout && !pubout ? 1 : 0;
-    if (text && !pubtext)
-        private = 1;
+    if (noout && pubout)
+        BIO_printf(bio_err,
+                   "Warning: The -pubout option is ignored with -noout\n");
+    if (text && text_pub)
+        BIO_printf(bio_err,
+                   "Warning: The -text option is ignored with -text_pub\n");
+    if (traditional && (noout || outformat != FORMAT_PEM))
+        BIO_printf(bio_err,
+                   "Warning: The -traditional is ignored since there is no PEM output\n");
+    private = (!noout && !pubout) || (text && !text_pub);
 
-    if (outformat == FORMAT_ASN1 && passoutarg != NULL) {
-        BIO_printf(bio_err, "The -passout option is not supported for DER output\n");
-        goto end;
+    if (cipher == NULL) {
+        if (passoutarg != NULL)
+            BIO_printf(bio_err,
+                       "Warning: The -passout option is ignored without a cipher option\n");
+    } else {
+        if (noout || outformat != FORMAT_PEM) {
+            BIO_printf(bio_err,
+                       "Error: Cipher options are supported only for PEM output\n");
+            goto end;
+        }
     }
-
     if (!app_passwd(passinarg, passoutarg, &passin, &passout)) {
         BIO_printf(bio_err, "Error getting passwords\n");
         goto end;
@@ -291,6 +304,11 @@ int pkey_main(int argc, char **argv)
                 }
             }
         } else if (outformat == FORMAT_ASN1) {
+            if (text || text_pub) {
+                BIO_printf(bio_err,
+                           "Error: Text output cannot be combined with DER output\n");
+                goto end;
+            }
             if (pubout) {
                 if (!i2d_PUBKEY_bio(out, pkey))
                     goto end;
@@ -305,15 +323,13 @@ int pkey_main(int argc, char **argv)
         }
     }
 
-    if (text) {
-        if (pubtext) {
-            if (EVP_PKEY_print_public(out, pkey, 0, NULL) <= 0)
-                goto end;
-        } else {
-            assert(private);
-            if (EVP_PKEY_print_private(out, pkey, 0, NULL) <= 0)
-                goto end;
-        }
+    if (text_pub) {
+        if (EVP_PKEY_print_public(out, pkey, 0, NULL) <= 0)
+            goto end;
+    } else if (text) {
+        assert(private);
+        if (EVP_PKEY_print_private(out, pkey, 0, NULL) <= 0)
+            goto end;
     }
 
     ret = 0;

--- a/apps/pkey.c
+++ b/apps/pkey.c
@@ -66,7 +66,7 @@ const OPTIONS pkey_options[] = {
 
     OPT_SECTION("Output"),
     {"outform", OPT_OUTFORM, 'F', "Output format (DER or PEM)"},
-    {"passout", OPT_PASSOUT, 's', "Output file pass phrase source"},
+    {"passout", OPT_PASSOUT, 's', "Output PEM file pass phrase source"},
     {"out", OPT_OUT, '>', "Output file"},
     {"pubout", OPT_PUBOUT, '-', "Output public key, not private"},
     {"text_pub", OPT_TEXT_PUB, '-', "Only output public key components"},
@@ -194,6 +194,11 @@ int pkey_main(int argc, char **argv)
     private = !noout && !pubout ? 1 : 0;
     if (text && !pubtext)
         private = 1;
+
+    if (outformat == FORMAT_ASN1 && passoutarg != NULL) {
+        BIO_printf(bio_err, "The -passout option is not supported for DER output\n");
+        goto end;
+    }
 
     if (!app_passwd(passinarg, passoutarg, &passin, &passout)) {
         BIO_printf(bio_err, "Error getting passwords\n");

--- a/apps/pkey.c
+++ b/apps/pkey.c
@@ -36,7 +36,7 @@ typedef enum OPTION_choice {
     OPT_ERR = -1, OPT_EOF = 0, OPT_HELP,
     OPT_INFORM, OPT_OUTFORM, OPT_PASSIN, OPT_PASSOUT, OPT_ENGINE,
     OPT_IN, OPT_OUT, OPT_PUBIN, OPT_PUBOUT, OPT_TEXT_PUB,
-    OPT_TEXT, OPT_NOOUT, OPT_MD, OPT_TRADITIONAL, OPT_CHECK, OPT_PUB_CHECK,
+    OPT_TEXT, OPT_NOOUT, OPT_CIPHER, OPT_TRADITIONAL, OPT_CHECK, OPT_PUB_CHECK,
     OPT_EC_PARAM_ENC, OPT_EC_CONV_FORM,
     OPT_PROV_ENUM
 } OPTION_CHOICE;
@@ -47,33 +47,36 @@ const OPTIONS pkey_options[] = {
 #ifndef OPENSSL_NO_ENGINE
     {"engine", OPT_ENGINE, 's', "Use engine, possibly a hardware device"},
 #endif
+    OPT_PROV_OPTIONS,
+
     {"check", OPT_CHECK, '-', "Check key consistency"},
     {"pubcheck", OPT_PUB_CHECK, '-', "Check public key consistency"},
-    {"", OPT_MD, '-', "Any supported cipher"},
-    {"ec_param_enc", OPT_EC_PARAM_ENC, 's',
-     "Specifies the way the ec parameters are encoded"},
-    {"ec_conv_form", OPT_EC_CONV_FORM, 's',
-     "Specifies the point conversion form "},
 
     OPT_SECTION("Input"),
     {"in", OPT_IN, 's', "Input key"},
-    {"inform", OPT_INFORM, 'f', "Input format (DER/PEM/P12/ENGINE)"},
-    {"passin", OPT_PASSIN, 's', "Input file pass phrase source"},
+    {"inform", OPT_INFORM, 'f',
+     "Key input format (ENGINE, other values ignored)"},
+    {"passin", OPT_PASSIN, 's', "Key input pass phrase source"},
     {"pubin", OPT_PUBIN, '-',
      "Read public key from input (default is private key)"},
-    {"traditional", OPT_TRADITIONAL, '-',
-     "Use traditional format for private keys"},
 
     OPT_SECTION("Output"),
-    {"outform", OPT_OUTFORM, 'F', "Output format (DER or PEM)"},
-    {"passout", OPT_PASSOUT, 's', "Output PEM file pass phrase source"},
     {"out", OPT_OUT, '>', "Output file"},
-    {"pubout", OPT_PUBOUT, '-', "Output public key, not private"},
-    {"text_pub", OPT_TEXT_PUB, '-', "Only output public key components"},
-    {"text", OPT_TEXT, '-', "Output in plaintext as well"},
+    {"outform", OPT_OUTFORM, 'F', "Output format (DER or PEM)"},
+    {"", OPT_CIPHER, '-', "Any supported cipher to be used for encryption"},
+    {"passout", OPT_PASSOUT, 's', "Output PEM file pass phrase source"},
+    {"traditional", OPT_TRADITIONAL, '-',
+     "Use traditional format for private key PEM output"},
+    {"pubout", OPT_PUBOUT, '-', "Output public key components only"},
     {"noout", OPT_NOOUT, '-', "Don't output the key"},
+    {"text_pub", OPT_TEXT_PUB, '-',
+     "Output public key components in text form"},
+    {"text", OPT_TEXT, '-', "Output private components in plaintext as well"},
+    {"ec_conv_form", OPT_EC_CONV_FORM, 's',
+     "Specifies the point conversion form "},
+    {"ec_param_enc", OPT_EC_PARAM_ENC, 's',
+     "Specifies the way the ec parameters are encoded"},
 
-    OPT_PROV_OPTIONS,
     {NULL}
 };
 
@@ -155,7 +158,7 @@ int pkey_main(int argc, char **argv)
         case OPT_PUB_CHECK:
             pub_check = 1;
             break;
-        case OPT_MD:
+        case OPT_CIPHER:
             if (!opt_cipher(opt_unknown(), &cipher))
                 goto opthelp;
             break;

--- a/doc/man1/openssl-pkey.pod.in
+++ b/doc/man1/openssl-pkey.pod.in
@@ -67,6 +67,8 @@ prompted for.
 =item B<-passin> I<arg>, B<-passout> I<arg>
 
 The password source for the input and output file.
+The -passout option is not supported for DER output.
+
 For more information about the format of B<arg>
 see L<openssl-passphrase-options(1)>.
 

--- a/doc/man1/openssl-pkey.pod.in
+++ b/doc/man1/openssl-pkey.pod.in
@@ -27,8 +27,8 @@ B<openssl> B<pkey>
 [B<-traditional>]
 [B<-pubout>]
 [B<-noout>]
-[B<-text_pub>]
 [B<-text>]
+[B<-text_pub>]
 [B<-ec_conv_form> I<arg>]
 [B<-ec_param_enc> I<arg>]
 
@@ -73,7 +73,7 @@ or the public component of a key pair.
 
 This specifies the input to read a key from
 or standard input if this option is not specified.
-If the key is encrypted and B<-passin> is not given
+If the key input is encrypted and B<-passin> is not given
 a pass phrase will be prompted for.
 
 =item B<-inform> B<DER>|B<PEM>|B<P12>|B<ENGINE>
@@ -91,8 +91,8 @@ see L<openssl-passphrase-options(1)>.
 
 =item B<-pubin>
 
-By default a private key is read from the input file: with this
-option a public key is read instead.
+By default a private key is read from the input.
+With this option only the public components are read.
 
 =back
 
@@ -102,9 +102,9 @@ option a public key is read instead.
 
 =item B<-out> I<filename>
 
-This specifies the output filename to write a key to
+This specifies the output filename to save the encoded and/or text output of key
 or standard output if this option is not specified.
-If any encryption option is set but no B<-passout> is given
+If any cipher option is set but no B<-passout> is given
 then a pass phrase will be prompted for.
 The output filename should B<not> be the same as the input filename.
 
@@ -115,13 +115,13 @@ See L<openssl-format-options(1)> for details.
 
 =item B<-I<cipher>>
 
-These options encrypt the private key with the supplied cipher. Any algorithm
+Encrypt the PEM encoded private key with the supplied cipher. Any algorithm
 name accepted by EVP_get_cipherbyname() is acceptable such as B<aes128>.
+Encryption is not supported for DER output.
 
 =item B<-passout> I<arg>
 
 The password source for the output file.
-The -passout option is not supported for DER output.
 
 For more information about the format of B<arg>
 see L<openssl-passphrase-options(1)>.
@@ -134,22 +134,24 @@ option is specified then the older "traditional" format is used instead.
 
 =item B<-pubout>
 
-By default the encoded private key is output:
-with this option the encoded public key will be output instead.
+By default the encoded private and public key is output;
+this option restricts the encoded output to the public components.
 This option is automatically set if the input is a public key.
 
 =item B<-noout>
 
-Do not output the encoded version of the key.
+Do not output the key in encoded form.
 
 =item B<-text>
 
-Output the various public or private key components in
-plain text (possibly in addition to the encoded version).
+Output the various key components in plain text
+(possibly in addition to the PEM encoded form).
+This cannot be combined with encoded output in DER format.
 
 =item B<-text_pub>
 
-Output in text form the public key components (also for private keys).
+Output in text form only the public key components (also for private keys).
+This cannot be combined with encoded output in DER format.
 
 =item B<-ec_conv_form> I<arg>
 

--- a/doc/man1/openssl-pkey.pod.in
+++ b/doc/man1/openssl-pkey.pod.in
@@ -13,33 +13,35 @@ openssl-pkey - public or private key processing command
 
 B<openssl> B<pkey>
 [B<-help>]
-[B<-inform> B<DER>|B<PEM>|B<P12>|B<ENGINE>]
-[B<-outform> B<DER>|B<PEM>]
-[B<-in> I<filename>|I<uri>]
-[B<-passin> I<arg>]
-[B<-out> I<filename>]
-[B<-passout> I<arg>]
-[B<-traditional>]
-[B<-I<cipher>>]
-[B<-text>]
-[B<-text_pub>]
-[B<-noout>]
-[B<-pubin>]
-[B<-pubout>]
+{- $OpenSSL::safe::opt_engine_synopsis -}{- $OpenSSL::safe::opt_provider_synopsis -}
 [B<-check>]
 [B<-pubcheck>]
+[B<-in> I<filename>|I<uri>]
+[B<-inform> B<DER>|B<PEM>|B<P12>|B<ENGINE>]
+[B<-passin> I<arg>]
+[B<-pubin>]
+[B<-out> I<filename>]
+[B<-outform> B<DER>|B<PEM>]
+[B<-I<cipher>>]
+[B<-passout> I<arg>]
+[B<-traditional>]
+[B<-pubout>]
+[B<-noout>]
+[B<-text_pub>]
+[B<-text>]
 [B<-ec_conv_form> I<arg>]
 [B<-ec_param_enc> I<arg>]
-{- $OpenSSL::safe::opt_engine_synopsis -}{- $OpenSSL::safe::opt_provider_synopsis -}
 
 =for openssl ifdef engine
 
 =head1 DESCRIPTION
 
 This command processes public or private keys. They can be
-converted between various forms and their components printed out.
+converted between various forms and their components printed.
 
 =head1 OPTIONS
+
+=head2 General options
 
 =over 4
 
@@ -47,72 +49,9 @@ converted between various forms and their components printed out.
 
 Print out a usage message.
 
-=item B<-inform> B<DER>|B<PEM>|B<P12>|B<ENGINE>
+{- $OpenSSL::safe::opt_engine_item -}
 
-The key input format; the default is B<PEM>.
-The only value with effect is B<ENGINE>; all others have become obsolete.
-See L<openssl-format-options(1)> for details.
-
-=item B<-outform> B<DER>|B<PEM>
-
-The key output formats; the default is B<PEM>.
-See L<openssl-format-options(1)> for details.
-
-=item B<-in> I<filename>|I<uri>
-
-This specifies the input to read a key from or standard input if this
-option is not specified. If the key is encrypted a pass phrase will be
-prompted for.
-
-=item B<-passin> I<arg>, B<-passout> I<arg>
-
-The password source for the input and output file.
-The -passout option is not supported for DER output.
-
-For more information about the format of B<arg>
-see L<openssl-passphrase-options(1)>.
-
-=item B<-out> I<filename>
-
-This specifies the output filename to write a key to or standard output if this
-option is not specified. If any encryption options are set then a pass phrase
-will be prompted for. The output filename should B<not> be the same as the input
-filename.
-
-=item B<-traditional>
-
-Normally a private key is written using standard format: this is PKCS#8 form
-with the appropriate encryption algorithm (if any). If the B<-traditional>
-option is specified then the older "traditional" format is used instead.
-
-=item B<-I<cipher>>
-
-These options encrypt the private key with the supplied cipher. Any algorithm
-name accepted by EVP_get_cipherbyname() is acceptable such as B<des3>.
-
-=item B<-text>
-
-Prints out the various public or private key components in
-plain text in addition to the encoded version.
-
-=item B<-text_pub>
-
-Print out only public key components even if a private key is being processed.
-
-=item B<-noout>
-
-Do not output the encoded version of the key.
-
-=item B<-pubin>
-
-By default a private key is read from the input file: with this
-option a public key is read instead.
-
-=item B<-pubout>
-
-By default a private key is output: with this option a public
-key will be output instead. This option is automatically set if
-the input is a public key.
+{- $OpenSSL::safe::opt_provider_item -}
 
 =item B<-check>
 
@@ -121,12 +60,100 @@ components.
 
 =item B<-pubcheck>
 
-This option checks the correctness of either a public key or the public component
-of a key pair.
+This option checks the correctness of either a public key
+or the public component of a key pair.
+
+=back
+
+=head2 Input options
+
+=over 4
+
+=item B<-in> I<filename>|I<uri>
+
+This specifies the input to read a key from
+or standard input if this option is not specified.
+If the key is encrypted and B<-passin> is not given
+a pass phrase will be prompted for.
+
+=item B<-inform> B<DER>|B<PEM>|B<P12>|B<ENGINE>
+
+The key input format; the default is B<PEM>.
+The only value with effect is B<ENGINE>; all others have become obsolete.
+See L<openssl-format-options(1)> for details.
+
+=item B<-passin> I<arg>
+
+The password source for the key input.
+
+For more information about the format of B<arg>
+see L<openssl-passphrase-options(1)>.
+
+=item B<-pubin>
+
+By default a private key is read from the input file: with this
+option a public key is read instead.
+
+=back
+
+=head2 Output options
+
+=over 4
+
+=item B<-out> I<filename>
+
+This specifies the output filename to write a key to
+or standard output if this option is not specified.
+If any encryption option is set but no B<-passout> is given
+then a pass phrase will be prompted for.
+The output filename should B<not> be the same as the input filename.
+
+=item B<-outform> B<DER>|B<PEM>
+
+The key output format; the default is B<PEM>.
+See L<openssl-format-options(1)> for details.
+
+=item B<-I<cipher>>
+
+These options encrypt the private key with the supplied cipher. Any algorithm
+name accepted by EVP_get_cipherbyname() is acceptable such as B<aes128>.
+
+=item B<-passout> I<arg>
+
+The password source for the output file.
+The -passout option is not supported for DER output.
+
+For more information about the format of B<arg>
+see L<openssl-passphrase-options(1)>.
+
+=item B<-traditional>
+
+Normally a private key is written using standard format: this is PKCS#8 form
+with the appropriate encryption algorithm (if any). If the B<-traditional>
+option is specified then the older "traditional" format is used instead.
+
+=item B<-pubout>
+
+By default the encoded private key is output:
+with this option the encoded public key will be output instead.
+This option is automatically set if the input is a public key.
+
+=item B<-noout>
+
+Do not output the encoded version of the key.
+
+=item B<-text>
+
+Output the various public or private key components in
+plain text (possibly in addition to the encoded version).
+
+=item B<-text_pub>
+
+Output in text form the public key components (also for private keys).
 
 =item B<-ec_conv_form> I<arg>
 
-This option only applies to elliptic curve based public and private keys.
+This option only applies to elliptic-curve based keys.
 
 This specifies how the points on the elliptic curve are converted
 into octet strings. Possible values are: B<compressed> (the default
@@ -147,10 +174,6 @@ explicitly given (see RFC 3279 for the definition of the
 EC parameters structures). The default value is B<named_curve>.
 B<Note> the B<implicitlyCA> alternative, as specified in RFC 3279,
 is currently not implemented in OpenSSL.
-
-{- $OpenSSL::safe::opt_engine_item -}
-
-{- $OpenSSL::safe::opt_provider_item -}
 
 =back
 


### PR DESCRIPTION
* `apps/pkey.c`: Improve help output and documentation, in particular re-order the presentation of options
* `apps/pkey.c`: Make clear that `-passout` is not supported for DER output and prevent or point out other nonsensical cases
* `apps.c`: Fix crash in case `uri` arg of `IS_HTTP` or `IS_HTTPS` is NULL

- [x] documentation is added or updated

