### PR TITLE
Deprecate EVP_MD_CTX_{set_}update_fn()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,6 +29,11 @@ OpenSSL 3.0
 
    *Tomas Mraz*
 
+ * Deprecate EVP_MD_CTX_set_update_fn() and EVP_MD_CTX_update_fn()
+   as they are not useful with non-deprecated functions.
+
+   *Rich Salz*
+
  * Deprecated the type OCSP_REQ_CTX and the functions OCSP_REQ_CTX_new(),
    OCSP_REQ_CTX_free(), OCSP_REQ_CTX_http(), OCSP_REQ_CTX_add1_header(),
    OCSP_REQ_CTX_i2d(), OCSP_REQ_CTX_nbio(), OCSP_REQ_CTX_nbio_d2i(),

--- a/doc/man3/EVP_DigestInit.pod
+++ b/doc/man3/EVP_DigestInit.pod
@@ -80,11 +80,6 @@ EVP_MD_do_all_provided
  int EVP_MD_CTX_block_size(const EVP_MD_CTX *ctx);
  int EVP_MD_CTX_type(const EVP_MD_CTX *ctx);
  void *EVP_MD_CTX_md_data(const EVP_MD_CTX *ctx);
- int (*EVP_MD_CTX_update_fn(EVP_MD_CTX *ctx))(EVP_MD_CTX *ctx,
-                                              const void *data, size_t count);
- void EVP_MD_CTX_set_update_fn(EVP_MD_CTX *ctx,
-                               int (*update)(EVP_MD_CTX *ctx,
-                                             const void *data, size_t count));
 
  const EVP_MD *EVP_md_null(void);
 
@@ -98,6 +93,17 @@ EVP_MD_do_all_provided
  void EVP_MD_do_all_provided(OSSL_LIB_CTX *libctx,
                              void (*fn)(EVP_MD *mac, void *arg),
                              void *arg);
+
+Deprecated since OpenSSL 3.0, can be hidden entirely by defining
+B<OPENSSL_API_COMPAT> with a suitable version value, see
+L<openssl_user_macros(7)>:
+
+ int (*EVP_MD_CTX_update_fn(EVP_MD_CTX *ctx))(EVP_MD_CTX *ctx,
+                                              const void *data, size_t count);
+
+ void EVP_MD_CTX_set_update_fn(EVP_MD_CTX *ctx,
+                               int (*update)(EVP_MD_CTX *ctx,
+                                             const void *data, size_t count));
 
 =head1 DESCRIPTION
 
@@ -325,7 +331,7 @@ should not be used after the EVP_MD_CTX is freed.
 =item EVP_MD_CTX_set_update_fn()
 
 Sets the update function for I<ctx> to I<update>.
-This is the function that is called by EVP_DigestUpdate. If not set, the
+This is the function that is called by EVP_DigestUpdate(). If not set, the
 update function from the B<EVP_MD> type specified at initialization is used.
 
 =item EVP_MD_CTX_update_fn()
@@ -645,10 +651,12 @@ later, so now EVP_sha1() can be used with RSA and DSA.
 
 The EVP_dss1() function was removed in OpenSSL 1.1.0.
 
-The EVP_MD_CTX_set_pkey_ctx() function was added in 1.1.1.
+The EVP_MD_CTX_set_pkey_ctx() function was added in OpenSSL 1.1.1.
 
 The EVP_MD_fetch(), EVP_MD_free(), EVP_MD_up_ref(), EVP_MD_CTX_set_params()
-and EVP_MD_CTX_get_params() functions were added in 3.0.
+and EVP_MD_CTX_get_params() functions were added in OpenSSL 3.0.
+The EVP_MD_CTX_update_fn() and EVP_MD_CTX_set_update_fn() were deprecated
+in OpenSSL 3.0.
 
 =head1 COPYRIGHT
 

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -531,11 +531,15 @@ int EVP_MD_block_size(const EVP_MD *md);
 unsigned long EVP_MD_flags(const EVP_MD *md);
 
 const EVP_MD *EVP_MD_CTX_md(const EVP_MD_CTX *ctx);
+# ifndef OPENSSL_NO_DEPRECATED_3_0
+OSSL_DEPRECATEDIN_3_0
 int (*EVP_MD_CTX_update_fn(EVP_MD_CTX *ctx))(EVP_MD_CTX *ctx,
                                              const void *data, size_t count);
+OSSL_DEPRECATEDIN_3_0
 void EVP_MD_CTX_set_update_fn(EVP_MD_CTX *ctx,
                               int (*update) (EVP_MD_CTX *ctx,
                                              const void *data, size_t count));
+# endif
 # define EVP_MD_CTX_name(e)              EVP_MD_name(EVP_MD_CTX_md(e))
 # define EVP_MD_CTX_size(e)              EVP_MD_size(EVP_MD_CTX_md(e))
 # define EVP_MD_CTX_block_size(e)        EVP_MD_block_size(EVP_MD_CTX_md(e))

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -2524,7 +2524,7 @@ EVP_PKEY_meth_new                       2577	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_
 RSA_padding_check_PKCS1_OAEP            2578	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
 OCSP_SERVICELOC_it                      2579	3_0_0	EXIST::FUNCTION:OCSP
 PKCS12_SAFEBAG_get_nid                  2580	3_0_0	EXIST::FUNCTION:
-EVP_MD_CTX_set_update_fn                2581	3_0_0	EXIST::FUNCTION:
+EVP_MD_CTX_set_update_fn                2581	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
 BIO_f_asn1                              2582	3_0_0	EXIST::FUNCTION:
 BIO_dump                                2583	3_0_0	EXIST::FUNCTION:
 ENGINE_load_ssl_client_cert             2584	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,ENGINE
@@ -3106,7 +3106,7 @@ IDEA_cfb64_encrypt                      3170	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_
 BN_mod_sub                              3171	3_0_0	EXIST::FUNCTION:
 ASN1_NULL_new                           3172	3_0_0	EXIST::FUNCTION:
 HMAC_Init                               3173	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_1_1_0
-EVP_MD_CTX_update_fn                    3174	3_0_0	EXIST::FUNCTION:
+EVP_MD_CTX_update_fn                    3174	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
 EVP_aes_128_ecb                         3175	3_0_0	EXIST::FUNCTION:
 i2d_PKCS7_bio_stream                    3176	3_0_0	EXIST::FUNCTION:
 i2a_ACCESS_DESCRIPTION                  3178	3_0_0	EXIST::FUNCTION:


### PR DESCRIPTION
They are still used internally in legacy code.

Also fixed up some minor things in EVP_DigestInit.pod

Fixes: #14003

