### PR TITLE
Add deep copy of propq field in mac_dupctx to avoid double free

### DIFF
--- a/providers/implementations/signature/mac_legacy.c
+++ b/providers/implementations/signature/mac_legacy.c
@@ -172,8 +172,12 @@ static void *mac_dupctx(void *vpmacctx)
         return NULL;
 
     *dstctx = *srcctx;
+    dstctx->propq = NULL;
     dstctx->key = NULL;
     dstctx->macctx = NULL;
+
+    if (srcctx->propq != NULL && (dstctx->propq = OPENSSL_strdup(srcctx->propq)) == NULL)
+        goto err;
 
     if (srcctx->key != NULL && !ossl_mac_key_up_ref(srcctx->key))
         goto err;


### PR DESCRIPTION
CLA: trivial

mac_dupctx should make a copy of the propq field.  Currently it does a shallow copy which can result in a double free and causing a crash.  The double free occurs when using a provider property string.  For example, passing in "fips=no" to SSL_CTX_new_ex() causes the propq field to get set to that value.  When mac_dupctx and mac_freectx is called (ie: in SSL_write) it ends up freeing the reference of the original object instead of a copy.