### PR TITLE
Fix build error with gcc 4.9.2

### DIFF
--- a/test/rsa_test.c
+++ b/test/rsa_test.c
@@ -303,7 +303,7 @@ err:
 static int test_rsa_oaep(int idx)
 {
     int ret = 0;
-    RSA *key;
+    RSA *key = NULL;
     unsigned char ptext[256];
     unsigned char ctext[256];
     static unsigned char ptext_ex[] = "\x54\x85\x9b\x34\x2c\x49\xea\x2a";


### PR DESCRIPTION
GCC 4.9.2 errors out:
```
test/rsa_test.c:349:5: error: 'key' may be used uninitialized in this function [-Werror=maybe-uninitialized]
     RSA_free(key);
```

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
