### PR TITLE
WIP: Write makefile to build app&tests 

### DIFF
--- a/Configurations/unix-mk-sep
+++ b/Configurations/unix-mk-sep
@@ -1,0 +1,111 @@
+#! /usr/bin/env perl
+# Copyright 2021 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+use strict;
+use warnings;
+
+# Wrap an array of values Makefile-style.
+sub wrap {
+    my $length = 8;
+    my $res = '';
+
+    foreach my $f ( @_ ) {
+        my $i = length $f;
+        if ( $i + $length >= 75 ) {
+            $res .= " \\\n\t";
+            $length = 8;
+        }
+        $length += $i + 1;
+        $res .= "$f ";
+    }
+    $res .= "\n";
+    return $res;
+}
+
+# Inherit CFLAGS without any -I flags.
+my $cflags = &wrap(grep { $_ !~ /-I/ } @{$config{CFLAGS}});
+chomp($cflags);
+
+# Used to set variables in Makefile
+my $appslib = "apps/lib/libapps.a";
+my $testlib = "test/testutil/libtestutil.a";
+my $ossl_libdir = $ENV{OPENSSL_LIBDIR} // '???';
+my $ossl_headers = $ENV{OPENSSL_HEADERS} // '???';
+
+print <<EOF;
+##
+## Makefile to build the OpenSSL application and tests,
+## using external headers and library.
+##
+
+# Path to where the libraries are.
+OPENSSL_LIBDIR ?= $ossl_libdir
+# Path to where the headers are.
+OPENSSL_HEADERS ?= $ossl_headers
+
+# Edit appropriately.
+CFLAGS = $cflags -I\$(OPENSSL_HEADERS)
+CC = $config{CC}
+TESTLIBS = $testlib $appslib \\
+\t\$(OPENSSL_LIBDIR) -lcrypto -lssl
+EOF
+
+my @appfiles =
+    map { s/.c$/.o/; $_ }
+        map { $unified_info{sources}->{$_}->[0] }
+            grep { !/apps\/lib/ }
+                grep { /apps\/.*\.o/ } keys %{$unified_info{sources}};
+print "\n# Object files for the OpenSSL app\n";
+print "APPOBJECTS = \\\n\t", &wrap(@appfiles);
+
+my @applibfiles =
+    map { s/.c$/.o/; $_ }
+        map { $unified_info{sources}->{$_}->[0] }
+            grep { /apps\/lib\/.*\.o/ } keys %{$unified_info{sources}};
+print "\n# Object files for the app library\n";
+print "APPLIBOBJECTS = \\\n\t", &wrap(@applibfiles);
+
+my @testlibfiles =
+    map { s/.c$/.o/; $_ }
+        map { $unified_info{sources}->{$_}->[0] }
+            grep { /test\/testutil\/.*\.o/ } keys %{$unified_info{sources}};
+print "\n# Object files for the test library\n";
+print "TESTLIBOBJECTS = \\\n\t", &wrap(@testlibfiles);
+
+my @testprogs =
+    grep { !/buildtest/ }
+        grep { /test\// } @{$unified_info{programs}};
+print "\n# Test programs\n";
+print "TESTPROGS = \\\n\t", &wrap(@testprogs);
+
+print <<EOF;
+
+all: openssl \$(TESTPROGS)
+
+openssl: \$(APPOBJECTS) $appslib $testlib
+\t\$(CC) -o \$@ \$(APPOBJECTS) $appslib \\
+\t\t-L\$(OPENSSL_LIBDIR) -lcrypto -lssl
+
+${appslib}: \$(APPLIBOBJECTS)
+\tar r $appslib \$(APPLIBOBJECTS)
+
+${testlib}: \$(TESTLIBOBJECTS)
+\tar r $testlib \$(TESTLIBOBJECTS)
+
+clean:
+\trm -f openssl apps/*.o
+\trm -f ${appslib} apps/lib/*.o
+\trm -f ${testlib} test/testutil/*.o
+\trm -f \$(TESTPROGS) test/*.o
+
+EOF
+
+print "# Build all test programs\n";
+foreach my $t ( @testprogs ) {
+    print "$t : ${t}.o\n";
+    print "\t\$(CC) -o \$@ ${t}.o \$(TESTLIBS)\n";
+}

--- a/configdata.pm.in
+++ b/configdata.pm.in
@@ -1,5 +1,26 @@
 #! {- $config{HASHBANGPERL} -}
-# -*- mode: perl -*-
+# Copyright 2021 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+#
+{-
+    $OUT = "# Do not ";
+    $OUT .= "edit this file; ";
+    $OUT .= "it was generated during the OpenSSL configuration.\n";
+-}
+use strict;
+use warnings;
+
+package configdata;
+use Exporter;
+our @ISA = qw(Exporter);
+our @EXPORT = qw(
+    %config %target %disabled %withargs %unified_info
+    @disablables @disablables_int
+);
 {-
  # We must make sourcedir() return an absolute path, because configdata.pm
  # may be loaded as a module from any script in any directory, making
@@ -54,11 +75,17 @@ our @EXPORT = qw(
 );
 
 our %config = ({- dump_data(\%config, indent => 0); -});
+
 our %target = ({- dump_data(\%target, indent => 0); -});
+
 our @disablables = ({- dump_data(\@disablables, indent => 0) -});
+
 our @disablables_int = ({- dump_data(\@disablables_int, indent => 0) -});
+
 our %disabled = ({- dump_data(\%disabled, indent => 0); -});
+
 our %withargs = ({- dump_data(\%withargs, indent => 0); -});
+
 our %unified_info = ({- dump_data(\%unified_info, indent => 0); -});
 
 # Unexported, only used by OpenSSL::Test::Utils::available_protocols()


### PR DESCRIPTION
This uses the data in configdata to create a new makefile that builds just the apps and test programs against an already-built openssl.

Once done, this PR should also work on 1.1.1  It's a new feature so maybe not official, but it will make it easy to build and run the apps and tests against 3.0
