### PR TITLE
Configure: Add check for non-existing C(++) source files in build.info

### DIFF
--- a/Configure
+++ b/Configure
@@ -2242,6 +2242,11 @@ EOF
                 }
                 # We recognise C++, C and asm files
                 if ($s =~ /\.(cc|cpp|c|s|S)$/) {
+                    die "source file '$s' does not exist\n"
+                        unless ($s =~ m/^providers.common.der.der_/ ||
+                                $s =~ m/^test.buildtest_/ ||
+                                $s =~ m/^apps.progs\.c$/ ||
+                                $s =~ m/\.[sS]$/ || -e $s);
                     my $o = $_;
                     $o =~ s/\.[csS]$/.o/; # C and assembler
                     $o =~ s/\.(cc|cpp)$/_cc.o/; # C++


### PR DESCRIPTION
This makes `Configure` fail in case a `build.info` file refers to non-existing source file,
which may happen by mistake for instance after renaming source files.

If such mistakes are not caught then `make` likely fails later with a (not always intelligible) build dependency error.