### PR TITLE
evp_extra_test: Do not manipulate providers in default context

### DIFF
--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -2418,13 +2418,11 @@ err:
 static int test_EVP_rsa_pss_with_keygen_bits(void)
 {
     int ret;
-    OSSL_PROVIDER *provider;
     EVP_PKEY_CTX *ctx;
     EVP_PKEY *pkey;
     const EVP_MD *md;
     pkey = NULL;
     ret = 0;
-    provider = OSSL_PROVIDER_load(NULL, "default");
     md = EVP_get_digestbyname("sha256");
 
     ret = TEST_ptr((ctx = EVP_PKEY_CTX_new_id(EVP_PKEY_RSA_PSS, NULL)))
@@ -2435,7 +2433,6 @@ static int test_EVP_rsa_pss_with_keygen_bits(void)
 
     EVP_PKEY_free(pkey);
     EVP_PKEY_CTX_free(ctx);
-    OSSL_PROVIDER_unload(provider);
     return ret;
 }
 

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -2423,8 +2423,8 @@ static int test_EVP_rsa_pss_with_keygen_bits(void)
     const EVP_MD *md;
     pkey = NULL;
     ret = 0;
-    md = EVP_get_digestbyname("sha256");
 
+    md = EVP_get_digestbyname("sha256");
     ret = TEST_ptr((ctx = EVP_PKEY_CTX_new_id(EVP_PKEY_RSA_PSS, NULL)))
         && TEST_true(EVP_PKEY_keygen_init(ctx))
         && TEST_int_gt(EVP_PKEY_CTX_set_rsa_keygen_bits(ctx, 512), 0)


### PR DESCRIPTION
Otherwise the with OPENSSL_TEST_RAND_ORDER following tests will
be broken. There is also no real need to do that.

Fixes #14070 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
