### PR TITLE
Mac/IOS ARM 64 tick implementation removing special case.

### DIFF
--- a/crypto/arm64cpuid.pl
+++ b/crypto/arm64cpuid.pl
@@ -38,11 +38,7 @@ _armv7_neon_probe:
 .globl	_armv7_tick
 .type	_armv7_tick,%function
 _armv7_tick:
-#ifdef	__APPLE__
-	mrs	x0, CNTPCT_EL0
-#else
 	mrs	x0, CNTVCT_EL0
-#endif
 	ret
 .size	_armv7_tick,.-_armv7_tick
 


### PR DESCRIPTION
even on these platforms, this common register has replaced
 cntpct_el0 (which requires an offset correction) in the clock api internally since years.
In addition, a barrier to avoid possible speculation across calls.