### PR TITLE
Add tests for EC public key encoding/decoding with the legacy APIs

### DIFF
--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -2428,7 +2428,7 @@ static int test_ecpub(int idx)
     unsigned char buf[1024];
     unsigned char *p;
     const unsigned char *q;
-    EVP_PKEY *pkey = NULL, *pkey2 = NULL, *pkeytmp = NULL;
+    EVP_PKEY *pkey = NULL, *pkey2 = NULL;
     EVP_PKEY_CTX *ctx = NULL;
     EC_KEY *ec = NULL;
 
@@ -2453,14 +2453,13 @@ static int test_ecpub(int idx)
 
     /* Now try to decode the just-created DER. */
     q = buf;
-    if (!TEST_ptr((pkeytmp = EVP_PKEY_new()))
+    if (!TEST_ptr((pkey2 = EVP_PKEY_new()))
             || !TEST_ptr((ec = EC_KEY_new_by_curve_name(nid)))
-            || !TEST_true(EVP_PKEY_assign_EC_KEY(pkeytmp, ec)))
+            || !TEST_true(EVP_PKEY_assign_EC_KEY(pkey2, ec)))
         goto done;
     /* EC_KEY ownership transferred */
     ec = NULL;
-    if (!TEST_ptr((pkey2 = d2i_PublicKey(EVP_PKEY_EC, &pkeytmp, &q,
-                                                savelen))))
+    if (!TEST_ptr(d2i_PublicKey(EVP_PKEY_EC, &pkey2, &q, savelen)))
         goto done;
     /* The keys should match. */
     if (!TEST_int_eq(EVP_PKEY_cmp(pkey, pkey2), 1))
@@ -2471,7 +2470,6 @@ static int test_ecpub(int idx)
  done:
     EVP_PKEY_CTX_free(ctx);
     EVP_PKEY_free(pkey);
-    EVP_PKEY_free(pkeytmp);
     EVP_PKEY_free(pkey2);
     EC_KEY_free(ec);
     return ret;

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -2415,6 +2415,7 @@ err:
     return ret;
 }
 
+#ifndef OPENSSL_NO_EC
 static int ecpub_nids[] = { NID_brainpoolP256r1, NID_X9_62_prime256v1,
     NID_secp384r1, NID_secp521r1, NID_sect233k1, NID_sect233r1, NID_sect283r1,
     NID_sect409k1, NID_sect409r1, NID_sect571k1, NID_sect571r1,
@@ -2475,6 +2476,7 @@ static int test_ecpub(int idx)
     EC_KEY_free(ec);
     return ret;
 }
+#endif
 
 static int test_EVP_rsa_pss_with_keygen_bits(void)
 {
@@ -2573,7 +2575,9 @@ int setup_tests(void)
     ADD_TEST(test_rand_agglomeration);
     ADD_ALL_TESTS(test_evp_iv, 10);
     ADD_TEST(test_EVP_rsa_pss_with_keygen_bits);
+#ifndef OPENSSL_NO_EC
     ADD_ALL_TESTS(test_ecpub, OSSL_NELEM(ecpub_nids));
+#endif
 
     return 1;
 }

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -2414,6 +2414,82 @@ err:
         EVP_CIPHER_free((EVP_CIPHER *)type);
     return ret;
 }
+static int test_ecpub(int idx)
+{
+    int ret = 0, len;
+    int nid;
+    unsigned char buf[1024];
+    unsigned char *p;
+    EVP_PKEY *pkey = NULL;
+    EVP_PKEY_CTX *ctx = NULL;
+
+    switch(idx) {
+    case 0:
+        nid = NID_brainpoolP256r1;
+        break;
+    case 1:
+        nid = NID_X9_62_prime256v1;
+        break;
+    case 2:
+        nid = NID_secp384r1;
+        break;
+    case 3:
+        nid = NID_secp521r1;
+        break;
+    case 4:
+        nid = NID_sect233k1;
+        break;
+    case 5:
+        nid = NID_sect233r1;
+        break;
+    case 6:
+        nid = NID_sect283r1;
+        break;
+    case 7:
+        nid = NID_sect409k1;
+        break;
+    case 8:
+        nid = NID_sect409r1;
+        break;
+    case 9:
+        nid = NID_sect571k1;
+        break;
+    case 10:
+        nid = NID_sect571r1;
+        break;
+    case 11:
+        nid = NID_brainpoolP384r1;
+        break;
+    case 12:
+        nid = NID_brainpoolP512r1;
+        break;
+    default:
+        TEST_info("unhandled ecpub index");
+        goto done;
+    }
+
+    ctx = EVP_PKEY_CTX_new_id(EVP_PKEY_EC, NULL);
+    if (!TEST_ptr(ctx)
+        || !TEST_true(EVP_PKEY_keygen_init(ctx))
+        || !TEST_true(EVP_PKEY_CTX_set_ec_paramgen_curve_nid(ctx, nid))
+        || !TEST_true(EVP_PKEY_keygen(ctx, &pkey)))
+        goto done;
+    len = i2d_PublicKey(pkey, NULL);
+    if (!TEST_int_ge(len, 1)
+        || !TEST_int_lt(len, 1024))
+        goto done;
+    p = buf;
+    len = i2d_PublicKey(pkey, &p);
+    if (!TEST_int_ge(len, 1))
+        goto done;
+
+    ret = 1;
+
+ done:
+    EVP_PKEY_CTX_free(ctx);
+    EVP_PKEY_free(pkey);
+    return ret;
+}
 
 static int test_EVP_rsa_pss_with_keygen_bits(void)
 {
@@ -2512,6 +2588,7 @@ int setup_tests(void)
     ADD_TEST(test_rand_agglomeration);
     ADD_ALL_TESTS(test_evp_iv, 10);
     ADD_TEST(test_EVP_rsa_pss_with_keygen_bits);
+    ADD_ALL_TESTS(test_ecpub, 13);
 
     return 1;
 }

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -2416,7 +2416,7 @@ err:
 }
 static int test_ecpub(int idx)
 {
-    int ret = 0, len;
+    int ret = 0, len, savelen;
     int nid;
     unsigned char buf[1024];
     unsigned char *p;
@@ -2475,12 +2475,14 @@ static int test_ecpub(int idx)
         || !TEST_true(EVP_PKEY_keygen(ctx, &pkey)))
         goto done;
     len = i2d_PublicKey(pkey, NULL);
+    savelen = len;
     if (!TEST_int_ge(len, 1)
         || !TEST_int_lt(len, 1024))
         goto done;
     p = buf;
     len = i2d_PublicKey(pkey, &p);
-    if (!TEST_int_ge(len, 1))
+    if (!TEST_int_ge(len, 1)
+            || !TEST_int_eq(len, savelen))
         goto done;
 
     ret = 1;

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -2414,6 +2414,12 @@ err:
         EVP_CIPHER_free((EVP_CIPHER *)type);
     return ret;
 }
+
+static int ecpub_nids[] = { NID_brainpoolP256r1, NID_X9_62_prime256v1,
+    NID_secp384r1, NID_secp521r1, NID_sect233k1, NID_sect233r1, NID_sect283r1,
+    NID_sect409k1, NID_sect409r1, NID_sect571k1, NID_sect571r1,
+    NID_brainpoolP384r1, NID_brainpoolP512r1};
+
 static int test_ecpub(int idx)
 {
     int ret = 0, len, savelen;
@@ -2425,50 +2431,7 @@ static int test_ecpub(int idx)
     EVP_PKEY_CTX *ctx = NULL;
     EC_KEY *ec = NULL;
 
-    switch(idx) {
-    case 0:
-        nid = NID_brainpoolP256r1;
-        break;
-    case 1:
-        nid = NID_X9_62_prime256v1;
-        break;
-    case 2:
-        nid = NID_secp384r1;
-        break;
-    case 3:
-        nid = NID_secp521r1;
-        break;
-    case 4:
-        nid = NID_sect233k1;
-        break;
-    case 5:
-        nid = NID_sect233r1;
-        break;
-    case 6:
-        nid = NID_sect283r1;
-        break;
-    case 7:
-        nid = NID_sect409k1;
-        break;
-    case 8:
-        nid = NID_sect409r1;
-        break;
-    case 9:
-        nid = NID_sect571k1;
-        break;
-    case 10:
-        nid = NID_sect571r1;
-        break;
-    case 11:
-        nid = NID_brainpoolP384r1;
-        break;
-    case 12:
-        nid = NID_brainpoolP512r1;
-        break;
-    default:
-        TEST_info("unhandled ecpub index");
-        goto done;
-    }
+    nid = ecpub_nids[idx];
 
     ctx = EVP_PKEY_CTX_new_id(EVP_PKEY_EC, NULL);
     if (!TEST_ptr(ctx)
@@ -2610,7 +2573,7 @@ int setup_tests(void)
     ADD_TEST(test_rand_agglomeration);
     ADD_ALL_TESTS(test_evp_iv, 10);
     ADD_TEST(test_EVP_rsa_pss_with_keygen_bits);
-    ADD_ALL_TESTS(test_ecpub, 13);
+    ADD_ALL_TESTS(test_ecpub, OSSL_NELEM(ecpub_nids));
 
     return 1;
 }


### PR DESCRIPTION
Add some tests that expose the issues reported at #14258 .  The issues are not fixed, so the CI is expected to fail.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated

https://github.com/kaduk/openssl/commit/8d12b3bf581c02548d593c0852d538d17a509e8a is a crude hack that I used in order to get just the first commit's test to be able to pass, but I do not have even bad workarounds like that for the other two issues.