### PR TITLE
Fix filename escaping in c_rehash

### DIFF
--- a/tools/c_rehash.in
+++ b/tools/c_rehash.in
@@ -161,7 +161,7 @@ sub check_file {
 
 sub link_hash_cert {
 		my $fname = $_[0];
-		$fname =~ s/'/'\\''/g;
+		$fname =~ s/\"/\\\"/g;
 		my ($hash, $fprint) = `"$openssl" x509 $x509hash -fingerprint -noout -in "$fname"`;
 		chomp $hash;
 		chomp $fprint;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
