### PR TITLE
Remove dead code in rsa_pkey_ctrl.

### DIFF
--- a/crypto/rsa/rsa_ameth.c
+++ b/crypto/rsa/rsa_ameth.c
@@ -486,7 +486,6 @@ static int rsa_sig_print(BIO *bp, const X509_ALGOR *sigalg,
 
 static int rsa_pkey_ctrl(EVP_PKEY *pkey, int op, long arg1, void *arg2)
 {
-    X509_ALGOR *alg = NULL;
     const EVP_MD *md;
     const EVP_MD *mgf1md;
     int min_saltlen;
@@ -508,14 +507,7 @@ static int rsa_pkey_ctrl(EVP_PKEY *pkey, int op, long arg1, void *arg2)
 
     default:
         return -2;
-
     }
-
-    if (alg)
-        X509_ALGOR_set0(alg, OBJ_nid2obj(NID_rsaEncryption), V_ASN1_NULL, 0);
-
-    return 1;
-
 }
 
 /*


### PR DESCRIPTION
Fixes CID #1472393

Previously this switch handled CMS & PCKS7 controls (e.g ANS1_PKEY_CTRL_PKCS7_SIGN)
which fell thru to the dead code to set the X509_ALG.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
