### PR TITLE
Make i2d_PublicKey() work with provider side EC EVP_PKEYs

### DIFF
--- a/providers/encoders.inc
+++ b/providers/encoders.inc
@@ -104,12 +104,15 @@ ENCODER_w_structure("DSA", dsa, yes, der, type_specific),
 ENCODER_w_structure("DSA", dsa, yes, pem, type_specific),
 #endif
 #ifndef OPENSSL_NO_EC
-/* EC only supports keypair and parameters output. */
+/* EC only supports keypair and parameters DER and PEM output. */
 ENCODER_w_structure("EC", ec, yes, der, type_specific_no_pub),
 ENCODER_w_structure("EC", ec, yes, pem, type_specific_no_pub),
+/* EC supports blob output for the public key */
+ENCODER("EC", ec, yes, blob),
 # ifndef OPENSSL_NO_SM2
 ENCODER_w_structure("SM2", sm2, yes, der, type_specific_no_pub),
 ENCODER_w_structure("SM2", sm2, yes, pem, type_specific_no_pub),
+ENCODER("SM2", sm2, yes, blob),
 # endif
 #endif
 

--- a/providers/implementations/encode_decode/build.info
+++ b/providers/implementations/encode_decode/build.info
@@ -15,4 +15,10 @@ SOURCE[$ENCODER_GOAL]=endecoder_common.c
 SOURCE[$DECODER_GOAL]=decode_der2key.c decode_pem2der.c decode_ms2key.c
 
 SOURCE[$ENCODER_GOAL]=encode_key2any.c encode_key2text.c encode_key2ms.c
+# encode_key2blob.c is only being included when EC is enabled, because we
+# currently only define a "blob" output type for EC public keys.  This may
+# change in the future.
+IF[{- !$disabled{ec} -}]
+  SOURCE[$ENCODER_GOAL]=encode_key2blob.c
+ENDIF
 DEPEND[encode_key2any.o]=../../common/include/prov/der_rsa.h

--- a/providers/implementations/encode_decode/encode_key2blob.c
+++ b/providers/implementations/encode_decode/encode_key2blob.c
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2021 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+/*
+ * Low level APIs are deprecated for public use, but still ok for internal use.
+ */
+#include "internal/deprecated.h"
+
+#include <string.h>
+#include <openssl/core.h>
+#include <openssl/core_dispatch.h>
+#include <openssl/core_names.h>
+#include <openssl/params.h>
+#include <openssl/err.h>
+#include <openssl/pem.h>         /* Functions for writing MSBLOB and PVK */
+#include <openssl/dsa.h>
+#include "internal/passphrase.h"
+#include "crypto/rsa.h"
+#include "prov/implementations.h"
+#include "prov/bio.h"
+#include "prov/provider_ctx.h"
+#include "endecoder_local.h"
+
+static int write_blob(void *provctx, OSSL_CORE_BIO *cout,
+                      void *data, int len)
+{
+    BIO *out = bio_new_from_core_bio(provctx, cout);
+    int ret = BIO_write(out, data, len);
+
+    BIO_free(out);
+    return ret;
+}
+
+static OSSL_FUNC_encoder_newctx_fn key2blob_newctx;
+static OSSL_FUNC_encoder_freectx_fn key2blob_freectx;
+static OSSL_FUNC_encoder_gettable_params_fn key2blob_gettable_params;
+static OSSL_FUNC_encoder_get_params_fn key2blob_get_params;
+static OSSL_FUNC_encoder_does_selection_fn key2blob_does_selection;
+
+static void *key2blob_newctx(void *provctx)
+{
+    return provctx;
+}
+
+static void key2blob_freectx(void *vctx)
+{
+}
+
+static const OSSL_PARAM *key2blob_gettable_params(ossl_unused void *provctx)
+{
+    static const OSSL_PARAM gettables[] = {
+        { OSSL_ENCODER_PARAM_OUTPUT_TYPE, OSSL_PARAM_UTF8_PTR, NULL, 0, 0 },
+        OSSL_PARAM_END,
+    };
+
+    return gettables;
+}
+
+static int key2blob_get_params(OSSL_PARAM params[])
+{
+    OSSL_PARAM *p;
+
+    p = OSSL_PARAM_locate(params, OSSL_ENCODER_PARAM_OUTPUT_TYPE);
+    if (p != NULL && !OSSL_PARAM_set_utf8_ptr(p, "blob"))
+        return 0;
+
+    return 1;
+}
+
+static int key2blob_does_selection(void *vctx, int selection)
+{
+    return (selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY) != 0
+        && (selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) == 0;
+}
+
+static int key2blob_encode(void *vctx, const void *key, int selection,
+                           OSSL_CORE_BIO *cout)
+{
+    int pubkey_len = 0, ok = 0;
+    unsigned char *pubkey = NULL;
+
+    pubkey_len = i2o_ECPublicKey(key, &pubkey);
+    if (pubkey_len > 0 && pubkey != NULL)
+        ok = write_blob(vctx, cout, pubkey, pubkey_len);
+    OPENSSL_free(pubkey);
+    return ok;
+}
+
+#define MAKE_BLOB_ENCODER(impl, type)                                   \
+    static OSSL_FUNC_encoder_import_object_fn                           \
+    impl##2blob_import_object;                                          \
+    static OSSL_FUNC_encoder_free_object_fn impl##2blob_free_object;    \
+    static OSSL_FUNC_encoder_encode_fn impl##2blob_encode;              \
+                                                                        \
+    static void *impl##2blob_import_object(void *ctx, int selection,    \
+                                           const OSSL_PARAM params[])   \
+    {                                                                   \
+        return ossl_prov_import_key(ossl_##impl##_keymgmt_functions,    \
+                                    ctx, selection, params);            \
+    }                                                                   \
+    static void impl##2blob_free_object(void *key)                      \
+    {                                                                   \
+        ossl_prov_free_key(ossl_##impl##_keymgmt_functions, key);       \
+    }                                                                   \
+    static int impl##2blob_encode(void *vctx, OSSL_CORE_BIO *cout,      \
+                                  const void *key,                      \
+                                  const OSSL_PARAM key_abstract[],      \
+                                  int selection,                        \
+                                  OSSL_PASSPHRASE_CALLBACK *cb,         \
+                                  void *cbarg)                          \
+    {                                                                   \
+        /* We don't deal with abstract objects */                       \
+        if (key_abstract != NULL) {                                     \
+            ERR_raise(ERR_LIB_PROV, ERR_R_PASSED_INVALID_ARGUMENT);     \
+            return 0;                                                   \
+        }                                                               \
+        return key2blob_encode(vctx, key, selection, cout);             \
+    }                                                                   \
+    const OSSL_DISPATCH ossl_##impl##_to_blob_encoder_functions[] = {   \
+        { OSSL_FUNC_ENCODER_NEWCTX,                                     \
+          (void (*)(void))key2blob_newctx },                            \
+        { OSSL_FUNC_ENCODER_FREECTX,                                    \
+          (void (*)(void))key2blob_freectx },                           \
+        { OSSL_FUNC_ENCODER_GETTABLE_PARAMS,                            \
+          (void (*)(void))key2blob_gettable_params },                   \
+        { OSSL_FUNC_ENCODER_GET_PARAMS,                                 \
+          (void (*)(void))key2blob_get_params },                        \
+        { OSSL_FUNC_ENCODER_DOES_SELECTION,                             \
+          (void (*)(void))key2blob_does_selection },                    \
+        { OSSL_FUNC_ENCODER_IMPORT_OBJECT,                              \
+          (void (*)(void))impl##2blob_import_object },                  \
+        { OSSL_FUNC_ENCODER_FREE_OBJECT,                                \
+          (void (*)(void))impl##2blob_free_object },                    \
+        { OSSL_FUNC_ENCODER_ENCODE,                                     \
+          (void (*)(void))impl##2blob_encode },                         \
+        { 0, NULL }                                                     \
+    }
+
+#ifndef OPENSSL_NO_EC
+MAKE_BLOB_ENCODER(ec, ec);
+# ifndef OPENSSL_NO_SM2
+MAKE_BLOB_ENCODER(sm2, ec);
+# endif
+#endif

--- a/providers/implementations/include/prov/implementations.h
+++ b/providers/implementations/include/prov/implementations.h
@@ -381,7 +381,6 @@ extern const OSSL_DISPATCH ossl_dsa_to_text_encoder_functions[];
 extern const OSSL_DISPATCH ossl_ec_to_EC_der_encoder_functions[];
 extern const OSSL_DISPATCH ossl_ec_to_EC_pem_encoder_functions[];
 extern const OSSL_DISPATCH ossl_ec_to_blob_encoder_functions[];
-extern const OSSL_DISPATCH ossl_ec_to_blob_encoder_functions[];
 extern const OSSL_DISPATCH ossl_ec_to_PKCS8_der_encoder_functions[];
 extern const OSSL_DISPATCH ossl_ec_to_PKCS8_pem_encoder_functions[];
 extern const OSSL_DISPATCH ossl_ec_to_SubjectPublicKeyInfo_der_encoder_functions[];
@@ -395,7 +394,6 @@ extern const OSSL_DISPATCH ossl_ec_to_text_encoder_functions[];
 #ifndef OPENSSL_NO_SM2
 extern const OSSL_DISPATCH ossl_sm2_to_SM2_der_encoder_functions[];
 extern const OSSL_DISPATCH ossl_sm2_to_SM2_pem_encoder_functions[];
-extern const OSSL_DISPATCH ossl_sm2_to_blob_encoder_functions[];
 extern const OSSL_DISPATCH ossl_sm2_to_blob_encoder_functions[];
 extern const OSSL_DISPATCH ossl_sm2_to_PKCS8_der_encoder_functions[];
 extern const OSSL_DISPATCH ossl_sm2_to_PKCS8_pem_encoder_functions[];

--- a/providers/implementations/include/prov/implementations.h
+++ b/providers/implementations/include/prov/implementations.h
@@ -380,6 +380,8 @@ extern const OSSL_DISPATCH ossl_dsa_to_text_encoder_functions[];
 
 extern const OSSL_DISPATCH ossl_ec_to_EC_der_encoder_functions[];
 extern const OSSL_DISPATCH ossl_ec_to_EC_pem_encoder_functions[];
+extern const OSSL_DISPATCH ossl_ec_to_blob_encoder_functions[];
+extern const OSSL_DISPATCH ossl_ec_to_blob_encoder_functions[];
 extern const OSSL_DISPATCH ossl_ec_to_PKCS8_der_encoder_functions[];
 extern const OSSL_DISPATCH ossl_ec_to_PKCS8_pem_encoder_functions[];
 extern const OSSL_DISPATCH ossl_ec_to_SubjectPublicKeyInfo_der_encoder_functions[];
@@ -393,6 +395,8 @@ extern const OSSL_DISPATCH ossl_ec_to_text_encoder_functions[];
 #ifndef OPENSSL_NO_SM2
 extern const OSSL_DISPATCH ossl_sm2_to_SM2_der_encoder_functions[];
 extern const OSSL_DISPATCH ossl_sm2_to_SM2_pem_encoder_functions[];
+extern const OSSL_DISPATCH ossl_sm2_to_blob_encoder_functions[];
+extern const OSSL_DISPATCH ossl_sm2_to_blob_encoder_functions[];
 extern const OSSL_DISPATCH ossl_sm2_to_PKCS8_der_encoder_functions[];
 extern const OSSL_DISPATCH ossl_sm2_to_PKCS8_pem_encoder_functions[];
 extern const OSSL_DISPATCH ossl_sm2_to_SubjectPublicKeyInfo_der_encoder_functions[];

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -2423,7 +2423,7 @@ static int ecpub_nids[] = { NID_brainpoolP256r1, NID_X9_62_prime256v1,
 
 static int test_ecpub(int idx)
 {
-    int ret = 0, len;
+    int ret = 0, len, savelen;
     int nid;
     unsigned char buf[1024];
     unsigned char *p;
@@ -2439,12 +2439,14 @@ static int test_ecpub(int idx)
         || !TEST_true(EVP_PKEY_keygen(ctx, &pkey)))
         goto done;
     len = i2d_PublicKey(pkey, NULL);
+    savelen = len;
     if (!TEST_int_ge(len, 1)
         || !TEST_int_lt(len, 1024))
         goto done;
     p = buf;
     len = i2d_PublicKey(pkey, &p);
-    if (!TEST_int_ge(len, 1))
+    if (!TEST_int_ge(len, 1)
+            || !TEST_int_eq(len, savelen))
         goto done;
 
     ret = 1;

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -2415,6 +2415,47 @@ err:
     return ret;
 }
 
+#ifndef OPENSSL_NO_EC
+static int ecpub_nids[] = { NID_brainpoolP256r1, NID_X9_62_prime256v1,
+    NID_secp384r1, NID_secp521r1, NID_sect233k1, NID_sect233r1, NID_sect283r1,
+    NID_sect409k1, NID_sect409r1, NID_sect571k1, NID_sect571r1,
+    NID_brainpoolP384r1, NID_brainpoolP512r1};
+
+static int test_ecpub(int idx)
+{
+    int ret = 0, len;
+    int nid;
+    unsigned char buf[1024];
+    unsigned char *p;
+    EVP_PKEY *pkey = NULL;
+    EVP_PKEY_CTX *ctx = NULL;
+
+    nid = ecpub_nids[idx];
+
+    ctx = EVP_PKEY_CTX_new_id(EVP_PKEY_EC, NULL);
+    if (!TEST_ptr(ctx)
+        || !TEST_true(EVP_PKEY_keygen_init(ctx))
+        || !TEST_true(EVP_PKEY_CTX_set_ec_paramgen_curve_nid(ctx, nid))
+        || !TEST_true(EVP_PKEY_keygen(ctx, &pkey)))
+        goto done;
+    len = i2d_PublicKey(pkey, NULL);
+    if (!TEST_int_ge(len, 1)
+        || !TEST_int_lt(len, 1024))
+        goto done;
+    p = buf;
+    len = i2d_PublicKey(pkey, &p);
+    if (!TEST_int_ge(len, 1))
+        goto done;
+
+    ret = 1;
+
+ done:
+    EVP_PKEY_CTX_free(ctx);
+    EVP_PKEY_free(pkey);
+    return ret;
+}
+#endif
+
 static int test_EVP_rsa_pss_with_keygen_bits(void)
 {
     int ret;
@@ -2512,6 +2553,9 @@ int setup_tests(void)
     ADD_TEST(test_rand_agglomeration);
     ADD_ALL_TESTS(test_evp_iv, 10);
     ADD_TEST(test_EVP_rsa_pss_with_keygen_bits);
+#ifndef OPENSSL_NO_EC
+    ADD_ALL_TESTS(test_ecpub, OSSL_NELEM(ecpub_nids));
+#endif
 
     return 1;
 }

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -2427,12 +2427,13 @@ static int test_ecpub(int idx)
     int nid;
     unsigned char buf[1024];
     unsigned char *p;
+    EVP_PKEY *pkey = NULL;
+    EVP_PKEY_CTX *ctx = NULL;
 # ifndef OPENSSL_NO_DEPRECATED_3_0
     const unsigned char *q;
-# endif
-    EVP_PKEY *pkey = NULL, *pkey2 = NULL;
-    EVP_PKEY_CTX *ctx = NULL;
+    EVP_PKEY *pkey2 = NULL;
     EC_KEY *ec = NULL;
+# endif
 
     nid = ecpub_nids[idx];
 
@@ -2474,8 +2475,10 @@ static int test_ecpub(int idx)
  done:
     EVP_PKEY_CTX_free(ctx);
     EVP_PKEY_free(pkey);
+# ifndef OPENSSL_NO_DEPRECATED_3_0
     EVP_PKEY_free(pkey2);
     EC_KEY_free(ec);
+# endif
     return ret;
 }
 #endif

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -2427,8 +2427,12 @@ static int test_ecpub(int idx)
     int nid;
     unsigned char buf[1024];
     unsigned char *p;
-    EVP_PKEY *pkey = NULL;
+# ifndef OPENSSL_NO_DEPRECATED_3_0
+    const unsigned char *q;
+# endif
+    EVP_PKEY *pkey = NULL, *pkey2 = NULL;
     EVP_PKEY_CTX *ctx = NULL;
+    EC_KEY *ec = NULL;
 
     nid = ecpub_nids[idx];
 
@@ -2449,11 +2453,29 @@ static int test_ecpub(int idx)
             || !TEST_int_eq(len, savelen))
         goto done;
 
+# ifndef OPENSSL_NO_DEPRECATED_3_0
+    /* Now try to decode the just-created DER. */
+    q = buf;
+    if (!TEST_ptr((pkey2 = EVP_PKEY_new()))
+            || !TEST_ptr((ec = EC_KEY_new_by_curve_name(nid)))
+            || !TEST_true(EVP_PKEY_assign_EC_KEY(pkey2, ec)))
+        goto done;
+    /* EC_KEY ownership transferred */
+    ec = NULL;
+    if (!TEST_ptr(d2i_PublicKey(EVP_PKEY_EC, &pkey2, &q, savelen)))
+        goto done;
+    /* The keys should match. */
+    if (!TEST_int_eq(EVP_PKEY_cmp(pkey, pkey2), 1))
+        goto done;
+# endif
+
     ret = 1;
 
  done:
     EVP_PKEY_CTX_free(ctx);
     EVP_PKEY_free(pkey);
+    EVP_PKEY_free(pkey2);
+    EC_KEY_free(ec);
     return ret;
 }
 #endif


### PR DESCRIPTION
Since EC public keys are encoded as binary blob with no structure, they didn't fit into a DER encoder, and were ignored.
However, we have to make a replacement for i2o_ECPublicKey(), which is what i2d_PublieKey() uses to get an encoded public key from a legacy EC EVP_PKEY.

-   PROV: Implement an EC key -> blob encoder, to get the public key 
-   Modify i2d_PublicKey() so it can get an EC public key as a blob
    
    This introduces the encoder output type "blob", to be used for
    anything that outputs an unstructured blob of data.
-   crypto/asn1/i2d_evp.c: Fix i2d_provided() to return a proper length 

This includes @kaduk's added test from #14259

Fixes #14258