### PR TITLE
x509_vfy.c: Sort out return values 0 vs. -1 (failure/internal error), correct X509_get_pubkey_parameters()

### DIFF
--- a/doc/man3/X509_verify_cert.pod
+++ b/doc/man3/X509_verify_cert.pod
@@ -33,10 +33,11 @@ SSL/TLS code.
 A negative return value from X509_verify_cert() can occur if it is invoked
 incorrectly, such as with no certificate set in I<ctx>, or when it is called
 twice in succession without reinitialising I<ctx> for the second call.
-A negative return value can also happen due to internal resource problems or if
+A negative return value can also happen due to internal resource problems
+or because internal inconsistenty has been detected or if
 a retry operation is requested during internal lookups (which never happens
 with standard lookup methods).
-Applications must check for <= 0 return value on error.
+Applications must interpret any return value <= 0 as an error.
 
 The X509_STORE_CTX_verify() behaves like X509_verify_cert() except that its
 target certificate is the first element of the list of untrusted certificates
@@ -47,6 +48,11 @@ in I<ctx> unless a target certificate is set explicitly.
 Both functions return 1 if a complete chain can be built and validated,
 otherwise they return 0, and in exceptional circumstances (such as malloc
 failure and internal errors) they can also return a negative code.
+
+If a complete chain can be built and validated both functions return 1.
+If the certificate must be rejected on the basis of the data available
+or required certificate status data in not available they return 0.
+If no definite answer possible they usually return a negative code.
 
 On error or failure additional error information can be obtained by
 examining I<ctx> using, for example, L<X509_STORE_CTX_get_error(3)>.

--- a/doc/man3/X509_verify_cert.pod
+++ b/doc/man3/X509_verify_cert.pod
@@ -34,9 +34,9 @@ A negative return value from X509_verify_cert() can occur if it is invoked
 incorrectly, such as with no certificate set in I<ctx>, or when it is called
 twice in succession without reinitialising I<ctx> for the second call.
 A negative return value can also happen due to internal resource problems
-or because internal inconsistenty has been detected or if
-a retry operation is requested during internal lookups (which never happens
-with standard lookup methods).
+or because an internal inconsistency has been detected
+or if a retry operation is requested during internal lookups
+(which never happens with standard lookup methods).
 Applications must interpret any return value <= 0 as an error.
 
 The X509_STORE_CTX_verify() behaves like X509_verify_cert() except that its
@@ -51,7 +51,7 @@ failure and internal errors) they can also return a negative code.
 
 If a complete chain can be built and validated both functions return 1.
 If the certificate must be rejected on the basis of the data available
-or required certificate status data in not available they return 0.
+or any required certificate status data is not available they return 0.
 If no definite answer possible they usually return a negative code.
 
 On error or failure additional error information can be obtained by


### PR DESCRIPTION
When verifying certificates or the like one should be able to distinguish three major types of result:
* clear acceptance, indicated by returning `1`
* clear rejection, which should be  indicated by returning `0`
* no clear outcome due to missing information (for instance, when CRLs are required to be checked but are not available) or internal errors (such as malloc failure), which should be indicated by returning `-1`.
Applications typically need to treat this case as rejection to be on the safe side, 
but it may be of interest to know if the verification did not come to a clear negative conclusion.

So far `x509_vfy` does not do the distinction between the latter two cases in a consistent way.
This PR sorts out the cases as far as can be done rather easily.
Unfortunately missing or erroneous CRLs still lead to `0` being returned rather than `-1`.

This PR also corrects (in a separate commit) the failure behavior and use of `X509_get_pubkey_parameters()`, which simplifies the first part of `verify_chain()`.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
