### PR TITLE
Add EVP_PKEY_public_check_quick.

### DIFF
--- a/crypto/dh/dh_group_params.c
+++ b/crypto/dh/dh_group_params.c
@@ -81,6 +81,17 @@ void dh_cache_named_group(DH *dh)
     }
 }
 
+int ossl_dh_is_named_safe_prime_group(const DH *dh)
+{
+    int id = DH_get_nid(dh);
+
+    /*
+     * Exclude RFC5114 groups (id = 1..3) since they do not have
+     * q = (p - 1) / 2
+     */
+    return (id > 3);
+}
+
 int DH_get_nid(const DH *dh)
 {
     if (dh == NULL)

--- a/crypto/evp/pmeth_check.c
+++ b/crypto/evp/pmeth_check.c
@@ -42,7 +42,7 @@ static int try_provided_check(EVP_PKEY_CTX *ctx, int selection, int checktype)
     return evp_keymgmt_validate(keymgmt, keydata, selection, checktype);
 }
 
-int EVP_PKEY_public_check(EVP_PKEY_CTX *ctx)
+static int evp_pkey_public_check_combined(EVP_PKEY_CTX *ctx, int checktype)
 {
     EVP_PKEY *pkey = ctx->pkey;
     int ok;
@@ -53,7 +53,7 @@ int EVP_PKEY_public_check(EVP_PKEY_CTX *ctx)
     }
 
     if ((ok = try_provided_check(ctx, OSSL_KEYMGMT_SELECT_PUBLIC_KEY,
-                                 OSSL_KEYMGMT_VALIDATE_FULL_CHECK)) != -1)
+                                 checktype)) != -1)
         return ok;
 
     if (pkey->type == EVP_PKEY_NONE)
@@ -74,6 +74,16 @@ int EVP_PKEY_public_check(EVP_PKEY_CTX *ctx)
  not_supported:
     ERR_raise(ERR_LIB_EVP, EVP_R_OPERATION_NOT_SUPPORTED_FOR_THIS_KEYTYPE);
     return -2;
+}
+
+int EVP_PKEY_public_check(EVP_PKEY_CTX *ctx)
+{
+    return evp_pkey_public_check_combined(ctx, OSSL_KEYMGMT_VALIDATE_FULL_CHECK);
+}
+
+int EVP_PKEY_public_check_quick(EVP_PKEY_CTX *ctx)
+{
+    return evp_pkey_public_check_combined(ctx, OSSL_KEYMGMT_VALIDATE_QUICK_CHECK);
 }
 
 static int evp_pkey_param_check_combined(EVP_PKEY_CTX *ctx, int checktype)

--- a/doc/man3/EVP_PKEY_check.pod
+++ b/doc/man3/EVP_PKEY_check.pod
@@ -3,7 +3,8 @@
 =head1 NAME
 
 EVP_PKEY_check, EVP_PKEY_param_check, EVP_PKEY_param_check_quick,
-EVP_PKEY_public_check, EVP_PKEY_private_check, EVP_PKEY_pairwise_check
+EVP_PKEY_public_check, EVP_PKEY_public_check_quick, EVP_PKEY_private_check,
+EVP_PKEY_pairwise_check
 - key and parameter validation functions
 
 =head1 SYNOPSIS
@@ -14,6 +15,7 @@ EVP_PKEY_public_check, EVP_PKEY_private_check, EVP_PKEY_pairwise_check
  int EVP_PKEY_param_check(EVP_PKEY_CTX *ctx);
  int EVP_PKEY_param_check_quick(EVP_PKEY_CTX *ctx);
  int EVP_PKEY_public_check(EVP_PKEY_CTX *ctx);
+ int EVP_PKEY_public_check_quick(EVP_PKEY_CTX *ctx);
  int EVP_PKEY_private_check(EVP_PKEY_CTX *ctx);
  int EVP_PKEY_pairwise_check(EVP_PKEY_CTX *ctx);
 
@@ -29,6 +31,12 @@ order to perform a lightweight sanity check of the key. If a quicker form is not
 provided then this function call does the same thing as EVP_PKEY_param_check().
 
 EVP_PKEY_public_check() validates the public component of the key given by B<ctx>.
+
+EVP_PKEY_public_check_quick() validates the public component of the key
+given by B<ctx> like EVP_PKEY_public_check() does. However some algorithm
+implementations may offer a quicker form of validation that omits some checks in
+order to perform a lightweight sanity check of the key. If a quicker form is not
+provided then this function call does the same thing as EVP_PKEY_public_check().
 
 EVP_PKEY_private_check() validates the private component of the key given by B<ctx>.
 
@@ -60,8 +68,8 @@ L<EVP_PKEY_fromdata(3)>,
 EVP_PKEY_check(), EVP_PKEY_public_check() and EVP_PKEY_param_check() were added
 in OpenSSL 1.1.1.
 
-EVP_PKEY_param_check_quick(), EVP_PKEY_private_check() and
-EVP_PKEY_pairwise_check() were added in OpenSSL 3.0.
+EVP_PKEY_param_check_quick(), EVP_PKEY_public_check_quick(),
+EVP_PKEY_private_check() and EVP_PKEY_pairwise_check() were added in OpenSSL 3.0.
 
 =head1 COPYRIGHT
 

--- a/include/crypto/dh.h
+++ b/include/crypto/dh.h
@@ -28,6 +28,7 @@ int dh_get_named_group_uid_from_size(int pbits);
 const char *dh_gen_type_id2name(int id);
 int dh_gen_type_name2id(const char *name);
 void dh_cache_named_group(DH *dh);
+int ossl_dh_is_named_safe_prime_group(const DH *dh);
 
 FFC_PARAMS *dh_get0_params(DH *dh);
 int dh_get0_nid(const DH *dh);

--- a/include/crypto/ec.h
+++ b/include/crypto/ec.h
@@ -60,6 +60,7 @@ int ecdh_KDF_X9_63(unsigned char *out, size_t outlen,
                    const EVP_MD *md, OSSL_LIB_CTX *libctx, const char *propq);
 
 int ec_key_public_check(const EC_KEY *eckey, BN_CTX *ctx);
+int ec_key_public_check_quick(const EC_KEY *eckey, BN_CTX *ctx);
 int ec_key_private_check(const EC_KEY *eckey);
 int ec_key_pairwise_check(const EC_KEY *eckey, BN_CTX *ctx);
 OSSL_LIB_CTX *ec_key_get_libctx(const EC_KEY *eckey);

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -1827,6 +1827,7 @@ int EVP_PKEY_keygen(EVP_PKEY_CTX *ctx, EVP_PKEY **ppkey);
 int EVP_PKEY_gen(EVP_PKEY_CTX *ctx, EVP_PKEY **ppkey);
 int EVP_PKEY_check(EVP_PKEY_CTX *ctx);
 int EVP_PKEY_public_check(EVP_PKEY_CTX *ctx);
+int EVP_PKEY_public_check_quick(EVP_PKEY_CTX *ctx);
 int EVP_PKEY_param_check(EVP_PKEY_CTX *ctx);
 int EVP_PKEY_param_check_quick(EVP_PKEY_CTX *ctx);
 int EVP_PKEY_private_check(EVP_PKEY_CTX *ctx);

--- a/providers/implementations/keymgmt/ec_kmgmt.c
+++ b/providers/implementations/keymgmt/ec_kmgmt.c
@@ -852,8 +852,12 @@ int sm2_validate(const void *keydata, int selection, int checktype)
     if ((selection & OSSL_KEYMGMT_SELECT_DOMAIN_PARAMETERS) != 0)
         ok = ok && EC_GROUP_check(EC_KEY_get0_group(eck), ctx);
 
-    if ((selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY) != 0)
-        ok = ok && ec_key_public_check(eck, ctx);
+    if ((selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY) != 0) {
+        if (checktype == OSSL_KEYMGMT_VALIDATE_QUICK_CHECK)
+            ok = ok && ec_key_public_check_quick(eck, ctx);
+        else
+            ok = ok && ec_key_public_check(eck, ctx);
+    }
 
     if ((selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) != 0)
         ok = ok && sm2_key_private_check(eck);
@@ -894,8 +898,12 @@ int ec_validate(const void *keydata, int selection, int checktype)
             ok = ok && EC_GROUP_check(EC_KEY_get0_group(eck), ctx);
     }
 
-    if ((selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY) != 0)
-        ok = ok && ec_key_public_check(eck, ctx);
+    if ((selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY) != 0) {
+        if (checktype == OSSL_KEYMGMT_VALIDATE_QUICK_CHECK)
+            ok = ok && ec_key_public_check_quick(eck, ctx);
+        else
+            ok = ok && ec_key_public_check(eck, ctx);
+    }
 
     if ((selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) != 0)
         ok = ok && ec_key_private_check(eck);

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5299,3 +5299,4 @@ EVP_PKEY_get_params                     ?	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_fromdata_init                  ?	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_fromdata_settable              ?	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_param_check_quick              ?	3_0_0	EXIST::FUNCTION:
+EVP_PKEY_public_check_quick             ?	3_0_0	EXIST::FUNCTION:


### PR DESCRIPTION
Adding the EVP_PKEY_param_check_quick() reminded me that there are also
partial checks for public keys as part of SP800-56A for FFC (DH named safe
prime groups) and ECC. The code was mainly already there and just needed
to be plumbed into the validate methods.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
