### PR TITLE
Match description with actual output of dgst

### DIFF
--- a/doc/man1/openssl-dgst.pod.in
+++ b/doc/man1/openssl-dgst.pod.in
@@ -125,7 +125,7 @@ see L<openssl-passphrase-options(1)>.
 =item B<-verify> I<filename>
 
 Verify the signature using the public key in "filename".
-The output is either "Verification OK" or "Verification Failure".
+The output is either "Verified OK" or "Verification Failure".
 
 =item B<-prverify> I<filename>
 


### PR DESCRIPTION
CLA: trivial

This is a PR to fix inconsistency that `dgst -verify` outputs "Verified OK" but the manual says it outputs "Verification OK".