### PR TITLE
Rename OSSL_ENCODER_CTX_new_by_EVP_PKEY and OSSL_DECODER_CTX_new_by_EVP_PKEY

### DIFF
--- a/apps/dhparam.c
+++ b/apps/dhparam.c
@@ -253,14 +253,14 @@ int dhparam_main(int argc, char **argv)
             * We check that we got one of those key types afterwards.
             */
             decoderctx
-                = OSSL_DECODER_CTX_new_by_EVP_PKEY(&tmppkey,
-                                                    (informat == FORMAT_ASN1)
+                = OSSL_DECODER_CTX_new_for_pkey(&tmppkey,
+                                                (informat == FORMAT_ASN1)
                                                     ? "DER" : "PEM",
-                                                    NULL,
-                                                    (informat == FORMAT_ASN1)
+                                                NULL,
+                                                (informat == FORMAT_ASN1)
                                                     ? keytype : NULL,
-                                                    OSSL_KEYMGMT_SELECT_DOMAIN_PARAMETERS,
-                                                    NULL, NULL);
+                                                OSSL_KEYMGMT_SELECT_DOMAIN_PARAMETERS,
+                                                NULL, NULL);
 
             if (decoderctx != NULL
                     && !OSSL_DECODER_from_bio(decoderctx, in)
@@ -327,11 +327,11 @@ int dhparam_main(int argc, char **argv)
 
     if (!noout) {
         OSSL_ENCODER_CTX *ectx =
-            OSSL_ENCODER_CTX_new_by_EVP_PKEY(pkey,
-                                             OSSL_KEYMGMT_SELECT_DOMAIN_PARAMETERS,
-                                             outformat == FORMAT_ASN1
-                                             ? "DER" : "PEM",
-                                             NULL, NULL);
+            OSSL_ENCODER_CTX_new_for_pkey(pkey,
+                                          OSSL_KEYMGMT_SELECT_DOMAIN_PARAMETERS,
+                                          outformat == FORMAT_ASN1
+                                              ? "DER" : "PEM",
+                                          NULL, NULL);
 
         if (ectx == NULL || !OSSL_ENCODER_to_bio(ectx, out)) {
             OSSL_ENCODER_CTX_free(ectx);

--- a/apps/dsa.c
+++ b/apps/dsa.c
@@ -257,8 +257,8 @@ int dsa_main(int argc, char **argv)
     }
 
     /* Perform the encoding */
-    ectx = OSSL_ENCODER_CTX_new_by_EVP_PKEY(pkey, selection, output_type,
-                                            output_structure, NULL);
+    ectx = OSSL_ENCODER_CTX_new_for_pkey(pkey, selection, output_type,
+                                         output_structure, NULL);
     if (OSSL_ENCODER_CTX_get_num_encoders(ectx) == 0) {
         BIO_printf(bio_err, "%s format not supported\n", output_type);
         goto end;

--- a/apps/ec.c
+++ b/apps/ec.c
@@ -253,9 +253,9 @@ int ec_main(int argc, char **argv)
             assert(private);
         }
 
-        ectx = OSSL_ENCODER_CTX_new_by_EVP_PKEY(eckey, selection,
-                                                output_type, output_structure,
-                                                NULL);
+        ectx = OSSL_ENCODER_CTX_new_for_pkey(eckey, selection,
+                                             output_type, output_structure,
+                                             NULL);
         if (enc != NULL) {
             OSSL_ENCODER_CTX_set_cipher(ectx, EVP_CIPHER_name(enc), NULL);
             if (passout != NULL)

--- a/apps/ecparam.c
+++ b/apps/ecparam.c
@@ -291,7 +291,7 @@ int ecparam_main(int argc, char **argv)
         noout = 1;
 
     if (!noout) {
-        ectx_params = OSSL_ENCODER_CTX_new_by_EVP_PKEY(
+        ectx_params = OSSL_ENCODER_CTX_new_for_pkey(
                           params_key, OSSL_KEYMGMT_SELECT_DOMAIN_PARAMETERS,
                           outformat == FORMAT_ASN1 ? "DER" : "PEM", NULL, NULL);
         if (!OSSL_ENCODER_to_bio(ectx_params, out)) {
@@ -316,7 +316,7 @@ int ecparam_main(int argc, char **argv)
             goto end;
         }
         assert(private);
-        ectx_key = OSSL_ENCODER_CTX_new_by_EVP_PKEY(
+        ectx_key = OSSL_ENCODER_CTX_new_for_pkey(
                        key, OSSL_KEYMGMT_SELECT_ALL,
                        outformat == FORMAT_ASN1 ? "DER" : "PEM", NULL, NULL);
         if (!OSSL_ENCODER_to_bio(ectx_key, out)) {

--- a/apps/rsa.c
+++ b/apps/rsa.c
@@ -331,9 +331,9 @@ int rsa_main(int argc, char **argv)
     }
 
     /* Now, perform the encoding */
-    ectx = OSSL_ENCODER_CTX_new_by_EVP_PKEY(pkey, selection,
-                                            output_type, output_structure,
-                                            NULL);
+    ectx = OSSL_ENCODER_CTX_new_for_pkey(pkey, selection,
+                                         output_type, output_structure,
+                                         NULL);
     if (OSSL_ENCODER_CTX_get_num_encoders(ectx) == 0) {
         BIO_printf(bio_err, "%s format not supported\n", output_type);
         goto end;

--- a/crypto/asn1/i2d_evp.c
+++ b/crypto/asn1/i2d_evp.c
@@ -42,8 +42,8 @@ static int i2d_provided(const EVP_PKEY *a, int selection,
          */
         size_t len = INT_MAX;
 
-        ctx = OSSL_ENCODER_CTX_new_by_EVP_PKEY(a, selection, "DER",
-                                               *output_structures, NULL);
+        ctx = OSSL_ENCODER_CTX_new_for_pkey(a, selection, "DER",
+                                            *output_structures, NULL);
         if (ctx == NULL)
             return -1;
         if (OSSL_ENCODER_to_data(ctx, pp, &len))

--- a/crypto/cms/cms_ec.c
+++ b/crypto/cms/cms_ec.c
@@ -27,8 +27,8 @@ static EVP_PKEY *pkey_type2param(int ptype, const void *pval,
         OSSL_DECODER_CTX *ctx = NULL;
         int selection = OSSL_KEYMGMT_SELECT_ALL_PARAMETERS;
 
-        ctx = OSSL_DECODER_CTX_new_by_EVP_PKEY(&pkey, "DER", NULL, "EC",
-                                               selection, libctx, propq);
+        ctx = OSSL_DECODER_CTX_new_for_pkey(&pkey, "DER", NULL, "EC",
+                                            selection, libctx, propq);
         if (ctx == NULL)
             goto err;
 

--- a/crypto/encode_decode/decoder_pkey.c
+++ b/crypto/encode_decode/decoder_pkey.c
@@ -48,13 +48,13 @@ int OSSL_DECODER_CTX_set_passphrase_cb(OSSL_DECODER_CTX *ctx,
 }
 
 /*
- * Support for OSSL_DECODER_CTX_new_by_EVP_PKEY:
+ * Support for OSSL_DECODER_CTX_new_for_pkey:
  * The construct data, and collecting keymgmt information for it
  */
 
 DEFINE_STACK_OF(EVP_KEYMGMT)
 
-struct decoder_EVP_PKEY_data_st {
+struct decoder_pkey_data_st {
     OSSL_LIB_CTX *libctx;
     char *propq;
 
@@ -62,11 +62,11 @@ struct decoder_EVP_PKEY_data_st {
     void **object;               /* Where the result should end up */
 };
 
-static int decoder_construct_EVP_PKEY(OSSL_DECODER_INSTANCE *decoder_inst,
-                                      const OSSL_PARAM *params,
-                                      void *construct_data)
+static int decoder_construct_pkey(OSSL_DECODER_INSTANCE *decoder_inst,
+                                  const OSSL_PARAM *params,
+                                  void *construct_data)
 {
-    struct decoder_EVP_PKEY_data_st *data = construct_data;
+    struct decoder_pkey_data_st *data = construct_data;
     OSSL_DECODER *decoder = OSSL_DECODER_INSTANCE_get_decoder(decoder_inst);
     void *decoderctx = OSSL_DECODER_INSTANCE_get_decoder_ctx(decoder_inst);
     EVP_KEYMGMT *keymgmt = NULL;
@@ -159,9 +159,9 @@ static int decoder_construct_EVP_PKEY(OSSL_DECODER_INSTANCE *decoder_inst,
     return (*data->object != NULL);
 }
 
-static void decoder_clean_EVP_PKEY_construct_arg(void *construct_data)
+static void decoder_clean_pkey_construct_arg(void *construct_data)
 {
-    struct decoder_EVP_PKEY_data_st *data = construct_data;
+    struct decoder_pkey_data_st *data = construct_data;
 
     if (data != NULL) {
         OPENSSL_free(data->propq);
@@ -269,12 +269,12 @@ static void collect_decoder(OSSL_DECODER *decoder, void *arg)
     data->error_occured = 0;         /* All is good now */
 }
 
-int ossl_decoder_ctx_setup_for_EVP_PKEY(OSSL_DECODER_CTX *ctx,
-                                        EVP_PKEY **pkey, const char *keytype,
-                                        OSSL_LIB_CTX *libctx,
-                                        const char *propquery)
+int ossl_decoder_ctx_setup_for_pkey(OSSL_DECODER_CTX *ctx,
+                                    EVP_PKEY **pkey, const char *keytype,
+                                    OSSL_LIB_CTX *libctx,
+                                    const char *propquery)
 {
-    struct decoder_EVP_PKEY_data_st *process_data = NULL;
+    struct decoder_pkey_data_st *process_data = NULL;
     STACK_OF(EVP_KEYMGMT) *keymgmts = NULL;
     STACK_OF(OPENSSL_CSTRING) *names = NULL;
     int ok = 0;
@@ -327,10 +327,10 @@ int ossl_decoder_ctx_setup_for_EVP_PKEY(OSSL_DECODER_CTX *ctx,
     }
 
     if (OSSL_DECODER_CTX_get_num_decoders(ctx) != 0) {
-        if (!OSSL_DECODER_CTX_set_construct(ctx, decoder_construct_EVP_PKEY)
+        if (!OSSL_DECODER_CTX_set_construct(ctx, decoder_construct_pkey)
             || !OSSL_DECODER_CTX_set_construct_data(ctx, process_data)
             || !OSSL_DECODER_CTX_set_cleanup(ctx,
-                                             decoder_clean_EVP_PKEY_construct_arg))
+                                             decoder_clean_pkey_construct_arg))
             goto err;
 
         process_data = NULL; /* Avoid it being freed */
@@ -338,16 +338,16 @@ int ossl_decoder_ctx_setup_for_EVP_PKEY(OSSL_DECODER_CTX *ctx,
 
     ok = 1;
  err:
-    decoder_clean_EVP_PKEY_construct_arg(process_data);
+    decoder_clean_pkey_construct_arg(process_data);
     return ok;
 }
 
 OSSL_DECODER_CTX *
-OSSL_DECODER_CTX_new_by_EVP_PKEY(EVP_PKEY **pkey,
-                                 const char *input_type,
-                                 const char *input_structure,
-                                 const char *keytype, int selection,
-                                 OSSL_LIB_CTX *libctx, const char *propquery)
+OSSL_DECODER_CTX_new_for_pkey(EVP_PKEY **pkey,
+                              const char *input_type,
+                              const char *input_structure,
+                              const char *keytype, int selection,
+                              OSSL_LIB_CTX *libctx, const char *propquery)
 {
     OSSL_DECODER_CTX *ctx = NULL;
 
@@ -367,8 +367,8 @@ OSSL_DECODER_CTX_new_by_EVP_PKEY(EVP_PKEY **pkey,
     if (OSSL_DECODER_CTX_set_input_type(ctx, input_type)
         && OSSL_DECODER_CTX_set_input_structure(ctx, input_structure)
         && OSSL_DECODER_CTX_set_selection(ctx, selection)
-        && ossl_decoder_ctx_setup_for_EVP_PKEY(ctx, pkey, keytype,
-                                               libctx, propquery)
+        && ossl_decoder_ctx_setup_for_pkey(ctx, pkey, keytype,
+                                           libctx, propquery)
         && OSSL_DECODER_CTX_add_extra(ctx, libctx, propquery)) {
         OSSL_TRACE_BEGIN(DECODER) {
             BIO_printf(trc_out, "(ctx %p) Got %d decoders\n",

--- a/crypto/encode_decode/encoder_pkey.c
+++ b/crypto/encode_decode/encoder_pkey.c
@@ -67,7 +67,7 @@ int OSSL_ENCODER_CTX_set_passphrase_cb(OSSL_ENCODER_CTX *ctx,
 }
 
 /*
- * Support for OSSL_ENCODER_CTX_new_by_TYPE:
+ * Support for OSSL_ENCODER_CTX_new_for_type:
  * finding a suitable encoder
  */
 
@@ -162,7 +162,7 @@ static int encoder_import_cb(const OSSL_PARAM params[], void *arg)
 }
 
 static const void *
-encoder_construct_EVP_PKEY(OSSL_ENCODER_INSTANCE *encoder_inst, void *arg)
+encoder_construct_pkey(OSSL_ENCODER_INSTANCE *encoder_inst, void *arg)
 {
     struct construct_data_st *data = arg;
 
@@ -188,7 +188,7 @@ encoder_construct_EVP_PKEY(OSSL_ENCODER_INSTANCE *encoder_inst, void *arg)
     return data->obj;
 }
 
-static void encoder_destruct_EVP_PKEY(void *arg)
+static void encoder_destruct_pkey(void *arg)
 {
     struct construct_data_st *data = arg;
 
@@ -202,15 +202,15 @@ static void encoder_destruct_EVP_PKEY(void *arg)
 }
 
 /*
- * OSSL_ENCODER_CTX_new_by_EVP_PKEY() returns a ctx with no encoder if
+ * OSSL_ENCODER_CTX_new_for_pkey() returns a ctx with no encoder if
  * it couldn't find a suitable encoder.  This allows a caller to detect if
  * a suitable encoder was found, with OSSL_ENCODER_CTX_get_num_encoder(),
  * and to use fallback methods if the result is NULL.
  */
-static int ossl_encoder_ctx_setup_for_EVP_PKEY(OSSL_ENCODER_CTX *ctx,
-                                               const EVP_PKEY *pkey,
-                                               int selection,
-                                               const char *propquery)
+static int ossl_encoder_ctx_setup_for_pkey(OSSL_ENCODER_CTX *ctx,
+                                           const EVP_PKEY *pkey,
+                                           int selection,
+                                           const char *propquery)
 {
     struct construct_data_st *data = NULL;
     OSSL_LIB_CTX *libctx = NULL;
@@ -262,9 +262,9 @@ static int ossl_encoder_ctx_setup_for_EVP_PKEY(OSSL_ENCODER_CTX *ctx,
     }
 
     if (OSSL_ENCODER_CTX_get_num_encoders(ctx) != 0) {
-        if (!OSSL_ENCODER_CTX_set_construct(ctx, encoder_construct_EVP_PKEY)
+        if (!OSSL_ENCODER_CTX_set_construct(ctx, encoder_construct_pkey)
             || !OSSL_ENCODER_CTX_set_construct_data(ctx, data)
-            || !OSSL_ENCODER_CTX_set_cleanup(ctx, encoder_destruct_EVP_PKEY))
+            || !OSSL_ENCODER_CTX_set_cleanup(ctx, encoder_destruct_pkey))
             goto err;
 
         data->pk = pkey;
@@ -282,11 +282,11 @@ static int ossl_encoder_ctx_setup_for_EVP_PKEY(OSSL_ENCODER_CTX *ctx,
     return ok;
 }
 
-OSSL_ENCODER_CTX *OSSL_ENCODER_CTX_new_by_EVP_PKEY(const EVP_PKEY *pkey,
-                                                   int selection,
-                                                   const char *output_type,
-                                                   const char *output_struct,
-                                                   const char *propquery)
+OSSL_ENCODER_CTX *OSSL_ENCODER_CTX_new_for_pkey(const EVP_PKEY *pkey,
+                                                int selection,
+                                                const char *output_type,
+                                                const char *output_struct,
+                                                const char *propquery)
 {
     OSSL_ENCODER_CTX *ctx = NULL;
     OSSL_LIB_CTX *libctx = NULL;
@@ -325,7 +325,7 @@ OSSL_ENCODER_CTX *OSSL_ENCODER_CTX_new_by_EVP_PKEY(const EVP_PKEY *pkey,
         && (output_struct == NULL
             || OSSL_ENCODER_CTX_set_output_structure(ctx, output_struct))
         && OSSL_ENCODER_CTX_set_selection(ctx, selection)
-        && ossl_encoder_ctx_setup_for_EVP_PKEY(ctx, pkey, selection, propquery)
+        && ossl_encoder_ctx_setup_for_pkey(ctx, pkey, selection, propquery)
         && OSSL_ENCODER_CTX_add_extra(ctx, libctx, propquery)) {
         OSSL_TRACE_BEGIN(ENCODER) {
             BIO_printf(trc_out, "(ctx %p) Got %d encoders\n",

--- a/crypto/evp/evp_pkey.c
+++ b/crypto/evp/evp_pkey.c
@@ -85,9 +85,9 @@ PKCS8_PRIV_KEY_INFO *EVP_PKEY2PKCS8(const EVP_PKEY *pkey)
         size_t derlen = 0;
         const unsigned char *pp;
 
-        if ((ctx = OSSL_ENCODER_CTX_new_by_EVP_PKEY(pkey, selection,
-                                                    "DER", "pkcs8",
-                                                    NULL)) == NULL
+        if ((ctx = OSSL_ENCODER_CTX_new_for_pkey(pkey, selection,
+                                                 "DER", "pkcs8",
+                                                 NULL)) == NULL
             || !OSSL_ENCODER_to_data(ctx, &der, &derlen))
             goto error;
 

--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -1093,8 +1093,8 @@ static int print_pkey(const EVP_PKEY *pkey, BIO *out, int indent,
     if (!print_set_indent(&out, &pop_f_prefix, &saved_indent, indent))
         return 0;
 
-    ctx = OSSL_ENCODER_CTX_new_by_EVP_PKEY(pkey, selection, "TEXT", NULL,
-                                           propquery);
+    ctx = OSSL_ENCODER_CTX_new_for_pkey(pkey, selection, "TEXT", NULL,
+                                        propquery);
     if (OSSL_ENCODER_CTX_get_num_encoders(ctx) != 0)
         ret = OSSL_ENCODER_to_bio(ctx, out);
     OSSL_ENCODER_CTX_free(ctx);

--- a/crypto/pem/pem_all.c
+++ b/crypto/pem/pem_all.c
@@ -223,4 +223,4 @@ DH *PEM_read_DHparams(FILE *fp, DH **x, pem_password_cb *cb, void *u)
 # endif
 
 #endif
-IMPLEMENT_PEM_provided_write(PUBKEY, EVP_PKEY, PEM_STRING_PUBLIC, PUBKEY)
+IMPLEMENT_PEM_provided_write(PUBKEY, EVP_PKEY, pkey, PEM_STRING_PUBLIC, PUBKEY)

--- a/crypto/pem/pem_local.h
+++ b/crypto/pem/pem_local.h
@@ -47,7 +47,7 @@
 # define IMPLEMENT_PEM_provided_write_body_vars(type, asn1, pq)         \
     int ret = 0;                                                        \
     OSSL_ENCODER_CTX *ctx =                                             \
-        OSSL_ENCODER_CTX_new_by_##type(x, PEM_SELECTION_##asn1,         \
+        OSSL_ENCODER_CTX_new_for_##type(x, PEM_SELECTION_##asn1,        \
                                        "PEM", PEM_STRUCTURE_##asn1,     \
                                        (pq));                           \
                                                                         \
@@ -98,16 +98,16 @@
     return PEM_ASN1_##writename##((i2d_of_void *)i2d_##asn1, str, out,  \
                                   x, enc, kstr, klen, cb, u)
 
-# define IMPLEMENT_PEM_provided_write_to(name, type, str, asn1,         \
+# define IMPLEMENT_PEM_provided_write_to(name, TYPE, type, str, asn1,   \
                                          OUTTYPE, outtype, writename)   \
-    PEM_write_fnsig(name, type, OUTTYPE, writename)                     \
+    PEM_write_fnsig(name, TYPE, OUTTYPE, writename)                     \
     {                                                                   \
         IMPLEMENT_PEM_provided_write_body_vars(type, asn1, NULL);       \
         IMPLEMENT_PEM_provided_write_body_main(type, outtype);          \
         IMPLEMENT_PEM_provided_write_body_fallback(str, asn1,           \
                                                    writename);          \
     }                                                                   \
-    PEM_write_ex_fnsig(name, type, OUTTYPE, writename)                  \
+    PEM_write_ex_fnsig(name, TYPE, OUTTYPE, writename)                  \
     {                                                                   \
         IMPLEMENT_PEM_provided_write_body_vars(type, asn1, propq);      \
         IMPLEMENT_PEM_provided_write_body_main(type, outtype);          \
@@ -116,9 +116,9 @@
     }
 
 
-# define IMPLEMENT_PEM_provided_write_cb_to(name, type, str, asn1,      \
+# define IMPLEMENT_PEM_provided_write_cb_to(name, TYPE, type, str, asn1, \
                                             OUTTYPE, outtype, writename) \
-    PEM_write_cb_fnsig(name, type, OUTTYPE, writename)                  \
+    PEM_write_cb_fnsig(name, TYPE, OUTTYPE, writename)                  \
     {                                                                   \
         IMPLEMENT_PEM_provided_write_body_vars(type, asn1, NULL);       \
         IMPLEMENT_PEM_provided_write_body_pass();                       \
@@ -126,7 +126,7 @@
         IMPLEMENT_PEM_provided_write_body_fallback_cb(str, asn1,        \
                                                       writename);       \
     }                                                                   \
-    PEM_write_ex_cb_fnsig(name, type, OUTTYPE, writename)               \
+    PEM_write_ex_cb_fnsig(name, TYPE, OUTTYPE, writename)               \
     {                                                                   \
         IMPLEMENT_PEM_provided_write_body_vars(type, asn1, propq);      \
         IMPLEMENT_PEM_provided_write_body_pass();                       \
@@ -137,36 +137,36 @@
 
 # ifdef OPENSSL_NO_STDIO
 
-#  define IMPLEMENT_PEM_provided_write_fp(name, type, str, asn1)
-#  define IMPLEMENT_PEM_provided_write_cb_fp(name, type, str, asn1)
+#  define IMPLEMENT_PEM_provided_write_fp(name, TYPE, type, str, asn1)
+#  define IMPLEMENT_PEM_provided_write_cb_fp(name, TYPE, type, str, asn1)
 
 # else
 
-#  define IMPLEMENT_PEM_provided_write_fp(name, type, str, asn1)        \
-    IMPLEMENT_PEM_provided_write_to(name, type, str, asn1, FILE, fp, write)
-#  define IMPLEMENT_PEM_provided_write_cb_fp(name, type, str, asn1)     \
-    IMPLEMENT_PEM_provided_write_cb_to(name, type, str, asn1, FILE, fp, write)
+#  define IMPLEMENT_PEM_provided_write_fp(name, TYPE, type, str, asn1)    \
+    IMPLEMENT_PEM_provided_write_to(name, TYPE, type, str, asn1, FILE, fp, write)
+#  define IMPLEMENT_PEM_provided_write_cb_fp(name, TYPE, type, str, asn1) \
+    IMPLEMENT_PEM_provided_write_cb_to(name, TYPE, type, str, asn1, FILE, fp, write)
 
 # endif
 
-# define IMPLEMENT_PEM_provided_write_bio(name, type, str, asn1)        \
-    IMPLEMENT_PEM_provided_write_to(name, type, str, asn1, BIO, bio, write_bio)
-# define IMPLEMENT_PEM_provided_write_cb_bio(name, type, str, asn1)     \
-    IMPLEMENT_PEM_provided_write_cb_to(name, type, str, asn1, BIO, bio, write_bio)
+# define IMPLEMENT_PEM_provided_write_bio(name, TYPE, type, str, asn1)    \
+    IMPLEMENT_PEM_provided_write_to(name, TYPE, type, str, asn1, BIO, bio, write_bio)
+# define IMPLEMENT_PEM_provided_write_cb_bio(name, TYPE, type, str, asn1) \
+    IMPLEMENT_PEM_provided_write_cb_to(name, TYPE, type, str, asn1, BIO, bio, write_bio)
 
-# define IMPLEMENT_PEM_provided_write(name, type, str, asn1)    \
-    IMPLEMENT_PEM_provided_write_bio(name, type, str, asn1)     \
-    IMPLEMENT_PEM_provided_write_fp(name, type, str, asn1)
+# define IMPLEMENT_PEM_provided_write(name, TYPE, type, str, asn1)        \
+    IMPLEMENT_PEM_provided_write_bio(name, TYPE, type, str, asn1)         \
+    IMPLEMENT_PEM_provided_write_fp(name, TYPE, type, str, asn1)
 
-# define IMPLEMENT_PEM_provided_write_cb(name, type, str, asn1)         \
-    IMPLEMENT_PEM_provided_write_cb_bio(name, type, str, asn1)          \
-    IMPLEMENT_PEM_provided_write_cb_fp(name, type, str, asn1)
+# define IMPLEMENT_PEM_provided_write_cb(name, TYPE, type, str, asn1)     \
+    IMPLEMENT_PEM_provided_write_cb_bio(name, TYPE, type, str, asn1)      \
+    IMPLEMENT_PEM_provided_write_cb_fp(name, TYPE, type, str, asn1)
 
-# define IMPLEMENT_PEM_provided_rw(name, type, str, asn1)       \
-    IMPLEMENT_PEM_read(name, type, str, asn1)                   \
-    IMPLEMENT_PEM_provided_write(name, type, str, asn1)
+# define IMPLEMENT_PEM_provided_rw(name, TYPE, type, str, asn1)           \
+    IMPLEMENT_PEM_read(name, TYPE, str, asn1)                             \
+    IMPLEMENT_PEM_provided_write(name, TYPE, type, str, asn1)
 
-# define IMPLEMENT_PEM_provided_rw_cb(name, type, str, asn1)    \
-    IMPLEMENT_PEM_read(name, type, str, asn1)                   \
-    IMPLEMENT_PEM_provided_write_cb(name, type, str, asn1)
+# define IMPLEMENT_PEM_provided_rw_cb(name, TYPE, type, str, asn1)        \
+    IMPLEMENT_PEM_read(name, TYPE, str, asn1)                             \
+    IMPLEMENT_PEM_provided_write_cb(name, TYPE, type, str, asn1)
 

--- a/crypto/pem/pem_pk8.c
+++ b/crypto/pem/pem_pk8.c
@@ -73,8 +73,8 @@ static int do_pk8pkey(BIO *bp, const EVP_PKEY *x, int isder, int nid,
     int ret = 0;
     const char *outtype = isder ? "DER" : "PEM";
     OSSL_ENCODER_CTX *ctx =
-        OSSL_ENCODER_CTX_new_by_EVP_PKEY(x, OSSL_KEYMGMT_SELECT_ALL,
-                                         outtype, "pkcs8", propq);
+        OSSL_ENCODER_CTX_new_for_pkey(x, OSSL_KEYMGMT_SELECT_ALL,
+                                      outtype, "pkcs8", propq);
 
     if (ctx == NULL)
         return 0;

--- a/crypto/pem/pem_pkey.c
+++ b/crypto/pem/pem_pkey.c
@@ -153,10 +153,10 @@ EVP_PKEY *PEM_read_bio_PrivateKey(BIO *bp, EVP_PKEY **x, pem_password_cb *cb,
 
 PEM_write_cb_ex_fnsig(PrivateKey, EVP_PKEY, BIO, write_bio)
 {
-    IMPLEMENT_PEM_provided_write_body_vars(EVP_PKEY, PrivateKey, propq);
+    IMPLEMENT_PEM_provided_write_body_vars(pkey, PrivateKey, propq);
 
     IMPLEMENT_PEM_provided_write_body_pass();
-    IMPLEMENT_PEM_provided_write_body_main(EVP_PKEY, bio);
+    IMPLEMENT_PEM_provided_write_body_main(pkey, bio);
 
  legacy:
     if (x->ameth == NULL || x->ameth->priv_encode != NULL)
@@ -218,9 +218,9 @@ EVP_PKEY *PEM_read_bio_Parameters(BIO *bp, EVP_PKEY **x)
 PEM_write_fnsig(Parameters, EVP_PKEY, BIO, write_bio)
 {
     char pem_str[80];
-    IMPLEMENT_PEM_provided_write_body_vars(EVP_PKEY, Parameters, NULL);
+    IMPLEMENT_PEM_provided_write_body_vars(pkey, Parameters, NULL);
 
-    IMPLEMENT_PEM_provided_write_body_main(EVP_PKEY, bio);
+    IMPLEMENT_PEM_provided_write_body_main(pkey, bio);
 
  legacy:
     if (!x->ameth || !x->ameth->param_encode)

--- a/crypto/store/store_result.c
+++ b/crypto/store/store_result.c
@@ -274,8 +274,8 @@ static EVP_PKEY *try_key_value(struct extracted_param_data_st *data,
     }
 
     decoderctx =
-        OSSL_DECODER_CTX_new_by_EVP_PKEY(&pk, "DER", NULL, data->data_type,
-                                         selection, libctx, propq);
+        OSSL_DECODER_CTX_new_for_pkey(&pk, "DER", NULL, data->data_type,
+                                      selection, libctx, propq);
     (void)OSSL_DECODER_CTX_set_passphrase_cb(decoderctx, cb, cbarg);
 
     /* No error if this couldn't be decoded */

--- a/crypto/x509/x_pubkey.c
+++ b/crypto/x509/x_pubkey.c
@@ -122,9 +122,9 @@ int X509_PUBKEY_set(X509_PUBKEY **x, EVP_PKEY *pkey)
         unsigned char *der = NULL;
         size_t derlen = 0;
         OSSL_ENCODER_CTX *ectx =
-            OSSL_ENCODER_CTX_new_by_EVP_PKEY(pkey, EVP_PKEY_PUBLIC_KEY,
-                                             "DER", "SubjectPublicKeyInfo",
-                                             NULL);
+            OSSL_ENCODER_CTX_new_for_pkey(pkey, EVP_PKEY_PUBLIC_KEY,
+                                          "DER", "SubjectPublicKeyInfo",
+                                          NULL);
 
         if (OSSL_ENCODER_to_data(ectx, &der, &derlen)) {
             const unsigned char *pder = der;
@@ -325,9 +325,9 @@ int i2d_PUBKEY(const EVP_PKEY *a, unsigned char **pp)
         X509_PUBKEY_free(xpk);
     } else if (a->keymgmt != NULL) {
         OSSL_ENCODER_CTX *ctx =
-            OSSL_ENCODER_CTX_new_by_EVP_PKEY(a, EVP_PKEY_PUBLIC_KEY,
-                                             "DER", "SubjectPublicKeyInfo",
-                                             NULL);
+            OSSL_ENCODER_CTX_new_for_pkey(a, EVP_PKEY_PUBLIC_KEY,
+                                          "DER", "SubjectPublicKeyInfo",
+                                          NULL);
         BIO *out = BIO_new(BIO_s_mem());
         BUF_MEM *buf = NULL;
 

--- a/doc/man3/OSSL_DECODER.pod
+++ b/doc/man3/OSSL_DECODER.pod
@@ -124,7 +124,7 @@ Text, because pod2xxx doesn't like empty sections
 =head1 SEE ALSO
 
 L<provider(7)>, L<OSSL_DECODER_CTX(3)>, L<OSSL_DECODER_from_bio(3)>,
-L<OSSL_DECODER_CTX_new_by_EVP_PKEY(3)>, L<OSSL_LIB_CTX(3)>
+L<OSSL_DECODER_CTX_new_for_pkey(3)>, L<OSSL_LIB_CTX(3)>
 
 =head1 HISTORY
 

--- a/doc/man3/OSSL_DECODER_CTX_new_for_pkey.pod
+++ b/doc/man3/OSSL_DECODER_CTX_new_for_pkey.pod
@@ -2,7 +2,7 @@
 
 =head1 NAME
 
-OSSL_DECODER_CTX_new_by_EVP_PKEY,
+OSSL_DECODER_CTX_new_for_pkey,
 OSSL_DECODER_CTX_set_passphrase,
 OSSL_DECODER_CTX_set_pem_password_cb,
 OSSL_DECODER_CTX_set_passphrase_ui,
@@ -14,11 +14,11 @@ OSSL_DECODER_CTX_set_passphrase_cb
  #include <openssl/decoder.h>
 
  OSSL_DECODER_CTX *
- OSSL_DECODER_CTX_new_by_EVP_PKEY(EVP_PKEY **pkey,
-                                  const char *input_type,
-                                  const char *input_struct,
-                                  const char *keytype, int selection,
-                                  OSSL_LIB_CTX *libctx, const char *propquery);
+ OSSL_DECODER_CTX_new_for_pkey(EVP_PKEY **pkey,
+                               const char *input_type,
+                               const char *input_struct,
+                               const char *keytype, int selection,
+                               OSSL_LIB_CTX *libctx, const char *propquery);
 
  int OSSL_DECODER_CTX_set_passphrase(OSSL_DECODER_CTX *ctx,
                                      const unsigned char *kstr,
@@ -35,14 +35,14 @@ OSSL_DECODER_CTX_set_passphrase_cb
 
 =head1 DESCRIPTION
 
-OSSL_DECODER_CTX_new_by_EVP_PKEY() is a utility function that creates a
+OSSL_DECODER_CTX_new_for_pkey() is a utility function that creates a
 B<OSSL_DECODER_CTX>, finds all applicable decoder implementations and sets
 them up, so all the caller has to do next is call functions like
 L<OSSL_DECODER_from_bio(3)>.  The caller may use the optional I<input_type>,
 I<input_struct>, I<keytype> and I<selection> to specify what the input is
 expected to contain.
 
-Internally OSSL_DECODER_CTX_new_by_EVP_PKEY() searches for all available
+Internally OSSL_DECODER_CTX_new_for_pkey() searches for all available
 L<EVP_KEYMGMT(3)> implementations, and then builds a list of all potential
 decoder implementations that may be able to process the encoded input into
 data suitable for B<EVP_PKEY>s.  All these implementations are implicitly
@@ -62,7 +62,7 @@ NULL and zero are valid and signify that the decoder implementations will
 find out the keytype and key contents on their own from the input they get.
 
 If no suitable decoder implementation is found,
-OSSL_DECODER_CTX_new_by_EVP_PKEY() still creates a B<OSSL_DECODER_CTX>, but
+OSSL_DECODER_CTX_new_for_pkey() still creates a B<OSSL_DECODER_CTX>, but
 with no associated decoder (L<OSSL_DECODER_CTX_get_num_decoders(3)> returns
 zero).  This helps the caller to distinguish between an error when creating
 the B<OSSL_ENCODER_CTX> and missing encoder implementation, and allows it to
@@ -107,7 +107,7 @@ encoded according to PKCS#1.
 
 =head1 RETURN VALUES
 
-OSSL_DECODER_CTX_new_by_EVP_PKEY() returns a pointer to a
+OSSL_DECODER_CTX_new_for_pkey() returns a pointer to a
 B<OSSL_DECODER_CTX>, or NULL if it couldn't be created.
 
 OSSL_DECODER_CTX_set_passphrase(), OSSL_DECODER_CTX_set_pem_password_cb(),
@@ -119,10 +119,6 @@ failure.
 
 Parts of the function names are made to match already existing OpenSSL
 names.
-
-B<EVP_PKEY> in OSSL_DECODER_CTX_new_by_EVP_PKEY() matches the type name,
-thus making for the naming pattern B<OSSL_DECODER_CTX_new_by_I<TYPE>>() when
-new types are handled.
 
 =head1 SEE ALSO
 

--- a/doc/man3/OSSL_DECODER_CTX_new_for_pkey.pod
+++ b/doc/man3/OSSL_DECODER_CTX_new_for_pkey.pod
@@ -40,7 +40,10 @@ B<OSSL_DECODER_CTX>, finds all applicable decoder implementations and sets
 them up, so all the caller has to do next is call functions like
 L<OSSL_DECODER_from_bio(3)>.  The caller may use the optional I<input_type>,
 I<input_struct>, I<keytype> and I<selection> to specify what the input is
-expected to contain.
+expected to contain.  The I<pkey> must reference an B<EVP_PKEY *> variable
+that will be set to the newly created B<EVP_PKEY> on succesfull decoding.
+The referenced variable must be initialized to NULL before calling the
+function.
 
 Internally OSSL_DECODER_CTX_new_for_pkey() searches for all available
 L<EVP_KEYMGMT(3)> implementations, and then builds a list of all potential

--- a/doc/man3/OSSL_DECODER_CTX_new_for_pkey.pod
+++ b/doc/man3/OSSL_DECODER_CTX_new_for_pkey.pod
@@ -118,11 +118,6 @@ OSSL_DECODER_CTX_set_passphrase_ui() and
 OSSL_DECODER_CTX_set_passphrase_cb() all return 1 on success, or 0 on
 failure.
 
-=head1 NOTES
-
-Parts of the function names are made to match already existing OpenSSL
-names.
-
 =head1 SEE ALSO
 
 L<provider(7)>, L<OSSL_DECODER(3)>, L<OSSL_DECODER_CTX(3)>

--- a/doc/man3/OSSL_ENCODER.pod
+++ b/doc/man3/OSSL_ENCODER.pod
@@ -117,7 +117,7 @@ OSSL_ENCODER_number() returns an integer.
 =head1 SEE ALSO
 
 L<provider(7)>, L<OSSL_ENCODER_CTX(3)>, L<OSSL_ENCODER_to_bio(3)>,
-L<OSSL_ENCODER_CTX_new_by_EVP_PKEY(3)>, L<OSSL_LIB_CTX(3)>
+L<OSSL_ENCODER_CTX_new_for_pkey(3)>, L<OSSL_LIB_CTX(3)>
 
 =head1 HISTORY
 

--- a/doc/man3/OSSL_ENCODER_CTX_new_for_pkey.pod
+++ b/doc/man3/OSSL_ENCODER_CTX_new_for_pkey.pod
@@ -2,7 +2,7 @@
 
 =head1 NAME
 
-OSSL_ENCODER_CTX_new_by_EVP_PKEY,
+OSSL_ENCODER_CTX_new_for_pkey,
 OSSL_ENCODER_CTX_set_cipher,
 OSSL_ENCODER_CTX_set_passphrase,
 OSSL_ENCODER_CTX_set_pem_password_cb,
@@ -15,10 +15,10 @@ OSSL_ENCODER_CTX_set_passphrase_ui
  #include <openssl/encoder.h>
 
  OSSL_ENCODER_CTX *
- OSSL_ENCODER_CTX_new_by_EVP_PKEY(const EVP_PKEY *pkey, int selection,
-                                  const char *output_type,
-                                  const char *output_structure,
-                                  const char *propquery);
+ OSSL_ENCODER_CTX_new_for_pkey(const EVP_PKEY *pkey, int selection,
+                               const char *output_type,
+                               const char *output_structure,
+                               const char *propquery);
 
  int OSSL_ENCODER_CTX_set_cipher(OSSL_ENCODER_CTX *ctx,
                                  const char *cipher_name,
@@ -37,7 +37,7 @@ OSSL_ENCODER_CTX_set_passphrase_ui
 
 =head1 DESCRIPTION
 
-OSSL_ENCODER_CTX_new_by_EVP_PKEY() is a utility function that creates a
+OSSL_ENCODER_CTX_new_for_pkey() is a utility function that creates a
 B<OSSL_ENCODER_CTX>, finds all applicable encoder implementations and sets
 them up, so almost all the caller has to do next is call functions like
 L<OSSL_ENCODER_to_bio(3)>.  I<output_type> determines the final output
@@ -46,7 +46,7 @@ should be included in the output.  I<output_type> is further discussed in
 L</Output types> below, and I<selection> is further described in
 L</Selections>.
 
-Internally, OSSL_ENCODER_CTX_new_by_EVP_PKEY() uses the names from the
+Internally, OSSL_ENCODER_CTX_new_for_pkey() uses the names from the
 L<EVP_KEYMGMT(3)> implementation associated with I<pkey> to build a list of
 applicable encoder implementations that are used to process the I<pkey> into
 the encoding named by I<output_type>, with the outermost structure named by
@@ -54,7 +54,7 @@ I<output_structure> if that's relevant.  All these implementations are
 implicitly fetched, with I<propquery> for finer selection.
 
 If no suitable encoder implementation is found,
-OSSL_ENCODER_CTX_new_by_EVP_PKEY() still creates a B<OSSL_ENCODER_CTX>, but
+OSSL_ENCODER_CTX_new_for_pkey() still creates a B<OSSL_ENCODER_CTX>, but
 with no associated encoder (L<OSSL_ENCODER_CTX_get_num_encoders(3)> returns
 zero).  This helps the caller to distinguish between an error when creating
 the B<OSSL_ENCODER_CTX> and missing encoder implementation, and allows it to
@@ -146,8 +146,8 @@ usually include the public key.
 
 =head1 RETURN VALUES
 
-OSSL_ENCODER_CTX_new_by_EVP_PKEY() returns a pointer to a
-B<OSSL_ENCODER_CTX>, or NULL if it couldn't be created.
+OSSL_ENCODER_CTX_new_for_pkey() returns a pointer to an B<OSSL_ENCODER_CTX>,
+or NULL if it couldn't be created.
 
 OSSL_ENCODER_CTX_set_cipher(), OSSL_ENCODER_CTX_set_passphrase(),
 OSSL_ENCODER_CTX_set_pem_password_cb(), OSSL_ENCODER_CTX_set_passphrase_ui()
@@ -158,10 +158,6 @@ failure.
 
 Parts of the function names are made to match already existing OpenSSL
 names.
-
-B<EVP_PKEY> in OSSL_ENCODER_CTX_new_by_EVP_PKEY() matches the type name,
-thus making for the naming pattern B<OSSL_ENCODER_CTX_new_by_I<TYPE>>() when
-new types are handled.
 
 =head1 SEE ALSO
 

--- a/doc/man3/OSSL_ENCODER_CTX_new_for_pkey.pod
+++ b/doc/man3/OSSL_ENCODER_CTX_new_for_pkey.pod
@@ -154,11 +154,6 @@ OSSL_ENCODER_CTX_set_pem_password_cb(), OSSL_ENCODER_CTX_set_passphrase_ui()
 and OSSL_ENCODER_CTX_set_passphrase_cb() all return 1 on success, or 0 on
 failure.
 
-=head1 NOTES
-
-Parts of the function names are made to match already existing OpenSSL
-names.
-
 =head1 SEE ALSO
 
 L<provider(7)>, L<OSSL_ENCODER(3)>, L<OSSL_ENCODER_CTX(3)>

--- a/doc/man3/d2i_RSAPrivateKey.pod
+++ b/doc/man3/d2i_RSAPrivateKey.pod
@@ -222,8 +222,8 @@ The following sample code does the rest of the work:
  unsigned char *p = buffer;     /* |buffer| is supplied by the caller */
  size_t len = buffer_size;      /* assumed be the size of |buffer| */
  OSSL_ENCODER_CTX *ctx =
-     OSSL_ENCODER_CTX_new_by_EVP_PKEY(pkey, selection, "DER", structure,
-                                      NULL, NULL);
+     OSSL_ENCODER_CTX_new_for_pkey(pkey, selection, "DER", structure,
+                                   NULL, NULL);
  if (ctx == NULL) {
      /* fatal error handling */
  }

--- a/include/crypto/decoder.h
+++ b/include/crypto/decoder.h
@@ -32,10 +32,10 @@ void ossl_decoder_instance_free(OSSL_DECODER_INSTANCE *decoder_inst);
 int ossl_decoder_ctx_add_decoder_inst(OSSL_DECODER_CTX *ctx,
                                       OSSL_DECODER_INSTANCE *di);
 
-int ossl_decoder_ctx_setup_for_EVP_PKEY(OSSL_DECODER_CTX *ctx,
-                                        EVP_PKEY **pkey, const char *keytype,
-                                        OSSL_LIB_CTX *libctx,
-                                        const char *propquery);
+int ossl_decoder_ctx_setup_for_pkey(OSSL_DECODER_CTX *ctx,
+                                    EVP_PKEY **pkey, const char *keytype,
+                                    OSSL_LIB_CTX *libctx,
+                                    const char *propquery);
 
 #endif
 

--- a/include/openssl/decoder.h
+++ b/include/openssl/decoder.h
@@ -120,11 +120,11 @@ int OSSL_DECODER_from_data(OSSL_DECODER_CTX *ctx, const unsigned char **pdata,
  * an implicit OSSL_DECODER_fetch(), suitable for the object of that type.
  */
 OSSL_DECODER_CTX *
-OSSL_DECODER_CTX_new_by_EVP_PKEY(EVP_PKEY **pkey,
-                                 const char *input_type,
-                                 const char *input_struct,
-                                 const char *keytype, int selection,
-                                 OSSL_LIB_CTX *libctx, const char *propquery);
+OSSL_DECODER_CTX_new_for_pkey(EVP_PKEY **pkey,
+                              const char *input_type,
+                              const char *input_struct,
+                              const char *keytype, int selection,
+                              OSSL_LIB_CTX *libctx, const char *propquery);
 
 # ifdef __cplusplus
 }

--- a/include/openssl/encoder.h
+++ b/include/openssl/encoder.h
@@ -113,11 +113,11 @@ int OSSL_ENCODER_to_data(OSSL_ENCODER_CTX *ctx, unsigned char **pdata,
  * an implicit OSSL_ENCODER_fetch(), suitable for the object of that type.
  * This is more useful than calling OSSL_ENCODER_CTX_new().
  */
-OSSL_ENCODER_CTX *OSSL_ENCODER_CTX_new_by_EVP_PKEY(const EVP_PKEY *pkey,
-                                                   int selection,
-                                                   const char *output_type,
-                                                   const char *output_struct,
-                                                   const char *propquery);
+OSSL_ENCODER_CTX *OSSL_ENCODER_CTX_new_for_pkey(const EVP_PKEY *pkey,
+                                                int selection,
+                                                const char *output_type,
+                                                const char *output_struct,
+                                                const char *propquery);
 
 # ifdef __cplusplus
 }

--- a/providers/encoders.inc
+++ b/providers/encoders.inc
@@ -74,16 +74,16 @@ ENCODER_TEXT("SM2", sm2, yes),
  * created like this:
  *
  * OSSL_ENCODER_CTX *ctx =
- *     OSSL_ENCODER_CTX_new_by_EVP_PKEY(pkey, selection, "DER", "type-specific",
- *                                      NULL, NULL);
+ *     OSSL_ENCODER_CTX_new_for_pkey(pkey, selection, "DER", "type-specific",
+ *                                   NULL, NULL);
  *
  * To replace PEM_write_bio_{TYPE}PrivateKey(), PEM_write_bio_{TYPE}PublicKey()
  * and PEM_write_bio_{TYPE}Params(), use OSSL_ENCODER functions with an
  * OSSL_ENCODER_CTX created like this:
  *
  * OSSL_ENCODER_CTX *ctx =
- *     OSSL_ENCODER_CTX_new_by_EVP_PKEY(pkey, selection, "PEM", "type-specific",
- *                                      NULL, NULL);
+ *     OSSL_ENCODER_CTX_new_for_pkey(pkey, selection, "PEM", "type-specific",
+ *                                   NULL, NULL);
  *
  * We only implement those for which there are current i2d_ and PEM_write_bio
  * implementations.
@@ -197,7 +197,7 @@ ENCODER_w_structure("SM2", sm2, yes, pem, SubjectPublicKeyInfo),
  * Entries for key type specific output formats.  These are exactly the
  * same as the type specific above, except that they use the key type
  * name as structure name instead of "type-specific", in the call on
- * OSSL_ENCODER_CTX_new_by_EVP_PKEY().
+ * OSSL_ENCODER_CTX_new_for_pkey().
  */
 
 /* The RSA encoders only support private key and public key output */

--- a/providers/implementations/storemgmt/file_store.c
+++ b/providers/implementations/storemgmt/file_store.c
@@ -59,7 +59,7 @@ static OSSL_FUNC_store_close_fn file_close;
  * internal OpenSSL functions, thereby bypassing the need for a surrounding
  * provider.  This is ok, since this is a local decoder, not meant for
  * public consumption.  It also uses the libcrypto internal decoder
- * setup function ossl_decoder_ctx_setup_for_EVP_PKEY(), to allow the
+ * setup function ossl_decoder_ctx_setup_for_pkey(), to allow the
  * last resort decoder to be added first (and thereby be executed last).
  * Finally, it sets up its own construct and cleanup functions.
  *
@@ -535,7 +535,7 @@ void file_load_cleanup(void *construct_data)
 
 static int file_setup_decoders(struct file_ctx_st *ctx)
 {
-    EVP_PKEY *dummy; /* for OSSL_DECODER_CTX_new_by_EVP_PKEY() */
+    EVP_PKEY *dummy; /* for ossl_decoder_ctx_setup_for_pkey() */
     OSSL_LIB_CTX *libctx = ossl_prov_ctx_get0_libctx(ctx->provctx);
     OSSL_DECODER *to_obj = NULL; /* Last resort decoder */
     OSSL_DECODER_INSTANCE *to_obj_inst = NULL;
@@ -588,9 +588,9 @@ static int file_setup_decoders(struct file_ctx_st *ctx)
          * Since we're setting up our own constructor, we don't need to care
          * more than that...
          */
-        if (!ossl_decoder_ctx_setup_for_EVP_PKEY(ctx->_.file.decoderctx,
-                                                 &dummy, NULL,
-                                                 libctx, ctx->_.file.propq)
+        if (!ossl_decoder_ctx_setup_for_pkey(ctx->_.file.decoderctx,
+                                             &dummy, NULL,
+                                             libctx, ctx->_.file.propq)
             || !OSSL_DECODER_CTX_add_extra(ctx->_.file.decoderctx,
                                            libctx, ctx->_.file.propq)) {
             ERR_raise(ERR_LIB_PROV, ERR_R_OSSL_DECODER_LIB);

--- a/ssl/ssl_conf.c
+++ b/ssl/ssl_conf.c
@@ -587,9 +587,9 @@ static int cmd_DHParameters(SSL_CONF_CTX *cctx, const char *value)
             goto end;
 
         decoderctx
-            = OSSL_DECODER_CTX_new_by_EVP_PKEY(&dhpkey, "PEM", NULL, "DH",
-                                               OSSL_KEYMGMT_SELECT_DOMAIN_PARAMETERS,
-                                               sslctx->libctx, sslctx->propq);
+            = OSSL_DECODER_CTX_new_for_pkey(&dhpkey, "PEM", NULL, "DH",
+                                            OSSL_KEYMGMT_SELECT_DOMAIN_PARAMETERS,
+                                            sslctx->libctx, sslctx->propq);
         if (decoderctx == NULL
                 || !OSSL_DECODER_from_bio(decoderctx, in)) {
             OSSL_DECODER_CTX_free(decoderctx);

--- a/test/endecode_test.c
+++ b/test/endecode_test.c
@@ -198,10 +198,10 @@ static int encode_EVP_PKEY_prov(void **encoded, long *encoded_len,
     const unsigned char *upass = (const unsigned char *)pass;
     int ok = 0;
 
-    if (!TEST_ptr(ectx = OSSL_ENCODER_CTX_new_by_EVP_PKEY(pkey, selection,
-                                                          output_type,
-                                                          output_structure,
-                                                          NULL))
+    if (!TEST_ptr(ectx = OSSL_ENCODER_CTX_new_for_pkey(pkey, selection,
+                                                       output_type,
+                                                       output_structure,
+                                                       NULL))
         || !TEST_int_gt(OSSL_ENCODER_CTX_get_num_encoders(ectx), 0)
         || (pass != NULL
             && !TEST_true(OSSL_ENCODER_CTX_set_passphrase(ectx, upass,
@@ -256,12 +256,12 @@ static int decode_EVP_PKEY_prov(void **object, void *encoded, long encoded_len,
         const char *testtype = (i == 0) ? input_type
                                         : ((i == 1) ? NULL : badtype);
 
-        if (!TEST_ptr(dctx = OSSL_DECODER_CTX_new_by_EVP_PKEY(&testpkey,
-                                                              testtype,
-                                                              NULL,
-                                                              keytype,
-                                                              selection,
-                                                              NULL, NULL))
+        if (!TEST_ptr(dctx = OSSL_DECODER_CTX_new_for_pkey(&testpkey,
+                                                           testtype,
+                                                           NULL,
+                                                           keytype,
+                                                           selection,
+                                                           NULL, NULL))
             || (pass != NULL
                 && !OSSL_DECODER_CTX_set_passphrase(dctx, upass, strlen(pass)))
             || !TEST_int_gt(BIO_reset(encoded_bio), 0)

--- a/test/endecoder_legacy_test.c
+++ b/test/endecoder_legacy_test.c
@@ -317,9 +317,9 @@ static int test_protected_PEM(const char *keytype, int evp_type,
         goto end;
 
     if (!TEST_ptr(ectx =
-                  OSSL_ENCODER_CTX_new_by_EVP_PKEY(provided_pkey, selection,
-                                                   "PEM", structure,
-                                                   NULL))
+                  OSSL_ENCODER_CTX_new_for_pkey(provided_pkey, selection,
+                                                "PEM", structure,
+                                                NULL))
         || !TEST_true(OSSL_ENCODER_to_bio(ectx, membio_provided))
         || !TEST_true(pem_write_bio(membio_legacy, legacy_key,
                                    NULL, NULL, 0, NULL, NULL))
@@ -331,10 +331,10 @@ static int test_protected_PEM(const char *keytype, int evp_type,
 
         if (!TEST_ptr(decoded_legacy_pkey = EVP_PKEY_new())
             || !TEST_ptr(dctx =
-                         OSSL_DECODER_CTX_new_by_EVP_PKEY(&decoded_provided_pkey,
-                                                          "PEM", structure,
-                                                          keytype, selection,
-                                                          NULL, NULL))
+                         OSSL_DECODER_CTX_new_for_pkey(&decoded_provided_pkey,
+                                                       "PEM", structure,
+                                                       keytype, selection,
+                                                       NULL, NULL))
             || !TEST_true(OSSL_DECODER_from_bio(dctx, membio_provided))
             || !TEST_ptr(decoded_legacy_key =
                          pem_read_bio(membio_legacy, NULL, NULL, NULL))
@@ -385,9 +385,9 @@ static int test_unprotected_PEM(const char *keytype, int evp_type,
         goto end;
 
     if (!TEST_ptr(ectx =
-                  OSSL_ENCODER_CTX_new_by_EVP_PKEY(provided_pkey, selection,
-                                                   "PEM", structure,
-                                                   NULL))
+                  OSSL_ENCODER_CTX_new_for_pkey(provided_pkey, selection,
+                                                "PEM", structure,
+                                                NULL))
         || !TEST_true(OSSL_ENCODER_to_bio(ectx, membio_provided))
         || !TEST_true(pem_write_bio(membio_legacy, legacy_key))
         || !test_membio_str_eq(membio_provided, membio_legacy))
@@ -398,10 +398,10 @@ static int test_unprotected_PEM(const char *keytype, int evp_type,
 
         if (!TEST_ptr(decoded_legacy_pkey = EVP_PKEY_new())
             || !TEST_ptr(dctx =
-                         OSSL_DECODER_CTX_new_by_EVP_PKEY(&decoded_provided_pkey,
-                                                          "PEM", structure,
-                                                          keytype, selection,
-                                                          NULL, NULL))
+                         OSSL_DECODER_CTX_new_for_pkey(&decoded_provided_pkey,
+                                                       "PEM", structure,
+                                                       keytype, selection,
+                                                       NULL, NULL))
             || !TEST_true(OSSL_DECODER_from_bio(dctx, membio_provided))
             || !TEST_ptr(decoded_legacy_key =
                          pem_read_bio(membio_legacy, NULL, NULL, NULL))
@@ -450,9 +450,9 @@ static int test_DER(const char *keytype, int evp_type,
     EVP_PKEY *decoded_provided_pkey = NULL;
 
     if (!TEST_ptr(ectx =
-                 OSSL_ENCODER_CTX_new_by_EVP_PKEY(provided_pkey, selection,
-                                                  "DER", structure,
-                                                  NULL))
+                 OSSL_ENCODER_CTX_new_for_pkey(provided_pkey, selection,
+                                               "DER", structure,
+                                               NULL))
         || !TEST_true(OSSL_ENCODER_to_data(ectx,
                                           &der_provided, &der_provided_len))
         || !TEST_size_t_gt(der_legacy_len = i2d(legacy_key, &der_legacy), 0)
@@ -465,10 +465,10 @@ static int test_DER(const char *keytype, int evp_type,
 
         if (!TEST_ptr(decoded_legacy_pkey = EVP_PKEY_new())
             || !TEST_ptr(dctx =
-                         OSSL_DECODER_CTX_new_by_EVP_PKEY(&decoded_provided_pkey,
-                                                          "DER", structure,
-                                                          keytype, selection,
-                                                          NULL, NULL))
+                         OSSL_DECODER_CTX_new_for_pkey(&decoded_provided_pkey,
+                                                       "DER", structure,
+                                                       keytype, selection,
+                                                       NULL, NULL))
             || !TEST_true((pder_provided = der_provided,
                            tmp_size = der_provided_len,
                            OSSL_DECODER_from_data(dctx, &pder_provided,

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -419,8 +419,8 @@ static EVP_PKEY *load_example_key(const char *keytype,
     const unsigned char **pdata = &data;
     EVP_PKEY *pkey = NULL;
     OSSL_DECODER_CTX *dctx =
-        OSSL_DECODER_CTX_new_by_EVP_PKEY(&pkey, "DER", NULL, keytype, 0,
-                                         testctx, NULL);
+        OSSL_DECODER_CTX_new_for_pkey(&pkey, "DER", NULL, keytype, 0,
+                                      testctx, NULL);
 
     /* |pkey| will be NULL on error */
     (void)OSSL_DECODER_from_data(dctx, pdata, &data_len);

--- a/test/evp_libctx_test.c
+++ b/test/evp_libctx_test.c
@@ -474,10 +474,10 @@ static int rsa_keygen(int bits, EVP_PKEY **pub, EVP_PKEY **priv)
         || !TEST_true(EVP_PKEY_CTX_set_rsa_keygen_bits(keygen_ctx, bits))
         || !TEST_int_gt(EVP_PKEY_keygen(keygen_ctx, priv), 0)
         || !TEST_ptr(ectx =
-                     OSSL_ENCODER_CTX_new_by_EVP_PKEY(*priv,
-                                                      EVP_PKEY_PUBLIC_KEY,
-                                                      "DER", "type-specific",
-                                                      NULL))
+                     OSSL_ENCODER_CTX_new_for_pkey(*priv,
+                                                   EVP_PKEY_PUBLIC_KEY,
+                                                   "DER", "type-specific",
+                                                   NULL))
         || !TEST_true(OSSL_ENCODER_to_data(ectx, &pub_der, &len)))
         goto err;
     pp = pub_der;

--- a/test/evp_pkey_provided_test.c
+++ b/test/evp_pkey_provided_test.c
@@ -219,10 +219,10 @@ static int test_print_key_type_using_encoder(const char *alg, int type,
 
     /* Make a context, it's valid for several prints */
     TEST_note("Setting up a OSSL_ENCODER context with passphrase");
-    if (!TEST_ptr(ctx = OSSL_ENCODER_CTX_new_by_EVP_PKEY(pk, selection,
-                                                         output_type,
-                                                         output_structure,
-                                                         NULL))
+    if (!TEST_ptr(ctx = OSSL_ENCODER_CTX_new_for_pkey(pk, selection,
+                                                      output_type,
+                                                      output_structure,
+                                                      NULL))
         /* Check that this operation is supported */
         || !TEST_int_ne(OSSL_ENCODER_CTX_get_num_encoders(ctx), 0))
         goto err;

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4838,7 +4838,7 @@ OSSL_ENCODER_CTX_free                   ?	3_0_0	EXIST::FUNCTION:
 OSSL_ENCODER_properties                 ?	3_0_0	EXIST::FUNCTION:
 OSSL_ENCODER_to_bio                     ?	3_0_0	EXIST::FUNCTION:
 OSSL_ENCODER_to_fp                      ?	3_0_0	EXIST::FUNCTION:STDIO
-OSSL_ENCODER_CTX_new_by_EVP_PKEY        ?	3_0_0	EXIST::FUNCTION:
+OSSL_ENCODER_CTX_new_for_pkey           ?	3_0_0	EXIST::FUNCTION:
 OSSL_ENCODER_CTX_set_cipher             ?	3_0_0	EXIST::FUNCTION:
 OSSL_ENCODER_CTX_set_passphrase         ?	3_0_0	EXIST::FUNCTION:
 OSSL_ENCODER_CTX_set_pem_password_cb    ?	3_0_0	EXIST::FUNCTION:
@@ -5127,7 +5127,7 @@ OSSL_DECODER_INSTANCE_get_decoder       ?	3_0_0	EXIST::FUNCTION:
 OSSL_DECODER_INSTANCE_get_decoder_ctx   ?	3_0_0	EXIST::FUNCTION:
 OSSL_DECODER_gettable_params            ?	3_0_0	EXIST::FUNCTION:
 OSSL_DECODER_get_params                 ?	3_0_0	EXIST::FUNCTION:
-OSSL_DECODER_CTX_new_by_EVP_PKEY        ?	3_0_0	EXIST::FUNCTION:
+OSSL_DECODER_CTX_new_for_pkey           ?	3_0_0	EXIST::FUNCTION:
 OSSL_DECODER_CTX_set_construct          ?	3_0_0	EXIST::FUNCTION:
 OSSL_DECODER_CTX_set_construct_data     ?	3_0_0	EXIST::FUNCTION:
 OSSL_DECODER_CTX_set_cleanup            ?	3_0_0	EXIST::FUNCTION:


### PR DESCRIPTION
Additional renames done in encoder and decoder implementation
to follow the style.

Fixes #13622

Although in the OTC discussion it was preferred to split out the new and setup for phases into separate functions in the end I've decided not to do it as it is really convenient for the applications to have it like this. I do not see a point in having to always call two functions instead of one and it also conveniently avoids reusing the ctx for multiple encode/decode calls which we might not want to allow anyway.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
