### PR TITLE
X509_print_ex(): Do not abort printing when notBefore/notAfter times are invalid

### DIFF
--- a/crypto/asn1/a_time.c
+++ b/crypto/asn1/a_time.c
@@ -476,7 +476,9 @@ int ASN1_TIME_print(BIO *bp, const ASN1_TIME *tm)
 
     if (!asn1_time_to_tm(&stm, tm)) {
         /* asn1_time_to_tm will check the time type */
-        goto err;
+        (void)BIO_write(bp, "Bad time value", 14);
+        return 0;
+        /* It would have been more consistent to return BIO_write(...) */
     }
 
     l = tm->length;
@@ -509,9 +511,6 @@ int ASN1_TIME_print(BIO *bp, const ASN1_TIME *tm)
                           stm.tm_min, stm.tm_sec, stm.tm_year + 1900,
                           (gmt ? " GMT" : "")) > 0;
     }
- err:
-    BIO_write(bp, "Bad time value", 14);
-    return 0;
 }
 
 int ASN1_TIME_cmp_time_t(const ASN1_TIME *s, time_t t)

--- a/crypto/x509/t_x509.c
+++ b/crypto/x509/t_x509.c
@@ -140,11 +140,11 @@ int X509_print_ex(BIO *bp, X509 *x, unsigned long nmflags,
             goto err;
         if (BIO_write(bp, "            Not Before: ", 24) <= 0)
             goto err;
-        if (!ASN1_TIME_print(bp, X509_get0_notBefore(x)))
+        if (asn1_time_print_ex(bp, X509_get0_notBefore(x)) == 0)
             goto err;
         if (BIO_write(bp, "\n            Not After : ", 25) <= 0)
             goto err;
-        if (!ASN1_TIME_print(bp, X509_get0_notAfter(x)))
+        if (asn1_time_print_ex(bp, X509_get0_notAfter(x)) == 0)
             goto err;
         if (BIO_write(bp, "\n", 1) <= 0)
             goto err;

--- a/doc/man3/ASN1_TIME_set.pod
+++ b/doc/man3/ASN1_TIME_set.pod
@@ -102,9 +102,9 @@ functions check the syntax of the time structure I<s>.
 The ASN1_TIME_print(), ASN1_UTCTIME_print() and ASN1_GENERALIZEDTIME_print()
 functions print the time structure I<s> to BIO I<b> in human readable
 format. It will be of the format MMM DD HH:MM:SS YYYY [GMT], for example
-"Feb  3 00:55:52 2015 GMT" it does not include a newline. If the time
-structure has invalid format it prints out "Bad time value" and returns
-an error. The output for generalized time may include a fractional part
+"Feb  3 00:55:52 2015 GMT", which does not include a newline.
+If the time structure has invalid format it prints out "Bad time value" and
+returns an error. The output for generalized time may include a fractional part
 following the second.
 
 ASN1_TIME_to_tm() converts the time I<s> to the standard I<tm> structure.
@@ -181,6 +181,9 @@ ASN1_TIME_print(), ASN1_UTCTIME_print() and ASN1_GENERALIZEDTIME_print()
 do not print out the timezone: it either prints out "GMT" or nothing. But all
 certificates complying with RFC5280 et al use GMT anyway.
 
+ASN1_TIME_print(), ASN1_UTCTIME_print() and ASN1_GENERALIZEDTIME_print()
+do not distinguish if they fail because of an I/O error or invalid time format.
+
 Use the ASN1_TIME_normalize() function to normalize the time value before
 printing to get GMT results.
 
@@ -199,9 +202,9 @@ ASN1_TIME_normalize() returns 1 on success, and 0 on error.
 ASN1_TIME_check(), ASN1_UTCTIME_check and ASN1_GENERALIZEDTIME_check() return 1
 if the structure is syntactically correct and 0 otherwise.
 
-ASN1_TIME_print(), ASN1_UTCTIME_print() and ASN1_GENERALIZEDTIME_print() return
-1 if the time is successfully printed out and 0 if an error occurred (I/O error
-or invalid time format).
+ASN1_TIME_print(), ASN1_UTCTIME_print() and ASN1_GENERALIZEDTIME_print()
+return 1 if the time is successfully printed out and
+0 if an I/O error occurred an error occurred (I/O error or invalid time format).
 
 ASN1_TIME_to_tm() returns 1 if the time is successfully parsed and 0 if an
 error occurred (invalid time format).

--- a/include/crypto/asn1.h
+++ b/include/crypto/asn1.h
@@ -138,3 +138,4 @@ int x509_algor_new_from_md(X509_ALGOR **palg, const EVP_MD *md);
 const EVP_MD *x509_algor_get_md(X509_ALGOR *alg);
 X509_ALGOR *x509_algor_mgf1_decode(X509_ALGOR *alg);
 int x509_algor_md_to_mgf1(X509_ALGOR **palg, const EVP_MD *mgf1md);
+int asn1_time_print_ex(BIO *bp, const ASN1_TIME *tm);


### PR DESCRIPTION
When doing #13711 I found that the `-text` output of the `x509` app can stop prematurely in case the printed cert does not have notBefore or notAfter attributes, such as here:
```
Certificate:
    Data:
        Version: 1 (0x0)
        Serial Number:
            74:5f:dd:21:c4:74:e1:d4:6f:7f:27:76:22:a5:66:5c:29:e9:a9:77
        Signature Algorithm: sha256WithRSAEncryption
        Issuer: CN = t
        Validity
            Not Before: Bad time value-----BEGIN CERTIFICATE-----
MIICgTCCAWsCFHRf3SHEdOHUb38ndiKlZlwp6al3MAsGCSqGSIb3DQEBCzAMMQow
[...]
w1OUl8HhQdEOeiLPZg5IgujC1Jyn
-----END CERTIFICATE-----
```

This PR fixes the printing by making the output of `ASN1_TIME_print()` more consistent: 
it now returns failure only in case of an I/O error, 
also in case the input format is not valid, where anyway a suitable text output is provided: `Bad time value`.