### PR TITLE
test: turn off parallel tests in verbose mode.

### DIFF
--- a/test/run_tests.pl
+++ b/test/run_tests.pl
@@ -46,8 +46,14 @@ my %tapargs =
       merge             => 1,
     );
 
-$tapargs{jobs} = $jobs if $jobs > 1;
-print "Using HARNESS_JOBS=$jobs\n" if $jobs > 1;
+if ($jobs > 1) {
+    if ($ENV{HARNESS_VERBOSE}) {
+        print "Warning: HARNESS_JOBS > 1 ignored with HARNESS_VERBOSE\n";
+    } else {
+        $tapargs{jobs} = $jobs;
+        print "Using HARNESS_JOBS=$jobs\n";
+    }
+}
 
 # Additional OpenSSL special TAP arguments.  Because we can't pass them via
 # TAP::Harness->new(), they will be accessed directly, see the
@@ -57,8 +63,6 @@ my %openssl_args = ();
 $openssl_args{'failure_verbosity'} = $ENV{HARNESS_VERBOSE} ? 0 :
     $ENV{HARNESS_VERBOSE_FAILURE_PROGRESS} ? 2 :
     1; # $ENV{HARNESS_VERBOSE_FAILURE}
-print "Warning: HARNESS_JOBS > 1 overrides HARNESS_VERBOSE\n"
-    if $jobs > 1 && $ENV{HARNESS_VERBOSE};
 print "Warning: HARNESS_VERBOSE overrides HARNESS_VERBOSE_FAILURE*\n"
     if ($ENV{HARNESS_VERBOSE} && ($ENV{HARNESS_VERBOSE_FAILURE}
                                   || $ENV{HARNESS_VERBOSE_FAILURE_PROGRESS}));


### PR DESCRIPTION
The existing code prints a warning saying that verbose mode is ignored with parallel jobs.  This seems backward, more useful is disabling parallel jobs when verbose is enabled.

- [ ] documentation is added or updated
- [x] tests are added or updated
