### PR TITLE
Fix typo in crl2pkcs documentation #13910

### DIFF
--- a/doc/man1/openssl-crl2pkcs7.pod.in
+++ b/doc/man1/openssl-crl2pkcs7.pod.in
@@ -55,7 +55,7 @@ output by default.
 
 Specifies a filename containing one or more certificates in B<PEM> format.
 All certificates in the file will be added to the PKCS#7 structure. This
-option can be used more than once to read certificates form multiple
+option can be used more than once to read certificates from multiple
 files.
 
 =item B<-nocrl>


### PR DESCRIPTION
Fix typo in crl2pkcs documentation "form" to "from"

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist