### PR TITLE
Allow MinGW build to use BCryptGenRandom like MSVC build [master]

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1592,7 +1592,7 @@ my %targets = (
         cppflags         => combine("-DUNICODE -D_UNICODE -DWIN32_LEAN_AND_MEAN",
                                     threads("-D_MT")),
         lib_cppflags     => "-DL_ENDIAN",
-        ex_libs          => add("-lws2_32 -lgdi32 -lcrypt32"),
+        ex_libs          => add("-lws2_32 -lgdi32 -lcrypt32 -lbcrypt"),
         thread_scheme    => "winthreads",
         dso_scheme       => "win32",
         shared_target    => "mingw-shared",

--- a/providers/implementations/rands/seeding/rand_win.c
+++ b/providers/implementations/rands/seeding/rand_win.c
@@ -21,8 +21,9 @@
 #endif
 
 /* On Windows Vista or higher use BCrypt instead of the legacy CryptoAPI */
-#if defined(_MSC_VER) && _MSC_VER > 1500 /* 1500 = Visual Studio 2008 */ \
-    && defined(_WIN32_WINNT) && _WIN32_WINNT >= 0x0600
+#if defined(_WIN32_WINNT) && _WIN32_WINNT >= 0x0600 \
+    && ((defined(_MSC_VER) && _MSC_VER > 1500)      \
+        || (defined(__MINGW64_VERSION_MAJOR) && __MINGW64_VERSION_MAJOR >= 2))
 #define USE_BCRYPTGENRANDOM
 #endif
 


### PR DESCRIPTION
This updates the Windows RAND seeding implementation so MinGW-w64 builds use `BCryptGenRandom` through the same `USE_BCRYPTGENRANDOM` path already used by supported MSVC builds.

After more than five years since this PR was opened, the implementation has been simplified. Instead of dynamically loading `bcrypt.dll` at runtime with `LoadLibraryA`/`GetProcAddress`, MinGW-w64 builds now link directly against the bcrypt import library via `-lbcrypt`.

The MinGW-w64 guard uses `__MINGW64_VERSION_MAJOR`, which is defined by both the 32-bit and 64-bit MinGW-w64 toolchains. BCrypt is enabled only when `_WIN32_WINNT >= 0x0600`: builds targeting older Windows versions continue to use the existing CryptoAPI fallback.

Fixes #13878