### PR TITLE
Improve diagnostics in evp_pkey_provided_test and for HARNESS_VERBOSE_FAILURE

### DIFF
--- a/test/evp_pkey_provided_test.c
+++ b/test/evp_pkey_provided_test.c
@@ -361,15 +361,16 @@ static int test_fromdata_rsa(void)
         || !TEST_false(EVP_PKEY_copy_parameters(copy_pk, pk)))
         goto err;
 
+    ret = test_print_key_using_pem("RSA", pk)
+          && test_print_key_using_encoder("RSA", pk);
+ err:
+    /* for better diagnostics always compare key params */
     for (i = 0; fromdata_params[i].key != NULL; ++i) {
         if (!TEST_true(BN_set_word(bn_from, key_numbers[i]))
             || !TEST_true(EVP_PKEY_get_bn_param(pk, fromdata_params[i].key, &bn))
             || !TEST_BN_eq(bn, bn_from))
-            goto err;
+            ret = 0;
     }
-    ret = test_print_key_using_pem("RSA", pk)
-          && test_print_key_using_encoder("RSA", pk);
- err:
     BN_free(bn_from);
     BN_free(bn);
     EVP_PKEY_free(pk);

--- a/test/testutil/driver.c
+++ b/test/testutil/driver.c
@@ -327,8 +327,8 @@ int run_tests(const char *test_prog_name)
         } else if (all_tests[i].num == -1) {
             set_test_title(all_tests[i].test_case_name);
             verdict = all_tests[i].test_fn();
-            test_verdict(verdict, "%d - %s", ii + 1, test_title);
             finalize(verdict != 0);
+            test_verdict(verdict, "%d - %s", ii + 1, test_title);
             if (verdict == 0)
                 num_failed++;
         } else {


### PR DESCRIPTION
The HARNESS_VERBOSE_FAILURE did not show the errors from the failed test because they were printed after the test verdict.

The improved diagnostic might help with finding the cause of #13995.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
