### PR TITLE
Ensure SRP BN_mod_exp follows the constant time path (1.1.1)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,7 +9,15 @@
 
  Changes between 1.1.1i and 1.1.1j [xx XXX xxxx]
 
-  *)
+  *) Fixed SRP_Calc_client_key so that it uses constant time. The previous
+     implementation called BN_mod_exp without setting BN_FLG_CONSTTIME. This
+     could be exploited in a side channel attack to recover the password. Since
+     the attack is local host only this is outside of the current OpenSSL
+     threat model and therefore no CVE is assigned.
+
+     Thanks to Mohammed Sabt and Daniel De Almeida Braga for reporting this
+     issue.
+     [Matt Caswell]
 
  Changes between 1.1.1h and 1.1.1i [8 Dec 2020]
 

--- a/crypto/srp/srp_lib.c
+++ b/crypto/srp/srp_lib.c
@@ -177,6 +177,7 @@ BIGNUM *SRP_Calc_client_key(const BIGNUM *N, const BIGNUM *B, const BIGNUM *g,
                             const BIGNUM *x, const BIGNUM *a, const BIGNUM *u)
 {
     BIGNUM *tmp = NULL, *tmp2 = NULL, *tmp3 = NULL, *k = NULL, *K = NULL;
+    BIGNUM *xtmp = NULL;
     BN_CTX *bn_ctx;
 
     if (u == NULL || B == NULL || N == NULL || g == NULL || x == NULL
@@ -185,10 +186,13 @@ BIGNUM *SRP_Calc_client_key(const BIGNUM *N, const BIGNUM *B, const BIGNUM *g,
 
     if ((tmp = BN_new()) == NULL ||
         (tmp2 = BN_new()) == NULL ||
-        (tmp3 = BN_new()) == NULL)
+        (tmp3 = BN_new()) == NULL ||
+        (xtmp = BN_new()) == NULL)
         goto err;
 
-    if (!BN_mod_exp(tmp, g, x, N, bn_ctx))
+    BN_with_flags(xtmp, x, BN_FLG_CONSTTIME);
+    BN_set_flags(tmp, BN_FLG_CONSTTIME);
+    if (!BN_mod_exp(tmp, g, xtmp, N, bn_ctx))
         goto err;
     if ((k = srp_Calc_k(N, g)) == NULL)
         goto err;
@@ -196,7 +200,7 @@ BIGNUM *SRP_Calc_client_key(const BIGNUM *N, const BIGNUM *B, const BIGNUM *g,
         goto err;
     if (!BN_mod_sub(tmp, B, tmp2, N, bn_ctx))
         goto err;
-    if (!BN_mul(tmp3, u, x, bn_ctx))
+    if (!BN_mul(tmp3, u, xtmp, bn_ctx))
         goto err;
     if (!BN_add(tmp2, a, tmp3))
         goto err;
@@ -208,6 +212,7 @@ BIGNUM *SRP_Calc_client_key(const BIGNUM *N, const BIGNUM *B, const BIGNUM *g,
 
  err:
     BN_CTX_free(bn_ctx);
+    BN_free(xtmp);
     BN_clear_free(tmp);
     BN_clear_free(tmp2);
     BN_clear_free(tmp3);


### PR DESCRIPTION
SRP_Calc_client_key calls BN_mod_exp with private data. However it was
not setting BN_FLG_CONSTTIME and therefore not using the constant time
implementation. This could be exploited in a side channel attack to
recover the password.

Since the attack is local host only this is outside of the current OpenSSL
threat model and therefore no CVE is assigned.

Thanks to Mohammed Sabt and Daniel De Almeida Braga for reporting this
issue.
