### PR TITLE
Make 'tests' depend on a generated 'providers/fipsmodule.cnf'

### DIFF
--- a/Configurations/common.tmpl
+++ b/Configurations/common.tmpl
@@ -137,6 +137,8 @@
  # generated source file.
  sub dogenerate {
      my $src = shift;
+     # Safety measure
+     return "" unless defined $unified_info{generate}->{$_};
      return "" if $cache{$src};
      my $obj = shift;
      my $bin = shift;
@@ -169,6 +171,17 @@
          }
      }
      $cache{$src} = 1;
+ }
+
+ sub dotarget {
+     my $target = shift;
+     return "" if $cache{$target};
+     $OUT .= generatetarget(target => $target,
+                            deps => $unified_info{depends}->{$target});
+     foreach (@{$unified_info{depends}->{$target}}) {
+         dogenerate($_);
+     }
+     $cache{$target} = 1;
  }
 
  # doobj is responsible for producing all the recipes that build
@@ -463,11 +476,12 @@
  # Start with populating the cache with all the overrides
  %cache = map { $_ => 1 } @{$unified_info{overrides}};
 
- # Build mandatory generated headers
+ # Build mandatory header file generators
  foreach (@{$unified_info{depends}->{""}}) { dogenerate($_); }
 
- # Build all known libraries, modules, programs and scripts.
+ # Build all known targets, libraries, modules, programs and scripts.
  # Everything else will be handled as a consequence.
+ foreach (@{$unified_info{targets}})   { dotarget($_); }
  foreach (@{$unified_info{libraries}}) { dolib($_);    }
  foreach (@{$unified_info{modules}})   { domodule($_); }
  foreach (@{$unified_info{programs}})  { dobin($_);    }

--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -806,8 +806,10 @@ EOF
 
   sub generatesrc {
       my %args = @_;
-      my $generator = join(" ", @{$args{generator}});
-      my $generator_incs = join("", map { ' "-I'.$_.'"' } @{$args{generator_incs}});
+      my $gen0 = $args{generator}->[0];
+      my $gen_args = join('', map { " $_" }
+                              @{$args{generator}}[1..$#{$args{generator}}]);
+      my $gen_incs = join("", map { ' "-I'.$_.'"' } @{$args{generator_incs}});
       my $deps = join(", -\n\t\t", @{$args{generator_deps}}, @{$args{deps}});
 
       if ($args{src} =~ /\.html$/) {
@@ -815,7 +817,7 @@ EOF
           # HTML generator
           #
           my $title = basename($args{src}, ".html");
-          my $pod = $args{generator}->[0];
+          my $pod = $gen0;
           my $mkpod2html = sourcefile('util', 'mkpod2html.pl');
           return <<"EOF";
 $args{src}: $pod
@@ -834,8 +836,8 @@ EOF
               $target{$args{intent}.'_cflags'} =~ m|/NAMES=[^/]*AS_IS|i
               ? '' : ' --case-insensitive';
           return <<"EOF";
-$target : $args{generator}->[0] $deps $mkdef
-	\$(PERL) $mkdef$ord_ver --ordinals $args{generator}->[0] --name $ord_name "--OS" "VMS"$case_insensitive > $target
+$target : $gen0 $deps $mkdef
+	\$(PERL) $mkdef$ord_ver --ordinals $gen0 --name $ord_name "--OS" "VMS"$case_insensitive > $target
 EOF
       } elsif (platform->isasm($args{src})) {
           #
@@ -859,13 +861,14 @@ EOF
           my $defs = join("", map { ",".$_ } @{$args{defs}});
           my $target = platform->asm($args{src});
 
-          if ($args{generator}->[0] =~ /\.pl$/) {
-              $generator = '$(PERL)'.$generator_incs.' '.$generator
+          my $generator;
+          if ($gen0 =~ /\.pl$/) {
+              $generator = '$(PERL)'.$gen_incs.' '.$gen0.$gen_args
                   .' '.$cppflags;
-          } elsif ($args{generator}->[0] =~ /\.S$/) {
+          } elsif ($gen0 =~ /\.S$/) {
               $generator = undef;
           } else {
-              die "Generator type for $src unknown: $generator\n";
+              die "Generator type for $src unknown: $gen0.$gen_args\n";
           }
 
           if (defined($generator)) {
@@ -873,7 +876,7 @@ EOF
               # end up generating foo.s in two steps.
               if ($args{src} =~ /\.S$/) {
                    return <<"EOF";
-$target : $args{generator}->[0] $deps
+$target : $gen0 $deps
 	$generator \$\@-S
         \@ $incs_on
         \@ extradefines = "$defs"
@@ -887,7 +890,7 @@ EOF
               }
               # Otherwise....
               return <<"EOF";
-$target : $args{generator}->[0] $deps
+$target : $gen0 $deps
         \@ $incs_on
         \@ extradefines = "$defs"
 	$generator \$\@
@@ -896,16 +899,16 @@ $target : $args{generator}->[0] $deps
 EOF
           }
           return <<"EOF";
-$target : $args{generator}->[0] $deps
+$target : $gen0 $deps
         \@ $incs_on
         \@ extradefines = "$defs"
         SHOW SYMBOL qual_includes
-        PIPE \$(CPP) $cppflags $args{generator}->[0] | -
+        PIPE \$(CPP) $cppflags $gen0 | -
         \$(PERL) "-ne" "/^#(\\s*line)?\\s*[0-9]+\\s+""/ or print" > \$\@
         \@ DELETE/SYMBOL/LOCAL extradefines
         \@ $incs_off
 EOF
-      } elsif ($args{generator}->[0] =~ m|^.*\.in$|) {
+      } elsif ($gen0 =~ m|^.*\.in$|) {
           #
           # "dofile" generator (file.in -> file)
           #
@@ -919,10 +922,10 @@ EOF
           @modules = map { '"-M'.basename($_, '.pm').'"' } @modules;
           my $modules = join(' ', '', sort keys %moduleincs, @modules);
           return <<"EOF";
-$target : $args{generator}->[0] $deps
-	\$(PERL)$modules $dofile "-o$target{build_file}" $generator > \$\@
+$target : $gen0 $deps
+	\$(PERL)$modules $dofile "-o$target{build_file}" $gen0$gen_args > \$\@
 EOF
-      } elsif (grep { $_ eq $args{generator}->[0] } @{$unified_info{programs}}) {
+      } elsif (grep { $_ eq $gen0 } @{$unified_info{programs}}) {
           #
           # Generic generator using OpenSSL programs
           #
@@ -943,17 +946,19 @@ EOF
                                       $x;
                                   }
                                 } @{$args{deps}});
+          # Also redo $gen0, to ensure that we have the proper extension
+          $gen0 = platform->bin($gen0);
           return <<"EOF";
-$args{src}: $args{generator}->[0] $deps
-	PIPE $generator > \$@
+$args{src}: $gen0 $deps
+	PIPE $gen0$gen_args > \$@
 EOF
       } else {
           #
           # Generic generator using Perl
           #
           return <<"EOF";
-$target : $args{generator}->[0] $deps
-	\$(PERL)$generator_incs $generator > \$\@
+$target : $gen0 $deps
+	\$(PERL)$gen_incs $gen0$gen_args > \$\@
 EOF
       }
   }

--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -795,6 +795,14 @@ reconfigure reconf :
       return ([ @before ], [ @after ]);
   }
 
+  sub generatetarget {
+      my %args = @_;
+      my $deps = join(" ", @{$args{deps}});
+      return <<"EOF";
+$args{target} : $deps
+EOF
+  }
+
   sub generatesrc {
       my %args = @_;
       my $generator = join(" ", @{$args{generator}});

--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -810,14 +810,20 @@ EOF
       my $deps = join(", -\n\t\t", @{$args{generator_deps}}, @{$args{deps}});
 
       if ($args{src} =~ /\.html$/) {
-	  my $title = basename($args{src}, ".html");
-	  my $pod = $args{generator}->[0];
-	  my $mkpod2html = sourcefile('util', 'mkpod2html.pl');
-	  return <<"EOF";
+          #
+          # HTML generator
+          #
+          my $title = basename($args{src}, ".html");
+          my $pod = $args{generator}->[0];
+          my $mkpod2html = sourcefile('util', 'mkpod2html.pl');
+          return <<"EOF";
 $args{src}: $pod
 	\$(PERL) $mkpod2html -i $pod -o \$\@ -t "$title" -r "\$(SRCDIR)/doc"
 EOF
       } elsif (platform->isdef($args{src})) {
+          #
+          # Linker script-ish generator
+          #
           my $target = platform->def($args{src});
           my $mkdef = sourcefile('util', 'mkdef.pl');
           my $ord_ver = $args{intent} eq 'lib' ? ' --version $(VERSION)' : '';
@@ -830,28 +836,10 @@ EOF
 $target : $args{generator}->[0] $deps $mkdef
 	\$(PERL) $mkdef$ord_ver --ordinals $args{generator}->[0] --name $ord_name "--OS" "VMS"$case_insensitive > $target
 EOF
-      } elsif (!platform->isasm($args{src})) {
-          my $target = $args{src};
-          if ($args{generator}->[0] =~ m|^.*\.in$|) {
-	      my $dofile = abs2rel(rel2abs(catfile($config{sourcedir},
-                                                   "util", "dofile.pl")),
-                                   rel2abs($config{builddir}));
-              my @modules = ( 'configdata.pm',
-                              grep { $_ =~ m|\.pm$| } @{$args{deps}} );
-              my %moduleincs = map { '"-I'.dirname($_).'"' => 1 } @modules;
-              @modules = map { '"-M'.basename($_, '.pm').'"' } @modules;
-              my $modules = join(' ', '', sort keys %moduleincs, @modules);
-              return <<"EOF";
-$target : $args{generator}->[0] $deps
-	\$(PERL)$modules $dofile "-o$target{build_file}" $generator > \$\@
-EOF
-	  } else {
-              return <<"EOF";
-$target : $args{generator}->[0] $deps
-	\$(PERL)$generator_incs $generator > \$\@
-EOF
-	  }
-      } else {
+      } elsif (platform->isasm($args{src})) {
+          #
+          # Assembler generator
+          #
           my $cppflags = {
               shlib => '$(LIB_CFLAGS) $(LIB_CPPFLAGS)',
               lib => '$(LIB_CFLAGS) $(LIB_CPPFLAGS)',
@@ -915,6 +903,56 @@ $target : $args{generator}->[0] $deps
         \$(PERL) "-ne" "/^#(\\s*line)?\\s*[0-9]+\\s+""/ or print" > \$\@
         \@ DELETE/SYMBOL/LOCAL extradefines
         \@ $incs_off
+EOF
+      } elsif ($args{generator}->[0] =~ m|^.*\.in$|) {
+          #
+          # "dofile" generator (file.in -> file)
+          #
+          my $dofile = abs2rel(rel2abs(catfile($config{sourcedir},
+                                               "util", "dofile.pl")),
+                               rel2abs($config{builddir}));
+          my @modules = ( 'configdata.pm',
+                          grep { $_ =~ m|\.pm$| } @{$args{deps}} );
+          my %moduleincs = map { '"-I'.dirname($_).'"' => 1 } @modules;
+          $deps = join(' ', $deps, @modules);
+          @modules = map { '"-M'.basename($_, '.pm').'"' } @modules;
+          my $modules = join(' ', '', sort keys %moduleincs, @modules);
+          return <<"EOF";
+$target : $args{generator}->[0] $deps
+	\$(PERL)$modules $dofile "-o$target{build_file}" $generator > \$\@
+EOF
+      } elsif (grep { $_ eq $args{generator}->[0] } @{$unified_info{programs}}) {
+          #
+          # Generic generator using OpenSSL programs
+          #
+
+          # Redo $deps, because programs aren't expected to have deps of their
+          # own.  This is a little more tricky, though, because running programs
+          # may have dependencies on all sorts of files, so we search through
+          # our database of programs and modules to see if our dependencies
+          # are one of those.
+          $deps = join(' ', map { my $x = $_;
+                                  if (grep { $x eq $_ }
+                                          @{$unified_info{programs}}) {
+                                      platform->bin($x);
+                                  } elsif (grep { $x eq $_ }
+                                          @{$unified_info{modules}}) {
+                                      platform->dso($x);
+                                  } else {
+                                      $x;
+                                  }
+                                } @{$args{deps}});
+          return <<"EOF";
+$args{src}: $args{generator}->[0] $deps
+	PIPE $generator > \$@
+EOF
+      } else {
+          #
+          # Generic generator using Perl
+          #
+          return <<"EOF";
+$target : $args{generator}->[0] $deps
+	\$(PERL)$generator_incs $generator > \$\@
 EOF
       }
   }

--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -122,12 +122,13 @@ SHLIB_TARGET={- $target{shared_target} -}
 LIBS={- join(", ", map { "-\n\t".$_.".OLB" } @libs) -}
 SHLIBS={- join(", ", map { "-\n\t".$_.".EXE" } @shlibs) -}
 FIPSMODULENAME={- # We do some extra checking here, as there should be only one
+                  use File::Basename;
                   my @fipsmodules =
                       grep { !$unified_info{attributes}->{modules}->{$_}->{noinst}
                              && $unified_info{attributes}->{modules}->{$_}->{fips} }
                       @{$unified_info{modules}};
                   die "More that one FIPS module" if scalar @fipsmodules > 1;
-                  join(", ", map { basename platform->dso($_) } @fipsmodules) -}
+                  join(", ", map { basename(platform->dso($_)) } @fipsmodules) -}
 MODULES={- join(", ", map { "-\n\t".$_.".EXE" } @{$unified_info{modules}}) -}
 PROGRAMS={- join(", ", map { "-\n\t".$_.".EXE" } @{$unified_info{programs}}) -}
 SCRIPTS={- join(", ", map { "-\n\t".$_ } @{$unified_info{scripts}}) -}

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -1322,22 +1322,31 @@ EOF
       my $deps = join(" ", @{$args{generator_deps}}, @{$args{deps}});
 
       if ($args{src} =~ /\.html$/) {
-	  my $title = basename($args{src}, ".html");
-	  my $pod = $args{generator}->[0];
-	  return <<"EOF";
+          #
+          # HTML generator
+          #
+          my $title = basename($args{src}, ".html");
+          my $pod = $args{generator}->[0];
+          return <<"EOF";
 $args{src}: $pod
 	\$(PERL) \$(SRCDIR)/util/mkpod2html.pl -i "$pod" -o \$\@ -t "$title" -r "\$(SRCDIR)/doc"
 EOF
       } elsif ($args{src} =~ /\.(\d)$/) {
-	  my $section = $1;
-	  my $name = uc basename($args{src}, ".$section");
-	  my $pod = $args{generator}->[0];
-	  return <<"EOF";
+          #
+          # Man-page generator
+          #
+          my $section = $1;
+          my $name = uc basename($args{src}, ".$section");
+          my $pod = $args{generator}->[0];
+          return <<"EOF";
 $args{src}: $pod
 	pod2man --name=$name --section=$section --center=OpenSSL \\
 		--release=\$(VERSION) $pod >\$\@
 EOF
       } elsif (platform->isdef($args{src})) {
+          #
+          # Linker script-ish generator
+          #
           my $target = platform->def($args{src});
           (my $mkdef_os = $target{shared_target}) =~ s|-shared$||;
           my $ord_ver = $args{intent} eq 'lib' ? ' --version $(VERSION)' : '';
@@ -1346,27 +1355,10 @@ EOF
 $target: $args{generator}->[0] $deps \$(SRCDIR)/util/mkdef.pl
 	\$(PERL) \$(SRCDIR)/util/mkdef.pl$ord_ver --ordinals $args{generator}->[0]  --name $ord_name --OS $mkdef_os > $target
 EOF
-      } elsif (!platform->isasm($args{src})) {
-          if ($args{generator}->[0] =~ m|^.*\.in$|) {
-              my $dofile = abs2rel(rel2abs(catfile($config{sourcedir},
-                                                   "util", "dofile.pl")),
-                                   rel2abs($config{builddir}));
-              my @modules = ( 'configdata.pm',
-                              grep { $_ =~ m|\.pm$| } @{$args{deps}} );
-              my %moduleincs = map { '"-I'.dirname($_).'"' => 1 } @modules;
-              @modules = map { "-M".basename($_, '.pm') } @modules;
-              my $modules = join(' ', '', sort keys %moduleincs, @modules);
-              return <<"EOF";
-$args{src}: $args{generator}->[0] $deps \$(BLDDIR)/configdata.pm
-	\$(PERL)$modules "$dofile" "-o$target{build_file}" $generator > \$@
-EOF
-	  } else {
-              return <<"EOF";
-$args{src}: $args{generator}->[0] $deps
-	\$(PERL)$generator_incs $generator > \$@
-EOF
-	  }
-      } else {
+      } elsif (platform->isasm($args{src})) {
+          #
+          # Assembler generator
+          #
           my $cppflags = {
               shlib => '$(LIB_CFLAGS) $(LIB_CPPFLAGS)',
               lib => '$(LIB_CFLAGS) $(LIB_CPPFLAGS)',
@@ -1395,6 +1387,56 @@ EOF
 $args{src}: $args{generator}->[0] $deps
 	\$(CC) $incs $cppflags $defs -E $args{generator}->[0] | \\
 	\$(PERL) -ne '/^#(line)?\\s*[0-9]+/ or print' > \$@
+EOF
+      } elsif ($args{generator}->[0] =~ m|^.*\.in$|) {
+          #
+          # "dofile" generator (file.in -> file)
+          #
+          my $dofile = abs2rel(rel2abs(catfile($config{sourcedir},
+                                               "util", "dofile.pl")),
+                               rel2abs($config{builddir}));
+          my @modules = ( 'configdata.pm',
+                          grep { $_ =~ m|\.pm$| } @{$args{deps}} );
+          my %moduleincs = map { '"-I'.dirname($_).'"' => 1 } @modules;
+          $deps = join(' ', $deps, @modules);
+          @modules = map { "-M".basename($_, '.pm') } @modules;
+          my $modules = join(' ', '', sort keys %moduleincs, @modules);
+          return <<"EOF";
+$args{src}: $args{generator}->[0] $deps
+	\$(PERL)$modules "$dofile" "-o$target{build_file}" $generator > \$@
+EOF
+      } elsif (grep { $_ eq $args{generator}->[0] } @{$unified_info{programs}}) {
+          #
+          # Generic generator using OpenSSL programs
+          #
+
+          # Redo $deps, because programs aren't expected to have deps of their
+          # own.  This is a little more tricky, though, because running programs
+          # may have dependencies on all sorts of files, so we search through
+          # our database of programs and modules to see if our dependencies
+          # are one of those.
+          $deps = join(' ', map { my $x = $_;
+                                  if (grep { $x eq $_ }
+                                          @{$unified_info{programs}}) {
+                                      platform->bin($x);
+                                  } elsif (grep { $x eq $_ }
+                                          @{$unified_info{modules}}) {
+                                      platform->dso($x);
+                                  } else {
+                                      $x;
+                                  }
+                                } @{$args{deps}});
+          return <<"EOF";
+$args{src}: $args{generator}->[0] $deps \$(BLDDIR)/util/wrap.pl
+	\$(BLDDIR)/util/wrap.pl $generator > \$@
+EOF
+      } else {
+          #
+          # Generic generator using Perl
+          #
+          return <<"EOF";
+$args{src}: $args{generator}->[0] $deps
+	\$(PERL)$generator_incs $generator > \$@
 EOF
       }
   }

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -1316,8 +1316,10 @@ EOF
 
   sub generatesrc {
       my %args = @_;
-      my $generator = join(" ", @{$args{generator}});
-      my $generator_incs = join("", map { " -I".$_ } @{$args{generator_incs}});
+      my $gen0 = $args{generator}->[0];
+      my $gen_args = join('', map { " $_" }
+                              @{$args{generator}}[1..$#{$args{generator}}]);
+      my $gen_incs = join("", map { " -I".$_ } @{$args{generator_incs}});
       my $incs = join("", map { " -I".$_ } @{$args{incs}});
       my $defs = join("", map { " -D".$_ } @{$args{defs}});
       my $deps = join(" ", @{$args{generator_deps}}, @{$args{deps}});
@@ -1327,7 +1329,7 @@ EOF
           # HTML generator
           #
           my $title = basename($args{src}, ".html");
-          my $pod = $args{generator}->[0];
+          my $pod = $gen0;
           return <<"EOF";
 $args{src}: $pod
 	\$(PERL) \$(SRCDIR)/util/mkpod2html.pl -i "$pod" -o \$\@ -t "$title" -r "\$(SRCDIR)/doc"
@@ -1338,7 +1340,7 @@ EOF
           #
           my $section = $1;
           my $name = uc basename($args{src}, ".$section");
-          my $pod = $args{generator}->[0];
+          my $pod = $gen0;
           return <<"EOF";
 $args{src}: $pod
 	pod2man --name=$name --section=$section --center=OpenSSL \\
@@ -1353,8 +1355,8 @@ EOF
           my $ord_ver = $args{intent} eq 'lib' ? ' --version $(VERSION)' : '';
           my $ord_name = $args{generator}->[1] || $args{product};
           return <<"EOF";
-$target: $args{generator}->[0] $deps \$(SRCDIR)/util/mkdef.pl
-	\$(PERL) \$(SRCDIR)/util/mkdef.pl$ord_ver --ordinals $args{generator}->[0]  --name $ord_name --OS $mkdef_os > $target
+$target: $gen0 $deps \$(SRCDIR)/util/mkdef.pl
+	\$(PERL) \$(SRCDIR)/util/mkdef.pl$ord_ver --ordinals $gen0  --name $ord_name --OS $mkdef_os > $target
 EOF
       } elsif (platform->isasm($args{src})) {
           #
@@ -1367,29 +1369,30 @@ EOF
               bin => '$(BIN_CFLAGS) $(BIN_CPPFLAGS)'
           } -> {$args{intent}};
 
-          if ($args{generator}->[0] =~ /\.pl$/) {
-              $generator = 'CC="$(CC)" $(PERL)'.$generator_incs.' '.$generator
+          my $generator;
+          if ($gen0 =~ /\.pl$/) {
+              $generator = 'CC="$(CC)" $(PERL)'.$gen_incs.' '.$gen0.$gen_args
                   .' "$(PERLASM_SCHEME)"'.$incs.' '.$cppflags.$defs.' $(PROCESSOR)';
-          } elsif ($args{generator}->[0] =~ /\.m4$/) {
-              $generator = 'm4 -B 8192'.$generator_incs.' '.$generator.' >'
-          } elsif ($args{generator}->[0] =~ /\.S$/) {
+          } elsif ($gen0 =~ /\.m4$/) {
+              $generator = 'm4 -B 8192'.$gen_incs.' '.$gen0.$gen_args.' >'
+          } elsif ($gen0 =~ /\.S$/) {
               $generator = undef;
           } else {
-              die "Generator type for $args{src} unknown: $generator\n";
+              die "Generator type for $args{src} unknown: $gen0\n";
           }
 
           if (defined($generator)) {
               return <<"EOF";
-$args{src}: $args{generator}->[0] $deps
+$args{src}: $gen0 $deps
 	$generator \$@
 EOF
           }
           return <<"EOF";
-$args{src}: $args{generator}->[0] $deps
-	\$(CC) $incs $cppflags $defs -E $args{generator}->[0] | \\
+$args{src}: $gen0 $deps
+	\$(CC) $incs $cppflags $defs -E $gen0 | \\
 	\$(PERL) -ne '/^#(line)?\\s*[0-9]+/ or print' > \$@
 EOF
-      } elsif ($args{generator}->[0] =~ m|^.*\.in$|) {
+      } elsif ($gen0 =~ m|^.*\.in$|) {
           #
           # "dofile" generator (file.in -> file)
           #
@@ -1403,10 +1406,10 @@ EOF
           @modules = map { "-M".basename($_, '.pm') } @modules;
           my $modules = join(' ', '', sort keys %moduleincs, @modules);
           return <<"EOF";
-$args{src}: $args{generator}->[0] $deps
-	\$(PERL)$modules "$dofile" "-o$target{build_file}" $generator > \$@
+$args{src}: $gen0 $deps
+	\$(PERL)$modules "$dofile" "-o$target{build_file}" $gen0$gen_args > \$@
 EOF
-      } elsif (grep { $_ eq $args{generator}->[0] } @{$unified_info{programs}}) {
+      } elsif (grep { $_ eq $gen0 } @{$unified_info{programs}}) {
           #
           # Generic generator using OpenSSL programs
           #
@@ -1427,17 +1430,20 @@ EOF
                                       $x;
                                   }
                                 } @{$args{deps}});
+          # Also redo $gen0, to ensure that we have the proper extension where
+          # necessary.
+          $gen0 = platform->bin($gen0);
           return <<"EOF";
-$args{src}: $args{generator}->[0] $deps \$(BLDDIR)/util/wrap.pl
-	\$(BLDDIR)/util/wrap.pl $generator > \$@
+$args{src}: $gen0 $deps \$(BLDDIR)/util/wrap.pl
+	\$(BLDDIR)/util/wrap.pl $gen0$gen_args > \$@
 EOF
       } else {
           #
           # Generic generator using Perl
           #
           return <<"EOF";
-$args{src}: $args{generator}->[0] $deps
-	\$(PERL)$generator_incs $generator > \$@
+$args{src}: $gen0 $deps
+	\$(PERL)$gen_incs $gen0$gen_args > \$@
 EOF
       }
   }

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -89,12 +89,13 @@ MODULES={- join(" \\\n" . ' ' x 8,
                            map { platform->dso($_) }
                            @{$unified_info{modules}})) -}
 FIPSMODULENAME={- # We do some extra checking here, as there should be only one
+                  use File::Basename;
                   my @fipsmodules =
                       grep { !$unified_info{attributes}->{modules}->{$_}->{noinst}
                              && $unified_info{attributes}->{modules}->{$_}->{fips} }
                       @{$unified_info{modules}};
                   die "More that one FIPS module" if scalar @fipsmodules > 1;
-                  join(" ", map { basename platform->dso($_) } @fipsmodules) -}
+                  join(" ", map { basename(platform->dso($_)) } @fipsmodules) -}
 
 PROGRAMS={- join(" \\\n" . ' ' x 9,
                  fill_lines(" ", $COLUMNS - 9,

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -1305,6 +1305,14 @@ reconfigure reconf:
                  } @_;
   }
 
+  sub generatetarget {
+      my %args = @_;
+      my $deps = join(" ", @{$args{deps}});
+      return <<"EOF";
+$args{target}: $deps
+EOF
+  }
+
   sub generatesrc {
       my %args = @_;
       my $generator = join(" ", @{$args{generator}});

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -52,12 +52,13 @@ MODULES={- our @MODULES = map { platform->dso($_) } @{$unified_info{modules}};
            join(" ", @MODULES) -}
 MODULEPDBS={- join(" ", map { platform->dsopdb($_) } @{$unified_info{modules}}) -}
 FIPSMODULENAME={- # We do some extra checking here, as there should be only one
+                  use File::Basename;
                   my @fipsmodules =
                       grep { !$unified_info{attributes}->{modules}->{$_}->{noinst}
                              && $unified_info{attributes}->{modules}->{$_}->{fips} }
                       @{$unified_info{modules}};
                   die "More that one FIPS module" if scalar @fipsmodules > 1;
-                  join(" ", map { basename platform->dso($_) } @fipsmodules) -}
+                  join(" ", map { basename(platform->dso($_)) } @fipsmodules) -}
 PROGRAMS={- our @PROGRAMS = map { platform->bin($_) } @{$unified_info{programs}}; join(" ", @PROGRAMS) -}
 PROGRAMPDBS={- join(" ", map { $_.".pdb" } @{$unified_info{programs}}) -}
 SCRIPTS={- our @SCRIPTS = @{$unified_info{scripts}}; join(" ", @SCRIPTS) -}

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -762,7 +762,7 @@ EOF
           # Generic generator using Perl
           #
           return <<"EOF";
-$target: "$args{generator}->[0]" $deps
+$args{src}: "$args{generator}->[0]" $deps
 	"\$(PERL)"$generator_incs $generator > \$@
 EOF
       }

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -638,9 +638,10 @@ EOF
 
   sub generatesrc {
       my %args = @_;
-      my ($gen0, @gens) = @{$args{generator}};
-      my $generator = '"'.$gen0.'"'.join('', map { " $_" } @gens);
-      my $generator_incs = join("", map { " -I \"$_\"" } @{$args{generator_incs}});
+      my $gen0 = $args{generator}->[0];
+      my $gen_args = join('', map { " $_" }
+                              @{$args{generator}}[1..$#{$args{generator}}]);
+      my $gen_incs = join("", map { " -I \"$_\"" } @{$args{generator_incs}});
       my $incs = join("", map { " -I \"$_\"" } @{$args{incs}});
       my $defs = join("", map { " -D".$_ } @{$args{defs}});
       my $deps = @{$args{deps}} ?
@@ -651,7 +652,7 @@ EOF
           # HTML generator
           #
           my $title = basename($args{src}, ".html");
-          my $pod = $args{generator}->[0];
+          my $pod = $gen0;
           return <<"EOF";
 $args{src}: "$pod"
 	\$(PERL) \$(SRCDIR)/util/mkpod2html.pl -i "$pod" -o \$\@ -t "$title" -r "\$(SRCDIR)/doc"
@@ -668,8 +669,8 @@ EOF
           my $ord_name =
               $args{generator}->[1] || platform->dsoname($args{product});
           return <<"EOF";
-$target: $args{generator}->[0] $deps $mkdef
-	"\$(PERL)" $mkdef$ord_ver --ordinals $args{generator}->[0] --name $ord_name --OS windows > $target
+$target: $gen0 $deps $mkdef
+	"\$(PERL)" $mkdef$ord_ver --ordinals $gen0 --name $ord_name --OS windows > $target
 EOF
       } elsif (platform->isasm($args{src})) {
           #
@@ -683,13 +684,14 @@ EOF
           } -> {$args{intent}};
           my $target = platform->asm($args{src});
 
-          if ($args{generator}->[0] =~ /\.pl$/) {
-              $generator = '"$(PERL)"'.$generator_incs.' '.$generator
+          my $generator;
+          if ($gen0 =~ /\.pl$/) {
+              $generator = '"$(PERL)"'.$gen_incs.' '.$gen0.$gen_args
                   .' "$(PERLASM_SCHEME)"'.$incs.' '.$cppflags.$defs.' $(PROCESSSOR)';
-          } elsif ($args{generator}->[0] =~ /\.S$/) {
+          } elsif ($gen0 =~ /\.S$/) {
               $generator = undef;
           } else {
-              die "Generator type for $src unknown: $generator\n";
+              die "Generator type for $src unknown: $gen0\n";
           }
 
           if (defined($generator)) {
@@ -697,7 +699,7 @@ EOF
               # end up generating foo.s in two steps.
               if ($args{src} =~ /\.S$/) {
                    return <<"EOF";
-$target: "$args{generator}->[0]" $deps
+$target: "$gen0" $deps
 	set ASM=\$(AS)
 	$generator \$@.S
 	\$(CPP) $incs $cppflags $defs \$@.S > \$@.i && move /Y \$@.i \$@
@@ -706,16 +708,16 @@ EOF
               }
               # Otherwise....
               return <<"EOF";
-$target: "$args{generator}->[0]" $deps
+$target: "$gen0" $deps
 	set ASM=\$(AS)
 	$generator \$@
 EOF
           }
           return <<"EOF";
-$target: "$args{generator}->[0]" $deps
-	\$(CPP) $incs $cppflags $defs "$args{generator}->[0]" > \$@.i && move /Y \$@.i \$@
+$target: "$gen0" $deps
+	\$(CPP) $incs $cppflags $defs "$gen0" > \$@.i && move /Y \$@.i \$@
 EOF
-      } elsif ($args{generator}->[0] =~ m|^.*\.in$|) {
+      } elsif ($gen0 =~ m|^.*\.in$|) {
           #
           # "dofile" generator (file.in -> file)
           #
@@ -729,10 +731,10 @@ EOF
           @modules = map { "-M".basename($_, '.pm') } @modules;
           my $modules = join(' ', '', sort keys %moduleincs, @modules);
           return <<"EOF";
-$args{src}: "$args{generator}->[0]" $deps
-	"\$(PERL)"$modules "$dofile" "-o$target{build_file}" $generator > \$@
+$args{src}: "$gen0" $deps
+	"\$(PERL)"$modules "$dofile" "-o$target{build_file}" "$gen0"$gen_args > \$@
 EOF
-      } elsif (grep { $_ eq $args{generator}->[0] } @{$unified_info{programs}}) {
+      } elsif (grep { $_ eq $gen0 } @{$unified_info{programs}}) {
           #
           # Generic generator using OpenSSL programs
           #
@@ -753,17 +755,19 @@ EOF
                                       $x;
                                   }
                                 } @{$args{deps}});
+          # Also redo $gen0, to ensure that we have the proper extension.
+          $gen0 = platform->bin($gen0);
           return <<"EOF";
-$args{src}: $args{generator}->[0] $deps
-	$generator > \$@
+$args{src}: $gen0 $deps
+	$gen0$gen_args > \$@
 EOF
       } else {
           #
           # Generic generator using Perl
           #
           return <<"EOF";
-$args{src}: "$args{generator}->[0]" $deps
-	"\$(PERL)"$generator_incs $generator > \$@
+$args{src}: "$gen0" $deps
+	"\$(PERL)"$gen_incs $gen0$gen_args > \$@
 EOF
       }
   }

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -627,6 +627,14 @@ reconfigure reconf:
      return map { platform->sharedlib_import($_) // platform->staticlib($_) } @_;
  }
 
+  sub generatetarget {
+      my %args = @_;
+      my $deps = join(" ", @{$args{deps}});
+      return <<"EOF";
+$args{target}: $deps
+EOF
+  }
+
   sub generatesrc {
       my %args = @_;
       my ($gen0, @gens) = @{$args{generator}};

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -646,13 +646,19 @@ EOF
           '"'.join('" "', @{$args{generator_deps}}, @{$args{deps}}).'"' : '';
 
       if ($args{src} =~ /\.html$/) {
-	  my $title = basename($args{src}, ".html");
-	  my $pod = $args{generator}->[0];
-	  return <<"EOF";
+          #
+          # HTML generator
+          #
+          my $title = basename($args{src}, ".html");
+          my $pod = $args{generator}->[0];
+          return <<"EOF";
 $args{src}: "$pod"
 	\$(PERL) \$(SRCDIR)/util/mkpod2html.pl -i "$pod" -o \$\@ -t "$title" -r "\$(SRCDIR)/doc"
 EOF
       } elsif (platform->isdef($args{src})) {
+          #
+          # Linker script-ish generator
+          #
           my $target = platform->def($args{src});
           my $mkdef = abs2rel(rel2abs(catfile($config{sourcedir},
                                               "util", "mkdef.pl")),
@@ -664,28 +670,10 @@ EOF
 $target: $args{generator}->[0] $deps $mkdef
 	"\$(PERL)" $mkdef$ord_ver --ordinals $args{generator}->[0] --name $ord_name --OS windows > $target
 EOF
-      } elsif (!platform->isasm($args{src})) {
-          my $target = $args{src};
-          if ($args{generator}->[0] =~ m|^.*\.in$|) {
-              my $dofile = abs2rel(rel2abs(catfile($config{sourcedir},
-                                                   "util", "dofile.pl")),
-                                   rel2abs($config{builddir}));
-              my @modules = ( 'configdata.pm',
-                              grep { $_ =~ m|\.pm$| } @{$args{deps}} );
-              my %moduleincs = map { '"-I'.dirname($_).'"' => 1 } @modules;
-              @modules = map { "-M".basename($_, '.pm') } @modules;
-              my $modules = join(' ', '', sort keys %moduleincs, @modules);
-              return <<"EOF";
-$target: "$args{generator}->[0]" $deps
-	"\$(PERL)"$modules "$dofile" "-o$target{build_file}" $generator > \$@
-EOF
-	  } else {
-              return <<"EOF";
-$target: "$args{generator}->[0]" $deps
-	"\$(PERL)"$generator_incs $generator > \$@
-EOF
-	  }
-      } else {
+      } elsif (platform->isasm($args{src})) {
+          #
+          # Assembler generator
+          #
           my $cppflags = {
               shlib => '$(LIB_CFLAGS) $(LIB_CPPFLAGS)',
               lib => '$(LIB_CFLAGS) $(LIB_CPPFLAGS)',
@@ -725,6 +713,56 @@ EOF
           return <<"EOF";
 $target: "$args{generator}->[0]" $deps
 	\$(CPP) $incs $cppflags $defs "$args{generator}->[0]" > \$@.i && move /Y \$@.i \$@
+EOF
+      } elsif ($args{generator}->[0] =~ m|^.*\.in$|) {
+          #
+          # "dofile" generator (file.in -> file)
+          #
+          my $dofile = abs2rel(rel2abs(catfile($config{sourcedir},
+                                               "util", "dofile.pl")),
+                               rel2abs($config{builddir}));
+          my @modules = ( 'configdata.pm',
+                          grep { $_ =~ m|\.pm$| } @{$args{deps}} );
+          my %moduleincs = map { '"-I'.dirname($_).'"' => 1 } @modules;
+          $deps = join(' ', $deps, @modules);
+          @modules = map { "-M".basename($_, '.pm') } @modules;
+          my $modules = join(' ', '', sort keys %moduleincs, @modules);
+          return <<"EOF";
+$args{src}: "$args{generator}->[0]" $deps
+	"\$(PERL)"$modules "$dofile" "-o$target{build_file}" $generator > \$@
+EOF
+      } elsif (grep { $_ eq $args{generator}->[0] } @{$unified_info{programs}}) {
+          #
+          # Generic generator using OpenSSL programs
+          #
+
+          # Redo $deps, because programs aren't expected to have deps of their
+          # own.  This is a little more tricky, though, because running programs
+          # may have dependencies on all sorts of files, so we search through
+          # our database of programs and modules to see if our dependencies
+          # are one of those.
+          $deps = join(' ', map { my $x = $_;
+                                  if (grep { $x eq $_ }
+                                          @{$unified_info{programs}}) {
+                                      platform->bin($x);
+                                  } elsif (grep { $x eq $_ }
+                                          @{$unified_info{modules}}) {
+                                      platform->dso($x);
+                                  } else {
+                                      $x;
+                                  }
+                                } @{$args{deps}});
+          return <<"EOF";
+$args{src}: $args{generator}->[0] $deps
+	$generator > \$@
+EOF
+      } else {
+          #
+          # Generic generator using Perl
+          #
+          return <<"EOF";
+$target: "$args{generator}->[0]" $deps
+	"\$(PERL)"$generator_incs $generator > \$@
 EOF
       }
   }

--- a/Configure
+++ b/Configure
@@ -2320,7 +2320,7 @@ EOF
             $generator[0] = cleanfile($sourced, $gen, $blddir);
 
             # If the generator is itself generated, it's in the build tree
-            if ($generate{$gen}) {
+            if ($generate{$gen} || ! -f $generator[0]) {
                 $generator[0] = cleanfile($buildd, $gen, $blddir);
             }
             $check_generate{$ddest}->{$generator[0]}++;

--- a/Configure
+++ b/Configure
@@ -2330,12 +2330,22 @@ EOF
 
         foreach (keys %depends) {
             my $dest = $_;
-            my $ddest = $dest eq "" ? "" : cleanfile($sourced, $_, $blddir);
+            my $ddest = $dest;
 
-            # If the destination doesn't exist in source, it can only be
-            # a generated file in the build tree.
-            if ($ddest ne "" && ($ddest eq $src_configdata || ! -f $ddest)) {
-                $ddest = cleanfile($buildd, $_, $blddir);
+            if ($dest =~ /^\|(.*)\|$/) {
+                # Collect the raw target
+                $unified_info{targets}->{$1} = 1;
+                $ddest = $1;
+            } elsif ($dest eq '') {
+                $ddest = '';
+            } else {
+                $ddest = cleanfile($sourced, $_, $blddir);
+
+                # If the destination doesn't exist in source, it can only be
+                # a generated file in the build tree.
+                if ($ddest eq $src_configdata || ! -f $ddest) {
+                    $ddest = cleanfile($buildd, $_, $blddir);
+                }
             }
             foreach (@{$depends{$dest}}) {
                 my $d = cleanfile($sourced, $_, $blddir);
@@ -2628,7 +2638,7 @@ EOF
 
     ### Make unified_info a bit more efficient
     # One level structures
-    foreach (("programs", "libraries", "modules", "scripts")) {
+    foreach (("programs", "libraries", "modules", "scripts", "targets")) {
         $unified_info{$_} = [ sort keys %{$unified_info{$_}} ];
     }
     # Two level structures

--- a/apps/fipsinstall.c
+++ b/apps/fipsinstall.c
@@ -384,7 +384,7 @@ opthelp:
         if (verify_module_load(parent_config)) {
             ret = OSSL_PROVIDER_available(NULL, prov_name) ? 0 : 1;
             if (!quiet)
-                BIO_printf(bio_out, "FIPS provider is %s\n",
+                BIO_printf(bio_err, "FIPS provider is %s\n",
                            ret == 0 ? "available" : " not available");
         }
         goto end;
@@ -478,7 +478,7 @@ opthelp:
                            install_mac, install_mac_len))
             goto end;
         if (!quiet)
-            BIO_printf(bio_out, "VERIFY PASSED\n");
+            BIO_printf(bio_err, "VERIFY PASSED\n");
     } else {
 
         conf = generate_config_and_load(prov_name, section_name, module_mac,
@@ -502,7 +502,7 @@ opthelp:
                                        install_mac, install_mac_len))
             goto end;
         if (!quiet)
-            BIO_printf(bio_out, "INSTALL PASSED\n");
+            BIO_printf(bio_err, "INSTALL PASSED\n");
     }
 
     ret = 0;
@@ -550,10 +550,10 @@ static int self_test_events(const OSSL_PARAM params[], void *arg)
 
     if (self_test_log) {
         if (strcmp(phase, OSSL_SELF_TEST_PHASE_START) == 0)
-            BIO_printf(bio_out, "%s : (%s) : ", desc, type);
+            BIO_printf(bio_err, "%s : (%s) : ", desc, type);
         else if (strcmp(phase, OSSL_SELF_TEST_PHASE_PASS) == 0
                  || strcmp(phase, OSSL_SELF_TEST_PHASE_FAIL) == 0)
-            BIO_printf(bio_out, "%s\n", phase);
+            BIO_printf(bio_err, "%s\n", phase);
     }
     /*
      * The self test code will internally corrupt the KAT test result if an
@@ -568,7 +568,7 @@ static int self_test_events(const OSSL_PARAM params[], void *arg)
         if (self_test_corrupt_type != NULL
                 && strcmp(self_test_corrupt_type, type) != 0)
             goto end;
-        BIO_printf(bio_out, "%s ", phase);
+        BIO_printf(bio_err, "%s ", phase);
         goto err;
     }
 end:

--- a/doc/internal/man7/build.info.pod
+++ b/doc/internal/man7/build.info.pod
@@ -444,6 +444,12 @@ rather than the specific I<items>.
 The I<items> may be any program, library, module, script, or any
 filename used as a value anywhere.
 
+The I<items> may also be literal build file targets.  Those are
+recognised by being surrounded be vertical bars (also known as the
+"pipe" character), C<|>.  For example:
+
+    DEPEND[|tests|]=fipsmodule.cnf
+
 B<DEPEND> statements may have attributes, which apply to each
 individual dependency in such a statement.  For example:
 

--- a/providers/build.info
+++ b/providers/build.info
@@ -142,6 +142,16 @@ IF[{- !$disabled{fips} -}]
   # statements, the final build file will not have a trace of it.
   MODULES{fips}=$FIPSGOAL
   LIBS{noinst}=$LIBFIPS
+
+  # For tests that try to use the FIPS module, we need to make a local fips
+  # module installation.  We have the output go to standard output, because
+  # the generated commands in build templates are expected to catch that,
+  # and thereby keep control over the exact output file location.
+  DEPEND[|tests|]=fipsmodule.cnf
+  GENERATE[fipsmodule.cnf]=../apps/openssl fipsinstall \
+        -module providers/$(FIPSMODULENAME) -provider_name fips \
+        -mac_name HMAC -section_name fips_sect -out -
+  DEPEND[fipsmodule.cnf]=$FIPSGOAL
 ENDIF
 
 #

--- a/test/recipes/01-test_fipsmodule_cnf.t
+++ b/test/recipes/01-test_fipsmodule_cnf.t
@@ -23,7 +23,7 @@ use lib srctop_dir('Configurations');
 use lib bldtop_dir('.');
 use platform;
 
-my $no_check = disabled("fips")
+my $no_check = disabled("fips");
 plan skip_all => "Test only supported in a fips build"
     if $no_check;
 plan tests => 1;

--- a/test/recipes/01-test_fipsmodule_cnf.t
+++ b/test/recipes/01-test_fipsmodule_cnf.t
@@ -23,8 +23,8 @@ use lib srctop_dir('Configurations');
 use lib bldtop_dir('.');
 use platform;
 
-my $no_check = disabled("fips") || disabled('fips-securitychecks');
-plan skip_all => "Test only supported in a fips build with security checks"
+my $no_check = disabled("fips")
+plan skip_all => "Test only supported in a fips build"
     if $no_check;
 plan tests => 1;
 

--- a/test/recipes/01-test_fipsmodule_cnf.t
+++ b/test/recipes/01-test_fipsmodule_cnf.t
@@ -1,0 +1,37 @@
+#! /usr/bin/env perl
+# Copyright 2021 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+# This is a sanity checker to see that the fipsmodule.cnf that's been
+# generated for testing is valid.
+
+use strict;
+use warnings;
+
+use OpenSSL::Test qw/:DEFAULT srctop_dir bldtop_dir bldtop_file srctop_file data_file/;
+use OpenSSL::Test::Utils;
+
+BEGIN {
+    setup("test_fipsmodule");
+}
+
+use lib srctop_dir('Configurations');
+use lib bldtop_dir('.');
+use platform;
+
+my $no_check = disabled("fips") || disabled('fips-securitychecks');
+plan skip_all => "Test only supported in a fips build with security checks"
+    if $no_check;
+plan tests => 1;
+
+my $fipsmodule = bldtop_file('providers', platform->dso('fips'));
+my $fipsmoduleconf = bldtop_file('providers', 'fipsmodule.cnf');
+
+# verify the $fipsconf file
+ok(run(app(['openssl', 'fipsinstall',
+            '-in',  $fipsmoduleconf, '-module', $fipsmodule, '-verify'])),
+   "fipsinstall verify");

--- a/test/recipes/03-test_fipsinstall.t
+++ b/test/recipes/03-test_fipsinstall.t
@@ -9,7 +9,7 @@
 use strict;
 use warnings;
 
-use File::Spec;
+use File::Spec::Functions qw(:DEFAULT abs2rel);
 use File::Copy;
 use OpenSSL::Glob;
 use OpenSSL::Test qw/:DEFAULT srctop_dir srctop_file bldtop_dir bldtop_file/;
@@ -235,7 +235,8 @@ SKIP: {
        "fipsinstall fails when the asymmetric cipher result is corrupted");
 }
 
-$ENV{OPENSSL_CONF_INCLUDE} = ".";
+# 'local' ensures that this change is only done in this file.
+local $ENV{OPENSSL_CONF_INCLUDE} = abs2rel(curdir());
 
 ok(replace_parent_line_file('fips.cnf', 'fips_parent.cnf')
    && run(app(['openssl', 'fipsinstall', '-config', 'fips_parent.cnf'])),
@@ -271,5 +272,3 @@ ok(replace_parent_line_file('fips_bad_module_mac.cnf',
    && !run(app(['openssl', 'fipsinstall',
                 '-config', 'fips_parent_bad_module_mac.cnf'])),
    "verify load config fail bad module mac");
-
-delete $ENV{OPENSSL_CONF_INCLUDE};

--- a/test/recipes/15-test_gendsa.t
+++ b/test/recipes/15-test_gendsa.t
@@ -20,7 +20,6 @@ BEGIN {
 
 use lib srctop_dir('Configurations');
 use lib bldtop_dir('.');
-use platform;
 
 plan skip_all => "This test is unsupported in a no-dsa build"
     if disabled("dsa");
@@ -28,7 +27,7 @@ plan skip_all => "This test is unsupported in a no-dsa build"
 my $no_fips = disabled('fips') || ($ENV{NO_FIPS} // 0);
 
 plan tests =>
-    ($no_fips ? 0 : 3)          # FIPS install test + fips related tests
+    ($no_fips ? 0 : 2)          # FIPS related tests
     + 11;
 
 ok(run(app([ 'openssl', 'genpkey', '-genparam',
@@ -113,14 +112,6 @@ unless ($no_fips) {
     my $provpath = bldtop_dir("providers");
     my @prov = ( "-provider-path", $provpath,
                  "-config", $provconf);
-    my $infile = bldtop_file('providers', platform->dso('fips'));
-
-    ok(run(app(['openssl', 'fipsinstall',
-                '-out', bldtop_file('providers', 'fipsmodule.cnf'),
-                '-module', $infile,
-                '-provider_name', 'fips', '-mac_name', 'HMAC',
-                '-section_name', 'fips_sect'])),
-       "fipsinstall");
 
     $ENV{OPENSSL_TEST_LIBCTX} = "1";
 

--- a/test/recipes/15-test_genrsa.t
+++ b/test/recipes/15-test_genrsa.t
@@ -25,7 +25,7 @@ use platform;
 my $no_fips = disabled('fips') || ($ENV{NO_FIPS} // 0);
 
 plan tests =>
-    ($no_fips ? 0 : 2)          # FIPS install test + fips related test
+    ($no_fips ? 0 : 1)          # Extra FIPS related test
     + 13;
 
 # We want to know that an absurdly small number of bits isn't support
@@ -125,13 +125,6 @@ unless ($no_fips) {
     my @prov = ( "-provider-path", $provpath,
                  "-config", $provconf);
     my $infile = bldtop_file('providers', platform->dso('fips'));
-
-    ok(run(app(['openssl', 'fipsinstall',
-                '-out', bldtop_file('providers', 'fipsmodule.cnf'),
-                '-module', $infile,
-                '-provider_name', 'fips', '-mac_name', 'HMAC',
-                '-section_name', 'fips_sect'])),
-       "fipsinstall");
 
     $ENV{OPENSSL_TEST_LIBCTX} = "1";
     ok(run(app(['openssl', 'genpkey',

--- a/test/recipes/15-test_genrsa.t
+++ b/test/recipes/15-test_genrsa.t
@@ -20,7 +20,6 @@ BEGIN {
 
 use lib srctop_dir('Configurations');
 use lib bldtop_dir('.');
-use platform;
 
 my $no_fips = disabled('fips') || ($ENV{NO_FIPS} // 0);
 
@@ -124,7 +123,6 @@ unless ($no_fips) {
     my $provpath = bldtop_dir("providers");
     my @prov = ( "-provider-path", $provpath,
                  "-config", $provconf);
-    my $infile = bldtop_file('providers', platform->dso('fips'));
 
     $ENV{OPENSSL_TEST_LIBCTX} = "1";
     ok(run(app(['openssl', 'genpkey',

--- a/test/recipes/15-test_rsaoaep.t
+++ b/test/recipes/15-test_rsaoaep.t
@@ -18,12 +18,11 @@ BEGIN {
 }
 use lib srctop_dir('Configurations');
 use lib bldtop_dir('.');
-use platform;
 
 my $no_check = disabled('fips-securitychecks');
 
 plan tests =>
-    ($no_check ? 0 : 1)         # FIPS install test
+    ($no_check ? 0 : 1)         # FIPS security check
     + 9;
 
 my @prov = ( );
@@ -42,6 +41,7 @@ my $small_key_file = srctop_file("test", "testrsa.pem");
 $ENV{OPENSSL_TEST_LIBCTX} = "1";
 
 unless ($no_check) {
+    @prov = ( "-provider-path", $provpath, "-config", $provconf );
     ok(!run(app(['openssl', 'pkeyutl',
                  @prov,
                  '-encrypt',

--- a/test/recipes/15-test_rsaoaep.t
+++ b/test/recipes/15-test_rsaoaep.t
@@ -20,11 +20,10 @@ use lib srctop_dir('Configurations');
 use lib bldtop_dir('.');
 use platform;
 
-my $no_fips = disabled('fips') || ($ENV{NO_FIPS} // 0);
 my $no_check = disabled('fips-securitychecks');
 
 plan tests =>
-    ($no_fips ? 0 : 1 + ($no_check ? 0 : 1))          # FIPS install test
+    ($no_check ? 0 : 1)         # FIPS install test
     + 9;
 
 my @prov = ( );
@@ -40,29 +39,20 @@ my $dec3_file = "dec3.txt";
 my $key_file = srctop_file("test", "testrsa2048.pem");
 my $small_key_file = srctop_file("test", "testrsa.pem");
 
-unless ($no_fips) {
-    @prov = ( "-provider-path", $provpath, "-config", $provconf );
-    my $infile = bldtop_file('providers', platform->dso('fips'));
+$ENV{OPENSSL_TEST_LIBCTX} = "1";
 
-    ok(run(app(['openssl', 'fipsinstall',
-                '-out', bldtop_file('providers', 'fipsmodule.cnf'),
-                '-module', $infile])),
-       "fipsinstall");
-    $ENV{OPENSSL_TEST_LIBCTX} = "1";
-
-    unless ($no_check) {
-        ok(!run(app(['openssl', 'pkeyutl',
-                    @prov,
-                    '-encrypt',
-                    '-in', $msg_file,
-                    '-inkey', $small_key_file,
-                    '-pkeyopt', 'pad-mode:oaep',
-                    '-pkeyopt', 'oaep-label:123',
-                    '-pkeyopt', 'digest:sha1',
-                    '-pkeyopt', 'mgf1-digest:sha1',
-                    '-out', $enc1_file])),
-           "RSA OAEP Encryption with a key smaller than 2048 in fips mode should fail");
-    }
+unless ($no_check) {
+    ok(!run(app(['openssl', 'pkeyutl',
+                 @prov,
+                 '-encrypt',
+                 '-in', $msg_file,
+                 '-inkey', $small_key_file,
+                 '-pkeyopt', 'pad-mode:oaep',
+                 '-pkeyopt', 'oaep-label:123',
+                 '-pkeyopt', 'digest:sha1',
+                 '-pkeyopt', 'mgf1-digest:sha1',
+                 '-out', $enc1_file])),
+       "RSA OAEP Encryption with a key smaller than 2048 in fips mode should fail");
 }
 
 ok(run(app(['openssl', 'pkeyutl',

--- a/test/recipes/20-test_cli_fips.t
+++ b/test/recipes/20-test_cli_fips.t
@@ -26,7 +26,7 @@ use platform;
 my $no_check = disabled('fips-securitychecks');
 plan skip_all => "Test only supported in a fips build with security checks"
     if disabled("fips") || disabled("fips-securitychecks");
-plan tests => 13;
+plan tests => 11;
 
 my $fipsmodule = bldtop_file('providers', platform->dso('fips'));
 my $fipsconf = srctop_file("test", "fips-and-base.cnf");
@@ -34,7 +34,6 @@ my $defaultconf = srctop_file("test", "default.cnf");
 my $tbs_data = $fipsmodule;
 my $bogus_data = $fipsconf;
 
-$ENV{OPENSSL_CONF_INCLUDE} = abs2rel(curdir());
 $ENV{OPENSSL_CONF} = $fipsconf;
 
 ok(run(app(['openssl', 'list', '-public-key-methods', '-verbose'])),

--- a/test/recipes/20-test_cli_fips.t
+++ b/test/recipes/20-test_cli_fips.t
@@ -23,9 +23,9 @@ use lib srctop_dir('Configurations');
 use lib bldtop_dir('.');
 use platform;
 
-my $no_check = disabled('fips-securitychecks');
+my $no_check = disabled("fips") || disabled('fips-securitychecks');
 plan skip_all => "Test only supported in a fips build with security checks"
-    if disabled("fips") || disabled("fips-securitychecks");
+    if $no_check;
 plan tests => 11;
 
 my $fipsmodule = bldtop_file('providers', platform->dso('fips'));

--- a/test/recipes/20-test_cli_fips.t
+++ b/test/recipes/20-test_cli_fips.t
@@ -34,16 +34,6 @@ my $defaultconf = srctop_file("test", "default.cnf");
 my $tbs_data = $fipsmodule;
 my $bogus_data = $fipsconf;
 
-# output a fipsmodule.cnf file containing mac data
-ok(run(app(['openssl', 'fipsinstall', '-out', 'fipsmodule.cnf',
-            '-module', $fipsmodule, ])),
-   "fipsinstall");
-
-# verify the $fipsconf file
-ok(run(app(['openssl', 'fipsinstall', '-in', 'fipsmodule.cnf', '-module', $fipsmodule,
-            '-verify'])),
-   "fipsinstall verify");
-
 $ENV{OPENSSL_CONF_INCLUDE} = abs2rel(curdir());
 $ENV{OPENSSL_CONF} = $fipsconf;
 

--- a/test/recipes/30-test_acvp.t
+++ b/test/recipes/30-test_acvp.t
@@ -27,12 +27,7 @@ use platform;
 
 my $infile = bldtop_file('providers', platform->dso('fips'));
 
-plan tests => 2;
-
-ok(run(app(['openssl', 'fipsinstall',
-           '-out', bldtop_file('providers', 'fipsmodule.cnf'),
-           '-module', $infile])),
-   "fipsinstall");
+plan tests => 1;
 
 ok(run(test(["acvp_test", "-config", srctop_file("test","fips.cnf")])),
    "running acvp_test");

--- a/test/recipes/30-test_acvp.t
+++ b/test/recipes/30-test_acvp.t
@@ -23,9 +23,6 @@ plan skip_all => "ACVP is not supported by this test"
 
 use lib srctop_dir('Configurations');
 use lib bldtop_dir('.');
-use platform;
-
-my $infile = bldtop_file('providers', platform->dso('fips'));
 
 plan tests => 1;
 

--- a/test/recipes/30-test_defltfips.t
+++ b/test/recipes/30-test_defltfips.t
@@ -20,7 +20,6 @@ BEGIN {
 
 use lib srctop_dir('Configurations');
 use lib bldtop_dir('.');
-use platform;
 
 my $no_fips = disabled('fips') || ($ENV{NO_FIPS} // 0);
 
@@ -28,8 +27,6 @@ plan tests =>
     ($no_fips ? 1 : 2);
 
 unless ($no_fips) {
-    my $infile = bldtop_file('providers', platform->dso('fips'));
-
     $ENV{OPENSSL_CONF} = abs_path(srctop_file("test", "fips.cnf"));
     ok(run(test(["defltfips_test", "fips"])), "running defltfips_test fips");
 }

--- a/test/recipes/30-test_defltfips.t
+++ b/test/recipes/30-test_defltfips.t
@@ -25,15 +25,10 @@ use platform;
 my $no_fips = disabled('fips') || ($ENV{NO_FIPS} // 0);
 
 plan tests =>
-    ($no_fips ? 1 : 3);
+    ($no_fips ? 1 : 2);
 
 unless ($no_fips) {
     my $infile = bldtop_file('providers', platform->dso('fips'));
-
-    ok(run(app(['openssl', 'fipsinstall',
-                '-out', bldtop_file('providers', 'fipsmodule.cnf'),
-                '-module', $infile])),
-       "fipsinstall");
 
     $ENV{OPENSSL_CONF} = abs_path(srctop_file("test", "fips.cnf"));
     ok(run(test(["defltfips_test", "fips"])), "running defltfips_test fips");

--- a/test/recipes/30-test_evp.t
+++ b/test/recipes/30-test_evp.t
@@ -19,7 +19,6 @@ BEGIN {
 
 use lib srctop_dir('Configurations');
 use lib bldtop_dir('.');
-use platform;
 
 my $no_fips = disabled('fips') || ($ENV{NO_FIPS} // 0);
 my $no_legacy = disabled('legacy') || ($ENV{NO_LEGACY} // 0);

--- a/test/recipes/30-test_evp.t
+++ b/test/recipes/30-test_evp.t
@@ -108,19 +108,9 @@ push @defltfiles, qw(evppkey_brainpool.txt) unless $no_ec;
 push @defltfiles, qw(evppkey_sm2.txt) unless $no_sm2;
 
 plan tests =>
-    ($no_fips ? 0 : 1)          # FIPS install test
     + (scalar(@configs) * scalar(@files))
     + scalar(@defltfiles)
     + 3; # error output tests
-
-unless ($no_fips) {
-    my $infile = bldtop_file('providers', platform->dso('fips'));
-
-    ok(run(app(['openssl', 'fipsinstall',
-                '-out', bldtop_file('providers', 'fipsmodule.cnf'),
-                '-module', $infile])),
-       "fipsinstall");
-}
 
 foreach (@configs) {
     my $conf = srctop_file("test", $_);

--- a/test/recipes/30-test_evp_fetch_prov.t
+++ b/test/recipes/30-test_evp_fetch_prov.t
@@ -18,10 +18,8 @@ setup("test_evp_fetch_prov");
 
 use lib srctop_dir('Configurations');
 use lib bldtop_dir('.');
-use platform;
 
 my $no_fips = disabled('fips') || ($ENV{NO_FIPS} // 0);
-my $infile = bldtop_file('providers', platform->dso('fips'));
 
 my @types = ( "digest", "cipher" );
 

--- a/test/recipes/30-test_evp_fetch_prov.t
+++ b/test/recipes/30-test_evp_fetch_prov.t
@@ -25,7 +25,6 @@ my $infile = bldtop_file('providers', platform->dso('fips'));
 
 my @types = ( "digest", "cipher" );
 
-my @setups = ();
 my @testdata = (
     { config    => srctop_file("test", "default.cnf"),
       providers => [ 'default' ],
@@ -44,12 +43,6 @@ my @testdata = (
 );
 
 unless ($no_fips) {
-    push @setups, {
-        cmd     => app(['openssl', 'fipsinstall',
-                        '-out', bldtop_file('providers', 'fipsmodule.cnf'),
-                        '-module', $infile]),
-        message => "fipsinstall"
-    };
     push @testdata, (
         { config    => srctop_file("test", "fips.cnf"),
           providers => [ 'fips' ],
@@ -105,14 +98,10 @@ foreach (@testdata) {
     $testcount += scalar @{$_->{tests}};
 }
 
-plan tests => 1 + scalar @setups + $testcount * scalar(@types);
+plan tests => 1 + $testcount * scalar(@types);
 
 ok(run(test(["evp_fetch_prov_test", "-defaultctx"])),
    "running evp_fetch_prov_test using the default libctx");
-
-foreach my $setup (@setups) {
-    ok(run($setup->{cmd}), $setup->{message});
-}
 
 foreach my $alg (@types) {
     foreach my $testcase (@testdata) {

--- a/test/recipes/30-test_evp_libctx.t
+++ b/test/recipes/30-test_evp_libctx.t
@@ -27,17 +27,13 @@ my $infile = bldtop_file('providers', platform->dso('fips'));
 my @test_args = ( );
 
 plan tests =>
-    ($no_fips ? 0 : 2)          # FIPS install test
+    ($no_fips ? 0 : 1)          # FIPS install test
     + 1;
 
 unless ($no_fips) {
     @test_args = ("-config", srctop_file("test","fips-and-base.cnf"),
                   "-provider", "fips");
 
-    ok(run(app(['openssl', 'fipsinstall',
-               '-out', bldtop_file('providers', 'fipsmodule.cnf'),
-               '-module', $infile])),
-       "fipsinstall");
     ok(run(test(["evp_libctx_test", @test_args])), "running fips evp_libctx_test");
 }
 

--- a/test/recipes/30-test_evp_libctx.t
+++ b/test/recipes/30-test_evp_libctx.t
@@ -20,9 +20,7 @@ my $no_fips = disabled('fips') || ($ENV{NO_FIPS} // 0);
 
 use lib srctop_dir('Configurations');
 use lib bldtop_dir('.');
-use platform;
 
-my $infile = bldtop_file('providers', platform->dso('fips'));
 # If no fips then run the test with no extra arguments.
 my @test_args = ( );
 

--- a/test/recipes/30-test_provider_status.t
+++ b/test/recipes/30-test_provider_status.t
@@ -19,7 +19,6 @@ setup("test_provider_status");
 
 use lib srctop_dir('Configurations');
 use lib bldtop_dir('.');
-use platform;
 
 my $no_fips = disabled('fips') || ($ENV{NO_FIPS} // 0);
 
@@ -27,8 +26,6 @@ plan skip_all => "provider_status is not supported by this test"
     if $no_fips;
 
 plan tests => 1;
-
-my $infile = bldtop_file('providers', platform->dso('fips'));
 
 ok(run(test(["provider_status_test", "-config", srctop_file("test","fips.cnf"),
              "-provider_name", "fips"])),

--- a/test/recipes/30-test_provider_status.t
+++ b/test/recipes/30-test_provider_status.t
@@ -26,14 +26,9 @@ my $no_fips = disabled('fips') || ($ENV{NO_FIPS} // 0);
 plan skip_all => "provider_status is not supported by this test"
     if $no_fips;
 
-plan tests => 2;
+plan tests => 1;
 
 my $infile = bldtop_file('providers', platform->dso('fips'));
-
-ok(run(app(['openssl', 'fipsinstall',
-            '-out', bldtop_file('providers', 'fipsmodule.cnf'),
-            '-module', $infile])),
-   "fipsinstall");
 
 ok(run(test(["provider_status_test", "-config", srctop_file("test","fips.cnf"),
              "-provider_name", "fips"])),

--- a/test/recipes/65-test_cmp_client.t
+++ b/test/recipes/65-test_cmp_client.t
@@ -18,7 +18,6 @@ BEGIN {
 
 use lib srctop_dir('Configurations');
 use lib bldtop_dir('.');
-use platform;
 
 my $no_fips = disabled('fips') || ($ENV{NO_FIPS} // 0);
 

--- a/test/recipes/65-test_cmp_client.t
+++ b/test/recipes/65-test_cmp_client.t
@@ -25,7 +25,7 @@ my $no_fips = disabled('fips') || ($ENV{NO_FIPS} // 0);
 plan skip_all => "This test is not supported in a no-cmp or no-ec build"
     if disabled("cmp") || disabled("ec");
 
-plan tests => 2 + ($no_fips ? 0 : 2); #fips install + fips test
+plan tests => 2 + ($no_fips ? 0 : 1); # fips test
 
 my @basic_cmd = ("cmp_client_test",
                  data_file("server.key"),
@@ -39,10 +39,5 @@ ok(run(test([@basic_cmd, "none"])));
 ok(run(test([@basic_cmd, "default", srctop_file("test", "default.cnf")])));
 
 unless ($no_fips) {
-    ok(run(app(['openssl', 'fipsinstall',
-                '-out', bldtop_file('providers', 'fipsmodule.cnf'),
-                '-module', bldtop_file('providers', platform->dso('fips'))])),
-       "fipsinstall");
-
     ok(run(test([@basic_cmd, "fips", srctop_file("test", "fips-and-base.cnf")])));
 }

--- a/test/recipes/65-test_cmp_msg.t
+++ b/test/recipes/65-test_cmp_msg.t
@@ -18,7 +18,6 @@ BEGIN {
 
 use lib srctop_dir('Configurations');
 use lib bldtop_dir('.');
-use platform;
 
 my $no_fips = disabled('fips') || ($ENV{NO_FIPS} // 0);
 

--- a/test/recipes/65-test_cmp_msg.t
+++ b/test/recipes/65-test_cmp_msg.t
@@ -25,7 +25,7 @@ my $no_fips = disabled('fips') || ($ENV{NO_FIPS} // 0);
 plan skip_all => "This test is not supported in a no-cmp build"
     if disabled("cmp");
 
-plan tests => 2 + ($no_fips ? 0 : 2); #fips install + fips test
+plan tests => 2 + ($no_fips ? 0 : 1); #fips test
 
 my @basic_cmd = ("cmp_msg_test",
                  data_file("new.key"),
@@ -37,11 +37,6 @@ ok(run(test([@basic_cmd, "none"])));
 ok(run(test([@basic_cmd, "default", srctop_file("test", "default.cnf")])));
 
 unless ($no_fips) {
-    ok(run(app(['openssl', 'fipsinstall',
-                '-out', bldtop_file('providers', 'fipsmodule.cnf'),
-                '-module', bldtop_file('providers', platform->dso('fips'))])),
-       "fipsinstall");
-
     ok(run(test([@basic_cmd,
                  "fips", srctop_file("test", "fips-and-base.cnf")])));
 }

--- a/test/recipes/65-test_cmp_protect.t
+++ b/test/recipes/65-test_cmp_protect.t
@@ -18,7 +18,6 @@ BEGIN {
 
 use lib srctop_dir('Configurations');
 use lib bldtop_dir('.');
-use platform;
 
 my $no_fips = disabled('fips') || ($ENV{NO_FIPS} // 0);
 

--- a/test/recipes/65-test_cmp_protect.t
+++ b/test/recipes/65-test_cmp_protect.t
@@ -28,7 +28,7 @@ plan skip_all => "This test is not supported in a no-cmp build"
 plan skip_all => "This test is not supported in a shared library build on Windows"
     if $^O eq 'MSWin32' && !disabled("shared");
 
-plan tests => 2 + ($no_fips ? 0 : 2); #fips install + fips test
+plan tests => 2 + ($no_fips ? 0 : 1); #fips test
 
 my @basic_cmd = ("cmp_protect_test",
                  data_file("server.pem"),
@@ -47,11 +47,6 @@ ok(run(test([@basic_cmd, "none"])));
 ok(run(test([@basic_cmd, "default", srctop_file("test", "default.cnf")])));
 
 unless ($no_fips) {
-    ok(run(app(['openssl', 'fipsinstall',
-                '-out', bldtop_file('providers', 'fipsmodule.cnf'),
-                '-module', bldtop_file('providers', platform->dso('fips'))])),
-       "fipsinstall");
-
     ok(run(test([@basic_cmd,
                  "fips", srctop_file("test", "fips-and-base.cnf")])));
 }

--- a/test/recipes/65-test_cmp_server.t
+++ b/test/recipes/65-test_cmp_server.t
@@ -18,7 +18,6 @@ BEGIN {
 
 use lib srctop_dir('Configurations');
 use lib bldtop_dir('.');
-use platform;
 
 my $no_fips = disabled('fips') || ($ENV{NO_FIPS} // 0);
 

--- a/test/recipes/65-test_cmp_server.t
+++ b/test/recipes/65-test_cmp_server.t
@@ -28,7 +28,7 @@ plan skip_all => "This test is not supported in a no-cmp build"
 plan skip_all => "This test is not supported in a no-ec build"
     if disabled("ec");
 
-plan tests => 2 + ($no_fips ? 0 : 2); #fips install + fips test
+plan tests => 2 + ($no_fips ? 0 : 1); #fips test
 
 my @basic_cmd = ("cmp_server_test", data_file("CR_protected_PBM_1234.der"));
 
@@ -37,10 +37,5 @@ ok(run(test([@basic_cmd, "none"])));
 ok(run(test([@basic_cmd, "default", srctop_file("test", "default.cnf")])));
 
 unless ($no_fips) {
-    ok(run(app(['openssl', 'fipsinstall',
-                '-out', bldtop_file('providers', 'fipsmodule.cnf'),
-                '-module', bldtop_file('providers', platform->dso('fips'))])),
-       "fipsinstall");
-
     ok(run(test([@basic_cmd, "fips", srctop_file("test", "fips.cnf")])));
 }

--- a/test/recipes/65-test_cmp_vfy.t
+++ b/test/recipes/65-test_cmp_vfy.t
@@ -18,7 +18,6 @@ BEGIN {
 
 use lib srctop_dir('Configurations');
 use lib bldtop_dir('.');
-use platform;
 
 my $no_fips = disabled('fips') || ($ENV{NO_FIPS} // 0);
 

--- a/test/recipes/65-test_cmp_vfy.t
+++ b/test/recipes/65-test_cmp_vfy.t
@@ -28,7 +28,7 @@ plan skip_all => "This test is not supported in a no-cmp build"
 plan skip_all => "This test is not supported in a no-ec build"
     if disabled("ec");
 
-plan tests => 2 + ($no_fips ? 0 : 2); #fips install + fips test
+plan tests => 2 + ($no_fips ? 0 : 1); #fips test
 
 my @basic_cmd = ("cmp_vfy_test",
                  data_file("server.crt"),     data_file("client.crt"),
@@ -48,10 +48,5 @@ ok(run(test([@basic_cmd, "none"])));
 ok(run(test([@basic_cmd, "default", srctop_file("test", "default.cnf")])));
 
 unless ($no_fips) {
-    ok(run(app(['openssl', 'fipsinstall',
-                '-out', bldtop_file('providers', 'fipsmodule.cnf'),
-                '-module', bldtop_file('providers', platform->dso('fips'))])),
-       "fipsinstall");
-
     ok(run(test([@basic_cmd, "fips", srctop_file("test", "fips.cnf")])));
 }

--- a/test/recipes/80-test_cmp_http.t
+++ b/test/recipes/80-test_cmp_http.t
@@ -20,7 +20,7 @@ BEGIN {
 }
 use lib srctop_dir('Configurations');
 use lib bldtop_dir('.');
-use platform;
+
 plan skip_all => "These tests are not supported in a fuzz build"
     if config('options') =~ /-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION/;
 

--- a/test/recipes/80-test_cms.t
+++ b/test/recipes/80-test_cms.t
@@ -23,7 +23,6 @@ BEGIN {
 
 use lib srctop_dir('Configurations');
 use lib bldtop_dir('.');
-use platform;
 
 my $no_fips = disabled('fips') || ($ENV{NO_FIPS} // 0);
 
@@ -55,8 +54,6 @@ plan tests =>
     + 10;
 
 unless ($no_fips) {
-    my $infile = bldtop_file('providers', platform->dso('fips'));
-
     @config = ( "-config", srctop_file("test", "fips-and-base.cnf") );
     $provname = 'fips';
 }

--- a/test/recipes/80-test_cms.t
+++ b/test/recipes/80-test_cms.t
@@ -52,16 +52,11 @@ my ($no_des, $no_dh, $no_dsa, $no_ec, $no_ec2m, $no_rc2, $no_zlib)
 $no_rc2 = 1 if disabled("legacy");
 
 plan tests =>
-    ($no_fips ? 0 : 1)          # FIPS install test
     + 10;
 
 unless ($no_fips) {
     my $infile = bldtop_file('providers', platform->dso('fips'));
 
-    ok(run(app(['openssl', 'fipsinstall',
-                '-out', bldtop_file('providers', 'fipsmodule.cnf'),
-                '-module', $infile])),
-       "fipsinstall");
     @config = ( "-config", srctop_file("test", "fips-and-base.cnf") );
     $provname = 'fips';
 }

--- a/test/recipes/80-test_ssl_new.t
+++ b/test/recipes/80-test_ssl_new.t
@@ -22,10 +22,8 @@ setup("test_ssl_new");
 
 use lib srctop_dir('Configurations');
 use lib bldtop_dir('.');
-use platform;
 
 my $no_fips = disabled('fips') || ($ENV{NO_FIPS} // 0);
-my $infile = bldtop_file('providers', platform->dso('fips'));
 
 $ENV{TEST_CERTS_DIR} = srctop_dir("test", "certs");
 

--- a/test/recipes/80-test_ssl_new.t
+++ b/test/recipes/80-test_ssl_new.t
@@ -36,8 +36,7 @@ map { s/\^// } @conf_files if $^O eq "VMS";
 
 # We hard-code the number of tests to double-check that the globbing above
 # finds all files as expected.
-plan tests => 30 # = scalar @conf_srcs
-              + ($no_fips ? 0 : 1); # fipsinstall
+plan tests => 30;
 
 # Some test results depend on the configuration of enabled protocols. We only
 # verify generated sources in the default configuration.
@@ -117,13 +116,6 @@ my %skip = (
   "26-tls13_client_auth.cnf" => disabled("tls1_3") || ($no_ec && $no_dh),
   "29-dtls-sctp-label-bug.cnf" => disabled("sctp") || disabled("sock"),
 );
-
-unless ($no_fips) {
-    ok(run(app(['openssl', 'fipsinstall',
-                '-out', bldtop_file('providers', 'fipsmodule.cnf'),
-                '-module', $infile])),
-       "fipsinstall");
-}
 
 foreach my $conf (@conf_files) {
     subtest "Test configuration $conf" => sub {

--- a/test/recipes/80-test_ssl_old.t
+++ b/test/recipes/80-test_ssl_old.t
@@ -22,11 +22,8 @@ setup("test_ssl_old");
 
 use lib srctop_dir('Configurations');
 use lib bldtop_dir('.');
-use platform;
 
 my $no_fips = disabled('fips') || ($ENV{NO_FIPS} // 0);
-my $infile = bldtop_file('providers', platform->dso('fips'));
-
 my ($no_rsa, $no_dsa, $no_dh, $no_ec, $no_psk,
     $no_ssl3, $no_tls1, $no_tls1_1, $no_tls1_2, $no_tls1_3,
     $no_dtls, $no_dtls1, $no_dtls1_2, $no_ct) =

--- a/test/recipes/80-test_ssl_old.t
+++ b/test/recipes/80-test_ssl_old.t
@@ -81,17 +81,10 @@ my $client_sess="client.ss";
 # If you're adding tests here, you probably want to convert them to the
 # new format in ssl_test.c and add recipes to 80-test_ssl_new.t instead.
 plan tests =>
-   ($no_fips ? 0 : 1 + 5) # For fipsinstall + testssl with fips provider
+   ($no_fips ? 0 : 5)     # testssl with fips provider
     + 1                   # For testss
     + 5                   # For the testssl with default provider
     ;
-
-unless ($no_fips) {
-    ok(run(app(['openssl', 'fipsinstall',
-                '-out', bldtop_file('providers', 'fipsmodule.cnf'),
-                '-module', $infile])),
-       "fipsinstall");
-}
 
 subtest 'test_ss' => sub {
     if (testss()) {

--- a/test/recipes/81-test_cmp_cli.t
+++ b/test/recipes/81-test_cmp_cli.t
@@ -21,7 +21,7 @@ BEGIN {
 }
 use lib srctop_dir('Configurations');
 use lib bldtop_dir('.');
-use platform;
+
 plan skip_all => "These tests are not supported in a fuzz build"
     if config('options') =~ /-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION/;
 

--- a/test/recipes/90-test_sslapi.t
+++ b/test/recipes/90-test_sslapi.t
@@ -17,7 +17,6 @@ setup("test_sslapi");
 
 use lib srctop_dir('Configurations');
 use lib bldtop_dir('.');
-use platform;
 
 my $no_fips = disabled('fips') || ($ENV{NO_FIPS} // 0);
 

--- a/test/recipes/90-test_sslapi.t
+++ b/test/recipes/90-test_sslapi.t
@@ -25,7 +25,7 @@ plan skip_all => "No TLS/SSL protocols are supported by this OpenSSL build"
     if alldisabled(grep { $_ ne "ssl3" } available_protocols("tls"));
 
 plan tests =>
-    ($no_fips ? 0 : 2)          # FIPS install test + sslapitest with fips
+    ($no_fips ? 0 : 1)          # sslapitest with fips
     + 1;                        # sslapitest with default provider
 
 (undef, my $tmpfilename) = tempfile();
@@ -37,11 +37,6 @@ ok(run(test(["sslapitest", srctop_dir("test", "certs"),
              "running sslapitest");
 
 unless ($no_fips) {
-    ok(run(app(['openssl', 'fipsinstall',
-                '-out', bldtop_file('providers', 'fipsmodule.cnf'),
-                '-module', bldtop_file('providers', platform->dso('fips'))])),
-       "fipsinstall");
-
     ok(run(test(["sslapitest", srctop_dir("test", "certs"),
                  srctop_file("test", "recipes", "90-test_sslapi_data",
                              "passwd.txt"), $tmpfilename, "fips",

--- a/test/recipes/90-test_threads.t
+++ b/test/recipes/90-test_threads.t
@@ -18,20 +18,10 @@ setup("test_threads");
 
 use lib srctop_dir('Configurations');
 use lib bldtop_dir('.');
-use platform;
 
 my $no_fips = disabled('fips') || ($ENV{NO_FIPS} // 0);
 
-
-plan tests => 1 + ($no_fips ? 0 : 1);
-
-if (!$no_fips) {
-    my $infile = bldtop_file('providers', platform->dso('fips'));
-    ok(run(app(['openssl', 'fipsinstall',
-            '-out', bldtop_file('providers', 'fipsmodule.cnf'),
-            '-module', $infile])),
-    "fipsinstall");
-}
+plan tests => 1;
 
 if ($no_fips) {
     $ENV{OPENSSL_CONF} = abs_path(srctop_file("test", "default.cnf"));


### PR DESCRIPTION
To generalize this so it doesn't become a specific hack in the build file templates, this PR adds the possibility to specify dependencies for existing targets with a special syntax (||).  With that, we can specify this in providers/build.info:

    DEPEND[|tests|]=fipsmodule.cnf

Furthermore, we add the possibility to use a program compiled as part of the build as a generator, giving us this in providers/build.info:

    GENERATE[fipsmodule.cnf]=../apps/openssl fipsinstall \
          -module providers/$(FIPSMODULENAME) -provider_name fips \
          -mac_name HMAC -section_name fips_sect -out -
    DEPEND[fipsmodule.cnf]=$FIPSGOAL

EDIT: Since we make the target `tests` depend on `fipsmodule.cnf`, this file is generated during test, not when building OpenSSL.

Fixes #14315