### PR TITLE
No arg order

### DIFF
--- a/apps/ca.c
+++ b/apps/ca.c
@@ -209,7 +209,7 @@ const OPTIONS ca_options[] = {
     {"noemailDN", OPT_NOEMAILDN, '-', "Don't add the EMAIL field to the DN"},
 
     OPT_SECTION("Signing"),
-    {"md", OPT_MD, 's', "md to use; one of md2, md5, sha or sha1"},
+    {"md", OPT_MD, 's', "md to use; (e.g., sha256)"},
     {"keyfile", OPT_KEYFILE, 's', "The CA private key"},
     {"keyform", OPT_KEYFORM, 'f',
      "Private key file format (ENGINE, other values ignored)"},
@@ -521,6 +521,7 @@ end_of_options:
         goto end;
 
     app_RAND_load_conf(conf, BASE_SECTION);
+    app_RAND_load();
 
     f = NCONF_get_string(conf, section, STRING_MASK);
     if (f == NULL)

--- a/apps/ca.c
+++ b/apps/ca.c
@@ -209,7 +209,7 @@ const OPTIONS ca_options[] = {
     {"noemailDN", OPT_NOEMAILDN, '-', "Don't add the EMAIL field to the DN"},
 
     OPT_SECTION("Signing"),
-    {"md", OPT_MD, 's', "md to use; (e.g., sha256)"},
+    {"md", OPT_MD, 's', "Digest to use, such as sha256"},
     {"keyfile", OPT_KEYFILE, 's', "The CA private key"},
     {"keyform", OPT_KEYFORM, 'f',
      "Private key file format (ENGINE, other values ignored)"},

--- a/apps/cms.c
+++ b/apps/cms.c
@@ -698,6 +698,7 @@ int cms_main(int argc, char **argv)
             break;
         }
     }
+    app_RAND_load();
 
     /* Remaining args are files to process. */
     argc = opt_num_rest();

--- a/apps/cms.c
+++ b/apps/cms.c
@@ -286,7 +286,7 @@ int cms_main(int argc, char **argv)
     X509_VERIFY_PARAM *vpm = NULL;
     char *certfile = NULL, *keyfile = NULL, *contfile = NULL;
     const char *CAfile = NULL, *CApath = NULL, *CAstore = NULL;
-    char *certsoutfile = NULL;
+    char *certsoutfile = NULL, *digestname = NULL;
     int noCAfile = 0, noCApath = 0, noCAstore = 0;
     char *infile = NULL, *outfile = NULL, *rctfile = NULL;
     char *passinarg = NULL, *passin = NULL, *signerfile = NULL, *originatorfile = NULL, *recipfile = NULL;
@@ -565,8 +565,7 @@ int cms_main(int argc, char **argv)
             certsoutfile = opt_arg();
             break;
         case OPT_MD:
-            if (!opt_md(opt_arg(), &sign_md))
-                goto end;
+            digestname = opt_arg();
             break;
         case OPT_SIGNER:
             /* If previous -signer argument add signer to list */
@@ -699,6 +698,8 @@ int cms_main(int argc, char **argv)
         }
     }
     app_RAND_load();
+    if (digestname != NULL && !opt_md(digestname, &sign_md))
+        goto end;
 
     /* Remaining args are files to process. */
     argc = opt_num_rest();

--- a/apps/cms.c
+++ b/apps/cms.c
@@ -289,7 +289,8 @@ int cms_main(int argc, char **argv)
     char *certsoutfile = NULL, *digestname = NULL;
     int noCAfile = 0, noCApath = 0, noCAstore = 0;
     char *infile = NULL, *outfile = NULL, *rctfile = NULL;
-    char *passinarg = NULL, *passin = NULL, *signerfile = NULL, *originatorfile = NULL, *recipfile = NULL;
+    char *passinarg = NULL, *passin = NULL, *signerfile = NULL;
+    char *originatorfile = NULL, *recipfile = NULL, *ciphername = NULL;
     char *to = NULL, *from = NULL, *subject = NULL, *prog;
     cms_key_param *key_first = NULL, *key_param = NULL;
     int flags = CMS_DETACHED, noout = 0, print = 0, keyidx = -1, vpmtouched = 0;
@@ -624,8 +625,7 @@ int cms_main(int argc, char **argv)
             }
             break;
         case OPT_CIPHER:
-            if (!opt_cipher(opt_unknown(), &cipher))
-                goto end;
+            ciphername = opt_unknown();
             break;
         case OPT_KEYOPT:
             keyidx = -1;
@@ -698,8 +698,14 @@ int cms_main(int argc, char **argv)
         }
     }
     app_RAND_load();
-    if (digestname != NULL && !opt_md(digestname, &sign_md))
-        goto end;
+    if (digestname != NULL) {
+        if (!opt_md(digestname, &sign_md))
+            goto end;
+    }
+    if (ciphername != NULL) {
+        if (!opt_cipher(ciphername, &cipher))
+            goto end;
+    }
 
     /* Remaining args are files to process. */
     argc = opt_num_rest();

--- a/apps/crl.c
+++ b/apps/crl.c
@@ -84,6 +84,7 @@ int crl_main(int argc, char **argv)
     EVP_PKEY *pkey;
     const EVP_MD *digest = EVP_sha1();
     char *infile = NULL, *outfile = NULL, *crldiff = NULL, *keyfile = NULL;
+    char *digestname = NULL;
     const char *CAfile = NULL, *CApath = NULL, *CAstore = NULL, *prog;
     OPTION_CHOICE o;
     int hash = 0, issuer = 0, lastupdate = 0, nextupdate = 0, noout = 0;
@@ -192,8 +193,7 @@ int crl_main(int argc, char **argv)
                 goto opthelp;
             break;
         case OPT_MD:
-            if (!opt_md(opt_unknown(), &digest))
-                goto opthelp;
+            digestname = opt_unknown();
             break;
         case OPT_PROV_CASES:
             if (!opt_provider(o))
@@ -207,6 +207,8 @@ int crl_main(int argc, char **argv)
     if (argc != 0)
         goto opthelp;
 
+    if (digestname != NULL && !opt_md(digestname, &digest))
+        goto opthelp;
     x = load_crl(infile, "CRL");
     if (x == NULL)
         goto end;

--- a/apps/crl.c
+++ b/apps/crl.c
@@ -207,8 +207,10 @@ int crl_main(int argc, char **argv)
     if (argc != 0)
         goto opthelp;
 
-    if (digestname != NULL && !opt_md(digestname, &digest))
-        goto opthelp;
+    if (digestname != NULL) {
+        if (!opt_md(digestname, &digest))
+            goto opthelp;
+    }
     x = load_crl(infile, "CRL");
     if (x == NULL)
         goto end;

--- a/apps/dgst.c
+++ b/apps/dgst.c
@@ -97,9 +97,9 @@ int dgst_main(int argc, char **argv)
     EVP_PKEY *sigkey = NULL;
     STACK_OF(OPENSSL_STRING) *sigopts = NULL, *macopts = NULL;
     char *hmac_key = NULL;
-    char *mac_name = NULL;
+    char *mac_name = NULL, *digestname = NULL;
     char *passinarg = NULL, *passin = NULL;
-    const EVP_MD *md = NULL, *m;
+    const EVP_MD *md = NULL;
     const char *outfile = NULL, *keyfile = NULL, *prog = NULL;
     const char *sigfile = NULL;
     const char *md_name = NULL;
@@ -209,9 +209,7 @@ int dgst_main(int argc, char **argv)
                 goto opthelp;
             break;
         case OPT_DIGEST:
-            if (!opt_md(opt_unknown(), &m))
-                goto opthelp;
-            md = m;
+            digestname = opt_unknown();
             break;
         case OPT_PROV_CASES:
             if (!opt_provider(o))
@@ -228,6 +226,10 @@ int dgst_main(int argc, char **argv)
         goto end;
     }
     app_RAND_load();
+    if (digestname != NULL) {
+        if (!opt_md(digestname, &md))
+            goto opthelp;
+    }
 
     if (do_verify && sigfile == NULL) {
         BIO_printf(bio_err,

--- a/apps/dgst.c
+++ b/apps/dgst.c
@@ -227,6 +227,7 @@ int dgst_main(int argc, char **argv)
         BIO_printf(bio_err, "%s: Can only sign or verify one file.\n", prog);
         goto end;
     }
+    app_RAND_load();
 
     if (do_verify && sigfile == NULL) {
         BIO_printf(bio_err,

--- a/apps/dhparam.c
+++ b/apps/dhparam.c
@@ -158,6 +158,7 @@ int dhparam_main(int argc, char **argv)
     } else if (argc != 0) {
         goto opthelp;
     }
+    app_RAND_load();
 
 
     if (g && !num)

--- a/apps/dsa.c
+++ b/apps/dsa.c
@@ -87,7 +87,7 @@ int dsa_main(int argc, char **argv)
     int modulus = 0, pubin = 0, pubout = 0, ret = 1;
     int pvk_encr = DEFAULT_PVK_ENCR_STRENGTH;
     int private = 0;
-    const char *output_type = NULL;
+    const char *output_type = NULL, *ciphername = NULL;
     const char *output_structure = NULL;
     int selection = 0;
     OSSL_ENCODER_CTX *ectx = NULL;
@@ -151,8 +151,7 @@ int dsa_main(int argc, char **argv)
             pubout = 1;
             break;
         case OPT_CIPHER:
-            if (!opt_cipher(opt_unknown(), &enc))
-                goto end;
+            ciphername = opt_unknown();
             break;
         case OPT_PROV_CASES:
             if (!opt_provider(o))
@@ -166,6 +165,10 @@ int dsa_main(int argc, char **argv)
     if (argc != 0)
         goto opthelp;
 
+    if (ciphername != NULL) {
+        if (!opt_cipher(ciphername, &enc))
+            goto end;
+    }
     private = pubin || pubout ? 0 : 1;
     if (text && !pubin)
         private = 1;

--- a/apps/dsaparam.c
+++ b/apps/dsaparam.c
@@ -135,6 +135,7 @@ int dsaparam_main(int argc, char **argv)
     } else if (argc != 0) {
         goto opthelp;
     }
+    app_RAND_load();
 
     /* generate a key */
     numbits = num;

--- a/apps/ec.c
+++ b/apps/ec.c
@@ -70,7 +70,7 @@ int ec_main(int argc, char **argv)
     BIO *in = NULL, *out = NULL;
     ENGINE *e = NULL;
     const EVP_CIPHER *enc = NULL;
-    char *infile = NULL, *outfile = NULL, *prog;
+    char *infile = NULL, *outfile = NULL, *ciphername = NULL, *prog;
     char *passin = NULL, *passout = NULL, *passinarg = NULL, *passoutarg = NULL;
     OPTION_CHOICE o;
     int informat = FORMAT_PEM, outformat = FORMAT_PEM, text = 0, noout = 0;
@@ -131,8 +131,7 @@ int ec_main(int argc, char **argv)
             e = setup_engine(opt_arg(), 0);
             break;
         case OPT_CIPHER:
-            if (!opt_cipher(opt_unknown(), &enc))
-                goto opthelp;
+            ciphername = opt_unknown();
             break;
         case OPT_CONV_FORM:
             point_format = opt_arg();
@@ -162,6 +161,10 @@ int ec_main(int argc, char **argv)
     if (argc != 0)
         goto opthelp;
 
+    if (ciphername != NULL) {
+        if (!opt_cipher(ciphername, &enc))
+            goto opthelp;
+    }
     private = param_out || pubin || pubout ? 0 : 1;
     if (text && !pubin)
         private = 1;

--- a/apps/ecparam.c
+++ b/apps/ecparam.c
@@ -190,6 +190,7 @@ int ecparam_main(int argc, char **argv)
     if (argc != 0)
         goto opthelp;
 
+    app_RAND_load();
     private = genkey ? 1 : 0;
 
     in = bio_open_default(infile, 'r', informat);

--- a/apps/enc.c
+++ b/apps/enc.c
@@ -111,7 +111,7 @@ int enc_main(int argc, char **argv)
     EVP_CIPHER_CTX *ctx = NULL;
     const EVP_CIPHER *cipher = NULL;
     const EVP_MD *dgst = NULL;
-    const char *dgstname = NULL;
+    const char *digestname = NULL;
     char *hkey = NULL, *hiv = NULL, *hsalt = NULL, *p;
     char *infile = NULL, *outfile = NULL, *prog;
     char *str = NULL, *passarg = NULL, *pass = NULL, *strbuf = NULL;
@@ -260,7 +260,7 @@ int enc_main(int argc, char **argv)
             hiv = opt_arg();
             break;
         case OPT_MD:
-            dgstname = opt_arg();
+            digestname = opt_arg();
             break;
         case OPT_CIPHER:
             ciphername = opt_unknown();
@@ -308,8 +308,8 @@ int enc_main(int argc, char **argv)
         BIO_printf(bio_err, "%s XTS ciphers not supported\n", prog);
         goto end;
     }
-    if (dgstname != NULL) {
-        if (!!opt_md(opt_arg(), &dgst))
+    if (digestname != NULL) {
+        if (!opt_md(digestname, &dgst))
             goto opthelp;
     }
     if (dgst == NULL)

--- a/apps/enc.c
+++ b/apps/enc.c
@@ -109,11 +109,13 @@ int enc_main(int argc, char **argv)
     BIO *in = NULL, *out = NULL, *b64 = NULL, *benc = NULL, *rbio =
         NULL, *wbio = NULL;
     EVP_CIPHER_CTX *ctx = NULL;
-    const EVP_CIPHER *cipher = NULL, *c;
+    const EVP_CIPHER *cipher = NULL;
     const EVP_MD *dgst = NULL;
+    const char *dgstname = NULL;
     char *hkey = NULL, *hiv = NULL, *hsalt = NULL, *p;
-    char *infile = NULL, *outfile = NULL, *prog, *arg0;
+    char *infile = NULL, *outfile = NULL, *prog;
     char *str = NULL, *passarg = NULL, *pass = NULL, *strbuf = NULL;
+    const char *ciphername = NULL;
     char mbuf[sizeof(magic) - 1];
     OPTION_CHOICE o;
     int bsize = BSIZE, verbose = 0, debug = 0, olb64 = 0, nosalt = 0;
@@ -132,20 +134,14 @@ int enc_main(int argc, char **argv)
 #endif
 
     /* first check the command name */
-    arg0 = argv[0];
-    if (strcmp(arg0, "base64") == 0) {
+    if (strcmp(argv[0], "base64") == 0)
         base64 = 1;
 #ifdef ZLIB
-    } else if (strcmp(arg0, "zlib") == 0) {
+    else if (strcmp(argv[0], "zlib") == 0)
         do_zlib = 1;
 #endif
-    } else {
-        cipher = EVP_get_cipherbyname(arg0);
-        if (cipher == NULL && strcmp(arg0, "enc") != 0) {
-            BIO_printf(bio_err, "%s is not a known cipher\n", arg0);
-            goto end;
-        }
-    }
+    else if (strcmp(argv[0], "enc") != 0)
+        ciphername = argv[0];
 
     prog = opt_init(argc, argv, enc_options);
     while ((o = opt_next()) != OPT_EOF) {
@@ -264,13 +260,10 @@ int enc_main(int argc, char **argv)
             hiv = opt_arg();
             break;
         case OPT_MD:
-            if (!opt_md(opt_arg(), &dgst))
-                goto opthelp;
+            dgstname = opt_arg();
             break;
         case OPT_CIPHER:
-            if (!opt_cipher(opt_unknown(), &c))
-                goto opthelp;
-            cipher = c;
+            ciphername = opt_unknown();
             break;
         case OPT_ITER:
             if (!opt_int(opt_arg(), &iter))
@@ -301,16 +294,23 @@ int enc_main(int argc, char **argv)
     if (argc != 0)
         goto opthelp;
 
+    /* Get the cipher name, either from progname (if set) or flag. */
+    if (ciphername != NULL) {
+        if (!opt_cipher(ciphername, &cipher))
+            goto opthelp;
+    }
     if (cipher && EVP_CIPHER_flags(cipher) & EVP_CIPH_FLAG_AEAD_CIPHER) {
         BIO_printf(bio_err, "%s: AEAD ciphers not supported\n", prog);
         goto end;
     }
-
     if (cipher && (EVP_CIPHER_mode(cipher) == EVP_CIPH_XTS_MODE)) {
         BIO_printf(bio_err, "%s XTS ciphers not supported\n", prog);
         goto end;
     }
-
+    if (dgstname != NULL) {
+        if (!!opt_md(opt_arg(), &dgst))
+            goto opthelp;
+    }
     if (dgst == NULL)
         dgst = EVP_sha256();
 

--- a/apps/enc.c
+++ b/apps/enc.c
@@ -293,6 +293,7 @@ int enc_main(int argc, char **argv)
     argc = opt_num_rest();
     if (argc != 0)
         goto opthelp;
+    app_RAND_load();
 
     /* Get the cipher name, either from progname (if set) or flag. */
     if (ciphername != NULL) {

--- a/apps/gendsa.c
+++ b/apps/gendsa.c
@@ -108,6 +108,7 @@ int gendsa_main(int argc, char **argv)
     if (argc != 1)
         goto opthelp;
 
+    app_RAND_load();
     dsaparams = argv[0];
     private = 1;
 

--- a/apps/gendsa.c
+++ b/apps/gendsa.c
@@ -57,7 +57,7 @@ int gendsa_main(int argc, char **argv)
     EVP_PKEY *pkey = NULL;
     EVP_PKEY_CTX *ctx = NULL;
     const EVP_CIPHER *enc = NULL;
-    char *dsaparams = NULL;
+    char *dsaparams = NULL, *ciphername = NULL;
     char *outfile = NULL, *passoutarg = NULL, *passout = NULL, *prog;
     OPTION_CHOICE o;
     int ret = 1, private = 0, verbose = 0;
@@ -93,8 +93,7 @@ int gendsa_main(int argc, char **argv)
                 goto end;
             break;
         case OPT_CIPHER:
-            if (!opt_cipher(opt_unknown(), &enc))
-                goto end;
+            ciphername = opt_unknown();
             break;
         case OPT_VERBOSE:
             verbose = 1;
@@ -107,9 +106,13 @@ int gendsa_main(int argc, char **argv)
     argv = opt_rest();
     if (argc != 1)
         goto opthelp;
+    dsaparams = argv[0];
 
     app_RAND_load();
-    dsaparams = argv[0];
+    if (ciphername != NULL) {
+        if (!opt_cipher(ciphername, &enc))
+            goto end;
+    }
     private = 1;
 
     if (!app_passwd(NULL, passoutarg, NULL, &passout)) {

--- a/apps/genrsa.c
+++ b/apps/genrsa.c
@@ -86,7 +86,7 @@ int genrsa_main(int argc, char **argv)
     int ret = 1, num = DEFBITS, private = 0, primes = DEFPRIMES;
     unsigned long f4 = RSA_F4;
     char *outfile = NULL, *passoutarg = NULL, *passout = NULL;
-    char *prog, *hexe, *dece;
+    char *prog, *hexe, *dece, *ciphername = NULL;
     OPTION_CHOICE o;
     int traditional = 0;
 
@@ -131,8 +131,7 @@ opthelp:
             passoutarg = opt_arg();
             break;
         case OPT_CIPHER:
-            if (!opt_cipher(opt_unknown(), &enc))
-                goto end;
+            ciphername = opt_unknown();
             break;
         case OPT_PRIMES:
             if (!opt_int(opt_arg(), &primes))
@@ -166,6 +165,10 @@ opthelp:
 
     app_RAND_load();
     private = 1;
+    if (ciphername != NULL) {
+        if (!opt_cipher(ciphername, &enc))
+            goto end;
+    }
     if (!app_passwd(NULL, passoutarg, NULL, &passout)) {
         BIO_printf(bio_err, "Error getting password\n");
         goto end;

--- a/apps/genrsa.c
+++ b/apps/genrsa.c
@@ -164,6 +164,7 @@ opthelp:
         goto opthelp;
     }
 
+    app_RAND_load();
     private = 1;
     if (!app_passwd(NULL, passoutarg, NULL, &passout)) {
         BIO_printf(bio_err, "Error getting password\n");

--- a/apps/include/apps.h
+++ b/apps/include/apps.h
@@ -47,6 +47,7 @@
 
 void app_RAND_load_conf(CONF *c, const char *section);
 void app_RAND_write(void);
+int app_RAND_load(void);
 
 extern char *default_config_file; /* may be "" */
 extern BIO *bio_in;

--- a/apps/ocsp.c
+++ b/apps/ocsp.c
@@ -223,7 +223,7 @@ int ocsp_main(int argc, char **argv)
     X509_STORE *store = NULL;
     X509_VERIFY_PARAM *vpm = NULL;
     const char *CAfile = NULL, *CApath = NULL, *CAstore = NULL;
-    char *header, *value;
+    char *header, *value, *respdigname = NULL;
     char *host = NULL, *port = NULL, *path = "/", *outfile = NULL;
     char *rca_filename = NULL, *reqin = NULL, *respin = NULL;
     char *reqout = NULL, *respout = NULL, *ridx_filename = NULL;
@@ -467,8 +467,7 @@ int ocsp_main(int argc, char **argv)
             rcertfile = opt_arg();
             break;
         case OPT_RMD:   /* Response MessageDigest */
-            if (!opt_md(opt_arg(), &rsign_md))
-                goto end;
+            respdigname = opt_arg();
             break;
         case OPT_RSIGOPT:
             if (rsign_sigopts == NULL)
@@ -524,6 +523,11 @@ int ocsp_main(int argc, char **argv)
         BIO_printf(bio_err, "%s: Digest must be before -cert or -serial\n",
                    prog);
         goto opthelp;
+    }
+
+    if (respdigname != NULL) {
+        if (!opt_md(respdigname, &rsign_md))
+            goto end;
     }
 
     /* Have we anything to do? */

--- a/apps/passwd.c
+++ b/apps/passwd.c
@@ -195,6 +195,7 @@ int passwd_main(int argc, char **argv)
         passwds = argv;
     }
 
+    app_RAND_load();
     if (mode == passwd_unset) {
         /* use default */
         mode = passwd_md5;

--- a/apps/pkcs12.c
+++ b/apps/pkcs12.c
@@ -145,7 +145,7 @@ const OPTIONS pkcs12_options[] = {
 int pkcs12_main(int argc, char **argv)
 {
     char *infile = NULL, *outfile = NULL, *keyname = NULL, *certfile = NULL;
-    char *untrusted = NULL;
+    char *untrusted = NULL, *ciphername = NULL;
     char *passcertsarg = NULL, *passcerts = NULL;
     char *name = NULL, *csp_name = NULL;
     char pass[PASSWD_BUF_SIZE] = "", macpass[PASSWD_BUF_SIZE] = "";
@@ -221,9 +221,8 @@ int pkcs12_main(int argc, char **argv)
             export_pkcs12 = 1;
             break;
         case OPT_CIPHER:
-            enc_flag = opt_unknown();
-            if (!opt_cipher(enc_flag, &enc))
-                goto opthelp;
+            ciphername = opt_unknown();
+            enc_flag = opt_unknown();   /* overloaded meaning; see below. */
             break;
         case OPT_ITER:
             if (!opt_int(opt_arg(), &iter))
@@ -342,6 +341,10 @@ int pkcs12_main(int argc, char **argv)
         goto opthelp;
 
     app_RAND_load();
+    if (ciphername != NULL) {
+        if (!opt_cipher(ciphername, &enc))
+            goto opthelp;
+    }
     if (export_pkcs12) {
         if ((options & INFO) != 0)
             WARN_EXPORT("info");

--- a/apps/pkcs12.c
+++ b/apps/pkcs12.c
@@ -220,9 +220,18 @@ int pkcs12_main(int argc, char **argv)
         case OPT_EXPORT:
             export_pkcs12 = 1;
             break;
+        case OPT_NODES:
+        case OPT_NOENC:
+            /*
+             * |enc_flag| stores the name of the option used so it
+             * can be printed if an error message is output.
+             */
+            enc_flag = opt_flag() + 1;
+            enc = NULL;
+            break;
         case OPT_CIPHER:
             ciphername = opt_unknown();
-            enc_flag = opt_unknown();   /* overloaded meaning; see below. */
+            enc_flag = opt_unknown();
             break;
         case OPT_ITER:
             if (!opt_int(opt_arg(), &iter))
@@ -244,11 +253,6 @@ int pkcs12_main(int argc, char **argv)
             break;
         case OPT_MACALG:
             macalg = opt_arg();
-            break;
-        case OPT_NODES:
-        case OPT_NOENC:
-            enc_flag = opt_flag() + 1;
-            enc = NULL;
             break;
         case OPT_CERTPBE:
             if (!set_pbe(&cert_pbe, opt_arg()))

--- a/apps/pkcs12.c
+++ b/apps/pkcs12.c
@@ -341,6 +341,7 @@ int pkcs12_main(int argc, char **argv)
     if (argc != 0)
         goto opthelp;
 
+    app_RAND_load();
     if (export_pkcs12) {
         if ((options & INFO) != 0)
             WARN_EXPORT("info");

--- a/apps/pkcs12.c
+++ b/apps/pkcs12.c
@@ -145,7 +145,7 @@ const OPTIONS pkcs12_options[] = {
 int pkcs12_main(int argc, char **argv)
 {
     char *infile = NULL, *outfile = NULL, *keyname = NULL, *certfile = NULL;
-    char *untrusted = NULL, *ciphername = NULL;
+    char *untrusted = NULL, *ciphername = NULL, *enc_flag = NULL;
     char *passcertsarg = NULL, *passcerts = NULL;
     char *name = NULL, *csp_name = NULL;
     char pass[PASSWD_BUF_SIZE] = "", macpass[PASSWD_BUF_SIZE] = "";
@@ -164,7 +164,6 @@ int pkcs12_main(int argc, char **argv)
     BIO *in = NULL, *out = NULL;
     PKCS12 *p12 = NULL;
     STACK_OF(OPENSSL_STRING) *canames = NULL;
-    const char *enc_flag = NULL;
     const EVP_CIPHER *const default_enc = EVP_aes_256_cbc();
     const EVP_CIPHER *enc = default_enc;
     OPTION_CHOICE o;
@@ -228,6 +227,7 @@ int pkcs12_main(int argc, char **argv)
              */
             enc_flag = opt_flag() + 1;
             enc = NULL;
+            ciphername = NULL;
             break;
         case OPT_CIPHER:
             ciphername = opt_unknown();

--- a/apps/pkcs8.c
+++ b/apps/pkcs8.c
@@ -75,7 +75,7 @@ int pkcs8_main(int argc, char **argv)
     PKCS8_PRIV_KEY_INFO *p8inf = NULL;
     X509_SIG *p8 = NULL;
     const EVP_CIPHER *cipher = NULL;
-    char *infile = NULL, *outfile = NULL;
+    char *infile = NULL, *outfile = NULL, *ciphername = NULL;
     char *passinarg = NULL, *passoutarg = NULL, *prog;
 #ifndef OPENSSL_NO_UI_CONSOLE
     char pass[APP_PASS_LEN];
@@ -136,8 +136,7 @@ int pkcs8_main(int argc, char **argv)
             traditional = 1;
             break;
         case OPT_V2:
-            if (!opt_cipher(opt_arg(), &cipher))
-                goto opthelp;
+            ciphername = opt_arg();
             break;
         case OPT_V1:
             pbe_nid = OBJ_txt2nid(opt_arg());
@@ -201,6 +200,10 @@ int pkcs8_main(int argc, char **argv)
 
     private = 1;
     app_RAND_load();
+    if (ciphername != NULL) {
+        if (!opt_cipher(ciphername, &cipher))
+            goto opthelp;
+    }
 
     if (!app_passwd(passinarg, passoutarg, &passin, &passout)) {
         BIO_printf(bio_err, "Error getting passwords\n");

--- a/apps/pkcs8.c
+++ b/apps/pkcs8.c
@@ -200,6 +200,7 @@ int pkcs8_main(int argc, char **argv)
         goto opthelp;
 
     private = 1;
+    app_RAND_load();
 
     if (!app_passwd(passinarg, passoutarg, &passin, &passout)) {
         BIO_printf(bio_err, "Error getting passwords\n");

--- a/apps/pkey.c
+++ b/apps/pkey.c
@@ -73,7 +73,7 @@ int pkey_main(int argc, char **argv)
     EVP_PKEY_CTX *ctx = NULL;
     const EVP_CIPHER *cipher = NULL;
     char *infile = NULL, *outfile = NULL, *passin = NULL, *passout = NULL;
-    char *passinarg = NULL, *passoutarg = NULL, *prog;
+    char *passinarg = NULL, *passoutarg = NULL, *ciphername = NULL, *prog;
     OPTION_CHOICE o;
     int informat = FORMAT_PEM, outformat = FORMAT_PEM;
     int pubin = 0, pubout = 0, text_pub = 0, text = 0, noout = 0, ret = 1;
@@ -143,8 +143,7 @@ int pkey_main(int argc, char **argv)
             pub_check = 1;
             break;
         case OPT_CIPHER:
-            if (!opt_cipher(opt_unknown(), &cipher))
-                goto opthelp;
+            ciphername = opt_unknown();
             break;
         case OPT_EC_CONV_FORM:
 #ifdef OPENSSL_NO_EC
@@ -187,6 +186,10 @@ int pkey_main(int argc, char **argv)
                    "Warning: The -traditional is ignored since there is no PEM output\n");
     private = (!noout && !pubout) || (text && !text_pub);
 
+    if (ciphername != NULL) {
+        if (!opt_cipher(ciphername, &cipher))
+            goto opthelp;
+    }
     if (cipher == NULL) {
         if (passoutarg != NULL)
             BIO_printf(bio_err,

--- a/apps/pkeyutl.c
+++ b/apps/pkeyutl.c
@@ -255,6 +255,8 @@ int pkeyutl_main(int argc, char **argv)
     if (argc != 0)
         goto opthelp;
 
+    app_RAND_load();
+
     if (rawin && pkey_op != EVP_PKEY_OP_SIGN && pkey_op != EVP_PKEY_OP_VERIFY) {
         BIO_printf(bio_err,
                    "%s: -rawin can only be used with -sign or -verify\n",

--- a/apps/pkeyutl.c
+++ b/apps/pkeyutl.c
@@ -117,7 +117,7 @@ int pkeyutl_main(int argc, char **argv)
     size_t buf_outlen;
     const char *inkey = NULL;
     const char *peerkey = NULL;
-    const char *kdfalg = NULL;
+    const char *kdfalg = NULL, *digestname = NULL;
     int kdflen = 0;
     STACK_OF(OPENSSL_STRING) *pkeyopts = NULL;
     STACK_OF(OPENSSL_STRING) *pkeyopts_passin = NULL;
@@ -244,8 +244,7 @@ int pkeyutl_main(int argc, char **argv)
             rawin = 1;
             break;
         case OPT_DIGEST:
-            if (!opt_md(opt_arg(), &md))
-                goto end;
+            digestname = opt_arg();
             break;
         }
     }
@@ -256,6 +255,10 @@ int pkeyutl_main(int argc, char **argv)
         goto opthelp;
 
     app_RAND_load();
+    if (digestname != NULL) {
+        if (!opt_md(digestname, &md))
+            goto end;
+    }
 
     if (rawin && pkey_op != EVP_PKEY_OP_SIGN && pkey_op != EVP_PKEY_OP_VERIFY) {
         BIO_printf(bio_err,

--- a/apps/rand.c
+++ b/apps/rand.c
@@ -99,6 +99,7 @@ int rand_main(int argc, char **argv)
         goto opthelp;
     }
 
+    app_RAND_load();
     out = bio_open_default(outfile, 'w', format);
     if (out == NULL)
         goto end;

--- a/apps/req.c
+++ b/apps/req.c
@@ -480,6 +480,7 @@ int req_main(int argc, char **argv)
     if (argc != 0)
         goto opthelp;
 
+    app_RAND_load();
     if (!gen_x509) {
         if (days != UNSET_DAYS)
             BIO_printf(bio_err, "Ignoring -days without -x509; not generating a certificate\n");

--- a/apps/req.c
+++ b/apps/req.c
@@ -245,7 +245,7 @@ int req_main(int argc, char **argv)
     BIO *addext_bio = NULL;
     char *extensions = NULL;
     const char *infile = NULL, *CAfile = NULL, *CAkeyfile = NULL;
-    char *outfile = NULL, *keyfile = NULL;
+    char *outfile = NULL, *keyfile = NULL, *digestname = NULL;
     char *keyalgstr = NULL, *p, *prog, *passargin = NULL, *passargout = NULL;
     char *passin = NULL, *passout = NULL;
     char *nofree_passin = NULL, *nofree_passout = NULL;
@@ -468,9 +468,7 @@ int req_main(int argc, char **argv)
             newreq = precert = 1;
             break;
         case OPT_MD:
-            if (!opt_md(opt_unknown(), &md_alg))
-                goto opthelp;
-            digest = md_alg;
+            digestname = opt_unknown();
             break;
         }
     }
@@ -481,6 +479,12 @@ int req_main(int argc, char **argv)
         goto opthelp;
 
     app_RAND_load();
+    if (digestname != NULL) {
+        if (!opt_md(digestname, &md_alg))
+            goto opthelp;
+        digest = md_alg;
+    }
+
     if (!gen_x509) {
         if (days != UNSET_DAYS)
             BIO_printf(bio_err, "Ignoring -days without -x509; not generating a certificate\n");

--- a/apps/rsa.c
+++ b/apps/rsa.c
@@ -93,7 +93,7 @@ int rsa_main(int argc, char **argv)
     EVP_PKEY *pkey = NULL;
     EVP_PKEY_CTX *pctx;
     const EVP_CIPHER *enc = NULL;
-    char *infile = NULL, *outfile = NULL, *prog;
+    char *infile = NULL, *outfile = NULL, *ciphername = NULL, *prog;
     char *passin = NULL, *passout = NULL, *passinarg = NULL, *passoutarg = NULL;
     int private = 0;
     int informat = FORMAT_PEM, outformat = FORMAT_PEM, text = 0, check = 0;
@@ -171,8 +171,7 @@ int rsa_main(int argc, char **argv)
             check = 1;
             break;
         case OPT_CIPHER:
-            if (!opt_cipher(opt_unknown(), &enc))
-                goto opthelp;
+            ciphername = opt_unknown();
             break;
         case OPT_PROV_CASES:
             if (!opt_provider(o))
@@ -189,6 +188,10 @@ int rsa_main(int argc, char **argv)
     if (argc != 0)
         goto opthelp;
 
+    if (ciphername != NULL) {
+        if (!opt_cipher(ciphername, &enc))
+            goto opthelp;
+    }
     private = (text && !pubin) || (!pubout && !noout) ? 1 : 0;
 
     if (!app_passwd(passinarg, passoutarg, &passin, &passout)) {

--- a/apps/rsautl.c
+++ b/apps/rsautl.c
@@ -177,6 +177,7 @@ int rsautl_main(int argc, char **argv)
     if (argc != 0)
         goto opthelp;
 
+    app_RAND_load();
     if (need_priv && (key_type != KEY_PRIVKEY)) {
         BIO_printf(bio_err, "A private key is needed for this operation\n");
         goto end;

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -1574,9 +1574,7 @@ int s_client_main(int argc, char **argv)
     /* Optional argument is connect string if -connect not used. */
     argc = opt_num_rest();
     if (argc == 1) {
-        /*
-         * Don't allow -connect and a separate argument.
-         */
+        /* Don't allow -connect and a separate argument. */
         if (connectstr != NULL) {
             BIO_printf(bio_err,
                        "%s: cannot provide both -connect option and target parameter\n",
@@ -1588,6 +1586,7 @@ int s_client_main(int argc, char **argv)
     } else if (argc != 0) {
         goto opthelp;
     }
+    app_RAND_load();
 
     if (count4or6 >= 2) {
         BIO_printf(bio_err, "%s: Can't use both -4 and -6\n", prog);

--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -1662,6 +1662,7 @@ int s_server_main(int argc, char *argv[])
     if (argc != 0)
         goto opthelp;
 
+    app_RAND_load();
 #ifndef OPENSSL_NO_NEXTPROTONEG
     if (min_version == TLS1_3_VERSION && next_proto_neg_in != NULL) {
         BIO_printf(bio_err, "Cannot supply -nextprotoneg with TLSv1.3\n");

--- a/apps/smime.c
+++ b/apps/smime.c
@@ -145,7 +145,8 @@ int smime_main(int argc, char **argv)
     const char *CAfile = NULL, *CApath = NULL, *CAstore = NULL, *prog = NULL;
     char *certfile = NULL, *keyfile = NULL, *contfile = NULL;
     char *infile = NULL, *outfile = NULL, *signerfile = NULL, *recipfile = NULL;
-    char *passinarg = NULL, *passin = NULL, *to = NULL, *from = NULL, *subject = NULL;
+    char *passinarg = NULL, *passin = NULL, *to = NULL, *from = NULL;
+    char *subject = NULL, *digestname = NULL;
     OPTION_CHOICE o;
     int noCApath = 0, noCAfile = 0, noCAstore = 0;
     int flags = PKCS7_DETACHED, operation = 0, ret = 0, indef = 0;
@@ -293,8 +294,7 @@ int smime_main(int argc, char **argv)
             recipfile = opt_arg();
             break;
         case OPT_MD:
-            if (!opt_md(opt_arg(), &sign_md))
-                goto opthelp;
+            digestname = opt_arg();
             break;
         case OPT_CIPHER:
             if (!opt_cipher(opt_unknown(), &cipher))
@@ -361,6 +361,10 @@ int smime_main(int argc, char **argv)
     argv = opt_rest();
 
     app_RAND_load();
+    if (digestname != NULL) {
+        if (!opt_md(digestname, &sign_md))
+            goto opthelp;
+    }
     if (!(operation & SMIME_SIGNERS) && (skkeys != NULL || sksigners != NULL)) {
         BIO_puts(bio_err, "Multiple signers or keys not allowed\n");
         goto opthelp;

--- a/apps/smime.c
+++ b/apps/smime.c
@@ -360,6 +360,7 @@ int smime_main(int argc, char **argv)
     argc = opt_num_rest();
     argv = opt_rest();
 
+    app_RAND_load();
     if (!(operation & SMIME_SIGNERS) && (skkeys != NULL || sksigners != NULL)) {
         BIO_puts(bio_err, "Multiple signers or keys not allowed\n");
         goto opthelp;

--- a/apps/smime.c
+++ b/apps/smime.c
@@ -146,7 +146,7 @@ int smime_main(int argc, char **argv)
     char *certfile = NULL, *keyfile = NULL, *contfile = NULL;
     char *infile = NULL, *outfile = NULL, *signerfile = NULL, *recipfile = NULL;
     char *passinarg = NULL, *passin = NULL, *to = NULL, *from = NULL;
-    char *subject = NULL, *digestname = NULL;
+    char *subject = NULL, *digestname = NULL, *ciphername = NULL;
     OPTION_CHOICE o;
     int noCApath = 0, noCAfile = 0, noCAstore = 0;
     int flags = PKCS7_DETACHED, operation = 0, ret = 0, indef = 0;
@@ -297,8 +297,7 @@ int smime_main(int argc, char **argv)
             digestname = opt_arg();
             break;
         case OPT_CIPHER:
-            if (!opt_cipher(opt_unknown(), &cipher))
-                goto opthelp;
+            ciphername = opt_unknown();
             break;
         case OPT_INKEY:
             /* If previous -inkey argument add signer to list */
@@ -363,6 +362,10 @@ int smime_main(int argc, char **argv)
     app_RAND_load();
     if (digestname != NULL) {
         if (!opt_md(digestname, &sign_md))
+            goto opthelp;
+    }
+    if (ciphername != NULL) {
+        if (!opt_cipher(ciphername, &cipher))
             goto opthelp;
     }
     if (!(operation & SMIME_SIGNERS) && (skkeys != NULL || sksigners != NULL)) {

--- a/apps/speed.c
+++ b/apps/speed.c
@@ -1854,6 +1854,7 @@ int speed_main(int argc, char **argv)
     argc = opt_num_rest();
     argv = opt_rest();
 
+    app_RAND_load();
     for (; *argv; argv++) {
         const char *algo = *argv;
 

--- a/apps/srp.c
+++ b/apps/srp.c
@@ -306,6 +306,7 @@ int srp_main(int argc, char **argv)
     argc = opt_num_rest();
     argv = opt_rest();
 
+    app_RAND_load();
     if (srpvfile != NULL && configfile != NULL) {
         BIO_printf(bio_err,
                    "-srpvfile and -configfile cannot be specified together.\n");

--- a/apps/storeutl.c
+++ b/apps/storeutl.c
@@ -81,7 +81,7 @@ int storeutl_main(int argc, char *argv[])
     ASN1_INTEGER *serial = NULL;
     unsigned char *fingerprint = NULL;
     size_t fingerprintlen = 0;
-    char *alias = NULL;
+    char *alias = NULL, *digestname = NULL;
     OSSL_STORE_SEARCH *search = NULL;
     const EVP_MD *digest = NULL;
     OSSL_LIB_CTX *libctx = app_get0_libctx();
@@ -247,8 +247,8 @@ int storeutl_main(int argc, char *argv[])
             e = setup_engine(opt_arg(), 0);
             break;
         case OPT_MD:
-            if (!opt_md(opt_unknown(), &digest))
-                goto opthelp;
+            digestname = opt_unknown();
+            break;
         case OPT_PROV_CASES:
             if (!opt_provider(o))
                 goto end;
@@ -261,6 +261,11 @@ int storeutl_main(int argc, char *argv[])
     argv = opt_rest();
     if (argc != 1)
         goto opthelp;
+
+    if (digestname != NULL) {
+        if (!opt_md(digestname, &digest))
+            goto opthelp;
+    }
 
     if (criterion != 0) {
         switch (criterion) {

--- a/apps/ts.c
+++ b/apps/ts.c
@@ -292,6 +292,7 @@ int ts_main(int argc, char **argv)
     if (argc != 0 || mode == OPT_ERR)
         goto opthelp;
 
+    app_RAND_load();
     if (mode == OPT_REPLY && passin &&
         !app_passwd(passin, NULL, &password, NULL)) {
         BIO_printf(bio_err, "Error getting password.\n");

--- a/apps/ts.c
+++ b/apps/ts.c
@@ -160,7 +160,7 @@ int ts_main(int argc, char **argv)
     CONF *conf = NULL;
     const char *CAfile = NULL, *untrusted = NULL, *prog;
     const char *configfile = default_config_file, *engine = NULL;
-    const char *section = NULL;
+    const char *section = NULL, *digestname = NULL;
     char **helpp;
     char *password = NULL;
     char *data = NULL, *digest = NULL, *policy = NULL;
@@ -276,8 +276,7 @@ int ts_main(int argc, char **argv)
             engine = opt_arg();
             break;
         case OPT_MD:
-            if (!opt_md(opt_unknown(), &md))
-                goto opthelp;
+            digestname = opt_unknown();
             break;
         case OPT_V_CASES:
             if (!opt_verify(o, vpm))
@@ -293,6 +292,10 @@ int ts_main(int argc, char **argv)
         goto opthelp;
 
     app_RAND_load();
+    if (digestname != NULL) {
+        if (!opt_md(digestname, &md))
+            goto opthelp;
+    }
     if (mode == OPT_REPLY && passin &&
         !app_passwd(passin, NULL, &password, NULL)) {
         BIO_printf(bio_err, "Error getting password.\n");

--- a/apps/x509.c
+++ b/apps/x509.c
@@ -579,6 +579,7 @@ int x509_main(int argc, char **argv)
     if (argc != 0)
         goto opthelp;
 
+    app_RAND_load();
     if (preserve_dates && days != UNSET_DAYS) {
         BIO_printf(bio_err, "Cannot use -preserve_dates with -days option\n");
         goto end;

--- a/apps/x509.c
+++ b/apps/x509.c
@@ -246,7 +246,7 @@ int x509_main(int argc, char **argv)
     X509V3_CTX ext_ctx;
     EVP_PKEY *signkey = NULL, *CAkey = NULL, *pubkey = NULL;
     int newcert = 0;
-    char *subj = NULL;
+    char *subj = NULL, *digestname = NULL;
     X509_NAME *fsubj = NULL;
     const unsigned long chtype = MBSTRING_ASC;
     const int multirdn = 1;
@@ -569,8 +569,8 @@ int x509_main(int argc, char **argv)
             preserve_dates = 1;
             break;
         case OPT_MD:
-            if (!opt_md(opt_unknown(), &digest))
-                goto opthelp;
+            digestname = opt_unknown();
+            break;
         }
     }
 
@@ -580,6 +580,10 @@ int x509_main(int argc, char **argv)
         goto opthelp;
 
     app_RAND_load();
+    if (digestname != NULL) {
+        if (!opt_md(digestname, &digest))
+            goto opthelp;
+    }
     if (preserve_dates && days != UNSET_DAYS) {
         BIO_printf(bio_err, "Cannot use -preserve_dates with -days option\n");
         goto end;


### PR DESCRIPTION
This defers processing of cipher,digest,rand,key-options until *after* the argument processing is done so that providers
specified on the command line can be loaded first.

I believe that this fixes #14069.

Do we need a CHANGES entry?

Using "stacks of strings" to collect options and then parse them later is gross.  All you need is something `argv`-like. But that's not needed for 3.0 so it will have to wait.
