### PR TITLE
Fix running mingw dhparam test under wine

### DIFF
--- a/test/recipes/20-test_dhparam.t
+++ b/test/recipes/20-test_dhparam.t
@@ -36,7 +36,7 @@ sub checkdhparams {
         #Text file. Check it looks like PEM
         open(PEMFILE, '<', $file) or die $!;
         if (my $firstline = <PEMFILE>) {
-            $firstline =~ s/\r|\n//g;
+            $firstline =~ s/\R$//;
             if ($firstline eq "-----BEGIN DH PARAMETERS-----") {
                 $pemtype = "PKCS3";
             } elsif ($firstline eq "-----BEGIN X9.42 DH PARAMETERS-----") {

--- a/test/recipes/20-test_dhparam.t
+++ b/test/recipes/20-test_dhparam.t
@@ -36,11 +36,13 @@ sub checkdhparams {
         #Text file. Check it looks like PEM
         open(PEMFILE, '<', $file) or die $!;
         if (my $firstline = <PEMFILE>) {
-            chomp($firstline);
+            $firstline =~ s/\r|\n//g;
             if ($firstline eq "-----BEGIN DH PARAMETERS-----") {
                 $pemtype = "PKCS3";
             } elsif ($firstline eq "-----BEGIN X9.42 DH PARAMETERS-----") {
                 $pemtype = "X9.42";
+            } else {
+                $pemtype = "";
             }
         } else {
             $pemtype = "";


### PR DESCRIPTION
The dhparam test was failing to properly handle line endings when
running a mingw configured build under wine.

Fixes #13557

