### PR TITLE
DOCS: Fix incorrect pass phrase options references [1.1.1]

### DIFF
--- a/doc/man1/ca.pod
+++ b/doc/man1/ca.pod
@@ -163,7 +163,7 @@ self-signed certificate.
 =item B<-passin arg>
 
 The key password source. For more information about the format of B<arg>
-see the B<PASS PHRASE ARGUMENTS> section in L<openssl(1)>.
+see L<openssl(1)/Pass Phrase Options>.
 
 =item B<-notext>
 

--- a/doc/man1/cms.pod
+++ b/doc/man1/cms.pod
@@ -465,7 +465,7 @@ or to modify default parameters for ECDH.
 =item B<-passin arg>
 
 The private key password source. For more information about the format of B<arg>
-see the B<PASS PHRASE ARGUMENTS> section in L<openssl(1)>.
+see L<openssl(1)/Pass Phrase Options>.
 
 =item B<-rand file...>
 

--- a/doc/man1/dgst.pod
+++ b/doc/man1/dgst.pod
@@ -109,7 +109,7 @@ Names and values of these options are algorithm-specific.
 =item B<-passin arg>
 
 The private key password source. For more information about the format of B<arg>
-see the B<PASS PHRASE ARGUMENTS> section in L<openssl(1)>.
+see L<openssl(1)/Pass Phrase Options>.
 
 =item B<-verify filename>
 

--- a/doc/man1/dsa.pod
+++ b/doc/man1/dsa.pod
@@ -75,7 +75,7 @@ prompted for.
 =item B<-passin arg>
 
 The input file password source. For more information about the format of B<arg>
-see the B<PASS PHRASE ARGUMENTS> section in L<openssl(1)>.
+see L<openssl(1)/Pass Phrase Options>.
 
 =item B<-out filename>
 
@@ -87,7 +87,7 @@ filename.
 =item B<-passout arg>
 
 The output file password source. For more information about the format of B<arg>
-see the B<PASS PHRASE ARGUMENTS> section in L<openssl(1)>.
+see L<openssl(1)/Pass Phrase Options>.
 
 =item B<-aes128>, B<-aes192>, B<-aes256>, B<-aria128>, B<-aria192>, B<-aria256>, B<-camellia128>, B<-camellia192>, B<-camellia256>, B<-des>, B<-des3>, B<-idea>
 

--- a/doc/man1/ec.pod
+++ b/doc/man1/ec.pod
@@ -68,7 +68,7 @@ prompted for.
 =item B<-passin arg>
 
 The input file password source. For more information about the format of B<arg>
-see the B<PASS PHRASE ARGUMENTS> section in L<openssl(1)>.
+see L<openssl(1)/Pass Phrase Options>.
 
 =item B<-out filename>
 
@@ -80,7 +80,7 @@ filename.
 =item B<-passout arg>
 
 The output file password source. For more information about the format of B<arg>
-see the B<PASS PHRASE ARGUMENTS> section in L<openssl(1)>.
+see L<openssl(1)/Pass Phrase Options>.
 
 =item B<-des|-des3|-idea>
 

--- a/doc/man1/enc.pod
+++ b/doc/man1/enc.pod
@@ -76,7 +76,7 @@ The output filename, standard output by default.
 =item B<-pass arg>
 
 The password source. For more information about the format of B<arg>
-see the B<PASS PHRASE ARGUMENTS> section in L<openssl(1)>.
+see L<openssl(1)/Pass Phrase Options>.
 
 =item B<-e>
 

--- a/doc/man1/genpkey.pod
+++ b/doc/man1/genpkey.pod
@@ -44,7 +44,7 @@ This specifies the output format DER or PEM. The default format is PEM.
 =item B<-pass arg>
 
 The output file password source. For more information about the format of B<arg>
-see the B<PASS PHRASE ARGUMENTS> section in L<openssl(1)>.
+see L<openssl(1)/Pass Phrase Options>.
 
 =item B<-I<cipher>>
 

--- a/doc/man1/genrsa.pod
+++ b/doc/man1/genrsa.pod
@@ -51,7 +51,7 @@ standard output is used.
 =item B<-passout arg>
 
 The output file password source. For more information about the format
-of B<arg> see the B<PASS PHRASE ARGUMENTS> section in L<openssl(1)>.
+of B<arg> see L<openssl(1)/Pass Phrase Options>.
 
 =item B<-aes128>, B<-aes192>, B<-aes256>, B<-aria128>, B<-aria192>, B<-aria256>, B<-camellia128>, B<-camellia192>, B<-camellia256>, B<-des>, B<-des3>, B<-idea>
 

--- a/doc/man1/pkcs12.pod
+++ b/doc/man1/pkcs12.pod
@@ -78,14 +78,12 @@ default.  They are all written in PEM format.
 =item B<-passin arg>
 
 The PKCS#12 file (i.e. input file) password source. For more information about
-the format of B<arg> see the B<PASS PHRASE ARGUMENTS> section in
-L<openssl(1)>.
+the format of B<arg> see L<openssl(1)/Pass Phrase Options>.
 
 =item B<-passout arg>
 
 Pass phrase source to encrypt any outputted private keys with. For more
-information about the format of B<arg> see the B<PASS PHRASE ARGUMENTS> section
-in L<openssl(1)>.
+information about the format of B<arg> see L<openssl(1)/Pass Phrase Options>.
 
 =item B<-password arg>
 
@@ -206,14 +204,12 @@ displays them.
 =item B<-pass arg>, B<-passout arg>
 
 The PKCS#12 file (i.e. output file) password source. For more information about
-the format of B<arg> see the B<PASS PHRASE ARGUMENTS> section in
-L<openssl(1)>.
+the format of B<arg> see L<openssl(1)/Pass Phrase Options>.
 
 =item B<-passin password>
 
 Pass phrase source to decrypt any input private keys with. For more information
-about the format of B<arg> see the B<PASS PHRASE ARGUMENTS> section in
-L<openssl(1)>.
+about the format of B<arg> see L<openssl(1)/Pass Phrase Options>.
 
 =item B<-chain>
 

--- a/doc/man1/pkcs8.pod
+++ b/doc/man1/pkcs8.pod
@@ -75,7 +75,7 @@ prompted for.
 =item B<-passin arg>
 
 The input file password source. For more information about the format of B<arg>
-see the B<PASS PHRASE ARGUMENTS> section in L<openssl(1)>.
+see L<openssl(1)/Pass Phrase Options>.
 
 =item B<-out filename>
 
@@ -87,7 +87,7 @@ filename.
 =item B<-passout arg>
 
 The output file password source. For more information about the format of B<arg>
-see the B<PASS PHRASE ARGUMENTS> section in L<openssl(1)>.
+see L<openssl(1)/Pass Phrase Options>.
 
 =item B<-iter count>
 

--- a/doc/man1/pkey.pod
+++ b/doc/man1/pkey.pod
@@ -57,7 +57,7 @@ prompted for.
 =item B<-passin arg>
 
 The input file password source. For more information about the format of B<arg>
-see the B<PASS PHRASE ARGUMENTS> section in L<openssl(1)>.
+see L<openssl(1)/Pass Phrase Options>.
 
 =item B<-out filename>
 
@@ -69,7 +69,7 @@ filename.
 =item B<-passout password>
 
 The output file password source. For more information about the format of B<arg>
-see the B<PASS PHRASE ARGUMENTS> section in L<openssl(1)>.
+see L<openssl(1)/Pass Phrase Options>.
 
 =item B<-traditional>
 

--- a/doc/man1/pkeyutl.pod
+++ b/doc/man1/pkeyutl.pod
@@ -74,7 +74,7 @@ The key format PEM, DER or ENGINE. Default is PEM.
 =item B<-passin arg>
 
 The input key password source. For more information about the format of B<arg>
-see the B<PASS PHRASE ARGUMENTS> section in L<openssl(1)>.
+see L<openssl(1)/Pass Phrase Options>.
 
 =item B<-peerkey file>
 

--- a/doc/man1/req.pod
+++ b/doc/man1/req.pod
@@ -91,7 +91,7 @@ Names and values of these options are algorithm-specific.
 =item B<-passin arg>
 
 The input file password source. For more information about the format of B<arg>
-see the B<PASS PHRASE ARGUMENTS> section in L<openssl(1)>.
+see L<openssl(1)/Pass Phrase Options>.
 
 =item B<-out filename>
 
@@ -101,7 +101,7 @@ default.
 =item B<-passout arg>
 
 The output file password source. For more information about the format of B<arg>
-see the B<PASS PHRASE ARGUMENTS> section in L<openssl(1)>.
+see L<openssl(1)/Pass Phrase Options>.
 
 =item B<-text>
 

--- a/doc/man1/rsa.pod
+++ b/doc/man1/rsa.pod
@@ -75,7 +75,7 @@ prompted for.
 =item B<-passin arg>
 
 The input file password source. For more information about the format of B<arg>
-see the B<PASS PHRASE ARGUMENTS> section in L<openssl(1)>.
+see L<openssl(1)/Pass Phrase Options>.
 
 =item B<-out filename>
 
@@ -87,7 +87,7 @@ filename.
 =item B<-passout password>
 
 The output file password source. For more information about the format of B<arg>
-see the B<PASS PHRASE ARGUMENTS> section in L<openssl(1)>.
+see L<openssl(1)/Pass Phrase Options>.
 
 =item B<-aes128>, B<-aes192>, B<-aes256>, B<-aria128>, B<-aria192>, B<-aria256>, B<-camellia128>, B<-camellia192>, B<-camellia256>, B<-des>, B<-des3>, B<-idea>
 

--- a/doc/man1/s_client.pod
+++ b/doc/man1/s_client.pod
@@ -258,7 +258,7 @@ Extra certificate and private key format respectively.
 =item B<-pass arg>
 
 the private key password source. For more information about the format of B<arg>
-see the B<PASS PHRASE ARGUMENTS> section in L<openssl(1)>.
+see L<openssl(1)/Pass Phrase Options>.
 
 =item B<-verify depth>
 

--- a/doc/man1/s_server.pod
+++ b/doc/man1/s_server.pod
@@ -297,7 +297,7 @@ The private format to use: DER or PEM. PEM is the default.
 =item B<-pass val>
 
 The private key password source. For more information about the format of B<val>
-see the B<PASS PHRASE ARGUMENTS> section in L<openssl(1)>.
+see L<openssl(1)/Pass Phrase Options>.
 
 =item B<-dcert infile>, B<-dkey infile>
 

--- a/doc/man1/smime.pod
+++ b/doc/man1/smime.pod
@@ -295,7 +295,7 @@ specified, the argument is given to the engine as a key identifier.
 =item B<-passin arg>
 
 The private key password source. For more information about the format of B<arg>
-see the B<PASS PHRASE ARGUMENTS> section in L<openssl(1)>.
+see L<openssl(1)/Pass Phrase Options>.
 
 =item B<-rand file...>
 

--- a/doc/man1/spkac.pod
+++ b/doc/man1/spkac.pod
@@ -60,7 +60,7 @@ The default is PEM.
 =item B<-passin password>
 
 The input file password source. For more information about the format of B<arg>
-see the B<PASS PHRASE ARGUMENTS> section in L<openssl(1)>.
+see L<openssl(1)/Pass Phrase Options>.
 
 =item B<-challenge string>
 

--- a/doc/man1/storeutl.pod
+++ b/doc/man1/storeutl.pod
@@ -51,7 +51,7 @@ this option prevents output of the PEM data.
 =item B<-passin arg>
 
 the key password source. For more information about the format of B<arg>
-see the B<PASS PHRASE ARGUMENTS> section in L<openssl(1)>.
+see L<openssl(1)/Pass Phrase Options>.
 
 =item B<-text>
 

--- a/doc/man1/ts.pod
+++ b/doc/man1/ts.pod
@@ -242,7 +242,7 @@ The name of the file containing a DER encoded timestamp request. (Optional)
 =item B<-passin> password_src
 
 Specifies the password source for the private key of the TSA. See
-B<PASS PHRASE ARGUMENTS> in L<openssl(1)>. (Optional)
+the B<PASS PHRASE ARGUMENTS> in L<openssl(1)>. (Optional)
 
 =item B<-signer> tsa_cert.pem
 

--- a/doc/man1/ts.pod
+++ b/doc/man1/ts.pod
@@ -242,7 +242,7 @@ The name of the file containing a DER encoded timestamp request. (Optional)
 =item B<-passin> password_src
 
 Specifies the password source for the private key of the TSA. See
-the B<PASS PHRASE ARGUMENTS> in L<openssl(1)>. (Optional)
+L<openssl(1)/Pass Phrase Options>. (Optional)
 
 =item B<-signer> tsa_cert.pem
 

--- a/doc/man1/x509.pod
+++ b/doc/man1/x509.pod
@@ -376,7 +376,7 @@ Names and values of these options are algorithm-specific.
 =item B<-passin arg>
 
 The key password source. For more information about the format of B<arg>
-see the B<PASS PHRASE ARGUMENTS> section in L<openssl(1)>.
+see L<openssl(1)/Pass Phrase Options>.
 
 =item B<-clrext>
 


### PR DESCRIPTION
There were a number of older style references to the pass phrase
options section, now streamlined with the current openssl(1).

Fixes #13883
