### PR TITLE
 Fix external symbols related to provider digests and key securitychecks

### DIFF
--- a/crypto/evp/legacy_blake2.c
+++ b/crypto/evp/legacy_blake2.c
@@ -11,11 +11,11 @@
 #include "prov/blake2.h"        /* diverse BLAKE2 macros */
 #include "legacy_meth.h"
 
-#define blake2b_init blake2b512_init
-#define blake2s_init blake2s256_init
+#define ossl_blake2b_init ossl_blake2b512_init
+#define ossl_blake2s_init ossl_blake2s256_init
 
-IMPLEMENT_LEGACY_EVP_MD_METH_LC(blake2s_int, blake2s)
-IMPLEMENT_LEGACY_EVP_MD_METH_LC(blake2b_int, blake2b)
+IMPLEMENT_LEGACY_EVP_MD_METH_LC(blake2s_int, ossl_blake2s)
+IMPLEMENT_LEGACY_EVP_MD_METH_LC(blake2b_int, ossl_blake2b)
 
 static const EVP_MD blake2b_md = {
     NID_blake2b512,

--- a/providers/common/digest_to_nid.c
+++ b/providers/common/digest_to_nid.c
@@ -20,7 +20,7 @@
  * Internal library code deals with NIDs, so we need to translate from a name.
  * We do so using EVP_MD_is_a(), and therefore need a name to NID map.
  */
-int digest_md_to_nid(const EVP_MD *md, const OSSL_ITEM *it, size_t it_len)
+int ossl_digest_md_to_nid(const EVP_MD *md, const OSSL_ITEM *it, size_t it_len)
 {
     size_t i;
 
@@ -37,7 +37,7 @@ int digest_md_to_nid(const EVP_MD *md, const OSSL_ITEM *it, size_t it_len)
  * Retrieve one of the FIPs approved hash algorithms by nid.
  * See FIPS 180-4 "Secure Hash Standard" and FIPS 202 - SHA-3.
  */
-int digest_get_approved_nid(const EVP_MD *md)
+int ossl_digest_get_approved_nid(const EVP_MD *md)
 {
     static const OSSL_ITEM name_to_nid[] = {
         { NID_sha1,      OSSL_DIGEST_NAME_SHA1      },
@@ -53,5 +53,5 @@ int digest_get_approved_nid(const EVP_MD *md)
         { NID_sha3_512,  OSSL_DIGEST_NAME_SHA3_512  },
     };
 
-    return digest_md_to_nid(md, name_to_nid, OSSL_NELEM(name_to_nid));
+    return ossl_digest_md_to_nid(md, name_to_nid, OSSL_NELEM(name_to_nid));
 }

--- a/providers/common/include/prov/securitycheck.h
+++ b/providers/common/include/prov/securitycheck.h
@@ -11,17 +11,17 @@
 
 /* Functions that are common */
 int ossl_rsa_check_key(const RSA *rsa, int protect);
-int ec_check_key(const EC_KEY *ec, int protect);
-int dsa_check_key(const DSA *dsa, int sign);
-int dh_check_key(const DH *dh);
+int ossl_ec_check_key(const EC_KEY *ec, int protect);
+int ossl_dsa_check_key(const DSA *dsa, int sign);
+int ossl_dh_check_key(const DH *dh);
 
-int digest_is_allowed(const EVP_MD *md);
-int digest_get_approved_nid_with_sha1(const EVP_MD *md, int sha1_allowed);
+int ossl_digest_is_allowed(const EVP_MD *md);
+int ossl_digest_get_approved_nid_with_sha1(const EVP_MD *md, int sha1_allowed);
 
 /* Functions that are common */
-int digest_md_to_nid(const EVP_MD *md, const OSSL_ITEM *it, size_t it_len);
-int digest_get_approved_nid(const EVP_MD *md);
+int ossl_digest_md_to_nid(const EVP_MD *md, const OSSL_ITEM *it, size_t it_len);
+int ossl_digest_get_approved_nid(const EVP_MD *md);
 
 /* Functions that have different implementations for the FIPS_MODULE */
-int digest_rsa_sign_get_md_nid(const EVP_MD *md, int sha1_allowed);
-int securitycheck_enabled(void);
+int ossl_digest_rsa_sign_get_md_nid(const EVP_MD *md, int sha1_allowed);
+int ossl_securitycheck_enabled(void);

--- a/providers/common/securitycheck.c
+++ b/providers/common/securitycheck.c
@@ -28,7 +28,7 @@
 int ossl_rsa_check_key(const RSA *rsa, int protect)
 {
 #if !defined(OPENSSL_NO_FIPS_SECURITYCHECKS)
-    if (securitycheck_enabled()) {
+    if (ossl_securitycheck_enabled()) {
         int sz = RSA_bits(rsa);
 
         return protect ? (sz >= 2048) : (sz >= 1024);
@@ -52,10 +52,10 @@ int ossl_rsa_check_key(const RSA *rsa, int protect)
  * https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-131Ar2.pdf
  * "Table 2"
  */
-int ec_check_key(const EC_KEY *ec, int protect)
+int ossl_ec_check_key(const EC_KEY *ec, int protect)
 {
 # if !defined(OPENSSL_NO_FIPS_SECURITYCHECKS)
-    if (securitycheck_enabled()) {
+    if (ossl_securitycheck_enabled()) {
         int nid, strength;
         const char *curve_name;
         const EC_GROUP *group = EC_KEY_get0_group(ec);
@@ -110,10 +110,10 @@ int ec_check_key(const EC_KEY *ec, int protect)
  * https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-131Ar2.pdf
  * "Table 2"
  */
-int dsa_check_key(const DSA *dsa, int sign)
+int ossl_dsa_check_key(const DSA *dsa, int sign)
 {
 # if !defined(OPENSSL_NO_FIPS_SECURITYCHECKS)
-    if (securitycheck_enabled()) {
+    if (ossl_securitycheck_enabled()) {
         size_t L, N;
         const BIGNUM *p, *q;
 
@@ -154,10 +154,10 @@ int dsa_check_key(const DSA *dsa, int sign)
  * "Section 5.5.1.1FFC Domain Parameter Selection/Generation" and
  * "Appendix D" FFC Safe-prime Groups
  */
-int dh_check_key(const DH *dh)
+int ossl_dh_check_key(const DH *dh)
 {
 # if !defined(OPENSSL_NO_FIPS_SECURITYCHECKS)
-    if (securitycheck_enabled()) {
+    if (ossl_securitycheck_enabled()) {
         size_t L, N;
         const BIGNUM *p, *q;
 
@@ -187,12 +187,12 @@ int dh_check_key(const DH *dh)
 }
 #endif /* OPENSSL_NO_DH */
 
-int digest_get_approved_nid_with_sha1(const EVP_MD *md, int sha1_allowed)
+int ossl_digest_get_approved_nid_with_sha1(const EVP_MD *md, int sha1_allowed)
 {
-    int mdnid = digest_get_approved_nid(md);
+    int mdnid = ossl_digest_get_approved_nid(md);
 
 # if !defined(OPENSSL_NO_FIPS_SECURITYCHECKS)
-    if (securitycheck_enabled()) {
+    if (ossl_securitycheck_enabled()) {
         if (mdnid == NID_sha1 && !sha1_allowed)
             mdnid = NID_undef;
     }
@@ -200,11 +200,11 @@ int digest_get_approved_nid_with_sha1(const EVP_MD *md, int sha1_allowed)
     return mdnid;
 }
 
-int digest_is_allowed(const EVP_MD *md)
+int ossl_digest_is_allowed(const EVP_MD *md)
 {
 # if !defined(OPENSSL_NO_FIPS_SECURITYCHECKS)
-    if (securitycheck_enabled())
-        return digest_get_approved_nid(md) != NID_undef;
+    if (ossl_securitycheck_enabled())
+        return ossl_digest_get_approved_nid(md) != NID_undef;
 # endif /* OPENSSL_NO_FIPS_SECURITYCHECKS */
     return 1;
 }

--- a/providers/common/securitycheck_default.c
+++ b/providers/common/securitycheck_default.c
@@ -17,12 +17,13 @@
 #include "internal/nelem.h"
 
 /* Disable the security checks in the default provider */
-int securitycheck_enabled(void)
+int ossl_securitycheck_enabled(void)
 {
     return 0;
 }
 
-int digest_rsa_sign_get_md_nid(const EVP_MD *md, ossl_unused int sha1_allowed)
+int ossl_digest_rsa_sign_get_md_nid(const EVP_MD *md,
+                                    ossl_unused int sha1_allowed)
 {
     int mdnid;
 
@@ -35,8 +36,8 @@ int digest_rsa_sign_get_md_nid(const EVP_MD *md, ossl_unused int sha1_allowed)
         { NID_ripemd160, OSSL_DIGEST_NAME_RIPEMD160 },
     };
 
-    mdnid = digest_get_approved_nid_with_sha1(md, 1);
+    mdnid = ossl_digest_get_approved_nid_with_sha1(md, 1);
     if (mdnid == NID_undef)
-        mdnid = digest_md_to_nid(md, name_to_nid, OSSL_NELEM(name_to_nid));
+        mdnid = ossl_digest_md_to_nid(md, name_to_nid, OSSL_NELEM(name_to_nid));
     return mdnid;
 }

--- a/providers/common/securitycheck_fips.c
+++ b/providers/common/securitycheck_fips.c
@@ -21,7 +21,7 @@
 
 extern int FIPS_security_check_enabled(void);
 
-int securitycheck_enabled(void)
+int ossl_securitycheck_enabled(void)
 {
 #if !defined(OPENSSL_NO_FIPS_SECURITYCHECKS)
     return FIPS_security_check_enabled();
@@ -30,11 +30,11 @@ int securitycheck_enabled(void)
 #endif /* OPENSSL_NO_FIPS_SECURITYCHECKS */
 }
 
-int digest_rsa_sign_get_md_nid(const EVP_MD *md, int sha1_allowed)
+int ossl_digest_rsa_sign_get_md_nid(const EVP_MD *md, int sha1_allowed)
 {
 #if !defined(OPENSSL_NO_FIPS_SECURITYCHECKS)
-    if (securitycheck_enabled())
-        return digest_get_approved_nid_with_sha1(md, sha1_allowed);
+    if (ossl_securitycheck_enabled())
+        return ossl_digest_get_approved_nid_with_sha1(md, sha1_allowed);
 #endif /* OPENSSL_NO_FIPS_SECURITYCHECKS */
-    return digest_get_approved_nid(md);
+    return ossl_digest_get_approved_nid(md);
 }

--- a/providers/implementations/digests/blake2_prov.c
+++ b/providers/implementations/digests/blake2_prov.c
@@ -12,31 +12,33 @@
 #include "prov/digestcommon.h"
 #include "prov/implementations.h"
 
-OSSL_FUNC_digest_init_fn blake2s256_init;
-OSSL_FUNC_digest_init_fn blake2b512_init;
+OSSL_FUNC_digest_init_fn ossl_blake2s256_init;
+OSSL_FUNC_digest_init_fn ossl_blake2b512_init;
 
-int blake2s256_init(void *ctx)
+int ossl_blake2s256_init(void *ctx)
 {
     BLAKE2S_PARAM P;
 
-    blake2s_param_init(&P);
-    return blake2s_init((BLAKE2S_CTX *)ctx, &P);
+    ossl_blake2s_param_init(&P);
+    return ossl_blake2s_init((BLAKE2S_CTX *)ctx, &P);
 }
 
-int blake2b512_init(void *ctx)
+int ossl_blake2b512_init(void *ctx)
 {
     BLAKE2B_PARAM P;
 
-    blake2b_param_init(&P);
-    return blake2b_init((BLAKE2B_CTX *)ctx, &P);
+    ossl_blake2b_param_init(&P);
+    return ossl_blake2b_init((BLAKE2B_CTX *)ctx, &P);
 }
 
 /* ossl_blake2s256_functions */
 IMPLEMENT_digest_functions(blake2s256, BLAKE2S_CTX,
                            BLAKE2S_BLOCKBYTES, BLAKE2S_DIGEST_LENGTH, 0,
-                           blake2s256_init, blake2s_update, blake2s_final)
+                           ossl_blake2s256_init, ossl_blake2s_update,
+                           ossl_blake2s_final)
 
 /* ossl_blake2b512_functions */
 IMPLEMENT_digest_functions(blake2b512, BLAKE2B_CTX,
                            BLAKE2B_BLOCKBYTES, BLAKE2B_DIGEST_LENGTH, 0,
-                           blake2b512_init, blake2b_update, blake2b_final)
+                           ossl_blake2b512_init, ossl_blake2b_update,
+                           ossl_blake2b_final)

--- a/providers/implementations/digests/blake2b_prov.c
+++ b/providers/implementations/digests/blake2b_prov.c
@@ -80,7 +80,7 @@ static void blake2b_init_param(BLAKE2B_CTX *S, const BLAKE2B_PARAM *P)
 }
 
 /* Initialize the parameter block with default values */
-void blake2b_param_init(BLAKE2B_PARAM *P)
+void ossl_blake2b_param_init(BLAKE2B_PARAM *P)
 {
     P->digest_length = BLAKE2B_DIGEST_LENGTH;
     P->key_length    = 0;
@@ -95,23 +95,25 @@ void blake2b_param_init(BLAKE2B_PARAM *P)
     memset(P->personal, 0, sizeof(P->personal));
 }
 
-void blake2b_param_set_digest_length(BLAKE2B_PARAM *P, uint8_t outlen)
+void ossl_blake2b_param_set_digest_length(BLAKE2B_PARAM *P, uint8_t outlen)
 {
     P->digest_length = outlen;
 }
 
-void blake2b_param_set_key_length(BLAKE2B_PARAM *P, uint8_t keylen)
+void ossl_blake2b_param_set_key_length(BLAKE2B_PARAM *P, uint8_t keylen)
 {
     P->key_length = keylen;
 }
 
-void blake2b_param_set_personal(BLAKE2B_PARAM *P, const uint8_t *personal, size_t len)
+void ossl_blake2b_param_set_personal(BLAKE2B_PARAM *P, const uint8_t *personal,
+                                     size_t len)
 {
     memcpy(P->personal, personal, len);
     memset(P->personal + len, 0, BLAKE2B_PERSONALBYTES - len);
 }
 
-void blake2b_param_set_salt(BLAKE2B_PARAM *P, const uint8_t *salt, size_t len)
+void ossl_blake2b_param_set_salt(BLAKE2B_PARAM *P, const uint8_t *salt,
+                                 size_t len)
 {
     memcpy(P->salt, salt, len);
     memset(P->salt + len, 0, BLAKE2B_SALTBYTES - len);
@@ -121,7 +123,7 @@ void blake2b_param_set_salt(BLAKE2B_PARAM *P, const uint8_t *salt, size_t len)
  * Initialize the hashing context with the given parameter block.
  * Always returns 1.
  */
-int blake2b_init(BLAKE2B_CTX *c, const BLAKE2B_PARAM *P)
+int ossl_blake2b_init(BLAKE2B_CTX *c, const BLAKE2B_PARAM *P)
 {
     blake2b_init_param(c, P);
     return 1;
@@ -131,7 +133,8 @@ int blake2b_init(BLAKE2B_CTX *c, const BLAKE2B_PARAM *P)
  * Initialize the hashing context with the given parameter block and key.
  * Always returns 1.
  */
-int blake2b_init_key(BLAKE2B_CTX *c, const BLAKE2B_PARAM *P, const void *key)
+int ossl_blake2b_init_key(BLAKE2B_CTX *c, const BLAKE2B_PARAM *P,
+                          const void *key)
 {
     blake2b_init_param(c, P);
 
@@ -140,7 +143,7 @@ int blake2b_init_key(BLAKE2B_CTX *c, const BLAKE2B_PARAM *P, const void *key)
         uint8_t block[BLAKE2B_BLOCKBYTES] = {0};
 
         memcpy(block, key, P->key_length);
-        blake2b_update(c, block, BLAKE2B_BLOCKBYTES);
+        ossl_blake2b_update(c, block, BLAKE2B_BLOCKBYTES);
         OPENSSL_cleanse(block, BLAKE2B_BLOCKBYTES);
     }
 
@@ -252,7 +255,7 @@ static void blake2b_compress(BLAKE2B_CTX *S,
 }
 
 /* Absorb the input data into the hash state.  Always returns 1. */
-int blake2b_update(BLAKE2B_CTX *c, const void *data, size_t datalen)
+int ossl_blake2b_update(BLAKE2B_CTX *c, const void *data, size_t datalen)
 {
     const uint8_t *in = data;
     size_t fill;
@@ -300,7 +303,7 @@ int blake2b_update(BLAKE2B_CTX *c, const void *data, size_t datalen)
  * Calculate the final hash and save it in md.
  * Always returns 1.
  */
-int blake2b_final(unsigned char *md, BLAKE2B_CTX *c)
+int ossl_blake2b_final(unsigned char *md, BLAKE2B_CTX *c)
 {
     uint8_t outbuffer[BLAKE2B_OUTBYTES] = {0};
     uint8_t *target = outbuffer;

--- a/providers/implementations/digests/blake2s_prov.c
+++ b/providers/implementations/digests/blake2s_prov.c
@@ -75,7 +75,7 @@ static void blake2s_init_param(BLAKE2S_CTX *S, const BLAKE2S_PARAM *P)
     }
 }
 
-void blake2s_param_init(BLAKE2S_PARAM *P)
+void ossl_blake2s_param_init(BLAKE2S_PARAM *P)
 {
     P->digest_length = BLAKE2S_DIGEST_LENGTH;
     P->key_length    = 0;
@@ -89,23 +89,25 @@ void blake2s_param_init(BLAKE2S_PARAM *P)
     memset(P->personal, 0, sizeof(P->personal));
 }
 
-void blake2s_param_set_digest_length(BLAKE2S_PARAM *P, uint8_t outlen)
+void ossl_blake2s_param_set_digest_length(BLAKE2S_PARAM *P, uint8_t outlen)
 {
     P->digest_length = outlen;
 }
 
-void blake2s_param_set_key_length(BLAKE2S_PARAM *P, uint8_t keylen)
+void ossl_blake2s_param_set_key_length(BLAKE2S_PARAM *P, uint8_t keylen)
 {
     P->key_length = keylen;
 }
 
-void blake2s_param_set_personal(BLAKE2S_PARAM *P, const uint8_t *personal, size_t len)
+void ossl_blake2s_param_set_personal(BLAKE2S_PARAM *P, const uint8_t *personal,
+                                     size_t len)
 {
     memcpy(P->personal, personal, len);
     memset(P->personal + len, 0, BLAKE2S_PERSONALBYTES - len);
 }
 
-void blake2s_param_set_salt(BLAKE2S_PARAM *P, const uint8_t *salt, size_t len)
+void ossl_blake2s_param_set_salt(BLAKE2S_PARAM *P, const uint8_t *salt,
+                                 size_t len)
 {
     memcpy(P->salt, salt, len);
     memset(P->salt + len, 0, BLAKE2S_SALTBYTES - len);}
@@ -114,7 +116,7 @@ void blake2s_param_set_salt(BLAKE2S_PARAM *P, const uint8_t *salt, size_t len)
  * Initialize the hashing context with the given parameter block.
  * Always returns 1.
  */
-int blake2s_init(BLAKE2S_CTX *c, const BLAKE2S_PARAM *P)
+int ossl_blake2s_init(BLAKE2S_CTX *c, const BLAKE2S_PARAM *P)
 {
     blake2s_init_param(c, P);
     return 1;
@@ -124,7 +126,8 @@ int blake2s_init(BLAKE2S_CTX *c, const BLAKE2S_PARAM *P)
  * Initialize the hashing context with the given parameter block and key.
  * Always returns 1.
  */
-int blake2s_init_key(BLAKE2S_CTX *c, const BLAKE2S_PARAM *P, const void *key)
+int ossl_blake2s_init_key(BLAKE2S_CTX *c, const BLAKE2S_PARAM *P,
+                          const void *key)
 {
     blake2s_init_param(c, P);
 
@@ -133,7 +136,7 @@ int blake2s_init_key(BLAKE2S_CTX *c, const BLAKE2S_PARAM *P, const void *key)
         uint8_t block[BLAKE2S_BLOCKBYTES] = {0};
 
         memcpy(block, key, P->key_length);
-        blake2s_update(c, block, BLAKE2S_BLOCKBYTES);
+        ossl_blake2s_update(c, block, BLAKE2S_BLOCKBYTES);
         OPENSSL_cleanse(block, BLAKE2S_BLOCKBYTES);
     }
 
@@ -243,7 +246,7 @@ static void blake2s_compress(BLAKE2S_CTX *S,
 }
 
 /* Absorb the input data into the hash state.  Always returns 1. */
-int blake2s_update(BLAKE2S_CTX *c, const void *data, size_t datalen)
+int ossl_blake2s_update(BLAKE2S_CTX *c, const void *data, size_t datalen)
 {
     const uint8_t *in = data;
     size_t fill;
@@ -291,7 +294,7 @@ int blake2s_update(BLAKE2S_CTX *c, const void *data, size_t datalen)
  * Calculate the final hash and save it in md.
  * Always returns 1.
  */
-int blake2s_final(unsigned char *md, BLAKE2S_CTX *c)
+int ossl_blake2s_final(unsigned char *md, BLAKE2S_CTX *c)
 {
     uint8_t outbuffer[BLAKE2S_OUTBYTES] = {0};
     uint8_t *target = outbuffer;

--- a/providers/implementations/digests/digestcommon.c
+++ b/providers/implementations/digests/digestcommon.c
@@ -11,8 +11,8 @@
 #include <openssl/proverr.h>
 #include "prov/digestcommon.h"
 
-int digest_default_get_params(OSSL_PARAM params[], size_t blksz, size_t paramsz,
-                              unsigned long flags)
+int ossl_digest_default_get_params(OSSL_PARAM params[], size_t blksz,
+                                   size_t paramsz, unsigned long flags)
 {
     OSSL_PARAM *p = NULL;
 
@@ -48,7 +48,7 @@ static const OSSL_PARAM digest_default_known_gettable_params[] = {
     OSSL_PARAM_int(OSSL_DIGEST_PARAM_ALGID_ABSENT, NULL),
     OSSL_PARAM_END
 };
-const OSSL_PARAM *digest_default_gettable_params(void *provctx)
+const OSSL_PARAM *ossl_digest_default_gettable_params(void *provctx)
 {
     return digest_default_known_gettable_params;
 }

--- a/providers/implementations/exchange/dh_exch.c
+++ b/providers/implementations/exchange/dh_exch.c
@@ -104,7 +104,7 @@ static int dh_init(void *vpdhctx, void *vdh)
     DH_free(pdhctx->dh);
     pdhctx->dh = vdh;
     pdhctx->kdf_type = PROV_DH_KDF_NONE;
-    return dh_check_key(vdh);
+    return ossl_dh_check_key(vdh);
 }
 
 static int dh_set_peer(void *vpdhctx, void *vdh)
@@ -321,7 +321,7 @@ static int dh_set_ctx_params(void *vpdhctx, const OSSL_PARAM params[])
 
         EVP_MD_free(pdhctx->kdf_md);
         pdhctx->kdf_md = EVP_MD_fetch(pdhctx->libctx, name, mdprops);
-        if (!digest_is_allowed(pdhctx->kdf_md)) {
+        if (!ossl_digest_is_allowed(pdhctx->kdf_md)) {
             EVP_MD_free(pdhctx->kdf_md);
             pdhctx->kdf_md = NULL;
         }

--- a/providers/implementations/exchange/ecdh_exch.c
+++ b/providers/implementations/exchange/ecdh_exch.c
@@ -111,7 +111,7 @@ int ecdh_init(void *vpecdhctx, void *vecdh)
     pecdhctx->k = vecdh;
     pecdhctx->cofactor_mode = -1;
     pecdhctx->kdf_type = PROV_ECDH_KDF_NONE;
-    return ec_check_key(vecdh, 1);
+    return ossl_ec_check_key(vecdh, 1);
 }
 
 static
@@ -126,7 +126,7 @@ int ecdh_set_peer(void *vpecdhctx, void *vecdh)
         return 0;
     EC_KEY_free(pecdhctx->peerk);
     pecdhctx->peerk = vecdh;
-    return ec_check_key(vecdh, 1);
+    return ossl_ec_check_key(vecdh, 1);
 }
 
 static
@@ -254,7 +254,7 @@ int ecdh_set_ctx_params(void *vpecdhctx, const OSSL_PARAM params[])
 
         EVP_MD_free(pectx->kdf_md);
         pectx->kdf_md = EVP_MD_fetch(pectx->libctx, name, mdprops);
-        if (!digest_is_allowed(pectx->kdf_md)) {
+        if (!ossl_digest_is_allowed(pectx->kdf_md)) {
             EVP_MD_free(pectx->kdf_md);
             pectx->kdf_md = NULL;
         }

--- a/providers/implementations/include/prov/blake2.h
+++ b/providers/implementations/include/prov/blake2.h
@@ -83,34 +83,39 @@ struct blake2b_ctx_st {
 typedef struct blake2s_ctx_st BLAKE2S_CTX;
 typedef struct blake2b_ctx_st BLAKE2B_CTX;
 
-int blake2s256_init(void *ctx);
-int blake2b512_init(void *ctx);
+int ossl_blake2s256_init(void *ctx);
+int ossl_blake2b512_init(void *ctx);
 
-int blake2b_init(BLAKE2B_CTX *c, const BLAKE2B_PARAM *P);
-int blake2b_init_key(BLAKE2B_CTX *c, const BLAKE2B_PARAM *P, const void *key);
-int blake2b_update(BLAKE2B_CTX *c, const void *data, size_t datalen);
-int blake2b_final(unsigned char *md, BLAKE2B_CTX *c);
+int ossl_blake2b_init(BLAKE2B_CTX *c, const BLAKE2B_PARAM *P);
+int ossl_blake2b_init_key(BLAKE2B_CTX *c, const BLAKE2B_PARAM *P,
+                          const void *key);
+int ossl_blake2b_update(BLAKE2B_CTX *c, const void *data, size_t datalen);
+int ossl_blake2b_final(unsigned char *md, BLAKE2B_CTX *c);
 
 /*
  * These setters are internal and do not check the validity of their parameters.
  * See blake2b_mac_ctrl for validation logic.
  */
 
-void blake2b_param_init(BLAKE2B_PARAM *P);
-void blake2b_param_set_digest_length(BLAKE2B_PARAM *P, uint8_t outlen);
-void blake2b_param_set_key_length(BLAKE2B_PARAM *P, uint8_t keylen);
-void blake2b_param_set_personal(BLAKE2B_PARAM *P, const uint8_t *personal, size_t length);
-void blake2b_param_set_salt(BLAKE2B_PARAM *P, const uint8_t *salt, size_t length);
+void ossl_blake2b_param_init(BLAKE2B_PARAM *P);
+void ossl_blake2b_param_set_digest_length(BLAKE2B_PARAM *P, uint8_t outlen);
+void ossl_blake2b_param_set_key_length(BLAKE2B_PARAM *P, uint8_t keylen);
+void ossl_blake2b_param_set_personal(BLAKE2B_PARAM *P, const uint8_t *personal,
+                                     size_t length);
+void ossl_blake2b_param_set_salt(BLAKE2B_PARAM *P, const uint8_t *salt,
+                                 size_t length);
+int ossl_blake2s_init(BLAKE2S_CTX *c, const BLAKE2S_PARAM *P);
+int ossl_blake2s_init_key(BLAKE2S_CTX *c, const BLAKE2S_PARAM *P,
+                          const void *key);
+int ossl_blake2s_update(BLAKE2S_CTX *c, const void *data, size_t datalen);
+int ossl_blake2s_final(unsigned char *md, BLAKE2S_CTX *c);
 
-int blake2s_init(BLAKE2S_CTX *c, const BLAKE2S_PARAM *P);
-int blake2s_init_key(BLAKE2S_CTX *c, const BLAKE2S_PARAM *P, const void *key);
-int blake2s_update(BLAKE2S_CTX *c, const void *data, size_t datalen);
-int blake2s_final(unsigned char *md, BLAKE2S_CTX *c);
-
-void blake2s_param_init(BLAKE2S_PARAM *P);
-void blake2s_param_set_digest_length(BLAKE2S_PARAM *P, uint8_t outlen);
-void blake2s_param_set_key_length(BLAKE2S_PARAM *P, uint8_t keylen);
-void blake2s_param_set_personal(BLAKE2S_PARAM *P, const uint8_t *personal, size_t length);
-void blake2s_param_set_salt(BLAKE2S_PARAM *P, const uint8_t *salt, size_t length);
+void ossl_blake2s_param_init(BLAKE2S_PARAM *P);
+void ossl_blake2s_param_set_digest_length(BLAKE2S_PARAM *P, uint8_t outlen);
+void ossl_blake2s_param_set_key_length(BLAKE2S_PARAM *P, uint8_t keylen);
+void ossl_blake2s_param_set_personal(BLAKE2S_PARAM *P, const uint8_t *personal,
+                                     size_t length);
+void ossl_blake2s_param_set_salt(BLAKE2S_PARAM *P, const uint8_t *salt,
+                                 size_t length);
 
 #endif /* OSSL_PROVIDERS_DEFAULT_INCLUDE_INTERNAL_BLAKE2_H */

--- a/providers/implementations/include/prov/digestcommon.h
+++ b/providers/implementations/include/prov/digestcommon.h
@@ -24,25 +24,25 @@ extern "C" {
 # endif
 
 #define PROV_FUNC_DIGEST_GET_PARAM(name, blksize, dgstsize, flags)             \
-static OSSL_FUNC_digest_get_params_fn name##_get_params;                         \
+static OSSL_FUNC_digest_get_params_fn name##_get_params;                       \
 static int name##_get_params(OSSL_PARAM params[])                              \
 {                                                                              \
-    return digest_default_get_params(params, blksize, dgstsize, flags);        \
+    return ossl_digest_default_get_params(params, blksize, dgstsize, flags);   \
 }
 
 #define PROV_DISPATCH_FUNC_DIGEST_GET_PARAMS(name)                             \
 { OSSL_FUNC_DIGEST_GET_PARAMS, (void (*)(void))name##_get_params },            \
 { OSSL_FUNC_DIGEST_GETTABLE_PARAMS,                                            \
-  (void (*)(void))digest_default_gettable_params }
+  (void (*)(void))ossl_digest_default_gettable_params }
 
 # define PROV_DISPATCH_FUNC_DIGEST_CONSTRUCT_START(                            \
     name, CTX, blksize, dgstsize, flags, init, upd, fin)                       \
-static OSSL_FUNC_digest_newctx_fn name##_newctx;                                 \
-static OSSL_FUNC_digest_freectx_fn name##_freectx;                               \
-static OSSL_FUNC_digest_dupctx_fn name##_dupctx;                                 \
+static OSSL_FUNC_digest_newctx_fn name##_newctx;                               \
+static OSSL_FUNC_digest_freectx_fn name##_freectx;                             \
+static OSSL_FUNC_digest_dupctx_fn name##_dupctx;                               \
 static void *name##_newctx(void *prov_ctx)                                     \
 {                                                                              \
-    CTX *ctx = ossl_prov_is_running() ? OPENSSL_zalloc(sizeof(*ctx)) : NULL;    \
+    CTX *ctx = ossl_prov_is_running() ? OPENSSL_zalloc(sizeof(*ctx)) : NULL;   \
     return ctx;                                                                \
 }                                                                              \
 static void name##_freectx(void *vctx)                                         \
@@ -53,7 +53,7 @@ static void name##_freectx(void *vctx)                                         \
 static void *name##_dupctx(void *ctx)                                          \
 {                                                                              \
     CTX *in = (CTX *)ctx;                                                      \
-    CTX *ret = ossl_prov_is_running() ? OPENSSL_malloc(sizeof(*ret)) : NULL;    \
+    CTX *ret = ossl_prov_is_running() ? OPENSSL_malloc(sizeof(*ret)) : NULL;   \
     if (ret != NULL)                                                           \
         *ret = *in;                                                            \
     return ret;                                                                \
@@ -61,13 +61,13 @@ static void *name##_dupctx(void *ctx)                                          \
 static OSSL_FUNC_digest_init_fn name##_internal_init;                          \
 static int name##_internal_init(void *ctx)                                     \
 {                                                                              \
-    return ossl_prov_is_running() ? init(ctx) : 0;                              \
+    return ossl_prov_is_running() ? init(ctx) : 0;                             \
 }                                                                              \
 static OSSL_FUNC_digest_final_fn name##_internal_final;                        \
 static int name##_internal_final(void *ctx, unsigned char *out, size_t *outl,  \
                                  size_t outsz)                                 \
 {                                                                              \
-    if (ossl_prov_is_running() && outsz >= dgstsize && fin(out, ctx)) {         \
+    if (ossl_prov_is_running() && outsz >= dgstsize && fin(out, ctx)) {        \
         *outl = dgstsize;                                                      \
         return 1;                                                              \
     }                                                                          \
@@ -103,9 +103,9 @@ PROV_DISPATCH_FUNC_DIGEST_CONSTRUCT_START(name, CTX, blksize, dgstsize, flags, \
 PROV_DISPATCH_FUNC_DIGEST_CONSTRUCT_END
 
 
-const OSSL_PARAM *digest_default_gettable_params(void *provctx);
-int digest_default_get_params(OSSL_PARAM params[], size_t blksz, size_t paramsz,
-                              unsigned long flags);
+const OSSL_PARAM *ossl_digest_default_gettable_params(void *provctx);
+int ossl_digest_default_get_params(OSSL_PARAM params[], size_t blksz,
+                                   size_t paramsz, unsigned long flags);
 
 # ifdef __cplusplus
 }

--- a/providers/implementations/macs/blake2b_mac.c
+++ b/providers/implementations/macs/blake2b_mac.c
@@ -16,14 +16,14 @@
 #define BLAKE2_SALTBYTES BLAKE2B_SALTBYTES
 
 /* Function names */
-#define BLAKE2_PARAM_INIT blake2b_param_init
-#define BLAKE2_INIT_KEY blake2b_init_key
-#define BLAKE2_UPDATE blake2b_update
-#define BLAKE2_FINAL blake2b_final
-#define BLAKE2_PARAM_SET_DIGEST_LENGTH blake2b_param_set_digest_length
-#define BLAKE2_PARAM_SET_KEY_LENGTH blake2b_param_set_key_length
-#define BLAKE2_PARAM_SET_PERSONAL blake2b_param_set_personal
-#define BLAKE2_PARAM_SET_SALT blake2b_param_set_salt
+#define BLAKE2_PARAM_INIT ossl_blake2b_param_init
+#define BLAKE2_INIT_KEY ossl_blake2b_init_key
+#define BLAKE2_UPDATE ossl_blake2b_update
+#define BLAKE2_FINAL ossl_blake2b_final
+#define BLAKE2_PARAM_SET_DIGEST_LENGTH ossl_blake2b_param_set_digest_length
+#define BLAKE2_PARAM_SET_KEY_LENGTH ossl_blake2b_param_set_key_length
+#define BLAKE2_PARAM_SET_PERSONAL ossl_blake2b_param_set_personal
+#define BLAKE2_PARAM_SET_SALT ossl_blake2b_param_set_salt
 
 /* OSSL_DISPATCH symbol */
 #define BLAKE2_FUNCTIONS ossl_blake2bmac_functions

--- a/providers/implementations/macs/blake2s_mac.c
+++ b/providers/implementations/macs/blake2s_mac.c
@@ -16,14 +16,14 @@
 #define BLAKE2_SALTBYTES BLAKE2S_SALTBYTES
 
 /* Function names */
-#define BLAKE2_PARAM_INIT blake2s_param_init
-#define BLAKE2_INIT_KEY blake2s_init_key
-#define BLAKE2_UPDATE blake2s_update
-#define BLAKE2_FINAL blake2s_final
-#define BLAKE2_PARAM_SET_DIGEST_LENGTH blake2s_param_set_digest_length
-#define BLAKE2_PARAM_SET_KEY_LENGTH blake2s_param_set_key_length
-#define BLAKE2_PARAM_SET_PERSONAL blake2s_param_set_personal
-#define BLAKE2_PARAM_SET_SALT blake2s_param_set_salt
+#define BLAKE2_PARAM_INIT ossl_blake2s_param_init
+#define BLAKE2_INIT_KEY ossl_blake2s_init_key
+#define BLAKE2_UPDATE ossl_blake2s_update
+#define BLAKE2_FINAL ossl_blake2s_final
+#define BLAKE2_PARAM_SET_DIGEST_LENGTH ossl_blake2s_param_set_digest_length
+#define BLAKE2_PARAM_SET_KEY_LENGTH ossl_blake2s_param_set_key_length
+#define BLAKE2_PARAM_SET_PERSONAL ossl_blake2s_param_set_personal
+#define BLAKE2_PARAM_SET_SALT ossl_blake2s_param_set_salt
 
 /* OSSL_DISPATCH symbol */
 #define BLAKE2_FUNCTIONS ossl_blake2smac_functions

--- a/providers/implementations/signature/dsa.c
+++ b/providers/implementations/signature/dsa.c
@@ -127,7 +127,7 @@ static int dsa_setup_md(PROV_DSA_CTX *ctx,
         int sha1_allowed = (ctx->operation != EVP_PKEY_OP_SIGN);
         WPACKET pkt;
         EVP_MD *md = EVP_MD_fetch(ctx->libctx, mdname, mdprops);
-        int md_nid = digest_get_approved_nid_with_sha1(md, sha1_allowed);
+        int md_nid = ossl_digest_get_approved_nid_with_sha1(md, sha1_allowed);
         size_t mdname_len = strlen(mdname);
 
         if (md == NULL || md_nid == NID_undef) {
@@ -183,7 +183,7 @@ static int dsa_signverify_init(void *vpdsactx, void *vdsa, int operation)
     DSA_free(pdsactx->dsa);
     pdsactx->dsa = vdsa;
     pdsactx->operation = operation;
-    if (!dsa_check_key(vdsa, operation == EVP_PKEY_OP_SIGN)) {
+    if (!ossl_dsa_check_key(vdsa, operation == EVP_PKEY_OP_SIGN)) {
         ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_KEY_LENGTH);
         return 0;
     }

--- a/providers/implementations/signature/ecdsa.c
+++ b/providers/implementations/signature/ecdsa.c
@@ -137,7 +137,7 @@ static int ecdsa_signverify_init(void *vctx, void *ec, int operation)
     EC_KEY_free(ctx->ec);
     ctx->ec = ec;
     ctx->operation = operation;
-    return ec_check_key(ec, operation == EVP_PKEY_OP_SIGN);
+    return ossl_ec_check_key(ec, operation == EVP_PKEY_OP_SIGN);
 }
 
 static int ecdsa_sign_init(void *vctx, void *ec)
@@ -222,7 +222,7 @@ static int ecdsa_setup_md(PROV_ECDSA_CTX *ctx, const char *mdname,
         return 0;
     }
     sha1_allowed = (ctx->operation != EVP_PKEY_OP_SIGN);
-    md_nid = digest_get_approved_nid_with_sha1(md, sha1_allowed);
+    md_nid = ossl_digest_get_approved_nid_with_sha1(md, sha1_allowed);
     if (md_nid == NID_undef) {
         ERR_raise_data(ERR_LIB_PROV, PROV_R_DIGEST_NOT_ALLOWED,
                        "digest=%s", mdname);

--- a/providers/implementations/signature/rsa.c
+++ b/providers/implementations/signature/rsa.c
@@ -276,7 +276,7 @@ static int rsa_setup_md(PROV_RSA_CTX *ctx, const char *mdname,
     if (mdname != NULL) {
         EVP_MD *md = EVP_MD_fetch(ctx->libctx, mdname, mdprops);
         int sha1_allowed = (ctx->operation != EVP_PKEY_OP_SIGN);
-        int md_nid = digest_rsa_sign_get_md_nid(md, sha1_allowed);
+        int md_nid = ossl_digest_rsa_sign_get_md_nid(md, sha1_allowed);
         size_t mdname_len = strlen(mdname);
 
         if (md == NULL
@@ -335,7 +335,7 @@ static int rsa_setup_mgf1_md(PROV_RSA_CTX *ctx, const char *mdname,
         return 0;
     }
     /* The default for mgf1 is SHA1 - so allow SHA1 */
-    if ((mdnid = digest_rsa_sign_get_md_nid(md, 1)) == NID_undef
+    if ((mdnid = ossl_digest_rsa_sign_get_md_nid(md, 1)) == NID_undef
         || !rsa_check_padding(ctx, NULL, mdname, mdnid)) {
         if (mdnid == NID_undef)
             ERR_raise_data(ERR_LIB_PROV, PROV_R_DIGEST_NOT_ALLOWED,


### PR DESCRIPTION
    Partial fix for #12964
    
    This adds ossl_ names for the following symbols:
  
````  
    digest_get_approved_nid, digest_get_approved_nid_with_sha1
    digest_is_allowed, digest_md_to_nid, digest_rsa_sign_get_md_nid,
    securitycheck_enabled,
    dh_check_key, dsa_check_key, ec_check_key,
    blake2b512_init,blake2b_final,blake2b_init,blake2b_init_key,
    blake2b_param_init,blake2b_param_set_digest_length,blake2b_param_set_key_length,
    blake2b_param_set_personal,blake2b_param_set_salt,blake2b_update,
    blake2s256_init,blake2s_final,blake2s_init,blake2s_init_key,
    blake2s_param_init,blake2s_param_set_digest_length,blake2s_param_set_key_length,
    blake2s_param_set_personal,blake2s_param_set_salt,blake2s_update,
    digest_default_get_params,digest_default_gettable_params
````

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
