### PR TITLE
CI: Add some legacy stuff that we do not test in GitHub CI yet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: config
-      run: ./config -Werror --debug no-afalgeng no-shared enable-crypto-mdebug enable-rc5 enable-md2 && perl configdata.pm --dump
+      run: ./config -Werror --debug no-afalgeng no-shared enable-crypto-mdebug enable-rc5 enable-md2 enable-ssl3 enable-ssl3-method enable-weak-ssl-ciphers enable-zlib enable-ec_nistp_64_gcc_128 && perl configdata.pm --dump
     - name: make
       run: make -s -j4
     - name: make test


### PR DESCRIPTION
There are some options that seem to belong to the legacy build.

##### Checklist
- [x] tests are added or updated
