### PR TITLE
Cache legacy keys instead of downgrading them

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -39,6 +39,17 @@ OpenSSL 3.0
    changed made to the cached copy by application code will not be reflected
    back in the internal provider key.
 
+   For the above reasons the keys returned from these functions should typically
+   be treated as read-only. To emphasise this the value returned from
+   EVP_PKEY_get0(), EVP_PKEY_get0_RSA(), EVP_PKEY_get0_DSA(),
+   EVP_PKEY_get0_EC_KEY() and EVP_PKEY_get0_DH() has been made const. This may
+   break some existing code. Applications broken by this change should be
+   modified. The preferred solution is to refactor the code to avoid the use of
+   these deprecated functions. Failing this code should be modified to use a
+   const pointer instead. The EVP_PKEY_get1_RSA(), EVP_PKEY_get1_DSA(),
+   EVP_PKEY_get1_EC_KEY() and EVP_PKEY_get1_DH() functions continue to return a
+   non-const pointer to enable them to be "freed".
+
    *Matt Caswell*
 
  * A number of functions handling low level keys or engines were deprecated

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -719,12 +719,12 @@ OpenSSL 3.0
    time.  Instead applications should use L<EVP_DigestSignInit_ex(3)>,
    L<EVP_DigestSignUpdate(3)> and L<EVP_DigestSignFinal(3)>.
 
-   Finaly functions that assign or obtain DH objects from an EVP_PKEY such as
+   Finaly functions that assign or obtain DSA objects from an EVP_PKEY such as
    `EVP_PKEY_assign_DSA()`, `EVP_PKEY_get0_DSA()`, `EVP_PKEY_get1_DSA()`, and
    `EVP_PKEY_set1_DSA()` are also deprecated.
    Applications should instead either read or write an
-   EVP_PKEY directly using the OSSL_DECODER and OSSL_ENCODER APIs.
-   Or load an EVP_PKEY directly from DSA data using `EVP_PKEY_fromdata()`.
+   EVP_PKEY directly using the OSSL_DECODER and OSSL_ENCODER APIs,
+   or load an EVP_PKEY directly from DSA data using `EVP_PKEY_fromdata()`.
 
    *Paul Dale*
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,7 +36,7 @@ OpenSSL 3.0
    then these functions now return a cached copy of the key. Changes to
    the internal provider key that take place after the first time the cached key
    is accessed will not be reflected back in the cached copy. Similarly any
-   changed made to the cached copy by application code will not be reflected
+   changes made to the cached copy by application code will not be reflected
    back in the internal provider key.
 
    For the above reasons the keys returned from these functions should typically
@@ -48,7 +48,8 @@ OpenSSL 3.0
    these deprecated functions. Failing this the code should be modified to use a
    const pointer instead. The EVP_PKEY_get1_RSA(), EVP_PKEY_get1_DSA(),
    EVP_PKEY_get1_EC_KEY() and EVP_PKEY_get1_DH() functions continue to return a
-   non-const pointer to enable them to be "freed".
+   non-const pointer to enable them to be "freed". However they should also be
+   treated as read-only.
 
    *Matt Caswell*
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,17 @@ OpenSSL 3.0
 -----------
 
 ### Changes between 1.1.1 and 3.0 [xx XXX xxxx]
+
+ * A number of functions handling low level keys or engines were deprecated
+   including EVP_PKEY_set1_engine(), EVP_PKEY_get0_engine(), EVP_PKEY_assign(),
+   EVP_PKEY_get0(), EVP_PKEY_get0_hmac(), EVP_PKEY_get0_poly1305() and
+   EVP_PKEY_get0_siphash(). Applications using engines should instead use
+   providers. Applications getting or setting low level keys in an EVP_PKEY
+   should instead use the OSSL_ENCODER or OSSL_DECODER APIs, or alternatively
+   use EVP_PKEY_fromdata() or EVP_PKEY_get_params().
+
+   *Matt Caswell*
+
  * Deprecated obsolete EVP_PKEY_CTX_get0_dh_kdf_ukm() and
    EVP_PKEY_CTX_get0_ecdh_kdf_ukm() functions. They are not needed
    and require returning octet ptr parameters from providers that
@@ -35,6 +46,7 @@ OpenSSL 3.0
    be used instead via EVP_RAND(3).
 
    *Paul Dale*
+
  * The SRP APIs have been deprecated. The old APIs do not work via providers,
    and there is no EVP interface to them. Unfortunately there is no replacement
    for these APIs at this time.
@@ -492,12 +504,6 @@ OpenSSL 3.0
 
    *Kurt Roeckx*
 
- * EVP_PKEY_get0_RSA(), EVP_PKEY_get0_DSA(), EVP_PKEY_get0_DH(), and
-   EVP_PKEY_get0_EC_KEY() can now handle EVP_PKEYs with provider side
-   internal keys, if they correspond to one of those built in types.
-
-   *Richard Levitte*
-
  * Added EVP_PKEY_set_type_by_keymgmt(), to initialise an EVP_PKEY to
    contain a provider side internal key.
 
@@ -667,7 +673,7 @@ OpenSSL 3.0
    `EVP_PKEY_set1_DH()` are also deprecated.
    Applications should instead either read or write an
    EVP_PKEY directly using the OSSL_DECODER and OSSL_ENCODER APIs.
-   Or load an    EVP_PKEY directly from DH data using `EVP_PKEY_fromdata()`.
+   Or load an EVP_PKEY directly from DH data using `EVP_PKEY_fromdata()`.
 
    *Paul Dale and Matt Caswell*
 
@@ -694,6 +700,13 @@ OpenSSL 3.0
    Use of these low level functions has been informally discouraged for a long
    time.  Instead applications should use L<EVP_DigestSignInit_ex(3)>,
    L<EVP_DigestSignUpdate(3)> and L<EVP_DigestSignFinal(3)>.
+
+   Finaly functions that assign or obtain DH objects from an EVP_PKEY such as
+   `EVP_PKEY_assign_DSA()`, `EVP_PKEY_get0_DSA()`, `EVP_PKEY_get1_DSA()`, and
+   `EVP_PKEY_set1_DSA()` are also deprecated.
+   Applications should instead either read or write an
+   EVP_PKEY directly using the OSSL_DECODER and OSSL_ENCODER APIs.
+   Or load an EVP_PKEY directly from DSA data using `EVP_PKEY_fromdata()`.
 
    *Paul Dale*
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,24 @@ OpenSSL 3.0
 
 ### Changes between 1.1.1 and 3.0 [xx XXX xxxx]
 
+ * The deprecated functions EVP_PKEY_get0(), EVP_PKEY_get0_RSA(),
+   EVP_PKEY_get0_DSA(), EVP_PKEY_get0_EC_KEY(), EVP_PKEY_get0_DH(),
+   EVP_PKEY_get0_hmac(), EVP_PKEY_get0_poly1305() and EVP_PKEY_get0_siphash() as
+   well as the similarly named "get1" functions behave slightly differently in
+   OpenSSL 3.0. Previously they returned a pointer to the low-level key used
+   internally by libcrypto. From OpenSSL 3.0 this key may now be held in a
+   provider. Calling these functions will only return a handle on the internal
+   key where the EVP_PKEY was constructed using this key in the first place, for
+   example using a function or macro such as EVP_PKEY_assign_RSA(),
+   EVP_PKEY_set1_RSA(), etc. Where the EVP_PKEY holds a provider managed key,
+   then these functions now return a cached copy of the key. Changes to
+   the internal provider key that take place after the first time the cached key
+   is accessed will not be reflected back in the cached copy. Similarly any
+   changed made to the cached copy by application code will not be reflected
+   back in the internal provider key.
+
+   *Matt Caswell*
+
  * A number of functions handling low level keys or engines were deprecated
    including EVP_PKEY_set1_engine(), EVP_PKEY_get0_engine(), EVP_PKEY_assign(),
    EVP_PKEY_get0(), EVP_PKEY_get0_hmac(), EVP_PKEY_get0_poly1305() and

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -45,7 +45,7 @@ OpenSSL 3.0
    EVP_PKEY_get0_EC_KEY() and EVP_PKEY_get0_DH() has been made const. This may
    break some existing code. Applications broken by this change should be
    modified. The preferred solution is to refactor the code to avoid the use of
-   these deprecated functions. Failing this code should be modified to use a
+   these deprecated functions. Failing this the code should be modified to use a
    const pointer instead. The EVP_PKEY_get1_RSA(), EVP_PKEY_get1_DSA(),
    EVP_PKEY_get1_EC_KEY() and EVP_PKEY_get1_DH() functions continue to return a
    non-const pointer to enable them to be "freed".

--- a/crypto/dh/dh_ameth.c
+++ b/crypto/dh/dh_ameth.c
@@ -433,7 +433,10 @@ static int dh_pkey_ctrl(EVP_PKEY *pkey, int op, long arg1, void *arg2)
 {
     switch (op) {
     case ASN1_PKEY_CTRL_SET1_TLS_ENCPT:
-        return ossl_dh_buf2key(EVP_PKEY_get0_DH(pkey), arg2, arg1);
+        /* We should only be here if we have a legacy key */
+        if (!ossl_assert(evp_pkey_is_legacy(pkey)))
+            return 0;
+        return ossl_dh_buf2key(evp_pkey_get0_DH_int(pkey), arg2, arg1);
     case ASN1_PKEY_CTRL_GET1_TLS_ENCPT:
         return ossl_dh_key2buf(EVP_PKEY_get0_DH(pkey), arg2, 0, 1);
     default:

--- a/crypto/ec/ec_ameth.c
+++ b/crypto/ec/ec_ameth.c
@@ -482,7 +482,10 @@ static int ec_pkey_ctrl(EVP_PKEY *pkey, int op, long arg1, void *arg2)
         return 1;
 
     case ASN1_PKEY_CTRL_SET1_TLS_ENCPT:
-        return EC_KEY_oct2key(EVP_PKEY_get0_EC_KEY(pkey), arg2, arg1, NULL);
+        /* We should only be here if we have a legacy key */
+        if (!ossl_assert(evp_pkey_is_legacy(pkey)))
+            return 0;
+        return EC_KEY_oct2key(evp_pkey_get0_EC_KEY_int(pkey), arg2, arg1, NULL);
 
     case ASN1_PKEY_CTRL_GET1_TLS_ENCPT:
         return EC_KEY_key2buf(EVP_PKEY_get0_EC_KEY(pkey),

--- a/crypto/evp/ctrl_params_translate.c
+++ b/crypto/evp/ctrl_params_translate.c
@@ -1481,7 +1481,7 @@ static int get_payload_group_name(enum state state,
 #ifndef OPENSSL_NO_DH
     case EVP_PKEY_DH:
         {
-            DH *dh = EVP_PKEY_get0_DH(pkey);
+            const DH *dh = EVP_PKEY_get0_DH(pkey);
             int uid = DH_get_nid(dh);
 
             if (uid != NID_undef) {
@@ -1531,7 +1531,7 @@ static int get_payload_private_key(enum state state,
 #ifndef OPENSSL_NO_DH
     case EVP_PKEY_DH:
         {
-            DH *dh = EVP_PKEY_get0_DH(pkey);
+            const DH *dh = EVP_PKEY_get0_DH(pkey);
 
             ctx->p2 = (BIGNUM *)DH_get0_priv_key(dh);
         }
@@ -1540,7 +1540,7 @@ static int get_payload_private_key(enum state state,
 #ifndef OPENSSL_NO_EC
     case EVP_PKEY_EC:
         {
-            EC_KEY *ec = EVP_PKEY_get0_EC_KEY(pkey);
+            const EC_KEY *ec = EVP_PKEY_get0_EC_KEY(pkey);
 
             ctx->p2 = (BIGNUM *)EC_KEY_get0_private_key(ec);
         }
@@ -1590,7 +1590,7 @@ static int get_payload_public_key(enum state state,
 #ifndef OPENSSL_NO_EC
     case EVP_PKEY_EC:
         if (ctx->params->data_type == OSSL_PARAM_OCTET_STRING) {
-            EC_KEY *eckey = EVP_PKEY_get0_EC_KEY(pkey);
+            const EC_KEY *eckey = EVP_PKEY_get0_EC_KEY(pkey);
             BN_CTX *bnctx = BN_CTX_new_ex(ossl_ec_key_get_libctx(eckey));
             const EC_GROUP *ecg = EC_KEY_get0_group(eckey);
             const EC_POINT *point = EC_KEY_get0_public_key(eckey);

--- a/crypto/evp/p_dec.c
+++ b/crypto/evp/p_dec.c
@@ -16,6 +16,7 @@
 #include <openssl/evp.h>
 #include <openssl/objects.h>
 #include <openssl/x509.h>
+#include "crypto/evp.h"
 
 int EVP_PKEY_decrypt_old(unsigned char *key, const unsigned char *ek, int ekl,
                          EVP_PKEY *priv)
@@ -28,7 +29,7 @@ int EVP_PKEY_decrypt_old(unsigned char *key, const unsigned char *ek, int ekl,
     }
 
     ret =
-        RSA_private_decrypt(ekl, ek, key, EVP_PKEY_get0_RSA(priv),
+        RSA_private_decrypt(ekl, ek, key, evp_pkey_get0_RSA_int(priv),
                             RSA_PKCS1_PADDING);
  err:
     return ret;

--- a/crypto/evp/p_enc.c
+++ b/crypto/evp/p_enc.c
@@ -16,6 +16,7 @@
 #include <openssl/evp.h>
 #include <openssl/objects.h>
 #include <openssl/x509.h>
+#include "crypto/evp.h"
 
 int EVP_PKEY_encrypt_old(unsigned char *ek, const unsigned char *key,
                          int key_len, EVP_PKEY *pubk)
@@ -26,8 +27,9 @@ int EVP_PKEY_encrypt_old(unsigned char *ek, const unsigned char *key,
         ERR_raise(ERR_LIB_EVP, EVP_R_PUBLIC_KEY_NOT_RSA);
         goto err;
     }
+
     ret =
-        RSA_public_encrypt(key_len, key, ek, EVP_PKEY_get0_RSA(pubk),
+        RSA_public_encrypt(key_len, key, ek, evp_pkey_get0_RSA_int(pubk),
                            RSA_PKCS1_PADDING);
  err:
     return ret;

--- a/crypto/evp/p_legacy.c
+++ b/crypto/evp/p_legacy.c
@@ -31,7 +31,7 @@ int EVP_PKEY_set1_RSA(EVP_PKEY *pkey, RSA *key)
     return ret;
 }
 
-RSA *EVP_PKEY_get0_RSA(const EVP_PKEY *pkey)
+RSA *evp_pkey_get0_RSA_int(const EVP_PKEY *pkey)
 {
     if (pkey->type != EVP_PKEY_RSA && pkey->type != EVP_PKEY_RSA_PSS) {
         ERR_raise(ERR_LIB_EVP, EVP_R_EXPECTING_AN_RSA_KEY);
@@ -40,9 +40,14 @@ RSA *EVP_PKEY_get0_RSA(const EVP_PKEY *pkey)
     return evp_pkey_get_legacy((EVP_PKEY *)pkey);
 }
 
+const RSA *EVP_PKEY_get0_RSA(const EVP_PKEY *pkey)
+{
+    return evp_pkey_get0_RSA_int(pkey);
+}
+
 RSA *EVP_PKEY_get1_RSA(EVP_PKEY *pkey)
 {
-    RSA *ret = EVP_PKEY_get0_RSA(pkey);
+    RSA *ret = evp_pkey_get0_RSA_int(pkey);
 
     if (ret != NULL)
         RSA_up_ref(ret);
@@ -59,7 +64,7 @@ int EVP_PKEY_set1_EC_KEY(EVP_PKEY *pkey, EC_KEY *key)
     return ret;
 }
 
-EC_KEY *EVP_PKEY_get0_EC_KEY(const EVP_PKEY *pkey)
+EC_KEY *evp_pkey_get0_EC_KEY_int(const EVP_PKEY *pkey)
 {
     if (EVP_PKEY_base_id(pkey) != EVP_PKEY_EC) {
         EVPerr(EVP_F_EVP_PKEY_GET0_EC_KEY, EVP_R_EXPECTING_A_EC_KEY);
@@ -68,9 +73,14 @@ EC_KEY *EVP_PKEY_get0_EC_KEY(const EVP_PKEY *pkey)
     return evp_pkey_get_legacy((EVP_PKEY *)pkey);
 }
 
+const EC_KEY *EVP_PKEY_get0_EC_KEY(const EVP_PKEY *pkey)
+{
+    return evp_pkey_get0_EC_KEY_int(pkey);
+}
+
 EC_KEY *EVP_PKEY_get1_EC_KEY(EVP_PKEY *pkey)
 {
-    EC_KEY *ret = EVP_PKEY_get0_EC_KEY(pkey);
+    EC_KEY *ret = evp_pkey_get0_EC_KEY_int(pkey);
 
     if (ret != NULL)
         EC_KEY_up_ref(ret);

--- a/crypto/evp/p_legacy.c
+++ b/crypto/evp/p_legacy.c
@@ -67,7 +67,7 @@ int EVP_PKEY_set1_EC_KEY(EVP_PKEY *pkey, EC_KEY *key)
 EC_KEY *evp_pkey_get0_EC_KEY_int(const EVP_PKEY *pkey)
 {
     if (EVP_PKEY_base_id(pkey) != EVP_PKEY_EC) {
-        EVPerr(EVP_F_EVP_PKEY_GET0_EC_KEY, EVP_R_EXPECTING_A_EC_KEY);
+        ERR_raise(ERR_LIB_EVP, EVP_R_EXPECTING_A_EC_KEY);
         return NULL;
     }
     return evp_pkey_get_legacy((EVP_PKEY *)pkey);

--- a/crypto/evp/p_legacy.c
+++ b/crypto/evp/p_legacy.c
@@ -33,15 +33,11 @@ int EVP_PKEY_set1_RSA(EVP_PKEY *pkey, RSA *key)
 
 RSA *EVP_PKEY_get0_RSA(const EVP_PKEY *pkey)
 {
-    if (!evp_pkey_downgrade((EVP_PKEY *)pkey)) {
-        ERR_raise(ERR_LIB_EVP, EVP_R_INACCESSIBLE_KEY);
-        return NULL;
-    }
     if (pkey->type != EVP_PKEY_RSA && pkey->type != EVP_PKEY_RSA_PSS) {
         ERR_raise(ERR_LIB_EVP, EVP_R_EXPECTING_AN_RSA_KEY);
         return NULL;
     }
-    return pkey->pkey.rsa;
+    return evp_pkey_get_legacy((EVP_PKEY *)pkey);
 }
 
 RSA *EVP_PKEY_get1_RSA(EVP_PKEY *pkey)
@@ -65,15 +61,11 @@ int EVP_PKEY_set1_EC_KEY(EVP_PKEY *pkey, EC_KEY *key)
 
 EC_KEY *EVP_PKEY_get0_EC_KEY(const EVP_PKEY *pkey)
 {
-    if (!evp_pkey_downgrade((EVP_PKEY *)pkey)) {
-        ERR_raise(ERR_LIB_EVP, EVP_R_INACCESSIBLE_KEY);
-        return NULL;
-    }
     if (EVP_PKEY_base_id(pkey) != EVP_PKEY_EC) {
         EVPerr(EVP_F_EVP_PKEY_GET0_EC_KEY, EVP_R_EXPECTING_A_EC_KEY);
         return NULL;
     }
-    return pkey->pkey.ec;
+    return evp_pkey_get_legacy((EVP_PKEY *)pkey);
 }
 
 EC_KEY *EVP_PKEY_get1_EC_KEY(EVP_PKEY *pkey)

--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -661,7 +661,7 @@ int EVP_PKEY_set_type_str(EVP_PKEY *pkey, const char *str, int len)
     return pkey_set_type(pkey, NULL, EVP_PKEY_NONE, str, len, NULL);
 }
 
-#ifndef OPENSSL_NO_DEPRECATED_3_0
+# ifndef OPENSSL_NO_DEPRECATED_3_0
 int EVP_PKEY_set_alias_type(EVP_PKEY *pkey, int type)
 {
     if (!evp_pkey_is_legacy(pkey)) {
@@ -690,7 +690,7 @@ int EVP_PKEY_set_alias_type(EVP_PKEY *pkey, int type)
     pkey->type = type;
     return 1;
 }
-#endif
+# endif
 
 # ifndef OPENSSL_NO_ENGINE
 int EVP_PKEY_set1_engine(EVP_PKEY *pkey, ENGINE *e)
@@ -716,18 +716,20 @@ ENGINE *EVP_PKEY_get0_engine(const EVP_PKEY *pkey)
     return pkey->engine;
 }
 # endif
+
+# ifndef OPENSSL_NO_DEPRECATED_3_0
 int EVP_PKEY_assign(EVP_PKEY *pkey, int type, void *key)
 {
     int alias = type;
 
-#ifndef OPENSSL_NO_EC
+#  ifndef OPENSSL_NO_EC
     if ((key != NULL) && (EVP_PKEY_type(type) == EVP_PKEY_EC)) {
         const EC_GROUP *group = EC_KEY_get0_group(key);
 
         if (group != NULL && EC_GROUP_get_curve_name(group) == NID_sm2)
             alias = EVP_PKEY_SM2;
     }
-#endif
+#  endif
 
     if (pkey == NULL || !EVP_PKEY_set_type(pkey, type))
         return 0;
@@ -736,6 +738,7 @@ int EVP_PKEY_assign(EVP_PKEY *pkey, int type, void *key)
     pkey->pkey.ptr = key;
     return (key != NULL);
 }
+# endif
 
 void *EVP_PKEY_get0(const EVP_PKEY *pkey)
 {

--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -1824,10 +1824,15 @@ int evp_pkey_copy_downgraded(EVP_PKEY **dest, const EVP_PKEY *src)
             keytype = OBJ_nid2sn(type);
 
         /* Make sure we have a clean slate to copy into */
-        if (*dest == NULL)
+        if (*dest == NULL) {
             *dest = EVP_PKEY_new();
-        else
+            if (*dest == NULL) {
+                ERR_raise(ERR_LIB_EVP, ERR_R_MALLOC_FAILURE);
+                return 0;
+            }
+        } else {
             evp_pkey_free_it(*dest);
+        }
 
         if (EVP_PKEY_set_type(*dest, type)) {
             /* If the key is typed but empty, we're done */

--- a/crypto/evp/pmeth_gn.c
+++ b/crypto/evp/pmeth_gn.c
@@ -197,7 +197,7 @@ int EVP_PKEY_gen(EVP_PKEY_CTX *ctx, EVP_PKEY **ppkey)
 #endif
 
     /*
-     * Because we still have legacy keys, and evp_pkey_downgrade()
+     * Because we still have legacy keys
      * TODO remove this #legacy internal keys are gone
      */
     (*ppkey)->type = ctx->legacy_keytype;

--- a/crypto/evp/pmeth_gn.c
+++ b/crypto/evp/pmeth_gn.c
@@ -208,8 +208,17 @@ int EVP_PKEY_gen(EVP_PKEY_CTX *ctx, EVP_PKEY **ppkey)
 #ifdef FIPS_MODULE
     goto not_supported;
 #else
-    if (ctx->pkey && !evp_pkey_downgrade(ctx->pkey))
+    /*
+     * If we get here then we're using legacy paramgen/keygen. In that case
+     * the pkey in ctx (if there is one) had better not be provided (because the
+     * legacy methods may not know how to handle it). However we can only get
+     * here if ctx->op.keymgmt.genctx == NULL, but that should never be the case
+     * if ctx->pkey is provided because we don't allow this when we initialise
+     * the ctx.
+     */
+    if (ctx->pkey != NULL && !ossl_assert(!evp_pkey_is_provided(ctx->pkey)))
         goto not_accessible;
+
     switch (ctx->operation) {
     case EVP_PKEY_OP_PARAMGEN:
         ret = ctx->pmeth->paramgen(ctx, *ppkey);

--- a/crypto/evp/pmeth_lib.c
+++ b/crypto/evp/pmeth_lib.c
@@ -269,8 +269,7 @@ static EVP_PKEY_CTX *int_ctx_new(OSSL_LIB_CTX *libctx,
         /*
          * Chase down the legacy NID, as that might be needed for diverse
          * purposes, such as ensure that EVP_PKEY_type() can return sensible
-         * values, or that there's a better chance to "downgrade" a key when
-         * needed.  We go through all keymgmt names, because the keytype
+         * values. We go through all keymgmt names, because the keytype
          * that's passed to this function doesn't necessarily translate
          * directly.
          * TODO: Remove this when #legacy keys are gone.

--- a/crypto/pem/pvkfmt.c
+++ b/crypto/pem/pvkfmt.c
@@ -450,12 +450,12 @@ static void write_lebn(unsigned char **out, const BIGNUM *bn, int len)
     *out += len;
 }
 
-static int check_bitlen_rsa(RSA *rsa, int ispub, unsigned int *magic);
-static void write_rsa(unsigned char **out, RSA *rsa, int ispub);
+static int check_bitlen_rsa(const RSA *rsa, int ispub, unsigned int *magic);
+static void write_rsa(unsigned char **out, const RSA *rsa, int ispub);
 
 #ifndef OPENSSL_NO_DSA
-static int check_bitlen_dsa(DSA *dsa, int ispub, unsigned int *magic);
-static void write_dsa(unsigned char **out, DSA *dsa, int ispub);
+static int check_bitlen_dsa(const DSA *dsa, int ispub, unsigned int *magic);
+static void write_dsa(unsigned char **out, const DSA *dsa, int ispub);
 #endif
 
 static int do_i2b(unsigned char **out, const EVP_PKEY *pk, int ispub)
@@ -542,7 +542,7 @@ static int do_i2b_bio(BIO *out, const EVP_PKEY *pk, int ispub)
     return -1;
 }
 
-static int check_bitlen_rsa(RSA *rsa, int ispub, unsigned int *pmagic)
+static int check_bitlen_rsa(const RSA *rsa, int ispub, unsigned int *pmagic)
 {
     int nbyte, hnbyte, bitlen;
     const BIGNUM *e;
@@ -582,7 +582,7 @@ static int check_bitlen_rsa(RSA *rsa, int ispub, unsigned int *pmagic)
     return 0;
 }
 
-static void write_rsa(unsigned char **out, RSA *rsa, int ispub)
+static void write_rsa(unsigned char **out, const RSA *rsa, int ispub)
 {
     int nbyte, hnbyte;
     const BIGNUM *n, *d, *e, *p, *q, *iqmp, *dmp1, *dmq1;
@@ -605,7 +605,7 @@ static void write_rsa(unsigned char **out, RSA *rsa, int ispub)
 }
 
 #ifndef OPENSSL_NO_DSA
-static int check_bitlen_dsa(DSA *dsa, int ispub, unsigned int *pmagic)
+static int check_bitlen_dsa(const DSA *dsa, int ispub, unsigned int *pmagic)
 {
     int bitlen;
     const BIGNUM *p = NULL, *q = NULL, *g = NULL;
@@ -633,7 +633,7 @@ static int check_bitlen_dsa(DSA *dsa, int ispub, unsigned int *pmagic)
     return 0;
 }
 
-static void write_dsa(unsigned char **out, DSA *dsa, int ispub)
+static void write_dsa(unsigned char **out, const DSA *dsa, int ispub)
 {
     int nbyte;
     const BIGNUM *p = NULL, *q = NULL, *g = NULL;

--- a/doc/internal/man3/evp_pkey_export_to_provider.pod
+++ b/doc/internal/man3/evp_pkey_export_to_provider.pod
@@ -2,7 +2,7 @@
 
 =head1 NAME
 
-evp_pkey_export_to_provider, evp_pkey_copy_downgraded, evp_pkey_downgrade
+evp_pkey_export_to_provider, evp_pkey_copy_downgraded, evp_pkey_get_legacy
 - internal EVP_PKEY support functions for providers
 
 =head1 SYNOPSIS
@@ -14,7 +14,7 @@ evp_pkey_export_to_provider, evp_pkey_copy_downgraded, evp_pkey_downgrade
                                    EVP_KEYMGMT **keymgmt,
                                    const char *propquery);
  int evp_pkey_copy_downgraded(EVP_PKEY **dest, const EVP_PKEY *src);
- void *evp_pkey_get_legacy(EVP_PKEY *pk)
+ void *evp_pkey_get_legacy(EVP_PKEY *pk);
 
 =head1 DESCRIPTION
 
@@ -56,10 +56,9 @@ evp_pkey_get_legacy() returns the legacy key or NULL on error.
 
 =head1 NOTES
 
-Some functions calling evp_pkey_export_to_provider() or evp_pkey_downgrade()
-may have received a const key, and may therefore have to cast the key to
-non-const form to call this function.  Since B<EVP_PKEY> is always dynamically
-allocated, this is OK.
+Some functions calling evp_pkey_export_to_provider() may have received a const
+key, and may therefore have to cast the key to non-const form to call this
+function.  Since B<EVP_PKEY> is always dynamically allocated, this is OK.
 
 =head1 SEE ALSO
 

--- a/doc/internal/man3/evp_pkey_export_to_provider.pod
+++ b/doc/internal/man3/evp_pkey_export_to_provider.pod
@@ -14,7 +14,7 @@ evp_pkey_export_to_provider, evp_pkey_copy_downgraded, evp_pkey_downgrade
                                    EVP_KEYMGMT **keymgmt,
                                    const char *propquery);
  int evp_pkey_copy_downgraded(EVP_PKEY **dest, const EVP_PKEY *src);
- int evp_pkey_downgrade(EVP_PKEY *pk);
+ void *evp_pkey_get_legacy(EVP_PKEY *pk)
 
 =head1 DESCRIPTION
 
@@ -37,11 +37,14 @@ For example, L<PEM_write_bio_PrivateKey_traditional(3)> uses this to try its
 best to get "traditional" PEM output even if the input B<EVP_PKEY> has a
 provider-native internal key.
 
-evp_pkey_downgrade() converts an B<EVP_PKEY> with a provider side "origin" key
-to one with a legacy "origin", if there's a corresponding legacy implementation.
-This clears the operation cache, except for the provider side "origin" key.
-This function is used in spots where provider side keys aren't yet supported,
-in an attempt to keep operating with available implementations.
+evp_pkey_get_legacy() obtains and returns a legacy key structure. If the
+EVP_PKEY already contains a legacy key then it is simply returned. If it is a
+provider based key, then a new legacy key is constructed based on the provider
+key. The legacy key is cached inside the EVP_PKEY and its value returned from
+this function. Subsequent calls to evp_pkey_get_legacy() will return the cached
+key. Subsequent changes to the provider key are not reflected back in the
+legacy key. Similarly changes to the legacy key are not reflected back in the
+provider key.
 
 =head1 RETURN VALUES
 
@@ -49,7 +52,7 @@ evp_pkey_export_to_provider() returns the provider key data if there was any
 allocated.  It also either sets I<*keymgmt> to the B<EVP_KEYMGMT> associated
 with the returned key data, or NULL on error.
 
-evp_pkey_downgrade() returns 1 on success or 0 on error.
+evp_pkey_get_legacy() returns the legacy key or NULL on error.
 
 =head1 NOTES
 

--- a/doc/internal/man7/EVP_PKEY.pod
+++ b/doc/internal/man7/EVP_PKEY.pod
@@ -181,27 +181,20 @@ OSSL_FUNC_keymgmt_import() function.
 
 =back
 
-=head2 Upgrading and downgrading a key
+=head2 Changing a key origin
 
-An B<EVP_PKEY> with a legacy origin will I<never> be upgraded to
-become an B<EVP_PKEY> with a provider native origin.  Instead, we have
-the operation cache as described above, that takes care of the needs
-of the diverse operation the application may want to perform.
+It is never possible to change the origin of a key. An B<EVP_PKEY> with a legacy
+origin will I<never> be upgraded to become an B<EVP_PKEY> with a provider
+native origin. Instead, we have the operation cache as described above, that
+takes care of the needs of the diverse operation the application may want to
+perform.
 
-An B<EVP_PKEY> with a provider native origin, I<may> be downgraded to
-be I<transformed> into an B<EVP_PKEY> with a legacy origin.  Because
-an B<EVP_PKEY> can't have two origins, it means that it stops having a
-provider native origin.  The previous provider native key data is
-moved to the operation cache.  Downgrading is performed with the
-internal function L<evp_pkey_downgrade(3)>.
-
-I<Downgrading a key is understandably fragile>, and possibly surprising,
-and should therefore be done I<as little as possible>, but is needed
-to be able to support functions like L<EVP_PKEY_get0_RSA(3)>.
-The general recommendation is to use L<evp_pkey_copy_downgraded(3)>
-whenever possible, which it should be if the need for a legacy origin
-is only internal, or better yet, to remove the need for downgrade at
-all.
+Similarly an B<EVP_PKEY> with a provider native origin, will I<never> be
+downgraded to be I<transformed> into an B<EVP_PKEY> with a legacy origin.
+Instead we may have a cached copy of the provider key in legacy form. Once the
+cached copy is created it is never updated. Changes made to the provider key
+are not reflected back in the cached legacy copy. Similarly changes made to the
+cached legacy copy are not reflected back in the provider key.
 
 =head1 SEE ALSO
 

--- a/doc/internal/man7/EVP_PKEY.pod
+++ b/doc/internal/man7/EVP_PKEY.pod
@@ -190,11 +190,11 @@ takes care of the needs of the diverse operation the application may want to
 perform.
 
 Similarly an B<EVP_PKEY> with a provider native origin, will I<never> be
-downgraded to be I<transformed> into an B<EVP_PKEY> with a legacy origin.
-Instead we may have a cached copy of the provider key in legacy form. Once the
-cached copy is created it is never updated. Changes made to the provider key
-are not reflected back in the cached legacy copy. Similarly changes made to the
-cached legacy copy are not reflected back in the provider key.
+I<transformed> into an B<EVP_PKEY> with a legacy origin. Instead we may have a
+cached copy of the provider key in legacy form. Once the cached copy is created
+it is never updated. Changes made to the provider key are not reflected back in
+the cached legacy copy. Similarly changes made to the cached legacy copy are not
+reflected back in the provider key.
 
 =head1 SEE ALSO
 

--- a/doc/internal/man7/EVP_PKEY.pod
+++ b/doc/internal/man7/EVP_PKEY.pod
@@ -65,7 +65,10 @@ The B<EVP_PKEY> internal keys are mutable.
 
 This is especially visible with internal legacy keys, since they can
 be extracted with functions like L<EVP_PKEY_get0_RSA(3)> and then
-modified at will with functions like L<RSA_set0_key(3)>.
+modified at will with functions like L<RSA_set0_key(3)>. Note that if the
+internal key is a provider key then the return value from functions such as
+L<EVP_PKEY_get0_RSA(3)> is a cached copy of the key. Changes to the cached
+copy are not reflected back in the provider key.
 
 Internal provider native keys are also possible to be modified, if the
 associated L<EVP_KEYMGMT(3)> implementation allows it.  This is done

--- a/doc/man3/EVP_PKEY_set1_RSA.pod
+++ b/doc/man3/EVP_PKEY_set1_RSA.pod
@@ -94,9 +94,9 @@ L<OSSL_ENCODER_CTX_new_for_pkey(3)>).
 EVP_PKEY_get0_hmac(), EVP_PKEY_get0_poly1305(), EVP_PKEY_get0_siphash(),
 EVP_PKEY_get0_RSA(), EVP_PKEY_get0_DSA(), EVP_PKEY_get0_DH() and
 EVP_PKEY_get0_EC_KEY() return the referenced key in I<pkey> or NULL if the
-key is not of the correct type but the reference count of the returned key
-is B<not> incremented and so must not be freed after use. These functions are
-deprecated. Applications should instead use the EVP_PKEY directly where
+key is not of the correct type. The reference count of the returned key is
+B<not> incremented and so the key must not be freed after use. These functions
+are deprecated. Applications should instead use the EVP_PKEY directly where
 possible. If access to the low level key parameters is required then
 applications should use L<EVP_PKEY_get_params(3)> and other similar functions.
 To write an EVP_PKEY out use the OSSL_ENCODER APIs (see

--- a/doc/man3/EVP_PKEY_set1_RSA.pod
+++ b/doc/man3/EVP_PKEY_set1_RSA.pod
@@ -143,6 +143,17 @@ EVP_PKEY_id(), EVP_PKEY_base_id(), EVP_PKEY_type(), EVP_PKEY_set_alias_type()
 
 For EVP_PKEY key type checking purposes, L<EVP_PKEY_is_a(3)> is more generic.
 
+The keys returned from the functions EVP_PKEY_get0_RSA(), EVP_PKEY_get0_DSA(),
+EVP_PKEY_get0_DH() and EVP_PKEY_get0_EC_KEY() were changed to have a "const"
+return type in OpenSSL 3.0. As described above the keys returned may be cached
+copies of the key held in a provider. Due to this, and unlike in earlier
+versions of OpenSSL, they should be considered read-only copies of the key.
+Updates to these keys will not be reflected back in the provider side key. The
+EVP_PKEY_get1_RSA(), EVP_PKEY_get1_DSA(), EVP_PKEY_get1_DH() and
+EVP_PKEY_get1_EC_KEY() functions were not changed to have a "const" return type
+in order that application can "free" the return value. However applications
+should still consider them as read-only copies.
+
 =head1 NOTES
 
 In accordance with the OpenSSL naming convention the key obtained

--- a/doc/man3/EVP_PKEY_set1_RSA.pod
+++ b/doc/man3/EVP_PKEY_set1_RSA.pod
@@ -102,6 +102,21 @@ applications should use L<EVP_PKEY_get_params(3)> and other similar functions.
 To write an EVP_PKEY out use the OSSL_ENCODER APIs (see
 L<OSSL_ENCODER_CTX_new_for_pkey(3)>).
 
+Note that if an EVP_PKEY was not constructed using one of the deprecated
+functions such as EVP_PKEY_set1_RSA(), EVP_PKEY_set1_DSA(), EVP_PKEY_set1_DH()
+or EVP_PKEY_set1_EC_KEY(), or via the similarly named B<EVP_PKEY_assign> macros
+described above then the internal key will be managed by a provider (see
+L<provider(7)>). In that case the key returned by EVP_PKEY_get1_RSA(),
+EVP_PKEY_get1_DSA(), EVP_PKEY_get1_DH(), EVP_PKEY_get1_EC_KEY(),
+EVP_PKEY_get0_hmac(), EVP_PKEY_get0_poly1305(), EVP_PKEY_get0_siphash(),
+EVP_PKEY_get0_RSA(), EVP_PKEY_get0_DSA(), EVP_PKEY_get0_DH() or
+EVP_PKEY_get0_EC_KEY() will be a cached copy of the provider's key. Subsequent
+updates to the provider's key will not be reflected back in the cached copy, and
+updates made by an application to the returned key will not be reflected back in
+the provider's key. Subsequent calls to EVP_PKEY_get1_RSA(),
+EVP_PKEY_get1_DSA(), EVP_PKEY_get1_DH() and EVP_PKEY_get1_EC_KEY() will always
+return the cached copy returned by the first call.
+
 EVP_PKEY_get0_engine() returns a reference to the ENGINE handling I<pkey>. This
 function is deprecated. Applications should use providers instead of engines
 (see L<provider(7)> for details).

--- a/doc/man3/EVP_PKEY_set1_RSA.pod
+++ b/doc/man3/EVP_PKEY_set1_RSA.pod
@@ -84,7 +84,7 @@ L<EVP_PKEY_fromdata(3)>.
 
 EVP_PKEY_get1_RSA(), EVP_PKEY_get1_DSA(), EVP_PKEY_get1_DH() and
 EVP_PKEY_get1_EC_KEY() return the referenced key in I<pkey> or NULL if the
-key is not of the correct type.  The returned key must be freed after use.
+key is not of the correct type. The returned key must be freed after use.
 These functions are deprecated. Applications should instead use the EVP_PKEY
 directly where possible. If access to the low level key parameters is required
 then applications should use L<EVP_PKEY_get_params(3)> and other similar

--- a/doc/man3/EVP_PKEY_set1_RSA.pod
+++ b/doc/man3/EVP_PKEY_set1_RSA.pod
@@ -15,6 +15,16 @@ EVP_PKEY_set1_engine, EVP_PKEY_get0_engine - EVP_PKEY assignment functions
 
  #include <openssl/evp.h>
 
+ int EVP_PKEY_id(const EVP_PKEY *pkey);
+ int EVP_PKEY_base_id(const EVP_PKEY *pkey);
+ int EVP_PKEY_type(int type);
+
+Deprecated since OpenSSL 3.0, can be hidden entirely by defining
+B<OPENSSL_API_COMPAT> with a suitable version value, see
+L<openssl_user_macros(7)>:
+
+ int EVP_PKEY_set_alias_type(EVP_PKEY *pkey, int type);
+
  int EVP_PKEY_set1_RSA(EVP_PKEY *pkey, RSA *key);
  int EVP_PKEY_set1_DSA(EVP_PKEY *pkey, DSA *key);
  int EVP_PKEY_set1_DH(EVP_PKEY *pkey, DH *key);
@@ -40,39 +50,10 @@ EVP_PKEY_set1_engine, EVP_PKEY_get0_engine - EVP_PKEY assignment functions
  int EVP_PKEY_assign_POLY1305(EVP_PKEY *pkey, ASN1_OCTET_STRING *key);
  int EVP_PKEY_assign_SIPHASH(EVP_PKEY *pkey, ASN1_OCTET_STRING *key);
 
- int EVP_PKEY_id(const EVP_PKEY *pkey);
- int EVP_PKEY_base_id(const EVP_PKEY *pkey);
- int EVP_PKEY_type(int type);
-
  ENGINE *EVP_PKEY_get0_engine(const EVP_PKEY *pkey);
  int EVP_PKEY_set1_engine(EVP_PKEY *pkey, ENGINE *engine);
 
-Deprecated since OpenSSL 3.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
-
- int EVP_PKEY_set_alias_type(EVP_PKEY *pkey, int type);
-
 =head1 DESCRIPTION
-
-EVP_PKEY_set1_RSA(), EVP_PKEY_set1_DSA(), EVP_PKEY_set1_DH() and
-EVP_PKEY_set1_EC_KEY() set the key referenced by I<pkey> to I<key>.
-
-EVP_PKEY_get1_RSA(), EVP_PKEY_get1_DSA(), EVP_PKEY_get1_DH() and
-EVP_PKEY_get1_EC_KEY() return the referenced key in I<pkey> or NULL if the
-key is not of the correct type.  The returned key must be freed after use.
-
-EVP_PKEY_get0_hmac(), EVP_PKEY_get0_poly1305(), EVP_PKEY_get0_siphash(),
-EVP_PKEY_get0_RSA(), EVP_PKEY_get0_DSA(), EVP_PKEY_get0_DH() and
-EVP_PKEY_get0_EC_KEY() return the referenced key in I<pkey> or NULL if the
-key is not of the correct type but the reference count of the returned key
-is B<not> incremented and so must not be freed after use.
-
-EVP_PKEY_assign_RSA(), EVP_PKEY_assign_DSA(), EVP_PKEY_assign_DH(),
-EVP_PKEY_assign_EC_KEY(), EVP_PKEY_assign_POLY1305() and
-EVP_PKEY_assign_SIPHASH() set the referenced key to I<key> however these use
-the supplied I<key> internally and so I<key> will be freed when the parent
-I<pkey> is freed.
 
 EVP_PKEY_base_id() returns the type of I<pkey>. For example
 an RSA key will return B<EVP_PKEY_RSA>.
@@ -87,15 +68,56 @@ often seen in practice.
 EVP_PKEY_type() returns the underlying type of the NID I<type>. For example
 EVP_PKEY_type(EVP_PKEY_RSA2) will return B<EVP_PKEY_RSA>.
 
-EVP_PKEY_get0_engine() returns a reference to the ENGINE handling I<pkey>.
+EVP_PKEY_set1_RSA(), EVP_PKEY_set1_DSA(), EVP_PKEY_set1_DH() and
+EVP_PKEY_set1_EC_KEY() set the key referenced by I<pkey> to I<key>. These
+functions are deprecated. Applications should instead use
+L<EVP_PKEY_fromdata(3)>.
+
+EVP_PKEY_assign_RSA(), EVP_PKEY_assign_DSA(), EVP_PKEY_assign_DH(),
+EVP_PKEY_assign_EC_KEY(), EVP_PKEY_assign_POLY1305() and
+EVP_PKEY_assign_SIPHASH() set the referenced key to I<key> however these use
+the supplied I<key> internally and so I<key> will be freed when the parent
+I<pkey> is freed. These macros are deprecated. Applications should instead read
+an EVP_PKEY directly using the OSSL_DECODER APIs (see
+L<OSSL_DECODER_CTX_new_for_pkey(3)>), or construct an EVP_PKEY from data using
+L<EVP_PKEY_fromdata(3)>.
+
+EVP_PKEY_get1_RSA(), EVP_PKEY_get1_DSA(), EVP_PKEY_get1_DH() and
+EVP_PKEY_get1_EC_KEY() return the referenced key in I<pkey> or NULL if the
+key is not of the correct type.  The returned key must be freed after use.
+These functions are deprecated. Applications should instead use the EVP_PKEY
+directly where possible. If access to the low level key parameters is required
+then applications should use L<EVP_PKEY_get_params(3)> and other similar
+functions. To write an EVP_PKEY out use the OSSL_ENCODER APIs (see
+L<OSSL_ENCODER_CTX_new_for_pkey(3)>).
+
+EVP_PKEY_get0_hmac(), EVP_PKEY_get0_poly1305(), EVP_PKEY_get0_siphash(),
+EVP_PKEY_get0_RSA(), EVP_PKEY_get0_DSA(), EVP_PKEY_get0_DH() and
+EVP_PKEY_get0_EC_KEY() return the referenced key in I<pkey> or NULL if the
+key is not of the correct type but the reference count of the returned key
+is B<not> incremented and so must not be freed after use. These functions are
+deprecated. Applications should instead use the EVP_PKEY directly where
+possible. If access to the low level key parameters is required then
+applications should use L<EVP_PKEY_get_params(3)> and other similar functions.
+To write an EVP_PKEY out use the OSSL_ENCODER APIs (see
+L<OSSL_ENCODER_CTX_new_for_pkey(3)>).
+
+EVP_PKEY_get0_engine() returns a reference to the ENGINE handling I<pkey>. This
+function is deprecated. Applications should use providers instead of engines
+(see L<provider(7)> for details).
 
 EVP_PKEY_set1_engine() sets the ENGINE handling I<pkey> to I<engine>. It
 must be called after the key algorithm and components are set up.
 If I<engine> does not include an B<EVP_PKEY_METHOD> for I<pkey> an
-error occurs.
+error occurs. This function is deprecated. Applications should use providers
+instead of engines (see L<provider(7)> for details).
 
-EVP_PKEY_set_alias_type() allows modifying a EVP_PKEY to use a
-different set of algorithms than the default.
+EVP_PKEY_set_alias_type() allows modifying an EVP_PKEY to use a
+different set of algorithms than the default. This function is deprecated and
+was previously needed as a workaround to recognise SM2 keys. From OpenSSL 3.0,
+this key type is internally recognised so the workaround is no longer needed.
+Functionality is still retained as it is, but will only work with EVP_PKEYs
+with a legacy internal key.
 
 =head1 WARNINGS
 
@@ -170,7 +192,14 @@ L<EVP_PKEY_new(3)>, L<SM2(7)>
 
 =head1 HISTORY
 
-EVP_PKEY_set_alias_type() was deprecated in OpenSSL 3.0.
+EVP_PKEY_set1_RSA, EVP_PKEY_set1_DSA, EVP_PKEY_set1_DH, EVP_PKEY_set1_EC_KEY,
+EVP_PKEY_get1_RSA, EVP_PKEY_get1_DSA, EVP_PKEY_get1_DH, EVP_PKEY_get1_EC_KEY,
+EVP_PKEY_get0_RSA, EVP_PKEY_get0_DSA, EVP_PKEY_get0_DH, EVP_PKEY_get0_EC_KEY,
+EVP_PKEY_assign_RSA, EVP_PKEY_assign_DSA, EVP_PKEY_assign_DH,
+EVP_PKEY_assign_EC_KEY, EVP_PKEY_assign_POLY1305, EVP_PKEY_assign_SIPHASH,
+EVP_PKEY_get0_hmac, EVP_PKEY_get0_poly1305, EVP_PKEY_get0_siphash,
+EVP_PKEY_set_alias_type, EVP_PKEY_set1_engine and EVP_PKEY_get0_engine were
+deprecated in OpenSSL 3.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/EVP_PKEY_set1_RSA.pod
+++ b/doc/man3/EVP_PKEY_set1_RSA.pod
@@ -38,10 +38,10 @@ L<openssl_user_macros(7)>:
  const unsigned char *EVP_PKEY_get0_hmac(const EVP_PKEY *pkey, size_t *len);
  const unsigned char *EVP_PKEY_get0_poly1305(const EVP_PKEY *pkey, size_t *len);
  const unsigned char *EVP_PKEY_get0_siphash(const EVP_PKEY *pkey, size_t *len);
- RSA *EVP_PKEY_get0_RSA(const EVP_PKEY *pkey);
- DSA *EVP_PKEY_get0_DSA(const EVP_PKEY *pkey);
- DH *EVP_PKEY_get0_DH(const EVP_PKEY *pkey);
- EC_KEY *EVP_PKEY_get0_EC_KEY(const EVP_PKEY *pkey);
+ const RSA *EVP_PKEY_get0_RSA(const EVP_PKEY *pkey);
+ const DSA *EVP_PKEY_get0_DSA(const EVP_PKEY *pkey);
+ const DH *EVP_PKEY_get0_DH(const EVP_PKEY *pkey);
+ const EC_KEY *EVP_PKEY_get0_EC_KEY(const EVP_PKEY *pkey);
 
  int EVP_PKEY_assign_RSA(EVP_PKEY *pkey, RSA *key);
  int EVP_PKEY_assign_DSA(EVP_PKEY *pkey, DSA *key);
@@ -215,6 +215,9 @@ EVP_PKEY_assign_EC_KEY, EVP_PKEY_assign_POLY1305, EVP_PKEY_assign_SIPHASH,
 EVP_PKEY_get0_hmac, EVP_PKEY_get0_poly1305, EVP_PKEY_get0_siphash,
 EVP_PKEY_set_alias_type, EVP_PKEY_set1_engine and EVP_PKEY_get0_engine were
 deprecated in OpenSSL 3.0.
+
+The return value from EVP_PKEY_get0_RSA, EVP_PKEY_get0_DSA, EVP_PKEY_get0_DH,
+EVP_PKEY_get0_EC_KEY were made const in OpenSSL 3.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man7/evp.pod
+++ b/doc/man7/evp.pod
@@ -29,7 +29,7 @@ The B<EVP_PKEY>I<XXX> functions provide a high-level interface to
 asymmetric algorithms. To create a new EVP_PKEY see
 L<EVP_PKEY_new(3)>. EVP_PKEYs can be associated
 with a private key of a particular algorithm by using the functions
-described on the L<EVP_PKEY_set1_RSA(3)> page, or
+described on the L<EVP_PKEY_fromdata(3)> page, or
 new keys can be generated using L<EVP_PKEY_keygen(3)>.
 EVP_PKEYs can be compared using L<EVP_PKEY_cmp(3)>, or printed using
 L<EVP_PKEY_print_private(3)>.
@@ -90,7 +90,7 @@ L<EVP_SignInit(3)>,
 L<EVP_VerifyInit(3)>,
 L<EVP_EncodeInit(3)>,
 L<EVP_PKEY_new(3)>,
-L<EVP_PKEY_set1_RSA(3)>,
+L<EVP_PKEY_fromdata(3)>,
 L<EVP_PKEY_keygen(3)>,
 L<EVP_PKEY_print_private(3)>,
 L<EVP_PKEY_decrypt(3)>,

--- a/include/crypto/evp.h
+++ b/include/crypto/evp.h
@@ -610,6 +610,21 @@ DEFINE_STACK_OF(OP_CACHE_ELEM)
 #define evp_pkey_is_provided(pk)                                \
     ((pk)->keymgmt != NULL)
 
+union legacy_pkey_st {
+    void *ptr;
+    struct rsa_st *rsa;     /* RSA */
+#  ifndef OPENSSL_NO_DSA
+    struct dsa_st *dsa;     /* DSA */
+#  endif
+#  ifndef OPENSSL_NO_DH
+    struct dh_st *dh;       /* DH */
+#  endif
+#  ifndef OPENSSL_NO_EC
+    struct ec_key_st *ec;   /* ECC */
+    ECX_KEY *ecx;           /* X25519, X448, Ed25519, Ed448 */
+#  endif
+};
+
 struct evp_pkey_st {
     /* == Legacy attributes == */
     int type;
@@ -623,20 +638,12 @@ struct evp_pkey_st {
     const EVP_PKEY_ASN1_METHOD *ameth;
     ENGINE *engine;
     ENGINE *pmeth_engine; /* If not NULL public key ENGINE to use */
-    union {
-        void *ptr;
-        struct rsa_st *rsa;     /* RSA */
-#  ifndef OPENSSL_NO_DSA
-        struct dsa_st *dsa;     /* DSA */
-#  endif
-#  ifndef OPENSSL_NO_DH
-        struct dh_st *dh;       /* DH */
-#  endif
-#  ifndef OPENSSL_NO_EC
-        struct ec_key_st *ec;   /* ECC */
-        ECX_KEY *ecx;           /* X25519, X448, Ed25519, Ed448 */
-#  endif
-    } pkey;
+
+    /* Union to store the reference to an origin legacy key */
+    union legacy_pkey_st pkey;
+
+    /* Union to store the reference to a non-origin legacy key */
+    union legacy_pkey_st legacy_cache_pkey;
 # endif
 
     /* == Common attributes == */
@@ -721,7 +728,7 @@ void *evp_pkey_export_to_provider(EVP_PKEY *pk, OSSL_LIB_CTX *libctx,
                                   const char *propquery);
 #ifndef FIPS_MODULE
 int evp_pkey_copy_downgraded(EVP_PKEY **dest, const EVP_PKEY *src);
-int evp_pkey_downgrade(EVP_PKEY *pk);
+void *evp_pkey_get_legacy(EVP_PKEY *pk);
 void evp_pkey_free_legacy(EVP_PKEY *x);
 #endif
 

--- a/include/crypto/evp.h
+++ b/include/crypto/evp.h
@@ -893,8 +893,10 @@ int evp_pkey_ctx_get_params_to_ctrl(EVP_PKEY_CTX *ctx, OSSL_PARAM *params);
 int evp_pkey_get_params_to_ctrl(const EVP_PKEY *pkey, OSSL_PARAM *params);
 
 /* Same as the public get0 functions but are not const */
+# ifndef OPENSSL_NO_DEPRECATED_3_0
 DH *evp_pkey_get0_DH_int(const EVP_PKEY *pkey);
 EC_KEY *evp_pkey_get0_EC_KEY_int(const EVP_PKEY *pkey);
 RSA *evp_pkey_get0_RSA_int(const EVP_PKEY *pkey);
+# endif
 
 #endif /* OSSL_CRYPTO_EVP_H */

--- a/include/crypto/evp.h
+++ b/include/crypto/evp.h
@@ -893,4 +893,9 @@ int evp_pkey_ctx_get_params_to_ctrl(EVP_PKEY_CTX *ctx, OSSL_PARAM *params);
 /* This must ONLY be called for legacy EVP_PKEYs */
 int evp_pkey_get_params_to_ctrl(const EVP_PKEY *pkey, OSSL_PARAM *params);
 
+/* Same as the public get0 functions but are not const */
+DH *evp_pkey_get0_DH_int(const EVP_PKEY *pkey);
+EC_KEY *evp_pkey_get0_EC_KEY_int(const EVP_PKEY *pkey);
+RSA *evp_pkey_get0_RSA_int(const EVP_PKEY *pkey);
+
 #endif /* OSSL_CRYPTO_EVP_H */

--- a/include/crypto/evp.h
+++ b/include/crypto/evp.h
@@ -647,7 +647,6 @@ struct evp_pkey_st {
 # endif
 
     /* == Common attributes == */
-    /* If these are modified, so must evp_pkey_downgrade() */
     CRYPTO_REF_COUNT references;
     CRYPTO_RWLOCK *lock;
     STACK_OF(X509_ATTRIBUTE) *attributes; /* [ 0 ] */

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -1240,22 +1240,27 @@ int EVP_PKEY_set_type_str(EVP_PKEY *pkey, const char *str, int len);
 int EVP_PKEY_set_type_by_keymgmt(EVP_PKEY *pkey, EVP_KEYMGMT *keymgmt);
 # ifndef OPENSSL_NO_DEPRECATED_3_0
 OSSL_DEPRECATEDIN_3_0 int EVP_PKEY_set_alias_type(EVP_PKEY *pkey, int type);
-# endif
-# ifndef OPENSSL_NO_ENGINE
+#  ifndef OPENSSL_NO_ENGINE
+OSSL_DEPRECATEDIN_3_0
 int EVP_PKEY_set1_engine(EVP_PKEY *pkey, ENGINE *e);
+OSSL_DEPRECATEDIN_3_0
 ENGINE *EVP_PKEY_get0_engine(const EVP_PKEY *pkey);
-# endif
+#  endif
+OSSL_DEPRECATEDIN_3_0
 int EVP_PKEY_assign(EVP_PKEY *pkey, int type, void *key);
+OSSL_DEPRECATEDIN_3_0
 void *EVP_PKEY_get0(const EVP_PKEY *pkey);
+OSSL_DEPRECATEDIN_3_0
 const unsigned char *EVP_PKEY_get0_hmac(const EVP_PKEY *pkey, size_t *len);
-# ifndef OPENSSL_NO_POLY1305
+#  ifndef OPENSSL_NO_POLY1305
+OSSL_DEPRECATEDIN_3_0
 const unsigned char *EVP_PKEY_get0_poly1305(const EVP_PKEY *pkey, size_t *len);
-# endif
-# ifndef OPENSSL_NO_SIPHASH
+#  endif
+#  ifndef OPENSSL_NO_SIPHASH
+OSSL_DEPRECATEDIN_3_0
 const unsigned char *EVP_PKEY_get0_siphash(const EVP_PKEY *pkey, size_t *len);
-# endif
+#  endif
 
-# ifndef OPENSSL_NO_DEPRECATED_3_0
 struct rsa_st;
 OSSL_DEPRECATEDIN_3_0
 int EVP_PKEY_set1_RSA(EVP_PKEY *pkey, struct rsa_st *key);
@@ -1263,22 +1268,24 @@ OSSL_DEPRECATEDIN_3_0
 struct rsa_st *EVP_PKEY_get0_RSA(const EVP_PKEY *pkey);
 OSSL_DEPRECATEDIN_3_0
 struct rsa_st *EVP_PKEY_get1_RSA(EVP_PKEY *pkey);
-# endif
-# ifndef OPENSSL_NO_DSA
+
+#  ifndef OPENSSL_NO_DSA
 struct dsa_st;
+OSSL_DEPRECATEDIN_3_0
 int EVP_PKEY_set1_DSA(EVP_PKEY *pkey, struct dsa_st *key);
+OSSL_DEPRECATEDIN_3_0
 struct dsa_st *EVP_PKEY_get0_DSA(const EVP_PKEY *pkey);
+OSSL_DEPRECATEDIN_3_0
 struct dsa_st *EVP_PKEY_get1_DSA(EVP_PKEY *pkey);
-# endif
-# ifndef OPENSSL_NO_DEPRECATED_3_0
+#  endif
+
 #  ifndef OPENSSL_NO_DH
 struct dh_st;
 OSSL_DEPRECATEDIN_3_0 int EVP_PKEY_set1_DH(EVP_PKEY *pkey, struct dh_st *key);
 OSSL_DEPRECATEDIN_3_0 struct dh_st *EVP_PKEY_get0_DH(const EVP_PKEY *pkey);
 OSSL_DEPRECATEDIN_3_0 struct dh_st *EVP_PKEY_get1_DH(EVP_PKEY *pkey);
 #  endif
-# endif
-# ifndef OPENSSL_NO_DEPRECATED_3_0
+
 #  ifndef OPENSSL_NO_EC
 struct ec_key_st;
 OSSL_DEPRECATEDIN_3_0
@@ -1288,7 +1295,7 @@ struct ec_key_st *EVP_PKEY_get0_EC_KEY(const EVP_PKEY *pkey);
 OSSL_DEPRECATEDIN_3_0
 struct ec_key_st *EVP_PKEY_get1_EC_KEY(EVP_PKEY *pkey);
 #  endif
-# endif
+# endif /* OPENSSL_NO_DEPRECATED_3_0 */
 
 EVP_PKEY *EVP_PKEY_new(void);
 int EVP_PKEY_up_ref(EVP_PKEY *pkey);

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -1249,7 +1249,7 @@ ENGINE *EVP_PKEY_get0_engine(const EVP_PKEY *pkey);
 OSSL_DEPRECATEDIN_3_0
 int EVP_PKEY_assign(EVP_PKEY *pkey, int type, void *key);
 OSSL_DEPRECATEDIN_3_0
-void *EVP_PKEY_get0(const EVP_PKEY *pkey);
+const void *EVP_PKEY_get0(const EVP_PKEY *pkey);
 OSSL_DEPRECATEDIN_3_0
 const unsigned char *EVP_PKEY_get0_hmac(const EVP_PKEY *pkey, size_t *len);
 #  ifndef OPENSSL_NO_POLY1305
@@ -1265,7 +1265,7 @@ struct rsa_st;
 OSSL_DEPRECATEDIN_3_0
 int EVP_PKEY_set1_RSA(EVP_PKEY *pkey, struct rsa_st *key);
 OSSL_DEPRECATEDIN_3_0
-struct rsa_st *EVP_PKEY_get0_RSA(const EVP_PKEY *pkey);
+const struct rsa_st *EVP_PKEY_get0_RSA(const EVP_PKEY *pkey);
 OSSL_DEPRECATEDIN_3_0
 struct rsa_st *EVP_PKEY_get1_RSA(EVP_PKEY *pkey);
 
@@ -1274,7 +1274,7 @@ struct dsa_st;
 OSSL_DEPRECATEDIN_3_0
 int EVP_PKEY_set1_DSA(EVP_PKEY *pkey, struct dsa_st *key);
 OSSL_DEPRECATEDIN_3_0
-struct dsa_st *EVP_PKEY_get0_DSA(const EVP_PKEY *pkey);
+const struct dsa_st *EVP_PKEY_get0_DSA(const EVP_PKEY *pkey);
 OSSL_DEPRECATEDIN_3_0
 struct dsa_st *EVP_PKEY_get1_DSA(EVP_PKEY *pkey);
 #  endif
@@ -1282,7 +1282,7 @@ struct dsa_st *EVP_PKEY_get1_DSA(EVP_PKEY *pkey);
 #  ifndef OPENSSL_NO_DH
 struct dh_st;
 OSSL_DEPRECATEDIN_3_0 int EVP_PKEY_set1_DH(EVP_PKEY *pkey, struct dh_st *key);
-OSSL_DEPRECATEDIN_3_0 struct dh_st *EVP_PKEY_get0_DH(const EVP_PKEY *pkey);
+OSSL_DEPRECATEDIN_3_0 const struct dh_st *EVP_PKEY_get0_DH(const EVP_PKEY *pkey);
 OSSL_DEPRECATEDIN_3_0 struct dh_st *EVP_PKEY_get1_DH(EVP_PKEY *pkey);
 #  endif
 
@@ -1291,7 +1291,7 @@ struct ec_key_st;
 OSSL_DEPRECATEDIN_3_0
 int EVP_PKEY_set1_EC_KEY(EVP_PKEY *pkey, struct ec_key_st *key);
 OSSL_DEPRECATEDIN_3_0
-struct ec_key_st *EVP_PKEY_get0_EC_KEY(const EVP_PKEY *pkey);
+const struct ec_key_st *EVP_PKEY_get0_EC_KEY(const EVP_PKEY *pkey);
 OSSL_DEPRECATEDIN_3_0
 struct ec_key_st *EVP_PKEY_get1_EC_KEY(EVP_PKEY *pkey);
 #  endif

--- a/test/endecoder_legacy_test.c
+++ b/test/endecoder_legacy_test.c
@@ -58,11 +58,11 @@
 
 #include "testutil.h"
 
-typedef int PEM_write_bio_of_void_protected(BIO *out, void *obj,
+typedef int PEM_write_bio_of_void_protected(BIO *out, const void *obj,
                                             const EVP_CIPHER *enc,
                                             unsigned char *kstr, int klen,
                                             pem_password_cb *cb, void *u);
-typedef int PEM_write_bio_of_void_unprotected(BIO *out, void *obj);
+typedef int PEM_write_bio_of_void_unprotected(BIO *out, const void *obj);
 typedef void *PEM_read_bio_of_void(BIO *out, void **obj,
                                    pem_password_cb *cb, void *u);
 typedef int EVP_PKEY_print_fn(BIO *out, const EVP_PKEY *pkey,
@@ -294,7 +294,7 @@ static int test_membio_str_eq(BIO *bio_provided, BIO *bio_legacy)
 }
 
 static int test_protected_PEM(const char *keytype, int evp_type,
-                              void *legacy_key,
+                              const void *legacy_key,
                               PEM_write_bio_of_void_protected *pem_write_bio,
                               PEM_read_bio_of_void *pem_read_bio,
                               EVP_PKEY_eq_fn *evp_pkey_eq,
@@ -362,7 +362,7 @@ static int test_protected_PEM(const char *keytype, int evp_type,
 }
 
 static int test_unprotected_PEM(const char *keytype, int evp_type,
-                                void *legacy_key,
+                                const void *legacy_key,
                                 PEM_write_bio_of_void_unprotected *pem_write_bio,
                                 PEM_read_bio_of_void *pem_read_bio,
                                 EVP_PKEY_eq_fn *evp_pkey_eq,
@@ -429,7 +429,7 @@ static int test_unprotected_PEM(const char *keytype, int evp_type,
 }
 
 static int test_DER(const char *keytype, int evp_type,
-                    void *legacy_key, i2d_of_void *i2d, d2i_of_void *d2i,
+                    const void *legacy_key, i2d_of_void *i2d, d2i_of_void *d2i,
                     EVP_PKEY_eq_fn *evp_pkey_eq,
                     EVP_PKEY_print_fn *evp_pkey_print,
                     EVP_PKEY *provided_pkey, int selection,
@@ -506,7 +506,7 @@ static int test_key(int idx)
     int ok = 0;
     size_t i;
     EVP_PKEY *pkey = NULL, *downgraded_pkey = NULL;
-    void *legacy_obj = NULL;
+    const void *legacy_obj = NULL;
 
     /* Get the test data */
     if (!TEST_ptr(test_stanza = &test_stanzas[idx])

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -8259,8 +8259,8 @@ static DH *tmp_dh_callback(SSL *s, int is_export, int keylen)
         return NULL;
 
     /*
-     * libssl does not free the the returned DH, so we free it now knowing that
-     * even after we free dhpkey, there will still be a reference to the owning
+     * libssl does not free the returned DH, so we free it now knowing that even
+     * after we free dhpkey, there will still be a reference to the owning
      * EVP_PKEY in tmp_dh_params, and so the DH object will live for the length
      * of time we need it for.
      */

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -8258,7 +8258,14 @@ static DH *tmp_dh_callback(SSL *s, int is_export, int keylen)
     if (!TEST_ptr(dhpkey))
         return NULL;
 
-    ret = EVP_PKEY_get0_DH(dhpkey);
+    /*
+     * libssl does not free the the returned DH, so we free it now knowing that
+     * even after we free dhpkey, there will still be a reference to the owning
+     * EVP_PKEY in tmp_dh_params, and so the DH object will live for the length
+     * of time we need it for.
+     */
+    ret = EVP_PKEY_get1_DH(dhpkey);
+    DH_free(ret);
 
     EVP_PKEY_free(dhpkey);
 
@@ -8306,7 +8313,7 @@ static int test_set_tmp_dh(int idx)
     }
 #  ifndef OPENSSL_NO_DEPRECATED_3_0
     if (idx == 7 || idx == 8) {
-        dh = EVP_PKEY_get0_DH(dhpkey);
+        dh = EVP_PKEY_get1_DH(dhpkey);
         if (!TEST_ptr(dh))
             goto end;
     }
@@ -8376,6 +8383,9 @@ static int test_set_tmp_dh(int idx)
     testresult = 1;
 
  end:
+#  ifndef OPENSSL_NO_DEPRECATED_3_0
+    DH_free(dh);
+#  endif
     SSL_free(serverssl);
     SSL_free(clientssl);
     SSL_CTX_free(sctx);

--- a/test/threadstest.c
+++ b/test/threadstest.c
@@ -7,6 +7,9 @@
  * https://www.openssl.org/source/license.html
  */
 
+/* test_multi below tests the thread safety of a deprecated function */
+#define OPENSSL_SUPPRESS_DEPRECATED
+
 #if defined(_WIN32)
 # include <windows.h>
 #endif

--- a/test/threadstest.c
+++ b/test/threadstest.c
@@ -401,22 +401,45 @@ static void thread_shared_evp_pkey(void)
         multi_success = 0;
 }
 
+static void thread_downgrade_shared_evp_pkey(void)
+{
+#ifndef OPENSSL_NO_DEPRECATED_3_0
+    /*
+     * This test is only relevant for deprecated functions that perform
+     * downgrading
+     */
+    if (EVP_PKEY_get0(shared_evp_pkey) == NULL)
+        multi_success = 0;
+#else
+    /* Shouldn't ever get here */
+    multi_success = 0;
+#endif
+}
+
+
 /*
  * Do work in multiple worker threads at the same time.
  * Test 0: General worker, using the default provider
  * Test 1: General worker, using the fips provider
  * Test 2: Simple fetch worker
- * Test 3: Worker using a shared EVP_PKEY
+ * Test 3: Worker downgrading a shared EVP_PKEY
+ * Test 4: Worker using a shared EVP_PKEY
  */
 static int test_multi(int idx)
 {
     thread_t thread1, thread2;
     int testresult = 0;
     OSSL_PROVIDER *prov = NULL, *prov2 = NULL;
-    void (*worker)(void);
+    void (*worker)(void) = NULL;
+    void (*worker2)(void) = NULL;
 
     if (idx == 1 && !do_fips)
         return TEST_skip("FIPS not supported");
+
+#ifdef OPENSSL_NO_DEPRECATED_3_0
+    if (idx == 3)
+        return TEST_skip("Skipping tests for deprected functions");
+#endif
 
     multi_success = 1;
     multi_libctx = OSSL_LIB_CTX_new();
@@ -435,6 +458,9 @@ static int test_multi(int idx)
         worker = thread_multi_simple_fetch;
         break;
     case 3:
+        worker2 = thread_downgrade_shared_evp_pkey;
+        /* fall through */
+    case 4:
         /*
          * If available we have both the default and fips providers for this
          * test
@@ -450,9 +476,11 @@ static int test_multi(int idx)
         TEST_error("Invalid test index");
         goto err;
     }
+    if (worker2 == NULL)
+        worker2 = worker;
 
     if (!TEST_true(run_thread(&thread1, worker))
-            || !TEST_true(run_thread(&thread2, worker)))
+            || !TEST_true(run_thread(&thread2, worker2)))
         goto err;
 
     worker();
@@ -518,7 +546,7 @@ int setup_tests(void)
     ADD_TEST(test_once);
     ADD_TEST(test_thread_local);
     ADD_TEST(test_atomic);
-    ADD_ALL_TESTS(test_multi, 4);
+    ADD_ALL_TESTS(test_multi, 5);
     return 1;
 }
 

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -1818,7 +1818,7 @@ PEM_write_PKCS8                         1860	3_0_0	EXIST::FUNCTION:STDIO
 PKCS7_digest_from_attributes            1861	3_0_0	EXIST::FUNCTION:
 EC_GROUP_set_curve_GFp                  1862	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,EC
 X509_PURPOSE_get0                       1863	3_0_0	EXIST::FUNCTION:
-EVP_PKEY_set1_DSA                       1864	3_0_0	EXIST::FUNCTION:DSA
+EVP_PKEY_set1_DSA                       1864	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,DSA
 X509_NAME_it                            1865	3_0_0	EXIST::FUNCTION:
 OBJ_add_object                          1866	3_0_0	EXIST::FUNCTION:
 DSA_generate_key                        1867	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,DSA
@@ -1938,7 +1938,7 @@ OBJ_NAME_do_all                         1983	3_0_0	EXIST::FUNCTION:
 d2i_TS_MSG_IMPRINT_fp                   1984	3_0_0	EXIST::FUNCTION:STDIO,TS
 X509_CRL_verify                         1985	3_0_0	EXIST::FUNCTION:
 X509_get0_uids                          1986	3_0_0	EXIST::FUNCTION:
-EVP_PKEY_get0_DSA                       1987	3_0_0	EXIST::FUNCTION:DSA
+EVP_PKEY_get0_DSA                       1987	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,DSA
 d2i_CMS_ContentInfo                     1988	3_0_0	EXIST::FUNCTION:CMS
 EVP_CIPHER_meth_get_do_cipher           1989	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
 i2d_DSA_PUBKEY                          1990	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,DSA
@@ -2093,7 +2093,7 @@ BN_GF2m_mod_sqr                         2138	3_0_0	EXIST::FUNCTION:EC2M
 ASN1_PRINTABLE_new                      2139	3_0_0	EXIST::FUNCTION:
 OBJ_NAME_new_index                      2140	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_asn1_add_alias                 2141	3_0_0	EXIST::FUNCTION:
-EVP_PKEY_get1_DSA                       2142	3_0_0	EXIST::FUNCTION:DSA
+EVP_PKEY_get1_DSA                       2142	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,DSA
 SEED_cbc_encrypt                        2143	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,SEED
 EVP_rc2_40_cbc                          2144	3_0_0	EXIST::FUNCTION:RC2
 ECDSA_SIG_new                           2145	3_0_0	EXIST::FUNCTION:EC
@@ -2603,7 +2603,7 @@ TS_MSG_IMPRINT_print_bio                2658	3_0_0	EXIST::FUNCTION:TS
 CONF_module_set_usr_data                2659	3_0_0	EXIST::FUNCTION:
 EC_KEY_generate_key                     2660	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,EC
 BIO_ctrl_get_write_guarantee            2661	3_0_0	EXIST::FUNCTION:
-EVP_PKEY_assign                         2662	3_0_0	EXIST::FUNCTION:
+EVP_PKEY_assign                         2662	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
 EVP_aes_128_ofb                         2663	3_0_0	EXIST::FUNCTION:
 CMS_data                                2664	3_0_0	EXIST::FUNCTION:CMS
 X509_load_cert_file                     2665	3_0_0	EXIST::FUNCTION:
@@ -2809,7 +2809,7 @@ i2d_OCSP_CERTID                         2870	3_0_0	EXIST::FUNCTION:OCSP
 BN_CTX_start                            2871	3_0_0	EXIST::FUNCTION:
 BN_print                                2872	3_0_0	EXIST::FUNCTION:
 EC_KEY_set_flags                        2873	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,EC
-EVP_PKEY_get0                           2874	3_0_0	EXIST::FUNCTION:
+EVP_PKEY_get0                           2874	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
 ENGINE_set_default                      2875	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,ENGINE
 NCONF_get_number_e                      2876	3_0_0	EXIST::FUNCTION:
 OPENSSL_cleanse                         2877	3_0_0	EXIST::FUNCTION:
@@ -4002,7 +4002,7 @@ PEM_write_bio_PrivateKey_traditional    4091	3_0_0	EXIST::FUNCTION:
 X509_get_pathlen                        4092	3_0_0	EXIST::FUNCTION:
 ECDSA_SIG_set0                          4093	3_0_0	EXIST::FUNCTION:EC
 DSA_SIG_set0                            4094	3_0_0	EXIST::FUNCTION:DSA
-EVP_PKEY_get0_hmac                      4095	3_0_0	EXIST::FUNCTION:
+EVP_PKEY_get0_hmac                      4095	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
 HMAC_CTX_get_md                         4096	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
 NAME_CONSTRAINTS_check_CN               4097	3_0_0	EXIST::FUNCTION:
 OCSP_resp_get0_id                       4098	3_0_0	EXIST::FUNCTION:OCSP
@@ -4089,9 +4089,9 @@ UI_method_set_ex_data                   4178	3_0_0	EXIST::FUNCTION:
 UI_method_get_ex_data                   4179	3_0_0	EXIST::FUNCTION:
 UI_UTIL_wrap_read_pem_callback          4180	3_0_0	EXIST::FUNCTION:
 X509_VERIFY_PARAM_get_time              4181	3_0_0	EXIST::FUNCTION:
-EVP_PKEY_get0_poly1305                  4182	3_0_0	EXIST::FUNCTION:POLY1305
+EVP_PKEY_get0_poly1305                  4182	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,POLY1305
 DH_check_params                         4183	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,DH
-EVP_PKEY_get0_siphash                   4184	3_0_0	EXIST::FUNCTION:SIPHASH
+EVP_PKEY_get0_siphash                   4184	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,SIPHASH
 EVP_aria_256_ofb                        4185	3_0_0	EXIST::FUNCTION:ARIA
 EVP_aria_256_cfb128                     4186	3_0_0	EXIST::FUNCTION:ARIA
 EVP_aria_128_cfb1                       4187	3_0_0	EXIST::FUNCTION:ARIA
@@ -4234,7 +4234,7 @@ EVP_PKEY_meth_set_check                 4341	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_
 EVP_PKEY_meth_get_check                 4342	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
 EVP_PKEY_meth_remove                    4343	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
 OPENSSL_sk_reserve                      4344	3_0_0	EXIST::FUNCTION:
-EVP_PKEY_set1_engine                    4347	3_0_0	EXIST::FUNCTION:ENGINE
+EVP_PKEY_set1_engine                    4347	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,ENGINE
 DH_new_by_nid                           4348	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,DH
 DH_get_nid                              4349	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,DH
 CRYPTO_get_alloc_counts                 4350	3_0_0	EXIST::FUNCTION:CRYPTO_MDEBUG
@@ -4572,7 +4572,7 @@ OSSL_PARAM_get_octet_ptr                ?	3_0_0	EXIST::FUNCTION:
 OSSL_PARAM_set_octet_ptr                ?	3_0_0	EXIST::FUNCTION:
 X509_set0_distinguishing_id             ?	3_0_0	EXIST::FUNCTION:
 X509_get0_distinguishing_id             ?	3_0_0	EXIST::FUNCTION:
-EVP_PKEY_get0_engine                    ?	3_0_0	EXIST::FUNCTION:ENGINE
+EVP_PKEY_get0_engine                    ?	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,ENGINE
 EVP_MD_up_ref                           ?	3_0_0	EXIST::FUNCTION:
 EVP_MD_fetch                            ?	3_0_0	EXIST::FUNCTION:
 EVP_set_default_properties              ?	3_0_0	EXIST::FUNCTION:


### PR DESCRIPTION
If someone calls an `EVP_PKEY_get0*()` function then we create a legacy key and cache it in the EVP_PKEY - but it doesn't become an "origin" and it doesn't ever get updated. This will be documented as a restriction of the `EVP_PKEY_get0*() `function with provided keys.

This avoids lots of multi-threading issues with the current "downgrade" approach.

Fixes #14020

While implementing this I noticed various functions that should have been deprecated that weren't. Since I was touching the man pages for these anyway, I also deprecated those while I was at it.

Fixes #14303
Fixes #14317
