### PR TITLE
A couple of small no-deprecated fixes

### DIFF
--- a/crypto/des/build.info
+++ b/crypto/des/build.info
@@ -31,7 +31,7 @@ DEFINE[../../providers/liblegacy.a]=$DESDEF
 
 # When all deprecated symbols are removed, libcrypto doesn't export the
 # DES functions, so we must include them directly in liblegacy.a
-IF[{- $disabled{'deprecated-3.0'} && !$disabled{"mdc2"} -}]
+IF[{- $disabled{'deprecated-3.0'} && !$disabled{des} -}]
   SOURCE[../../providers/liblegacy.a]=$ALL
   DEFINE[../../providers/liblegacy.a]=$DESDEF
 ENDIF

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -8157,7 +8157,7 @@ static EVP_PKEY *get_tmp_dh_params(void)
     return tmp_dh_params;
 }
 
-#  ifndef OPENSSL_NO_DEPRECATED
+#  ifndef OPENSSL_NO_DEPRECATED_3_0
 /* Callback used by test_set_tmp_dh() */
 static DH *tmp_dh_callback(SSL *s, int is_export, int keylen)
 {


### PR DESCRIPTION
## Fix crypto/des/build.info

!$disabled{mdc2} was used to determine if DES files should be included
in providers/liblegacy.a.  Use !$disabled{des} instead.

##  Fix incomplete deprecation guard in test/sslapitest.c

OPENSSL_NO_DEPRECATED_3_0 should be used rather than OPENSSL_NO_DEPRECATED,
as the latter doesn't take the configuration option '--api=' in account.

Fixes #13865