### PR TITLE
Deprecated EVP_PKEY_CTX_get0_dh_kdf_ukm() and EVP_PKEY_CTX_get0_ecdh_kdf_ukm()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,15 +22,20 @@ OpenSSL 3.0
 -----------
 
 ### Changes between 1.1.1 and 3.0 [xx XXX xxxx]
+ * Deprecated obsolete EVP_PKEY_CTX_get0_dh_kdf_ukm() and
+   EVP_PKEY_CTX_get0_ecdh_kdf_ukm() functions. They are not needed
+   and require returning octet ptr parameters from providers that
+   would like to support them which complicates provider implementations.
 
-* The RAND_METHOD APIs have been deprecated.  The functions deprecated are:
+   *Tomáš Mráz*
+
+ * The RAND_METHOD APIs have been deprecated.  The functions deprecated are:
    RAND_OpenSSL(), RAND_get_rand_method(), RAND_set_rand_engine() and
    RAND_set_rand_method().  Provider based random number generators should
    be used instead via EVP_RAND(3).
 
    *Paul Dale*
-
-* The SRP APIs have been deprecated. The old APIs do not work via providers,
+ * The SRP APIs have been deprecated. The old APIs do not work via providers,
    and there is no EVP interface to them. Unfortunately there is no replacement
    for these APIs at this time.
 
@@ -41,7 +46,7 @@ OpenSSL 3.0
    at configuration time.
 
    *Paul Dale*
- 
+
  * Combining the Configure options no-ec and no-dh no longer disables TLSv1.3.
    Typically if OpenSSL has no EC or DH algorithms then it cannot support
    connections with TLSv1.3. However OpenSSL now supports "pluggable" groups

--- a/crypto/evp/dh_ctrl.c
+++ b/crypto/evp/dh_ctrl.c
@@ -7,6 +7,8 @@
  * https://www.openssl.org/source/license.html
  */
 
+#include "internal/deprecated.h"
+
 #include <stdio.h>
 #include <string.h>
 #include <openssl/core_names.h>
@@ -322,6 +324,7 @@ int EVP_PKEY_CTX_set0_dh_kdf_ukm(EVP_PKEY_CTX *ctx, unsigned char *ukm, int len)
     return ret;
 }
 
+#ifndef OPENSSL_NO_DEPRECATED_3_0
 int EVP_PKEY_CTX_get0_dh_kdf_ukm(EVP_PKEY_CTX *ctx, unsigned char **pukm)
 {
     int ret;
@@ -348,3 +351,4 @@ int EVP_PKEY_CTX_get0_dh_kdf_ukm(EVP_PKEY_CTX *ctx, unsigned char **pukm)
 
     return (int)ukmlen;
 }
+#endif

--- a/crypto/evp/ec_ctrl.c
+++ b/crypto/evp/ec_ctrl.c
@@ -243,6 +243,7 @@ int EVP_PKEY_CTX_set0_ecdh_kdf_ukm(EVP_PKEY_CTX *ctx, unsigned char *ukm, int le
     return ret;
 }
 
+#ifndef OPENSSL_NO_DEPRECATED_3_0
 int EVP_PKEY_CTX_get0_ecdh_kdf_ukm(EVP_PKEY_CTX *ctx, unsigned char **pukm)
 {
     size_t ukmlen;
@@ -283,6 +284,7 @@ int EVP_PKEY_CTX_get0_ecdh_kdf_ukm(EVP_PKEY_CTX *ctx, unsigned char **pukm)
 
     return ret;
 }
+#endif
 
 #ifndef FIPS_MODULE
 /*

--- a/doc/man3/EVP_PKEY_CTX_ctrl.pod
+++ b/doc/man3/EVP_PKEY_CTX_ctrl.pod
@@ -134,6 +134,7 @@ EVP_PKEY_CTX_set_kem_op
                                         const unsigned char *seed,
                                         size_t seedlen);
 
+ #include <openssl/dh.h>
 
  int EVP_PKEY_CTX_set_dh_paramgen_prime_len(EVP_PKEY_CTX *ctx, int len);
  int EVP_PKEY_CTX_set_dh_paramgen_subprime_len(EVP_PKEY_CTX *ctx, int len);

--- a/doc/man3/EVP_PKEY_CTX_ctrl.pod
+++ b/doc/man3/EVP_PKEY_CTX_ctrl.pod
@@ -134,7 +134,6 @@ EVP_PKEY_CTX_set_kem_op
                                         const unsigned char *seed,
                                         size_t seedlen);
 
- #include <openssl/dh.h>
 
  int EVP_PKEY_CTX_set_dh_paramgen_prime_len(EVP_PKEY_CTX *ctx, int len);
  int EVP_PKEY_CTX_set_dh_paramgen_subprime_len(EVP_PKEY_CTX *ctx, int len);
@@ -157,7 +156,6 @@ EVP_PKEY_CTX_set_kem_op
  int EVP_PKEY_CTX_set_dh_kdf_outlen(EVP_PKEY_CTX *ctx, int len);
  int EVP_PKEY_CTX_get_dh_kdf_outlen(EVP_PKEY_CTX *ctx, int *len);
  int EVP_PKEY_CTX_set0_dh_kdf_ukm(EVP_PKEY_CTX *ctx, unsigned char *ukm, int len);
- int EVP_PKEY_CTX_get0_dh_kdf_ukm(EVP_PKEY_CTX *ctx, unsigned char **ukm);
 
  #include <openssl/ec.h>
 
@@ -172,7 +170,6 @@ EVP_PKEY_CTX_set_kem_op
  int EVP_PKEY_CTX_set_ecdh_kdf_outlen(EVP_PKEY_CTX *ctx, int len);
  int EVP_PKEY_CTX_get_ecdh_kdf_outlen(EVP_PKEY_CTX *ctx, int *len);
  int EVP_PKEY_CTX_set0_ecdh_kdf_ukm(EVP_PKEY_CTX *ctx, unsigned char *ukm, int len);
- int EVP_PKEY_CTX_get0_ecdh_kdf_ukm(EVP_PKEY_CTX *ctx, unsigned char **ukm);
 
  int EVP_PKEY_CTX_set1_id(EVP_PKEY_CTX *ctx, void *id, size_t id_len);
  int EVP_PKEY_CTX_get1_id(EVP_PKEY_CTX *ctx, void *id);
@@ -185,6 +182,14 @@ L<openssl_user_macros(7)>:
  #include <openssl/rsa.h>
 
  int EVP_PKEY_CTX_set_rsa_keygen_pubexp(EVP_PKEY_CTX *ctx, BIGNUM *pubexp);
+
+ #include <openssl/dh.h>
+
+ int EVP_PKEY_CTX_get0_dh_kdf_ukm(EVP_PKEY_CTX *ctx, unsigned char **ukm);
+
+ #include <openssl/ec.h>
+
+ int EVP_PKEY_CTX_get0_ecdh_kdf_ukm(EVP_PKEY_CTX *ctx, unsigned char **ukm);
 
 =head1 DESCRIPTION
 
@@ -668,6 +673,9 @@ added in OpenSSL 1.0.0.
 
 In OpenSSL 1.1.1 and below the functions were mostly macros.
 From OpenSSL 3.0 they are all functions.
+
+EVP_PKEY_CTX_set_rsa_keygen_pubexp(), EVP_PKEY_CTX_get0_dh_kdf_ukm(),
+and EVP_PKEY_CTX_get0_ecdh_kdf_ukm() were deprecated in OpenSSL 3.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man7/EVP_KEYEXCH-DH.pod
+++ b/doc/man7/EVP_KEYEXCH-DH.pod
@@ -17,6 +17,19 @@ Key exchange support for the B<DH> key type.
 
 See L<provider-keyexch(7)/Common Key Exchange parameters>.
 
+=item "kdf-ukm" (B<OSSL_EXCHANGE_PARAM_KDF_UKM>) <octet_string>
+
+Sets the User Key Material to be used as part of the selected Key Derivation
+Function associated with the given key exchange ctx.
+
+=item "kdf-ukm" (B<OSSL_EXCHANGE_PARAM_KDF_UKM>) <octet_string_ptr>
+
+Gets a pointer to the User Key Material to be used as part of the selected
+Key Derivation Function associated with the given key exchange ctx. Providers
+usually do not need to support this gettable parameter as the sole purpose
+is to support functionality of the deprecated EVP_PKEY_CTX_get0_dh_kdf_ukm()
+function.
+
 =back
 
 =head1 EXAMPLES

--- a/doc/man7/EVP_KEYEXCH-DH.pod
+++ b/doc/man7/EVP_KEYEXCH-DH.pod
@@ -26,7 +26,7 @@ Function associated with the given key exchange ctx.
 
 Gets a pointer to the User Key Material to be used as part of the selected
 Key Derivation Function associated with the given key exchange ctx. Providers
-usually do not need to support this gettable parameter as the sole purpose
+usually do not need to support this gettable parameter as its sole purpose
 is to support functionality of the deprecated EVP_PKEY_CTX_get0_dh_kdf_ukm()
 function.
 

--- a/doc/man7/EVP_KEYEXCH-ECDH.pod
+++ b/doc/man7/EVP_KEYEXCH-ECDH.pod
@@ -60,7 +60,10 @@ Function associated with the given key exchange ctx.
 =item "kdf-ukm" (B<OSSL_EXCHANGE_PARAM_KDF_UKM>) <octet_string_ptr>
 
 Gets a pointer to the User Key Material to be used as part of the selected
-Key Derivation Function associated with the given key exchange ctx.
+Key Derivation Function associated with the given key exchange ctx. Providers
+usually do not need to support this gettable parameter as the sole purpose
+is to support functionality of the deprecated EVP_PKEY_CTX_get0_ecdh_kdf_ukm()
+function.
 
 =back
 

--- a/doc/man7/EVP_KEYEXCH-ECDH.pod
+++ b/doc/man7/EVP_KEYEXCH-ECDH.pod
@@ -61,7 +61,7 @@ Function associated with the given key exchange ctx.
 
 Gets a pointer to the User Key Material to be used as part of the selected
 Key Derivation Function associated with the given key exchange ctx. Providers
-usually do not need to support this gettable parameter as the sole purpose
+usually do not need to support this gettable parameter as its sole purpose
 is to support functionality of the deprecated EVP_PKEY_CTX_get0_ecdh_kdf_ukm()
 function.
 

--- a/include/openssl/core_names.h
+++ b/include/openssl/core_names.h
@@ -432,7 +432,7 @@ extern "C" {
 #define OSSL_EXCHANGE_PARAM_KDF_DIGEST            "kdf-digest" /* utf8_string */
 #define OSSL_EXCHANGE_PARAM_KDF_DIGEST_PROPS      "kdf-digest-props" /* utf8_string */
 #define OSSL_EXCHANGE_PARAM_KDF_OUTLEN            "kdf-outlen" /* size_t */
-/* The following parameter is octet_string on set and octet_ptr on get */
+/* The following parameter is an octet_string on set and octet_ptr on get */
 #define OSSL_EXCHANGE_PARAM_KDF_UKM               "kdf-ukm"
 
 /* Signature parameters */
@@ -457,7 +457,7 @@ extern "C" {
     OSSL_PKEY_PARAM_MGF1_PROPERTIES
 #define OSSL_ASYM_CIPHER_PARAM_OAEP_DIGEST              OSSL_ALG_PARAM_DIGEST
 #define OSSL_ASYM_CIPHER_PARAM_OAEP_DIGEST_PROPS        "digest-props"
-/* The following parameter is octet_string on set and octet_ptr on get */
+/* The following parameter is an octet_string on set and octet_ptr on get */
 #define OSSL_ASYM_CIPHER_PARAM_OAEP_LABEL               "oaep-label"
 #define OSSL_ASYM_CIPHER_PARAM_TLS_CLIENT_VERSION       "tls-client-version"
 #define OSSL_ASYM_CIPHER_PARAM_TLS_NEGOTIATED_VERSION   "tls-negotiated-version"

--- a/include/openssl/core_names.h
+++ b/include/openssl/core_names.h
@@ -432,7 +432,7 @@ extern "C" {
 #define OSSL_EXCHANGE_PARAM_KDF_DIGEST            "kdf-digest" /* utf8_string */
 #define OSSL_EXCHANGE_PARAM_KDF_DIGEST_PROPS      "kdf-digest-props" /* utf8_string */
 #define OSSL_EXCHANGE_PARAM_KDF_OUTLEN            "kdf-outlen" /* size_t */
-/* The following parameter is an octet_string on set and octet_ptr on get */
+/* The following parameter is an octet_string on set and an octet_ptr on get */
 #define OSSL_EXCHANGE_PARAM_KDF_UKM               "kdf-ukm"
 
 /* Signature parameters */
@@ -457,7 +457,7 @@ extern "C" {
     OSSL_PKEY_PARAM_MGF1_PROPERTIES
 #define OSSL_ASYM_CIPHER_PARAM_OAEP_DIGEST              OSSL_ALG_PARAM_DIGEST
 #define OSSL_ASYM_CIPHER_PARAM_OAEP_DIGEST_PROPS        "digest-props"
-/* The following parameter is an octet_string on set and octet_ptr on get */
+/* The following parameter is an octet_string on set and an octet_ptr on get */
 #define OSSL_ASYM_CIPHER_PARAM_OAEP_LABEL               "oaep-label"
 #define OSSL_ASYM_CIPHER_PARAM_TLS_CLIENT_VERSION       "tls-client-version"
 #define OSSL_ASYM_CIPHER_PARAM_TLS_NEGOTIATED_VERSION   "tls-negotiated-version"

--- a/include/openssl/core_names.h
+++ b/include/openssl/core_names.h
@@ -432,20 +432,8 @@ extern "C" {
 #define OSSL_EXCHANGE_PARAM_KDF_DIGEST            "kdf-digest" /* utf8_string */
 #define OSSL_EXCHANGE_PARAM_KDF_DIGEST_PROPS      "kdf-digest-props" /* utf8_string */
 #define OSSL_EXCHANGE_PARAM_KDF_OUTLEN            "kdf-outlen" /* size_t */
-
-/*
- * TODO(3.0): improve this pattern
- *
- * Currently the sole internal user of OSSL_EXCHANGE_PARAM_KDF_UKM is
- * EVP_PKEY_CTX_{set0,get0}_ecdh_kdf_ukm():
- *      OSSL_EXCHANGE_PARAM_KDF_UKM is handled as a octet_string on set0,
- *      and as an octet_ptr on get0.
- *
- * This pattern is borrowed from the handling of
- * OSSL_ASYM_CIPHER_PARAM_OAEP_LABEL in
- * EVP_PKEY_CTX_{set0,get0}_rsa_oaep_label().
- */
-#define OSSL_EXCHANGE_PARAM_KDF_UKM               "kdf-ukm" /* see note above */
+/* The following parameter is octet_string on set and octet_ptr on get */
+#define OSSL_EXCHANGE_PARAM_KDF_UKM               "kdf-ukm"
 
 /* Signature parameters */
 #define OSSL_SIGNATURE_PARAM_ALGORITHM_ID       "algorithm-id"
@@ -469,6 +457,7 @@ extern "C" {
     OSSL_PKEY_PARAM_MGF1_PROPERTIES
 #define OSSL_ASYM_CIPHER_PARAM_OAEP_DIGEST              OSSL_ALG_PARAM_DIGEST
 #define OSSL_ASYM_CIPHER_PARAM_OAEP_DIGEST_PROPS        "digest-props"
+/* The following parameter is octet_string on set and octet_ptr on get */
 #define OSSL_ASYM_CIPHER_PARAM_OAEP_LABEL               "oaep-label"
 #define OSSL_ASYM_CIPHER_PARAM_TLS_CLIENT_VERSION       "tls-client-version"
 #define OSSL_ASYM_CIPHER_PARAM_TLS_NEGOTIATED_VERSION   "tls-negotiated-version"

--- a/include/openssl/dh.h
+++ b/include/openssl/dh.h
@@ -53,7 +53,10 @@ int EVP_PKEY_CTX_get_dh_kdf_md(EVP_PKEY_CTX *ctx, const EVP_MD **md);
 int EVP_PKEY_CTX_set_dh_kdf_outlen(EVP_PKEY_CTX *ctx, int len);
 int EVP_PKEY_CTX_get_dh_kdf_outlen(EVP_PKEY_CTX *ctx, int *len);
 int EVP_PKEY_CTX_set0_dh_kdf_ukm(EVP_PKEY_CTX *ctx, unsigned char *ukm, int len);
+# ifndef OPENSSL_NO_DEPRECATED_3_0
+OSSL_DEPRECATEDIN_3_0
 int EVP_PKEY_CTX_get0_dh_kdf_ukm(EVP_PKEY_CTX *ctx, unsigned char **ukm);
+#endif
 
 # define EVP_PKEY_CTRL_DH_PARAMGEN_PRIME_LEN     (EVP_PKEY_ALG_CTRL + 1)
 # define EVP_PKEY_CTRL_DH_PARAMGEN_GENERATOR     (EVP_PKEY_ALG_CTRL + 2)

--- a/include/openssl/ec.h
+++ b/include/openssl/ec.h
@@ -44,7 +44,10 @@ int EVP_PKEY_CTX_get_ecdh_kdf_outlen(EVP_PKEY_CTX *ctx, int *len);
 
 int EVP_PKEY_CTX_set0_ecdh_kdf_ukm(EVP_PKEY_CTX *ctx, unsigned char *ukm,
                                    int len);
+# ifndef OPENSSL_NO_DEPRECATED_3_0
+OSSL_DEPRECATEDIN_3_0
 int EVP_PKEY_CTX_get0_ecdh_kdf_ukm(EVP_PKEY_CTX *ctx, unsigned char **ukm);
+# endif
 
 # define EVP_PKEY_CTRL_EC_PARAMGEN_CURVE_NID    (EVP_PKEY_ALG_CTRL + 1)
 # define EVP_PKEY_CTRL_EC_PARAM_ENC             (EVP_PKEY_ALG_CTRL + 2)

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4900,7 +4900,7 @@ EVP_PKEY_CTX_get_ecdh_kdf_md            ?	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_CTX_set_ecdh_kdf_outlen        ?	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_CTX_get_ecdh_kdf_outlen        ?	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_CTX_set0_ecdh_kdf_ukm          ?	3_0_0	EXIST::FUNCTION:
-EVP_PKEY_CTX_get0_ecdh_kdf_ukm          ?	3_0_0	EXIST::FUNCTION:
+EVP_PKEY_CTX_get0_ecdh_kdf_ukm          ?	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
 EVP_PKEY_CTX_set_rsa_pss_saltlen        ?	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_CTX_get_rsa_pss_saltlen        ?	3_0_0	EXIST::FUNCTION:
 d2i_ISSUER_SIGN_TOOL                    ?	3_0_0	EXIST::FUNCTION:
@@ -5186,7 +5186,7 @@ EVP_PKEY_CTX_get_dh_kdf_md              ?	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_CTX_set_dh_kdf_outlen          ?	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_CTX_get_dh_kdf_outlen          ?	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_CTX_set0_dh_kdf_ukm            ?	3_0_0	EXIST::FUNCTION:
-EVP_PKEY_CTX_get0_dh_kdf_ukm            ?	3_0_0	EXIST::FUNCTION:
+EVP_PKEY_CTX_get0_dh_kdf_ukm            ?	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
 EVP_CIPHER_CTX_get_updated_iv           ?	3_0_0	EXIST::FUNCTION:
 EVP_CIPHER_CTX_get_original_iv          ?	3_0_0	EXIST::FUNCTION:
 EVP_KEYMGMT_gettable_params             ?	3_0_0	EXIST::FUNCTION:


### PR DESCRIPTION
The functions are not needed and require returning octet ptr parameters
from providers that would like to support them which complicates provider
implementations.

Fixes #12985

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
