### PR TITLE
util/wrap.pl: use the apps/openssl.cnf from the source tree

### DIFF
--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -1215,12 +1215,19 @@ tar:
 
 # Helper targets #####################################################
 
-link-utils: $(BLDDIR)/util/opensslwrap.sh $(BLDDIR)/util/wrap.pl
+link-utils: $(BLDDIR)/util/opensslwrap.sh $(BLDDIR)/util/wrap.pl \
+            $(BLDDIR)/apps/openssl.cnf
 
 $(BLDDIR)/util/opensslwrap.sh $(BLDDIR)/util/wrap.pl: configdata.pm
 	@if [ "$(SRCDIR)" != "$(BLDDIR)" ]; then \
 	    mkdir -p "$(BLDDIR)/util"; \
 	    ln -sf "../$(SRCDIR)/util/`basename "$@"`" "$(BLDDIR)/util"; \
+	fi
+
+$(BLDDIR)/apps/openssl.cnf: configdata.pm
+	@if [ "$(SRCDIR)" != "$(BLDDIR)" ]; then \
+	    mkdir -p "$(BLDDIR)/apps"; \
+	    ln -sf "../$(SRCDIR)/apps/`basename "$@"`" "$(BLDDIR)/apps"; \
 	fi
 
 FORCE:

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -594,11 +594,15 @@ uninstall_html_docs:
 
 # Helper targets #####################################################
 
-copy-utils: $(BLDDIR)\util\wrap.pl
+copy-utils: $(BLDDIR)\util\wrap.pl $(BLDDIR)\apps\openssl.cnf
 
 $(BLDDIR)\util\wrap.pl: configdata.pm
 	@if NOT EXIST "$(BLDDIR)\util" mkdir "$(BLDDIR)\util"
 	@if NOT "$(SRCDIR)"=="$(BLDDIR)" copy "$(SRCDIR)\util\$(@F)" "$(BLDDIR)\util"
+
+$(BLDDIR)\apps\openssl.cnf: configdata.pm
+	@if NOT EXIST "$(BLDDIR)\apps" mkdir "$(BLDDIR)\apps"
+	@if NOT "$(SRCDIR)"=="$(BLDDIR)" copy "$(SRCDIR)\apps\$(@F)" "$(BLDDIR)\apps"
 
 # Building targets ###################################################
 

--- a/util/wrap.pl
+++ b/util/wrap.pl
@@ -9,12 +9,15 @@ use File::Spec::Functions;
 my $there = canonpath(catdir(dirname($0), updir()));
 my $std_engines = catdir($there, 'engines');
 my $std_providers = catdir($there, 'providers');
+my $std_openssl_conf = catdir($there, 'apps/openssl.cnf');
 my $unix_shlib_wrap = catfile($there, 'util/shlib_wrap.sh');
 
 $ENV{OPENSSL_ENGINES} = $std_engines
     if ($ENV{OPENSSL_ENGINES} // '') eq '' && -d $std_engines;
 $ENV{OPENSSL_MODULES} = $std_providers
     if ($ENV{OPENSSL_MODULES} // '') eq '' && -d $std_providers;
+$ENV{OPENSSL_CONF} = $std_openssl_conf
+    if ($ENV{OPENSSL_CONF} // '') eq '' && -f $std_openssl_conf;
 
 my $use_system = 0;
 my @cmd;


### PR DESCRIPTION
The `make install_fips` target failed in pull request #13684

    msp@debian:~/src/openssl$ make install_fips
    *** Installing FIPS module
    install providers/fips.so -> /opt/openssl-dev/lib/ossl-modules/fips.so
    *** Installing FIPS module configuration
    fipsinstall /opt/openssl-dev/ssl/fipsmodule.cnf
    FATAL: Startup failure (dev note: apps_startup()) for ./apps/openssl
    ... No such file or directory:crypto/conf/conf_def.c:771:calling stat(fipsmodule.cnf)
    ...
    make: *** [Makefile:3341: install_fips] Error 1

because the `openssl fipsinstall` command was loading a previously installed
configuration file instead of the copy shipped with the source tree.

    msp@debian:~/src/openssl$ strace -f make install_fips |& grep openssl.cnf
    [pid 128683] openat(AT_FDCWD, "/opt/openssl-dev/ssl/openssl.cnf", O_RDONLY) = 3

This issue reveiled a more general problem, which applies to the tests as well:
unless openssl is installed, the openssl app must not use any preinstalled
configuration file. This holds in particular when the preinstalled configuration
file load providers, which caused the above failure.

The most consistent way to achieve this behaviour is to set the OPENSSL_CONF
environment variable to the correct location in the util/wrap.pl perl wrapper.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn`t one already

If this fixes a GitHub issue, make sure to have a line saying `Fixes #XXXX` (without quotes) in the commit message.
-->

##### Checklist
- [x] tested `make test` (with in-tree and out-of-tree build)
- [x] tested `make install_fips`  (with #13684)
