### PR TITLE
Fix low-level and legacy HTTP API

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,15 +23,15 @@ OpenSSL 3.0
 
 ### Changes between 1.1.1 and 3.0 [xx XXX xxxx]
 
- * Deprecated the type OCSP_REQ_CTX and the functions OCSP_REQ_CTX_new(), 
+ * Deprecated the type OCSP_REQ_CTX and the functions OCSP_REQ_CTX_new(),
    OCSP_REQ_CTX_free(), OCSP_REQ_CTX_http(), OCSP_REQ_CTX_add1_header(),
    OCSP_REQ_CTX_i2d(), OCSP_REQ_CTX_nbio(), OCSP_REQ_CTX_nbio_d2i(),
    OCSP_REQ_CTX_get0_mem_bio() and OCSP_set_max_response_length().  These
    were used to collect all necessary data to form a HTTP request, and to
    perform the HTTP transfer with that request.  With OpenSSL 3.0, the
    type is OSSL_HTTP_REQ_CTX, and the deprecated functions are replaced
-   with OSSL_HTTP_REQ_CTX_new(), OSSL_HTTP_REQ_CTX_free(), 
-   OSSL_HTTP_REQ_CTX_header(), OSSL_HTTP_REQ_CTX_add1_header(),
+   with OSSL_HTTP_REQ_CTX_new(), OSSL_HTTP_REQ_CTX_free(),
+   OSSL_HTTP_REQ_CTX_set_request_line(), OSSL_HTTP_REQ_CTX_add1_header(),
    OSSL_HTTP_REQ_CTX_i2d(), OSSL_HTTP_REQ_CTX_nbio(),
    OSSL_HTTP_REQ_CTX_sendreq_d2i(), OSSL_HTTP_REQ_CTX_get0_mem_bio() and
    OSSL_HTTP_REQ_CTX_set_max_response_length().

--- a/crypto/http/http_client.c
+++ b/crypto/http/http_client.c
@@ -138,11 +138,12 @@ void OSSL_HTTP_REQ_CTX_set_max_response_length(OSSL_HTTP_REQ_CTX *rctx,
 }
 
 /*
- * Create HTTP header using given op and path (or "/" in case path is NULL).
+ * Create request line using |ctx| and |path| (or "/" in case |path| is NULL).
  * Server name (and port) must be given if and only if plain HTTP proxy is used.
  */
-int OSSL_HTTP_REQ_CTX_header(OSSL_HTTP_REQ_CTX *rctx, const char *server,
-                             const char *port, const char *path)
+int OSSL_HTTP_REQ_CTX_set_request_line(OSSL_HTTP_REQ_CTX *rctx,
+                                       const char *server, const char *port,
+                                       const char *path)
 {
     if (rctx == NULL) {
         ERR_raise(ERR_LIB_HTTP, ERR_R_PASSED_NULL_PARAMETER);
@@ -309,8 +310,9 @@ OSSL_HTTP_REQ_CTX *HTTP_REQ_CTX_new(BIO *wbio, BIO *rbio, int use_http_proxy,
         == NULL)
         return NULL;
 
-    if (OSSL_HTTP_REQ_CTX_header(rctx, use_http_proxy ? server : NULL,
-                                 port, path)
+    if (OSSL_HTTP_REQ_CTX_set_request_line(rctx,
+                                           use_http_proxy ? server : NULL, port,
+                                           path)
         && OSSL_HTTP_REQ_CTX_add1_headers(rctx, headers, server)
         && (req_mem == NULL
             || OSSL_HTTP_REQ_CTX_content(rctx, content_type, req_mem)))

--- a/crypto/http/http_client.c
+++ b/crypto/http/http_client.c
@@ -207,6 +207,10 @@ static int OSSL_HTTP_REQ_CTX_content(OSSL_HTTP_REQ_CTX *rctx,
         ERR_raise(ERR_LIB_HTTP, ERR_R_PASSED_NULL_PARAMETER);
         return 0;
     }
+    if (rctx->method_GET) {
+        ERR_raise(ERR_LIB_HTTP, ERR_R_SHOULD_NOT_HAVE_BEEN_CALLED);
+        return 0;
+    }
 
     if (content_type != NULL
             && BIO_printf(rctx->mem, "Content-Type: %s\r\n", content_type) <= 0)

--- a/crypto/ocsp/ocsp_http.c
+++ b/crypto/ocsp/ocsp_http.c
@@ -13,13 +13,6 @@
 
 #ifndef OPENSSL_NO_OCSP
 
-int OCSP_REQ_CTX_set1_req(OSSL_HTTP_REQ_CTX *rctx, const OCSP_REQUEST *req)
-{
-    return OSSL_HTTP_REQ_CTX_i2d(rctx, "application/ocsp-request",
-                                 ASN1_ITEM_rptr(OCSP_REQUEST),
-                                 (ASN1_VALUE *)req);
-}
-
 OSSL_HTTP_REQ_CTX *OCSP_sendreq_new(BIO *io, const char *path,
                                     const OCSP_REQUEST *req, int maxline)
 {
@@ -34,7 +27,9 @@ OSSL_HTTP_REQ_CTX *OCSP_sendreq_new(BIO *io, const char *path,
     if (!OSSL_HTTP_REQ_CTX_set_request_line(rctx, NULL, NULL, path))
         goto err;
 
-    if (req != NULL && !OCSP_REQ_CTX_set1_req(rctx, req))
+    if (req != NULL && !OSSL_HTTP_REQ_CTX_i2d(rctx, "application/ocsp-request",
+                                              ASN1_ITEM_rptr(OCSP_REQUEST),
+                                              (ASN1_VALUE *)req))
         goto err;
 
     return rctx;

--- a/crypto/ocsp/ocsp_http.c
+++ b/crypto/ocsp/ocsp_http.c
@@ -13,29 +13,35 @@
 
 #ifndef OPENSSL_NO_OCSP
 
-# ifndef OPENSSL_NO_DEPRECATED_3_0
 int OCSP_REQ_CTX_set1_req(OSSL_HTTP_REQ_CTX *rctx, const OCSP_REQUEST *req)
 {
     return OSSL_HTTP_REQ_CTX_i2d(rctx, "application/ocsp-request",
                                  ASN1_ITEM_rptr(OCSP_REQUEST),
                                  (ASN1_VALUE *)req);
 }
-# endif
 
 OSSL_HTTP_REQ_CTX *OCSP_sendreq_new(BIO *io, const char *path,
-                                    OCSP_REQUEST *req, int maxline)
+                                    const OCSP_REQUEST *req, int maxline)
 {
-    BIO *req_mem = HTTP_asn1_item2bio(ASN1_ITEM_rptr(OCSP_REQUEST),
-                                      (ASN1_VALUE *)req);
-    OSSL_HTTP_REQ_CTX *res =
-        HTTP_REQ_CTX_new(io, io, 0 /* no HTTP proxy used */, NULL, NULL, path,
-                         NULL /* headers */, "application/ocsp-request",
-                         req_mem /* may be NULL */,
-                         maxline, 0 /* default max_resp_len */,
-                         0 /* no timeout, blocking indefinite */, NULL,
-                         1 /* expect_asn1 */);
-    BIO_free(req_mem);
-    return res;
+    OSSL_HTTP_REQ_CTX *rctx = NULL;
+
+    if ((rctx = OSSL_HTTP_REQ_CTX_new(io, io, 1 /* POST */,
+                                      maxline, 0 /* default max_resp_len */,
+                                      0 /* no timeout, blocking indefinitely */,
+                                      NULL, 1 /* expect_asn1 */)) == NULL)
+        return NULL;
+
+    if (!OSSL_HTTP_REQ_CTX_set_request_line(rctx, NULL, NULL, path))
+        goto err;
+
+    if (req != NULL && !OCSP_REQ_CTX_set1_req(rctx, req))
+        goto err;
+
+    return rctx;
+
+ err:
+    OSSL_HTTP_REQ_CTX_free(rctx);
+    return NULL;
 }
 
 int OCSP_sendreq_nbio(OCSP_RESPONSE **presp, OSSL_HTTP_REQ_CTX *rctx)

--- a/doc/man3/OCSP_sendreq_new.pod
+++ b/doc/man3/OCSP_sendreq_new.pod
@@ -3,13 +3,13 @@
 =head1 NAME
 
 OCSP_sendreq_new,
-OCSP_REQ_CTX_set1_req,
 OCSP_sendreq_nbio,
 OCSP_sendreq_bio,
 OCSP_REQ_CTX_i2d,
 OCSP_REQ_CTX_add1_header,
 OCSP_REQ_CTX_free,
-OCSP_set_max_response_length
+OCSP_set_max_response_length,
+OCSP_REQ_CTX_set1_req
 - OCSP responder query functions
 
 =head1 SYNOPSIS
@@ -18,7 +18,6 @@ OCSP_set_max_response_length
 
  OSSL_HTTP_REQ_CTX *OCSP_sendreq_new(BIO *io, const char *path,
                                      const OCSP_REQUEST *req, int maxline);
- int OCSP_REQ_CTX_set1_req(OSSL_HTTP_REQ_CTX *rctx, const OCSP_REQUEST *req);
 
  int OCSP_sendreq_nbio(OCSP_RESPONSE **presp, OSSL_HTTP_REQ_CTX *rctx);
 
@@ -31,9 +30,10 @@ L<openssl_user_macros(7)>:
  int OCSP_REQ_CTX_i2d(OCSP_REQ_CT *rctx, const ASN1_ITEM *it, ASN1_VALUE *req);
  int OCSP_REQ_CTX_add1_header(OCSP_REQ_CT *rctx,
                               const char *name, const char *value);
- void OCSP_REQ_CTX_free(OCSP_REQ_CTX *rctx);
+ void OCSP_REQ_CTX_free(OSSL_HTTP_REQ_CTX *rctx);
  void OCSP_set_max_response_length(OCSP_REQ_CT *rctx,
                                    unsigned long len);
+ int OCSP_REQ_CTX_set1_req(OSSL_HTTP_REQ_CTX *rctx, const OCSP_REQUEST *req);
 
 =head1 DESCRIPTION
 
@@ -44,17 +44,14 @@ The function OCSP_sendreq_new() builds a complete B<OSSL_HTTP_REQ_CTX>
 structure using connection B<BIO> I<io>, the URL path I<path>, the OCSP
 request I<req>, and with a response header maximum line length of I<maxline>.
 If I<maxline> is zero a default value of 4k is used.
-The I<req> may be set to NULL and provided later using OCSP_REQ_CTX_set1_req().
+The I<req> may be set to NULL and provided later using OCSP_REQ_CTX_set1_req()
+or L<OSSL_HTTP_REQ_CTX_i2d(3)> .
 
 The I<io> and I<path> arguments to OCSP_sendreq_new() correspond to the
 components of the URL.
 For example if the responder URL is C<http://example.com/ocspreq> the BIO
 I<io> should be connected to host C<example.com> on port 80 and I<path>
 should be set to C</ocspreq>.
-
-OCSP_REQ_CTX_set1_req finalizes the HTTP request context I<rctx>
-by adding the HTTP header C<Content-Type> C<application/ocsp-request>
-and the DER encoding of the OCSP request I<req>.
 
 OCSP_sendreq_nbio() performs I/O on the OCSP request context I<rctx>.
 When the operation is complete it assigns the response, a pointer to a
@@ -70,6 +67,11 @@ OCSP_REQ_CTX_i2d(rctx, it, req) is equivalent to the following:
 
   OSSL_HTTP_REQ_CTX_i2d(rctx, "application/ocsp-request", it, req)
 
+OCSP_REQ_CTX_set1_req(rctx, req) is equivalent to the following:
+
+ OSSL_HTTP_REQ_CTX_i2d(rctx, "application/ocsp-request",
+                       ASN1_ITEM_rptr(OCSP_REQUEST), (ASN1_VALUE *)req)
+
 The other deprecated type and functions have been superseded by the
 following equivalents:
 B<OCSP_REQ_CTX> by L<OSSL_HTTP_REQ_CTX(3)>,
@@ -83,7 +85,7 @@ L<OSSL_HTTP_REQ_CTX_set_max_response_length(3)>.
 OCSP_sendreq_new() returns a valid B<OSSL_HTTP_REQ_CTX> structure or NULL
 if an error occurred.
 
-OCSP_REQ_CTX_set1_req(), OCSP_sendreq_nbio(), and OCSP_REQ_CTX_i2d()
+OCSP_sendreq_nbio(), OCSP_REQ_CTX_i2d(), and OCSP_REQ_CTX_set1_req()
 return 1 for success and 0 for failure.
 
 OCSP_sendreq_bio() returns the B<OCSP_RESPONSE> structure sent by the
@@ -104,7 +106,8 @@ B<OCSP_REQ_CTX>,
 OCSP_REQ_CTX_i2d(),
 OCSP_REQ_CTX_add1_header(),
 OCSP_REQ_CTX_free(),
-and OCSP_set_max_response_length()
+OCSP_set_max_response_length(),
+and OCSP_REQ_CTX_set1_req()
 were deprecated in OpenSSL 3.0.
 
 =head1 COPYRIGHT

--- a/doc/man3/OCSP_sendreq_new.pod
+++ b/doc/man3/OCSP_sendreq_new.pod
@@ -3,13 +3,13 @@
 =head1 NAME
 
 OCSP_sendreq_new,
+OCSP_REQ_CTX_set1_req,
 OCSP_sendreq_nbio,
 OCSP_sendreq_bio,
 OCSP_REQ_CTX_i2d,
 OCSP_REQ_CTX_add1_header,
 OCSP_REQ_CTX_free,
-OCSP_set_max_response_length,
-OCSP_REQ_CTX_set1_req
+OCSP_set_max_response_length
 - OCSP responder query functions
 
 =head1 SYNOPSIS
@@ -17,7 +17,8 @@ OCSP_REQ_CTX_set1_req
  #include <openssl/ocsp.h>
 
  OSSL_HTTP_REQ_CTX *OCSP_sendreq_new(BIO *io, const char *path,
-                                     OCSP_REQUEST *req, int maxline);
+                                     const OCSP_REQUEST *req, int maxline);
+ int OCSP_REQ_CTX_set1_req(OSSL_HTTP_REQ_CTX *rctx, const OCSP_REQUEST *req);
 
  int OCSP_sendreq_nbio(OCSP_RESPONSE **presp, OSSL_HTTP_REQ_CTX *rctx);
 
@@ -27,32 +28,33 @@ Deprecated since OpenSSL 3.0, can be hidden entirely by defining
 B<OPENSSL_API_COMPAT> with a suitable version value, see
 L<openssl_user_macros(7)>:
 
- int OCSP_REQ_CTX_i2d(OCSP_REQ_CT *rctx, const char *content_type,
-                      const ASN1_ITEM *it, ASN1_VALUE *req);
+ int OCSP_REQ_CTX_i2d(OCSP_REQ_CT *rctx, const ASN1_ITEM *it, ASN1_VALUE *req);
  int OCSP_REQ_CTX_add1_header(OCSP_REQ_CT *rctx,
                               const char *name, const char *value);
  void OCSP_REQ_CTX_free(OCSP_REQ_CTX *rctx);
  void OCSP_set_max_response_length(OCSP_REQ_CT *rctx,
                                    unsigned long len);
- int OCSP_REQ_CTX_set1_req(OCSP_REQ_CTX *rctx, const OCSP_REQUEST *req);
 
 =head1 DESCRIPTION
 
-These functions perform an OCSP request / response transfer over HTTP, using
-the HTTP request functions described in L<OSSL_HTTP_REQ_CTX(3)>.
+These functions perform an OCSP POST request / response transfer over HTTP,
+using the HTTP request functions described in L<OSSL_HTTP_REQ_CTX(3)>.
 
 The function OCSP_sendreq_new() builds a complete B<OSSL_HTTP_REQ_CTX>
 structure using connection B<BIO> I<io>, the URL path I<path>, the OCSP
-request I<req> and with a response header maximum line length of I<maxline>.
-If I<maxline> is zero a default value of 4k is used. The OCSP request I<req>
-may be set to NULL and provided later with L<OSSL_HTTP_REQ_CTX_i2d(3)> if
-required.
+request I<req>, and with a response header maximum line length of I<maxline>.
+If I<maxline> is zero a default value of 4k is used.
+The I<req> may be set to NULL and provided later using OCSP_REQ_CTX_set1_req().
 
 The I<io> and I<path> arguments to OCSP_sendreq_new() correspond to the
 components of the URL.
 For example if the responder URL is C<http://example.com/ocspreq> the BIO
 I<io> should be connected to host C<example.com> on port 80 and I<path>
 should be set to C</ocspreq>.
+
+OCSP_REQ_CTX_set1_req finalizes the HTTP request context I<rctx>
+by adding the HTTP header C<Content-Type> C<application/ocsp-request>
+and the DER encoding of the OCSP request I<req>.
 
 OCSP_sendreq_nbio() performs I/O on the OCSP request context I<rctx>.
 When the operation is complete it assigns the response, a pointer to a
@@ -64,15 +66,13 @@ response header maximum line length 4k. It waits indefinitely on a response.
 It does not support setting a timeout or adding headers and is retained
 for compatibility; use OCSP_sendreq_nbio() instead.
 
-OCSP_REQ_CTX_set1_req(rctx, req) is equivalent to the following:
+OCSP_REQ_CTX_i2d(rctx, it, req) is equivalent to the following:
 
- OSSL_HTTP_REQ_CTX_i2d(rctx, "application/ocsp-request",
-                       ASN1_ITEM_rptr(OCSP_REQUEST), (ASN1_VALUE *)req)
+  OSSL_HTTP_REQ_CTX_i2d(rctx, "application/ocsp-request", it, req)
 
 The other deprecated type and functions have been superseded by the
 following equivalents:
 B<OCSP_REQ_CTX> by L<OSSL_HTTP_REQ_CTX(3)>,
-OCSP_REQ_CTX_i2d() by L<OSSL_HTTP_REQ_CTX_i2d(3)>,
 OCSP_REQ_CTX_add1_header() by L<OSSL_HTTP_REQ_CTX_add1_header(3)>,
 OCSP_REQ_CTX_free() by L<OSSL_HTTP_REQ_CTX_free(3)>, and
 OCSP_set_max_response_length() by
@@ -83,7 +83,7 @@ L<OSSL_HTTP_REQ_CTX_set_max_response_length(3)>.
 OCSP_sendreq_new() returns a valid B<OSSL_HTTP_REQ_CTX> structure or NULL
 if an error occurred.
 
-OCSP_sendreq_nbio(), OCSP_REQ_CTX_i2d(), and OCSP_REQ_CTX_set1_req()
+OCSP_REQ_CTX_set1_req(), OCSP_sendreq_nbio(), and OCSP_REQ_CTX_i2d()
 return 1 for success and 0 for failure.
 
 OCSP_sendreq_bio() returns the B<OCSP_RESPONSE> structure sent by the
@@ -91,7 +91,7 @@ responder or NULL if an error occurred.
 
 =head1 SEE ALSO
 
-L<crypto(7)>,
+L<OSSL_HTTP_REQ_CTX(3)>
 L<OCSP_cert_to_id(3)>,
 L<OCSP_request_add1_nonce(3)>,
 L<OCSP_REQUEST_new(3)>,
@@ -104,8 +104,7 @@ B<OCSP_REQ_CTX>,
 OCSP_REQ_CTX_i2d(),
 OCSP_REQ_CTX_add1_header(),
 OCSP_REQ_CTX_free(),
-OCSP_set_max_response_length(),
-and OCSP_REQ_CTX_set1_req()
+and OCSP_set_max_response_length()
 were deprecated in OpenSSL 3.0.
 
 =head1 COPYRIGHT

--- a/doc/man3/OSSL_HTTP_REQ_CTX.pod
+++ b/doc/man3/OSSL_HTTP_REQ_CTX.pod
@@ -12,7 +12,7 @@ OSSL_HTTP_REQ_CTX_nbio,
 OSSL_HTTP_REQ_CTX_sendreq_d2i,
 OSSL_HTTP_REQ_CTX_get0_mem_bio,
 OSSL_HTTP_REQ_CTX_set_max_response_length
-- HTTP request functions
+- HTTP client low-level functions
 
 =head1 SYNOPSIS
 

--- a/doc/man3/OSSL_HTTP_REQ_CTX.pod
+++ b/doc/man3/OSSL_HTTP_REQ_CTX.pod
@@ -92,8 +92,7 @@ encoding of I<req>, using the ASN.1 template I<it> to do the encoding.  The
 HTTP header C<Content-Length> is automatically filled out, and if
 I<content_type> isn't NULL, the HTTP header C<Content-Type> is also added with
 its content as value.  All of this ends up in the internal memory B<BIO>.
-This requires that the request type be C<POST>,
-i.e., that I<method_POST> is 1 in the OSSL_HTTP_REQ_CTX_new() call.
+This requires that I<method_POST> was 1 in the OSSL_HTTP_REQ_CTX_new() call.
 
 OSSL_HTTP_REQ_CTX_nbio() attempts the exchange of request and response via HTTP,
 using the I<rbio> and I<wbio> that were given in the OSSL_HTTP_REQ_CTX_new()

--- a/doc/man3/OSSL_HTTP_REQ_CTX.pod
+++ b/doc/man3/OSSL_HTTP_REQ_CTX.pod
@@ -135,7 +135,8 @@ Calling OSSL_HTTP_REQ_CTX_set_request_line().  This must be done exactly once.
 
 =item 2.
 
-Adding extra headers with OSSL_HTTP_REQ_CTX_add1_header().  This is optional.
+Adding extra headers with OSSL_HTTP_REQ_CTX_add1_header().
+This is optional and may be done multiple times with different names.
 
 =item 3.
 
@@ -147,10 +148,6 @@ exactly once in that case.
 
 When the request context is fully prepared, the HTTP exchange may be performed
 with OSSL_HTTP_REQ_CTX_nbio() or OSSL_HTTP_REQ_CTX_sendreq_d2i().
-
-Furthermore, all calls of OSSL_HTTP_REQ_CTX_set_request_line() and
-OSSL_HTTP_REQ_CTX_add1_header() must be done before any call to
-int OSSL_HTTP_REQ_CTX_nbio() or OSSL_HTTP_REQ_CTX_sendreq_d2i().
 
 =head1 RETURN VALUES
 

--- a/doc/man3/OSSL_HTTP_REQ_CTX.pod
+++ b/doc/man3/OSSL_HTTP_REQ_CTX.pod
@@ -5,7 +5,7 @@
 OSSL_HTTP_REQ_CTX,
 OSSL_HTTP_REQ_CTX_new,
 OSSL_HTTP_REQ_CTX_free,
-OSSL_HTTP_REQ_CTX_header,
+OSSL_HTTP_REQ_CTX_set_request_line,
 OSSL_HTTP_REQ_CTX_add1_header,
 OSSL_HTTP_REQ_CTX_i2d,
 OSSL_HTTP_REQ_CTX_nbio,
@@ -28,9 +28,9 @@ OSSL_HTTP_REQ_CTX_set_max_response_length
                                           int expect_asn1);
  void OSSL_HTTP_REQ_CTX_free(OSSL_HTTP_REQ_CTX *rctx);
 
- int OSSL_HTTP_REQ_CTX_header(OSSL_HTTP_REQ_CTX *rctx,
-                              const char *server,
-                              const char *port, const char *path);
+ int OSSL_HTTP_REQ_CTX_set_request_line(OSSL_HTTP_REQ_CTX *rctx,
+                                        const char *server, const char *port,
+                                        const char *path);
  int OSSL_HTTP_REQ_CTX_add1_header(OSSL_HTTP_REQ_CTX *rctx,
                                    const char *name, const char *value);
 
@@ -72,7 +72,7 @@ OSSL_HTTP_REQ_CTX_free() frees up the HTTP request context I<rctx>.
 The I<wbio> and I<rbio> are not free'd and it is up to the application
 to do so.
 
-OSSL_HTTP_REQ_CTX_header() adds an HTTP request line to the request context.
+OSSL_HTTP_REQ_CTX_set_request_line() adds the HTTP request line to the context.
 The request command itself becomes C<GET> or C<POST> depending on the value
 of I<method_GET> in the OSSL_HTTP_REQ_CTX_new() call.  I<server> and I<port>
 may be set to indicate a proxy server and port that the request should go
@@ -129,7 +129,7 @@ Then, the HTTP request must be prepared with request data:
 
 =item 1.
 
-Calling OSSL_HTTP_REQ_CTX_header().  This must be done exactly once.
+Calling OSSL_HTTP_REQ_CTX_set_request_line().  This must be done exactly once.
 
 =item 2.
 
@@ -146,7 +146,7 @@ exactly once in that case.
 When the request context is fully prepared, the HTTP exchange may be performed
 with OSSL_HTTP_REQ_CTX_nbio() or OSSL_HTTP_REQ_CTX_sendreq_d2i().
 
-Furthermore, all calls of OSSL_HTTP_REQ_CTX_header() and
+Furthermore, all calls of OSSL_HTTP_REQ_CTX_set_request_line() and
 OSSL_HTTP_REQ_CTX_add1_header() must be done before any call to
 int OSSL_HTTP_REQ_CTX_nbio() or OSSL_HTTP_REQ_CTX_sendreq_d2i().
 
@@ -158,7 +158,7 @@ on error.
 OSSL_HTTP_REQ_CTX_free() and OSSL_HTTP_REQ_CTX_set_max_response_length()
 do not return values.
 
-OSSL_HTTP_REQ_CTX_header(), OSSL_HTTP_REQ_CTX_add1_header(),
+OSSL_HTTP_REQ_CTX_set_request_line(), OSSL_HTTP_REQ_CTX_add1_header(),
 OSSL_HTTP_REQ_CTX_i2d() and OSSL_HTTP_REQ_CTX_nbio return 1 for success and 0
 for failure.
 

--- a/doc/man3/OSSL_HTTP_REQ_CTX.pod
+++ b/doc/man3/OSSL_HTTP_REQ_CTX.pod
@@ -21,7 +21,7 @@ OSSL_HTTP_REQ_CTX_set_max_response_length
  typedef struct ossl_http_req_ctx_st OSSL_HTTP_REQ_CTX;
 
  OSSL_HTTP_REQ_CTX *OSSL_HTTP_REQ_CTX_new(BIO *wbio, BIO *rbio,
-                                          int method_GET, int maxline,
+                                          int method_POST, int maxline,
                                           unsigned long max_resp_len,
                                           int timeout,
                                           const char *expected_content_type,
@@ -53,17 +53,19 @@ This file documents low-level HTTP functions rarely used directly.  High-level
 HTTP client functions like L<OSSL_HTTP_get(3)> and L<OSSL_HTTP_transfer(3)>
 should be preferred.
 
-OSSL_HTTP_REQ_CTX_new() allocates a new HTTP request context structure, which
-gets populated with the B<BIO> to send the request to (I<wbio>), the B<BIO> to
-read the response from (I<rbio>, which may be the same as I<wbio>), the
-request method (I<method_GET>, which may be 1 to indicate that the C<GET>
-method is to be used, or 0 to indicate that the C<POST> method is to be used),
-the maximum expected response header length (I<max_resp_len>, where any zero
-or less indicates the default of 4KiB), a response timeout measure in seconds
-(I<timeout>, where 0 indicates no timeout, i.e., waiting indefinitely), the
-expected MIME content type of the response (I<expected_content_type>, which
-may be NULL for no expectation), and a flag indicating that the response is
-expected to be a DER encoded ASN.1 structure (I<expect_asn1>).
+OSSL_HTTP_REQ_CTX_new() allocates a new HTTP request context structure,
+which gets populated with the B<BIO> to send the request to (I<wbio>),
+the B<BIO> to read the response from (I<rbio>, which may be equal to I<wbio>),
+the request method (I<method_POST>, which may be 1 to indicate that the C<POST>
+method is to be used, or 0 to indicate that the C<GET> method is to be used),
+the maximum expected response header length (I<max_resp_len>,
+where any zero or less indicates the default of 4KiB),
+a response timeout measure in seconds (I<timeout>,
+where 0 indicates no timeout, i.e., waiting indefinitely),
+the expected MIME content type of the response (I<expected_content_type>,
+which may be NULL for no expectation),
+and a flag indicating that the response is expected to be
+a DER encoded ASN.1 structure (I<expect_asn1>).
 The allocated context structure is also populated with an internal allocated
 memory B<BIO>, which collects the HTTP request and additional headers as text.
 The returned context should only be used for a single HTTP request/response.
@@ -73,8 +75,8 @@ The I<wbio> and I<rbio> are not free'd and it is up to the application
 to do so.
 
 OSSL_HTTP_REQ_CTX_set_request_line() adds the HTTP request line to the context.
-The request command itself becomes C<GET> or C<POST> depending on the value
-of I<method_GET> in the OSSL_HTTP_REQ_CTX_new() call.  I<server> and I<port>
+The request method itself becomes C<GET> or C<POST> depending on the value
+of I<method_POST> in the OSSL_HTTP_REQ_CTX_new() call.  I<server> and I<port>
 may be set to indicate a proxy server and port that the request should go
 through, otherwise they should be left NULL.  I<path> is the HTTP request path;
 if left NULL, C</> is used.
@@ -90,8 +92,8 @@ encoding of I<req>, using the ASN.1 template I<it> to do the encoding.  The
 HTTP header C<Content-Length> is automatically filled out, and if
 I<content_type> isn't NULL, the HTTP header C<Content-Type> is also added with
 its content as value.  All of this ends up in the internal memory B<BIO>.
-This requires that the request type be C<POST>, i.e. that I<method_GET> is 0
-in the OSSL_HTTP_REQ_CTX_new() call.
+This requires that the request type be C<POST>,
+i.e., that I<method_POST> is 1 in the OSSL_HTTP_REQ_CTX_new() call.
 
 OSSL_HTTP_REQ_CTX_nbio() attempts the exchange of request and response via HTTP,
 using the I<rbio> and I<wbio> that were given in the OSSL_HTTP_REQ_CTX_new()
@@ -138,7 +140,7 @@ Adding extra headers with OSSL_HTTP_REQ_CTX_add1_header().  This is optional.
 =item 3.
 
 Add C<POST> data with OSSL_HTTP_REQ_CTX_i2d().  This may only be done if
-I<method_GET> was 0 in the OSSL_HTTP_REQ_CTX_new() call, and must be done
+I<method_POST> was 1 in the OSSL_HTTP_REQ_CTX_new() call, and must be done
 exactly once in that case.
 
 =back

--- a/include/openssl/http.h
+++ b/include/openssl/http.h
@@ -42,9 +42,9 @@ OSSL_HTTP_REQ_CTX *OSSL_HTTP_REQ_CTX_new(BIO *wbio, BIO *rbio,
                                          const char *expected_content_type,
                                          int expect_asn1);
 void OSSL_HTTP_REQ_CTX_free(OSSL_HTTP_REQ_CTX *rctx);
-int OSSL_HTTP_REQ_CTX_header(OSSL_HTTP_REQ_CTX *rctx,
-                             const char *server,
-                             const char *port, const char *path);
+int OSSL_HTTP_REQ_CTX_set_request_line(OSSL_HTTP_REQ_CTX *rctx,
+                                       const char *server, const char *port,
+                                       const char *path);
 int OSSL_HTTP_REQ_CTX_add1_header(OSSL_HTTP_REQ_CTX *rctx,
                                   const char *name, const char *value);
 int OSSL_HTTP_REQ_CTX_i2d(OSSL_HTTP_REQ_CTX *rctx, const char *content_type,

--- a/include/openssl/ocsp.h.in
+++ b/include/openssl/ocsp.h.in
@@ -172,24 +172,23 @@ DECLARE_ASN1_DUP_FUNCTION(OCSP_CERTID)
 
 OCSP_RESPONSE *OCSP_sendreq_bio(BIO *b, const char *path, OCSP_REQUEST *req);
 OSSL_HTTP_REQ_CTX *OCSP_sendreq_new(BIO *io, const char *path,
-                                    OCSP_REQUEST *req, int maxline);
+                                    const OCSP_REQUEST *req, int maxline);
 int OCSP_sendreq_nbio(OCSP_RESPONSE **presp, OSSL_HTTP_REQ_CTX *rctx);
+int OCSP_REQ_CTX_set1_req(OSSL_HTTP_REQ_CTX *rctx, const OCSP_REQUEST *req);
 
 #  ifndef OPENSSL_NO_DEPRECATED_3_0
 typedef OSSL_HTTP_REQ_CTX OCSP_REQ_CTX;
-OSSL_DEPRECATEDIN_3_0
-int OCSP_REQ_CTX_set1_req(OSSL_HTTP_REQ_CTX *rctx, const OCSP_REQUEST *req);
 
-#   define OCSP_REQ_CTX_new(wb, rb, m, ml, mrl, t, ect, ea) \
-        OSSL_HTTP_REQ_CTX_new(wb, rb, m, ml, mrl, t, ect, ea)
+#   define OCSP_REQ_CTX_new(io, maxline)  \
+        OSSL_HTTP_REQ_CTX_new(io, io, 1, maxline, 0, 0, NULL, 1)
 #   define OCSP_REQ_CTX_free(r) \
         OSSL_HTTP_REQ_CTX_free(r)
-#   define OCSP_REQ_CTX_http(r, s, p, path) \
-        OSSL_HTTP_REQ_CTX_set_request_line(r, s, p, path)
+#   define OCSP_REQ_CTX_http(rctx, op, path) \
+        OSSL_HTTP_REQ_CTX_set_request_line(rctx, NULL, NULL, path)
 #   define OCSP_REQ_CTX_add1_header(r, n, v) \
         OSSL_HTTP_REQ_CTX_add1_header(r, n, v)
-#   define OCSP_REQ_CTX_i2d(r, c, i, req) \
-        OSSL_HTTP_REQ_CTX_i2d(r, c, i, req)
+#   define OCSP_REQ_CTX_i2d(r, i, req) \
+        OSSL_HTTP_REQ_CTX_i2d(r, "application/ocsp-request", i, req)
 #   define OCSP_REQ_CTX_nbio(r) \
         OSSL_HTTP_REQ_CTX_nbio(r)
 #   define OCSP_REQ_CTX_nbio_d2i(r, i) \

--- a/include/openssl/ocsp.h.in
+++ b/include/openssl/ocsp.h.in
@@ -184,8 +184,8 @@ int OCSP_REQ_CTX_set1_req(OSSL_HTTP_REQ_CTX *rctx, const OCSP_REQUEST *req);
         OSSL_HTTP_REQ_CTX_new(wb, rb, m, ml, mrl, t, ect, ea)
 #   define OCSP_REQ_CTX_free(r) \
         OSSL_HTTP_REQ_CTX_free(r)
-#   define OCSP_REQ_CTX_http(r, s, po, pa) \
-        OSSL_HTTP_REQ_CTX_header(r, s, po, pa)
+#   define OCSP_REQ_CTX_http(r, s, p, path) \
+        OSSL_HTTP_REQ_CTX_set_request_line(r, s, p, path)
 #   define OCSP_REQ_CTX_add1_header(r, n, v) \
         OSSL_HTTP_REQ_CTX_add1_header(r, n, v)
 #   define OCSP_REQ_CTX_i2d(r, c, i, req) \

--- a/include/openssl/ocsp.h.in
+++ b/include/openssl/ocsp.h.in
@@ -174,12 +174,10 @@ OCSP_RESPONSE *OCSP_sendreq_bio(BIO *b, const char *path, OCSP_REQUEST *req);
 OSSL_HTTP_REQ_CTX *OCSP_sendreq_new(BIO *io, const char *path,
                                     const OCSP_REQUEST *req, int maxline);
 int OCSP_sendreq_nbio(OCSP_RESPONSE **presp, OSSL_HTTP_REQ_CTX *rctx);
-int OCSP_REQ_CTX_set1_req(OSSL_HTTP_REQ_CTX *rctx, const OCSP_REQUEST *req);
 
 #  ifndef OPENSSL_NO_DEPRECATED_3_0
 typedef OSSL_HTTP_REQ_CTX OCSP_REQ_CTX;
-
-#   define OCSP_REQ_CTX_new(io, maxline)  \
+#   define OCSP_REQ_CTX_new(io, maxline) \
         OSSL_HTTP_REQ_CTX_new(io, io, 1, maxline, 0, 0, NULL, 1)
 #   define OCSP_REQ_CTX_free(r) \
         OSSL_HTTP_REQ_CTX_free(r)
@@ -197,6 +195,8 @@ typedef OSSL_HTTP_REQ_CTX OCSP_REQ_CTX;
         OSSL_HTTP_REQ_CTX_get0_mem_bio(r)
 #   define OCSP_set_max_response_length(r, l) \
         OSSL_HTTP_REQ_CTX_set_max_response_length(r, l)
+#   define OCSP_REQ_CTX_set1_req(r, req) \
+        OCSP_REQ_CTX_i2d(r, ASN1_ITEM_rptr(OCSP_REQUEST), (ASN1_VALUE *)(req))
 #  endif
 
 OCSP_CERTID *OCSP_cert_to_id(const EVP_MD *dgst, const X509 *subject,

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -3334,7 +3334,7 @@ EVP_PKEY_meth_get_verify                3403	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_
 CRYPTO_128_wrap                         3404	3_0_0	EXIST::FUNCTION:
 X509_STORE_set_lookup_crls              3405	3_0_0	EXIST::FUNCTION:
 EVP_CIPHER_meth_get_ctrl                3406	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
-OCSP_REQ_CTX_set1_req                   3407	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,OCSP
+OCSP_REQ_CTX_set1_req                   3407	3_0_0	EXIST::FUNCTION:OCSP
 CONF_imodule_get_usr_data               3408	3_0_0	EXIST::FUNCTION:
 CRYPTO_new_ex_data                      3409	3_0_0	EXIST::FUNCTION:
 PEM_read_PKCS8_PRIV_KEY_INFO            3410	3_0_0	EXIST::FUNCTION:STDIO

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -1379,7 +1379,7 @@ BIO_set_ex_data                         1411	3_0_0	EXIST::FUNCTION:
 SHA512                                  1412	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
 X509_STORE_CTX_get_explicit_policy      1413	3_0_0	EXIST::FUNCTION:
 EVP_DecodeBlock                         1414	3_0_0	EXIST::FUNCTION:
-OSSL_HTTP_REQ_CTX_header                1415	3_0_0	EXIST::FUNCTION:
+OSSL_HTTP_REQ_CTX_set_request_line      1415	3_0_0	EXIST::FUNCTION:
 EVP_MD_CTX_reset                        1416	3_0_0	EXIST::FUNCTION:
 X509_NAME_new                           1417	3_0_0	EXIST::FUNCTION:
 ASN1_item_pack                          1418	3_0_0	EXIST::FUNCTION:

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -3334,7 +3334,6 @@ EVP_PKEY_meth_get_verify                3403	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_
 CRYPTO_128_wrap                         3404	3_0_0	EXIST::FUNCTION:
 X509_STORE_set_lookup_crls              3405	3_0_0	EXIST::FUNCTION:
 EVP_CIPHER_meth_get_ctrl                3406	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
-OCSP_REQ_CTX_set1_req                   3407	3_0_0	EXIST::FUNCTION:OCSP
 CONF_imodule_get_usr_data               3408	3_0_0	EXIST::FUNCTION:
 CRYPTO_new_ex_data                      3409	3_0_0	EXIST::FUNCTION:
 PEM_read_PKCS8_PRIV_KEY_INFO            3410	3_0_0	EXIST::FUNCTION:STDIO

--- a/util/other.syms
+++ b/util/other.syms
@@ -337,6 +337,7 @@ OCSP_REQ_CTX_add1_header                define deprecated 3.0.0
 OCSP_REQ_CTX_free                       define deprecated 3.0.0
 OCSP_REQ_CTX_i2d                        define deprecated 3.0.0
 OCSP_set_max_response_length            define deprecated 3.0.0
+OCSP_REQ_CTX_set1_req                   define deprecated 3.0.0
 OPENSSL_FILE                            define
 OPENSSL_FUNC                            define
 OPENSSL_LINE                            define

--- a/util/perl/OpenSSL/Util/Pod.pm
+++ b/util/perl/OpenSSL/Util/Pod.pm
@@ -116,6 +116,7 @@ sub extract_pod_info {
 
     my @invisible_names = ();
     my %podinfo = ( section => $defaults{section});
+    $podinfo{lastsecttext} = ""; # init needed in case input file is empty
 
     # Regexp to split a text into paragraphs found at
     # https://www.perlmonks.org/?node_id=584367


### PR DESCRIPTION
* OCSP HTTP: Restore API of undocumented and recently deprecated functions:
  ```  
    Restore parameters of OCSP_REQ_CTX_new(), OCSP_REQ_CTX_http(), OCSP_REQ_CTX_i2d().
    Fix a bug (wrong HTTP method selected on req == NULL in OCSP_sendreq_new().
    Minor further fixes in OSSL_HTTP_REQ_CTX.pod
 Fixes #13873.
 
* `OSSL_HTTP_REQ_CTX.pod`: minor addition and remove redundant paragraph
* ` OSSL_HTTP_REQ_CTX_new()`: replace` method_GET` parameter by `method_POST`
* rename `OSSL_HTTP_REQ_CTX_header` to `OSSL_HTTP_REQ_CTX_set_request_line`
* Add check of HTTP method to `OSSL_HTTP_REQ_CTX_content()`
* `Util/Pod.pm`: Fix uninitialized `$podinfo{lastsecttext}` on empty input

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated

