### PR TITLE
Abstract out policy and extensions in CA.pl

### DIFF
--- a/apps/CA.pl.in
+++ b/apps/CA.pl.in
@@ -1,5 +1,5 @@
 #!{- $config{HASHBANGPERL} -}
-# Copyright 2000-2020 The OpenSSL Project Authors. All Rights Reserved.
+# Copyright 2000-2021 The OpenSSL Project Authors. All Rights Reserved.
 #
 # Licensed under the Apache License 2.0 (the "License").  You may not use
 # this file except in compliance with the License.  You can obtain a copy
@@ -36,6 +36,8 @@ my $CACERT = "cacert.pem";
 my $CACRL = "crl.pem";
 my $DAYS = "-days 365";
 my $CADAYS = "-days 1095";	# 3 years
+my $EXTENSIONS = "-extensions v3_ca";
+my $POLICY = "-policy policy_anything";
 my $NEWKEY = "newkey.pem";
 my $NEWREQ = "newreq.pem";
 my $NEWCERT = "newcert.pem";
@@ -179,7 +181,7 @@ if ($WHAT eq '-newcert' ) {
         $RET = run("$CA -create_serial"
                 . " -out ${CATOP}/$CACERT $CADAYS -batch"
                 . " -keyfile ${CATOP}/private/$CAKEY -selfsign"
-                . " -extensions v3_ca"
+                . " $EXTENSIONS"
                 . " -infiles ${CATOP}/$CAREQ $EXTRA{ca}") if $RET == 0;
         print "CA certificate is in ${CATOP}/$CACERT\n" if $RET == 0;
     }
@@ -191,19 +193,19 @@ if ($WHAT eq '-newcert' ) {
             . " -export -name \"$cname\" $EXTRA{pkcs12}");
     print "PKCS #12 file is in $NEWP12\n" if $RET == 0;
 } elsif ($WHAT eq '-xsign' ) {
-    $RET = run("$CA -policy policy_anything -infiles $NEWREQ $EXTRA{ca}");
+    $RET = run("$CA $POLICY -infiles $NEWREQ $EXTRA{ca}");
 } elsif ($WHAT eq '-sign' ) {
-    $RET = run("$CA -policy policy_anything -out $NEWCERT"
+    $RET = run("$CA $POLICY -out $NEWCERT"
             . " -infiles $NEWREQ $EXTRA{ca}");
     print "Signed certificate is in $NEWCERT\n" if $RET == 0;
 } elsif ($WHAT eq '-signCA' ) {
-    $RET = run("$CA -policy policy_anything -out $NEWCERT"
-            . " -extensions v3_ca -infiles $NEWREQ $EXTRA{ca}");
+    $RET = run("$CA $POLICY -out $NEWCERT"
+            . " $EXTENSIONS -infiles $NEWREQ $EXTRA{ca}");
     print "Signed CA certificate is in $NEWCERT\n" if $RET == 0;
 } elsif ($WHAT eq '-signcert' ) {
     $RET = run("$X509 -x509toreq -in $NEWREQ -signkey $NEWREQ"
             . " -out tmp.pem $EXTRA{x509}");
-    $RET = run("$CA -policy policy_anything -out $NEWCERT"
+    $RET = run("$CA $POLICY -out $NEWCERT"
             .  "-infiles tmp.pem $EXTRA{ca}") if $RET == 0;
     print "Signed certificate is in $NEWCERT\n" if $RET == 0;
 } elsif ($WHAT eq '-verify' ) {


### PR DESCRIPTION
This lets you customize extensions and policy used in CA.pl in one place rather than scattered around.

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
