### PR TITLE
util/perl/OpenSSL/config.pm: Fix determine_compiler_settings()

### DIFF
--- a/util/perl/OpenSSL/config.pm
+++ b/util/perl/OpenSSL/config.pm
@@ -337,6 +337,19 @@ sub determine_compiler_settings {
 
     # Vendor specific overrides, only if we determined the compiler here
     if ( ! $cc ) {
+        if ( $SYSTEM eq 'OpenVMS' ) {
+            my $v = `CC/VERSION NLA0:`;
+            if ($? == 0) {
+                my ($vendor, $version) =
+                    ( $v =~ m/^([A-Z]+) C V([0-9\.-]+) on / );
+                my ($major, $minor, $patch) =
+                    ( $version =~ m/^([0-9]+)\.([0-9]+)-0*?(0|[1-9][0-9]*)$/ );
+                $CC = 'CC';
+                $CCVENDOR = $vendor;
+                $CCVER = ( $major * 100 + $minor ) * 100 + $patch;
+            }
+        }
+
         if ( ${SYSTEM} eq 'AIX' ) {
             # favor vendor cc over gcc
             if (IPC::Cmd::can_run('cc')) {

--- a/util/perl/OpenSSL/config.pm
+++ b/util/perl/OpenSSL/config.pm
@@ -280,8 +280,8 @@ sub _pairs (@) {
 
 # Figure out CC, GCCVAR, etc.
 sub determine_compiler_settings {
-    # Make a copy and don't touch it.  That helps determine if we're
-    # finding the compiler here
+    # Make a copy and don't touch it.  That helps determine if we're finding
+    # the compiler here (false), or if it was set by the user (true.
     my $cc = $CC;
 
     # Set certain default
@@ -335,7 +335,7 @@ sub determine_compiler_settings {
         }
     }
 
-    # Vendor specific overrides, only if we determined the compiler here
+    # Vendor specific overrides, only if we didn't determine the compiler here
     if ( ! $cc ) {
         if ( $SYSTEM eq 'OpenVMS' ) {
             my $v = `CC/VERSION NLA0:`;


### PR DESCRIPTION
There may be times when a compiler can't be detected, in which case
determine_compiler_settings() bailed out too early, before platform
specific fallbacks have a chance to set the record straight.  That
bail out has been moved to be done after the platform specific
fallbacks.

Furthermore, the attempt to check for gcc or clang and get their
version number was done even if no compiler had been automatically
detected or pre-specified via $CC.  It now only does this when there
is a compiler specified or detected.  The platform specific fallbacks
check the versions separately.

This also includes adding a VMS specific fallback