### PR TITLE
x509 find_issuer(): When returning an expired issuer, take the most recently expired one

### DIFF
--- a/doc/man1/openssl-verification-options.pod
+++ b/doc/man1/openssl-verification-options.pod
@@ -36,6 +36,8 @@ name of the current certificate are subject to further tests.
 The relevant authority key identifier components of the current certificate
 (if present) must match the subject key identifier (if present)
 and issuer and serial number of the candidate issuer certificate.
+If there is such a certificate, the first one found that is currently valid
+is taken, otherwise the one that expired most recently of all such certificates.
 
 The lookup first searches for issuer certificates in the trust store.
 If it does not find a match there it consults


### PR DESCRIPTION
Also point out in the documenting comment that a non-expired issuer is preferred.
This is a spin-off of #13762.

For the internal function `find_issuer()` the behavior on expired issuer certs was not properly described.
This is fixed by this PR, as well as an oddity: If only expired ones are found, so far the function returned the last such one,
which was inconsistent with other lookup functions and thus would have been needed to be explicitly documented.
Now, the function returns in such a situation ~the first such issuer~ the most recently expired one.

Note that this PR does not modify successful chain building but may only affect which of several expired cert is reported as such.