### PR TITLE
EVP: Don't find standard EVP_PKEY_METHODs automatically

### DIFF
--- a/crypto/ec/ec_lib.c
+++ b/crypto/ec/ec_lib.c
@@ -63,7 +63,7 @@ EC_GROUP *ec_group_new_ex(OSSL_LIB_CTX *libctx, const char *propq,
         if (ret->cofactor == NULL)
             goto err;
     }
-    ret->asn1_flag = OPENSSL_EC_NAMED_CURVE;
+    ret->asn1_flag = OPENSSL_EC_EXPLICIT_CURVE;
     ret->asn1_form = POINT_CONVERSION_UNCOMPRESSED;
     if (!meth->group_init(ret))
         goto err;
@@ -481,6 +481,7 @@ const BIGNUM *EC_GROUP_get0_cofactor(const EC_GROUP *group)
 void EC_GROUP_set_curve_name(EC_GROUP *group, int nid)
 {
     group->curve_name = nid;
+    group->asn1_flag = OPENSSL_EC_NAMED_CURVE;
 }
 
 int EC_GROUP_get_curve_name(const EC_GROUP *group)

--- a/crypto/ec/ec_lib.c
+++ b/crypto/ec/ec_lib.c
@@ -481,7 +481,10 @@ const BIGNUM *EC_GROUP_get0_cofactor(const EC_GROUP *group)
 void EC_GROUP_set_curve_name(EC_GROUP *group, int nid)
 {
     group->curve_name = nid;
-    group->asn1_flag = OPENSSL_EC_NAMED_CURVE;
+    group->asn1_flag =
+        (nid != NID_undef)
+        ? OPENSSL_EC_NAMED_CURVE
+        : OPENSSL_EC_EXPLICIT_CURVE;
 }
 
 int EC_GROUP_get_curve_name(const EC_GROUP *group)

--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -918,7 +918,7 @@ int EVP_PKEY_base_id(const EVP_PKEY *pkey)
  * EVP_PKEY_EC, because of aliasing.
  * TODO Clean this away along with all other #legacy support.
  */
-const OSSL_ITEM standard_name2type[] = {
+static const OSSL_ITEM standard_name2type[] = {
     { EVP_PKEY_RSA,     "RSA" },
     { EVP_PKEY_RSA_PSS, "RSA-PSS" },
     { EVP_PKEY_EC,      "EC" },

--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -906,53 +906,58 @@ int EVP_PKEY_base_id(const EVP_PKEY *pkey)
 }
 
 #ifndef FIPS_MODULE
+/*
+ * These hard coded cases are pure hackery to get around the fact
+ * that names in crypto/objects/objects.txt are a mess.  There is
+ * no "EC", and "RSA" leads to the NID for 2.5.8.1.1, an OID that's
+ * fallen out in favor of { pkcs-1 1 }, i.e. 1.2.840.113549.1.1.1,
+ * the NID of which is used for EVP_PKEY_RSA.  Strangely enough,
+ * "DSA" is accurate...  but still, better be safe and hard-code
+ * names that we know.
+ * On a similar topic, EVP_PKEY_type(EVP_PKEY_SM2) will result in
+ * EVP_PKEY_EC, because of aliasing.
+ * TODO Clean this away along with all other #legacy support.
+ */
+const OSSL_ITEM standard_name2type[] = {
+    { EVP_PKEY_RSA,     "RSA" },
+    { EVP_PKEY_RSA_PSS, "RSA-PSS" },
+    { EVP_PKEY_EC,      "EC" },
+    { EVP_PKEY_ED25519, "ED25519" },
+    { EVP_PKEY_ED448,   "ED448" },
+    { EVP_PKEY_X25519,  "X25519" },
+    { EVP_PKEY_X448,    "X448" },
+    { EVP_PKEY_SM2,     "SM2" },
+    { EVP_PKEY_DH,      "DH" },
+    { EVP_PKEY_DHX,     "X9.42 DH" },
+    { EVP_PKEY_DHX,     "DHX" },
+    { EVP_PKEY_DSA,     "DSA" },
+};
+
 int evp_pkey_name2type(const char *name)
 {
-    /*
-     * These hard coded cases are pure hackery to get around the fact
-     * that names in crypto/objects/objects.txt are a mess.  There is
-     * no "EC", and "RSA" leads to the NID for 2.5.8.1.1, an OID that's
-     * fallen out in favor of { pkcs-1 1 }, i.e. 1.2.840.113549.1.1.1,
-     * the NID of which is used for EVP_PKEY_RSA.  Strangely enough,
-     * "DSA" is accurate...  but still, better be safe and hard-code
-     * names that we know.
-     * On a similar topic, EVP_PKEY_type(EVP_PKEY_SM2) will result in
-     * EVP_PKEY_EC, because of aliasing.
-     * TODO Clean this away along with all other #legacy support.
-     */
-    int type = NID_undef;
+    int type;
+    size_t i;
 
-    if (strcasecmp(name, "RSA") == 0)
-        type = EVP_PKEY_RSA;
-    else if (strcasecmp(name, "RSA-PSS") == 0)
-        type = EVP_PKEY_RSA_PSS;
-    else if (strcasecmp(name, "EC") == 0)
-        type = EVP_PKEY_EC;
-    else if (strcasecmp(name, "ED25519") == 0)
-        type = EVP_PKEY_ED25519;
-    else if (strcasecmp(name, "ED448") == 0)
-        type = EVP_PKEY_ED448;
-    else if (strcasecmp(name, "X25519") == 0)
-        type = EVP_PKEY_X25519;
-    else if (strcasecmp(name, "X448") == 0)
-        type = EVP_PKEY_X448;
-    else if (strcasecmp(name, "SM2") == 0)
-        type = EVP_PKEY_SM2;
-    else if (strcasecmp(name, "DH") == 0)
-        type = EVP_PKEY_DH;
-    else if (strcasecmp(name, "X9.42 DH") == 0)
-        type = EVP_PKEY_DHX;
-    else if (strcasecmp(name, "DHX") == 0)
-        type = EVP_PKEY_DHX;
-    else if (strcasecmp(name, "DSA") == 0)
-        type = EVP_PKEY_DSA;
+    for (i = 0; i < OSSL_NELEM(standard_name2type); i++) {
+        if (strcasecmp(name, standard_name2type[i].ptr) == 0)
+            return (int)standard_name2type[i].id;
+    }
 
-    if (type == NID_undef)
-        type = EVP_PKEY_type(OBJ_sn2nid(name));
-    if (type == NID_undef)
-        type = EVP_PKEY_type(OBJ_ln2nid(name));
+    if ((type = EVP_PKEY_type(OBJ_sn2nid(name))) != NID_undef)
+        return type;
+    return EVP_PKEY_type(OBJ_ln2nid(name));
+}
 
-    return type;
+const char *evp_pkey_type2name(int type)
+{
+    size_t i;
+
+    for (i = 0; i < OSSL_NELEM(standard_name2type); i++) {
+        if (type == (int)standard_name2type[i].id)
+            return standard_name2type[i].ptr;
+    }
+
+    return OBJ_nid2sn(type);
 }
 #endif
 

--- a/crypto/evp/pmeth_lib.c
+++ b/crypto/evp/pmeth_lib.c
@@ -90,12 +90,11 @@ static int pmeth_cmp(const EVP_PKEY_METHOD *const *a,
 
 static const EVP_PKEY_METHOD *evp_pkey_meth_find_added_by_application(int type)
 {
-    EVP_PKEY_METHOD tmp;
-
-    tmp.pkey_id = type;
-    if (app_pkey_methods) {
+    if (app_pkey_methods != NULL) {
         int idx;
+        EVP_PKEY_METHOD tmp;
 
+        tmp.pkey_id = type;
         idx = sk_EVP_PKEY_METHOD_find(app_pkey_methods, &tmp);
         if (idx >= 0)
             return sk_EVP_PKEY_METHOD_value(app_pkey_methods, idx);

--- a/crypto/evp/pmeth_lib.c
+++ b/crypto/evp/pmeth_lib.c
@@ -255,6 +255,7 @@ static EVP_PKEY_CTX *int_ctx_new(OSSL_LIB_CTX *libctx,
      */
     if (e != NULL)
         pmeth = ENGINE_get_pkey_meth(e, id);
+    else
 # endif
         pmeth = evp_pkey_meth_find_added_by_application(id);
 

--- a/crypto/evp/pmeth_lib.c
+++ b/crypto/evp/pmeth_lib.c
@@ -1685,8 +1685,33 @@ static int evp_pkey_ctx_store_cached_data(EVP_PKEY_CTX *ctx,
                                           int cmd, const char *name,
                                           const void *data, size_t data_len)
 {
-    if ((keytype != -1 && ctx->pmeth->pkey_id != keytype)
-        || ((optype != -1) && !(ctx->operation & optype))) {
+    if (keytype != -1) {
+        switch (evp_pkey_ctx_state(ctx)) {
+        case EVP_PKEY_STATE_PROVIDER:
+            if (ctx->keymgmt == NULL) {
+                ERR_raise(ERR_LIB_EVP, EVP_R_COMMAND_NOT_SUPPORTED);
+                return -2;
+            }
+            if (!EVP_KEYMGMT_is_a(ctx->keymgmt,
+                                  evp_pkey_type2name(keytype))) {
+                ERR_raise(ERR_LIB_EVP, EVP_R_INVALID_OPERATION);
+                return -1;
+            }
+            break;
+        case EVP_PKEY_STATE_UNKNOWN:
+        case EVP_PKEY_STATE_LEGACY:
+            if (ctx->pmeth == NULL) {
+                ERR_raise(ERR_LIB_EVP, EVP_R_COMMAND_NOT_SUPPORTED);
+                return -2;
+            }
+            if (ctx->pmeth->pkey_id != keytype) {
+                ERR_raise(ERR_LIB_EVP, EVP_R_INVALID_OPERATION);
+                return -1;
+            }
+            break;
+        }
+    }
+    if (optype != -1 && (ctx->operation & optype) == 0) {
         ERR_raise(ERR_LIB_EVP, EVP_R_INVALID_OPERATION);
         return -1;
     }

--- a/include/crypto/evp.h
+++ b/include/crypto/evp.h
@@ -828,6 +828,7 @@ int evp_pkey_ctx_get_params_strict(EVP_PKEY_CTX *ctx, OSSL_PARAM *params);
 EVP_MD_CTX *evp_md_ctx_new_ex(EVP_PKEY *pkey, const ASN1_OCTET_STRING *id,
                               OSSL_LIB_CTX *libctx, const char *propq);
 int evp_pkey_name2type(const char *name);
+const char *evp_pkey_type2name(int type);
 
 int evp_pkey_ctx_set1_id_prov(EVP_PKEY_CTX *ctx, const void *id, int len);
 int evp_pkey_ctx_get1_id_prov(EVP_PKEY_CTX *ctx, void *id);


### PR DESCRIPTION
EVP_PKEY_meth_find() got called automatically any time a new
EVP_PKEY_CTX allocator was called with some sort of key type data.
Since we have now moved all our standard algorithms to our providers,
this is no longer necessary.

We do retain looking up EVP_PKEY_METHODs that are added by the calling
application.

Fixes #11424
