### PR TITLE
[1.1.1] Fix regression in no-deprecated build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,17 @@ jobs:
       - name: make test
         run: make test
 
+  no-deprecated:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: config
+        run: ./config --strict-warnings no-deprecated && perl configdata.pm --dump
+      - name: make
+        run: make -s -j4
+      - name: make test
+        run: make test
+
   sanitizers:
     runs-on: ubuntu-latest
     steps:

--- a/test/verify_extra_test.c
+++ b/test/verify_extra_test.c
@@ -200,7 +200,7 @@ static int test_self_signed(const char *filename, int expected)
     ret = TEST_ptr(cert)
         && TEST_true(sk_X509_push(trusted, cert))
         && TEST_true(X509_STORE_CTX_init(ctx, NULL, cert, NULL));
-    X509_STORE_CTX_trusted_stack(ctx, trusted);
+    X509_STORE_CTX_set0_trusted_stack(ctx, trusted);
     ret = ret && TEST_int_eq(X509_verify_cert(ctx), expected);
 
     X509_STORE_CTX_free(ctx);


### PR DESCRIPTION
Also add the no-deprecated to the minimal CI build to test it.

Fixes #13896
##### Checklist
- [x] tests are added or updated
