### PR TITLE
Don't hold a lock when calling a callback in ossl_namemap_doall_names

### DIFF
--- a/apps/list.c
+++ b/apps/list.c
@@ -91,22 +91,23 @@ static void list_ciphers(void)
             continue;
 
         names = sk_OPENSSL_CSTRING_new(name_cmp);
-        EVP_CIPHER_names_do_all(c, collect_names, names);
-        BIO_printf(bio_out, "  ");
-        print_names(bio_out, names);
-        sk_OPENSSL_CSTRING_free(names);
+        if (names != NULL && EVP_CIPHER_names_do_all(c, collect_names, names)) {
+            BIO_printf(bio_out, "  ");
+            print_names(bio_out, names);
 
-        BIO_printf(bio_out, " @ %s\n",
-                   OSSL_PROVIDER_name(EVP_CIPHER_provider(c)));
+            BIO_printf(bio_out, " @ %s\n",
+                    OSSL_PROVIDER_name(EVP_CIPHER_provider(c)));
 
-        if (verbose) {
-            print_param_types("retrievable algorithm parameters",
-                              EVP_CIPHER_gettable_params(c), 4);
-            print_param_types("retrievable operation parameters",
-                              EVP_CIPHER_gettable_ctx_params(c), 4);
-            print_param_types("settable operation parameters",
-                              EVP_CIPHER_settable_ctx_params(c), 4);
+            if (verbose) {
+                print_param_types("retrievable algorithm parameters",
+                                EVP_CIPHER_gettable_params(c), 4);
+                print_param_types("retrievable operation parameters",
+                                EVP_CIPHER_gettable_ctx_params(c), 4);
+                print_param_types("settable operation parameters",
+                                EVP_CIPHER_settable_ctx_params(c), 4);
+            }
         }
+        sk_OPENSSL_CSTRING_free(names);
     }
     sk_EVP_CIPHER_pop_free(ciphers, EVP_CIPHER_free);
 }
@@ -168,21 +169,22 @@ static void list_digests(void)
             continue;
 
         names = sk_OPENSSL_CSTRING_new(name_cmp);
-        EVP_MD_names_do_all(m, collect_names, names);
-        BIO_printf(bio_out, "  ");
-        print_names(bio_out, names);
-        sk_OPENSSL_CSTRING_free(names);
+        if (names != NULL && EVP_MD_names_do_all(m, collect_names, names)) {
+            BIO_printf(bio_out, "  ");
+            print_names(bio_out, names);
 
-        BIO_printf(bio_out, " @ %s\n", OSSL_PROVIDER_name(EVP_MD_provider(m)));
+            BIO_printf(bio_out, " @ %s\n", OSSL_PROVIDER_name(EVP_MD_provider(m)));
 
-        if (verbose) {
-            print_param_types("retrievable algorithm parameters",
-                              EVP_MD_gettable_params(m), 4);
-            print_param_types("retrievable operation parameters",
-                              EVP_MD_gettable_ctx_params(m), 4);
-            print_param_types("settable operation parameters",
-                              EVP_MD_settable_ctx_params(m), 4);
+            if (verbose) {
+                print_param_types("retrievable algorithm parameters",
+                                EVP_MD_gettable_params(m), 4);
+                print_param_types("retrievable operation parameters",
+                                EVP_MD_gettable_ctx_params(m), 4);
+                print_param_types("settable operation parameters",
+                                EVP_MD_settable_ctx_params(m), 4);
+            }
         }
+        sk_OPENSSL_CSTRING_free(names);
     }
     sk_EVP_MD_pop_free(digests, EVP_MD_free);
 }
@@ -227,21 +229,22 @@ static void list_macs(void)
             continue;
 
         names = sk_OPENSSL_CSTRING_new(name_cmp);
-        EVP_MAC_names_do_all(m, collect_names, names);
-        BIO_printf(bio_out, "  ");
-        print_names(bio_out, names);
-        sk_OPENSSL_CSTRING_free(names);
+        if (names != NULL && EVP_MAC_names_do_all(m, collect_names, names)) {
+            BIO_printf(bio_out, "  ");
+            print_names(bio_out, names);
 
-        BIO_printf(bio_out, " @ %s\n", OSSL_PROVIDER_name(EVP_MAC_provider(m)));
+            BIO_printf(bio_out, " @ %s\n", OSSL_PROVIDER_name(EVP_MAC_provider(m)));
 
-        if (verbose) {
-            print_param_types("retrievable algorithm parameters",
-                              EVP_MAC_gettable_params(m), 4);
-            print_param_types("retrievable operation parameters",
-                              EVP_MAC_gettable_ctx_params(m), 4);
-            print_param_types("settable operation parameters",
-                              EVP_MAC_settable_ctx_params(m), 4);
+            if (verbose) {
+                print_param_types("retrievable algorithm parameters",
+                                EVP_MAC_gettable_params(m), 4);
+                print_param_types("retrievable operation parameters",
+                                EVP_MAC_gettable_ctx_params(m), 4);
+                print_param_types("settable operation parameters",
+                                EVP_MAC_settable_ctx_params(m), 4);
+            }
         }
+        sk_OPENSSL_CSTRING_free(names);
     }
     sk_EVP_MAC_pop_free(macs, EVP_MAC_free);
 }
@@ -289,21 +292,22 @@ static void list_kdfs(void)
             continue;
 
         names = sk_OPENSSL_CSTRING_new(name_cmp);
-        EVP_KDF_names_do_all(k, collect_names, names);
-        BIO_printf(bio_out, "  ");
-        print_names(bio_out, names);
-        sk_OPENSSL_CSTRING_free(names);
+        if (names != NULL && EVP_KDF_names_do_all(k, collect_names, names)) {
+            BIO_printf(bio_out, "  ");
+            print_names(bio_out, names);
 
-        BIO_printf(bio_out, " @ %s\n", OSSL_PROVIDER_name(EVP_KDF_provider(k)));
+            BIO_printf(bio_out, " @ %s\n", OSSL_PROVIDER_name(EVP_KDF_provider(k)));
 
-        if (verbose) {
-            print_param_types("retrievable algorithm parameters",
-                              EVP_KDF_gettable_params(k), 4);
-            print_param_types("retrievable operation parameters",
-                              EVP_KDF_gettable_ctx_params(k), 4);
-            print_param_types("settable operation parameters",
-                              EVP_KDF_settable_ctx_params(k), 4);
+            if (verbose) {
+                print_param_types("retrievable algorithm parameters",
+                                EVP_KDF_gettable_params(k), 4);
+                print_param_types("retrievable operation parameters",
+                                EVP_KDF_gettable_ctx_params(k), 4);
+                print_param_types("settable operation parameters",
+                                EVP_KDF_settable_ctx_params(k), 4);
+            }
         }
+        sk_OPENSSL_CSTRING_free(names);
     }
     sk_EVP_KDF_pop_free(kdfs, EVP_KDF_free);
 }
@@ -478,19 +482,20 @@ static void list_encoders(void)
             continue;
 
         names = sk_OPENSSL_CSTRING_new(name_cmp);
-        OSSL_ENCODER_names_do_all(k, collect_names, names);
-        BIO_printf(bio_out, "  ");
-        print_names(bio_out, names);
-        sk_OPENSSL_CSTRING_free(names);
+        if (names != NULL && OSSL_ENCODER_names_do_all(k, collect_names, names)) {
+            BIO_printf(bio_out, "  ");
+            print_names(bio_out, names);
 
-        BIO_printf(bio_out, " @ %s (%s)\n",
-                   OSSL_PROVIDER_name(OSSL_ENCODER_provider(k)),
-                   OSSL_ENCODER_properties(k));
+            BIO_printf(bio_out, " @ %s (%s)\n",
+                    OSSL_PROVIDER_name(OSSL_ENCODER_provider(k)),
+                    OSSL_ENCODER_properties(k));
 
-        if (verbose) {
-            print_param_types("settable operation parameters",
-                              OSSL_ENCODER_settable_ctx_params(k), 4);
+            if (verbose) {
+                print_param_types("settable operation parameters",
+                                OSSL_ENCODER_settable_ctx_params(k), 4);
+            }
         }
+        sk_OPENSSL_CSTRING_free(names);
     }
     sk_OSSL_ENCODER_pop_free(encoders, OSSL_ENCODER_free);
 }
@@ -541,19 +546,20 @@ static void list_decoders(void)
             continue;
 
         names = sk_OPENSSL_CSTRING_new(name_cmp);
-        OSSL_DECODER_names_do_all(k, collect_names, names);
-        BIO_printf(bio_out, "  ");
-        print_names(bio_out, names);
-        sk_OPENSSL_CSTRING_free(names);
+        if (names != NULL && OSSL_DECODER_names_do_all(k, collect_names, names)) {
+            BIO_printf(bio_out, "  ");
+            print_names(bio_out, names);
 
-        BIO_printf(bio_out, " @ %s (%s)\n",
-                   OSSL_PROVIDER_name(OSSL_DECODER_provider(k)),
-                   OSSL_DECODER_properties(k));
+            BIO_printf(bio_out, " @ %s (%s)\n",
+                    OSSL_PROVIDER_name(OSSL_DECODER_provider(k)),
+                    OSSL_DECODER_properties(k));
 
-        if (verbose) {
-            print_param_types("settable operation parameters",
-                              OSSL_DECODER_settable_ctx_params(k), 4);
+            if (verbose) {
+                print_param_types("settable operation parameters",
+                                OSSL_DECODER_settable_ctx_params(k), 4);
+            }
         }
+        sk_OPENSSL_CSTRING_free(names);
     }
     sk_OSSL_DECODER_pop_free(decoders, OSSL_DECODER_free);
 }
@@ -594,22 +600,23 @@ static void list_keymanagers(void)
             continue;
 
         names = sk_OPENSSL_CSTRING_new(name_cmp);
-        EVP_KEYMGMT_names_do_all(k, collect_names, names);
-        BIO_printf(bio_out, "  ");
-        print_names(bio_out, names);
-        sk_OPENSSL_CSTRING_free(names);
+        if (names != NULL && EVP_KEYMGMT_names_do_all(k, collect_names, names)) {
+            BIO_printf(bio_out, "  ");
+            print_names(bio_out, names);
 
-        BIO_printf(bio_out, " @ %s\n",
-                   OSSL_PROVIDER_name(EVP_KEYMGMT_provider(k)));
+            BIO_printf(bio_out, " @ %s\n",
+                    OSSL_PROVIDER_name(EVP_KEYMGMT_provider(k)));
 
-        if (verbose) {
-            print_param_types("settable key generation parameters",
-                              EVP_KEYMGMT_gen_settable_params(k), 4);
-            print_param_types("settable operation parameters",
-                              EVP_KEYMGMT_settable_params(k), 4);
-            print_param_types("retrievable operation parameters",
-                              EVP_KEYMGMT_gettable_params(k), 4);
+            if (verbose) {
+                print_param_types("settable key generation parameters",
+                                EVP_KEYMGMT_gen_settable_params(k), 4);
+                print_param_types("settable operation parameters",
+                                EVP_KEYMGMT_settable_params(k), 4);
+                print_param_types("retrievable operation parameters",
+                                EVP_KEYMGMT_gettable_params(k), 4);
+            }
         }
+        sk_OPENSSL_CSTRING_free(names);
     }
     sk_EVP_KEYMGMT_pop_free(km_stack, EVP_KEYMGMT_free);
 }
@@ -650,21 +657,22 @@ static void list_signatures(void)
             continue;
 
         names = sk_OPENSSL_CSTRING_new(name_cmp);
-        EVP_SIGNATURE_names_do_all(k, collect_names, names);
-        count++;
-        BIO_printf(bio_out, "  ");
-        print_names(bio_out, names);
-        sk_OPENSSL_CSTRING_free(names);
+        if (names != NULL && EVP_SIGNATURE_names_do_all(k, collect_names, names)) {
+            count++;
+            BIO_printf(bio_out, "  ");
+            print_names(bio_out, names);
 
-        BIO_printf(bio_out, " @ %s\n",
-                   OSSL_PROVIDER_name(EVP_SIGNATURE_provider(k)));
+            BIO_printf(bio_out, " @ %s\n",
+                    OSSL_PROVIDER_name(EVP_SIGNATURE_provider(k)));
 
-        if (verbose) {
-            print_param_types("settable operation parameters",
-                              EVP_SIGNATURE_settable_ctx_params(k), 4);
-            print_param_types("retrievable operation parameters",
-                              EVP_SIGNATURE_gettable_ctx_params(k), 4);
+            if (verbose) {
+                print_param_types("settable operation parameters",
+                                EVP_SIGNATURE_settable_ctx_params(k), 4);
+                print_param_types("retrievable operation parameters",
+                                EVP_SIGNATURE_gettable_ctx_params(k), 4);
+            }
         }
+        sk_OPENSSL_CSTRING_free(names);
     }
     sk_EVP_SIGNATURE_pop_free(sig_stack, EVP_SIGNATURE_free);
     if (count == 0)
@@ -707,20 +715,21 @@ static void list_kems(void)
             continue;
 
         names = sk_OPENSSL_CSTRING_new(name_cmp);
-        EVP_KEM_names_do_all(k, collect_names, names);
-        count++;
-        BIO_printf(bio_out, "  ");
-        print_names(bio_out, names);
-        sk_OPENSSL_CSTRING_free(names);
+        if (names != NULL && EVP_KEM_names_do_all(k, collect_names, names)) {
+            count++;
+            BIO_printf(bio_out, "  ");
+            print_names(bio_out, names);
 
-        BIO_printf(bio_out, " @ %s\n", OSSL_PROVIDER_name(EVP_KEM_provider(k)));
+            BIO_printf(bio_out, " @ %s\n", OSSL_PROVIDER_name(EVP_KEM_provider(k)));
 
-        if (verbose) {
-            print_param_types("settable operation parameters",
-                              EVP_KEM_settable_ctx_params(k), 4);
-            print_param_types("retrievable operation parameters",
-                              EVP_KEM_gettable_ctx_params(k), 4);
+            if (verbose) {
+                print_param_types("settable operation parameters",
+                                EVP_KEM_settable_ctx_params(k), 4);
+                print_param_types("retrievable operation parameters",
+                                EVP_KEM_gettable_ctx_params(k), 4);
+            }
         }
+        sk_OPENSSL_CSTRING_free(names);
     }
     sk_EVP_KEM_pop_free(kem_stack, EVP_KEM_free);
     if (count == 0)
@@ -764,21 +773,23 @@ static void list_asymciphers(void)
             continue;
 
         names = sk_OPENSSL_CSTRING_new(name_cmp);
-        EVP_ASYM_CIPHER_names_do_all(k, collect_names, names);
-        count++;
-        BIO_printf(bio_out, "  ");
-        print_names(bio_out, names);
-        sk_OPENSSL_CSTRING_free(names);
+        if (names != NULL
+                && EVP_ASYM_CIPHER_names_do_all(k, collect_names, names)) {
+            count++;
+            BIO_printf(bio_out, "  ");
+            print_names(bio_out, names);
 
-        BIO_printf(bio_out, " @ %s\n",
-                   OSSL_PROVIDER_name(EVP_ASYM_CIPHER_provider(k)));
+            BIO_printf(bio_out, " @ %s\n",
+                    OSSL_PROVIDER_name(EVP_ASYM_CIPHER_provider(k)));
 
-        if (verbose) {
-            print_param_types("settable operation parameters",
-                              EVP_ASYM_CIPHER_settable_ctx_params(k), 4);
-            print_param_types("retrievable operation parameters",
-                              EVP_ASYM_CIPHER_gettable_ctx_params(k), 4);
+            if (verbose) {
+                print_param_types("settable operation parameters",
+                                EVP_ASYM_CIPHER_settable_ctx_params(k), 4);
+                print_param_types("retrievable operation parameters",
+                                EVP_ASYM_CIPHER_gettable_ctx_params(k), 4);
+            }
         }
+        sk_OPENSSL_CSTRING_free(names);
     }
     sk_EVP_ASYM_CIPHER_pop_free(asymciph_stack, EVP_ASYM_CIPHER_free);
     if (count == 0)
@@ -821,21 +832,22 @@ static void list_keyexchanges(void)
             continue;
 
         names = sk_OPENSSL_CSTRING_new(name_cmp);
-        EVP_KEYEXCH_names_do_all(k, collect_names, names);
-        count++;
-        BIO_printf(bio_out, "  ");
-        print_names(bio_out, names);
-        sk_OPENSSL_CSTRING_free(names);
+        if (names != NULL && EVP_KEYEXCH_names_do_all(k, collect_names, names)) {
+            count++;
+            BIO_printf(bio_out, "  ");
+            print_names(bio_out, names);
 
-        BIO_printf(bio_out, " @ %s\n",
-                   OSSL_PROVIDER_name(EVP_KEYEXCH_provider(k)));
+            BIO_printf(bio_out, " @ %s\n",
+                    OSSL_PROVIDER_name(EVP_KEYEXCH_provider(k)));
 
-        if (verbose) {
-            print_param_types("settable operation parameters",
-                              EVP_KEYEXCH_settable_ctx_params(k), 4);
-            print_param_types("retrievable operation parameters",
-                              EVP_KEYEXCH_gettable_ctx_params(k), 4);
+            if (verbose) {
+                print_param_types("settable operation parameters",
+                                EVP_KEYEXCH_settable_ctx_params(k), 4);
+                print_param_types("retrievable operation parameters",
+                                EVP_KEYEXCH_gettable_ctx_params(k), 4);
+            }
         }
+        sk_OPENSSL_CSTRING_free(names);
     }
     sk_EVP_KEYEXCH_pop_free(kex_stack, EVP_KEYEXCH_free);
     if (count == 0)

--- a/crypto/core_namemap.c
+++ b/crypto/core_namemap.c
@@ -116,31 +116,55 @@ int ossl_namemap_empty(OSSL_NAMEMAP *namemap)
 
 typedef struct doall_names_data_st {
     int number;
-    void (*fn)(const char *name, void *data);
-    void *data;
+    const char **names;
+    int found;
 } DOALL_NAMES_DATA;
 
 static void do_name(const NAMENUM_ENTRY *namenum, DOALL_NAMES_DATA *data)
 {
     if (namenum->number == data->number)
-        data->fn(namenum->name, data->data);
+        data->names[data->found++] = namenum->name;
 }
 
 IMPLEMENT_LHASH_DOALL_ARG_CONST(NAMENUM_ENTRY, DOALL_NAMES_DATA);
 
-void ossl_namemap_doall_names(const OSSL_NAMEMAP *namemap, int number,
-                              void (*fn)(const char *name, void *data),
-                              void *data)
+int ossl_namemap_doall_names(const OSSL_NAMEMAP *namemap, int number,
+                             void (*fn)(const char *name, void *data),
+                             void *data)
 {
     DOALL_NAMES_DATA cbdata;
+    size_t num_names;
+    int i;
 
     cbdata.number = number;
-    cbdata.fn = fn;
-    cbdata.data = data;
+    cbdata.found = 0;
+
+    /*
+     * We collect all the names first under a read lock. Subsequently we call
+     * the user function, so that we're not holding the read lock when in user
+     * code. This could lead to deadlocks.
+     */
     CRYPTO_THREAD_read_lock(namemap->lock);
+    num_names = lh_NAMENUM_ENTRY_num_items(namemap->namenum);
+
+    if (num_names == 0) {
+        CRYPTO_THREAD_unlock(namemap->lock);
+        return 0;
+    }
+    cbdata.names = OPENSSL_malloc(sizeof(*cbdata.names) * num_names);
+    if (cbdata.names == NULL) {
+        CRYPTO_THREAD_unlock(namemap->lock);
+        return 0;
+    }
     lh_NAMENUM_ENTRY_doall_DOALL_NAMES_DATA(namemap->namenum, do_name,
                                             &cbdata);
     CRYPTO_THREAD_unlock(namemap->lock);
+
+    for (i = 0; i < cbdata.found; i++)
+        fn(cbdata.names[i], data);
+
+    OPENSSL_free(cbdata.names);
+    return 1;
 }
 
 static int namemap_name2num_n(const OSSL_NAMEMAP *namemap,
@@ -207,7 +231,8 @@ const char *ossl_namemap_num2name(const OSSL_NAMEMAP *namemap, int number,
 
     data.idx = idx;
     data.name = NULL;
-    ossl_namemap_doall_names(namemap, number, do_num2name, &data);
+    if (!ossl_namemap_doall_names(namemap, number, do_num2name, &data))
+        return NULL;
     return data.name;
 }
 

--- a/crypto/core_namemap.c
+++ b/crypto/core_namemap.c
@@ -128,6 +128,11 @@ static void do_name(const NAMENUM_ENTRY *namenum, DOALL_NAMES_DATA *data)
 
 IMPLEMENT_LHASH_DOALL_ARG_CONST(NAMENUM_ENTRY, DOALL_NAMES_DATA);
 
+/*
+ * Call the callback for all names in the namemap with the given number.
+ * A return value 1 means that the callback was called for all names. A
+ * return value of 0 means that the callback was not called for any names.
+ */
 int ossl_namemap_doall_names(const OSSL_NAMEMAP *namemap, int number,
                              void (*fn)(const char *name, void *data),
                              void *data)

--- a/crypto/encode_decode/decoder_meth.c
+++ b/crypto/encode_decode/decoder_meth.c
@@ -473,19 +473,21 @@ void OSSL_DECODER_do_all_provided(OSSL_LIB_CTX *libctx,
                           &data);
 }
 
-void OSSL_DECODER_names_do_all(const OSSL_DECODER *decoder,
-                               void (*fn)(const char *name, void *data),
-                               void *data)
+int OSSL_DECODER_names_do_all(const OSSL_DECODER *decoder,
+                              void (*fn)(const char *name, void *data),
+                              void *data)
 {
     if (decoder == NULL)
-        return;
+        return 0;
 
     if (decoder->base.prov != NULL) {
         OSSL_LIB_CTX *libctx = ossl_provider_libctx(decoder->base.prov);
         OSSL_NAMEMAP *namemap = ossl_namemap_stored(libctx);
 
-        ossl_namemap_doall_names(namemap, decoder->base.id, fn, data);
+        return ossl_namemap_doall_names(namemap, decoder->base.id, fn, data);
     }
+
+    return 1;
 }
 
 const OSSL_PARAM *

--- a/crypto/encode_decode/decoder_pkey.c
+++ b/crypto/encode_decode/decoder_pkey.c
@@ -302,8 +302,12 @@ int ossl_decoder_ctx_setup_for_pkey(OSSL_DECODER_CTX *ctx,
          * If the key type is given by the caller, we only use the matching
          * KEYMGMTs, otherwise we use them all.
          */
-        if (keytype == NULL || EVP_KEYMGMT_is_a(keymgmt, keytype))
-            EVP_KEYMGMT_names_do_all(keymgmt, collect_name, names);
+        if (keytype == NULL || EVP_KEYMGMT_is_a(keymgmt, keytype)) {
+            if (!EVP_KEYMGMT_names_do_all(keymgmt, collect_name, names)) {
+                ERR_raise(ERR_LIB_OSSL_DECODER, ERR_R_INTERNAL_ERROR);
+                goto err;
+            }
+        }
 
         EVP_KEYMGMT_free(keymgmt);
     }

--- a/crypto/encode_decode/encoder_meth.c
+++ b/crypto/encode_decode/encoder_meth.c
@@ -490,19 +490,21 @@ void OSSL_ENCODER_do_all_provided(OSSL_LIB_CTX *libctx,
                           encoder_do_one, NULL, &data);
 }
 
-void OSSL_ENCODER_names_do_all(const OSSL_ENCODER *encoder,
-                               void (*fn)(const char *name, void *data),
-                               void *data)
+int OSSL_ENCODER_names_do_all(const OSSL_ENCODER *encoder,
+                              void (*fn)(const char *name, void *data),
+                              void *data)
 {
     if (encoder == NULL)
-        return;
+        return 0;
 
     if (encoder->base.prov != NULL) {
         OSSL_LIB_CTX *libctx = ossl_provider_libctx(encoder->base.prov);
         OSSL_NAMEMAP *namemap = ossl_namemap_stored(libctx);
 
-        ossl_namemap_doall_names(namemap, encoder->base.id, fn, data);
+        return ossl_namemap_doall_names(namemap, encoder->base.id, fn, data);
     }
+
+    return 1;
 }
 
 const OSSL_PARAM *

--- a/crypto/evp/asymcipher.c
+++ b/crypto/evp/asymcipher.c
@@ -434,12 +434,14 @@ void EVP_ASYM_CIPHER_do_all_provided(OSSL_LIB_CTX *libctx,
 }
 
 
-void EVP_ASYM_CIPHER_names_do_all(const EVP_ASYM_CIPHER *cipher,
-                                  void (*fn)(const char *name, void *data),
-                                  void *data)
+int EVP_ASYM_CIPHER_names_do_all(const EVP_ASYM_CIPHER *cipher,
+                                 void (*fn)(const char *name, void *data),
+                                 void *data)
 {
     if (cipher->prov != NULL)
-        evp_names_do_all(cipher->prov, cipher->name_id, fn, data);
+        return evp_names_do_all(cipher->prov, cipher->name_id, fn, data);
+
+    return 1;
 }
 
 const OSSL_PARAM *EVP_ASYM_CIPHER_gettable_ctx_params(const EVP_ASYM_CIPHER *cip)

--- a/crypto/evp/digest.c
+++ b/crypto/evp/digest.c
@@ -881,8 +881,8 @@ static void *evp_md_from_dispatch(int name_id,
 #ifndef FIPS_MODULE
     /* TODO(3.x) get rid of the need for legacy NIDs */
     md->type = NID_undef;
-    evp_names_do_all(prov, name_id, set_legacy_nid, &md->type);
-    if (md->type == -1) {
+    if (!evp_names_do_all(prov, name_id, set_legacy_nid, &md->type)
+            || md->type == -1) {
         ERR_raise(ERR_LIB_EVP, ERR_R_INTERNAL_ERROR);
         EVP_MD_free(md);
         return NULL;

--- a/crypto/evp/evp_enc.c
+++ b/crypto/evp/evp_enc.c
@@ -1395,8 +1395,8 @@ static void *evp_cipher_from_dispatch(const int name_id,
 #ifndef FIPS_MODULE
     /* TODO(3.x) get rid of the need for legacy NIDs */
     cipher->nid = NID_undef;
-    evp_names_do_all(prov, name_id, set_legacy_nid, &cipher->nid);
-    if (cipher->nid == -1) {
+    if (!evp_names_do_all(prov, name_id, set_legacy_nid, &cipher->nid)
+            || cipher->nid == -1) {
         ERR_raise(ERR_LIB_EVP, ERR_R_INTERNAL_ERROR);
         EVP_CIPHER_free(cipher);
         return NULL;

--- a/crypto/evp/evp_fetch.c
+++ b/crypto/evp/evp_fetch.c
@@ -531,8 +531,8 @@ int evp_is_a(OSSL_PROVIDER *prov, int number,
 }
 
 int evp_names_do_all(OSSL_PROVIDER *prov, int number,
-                      void (*fn)(const char *name, void *data),
-                      void *data)
+                     void (*fn)(const char *name, void *data),
+                     void *data)
 {
     OSSL_LIB_CTX *libctx = ossl_provider_libctx(prov);
     OSSL_NAMEMAP *namemap = ossl_namemap_stored(libctx);

--- a/crypto/evp/evp_fetch.c
+++ b/crypto/evp/evp_fetch.c
@@ -530,12 +530,12 @@ int evp_is_a(OSSL_PROVIDER *prov, int number,
     return ossl_namemap_name2num(namemap, name) == number;
 }
 
-void evp_names_do_all(OSSL_PROVIDER *prov, int number,
+int evp_names_do_all(OSSL_PROVIDER *prov, int number,
                       void (*fn)(const char *name, void *data),
                       void *data)
 {
     OSSL_LIB_CTX *libctx = ossl_provider_libctx(prov);
     OSSL_NAMEMAP *namemap = ossl_namemap_stored(libctx);
 
-    ossl_namemap_doall_names(namemap, number, fn, data);
+    return ossl_namemap_doall_names(namemap, number, fn, data);
 }

--- a/crypto/evp/evp_lib.c
+++ b/crypto/evp/evp_lib.c
@@ -644,12 +644,14 @@ const char *EVP_CIPHER_name(const EVP_CIPHER *cipher)
 #endif
 }
 
-void EVP_CIPHER_names_do_all(const EVP_CIPHER *cipher,
-                             void (*fn)(const char *name, void *data),
-                             void *data)
+int EVP_CIPHER_names_do_all(const EVP_CIPHER *cipher,
+                            void (*fn)(const char *name, void *data),
+                            void *data)
 {
     if (cipher->prov != NULL)
-        evp_names_do_all(cipher->prov, cipher->name_id, fn, data);
+        return evp_names_do_all(cipher->prov, cipher->name_id, fn, data);
+
+    return 1;
 }
 
 const OSSL_PROVIDER *EVP_CIPHER_provider(const EVP_CIPHER *cipher)
@@ -685,12 +687,14 @@ const char *EVP_MD_name(const EVP_MD *md)
 #endif
 }
 
-void EVP_MD_names_do_all(const EVP_MD *md,
-                         void (*fn)(const char *name, void *data),
-                         void *data)
+int EVP_MD_names_do_all(const EVP_MD *md,
+                        void (*fn)(const char *name, void *data),
+                        void *data)
 {
     if (md->prov != NULL)
-        evp_names_do_all(md->prov, md->name_id, fn, data);
+        return evp_names_do_all(md->prov, md->name_id, fn, data);
+
+    return 1;
 }
 
 const OSSL_PROVIDER *EVP_MD_provider(const EVP_MD *md)

--- a/crypto/evp/evp_local.h
+++ b/crypto/evp/evp_local.h
@@ -317,7 +317,7 @@ void evp_pkey_ctx_free_old_ops(EVP_PKEY_CTX *ctx);
 const char *evp_first_name(const OSSL_PROVIDER *prov, int name_id);
 int evp_is_a(OSSL_PROVIDER *prov, int number,
              const char *legacy_name, const char *name);
-void evp_names_do_all(OSSL_PROVIDER *prov, int number,
-                      void (*fn)(const char *name, void *data),
-                      void *data);
+int evp_names_do_all(OSSL_PROVIDER *prov, int number,
+                     void (*fn)(const char *name, void *data),
+                     void *data);
 int evp_cipher_cache_constants(EVP_CIPHER *cipher);

--- a/crypto/evp/evp_rand.c
+++ b/crypto/evp/evp_rand.c
@@ -450,12 +450,14 @@ void EVP_RAND_do_all_provided(OSSL_LIB_CTX *libctx,
                        evp_rand_from_dispatch, evp_rand_free);
 }
 
-void EVP_RAND_names_do_all(const EVP_RAND *rand,
-                           void (*fn)(const char *name, void *data),
-                           void *data)
+int EVP_RAND_names_do_all(const EVP_RAND *rand,
+                          void (*fn)(const char *name, void *data),
+                          void *data)
 {
     if (rand->prov != NULL)
-        evp_names_do_all(rand->prov, rand->name_id, fn, data);
+        return evp_names_do_all(rand->prov, rand->name_id, fn, data);
+
+    return 1;
 }
 
 static int evp_rand_instantiate_locked

--- a/crypto/evp/exchange.c
+++ b/crypto/evp/exchange.c
@@ -460,12 +460,14 @@ void EVP_KEYEXCH_do_all_provided(OSSL_LIB_CTX *libctx,
                        (void (*)(void *))EVP_KEYEXCH_free);
 }
 
-void EVP_KEYEXCH_names_do_all(const EVP_KEYEXCH *keyexch,
-                              void (*fn)(const char *name, void *data),
-                              void *data)
+int EVP_KEYEXCH_names_do_all(const EVP_KEYEXCH *keyexch,
+                             void (*fn)(const char *name, void *data),
+                             void *data)
 {
     if (keyexch->prov != NULL)
-        evp_names_do_all(keyexch->prov, keyexch->name_id, fn, data);
+        return evp_names_do_all(keyexch->prov, keyexch->name_id, fn, data);
+
+    return 1;
 }
 
 const OSSL_PARAM *EVP_KEYEXCH_gettable_ctx_params(const EVP_KEYEXCH *keyexch)

--- a/crypto/evp/kdf_lib.c
+++ b/crypto/evp/kdf_lib.c
@@ -172,10 +172,12 @@ int EVP_KDF_CTX_set_params(EVP_KDF_CTX *ctx, const OSSL_PARAM params[])
     return 1;
 }
 
-void EVP_KDF_names_do_all(const EVP_KDF *kdf,
-                          void (*fn)(const char *name, void *data),
-                          void *data)
+int EVP_KDF_names_do_all(const EVP_KDF *kdf,
+                         void (*fn)(const char *name, void *data),
+                         void *data)
 {
     if (kdf->prov != NULL)
-        evp_names_do_all(kdf->prov, kdf->name_id, fn, data);
+        return evp_names_do_all(kdf->prov, kdf->name_id, fn, data);
+
+    return 1;
 }

--- a/crypto/evp/kem.c
+++ b/crypto/evp/kem.c
@@ -349,12 +349,14 @@ void EVP_KEM_do_all_provided(OSSL_LIB_CTX *libctx,
                        (void (*)(void *))EVP_KEM_free);
 }
 
-void EVP_KEM_names_do_all(const EVP_KEM *kem,
-                          void (*fn)(const char *name, void *data),
-                          void *data)
+int EVP_KEM_names_do_all(const EVP_KEM *kem,
+                         void (*fn)(const char *name, void *data),
+                         void *data)
 {
     if (kem->prov != NULL)
-        evp_names_do_all(kem->prov, kem->name_id, fn, data);
+        return evp_names_do_all(kem->prov, kem->name_id, fn, data);
+
+    return 1;
 }
 
 const OSSL_PARAM *EVP_KEM_gettable_ctx_params(const EVP_KEM *kem)

--- a/crypto/evp/keymgmt_meth.c
+++ b/crypto/evp/keymgmt_meth.c
@@ -269,12 +269,14 @@ void EVP_KEYMGMT_do_all_provided(OSSL_LIB_CTX *libctx,
                        (void (*)(void *))EVP_KEYMGMT_free);
 }
 
-void EVP_KEYMGMT_names_do_all(const EVP_KEYMGMT *keymgmt,
-                              void (*fn)(const char *name, void *data),
-                              void *data)
+int EVP_KEYMGMT_names_do_all(const EVP_KEYMGMT *keymgmt,
+                             void (*fn)(const char *name, void *data),
+                             void *data)
 {
     if (keymgmt->prov != NULL)
-        evp_names_do_all(keymgmt->prov, keymgmt->name_id, fn, data);
+        return evp_names_do_all(keymgmt->prov, keymgmt->name_id, fn, data);
+
+    return 1;
 }
 
 /*

--- a/crypto/evp/mac_lib.c
+++ b/crypto/evp/mac_lib.c
@@ -174,10 +174,12 @@ int EVP_MAC_is_a(const EVP_MAC *mac, const char *name)
     return evp_is_a(mac->prov, mac->name_id, NULL, name);
 }
 
-void EVP_MAC_names_do_all(const EVP_MAC *mac,
-                          void (*fn)(const char *name, void *data),
-                          void *data)
+int EVP_MAC_names_do_all(const EVP_MAC *mac,
+                         void (*fn)(const char *name, void *data),
+                         void *data)
 {
     if (mac->prov != NULL)
-        evp_names_do_all(mac->prov, mac->name_id, fn, data);
+        return evp_names_do_all(mac->prov, mac->name_id, fn, data);
+
+    return 1;
 }

--- a/crypto/evp/names.c
+++ b/crypto/evp/names.c
@@ -98,7 +98,8 @@ const EVP_CIPHER *evp_get_cipherbyname_ex(OSSL_LIB_CTX *libctx,
     if (id == 0)
         return NULL;
 
-    ossl_namemap_doall_names(namemap, id, cipher_from_name, &cp);
+    if (!ossl_namemap_doall_names(namemap, id, cipher_from_name, &cp))
+        return NULL;
 
     return cp;
 }
@@ -143,7 +144,8 @@ const EVP_MD *evp_get_digestbyname_ex(OSSL_LIB_CTX *libctx, const char *name)
     if (id == 0)
         return NULL;
 
-    ossl_namemap_doall_names(namemap, id, digest_from_name, &dp);
+    if (!ossl_namemap_doall_names(namemap, id, digest_from_name, &dp))
+        return NULL;
 
     return dp;
 }

--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -982,20 +982,20 @@ int EVP_PKEY_is_a(const EVP_PKEY *pkey, const char *name)
     return EVP_KEYMGMT_is_a(pkey->keymgmt, name);
 }
 
-void EVP_PKEY_typenames_do_all(const EVP_PKEY *pkey,
-                               void (*fn)(const char *name, void *data),
-                               void *data)
+int EVP_PKEY_typenames_do_all(const EVP_PKEY *pkey,
+                              void (*fn)(const char *name, void *data),
+                              void *data)
 {
     if (!evp_pkey_is_typed(pkey))
-        return;
+        return 0;
 
     if (!evp_pkey_is_provided(pkey)) {
         const char *name = OBJ_nid2sn(EVP_PKEY_id(pkey));
 
         fn(name, data);
-        return;
+        return 1;
     }
-    EVP_KEYMGMT_names_do_all(pkey->keymgmt, fn, data);
+    return EVP_KEYMGMT_names_do_all(pkey->keymgmt, fn, data);
 }
 
 int EVP_PKEY_can_sign(const EVP_PKEY *pkey)
@@ -1182,7 +1182,8 @@ static int legacy_asn1_ctrl_to_param(EVP_PKEY *pkey, int op,
                  * We have the namemap number - now we need to find the
                  * associated nid
                  */
-                ossl_namemap_doall_names(namemap, mdnum, mdname2nid, &nid);
+                if (!ossl_namemap_doall_names(namemap, mdnum, mdname2nid, &nid))
+                    return 0;
                 *(int *)arg2 = nid;
             }
             return rv;
@@ -1578,8 +1579,8 @@ int EVP_PKEY_set_type_by_keymgmt(EVP_PKEY *pkey, EVP_KEYMGMT *keymgmt)
      */
     const char *str[2] = { NULL, NULL };
 
-    EVP_KEYMGMT_names_do_all(keymgmt, find_ameth, &str);
-    if (str[1] != NULL) {
+    if (!EVP_KEYMGMT_names_do_all(keymgmt, find_ameth, &str)
+            || str[1] != NULL) {
         ERR_raise(ERR_LIB_EVP, ERR_R_INTERNAL_ERROR);
         return 0;
     }

--- a/crypto/evp/signature.c
+++ b/crypto/evp/signature.c
@@ -329,12 +329,14 @@ void EVP_SIGNATURE_do_all_provided(OSSL_LIB_CTX *libctx,
 }
 
 
-void EVP_SIGNATURE_names_do_all(const EVP_SIGNATURE *signature,
-                                void (*fn)(const char *name, void *data),
-                                void *data)
+int EVP_SIGNATURE_names_do_all(const EVP_SIGNATURE *signature,
+                               void (*fn)(const char *name, void *data),
+                               void *data)
 {
     if (signature->prov != NULL)
-        evp_names_do_all(signature->prov, signature->name_id, fn, data);
+        return evp_names_do_all(signature->prov, signature->name_id, fn, data);
+
+    return 1;
 }
 
 const OSSL_PARAM *EVP_SIGNATURE_gettable_ctx_params(const EVP_SIGNATURE *sig)

--- a/crypto/store/store_meth.c
+++ b/crypto/store/store_meth.c
@@ -452,17 +452,19 @@ void OSSL_STORE_LOADER_do_all_provided(OSSL_LIB_CTX *libctx,
                           &data);
 }
 
-void OSSL_STORE_LOADER_names_do_all(const OSSL_STORE_LOADER *loader,
-                                    void (*fn)(const char *name, void *data),
-                                    void *data)
+int OSSL_STORE_LOADER_names_do_all(const OSSL_STORE_LOADER *loader,
+                                   void (*fn)(const char *name, void *data),
+                                   void *data)
 {
     if (loader == NULL)
-        return;
+        return 0;
 
     if (loader->prov != NULL) {
         OSSL_LIB_CTX *libctx = ossl_provider_libctx(loader->prov);
         OSSL_NAMEMAP *namemap = ossl_namemap_stored(libctx);
 
-        ossl_namemap_doall_names(namemap, loader->scheme_id, fn, data);
+        return ossl_namemap_doall_names(namemap, loader->scheme_id, fn, data);
     }
+
+    return 1;
 }

--- a/doc/internal/man3/ossl_namemap_new.pod
+++ b/doc/internal/man3/ossl_namemap_new.pod
@@ -98,7 +98,8 @@ ossl_namemap_name2num() and ossl_namemap_name2num_n() return the number
 corresponding to the given name, or 0 if it's undefined in the given
 B<OSSL_NAMEMAP>.
 
-ossl_namemap_doall_names() returns 1 on success or 0 on failure.
+ossl_namemap_doall_names() returns 1 if the callback was called for all names. A
+return value of 0 means that the callback was not called for any names.
 
 ossl_namemap_add_names() returns the number associated with the added
 names, or zero on error.

--- a/doc/internal/man3/ossl_namemap_new.pod
+++ b/doc/internal/man3/ossl_namemap_new.pod
@@ -25,9 +25,9 @@ ossl_namemap_doall_names
  int ossl_namemap_name2num(const OSSL_NAMEMAP *namemap, const char *name);
  int ossl_namemap_name2num_n(const OSSL_NAMEMAP *namemap,
                              const char *name, size_t name_len);
- void ossl_namemap_doall_names(const OSSL_NAMEMAP *namemap, int number,
-                               void (*fn)(const char *name, void *data),
-                               void *data);
+ int ossl_namemap_doall_names(const OSSL_NAMEMAP *namemap, int number,
+                              void (*fn)(const char *name, void *data),
+                              void *data);
 
  int ossl_namemap_add_names(OSSL_NAMEMAP *namemap, int number,
                             const char *names, const char separator);
@@ -97,6 +97,8 @@ it's undefined in the given B<OSSL_NAMEMAP>.
 ossl_namemap_name2num() and ossl_namemap_name2num_n() return the number
 corresponding to the given name, or 0 if it's undefined in the given
 B<OSSL_NAMEMAP>.
+
+ossl_namemap_doall_names() returns 1 on success or 0 on failure.
 
 ossl_namemap_add_names() returns the number associated with the added
 names, or zero on error.

--- a/doc/man3/EVP_ASYM_CIPHER_free.pod
+++ b/doc/man3/EVP_ASYM_CIPHER_free.pod
@@ -74,8 +74,10 @@ L<EVP_PKEY_CTX_get_params(3)> and L<EVP_PKEY_CTX_set_params(3)>.
 EVP_ASYM_CIPHER_fetch() returns a pointer to an B<EVP_ASYM_CIPHER> for success
 or B<NULL> for failure.
 
-EVP_ASYM_CIPHER_up_ref() and EVP_ASYM_CIPHER_names_do_all() return 1 for success
-or 0 otherwise.
+EVP_ASYM_CIPHER_up_ref() returns 1 for success or 0 otherwise.
+
+EVP_ASYM_CIPHER_names_do_all() returns 1 if the callback was called for all
+names. A return value of 0 means that the callback was not called for any names.
 
 EVP_ASYM_CIPHER_gettable_ctx_params() and EVP_ASYM_CIPHER_settable_ctx_params()
 return a constant B<OSSL_PARAM> array or NULL on error.

--- a/doc/man3/EVP_ASYM_CIPHER_free.pod
+++ b/doc/man3/EVP_ASYM_CIPHER_free.pod
@@ -23,9 +23,9 @@ EVP_ASYM_CIPHER_gettable_ctx_params, EVP_ASYM_CIPHER_settable_ctx_params
                                       void (*fn)(EVP_ASYM_CIPHER *cipher,
                                                  void *arg),
                                       void *arg);
- void EVP_ASYM_CIPHER_names_do_all(const EVP_ASYM_CIPHER *cipher,
-                                   void (*fn)(const char *name, void *data),
-                                   void *data);
+ int EVP_ASYM_CIPHER_names_do_all(const EVP_ASYM_CIPHER *cipher,
+                                  void (*fn)(const char *name, void *data),
+                                  void *data);
  const OSSL_PARAM *EVP_ASYM_CIPHER_gettable_ctx_params(const EVP_ASYM_CIPHER *cip);
  const OSSL_PARAM *EVP_ASYM_CIPHER_settable_ctx_params(const EVP_ASYM_CIPHER *cip);
 
@@ -74,7 +74,8 @@ L<EVP_PKEY_CTX_get_params(3)> and L<EVP_PKEY_CTX_set_params(3)>.
 EVP_ASYM_CIPHER_fetch() returns a pointer to an B<EVP_ASYM_CIPHER> for success
 or B<NULL> for failure.
 
-EVP_ASYM_CIPHER_up_ref() returns 1 for success or 0 otherwise.
+EVP_ASYM_CIPHER_up_ref() and EVP_ASYM_CIPHER_names_do_all() return 1 for success
+or 0 otherwise.
 
 EVP_ASYM_CIPHER_gettable_ctx_params() and EVP_ASYM_CIPHER_settable_ctx_params()
 return a constant B<OSSL_PARAM> array or NULL on error.

--- a/doc/man3/EVP_DigestInit.pod
+++ b/doc/man3/EVP_DigestInit.pod
@@ -544,7 +544,8 @@ This function has no return value.
 
 =item EVP_MD_names_do_all()
 
-Returns 1 on success or 0 otherwise.
+Returns 1 if the callback was called for all names. A return value of 0 means
+that the callback was not called for any names.
 
 =back
 

--- a/doc/man3/EVP_DigestInit.pod
+++ b/doc/man3/EVP_DigestInit.pod
@@ -64,9 +64,9 @@ EVP_MD_do_all_provided
  const char *EVP_MD_name(const EVP_MD *md);
  int EVP_MD_number(const EVP_MD *md);
  int EVP_MD_is_a(const EVP_MD *md, const char *name);
- void EVP_MD_names_do_all(const EVP_MD *md,
-                          void (*fn)(const char *name, void *data),
-                          void *data);
+ int EVP_MD_names_do_all(const EVP_MD *md,
+                         void (*fn)(const char *name, void *data),
+                         void *data);
  const OSSL_PROVIDER *EVP_MD_provider(const EVP_MD *md);
  int EVP_MD_type(const EVP_MD *md);
  int EVP_MD_pkey_type(const EVP_MD *md);
@@ -541,6 +541,10 @@ Returns either an B<EVP_MD> structure or NULL if an error occurs.
 =item EVP_MD_CTX_set_pkey_ctx()
 
 This function has no return value.
+
+=item EVP_MD_names_do_all()
+
+Returns 1 on success or 0 otherwise.
 
 =back
 

--- a/doc/man3/EVP_EncryptInit.pod
+++ b/doc/man3/EVP_EncryptInit.pod
@@ -125,9 +125,9 @@ EVP_CIPHER_do_all_provided
  int EVP_CIPHER_nid(const EVP_CIPHER *e);
  int EVP_CIPHER_number(const EVP_CIPHER *e);
  int EVP_CIPHER_is_a(const EVP_CIPHER *cipher, const char *name);
- void EVP_CIPHER_names_do_all(const EVP_CIPHER *cipher,
-                              void (*fn)(const char *name, void *data),
-                              void *data);
+ int EVP_CIPHER_names_do_all(const EVP_CIPHER *cipher,
+                             void (*fn)(const char *name, void *data),
+                             void *data);
  const char *EVP_CIPHER_name(const EVP_CIPHER *cipher);
  const OSSL_PROVIDER *EVP_CIPHER_provider(const EVP_CIPHER *cipher);
  int EVP_CIPHER_block_size(const EVP_CIPHER *e);
@@ -460,6 +460,8 @@ EVP_CIPHER_param_to_asn1() and EVP_CIPHER_asn1_to_param() return greater
 than zero for success and zero or a negative number on failure.
 
 EVP_CIPHER_CTX_rand_key() returns 1 for success.
+
+EVP_CIPHER_names_do_all() returns 1 on success or 0 otherwise.
 
 =head1 CIPHER LISTING
 

--- a/doc/man3/EVP_EncryptInit.pod
+++ b/doc/man3/EVP_EncryptInit.pod
@@ -461,7 +461,8 @@ than zero for success and zero or a negative number on failure.
 
 EVP_CIPHER_CTX_rand_key() returns 1 for success.
 
-EVP_CIPHER_names_do_all() returns 1 on success or 0 otherwise.
+EVP_CIPHER_names_do_all() returns 1 if the callback was called for all names.
+A return value of 0 means that the callback was not called for any names.
 
 =head1 CIPHER LISTING
 

--- a/doc/man3/EVP_KDF.pod
+++ b/doc/man3/EVP_KDF.pod
@@ -36,9 +36,9 @@ EVP_KDF_gettable_params - EVP KDF routines
  void EVP_KDF_do_all_provided(OSSL_LIB_CTX *libctx,
                               void (*fn)(EVP_KDF *kdf, void *arg),
                               void *arg);
- void EVP_KDF_names_do_all(const EVP_KDF *kdf,
-                           void (*fn)(const char *name, void *data),
-                           void *data);
+ int EVP_KDF_names_do_all(const EVP_KDF *kdf,
+                          void (*fn)(const char *name, void *data),
+                          void *data);
  int EVP_KDF_get_params(EVP_KDF *kdf, OSSL_PARAM params[]);
  int EVP_KDF_CTX_get_params(EVP_KDF_CTX *ctx, OSSL_PARAM params[]);
  int EVP_KDF_CTX_set_params(EVP_KDF_CTX *ctx, const OSSL_PARAM params[]);
@@ -251,6 +251,8 @@ EVP_KDF_CTX_get_kdf_size() returns the output size.  B<SIZE_MAX> is returned to 
 that the algorithm produces a variable amount of output; 0 to indicate failure.
 
 EVP_KDF_name() returns the name of the KDF, or NULL on error.
+
+EVP_KDF_names_do_all() returns 1 on success or 0 otherwise.
 
 The remaining functions return 1 for success and 0 or a negative value for
 failure.  In particular, a return value of -2 indicates the operation is not

--- a/doc/man3/EVP_KDF.pod
+++ b/doc/man3/EVP_KDF.pod
@@ -252,7 +252,8 @@ that the algorithm produces a variable amount of output; 0 to indicate failure.
 
 EVP_KDF_name() returns the name of the KDF, or NULL on error.
 
-EVP_KDF_names_do_all() returns 1 on success or 0 otherwise.
+EVP_KDF_names_do_all() returns 1 if the callback was called for all names. A
+return value of 0 means that the callback was not called for any names.
 
 The remaining functions return 1 for success and 0 or a negative value for
 failure.  In particular, a return value of -2 indicates the operation is not

--- a/doc/man3/EVP_KEM_free.pod
+++ b/doc/man3/EVP_KEM_free.pod
@@ -21,8 +21,8 @@ EVP_KEM_gettable_ctx_params, EVP_KEM_settable_ctx_params
  OSSL_PROVIDER *EVP_KEM_provider(const EVP_KEM *kem);
  void EVP_KEM_do_all_provided(OSSL_LIB_CTX *libctx,
                               void (*fn)(EVP_KEM *kem, void *arg), void *arg);
- void EVP_KEM_names_do_all(const EVP_KEM *kem,
-                           void (*fn)(const char *name, void *data), void *data);
+ int EVP_KEM_names_do_all(const EVP_KEM *kem,
+                          void (*fn)(const char *name, void *data), void *data);
  const OSSL_PARAM *EVP_KEM_gettable_ctx_params(const EVP_KEM *kem);
  const OSSL_PARAM *EVP_KEM_settable_ctx_params(const EVP_KEM *kem);
 
@@ -68,7 +68,7 @@ L<EVP_PKEY_CTX_get_params(3)> and L<EVP_PKEY_CTX_set_params(3)>.
 EVP_KEM_fetch() returns a pointer to an B<EVP_KEM> for success or B<NULL> for
 failure.
 
-EVP_KEM_up_ref() returns 1 for success or 0 otherwise.
+EVP_KEM_up_ref() and EVP_KEM_names_do_all() return 1 for success or 0 otherwise.
 
 EVP_KEM_gettable_ctx_params() and EVP_KEM_settable_ctx_params() return
 a constant B<OSSL_PARAM> array or NULL on error.

--- a/doc/man3/EVP_KEM_free.pod
+++ b/doc/man3/EVP_KEM_free.pod
@@ -68,7 +68,10 @@ L<EVP_PKEY_CTX_get_params(3)> and L<EVP_PKEY_CTX_set_params(3)>.
 EVP_KEM_fetch() returns a pointer to an B<EVP_KEM> for success or B<NULL> for
 failure.
 
-EVP_KEM_up_ref() and EVP_KEM_names_do_all() return 1 for success or 0 otherwise.
+EVP_KEM_up_ref() returns 1 for success or 0 otherwise.
+
+EVP_KEM_names_do_all() returns 1 if the callback was called for all names. A
+return value of 0 means that the callback was not called for any names.
 
 EVP_KEM_gettable_ctx_params() and EVP_KEM_settable_ctx_params() return
 a constant B<OSSL_PARAM> array or NULL on error.

--- a/doc/man3/EVP_KEYEXCH_free.pod
+++ b/doc/man3/EVP_KEYEXCH_free.pod
@@ -22,9 +22,9 @@ EVP_KEYEXCH_gettable_ctx_params, EVP_KEYEXCH_settable_ctx_params
  void EVP_KEYEXCH_do_all_provided(OSSL_LIB_CTX *libctx,
                                   void (*fn)(EVP_KEYEXCH *exchange, void *arg),
                                   void *arg);
- void EVP_KEYEXCH_names_do_all(const EVP_KEYEXCH *exchange,
-                               void (*fn)(const char *name, void *data),
-                               void *data);
+ int EVP_KEYEXCH_names_do_all(const EVP_KEYEXCH *exchange,
+                              void (*fn)(const char *name, void *data),
+                              void *data);
  const OSSL_PARAM *EVP_KEYEXCH_gettable_ctx_params(const EVP_KEYEXCH *keyexch);
  const OSSL_PARAM *EVP_KEYEXCH_settable_ctx_params(const EVP_KEYEXCH *keyexch);
 
@@ -71,7 +71,8 @@ L<EVP_PKEY_CTX_get_params(3)> and L<EVP_PKEY_CTX_set_params(3)>.
 EVP_KEYEXCH_fetch() returns a pointer to a B<EVP_KEYEXCH> for success
 or NULL for failure.
 
-EVP_KEYEXCH_up_ref() returns 1 for success or 0 otherwise.
+EVP_KEYEXCH_up_ref() and EVP_KEYEXCH_names_do_all() return 1 for success or 0
+otherwise.
 
 EVP_KEYEXCH_is_a() returns 1 of I<exchange> was identifiable,
 otherwise 0.

--- a/doc/man3/EVP_KEYEXCH_free.pod
+++ b/doc/man3/EVP_KEYEXCH_free.pod
@@ -71,8 +71,10 @@ L<EVP_PKEY_CTX_get_params(3)> and L<EVP_PKEY_CTX_set_params(3)>.
 EVP_KEYEXCH_fetch() returns a pointer to a B<EVP_KEYEXCH> for success
 or NULL for failure.
 
-EVP_KEYEXCH_up_ref() and EVP_KEYEXCH_names_do_all() return 1 for success or 0
-otherwise.
+EVP_KEYEXCH_up_ref() returns 1 for success or 0 otherwise.
+
+EVP_KEYEXCH_names_do_all() returns 1 if the callback was called for all
+names. A return value of 0 means that the callback was not called for any names.
 
 EVP_KEYEXCH_is_a() returns 1 of I<exchange> was identifiable,
 otherwise 0.

--- a/doc/man3/EVP_KEYMGMT.pod
+++ b/doc/man3/EVP_KEYMGMT.pod
@@ -108,8 +108,10 @@ EVP_KEYMGMT_fetch() returns a pointer to the key management
 implementation represented by an EVP_KEYMGMT object, or NULL on
 error.
 
-EVP_KEYMGMT_up_ref() and EVP_KEYMGMT_names_do_all() return 1 on success, or 0
-on error.
+EVP_KEYMGMT_up_ref() returns 1 on success, or 0 on error.
+
+EVP_KEYMGMT_names_do_all() returns 1 if the callback was called for all
+names. A return value of 0 means that the callback was not called for any names.
 
 EVP_KEYMGMT_free() doesn't return any value.
 

--- a/doc/man3/EVP_KEYMGMT.pod
+++ b/doc/man3/EVP_KEYMGMT.pod
@@ -35,9 +35,9 @@ EVP_KEYMGMT_gen_settable_params
  void EVP_KEYMGMT_do_all_provided(OSSL_LIB_CTX *libctx,
                                   void (*fn)(EVP_KEYMGMT *keymgmt, void *arg),
                                   void *arg);
- void EVP_KEYMGMT_names_do_all(const EVP_KEYMGMT *keymgmt,
-                               void (*fn)(const char *name, void *data),
-                               void *data);
+ int EVP_KEYMGMT_names_do_all(const EVP_KEYMGMT *keymgmt,
+                              void (*fn)(const char *name, void *data),
+                              void *data);
  const OSSL_PARAM *EVP_KEYMGMT_gettable_params(const EVP_KEYMGMT *keymgmt);
  const OSSL_PARAM *EVP_KEYMGMT_settable_params(const EVP_KEYMGMT *keymgmt);
  const OSSL_PARAM *EVP_KEYMGMT_gen_settable_params(const EVP_KEYMGMT *keymgmt);
@@ -108,7 +108,8 @@ EVP_KEYMGMT_fetch() returns a pointer to the key management
 implementation represented by an EVP_KEYMGMT object, or NULL on
 error.
 
-EVP_KEYMGMT_up_ref() returns 1 on success, or 0 on error.
+EVP_KEYMGMT_up_ref() and EVP_KEYMGMT_names_do_all() return 1 on success, or 0
+on error.
 
 EVP_KEYMGMT_free() doesn't return any value.
 

--- a/doc/man3/EVP_MAC.pod
+++ b/doc/man3/EVP_MAC.pod
@@ -25,9 +25,9 @@ EVP_MAC_do_all_provided - EVP MAC routines
  int EVP_MAC_is_a(const EVP_MAC *mac, const char *name);
  int EVP_MAC_number(const EVP_MAC *mac);
  const char *EVP_MAC_name(const EVP_MAC *mac);
- void EVP_MAC_names_do_all(const EVP_MAC *mac,
-                           void (*fn)(const char *name, void *data),
-                           void *data);
+ int EVP_MAC_names_do_all(const EVP_MAC *mac,
+                          void (*fn)(const char *name, void *data),
+                          void *data);
  const OSSL_PROVIDER *EVP_MAC_provider(const EVP_MAC *mac);
  int EVP_MAC_get_params(EVP_MAC *mac, OSSL_PARAM params[]);
 
@@ -289,7 +289,7 @@ Anything else may give undefined results.
 EVP_MAC_fetch() returns a pointer to a newly fetched EVP_MAC, or
 NULL if allocation failed.
 
-EVP_MAC_up_ref() returns 1 on success, 0 on error.
+EVP_MAC_up_ref() and EVP_MAC_names_do_all() return 1 on success, 0 on error.
 
 EVP_MAC_free() returns nothing at all.
 

--- a/doc/man3/EVP_MAC.pod
+++ b/doc/man3/EVP_MAC.pod
@@ -289,7 +289,10 @@ Anything else may give undefined results.
 EVP_MAC_fetch() returns a pointer to a newly fetched EVP_MAC, or
 NULL if allocation failed.
 
-EVP_MAC_up_ref() and EVP_MAC_names_do_all() return 1 on success, 0 on error.
+EVP_MAC_up_ref() returns 1 on success, 0 on error.
+
+EVP_MAC_names_do_all() returns 1 if the callback was called for all names. A
+return value of 0 means that the callback was not called for any names.
 
 EVP_MAC_free() returns nothing at all.
 

--- a/doc/man3/EVP_PKEY_is_a.pod
+++ b/doc/man3/EVP_PKEY_is_a.pod
@@ -46,7 +46,8 @@ supports signing, otherwise 0.
 
 EVP_PKEY_get0_first_alg_name() returns the name that is found or NULL on error.
 
-EVP_PKEY_typenames_do_all() returns 1 on success or 0 otherwise.
+EVP_PKEY_typenames_do_all() returns 1 if the callback was called for all names.
+A return value of 0 means that the callback was not called for any names.
 
 =head1 EXAMPLES
 

--- a/doc/man3/EVP_PKEY_is_a.pod
+++ b/doc/man3/EVP_PKEY_is_a.pod
@@ -12,9 +12,9 @@ EVP_PKEY_get0_first_alg_name
 
  int EVP_PKEY_is_a(const EVP_PKEY *pkey, const char *name);
  int EVP_PKEY_can_sign(const EVP_PKEY *pkey);
- void EVP_PKEY_typenames_do_all(const EVP_PKEY *pkey,
-                                void (*fn)(const char *name, void *data),
-                                void *data);
+ int EVP_PKEY_typenames_do_all(const EVP_PKEY *pkey,
+                               void (*fn)(const char *name, void *data),
+                               void *data);
  const char *EVP_PKEY_get0_first_alg_name(const EVP_PKEY *key);
 
 =head1 DESCRIPTION
@@ -45,6 +45,8 @@ EVP_PKEY_can_sign() returns 1 if the I<pkey> key type functionality
 supports signing, otherwise 0.
 
 EVP_PKEY_get0_first_alg_name() returns the name that is found or NULL on error.
+
+EVP_PKEY_typenames_do_all() returns 1 on success or 0 otherwise.
 
 =head1 EXAMPLES
 

--- a/doc/man3/EVP_RAND.pod
+++ b/doc/man3/EVP_RAND.pod
@@ -327,7 +327,10 @@ EVP_RAND_name() returns the name of the random number generation algorithm.
 EVP_RAND_number() returns the provider specific identification number
 for the specified algorithm.
 
-EVP_RAND_up_ref() and EVP_RAND_names_do_all() return 1 on success, 0 on error.
+EVP_RAND_up_ref() returns 1 on success, 0 on error.
+
+EVP_RAND_names_do_all() returns 1 if the callback was called for all names. A
+return value of 0 means that the callback was not called for any names.
 
 EVP_RAND_CTX_new() returns either the newly allocated
 B<EVP_RAND_CTX> structure or NULL if an error occurred.

--- a/doc/man3/EVP_RAND.pod
+++ b/doc/man3/EVP_RAND.pod
@@ -41,9 +41,9 @@ EVP_RAND_STATE_ERROR - EVP RAND routines
  void EVP_RAND_do_all_provided(OSSL_LIB_CTX *libctx,
                                void (*fn)(EVP_RAND *rand, void *arg),
                                void *arg);
- void EVP_RAND_names_do_all(const EVP_RAND *rand,
-                            void (*fn)(const char *name, void *data),
-                            void *data);
+ int EVP_RAND_names_do_all(const EVP_RAND *rand,
+                           void (*fn)(const char *name, void *data),
+                           void *data);
 
  int EVP_RAND_instantiate(EVP_RAND_CTX *ctx, unsigned int strength,
                           int prediction_resistance,
@@ -327,7 +327,7 @@ EVP_RAND_name() returns the name of the random number generation algorithm.
 EVP_RAND_number() returns the provider specific identification number
 for the specified algorithm.
 
-EVP_RAND_up_ref() returns 1 on success, 0 on error.
+EVP_RAND_up_ref() and EVP_RAND_names_do_all() return 1 on success, 0 on error.
 
 EVP_RAND_CTX_new() returns either the newly allocated
 B<EVP_RAND_CTX> structure or NULL if an error occurred.

--- a/doc/man3/EVP_SIGNATURE_free.pod
+++ b/doc/man3/EVP_SIGNATURE_free.pod
@@ -74,8 +74,10 @@ L<EVP_PKEY_CTX_get_params(3)> and L<EVP_PKEY_CTX_set_params(3)>.
 EVP_SIGNATURE_fetch() returns a pointer to an B<EVP_SIGNATURE> for success
 or B<NULL> for failure.
 
-EVP_SIGNATURE_up_ref() and EVP_SIGNATURE_names_do_all() return 1 for success or
-0 otherwise.
+EVP_SIGNATURE_up_ref() returns 1 for success or 0 otherwise.
+
+EVP_SIGNATURE_names_do_all() returns 1 if the callback was called for all names.
+A return value of 0 means that the callback was not called for any names.
 
 EVP_SIGNATURE_gettable_ctx_params() and EVP_SIGNATURE_settable_ctx_params()
 return a constant B<OSSL_PARAM> array or NULL on error.

--- a/doc/man3/EVP_SIGNATURE_free.pod
+++ b/doc/man3/EVP_SIGNATURE_free.pod
@@ -23,9 +23,9 @@ EVP_SIGNATURE_gettable_ctx_params, EVP_SIGNATURE_settable_ctx_params
                                     void (*fn)(EVP_SIGNATURE *signature,
                                                void *arg),
                                     void *arg);
- void EVP_SIGNATURE_names_do_all(const EVP_SIGNATURE *signature,
-                                 void (*fn)(const char *name, void *data),
-                                 void *data);
+ int EVP_SIGNATURE_names_do_all(const EVP_SIGNATURE *signature,
+                                void (*fn)(const char *name, void *data),
+                                void *data);
  const OSSL_PARAM *EVP_SIGNATURE_gettable_ctx_params(const EVP_SIGNATURE *sig);
  const OSSL_PARAM *EVP_SIGNATURE_settable_ctx_params(const EVP_SIGNATURE *sig);
 
@@ -74,7 +74,8 @@ L<EVP_PKEY_CTX_get_params(3)> and L<EVP_PKEY_CTX_set_params(3)>.
 EVP_SIGNATURE_fetch() returns a pointer to an B<EVP_SIGNATURE> for success
 or B<NULL> for failure.
 
-EVP_SIGNATURE_up_ref() returns 1 for success or 0 otherwise.
+EVP_SIGNATURE_up_ref() and EVP_SIGNATURE_names_do_all() return 1 for success or
+0 otherwise.
 
 EVP_SIGNATURE_gettable_ctx_params() and EVP_SIGNATURE_settable_ctx_params()
 return a constant B<OSSL_PARAM> array or NULL on error.

--- a/doc/man3/OSSL_DECODER.pod
+++ b/doc/man3/OSSL_DECODER.pod
@@ -33,9 +33,9 @@ OSSL_DECODER_get_params
  void OSSL_DECODER_do_all_provided(OSSL_LIB_CTX *libctx,
                                    void (*fn)(OSSL_DECODER *decoder, void *arg),
                                    void *arg);
- void OSSL_DECODER_names_do_all(const OSSL_DECODER *decoder,
-                                void (*fn)(const char *name, void *data),
-                                void *data);
+ int OSSL_DECODER_names_do_all(const OSSL_DECODER *decoder,
+                               void (*fn)(const char *name, void *data),
+                               void *data);
  const OSSL_PARAM *OSSL_DECODER_gettable_params(OSSL_DECODER *decoder);
  int OSSL_DECODER_get_params(OSSL_DECODER_CTX *ctx, const OSSL_PARAM params[]);
 
@@ -106,6 +106,8 @@ OSSL_DECODER_is_a() returns 1 if I<decoder> was identifiable,
 otherwise 0.
 
 OSSL_DECODER_number() returns an integer.
+
+OSSL_DECODER_names_do_all() returns 1 on success or 0 on failure.
 
 =head1 NOTES
 

--- a/doc/man3/OSSL_DECODER.pod
+++ b/doc/man3/OSSL_DECODER.pod
@@ -107,7 +107,8 @@ otherwise 0.
 
 OSSL_DECODER_number() returns an integer.
 
-OSSL_DECODER_names_do_all() returns 1 on success or 0 on failure.
+OSSL_DECODER_names_do_all() returns 1 if the callback was called for all
+names. A return value of 0 means that the callback was not called for any names.
 
 =head1 NOTES
 

--- a/doc/man3/OSSL_ENCODER.pod
+++ b/doc/man3/OSSL_ENCODER.pod
@@ -33,9 +33,9 @@ OSSL_ENCODER_get_params
  void OSSL_ENCODER_do_all_provided(OSSL_LIB_CTX *libctx,
                                    void (*fn)(OSSL_ENCODER *encoder, void *arg),
                                    void *arg);
- void OSSL_ENCODER_names_do_all(const OSSL_ENCODER *encoder,
-                                void (*fn)(const char *name, void *data),
-                                void *data);
+ int OSSL_ENCODER_names_do_all(const OSSL_ENCODER *encoder,
+                               void (*fn)(const char *name, void *data),
+                               void *data);
  const OSSL_PARAM *OSSL_ENCODER_gettable_params(OSSL_ENCODER *encoder);
  int OSSL_ENCODER_get_params(OSSL_ENCODER_CTX *ctx, const OSSL_PARAM params[]);
 
@@ -107,6 +107,8 @@ OSSL_ENCODER_is_a() returns 1 of I<encoder> was identifiable,
 otherwise 0.
 
 OSSL_ENCODER_number() returns an integer.
+
+OSSL_ENCODER_names_do_all() returns 1 on success or 0 otherwise.
 
 =head1 SEE ALSO
 

--- a/doc/man3/OSSL_ENCODER.pod
+++ b/doc/man3/OSSL_ENCODER.pod
@@ -108,7 +108,8 @@ otherwise 0.
 
 OSSL_ENCODER_number() returns an integer.
 
-OSSL_ENCODER_names_do_all() returns 1 on success or 0 otherwise.
+OSSL_ENCODER_names_do_all() returns 1 if the callback was called for all
+names. A return value of 0 means that the callback was not called for any names.
 
 =head1 SEE ALSO
 

--- a/doc/man3/OSSL_STORE_LOADER.pod
+++ b/doc/man3/OSSL_STORE_LOADER.pod
@@ -310,8 +310,10 @@ I<scheme>.
 OSSL_STORE_LOADER_fetch() returns a pointer to an OSSL_STORE_LOADER object,
 or NULL on error.
 
-OSSL_STORE_LOADER_up_ref() and EVP_SIGNATURE_names_do_all() return 1 on success,
-or 0 on error.
+OSSL_STORE_LOADER_up_ref() returns 1 on success, or 0 on error.
+
+OSSL_STORE_LOADER_names_do_all() returns 1 if the callback was called for all
+names. A return value of 0 means that the callback was not called for any names.
 
 OSSL_STORE_LOADER_free() doesn't return any value.
 

--- a/doc/man3/OSSL_STORE_LOADER.pod
+++ b/doc/man3/OSSL_STORE_LOADER.pod
@@ -48,9 +48,9 @@ unregister STORE loaders for different URI schemes
                                         void (*fn)(OSSL_STORE_LOADER *loader,
                                                    void *arg),
                                         void *arg);
- void OSSL_STORE_LOADER_names_do_all(const OSSL_STORE_LOADER *loader,
-                                     void (*fn)(const char *name, void *data),
-                                     void *data);
+ int OSSL_STORE_LOADER_names_do_all(const OSSL_STORE_LOADER *loader,
+                                    void (*fn)(const char *name, void *data),
+                                    void *data);
 
 Deprecated since OpenSSL 3.0, can be hidden entirely by defining
 B<OPENSSL_API_COMPAT> with a suitable version value, see
@@ -310,7 +310,8 @@ I<scheme>.
 OSSL_STORE_LOADER_fetch() returns a pointer to an OSSL_STORE_LOADER object,
 or NULL on error.
 
-OSSL_STORE_LOADER_up_ref() returns 1 on success, or 0 on error.
+OSSL_STORE_LOADER_up_ref() and EVP_SIGNATURE_names_do_all() return 1 on success,
+or 0 on error.
 
 OSSL_STORE_LOADER_free() doesn't return any value.
 

--- a/include/internal/namemap.h
+++ b/include/internal/namemap.h
@@ -31,9 +31,9 @@ int ossl_namemap_name2num_n(const OSSL_NAMEMAP *namemap,
                             const char *name, size_t name_len);
 const char *ossl_namemap_num2name(const OSSL_NAMEMAP *namemap, int number,
                                   size_t idx);
-void ossl_namemap_doall_names(const OSSL_NAMEMAP *namemap, int number,
-                              void (*fn)(const char *name, void *data),
-                              void *data);
+int ossl_namemap_doall_names(const OSSL_NAMEMAP *namemap, int number,
+                             void (*fn)(const char *name, void *data),
+                             void *data);
 
 /*
  * A utility that handles several names in a string, divided by a given

--- a/include/openssl/decoder.h
+++ b/include/openssl/decoder.h
@@ -39,9 +39,9 @@ int OSSL_DECODER_is_a(const OSSL_DECODER *encoder, const char *name);
 void OSSL_DECODER_do_all_provided(OSSL_LIB_CTX *libctx,
                                   void (*fn)(OSSL_DECODER *encoder, void *arg),
                                   void *arg);
-void OSSL_DECODER_names_do_all(const OSSL_DECODER *encoder,
-                               void (*fn)(const char *name, void *data),
-                               void *data);
+int OSSL_DECODER_names_do_all(const OSSL_DECODER *encoder,
+                              void (*fn)(const char *name, void *data),
+                              void *data);
 const OSSL_PARAM *OSSL_DECODER_gettable_params(OSSL_DECODER *decoder);
 int OSSL_DECODER_get_params(OSSL_DECODER *decoder, OSSL_PARAM params[]);
 

--- a/include/openssl/encoder.h
+++ b/include/openssl/encoder.h
@@ -39,9 +39,9 @@ int OSSL_ENCODER_is_a(const OSSL_ENCODER *encoder, const char *name);
 void OSSL_ENCODER_do_all_provided(OSSL_LIB_CTX *libctx,
                                   void (*fn)(OSSL_ENCODER *encoder, void *arg),
                                   void *arg);
-void OSSL_ENCODER_names_do_all(const OSSL_ENCODER *encoder,
-                               void (*fn)(const char *name, void *data),
-                               void *data);
+int OSSL_ENCODER_names_do_all(const OSSL_ENCODER *encoder,
+                              void (*fn)(const char *name, void *data),
+                              void *data);
 const OSSL_PARAM *OSSL_ENCODER_gettable_params(OSSL_ENCODER *encoder);
 int OSSL_ENCODER_get_params(OSSL_ENCODER *encoder, OSSL_PARAM params[]);
 

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -524,9 +524,9 @@ int EVP_MD_type(const EVP_MD *md);
 const char *EVP_MD_name(const EVP_MD *md);
 int EVP_MD_number(const EVP_MD *md);
 int EVP_MD_is_a(const EVP_MD *md, const char *name);
-void EVP_MD_names_do_all(const EVP_MD *md,
-                         void (*fn)(const char *name, void *data),
-                         void *data);
+int EVP_MD_names_do_all(const EVP_MD *md,
+                        void (*fn)(const char *name, void *data),
+                        void *data);
 const OSSL_PROVIDER *EVP_MD_provider(const EVP_MD *md);
 int EVP_MD_pkey_type(const EVP_MD *md);
 int EVP_MD_size(const EVP_MD *md);
@@ -555,9 +555,9 @@ int EVP_CIPHER_nid(const EVP_CIPHER *cipher);
 const char *EVP_CIPHER_name(const EVP_CIPHER *cipher);
 int EVP_CIPHER_number(const EVP_CIPHER *cipher);
 int EVP_CIPHER_is_a(const EVP_CIPHER *cipher, const char *name);
-void EVP_CIPHER_names_do_all(const EVP_CIPHER *cipher,
-                             void (*fn)(const char *name, void *data),
-                             void *data);
+int EVP_CIPHER_names_do_all(const EVP_CIPHER *cipher,
+                            void (*fn)(const char *name, void *data),
+                            void *data);
 const OSSL_PROVIDER *EVP_CIPHER_provider(const EVP_CIPHER *cipher);
 int EVP_CIPHER_block_size(const EVP_CIPHER *cipher);
 int EVP_CIPHER_impl_ctx_size(const EVP_CIPHER *cipher);
@@ -1153,9 +1153,9 @@ const OSSL_PARAM *EVP_MAC_settable_ctx_params(const EVP_MAC *mac);
 void EVP_MAC_do_all_provided(OSSL_LIB_CTX *libctx,
                              void (*fn)(EVP_MAC *mac, void *arg),
                              void *arg);
-void EVP_MAC_names_do_all(const EVP_MAC *mac,
-                          void (*fn)(const char *name, void *data),
-                          void *data);
+int EVP_MAC_names_do_all(const EVP_MAC *mac,
+                         void (*fn)(const char *name, void *data),
+                         void *data);
 
 /* RAND stuff */
 EVP_RAND *EVP_RAND_fetch(OSSL_LIB_CTX *libctx, const char *algorithm,
@@ -1180,9 +1180,9 @@ const OSSL_PARAM *EVP_RAND_settable_ctx_params(const EVP_RAND *rand);
 void EVP_RAND_do_all_provided(OSSL_LIB_CTX *libctx,
                               void (*fn)(EVP_RAND *rand, void *arg),
                               void *arg);
-void EVP_RAND_names_do_all(const EVP_RAND *rand,
-                           void (*fn)(const char *name, void *data),
-                           void *data);
+int EVP_RAND_names_do_all(const EVP_RAND *rand,
+                          void (*fn)(const char *name, void *data),
+                          void *data);
 
 __owur int EVP_RAND_instantiate(EVP_RAND_CTX *ctx, unsigned int strength,
                                 int prediction_resistance,
@@ -1217,9 +1217,9 @@ OSSL_DEPRECATEDIN_3_0 int EVP_PKEY_encrypt_old(unsigned char *enc_key,
                                           int key_len, EVP_PKEY *pub_key);
 #endif
 int EVP_PKEY_is_a(const EVP_PKEY *pkey, const char *name);
-void EVP_PKEY_typenames_do_all(const EVP_PKEY *pkey,
-                               void (*fn)(const char *name, void *data),
-                               void *data);
+int EVP_PKEY_typenames_do_all(const EVP_PKEY *pkey,
+                              void (*fn)(const char *name, void *data),
+                              void *data);
 int EVP_PKEY_type(int type);
 int EVP_PKEY_id(const EVP_PKEY *pkey);
 int EVP_PKEY_base_id(const EVP_PKEY *pkey);
@@ -1633,9 +1633,9 @@ int EVP_KEYMGMT_is_a(const EVP_KEYMGMT *keymgmt, const char *name);
 void EVP_KEYMGMT_do_all_provided(OSSL_LIB_CTX *libctx,
                                  void (*fn)(EVP_KEYMGMT *keymgmt, void *arg),
                                  void *arg);
-void EVP_KEYMGMT_names_do_all(const EVP_KEYMGMT *keymgmt,
-                              void (*fn)(const char *name, void *data),
-                              void *data);
+int EVP_KEYMGMT_names_do_all(const EVP_KEYMGMT *keymgmt,
+                             void (*fn)(const char *name, void *data),
+                             void *data);
 const OSSL_PARAM *EVP_KEYMGMT_gettable_params(const EVP_KEYMGMT *keymgmt);
 const OSSL_PARAM *EVP_KEYMGMT_settable_params(const EVP_KEYMGMT *keymgmt);
 const OSSL_PARAM *EVP_KEYMGMT_gen_settable_params(const EVP_KEYMGMT *keymgmt);
@@ -1715,9 +1715,9 @@ void EVP_SIGNATURE_do_all_provided(OSSL_LIB_CTX *libctx,
                                    void (*fn)(EVP_SIGNATURE *signature,
                                               void *data),
                                    void *data);
-void EVP_SIGNATURE_names_do_all(const EVP_SIGNATURE *signature,
-                                void (*fn)(const char *name, void *data),
-                                void *data);
+int EVP_SIGNATURE_names_do_all(const EVP_SIGNATURE *signature,
+                               void (*fn)(const char *name, void *data),
+                               void *data);
 const OSSL_PARAM *EVP_SIGNATURE_gettable_ctx_params(const EVP_SIGNATURE *sig);
 const OSSL_PARAM *EVP_SIGNATURE_settable_ctx_params(const EVP_SIGNATURE *sig);
 
@@ -1732,9 +1732,9 @@ void EVP_ASYM_CIPHER_do_all_provided(OSSL_LIB_CTX *libctx,
                                      void (*fn)(EVP_ASYM_CIPHER *cipher,
                                                 void *arg),
                                      void *arg);
-void EVP_ASYM_CIPHER_names_do_all(const EVP_ASYM_CIPHER *cipher,
-                                  void (*fn)(const char *name, void *data),
-                                  void *data);
+int EVP_ASYM_CIPHER_names_do_all(const EVP_ASYM_CIPHER *cipher,
+                                 void (*fn)(const char *name, void *data),
+                                 void *data);
 const OSSL_PARAM *EVP_ASYM_CIPHER_gettable_ctx_params(const EVP_ASYM_CIPHER *ciph);
 const OSSL_PARAM *EVP_ASYM_CIPHER_settable_ctx_params(const EVP_ASYM_CIPHER *ciph);
 
@@ -1747,8 +1747,8 @@ int EVP_KEM_is_a(const EVP_KEM *wrap, const char *name);
 int EVP_KEM_number(const EVP_KEM *wrap);
 void EVP_KEM_do_all_provided(OSSL_LIB_CTX *libctx,
                              void (*fn)(EVP_KEM *wrap, void *arg), void *arg);
-void EVP_KEM_names_do_all(const EVP_KEM *wrap,
-                          void (*fn)(const char *name, void *data), void *data);
+int EVP_KEM_names_do_all(const EVP_KEM *wrap,
+                         void (*fn)(const char *name, void *data), void *data);
 const OSSL_PARAM *EVP_KEM_gettable_ctx_params(const EVP_KEM *kem);
 const OSSL_PARAM *EVP_KEM_settable_ctx_params(const EVP_KEM *kem);
 
@@ -1994,9 +1994,9 @@ int EVP_KEYEXCH_number(const EVP_KEYEXCH *keyexch);
 void EVP_KEYEXCH_do_all_provided(OSSL_LIB_CTX *libctx,
                                  void (*fn)(EVP_KEYEXCH *keyexch, void *data),
                                  void *data);
-void EVP_KEYEXCH_names_do_all(const EVP_KEYEXCH *keyexch,
-                              void (*fn)(const char *name, void *data),
-                              void *data);
+int EVP_KEYEXCH_names_do_all(const EVP_KEYEXCH *keyexch,
+                             void (*fn)(const char *name, void *data),
+                             void *data);
 const OSSL_PARAM *EVP_KEYEXCH_gettable_ctx_params(const EVP_KEYEXCH *keyexch);
 const OSSL_PARAM *EVP_KEYEXCH_settable_ctx_params(const EVP_KEYEXCH *keyexch);
 

--- a/include/openssl/kdf.h
+++ b/include/openssl/kdf.h
@@ -52,9 +52,9 @@ const OSSL_PARAM *EVP_KDF_settable_ctx_params(const EVP_KDF *kdf);
 void EVP_KDF_do_all_provided(OSSL_LIB_CTX *libctx,
                              void (*fn)(EVP_KDF *kdf, void *arg),
                              void *arg);
-void EVP_KDF_names_do_all(const EVP_KDF *kdf,
-                          void (*fn)(const char *name, void *data),
-                          void *data);
+int EVP_KDF_names_do_all(const EVP_KDF *kdf,
+                         void (*fn)(const char *name, void *data),
+                         void *data);
 
 # define EVP_KDF_HKDF_MODE_EXTRACT_AND_EXPAND  0
 # define EVP_KDF_HKDF_MODE_EXTRACT_ONLY        1

--- a/include/openssl/store.h
+++ b/include/openssl/store.h
@@ -266,9 +266,9 @@ void OSSL_STORE_LOADER_do_all_provided(OSSL_LIB_CTX *libctx,
                                        void (*fn)(OSSL_STORE_LOADER *loader,
                                                   void *arg),
                                        void *arg);
-void OSSL_STORE_LOADER_names_do_all(const OSSL_STORE_LOADER *loader,
-                                    void (*fn)(const char *name, void *data),
-                                    void *data);
+int OSSL_STORE_LOADER_names_do_all(const OSSL_STORE_LOADER *loader,
+                                   void (*fn)(const char *name, void *data),
+                                   void *data);
 
 /*-
  *  Function to register a loader for the given URI scheme.

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -2439,6 +2439,51 @@ static int test_EVP_rsa_pss_with_keygen_bits(void)
     return ret;
 }
 
+static int success = 1;
+static void md_names(const char *name, void *vctx)
+{
+    OSSL_LIB_CTX *ctx = (OSSL_LIB_CTX *)vctx;
+    /* Force a namemap update */
+    EVP_CIPHER *aes128 = EVP_CIPHER_fetch(ctx, "AES-128-CBC", NULL);
+
+    if (!TEST_ptr(aes128))
+        success = 0;
+}
+
+/*
+ * Test that changing the namemap in a user callback works in a names_do_all
+ * function.
+ */
+static int test_names_do_all(void)
+{
+    /* We use a custom libctx so that we know the state of the namemap */
+    OSSL_LIB_CTX *ctx = OSSL_LIB_CTX_new();
+    EVP_MD *sha256 = NULL;
+    int testresult = 0;
+
+    if (!TEST_ptr(ctx))
+        goto err;
+
+    sha256 = EVP_MD_fetch(ctx, "SHA2-256", NULL);
+    if (!TEST_ptr(sha256))
+        goto err;
+
+    /*
+     * We loop through all the names for a given digest. This should still work
+     * even if the namemap changes part way through.
+     */
+    if (!TEST_true(EVP_MD_names_do_all(sha256, md_names, ctx)))
+        goto err;
+
+    if (!TEST_true(success))
+        goto err;
+
+    testresult = 1;
+ err:
+    EVP_MD_free(sha256);
+    OSSL_LIB_CTX_free(ctx);
+    return testresult;
+}
 
 int setup_tests(void)
 {
@@ -2512,6 +2557,8 @@ int setup_tests(void)
     ADD_TEST(test_rand_agglomeration);
     ADD_ALL_TESTS(test_evp_iv, 10);
     ADD_TEST(test_EVP_rsa_pss_with_keygen_bits);
+
+    ADD_TEST(test_names_do_all);
 
     return 1;
 }

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -2448,6 +2448,8 @@ static void md_names(const char *name, void *vctx)
 
     if (!TEST_ptr(aes128))
         success = 0;
+
+    EVP_CIPHER_free(aes128);
 }
 
 /*


### PR DESCRIPTION
We don't want to hold a read lock when calling a user supplied callback.
That callback could do anything so the risk of a deadlock is high.
Instead we collect all the names first inside the read lock, and then
subsequently call the user callback outside the read lock.

Fixes #14225
