### PR TITLE
Handle NULL result of ERR_reason_error_string() in some apps

### DIFF
--- a/apps/pkey.c
+++ b/apps/pkey.c
@@ -272,17 +272,8 @@ int pkey_main(int argc, char **argv)
              * Note: at least for RSA keys if this function returns
              * -1, there will be no error reasons.
              */
-            unsigned long err;
-
-            BIO_printf(out, "Key is invalid\n");
-
-            while ((err = ERR_peek_error()) != 0) {
-                const char *reason = ERR_reason_error_string(err);
-
-                if (reason != NULL)
-                    BIO_printf(out, "Detailed error: %s\n", reason);
-                ERR_get_error(); /* remove err from error stack */
-            }
+            BIO_printf(bio_err, "Key is invalid\n");
+            ERR_print_errors(bio_err);
             goto end;
         }
     }

--- a/apps/pkey.c
+++ b/apps/pkey.c
@@ -277,8 +277,10 @@ int pkey_main(int argc, char **argv)
             BIO_printf(out, "Key is invalid\n");
 
             while ((err = ERR_peek_error()) != 0) {
-                BIO_printf(out, "Detailed error: %s\n",
-                           ERR_reason_error_string(err));
+                const char *reason = ERR_reason_error_string(err);
+
+                if (reason != NULL)
+                    BIO_printf(out, "Detailed error: %s\n", reason);
                 ERR_get_error(); /* remove err from error stack */
             }
             goto end;

--- a/apps/pkeyparam.c
+++ b/apps/pkeyparam.c
@@ -52,7 +52,6 @@ int pkeyparam_main(int argc, char **argv)
     int text = 0, noout = 0, ret = EXIT_FAILURE, check = 0, r;
     OPTION_CHOICE o;
     char *infile = NULL, *outfile = NULL, *prog;
-    unsigned long err;
 
     prog = opt_init(argc, argv, pkeyparam_options);
     while ((o = opt_next()) != OPT_EOF) {
@@ -125,15 +124,8 @@ int pkeyparam_main(int argc, char **argv)
              * Note: at least for RSA keys if this function returns
              * -1, there will be no error reasons.
              */
-            BIO_printf(out, "Parameters are invalid\n");
-
-            while ((err = ERR_peek_error()) != 0) {
-                const char *reason = ERR_reason_error_string(err);
-
-                if (reason != NULL)
-                    BIO_printf(out, "Detailed error: %s\n", reason);
-                ERR_get_error(); /* remove err from error stack */
-            }
+            BIO_printf(bio_err, "Parameters are invalid\n");
+            ERR_print_errors(bio_err);
             goto end;
         }
     }

--- a/apps/pkeyparam.c
+++ b/apps/pkeyparam.c
@@ -128,8 +128,10 @@ int pkeyparam_main(int argc, char **argv)
             BIO_printf(out, "Parameters are invalid\n");
 
             while ((err = ERR_peek_error()) != 0) {
-                BIO_printf(out, "Detailed error: %s\n",
-                           ERR_reason_error_string(err));
+                const char *reason = ERR_reason_error_string(err);
+
+                if (reason != NULL)
+                    BIO_printf(out, "Detailed error: %s\n", reason);
                 ERR_get_error(); /* remove err from error stack */
             }
             goto end;

--- a/apps/rsa.c
+++ b/apps/rsa.c
@@ -256,7 +256,7 @@ int rsa_main(int argc, char **argv)
 
         pctx = EVP_PKEY_CTX_new_from_pkey(NULL, pkey, NULL);
         if (pctx == NULL) {
-            BIO_printf(out, "RSA unable to create PKEY context\n");
+            BIO_printf(bio_err, "RSA unable to create PKEY context\n");
             ERR_print_errors(bio_err);
             goto end;
         }
@@ -266,17 +266,8 @@ int rsa_main(int argc, char **argv)
         if (r == 1) {
             BIO_printf(out, "RSA key ok\n");
         } else if (r == 0) {
-            unsigned long err;
-
-            while ((err = ERR_peek_error()) != 0 &&
-                   ERR_GET_LIB(err) == ERR_LIB_RSA &&
-                   ERR_GET_REASON(err) != ERR_R_MALLOC_FAILURE) {
-                const char *reason = ERR_reason_error_string(err);
-
-                BIO_printf(out, "RSA key error: %s\n",
-                           reason != NULL ? reason : "<unknown reason>");
-                ERR_get_error(); /* remove err from error stack */
-            }
+            BIO_printf(bio_err, "RSA key not ok\n");
+            ERR_print_errors(bio_err);
         } else if (r == -1) {
             ERR_print_errors(bio_err);
             goto end;

--- a/apps/rsa.c
+++ b/apps/rsa.c
@@ -271,8 +271,10 @@ int rsa_main(int argc, char **argv)
             while ((err = ERR_peek_error()) != 0 &&
                    ERR_GET_LIB(err) == ERR_LIB_RSA &&
                    ERR_GET_REASON(err) != ERR_R_MALLOC_FAILURE) {
+                const char *reason = ERR_reason_error_string(err);
+
                 BIO_printf(out, "RSA key error: %s\n",
-                           ERR_reason_error_string(err));
+                           reason != NULL ? reason : "<unknown reason>");
                 ERR_get_error(); /* remove err from error stack */
             }
         } else if (r == -1) {

--- a/crypto/bio/b_sock2.c
+++ b/crypto/bio/b_sock2.c
@@ -175,7 +175,7 @@ int BIO_bind(int sock, const BIO_ADDR *addr, int options)
 # endif
 
     if (bind(sock, BIO_ADDR_sockaddr(addr), BIO_ADDR_sockaddr_size(addr)) != 0) {
-        ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
+        ERR_raise_data(ERR_LIB_SYS, get_last_socket_error() /* may be 0 */,
                        "calling bind()");
         ERR_raise(ERR_LIB_BIO, BIO_R_UNABLE_TO_BIND_SOCKET);
         return 0;

--- a/test/cmp_ctx_test.c
+++ b/test/cmp_ctx_test.c
@@ -158,8 +158,8 @@ static int execute_CTX_print_errors_test(OSSL_CMP_CTX_TEST_FIXTURE *fixture)
         ERR_raise(ERR_LIB_CMP, CMP_R_NULL_ARGUMENT);
         base_err_msg_size += strlen("NULL_ARGUMENT");
         expected_size = base_err_msg_size;
-        ossl_cmp_add_error_data("data1"); /* should prepend separator " : " */
-        expected_size += strlen(" : " "data1");
+        ossl_cmp_add_error_data("data1"); /* should prepend separator ":" */
+        expected_size += strlen(":" "data1");
         ossl_cmp_add_error_data("data2"); /* should prepend separator " : " */
         expected_size += strlen(" : " "data2");
         ossl_cmp_add_error_line("new line"); /* should prepend separator "\n" */
@@ -169,7 +169,7 @@ static int execute_CTX_print_errors_test(OSSL_CMP_CTX_TEST_FIXTURE *fixture)
             res = 0;
 
         ERR_raise(ERR_LIB_CMP, CMP_R_INVALID_ARGS);
-        base_err_msg_size = strlen("INVALID_ARGS") + strlen(" : ");
+        base_err_msg_size = strlen("INVALID_ARGS") + strlen(":");
         expected_size = base_err_msg_size;
         while (expected_size < 4096) { /* force split */
             ERR_add_error_txt(STR_SEP, max_str_literal);


### PR DESCRIPTION
There are a couple of cases where the result of `ERR_reason_error_string()` is directly used for printing with `%s`.
Unfortunately, its result may be NULL not only in case of non-existing reason codes but also for system error codes (`errno`).
This PR makes sure that no `<NULL>` is printed.

BTW, would be nice if there was a conveniently usable function that supports the `errno` case and is guaranteed to return suitable a non-NULL string, so if there is no string translation available returned something like `"reason(%d)"` giving in `%d` the reason code as decimal string.
I know this is not trivial due to tread safety and variable string lengths, but maybe via a thread-local buffer of sufficient length?
