### PR TITLE
Correct the return value of BIO_get_ktls_*().

### DIFF
--- a/crypto/bio/bss_conn.c
+++ b/crypto/bio/bss_conn.c
@@ -536,7 +536,7 @@ static long conn_ctrl(BIO *b, int cmd, long num, void *ptr)
         }
         break;
     case BIO_CTRL_EOF:
-        ret = (b->flags & BIO_FLAGS_IN_EOF) != 0 ? 1 : 0;
+        ret = (b->flags & BIO_FLAGS_IN_EOF) != 0;
         break;
 # ifndef OPENSSL_NO_KTLS
     case BIO_CTRL_SET_KTLS:

--- a/crypto/bio/bss_conn.c
+++ b/crypto/bio/bss_conn.c
@@ -546,9 +546,9 @@ static long conn_ctrl(BIO *b, int cmd, long num, void *ptr)
             BIO_set_ktls_flag(b, num);
         break;
     case BIO_CTRL_GET_KTLS_SEND:
-        return BIO_should_ktls_flag(b, 1);
+        return BIO_should_ktls_flag(b, 1) != 0;
     case BIO_CTRL_GET_KTLS_RECV:
-        return BIO_should_ktls_flag(b, 0);
+        return BIO_should_ktls_flag(b, 0) != 0;
     case BIO_CTRL_SET_KTLS_TX_SEND_CTRL_MSG:
         BIO_set_ktls_ctrl_msg_flag(b);
         data->record_type = num;

--- a/crypto/bio/bss_fd.c
+++ b/crypto/bio/bss_fd.c
@@ -189,7 +189,7 @@ static long fd_ctrl(BIO *b, int cmd, long num, void *ptr)
         ret = 1;
         break;
     case BIO_CTRL_EOF:
-        ret = (b->flags & BIO_FLAGS_IN_EOF) != 0 ? 1 : 0;
+        ret = (b->flags & BIO_FLAGS_IN_EOF) != 0;
         break;
     default:
         ret = 0;

--- a/crypto/bio/bss_sock.c
+++ b/crypto/bio/bss_sock.c
@@ -191,9 +191,9 @@ static long sock_ctrl(BIO *b, int cmd, long num, void *ptr)
             BIO_set_ktls_flag(b, num);
         break;
     case BIO_CTRL_GET_KTLS_SEND:
-        return BIO_should_ktls_flag(b, 1);
+        return BIO_should_ktls_flag(b, 1) != 0;
     case BIO_CTRL_GET_KTLS_RECV:
-        return BIO_should_ktls_flag(b, 0);
+        return BIO_should_ktls_flag(b, 0) != 0;
     case BIO_CTRL_SET_KTLS_TX_SEND_CTRL_MSG:
         BIO_set_ktls_ctrl_msg_flag(b);
         b->ptr = (void *)num;

--- a/crypto/bio/bss_sock.c
+++ b/crypto/bio/bss_sock.c
@@ -205,7 +205,7 @@ static long sock_ctrl(BIO *b, int cmd, long num, void *ptr)
         break;
 # endif
     case BIO_CTRL_EOF:
-        ret = (b->flags & BIO_FLAGS_IN_EOF) != 0 ? 1 : 0;
+        ret = (b->flags & BIO_FLAGS_IN_EOF) != 0;
         break;
     default:
         ret = 0;


### PR DESCRIPTION
BIO_get_ktls_send() and BIO_get_ktls_recv() are documented as
returning either 0 or 1.  However, they were actually returning the
internal value of the associated BIO flag for the true case instead of
1.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->
