### PR TITLE
CMS_ReceiptRequest_create0_ex propq param has been marked as unused.

### DIFF
--- a/crypto/cms/cms_ess.c
+++ b/crypto/cms/cms_ess.c
@@ -115,7 +115,7 @@ int ess_check_signing_certs(CMS_SignerInfo *si, STACK_OF(X509) *chain)
 CMS_ReceiptRequest *CMS_ReceiptRequest_create0_ex(
     unsigned char *id, int idlen, int allorfirst,
     STACK_OF(GENERAL_NAMES) *receiptList, STACK_OF(GENERAL_NAMES) *receiptsTo,
-    OSSL_LIB_CTX *libctx, const char *propq)
+    OSSL_LIB_CTX *libctx, ossl_unused const char *propq)
 {
     CMS_ReceiptRequest *rr;
 

--- a/doc/man3/CMS_get1_ReceiptRequest.pod
+++ b/doc/man3/CMS_get1_ReceiptRequest.pod
@@ -33,7 +33,8 @@ If I<receiptList> is NULL the allOrFirstTier option in I<receiptsFrom> is used
 and set to the value of the I<allorfirst> parameter. If I<receiptList> is not
 NULL the I<receiptList> option in I<receiptsFrom> is used. The I<receiptsTo>
 parameter specifies the I<receiptsTo> field value. The library context I<libctx>
-and the property query I<propq> are used when retrieving algorithms from providers.
+is used internally to find the public Random generator. I<propq> is currently
+unused.
 
 CMS_ReceiptRequest_create0() is similar to
 CMS_ReceiptRequest_create0_ex() but uses default values of NULL for the

--- a/include/openssl/cms.h.in
+++ b/include/openssl/cms.h.in
@@ -342,7 +342,7 @@ CMS_ReceiptRequest *CMS_ReceiptRequest_create0_ex(
     unsigned char *id, int idlen, int allorfirst,
     STACK_OF(GENERAL_NAMES) *receiptList,
     STACK_OF(GENERAL_NAMES) *receiptsTo,
-    OSSL_LIB_CTX *ctx, const char *propq);
+    OSSL_LIB_CTX *ctx, ossl_unused const char *propq);
 
 int CMS_add1_ReceiptRequest(CMS_SignerInfo *si, CMS_ReceiptRequest *rr);
 void CMS_ReceiptRequest_get0_values(CMS_ReceiptRequest *rr,


### PR DESCRIPTION
This function only requires access to the libctx currently in order to
access the rand generator.

Fixes #13943.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
