### PR TITLE
APPS: Restore inclusions

### DIFF
--- a/apps/ec.c
+++ b/apps/ec.c
@@ -7,6 +7,7 @@
  * https://www.openssl.org/source/license.html
  */
 
+#include <string.h>
 #include <openssl/opensslconf.h>
 #include <openssl/evp.h>
 #include <openssl/encoder.h>

--- a/apps/ecparam.c
+++ b/apps/ecparam.c
@@ -8,6 +8,7 @@
  * https://www.openssl.org/source/license.html
  */
 
+#include <string.h>
 #include <openssl/opensslconf.h>
 #include <openssl/evp.h>
 #include <openssl/encoder.h>


### PR DESCRIPTION
An '#include <string.h>' was mistakenly removed from apps/ec.c

Fixes #13986
