### PR TITLE
X509_STORE_CTX_cleanup(): Use internally so no need to call explicitly

### DIFF
--- a/crypto/pkcs7/pk7_doit.c
+++ b/crypto/pkcs7/pk7_doit.c
@@ -1053,10 +1053,8 @@ int PKCS7_dataVerify(X509_STORE *cert_store, X509_STORE_CTX *ctx, BIO *bio,
     i = X509_verify_cert(ctx);
     if (i <= 0) {
         ERR_raise(ERR_LIB_PKCS7, ERR_R_X509_LIB);
-        X509_STORE_CTX_cleanup(ctx);
         goto err;
     }
-    X509_STORE_CTX_cleanup(ctx);
 
     return PKCS7_signatureVerify(bio, p7, si, x509);
  err:

--- a/crypto/pkcs7/pk7_smime.c
+++ b/crypto/pkcs7/pk7_smime.c
@@ -289,7 +289,6 @@ int PKCS7_verify(PKCS7 *p7, STACK_OF(X509) *certs, X509_STORE *store,
             i = X509_verify_cert(cert_ctx);
             if (i <= 0)
                 j = X509_STORE_CTX_get_error(cert_ctx);
-            X509_STORE_CTX_cleanup(cert_ctx);
             if (i <= 0) {
                 ERR_raise_data(ERR_LIB_PKCS7, PKCS7_R_CERTIFICATE_VERIFY_ERROR,
                                "Verify error: %s",

--- a/crypto/x509/x509_vfy.c
+++ b/crypto/x509/x509_vfy.c
@@ -1304,7 +1304,7 @@ static void crl_akid_check(X509_STORE_CTX *ctx, X509_CRL *crl,
  */
 static int check_crl_path(X509_STORE_CTX *ctx, X509 *x)
 {
-    X509_STORE_CTX crl_ctx;
+    X509_STORE_CTX crl_ctx = {0};
     int ret;
 
     /* Don't allow recursive CRL path validation */
@@ -2300,6 +2300,12 @@ int X509_STORE_CTX_init(X509_STORE_CTX *ctx, X509_STORE *store, X509 *x509,
 {
     int ret = 1;
 
+    if (ctx == NULL) {
+        ERR_raise(ERR_LIB_X509, ERR_R_PASSED_NULL_PARAMETER);
+        return 0;
+    }
+    X509_STORE_CTX_cleanup(ctx);
+
     ctx->store = store;
     ctx->cert = x509;
     ctx->untrusted = chain;
@@ -2327,7 +2333,7 @@ int X509_STORE_CTX_init(X509_STORE_CTX *ctx, X509_STORE *store, X509 *x509,
     if (store != NULL)
         ctx->cleanup = store->cleanup;
     else
-        ctx->cleanup = 0;
+        ctx->cleanup = NULL;
 
     if (store != NULL && store->check_issued != NULL)
         ctx->check_issued = store->check_issued;
@@ -2450,7 +2456,7 @@ void X509_STORE_CTX_cleanup(X509_STORE_CTX *ctx)
      * calls cleanup() for the same object twice!  Thus we must zero the
      * pointers below after they're freed!
      */
-    /* Seems to always be 0 in OpenSSL, do this at most once. */
+    /* Seems to always be NULL in OpenSSL, do this at most once. */
     if (ctx->cleanup != NULL) {
         ctx->cleanup(ctx);
         ctx->cleanup = NULL;

--- a/doc/man3/X509_STORE_CTX_new.pod
+++ b/doc/man3/X509_STORE_CTX_new.pod
@@ -68,7 +68,7 @@ If I<ctx> is NULL nothing is done.
 
 X509_STORE_CTX_init() sets up I<ctx> for a subsequent verification operation.
 It must be called before each call to L<X509_verify_cert(3)> or
-L<X509_STORE_CTX_verify(3)>, i.e., an I<ctx> is only good for one verification.
+L<X509_STORE_CTX_verify(3)>, i.e., a context is only good for one verification.
 If you want to verify a further certificate or chain with the same I<ctx>
 then you must call X509_STORE_CTX_init() again.
 The trusted certificate store is set to I<trust_store> of type B<X509_STORE>.

--- a/doc/man3/X509_STORE_CTX_new.pod
+++ b/doc/man3/X509_STORE_CTX_new.pod
@@ -68,16 +68,16 @@ If I<ctx> is NULL nothing is done.
 
 X509_STORE_CTX_init() sets up I<ctx> for a subsequent verification operation.
 It must be called before each call to L<X509_verify_cert(3)> or
-L<X509_STORE_CTX_verify(3)>, i.e., a I<ctx> is only good for one verification.
+L<X509_STORE_CTX_verify(3)>, i.e., an I<ctx> is only good for one verification.
 If you want to verify a further certificate or chain with the same I<ctx>
-then you must call X509_STORE_CTX_init() again before the second verification.
+then you must call X509_STORE_CTX_init() again.
 The trusted certificate store is set to I<trust_store> of type B<X509_STORE>.
 This may be NULL because there are no trusted certificates or because
 they are provided simply as a list using X509_STORE_CTX_set0_trusted_stack().
 The certificate to be verified is set to I<target>,
 and a list of additional certificates may be provided in I<chain>,
 which will be untrusted but may be used to build the chain.
-Each of the I<trust_store>, I<target> and I<chain> parameters can be B<NULL>.
+Each of the I<trust_store>, I<target> and I<chain> parameters can be NULL.
 Yet note that L<X509_verify_cert(3)> and L<X509_STORE_CTX_verify(3)>
 will need a verification target.
 This can also be set using X509_STORE_CTX_set_cert().
@@ -152,13 +152,13 @@ should be made or reference counts increased instead.
 
 =head1 RETURN VALUES
 
-X509_STORE_CTX_new() returns a newly allocates context or B<NULL> is an
+X509_STORE_CTX_new() returns a newly allocates context or NULL is an
 error occurred.
 
 X509_STORE_CTX_init() returns 1 for success or 0 if an error occurred.
 
 X509_STORE_CTX_get0_param() returns a pointer to an B<X509_VERIFY_PARAM>
-structure or B<NULL> if an error occurred.
+structure or NULL if an error occurred.
 
 X509_STORE_CTX_cleanup(), X509_STORE_CTX_free(),
 X509_STORE_CTX_set0_trusted_stack(),

--- a/doc/man3/X509_STORE_CTX_new.pod
+++ b/doc/man3/X509_STORE_CTX_new.pod
@@ -24,7 +24,7 @@ X509_STORE_CTX_verify_fn
  void X509_STORE_CTX_free(X509_STORE_CTX *ctx);
 
  int X509_STORE_CTX_init(X509_STORE_CTX *ctx, X509_STORE *trust_store,
-                         X509 *target, STACK_OF(X509) *untrusted);
+                         X509 *target, STACK_OF(X509) *chain);
 
  void X509_STORE_CTX_set0_trusted_stack(X509_STORE_CTX *ctx, STACK_OF(X509) *sk);
 
@@ -60,26 +60,25 @@ X509_STORE_CTX_new() is the same as X509_STORE_CTX_new_ex() except that
 the default library context and a NULL property query string are used.
 
 X509_STORE_CTX_cleanup() internally cleans up an B<X509_STORE_CTX> structure.
-The context can then be reused with a new call to X509_STORE_CTX_init().
+It is used by X509_STORE_CTX_init() and X509_STORE_CTX_free().
 
 X509_STORE_CTX_free() completely frees up I<ctx>. After this call I<ctx>
 is no longer valid.
 If I<ctx> is NULL nothing is done.
 
 X509_STORE_CTX_init() sets up I<ctx> for a subsequent verification operation.
-It must be called before each call to L<X509_verify_cert(3)>, i.e., a I<ctx> is
-only good for one verification; if you want to verify a second certificate
-or chain with the same I<ctx> then you must call X509_STORE_CTX_cleanup()
-and then X509_STORE_CTX_init() again before the second call to
-L<X509_verify_cert(3)> or L<X509_STORE_CTX_verify(3)>.
+It must be called before each call to L<X509_verify_cert(3)> or
+L<X509_STORE_CTX_verify(3)>, i.e., a I<ctx> is only good for one verification.
+If you want to verify a further certificate or chain with the same I<ctx>
+then you must call X509_STORE_CTX_init() again before the second verification.
 The trusted certificate store is set to I<trust_store> of type B<X509_STORE>.
 This may be NULL because there are no trusted certificates or because
 they are provided simply as a list using X509_STORE_CTX_set0_trusted_stack().
-The end entity certificate to be verified is set to I<target>,
-and a list of additional certificates may be provided in I<untrusted>,
-which will not be trusted but may be used to build the chain.
-Each of the I<trust_store>, I<target> and I<untrusted> parameters can be
-B<NULL>. Yet note that L<X509_verify_cert(3)> and L<X509_STORE_CTX_verify(3)>
+The certificate to be verified is set to I<target>,
+and a list of additional certificates may be provided in I<chain>,
+which will be untrusted but may be used to build the chain.
+Each of the I<trust_store>, I<target> and I<chain> parameters can be B<NULL>.
+Yet note that L<X509_verify_cert(3)> and L<X509_STORE_CTX_verify(3)>
 will need a verification target.
 This can also be set using X509_STORE_CTX_set_cert().
 For L<X509_STORE_CTX_verify(3)>, which takes by default the first element of the
@@ -182,6 +181,8 @@ L<X509_VERIFY_PARAM_set_flags(3)>
 The X509_STORE_CTX_set0_crls() function was added in OpenSSL 1.0.0.
 The X509_STORE_CTX_get_num_untrusted() function was added in OpenSSL 1.1.0.
 The X509_STORE_CTX_new_ex() function was added in OpenSSL 3.0.
+
+There is no need to call X509_STORE_CTX_cleanup() explicitly since OpenSSL 3.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/X509_STORE_CTX_new.pod
+++ b/doc/man3/X509_STORE_CTX_new.pod
@@ -152,7 +152,7 @@ should be made or reference counts increased instead.
 
 =head1 RETURN VALUES
 
-X509_STORE_CTX_new() returns a newly allocates context or NULL is an
+X509_STORE_CTX_new() returns a newly allocated context or NULL if an
 error occurred.
 
 X509_STORE_CTX_init() returns 1 for success or 0 if an error occurred.

--- a/test/danetest.c
+++ b/test/danetest.c
@@ -82,7 +82,6 @@ static int verify_chain(SSL *ssl, STACK_OF(X509) *chain)
         ret = 0;
 
     SSL_set_verify_result(ssl, X509_STORE_CTX_get_error(store_ctx));
-    X509_STORE_CTX_cleanup(store_ctx);
 
 end:
     X509_STORE_CTX_free(store_ctx);


### PR DESCRIPTION
This is motivated by https://github.com/openssl/openssl/pull/14021#discussion_r571041958.
Make `X509_STORE_CTX_init()` call `X509_STORE_CTX_cleanup()` automatically,
such that users do not need to call both functions when they want to reuse the context.

This change is backward compatible because it should not hurt if `X509_STORE_CTX_cleanup()` is called in addition before `X509_STORE_CTX_init()` because it is idempotent.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
