### PR TITLE
Use ERR_R_*_LIB instead of ERR_LIB_* as reason code for sub-libraries

### DIFF
--- a/crypto/ct/ct_log.c
+++ b/crypto/ct/ct_log.c
@@ -88,7 +88,7 @@ static int ct_v1_log_id_from_pkey(CTLOG *log, EVP_PKEY *pkey)
     }
     sha256 = EVP_MD_fetch(log->libctx, "SHA2-256", log->propq);
     if (sha256 == NULL) {
-        ERR_raise(ERR_LIB_CT, ERR_LIB_EVP);
+        ERR_raise(ERR_LIB_CT, ERR_R_EVP_LIB);
         goto err;
     }
 

--- a/crypto/rsa/rsa_gen.c
+++ b/crypto/rsa/rsa_gen.c
@@ -410,7 +410,7 @@ static int rsa_multiprime_keygen(RSA *rsa, int bits, int primes,
     ok = 1;
  err:
     if (ok == -1) {
-        ERR_raise(ERR_LIB_RSA, ERR_LIB_BN);
+        ERR_raise(ERR_LIB_RSA, ERR_R_BN_LIB);
         ok = 0;
     }
     BN_CTX_end(ctx);

--- a/providers/implementations/signature/rsa.c
+++ b/providers/implementations/signature/rsa.c
@@ -517,7 +517,7 @@ static int rsa_sign(void *vprsactx, unsigned char *sig, size_t *siglen,
                                              prsactx->rsa);
 
             if (ret <= 0) {
-                ERR_raise(ERR_LIB_PROV, ERR_LIB_RSA);
+                ERR_raise(ERR_LIB_PROV, ERR_R_RSA_LIB);
                 return 0;
             }
             ret = sltmp;
@@ -550,7 +550,7 @@ static int rsa_sign(void *vprsactx, unsigned char *sig, size_t *siglen,
                 ret = RSA_sign(prsactx->mdnid, tbs, tbslen, sig, &sltmp,
                                prsactx->rsa);
                 if (ret <= 0) {
-                    ERR_raise(ERR_LIB_PROV, ERR_LIB_RSA);
+                    ERR_raise(ERR_LIB_PROV, ERR_R_RSA_LIB);
                     return 0;
                 }
                 ret = sltmp;
@@ -592,7 +592,7 @@ static int rsa_sign(void *vprsactx, unsigned char *sig, size_t *siglen,
                                                 prsactx->tbuf, tbs,
                                                 prsactx->md, prsactx->mgf1_md,
                                                 prsactx->saltlen)) {
-                ERR_raise(ERR_LIB_PROV, ERR_LIB_RSA);
+                ERR_raise(ERR_LIB_PROV, ERR_R_RSA_LIB);
                 return 0;
             }
             ret = RSA_private_encrypt(RSA_size(prsactx->rsa), prsactx->tbuf,
@@ -614,7 +614,7 @@ static int rsa_sign(void *vprsactx, unsigned char *sig, size_t *siglen,
  end:
 #endif
     if (ret <= 0) {
-        ERR_raise(ERR_LIB_PROV, ERR_LIB_RSA);
+        ERR_raise(ERR_LIB_PROV, ERR_R_RSA_LIB);
         return 0;
     }
 
@@ -655,7 +655,7 @@ static int rsa_verify_recover(void *vprsactx,
             ret = RSA_public_decrypt(siglen, sig, prsactx->tbuf, prsactx->rsa,
                                      RSA_X931_PADDING);
             if (ret < 1) {
-                ERR_raise(ERR_LIB_PROV, ERR_LIB_RSA);
+                ERR_raise(ERR_LIB_PROV, ERR_R_RSA_LIB);
                 return 0;
             }
             ret--;
@@ -689,7 +689,7 @@ static int rsa_verify_recover(void *vprsactx,
                 ret = int_rsa_verify(prsactx->mdnid, NULL, 0, rout, &sltmp,
                                      sig, siglen, prsactx->rsa);
                 if (ret <= 0) {
-                    ERR_raise(ERR_LIB_PROV, ERR_LIB_RSA);
+                    ERR_raise(ERR_LIB_PROV, ERR_R_RSA_LIB);
                     return 0;
                 }
                 ret = sltmp;
@@ -705,7 +705,7 @@ static int rsa_verify_recover(void *vprsactx,
         ret = RSA_public_decrypt(siglen, sig, rout, prsactx->rsa,
                                  prsactx->pad_mode);
         if (ret < 0) {
-            ERR_raise(ERR_LIB_PROV, ERR_LIB_RSA);
+            ERR_raise(ERR_LIB_PROV, ERR_R_RSA_LIB);
             return 0;
         }
     }
@@ -733,7 +733,7 @@ static int rsa_verify(void *vprsactx, const unsigned char *sig, size_t siglen,
         case RSA_PKCS1_PADDING:
             if (!RSA_verify(prsactx->mdnid, tbs, tbslen, sig, siglen,
                             prsactx->rsa)) {
-                ERR_raise(ERR_LIB_PROV, ERR_LIB_RSA);
+                ERR_raise(ERR_LIB_PROV, ERR_R_RSA_LIB);
                 return 0;
             }
             return 1;
@@ -766,7 +766,7 @@ static int rsa_verify(void *vprsactx, const unsigned char *sig, size_t siglen,
                 ret = RSA_public_decrypt(siglen, sig, prsactx->tbuf,
                                          prsactx->rsa, RSA_NO_PADDING);
                 if (ret <= 0) {
-                    ERR_raise(ERR_LIB_PROV, ERR_LIB_RSA);
+                    ERR_raise(ERR_LIB_PROV, ERR_R_RSA_LIB);
                     return 0;
                 }
                 ret = RSA_verify_PKCS1_PSS_mgf1(prsactx->rsa, tbs,
@@ -774,7 +774,7 @@ static int rsa_verify(void *vprsactx, const unsigned char *sig, size_t siglen,
                                                 prsactx->tbuf,
                                                 prsactx->saltlen);
                 if (ret <= 0) {
-                    ERR_raise(ERR_LIB_PROV, ERR_LIB_RSA);
+                    ERR_raise(ERR_LIB_PROV, ERR_R_RSA_LIB);
                     return 0;
                 }
                 return 1;
@@ -790,7 +790,7 @@ static int rsa_verify(void *vprsactx, const unsigned char *sig, size_t siglen,
         rslen = RSA_public_decrypt(siglen, sig, prsactx->tbuf, prsactx->rsa,
                                    prsactx->pad_mode);
         if (rslen == 0) {
-            ERR_raise(ERR_LIB_PROV, ERR_LIB_RSA);
+            ERR_raise(ERR_LIB_PROV, ERR_R_RSA_LIB);
             return 0;
         }
     }

--- a/ssl/record/ssl3_record.c
+++ b/ssl/record/ssl3_record.c
@@ -528,7 +528,7 @@ int ssl3_get_record(SSL *s)
         if (tmpmd != NULL) {
             imac_size = EVP_MD_size(tmpmd);
             if (!ossl_assert(imac_size >= 0 && imac_size <= EVP_MAX_MD_SIZE)) {
-                    SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_LIB_EVP);
+                    SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_EVP_LIB);
                     return -1;
             }
             mac_size = (size_t)imac_size;
@@ -1552,7 +1552,7 @@ int dtls1_process_record(SSL *s, DTLS1_BITMAP *bitmap)
         if (tmpmd != NULL) {
             imac_size = EVP_MD_size(tmpmd);
             if (!ossl_assert(imac_size >= 0 && imac_size <= EVP_MAX_MD_SIZE)) {
-                    SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_LIB_EVP);
+                    SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_EVP_LIB);
                     return -1;
             }
             mac_size = (size_t)imac_size;


### PR DESCRIPTION
Using ERR_LIB_* causes the error output to say 'reason(n)' instead of
the name of the sub-library in question.
