### PR TITLE
NOTES.WIN: fix typo

### DIFF
--- a/NOTES.WIN
+++ b/NOTES.WIN
@@ -62,8 +62,8 @@
 
  For VC-WIN32, the following defaults are use:
 
-     PREFIX:      %ProgramFiles(86)%\OpenSSL
-     OPENSSLDIR:  %CommonProgramFiles(86)%\SSL
+     PREFIX:      %ProgramFiles(x86)%\OpenSSL
+     OPENSSLDIR:  %CommonProgramFiles(x86)%\SSL
 
  For VC-WIN64, the following defaults are use:
 


### PR DESCRIPTION
86 => x86

---

Also, NOTES.WIN says "The default installation directories are derived from environment variables." If I `set PREFIX=something` it does not appear to be used; ie makefile for INSTALLTOP_dir will not show it. That may just be user error but if so IMO the statement could use some clarification. Instead I have to do it like `perl Configure --prefix=something ...`. 