### PR TITLE
FreeBSD Kernel TLS chacha20

### DIFF
--- a/include/internal/ktls.h
+++ b/include/internal/ktls.h
@@ -40,6 +40,11 @@
 #   define OPENSSL_KTLS_AES_GCM_128
 #   define OPENSSL_KTLS_AES_GCM_256
 #   define OPENSSL_KTLS_TLS13
+#   ifdef TLS_CHACHA20_IV_LEN
+#    ifndef OPENSSL_NO_CHACHA
+#     define OPENSSL_KTLS_CHACHA20_POLY1305
+#    endif
+#   endif
 
 typedef struct tls_enable ktls_crypto_info_t;
 

--- a/ssl/ktls.c
+++ b/ssl/ktls.c
@@ -37,6 +37,10 @@ int ktls_check_supported_cipher(const SSL *s, const EVP_CIPHER *c,
     case SSL_AES128GCM:
     case SSL_AES256GCM:
         return 1;
+# ifdef OPENSSL_KTLS_CHACHA20_POLY1305
+    case SSL_CHACHA20POLY1305:
+        return 1;
+# endif
     case SSL_AES128:
     case SSL_AES256:
         if (s->ext.use_etm)
@@ -71,6 +75,12 @@ int ktls_configure_crypto(const SSL *s, const EVP_CIPHER *c, EVP_CIPHER_CTX *dd,
         else
             crypto_info->iv_len = EVP_GCM_TLS_FIXED_IV_LEN;
         break;
+# ifdef OPENSSL_KTLS_CHACHA20_POLY1305
+    case SSL_CHACHA20POLY1305:
+        crypto_info->cipher_algorithm = CRYPTO_CHACHA20_POLY1305;
+        crypto_info->iv_len = EVP_CIPHER_CTX_get_iv_length(dd);
+        break;
+# endif
     case SSL_AES128:
     case SSL_AES256:
         switch (s->s3.tmp.new_cipher->algorithm_mac) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated

I was not aware of #13475 when I started on this, but this PR should complement that one.  About the only thing is settling on a common name for `OPENSSL_KTLS_CHACHA20` vs `OPENSSL_KTLS_CHACHA20_POLY1305`.  I have tested this with both TLS 1.2 (TX and RX) and TLS 1.3 (TX offload only) on a patched FreeBSD kernel.  The FreeBSD kernel patches are not yet upstream in FreeBSD.  I have no reason to suspect they won't be accepted though (and that any changes that might be made in review would stick with the API used here).  I'm happy enough to have this wait for final merging until the FreeBSD patches are all merged upstream.