### PR TITLE
Only perform special TLS handling if TLS has been configured

### DIFF
--- a/providers/implementations/ciphers/ciphercommon.c
+++ b/providers/implementations/ciphers/ciphercommon.c
@@ -429,7 +429,7 @@ int ossl_cipher_generic_stream_update(void *vctx, unsigned char *out,
     }
 
     *outl = inl;
-    if (!ctx->enc) {
+    if (!ctx->enc && ctx->tlsversion > 0) {
         /*
         * Remove any TLS padding. Only used by cipher_aes_cbc_hmac_sha1_hw.c and
         * cipher_aes_cbc_hmac_sha256_hw.c


### PR DESCRIPTION
Skip over special TLS steps for stream ciphers if we haven't been
configured for TLS.

Fixes #12528

