### PR TITLE
PROV: Fix encoding of MDWithRSAEncryption signature AlgorithmID

### DIFF
--- a/providers/common/der/der_rsa_sig.c
+++ b/providers/common/der/der_rsa_sig.c
@@ -58,7 +58,9 @@ int ossl_DER_w_algorithmIdentifier_MDWithRSAEncryption(WPACKET *pkt, int tag,
     }
 
     return ossl_DER_w_begin_sequence(pkt, tag)
-        /* No parameters (yet?) */
+        /* PARAMETERS, always NULL according to current standards */
+        && ossl_DER_w_null(pkt, -1)
+        /* OID */
         && ossl_DER_w_precompiled(pkt, -1, precompiled, precompiled_sz)
         && ossl_DER_w_end_sequence(pkt, tag);
 }


### PR DESCRIPTION
All {MD}WithRSAEncryption signature AlgorithmID have the parameters
being NULL, according to PKCS#1.  We didn't.  Now corrected.

This bug was the topic of this thread on openssl-users@openssl.org:
https://mta.openssl.org/pipermail/openssl-users/2021-January/013416.html
