### PR TITLE
DOCS: Remove the "global" dependency on writing .pod files from .pod.in

### DIFF
--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -112,6 +112,19 @@ DEPS={- join(" \\\n" . ' ' x 5,
 GENERATED_MANDATORY={- join(" \\\n" . ' ' x 20,
                             fill_lines(" ", $COLUMNS - 20,
                                        @{$unified_info{depends}->{""}})) -}
+GENERATED_PODS={- # common0.tmpl provides @generated
+                  join(" \\\n" . ' ' x 15,
+                       fill_lines(" ", $COLUMNS - 15,
+                                  map { my $x = $_;
+                                        (
+                                          grep { 
+                                                 $unified_info{attributes}->{depends}
+                                                 ->{$x}->{$_}->{pod} // 0
+                                               }
+                                              keys %{$unified_info{attributes}->{depends}->{$x}}
+                                        ) ? $x : ();
+                                      }
+                                      @generated)) -}
 GENERATED={- # common0.tmpl provides @generated
              join(" \\\n" . ' ' x 5,
                   fill_lines(" ", $COLUMNS - 5,
@@ -457,6 +470,7 @@ LANG=C
 {- dependmagic('build_modules'); -}: build_modules_nodep
 {- dependmagic('build_programs'); -}: build_programs_nodep
 
+build_generated_pods: $(GENERATED_PODS)
 build_docs: build_man_docs build_html_docs
 build_man_docs: $(MANDOCS1) $(MANDOCS3) $(MANDOCS5) $(MANDOCS7)
 build_html_docs: $(HTMLDOCS1) $(HTMLDOCS3) $(HTMLDOCS5) $(HTMLDOCS7)
@@ -1014,10 +1028,10 @@ generate: generate_apps generate_crypto_bn generate_crypto_objects \
           generate_crypto_conf generate_crypto_asn1 generate_fuzz_oids
 
 .PHONY: doc-nits cmd-nits md-nits
-doc-nits: build_generated
+doc-nits: build_generated_pods
 	$(PERL) $(SRCDIR)/util/find-doc-nits -n -l -e
 
-cmd-nits: build_generated apps/openssl
+cmd-nits: build_generated apps/openssl build_generated_pods
 	$(PERL) $(SRCDIR)/util/find-doc-nits -c
 
 # This uses "mdl", the markdownlint application, which is written in ruby.

--- a/build.info
+++ b/build.info
@@ -38,8 +38,7 @@ DEPEND[]=include/openssl/asn1.h \
          include/openssl/x509.h \
          include/openssl/x509v3.h \
          include/openssl/x509_vfy.h \
-         include/crypto/bn_conf.h include/crypto/dso_conf.h \
-         doc/man7/openssl_user_macros.pod
+         include/crypto/bn_conf.h include/crypto/dso_conf.h
 
 GENERATE[include/openssl/asn1.h]=include/openssl/asn1.h.in
 GENERATE[include/openssl/asn1t.h]=include/openssl/asn1t.h.in

--- a/doc/build.info
+++ b/doc/build.info
@@ -56,6 +56,7 @@ DEPEND[$manfile]=$podfile
 GENERATE[$manfile]=$podfile
 _____
          $OUT .= << "_____" if $podinfile;
+DEPEND[$podfile]{pod}=$podinfile
 GENERATE[$podfile]=$podinfile
 _____
      }

--- a/doc/man1/build.info
+++ b/doc/man1/build.info
@@ -1,58 +1,6 @@
-
-DEPEND[]= \
-         openssl-asn1parse.pod \
-         openssl-ca.pod \
-         openssl-ciphers.pod \
-         openssl-cmds.pod \
-         openssl-cmp.pod \
-         openssl-cms.pod \
-         openssl-crl2pkcs7.pod \
-         openssl-crl.pod \
-         openssl-dgst.pod \
-         openssl-dhparam.pod \
-         openssl-dsaparam.pod \
-         openssl-dsa.pod \
-         openssl-ecparam.pod \
-         openssl-ec.pod \
-         openssl-enc.pod \
-         openssl-engine.pod \
-         openssl-errstr.pod \
-         openssl-fipsinstall.pod \
-         openssl-gendsa.pod \
-         openssl-genpkey.pod \
-         openssl-genrsa.pod \
-         openssl-info.pod \
-         openssl-kdf.pod \
-         openssl-list.pod \
-         openssl-mac.pod \
-         openssl-nseq.pod \
-         openssl-ocsp.pod \
-         openssl-passwd.pod \
-         openssl-pkcs12.pod \
-         openssl-pkcs7.pod \
-         openssl-pkcs8.pod \
-         openssl-pkeyparam.pod \
-         openssl-pkey.pod \
-         openssl-pkeyutl.pod \
-         openssl-prime.pod \
-         openssl-rand.pod \
-         openssl-rehash.pod \
-         openssl-req.pod \
-         openssl-rsa.pod \
-         openssl-rsautl.pod \
-         openssl-s_client.pod \
-         openssl-sess_id.pod \
-         openssl-smime.pod \
-         openssl-speed.pod \
-         openssl-spkac.pod \
-         openssl-srp.pod \
-         openssl-s_server.pod \
-         openssl-s_time.pod \
-         openssl-storeutl.pod \
-         openssl-ts.pod \
-         openssl-verify.pod \
-         openssl-version.pod \
-         openssl-x509.pod
+# All .pod.in files are detected by build.info in the parent directory, and
+# turned into appropriate DEPEND and GENERATE lines.  All we need here are
+# the additional dependencies on ../perlvars.pm.
 
 DEPEND[openssl-asn1parse.pod]=../perlvars.pm
 DEPEND[openssl-ca.pod]=../perlvars.pm
@@ -107,6 +55,3 @@ DEPEND[openssl-ts.pod]=../perlvars.pm
 DEPEND[openssl-verify.pod]=../perlvars.pm
 DEPEND[openssl-version.pod]=../perlvars.pm
 DEPEND[openssl-x509.pod]=../perlvars.pm
-
-# All .pod.in files are detected by build.info in the parent directory, and
-# turned into appropriate GENERATE lines.


### PR DESCRIPTION
The dependency was made in such a way that .pod.in -> .pod generation
would always be done, no matter what.  This changes the procedure so
that the generation is made "on demand", i.e. when the resulting .pod
files are needed.

This turned out to be duplicated dependencies, as the .pod -> .pod.in
dependencies were already in place.  Just removing the duplicate fixes
the situation.

'make build_all_generated' still works, for those who do want to have
all file generations performed.  (as a reminder, this is suitable to
generate the files a fast system and then copy the result to a slower
system, or system where there's no perl)
