### PR TITLE
Don't forget the type of object we are trying to load

### DIFF
--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -730,11 +730,11 @@ int load_key_certs_crls(const char *uri, int maybe_stdin,
         return 0;
     }
 
-    if (pcerts != NULL && *pcerts == NULL
-            && (*pcerts = sk_X509_new_null()) == NULL) {
-        BIO_printf(bio_err, "Out of memory loading");
-        goto end;
-    } else {
+    if (pcerts != NULL) {
+        if (*pcerts == NULL && (*pcerts = sk_X509_new_null()) == NULL) {
+            BIO_printf(bio_err, "Out of memory loading");
+            goto end;
+        }
         cnt_expectations++;
         expect = OSSL_STORE_INFO_CERT;
     }
@@ -743,11 +743,11 @@ int load_key_certs_crls(const char *uri, int maybe_stdin,
         cnt_expectations++;
         expect = OSSL_STORE_INFO_CRL;
     }
-    if (pcrls != NULL && *pcrls == NULL
-            && (*pcrls = sk_X509_CRL_new_null()) == NULL) {
-        BIO_printf(bio_err, "Out of memory loading");
-        goto end;
-    } else {
+    if (pcrls != NULL) {
+        if (*pcrls == NULL && (*pcrls = sk_X509_CRL_new_null()) == NULL) {
+            BIO_printf(bio_err, "Out of memory loading");
+            goto end;
+        }
         cnt_expectations++;
         expect = OSSL_STORE_INFO_CRL;
     }
@@ -787,8 +787,21 @@ int load_key_certs_crls(const char *uri, int maybe_stdin,
         OSSL_STORE_INFO *info = OSSL_STORE_load(ctx);
         int type, ok = 1;
 
-        if (info == NULL)
-            break;
+        /*
+         * This can happen (for example) if we attempt to load a file with
+         * multiple different types of things in it - but the thing we just
+         * tried to load wasn't one of the ones we wanted, e.g. if we're trying
+         * to load a certificate but the file has both the private key and the
+         * certificate in it. We just retry until eof.
+         */
+        if (info == NULL) {
+            if (OSSL_STORE_error(ctx)) {
+                ERR_print_errors(bio_err);
+                ERR_clear_error();
+            }
+            continue;
+        }
+
         type = OSSL_STORE_INFO_get_type(info);
         switch (type) {
         case OSSL_STORE_INFO_PKEY:

--- a/crypto/store/store_result.c
+++ b/crypto/store/store_result.c
@@ -62,6 +62,7 @@
 struct extracted_param_data_st {
     int object_type;
     const char *data_type;
+    const char *data_structure;
     const char *utf8_data;
     const void *octet_data;
     size_t octet_data_size;
@@ -127,6 +128,10 @@ int ossl_store_handle_load_result(const OSSL_PARAM params[], void *arg)
         && !OSSL_PARAM_get_octet_string_ptr(p, &helper_data.octet_data,
                                             &helper_data.octet_data_size)
         && !OSSL_PARAM_get_utf8_string_ptr(p, &helper_data.utf8_data))
+        return 0;
+    p = OSSL_PARAM_locate_const(params, OSSL_OBJECT_PARAM_DATA_STRUCTURE);
+    if (p != NULL
+        && !OSSL_PARAM_get_utf8_string_ptr(p, &helper_data.data_structure))
         return 0;
     p = OSSL_PARAM_locate_const(params, OSSL_OBJECT_PARAM_REFERENCE);
     if (p != NULL && !OSSL_PARAM_get_octet_string_ptr(p, &helper_data.ref,
@@ -274,8 +279,9 @@ static EVP_PKEY *try_key_value(struct extracted_param_data_st *data,
     }
 
     decoderctx =
-        OSSL_DECODER_CTX_new_for_pkey(&pk, "DER", NULL, data->data_type,
-                                      selection, libctx, propq);
+        OSSL_DECODER_CTX_new_for_pkey(&pk, "DER", data->data_structure,
+                                      data->data_type, selection, libctx,
+                                      propq);
     (void)OSSL_DECODER_CTX_set_passphrase_cb(decoderctx, cb, cbarg);
 
     /* No error if this couldn't be decoded */

--- a/providers/implementations/encode_decode/decode_pem2der.c
+++ b/providers/implementations/encode_decode/decode_pem2der.c
@@ -17,6 +17,7 @@
 
 #include <openssl/core_dispatch.h>
 #include <openssl/core_names.h>
+#include <openssl/core_object.h>
 #include <openssl/crypto.h>
 #include <openssl/err.h>
 #include <openssl/params.h>
@@ -114,20 +115,23 @@ static int pem2der_decode(void *vctx, OSSL_CORE_BIO *cin, int selection,
                           OSSL_CALLBACK *data_cb, void *data_cbarg,
                           OSSL_PASSPHRASE_CALLBACK *pw_cb, void *pw_cbarg)
 {
-    /* Strings to peal off the pem name */
-    static const char *pealable_pem_name_endings[] = {
+    /* Strings to peel off the pem name */
+    static struct peelablee_pem_name_endings_st {
+        const char *ending;
+        const char *data_structure;
+    } peelable_pem_name_endings[] = {
         /*
          * These entries should be in longest to shortest order to avoid
          * mixups.
          */
-        "ENCRYPTED PRIVATE KEY",
-        "PRIVATE KEY",
-        "PUBLIC KEY",
-        "PARAMETERS"
+        { "ENCRYPTED PRIVATE KEY", "pkcs8" },
+        { "PRIVATE KEY", "pkcs8" },
+        { "PUBLIC KEY", "SubjectPublicKeyInfo" },
+        { "PARAMETERS", NULL }
 
         /*
          * Libcrypto currently only supports decoding keys with provider side
-         * decoders, so we don't try to peal any other PEM name.  That's an
+         * decoders, so we don't try to peel any other PEM name.  That's an
          * exercise for when libcrypto starts to treat other types of objects
          * via providers.
          */
@@ -138,6 +142,8 @@ static int pem2der_decode(void *vctx, OSSL_CORE_BIO *cin, int selection,
     unsigned char *der = NULL;
     long der_len = 0;
     int ok = 0;
+    int objtype = OSSL_OBJECT_UNKNOWN;
+    const char *data_structure = NULL;
 
     if (read_pem(ctx->provctx, cin, &pem_name, &pem_header,
                  &der, &der_len) <= 0)
@@ -166,15 +172,15 @@ static int pem2der_decode(void *vctx, OSSL_CORE_BIO *cin, int selection,
      * no further purpose.
      */
     for (i = 0, pem_name_len = strlen(pem_name);
-         i < OSSL_NELEM(pealable_pem_name_endings);
+         i < OSSL_NELEM(peelable_pem_name_endings);
          i++) {
-        size_t peal_len = strlen(pealable_pem_name_endings[i]);
+        size_t peel_len = strlen(peelable_pem_name_endings[i].ending);
         size_t pem_name_offset;
 
-        if (peal_len <= pem_name_len) {
-            pem_name_offset = pem_name_len - peal_len;
+        if (peel_len <= pem_name_len) {
+            pem_name_offset = pem_name_len - peel_len;
             if (strcmp(pem_name + pem_name_offset,
-                       pealable_pem_name_endings[i]) == 0) {
+                       peelable_pem_name_endings[i].ending) == 0) {
 
                 do {
                     pem_name[pem_name_offset] = '\0';
@@ -185,21 +191,53 @@ static int pem2der_decode(void *vctx, OSSL_CORE_BIO *cin, int selection,
                     OPENSSL_free(pem_name);
                     pem_name = NULL;
                 }
+                /* All of these peelable endings are for EVP_PKEYs */
+                objtype = OSSL_OBJECT_PKEY;
+                if (pem_name == NULL) {
+                    data_structure = peelable_pem_name_endings[i].data_structure;
+                    if (data_structure == NULL)
+                        goto end;
+                } else {
+                    /*
+                     * If there is an algorithm name prefix then it is a
+                     * type-specific data structure
+                     */
+                    data_structure = "type-specific";
+                }
                 break;
             }
         }
     }
 
+    /* If we don't know the object type yet check if it's one we know about */
+    if (objtype == OSSL_OBJECT_UNKNOWN) {
+        if (strcmp(pem_name, PEM_STRING_X509) == 0
+                || strcmp(pem_name, PEM_STRING_X509_TRUSTED) == 0
+                || strcmp(pem_name, PEM_STRING_X509_OLD) == 0)
+            objtype = OSSL_OBJECT_CERT;
+        else if (strcmp(pem_name, PEM_STRING_X509_CRL) == 0)
+            objtype = OSSL_OBJECT_CRL;
+    }
+
     {
-        OSSL_PARAM params[3], *p = params;
+        OSSL_PARAM params[5], *p = params;
 
         if (pem_name != NULL)
             *p++ =
                 OSSL_PARAM_construct_utf8_string(OSSL_OBJECT_PARAM_DATA_TYPE,
                                                  pem_name, 0);
+
+        /* We expect this to be read only so casting away the const is ok */
+        if (data_structure != NULL)
+            *p++ =
+                OSSL_PARAM_construct_utf8_string(OSSL_OBJECT_PARAM_DATA_STRUCTURE,
+                                                 (char *)data_structure, 0);
         *p++ =
             OSSL_PARAM_construct_octet_string(OSSL_OBJECT_PARAM_DATA,
                                               der, der_len);
+        *p++ =
+            OSSL_PARAM_construct_int(OSSL_OBJECT_PARAM_TYPE, &objtype);
+
         *p = OSSL_PARAM_construct_end();
 
         ok = data_cb(params, data_cbarg);


### PR DESCRIPTION
This PR addresses two separate but related issues which can lead to information about the type of object we are trying to load being forgotten. This can result in us looping through lots of different decoders trying to find one that matches - even though we may already know up front what kind of decoder we are going to need.

The first issue a bug in the apps. The apps helper function `load_key_certs_crls()` is a general purpose function for loading different types of objects from a given URI. It sets up an OSSL_STORE and calls OSSL_STORE_expect() so that the store knows what type of thing to expect to load. Unfortunately this wasn't working and was always setting "expect" to 0 - which means "anything".

Fixes #13709

The second issue in is in the pem2der decoder. We learn information about what is in the file from the PEM header. This information can be used to infer things about the type of object we are trying to load and the data structure being used in the DER. This needs to be passed down the chain so that we subsequently attempt to load the right kind of thing without looping through things that we know will never succeed.