### PR TITLE
Deprecate SRP

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,12 @@ OpenSSL 3.0
 
 ### Changes between 1.1.1 and 3.0 [xx XXX xxxx]
 
+ * The SRP APIs have been deprecated. The old APIs do not work via providers,
+   and there is no EVP interface to them. Unfortunately there is no replacement
+   for these APIs at this time.
+
+   *Matt Caswell*
+
  * Combining the Configure options no-ec and no-dh no longer disables TLSv1.3.
    Typically if OpenSSL has no EC or DH algorithms then it cannot support
    connections with TLSv1.3. However OpenSSL now supports "pluggable" groups

--- a/Configure
+++ b/Configure
@@ -611,13 +611,12 @@ my @disable_cascades = (
 
     sub { !$disabled{"msan"} } => [ "asm" ],
 
-    sub { $disabled{cmac}; } => [ "siv" ],
-    "legacy"                 => [ "md2" ],
+    "cmac"              => [ "siv" ],
+    "legacy"            => [ "md2" ],
 
     "cmp"               => [ "crmf" ],
 
-    sub { $disabled{"deprecated-3.0"} }
-          => [ "engine" ]
+    "deprecated-3.0"    => [ "engine", "srp" ]
     );
 
 # Avoid protocol support holes.  Also disable all versions below N, if version

--- a/apps/ciphers.c
+++ b/apps/ciphers.c
@@ -14,6 +14,7 @@
 #include "progs.h"
 #include <openssl/err.h>
 #include <openssl/ssl.h>
+#include "s_apps.h"
 
 typedef enum OPTION_choice {
     OPT_ERR = -1, OPT_EOF = 0, OPT_HELP,
@@ -63,7 +64,7 @@ const OPTIONS ciphers_options[] = {
     {"psk", OPT_PSK, '-', "Include ciphersuites requiring PSK"},
 #endif
 #ifndef OPENSSL_NO_SRP
-    {"srp", OPT_SRP, '-', "Include ciphersuites requiring SRP"},
+    {"srp", OPT_SRP, '-', "(deprecated) Include ciphersuites requiring SRP"},
 #endif
     {"ciphersuites", OPT_CIPHERSUITES, 's',
      "Configure the TLSv1.3 ciphersuites to use"},
@@ -81,12 +82,6 @@ static unsigned int dummy_psk(SSL *ssl, const char *hint, char *identity,
                               unsigned int max_psk_len)
 {
     return 0;
-}
-#endif
-#ifndef OPENSSL_NO_SRP
-static char *dummy_srp(SSL *ssl, void *arg)
-{
-    return "";
 }
 #endif
 
@@ -205,7 +200,7 @@ int ciphers_main(int argc, char **argv)
 #endif
 #ifndef OPENSSL_NO_SRP
     if (srp)
-        SSL_CTX_set_srp_client_pwd_callback(ctx, dummy_srp);
+        set_up_dummy_srp(ctx);
 #endif
 
     if (ciphersuites != NULL && !SSL_CTX_set_ciphersuites(ctx, ciphersuites)) {

--- a/apps/include/s_apps.h
+++ b/apps/include/s_apps.h
@@ -92,6 +92,7 @@ typedef struct srp_arg_st {
 
 int set_up_srp_arg(SSL_CTX *ctx, SRP_ARG *srp_arg, int srp_lateuser, int c_msg,
                    int c_debug);
+void set_up_dummy_srp(SSL_CTX *ctx);
 
 /* The server side SRP context that we pass to all SRP related callbacks */
 typedef struct srpsrvparm_st {

--- a/apps/include/s_apps.h
+++ b/apps/include/s_apps.h
@@ -10,6 +10,7 @@
 #include <openssl/opensslconf.h>
 
 #include <openssl/ssl.h>
+#include <openssl/srp.h>
 
 #define PORT            "4433"
 #define PROTOCOL        "tcp"
@@ -77,3 +78,29 @@ int ssl_load_stores(SSL_CTX *ctx, const char *vfyCApath,
 void ssl_ctx_security_debug(SSL_CTX *ctx, int verbose);
 int set_keylog_file(SSL_CTX *ctx, const char *keylog_file);
 void print_ca_names(BIO *bio, SSL *s);
+
+#ifndef OPENSSL_NO_SRP
+/* The client side SRP context that we pass to all SRP related callbacks */
+typedef struct srp_arg_st {
+    char *srppassin;
+    char *srplogin;
+    int msg;                    /* copy from c_msg */
+    int debug;                  /* copy from c_debug */
+    int amp;                    /* allow more groups */
+    int strength;               /* minimal size for N */
+} SRP_ARG;
+
+int set_up_srp_arg(SSL_CTX *ctx, SRP_ARG *srp_arg, int srp_lateuser, int c_msg,
+                   int c_debug);
+
+/* The server side SRP context that we pass to all SRP related callbacks */
+typedef struct srpsrvparm_st {
+    char *login;
+    SRP_VBASE *vb;
+    SRP_user_pwd *user;
+} srpsrvparm;
+
+int set_up_srp_verifier_file(SSL_CTX *ctx, srpsrvparm *srp_callback_parm,
+                             char *srpuserseed, char *srp_verifier_file);
+void lookup_srp_user(srpsrvparm *srp_callback_parm, BIO *bio_s_out);
+#endif /* OPENSSL_NO_SRP */

--- a/apps/lib/build.info
+++ b/apps/lib/build.info
@@ -17,3 +17,7 @@ IF[{- !$disabled{apps} -}]
   SOURCE[../libapps.a]=$LIBAPPSSRC $AUXLIBAPPSSRC
   INCLUDE[../libapps.a]=../.. ../../include ../include
 ENDIF
+
+IF[{- !$disabled{srp} -}]
+  SOURCE[../libapps.a]=tlssrp_depr.c
+ENDIF

--- a/apps/lib/tlssrp_depr.c
+++ b/apps/lib/tlssrp_depr.c
@@ -1,0 +1,221 @@
+/*
+ * Copyright 1995-2021 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2005 Nokia. All rights reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+/*
+ * This file is to enable backwards compatibility for the SRP features of
+ * s_client and s_server. All of those features are deprecated and will
+ * eventually disappear. In the meantime, to continue to support them, we
+ * need to access deprecated SRP APIs.
+ */
+#define OPENSSL_SUPPRESS_DEPRECATED
+
+#include <openssl/bn.h>
+#include <openssl/bio.h>
+#include <openssl/ssl.h>
+#include <openssl/srp.h>
+#include "apps_ui.h"
+#include "apps.h"
+#include "s_apps.h"
+
+static int srp_Verify_N_and_g(const BIGNUM *N, const BIGNUM *g)
+{
+    BN_CTX *bn_ctx = BN_CTX_new();
+    BIGNUM *p = BN_new();
+    BIGNUM *r = BN_new();
+    int ret =
+        g != NULL && N != NULL && bn_ctx != NULL && BN_is_odd(N) &&
+        BN_check_prime(N, bn_ctx, NULL) == 1 &&
+        p != NULL && BN_rshift1(p, N) &&
+        /* p = (N-1)/2 */
+        BN_check_prime(p, bn_ctx, NULL) == 1 &&
+        r != NULL &&
+        /* verify g^((N-1)/2) == -1 (mod N) */
+        BN_mod_exp(r, g, p, N, bn_ctx) &&
+        BN_add_word(r, 1) && BN_cmp(r, N) == 0;
+
+    BN_free(r);
+    BN_free(p);
+    BN_CTX_free(bn_ctx);
+    return ret;
+}
+
+/*-
+ * This callback is used here for two purposes:
+ * - extended debugging
+ * - making some primality tests for unknown groups
+ * The callback is only called for a non default group.
+ *
+ * An application does not need the call back at all if
+ * only the standard groups are used.  In real life situations,
+ * client and server already share well known groups,
+ * thus there is no need to verify them.
+ * Furthermore, in case that a server actually proposes a group that
+ * is not one of those defined in RFC 5054, it is more appropriate
+ * to add the group to a static list and then compare since
+ * primality tests are rather cpu consuming.
+ */
+
+static int ssl_srp_verify_param_cb(SSL *s, void *arg)
+{
+    SRP_ARG *srp_arg = (SRP_ARG *)arg;
+    BIGNUM *N = NULL, *g = NULL;
+
+    if (((N = SSL_get_srp_N(s)) == NULL) || ((g = SSL_get_srp_g(s)) == NULL))
+        return 0;
+    if (srp_arg->debug || srp_arg->msg || srp_arg->amp == 1) {
+        BIO_printf(bio_err, "SRP parameters:\n");
+        BIO_printf(bio_err, "\tN=");
+        BN_print(bio_err, N);
+        BIO_printf(bio_err, "\n\tg=");
+        BN_print(bio_err, g);
+        BIO_printf(bio_err, "\n");
+    }
+
+    if (SRP_check_known_gN_param(g, N))
+        return 1;
+
+    if (srp_arg->amp == 1) {
+        if (srp_arg->debug)
+            BIO_printf(bio_err,
+                       "SRP param N and g are not known params, going to check deeper.\n");
+
+        /*
+         * The srp_moregroups is a real debugging feature. Implementors
+         * should rather add the value to the known ones. The minimal size
+         * has already been tested.
+         */
+        if (BN_num_bits(g) <= BN_BITS && srp_Verify_N_and_g(N, g))
+            return 1;
+    }
+    BIO_printf(bio_err, "SRP param N and g rejected.\n");
+    return 0;
+}
+
+#define PWD_STRLEN 1024
+
+static char *ssl_give_srp_client_pwd_cb(SSL *s, void *arg)
+{
+    SRP_ARG *srp_arg = (SRP_ARG *)arg;
+    char *pass = app_malloc(PWD_STRLEN + 1, "SRP password buffer");
+    PW_CB_DATA cb_tmp;
+    int l;
+
+    cb_tmp.password = (char *)srp_arg->srppassin;
+    cb_tmp.prompt_info = "SRP user";
+    if ((l = password_callback(pass, PWD_STRLEN, 0, &cb_tmp)) < 0) {
+        BIO_printf(bio_err, "Can't read Password\n");
+        OPENSSL_free(pass);
+        return NULL;
+    }
+    *(pass + l) = '\0';
+
+    return pass;
+}
+
+int set_up_srp_arg(SSL_CTX *ctx, SRP_ARG *srp_arg, int srp_lateuser, int c_msg,
+                   int c_debug)
+{
+    if (!srp_lateuser && !SSL_CTX_set_srp_username(ctx, srp_arg->srplogin)) {
+        BIO_printf(bio_err, "Unable to set SRP username\n");
+        return 0;
+    }
+    srp_arg->msg = c_msg;
+    srp_arg->debug = c_debug;
+    SSL_CTX_set_srp_cb_arg(ctx, &srp_arg);
+    SSL_CTX_set_srp_client_pwd_callback(ctx, ssl_give_srp_client_pwd_cb);
+    SSL_CTX_set_srp_strength(ctx, srp_arg->strength);
+    if (c_msg || c_debug || srp_arg->amp == 0)
+        SSL_CTX_set_srp_verify_param_callback(ctx, ssl_srp_verify_param_cb);
+
+    return 1;
+}
+
+/*
+ * This callback pretends to require some asynchronous logic in order to
+ * obtain a verifier. When the callback is called for a new connection we
+ * return with a negative value. This will provoke the accept etc to return
+ * with an LOOKUP_X509. The main logic of the reinvokes the suspended call
+ * (which would normally occur after a worker has finished) and we set the
+ * user parameters.
+ */
+static int ssl_srp_server_param_cb(SSL *s, int *ad, void *arg)
+{
+    srpsrvparm *p = (srpsrvparm *) arg;
+    int ret = SSL3_AL_FATAL;
+
+    if (p->login == NULL && p->user == NULL) {
+        p->login = SSL_get_srp_username(s);
+        BIO_printf(bio_err, "SRP username = \"%s\"\n", p->login);
+        return -1;
+    }
+
+    if (p->user == NULL) {
+        BIO_printf(bio_err, "User %s doesn't exist\n", p->login);
+        goto err;
+    }
+
+    if (SSL_set_srp_server_param
+        (s, p->user->N, p->user->g, p->user->s, p->user->v,
+         p->user->info) < 0) {
+        *ad = SSL_AD_INTERNAL_ERROR;
+        goto err;
+    }
+    BIO_printf(bio_err,
+               "SRP parameters set: username = \"%s\" info=\"%s\" \n",
+               p->login, p->user->info);
+    ret = SSL_ERROR_NONE;
+
+ err:
+    SRP_user_pwd_free(p->user);
+    p->user = NULL;
+    p->login = NULL;
+    return ret;
+}
+
+int set_up_srp_verifier_file(SSL_CTX *ctx, srpsrvparm *srp_callback_parm,
+                             char *srpuserseed, char *srp_verifier_file)
+{
+    int ret;
+
+    srp_callback_parm->vb = SRP_VBASE_new(srpuserseed);
+    srp_callback_parm->user = NULL;
+    srp_callback_parm->login = NULL;
+
+    if (srp_callback_parm->vb == NULL) {
+        BIO_printf(bio_err, "Failed to initialize SRP verifier file \n");
+        return 0;
+    }
+    if ((ret =
+            SRP_VBASE_init(srp_callback_parm->vb,
+                           srp_verifier_file)) != SRP_NO_ERROR) {
+        BIO_printf(bio_err,
+                    "Cannot initialize SRP verifier file \"%s\":ret=%d\n",
+                    srp_verifier_file, ret);
+        return 0;
+    }
+    SSL_CTX_set_verify(ctx, SSL_VERIFY_NONE, verify_callback);
+    SSL_CTX_set_srp_cb_arg(ctx, &srp_callback_parm);
+    SSL_CTX_set_srp_username_callback(ctx, ssl_srp_server_param_cb);
+
+    return 1;
+}
+
+void lookup_srp_user(srpsrvparm *srp_callback_parm, BIO *bio_s_out)
+{
+    SRP_user_pwd_free(srp_callback_parm->user);
+    srp_callback_parm->user = SRP_VBASE_get1_by_user(srp_callback_parm->vb,
+                                                     srp_callback_parm->login);
+
+    if (srp_callback_parm->user != NULL)
+        BIO_printf(bio_s_out, "LOOKUP done %s\n",
+                    srp_callback_parm->user->info);
+    else
+        BIO_printf(bio_s_out, "LOOKUP not successful\n");
+}

--- a/apps/lib/tlssrp_depr.c
+++ b/apps/lib/tlssrp_depr.c
@@ -10,7 +10,7 @@
 
 /*
  * This file is to enable backwards compatibility for the SRP features of
- * s_client and s_server. All of those features are deprecated and will
+ * s_client, s_server and ciphers. All of those features are deprecated and will
  * eventually disappear. In the meantime, to continue to support them, we
  * need to access deprecated SRP APIs.
  */
@@ -135,6 +135,16 @@ int set_up_srp_arg(SSL_CTX *ctx, SRP_ARG *srp_arg, int srp_lateuser, int c_msg,
         SSL_CTX_set_srp_verify_param_callback(ctx, ssl_srp_verify_param_cb);
 
     return 1;
+}
+
+static char *dummy_srp(SSL *ssl, void *arg)
+{
+    return "";
+}
+
+void set_up_dummy_srp(SSL_CTX *ctx)
+{
+        SSL_CTX_set_srp_client_pwd_callback(ctx, dummy_srp);
 }
 
 /*

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -40,9 +40,6 @@ typedef unsigned int u_int;
 #include <openssl/bn.h>
 #include <openssl/trace.h>
 #include <openssl/async.h>
-#ifndef OPENSSL_NO_SRP
-# include <openssl/srp.h>
-#endif
 #ifndef OPENSSL_NO_CT
 # include <openssl/ct.h>
 #endif
@@ -237,115 +234,6 @@ static int ssl_servername_cb(SSL *s, int *ad, void *arg)
 
     return SSL_TLSEXT_ERR_OK;
 }
-
-#ifndef OPENSSL_NO_SRP
-
-/* This is a context that we pass to all callbacks */
-typedef struct srp_arg_st {
-    char *srppassin;
-    char *srplogin;
-    int msg;                    /* copy from c_msg */
-    int debug;                  /* copy from c_debug */
-    int amp;                    /* allow more groups */
-    int strength;               /* minimal size for N */
-} SRP_ARG;
-
-static int srp_Verify_N_and_g(const BIGNUM *N, const BIGNUM *g)
-{
-    BN_CTX *bn_ctx = BN_CTX_new();
-    BIGNUM *p = BN_new();
-    BIGNUM *r = BN_new();
-    int ret =
-        g != NULL && N != NULL && bn_ctx != NULL && BN_is_odd(N) &&
-        BN_check_prime(N, bn_ctx, NULL) == 1 &&
-        p != NULL && BN_rshift1(p, N) &&
-        /* p = (N-1)/2 */
-        BN_check_prime(p, bn_ctx, NULL) == 1 &&
-        r != NULL &&
-        /* verify g^((N-1)/2) == -1 (mod N) */
-        BN_mod_exp(r, g, p, N, bn_ctx) &&
-        BN_add_word(r, 1) && BN_cmp(r, N) == 0;
-
-    BN_free(r);
-    BN_free(p);
-    BN_CTX_free(bn_ctx);
-    return ret;
-}
-
-/*-
- * This callback is used here for two purposes:
- * - extended debugging
- * - making some primality tests for unknown groups
- * The callback is only called for a non default group.
- *
- * An application does not need the call back at all if
- * only the standard groups are used.  In real life situations,
- * client and server already share well known groups,
- * thus there is no need to verify them.
- * Furthermore, in case that a server actually proposes a group that
- * is not one of those defined in RFC 5054, it is more appropriate
- * to add the group to a static list and then compare since
- * primality tests are rather cpu consuming.
- */
-
-static int ssl_srp_verify_param_cb(SSL *s, void *arg)
-{
-    SRP_ARG *srp_arg = (SRP_ARG *)arg;
-    BIGNUM *N = NULL, *g = NULL;
-
-    if (((N = SSL_get_srp_N(s)) == NULL) || ((g = SSL_get_srp_g(s)) == NULL))
-        return 0;
-    if (srp_arg->debug || srp_arg->msg || srp_arg->amp == 1) {
-        BIO_printf(bio_err, "SRP parameters:\n");
-        BIO_printf(bio_err, "\tN=");
-        BN_print(bio_err, N);
-        BIO_printf(bio_err, "\n\tg=");
-        BN_print(bio_err, g);
-        BIO_printf(bio_err, "\n");
-    }
-
-    if (SRP_check_known_gN_param(g, N))
-        return 1;
-
-    if (srp_arg->amp == 1) {
-        if (srp_arg->debug)
-            BIO_printf(bio_err,
-                       "SRP param N and g are not known params, going to check deeper.\n");
-
-        /*
-         * The srp_moregroups is a real debugging feature. Implementors
-         * should rather add the value to the known ones. The minimal size
-         * has already been tested.
-         */
-        if (BN_num_bits(g) <= BN_BITS && srp_Verify_N_and_g(N, g))
-            return 1;
-    }
-    BIO_printf(bio_err, "SRP param N and g rejected.\n");
-    return 0;
-}
-
-# define PWD_STRLEN 1024
-
-static char *ssl_give_srp_client_pwd_cb(SSL *s, void *arg)
-{
-    SRP_ARG *srp_arg = (SRP_ARG *)arg;
-    char *pass = app_malloc(PWD_STRLEN + 1, "SRP password buffer");
-    PW_CB_DATA cb_tmp;
-    int l;
-
-    cb_tmp.password = (char *)srp_arg->srppassin;
-    cb_tmp.prompt_info = "SRP user";
-    if ((l = password_callback(pass, PWD_STRLEN, 0, &cb_tmp)) < 0) {
-        BIO_printf(bio_err, "Can't read Password\n");
-        OPENSSL_free(pass);
-        return NULL;
-    }
-    *(pass + l) = '\0';
-
-    return pass;
-}
-
-#endif
 
 #ifndef OPENSSL_NO_NEXTPROTONEG
 /* This the context that we pass to next_proto_cb */
@@ -767,13 +655,14 @@ const OPTIONS s_client_options[] = {
      "Offer SRTP key management with a colon-separated profile list"},
 #endif
 #ifndef OPENSSL_NO_SRP
-    {"srpuser", OPT_SRPUSER, 's', "SRP authentication for 'user'"},
-    {"srppass", OPT_SRPPASS, 's', "Password for 'user'"},
+    {"srpuser", OPT_SRPUSER, 's', "(deprecated) SRP authentication for 'user'"},
+    {"srppass", OPT_SRPPASS, 's', "(deprecated) Password for 'user'"},
     {"srp_lateuser", OPT_SRP_LATEUSER, '-',
-     "SRP username into second ClientHello message"},
+     "(deprecated) SRP username into second ClientHello message"},
     {"srp_moregroups", OPT_SRP_MOREGROUPS, '-',
-     "Tolerate other than the known g N values."},
-    {"srp_strength", OPT_SRP_STRENGTH, 'p', "Minimal length in bits for N"},
+     "(deprecated) Tolerate other than the known g N values."},
+    {"srp_strength", OPT_SRP_STRENGTH, 'p',
+     "(deprecated) Minimal length in bits for N"},
 #endif
 
     OPT_R_OPTIONS,
@@ -2001,21 +1890,10 @@ int s_client_main(int argc, char **argv)
         SSL_CTX_set_tlsext_servername_callback(ctx, ssl_servername_cb);
         SSL_CTX_set_tlsext_servername_arg(ctx, &tlsextcbp);
     }
-# ifndef OPENSSL_NO_SRP
-    if (srp_arg.srplogin) {
-        if (!srp_lateuser && !SSL_CTX_set_srp_username(ctx, srp_arg.srplogin)) {
-            BIO_printf(bio_err, "Unable to set SRP username\n");
-            goto end;
-        }
-        srp_arg.msg = c_msg;
-        srp_arg.debug = c_debug;
-        SSL_CTX_set_srp_cb_arg(ctx, &srp_arg);
-        SSL_CTX_set_srp_client_pwd_callback(ctx, ssl_give_srp_client_pwd_cb);
-        SSL_CTX_set_srp_strength(ctx, srp_arg.strength);
-        if (c_msg || c_debug || srp_arg.amp == 0)
-            SSL_CTX_set_srp_verify_param_callback(ctx,
-                                                  ssl_srp_verify_param_cb);
-    }
+#ifndef OPENSSL_NO_SRP
+    if (srp_arg.srplogin != NULL
+            && !set_up_srp_arg(ctx, &srp_arg, srp_lateuser, c_msg, c_debug))
+        goto end;
 # endif
 
     if (dane_tlsa_domain != NULL) {

--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -49,9 +49,6 @@ typedef unsigned int u_int;
 # include <openssl/dh.h>
 #endif
 #include <openssl/rsa.h>
-#ifndef OPENSSL_NO_SRP
-# include <openssl/srp.h>
-#endif
 #include "s_apps.h"
 #include "timeouts.h"
 #ifdef CHARSET_EBCDIC
@@ -230,56 +227,7 @@ static int psk_find_session_cb(SSL *ssl, const unsigned char *identity,
 }
 
 #ifndef OPENSSL_NO_SRP
-/* This is a context that we pass to callbacks */
-typedef struct srpsrvparm_st {
-    char *login;
-    SRP_VBASE *vb;
-    SRP_user_pwd *user;
-} srpsrvparm;
 static srpsrvparm srp_callback_parm;
-
-/*
- * This callback pretends to require some asynchronous logic in order to
- * obtain a verifier. When the callback is called for a new connection we
- * return with a negative value. This will provoke the accept etc to return
- * with an LOOKUP_X509. The main logic of the reinvokes the suspended call
- * (which would normally occur after a worker has finished) and we set the
- * user parameters.
- */
-static int ssl_srp_server_param_cb(SSL *s, int *ad, void *arg)
-{
-    srpsrvparm *p = (srpsrvparm *) arg;
-    int ret = SSL3_AL_FATAL;
-
-    if (p->login == NULL && p->user == NULL) {
-        p->login = SSL_get_srp_username(s);
-        BIO_printf(bio_err, "SRP username = \"%s\"\n", p->login);
-        return -1;
-    }
-
-    if (p->user == NULL) {
-        BIO_printf(bio_err, "User %s doesn't exist\n", p->login);
-        goto err;
-    }
-
-    if (SSL_set_srp_server_param
-        (s, p->user->N, p->user->g, p->user->s, p->user->v,
-         p->user->info) < 0) {
-        *ad = SSL_AD_INTERNAL_ERROR;
-        goto err;
-    }
-    BIO_printf(bio_err,
-               "SRP parameters set: username = \"%s\" info=\"%s\" \n",
-               p->login, p->user->info);
-    ret = SSL_ERROR_NONE;
-
- err:
-    SRP_user_pwd_free(p->user);
-    p->user = NULL;
-    p->login = NULL;
-    return ret;
-}
-
 #endif
 
 static int local_argc = 0;
@@ -926,9 +874,9 @@ const OPTIONS s_server_options[] = {
     {"psk", OPT_PSK, 's', "PSK in hex (without 0x)"},
     {"psk_session", OPT_PSK_SESS, '<', "File to read PSK SSL session from"},
 #ifndef OPENSSL_NO_SRP
-    {"srpvfile", OPT_SRPVFILE, '<', "The verifier file for SRP"},
+    {"srpvfile", OPT_SRPVFILE, '<', "(deprecated) The verifier file for SRP"},
     {"srpuserseed", OPT_SRPUSERSEED, 's',
-     "A seed string for a default user salt"},
+     "(deprecated) A seed string for a default user salt"},
 #endif
 
     OPT_SECTION("Protocol and version"),
@@ -2182,20 +2130,9 @@ int s_server_main(int argc, char *argv[])
 
 #ifndef OPENSSL_NO_SRP
     if (srp_verifier_file != NULL) {
-        srp_callback_parm.vb = SRP_VBASE_new(srpuserseed);
-        srp_callback_parm.user = NULL;
-        srp_callback_parm.login = NULL;
-        if ((ret =
-             SRP_VBASE_init(srp_callback_parm.vb,
-                            srp_verifier_file)) != SRP_NO_ERROR) {
-            BIO_printf(bio_err,
-                       "Cannot initialize SRP verifier file \"%s\":ret=%d\n",
-                       srp_verifier_file, ret);
+        if (!set_up_srp_verifier_file(ctx, &srp_callback_parm, srpuserseed,
+                                      srp_verifier_file))
             goto end;
-        }
-        SSL_CTX_set_verify(ctx, SSL_VERIFY_NONE, verify_callback);
-        SSL_CTX_set_srp_cb_arg(ctx, &srp_callback_parm);
-        SSL_CTX_set_srp_username_callback(ctx, ssl_srp_server_param_cb);
     } else
 #endif
     if (CAfile != NULL) {
@@ -2650,15 +2587,9 @@ static int sv_body(int s, int stype, int prot, unsigned char *context)
 #ifndef OPENSSL_NO_SRP
                 while (SSL_get_error(con, k) == SSL_ERROR_WANT_X509_LOOKUP) {
                     BIO_printf(bio_s_out, "LOOKUP renego during write\n");
-                    SRP_user_pwd_free(srp_callback_parm.user);
-                    srp_callback_parm.user =
-                        SRP_VBASE_get1_by_user(srp_callback_parm.vb,
-                                               srp_callback_parm.login);
-                    if (srp_callback_parm.user)
-                        BIO_printf(bio_s_out, "LOOKUP done %s\n",
-                                   srp_callback_parm.user->info);
-                    else
-                        BIO_printf(bio_s_out, "LOOKUP not successful\n");
+
+                    lookup_srp_user(&srp_callback_parm, bio_s_out);
+
                     k = SSL_write(con, &(buf[l]), (unsigned int)i);
                 }
 #endif
@@ -2725,15 +2656,9 @@ static int sv_body(int s, int stype, int prot, unsigned char *context)
 #ifndef OPENSSL_NO_SRP
                 while (SSL_get_error(con, i) == SSL_ERROR_WANT_X509_LOOKUP) {
                     BIO_printf(bio_s_out, "LOOKUP renego during read\n");
-                    SRP_user_pwd_free(srp_callback_parm.user);
-                    srp_callback_parm.user =
-                        SRP_VBASE_get1_by_user(srp_callback_parm.vb,
-                                               srp_callback_parm.login);
-                    if (srp_callback_parm.user)
-                        BIO_printf(bio_s_out, "LOOKUP done %s\n",
-                                   srp_callback_parm.user->info);
-                    else
-                        BIO_printf(bio_s_out, "LOOKUP not successful\n");
+
+                    lookup_srp_user(&srp_callback_parm, bio_s_out);
+
                     i = SSL_read(con, (char *)buf, bufsize);
                 }
 #endif
@@ -2875,15 +2800,9 @@ static int init_ssl_connection(SSL *con)
                    && SSL_get_error(con, i) == SSL_ERROR_WANT_X509_LOOKUP) {
                 BIO_printf(bio_s_out, "LOOKUP during accept %s\n",
                            srp_callback_parm.login);
-                SRP_user_pwd_free(srp_callback_parm.user);
-                srp_callback_parm.user =
-                    SRP_VBASE_get1_by_user(srp_callback_parm.vb,
-                                           srp_callback_parm.login);
-                if (srp_callback_parm.user)
-                    BIO_printf(bio_s_out, "LOOKUP done %s\n",
-                               srp_callback_parm.user->info);
-                else
-                    BIO_printf(bio_s_out, "LOOKUP not successful\n");
+
+                lookup_srp_user(&srp_callback_parm, bio_s_out);
+
                 i = SSL_accept(con);
                 if (i <= 0)
                     retry = is_retryable(con, i);
@@ -3099,15 +3018,9 @@ static int www_body(int s, int stype, int prot, unsigned char *context)
                 if (BIO_should_io_special(io)
                     && BIO_get_retry_reason(io) == BIO_RR_SSL_X509_LOOKUP) {
                     BIO_printf(bio_s_out, "LOOKUP renego during read\n");
-                    SRP_user_pwd_free(srp_callback_parm.user);
-                    srp_callback_parm.user =
-                        SRP_VBASE_get1_by_user(srp_callback_parm.vb,
-                                               srp_callback_parm.login);
-                    if (srp_callback_parm.user)
-                        BIO_printf(bio_s_out, "LOOKUP done %s\n",
-                                   srp_callback_parm.user->info);
-                    else
-                        BIO_printf(bio_s_out, "LOOKUP not successful\n");
+
+                    lookup_srp_user(&srp_callback_parm, bio_s_out);
+
                     continue;
                 }
 #endif
@@ -3511,15 +3424,9 @@ static int rev_body(int s, int stype, int prot, unsigned char *context)
         if (BIO_should_io_special(io)
             && BIO_get_retry_reason(io) == BIO_RR_SSL_X509_LOOKUP) {
             BIO_printf(bio_s_out, "LOOKUP renego during accept\n");
-            SRP_user_pwd_free(srp_callback_parm.user);
-            srp_callback_parm.user =
-                SRP_VBASE_get1_by_user(srp_callback_parm.vb,
-                                       srp_callback_parm.login);
-            if (srp_callback_parm.user)
-                BIO_printf(bio_s_out, "LOOKUP done %s\n",
-                           srp_callback_parm.user->info);
-            else
-                BIO_printf(bio_s_out, "LOOKUP not successful\n");
+
+            lookup_srp_user(&srp_callback_parm, bio_s_out);
+
             continue;
         }
 #endif
@@ -3540,15 +3447,9 @@ static int rev_body(int s, int stype, int prot, unsigned char *context)
                 if (BIO_should_io_special(io)
                     && BIO_get_retry_reason(io) == BIO_RR_SSL_X509_LOOKUP) {
                     BIO_printf(bio_s_out, "LOOKUP renego during read\n");
-                    SRP_user_pwd_free(srp_callback_parm.user);
-                    srp_callback_parm.user =
-                        SRP_VBASE_get1_by_user(srp_callback_parm.vb,
-                                               srp_callback_parm.login);
-                    if (srp_callback_parm.user)
-                        BIO_printf(bio_s_out, "LOOKUP done %s\n",
-                                   srp_callback_parm.user->info);
-                    else
-                        BIO_printf(bio_s_out, "LOOKUP not successful\n");
+
+                    lookup_srp_user(&srp_callback_parm, bio_s_out);
+
                     continue;
                 }
 #endif

--- a/apps/srp.c
+++ b/apps/srp.c
@@ -11,6 +11,9 @@
  * for the EdelKey project.
  */
 
+/* SRP is deprecated, so we're going to have to use some deprecated APIs */
+#define OPENSSL_SUPPRESS_DEPRECATED
+
 #include <openssl/opensslconf.h>
 
 #include <stdio.h>

--- a/crypto/srp/srp_lib.c
+++ b/crypto/srp/srp_lib.c
@@ -11,11 +11,8 @@
  * for the EdelKey project.
  */
 
-/*
- * SRP low level APIs are deprecated for public use, but still ok for
- * internal use.
- */
-#include "internal/deprecated.h"
+/* All the SRP APIs in this file are deprecated */
+#define OPENSSL_SUPPRESS_DEPRECATED
 
 #ifndef OPENSSL_NO_SRP
 # include "internal/cryptlib.h"

--- a/crypto/srp/srp_lib.c
+++ b/crypto/srp/srp_lib.c
@@ -11,6 +11,12 @@
  * for the EdelKey project.
  */
 
+/*
+ * SRP low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #ifndef OPENSSL_NO_SRP
 # include "internal/cryptlib.h"
 # include <openssl/sha.h>

--- a/crypto/srp/srp_vfy.c
+++ b/crypto/srp/srp_vfy.c
@@ -11,11 +11,8 @@
  * for the EdelKey project.
  */
 
-/*
- * SRP low level APIs are deprecated for public use, but still ok for
- * internal use.
- */
-#include "internal/deprecated.h"
+/* All the SRP APIs in this file are deprecated */
+#define OPENSSL_SUPPRESS_DEPRECATED
 
 #ifndef OPENSSL_NO_SRP
 # include "internal/cryptlib.h"

--- a/crypto/srp/srp_vfy.c
+++ b/crypto/srp/srp_vfy.c
@@ -11,6 +11,12 @@
  * for the EdelKey project.
  */
 
+/*
+ * SRP low level APIs are deprecated for public use, but still ok for
+ * internal use.
+ */
+#include "internal/deprecated.h"
+
 #ifndef OPENSSL_NO_SRP
 # include "internal/cryptlib.h"
 # include "crypto/evp.h"

--- a/doc/man1/openssl-ciphers.pod.in
+++ b/doc/man1/openssl-ciphers.pod.in
@@ -67,7 +67,8 @@ When combined with B<-s> includes cipher suites which require PSK.
 
 =item B<-srp>
 
-When combined with B<-s> includes cipher suites which require SRP.
+When combined with B<-s> includes cipher suites which require SRP. This option
+is deprecated.
 
 =item B<-v>
 

--- a/doc/man1/openssl-s_client.pod.in
+++ b/doc/man1/openssl-s_client.pod.in
@@ -752,23 +752,24 @@ Offer SRTP key management, where B<value> is a colon-separated profile list.
 
 =item B<-srpuser> I<value>
 
-Set the SRP username to the specified value.
+Set the SRP username to the specified value. This option is deprecated.
 
 =item B<-srppass> I<value>
 
-Set the SRP password to the specified value.
+Set the SRP password to the specified value. This option is deprecated.
 
 =item B<-srp_lateuser>
 
-SRP username for the second ClientHello message.
+SRP username for the second ClientHello message. This option is deprecated.
 
-=item B<-srp_moregroups>
+=item B<-srp_moregroups>  This option is deprecated.
 
 Tolerate other than the known B<g> and B<N> values.
 
 =item B<-srp_strength> I<number>
 
-Set the minimal acceptable length, in bits, for B<N>.
+Set the minimal acceptable length, in bits, for B<N>.  This option is
+deprecated.
 
 {- $OpenSSL::safe::opt_version_item -}
 

--- a/doc/man1/openssl-srp.pod.in
+++ b/doc/man1/openssl-srp.pod.in
@@ -29,9 +29,9 @@ B<openssl srp>
 
 =head1 DESCRIPTION
 
-This command is used to maintain an SRP (secure remote password) file.
-At most one of the B<-add>, B<-modify>, B<-delete>, and B<-list> options
-can be specified.
+This command is deprecated. It is used to maintain an SRP (secure remote
+password) file. At most one of the B<-add>, B<-modify>, B<-delete>, and B<-list>
+options can be specified.
 These options take zero or more usernames as parameters and perform the
 appropriate operation on the SRP file.
 For B<-list>, if no I<user> is given then all users are displayed.

--- a/doc/man1/openssl.pod
+++ b/doc/man1/openssl.pod
@@ -294,7 +294,7 @@ SPKAC printing and generating command.
 
 =item B<srp>
 
-Maintain SRP password file.
+Maintain SRP password file. This command is deprecated.
 
 =item B<storeutl>
 

--- a/doc/man3/SRP_Calc_B.pod
+++ b/doc/man3/SRP_Calc_B.pod
@@ -18,6 +18,10 @@ SRP_Calc_client_key
 
  #include <openssl/srp.h>
 
+Deprecated since OpenSSL 3.0, can be hidden entirely by defining
+B<OPENSSL_API_COMPAT> with a suitable version value, see
+L<openssl_user_macros(7)>:
+
  /* server side .... */
  BIGNUM *SRP_Calc_server_key(const BIGNUM *A, const BIGNUM *v, const BIGNUM *u,
                              const BIGNUM *b, const BIGNUM *N);
@@ -42,6 +46,9 @@ SRP_Calc_client_key
  BIGNUM *SRP_Calc_A(const BIGNUM *a, const BIGNUM *N, const BIGNUM *g);
 
 =head1 DESCRIPTION
+
+All of the functions described on this page are deprecated. There are no
+available replacement functions at this time.
 
 The SRP functions described on this page are used to calculate various
 parameters and keys used by SRP as defined in RFC2945. The server key and I<B>
@@ -74,7 +81,12 @@ L<SRP_user_pwd_new(3)>
 
 =head1 HISTORY
 
-These functions were added in OpenSSL 1.0.1.
+SRP_Calc_B_ex, SRP_Calc_u_ex, SRP_Calc_client_key_ex and SRP_Calc_x_ex were
+introduced in OpenSSL 3.0.
+
+All of the other functions were added in OpenSSL 1.0.1.
+
+All of these functions were deprecated in OpenSSL 3.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/SRP_VBASE_new.pod
+++ b/doc/man3/SRP_VBASE_new.pod
@@ -14,6 +14,10 @@ SRP_VBASE_get_by_user
 
  #include <openssl/srp.h>
 
+Deprecated since OpenSSL 3.0, can be hidden entirely by defining
+B<OPENSSL_API_COMPAT> with a suitable version value, see
+L<openssl_user_macros(7)>:
+
  SRP_VBASE *SRP_VBASE_new(char *seed_key);
  void SRP_VBASE_free(SRP_VBASE *vb);
 
@@ -24,6 +28,9 @@ SRP_VBASE_get_by_user
  SRP_user_pwd *SRP_VBASE_get_by_user(SRP_VBASE *vb, char *username);
 
 =head1 DESCRIPTION
+
+All of the functions described on this page are deprecated. There are no
+available replacement functions at this time.
 
 The SRP_VBASE_new() function allocates a structure to store server side SRP
 verifier information.
@@ -86,6 +93,8 @@ L<SSL_CTX_set_srp_password(3)>
 The SRP_VBASE_add0_user() function was added in OpenSSL 3.0.
 
 All other functions were added in OpenSSL 1.0.1.
+
+All of these functions were deprecated in OpenSSL 3.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/SRP_create_verifier.pod
+++ b/doc/man3/SRP_create_verifier.pod
@@ -14,6 +14,10 @@ SRP_get_default_gN
 
  #include <openssl/srp.h>
 
+Deprecated since OpenSSL 3.0, can be hidden entirely by defining
+B<OPENSSL_API_COMPAT> with a suitable version value, see
+L<openssl_user_macros(7)>:
+
  int SRP_create_verifier_BN_ex(const char *user, const char *pass, BIGNUM **salt,
                                BIGNUM **verifier, const BIGNUM *N,
                                const BIGNUM *g, OSSL_LIB_CTX *libctx,
@@ -30,6 +34,9 @@ SRP_get_default_gN
  SRP_gN *SRP_get_default_gN(const char *id);
 
 =head1 DESCRIPTION
+
+All of the functions described on this page are deprecated. There are no
+available replacement functions at this time.
 
 The SRP_create_verifier_BN_ex() function creates an SRP password verifier from
 the supplied parameters as defined in section 2.4 of RFC 5054 using the library
@@ -115,7 +122,10 @@ L<SRP_user_pwd_new(3)>
 
 =head1 HISTORY
 
-These functions were added in OpenSSL 1.0.1.
+SRP_create_verifier_BN_ex() and SRP_create_verifier_ex() were introduced in
+OpenSSL 3.0. All other functions were added in OpenSSL 1.0.1.
+
+All of these functions were deprecated in OpenSSL 3.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/SRP_user_pwd_new.pod
+++ b/doc/man3/SRP_user_pwd_new.pod
@@ -13,6 +13,10 @@ SRP_user_pwd_set0_sv
 
  #include <openssl/srp.h>
 
+Deprecated since OpenSSL 3.0, can be hidden entirely by defining
+B<OPENSSL_API_COMPAT> with a suitable version value, see
+L<openssl_user_macros(7)>:
+
  SRP_user_pwd *SRP_user_pwd_new(void);
  void SRP_user_pwd_free(SRP_user_pwd *user_pwd);
 
@@ -21,6 +25,9 @@ SRP_user_pwd_set0_sv
  int SRP_user_pwd_set0_sv(SRP_user_pwd *user_pwd, BIGNUM *s, BIGNUM *v);
 
 =head1 DESCRIPTION
+
+All of the functions described on this page are deprecated. There are no
+available replacement functions at this time.
 
 The SRP_user_pwd_new() function allocates a structure to store a user verifier
 record.
@@ -56,7 +63,7 @@ L<SSL_CTX_set_srp_password(3)>
 
 =head1 HISTORY
 
-These functions were made public in OpenSSL 3.0.
+These functions were made public in OpenSSL 3.0 and are deprecated.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/SSL_CTX_set_srp_password.pod
+++ b/doc/man3/SSL_CTX_set_srp_password.pod
@@ -21,6 +21,10 @@ SSL_get_srp_userinfo
 
  #include <openssl/ssl.h>
 
+Deprecated since OpenSSL 3.0, can be hidden entirely by defining
+B<OPENSSL_API_COMPAT> with a suitable version value, see
+L<openssl_user_macros(7)>:
+
  int SSL_CTX_set_srp_username(SSL_CTX *ctx, char *name);
  int SSL_CTX_set_srp_password(SSL_CTX *ctx, char *password);
  int SSL_CTX_set_srp_strength(SSL_CTX *ctx, int strength);
@@ -44,6 +48,9 @@ SSL_get_srp_userinfo
  char *SSL_get_srp_userinfo(SSL *s);
 
 =head1 DESCRIPTION
+
+All of the functions described on this page are deprecated. There are no
+available replacement functions at this time.
 
 These functions provide access to SRP (Secure Remote Password) parameters,
 an alternate authentication mechanism for TLS. SRP allows the use of usernames
@@ -203,7 +210,7 @@ L<SRP_create_verifier(3)>
 
 =head1 HISTORY
 
-These functions were added in OpenSSL 1.0.1.
+These functions were added in OpenSSL 1.0.1 and deprecated in OpenSSL 3.0.
 
 =head1 COPYRIGHT
 

--- a/include/openssl/srp.h.in
+++ b/include/openssl/srp.h.in
@@ -39,6 +39,8 @@ use OpenSSL::stackhash qw(generate_stack_macros);
 extern "C" {
 # endif
 
+# ifndef OPENSSL_NO_DEPRECATED_3_0
+
 typedef struct SRP_gN_cache_st {
     char *b64_bn;
     BIGNUM *bn;
@@ -63,11 +65,18 @@ typedef struct SRP_user_pwd_st {
     generate_stack_macros("SRP_user_pwd");
 -}
 
+OSSL_DEPRECATEDIN_3_0
 SRP_user_pwd *SRP_user_pwd_new(void);
+OSSL_DEPRECATEDIN_3_0
 void SRP_user_pwd_free(SRP_user_pwd *user_pwd);
 
-void SRP_user_pwd_set_gN(SRP_user_pwd *user_pwd, const BIGNUM *g, const BIGNUM *N);
-int SRP_user_pwd_set1_ids(SRP_user_pwd *user_pwd, const char *id, const char *info);
+OSSL_DEPRECATEDIN_3_0
+void SRP_user_pwd_set_gN(SRP_user_pwd *user_pwd, const BIGNUM *g,
+                         const BIGNUM *N);
+OSSL_DEPRECATEDIN_3_0
+int SRP_user_pwd_set1_ids(SRP_user_pwd *user_pwd, const char *id,
+                          const char *info);
+OSSL_DEPRECATEDIN_3_0
 int SRP_user_pwd_set0_sv(SRP_user_pwd *user_pwd, BIGNUM *s, BIGNUM *v);
 
 typedef struct SRP_VBASE_st {
@@ -92,81 +101,108 @@ typedef struct SRP_gN_st {
 -}
 
 
+OSSL_DEPRECATEDIN_3_0
 SRP_VBASE *SRP_VBASE_new(char *seed_key);
+OSSL_DEPRECATEDIN_3_0
 void SRP_VBASE_free(SRP_VBASE *vb);
+OSSL_DEPRECATEDIN_3_0
 int SRP_VBASE_init(SRP_VBASE *vb, char *verifier_file);
 
+OSSL_DEPRECATEDIN_3_0
 int SRP_VBASE_add0_user(SRP_VBASE *vb, SRP_user_pwd *user_pwd);
 /* This method ignores the configured seed and fails for an unknown user. */
-# ifndef OPENSSL_NO_DEPRECATED_1_1_0
+#  ifndef OPENSSL_NO_DEPRECATED_1_1_0
 OSSL_DEPRECATEDIN_1_1_0
 SRP_user_pwd *SRP_VBASE_get_by_user(SRP_VBASE *vb, char *username);
-# endif
+#  endif
 /* NOTE: unlike in SRP_VBASE_get_by_user, caller owns the returned pointer.*/
+OSSL_DEPRECATEDIN_3_0
 SRP_user_pwd *SRP_VBASE_get1_by_user(SRP_VBASE *vb, char *username);
 
+OSSL_DEPRECATEDIN_3_0
 char *SRP_create_verifier_ex(const char *user, const char *pass, char **salt,
                              char **verifier, const char *N, const char *g,
                              OSSL_LIB_CTX *libctx, const char *propq);
+OSSL_DEPRECATEDIN_3_0
 char *SRP_create_verifier(const char *user, const char *pass, char **salt,
                           char **verifier, const char *N, const char *g);
+OSSL_DEPRECATEDIN_3_0
 int SRP_create_verifier_BN_ex(const char *user, const char *pass, BIGNUM **salt,
                               BIGNUM **verifier, const BIGNUM *N,
                               const BIGNUM *g, OSSL_LIB_CTX *libctx,
                               const char *propq);
+OSSL_DEPRECATEDIN_3_0
 int SRP_create_verifier_BN(const char *user, const char *pass, BIGNUM **salt,
                            BIGNUM **verifier, const BIGNUM *N,
                            const BIGNUM *g);
 
-# define SRP_NO_ERROR 0
-# define SRP_ERR_VBASE_INCOMPLETE_FILE 1
-# define SRP_ERR_VBASE_BN_LIB 2
-# define SRP_ERR_OPEN_FILE 3
-# define SRP_ERR_MEMORY 4
+#  define SRP_NO_ERROR 0
+#  define SRP_ERR_VBASE_INCOMPLETE_FILE 1
+#  define SRP_ERR_VBASE_BN_LIB 2
+#  define SRP_ERR_OPEN_FILE 3
+#  define SRP_ERR_MEMORY 4
 
-# define DB_srptype      0
-# define DB_srpverifier  1
-# define DB_srpsalt      2
-# define DB_srpid        3
-# define DB_srpgN        4
-# define DB_srpinfo      5
-# undef  DB_NUMBER
-# define DB_NUMBER       6
+#  define DB_srptype      0
+#  define DB_srpverifier  1
+#  define DB_srpsalt      2
+#  define DB_srpid        3
+#  define DB_srpgN        4
+#  define DB_srpinfo      5
+#  undef  DB_NUMBER
+#  define DB_NUMBER       6
 
-# define DB_SRP_INDEX    'I'
-# define DB_SRP_VALID    'V'
-# define DB_SRP_REVOKED  'R'
-# define DB_SRP_MODIF    'v'
+#  define DB_SRP_INDEX    'I'
+#  define DB_SRP_VALID    'V'
+#  define DB_SRP_REVOKED  'R'
+#  define DB_SRP_MODIF    'v'
 
 /* see srp.c */
+OSSL_DEPRECATEDIN_3_0
 char *SRP_check_known_gN_param(const BIGNUM *g, const BIGNUM *N);
+OSSL_DEPRECATEDIN_3_0
 SRP_gN *SRP_get_default_gN(const char *id);
 
 /* server side .... */
+OSSL_DEPRECATEDIN_3_0
 BIGNUM *SRP_Calc_server_key(const BIGNUM *A, const BIGNUM *v, const BIGNUM *u,
                             const BIGNUM *b, const BIGNUM *N);
+OSSL_DEPRECATEDIN_3_0
 BIGNUM *SRP_Calc_B_ex(const BIGNUM *b, const BIGNUM *N, const BIGNUM *g,
                       const BIGNUM *v, OSSL_LIB_CTX *libctx, const char *propq);
+OSSL_DEPRECATEDIN_3_0
 BIGNUM *SRP_Calc_B(const BIGNUM *b, const BIGNUM *N, const BIGNUM *g,
                    const BIGNUM *v);
+
+OSSL_DEPRECATEDIN_3_0
 int SRP_Verify_A_mod_N(const BIGNUM *A, const BIGNUM *N);
+OSSL_DEPRECATEDIN_3_0
 BIGNUM *SRP_Calc_u_ex(const BIGNUM *A, const BIGNUM *B, const BIGNUM *N,
                       OSSL_LIB_CTX *libctx, const char *propq);
+OSSL_DEPRECATEDIN_3_0
 BIGNUM *SRP_Calc_u(const BIGNUM *A, const BIGNUM *B, const BIGNUM *N);
 
 /* client side .... */
+
+OSSL_DEPRECATEDIN_3_0
 BIGNUM *SRP_Calc_x_ex(const BIGNUM *s, const char *user, const char *pass,
                       OSSL_LIB_CTX *libctx, const char *propq);
+OSSL_DEPRECATEDIN_3_0
 BIGNUM *SRP_Calc_x(const BIGNUM *s, const char *user, const char *pass);
+OSSL_DEPRECATEDIN_3_0
 BIGNUM *SRP_Calc_A(const BIGNUM *a, const BIGNUM *N, const BIGNUM *g);
+OSSL_DEPRECATEDIN_3_0
 BIGNUM *SRP_Calc_client_key_ex(const BIGNUM *N, const BIGNUM *B, const BIGNUM *g,
                             const BIGNUM *x, const BIGNUM *a, const BIGNUM *u,
                             OSSL_LIB_CTX *libctx, const char *propq);
+OSSL_DEPRECATEDIN_3_0
 BIGNUM *SRP_Calc_client_key(const BIGNUM *N, const BIGNUM *B, const BIGNUM *g,
                             const BIGNUM *x, const BIGNUM *a, const BIGNUM *u);
+OSSL_DEPRECATEDIN_3_0
 int SRP_Verify_B_mod_N(const BIGNUM *B, const BIGNUM *N);
 
-# define SRP_MINIMAL_N 1024
+#  define SRP_MINIMAL_N 1024
+
+# endif /* OPENSSL_NO_DEPRECATED_3_0 */
 
 # ifdef  __cplusplus
 }

--- a/include/openssl/srp.h.in
+++ b/include/openssl/srp.h.in
@@ -110,11 +110,7 @@ int SRP_VBASE_init(SRP_VBASE *vb, char *verifier_file);
 
 OSSL_DEPRECATEDIN_3_0
 int SRP_VBASE_add0_user(SRP_VBASE *vb, SRP_user_pwd *user_pwd);
-/* This method ignores the configured seed and fails for an unknown user. */
-#  ifndef OPENSSL_NO_DEPRECATED_1_1_0
-OSSL_DEPRECATEDIN_1_1_0
-SRP_user_pwd *SRP_VBASE_get_by_user(SRP_VBASE *vb, char *username);
-#  endif
+
 /* NOTE: unlike in SRP_VBASE_get_by_user, caller owns the returned pointer.*/
 OSSL_DEPRECATEDIN_3_0
 SRP_user_pwd *SRP_VBASE_get1_by_user(SRP_VBASE *vb, char *username);
@@ -203,6 +199,12 @@ int SRP_Verify_B_mod_N(const BIGNUM *B, const BIGNUM *N);
 #  define SRP_MINIMAL_N 1024
 
 # endif /* OPENSSL_NO_DEPRECATED_3_0 */
+
+/* This method ignores the configured seed and fails for an unknown user. */
+# ifndef OPENSSL_NO_DEPRECATED_1_1_0
+OSSL_DEPRECATEDIN_1_1_0
+SRP_user_pwd *SRP_VBASE_get_by_user(SRP_VBASE *vb, char *username);
+# endif
 
 # ifdef  __cplusplus
 }

--- a/include/openssl/ssl.h.in
+++ b/include/openssl/ssl.h.in
@@ -666,12 +666,13 @@ void SSL_set_msg_callback(SSL *ssl,
 # ifndef OPENSSL_NO_SRP
 
 /* see tls_srp.c */
-__owur int SSL_SRP_CTX_init(SSL *s);
-__owur int SSL_CTX_SRP_CTX_init(SSL_CTX *ctx);
-int SSL_SRP_CTX_free(SSL *ctx);
-int SSL_CTX_SRP_CTX_free(SSL_CTX *ctx);
-__owur int SSL_srp_server_param_with_username(SSL *s, int *ad);
-__owur int SRP_Calc_A_param(SSL *s);
+OSSL_DEPRECATEDIN_3_0 __owur int SSL_SRP_CTX_init(SSL *s);
+OSSL_DEPRECATEDIN_3_0 __owur int SSL_CTX_SRP_CTX_init(SSL_CTX *ctx);
+OSSL_DEPRECATEDIN_3_0 int SSL_SRP_CTX_free(SSL *ctx);
+OSSL_DEPRECATEDIN_3_0 int SSL_CTX_SRP_CTX_free(SSL_CTX *ctx);
+OSSL_DEPRECATEDIN_3_0 __owur int SSL_srp_server_param_with_username(SSL *s,
+                                                                    int *ad);
+OSSL_DEPRECATEDIN_3_0 __owur int SRP_Calc_A_param(SSL *s);
 
 # endif
 
@@ -1833,27 +1834,32 @@ __owur X509_VERIFY_PARAM *SSL_CTX_get0_param(SSL_CTX *ctx);
 __owur X509_VERIFY_PARAM *SSL_get0_param(SSL *ssl);
 
 # ifndef OPENSSL_NO_SRP
-int SSL_CTX_set_srp_username(SSL_CTX *ctx, char *name);
-int SSL_CTX_set_srp_password(SSL_CTX *ctx, char *password);
-int SSL_CTX_set_srp_strength(SSL_CTX *ctx, int strength);
+OSSL_DEPRECATEDIN_3_0 int SSL_CTX_set_srp_username(SSL_CTX *ctx, char *name);
+OSSL_DEPRECATEDIN_3_0 int SSL_CTX_set_srp_password(SSL_CTX *ctx, char *password);
+OSSL_DEPRECATEDIN_3_0 int SSL_CTX_set_srp_strength(SSL_CTX *ctx, int strength);
+OSSL_DEPRECATEDIN_3_0
 int SSL_CTX_set_srp_client_pwd_callback(SSL_CTX *ctx,
                                         char *(*cb) (SSL *, void *));
+OSSL_DEPRECATEDIN_3_0
 int SSL_CTX_set_srp_verify_param_callback(SSL_CTX *ctx,
                                           int (*cb) (SSL *, void *));
+OSSL_DEPRECATEDIN_3_0
 int SSL_CTX_set_srp_username_callback(SSL_CTX *ctx,
                                       int (*cb) (SSL *, int *, void *));
-int SSL_CTX_set_srp_cb_arg(SSL_CTX *ctx, void *arg);
+OSSL_DEPRECATEDIN_3_0 int SSL_CTX_set_srp_cb_arg(SSL_CTX *ctx, void *arg);
 
+OSSL_DEPRECATEDIN_3_0
 int SSL_set_srp_server_param(SSL *s, const BIGNUM *N, const BIGNUM *g,
                              BIGNUM *sa, BIGNUM *v, char *info);
+OSSL_DEPRECATEDIN_3_0
 int SSL_set_srp_server_param_pw(SSL *s, const char *user, const char *pass,
                                 const char *grp);
 
-__owur BIGNUM *SSL_get_srp_g(SSL *s);
-__owur BIGNUM *SSL_get_srp_N(SSL *s);
+OSSL_DEPRECATEDIN_3_0 __owur BIGNUM *SSL_get_srp_g(SSL *s);
+OSSL_DEPRECATEDIN_3_0 __owur BIGNUM *SSL_get_srp_N(SSL *s);
 
-__owur char *SSL_get_srp_username(SSL *s);
-__owur char *SSL_get_srp_userinfo(SSL *s);
+OSSL_DEPRECATEDIN_3_0 __owur char *SSL_get_srp_username(SSL *s);
+OSSL_DEPRECATEDIN_3_0 __owur char *SSL_get_srp_userinfo(SSL *s);
 # endif
 
 /*

--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -3330,7 +3330,7 @@ int ssl3_handshake_write(SSL *s)
 int ssl3_new(SSL *s)
 {
 #ifndef OPENSSL_NO_SRP
-    if (!SSL_SRP_CTX_init(s))
+    if (!ssl_srp_ctx_init_intern(s))
         return 0;
 #endif
 
@@ -3366,7 +3366,7 @@ void ssl3_free(SSL *s)
     OPENSSL_free(s->s3.alpn_proposed);
 
 #ifndef OPENSSL_NO_SRP
-    SSL_SRP_CTX_free(s);
+    ssl_srp_ctx_free_intern(s);
 #endif
     memset(&s->s3, 0, sizeof(s->s3));
 }

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -3239,7 +3239,7 @@ SSL_CTX *SSL_CTX_new_ex(OSSL_LIB_CTX *libctx, const char *propq,
         goto err;
 
 #ifndef OPENSSL_NO_SRP
-    if (!SSL_CTX_SRP_CTX_init(ret))
+    if (!ssl_ctx_srp_ctx_init_intern(ret))
         goto err;
 #endif
 #ifndef OPENSSL_NO_ENGINE
@@ -3382,7 +3382,7 @@ void SSL_CTX_free(SSL_CTX *a)
     sk_SRTP_PROTECTION_PROFILE_free(a->srtp_profiles);
 #endif
 #ifndef OPENSSL_NO_SRP
-    SSL_CTX_SRP_CTX_free(a);
+    ssl_ctx_srp_ctx_free_intern(a);
 #endif
 #ifndef OPENSSL_NO_ENGINE
     tls_engine_finish(a->client_cert_engine);

--- a/ssl/ssl_local.h
+++ b/ssl/ssl_local.h
@@ -2829,6 +2829,14 @@ int ssl_hmac_old_update(SSL_HMAC *ctx, const unsigned char *data, size_t len);
 int ssl_hmac_old_final(SSL_HMAC *ctx, unsigned char *md, size_t *len);
 size_t ssl_hmac_old_size(const SSL_HMAC *ctx);
 
+int ssl_ctx_srp_ctx_free_intern(SSL_CTX *ctx);
+int ssl_ctx_srp_ctx_init_intern(SSL_CTX *ctx);
+int ssl_srp_ctx_free_intern(SSL *s);
+int ssl_srp_ctx_init_intern(SSL *s);
+
+int ssl_srp_calc_a_param_intern(SSL *s);
+int ssl_srp_server_param_with_username_intern(SSL *s, int *ad);
+
 # else /* OPENSSL_UNIT_TEST */
 
 #  define ssl_init_wbio_buffer SSL_test_functions()->p_ssl_init_wbio_buffer

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -2717,7 +2717,7 @@ MSG_PROCESS_RETURN tls_process_server_done(SSL *s, PACKET *pkt)
     }
 #ifndef OPENSSL_NO_SRP
     if (s->s3.tmp.new_cipher->algorithm_mkey & SSL_kSRP) {
-        if (SRP_Calc_A_param(s) <= 0) {
+        if (ssl_srp_calc_a_param_intern(s) <= 0) {
             SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_R_SRP_A_CALC);
             return MSG_PROCESS_ERROR;
         }

--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -1258,7 +1258,7 @@ static int ssl_check_srp_ext_ClientHello(SSL *s)
                      SSL_R_PSK_IDENTITY_NOT_FOUND);
             return -1;
         } else {
-            ret = SSL_srp_server_param_with_username(s, &al);
+            ret = ssl_srp_server_param_with_username_intern(s, &al);
             if (ret < 0)
                 return 0;
             if (ret == SSL3_AL_FATAL) {

--- a/ssl/tls_srp.c
+++ b/ssl/tls_srp.c
@@ -11,6 +11,9 @@
  * for the EdelKey project.
  */
 
+/* We need to use the SRP deprecated APIs */
+#define OPENSSL_SUPPRESS_DEPRECATED
+
 #include <openssl/crypto.h>
 #include <openssl/rand.h>
 #include <openssl/err.h>

--- a/ssl/tls_srp.c
+++ b/ssl/tls_srp.c
@@ -11,7 +11,10 @@
  * for the EdelKey project.
  */
 
-/* We need to use the SRP deprecated APIs */
+/*
+ * We need to use the SRP deprecated APIs in order to implement the SSL SRP
+ * APIs - which are themselves deprecated.
+ */
 #define OPENSSL_SUPPRESS_DEPRECATED
 
 #include <openssl/crypto.h>
@@ -22,7 +25,11 @@
 #ifndef OPENSSL_NO_SRP
 # include <openssl/srp.h>
 
-int SSL_CTX_SRP_CTX_free(struct ssl_ctx_st *ctx)
+/*
+ * The public API SSL_CTX_SRP_CTX_free() is deprecated so we use
+ * ssl_ctx_srp_ctx_free_intern() internally.
+ */
+int ssl_ctx_srp_ctx_free_intern(SSL_CTX *ctx)
 {
     if (ctx == NULL)
         return 0;
@@ -41,7 +48,16 @@ int SSL_CTX_SRP_CTX_free(struct ssl_ctx_st *ctx)
     return 1;
 }
 
-int SSL_SRP_CTX_free(struct ssl_st *s)
+int SSL_CTX_SRP_CTX_free(SSL_CTX *ctx)
+{
+    return ssl_ctx_srp_ctx_free_intern(ctx);
+}
+
+/*
+ * The public API SSL_SRP_CTX_free() is deprecated so we use
+ * ssl_srp_ctx_free_intern() internally.
+ */
+int ssl_srp_ctx_free_intern(SSL *s)
 {
     if (s == NULL)
         return 0;
@@ -60,7 +76,16 @@ int SSL_SRP_CTX_free(struct ssl_st *s)
     return 1;
 }
 
-int SSL_SRP_CTX_init(struct ssl_st *s)
+int SSL_SRP_CTX_free(SSL *s)
+{
+    return ssl_srp_ctx_free_intern(s);
+}
+
+/*
+ * The public API SSL_SRP_CTX_init() is deprecated so we use
+ * ssl_srp_ctx_init_intern() internally.
+ */
+int ssl_srp_ctx_init_intern(SSL *s)
 {
     SSL_CTX *ctx;
 
@@ -129,7 +154,16 @@ int SSL_SRP_CTX_init(struct ssl_st *s)
     return 0;
 }
 
-int SSL_CTX_SRP_CTX_init(struct ssl_ctx_st *ctx)
+int SSL_SRP_CTX_init(SSL *s)
+{
+    return ssl_srp_ctx_init_intern(s);
+}
+
+/*
+ * The public API SSL_CTX_SRP_CTX_init() is deprecated so we use
+ * ssl_ctx_srp_ctx_init_intern() internally.
+ */
+int ssl_ctx_srp_ctx_init_intern(SSL_CTX *ctx)
 {
     if (ctx == NULL)
         return 0;
@@ -140,8 +174,17 @@ int SSL_CTX_SRP_CTX_init(struct ssl_ctx_st *ctx)
     return 1;
 }
 
+int SSL_CTX_SRP_CTX_init(SSL_CTX *ctx)
+{
+    return ssl_ctx_srp_ctx_init_intern(ctx);
+}
+
 /* server side */
-int SSL_srp_server_param_with_username(SSL *s, int *ad)
+/*
+ * The public API SSL_srp_server_param_with_username() is deprecated so we use
+ * ssl_srp_server_param_with_username_intern() internally.
+ */
+int ssl_srp_server_param_with_username_intern(SSL *s, int *ad)
 {
     unsigned char b[SSL_MAX_MASTER_KEY_LENGTH];
     int al;
@@ -171,6 +214,11 @@ int SSL_srp_server_param_with_username(SSL *s, int *ad)
              SRP_Calc_B_ex(s->srp_ctx.b, s->srp_ctx.N, s->srp_ctx.g,
                            s->srp_ctx.v, s->ctx->libctx, s->ctx->propq)) !=
             NULL) ? SSL_ERROR_NONE : SSL3_AL_FATAL;
+}
+
+int SSL_srp_server_param_with_username(SSL *s, int *ad)
+{
+    return ssl_srp_server_param_with_username_intern(s, ad);
 }
 
 /*
@@ -364,7 +412,11 @@ int srp_verify_server_param(SSL *s)
     return 1;
 }
 
-int SRP_Calc_A_param(SSL *s)
+/*
+ * The public API SRP_Calc_A_param() is deprecated so we use
+ * ssl_srp_calc_a_param_intern() internally.
+ */
+int ssl_srp_calc_a_param_intern(SSL *s)
 {
     unsigned char rnd[SSL_MAX_MASTER_KEY_LENGTH];
 
@@ -377,6 +429,11 @@ int SRP_Calc_A_param(SSL *s)
         return 0;
 
     return 1;
+}
+
+int SRP_Calc_A_param(SSL *s)
+{
+    return ssl_srp_calc_a_param_intern(s);
 }
 
 BIGNUM *SSL_get_srp_g(SSL *s)

--- a/test/build.info
+++ b/test/build.info
@@ -279,6 +279,9 @@ IF[{- !$disabled{tests} -}]
   DEPEND[ssl_test_ctx_test]=../libcrypto ../libssl libtestutil.a
 
   SOURCE[ssl_test]=ssl_test.c helpers/ssl_test_ctx.c helpers/handshake.c
+  IF[{- !$disabled{'srp'} -}]
+    SOURCE[ssl_test]=helpers/handshake_srp.c
+  ENDIF
   INCLUDE[ssl_test]=../include ../apps/include
   DEPEND[ssl_test]=../libcrypto ../libssl libtestutil.a
 

--- a/test/helpers/handshake.h
+++ b/test/helpers/handshake.h
@@ -12,6 +12,16 @@
 
 #include "ssl_test_ctx.h"
 
+typedef struct ctx_data_st {
+    unsigned char *npn_protocols;
+    size_t npn_protocols_len;
+    unsigned char *alpn_protocols;
+    size_t alpn_protocols_len;
+    char *srp_user;
+    char *srp_password;
+    char *session_ticket_app_data;
+} CTX_DATA;
+
 typedef struct handshake_result {
     ssl_test_result_t result;
     /* These alerts are in the 2-byte format returned by the info_callback. */
@@ -77,5 +87,12 @@ HANDSHAKE_RESULT *do_handshake(SSL_CTX *server_ctx, SSL_CTX *server2_ctx,
                                SSL_CTX *client_ctx, SSL_CTX *resume_server_ctx,
                                SSL_CTX *resume_client_ctx,
                                const SSL_TEST_CTX *test_ctx);
+
+int configure_handshake_ctx_for_srp(SSL_CTX *server_ctx, SSL_CTX *server2_ctx,
+                                    SSL_CTX *client_ctx,
+                                    const SSL_TEST_EXTRA_CONF *extra,
+                                    CTX_DATA *server_ctx_data,
+                                    CTX_DATA *server2_ctx_data,
+                                    CTX_DATA *client_ctx_data);
 
 #endif  /* OSSL_TEST_HANDSHAKE_HELPER_H */

--- a/test/helpers/handshake_srp.c
+++ b/test/helpers/handshake_srp.c
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2016-2021 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+/*
+ * SRP is deprecated and there is no replacent. When SRP is removed, the code in
+ * this file can be removed too. Until then we have to use the deprecated APIs.
+ */
+#define OPENSSL_SUPPRESS_DEPRECATED
+
+#include <openssl/srp.h>
+#include <openssl/ssl.h>
+#include "handshake.h"
+#include "../testutil.h"
+
+static char *client_srp_cb(SSL *s, void *arg)
+{
+    CTX_DATA *ctx_data = (CTX_DATA*)(arg);
+    return OPENSSL_strdup(ctx_data->srp_password);
+}
+
+static int server_srp_cb(SSL *s, int *ad, void *arg)
+{
+    CTX_DATA *ctx_data = (CTX_DATA*)(arg);
+    if (strcmp(ctx_data->srp_user, SSL_get_srp_username(s)) != 0)
+        return SSL3_AL_FATAL;
+    if (SSL_set_srp_server_param_pw(s, ctx_data->srp_user,
+                                    ctx_data->srp_password,
+                                    "2048" /* known group */) < 0) {
+        *ad = SSL_AD_INTERNAL_ERROR;
+        return SSL3_AL_FATAL;
+    }
+    return SSL_ERROR_NONE;
+}
+
+int configure_handshake_ctx_for_srp(SSL_CTX *server_ctx, SSL_CTX *server2_ctx,
+                                    SSL_CTX *client_ctx,
+                                    const SSL_TEST_EXTRA_CONF *extra,
+                                    CTX_DATA *server_ctx_data,
+                                    CTX_DATA *server2_ctx_data,
+                                    CTX_DATA *client_ctx_data)
+{
+    if (extra->server.srp_user != NULL) {
+        SSL_CTX_set_srp_username_callback(server_ctx, server_srp_cb);
+        server_ctx_data->srp_user = OPENSSL_strdup(extra->server.srp_user);
+        server_ctx_data->srp_password = OPENSSL_strdup(extra->server.srp_password);
+        SSL_CTX_set_srp_cb_arg(server_ctx, server_ctx_data);
+    }
+    if (extra->server2.srp_user != NULL) {
+        if (!TEST_ptr(server2_ctx))
+            return 0;
+        SSL_CTX_set_srp_username_callback(server2_ctx, server_srp_cb);
+        server2_ctx_data->srp_user = OPENSSL_strdup(extra->server2.srp_user);
+        server2_ctx_data->srp_password = OPENSSL_strdup(extra->server2.srp_password);
+        SSL_CTX_set_srp_cb_arg(server2_ctx, server2_ctx_data);
+    }
+    if (extra->client.srp_user != NULL) {
+        if (!TEST_true(SSL_CTX_set_srp_username(client_ctx,
+                                                extra->client.srp_user)))
+            return 0;
+        SSL_CTX_set_srp_client_pwd_callback(client_ctx, client_srp_cb);
+        client_ctx_data->srp_password = OPENSSL_strdup(extra->client.srp_password);
+        SSL_CTX_set_srp_cb_arg(client_ctx, client_ctx_data);
+    }
+    return 1;
+}

--- a/test/srptest.c
+++ b/test/srptest.c
@@ -7,6 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * SRP is deprecated, so we're going to have to use some deprecated APIs in
+ * order to test it.
+ */
+#define OPENSSL_SUPPRESS_DEPRECATED
+
 #include <openssl/opensslconf.h>
 # include "testutil.h"
 

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -16,7 +16,7 @@ X509_PUBKEY_set0_param                  15	3_0_0	EXIST::FUNCTION:
 PKCS12_it                               16	3_0_0	EXIST::FUNCTION:
 i2d_ASN1_OCTET_STRING                   17	3_0_0	EXIST::FUNCTION:
 EC_KEY_set_private_key                  18	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,EC
-SRP_VBASE_get_by_user                   19	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_1_1_0,SRP
+SRP_VBASE_get_by_user                   19	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_1_1_0,DEPRECATEDIN_3_0,SRP
 Camellia_cfb128_encrypt                 21	3_0_0	EXIST::FUNCTION:CAMELLIA,DEPRECATEDIN_3_0
 DES_ncbc_encrypt                        22	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,DES
 TS_REQ_get_ext_count                    23	3_0_0	EXIST::FUNCTION:TS
@@ -56,7 +56,7 @@ EVP_MD_do_all_sorted                    57	3_0_0	EXIST::FUNCTION:
 OCSP_crl_reason_str                     58	3_0_0	EXIST::FUNCTION:OCSP
 ENGINE_ctrl_cmd_string                  59	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,ENGINE
 ENGINE_finish                           60	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,ENGINE
-SRP_Calc_client_key                     61	3_0_0	EXIST::FUNCTION:SRP
+SRP_Calc_client_key                     61	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,SRP
 X509_PUBKEY_free                        62	3_0_0	EXIST::FUNCTION:
 BIO_free_all                            63	3_0_0	EXIST::FUNCTION:
 EVP_idea_ofb                            64	3_0_0	EXIST::FUNCTION:IDEA
@@ -328,7 +328,7 @@ d2i_RSAPrivateKey_fp                    333	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3
 s2i_ASN1_IA5STRING                      334	3_0_0	EXIST::FUNCTION:
 UI_get_ex_data                          335	3_0_0	EXIST::FUNCTION:
 EVP_EncryptUpdate                       336	3_0_0	EXIST::FUNCTION:
-SRP_create_verifier                     337	3_0_0	EXIST::FUNCTION:SRP
+SRP_create_verifier                     337	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,SRP
 TS_TST_INFO_print_bio                   338	3_0_0	EXIST::FUNCTION:TS
 X509_NAME_get_index_by_OBJ              339	3_0_0	EXIST::FUNCTION:
 BIO_get_host_ip                         340	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_1_1_0,SOCK
@@ -1373,7 +1373,7 @@ BIO_dump_cb                             1405	3_0_0	EXIST::FUNCTION:
 v2i_GENERAL_NAMES                       1406	3_0_0	EXIST::FUNCTION:
 EVP_des_ede3_ofb                        1407	3_0_0	EXIST::FUNCTION:DES
 EVP_MD_meth_get_cleanup                 1408	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
-SRP_Calc_server_key                     1409	3_0_0	EXIST::FUNCTION:SRP
+SRP_Calc_server_key                     1409	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,SRP
 BN_mod_exp_simple                       1410	3_0_0	EXIST::FUNCTION:
 BIO_set_ex_data                         1411	3_0_0	EXIST::FUNCTION:
 SHA512                                  1412	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
@@ -1504,7 +1504,7 @@ ASN1_INTEGER_set_uint64                 1537	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_get_attr_by_OBJ                1538	3_0_0	EXIST::FUNCTION:
 ASN1_add_oid_module                     1539	3_0_0	EXIST::FUNCTION:
 BN_div_recp                             1540	3_0_0	EXIST::FUNCTION:
-SRP_Verify_B_mod_N                      1541	3_0_0	EXIST::FUNCTION:SRP
+SRP_Verify_B_mod_N                      1541	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,SRP
 SXNET_free                              1542	3_0_0	EXIST::FUNCTION:
 CMS_get0_content                        1543	3_0_0	EXIST::FUNCTION:CMS
 BN_is_word                              1544	3_0_0	EXIST::FUNCTION:
@@ -1549,8 +1549,8 @@ X509_policy_tree_get0_user_policies     1582	3_0_0	EXIST::FUNCTION:
 DSA_do_sign                             1584	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,DSA
 EVP_CIPHER_CTX_reset                    1585	3_0_0	EXIST::FUNCTION:
 OCSP_REVOKEDINFO_new                    1586	3_0_0	EXIST::FUNCTION:OCSP
-SRP_Verify_A_mod_N                      1587	3_0_0	EXIST::FUNCTION:SRP
-SRP_VBASE_free                          1588	3_0_0	EXIST::FUNCTION:SRP
+SRP_Verify_A_mod_N                      1587	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,SRP
+SRP_VBASE_free                          1588	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,SRP
 PKCS7_add0_attrib_signing_time          1589	3_0_0	EXIST::FUNCTION:
 X509_STORE_set_flags                    1590	3_0_0	EXIST::FUNCTION:
 UI_get0_output_string                   1591	3_0_0	EXIST::FUNCTION:
@@ -1862,7 +1862,7 @@ SCT_set1_signature                      1906	3_0_0	EXIST::FUNCTION:CT
 CONF_imodule_get_module                 1907	3_0_0	EXIST::FUNCTION:
 NAME_CONSTRAINTS_new                    1908	3_0_0	EXIST::FUNCTION:
 BN_usub                                 1909	3_0_0	EXIST::FUNCTION:
-SRP_Calc_B                              1910	3_0_0	EXIST::FUNCTION:SRP
+SRP_Calc_B                              1910	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,SRP
 CMS_decrypt_set1_key                    1911	3_0_0	EXIST::FUNCTION:CMS
 EC_GROUP_get_degree                     1912	3_0_0	EXIST::FUNCTION:EC
 X509_ALGOR_set0                         1913	3_0_0	EXIST::FUNCTION:
@@ -1877,7 +1877,7 @@ X509_REQ_free                           1921	3_0_0	EXIST::FUNCTION:
 ASN1_INTEGER_set                        1922	3_0_0	EXIST::FUNCTION:
 EVP_DecodeFinal                         1923	3_0_0	EXIST::FUNCTION:
 MD5_Transform                           1925	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,MD5
-SRP_create_verifier_BN                  1926	3_0_0	EXIST::FUNCTION:SRP
+SRP_create_verifier_BN                  1926	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,SRP
 ENGINE_register_all_EC                  1927	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,ENGINE
 EVP_camellia_128_ofb                    1928	3_0_0	EXIST::FUNCTION:CAMELLIA
 PEM_write_X509_AUX                      1929	3_0_0	EXIST::FUNCTION:STDIO
@@ -1967,7 +1967,7 @@ ENGINE_get_init_function                2012	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_
 EC_POINT_point2hex                      2013	3_0_0	EXIST::FUNCTION:EC
 ENGINE_get_default_DSA                  2014	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,ENGINE
 ENGINE_register_all_complete            2015	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,ENGINE
-SRP_get_default_gN                      2016	3_0_0	EXIST::FUNCTION:SRP
+SRP_get_default_gN                      2016	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,SRP
 UI_dup_input_boolean                    2017	3_0_0	EXIST::FUNCTION:
 PKCS7_dup                               2018	3_0_0	EXIST::FUNCTION:
 i2d_TS_REQ_fp                           2019	3_0_0	EXIST::FUNCTION:STDIO,TS
@@ -2190,7 +2190,7 @@ PKCS7_SIGNER_INFO_set                   2237	3_0_0	EXIST::FUNCTION:
 PEM_write_bio_PKCS8_PRIV_KEY_INFO       2238	3_0_0	EXIST::FUNCTION:
 EC_GROUP_set_curve_GF2m                 2239	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,EC,EC2M
 ENGINE_load_builtin_engines             2240	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,ENGINE
-SRP_VBASE_init                          2241	3_0_0	EXIST::FUNCTION:SRP
+SRP_VBASE_init                          2241	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,SRP
 SHA224_Final                            2242	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
 OCSP_CERTSTATUS_free                    2243	3_0_0	EXIST::FUNCTION:OCSP
 d2i_TS_TST_INFO                         2244	3_0_0	EXIST::FUNCTION:TS
@@ -2350,7 +2350,7 @@ X509_TRUST_get_count                    2399	3_0_0	EXIST::FUNCTION:
 IPAddressOrRange_free                   2400	3_0_0	EXIST::FUNCTION:RFC3779
 RSA_padding_add_PKCS1_OAEP              2401	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
 EC_KEY_set_ex_data                      2402	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,EC
-SRP_VBASE_new                           2403	3_0_0	EXIST::FUNCTION:SRP
+SRP_VBASE_new                           2403	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,SRP
 i2d_ECDSA_SIG                           2404	3_0_0	EXIST::FUNCTION:EC
 BIO_dump_indent                         2405	3_0_0	EXIST::FUNCTION:
 ENGINE_set_pkey_asn1_meths              2406	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,ENGINE
@@ -2771,7 +2771,7 @@ TS_TST_INFO_get_ext                     2831	3_0_0	EXIST::FUNCTION:TS
 i2d_OCSP_RESPID                         2832	3_0_0	EXIST::FUNCTION:OCSP
 EVP_camellia_256_cfb8                   2833	3_0_0	EXIST::FUNCTION:CAMELLIA
 EC_KEY_get0_public_key                  2834	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,EC
-SRP_Calc_x                              2835	3_0_0	EXIST::FUNCTION:SRP
+SRP_Calc_x                              2835	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,SRP
 a2i_ASN1_ENUMERATED                     2836	3_0_0	EXIST::FUNCTION:
 CONF_module_get_usr_data                2837	3_0_0	EXIST::FUNCTION:
 i2d_X509_NAME_ENTRY                     2838	3_0_0	EXIST::FUNCTION:
@@ -3033,7 +3033,7 @@ TS_RESP_create_response                 3097	3_0_0	EXIST::FUNCTION:TS
 BIO_ADDR_rawaddress                     3098	3_0_0	EXIST::FUNCTION:SOCK
 PKCS7_ENCRYPT_new                       3099	3_0_0	EXIST::FUNCTION:
 i2d_PKCS8PrivateKey_fp                  3100	3_0_0	EXIST::FUNCTION:STDIO
-SRP_user_pwd_free                       3101	3_0_0	EXIST::FUNCTION:SRP
+SRP_user_pwd_free                       3101	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,SRP
 Camellia_encrypt                        3102	3_0_0	EXIST::FUNCTION:CAMELLIA,DEPRECATEDIN_3_0
 BIO_ADDR_hostname_string                3103	3_0_0	EXIST::FUNCTION:SOCK
 USERNOTICE_new                          3104	3_0_0	EXIST::FUNCTION:
@@ -3132,7 +3132,7 @@ SCT_get_version                         3197	3_0_0	EXIST::FUNCTION:CT
 IDEA_set_encrypt_key                    3198	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,IDEA
 ENGINE_get_DH                           3199	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,ENGINE
 i2d_ASIdentifierChoice                  3200	3_0_0	EXIST::FUNCTION:RFC3779
-SRP_Calc_A                              3201	3_0_0	EXIST::FUNCTION:SRP
+SRP_Calc_A                              3201	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,SRP
 OCSP_BASICRESP_add_ext                  3202	3_0_0	EXIST::FUNCTION:OCSP
 EVP_idea_cfb64                          3203	3_0_0	EXIST::FUNCTION:IDEA
 PKCS12_newpass                          3204	3_0_0	EXIST::FUNCTION:
@@ -3218,7 +3218,7 @@ OCSP_cert_id_new                        3284	3_0_0	EXIST::FUNCTION:OCSP
 GENERAL_SUBTREE_new                     3285	3_0_0	EXIST::FUNCTION:
 OPENSSL_sk_push                         3286	3_0_0	EXIST::FUNCTION:
 X509_LOOKUP_ctrl                        3287	3_0_0	EXIST::FUNCTION:
-SRP_check_known_gN_param                3288	3_0_0	EXIST::FUNCTION:SRP
+SRP_check_known_gN_param                3288	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,SRP
 d2i_DIST_POINT                          3289	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_CTX_free                       3290	3_0_0	EXIST::FUNCTION:
 PBEPARAM_free                           3291	3_0_0	EXIST::FUNCTION:
@@ -3541,7 +3541,7 @@ ERR_get_error                           3618	3_0_0	EXIST::FUNCTION:
 TS_CONF_set_signer_digest               3619	3_0_0	EXIST::FUNCTION:TS
 OBJ_new_nid                             3620	3_0_0	EXIST::FUNCTION:
 CMS_ReceiptRequest_new                  3621	3_0_0	EXIST::FUNCTION:CMS
-SRP_VBASE_get1_by_user                  3622	3_0_0	EXIST::FUNCTION:SRP
+SRP_VBASE_get1_by_user                  3622	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,SRP
 UI_method_get_closer                    3623	3_0_0	EXIST::FUNCTION:
 ENGINE_get_ex_data                      3624	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,ENGINE
 BN_print_fp                             3625	3_0_0	EXIST::FUNCTION:STDIO
@@ -3654,7 +3654,7 @@ EVP_CIPHER_meth_get_set_asn1_params     3734	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_
 X509_STORE_CTX_get_ex_data              3735	3_0_0	EXIST::FUNCTION:
 CMS_RecipientInfo_kari_set0_pkey        3736	3_0_0	EXIST::FUNCTION:CMS
 X509v3_addr_add_inherit                 3737	3_0_0	EXIST::FUNCTION:RFC3779
-SRP_Calc_u                              3738	3_0_0	EXIST::FUNCTION:SRP
+SRP_Calc_u                              3738	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,SRP
 i2d_PKCS8PrivateKey_bio                 3739	3_0_0	EXIST::FUNCTION:
 X509_get_extension_flags                3740	3_0_0	EXIST::FUNCTION:
 X509V3_EXT_val_prn                      3741	3_0_0	EXIST::FUNCTION:
@@ -4414,11 +4414,11 @@ EVP_MAC_init                            ?	3_0_0	EXIST::FUNCTION:
 EVP_MAC_update                          ?	3_0_0	EXIST::FUNCTION:
 EVP_MAC_final                           ?	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_supports_digest_nid            ?	3_0_0	EXIST::FUNCTION:
-SRP_VBASE_add0_user                     ?	3_0_0	EXIST::FUNCTION:SRP
-SRP_user_pwd_new                        ?	3_0_0	EXIST::FUNCTION:SRP
-SRP_user_pwd_set_gN                     ?	3_0_0	EXIST::FUNCTION:SRP
-SRP_user_pwd_set1_ids                   ?	3_0_0	EXIST::FUNCTION:SRP
-SRP_user_pwd_set0_sv                    ?	3_0_0	EXIST::FUNCTION:SRP
+SRP_VBASE_add0_user                     ?	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,SRP
+SRP_user_pwd_new                        ?	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,SRP
+SRP_user_pwd_set_gN                     ?	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,SRP
+SRP_user_pwd_set1_ids                   ?	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,SRP
+SRP_user_pwd_set0_sv                    ?	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,SRP
 OPENSSL_version_major                   ?	3_0_0	EXIST::FUNCTION:
 OPENSSL_version_minor                   ?	3_0_0	EXIST::FUNCTION:
 OPENSSL_version_patch                   ?	3_0_0	EXIST::FUNCTION:
@@ -4977,12 +4977,12 @@ OSSL_PARAM_BLD_free                     ?	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_set_type_by_keymgmt            ?	3_0_0	EXIST::FUNCTION:
 OCSP_RESPID_set_by_key_ex               ?	3_0_0	EXIST::FUNCTION:OCSP
 OCSP_RESPID_match_ex                    ?	3_0_0	EXIST::FUNCTION:OCSP
-SRP_create_verifier_ex                  ?	3_0_0	EXIST::FUNCTION:SRP
-SRP_create_verifier_BN_ex               ?	3_0_0	EXIST::FUNCTION:SRP
-SRP_Calc_B_ex                           ?	3_0_0	EXIST::FUNCTION:SRP
-SRP_Calc_u_ex                           ?	3_0_0	EXIST::FUNCTION:SRP
-SRP_Calc_x_ex                           ?	3_0_0	EXIST::FUNCTION:SRP
-SRP_Calc_client_key_ex                  ?	3_0_0	EXIST::FUNCTION:SRP
+SRP_create_verifier_ex                  ?	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,SRP
+SRP_create_verifier_BN_ex               ?	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,SRP
+SRP_Calc_B_ex                           ?	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,SRP
+SRP_Calc_u_ex                           ?	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,SRP
+SRP_Calc_x_ex                           ?	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,SRP
+SRP_Calc_client_key_ex                  ?	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,SRP
 EVP_PKEY_gettable_params                ?	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_get_int_param                  ?	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_get_size_t_param               ?	3_0_0	EXIST::FUNCTION:

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -16,7 +16,7 @@ X509_PUBKEY_set0_param                  15	3_0_0	EXIST::FUNCTION:
 PKCS12_it                               16	3_0_0	EXIST::FUNCTION:
 i2d_ASN1_OCTET_STRING                   17	3_0_0	EXIST::FUNCTION:
 EC_KEY_set_private_key                  18	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,EC
-SRP_VBASE_get_by_user                   19	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_1_1_0,DEPRECATEDIN_3_0,SRP
+SRP_VBASE_get_by_user                   19	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_1_1_0,SRP
 Camellia_cfb128_encrypt                 21	3_0_0	EXIST::FUNCTION:CAMELLIA,DEPRECATEDIN_3_0
 DES_ncbc_encrypt                        22	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,DES
 TS_REQ_get_ext_count                    23	3_0_0	EXIST::FUNCTION:TS


### PR DESCRIPTION
The OTC recently decided to deprecate the SRP APIs. This PR implements that deprecation.

Unfortunately, at this time, SRP is not available via EVP so there is no replacement available.

Fixes #13917
