### PR TITLE
passwd.c: use the actual ROUNDS_DEFAULT macro

### DIFF
--- a/apps/passwd.c
+++ b/apps/passwd.c
@@ -515,7 +515,7 @@ static char *shacrypt(const char *passwd, const char *magic, const char *salt)
     EVP_MD_CTX *md = NULL, *md2 = NULL;
     const EVP_MD *sha = NULL;
     size_t passwd_len, salt_len, magic_len;
-    unsigned int rounds = 5000;        /* Default */
+    unsigned int rounds = ROUNDS_DEFAULT;        /* Default */
     char rounds_custom = 0;
     char *p_bytes = NULL;
     char *s_bytes = NULL;


### PR DESCRIPTION
Before this commit, the `ROUNDS_DEFAULT` macro was not used at all, while defined in the source code.
Instead, a `unsigned int rounds = 5000;` was set, which uses the same value.

This commit changes the `5000` to `ROUNDS_DEFAULT`.