### PR TITLE
Remove unused 'peer_type' from SSL_SESSION

### DIFF
--- a/ssl/ssl_local.h
+++ b/ssl/ssl_local.h
@@ -585,7 +585,6 @@ struct ssl_session_st {
     int not_resumable;
     /* This is the cert and type for the other end. */
     X509 *peer;
-    int peer_type;
     /* Certificate chain peer sent. */
     STACK_OF(X509) *peer_chain;
     /*

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -1920,7 +1920,6 @@ WORK_STATE tls_post_process_server_certificate(SSL *s, WORK_STATE wst)
             return WORK_ERROR;
         }
     }
-    s->session->peer_type = certidx;
 
     X509_free(s->session->peer);
     X509_up_ref(x);


### PR DESCRIPTION
This field has not been used since #3858 was merged in 2017 when we
moved to a table-based lookup for certificate type properties instead of
an index-based one.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
