### PR TITLE
Deprecate BN_pseudo_rand() and BN_pseudo_rand_range()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,6 +29,12 @@ OpenSSL 3.0
 
    *Rich Salz*
 
+ * Deprecated the obsolete BN_pseudo_rand() and BN_pseudo_rand_range()
+   functions. They are identical to BN_rand() and BN_rand_range()
+   respectively.
+
+   *Tomáš Mráz*
+
  * Deprecated the obsolete X9.31 RSA key generation related functions
    BN_X931_generate_Xpq(), BN_X931_derive_prime_ex(), and
    BN_X931_generate_prime_ex().

--- a/crypto/bn/bn_rand.c
+++ b/crypto/bn/bn_rand.c
@@ -217,6 +217,7 @@ int BN_priv_rand_range(BIGNUM *r, const BIGNUM *range)
     return bnrand_range(PRIVATE, r, range, NULL);
 }
 
+# ifndef OPENSSL_NO_DEPRECATED_3_0
 int BN_pseudo_rand(BIGNUM *rnd, int bits, int top, int bottom)
 {
     return BN_rand(rnd, bits, top, bottom);
@@ -226,6 +227,7 @@ int BN_pseudo_rand_range(BIGNUM *r, const BIGNUM *range)
 {
     return BN_rand_range(r, range);
 }
+# endif
 #endif
 
 /*

--- a/doc/man3/BN_rand.pod
+++ b/doc/man3/BN_rand.pod
@@ -17,14 +17,17 @@ BN_pseudo_rand_range
  int BN_priv_rand_ex(BIGNUM *rnd, int bits, int top, int bottom, BN_CTX *ctx);
  int BN_priv_rand(BIGNUM *rnd, int bits, int top, int bottom);
 
- int BN_pseudo_rand(BIGNUM *rnd, int bits, int top, int bottom);
-
  int BN_rand_range_ex(BIGNUM *rnd, BIGNUM *range, BN_CTX *ctx);
  int BN_rand_range(BIGNUM *rnd, BIGNUM *range);
 
  int BN_priv_rand_range_ex(BIGNUM *rnd, BIGNUM *range, BN_CTX *ctx);
  int BN_priv_rand_range(BIGNUM *rnd, BIGNUM *range);
 
+Deprecated since OpenSSL 3.0, can be hidden entirely by defining
+OPENSSL_API_COMPAT with a suitable version value, see
+openssl_user_macros(7):
+
+ int BN_pseudo_rand(BIGNUM *rnd, int bits, int top, int bottom);
  int BN_pseudo_rand_range(BIGNUM *rnd, BIGNUM *range);
 
 =head1 DESCRIPTION
@@ -93,13 +96,13 @@ L<EVP_RAND(7)>
 Starting with OpenSSL release 1.1.0, BN_pseudo_rand() has been identical
 to BN_rand() and BN_pseudo_rand_range() has been identical to
 BN_rand_range().
-The "pseudo" functions should not be used and may be deprecated in
-a future release.
+The BN_pseudo_rand() and BN_pseudo_rand_range() functions were
+deprecated in OpenSSL 3.0.
 
 =item *
 
-The
-BN_priv_rand() and BN_priv_rand_range() functions were added in OpenSSL 1.1.1.
+The BN_priv_rand() and BN_priv_rand_range() functions were added in
+OpenSSL 1.1.1.
 
 =item *
 

--- a/include/openssl/bn.h
+++ b/include/openssl/bn.h
@@ -222,8 +222,12 @@ int BN_rand_range_ex(BIGNUM *r, const BIGNUM *range, BN_CTX *ctx);
 int BN_rand_range(BIGNUM *rnd, const BIGNUM *range);
 int BN_priv_rand_range_ex(BIGNUM *r, const BIGNUM *range, BN_CTX *ctx);
 int BN_priv_rand_range(BIGNUM *rnd, const BIGNUM *range);
+# ifndef OPENSSL_NO_DEPRECATED_3_0
+OSSL_DEPRECATEDIN_3_0
 int BN_pseudo_rand(BIGNUM *rnd, int bits, int top, int bottom);
+OSSL_DEPRECATEDIN_3_0
 int BN_pseudo_rand_range(BIGNUM *rnd, const BIGNUM *range);
+# endif
 int BN_num_bits(const BIGNUM *a);
 int BN_num_bits_word(BN_ULONG l);
 int BN_security_bits(int L, int N);

--- a/test/ec_internal_test.c
+++ b/test/ec_internal_test.c
@@ -38,8 +38,8 @@ static int group_field_tests(const EC_GROUP *group, BN_CTX *ctx)
         || !TEST_true(group->meth->field_inv(group, b, BN_value_one(), ctx))
         || !TEST_true(BN_is_one(b))
         /* (1/a)*a = 1 */
-        || !TEST_true(BN_pseudo_rand(a, BN_num_bits(group->field) - 1,
-                                     BN_RAND_TOP_ONE, BN_RAND_BOTTOM_ANY))
+        || !TEST_true(BN_rand(a, BN_num_bits(group->field) - 1,
+                              BN_RAND_TOP_ONE, BN_RAND_BOTTOM_ANY))
         || !TEST_true(group->meth->field_inv(group, b, a, ctx))
         || (group->meth->field_encode &&
             !TEST_true(group->meth->field_encode(group, a, a, ctx)))

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -2423,7 +2423,7 @@ EC_POINT_get_Jprojective_coordinates_GFp 2473	3_0_0	EXIST::FUNCTION:DEPRECATEDIN
 EVP_aes_128_cbc_hmac_sha256             2474	3_0_0	EXIST::FUNCTION:
 i2d_PKCS7_SIGNED                        2475	3_0_0	EXIST::FUNCTION:
 TS_VERIFY_CTX_set_data                  2476	3_0_0	EXIST::FUNCTION:TS
-BN_pseudo_rand_range                    2477	3_0_0	EXIST::FUNCTION:
+BN_pseudo_rand_range                    2477	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
 X509V3_EXT_add_nconf                    2478	3_0_0	EXIST::FUNCTION:
 EVP_CIPHER_CTX_ctrl                     2479	3_0_0	EXIST::FUNCTION:
 ASN1_T61STRING_it                       2480	3_0_0	EXIST::FUNCTION:
@@ -3435,7 +3435,7 @@ X509_check_host                         3506	3_0_0	EXIST::FUNCTION:
 PEM_read_ECPKParameters                 3507	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,EC,STDIO
 X509_ATTRIBUTE_get0_data                3508	3_0_0	EXIST::FUNCTION:
 CMS_add1_signer                         3509	3_0_0	EXIST::FUNCTION:CMS
-BN_pseudo_rand                          3510	3_0_0	EXIST::FUNCTION:
+BN_pseudo_rand                          3510	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
 d2i_DIRECTORYSTRING                     3511	3_0_0	EXIST::FUNCTION:
 d2i_ASN1_PRINTABLE                      3512	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_add1_attr_by_NID               3513	3_0_0	EXIST::FUNCTION:


### PR DESCRIPTION
The functions are obsolete aliases for BN_rand() and BN_rand_range()
since 1.1.0.
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
