### PR TITLE
Duplicate the file and func error strings

### DIFF
--- a/crypto/err/err.c
+++ b/crypto/err/err.c
@@ -190,7 +190,7 @@ static void ERR_STATE_free(ERR_STATE *s)
     if (s == NULL)
         return;
     for (i = 0; i < ERR_NUM_ERRORS; i++) {
-        err_clear_data(s, i, 1);
+        err_clear(s, i, 1);
     }
     OPENSSL_free(s);
 }

--- a/crypto/err/err_local.h
+++ b/crypto/err/err_local.h
@@ -48,9 +48,11 @@ static ossl_inline void err_set_debug(ERR_STATE *es, size_t i,
                                       const char *file, int line,
                                       const char *fn)
 {
-    es->err_file[i] = file;
+    OPENSSL_free(es->err_file[i]);
+    es->err_file[i] = OPENSSL_strdup(file);
     es->err_line[i] = line;
-    es->err_func[i] = fn;
+    OPENSSL_free(es->err_func[i]);
+    es->err_func[i] = OPENSSL_strdup(fn);
 }
 
 static ossl_inline void err_set_data(ERR_STATE *es, size_t i,
@@ -67,8 +69,11 @@ static ossl_inline void err_clear(ERR_STATE *es, size_t i, int deall)
     es->err_marks[i] = 0;
     es->err_flags[i] = 0;
     es->err_buffer[i] = 0;
-    es->err_file[i] = NULL;
     es->err_line[i] = -1;
+    OPENSSL_free(es->err_file[i]);
+    es->err_file[i] = NULL;
+    OPENSSL_free(es->err_func[i]);
+    es->err_func[i] = NULL;
 }
 
 ERR_STATE *err_get_state_int(void);

--- a/crypto/err/err_local.h
+++ b/crypto/err/err_local.h
@@ -53,10 +53,16 @@ static ossl_inline void err_set_debug(ERR_STATE *es, size_t i,
      * provider gets unloaded, they may not be valid anymore.
      */
     OPENSSL_free(es->err_file[i]);
-    es->err_file[i] = OPENSSL_strdup(file);
+    if (file == NULL || file[0] == '\0')
+        es->err_file[i] = NULL;
+    else
+        es->err_file[i] = OPENSSL_strdup(file);
     es->err_line[i] = line;
     OPENSSL_free(es->err_func[i]);
-    es->err_func[i] = OPENSSL_strdup(fn);
+    if (fn == NULL || fn[0] == '\0')
+        es->err_func[i] = NULL;
+    else
+        es->err_func[i] = OPENSSL_strdup(fn);
 }
 
 static ossl_inline void err_set_data(ERR_STATE *es, size_t i,

--- a/crypto/err/err_local.h
+++ b/crypto/err/err_local.h
@@ -48,6 +48,10 @@ static ossl_inline void err_set_debug(ERR_STATE *es, size_t i,
                                       const char *file, int line,
                                       const char *fn)
 {
+    /*
+     * We dup the file and fn strings because they may be provider owned. If the
+     * provider gets unloaded, they may not be valid anymore.
+     */
     OPENSSL_free(es->err_file[i]);
     es->err_file[i] = OPENSSL_strdup(file);
     es->err_line[i] = line;

--- a/include/openssl/err.h.in
+++ b/include/openssl/err.h.in
@@ -62,9 +62,9 @@ struct err_state_st {
     char *err_data[ERR_NUM_ERRORS];
     size_t err_data_size[ERR_NUM_ERRORS];
     int err_data_flags[ERR_NUM_ERRORS];
-    const char *err_file[ERR_NUM_ERRORS];
+    char *err_file[ERR_NUM_ERRORS];
     int err_line[ERR_NUM_ERRORS];
-    const char *err_func[ERR_NUM_ERRORS];
+    char *err_func[ERR_NUM_ERRORS];
     int top, bottom;
 };
 # endif

--- a/test/build.info
+++ b/test/build.info
@@ -762,17 +762,17 @@ IF[{- !$disabled{tests} -}]
   PROGRAMS{noinst}=provider_internal_test
   DEFINE[provider_internal_test]=PROVIDER_INIT_FUNCTION_NAME=p_test_init
   SOURCE[provider_internal_test]=provider_internal_test.c p_test.c
-  INCLUDE[provider_internal_test]=../include ../apps/include
+  INCLUDE[provider_internal_test]=../include ../apps/include ..
   DEPEND[provider_internal_test]=../libcrypto.a libtestutil.a
   PROGRAMS{noinst}=provider_test
   DEFINE[provider_test]=PROVIDER_INIT_FUNCTION_NAME=p_test_init
   SOURCE[provider_test]=provider_test.c p_test.c
-  INCLUDE[provider_test]=../include ../apps/include
+  INCLUDE[provider_test]=../include ../apps/include ..
   DEPEND[provider_test]=../libcrypto.a libtestutil.a
   IF[{- !$disabled{module} -}]
     MODULES{noinst}=p_test
     SOURCE[p_test]=p_test.c
-    INCLUDE[p_test]=../include
+    INCLUDE[p_test]=../include ..
     IF[{- defined $target{shared_defflag} -}]
       SOURCE[p_test]=p_test.ld
       GENERATE[p_test.ld]=../util/providers.num

--- a/test/p_test.c
+++ b/test/p_test.c
@@ -28,9 +28,19 @@
 
 #include <openssl/core.h>
 #include <openssl/core_dispatch.h>
+#include <openssl/err.h>
+
+typedef struct p_test_ctx {
+    char *thisfile;
+    char *thisfunc;
+    const OSSL_CORE_HANDLE *handle;
+} P_TEST_CTX;
 
 static OSSL_FUNC_core_gettable_params_fn *c_gettable_params = NULL;
 static OSSL_FUNC_core_get_params_fn *c_get_params = NULL;
+static OSSL_FUNC_core_new_error_fn *c_new_error;
+static OSSL_FUNC_core_set_error_debug_fn *c_set_error_debug;
+static OSSL_FUNC_core_vset_error_fn *c_vset_error;
 
 /* Tell the core what params we provide and what type they are */
 static const OSSL_PARAM p_param_types[] = {
@@ -42,15 +52,17 @@ static const OSSL_PARAM p_param_types[] = {
 static OSSL_FUNC_provider_gettable_params_fn p_gettable_params;
 static OSSL_FUNC_provider_get_params_fn p_get_params;
 static OSSL_FUNC_provider_get_reason_strings_fn p_get_reason_strings;
+static OSSL_FUNC_provider_teardown_fn p_teardown;
 
 static const OSSL_PARAM *p_gettable_params(void *_)
 {
     return p_param_types;
 }
 
-static int p_get_params(void *vhand, OSSL_PARAM params[])
+static int p_get_params(void *provctx, OSSL_PARAM params[])
 {
-    const OSSL_CORE_HANDLE *hand = vhand;
+    P_TEST_CTX *ctx = (P_TEST_CTX *)provctx;
+    const OSSL_CORE_HANDLE *hand = ctx->handle;
     OSSL_PARAM *p = params;
     int ok = 1;
 
@@ -101,6 +113,14 @@ static int p_get_params(void *vhand, OSSL_PARAM params[])
     return ok;
 }
 
+static void p_set_error(int lib, int reason, const char *file, int line,
+                        const char *func)
+{
+    c_new_error(NULL);
+    c_set_error_debug(NULL, file, line, func);
+    c_vset_error(NULL, ERR_PACK(lib, 0, reason), NULL, NULL);
+}
+
 static const OSSL_ITEM *p_get_reason_strings(void *_)
 {
     static const OSSL_ITEM reason_strings[] = {
@@ -116,6 +136,7 @@ static const OSSL_DISPATCH p_test_table[] = {
     { OSSL_FUNC_PROVIDER_GET_PARAMS, (void (*)(void))p_get_params },
     { OSSL_FUNC_PROVIDER_GET_REASON_STRINGS,
         (void (*)(void))p_get_reason_strings},
+    { OSSL_FUNC_PROVIDER_TEARDOWN, (void (*)(void))p_teardown },
     { 0, NULL }
 };
 
@@ -124,6 +145,8 @@ int OSSL_provider_init(const OSSL_CORE_HANDLE *handle,
                        const OSSL_DISPATCH **out,
                        void **provctx)
 {
+    P_TEST_CTX *ctx;
+
     for (; in->function_id != 0; in++) {
         switch (in->function_id) {
         case OSSL_FUNC_CORE_GETTABLE_PARAMS:
@@ -132,15 +155,50 @@ int OSSL_provider_init(const OSSL_CORE_HANDLE *handle,
         case OSSL_FUNC_CORE_GET_PARAMS:
             c_get_params = OSSL_FUNC_core_get_params(in);
             break;
+        case OSSL_FUNC_CORE_NEW_ERROR:
+            c_new_error = OSSL_FUNC_core_new_error(in);
+            break;
+        case OSSL_FUNC_CORE_SET_ERROR_DEBUG:
+            c_set_error_debug = OSSL_FUNC_core_set_error_debug(in);
+            break;
+        case OSSL_FUNC_CORE_VSET_ERROR:
+            c_vset_error = OSSL_FUNC_core_vset_error(in);
+            break;
         default:
             /* Just ignore anything we don't understand */
             break;
         }
     }
 
-    /* Because we use this in get_params, we need to pass it back */
-    *provctx = (void *)handle;
+    /*
+     * We dynamically allocate these strings to ensure that we don't reference
+     * them after the provider has been torn down (asan will tell us if we do).
+     * This files isn't linked against libcrypto, so we use malloc and strdup
+     * instead of OPENSSL_malloc and OPENSSL_strdup
+     */
+    ctx = malloc(sizeof(*ctx));
+    if (ctx == NULL)
+        return 0;
+    ctx->thisfile = strdup(OPENSSL_FILE);
+    ctx->thisfunc = strdup(OPENSSL_FUNC);
+    ctx->handle = handle;
 
+    /*
+     * Set a spurious error to check error handling works correctly. This will
+     * be ignored
+     */
+    p_set_error(ERR_LIB_PROV, 1, ctx->thisfile, OPENSSL_LINE, ctx->thisfunc);
+
+    *provctx = (void *)ctx;
     *out = p_test_table;
     return 1;
+}
+
+static void p_teardown(void *provctx)
+{
+    P_TEST_CTX *ctx = (P_TEST_CTX *)provctx;
+
+    free(ctx->thisfile);
+    free(ctx->thisfunc);
+    free(ctx);
 }

--- a/test/p_test.c
+++ b/test/p_test.c
@@ -171,9 +171,13 @@ int OSSL_provider_init(const OSSL_CORE_HANDLE *handle,
     }
 
     /*
-     * We dynamically allocate these strings to ensure that we don't reference
-     * them after the provider has been torn down (asan will tell us if we do).
-     * This files isn't linked against libcrypto, so we use malloc and strdup
+     * We want to test that libcrypto doesn't use the file and func pointers
+     * that we provide to it via c_set_error_debug beyond the time that they
+     * are valid for. Therefore we dynamically allocate these strings now and
+     * free them again when the provider is torn down. If anything tries to
+     * use those strings after that point there will be a use-after-free and
+     * asan will complain (and hence the tests will fail).
+     * This file isn't linked against libcrypto, so we use malloc and strdup
      * instead of OPENSSL_malloc and OPENSSL_strdup
      */
     ctx = malloc(sizeof(*ctx));

--- a/test/p_test.c
+++ b/test/p_test.c
@@ -26,6 +26,7 @@
 # define OSSL_provider_init PROVIDER_INIT_FUNCTION_NAME
 #endif
 
+#include "e_os.h"
 #include <openssl/core.h>
 #include <openssl/core_dispatch.h>
 #include <openssl/err.h>

--- a/test/provider_test.c
+++ b/test/provider_test.c
@@ -63,7 +63,7 @@ static int test_builtin_provider(void)
     ok =
         TEST_ptr(libctx)
         && TEST_true(OSSL_PROVIDER_add_builtin(libctx, name,
-                                            PROVIDER_INIT_FUNCTION_NAME))
+                                               PROVIDER_INIT_FUNCTION_NAME))
         && test_provider(&libctx, name);
 
     OSSL_LIB_CTX_free(libctx);


### PR DESCRIPTION
Errors raised from a provider that is subsequently unloaded from memory may have references to strings representing the file and function that are no longer present because the provider is no longer in memory. This can cause crashes. To avoid this we duplicate the file and func strings.

I believe this is the most likely cause of the failures described in #13623. However, I've been unable to replicate that particular failure.

Fixes #13623