### PR TITLE
[WIP]: Support library context for PKCS12 APIs

### DIFF
--- a/crypto/asn1/p5_scrypt.c
+++ b/crypto/asn1/p5_scrypt.c
@@ -142,6 +142,23 @@ X509_ALGOR *PKCS5_pbe2_set_scrypt(const EVP_CIPHER *cipher,
     return NULL;
 }
 
+int PKCS5_v2_scrypt_keygen_ex(EVP_CIPHER_CTX **ctx, OSSL_PARAM *params, 
+                        const char *pass, int passlen, int en_de, 
+                        OSSL_LIB_CTX *libctx, const char *propq)
+{
+    return 0;
+}
+
+int PKCS5_v2_scrypt_encode(X509_ALGOR **algor, OSSL_PARAM *params)
+{
+    return 0;
+}
+
+int PKCS5_v2_scrypt_decode(X509_ALGOR *algor, OSSL_PARAM **params)
+{
+    return 0;
+}
+
 static X509_ALGOR *pkcs5_scrypt_set(const unsigned char *salt, size_t saltlen,
                                     size_t keylen, uint64_t N, uint64_t r,
                                     uint64_t p)

--- a/crypto/evp/evp_local.h
+++ b/crypto/evp/evp_local.h
@@ -208,7 +208,33 @@ int PKCS5_v2_PBKDF2_keyivgen(EVP_CIPHER_CTX *ctx, const char *pass,
                              const EVP_CIPHER *c, const EVP_MD *md,
                              int en_de);
 
-int PKCS12_PBE_params_decode(ASN1_TYPE *param, OSSL_PARAM **params, int params_len);
+int PKCS5_PBE_keygen_ex(EVP_CIPHER_CTX **ctx, OSSL_PARAM *params,
+                        const char *pass, int passlen, int en_de,
+                        OSSL_LIB_CTX *libctx, const char *propq);
+int PKCS5_PBE2_keygen_ex(EVP_CIPHER_CTX **ctx, OSSL_PARAM *params,
+                        const char *pass, int passlen, int en_de,
+                        OSSL_LIB_CTX *libctx, const char *propq);
+int PKCS12_PBE_keygen_ex(EVP_CIPHER_CTX **ctx, OSSL_PARAM *params,
+                        const char *pass, int passlen, int en_de,
+                        OSSL_LIB_CTX *libctx, const char *propq);
+int PKCS5_v2_PBKDF2_keygen_ex(EVP_CIPHER_CTX **ctx, OSSL_PARAM *params,
+                        const char *pass, int passlen, int en_de,
+                        OSSL_LIB_CTX *libctx, const char *propq);
+int PKCS5_v2_scrypt_keygen_ex(EVP_CIPHER_CTX **ctx, OSSL_PARAM *params,
+                        const char *pass, int passlen, int en_de,
+                        OSSL_LIB_CTX *libctx, const char *propq);
+
+int PKCS5_PBE_encode(X509_ALGOR **algor, OSSL_PARAM *params);
+int PKCS5_PBE2_encode(X509_ALGOR **algor, OSSL_PARAM *params);
+int PKCS12_PBE_encode(X509_ALGOR **algor, OSSL_PARAM *params);
+int PKCS5_v2_PBKDF2_encode(X509_ALGOR **algor, OSSL_PARAM *params);
+int PKCS5_v2_scrypt_encode(X509_ALGOR **algor, OSSL_PARAM *params);
+
+int PKCS5_PBE_decode(X509_ALGOR *algor, OSSL_PARAM **params);
+int PKCS5_PBE2_decode(X509_ALGOR *algor, OSSL_PARAM **params);
+int PKCS12_PBE_decode(X509_ALGOR *algor, OSSL_PARAM **params);
+int PKCS5_v2_PBKDF2_decode(X509_ALGOR *algor, OSSL_PARAM **params);
+int PKCS5_v2_scrypt_decode(X509_ALGOR *algor, OSSL_PARAM **params);
 
 struct evp_Encode_Ctx_st {
     /* number saved in a partial encode/decode */

--- a/crypto/evp/evp_local.h
+++ b/crypto/evp/evp_local.h
@@ -208,6 +208,8 @@ int PKCS5_v2_PBKDF2_keyivgen(EVP_CIPHER_CTX *ctx, const char *pass,
                              const EVP_CIPHER *c, const EVP_MD *md,
                              int en_de);
 
+int PKCS12_PBE_params_decode(ASN1_TYPE *param, OSSL_PARAM **params, int params_len);
+
 struct evp_Encode_Ctx_st {
     /* number saved in a partial encode/decode */
     int num;

--- a/crypto/evp/evp_pbe.c
+++ b/crypto/evp/evp_pbe.c
@@ -10,6 +10,8 @@
 #include <stdio.h>
 #include "internal/cryptlib.h"
 #include <openssl/evp.h>
+#include <openssl/core.h>
+#include <openssl/core_names.h>
 #include <openssl/pkcs12.h>
 #include <openssl/x509.h>
 #include "crypto/evp.h"
@@ -25,13 +27,16 @@ struct evp_pbe_st {
     int cipher_nid;
     int md_nid;
     EVP_PBE_KEYGEN *keygen;
+//    const char * pbe_name;
+    EVP_PBE_ENCODE *encode;
+    EVP_PBE_DECODE *decode;
 };
 
 static STACK_OF(EVP_PBE_CTL) *pbe_algs;
 
 static const EVP_PBE_CTL builtin_pbe[] = {
     {EVP_PBE_TYPE_OUTER, NID_pbeWithMD2AndDES_CBC,
-     NID_des_cbc, NID_md2, PKCS5_PBE_keyivgen},
+     NID_des_cbc, NID_md2, PKCS5_PBE_keyivgen, OSSL_PBE_NAME_PKCS5},
     {EVP_PBE_TYPE_OUTER, NID_pbeWithMD5AndDES_CBC,
      NID_des_cbc, NID_md5, PKCS5_PBE_keyivgen},
     {EVP_PBE_TYPE_OUTER, NID_pbeWithSHA1AndRC2_CBC,
@@ -40,19 +45,19 @@ static const EVP_PBE_CTL builtin_pbe[] = {
     {EVP_PBE_TYPE_OUTER, NID_id_pbkdf2, -1, -1, PKCS5_v2_PBKDF2_keyivgen},
 
     {EVP_PBE_TYPE_OUTER, NID_pbe_WithSHA1And128BitRC4,
-     NID_rc4, NID_sha1, PKCS12_PBE_keyivgen},
+     NID_rc4, NID_sha1, PKCS12_PBE_keyivgen, OSSL_PBE_NAME_PKCS12},
     {EVP_PBE_TYPE_OUTER, NID_pbe_WithSHA1And40BitRC4,
-     NID_rc4_40, NID_sha1, PKCS12_PBE_keyivgen},
+     NID_rc4_40, NID_sha1, PKCS12_PBE_keyivgen, OSSL_PBE_NAME_PKCS12},
     {EVP_PBE_TYPE_OUTER, NID_pbe_WithSHA1And3_Key_TripleDES_CBC,
-     NID_des_ede3_cbc, NID_sha1, PKCS12_PBE_keyivgen},
+     NID_des_ede3_cbc, NID_sha1, PKCS12_PBE_keyivgen, OSSL_PBE_NAME_PKCS12},
     {EVP_PBE_TYPE_OUTER, NID_pbe_WithSHA1And2_Key_TripleDES_CBC,
-     NID_des_ede_cbc, NID_sha1, PKCS12_PBE_keyivgen},
+     NID_des_ede_cbc, NID_sha1, PKCS12_PBE_keyivgen, OSSL_PBE_NAME_PKCS12},
     {EVP_PBE_TYPE_OUTER, NID_pbe_WithSHA1And128BitRC2_CBC,
-     NID_rc2_cbc, NID_sha1, PKCS12_PBE_keyivgen},
+     NID_rc2_cbc, NID_sha1, PKCS12_PBE_keyivgen, OSSL_PBE_NAME_PKCS12},
     {EVP_PBE_TYPE_OUTER, NID_pbe_WithSHA1And40BitRC2_CBC,
-     NID_rc2_40_cbc, NID_sha1, PKCS12_PBE_keyivgen},
+     NID_rc2_40_cbc, NID_sha1, PKCS12_PBE_keyivgen, OSSL_PBE_NAME_PKCS12},
 
-    {EVP_PBE_TYPE_OUTER, NID_pbes2, -1, -1, PKCS5_v2_PBE_keyivgen},
+    {EVP_PBE_TYPE_OUTER, NID_pbes2, -1, -1, PKCS5_v2_PBE_keyivgen, OSSL_PBE_NAME_PBES2},
 
     {EVP_PBE_TYPE_OUTER, NID_pbeWithMD2AndRC2_CBC,
      NID_rc2_64_cbc, NID_md2, PKCS5_PBE_keyivgen},
@@ -81,6 +86,174 @@ static const EVP_PBE_CTL builtin_pbe[] = {
     {EVP_PBE_TYPE_KDF, NID_id_scrypt, -1, -1, PKCS5_v2_scrypt_keyivgen}
 #endif
 };
+
+int EVP_PBE_params_decode(ASN1_OBJECT *pbe_obj, const char *pass, int passlen,
+                          ASN1_TYPE *param, OSSL_PARAM **params, int *params_len)
+{
+    int p_index = 0;
+    int pbe_nid, cipher_nid, md_nid;
+    const char *pbe_name, *cipher_name, *md_name;
+    EVP_PBE_KEYGEN *keygen;
+
+    pbe_nid = OBJ_obj2nid(pbe_obj);
+    if (!EVP_PBE_find_ex(EVP_PBE_TYPE_OUTER, pbe_nid, &cipher_nid, &md_nid,
+                         &keygen, &pbe_name)) {
+        char obj_tmp[80];
+        if (pbe_obj == NULL)
+            OPENSSL_strlcpy(obj_tmp, "NULL", sizeof(obj_tmp));
+        else
+            i2t_ASN1_OBJECT(obj_tmp, sizeof(obj_tmp), pbe_obj);
+        ERR_raise_data(ERR_LIB_EVP, EVP_R_UNKNOWN_PBE_ALGORITHM,
+                       "TYPE=%s", obj_tmp);
+        return 0;
+    }
+
+    if (pbe_name == NULL) {
+        ERR_raise(ERR_LIB_EVP, EVP_R_UNKNOWN_PBE_ALGORITHM);
+        return 0;
+    }
+
+    *params[p_index++] = OSSL_PARAM_construct_utf8_string(OSSL_PBE_PARAM_ALG, pbe_name, 0);
+
+    if (pass == NULL)
+        passlen = 0;
+    else if (passlen == -1)
+        passlen = strlen(pass);
+    *params[p_index++] = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_PASSWORD, pass,
+                                             passlen);
+
+    /* If cipher/digest can be determined from PBE OID, set them here */
+    if (cipher_nid != -1) {
+        cipher_name = OBJ_nid2sn(cipher_nid);
+        if (!cipher_name) {
+            ERR_raise(ERR_LIB_EVP, EVP_R_UNKNOWN_CIPHER);
+            return 0;
+        }
+        *params[p_index++] = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_CIPHER, cipher_name, 0);
+    }
+
+    if (md_nid != -1) {
+        md_name = OBJ_nid2sn(md_nid);
+        if (!md_name) {
+            ERR_raise(ERR_LIB_EVP, EVP_R_UNKNOWN_DIGEST);
+            return 0;
+        }
+        *params[p_index++] = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_DIGEST, md_name, 0);
+    }
+
+  if (strcmp(pbe_name, "PBES2") == 0)
+  {
+    /* Decode PBES2 */
+    PBE2PARAM *pbe2 = NULL;
+    const EVP_CIPHER *cipher;
+    EVP_PBE_KEYGEN *kdf;
+
+    int rv = 0;
+
+    pbe2 = ASN1_TYPE_unpack_sequence(ASN1_ITEM_rptr(PBE2PARAM), param);
+    if (pbe2 == NULL) {
+        ERR_raise(ERR_LIB_EVP, EVP_R_DECODE_ERROR);
+        return 0;
+    }
+
+    /* See if we recognise the key derivation function */
+    if (!EVP_PBE_find(EVP_PBE_TYPE_KDF, OBJ_obj2nid(pbe2->keyfunc->algorithm),
+                        NULL, NULL, &kdf)) {
+        ERR_raise(ERR_LIB_EVP, EVP_R_UNSUPPORTED_KEY_DERIVATION_FUNCTION);
+        return 0;
+    }
+
+    /*
+     * lets see if we recognise the encryption algorithm.
+     */
+
+    cipher_name = OBJ_obj2sn(pbe2->encryption->algorithm);
+
+    if (!cipher) {
+        ERR_raise(ERR_LIB_EVP, EVP_R_UNSUPPORTED_CIPHER);
+        return 0;
+    }
+
+  } else {
+    /* Decode PBES1 */
+    PBEPARAM *pbe;
+    OSSL_PARAM *p = params;
+    unsigned int iter = 0;
+
+    while (p != NULL)
+        p++;
+
+    /* Extract useful info from parameter */
+    pbe = ASN1_TYPE_unpack_sequence(ASN1_ITEM_rptr(PBEPARAM), param);
+    if (pbe == NULL) {
+        ERR_raise(ERR_LIB_PKCS12, PKCS12_R_DECODE_ERROR);
+        return 0;
+    }
+
+    if (pbe->iter != NULL) {
+        iter = ASN1_INTEGER_get(pbe->iter);
+        *p++ = OSSL_PARAM_construct_uint(OSSL_KDF_PARAM_ITER, &iter);
+    }
+    *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_SALT, pbe->salt->data,
+                                             pbe->salt->length);
+    PBEPARAM_free(pbe);
+  }
+
+    return decode(param, params, params_len);
+}
+
+int EVP_PBE_from_params(OSSL_PARAM *params,
+                        EVP_CIPHER_CTX *ctx, int en_de)
+{
+/* TODO: Implement
+    const EVP_CIPHER *cipher;
+    const EVP_MD *md;
+    int cipher_nid, md_nid;
+    EVP_PBE_KEYGEN *keygen;
+
+    if (!EVP_PBE_find_ex(EVP_PBE_TYPE_OUTER, OBJ_obj2nid(pbe_obj),
+                         &cipher_nid, &md_nid, &keygen, NULL)) {
+        char obj_tmp[80];
+
+        if (pbe_obj == NULL)
+            OPENSSL_strlcpy(obj_tmp, "NULL", sizeof(obj_tmp));
+        else
+            i2t_ASN1_OBJECT(obj_tmp, sizeof(obj_tmp), pbe_obj);
+        ERR_raise_data(ERR_LIB_EVP, EVP_R_UNKNOWN_PBE_ALGORITHM,
+                       "TYPE=%s", obj_tmp);
+        return 0;
+    }
+
+    if (pass == NULL)
+        passlen = 0;
+    else if (passlen == -1)
+        passlen = strlen(pass);
+
+    if (cipher_nid == -1)
+        cipher = NULL;
+    else {
+        cipher = EVP_get_cipherbynid(cipher_nid);
+        if (!cipher) {
+            ERR_raise_data(ERR_LIB_EVP, EVP_R_UNKNOWN_CIPHER,
+                           OBJ_nid2sn(cipher_nid));
+            return 0;
+        }
+    }
+
+    if (md_nid == -1)
+        md = NULL;
+    else {
+        md = EVP_get_digestbynid(md_nid);
+        if (!md) {
+            ERR_raise(ERR_LIB_EVP, EVP_R_UNKNOWN_DIGEST);
+            return 0;
+        }
+    }
+
+    return keygen(ctx, pass, passlen, param, cipher, md, en_de);
+*/
+    return 0;
+}
 
 int EVP_PBE_CipherInit(ASN1_OBJECT *pbe_obj, const char *pass, int passlen,
                        ASN1_TYPE *param, EVP_CIPHER_CTX *ctx, int en_de)
@@ -205,8 +378,9 @@ int EVP_PBE_alg_add(int nid, const EVP_CIPHER *cipher, const EVP_MD *md,
                                 cipher_nid, md_nid, keygen);
 }
 
-int EVP_PBE_find(int type, int pbe_nid,
-                 int *pcnid, int *pmnid, EVP_PBE_KEYGEN **pkeygen)
+int EVP_PBE_find_ex(int type, int pbe_nid,
+                    int *pcnid, int *pmnid, EVP_PBE_KEYGEN **pkeygen,
+                    const char **pbe_name)
 {
     EVP_PBE_CTL *pbetmp = NULL, pbelu;
     int i;
@@ -231,7 +405,15 @@ int EVP_PBE_find(int type, int pbe_nid,
         *pmnid = pbetmp->md_nid;
     if (pkeygen)
         *pkeygen = pbetmp->keygen;
+    if (pbe_name)
+        *pbe_name = pbetmp->pbe_name;
     return 1;
+}
+
+int EVP_PBE_find(int type, int pbe_nid,
+                 int *pcnid, int *pmnid, EVP_PBE_KEYGEN **pkeygen)
+{
+    return EVP_PBE_find_ex(type, pbe_nid, pcnid, pmnid, pkeygen, NULL);
 }
 
 static void free_evp_pbe_ctl(EVP_PBE_CTL *pbe)

--- a/crypto/evp/evp_pbe.c
+++ b/crypto/evp/evp_pbe.c
@@ -27,7 +27,7 @@ struct evp_pbe_st {
     int cipher_nid;
     int md_nid;
     EVP_PBE_KEYGEN *keygen;
-//    const char * pbe_name;
+    EVP_PBE_KEYGEN_EX *keygen_ex;
     EVP_PBE_ENCODE *encode;
     EVP_PBE_DECODE *decode;
 };
@@ -36,35 +36,35 @@ static STACK_OF(EVP_PBE_CTL) *pbe_algs;
 
 static const EVP_PBE_CTL builtin_pbe[] = {
     {EVP_PBE_TYPE_OUTER, NID_pbeWithMD2AndDES_CBC,
-     NID_des_cbc, NID_md2, PKCS5_PBE_keyivgen, OSSL_PBE_NAME_PKCS5},
+     NID_des_cbc, NID_md2, PKCS5_PBE_keyivgen, PKCS5_PBE_keygen_ex, PKCS5_PBE_encode, PKCS5_PBE_decode},
     {EVP_PBE_TYPE_OUTER, NID_pbeWithMD5AndDES_CBC,
-     NID_des_cbc, NID_md5, PKCS5_PBE_keyivgen},
+     NID_des_cbc, NID_md5, PKCS5_PBE_keyivgen, PKCS5_PBE_keygen_ex, PKCS5_PBE_encode, PKCS5_PBE_decode},
     {EVP_PBE_TYPE_OUTER, NID_pbeWithSHA1AndRC2_CBC,
-     NID_rc2_64_cbc, NID_sha1, PKCS5_PBE_keyivgen},
+     NID_rc2_64_cbc, NID_sha1, PKCS5_PBE_keyivgen, PKCS5_PBE_keygen_ex, PKCS5_PBE_encode, PKCS5_PBE_decode},
 
     {EVP_PBE_TYPE_OUTER, NID_id_pbkdf2, -1, -1, PKCS5_v2_PBKDF2_keyivgen},
 
     {EVP_PBE_TYPE_OUTER, NID_pbe_WithSHA1And128BitRC4,
-     NID_rc4, NID_sha1, PKCS12_PBE_keyivgen, OSSL_PBE_NAME_PKCS12},
+     NID_rc4, NID_sha1, PKCS12_PBE_keyivgen, PKCS12_PBE_keygen_ex, PKCS12_PBE_encode, PKCS12_PBE_decode},
     {EVP_PBE_TYPE_OUTER, NID_pbe_WithSHA1And40BitRC4,
-     NID_rc4_40, NID_sha1, PKCS12_PBE_keyivgen, OSSL_PBE_NAME_PKCS12},
+     NID_rc4_40, NID_sha1, PKCS12_PBE_keyivgen, PKCS12_PBE_keygen_ex, PKCS12_PBE_encode, PKCS12_PBE_decode},
     {EVP_PBE_TYPE_OUTER, NID_pbe_WithSHA1And3_Key_TripleDES_CBC,
-     NID_des_ede3_cbc, NID_sha1, PKCS12_PBE_keyivgen, OSSL_PBE_NAME_PKCS12},
+     NID_des_ede3_cbc, NID_sha1, PKCS12_PBE_keyivgen, PKCS12_PBE_keygen_ex, PKCS12_PBE_encode, PKCS12_PBE_decode},
     {EVP_PBE_TYPE_OUTER, NID_pbe_WithSHA1And2_Key_TripleDES_CBC,
-     NID_des_ede_cbc, NID_sha1, PKCS12_PBE_keyivgen, OSSL_PBE_NAME_PKCS12},
+     NID_des_ede_cbc, NID_sha1, PKCS12_PBE_keyivgen, PKCS12_PBE_keygen_ex, PKCS12_PBE_encode, PKCS12_PBE_decode},
     {EVP_PBE_TYPE_OUTER, NID_pbe_WithSHA1And128BitRC2_CBC,
-     NID_rc2_cbc, NID_sha1, PKCS12_PBE_keyivgen, OSSL_PBE_NAME_PKCS12},
+     NID_rc2_cbc, NID_sha1, PKCS12_PBE_keyivgen, PKCS12_PBE_keygen_ex, PKCS12_PBE_encode, PKCS12_PBE_decode},
     {EVP_PBE_TYPE_OUTER, NID_pbe_WithSHA1And40BitRC2_CBC,
-     NID_rc2_40_cbc, NID_sha1, PKCS12_PBE_keyivgen, OSSL_PBE_NAME_PKCS12},
+     NID_rc2_40_cbc, NID_sha1, PKCS12_PBE_keyivgen, PKCS12_PBE_keygen_ex, PKCS12_PBE_encode, PKCS12_PBE_decode},
 
-    {EVP_PBE_TYPE_OUTER, NID_pbes2, -1, -1, PKCS5_v2_PBE_keyivgen, OSSL_PBE_NAME_PBES2},
+    {EVP_PBE_TYPE_OUTER, NID_pbes2, -1, -1, PKCS5_v2_PBE_keyivgen, PKCS5_PBE2_keygen_ex, PKCS5_PBE2_encode, PKCS5_PBE2_decode},
 
     {EVP_PBE_TYPE_OUTER, NID_pbeWithMD2AndRC2_CBC,
-     NID_rc2_64_cbc, NID_md2, PKCS5_PBE_keyivgen},
+     NID_rc2_64_cbc, NID_md2, PKCS5_PBE_keyivgen, PKCS5_PBE_keygen_ex, PKCS5_PBE_encode, PKCS5_PBE_decode},
     {EVP_PBE_TYPE_OUTER, NID_pbeWithMD5AndRC2_CBC,
-     NID_rc2_64_cbc, NID_md5, PKCS5_PBE_keyivgen},
+     NID_rc2_64_cbc, NID_md5, PKCS5_PBE_keyivgen, PKCS5_PBE_keygen_ex, PKCS5_PBE_encode, PKCS5_PBE_decode},
     {EVP_PBE_TYPE_OUTER, NID_pbeWithSHA1AndDES_CBC,
-     NID_des_cbc, NID_sha1, PKCS5_PBE_keyivgen},
+     NID_des_cbc, NID_sha1, PKCS5_PBE_keyivgen, PKCS5_PBE_keygen_ex, PKCS5_PBE_encode, PKCS5_PBE_decode},
 
     {EVP_PBE_TYPE_PRF, NID_hmacWithSHA1, -1, NID_sha1, 0},
     {EVP_PBE_TYPE_PRF, NID_hmac_md5, -1, NID_md5, 0},
@@ -81,146 +81,81 @@ static const EVP_PBE_CTL builtin_pbe[] = {
      NID_id_GostR3411_2012_512, 0},
     {EVP_PBE_TYPE_PRF, NID_hmacWithSHA512_224, -1, NID_sha512_224, 0},
     {EVP_PBE_TYPE_PRF, NID_hmacWithSHA512_256, -1, NID_sha512_256, 0},
-    {EVP_PBE_TYPE_KDF, NID_id_pbkdf2, -1, -1, PKCS5_v2_PBKDF2_keyivgen},
+    {EVP_PBE_TYPE_KDF, NID_id_pbkdf2, -1, -1, PKCS5_v2_PBKDF2_keyivgen, PKCS5_v2_PBKDF2_keygen_ex, PKCS5_v2_PBKDF2_encode, PKCS5_v2_PBKDF2_decode},
 #ifndef OPENSSL_NO_SCRYPT
-    {EVP_PBE_TYPE_KDF, NID_id_scrypt, -1, -1, PKCS5_v2_scrypt_keyivgen}
+    {EVP_PBE_TYPE_KDF, NID_id_scrypt, -1, -1, PKCS5_v2_scrypt_keyivgen, PKCS5_v2_scrypt_keygen_ex, PKCS5_v2_scrypt_encode, PKCS5_v2_scrypt_decode}
 #endif
 };
 
-int EVP_PBE_params_decode(ASN1_OBJECT *pbe_obj, const char *pass, int passlen,
-                          ASN1_TYPE *param, OSSL_PARAM **params, int *params_len)
+int EVP_PBE_asn1_to_params(X509_ALGOR *algor,
+ // TODO: Handle password somewhere else?  const char *pass, int passlen,
+                           OSSL_PARAM **params)
 {
-    int p_index = 0;
-    int pbe_nid, cipher_nid, md_nid;
-    const char *pbe_name, *cipher_name, *md_name;
-    EVP_PBE_KEYGEN *keygen;
+    int pbe_nid;
+    EVP_PBE_DECODE *decode;
 
-    pbe_nid = OBJ_obj2nid(pbe_obj);
-    if (!EVP_PBE_find_ex(EVP_PBE_TYPE_OUTER, pbe_nid, &cipher_nid, &md_nid,
-                         &keygen, &pbe_name)) {
+    pbe_nid = OBJ_obj2nid(algor->algorithm);
+    if (!EVP_PBE_find_ex(EVP_PBE_TYPE_OUTER, pbe_nid, NULL, NULL,
+                         NULL, NULL, NULL, &decode)) {
         char obj_tmp[80];
-        if (pbe_obj == NULL)
+        if (algor->algorithm == NULL)
             OPENSSL_strlcpy(obj_tmp, "NULL", sizeof(obj_tmp));
         else
-            i2t_ASN1_OBJECT(obj_tmp, sizeof(obj_tmp), pbe_obj);
+            i2t_ASN1_OBJECT(obj_tmp, sizeof(obj_tmp), algor->algorithm);
         ERR_raise_data(ERR_LIB_EVP, EVP_R_UNKNOWN_PBE_ALGORITHM,
                        "TYPE=%s", obj_tmp);
         return 0;
     }
 
-    if (pbe_name == NULL) {
-        ERR_raise(ERR_LIB_EVP, EVP_R_UNKNOWN_PBE_ALGORITHM);
-        return 0;
-    }
-
-    *params[p_index++] = OSSL_PARAM_construct_utf8_string(OSSL_PBE_PARAM_ALG, pbe_name, 0);
-
-    if (pass == NULL)
-        passlen = 0;
-    else if (passlen == -1)
-        passlen = strlen(pass);
-    *params[p_index++] = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_PASSWORD, pass,
-                                             passlen);
-
-    /* If cipher/digest can be determined from PBE OID, set them here */
-    if (cipher_nid != -1) {
-        cipher_name = OBJ_nid2sn(cipher_nid);
-        if (!cipher_name) {
-            ERR_raise(ERR_LIB_EVP, EVP_R_UNKNOWN_CIPHER);
-            return 0;
-        }
-        *params[p_index++] = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_CIPHER, cipher_name, 0);
-    }
-
-    if (md_nid != -1) {
-        md_name = OBJ_nid2sn(md_nid);
-        if (!md_name) {
-            ERR_raise(ERR_LIB_EVP, EVP_R_UNKNOWN_DIGEST);
-            return 0;
-        }
-        *params[p_index++] = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_DIGEST, md_name, 0);
-    }
-
-  if (strcmp(pbe_name, "PBES2") == 0)
+/* TODO: Move out into pbes2 decode func */
+/*  if (strcmp(pbe_name, "PBES2") == 0)
   {
-    /* Decode PBES2 */
     PBE2PARAM *pbe2 = NULL;
-    const EVP_CIPHER *cipher;
-    EVP_PBE_KEYGEN *kdf;
+    EVP_PBE_DECODE *decode2;
 
-    int rv = 0;
-
-    pbe2 = ASN1_TYPE_unpack_sequence(ASN1_ITEM_rptr(PBE2PARAM), param);
+    pbe2 = ASN1_TYPE_unpack_sequence(ASN1_ITEM_rptr(PBE2PARAM), algor->parameters);
     if (pbe2 == NULL) {
         ERR_raise(ERR_LIB_EVP, EVP_R_DECODE_ERROR);
         return 0;
     }
 
-    /* See if we recognise the key derivation function */
-    if (!EVP_PBE_find(EVP_PBE_TYPE_KDF, OBJ_obj2nid(pbe2->keyfunc->algorithm),
-                        NULL, NULL, &kdf)) {
+    / See if we recognise the key derivation function /
+    if (!EVP_PBE_find_ex(EVP_PBE_TYPE_KDF, OBJ_obj2nid(pbe2->keyfunc->algorithm),
+                         NULL, NULL, NULL, NULL, &decode2)) {
         ERR_raise(ERR_LIB_EVP, EVP_R_UNSUPPORTED_KEY_DERIVATION_FUNCTION);
         return 0;
     }
 
-    /*
-     * lets see if we recognise the encryption algorithm.
-     */
-
-    cipher_name = OBJ_obj2sn(pbe2->encryption->algorithm);
-
-    if (!cipher) {
-        ERR_raise(ERR_LIB_EVP, EVP_R_UNSUPPORTED_CIPHER);
-        return 0;
-    }
-
-  } else {
-    /* Decode PBES1 */
-    PBEPARAM *pbe;
-    OSSL_PARAM *p = params;
-    unsigned int iter = 0;
-
-    while (p != NULL)
-        p++;
-
-    /* Extract useful info from parameter */
-    pbe = ASN1_TYPE_unpack_sequence(ASN1_ITEM_rptr(PBEPARAM), param);
-    if (pbe == NULL) {
-        ERR_raise(ERR_LIB_PKCS12, PKCS12_R_DECODE_ERROR);
-        return 0;
-    }
-
-    if (pbe->iter != NULL) {
-        iter = ASN1_INTEGER_get(pbe->iter);
-        *p++ = OSSL_PARAM_construct_uint(OSSL_KDF_PARAM_ITER, &iter);
-    }
-    *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_SALT, pbe->salt->data,
-                                             pbe->salt->length);
-    PBEPARAM_free(pbe);
   }
-
-    return decode(param, params, params_len);
+*/
+    return decode(algor, params);
 }
 
-int EVP_PBE_from_params(OSSL_PARAM *params,
-                        EVP_CIPHER_CTX *ctx, int en_de)
+int EVP_PBE_params_to_asn1(OSSL_PARAM *params, X509_ALGOR **algor)
 {
-/* TODO: Implement
-    const EVP_CIPHER *cipher;
-    const EVP_MD *md;
-    int cipher_nid, md_nid;
-    EVP_PBE_KEYGEN *keygen;
+    return 0;
+}
 
-    if (!EVP_PBE_find_ex(EVP_PBE_TYPE_OUTER, OBJ_obj2nid(pbe_obj),
-                         &cipher_nid, &md_nid, &keygen, NULL)) {
-        char obj_tmp[80];
 
-        if (pbe_obj == NULL)
-            OPENSSL_strlcpy(obj_tmp, "NULL", sizeof(obj_tmp));
-        else
-            i2t_ASN1_OBJECT(obj_tmp, sizeof(obj_tmp), pbe_obj);
+int EVP_PBE_CipherInit_ex(EVP_CIPHER_CTX **ctx, OSSL_PARAM *params,
+                          const char *pass, int passlen,
+                          OSSL_LIB_CTX *libctx, const char *propq,
+                          int en_de)
+{
+    const char *ciph_name;
+    EVP_PBE_KEYGEN_EX *keygen_ex;
+    const OSSL_PARAM *p;
+
+    p = OSSL_PARAM_locate_const(params, OSSL_PBE_PARAM_CIPHER);
+    if (p == NULL)
+        return 0;
+    if (!OSSL_PARAM_get_utf8_ptr(p, &ciph_name))
+        return 0;
+
+    if (!EVP_PBE_find_ex(EVP_PBE_TYPE_OUTER, OBJ_txt2nid(ciph_name),
+                         NULL, NULL, NULL, &keygen_ex, NULL, NULL)) {
         ERR_raise_data(ERR_LIB_EVP, EVP_R_UNKNOWN_PBE_ALGORITHM,
-                       "TYPE=%s", obj_tmp);
+                       ciph_name);
         return 0;
     }
 
@@ -229,30 +164,7 @@ int EVP_PBE_from_params(OSSL_PARAM *params,
     else if (passlen == -1)
         passlen = strlen(pass);
 
-    if (cipher_nid == -1)
-        cipher = NULL;
-    else {
-        cipher = EVP_get_cipherbynid(cipher_nid);
-        if (!cipher) {
-            ERR_raise_data(ERR_LIB_EVP, EVP_R_UNKNOWN_CIPHER,
-                           OBJ_nid2sn(cipher_nid));
-            return 0;
-        }
-    }
-
-    if (md_nid == -1)
-        md = NULL;
-    else {
-        md = EVP_get_digestbynid(md_nid);
-        if (!md) {
-            ERR_raise(ERR_LIB_EVP, EVP_R_UNKNOWN_DIGEST);
-            return 0;
-        }
-    }
-
-    return keygen(ctx, pass, passlen, param, cipher, md, en_de);
-*/
-    return 0;
+    return keygen_ex(ctx, params, pass, passlen, en_de, libctx, propq);
 }
 
 int EVP_PBE_CipherInit(ASN1_OBJECT *pbe_obj, const char *pass, int passlen,
@@ -378,9 +290,9 @@ int EVP_PBE_alg_add(int nid, const EVP_CIPHER *cipher, const EVP_MD *md,
                                 cipher_nid, md_nid, keygen);
 }
 
-int EVP_PBE_find_ex(int type, int pbe_nid,
-                    int *pcnid, int *pmnid, EVP_PBE_KEYGEN **pkeygen,
-                    const char **pbe_name)
+int EVP_PBE_find_ex(int type, int pbe_nid, int *pcnid, int *pmnid,
+                    EVP_PBE_KEYGEN **pkeygen, EVP_PBE_KEYGEN_EX **keygen_ex,
+                    EVP_PBE_ENCODE **encode, EVP_PBE_DECODE **decode)
 {
     EVP_PBE_CTL *pbetmp = NULL, pbelu;
     int i;
@@ -405,15 +317,19 @@ int EVP_PBE_find_ex(int type, int pbe_nid,
         *pmnid = pbetmp->md_nid;
     if (pkeygen)
         *pkeygen = pbetmp->keygen;
-    if (pbe_name)
-        *pbe_name = pbetmp->pbe_name;
+    if (keygen_ex)
+        *keygen_ex = pbetmp->keygen_ex;
+    if (encode)
+        *encode = pbetmp->encode;
+    if (decode)
+        *decode = pbetmp->decode;
     return 1;
 }
 
 int EVP_PBE_find(int type, int pbe_nid,
                  int *pcnid, int *pmnid, EVP_PBE_KEYGEN **pkeygen)
 {
-    return EVP_PBE_find_ex(type, pbe_nid, pcnid, pmnid, pkeygen, NULL);
+    return EVP_PBE_find_ex(type, pbe_nid, pcnid, pmnid, pkeygen, NULL, NULL, NULL);
 }
 
 static void free_evp_pbe_ctl(EVP_PBE_CTL *pbe)

--- a/crypto/evp/p5_crpt.c
+++ b/crypto/evp/p5_crpt.c
@@ -113,3 +113,22 @@ int PKCS5_PBE_keyivgen(EVP_CIPHER_CTX *cctx, const char *pass, int passlen,
     EVP_MD_CTX_free(ctx);
     return rv;
 }
+
+int PKCS5_PBE_keygen_ex(EVP_CIPHER_CTX **ctx, OSSL_PARAM *params,
+                        const char *pass, int passlen, int en_de,
+                        OSSL_LIB_CTX *libctx, const char *propq)
+{
+    return 0;
+}
+
+int PKCS5_PBE_encode(X509_ALGOR **algor, OSSL_PARAM *params)
+{
+    return PKCS12_PBE_encode(algor, params);
+}
+
+// TODO - May need to add extra PKCS5 mode param here?
+int PKCS5_PBE_decode(X509_ALGOR *algor, OSSL_PARAM **params)
+{
+    return PKCS12_PBE_decode(algor, params);
+}
+

--- a/crypto/evp/pbe_scrypt.c
+++ b/crypto/evp/pbe_scrypt.c
@@ -87,4 +87,47 @@ int EVP_PBE_scrypt(const char *pass, size_t passlen,
     return rv;
 }
 
+int EVP_PBE_scrypt_ex(OSSL_PARAM *params, unsigned char *key, size_t keylen,
+                      OSSL_LIB_CTX *ctx, const char *propq)
+{
+//    const char *empty = "";
+    int rv = 1;
+    EVP_KDF *kdf;
+    EVP_KDF_CTX *kctx;
+
+/* TODO: Is this check inside the KDF derive?
+    if (r > UINT32_MAX || p > UINT32_MAX) {
+        ERR_raise(ERR_LIB_EVP, EVP_R_PARAMETER_TOO_LARGE);
+        return 0;
+    }
+*/
+    /* Maintain existing behaviour. */
+/* TODO: add these checks?
+    if (pass == NULL) {
+        pass = empty;
+        passlen = 0;
+    }
+    if (salt == NULL) {
+        salt = (const unsigned char *)empty;
+        saltlen = 0;
+    }
+    if (maxmem == 0)
+        maxmem = SCRYPT_MAX_MEM;
+*/
+
+    /* Use OSSL_LIB_CTX_set0_default() if you need a library context */
+    kdf = EVP_KDF_fetch(ctx, OSSL_KDF_NAME_SCRYPT, propq);
+    kctx = EVP_KDF_CTX_new(kdf);
+    EVP_KDF_free(kdf);
+    if (kctx == NULL)
+        return 0;
+
+    if (EVP_KDF_CTX_set_params(kctx, params) != 1
+            || EVP_KDF_derive(kctx, key, keylen) != 1)
+        rv = 0;
+
+    EVP_KDF_CTX_free(kctx);
+    return rv;
+}
+
 #endif

--- a/crypto/pkcs12/p12_add.c
+++ b/crypto/pkcs12/p12_add.c
@@ -120,18 +120,17 @@ PKCS7 *PKCS12_pack_p7encdata(int pbe_nid, const char *pass, int passlen,
                                                 "PBES2", 0);
         *p++ = OSSL_PARAM_construct_utf8_string(OSSL_PBE_PARAM_CIPHER,
                                                 EVP_CIPHER_name(pbe_ciph), 0);
+        *p = OSSL_PARAM_construct_end();
+        if (!PKCS5_PBE2_encode(&pbe, params))
+            goto err;
     } else {
         *p++ = OSSL_PARAM_construct_utf8_string(OSSL_PBE_PARAM_ALG,
-                                                "PBES2", 0);
+                                                "PKCS12", 0);
+        *p = OSSL_PARAM_construct_end();
+        if (!PKCS5_PBE_encode(&pbe, params))
+            goto err;
     }
-    *p = OSSL_PARAM_construct_end();
 
-    /* TODO: Handle both pbe1 and pbe2 */
-    pbe = PKCS5_pbe2_set_param(params, NULL, NULL);
-    if (pbe == NULL) {
-        ERR_raise(ERR_LIB_PKCS12, ERR_R_MALLOC_FAILURE);
-        goto err;
-    }
     X509_ALGOR_free(p7->d.encrypted->enc_data->algorithm);
     p7->d.encrypted->enc_data->algorithm = pbe;
     ASN1_OCTET_STRING_free(p7->d.encrypted->enc_data->enc_data);

--- a/crypto/pkcs12/p12_crpt.c
+++ b/crypto/pkcs12/p12_crpt.c
@@ -71,17 +71,94 @@ int PKCS12_PBE_keyivgen(EVP_CIPHER_CTX *ctx, const char *pass, int passlen,
     return ret;
 }
 
-int PKCS12_PBE_params_decode(ASN1_TYPE *param, OSSL_PARAM **params, int params_len)
+int PKCS12_PBE_keygen_ex(EVP_CIPHER_CTX **ctx, OSSL_PARAM *params,
+                         const char *pass, int passlen,
+                         int en_de, OSSL_LIB_CTX *libctx, const char *propq)
+{
+    int ret;
+    unsigned char key[EVP_MAX_KEY_LENGTH], iv[EVP_MAX_IV_LENGTH];
+    const char *ciph_name;
+    const OSSL_PARAM *p;
+    EVP_CIPHER *cipher;
+
+    *ctx = EVP_CIPHER_CTX_new();
+    if (*ctx == NULL)
+        return 0;
+    /*
+     * Get the cipher to be used for the PBE enc/dec operation
+     * so we can determine key and IV lengths
+     */
+    p = OSSL_PARAM_locate_const(params, OSSL_PBE_PARAM_CIPHER);
+    if (p == NULL)
+        return 0;
+    if (!OSSL_PARAM_get_utf8_ptr(p, &ciph_name))
+        return 0;
+    cipher = EVP_CIPHER_fetch(libctx, ciph_name, propq);
+
+    if (!PKCS12_key_gen_ex(key, EVP_CIPHER_key_length(cipher), params, libctx, propq)) {
+        ERR_raise(ERR_LIB_PKCS12, PKCS12_R_KEY_GEN_ERROR);
+        return 0;
+    }
+    if (!PKCS12_key_gen_ex(iv, EVP_CIPHER_iv_length(cipher), params, libctx, propq)) {
+        ERR_raise(ERR_LIB_PKCS12, PKCS12_R_IV_GEN_ERROR);
+        return 0;
+    }
+    ret = EVP_CipherInit_ex(*ctx, cipher, NULL, key, iv, en_de);
+    OPENSSL_cleanse(key, EVP_MAX_KEY_LENGTH);
+    OPENSSL_cleanse(iv, EVP_MAX_IV_LENGTH);
+    return ret;
+}
+
+int PKCS12_PBE_encode(X509_ALGOR **algor, OSSL_PARAM *params)
+{
+    return 0;
+}
+
+int PKCS12_PBE_decode(X509_ALGOR *algor, OSSL_PARAM **params)
 {
     PBEPARAM *pbe;
-    OSSL_PARAM *p = params;
     unsigned int iter = 0;
+    OSSL_PARAM *p;
+    int pbe_nid, cipher_nid, md_nid;
+    const char *cipher_name, *md_name;
 
-    while (p != NULL)
-        p++;
+    *params = OPENSSL_malloc(sizeof(OSSL_PARAM) * 5);
+    p = *params;
+
+    pbe_nid = OBJ_obj2nid(algor->algorithm);
+    if (!EVP_PBE_find_ex(EVP_PBE_TYPE_OUTER, pbe_nid, &cipher_nid, &md_nid,
+                         NULL, NULL, NULL, NULL)) {
+        char obj_tmp[80];
+        if (algor->algorithm == NULL)
+            OPENSSL_strlcpy(obj_tmp, "NULL", sizeof(obj_tmp));
+        else
+            i2t_ASN1_OBJECT(obj_tmp, sizeof(obj_tmp), algor->algorithm);
+        ERR_raise_data(ERR_LIB_EVP, EVP_R_UNKNOWN_PBE_ALGORITHM,
+                       "TYPE=%s", obj_tmp);
+        return 0;
+    }
+
+    /* If cipher/digest can be determined from PBE OID, set them here */
+    if (cipher_nid != -1) {
+        cipher_name = OBJ_nid2sn(cipher_nid);
+        if (!cipher_name) {
+            ERR_raise(ERR_LIB_EVP, EVP_R_UNKNOWN_CIPHER);
+            return 0;
+        }
+        *p++ = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_CIPHER, cipher_name, 0);
+    }
+
+    if (md_nid != -1) {
+        md_name = OBJ_nid2sn(md_nid);
+        if (!md_name) {
+            ERR_raise(ERR_LIB_EVP, EVP_R_UNKNOWN_DIGEST);
+            return 0;
+        }
+        *p++ = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_DIGEST, md_name, 0);
+    }
 
     /* Extract useful info from parameter */
-    pbe = ASN1_TYPE_unpack_sequence(ASN1_ITEM_rptr(PBEPARAM), param);
+    pbe = ASN1_TYPE_unpack_sequence(ASN1_ITEM_rptr(PBEPARAM), algor->parameter);
     if (pbe == NULL) {
         ERR_raise(ERR_LIB_PKCS12, PKCS12_R_DECODE_ERROR);
         return 0;

--- a/crypto/pkcs12/p12_key.c
+++ b/crypto/pkcs12/p12_key.c
@@ -92,14 +92,14 @@ int PKCS12_key_gen_uni(unsigned char *pass, int passlen, unsigned char *salt,
     return PKCS12_key_gen_ex(out, n, params, ossl_provider_libctx(EVP_MD_provider(md_type)), NULL);
 }
 
-int PKCS12_key_gen_ex(unsigned char *out, size_t keylen, OSSL_PARAM params[],
+int PKCS12_key_gen_ex(unsigned char *out, size_t outlen, OSSL_PARAM params[],
                       OSSL_LIB_CTX *ctx, const char *propq)
 {
     int res = 0;
     EVP_KDF *kdf;
     EVP_KDF_CTX *kdf_ctx;
 
-    if (keylen <= 0)
+    if (outlen <= 0)
         return 0;
 
     kdf = EVP_KDF_fetch(ctx, "PKCS12KDF", propq);
@@ -114,11 +114,11 @@ int PKCS12_key_gen_ex(unsigned char *out, size_t keylen, OSSL_PARAM params[],
     if (!EVP_KDF_CTX_set_params(kdf_ctx, params))
         goto err;
 
-    if (EVP_KDF_derive(kdf_ctx, out, keylen)) {
+    if (EVP_KDF_derive(kdf_ctx, out, outlen)) {
         res = 1;
         OSSL_TRACE_BEGIN(PKCS12_KEYGEN) {
-            BIO_printf(trc_out, "Output KEY (length %d)\n", keylen);
-            BIO_hex_string(trc_out, 0, keylen, out, keylen);
+            BIO_printf(trc_out, "Output KEY (length %d)\n", outlen);
+            BIO_hex_string(trc_out, 0, outlen, out, outlen);
             BIO_printf(trc_out, "\n");
         } OSSL_TRACE_END(PKCS12_KEYGEN);
     }

--- a/crypto/pkcs12/p12_p8e.c
+++ b/crypto/pkcs12/p12_p8e.c
@@ -28,7 +28,7 @@ X509_SIG *PKCS8_encrypt_ex(PKCS8_PRIV_KEY_INFO *p8inf, OSSL_PARAM params[],
     X509_ALGOR *pbe;
     X509_SIG *p8 = NULL;
 
-    pbe = PKCS5_pbe_set_params(params, ctx, propq);
+    EVP_PBE_params_to_asn1(&pbe, params);
     if (pbe == NULL) {
         ERR_raise(ERR_LIB_PKCS12, ERR_R_ASN1_LIB);
         return NULL;

--- a/crypto/pkcs12/p12_p8e.c
+++ b/crypto/pkcs12/p12_p8e.c
@@ -9,8 +9,48 @@
 
 #include <stdio.h>
 #include "internal/cryptlib.h"
+#include <openssl/core.h>
 #include <openssl/pkcs12.h>
 #include "crypto/x509.h"
+
+/*
+ * TODO: Params must include:
+ * - PBE ID
+ * - Cipher ID (Optional based on PBE type)
+ * - Password
+ * - IV (Optional)
+ * - Iterations
+ *
+ */
+X509_SIG *PKCS8_encrypt_ex(PKCS8_PRIV_KEY_INFO *p8, OSSL_PARAM params[],
+                           OSSL_LIB_CTX *ctx, const char *propq)
+{
+/*    X509_SIG *p8 = NULL;
+    X509_ALGOR *pbe;
+
+    if (pbe_nid == -1)
+        pbe = PKCS5_pbe2_set(cipher, iter, salt, saltlen);
+    else if (EVP_PBE_find(EVP_PBE_TYPE_PRF, pbe_nid, NULL, NULL, 0))
+        pbe = PKCS5_pbe2_set_iv(cipher, iter, salt, saltlen, NULL, pbe_nid);
+    else {
+        ERR_clear_error();
+        pbe = PKCS5_pbe_set(pbe_nid, iter, salt, saltlen);
+    }
+    if (pbe == NULL) {
+        ERR_raise(ERR_LIB_PKCS12, ERR_R_ASN1_LIB);
+        return NULL;
+    }
+    p8 = PKCS8_set0_pbe(pass, passlen, p8inf, pbe);
+    if (p8 == NULL) {
+        X509_ALGOR_free(pbe);
+        return NULL;
+    }
+
+    return p8;
+*/
+    return NULL;
+}
+
 
 X509_SIG *PKCS8_encrypt(int pbe_nid, const EVP_CIPHER *cipher,
                         const char *pass, int passlen,

--- a/crypto/pkcs12/p12_p8e.c
+++ b/crypto/pkcs12/p12_p8e.c
@@ -22,9 +22,26 @@
  * - Iterations
  *
  */
-X509_SIG *PKCS8_encrypt_ex(PKCS8_PRIV_KEY_INFO *p8, OSSL_PARAM params[],
+X509_SIG *PKCS8_encrypt_ex(PKCS8_PRIV_KEY_INFO *p8inf, OSSL_PARAM params[],
                            OSSL_LIB_CTX *ctx, const char *propq)
 {
+    X509_ALGOR *pbe;
+    X509_SIG *p8 = NULL;
+
+    pbe = PKCS5_pbe_set_params(params, ctx, propq);
+    if (pbe == NULL) {
+        ERR_raise(ERR_LIB_PKCS12, ERR_R_ASN1_LIB);
+        return NULL;
+    }
+/* TODO: Invert this so we set the X509ALGOR inside the encrypt function */
+/*    p8 = PKCS8_set0_pbe(pass, passlen, p8inf, pbe);
+    if (p8 == NULL) {
+        X509_ALGOR_free(pbe);
+        return NULL;
+    }
+*/
+    return p8;
+
 /*    X509_SIG *p8 = NULL;
     X509_ALGOR *pbe;
 
@@ -48,7 +65,6 @@ X509_SIG *PKCS8_encrypt_ex(PKCS8_PRIV_KEY_INFO *p8, OSSL_PARAM params[],
 
     return p8;
 */
-    return NULL;
 }
 
 

--- a/crypto/pkcs12/p12_sbag.c
+++ b/crypto/pkcs12/p12_sbag.c
@@ -224,3 +224,21 @@ PKCS12_SAFEBAG *PKCS12_SAFEBAG_create_pkcs8_encrypt(int pbe_nid,
 
     return bag;
 }
+
+PKCS12_SAFEBAG *PKCS12_SAFEBAG_create_pkcs8_encrypt_ex(PKCS8_PRIV_KEY_INFO *p8inf,
+                                                       OSSL_PARAM params[],
+                                                       OSSL_LIB_CTX *ctx, const char *propq)
+{
+    PKCS12_SAFEBAG *bag;
+    X509_SIG *p8;
+
+    p8 = PKCS8_encrypt_ex(p8inf, params, ctx, propq);
+    if (p8 == NULL)
+        return NULL;
+
+    bag = PKCS12_SAFEBAG_create0_pkcs8(p8);
+    if (bag == NULL)
+        X509_SIG_free(p8);
+
+    return bag;
+}

--- a/include/openssl/core_names.h
+++ b/include/openssl/core_names.h
@@ -188,6 +188,7 @@ extern "C" {
 #define OSSL_KDF_PARAM_DIGEST       OSSL_ALG_PARAM_DIGEST     /* utf8 string */
 #define OSSL_KDF_PARAM_CIPHER       OSSL_ALG_PARAM_CIPHER     /* utf8 string */
 #define OSSL_KDF_PARAM_MAC          OSSL_ALG_PARAM_MAC        /* utf8 string */
+#define OSSL_KDF_PARAM_PRF          "prf"       /* utf8 string */
 #define OSSL_KDF_PARAM_MAC_SIZE     "maclen"    /* size_t */
 #define OSSL_KDF_PARAM_PROPERTIES   OSSL_ALG_PARAM_PROPERTIES /* utf8 string */
 #define OSSL_KDF_PARAM_ITER         "iter"      /* unsigned int */
@@ -205,7 +206,6 @@ extern "C" {
 #define OSSL_KDF_PARAM_SSHKDF_SESSION_ID "session_id" /* octet string */
 #define OSSL_KDF_PARAM_SSHKDF_TYPE  "type"      /* int */
 #define OSSL_KDF_PARAM_SIZE         "size"      /* size_t */
-#define OSSL_KDF_PARAM_CIPHER       OSSL_ALG_PARAM_CIPHER     /* utf8 string */
 #define OSSL_KDF_PARAM_CONSTANT     "constant"  /* octet string */
 #define OSSL_KDF_PARAM_PKCS12_ID    "id"        /* int */
 #define OSSL_KDF_PARAM_KBKDF_USE_L  "use-l"             /* int */
@@ -229,6 +229,18 @@ extern "C" {
 #define OSSL_KDF_NAME_X963KDF        "X963KDF"
 #define OSSL_KDF_NAME_KBKDF          "KBKDF"
 #define OSSL_KDF_NAME_KRB5KDF        "KRB5KDF"
+
+/* PBE params */
+#define OSSL_PBE_PARAM_ALG           "alg"      /* utf8 string */
+#define OSSL_PBE_PARAM_PASSWORD      OSSL_KDF_PARAM_PASSWORD  /* octet string */
+#define OSSL_PBE_PARAM_ITER          OSSL_KDF_PARAM_ITER      /* unsigned int */
+#define OSSL_PBE_PARAM_SALT          OSSL_KDF_PARAM_SALT      /* octet string */
+#define OSSL_PBE_PARAM_CIPHER        OSSL_ALG_PARAM_CIPHER    /* utf8 string */
+
+/* PBE Algorithm class names */
+#define OSSL_PBE_NAME_PKCS5          "PKCS5"    /* PKCS#5 v1.5 */
+#define OSSL_PBE_NAME_PKCS12         "PKCS12"
+#define OSSL_PBE_NAME_PBES2          "PBES2"    /* PKCS#5 v2 */
 
 /* Known RAND names */
 #define OSSL_RAND_PARAM_STATE                   "state"

--- a/include/openssl/core_names.h
+++ b/include/openssl/core_names.h
@@ -236,6 +236,7 @@ extern "C" {
 #define OSSL_PBE_PARAM_ITER          OSSL_KDF_PARAM_ITER      /* unsigned int */
 #define OSSL_PBE_PARAM_SALT          OSSL_KDF_PARAM_SALT      /* octet string */
 #define OSSL_PBE_PARAM_CIPHER        OSSL_ALG_PARAM_CIPHER    /* utf8 string */
+#define OSSL_PBE_PARAM_IV            "iv"       /* octet string */
 
 /* PBE Algorithm class names */
 #define OSSL_PBE_NAME_PKCS5          "PKCS5"    /* PKCS#5 v1.5 */

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -483,6 +483,12 @@ typedef int (EVP_PBE_KEYGEN) (EVP_CIPHER_CTX *ctx, const char *pass,
                               const EVP_CIPHER *cipher, const EVP_MD *md,
                               int en_de);
 
+/* Password based encryption parameter encode function */
+typedef int (EVP_PBE_ENCODE) (ASN1_TYPE *param, OSSL_PARAM **params, int *param_len);
+
+/* Password based encryption parameter decode function */
+typedef int (EVP_PBE_DECODE) (ASN1_TYPE *param, OSSL_PARAM **params, int *param_len);
+
 # ifndef OPENSSL_NO_DEPRECATED_3_0
 #  define EVP_PKEY_assign_RSA(pkey,rsa) EVP_PKEY_assign((pkey),EVP_PKEY_RSA,\
                                                          (rsa))
@@ -1408,6 +1414,8 @@ int EVP_PBE_alg_add(int nid, const EVP_CIPHER *cipher, const EVP_MD *md,
                     EVP_PBE_KEYGEN *keygen);
 int EVP_PBE_find(int type, int pbe_nid, int *pcnid, int *pmnid,
                  EVP_PBE_KEYGEN **pkeygen);
+int EVP_PBE_find_ex(int type, int pbe_nid, int *pcnid, int *pmnid,
+                 EVP_PBE_KEYGEN **pkeygen, const char **pbe_name);
 void EVP_PBE_cleanup(void);
 int EVP_PBE_get(int *ptype, int *ppbe_nid, size_t num);
 

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -483,11 +483,15 @@ typedef int (EVP_PBE_KEYGEN) (EVP_CIPHER_CTX *ctx, const char *pass,
                               const EVP_CIPHER *cipher, const EVP_MD *md,
                               int en_de);
 
+typedef int (EVP_PBE_KEYGEN_EX) (EVP_CIPHER_CTX **ctx, OSSL_PARAM *params,
+                                 const char *pass, int passlen, int en_de,
+                                 OSSL_LIB_CTX *libctx, const char *propq);
+
 /* Password based encryption parameter encode function */
-typedef int (EVP_PBE_ENCODE) (ASN1_TYPE *param, OSSL_PARAM **params, int *param_len);
+typedef int (EVP_PBE_ENCODE) (X509_ALGOR **algor, OSSL_PARAM *params);
 
 /* Password based encryption parameter decode function */
-typedef int (EVP_PBE_DECODE) (ASN1_TYPE *param, OSSL_PARAM **params, int *param_len);
+typedef int (EVP_PBE_DECODE) (X509_ALGOR *algor, OSSL_PARAM **params);
 
 # ifndef OPENSSL_NO_DEPRECATED_3_0
 #  define EVP_PKEY_assign_RSA(pkey,rsa) EVP_PKEY_assign((pkey),EVP_PKEY_RSA,\
@@ -1399,6 +1403,11 @@ void PKCS5_PBE_add(void);
 int EVP_PBE_CipherInit(ASN1_OBJECT *pbe_obj, const char *pass, int passlen,
                        ASN1_TYPE *param, EVP_CIPHER_CTX *ctx, int en_de);
 
+int EVP_PBE_CipherInit_ex(EVP_CIPHER_CTX **ctx, OSSL_PARAM *params,
+                          const char *pass, int passlen,
+                          OSSL_LIB_CTX *libctx, const char *propq,
+                          int en_de);
+
 /* PBE type */
 
 /* Can appear as the outermost AlgorithmIdentifier */
@@ -1415,7 +1424,8 @@ int EVP_PBE_alg_add(int nid, const EVP_CIPHER *cipher, const EVP_MD *md,
 int EVP_PBE_find(int type, int pbe_nid, int *pcnid, int *pmnid,
                  EVP_PBE_KEYGEN **pkeygen);
 int EVP_PBE_find_ex(int type, int pbe_nid, int *pcnid, int *pmnid,
-                 EVP_PBE_KEYGEN **pkeygen, const char **pbe_name);
+                    EVP_PBE_KEYGEN **pkeygen, EVP_PBE_KEYGEN_EX **keygen_ex,
+                    EVP_PBE_ENCODE **encode, EVP_PBE_DECODE **decode);
 void EVP_PBE_cleanup(void);
 int EVP_PBE_get(int *ptype, int *ppbe_nid, size_t num);
 

--- a/include/openssl/pkcs12.h.in
+++ b/include/openssl/pkcs12.h.in
@@ -204,6 +204,8 @@ int PKCS12_key_gen_ex(unsigned char *out, size_t keylen, OSSL_PARAM params[],
 int PKCS12_PBE_keyivgen(EVP_CIPHER_CTX *ctx, const char *pass, int passlen,
                         ASN1_TYPE *param, const EVP_CIPHER *cipher,
                         const EVP_MD *md_type, int en_de);
+int PKCS12_PBE_params_decode(ASN1_TYPE *param, OSSL_PARAM **params, int params_len);
+
 int PKCS12_gen_mac(PKCS12 *p12, const char *pass, int passlen,
                    unsigned char *mac, unsigned int *maclen);
 int PKCS12_verify_mac(PKCS12 *p12, const char *pass, int passlen);

--- a/include/openssl/pkcs12.h.in
+++ b/include/openssl/pkcs12.h.in
@@ -23,6 +23,7 @@ use OpenSSL::stackhash qw(generate_stack_macros);
 # endif
 
 # include <openssl/bio.h>
+# include <openssl/core.h>
 # include <openssl/x509.h>
 # include <openssl/pkcs12err.h>
 
@@ -125,7 +126,7 @@ PKCS12_SAFEBAG *PKCS12_SAFEBAG_create_pkcs8_encrypt(int pbe_nid,
                                                     int saltlen, int iter,
                                                     PKCS8_PRIV_KEY_INFO *p8inf);
 PKCS12_SAFEBAG *PKCS12_SAFEBAG_create_pkcs8_encrypt_ex(PKCS8_PRIV_KEY_INFO *p8inf,
-                                                       OSSL_PARAM[] params,
+                                                       OSSL_PARAM params[],
                                                        OSSL_LIB_CTX *ctx, const char *propq);
 
 PKCS12_SAFEBAG *PKCS12_item_pack_safebag(void *obj, const ASN1_ITEM *it,
@@ -137,7 +138,7 @@ PKCS8_PRIV_KEY_INFO *PKCS12_decrypt_skey(const PKCS12_SAFEBAG *bag,
 X509_SIG *PKCS8_encrypt(int pbe_nid, const EVP_CIPHER *cipher,
                         const char *pass, int passlen, unsigned char *salt,
                         int saltlen, int iter, PKCS8_PRIV_KEY_INFO *p8);
-X509_SIG *PKCS8_encrypt_ex(PKCS8_PRIV_KEY_INFO *p8, OSSL_PARAM[] params,
+X509_SIG *PKCS8_encrypt_ex(PKCS8_PRIV_KEY_INFO *p8, OSSL_PARAM params[],
                            OSSL_LIB_CTX *ctx, const char *propq);
 X509_SIG *PKCS8_set0_pbe(const char *pass, int passlen,
                         PKCS8_PRIV_KEY_INFO *p8inf, X509_ALGOR *pbe);
@@ -146,7 +147,7 @@ STACK_OF(PKCS12_SAFEBAG) *PKCS12_unpack_p7data(PKCS7 *p7);
 PKCS7 *PKCS12_pack_p7encdata(int pbe_nid, const char *pass, int passlen,
                              unsigned char *salt, int saltlen, int iter,
                              STACK_OF(PKCS12_SAFEBAG) *bags);
-PKCS7 *PKCS12_pack_p7encdata_ex(STACK_OF(PKCS12_SAFEBAG) *bags, OSSL_PARAM[] params,
+PKCS7 *PKCS12_pack_p7encdata_ex(STACK_OF(PKCS12_SAFEBAG) *bags, OSSL_PARAM params[],
                                 OSSL_LIB_CTX *ctx, const char *propq);
 
 STACK_OF(PKCS12_SAFEBAG) *PKCS12_unpack_p7encdata(PKCS7 *p7, const char *pass,
@@ -197,7 +198,7 @@ int PKCS12_key_gen_uni(unsigned char *pass, int passlen, unsigned char *salt,
 int PKCS12_key_gen_utf8(const char *pass, int passlen, unsigned char *salt,
                         int saltlen, int id, int iter, int n,
                         unsigned char *out, const EVP_MD *md_type);
-int PKCS12_key_gen_ex(unsigned char *out, size_t keylen, OSSL_PARAM[] params,
+int PKCS12_key_gen_ex(unsigned char *out, size_t keylen, OSSL_PARAM params[],
                       OSSL_LIB_CTX *ctx, const char *propq);
 
 int PKCS12_PBE_keyivgen(EVP_CIPHER_CTX *ctx, const char *pass, int passlen,
@@ -209,11 +210,11 @@ int PKCS12_verify_mac(PKCS12 *p12, const char *pass, int passlen);
 int PKCS12_set_mac(PKCS12 *p12, const char *pass, int passlen,
                    unsigned char *salt, int saltlen, int iter,
                    const EVP_MD *md_type);
-int PKCS12_set_mac_ex(PKCS12 *p12, OSSL_PARAM[] params,
+int PKCS12_set_mac_ex(PKCS12 *p12, OSSL_PARAM params[],
                       OSSL_LIB_CTX *ctx, const char *propq);
 int PKCS12_setup_mac(PKCS12 *p12, int iter, unsigned char *salt,
                      int saltlen, const EVP_MD *md_type);
-int PKCS12_setup_mac_ex(PKCS12 *p12, OSSL_PARAM[] params,
+int PKCS12_setup_mac_ex(PKCS12 *p12, OSSL_PARAM params[],
                         OSSL_LIB_CTX *ctx, const char *propq);
 
 unsigned char *OPENSSL_asc2uni(const char *asc, int asclen,
@@ -238,14 +239,14 @@ PKCS12 *PKCS12_create(const char *pass, const char *name, EVP_PKEY *pkey,
                       X509 *cert, STACK_OF(X509) *ca, int nid_key, int nid_cert,
                       int iter, int mac_iter, int keytype);
 PKCS12 *PKCS12_create_ex(EVP_PKEY *pkey, X509 *cert, STACK_OF(X509) *ca,
-                         OSSL_PARAM[] params, OSSL_LIB_CTX *ctx, const char *propq);
+                         OSSL_PARAM params[], OSSL_LIB_CTX *ctx, const char *propq);
 
 PKCS12_SAFEBAG *PKCS12_add_cert(STACK_OF(PKCS12_SAFEBAG) **pbags, X509 *cert);
 PKCS12_SAFEBAG *PKCS12_add_key(STACK_OF(PKCS12_SAFEBAG) **pbags,
                                EVP_PKEY *key, int key_usage, int iter,
                                int key_nid, const char *pass);
 PKCS12_SAFEBAG *PKCS12_add_key_ex(STACK_OF(PKCS12_SAFEBAG) **pbags,
-                                  EVP_PKEY *key, int key_usage, OSSL_PARAM[] params,
+                                  EVP_PKEY *key, int key_usage, OSSL_PARAM params[],
                                   OSSL_LIB_CTX *ctx, const char *propq);
 
 PKCS12_SAFEBAG *PKCS12_add_secret(STACK_OF(PKCS12_SAFEBAG) **pbags,
@@ -254,7 +255,7 @@ PKCS12_SAFEBAG *PKCS12_add_secret(STACK_OF(PKCS12_SAFEBAG) **pbags,
 int PKCS12_add_safe(STACK_OF(PKCS7) **psafes, STACK_OF(PKCS12_SAFEBAG) *bags,
                     int safe_nid, int iter, const char *pass);
 int PKCS12_add_safe_ex(STACK_OF(PKCS7) **psafes, STACK_OF(PKCS12_SAFEBAG) *bags,
-                       OSSL_PARAM[] params, OSSL_LIB_CTX *ctx, const char *propq);
+                       OSSL_PARAM params[], OSSL_LIB_CTX *ctx, const char *propq);
 
 PKCS12 *PKCS12_add_safes(STACK_OF(PKCS7) *safes, int p7_nid);
 

--- a/include/openssl/pkcs12.h.in
+++ b/include/openssl/pkcs12.h.in
@@ -124,6 +124,9 @@ PKCS12_SAFEBAG *PKCS12_SAFEBAG_create_pkcs8_encrypt(int pbe_nid,
                                                     unsigned char *salt,
                                                     int saltlen, int iter,
                                                     PKCS8_PRIV_KEY_INFO *p8inf);
+PKCS12_SAFEBAG *PKCS12_SAFEBAG_create_pkcs8_encrypt_ex(PKCS8_PRIV_KEY_INFO *p8inf,
+                                                       OSSL_PARAM[] params,
+                                                       OSSL_LIB_CTX *ctx, const char *propq);
 
 PKCS12_SAFEBAG *PKCS12_item_pack_safebag(void *obj, const ASN1_ITEM *it,
                                          int nid1, int nid2);
@@ -134,6 +137,8 @@ PKCS8_PRIV_KEY_INFO *PKCS12_decrypt_skey(const PKCS12_SAFEBAG *bag,
 X509_SIG *PKCS8_encrypt(int pbe_nid, const EVP_CIPHER *cipher,
                         const char *pass, int passlen, unsigned char *salt,
                         int saltlen, int iter, PKCS8_PRIV_KEY_INFO *p8);
+X509_SIG *PKCS8_encrypt_ex(PKCS8_PRIV_KEY_INFO *p8, OSSL_PARAM[] params,
+                           OSSL_LIB_CTX *ctx, const char *propq);
 X509_SIG *PKCS8_set0_pbe(const char *pass, int passlen,
                         PKCS8_PRIV_KEY_INFO *p8inf, X509_ALGOR *pbe);
 PKCS7 *PKCS12_pack_p7data(STACK_OF(PKCS12_SAFEBAG) *sk);
@@ -141,6 +146,9 @@ STACK_OF(PKCS12_SAFEBAG) *PKCS12_unpack_p7data(PKCS7 *p7);
 PKCS7 *PKCS12_pack_p7encdata(int pbe_nid, const char *pass, int passlen,
                              unsigned char *salt, int saltlen, int iter,
                              STACK_OF(PKCS12_SAFEBAG) *bags);
+PKCS7 *PKCS12_pack_p7encdata_ex(STACK_OF(PKCS12_SAFEBAG) *bags, OSSL_PARAM[] params,
+                                OSSL_LIB_CTX *ctx, const char *propq);
+
 STACK_OF(PKCS12_SAFEBAG) *PKCS12_unpack_p7encdata(PKCS7 *p7, const char *pass,
                                                   int passlen);
 
@@ -189,6 +197,9 @@ int PKCS12_key_gen_uni(unsigned char *pass, int passlen, unsigned char *salt,
 int PKCS12_key_gen_utf8(const char *pass, int passlen, unsigned char *salt,
                         int saltlen, int id, int iter, int n,
                         unsigned char *out, const EVP_MD *md_type);
+int PKCS12_key_gen_ex(unsigned char *out, size_t keylen, OSSL_PARAM[] params,
+                      OSSL_LIB_CTX *ctx, const char *propq);
+
 int PKCS12_PBE_keyivgen(EVP_CIPHER_CTX *ctx, const char *pass, int passlen,
                         ASN1_TYPE *param, const EVP_CIPHER *cipher,
                         const EVP_MD *md_type, int en_de);
@@ -198,8 +209,13 @@ int PKCS12_verify_mac(PKCS12 *p12, const char *pass, int passlen);
 int PKCS12_set_mac(PKCS12 *p12, const char *pass, int passlen,
                    unsigned char *salt, int saltlen, int iter,
                    const EVP_MD *md_type);
+int PKCS12_set_mac_ex(PKCS12 *p12, OSSL_PARAM[] params,
+                      OSSL_LIB_CTX *ctx, const char *propq);
 int PKCS12_setup_mac(PKCS12 *p12, int iter, unsigned char *salt,
                      int saltlen, const EVP_MD *md_type);
+int PKCS12_setup_mac_ex(PKCS12 *p12, OSSL_PARAM[] params,
+                        OSSL_LIB_CTX *ctx, const char *propq);
+
 unsigned char *OPENSSL_asc2uni(const char *asc, int asclen,
                                unsigned char **uni, int *unilen);
 char *OPENSSL_uni2asc(const unsigned char *uni, int unilen);
@@ -221,15 +237,25 @@ int PKCS12_parse(PKCS12 *p12, const char *pass, EVP_PKEY **pkey, X509 **cert,
 PKCS12 *PKCS12_create(const char *pass, const char *name, EVP_PKEY *pkey,
                       X509 *cert, STACK_OF(X509) *ca, int nid_key, int nid_cert,
                       int iter, int mac_iter, int keytype);
+PKCS12 *PKCS12_create_ex(EVP_PKEY *pkey, X509 *cert, STACK_OF(X509) *ca,
+                         OSSL_PARAM[] params, OSSL_LIB_CTX *ctx, const char *propq);
 
 PKCS12_SAFEBAG *PKCS12_add_cert(STACK_OF(PKCS12_SAFEBAG) **pbags, X509 *cert);
 PKCS12_SAFEBAG *PKCS12_add_key(STACK_OF(PKCS12_SAFEBAG) **pbags,
                                EVP_PKEY *key, int key_usage, int iter,
                                int key_nid, const char *pass);
+PKCS12_SAFEBAG *PKCS12_add_key_ex(STACK_OF(PKCS12_SAFEBAG) **pbags,
+                                  EVP_PKEY *key, int key_usage, OSSL_PARAM[] params,
+                                  OSSL_LIB_CTX *ctx, const char *propq);
+
 PKCS12_SAFEBAG *PKCS12_add_secret(STACK_OF(PKCS12_SAFEBAG) **pbags,
                                   int nid_type, const unsigned char *value, int len);
+
 int PKCS12_add_safe(STACK_OF(PKCS7) **psafes, STACK_OF(PKCS12_SAFEBAG) *bags,
                     int safe_nid, int iter, const char *pass);
+int PKCS12_add_safe_ex(STACK_OF(PKCS7) **psafes, STACK_OF(PKCS12_SAFEBAG) *bags,
+                       OSSL_PARAM[] params, OSSL_LIB_CTX *ctx, const char *propq);
+
 PKCS12 *PKCS12_add_safes(STACK_OF(PKCS7) *safes, int p7_nid);
 
 int i2d_PKCS12_bio(BIO *bp, const PKCS12 *p12);

--- a/include/openssl/pkcs12.h.in
+++ b/include/openssl/pkcs12.h.in
@@ -204,7 +204,8 @@ int PKCS12_key_gen_ex(unsigned char *out, size_t keylen, OSSL_PARAM params[],
 int PKCS12_PBE_keyivgen(EVP_CIPHER_CTX *ctx, const char *pass, int passlen,
                         ASN1_TYPE *param, const EVP_CIPHER *cipher,
                         const EVP_MD *md_type, int en_de);
-int PKCS12_PBE_params_decode(ASN1_TYPE *param, OSSL_PARAM **params, int params_len);
+int PKCS12_PBE_encode(X509_ALGOR **algor, OSSL_PARAM *params);
+int PKCS12_PBE_decode(X509_ALGOR *algor, OSSL_PARAM **params);
 
 int PKCS12_gen_mac(PKCS12 *p12, const char *pass, int passlen,
                    unsigned char *mac, unsigned int *maclen);

--- a/include/openssl/x509.h.in
+++ b/include/openssl/x509.h.in
@@ -1064,6 +1064,7 @@ X509_ALGOR *PKCS5_pbe2_set(const EVP_CIPHER *cipher, int iter,
 X509_ALGOR *PKCS5_pbe2_set_iv(const EVP_CIPHER *cipher, int iter,
                               unsigned char *salt, int saltlen,
                               unsigned char *aiv, int prf_nid);
+X509_ALGOR *PKCS5_pbe2_set_param(OSSL_PARAM params[], OSSL_LIB_CTX *libctx, char *propq);
 
 #ifndef OPENSSL_NO_SCRYPT
 X509_ALGOR *PKCS5_pbe2_set_scrypt(const EVP_CIPHER *cipher,
@@ -1074,6 +1075,7 @@ X509_ALGOR *PKCS5_pbe2_set_scrypt(const EVP_CIPHER *cipher,
 
 X509_ALGOR *PKCS5_pbkdf2_set(int iter, unsigned char *salt, int saltlen,
                              int prf_nid, int keylen);
+X509_ALGOR *PKCS5_pbkdf2_set_params(OSSL_PARAM params[]);
 
 /* PKCS#8 utilities */
 

--- a/test/helpers/pkcs12.c
+++ b/test/helpers/pkcs12.c
@@ -259,9 +259,13 @@ void end_contentinfo_encrypted(PKCS12_BUILDER *pb, const PKCS12_ENC *enc)
 static STACK_OF(PKCS12_SAFEBAG) *decode_contentinfo(STACK_OF(PKCS7) *safes, int idx, const PKCS12_ENC *enc)
 {
     STACK_OF(PKCS12_SAFEBAG) *bags = NULL;
+    int bagnid;
     PKCS7 *p7 = sk_PKCS7_value(safes, idx);
-    int bagnid = OBJ_obj2nid(p7->type);
 
+    if (!TEST_ptr(p7))
+        goto err;
+
+    bagnid = OBJ_obj2nid(p7->type);
     if (enc) {
         if (!TEST_int_eq(bagnid, NID_pkcs7_encrypted))
             goto err;


### PR DESCRIPTION
Added some prototypes for PKCS12 APIs which allow a library context and property query.

The APIs are also simplified by passing parameters using OSSL_PARAMs, allowing for future expansion of these parameters.

I'm not sure yet if this would cover all PKCS12 cryptographic operations but would welcome input on this approach.
