### PR TITLE
Fix backward incompatibility revolving around OSSL_HTTP_REQ_CTX_sendreq_d2i()

### DIFF
--- a/include/openssl/ocsp.h.in
+++ b/include/openssl/ocsp.h.in
@@ -189,8 +189,8 @@ typedef OSSL_HTTP_REQ_CTX OCSP_REQ_CTX;
         OSSL_HTTP_REQ_CTX_i2d(r, "application/ocsp-request", i, req)
 #   define OCSP_REQ_CTX_nbio(r) \
         OSSL_HTTP_REQ_CTX_nbio(r)
-#   define OCSP_REQ_CTX_nbio_d2i(r, i) \
-        OSSL_HTTP_REQ_CTX_sendreq_d2i(r, i)
+#   define OCSP_REQ_CTX_nbio_d2i(r, p, i)        \
+        ((*(p) = OSSL_HTTP_REQ_CTX_sendreq_d2i(r, i)) != NULL)
 #   define OCSP_REQ_CTX_get0_mem_bio(r) \
         OSSL_HTTP_REQ_CTX_get0_mem_bio(r)
 #   define OCSP_set_max_response_length(r, l) \

--- a/include/openssl/x509.h.in
+++ b/include/openssl/x509.h.in
@@ -403,11 +403,11 @@ int X509_NAME_digest(const X509_NAME *data, const EVP_MD *type,
                      unsigned char *md, unsigned int *len);
 
 X509 *X509_load_http(const char *url, BIO *bio, BIO *rbio, int timeout);
-# define X509_http_nbio(rctx, pcert) \
-    ((*(pcrl) =                                                         \
+# define X509_http_nbio(rctx, pcert)                                    \
+    ((*(pcert) =                                                        \
       OSSL_HTTP_REQ_CTX_sendreq_d2i(rctx, ASN1_ITEM_rptr(X509))) != NULL)
 X509_CRL *X509_CRL_load_http(const char *url, BIO *bio, BIO *rbio, int timeout);
-# define X509_CRL_http_nbio(rctx, pcrl) \
+# define X509_CRL_http_nbio(rctx, pcrl)                                 \
     ((*(pcrl) =                                                         \
       OSSL_HTTP_REQ_CTX_sendreq_d2i(rctx, ASN1_ITEM_rptr(X509_CRL))) != NULL)
 

--- a/include/openssl/x509.h.in
+++ b/include/openssl/x509.h.in
@@ -404,12 +404,12 @@ int X509_NAME_digest(const X509_NAME *data, const EVP_MD *type,
 
 X509 *X509_load_http(const char *url, BIO *bio, BIO *rbio, int timeout);
 # define X509_http_nbio(rctx, pcert) \
-    OSSL_HTTP_REQ_CTX_sendreq_d2i(rctx, (ASN1_VALUE **)(pcert), \
-                                  ASN1_ITEM_rptr(X509))
+    ((*(pcrl) =                                                         \
+      OSSL_HTTP_REQ_CTX_sendreq_d2i(rctx, ASN1_ITEM_rptr(X509))) != NULL)
 X509_CRL *X509_CRL_load_http(const char *url, BIO *bio, BIO *rbio, int timeout);
 # define X509_CRL_http_nbio(rctx, pcrl) \
-    OSSL_HTTP_REQ_CTX_sendreq_d2i(rctx, (ASN1_VALUE **)(pcrl), \
-                                  ASN1_ITEM_rptr(X509_CRL))
+    ((*(pcrl) =                                                         \
+      OSSL_HTTP_REQ_CTX_sendreq_d2i(rctx, ASN1_ITEM_rptr(X509_CRL))) != NULL)
 
 # ifndef OPENSSL_NO_STDIO
 X509 *d2i_X509_fp(FILE *fp, X509 **x509);


### PR DESCRIPTION
The OSSL_HTTP_REQ_CTX API has a few changes compared to the older
OCSP_REQ_CTX API which are not quite obvious at first sight.

The old OCSP_REQ_CTX_nbio_d2i() took three arguments, of which one is
an output argument, and return an int, while the newer
OSSL_HTTP_REQ_CTX_sendreq_d2i() returns the value directly and thereby
takes one less argument.

The mapping from the old to the new wasn't quite right, this corrects
it, along with a couple of X509 macros that needed the same kind of
fix.
