### PR TITLE
Configuration: ensure that 'no-tests' works correctly

### DIFF
--- a/build.info
+++ b/build.info
@@ -1,7 +1,10 @@
 # Note that some of these directories are filtered in Configure.  Look for
 # %skipdir there for further explanations.
 
-SUBDIRS=crypto ssl apps test util tools fuzz providers doc
+SUBDIRS=crypto ssl apps util tools fuzz providers doc
+IF[{- !$disabled{tests} -}]
+  SUBDIRS=test
+ENDIF
 IF[{- !$disabled{'deprecated-3.0'} -}]
   SUBDIRS=engines
 ENDIF


### PR DESCRIPTION
'no-tests' wasn't entirely respected when specifying subdirs in the
top build.info.
