### PR TITLE
Remove some TODO(OpenSSL1.2) references

### DIFF
--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -3491,7 +3491,6 @@ long ssl3_ctrl(SSL *s, int cmd, long larg, void *parg)
 #endif
     case SSL_CTRL_SET_TLSEXT_HOSTNAME:
         /*
-         * TODO(OpenSSL1.2)
          * This API is only used for a client to set what SNI it will request
          * from the server, but we currently allow it to be used on servers
          * as well, which is a programming error.  Currently we just clear

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -2036,7 +2036,10 @@ static int tls12_sigalg_allowed(const SSL *s, int op, const SIGALG_LOOKUP *lu)
     /* DSA is not allowed in TLS 1.3 */
     if (SSL_IS_TLS13(s) && lu->sig == EVP_PKEY_DSA)
         return 0;
-    /* TODO(OpenSSL1.2) fully axe DSA/etc. in ClientHello per TLS 1.3 spec */
+    /*
+     * At some point we should fully axe DSA/etc. in ClientHello as per TLS 1.3
+     * spec
+     */
     if (!s->server && !SSL_IS_DTLS(s) && s->s3.tmp.min_ver >= TLS1_3_VERSION
         && (lu->sig == EVP_PKEY_DSA || lu->hash_idx == SSL_MD_SHA1_IDX
             || lu->hash_idx == SSL_MD_MD5_IDX


### PR DESCRIPTION
We had a couple of stray references to OpenSSL1.2 in libssl. We just
reword the comments to remove those references without changing any
behaviour.

The first one in t1_lib.c is a technical non-compliance in the TLSv1.3
spec where, under some circumstances, we offer DSA sigalgs even in a
ClientHello that eventually negotiates TLSv1.3. We explicitly chose to
accept this behaviour in 1.1.1 and we're not planning to change it for
3.0.

The second one in s3_lib.c is regarnding the behaviour of
SSL_set_tlsext_host_name(). Technically you shouldn't be able to call
this from a server - but we allow it and just ignore it rather than
raising an error. The TODO suggest we consider raising an error instead.
However, with 3.0 we are trying to minimise breaking changes so I suggest
not making this change now.

Fixes #13161

