### PR TITLE
preprocessor: add missing #pragma once

### DIFF
--- a/crypto/objects/obj_compat.h
+++ b/crypto/objects/obj_compat.h
@@ -43,4 +43,4 @@
 #define SN_grasshopper_mac              SN_kuznyechik_mac
 #define NID_grasshopper_mac             NID_kuznyechik_mac
 
-#endif
+#endif  /* OPENSSL_NO_DEPRECATED_3_0 */

--- a/crypto/objects/objects.pl
+++ b/crypto/objects/objects.pl
@@ -144,6 +144,10 @@ print <<"EOF";
  * https://www.openssl.org/source/license.html
  */
 
+#ifndef OPENSSL_OBJ_MAC_H
+# define OPENSSL_OBJ_MAC_H
+# pragma once
+
 #define SN_undef                        "UNDEF"
 #define LN_undef                        "undefined"
 #define NID_undef                       0
@@ -168,6 +172,11 @@ foreach (sort { $a <=> $b } keys %ordern)
 	print expand("#define NID_$Cname\t\t$nid{$Cname}\n") if $nid{$Cname} ne "";
 	print expand("#define OBJ_$Cname\t\t$obj{$Cname}\n") if $obj{$Cname} ne "";
 	}
+
+print <<EOF;
+
+#endif /* OPENSSL_OBJ_MAC_H */
+EOF
 
 sub process_oid
 	{

--- a/include/crypto/aes_platform.h
+++ b/include/crypto/aes_platform.h
@@ -9,6 +9,7 @@
 
 #ifndef OSSL_AES_PLATFORM_H
 # define OSSL_AES_PLATFORM_H
+# pragma once
 
 # include "openssl/aes.h"
 

--- a/include/crypto/aria.h
+++ b/include/crypto/aria.h
@@ -12,6 +12,7 @@
 
 #ifndef OSSL_CRYPTO_ARIA_H
 # define OSSL_CRYPTO_ARIA_H
+# pragma once
 
 # include <openssl/opensslconf.h>
 

--- a/include/crypto/asn1.h
+++ b/include/crypto/asn1.h
@@ -7,7 +7,11 @@
  * https://www.openssl.org/source/license.html
  */
 
-#include <openssl/asn1.h>
+#ifndef OSSL_CRYPTO_ASN1_H
+# define OSSL_CRYPTO_ASN1_H
+# pragma once
+
+# include <openssl/asn1.h>
 
 /* Internal ASN1 structures and functions: not for application use */
 
@@ -139,3 +143,5 @@ const EVP_MD *x509_algor_get_md(X509_ALGOR *alg);
 X509_ALGOR *x509_algor_mgf1_decode(X509_ALGOR *alg);
 int x509_algor_md_to_mgf1(X509_ALGOR **palg, const EVP_MD *mgf1md);
 int asn1_time_print_ex(BIO *bp, const ASN1_TIME *tm);
+
+#endif /* ndef OSSL_CRYPTO_ASN1_H */

--- a/include/crypto/asn1_dsa.h
+++ b/include/crypto/asn1_dsa.h
@@ -9,6 +9,7 @@
 
 #ifndef OSSL_CRYPTO_ASN1_DSA_H
 # define OSSL_CRYPTO_ASN1_DSA_H
+# pragma once
 
 #include "internal/packet.h"
 

--- a/include/crypto/async.h
+++ b/include/crypto/async.h
@@ -7,8 +7,13 @@
  * https://www.openssl.org/source/license.html
  */
 
-#include <openssl/async.h>
+#ifndef OSSL_CRYPTO_ASYNC_H
+# define OSSL_CRYPTO_ASYNC_H
+# pragma once
+
+# include <openssl/async.h>
 
 int async_init(void);
 void async_deinit(void);
 
+#endif

--- a/include/crypto/bn.h
+++ b/include/crypto/bn.h
@@ -9,6 +9,7 @@
 
 #ifndef OSSL_CRYPTO_BN_H
 # define OSSL_CRYPTO_BN_H
+# pragma once
 
 # include <openssl/bn.h>
 # include <limits.h>

--- a/include/crypto/bn_conf.h.in
+++ b/include/crypto/bn_conf.h.in
@@ -10,6 +10,7 @@
 
 #ifndef OSSL_CRYPTO_BN_CONF_H
 # define OSSL_CRYPTO_BN_CONF_H
+# pragma once
 
 /*
  * The contents of this file are not used in the UEFI build, as

--- a/include/crypto/chacha.h
+++ b/include/crypto/chacha.h
@@ -9,6 +9,7 @@
 
 #ifndef OSSL_CRYPTO_CHACHA_H
 #define OSSL_CRYPTO_CHACHA_H
+# pragma once
 
 #include <stddef.h>
 

--- a/include/crypto/cmll_platform.h
+++ b/include/crypto/cmll_platform.h
@@ -9,6 +9,7 @@
 
 #ifndef OSSL_CMLL_PLATFORM_H
 # define OSSL_CMLL_PLATFORM_H
+# pragma once
 
 # if defined(CMLL_ASM) && (defined(__sparc) || defined(__sparc__))
 

--- a/include/crypto/cms.h
+++ b/include/crypto/cms.h
@@ -7,7 +7,11 @@
  * https://www.openssl.org/source/license.html
  */
 
-#ifndef OPENSSL_NO_CMS
+#ifndef OSSL_CRYPTO_CMS_H
+# define OSSL_CRYPTO_CMS_H
+# pragma once
+
+# ifndef OPENSSL_NO_CMS
 
 /* internal CMS-ESS related stuff */
 
@@ -18,4 +22,6 @@ int cms_signerinfo_get_signing_cert_v2(CMS_SignerInfo *si,
                                        ESS_SIGNING_CERT_V2 **psc);
 int cms_signerinfo_get_signing_cert(CMS_SignerInfo *si,
                                     ESS_SIGNING_CERT **psc);
+# endif /* OPENSSL_NO_CMS */
+
 #endif

--- a/include/crypto/cryptlib.h
+++ b/include/crypto/cryptlib.h
@@ -7,8 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
-#include <openssl/core.h>
-#include "internal/cryptlib.h"
+#ifndef OSSL_CRYPTO_CRYPTLIB_H
+# define OSSL_CRYPTO_CRYPTLIB_H
+# pragma once
+
+# include <openssl/core.h>
+# include "internal/cryptlib.h"
 
 /* This file is not scanned by mkdef.pl, whereas cryptlib.h is */
 
@@ -32,3 +36,5 @@ void ossl_malloc_setup_failures(void);
 
 int ossl_crypto_alloc_ex_data_intern(int class_index, void *obj,
                                      CRYPTO_EX_DATA *ad, int idx);
+
+#endif  /* OSSL_CRYPTO_CRYPTLIB_H */

--- a/include/crypto/ctype.h
+++ b/include/crypto/ctype.h
@@ -20,6 +20,7 @@
  */
 #ifndef OSSL_CRYPTO_CTYPE_H
 # define OSSL_CRYPTO_CTYPE_H
+# pragma once
 
 # define CTYPE_MASK_lower       0x1
 # define CTYPE_MASK_upper       0x2

--- a/include/crypto/decoder.h
+++ b/include/crypto/decoder.h
@@ -9,6 +9,7 @@
 
 #ifndef OSSL_CRYPTO_DECODER_H
 # define OSSL_CRYPTO_DECODER_H
+# pragma once
 
 # include <openssl/decoder.h>
 

--- a/include/crypto/des_platform.h
+++ b/include/crypto/des_platform.h
@@ -9,6 +9,7 @@
 
 #ifndef OSSL_DES_PLATFORM_H
 # define OSSL_DES_PLATFORM_H
+# pragma once
 
 # if defined(DES_ASM) && (defined(__sparc) || defined(__sparc__))
 

--- a/include/crypto/dh.h
+++ b/include/crypto/dh.h
@@ -7,10 +7,14 @@
  * https://www.openssl.org/source/license.html
  */
 
-#include <openssl/core.h>
-#include <openssl/params.h>
-#include <openssl/dh.h>
-#include "internal/ffc.h"
+#ifndef OSSL_CRYPTO_DH_H
+# define OSSL_CRYPTO_DH_H
+# pragma once
+
+# include <openssl/core.h>
+# include <openssl/params.h>
+# include <openssl/dh.h>
+# include "internal/ffc.h"
 
 DH *dh_new_by_nid_ex(OSSL_LIB_CTX *libctx, int nid);
 DH *dh_new_ex(OSSL_LIB_CTX *libctx);
@@ -46,3 +50,5 @@ int dh_KDF_X9_42_asn1(unsigned char *out, size_t outlen,
                       const char *cek_alg,
                       const unsigned char *ukm, size_t ukmlen, const EVP_MD *md,
                       OSSL_LIB_CTX *libctx, const char *propq);
+
+#endif  /* OSSL_CRYPTO_DH_H */

--- a/include/crypto/dsa.h
+++ b/include/crypto/dsa.h
@@ -7,9 +7,13 @@
  * https://www.openssl.org/source/license.html
  */
 
-#include <openssl/core.h>
-#include <openssl/dsa.h>
-#include "internal/ffc.h"
+#ifndef OSSL_CRYPTO_DSAERR_H
+# define OSSL_CRYPTO_DSAERR_H
+# pragma once
+
+# include <openssl/core.h>
+# include <openssl/dsa.h>
+# include "internal/ffc.h"
 
 #define DSA_PARAMGEN_TYPE_FIPS_186_4   0   /* Use FIPS186-4 standard */
 #define DSA_PARAMGEN_TYPE_FIPS_186_2   1   /* Use legacy FIPS186-2 standard */
@@ -34,3 +38,5 @@ int dsa_check_pub_key(const DSA *dsa, const BIGNUM *pub_key, int *ret);
 int dsa_check_pub_key_partial(const DSA *dsa, const BIGNUM *pub_key, int *ret);
 int dsa_check_priv_key(const DSA *dsa, const BIGNUM *priv_key, int *ret);
 int dsa_check_pairwise(const DSA *dsa);
+
+#endif

--- a/include/crypto/dso_conf.h.in
+++ b/include/crypto/dso_conf.h.in
@@ -10,6 +10,8 @@
 
 #ifndef OSSL_CRYPTO_DSO_CONF_H
 # define OSSL_CRYPTO_DSO_CONF_H
+# pragma once
+
 {-  # The DSO code currently always implements all functions so that no
     # applications will have to worry about that from a compilation point
     # of view. However, the "method"s may return zero unless that platform

--- a/include/crypto/ec.h
+++ b/include/crypto/ec.h
@@ -11,6 +11,8 @@
 
 #ifndef OSSL_CRYPTO_EC_H
 # define OSSL_CRYPTO_EC_H
+# pragma once
+
 # include <openssl/opensslconf.h>
 # include <openssl/evp.h>
 

--- a/include/crypto/ecx.h
+++ b/include/crypto/ecx.h
@@ -11,6 +11,8 @@
 
 #ifndef OSSL_CRYPTO_ECX_H
 # define OSSL_CRYPTO_ECX_H
+# pragma once
+
 # include <openssl/opensslconf.h>
 
 # ifndef OPENSSL_NO_EC

--- a/include/crypto/err.h
+++ b/include/crypto/err.h
@@ -9,6 +9,7 @@
 
 #ifndef OSSL_CRYPTO_ERR_H
 # define OSSL_CRYPTO_ERR_H
+# pragma once
 
 int err_load_ERR_strings_int(void);
 int err_load_crypto_strings_int(void);

--- a/include/crypto/ess.h
+++ b/include/crypto/ess.h
@@ -7,6 +7,10 @@
  * https://www.openssl.org/source/license.html
  */
 
+#ifndef OSSL_CRYPTO_ESS_H
+# define OSSL_CRYPTO_ESS_H
+# pragma once
+
 /* internal ESS related stuff */
 
 ESS_SIGNING_CERT *ESS_SIGNING_CERT_get(PKCS7_SIGNER_INFO *si);
@@ -89,3 +93,5 @@ struct ESS_signing_cert_v2_st {
     STACK_OF(ESS_CERT_ID_V2) *cert_ids;
     STACK_OF(POLICYINFO) *policy_info;
 };
+
+#endif /* OSSL_CRYPTO_ESS_H */

--- a/include/crypto/evp.h
+++ b/include/crypto/evp.h
@@ -7,10 +7,14 @@
  * https://www.openssl.org/source/license.html
  */
 
-#include <openssl/evp.h>
-#include <openssl/core_dispatch.h>
-#include "internal/refcount.h"
-#include "crypto/ecx.h"
+#ifndef OSSL_CRYPTO_EVP_H
+# define OSSL_CRYPTO_EVP_H
+# pragma once
+
+# include <openssl/evp.h>
+# include <openssl/core_dispatch.h>
+# include "internal/refcount.h"
+# include "crypto/ecx.h"
 
 /*
  * Don't free up md_ctx->pctx in EVP_MD_CTX_reset, use the reserved flag
@@ -785,10 +789,10 @@ int evp_keymgmt_copy(const EVP_KEYMGMT *keymgmt,
 
 /* Pulling defines out of C source files */
 
-#define EVP_RC4_KEY_SIZE 16
-#ifndef TLS1_1_VERSION
-# define TLS1_1_VERSION   0x0302
-#endif
+# define EVP_RC4_KEY_SIZE 16
+# ifndef TLS1_1_VERSION
+#  define TLS1_1_VERSION   0x0302
+# endif
 
 void evp_encode_ctx_set_flags(EVP_ENCODE_CTX *ctx, unsigned int flags);
 
@@ -808,7 +812,7 @@ int pkcs5_pbkdf2_hmac_ex(const char *pass, int passlen,
                          const EVP_MD *digest, int keylen, unsigned char *out,
                          OSSL_LIB_CTX *libctx, const char *propq);
 
-#ifndef FIPS_MODULE
+# ifndef FIPS_MODULE
 /*
  * Internal helpers for stricter EVP_PKEY_CTX_{set,get}_params().
  *
@@ -834,9 +838,12 @@ int evp_pkey_ctx_get1_id_prov(EVP_PKEY_CTX *ctx, void *id);
 int evp_pkey_ctx_get1_id_len_prov(EVP_PKEY_CTX *ctx, size_t *id_len);
 
 int evp_pkey_ctx_use_cached_data(EVP_PKEY_CTX *ctx);
-#endif /* !defined(FIPS_MODULE) */
+# endif /* !defined(FIPS_MODULE) */
+
 void evp_method_store_flush(OSSL_LIB_CTX *libctx);
 int evp_set_default_properties_int(OSSL_LIB_CTX *libctx, const char *propq,
                                    int loadconfig);
 
 void evp_md_ctx_clear_digest(EVP_MD_CTX *ctx, int force);
+
+#endif /* OSSL_CRYPTO_EVP_H */

--- a/include/crypto/lhash.h
+++ b/include/crypto/lhash.h
@@ -9,7 +9,8 @@
 
 #ifndef OSSL_CRYPTO_LHASH_H
 # define OSSL_CRYPTO_LHASH_H
+# pragma once
 
 unsigned long openssl_lh_strcasehash(const char *);
 
-#endif
+#endif  /* OSSL_CRYPTO_LHASH_H */

--- a/include/crypto/pem.h
+++ b/include/crypto/pem.h
@@ -9,6 +9,7 @@
 
 #ifndef OSSL_INTERNAL_PEM_H
 # define OSSL_INTERNAL_PEM_H
+# pragma once
 
 # include <openssl/pem.h>
 

--- a/include/crypto/pkcs7.h
+++ b/include/crypto/pkcs7.h
@@ -7,4 +7,10 @@
  * https://www.openssl.org/source/license.html
  */
 
+#ifndef OSSL_CRYPTO_PKCS7_H
+# define OSSL_CRYPTO_PKCS7_H
+# pragma once
+
 void pkcs7_resolve_libctx(PKCS7 *p7);
+
+#endif

--- a/include/crypto/poly1305.h
+++ b/include/crypto/poly1305.h
@@ -7,6 +7,10 @@
  * https://www.openssl.org/source/license.html
  */
 
+#ifndef OSSL_CRYPTO_POLY1305_H
+# define OSSL_CRYPTO_POLY1305_H
+# pragma once
+
 #include <stddef.h>
 
 #define POLY1305_BLOCK_SIZE  16
@@ -38,3 +42,5 @@ size_t Poly1305_ctx_size(void);
 void Poly1305_Init(POLY1305 *ctx, const unsigned char key[32]);
 void Poly1305_Update(POLY1305 *ctx, const unsigned char *inp, size_t len);
 void Poly1305_Final(POLY1305 *ctx, unsigned char mac[16]);
+
+#endif /* OSSL_CRYPTO_POLY1305_H */

--- a/include/crypto/punycode.h
+++ b/include/crypto/punycode.h
@@ -9,7 +9,7 @@
 
 #ifndef OSSL_CRYPTO_PUNYCODE_H
 # define OSSL_CRYPTO_PUNYCODE_H
-
+# pragma once
 
 int ossl_punycode_decode (
 	const char *pEncoded,

--- a/include/crypto/rand.h
+++ b/include/crypto/rand.h
@@ -17,6 +17,7 @@
 
 #ifndef OSSL_CRYPTO_RAND_H
 # define OSSL_CRYPTO_RAND_H
+# pragma once
 
 # include <openssl/rand.h>
 # include "crypto/rand_pool.h"

--- a/include/crypto/rand_pool.h
+++ b/include/crypto/rand_pool.h
@@ -9,6 +9,7 @@
 
 #ifndef OSSL_PROVIDER_RAND_POOL_H
 # define OSSL_PROVIDER_RAND_POOL_H
+# pragma once
 
 # include <stdio.h>
 # include <openssl/rand.h>

--- a/include/crypto/rsa.h
+++ b/include/crypto/rsa.h
@@ -9,6 +9,7 @@
 
 #ifndef OSSL_INTERNAL_RSA_H
 # define OSSL_INTERNAL_RSA_H
+# pragma once
 
 # include <openssl/core.h>
 # include <openssl/rsa.h>

--- a/include/crypto/security_bits.h
+++ b/include/crypto/security_bits.h
@@ -9,6 +9,7 @@
 
 #ifndef OSSL_SECURITY_BITS_H
 # define OSSL_SECURITY_BITS_H
+# pragma once
 
 uint16_t ifc_ffc_compute_security_bits(int n);
 

--- a/include/crypto/sha.h
+++ b/include/crypto/sha.h
@@ -10,6 +10,7 @@
 
 #ifndef OSSL_CRYPTO_SHA_H
 # define OSSL_CRYPTO_SHA_H
+# pragma once
 
 # include <openssl/opensslconf.h>
 

--- a/include/crypto/siphash.h
+++ b/include/crypto/siphash.h
@@ -7,12 +7,16 @@
  * https://www.openssl.org/source/license.html
  */
 
-#include <stddef.h>
+#ifndef OSSL_CRYPTO_SIPHASH_H
+# define OSSL_CRYPTO_SIPHASH_H
+# pragma once
 
-#define SIPHASH_BLOCK_SIZE        8
-#define SIPHASH_KEY_SIZE         16
-#define SIPHASH_MIN_DIGEST_SIZE   8
-#define SIPHASH_MAX_DIGEST_SIZE  16
+# include <stddef.h>
+
+# define SIPHASH_BLOCK_SIZE        8
+# define SIPHASH_KEY_SIZE         16
+# define SIPHASH_MIN_DIGEST_SIZE   8
+# define SIPHASH_MAX_DIGEST_SIZE  16
 
 typedef struct siphash_st SIPHASH;
 
@@ -23,3 +27,5 @@ int SipHash_Init(SIPHASH *ctx, const unsigned char *k,
                  int crounds, int drounds);
 void SipHash_Update(SIPHASH *ctx, const unsigned char *in, size_t inlen);
 int SipHash_Final(SIPHASH *ctx, unsigned char *out, size_t outlen);
+
+#endif

--- a/include/crypto/sm2.h
+++ b/include/crypto/sm2.h
@@ -11,6 +11,8 @@
 
 #ifndef OSSL_CRYPTO_SM2_H
 # define OSSL_CRYPTO_SM2_H
+# pragma once
+
 # include <openssl/opensslconf.h>
 
 # ifndef OPENSSL_NO_SM2

--- a/include/crypto/sm4.h
+++ b/include/crypto/sm4.h
@@ -10,6 +10,7 @@
 
 #ifndef OSSL_CRYPTO_SM4_H
 # define OSSL_CRYPTO_SM4_H
+# pragma once
 
 # include <openssl/opensslconf.h>
 # include <openssl/e_os2.h>

--- a/include/crypto/sparse_array.h
+++ b/include/crypto/sparse_array.h
@@ -10,6 +10,7 @@
 
 #ifndef OSSL_CRYPTO_SPARSE_ARRAY_H
 # define OSSL_CRYPTO_SPARSE_ARRAY_H
+# pragma once
 
 # include <openssl/e_os2.h>
 

--- a/include/crypto/store.h
+++ b/include/crypto/store.h
@@ -9,6 +9,7 @@
 
 #ifndef OSSL_CRYPTO_STORE_H
 # define OSSL_CRYPTO_STORE_H
+# pragma once
 
 # include <openssl/bio.h>
 # include <openssl/store.h>

--- a/include/crypto/x509.h
+++ b/include/crypto/x509.h
@@ -7,9 +7,13 @@
  * https://www.openssl.org/source/license.html
  */
 
-#include "internal/refcount.h"
-#include <openssl/asn1.h>
-#include <openssl/x509.h>
+#ifndef OSSL_CRYPTO_X509_H
+# define OSSL_CRYPTO_X509_H
+# pragma once
+
+# include "internal/refcount.h"
+# include <openssl/asn1.h>
+# include <openssl/x509.h>
 
 /* Internal X509 structures and functions: not for application use */
 
@@ -320,3 +324,5 @@ int X509_PUBKEY_get0_libctx(OSSL_LIB_CTX **plibctx, const char **ppropq,
                             const X509_PUBKEY *key);
 /* Calculate default key identifier according to RFC 5280 section 4.2.1.2 (1) */
 ASN1_OCTET_STRING *x509_pubkey_hash(X509_PUBKEY *pubkey);
+
+#endif

--- a/include/internal/asn1.h
+++ b/include/internal/asn1.h
@@ -9,6 +9,7 @@
 
 #ifndef OSSL_INTERNAL_ASN1_H
 # define OSSL_INTERNAL_ASN1_H
+# pragma once
 
 int asn1_d2i_read_bio(BIO *in, BUF_MEM **pb);
 

--- a/include/internal/bio.h
+++ b/include/internal/bio.h
@@ -9,8 +9,9 @@
 
 #ifndef OSSL_INTERNAL_BIO_H
 # define OSSL_INTERNAL_BIO_H
+# pragma once
 
-#include <openssl/bio.h>
+# include <openssl/bio.h>
 
 struct bio_method_st {
     int type;
@@ -62,11 +63,11 @@ int bread_conv(BIO *bio, char *data, size_t datal, size_t *read);
 # define BIO_clear_ktls_ctrl_msg_flag(b) \
     BIO_clear_flags(b, BIO_FLAGS_KTLS_TX_CTRL_MSG)
 
-#  define BIO_set_ktls(b, keyblob, is_tx)   \
+# define BIO_set_ktls(b, keyblob, is_tx)   \
      BIO_ctrl(b, BIO_CTRL_SET_KTLS, is_tx, keyblob)
-#  define BIO_set_ktls_ctrl_msg(b, record_type)   \
+# define BIO_set_ktls_ctrl_msg(b, record_type)   \
      BIO_ctrl(b, BIO_CTRL_SET_KTLS_TX_SEND_CTRL_MSG, record_type, NULL)
-#  define BIO_clear_ktls_ctrl_msg(b) \
+# define BIO_clear_ktls_ctrl_msg(b) \
      BIO_ctrl(b, BIO_CTRL_CLEAR_KTLS_TX_CTRL_MSG, 0, NULL)
 
 #endif

--- a/include/internal/conf.h
+++ b/include/internal/conf.h
@@ -9,10 +9,11 @@
 
 #ifndef OSSL_INTERNAL_CONF_H
 # define OSSL_INTERNAL_CONF_H
+# pragma once
 
-#include <openssl/conf.h>
+# include <openssl/conf.h>
 
-#define DEFAULT_CONF_MFLAGS \
+# define DEFAULT_CONF_MFLAGS \
     (CONF_MFLAGS_DEFAULT_SECTION | \
      CONF_MFLAGS_IGNORE_MISSING_FILE | \
      CONF_MFLAGS_IGNORE_RETURN_CODES)

--- a/include/internal/constant_time.h
+++ b/include/internal/constant_time.h
@@ -9,6 +9,7 @@
 
 #ifndef OSSL_INTERNAL_CONSTANT_TIME_H
 # define OSSL_INTERNAL_CONSTANT_TIME_H
+# pragma once
 
 # include <stdlib.h>
 # include <string.h>

--- a/include/internal/core.h
+++ b/include/internal/core.h
@@ -9,6 +9,7 @@
 
 #ifndef OSSL_INTERNAL_CORE_H
 # define OSSL_INTERNAL_CORE_H
+# pragma once
 
 /*
  * namespaces:

--- a/include/internal/cryptlib.h
+++ b/include/internal/cryptlib.h
@@ -9,6 +9,7 @@
 
 #ifndef OSSL_INTERNAL_CRYPTLIB_H
 # define OSSL_INTERNAL_CRYPTLIB_H
+# pragma once
 
 # include <stdlib.h>
 # include <string.h>

--- a/include/internal/dane.h
+++ b/include/internal/dane.h
@@ -9,8 +9,9 @@
 
 #ifndef OSSL_INTERNAL_DANE_H
 #define OSSL_INTERNAL_DANE_H
+# pragma once
 
-#include <openssl/safestack.h>
+# include <openssl/safestack.h>
 
 /*-
  * Certificate usages:

--- a/include/internal/deprecated.h
+++ b/include/internal/deprecated.h
@@ -18,6 +18,7 @@
 
 #ifndef OSSL_INTERNAL_DEPRECATED_H
 # define OSSL_INTERNAL_DEPRECATED_H
+# pragma once
 
 # include <openssl/configuration.h>
 

--- a/include/internal/dso.h
+++ b/include/internal/dso.h
@@ -9,6 +9,7 @@
 
 #ifndef OSSL_INTERNAL_DSO_H
 # define OSSL_INTERNAL_DSO_H
+# pragma once
 
 # include <openssl/crypto.h>
 # include "internal/dsoerr.h"

--- a/include/internal/endian.h
+++ b/include/internal/endian.h
@@ -9,6 +9,7 @@
 
 #ifndef OSSL_INTERNAL_ENDIAN_H
 # define OSSL_INTERNAL_ENDIAN_H
+# pragma once
 
 /*
  * IS_LITTLE_ENDIAN and IS_BIG_ENDIAN can be used to detect the endiannes

--- a/include/internal/err.h
+++ b/include/internal/err.h
@@ -9,6 +9,7 @@
 
 #ifndef OSSL_INTERNAL_ERR_H
 # define OSSL_INTERNAL_ERR_H
+# pragma once
 
 void err_free_strings_int(void);
 

--- a/include/internal/ffc.h
+++ b/include/internal/ffc.h
@@ -9,6 +9,7 @@
 
 #ifndef OSSL_INTERNAL_FFC_H
 # define OSSL_INTERNAL_FFC_H
+# pragma once
 
 # include <openssl/core.h>
 # include <openssl/bn.h>

--- a/include/internal/ktls.h
+++ b/include/internal/ktls.h
@@ -22,6 +22,8 @@
 
 #ifndef HEADER_INTERNAL_KTLS
 # define HEADER_INTERNAL_KTLS
+# pragma once
+
 # ifndef OPENSSL_NO_KTLS
 
 #  if defined(__FreeBSD__)

--- a/include/internal/nelem.h
+++ b/include/internal/nelem.h
@@ -9,6 +9,7 @@
 
 #ifndef OSSL_INTERNAL_NELEM_H
 # define OSSL_INTERNAL_NELEM_H
+# pragma once
 
 # define OSSL_NELEM(x)    (sizeof(x)/sizeof((x)[0]))
 #endif

--- a/include/internal/numbers.h
+++ b/include/internal/numbers.h
@@ -9,6 +9,7 @@
 
 #ifndef OSSL_INTERNAL_NUMBERS_H
 # define OSSL_INTERNAL_NUMBERS_H
+# pragma once
 
 # include <limits.h>
 

--- a/include/internal/o_dir.h
+++ b/include/internal/o_dir.h
@@ -38,6 +38,7 @@
 
 #ifndef OSSL_INTERNAL_O_DIR_H
 # define OSSL_INTERNAL_O_DIR_H
+# pragma once
 
 typedef struct OPENSSL_dir_context_st OPENSSL_DIR_CTX;
 

--- a/include/internal/packet.h
+++ b/include/internal/packet.h
@@ -9,6 +9,7 @@
 
 #ifndef OSSL_INTERNAL_PACKET_H
 # define OSSL_INTERNAL_PACKET_H
+# pragma once
 
 # include <string.h>
 # include <openssl/bn.h>

--- a/include/internal/param_build_set.h
+++ b/include/internal/param_build_set.h
@@ -7,8 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
-#include <openssl/safestack.h>
-#include <openssl/param_build.h>
+#ifndef OSSL_INTERNAL_PARAM_BUILD_SET_H
+# define OSSL_INTERNAL_PARAM_BUILD_SET_H
+# pragma once
+
+# include <openssl/safestack.h>
+# include <openssl/param_build.h>
 
 int ossl_param_build_set_int(OSSL_PARAM_BLD *bld, OSSL_PARAM *p,
                              const char *key, int num);
@@ -27,3 +31,5 @@ int ossl_param_build_set_bn_pad(OSSL_PARAM_BLD *bld, OSSL_PARAM *p,
 int ossl_param_build_set_multi_key_bn(OSSL_PARAM_BLD *bld, OSSL_PARAM *p,
                                       const char *names[],
                                       STACK_OF(BIGNUM_const) *stk);
+
+#endif  /* OSSL_INTERNAL_PARAM_BUILD_SET_H */

--- a/include/internal/passphrase.h
+++ b/include/internal/passphrase.h
@@ -9,6 +9,7 @@
 
 #ifndef OSSL_INTERNAL_PASSPHRASE_H
 # define OSSL_INTERNAL_PASSPHRASE_H
+# pragma once
 
 /*
  * This is a passphrase reader bridge with bells and whistles.

--- a/include/internal/property.h
+++ b/include/internal/property.h
@@ -10,8 +10,9 @@
 
 #ifndef OSSL_INTERNAL_PROPERTY_H
 # define OSSL_INTERNAL_PROPERTY_H
+# pragma once
 
-#include "internal/cryptlib.h"
+# include "internal/cryptlib.h"
 
 typedef struct ossl_method_store_st OSSL_METHOD_STORE;
 typedef struct ossl_property_list_st OSSL_PROPERTY_LIST;

--- a/include/internal/provider.h
+++ b/include/internal/provider.h
@@ -9,6 +9,7 @@
 
 #ifndef OSSL_INTERNAL_PROVIDER_H
 # define OSSL_INTERNAL_PROVIDER_H
+# pragma once
 
 # include <openssl/core.h>
 # include <openssl/core_dispatch.h>

--- a/include/internal/refcount.h
+++ b/include/internal/refcount.h
@@ -8,6 +8,7 @@
  */
 #ifndef OSSL_INTERNAL_REFCOUNT_H
 # define OSSL_INTERNAL_REFCOUNT_H
+# pragma once
 
 # include <openssl/e_os2.h>
 

--- a/include/internal/sha3.h
+++ b/include/internal/sha3.h
@@ -10,6 +10,7 @@
 /* TODO(3.0) Move this header into provider when dependencies are removed */
 #ifndef OSSL_INTERNAL_SHA3_H
 # define OSSL_INTERNAL_SHA3_H
+# pragma once
 
 # include <openssl/e_os2.h>
 # include <stddef.h>

--- a/include/internal/sizes.h
+++ b/include/internal/sizes.h
@@ -9,6 +9,7 @@
 
 #ifndef OSSL_INTERNAL_SIZES_H
 # define OSSL_INTERNAL_SIZES_H
+# pragma once
 
 /*
  * Max sizes used to allocate buffers with a fixed sizes, for example for

--- a/include/internal/sm3.h
+++ b/include/internal/sm3.h
@@ -11,6 +11,7 @@
 /* TODO(3.0) Move this header into provider when dependencies are removed */
 #ifndef OSSL_INTERNAL_SM3_H
 # define OSSL_INTERNAL_SM3_H
+# pragma once
 
 # include <openssl/opensslconf.h>
 

--- a/include/internal/sockets.h
+++ b/include/internal/sockets.h
@@ -10,6 +10,7 @@
 
 #ifndef OSSL_INTERNAL_SOCKETS_H
 # define OSSL_INTERNAL_SOCKETS_H
+# pragma once
 
 # if defined(OPENSSL_SYS_VXWORKS) || defined(OPENSSL_SYS_UEFI)
 #  define NO_SYS_PARAM_H

--- a/include/internal/sslconf.h
+++ b/include/internal/sslconf.h
@@ -9,6 +9,7 @@
 
 #ifndef OSSL_INTERNAL_SSLCONF_H
 # define OSSL_INTERNAL_SSLCONF_H
+# pragma once
 
 typedef struct ssl_conf_cmd_st SSL_CONF_CMD;
 

--- a/include/internal/symhacks.h
+++ b/include/internal/symhacks.h
@@ -9,6 +9,7 @@
 
 #ifndef OSSL_INTERNAL_SYMHACKS_H
 # define OSSL_INTERNAL_SYMHACKS_H
+# pragma once
 
 # include <openssl/e_os2.h>
 

--- a/include/internal/thread_once.h
+++ b/include/internal/thread_once.h
@@ -7,7 +7,11 @@
  * https://www.openssl.org/source/license.html
  */
 
-#include <openssl/crypto.h>
+#ifndef OSSL_INTERNAL_THREAD_ONCE_H
+# define OSSL_INTERNAL_THREAD_ONCE_H
+# pragma once
+
+# include <openssl/crypto.h>
 
 /*
  * Initialisation of global data should never happen via "RUN_ONCE" inside the
@@ -15,7 +19,7 @@
  * OSSL_LIB_CTX object. In this way data will get cleaned up correctly when the
  * module gets unloaded.
  */
-#if !defined(FIPS_MODULE) || defined(ALLOW_RUN_ONCE_IN_FIPS)
+# if !defined(FIPS_MODULE) || defined(ALLOW_RUN_ONCE_IN_FIPS)
 /*
  * DEFINE_RUN_ONCE: Define an initialiser function that should be run exactly
  * once. It takes no arguments and returns an int result (1 for success or
@@ -30,7 +34,7 @@
  *     return 0;
  * }
  */
-# define DEFINE_RUN_ONCE(init)                   \
+#  define DEFINE_RUN_ONCE(init)                   \
     static int init(void);                     \
     int init##_ossl_ret_ = 0;                   \
     void init##_ossl_(void)                     \
@@ -43,7 +47,7 @@
  * DECLARE_RUN_ONCE: Declare an initialiser function that should be run exactly
  * once that has been defined in another file via DEFINE_RUN_ONCE().
  */
-# define DECLARE_RUN_ONCE(init)                  \
+#  define DECLARE_RUN_ONCE(init)                  \
     extern int init##_ossl_ret_;                \
     void init##_ossl_(void);
 
@@ -62,7 +66,7 @@
  *     return 0;
  * }
  */
-# define DEFINE_RUN_ONCE_STATIC(init)            \
+#  define DEFINE_RUN_ONCE_STATIC(init)            \
     static int init(void);                     \
     static int init##_ossl_ret_ = 0;            \
     static void init##_ossl_(void)              \
@@ -103,7 +107,7 @@
  *     return 0;
  * }
  */
-# define DEFINE_RUN_ONCE_STATIC_ALT(initalt, init) \
+#  define DEFINE_RUN_ONCE_STATIC_ALT(initalt, init) \
     static int initalt(void);                     \
     static void initalt##_ossl_(void)             \
     {                                             \
@@ -122,7 +126,7 @@
  *
  * (*) by convention, since the init function must return 1 on success.
  */
-# define RUN_ONCE(once, init)                                            \
+#  define RUN_ONCE(once, init)                                            \
     (CRYPTO_THREAD_run_once(once, init##_ossl_) ? init##_ossl_ret_ : 0)
 
 /*
@@ -140,7 +144,8 @@
  *
  * (*) by convention, since the init function must return 1 on success.
  */
-# define RUN_ONCE_ALT(once, initalt, init)                               \
+#  define RUN_ONCE_ALT(once, initalt, init)                               \
     (CRYPTO_THREAD_run_once(once, initalt##_ossl_) ? init##_ossl_ret_ : 0)
 
-#endif /* FIPS_MODULE */
+# endif /* FIPS_MODULE */
+#endif /* OSSL_INTERNAL_THREAD_ONCE_H */

--- a/include/internal/tlsgroups.h
+++ b/include/internal/tlsgroups.h
@@ -9,6 +9,7 @@
 
 #ifndef OSSL_INTERNAL_TLSGROUPS_H
 # define OSSL_INTERNAL_TLSGROUPS_H
+# pragma once
 
 # define OSSL_TLS_GROUP_ID_sect163k1        0x0001
 # define OSSL_TLS_GROUP_ID_sect163r1        0x0002

--- a/include/openssl/cmp_util.h
+++ b/include/openssl/cmp_util.h
@@ -11,6 +11,7 @@
 
 #ifndef OPENSSL_CMP_UTIL_H
 # define OPENSSL_CMP_UTIL_H
+# pragma once
 
 # include <openssl/opensslconf.h>
 # ifndef OPENSSL_NO_CMP

--- a/include/openssl/configuration.h.in
+++ b/include/openssl/configuration.h.in
@@ -11,6 +11,7 @@
 
 #ifndef OPENSSL_CONFIGURATION_H
 # define OPENSSL_CONFIGURATION_H
+# pragma once
 
 # ifdef  __cplusplus
 extern "C" {

--- a/include/openssl/core.h
+++ b/include/openssl/core.h
@@ -9,6 +9,7 @@
 
 #ifndef OPENSSL_CORE_H
 # define OPENSSL_CORE_H
+# pragma once
 
 # include <stddef.h>
 # include <openssl/types.h>

--- a/include/openssl/core_dispatch.h
+++ b/include/openssl/core_dispatch.h
@@ -9,6 +9,7 @@
 
 #ifndef OPENSSL_CORE_NUMBERS_H
 # define OPENSSL_CORE_NUMBERS_H
+# pragma once
 
 # include <stdarg.h>
 # include <openssl/core.h>

--- a/include/openssl/core_names.h
+++ b/include/openssl/core_names.h
@@ -9,6 +9,7 @@
 
 #ifndef OPENSSL_CORE_NAMES_H
 # define OPENSSL_CORE_NAMES_H
+# pragma once
 
 # ifdef __cplusplus
 extern "C" {

--- a/include/openssl/core_object.h
+++ b/include/openssl/core_object.h
@@ -9,6 +9,7 @@
 
 #ifndef OPENSSL_CORE_OBJECT_H
 # define OPENSSL_CORE_OBJECT_H
+# pragma once
 
 # ifdef __cplusplus
 extern "C" {

--- a/include/openssl/crypto.h.in
+++ b/include/openssl/crypto.h.in
@@ -14,7 +14,6 @@
 use OpenSSL::stackhash qw(generate_stack_macros);
 -}
 
-
 #ifndef OPENSSL_CRYPTO_H
 # define OPENSSL_CRYPTO_H
 # pragma once

--- a/include/openssl/ess.h.in
+++ b/include/openssl/ess.h.in
@@ -15,15 +15,17 @@ use OpenSSL::stackhash qw(generate_stack_macros);
 
 #ifndef OPENSSL_ESS_H
 # define OPENSSL_ESS_H
+# pragma once
 
 # include <openssl/opensslconf.h>
+
+# include <openssl/safestack.h>
+# include <openssl/x509.h>
+# include <openssl/esserr.h>
 
 # ifdef  __cplusplus
 extern "C" {
 # endif
-# include <openssl/safestack.h>
-# include <openssl/x509.h>
-# include <openssl/esserr.h>
 
 
 typedef struct ESS_issuer_serial ESS_ISSUER_SERIAL;

--- a/include/openssl/fips_names.h
+++ b/include/openssl/fips_names.h
@@ -9,6 +9,7 @@
 
 #ifndef OPENSSL_FIPS_NAMES_H
 # define OPENSSL_FIPS_NAMES_H
+# pragma once
 
 # ifdef __cplusplus
 extern "C" {

--- a/include/openssl/fipskey.h.in
+++ b/include/openssl/fipskey.h.in
@@ -11,6 +11,7 @@
 
 #ifndef OPENSSL_FIPSKEY_H
 # define OPENSSL_FIPSKEY_H
+# pragma once
 
 # ifdef  __cplusplus
 extern "C" {

--- a/include/openssl/kdferr.h
+++ b/include/openssl/kdferr.h
@@ -7,4 +7,10 @@
  * https://www.openssl.org/source/license.html
  */
 
+#ifndef OPENSSL_KDFERR_H
+# define OPENSSL_KDFERR_H
+# pragma once
+
 #include <openssl/cryptoerr_legacy.h>
+
+#endif /* !defined(OPENSSL_KDFERR_H) */

--- a/include/openssl/macros.h
+++ b/include/openssl/macros.h
@@ -7,11 +7,13 @@
  * https://www.openssl.org/source/license.html
  */
 
+#ifndef OPENSSL_MACROS_H
+# define OPENSSL_MACROS_H
+# pragma once
+
 #include <openssl/opensslconf.h>
 #include <openssl/opensslv.h>
 
-#ifndef OPENSSL_MACROS_H
-# define OPENSSL_MACROS_H
 
 /* Helper macros for CPP string composition */
 # define OPENSSL_MSTR_HELPER(x) #x

--- a/include/openssl/obj_mac.h
+++ b/include/openssl/obj_mac.h
@@ -9,6 +9,10 @@
  * https://www.openssl.org/source/license.html
  */
 
+#ifndef OPENSSL_OBJ_MAC_H
+# define OPENSSL_OBJ_MAC_H
+# pragma once
+
 #define SN_undef                        "UNDEF"
 #define LN_undef                        "undefined"
 #define NID_undef                       0
@@ -5420,6 +5424,8 @@
 #define LN_aes_256_siv          "aes-256-siv"
 #define NID_aes_256_siv         1200
 
+#endif /* OPENSSL_OBJ_MAC_H */
+
 #ifndef OPENSSL_NO_DEPRECATED_3_0
 
 #define SN_id_tc26_cipher_gostr3412_2015_magma_ctracpkm                 SN_magma_ctr_acpkm
@@ -5464,4 +5470,4 @@
 #define SN_grasshopper_mac              SN_kuznyechik_mac
 #define NID_grasshopper_mac             NID_kuznyechik_mac
 
-#endif
+#endif  /* OPENSSL_NO_DEPRECATED_3_0 */

--- a/include/openssl/opensslconf.h
+++ b/include/openssl/opensslconf.h
@@ -9,8 +9,9 @@
 
 #ifndef OPENSSL_OPENSSLCONF_H
 # define OPENSSL_OPENSSLCONF_H
+# pragma once
 
-#include <openssl/configuration.h>
-#include <openssl/macros.h>
+# include <openssl/configuration.h>
+# include <openssl/macros.h>
 
 #endif  /* OPENSSL_OPENSSLCONF_H */

--- a/include/openssl/param_build.h
+++ b/include/openssl/param_build.h
@@ -8,8 +8,16 @@
  * https://www.openssl.org/source/license.html
  */
 
-#include <openssl/params.h>
-#include <openssl/types.h>
+#ifndef OPENSSL_PARAM_BUILD_H
+# define OPENSSL_PARAM_BUILD_H
+# pragma once
+
+# include <openssl/params.h>
+# include <openssl/types.h>
+
+# ifdef __cplusplus
+extern "C" {
+# endif
 
 OSSL_PARAM_BLD *OSSL_PARAM_BLD_new(void);
 OSSL_PARAM *OSSL_PARAM_BLD_to_param(OSSL_PARAM_BLD *bld);
@@ -49,3 +57,8 @@ int OSSL_PARAM_BLD_push_octet_string(OSSL_PARAM_BLD *bld, const char *key,
                                      const void *buf, size_t bsize);
 int OSSL_PARAM_BLD_push_octet_ptr(OSSL_PARAM_BLD *bld, const char *key,
                                   void *buf, size_t bsize);
+
+# ifdef __cplusplus
+}
+# endif
+#endif  /* OPENSSL_PARAM_BUILD_H */

--- a/include/openssl/params.h
+++ b/include/openssl/params.h
@@ -10,6 +10,7 @@
 
 #ifndef OPENSSL_PARAMS_H
 # define OPENSSL_PARAMS_H
+# pragma once
 
 # include <openssl/core.h>
 # include <openssl/bn.h>

--- a/include/openssl/provider.h
+++ b/include/openssl/provider.h
@@ -9,6 +9,7 @@
 
 #ifndef OPENSSL_PROVIDER_H
 # define OPENSSL_PROVIDER_H
+# pragma once
 
 # include <openssl/core.h>
 

--- a/include/openssl/self_test.h
+++ b/include/openssl/self_test.h
@@ -9,6 +9,7 @@
 
 #ifndef OPENSSL_SELF_TEST_H
 # define OPENSSL_SELF_TEST_H
+# pragma once
 
 # include <openssl/core.h> /* OSSL_CALLBACK */
 

--- a/include/openssl/trace.h
+++ b/include/openssl/trace.h
@@ -9,6 +9,7 @@
 
 #ifndef OPENSSL_TRACE_H
 # define OPENSSL_TRACE_H
+# pragma once
 
 # include <stdarg.h>
 

--- a/include/openssl/types.h
+++ b/include/openssl/types.h
@@ -9,12 +9,13 @@
 
 #ifndef OPENSSL_TYPES_H
 # define OPENSSL_TYPES_H
+# pragma once
 
-#include <limits.h>
+# include <limits.h>
 
-#ifdef  __cplusplus
+# ifdef  __cplusplus
 extern "C" {
-#endif
+# endif
 
 # include <openssl/e_os2.h>
 # include <openssl/safestack.h>


### PR DESCRIPTION
Code cleanup in some header files : 
- add some missing  `#pragma once`
- add a few missing  include guards 

This may be a small improvement to help fixing #14055
It is a rabbit-hole, so this is not a complete fix.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
