### PR TITLE
Prevent creating empty folder "../apps/include"

### DIFF
--- a/test/build.info
+++ b/test/build.info
@@ -499,7 +499,7 @@ INCLUDE_MAIN___test_libtestutil_OLB = /INCLUDE=MAIN
 
     IF[{- !$disabled{cmac} -}]
       SOURCE[cmactest]=cmactest.c
-      INCLUDE[cmactest]=../include ../apps/include
+      INCLUDE[cmactest]=../include
       DEPEND[cmactest]=../libcrypto.a libtestutil.a
     ENDIF
 


### PR DESCRIPTION
This folder "../apps/include" is accidentally created.
This prevents this glitch.

Fixes 19b4fe5844b ("Add a CMAC test")
