### PR TITLE
Don't call EVP_CIPHER_CTX_block_size() to find the block size

### DIFF
--- a/crypto/evp/evp_enc.c
+++ b/crypto/evp/evp_enc.c
@@ -556,7 +556,7 @@ int EVP_EncryptUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl,
     if (ctx->cipher->prov == NULL)
         goto legacy;
 
-    blocksize = EVP_CIPHER_CTX_block_size(ctx);
+    blocksize = ctx->cipher->block_size;
 
     if (ctx->cipher->cupdate == NULL  || blocksize < 1) {
         ERR_raise(ERR_LIB_EVP, EVP_R_UPDATE_ERROR);


### PR DESCRIPTION
The EVP lib was calling EVP_CIPHER_CTX_block_size(), which in turn calls
EVP_CIPHER_block_size() in order to find the block_size in every
EVP_EncryptUpdate() call. This adds a surprising amount of overhead when
using speed to test aes-128-cbc. Since we're in the EVP lib itself, we can
just directly access this value.

To test performance I ran the command:
openssl speed -evp aes-128-cbc -bytes 16 -seconds 30

For the before and after, I ran this twice and discarded the first result
to "warm up" my machine.

Before:
aes-128-cbc     716949.71k

After:
aes-128-cbc     742807.11k

This represents a performance improvement of about 4%

Partially fixes #13407

Testing for both before and after was performed with #13730, #13731 and #13733 in place.