### PR TITLE
Fix external symbols in the provider cipher implementations.

### DIFF
--- a/providers/implementations/ciphers/cipher_aes_ccm.c
+++ b/providers/implementations/ciphers/cipher_aes_ccm.c
@@ -29,7 +29,7 @@ static void *aes_ccm_newctx(void *provctx, size_t keybits)
 
     ctx = OPENSSL_zalloc(sizeof(*ctx));
     if (ctx != NULL)
-        ccm_initctx(&ctx->base, keybits, ossl_prov_aes_hw_ccm(keybits));
+        ossl_ccm_initctx(&ctx->base, keybits, ossl_prov_aes_hw_ccm(keybits));
     return ctx;
 }
 

--- a/providers/implementations/ciphers/cipher_aes_ccm_hw.c
+++ b/providers/implementations/ciphers/cipher_aes_ccm_hw.c
@@ -48,11 +48,11 @@ static int ccm_generic_aes_initkey(PROV_CCM_CTX *ctx, const unsigned char *key,
 
 static const PROV_CCM_HW aes_ccm = {
     ccm_generic_aes_initkey,
-    ccm_generic_setiv,
-    ccm_generic_setaad,
-    ccm_generic_auth_encrypt,
-    ccm_generic_auth_decrypt,
-    ccm_generic_gettag
+    ossl_ccm_generic_setiv,
+    ossl_ccm_generic_setaad,
+    ossl_ccm_generic_auth_encrypt,
+    ossl_ccm_generic_auth_decrypt,
+    ossl_ccm_generic_gettag
 };
 
 #if defined(S390X_aes_128_CAPABLE)

--- a/providers/implementations/ciphers/cipher_aes_ccm_hw_aesni.inc
+++ b/providers/implementations/ciphers/cipher_aes_ccm_hw_aesni.inc
@@ -25,11 +25,11 @@ static int ccm_aesni_initkey(PROV_CCM_CTX *ctx, const unsigned char *key,
 
 static const PROV_CCM_HW aesni_ccm = {
     ccm_aesni_initkey,
-    ccm_generic_setiv,
-    ccm_generic_setaad,
-    ccm_generic_auth_encrypt,
-    ccm_generic_auth_decrypt,
-    ccm_generic_gettag
+    ossl_ccm_generic_setiv,
+    ossl_ccm_generic_setaad,
+    ossl_ccm_generic_auth_encrypt,
+    ossl_ccm_generic_auth_decrypt,
+    ossl_ccm_generic_gettag
 };
 
 const PROV_CCM_HW *ossl_prov_aes_hw_ccm(size_t keybits)

--- a/providers/implementations/ciphers/cipher_aes_ccm_hw_t4.inc
+++ b/providers/implementations/ciphers/cipher_aes_ccm_hw_t4.inc
@@ -23,11 +23,11 @@ static int ccm_t4_aes_initkey(PROV_CCM_CTX *ctx, const unsigned char *key,
 
 static const PROV_CCM_HW t4_aes_ccm = {
     ccm_t4_aes_initkey,
-    ccm_generic_setiv,
-    ccm_generic_setaad,
-    ccm_generic_auth_encrypt,
-    ccm_generic_auth_decrypt,
-    ccm_generic_gettag
+    ossl_ccm_generic_setiv,
+    ossl_ccm_generic_setaad,
+    ossl_ccm_generic_auth_encrypt,
+    ossl_ccm_generic_auth_decrypt,
+    ossl_ccm_generic_gettag
 };
 
 const PROV_CCM_HW *ossl_prov_aes_hw_ccm(size_t keybits)

--- a/providers/implementations/ciphers/cipher_aes_gcm.c
+++ b/providers/implementations/ciphers/cipher_aes_gcm.c
@@ -32,8 +32,8 @@ static void *aes_gcm_newctx(void *provctx, size_t keybits)
 
     ctx = OPENSSL_zalloc(sizeof(*ctx));
     if (ctx != NULL)
-        gcm_initctx(provctx, &ctx->base, keybits, ossl_prov_aes_hw_gcm(keybits),
-                    AES_GCM_IV_MIN_SIZE);
+        ossl_gcm_initctx(provctx, &ctx->base, keybits,
+                         ossl_prov_aes_hw_gcm(keybits), AES_GCM_IV_MIN_SIZE);
     return ctx;
 }
 

--- a/providers/implementations/ciphers/cipher_aes_gcm_hw.c
+++ b/providers/implementations/ciphers/cipher_aes_gcm_hw.c
@@ -126,11 +126,11 @@ static int generic_aes_gcm_cipher_update(PROV_GCM_CTX *ctx, const unsigned char 
 
 static const PROV_GCM_HW aes_gcm = {
     aes_gcm_initkey,
-    gcm_setiv,
-    gcm_aad_update,
+    ossl_gcm_setiv,
+    ossl_gcm_aad_update,
     generic_aes_gcm_cipher_update,
-    gcm_cipher_final,
-    gcm_one_shot
+    ossl_gcm_cipher_final,
+    ossl_gcm_one_shot
 };
 
 #if defined(S390X_aes_128_CAPABLE)

--- a/providers/implementations/ciphers/cipher_aes_gcm_hw_aesni.inc
+++ b/providers/implementations/ciphers/cipher_aes_gcm_hw_aesni.inc
@@ -24,11 +24,11 @@ static int aesni_gcm_initkey(PROV_GCM_CTX *ctx, const unsigned char *key,
 
 static const PROV_GCM_HW aesni_gcm = {
     aesni_gcm_initkey,
-    gcm_setiv,
-    gcm_aad_update,
+    ossl_gcm_setiv,
+    ossl_gcm_aad_update,
     generic_aes_gcm_cipher_update,
-    gcm_cipher_final,
-    gcm_one_shot
+    ossl_gcm_cipher_final,
+    ossl_gcm_one_shot
 };
 
 const PROV_GCM_HW *ossl_prov_aes_hw_gcm(size_t keybits)

--- a/providers/implementations/ciphers/cipher_aes_gcm_hw_armv8.inc
+++ b/providers/implementations/ciphers/cipher_aes_gcm_hw_armv8.inc
@@ -70,11 +70,11 @@ static int armv8_aes_gcm_initkey(PROV_GCM_CTX *ctx, const unsigned char *key,
 
 static const PROV_GCM_HW armv8_aes_gcm = {
     armv8_aes_gcm_initkey,
-    gcm_setiv,
-    gcm_aad_update,
+    ossl_gcm_setiv,
+    ossl_gcm_aad_update,
     generic_aes_gcm_cipher_update,
-    gcm_cipher_final,
-    gcm_one_shot
+    ossl_gcm_cipher_final,
+    ossl_gcm_one_shot
 };
 
 const PROV_GCM_HW *ossl_prov_aes_hw_gcm(size_t keybits)

--- a/providers/implementations/ciphers/cipher_aes_gcm_hw_t4.inc
+++ b/providers/implementations/ciphers/cipher_aes_gcm_hw_t4.inc
@@ -40,11 +40,11 @@ static int t4_aes_gcm_initkey(PROV_GCM_CTX *ctx, const unsigned char *key,
 
 static const PROV_GCM_HW t4_aes_gcm = {
     t4_aes_gcm_initkey,
-    gcm_setiv,
-    gcm_aad_update,
+    ossl_gcm_setiv,
+    ossl_gcm_aad_update,
     generic_aes_gcm_cipher_update,
-    gcm_cipher_final,
-    gcm_one_shot
+    ossl_gcm_cipher_final,
+    ossl_gcm_one_shot
 };
 const PROV_GCM_HW *ossl_prov_aes_hw_gcm(size_t keybits)
 {

--- a/providers/implementations/ciphers/cipher_aes_ocb.c
+++ b/providers/implementations/ciphers/cipher_aes_ocb.c
@@ -162,7 +162,7 @@ static int aes_ocb_block_update_internal(PROV_AES_OCB_CTX *ctx,
     size_t outlint = 0;
 
     if (*bufsz != 0)
-        nextblocks = fillblock(buf, bufsz, AES_BLOCK_SIZE, &in, &inl);
+        nextblocks = ossl_cipher_fillblock(buf, bufsz, AES_BLOCK_SIZE, &in, &inl);
     else
         nextblocks = inl & ~(AES_BLOCK_SIZE-1);
 
@@ -193,7 +193,8 @@ static int aes_ocb_block_update_internal(PROV_AES_OCB_CTX *ctx,
         in += nextblocks;
         inl -= nextblocks;
     }
-    if (inl != 0 && !trailingdata(buf, bufsz, AES_BLOCK_SIZE, &in, &inl)) {
+    if (inl != 0
+        && !ossl_cipher_trailingdata(buf, bufsz, AES_BLOCK_SIZE, &in, &inl)) {
         /* PROVerr already called */
         return 0;
     }

--- a/providers/implementations/ciphers/cipher_aria_ccm.c
+++ b/providers/implementations/ciphers/cipher_aria_ccm.c
@@ -24,7 +24,7 @@ static void *aria_ccm_newctx(void *provctx, size_t keybits)
 
     ctx = OPENSSL_zalloc(sizeof(*ctx));
     if (ctx != NULL)
-        ccm_initctx(&ctx->base, keybits, ossl_prov_aria_hw_ccm(keybits));
+        ossl_ccm_initctx(&ctx->base, keybits, ossl_prov_aria_hw_ccm(keybits));
     return ctx;
 }
 

--- a/providers/implementations/ciphers/cipher_aria_ccm_hw.c
+++ b/providers/implementations/ciphers/cipher_aria_ccm_hw.c
@@ -28,11 +28,11 @@ static int ccm_aria_initkey(PROV_CCM_CTX *ctx,
 
 static const PROV_CCM_HW ccm_aria = {
     ccm_aria_initkey,
-    ccm_generic_setiv,
-    ccm_generic_setaad,
-    ccm_generic_auth_encrypt,
-    ccm_generic_auth_decrypt,
-    ccm_generic_gettag
+    ossl_ccm_generic_setiv,
+    ossl_ccm_generic_setaad,
+    ossl_ccm_generic_auth_encrypt,
+    ossl_ccm_generic_auth_decrypt,
+    ossl_ccm_generic_gettag
 };
 const PROV_CCM_HW *ossl_prov_aria_hw_ccm(size_t keybits)
 {

--- a/providers/implementations/ciphers/cipher_aria_gcm.c
+++ b/providers/implementations/ciphers/cipher_aria_gcm.c
@@ -24,8 +24,8 @@ static void *aria_gcm_newctx(void *provctx, size_t keybits)
 
     ctx = OPENSSL_zalloc(sizeof(*ctx));
     if (ctx != NULL)
-        gcm_initctx(provctx, &ctx->base, keybits,
-                    ossl_prov_aria_hw_gcm(keybits), ARIA_GCM_IV_MIN_SIZE);
+        ossl_gcm_initctx(provctx, &ctx->base, keybits,
+                         ossl_prov_aria_hw_gcm(keybits), ARIA_GCM_IV_MIN_SIZE);
     return ctx;
 }
 

--- a/providers/implementations/ciphers/cipher_aria_gcm_hw.c
+++ b/providers/implementations/ciphers/cipher_aria_gcm_hw.c
@@ -25,11 +25,11 @@ static int aria_gcm_initkey(PROV_GCM_CTX *ctx, const unsigned char *key,
 
 static const PROV_GCM_HW aria_gcm = {
     aria_gcm_initkey,
-    gcm_setiv,
-    gcm_aad_update,
-    gcm_cipher_update,
-    gcm_cipher_final,
-    gcm_one_shot
+    ossl_gcm_setiv,
+    ossl_gcm_aad_update,
+    ossl_gcm_cipher_update,
+    ossl_gcm_cipher_final,
+    ossl_gcm_one_shot
 };
 const PROV_GCM_HW *ossl_prov_aria_hw_gcm(size_t keybits)
 {

--- a/providers/implementations/ciphers/cipher_chacha20.c
+++ b/providers/implementations/ciphers/cipher_chacha20.c
@@ -31,7 +31,7 @@ static OSSL_FUNC_cipher_settable_ctx_params_fn chacha20_settable_ctx_params;
 #define chacha20_final ossl_cipher_generic_stream_final
 #define chacha20_gettable_params ossl_cipher_generic_gettable_params
 
-void chacha20_initctx(PROV_CHACHA20_CTX *ctx)
+void ossl_chacha20_initctx(PROV_CHACHA20_CTX *ctx)
 {
     ossl_cipher_generic_initkey(ctx, CHACHA20_KEYLEN * 8,
                                 CHACHA20_BLKLEN * 8,
@@ -50,7 +50,7 @@ static void *chacha20_newctx(void *provctx)
 
     ctx = OPENSSL_zalloc(sizeof(*ctx));
     if (ctx != NULL)
-        chacha20_initctx(ctx);
+        ossl_chacha20_initctx(ctx);
     return ctx;
 }
 
@@ -140,8 +140,8 @@ const OSSL_PARAM *chacha20_settable_ctx_params(ossl_unused void *provctx)
     return chacha20_known_settable_ctx_params;
 }
 
-int chacha20_einit(void *vctx, const unsigned char *key, size_t keylen,
-                   const unsigned char *iv, size_t ivlen)
+int ossl_chacha20_einit(void *vctx, const unsigned char *key, size_t keylen,
+                        const unsigned char *iv, size_t ivlen)
 {
     int ret;
 
@@ -156,8 +156,8 @@ int chacha20_einit(void *vctx, const unsigned char *key, size_t keylen,
     return ret;
 }
 
-int chacha20_dinit(void *vctx, const unsigned char *key, size_t keylen,
-                   const unsigned char *iv, size_t ivlen)
+int ossl_chacha20_dinit(void *vctx, const unsigned char *key, size_t keylen,
+                        const unsigned char *iv, size_t ivlen)
 {
     int ret;
 
@@ -176,8 +176,8 @@ int chacha20_dinit(void *vctx, const unsigned char *key, size_t keylen,
 const OSSL_DISPATCH ossl_chacha20_functions[] = {
     { OSSL_FUNC_CIPHER_NEWCTX, (void (*)(void))chacha20_newctx },
     { OSSL_FUNC_CIPHER_FREECTX, (void (*)(void))chacha20_freectx },
-    { OSSL_FUNC_CIPHER_ENCRYPT_INIT, (void (*)(void))chacha20_einit },
-    { OSSL_FUNC_CIPHER_DECRYPT_INIT, (void (*)(void))chacha20_dinit },
+    { OSSL_FUNC_CIPHER_ENCRYPT_INIT, (void (*)(void))ossl_chacha20_einit },
+    { OSSL_FUNC_CIPHER_DECRYPT_INIT, (void (*)(void))ossl_chacha20_dinit },
     { OSSL_FUNC_CIPHER_UPDATE, (void (*)(void))chacha20_update },
     { OSSL_FUNC_CIPHER_FINAL, (void (*)(void))chacha20_final },
     { OSSL_FUNC_CIPHER_CIPHER, (void (*)(void))chacha20_cipher},

--- a/providers/implementations/ciphers/cipher_chacha20.h
+++ b/providers/implementations/ciphers/cipher_chacha20.h
@@ -29,6 +29,6 @@ typedef struct prov_cipher_hw_chacha20_st {
 
 const PROV_CIPHER_HW *ossl_prov_cipher_hw_chacha20(size_t keybits);
 
-OSSL_FUNC_cipher_encrypt_init_fn chacha20_einit;
-OSSL_FUNC_cipher_decrypt_init_fn chacha20_dinit;
-void chacha20_initctx(PROV_CHACHA20_CTX *ctx);
+OSSL_FUNC_cipher_encrypt_init_fn ossl_chacha20_einit;
+OSSL_FUNC_cipher_decrypt_init_fn ossl_chacha20_dinit;
+void ossl_chacha20_initctx(PROV_CHACHA20_CTX *ctx);

--- a/providers/implementations/ciphers/cipher_chacha20_poly1305.c
+++ b/providers/implementations/ciphers/cipher_chacha20_poly1305.c
@@ -55,7 +55,7 @@ static void *chacha20_poly1305_newctx(void *provctx)
                                     NULL);
         ctx->nonce_len = CHACHA20_POLY1305_IVLEN;
         ctx->tls_payload_length = NO_TLS_PAYLOAD_LENGTH;
-        chacha20_initctx(&ctx->chacha);
+        ossl_chacha20_initctx(&ctx->chacha);
     }
     return ctx;
 }

--- a/providers/implementations/ciphers/cipher_chacha20_poly1305_hw.c
+++ b/providers/implementations/ciphers/cipher_chacha20_poly1305_hw.c
@@ -68,9 +68,9 @@ static int chacha20_poly1305_initkey(PROV_CIPHER_CTX *bctx,
     ctx->tls_payload_length = NO_TLS_PAYLOAD_LENGTH;
 
     if (bctx->enc)
-        return chacha20_einit(&ctx->chacha, key, keylen, NULL, 0);
+        return ossl_chacha20_einit(&ctx->chacha, key, keylen, NULL, 0);
     else
-        return chacha20_dinit(&ctx->chacha, key, keylen, NULL, 0);
+        return ossl_chacha20_dinit(&ctx->chacha, key, keylen, NULL, 0);
 }
 
 static int chacha20_poly1305_initiv(PROV_CIPHER_CTX *bctx)
@@ -91,9 +91,11 @@ static int chacha20_poly1305_initiv(PROV_CIPHER_CTX *bctx)
                    ctx->nonce_len);
 
         if (bctx->enc)
-            ret = chacha20_einit(&ctx->chacha, NULL, 0, tempiv, sizeof(tempiv));
+            ret = ossl_chacha20_einit(&ctx->chacha, NULL, 0,
+                                      tempiv, sizeof(tempiv));
         else
-            ret = chacha20_dinit(&ctx->chacha, NULL, 0, tempiv, sizeof(tempiv));
+            ret = ossl_chacha20_dinit(&ctx->chacha, NULL, 0,
+                                      tempiv, sizeof(tempiv));
         ctx->nonce[0] = ctx->chacha.counter[1];
         ctx->nonce[1] = ctx->chacha.counter[2];
         ctx->nonce[2] = ctx->chacha.counter[3];

--- a/providers/implementations/ciphers/cipher_des.c
+++ b/providers/implementations/ciphers/cipher_des.c
@@ -148,7 +148,7 @@ static void *des_##lcmode##_newctx(void *provctx)                              \
 {                                                                              \
     return des_newctx(provctx, kbits, blkbits, ivbits,                         \
                       EVP_CIPH_##UCMODE##_MODE, flags,                         \
-                      PROV_CIPHER_HW_des_##lcmode());                          \
+                      ossl_prov_cipher_hw_des_##lcmode());                          \
 }                                                                              \
 static OSSL_FUNC_cipher_get_params_fn des_##lcmode##_get_params;               \
 static int des_##lcmode##_get_params(OSSL_PARAM params[])                      \

--- a/providers/implementations/ciphers/cipher_des.h
+++ b/providers/implementations/ciphers/cipher_des.h
@@ -25,9 +25,9 @@ typedef struct prov_des_ctx_st {
 
 } PROV_DES_CTX;
 
-const PROV_CIPHER_HW *PROV_CIPHER_HW_des_cbc(void);
-const PROV_CIPHER_HW *PROV_CIPHER_HW_des_ecb(void);
-const PROV_CIPHER_HW *PROV_CIPHER_HW_des_ofb64(void);
-const PROV_CIPHER_HW *PROV_CIPHER_HW_des_cfb64(void);
-const PROV_CIPHER_HW *PROV_CIPHER_HW_des_cfb1(void);
-const PROV_CIPHER_HW *PROV_CIPHER_HW_des_cfb8(void);
+const PROV_CIPHER_HW *ossl_prov_cipher_hw_des_cbc(void);
+const PROV_CIPHER_HW *ossl_prov_cipher_hw_des_ecb(void);
+const PROV_CIPHER_HW *ossl_prov_cipher_hw_des_ofb64(void);
+const PROV_CIPHER_HW *ossl_prov_cipher_hw_des_cfb64(void);
+const PROV_CIPHER_HW *ossl_prov_cipher_hw_des_cfb1(void);
+const PROV_CIPHER_HW *ossl_prov_cipher_hw_des_cfb8(void);

--- a/providers/implementations/ciphers/cipher_des_hw.c
+++ b/providers/implementations/ciphers/cipher_des_hw.c
@@ -183,7 +183,7 @@ static const PROV_CIPHER_HW des_##mode = {                                     \
     cipher_hw_des_##mode##_cipher,                                             \
     cipher_hw_des_copyctx                                                      \
 };                                                                             \
-const PROV_CIPHER_HW *PROV_CIPHER_HW_des_##mode(void)                          \
+const PROV_CIPHER_HW *ossl_prov_cipher_hw_des_##mode(void)                     \
 {                                                                              \
     return &des_##mode;                                                        \
 }

--- a/providers/implementations/ciphers/cipher_tdes.h
+++ b/providers/implementations/ciphers/cipher_tdes.h
@@ -33,7 +33,7 @@ typedef struct prov_tdes_ctx_st {
 static OSSL_FUNC_cipher_newctx_fn tdes_##type##_##lcmode##_newctx;             \
 static void *tdes_##type##_##lcmode##_newctx(void *provctx)                    \
 {                                                                              \
-    return tdes_newctx(provctx, EVP_CIPH_##UCMODE##_MODE, kbits, blkbits,      \
+    return ossl_tdes_newctx(provctx, EVP_CIPH_##UCMODE##_MODE, kbits, blkbits, \
                        ivbits, flags,                                          \
                        ossl_prov_cipher_hw_tdes_##type##_##lcmode());          \
 }                                                                              \
@@ -44,23 +44,25 @@ static int tdes_##type##_##lcmode##_get_params(OSSL_PARAM params[])            \
                                           flags, kbits, blkbits, ivbits);      \
 }                                                                              \
 const OSSL_DISPATCH ossl_tdes_##type##_##lcmode##_functions[] = {              \
-    { OSSL_FUNC_CIPHER_ENCRYPT_INIT, (void (*)(void))tdes_einit },             \
-    { OSSL_FUNC_CIPHER_DECRYPT_INIT, (void (*)(void))tdes_dinit },             \
+    { OSSL_FUNC_CIPHER_ENCRYPT_INIT, (void (*)(void))ossl_tdes_einit },        \
+    { OSSL_FUNC_CIPHER_DECRYPT_INIT, (void (*)(void))ossl_tdes_dinit },        \
     { OSSL_FUNC_CIPHER_UPDATE,                                                 \
       (void (*)(void))ossl_cipher_generic_##block##_update },                  \
-    { OSSL_FUNC_CIPHER_FINAL, (void (*)(void))ossl_cipher_generic_##block##_final },\
+    { OSSL_FUNC_CIPHER_FINAL,                                                  \
+      (void (*)(void))ossl_cipher_generic_##block##_final },                   \
     { OSSL_FUNC_CIPHER_CIPHER, (void (*)(void))ossl_cipher_generic_cipher },   \
     { OSSL_FUNC_CIPHER_NEWCTX,                                                 \
       (void (*)(void))tdes_##type##_##lcmode##_newctx },                       \
-    { OSSL_FUNC_CIPHER_DUPCTX, (void (*)(void))tdes_dupctx },                  \
-    { OSSL_FUNC_CIPHER_FREECTX, (void (*)(void))tdes_freectx },                \
+    { OSSL_FUNC_CIPHER_DUPCTX, (void (*)(void))ossl_tdes_dupctx },             \
+    { OSSL_FUNC_CIPHER_FREECTX, (void (*)(void))ossl_tdes_freectx },           \
     { OSSL_FUNC_CIPHER_GET_PARAMS,                                             \
       (void (*)(void))tdes_##type##_##lcmode##_get_params },                   \
     { OSSL_FUNC_CIPHER_GETTABLE_PARAMS,                                        \
       (void (*)(void))ossl_cipher_generic_gettable_params },                   \
-    { OSSL_FUNC_CIPHER_GET_CTX_PARAMS, (void (*)(void))tdes_get_ctx_params },  \
+    { OSSL_FUNC_CIPHER_GET_CTX_PARAMS,                                         \
+      (void (*)(void))ossl_tdes_get_ctx_params },                              \
     { OSSL_FUNC_CIPHER_GETTABLE_CTX_PARAMS,                                    \
-      (void (*)(void))tdes_gettable_ctx_params },                              \
+      (void (*)(void))ossl_tdes_gettable_ctx_params },                         \
     { OSSL_FUNC_CIPHER_SET_CTX_PARAMS,                                         \
      (void (*)(void))ossl_cipher_generic_set_ctx_params },                     \
     { OSSL_FUNC_CIPHER_SETTABLE_CTX_PARAMS,                                    \
@@ -68,14 +70,14 @@ const OSSL_DISPATCH ossl_tdes_##type##_##lcmode##_functions[] = {              \
     { 0, NULL }                                                                \
 }
 
-void *tdes_newctx(void *provctx, int mode, size_t kbits, size_t blkbits,
-                  size_t ivbits, uint64_t flags, const PROV_CIPHER_HW *hw);
-OSSL_FUNC_cipher_dupctx_fn tdes_dupctx;
-OSSL_FUNC_cipher_freectx_fn tdes_freectx;
-OSSL_FUNC_cipher_encrypt_init_fn tdes_einit;
-OSSL_FUNC_cipher_decrypt_init_fn tdes_dinit;
-OSSL_FUNC_cipher_get_ctx_params_fn tdes_get_ctx_params;
-OSSL_FUNC_cipher_gettable_ctx_params_fn tdes_gettable_ctx_params;
+void *ossl_tdes_newctx(void *provctx, int mode, size_t kbits, size_t blkbits,
+                       size_t ivbits, uint64_t flags, const PROV_CIPHER_HW *hw);
+OSSL_FUNC_cipher_dupctx_fn ossl_tdes_dupctx;
+OSSL_FUNC_cipher_freectx_fn ossl_tdes_freectx;
+OSSL_FUNC_cipher_encrypt_init_fn ossl_tdes_einit;
+OSSL_FUNC_cipher_decrypt_init_fn ossl_tdes_dinit;
+OSSL_FUNC_cipher_get_ctx_params_fn ossl_tdes_get_ctx_params;
+OSSL_FUNC_cipher_gettable_ctx_params_fn ossl_tdes_gettable_ctx_params;
 
 #define PROV_CIPHER_HW_tdes_mode(type, mode)                                   \
 static const PROV_CIPHER_HW type##_##mode = {                                  \

--- a/providers/implementations/ciphers/cipher_tdes_common.c
+++ b/providers/implementations/ciphers/cipher_tdes_common.c
@@ -20,8 +20,8 @@
 #include "prov/implementations.h"
 #include "prov/providercommon.h"
 
-void *tdes_newctx(void *provctx, int mode, size_t kbits, size_t blkbits,
-                  size_t ivbits, uint64_t flags, const PROV_CIPHER_HW *hw)
+void *ossl_tdes_newctx(void *provctx, int mode, size_t kbits, size_t blkbits,
+                       size_t ivbits, uint64_t flags, const PROV_CIPHER_HW *hw)
 {
     PROV_TDES_CTX *tctx;
 
@@ -35,7 +35,7 @@ void *tdes_newctx(void *provctx, int mode, size_t kbits, size_t blkbits,
     return tctx;
 }
 
-void *tdes_dupctx(void *ctx)
+void *ossl_tdes_dupctx(void *ctx)
 {
     PROV_TDES_CTX *in = (PROV_TDES_CTX *)ctx;
     PROV_TDES_CTX *ret;
@@ -53,7 +53,7 @@ void *tdes_dupctx(void *ctx)
     return ret;
 }
 
-void tdes_freectx(void *vctx)
+void ossl_tdes_freectx(void *vctx)
 {
     PROV_TDES_CTX *ctx = (PROV_TDES_CTX *)vctx;
 
@@ -88,21 +88,21 @@ static int tdes_init(void *vctx, const unsigned char *key, size_t keylen,
     return 1;
 }
 
-int tdes_einit(void *vctx, const unsigned char *key, size_t keylen,
-               const unsigned char *iv, size_t ivlen)
+int ossl_tdes_einit(void *vctx, const unsigned char *key, size_t keylen,
+                    const unsigned char *iv, size_t ivlen)
 {
     return tdes_init(vctx, key, keylen, iv, ivlen, 1);
 }
 
-int tdes_dinit(void *vctx, const unsigned char *key, size_t keylen,
-               const unsigned char *iv, size_t ivlen)
+int ossl_tdes_dinit(void *vctx, const unsigned char *key, size_t keylen,
+                    const unsigned char *iv, size_t ivlen)
 {
     return tdes_init(vctx, key, keylen, iv, ivlen, 0);
 }
 
-CIPHER_DEFAULT_GETTABLE_CTX_PARAMS_START(tdes)
+CIPHER_DEFAULT_GETTABLE_CTX_PARAMS_START(ossl_tdes)
     OSSL_PARAM_octet_string(OSSL_CIPHER_PARAM_RANDOM_KEY, NULL, 0),
-CIPHER_DEFAULT_GETTABLE_CTX_PARAMS_END(tdes)
+CIPHER_DEFAULT_GETTABLE_CTX_PARAMS_END(ossl_tdes)
 
 static int tdes_generatekey(PROV_CIPHER_CTX *ctx, void *ptr)
 {
@@ -122,7 +122,7 @@ static int tdes_generatekey(PROV_CIPHER_CTX *ctx, void *ptr)
     return 0;
 }
 
-int tdes_get_ctx_params(void *vctx, OSSL_PARAM params[])
+int ossl_tdes_get_ctx_params(void *vctx, OSSL_PARAM params[])
 {
     PROV_CIPHER_CTX  *ctx = (PROV_CIPHER_CTX *)vctx;
     OSSL_PARAM *p;

--- a/providers/implementations/ciphers/cipher_tdes_wrap.c
+++ b/providers/implementations/ciphers/cipher_tdes_wrap.c
@@ -172,8 +172,9 @@ static int tdes_wrap_update(void *vctx, unsigned char *out, size_t *outl,
 static OSSL_FUNC_cipher_newctx_fn tdes_wrap_newctx;                            \
 static void *tdes_wrap_newctx(void *provctx)                                   \
 {                                                                              \
-    return tdes_newctx(provctx, EVP_CIPH_WRAP_MODE, kbits, blkbits, ivbits,    \
-                       flags, ossl_prov_cipher_hw_tdes_wrap_cbc());            \
+    return ossl_tdes_newctx(provctx, EVP_CIPH_WRAP_MODE, kbits, blkbits,       \
+                            ivbits, flags,                                     \
+                            ossl_prov_cipher_hw_tdes_wrap_cbc());              \
 }                                                                              \
 static OSSL_FUNC_cipher_get_params_fn tdes_wrap_get_params;                    \
 static int tdes_wrap_get_params(OSSL_PARAM params[])                           \
@@ -183,19 +184,21 @@ static int tdes_wrap_get_params(OSSL_PARAM params[])                           \
 }                                                                              \
 const OSSL_DISPATCH ossl_tdes_wrap_cbc_functions[] =                           \
 {                                                                              \
-    { OSSL_FUNC_CIPHER_ENCRYPT_INIT, (void (*)(void)) tdes_einit },            \
-    { OSSL_FUNC_CIPHER_DECRYPT_INIT, (void (*)(void)) tdes_dinit },            \
+    { OSSL_FUNC_CIPHER_ENCRYPT_INIT, (void (*)(void)) ossl_tdes_einit },       \
+    { OSSL_FUNC_CIPHER_DECRYPT_INIT, (void (*)(void)) ossl_tdes_dinit },       \
     { OSSL_FUNC_CIPHER_CIPHER, (void (*)(void))tdes_wrap_cipher },             \
     { OSSL_FUNC_CIPHER_NEWCTX, (void (*)(void))tdes_wrap_newctx },             \
-    { OSSL_FUNC_CIPHER_FREECTX, (void (*)(void))tdes_freectx },                \
+    { OSSL_FUNC_CIPHER_FREECTX, (void (*)(void))ossl_tdes_freectx },           \
     { OSSL_FUNC_CIPHER_UPDATE, (void (*)(void))tdes_wrap_update },             \
-    { OSSL_FUNC_CIPHER_FINAL, (void (*)(void))ossl_cipher_generic_stream_final },\
+    { OSSL_FUNC_CIPHER_FINAL,                                                  \
+      (void (*)(void))ossl_cipher_generic_stream_final },                      \
     { OSSL_FUNC_CIPHER_GET_PARAMS, (void (*)(void))tdes_wrap_get_params },     \
     { OSSL_FUNC_CIPHER_GETTABLE_PARAMS,                                        \
       (void (*)(void))ossl_cipher_generic_gettable_params },                   \
-    { OSSL_FUNC_CIPHER_GET_CTX_PARAMS, (void (*)(void))tdes_get_ctx_params },  \
+    { OSSL_FUNC_CIPHER_GET_CTX_PARAMS,                                         \
+      (void (*)(void))ossl_tdes_get_ctx_params },                              \
     { OSSL_FUNC_CIPHER_GETTABLE_CTX_PARAMS,                                    \
-      (void (*)(void))tdes_gettable_ctx_params },                              \
+      (void (*)(void))ossl_tdes_gettable_ctx_params },                         \
     { OSSL_FUNC_CIPHER_SET_CTX_PARAMS,                                         \
       (void (*)(void))ossl_cipher_generic_set_ctx_params },                    \
     { OSSL_FUNC_CIPHER_SETTABLE_CTX_PARAMS,                                    \

--- a/providers/implementations/ciphers/ciphercommon.c
+++ b/providers/implementations/ciphers/ciphercommon.c
@@ -296,9 +296,10 @@ int ossl_cipher_generic_block_update(void *vctx, unsigned char *out,
         /* This only fails if padding is publicly invalid */
         *outl = inl;
         if (!ctx->enc
-                && !tlsunpadblock(ctx->libctx, ctx->tlsversion, out, outl,
-                                  blksz, &ctx->tlsmac, &ctx->alloced,
-                                  ctx->tlsmacsize, 0)) {
+            && !ossl_cipher_tlsunpadblock(ctx->libctx, ctx->tlsversion,
+                                          out, outl,
+                                          blksz, &ctx->tlsmac, &ctx->alloced,
+                                          ctx->tlsmacsize, 0)) {
             ERR_raise(ERR_LIB_PROV, PROV_R_CIPHER_OPERATION_FAILED);
             return 0;
         }
@@ -306,7 +307,8 @@ int ossl_cipher_generic_block_update(void *vctx, unsigned char *out,
     }
 
     if (ctx->bufsz != 0)
-        nextblocks = fillblock(ctx->buf, &ctx->bufsz, blksz, &in, &inl);
+        nextblocks = ossl_cipher_fillblock(ctx->buf, &ctx->bufsz, blksz,
+                                           &in, &inl);
     else
         nextblocks = inl & ~(blksz-1);
 
@@ -350,7 +352,8 @@ int ossl_cipher_generic_block_update(void *vctx, unsigned char *out,
         in += nextblocks;
         inl -= nextblocks;
     }
-    if (inl != 0 && !trailingdata(ctx->buf, &ctx->bufsz, blksz, &in, &inl)) {
+    if (inl != 0
+        && !ossl_cipher_trailingdata(ctx->buf, &ctx->bufsz, blksz, &in, &inl)) {
         /* ERR_raise already called */
         return 0;
     }
@@ -376,7 +379,7 @@ int ossl_cipher_generic_block_final(void *vctx, unsigned char *out,
 
     if (ctx->enc) {
         if (ctx->pad) {
-            padblock(ctx->buf, &ctx->bufsz, blksz);
+            ossl_cipher_padblock(ctx->buf, &ctx->bufsz, blksz);
         } else if (ctx->bufsz == 0) {
             *outl = 0;
             return 1;
@@ -413,7 +416,7 @@ int ossl_cipher_generic_block_final(void *vctx, unsigned char *out,
         return 0;
     }
 
-    if (ctx->pad && !unpadblock(ctx->buf, &ctx->bufsz, blksz)) {
+    if (ctx->pad && !ossl_cipher_unpadblock(ctx->buf, &ctx->bufsz, blksz)) {
         /* ERR_raise already called */
         return 0;
     }

--- a/providers/implementations/ciphers/ciphercommon_block.c
+++ b/providers/implementations/ciphers/ciphercommon_block.c
@@ -53,8 +53,9 @@ int tls1_cbc_remove_padding_and_mac(size_t *reclen,
  * the remaining amount of data in *in. Returns the largest value <= *inlen
  * which is a multiple of the blocksize.
  */
-size_t fillblock(unsigned char *buf, size_t *buflen, size_t blocksize,
-                 const unsigned char **in, size_t *inlen)
+size_t ossl_cipher_fillblock(unsigned char *buf, size_t *buflen,
+                             size_t blocksize,
+                             const unsigned char **in, size_t *inlen)
 {
     size_t blockmask = ~(blocksize - 1);
     size_t bufremain = blocksize - *buflen;
@@ -76,8 +77,8 @@ size_t fillblock(unsigned char *buf, size_t *buflen, size_t blocksize,
  * Fills the buffer with trailing data from an encryption/decryption that didn't
  * fit into a full block.
  */
-int trailingdata(unsigned char *buf, size_t *buflen, size_t blocksize,
-                 const unsigned char **in, size_t *inlen)
+int ossl_cipher_trailingdata(unsigned char *buf, size_t *buflen, size_t blocksize,
+                             const unsigned char **in, size_t *inlen)
 {
     if (*inlen == 0)
         return 1;
@@ -95,7 +96,7 @@ int trailingdata(unsigned char *buf, size_t *buflen, size_t blocksize,
 }
 
 /* Pad the final block for encryption */
-void padblock(unsigned char *buf, size_t *buflen, size_t blocksize)
+void ossl_cipher_padblock(unsigned char *buf, size_t *buflen, size_t blocksize)
 {
     size_t i;
     unsigned char pad = (unsigned char)(blocksize - *buflen);
@@ -104,7 +105,7 @@ void padblock(unsigned char *buf, size_t *buflen, size_t blocksize)
         buf[i] = pad;
 }
 
-int unpadblock(unsigned char *buf, size_t *buflen, size_t blocksize)
+int ossl_cipher_unpadblock(unsigned char *buf, size_t *buflen, size_t blocksize)
 {
     size_t pad, i;
     size_t len = *buflen;
@@ -134,7 +135,7 @@ int unpadblock(unsigned char *buf, size_t *buflen, size_t blocksize)
 }
 
 /*-
- * tlsunpadblock removes the CBC padding from the decrypted, TLS, CBC
+ * ossl_cipher_tlsunpadblock removes the CBC padding from the decrypted, TLS, CBC
  * record in constant time. Also removes the MAC from the record in constant
  * time.
  *
@@ -154,9 +155,11 @@ int unpadblock(unsigned char *buf, size_t *buflen, size_t blocksize)
  *   1: (in constant time) Record is publicly valid. If padding is invalid then
  *      the mac is random
  */
-int tlsunpadblock(OSSL_LIB_CTX *libctx, unsigned int tlsversion,
-                  unsigned char *buf, size_t *buflen, size_t blocksize,
-                  unsigned char **mac, int *alloced, size_t macsize, int aead)
+int ossl_cipher_tlsunpadblock(OSSL_LIB_CTX *libctx, unsigned int tlsversion,
+                              unsigned char *buf, size_t *buflen,
+                              size_t blocksize,
+                              unsigned char **mac, int *alloced, size_t macsize,
+                              int aead)
 {
     int ret;
 

--- a/providers/implementations/ciphers/ciphercommon_ccm.c
+++ b/providers/implementations/ciphers/ciphercommon_ccm.c
@@ -65,7 +65,7 @@ static size_t ccm_get_ivlen(PROV_CCM_CTX *ctx)
     return 15 - ctx->l;
 }
 
-int ccm_set_ctx_params(void *vctx, const OSSL_PARAM params[])
+int ossl_ccm_set_ctx_params(void *vctx, const OSSL_PARAM params[])
 {
     PROV_CCM_CTX *ctx = (PROV_CCM_CTX *)vctx;
     const OSSL_PARAM *p;
@@ -138,7 +138,7 @@ int ccm_set_ctx_params(void *vctx, const OSSL_PARAM params[])
     return 1;
 }
 
-int ccm_get_ctx_params(void *vctx, OSSL_PARAM params[])
+int ossl_ccm_get_ctx_params(void *vctx, OSSL_PARAM params[])
 {
     PROV_CCM_CTX *ctx = (PROV_CCM_CTX *)vctx;
     OSSL_PARAM *p;
@@ -244,21 +244,21 @@ static int ccm_init(void *vctx, const unsigned char *key, size_t keylen,
     return 1;
 }
 
-int ccm_einit(void *vctx, const unsigned char *key, size_t keylen,
-                     const unsigned char *iv, size_t ivlen)
+int ossl_ccm_einit(void *vctx, const unsigned char *key, size_t keylen,
+                   const unsigned char *iv, size_t ivlen)
 {
     return ccm_init(vctx, key, keylen, iv, ivlen, 1);
 }
 
-int ccm_dinit(void *vctx, const unsigned char *key, size_t keylen,
-                     const unsigned char *iv, size_t ivlen)
+int ossl_ccm_dinit(void *vctx, const unsigned char *key, size_t keylen,
+                   const unsigned char *iv, size_t ivlen)
 {
     return ccm_init(vctx, key, keylen, iv, ivlen, 0);
 }
 
-int ccm_stream_update(void *vctx, unsigned char *out, size_t *outl,
-                             size_t outsize, const unsigned char *in,
-                             size_t inl)
+int ossl_ccm_stream_update(void *vctx, unsigned char *out, size_t *outl,
+                           size_t outsize, const unsigned char *in,
+                           size_t inl)
 {
     PROV_CCM_CTX *ctx = (PROV_CCM_CTX *)vctx;
 
@@ -274,8 +274,8 @@ int ccm_stream_update(void *vctx, unsigned char *out, size_t *outl,
     return 1;
 }
 
-int ccm_stream_final(void *vctx, unsigned char *out, size_t *outl,
-                            size_t outsize)
+int ossl_ccm_stream_final(void *vctx, unsigned char *out, size_t *outl,
+                          size_t outsize)
 {
     PROV_CCM_CTX *ctx = (PROV_CCM_CTX *)vctx;
     int i;
@@ -291,8 +291,8 @@ int ccm_stream_final(void *vctx, unsigned char *out, size_t *outl,
     return 1;
 }
 
-int ccm_cipher(void *vctx, unsigned char *out, size_t *outl, size_t outsize,
-               const unsigned char *in, size_t inl)
+int ossl_ccm_cipher(void *vctx, unsigned char *out, size_t *outl, size_t outsize,
+                    const unsigned char *in, size_t inl)
 {
     PROV_CCM_CTX *ctx = (PROV_CCM_CTX *)vctx;
 
@@ -432,7 +432,7 @@ err:
     return rv;
 }
 
-void ccm_initctx(PROV_CCM_CTX *ctx, size_t keybits, const PROV_CCM_HW *hw)
+void ossl_ccm_initctx(PROV_CCM_CTX *ctx, size_t keybits, const PROV_CCM_HW *hw)
 {
     ctx->keylen = keybits / 8;
     ctx->key_set = 0;
@@ -444,4 +444,3 @@ void ccm_initctx(PROV_CCM_CTX *ctx, size_t keybits, const PROV_CCM_HW *hw)
     ctx->tls_aad_len = UNINITIALISED_SIZET;
     ctx->hw = hw;
 }
-

--- a/providers/implementations/ciphers/ciphercommon_ccm_hw.c
+++ b/providers/implementations/ciphers/ciphercommon_ccm_hw.c
@@ -10,26 +10,27 @@
 #include "prov/ciphercommon.h"
 #include "prov/ciphercommon_ccm.h"
 
-int ccm_generic_setiv(PROV_CCM_CTX *ctx, const unsigned char *nonce,
-                      size_t nlen, size_t mlen)
+int ossl_ccm_generic_setiv(PROV_CCM_CTX *ctx, const unsigned char *nonce,
+                           size_t nlen, size_t mlen)
 {
     return CRYPTO_ccm128_setiv(&ctx->ccm_ctx, nonce, nlen, mlen) == 0;
 }
 
-int ccm_generic_setaad(PROV_CCM_CTX *ctx, const unsigned char *aad, size_t alen)
+int ossl_ccm_generic_setaad(PROV_CCM_CTX *ctx, const unsigned char *aad,
+                            size_t alen)
 {
     CRYPTO_ccm128_aad(&ctx->ccm_ctx, aad, alen);
     return 1;
 }
 
-int ccm_generic_gettag(PROV_CCM_CTX *ctx, unsigned char *tag, size_t tlen)
+int ossl_ccm_generic_gettag(PROV_CCM_CTX *ctx, unsigned char *tag, size_t tlen)
 {
     return CRYPTO_ccm128_tag(&ctx->ccm_ctx, tag, tlen) > 0;
 }
 
-int ccm_generic_auth_encrypt(PROV_CCM_CTX *ctx, const unsigned char *in,
-                             unsigned char *out, size_t len,
-                             unsigned char *tag, size_t taglen)
+int ossl_ccm_generic_auth_encrypt(PROV_CCM_CTX *ctx, const unsigned char *in,
+                                  unsigned char *out, size_t len,
+                                  unsigned char *tag, size_t taglen)
 {
     int rv;
 
@@ -44,9 +45,9 @@ int ccm_generic_auth_encrypt(PROV_CCM_CTX *ctx, const unsigned char *in,
     return rv;
 }
 
-int ccm_generic_auth_decrypt(PROV_CCM_CTX *ctx, const unsigned char *in,
-                             unsigned char *out, size_t len,
-                             unsigned char *expected_tag, size_t taglen)
+int ossl_ccm_generic_auth_decrypt(PROV_CCM_CTX *ctx, const unsigned char *in,
+                                  unsigned char *out, size_t len,
+                                  unsigned char *expected_tag, size_t taglen)
 {
     int rv = 0;
 
@@ -66,4 +67,3 @@ int ccm_generic_auth_decrypt(PROV_CCM_CTX *ctx, const unsigned char *in,
         OPENSSL_cleanse(out, len);
     return rv;
 }
-

--- a/providers/implementations/ciphers/ciphercommon_gcm.c
+++ b/providers/implementations/ciphers/ciphercommon_gcm.c
@@ -25,8 +25,8 @@ static int gcm_cipher_internal(PROV_GCM_CTX *ctx, unsigned char *out,
                                size_t *padlen, const unsigned char *in,
                                size_t len);
 
-void gcm_initctx(void *provctx, PROV_GCM_CTX *ctx, size_t keybits,
-                 const PROV_GCM_HW *hw, size_t ivlen_min)
+void ossl_gcm_initctx(void *provctx, PROV_GCM_CTX *ctx, size_t keybits,
+                      const PROV_GCM_HW *hw, size_t ivlen_min)
 {
     ctx->pad = 1;
     ctx->mode = EVP_CIPH_GCM_MODE;
@@ -69,14 +69,14 @@ static int gcm_init(void *vctx, const unsigned char *key, size_t keylen,
     return 1;
 }
 
-int gcm_einit(void *vctx, const unsigned char *key, size_t keylen,
-              const unsigned char *iv, size_t ivlen)
+int ossl_gcm_einit(void *vctx, const unsigned char *key, size_t keylen,
+                   const unsigned char *iv, size_t ivlen)
 {
     return gcm_init(vctx, key, keylen, iv, ivlen, 1);
 }
 
-int gcm_dinit(void *vctx, const unsigned char *key, size_t keylen,
-              const unsigned char *iv, size_t ivlen)
+int ossl_gcm_dinit(void *vctx, const unsigned char *key, size_t keylen,
+                   const unsigned char *iv, size_t ivlen)
 {
     return gcm_init(vctx, key, keylen, iv, ivlen, 0);
 }
@@ -129,7 +129,7 @@ static int setivinv(PROV_GCM_CTX *ctx, unsigned char *in, size_t inl)
     return 1;
 }
 
-int gcm_get_ctx_params(void *vctx, OSSL_PARAM params[])
+int ossl_gcm_get_ctx_params(void *vctx, OSSL_PARAM params[])
 {
     PROV_GCM_CTX *ctx = (PROV_GCM_CTX *)vctx;
     OSSL_PARAM *p;
@@ -216,7 +216,7 @@ int gcm_get_ctx_params(void *vctx, OSSL_PARAM params[])
     return 1;
 }
 
-int gcm_set_ctx_params(void *vctx, const OSSL_PARAM params[])
+int ossl_gcm_set_ctx_params(void *vctx, const OSSL_PARAM params[])
 {
     PROV_GCM_CTX *ctx = (PROV_GCM_CTX *)vctx;
     const OSSL_PARAM *p;
@@ -287,8 +287,8 @@ int gcm_set_ctx_params(void *vctx, const OSSL_PARAM params[])
     return 1;
 }
 
-int gcm_stream_update(void *vctx, unsigned char *out, size_t *outl,
-                      size_t outsize, const unsigned char *in, size_t inl)
+int ossl_gcm_stream_update(void *vctx, unsigned char *out, size_t *outl,
+                           size_t outsize, const unsigned char *in, size_t inl)
 {
     PROV_GCM_CTX *ctx = (PROV_GCM_CTX *)vctx;
 
@@ -309,8 +309,8 @@ int gcm_stream_update(void *vctx, unsigned char *out, size_t *outl,
     return 1;
 }
 
-int gcm_stream_final(void *vctx, unsigned char *out, size_t *outl,
-                     size_t outsize)
+int ossl_gcm_stream_final(void *vctx, unsigned char *out, size_t *outl,
+                          size_t outsize)
 {
     PROV_GCM_CTX *ctx = (PROV_GCM_CTX *)vctx;
     int i;
@@ -326,9 +326,9 @@ int gcm_stream_final(void *vctx, unsigned char *out, size_t *outl,
     return 1;
 }
 
-int gcm_cipher(void *vctx,
-               unsigned char *out, size_t *outl, size_t outsize,
-               const unsigned char *in, size_t inl)
+int ossl_gcm_cipher(void *vctx,
+                    unsigned char *out, size_t *outl, size_t outsize,
+                    const unsigned char *in, size_t inl)
 {
     PROV_GCM_CTX *ctx = (PROV_GCM_CTX *)vctx;
 
@@ -553,4 +553,3 @@ err:
     *padlen = plen;
     return rv;
 }
-

--- a/providers/implementations/ciphers/ciphercommon_gcm_hw.c
+++ b/providers/implementations/ciphers/ciphercommon_gcm_hw.c
@@ -11,19 +11,20 @@
 #include "prov/ciphercommon_gcm.h"
 
 
-int gcm_setiv(PROV_GCM_CTX *ctx, const unsigned char *iv, size_t ivlen)
+int ossl_gcm_setiv(PROV_GCM_CTX *ctx, const unsigned char *iv, size_t ivlen)
 {
     CRYPTO_gcm128_setiv(&ctx->gcm, iv, ivlen);
     return 1;
 }
 
-int gcm_aad_update(PROV_GCM_CTX *ctx, const unsigned char *aad, size_t aad_len)
+int ossl_gcm_aad_update(PROV_GCM_CTX *ctx, const unsigned char *aad,
+                        size_t aad_len)
 {
     return CRYPTO_gcm128_aad(&ctx->gcm, aad, aad_len) == 0;
 }
 
-int gcm_cipher_update(PROV_GCM_CTX *ctx, const unsigned char *in,
-                      size_t len, unsigned char *out)
+int ossl_gcm_cipher_update(PROV_GCM_CTX *ctx, const unsigned char *in,
+                           size_t len, unsigned char *out)
 {
     if (ctx->enc) {
         if (CRYPTO_gcm128_encrypt(&ctx->gcm, in, out, len))
@@ -35,7 +36,7 @@ int gcm_cipher_update(PROV_GCM_CTX *ctx, const unsigned char *in,
     return 1;
 }
 
-int gcm_cipher_final(PROV_GCM_CTX *ctx, unsigned char *tag)
+int ossl_gcm_cipher_final(PROV_GCM_CTX *ctx, unsigned char *tag)
 {
     if (ctx->enc) {
         CRYPTO_gcm128_tag(&ctx->gcm, tag, GCM_TAG_MAX_SIZE);
@@ -47,9 +48,9 @@ int gcm_cipher_final(PROV_GCM_CTX *ctx, unsigned char *tag)
     return 1;
 }
 
-int gcm_one_shot(PROV_GCM_CTX *ctx, unsigned char *aad, size_t aad_len,
-                 const unsigned char *in, size_t in_len,
-                 unsigned char *out, unsigned char *tag, size_t tag_len)
+int ossl_gcm_one_shot(PROV_GCM_CTX *ctx, unsigned char *aad, size_t aad_len,
+                      const unsigned char *in, size_t in_len,
+                      unsigned char *out, unsigned char *tag, size_t tag_len)
 {
     int ret = 0;
 

--- a/providers/implementations/ciphers/ciphercommon_local.h
+++ b/providers/implementations/ciphers/ciphercommon_local.h
@@ -9,8 +9,8 @@
 
 #include "prov/ciphercommon.h"
 
-void padblock(unsigned char *buf, size_t *buflen, size_t blocksize);
-int unpadblock(unsigned char *buf, size_t *buflen, size_t blocksize);
-int tlsunpadblock(OSSL_LIB_CTX *libctx, unsigned int tlsversion,
-                  unsigned char *buf, size_t *buflen, size_t blocksize,
-                  unsigned char **mac, int *alloced, size_t macsize, int aead);
+void ossl_cipher_padblock(unsigned char *buf, size_t *buflen, size_t blocksize);
+int ossl_cipher_unpadblock(unsigned char *buf, size_t *buflen, size_t blocksize);
+int ossl_cipher_tlsunpadblock(OSSL_LIB_CTX *libctx, unsigned int tlsversion,
+                              unsigned char *buf, size_t *buflen, size_t blocksize,
+                              unsigned char **mac, int *alloced, size_t macsize, int aead);

--- a/providers/implementations/include/prov/ciphercommon.h
+++ b/providers/implementations/include/prov/ciphercommon.h
@@ -353,8 +353,9 @@ const OSSL_PARAM * name##_settable_ctx_params(ossl_unused void *provctx)       \
 int ossl_cipher_generic_initiv(PROV_CIPHER_CTX *ctx, const unsigned char *iv,
                                size_t ivlen);
 
-size_t fillblock(unsigned char *buf, size_t *buflen, size_t blocksize,
-                 const unsigned char **in, size_t *inlen);
-int trailingdata(unsigned char *buf, size_t *buflen, size_t blocksize,
-                 const unsigned char **in, size_t *inlen);
-
+size_t ossl_cipher_fillblock(unsigned char *buf, size_t *buflen,
+                             size_t blocksize,
+                             const unsigned char **in, size_t *inlen);
+int ossl_cipher_trailingdata(unsigned char *buf, size_t *buflen,
+                             size_t blocksize,
+                             const unsigned char **in, size_t *inlen);

--- a/providers/implementations/include/prov/ciphercommon_aead.h
+++ b/providers/implementations/include/prov/ciphercommon_aead.h
@@ -16,7 +16,7 @@ static OSSL_FUNC_cipher_get_params_fn alg##_##kbits##_##lc##_get_params;       \
 static int alg##_##kbits##_##lc##_get_params(OSSL_PARAM params[])              \
 {                                                                              \
     return ossl_cipher_generic_get_params(params, EVP_CIPH_##UCMODE##_MODE,    \
-                                     flags, kbits, blkbits, ivbits);           \
+                                          flags, kbits, blkbits, ivbits);      \
 }                                                                              \
 static OSSL_FUNC_cipher_newctx_fn alg##kbits##lc##_newctx;                     \
 static void * alg##kbits##lc##_newctx(void *provctx)                           \
@@ -26,17 +26,17 @@ static void * alg##kbits##lc##_newctx(void *provctx)                           \
 const OSSL_DISPATCH ossl_##alg##kbits##lc##_functions[] = {                    \
     { OSSL_FUNC_CIPHER_NEWCTX, (void (*)(void))alg##kbits##lc##_newctx },      \
     { OSSL_FUNC_CIPHER_FREECTX, (void (*)(void))alg##_##lc##_freectx },        \
-    { OSSL_FUNC_CIPHER_ENCRYPT_INIT, (void (*)(void)) lc##_einit },            \
-    { OSSL_FUNC_CIPHER_DECRYPT_INIT, (void (*)(void)) lc##_dinit },            \
-    { OSSL_FUNC_CIPHER_UPDATE, (void (*)(void)) lc##_stream_update },          \
-    { OSSL_FUNC_CIPHER_FINAL, (void (*)(void)) lc##_stream_final },            \
-    { OSSL_FUNC_CIPHER_CIPHER, (void (*)(void)) lc##_cipher },                 \
+    { OSSL_FUNC_CIPHER_ENCRYPT_INIT, (void (*)(void))ossl_##lc##_einit },      \
+    { OSSL_FUNC_CIPHER_DECRYPT_INIT, (void (*)(void))ossl_##lc##_dinit },      \
+    { OSSL_FUNC_CIPHER_UPDATE, (void (*)(void))ossl_##lc##_stream_update },    \
+    { OSSL_FUNC_CIPHER_FINAL, (void (*)(void))ossl_##lc##_stream_final },      \
+    { OSSL_FUNC_CIPHER_CIPHER, (void (*)(void))ossl_##lc##_cipher },           \
     { OSSL_FUNC_CIPHER_GET_PARAMS,                                             \
       (void (*)(void)) alg##_##kbits##_##lc##_get_params },                    \
     { OSSL_FUNC_CIPHER_GET_CTX_PARAMS,                                         \
-      (void (*)(void)) lc##_get_ctx_params },                                  \
+      (void (*)(void)) ossl_##lc##_get_ctx_params },                           \
     { OSSL_FUNC_CIPHER_SET_CTX_PARAMS,                                         \
-      (void (*)(void)) lc##_set_ctx_params },                                  \
+      (void (*)(void)) ossl_##lc##_set_ctx_params },                           \
     { OSSL_FUNC_CIPHER_GETTABLE_PARAMS,                                        \
       (void (*)(void))ossl_cipher_generic_gettable_params },                   \
     { OSSL_FUNC_CIPHER_GETTABLE_CTX_PARAMS,                                    \

--- a/providers/implementations/include/prov/ciphercommon_ccm.h
+++ b/providers/implementations/include/prov/ciphercommon_ccm.h
@@ -78,22 +78,23 @@ struct prov_ccm_hw_st {
     OSSL_CCM_gettag_fn gettag;
 };
 
-OSSL_FUNC_cipher_encrypt_init_fn ccm_einit;
-OSSL_FUNC_cipher_decrypt_init_fn ccm_dinit;
-OSSL_FUNC_cipher_get_ctx_params_fn ccm_get_ctx_params;
-OSSL_FUNC_cipher_set_ctx_params_fn ccm_set_ctx_params;
-OSSL_FUNC_cipher_update_fn ccm_stream_update;
-OSSL_FUNC_cipher_final_fn ccm_stream_final;
-OSSL_FUNC_cipher_cipher_fn ccm_cipher;
-void ccm_initctx(PROV_CCM_CTX *ctx, size_t keybits, const PROV_CCM_HW *hw);
+OSSL_FUNC_cipher_encrypt_init_fn ossl_ccm_einit;
+OSSL_FUNC_cipher_decrypt_init_fn ossl_ccm_dinit;
+OSSL_FUNC_cipher_get_ctx_params_fn ossl_ccm_get_ctx_params;
+OSSL_FUNC_cipher_set_ctx_params_fn ossl_ccm_set_ctx_params;
+OSSL_FUNC_cipher_update_fn ossl_ccm_stream_update;
+OSSL_FUNC_cipher_final_fn ossl_ccm_stream_final;
+OSSL_FUNC_cipher_cipher_fn ossl_ccm_cipher;
+void ossl_ccm_initctx(PROV_CCM_CTX *ctx, size_t keybits, const PROV_CCM_HW *hw);
 
-int ccm_generic_setiv(PROV_CCM_CTX *ctx, const unsigned char *nonce,
-                      size_t nlen, size_t mlen);
-int ccm_generic_setaad(PROV_CCM_CTX *ctx, const unsigned char *aad, size_t alen);
-int ccm_generic_gettag(PROV_CCM_CTX *ctx, unsigned char *tag, size_t tlen);
-int ccm_generic_auth_encrypt(PROV_CCM_CTX *ctx, const unsigned char *in,
-                             unsigned char *out, size_t len,
-                             unsigned char *tag, size_t taglen);
-int ccm_generic_auth_decrypt(PROV_CCM_CTX *ctx, const unsigned char *in,
-                             unsigned char *out, size_t len,
-                             unsigned char *expected_tag, size_t taglen);
+int ossl_ccm_generic_setiv(PROV_CCM_CTX *ctx, const unsigned char *nonce,
+                           size_t nlen, size_t mlen);
+int ossl_ccm_generic_setaad(PROV_CCM_CTX *ctx, const unsigned char *aad,
+                            size_t alen);
+int ossl_ccm_generic_gettag(PROV_CCM_CTX *ctx, unsigned char *tag, size_t tlen);
+int ossl_ccm_generic_auth_encrypt(PROV_CCM_CTX *ctx, const unsigned char *in,
+                                  unsigned char *out, size_t len,
+                                  unsigned char *tag, size_t taglen);
+int ossl_ccm_generic_auth_decrypt(PROV_CCM_CTX *ctx, const unsigned char *in,
+                                  unsigned char *out, size_t len,
+                                  unsigned char *expected_tag, size_t taglen);

--- a/providers/implementations/include/prov/ciphercommon_gcm.h
+++ b/providers/implementations/include/prov/ciphercommon_gcm.h
@@ -102,25 +102,25 @@ struct prov_gcm_hw_st {
   OSSL_GCM_oneshot_fn oneshot;
 };
 
-OSSL_FUNC_cipher_encrypt_init_fn gcm_einit;
-OSSL_FUNC_cipher_decrypt_init_fn gcm_dinit;
-OSSL_FUNC_cipher_get_ctx_params_fn gcm_get_ctx_params;
-OSSL_FUNC_cipher_set_ctx_params_fn gcm_set_ctx_params;
-OSSL_FUNC_cipher_cipher_fn gcm_cipher;
-OSSL_FUNC_cipher_update_fn gcm_stream_update;
-OSSL_FUNC_cipher_final_fn gcm_stream_final;
-void gcm_initctx(void *provctx, PROV_GCM_CTX *ctx, size_t keybits,
-                 const PROV_GCM_HW *hw, size_t ivlen_min);
+OSSL_FUNC_cipher_encrypt_init_fn ossl_gcm_einit;
+OSSL_FUNC_cipher_decrypt_init_fn ossl_gcm_dinit;
+OSSL_FUNC_cipher_get_ctx_params_fn ossl_gcm_get_ctx_params;
+OSSL_FUNC_cipher_set_ctx_params_fn ossl_gcm_set_ctx_params;
+OSSL_FUNC_cipher_cipher_fn ossl_gcm_cipher;
+OSSL_FUNC_cipher_update_fn ossl_gcm_stream_update;
+OSSL_FUNC_cipher_final_fn ossl_gcm_stream_final;
+void ossl_gcm_initctx(void *provctx, PROV_GCM_CTX *ctx, size_t keybits,
+                      const PROV_GCM_HW *hw, size_t ivlen_min);
 
-int gcm_setiv(PROV_GCM_CTX *ctx, const unsigned char *iv, size_t ivlen);
-int gcm_aad_update(PROV_GCM_CTX *ctx, const unsigned char *aad,
-                   size_t aad_len);
-int gcm_cipher_final(PROV_GCM_CTX *ctx, unsigned char *tag);
-int gcm_one_shot(PROV_GCM_CTX *ctx, unsigned char *aad, size_t aad_len,
-                 const unsigned char *in, size_t in_len,
-                 unsigned char *out, unsigned char *tag, size_t tag_len);
-int gcm_cipher_update(PROV_GCM_CTX *ctx, const unsigned char *in,
-                      size_t len, unsigned char *out);
+int ossl_gcm_setiv(PROV_GCM_CTX *ctx, const unsigned char *iv, size_t ivlen);
+int ossl_gcm_aad_update(PROV_GCM_CTX *ctx, const unsigned char *aad,
+                        size_t aad_len);
+int ossl_gcm_cipher_final(PROV_GCM_CTX *ctx, unsigned char *tag);
+int ossl_gcm_one_shot(PROV_GCM_CTX *ctx, unsigned char *aad, size_t aad_len,
+                      const unsigned char *in, size_t in_len,
+                      unsigned char *out, unsigned char *tag, size_t tag_len);
+int ossl_gcm_cipher_update(PROV_GCM_CTX *ctx, const unsigned char *in,
+                           size_t len, unsigned char *out);
 
 #define GCM_HW_SET_KEY_CTR_FN(ks, fn_set_enc_key, fn_block, fn_ctr)            \
     ctx->ks = ks;                                                              \


### PR DESCRIPTION
Partial fix for #12964

This add ossl_ names for the following symbols.

chacha20_dinit, chacha20_einit, chacha20_initctx,
ccm_cipher, ccm_dinit, ccm_einit, ccm_generic_auth_decrypt, ccm_generic_auth_encrypt,
ccm_generic_gettag, ccm_generic_setaad, ccm_generic_setiv, ccm_get_ctx_params,
ccm_initctx, ccm_set_ctx_params, ccm_stream_final, ccm_stream_update
gcm_aad_update, gcm_cipher, gcm_cipher_final, gcm_cipher_update
gcm_dinit, gcm_einit, gcm_get_ctx_params, gcm_initctx, gcm_one_shot
gcm_set_ctx_params, gcm_setiv, gcm_stream_final, gcm_stream_update
tdes_dinit, tdes_dupctx, tdes_einit, tdes_freectx
tdes_get_ctx_params, tdes_gettable_ctx_params, tdes_newctx
PROV_CIPHER_HW_des_*,
padblock, unpadblock, tlsunpadblock, fillblock, trailingdata

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
