### PR TITLE
chacha20: Properly reinitialize the cipher context with NULL key

### DIFF
--- a/providers/implementations/ciphers/cipher_chacha20_hw.c
+++ b/providers/implementations/ciphers/cipher_chacha20_hw.c
@@ -34,6 +34,7 @@ static int chacha20_initiv(PROV_CIPHER_CTX *bctx)
         for (i = 0; i < CHACHA_CTR_SIZE; i += 4)
             ctx->counter[i / 4] = CHACHA_U8TOU32(bctx->oiv + i);
     }
+    ctx->partial_len = 0;
     return 1;
 }
 

--- a/providers/implementations/ciphers/cipher_chacha20_poly1305_hw.c
+++ b/providers/implementations/ciphers/cipher_chacha20_poly1305_hw.c
@@ -79,6 +79,12 @@ static int chacha20_poly1305_initiv(PROV_CIPHER_CTX *bctx)
     unsigned char tempiv[CHACHA_CTR_SIZE] = { 0 };
     int ret = 1;
 
+    ctx->len.aad = 0;
+    ctx->len.text = 0;
+    ctx->aad = 0;
+    ctx->mac_inited = 0;
+    ctx->tls_payload_length = NO_TLS_PAYLOAD_LENGTH;
+
         /* pad on the left */
     if (ctx->nonce_len <= CHACHA_CTR_SIZE) {
             memcpy(tempiv + CHACHA_CTR_SIZE - ctx->nonce_len, bctx->oiv,


### PR DESCRIPTION
Same for chacha20-poly1305.

The test_cipher_reinit and test_cipher_reinit_partialupdate is modified
to test this case of cipher context reinitialization.

Fixes #13064

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
