### PR TITLE
Make the OSSL_SELF_TEST manual conform with man-pages(7)

### DIFF
--- a/doc/man3/OSSL_SELF_TEST_set_callback.pod
+++ b/doc/man3/OSSL_SELF_TEST_set_callback.pod
@@ -24,7 +24,8 @@ See L<openssl-core.h(7)> for further information on the callback.
 =head1 RETURN VALUES
 
 OSSL_SELF_TEST_get_callback() returns the callback and callback argument that
-has been set via OSSL_SELF_TEST_set_callback() for the given library context B<ctx>.
+has been set via OSSL_SELF_TEST_set_callback() for the given library context
+I<ctx>.
 These returned parameters will be NULL if OSSL_SELF_TEST_set_callback() has
 not been called.
 


### PR DESCRIPTION
Details from man-pages(7) that are used:

    Formatting conventions for manual pages describing functions

        ...
        Variable names should, like argument names, be specified in italics.
        ...

    Formatting conventions (general)

        ...
        Special macros, which are usually in uppercase, are in bold.
        Exception: don't boldface NULL.
        ...
