### PR TITLE
Don't copy parameters on setting a key in libssl

### DIFF
--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -1159,7 +1159,7 @@ int EVP_PKEY_print_params(BIO *out, const EVP_PKEY *pkey,
                       pctx);
 }
 
-static void find_md_nid(const char *mdname, void *data)
+static void mdname2nid(const char *mdname, void *data)
 {
     int *nid = (int *)data;
 
@@ -1204,7 +1204,7 @@ static int legacy_asn1_ctrl_to_param(EVP_PKEY *pkey, int op,
                  * We have the namemap number - now we need to find the
                  * associated nid
                  */
-                ossl_namemap_doall_names(namemap, mdnum, find_md_nid, &nid);
+                ossl_namemap_doall_names(namemap, mdnum, mdname2nid, &nid);
                 *(int *)arg2 = nid;
             }
             return rv;

--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -16,6 +16,7 @@
 #include <stdio.h>
 #include "internal/cryptlib.h"
 #include "internal/refcount.h"
+#include "internal/namemap.h"
 #include <openssl/bn.h>
 #include <openssl/err.h>
 #include <openssl/objects.h>
@@ -1158,6 +1159,18 @@ int EVP_PKEY_print_params(BIO *out, const EVP_PKEY *pkey,
                       pctx);
 }
 
+static void find_md_nid(const char *mdname, void *data)
+{
+    int *nid = (int *)data;
+
+    if (*nid != NID_undef)
+        return;
+
+    *nid = OBJ_sn2nid(mdname);
+    if (*nid == NID_undef)
+        *nid = OBJ_ln2nid(mdname);
+}
+
 static int legacy_asn1_ctrl_to_param(EVP_PKEY *pkey, int op,
                                      int arg1, void *arg2)
 {
@@ -1171,11 +1184,27 @@ static int legacy_asn1_ctrl_to_param(EVP_PKEY *pkey, int op,
                                                       sizeof(mdname));
 
             if (rv > 0) {
-                int nid;
+                int mdnum;
+                OSSL_LIB_CTX *libctx = ossl_provider_libctx(pkey->keymgmt->prov);
+                /* Make sure the MD is in the namemap if available */
+                EVP_MD *md = EVP_MD_fetch(libctx, mdname, NULL);
+                OSSL_NAMEMAP *namemap = ossl_namemap_stored(libctx);
+                int nid = NID_undef;
 
-                nid = OBJ_sn2nid(mdname);
-                if (nid == NID_undef)
-                    nid = OBJ_ln2nid(mdname);
+                /*
+                 * The only reason to fetch the MD was to make sure it is in the
+                 * namemap. We can immediately free it.
+                 */
+                EVP_MD_free(md);
+                mdnum = ossl_namemap_name2num(namemap, mdname);
+                if (mdnum == 0)
+                    return 0;
+
+                /*
+                 * We have the namemap number - now we need to find the
+                 * associated nid
+                 */
+                ossl_namemap_doall_names(namemap, mdnum, find_md_nid, &nid);
                 *(int *)arg2 = nid;
             }
             return rv;

--- a/ssl/ssl_rsa.c
+++ b/ssl/ssl_rsa.c
@@ -124,26 +124,9 @@ static int ssl_set_pkey(CERT *c, EVP_PKEY *pkey)
         return 0;
     }
 
-    if (c->pkeys[i].x509 != NULL) {
-        EVP_PKEY *pktmp;
-        pktmp = X509_get0_pubkey(c->pkeys[i].x509);
-        if (pktmp == NULL) {
-            ERR_raise(ERR_LIB_SSL, ERR_R_MALLOC_FAILURE);
-            return 0;
-        }
-        /*
-         * The return code from EVP_PKEY_copy_parameters is deliberately
-         * ignored. Some EVP_PKEY types cannot do this.
-         */
-        EVP_PKEY_copy_parameters(pktmp, pkey);
-        ERR_clear_error();
-
-        if (!X509_check_private_key(c->pkeys[i].x509, pkey)) {
-            X509_free(c->pkeys[i].x509);
-            c->pkeys[i].x509 = NULL;
-            return 0;
-        }
-    }
+    if (c->pkeys[i].x509 != NULL
+            && !X509_check_private_key(c->pkeys[i].x509, pkey))
+        return 0;
 
     EVP_PKEY_free(c->pkeys[i].privatekey);
     EVP_PKEY_up_ref(pkey);


### PR DESCRIPTION
Whenever we set a private key in libssl, we first found the certificate that matched the key algorithm. Then we copied the key parameters from the private key into the public key for the certficate before finally checking that the private key matched the public key in the certificate. This makes no sense! Part of checking the private key is to make sure that the parameters match. It seems that this code has been present since SSLeay. Perhaps at some point it made sense to do this - but it doesn't any more.

We remove that piece of code altogether. The previous code also had the undocumented side effect of removing the certificate if the key didn't match. This makes sense if you've just overwritten the parameters in the certificate with bad values - but doesn't seem to otherwise. I've also removed that error logic.

Due to issue #13893, the public key associated with the certificate is always a legacy key. `EVP_PKEY_copy_parameters` will downgrade the "from" key to legacy if the target is legacy, so this means that in libssl all private keys were always downgraded to legacy when they are first set in the `SSL`/`SSL_CTX`. Removing the `EVP_PKEY_copy_parameters code` has the added benefit of removing that downgrade.

Once the above change had been made I found that the tests started to fail. This was due to an unrelated bug that was exposed because we were using provider based keys for the first time in libssl. The `legacy_asn1_ctrl_to_param` implementation of
`ASN1_PKEY_CTRL_DEFAULT_MD_NID` calls `EVP_PKEY_get_default_digest_name() `which returns an `mdname`. Previously we were using `OBJ_sn2nid`/`OBJ_ln2nid` to lookup that name in the OBJ database. However we might get an `mdname` back that only exists in the `namemap`, not in the OBJ database. In that case we need to check the various aliases for the name, to see if one of those matches the name we are looking for.