### PR TITLE
speed: Always use the EVP APIs for speed measurements

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -47,6 +47,13 @@ OpenSSL 3.0
 
    *Paul Dale*
 
+ * The openssl speed command does not use low-level API calls anymore. This
+   implies some of the performance numbers might not be fully comparable
+   with the previous releases due to higher overhead. This applies
+   particularly to measuring performance on smaller data chunks.
+
+   *Tomáš Mráz*
+
  * Combining the Configure options no-ec and no-dh no longer disables TLSv1.3.
    Typically if OpenSSL has no EC or DH algorithms then it cannot support
    connections with TLSv1.3. However OpenSSL now supports "pluggable" groups

--- a/apps/speed.c
+++ b/apps/speed.c
@@ -630,6 +630,7 @@ static int EVP_MAC_loop(int algindex, void *args)
 
     for (count = 0; COND(c[algindex][testnum]); count++) {
         size_t outl;
+
         if (!EVP_MAC_init(mctx)
             || !EVP_MAC_update(mctx, buf, lengths[testnum])
             || !EVP_MAC_final(mctx, mac, &outl, sizeof(mac)))

--- a/apps/speed.c
+++ b/apps/speed.c
@@ -865,6 +865,7 @@ static int RSA_sign_loop(void *args)
     size_t *rsa_num = &tempargs->sigsize;
     EVP_PKEY_CTX **rsa_sign_ctx = tempargs->rsa_sign_ctx;
     int ret, count;
+
     for (count = 0; COND(rsa_c[testnum][0]); count++) {
         ret = EVP_PKEY_sign(rsa_sign_ctx[testnum], buf2, rsa_num, buf, 36);
         if (ret <= 0) {
@@ -885,6 +886,7 @@ static int RSA_verify_loop(void *args)
     size_t rsa_num = tempargs->sigsize;
     EVP_PKEY_CTX **rsa_verify_ctx = tempargs->rsa_verify_ctx;
     int ret, count;
+
     for (count = 0; COND(rsa_c[testnum][1]); count++) {
         ret = EVP_PKEY_verify(rsa_verify_ctx[testnum], buf2, rsa_num, buf, 36);
         if (ret <= 0) {
@@ -2131,6 +2133,7 @@ int speed_main(int argc, char **argv)
     for (algindex = D_RC4; algindex <= D_CBC_CAST; algindex++) {
         if (doit[algindex]) {
             int st = 1;
+
             keylen = 16;
             for (i = 0; st && i < loopargs_len; i++) {
                 loopargs[i].ctx = init_evp_cipher_ctx(names[algindex],

--- a/apps/speed.c
+++ b/apps/speed.c
@@ -746,7 +746,7 @@ static EVP_CIPHER_CTX *init_evp_cipher_ctx(const char *ciphername,
         ctx = NULL;
         goto end;
     }
-    
+
     EVP_CIPHER_CTX_set_key_length(ctx, keylen);
 
     if (!EVP_CipherInit_ex(ctx, NULL, NULL, key, iv, 1)) {
@@ -1349,7 +1349,7 @@ static EVP_PKEY *get_ecdsa(const EC_CURVE *curve)
         }
 
         /* Create the context for parameter generation */
-        if ((pctx = EVP_PKEY_CTX_new_id(EVP_PKEY_EC, NULL)) == NULL
+        if ((pctx = EVP_PKEY_CTX_new_from_name(NULL, "EC", NULL)) == NULL
             || EVP_PKEY_paramgen_init(pctx) <= 0
             || EVP_PKEY_CTX_set_ec_paramgen_curve_nid(pctx,
                                                       curve->nid) <= 0

--- a/apps/speed.c
+++ b/apps/speed.c
@@ -2047,12 +2047,15 @@ int speed_main(int argc, char **argv)
     }
 
     if (doit[D_CBC_DES]) {
-        for (i = 0; i < loopargs_len; i++) {
+        int st = 1;
+
+        for (i = 0; st && i < loopargs_len; i++) {
             loopargs[i].ctx = init_evp_cipher_ctx("des-cbc", deskey,
                                                   sizeof(deskey)/3);
+            st = loopargs[i].ctx != NULL;
         }
         algindex = D_CBC_DES;
-        for (testnum = 0; testnum < size_num; testnum++) {
+        for (testnum = 0; st && testnum < size_num; testnum++) {
             print_message(names[D_CBC_DES], c[D_CBC_DES][testnum],
                           lengths[testnum], seconds.sym);
             Time_F(START);
@@ -2066,12 +2069,15 @@ int speed_main(int argc, char **argv)
     }
 
     if (doit[D_EDE3_DES]) {
-        for (i = 0; i < loopargs_len; i++) {
+        int st = 1;
+
+        for (i = 0; st && i < loopargs_len; i++) {
             loopargs[i].ctx = init_evp_cipher_ctx("des-ede3-cbc", deskey,
                                                   sizeof(deskey));
+            st = loopargs[i].ctx != NULL;
         }
         algindex = D_EDE3_DES;
-        for (testnum = 0; testnum < size_num; testnum++) {
+        for (testnum = 0; st && testnum < size_num; testnum++) {
             print_message(names[D_EDE3_DES], c[D_EDE3_DES][testnum],
                           lengths[testnum], seconds.sym);
             Time_F(START);
@@ -2088,13 +2094,16 @@ int speed_main(int argc, char **argv)
     for (k = 0; k < 3; k++) {
         algindex = D_CBC_128_AES + k;
         if (doit[algindex]) {
+            int st = 1;
+
             keylen = 16 + i * 8;
-            for (i = 0; i < loopargs_len; i++) {
+            for (i = 0; st && i < loopargs_len; i++) {
                 loopargs[i].ctx = init_evp_cipher_ctx(names[algindex],
                                                       key32, keylen);
+                st = loopargs[i].ctx != NULL;
             }
 
-            for (testnum = 0; testnum < size_num; testnum++) {
+            for (testnum = 0; st && testnum < size_num; testnum++) {
                 print_message(names[algindex], c[algindex][testnum],
                               lengths[testnum], seconds.sym);
                 Time_F(START);
@@ -2112,13 +2121,16 @@ int speed_main(int argc, char **argv)
     for (k = 0; k < 3; k++) {
         algindex = D_CBC_128_CML + k;
         if (doit[algindex]) {
+            int st = 1;
+
             keylen = 16 + i * 8;
-            for (i = 0; i < loopargs_len; i++) {
+            for (i = 0; st && i < loopargs_len; i++) {
                 loopargs[i].ctx = init_evp_cipher_ctx(names[algindex],
                                                       key32, keylen);
+                st = loopargs[i].ctx != NULL;
             }
 
-            for (testnum = 0; testnum < size_num; testnum++) {
+            for (testnum = 0; st && testnum < size_num; testnum++) {
                 print_message(names[algindex], c[algindex][testnum],
                               lengths[testnum], seconds.sym);
                 Time_F(START);
@@ -2135,13 +2147,15 @@ int speed_main(int argc, char **argv)
 
     for (algindex = D_RC4; algindex <= D_CBC_CAST; algindex++) {
         if (doit[algindex]) {
+            int st = 1;
             keylen = 16;
-            for (i = 0; i < loopargs_len; i++) {
+            for (i = 0; st && i < loopargs_len; i++) {
                 loopargs[i].ctx = init_evp_cipher_ctx(names[algindex],
                                                       key32, keylen);
+                st = loopargs[i].ctx != NULL;
             }
 
-            for (testnum = 0; testnum < size_num; testnum++) {
+            for (testnum = 0; st && testnum < size_num; testnum++) {
                 print_message(names[algindex], c[algindex][testnum],
                               lengths[testnum], seconds.sym);
                 Time_F(START);

--- a/apps/speed.c
+++ b/apps/speed.c
@@ -71,6 +71,9 @@
 #endif
 #include <openssl/rsa.h>
 #include "./testrsa.h"
+#ifndef OPENSSL_NO_DH
+# include <openssl/dh.h>
+#endif
 #include <openssl/x509.h>
 #include <openssl/dsa.h>
 #include "./testdsa.h"
@@ -94,6 +97,10 @@
 #define MAX_ECDH_SIZE   256
 #define MISALIGN        64
 #define MAX_FFDH_SIZE 1024
+
+#ifndef RSA_DEFAULT_PRIME_NUM
+# define RSA_DEFAULT_PRIME_NUM 2
+#endif
 
 typedef struct openssl_speed_sec_st {
     int sym;

--- a/apps/speed.c
+++ b/apps/speed.c
@@ -1428,7 +1428,7 @@ int speed_main(int argc, char **argv)
         {  test1024,  sizeof(test1024),  1024 },
         {  test2048,  sizeof(test2048),  2048 },
         {  test3072,  sizeof(test3072),  3072 },
-        {  test4096,  sizeof(test4096),  4092 },
+        {  test4096,  sizeof(test4096),  4096 },
         {  test7680,  sizeof(test7680),  7680 },
         { test15360, sizeof(test15360), 15360 }
     };
@@ -2374,7 +2374,7 @@ int speed_main(int argc, char **argv)
             const unsigned char *p = rsa_keys[testnum].data;
 
             st = (rsa_key = d2i_PrivateKey(EVP_PKEY_RSA, NULL, &p,
-                                           rsa_keys[k].length)) != NULL;
+                                           rsa_keys[testnum].length)) != NULL;
         }
 
         for (i = 0; st && i < loopargs_len; i++) {

--- a/apps/speed.c
+++ b/apps/speed.c
@@ -51,24 +51,6 @@
 #endif
 
 #include <openssl/bn.h>
-#ifndef OPENSSL_NO_DES
-# include <openssl/des.h>
-#endif
-#ifndef OPENSSL_NO_DEPRECATED_3_0
-#include <openssl/aes.h>
-#endif
-#ifndef OPENSSL_NO_MD2
-# include <openssl/md2.h>
-#endif
-#ifndef OPENSSL_NO_RC4
-# include <openssl/rc4.h>
-#endif
-#ifndef OPENSSL_NO_IDEA
-# include <openssl/idea.h>
-#endif
-#ifndef OPENSSL_NO_BF
-# include <openssl/blowfish.h>
-#endif
 #include <openssl/rsa.h>
 #include "./testrsa.h"
 #ifndef OPENSSL_NO_DH
@@ -285,7 +267,7 @@ enum {
     D_CBC_RC2, D_CBC_RC5, D_CBC_BF, D_CBC_CAST,
     D_CBC_128_AES, D_CBC_192_AES, D_CBC_256_AES,
     D_CBC_128_CML, D_CBC_192_CML, D_CBC_256_CML,
-    D_EVP, D_GHASH, D_RAND, D_EVP_CMAC, ALGOR_NUM 
+    D_EVP, D_GHASH, D_RAND, D_EVP_CMAC, ALGOR_NUM
 };
 /* name of algorithms to test. MUST BE KEEP IN SYNC with above enum ! */
 static const char *names[ALGOR_NUM] = {
@@ -469,7 +451,7 @@ static const OPT_PAIR sm2_choices[SM2_NUM] = {
 static double sm2_results[SM2_NUM][2];    /* 2 ops: sign then verify */
 #endif /* OPENSSL_NO_SM2 */
 
-#define COND(unused_cond) (run && count<0x7fffffff)
+#define COND(unused_cond) (run && count < 0x7fffffff)
 #define COUNT(d) (count)
 
 typedef struct loopargs_st {
@@ -722,7 +704,6 @@ static int GHASH_loop(void *args)
     return count;
 }
 
-
 #define MAX_BLOCK_SIZE 128
 
 static unsigned char iv[2 * MAX_BLOCK_SIZE / 8];
@@ -921,16 +902,15 @@ static long ffdh_c[FFDH_NUM][1];
 
 static int FFDH_derive_key_loop(void *args)
 {
-        loopargs_t *tempargs = *(loopargs_t **) args;
-        EVP_PKEY_CTX *ffdh_ctx = tempargs->ffdh_ctx[testnum];
-        unsigned char *derived_secret = tempargs->secret_ff_a;
-        size_t outlen = MAX_FFDH_SIZE;
-        int count;
+    loopargs_t *tempargs = *(loopargs_t **) args;
+    EVP_PKEY_CTX *ffdh_ctx = tempargs->ffdh_ctx[testnum];
+    unsigned char *derived_secret = tempargs->secret_ff_a;
+    size_t outlen = MAX_FFDH_SIZE;
+    int count;
 
-        for (count = 0; COND(ffdh_c[testnum][0]); count++)
-            EVP_PKEY_derive(ffdh_ctx, derived_secret, &outlen);
-
-        return count;
+    for (count = 0; COND(ffdh_c[testnum][0]); count++)
+        EVP_PKEY_derive(ffdh_ctx, derived_secret, &outlen);
+    return count;
 }
 #endif /* OPENSSL_NO_DH */
 
@@ -943,6 +923,7 @@ static int DSA_sign_loop(void *args)
     size_t *dsa_num = &tempargs->sigsize;
     EVP_PKEY_CTX **dsa_sign_ctx = tempargs->dsa_sign_ctx;
     int ret, count;
+
     for (count = 0; COND(dsa_c[testnum][0]); count++) {
         ret = EVP_PKEY_sign(dsa_sign_ctx[testnum], buf2, dsa_num, buf, 20);
         if (ret <= 0) {
@@ -963,6 +944,7 @@ static int DSA_verify_loop(void *args)
     size_t dsa_num = tempargs->sigsize;
     EVP_PKEY_CTX **dsa_verify_ctx = tempargs->dsa_verify_ctx;
     int ret, count;
+
     for (count = 0; COND(dsa_c[testnum][1]); count++) {
         ret = EVP_PKEY_verify(dsa_verify_ctx[testnum], buf2, dsa_num, buf, 20);
         if (ret <= 0) {
@@ -984,6 +966,7 @@ static int ECDSA_sign_loop(void *args)
     size_t *ecdsa_num = &tempargs->sigsize;
     EVP_PKEY_CTX **ecdsa_sign_ctx = tempargs->ecdsa_sign_ctx;
     int ret, count;
+
     for (count = 0; COND(ecdsa_c[testnum][0]); count++) {
         ret = EVP_PKEY_sign(ecdsa_sign_ctx[testnum], buf2, ecdsa_num, buf, 20);
         if (ret <= 0) {
@@ -1004,8 +987,10 @@ static int ECDSA_verify_loop(void *args)
     size_t ecdsa_num = tempargs->sigsize;
     EVP_PKEY_CTX **ecdsa_verify_ctx = tempargs->ecdsa_verify_ctx;
     int ret, count;
+
     for (count = 0; COND(ecdsa_c[testnum][1]); count++) {
-        ret = EVP_PKEY_verify(ecdsa_verify_ctx[testnum], buf2, ecdsa_num, buf, 20);
+        ret = EVP_PKEY_verify(ecdsa_verify_ctx[testnum], buf2, ecdsa_num,
+                              buf, 20);
         if (ret <= 0) {
             BIO_printf(bio_err, "ECDSA verify failure\n");
             ERR_print_errors(bio_err);
@@ -1772,8 +1757,8 @@ int speed_main(int argc, char **argv)
     }
     if (multiblock) {
         if (evp_cipher == NULL) {
-            BIO_printf(bio_err,"-mb can be used only with a multi-block"
-                               " capable cipher\n");
+            BIO_printf(bio_err, "-mb can be used only with a multi-block"
+                                " capable cipher\n");
             goto end;
         } else if (!(EVP_CIPHER_flags(evp_cipher) &
                      EVP_CIPH_FLAG_TLS1_1_MULTIBLOCK)) {
@@ -2018,9 +2003,11 @@ int speed_main(int argc, char **argv)
         names[D_HMAC] = evp_hmac_name;
 
         params[0] =
-            OSSL_PARAM_construct_utf8_string(OSSL_MAC_PARAM_DIGEST, evp_mac_mdname, 0);
+            OSSL_PARAM_construct_utf8_string(OSSL_MAC_PARAM_DIGEST,
+                                             evp_mac_mdname, 0);
         params[1] =
-            OSSL_PARAM_construct_octet_string(OSSL_MAC_PARAM_KEY, (char *)hmac_key, len);
+            OSSL_PARAM_construct_octet_string(OSSL_MAC_PARAM_KEY,
+                                              (char *)hmac_key, len);
         params[2] = OSSL_PARAM_construct_end();
 
         for (i = 0; i < loopargs_len; i++) {
@@ -2051,7 +2038,7 @@ int speed_main(int argc, char **argv)
 
         for (i = 0; st && i < loopargs_len; i++) {
             loopargs[i].ctx = init_evp_cipher_ctx("des-cbc", deskey,
-                                                  sizeof(deskey)/3);
+                                                  sizeof(deskey) / 3);
             st = loopargs[i].ctx != NULL;
         }
         algindex = D_CBC_DES;
@@ -2063,9 +2050,8 @@ int speed_main(int argc, char **argv)
             d = Time_F(STOP);
             print_result(D_CBC_DES, testnum, count, d);
         }
-        for (i = 0; i < loopargs_len; i++) {
+        for (i = 0; i < loopargs_len; i++)
             EVP_CIPHER_CTX_free(loopargs[i].ctx);
-        }
     }
 
     if (doit[D_EDE3_DES]) {
@@ -2086,9 +2072,8 @@ int speed_main(int argc, char **argv)
             d = Time_F(STOP);
             print_result(D_EDE3_DES, testnum, count, d);
         }
-        for (i = 0; i < loopargs_len; i++) {
+        for (i = 0; i < loopargs_len; i++)
             EVP_CIPHER_CTX_free(loopargs[i].ctx);
-        }
     }
 
     for (k = 0; k < 3; k++) {
@@ -2112,9 +2097,8 @@ int speed_main(int argc, char **argv)
                 d = Time_F(STOP);
                 print_result(algindex, testnum, count, d);
             }
-            for (i = 0; i < loopargs_len; i++) {
+            for (i = 0; i < loopargs_len; i++)
                 EVP_CIPHER_CTX_free(loopargs[i].ctx);
-            }
         }
     }
 
@@ -2139,9 +2123,8 @@ int speed_main(int argc, char **argv)
                 d = Time_F(STOP);
                 print_result(algindex, testnum, count, d);
             }
-            for (i = 0; i < loopargs_len; i++) {
+            for (i = 0; i < loopargs_len; i++)
                 EVP_CIPHER_CTX_free(loopargs[i].ctx);
-            }
         }
     }
 
@@ -2164,9 +2147,8 @@ int speed_main(int argc, char **argv)
                 d = Time_F(STOP);
                 print_result(algindex, testnum, count, d);
             }
-            for (i = 0; i < loopargs_len; i++) {
+            for (i = 0; i < loopargs_len; i++)
                 EVP_CIPHER_CTX_free(loopargs[i].ctx);
-            }
         }
     }
     if (doit[D_GHASH]) {
@@ -2177,13 +2159,13 @@ int speed_main(int argc, char **argv)
         if (mac == NULL)
             goto end;
 
-        params[0] =
-            OSSL_PARAM_construct_utf8_string(OSSL_ALG_PARAM_CIPHER, "aes-128-gcm", 0);
-        params[1] =
-            OSSL_PARAM_construct_octet_string(OSSL_MAC_PARAM_KEY, (char *)key32, 16);
-        params[2] =
-            OSSL_PARAM_construct_octet_string(OSSL_MAC_PARAM_IV, (char *)gmac_iv,
-                                              sizeof(gmac_iv) - 1);
+        params[0] = OSSL_PARAM_construct_utf8_string(OSSL_ALG_PARAM_CIPHER,
+                                                     "aes-128-gcm", 0);
+        params[1] = OSSL_PARAM_construct_octet_string(OSSL_MAC_PARAM_KEY,
+                                                      (char *)key32, 16);
+        params[2] = OSSL_PARAM_construct_octet_string(OSSL_MAC_PARAM_IV,
+                                                      (char *)gmac_iv,
+                                                      sizeof(gmac_iv) - 1);
         params[3] = OSSL_PARAM_construct_end();
 
         for (i = 0; i < loopargs_len; i++) {
@@ -2278,15 +2260,15 @@ int speed_main(int argc, char **argv)
 
                     /* SIV mode only allows for a single Update operation */
                     if (EVP_CIPHER_mode(evp_cipher) == EVP_CIPH_SIV_MODE)
-                        EVP_CIPHER_CTX_ctrl(loopargs[k].ctx, EVP_CTRL_SET_SPEED, 1, NULL);
+                        EVP_CIPHER_CTX_ctrl(loopargs[k].ctx, EVP_CTRL_SET_SPEED,
+                                            1, NULL);
                 }
 
                 Time_F(START);
                 count = run_benchmark(async_jobs, loopfunc, loopargs);
                 d = Time_F(STOP);
-                for (k = 0; k < loopargs_len; k++) {
+                for (k = 0; k < loopargs_len; k++)
                     EVP_CIPHER_CTX_free(loopargs[k].ctx);
-                }
                 print_result(D_EVP, testnum, count, d);
             }
         } else if (evp_md_name != NULL) {
@@ -2323,16 +2305,15 @@ int speed_main(int argc, char **argv)
             BIO_printf(bio_err, "\nRequested CMAC cipher with unsupported key length.\n");
             goto end;
         }
-        evp_cmac_name = app_malloc(sizeof("cmac()") + strlen(evp_mac_ciphername),
-                                   "CMAC name");
+        evp_cmac_name = app_malloc(sizeof("cmac()")
+                                   + strlen(evp_mac_ciphername), "CMAC name");
         sprintf(evp_cmac_name, "cmac(%s)", evp_mac_ciphername);
         names[D_EVP_CMAC] = evp_cmac_name;
 
-        params[0] =
-            OSSL_PARAM_construct_utf8_string(OSSL_ALG_PARAM_CIPHER,
-                                             evp_mac_ciphername, 0);
-        params[1] =
-            OSSL_PARAM_construct_octet_string(OSSL_MAC_PARAM_KEY, (char *)key32, keylen);
+        params[0] = OSSL_PARAM_construct_utf8_string(OSSL_ALG_PARAM_CIPHER,
+                                                     evp_mac_ciphername, 0);
+        params[1] = OSSL_PARAM_construct_octet_string(OSSL_MAC_PARAM_KEY,
+                                                      (char *)key32, keylen);
         params[2] = OSSL_PARAM_construct_end();
 
         for (i = 0; i < loopargs_len; i++) {
@@ -2343,10 +2324,10 @@ int speed_main(int argc, char **argv)
             if (!EVP_MAC_CTX_set_params(loopargs[i].mctx, params))
                 goto end;
         }
-        
+
         for (testnum = 0; testnum < size_num; testnum++) {
-            print_message(names[D_EVP_CMAC], c[D_EVP_CMAC][testnum], lengths[testnum],
-                          seconds.sym);
+            print_message(names[D_EVP_CMAC], c[D_EVP_CMAC][testnum],
+                          lengths[testnum], seconds.sym);
             Time_F(START);
             count = run_benchmark(async_jobs, CMAC_loop, loopargs);
             d = Time_F(STOP);
@@ -2392,8 +2373,7 @@ int speed_main(int argc, char **argv)
         }
 
         for (i = 0; st && i < loopargs_len; i++) {
-            loopargs[i].rsa_sign_ctx[testnum] = EVP_PKEY_CTX_new(rsa_key,
-                                                                 NULL);
+            loopargs[i].rsa_sign_ctx[testnum] = EVP_PKEY_CTX_new(rsa_key, NULL);
             if (loopargs[i].rsa_sign_ctx[testnum] == NULL
                 || EVP_PKEY_sign_init(loopargs[i].rsa_sign_ctx[testnum]) <= 0
                 || EVP_PKEY_sign(loopargs[i].rsa_sign_ctx[testnum],
@@ -2581,7 +2561,7 @@ int speed_main(int argc, char **argv)
 
         for (i = 0; st && i < loopargs_len; i++) {
             loopargs[i].ecdsa_verify_ctx[testnum] = EVP_PKEY_CTX_new(ecdsa_key,
-                                                                   NULL);
+                                                                     NULL);
             if (loopargs[i].ecdsa_verify_ctx[testnum] == NULL
                 || EVP_PKEY_verify_init(loopargs[i].ecdsa_verify_ctx[testnum]) <= 0
                 || EVP_PKEY_verify(loopargs[i].ecdsa_verify_ctx[testnum],
@@ -2629,14 +2609,14 @@ int speed_main(int argc, char **argv)
             size_t outlen;
             size_t test_outlen;
 
-            if ((key_A = get_ecdsa(&ec_curves[testnum])) == NULL || /* generate secret key A */
-                (key_B = get_ecdsa(&ec_curves[testnum])) == NULL || /* generate secret key B */
-                (ctx = EVP_PKEY_CTX_new(key_A, NULL)) == NULL || /* derivation ctx from skeyA */
-                EVP_PKEY_derive_init(ctx) <= 0 || /* init derivation ctx */
-                EVP_PKEY_derive_set_peer(ctx, key_B) <= 0 || /* set peer pubkey in ctx */
-                EVP_PKEY_derive(ctx, NULL, &outlen) <= 0 || /* determine max length */
-                outlen == 0 ||  /* ensure outlen is a valid size */
-                outlen > MAX_ECDH_SIZE /* avoid buffer overflow */ ) {
+            if ((key_A = get_ecdsa(&ec_curves[testnum])) == NULL /* generate secret key A */
+                || (key_B = get_ecdsa(&ec_curves[testnum])) == NULL /* generate secret key B */
+                || (ctx = EVP_PKEY_CTX_new(key_A, NULL)) == NULL /* derivation ctx from skeyA */
+                || EVP_PKEY_derive_init(ctx) <= 0 /* init derivation ctx */
+                || EVP_PKEY_derive_set_peer(ctx, key_B) <= 0 /* set peer pubkey in ctx */
+                || EVP_PKEY_derive(ctx, NULL, &outlen) <= 0 /* determine max length */
+                || outlen == 0 /* ensure outlen is a valid size */
+                || outlen > MAX_ECDH_SIZE /* avoid buffer overflow */) {
                 ecdh_checks = 0;
                 BIO_printf(bio_err, "ECDH key generation failure.\n");
                 ERR_print_errors(bio_err);
@@ -2644,17 +2624,19 @@ int speed_main(int argc, char **argv)
                 break;
             }
 
-            /* Here we perform a test run, comparing the output of a*B and b*A;
+            /*
+             * Here we perform a test run, comparing the output of a*B and b*A;
              * we try this here and assume that further EVP_PKEY_derive calls
              * never fail, so we can skip checks in the actually benchmarked
-             * code, for maximum performance. */
-            if ((test_ctx = EVP_PKEY_CTX_new(key_B, NULL)) == NULL || /* test ctx from skeyB */
-                !EVP_PKEY_derive_init(test_ctx) || /* init derivation test_ctx */
-                !EVP_PKEY_derive_set_peer(test_ctx, key_A) || /* set peer pubkey in test_ctx */
-                !EVP_PKEY_derive(test_ctx, NULL, &test_outlen) || /* determine max length */
-                !EVP_PKEY_derive(ctx, loopargs[i].secret_a, &outlen) || /* compute a*B */
-                !EVP_PKEY_derive(test_ctx, loopargs[i].secret_b, &test_outlen) || /* compute b*A */
-                test_outlen != outlen /* compare output length */ ) {
+             * code, for maximum performance.
+             */
+            if ((test_ctx = EVP_PKEY_CTX_new(key_B, NULL)) == NULL /* test ctx from skeyB */
+                || !EVP_PKEY_derive_init(test_ctx) /* init derivation test_ctx */
+                || !EVP_PKEY_derive_set_peer(test_ctx, key_A) /* set peer pubkey in test_ctx */
+                || !EVP_PKEY_derive(test_ctx, NULL, &test_outlen) /* determine max length */
+                || !EVP_PKEY_derive(ctx, loopargs[i].secret_a, &outlen) /* compute a*B */
+                || !EVP_PKEY_derive(test_ctx, loopargs[i].secret_b, &test_outlen) /* compute b*A */
+                || test_outlen != outlen /* compare output length */) {
                 ecdh_checks = 0;
                 BIO_printf(bio_err, "ECDH computation failure.\n");
                 ERR_print_errors(bio_err);
@@ -2721,8 +2703,8 @@ int speed_main(int argc, char **argv)
                 break;
             }
 
-            if ((ed_pctx = EVP_PKEY_CTX_new_id(ed_curves[testnum].nid, NULL))
-                    == NULL
+            if ((ed_pctx = EVP_PKEY_CTX_new_id(ed_curves[testnum].nid,
+                                               NULL)) == NULL
                 || EVP_PKEY_keygen_init(ed_pctx) <= 0
                 || EVP_PKEY_keygen(ed_pctx, &ed_pkey) <= 0) {
                 st = 0;
@@ -2737,8 +2719,8 @@ int speed_main(int argc, char **argv)
                 EVP_PKEY_free(ed_pkey);
                 break;
             }
-           if (!EVP_DigestVerifyInit(loopargs[i].eddsa_ctx2[testnum], NULL,
-                                     NULL, NULL, ed_pkey)) {
+            if (!EVP_DigestVerifyInit(loopargs[i].eddsa_ctx2[testnum], NULL,
+                                      NULL, NULL, ed_pkey)) {
                 st = 0;
                 EVP_PKEY_free(ed_pkey);
                 break;
@@ -3026,9 +3008,11 @@ int speed_main(int argc, char **argv)
 
             EVP_PKEY_CTX_free(ffdh_ctx);
 
-            /* check if the derivation works correctly both ways so that
+            /*
+             * check if the derivation works correctly both ways so that
              * we know if future derive calls will fail, and we can skip
-             * error checking in benchmarked code */
+             * error checking in benchmarked code
+             */
             ffdh_ctx = EVP_PKEY_CTX_new(pkey_A, NULL);
             if (ffdh_ctx == NULL) {
                 BIO_printf(bio_err, "Error while allocating EVP_PKEY_CTX.\n");
@@ -3125,7 +3109,7 @@ int speed_main(int argc, char **argv)
                        ffdh_params[testnum].bits, d);
             ffdh_results[testnum][0] = (double)count / d;
             op_count = count;
-        };
+        }
         if (op_count <= 1) {
             /* if longer than 10s, don't do any more */
             stop_it(ffdh_doit, testnum);
@@ -3140,34 +3124,15 @@ int speed_main(int argc, char **argv)
         printf("built on: %s\n", OpenSSL_version(OPENSSL_BUILT_ON));
         printf("options:");
         printf("%s ", BN_options());
-#if !defined(OPENSSL_NO_MD2) && !defined(OPENSSL_NO_DEPRECATED_3_0)
-        printf("%s ", MD2_options());
-#endif
-#if !defined(OPENSSL_NO_RC4) && !defined(OPENSSL_NO_DEPRECATED_3_0)
-        printf("%s ", RC4_options());
-#endif
-#if !defined(OPENSSL_NO_DES) && !defined(OPENSSL_NO_DEPRECATED_3_0)
-        printf("%s ", DES_options());
-#endif
-#ifndef OPENSSL_NO_DEPRECATED_3_0
-        printf("%s ", AES_options());
-#endif
-#if !defined(OPENSSL_NO_IDEA) && !defined(OPENSSL_NO_DEPRECATED_3_0)
-        printf("%s ", IDEA_options());
-#endif
-#if !defined(OPENSSL_NO_BF) && !defined(OPENSSL_NO_DEPRECATED_3_0)
-        printf("%s ", BF_options());
-#endif
         printf("\n%s\n", OpenSSL_version(OPENSSL_CFLAGS));
         printf("%s\n", OpenSSL_version(OPENSSL_CPU_INFO));
     }
 
     if (pr_header) {
-        if (mr)
+        if (mr) {
             printf("+H");
-        else {
-            printf
-                ("The 'numbers' are in 1000s of bytes per second processed.\n");
+        } else {
+            printf("The 'numbers' are in 1000s of bytes per second processed.\n");
             printf("type        ");
         }
         for (testnum = 0; testnum < size_num; testnum++)
@@ -3340,9 +3305,8 @@ int speed_main(int argc, char **argv)
 #ifndef OPENSSL_NO_DH
         OPENSSL_free(loopargs[i].secret_ff_a);
         OPENSSL_free(loopargs[i].secret_ff_b);
-        for (k = 0; k < FFDH_NUM; k++) {
+        for (k = 0; k < FFDH_NUM; k++)
             EVP_PKEY_CTX_free(loopargs[i].ffdh_ctx[k]);
-        }
 #endif
         for (k = 0; k < DSA_NUM; k++) {
             EVP_PKEY_CTX_free(loopargs[i].dsa_sign_ctx[k]);
@@ -3357,7 +3321,7 @@ int speed_main(int argc, char **argv)
         for (k = 0; k < EdDSA_NUM; k++) {
             EVP_MD_CTX_free(loopargs[i].eddsa_ctx[k]);
             EVP_MD_CTX_free(loopargs[i].eddsa_ctx2[k]);
-	}
+        }
 #ifndef OPENSSL_NO_SM2
         for (k = 0; k < SM2_NUM; k++) {
             EVP_PKEY_CTX *pctx = NULL;
@@ -3424,7 +3388,6 @@ static void print_result(int alg, int run_no, int count, double time_used)
     if (count == -1) {
         BIO_printf(bio_err, "%s error!\n", names[alg]);
         ERR_print_errors(bio_err);
-        /* exit(1);  disable exit until default provider enabled */
         return;
     }
     BIO_printf(bio_err,
@@ -3450,9 +3413,8 @@ static char *sstrsep(char **string, const char *delim)
         delim++;
     }
 
-    while (!isdelim[(unsigned char)(**string)]) {
+    while (!isdelim[(unsigned char)(**string)])
         (*string)++;
-    }
 
     if (**string) {
         **string = 0;
@@ -3523,8 +3485,7 @@ static int do_multi(int multi, int size_num)
                 sstrsep(&p, sep);
                 for (j = 0; j < size_num; ++j)
                     results[alg][j] += atof(sstrsep(&p, sep));
-            }
-            else if (strncmp(buf, "+F2:", 4) == 0) {
+            } else if (strncmp(buf, "+F2:", 4) == 0) {
                 int k;
                 double d;
 
@@ -3537,8 +3498,7 @@ static int do_multi(int multi, int size_num)
 
                 d = atof(sstrsep(&p, sep));
                 rsa_results[k][1] += d;
-            }
-            else if (strncmp(buf, "+F3:", 4) == 0) {
+            } else if (strncmp(buf, "+F3:", 4) == 0) {
                 int k;
                 double d;
 
@@ -3551,8 +3511,7 @@ static int do_multi(int multi, int size_num)
 
                 d = atof(sstrsep(&p, sep));
                 dsa_results[k][1] += d;
-            }
-            else if (strncmp(buf, "+F4:", 4) == 0) {
+            } else if (strncmp(buf, "+F4:", 4) == 0) {
                 int k;
                 double d;
 
@@ -3589,9 +3548,8 @@ static int do_multi(int multi, int size_num)
 
                 d = atof(sstrsep(&p, sep));
                 eddsa_results[k][1] += d;
-            }
 # ifndef OPENSSL_NO_SM2
-            else if (strncmp(buf, "+F7:", 4) == 0) {
+            } else if (strncmp(buf, "+F7:", 4) == 0) {
                 int k;
                 double d;
 
@@ -3605,10 +3563,9 @@ static int do_multi(int multi, int size_num)
 
                 d = atof(sstrsep(&p, sep));
                 sm2_results[k][1] += d;
-            }
 # endif /* OPENSSL_NO_SM2 */
 # ifndef OPENSSL_NO_DH
-            else if (strncmp(buf, "+F8:", 4) == 0) {
+            } else if (strncmp(buf, "+F8:", 4) == 0) {
                 int k;
                 double d;
 
@@ -3618,14 +3575,13 @@ static int do_multi(int multi, int size_num)
 
                 d = atof(sstrsep(&p, sep));
                 ffdh_results[k][0] += d;
-            }
 # endif /* OPENSSL_NO_DH */
-
-            else if (strncmp(buf, "+H:", 3) == 0) {
+            } else if (strncmp(buf, "+H:", 3) == 0) {
                 ;
-            } else
+            } else {
                 BIO_printf(bio_err, "Unknown type '%s' from child %d\n", buf,
                            n);
+            }
         }
 
         fclose(f);

--- a/apps/speed.c
+++ b/apps/speed.c
@@ -9,14 +9,16 @@
  */
 
 #undef SECONDS
-#define SECONDS                 3
-#define RSA_SECONDS             10
-#define DSA_SECONDS             10
-#define ECDSA_SECONDS   10
-#define ECDH_SECONDS    10
-#define EdDSA_SECONDS   10
-#define SM2_SECONDS     10
-#define FFDH_SECONDS    10
+#define SECONDS          3
+#define PKEY_SECONDS    10
+
+#define RSA_SECONDS     PKEY_SECONDS
+#define DSA_SECONDS     PKEY_SECONDS
+#define ECDSA_SECONDS   PKEY_SECONDS
+#define ECDH_SECONDS    PKEY_SECONDS
+#define EdDSA_SECONDS   PKEY_SECONDS
+#define SM2_SECONDS     PKEY_SECONDS
+#define FFDH_SECONDS    PKEY_SECONDS
 
 /* We need to use some deprecated APIs */
 #define OPENSSL_SUPPRESS_DEPRECATED
@@ -32,6 +34,7 @@
 #include <openssl/err.h>
 #include <openssl/evp.h>
 #include <openssl/objects.h>
+#include <openssl/core_names.h>
 #include <openssl/async.h>
 #if !defined(OPENSSL_SYS_MSDOS)
 # include <unistd.h>
@@ -54,51 +57,23 @@
 #ifndef OPENSSL_NO_DEPRECATED_3_0
 #include <openssl/aes.h>
 #endif
-#ifndef OPENSSL_NO_CAMELLIA
-# include <openssl/camellia.h>
-#endif
 #ifndef OPENSSL_NO_MD2
 # include <openssl/md2.h>
-#endif
-#ifndef OPENSSL_NO_CMAC
-#include <openssl/cmac.h>
 #endif
 #ifndef OPENSSL_NO_RC4
 # include <openssl/rc4.h>
 #endif
-#ifndef OPENSSL_NO_RC5
-# include <openssl/rc5.h>
-#endif
-#ifndef OPENSSL_NO_RC2
-# include <openssl/rc2.h>
-#endif
 #ifndef OPENSSL_NO_IDEA
 # include <openssl/idea.h>
-#endif
-#ifndef OPENSSL_NO_SEED
-# include <openssl/seed.h>
 #endif
 #ifndef OPENSSL_NO_BF
 # include <openssl/blowfish.h>
 #endif
-#ifndef OPENSSL_NO_CAST
-# include <openssl/cast.h>
-#endif
-#ifndef OPENSSL_NO_DEPRECATED_3_0
-# include <openssl/rsa.h>
-# include "./testrsa.h"
-#endif
-#ifndef OPENSSL_NO_DH
-# include <openssl/dh.h>
-#endif
+#include <openssl/rsa.h>
+#include "./testrsa.h"
 #include <openssl/x509.h>
-#if !defined(OPENSSL_NO_DSA) && !defined(OPENSSL_NO_DEPRECATED_3_0)
-# include <openssl/dsa.h>
-# include "./testdsa.h"
-#endif
-#ifndef OPENSSL_NO_EC
-# include <openssl/ec.h>
-#endif
+#include <openssl/dsa.h>
+#include "./testdsa.h"
 #include <openssl/modes.h>
 
 #ifndef HAVE_FORK
@@ -138,13 +113,8 @@ static int usertime = 1;
 
 static double Time_F(int s);
 static void print_message(const char *s, long num, int length, int tm);
-#if !defined(OPENSSL_NO_DEPRECATED_3_0)         \
-    || !defined(OPENSSL_NO_DSA)                 \
-    || !defined(OPENSSL_NO_DH)                  \
-    || !defined(OPENSSL_NO_EC)
 static void pkey_print_message(const char *str, const char *str2,
                                long num, unsigned int bits, int sec);
-#endif
 static void print_result(int alg, int run_no, int count, double time_used);
 #ifndef NO_FORK
 static int do_multi(int multi, int size_num);
@@ -276,12 +246,8 @@ const OPTIONS speed_options[] = {
 
     OPT_SECTION("Selection"),
     {"evp", OPT_EVP, 's', "Use EVP-named cipher or digest"},
-#ifndef OPENSSL_NO_DEPRECATED_3_0
     {"hmac", OPT_HMAC, 's', "HMAC using EVP-named digest"},
-#endif
-#if !defined(OPENSSL_NO_CMAC) && !defined(OPENSSL_NO_DEPRECATED_3_0)
     {"cmac", OPT_CMAC, 's', "CMAC using EVP-named cipher"},
-#endif
     {"decrypt", OPT_DECRYPT, '-',
      "Time decryption instead of encryption (only EVP)"},
     {"aead", OPT_AEAD, '-',
@@ -308,23 +274,21 @@ const OPTIONS speed_options[] = {
 enum {
     D_MD2, D_MDC2, D_MD4, D_MD5, D_SHA1, D_RMD160,
     D_SHA256, D_SHA512, D_WHIRLPOOL, D_HMAC,
-    D_RC4, D_CBC_DES, D_EDE3_DES, D_CBC_IDEA, D_CBC_SEED,
+    D_CBC_DES, D_EDE3_DES, D_RC4, D_CBC_IDEA, D_CBC_SEED,
     D_CBC_RC2, D_CBC_RC5, D_CBC_BF, D_CBC_CAST,
     D_CBC_128_AES, D_CBC_192_AES, D_CBC_256_AES,
     D_CBC_128_CML, D_CBC_192_CML, D_CBC_256_CML,
-    D_EVP, D_IGE_128_AES, D_IGE_192_AES, D_IGE_256_AES,
-    D_GHASH, D_RAND, D_EVP_CMAC, ALGOR_NUM 
+    D_EVP, D_GHASH, D_RAND, D_EVP_CMAC, ALGOR_NUM 
 };
 /* name of algorithms to test. MUST BE KEEP IN SYNC with above enum ! */
 static const char *names[ALGOR_NUM] = {
     "md2", "mdc2", "md4", "md5", "sha1", "rmd160",
     "sha256", "sha512", "whirlpool", "hmac(md5)",
-    "rc4", "des cbc", "des ede3", "idea cbc", "seed cbc",
-    "rc2 cbc", "rc5-32/12 cbc", "blowfish cbc", "cast cbc",
-    "aes-128 cbc", "aes-192 cbc", "aes-256 cbc",
-    "camellia-128 cbc", "camellia-192 cbc", "camellia-256 cbc",
-    "evp", "aes-128 ige", "aes-192 ige", "aes-256 ige", "ghash",
-    "rand", "cmac"
+    "des-cbc", "des-ede3", "rc4", "idea-cbc", "seed-cbc",
+    "rc2-cbc", "rc5-cbc", "blowfish", "cast-cbc",
+    "aes-128-cbc", "aes-192-cbc", "aes-256-cbc",
+    "camellia-128-cbc", "camellia-192-cbc", "camellia-256-cbc",
+    "evp", "ghash", "rand", "cmac"
 };
 
 /* list of configured algorithm (remaining), with some few alias */
@@ -341,54 +305,35 @@ static const OPT_PAIR doit_choices[] = {
     {"ripemd", D_RMD160},
     {"rmd160", D_RMD160},
     {"ripemd160", D_RMD160},
-#if !defined(OPENSSL_NO_RC4) && !defined(OPENSSL_NO_DEPRECATED_3_0)
     {"rc4", D_RC4},
-#endif
-#if !defined(OPENSSL_NO_DES) && !defined(OPENSSL_NO_DEPRECATED_3_0)
     {"des-cbc", D_CBC_DES},
     {"des-ede3", D_EDE3_DES},
-#endif
-#ifndef OPENSSL_NO_DEPRECATED_3_0
     {"aes-128-cbc", D_CBC_128_AES},
     {"aes-192-cbc", D_CBC_192_AES},
     {"aes-256-cbc", D_CBC_256_AES},
-    {"aes-128-ige", D_IGE_128_AES},
-    {"aes-192-ige", D_IGE_192_AES},
-    {"aes-256-ige", D_IGE_256_AES},
-#endif
-#if !defined(OPENSSL_NO_RC2) && !defined(OPENSSL_NO_DEPRECATED_3_0)
+    {"camellia-128-cbc", D_CBC_128_CML},
+    {"camellia-192-cbc", D_CBC_192_CML},
+    {"camellia-256-cbc", D_CBC_256_CML},
     {"rc2-cbc", D_CBC_RC2},
     {"rc2", D_CBC_RC2},
-#endif
-#if !defined(OPENSSL_NO_RC5) && !defined(OPENSSL_NO_DEPRECATED_3_0)
     {"rc5-cbc", D_CBC_RC5},
     {"rc5", D_CBC_RC5},
-#endif
-#if !defined(OPENSSL_NO_IDEA) && !defined(OPENSSL_NO_DEPRECATED_3_0)
     {"idea-cbc", D_CBC_IDEA},
     {"idea", D_CBC_IDEA},
-#endif
-#if !defined(OPENSSL_NO_SEED) && !defined(OPENSSL_NO_DEPRECATED_3_0)
     {"seed-cbc", D_CBC_SEED},
     {"seed", D_CBC_SEED},
-#endif
-#if !defined(OPENSSL_NO_BF) && !defined(OPENSSL_NO_DEPRECATED_3_0)
     {"bf-cbc", D_CBC_BF},
     {"blowfish", D_CBC_BF},
     {"bf", D_CBC_BF},
-#endif
-#if !defined(OPENSSL_NO_CAST) && !defined(OPENSSL_NO_DEPRECATED_3_0)
     {"cast-cbc", D_CBC_CAST},
     {"cast", D_CBC_CAST},
     {"cast5", D_CBC_CAST},
-#endif
     {"ghash", D_GHASH},
     {"rand", D_RAND}
 };
 
 static double results[ALGOR_NUM][SIZE_NUM];
 
-#if !defined(OPENSSL_NO_DSA) && !defined(OPENSSL_NO_DEPRECATED_3_0)
 enum { R_DSA_512, R_DSA_1024, R_DSA_2048, DSA_NUM };
 static const OPT_PAIR dsa_choices[DSA_NUM] = {
     {"dsa512", R_DSA_512},
@@ -396,9 +341,7 @@ static const OPT_PAIR dsa_choices[DSA_NUM] = {
     {"dsa2048", R_DSA_2048}
 };
 static double dsa_results[DSA_NUM][2];  /* 2 ops: sign then verify */
-#endif  /* OPENSSL_NO_DSA */
 
-#ifndef OPENSSL_NO_DEPRECATED_3_0
 enum {
     R_RSA_512, R_RSA_1024, R_RSA_2048, R_RSA_3072, R_RSA_4096, R_RSA_7680,
     R_RSA_15360, RSA_NUM
@@ -414,7 +357,6 @@ static const OPT_PAIR rsa_choices[RSA_NUM] = {
 };
 
 static double rsa_results[RSA_NUM][2];  /* 2 ops: sign then verify */
-#endif /* OPENSSL_NO_DEPRECATED_3_0 */
 
 #ifndef OPENSSL_NO_DH
 enum ff_params_t {
@@ -432,13 +374,12 @@ static const OPT_PAIR ffdh_choices[FFDH_NUM] = {
 static double ffdh_results[FFDH_NUM][1];  /* 1 op: derivation */
 #endif /* OPENSSL_NO_DH */
 
-#ifndef OPENSSL_NO_EC
 enum ec_curves_t {
     R_EC_P160, R_EC_P192, R_EC_P224, R_EC_P256, R_EC_P384, R_EC_P521,
-# ifndef OPENSSL_NO_EC2M
+#ifndef OPENSSL_NO_EC2M
     R_EC_K163, R_EC_K233, R_EC_K283, R_EC_K409, R_EC_K571,
     R_EC_B163, R_EC_B233, R_EC_B283, R_EC_B409, R_EC_B571,
-# endif
+#endif
     R_EC_BRP256R1, R_EC_BRP256T1, R_EC_BRP384R1, R_EC_BRP384T1,
     R_EC_BRP512R1, R_EC_BRP512T1, ECDSA_NUM
 };
@@ -450,7 +391,7 @@ static const OPT_PAIR ecdsa_choices[ECDSA_NUM] = {
     {"ecdsap256", R_EC_P256},
     {"ecdsap384", R_EC_P384},
     {"ecdsap521", R_EC_P521},
-# ifndef OPENSSL_NO_EC2M
+#ifndef OPENSSL_NO_EC2M
     {"ecdsak163", R_EC_K163},
     {"ecdsak233", R_EC_K233},
     {"ecdsak283", R_EC_K283},
@@ -461,7 +402,7 @@ static const OPT_PAIR ecdsa_choices[ECDSA_NUM] = {
     {"ecdsab283", R_EC_B283},
     {"ecdsab409", R_EC_B409},
     {"ecdsab571", R_EC_B571},
-# endif
+#endif
     {"ecdsabrp256r1", R_EC_BRP256R1},
     {"ecdsabrp256t1", R_EC_BRP256T1},
     {"ecdsabrp384r1", R_EC_BRP384R1},
@@ -478,7 +419,7 @@ static const OPT_PAIR ecdh_choices[EC_NUM] = {
     {"ecdhp256", R_EC_P256},
     {"ecdhp384", R_EC_P384},
     {"ecdhp521", R_EC_P521},
-# ifndef OPENSSL_NO_EC2M
+#ifndef OPENSSL_NO_EC2M
     {"ecdhk163", R_EC_K163},
     {"ecdhk233", R_EC_K233},
     {"ecdhk283", R_EC_K283},
@@ -489,7 +430,7 @@ static const OPT_PAIR ecdh_choices[EC_NUM] = {
     {"ecdhb283", R_EC_B283},
     {"ecdhb409", R_EC_B409},
     {"ecdhb571", R_EC_B571},
-# endif
+#endif
     {"ecdhbrp256r1", R_EC_BRP256R1},
     {"ecdhbrp256t1", R_EC_BRP256T1},
     {"ecdhbrp384r1", R_EC_BRP384R1},
@@ -511,16 +452,15 @@ static const OPT_PAIR eddsa_choices[EdDSA_NUM] = {
 };
 static double eddsa_results[EdDSA_NUM][2];    /* 2 ops: sign then verify */
 
-# ifndef OPENSSL_NO_SM2
+#ifndef OPENSSL_NO_SM2
 enum { R_EC_CURVESM2, SM2_NUM };
 static const OPT_PAIR sm2_choices[SM2_NUM] = {
     {"curveSM2", R_EC_CURVESM2}
 };
-#  define SM2_ID        "TLSv1.3+GM+Cipher+Suite"
-#  define SM2_ID_LEN    sizeof("TLSv1.3+GM+Cipher+Suite") - 1
+# define SM2_ID        "TLSv1.3+GM+Cipher+Suite"
+# define SM2_ID_LEN    sizeof("TLSv1.3+GM+Cipher+Suite") - 1
 static double sm2_results[SM2_NUM][2];    /* 2 ops: sign then verify */
-# endif /* OPENSSL_NO_SM2 */
-#endif /* OPENSSL_NO_EC */
+#endif /* OPENSSL_NO_SM2 */
 
 #define COND(unused_cond) (run && count<0x7fffffff)
 #define COUNT(d) (count)
@@ -533,30 +473,24 @@ typedef struct loopargs_st {
     unsigned char *buf_malloc;
     unsigned char *buf2_malloc;
     unsigned char *key;
-    unsigned int siglen;
     size_t sigsize;
-#ifndef OPENSSL_NO_DEPRECATED_3_0
-    RSA *rsa_key[RSA_NUM];
-#endif
-#if !defined(OPENSSL_NO_DSA) && !defined(OPENSSL_NO_DEPRECATED_3_0)
-    DSA *dsa_key[DSA_NUM];
-#endif
-#ifndef OPENSSL_NO_EC
-# ifndef OPENSSL_NO_DEPRECATED_3_0
-    EC_KEY *ecdsa[ECDSA_NUM];
-# endif
+    EVP_PKEY_CTX *rsa_sign_ctx[RSA_NUM];
+    EVP_PKEY_CTX *rsa_verify_ctx[RSA_NUM];
+    EVP_PKEY_CTX *dsa_sign_ctx[DSA_NUM];
+    EVP_PKEY_CTX *dsa_verify_ctx[DSA_NUM];
+    EVP_PKEY_CTX *ecdsa_sign_ctx[ECDSA_NUM];
+    EVP_PKEY_CTX *ecdsa_verify_ctx[ECDSA_NUM];
     EVP_PKEY_CTX *ecdh_ctx[EC_NUM];
     EVP_MD_CTX *eddsa_ctx[EdDSA_NUM];
     EVP_MD_CTX *eddsa_ctx2[EdDSA_NUM];
-# ifndef OPENSSL_NO_SM2
+#ifndef OPENSSL_NO_SM2
     EVP_MD_CTX *sm2_ctx[SM2_NUM];
     EVP_MD_CTX *sm2_vfy_ctx[SM2_NUM];
     EVP_PKEY *sm2_pkey[SM2_NUM];
-# endif
+#endif
     unsigned char *secret_a;
     unsigned char *secret_b;
     size_t outlen[EC_NUM];
-#endif
 #ifndef OPENSSL_NO_DH
     EVP_PKEY_CTX *ffdh_ctx[FFDH_NUM];
     unsigned char *secret_ff_a;
@@ -564,10 +498,6 @@ typedef struct loopargs_st {
 #endif
     EVP_CIPHER_CTX *ctx;
     EVP_MAC_CTX *mctx;
-#if !defined(OPENSSL_NO_CMAC) && !defined(OPENSSL_NO_DEPRECATED_3_0)
-    CMAC_CTX *cmac_ctx;
-#endif
-    GCM128_CONTEXT *gcm_ctx;
 } loopargs_t;
 static int run_benchmark(int async_jobs, int (*loop_function) (void *),
                          loopargs_t * loopargs);
@@ -580,6 +510,8 @@ static long c[ALGOR_NUM][SIZE_NUM];
 static char *evp_mac_mdname = "md5";
 static char *evp_hmac_name = NULL;
 static const char *evp_md_name = NULL;
+static char *evp_mac_ciphername = "aes-128-cbc";
+static char *evp_cmac_name = NULL;
 
 static EVP_MD *obtain_md(const char *name, int *fetched)
 {
@@ -601,14 +533,55 @@ static EVP_MD *obtain_md(const char *name, int *fetched)
 static int have_md(const char *name)
 {
     int fetched = 0;
+    int ret = 0;
     EVP_MD *md = obtain_md(name, &fetched);
 
     if (md != NULL) {
+        EVP_MD_CTX *ctx = EVP_MD_CTX_new();
+
+        if (ctx != NULL && EVP_DigestInit(ctx, md) > 0)
+            ret = 1;
+        EVP_MD_CTX_free(ctx);
         if (fetched)
             EVP_MD_free(md);
-        return 1;
     }
-    return 0;
+    return ret;
+}
+
+static EVP_CIPHER *obtain_cipher(const char *name, int *fetched)
+{
+    EVP_CIPHER *cipher = NULL;
+
+    *fetched = 0;
+    /* Look through providers' digests */
+    ERR_set_mark();
+    cipher = EVP_CIPHER_fetch(NULL, name, NULL);
+    ERR_pop_to_mark();
+    if (cipher != NULL) {
+        *fetched = 1;
+        return cipher;
+    }
+
+    return (EVP_CIPHER *)EVP_get_cipherbyname(name);
+}
+
+static int have_cipher(const char *name)
+{
+    int fetched = 0;
+    int ret = 0;
+    EVP_CIPHER *cipher = obtain_cipher(name, &fetched);
+
+    if (cipher != NULL) {
+        EVP_CIPHER_CTX *ctx = EVP_CIPHER_CTX_new();
+
+        if (ctx != NULL
+            && EVP_CipherInit_ex(ctx, cipher, NULL, NULL, NULL, 1) > 0)
+            ret = 1;
+        EVP_CIPHER_CTX_free(ctx);
+        if (fetched)
+            EVP_CIPHER_free(cipher);
+    }
+    return ret;
 }
 
 static int EVP_Digest_loop(const char *mdname, int algindex, void *args)
@@ -617,20 +590,10 @@ static int EVP_Digest_loop(const char *mdname, int algindex, void *args)
     unsigned char *buf = tempargs->buf;
     unsigned char digest[EVP_MAX_MD_SIZE];
     int count, fetched = 0;
-    EVP_MD *md = NULL;
-
-    /* Look through providers' digests */
-    ERR_set_mark();
-    md = EVP_MD_fetch(NULL, mdname, NULL);
-    ERR_pop_to_mark();
-    if (md != NULL)
-        fetched = 1;
-    else
-        md = (EVP_MD *)EVP_get_digestbyname(mdname);
+    EVP_MD *md = obtain_md(mdname, &fetched);
 
     if (md == NULL)
         return -1;
-
     for (count = 0; COND(c[algindex][testnum]); count++) {
         if (!EVP_Digest(buf, (size_t)lengths[testnum], digest, NULL, md,
                         NULL)) {
@@ -668,7 +631,7 @@ static int MD5_loop(void *args)
     return EVP_Digest_loop("md5", D_MD5, args);
 }
 
-static int HMAC_loop(void *args)
+static int EVP_MAC_loop(int algindex, void *args)
 {
     loopargs_t *tempargs = *(loopargs_t **) args;
     unsigned char *buf = tempargs->buf;
@@ -676,7 +639,7 @@ static int HMAC_loop(void *args)
     unsigned char mac[EVP_MAX_MD_SIZE];
     int count;
 
-    for (count = 0; COND(c[D_HMAC][testnum]); count++) {
+    for (count = 0; COND(c[algindex][testnum]); count++) {
         size_t outl;
         if (!EVP_MAC_init(mctx)
             || !EVP_MAC_update(mctx, buf, lengths[testnum])
@@ -684,6 +647,16 @@ static int HMAC_loop(void *args)
             return -1;
     }
     return count;
+}
+
+static int HMAC_loop(void *args)
+{
+    return EVP_MAC_loop(D_HMAC, args);
+}
+
+static int CMAC_loop(void *args)
+{
+    return EVP_MAC_loop(D_EVP_CMAC, args);
 }
 
 static int SHA1_loop(void *args)
@@ -711,131 +684,75 @@ static int EVP_Digest_RMD160_loop(void *args)
     return EVP_Digest_loop("ripemd160", D_RMD160, args);
 }
 
-#if !defined(OPENSSL_NO_RC4) && !defined(OPENSSL_NO_DEPRECATED_3_0)
-static RC4_KEY rc4_ks;
-static int RC4_loop(void *args)
-{
-    loopargs_t *tempargs = *(loopargs_t **) args;
-    unsigned char *buf = tempargs->buf;
-    int count;
-    for (count = 0; COND(c[D_RC4][testnum]); count++)
-        RC4(&rc4_ks, (size_t)lengths[testnum], buf, buf);
-    return count;
-}
-#endif
+static int algindex;
 
-#if !defined(OPENSSL_NO_DES) && !defined(OPENSSL_NO_DEPRECATED_3_0)
-static unsigned char DES_iv[8];
-static DES_key_schedule sch[3];
-static int DES_ncbc_encrypt_loop(void *args)
+static int EVP_Cipher_loop(void *args)
 {
     loopargs_t *tempargs = *(loopargs_t **) args;
     unsigned char *buf = tempargs->buf;
     int count;
-    for (count = 0; COND(c[D_CBC_DES][testnum]); count++)
-        DES_ncbc_encrypt(buf, buf, lengths[testnum], &sch[0],
-                         &DES_iv, DES_ENCRYPT);
+
+    if (tempargs->ctx == NULL)
+        return -1;
+    for (count = 0; COND(c[algindex][testnum]); count++)
+        if (EVP_Cipher(tempargs->ctx, buf, buf, (size_t)lengths[testnum]) <= 0)
+            return -1;
     return count;
 }
 
-static int DES_ede3_cbc_encrypt_loop(void *args)
+static int GHASH_loop(void *args)
 {
     loopargs_t *tempargs = *(loopargs_t **) args;
     unsigned char *buf = tempargs->buf;
+    EVP_MAC_CTX *mctx = tempargs->mctx;
     int count;
-    for (count = 0; COND(c[D_EDE3_DES][testnum]); count++)
-        DES_ede3_cbc_encrypt(buf, buf, lengths[testnum],
-                             &sch[0], &sch[1], &sch[2], &DES_iv, DES_ENCRYPT);
+
+    /* just do the update in the loop to be comparable with 1.1.1 */
+    for (count = 0; COND(c[D_GHASH][testnum]); count++) {
+        if (!EVP_MAC_update(mctx, buf, lengths[testnum]))
+            return -1;
+    }
     return count;
 }
-#endif
+
 
 #define MAX_BLOCK_SIZE 128
 
 static unsigned char iv[2 * MAX_BLOCK_SIZE / 8];
 
-#ifndef OPENSSL_NO_DEPRECATED_3_0
-static AES_KEY aes_ks1, aes_ks2, aes_ks3;
-static int AES_cbc_128_encrypt_loop(void *args)
+static EVP_CIPHER_CTX *init_evp_cipher_ctx(const char *ciphername,
+                                           const unsigned char *key,
+                                           int keylen)
 {
-    loopargs_t *tempargs = *(loopargs_t **) args;
-    unsigned char *buf = tempargs->buf;
-    int count;
-    for (count = 0; COND(c[D_CBC_128_AES][testnum]); count++)
-        AES_cbc_encrypt(buf, buf,
-                        (size_t)lengths[testnum], &aes_ks1, iv, AES_ENCRYPT);
-    return count;
-}
+    EVP_CIPHER_CTX *ctx = NULL;
+    int fetched = 0;
+    EVP_CIPHER *cipher = obtain_cipher(ciphername, &fetched);
 
-static int AES_cbc_192_encrypt_loop(void *args)
-{
-    loopargs_t *tempargs = *(loopargs_t **) args;
-    unsigned char *buf = tempargs->buf;
-    int count;
-    for (count = 0; COND(c[D_CBC_192_AES][testnum]); count++)
-        AES_cbc_encrypt(buf, buf,
-                        (size_t)lengths[testnum], &aes_ks2, iv, AES_ENCRYPT);
-    return count;
-}
+    if (cipher == NULL)
+        return NULL;
 
-static int AES_cbc_256_encrypt_loop(void *args)
-{
-    loopargs_t *tempargs = *(loopargs_t **) args;
-    unsigned char *buf = tempargs->buf;
-    int count;
-    for (count = 0; COND(c[D_CBC_256_AES][testnum]); count++)
-        AES_cbc_encrypt(buf, buf,
-                        (size_t)lengths[testnum], &aes_ks3, iv, AES_ENCRYPT);
-    return count;
-}
+    if ((ctx = EVP_CIPHER_CTX_new()) == NULL)
+        goto end;
 
-static int AES_ige_128_encrypt_loop(void *args)
-{
-    loopargs_t *tempargs = *(loopargs_t **) args;
-    unsigned char *buf = tempargs->buf;
-    unsigned char *buf2 = tempargs->buf2;
-    int count;
-    for (count = 0; COND(c[D_IGE_128_AES][testnum]); count++)
-        AES_ige_encrypt(buf, buf2,
-                        (size_t)lengths[testnum], &aes_ks1, iv, AES_ENCRYPT);
-    return count;
-}
+    if (!EVP_CipherInit_ex(ctx, cipher, NULL, NULL, NULL, 1)) {
+        EVP_CIPHER_CTX_free(ctx);
+        ctx = NULL;
+        goto end;
+    }
+    
+    EVP_CIPHER_CTX_set_key_length(ctx, keylen);
 
-static int AES_ige_192_encrypt_loop(void *args)
-{
-    loopargs_t *tempargs = *(loopargs_t **) args;
-    unsigned char *buf = tempargs->buf;
-    unsigned char *buf2 = tempargs->buf2;
-    int count;
-    for (count = 0; COND(c[D_IGE_192_AES][testnum]); count++)
-        AES_ige_encrypt(buf, buf2,
-                        (size_t)lengths[testnum], &aes_ks2, iv, AES_ENCRYPT);
-    return count;
-}
+    if (!EVP_CipherInit_ex(ctx, NULL, NULL, key, iv, 1)) {
+        EVP_CIPHER_CTX_free(ctx);
+        ctx = NULL;
+        goto end;
+    }
 
-static int AES_ige_256_encrypt_loop(void *args)
-{
-    loopargs_t *tempargs = *(loopargs_t **) args;
-    unsigned char *buf = tempargs->buf;
-    unsigned char *buf2 = tempargs->buf2;
-    int count;
-    for (count = 0; COND(c[D_IGE_256_AES][testnum]); count++)
-        AES_ige_encrypt(buf, buf2,
-                        (size_t)lengths[testnum], &aes_ks3, iv, AES_ENCRYPT);
-    return count;
+end:
+    if (fetched)
+        EVP_CIPHER_free(cipher);
+    return ctx;
 }
-
-static int CRYPTO_gcm128_aad_loop(void *args)
-{
-    loopargs_t *tempargs = *(loopargs_t **) args;
-    unsigned char *buf = tempargs->buf;
-    GCM128_CONTEXT *gcm_ctx = tempargs->gcm_ctx;
-    int count;
-    for (count = 0; COND(c[D_GHASH][testnum]); count++)
-        CRYPTO_gcm128_aad(gcm_ctx, buf, lengths[testnum]);
-    return count;
-}
-#endif
 
 static int RAND_bytes_loop(void *args)
 {
@@ -950,31 +867,6 @@ static int EVP_Update_loop_aead(void *args)
     return count;
 }
 
-#if !defined(OPENSSL_NO_CMAC) && !defined(OPENSSL_NO_DEPRECATED_3_0)
-static const EVP_CIPHER *evp_cmac_cipher = NULL;
-static char *evp_cmac_name = NULL;
-
-static int EVP_CMAC_loop(void *args)
-{
-    loopargs_t *tempargs = *(loopargs_t **) args;
-    unsigned char *buf = tempargs->buf;
-    CMAC_CTX *cmac_ctx = tempargs->cmac_ctx;
-    static const char key[16] = "This is a key...";
-    unsigned char mac[16];
-    size_t len = sizeof(mac);
-    int count;
-
-    for (count = 0; COND(c[D_EVP_CMAC][testnum]); count++) {
-        if (!CMAC_Init(cmac_ctx, key, sizeof(key), evp_cmac_cipher, NULL)
-                || !CMAC_Update(cmac_ctx, buf, lengths[testnum])
-                || !CMAC_Final(cmac_ctx, mac, &len))
-            return -1;
-    }
-    return count;
-}
-#endif
-
-#ifndef OPENSSL_NO_DEPRECATED_3_0
 static long rsa_c[RSA_NUM][2];  /* # RSA iteration test */
 
 static int RSA_sign_loop(void *args)
@@ -982,12 +874,12 @@ static int RSA_sign_loop(void *args)
     loopargs_t *tempargs = *(loopargs_t **) args;
     unsigned char *buf = tempargs->buf;
     unsigned char *buf2 = tempargs->buf2;
-    unsigned int *rsa_num = &tempargs->siglen;
-    RSA **rsa_key = tempargs->rsa_key;
+    size_t *rsa_num = &tempargs->sigsize;
+    EVP_PKEY_CTX **rsa_sign_ctx = tempargs->rsa_sign_ctx;
     int ret, count;
     for (count = 0; COND(rsa_c[testnum][0]); count++) {
-        ret = RSA_sign(NID_md5_sha1, buf, 36, buf2, rsa_num, rsa_key[testnum]);
-        if (ret == 0) {
+        ret = EVP_PKEY_sign(rsa_sign_ctx[testnum], buf2, rsa_num, buf, 36);
+        if (ret <= 0) {
             BIO_printf(bio_err, "RSA sign failure\n");
             ERR_print_errors(bio_err);
             count = -1;
@@ -1002,12 +894,11 @@ static int RSA_verify_loop(void *args)
     loopargs_t *tempargs = *(loopargs_t **) args;
     unsigned char *buf = tempargs->buf;
     unsigned char *buf2 = tempargs->buf2;
-    unsigned int rsa_num = tempargs->siglen;
-    RSA **rsa_key = tempargs->rsa_key;
+    size_t rsa_num = tempargs->sigsize;
+    EVP_PKEY_CTX **rsa_verify_ctx = tempargs->rsa_verify_ctx;
     int ret, count;
     for (count = 0; COND(rsa_c[testnum][1]); count++) {
-        ret =
-            RSA_verify(NID_md5_sha1, buf, 36, buf2, rsa_num, rsa_key[testnum]);
+        ret = EVP_PKEY_verify(rsa_verify_ctx[testnum], buf2, rsa_num, buf, 36);
         if (ret <= 0) {
             BIO_printf(bio_err, "RSA verify failure\n");
             ERR_print_errors(bio_err);
@@ -1017,7 +908,6 @@ static int RSA_verify_loop(void *args)
     }
     return count;
 }
-#endif
 
 #ifndef OPENSSL_NO_DH
 static long ffdh_c[FFDH_NUM][1];
@@ -1037,19 +927,18 @@ static int FFDH_derive_key_loop(void *args)
 }
 #endif /* OPENSSL_NO_DH */
 
-#if !defined(OPENSSL_NO_DSA) && !defined(OPENSSL_NO_DEPRECATED_3_0)
 static long dsa_c[DSA_NUM][2];
 static int DSA_sign_loop(void *args)
 {
     loopargs_t *tempargs = *(loopargs_t **) args;
     unsigned char *buf = tempargs->buf;
     unsigned char *buf2 = tempargs->buf2;
-    DSA **dsa_key = tempargs->dsa_key;
-    unsigned int *siglen = &tempargs->siglen;
+    size_t *dsa_num = &tempargs->sigsize;
+    EVP_PKEY_CTX **dsa_sign_ctx = tempargs->dsa_sign_ctx;
     int ret, count;
     for (count = 0; COND(dsa_c[testnum][0]); count++) {
-        ret = DSA_sign(0, buf, 20, buf2, siglen, dsa_key[testnum]);
-        if (ret == 0) {
+        ret = EVP_PKEY_sign(dsa_sign_ctx[testnum], buf2, dsa_num, buf, 20);
+        if (ret <= 0) {
             BIO_printf(bio_err, "DSA sign failure\n");
             ERR_print_errors(bio_err);
             count = -1;
@@ -1064,11 +953,11 @@ static int DSA_verify_loop(void *args)
     loopargs_t *tempargs = *(loopargs_t **) args;
     unsigned char *buf = tempargs->buf;
     unsigned char *buf2 = tempargs->buf2;
-    DSA **dsa_key = tempargs->dsa_key;
-    unsigned int siglen = tempargs->siglen;
+    size_t dsa_num = tempargs->sigsize;
+    EVP_PKEY_CTX **dsa_verify_ctx = tempargs->dsa_verify_ctx;
     int ret, count;
     for (count = 0; COND(dsa_c[testnum][1]); count++) {
-        ret = DSA_verify(0, buf, 20, buf2, siglen, dsa_key[testnum]);
+        ret = EVP_PKEY_verify(dsa_verify_ctx[testnum], buf2, dsa_num, buf, 20);
         if (ret <= 0) {
             BIO_printf(bio_err, "DSA verify failure\n");
             ERR_print_errors(bio_err);
@@ -1078,22 +967,19 @@ static int DSA_verify_loop(void *args)
     }
     return count;
 }
-#endif
 
-#ifndef OPENSSL_NO_EC
-# ifndef OPENSSL_NO_DEPRECATED_3_0
 static long ecdsa_c[ECDSA_NUM][2];
 static int ECDSA_sign_loop(void *args)
 {
     loopargs_t *tempargs = *(loopargs_t **) args;
     unsigned char *buf = tempargs->buf;
-    EC_KEY **ecdsa = tempargs->ecdsa;
-    unsigned char *ecdsasig = tempargs->buf2;
-    unsigned int *ecdsasiglen = &tempargs->siglen;
+    unsigned char *buf2 = tempargs->buf2;
+    size_t *ecdsa_num = &tempargs->sigsize;
+    EVP_PKEY_CTX **ecdsa_sign_ctx = tempargs->ecdsa_sign_ctx;
     int ret, count;
     for (count = 0; COND(ecdsa_c[testnum][0]); count++) {
-        ret = ECDSA_sign(0, buf, 20, ecdsasig, ecdsasiglen, ecdsa[testnum]);
-        if (ret == 0) {
+        ret = EVP_PKEY_sign(ecdsa_sign_ctx[testnum], buf2, ecdsa_num, buf, 20);
+        if (ret <= 0) {
             BIO_printf(bio_err, "ECDSA sign failure\n");
             ERR_print_errors(bio_err);
             count = -1;
@@ -1107,13 +993,13 @@ static int ECDSA_verify_loop(void *args)
 {
     loopargs_t *tempargs = *(loopargs_t **) args;
     unsigned char *buf = tempargs->buf;
-    EC_KEY **ecdsa = tempargs->ecdsa;
-    unsigned char *ecdsasig = tempargs->buf2;
-    unsigned int ecdsasiglen = tempargs->siglen;
+    unsigned char *buf2 = tempargs->buf2;
+    size_t ecdsa_num = tempargs->sigsize;
+    EVP_PKEY_CTX **ecdsa_verify_ctx = tempargs->ecdsa_verify_ctx;
     int ret, count;
     for (count = 0; COND(ecdsa_c[testnum][1]); count++) {
-        ret = ECDSA_verify(0, buf, 20, ecdsasig, ecdsasiglen, ecdsa[testnum]);
-        if (ret != 1) {
+        ret = EVP_PKEY_verify(ecdsa_verify_ctx[testnum], buf2, ecdsa_num, buf, 20);
+        if (ret <= 0) {
             BIO_printf(bio_err, "ECDSA verify failure\n");
             ERR_print_errors(bio_err);
             count = -1;
@@ -1122,7 +1008,6 @@ static int ECDSA_verify_loop(void *args)
     }
     return count;
 }
-# endif
 
 /* ******************************************************************** */
 static long ecdh_c[EC_NUM][1];
@@ -1184,7 +1069,7 @@ static int EdDSA_verify_loop(void *args)
     return count;
 }
 
-# ifndef OPENSSL_NO_SM2
+#ifndef OPENSSL_NO_SM2
 static long sm2_c[SM2_NUM][2];
 static int SM2_sign_loop(void *args)
 {
@@ -1251,8 +1136,7 @@ static int SM2_verify_loop(void *args)
     }
     return count;
 }
-# endif                         /* OPENSSL_NO_SM2 */
-#endif                          /* OPENSSL_NO_EC */
+#endif                         /* OPENSSL_NO_SM2 */
 
 static int run_benchmark(int async_jobs,
                          int (*loop_function) (void *), loopargs_t * loopargs)
@@ -1405,22 +1289,84 @@ static int run_benchmark(int async_jobs,
     return error ? -1 : total_op_count;
 }
 
-static int fetched_alg = 0;
+typedef struct ec_curve_st {
+    const char *name;
+    unsigned int nid;
+    unsigned int bits;
+    size_t sigsize; /* only used for EdDSA curves */
+} EC_CURVE;
 
-static EVP_CIPHER *obtain_cipher(const char *name)
+static EVP_PKEY *get_ecdsa(const EC_CURVE *curve)
 {
-    EVP_CIPHER *cipher = NULL;
+    EVP_PKEY_CTX *kctx = NULL;
+    EVP_PKEY *key = NULL;
 
-    /* Look through providers' ciphers */
-    ERR_set_mark();
-    cipher = EVP_CIPHER_fetch(NULL, name, NULL);
-    ERR_pop_to_mark();
-    if (cipher != NULL) {
-        fetched_alg = 1;
-        return cipher;
+    /* Ensure that the error queue is empty */
+    if (ERR_peek_error()) {
+        BIO_printf(bio_err,
+                   "WARNING: the error queue contains previous unhandled errors.\n");
+        ERR_print_errors(bio_err);
     }
 
-    return (EVP_CIPHER *)EVP_get_cipherbyname(name);
+    /*
+     * Let's try to create a ctx directly from the NID: this works for
+     * curves like Curve25519 that are not implemented through the low
+     * level EC interface.
+     * If this fails we try creating a EVP_PKEY_EC generic param ctx,
+     * then we set the curve by NID before deriving the actual keygen
+     * ctx for that specific curve.
+     */
+    kctx = EVP_PKEY_CTX_new_id(curve->nid, NULL);
+    if (kctx == NULL) {
+        EVP_PKEY_CTX *pctx = NULL;
+        EVP_PKEY *params = NULL;
+        /*
+         * If we reach this code EVP_PKEY_CTX_new_id() failed and a
+         * "int_ctx_new:unsupported algorithm" error was added to the
+         * error queue.
+         * We remove it from the error queue as we are handling it.
+         */
+        unsigned long error = ERR_peek_error();
+
+        if (error == ERR_peek_last_error() /* oldest and latest errors match */
+            /* check that the error origin matches */
+            && ERR_GET_LIB(error) == ERR_LIB_EVP
+            && (ERR_GET_REASON(error) == EVP_R_UNSUPPORTED_ALGORITHM
+                || ERR_GET_REASON(error) == ERR_R_UNSUPPORTED))
+            ERR_get_error(); /* pop error from queue */
+        if (ERR_peek_error()) {
+            BIO_printf(bio_err,
+                       "Unhandled error in the error queue during EC key setup.\n");
+            ERR_print_errors(bio_err);
+            return NULL;
+        }
+
+        /* Create the context for parameter generation */
+        if ((pctx = EVP_PKEY_CTX_new_id(EVP_PKEY_EC, NULL)) == NULL
+            || EVP_PKEY_paramgen_init(pctx) <= 0
+            || EVP_PKEY_CTX_set_ec_paramgen_curve_nid(pctx,
+                                                      curve->nid) <= 0
+            || EVP_PKEY_paramgen(pctx, &params) <= 0) {
+            BIO_printf(bio_err, "EC params init failure.\n");
+            ERR_print_errors(bio_err);
+            EVP_PKEY_CTX_free(pctx);
+            return NULL;
+        }
+        EVP_PKEY_CTX_free(pctx);
+
+        /* Create the context for the key generation */
+        kctx = EVP_PKEY_CTX_new(params, NULL);
+        EVP_PKEY_free(params);
+    }
+    if (kctx == NULL
+        || EVP_PKEY_keygen_init(kctx) <= 0
+        || EVP_PKEY_keygen(kctx, &key) <= 0) {
+        BIO_printf(bio_err, "EC key generation failure.\n");
+        ERR_print_errors(bio_err);
+        key = NULL;
+    }
+    EVP_PKEY_CTX_free(kctx);
+    return key;
 }
 
 #define stop_it(do_it, test_num)\
@@ -1443,60 +1389,29 @@ int speed_main(int argc, char **argv)
     unsigned int i, k, loopargs_len = 0, async_jobs = 0;
     int keylen;
     int buflen;
+    int fetched_cipher = 0;
+    BIGNUM *bn = NULL;
+    EVP_PKEY_CTX *genctx = NULL;
 #ifndef NO_FORK
     int multi = 0;
 #endif
-#if !defined(OPENSSL_NO_DEPRECATED_3_0)         \
-    || !defined(OPENSSL_NO_DSA)                 \
-    || !defined(OPENSSL_NO_DH)                  \
-    || !defined(OPENSSL_NO_EC)
-     long op_count = 1;
-#endif
+    long op_count = 1;
     openssl_speed_sec_t seconds = { SECONDS, RSA_SECONDS, DSA_SECONDS,
                                     ECDSA_SECONDS, ECDH_SECONDS,
                                     EdDSA_SECONDS, SM2_SECONDS,
                                     FFDH_SECONDS };
 
-    /* What follows are the buffers and key material. */
-#if !defined(OPENSSL_NO_RC5) && !defined(OPENSSL_NO_DEPRECATED_3_0)
-    RC5_32_KEY rc5_ks;
-#endif
-#if !defined(OPENSSL_NO_RC2) && !defined(OPENSSL_NO_DEPRECATED_3_0)
-    RC2_KEY rc2_ks;
-#endif
-#if !defined(OPENSSL_NO_IDEA) && !defined(OPENSSL_NO_DEPRECATED_3_0)
-    IDEA_KEY_SCHEDULE idea_ks;
-#endif
-#if !defined(OPENSSL_NO_SEED) && !defined(OPENSSL_NO_DEPRECATED_3_0)
-    SEED_KEY_SCHEDULE seed_ks;
-#endif
-#if !defined(OPENSSL_NO_BF) && !defined(OPENSSL_NO_DEPRECATED_3_0)
-    BF_KEY bf_ks;
-#endif
-#if !defined(OPENSSL_NO_CAST) && !defined(OPENSSL_NO_DEPRECATED_3_0)
-    CAST_KEY cast_ks;
-#endif
-#ifndef OPENSSL_NO_DEPRECATED_3_0
-    static const unsigned char key16[16] = {
-        0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0,
-        0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0, 0x12
-    };
-    static const unsigned char key24[24] = {
-        0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0,
-        0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0, 0x12,
-        0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0, 0x12, 0x34
-    };
     static const unsigned char key32[32] = {
         0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0,
         0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0, 0x12,
         0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0, 0x12, 0x34,
         0x78, 0x9a, 0xbc, 0xde, 0xf0, 0x12, 0x34, 0x56
     };
-#endif
-#if !defined(OPENSSL_NO_CAMELLIA) && !defined(OPENSSL_NO_DEPRECATED_3_0)
-    CAMELLIA_KEY camellia_ks[3];
-#endif
-#ifndef OPENSSL_NO_DEPRECATED_3_0
+    static const unsigned char deskey[] = {
+        0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0, /* key1 */
+        0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0, 0x12, /* key2 */
+        0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0, 0x12, 0x34  /* key3 */
+    };
     static const struct {
         const unsigned char *data;
         unsigned int length;
@@ -1512,7 +1427,6 @@ int speed_main(int argc, char **argv)
     };
     uint8_t rsa_doit[RSA_NUM] = { 0 };
     int primes = RSA_DEFAULT_PRIME_NUM;
-#endif
 #ifndef OPENSSL_NO_DH
     typedef struct ffdh_params_st {
         const char *name;
@@ -1530,17 +1444,8 @@ int speed_main(int argc, char **argv)
     uint8_t ffdh_doit[FFDH_NUM] = { 0 };
 
 #endif /* OPENSSL_NO_DH */
-#if !defined(OPENSSL_NO_DSA) && !defined(OPENSSL_NO_DEPRECATED_3_0)
     static const unsigned int dsa_bits[DSA_NUM] = { 512, 1024, 2048 };
     uint8_t dsa_doit[DSA_NUM] = { 0 };
-#endif
-#ifndef OPENSSL_NO_EC
-    typedef struct ec_curve_st {
-        const char *name;
-        unsigned int nid;
-        unsigned int bits;
-        size_t sigsize; /* only used for EdDSA curves */
-    } EC_CURVE;
     /*
      * We only test over the following curves as they are representative, To
      * add tests over more curves, simply add the curve NID and curve name to
@@ -1555,7 +1460,7 @@ int speed_main(int argc, char **argv)
         {"nistp256", NID_X9_62_prime256v1, 256},
         {"nistp384", NID_secp384r1, 384},
         {"nistp521", NID_secp521r1, 521},
-# ifndef OPENSSL_NO_EC2M
+#ifndef OPENSSL_NO_EC2M
         /* Binary Curves */
         {"nistk163", NID_sect163k1, 163},
         {"nistk233", NID_sect233k1, 233},
@@ -1567,7 +1472,7 @@ int speed_main(int argc, char **argv)
         {"nistb283", NID_sect283r1, 283},
         {"nistb409", NID_sect409r1, 409},
         {"nistb571", NID_sect571r1, 571},
-# endif
+#endif
         {"brainpoolP256r1", NID_brainpoolP256r1, 256},
         {"brainpoolP256t1", NID_brainpoolP256t1, 256},
         {"brainpoolP384r1", NID_brainpoolP384r1, 384},
@@ -1583,13 +1488,13 @@ int speed_main(int argc, char **argv)
         {"Ed25519", NID_ED25519, 253, 64},
         {"Ed448", NID_ED448, 456, 114}
     };
-# ifndef OPENSSL_NO_SM2
+#ifndef OPENSSL_NO_SM2
     static const EC_CURVE sm2_curves[SM2_NUM] = {
         /* SM2 */
         {"CurveSM2", NID_sm2, 256}
     };
     uint8_t sm2_doit[SM2_NUM] = { 0 };
-# endif
+#endif
     uint8_t ecdsa_doit[ECDSA_NUM] = { 0 };
     uint8_t ecdh_doit[EC_NUM] = { 0 };
     uint8_t eddsa_doit[EdDSA_NUM] = { 0 };
@@ -1604,11 +1509,10 @@ int speed_main(int argc, char **argv)
     OPENSSL_assert(ec_curves[ECDSA_NUM - 1].nid == NID_brainpoolP512t1);
     OPENSSL_assert(strcmp(ecdsa_choices[ECDSA_NUM - 1].name, "ecdsabrp512t1") == 0);
 
-# ifndef OPENSSL_NO_SM2
+#ifndef OPENSSL_NO_SM2
     OPENSSL_assert(sm2_curves[SM2_NUM - 1].nid == NID_sm2);
     OPENSSL_assert(strcmp(sm2_choices[SM2_NUM - 1].name, "curveSM2") == 0);
-# endif
-#endif                          /* ndef OPENSSL_NO_EC */
+#endif
 
     prog = opt_init(argc, argv, speed_options);
     while ((o = opt_next()) != OPT_EOF) {
@@ -1630,7 +1534,7 @@ int speed_main(int argc, char **argv)
                 BIO_printf(bio_err, "%s: -evp option cannot be used more than once\n", prog);
                 goto opterr;
             }
-            evp_cipher = obtain_cipher(opt_arg());
+            evp_cipher = obtain_cipher(opt_arg(), &fetched_cipher);
             if (evp_cipher == NULL) {
                 if (have_md(opt_arg()))
                     evp_md_name = opt_arg();
@@ -1653,15 +1557,13 @@ int speed_main(int argc, char **argv)
             doit[D_HMAC] = 1;
             break;
         case OPT_CMAC:
-#if !defined(OPENSSL_NO_CMAC) && !defined(OPENSSL_NO_DEPRECATED_3_0)
-            evp_cmac_cipher = EVP_get_cipherbyname(opt_arg());
-            if (evp_cmac_cipher == NULL) {
+            if (!have_cipher(opt_arg())) {
                 BIO_printf(bio_err, "%s: %s is an unknown cipher\n",
                            prog, opt_arg());
                 goto end;
             }
+            evp_mac_ciphername = opt_arg();
             doit[D_EVP_CMAC] = 1;
-#endif
             break;
         case OPT_DECRYPT:
             decrypt = 1;
@@ -1724,10 +1626,8 @@ int speed_main(int argc, char **argv)
                 goto end;
             break;
         case OPT_PRIMES:
-#ifndef OPENSSL_NO_DEPRECATED_3_0
             if (!opt_int(opt_arg(), &primes))
                 goto end;
-#endif
             break;
         case OPT_SECONDS:
             seconds.sym = seconds.rsa = seconds.dsa = seconds.ecdsa
@@ -1757,12 +1657,10 @@ int speed_main(int argc, char **argv)
             doit[i] = 1;
             continue;
         }
-#if !defined(OPENSSL_NO_DES) && !defined(OPENSSL_NO_DEPRECATED_3_0)
         if (strcmp(algo, "des") == 0) {
             doit[D_CBC_DES] = doit[D_EDE3_DES] = 1;
             continue;
         }
-#endif
         if (strcmp(algo, "sha") == 0) {
             doit[D_SHA1] = doit[D_SHA256] = doit[D_SHA512] = 1;
             continue;
@@ -1770,6 +1668,7 @@ int speed_main(int argc, char **argv)
 #ifndef OPENSSL_NO_DEPRECATED_3_0
         if (strcmp(algo, "openssl") == 0) /* just for compatibility */
             continue;
+#endif
         if (strncmp(algo, "rsa", 3) == 0) {
             if (algo[3] == '\0') {
                 memset(rsa_doit, 1, sizeof(rsa_doit));
@@ -1780,7 +1679,6 @@ int speed_main(int argc, char **argv)
                 continue;
             }
         }
-#endif
 #ifndef OPENSSL_NO_DH
         if (strncmp(algo, "ffdh", 4) == 0) {
             if (algo[4] == '\0') {
@@ -1793,7 +1691,6 @@ int speed_main(int argc, char **argv)
             }
         }
 #endif
-#if !defined(OPENSSL_NO_DSA) && !defined(OPENSSL_NO_DEPRECATED_3_0)
         if (strncmp(algo, "dsa", 3) == 0) {
             if (algo[3] == '\0') {
                 memset(dsa_doit, 1, sizeof(dsa_doit));
@@ -1804,20 +1701,14 @@ int speed_main(int argc, char **argv)
                 continue;
             }
         }
-#endif
-#ifndef OPENSSL_NO_DEPRECATED_3_0
         if (strcmp(algo, "aes") == 0) {
             doit[D_CBC_128_AES] = doit[D_CBC_192_AES] = doit[D_CBC_256_AES] = 1;
             continue;
         }
-#endif
-#if !defined(OPENSSL_NO_CAMELLIA) && !defined(OPENSSL_NO_DEPRECATED_3_0)
         if (strcmp(algo, "camellia") == 0) {
             doit[D_CBC_128_CML] = doit[D_CBC_192_CML] = doit[D_CBC_256_CML] = 1;
             continue;
         }
-#endif
-#ifndef OPENSSL_NO_EC
         if (strncmp(algo, "ecdsa", 5) == 0) {
             if (algo[5] == '\0') {
                 memset(ecdsa_doit, 1, sizeof(ecdsa_doit));
@@ -1846,7 +1737,7 @@ int speed_main(int argc, char **argv)
             eddsa_doit[i] = 2;
             continue;
         }
-# ifndef OPENSSL_NO_SM2
+#ifndef OPENSSL_NO_SM2
         if (strcmp(algo, "sm2") == 0) {
             memset(sm2_doit, 1, sizeof(sm2_doit));
             continue;
@@ -1855,8 +1746,7 @@ int speed_main(int argc, char **argv)
             sm2_doit[i] = 2;
             continue;
         }
-# endif
-#endif  /* OPENSSL_NO_EC */
+#endif
         BIO_printf(bio_err, "%s: Unknown algorithm %s\n", prog, algo);
         goto end;
     }
@@ -1924,10 +1814,8 @@ int speed_main(int argc, char **argv)
         /* Align the start of buffers on a 64 byte boundary */
         loopargs[i].buf = loopargs[i].buf_malloc + misalign;
         loopargs[i].buf2 = loopargs[i].buf2_malloc + misalign;
-#ifndef OPENSSL_NO_EC
         loopargs[i].secret_a = app_malloc(MAX_ECDH_SIZE, "ECDH secret a");
         loopargs[i].secret_b = app_malloc(MAX_ECDH_SIZE, "ECDH secret b");
-#endif
 #ifndef OPENSSL_NO_DH
         loopargs[i].secret_ff_a = app_malloc(MAX_FFDH_SIZE, "FFDH secret a");
         loopargs[i].secret_ff_b = app_malloc(MAX_FFDH_SIZE, "FFDH secret b");
@@ -1944,28 +1832,38 @@ int speed_main(int argc, char **argv)
 
     /* No parameters; turn on everything. */
     if (argc == 0 && !doit[D_EVP] && !doit[D_HMAC] && !doit[D_EVP_CMAC]) {
+        EVP_MAC *mac;
+
         memset(doit, 1, sizeof(doit));
         doit[D_EVP] = doit[D_EVP_CMAC] = 0;
+        ERR_set_mark();
         for (i = D_MD2; i <= D_WHIRLPOOL; i++) {
             if (!have_md(names[i]))
                 doit[i] = 0;
         }
-#ifndef OPENSSL_NO_DEPRECATED_3_0
+        for (i = D_CBC_DES; i <= D_CBC_256_CML; i++) {
+            if (!have_cipher(names[i]))
+                doit[i] = 0;
+        }
+        if ((mac = EVP_MAC_fetch(NULL, "GMAC", NULL)) != NULL)
+            EVP_MAC_free(mac);
+        else
+            doit[D_GHASH] = 0;
+        if ((mac = EVP_MAC_fetch(NULL, "HMAC", NULL)) != NULL)
+            EVP_MAC_free(mac);
+        else
+            doit[D_HMAC] = 0;
+        ERR_pop_to_mark();
         memset(rsa_doit, 1, sizeof(rsa_doit));
-#endif
 #ifndef OPENSSL_NO_DH
         memset(ffdh_doit, 1, sizeof(ffdh_doit));
 #endif
-#if !defined(OPENSSL_NO_DSA) && !defined(OPENSSL_NO_DEPRECATED_3_0)
         memset(dsa_doit, 1, sizeof(dsa_doit));
-#endif
-#ifndef OPENSSL_NO_EC
         memset(ecdsa_doit, 1, sizeof(ecdsa_doit));
         memset(ecdh_doit, 1, sizeof(ecdh_doit));
         memset(eddsa_doit, 1, sizeof(eddsa_doit));
-# ifndef OPENSSL_NO_SM2
+#ifndef OPENSSL_NO_SM2
         memset(sm2_doit, 1, sizeof(sm2_doit));
-# endif
 #endif
     }
     for (i = 0; i < ALGOR_NUM; i++)
@@ -1977,87 +1875,6 @@ int speed_main(int argc, char **argv)
                    "You have chosen to measure elapsed time "
                    "instead of user CPU time.\n");
 
-#ifndef OPENSSL_NO_DEPRECATED_3_0
-    for (i = 0; i < loopargs_len; i++) {
-        if (primes > RSA_DEFAULT_PRIME_NUM) {
-            /* for multi-prime RSA, skip this */
-            break;
-        }
-        for (k = 0; k < RSA_NUM; k++) {
-            const unsigned char *p = rsa_keys[k].data;
-
-            loopargs[i].rsa_key[k] =
-                d2i_RSAPrivateKey(NULL, &p, rsa_keys[k].length);
-            if (loopargs[i].rsa_key[k] == NULL) {
-                BIO_printf(bio_err,
-                           "internal error loading RSA key number %d\n", k);
-                goto end;
-            }
-        }
-    }
-#endif
-#if !defined(OPENSSL_NO_DSA) && !defined(OPENSSL_NO_DEPRECATED_3_0)
-    for (i = 0; i < loopargs_len; i++) {
-        loopargs[i].dsa_key[0] = get_dsa(512);
-        loopargs[i].dsa_key[1] = get_dsa(1024);
-        loopargs[i].dsa_key[2] = get_dsa(2048);
-    }
-#endif
-#if !defined(OPENSSL_NO_DES) && !defined(OPENSSL_NO_DEPRECATED_3_0)
-    if (doit[D_CBC_DES] || doit[D_EDE3_DES]) {
-        static DES_cblock keys[] = {
-            { 0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0 }, /* keys[0] */
-            { 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0, 0x12 }, /* keys[1] */
-            { 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0, 0x12, 0x34 }  /* keys[3] */
-        };
-        DES_set_key_unchecked(&keys[0], &sch[0]);
-        DES_set_key_unchecked(&keys[1], &sch[1]);
-        DES_set_key_unchecked(&keys[2], &sch[2]);
-    }
-#endif
-#ifndef OPENSSL_NO_DEPRECATED_3_0
-    AES_set_encrypt_key(key16, 128, &aes_ks1);
-    AES_set_encrypt_key(key24, 192, &aes_ks2);
-    AES_set_encrypt_key(key32, 256, &aes_ks3);
-#endif
-#if !defined(OPENSSL_NO_CAMELLIA) && !defined(OPENSSL_NO_DEPRECATED_3_0)
-    if (doit[D_CBC_128_CML] || doit[D_CBC_192_CML] || doit[D_CBC_256_CML]) {
-        Camellia_set_key(key16, 128, &camellia_ks[0]);
-        Camellia_set_key(key24, 192, &camellia_ks[1]);
-        Camellia_set_key(key32, 256, &camellia_ks[2]);
-    }
-#endif
-#if !defined(OPENSSL_NO_IDEA) && !defined(OPENSSL_NO_DEPRECATED_3_0)
-    if (doit[D_CBC_IDEA])
-        IDEA_set_encrypt_key(key16, &idea_ks);
-#endif
-#if !defined(OPENSSL_NO_SEED) && !defined(OPENSSL_NO_DEPRECATED_3_0)
-    if (doit[D_CBC_SEED])
-        SEED_set_key(key16, &seed_ks);
-#endif
-#if !defined(OPENSSL_NO_RC4) && !defined(OPENSSL_NO_DEPRECATED_3_0)
-    if (doit[D_RC4])
-        RC4_set_key(&rc4_ks, 16, key16);
-#endif
-#if !defined(OPENSSL_NO_RC2) && !defined(OPENSSL_NO_DEPRECATED_3_0)
-    if (doit[D_CBC_RC2])
-        RC2_set_key(&rc2_ks, 16, key16, 128);
-#endif
-#if !defined(OPENSSL_NO_RC5) && !defined(OPENSSL_NO_DEPRECATED_3_0)
-    if (doit[D_CBC_RC5])
-        if (!RC5_32_set_key(&rc5_ks, 16, key16, 12)) {
-            BIO_printf(bio_err, "Failed setting RC5 key\n");
-            goto end;
-        }
-#endif
-#if !defined(OPENSSL_NO_BF) && !defined(OPENSSL_NO_DEPRECATED_3_0)
-    if (doit[D_CBC_BF])
-        BF_set_key(&bf_ks, 16, key16);
-#endif
-#if !defined(OPENSSL_NO_CAST) && !defined(OPENSSL_NO_DEPRECATED_3_0)
-    if (doit[D_CBC_CAST]) 
-        CAST_set_key(&cast_ks, 16, key16);
-#endif
 #if SIGALRM > 0
     signal(SIGALRM, alarmed);
 #endif
@@ -2194,9 +2011,9 @@ int speed_main(int argc, char **argv)
         names[D_HMAC] = evp_hmac_name;
 
         params[0] =
-            OSSL_PARAM_construct_utf8_string("digest", "md5", 0);
+            OSSL_PARAM_construct_utf8_string(OSSL_MAC_PARAM_DIGEST, evp_mac_mdname, 0);
         params[1] =
-            OSSL_PARAM_construct_octet_string("key", (char *)hmac_key, len);
+            OSSL_PARAM_construct_octet_string(OSSL_MAC_PARAM_KEY, (char *)hmac_key, len);
         params[2] = OSSL_PARAM_construct_end();
 
         for (i = 0; i < loopargs_len; i++) {
@@ -2205,7 +2022,7 @@ int speed_main(int argc, char **argv)
                 goto end;
 
             if (!EVP_MAC_CTX_set_params(loopargs[i].mctx, params))
-                 goto end;
+                goto end;
         }
         for (testnum = 0; testnum < size_num; testnum++) {
             print_message(names[D_HMAC], c[D_HMAC][testnum], lengths[testnum],
@@ -2222,319 +2039,157 @@ int speed_main(int argc, char **argv)
         EVP_MAC_free(mac);
     }
 
-#if !defined(OPENSSL_NO_RC4) && !defined(OPENSSL_NO_DEPRECATED_3_0)
-    if (doit[D_RC4]) {
-        for (testnum = 0; testnum < size_num; testnum++) {
-            print_message(names[D_RC4], c[D_RC4][testnum], lengths[testnum],
-                          seconds.sym);
-            Time_F(START);
-            count = run_benchmark(async_jobs, RC4_loop, loopargs);
-            d = Time_F(STOP);
-            print_result(D_RC4, testnum, count, d);
-        }
-    }
-#endif
-#if !defined(OPENSSL_NO_DES) && !defined(OPENSSL_NO_DEPRECATED_3_0)
     if (doit[D_CBC_DES]) {
+        for (i = 0; i < loopargs_len; i++) {
+            loopargs[i].ctx = init_evp_cipher_ctx("des-cbc", deskey,
+                                                  sizeof(deskey)/3);
+        }
+        algindex = D_CBC_DES;
         for (testnum = 0; testnum < size_num; testnum++) {
             print_message(names[D_CBC_DES], c[D_CBC_DES][testnum],
                           lengths[testnum], seconds.sym);
             Time_F(START);
-            count = run_benchmark(async_jobs, DES_ncbc_encrypt_loop, loopargs);
+            count = run_benchmark(async_jobs, EVP_Cipher_loop, loopargs);
             d = Time_F(STOP);
             print_result(D_CBC_DES, testnum, count, d);
+        }
+        for (i = 0; i < loopargs_len; i++) {
+            EVP_CIPHER_CTX_free(loopargs[i].ctx);
         }
     }
 
     if (doit[D_EDE3_DES]) {
+        for (i = 0; i < loopargs_len; i++) {
+            loopargs[i].ctx = init_evp_cipher_ctx("des-ede3-cbc", deskey,
+                                                  sizeof(deskey));
+        }
+        algindex = D_EDE3_DES;
         for (testnum = 0; testnum < size_num; testnum++) {
             print_message(names[D_EDE3_DES], c[D_EDE3_DES][testnum],
                           lengths[testnum], seconds.sym);
             Time_F(START);
             count =
-                run_benchmark(async_jobs, DES_ede3_cbc_encrypt_loop, loopargs);
+                run_benchmark(async_jobs, EVP_Cipher_loop, loopargs);
             d = Time_F(STOP);
             print_result(D_EDE3_DES, testnum, count, d);
         }
-    }
-#endif
-
-#ifndef OPENSSL_NO_DEPRECATED_3_0
-    if (doit[D_CBC_128_AES]) {
-        for (testnum = 0; testnum < size_num; testnum++) {
-            print_message(names[D_CBC_128_AES], c[D_CBC_128_AES][testnum],
-                          lengths[testnum], seconds.sym);
-            Time_F(START);
-            count =
-                run_benchmark(async_jobs, AES_cbc_128_encrypt_loop, loopargs);
-            d = Time_F(STOP);
-            print_result(D_CBC_128_AES, testnum, count, d);
-        }
-    }
-    if (doit[D_CBC_192_AES]) {
-        for (testnum = 0; testnum < size_num; testnum++) {
-            print_message(names[D_CBC_192_AES], c[D_CBC_192_AES][testnum],
-                          lengths[testnum], seconds.sym);
-            Time_F(START);
-            count =
-                run_benchmark(async_jobs, AES_cbc_192_encrypt_loop, loopargs);
-            d = Time_F(STOP);
-            print_result(D_CBC_192_AES, testnum, count, d);
-        }
-    }
-    if (doit[D_CBC_256_AES]) {
-        for (testnum = 0; testnum < size_num; testnum++) {
-            print_message(names[D_CBC_256_AES], c[D_CBC_256_AES][testnum],
-                          lengths[testnum], seconds.sym);
-            Time_F(START);
-            count =
-                run_benchmark(async_jobs, AES_cbc_256_encrypt_loop, loopargs);
-            d = Time_F(STOP);
-            print_result(D_CBC_256_AES, testnum, count, d);
+        for (i = 0; i < loopargs_len; i++) {
+            EVP_CIPHER_CTX_free(loopargs[i].ctx);
         }
     }
 
+    for (k = 0; k < 3; k++) {
+        algindex = D_CBC_128_AES + k;
+        if (doit[algindex]) {
+            keylen = 16 + i * 8;
+            for (i = 0; i < loopargs_len; i++) {
+                loopargs[i].ctx = init_evp_cipher_ctx(names[algindex],
+                                                      key32, keylen);
+            }
 
-    if (doit[D_IGE_128_AES]) {
-        for (testnum = 0; testnum < size_num; testnum++) {
-            print_message(names[D_IGE_128_AES], c[D_IGE_128_AES][testnum],
-                          lengths[testnum], seconds.sym);
-            Time_F(START);
-            count =
-                run_benchmark(async_jobs, AES_ige_128_encrypt_loop, loopargs);
-            d = Time_F(STOP);
-            print_result(D_IGE_128_AES, testnum, count, d);
+            for (testnum = 0; testnum < size_num; testnum++) {
+                print_message(names[algindex], c[algindex][testnum],
+                              lengths[testnum], seconds.sym);
+                Time_F(START);
+                count =
+                    run_benchmark(async_jobs, EVP_Cipher_loop, loopargs);
+                d = Time_F(STOP);
+                print_result(algindex, testnum, count, d);
+            }
+            for (i = 0; i < loopargs_len; i++) {
+                EVP_CIPHER_CTX_free(loopargs[i].ctx);
+            }
         }
     }
-    if (doit[D_IGE_192_AES]) {
-        for (testnum = 0; testnum < size_num; testnum++) {
-            print_message(names[D_IGE_192_AES], c[D_IGE_192_AES][testnum],
-                          lengths[testnum], seconds.sym);
-            Time_F(START);
-            count =
-                run_benchmark(async_jobs, AES_ige_192_encrypt_loop, loopargs);
-            d = Time_F(STOP);
-            print_result(D_IGE_192_AES, testnum, count, d);
+
+    for (k = 0; k < 3; k++) {
+        algindex = D_CBC_128_CML + k;
+        if (doit[algindex]) {
+            keylen = 16 + i * 8;
+            for (i = 0; i < loopargs_len; i++) {
+                loopargs[i].ctx = init_evp_cipher_ctx(names[algindex],
+                                                      key32, keylen);
+            }
+
+            for (testnum = 0; testnum < size_num; testnum++) {
+                print_message(names[algindex], c[algindex][testnum],
+                              lengths[testnum], seconds.sym);
+                Time_F(START);
+                count =
+                    run_benchmark(async_jobs, EVP_Cipher_loop, loopargs);
+                d = Time_F(STOP);
+                print_result(algindex, testnum, count, d);
+            }
+            for (i = 0; i < loopargs_len; i++) {
+                EVP_CIPHER_CTX_free(loopargs[i].ctx);
+            }
         }
     }
-    if (doit[D_IGE_256_AES]) {
-        for (testnum = 0; testnum < size_num; testnum++) {
-            print_message(names[D_IGE_256_AES], c[D_IGE_256_AES][testnum],
-                          lengths[testnum], seconds.sym);
-            Time_F(START);
-            count =
-                run_benchmark(async_jobs, AES_ige_256_encrypt_loop, loopargs);
-            d = Time_F(STOP);
-            print_result(D_IGE_256_AES, testnum, count, d);
+
+    for (algindex = D_RC4; algindex <= D_CBC_CAST; algindex++) {
+        if (doit[algindex]) {
+            keylen = 16;
+            for (i = 0; i < loopargs_len; i++) {
+                loopargs[i].ctx = init_evp_cipher_ctx(names[algindex],
+                                                      key32, keylen);
+            }
+
+            for (testnum = 0; testnum < size_num; testnum++) {
+                print_message(names[algindex], c[algindex][testnum],
+                              lengths[testnum], seconds.sym);
+                Time_F(START);
+                count =
+                    run_benchmark(async_jobs, EVP_Cipher_loop, loopargs);
+                d = Time_F(STOP);
+                print_result(algindex, testnum, count, d);
+            }
+            for (i = 0; i < loopargs_len; i++) {
+                EVP_CIPHER_CTX_free(loopargs[i].ctx);
+            }
         }
     }
     if (doit[D_GHASH]) {
-        for (i = 0; i < loopargs_len; i++) {
-            loopargs[i].gcm_ctx =
-                CRYPTO_gcm128_new(&aes_ks1, (block128_f) AES_encrypt);
-            CRYPTO_gcm128_setiv(loopargs[i].gcm_ctx,
-                                (unsigned char *)"0123456789ab", 12);
-        }
+        static const char gmac_iv[] = "0123456789ab";
+        EVP_MAC *mac = EVP_MAC_fetch(NULL, "GMAC", NULL);
+        OSSL_PARAM params[4];
 
+        if (mac == NULL)
+            goto end;
+
+        params[0] =
+            OSSL_PARAM_construct_utf8_string(OSSL_ALG_PARAM_CIPHER, "aes-128-gcm", 0);
+        params[1] =
+            OSSL_PARAM_construct_octet_string(OSSL_MAC_PARAM_KEY, (char *)key32, 16);
+        params[2] =
+            OSSL_PARAM_construct_octet_string(OSSL_MAC_PARAM_IV, (char *)gmac_iv,
+                                              sizeof(gmac_iv) - 1);
+        params[3] = OSSL_PARAM_construct_end();
+
+        for (i = 0; i < loopargs_len; i++) {
+            loopargs[i].mctx = EVP_MAC_CTX_new(mac);
+            if (loopargs[i].mctx == NULL)
+                goto end;
+
+            if (!EVP_MAC_CTX_set_params(loopargs[i].mctx, params))
+                goto end;
+            if (!EVP_MAC_init(loopargs[i].mctx))
+                goto end;
+        }
         for (testnum = 0; testnum < size_num; testnum++) {
-            print_message(names[D_GHASH], c[D_GHASH][testnum],
-                          lengths[testnum], seconds.sym);
+            print_message(names[D_GHASH], c[D_GHASH][testnum], lengths[testnum],
+                          seconds.sym);
             Time_F(START);
-            count = run_benchmark(async_jobs, CRYPTO_gcm128_aad_loop, loopargs);
+            count = run_benchmark(async_jobs, GHASH_loop, loopargs);
             d = Time_F(STOP);
             print_result(D_GHASH, testnum, count, d);
+            if (count < 0)
+                break;
         }
         for (i = 0; i < loopargs_len; i++)
-            CRYPTO_gcm128_release(loopargs[i].gcm_ctx);
+            EVP_MAC_CTX_free(loopargs[i].mctx);
+        EVP_MAC_free(mac);
     }
-#endif /* OPENSSL_NO_DEPRECATED_3_0 */
-#if !defined(OPENSSL_NO_CAMELLIA) && !defined(OPENSSL_NO_DEPRECATED_3_0)
-    if (doit[D_CBC_128_CML]) {
-        if (async_jobs > 0) {
-            BIO_printf(bio_err, "Async mode is not supported with %s\n",
-                       names[D_CBC_128_CML]);
-            doit[D_CBC_128_CML] = 0;
-        }
-        for (testnum = 0; testnum < size_num && async_init == 0; testnum++) {
-            print_message(names[D_CBC_128_CML], c[D_CBC_128_CML][testnum],
-                          lengths[testnum], seconds.sym);
-            Time_F(START);
-            for (count = 0; COND(c[D_CBC_128_CML][testnum]); count++)
-                Camellia_cbc_encrypt(loopargs[0].buf, loopargs[0].buf,
-                                     (size_t)lengths[testnum], &camellia_ks[0],
-                                     iv, CAMELLIA_ENCRYPT);
-            d = Time_F(STOP);
-            print_result(D_CBC_128_CML, testnum, count, d);
-        }
-    }
-    if (doit[D_CBC_192_CML]) {
-        if (async_jobs > 0) {
-            BIO_printf(bio_err, "Async mode is not supported with %s\n",
-                       names[D_CBC_192_CML]);
-            doit[D_CBC_192_CML] = 0;
-        }
-        for (testnum = 0; testnum < size_num && async_init == 0; testnum++) {
-            print_message(names[D_CBC_192_CML], c[D_CBC_192_CML][testnum],
-                          lengths[testnum], seconds.sym);
-            if (async_jobs > 0) {
-                BIO_printf(bio_err, "Async mode is not supported, exiting...");
-                exit(1);
-            }
-            Time_F(START);
-            for (count = 0; COND(c[D_CBC_192_CML][testnum]); count++)
-                Camellia_cbc_encrypt(loopargs[0].buf, loopargs[0].buf,
-                                     (size_t)lengths[testnum], &camellia_ks[1],
-                                     iv, CAMELLIA_ENCRYPT);
-            d = Time_F(STOP);
-            print_result(D_CBC_192_CML, testnum, count, d);
-        }
-    }
-    if (doit[D_CBC_256_CML]) {
-        if (async_jobs > 0) {
-            BIO_printf(bio_err, "Async mode is not supported with %s\n",
-                       names[D_CBC_256_CML]);
-            doit[D_CBC_256_CML] = 0;
-        }
-        for (testnum = 0; testnum < size_num && async_init == 0; testnum++) {
-            print_message(names[D_CBC_256_CML], c[D_CBC_256_CML][testnum],
-                          lengths[testnum], seconds.sym);
-            Time_F(START);
-            for (count = 0; COND(c[D_CBC_256_CML][testnum]); count++)
-                Camellia_cbc_encrypt(loopargs[0].buf, loopargs[0].buf,
-                                     (size_t)lengths[testnum], &camellia_ks[2],
-                                     iv, CAMELLIA_ENCRYPT);
-            d = Time_F(STOP);
-            print_result(D_CBC_256_CML, testnum, count, d);
-        }
-    }
-#endif
-#if !defined(OPENSSL_NO_IDEA) && !defined(OPENSSL_NO_DEPRECATED_3_0)
-    if (doit[D_CBC_IDEA]) {
-        if (async_jobs > 0) {
-            BIO_printf(bio_err, "Async mode is not supported with %s\n",
-                       names[D_CBC_IDEA]);
-            doit[D_CBC_IDEA] = 0;
-        }
-        for (testnum = 0; testnum < size_num && async_init == 0; testnum++) {
-            print_message(names[D_CBC_IDEA], c[D_CBC_IDEA][testnum],
-                          lengths[testnum], seconds.sym);
-            Time_F(START);
-            for (count = 0; COND(c[D_CBC_IDEA][testnum]); count++)
-                IDEA_cbc_encrypt(loopargs[0].buf, loopargs[0].buf,
-                                 (size_t)lengths[testnum], &idea_ks,
-                                 iv, IDEA_ENCRYPT);
-            d = Time_F(STOP);
-            print_result(D_CBC_IDEA, testnum, count, d);
-        }
-    }
-#endif
-#if !defined(OPENSSL_NO_SEED) && !defined(OPENSSL_NO_DEPRECATED_3_0)
-    if (doit[D_CBC_SEED]) {
-        if (async_jobs > 0) {
-            BIO_printf(bio_err, "Async mode is not supported with %s\n",
-                       names[D_CBC_SEED]);
-            doit[D_CBC_SEED] = 0;
-        }
-        for (testnum = 0; testnum < size_num && async_init == 0; testnum++) {
-            print_message(names[D_CBC_SEED], c[D_CBC_SEED][testnum],
-                          lengths[testnum], seconds.sym);
-            Time_F(START);
-            for (count = 0; COND(c[D_CBC_SEED][testnum]); count++)
-                SEED_cbc_encrypt(loopargs[0].buf, loopargs[0].buf,
-                                 (size_t)lengths[testnum], &seed_ks, iv, 1);
-            d = Time_F(STOP);
-            print_result(D_CBC_SEED, testnum, count, d);
-        }
-    }
-#endif
-#if !defined(OPENSSL_NO_RC2) && !defined(OPENSSL_NO_DEPRECATED_3_0)
-    if (doit[D_CBC_RC2]) {
-        if (async_jobs > 0) {
-            BIO_printf(bio_err, "Async mode is not supported with %s\n",
-                       names[D_CBC_RC2]);
-            doit[D_CBC_RC2] = 0;
-        }
-        for (testnum = 0; testnum < size_num && async_init == 0; testnum++) {
-            print_message(names[D_CBC_RC2], c[D_CBC_RC2][testnum],
-                          lengths[testnum], seconds.sym);
-            if (async_jobs > 0) {
-                BIO_printf(bio_err, "Async mode is not supported, exiting...");
-                exit(1);
-            }
-            Time_F(START);
-            for (count = 0; COND(c[D_CBC_RC2][testnum]); count++)
-                RC2_cbc_encrypt(loopargs[0].buf, loopargs[0].buf,
-                                (size_t)lengths[testnum], &rc2_ks,
-                                iv, RC2_ENCRYPT);
-            d = Time_F(STOP);
-            print_result(D_CBC_RC2, testnum, count, d);
-        }
-    }
-#endif
-#if !defined(OPENSSL_NO_RC5) && !defined(OPENSSL_NO_DEPRECATED_3_0)
-    if (doit[D_CBC_RC5]) {
-        if (async_jobs > 0) {
-            BIO_printf(bio_err, "Async mode is not supported with %s\n",
-                       names[D_CBC_RC5]);
-            doit[D_CBC_RC5] = 0;
-        }
-        for (testnum = 0; testnum < size_num && async_init == 0; testnum++) {
-            print_message(names[D_CBC_RC5], c[D_CBC_RC5][testnum],
-                          lengths[testnum], seconds.sym);
-            if (async_jobs > 0) {
-                BIO_printf(bio_err, "Async mode is not supported, exiting...");
-                exit(1);
-            }
-            Time_F(START);
-            for (count = 0; COND(c[D_CBC_RC5][testnum]); count++)
-                RC5_32_cbc_encrypt(loopargs[0].buf, loopargs[0].buf,
-                                   (size_t)lengths[testnum], &rc5_ks,
-                                   iv, RC5_ENCRYPT);
-            d = Time_F(STOP);
-            print_result(D_CBC_RC5, testnum, count, d);
-        }
-    }
-#endif
-#if !defined(OPENSSL_NO_BF) && !defined(OPENSSL_NO_DEPRECATED_3_0)
-    if (doit[D_CBC_BF]) {
-        if (async_jobs > 0) {
-            BIO_printf(bio_err, "Async mode is not supported with %s\n",
-                       names[D_CBC_BF]);
-            doit[D_CBC_BF] = 0;
-        }
-        for (testnum = 0; testnum < size_num && async_init == 0; testnum++) {
-            print_message(names[D_CBC_BF], c[D_CBC_BF][testnum],
-                          lengths[testnum], seconds.sym);
-            Time_F(START);
-            for (count = 0; COND(c[D_CBC_BF][testnum]); count++)
-                BF_cbc_encrypt(loopargs[0].buf, loopargs[0].buf,
-                               (size_t)lengths[testnum], &bf_ks,
-                               iv, BF_ENCRYPT);
-            d = Time_F(STOP);
-            print_result(D_CBC_BF, testnum, count, d);
-        }
-    }
-#endif
-#if !defined(OPENSSL_NO_CAST) && !defined(OPENSSL_NO_DEPRECATED_3_0)
-    if (doit[D_CBC_CAST]) {
-        if (async_jobs > 0) {
-            BIO_printf(bio_err, "Async mode is not supported with %s\n",
-                       names[D_CBC_CAST]);
-            doit[D_CBC_CAST] = 0;
-        }
-        for (testnum = 0; testnum < size_num && async_init == 0; testnum++) {
-            print_message(names[D_CBC_CAST], c[D_CBC_CAST][testnum],
-                          lengths[testnum], seconds.sym);
-            Time_F(START);
-            for (count = 0; COND(c[D_CBC_CAST][testnum]); count++)
-                CAST_cbc_encrypt(loopargs[0].buf, loopargs[0].buf,
-                                 (size_t)lengths[testnum], &cast_ks,
-                                 iv, CAST_ENCRYPT);
-            d = Time_F(STOP);
-            print_result(D_CBC_CAST, testnum, count, d);
-        }
-    }
-#endif
+
     if (doit[D_RAND]) {
         for (testnum = 0; testnum < size_num; testnum++) {
             print_message(names[D_RAND], c[D_RAND][testnum], lengths[testnum],
@@ -2629,81 +2284,106 @@ int speed_main(int argc, char **argv)
         }
     }
 
-#if !defined(OPENSSL_NO_CMAC) && !defined(OPENSSL_NO_DEPRECATED_3_0)
-    if (doit[D_EVP_CMAC] && evp_cmac_cipher != NULL) {
-        const char *cipher_name = OBJ_nid2ln(EVP_CIPHER_type(evp_cmac_cipher));
+    if (doit[D_EVP_CMAC]) {
+        EVP_MAC *mac = EVP_MAC_fetch(NULL, "CMAC", NULL);
+        OSSL_PARAM params[3];
+        EVP_CIPHER *cipher;
+        int fetched = 0;
 
-        evp_cmac_name = app_malloc(sizeof("CMAC()") + strlen(cipher_name),
+        if (mac == NULL || evp_mac_ciphername == NULL)
+            goto end;
+        if ((cipher = obtain_cipher(evp_mac_ciphername, &fetched)) == NULL)
+            goto end;
+
+        keylen = EVP_CIPHER_key_length(cipher);
+        if (fetched)
+            EVP_CIPHER_free(cipher);
+        if (keylen <= 0 || keylen > (int)sizeof(key32)) {
+            BIO_printf(bio_err, "\nRequested CMAC cipher with unsupported key length.\n");
+            goto end;
+        }
+        evp_cmac_name = app_malloc(sizeof("cmac()") + strlen(evp_mac_ciphername),
                                    "CMAC name");
-        sprintf(evp_cmac_name, "CMAC(%s)", cipher_name);
+        sprintf(evp_cmac_name, "cmac(%s)", evp_mac_ciphername);
         names[D_EVP_CMAC] = evp_cmac_name;
 
+        params[0] =
+            OSSL_PARAM_construct_utf8_string(OSSL_ALG_PARAM_CIPHER,
+                                             evp_mac_ciphername, 0);
+        params[1] =
+            OSSL_PARAM_construct_octet_string(OSSL_MAC_PARAM_KEY, (char *)key32, keylen);
+        params[2] = OSSL_PARAM_construct_end();
+
         for (i = 0; i < loopargs_len; i++) {
-            loopargs[i].cmac_ctx = CMAC_CTX_new();
-            if (loopargs[i].cmac_ctx == NULL) {
-                BIO_printf(bio_err, "CMAC malloc failure, exiting...");
-                exit(1);
-            }
+            loopargs[i].mctx = EVP_MAC_CTX_new(mac);
+            if (loopargs[i].mctx == NULL)
+                goto end;
+
+            if (!EVP_MAC_CTX_set_params(loopargs[i].mctx, params))
+                goto end;
         }
+        
         for (testnum = 0; testnum < size_num; testnum++) {
             print_message(names[D_EVP_CMAC], c[D_EVP_CMAC][testnum], lengths[testnum],
                           seconds.sym);
             Time_F(START);
-            count = run_benchmark(async_jobs, EVP_CMAC_loop, loopargs);
+            count = run_benchmark(async_jobs, CMAC_loop, loopargs);
             d = Time_F(STOP);
             print_result(D_EVP_CMAC, testnum, count, d);
+            if (count < 0)
+                break;
         }
         for (i = 0; i < loopargs_len; i++)
-            CMAC_CTX_free(loopargs[i].cmac_ctx);
+            EVP_MAC_CTX_free(loopargs[i].mctx);
+        EVP_MAC_free(mac);
     }
-#endif
 
     for (i = 0; i < loopargs_len; i++)
         if (RAND_bytes(loopargs[i].buf, 36) <= 0)
             goto end;
 
-#ifndef OPENSSL_NO_DEPRECATED_3_0
     for (testnum = 0; testnum < RSA_NUM; testnum++) {
+        EVP_PKEY *rsa_key = NULL;
         int st = 0;
+
         if (!rsa_doit[testnum])
             continue;
-        for (i = 0; i < loopargs_len; i++) {
-            if (primes > RSA_DEFAULT_PRIME_NUM) {
-                /* we haven't set keys yet,  generate multi-prime RSA keys */
-                BIGNUM *bn = BN_new();
 
-                if (bn == NULL)
-                    goto end;
-                if (!BN_set_word(bn, RSA_F4)) {
-                    BN_free(bn);
-                    goto end;
-                }
+        if (primes > RSA_DEFAULT_PRIME_NUM) {
+            /* we haven't set keys yet,  generate multi-prime RSA keys */
+            bn = BN_new();
+            st = bn != NULL
+                && BN_set_word(bn, RSA_F4)
+                && init_gen_str(&genctx, "RSA", NULL, 0, NULL, NULL)
+                && EVP_PKEY_CTX_set_rsa_keygen_bits(genctx, rsa_keys[testnum].bits) > 0
+                && EVP_PKEY_CTX_set1_rsa_keygen_pubexp(genctx, bn) > 0
+                && EVP_PKEY_CTX_set_rsa_keygen_primes(genctx, primes) > 0
+                && EVP_PKEY_keygen(genctx, &rsa_key);
+            BN_free(bn);
+            bn = NULL;
+            EVP_PKEY_CTX_free(genctx);
+            genctx = NULL;
+        } else {
+            const unsigned char *p = rsa_keys[testnum].data;
 
-                BIO_printf(bio_err, "Generate multi-prime RSA key for %s\n",
-                           rsa_choices[testnum].name);
-
-                loopargs[i].rsa_key[testnum] = RSA_new();
-                if (loopargs[i].rsa_key[testnum] == NULL) {
-                    BN_free(bn);
-                    goto end;
-                }
-
-                if (!RSA_generate_multi_prime_key(loopargs[i].rsa_key[testnum],
-                                                  rsa_keys[testnum].bits,
-                                                  primes, bn, NULL)) {
-                    BN_free(bn);
-                    goto end;
-                }
-                BN_free(bn);
-            }
-            st = RSA_sign(NID_md5_sha1, loopargs[i].buf, 36, loopargs[i].buf2,
-                          &loopargs[i].siglen, loopargs[i].rsa_key[testnum]);
-            if (st == 0)
-                break;
+            st = (rsa_key = d2i_PrivateKey(EVP_PKEY_RSA, NULL, &p,
+                                           rsa_keys[k].length)) != NULL;
         }
-        if (st == 0) {
+
+        for (i = 0; st && i < loopargs_len; i++) {
+            loopargs[i].rsa_sign_ctx[testnum] = EVP_PKEY_CTX_new(rsa_key,
+                                                                 NULL);
+            if (loopargs[i].rsa_sign_ctx[testnum] == NULL
+                || EVP_PKEY_sign_init(loopargs[i].rsa_sign_ctx[testnum]) <= 0
+                || EVP_PKEY_sign(loopargs[i].rsa_sign_ctx[testnum],
+                                 loopargs[i].buf2,
+                                 &loopargs[i].sigsize,
+                                 loopargs[i].buf, 36) <= 0)
+                st = 0;
+        }
+        if (!st) {
             BIO_printf(bio_err,
-                       "RSA sign failure.  No RSA sign will be done.\n");
+                       "RSA sign setup failure.  No RSA sign will be done.\n");
             ERR_print_errors(bio_err);
             op_count = 1;
         } else {
@@ -2722,15 +2402,20 @@ int speed_main(int argc, char **argv)
             op_count = count;
         }
 
-        for (i = 0; i < loopargs_len; i++) {
-            st = RSA_verify(NID_md5_sha1, loopargs[i].buf, 36, loopargs[i].buf2,
-                            loopargs[i].siglen, loopargs[i].rsa_key[testnum]);
-            if (st <= 0)
-                break;
+        for (i = 0; st && i < loopargs_len; i++) {
+            loopargs[i].rsa_verify_ctx[testnum] = EVP_PKEY_CTX_new(rsa_key,
+                                                                   NULL);
+            if (loopargs[i].rsa_verify_ctx[testnum] == NULL
+                || EVP_PKEY_verify_init(loopargs[i].rsa_verify_ctx[testnum]) <= 0
+                || EVP_PKEY_verify(loopargs[i].rsa_verify_ctx[testnum],
+                                   loopargs[i].buf2,
+                                   loopargs[i].sigsize,
+                                   loopargs[i].buf, 36) <= 0)
+                st = 0;
         }
-        if (st <= 0) {
+        if (!st) {
             BIO_printf(bio_err,
-                       "RSA verify failure.  No RSA verify will be done.\n");
+                       "RSA verify setup failure.  No RSA verify will be done.\n");
             ERR_print_errors(bio_err);
             rsa_doit[testnum] = 0;
         } else {
@@ -2751,30 +2436,33 @@ int speed_main(int argc, char **argv)
             /* if longer than 10s, don't do any more */
             stop_it(rsa_doit, testnum);
         }
+        EVP_PKEY_free(rsa_key);
     }
-#endif  /* OPENSSL_NO_DEPRECATED_3_0 */
 
-    for (i = 0; i < loopargs_len; i++)
-        if (RAND_bytes(loopargs[i].buf, 36) <= 0)
-            goto end;
-
-#if !defined(OPENSSL_NO_DSA) && !defined(OPENSSL_NO_DEPRECATED_3_0)
     for (testnum = 0; testnum < DSA_NUM; testnum++) {
-        int st = 0;
+        EVP_PKEY *dsa_key = NULL;
+        int st;
+
         if (!dsa_doit[testnum])
             continue;
 
-        /* DSA_generate_key(dsa_key[testnum]); */
-        /* DSA_sign_setup(dsa_key[testnum],NULL); */
-        for (i = 0; i < loopargs_len; i++) {
-            st = DSA_sign(0, loopargs[i].buf, 20, loopargs[i].buf2,
-                          &loopargs[i].siglen, loopargs[i].dsa_key[testnum]);
-            if (st == 0)
-                break;
+        st = (dsa_key = get_dsa(dsa_bits[testnum])) != NULL;
+
+        for (i = 0; st && i < loopargs_len; i++) {
+            loopargs[i].dsa_sign_ctx[testnum] = EVP_PKEY_CTX_new(dsa_key,
+                                                                 NULL);
+            if (loopargs[i].dsa_sign_ctx[testnum] == NULL
+                || EVP_PKEY_sign_init(loopargs[i].dsa_sign_ctx[testnum]) <= 0
+
+                || EVP_PKEY_sign(loopargs[i].dsa_sign_ctx[testnum],
+                                 loopargs[i].buf2,
+                                 &loopargs[i].sigsize,
+                                 loopargs[i].buf, 20) <= 0)
+                st = 0;
         }
-        if (st == 0) {
+        if (!st) {
             BIO_printf(bio_err,
-                       "DSA sign failure.  No DSA sign will be done.\n");
+                       "DSA sign setup failure.  No DSA sign will be done.\n");
             ERR_print_errors(bio_err);
             op_count = 1;
         } else {
@@ -2792,15 +2480,20 @@ int speed_main(int argc, char **argv)
             op_count = count;
         }
 
-        for (i = 0; i < loopargs_len; i++) {
-            st = DSA_verify(0, loopargs[i].buf, 20, loopargs[i].buf2,
-                            loopargs[i].siglen, loopargs[i].dsa_key[testnum]);
-            if (st <= 0)
-                break;
+        for (i = 0; st && i < loopargs_len; i++) {
+            loopargs[i].dsa_verify_ctx[testnum] = EVP_PKEY_CTX_new(dsa_key,
+                                                                   NULL);
+            if (loopargs[i].dsa_verify_ctx[testnum] == NULL
+                || EVP_PKEY_verify_init(loopargs[i].dsa_verify_ctx[testnum]) <= 0
+                || EVP_PKEY_verify(loopargs[i].dsa_verify_ctx[testnum],
+                                   loopargs[i].buf2,
+                                   loopargs[i].sigsize,
+                                   loopargs[i].buf, 36) <= 0)
+                st = 0;
         }
-        if (st <= 0) {
+        if (!st) {
             BIO_printf(bio_err,
-                       "DSA verify failure.  No DSA verify will be done.\n");
+                       "DSA verify setup failure.  No DSA verify will be done.\n");
             ERR_print_errors(bio_err);
             dsa_doit[testnum] = 0;
         } else {
@@ -2821,93 +2514,85 @@ int speed_main(int argc, char **argv)
             /* if longer than 10s, don't do any more */
             stop_it(dsa_doit, testnum);
         }
+        EVP_PKEY_free(dsa_key);
     }
-#endif                          /* OPENSSL_NO_DSA */
 
-#ifndef OPENSSL_NO_EC
-# ifndef OPENSSL_NO_DEPRECATED_3_0
     for (testnum = 0; testnum < ECDSA_NUM; testnum++) {
-        int st = 1;
+        EVP_PKEY *ecdsa_key = NULL;
+        int st;
 
         if (!ecdsa_doit[testnum])
-            continue;           /* Ignore Curve */
-        for (i = 0; i < loopargs_len; i++) {
-            loopargs[i].ecdsa[testnum] =
-                EC_KEY_new_by_curve_name(ec_curves[testnum].nid);
-            if (loopargs[i].ecdsa[testnum] == NULL) {
+            continue;
+
+        st = (ecdsa_key = get_ecdsa(&ec_curves[testnum])) != NULL;
+
+        for (i = 0; st && i < loopargs_len; i++) {
+            loopargs[i].ecdsa_sign_ctx[testnum] = EVP_PKEY_CTX_new(ecdsa_key,
+                                                                   NULL);
+            if (loopargs[i].ecdsa_sign_ctx[testnum] == NULL
+                || EVP_PKEY_sign_init(loopargs[i].ecdsa_sign_ctx[testnum]) <= 0
+
+                || EVP_PKEY_sign(loopargs[i].ecdsa_sign_ctx[testnum],
+                                 loopargs[i].buf2,
+                                 &loopargs[i].sigsize,
+                                 loopargs[i].buf, 20) <= 0)
                 st = 0;
-                break;
-            }
         }
-        if (st == 0) {
-            BIO_printf(bio_err, "ECDSA failure.\n");
+        if (!st) {
+            BIO_printf(bio_err,
+                       "ECDSA sign setup failure.  No ECDSA sign will be done.\n");
             ERR_print_errors(bio_err);
             op_count = 1;
         } else {
-            for (i = 0; i < loopargs_len; i++) {
-                /* Perform ECDSA signature test */
-                EC_KEY_generate_key(loopargs[i].ecdsa[testnum]);
-                st = ECDSA_sign(0, loopargs[i].buf, 20, loopargs[i].buf2,
-                                &loopargs[i].siglen,
-                                loopargs[i].ecdsa[testnum]);
-                if (st == 0)
-                    break;
-            }
-            if (st == 0) {
-                BIO_printf(bio_err,
-                           "ECDSA sign failure.  No ECDSA sign will be done.\n");
-                ERR_print_errors(bio_err);
-                op_count = 1;
-            } else {
-                pkey_print_message("sign", "ecdsa",
-                                   ecdsa_c[testnum][0],
-                                   ec_curves[testnum].bits, seconds.ecdsa);
-                Time_F(START);
-                count = run_benchmark(async_jobs, ECDSA_sign_loop, loopargs);
-                d = Time_F(STOP);
+            pkey_print_message("sign", "ecdsa",
+                               ecdsa_c[testnum][0], ec_curves[testnum].bits,
+                               seconds.ecdsa);
+            Time_F(START);
+            count = run_benchmark(async_jobs, ECDSA_sign_loop, loopargs);
+            d = Time_F(STOP);
+            BIO_printf(bio_err,
+                       mr ? "+R5:%ld:%u:%.2f\n"
+                       : "%ld %u bits ECDSA signs in %.2fs\n",
+                       count, ec_curves[testnum].bits, d);
+            ecdsa_results[testnum][0] = (double)count / d;
+            op_count = count;
+        }
 
-                BIO_printf(bio_err,
-                           mr ? "+R5:%ld:%u:%.2f\n" :
-                           "%ld %u bits ECDSA signs in %.2fs \n",
-                           count, ec_curves[testnum].bits, d);
-                ecdsa_results[testnum][0] = (double)count / d;
-                op_count = count;
-            }
+        for (i = 0; st && i < loopargs_len; i++) {
+            loopargs[i].ecdsa_verify_ctx[testnum] = EVP_PKEY_CTX_new(ecdsa_key,
+                                                                   NULL);
+            if (loopargs[i].ecdsa_verify_ctx[testnum] == NULL
+                || EVP_PKEY_verify_init(loopargs[i].ecdsa_verify_ctx[testnum]) <= 0
+                || EVP_PKEY_verify(loopargs[i].ecdsa_verify_ctx[testnum],
+                                   loopargs[i].buf2,
+                                   loopargs[i].sigsize,
+                                   loopargs[i].buf, 20) <= 0)
+                st = 0;
+        }
+        if (!st) {
+            BIO_printf(bio_err,
+                       "ECDSA verify setup failure.  No ECDSA verify will be done.\n");
+            ERR_print_errors(bio_err);
+            ecdsa_doit[testnum] = 0;
+        } else {
+            pkey_print_message("verify", "ecdsa",
+                               ecdsa_c[testnum][1], ec_curves[testnum].bits,
+                               seconds.ecdsa);
+            Time_F(START);
+            count = run_benchmark(async_jobs, ECDSA_verify_loop, loopargs);
+            d = Time_F(STOP);
+            BIO_printf(bio_err,
+                       mr ? "+R6:%ld:%u:%.2f\n"
+                       : "%ld %u bits ECDSA verify in %.2fs\n",
+                       count, ec_curves[testnum].bits, d);
+            ecdsa_results[testnum][1] = (double)count / d;
+        }
 
-            /* Perform ECDSA verification test */
-            for (i = 0; i < loopargs_len; i++) {
-                st = ECDSA_verify(0, loopargs[i].buf, 20, loopargs[i].buf2,
-                                  loopargs[i].siglen,
-                                  loopargs[i].ecdsa[testnum]);
-                if (st != 1)
-                    break;
-            }
-            if (st != 1) {
-                BIO_printf(bio_err,
-                           "ECDSA verify failure.  No ECDSA verify will be done.\n");
-                ERR_print_errors(bio_err);
-                ecdsa_doit[testnum] = 0;
-            } else {
-                pkey_print_message("verify", "ecdsa",
-                                   ecdsa_c[testnum][1],
-                                   ec_curves[testnum].bits, seconds.ecdsa);
-                Time_F(START);
-                count = run_benchmark(async_jobs, ECDSA_verify_loop, loopargs);
-                d = Time_F(STOP);
-                BIO_printf(bio_err,
-                           mr ? "+R6:%ld:%u:%.2f\n"
-                           : "%ld %u bits ECDSA verify in %.2fs\n",
-                           count, ec_curves[testnum].bits, d);
-                ecdsa_results[testnum][1] = (double)count / d;
-            }
-
-            if (op_count <= 1) {
-                /* if longer than 10s, don't do any more */
-                stop_it(ecdsa_doit, testnum);
-            }
+        if (op_count <= 1) {
+            /* if longer than 10s, don't do any more */
+            stop_it(ecdsa_doit, testnum);
         }
     }
-# endif /* OPENSSL_NO_DEPRECATED_3_0 */
 
     for (testnum = 0; testnum < EC_NUM; testnum++) {
         int ecdh_checks = 1;
@@ -2916,7 +2601,6 @@ int speed_main(int argc, char **argv)
             continue;
 
         for (i = 0; i < loopargs_len; i++) {
-            EVP_PKEY_CTX *kctx = NULL;
             EVP_PKEY_CTX *test_ctx = NULL;
             EVP_PKEY_CTX *ctx = NULL;
             EVP_PKEY *key_A = NULL;
@@ -2924,78 +2608,9 @@ int speed_main(int argc, char **argv)
             size_t outlen;
             size_t test_outlen;
 
-            /* Ensure that the error queue is empty */
-            if (ERR_peek_error()) {
-                BIO_printf(bio_err,
-                           "WARNING: the error queue contains previous unhandled errors.\n");
-                ERR_print_errors(bio_err);
-            }
-
-            /* Let's try to create a ctx directly from the NID: this works for
-             * curves like Curve25519 that are not implemented through the low
-             * level EC interface.
-             * If this fails we try creating a EVP_PKEY_EC generic param ctx,
-             * then we set the curve by NID before deriving the actual keygen
-             * ctx for that specific curve. */
-            kctx = EVP_PKEY_CTX_new_id(ec_curves[testnum].nid, NULL); /* keygen ctx from NID */
-            if (!kctx) {
-                EVP_PKEY_CTX *pctx = NULL;
-                EVP_PKEY *params = NULL;
-
-                /* If we reach this code EVP_PKEY_CTX_new_id() failed and a
-                 * "int_ctx_new:unsupported algorithm" error was added to the
-                 * error queue.
-                 * We remove it from the error queue as we are handling it. */
-                unsigned long error = ERR_peek_error(); /* peek the latest error in the queue */
-                if (error == ERR_peek_last_error() && /* oldest and latest errors match */
-                    /* check that the error origin matches */
-                    ERR_GET_LIB(error) == ERR_LIB_EVP &&
-                    ERR_GET_REASON(error) == EVP_R_UNSUPPORTED_ALGORITHM)
-                    ERR_get_error(); /* pop error from queue */
-                if (ERR_peek_error()) {
-                    BIO_printf(bio_err,
-                               "Unhandled error in the error queue during ECDH init.\n");
-                    ERR_print_errors(bio_err);
-                    op_count = 1;
-                    break;
-                }
-
-                /* Create the context for parameter generation */
-                if (!(pctx = EVP_PKEY_CTX_new_id(EVP_PKEY_EC, NULL)) ||
-                       /* Initialise the parameter generation */
-                       !EVP_PKEY_paramgen_init(pctx) ||
-                       /* Set the curve by NID */
-                       !EVP_PKEY_CTX_set_ec_paramgen_curve_nid(pctx,
-                                                               ec_curves
-                                                               [testnum].nid) ||
-                       /* Create the parameter object params */
-                       !EVP_PKEY_paramgen(pctx, &params)) {
-                    ecdh_checks = 0;
-                    BIO_printf(bio_err, "ECDH EC params init failure.\n");
-                    ERR_print_errors(bio_err);
-                    op_count = 1;
-                    break;
-                }
-                /* Create the context for the key generation */
-                kctx = EVP_PKEY_CTX_new(params, NULL);
-
-                EVP_PKEY_free(params);
-                params = NULL;
-                EVP_PKEY_CTX_free(pctx);
-                pctx = NULL;
-            }
-            if (kctx == NULL ||      /* keygen ctx is not null */
-                EVP_PKEY_keygen_init(kctx) <= 0/* init keygen ctx */ ) {
-                ecdh_checks = 0;
-                BIO_printf(bio_err, "ECDH keygen failure.\n");
-                ERR_print_errors(bio_err);
-                op_count = 1;
-                break;
-            }
-
-            if (EVP_PKEY_keygen(kctx, &key_A) <= 0 || /* generate secret key A */
-                EVP_PKEY_keygen(kctx, &key_B) <= 0 || /* generate secret key B */
-                !(ctx = EVP_PKEY_CTX_new(key_A, NULL)) || /* derivation ctx from skeyA */
+            if ((key_A = get_ecdsa(&ec_curves[testnum])) == NULL || /* generate secret key A */
+                (key_B = get_ecdsa(&ec_curves[testnum])) == NULL || /* generate secret key B */
+                (ctx = EVP_PKEY_CTX_new(key_A, NULL)) == NULL || /* derivation ctx from skeyA */
                 EVP_PKEY_derive_init(ctx) <= 0 || /* init derivation ctx */
                 EVP_PKEY_derive_set_peer(ctx, key_B) <= 0 || /* set peer pubkey in ctx */
                 EVP_PKEY_derive(ctx, NULL, &outlen) <= 0 || /* determine max length */
@@ -3012,7 +2627,7 @@ int speed_main(int argc, char **argv)
              * we try this here and assume that further EVP_PKEY_derive calls
              * never fail, so we can skip checks in the actually benchmarked
              * code, for maximum performance. */
-            if (!(test_ctx = EVP_PKEY_CTX_new(key_B, NULL)) || /* test ctx from skeyB */
+            if ((test_ctx = EVP_PKEY_CTX_new(key_B, NULL)) == NULL || /* test ctx from skeyB */
                 !EVP_PKEY_derive_init(test_ctx) || /* init derivation test_ctx */
                 !EVP_PKEY_derive_set_peer(test_ctx, key_A) || /* set peer pubkey in test_ctx */
                 !EVP_PKEY_derive(test_ctx, NULL, &test_outlen) || /* determine max length */
@@ -3041,8 +2656,6 @@ int speed_main(int argc, char **argv)
 
             EVP_PKEY_free(key_A);
             EVP_PKEY_free(key_B);
-            EVP_PKEY_CTX_free(kctx);
-            kctx = NULL;
             EVP_PKEY_CTX_free(test_ctx);
             test_ctx = NULL;
         }
@@ -3183,7 +2796,7 @@ int speed_main(int argc, char **argv)
         }
     }
 
-# ifndef OPENSSL_NO_SM2
+#ifndef OPENSSL_NO_SM2
     for (testnum = 0; testnum < SM2_NUM; testnum++) {
         int st = 1;
         EVP_PKEY *sm2_pkey = NULL;
@@ -3316,8 +2929,7 @@ int speed_main(int argc, char **argv)
             }
         }
     }
-# endif                         /* OPENSSL_NO_SM2 */
-#endif                          /* OPENSSL_NO_EC */
+#endif                         /* OPENSSL_NO_SM2 */
 
 #ifndef OPENSSL_NO_DH
     for (testnum = 0; testnum < FFDH_NUM; testnum++) {
@@ -3397,7 +3009,7 @@ int speed_main(int argc, char **argv)
              * we know if future derive calls will fail, and we can skip
              * error checking in benchmarked code */
             ffdh_ctx = EVP_PKEY_CTX_new(pkey_A, NULL);
-            if (!ffdh_ctx) {
+            if (ffdh_ctx == NULL) {
                 BIO_printf(bio_err, "Error while allocating EVP_PKEY_CTX.\n");
                 ERR_print_errors(bio_err);
                 op_count = 1;
@@ -3557,7 +3169,6 @@ int speed_main(int argc, char **argv)
         }
         printf("\n");
     }
-#ifndef OPENSSL_NO_DEPRECATED_3_0
     testnum = 1;
     for (k = 0; k < RSA_NUM; k++) {
         if (!rsa_doit[k])
@@ -3574,8 +3185,6 @@ int speed_main(int argc, char **argv)
                    rsa_keys[k].bits, 1.0 / rsa_results[k][0], 1.0 / rsa_results[k][1],
                    rsa_results[k][0], rsa_results[k][1]);
     }
-#endif
-#if !defined(OPENSSL_NO_DSA) && !defined(OPENSSL_NO_DEPRECATED_3_0)
     testnum = 1;
     for (k = 0; k < DSA_NUM; k++) {
         if (!dsa_doit[k])
@@ -3592,8 +3201,6 @@ int speed_main(int argc, char **argv)
                    dsa_bits[k], 1.0 / dsa_results[k][0], 1.0 / dsa_results[k][1],
                    dsa_results[k][0], dsa_results[k][1]);
     }
-#endif
-#ifndef OPENSSL_NO_EC
     testnum = 1;
     for (k = 0; k < OSSL_NELEM(ecdsa_doit); k++) {
         if (!ecdsa_doit[k])
@@ -3653,7 +3260,7 @@ int speed_main(int argc, char **argv)
                    eddsa_results[k][0], eddsa_results[k][1]);
     }
 
-# ifndef OPENSSL_NO_SM2
+#ifndef OPENSSL_NO_SM2
     testnum = 1;
     for (k = 0; k < OSSL_NELEM(sm2_doit); k++) {
         if (!sm2_doit[k])
@@ -3673,8 +3280,7 @@ int speed_main(int argc, char **argv)
                    1.0 / sm2_results[k][0], 1.0 / sm2_results[k][1],
                    sm2_results[k][0], sm2_results[k][1]);
     }
-# endif
-#endif                          /* OPENSSL_NO_EC */
+#endif
 #ifndef OPENSSL_NO_DH
     testnum = 1;
     for (k = 0; k < FFDH_NUM; k++) {
@@ -3704,10 +3310,12 @@ int speed_main(int argc, char **argv)
         OPENSSL_free(loopargs[i].buf_malloc);
         OPENSSL_free(loopargs[i].buf2_malloc);
 
-#ifndef OPENSSL_NO_DEPRECATED_3_0
-        for (k = 0; k < RSA_NUM; k++)
-            RSA_free(loopargs[i].rsa_key[k]);
-#endif
+        BN_free(bn);
+        EVP_PKEY_CTX_free(genctx);
+        for (k = 0; k < RSA_NUM; k++) {
+            EVP_PKEY_CTX_free(loopargs[i].rsa_sign_ctx[k]);
+            EVP_PKEY_CTX_free(loopargs[i].rsa_verify_ctx[k]);
+        }
 #ifndef OPENSSL_NO_DH
         OPENSSL_free(loopargs[i].secret_ff_a);
         OPENSSL_free(loopargs[i].secret_ff_b);
@@ -3715,22 +3323,21 @@ int speed_main(int argc, char **argv)
             EVP_PKEY_CTX_free(loopargs[i].ffdh_ctx[k]);
         }
 #endif
-#if !defined(OPENSSL_NO_DSA) && !defined(OPENSSL_NO_DEPRECATED_3_0)
-        for (k = 0; k < DSA_NUM; k++)
-            DSA_free(loopargs[i].dsa_key[k]);
-#endif
-#ifndef OPENSSL_NO_EC
-# if !defined(OPENSSL_NO_DEPRECATED_3_0)
-        for (k = 0; k < ECDSA_NUM; k++)
-            EC_KEY_free(loopargs[i].ecdsa[k]);
-# endif
+        for (k = 0; k < DSA_NUM; k++) {
+            EVP_PKEY_CTX_free(loopargs[i].dsa_sign_ctx[k]);
+            EVP_PKEY_CTX_free(loopargs[i].dsa_verify_ctx[k]);
+        }
+        for (k = 0; k < ECDSA_NUM; k++) {
+            EVP_PKEY_CTX_free(loopargs[i].ecdsa_sign_ctx[k]);
+            EVP_PKEY_CTX_free(loopargs[i].ecdsa_verify_ctx[k]);
+        }
         for (k = 0; k < EC_NUM; k++)
             EVP_PKEY_CTX_free(loopargs[i].ecdh_ctx[k]);
         for (k = 0; k < EdDSA_NUM; k++) {
             EVP_MD_CTX_free(loopargs[i].eddsa_ctx[k]);
             EVP_MD_CTX_free(loopargs[i].eddsa_ctx2[k]);
 	}
-# ifndef OPENSSL_NO_SM2
+#ifndef OPENSSL_NO_SM2
         for (k = 0; k < SM2_NUM; k++) {
             EVP_PKEY_CTX *pctx = NULL;
 
@@ -3747,15 +3354,12 @@ int speed_main(int argc, char **argv)
             /* free pkey */
             EVP_PKEY_free(loopargs[i].sm2_pkey[k]);
         }
-# endif
+#endif
         OPENSSL_free(loopargs[i].secret_a);
         OPENSSL_free(loopargs[i].secret_b);
-#endif
     }
     OPENSSL_free(evp_hmac_name);
-#if !defined(OPENSSL_NO_CMAC) && !defined(OPENSSL_NO_DEPRECATED_3_0)
     OPENSSL_free(evp_cmac_name);
-#endif
 
     if (async_jobs > 0) {
         for (i = 0; i < loopargs_len; i++)
@@ -3767,7 +3371,7 @@ int speed_main(int argc, char **argv)
     }
     OPENSSL_free(loopargs);
     release_engine(e);
-    if (fetched_alg) {
+    if (fetched_cipher) {
         EVP_CIPHER_free(evp_cipher);
     }
     return ret;
@@ -3783,10 +3387,6 @@ static void print_message(const char *s, long num, int length, int tm)
     alarm(tm);
 }
 
-#if !defined(OPENSSL_NO_DEPRECATED_3_0)         \
-    || !defined(OPENSSL_NO_DSA)                 \
-    || !defined(OPENSSL_NO_DH)                  \
-    || !defined(OPENSSL_NO_EC)
 static void pkey_print_message(const char *str, const char *str2, long num,
                                unsigned int bits, int tm)
 {
@@ -3797,7 +3397,6 @@ static void pkey_print_message(const char *str, const char *str2, long num,
     run = 1;
     alarm(tm);
 }
-#endif
 
 static void print_result(int alg, int run_no, int count, double time_used)
 {
@@ -3904,7 +3503,6 @@ static int do_multi(int multi, int size_num)
                 for (j = 0; j < size_num; ++j)
                     results[alg][j] += atof(sstrsep(&p, sep));
             }
-#ifndef OPENSSL_NO_DEPRECATED_3_0
             else if (strncmp(buf, "+F2:", 4) == 0) {
                 int k;
                 double d;
@@ -3919,8 +3517,6 @@ static int do_multi(int multi, int size_num)
                 d = atof(sstrsep(&p, sep));
                 rsa_results[k][1] += d;
             }
-#endif
-#if !defined(OPENSSL_NO_DSA) && !defined(OPENSSL_NO_DEPRECATED_3_0)
             else if (strncmp(buf, "+F3:", 4) == 0) {
                 int k;
                 double d;
@@ -3935,8 +3531,6 @@ static int do_multi(int multi, int size_num)
                 d = atof(sstrsep(&p, sep));
                 dsa_results[k][1] += d;
             }
-# endif
-# ifndef OPENSSL_NO_EC
             else if (strncmp(buf, "+F4:", 4) == 0) {
                 int k;
                 double d;
@@ -3975,7 +3569,7 @@ static int do_multi(int multi, int size_num)
                 d = atof(sstrsep(&p, sep));
                 eddsa_results[k][1] += d;
             }
-#  ifndef OPENSSL_NO_SM2
+# ifndef OPENSSL_NO_SM2
             else if (strncmp(buf, "+F7:", 4) == 0) {
                 int k;
                 double d;
@@ -3991,8 +3585,7 @@ static int do_multi(int multi, int size_num)
                 d = atof(sstrsep(&p, sep));
                 sm2_results[k][1] += d;
             }
-#  endif /* OPENSSL_NO_SM2 */
-# endif /* OPENSSL_NO_EC */
+# endif /* OPENSSL_NO_SM2 */
 # ifndef OPENSSL_NO_DH
             else if (strncmp(buf, "+F8:", 4) == 0) {
                 int k;

--- a/apps/testdsa.h
+++ b/apps/testdsa.h
@@ -244,8 +244,8 @@ EVP_PKEY *get_dsa(int dsa_bits)
     p = BN_bin2bn(dsa_t.p, dsa_t.p_l, NULL);
     q = BN_bin2bn(dsa_t.q, dsa_t.q_l, NULL);
     g = BN_bin2bn(dsa_t.g, dsa_t.g_l, NULL);
-    if ((priv_key == NULL) || (pub_key == NULL) || (p == NULL) || (q == NULL)
-         || (g == NULL)) {
+    if (priv_key == NULL || pub_key == NULL || p == NULL || q == NULL
+        || g == NULL) {
         goto err;
     }
     if ((tmpl = OSSL_PARAM_BLD_new()) == NULL
@@ -264,7 +264,7 @@ EVP_PKEY *get_dsa(int dsa_bits)
 
     if (EVP_PKEY_fromdata_init(pctx) <= 0
         || EVP_PKEY_fromdata(pctx, &pkey, EVP_PKEY_KEYPAIR,
-                                          params) <= 0)
+                             params) <= 0)
         pkey = NULL;
 err:
     OSSL_PARAM_BLD_free_params(params);

--- a/apps/testdsa.h
+++ b/apps/testdsa.h
@@ -7,8 +7,10 @@
  * https://www.openssl.org/source/license.html
  */
 
+#include <openssl/param_build.h>
+
 /* used by speed.c */
-DSA *get_dsa(int);
+EVP_PKEY *get_dsa(int);
 
 static unsigned char dsa512_priv[] = {
     0x65, 0xe5, 0xc7, 0x38, 0x60, 0x24, 0xb5, 0x89, 0xd4, 0x9c, 0xeb, 0x4c,
@@ -211,11 +213,14 @@ typedef struct testdsa_st {
         st.q_l = sizeof(dsa##bits##_q); \
     } while (0)
 
-DSA *get_dsa(int dsa_bits)
+EVP_PKEY *get_dsa(int dsa_bits)
 {
-    DSA *dsa;
+    EVP_PKEY *pkey = NULL;
     BIGNUM *priv_key, *pub_key, *p, *q, *g;
+    EVP_PKEY_CTX *pctx;
     testdsa dsa_t;
+    OSSL_PARAM_BLD *tmpl = NULL;
+    OSSL_PARAM *params = NULL;
 
     switch (dsa_bits) {
     case 512:
@@ -231,8 +236,9 @@ DSA *get_dsa(int dsa_bits)
         return NULL;
     }
 
-    if ((dsa = DSA_new()) == NULL)
+    if ((pctx = EVP_PKEY_CTX_new_from_name(NULL, "DSA", NULL)) == NULL)
         return NULL;
+
     priv_key = BN_bin2bn(dsa_t.priv, dsa_t.priv_l, NULL);
     pub_key = BN_bin2bn(dsa_t.pub, dsa_t.pub_l, NULL);
     p = BN_bin2bn(dsa_t.p, dsa_t.p_l, NULL);
@@ -242,19 +248,32 @@ DSA *get_dsa(int dsa_bits)
          || (g == NULL)) {
         goto err;
     }
-    if (!DSA_set0_pqg(dsa, p, q, g))
+    if ((tmpl = OSSL_PARAM_BLD_new()) == NULL
+        || !OSSL_PARAM_BLD_push_BN(tmpl, OSSL_PKEY_PARAM_FFC_P,
+                                   p)
+        || !OSSL_PARAM_BLD_push_BN(tmpl, OSSL_PKEY_PARAM_FFC_Q,
+                                   q)
+        || !OSSL_PARAM_BLD_push_BN(tmpl, OSSL_PKEY_PARAM_FFC_G,
+                                   g)
+        || !OSSL_PARAM_BLD_push_BN(tmpl, OSSL_PKEY_PARAM_PRIV_KEY,
+                                   priv_key)
+        || !OSSL_PARAM_BLD_push_BN(tmpl, OSSL_PKEY_PARAM_PUB_KEY,
+                                   pub_key)
+        || (params = OSSL_PARAM_BLD_to_param(tmpl)) == NULL)
         goto err;
 
-    if (!DSA_set0_key(dsa, pub_key, priv_key))
-        goto err;
-
-    return dsa;
- err:
-    DSA_free(dsa);
+    if (EVP_PKEY_fromdata_init(pctx) <= 0
+        || EVP_PKEY_fromdata(pctx, &pkey, EVP_PKEY_KEYPAIR,
+                                          params) <= 0)
+        pkey = NULL;
+err:
+    OSSL_PARAM_BLD_free_params(params);
+    OSSL_PARAM_BLD_free(tmpl);
     BN_free(priv_key);
     BN_free(pub_key);
     BN_free(p);
     BN_free(q);
     BN_free(g);
-    return NULL;
+    EVP_PKEY_CTX_free(pctx);
+    return pkey;
 }


### PR DESCRIPTION
Also drop code to handle platforms without SIGALRM (except for Windows) as the code was uncompilable anyway.

There could be further refactoring and cleanups done, but I am not sure it is worth it.

Also some of the choices made were done so the speed measurement is as close to 1.1.1 as possible to keep the values roughly comparable.

Fixes #13909
