### PR TITLE
Switch to BIO_snprintf to avoid missing symbol problems on Windows

### DIFF
--- a/apps/lib/opt.c
+++ b/apps/lib/opt.c
@@ -143,7 +143,7 @@ char *opt_appname(const char *arg0)
     size_t len = strlen(prog);
 
     if (arg0 != NULL)
-        snprintf(prog + len, sizeof(prog) - len - 1, " %s", arg0);
+        BIO_snprintf(prog + len, sizeof(prog) - len - 1, " %s", arg0);
     return prog;
 }
 


### PR DESCRIPTION
It seems the snprintf() call introduced in https://github.com/openssl/openssl/commit/3372039252c4d9c67de784a0fbdad5589991a347 fails to compile for some windows builds. I've replaced with OpenSSL's own BIO_snprintf() which is available on all platforms.

