### PR TITLE
Fix external symbols for pkcs7 and cms

### DIFF
--- a/crypto/cms/cms_cd.c
+++ b/crypto/cms/cms_cd.c
@@ -21,8 +21,9 @@
 
 /* CMS CompressedData Utilities */
 
-CMS_ContentInfo *cms_CompressedData_create(int comp_nid, OSSL_LIB_CTX *libctx,
-                                           const char *propq)
+CMS_ContentInfo *ossl_cms_CompressedData_create(int comp_nid,
+                                                OSSL_LIB_CTX *libctx,
+                                                const char *propq)
 {
     CMS_ContentInfo *cms;
     CMS_CompressedData *cd;
@@ -61,7 +62,7 @@ CMS_ContentInfo *cms_CompressedData_create(int comp_nid, OSSL_LIB_CTX *libctx,
     return NULL;
 }
 
-BIO *cms_CompressedData_init_bio(const CMS_ContentInfo *cms)
+BIO *ossl_cms_CompressedData_init_bio(const CMS_ContentInfo *cms)
 {
     CMS_CompressedData *cd;
     const ASN1_OBJECT *compoid;

--- a/crypto/cms/cms_dd.c
+++ b/crypto/cms/cms_dd.c
@@ -17,9 +17,9 @@
 
 /* CMS DigestedData Utilities */
 
-CMS_ContentInfo *cms_DigestedData_create(const EVP_MD *md,
-                                         OSSL_LIB_CTX *libctx,
-                                         const char *propq)
+CMS_ContentInfo *ossl_cms_DigestedData_create(const EVP_MD *md,
+                                              OSSL_LIB_CTX *libctx,
+                                              const char *propq)
 {
     CMS_ContentInfo *cms;
     CMS_DigestedData *dd;
@@ -48,14 +48,16 @@ CMS_ContentInfo *cms_DigestedData_create(const EVP_MD *md,
     return NULL;
 }
 
-BIO *cms_DigestedData_init_bio(const CMS_ContentInfo *cms)
+BIO *ossl_cms_DigestedData_init_bio(const CMS_ContentInfo *cms)
 {
     CMS_DigestedData *dd = cms->d.digestedData;
 
-    return cms_DigestAlgorithm_init_bio(dd->digestAlgorithm, cms_get0_cmsctx(cms));
+    return ossl_cms_DigestAlgorithm_init_bio(dd->digestAlgorithm,
+                                             ossl_cms_get0_cmsctx(cms));
 }
 
-int cms_DigestedData_do_final(const CMS_ContentInfo *cms, BIO *chain, int verify)
+int ossl_cms_DigestedData_do_final(const CMS_ContentInfo *cms, BIO *chain,
+                                   int verify)
 {
     EVP_MD_CTX *mctx = EVP_MD_CTX_new();
     unsigned char md[EVP_MAX_MD_SIZE];
@@ -70,7 +72,7 @@ int cms_DigestedData_do_final(const CMS_ContentInfo *cms, BIO *chain, int verify
 
     dd = cms->d.digestedData;
 
-    if (!cms_DigestAlgorithm_find_ctx(mctx, chain, dd->digestAlgorithm))
+    if (!ossl_cms_DigestAlgorithm_find_ctx(mctx, chain, dd->digestAlgorithm))
         goto err;
 
     if (EVP_DigestFinal_ex(mctx, md, &mdlen) <= 0)

--- a/crypto/cms/cms_dh.c
+++ b/crypto/cms/cms_dh.c
@@ -327,7 +327,7 @@ static int dh_cms_encrypt(CMS_RecipientInfo *ri)
     return rv;
 }
 
-int cms_dh_envelope(CMS_RecipientInfo *ri, int decrypt)
+int ossl_cms_dh_envelope(CMS_RecipientInfo *ri, int decrypt)
 {
     assert(decrypt == 0 || decrypt == 1);
 

--- a/crypto/cms/cms_ec.c
+++ b/crypto/cms/cms_ec.c
@@ -370,7 +370,7 @@ static int ecdh_cms_encrypt(CMS_RecipientInfo *ri)
     return rv;
 }
 
-int cms_ecdh_envelope(CMS_RecipientInfo *ri, int decrypt)
+int ossl_cms_ecdh_envelope(CMS_RecipientInfo *ri, int decrypt)
 {
     assert(decrypt == 0 || decrypt == 1);
 
@@ -385,7 +385,7 @@ int cms_ecdh_envelope(CMS_RecipientInfo *ri, int decrypt)
 }
 
 /* ECDSA and DSA implementation is the same */
-int cms_ecdsa_dsa_sign(CMS_SignerInfo *si, int verify)
+int ossl_cms_ecdsa_dsa_sign(CMS_SignerInfo *si, int verify)
 {
     assert(verify == 0 || verify == 1);
 

--- a/crypto/cms/cms_enc.c
+++ b/crypto/cms/cms_enc.c
@@ -21,8 +21,8 @@
 
 /* Return BIO based on EncryptedContentInfo and key */
 
-BIO *cms_EncryptedContent_init_bio(CMS_EncryptedContentInfo *ec,
-                                   const CMS_CTX *cms_ctx)
+BIO *ossl_cms_EncryptedContent_init_bio(CMS_EncryptedContentInfo *ec,
+                                        const CMS_CTX *cms_ctx)
 {
     BIO *b;
     EVP_CIPHER_CTX *ctx;
@@ -37,8 +37,8 @@ BIO *cms_EncryptedContent_init_bio(CMS_EncryptedContentInfo *ec,
     size_t tkeylen = 0;
     int ok = 0;
     int enc, keep_key = 0;
-    OSSL_LIB_CTX *libctx = cms_ctx_get0_libctx(cms_ctx);
-    const char *propq = cms_ctx_get0_propq(cms_ctx);
+    OSSL_LIB_CTX *libctx = ossl_cms_ctx_get0_libctx(cms_ctx);
+    const char *propq = ossl_cms_ctx_get0_propq(cms_ctx);
 
     enc = ec->cipher ? 1 : 0;
 
@@ -193,10 +193,10 @@ BIO *cms_EncryptedContent_init_bio(CMS_EncryptedContentInfo *ec,
     return NULL;
 }
 
-int cms_EncryptedContent_init(CMS_EncryptedContentInfo *ec,
-                              const EVP_CIPHER *cipher,
-                              const unsigned char *key, size_t keylen,
-                              const CMS_CTX *cms_ctx)
+int ossl_cms_EncryptedContent_init(CMS_EncryptedContentInfo *ec,
+                                   const EVP_CIPHER *cipher,
+                                   const unsigned char *key, size_t keylen,
+                                   const CMS_CTX *cms_ctx)
 {
     ec->cipher = cipher;
     if (key) {
@@ -234,14 +234,15 @@ int CMS_EncryptedData_set1_key(CMS_ContentInfo *cms, const EVP_CIPHER *ciph,
         return 0;
     }
     ec = cms->d.encryptedData->encryptedContentInfo;
-    return cms_EncryptedContent_init(ec, ciph, key, keylen, cms_get0_cmsctx(cms));
+    return ossl_cms_EncryptedContent_init(ec, ciph, key, keylen,
+                                          ossl_cms_get0_cmsctx(cms));
 }
 
-BIO *cms_EncryptedData_init_bio(const CMS_ContentInfo *cms)
+BIO *ossl_cms_EncryptedData_init_bio(const CMS_ContentInfo *cms)
 {
     CMS_EncryptedData *enc = cms->d.encryptedData;
     if (enc->encryptedContentInfo->cipher && enc->unprotectedAttrs)
         enc->version = 2;
-    return cms_EncryptedContent_init_bio(enc->encryptedContentInfo,
-                                         cms_get0_cmsctx(cms));
+    return ossl_cms_EncryptedContent_init_bio(enc->encryptedContentInfo,
+                                              ossl_cms_get0_cmsctx(cms));
 }

--- a/crypto/cms/cms_ess.c
+++ b/crypto/cms/cms_ess.c
@@ -52,18 +52,19 @@ int CMS_get1_ReceiptRequest(CMS_SignerInfo *si, CMS_ReceiptRequest **prr)
     the |cert_ids|(Hash+IssuerID) list from this ESS_SIGNING_CERT.
     Derived from ts_check_signing_certs()
 */
-int ess_check_signing_certs(CMS_SignerInfo *si, STACK_OF(X509) *chain)
+int ossl_ess_check_signing_certs(CMS_SignerInfo *si, STACK_OF(X509) *chain)
 {
     ESS_SIGNING_CERT *ss = NULL;
     ESS_SIGNING_CERT_V2 *ssv2 = NULL;
     X509 *cert;
     int i = 0, ret = 0;
 
-    if (cms_signerinfo_get_signing_cert(si, &ss) > 0 && ss->cert_ids != NULL) {
+    if (ossl_cms_signerinfo_get_signing_cert(si, &ss) > 0
+            && ss->cert_ids != NULL) {
         STACK_OF(ESS_CERT_ID) *cert_ids = ss->cert_ids;
 
         cert = sk_X509_value(chain, 0);
-        if (ess_find_cert(cert_ids, cert) != 0)
+        if (ossl_ess_find_cert(cert_ids, cert) != 0)
             goto err;
 
         /*
@@ -74,16 +75,16 @@ int ess_check_signing_certs(CMS_SignerInfo *si, STACK_OF(X509) *chain)
             /* for each chain cert, try to find its cert id */
             for (i = 1; i < sk_X509_num(chain); ++i) {
                 cert = sk_X509_value(chain, i);
-                if (ess_find_cert(cert_ids, cert) < 0)
+                if (ossl_ess_find_cert(cert_ids, cert) < 0)
                     goto err;
             }
         }
-    } else if (cms_signerinfo_get_signing_cert_v2(si, &ssv2) > 0
+    } else if (ossl_cms_signerinfo_get_signing_cert_v2(si, &ssv2) > 0
                    && ssv2->cert_ids!= NULL) {
         STACK_OF(ESS_CERT_ID_V2) *cert_ids_v2 = ssv2->cert_ids;
 
         cert = sk_X509_value(chain, 0);
-        if (ess_find_cert_v2(cert_ids_v2, cert) != 0)
+        if (ossl_ess_find_cert_v2(cert_ids_v2, cert) != 0)
             goto err;
 
         /*
@@ -94,7 +95,7 @@ int ess_check_signing_certs(CMS_SignerInfo *si, STACK_OF(X509) *chain)
             /* for each chain cert, try to find its cert id */
             for (i = 1; i < sk_X509_num(chain); ++i) {
                 cert = sk_X509_value(chain, i);
-                if (ess_find_cert_v2(cert_ids_v2, cert) < 0)
+                if (ossl_ess_find_cert_v2(cert_ids_v2, cert) < 0)
                     goto err;
             }
         }
@@ -220,15 +221,15 @@ static int cms_msgSigDigest(CMS_SignerInfo *si,
         return 0;
     if (!asn1_item_digest_ex(ASN1_ITEM_rptr(CMS_Attributes_Verify), md,
                              si->signedAttrs, dig, diglen,
-                             cms_ctx_get0_libctx(si->cms_ctx),
-                             cms_ctx_get0_propq(si->cms_ctx)))
+                             ossl_cms_ctx_get0_libctx(si->cms_ctx),
+                             ossl_cms_ctx_get0_propq(si->cms_ctx)))
         return 0;
     return 1;
 }
 
 /* Add a msgSigDigest attribute to a SignerInfo */
 
-int cms_msgSigDigest_add1(CMS_SignerInfo *dest, CMS_SignerInfo *src)
+int ossl_cms_msgSigDigest_add1(CMS_SignerInfo *dest, CMS_SignerInfo *src)
 {
     unsigned char dig[EVP_MAX_MD_SIZE];
     unsigned int diglen;
@@ -247,7 +248,7 @@ int cms_msgSigDigest_add1(CMS_SignerInfo *dest, CMS_SignerInfo *src)
 
 /* Verify signed receipt after it has already passed normal CMS verify */
 
-int cms_Receipt_verify(CMS_ContentInfo *cms, CMS_ContentInfo *req_cms)
+int ossl_cms_Receipt_verify(CMS_ContentInfo *cms, CMS_ContentInfo *req_cms)
 {
     int r = 0, i;
     CMS_ReceiptRequest *rr = NULL;
@@ -376,7 +377,7 @@ int cms_Receipt_verify(CMS_ContentInfo *cms, CMS_ContentInfo *req_cms)
  * SignedData ContentInfo.
  */
 
-ASN1_OCTET_STRING *cms_encode_Receipt(CMS_SignerInfo *si)
+ASN1_OCTET_STRING *ossl_cms_encode_Receipt(CMS_SignerInfo *si)
 {
     CMS_Receipt rct;
     CMS_ReceiptRequest *rr = NULL;
@@ -418,7 +419,7 @@ ASN1_OCTET_STRING *cms_encode_Receipt(CMS_SignerInfo *si)
  * Add signer certificate's V2 digest |sc| to a SignerInfo structure |si|
  */
 
-int cms_add1_signing_cert_v2(CMS_SignerInfo *si, ESS_SIGNING_CERT_V2 *sc)
+int ossl_cms_add1_signing_cert_v2(CMS_SignerInfo *si, ESS_SIGNING_CERT_V2 *sc)
 {
     ASN1_STRING *seq = NULL;
     unsigned char *p, *pp = NULL;
@@ -450,7 +451,7 @@ int cms_add1_signing_cert_v2(CMS_SignerInfo *si, ESS_SIGNING_CERT_V2 *sc)
  * Add signer certificate's digest |sc| to a SignerInfo structure |si|
  */
 
-int cms_add1_signing_cert(CMS_SignerInfo *si, ESS_SIGNING_CERT *sc)
+int ossl_cms_add1_signing_cert(CMS_SignerInfo *si, ESS_SIGNING_CERT *sc)
 {
     ASN1_STRING *seq = NULL;
     unsigned char *p, *pp = NULL;

--- a/crypto/cms/cms_io.c
+++ b/crypto/cms/cms_io.c
@@ -39,7 +39,7 @@ CMS_ContentInfo *d2i_CMS_bio(BIO *bp, CMS_ContentInfo **cms)
 
     ci = ASN1_item_d2i_bio(ASN1_ITEM_rptr(CMS_ContentInfo), bp, cms);
     if (ci != NULL)
-        cms_resolve_libctx(ci);
+        ossl_cms_resolve_libctx(ci);
     return ci;
 }
 
@@ -76,7 +76,7 @@ int SMIME_write_CMS(BIO *bio, CMS_ContentInfo *cms, BIO *data, int flags)
     STACK_OF(X509_ALGOR) *mdalgs;
     int ctype_nid = OBJ_obj2nid(cms->contentType);
     int econt_nid = OBJ_obj2nid(CMS_get0_eContentType(cms));
-    const CMS_CTX *ctx = cms_get0_cmsctx(cms);
+    const CMS_CTX *ctx = ossl_cms_get0_cmsctx(cms);
 
     if (ctype_nid == NID_pkcs7_signed)
         mdalgs = cms->d.signedData->digestAlgorithms;
@@ -86,8 +86,8 @@ int SMIME_write_CMS(BIO *bio, CMS_ContentInfo *cms, BIO *data, int flags)
     return SMIME_write_ASN1_ex(bio, (ASN1_VALUE *)cms, data, flags, ctype_nid,
                                econt_nid, mdalgs,
                                ASN1_ITEM_rptr(CMS_ContentInfo),
-                               cms_ctx_get0_libctx(ctx),
-                               cms_ctx_get0_propq(ctx));
+                               ossl_cms_ctx_get0_libctx(ctx),
+                               ossl_cms_ctx_get0_propq(ctx));
 }
 
 CMS_ContentInfo *SMIME_read_CMS_ex(BIO *bio, BIO **bcont, CMS_ContentInfo **cms)
@@ -98,7 +98,7 @@ CMS_ContentInfo *SMIME_read_CMS_ex(BIO *bio, BIO **bcont, CMS_ContentInfo **cms)
                                                ASN1_ITEM_rptr(CMS_ContentInfo),
                                                (ASN1_VALUE **)cms);
     if (ci != NULL)
-        cms_resolve_libctx(ci);
+        ossl_cms_resolve_libctx(ci);
     return ci;
 }
 

--- a/crypto/cms/cms_kari.c
+++ b/crypto/cms/cms_kari.c
@@ -104,9 +104,9 @@ int CMS_RecipientInfo_kari_orig_id_cmp(CMS_RecipientInfo *ri, X509 *cert)
     }
     oik = ri->d.kari->originator;
     if (oik->type == CMS_OIK_ISSUER_SERIAL)
-        return cms_ias_cert_cmp(oik->d.issuerAndSerialNumber, cert);
+        return ossl_cms_ias_cert_cmp(oik->d.issuerAndSerialNumber, cert);
     else if (oik->type == CMS_OIK_KEYIDENTIFIER)
-        return cms_keyid_cert_cmp(oik->d.subjectKeyIdentifier, cert);
+        return ossl_cms_keyid_cert_cmp(oik->d.subjectKeyIdentifier, cert);
     return -1;
 }
 
@@ -151,14 +151,16 @@ int CMS_RecipientEncryptedKey_cert_cmp(CMS_RecipientEncryptedKey *rek,
     CMS_KeyAgreeRecipientIdentifier *rid = rek->rid;
 
     if (rid->type == CMS_REK_ISSUER_SERIAL)
-        return cms_ias_cert_cmp(rid->d.issuerAndSerialNumber, cert);
+        return ossl_cms_ias_cert_cmp(rid->d.issuerAndSerialNumber, cert);
     else if (rid->type == CMS_REK_KEYIDENTIFIER)
-        return cms_keyid_cert_cmp(rid->d.rKeyId->subjectKeyIdentifier, cert);
+        return ossl_cms_keyid_cert_cmp(rid->d.rKeyId->subjectKeyIdentifier,
+                                       cert);
     else
         return -1;
 }
 
-int CMS_RecipientInfo_kari_set0_pkey_and_peer(CMS_RecipientInfo *ri, EVP_PKEY *pk, X509 *peer)
+int CMS_RecipientInfo_kari_set0_pkey_and_peer(CMS_RecipientInfo *ri,
+                                              EVP_PKEY *pk, X509 *peer)
 {
     EVP_PKEY_CTX *pctx;
     CMS_KeyAgreeRecipientInfo *kari = ri->d.kari;
@@ -168,8 +170,9 @@ int CMS_RecipientInfo_kari_set0_pkey_and_peer(CMS_RecipientInfo *ri, EVP_PKEY *p
     if (pk == NULL)
         return 1;
 
-    pctx = EVP_PKEY_CTX_new_from_pkey(cms_ctx_get0_libctx(kari->cms_ctx), pk,
-                                      cms_ctx_get0_propq(kari->cms_ctx));
+    pctx = EVP_PKEY_CTX_new_from_pkey(ossl_cms_ctx_get0_libctx(kari->cms_ctx),
+                                      pk,
+                                      ossl_cms_ctx_get0_propq(kari->cms_ctx));
     if (pctx == NULL || EVP_PKEY_derive_init(pctx) <= 0)
         goto err;
 
@@ -260,12 +263,12 @@ int CMS_RecipientInfo_kari_decrypt(CMS_ContentInfo *cms,
     enckeylen = rek->encryptedKey->length;
     enckey = rek->encryptedKey->data;
     /* Setup all parameters to derive KEK */
-    if (!cms_env_asn1_ctrl(ri, 1))
+    if (!ossl_cms_env_asn1_ctrl(ri, 1))
         goto err;
     /* Attempt to decrypt CEK */
     if (!cms_kek_cipher(&cek, &ceklen, enckey, enckeylen, ri->d.kari, 0))
         goto err;
-    ec = cms_get0_env_enc_content(cms);
+    ec = ossl_cms_get0_env_enc_content(cms);
     OPENSSL_clear_free(ec->key, ec->keylen);
     ec->key = cek;
     ec->keylen = ceklen;
@@ -284,8 +287,8 @@ static int cms_kari_create_ephemeral_key(CMS_KeyAgreeRecipientInfo *kari,
     EVP_PKEY *ekey = NULL;
     int rv = 0;
     const CMS_CTX *ctx = kari->cms_ctx;
-    OSSL_LIB_CTX *libctx = cms_ctx_get0_libctx(ctx);
-    const char *propq = cms_ctx_get0_propq(ctx);
+    OSSL_LIB_CTX *libctx = ossl_cms_ctx_get0_libctx(ctx);
+    const char *propq = ossl_cms_ctx_get0_propq(ctx);
 
     pctx = EVP_PKEY_CTX_new_from_pkey(libctx, pk, propq);
     if (pctx == NULL)
@@ -317,9 +320,9 @@ static int cms_kari_set_originator_private_key(CMS_KeyAgreeRecipientInfo *kari,
     int rv = 0;
     const CMS_CTX *ctx = kari->cms_ctx;
 
-    pctx = EVP_PKEY_CTX_new_from_pkey(cms_ctx_get0_libctx(ctx),
+    pctx = EVP_PKEY_CTX_new_from_pkey(ossl_cms_ctx_get0_libctx(ctx),
                                       originatorPrivKey,
-                                      cms_ctx_get0_propq(ctx));
+                                      ossl_cms_ctx_get0_propq(ctx));
     if (pctx == NULL)
         goto err;
     if (EVP_PKEY_derive_init(pctx) <= 0)
@@ -335,10 +338,10 @@ static int cms_kari_set_originator_private_key(CMS_KeyAgreeRecipientInfo *kari,
 
 /* Initialise a kari based on passed certificate and key */
 
-int cms_RecipientInfo_kari_init(CMS_RecipientInfo *ri,  X509 *recip,
-                                EVP_PKEY *recipPubKey, X509 *originator,
-                                EVP_PKEY *originatorPrivKey, unsigned int flags,
-                                const CMS_CTX *ctx)
+int ossl_cms_RecipientInfo_kari_init(CMS_RecipientInfo *ri,  X509 *recip,
+                                     EVP_PKEY *recipPubKey, X509 *originator,
+                                     EVP_PKEY *originatorPrivKey,
+                                     unsigned int flags, const CMS_CTX *ctx)
 {
     CMS_KeyAgreeRecipientInfo *kari;
     CMS_RecipientEncryptedKey *rek = NULL;
@@ -366,11 +369,11 @@ int cms_RecipientInfo_kari_init(CMS_RecipientInfo *ri,  X509 *recip,
         rek->rid->d.rKeyId = M_ASN1_new_of(CMS_RecipientKeyIdentifier);
         if (rek->rid->d.rKeyId == NULL)
             return 0;
-        if (!cms_set1_keyid(&rek->rid->d.rKeyId->subjectKeyIdentifier, recip))
+        if (!ossl_cms_set1_keyid(&rek->rid->d.rKeyId->subjectKeyIdentifier, recip))
             return 0;
     } else {
         rek->rid->type = CMS_REK_ISSUER_SERIAL;
-        if (!cms_set1_ias(&rek->rid->d.issuerAndSerialNumber, recip))
+        if (!ossl_cms_set1_ias(&rek->rid->d.issuerAndSerialNumber, recip))
             return 0;
     }
 
@@ -390,11 +393,11 @@ int cms_RecipientInfo_kari_init(CMS_RecipientInfo *ri,  X509 *recip,
              oik->d.subjectKeyIdentifier = ASN1_OCTET_STRING_new();
              if (oik->d.subjectKeyIdentifier == NULL)
                   return 0;
-             if (!cms_set1_keyid(&oik->d.subjectKeyIdentifier, originator))
+             if (!ossl_cms_set1_keyid(&oik->d.subjectKeyIdentifier, originator))
                   return 0;
         } else {
              oik->type = CMS_REK_ISSUER_SERIAL;
-             if (!cms_set1_ias(&oik->d.issuerAndSerialNumber, originator))
+             if (!ossl_cms_set1_ias(&oik->d.issuerAndSerialNumber, originator))
                   return 0;
         }
 
@@ -459,9 +462,9 @@ static int cms_wrap_init(CMS_KeyAgreeRecipientInfo *kari,
     else
         kekcipher_name = SN_id_aes256_wrap;
 enc:
-    fetched_kekcipher = EVP_CIPHER_fetch(cms_ctx_get0_libctx(cms_ctx),
+    fetched_kekcipher = EVP_CIPHER_fetch(ossl_cms_ctx_get0_libctx(cms_ctx),
                                          kekcipher_name,
-                                         cms_ctx_get0_propq(cms_ctx));
+                                         ossl_cms_ctx_get0_propq(cms_ctx));
     if (fetched_kekcipher == NULL)
         return 0;
     ret = EVP_EncryptInit_ex(ctx, fetched_kekcipher, NULL, NULL, NULL);
@@ -471,8 +474,8 @@ enc:
 
 /* Encrypt content key in key agreement recipient info */
 
-int cms_RecipientInfo_kari_encrypt(const CMS_ContentInfo *cms,
-                                   CMS_RecipientInfo *ri)
+int ossl_cms_RecipientInfo_kari_encrypt(const CMS_ContentInfo *cms,
+                                        CMS_RecipientInfo *ri)
 {
     CMS_KeyAgreeRecipientInfo *kari;
     CMS_EncryptedContentInfo *ec;
@@ -486,7 +489,7 @@ int cms_RecipientInfo_kari_encrypt(const CMS_ContentInfo *cms,
     }
     kari = ri->d.kari;
     reks = kari->recipientEncryptedKeys;
-    ec = cms_get0_env_enc_content(cms);
+    ec = ossl_cms_get0_env_enc_content(cms);
     /* Initialise wrap algorithm parameters */
     if (!cms_wrap_init(kari, ec->cipher))
         return 0;
@@ -502,7 +505,7 @@ int cms_RecipientInfo_kari_encrypt(const CMS_ContentInfo *cms,
             return 0;
     }
     /* Initialise KDF algorithm */
-    if (!cms_env_asn1_ctrl(ri, 0))
+    if (!ossl_cms_env_asn1_ctrl(ri, 0))
         return 0;
     /* For each rek, derive KEK, encrypt CEK */
     for (i = 0; i < sk_CMS_RecipientEncryptedKey_num(reks); i++) {

--- a/crypto/cms/cms_local.h
+++ b/crypto/cms/cms_local.h
@@ -388,96 +388,98 @@ DECLARE_ASN1_ALLOC_FUNCTIONS(CMS_IssuerAndSerialNumber)
 # define CMS_OIK_KEYIDENTIFIER           1
 # define CMS_OIK_PUBKEY                  2
 
-BIO *cms_content_bio(CMS_ContentInfo *cms);
-const CMS_CTX *cms_get0_cmsctx(const CMS_ContentInfo *cms);
-OSSL_LIB_CTX *cms_ctx_get0_libctx(const CMS_CTX *ctx);
-const char *cms_ctx_get0_propq(const CMS_CTX *ctx);
-void cms_resolve_libctx(CMS_ContentInfo *ci);
+BIO *ossl_cms_content_bio(CMS_ContentInfo *cms);
+const CMS_CTX *ossl_cms_get0_cmsctx(const CMS_ContentInfo *cms);
+OSSL_LIB_CTX *ossl_cms_ctx_get0_libctx(const CMS_CTX *ctx);
+const char *ossl_cms_ctx_get0_propq(const CMS_CTX *ctx);
+void ossl_cms_resolve_libctx(CMS_ContentInfo *ci);
 
-CMS_ContentInfo *cms_Data_create(OSSL_LIB_CTX *ctx, const char *propq);
+CMS_ContentInfo *ossl_cms_Data_create(OSSL_LIB_CTX *ctx, const char *propq);
 
-CMS_ContentInfo *cms_DigestedData_create(const EVP_MD *md,
-                                         OSSL_LIB_CTX *libctx,
-                                         const char *propq);
-BIO *cms_DigestedData_init_bio(const CMS_ContentInfo *cms);
-int cms_DigestedData_do_final(const CMS_ContentInfo *cms,
-                              BIO *chain, int verify);
+CMS_ContentInfo *ossl_cms_DigestedData_create(const EVP_MD *md,
+                                              OSSL_LIB_CTX *libctx,
+                                              const char *propq);
+BIO *ossl_cms_DigestedData_init_bio(const CMS_ContentInfo *cms);
+int ossl_cms_DigestedData_do_final(const CMS_ContentInfo *cms,
+                                   BIO *chain, int verify);
 
-BIO *cms_SignedData_init_bio(CMS_ContentInfo *cms);
-int cms_SignedData_final(CMS_ContentInfo *cms, BIO *chain);
-int cms_set1_SignerIdentifier(CMS_SignerIdentifier *sid, X509 *cert,
-                              int type, const CMS_CTX *ctx);
-int cms_SignerIdentifier_get0_signer_id(CMS_SignerIdentifier *sid,
-                                        ASN1_OCTET_STRING **keyid,
-                                        X509_NAME **issuer,
-                                        ASN1_INTEGER **sno);
-int cms_SignerIdentifier_cert_cmp(CMS_SignerIdentifier *sid, X509 *cert);
+BIO *ossl_cms_SignedData_init_bio(CMS_ContentInfo *cms);
+int ossl_cms_SignedData_final(CMS_ContentInfo *cms, BIO *chain);
+int ossl_cms_set1_SignerIdentifier(CMS_SignerIdentifier *sid, X509 *cert,
+                                   int type, const CMS_CTX *ctx);
+int ossl_cms_SignerIdentifier_get0_signer_id(CMS_SignerIdentifier *sid,
+                                             ASN1_OCTET_STRING **keyid,
+                                             X509_NAME **issuer,
+                                             ASN1_INTEGER **sno);
+int ossl_cms_SignerIdentifier_cert_cmp(CMS_SignerIdentifier *sid, X509 *cert);
 
-CMS_ContentInfo *cms_CompressedData_create(int comp_nid, OSSL_LIB_CTX *libctx,
-                                           const char *propq);
-BIO *cms_CompressedData_init_bio(const CMS_ContentInfo *cms);
+CMS_ContentInfo *ossl_cms_CompressedData_create(int comp_nid,
+                                                OSSL_LIB_CTX *libctx,
+                                                const char *propq);
+BIO *ossl_cms_CompressedData_init_bio(const CMS_ContentInfo *cms);
 
-BIO *cms_DigestAlgorithm_init_bio(X509_ALGOR *digestAlgorithm,
-                                  const CMS_CTX *ctx);
-int cms_DigestAlgorithm_find_ctx(EVP_MD_CTX *mctx, BIO *chain,
-                                 X509_ALGOR *mdalg);
+BIO *ossl_cms_DigestAlgorithm_init_bio(X509_ALGOR *digestAlgorithm,
+                                       const CMS_CTX *ctx);
+int ossl_cms_DigestAlgorithm_find_ctx(EVP_MD_CTX *mctx, BIO *chain,
+                                      X509_ALGOR *mdalg);
 
-int cms_ias_cert_cmp(CMS_IssuerAndSerialNumber *ias, X509 *cert);
-int cms_keyid_cert_cmp(ASN1_OCTET_STRING *keyid, X509 *cert);
-int cms_set1_ias(CMS_IssuerAndSerialNumber **pias, X509 *cert);
-int cms_set1_keyid(ASN1_OCTET_STRING **pkeyid, X509 *cert);
+int ossl_cms_ias_cert_cmp(CMS_IssuerAndSerialNumber *ias, X509 *cert);
+int ossl_cms_keyid_cert_cmp(ASN1_OCTET_STRING *keyid, X509 *cert);
+int ossl_cms_set1_ias(CMS_IssuerAndSerialNumber **pias, X509 *cert);
+int ossl_cms_set1_keyid(ASN1_OCTET_STRING **pkeyid, X509 *cert);
 
-BIO *cms_EncryptedContent_init_bio(CMS_EncryptedContentInfo *ec,
+BIO *ossl_cms_EncryptedContent_init_bio(CMS_EncryptedContentInfo *ec,
+                                        const CMS_CTX *ctx);
+BIO *ossl_cms_EncryptedData_init_bio(const CMS_ContentInfo *cms);
+int ossl_cms_EncryptedContent_init(CMS_EncryptedContentInfo *ec,
+                                   const EVP_CIPHER *cipher,
+                                   const unsigned char *key, size_t keylen,
                                    const CMS_CTX *ctx);
-BIO *cms_EncryptedData_init_bio(const CMS_ContentInfo *cms);
-int cms_EncryptedContent_init(CMS_EncryptedContentInfo *ec,
-                              const EVP_CIPHER *cipher,
-                              const unsigned char *key, size_t keylen,
-                              const CMS_CTX *ctx);
 
-int cms_Receipt_verify(CMS_ContentInfo *cms, CMS_ContentInfo *req_cms);
-int cms_msgSigDigest_add1(CMS_SignerInfo *dest, CMS_SignerInfo *src);
-ASN1_OCTET_STRING *cms_encode_Receipt(CMS_SignerInfo *si);
+int ossl_cms_Receipt_verify(CMS_ContentInfo *cms, CMS_ContentInfo *req_cms);
+int ossl_cms_msgSigDigest_add1(CMS_SignerInfo *dest, CMS_SignerInfo *src);
+ASN1_OCTET_STRING *ossl_cms_encode_Receipt(CMS_SignerInfo *si);
 
-BIO *cms_EnvelopedData_init_bio(CMS_ContentInfo *cms);
-int cms_EnvelopedData_final(CMS_ContentInfo *cms, BIO *chain);
-BIO *cms_AuthEnvelopedData_init_bio(CMS_ContentInfo *cms);
-int cms_AuthEnvelopedData_final(CMS_ContentInfo *cms, BIO *cmsbio);
-CMS_EnvelopedData *cms_get0_enveloped(CMS_ContentInfo *cms);
-CMS_AuthEnvelopedData *cms_get0_auth_enveloped(CMS_ContentInfo *cms);
-CMS_EncryptedContentInfo* cms_get0_env_enc_content(const CMS_ContentInfo *cms);
+BIO *ossl_cms_EnvelopedData_init_bio(CMS_ContentInfo *cms);
+int ossl_cms_EnvelopedData_final(CMS_ContentInfo *cms, BIO *chain);
+BIO *ossl_cms_AuthEnvelopedData_init_bio(CMS_ContentInfo *cms);
+int ossl_cms_AuthEnvelopedData_final(CMS_ContentInfo *cms, BIO *cmsbio);
+CMS_EnvelopedData *ossl_cms_get0_enveloped(CMS_ContentInfo *cms);
+CMS_AuthEnvelopedData *ossl_cms_get0_auth_enveloped(CMS_ContentInfo *cms);
+CMS_EncryptedContentInfo *ossl_cms_get0_env_enc_content(const CMS_ContentInfo *cms);
 
 /* RecipientInfo routines */
-int cms_env_asn1_ctrl(CMS_RecipientInfo *ri, int cmd);
-int cms_pkey_get_ri_type(EVP_PKEY *pk);
-int cms_pkey_is_ri_type_supported(EVP_PKEY *pk, int ri_type);
+int ossl_cms_env_asn1_ctrl(CMS_RecipientInfo *ri, int cmd);
+int ossl_cms_pkey_get_ri_type(EVP_PKEY *pk);
+int ossl_cms_pkey_is_ri_type_supported(EVP_PKEY *pk, int ri_type);
 
-void cms_RecipientInfos_set_cmsctx(CMS_ContentInfo *cms);
+void ossl_cms_RecipientInfos_set_cmsctx(CMS_ContentInfo *cms);
 
 /* KARI routines */
-int cms_RecipientInfo_kari_init(CMS_RecipientInfo *ri, X509 *recip,
-                                EVP_PKEY *recipPubKey, X509 *originator,
-                                EVP_PKEY *originatorPrivKey, unsigned int flags,
-                                const CMS_CTX *ctx);
-int cms_RecipientInfo_kari_encrypt(const CMS_ContentInfo *cms,
-                                   CMS_RecipientInfo *ri);
+int ossl_cms_RecipientInfo_kari_init(CMS_RecipientInfo *ri, X509 *recip,
+                                     EVP_PKEY *recipPubKey, X509 *originator,
+                                     EVP_PKEY *originatorPrivKey,
+                                     unsigned int flags,
+                                     const CMS_CTX *ctx);
+int ossl_cms_RecipientInfo_kari_encrypt(const CMS_ContentInfo *cms,
+                                        CMS_RecipientInfo *ri);
 
 /* PWRI routines */
-int cms_RecipientInfo_pwri_crypt(const CMS_ContentInfo *cms,
-                                 CMS_RecipientInfo *ri, int en_de);
+int ossl_cms_RecipientInfo_pwri_crypt(const CMS_ContentInfo *cms,
+                                      CMS_RecipientInfo *ri, int en_de);
 /* SignerInfo routines */
 int CMS_si_check_attributes(const CMS_SignerInfo *si);
-void cms_SignerInfos_set_cmsctx(CMS_ContentInfo *cms);
+void ossl_cms_SignerInfos_set_cmsctx(CMS_ContentInfo *cms);
 
 
 /* ESS routines */
-int ess_check_signing_certs(CMS_SignerInfo *si, STACK_OF(X509) *chain);
+int ossl_ess_check_signing_certs(CMS_SignerInfo *si, STACK_OF(X509) *chain);
 
-int cms_dh_envelope(CMS_RecipientInfo *ri, int decrypt);
-int cms_ecdh_envelope(CMS_RecipientInfo *ri, int decrypt);
-int cms_rsa_envelope(CMS_RecipientInfo *ri, int decrypt);
-int cms_ecdsa_dsa_sign(CMS_SignerInfo *si, int verify);
-int cms_rsa_sign(CMS_SignerInfo *si, int verify);
+int ossl_cms_dh_envelope(CMS_RecipientInfo *ri, int decrypt);
+int ossl_cms_ecdh_envelope(CMS_RecipientInfo *ri, int decrypt);
+int ossl_cms_rsa_envelope(CMS_RecipientInfo *ri, int decrypt);
+int ossl_cms_ecdsa_dsa_sign(CMS_SignerInfo *si, int verify);
+int ossl_cms_rsa_sign(CMS_SignerInfo *si, int verify);
 
 DECLARE_ASN1_ITEM(CMS_CertificateChoices)
 DECLARE_ASN1_ITEM(CMS_DigestedData)

--- a/crypto/cms/cms_pwri.c
+++ b/crypto/cms/cms_pwri.c
@@ -50,9 +50,9 @@ CMS_RecipientInfo *CMS_add0_recipient_password(CMS_ContentInfo *cms,
     X509_ALGOR *encalg = NULL;
     unsigned char iv[EVP_MAX_IV_LENGTH];
     int ivlen;
-    const CMS_CTX *cms_ctx = cms_get0_cmsctx(cms);
+    const CMS_CTX *cms_ctx = ossl_cms_get0_cmsctx(cms);
 
-    ec = cms_get0_env_enc_content(cms);
+    ec = ossl_cms_get0_env_enc_content(cms);
     if (ec == NULL)
         return NULL;
     ris = CMS_get0_RecipientInfos(cms);
@@ -93,7 +93,7 @@ CMS_RecipientInfo *CMS_add0_recipient_password(CMS_ContentInfo *cms,
     ivlen = EVP_CIPHER_CTX_iv_length(ctx);
 
     if (ivlen > 0) {
-        if (RAND_bytes_ex(cms_ctx_get0_libctx(cms_ctx), iv, ivlen) <= 0)
+        if (RAND_bytes_ex(ossl_cms_ctx_get0_libctx(cms_ctx), iv, ivlen) <= 0)
             goto err;
         if (EVP_EncryptInit_ex(ctx, NULL, NULL, NULL, iv) <= 0) {
             ERR_raise(ERR_LIB_CMS, ERR_R_EVP_LIB);
@@ -262,7 +262,7 @@ static int kek_wrap_key(unsigned char *out, size_t *outlen,
         memcpy(out + 4, in, inlen);
         /* Add random padding to end */
         if (olen > inlen + 4
-            && RAND_bytes_ex(cms_ctx_get0_libctx(cms_ctx), out + 4 + inlen,
+            && RAND_bytes_ex(ossl_cms_ctx_get0_libctx(cms_ctx), out + 4 + inlen,
                              olen - 4 - inlen) <= 0)
             return 0;
         /* Encrypt twice */
@@ -278,8 +278,8 @@ static int kek_wrap_key(unsigned char *out, size_t *outlen,
 
 /* Encrypt/Decrypt content key in PWRI recipient info */
 
-int cms_RecipientInfo_pwri_crypt(const CMS_ContentInfo *cms,
-                                 CMS_RecipientInfo *ri, int en_de)
+int ossl_cms_RecipientInfo_pwri_crypt(const CMS_ContentInfo *cms,
+                                      CMS_RecipientInfo *ri, int en_de)
 {
     CMS_EncryptedContentInfo *ec;
     CMS_PasswordRecipientInfo *pwri;
@@ -290,9 +290,9 @@ int cms_RecipientInfo_pwri_crypt(const CMS_ContentInfo *cms,
     EVP_CIPHER *kekcipher;
     unsigned char *key = NULL;
     size_t keylen;
-    const CMS_CTX *cms_ctx = cms_get0_cmsctx(cms);
+    const CMS_CTX *cms_ctx = ossl_cms_get0_cmsctx(cms);
 
-    ec = cms_get0_env_enc_content(cms);
+    ec = ossl_cms_get0_env_enc_content(cms);
 
     pwri = ri->d.pwri;
 
@@ -316,8 +316,8 @@ int cms_RecipientInfo_pwri_crypt(const CMS_ContentInfo *cms,
     }
 
     name = OBJ_nid2sn(OBJ_obj2nid(kekalg->algorithm));
-    kekcipher = EVP_CIPHER_fetch(cms_ctx_get0_libctx(cms_ctx), name,
-                                 cms_ctx_get0_propq(cms_ctx));
+    kekcipher = EVP_CIPHER_fetch(ossl_cms_ctx_get0_libctx(cms_ctx), name,
+                                 ossl_cms_ctx_get0_propq(cms_ctx));
 
     if (kekcipher == NULL) {
         ERR_raise(ERR_LIB_CMS, CMS_R_UNKNOWN_CIPHER);

--- a/crypto/cms/cms_rsa.c
+++ b/crypto/cms/cms_rsa.c
@@ -172,7 +172,7 @@ static int rsa_cms_encrypt(CMS_RecipientInfo *ri)
     return rv;
 }
 
-int cms_rsa_envelope(CMS_RecipientInfo *ri, int decrypt)
+int ossl_cms_rsa_envelope(CMS_RecipientInfo *ri, int decrypt)
 {
     assert(decrypt == 0 || decrypt == 1);
 
@@ -238,7 +238,7 @@ static int rsa_cms_verify(CMS_SignerInfo *si)
     return 0;
 }
 
-int cms_rsa_sign(CMS_SignerInfo *si, int verify)
+int ossl_cms_rsa_sign(CMS_SignerInfo *si, int verify)
 {
     assert(verify == 0 || verify == 1);
 

--- a/crypto/cms/cms_sd.c
+++ b/crypto/cms/cms_sd.c
@@ -175,17 +175,17 @@ static int cms_copy_messageDigest(CMS_ContentInfo *cms, CMS_SignerInfo *si)
     return 0;
 }
 
-int cms_set1_SignerIdentifier(CMS_SignerIdentifier *sid, X509 *cert, int type,
-                              const CMS_CTX *ctx)
+int ossl_cms_set1_SignerIdentifier(CMS_SignerIdentifier *sid, X509 *cert,
+                                   int type, const CMS_CTX *ctx)
 {
     switch (type) {
     case CMS_SIGNERINFO_ISSUER_SERIAL:
-        if (!cms_set1_ias(&sid->d.issuerAndSerialNumber, cert))
+        if (!ossl_cms_set1_ias(&sid->d.issuerAndSerialNumber, cert))
             return 0;
         break;
 
     case CMS_SIGNERINFO_KEYIDENTIFIER:
-        if (!cms_set1_keyid(&sid->d.subjectKeyIdentifier, cert))
+        if (!ossl_cms_set1_keyid(&sid->d.subjectKeyIdentifier, cert))
             return 0;
         break;
 
@@ -199,10 +199,10 @@ int cms_set1_SignerIdentifier(CMS_SignerIdentifier *sid, X509 *cert, int type,
     return 1;
 }
 
-int cms_SignerIdentifier_get0_signer_id(CMS_SignerIdentifier *sid,
-                                        ASN1_OCTET_STRING **keyid,
-                                        X509_NAME **issuer,
-                                        ASN1_INTEGER **sno)
+int ossl_cms_SignerIdentifier_get0_signer_id(CMS_SignerIdentifier *sid,
+                                             ASN1_OCTET_STRING **keyid,
+                                             X509_NAME **issuer,
+                                             ASN1_INTEGER **sno)
 {
     if (sid->type == CMS_SIGNERINFO_ISSUER_SERIAL) {
         if (issuer)
@@ -217,12 +217,12 @@ int cms_SignerIdentifier_get0_signer_id(CMS_SignerIdentifier *sid,
     return 1;
 }
 
-int cms_SignerIdentifier_cert_cmp(CMS_SignerIdentifier *sid, X509 *cert)
+int ossl_cms_SignerIdentifier_cert_cmp(CMS_SignerIdentifier *sid, X509 *cert)
 {
     if (sid->type == CMS_SIGNERINFO_ISSUER_SERIAL)
-        return cms_ias_cert_cmp(sid->d.issuerAndSerialNumber, cert);
+        return ossl_cms_ias_cert_cmp(sid->d.issuerAndSerialNumber, cert);
     else if (sid->type == CMS_SIGNERINFO_KEYIDENTIFIER)
-        return cms_keyid_cert_cmp(sid->d.subjectKeyIdentifier, cert);
+        return ossl_cms_keyid_cert_cmp(sid->d.subjectKeyIdentifier, cert);
     else
         return -1;
 }
@@ -233,9 +233,9 @@ static int cms_sd_asn1_ctrl(CMS_SignerInfo *si, int cmd)
     int i;
 
     if (EVP_PKEY_is_a(pkey, "DSA") || EVP_PKEY_is_a(pkey, "EC"))
-        return cms_ecdsa_dsa_sign(si, cmd);
+        return ossl_cms_ecdsa_dsa_sign(si, cmd);
     else if (EVP_PKEY_is_a(pkey, "RSA") || EVP_PKEY_is_a(pkey, "RSA-PSS"))
-        return cms_rsa_sign(si, cmd);
+        return ossl_cms_rsa_sign(si, cmd);
 
     /* Something else? We'll give engines etc a chance to handle this */
     if (pkey->ameth == NULL || pkey->ameth->pkey_ctrl == NULL)
@@ -260,7 +260,7 @@ CMS_SignerInfo *CMS_add1_signer(CMS_ContentInfo *cms,
     CMS_SignerInfo *si = NULL;
     X509_ALGOR *alg;
     int i, type;
-    const CMS_CTX *ctx = cms_get0_cmsctx(cms);
+    const CMS_CTX *ctx = ossl_cms_get0_cmsctx(cms);
 
     if (!X509_check_private_key(signer, pk)) {
         ERR_raise(ERR_LIB_CMS, CMS_R_PRIVATE_KEY_DOES_NOT_MATCH_CERTIFICATE);
@@ -299,7 +299,7 @@ CMS_SignerInfo *CMS_add1_signer(CMS_ContentInfo *cms,
         si->version = 1;
     }
 
-    if (!cms_set1_SignerIdentifier(si->sid, signer, type, ctx))
+    if (!ossl_cms_set1_SignerIdentifier(si->sid, signer, type, ctx))
         goto err;
 
     if (md == NULL) {
@@ -373,16 +373,16 @@ CMS_SignerInfo *CMS_add1_signer(CMS_ContentInfo *cms,
             int add_sc;
 
             if (md == EVP_sha1() || md == NULL) {
-                if ((sc = ESS_SIGNING_CERT_new_init(signer,
-                                                    NULL, 1)) == NULL)
+                if ((sc = ossl_ess_signing_cert_new_init(signer,
+                                                         NULL, 1)) == NULL)
                     goto err;
-                add_sc = cms_add1_signing_cert(si, sc);
+                add_sc = ossl_cms_add1_signing_cert(si, sc);
                 ESS_SIGNING_CERT_free(sc);
             } else {
-                if ((sc2 = ESS_SIGNING_CERT_V2_new_init(md, signer,
-                                                        NULL, 1)) == NULL)
+                if ((sc2 = ossl_ess_signing_cert_v2_new_init(md, signer,
+                                                             NULL, 1)) == NULL)
                     goto err;
-                add_sc = cms_add1_signing_cert_v2(si, sc2);
+                add_sc = ossl_cms_add1_signing_cert_v2(si, sc2);
                 ESS_SIGNING_CERT_V2_free(sc2);
             }
             if (!add_sc)
@@ -407,9 +407,9 @@ CMS_SignerInfo *CMS_add1_signer(CMS_ContentInfo *cms,
 
     if (flags & CMS_KEY_PARAM) {
         if (flags & CMS_NOATTR) {
-            si->pctx = EVP_PKEY_CTX_new_from_pkey(cms_ctx_get0_libctx(ctx),
+            si->pctx = EVP_PKEY_CTX_new_from_pkey(ossl_cms_ctx_get0_libctx(ctx),
                                                   si->pkey,
-                                                  cms_ctx_get0_propq(ctx));
+                                                  ossl_cms_ctx_get0_propq(ctx));
             if (si->pctx == NULL)
                 goto err;
             if (EVP_PKEY_sign_init(si->pctx) <= 0)
@@ -417,8 +417,9 @@ CMS_SignerInfo *CMS_add1_signer(CMS_ContentInfo *cms,
             if (EVP_PKEY_CTX_set_signature_md(si->pctx, md) <= 0)
                 goto err;
         } else if (EVP_DigestSignInit_ex(si->mctx, &si->pctx, EVP_MD_name(md),
-                                         cms_ctx_get0_libctx(ctx),
-                                         cms_ctx_get0_propq(ctx), pk) <= 0) {
+                                         ossl_cms_ctx_get0_libctx(ctx),
+                                         ossl_cms_ctx_get0_propq(ctx),
+                                         pk) <= 0) {
             goto err;
         }
     }
@@ -438,12 +439,12 @@ CMS_SignerInfo *CMS_add1_signer(CMS_ContentInfo *cms,
 
 }
 
-void cms_SignerInfos_set_cmsctx(CMS_ContentInfo *cms)
+void ossl_cms_SignerInfos_set_cmsctx(CMS_ContentInfo *cms)
 {
     int i;
     CMS_SignerInfo *si;
     STACK_OF(CMS_SignerInfo) *sinfos = CMS_get0_SignerInfos(cms);
-    const CMS_CTX *ctx = cms_get0_cmsctx(cms);
+    const CMS_CTX *ctx = ossl_cms_get0_cmsctx(cms);
 
     for (i = 0; i < sk_CMS_SignerInfo_num(sinfos); i++) {
         si = sk_CMS_SignerInfo_value(sinfos, i);
@@ -534,12 +535,12 @@ int CMS_SignerInfo_get0_signer_id(CMS_SignerInfo *si,
                                   ASN1_OCTET_STRING **keyid,
                                   X509_NAME **issuer, ASN1_INTEGER **sno)
 {
-    return cms_SignerIdentifier_get0_signer_id(si->sid, keyid, issuer, sno);
+    return ossl_cms_SignerIdentifier_get0_signer_id(si->sid, keyid, issuer, sno);
 }
 
 int CMS_SignerInfo_cert_cmp(CMS_SignerInfo *si, X509 *cert)
 {
-    return cms_SignerIdentifier_cert_cmp(si->sid, cert);
+    return ossl_cms_SignerIdentifier_cert_cmp(si->sid, cert);
 }
 
 int CMS_set1_signers_certs(CMS_ContentInfo *cms, STACK_OF(X509) *scerts,
@@ -614,7 +615,7 @@ static int cms_SignerInfo_content_sign(CMS_ContentInfo *cms,
     EVP_MD_CTX *mctx = EVP_MD_CTX_new();
     int r = 0;
     EVP_PKEY_CTX *pctx = NULL;
-    const CMS_CTX *ctx = cms_get0_cmsctx(cms);
+    const CMS_CTX *ctx = ossl_cms_get0_cmsctx(cms);
 
     if (mctx == NULL) {
         ERR_raise(ERR_LIB_CMS, ERR_R_MALLOC_FAILURE);
@@ -626,7 +627,7 @@ static int cms_SignerInfo_content_sign(CMS_ContentInfo *cms,
         goto err;
     }
 
-    if (!cms_DigestAlgorithm_find_ctx(mctx, chain, si->digestAlgorithm))
+    if (!ossl_cms_DigestAlgorithm_find_ctx(mctx, chain, si->digestAlgorithm))
         goto err;
     /* Set SignerInfo algorithm details if we used custom parameter */
     if (si->pctx && !cms_sd_asn1_ctrl(si, 0))
@@ -681,8 +682,8 @@ static int cms_SignerInfo_content_sign(CMS_ContentInfo *cms,
             goto err;
         }
         if (!EVP_SignFinal_ex(mctx, sig, &siglen, si->pkey,
-                              cms_ctx_get0_libctx(ctx),
-                              cms_ctx_get0_propq(ctx))) {
+                              ossl_cms_ctx_get0_libctx(ctx),
+                              ossl_cms_ctx_get0_propq(ctx))) {
             ERR_raise(ERR_LIB_CMS, CMS_R_SIGNFINAL_ERROR);
             OPENSSL_free(sig);
             goto err;
@@ -699,7 +700,7 @@ static int cms_SignerInfo_content_sign(CMS_ContentInfo *cms,
 
 }
 
-int cms_SignedData_final(CMS_ContentInfo *cms, BIO *chain)
+int ossl_cms_SignedData_final(CMS_ContentInfo *cms, BIO *chain)
 {
     STACK_OF(CMS_SignerInfo) *sinfos;
     CMS_SignerInfo *si;
@@ -740,8 +741,9 @@ int CMS_SignerInfo_sign(CMS_SignerInfo *si)
         pctx = si->pctx;
     else {
         EVP_MD_CTX_reset(mctx);
-        if (EVP_DigestSignInit_ex(mctx, &pctx, md_name, cms_ctx_get0_libctx(ctx),
-                                  cms_ctx_get0_propq(ctx), si->pkey) <= 0)
+        if (EVP_DigestSignInit_ex(mctx, &pctx, md_name,
+                                  ossl_cms_ctx_get0_libctx(ctx),
+                                  ossl_cms_ctx_get0_propq(ctx), si->pkey) <= 0)
             goto err;
         si->pctx = pctx;
     }
@@ -818,8 +820,8 @@ int CMS_SignerInfo_verify(CMS_SignerInfo *si)
     const EVP_MD *md;
     EVP_MD *fetched_md = NULL;
     const CMS_CTX *ctx = si->cms_ctx;
-    OSSL_LIB_CTX *libctx = cms_ctx_get0_libctx(ctx);
-    const char *propq = cms_ctx_get0_propq(ctx);
+    OSSL_LIB_CTX *libctx = ossl_cms_ctx_get0_libctx(ctx);
+    const char *propq = ossl_cms_ctx_get0_propq(ctx);
 
     if (si->pkey == NULL) {
         ERR_raise(ERR_LIB_CMS, CMS_R_NO_PUBLIC_KEY);
@@ -879,7 +881,7 @@ int CMS_SignerInfo_verify(CMS_SignerInfo *si)
 
 /* Create a chain of digest BIOs from a CMS ContentInfo */
 
-BIO *cms_SignedData_init_bio(CMS_ContentInfo *cms)
+BIO *ossl_cms_SignedData_init_bio(CMS_ContentInfo *cms)
 {
     int i;
     CMS_SignedData *sd;
@@ -895,7 +897,8 @@ BIO *cms_SignedData_init_bio(CMS_ContentInfo *cms)
         BIO *mdbio;
 
         digestAlgorithm = sk_X509_ALGOR_value(sd->digestAlgorithms, i);
-        mdbio = cms_DigestAlgorithm_init_bio(digestAlgorithm, cms_get0_cmsctx(cms));
+        mdbio = ossl_cms_DigestAlgorithm_init_bio(digestAlgorithm,
+                                                  ossl_cms_get0_cmsctx(cms));
         if (mdbio == NULL)
             goto err;
         if (chain != NULL)
@@ -933,7 +936,7 @@ int CMS_SignerInfo_verify_content(CMS_SignerInfo *si, BIO *chain)
         }
     }
 
-    if (!cms_DigestAlgorithm_find_ctx(mctx, chain, si->digestAlgorithm))
+    if (!ossl_cms_DigestAlgorithm_find_ctx(mctx, chain, si->digestAlgorithm))
         goto err;
 
     if (EVP_DigestFinal_ex(mctx, mval, &mlen) <= 0) {
@@ -958,8 +961,9 @@ int CMS_SignerInfo_verify_content(CMS_SignerInfo *si, BIO *chain)
         const EVP_MD *md = EVP_MD_CTX_md(mctx);
         const CMS_CTX *ctx = si->cms_ctx;
 
-        pkctx = EVP_PKEY_CTX_new_from_pkey(cms_ctx_get0_libctx(ctx), si->pkey,
-                                           cms_ctx_get0_propq(ctx));
+        pkctx = EVP_PKEY_CTX_new_from_pkey(ossl_cms_ctx_get0_libctx(ctx),
+                                           si->pkey,
+                                           ossl_cms_ctx_get0_propq(ctx));
         if (pkctx == NULL)
             goto err;
         if (EVP_PKEY_verify_init(pkctx) <= 0)

--- a/crypto/ess/ess_asn1.c
+++ b/crypto/ess/ess_asn1.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2019-2021 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -65,8 +65,8 @@ IMPLEMENT_ASN1_DUP_FUNCTION(ESS_SIGNING_CERT_V2)
  * Returns < 0 if attribute is not found, 1 if found, or 
  * -1 on attribute parsing failure.
  */
-int cms_signerinfo_get_signing_cert_v2(CMS_SignerInfo *si,
-                                       ESS_SIGNING_CERT_V2 **psc)
+int ossl_cms_signerinfo_get_signing_cert_v2(CMS_SignerInfo *si,
+                                            ESS_SIGNING_CERT_V2 **psc)
 {
     ASN1_STRING *str;
     ESS_SIGNING_CERT_V2 *sc;
@@ -92,8 +92,8 @@ int cms_signerinfo_get_signing_cert_v2(CMS_SignerInfo *si,
  * Returns < 0 if attribute is not found, 1 if found, or 
  * -1 on attribute parsing failure.
  */
-int cms_signerinfo_get_signing_cert(CMS_SignerInfo *si,
-                                    ESS_SIGNING_CERT **psc)
+int ossl_cms_signerinfo_get_signing_cert(CMS_SignerInfo *si,
+                                         ESS_SIGNING_CERT **psc)
 {
     ASN1_STRING *str;
     ESS_SIGNING_CERT *sc;

--- a/crypto/ess/ess_lib.c
+++ b/crypto/ess/ess_lib.c
@@ -18,9 +18,9 @@ static ESS_CERT_ID *ESS_CERT_ID_new_init(X509 *cert, int issuer_needed);
 static ESS_CERT_ID_V2 *ESS_CERT_ID_V2_new_init(const EVP_MD *hash_alg,
                                                X509 *cert, int issuer_needed);
 
-ESS_SIGNING_CERT *ESS_SIGNING_CERT_new_init(X509 *signcert,
-                                            STACK_OF(X509) *certs,
-                                            int issuer_needed)
+ESS_SIGNING_CERT *ossl_ess_signing_cert_new_init(X509 *signcert,
+                                                 STACK_OF(X509) *certs,
+                                                 int issuer_needed)
 {
     ESS_CERT_ID *cid = NULL;
     ESS_SIGNING_CERT *sc;
@@ -96,10 +96,10 @@ static ESS_CERT_ID *ESS_CERT_ID_new_init(X509 *cert, int issuer_needed)
     return NULL;
 }
 
-ESS_SIGNING_CERT_V2 *ESS_SIGNING_CERT_V2_new_init(const EVP_MD *hash_alg,
-                                                  X509 *signcert,
-                                                  STACK_OF(X509) *certs,
-                                                  int issuer_needed)
+ESS_SIGNING_CERT_V2 *ossl_ess_signing_cert_v2_new_init(const EVP_MD *hash_alg,
+                                                       X509 *signcert,
+                                                       STACK_OF(X509) *certs,
+                                                       int issuer_needed)
 {
     ESS_CERT_ID_V2 *cid = NULL;
     ESS_SIGNING_CERT_V2 *sc;
@@ -192,7 +192,7 @@ static ESS_CERT_ID_V2 *ESS_CERT_ID_V2_new_init(const EVP_MD *hash_alg,
     return NULL;
 }
 
-ESS_SIGNING_CERT *ESS_SIGNING_CERT_get(PKCS7_SIGNER_INFO *si)
+ESS_SIGNING_CERT *ossl_ess_signing_cert_get(PKCS7_SIGNER_INFO *si)
 {
     ASN1_TYPE *attr;
     const unsigned char *p;
@@ -204,7 +204,7 @@ ESS_SIGNING_CERT *ESS_SIGNING_CERT_get(PKCS7_SIGNER_INFO *si)
     return d2i_ESS_SIGNING_CERT(NULL, &p, attr->value.sequence->length);
 }
 
-ESS_SIGNING_CERT_V2 *ESS_SIGNING_CERT_V2_get(PKCS7_SIGNER_INFO *si)
+ESS_SIGNING_CERT_V2 *ossl_ess_signing_cert_v2_get(PKCS7_SIGNER_INFO *si)
 {
     ASN1_TYPE *attr;
     const unsigned char *p;
@@ -216,7 +216,7 @@ ESS_SIGNING_CERT_V2 *ESS_SIGNING_CERT_V2_get(PKCS7_SIGNER_INFO *si)
     return d2i_ESS_SIGNING_CERT_V2(NULL, &p, attr->value.sequence->length);
 }
 
-int ESS_SIGNING_CERT_add(PKCS7_SIGNER_INFO *si, ESS_SIGNING_CERT *sc)
+int ossl_ess_signing_cert_add(PKCS7_SIGNER_INFO *si, ESS_SIGNING_CERT *sc)
 {
     ASN1_STRING *seq = NULL;
     unsigned char *p, *pp = NULL;
@@ -245,8 +245,7 @@ int ESS_SIGNING_CERT_add(PKCS7_SIGNER_INFO *si, ESS_SIGNING_CERT *sc)
     return 0;
 }
 
-int ESS_SIGNING_CERT_V2_add(PKCS7_SIGNER_INFO *si,
-                            ESS_SIGNING_CERT_V2 *sc)
+int ossl_ess_signing_cert_v2_add(PKCS7_SIGNER_INFO *si, ESS_SIGNING_CERT_V2 *sc)
 {
     ASN1_STRING *seq = NULL;
     unsigned char *p, *pp = NULL;
@@ -291,7 +290,7 @@ static int ess_issuer_serial_cmp(const ESS_ISSUER_SERIAL *is, const X509 *cert)
 }
 
 /* Returns < 0 if certificate is not found, certificate index otherwise. */
-int ess_find_cert(const STACK_OF(ESS_CERT_ID) *cert_ids, X509 *cert)
+int ossl_ess_find_cert(const STACK_OF(ESS_CERT_ID) *cert_ids, X509 *cert)
 {
     int i;
     unsigned char cert_sha1[SHA_DIGEST_LENGTH];
@@ -324,7 +323,8 @@ int ess_find_cert(const STACK_OF(ESS_CERT_ID) *cert_ids, X509 *cert)
 }
 
 /* Returns < 0 if certificate is not found, certificate index otherwise. */
-int ess_find_cert_v2(const STACK_OF(ESS_CERT_ID_V2) *cert_ids, const X509 *cert)
+int ossl_ess_find_cert_v2(const STACK_OF(ESS_CERT_ID_V2) *cert_ids,
+                          const X509 *cert)
 {
     int i;
     unsigned char cert_digest[EVP_MAX_MD_SIZE];

--- a/crypto/pkcs7/pk7_asn1.c
+++ b/crypto/pkcs7/pk7_asn1.c
@@ -69,7 +69,7 @@ PKCS7 *d2i_PKCS7(PKCS7 **a, const unsigned char **in, long len)
 
     ret = (PKCS7 *)ASN1_item_d2i((ASN1_VALUE **)a, in, len, (PKCS7_it()));
     if (ret != NULL)
-        pkcs7_resolve_libctx(ret);
+        ossl_pkcs7_resolve_libctx(ret);
     return ret;
 }
 

--- a/crypto/pkcs7/pk7_doit.c
+++ b/crypto/pkcs7/pk7_doit.c
@@ -69,8 +69,8 @@ static int pkcs7_bio_add_digest(BIO **pbio, X509_ALGOR *alg,
     name = OBJ_nid2sn(OBJ_obj2nid(alg->algorithm));
 
     (void)ERR_set_mark();
-    fetched = EVP_MD_fetch(pkcs7_ctx_get0_libctx(ctx), name,
-                           pkcs7_ctx_get0_propq(ctx));
+    fetched = EVP_MD_fetch(ossl_pkcs7_ctx_get0_libctx(ctx), name,
+                           ossl_pkcs7_ctx_get0_propq(ctx));
     if (fetched != NULL)
         md = fetched;
     else
@@ -114,8 +114,8 @@ static int pkcs7_encode_rinfo(PKCS7_RECIP_INFO *ri,
     if (pkey == NULL)
         return 0;
 
-    pctx = EVP_PKEY_CTX_new_from_pkey(pkcs7_ctx_get0_libctx(ctx), pkey,
-                                      pkcs7_ctx_get0_propq(ctx));
+    pctx = EVP_PKEY_CTX_new_from_pkey(ossl_pkcs7_ctx_get0_libctx(ctx), pkey,
+                                      ossl_pkcs7_ctx_get0_propq(ctx));
     if (pctx == NULL)
         return 0;
 
@@ -163,8 +163,8 @@ static int pkcs7_decrypt_rinfo(unsigned char **pek, int *peklen,
     int ret = -1;
     const PKCS7_CTX *ctx = ri->ctx;
 
-    pctx = EVP_PKEY_CTX_new_from_pkey(pkcs7_ctx_get0_libctx(ctx), pkey,
-                                      pkcs7_ctx_get0_propq(ctx));
+    pctx = EVP_PKEY_CTX_new_from_pkey(ossl_pkcs7_ctx_get0_libctx(ctx), pkey,
+                                      ossl_pkcs7_ctx_get0_propq(ctx));
     if (pctx == NULL)
         return -1;
 
@@ -232,9 +232,9 @@ BIO *PKCS7_dataInit(PKCS7 *p7, BIO *bio)
         ERR_raise(ERR_LIB_PKCS7, PKCS7_R_INVALID_NULL_POINTER);
         return NULL;
     }
-    p7_ctx = pkcs7_get0_ctx(p7);
-    libctx = pkcs7_ctx_get0_libctx(p7_ctx);
-    propq = pkcs7_ctx_get0_propq(p7_ctx);
+    p7_ctx = ossl_pkcs7_get0_ctx(p7);
+    libctx = ossl_pkcs7_ctx_get0_libctx(p7_ctx);
+    propq = ossl_pkcs7_ctx_get0_propq(p7_ctx);
 
     /*
      * The content field in the PKCS7 ContentInfo is optional, but that really
@@ -426,9 +426,9 @@ BIO *PKCS7_dataDecode(PKCS7 *p7, EVP_PKEY *pkey, BIO *in_bio, X509 *pcert)
         return NULL;
     }
 
-    p7_ctx = pkcs7_get0_ctx(p7);
-    libctx = pkcs7_ctx_get0_libctx(p7_ctx);
-    propq = pkcs7_ctx_get0_propq(p7_ctx);
+    p7_ctx = ossl_pkcs7_get0_ctx(p7);
+    libctx = ossl_pkcs7_ctx_get0_libctx(p7_ctx);
+    propq = ossl_pkcs7_ctx_get0_propq(p7_ctx);
 
     if (p7->d.ptr == NULL) {
         ERR_raise(ERR_LIB_PKCS7, PKCS7_R_NO_CONTENT);
@@ -744,7 +744,7 @@ int PKCS7_dataFinal(PKCS7 *p7, BIO *bio)
         return 0;
     }
 
-    p7_ctx = pkcs7_get0_ctx(p7);
+    p7_ctx = ossl_pkcs7_get0_ctx(p7);
 
     if (p7->d.ptr == NULL) {
         ERR_raise(ERR_LIB_PKCS7, PKCS7_R_NO_CONTENT);
@@ -854,8 +854,8 @@ int PKCS7_dataFinal(PKCS7 *p7, BIO *bio)
                     goto err;
 
                 if (!EVP_SignFinal_ex(ctx_tmp, abuf, &abuflen, si->pkey,
-                                      pkcs7_ctx_get0_libctx(p7_ctx),
-                                      pkcs7_ctx_get0_propq(p7_ctx))) {
+                                      ossl_pkcs7_ctx_get0_libctx(p7_ctx),
+                                      ossl_pkcs7_ctx_get0_propq(p7_ctx))) {
                     OPENSSL_free(abuf);
                     ERR_raise(ERR_LIB_PKCS7, ERR_R_EVP_LIB);
                     goto err;
@@ -927,8 +927,8 @@ int PKCS7_SIGNER_INFO_sign(PKCS7_SIGNER_INFO *si)
     }
 
     if (EVP_DigestSignInit_ex(mctx, &pctx, EVP_MD_name(md),
-                              pkcs7_ctx_get0_libctx(ctx),
-                              pkcs7_ctx_get0_propq(ctx), si->pkey) <= 0)
+                              ossl_pkcs7_ctx_get0_libctx(ctx),
+                              ossl_pkcs7_ctx_get0_propq(ctx), si->pkey) <= 0)
         goto err;
 
     /*
@@ -1073,9 +1073,9 @@ int PKCS7_signatureVerify(BIO *bio, PKCS7 *p7, PKCS7_SIGNER_INFO *si,
     STACK_OF(X509_ATTRIBUTE) *sk;
     BIO *btmp;
     EVP_PKEY *pkey;
-    const PKCS7_CTX *ctx = pkcs7_get0_ctx(p7);
-    OSSL_LIB_CTX *libctx = pkcs7_ctx_get0_libctx(ctx);
-    const char *propq = pkcs7_ctx_get0_propq(ctx);
+    const PKCS7_CTX *ctx = ossl_pkcs7_get0_ctx(p7);
+    OSSL_LIB_CTX *libctx = ossl_pkcs7_ctx_get0_libctx(ctx);
+    const char *propq = ossl_pkcs7_ctx_get0_propq(ctx);
 
     mdc_tmp = EVP_MD_CTX_new();
     if (mdc_tmp == NULL) {

--- a/crypto/pkcs7/pk7_lib.c
+++ b/crypto/pkcs7/pk7_lib.c
@@ -233,7 +233,7 @@ int PKCS7_add_signer(PKCS7 *p7, PKCS7_SIGNER_INFO *psi)
         }
     }
 
-    psi->ctx = pkcs7_get0_ctx(p7);
+    psi->ctx = ossl_pkcs7_get0_ctx(p7);
     if (!sk_PKCS7_SIGNER_INFO_push(signer_sk, psi))
         return 0;
     return 1;
@@ -425,12 +425,12 @@ static STACK_OF(PKCS7_RECIP_INFO) *pkcs7_get_recipient_info(const PKCS7 *p7)
  * Set up the library context into any loaded structure that needs it.
  * i.e loaded X509 objects.
  */
-void pkcs7_resolve_libctx(PKCS7 *p7)
+void ossl_pkcs7_resolve_libctx(PKCS7 *p7)
 {
     int i;
-    const PKCS7_CTX *ctx = pkcs7_get0_ctx(p7);
-    OSSL_LIB_CTX *libctx = pkcs7_ctx_get0_libctx(ctx);
-    const char *propq = pkcs7_ctx_get0_propq(ctx);
+    const PKCS7_CTX *ctx = ossl_pkcs7_get0_ctx(p7);
+    OSSL_LIB_CTX *libctx = ossl_pkcs7_ctx_get0_libctx(ctx);
+    const char *propq = ossl_pkcs7_ctx_get0_propq(ctx);
     STACK_OF(PKCS7_RECIP_INFO) *rinfos = pkcs7_get_recipient_info(p7);
     STACK_OF(PKCS7_SIGNER_INFO) *sinfos = PKCS7_get_signer_info(p7);
     STACK_OF(X509) *certs = pkcs7_get_signer_certs(p7);
@@ -455,16 +455,16 @@ void pkcs7_resolve_libctx(PKCS7 *p7)
     }
 }
 
-const PKCS7_CTX *pkcs7_get0_ctx(const PKCS7 *p7)
+const PKCS7_CTX *ossl_pkcs7_get0_ctx(const PKCS7 *p7)
 {
     return p7 != NULL ? &p7->ctx : NULL;
 }
 
-OSSL_LIB_CTX *pkcs7_ctx_get0_libctx(const PKCS7_CTX *ctx)
+OSSL_LIB_CTX *ossl_pkcs7_ctx_get0_libctx(const PKCS7_CTX *ctx)
 {
     return ctx != NULL ? ctx->libctx : NULL;
 }
-const char *pkcs7_ctx_get0_propq(const PKCS7_CTX *ctx)
+const char *ossl_pkcs7_ctx_get0_propq(const PKCS7_CTX *ctx)
 {
     return ctx != NULL ? ctx->propq : NULL;
 }
@@ -524,7 +524,7 @@ PKCS7_RECIP_INFO *PKCS7_add_recipient(PKCS7 *p7, X509 *x509)
         goto err;
     if (!PKCS7_add_recipient_info(p7, ri))
         goto err;
-    ri->ctx = pkcs7_get0_ctx(p7);
+    ri->ctx = ossl_pkcs7_get0_ctx(p7);
     return ri;
  err:
     PKCS7_RECIP_INFO_free(ri);
@@ -656,7 +656,7 @@ int PKCS7_set_cipher(PKCS7 *p7, const EVP_CIPHER *cipher)
     }
 
     ec->cipher = cipher;
-    ec->ctx = pkcs7_get0_ctx(p7);
+    ec->ctx = ossl_pkcs7_get0_ctx(p7);
     return 1;
 }
 

--- a/crypto/pkcs7/pk7_local.h
+++ b/crypto/pkcs7/pk7_local.h
@@ -9,6 +9,6 @@
 
 #include "crypto/pkcs7.h"
 
-const PKCS7_CTX *pkcs7_get0_ctx(const PKCS7 *p7);
-OSSL_LIB_CTX *pkcs7_ctx_get0_libctx(const PKCS7_CTX *ctx);
-const char *pkcs7_ctx_get0_propq(const PKCS7_CTX *ctx);
+const PKCS7_CTX *ossl_pkcs7_get0_ctx(const PKCS7 *p7);
+OSSL_LIB_CTX *ossl_pkcs7_ctx_get0_libctx(const PKCS7_CTX *ctx);
+const char *ossl_pkcs7_ctx_get0_propq(const PKCS7_CTX *ctx);

--- a/crypto/pkcs7/pk7_mime.c
+++ b/crypto/pkcs7/pk7_mime.c
@@ -31,7 +31,7 @@ int SMIME_write_PKCS7(BIO *bio, PKCS7 *p7, BIO *data, int flags)
 {
     STACK_OF(X509_ALGOR) *mdalgs;
     int ctype_nid = OBJ_obj2nid(p7->type);
-    const PKCS7_CTX *ctx = pkcs7_get0_ctx(p7);
+    const PKCS7_CTX *ctx = ossl_pkcs7_get0_ctx(p7);
 
     if (ctype_nid == NID_pkcs7_signed)
         mdalgs = p7->d.sign->md_algs;
@@ -42,8 +42,8 @@ int SMIME_write_PKCS7(BIO *bio, PKCS7 *p7, BIO *data, int flags)
 
     return SMIME_write_ASN1_ex(bio, (ASN1_VALUE *)p7, data, flags, ctype_nid,
                                NID_undef, mdalgs, ASN1_ITEM_rptr(PKCS7),
-                               pkcs7_ctx_get0_libctx(ctx),
-                               pkcs7_ctx_get0_propq(ctx));
+                               ossl_pkcs7_ctx_get0_libctx(ctx),
+                               ossl_pkcs7_ctx_get0_propq(ctx));
 }
 
 PKCS7 *SMIME_read_PKCS7_ex(BIO *bio, BIO **bcont, PKCS7 **p7)
@@ -53,7 +53,7 @@ PKCS7 *SMIME_read_PKCS7_ex(BIO *bio, BIO **bcont, PKCS7 **p7)
     ret = (PKCS7 *)SMIME_read_ASN1_ex(bio, bcont, ASN1_ITEM_rptr(PKCS7),
                                       (ASN1_VALUE **)p7);
     if (ret != NULL)
-        pkcs7_resolve_libctx(ret);
+        ossl_pkcs7_resolve_libctx(ret);
     return ret;
 }
 

--- a/crypto/pkcs7/pk7_smime.c
+++ b/crypto/pkcs7/pk7_smime.c
@@ -131,7 +131,7 @@ PKCS7_SIGNER_INFO *PKCS7_sign_add_signer(PKCS7 *p7, X509 *signcert,
         return NULL;
     }
 
-    si->ctx = pkcs7_get0_ctx(p7);
+    si->ctx = ossl_pkcs7_get0_ctx(p7);
     if (!(flags & PKCS7_NOCERTS)) {
         if (!PKCS7_add_certificate(p7, signcert))
             goto err;
@@ -265,9 +265,9 @@ int PKCS7_verify(PKCS7 *p7, STACK_OF(X509) *certs, X509_STORE *store,
         return 0;
 
     /* Now verify the certificates */
-    p7_ctx = pkcs7_get0_ctx(p7);
-    cert_ctx = X509_STORE_CTX_new_ex(pkcs7_ctx_get0_libctx(p7_ctx),
-                                     pkcs7_ctx_get0_propq(p7_ctx));
+    p7_ctx = ossl_pkcs7_get0_ctx(p7);
+    cert_ctx = X509_STORE_CTX_new_ex(ossl_pkcs7_ctx_get0_libctx(p7_ctx),
+                                     ossl_pkcs7_ctx_get0_propq(p7_ctx));
     if (cert_ctx == NULL)
         goto err;
     if (!(flags & PKCS7_NOVERIFY))

--- a/crypto/ts/ts_rsp_sign.c
+++ b/crypto/ts/ts_rsp_sign.c
@@ -664,20 +664,21 @@ static int ts_RESP_sign(TS_RESP_CTX *ctx)
     certs = ctx->flags & TS_ESS_CERT_ID_CHAIN ? ctx->certs : NULL;
     if (ctx->ess_cert_id_digest == NULL
         || ctx->ess_cert_id_digest == EVP_sha1()) {
-        if ((sc = ESS_SIGNING_CERT_new_init(ctx->signer_cert, certs, 0)) == NULL)
+        if ((sc = ossl_ess_signing_cert_new_init(ctx->signer_cert,
+                                                 certs, 0)) == NULL)
             goto err;
 
-        if (!ESS_SIGNING_CERT_add(si, sc)) {
+        if (!ossl_ess_signing_cert_add(si, sc)) {
             ERR_raise(ERR_LIB_TS, TS_R_ESS_ADD_SIGNING_CERT_ERROR);
             goto err;
         }
     } else {
-        sc2 = ESS_SIGNING_CERT_V2_new_init(ctx->ess_cert_id_digest,
-                                           ctx->signer_cert, certs, 0);
+        sc2 = ossl_ess_signing_cert_v2_new_init(ctx->ess_cert_id_digest,
+                                                ctx->signer_cert, certs, 0);
         if (sc2 == NULL)
             goto err;
 
-        if (!ESS_SIGNING_CERT_V2_add(si, sc2)) {
+        if (!ossl_ess_signing_cert_v2_add(si, sc2)) {
             ERR_raise(ERR_LIB_TS, TS_R_ESS_ADD_SIGNING_CERT_V2_ERROR);
             goto err;
         }

--- a/crypto/ts/ts_rsp_verify.c
+++ b/crypto/ts/ts_rsp_verify.c
@@ -197,9 +197,9 @@ end:
 static int ts_check_signing_certs(PKCS7_SIGNER_INFO *si,
                                   STACK_OF(X509) *chain)
 {
-    ESS_SIGNING_CERT *ss = ESS_SIGNING_CERT_get(si);
+    ESS_SIGNING_CERT *ss = ossl_ess_signing_cert_get(si);
     STACK_OF(ESS_CERT_ID) *cert_ids = NULL;
-    ESS_SIGNING_CERT_V2 *ssv2 = ESS_SIGNING_CERT_V2_get(si);
+    ESS_SIGNING_CERT_V2 *ssv2 = ossl_ess_signing_cert_v2_get(si);
     STACK_OF(ESS_CERT_ID_V2) *cert_ids_v2 = NULL;
     X509 *cert;
     int i = 0;
@@ -208,7 +208,7 @@ static int ts_check_signing_certs(PKCS7_SIGNER_INFO *si,
     if (ss != NULL) {
         cert_ids = ss->cert_ids;
         cert = sk_X509_value(chain, 0);
-        if (ess_find_cert(cert_ids, cert) != 0)
+        if (ossl_ess_find_cert(cert_ids, cert) != 0)
             goto err;
 
         /*
@@ -218,14 +218,14 @@ static int ts_check_signing_certs(PKCS7_SIGNER_INFO *si,
         if (sk_ESS_CERT_ID_num(cert_ids) > 1) {
             for (i = 1; i < sk_X509_num(chain); ++i) {
                 cert = sk_X509_value(chain, i);
-                if (ess_find_cert(cert_ids, cert) < 0)
+                if (ossl_ess_find_cert(cert_ids, cert) < 0)
                     goto err;
             }
         }
     } else if (ssv2 != NULL) {
         cert_ids_v2 = ssv2->cert_ids;
         cert = sk_X509_value(chain, 0);
-        if (ess_find_cert_v2(cert_ids_v2, cert) != 0)
+        if (ossl_ess_find_cert_v2(cert_ids_v2, cert) != 0)
             goto err;
 
         /*
@@ -235,7 +235,7 @@ static int ts_check_signing_certs(PKCS7_SIGNER_INFO *si,
         if (sk_ESS_CERT_ID_V2_num(cert_ids_v2) > 1) {
             for (i = 1; i < sk_X509_num(chain); ++i) {
                 cert = sk_X509_value(chain, i);
-                if (ess_find_cert_v2(cert_ids_v2, cert) < 0)
+                if (ossl_ess_find_cert_v2(cert_ids_v2, cert) < 0)
                     goto err;
             }
         }

--- a/crypto/x509/x_all.c
+++ b/crypto/x509/x_all.c
@@ -179,7 +179,7 @@ PKCS7 *d2i_PKCS7_fp(FILE *fp, PKCS7 **p7)
 
     ret = ASN1_item_d2i_fp(ASN1_ITEM_rptr(PKCS7), fp, p7);
     if (ret != NULL)
-        pkcs7_resolve_libctx(ret);
+        ossl_pkcs7_resolve_libctx(ret);
     return ret;
 }
 
@@ -195,7 +195,7 @@ PKCS7 *d2i_PKCS7_bio(BIO *bp, PKCS7 **p7)
 
     ret = ASN1_item_d2i_bio(ASN1_ITEM_rptr(PKCS7), bp, p7);
     if (ret != NULL)
-        pkcs7_resolve_libctx(ret);
+        ossl_pkcs7_resolve_libctx(ret);
     return ret;
 }
 

--- a/include/crypto/cms.h
+++ b/include/crypto/cms.h
@@ -15,13 +15,13 @@
 
 /* internal CMS-ESS related stuff */
 
-int cms_add1_signing_cert(CMS_SignerInfo *si, ESS_SIGNING_CERT *sc);
-int cms_add1_signing_cert_v2(CMS_SignerInfo *si, ESS_SIGNING_CERT_V2 *sc);
+int ossl_cms_add1_signing_cert(CMS_SignerInfo *si, ESS_SIGNING_CERT *sc);
+int ossl_cms_add1_signing_cert_v2(CMS_SignerInfo *si, ESS_SIGNING_CERT_V2 *sc);
 
-int cms_signerinfo_get_signing_cert_v2(CMS_SignerInfo *si,
-                                       ESS_SIGNING_CERT_V2 **psc);
-int cms_signerinfo_get_signing_cert(CMS_SignerInfo *si,
-                                    ESS_SIGNING_CERT **psc);
+int ossl_cms_signerinfo_get_signing_cert_v2(CMS_SignerInfo *si,
+                                            ESS_SIGNING_CERT_V2 **psc);
+int ossl_cms_signerinfo_get_signing_cert(CMS_SignerInfo *si,
+                                         ESS_SIGNING_CERT **psc);
 # endif /* OPENSSL_NO_CMS */
 
 #endif

--- a/include/crypto/ess.h
+++ b/include/crypto/ess.h
@@ -13,24 +13,25 @@
 
 /* internal ESS related stuff */
 
-ESS_SIGNING_CERT *ESS_SIGNING_CERT_get(PKCS7_SIGNER_INFO *si);
-int ESS_SIGNING_CERT_add(PKCS7_SIGNER_INFO *si, ESS_SIGNING_CERT *sc);
+ESS_SIGNING_CERT *ossl_ess_signing_cert_get(PKCS7_SIGNER_INFO *si);
+int ossl_ess_signing_cert_add(PKCS7_SIGNER_INFO *si, ESS_SIGNING_CERT *sc);
 
-ESS_SIGNING_CERT *ESS_SIGNING_CERT_new_init(X509 *signcert,
-                                            STACK_OF(X509) *certs,
-                                            int issuer_needed);
+ESS_SIGNING_CERT *ossl_ess_signing_cert_new_init(X509 *signcert,
+                                                 STACK_OF(X509) *certs,
+                                                 int issuer_needed);
 
-ESS_SIGNING_CERT_V2 *ESS_SIGNING_CERT_V2_get(PKCS7_SIGNER_INFO *si);
-int ESS_SIGNING_CERT_V2_add(PKCS7_SIGNER_INFO *si, ESS_SIGNING_CERT_V2 *sc);
+ESS_SIGNING_CERT_V2 *ossl_ess_signing_cert_v2_get(PKCS7_SIGNER_INFO *si);
+int ossl_ess_signing_cert_v2_add(PKCS7_SIGNER_INFO *si, ESS_SIGNING_CERT_V2 *sc);
 
-ESS_SIGNING_CERT_V2 *ESS_SIGNING_CERT_V2_new_init(const EVP_MD *hash_alg,
-                                                  X509 *signcert,
-                                                  STACK_OF(X509) *certs,
-                                                  int issuer_needed);
+ESS_SIGNING_CERT_V2 *ossl_ess_signing_cert_v2_new_init(const EVP_MD *hash_alg,
+                                                       X509 *signcert,
+                                                       STACK_OF(X509) *certs,
+                                                       int issuer_needed);
 
 /* Returns < 0 if certificate is not found, certificate index otherwise. */
-int ess_find_cert_v2(const STACK_OF(ESS_CERT_ID_V2) *cert_ids, const X509 *cert);
-int ess_find_cert(const STACK_OF(ESS_CERT_ID) *cert_ids, X509 *cert);
+int ossl_ess_find_cert_v2(const STACK_OF(ESS_CERT_ID_V2) *cert_ids,
+                          const X509 *cert);
+int ossl_ess_find_cert(const STACK_OF(ESS_CERT_ID) *cert_ids, X509 *cert);
 
 /*-
  * IssuerSerial ::= SEQUENCE {

--- a/include/crypto/pkcs7.h
+++ b/include/crypto/pkcs7.h
@@ -11,6 +11,6 @@
 # define OSSL_CRYPTO_PKCS7_H
 # pragma once
 
-void pkcs7_resolve_libctx(PKCS7 *p7);
+void ossl_pkcs7_resolve_libctx(PKCS7 *p7);
 
 #endif

--- a/include/openssl/symhacks.h
+++ b/include/openssl/symhacks.h
@@ -34,10 +34,6 @@
 #  undef i2d_ECPKPARAMETERS
 #  define i2d_ECPKPARAMETERS                      i2d_UC_ECPKPARAMETERS
 
-/* This one clashes with CMS_data_create */
-#  undef cms_Data_create
-#  define cms_Data_create                         priv_cms_Data_create
-
 # endif
 
 #endif                          /* ! defined HEADER_VMS_IDHACKS_H */


### PR DESCRIPTION
Partial fix for #12964
    
This adds ossl_ names for symbols related to cms_*, ess_* and pkcs7_*

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
