### PR TITLE
Handle partial data re-sending on ktls/sendfile on FreeBSD

### DIFF
--- a/doc/man3/SSL_write.pod
+++ b/doc/man3/SSL_write.pod
@@ -120,7 +120,8 @@ For SSL_sendfile(), the following return values can occur:
 =item Z<>>= 0
 
 The write operation was successful, the return value is the number
-of bytes of the file written to the TLS/SSL connection.
+of bytes of the file written to the TLS/SSL connection. The return
+value can be less than B<size> for a partial write.
 
 =item E<lt> 0
 

--- a/include/internal/ktls.h
+++ b/include/internal/ktls.h
@@ -192,10 +192,9 @@ static ossl_inline int ktls_read_record(int fd, void *data, size_t length)
 static ossl_inline ossl_ssize_t ktls_sendfile(int s, int fd, off_t off,
                                               size_t size, int flags)
 {
-    off_t sbytes;
+    off_t sbytes = 0;
     int ret;
 
-    sbytes = 0;
     ret = sendfile(fd, s, off, size, NULL, &sbytes, flags);
     if (ret == -1 && sbytes == 0)
         return -1;

--- a/include/internal/ktls.h
+++ b/include/internal/ktls.h
@@ -196,11 +196,8 @@ static ossl_inline ossl_ssize_t ktls_sendfile(int s, int fd, off_t off,
     int ret;
 
     ret = sendfile(fd, s, off, size, NULL, &sbytes, flags);
-    if (ret == -1) {
-	    if ((errno == EAGAIN || errno == EBUSY) && sbytes != 0)
-		    return sbytes;
-	    return -1;
-    }
+    if (ret == -1 && sbytes == 0)
+        return -1;
     return sbytes;
 }
 

--- a/include/internal/ktls.h
+++ b/include/internal/ktls.h
@@ -195,6 +195,7 @@ static ossl_inline ossl_ssize_t ktls_sendfile(int s, int fd, off_t off,
     off_t sbytes;
     int ret;
 
+    sbytes = 0;
     ret = sendfile(fd, s, off, size, NULL, &sbytes, flags);
     if (ret == -1 && sbytes == 0)
         return -1;

--- a/include/internal/ktls.h
+++ b/include/internal/ktls.h
@@ -197,7 +197,7 @@ static ossl_inline ossl_ssize_t ktls_sendfile(int s, int fd, off_t off,
 
     ret = sendfile(fd, s, off, size, NULL, &sbytes, flags);
     if (ret == -1) {
-	    if (errno == EAGAIN && sbytes != 0)
+	    if ((errno == EAGAIN || errno == EBUSY) && sbytes != 0)
 		    return sbytes;
 	    return -1;
     }


### PR DESCRIPTION
Add a handler for EBUSY sendfile error in addition to
EAGAIN. With EBUSY returned the data still can be partially
sent and user code has to be notified about it, otherwise it
may try to send data multiple times.

CLA: trivial