### PR TITLE
Remove a DSA related TODO

### DIFF
--- a/include/openssl/dsa.h
+++ b/include/openssl/dsa.h
@@ -98,10 +98,6 @@ int DSA_SIG_set0(DSA_SIG *sig, BIGNUM *r, BIGNUM *s);
 /* typedef struct dsa_st DSA; */
 /* typedef struct dsa_method DSA_METHOD; */
 
-/*
- * TODO(3.0): consider removing the ASN.1 encoding and decoding when
- * deserialization is completed elsewhere.
- */
 #   define d2i_DSAparams_fp(fp, x) \
         (DSA *)ASN1_d2i_fp((char *(*)())DSA_new, \
                            (char *(*)())d2i_DSAparams, (fp), \


### PR DESCRIPTION
There are no instances of the macros that this comment is referring to
being used anywhere within current master. All of the macros were
deprecated by commit f41ac0e. Therefore this TODO should just be removed.

Fixes #13020

