### PR TITLE
Fix simpledynamic test compilation when condigured without DSO support.

### DIFF
--- a/test/simpledynamic.h
+++ b/test/simpledynamic.h
@@ -36,9 +36,11 @@ typedef void *SD_SYM;
 
 # endif
 
+# if defined(DSO_DLFCN) || defined(DSO_WIN32)
 int sd_load(const char *filename, SD *sd, int type);
 int sd_sym(SD sd, const char *symname, SD_SYM *sym);
 int sd_close(SD lib);
 const char *sd_error(void);
+# endif
 
 #endif


### PR DESCRIPTION
This fixes this compilation error with the new alpha 10 when configured without DSO support on Linux:

```
In file included from test/simpledynamic.c:13:
test/simpledynamic.h:39:35: error: unknown type name 'SD'
   39 | int sd_load(const char *filename, SD *sd, int type);
      |                                   ^~
test/simpledynamic.h:40:12: error: unknown type name 'SD'
   40 | int sd_sym(SD sd, const char *symname, SD_SYM *sym);
      |            ^~
test/simpledynamic.h:40:40: error: unknown type name 'SD_SYM'
   40 | int sd_sym(SD sd, const char *symname, SD_SYM *sym);
      |                                        ^~~~~~
test/simpledynamic.h:41:14: error: unknown type name 'SD'
   41 | int sd_close(SD lib);
      |              ^~
make[1]: *** [Makefile:24670: test/moduleloadtest-bin-simpledynamic.o] Error 1
make[1]: *** Waiting for unfinished jobs....
In file included from test/moduleloadtest.c:19:
test/simpledynamic.h:39:35: error: unknown type name 'SD'
   39 | int sd_load(const char *filename, SD *sd, int type);
      |                                   ^~
test/simpledynamic.h:40:12: error: unknown type name 'SD'
   40 | int sd_sym(SD sd, const char *symname, SD_SYM *sym);
      |            ^~
test/simpledynamic.h:40:40: error: unknown type name 'SD_SYM'
   40 | int sd_sym(SD sd, const char *symname, SD_SYM *sym);
      |                                        ^~~~~~
test/simpledynamic.h:41:14: error: unknown type name 'SD'
   41 | int sd_close(SD lib);
      |              ^~
```