### PR TITLE
Dirty count for provider native keys + cleanup

### DIFF
--- a/crypto/evp/keymgmt_lib.c
+++ b/crypto/evp/keymgmt_lib.c
@@ -189,7 +189,7 @@ void *evp_keymgmt_util_export_to_provider(EVP_PKEY *pk, EVP_KEYMGMT *keymgmt)
      * operation cache.  In that case, we know that |i| is zero.
      */
     if (pk->dirty_cnt != pk->dirty_cnt_copy)
-        evp_keymgmt_util_clear_operation_cache(pk);
+        evp_keymgmt_util_clear_operation_cache(pk, 0);
 
     /* Add the new export to the operation cache */
     if (!evp_keymgmt_util_cache_keydata(pk, i, keymgmt, import_data.keydata)) {

--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -2037,7 +2037,7 @@ int EVP_PKEY_get_octet_string_param(const EVP_PKEY *pkey, const char *key_name,
                                     size_t *out_sz)
 {
     OSSL_PARAM params[2];
-    int ret;
+    int ret1 = 0, ret2 = 0;
 
     if (key_name == NULL
         || pkey == NULL
@@ -2046,13 +2046,11 @@ int EVP_PKEY_get_octet_string_param(const EVP_PKEY *pkey, const char *key_name,
 
     params[0] = OSSL_PARAM_construct_octet_string(key_name, buf, max_buf_sz);
     params[1] = OSSL_PARAM_construct_end();
-    ret = EVP_PKEY_get_params(pkey, params);
-    if (OSSL_PARAM_modified(params)) {
-        if (out_sz != NULL)
-            *out_sz = params[0].return_size;
-        ret = ret && 1;
-    }
-    return ret;
+    if ((ret1 = EVP_PKEY_get_params(pkey, params)))
+        ret2 = OSSL_PARAM_modified(params);
+    if (ret2 && out_sz != NULL)
+        *out_sz = params[0].return_size;
+    return ret1 && ret2;
 }
 
 int EVP_PKEY_get_utf8_string_param(const EVP_PKEY *pkey, const char *key_name,
@@ -2060,18 +2058,18 @@ int EVP_PKEY_get_utf8_string_param(const EVP_PKEY *pkey, const char *key_name,
                                     size_t *out_sz)
 {
     OSSL_PARAM params[2];
+    int ret1 = 0, ret2 = 0;
 
     if (key_name == NULL)
         return 0;
 
     params[0] = OSSL_PARAM_construct_utf8_string(key_name, str, max_buf_sz);
     params[1] = OSSL_PARAM_construct_end();
-    if (!EVP_PKEY_get_params(pkey, params)
-        || !OSSL_PARAM_modified(params))
-        return 0;
-    if (out_sz != NULL)
+    if ((ret1 = EVP_PKEY_get_params(pkey, params)))
+        ret2 = OSSL_PARAM_modified(params);
+    if (ret2 && out_sz != NULL)
         *out_sz = params[0].return_size;
-    return 1;
+    return ret1 && ret2;
 }
 
 int EVP_PKEY_get_int_param(const EVP_PKEY *pkey, const char *key_name,

--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -2004,11 +2004,10 @@ int EVP_PKEY_get_bn_param(const EVP_PKEY *pkey, const char *key_name,
     unsigned char *buf = NULL;
     size_t buf_sz = 0;
 
-    if (pkey == NULL
-        || pkey->keymgmt == NULL
-        || pkey->keydata == NULL
-        || key_name == NULL
-        || bn == NULL)
+    if (key_name == NULL
+        || bn == NULL
+        || pkey == NULL
+        || !evp_pkey_is_provided(pkey))
         return 0;
 
     memset(buffer, 0, sizeof(buffer));
@@ -2046,10 +2045,9 @@ int EVP_PKEY_get_octet_string_param(const EVP_PKEY *pkey, const char *key_name,
 {
     OSSL_PARAM params[2];
 
-    if (pkey == NULL
-        || pkey->keymgmt == NULL
-        || pkey->keydata == NULL
-        || key_name == NULL)
+    if (key_name == NULL
+        || pkey == NULL
+        || !evp_pkey_is_provided(pkey))
         return 0;
 
     params[0] = OSSL_PARAM_construct_octet_string(key_name, buf, max_buf_sz);
@@ -2068,10 +2066,7 @@ int EVP_PKEY_get_utf8_string_param(const EVP_PKEY *pkey, const char *key_name,
 {
     OSSL_PARAM params[2];
 
-    if (pkey == NULL
-        || pkey->keymgmt == NULL
-        || pkey->keydata == NULL
-        || key_name == NULL)
+    if (key_name == NULL)
         return 0;
 
     params[0] = OSSL_PARAM_construct_utf8_string(key_name, str, max_buf_sz);
@@ -2089,10 +2084,7 @@ int EVP_PKEY_get_int_param(const EVP_PKEY *pkey, const char *key_name,
 {
     OSSL_PARAM params[2];
 
-    if (pkey == NULL
-        || pkey->keymgmt == NULL
-        || pkey->keydata == NULL
-        || key_name == NULL)
+    if (key_name == NULL)
         return 0;
 
     params[0] = OSSL_PARAM_construct_int(key_name, out);
@@ -2106,10 +2098,7 @@ int EVP_PKEY_get_size_t_param(const EVP_PKEY *pkey, const char *key_name,
 {
     OSSL_PARAM params[2];
 
-    if (pkey == NULL
-        || pkey->keymgmt == NULL
-        || pkey->keydata == NULL
-        || key_name == NULL)
+    if (key_name == NULL)
         return 0;
 
     params[0] = OSSL_PARAM_construct_size_t(key_name, out);
@@ -2122,10 +2111,7 @@ int EVP_PKEY_set_int_param(EVP_PKEY *pkey, const char *key_name, int in)
 {
     OSSL_PARAM params[2];
 
-    if (pkey == NULL
-        || pkey->keymgmt == NULL
-        || pkey->keydata == NULL
-        || key_name == NULL)
+    if (key_name == NULL)
         return 0;
 
     params[0] = OSSL_PARAM_construct_int(key_name, &in);
@@ -2137,10 +2123,7 @@ int EVP_PKEY_set_size_t_param(EVP_PKEY *pkey, const char *key_name, size_t in)
 {
     OSSL_PARAM params[2];
 
-    if (pkey == NULL
-        || pkey->keymgmt == NULL
-        || pkey->keydata == NULL
-        || key_name == NULL)
+    if (key_name == NULL)
         return 0;
 
     params[0] = OSSL_PARAM_construct_size_t(key_name, &in);
@@ -2154,11 +2137,10 @@ int EVP_PKEY_set_bn_param(EVP_PKEY *pkey, const char *key_name, BIGNUM *bn)
     unsigned char buffer[2048];
     int bsize = 0;
 
-    if (pkey == NULL
-        || pkey->keymgmt == NULL
-        || pkey->keydata == NULL
-        || key_name == NULL
-        || bn == NULL)
+    if (key_name == NULL
+        || bn == NULL
+        || pkey == NULL
+        || !evp_pkey_is_provided(pkey))
         return 0;
 
     bsize = BN_num_bytes(bn);
@@ -2177,10 +2159,7 @@ int EVP_PKEY_set_utf8_string_param(EVP_PKEY *pkey, const char *key_name,
 {
     OSSL_PARAM params[2];
 
-    if (pkey == NULL
-        || pkey->keymgmt == NULL
-        || pkey->keydata == NULL
-        || key_name == NULL)
+    if (key_name == NULL)
         return 0;
 
     params[0] = OSSL_PARAM_construct_utf8_string(key_name, str, 0);
@@ -2193,10 +2172,7 @@ int EVP_PKEY_set_octet_string_param(EVP_PKEY *pkey, const char *key_name,
 {
     OSSL_PARAM params[2];
 
-    if (pkey == NULL
-        || pkey->keymgmt == NULL
-        || pkey->keydata == NULL
-        || key_name == NULL)
+    if (key_name == NULL)
         return 0;
 
     params[0] = OSSL_PARAM_construct_octet_string(key_name, buf, bsize);
@@ -2204,13 +2180,11 @@ int EVP_PKEY_set_octet_string_param(EVP_PKEY *pkey, const char *key_name,
     return EVP_PKEY_set_params(pkey, params);
 }
 
-const OSSL_PARAM *EVP_PKEY_settable_params(EVP_PKEY *pkey)
+const OSSL_PARAM *EVP_PKEY_settable_params(const EVP_PKEY *pkey)
 {
-    if (pkey == NULL
-        || pkey->keymgmt == NULL
-        || pkey->keydata == NULL)
-        return 0;
-    return EVP_KEYMGMT_settable_params(pkey->keymgmt);
+    return pkey != NULL
+        && evp_pkey_is_provided(pkey)
+        && EVP_KEYMGMT_settable_params(pkey->keymgmt);
 }
 
 int EVP_PKEY_set_params(EVP_PKEY *pkey, OSSL_PARAM params[])

--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -2143,7 +2143,7 @@ int EVP_PKEY_set_int_param(EVP_PKEY *pkey, const char *key_name, int in)
 
     params[0] = OSSL_PARAM_construct_int(key_name, &in);
     params[1] = OSSL_PARAM_construct_end();
-    return evp_keymgmt_set_params(pkey->keymgmt, pkey->keydata, params);
+    return EVP_PKEY_set_params(pkey, params);
 }
 
 int EVP_PKEY_set_size_t_param(EVP_PKEY *pkey, const char *key_name, size_t in)
@@ -2158,7 +2158,7 @@ int EVP_PKEY_set_size_t_param(EVP_PKEY *pkey, const char *key_name, size_t in)
 
     params[0] = OSSL_PARAM_construct_size_t(key_name, &in);
     params[1] = OSSL_PARAM_construct_end();
-    return evp_keymgmt_set_params(pkey->keymgmt, pkey->keydata, params);
+    return EVP_PKEY_set_params(pkey, params);
 }
 
 int EVP_PKEY_set_bn_param(EVP_PKEY *pkey, const char *key_name, BIGNUM *bn)
@@ -2182,7 +2182,7 @@ int EVP_PKEY_set_bn_param(EVP_PKEY *pkey, const char *key_name, BIGNUM *bn)
         return 0;
     params[0] = OSSL_PARAM_construct_BN(key_name, buffer, bsize);
     params[1] = OSSL_PARAM_construct_end();
-    return evp_keymgmt_set_params(pkey->keymgmt, pkey->keydata, params);
+    return EVP_PKEY_set_params(pkey, params);
 }
 
 int EVP_PKEY_set_utf8_string_param(EVP_PKEY *pkey, const char *key_name,
@@ -2198,7 +2198,7 @@ int EVP_PKEY_set_utf8_string_param(EVP_PKEY *pkey, const char *key_name,
 
     params[0] = OSSL_PARAM_construct_utf8_string(key_name, str, 0);
     params[1] = OSSL_PARAM_construct_end();
-    return evp_keymgmt_set_params(pkey->keymgmt, pkey->keydata, params);
+    return EVP_PKEY_set_params(pkey, params);
 }
 
 int EVP_PKEY_set_octet_string_param(EVP_PKEY *pkey, const char *key_name,
@@ -2214,7 +2214,7 @@ int EVP_PKEY_set_octet_string_param(EVP_PKEY *pkey, const char *key_name,
 
     params[0] = OSSL_PARAM_construct_octet_string(key_name, buf, bsize);
     params[1] = OSSL_PARAM_construct_end();
-    return evp_keymgmt_set_params(pkey->keymgmt, pkey->keydata, params);
+    return EVP_PKEY_set_params(pkey, params);
 }
 
 const OSSL_PARAM *EVP_PKEY_settable_params(EVP_PKEY *pkey)

--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -2228,11 +2228,13 @@ const OSSL_PARAM *EVP_PKEY_settable_params(EVP_PKEY *pkey)
 
 int EVP_PKEY_set_params(EVP_PKEY *pkey, OSSL_PARAM params[])
 {
-    if (pkey == NULL
-        || pkey->keymgmt == NULL
-        || pkey->keydata == NULL)
-        return 0;
-    return evp_keymgmt_set_params(pkey->keymgmt, pkey->keydata, params);
+    int ret = pkey != NULL
+        && evp_pkey_is_provided(pkey)
+        && evp_keymgmt_set_params(pkey->keymgmt, pkey->keydata, params);
+
+    if (ret)
+        pkey->dirty_cnt++;
+    return ret;
 }
 
 #ifndef FIPS_MODULE

--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -2131,7 +2131,8 @@ int EVP_PKEY_set_size_t_param(EVP_PKEY *pkey, const char *key_name, size_t in)
     return EVP_PKEY_set_params(pkey, params);
 }
 
-int EVP_PKEY_set_bn_param(EVP_PKEY *pkey, const char *key_name, BIGNUM *bn)
+int EVP_PKEY_set_bn_param(EVP_PKEY *pkey, const char *key_name,
+                          const BIGNUM *bn)
 {
     OSSL_PARAM params[2];
     unsigned char buffer[2048];
@@ -2155,27 +2156,28 @@ int EVP_PKEY_set_bn_param(EVP_PKEY *pkey, const char *key_name, BIGNUM *bn)
 }
 
 int EVP_PKEY_set_utf8_string_param(EVP_PKEY *pkey, const char *key_name,
-                                   char *str)
+                                   const char *str)
 {
     OSSL_PARAM params[2];
 
     if (key_name == NULL)
         return 0;
 
-    params[0] = OSSL_PARAM_construct_utf8_string(key_name, str, 0);
+    params[0] = OSSL_PARAM_construct_utf8_string(key_name, (char *)str, 0);
     params[1] = OSSL_PARAM_construct_end();
     return EVP_PKEY_set_params(pkey, params);
 }
 
 int EVP_PKEY_set_octet_string_param(EVP_PKEY *pkey, const char *key_name,
-                                    unsigned char *buf, size_t bsize)
+                                    const unsigned char *buf, size_t bsize)
 {
     OSSL_PARAM params[2];
 
     if (key_name == NULL)
         return 0;
 
-    params[0] = OSSL_PARAM_construct_octet_string(key_name, buf, bsize);
+    params[0] = OSSL_PARAM_construct_octet_string(key_name,
+                                                  (unsigned char *)buf, bsize);
     params[1] = OSSL_PARAM_construct_end();
     return EVP_PKEY_set_params(pkey, params);
 }

--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -2184,9 +2184,11 @@ const OSSL_PARAM *EVP_PKEY_settable_params(const EVP_PKEY *pkey)
 
 int EVP_PKEY_set_params(EVP_PKEY *pkey, OSSL_PARAM params[])
 {
+    if (pkey == NULL)
+        return 0;
+
     pkey->dirty_cnt++;
-    return pkey != NULL
-        && evp_pkey_is_provided(pkey)
+    return evp_pkey_is_provided(pkey)
         && evp_keymgmt_set_params(pkey->keymgmt, pkey->keydata, params);
 }
 

--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -2184,9 +2184,9 @@ int EVP_PKEY_set_octet_string_param(EVP_PKEY *pkey, const char *key_name,
 
 const OSSL_PARAM *EVP_PKEY_settable_params(const EVP_PKEY *pkey)
 {
-    return pkey != NULL
-        && evp_pkey_is_provided(pkey)
-        && EVP_KEYMGMT_settable_params(pkey->keymgmt);
+    return (pkey != NULL && evp_pkey_is_provided(pkey))
+        ? EVP_KEYMGMT_settable_params(pkey->keymgmt)
+        : NULL;
 }
 
 int EVP_PKEY_set_params(EVP_PKEY *pkey, OSSL_PARAM params[])
@@ -2202,9 +2202,9 @@ int EVP_PKEY_set_params(EVP_PKEY *pkey, OSSL_PARAM params[])
 
 const OSSL_PARAM *EVP_PKEY_gettable_params(const EVP_PKEY *pkey)
 {
-    return pkey != NULL
-        && evp_pkey_is_provided(pkey)
-        && EVP_KEYMGMT_gettable_params(pkey->keymgmt);
+    return (pkey != NULL && evp_pkey_is_provided(pkey))
+        ? EVP_KEYMGMT_gettable_params(pkey->keymgmt)
+        : NULL;
 }
 
 int EVP_PKEY_get_params(const EVP_PKEY *pkey, OSSL_PARAM params[])

--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -2013,7 +2013,7 @@ int EVP_PKEY_get_bn_param(const EVP_PKEY *pkey, const char *key_name,
     memset(buffer, 0, sizeof(buffer));
     params[0] = OSSL_PARAM_construct_BN(key_name, buffer, sizeof(buffer));
     params[1] = OSSL_PARAM_construct_end();
-    if (!EVP_KEYMGMT_get_params(pkey, params)) {
+    if (!EVP_PKEY_get_params(pkey, params)) {
         if (!OSSL_PARAM_modified(params) || params[0].return_size == 0)
             return 0;
         buf_sz = params[0].return_size;
@@ -2027,7 +2027,7 @@ int EVP_PKEY_get_bn_param(const EVP_PKEY *pkey, const char *key_name,
         params[0].data = buf;
         params[0].data_size = buf_sz;
 
-        if (!EVP_KEYMGMT_get_params(pkey, params))
+        if (!EVP_PKEY_get_params(pkey, params))
             goto err;
     }
     /* Fail if the param was not found */

--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -2184,13 +2184,10 @@ const OSSL_PARAM *EVP_PKEY_settable_params(const EVP_PKEY *pkey)
 
 int EVP_PKEY_set_params(EVP_PKEY *pkey, OSSL_PARAM params[])
 {
-    int ret = pkey != NULL
+    pkey->dirty_cnt++;
+    return pkey != NULL
         && evp_pkey_is_provided(pkey)
         && evp_keymgmt_set_params(pkey->keymgmt, pkey->keydata, params);
-
-    if (ret)
-        pkey->dirty_cnt++;
-    return ret;
 }
 
 const OSSL_PARAM *EVP_PKEY_gettable_params(const EVP_PKEY *pkey)

--- a/doc/man3/EVP_PKEY_gettable_params.pod
+++ b/doc/man3/EVP_PKEY_gettable_params.pod
@@ -13,7 +13,7 @@ EVP_PKEY_get_octet_string_param
  #include <openssl/evp.h>
 
  const OSSL_PARAM *EVP_PKEY_gettable_params(EVP_PKEY *pkey);
- int EVP_PKEY_get_params(EVP_PKEY *pkey, OSSL_PARAM params[]);
+ int EVP_PKEY_get_params(const EVP_PKEY *pkey, OSSL_PARAM params[]);
  int EVP_PKEY_get_int_param(const EVP_PKEY *pkey, const char *key_name,
                             int *out);
  int EVP_PKEY_get_size_t_param(const EVP_PKEY *pkey, const char *key_name,

--- a/doc/man3/EVP_PKEY_gettable_params.pod
+++ b/doc/man3/EVP_PKEY_gettable_params.pod
@@ -67,7 +67,8 @@ All other methods return 1 if a value associated with the key's I<key_name> was
 successfully returned, or 0 if there was an error.
 An error may be returned by methods EVP_PKEY_get_utf8_string_param() and
 EVP_PKEY_get_octet_string_param() if I<max_buf_sz> is not big enough to hold the
-value.
+value.  If I<out_sz> is not NULL, I<*out_sz> will be assigned the required
+buffer size to hold the value.
 
 =head1 EXAMPLES
 

--- a/doc/man3/EVP_PKEY_gettable_params.pod
+++ b/doc/man3/EVP_PKEY_gettable_params.pod
@@ -2,7 +2,8 @@
 
 =head1 NAME
 
-EVP_PKEY_gettable_params, EVP_PKEY_get_int_param, EVP_PKEY_get_size_t_param,
+EVP_PKEY_gettable_params, EVP_PKEY_get_params,
+EVP_PKEY_get_int_param, EVP_PKEY_get_size_t_param,
 EVP_PKEY_get_bn_param, EVP_PKEY_get_utf8_string_param,
 EVP_PKEY_get_octet_string_param
 - retrieve key parameters from a key
@@ -12,6 +13,7 @@ EVP_PKEY_get_octet_string_param
  #include <openssl/evp.h>
 
  const OSSL_PARAM *EVP_PKEY_gettable_params(EVP_PKEY *pkey);
+ int EVP_PKEY_get_params(EVP_PKEY *pkey, OSSL_PARAM params[]);
  int EVP_PKEY_get_int_param(const EVP_PKEY *pkey, const char *key_name,
                             int *out);
  int EVP_PKEY_get_size_t_param(const EVP_PKEY *pkey, const char *key_name,
@@ -26,6 +28,10 @@ EVP_PKEY_get_octet_string_param
                                      size_t *out_sz);
 
 =head1 DESCRIPTION
+
+EVP_PKEY_get_params() retrieves parameters from the key I<pkey>, according to
+the contents of I<params>.
+See L<OSSL_PARAM(3)> for information about parameters.
 
 EVP_PKEY_gettable_params() returns a constant list of I<params> indicating
 the names and types of key parameters that can be retrieved.

--- a/doc/man3/EVP_PKEY_settable_params.pod
+++ b/doc/man3/EVP_PKEY_settable_params.pod
@@ -11,7 +11,7 @@ EVP_PKEY_set_utf8_string_param, EVP_PKEY_set_octet_string_param
 
  #include <openssl/evp.h>
 
- const OSSL_PARAM *EVP_PKEY_settable_params(EVP_PKEY *pkey);
+ const OSSL_PARAM *EVP_PKEY_settable_params(const EVP_PKEY *pkey);
  int EVP_PKEY_set_params(EVP_PKEY *pkey, OSSL_PARAM params[]);
  int EVP_PKEY_set_int_param(EVP_PKEY *pkey, const char *key_name, int in);
  int EVP_PKEY_set_size_t_param(EVP_PKEY *pkey, const char *key_name, size_t in);

--- a/doc/man3/EVP_PKEY_settable_params.pod
+++ b/doc/man3/EVP_PKEY_settable_params.pod
@@ -15,11 +15,12 @@ EVP_PKEY_set_utf8_string_param, EVP_PKEY_set_octet_string_param
  int EVP_PKEY_set_params(EVP_PKEY *pkey, OSSL_PARAM params[]);
  int EVP_PKEY_set_int_param(EVP_PKEY *pkey, const char *key_name, int in);
  int EVP_PKEY_set_size_t_param(EVP_PKEY *pkey, const char *key_name, size_t in);
- int EVP_PKEY_set_bn_param(EVP_PKEY *pkey, const char *key_name, BIGNUM *bn);
+ int EVP_PKEY_set_bn_param(EVP_PKEY *pkey, const char *key_name,
+                           const BIGNUM *bn);
  int EVP_PKEY_set_utf8_string_param(EVP_PKEY *pkey, const char *key_name,
-                                    char *str);
+                                    const char *str);
  int EVP_PKEY_set_octet_string_param(EVP_PKEY *pkey, const char *key_name,
-                                     unsigned char *buf, size_t bsize);
+                                     const unsigned char *buf, size_t bsize);
 
 =head1 DESCRIPTION
 

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -1796,6 +1796,7 @@ int EVP_PKEY_fromdata(EVP_PKEY_CTX *ctx, EVP_PKEY **ppkey, OSSL_PARAM param[]);
 const OSSL_PARAM *EVP_PKEY_param_fromdata_settable(EVP_PKEY_CTX *ctx);
 const OSSL_PARAM *EVP_PKEY_key_fromdata_settable(EVP_PKEY_CTX *ctx);
 const OSSL_PARAM *EVP_PKEY_gettable_params(const EVP_PKEY *pkey);
+int EVP_PKEY_get_params(EVP_PKEY *pkey, OSSL_PARAM params[]);
 int EVP_PKEY_get_int_param(const EVP_PKEY *pkey, const char *key_name,
                            int *out);
 int EVP_PKEY_get_size_t_param(const EVP_PKEY *pkey, const char *key_name,

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -1796,7 +1796,7 @@ int EVP_PKEY_fromdata(EVP_PKEY_CTX *ctx, EVP_PKEY **ppkey, OSSL_PARAM param[]);
 const OSSL_PARAM *EVP_PKEY_param_fromdata_settable(EVP_PKEY_CTX *ctx);
 const OSSL_PARAM *EVP_PKEY_key_fromdata_settable(EVP_PKEY_CTX *ctx);
 const OSSL_PARAM *EVP_PKEY_gettable_params(const EVP_PKEY *pkey);
-int EVP_PKEY_get_params(EVP_PKEY *pkey, OSSL_PARAM params[]);
+int EVP_PKEY_get_params(const EVP_PKEY *pkey, OSSL_PARAM params[]);
 int EVP_PKEY_get_int_param(const EVP_PKEY *pkey, const char *key_name,
                            int *out);
 int EVP_PKEY_get_size_t_param(const EVP_PKEY *pkey, const char *key_name,

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -1809,7 +1809,7 @@ int EVP_PKEY_get_octet_string_param(const EVP_PKEY *pkey, const char *key_name,
                                     unsigned char *buf, size_t max_buf_sz,
                                     size_t *out_sz);
 
-const OSSL_PARAM *EVP_PKEY_settable_params(EVP_PKEY *pkey);
+const OSSL_PARAM *EVP_PKEY_settable_params(const EVP_PKEY *pkey);
 int EVP_PKEY_set_params(EVP_PKEY *pkey, OSSL_PARAM params[]);
 int EVP_PKEY_set_int_param(EVP_PKEY *pkey, const char *key_name, int in);
 int EVP_PKEY_set_size_t_param(EVP_PKEY *pkey, const char *key_name, size_t in);

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -1813,11 +1813,12 @@ const OSSL_PARAM *EVP_PKEY_settable_params(EVP_PKEY *pkey);
 int EVP_PKEY_set_params(EVP_PKEY *pkey, OSSL_PARAM params[]);
 int EVP_PKEY_set_int_param(EVP_PKEY *pkey, const char *key_name, int in);
 int EVP_PKEY_set_size_t_param(EVP_PKEY *pkey, const char *key_name, size_t in);
-int EVP_PKEY_set_bn_param(EVP_PKEY *pkey, const char *key_name, BIGNUM *bn);
+int EVP_PKEY_set_bn_param(EVP_PKEY *pkey, const char *key_name,
+                          const BIGNUM *bn);
 int EVP_PKEY_set_utf8_string_param(EVP_PKEY *pkey, const char *key_name,
-                                   char *str);
+                                   const char *str);
 int EVP_PKEY_set_octet_string_param(EVP_PKEY *pkey, const char *key_name,
-                                    unsigned char *buf, size_t bsize);
+                                    const unsigned char *buf, size_t bsize);
 
 int EVP_PKEY_get_ec_point_conv_form(const EVP_PKEY *pkey);
 int EVP_PKEY_get_field_type(const EVP_PKEY *pkey);

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5298,3 +5298,4 @@ EVP_PKEY_set_utf8_string_param          ?	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_set_octet_string_param         ?	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_get_ec_point_conv_form         ?	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_get_field_type                 ?	3_0_0	EXIST::FUNCTION:
+EVP_PKEY_get_params                     ?	3_0_0	EXIST::FUNCTION:


### PR DESCRIPTION
When the internal key of a provider native EVP_PKEY is modified, the dirty count wasn't updated, which might lead to diverse exports in the export cache not being properly replaced, and operations being performed with earlier (incorrect) versions of the key.

This is very simply fixed by having EVP_PKEY_set_params() update the dirty count.  Other than that, we make sure that EVP_PKEY_set_params() is used, rather than direct calls to evp_keymgmt_set_params().

I took the opportunity to do a little more cleanup.