### PR TITLE
Add context gettable and settable calls

### DIFF
--- a/crypto/evp/digest.c
+++ b/crypto/evp/digest.c
@@ -656,14 +656,19 @@ int EVP_MD_CTX_set_params(EVP_MD_CTX *ctx, const OSSL_PARAM params[])
 
 const OSSL_PARAM *EVP_MD_settable_ctx_params(const EVP_MD *md)
 {
-    if (md != NULL && md->settable_ctx_params != NULL)
-        return md->settable_ctx_params(ossl_provider_ctx(EVP_MD_provider(md)));
+    void *alg;
+
+    if (md != NULL && md->settable_ctx_params != NULL) {
+        alg = ossl_provider_ctx(EVP_MD_provider(md));
+        return md->settable_ctx_params(NULL, alg);
+    }
     return NULL;
 }
 
 const OSSL_PARAM *EVP_MD_CTX_settable_params(EVP_MD_CTX *ctx)
 {
     EVP_PKEY_CTX *pctx;
+    void *alg;
 
     if (ctx == NULL)
         return NULL;
@@ -678,9 +683,10 @@ const OSSL_PARAM *EVP_MD_CTX_settable_params(EVP_MD_CTX *ctx)
         return pctx->op.sig.signature->settable_ctx_md_params(
                    pctx->op.sig.sigprovctx);
 
-    if (ctx->digest != NULL && ctx->digest->settable_ctx_params != NULL)
-        return ctx->digest->settable_ctx_params(
-                  ossl_provider_ctx(EVP_MD_provider(ctx->digest)));
+    if (ctx->digest != NULL && ctx->digest->settable_ctx_params != NULL) {
+        alg = ossl_provider_ctx(EVP_MD_provider(ctx->digest));
+        return ctx->digest->settable_ctx_params(ctx->provctx, alg);
+    }
 
     return NULL;
 }
@@ -706,14 +712,19 @@ int EVP_MD_CTX_get_params(EVP_MD_CTX *ctx, OSSL_PARAM params[])
 
 const OSSL_PARAM *EVP_MD_gettable_ctx_params(const EVP_MD *md)
 {
-    if (md != NULL && md->gettable_ctx_params != NULL)
-        return md->gettable_ctx_params(ossl_provider_ctx(EVP_MD_provider(md)));
+    void *alg;
+
+    if (md != NULL && md->gettable_ctx_params != NULL) {
+        alg = ossl_provider_ctx(EVP_MD_provider(md));
+        return md->gettable_ctx_params(NULL, alg);
+    }
     return NULL;
 }
 
 const OSSL_PARAM *EVP_MD_CTX_gettable_params(EVP_MD_CTX *ctx)
 {
     EVP_PKEY_CTX *pctx;
+    void *alg;
 
     if (ctx == NULL)
         return NULL;
@@ -728,11 +739,10 @@ const OSSL_PARAM *EVP_MD_CTX_gettable_params(EVP_MD_CTX *ctx)
         return pctx->op.sig.signature->gettable_ctx_md_params(
                     pctx->op.sig.sigprovctx);
 
-    if (ctx->digest != NULL
-            && ctx->digest->gettable_ctx_params != NULL)
-        return ctx->digest->gettable_ctx_params(
-                   ossl_provider_ctx(EVP_MD_provider(ctx->digest)));
-
+    if (ctx->digest != NULL && ctx->digest->gettable_ctx_params != NULL) {
+        alg = ossl_provider_ctx(EVP_MD_provider(ctx->digest));
+        return ctx->digest->gettable_ctx_params(ctx->provctx, alg);
+    }
     return NULL;
 }
 

--- a/crypto/evp/evp_enc.c
+++ b/crypto/evp/evp_enc.c
@@ -1220,17 +1220,45 @@ const OSSL_PARAM *EVP_CIPHER_gettable_params(const EVP_CIPHER *cipher)
 
 const OSSL_PARAM *EVP_CIPHER_settable_ctx_params(const EVP_CIPHER *cipher)
 {
-    if (cipher != NULL && cipher->settable_ctx_params != NULL)
-        return cipher->settable_ctx_params(
-                   ossl_provider_ctx(EVP_CIPHER_provider(cipher)));
+    void *alg;
+
+    if (cipher != NULL && cipher->settable_ctx_params != NULL) {
+        alg = ossl_provider_ctx(EVP_CIPHER_provider(cipher));
+        return cipher->settable_ctx_params(NULL, alg);
+    }
     return NULL;
 }
 
 const OSSL_PARAM *EVP_CIPHER_gettable_ctx_params(const EVP_CIPHER *cipher)
 {
-    if (cipher != NULL && cipher->gettable_ctx_params != NULL)
-        return cipher->gettable_ctx_params(
-                   ossl_provider_ctx(EVP_CIPHER_provider(cipher)));
+    void *alg;
+
+    if (cipher != NULL && cipher->gettable_ctx_params != NULL) {
+        alg = ossl_provider_ctx(EVP_CIPHER_provider(cipher));
+        return cipher->gettable_ctx_params(NULL, alg);
+    }
+    return NULL;
+}
+
+const OSSL_PARAM *EVP_CIPHER_CTX_settable_params(EVP_CIPHER_CTX *cctx)
+{
+    void *alg;
+
+    if (cctx != NULL && cctx->cipher->settable_ctx_params != NULL) {
+        alg = ossl_provider_ctx(EVP_CIPHER_provider(cctx->cipher));
+        return cctx->cipher->settable_ctx_params(cctx->provctx, alg);
+    }
+    return NULL;
+}
+
+const OSSL_PARAM *EVP_CIPHER_CTX_gettable_params(EVP_CIPHER_CTX *cctx)
+{
+    void *alg;
+
+    if (cctx != NULL && cctx->cipher->gettable_ctx_params != NULL) {
+        alg = ossl_provider_ctx(EVP_CIPHER_provider(cctx->cipher));
+        return cctx->cipher->gettable_ctx_params(cctx->provctx, alg);
+    }
     return NULL;
 }
 

--- a/crypto/evp/evp_rand.c
+++ b/crypto/evp/evp_rand.c
@@ -428,18 +428,42 @@ const OSSL_PARAM *EVP_RAND_gettable_params(const EVP_RAND *rand)
 
 const OSSL_PARAM *EVP_RAND_gettable_ctx_params(const EVP_RAND *rand)
 {
+    void *provctx;
+
     if (rand->gettable_ctx_params == NULL)
         return NULL;
-    return rand->gettable_ctx_params(
-               ossl_provider_ctx(EVP_RAND_provider(rand)));
+    provctx = ossl_provider_ctx(EVP_RAND_provider(rand));
+    return rand->gettable_ctx_params(NULL, provctx);
 }
 
 const OSSL_PARAM *EVP_RAND_settable_ctx_params(const EVP_RAND *rand)
 {
+    void *provctx;
+
     if (rand->settable_ctx_params == NULL)
         return NULL;
-    return rand->settable_ctx_params(
-               ossl_provider_ctx(EVP_RAND_provider(rand)));
+    provctx = ossl_provider_ctx(EVP_RAND_provider(rand));
+    return rand->settable_ctx_params(NULL, provctx);
+}
+
+const OSSL_PARAM *EVP_RAND_CTX_gettable_params(EVP_RAND_CTX *ctx)
+{
+    void *provctx;
+
+    if (ctx->meth->gettable_ctx_params == NULL)
+        return NULL;
+    provctx = ossl_provider_ctx(EVP_RAND_provider(ctx->meth));
+    return ctx->meth->gettable_ctx_params(ctx->data, provctx);
+}
+
+const OSSL_PARAM *EVP_RAND_CTX_settable_params(EVP_RAND_CTX *ctx)
+{
+    void *provctx;
+
+    if (ctx->meth->settable_ctx_params == NULL)
+        return NULL;
+    provctx = ossl_provider_ctx(EVP_RAND_provider(ctx->meth));
+    return ctx->meth->settable_ctx_params(ctx->data, provctx);
 }
 
 void EVP_RAND_do_all_provided(OSSL_LIB_CTX *libctx,

--- a/crypto/evp/kdf_meth.c
+++ b/crypto/evp/kdf_meth.c
@@ -174,16 +174,42 @@ const OSSL_PARAM *EVP_KDF_gettable_params(const EVP_KDF *kdf)
 
 const OSSL_PARAM *EVP_KDF_gettable_ctx_params(const EVP_KDF *kdf)
 {
+    void *alg;
+
     if (kdf->gettable_ctx_params == NULL)
         return NULL;
-    return kdf->gettable_ctx_params(ossl_provider_ctx(EVP_KDF_provider(kdf)));
+    alg = ossl_provider_ctx(EVP_KDF_provider(kdf));
+    return kdf->gettable_ctx_params(NULL, alg);
 }
 
 const OSSL_PARAM *EVP_KDF_settable_ctx_params(const EVP_KDF *kdf)
 {
+    void *alg;
+
     if (kdf->settable_ctx_params == NULL)
         return NULL;
-    return kdf->settable_ctx_params(ossl_provider_ctx(EVP_KDF_provider(kdf)));
+    alg = ossl_provider_ctx(EVP_KDF_provider(kdf));
+    return kdf->settable_ctx_params(NULL, alg);
+}
+
+const OSSL_PARAM *EVP_KDF_CTX_gettable_params(EVP_KDF_CTX *ctx)
+{
+    void *alg;
+
+    if (ctx->meth->gettable_ctx_params == NULL)
+        return NULL;
+    alg = ossl_provider_ctx(EVP_KDF_provider(ctx->meth));
+    return ctx->meth->gettable_ctx_params(ctx->data, alg);
+}
+
+const OSSL_PARAM *EVP_KDF_CTX_settable_params(EVP_KDF_CTX *ctx)
+{
+    void *alg;
+
+    if (ctx->meth->settable_ctx_params == NULL)
+        return NULL;
+    alg = ossl_provider_ctx(EVP_KDF_provider(ctx->meth));
+    return ctx->meth->settable_ctx_params(ctx->data, alg);
 }
 
 void EVP_KDF_do_all_provided(OSSL_LIB_CTX *libctx,

--- a/crypto/evp/mac_meth.c
+++ b/crypto/evp/mac_meth.c
@@ -181,16 +181,42 @@ const OSSL_PARAM *EVP_MAC_gettable_params(const EVP_MAC *mac)
 
 const OSSL_PARAM *EVP_MAC_gettable_ctx_params(const EVP_MAC *mac)
 {
+    void *alg;
+
     if (mac->gettable_ctx_params == NULL)
         return NULL;
-    return mac->gettable_ctx_params(ossl_provider_ctx(EVP_MAC_provider(mac)));
+    alg = ossl_provider_ctx(EVP_MAC_provider(mac));
+    return mac->gettable_ctx_params(NULL, alg);
 }
 
 const OSSL_PARAM *EVP_MAC_settable_ctx_params(const EVP_MAC *mac)
 {
+    void *alg;
+
     if (mac->settable_ctx_params == NULL)
         return NULL;
-    return mac->settable_ctx_params(ossl_provider_ctx(EVP_MAC_provider(mac)));
+    alg = ossl_provider_ctx(EVP_MAC_provider(mac));
+    return mac->settable_ctx_params(NULL, alg);
+}
+
+const OSSL_PARAM *EVP_MAC_CTX_gettable_params(EVP_MAC_CTX *ctx)
+{
+    void *alg;
+
+    if (ctx->meth->gettable_ctx_params == NULL)
+        return NULL;
+    alg = ossl_provider_ctx(EVP_MAC_provider(ctx->meth));
+    return ctx->meth->gettable_ctx_params(ctx->data, alg);
+}
+
+const OSSL_PARAM *EVP_MAC_CTX_settable_params(EVP_MAC_CTX *ctx)
+{
+    void *alg;
+
+    if (ctx->meth->settable_ctx_params == NULL)
+        return NULL;
+    alg = ossl_provider_ctx(EVP_MAC_provider(ctx->meth));
+    return ctx->meth->settable_ctx_params(ctx->data, alg);
 }
 
 void EVP_MAC_do_all_provided(OSSL_LIB_CTX *libctx,

--- a/doc/man3/EVP_DigestInit.pod
+++ b/doc/man3/EVP_DigestInit.pod
@@ -180,18 +180,29 @@ See L</PARAMETERS> below for more information.
 Sets the list of I<params> into a MD context I<ctx>.
 See L</PARAMETERS> below for more information.
 
-=item EVP_MD_gettable_params(), EVP_MD_gettable_ctx_params(),
-EVP_MD_settable_ctx_params(), EVP_MD_CTX_gettable_params(),
-EVP_MD_CTX_settable_params()
+=item EVP_MD_gettable_params()
 
-Get a B<OSSL_PARAM> array that describes the retrievable and settable
-parameters. EVP_MD_gettable_params() returns parameters that can be used with
-EVP_MD_get_params(). EVP_MD_gettable_ctx_params() and
-EVP_MD_CTX_gettable_params() return parameters that can be used with
-EVP_MD_CTX_get_params(). EVP_MD_settable_ctx_params() and
-EVP_MD_CTX_settable_params() return parameters that can be used with
-EVP_MD_CTX_set_params().
-See L<OSSL_PARAM(3)> for the use of B<OSSL_PARAM> as parameter descriptor.
+Get a constant B<OSSL_PARAM> array that describes the retrievable parameters
+that can be used with EVP_MD_get_params().  See L<OSSL_PARAM(3)> for the
+use of B<OSSL_PARAM> as a parameter descriptor.
+
+=item EVP_MD_gettable_ctx_params(), EVP_MD_CTX_gettable_params()
+
+Get a constant B<OSSL_PARAM> array that describes the retrievable parameters
+that can be used with EVP_MD_CTX_get_params().  EVP_MD_gettable_ctx_params()
+returns the parameters that can be retrieved from the algorithm, whereas
+EVP_MD_CTX_gettable_params() returns the parameters that can be retrieved
+in the context's current state.  See L<OSSL_PARAM(3)> for the use of
+B<OSSL_PARAM> as a parameter descriptor.
+
+=item EVP_MD_settable_ctx_params(), EVP_MD_CTX_settable_params()
+
+Get a constant B<OSSL_PARAM> array that describes the settable parameters
+that can be used with EVP_MD_CTX_set_params().  EVP_MD_settable_ctx_params()
+returns the parameters that can be set from the algorithm, whereas
+EVP_MD_CTX_settable_params() returns the parameters that can be set in the
+context's current state.  See L<OSSL_PARAM(3)> for the use of B<OSSL_PARAM>
+as a parameter descriptor.
 
 =item EVP_MD_CTX_set_flags(), EVP_MD_CTX_clear_flags(), EVP_MD_CTX_test_flags()
 
@@ -658,8 +669,12 @@ The EVP_dss1() function was removed in OpenSSL 1.1.0.
 
 The EVP_MD_CTX_set_pkey_ctx() function was added in OpenSSL 1.1.1.
 
-The EVP_MD_fetch(), EVP_MD_free(), EVP_MD_up_ref(), EVP_MD_CTX_set_params()
-and EVP_MD_CTX_get_params() functions were added in OpenSSL 3.0.
+The EVP_MD_fetch(), EVP_MD_free(), EVP_MD_up_ref(),
+EVP_MD_get_params(), EVP_MD_CTX_set_params(), EVP_MD_CTX_get_params(),
+EVP_MD_gettable_params(), EVP_MD_gettable_ctx_params(),
+EVP_MD_settable_ctx_params(), EVP_MD_CTX_settable_params() and
+EVP_MD_CTX_gettable_params() functions were added in OpenSSL 3.0.
+
 The EVP_MD_CTX_update_fn() and EVP_MD_CTX_set_update_fn() were deprecated
 in OpenSSL 3.0.
 

--- a/doc/man3/EVP_EncryptInit.pod
+++ b/doc/man3/EVP_EncryptInit.pod
@@ -48,8 +48,10 @@ EVP_CIPHER_CTX_name,
 EVP_CIPHER_CTX_nid,
 EVP_CIPHER_CTX_get_params,
 EVP_CIPHER_gettable_ctx_params,
+EVP_CIPHER_CTX_gettable_params,
 EVP_CIPHER_CTX_set_params,
 EVP_CIPHER_settable_ctx_params,
+EVP_CIPHER_CTX_settable_params,
 EVP_CIPHER_CTX_block_size,
 EVP_CIPHER_CTX_key_length,
 EVP_CIPHER_CTX_iv_length,
@@ -147,6 +149,8 @@ EVP_CIPHER_do_all_provided
  const OSSL_PARAM *EVP_CIPHER_gettable_params(const EVP_CIPHER *cipher);
  const OSSL_PARAM *EVP_CIPHER_settable_ctx_params(const EVP_CIPHER *cipher);
  const OSSL_PARAM *EVP_CIPHER_gettable_ctx_params(const EVP_CIPHER *cipher);
+ const OSSL_PARAM *EVP_CIPHER_CTX_settable_params(EVP_CIPHER_CTX *ctx);
+ const OSSL_PARAM *EVP_CIPHER_CTX_gettable_params(EVP_CIPHER_CTX *ctx);
  int EVP_CIPHER_CTX_block_size(const EVP_CIPHER_CTX *ctx);
  int EVP_CIPHER_CTX_key_length(const EVP_CIPHER_CTX *ctx);
  int EVP_CIPHER_CTX_iv_length(const EVP_CIPHER_CTX *ctx);
@@ -302,12 +306,28 @@ context B<ctx>.
 EVP_CIPHER_CTX_get_params() retrieves the requested list of operation
 B<params> from CIPHER context B<ctx>.
 
-EVP_CIPHER_gettable_params(), EVP_CIPHER_gettable_ctx_params(), and
-EVP_CIPHER_settable_ctx_params() get a constant B<OSSL_PARAM> array
-that describes the retrievable and settable parameters, i.e. parameters
-that can be used with EVP_CIPHER_get_params(), EVP_CIPHER_CTX_get_params()
-and EVP_CIPHER_CTX_set_params(), respectively.
-See L<OSSL_PARAM(3)> for the use of B<OSSL_PARAM> as parameter descriptor.
+EVP_CIPHER_gettable_params() returns an B<OSSL_PARAM> array that describes
+the retrievable and settable parameters.  EVP_CIPHER_gettable_params()
+returns parameters that can be used with EVP_CIPHER_get_params().  See
+L<OSSL_PARAM(3)> for the use of B<OSSL_PARAM> as a parameter descriptor.
+
+EVP_CIPHER_gettable_ctx_params() and EVP_CIPHER_CTX_gettable_params()
+return constant B<OSSL_PARAM> arrays that describe the retrievable
+parameters that can be used with EVP_CIPHER_CTX_get_params().
+EVP_CIPHER_gettable_ctx_params() returns the parameters that can be
+retrieved from the algorithm, whereas EVP_CIPHER_CTX_gettable_params()
+returns the parameters that can be retrieved in the context's current
+state.  See L<OSSL_PARAM(3)> for the use of B<OSSL_PARAM> as a parameter
+descriptor.
+
+EVP_CIPHER_settable_ctx_params() and EVP_CIPHER_CTX_settable_params()
+return constant B<OSSL_PARAM> arrays that describe the settable
+parameters that can be used with EVP_CIPHER_CTX_set_params().
+EVP_CIPHER_settable_ctx_params() returns the parameters that can be
+retrieved from the algorithm, whereas EVP_CIPHER_CTX_settable_params()
+returns the parameters that can be retrieved in the context's current
+state.  See L<OSSL_PARAM(3)> for the use of B<OSSL_PARAM> as a parameter
+descriptor.
 
 EVP_CIPHER_key_length() and EVP_CIPHER_CTX_key_length() return the key
 length of a cipher when passed an B<EVP_CIPHER> or B<EVP_CIPHER_CTX>
@@ -884,8 +904,11 @@ disappeared.  EVP_CIPHER_CTX_init() remains as an alias for
 EVP_CIPHER_CTX_reset().
 
 The EVP_CIPHER_fetch(), EVP_CIPHER_free(), EVP_CIPHER_up_ref(),
-EVP_CIPHER_CTX_set_params() and EVP_CIPHER_CTX_get_params() functions
-were added in 3.0.
+EVP_CIPHER_get_params(), EVP_CIPHER_CTX_set_params(),
+EVP_CIPHER_CTX_get_params(), EVP_CIPHER_gettable_params(),
+EVP_CIPHER_settable_ctx_params(), EVP_CIPHER_gettable_ctx_params(),
+EVP_CIPHER_CTX_settable_params() and EVP_CIPHER_CTX_gettable_params()
+functions were added in 3.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/EVP_KDF.pod
+++ b/doc/man3/EVP_KDF.pod
@@ -8,8 +8,9 @@ EVP_KDF_CTX_reset, EVP_KDF_derive,
 EVP_KDF_CTX_get_kdf_size, EVP_KDF_provider, EVP_KDF_CTX_kdf, EVP_KDF_is_a,
 EVP_KDF_number, EVP_KDF_name, EVP_KDF_names_do_all,
 EVP_KDF_CTX_get_params, EVP_KDF_CTX_set_params, EVP_KDF_do_all_provided,
-EVP_KDF_get_params, EVP_KDF_gettable_ctx_params, EVP_KDF_settable_ctx_params,
-EVP_KDF_gettable_params - EVP KDF routines
+EVP_KDF_get_params, EVP_KDF_gettable_params,
+EVP_KDF_gettable_ctx_params, EVP_KDF_settable_ctx_params,
+EVP_KDF_CTX_gettable_params, EVP_KDF_CTX_settable_params - EVP KDF routines
 
 =head1 SYNOPSIS
 
@@ -45,6 +46,8 @@ EVP_KDF_gettable_params - EVP KDF routines
  const OSSL_PARAM *EVP_KDF_gettable_params(const EVP_KDF *kdf);
  const OSSL_PARAM *EVP_KDF_gettable_ctx_params(const EVP_KDF *kdf);
  const OSSL_PARAM *EVP_KDF_settable_ctx_params(const EVP_KDF *kdf);
+ const OSSL_PARAM *EVP_KDF_CTX_gettable_params(const EVP_KDF *kdf);
+ const OSSL_PARAM *EVP_KDF_CTX_settable_params(const EVP_KDF *kdf);
  const OSSL_PROVIDER *EVP_KDF_provider(const EVP_KDF *kdf);
 
 =head1 DESCRIPTION
@@ -124,12 +127,26 @@ simply ignored.
 Also, what happens when a needed parameter isn't passed down is
 defined by the implementation.
 
-EVP_KDF_gettable_params(), EVP_KDF_gettable_ctx_params() and
-EVP_KDF_settable_ctx_params() get a constant B<OSSL_PARAM> array that
-describes the retrievable and settable parameters, i.e. parameters that
-can be used with EVP_KDF_get_params(), EVP_KDF_CTX_get_params()
-and EVP_KDF_CTX_set_params(), respectively.
-See L<OSSL_PARAM(3)> for the use of B<OSSL_PARAM> as parameter descriptor.
+EVP_KDF_gettable_params() returns an B<OSSL_PARAM> array that describes
+the retrievable and settable parameters.  EVP_KDF_gettable_params()
+returns parameters that can be used with EVP_KDF_get_params().
+See L<OSSL_PARAM(3)> for the use of B<OSSL_PARAM> as a parameter descriptor.
+
+EVP_KDF_gettable_ctx_params() and EVP_KDF_CTX_gettable_params()
+return constant B<OSSL_PARAM> arrays that describe the retrievable
+parameters that can be used with EVP_KDF_CTX_get_params().
+EVP_KDF_gettable_ctx_params() returns the parameters that can be retrieved
+from the algorithm, whereas EVP_KDF_CTX_gettable_params() returns
+the parameters that can be retrieved in the context's current state.
+See L<OSSL_PARAM(3)> for the use of B<OSSL_PARAM> as a parameter descriptor.
+
+EVP_KDF_settable_ctx_params() and EVP_KDF_CTX_settable_params() return
+constant B<OSSL_PARAM> arrays that describe the settable parameters that
+can be used with EVP_KDF_CTX_set_params().  EVP_KDF_settable_ctx_params()
+returns the parameters that can be retrieved from the algorithm,
+whereas EVP_KDF_CTX_settable_params() returns the parameters that can
+be retrieved in the context's current state.  See L<OSSL_PARAM(3)>
+for the use of B<OSSL_PARAM> as a parameter descriptor.
 
 =head2 Information functions
 

--- a/doc/man3/EVP_MAC.pod
+++ b/doc/man3/EVP_MAC.pod
@@ -9,6 +9,7 @@ EVP_MAC_CTX, EVP_MAC_CTX_new, EVP_MAC_CTX_free, EVP_MAC_CTX_dup,
 EVP_MAC_CTX_mac, EVP_MAC_CTX_get_params, EVP_MAC_CTX_set_params,
 EVP_MAC_CTX_get_mac_size, EVP_MAC_init, EVP_MAC_update, EVP_MAC_final,
 EVP_MAC_gettable_ctx_params, EVP_MAC_settable_ctx_params,
+EVP_MAC_CTX_gettable_params, EVP_MAC_CTX_settable_params,
 EVP_MAC_do_all_provided - EVP MAC routines
 
 =head1 SYNOPSIS
@@ -47,6 +48,8 @@ EVP_MAC_do_all_provided - EVP MAC routines
  const OSSL_PARAM *EVP_MAC_gettable_params(const EVP_MAC *mac);
  const OSSL_PARAM *EVP_MAC_gettable_ctx_params(const EVP_MAC *mac);
  const OSSL_PARAM *EVP_MAC_settable_ctx_params(const EVP_MAC *mac);
+ const OSSL_PARAM *EVP_MAC_CTX_gettable_params(EVP_MAC_CTX *ctx);
+ const OSSL_PARAM *EVP_MAC_CTX_settable_params(EVP_MAC_CTX *ctx);
 
  void EVP_MAC_do_all_provided(OSSL_LIB_CTX *libctx,
                               void (*fn)(EVP_MAC *mac, void *arg),
@@ -153,12 +156,26 @@ simply ignored.
 Also, what happens when a needed parameter isn't passed down is
 defined by the implementation.
 
-EVP_MAC_gettable_params(), EVP_MAC_gettable_ctx_params() and
-EVP_MAC_settable_ctx_params() get a constant B<OSSL_PARAM> array that
-describes the retrievable and settable parameters, i.e. parameters that
-can be used with EVP_MAC_get_params(), EVP_MAC_CTX_get_params()
-and EVP_MAC_CTX_set_params(), respectively.
-See L<OSSL_PARAM(3)> for the use of B<OSSL_PARAM> as parameter descriptor.
+EVP_MAC_gettable_params() returns an B<OSSL_PARAM> array that describes
+the retrievable and settable parameters.  EVP_MAC_gettable_params()
+returns parameters that can be used with EVP_MAC_get_params().
+See L<OSSL_PARAM(3)> for the use of B<OSSL_PARAM> as a parameter descriptor.
+
+EVP_MAC_gettable_ctx_params() and EVP_MAC_CTX_gettable_params()
+return constant B<OSSL_PARAM> arrays that describe the retrievable
+parameters that can be used with EVP_MAC_CTX_get_params().
+EVP_MAC_gettable_ctx_params() returns the parameters that can be retrieved
+from the algorithm, whereas EVP_MAC_CTX_gettable_params() returns
+the parameters that can be retrieved in the context's current state.
+See L<OSSL_PARAM(3)> for the use of B<OSSL_PARAM> as a parameter descriptor.
+
+EVP_MAC_settable_ctx_params() and EVP_MAC_CTX_settable_params() return
+constant B<OSSL_PARAM> arrays that describe the settable parameters that
+can be used with EVP_MAC_CTX_set_params().  EVP_MAC_settable_ctx_params()
+returns the parameters that can be retrieved from the algorithm,
+whereas EVP_MAC_CTX_settable_params() returns the parameters that can
+be retrieved in the context's current state.  See L<OSSL_PARAM(3)>
+for the use of B<OSSL_PARAM> as a parameter descriptor.
 
 =head2 Information functions
 

--- a/doc/man3/EVP_RAND.pod
+++ b/doc/man3/EVP_RAND.pod
@@ -11,6 +11,7 @@ EVP_RAND_provider, EVP_RAND_CTX_rand, EVP_RAND_is_a, EVP_RAND_number,
 EVP_RAND_name, EVP_RAND_names_do_all, EVP_RAND_get_ctx_params,
 EVP_RAND_set_ctx_params, EVP_RAND_do_all_provided, EVP_RAND_get_params,
 EVP_RAND_gettable_ctx_params, EVP_RAND_settable_ctx_params,
+EVP_RAND_CTX_gettable_params, EVP_RAND_CTX_settable_params,
 EVP_RAND_gettable_params, EVP_RAND_STATE_UNINITIALISED, EVP_RAND_STATE_READY,
 EVP_RAND_STATE_ERROR - EVP RAND routines
 
@@ -34,6 +35,8 @@ EVP_RAND_STATE_ERROR - EVP RAND routines
  const OSSL_PARAM *EVP_RAND_gettable_params(const EVP_RAND *rand);
  const OSSL_PARAM *EVP_RAND_gettable_ctx_params(const EVP_RAND *rand);
  const OSSL_PARAM *EVP_RAND_settable_ctx_params(const EVP_RAND *rand);
+ const OSSL_PARAM *EVP_RAND_CTX_gettable_params(EVP_RAND_CTX *ctx);
+ const OSSL_PARAM *EVP_RAND_CTX_settable_params(EVP_RAND_CTX *ctx);
  int EVP_RAND_number(const EVP_RAND *rand);
  const char *EVP_RAND_name(const EVP_RAND *rand);
  int EVP_RAND_is_a(const EVP_RAND *rand, const char *name);
@@ -179,12 +182,26 @@ simply ignored.
 Also, what happens when a needed parameter isn't passed down is
 defined by the implementation.
 
-EVP_RAND_gettable_params(), EVP_RAND_gettable_ctx_params() and
-EVP_RAND_settable_ctx_params() get a constant B<OSSL_PARAM> array that
-describes the retrievable and settable parameters, i.e. parameters that
-can be used with EVP_RAND_get_params(), EVP_RAND_get_ctx_params()
-and EVP_RAND_set_ctx_params(), respectively.
-See L<OSSL_PARAM(3)> for the use of B<OSSL_PARAM> as parameter descriptor.
+EVP_RAND_gettable_params() returns an B<OSSL_PARAM> array that describes
+the retrievable and settable parameters.  EVP_RAND_gettable_params() returns
+parameters that can be used with EVP_RAND_get_params().  See L<OSSL_PARAM(3)>
+for the use of B<OSSL_PARAM> as a parameter descriptor.
+
+EVP_RAND_gettable_ctx_params() and EVP_RAND_CTX_gettable_params() return
+constant B<OSSL_PARAM> arrays that describe the retrievable parameters that
+can be used with EVP_RAND_CTX_get_params().  EVP_RAND_gettable_ctx_params()
+returns the parameters that can be retrieved from the algorithm, whereas
+EVP_RAND_CTX_gettable_params() returns the parameters that can be retrieved
+in the context's current state.  See L<OSSL_PARAM(3)> for the use of
+B<OSSL_PARAM> as a parameter descriptor.
+
+EVP_RAND_settable_ctx_params() and EVP_RAND_CTX_settable_params() return
+constant B<OSSL_PARAM> arrays that describe the settable parameters that
+can be used with EVP_RAND_CTX_set_params().  EVP_RAND_settable_ctx_params()
+returns the parameters that can be retrieved from the algorithm, whereas
+EVP_RAND_CTX_settable_params() returns the parameters that can be retrieved
+in the context's current state.  See L<OSSL_PARAM(3)> for the use of
+B<OSSL_PARAM> as a parameter descriptor.
 
 =head2 Information functions
 

--- a/doc/man7/provider-cipher.pod
+++ b/doc/man7/provider-cipher.pod
@@ -40,8 +40,10 @@ provider-cipher - The cipher library E<lt>-E<gt> provider functions
  const OSSL_PARAM *OSSL_FUNC_cipher_gettable_params(void *provctx);
 
  /* Cipher operation parameter descriptors */
- const OSSL_PARAM *OSSL_FUNC_cipher_gettable_ctx_params(void *provctx);
- const OSSL_PARAM *OSSL_FUNC_cipher_settable_ctx_params(void *provctx);
+ const OSSL_PARAM *OSSL_FUNC_cipher_gettable_ctx_params(void *cctx,
+                                                        void *provctx);
+ const OSSL_PARAM *OSSL_FUNC_cipher_settable_ctx_params(void *cctx,
+                                                        void *provctx);
 
  /* Cipher parameters */
  int OSSL_FUNC_cipher_get_params(OSSL_PARAM params[]);
@@ -186,11 +188,15 @@ Any parameter settings are additional to any that were previously set.
 OSSL_FUNC_cipher_get_ctx_params() gets cipher operation details details from
 the given provider side cipher context I<cctx> and stores them in I<params>.
 
-OSSL_FUNC_cipher_gettable_params(), OSSL_FUNC_cipher_gettable_ctx_params(), and
-OSSL_FUNC_cipher_settable_ctx_params() all return constant B<OSSL_PARAM> arrays
-as descriptors of the parameters that OSSL_FUNC_cipher_get_params(),
-OSSL_FUNC_cipher_get_ctx_params(), and OSSL_FUNC_cipher_set_ctx_params() can handle,
-respectively.
+OSSL_FUNC_cipher_gettable_params(), OSSL_FUNC_cipher_gettable_ctx_params(),
+and OSSL_FUNC_cipher_settable_ctx_params() all return constant B<OSSL_PARAM>
+arrays as descriptors of the parameters that OSSL_FUNC_cipher_get_params(),
+OSSL_FUNC_cipher_get_ctx_params(), and OSSL_FUNC_cipher_set_ctx_params()
+can handle, respectively.  OSSL_FUNC_cipher_gettable_ctx_params() and
+OSSL_FUNC_cipher_settable_ctx_params() will return the parameters associated
+with the provider side context I<cctx> in its current state if it is
+not NULL.  Otherwise, they return the parameters associated with the
+provider side algorithm I<provctx>.
 
 Parameters currently recognised by built-in ciphers are as follows. Not all
 parameters are relevant to, or are understood by all ciphers:

--- a/doc/man7/provider-digest.pod
+++ b/doc/man7/provider-digest.pod
@@ -33,8 +33,10 @@ provider-digest - The digest library E<lt>-E<gt> provider functions
  const OSSL_PARAM *OSSL_FUNC_digest_gettable_params(void *provctx);
 
  /* Digest operation parameter descriptors */
- const OSSL_PARAM *OSSL_FUNC_digest_gettable_ctx_params(void *provctx);
- const OSSL_PARAM *OSSL_FUNC_digest_settable_ctx_params(void *provctx);
+ const OSSL_PARAM *OSSL_FUNC_digest_gettable_ctx_params(void *dctx,
+                                                        void *provctx);
+ const OSSL_PARAM *OSSL_FUNC_digest_settable_ctx_params(void *dctx,
+                                                        void *provctx);
 
  /* Digest parameters */
  int OSSL_FUNC_digest_get_params(OSSL_PARAM params[]);
@@ -152,11 +154,17 @@ Any parameter settings are additional to any that were previously set.
 OSSL_FUNC_digest_get_ctx_params() gets digest operation details details from
 the given provider side digest context I<dctx> and stores them in I<params>.
 
-OSSL_FUNC_digest_gettable_params(), OSSL_FUNC_digest_gettable_ctx_params(), and
-OSSL_FUNC_digest_settable_ctx_params() all return constant B<OSSL_PARAM> arrays
-as descriptors of the parameters that OSSL_FUNC_digest_get_params(),
-OSSL_FUNC_digest_get_ctx_params(), and OSSL_FUNC_digest_set_ctx_params() can handle,
-respectively.
+OSSL_FUNC_digest_gettable_params() returns a constant B<OSSL_PARAM> array
+containing descriptors of the parameters that OSSL_FUNC_digest_get_params()
+can handle.
+
+OSSL_FUNC_digest_gettable_ctx_params() and
+OSSL_FUNC_digest_settable_ctx_params() both return constant
+B<OSSL_PARAM> arrays as descriptors of the parameters that
+OSSL_FUNC_digest_get_ctx_params() and OSSL_FUNC_digest_set_ctx_params()
+can handle, respectively.  The array is based on the current state of
+the provider side context if I<dctx> is not NULL and on the provider
+side algorithm I<provctx> otherwise.
 
 Parameters currently recognised by built-in digests with this function
 are as follows. Not all parameters are relevant to, or are understood

--- a/doc/man7/provider-kdf.pod
+++ b/doc/man7/provider-kdf.pod
@@ -28,8 +28,8 @@ provider-kdf - The KDF library E<lt>-E<gt> provider functions
 
  /* KDF parameter descriptors */
  const OSSL_PARAM *OSSL_FUNC_kdf_gettable_params(void *provctx);
- const OSSL_PARAM *OSSL_FUNC_kdf_gettable_ctx_params(void *provctx);
- const OSSL_PARAM *OSSL_FUNC_kdf_settable_ctx_params(void *provctx);
+ const OSSL_PARAM *OSSL_FUNC_kdf_gettable_ctx_params(void *kcxt, void *provctx);
+ const OSSL_PARAM *OSSL_FUNC_kdf_settable_ctx_params(void *kcxt, void *provctx);
 
  /* KDF parameters */
  int OSSL_FUNC_kdf_get_params(OSSL_PARAM params[]);
@@ -129,11 +129,16 @@ Any parameter settings are additional to any that were previously set.
 OSSL_FUNC_kdf_get_ctx_params() retrieves gettable parameter values associated
 with the given provider side KDF context I<kctx> and stores them in I<params>.
 
-OSSL_FUNC_kdf_gettable_params(), OSSL_FUNC_kdf_gettable_ctx_params(), and
-OSSL_FUNC_kdf_settable_ctx_params() all return constant B<OSSL_PARAM> arrays
-as descriptors of the parameters that OSSL_FUNC_kdf_get_params(),
-OSSL_FUNC_kdf_get_ctx_params(), and OSSL_FUNC_kdf_set_ctx_params() can handle,
-respectively.
+OSSL_FUNC_kdf_gettable_params(), OSSL_FUNC_kdf_gettable_ctx_params(),
+and OSSL_FUNC_kdf_settable_ctx_params() all return constant B<OSSL_PARAM>
+arrays as descriptors of the parameters that OSSL_FUNC_kdf_get_params(),
+OSSL_FUNC_kdf_get_ctx_params(), and OSSL_FUNC_kdf_set_ctx_params()
+can handle, respectively.  OSSL_FUNC_kdf_gettable_ctx_params() and
+OSSL_FUNC_kdf_settable_ctx_params() will return the parameters associated
+with the provider side context I<kctx> in its current state if it is
+not NULL.  Otherwise, they return the parameters associated with the
+provider side algorithm I<provctx>.
+
 
 Parameters currently recognised by built-in KDFs are as follows. Not all
 parameters are relevant to, or are understood by all KDFs:

--- a/doc/man7/provider-mac.pod
+++ b/doc/man7/provider-mac.pod
@@ -28,9 +28,9 @@ provider-mac - The mac library E<lt>-E<gt> provider functions
  int OSSL_FUNC_mac_final(void *mctx, unsigned char *out, size_t *outl, size_t outsize);
 
  /* MAC parameter descriptors */
- const OSSL_PARAM *OSSL_FUNC_mac_get_params(void *provctx);
- const OSSL_PARAM *OSSL_FUNC_mac_get_ctx_params(void *provctx);
- const OSSL_PARAM *OSSL_FUNC_mac_set_ctx_params(void *provctx);
+ const OSSL_PARAM *OSSL_FUNC_mac_gettable_params(void *provctx);
+ const OSSL_PARAM *OSSL_FUNC_mac_gettable_ctx_params(void *mctx, void *provctx);
+ const OSSL_PARAM *OSSL_FUNC_mac_settable_ctx_params(void *mctx, void *provctx);
 
  /* MAC parameters */
  int OSSL_FUNC_mac_get_params(OSSL_PARAM params[]);
@@ -140,11 +140,16 @@ OSSL_FUNC_mac_get_ctx_params() gets details of currently set parameter values
 associated with the given provider side mac context I<mctx> and stores them
 in I<params>.
 
-OSSL_FUNC_mac_gettable_params(), OSSL_FUNC_mac_gettable_ctx_params(), and
-OSSL_FUNC_mac_settable_ctx_params() all return constant B<OSSL_PARAM> arrays
-as descriptors of the parameters that OSSL_FUNC_mac_get_params(),
-OSSL_FUNC_mac_get_ctx_params(), and OSSL_FUNC_mac_set_ctx_params() can handle,
-respectively.
+OSSL_FUNC_mac_gettable_params(), OSSL_FUNC_mac_gettable_ctx_params(),
+and OSSL_FUNC_mac_settable_ctx_params() all return constant B<OSSL_PARAM>
+arrays as descriptors of the parameters that OSSL_FUNC_mac_get_params(),
+OSSL_FUNC_mac_get_ctx_params(), and OSSL_FUNC_mac_set_ctx_params()
+can handle, respectively.  OSSL_FUNC_mac_gettable_ctx_params() and
+OSSL_FUNC_mac_settable_ctx_params() will return the parameters associated
+with the provider side context I<mctx> in its current state if it is
+not NULL.  Otherwise, they return the parameters associated with the
+provider side algorithm I<provctx>.
+
 
 Parameters currently recognised by built-in macs are as follows. Not all
 parameters are relevant to, or are understood by all macs:

--- a/doc/man7/provider-rand.pod
+++ b/doc/man7/provider-rand.pod
@@ -53,8 +53,8 @@ functions
 
  /* RAND parameter descriptors */
  const OSSL_PARAM *OSSL_FUNC_rand_gettable_params(void *provctx);
- const OSSL_PARAM *OSSL_FUNC_rand_gettable_ctx_params(void *provctx);
- const OSSL_PARAM *OSSL_FUNC_rand_settable_ctx_params(void *provctx);
+ const OSSL_PARAM *OSSL_FUNC_rand_gettable_ctx_params(void *ctx, void *provctx);
+ const OSSL_PARAM *OSSL_FUNC_rand_settable_ctx_params(void *ctx, void *provctx);
 
  /* RAND parameters */
  int OSSL_FUNC_rand_get_params(OSSL_PARAM params[]);
@@ -163,11 +163,16 @@ OSSL_FUNC_rand_get_ctx_params() gets details of currently set parameter values
 associated with the given provider side rand context I<ctx> and stores them
 in I<params>.
 
-OSSL_FUNC_rand_gettable_params(), OSSL_FUNC_rand_gettable_ctx_params(), and
-OSSL_FUNC_rand_settable_ctx_params() all return constant B<OSSL_PARAM> arrays
-as descriptors of the parameters that OSSL_FUNC_rand_get_params(),
-OSSL_FUNC_rand_get_ctx_params(), and OSSL_FUNC_rand_set_ctx_params() can handle,
-respectively.
+OSSL_FUNC_rand_gettable_params(), OSSL_FUNC_rand_gettable_ctx_params(),
+and OSSL_FUNC_rand_settable_ctx_params() all return constant B<OSSL_PARAM>
+arrays as descriptors of the parameters that OSSL_FUNC_rand_get_params(),
+OSSL_FUNC_rand_get_ctx_params(), and OSSL_FUNC_rand_set_ctx_params()
+can handle, respectively.  OSSL_FUNC_rand_gettable_ctx_params()
+and OSSL_FUNC_rand_settable_ctx_params() will return the parameters
+associated with the provider side context I<ctx> in its current state
+if it is not NULL.  Otherwise, they return the parameters associated
+with the provider side algorithm I<provctx>.
+
 
 Parameters currently recognised by built-in rands are as follows. Not all
 parameters are relevant to, or are understood by all rands:

--- a/fuzz/fuzz_rand.c
+++ b/fuzz/fuzz_rand.c
@@ -91,7 +91,8 @@ static int fuzz_rand_get_ctx_params(void *vrng, OSSL_PARAM params[])
     return 1;
 }
 
-static const OSSL_PARAM *fuzz_rand_gettable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *fuzz_rand_gettable_ctx_params(ossl_unused void *vrng,
+                                                       ossl_unused void *provctx)
 {
     static const OSSL_PARAM known_gettable_ctx_params[] = {
         OSSL_PARAM_int(OSSL_RAND_PARAM_STATE, NULL),

--- a/include/openssl/core_dispatch.h
+++ b/include/openssl/core_dispatch.h
@@ -345,9 +345,9 @@ OSSL_CORE_MAKE_FUNC(int, mac_final,
                      unsigned char *out, size_t *outl, size_t outsize))
 OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, mac_gettable_params, (void *provctx))
 OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, mac_gettable_ctx_params,
-                    (void *provctx))
+                    (void *mctx, void *provctx))
 OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, mac_settable_ctx_params,
-                    (void *provctx))
+                    (void *mctx, void *provctx))
 OSSL_CORE_MAKE_FUNC(int, mac_get_params, (OSSL_PARAM params[]))
 OSSL_CORE_MAKE_FUNC(int, mac_get_ctx_params,
                     (void *mctx, OSSL_PARAM params[]))

--- a/include/openssl/core_dispatch.h
+++ b/include/openssl/core_dispatch.h
@@ -315,9 +315,9 @@ OSSL_CORE_MAKE_FUNC(int, cipher_set_ctx_params, (void *cctx,
 OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, cipher_gettable_params,
                     (void *provctx))
 OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, cipher_settable_ctx_params,
-                    (void *provctx))
+                    (void *cctx, void *provctx))
 OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, cipher_gettable_ctx_params,
-                    (void *provctx))
+                    (void *cctx, void *provctx))
 
 /* MACs */
 

--- a/include/openssl/core_dispatch.h
+++ b/include/openssl/core_dispatch.h
@@ -262,9 +262,9 @@ OSSL_CORE_MAKE_FUNC(int, digest_get_ctx_params,
 OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, digest_gettable_params,
                     (void *provctx))
 OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, digest_settable_ctx_params,
-                    (void *provctx))
+                    (void *dctx, void *provctx))
 OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, digest_gettable_ctx_params,
-                    (void *provctx))
+                    (void *dctx, void *provctx))
 
 /* Symmetric Ciphers */
 

--- a/include/openssl/core_dispatch.h
+++ b/include/openssl/core_dispatch.h
@@ -376,9 +376,9 @@ OSSL_CORE_MAKE_FUNC(int, kdf_derive, (void *kctx, unsigned char *key,
                                           size_t keylen))
 OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, kdf_gettable_params, (void *provctx))
 OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, kdf_gettable_ctx_params,
-                    (void *provctx))
+                    (void *kctx, void *provctx))
 OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, kdf_settable_ctx_params,
-                    (void *provctx))
+                    (void *kctx, void *provctx))
 OSSL_CORE_MAKE_FUNC(int, kdf_get_params, (OSSL_PARAM params[]))
 OSSL_CORE_MAKE_FUNC(int, kdf_get_ctx_params,
                     (void *kctx, OSSL_PARAM params[]))

--- a/include/openssl/core_dispatch.h
+++ b/include/openssl/core_dispatch.h
@@ -432,9 +432,9 @@ OSSL_CORE_MAKE_FUNC(int,rand_lock, (void *vctx))
 OSSL_CORE_MAKE_FUNC(void,rand_unlock, (void *vctx))
 OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *,rand_gettable_params, (void *provctx))
 OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *,rand_gettable_ctx_params,
-                    (void *provctx))
+                    (void *vctx, void *provctx))
 OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *,rand_settable_ctx_params,
-                    (void *provctx))
+                    (void *vctx, void *provctx))
 OSSL_CORE_MAKE_FUNC(int,rand_get_params, (OSSL_PARAM params[]))
 OSSL_CORE_MAKE_FUNC(int,rand_get_ctx_params,
                     (void *vctx, OSSL_PARAM params[]))

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -816,6 +816,8 @@ int EVP_CIPHER_CTX_get_params(EVP_CIPHER_CTX *ctx, OSSL_PARAM params[]);
 const OSSL_PARAM *EVP_CIPHER_gettable_params(const EVP_CIPHER *cipher);
 const OSSL_PARAM *EVP_CIPHER_settable_ctx_params(const EVP_CIPHER *cipher);
 const OSSL_PARAM *EVP_CIPHER_gettable_ctx_params(const EVP_CIPHER *cipher);
+const OSSL_PARAM *EVP_CIPHER_CTX_settable_params(EVP_CIPHER_CTX *ctx);
+const OSSL_PARAM *EVP_CIPHER_CTX_gettable_params(EVP_CIPHER_CTX *ctx);
 
 const BIO_METHOD *BIO_f_md(void);
 const BIO_METHOD *BIO_f_base64(void);

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -1176,6 +1176,8 @@ int EVP_RAND_set_ctx_params(EVP_RAND_CTX *ctx, const OSSL_PARAM params[]);
 const OSSL_PARAM *EVP_RAND_gettable_params(const EVP_RAND *rand);
 const OSSL_PARAM *EVP_RAND_gettable_ctx_params(const EVP_RAND *rand);
 const OSSL_PARAM *EVP_RAND_settable_ctx_params(const EVP_RAND *rand);
+const OSSL_PARAM *EVP_RAND_CTX_gettable_params(EVP_RAND_CTX *ctx);
+const OSSL_PARAM *EVP_RAND_CTX_settable_params(EVP_RAND_CTX *ctx);
 
 void EVP_RAND_do_all_provided(OSSL_LIB_CTX *libctx,
                               void (*fn)(EVP_RAND *rand, void *arg),

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -1149,6 +1149,8 @@ int EVP_MAC_final(EVP_MAC_CTX *ctx,
 const OSSL_PARAM *EVP_MAC_gettable_params(const EVP_MAC *mac);
 const OSSL_PARAM *EVP_MAC_gettable_ctx_params(const EVP_MAC *mac);
 const OSSL_PARAM *EVP_MAC_settable_ctx_params(const EVP_MAC *mac);
+const OSSL_PARAM *EVP_MAC_CTX_gettable_params(EVP_MAC_CTX *ctx);
+const OSSL_PARAM *EVP_MAC_CTX_settable_params(EVP_MAC_CTX *ctx);
 
 void EVP_MAC_do_all_provided(OSSL_LIB_CTX *libctx,
                              void (*fn)(EVP_MAC *mac, void *arg),

--- a/include/openssl/kdf.h
+++ b/include/openssl/kdf.h
@@ -48,6 +48,8 @@ int EVP_KDF_CTX_set_params(EVP_KDF_CTX *ctx, const OSSL_PARAM params[]);
 const OSSL_PARAM *EVP_KDF_gettable_params(const EVP_KDF *kdf);
 const OSSL_PARAM *EVP_KDF_gettable_ctx_params(const EVP_KDF *kdf);
 const OSSL_PARAM *EVP_KDF_settable_ctx_params(const EVP_KDF *kdf);
+const OSSL_PARAM *EVP_KDF_CTX_gettable_params(EVP_KDF_CTX *ctx);
+const OSSL_PARAM *EVP_KDF_CTX_settable_params(EVP_KDF_CTX *ctx);
 
 void EVP_KDF_do_all_provided(OSSL_LIB_CTX *libctx,
                              void (*fn)(EVP_KDF *kdf, void *arg),

--- a/providers/implementations/ciphers/cipher_aes_cbc_hmac_sha.c
+++ b/providers/implementations/ciphers/cipher_aes_cbc_hmac_sha.c
@@ -59,7 +59,8 @@ static const OSSL_PARAM cipher_aes_known_settable_ctx_params[] = {
     OSSL_PARAM_size_t(OSSL_CIPHER_PARAM_KEYLEN, NULL),
     OSSL_PARAM_END
 };
-const OSSL_PARAM *aes_settable_ctx_params(ossl_unused void *provctx)
+const OSSL_PARAM *aes_settable_ctx_params(ossl_unused void *cctx,
+                                          ossl_unused void *provctx)
 {
     return cipher_aes_known_settable_ctx_params;
 }
@@ -278,7 +279,8 @@ static const OSSL_PARAM cipher_aes_known_gettable_ctx_params[] = {
     OSSL_PARAM_octet_string(OSSL_CIPHER_PARAM_UPDATED_IV, NULL, 0),
     OSSL_PARAM_END
 };
-const OSSL_PARAM *aes_gettable_ctx_params(ossl_unused void *provctx)
+const OSSL_PARAM *aes_gettable_ctx_params(ossl_unused void *cctx,
+                                          ossl_unused void *provctx)
 {
     return cipher_aes_known_gettable_ctx_params;
 }

--- a/providers/implementations/ciphers/cipher_aes_ocb.c
+++ b/providers/implementations/ciphers/cipher_aes_ocb.c
@@ -469,7 +469,8 @@ static const OSSL_PARAM cipher_ocb_known_gettable_ctx_params[] = {
     OSSL_PARAM_octet_string(OSSL_CIPHER_PARAM_AEAD_TAG, NULL, 0),
     OSSL_PARAM_END
 };
-static const OSSL_PARAM *cipher_ocb_gettable_ctx_params(ossl_unused void *p_ctx)
+static const OSSL_PARAM *cipher_ocb_gettable_ctx_params(ossl_unused void *cctx,
+                                                        ossl_unused void *p_ctx)
 {
     return cipher_ocb_known_gettable_ctx_params;
 }
@@ -480,7 +481,8 @@ static const OSSL_PARAM cipher_ocb_known_settable_ctx_params[] = {
     OSSL_PARAM_octet_string(OSSL_CIPHER_PARAM_AEAD_TAG, NULL, 0),
     OSSL_PARAM_END
 };
-static const OSSL_PARAM *cipher_ocb_settable_ctx_params(ossl_unused void *p_ctx)
+static const OSSL_PARAM *cipher_ocb_settable_ctx_params(ossl_unused void *cctx,
+                                                        ossl_unused void *p_ctx)
 {
     return cipher_ocb_known_settable_ctx_params;
 }

--- a/providers/implementations/ciphers/cipher_aes_siv.c
+++ b/providers/implementations/ciphers/cipher_aes_siv.c
@@ -183,7 +183,8 @@ static const OSSL_PARAM aes_siv_known_gettable_ctx_params[] = {
     OSSL_PARAM_octet_string(OSSL_CIPHER_PARAM_AEAD_TAG, NULL, 0),
     OSSL_PARAM_END
 };
-static const OSSL_PARAM *aes_siv_gettable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *aes_siv_gettable_ctx_params(ossl_unused void *cctx,
+                                                     ossl_unused void *provctx)
 {
     return aes_siv_known_gettable_ctx_params;
 }
@@ -233,7 +234,8 @@ static const OSSL_PARAM aes_siv_known_settable_ctx_params[] = {
     OSSL_PARAM_octet_string(OSSL_CIPHER_PARAM_AEAD_TAG, NULL, 0),
     OSSL_PARAM_END
 };
-static const OSSL_PARAM *aes_siv_settable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *aes_siv_settable_ctx_params(ossl_unused void *cctx,
+                                                     ossl_unused void *provctx)
 {
     return aes_siv_known_settable_ctx_params;
 }
@@ -248,7 +250,6 @@ static OSSL_FUNC_cipher_update_fn lc##_stream_update;                          \
 static OSSL_FUNC_cipher_final_fn lc##_stream_final;                            \
 static OSSL_FUNC_cipher_cipher_fn lc##_cipher;                                 \
 static OSSL_FUNC_cipher_get_params_fn alg##_##kbits##_##lc##_get_params;       \
-static OSSL_FUNC_cipher_gettable_params_fn alg##_##lc##_gettable_ctx_params;   \
 static OSSL_FUNC_cipher_get_ctx_params_fn alg##_##lc##_get_ctx_params;         \
 static OSSL_FUNC_cipher_gettable_ctx_params_fn                                 \
             alg##_##lc##_gettable_ctx_params;                                  \

--- a/providers/implementations/ciphers/cipher_aes_xts.c
+++ b/providers/implementations/ciphers/cipher_aes_xts.c
@@ -218,7 +218,8 @@ static const OSSL_PARAM aes_xts_known_settable_ctx_params[] = {
     OSSL_PARAM_END
 };
 
-static const OSSL_PARAM *aes_xts_settable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *aes_xts_settable_ctx_params(ossl_unused void *cctx,
+                                                     ossl_unused void *provctx)
 {
     return aes_xts_known_settable_ctx_params;
 }

--- a/providers/implementations/ciphers/cipher_chacha20.c
+++ b/providers/implementations/ciphers/cipher_chacha20.c
@@ -95,7 +95,8 @@ static const OSSL_PARAM chacha20_known_gettable_ctx_params[] = {
     OSSL_PARAM_size_t(OSSL_CIPHER_PARAM_IVLEN, NULL),
     OSSL_PARAM_END
 };
-const OSSL_PARAM *chacha20_gettable_ctx_params(ossl_unused void *provctx)
+const OSSL_PARAM *chacha20_gettable_ctx_params(ossl_unused void *cctx,
+                                               ossl_unused void *provctx)
 {
     return chacha20_known_gettable_ctx_params;
 }
@@ -135,7 +136,8 @@ static const OSSL_PARAM chacha20_known_settable_ctx_params[] = {
     OSSL_PARAM_size_t(OSSL_CIPHER_PARAM_IVLEN, NULL),
     OSSL_PARAM_END
 };
-const OSSL_PARAM *chacha20_settable_ctx_params(ossl_unused void *provctx)
+const OSSL_PARAM *chacha20_settable_ctx_params(ossl_unused void *cctx,
+                                               ossl_unused void *provctx)
 {
     return chacha20_known_settable_ctx_params;
 }

--- a/providers/implementations/ciphers/cipher_chacha20_poly1305.c
+++ b/providers/implementations/ciphers/cipher_chacha20_poly1305.c
@@ -135,7 +135,7 @@ static const OSSL_PARAM chacha20_poly1305_known_gettable_ctx_params[] = {
     OSSL_PARAM_END
 };
 static const OSSL_PARAM *chacha20_poly1305_gettable_ctx_params
-    (ossl_unused void *provctx)
+    (ossl_unused void *cctx, ossl_unused void *provctx)
 {
     return chacha20_poly1305_known_gettable_ctx_params;
 }

--- a/providers/implementations/ciphers/cipher_null.c
+++ b/providers/implementations/ciphers/cipher_null.c
@@ -111,7 +111,8 @@ static const OSSL_PARAM null_known_gettable_ctx_params[] = {
 };
 
 static OSSL_FUNC_cipher_gettable_ctx_params_fn null_gettable_ctx_params;
-static const OSSL_PARAM *null_gettable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *null_gettable_ctx_params(ossl_unused void *cctx,
+                                                  ossl_unused void *provctx)
 {
     return null_known_gettable_ctx_params;
 }
@@ -147,7 +148,8 @@ static const OSSL_PARAM null_known_settable_ctx_params[] = {
 };
 
 static OSSL_FUNC_cipher_settable_ctx_params_fn null_settable_ctx_params;
-static const OSSL_PARAM *null_settable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *null_settable_ctx_params(ossl_unused void *cctx,
+                                                  ossl_unused void *provctx)
 {
     return null_known_settable_ctx_params;
 }

--- a/providers/implementations/ciphers/cipher_rc4_hmac_md5.c
+++ b/providers/implementations/ciphers/cipher_rc4_hmac_md5.c
@@ -77,7 +77,8 @@ static const OSSL_PARAM rc4_hmac_md5_known_gettable_ctx_params[] = {
     OSSL_PARAM_size_t(OSSL_CIPHER_PARAM_AEAD_TLS1_AAD_PAD, NULL),
     OSSL_PARAM_END
 };
-const OSSL_PARAM *rc4_hmac_md5_gettable_ctx_params(ossl_unused void *provctx)
+const OSSL_PARAM *rc4_hmac_md5_gettable_ctx_params(ossl_unused void *cctx,
+                                                   ossl_unused void *provctx)
 {
     return rc4_hmac_md5_known_gettable_ctx_params;
 }
@@ -112,7 +113,8 @@ static const OSSL_PARAM rc4_hmac_md5_known_settable_ctx_params[] = {
     OSSL_PARAM_octet_string(OSSL_CIPHER_PARAM_AEAD_TLS1_AAD, NULL, 0),
     OSSL_PARAM_END
 };
-const OSSL_PARAM *rc4_hmac_md5_settable_ctx_params(ossl_unused void *provctx)
+const OSSL_PARAM *rc4_hmac_md5_settable_ctx_params(ossl_unused void *cctx,
+                                                   ossl_unused void *provctx)
 {
     return rc4_hmac_md5_known_settable_ctx_params;
 }

--- a/providers/implementations/ciphers/ciphercommon.c
+++ b/providers/implementations/ciphers/ciphercommon.c
@@ -33,7 +33,7 @@ static const OSSL_PARAM cipher_known_gettable_params[] = {
     { OSSL_CIPHER_PARAM_TLS_MAC, OSSL_PARAM_OCTET_PTR, NULL, 0, OSSL_PARAM_UNMODIFIED },
     OSSL_PARAM_END
 };
-const OSSL_PARAM *ossl_cipher_generic_gettable_params(void *provctx)
+const OSSL_PARAM *ossl_cipher_generic_gettable_params(ossl_unused void *provctx)
 {
     return cipher_known_gettable_params;
 }
@@ -141,7 +141,7 @@ static const OSSL_PARAM cipher_aead_known_gettable_ctx_params[] = {
     OSSL_PARAM_END
 };
 const OSSL_PARAM *ossl_cipher_aead_gettable_ctx_params(
-        ossl_unused void *provctx
+        ossl_unused void *cctx, ossl_unused void *provctx
     )
 {
     return cipher_aead_known_gettable_ctx_params;
@@ -156,7 +156,7 @@ static const OSSL_PARAM cipher_aead_known_settable_ctx_params[] = {
     OSSL_PARAM_END
 };
 const OSSL_PARAM *ossl_cipher_aead_settable_ctx_params(
-        ossl_unused void *provctx
+        ossl_unused void *cctx, ossl_unused void *provctx
     )
 {
     return cipher_aead_known_settable_ctx_params;

--- a/providers/implementations/digests/md5_sha1_prov.c
+++ b/providers/implementations/digests/md5_sha1_prov.c
@@ -30,7 +30,8 @@ static const OSSL_PARAM known_md5_sha1_settable_ctx_params[] = {
     OSSL_PARAM_END
 };
 
-static const OSSL_PARAM *md5_sha1_settable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *md5_sha1_settable_ctx_params(ossl_unused void *ctx,
+                                                      ossl_unused void *provctx)
 {
     return known_md5_sha1_settable_ctx_params;
 }

--- a/providers/implementations/digests/mdc2_prov.c
+++ b/providers/implementations/digests/mdc2_prov.c
@@ -30,7 +30,8 @@ static const OSSL_PARAM known_mdc2_settable_ctx_params[] = {
     OSSL_PARAM_END
 };
 
-static const OSSL_PARAM *mdc2_settable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *mdc2_settable_ctx_params(ossl_unused void *ctx,
+                                                  ossl_unused void *provctx)
 {
     return known_mdc2_settable_ctx_params;
 }

--- a/providers/implementations/digests/sha2_prov.c
+++ b/providers/implementations/digests/sha2_prov.c
@@ -33,7 +33,8 @@ static const OSSL_PARAM known_sha1_settable_ctx_params[] = {
     {OSSL_DIGEST_PARAM_SSL3_MS, OSSL_PARAM_OCTET_STRING, NULL, 0, 0},
     OSSL_PARAM_END
 };
-static const OSSL_PARAM *sha1_settable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *sha1_settable_ctx_params(ossl_unused void *ctx,
+                                                  ossl_unused void *provctx)
 {
     return known_sha1_settable_ctx_params;
 }

--- a/providers/implementations/digests/sha3_prov.c
+++ b/providers/implementations/digests/sha3_prov.c
@@ -265,7 +265,8 @@ static const OSSL_PARAM known_shake_settable_ctx_params[] = {
     {OSSL_DIGEST_PARAM_XOFLEN, OSSL_PARAM_UNSIGNED_INTEGER, NULL, 0, 0},
     OSSL_PARAM_END
 };
-static const OSSL_PARAM *shake_settable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *shake_settable_ctx_params(ossl_unused void *ctx,
+                                                   ossl_unused void *provctx)
 {
     return known_shake_settable_ctx_params;
 }

--- a/providers/implementations/include/prov/ciphercommon.h
+++ b/providers/implementations/include/prov/ciphercommon.h
@@ -333,7 +333,8 @@ static const OSSL_PARAM name##_known_gettable_ctx_params[] = {                 \
 #define CIPHER_DEFAULT_GETTABLE_CTX_PARAMS_END(name)                           \
     OSSL_PARAM_END                                                             \
 };                                                                             \
-const OSSL_PARAM * name##_gettable_ctx_params(ossl_unused void *provctx)       \
+const OSSL_PARAM * name##_gettable_ctx_params(ossl_unused void *cctx,          \
+                                              ossl_unused void *provctx)       \
 {                                                                              \
     return name##_known_gettable_ctx_params;                                   \
 }
@@ -345,7 +346,8 @@ static const OSSL_PARAM name##_known_settable_ctx_params[] = {                 \
 #define CIPHER_DEFAULT_SETTABLE_CTX_PARAMS_END(name)                           \
     OSSL_PARAM_END                                                             \
 };                                                                             \
-const OSSL_PARAM * name##_settable_ctx_params(ossl_unused void *provctx)       \
+const OSSL_PARAM * name##_settable_ctx_params(ossl_unused void *cctx,          \
+                                              ossl_unused void *provctx)       \
 {                                                                              \
     return name##_known_settable_ctx_params;                                   \
 }

--- a/providers/implementations/kdfs/hkdf.c
+++ b/providers/implementations/kdfs/hkdf.c
@@ -237,7 +237,8 @@ static int kdf_hkdf_set_ctx_params(void *vctx, const OSSL_PARAM params[])
     return 1;
 }
 
-static const OSSL_PARAM *kdf_hkdf_settable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *kdf_hkdf_settable_ctx_params(ossl_unused void *ctx,
+                                                      ossl_unused void *provctx)
 {
     static const OSSL_PARAM known_settable_ctx_params[] = {
         OSSL_PARAM_utf8_string(OSSL_KDF_PARAM_MODE, NULL, 0),
@@ -262,7 +263,8 @@ static int kdf_hkdf_get_ctx_params(void *vctx, OSSL_PARAM params[])
     return -2;
 }
 
-static const OSSL_PARAM *kdf_hkdf_gettable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *kdf_hkdf_gettable_ctx_params(ossl_unused void *ctx,
+                                                      ossl_unused void *provctx)
 {
     static const OSSL_PARAM known_gettable_ctx_params[] = {
         OSSL_PARAM_size_t(OSSL_KDF_PARAM_SIZE, NULL),

--- a/providers/implementations/kdfs/kbkdf.c
+++ b/providers/implementations/kdfs/kbkdf.c
@@ -343,7 +343,8 @@ static int kbkdf_set_ctx_params(void *vctx, const OSSL_PARAM params[])
     return 1;
 }
 
-static const OSSL_PARAM *kbkdf_settable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *kbkdf_settable_ctx_params(ossl_unused void *ctx,
+                                                   ossl_unused void *provctx)
 {
     static const OSSL_PARAM known_settable_ctx_params[] = {
         OSSL_PARAM_octet_string(OSSL_KDF_PARAM_INFO, NULL, 0),
@@ -374,7 +375,8 @@ static int kbkdf_get_ctx_params(void *vctx, OSSL_PARAM params[])
     return OSSL_PARAM_set_size_t(p, SIZE_MAX);
 }
 
-static const OSSL_PARAM *kbkdf_gettable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *kbkdf_gettable_ctx_params(ossl_unused void *ctx,
+                                                   ossl_unused void *provctx)
 {
     static const OSSL_PARAM known_gettable_ctx_params[] =
         { OSSL_PARAM_size_t(OSSL_KDF_PARAM_SIZE, NULL), OSSL_PARAM_END };

--- a/providers/implementations/kdfs/krb5kdf.c
+++ b/providers/implementations/kdfs/krb5kdf.c
@@ -151,7 +151,8 @@ static int krb5kdf_set_ctx_params(void *vctx, const OSSL_PARAM params[])
     return 1;
 }
 
-static const OSSL_PARAM *krb5kdf_settable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *krb5kdf_settable_ctx_params(ossl_unused void *ctx,
+                                                     ossl_unused void *provctx)
 {
     static const OSSL_PARAM known_settable_ctx_params[] = {
         OSSL_PARAM_utf8_string(OSSL_KDF_PARAM_PROPERTIES, NULL, 0),
@@ -181,7 +182,8 @@ static int krb5kdf_get_ctx_params(void *vctx, OSSL_PARAM params[])
     return -2;
 }
 
-static const OSSL_PARAM *krb5kdf_gettable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *krb5kdf_gettable_ctx_params(ossl_unused void *ctx,
+                                                     ossl_unused void *provctx)
 {
     static const OSSL_PARAM known_gettable_ctx_params[] = {
         OSSL_PARAM_size_t(OSSL_KDF_PARAM_SIZE, NULL),

--- a/providers/implementations/kdfs/pbkdf2.c
+++ b/providers/implementations/kdfs/pbkdf2.c
@@ -208,7 +208,8 @@ static int kdf_pbkdf2_set_ctx_params(void *vctx, const OSSL_PARAM params[])
     return 1;
 }
 
-static const OSSL_PARAM *kdf_pbkdf2_settable_ctx_params(ossl_unused void *p_ctx)
+static const OSSL_PARAM *kdf_pbkdf2_settable_ctx_params(ossl_unused void *ctx,
+                                                        ossl_unused void *p_ctx)
 {
     static const OSSL_PARAM known_settable_ctx_params[] = {
         OSSL_PARAM_utf8_string(OSSL_KDF_PARAM_PROPERTIES, NULL, 0),
@@ -231,7 +232,8 @@ static int kdf_pbkdf2_get_ctx_params(void *vctx, OSSL_PARAM params[])
     return -2;
 }
 
-static const OSSL_PARAM *kdf_pbkdf2_gettable_ctx_params(ossl_unused void *p_ctx)
+static const OSSL_PARAM *kdf_pbkdf2_gettable_ctx_params(ossl_unused void *ctx,
+                                                        ossl_unused void *p_ctx)
 {
     static const OSSL_PARAM known_gettable_ctx_params[] = {
         OSSL_PARAM_size_t(OSSL_KDF_PARAM_SIZE, NULL),

--- a/providers/implementations/kdfs/pkcs12kdf.c
+++ b/providers/implementations/kdfs/pkcs12kdf.c
@@ -246,7 +246,8 @@ static int kdf_pkcs12_set_ctx_params(void *vctx, const OSSL_PARAM params[])
     return 1;
 }
 
-static const OSSL_PARAM *kdf_pkcs12_settable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *kdf_pkcs12_settable_ctx_params(
+        ossl_unused void *ctx, ossl_unused void *provctx)
 {
     static const OSSL_PARAM known_settable_ctx_params[] = {
         OSSL_PARAM_utf8_string(OSSL_KDF_PARAM_PROPERTIES, NULL, 0),
@@ -269,7 +270,8 @@ static int kdf_pkcs12_get_ctx_params(void *vctx, OSSL_PARAM params[])
     return -2;
 }
 
-static const OSSL_PARAM *kdf_pkcs12_gettable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *kdf_pkcs12_gettable_ctx_params(
+        ossl_unused void *ctx, ossl_unused void *provctx)
 {
     static const OSSL_PARAM known_gettable_ctx_params[] = {
         OSSL_PARAM_size_t(OSSL_KDF_PARAM_SIZE, NULL),

--- a/providers/implementations/kdfs/scrypt.c
+++ b/providers/implementations/kdfs/scrypt.c
@@ -233,7 +233,8 @@ static int kdf_scrypt_set_ctx_params(void *vctx, const OSSL_PARAM params[])
     return 1;
 }
 
-static const OSSL_PARAM *kdf_scrypt_settable_ctx_params(ossl_unused void *p_ctx)
+static const OSSL_PARAM *kdf_scrypt_settable_ctx_params(ossl_unused void *ctx,
+                                                        ossl_unused void *p_ctx)
 {
     static const OSSL_PARAM known_settable_ctx_params[] = {
         OSSL_PARAM_octet_string(OSSL_KDF_PARAM_PASSWORD, NULL, 0),
@@ -257,7 +258,8 @@ static int kdf_scrypt_get_ctx_params(void *vctx, OSSL_PARAM params[])
     return -2;
 }
 
-static const OSSL_PARAM *kdf_scrypt_gettable_ctx_params(ossl_unused void *p_ctx)
+static const OSSL_PARAM *kdf_scrypt_gettable_ctx_params(ossl_unused void *ctx,
+                                                        ossl_unused void *p_ctx)
 {
     static const OSSL_PARAM known_gettable_ctx_params[] = {
         OSSL_PARAM_size_t(OSSL_KDF_PARAM_SIZE, NULL),

--- a/providers/implementations/kdfs/sshkdf.c
+++ b/providers/implementations/kdfs/sshkdf.c
@@ -171,7 +171,8 @@ static int kdf_sshkdf_set_ctx_params(void *vctx, const OSSL_PARAM params[])
     return 1;
 }
 
-static const OSSL_PARAM *kdf_sshkdf_settable_ctx_params(ossl_unused void *p_ctx)
+static const OSSL_PARAM *kdf_sshkdf_settable_ctx_params(ossl_unused void *ctx,
+                                                        ossl_unused void *p_ctx)
 {
     static const OSSL_PARAM known_settable_ctx_params[] = {
         OSSL_PARAM_utf8_string(OSSL_KDF_PARAM_PROPERTIES, NULL, 0),
@@ -194,7 +195,8 @@ static int kdf_sshkdf_get_ctx_params(void *vctx, OSSL_PARAM params[])
     return -2;
 }
 
-static const OSSL_PARAM *kdf_sshkdf_gettable_ctx_params(ossl_unused void *p_ctx)
+static const OSSL_PARAM *kdf_sshkdf_gettable_ctx_params(ossl_unused void *ctx,
+                                                        ossl_unused void *p_ctx)
 {
     static const OSSL_PARAM known_gettable_ctx_params[] = {
         OSSL_PARAM_size_t(OSSL_KDF_PARAM_SIZE, NULL),

--- a/providers/implementations/kdfs/sskdf.c
+++ b/providers/implementations/kdfs/sskdf.c
@@ -484,7 +484,8 @@ static int sskdf_set_ctx_params(void *vctx, const OSSL_PARAM params[])
     return 1;
 }
 
-static const OSSL_PARAM *sskdf_settable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *sskdf_settable_ctx_params(ossl_unused void *ctx,
+                                                   ossl_unused void *provctx)
 {
     static const OSSL_PARAM known_settable_ctx_params[] = {
         OSSL_PARAM_octet_string(OSSL_KDF_PARAM_SECRET, NULL, 0),
@@ -510,7 +511,8 @@ static int sskdf_get_ctx_params(void *vctx, OSSL_PARAM params[])
     return -2;
 }
 
-static const OSSL_PARAM *sskdf_gettable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *sskdf_gettable_ctx_params(ossl_unused void *ctx,
+                                                   ossl_unused void *provctx)
 {
     static const OSSL_PARAM known_gettable_ctx_params[] = {
         OSSL_PARAM_size_t(OSSL_KDF_PARAM_SIZE, NULL),

--- a/providers/implementations/kdfs/tls1_prf.c
+++ b/providers/implementations/kdfs/tls1_prf.c
@@ -211,7 +211,8 @@ static int kdf_tls1_prf_set_ctx_params(void *vctx, const OSSL_PARAM params[])
     return 1;
 }
 
-static const OSSL_PARAM *kdf_tls1_prf_settable_ctx_params(ossl_unused void *ctx)
+static const OSSL_PARAM *kdf_tls1_prf_settable_ctx_params(
+        ossl_unused void *ctx, ossl_unused void *provctx)
 {
     static const OSSL_PARAM known_settable_ctx_params[] = {
         OSSL_PARAM_utf8_string(OSSL_KDF_PARAM_PROPERTIES, NULL, 0),
@@ -232,7 +233,8 @@ static int kdf_tls1_prf_get_ctx_params(void *vctx, OSSL_PARAM params[])
     return -2;
 }
 
-static const OSSL_PARAM *kdf_tls1_prf_gettable_ctx_params(ossl_unused void *ctx)
+static const OSSL_PARAM *kdf_tls1_prf_gettable_ctx_params(
+        ossl_unused void *ctx, ossl_unused void *provctx)
 {
     static const OSSL_PARAM known_gettable_ctx_params[] = {
         OSSL_PARAM_size_t(OSSL_KDF_PARAM_SIZE, NULL),

--- a/providers/implementations/kdfs/x942kdf.c
+++ b/providers/implementations/kdfs/x942kdf.c
@@ -533,7 +533,8 @@ static int x942kdf_set_ctx_params(void *vctx, const OSSL_PARAM params[])
     return 1;
 }
 
-static const OSSL_PARAM *x942kdf_settable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *x942kdf_settable_ctx_params(ossl_unused void *ctx,
+                                                     ossl_unused void *provctx)
 {
     static const OSSL_PARAM known_settable_ctx_params[] = {
         OSSL_PARAM_utf8_string(OSSL_KDF_PARAM_PROPERTIES, NULL, 0),
@@ -563,7 +564,8 @@ static int x942kdf_get_ctx_params(void *vctx, OSSL_PARAM params[])
     return -2;
 }
 
-static const OSSL_PARAM *x942kdf_gettable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *x942kdf_gettable_ctx_params(ossl_unused void *ctx,
+                                                     ossl_unused void *provctx)
 {
     static const OSSL_PARAM known_gettable_ctx_params[] = {
         OSSL_PARAM_size_t(OSSL_KDF_PARAM_SIZE, NULL),

--- a/providers/implementations/macs/blake2_mac_impl.c
+++ b/providers/implementations/macs/blake2_mac_impl.c
@@ -131,7 +131,8 @@ static const OSSL_PARAM known_gettable_ctx_params[] = {
     OSSL_PARAM_size_t(OSSL_MAC_PARAM_SIZE, NULL),
     OSSL_PARAM_END
 };
-static const OSSL_PARAM *blake2_gettable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *blake2_gettable_ctx_params(ossl_unused void *ctx,
+                                                    ossl_unused void *provctx)
 {
     return known_gettable_ctx_params;
 }
@@ -153,7 +154,8 @@ static const OSSL_PARAM known_settable_ctx_params[] = {
     OSSL_PARAM_octet_string(OSSL_MAC_PARAM_SALT, NULL, 0),
     OSSL_PARAM_END
 };
-static const OSSL_PARAM *blake2_mac_settable_ctx_params(ossl_unused void *p_ctx)
+static const OSSL_PARAM *blake2_mac_settable_ctx_params(
+            ossl_unused void *ctx, ossl_unused void *p_ctx)
 {
     return known_settable_ctx_params;
 }

--- a/providers/implementations/macs/cmac_prov.c
+++ b/providers/implementations/macs/cmac_prov.c
@@ -141,7 +141,8 @@ static const OSSL_PARAM known_gettable_ctx_params[] = {
     OSSL_PARAM_size_t(OSSL_MAC_PARAM_SIZE, NULL),
     OSSL_PARAM_END
 };
-static const OSSL_PARAM *cmac_gettable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *cmac_gettable_ctx_params(ossl_unused void *ctx,
+                                                  ossl_unused void *provctx)
 {
     return known_gettable_ctx_params;
 }
@@ -162,7 +163,8 @@ static const OSSL_PARAM known_settable_ctx_params[] = {
     OSSL_PARAM_octet_string(OSSL_MAC_PARAM_KEY, NULL, 0),
     OSSL_PARAM_END
 };
-static const OSSL_PARAM *cmac_settable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *cmac_settable_ctx_params(ossl_unused void *ctx,
+                                                  ossl_unused void *provctx)
 {
     return known_settable_ctx_params;
 }

--- a/providers/implementations/macs/gmac_prov.c
+++ b/providers/implementations/macs/gmac_prov.c
@@ -170,7 +170,8 @@ static const OSSL_PARAM known_settable_ctx_params[] = {
     OSSL_PARAM_octet_string(OSSL_MAC_PARAM_IV, NULL, 0),
     OSSL_PARAM_END
 };
-static const OSSL_PARAM *gmac_settable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *gmac_settable_ctx_params(ossl_unused void *ctx,
+                                                  ossl_unused void *provctx)
 {
     return known_settable_ctx_params;
 }

--- a/providers/implementations/macs/hmac_prov.c
+++ b/providers/implementations/macs/hmac_prov.c
@@ -219,7 +219,8 @@ static const OSSL_PARAM known_gettable_ctx_params[] = {
     OSSL_PARAM_size_t(OSSL_MAC_PARAM_SIZE, NULL),
     OSSL_PARAM_END
 };
-static const OSSL_PARAM *hmac_gettable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *hmac_gettable_ctx_params(ossl_unused void *ctx,
+                                                  ossl_unused void *provctx)
 {
     return known_gettable_ctx_params;
 }
@@ -243,7 +244,8 @@ static const OSSL_PARAM known_settable_ctx_params[] = {
     OSSL_PARAM_size_t(OSSL_MAC_PARAM_TLS_DATA_SIZE, NULL),
     OSSL_PARAM_END
 };
-static const OSSL_PARAM *hmac_settable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *hmac_settable_ctx_params(ossl_unused void *ctx,
+                                                  ossl_unused void *provctx)
 {
     return known_settable_ctx_params;
 }

--- a/providers/implementations/macs/kmac_prov.c
+++ b/providers/implementations/macs/kmac_prov.c
@@ -318,7 +318,8 @@ static const OSSL_PARAM known_gettable_ctx_params[] = {
     OSSL_PARAM_size_t(OSSL_MAC_PARAM_SIZE, NULL),
     OSSL_PARAM_END
 };
-static const OSSL_PARAM *kmac_gettable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *kmac_gettable_ctx_params(ossl_unused void *ctx,
+                                                  ossl_unused void *provctx)
 {
     return known_gettable_ctx_params;
 }
@@ -340,7 +341,8 @@ static const OSSL_PARAM known_settable_ctx_params[] = {
     OSSL_PARAM_octet_string(OSSL_MAC_PARAM_CUSTOM, NULL, 0),
     OSSL_PARAM_END
 };
-static const OSSL_PARAM *kmac_settable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *kmac_settable_ctx_params(ossl_unused void *ctx,
+                                                  ossl_unused void *provctx)
 {
     return known_settable_ctx_params;
 }

--- a/providers/implementations/macs/poly1305_prov.c
+++ b/providers/implementations/macs/poly1305_prov.c
@@ -131,7 +131,8 @@ static const OSSL_PARAM known_settable_ctx_params[] = {
     OSSL_PARAM_octet_string(OSSL_MAC_PARAM_KEY, NULL, 0),
     OSSL_PARAM_END
 };
-static const OSSL_PARAM *poly1305_settable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *poly1305_settable_ctx_params(ossl_unused void *ctx,
+                                                      ossl_unused void *provctx)
 {
     return known_settable_ctx_params;
 }

--- a/providers/implementations/macs/siphash_prov.c
+++ b/providers/implementations/macs/siphash_prov.c
@@ -36,7 +36,7 @@ static OSSL_FUNC_mac_dupctx_fn siphash_dup;
 static OSSL_FUNC_mac_freectx_fn siphash_free;
 static OSSL_FUNC_mac_gettable_ctx_params_fn siphash_gettable_ctx_params;
 static OSSL_FUNC_mac_get_ctx_params_fn siphash_get_ctx_params;
-static OSSL_FUNC_mac_settable_ctx_params_fn siphash_settable_params;
+static OSSL_FUNC_mac_settable_ctx_params_fn siphash_settable_ctx_params;
 static OSSL_FUNC_mac_set_ctx_params_fn siphash_set_params;
 static OSSL_FUNC_mac_init_fn siphash_init;
 static OSSL_FUNC_mac_update_fn siphash_update;
@@ -121,7 +121,8 @@ static const OSSL_PARAM known_gettable_ctx_params[] = {
     OSSL_PARAM_size_t(OSSL_MAC_PARAM_SIZE, NULL),
     OSSL_PARAM_END
 };
-static const OSSL_PARAM *siphash_gettable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *siphash_gettable_ctx_params(ossl_unused void *ctx,
+                                                     ossl_unused void *provctx)
 {
     return known_gettable_ctx_params;
 }
@@ -141,7 +142,9 @@ static const OSSL_PARAM known_settable_ctx_params[] = {
     OSSL_PARAM_octet_string(OSSL_MAC_PARAM_KEY, NULL, 0),
     OSSL_PARAM_END
 };
-static const OSSL_PARAM *siphash_settable_params(void *provctx)
+
+static const OSSL_PARAM *siphash_settable_ctx_params(ossl_unused void *ctx,
+                                                     void *provctx)
 {
     return known_settable_ctx_params;
 }
@@ -177,7 +180,7 @@ const OSSL_DISPATCH ossl_siphash_functions[] = {
       (void (*)(void))siphash_gettable_ctx_params },
     { OSSL_FUNC_MAC_GET_CTX_PARAMS, (void (*)(void))siphash_get_ctx_params },
     { OSSL_FUNC_MAC_SETTABLE_CTX_PARAMS,
-      (void (*)(void))siphash_settable_params },
+      (void (*)(void))siphash_settable_ctx_params },
     { OSSL_FUNC_MAC_SET_CTX_PARAMS, (void (*)(void))siphash_set_params },
     { 0, NULL }
 };

--- a/providers/implementations/rands/drbg_ctr.c
+++ b/providers/implementations/rands/drbg_ctr.c
@@ -648,7 +648,8 @@ static int drbg_ctr_get_ctx_params(void *vdrbg, OSSL_PARAM params[])
     return ossl_drbg_get_ctx_params(drbg, params);
 }
 
-static const OSSL_PARAM *drbg_ctr_gettable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *drbg_ctr_gettable_ctx_params(ossl_unused void *vctx,
+                                                      ossl_unused void *provctx)
 {
     static const OSSL_PARAM known_gettable_ctx_params[] = {
         OSSL_PARAM_utf8_string(OSSL_DRBG_PARAM_CIPHER, NULL, 0),
@@ -718,7 +719,8 @@ static int drbg_ctr_set_ctx_params(void *vctx, const OSSL_PARAM params[])
     return ossl_drbg_set_ctx_params(ctx, params);
 }
 
-static const OSSL_PARAM *drbg_ctr_settable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *drbg_ctr_settable_ctx_params(ossl_unused void *vctx,
+                                                      ossl_unused void *provctx)
 {
     static const OSSL_PARAM known_settable_ctx_params[] = {
         OSSL_PARAM_utf8_string(OSSL_DRBG_PARAM_PROPERTIES, NULL, 0),

--- a/providers/implementations/rands/drbg_hash.c
+++ b/providers/implementations/rands/drbg_hash.c
@@ -442,7 +442,8 @@ static int drbg_hash_get_ctx_params(void *vdrbg, OSSL_PARAM params[])
     return ossl_drbg_get_ctx_params(drbg, params);
 }
 
-static const OSSL_PARAM *drbg_hash_gettable_ctx_params(ossl_unused void *p_ctx)
+static const OSSL_PARAM *drbg_hash_gettable_ctx_params(ossl_unused void *vctx,
+                                                       ossl_unused void *p_ctx)
 {
     static const OSSL_PARAM known_gettable_ctx_params[] = {
         OSSL_PARAM_utf8_string(OSSL_DRBG_PARAM_DIGEST, NULL, 0),
@@ -487,7 +488,8 @@ static int drbg_hash_set_ctx_params(void *vctx, const OSSL_PARAM params[])
     return ossl_drbg_set_ctx_params(ctx, params);
 }
 
-static const OSSL_PARAM *drbg_hash_settable_ctx_params(ossl_unused void *p_ctx)
+static const OSSL_PARAM *drbg_hash_settable_ctx_params(ossl_unused void *vctx,
+                                                       ossl_unused void *p_ctx)
 {
     static const OSSL_PARAM known_settable_ctx_params[] = {
         OSSL_PARAM_utf8_string(OSSL_DRBG_PARAM_PROPERTIES, NULL, 0),

--- a/providers/implementations/rands/drbg_hmac.c
+++ b/providers/implementations/rands/drbg_hmac.c
@@ -349,7 +349,8 @@ static int drbg_hmac_get_ctx_params(void *vdrbg, OSSL_PARAM params[])
     return ossl_drbg_get_ctx_params(drbg, params);
 }
 
-static const OSSL_PARAM *drbg_hmac_gettable_ctx_params(ossl_unused void *p_ctx)
+static const OSSL_PARAM *drbg_hmac_gettable_ctx_params(ossl_unused void *vctx,
+                                                       ossl_unused void *p_ctx)
 {
     static const OSSL_PARAM known_gettable_ctx_params[] = {
         OSSL_PARAM_utf8_string(OSSL_DRBG_PARAM_MAC, NULL, 0),
@@ -400,7 +401,8 @@ static int drbg_hmac_set_ctx_params(void *vctx, const OSSL_PARAM params[])
     return ossl_drbg_set_ctx_params(ctx, params);
 }
 
-static const OSSL_PARAM *drbg_hmac_settable_ctx_params(ossl_unused void *p_ctx)
+static const OSSL_PARAM *drbg_hmac_settable_ctx_params(ossl_unused void *vctx,
+                                                       ossl_unused void *p_ctx)
 {
     static const OSSL_PARAM known_settable_ctx_params[] = {
         OSSL_PARAM_utf8_string(OSSL_DRBG_PARAM_PROPERTIES, NULL, 0),

--- a/providers/implementations/rands/seed_src.c
+++ b/providers/implementations/rands/seed_src.c
@@ -156,7 +156,8 @@ static int seed_src_get_ctx_params(void *vseed, OSSL_PARAM params[])
     return 1;
 }
 
-static const OSSL_PARAM *seed_src_gettable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *seed_src_gettable_ctx_params(ossl_unused void *vseed,
+                                                      ossl_unused void *provctx)
 {
     static const OSSL_PARAM known_gettable_ctx_params[] = {
         OSSL_PARAM_int(OSSL_RAND_PARAM_STATE, NULL),

--- a/providers/implementations/rands/test_rng.c
+++ b/providers/implementations/rands/test_rng.c
@@ -163,7 +163,8 @@ static int test_rng_get_ctx_params(void *vtest, OSSL_PARAM params[])
     return 1;
 }
 
-static const OSSL_PARAM *test_rng_gettable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *test_rng_gettable_ctx_params(ossl_unused void *vtest,
+                                                      ossl_unused void *provctx)
 {
     static const OSSL_PARAM known_gettable_ctx_params[] = {
         OSSL_PARAM_int(OSSL_RAND_PARAM_STATE, NULL),
@@ -212,7 +213,8 @@ static int test_rng_set_ctx_params(void *vtest, const OSSL_PARAM params[])
     return 1;
 }
 
-static const OSSL_PARAM *test_rng_settable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *test_rng_settable_ctx_params(ossl_unused void *vtest,
+                                                      ossl_unused void *provctx)
 {
     static const OSSL_PARAM known_settable_ctx_params[] = {
         OSSL_PARAM_octet_string(OSSL_RAND_PARAM_TEST_ENTROPY, NULL, 0),

--- a/test/testutil/fake_random.c
+++ b/test/testutil/fake_random.c
@@ -109,7 +109,8 @@ static int fake_rand_get_ctx_params(ossl_unused void *vrng, OSSL_PARAM params[])
     return 1;
 }
 
-static const OSSL_PARAM *fake_rand_gettable_ctx_params(void *vrng)
+static const OSSL_PARAM *fake_rand_gettable_ctx_params(ossl_unused void *vrng,
+                                                       ossl_unused void *provctx)
 {
     static const OSSL_PARAM known_gettable_ctx_params[] = {
         OSSL_PARAM_int(OSSL_RAND_PARAM_STATE, NULL),

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5304,6 +5304,8 @@ EVP_PKEY_public_check_quick             ?	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_CTX_is_a                       ?	3_0_0	EXIST::FUNCTION:
 EVP_KDF_CTX_gettable_params             ?	3_0_0	EXIST::FUNCTION:
 EVP_KDF_CTX_settable_params             ?	3_0_0	EXIST::FUNCTION:
+EVP_MAC_CTX_gettable_params             ?	3_0_0	EXIST::FUNCTION:
+EVP_MAC_CTX_settable_params             ?	3_0_0	EXIST::FUNCTION:
 EVP_RAND_CTX_gettable_params            ?	3_0_0	EXIST::FUNCTION:
 EVP_RAND_CTX_settable_params            ?	3_0_0	EXIST::FUNCTION:
 RAND_set_DRBG_type                      ?	3_0_0	EXIST::FUNCTION:

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5302,6 +5302,8 @@ EVP_PKEY_fromdata_settable              ?	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_param_check_quick              ?	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_public_check_quick             ?	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_CTX_is_a                       ?	3_0_0	EXIST::FUNCTION:
+EVP_CIPHER_CTX_settable_params          ?	3_0_0	EXIST::FUNCTION:
+EVP_CIPHER_CTX_gettable_params          ?	3_0_0	EXIST::FUNCTION:
 EVP_KDF_CTX_gettable_params             ?	3_0_0	EXIST::FUNCTION:
 EVP_KDF_CTX_settable_params             ?	3_0_0	EXIST::FUNCTION:
 EVP_MAC_CTX_gettable_params             ?	3_0_0	EXIST::FUNCTION:

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5302,5 +5302,7 @@ EVP_PKEY_fromdata_settable              ?	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_param_check_quick              ?	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_public_check_quick             ?	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_CTX_is_a                       ?	3_0_0	EXIST::FUNCTION:
+EVP_RAND_CTX_gettable_params            ?	3_0_0	EXIST::FUNCTION:
+EVP_RAND_CTX_settable_params            ?	3_0_0	EXIST::FUNCTION:
 RAND_set_DRBG_type                      ?	3_0_0	EXIST::FUNCTION:
 RAND_set_seed_source_type               ?	3_0_0	EXIST::FUNCTION:

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5302,6 +5302,8 @@ EVP_PKEY_fromdata_settable              ?	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_param_check_quick              ?	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_public_check_quick             ?	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_CTX_is_a                       ?	3_0_0	EXIST::FUNCTION:
+EVP_KDF_CTX_gettable_params             ?	3_0_0	EXIST::FUNCTION:
+EVP_KDF_CTX_settable_params             ?	3_0_0	EXIST::FUNCTION:
 EVP_RAND_CTX_gettable_params            ?	3_0_0	EXIST::FUNCTION:
 EVP_RAND_CTX_settable_params            ?	3_0_0	EXIST::FUNCTION:
 RAND_set_DRBG_type                      ?	3_0_0	EXIST::FUNCTION:


### PR DESCRIPTION
This permits context specific param arrays to be returned.

A fallback mechanism is also implemented to call the non-context specific version is the specific ones are not available.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
