### PR TITLE
Fix OSSL_PARAM_allocate_from_text() for EBCDIC

### DIFF
--- a/crypto/params_from_text.c
+++ b/crypto/params_from_text.c
@@ -9,6 +9,7 @@
  */
 
 #include <string.h>
+#include <openssl/ebcdic.h>
 #include <openssl/err.h>
 #include <openssl/params.h>
 
@@ -139,7 +140,11 @@ static int construct_from_text(OSSL_PARAM *to, const OSSL_PARAM *paramdef,
             }
             break;
         case OSSL_PARAM_UTF8_STRING:
+#ifdef CHARSET_EBCDIC
+            ebcdic2ascii(buf, value, buf_n);
+#else
             strncpy(buf, value, buf_n);
+#endif
             break;
         case OSSL_PARAM_OCTET_STRING:
             if (ishex) {

--- a/doc/man3/OSSL_PARAM_allocate_from_text.pod
+++ b/doc/man3/OSSL_PARAM_allocate_from_text.pod
@@ -73,8 +73,10 @@ considers that an error.
 If I<key> started with "hex", OSSL_PARAM_allocate_from_text()
 considers that an error.
 
-Otherwise, I<value> is considered a C string and is copied with no
-further checks to the I<< to->data >> storage.
+Otherwise, I<value> is considered a C string and is copied to the
+I<< to->data >> storage.
+On systems where the native character encoding is EBCDIC, the bytes in
+I<< to->data >> are converted to ASCII.
 
 =item B<OSSL_PARAM_OCTET_STRING>
 


### PR DESCRIPTION
OSSL_PARAM_allocate_from_text() converted text values to UTF-8
OSSL_PARAMs with a simple strncpy().  However, if the text is EBCDIC,
that won't become UTF-8.  Therefore, it's made to convert from EBCDIC
to ASCII on platforms where the native character encoding is the
former.

One might argue that the conversion should be the responsibility of
the application.  However, this is a helper function, and the calling
application can't easily know what sort of OSSL_PARAM the input values
are going to be used for.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
