### PR TITLE
configdata.pm: Better display of enabled/disabled options

### DIFF
--- a/Configure
+++ b/Configure
@@ -2611,19 +2611,22 @@ _____
         }
         print "\nEnabled features:\n\n";
         foreach my $what (@disablables) {
-            print "    $what\n" unless $disabled{$what};
+            print "    $what\n"
+                unless grep { $_ =~ /^${what}$/ } keys %disabled;
         }
         print "\nDisabled features:\n\n";
         foreach my $what (@disablables) {
-            if ($disabled{$what}) {
-                print "    $what", ' ' x ($longest - length($what) + 1),
-                    "[$disabled{$what}]", ' ' x ($longest2 - length($disabled{$what}) + 1);
-                print $disabled_info{$what}->{macro}
-                    if $disabled_info{$what}->{macro};
+            my @what2 = grep { $_ =~ /^${what}$/ } keys %disabled;
+            my $what3 = $what2[0];
+            if ($what3) {
+                print "    $what3", ' ' x ($longest - length($what3) + 1),
+                    "[$disabled{$what3}]", ' ' x ($longest2 - length($disabled{$what3}) + 1);
+                print $disabled_info{$what3}->{macro}
+                    if $disabled_info{$what3}->{macro};
                 print ' (skip ',
-                    join(', ', @{$disabled_info{$what}->{skipped}}),
+                    join(', ', @{$disabled_info{$what3}->{skipped}}),
                     ')'
-                    if $disabled_info{$what}->{skipped};
+                    if $disabled_info{$what3}->{skipped};
                 print "\n";
             }
         }

--- a/test/build.info
+++ b/test/build.info
@@ -567,7 +567,6 @@ INCLUDE_MAIN___test_libtestutil_OLB = /INCLUDE=MAIN
   SOURCE[gosttest]=gosttest.c ssltestlib.c
   INCLUDE[gosttest]=../include ..
   DEPEND[gosttest]=../libcrypto ../libssl libtestutil.a
-ENDIF
 
   SOURCE[ssl_ctx_test]=ssl_ctx_test.c
   INCLUDE[ssl_ctx_test]=../include
@@ -609,3 +608,4 @@ _____
 _____
    }
 -}
+ENDIF


### PR DESCRIPTION
The options listed in the array @disablables are regular expressions.
For most of them, it's not visible, but there are a few.

However, configdata.pm didn't quite treat them that way, which meant
that the few that are visibly regular expressions, there's a
difference between that and the corresponding the key in %disabled,
which is never a regular expression.

To correctly display the enabled and disabled options with --dump,
we must therefore go through a bit of Perl gymnastics to get the
output correct enough, primarly so that disabled features don't look
enabled.

Fixes #13790
