### PR TITLE
Fix propquery handling in EVP_DigestSignInit_ex

### DIFF
--- a/crypto/evp/m_sigver.c
+++ b/crypto/evp/m_sigver.c
@@ -60,7 +60,7 @@ static int do_sigver_init(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx,
     }
 
     if (ctx->pctx == NULL) {
-        if (libctx != NULL)
+        if (e == NULL)
             ctx->pctx = EVP_PKEY_CTX_new_from_pkey(libctx, pkey, props);
         else
             ctx->pctx = EVP_PKEY_CTX_new(pkey, e);


### PR DESCRIPTION
Fixes #14183. Fix the condition to detect legacy engines, so the `props` are considered even when libctx == NULL.