### PR TITLE
Use ASN1_TIME for handling time comparisons in ca.c:do_updatedb

### DIFF
--- a/apps/ca.c
+++ b/apps/ca.c
@@ -2223,62 +2223,48 @@ static int get_certificate_status(const char *serial, CA_DB *db)
 
 static int do_updatedb(CA_DB *db)
 {
-    ASN1_UTCTIME *a_tm = NULL;
+    ASN1_TIME *a_tm = NULL;
     int i, cnt = 0;
-    int db_y2k, a_y2k;          /* flags = 1 if y >= 2000 */
-    char **rrow, *a_tm_s;
+    char **rrow;
 
-    a_tm = ASN1_UTCTIME_new();
+    a_tm = ASN1_TIME_new();
     if (a_tm == NULL)
         return -1;
 
-    /* get actual time and make a string */
+    /* get actual time */
     if (X509_gmtime_adj(a_tm, 0) == NULL) {
-        ASN1_UTCTIME_free(a_tm);
+        ASN1_TIME_free(a_tm);
         return -1;
     }
-    a_tm_s = app_malloc(a_tm->length + 1, "time string");
-
-    memcpy(a_tm_s, a_tm->data, a_tm->length);
-    a_tm_s[a_tm->length] = '\0';
-
-    if (strncmp(a_tm_s, "49", 2) <= 0)
-        a_y2k = 1;
-    else
-        a_y2k = 0;
 
     for (i = 0; i < sk_OPENSSL_PSTRING_num(db->db->data); i++) {
         rrow = sk_OPENSSL_PSTRING_value(db->db->data, i);
 
         if (rrow[DB_type][0] == DB_TYPE_VAL) {
             /* ignore entries that are not valid */
-            if (strncmp(rrow[DB_exp_date], "49", 2) <= 0)
-                db_y2k = 1;
-            else
-                db_y2k = 0;
+            ASN1_TIME *exp_date = NULL;
 
-            if (db_y2k == a_y2k) {
-                /* all on the same y2k side */
-                if (strcmp(rrow[DB_exp_date], a_tm_s) <= 0) {
-                    rrow[DB_type][0] = DB_TYPE_EXP;
-                    rrow[DB_type][1] = '\0';
-                    cnt++;
+            exp_date = ASN1_TIME_new();
+            if (exp_date == NULL)
+                return -1;
 
-                    BIO_printf(bio_err, "%s=Expired\n", rrow[DB_serial]);
-                }
-            } else if (db_y2k < a_y2k) {
+            if (!ASN1_TIME_set_string(exp_date, rrow[DB_exp_date])) {
+                ASN1_TIME_free(exp_date);
+                return -1;
+            }
+
+            if (ASN1_TIME_compare(exp_date, a_tm) <= 0) {
                 rrow[DB_type][0] = DB_TYPE_EXP;
                 rrow[DB_type][1] = '\0';
                 cnt++;
 
                 BIO_printf(bio_err, "%s=Expired\n", rrow[DB_serial]);
             }
-
+            ASN1_TIME_free(exp_date);
         }
     }
 
-    ASN1_UTCTIME_free(a_tm);
-    OPENSSL_free(a_tm_s);
+    ASN1_TIME_free(a_tm);
     return cnt;
 }
 

--- a/apps/ca.c
+++ b/apps/ca.c
@@ -2245,10 +2245,13 @@ static int do_updatedb(CA_DB *db)
             ASN1_TIME *exp_date = NULL;
 
             exp_date = ASN1_TIME_new();
-            if (exp_date == NULL)
+            if (exp_date == NULL) {
+                ASN1_TIME_free(a_tm);
                 return -1;
+            }
 
             if (!ASN1_TIME_set_string(exp_date, rrow[DB_exp_date])) {
+                ASN1_TIME_free(a_tm);
                 ASN1_TIME_free(exp_date);
                 return -1;
             }


### PR DESCRIPTION
Fixes #13944
   + changed ASN1_UTCTIME to ASN1_TIME
   + removed all Y2K code from do_updatedb
   + changed compare to ASN1_TIME_compare