### PR TITLE
[DRAFT, pending on alternative #14193 and #14219] Allow 'openssl enc' and 'openssl dgst' to use "unknown" ciphers and digests

### DIFF
--- a/apps/ca.c
+++ b/apps/ca.c
@@ -270,7 +270,7 @@ int ca_main(int argc, char **argv)
     STACK_OF(OPENSSL_STRING) *sigopts = NULL, *vfyopts = NULL;
     STACK_OF(X509) *cert_sk = NULL;
     X509_CRL *crl = NULL;
-    const EVP_MD *dgst = NULL;
+    const EVP_MD *dgst = NULL; EVP_MD *fetched_dgst = NULL;
     char *configfile = default_config_file, *section = NULL;
     char *md = NULL, *policy = NULL, *keyfile = NULL;
     char *certfile = NULL, *crl_ext = NULL, *crlnumberfile = NULL;
@@ -807,7 +807,7 @@ end_of_options:
             md = (char *)OBJ_nid2sn(def_nid);
         }
 
-        if (!opt_md(md, &dgst))
+        if (!opt_md(md, &dgst, &fetched_dgst))
             goto end;
     }
 
@@ -1315,6 +1315,7 @@ end_of_options:
  end:
     if (ret)
         ERR_print_errors(bio_err);
+    EVP_MD_free(fetched_dgst);
     BIO_free_all(Sout);
     BIO_free_all(out);
     BIO_free_all(in);

--- a/apps/cms.c
+++ b/apps/cms.c
@@ -277,7 +277,9 @@ int cms_main(int argc, char **argv)
     ENGINE *e = NULL;
     EVP_PKEY *key = NULL;
     const EVP_CIPHER *cipher = NULL, *wrap_cipher = NULL;
+    EVP_CIPHER *fetched_cipher = NULL, *fetched_wrap_cipher = NULL;
     const EVP_MD *sign_md = NULL;
+    EVP_MD *fetched_sign_md = NULL;
     STACK_OF(OPENSSL_STRING) *rr_to = NULL, *rr_from = NULL;
     STACK_OF(OPENSSL_STRING) *sksigners = NULL, *skkeys = NULL;
     STACK_OF(X509) *encerts = NULL, *other = NULL;
@@ -692,18 +694,18 @@ int cms_main(int argc, char **argv)
             wrap_cipher = EVP_aes_256_wrap();
             break;
         case OPT_WRAP:
-            if (!opt_cipher(opt_unknown(), &wrap_cipher))
+            if (!opt_cipher(opt_unknown(), &wrap_cipher, &fetched_wrap_cipher))
                 goto end;
             break;
         }
     }
     app_RAND_load();
     if (digestname != NULL) {
-        if (!opt_md(digestname, &sign_md))
+        if (!opt_md(digestname, &sign_md, &fetched_sign_md))
             goto end;
     }
     if (ciphername != NULL) {
-        if (!opt_cipher(ciphername, &cipher))
+        if (!opt_cipher(ciphername, &cipher, &fetched_cipher))
             goto end;
     }
 
@@ -1223,6 +1225,9 @@ int cms_main(int argc, char **argv)
  end:
     if (ret)
         ERR_print_errors(bio_err);
+    EVP_CIPHER_free(fetched_cipher);
+    EVP_CIPHER_free(fetched_wrap_cipher);
+    EVP_MD_free(fetched_sign_md);
     sk_X509_pop_free(encerts, X509_free);
     sk_X509_pop_free(other, X509_free);
     X509_VERIFY_PARAM_free(vpm);

--- a/apps/crl.c
+++ b/apps/crl.c
@@ -82,7 +82,7 @@ int crl_main(int argc, char **argv)
     X509_LOOKUP *lookup = NULL;
     X509_OBJECT *xobj = NULL;
     EVP_PKEY *pkey;
-    const EVP_MD *digest = EVP_sha1();
+    const EVP_MD *digest = EVP_sha1(); EVP_MD *fetched_digest = NULL;
     char *infile = NULL, *outfile = NULL, *crldiff = NULL, *keyfile = NULL;
     char *digestname = NULL;
     const char *CAfile = NULL, *CApath = NULL, *CAstore = NULL, *prog;
@@ -208,7 +208,7 @@ int crl_main(int argc, char **argv)
         goto opthelp;
 
     if (digestname != NULL) {
-        if (!opt_md(digestname, &digest))
+        if (!opt_md(digestname, &digest, &fetched_digest))
             goto opthelp;
     }
     x = load_crl(infile, "CRL");
@@ -377,6 +377,7 @@ int crl_main(int argc, char **argv)
  end:
     if (ret != 0)
         ERR_print_errors(bio_err);
+    EVP_MD_free(fetched_digest);
     BIO_free_all(out);
     X509_CRL_free(x);
     X509_STORE_CTX_free(ctx);

--- a/apps/dgst.c
+++ b/apps/dgst.c
@@ -100,6 +100,7 @@ int dgst_main(int argc, char **argv)
     char *mac_name = NULL, *digestname = NULL;
     char *passinarg = NULL, *passin = NULL;
     const EVP_MD *md = NULL;
+    EVP_MD *fetched_md = NULL;
     const char *outfile = NULL, *keyfile = NULL, *prog = NULL;
     const char *sigfile = NULL;
     const char *md_name = NULL;
@@ -227,7 +228,7 @@ int dgst_main(int argc, char **argv)
     }
     app_RAND_load();
     if (digestname != NULL) {
-        if (!opt_md(digestname, &md))
+        if (!opt_md(digestname, &md, &fetched_md))
             goto opthelp;
     }
 
@@ -446,6 +447,8 @@ int dgst_main(int argc, char **argv)
         }
     }
  end:
+    ERR_print_errors(bio_err);
+    EVP_MD_free(fetched_md);
     OPENSSL_clear_free(buf, BUFSIZE);
     BIO_free(in);
     OPENSSL_free(passin);

--- a/apps/dsa.c
+++ b/apps/dsa.c
@@ -80,6 +80,7 @@ int dsa_main(int argc, char **argv)
     ENGINE *e = NULL;
     EVP_PKEY *pkey = NULL;
     const EVP_CIPHER *enc = NULL;
+    EVP_CIPHER *fetched_enc = NULL;
     char *infile = NULL, *outfile = NULL, *prog;
     char *passin = NULL, *passout = NULL, *passinarg = NULL, *passoutarg = NULL;
     OPTION_CHOICE o;
@@ -166,7 +167,7 @@ int dsa_main(int argc, char **argv)
         goto opthelp;
 
     if (ciphername != NULL) {
-        if (!opt_cipher(ciphername, &enc))
+        if (!opt_cipher(ciphername, &enc, &fetched_enc))
             goto end;
     }
     private = pubin || pubout ? 0 : 1;
@@ -286,6 +287,7 @@ int dsa_main(int argc, char **argv)
  end:
     if (ret != 0)
         ERR_print_errors(bio_err);
+    EVP_CIPHER_free(fetched_enc);
     OSSL_ENCODER_CTX_free(ectx);
     BIO_free_all(out);
     EVP_PKEY_free(pkey);

--- a/apps/ec.c
+++ b/apps/ec.c
@@ -70,6 +70,7 @@ int ec_main(int argc, char **argv)
     BIO *in = NULL, *out = NULL;
     ENGINE *e = NULL;
     const EVP_CIPHER *enc = NULL;
+    EVP_CIPHER *fetched_enc = NULL;
     char *infile = NULL, *outfile = NULL, *ciphername = NULL, *prog;
     char *passin = NULL, *passout = NULL, *passinarg = NULL, *passoutarg = NULL;
     OPTION_CHOICE o;
@@ -162,7 +163,7 @@ int ec_main(int argc, char **argv)
         goto opthelp;
 
     if (ciphername != NULL) {
-        if (!opt_cipher(ciphername, &enc))
+        if (!opt_cipher(ciphername, &enc, &fetched_enc))
             goto opthelp;
     }
     private = param_out || pubin || pubout ? 0 : 1;
@@ -276,6 +277,7 @@ int ec_main(int argc, char **argv)
 end:
     if (ret != 0)
         ERR_print_errors(bio_err);
+    EVP_CIPHER_free(fetched_enc);
     BIO_free(in);
     BIO_free_all(out);
     EVP_PKEY_free(eckey);

--- a/apps/enc.c
+++ b/apps/enc.c
@@ -110,7 +110,9 @@ int enc_main(int argc, char **argv)
         NULL, *wbio = NULL;
     EVP_CIPHER_CTX *ctx = NULL;
     const EVP_CIPHER *cipher = NULL;
+    EVP_CIPHER *fetched_cipher = NULL;
     const EVP_MD *dgst = NULL;
+    EVP_MD *fetched_dgst = NULL;
     const char *digestname = NULL;
     char *hkey = NULL, *hiv = NULL, *hsalt = NULL, *p;
     char *infile = NULL, *outfile = NULL, *prog;
@@ -297,7 +299,7 @@ int enc_main(int argc, char **argv)
 
     /* Get the cipher name, either from progname (if set) or flag. */
     if (ciphername != NULL) {
-        if (!opt_cipher(ciphername, &cipher))
+        if (!opt_cipher(ciphername, &cipher, &fetched_cipher))
             goto opthelp;
     }
     if (cipher && EVP_CIPHER_flags(cipher) & EVP_CIPH_FLAG_AEAD_CIPHER) {
@@ -309,7 +311,7 @@ int enc_main(int argc, char **argv)
         goto end;
     }
     if (digestname != NULL) {
-        if (!opt_md(digestname, &dgst))
+        if (!opt_md(digestname, &dgst, &fetched_dgst))
             goto opthelp;
     }
     if (dgst == NULL)
@@ -626,6 +628,8 @@ int enc_main(int argc, char **argv)
     }
  end:
     ERR_print_errors(bio_err);
+    EVP_CIPHER_free(fetched_cipher);
+    EVP_MD_free(fetched_dgst);
     OPENSSL_free(strbuf);
     OPENSSL_free(buff);
     BIO_free(in);

--- a/apps/gendsa.c
+++ b/apps/gendsa.c
@@ -57,6 +57,7 @@ int gendsa_main(int argc, char **argv)
     EVP_PKEY *pkey = NULL;
     EVP_PKEY_CTX *ctx = NULL;
     const EVP_CIPHER *enc = NULL;
+    EVP_CIPHER *fetched_enc = NULL;
     char *dsaparams = NULL, *ciphername = NULL;
     char *outfile = NULL, *passoutarg = NULL, *passout = NULL, *prog;
     OPTION_CHOICE o;
@@ -110,7 +111,7 @@ int gendsa_main(int argc, char **argv)
 
     app_RAND_load();
     if (ciphername != NULL) {
-        if (!opt_cipher(ciphername, &enc))
+        if (!opt_cipher(ciphername, &enc, &fetched_enc))
             goto end;
     }
     private = 1;
@@ -160,6 +161,7 @@ int gendsa_main(int argc, char **argv)
     if (ret != 0)
         ERR_print_errors(bio_err);
  end2:
+    EVP_CIPHER_free(fetched_enc);
     BIO_free(in);
     BIO_free_all(out);
     EVP_PKEY_free(pkey);

--- a/apps/genpkey.c
+++ b/apps/genpkey.c
@@ -65,6 +65,7 @@ int genpkey_main(int argc, char **argv)
     char *outfile = NULL, *passarg = NULL, *pass = NULL, *prog, *p;
     const char *ciphername = NULL, *paramfile = NULL, *algname = NULL;
     const EVP_CIPHER *cipher = NULL;
+    EVP_CIPHER *fetched_cipher = NULL;
     OPTION_CHOICE o;
     int outformat = FORMAT_PEM, text = 0, ret = 1, rv, do_param = 0;
     int private = 0, i, m;
@@ -158,7 +159,8 @@ int genpkey_main(int argc, char **argv)
         }
     }
     if (ciphername != NULL) {
-        if (!opt_cipher(ciphername, &cipher) || do_param == 1)
+        if (!opt_cipher(ciphername, &cipher, &fetched_cipher)
+            || do_param == 1)
             goto opthelp;
         m = EVP_CIPHER_mode(cipher);
         if (m == EVP_CIPH_GCM_MODE || m == EVP_CIPH_CCM_MODE
@@ -231,6 +233,7 @@ int genpkey_main(int argc, char **argv)
     }
 
  end:
+    EVP_CIPHER_free(fetched_cipher);
     sk_OPENSSL_STRING_free(keyopt);
     EVP_PKEY_free(pkey);
     EVP_PKEY_CTX_free(ctx);

--- a/apps/genrsa.c
+++ b/apps/genrsa.c
@@ -83,6 +83,7 @@ int genrsa_main(int argc, char **argv)
     EVP_PKEY *pkey = NULL;
     EVP_PKEY_CTX *ctx = NULL;
     const EVP_CIPHER *enc = NULL;
+    EVP_CIPHER *fetched_enc = NULL;
     int ret = 1, num = DEFBITS, private = 0, primes = DEFPRIMES;
     unsigned long f4 = RSA_F4;
     char *outfile = NULL, *passoutarg = NULL, *passout = NULL;
@@ -166,7 +167,7 @@ opthelp:
     app_RAND_load();
     private = 1;
     if (ciphername != NULL) {
-        if (!opt_cipher(ciphername, &enc))
+        if (!opt_cipher(ciphername, &enc, &fetched_enc))
             goto end;
     }
     if (!app_passwd(NULL, passoutarg, NULL, &passout)) {
@@ -237,6 +238,7 @@ opthelp:
 
     ret = 0;
  end:
+    EVP_CIPHER_free(fetched_enc);
     BN_free(bn);
     BN_GENCB_free(cb);
     EVP_PKEY_CTX_free(ctx);

--- a/apps/include/opt.h
+++ b/apps/include/opt.h
@@ -366,8 +366,9 @@ int opt_umax(const char *arg, uintmax_t *result);
 #endif
 int opt_pair(const char *arg, const OPT_PAIR * pairs, int *result);
 int opt_string(const char *name, const char **options);
-int opt_cipher(const char *name, const EVP_CIPHER **cipherp);
-int opt_md(const char *name, const EVP_MD **mdp);
+int opt_cipher(const char *name,
+               const EVP_CIPHER **cipherp, EVP_CIPHER **fetched_cipherp);
+int opt_md(const char *name, const EVP_MD **mdp, EVP_MD **fetched_mdp);
 char *opt_arg(void);
 char *opt_flag(void);
 char *opt_unknown(void);

--- a/apps/lib/opt.c
+++ b/apps/lib/opt.c
@@ -353,10 +353,12 @@ void print_format_error(int format, unsigned long flags)
 }
 
 /* Parse a cipher name, put it in *EVP_CIPHER; return 0 on failure, else 1. */
-int opt_cipher(const char *name, const EVP_CIPHER **cipherp)
+int opt_cipher(const char *name,
+               const EVP_CIPHER **cipherp, EVP_CIPHER **fetched_cipherp)
 {
-    *cipherp = EVP_get_cipherbyname(name);
-    if (*cipherp != NULL)
+    if ((*cipherp = EVP_get_cipherbyname(name)) != NULL
+        || (*cipherp = *fetched_cipherp =
+            EVP_CIPHER_fetch(NULL, name, NULL)) != NULL)
         return 1;
     opt_printf_stderr("%s: Unknown cipher: %s\n", prog, name);
     return 0;
@@ -365,10 +367,11 @@ int opt_cipher(const char *name, const EVP_CIPHER **cipherp)
 /*
  * Parse message digest name, put it in *EVP_MD; return 0 on failure, else 1.
  */
-int opt_md(const char *name, const EVP_MD **mdp)
+int opt_md(const char *name, const EVP_MD **mdp, EVP_MD **fetched_mdp)
 {
-    *mdp = EVP_get_digestbyname(name);
-    if (*mdp != NULL)
+    if ((*mdp = EVP_get_digestbyname(name)) != NULL
+        || (*mdp = *fetched_mdp =
+            EVP_MD_fetch(NULL, name, NULL)) != NULL)
         return 1;
     opt_printf_stderr("%s: Unknown option or message digest: %s\n", prog,
                       name != NULL ? name : "\"\"");

--- a/apps/ocsp.c
+++ b/apps/ocsp.c
@@ -204,6 +204,7 @@ int ocsp_main(int argc, char **argv)
 {
     BIO *acbio = NULL, *cbio = NULL, *derbio = NULL, *out = NULL;
     const EVP_MD *cert_id_md = NULL, *rsign_md = NULL;
+    EVP_MD *fetched_cert_id_md = NULL, *fetched_rsign_md = NULL;
     STACK_OF(OPENSSL_STRING) *rsign_sigopts = NULL;
     int trailing_md = 0;
     CA_DB *rdb = NULL;
@@ -499,7 +500,7 @@ int ocsp_main(int argc, char **argv)
                            prog);
                 goto opthelp;
             }
-            if (!opt_md(opt_unknown(), &cert_id_md))
+            if (!opt_md(opt_unknown(), &cert_id_md, &fetched_cert_id_md))
                 goto opthelp;
             trailing_md = 1;
             break;
@@ -527,7 +528,7 @@ int ocsp_main(int argc, char **argv)
     }
 
     if (respdigname != NULL) {
-        if (!opt_md(respdigname, &rsign_md))
+        if (!opt_md(respdigname, &rsign_md, &fetched_rsign_md))
             goto end;
     }
 
@@ -823,6 +824,8 @@ redo_accept:
         ret = 1;
 
  end:
+    EVP_MD_free(fetched_cert_id_md);
+    EVP_MD_free(fetched_rsign_md);
     ERR_print_errors(bio_err);
     X509_free(signer);
     X509_STORE_free(store);

--- a/apps/pkcs12.c
+++ b/apps/pkcs12.c
@@ -166,6 +166,7 @@ int pkcs12_main(int argc, char **argv)
     STACK_OF(OPENSSL_STRING) *canames = NULL;
     const EVP_CIPHER *const default_enc = EVP_aes_256_cbc();
     const EVP_CIPHER *enc = default_enc;
+    EVP_CIPHER *fetched_enc = NULL;
     OPTION_CHOICE o;
 
     prog = opt_init(argc, argv, pkcs12_options);
@@ -346,7 +347,7 @@ int pkcs12_main(int argc, char **argv)
 
     app_RAND_load();
     if (ciphername != NULL) {
-        if (!opt_cipher(ciphername, &enc))
+        if (!opt_cipher(ciphername, &enc, &fetched_enc))
             goto opthelp;
     }
     if (export_pkcs12) {
@@ -497,6 +498,7 @@ int pkcs12_main(int argc, char **argv)
         STACK_OF(X509) *certs = NULL;
         STACK_OF(X509) *untrusted_certs = NULL;
         const EVP_MD *macmd = NULL;
+        EVP_MD *fetched_macmd = NULL;
         unsigned char *catmp = NULL;
         int i;
 
@@ -650,7 +652,7 @@ int pkcs12_main(int argc, char **argv)
         }
 
         if (macalg != NULL) {
-            if (!opt_md(macalg, &macmd))
+            if (!opt_md(macalg, &macmd, &fetched_macmd))
                 goto opthelp;
         }
 
@@ -669,6 +671,7 @@ int pkcs12_main(int argc, char **argv)
 
  export_end:
 
+        EVP_MD_free(fetched_macmd);
         EVP_PKEY_free(key);
         sk_X509_pop_free(certs, X509_free);
         sk_X509_pop_free(untrusted_certs, X509_free);
@@ -767,6 +770,7 @@ int pkcs12_main(int argc, char **argv)
     }
     ret = 0;
  end:
+    EVP_CIPHER_free(fetched_enc);
     PKCS12_free(p12);
     release_engine(e);
     BIO_free(in);

--- a/apps/pkcs8.c
+++ b/apps/pkcs8.c
@@ -75,6 +75,7 @@ int pkcs8_main(int argc, char **argv)
     PKCS8_PRIV_KEY_INFO *p8inf = NULL;
     X509_SIG *p8 = NULL;
     const EVP_CIPHER *cipher = NULL;
+    EVP_CIPHER *fetched_cipher = NULL;
     char *infile = NULL, *outfile = NULL, *ciphername = NULL;
     char *passinarg = NULL, *passoutarg = NULL, *prog;
 #ifndef OPENSSL_NO_UI_CONSOLE
@@ -201,7 +202,7 @@ int pkcs8_main(int argc, char **argv)
     private = 1;
     app_RAND_load();
     if (ciphername != NULL) {
-        if (!opt_cipher(ciphername, &cipher))
+        if (!opt_cipher(ciphername, &cipher, &fetched_cipher))
             goto opthelp;
     }
 
@@ -365,6 +366,7 @@ int pkcs8_main(int argc, char **argv)
     ret = 0;
 
  end:
+    EVP_CIPHER_free(fetched_cipher);
     X509_SIG_free(p8);
     PKCS8_PRIV_KEY_INFO_free(p8inf);
     EVP_PKEY_free(pkey);

--- a/apps/pkey.c
+++ b/apps/pkey.c
@@ -72,6 +72,7 @@ int pkey_main(int argc, char **argv)
     EVP_PKEY *pkey = NULL;
     EVP_PKEY_CTX *ctx = NULL;
     const EVP_CIPHER *cipher = NULL;
+    EVP_CIPHER *fetched_cipher = NULL;
     char *infile = NULL, *outfile = NULL, *passin = NULL, *passout = NULL;
     char *passinarg = NULL, *passoutarg = NULL, *ciphername = NULL, *prog;
     OPTION_CHOICE o;
@@ -187,7 +188,7 @@ int pkey_main(int argc, char **argv)
     private = (!noout && !pubout) || (text && !text_pub);
 
     if (ciphername != NULL) {
-        if (!opt_cipher(ciphername, &cipher))
+        if (!opt_cipher(ciphername, &cipher, &fetched_cipher))
             goto opthelp;
     }
     if (cipher == NULL) {
@@ -316,6 +317,7 @@ int pkey_main(int argc, char **argv)
  end:
     if (ret != 0)
         ERR_print_errors(bio_err);
+    EVP_CIPHER_free(fetched_cipher);
     EVP_PKEY_CTX_free(ctx);
     EVP_PKEY_free(pkey);
     release_engine(e);

--- a/apps/req.c
+++ b/apps/req.c
@@ -241,6 +241,7 @@ int req_main(int argc, char **argv)
     X509_REQ *req = NULL;
     const EVP_CIPHER *cipher = NULL;
     const EVP_MD *md_alg = NULL, *digest = NULL;
+    EVP_MD *fetched_md_alg = NULL, *fetched_digest = NULL;
     int ext_copy = EXT_COPY_UNSET;
     BIO *addext_bio = NULL;
     char *extensions = NULL;
@@ -480,7 +481,7 @@ int req_main(int argc, char **argv)
 
     app_RAND_load();
     if (digestname != NULL) {
-        if (!opt_md(digestname, &md_alg))
+        if (!opt_md(digestname, &md_alg, &fetched_md_alg))
             goto opthelp;
         digest = md_alg;
     }
@@ -539,7 +540,7 @@ int req_main(int argc, char **argv)
         if (p == NULL) {
             ERR_clear_error();
         } else {
-            if (!opt_md(p, &md_alg))
+            if (!opt_md(p, &md_alg, &fetched_md_alg))
                 goto opthelp;
             digest = md_alg;
         }
@@ -1055,6 +1056,7 @@ int req_main(int argc, char **argv)
     NCONF_free(addext_conf);
     BIO_free(addext_bio);
     BIO_free_all(out);
+    EVP_MD_free(fetched_digest);
     EVP_PKEY_free(pkey);
     EVP_PKEY_CTX_free(genctx);
     sk_OPENSSL_STRING_free(pkeyopts);

--- a/apps/rsa.c
+++ b/apps/rsa.c
@@ -93,6 +93,7 @@ int rsa_main(int argc, char **argv)
     EVP_PKEY *pkey = NULL;
     EVP_PKEY_CTX *pctx;
     const EVP_CIPHER *enc = NULL;
+    EVP_CIPHER *fetched_enc = NULL;
     char *infile = NULL, *outfile = NULL, *ciphername = NULL, *prog;
     char *passin = NULL, *passout = NULL, *passinarg = NULL, *passoutarg = NULL;
     int private = 0;
@@ -189,7 +190,7 @@ int rsa_main(int argc, char **argv)
         goto opthelp;
 
     if (ciphername != NULL) {
-        if (!opt_cipher(ciphername, &enc))
+        if (!opt_cipher(ciphername, &enc, &fetched_enc))
             goto opthelp;
     }
     private = (text && !pubin) || (!pubout && !noout) ? 1 : 0;
@@ -353,6 +354,7 @@ int rsa_main(int argc, char **argv)
     }
     ret = 0;
  end:
+    EVP_CIPHER_free(fetched_enc);
     OSSL_ENCODER_CTX_free(ectx);
     release_engine(e);
     BIO_free_all(out);

--- a/apps/smime.c
+++ b/apps/smime.c
@@ -141,7 +141,9 @@ int smime_main(int argc, char **argv)
     X509_STORE *store = NULL;
     X509_VERIFY_PARAM *vpm = NULL;
     const EVP_CIPHER *cipher = NULL;
+    EVP_CIPHER *fetched_cipher = NULL;
     const EVP_MD *sign_md = NULL;
+    EVP_MD *fetched_sign_md = NULL;
     const char *CAfile = NULL, *CApath = NULL, *CAstore = NULL, *prog = NULL;
     char *certfile = NULL, *keyfile = NULL, *contfile = NULL;
     char *infile = NULL, *outfile = NULL, *signerfile = NULL, *recipfile = NULL;
@@ -361,11 +363,11 @@ int smime_main(int argc, char **argv)
 
     app_RAND_load();
     if (digestname != NULL) {
-        if (!opt_md(digestname, &sign_md))
+        if (!opt_md(digestname, &sign_md, &fetched_sign_md))
             goto opthelp;
     }
     if (ciphername != NULL) {
-        if (!opt_cipher(ciphername, &cipher))
+        if (!opt_cipher(ciphername, &cipher, &fetched_cipher))
             goto opthelp;
     }
     if (!(operation & SMIME_SIGNERS) && (skkeys != NULL || sksigners != NULL)) {
@@ -650,6 +652,8 @@ int smime_main(int argc, char **argv)
  end:
     if (ret)
         ERR_print_errors(bio_err);
+    EVP_CIPHER_free(fetched_cipher);
+    EVP_MD_free(fetched_sign_md);
     sk_X509_pop_free(encerts, X509_free);
     sk_X509_pop_free(other, X509_free);
     X509_VERIFY_PARAM_free(vpm);

--- a/apps/storeutl.c
+++ b/apps/storeutl.c
@@ -84,6 +84,7 @@ int storeutl_main(int argc, char *argv[])
     char *alias = NULL, *digestname = NULL;
     OSSL_STORE_SEARCH *search = NULL;
     const EVP_MD *digest = NULL;
+    EVP_MD *fetched_digest = NULL;
     OSSL_LIB_CTX *libctx = app_get0_libctx();
 
     while ((o = opt_next()) != OPT_EOF) {
@@ -263,7 +264,7 @@ int storeutl_main(int argc, char *argv[])
         goto opthelp;
 
     if (digestname != NULL) {
-        if (!opt_md(digestname, &digest))
+        if (!opt_md(digestname, &digest, &fetched_digest))
             goto opthelp;
     }
 
@@ -322,6 +323,7 @@ int storeutl_main(int argc, char *argv[])
                   text, noout, recursive, 0, out, prog, libctx);
 
  end:
+    EVP_MD_free(fetched_digest);
     OPENSSL_free(fingerprint);
     OPENSSL_free(alias);
     ASN1_INTEGER_free(serial);

--- a/apps/ts.c
+++ b/apps/ts.c
@@ -168,6 +168,7 @@ int ts_main(int argc, char **argv)
     char *inkey = NULL, *signer = NULL, *chain = NULL, *CApath = NULL;
     char *CAstore = NULL;
     const EVP_MD *md = NULL;
+    EVP_MD *fetched_md = NULL;
     OPTION_CHOICE o, mode = OPT_ERR;
     int ret = 1, no_nonce = 0, cert = 0, text = 0;
     int vpmtouched = 0;
@@ -293,7 +294,7 @@ int ts_main(int argc, char **argv)
 
     app_RAND_load();
     if (digestname != NULL) {
-        if (!opt_md(digestname, &md))
+        if (!opt_md(digestname, &md, &fetched_md))
             goto opthelp;
     }
     if (mode == OPT_REPLY && passin &&
@@ -339,6 +340,7 @@ int ts_main(int argc, char **argv)
     }
 
  end:
+    EVP_MD_free(fetched_md);
     X509_VERIFY_PARAM_free(vpm);
     NCONF_free(conf);
     OPENSSL_free(password);

--- a/apps/x509.c
+++ b/apps/x509.c
@@ -257,6 +257,7 @@ int x509_main(int argc, char **argv)
     X509_REQ *req = NULL, *rq = NULL;
     X509_STORE *ctx = NULL;
     const EVP_MD *digest = NULL;
+    EVP_MD *fetched_digest = NULL;
     char *CAkeyfile = NULL, *CAserial = NULL, *pubkeyfile = NULL, *alias = NULL;
     char *checkhost = NULL, *checkemail = NULL, *checkip = NULL;
     char *ext_names = NULL;
@@ -577,7 +578,7 @@ int x509_main(int argc, char **argv)
 
     app_RAND_load();
     if (digestname != NULL) {
-        if (!opt_md(digestname, &digest))
+        if (!opt_md(digestname, &digest, &fetched_digest))
             goto opthelp;
     }
     if (preserve_dates && days != UNSET_DAYS) {
@@ -1030,6 +1031,7 @@ int x509_main(int argc, char **argv)
     X509_REQ_free(req);
     X509_free(x);
     X509_free(xca);
+    EVP_MD_free(fetched_digest);
     EVP_PKEY_free(signkey);
     EVP_PKEY_free(CAkey);
     EVP_PKEY_free(pubkey);


### PR DESCRIPTION
'openssl enc' and 'openssl dgst' use opt_md() and opt_cipher() to get
the algorithms the user asks for, which only used EVP_get_cipherbyname()
and EVP_get_digestbyname().  That would only return legacy implementations
for things the libcrypto has prior knowledge of.

To allow all provider backed algorithms to be fully used, even without
libcrypto's prior knowledge, opt_md() and opt_cipher() now also use
EVP_MD_fetch() and EVP_CIPHER_fetch(), and return them in a second
pointer that our apps has to free.  This is made in such a way that
the application can otherwise continue to use the constant EVP_MD and
EVP_CIPHER pointers.

As a discussion point, this reiterates that application must know what
they have fetched explicitly, and therefore must also free (with
EVP_MD_free() or EVP_CIPHER_free() in this case), and what they have
not (which includes all constant pointers they get from all sorts of
other functions, such as EVP_MD_CTX_md()), and therefore must NOT free.

Fixes #14178
Fixes #14179