### PR TITLE
Fix typo and section order in doc/man3/OSSL_ENCODER.pod

### DIFF
--- a/doc/man3/OSSL_ENCODER.pod
+++ b/doc/man3/OSSL_ENCODER.pod
@@ -87,12 +87,6 @@ OSSL_ENCODER_get_params() attempts to get parameters specified
 with an L<OSSL_PARAM(3)> array I<params>.  Parameters that the
 implementation doesn't recognise should be ignored.
 
-=head1 NOTES
-
-OSSL_ENCODER_fetch() may be called implicitly by other fetching
-functions, using the same library context and properties.
-Any other API that uses keys will typically do this.
-
 =head1 RETURN VALUES
 
 OSSL_ENCODER_fetch() returns a pointer to the key management
@@ -113,6 +107,12 @@ OSSL_ENCODER_is_a() returns 1 of I<encoder> was identifiable,
 otherwise 0.
 
 OSSL_ENCODER_number() returns an integer.
+
+=head1 NOTES
+
+OSSL_ENCODER_fetch() may be called implicitly by other fetching
+functions, using the same library context and properties.
+Any other API that uses keys will typically do this.
 
 =head1 SEE ALSO
 

--- a/doc/man3/OSSL_ENCODER.pod
+++ b/doc/man3/OSSL_ENCODER.pod
@@ -63,7 +63,7 @@ I<encoder>, and when the count reaches zero, frees it.
 OSSL_ENCODER_provider() returns the provider of the given
 I<encoder>.
 
-OSSL_ENCODER_provider() returns the property definition associated
+OSSL_ENCODER_properties() returns the property definition associated
 with the given I<encoder>.
 
 OSSL_ENCODER_is_a() checks if I<encoder> is an implementation of an


### PR DESCRIPTION
Minor changes to `doc/man3/OSSL_ENCODER.pod`:

## Fix typo in DESCRIPTION of OSSL_ENCODER_properties

This commit fixes the DECSCRIPTION section of doc/man3/OSSL_ENCODER.pod, where `OSSL_ENCODER_properties` was incorrectly referred to as `OSSL_ENCODER_provider`.

## Move NOTES to the bottom

For consistency with OSSL_DECODER.pod, and man-pages(7), the NOTES
section is moved at the end of the file.

According to man-pages(7) the recommended section order is:

> NAME
> SYNOPSIS
> CONFIGURATION      [Normally only in Section 4]
> DESCRIPTION
> OPTIONS            [Normally only in Sections 1, 8]
> EXIT STATUS        [Normally only in Sections 1, 8]
> RETURN VALUE       [Normally only in Sections 2, 3]
> ERRORS             [Typically only in Sections 2, 3]
> ENVIRONMENT
> FILES
> VERSIONS           [Normally only in Sections 2, 3]
> CONFORMING TO
> NOTES
> BUGS
> EXAMPLE
> SEE ALSO

This commit does not attempt to fix the order in all pages but focuses
only on OSSL_ENCODER which has a "twin" man page in OSSL_DECODER, making
the inconsist section ordering quite jarring.

## Checklist

- [x] documentation is added or updated
