### PR TITLE
APPS: Make sure ext_ctx structure gets properly initialized

### DIFF
--- a/apps/ca.c
+++ b/apps/ca.c
@@ -863,6 +863,7 @@ end_of_options:
             if (extensions != NULL) {
                 /* Check syntax of config file section */
                 X509V3_CTX ctx;
+
                 X509V3_set_ctx_test(&ctx);
                 X509V3_set_nconf(&ctx, conf);
                 if (!X509V3_EXT_add_nconf(conf, &ctx, extensions, NULL)) {
@@ -1141,6 +1142,7 @@ end_of_options:
         if (crl_ext != NULL) {
             /* Check syntax of file */
             X509V3_CTX ctx;
+
             X509V3_set_ctx_test(&ctx);
             X509V3_set_nconf(&ctx, conf);
             if (!X509V3_EXT_add_nconf(conf, &ctx, crl_ext, NULL)) {
@@ -1230,6 +1232,7 @@ end_of_options:
 
         if (crl_ext != NULL || crlnumberfile != NULL) {
             X509V3_CTX crlctx;
+
             X509V3_set_ctx(&crlctx, x509, NULL, NULL, crl, 0);
             X509V3_set_nconf(&crlctx, conf);
 
@@ -1697,12 +1700,12 @@ static int do_body(X509 **xret, EVP_PKEY *pkey, X509 *x509,
     if (!i)
         goto end;
 
+    /* Initialize the context structure */
+    X509V3_set_ctx(&ext_ctx, selfsign ? ret : x509,
+                   ret, req, NULL, X509V3_CTX_REPLACE);
+
     /* Lets add the extensions, if there are any */
     if (ext_sect) {
-        /* Initialize the context structure */
-        X509V3_set_ctx(&ext_ctx, selfsign ? ret : x509,
-                       ret, req, NULL, X509V3_CTX_REPLACE);
-
         if (extfile_conf != NULL) {
             if (verbose)
                 BIO_printf(bio_err, "Extra configuration file found\n");

--- a/doc/man1/openssl-cmp.pod.in
+++ b/doc/man1/openssl-cmp.pod.in
@@ -298,6 +298,8 @@ validity period starts from the current time (as seen by the host).
 =item B<-reqexts> I<name>
 
 Name of section in OpenSSL config file defining certificate request extensions.
+If the B<-csr> option is present, these extensions augment the extensions
+contained the given PKCS#10 CSR, overriding any extensions with same OIDs.
 
 =item B<-sans> I<spec>
 


### PR DESCRIPTION
This fixes #14175 regarding a crash of the `ca` app when the `ext_ctx` structure is not initialized
and a more subtle initialization bug for the `ext_ctx` structure w.r.t. any CSR given with the `-csr` option.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated

