### PR TITLE
-Wunused-function cleanup

### DIFF
--- a/include/openssl/core_dispatch.h
+++ b/include/openssl/core_dispatch.h
@@ -44,7 +44,7 @@ extern "C" {
  */
 #define OSSL_CORE_MAKE_FUNC(type,name,args)                             \
     typedef type (OSSL_FUNC_##name##_fn)args;                           \
-    static ossl_inline \
+    static ossl_unused ossl_inline \
     OSSL_FUNC_##name##_fn *OSSL_FUNC_##name(const OSSL_DISPATCH *opf)   \
     {                                                                   \
         return (OSSL_FUNC_##name##_fn *)opf->function;                  \


### PR DESCRIPTION
core_dispatch.h seems to be the source of some compiler warnings with legacy applications in alpha12 now that it is implicitly exported via evp.h