### PR TITLE
Ensure SRP BN_mod_exp follows the constant time path

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1374,7 +1374,20 @@ OpenSSL 3.0
 OpenSSL 1.1.1
 -------------
 
-### Changes between 1.1.1h and 1.1.1i [xx XXX xxxx]
+### Changes between 1.1.1i and 1.1.1j [xx XXX xxxx]
+
+ * Fixed SRP_Calc_client_key so that it uses constant time. The previous
+   implementation called BN_mod_exp without setting BN_FLG_CONSTTIME. This
+   could be exploited in a side channel attack to recover the password. Since
+   the attack is local host only this is outside of the current OpenSSL
+   threat model and therefore no CVE is assigned.
+
+   Thanks to Mohammed Sabt and Daniel De Almeida Braga for reporting this
+   issue.
+
+   *Matt Caswell*
+
+### Changes between 1.1.1h and 1.1.1i [8 Dec 2020]
 
  * Fixed NULL pointer deref in the GENERAL_NAME_cmp function
    This function could crash if both GENERAL_NAMEs contain an EDIPARTYNAME.


### PR DESCRIPTION
SRP_Calc_client_key calls BN_mod_exp with private data. However it was
not setting BN_FLG_CONSTTIME and therefore not using the constant time
implementation. This could be exploited in a side channel attack to
recover the password.

Since the attack is local host only this is outside of the current OpenSSL
threat model and therefore no CVE is assigned.

Thanks to Mohammed Sabt and Daniel De Almeida Braga for reporting this
issue.
