### PR TITLE
Make d2i_PUBKEY_ex generate new style EVP_PKEYs

### DIFF
--- a/crypto/ct/ct_b64.c
+++ b/crypto/ct/ct_b64.c
@@ -153,7 +153,7 @@ int CTLOG_new_from_base64_ex(CTLOG **ct_log, const char *pkey_base64,
     }
 
     p = pkey_der;
-    pkey = d2i_PUBKEY(NULL, &p, pkey_der_len);
+    pkey = d2i_PUBKEY_ex(NULL, &p, pkey_der_len, libctx, propq);
     OPENSSL_free(pkey_der);
     if (pkey == NULL) {
         ERR_raise(ERR_LIB_CT, CT_R_LOG_CONF_INVALID_KEY);

--- a/include/crypto/evp.h
+++ b/include/crypto/evp.h
@@ -820,6 +820,10 @@ int pkcs5_pbkdf2_hmac_ex(const char *pass, int passlen,
                          const EVP_MD *digest, int keylen, unsigned char *out,
                          OSSL_LIB_CTX *libctx, const char *propq);
 
+EVP_PKEY *evp_publickey_from_binary(EVP_PKEY **a,
+                                    const unsigned char **pp, long length,
+                                    OSSL_LIB_CTX *libctx, const char *propq);
+
 # ifndef FIPS_MODULE
 /*
  * Internal helpers for stricter EVP_PKEY_CTX_{set,get}_params().

--- a/providers/implementations/encode_decode/decode_der2key.c
+++ b/providers/implementations/encode_decode/decode_der2key.c
@@ -29,6 +29,7 @@
 #include "crypto/dsa.h"
 #include "crypto/ec.h"
 #include "crypto/ecx.h"
+#include "crypto/evp.h"
 #include "crypto/rsa.h"
 #include "prov/bio.h"
 #include "prov/implementations.h"
@@ -329,7 +330,7 @@ static int der2key_decode(void *vctx, OSSL_CORE_BIO *cin, int selection,
             && (selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY) != 0) {
             RESET_ERR_MARK();
             derp = der;
-            pkey = d2i_PUBKEY_ex(NULL, &derp, der_len, libctx, NULL);
+            pkey = evp_publickey_from_binary(NULL, &derp, der_len, libctx, NULL);
         }
 
         if (pkey != NULL) {


### PR DESCRIPTION
Use new decoder for d2i_PUBKEY_ex so that the output is a non-legacy EVP_PKEY.

This change is similar to work done by @slontis in https://github.com/openssl/openssl/pull/13591
