### PR TITLE
Support /dev/crypto on FreeBSD 12.x and older

### DIFF
--- a/crypto/engine/eng_devcrypto.c
+++ b/crypto/engine/eng_devcrypto.c
@@ -771,9 +771,11 @@ void engine_load_devcrypto_int()
 #ifdef CRIOGET
     if (ioctl(fd, CRIOGET, &cfd) < 0) {
         fprintf(stderr, "Could not create crypto fd: %s\n", strerror(errno));
+        close(fd);
         cfd = -1;
         return;
     }
+    close(fd);
 #else
     cfd = fd;
 #endif


### PR DESCRIPTION
This is a cherry-pick of the first change from #13468 and the followup fix in #13807.  Note that the commit to use CIOCGSESSION2 to select between hardware and software drivers from #13468 is not included as the related code changes to support the same functionality on Linux are not present in the 1.1.1 branch.