### PR TITLE
Always check CRYPTO_LOCK_{read,write}_lock

### DIFF
--- a/crypto/bio/b_addr.c
+++ b/crypto/bio/b_addr.c
@@ -784,7 +784,10 @@ int BIO_lookup_ex(const char *host, const char *service, int lookup_type,
             goto err;
         }
 
-        CRYPTO_THREAD_write_lock(bio_lookup_lock);
+        if (!CRYPTO_THREAD_write_lock(bio_lookup_lock)) {
+            ret = 0;
+            goto err;
+        }
         he_fallback_address = INADDR_ANY;
         if (host == NULL) {
             he = &he_fallback;

--- a/crypto/engine/eng_ctrl.c
+++ b/crypto/engine/eng_ctrl.c
@@ -132,7 +132,8 @@ int ENGINE_ctrl(ENGINE *e, int cmd, long i, void *p, void (*f) (void))
         ERR_raise(ERR_LIB_ENGINE, ERR_R_PASSED_NULL_PARAMETER);
         return 0;
     }
-    CRYPTO_THREAD_write_lock(global_engine_lock);
+    if (!CRYPTO_THREAD_write_lock(global_engine_lock))
+        return 0;
     ref_exists = ((e->struct_ref > 0) ? 1 : 0);
     CRYPTO_THREAD_unlock(global_engine_lock);
     ctrl_exists = ((e->ctrl == NULL) ? 0 : 1);

--- a/crypto/engine/eng_list.c
+++ b/crypto/engine/eng_list.c
@@ -138,7 +138,8 @@ ENGINE *ENGINE_get_first(void)
         return NULL;
     }
 
-    CRYPTO_THREAD_write_lock(global_engine_lock);
+    if (!CRYPTO_THREAD_write_lock(global_engine_lock))
+        return NULL;
     ret = engine_list_head;
     if (ret) {
         ret->struct_ref++;
@@ -157,7 +158,8 @@ ENGINE *ENGINE_get_last(void)
         return NULL;
     }
 
-    CRYPTO_THREAD_write_lock(global_engine_lock);
+    if (!CRYPTO_THREAD_write_lock(global_engine_lock))
+        return NULL;
     ret = engine_list_tail;
     if (ret) {
         ret->struct_ref++;
@@ -173,9 +175,10 @@ ENGINE *ENGINE_get_next(ENGINE *e)
     ENGINE *ret = NULL;
     if (e == NULL) {
         ERR_raise(ERR_LIB_ENGINE, ERR_R_PASSED_NULL_PARAMETER);
-        return 0;
+        return NULL;
     }
-    CRYPTO_THREAD_write_lock(global_engine_lock);
+    if (!CRYPTO_THREAD_write_lock(global_engine_lock))
+        return NULL;
     ret = e->next;
     if (ret) {
         /* Return a valid structural reference to the next ENGINE */
@@ -193,9 +196,10 @@ ENGINE *ENGINE_get_prev(ENGINE *e)
     ENGINE *ret = NULL;
     if (e == NULL) {
         ERR_raise(ERR_LIB_ENGINE, ERR_R_PASSED_NULL_PARAMETER);
-        return 0;
+        return NULL;
     }
-    CRYPTO_THREAD_write_lock(global_engine_lock);
+    if (!CRYPTO_THREAD_write_lock(global_engine_lock))
+        return NULL;
     ret = e->prev;
     if (ret) {
         /* Return a valid structural reference to the next ENGINE */
@@ -220,7 +224,8 @@ int ENGINE_add(ENGINE *e)
         ERR_raise(ERR_LIB_ENGINE, ENGINE_R_ID_OR_NAME_MISSING);
         return 0;
     }
-    CRYPTO_THREAD_write_lock(global_engine_lock);
+    if (!CRYPTO_THREAD_write_lock(global_engine_lock))
+        return 0;
     if (!engine_list_add(e)) {
         ERR_raise(ERR_LIB_ENGINE, ENGINE_R_INTERNAL_LIST_ERROR);
         to_return = 0;
@@ -237,7 +242,8 @@ int ENGINE_remove(ENGINE *e)
         ERR_raise(ERR_LIB_ENGINE, ERR_R_PASSED_NULL_PARAMETER);
         return 0;
     }
-    CRYPTO_THREAD_write_lock(global_engine_lock);
+    if (!CRYPTO_THREAD_write_lock(global_engine_lock))
+        return 0;
     if (!engine_list_remove(e)) {
         ERR_raise(ERR_LIB_ENGINE, ENGINE_R_INTERNAL_LIST_ERROR);
         to_return = 0;
@@ -289,7 +295,8 @@ ENGINE *ENGINE_by_id(const char *id)
         return NULL;
     }
 
-    CRYPTO_THREAD_write_lock(global_engine_lock);
+    if (!CRYPTO_THREAD_write_lock(global_engine_lock))
+        return NULL;
     iterator = engine_list_head;
     while (iterator && (strcmp(id, iterator->id) != 0))
         iterator = iterator->next;

--- a/crypto/engine/eng_pkey.c
+++ b/crypto/engine/eng_pkey.c
@@ -60,23 +60,24 @@ EVP_PKEY *ENGINE_load_private_key(ENGINE *e, const char *key_id,
 
     if (e == NULL) {
         ERR_raise(ERR_LIB_ENGINE, ERR_R_PASSED_NULL_PARAMETER);
-        return 0;
+        return NULL;
     }
-    CRYPTO_THREAD_write_lock(global_engine_lock);
+    if (!CRYPTO_THREAD_write_lock(global_engine_lock))
+        return NULL;
     if (e->funct_ref == 0) {
         CRYPTO_THREAD_unlock(global_engine_lock);
         ERR_raise(ERR_LIB_ENGINE, ENGINE_R_NOT_INITIALISED);
-        return 0;
+        return NULL;
     }
     CRYPTO_THREAD_unlock(global_engine_lock);
     if (!e->load_privkey) {
         ERR_raise(ERR_LIB_ENGINE, ENGINE_R_NO_LOAD_FUNCTION);
-        return 0;
+        return NULL;
     }
     pkey = e->load_privkey(e, key_id, ui_method, callback_data);
     if (pkey == NULL) {
         ERR_raise(ERR_LIB_ENGINE, ENGINE_R_FAILED_LOADING_PRIVATE_KEY);
-        return 0;
+        return NULL;
     }
     return pkey;
 }
@@ -88,23 +89,24 @@ EVP_PKEY *ENGINE_load_public_key(ENGINE *e, const char *key_id,
 
     if (e == NULL) {
         ERR_raise(ERR_LIB_ENGINE, ERR_R_PASSED_NULL_PARAMETER);
-        return 0;
+        return NULL;
     }
-    CRYPTO_THREAD_write_lock(global_engine_lock);
+    if (!CRYPTO_THREAD_write_lock(global_engine_lock))
+        return NULL;
     if (e->funct_ref == 0) {
         CRYPTO_THREAD_unlock(global_engine_lock);
         ERR_raise(ERR_LIB_ENGINE, ENGINE_R_NOT_INITIALISED);
-        return 0;
+        return NULL;
     }
     CRYPTO_THREAD_unlock(global_engine_lock);
     if (!e->load_pubkey) {
         ERR_raise(ERR_LIB_ENGINE, ENGINE_R_NO_LOAD_FUNCTION);
-        return 0;
+        return NULL;
     }
     pkey = e->load_pubkey(e, key_id, ui_method, callback_data);
     if (pkey == NULL) {
         ERR_raise(ERR_LIB_ENGINE, ENGINE_R_FAILED_LOADING_PUBLIC_KEY);
-        return 0;
+        return NULL;
     }
     return pkey;
 }
@@ -119,7 +121,8 @@ int ENGINE_load_ssl_client_cert(ENGINE *e, SSL *s,
         ERR_raise(ERR_LIB_ENGINE, ERR_R_PASSED_NULL_PARAMETER);
         return 0;
     }
-    CRYPTO_THREAD_write_lock(global_engine_lock);
+    if (!CRYPTO_THREAD_write_lock(global_engine_lock))
+        return 0;
     if (e->funct_ref == 0) {
         CRYPTO_THREAD_unlock(global_engine_lock);
         ERR_raise(ERR_LIB_ENGINE, ENGINE_R_NOT_INITIALISED);

--- a/crypto/engine/tb_asnmth.c
+++ b/crypto/engine/tb_asnmth.c
@@ -199,7 +199,8 @@ const EVP_PKEY_ASN1_METHOD *ENGINE_pkey_asn1_find_str(ENGINE **pe,
         return NULL;
     }
 
-    CRYPTO_THREAD_write_lock(global_engine_lock);
+    if (!CRYPTO_THREAD_write_lock(global_engine_lock))
+        return NULL;
     engine_table_doall(pkey_asn1_meth_table, look_str_cb, &fstr);
     /* If found obtain a structural reference to engine */
     if (fstr.e) {

--- a/crypto/err/err.c
+++ b/crypto/err/err.c
@@ -176,7 +176,8 @@ static ERR_STRING_DATA *int_err_get_item(const ERR_STRING_DATA *d)
 {
     ERR_STRING_DATA *p = NULL;
 
-    CRYPTO_THREAD_read_lock(err_string_lock);
+    if (!CRYPTO_THREAD_read_lock(err_string_lock))
+        return NULL;
     p = lh_ERR_STRING_DATA_retrieve(int_error_hash, d);
     CRYPTO_THREAD_unlock(err_string_lock);
 
@@ -238,7 +239,8 @@ static void err_patch(int lib, ERR_STRING_DATA *str)
  */
 static int err_load_strings(const ERR_STRING_DATA *str)
 {
-    CRYPTO_THREAD_write_lock(err_string_lock);
+    if (!CRYPTO_THREAD_write_lock(err_string_lock))
+        return 0;
     for (; str->error; str++)
         (void)lh_ERR_STRING_DATA_insert(int_error_hash,
                                        (ERR_STRING_DATA *)str);
@@ -281,7 +283,8 @@ int ERR_unload_strings(int lib, ERR_STRING_DATA *str)
     if (!RUN_ONCE(&err_string_init, do_err_strings_init))
         return 0;
 
-    CRYPTO_THREAD_write_lock(err_string_lock);
+    if (!CRYPTO_THREAD_write_lock(err_string_lock))
+        return 0;
     /*
      * We don't need to ERR_PACK the lib, since that was done (to
      * the table) when it was loaded.
@@ -728,7 +731,8 @@ int ERR_get_next_error_library(void)
     if (!RUN_ONCE(&err_string_init, do_err_strings_init))
         return 0;
 
-    CRYPTO_THREAD_write_lock(err_string_lock);
+    if (!CRYPTO_THREAD_write_lock(err_string_lock))
+        return 0;
     ret = int_err_library_number++;
     CRYPTO_THREAD_unlock(err_string_lock);
     return ret;

--- a/crypto/ex_data.c
+++ b/crypto/ex_data.c
@@ -43,7 +43,8 @@ static EX_CALLBACKS *get_and_lock(OSSL_EX_DATA_GLOBAL *global, int class_index)
          return NULL;
     }
 
-    CRYPTO_THREAD_write_lock(global->ex_data_lock);
+    if (!CRYPTO_THREAD_write_lock(global->ex_data_lock))
+        return NULL;
     ip = &global->ex_data[class_index];
     return ip;
 }
@@ -367,7 +368,8 @@ void CRYPTO_free_ex_data(int class_index, void *obj, CRYPTO_EX_DATA *ad)
         if (storage != NULL)
             f = storage[i];
         else {
-            CRYPTO_THREAD_write_lock(global->ex_data_lock);
+            if (!CRYPTO_THREAD_write_lock(global->ex_data_lock))
+                continue;
             f = sk_EX_CALLBACK_value(ip->meth, i);
             CRYPTO_THREAD_unlock(global->ex_data_lock);
         }

--- a/crypto/init.c
+++ b/crypto/init.c
@@ -586,7 +586,8 @@ int OPENSSL_init_crypto(uint64_t opts, const OPENSSL_INIT_SETTINGS *settings)
         if (settings == NULL) {
             ret = RUN_ONCE(&config, ossl_init_config);
         } else {
-            CRYPTO_THREAD_write_lock(init_lock);
+            if (!CRYPTO_THREAD_write_lock(init_lock))
+                return 0;
             conf_settings = settings;
             ret = RUN_ONCE_ALT(&config, ossl_init_config_settings,
                                ossl_init_config);

--- a/crypto/rsa/rsa_ossl.c
+++ b/crypto/rsa/rsa_ossl.c
@@ -163,7 +163,8 @@ static BN_BLINDING *rsa_get_blinding(RSA *rsa, int *local, BN_CTX *ctx)
 {
     BN_BLINDING *ret;
 
-    CRYPTO_THREAD_write_lock(rsa->lock);
+    if (!CRYPTO_THREAD_write_lock(rsa->lock))
+        return NULL;
 
     if (rsa->blinding == NULL) {
         rsa->blinding = RSA_setup_blinding(rsa, ctx);

--- a/crypto/store/store_register.c
+++ b/crypto/store/store_register.c
@@ -194,7 +194,8 @@ int ossl_store_register_loader_int(OSSL_STORE_LOADER *loader)
         ERR_raise(ERR_LIB_OSSL_STORE, ERR_R_MALLOC_FAILURE);
         return 0;
     }
-    CRYPTO_THREAD_write_lock(registry_lock);
+    if (!CRYPTO_THREAD_write_lock(registry_lock))
+        return 0;
 
     if (ossl_store_register_init()
         && (lh_OSSL_STORE_LOADER_insert(loader_register, loader) != NULL
@@ -231,7 +232,8 @@ const OSSL_STORE_LOADER *ossl_store_get0_loader_int(const char *scheme)
         ERR_raise(ERR_LIB_OSSL_STORE, ERR_R_MALLOC_FAILURE);
         return NULL;
     }
-    CRYPTO_THREAD_write_lock(registry_lock);
+    if (!CRYPTO_THREAD_write_lock(registry_lock))
+        return NULL;
 
     if (!ossl_store_register_init())
         ERR_raise(ERR_LIB_OSSL_STORE, ERR_R_INTERNAL_ERROR);
@@ -260,7 +262,8 @@ OSSL_STORE_LOADER *ossl_store_unregister_loader_int(const char *scheme)
         ERR_raise(ERR_LIB_OSSL_STORE, ERR_R_MALLOC_FAILURE);
         return NULL;
     }
-    CRYPTO_THREAD_write_lock(registry_lock);
+    if (!CRYPTO_THREAD_write_lock(registry_lock))
+        return NULL;
 
     if (!ossl_store_register_init())
         ERR_raise(ERR_LIB_OSSL_STORE, ERR_R_INTERNAL_ERROR);

--- a/crypto/threads_none.c
+++ b/crypto/threads_none.c
@@ -31,14 +31,14 @@ CRYPTO_RWLOCK *CRYPTO_THREAD_lock_new(void)
     return lock;
 }
 
-int CRYPTO_THREAD_read_lock(CRYPTO_RWLOCK *lock)
+__owur int CRYPTO_THREAD_read_lock(CRYPTO_RWLOCK *lock)
 {
     if (!ossl_assert(*(unsigned int *)lock == 1))
         return 0;
     return 1;
 }
 
-int CRYPTO_THREAD_write_lock(CRYPTO_RWLOCK *lock)
+__owur int CRYPTO_THREAD_write_lock(CRYPTO_RWLOCK *lock)
 {
     if (!ossl_assert(*(unsigned int *)lock == 1))
         return 0;

--- a/crypto/threads_pthread.c
+++ b/crypto/threads_pthread.c
@@ -73,7 +73,7 @@ CRYPTO_RWLOCK *CRYPTO_THREAD_lock_new(void)
     return lock;
 }
 
-int CRYPTO_THREAD_read_lock(CRYPTO_RWLOCK *lock)
+__owur int CRYPTO_THREAD_read_lock(CRYPTO_RWLOCK *lock)
 {
 # ifdef USE_RWLOCK
     if (pthread_rwlock_rdlock(lock) != 0)
@@ -88,7 +88,7 @@ int CRYPTO_THREAD_read_lock(CRYPTO_RWLOCK *lock)
     return 1;
 }
 
-int CRYPTO_THREAD_write_lock(CRYPTO_RWLOCK *lock)
+__owur int CRYPTO_THREAD_write_lock(CRYPTO_RWLOCK *lock)
 {
 # ifdef USE_RWLOCK
     if (pthread_rwlock_wrlock(lock) != 0)

--- a/crypto/threads_win.c
+++ b/crypto/threads_win.c
@@ -57,7 +57,7 @@ CRYPTO_RWLOCK *CRYPTO_THREAD_lock_new(void)
     return lock;
 }
 
-int CRYPTO_THREAD_read_lock(CRYPTO_RWLOCK *lock)
+__owur int CRYPTO_THREAD_read_lock(CRYPTO_RWLOCK *lock)
 {
 # ifdef USE_RWLOCK
     CRYPTO_win_rwlock *rwlock = lock;
@@ -69,7 +69,7 @@ int CRYPTO_THREAD_read_lock(CRYPTO_RWLOCK *lock)
     return 1;
 }
 
-int CRYPTO_THREAD_write_lock(CRYPTO_RWLOCK *lock)
+__owur int CRYPTO_THREAD_write_lock(CRYPTO_RWLOCK *lock)
 {
 # ifdef USE_RWLOCK
     CRYPTO_win_rwlock *rwlock = lock;

--- a/crypto/trace.c
+++ b/crypto/trace.c
@@ -468,7 +468,8 @@ BIO *OSSL_trace_begin(int category)
     prefix = trace_channels[category].prefix;
 
     if (channel != NULL) {
-        CRYPTO_THREAD_write_lock(trace_lock);
+        if (!CRYPTO_THREAD_write_lock(trace_lock))
+            return NULL;
         current_channel = channel;
         switch (trace_channels[category].type) {
         case SIMPLE_CHANNEL:

--- a/crypto/ui/ui_openssl.c
+++ b/crypto/ui/ui_openssl.c
@@ -372,7 +372,8 @@ static int read_string_inner(UI *ui, UI_STRING *uis, int echo, int strip_nl)
 /* Internal functions to open, handle and close a channel to the console.  */
 static int open_console(UI *ui)
 {
-    CRYPTO_THREAD_write_lock(ui->lock);
+    if (!CRYPTO_THREAD_write_lock(ui->lock))
+        return 0;
     is_a_tty = 1;
 
 # if defined(OPENSSL_SYS_VXWORKS)

--- a/crypto/x509/by_dir.c
+++ b/crypto/x509/by_dir.c
@@ -268,7 +268,8 @@ static int get_cert_by_subject_ex(X509_LOOKUP *xl, X509_LOOKUP_TYPE type,
         }
         if (type == X509_LU_CRL && ent->hashes) {
             htmp.hash = h;
-            CRYPTO_THREAD_read_lock(ctx->lock);
+            if (!CRYPTO_THREAD_read_lock(ctx->lock))
+                goto finish;
             idx = sk_BY_DIR_HASH_find(ent->hashes, &htmp);
             if (idx >= 0) {
                 hent = sk_BY_DIR_HASH_value(ent->hashes, idx);
@@ -346,7 +347,8 @@ static int get_cert_by_subject_ex(X509_LOOKUP *xl, X509_LOOKUP_TYPE type,
         /* If a CRL, update the last file suffix added for this */
 
         if (type == X509_LU_CRL) {
-            CRYPTO_THREAD_write_lock(ctx->lock);
+            if (!CRYPTO_THREAD_write_lock(ctx->lock))
+                goto finish;
             /*
              * Look for entry again in case another thread added an entry
              * first.

--- a/crypto/x509/pcy_cache.c
+++ b/crypto/x509/pcy_cache.c
@@ -188,7 +188,8 @@ const X509_POLICY_CACHE *policy_cache_set(X509 *x)
 {
 
     if (x->policy_cache == NULL) {
-        CRYPTO_THREAD_write_lock(x->lock);
+        if (!CRYPTO_THREAD_write_lock(x->lock))
+            return NULL;
         policy_cache_new(x);
         CRYPTO_THREAD_unlock(x->lock);
     }

--- a/crypto/x509/v3_purp.c
+++ b/crypto/x509/v3_purp.c
@@ -411,7 +411,8 @@ int x509v3_cache_extensions(X509 *x)
         return (x->ex_flags & EXFLAG_INVALID) == 0;
 #endif
 
-    CRYPTO_THREAD_write_lock(x->lock);
+    if (!CRYPTO_THREAD_write_lock(x->lock))
+        return 0;
     if (x->ex_flags & EXFLAG_SET) { /* Cert has already been processed */
         CRYPTO_THREAD_unlock(x->lock);
         return (x->ex_flags & EXFLAG_INVALID) == 0;

--- a/crypto/x509/x_crl.c
+++ b/crypto/x509/x_crl.c
@@ -427,7 +427,8 @@ static int def_crl_lookup(X509_CRL *crl,
      * under a lock to avoid race condition.
      */
     if (!sk_X509_REVOKED_is_sorted(crl->crl.revoked)) {
-        CRYPTO_THREAD_write_lock(crl->lock);
+        if (!CRYPTO_THREAD_write_lock(crl->lock))
+            return 0;
         sk_X509_REVOKED_sort(crl->crl.revoked);
         CRYPTO_THREAD_unlock(crl->lock);
     }

--- a/doc/internal/man3/ossl_namemap_new.pod
+++ b/doc/internal/man3/ossl_namemap_new.pod
@@ -85,7 +85,8 @@ ossl_namemap_new() and ossl_namemap_stored() return the pointer to a
 B<OSSL_NAMEMAP>, or NULL on error.
 
 ossl_namemap_empty() returns 1 if the B<OSSL_NAMEMAP> is NULL or
-empty, or 0 if it's not empty.
+empty, 0 if it's not empty, or -1 on internal error (such as inability
+to lock).
 
 ossl_namemap_add_name() and ossl_namemap_add_name_n() return the number
 associated with the added string, or zero on error.

--- a/include/openssl/crypto.h.in
+++ b/include/openssl/crypto.h.in
@@ -79,8 +79,8 @@ typedef struct {
 typedef void CRYPTO_RWLOCK;
 
 CRYPTO_RWLOCK *CRYPTO_THREAD_lock_new(void);
-int CRYPTO_THREAD_read_lock(CRYPTO_RWLOCK *lock);
-int CRYPTO_THREAD_write_lock(CRYPTO_RWLOCK *lock);
+__owur int CRYPTO_THREAD_read_lock(CRYPTO_RWLOCK *lock);
+__owur int CRYPTO_THREAD_write_lock(CRYPTO_RWLOCK *lock);
 int CRYPTO_THREAD_unlock(CRYPTO_RWLOCK *lock);
 void CRYPTO_THREAD_lock_free(CRYPTO_RWLOCK *lock);
 

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -893,7 +893,8 @@ int SSL_set_session_id_context(SSL *ssl, const unsigned char *sid_ctx,
 
 int SSL_CTX_set_generate_session_id(SSL_CTX *ctx, GEN_SESSION_CB cb)
 {
-    CRYPTO_THREAD_write_lock(ctx->lock);
+    if (!CRYPTO_THREAD_write_lock(ctx->lock))
+        return 0;
     ctx->generate_session_id = cb;
     CRYPTO_THREAD_unlock(ctx->lock);
     return 1;
@@ -901,7 +902,8 @@ int SSL_CTX_set_generate_session_id(SSL_CTX *ctx, GEN_SESSION_CB cb)
 
 int SSL_set_generate_session_id(SSL *ssl, GEN_SESSION_CB cb)
 {
-    CRYPTO_THREAD_write_lock(ssl->lock);
+    if (!CRYPTO_THREAD_write_lock(ssl->lock))
+        return 0;
     ssl->generate_session_id = cb;
     CRYPTO_THREAD_unlock(ssl->lock);
     return 1;
@@ -926,7 +928,8 @@ int SSL_has_matching_session_id(const SSL *ssl, const unsigned char *id,
     r.session_id_length = id_len;
     memcpy(r.session_id, id, id_len);
 
-    CRYPTO_THREAD_read_lock(ssl->session_ctx->lock);
+    if (!CRYPTO_THREAD_read_lock(ssl->session_ctx->lock))
+        return 0;
     p = lh_SSL_SESSION_retrieve(ssl->session_ctx->sessions, &r);
     CRYPTO_THREAD_unlock(ssl->session_ctx->lock);
     return (p != NULL);

--- a/test/namemap_internal_test.c
+++ b/test/namemap_internal_test.c
@@ -21,11 +21,11 @@ static int test_namemap_empty(void)
     OSSL_NAMEMAP *nm = NULL;
     int ok;
 
-    ok = TEST_true(ossl_namemap_empty(NULL))
+    ok = TEST_int_eq(ossl_namemap_empty(NULL), 1)
          && TEST_ptr(nm = ossl_namemap_new())
-         && TEST_true(ossl_namemap_empty(nm))
+         && TEST_int_eq(ossl_namemap_empty(nm), 1)
          && TEST_int_ne(ossl_namemap_add_name(nm, 0, NAME1), 0)
-         && TEST_false(ossl_namemap_empty(nm));
+         && TEST_int_eq(ossl_namemap_empty(nm), 0);
     ossl_namemap_free(nm);
     return ok;
 }


### PR DESCRIPTION
Some functions that lock things are void, so we just return early.

Fixes: #14230

Also marks the lock routines `__owur` so the error doesn't propagate.