### PR TITLE
Fix merge problem in d2i_PrivateKey_ex

### DIFF
--- a/crypto/asn1/d2i_pr.c
+++ b/crypto/asn1/d2i_pr.c
@@ -44,9 +44,9 @@ EVP_PKEY *d2i_PrivateKey_ex(int keytype, EVP_PKEY **a, const unsigned char **pp,
         ppkey = a;
 
     for (i = 0;  i < (int)OSSL_NELEM(input_structures); ++i) {
-        dctx = OSSL_DECODER_CTX_new_by_EVP_PKEY(ppkey, "DER",
-                                                input_structures[i], key_name,
-                                                EVP_PKEY_KEYPAIR, libctx, propq);
+        dctx = OSSL_DECODER_CTX_new_for_pkey(ppkey, "DER",
+                                             input_structures[i], key_name,
+                                             EVP_PKEY_KEYPAIR, libctx, propq);
         if (dctx == NULL)
             return NULL;
 


### PR DESCRIPTION
The decoder rename change got merged after I rebased. Herein is a fix.

I need to stop doing merges at night.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
