### PR TITLE
CMP: On NULL-DN subject or issuer input omit field in cert template; further small improvements

### DIFF
--- a/apps/cmp.c
+++ b/apps/cmp.c
@@ -1610,11 +1610,84 @@ static int setup_request_ctx(OSSL_CMP_CTX *ctx, ENGINE *engine)
             && opt_csr == NULL && opt_oldcert == NULL && opt_cert == NULL
             && opt_cmd != CMP_RR && opt_cmd != CMP_GENM)
         CMP_warn("no -subject given; no -csr or -oldcert or -cert available for fallback");
-    if (!set_name(opt_subject, OSSL_CMP_CTX_set1_subjectName, ctx, "subject")
-            || !set_name(opt_issuer, OSSL_CMP_CTX_set1_issuer, ctx, "issuer"))
-        return 0;
 
-    if (opt_newkey != NULL) {
+    if (opt_cmd == CMP_IR || opt_cmd == CMP_CR || opt_cmd == CMP_KUR) {
+        if (opt_newkey == NULL && opt_key == NULL && opt_csr == NULL) {
+            CMP_err("missing -newkey (or -key) to be certified and no -csr given");
+            return 0;
+        }
+        if (opt_certout == NULL) {
+            CMP_err("-certout not given, nowhere to save newly enrolled certificate");
+            return 0;
+        }
+        if (!set_name(opt_subject, OSSL_CMP_CTX_set1_subjectName, ctx, "subject")
+                || !set_name(opt_issuer, OSSL_CMP_CTX_set1_issuer, ctx, "issuer"))
+            return 0;
+    } else {
+        const char *msg = "option is ignored for commands other than 'ir', 'cr', and 'kur'";
+
+        if (opt_subject != NULL) {
+            if (opt_ref == NULL && opt_cert == NULL) {
+                /* use subject as default sender unless oldcert subject is used */
+                if (!set_name(opt_subject, OSSL_CMP_CTX_set1_subjectName, ctx, "subject"))
+                    return 0;
+            } else {
+                CMP_warn1("-subject %s since -ref or -cert is given", msg);
+            }
+        }
+        if (opt_issuer != NULL)
+            CMP_warn1("-issuer %s", msg);
+        if (opt_reqexts != NULL)
+            CMP_warn1("-reqexts %s", msg);
+        if (opt_san_nodefault)
+            CMP_warn1("-san_nodefault %s", msg);
+        if (opt_sans != NULL)
+            CMP_warn1("-sans %s", msg);
+        if (opt_policies != NULL)
+            CMP_warn1("-policies %s", msg);
+        if (opt_policy_oids != NULL)
+            CMP_warn1("-policy_oids %s", msg);
+    }
+    if (opt_cmd == CMP_KUR) {
+        char *ref_cert = opt_oldcert != NULL ? opt_oldcert : opt_cert;
+
+        if (ref_cert == NULL && opt_csr == NULL) {
+            CMP_err("missing -oldcert for certificate to be updated and no -csr given");
+            return 0;
+        }
+        if (opt_subject != NULL)
+            CMP_warn2("given -subject '%s' overrides the subject of '%s' for KUR",
+                      opt_subject, ref_cert != NULL ? ref_cert : opt_csr);
+    }
+    if (opt_cmd == CMP_RR) {
+        if (opt_oldcert == NULL && opt_csr == NULL) {
+            CMP_err("missing -oldcert for certificate to be revoked and no -csr given");
+            return 0;
+        }
+        if (opt_oldcert != NULL && opt_csr != NULL)
+            CMP_warn("ignoring -csr since certificate to be revoked is given");
+    }
+    if (opt_cmd == CMP_P10CR && opt_csr == NULL) {
+        CMP_err("missing PKCS#10 CSR for p10cr");
+        return 0;
+    }
+
+    if (opt_recipient == NULL && opt_srvcert == NULL && opt_issuer == NULL
+            && opt_oldcert == NULL && opt_cert == NULL)
+        CMP_warn("missing -recipient, -srvcert, -issuer, -oldcert or -cert; recipient will be set to \"NULL-DN\"");
+
+    if (opt_cmd == CMP_P10CR || opt_cmd == CMP_RR) {
+        const char *msg = "option is ignored for 'p10cr' and 'rr' commands";
+
+        if (opt_newkeypass != NULL)
+            CMP_warn1("-newkeytype %s", msg);
+        if (opt_newkey != NULL)
+            CMP_warn1("-newkey %s", msg);
+        if (opt_days != 0)
+            CMP_warn1("-days %s", msg);
+        if (opt_popo != OSSL_CRMF_POPO_NONE - 1)
+            CMP_warn1("-popo %s", msg);
+    } else if (opt_newkey != NULL) {
         const char *file = opt_newkey;
         const int format = opt_keyform;
         const char *pass = opt_newkeypass;
@@ -1882,44 +1955,6 @@ static int setup_client_ctx(OSSL_CMP_CTX *ctx, ENGINE *engine)
 
     if (!transform_opts())
         goto err;
-
-    if (opt_cmd == CMP_IR || opt_cmd == CMP_CR || opt_cmd == CMP_KUR) {
-        if (opt_newkey == NULL && opt_key == NULL && opt_csr == NULL) {
-            CMP_err("missing -newkey (or -key) to be certified");
-            goto err;
-        }
-        if (opt_certout == NULL) {
-            CMP_err("-certout not given, nowhere to save certificate");
-            goto err;
-        }
-    }
-    if (opt_cmd == CMP_KUR) {
-        char *ref_cert = opt_oldcert != NULL ? opt_oldcert : opt_cert;
-
-        if (ref_cert == NULL && opt_csr == NULL) {
-            CMP_err("missing -oldcert for certificate to be updated and no fallback -csr given");
-            goto err;
-        }
-        if (opt_subject != NULL)
-            CMP_warn2("given -subject '%s' overrides the subject of '%s' for KUR",
-                      opt_subject, ref_cert != NULL ? ref_cert : opt_csr);
-    }
-    if (opt_cmd == CMP_RR) {
-        if (opt_oldcert == NULL && opt_csr == NULL) {
-            CMP_err("missing -oldcert for certificate to be revoked and no fallback -csr given");
-            goto err;
-        }
-        if (opt_oldcert != NULL && opt_csr != NULL)
-            CMP_warn("ignoring -csr since certificate to be revoked is given");
-    }
-    if (opt_cmd == CMP_P10CR && opt_csr == NULL) {
-        CMP_err("missing PKCS#10 CSR for p10cr");
-        goto err;
-    }
-
-    if (opt_recipient == NULL && opt_srvcert == NULL && opt_issuer == NULL
-            && opt_oldcert == NULL && opt_cert == NULL)
-        CMP_warn("missing -recipient, -srvcert, -issuer, -oldcert or -cert; recipient will be set to \"NULL-DN\"");
 
     if (opt_infotype_s != NULL) {
         char id_buf[100] = "id-it-";

--- a/crypto/cmp/cmp_local.h
+++ b/crypto/cmp/cmp_local.h
@@ -25,6 +25,8 @@
 # include <openssl/x509v3.h>
 # include "crypto/x509.h"
 
+#define IS_NULL_DN(name) (X509_NAME_get_entry(name, 0) == NULL)
+
 /*
  * this structure is used to store the context for CMP sessions
  */
@@ -778,6 +780,7 @@ int ossl_cmp_print_log(OSSL_CMP_severity level, const OSSL_CMP_CTX *ctx,
 # define ossl_cmp_warn(ctx, msg)  ossl_cmp_log(WARN,  ctx, msg)
 # define ossl_cmp_info(ctx, msg)  ossl_cmp_log(INFO,  ctx, msg)
 # define ossl_cmp_debug(ctx, msg) ossl_cmp_log(DEBUG, ctx, msg)
+# define ossl_cmp_trace(ctx, msg) ossl_cmp_log(TRACE, ctx, msg)
 int ossl_cmp_ctx_set0_validatedSrvCert(OSSL_CMP_CTX *ctx, X509 *cert);
 int ossl_cmp_ctx_set_status(OSSL_CMP_CTX *ctx, int status);
 int ossl_cmp_ctx_set0_statusString(OSSL_CMP_CTX *ctx,

--- a/crypto/cmp/cmp_msg.c
+++ b/crypto/cmp/cmp_msg.c
@@ -218,7 +218,7 @@ static const X509_NAME *determine_subj(OSSL_CMP_CTX *ctx,
                                        int for_KUR)
 {
     if (ctx->subjectName != NULL)
-        return ctx->subjectName;
+        return IS_NULL_DN(ctx->subjectName) ? NULL : ctx->subjectName;
 
     if (ref_subj != NULL && (for_KUR || !HAS_SAN(ctx)))
         /*
@@ -241,7 +241,8 @@ OSSL_CRMF_MSG *OSSL_CMP_CTX_setup_CRM(OSSL_CMP_CTX *ctx, int for_KUR, int rid)
         refcert != NULL ? X509_get_subject_name(refcert) : NULL;
     const X509_NAME *subject = determine_subj(ctx, ref_subj, for_KUR);
     const X509_NAME *issuer = ctx->issuer != NULL || refcert == NULL
-        ? ctx->issuer : X509_get_issuer_name(refcert);
+        ? (IS_NULL_DN(ctx->issuer) ? NULL : ctx->issuer)
+        : X509_get_issuer_name(refcert);
     int crit = ctx->setSubjectAltNameCritical || subject == NULL;
     /* RFC5280: subjectAltName MUST be critical if subject is null */
     X509_EXTENSIONS *exts = NULL;

--- a/doc/man1/openssl-cmp.pod.in
+++ b/doc/man1/openssl-cmp.pod.in
@@ -209,14 +209,14 @@ Currently implemented commands are:
 
 =back
 
-B<ir> requests initialization of an End Entity into a PKI hierarchy
+B<ir> requests initialization of an end entity into a PKI hierarchy
 by issuing a first certificate.
 
-B<cr> requests issuing an additional certificate for an End Entity already
+B<cr> requests issuing an additional certificate for an end entity already
 initialized to the PKI hierarchy.
 
 B<p10cr> requests issuing an additional certificate similarly to B<cr>
-but using PKCS#10 CSR format.
+but using legacy PKCS#10 CSR format.
 
 B<kur> requests a (key) update for an existing certificate.
 
@@ -263,15 +263,17 @@ L<openssl-passphrase-options(1)>.
 
 X509 Distinguished Name (DN) of subject to use in the requested certificate
 template.
-For KUR, it defaults to the subject DN of any given CSR
+For KUR, it defaults to the public key
+in the PKCS#10 CSR given with the B<-csr> option, if provided,
 or of the reference certificate (see B<-oldcert>) if provided.
 This default is used for IR and CR only if no SANs are set.
+If the NULL-DN (C</>) is given then no subject is placed in the template.
 
-The provided subject DN is also used as fallback sender of outgoing CMP messages
-if no B<-cert> and no B<-oldcert> are given.
+If provided and neither B<-cert> nor B<-oldcert> is given,
+the subject DN is used as fallback sender of outgoing CMP messages.
 
 The argument must be formatted as I</type0=value0/type1=value1/type2=...>.
-Special characters may be escaped by C<\> (backslash), whitespace is retained.
+Special characters may be escaped by C<\> (backslash); whitespace is retained.
 Empty values are permitted, but the corresponding type will not be included.
 Giving a single C</> will lead to an empty sequence of RDNs (a NULL-DN).
 Multi-valued RDNs can be formed by placing a C<+> character instead of a C</>
@@ -284,9 +286,13 @@ C</DC=org/DC=OpenSSL/DC=users/UID=123456+CN=John Doe>
 
 X509 issuer Distinguished Name (DN) of the CA server
 to place in the requested certificate template in IR/CR/KUR.
+If the NULL-DN (C</>) is given then no issuer is placed in the template.
 
-If neither B<-srvcert> nor B<-recipient> is available,
-the name given in this option is also set as the recipient of the CMP message.
+If provided and neither B<-recipient> nor B<-srvcert> is given,
+the issuer DN is used as fallback recipient of outgoing CMP messages.
+
+The argument must be formatted as I</type0=value0/type1=value1/type2=...>.
+For details see the description of the B<-subject> option.
 
 =item B<-days> I<number>
 
@@ -348,11 +354,11 @@ With B<-cmd> I<p10cr> it is used directly in a legacy P10CR message.
 When used with B<-cmd> I<ir>, I<cr>, or I<kur>, it is transformed into the
 respective regular CMP request.
 It may also be used with B<-cmd> I<rr> to specify the certificate to be revoked
-via the included subject and public key.
+via the included subject name and public key.
 
 =item B<-out_trusted> I<filenames>|I<uris>
 
-Trusted certificate(s) to use for verifying the newly enrolled certificate.
+Trusted certificate(s) to use for validating the newly enrolled certificate.
 
 Multiple sources may be given, separated by commas and/or whitespace
 (where in the latter case the whole argument must be enclosed in "...").
@@ -391,9 +397,9 @@ The file where the chain of the newly enrolled certificate should be saved.
 
 The certificate to be updated (i.e., renewed or re-keyed) in Key Update Request
 (KUR) messages or to be revoked in Revocation Request (RR) messages.
-For RR the certificate to be revoked can also be specified using B<-csr>.
 For KUR the certificate to be updated defaults to B<-cert>,
 and the resulting certificate is called I<reference certificate>.
+For RR the certificate to be revoked can also be specified using B<-csr>.
 
 The reference certificate, if any, is also used for
 deriving default subject DN and Subject Alternative Names and the
@@ -476,7 +482,7 @@ Default is 0 (infinite).
 
 =item B<-trusted> I<filenames>|I<uris>
 
-When verifying signature-based protection of CMP response messages,
+When validating signature-based protection of CMP response messages,
 these are the CA certificate(s) to trust while checking certificate chains
 during CMP server authentication.
 This option gives more flexibility than the B<-srvcert> option because the
@@ -502,8 +508,8 @@ All these certificates may be useful for cert path construction
 for the CMP client certificate (to include in the extraCerts field of outgoing
 messages) and for the TLS client certificate (if TLS is enabled)
 as well as for chain building
-when verifying the CMP server certificate (checking signature-based
-CMP message protection) and when verifying newly enrolled certificates.
+when validating the CMP server certificate (checking signature-based
+CMP message protection) and when validating newly enrolled certificates.
 
 Multiple sources may be given, separated by commas and/or whitespace.
 Each file may contain multiple certificates.
@@ -511,7 +517,7 @@ Each file may contain multiple certificates.
 =item B<-srvcert> I<filename>|I<uri>]
 
 The specific CMP server certificate to expect and directly trust (even if it is
-expired) when verifying signature-based protection of CMP response messages.
+expired) when validating signature-based protection of CMP response messages.
 May be set alternatively to the B<-trusted> option to pin the accepted server.
 
 If set, the subject of the certificate is also used
@@ -531,6 +537,9 @@ the issuer of the certificate given with the B<-oldcert> option,
 the issuer of the CMP client certificate (B<-cert> option),
 as far as any of those is present, else the NULL-DN as last resort.
 
+The argument must be formatted as I</type0=value0/type1=value1/type2=...>.
+For details see the description of the B<-subject> option.
+
 =item B<-expect_sender> I<name>
 
 Distinguished Name (DN) expected in the sender field of incoming CMP messages.
@@ -543,9 +552,12 @@ Note that this option gives slightly more freedom than setting the B<-srvcert>,
 which pins the server to the holder of a particular certificate, while the
 expected sender name will continue to match after updates of the server cert.
 
+The argument must be formatted as I</type0=value0/type1=value1/type2=...>.
+For details see the description of the B<-subject> option.
+
 =item B<-ignore_keyusage>
 
-Ignore key usage restrictions in CMP signer certificates when verifying
+Ignore key usage restrictions in CMP signer certificates when validating
 signature-based protection of incoming CMP messages,
 else C<digitalSignature> must be allowed for signer certificate.
 
@@ -611,7 +623,7 @@ is typically used when authenticating with pre-shared key (password-based MAC).
 
 Prefer PBM-based message protection with given source of a secret value.
 The secret is used for creating PBM-based protection of outgoing messages
-and (as far as needed) for verifying PBM-based protection of incoming messages.
+and (as far as needed) for validating PBM-based protection of incoming messages.
 PBM stands for Password-Based Message Authentication Code.
 This takes precedence over the B<-cert> and B<-key> options.
 
@@ -777,7 +789,7 @@ Extra certificates to provide to TLS server during TLS handshake
 
 =item B<-tls_trusted> I<filenames>|I<uris>
 
-Trusted certificate(s) to use for verifying the TLS server certificate.
+Trusted certificate(s) to use for validating the TLS server certificate.
 This implies hostname validation.
 
 Multiple sources may be given, separated by commas and/or whitespace
@@ -899,7 +911,7 @@ have no effect on the certificate verification enabled via this option.
 
 =item B<-srv_untrusted> I<filenames>|I<uris>
 
-Intermediate CA certs that may be useful when verifying client certificates.
+Intermediate CA certs that may be useful when validating client certificates.
 
 =item B<-rsp_cert> I<filename>|I<uri>]
 


### PR DESCRIPTION
According to user request, on NULL-DN subject or issuer input omit field in cert template.

Also 
* improve diagnostics on inconsistent cert request input in `apps/cmp.c`,
(which motivated a code cleanup there on where to check cert request options),
* add trace output for transactionIDs on new sessions,
* update a test case and the documentation in `openssl-cmp.pod.in`, and
* replace in `openssl-cmp.pod.in` the term 'verify' by the more correct 'validate'.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] test are added or updated