### PR TITLE
Enable fipsload test on NonStop x86.

### DIFF
--- a/test/recipes/90-test_fipsload.t
+++ b/test/recipes/90-test_fipsload.t
@@ -18,7 +18,7 @@ use platform;
 
 plan skip_all => 'Test only supported in a shared build' if disabled('shared');
 plan skip_all => 'Test is disabled on AIX' if config('target') =~ m|^aix|;
-plan skip_all => 'Test is disabled on NonStop' if config('target') =~ m|^nonstop|;
+plan skip_all => 'Test is disabled on NonStop ia64' if config('target') =~ m|^nonstop-nse|;
 plan skip_all => 'Test only supported in a dso build' if disabled('dso');
 plan skip_all => 'Test is disabled in an address sanitizer build' unless disabled('asan');
 


### PR DESCRIPTION
CLA: Trivial

Fixes: #14005

Signed-off-by: Randall S. Becker <rsbecker@nexbridge.com>
