### PR TITLE
CORE & PROV: clean away OSSL_FUNC_mac_size()

### DIFF
--- a/include/crypto/evp.h
+++ b/include/crypto/evp.h
@@ -196,7 +196,6 @@ struct evp_mac_st {
     OSSL_FUNC_mac_newctx_fn *newctx;
     OSSL_FUNC_mac_dupctx_fn *dupctx;
     OSSL_FUNC_mac_freectx_fn *freectx;
-    OSSL_FUNC_mac_size_fn *size;
     OSSL_FUNC_mac_init_fn *init;
     OSSL_FUNC_mac_update_fn *update;
     OSSL_FUNC_mac_final_fn *final;

--- a/include/openssl/core_dispatch.h
+++ b/include/openssl/core_dispatch.h
@@ -331,7 +331,6 @@ OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, cipher_gettable_ctx_params,
 OSSL_CORE_MAKE_FUNC(void *, mac_newctx, (void *provctx))
 OSSL_CORE_MAKE_FUNC(void *, mac_dupctx, (void *src))
 OSSL_CORE_MAKE_FUNC(void, mac_freectx, (void *mctx))
-OSSL_CORE_MAKE_FUNC(size_t, mac_size, (void *mctx))
 OSSL_CORE_MAKE_FUNC(int, mac_init, (void *mctx))
 OSSL_CORE_MAKE_FUNC(int, mac_update,
                     (void *mctx, const unsigned char *in, size_t inl))

--- a/providers/implementations/macs/blake2_mac_impl.c
+++ b/providers/implementations/macs/blake2_mac_impl.c
@@ -39,8 +39,6 @@ struct blake2_mac_data_st {
     unsigned char key[BLAKE2_KEYBYTES];
 };
 
-static size_t blake2_mac_size(void *vmacctx);
-
 static void *blake2_mac_new(void *unused_provctx)
 {
     struct blake2_mac_data_st *macctx;
@@ -80,6 +78,13 @@ static void blake2_mac_free(void *vmacctx)
         OPENSSL_cleanse(macctx->key, sizeof(macctx->key));
         OPENSSL_free(macctx);
     }
+}
+
+static size_t blake2_mac_size(void *vmacctx)
+{
+    struct blake2_mac_data_st *macctx = vmacctx;
+
+    return macctx->params.digest_length;
 }
 
 static int blake2_mac_init(void *vmacctx)
@@ -212,13 +217,6 @@ static int blake2_mac_set_ctx_params(void *vmacctx, const OSSL_PARAM params[])
         BLAKE2_PARAM_SET_SALT(&macctx->params, p->data, p->data_size);
     }
     return 1;
-}
-
-static size_t blake2_mac_size(void *vmacctx)
-{
-    struct blake2_mac_data_st *macctx = vmacctx;
-
-    return macctx->params.digest_length;
 }
 
 const OSSL_DISPATCH BLAKE2_FUNCTIONS[] = {

--- a/providers/implementations/macs/gmac_prov.c
+++ b/providers/implementations/macs/gmac_prov.c
@@ -45,8 +45,6 @@ struct gmac_data_st {
     PROV_CIPHER cipher;
 };
 
-static size_t gmac_size(void);
-
 static void gmac_free(void *vmacctx)
 {
     struct gmac_data_st *macctx = vmacctx;
@@ -95,6 +93,11 @@ static void *gmac_dup(void *vsrc)
     return dst;
 }
 
+static size_t gmac_size(void)
+{
+    return EVP_GCM_TLS_TAG_LEN;
+}
+
 static int gmac_init(void *vmacctx)
 {
     return ossl_prov_is_running();
@@ -139,11 +142,6 @@ static int gmac_final(void *vmacctx, unsigned char *out, size_t *outl,
 
     *outl = hlen;
     return 1;
-}
-
-static size_t gmac_size(void)
-{
-    return EVP_GCM_TLS_TAG_LEN;
 }
 
 static const OSSL_PARAM known_gettable_params[] = {

--- a/providers/implementations/macs/hmac_prov.c
+++ b/providers/implementations/macs/hmac_prov.c
@@ -71,8 +71,6 @@ int ssl3_cbc_digest_record(const EVP_MD *md,
                            const unsigned char *mac_secret,
                            size_t mac_secret_length, char is_sslv3);
 
-static size_t hmac_size(void *vmacctx);
-
 static void *hmac_new(void *provctx)
 {
     struct hmac_data_st *macctx;

--- a/providers/implementations/macs/kmac_prov.c
+++ b/providers/implementations/macs/kmac_prov.c
@@ -73,7 +73,6 @@ static OSSL_FUNC_mac_gettable_ctx_params_fn kmac_gettable_ctx_params;
 static OSSL_FUNC_mac_get_ctx_params_fn kmac_get_ctx_params;
 static OSSL_FUNC_mac_settable_ctx_params_fn kmac_settable_ctx_params;
 static OSSL_FUNC_mac_set_ctx_params_fn kmac_set_ctx_params;
-static OSSL_FUNC_mac_size_fn kmac_size;
 static OSSL_FUNC_mac_init_fn kmac_init;
 static OSSL_FUNC_mac_update_fn kmac_update;
 static OSSL_FUNC_mac_final_fn kmac_final;
@@ -235,6 +234,13 @@ static void *kmac_dup(void *vsrc)
     return dst;
 }
 
+static size_t kmac_size(void *vmacctx)
+{
+    struct kmac_data_st *kctx = vmacctx;
+
+    return kctx->out_len;
+}
+
 /*
  * The init() assumes that any ctrl methods are set beforehand for
  * md, key and custom. Setting the fields afterwards will have no
@@ -276,13 +282,6 @@ static int kmac_init(void *vmacctx)
                    kctx->custom, kctx->custom_len, block_len)
            && EVP_DigestUpdate(ctx, out, out_len)
            && EVP_DigestUpdate(ctx, kctx->key, kctx->key_len);
-}
-
-static size_t kmac_size(void *vmacctx)
-{
-    struct kmac_data_st *kctx = vmacctx;
-
-    return kctx->out_len;
 }
 
 static int kmac_update(void *vmacctx, const unsigned char *data,

--- a/providers/implementations/macs/poly1305_prov.c
+++ b/providers/implementations/macs/poly1305_prov.c
@@ -40,8 +40,6 @@ struct poly1305_data_st {
     POLY1305 poly1305;           /* Poly1305 data */
 };
 
-static size_t poly1305_size(void);
-
 static void *poly1305_new(void *provctx)
 {
     struct poly1305_data_st *ctx;

--- a/providers/implementations/macs/siphash_prov.c
+++ b/providers/implementations/macs/siphash_prov.c
@@ -38,7 +38,6 @@ static OSSL_FUNC_mac_gettable_ctx_params_fn siphash_gettable_ctx_params;
 static OSSL_FUNC_mac_get_ctx_params_fn siphash_get_ctx_params;
 static OSSL_FUNC_mac_settable_ctx_params_fn siphash_settable_params;
 static OSSL_FUNC_mac_set_ctx_params_fn siphash_set_params;
-static OSSL_FUNC_mac_size_fn siphash_size;
 static OSSL_FUNC_mac_init_fn siphash_init;
 static OSSL_FUNC_mac_update_fn siphash_update;
 static OSSL_FUNC_mac_final_fn siphash_final;
@@ -94,7 +93,7 @@ static int siphash_init(void *vmacctx)
 }
 
 static int siphash_update(void *vmacctx, const unsigned char *data,
-                       size_t datalen)
+                          size_t datalen)
 {
     struct siphash_data_st *ctx = vmacctx;
 


### PR DESCRIPTION
There was a remaining function signature declaration, but no
OSSL_DISPATCH number for it nor any way it's ever used.  It did exist
once, but was replaced with an OSSL_PARAM item to retrieve.
