### PR TITLE
Additional no-cache discovered fixes.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,17 @@ jobs:
     - name: make test
       run: make test HARNESS_JOBS=${HARNESS_JOBS:-4}
 
+  non-caching:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: config
+      run: ./config enable-asan enable-ubsan no-cached-fetch && perl configdata.pm --dump
+    - name: make
+      run: make -s -j4
+    - name: make test
+      run: make test HARNESS_JOBS=${HARNESS_JOBS:-4} OPENSSL_TEST_RAND_ORDER=0 TESTS="-test_fuzz* -test_ssl_* -test_evp -test_cmp_http -test_store -test_enc -[01][0-9]"
+
   sanitizers:
     runs-on: ubuntu-latest
     steps:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,12 @@ OpenSSL 3.0
 
 ### Changes between 1.1.1 and 3.0 [xx XXX xxxx]
 
+ * Add a compile time option to prevent the caching of provider fetched
+   algorithms.  This is enabled by including the no-cached-fetch option
+   at configuration time.
+
+   *Paul Dale*
+
  * Combining the Configure options no-ec and no-dh no longer disables TLSv1.3.
    Typically if OpenSSL has no EC or DH algorithms then it cannot support
    connections with TLSv1.3. However OpenSSL now supports "pluggable" groups

--- a/Configure
+++ b/Configure
@@ -392,6 +392,7 @@ my @disablables = (
     "blake2",
     "buildtest-c++",
     "bulk",
+    "cached-fetch",
     "camellia",
     "capieng",
     "cast",

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -582,6 +582,14 @@ alternative, you can use the language specific variables, `CFLAGS` and `CXXFLAGS
 Build only some minimal set of features.
 This is a developer option used internally for CI build tests of the project.
 
+### no-cached-fetch
+
+Never cache algorithms when they are fetched from a provider.  Normally, a
+provider indicates if the algorithms it supplies can be cached or not.  Using
+this option will reduce run-time memory usage but it also introduces a
+significant performance penalty.  This option is primarily designed to help
+with detecting incorrect reference counting.
+
 ### no-capieng
 
 Don't build the CAPI engine.

--- a/crypto/evp/evp_enc.c
+++ b/crypto/evp/evp_enc.c
@@ -182,6 +182,14 @@ int EVP_CipherInit_ex(EVP_CIPHER_CTX *ctx, const EVP_CIPHER *cipher,
 #endif
     }
 
+    if (cipher->prov != NULL) {
+        if (!EVP_CIPHER_up_ref((EVP_CIPHER *)cipher)) {
+            ERR_raise(ERR_LIB_EVP, EVP_R_INITIALIZATION_ERROR);
+            return 0;
+        }
+        EVP_CIPHER_free(ctx->fetched_cipher);
+        ctx->fetched_cipher = (EVP_CIPHER *)cipher;
+    }
     ctx->cipher = cipher;
     if (ctx->provctx == NULL) {
         ctx->provctx = ctx->cipher->newctx(ossl_provider_ctx(cipher->prov));

--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -914,8 +914,17 @@ const OSSL_ALGORITHM *ossl_provider_query_operation(const OSSL_PROVIDER *prov,
                                                     int operation_id,
                                                     int *no_cache)
 {
-    return prov->query_operation == NULL
-        ? NULL : prov->query_operation(prov->provctx, operation_id, no_cache);
+    const OSSL_ALGORITHM *res;
+
+    if (prov->query_operation == NULL)
+        return NULL;
+    res = prov->query_operation(prov->provctx, operation_id, no_cache);
+#if defined(OPENSSL_NO_CACHED_FETCH)
+    /* Forcing the non-caching of queries */
+    if (no_cache != NULL)
+        *no_cache = 1;
+#endif
+    return res;
 }
 
 int ossl_provider_set_operation_bit(OSSL_PROVIDER *provider, size_t bitnum)

--- a/test/filterprov.c
+++ b/test/filterprov.c
@@ -33,6 +33,7 @@ struct filter_prov_globals_st {
         OSSL_ALGORITHM alg[MAX_ALG_FILTERS + 1];
     } dispatch[MAX_FILTERS];
     int num_dispatch;
+    int no_cache;
 };
 
 static struct filter_prov_globals_st ourglobals;
@@ -83,7 +84,7 @@ static const OSSL_ALGORITHM *filter_query(void *provctx,
 
     for (i = 0; i < globs->num_dispatch; i++) {
         if (globs->dispatch[i].operation == operation_id) {
-            *no_cache = 0;
+            *no_cache = globs->no_cache;
             return globs->dispatch[i].alg;
         }
     }
@@ -156,10 +157,6 @@ int filter_provider_set_filter(int operation, const char *filterstr)
     if (filterstrtmp == NULL)
         goto err;
 
-    /* We don't support no_cache */
-    if (no_cache)
-        goto err;
-
     /* Nothing to filter */
     if (provalgs == NULL)
         goto err;
@@ -199,6 +196,7 @@ int filter_provider_set_filter(int operation, const char *filterstr)
     }
 
     globs->dispatch[globs->num_dispatch].operation = operation;
+    globs->no_cache = no_cache;
     globs->num_dispatch++;
 
     ret = 1;

--- a/test/tls-provider.c
+++ b/test/tls-provider.c
@@ -15,6 +15,11 @@
 /* For TLS1_3_VERSION */
 #include <openssl/ssl.h>
 
+static OSSL_FUNC_keymgmt_import_fn xor_import;
+static OSSL_FUNC_keymgmt_import_types_fn xor_import_types;
+static OSSL_FUNC_keymgmt_export_fn xor_export;
+static OSSL_FUNC_keymgmt_export_types_fn xor_export_types;
+
 int tls_provider_init(const OSSL_CORE_HANDLE *handle,
                       const OSSL_DISPATCH *in,
                       const OSSL_DISPATCH **out,
@@ -600,6 +605,82 @@ static void *xor_gen(void *genctx, OSSL_CALLBACK *osslcb, void *cbarg)
     return key;
 }
 
+/* IMPORT + EXPORT */
+
+static int xor_import(void *vkey, int select, const OSSL_PARAM params[])
+{
+    XORKEY *key = vkey;
+    const OSSL_PARAM *param_priv_key, *param_pub_key;
+    unsigned char privkey[XOR_KEY_SIZE];
+    unsigned char pubkey[XOR_KEY_SIZE];
+    void *pprivkey = privkey, *ppubkey = pubkey;
+    size_t priv_len = 0, pub_len = 0;
+    int res = 0;
+
+    if (key == NULL || (select & OSSL_KEYMGMT_SELECT_KEYPAIR) == 0)
+        return 0;
+
+    memset(privkey, 0, sizeof(privkey));
+    memset(pubkey, 0, sizeof(pubkey));
+    param_priv_key = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_PRIV_KEY);
+    param_pub_key = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_PUB_KEY);
+
+    if ((param_priv_key != NULL
+         && !OSSL_PARAM_get_octet_string(param_priv_key, &pprivkey,
+                                         sizeof(privkey), &priv_len))
+        || (param_pub_key != NULL
+            && !OSSL_PARAM_get_octet_string(param_pub_key, &ppubkey,
+                                            sizeof(pubkey), &pub_len)))
+        goto err;
+
+    if (priv_len > 0) {
+        memcpy(key->privkey, privkey, priv_len);
+        key->hasprivkey = 1;
+    }
+    if (pub_len > 0) {
+        memcpy(key->pubkey, pubkey, pub_len);
+        key->haspubkey = 1;
+    }
+    res = 1;
+ err:
+    return res;
+}
+
+static int xor_export(void *vkey, int select, OSSL_CALLBACK *param_cb,
+                      void *cbarg)
+{
+    XORKEY *key = vkey;
+    OSSL_PARAM params[3], *p = params;
+
+    if (key == NULL || (select & OSSL_KEYMGMT_SELECT_KEYPAIR) == 0)
+        return 0;
+
+    *p++ = OSSL_PARAM_construct_octet_string(OSSL_PKEY_PARAM_PRIV_KEY,
+                                             key->privkey,
+                                             sizeof(key->privkey));
+    *p++ = OSSL_PARAM_construct_octet_string(OSSL_PKEY_PARAM_PUB_KEY,
+                                             key->pubkey, sizeof(key->pubkey));
+    *p++ = OSSL_PARAM_construct_end();
+
+    return param_cb(params, cbarg);
+}
+
+static const OSSL_PARAM xor_key_types[] = {
+    OSSL_PARAM_BN(OSSL_PKEY_PARAM_PUB_KEY, NULL, 0),
+    OSSL_PARAM_BN(OSSL_PKEY_PARAM_PRIV_KEY, NULL, 0),
+    OSSL_PARAM_END
+};
+
+static const OSSL_PARAM *xor_import_types(int select)
+{
+    return (select & OSSL_KEYMGMT_SELECT_KEYPAIR) != 0 ? xor_key_types : NULL;
+}
+
+static const OSSL_PARAM *xor_export_types(int select)
+{
+    return (select & OSSL_KEYMGMT_SELECT_KEYPAIR) != 0 ? xor_key_types : NULL;
+}
+
 static void xor_gen_cleanup(void *genctx)
 {
     OPENSSL_free(genctx);
@@ -620,6 +701,10 @@ static const OSSL_DISPATCH xor_keymgmt_functions[] = {
     { OSSL_FUNC_KEYMGMT_HAS, (void (*)(void))xor_has },
     { OSSL_FUNC_KEYMGMT_COPY, (void (*)(void))xor_copy },
     { OSSL_FUNC_KEYMGMT_FREE, (void (*)(void))xor_freedata },
+    { OSSL_FUNC_KEYMGMT_IMPORT, (void (*)(void))xor_import },
+    { OSSL_FUNC_KEYMGMT_IMPORT_TYPES, (void (*)(void))xor_import_types },
+    { OSSL_FUNC_KEYMGMT_EXPORT, (void (*)(void))xor_export },
+    { OSSL_FUNC_KEYMGMT_EXPORT_TYPES, (void (*)(void))xor_export_types },
     { 0, NULL }
 };
 


### PR DESCRIPTION
A number of bugs in the fetch/caching mechanism have been discovered when turning caching off.  This PR will address those that are bug and that could be discovered in a normal build.

Additionally, an address sanitiser build is added that disables fetch caching for all providers.

- [ ] documentation is added or updated
- [x] tests are added or updated

Further fixes for #14126
