### PR TITLE
x509_vfy.c: Make chain_build() error diagnostics to the point

### DIFF
--- a/crypto/x509/x509_vfy.c
+++ b/crypto/x509/x509_vfy.c
@@ -134,8 +134,8 @@ static X509 *lookup_cert_match(X509_STORE_CTX *ctx, X509 *x)
 
 /*-
  * Inform the verify callback of an error.
- * The error code is set to |err| if |err| is not X509_V_OK,
- * else |ctx->error| is left unchanged (under the assumption is set elsewhere).
+ * The error code is set to |err| if |err| is not X509_V_OK, else
+ * |ctx->error| is left unchanged (under the assumption it is set elsewhere).
  * The error depth is |depth| if >= 0, else it defaults to |ctx->error_depth|.
  * The error cert is |x| if not NULL, else defaults to the chain cert at depth.
  *

--- a/crypto/x509/x509_vfy.c
+++ b/crypto/x509/x509_vfy.c
@@ -134,16 +134,19 @@ static X509 *lookup_cert_match(X509_STORE_CTX *ctx, X509 *x)
 
 /*-
  * Inform the verify callback of an error.
- * If 'x' is not NULL it is the error cert, otherwise use the chain cert at
- * 'depth'
- * If 'err' is not X509_V_OK, that's the error value, otherwise leave
- * unchanged (presumably set by the caller).
+ * The error code is set to |err| if |err| is not X509_V_OK,
+ * else |ctx->error| is left unchanged (under the assumption is set elsewhere).
+ * The error depth is |depth| if >= 0, else it defaults to |ctx->error_depth|.
+ * The error cert is |x| if not NULL, else defaults to the chain cert at depth.
  *
  * Returns 0 to abort verification with an error, non-zero to continue.
  */
 static int verify_cb_cert(X509_STORE_CTX *ctx, X509 *x, int depth, int err)
 {
-    ctx->error_depth = depth;
+    if (depth < 0)
+        depth = ctx->error_depth;
+    else
+        ctx->error_depth = depth;
     ctx->current_cert = (x != NULL) ? x : sk_X509_value(ctx->chain, depth);
     if (err != X509_V_OK)
         ctx->error = err;
@@ -333,7 +336,17 @@ static X509 *find_issuer(X509_STORE_CTX *ctx, STACK_OF(X509) *sk, X509 *x)
 /* Check that the given certificate 'x' is issued by the certificate 'issuer' */
 static int check_issued(ossl_unused X509_STORE_CTX *ctx, X509 *x, X509 *issuer)
 {
-    return x509_likely_issued(issuer, x) == X509_V_OK;
+    int err = x509_likely_issued(issuer, x);
+
+    if (err == X509_V_OK)
+        return 1;
+    /*
+     * SUBJECT_ISSUER_MISMATCH just means 'x' is clearly not issued by 'issuer'.
+     * Every other error code likely indicates a real error.
+     */
+    if (err != X509_V_ERR_SUBJECT_ISSUER_MISMATCH)
+        ctx->error = err;
+    return 0; /* Better call verify_cb_cert(ctx, x, ctx->error_depth, err) ? */
 }
 
 /* Alternative lookup method: look from a STACK stored in other_ctx */
@@ -1708,7 +1721,7 @@ static int internal_verify(X509_STORE_CTX *ctx)
          * We report the issuer as NULL because all we have is a bare key.
          */
         xi = NULL;
-    } else if (!ctx->check_issued(ctx, xi, xi)
+    } else if (x509_likely_issued(xi, xi) != X509_V_OK
                /* exceptional case: last cert in the chain is not self-issued */
                && ((ctx->param->flags & X509_V_FLAG_PARTIAL_CHAIN) == 0)) {
         if (n > 0) {
@@ -1726,7 +1739,7 @@ static int internal_verify(X509_STORE_CTX *ctx)
     }
 
     /*
-     * Do not clear ctx->error = 0, it must be "sticky",
+     * Do not clear error (by ctx->error = X509_V_OK), it must be "sticky",
      * only the user's callback is allowed to reset errors (at its own peril).
      */
     while (n >= 0) {
@@ -2279,7 +2292,7 @@ int X509_STORE_CTX_init(X509_STORE_CTX *ctx, X509_STORE *store, X509 *x509,
     ctx->other_ctx = NULL;
     ctx->valid = 0;
     ctx->chain = NULL;
-    ctx->error = 0;
+    ctx->error = X509_V_OK;
     ctx->explicit_policy = 0;
     ctx->error_depth = 0;
     ctx->current_cert = NULL;
@@ -2940,6 +2953,7 @@ static int build_chain(X509_STORE_CTX *ctx)
     int alt_untrusted = 0;
     int depth;
     int ok = 0;
+    int prev_error = ctx->error;
     int i;
 
     /* Our chain starts with a single untrusted element. */
@@ -3018,6 +3032,8 @@ static int build_chain(X509_STORE_CTX *ctx)
     while (search != 0) {
         X509 *issuer = NULL;
 
+        num = sk_X509_num(ctx->chain);
+        ctx->error_depth = num - 1;
         /*
          * Look in the trust store if enabled for first lookup, or we've run
          * out of untrusted issuers and search here is not disabled.  When we
@@ -3033,7 +3049,7 @@ static int build_chain(X509_STORE_CTX *ctx)
          * would be a-priori too long.
          */
         if ((search & S_DOTRUSTED) != 0) {
-            i = num = sk_X509_num(ctx->chain);
+            i = num;
             if ((search & S_DOALTERNATE) != 0) {
                 /*
                  * As high up the chain as we can, look for an alternative
@@ -3238,12 +3254,16 @@ static int build_chain(X509_STORE_CTX *ctx)
 
     switch (trust) {
     case X509_TRUST_TRUSTED:
+        /* Must restore any previous error value for backward compatibility */
+        ctx->error = prev_error;
         return 1;
     case X509_TRUST_REJECTED:
         /* Callback already issued */
         return 0;
     case X509_TRUST_UNTRUSTED:
-    default:
+        if (ctx->error != X509_V_OK)
+            /* Callback already issued in most such cases */
+            return 0;
         num = sk_X509_num(ctx->chain);
         CB_FAIL_IF(num > depth,
                    ctx, NULL, num - 1, X509_V_ERR_CERT_CHAIN_TOO_LONG);

--- a/crypto/x509/x509_vfy.c
+++ b/crypto/x509/x509_vfy.c
@@ -3261,6 +3261,7 @@ static int build_chain(X509_STORE_CTX *ctx)
         /* Callback already issued */
         return 0;
     case X509_TRUST_UNTRUSTED:
+    default:
         if (ctx->error != X509_V_OK)
             /* Callback already issued in most such cases */
             return 0;

--- a/include/openssl/x509_vfy.h.in
+++ b/include/openssl/x509_vfy.h.in
@@ -399,7 +399,7 @@ int X509_STORE_CTX_get1_issuer(X509 **issuer, X509_STORE_CTX *ctx, X509 *x);
 
 void X509_STORE_CTX_free(X509_STORE_CTX *ctx);
 int X509_STORE_CTX_init(X509_STORE_CTX *ctx, X509_STORE *store,
-                        X509 *x509, STACK_OF(X509) *chain);
+                        X509 *target, STACK_OF(X509) *chain);
 void X509_STORE_CTX_set0_trusted_stack(X509_STORE_CTX *ctx, STACK_OF(X509) *sk);
 void X509_STORE_CTX_cleanup(X509_STORE_CTX *ctx);
 


### PR DESCRIPTION
So far, when something goes wrong during the chain building phase of certificate verification,
the error code pretty often is "`unable to get local issuer certificate`" or the like.
Often this does not tell much about the real problem and may be even misleading.

Here is a simple example.
```
apps/openssl verify -auth_level 1 -purpose sslserver -trusted test/certs/root-cert.pem \
  -untrusted test/certs/ca-pss-cert.pem test/certs/ee-pss-wrong1.5-cert.pem
```
yields
```
CN = EE-PSS-wrong1.5
error 20 at 0 depth lookup: unable to get local issuer certificate
error test/certs/ee-pss-wrong1.5-cert.pem: verification failed
```
because `check_issued()` throws away all error codes.

This PR makes  `check_issued()` record any 'real' error code (i.e., everything except for
`X509_V_ERR_SUBJECT_ISSUER_MISMATCH`, which just means that the current cert `x` is clearly not issued by the candidate `issuer`) in `ctx->error`.
At this point it could make sense to even call `verify_cb_cert(ctx, x, ctx->error_depth, err)` -
what do you think?

Care is taken such that for backward compatibility any previous `ctx->error` contents are restored in case of successful chain building.

After these changes, the above verification yields much better diagnostics:
```
CN = EE-PSS-wrong1.5
error 77 at 0 depth lookup: subject signature algorithm and issuer public key algorithm mismatch
error test/certs/ee-pss-wrong1.5-cert.pem: verification failed
```

~On this occasion also various coding style and documentation style nits are fixed.~

- ~[x] documentation is added or updated~
