### PR TITLE
APPS: Fix confusion between program and app/cmd/alg name used in diagnostic/help output

### DIFF
--- a/apps/cmp.c
+++ b/apps/cmp.c
@@ -42,16 +42,13 @@
 #include <openssl/objects.h>
 #include <openssl/x509.h>
 
+static char *prog;
 static char *opt_config = NULL;
 #define CMP_SECTION "cmp"
 #define SECTION_NAME_MAX 40 /* max length of section name */
 #define DEFAULT_SECTION "default"
 static char *opt_section = CMP_SECTION;
 static int opt_verbosity = OSSL_CMP_LOG_INFO;
-
-#undef PROG
-#define PROG cmp_main
-static char *prog = "cmp";
 
 static int read_config(void);
 
@@ -2625,6 +2622,7 @@ int cmp_main(int argc, char **argv)
     int ret = 0; /* default: failure */
 
     if (argc <= 1) {
+        prog = opt_appname(argv[0]);
         opt_help(cmp_options);
         goto err;
     }

--- a/apps/dgst.c
+++ b/apps/dgst.c
@@ -111,9 +111,8 @@ int dgst_main(int argc, char **argv)
     int engine_impl = 0;
     struct doall_dgst_digests dec;
 
-    prog = opt_progname(argv[0]);
     buf = app_malloc(BUFSIZE, "I/O buffer");
-    md = EVP_get_digestbyname(prog);
+    md = EVP_get_digestbyname(argv[0]);
 
     prog = opt_init(argc, argv, dgst_options);
     while ((o = opt_next()) != OPT_EOF) {

--- a/apps/enc.c
+++ b/apps/enc.c
@@ -112,7 +112,7 @@ int enc_main(int argc, char **argv)
     const EVP_CIPHER *cipher = NULL, *c;
     const EVP_MD *dgst = NULL;
     char *hkey = NULL, *hiv = NULL, *hsalt = NULL, *p;
-    char *infile = NULL, *outfile = NULL, *prog;
+    char *infile = NULL, *outfile = NULL, *prog, *arg0;
     char *str = NULL, *passarg = NULL, *pass = NULL, *strbuf = NULL;
     char mbuf[sizeof(magic) - 1];
     OPTION_CHOICE o;
@@ -131,18 +131,18 @@ int enc_main(int argc, char **argv)
     BIO *bzl = NULL;
 #endif
 
-    /* first check the program name */
-    prog = opt_progname(argv[0]);
-    if (strcmp(prog, "base64") == 0) {
+    /* first check the command name */
+    arg0 = argv[0];
+    if (strcmp(arg0, "base64") == 0) {
         base64 = 1;
 #ifdef ZLIB
-    } else if (strcmp(prog, "zlib") == 0) {
+    } else if (strcmp(arg0, "zlib") == 0) {
         do_zlib = 1;
 #endif
     } else {
-        cipher = EVP_get_cipherbyname(prog);
-        if (cipher == NULL && strcmp(prog, "enc") != 0) {
-            BIO_printf(bio_err, "%s is not a known cipher\n", prog);
+        cipher = EVP_get_cipherbyname(arg0);
+        if (cipher == NULL && strcmp(arg0, "enc") != 0) {
+            BIO_printf(bio_err, "%s is not a known cipher\n", arg0);
             goto end;
         }
     }

--- a/apps/include/opt.h
+++ b/apps/include/opt.h
@@ -341,6 +341,7 @@ typedef struct string_int_pair_st {
 
 const char *opt_path_end(const char *filename);
 char *opt_progname(const char *argv0);
+char *opt_appname(const char *arg0);
 char *opt_getprog(void);
 char *opt_init(int ac, char **av, const OPTIONS * o);
 int opt_next(void);

--- a/apps/lib/opt.c
+++ b/apps/lib/opt.c
@@ -732,7 +732,8 @@ int opt_next(void)
         *arg++ = '\0';
     for (o = opts; o->name; ++o) {
         /* If not this option, move on to the next one. */
-        if (strcmp(p, o->name) != 0)
+        if (!(strcmp(p, "h") == 0 && strcmp(o->name, "help") == 0)
+                && strcmp(p, o->name) != 0)
             continue;
 
         /* If it doesn't take a value, make sure none was given. */

--- a/apps/lib/opt.c
+++ b/apps/lib/opt.c
@@ -138,6 +138,15 @@ char *opt_progname(const char *argv0)
 }
 #endif
 
+char *opt_appname(const char *arg0)
+{
+    size_t len = strlen(prog);
+
+    if (arg0 != NULL)
+        snprintf(prog + len, sizeof(prog) - len - 1, " %s", arg0);
+    return prog;
+}
+
 char *opt_getprog(void)
 {
     return prog;
@@ -151,7 +160,6 @@ char *opt_init(int ac, char **av, const OPTIONS *o)
     argv = av;
     opt_begin();
     opts = o;
-    opt_progname(av[0]);
     unknown = NULL;
 
     /* Check all options up until the PARAM marker (if present) */

--- a/apps/openssl.c
+++ b/apps/openssl.c
@@ -237,6 +237,7 @@ int main(int argc, char *argv[])
     char *pname;
     const char *fname;
     ARGS arg;
+    int global_help = 0;
     int ret = 0;
 
     arg.argv = NULL;
@@ -277,18 +278,21 @@ int main(int argc, char *argv[])
     f.name = pname;
     fp = lh_FUNCTION_retrieve(prog, &f);
     if (fp == NULL) {
-        /* We assume we've been called as 'openssl cmd' */
+        /* We assume we've been called as 'openssl ...' */
+        global_help = argc > 1
+            && (strcmp(argv[1], "-help") == 0 || strcmp(argv[1], "--help") == 0
+                || strcmp(argv[1], "-h") == 0 || strcmp(argv[1], "--h") == 0);
         argc--;
         argv++;
-        opt_appname(argv[0]);
+        opt_appname(argc == 1 || global_help ? "help" : argv[0]);
     } else {
         argv[0] = pname;
     }
 
     /* If there's a command, run with that, otherwise "help". */
-    ret = argc > 0
-        ? do_cmd(prog, argc, argv)
-        : do_cmd(prog, 1, help_argv);
+    ret = argc == 0 || global_help
+        ? do_cmd(prog, 1, help_argv)
+        : do_cmd(prog, argc, argv);
 
  end:
     OPENSSL_free(default_config_file);

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -1010,7 +1010,6 @@ int s_client_main(int argc, char **argv)
 # endif
 #endif
 
-    prog = opt_progname(argv[0]);
     c_quiet = 0;
     c_debug = 0;
     c_showcerts = 0;
@@ -1019,7 +1018,7 @@ int s_client_main(int argc, char **argv)
     cctx = SSL_CONF_CTX_new();
 
     if (vpm == NULL || cctx == NULL) {
-        BIO_printf(bio_err, "%s: out of memory\n", prog);
+        BIO_printf(bio_err, "%s: out of memory\n", opt_getprog());
         goto end;
     }
 

--- a/test/recipes/20-test_app.t
+++ b/test/recipes/20-test_app.t
@@ -13,7 +13,7 @@ use OpenSSL::Test;
 
 setup("test_app");
 
-plan tests => 3;
+plan tests => 5;
 
 ok(run(app(["openssl"])),
    "Run openssl app with no args");
@@ -21,5 +21,11 @@ ok(run(app(["openssl"])),
 ok(run(app(["openssl", "help"])),
    "Run openssl app with help");
 
-ok(!run(app(["openssl", "-help"])),
+ok(!run(app(["openssl", "-wrong"])),
    "Run openssl app with incorrect arg");
+
+ok(run(app(["openssl", "-help"])),
+   "Run openssl app with -help");
+
+ok(run(app(["openssl", "--help"])),
+   "Run openssl app with --help");


### PR DESCRIPTION
The app-internal `prog` variable has been used in an inconsistent way when printing help or error output
due to some confusion of the program name (usually `openssl`) and the app/cmd/alg name (such as `x509` or `des`).

This PR aims at cleaning this up by making sure that 
after `prog` initially holds the bare program name,
a space char and the app/cmd/alg name is appended when available.

This way for instance `openssl x509 --help` does not anymore print
```
Usage: x509 [options]
```
but
```
Usage: openssl x509 [options]
```

On this occasion I made sure that `openssl --help` and `openssl -help` do not complain
```
Invalid command '--help'; type "help" for a list.
```
but immediately prints the high-level help
and that this starts by echoing the program name:
```
openssl help:

Standard commands
[...]
```

- [x] tests are added or updated