### PR TITLE
Add propq to RAND_get0_public(), etc

### DIFF
--- a/apps/list.c
+++ b/apps/list.c
@@ -432,9 +432,9 @@ static void display_random(const char *name, EVP_RAND_CTX *drbg)
 
 static void list_random_instances(void)
 {
-    display_random("primary", RAND_get0_primary(NULL));
-    display_random("public", RAND_get0_public(NULL));
-    display_random("private", RAND_get0_private(NULL));
+    display_random("primary", RAND_get0_primary(NULL, NULL));
+    display_random("public", RAND_get0_public(NULL, NULL));
+    display_random("private", RAND_get0_private(NULL, NULL));
 }
 
 /*

--- a/crypto/asn1/asn_mime.c
+++ b/crypto/asn1/asn_mime.c
@@ -251,7 +251,7 @@ int SMIME_write_ASN1_ex(BIO *bio, ASN1_VALUE *val, BIO *data, int flags,
     if ((flags & SMIME_DETACHED) && data) {
         /* We want multipart/signed */
         /* Generate a random boundary */
-        if (RAND_bytes_ex(libctx, (unsigned char *)bound, 32) <= 0)
+        if (RAND_bytes_ex(libctx, (unsigned char *)bound, 32, propq) <= 0)
             return 0;
         for (i = 0; i < 32; i++) {
             c = bound[i] & 0xf;

--- a/crypto/bn/bn_gcd.c
+++ b/crypto/bn/bn_gcd.c
@@ -518,7 +518,7 @@ BIGNUM *BN_mod_inverse(BIGNUM *in,
     int noinv = 0;
 
     if (ctx == NULL) {
-        ctx = new_ctx = BN_CTX_new_ex(NULL);
+        ctx = new_ctx = BN_CTX_new_ex(NULL, NULL);
         if (ctx == NULL) {
             ERR_raise(ERR_LIB_BN, ERR_R_MALLOC_FAILURE);
             return NULL;

--- a/crypto/cmp/cmp_hdr.c
+++ b/crypto/cmp/cmp_hdr.c
@@ -146,7 +146,7 @@ static int set_random(ASN1_OCTET_STRING **tgt, OSSL_CMP_CTX *ctx, size_t len)
     unsigned char *bytes = OPENSSL_malloc(len);
     int res = 0;
 
-    if (bytes == NULL || RAND_bytes_ex(ctx->libctx, bytes, len) <= 0)
+    if (bytes == NULL || RAND_bytes_ex(ctx->libctx, bytes, len, ctx->propq) <= 0)
         ERR_raise(ERR_LIB_CMP, CMP_R_FAILURE_OBTAINING_RANDOM);
     else
         res = ossl_cmp_asn1_octet_string_set1_bytes(tgt, bytes, len);

--- a/crypto/cmp/cmp_protect.c
+++ b/crypto/cmp/cmp_protect.c
@@ -197,7 +197,7 @@ static int set_pbmac_algor(const OSSL_CMP_CTX *ctx, X509_ALGOR **alg)
 
     pbm = OSSL_CRMF_pbmp_new(ctx->libctx, ctx->pbm_slen,
                              EVP_MD_type(ctx->pbm_owf), ctx->pbm_itercnt,
-                             ctx->pbm_mac);
+                             ctx->pbm_mac, ctx->propq);
     pbm_str = ASN1_STRING_new();
     if (pbm == NULL || pbm_str == NULL)
         goto err;

--- a/crypto/cms/cms_enc.c
+++ b/crypto/cms/cms_enc.c
@@ -83,7 +83,7 @@ BIO *ossl_cms_EncryptedContent_init_bio(CMS_EncryptedContentInfo *ec,
         /* Generate a random IV if we need one */
         ivlen = EVP_CIPHER_CTX_iv_length(ctx);
         if (ivlen > 0) {
-            if (RAND_bytes_ex(libctx, iv, ivlen) <= 0)
+            if (RAND_bytes_ex(libctx, iv, ivlen, propq) <= 0)
                 goto err;
             piv = iv;
         }

--- a/crypto/cms/cms_ess.c
+++ b/crypto/cms/cms_ess.c
@@ -128,7 +128,8 @@ CMS_ReceiptRequest *CMS_ReceiptRequest_create0_ex(
     else {
         if (!ASN1_STRING_set(rr->signedContentIdentifier, NULL, 32))
             goto merr;
-        if (RAND_bytes_ex(libctx, rr->signedContentIdentifier->data, 32) <= 0)
+        if (RAND_bytes_ex(libctx, rr->signedContentIdentifier->data, 32,
+                          propq) <= 0)
             goto err;
     }
 

--- a/crypto/cms/cms_pwri.c
+++ b/crypto/cms/cms_pwri.c
@@ -93,7 +93,8 @@ CMS_RecipientInfo *CMS_add0_recipient_password(CMS_ContentInfo *cms,
     ivlen = EVP_CIPHER_CTX_iv_length(ctx);
 
     if (ivlen > 0) {
-        if (RAND_bytes_ex(ossl_cms_ctx_get0_libctx(cms_ctx), iv, ivlen) <= 0)
+        if (RAND_bytes_ex(ossl_cms_ctx_get0_libctx(cms_ctx), iv, ivlen,
+                          ossl_cms_ctx_get0_propq(cms_ctx)) <= 0)
             goto err;
         if (EVP_EncryptInit_ex(ctx, NULL, NULL, NULL, iv) <= 0) {
             ERR_raise(ERR_LIB_CMS, ERR_R_EVP_LIB);
@@ -263,7 +264,8 @@ static int kek_wrap_key(unsigned char *out, size_t *outlen,
         /* Add random padding to end */
         if (olen > inlen + 4
             && RAND_bytes_ex(ossl_cms_ctx_get0_libctx(cms_ctx), out + 4 + inlen,
-                             olen - 4 - inlen) <= 0)
+                             olen - 4 - inlen,
+                             ossl_cms_ctx_get0_propq(cms_ctx)) <= 0)
             return 0;
         /* Encrypt twice */
         if (!EVP_EncryptUpdate(ctx, out, &dummy, out, olen)

--- a/crypto/crmf/crmf_pbm.c
+++ b/crypto/crmf/crmf_pbm.c
@@ -37,7 +37,7 @@
  */
 OSSL_CRMF_PBMPARAMETER *OSSL_CRMF_pbmp_new(OSSL_LIB_CTX *libctx, size_t slen,
                                            int owfnid, size_t itercnt,
-                                           int macnid)
+                                           int macnid, const char *propq)
 {
     OSSL_CRMF_PBMPARAMETER *pbm = NULL;
     unsigned char *salt = NULL;
@@ -52,7 +52,7 @@ OSSL_CRMF_PBMPARAMETER *OSSL_CRMF_pbmp_new(OSSL_LIB_CTX *libctx, size_t slen,
      */
     if ((salt = OPENSSL_malloc(slen)) == NULL)
         goto err;
-    if (RAND_bytes_ex(libctx, salt, (int)slen) <= 0) {
+    if (RAND_bytes_ex(libctx, salt, (int)slen, propq) <= 0) {
         ERR_raise(ERR_LIB_CRMF, CRMF_R_FAILURE_OBTAINING_RANDOM);
         goto err;
     }

--- a/crypto/dh/dh_ameth.c
+++ b/crypto/dh/dh_ameth.c
@@ -543,7 +543,7 @@ static int dh_pkey_import_from_type(const OSSL_PARAM params[], void *vpctx,
 {
     EVP_PKEY_CTX *pctx = vpctx;
     EVP_PKEY *pkey = EVP_PKEY_CTX_get0_pkey(pctx);
-    DH *dh = ossl_dh_new_ex(pctx->libctx);
+    DH *dh = ossl_dh_new_ex(pctx->libctx, pctx->propquery);
 
     if (dh == NULL) {
         ERR_raise(ERR_LIB_DH, ERR_R_MALLOC_FAILURE);

--- a/crypto/dh/dh_check.c
+++ b/crypto/dh/dh_check.c
@@ -63,7 +63,8 @@ int DH_check_params(const DH *dh, int *ret)
      * validity tests.
      */
     return ossl_ffc_params_FIPS186_4_validate(dh->libctx, &dh->params,
-                                              FFC_PARAM_TYPE_DH, ret, NULL);
+                                              FFC_PARAM_TYPE_DH, dh->propq,
+                                              ret, NULL);
 }
 #else
 int DH_check_params(const DH *dh, int *ret)
@@ -235,7 +236,8 @@ int DH_check_pub_key_ex(const DH *dh, const BIGNUM *pub_key)
  */
 int DH_check_pub_key(const DH *dh, const BIGNUM *pub_key, int *ret)
 {
-    return ossl_ffc_validate_public_key(&dh->params, pub_key, ret);
+    return ossl_ffc_validate_public_key(dh->libctx, &dh->params, pub_key,
+                                        dh->propq, ret);
 }
 
 /*
@@ -245,7 +247,8 @@ int DH_check_pub_key(const DH *dh, const BIGNUM *pub_key, int *ret)
  */
 int ossl_dh_check_pub_key_partial(const DH *dh, const BIGNUM *pub_key, int *ret)
 {
-    return ossl_ffc_validate_public_key_partial(&dh->params, pub_key, ret);
+    return ossl_ffc_validate_public_key_partial(dh->libctx, &dh->params,
+                                                pub_key, dh->propq, ret);
 }
 
 int ossl_dh_check_priv_key(const DH *dh, const BIGNUM *priv_key, int *ret)
@@ -293,7 +296,7 @@ int ossl_dh_check_pairwise(const DH *dh)
         || dh->pub_key == NULL)
         return 0;
 
-    ctx = BN_CTX_new_ex(dh->libctx);
+    ctx = BN_CTX_new_ex(dh->libctx, dh->propq);
     if (ctx == NULL)
         goto err;
     pub_key = BN_new();

--- a/crypto/dh/dh_group_params.c
+++ b/crypto/dh/dh_group_params.c
@@ -25,9 +25,10 @@
 #include "crypto/dh.h"
 #include "e_os.h" /* strcasecmp */
 
-static DH *dh_param_init(OSSL_LIB_CTX *libctx, const DH_NAMED_GROUP *group)
+static DH *dh_param_init(OSSL_LIB_CTX *libctx, const DH_NAMED_GROUP *group,
+                         const char *propq)
 {
-    DH *dh = ossl_dh_new_ex(libctx);
+    DH *dh = ossl_dh_new_ex(libctx, propq);
 
     if (dh == NULL)
         return NULL;
@@ -39,12 +40,12 @@ static DH *dh_param_init(OSSL_LIB_CTX *libctx, const DH_NAMED_GROUP *group)
     return dh;
 }
 
-DH *ossl_dh_new_by_nid_ex(OSSL_LIB_CTX *libctx, int nid)
+DH *ossl_dh_new_by_nid_ex(OSSL_LIB_CTX *libctx, int nid, const char *propq)
 {
     const DH_NAMED_GROUP *group;
 
     if ((group = ossl_ffc_uid_to_dh_named_group(nid)) != NULL)
-        return dh_param_init(libctx, group);
+        return dh_param_init(libctx, group, propq);
 
     ERR_raise(ERR_LIB_DH, DH_R_INVALID_PARAMETER_NID);
     return NULL;
@@ -52,7 +53,7 @@ DH *ossl_dh_new_by_nid_ex(OSSL_LIB_CTX *libctx, int nid)
 
 DH *DH_new_by_nid(int nid)
 {
-    return ossl_dh_new_by_nid_ex(NULL, nid);
+    return ossl_dh_new_by_nid_ex(NULL, nid, NULL);
 }
 
 void ossl_dh_cache_named_group(DH *dh)

--- a/crypto/dh/dh_key.c
+++ b/crypto/dh/dh_key.c
@@ -53,7 +53,7 @@ static int compute_key(unsigned char *key, const BIGNUM *pub_key, DH *dh)
         return 0;
     }
 
-    ctx = BN_CTX_new_ex(dh->libctx);
+    ctx = BN_CTX_new_ex(dh->libctx, dh->propq);
     if (ctx == NULL)
         goto err;
     BN_CTX_start(ctx);
@@ -266,7 +266,7 @@ static int generate_key(DH *dh)
         return 0;
     }
 
-    ctx = BN_CTX_new_ex(dh->libctx);
+    ctx = BN_CTX_new_ex(dh->libctx, dh->propq);
     if (ctx == NULL)
         goto err;
 
@@ -328,7 +328,8 @@ static int generate_key(DH *dh)
             {
                 /* Do a partial check for invalid p, q, g */
                 if (!ossl_ffc_params_simple_validate(dh->libctx, &dh->params,
-                                                     FFC_PARAM_TYPE_DH, NULL))
+                                                     FFC_PARAM_TYPE_DH,
+                                                     dh->propq, NULL))
                     goto err;
                 /*
                  * For FFC FIPS 186-4 keygen

--- a/crypto/dh/dh_local.h
+++ b/crypto/dh/dh_local.h
@@ -33,6 +33,7 @@ struct dh_st {
     ENGINE *engine;
 #endif
     OSSL_LIB_CTX *libctx;
+    char *propq;
     const DH_METHOD *meth;
     CRYPTO_RWLOCK *lock;
 

--- a/crypto/dh/dh_pmeth.c
+++ b/crypto/dh/dh_pmeth.c
@@ -275,7 +275,7 @@ static int pkey_dh_ctrl_str(EVP_PKEY_CTX *ctx,
 }
 
 static DH *ffc_params_generate(OSSL_LIB_CTX *libctx, DH_PKEY_CTX *dctx,
-                               BN_GENCB *pcb)
+                               const char *propq, BN_GENCB *pcb)
 {
     DH *ret;
     int rv = 0;
@@ -303,16 +303,16 @@ static DH *ffc_params_generate(OSSL_LIB_CTX *libctx, DH_PKEY_CTX *dctx,
     if (dctx->paramgen_type == DH_PARAMGEN_TYPE_FIPS_186_2)
         rv = ossl_ffc_params_FIPS186_2_generate(libctx, &ret->params,
                                                 FFC_PARAM_TYPE_DH,
-                                                prime_len, subprime_len, &res,
-                                                pcb);
+                                                prime_len, subprime_len, propq,
+                                                &res, pcb);
     else
 # endif
     /* For FIPS we always use the DH_PARAMGEN_TYPE_FIPS_186_4 generator */
     if (dctx->paramgen_type >= DH_PARAMGEN_TYPE_FIPS_186_2)
         rv = ossl_ffc_params_FIPS186_4_generate(libctx, &ret->params,
                                                 FFC_PARAM_TYPE_DH,
-                                                prime_len, subprime_len, &res,
-                                                pcb);
+                                                prime_len, subprime_len, propq,
+                                                &res, pcb);
     if (rv <= 0) {
         DH_free(ret);
         return NULL;
@@ -372,7 +372,7 @@ static int pkey_dh_paramgen(EVP_PKEY_CTX *ctx,
     dctx->paramgen_type = DH_PARAMGEN_TYPE_FIPS_186_4;
 # endif /* FIPS_MODULE */
     if (dctx->paramgen_type >= DH_PARAMGEN_TYPE_FIPS_186_2) {
-        dh = ffc_params_generate(NULL, dctx, pcb);
+        dh = ffc_params_generate(NULL, dctx, NULL, pcb);
         BN_GENCB_free(pcb);
         if (dh == NULL)
             return 0;

--- a/crypto/dsa/dsa_ameth.c
+++ b/crypto/dsa/dsa_ameth.c
@@ -539,7 +539,7 @@ static int dsa_pkey_import_from(const OSSL_PARAM params[], void *vpctx)
 {
     EVP_PKEY_CTX *pctx = vpctx;
     EVP_PKEY *pkey = EVP_PKEY_CTX_get0_pkey(pctx);
-    DSA *dsa = ossl_dsa_new(pctx->libctx);
+    DSA *dsa = ossl_dsa_new(pctx->libctx, pctx->propquery);
 
     if (dsa == NULL) {
         ERR_raise(ERR_LIB_DSA, ERR_R_MALLOC_FAILURE);

--- a/crypto/dsa/dsa_check.c
+++ b/crypto/dsa/dsa_check.c
@@ -23,7 +23,8 @@ int ossl_dsa_check_params(const DSA *dsa, int checktype, int *ret)
 {
     if (checktype == OSSL_KEYMGMT_VALIDATE_QUICK_CHECK)
         return ossl_ffc_params_simple_validate(dsa->libctx, &dsa->params,
-                                               FFC_PARAM_TYPE_DSA, ret);
+                                               FFC_PARAM_TYPE_DSA, dsa->propq,
+                                               ret);
     else
         /*
          * Do full FFC domain params validation according to FIPS-186-4
@@ -31,7 +32,7 @@ int ossl_dsa_check_params(const DSA *dsa, int checktype, int *ret)
          *  - only if possible (i.e., seed is set) in default provider
          */
         return ossl_ffc_params_full_validate(dsa->libctx, &dsa->params,
-                                             FFC_PARAM_TYPE_DSA, ret);
+                                             FFC_PARAM_TYPE_DSA, dsa->propq, ret);
 }
 
 /*
@@ -39,7 +40,8 @@ int ossl_dsa_check_params(const DSA *dsa, int checktype, int *ret)
  */
 int ossl_dsa_check_pub_key(const DSA *dsa, const BIGNUM *pub_key, int *ret)
 {
-    return ossl_ffc_validate_public_key(&dsa->params, pub_key, ret);
+    return ossl_ffc_validate_public_key(dsa->libctx, &dsa->params, pub_key,
+                                        dsa->propq, ret);
 }
 
 /*
@@ -49,7 +51,8 @@ int ossl_dsa_check_pub_key(const DSA *dsa, const BIGNUM *pub_key, int *ret)
  */
 int ossl_dsa_check_pub_key_partial(const DSA *dsa, const BIGNUM *pub_key, int *ret)
 {
-    return ossl_ffc_validate_public_key_partial(&dsa->params, pub_key, ret);
+    return ossl_ffc_validate_public_key_partial(dsa->libctx, &dsa->params,
+                                        pub_key, dsa->propq, ret);
 }
 
 int ossl_dsa_check_priv_key(const DSA *dsa, const BIGNUM *priv_key, int *ret)
@@ -76,7 +79,7 @@ int ossl_dsa_check_pairwise(const DSA *dsa)
         || dsa->pub_key == NULL)
         return 0;
 
-    ctx = BN_CTX_new_ex(dsa->libctx);
+    ctx = BN_CTX_new_ex(dsa->libctx, dsa->propq);
     if (ctx == NULL)
         goto err;
     pub_key = BN_new();

--- a/crypto/dsa/dsa_gen.c
+++ b/crypto/dsa/dsa_gen.c
@@ -32,12 +32,14 @@ int ossl_dsa_generate_ffc_parameters(DSA *dsa, int type, int pbits, int qbits,
     if (type == DSA_PARAMGEN_TYPE_FIPS_186_2)
         ret = ossl_ffc_params_FIPS186_2_generate(dsa->libctx, &dsa->params,
                                                  FFC_PARAM_TYPE_DSA,
-                                                 pbits, qbits, &res, cb);
+                                                 pbits, qbits, dsa->propq,
+                                                 &res, cb);
     else
 #endif
         ret = ossl_ffc_params_FIPS186_4_generate(dsa->libctx, &dsa->params,
                                                  FFC_PARAM_TYPE_DSA,
-                                                 pbits, qbits, &res, cb);
+                                                 pbits, qbits, dsa->propq,
+                                                 &res, cb);
     if (ret > 0)
         dsa->dirty_cnt++;
     return ret;

--- a/crypto/dsa/dsa_key.c
+++ b/crypto/dsa/dsa_key.c
@@ -65,7 +65,7 @@ static int dsa_keygen(DSA *dsa, int pairwise_test)
     BN_CTX *ctx = NULL;
     BIGNUM *pub_key = NULL, *priv_key = NULL;
 
-    if ((ctx = BN_CTX_new_ex(dsa->libctx)) == NULL)
+    if ((ctx = BN_CTX_new_ex(dsa->libctx, dsa->propq)) == NULL)
         goto err;
 
     if (dsa->priv_key == NULL) {
@@ -77,7 +77,7 @@ static int dsa_keygen(DSA *dsa, int pairwise_test)
 
     /* Do a partial check for invalid p, q, g */
     if (!ossl_ffc_params_simple_validate(dsa->libctx, &dsa->params,
-                                         FFC_PARAM_TYPE_DSA, NULL))
+                                         FFC_PARAM_TYPE_DSA, dsa->propq, NULL))
         goto err;
 
     /*

--- a/crypto/dsa/dsa_local.h
+++ b/crypto/dsa/dsa_local.h
@@ -33,6 +33,7 @@ struct dsa_st {
     ENGINE *engine;
     CRYPTO_RWLOCK *lock;
     OSSL_LIB_CTX *libctx;
+    char *propq;
 
     /* Provider data */
     size_t dirty_cnt; /* If any key material changes, increment this */

--- a/crypto/dsa/dsa_ossl.c
+++ b/crypto/dsa/dsa_ossl.c
@@ -95,7 +95,7 @@ DSA_SIG *ossl_dsa_do_sign_int(const unsigned char *dgst, int dlen, DSA *dsa)
     if (ret->r == NULL || ret->s == NULL)
         goto err;
 
-    ctx = BN_CTX_new_ex(dsa->libctx);
+    ctx = BN_CTX_new_ex(dsa->libctx, dsa->propq);
     if (ctx == NULL)
         goto err;
     m = BN_CTX_get(ctx);
@@ -228,7 +228,7 @@ static int dsa_sign_setup(DSA *dsa, BN_CTX *ctx_in,
 
     if (ctx_in == NULL) {
         /* if you don't pass in ctx_in you get a default libctx */
-        if ((ctx = BN_CTX_new_ex(NULL)) == NULL)
+        if ((ctx = BN_CTX_new_ex(NULL, NULL)) == NULL)
             goto err;
     } else
         ctx = ctx_in;
@@ -345,7 +345,7 @@ static int dsa_do_verify(const unsigned char *dgst, int dgst_len,
     u1 = BN_new();
     u2 = BN_new();
     t1 = BN_new();
-    ctx = BN_CTX_new_ex(NULL); /* verify does not need a libctx */
+    ctx = BN_CTX_new_ex(NULL, NULL); /* verify does not need a libctx */
     if (u1 == NULL || u2 == NULL || t1 == NULL || ctx == NULL)
         goto err;
 

--- a/crypto/dsa/dsa_pmeth.c
+++ b/crypto/dsa/dsa_pmeth.c
@@ -221,7 +221,7 @@ static int pkey_dsa_paramgen(EVP_PKEY_CTX *ctx, EVP_PKEY *pkey)
 
     ret = ossl_ffc_params_FIPS186_4_generate(NULL, &dsa->params,
                                              FFC_PARAM_TYPE_DSA, dctx->nbits,
-                                             dctx->qbits, &res, pcb);
+                                             dctx->qbits, NULL, &res, pcb);
     BN_GENCB_free(pcb);
     if (ret > 0)
         EVP_PKEY_assign_DSA(pkey, dsa);

--- a/crypto/ec/ec_ameth.c
+++ b/crypto/ec/ec_ameth.c
@@ -578,7 +578,7 @@ int ec_pkey_export_to(const EVP_PKEY *from, void *to_keydata,
      * EC_POINT_point2buf() can generate random numbers in some
      * implementations so we need to ensure we use the correct libctx.
      */
-    bnctx = BN_CTX_new_ex(libctx);
+    bnctx = BN_CTX_new_ex(libctx, propq);
     if (bnctx == NULL)
         goto err;
     BN_CTX_start(bnctx);

--- a/crypto/ec/ec_backend.c
+++ b/crypto/ec/ec_backend.c
@@ -349,7 +349,7 @@ int ossl_ec_key_fromdata(EC_KEY *ec, const OSSL_PARAM params[], int include_priv
         param_priv_key =
             OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_PRIV_KEY);
 
-    ctx = BN_CTX_new_ex(ossl_ec_key_get_libctx(ec));
+    ctx = BN_CTX_new_ex(ossl_ec_key_get_libctx(ec), ossl_ec_key_get0_propq(ec));
     if (ctx == NULL)
         goto err;
 

--- a/crypto/ec/ec_check.c
+++ b/crypto/ec/ec_check.c
@@ -28,7 +28,7 @@ int EC_GROUP_check_named_curve(const EC_GROUP *group, int nist_only,
     }
 
     if (ctx == NULL) {
-        ctx = new_ctx = BN_CTX_new_ex(NULL);
+        ctx = new_ctx = BN_CTX_new_ex(NULL, NULL);
         if (ctx == NULL) {
             ERR_raise(ERR_LIB_EC, ERR_R_MALLOC_FAILURE);
             return NID_undef;

--- a/crypto/ec/ec_curve.c
+++ b/crypto/ec/ec_curve.c
@@ -3150,7 +3150,7 @@ static EC_GROUP *ec_group_new_from_data(OSSL_LIB_CTX *libctx,
         return ossl_ec_group_new_ex(libctx, propq,
                                     curve.meth != NULL ? curve.meth() : NULL);
 
-    if ((ctx = BN_CTX_new_ex(libctx)) == NULL) {
+    if ((ctx = BN_CTX_new_ex(libctx, propq)) == NULL) {
         ERR_raise(ERR_LIB_EC, ERR_R_MALLOC_FAILURE);
         goto err;
     }

--- a/crypto/ec/ec_key.c
+++ b/crypto/ec/ec_key.c
@@ -264,7 +264,7 @@ static int ec_generate_key(EC_KEY *eckey, int pairwise_test)
     BIGNUM *order = NULL;
     EC_POINT *pub_key = NULL;
     const EC_GROUP *group = eckey->group;
-    BN_CTX *ctx = BN_CTX_secure_new_ex(eckey->libctx);
+    BN_CTX *ctx = BN_CTX_secure_new_ex(eckey->libctx, eckey->propq);
     int sm2 = EC_KEY_get_flags(eckey) & EC_FLAG_SM2_RANGE ? 1 : 0;
 
     if (ctx == NULL)
@@ -366,7 +366,7 @@ int ossl_ec_key_simple_generate_key(EC_KEY *eckey)
 int ossl_ec_key_simple_generate_public_key(EC_KEY *eckey)
 {
     int ret;
-    BN_CTX *ctx = BN_CTX_new_ex(eckey->libctx);
+    BN_CTX *ctx = BN_CTX_new_ex(eckey->libctx, eckey->propq);
 
     if (ctx == NULL)
         return 0;
@@ -586,7 +586,7 @@ int ossl_ec_key_simple_check_key(const EC_KEY *eckey)
         ERR_raise(ERR_LIB_EC, ERR_R_PASSED_NULL_PARAMETER);
         return 0;
     }
-    if ((ctx = BN_CTX_new_ex(eckey->libctx)) == NULL)
+    if ((ctx = BN_CTX_new_ex(eckey->libctx, eckey->propq)) == NULL)
         return 0;
 
     if (!ossl_ec_key_public_check(eckey, ctx))
@@ -615,7 +615,7 @@ int EC_KEY_set_public_key_affine_coordinates(EC_KEY *key, BIGNUM *x,
         ERR_raise(ERR_LIB_EC, ERR_R_PASSED_NULL_PARAMETER);
         return 0;
     }
-    ctx = BN_CTX_new_ex(key->libctx);
+    ctx = BN_CTX_new_ex(key->libctx, key->propq);
     if (ctx == NULL)
         return 0;
 

--- a/crypto/ec/ec_lib.c
+++ b/crypto/ec/ec_lib.c
@@ -329,7 +329,7 @@ static int ec_guess_cofactor(EC_GROUP *group) {
         return 1;
     }
 
-    if ((ctx = BN_CTX_new_ex(group->libctx)) == NULL)
+    if ((ctx = BN_CTX_new_ex(group->libctx, group->propq)) == NULL)
         return 0;
 
     BN_CTX_start(ctx);
@@ -1185,7 +1185,7 @@ int EC_GROUP_have_precompute_mult(const EC_GROUP *group)
  */
 static int ec_precompute_mont_data(EC_GROUP *group)
 {
-    BN_CTX *ctx = BN_CTX_new_ex(group->libctx);
+    BN_CTX *ctx = BN_CTX_new_ex(group->libctx, group->propq);
     int ret = 0;
 
     BN_MONT_CTX_free(group->mont_data);
@@ -1560,7 +1560,7 @@ EC_GROUP *EC_GROUP_new_from_params(const OSSL_PARAM params[],
         return group;
     }
     /* If it gets here then we are trying explicit parameters */
-    bnctx = BN_CTX_new_ex(libctx);
+    bnctx = BN_CTX_new_ex(libctx, propq);
     if (bnctx == NULL) {
         ERR_raise(ERR_LIB_EC, ERR_R_MALLOC_FAILURE);
         return 0;

--- a/crypto/ec/ecdh_ossl.c
+++ b/crypto/ec/ecdh_ossl.c
@@ -58,7 +58,7 @@ int ossl_ecdh_simple_compute_key(unsigned char **pout, size_t *poutlen,
     size_t buflen, len;
     unsigned char *buf = NULL;
 
-    if ((ctx = BN_CTX_new_ex(ecdh->libctx)) == NULL)
+    if ((ctx = BN_CTX_new_ex(ecdh->libctx, ecdh->propq)) == NULL)
         goto err;
     BN_CTX_start(ctx);
     x = BN_CTX_get(ctx);

--- a/crypto/ec/ecdsa_ossl.c
+++ b/crypto/ec/ecdsa_ossl.c
@@ -99,7 +99,7 @@ static int ecdsa_sign_setup(EC_KEY *eckey, BN_CTX *ctx_in,
     }
 
     if ((ctx = ctx_in) == NULL) {
-        if ((ctx = BN_CTX_new_ex(eckey->libctx)) == NULL) {
+        if ((ctx = BN_CTX_new_ex(eckey->libctx, eckey->propq)) == NULL) {
             ERR_raise(ERR_LIB_EC, ERR_R_MALLOC_FAILURE);
             return 0;
         }
@@ -232,7 +232,7 @@ ECDSA_SIG *ossl_ecdsa_simple_sign_sig(const unsigned char *dgst, int dgst_len,
     }
     s = ret->s;
 
-    if ((ctx = BN_CTX_new_ex(eckey->libctx)) == NULL
+    if ((ctx = BN_CTX_new_ex(eckey->libctx, eckey->propq)) == NULL
         || (m = BN_new()) == NULL) {
         ERR_raise(ERR_LIB_EC, ERR_R_MALLOC_FAILURE);
         goto err;
@@ -376,7 +376,7 @@ int ossl_ecdsa_simple_verify_sig(const unsigned char *dgst, int dgst_len,
         return -1;
     }
 
-    ctx = BN_CTX_new_ex(eckey->libctx);
+    ctx = BN_CTX_new_ex(eckey->libctx, eckey->propq);
     if (ctx == NULL) {
         ERR_raise(ERR_LIB_EC, ERR_R_MALLOC_FAILURE);
         return -1;

--- a/crypto/ec/ecp_mont.c
+++ b/crypto/ec/ecp_mont.c
@@ -154,7 +154,7 @@ int ossl_ec_GFp_mont_group_set_curve(EC_GROUP *group, const BIGNUM *p,
     group->field_data2 = NULL;
 
     if (ctx == NULL) {
-        ctx = new_ctx = BN_CTX_new_ex(group->libctx);
+        ctx = new_ctx = BN_CTX_new_ex(group->libctx, group->propq);
         if (ctx == NULL)
             return 0;
     }
@@ -231,7 +231,8 @@ int ossl_ec_GFp_mont_field_inv(const EC_GROUP *group, BIGNUM *r, const BIGNUM *a
         return 0;
 
     if (ctx == NULL
-            && (ctx = new_ctx = BN_CTX_secure_new_ex(group->libctx)) == NULL)
+            && (ctx = new_ctx = BN_CTX_secure_new_ex(group->libctx,
+                                                     group->propq)) == NULL)
         return 0;
 
     BN_CTX_start(ctx);

--- a/crypto/ec/ecp_nist.c
+++ b/crypto/ec/ecp_nist.c
@@ -97,7 +97,7 @@ int ossl_ec_GFp_nist_group_set_curve(EC_GROUP *group, const BIGNUM *p,
     BN_CTX *new_ctx = NULL;
 
     if (ctx == NULL)
-        if ((ctx = new_ctx = BN_CTX_new_ex(group->libctx)) == NULL)
+        if ((ctx = new_ctx = BN_CTX_new_ex(group->libctx, group->propq)) == NULL)
             return 0;
 
     BN_CTX_start(ctx);
@@ -136,7 +136,7 @@ int ossl_ec_GFp_nist_field_mul(const EC_GROUP *group, BIGNUM *r, const BIGNUM *a
         goto err;
     }
     if (!ctx)
-        if ((ctx_new = ctx = BN_CTX_new_ex(group->libctx)) == NULL)
+        if ((ctx_new = ctx = BN_CTX_new_ex(group->libctx, group->propq)) == NULL)
             goto err;
 
     if (!BN_mul(r, a, b, ctx))
@@ -161,7 +161,7 @@ int ossl_ec_GFp_nist_field_sqr(const EC_GROUP *group, BIGNUM *r, const BIGNUM *a
         goto err;
     }
     if (!ctx)
-        if ((ctx_new = ctx = BN_CTX_new_ex(group->libctx)) == NULL)
+        if ((ctx_new = ctx = BN_CTX_new_ex(group->libctx, group->propq)) == NULL)
             goto err;
 
     if (!BN_sqr(r, a, ctx))

--- a/crypto/ec/ecp_nistz256.c
+++ b/crypto/ec/ecp_nistz256.c
@@ -849,7 +849,7 @@ __owur static int ecp_nistz256_mult_precompute(EC_GROUP *group, BN_CTX *ctx)
         return 0;
 
     if (ctx == NULL) {
-        ctx = new_ctx = BN_CTX_new_ex(group->libctx);
+        ctx = new_ctx = BN_CTX_new_ex(group->libctx, group->propq);
         if (ctx == NULL)
             goto err;
     }

--- a/crypto/ec/ecp_oct.c
+++ b/crypto/ec/ecp_oct.c
@@ -34,7 +34,7 @@ int ossl_ec_GFp_simple_set_compressed_coordinates(const EC_GROUP *group,
 #endif
 
     if (ctx == NULL) {
-        ctx = new_ctx = BN_CTX_new_ex(group->libctx);
+        ctx = new_ctx = BN_CTX_new_ex(group->libctx, group->propq);
         if (ctx == NULL)
             return 0;
     }
@@ -201,7 +201,7 @@ size_t ossl_ec_GFp_simple_point2oct(const EC_GROUP *group, const EC_POINT *point
         }
 
         if (ctx == NULL) {
-            ctx = new_ctx = BN_CTX_new_ex(group->libctx);
+            ctx = new_ctx = BN_CTX_new_ex(group->libctx, group->propq);
             if (ctx == NULL)
                 return 0;
         }
@@ -322,7 +322,7 @@ int ossl_ec_GFp_simple_oct2point(const EC_GROUP *group, EC_POINT *point,
     }
 
     if (ctx == NULL) {
-        ctx = new_ctx = BN_CTX_new_ex(group->libctx);
+        ctx = new_ctx = BN_CTX_new_ex(group->libctx, group->propq);
         if (ctx == NULL)
             return 0;
     }

--- a/crypto/ec/ecp_s390x_nistp.c
+++ b/crypto/ec/ecp_s390x_nistp.c
@@ -58,7 +58,7 @@ static int ec_GFp_s390x_nistp_mul(const EC_GROUP *group, EC_POINT *r,
     int rc = -1;
 
     if (ctx == NULL) {
-        ctx = new_ctx = BN_CTX_new_ex(group->libctx);
+        ctx = new_ctx = BN_CTX_new_ex(group->libctx, group->propq);
         if (ctx == NULL)
             return 0;
     }
@@ -241,7 +241,7 @@ static int ecdsa_s390x_nistp_verify_sig(const unsigned char *dgst, int dgstlen,
         return -1;
     }
 
-    ctx = BN_CTX_new_ex(group->libctx);
+    ctx = BN_CTX_new_ex(group->libctx, group->propq);
     if (ctx == NULL) {
         ERR_raise(ERR_LIB_EC, ERR_R_MALLOC_FAILURE);
         return -1;

--- a/crypto/ec/ecp_smpl.c
+++ b/crypto/ec/ecp_smpl.c
@@ -153,7 +153,7 @@ int ossl_ec_GFp_simple_group_set_curve(EC_GROUP *group,
     }
 
     if (ctx == NULL) {
-        ctx = new_ctx = BN_CTX_new_ex(group->libctx);
+        ctx = new_ctx = BN_CTX_new_ex(group->libctx, group->propq);
         if (ctx == NULL)
             return 0;
     }
@@ -211,7 +211,7 @@ int ossl_ec_GFp_simple_group_get_curve(const EC_GROUP *group, BIGNUM *p,
     if (a != NULL || b != NULL) {
         if (group->meth->field_decode) {
             if (ctx == NULL) {
-                ctx = new_ctx = BN_CTX_new_ex(group->libctx);
+                ctx = new_ctx = BN_CTX_new_ex(group->libctx, group->propq);
                 if (ctx == NULL)
                     return 0;
             }
@@ -256,7 +256,7 @@ int ossl_ec_GFp_simple_group_check_discriminant(const EC_GROUP *group,
     BN_CTX *new_ctx = NULL;
 
     if (ctx == NULL) {
-        ctx = new_ctx = BN_CTX_new_ex(group->libctx);
+        ctx = new_ctx = BN_CTX_new_ex(group->libctx, group->propq);
         if (ctx == NULL) {
             ERR_raise(ERR_LIB_EC, ERR_R_MALLOC_FAILURE);
             goto err;
@@ -383,7 +383,7 @@ int ossl_ec_GFp_simple_set_Jprojective_coordinates_GFp(const EC_GROUP *group,
     int ret = 0;
 
     if (ctx == NULL) {
-        ctx = new_ctx = BN_CTX_new_ex(group->libctx);
+        ctx = new_ctx = BN_CTX_new_ex(group->libctx, group->propq);
         if (ctx == NULL)
             return 0;
     }
@@ -442,7 +442,7 @@ int ossl_ec_GFp_simple_get_Jprojective_coordinates_GFp(const EC_GROUP *group,
 
     if (group->meth->field_decode != 0) {
         if (ctx == NULL) {
-            ctx = new_ctx = BN_CTX_new_ex(group->libctx);
+            ctx = new_ctx = BN_CTX_new_ex(group->libctx, group->propq);
             if (ctx == NULL)
                 return 0;
         }
@@ -514,7 +514,7 @@ int ossl_ec_GFp_simple_point_get_affine_coordinates(const EC_GROUP *group,
     }
 
     if (ctx == NULL) {
-        ctx = new_ctx = BN_CTX_new_ex(group->libctx);
+        ctx = new_ctx = BN_CTX_new_ex(group->libctx, group->propq);
         if (ctx == NULL)
             return 0;
     }
@@ -633,7 +633,7 @@ int ossl_ec_GFp_simple_add(const EC_GROUP *group, EC_POINT *r, const EC_POINT *a
     p = group->field;
 
     if (ctx == NULL) {
-        ctx = new_ctx = BN_CTX_new_ex(group->libctx);
+        ctx = new_ctx = BN_CTX_new_ex(group->libctx, group->propq);
         if (ctx == NULL)
             return 0;
     }
@@ -817,7 +817,7 @@ int ossl_ec_GFp_simple_dbl(const EC_GROUP *group, EC_POINT *r, const EC_POINT *a
     p = group->field;
 
     if (ctx == NULL) {
-        ctx = new_ctx = BN_CTX_new_ex(group->libctx);
+        ctx = new_ctx = BN_CTX_new_ex(group->libctx, group->propq);
         if (ctx == NULL)
             return 0;
     }
@@ -972,7 +972,7 @@ int ossl_ec_GFp_simple_is_on_curve(const EC_GROUP *group, const EC_POINT *point,
     p = group->field;
 
     if (ctx == NULL) {
-        ctx = new_ctx = BN_CTX_new_ex(group->libctx);
+        ctx = new_ctx = BN_CTX_new_ex(group->libctx, group->propq);
         if (ctx == NULL)
             return -1;
     }
@@ -1089,7 +1089,7 @@ int ossl_ec_GFp_simple_cmp(const EC_GROUP *group, const EC_POINT *a,
     field_sqr = group->meth->field_sqr;
 
     if (ctx == NULL) {
-        ctx = new_ctx = BN_CTX_new_ex(group->libctx);
+        ctx = new_ctx = BN_CTX_new_ex(group->libctx, group->propq);
         if (ctx == NULL)
             return -1;
     }
@@ -1175,7 +1175,7 @@ int ossl_ec_GFp_simple_make_affine(const EC_GROUP *group, EC_POINT *point,
         return 1;
 
     if (ctx == NULL) {
-        ctx = new_ctx = BN_CTX_new_ex(group->libctx);
+        ctx = new_ctx = BN_CTX_new_ex(group->libctx, group->propq);
         if (ctx == NULL)
             return 0;
     }
@@ -1216,7 +1216,7 @@ int ossl_ec_GFp_simple_points_make_affine(const EC_GROUP *group, size_t num,
         return 1;
 
     if (ctx == NULL) {
-        ctx = new_ctx = BN_CTX_new_ex(group->libctx);
+        ctx = new_ctx = BN_CTX_new_ex(group->libctx, group->propq);
         if (ctx == NULL)
             return 0;
     }
@@ -1388,7 +1388,8 @@ int ossl_ec_GFp_simple_field_inv(const EC_GROUP *group, BIGNUM *r,
     int ret = 0;
 
     if (ctx == NULL
-            && (ctx = new_ctx = BN_CTX_secure_new_ex(group->libctx)) == NULL)
+            && (ctx = new_ctx = BN_CTX_secure_new_ex(group->libctx,
+                                                     group->propq)) == NULL)
         return 0;
 
     BN_CTX_start(ctx);

--- a/crypto/ec/ecx_meth.c
+++ b/crypto/ec/ecx_meth.c
@@ -75,7 +75,7 @@ static int ecx_key_op(EVP_PKEY *pkey, int id, const X509_ALGOR *palg,
             goto err;
         }
         if (op == KEY_OP_KEYGEN) {
-            if (RAND_priv_bytes_ex(libctx, privkey, KEYLENID(id)) <= 0)
+            if (RAND_priv_bytes_ex(libctx, privkey, KEYLENID(id), propq) <= 0)
                 goto err;
             if (id == EVP_PKEY_X25519) {
                 privkey[0] &= 248;

--- a/crypto/evp/ctrl_params_translate.c
+++ b/crypto/evp/ctrl_params_translate.c
@@ -1592,7 +1592,8 @@ static int get_payload_public_key(enum state state,
     case EVP_PKEY_EC:
         if (ctx->params->data_type == OSSL_PARAM_OCTET_STRING) {
             EC_KEY *eckey = EVP_PKEY_get0_EC_KEY(pkey);
-            BN_CTX *bnctx = BN_CTX_new_ex(ossl_ec_key_get_libctx(eckey));
+            BN_CTX *bnctx = BN_CTX_new_ex(ossl_ec_key_get_libctx(eckey),
+                                          ossl_ec_key_get0_propq(eckey));
             const EC_GROUP *ecg = EC_KEY_get0_group(eckey);
             const EC_POINT *point = EC_KEY_get0_public_key(eckey);
 

--- a/crypto/evp/evp_enc.c
+++ b/crypto/evp/evp_enc.c
@@ -1261,7 +1261,7 @@ int EVP_CIPHER_CTX_rand_key(EVP_CIPHER_CTX *ctx, unsigned char *key)
         OSSL_LIB_CTX *libctx = EVP_CIPHER_CTX_get_libctx(ctx);
 
         kl = EVP_CIPHER_CTX_key_length(ctx);
-        if (kl <= 0 || RAND_priv_bytes_ex(libctx, key, kl) <= 0)
+        if (kl <= 0 || RAND_priv_bytes_ex(libctx, key, kl, NULL) <= 0)
             return 0;
         return 1;
     }

--- a/crypto/ffc/ffc_key_validate.c
+++ b/crypto/ffc/ffc_key_validate.c
@@ -16,15 +16,17 @@
  *
  * ret contains 0 on success, or error flags (see FFC_ERROR_PUBKEY_TOO_SMALL)
  */
-int ossl_ffc_validate_public_key_partial(const FFC_PARAMS *params,
-                                         const BIGNUM *pub_key, int *ret)
+int ossl_ffc_validate_public_key_partial(OSSL_LIB_CTX *libctx,
+                                         const FFC_PARAMS *params,
+                                         const BIGNUM *pub_key,
+                                         const char *propq, int *ret)
 {
     int ok = 0;
     BIGNUM *tmp = NULL;
     BN_CTX *ctx = NULL;
 
     *ret = 0;
-    ctx = BN_CTX_new_ex(NULL);
+    ctx = BN_CTX_new_ex(libctx, propq);
     if (ctx == NULL)
         goto err;
 
@@ -58,18 +60,21 @@ int ossl_ffc_validate_public_key_partial(const FFC_PARAMS *params,
 /*
  * See SP800-56Ar3 Section 5.6.2.3.1 : FFC Full public key validation.
  */
-int ossl_ffc_validate_public_key(const FFC_PARAMS *params,
-                                 const BIGNUM *pub_key, int *ret)
+int ossl_ffc_validate_public_key(OSSL_LIB_CTX *libctx,
+                                 const FFC_PARAMS *params,
+                                 const BIGNUM *pub_key,
+                                 const char *propq, int *ret)
 {
     int ok = 0;
     BIGNUM *tmp = NULL;
     BN_CTX *ctx = NULL;
 
-    if (!ossl_ffc_validate_public_key_partial(params, pub_key, ret))
+    if (!ossl_ffc_validate_public_key_partial(libctx, params, pub_key, propq,
+                                              ret))
         return 0;
 
     if (params->q != NULL) {
-        ctx = BN_CTX_new_ex(NULL);
+        ctx = BN_CTX_new_ex(libctx, propq);
         if (ctx == NULL)
             goto err;
         BN_CTX_start(ctx);

--- a/crypto/pkcs7/pk7_doit.c
+++ b/crypto/pkcs7/pk7_doit.c
@@ -311,7 +311,7 @@ BIO *PKCS7_dataInit(PKCS7 *p7, BIO *bio)
         ivlen = EVP_CIPHER_iv_length(evp_cipher);
         xalg->algorithm = OBJ_nid2obj(EVP_CIPHER_type(evp_cipher));
         if (ivlen > 0)
-            if (RAND_bytes_ex(libctx, iv, ivlen) <= 0)
+            if (RAND_bytes_ex(libctx, iv, ivlen, propq) <= 0)
                 goto err;
 
         (void)ERR_set_mark();

--- a/crypto/rand/rand_lib.c
+++ b/crypto/rand/rand_lib.c
@@ -242,7 +242,7 @@ void RAND_seed(const void *buf, int num)
     }
 # endif
 
-    drbg = RAND_get0_primary(NULL);
+    drbg = RAND_get0_primary(NULL, NULL);
     if (drbg != NULL && num > 0)
         EVP_RAND_reseed(drbg, 0, NULL, 0, buf, num);
 }
@@ -258,7 +258,7 @@ void RAND_add(const void *buf, int num, double randomness)
         return;
     }
 # endif
-    drbg = RAND_get0_primary(NULL);
+    drbg = RAND_get0_primary(NULL, NULL);
     if (drbg != NULL && num > 0)
         EVP_RAND_reseed(drbg, 0, NULL, 0, buf, num);
 }

--- a/crypto/rand/rand_meth.c
+++ b/crypto/rand/rand_meth.c
@@ -14,7 +14,7 @@
 /* Implements the default OpenSSL RAND_add() method */
 static int drbg_add(const void *buf, int num, double randomness)
 {
-    EVP_RAND_CTX *drbg = RAND_get0_primary(NULL);
+    EVP_RAND_CTX *drbg = RAND_get0_primary(NULL, NULL);
 
     if (drbg == NULL || num <= 0)
         return 0;
@@ -31,7 +31,7 @@ static int drbg_seed(const void *buf, int num)
 /* Implements the default OpenSSL RAND_status() method */
 static int drbg_status(void)
 {
-    EVP_RAND_CTX *drbg = RAND_get0_primary(NULL);
+    EVP_RAND_CTX *drbg = RAND_get0_primary(NULL, NULL);
 
     if (drbg == NULL)
         return 0;
@@ -42,7 +42,7 @@ static int drbg_status(void)
 /* Implements the default OpenSSL RAND_bytes() method */
 static int drbg_bytes(unsigned char *out, int count)
 {
-    EVP_RAND_CTX *drbg = RAND_get0_public(NULL);
+    EVP_RAND_CTX *drbg = RAND_get0_public(NULL, NULL);
 
     if (drbg == NULL)
         return 0;

--- a/crypto/rsa/rsa_ameth.c
+++ b/crypto/rsa/rsa_ameth.c
@@ -933,7 +933,7 @@ static int rsa_int_import_from(const OSSL_PARAM params[], void *vpctx,
 {
     EVP_PKEY_CTX *pctx = vpctx;
     EVP_PKEY *pkey = EVP_PKEY_CTX_get0_pkey(pctx);
-    RSA *rsa = ossl_rsa_new_with_ctx(pctx->libctx);
+    RSA *rsa = ossl_rsa_new_with_ctx(pctx->libctx, NULL);
     RSA_PSS_PARAMS_30 rsa_pss_params = { 0, };
     int pss_defaults_set = 0;
     int ok = 0;

--- a/crypto/rsa/rsa_crpt.c
+++ b/crypto/rsa/rsa_crpt.c
@@ -120,7 +120,7 @@ BN_BLINDING *RSA_setup_blinding(RSA *rsa, BN_CTX *in_ctx)
     BN_BLINDING *ret = NULL;
 
     if (in_ctx == NULL) {
-        if ((ctx = BN_CTX_new_ex(rsa->libctx)) == NULL)
+        if ((ctx = BN_CTX_new_ex(rsa->libctx, rsa->propq)) == NULL)
             return 0;
     } else {
         ctx = in_ctx;

--- a/crypto/rsa/rsa_local.h
+++ b/crypto/rsa/rsa_local.h
@@ -56,6 +56,7 @@ struct rsa_st {
     int dummy_zero;
 
     OSSL_LIB_CTX *libctx;
+    char *propq;
     int32_t version;
     const RSA_METHOD *meth;
     /* functional reference if 'meth' is ENGINE-provided */
@@ -197,9 +198,9 @@ int ossl_rsa_fips186_4_gen_prob_primes(RSA *rsa, RSA_ACVP_TEST *test,
 
 int ossl_rsa_padding_add_SSLv23_ex(OSSL_LIB_CTX *libctx, unsigned char *to,
                                    int tlen, const unsigned char *from,
-                                   int flen);
+                                   int flen, const char *propq);
 int ossl_rsa_padding_add_PKCS1_type_2_ex(OSSL_LIB_CTX *libctx, unsigned char *to,
                                          int tlen, const unsigned char *from,
-                                         int flen);
+                                         int flen, const char *propq);
 
 #endif /* OSSL_CRYPTO_RSA_LOCAL_H */

--- a/crypto/rsa/rsa_oaep.c
+++ b/crypto/rsa/rsa_oaep.c
@@ -41,7 +41,7 @@ int RSA_padding_add_PKCS1_OAEP(unsigned char *to, int tlen,
                                const unsigned char *param, int plen)
 {
     return ossl_rsa_padding_add_PKCS1_OAEP_mgf1_ex(NULL, to, tlen, from, flen,
-                                                   param, plen, NULL, NULL);
+                                                   param, plen, NULL, NULL, NULL);
 }
 
 /*
@@ -56,7 +56,8 @@ int ossl_rsa_padding_add_PKCS1_OAEP_mgf1_ex(OSSL_LIB_CTX *libctx,
                                             const unsigned char *from, int flen,
                                             const unsigned char *param,
                                             int plen, const EVP_MD *md,
-                                            const EVP_MD *mgf1md)
+                                            const EVP_MD *mgf1md,
+                                            const char *propq)
 {
     int rv = 0;
     int i, emlen = tlen - 1;
@@ -103,7 +104,7 @@ int ossl_rsa_padding_add_PKCS1_OAEP_mgf1_ex(OSSL_LIB_CTX *libctx,
     db[emlen - flen - mdlen - 1] = 0x01;
     memcpy(db + emlen - flen - mdlen, from, (unsigned int)flen);
     /* step 3d: generate random byte string */
-    if (RAND_bytes_ex(libctx, seed, mdlen) <= 0)
+    if (RAND_bytes_ex(libctx, seed, mdlen, propq) <= 0)
         goto err;
 
     dbmask_len = emlen - mdlen;
@@ -140,7 +141,7 @@ int RSA_padding_add_PKCS1_OAEP_mgf1(unsigned char *to, int tlen,
                                     const EVP_MD *md, const EVP_MD *mgf1md)
 {
     return ossl_rsa_padding_add_PKCS1_OAEP_mgf1_ex(NULL, to, tlen, from, flen,
-                                                   param, plen, md, mgf1md);
+                                                   param, plen, md, mgf1md, NULL);
 }
 
 int RSA_padding_check_PKCS1_OAEP(unsigned char *to, int tlen,

--- a/crypto/rsa/rsa_ossl.c
+++ b/crypto/rsa/rsa_ossl.c
@@ -97,7 +97,7 @@ static int rsa_ossl_public_encrypt(int flen, const unsigned char *from,
         }
     }
 
-    if ((ctx = BN_CTX_new_ex(rsa->libctx)) == NULL)
+    if ((ctx = BN_CTX_new_ex(rsa->libctx, rsa->propq)) == NULL)
         goto err;
     BN_CTX_start(ctx);
     f = BN_CTX_get(ctx);
@@ -112,16 +112,17 @@ static int rsa_ossl_public_encrypt(int flen, const unsigned char *from,
     switch (padding) {
     case RSA_PKCS1_PADDING:
         i = ossl_rsa_padding_add_PKCS1_type_2_ex(rsa->libctx, buf, num,
-                                                 from, flen);
+                                                 from, flen, rsa->propq);
         break;
     case RSA_PKCS1_OAEP_PADDING:
         i = ossl_rsa_padding_add_PKCS1_OAEP_mgf1_ex(rsa->libctx, buf, num,
                                                     from, flen, NULL, 0,
-                                                    NULL, NULL);
+                                                    NULL, NULL, rsa->propq);
         break;
 #ifndef FIPS_MODULE
     case RSA_SSLV23_PADDING:
-        i = ossl_rsa_padding_add_SSLv23_ex(rsa->libctx, buf, num, from, flen);
+        i = ossl_rsa_padding_add_SSLv23_ex(rsa->libctx, buf, num, from, flen,
+                                           rsa->propq);
         break;
 #endif
     case RSA_NO_PADDING:
@@ -256,7 +257,7 @@ static int rsa_ossl_private_encrypt(int flen, const unsigned char *from,
     BIGNUM *unblind = NULL;
     BN_BLINDING *blinding = NULL;
 
-    if ((ctx = BN_CTX_new_ex(rsa->libctx)) == NULL)
+    if ((ctx = BN_CTX_new_ex(rsa->libctx, rsa->propq)) == NULL)
         goto err;
     BN_CTX_start(ctx);
     f = BN_CTX_get(ctx);
@@ -389,7 +390,7 @@ static int rsa_ossl_private_decrypt(int flen, const unsigned char *from,
     BIGNUM *unblind = NULL;
     BN_BLINDING *blinding = NULL;
 
-    if ((ctx = BN_CTX_new_ex(rsa->libctx)) == NULL)
+    if ((ctx = BN_CTX_new_ex(rsa->libctx, rsa->propq)) == NULL)
         goto err;
     BN_CTX_start(ctx);
     f = BN_CTX_get(ctx);
@@ -543,7 +544,7 @@ static int rsa_ossl_public_decrypt(int flen, const unsigned char *from,
         }
     }
 
-    if ((ctx = BN_CTX_new_ex(rsa->libctx)) == NULL)
+    if ((ctx = BN_CTX_new_ex(rsa->libctx, rsa->propq)) == NULL)
         goto err;
     BN_CTX_start(ctx);
     f = BN_CTX_get(ctx);

--- a/crypto/rsa/rsa_pk1.c
+++ b/crypto/rsa/rsa_pk1.c
@@ -120,7 +120,7 @@ int RSA_padding_check_PKCS1_type_1(unsigned char *to, int tlen,
 
 int ossl_rsa_padding_add_PKCS1_type_2_ex(OSSL_LIB_CTX *libctx, unsigned char *to,
                                          int tlen, const unsigned char *from,
-                                         int flen)
+                                         int flen, const char *propq)
 {
     int i, j;
     unsigned char *p;
@@ -138,12 +138,12 @@ int ossl_rsa_padding_add_PKCS1_type_2_ex(OSSL_LIB_CTX *libctx, unsigned char *to
     /* pad out with non-zero random data */
     j = tlen - 3 - flen;
 
-    if (RAND_bytes_ex(libctx, p, j) <= 0)
+    if (RAND_bytes_ex(libctx, p, j, propq) <= 0)
         return 0;
     for (i = 0; i < j; i++) {
         if (*p == '\0')
             do {
-                if (RAND_bytes_ex(libctx, p, 1) <= 0)
+                if (RAND_bytes_ex(libctx, p, 1, propq) <= 0)
                     return 0;
             } while (*p == '\0');
         p++;
@@ -158,7 +158,7 @@ int ossl_rsa_padding_add_PKCS1_type_2_ex(OSSL_LIB_CTX *libctx, unsigned char *to
 int RSA_padding_add_PKCS1_type_2(unsigned char *to, int tlen,
                                  const unsigned char *from, int flen)
 {
-    return ossl_rsa_padding_add_PKCS1_type_2_ex(NULL, to, tlen, from, flen);
+    return ossl_rsa_padding_add_PKCS1_type_2_ex(NULL, to, tlen, from, flen, NULL);
 }
 
 int RSA_padding_check_PKCS1_type_2(unsigned char *to, int tlen,
@@ -295,7 +295,8 @@ int ossl_rsa_padding_check_PKCS1_type_2_TLS(OSSL_LIB_CTX *libctx,
                                             unsigned char *to, size_t tlen,
                                             const unsigned char *from,
                                             size_t flen, int client_version,
-                                            int alt_version)
+                                            int alt_version,
+                                            const char *propq)
 {
     unsigned int i, good, version_good;
     unsigned char rand_premaster_secret[SSL_MAX_MASTER_KEY_LENGTH];
@@ -315,7 +316,7 @@ int ossl_rsa_padding_check_PKCS1_type_2_TLS(OSSL_LIB_CTX *libctx,
      * to decrypt.
      */
     if (RAND_priv_bytes_ex(libctx, rand_premaster_secret,
-                           sizeof(rand_premaster_secret)) <= 0) {
+                           sizeof(rand_premaster_secret), propq) <= 0) {
         ERR_raise(ERR_LIB_RSA, ERR_R_INTERNAL_ERROR);
         return -1;
     }

--- a/crypto/rsa/rsa_pss.c
+++ b/crypto/rsa/rsa_pss.c
@@ -205,7 +205,7 @@ int RSA_padding_add_PKCS1_PSS_mgf1(RSA *rsa, unsigned char *EM,
             ERR_raise(ERR_LIB_RSA, ERR_R_MALLOC_FAILURE);
             goto err;
         }
-        if (RAND_bytes_ex(rsa->libctx, salt, sLen) <= 0)
+        if (RAND_bytes_ex(rsa->libctx, salt, sLen, rsa->propq) <= 0)
             goto err;
     }
     maskedDBLen = emLen - hLen - 1;

--- a/crypto/rsa/rsa_sp800_56b_check.c
+++ b/crypto/rsa/rsa_sp800_56b_check.c
@@ -320,7 +320,7 @@ int ossl_rsa_sp800_56b_check_public(const RSA *rsa)
         return 0;
     }
 
-    ctx = BN_CTX_new_ex(rsa->libctx);
+    ctx = BN_CTX_new_ex(rsa->libctx, rsa->propq);
     gcd = BN_new();
     if (ctx == NULL || gcd == NULL)
         goto err;
@@ -409,7 +409,7 @@ int ossl_rsa_sp800_56b_check_keypair(const RSA *rsa, const BIGNUM *efixed,
         return 0;
     }
 
-    ctx = BN_CTX_new_ex(rsa->libctx);
+    ctx = BN_CTX_new_ex(rsa->libctx, rsa->propq);
     if (ctx == NULL)
         return 0;
 

--- a/crypto/rsa/rsa_sp800_56b_gen.c
+++ b/crypto/rsa/rsa_sp800_56b_gen.c
@@ -347,7 +347,7 @@ int ossl_rsa_sp800_56b_generate_key(RSA *rsa, int nbits, const BIGNUM *efixed,
     if (!ossl_rsa_sp800_56b_validate_strength(nbits, -1))
         return 0;
 
-    ctx = BN_CTX_new_ex(rsa->libctx);
+    ctx = BN_CTX_new_ex(rsa->libctx, rsa->propq);
     if (ctx == NULL)
         return 0;
 

--- a/crypto/rsa/rsa_ssl.c
+++ b/crypto/rsa/rsa_ssl.c
@@ -23,7 +23,7 @@
 
 int ossl_rsa_padding_add_SSLv23_ex(OSSL_LIB_CTX *libctx, unsigned char *to,
                                    int tlen, const unsigned char *from,
-                                   int flen)
+                                   int flen, const char *propq)
 {
     int i, j;
     unsigned char *p;
@@ -41,12 +41,12 @@ int ossl_rsa_padding_add_SSLv23_ex(OSSL_LIB_CTX *libctx, unsigned char *to,
     /* pad out with non-zero random data */
     j = tlen - 3 - 8 - flen;
 
-    if (RAND_bytes_ex(libctx, p, j) <= 0)
+    if (RAND_bytes_ex(libctx, p, j, propq) <= 0)
         return 0;
     for (i = 0; i < j; i++) {
         if (*p == '\0')
             do {
-                if (RAND_bytes_ex(libctx, p, 1) <= 0)
+                if (RAND_bytes_ex(libctx, p, 1, propq) <= 0)
                     return 0;
             } while (*p == '\0');
         p++;
@@ -63,7 +63,7 @@ int ossl_rsa_padding_add_SSLv23_ex(OSSL_LIB_CTX *libctx, unsigned char *to,
 int RSA_padding_add_SSLv23(unsigned char *to, int tlen,
                            const unsigned char *from, int flen)
 {
-    return ossl_rsa_padding_add_SSLv23_ex(NULL, to, tlen, from, flen);
+    return ossl_rsa_padding_add_SSLv23_ex(NULL, to, tlen, from, flen, NULL);
 }
 
 /*

--- a/crypto/sm2/sm2_crypt.c
+++ b/crypto/sm2/sm2_crypt.c
@@ -159,7 +159,7 @@ int ossl_sm2_encrypt(const EC_KEY *key,
 
     kG = EC_POINT_new(group);
     kP = EC_POINT_new(group);
-    ctx = BN_CTX_new_ex(libctx);
+    ctx = BN_CTX_new_ex(libctx, propq);
     if (kG == NULL || kP == NULL || ctx == NULL) {
         ERR_raise(ERR_LIB_SM2, ERR_R_MALLOC_FAILURE);
         goto done;
@@ -321,7 +321,7 @@ int ossl_sm2_decrypt(const EC_KEY *key,
     C3 = sm2_ctext->C3->data;
     msg_len = sm2_ctext->C2->length;
 
-    ctx = BN_CTX_new_ex(libctx);
+    ctx = BN_CTX_new_ex(libctx, propq);
     if (ctx == NULL) {
         ERR_raise(ERR_LIB_SM2, ERR_R_MALLOC_FAILURE);
         goto done;

--- a/crypto/sm2/sm2_sign.c
+++ b/crypto/sm2/sm2_sign.c
@@ -44,7 +44,7 @@ int ossl_sm2_compute_z_digest(uint8_t *out,
     uint8_t e_byte = 0;
 
     hash = EVP_MD_CTX_new();
-    ctx = BN_CTX_new_ex(ossl_ec_key_get_libctx(key));
+    ctx = BN_CTX_new_ex(ossl_ec_key_get_libctx(key), ossl_ec_key_get0_propq(key));
     if (hash == NULL || ctx == NULL) {
         ERR_raise(ERR_LIB_SM2, ERR_R_MALLOC_FAILURE);
         goto done;
@@ -211,7 +211,7 @@ static ECDSA_SIG *sm2_sig_gen(const EC_KEY *key, const BIGNUM *e)
     OSSL_LIB_CTX *libctx = ossl_ec_key_get_libctx(key);
 
     kG = EC_POINT_new(group);
-    ctx = BN_CTX_new_ex(libctx);
+    ctx = BN_CTX_new_ex(libctx, ossl_ec_key_get0_propq(key));
     if (kG == NULL || ctx == NULL) {
         ERR_raise(ERR_LIB_SM2, ERR_R_MALLOC_FAILURE);
         goto done;
@@ -310,7 +310,7 @@ static int sm2_sig_verify(const EC_KEY *key, const ECDSA_SIG *sig,
     const BIGNUM *s = NULL;
     OSSL_LIB_CTX *libctx = ossl_ec_key_get_libctx(key);
 
-    ctx = BN_CTX_new_ex(libctx);
+    ctx = BN_CTX_new_ex(libctx, ossl_ec_key_get0_propq(key));
     pt = EC_POINT_new(group);
     if (ctx == NULL || pt == NULL) {
         ERR_raise(ERR_LIB_SM2, ERR_R_MALLOC_FAILURE);

--- a/crypto/srp/srp_lib.c
+++ b/crypto/srp/srp_lib.c
@@ -111,7 +111,7 @@ BIGNUM *SRP_Calc_B_ex(const BIGNUM *b, const BIGNUM *N, const BIGNUM *g,
     BN_CTX *bn_ctx;
 
     if (b == NULL || N == NULL || g == NULL || v == NULL ||
-        (bn_ctx = BN_CTX_new_ex(libctx)) == NULL)
+        (bn_ctx = BN_CTX_new_ex(libctx, propq)) == NULL)
         return NULL;
 
     if ((kv = BN_new()) == NULL ||
@@ -218,7 +218,7 @@ BIGNUM *SRP_Calc_client_key_ex(const BIGNUM *N, const BIGNUM *B, const BIGNUM *g
     BN_CTX *bn_ctx;
 
     if (u == NULL || B == NULL || N == NULL || g == NULL || x == NULL
-        || a == NULL || (bn_ctx = BN_CTX_new_ex(libctx)) == NULL)
+        || a == NULL || (bn_ctx = BN_CTX_new_ex(libctx, propq)) == NULL)
         return NULL;
 
     if ((tmp = BN_new()) == NULL ||

--- a/crypto/srp/srp_vfy.c
+++ b/crypto/srp/srp_vfy.c
@@ -638,7 +638,7 @@ char *SRP_create_verifier_ex(const char *user, const char *pass, char **salt,
     }
 
     if (*salt == NULL) {
-        if (RAND_bytes_ex(libctx, tmp2, SRP_RANDOM_SALT_LEN) <= 0)
+        if (RAND_bytes_ex(libctx, tmp2, SRP_RANDOM_SALT_LEN, propq) <= 0)
             goto err;
 
         s = BN_bin2bn(tmp2, SRP_RANDOM_SALT_LEN, NULL);
@@ -710,7 +710,7 @@ int SRP_create_verifier_BN_ex(const char *user, const char *pass, BIGNUM **salt,
 {
     int result = 0;
     BIGNUM *x = NULL;
-    BN_CTX *bn_ctx = BN_CTX_new_ex(libctx);
+    BN_CTX *bn_ctx = BN_CTX_new_ex(libctx, propq);
     unsigned char tmp2[MAX_LEN];
     BIGNUM *salttmp = NULL;
 
@@ -721,7 +721,7 @@ int SRP_create_verifier_BN_ex(const char *user, const char *pass, BIGNUM **salt,
         goto err;
 
     if (*salt == NULL) {
-        if (RAND_bytes_ex(libctx, tmp2, SRP_RANDOM_SALT_LEN) <= 0)
+        if (RAND_bytes_ex(libctx, tmp2, SRP_RANDOM_SALT_LEN, propq) <= 0)
             goto err;
 
         salttmp = BN_bin2bn(tmp2, SRP_RANDOM_SALT_LEN, NULL);

--- a/include/crypto/bn.h
+++ b/include/crypto/bn.h
@@ -111,7 +111,7 @@ int ossl_bn_rsa_fips186_4_derive_prime(BIGNUM *Y, BIGNUM *X, const BIGNUM *Xin,
                                        BN_GENCB *cb);
 
 OSSL_LIB_CTX *ossl_bn_get_libctx(BN_CTX *ctx);
-
+const char *ossl_bn_get0_propq(BN_CTX *ctx);
 extern const BIGNUM ossl_bn_inv_sqrt_2;
 
 #endif

--- a/include/crypto/dh.h
+++ b/include/crypto/dh.h
@@ -16,8 +16,8 @@
 # include <openssl/dh.h>
 # include "internal/ffc.h"
 
-DH *ossl_dh_new_by_nid_ex(OSSL_LIB_CTX *libctx, int nid);
-DH *ossl_dh_new_ex(OSSL_LIB_CTX *libctx);
+DH *ossl_dh_new_by_nid_ex(OSSL_LIB_CTX *libctx, int nid, const char *prop);
+DH *ossl_dh_new_ex(OSSL_LIB_CTX *libctx, const char *propq);
 void ossl_dh_set0_libctx(DH *d, OSSL_LIB_CTX *libctx);
 int ossl_dh_generate_ffc_parameters(DH *dh, int type, int pbits, int qbits,
                                     BN_GENCB *cb);

--- a/include/crypto/dsa.h
+++ b/include/crypto/dsa.h
@@ -18,7 +18,7 @@
 #define DSA_PARAMGEN_TYPE_FIPS_186_4   0   /* Use FIPS186-4 standard */
 #define DSA_PARAMGEN_TYPE_FIPS_186_2   1   /* Use legacy FIPS186-2 standard */
 
-DSA *ossl_dsa_new(OSSL_LIB_CTX *libctx);
+DSA *ossl_dsa_new(OSSL_LIB_CTX *libctx, const char *propq);
 void ossl_dsa_set0_libctx(DSA *d, OSSL_LIB_CTX *libctx);
 
 int ossl_dsa_generate_ffc_parameters(DSA *dsa, int type, int pbits, int qbits,

--- a/include/crypto/rsa.h
+++ b/include/crypto/rsa.h
@@ -50,8 +50,10 @@ const char *ossl_rsa_mgf_nid2name(int mgf);
 int ossl_rsa_oaeppss_md2nid(const EVP_MD *md);
 const char *ossl_rsa_oaeppss_nid2name(int md);
 
-RSA *ossl_rsa_new_with_ctx(OSSL_LIB_CTX *libctx);
+RSA *ossl_rsa_new_with_ctx(OSSL_LIB_CTX *libctx, const char *propq);
 OSSL_LIB_CTX *ossl_rsa_get0_libctx(RSA *r);
+const char *ossl_rsa_get0_propq(RSA *r);
+
 void ossl_rsa_set0_libctx(RSA *r, OSSL_LIB_CTX *libctx);
 
 int ossl_rsa_set0_all_params(RSA *r, const STACK_OF(BIGNUM) *primes,
@@ -74,13 +76,14 @@ int ossl_rsa_padding_check_PKCS1_type_2_TLS(OSSL_LIB_CTX *ctx, unsigned char *to
                                             size_t tlen,
                                             const unsigned char *from,
                                             size_t flen, int client_version,
-                                            int alt_version);
+                                            int alt_version, const char *propq);
 int ossl_rsa_padding_add_PKCS1_OAEP_mgf1_ex(OSSL_LIB_CTX *libctx,
                                             unsigned char *to, int tlen,
                                             const unsigned char *from, int flen,
                                             const unsigned char *param,
                                             int plen, const EVP_MD *md,
-                                            const EVP_MD *mgf1md);
+                                            const EVP_MD *mgf1md,
+                                            const char *propq);
 
 int ossl_rsa_validate_public(const RSA *key);
 int ossl_rsa_validate_private(const RSA *key);

--- a/include/internal/ffc.h
+++ b/include/internal/ffc.h
@@ -148,32 +148,37 @@ int ossl_ffc_params_print(BIO *bp, const FFC_PARAMS *ffc, int indent);
 
 int ossl_ffc_params_FIPS186_4_generate(OSSL_LIB_CTX *libctx, FFC_PARAMS *params,
                                        int type, size_t L, size_t N,
+                                       const char *propq,
                                        int *res, BN_GENCB *cb);
 int ossl_ffc_params_FIPS186_2_generate(OSSL_LIB_CTX *libctx, FFC_PARAMS *params,
                                        int type, size_t L, size_t N,
+                                       const char *propq,
                                        int *res, BN_GENCB *cb);
 
 int ossl_ffc_params_FIPS186_4_gen_verify(OSSL_LIB_CTX *libctx,
                                          FFC_PARAMS *params, int mode, int type,
-                                         size_t L, size_t N, int *res,
-                                         BN_GENCB *cb);
+                                         size_t L, size_t N, const char *propq,
+                                         int *res, BN_GENCB *cb);
 int ossl_ffc_params_FIPS186_2_gen_verify(OSSL_LIB_CTX *libctx,
                                          FFC_PARAMS *params, int mode, int type,
-                                         size_t L, size_t N, int *res,
-                                         BN_GENCB *cb);
+                                         size_t L, size_t N, const char *propq,
+                                         int *res, BN_GENCB *cb);
 
 int ossl_ffc_params_simple_validate(OSSL_LIB_CTX *libctx,
                                     const FFC_PARAMS *params,
-                                    int paramstype, int *res);
+                                    int paramstype,
+                                    const char *propq, int *res);
 int ossl_ffc_params_full_validate(OSSL_LIB_CTX *libctx,
                                   const FFC_PARAMS *params,
-                                  int paramstype, int *res);
+                                  int paramstype, const char *propq, int *res);
 int ossl_ffc_params_FIPS186_4_validate(OSSL_LIB_CTX *libctx,
                                        const FFC_PARAMS *params,
-                                       int type, int *res, BN_GENCB *cb);
+                                       int type, const char *propq,
+                                       int *res, BN_GENCB *cb);
 int ossl_ffc_params_FIPS186_2_validate(OSSL_LIB_CTX *libctx,
                                        const FFC_PARAMS *params,
-                                       int type, int *res, BN_GENCB *cb);
+                                       int type, const char *propq,
+                                       int *res, BN_GENCB *cb);
 
 int ossl_ffc_generate_private_key(BN_CTX *ctx, const FFC_PARAMS *params,
                                   int N, int s, BIGNUM *priv);
@@ -183,10 +188,13 @@ int ossl_ffc_params_validate_unverifiable_g(BN_CTX *ctx, BN_MONT_CTX *mont,
                                             const BIGNUM *g, BIGNUM *tmp,
                                             int *ret);
 
-int ossl_ffc_validate_public_key(const FFC_PARAMS *params,
-                                 const BIGNUM *pub_key, int *ret);
-int ossl_ffc_validate_public_key_partial(const FFC_PARAMS *params,
-                                         const BIGNUM *pub_key, int *ret);
+int ossl_ffc_validate_public_key(OSSL_LIB_CTX *libctx, const FFC_PARAMS *params,
+                                 const BIGNUM *pub_key, const char *propq,
+                                 int *ret);
+int ossl_ffc_validate_public_key_partial(OSSL_LIB_CTX *libctx,
+                                         const FFC_PARAMS *params,
+                                         const BIGNUM *pub_key,
+                                         const char *propq, int *ret);
 int ossl_ffc_validate_private_key(const BIGNUM *upper, const BIGNUM *priv_key,
                                  int *ret);
 

--- a/include/openssl/bn.h
+++ b/include/openssl/bn.h
@@ -206,9 +206,9 @@ void BN_zero_ex(BIGNUM *a);
 
 const BIGNUM *BN_value_one(void);
 char *BN_options(void);
-BN_CTX *BN_CTX_new_ex(OSSL_LIB_CTX *ctx);
+BN_CTX *BN_CTX_new_ex(OSSL_LIB_CTX *ctx, const char *propq);
 BN_CTX *BN_CTX_new(void);
-BN_CTX *BN_CTX_secure_new_ex(OSSL_LIB_CTX *ctx);
+BN_CTX *BN_CTX_secure_new_ex(OSSL_LIB_CTX *ctx, const char *propq);
 BN_CTX *BN_CTX_secure_new(void);
 void BN_CTX_free(BN_CTX *c);
 void BN_CTX_start(BN_CTX *ctx);

--- a/include/openssl/crmf.h.in
+++ b/include/openssl/crmf.h.in
@@ -79,7 +79,7 @@ typedef struct ossl_crmf_optionalvalidity_st OSSL_CRMF_OPTIONALVALIDITY;
 /* crmf_pbm.c */
 OSSL_CRMF_PBMPARAMETER *OSSL_CRMF_pbmp_new(OSSL_LIB_CTX *libctx, size_t slen,
                                            int owfnid, size_t itercnt,
-                                           int macnid);
+                                           int macnid, const char *propq);
 int OSSL_CRMF_pbm_new(OSSL_LIB_CTX *libctx, const char *propq,
                       const OSSL_CRMF_PBMPARAMETER *pbmp,
                       const unsigned char *msg, size_t msglen,

--- a/include/openssl/rand.h
+++ b/include/openssl/rand.h
@@ -62,17 +62,19 @@ int RAND_bytes(unsigned char *buf, int num);
 int RAND_priv_bytes(unsigned char *buf, int num);
 
 /* Equivalent of RAND_priv_bytes() but additionally taking an OSSL_LIB_CTX */
-int RAND_priv_bytes_ex(OSSL_LIB_CTX *ctx, unsigned char *buf, int num);
+int RAND_priv_bytes_ex(OSSL_LIB_CTX *ctx, unsigned char *buf, int num,
+                       const char *propq);
 
 /* Equivalent of RAND_bytes() but additionally taking an OSSL_LIB_CTX */
-int RAND_bytes_ex(OSSL_LIB_CTX *ctx, unsigned char *buf, int num);
+int RAND_bytes_ex(OSSL_LIB_CTX *ctx, unsigned char *buf, int num,
+                  const char *propq);
 # ifndef OPENSSL_NO_DEPRECATED_1_1_0
 OSSL_DEPRECATEDIN_1_1_0 int RAND_pseudo_bytes(unsigned char *buf, int num);
 # endif
 
-EVP_RAND_CTX *RAND_get0_primary(OSSL_LIB_CTX *ctx);
-EVP_RAND_CTX *RAND_get0_public(OSSL_LIB_CTX *ctx);
-EVP_RAND_CTX *RAND_get0_private(OSSL_LIB_CTX *ctx);
+EVP_RAND_CTX *RAND_get0_primary(OSSL_LIB_CTX *ctx, const char *propq);
+EVP_RAND_CTX *RAND_get0_public(OSSL_LIB_CTX *ctx, const char *propq);
+EVP_RAND_CTX *RAND_get0_private(OSSL_LIB_CTX *ctx, const char *propq);
 
 int RAND_set_DRBG_type(OSSL_LIB_CTX *ctx, const char *drbg, const char *propq,
                        const char *cipher, const char *digest);

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -633,7 +633,7 @@ int OSSL_provider_init(const OSSL_CORE_HANDLE *handle,
     }
 
     /* TODO(3.0): Tests will hang if this is removed */
-    (void)RAND_get0_public(libctx);
+    (void)RAND_get0_public(libctx, NULL);
 
     *out = fips_dispatch_table;
     return 1;

--- a/providers/fips/self_test.c
+++ b/providers/fips/self_test.c
@@ -326,7 +326,7 @@ int SELF_TEST_post(SELF_TEST_POST_PARAMS *st, int on_demand_test)
 
     /* Only runs the KAT's during installation OR on_demand() */
     if (on_demand_test || kats_already_passed == 0) {
-        if (!SELF_TEST_kats(ev, st->libctx)) {
+        if (!SELF_TEST_kats(ev, st->libctx, NULL)) {
             ERR_raise(ERR_LIB_PROV, PROV_R_SELF_TEST_KAT_FAILURE);
             goto end;
         }

--- a/providers/fips/self_test.h
+++ b/providers/fips/self_test.h
@@ -36,6 +36,7 @@ typedef struct self_test_post_params_st {
 } SELF_TEST_POST_PARAMS;
 
 int SELF_TEST_post(SELF_TEST_POST_PARAMS *st, int on_demand_test);
-int SELF_TEST_kats(OSSL_SELF_TEST *event, OSSL_LIB_CTX *libctx);
+int SELF_TEST_kats(OSSL_SELF_TEST *event, OSSL_LIB_CTX *libctx,
+                   const char *propq);
 
 void SELF_TEST_disable_conditional_error_state(void);

--- a/providers/implementations/asymciphers/rsa_enc.c
+++ b/providers/implementations/asymciphers/rsa_enc.c
@@ -153,6 +153,8 @@ static int rsa_encrypt(void *vprsactx, unsigned char *out, size_t *outlen,
     if (prsactx->pad_mode == RSA_PKCS1_OAEP_PADDING) {
         int rsasize = RSA_size(prsactx->rsa);
         unsigned char *tbuf;
+        const char *propq = ossl_rsa_get0_propq(prsactx->rsa);
+
 
         if ((tbuf = OPENSSL_malloc(rsasize)) == NULL) {
             ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
@@ -170,7 +172,8 @@ static int rsa_encrypt(void *vprsactx, unsigned char *out, size_t *outlen,
                                                     prsactx->oaep_label,
                                                     prsactx->oaep_labellen,
                                                     prsactx->oaep_md,
-                                                    prsactx->mgf1_md);
+                                                    prsactx->mgf1_md,
+                                                    propq);
 
         if (!ret) {
             OPENSSL_free(tbuf);
@@ -266,7 +269,8 @@ static int rsa_decrypt(void *vprsactx, unsigned char *out, size_t *outlen,
             }
             ret = ossl_rsa_padding_check_PKCS1_type_2_TLS(
                         prsactx->libctx, out, outsize, tbuf, len,
-                        prsactx->client_version, prsactx->alt_version);
+                        prsactx->client_version, prsactx->alt_version,
+                        ossl_rsa_get0_propq(prsactx->rsa));
         }
         OPENSSL_free(tbuf);
     } else {

--- a/providers/implementations/ciphers/cipher_aes_cbc_hmac_sha1_hw.c
+++ b/providers/implementations/ciphers/cipher_aes_cbc_hmac_sha1_hw.c
@@ -143,7 +143,8 @@ static size_t tls1_multi_block_encrypt(void *vctx,
 #  endif
 
     /* ask for IVs in bulk */
-    if (RAND_bytes_ex(ctx->base.libctx, (IVs = blocks[0].c), 16 * x4) <= 0)
+    if (RAND_bytes_ex(ctx->base.libctx, (IVs = blocks[0].c), 16 * x4,
+                      ctx->base.propq) <= 0)
         return 0;
 
     mctx = (SHA1_MB_CTX *) (storage + 32 - ((size_t)storage % 32)); /* align */

--- a/providers/implementations/ciphers/cipher_aes_cbc_hmac_sha256_hw.c
+++ b/providers/implementations/ciphers/cipher_aes_cbc_hmac_sha256_hw.c
@@ -147,7 +147,8 @@ static size_t tls1_multi_block_encrypt(void *vctx,
 #  endif
 
     /* ask for IVs in bulk */
-    if (RAND_bytes_ex(ctx->base.libctx, (IVs = blocks[0].c), 16 * x4) <= 0)
+    if (RAND_bytes_ex(ctx->base.libctx, (IVs = blocks[0].c), 16 * x4,
+                      ctx->base.propq) <= 0)
         return 0;
 
     mctx = (SHA256_MB_CTX *) (storage + 32 - ((size_t)storage % 32)); /* align */

--- a/providers/implementations/ciphers/cipher_des.c
+++ b/providers/implementations/ciphers/cipher_des.c
@@ -115,7 +115,7 @@ static int des_generatekey(PROV_CIPHER_CTX *ctx, void *ptr)
     DES_cblock *deskey = ptr;
     size_t kl = ctx->keylen;
 
-    if (kl == 0 || RAND_priv_bytes_ex(ctx->libctx, ptr, kl) <= 0)
+    if (kl == 0 || RAND_priv_bytes_ex(ctx->libctx, ptr, kl, ctx->propq) <= 0)
         return 0;
     DES_set_odd_parity(deskey);
     return 1;

--- a/providers/implementations/ciphers/cipher_tdes_common.c
+++ b/providers/implementations/ciphers/cipher_tdes_common.c
@@ -110,7 +110,7 @@ static int tdes_generatekey(PROV_CIPHER_CTX *ctx, void *ptr)
     DES_cblock *deskey = ptr;
     size_t kl = ctx->keylen;
 
-    if (kl == 0 || RAND_priv_bytes_ex(ctx->libctx, ptr, kl) <= 0)
+    if (kl == 0 || RAND_priv_bytes_ex(ctx->libctx, ptr, kl, ctx->propq) <= 0)
         return 0;
     DES_set_odd_parity(deskey);
     if (kl >= 16)

--- a/providers/implementations/ciphers/cipher_tdes_wrap.c
+++ b/providers/implementations/ciphers/cipher_tdes_wrap.c
@@ -97,7 +97,7 @@ static int des_ede3_wrap(PROV_CIPHER_CTX *ctx, unsigned char *out,
     memcpy(out + inl + ivlen, sha1tmp, icvlen);
     OPENSSL_cleanse(sha1tmp, SHA_DIGEST_LENGTH);
     /* Generate random IV */
-    if (RAND_bytes_ex(ctx->libctx, ctx->iv, ivlen) <= 0)
+    if (RAND_bytes_ex(ctx->libctx, ctx->iv, ivlen, ctx->propq) <= 0)
         return 0;
     memcpy(out, ctx->iv, ivlen);
     /* Encrypt everything after IV in place */

--- a/providers/implementations/ciphers/ciphercommon_gcm.c
+++ b/providers/implementations/ciphers/ciphercommon_gcm.c
@@ -364,7 +364,7 @@ static int gcm_iv_generate(PROV_GCM_CTX *ctx, int offset)
         return 0;
 
     /* Use DRBG to generate random iv */
-    if (RAND_bytes_ex(ctx->libctx, ctx->iv + offset, sz) <= 0)
+    if (RAND_bytes_ex(ctx->libctx, ctx->iv + offset, sz, ctx->propq) <= 0)
         return 0;
     ctx->iv_state = IV_STATE_BUFFERED;
     ctx->iv_gen_rand = 1;
@@ -478,7 +478,8 @@ static int gcm_tls_iv_set_fixed(PROV_GCM_CTX *ctx, unsigned char *iv,
     if (len > 0)
         memcpy(ctx->iv, iv, len);
     if (ctx->enc
-        && RAND_bytes_ex(ctx->libctx, ctx->iv + len, ctx->ivlen - len) <= 0)
+        && RAND_bytes_ex(ctx->libctx, ctx->iv + len, ctx->ivlen - len,
+                         ctx->propq) <= 0)
             return 0;
     ctx->iv_gen = 1;
     ctx->iv_state = IV_STATE_BUFFERED;

--- a/providers/implementations/encode_decode/encode_key2text.c
+++ b/providers/implementations/encode_decode/encode_key2text.c
@@ -417,7 +417,7 @@ static int ec_param_explicit_gen_to_text(BIO *out, const EC_GROUP *group,
 
 /* Print explicit parameters */
 static int ec_param_explicit_to_text(BIO *out, const EC_GROUP *group,
-                                     OSSL_LIB_CTX *libctx)
+                                     OSSL_LIB_CTX *libctx, const char *propq)
 {
     int ret = 0, tmp_nid;
     BN_CTX *ctx = NULL;
@@ -425,7 +425,7 @@ static int ec_param_explicit_to_text(BIO *out, const EC_GROUP *group,
     const unsigned char *seed;
     size_t seed_len = 0;
 
-    ctx = BN_CTX_new_ex(libctx);
+    ctx = BN_CTX_new_ex(libctx, propq);
     if (ctx == NULL)
         return 0;
     BN_CTX_start(ctx);
@@ -458,7 +458,7 @@ err:
 }
 
 static int ec_param_to_text(BIO *out, const EC_GROUP *group,
-                            OSSL_LIB_CTX *libctx)
+                            OSSL_LIB_CTX *libctx, const char *propq)
 {
     if (EC_GROUP_get_asn1_flag(group) & OPENSSL_EC_NAMED_CURVE) {
         const char *curve_name;
@@ -475,7 +475,7 @@ static int ec_param_to_text(BIO *out, const EC_GROUP *group,
         return (curve_name == NULL
                 || BIO_printf(out, "%s: %s\n", "NIST CURVE", curve_name) > 0);
     } else {
-        return ec_param_explicit_to_text(out, group, libctx);
+        return ec_param_explicit_to_text(out, group, libctx, propq);
     }
 }
 
@@ -539,7 +539,8 @@ static int ec_to_text(BIO *out, const void *key, int selection)
         && !print_labeled_buf(out, "pub:", pub, pub_len))
         goto err;
     if ((selection & OSSL_KEYMGMT_SELECT_DOMAIN_PARAMETERS) != 0)
-        ret = ec_param_to_text(out, group, ossl_ec_key_get_libctx(ec));
+        ret = ec_param_to_text(out, group, ossl_ec_key_get_libctx(ec),
+                               ossl_ec_key_get0_propq(ec));
 err:
     OPENSSL_clear_free(priv, priv_len);
     OPENSSL_free(pub);

--- a/providers/implementations/include/prov/ciphercommon.h
+++ b/providers/implementations/include/prov/ciphercommon.h
@@ -93,6 +93,7 @@ struct prov_cipher_ctx_st {
     const PROV_CIPHER_HW *hw; /* hardware specific functions */
     const void *ks; /* Pointer to algorithm specific key data */
     OSSL_LIB_CTX *libctx;
+    char *propq;
 };
 
 struct prov_cipher_hw_st {

--- a/providers/implementations/include/prov/ciphercommon_gcm.h
+++ b/providers/implementations/include/prov/ciphercommon_gcm.h
@@ -73,6 +73,7 @@ typedef struct prov_gcm_ctx_st {
     unsigned char buf[AES_BLOCK_SIZE]; /* Buffer of partial blocks processed via update calls */
 
     OSSL_LIB_CTX *libctx;    /* needed for rand calls */
+    const char *propq;
     const PROV_GCM_HW *hw;  /* hardware specific methods */
     GCM128_CONTEXT gcm;
     ctr128_f ctr;

--- a/providers/implementations/kem/rsa_kem.c
+++ b/providers/implementations/kem/rsa_kem.c
@@ -205,7 +205,8 @@ static int rsasve_gen_rand_bytes(RSA *rsa_pub,
     BN_CTX *bnctx;
     BIGNUM *z, *nminus3;
 
-    bnctx = BN_CTX_secure_new_ex(ossl_rsa_get0_libctx(rsa_pub));
+    bnctx = BN_CTX_secure_new_ex(ossl_rsa_get0_libctx(rsa_pub),
+                                 ossl_rsa_get0_propq(rsa_pub));
     if (bnctx == NULL)
         return 0;
 

--- a/providers/implementations/keymgmt/dh_kmgmt.c
+++ b/providers/implementations/keymgmt/dh_kmgmt.c
@@ -51,6 +51,7 @@ static OSSL_FUNC_keymgmt_export_types_fn dh_export_types;
 
 struct dh_gen_ctx {
     OSSL_LIB_CTX *libctx;
+    char *propq;
 
     FFC_PARAMS *ffc_params;
     int selection;
@@ -99,7 +100,7 @@ static void *dh_newdata(void *provctx)
     DH *dh = NULL;
 
     if (ossl_prov_is_running()) {
-        dh = ossl_dh_new_ex(PROV_LIBCTX_OF(provctx));
+        dh = ossl_dh_new_ex(PROV_LIBCTX_OF(provctx), NULL);
         if (dh != NULL) {
             DH_clear_flags(dh, DH_FLAG_TYPE_MASK);
             DH_set_flags(dh, DH_FLAG_TYPE_DH);
@@ -112,7 +113,7 @@ static void *dhx_newdata(void *provctx)
 {
     DH *dh = NULL;
 
-    dh = ossl_dh_new_ex(PROV_LIBCTX_OF(provctx));
+    dh = ossl_dh_new_ex(PROV_LIBCTX_OF(provctx), NULL);
     if (dh != NULL) {
         DH_clear_flags(dh, DH_FLAG_TYPE_MASK);
         DH_set_flags(dh, DH_FLAG_TYPE_DHX);
@@ -608,12 +609,12 @@ static void *dh_gen(void *genctx, OSSL_CALLBACK *osslcb, void *cbarg)
             gctx->group_nid = ossl_dh_get_named_group_uid_from_size(gctx->pbits);
         if (gctx->group_nid == NID_undef)
             return NULL;
-        dh = ossl_dh_new_by_nid_ex(gctx->libctx, gctx->group_nid);
+        dh = ossl_dh_new_by_nid_ex(gctx->libctx, gctx->group_nid, gctx->propq);
         if (dh == NULL)
             return NULL;
         ffc = ossl_dh_get0_params(dh);
     } else {
-        dh = ossl_dh_new_ex(gctx->libctx);
+        dh = ossl_dh_new_ex(gctx->libctx, gctx->propq);
         if (dh == NULL)
             return NULL;
         ffc = ossl_dh_get0_params(dh);

--- a/providers/implementations/keymgmt/dsa_kmgmt.c
+++ b/providers/implementations/keymgmt/dsa_kmgmt.c
@@ -117,7 +117,7 @@ static void *dsa_newdata(void *provctx)
 {
     if (!ossl_prov_is_running())
         return NULL;
-    return ossl_dsa_new(PROV_LIBCTX_OF(provctx));
+    return ossl_dsa_new(PROV_LIBCTX_OF(provctx), NULL);
 }
 
 static void dsa_freedata(void *keydata)
@@ -514,7 +514,7 @@ static void *dsa_gen(void *genctx, OSSL_CALLBACK *osslcb, void *cbarg)
 
     if (!ossl_prov_is_running() || gctx == NULL)
         return NULL;
-    dsa = ossl_dsa_new(gctx->libctx);
+    dsa = ossl_dsa_new(gctx->libctx, gctx->mdprops);
     if (dsa == NULL)
         return NULL;
 

--- a/providers/implementations/keymgmt/ec_kmgmt.c
+++ b/providers/implementations/keymgmt/ec_kmgmt.c
@@ -131,10 +131,10 @@ int key_to_params(const EC_KEY *eckey, OSSL_PARAM_BLD *tmpl,
          * EC_POINT_point2buf() can generate random numbers in some
          * implementations so we need to ensure we use the correct libctx.
          */
-        bnctx = BN_CTX_new_ex(ossl_ec_key_get_libctx(eckey));
+        bnctx = BN_CTX_new_ex(ossl_ec_key_get_libctx(eckey),
+                              ossl_ec_key_get0_propq(eckey));
         if (bnctx == NULL)
             goto err;
-
 
         /* If we are doing a get then check first before decoding the point */
         if (tmpl == NULL) {
@@ -314,7 +314,8 @@ static int ec_match(const void *keydata1, const void *keydata2, int selection)
     if (!ossl_prov_is_running())
         return 0;
 
-    ctx = BN_CTX_new_ex(ossl_ec_key_get_libctx(ec1));
+    ctx = BN_CTX_new_ex(ossl_ec_key_get_libctx(ec1),
+                        ossl_ec_key_get0_propq(ec1));
     if (ctx == NULL)
         return 0;
 
@@ -451,7 +452,8 @@ int ec_export(void *keydata, int selection, OSSL_CALLBACK *param_cb,
         return 0;
 
     if ((selection & OSSL_KEYMGMT_SELECT_DOMAIN_PARAMETERS) != 0) {
-        bnctx = BN_CTX_new_ex(ossl_ec_key_get_libctx(ec));
+        bnctx = BN_CTX_new_ex(ossl_ec_key_get_libctx(ec),
+                              ossl_ec_key_get0_propq(ec));
         if (bnctx == NULL) {
             ok = 0;
             goto end;
@@ -614,7 +616,7 @@ int common_get_params(void *key, OSSL_PARAM params[], int sm2)
     libctx = ossl_ec_key_get_libctx(eck);
     propq = ossl_ec_key_get0_propq(eck);
 
-    bnctx = BN_CTX_new_ex(libctx);
+    bnctx = BN_CTX_new_ex(libctx, propq);
     if (bnctx == NULL)
         return 0;
     BN_CTX_start(bnctx);
@@ -780,7 +782,8 @@ int ec_set_params(void *key, const OSSL_PARAM params[])
 
     p = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_ENCODED_PUBLIC_KEY);
     if (p != NULL) {
-        BN_CTX *ctx = BN_CTX_new_ex(ossl_ec_key_get_libctx(key));
+        BN_CTX *ctx = BN_CTX_new_ex(ossl_ec_key_get_libctx(key),
+                                    ossl_ec_key_get0_propq(key));
         int ret = 1;
 
         if (ctx == NULL
@@ -844,7 +847,8 @@ int sm2_validate(const void *keydata, int selection, int checktype)
     if (!ossl_prov_is_running())
         return 0;
 
-    ctx = BN_CTX_new_ex(ossl_ec_key_get_libctx(eck));
+    ctx = BN_CTX_new_ex(ossl_ec_key_get_libctx(eck),
+                        ossl_ec_key_get0_propq(eck));
     if  (ctx == NULL)
         return 0;
 
@@ -883,7 +887,8 @@ int ec_validate(const void *keydata, int selection, int checktype)
     if (!ossl_prov_is_running())
         return 0;
 
-    ctx = BN_CTX_new_ex(ossl_ec_key_get_libctx(eck));
+    ctx = BN_CTX_new_ex(ossl_ec_key_get_libctx(eck),
+                        ossl_ec_key_get0_propq(eck));
     if  (ctx == NULL)
         return 0;
 

--- a/providers/implementations/keymgmt/ecx_kmgmt.c
+++ b/providers/implementations/keymgmt/ecx_kmgmt.c
@@ -560,7 +560,7 @@ static void *ecx_gen(struct ecx_gen_ctx *gctx)
         ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
         goto err;
     }
-    if (RAND_priv_bytes_ex(gctx->libctx, privkey, key->keylen) <= 0)
+    if (RAND_priv_bytes_ex(gctx->libctx, privkey, key->keylen, gctx->propq) <= 0)
         goto err;
     switch (gctx->type) {
     case ECX_KEY_TYPE_X25519:
@@ -808,7 +808,8 @@ static void *s390x_ecx_keygen25519(struct ecx_gen_ctx *gctx)
         goto err;
     }
 
-    if (RAND_priv_bytes_ex(gctx->libctx, privkey, X25519_KEYLEN) <= 0)
+    if (RAND_priv_bytes_ex(gctx->libctx, privkey, X25519_KEYLEN,
+                           gctx->propq) <= 0)
         goto err;
 
     privkey[0] &= 248;
@@ -854,7 +855,7 @@ static void *s390x_ecx_keygen448(struct ecx_gen_ctx *gctx)
         goto err;
     }
 
-    if (RAND_priv_bytes_ex(gctx->libctx, privkey, X448_KEYLEN) <= 0)
+    if (RAND_priv_bytes_ex(gctx->libctx, privkey, X448_KEYLEN, gctx->propq) <= 0)
         goto err;
 
     privkey[0] &= 252;
@@ -906,7 +907,8 @@ static void *s390x_ecd_keygen25519(struct ecx_gen_ctx *gctx)
         goto err;
     }
 
-    if (RAND_priv_bytes_ex(gctx->libctx, privkey, ED25519_KEYLEN) <= 0)
+    if (RAND_priv_bytes_ex(gctx->libctx, privkey, ED25519_KEYLEN,
+                           gctx->propq) <= 0)
         goto err;
 
     sha = EVP_MD_fetch(gctx->libctx, "SHA512", gctx->propq);
@@ -976,7 +978,8 @@ static void *s390x_ecd_keygen448(struct ecx_gen_ctx *gctx)
     shake = EVP_MD_fetch(gctx->libctx, "SHAKE256", gctx->propq);
     if (shake == NULL)
         goto err;
-    if (RAND_priv_bytes_ex(gctx->libctx, privkey, ED448_KEYLEN) <= 0)
+    if (RAND_priv_bytes_ex(gctx->libctx, privkey, ED448_KEYLEN,
+                           gctx->propq) <= 0)
         goto err;
 
     hashctx = EVP_MD_CTX_new();

--- a/providers/implementations/keymgmt/rsa_kmgmt.c
+++ b/providers/implementations/keymgmt/rsa_kmgmt.c
@@ -80,7 +80,7 @@ static void *rsa_newdata(void *provctx)
     if (!ossl_prov_is_running())
         return NULL;
 
-    rsa = ossl_rsa_new_with_ctx(libctx);
+    rsa = ossl_rsa_new_with_ctx(libctx, NULL);
     if (rsa != NULL) {
         RSA_clear_flags(rsa, RSA_FLAG_TYPE_MASK);
         RSA_set_flags(rsa, RSA_FLAG_TYPE_RSA);
@@ -96,7 +96,7 @@ static void *rsapss_newdata(void *provctx)
     if (!ossl_prov_is_running())
         return NULL;
 
-    rsa = ossl_rsa_new_with_ctx(libctx);
+    rsa = ossl_rsa_new_with_ctx(libctx, NULL);
     if (rsa != NULL) {
         RSA_clear_flags(rsa, RSA_FLAG_TYPE_MASK);
         RSA_set_flags(rsa, RSA_FLAG_TYPE_RSASSAPSS);
@@ -549,7 +549,7 @@ static void *rsa_gen(void *genctx, OSSL_CALLBACK *osslcb, void *cbarg)
         return NULL;
     }
 
-    if ((rsa_tmp = ossl_rsa_new_with_ctx(gctx->libctx)) == NULL)
+    if ((rsa_tmp = ossl_rsa_new_with_ctx(gctx->libctx, gctx->propq)) == NULL)
         return NULL;
 
     gctx->cb = osslcb;

--- a/ssl/record/ssl3_record.c
+++ b/ssl/record/ssl3_record.c
@@ -996,7 +996,7 @@ int tls1_enc(SSL *s, SSL3_RECORD *recs, size_t n_recs, int sending,
                         SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
                         return 0;
                     } else if (RAND_bytes_ex(s->ctx->libctx, recs[ctr].input,
-                                             ivlen) <= 0) {
+                                             ivlen, s->ctx->propq) <= 0) {
                         SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
                         return 0;
                     }

--- a/ssl/record/tls_pad.c
+++ b/ssl/record/tls_pad.c
@@ -29,7 +29,8 @@ static int ssl3_cbc_copy_mac(size_t *reclen,
                              size_t block_size,
                              size_t mac_size,
                              size_t good,
-                             OSSL_LIB_CTX *libctx);
+                             OSSL_LIB_CTX *libctx,
+                             const char *propq);
 
 int ssl3_cbc_remove_padding_and_mac(size_t *reclen,
                                     size_t origreclen,
@@ -37,7 +38,7 @@ int ssl3_cbc_remove_padding_and_mac(size_t *reclen,
                                     unsigned char **mac,
                                     int *alloced,
                                     size_t block_size, size_t mac_size,
-                                    OSSL_LIB_CTX *libctx);
+                                    OSSL_LIB_CTX *libctx, const char *propq);
 
 int tls1_cbc_remove_padding_and_mac(size_t *reclen,
                                     size_t origreclen,
@@ -46,7 +47,7 @@ int tls1_cbc_remove_padding_and_mac(size_t *reclen,
                                     int *alloced,
                                     size_t block_size, size_t mac_size,
                                     int aead,
-                                    OSSL_LIB_CTX *libctx);
+                                    OSSL_LIB_CTX *libctx, const char *propq);
 
 /*-
  * ssl3_cbc_remove_padding removes padding from the decrypted, SSLv3, CBC
@@ -71,7 +72,7 @@ int ssl3_cbc_remove_padding_and_mac(size_t *reclen,
                                     unsigned char **mac,
                                     int *alloced,
                                     size_t block_size, size_t mac_size,
-                                    OSSL_LIB_CTX *libctx)
+                                    OSSL_LIB_CTX *libctx, const char *propq)
 {
     size_t padding_length;
     size_t good;
@@ -90,7 +91,7 @@ int ssl3_cbc_remove_padding_and_mac(size_t *reclen,
     *reclen -= good & (padding_length + 1);
 
     return ssl3_cbc_copy_mac(reclen, origreclen, recdata, mac, alloced,
-                             block_size, mac_size, good, libctx);
+                             block_size, mac_size, good, libctx, propq);
 }
 
 /*-
@@ -117,7 +118,7 @@ int tls1_cbc_remove_padding_and_mac(size_t *reclen,
                                     int *alloced,
                                     size_t block_size, size_t mac_size,
                                     int aead,
-                                    OSSL_LIB_CTX *libctx)
+                                    OSSL_LIB_CTX *libctx, const char *propq)
 {
     size_t good = -1;
     size_t padding_length, to_check, i;
@@ -176,7 +177,7 @@ int tls1_cbc_remove_padding_and_mac(size_t *reclen,
     }
 
     return ssl3_cbc_copy_mac(reclen, origreclen, recdata, mac, alloced,
-                             block_size, mac_size, good, libctx);
+                             block_size, mac_size, good, libctx, propq);
 }
 
 /*-
@@ -204,7 +205,8 @@ static int ssl3_cbc_copy_mac(size_t *reclen,
                              size_t block_size,
                              size_t mac_size,
                              size_t good,
-                             OSSL_LIB_CTX *libctx)
+                             OSSL_LIB_CTX *libctx,
+                             const char *propq)
 {
 #if defined(CBC_MAC_ROTATE_IN_PLACE)
     unsigned char rotated_mac_buf[64 + EVP_MAX_MD_SIZE];
@@ -253,7 +255,7 @@ static int ssl3_cbc_copy_mac(size_t *reclen,
     }
 
     /* Create the random MAC we will emit if padding is bad */
-    if (!RAND_bytes_ex(libctx, randmac, mac_size))
+    if (!RAND_bytes_ex(libctx, randmac, mac_size, propq))
         return 0;
 
     if (!ossl_assert(mac != NULL && alloced != NULL))

--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -4549,9 +4549,9 @@ int ssl_fill_hello_random(SSL *s, int server, unsigned char *result, size_t len,
         unsigned char *p = result;
 
         l2n(Time, p);
-        ret = RAND_bytes_ex(s->ctx->libctx, p, len - 4);
+        ret = RAND_bytes_ex(s->ctx->libctx, p, len - 4, s->ctx->propq);
     } else {
-        ret = RAND_bytes_ex(s->ctx->libctx, result, len);
+        ret = RAND_bytes_ex(s->ctx->libctx, result, len, s->ctx->propq);
     }
 
     if (ret > 0) {

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -3227,15 +3227,17 @@ SSL_CTX *SSL_CTX_new_ex(OSSL_LIB_CTX *libctx, const char *propq,
 
     /* Setup RFC5077 ticket keys */
     if ((RAND_bytes_ex(libctx, ret->ext.tick_key_name,
-                       sizeof(ret->ext.tick_key_name)) <= 0)
+                       sizeof(ret->ext.tick_key_name), propq) <= 0)
         || (RAND_priv_bytes_ex(libctx, ret->ext.secure->tick_hmac_key,
-                               sizeof(ret->ext.secure->tick_hmac_key)) <= 0)
+                               sizeof(ret->ext.secure->tick_hmac_key),
+                               propq) <= 0)
         || (RAND_priv_bytes_ex(libctx, ret->ext.secure->tick_aes_key,
-                               sizeof(ret->ext.secure->tick_aes_key)) <= 0))
+                               sizeof(ret->ext.secure->tick_aes_key),
+                               propq) <= 0))
         ret->options |= SSL_OP_NO_TICKET;
 
     if (RAND_priv_bytes_ex(libctx, ret->ext.cookie_hmac_key,
-                           sizeof(ret->ext.cookie_hmac_key)) <= 0)
+                           sizeof(ret->ext.cookie_hmac_key), propq) <= 0)
         goto err;
 
 #ifndef OPENSSL_NO_SRP

--- a/ssl/ssl_sess.c
+++ b/ssl/ssl_sess.c
@@ -259,7 +259,7 @@ static int def_generate_session_id(SSL *ssl, unsigned char *id,
 {
     unsigned int retry = 0;
     do
-        if (RAND_bytes_ex(ssl->ctx->libctx, id, *id_len) <= 0)
+        if (RAND_bytes_ex(ssl->ctx->libctx, id, *id_len, ssl->ctx->propq) <= 0)
             return 0;
     while (SSL_has_matching_session_id(ssl, id, *id_len) &&
            (++retry < MAX_SESS_ID_ATTEMPTS)) ;

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -1191,7 +1191,7 @@ int tls_construct_client_hello(SSL *s, WPACKET *pkt)
             session_id = s->tmp_session_id;
             if (s->hello_retry_request == SSL_HRR_NONE
                     && RAND_bytes_ex(s->ctx->libctx, s->tmp_session_id,
-                                     sess_id_len) <= 0) {
+                                     sess_id_len, s->ctx->propq) <= 0) {
                 SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
                 return 0;
             }
@@ -2846,7 +2846,8 @@ static int tls_construct_cke_rsa(SSL *s, WPACKET *pkt)
     pms[0] = s->client_version >> 8;
     pms[1] = s->client_version & 0xff;
     /* TODO(size_t): Convert this function */
-    if (RAND_bytes_ex(s->ctx->libctx, pms + 2, (int)(pmslen - 2)) <= 0) {
+    if (RAND_bytes_ex(s->ctx->libctx, pms + 2, (int)(pmslen - 2),
+                      s->ctx->propq) <= 0) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_MALLOC_FAILURE);
         goto err;
     }
@@ -3053,7 +3054,8 @@ static int tls_construct_cke_gost(SSL *s, WPACKET *pkt)
         /* Generate session key
          * TODO(size_t): Convert this function
          */
-        || RAND_bytes_ex(s->ctx->libctx, pms, (int)pmslen) <= 0) {
+        || RAND_bytes_ex(s->ctx->libctx, pms, (int)pmslen,
+                         s->ctx->propq) <= 0) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
         goto err;
     };
@@ -3178,7 +3180,7 @@ static int tls_construct_cke_gost18(SSL *s, WPACKET *pkt)
         goto err;
     }
 
-    if (RAND_bytes_ex(s->ctx->libctx, pms, (int)pmslen) <= 0) {
+    if (RAND_bytes_ex(s->ctx->libctx, pms, (int)pmslen, s->ctx->propq) <= 0) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
         goto err;
     }

--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -2726,7 +2726,7 @@ int tls_construct_certificate_request(SSL *s, WPACKET *pkt)
             s->pha_context_len = 32;
             if ((s->pha_context = OPENSSL_malloc(s->pha_context_len)) == NULL
                     || RAND_bytes_ex(s->ctx->libctx, s->pha_context,
-                                     s->pha_context_len) <= 0
+                                     s->pha_context_len, s->ctx->propq) <= 0
                     || !WPACKET_sub_memcpy_u8(pkt, s->pha_context, s->pha_context_len)) {
                 SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
                 return 0;
@@ -3763,7 +3763,7 @@ static int construct_stateless_ticket(SSL *s, WPACKET *pkt, uint32_t age_add,
         }
 
         iv_len = EVP_CIPHER_iv_length(cipher);
-        if (RAND_bytes_ex(s->ctx->libctx, iv, iv_len) <= 0
+        if (RAND_bytes_ex(s->ctx->libctx, iv, iv_len, s->ctx->propq) <= 0
                 || !EVP_EncryptInit_ex(ctx, cipher, NULL,
                                        tctx->ext.secure->tick_aes_key, iv)
                 || !ssl_hmac_init(hctx, tctx->ext.secure->tick_hmac_key,
@@ -3890,7 +3890,7 @@ int tls_construct_new_session_ticket(SSL *s, WPACKET *pkt)
             goto err;
         }
         if (RAND_bytes_ex(s->ctx->libctx, age_add_u.age_add_c,
-                          sizeof(age_add_u)) <= 0) {
+                          sizeof(age_add_u), s->ctx->propq) <= 0) {
             SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
             goto err;
         }

--- a/ssl/tls_srp.c
+++ b/ssl/tls_srp.c
@@ -203,7 +203,7 @@ int ssl_srp_server_param_with_username_intern(SSL *s, int *ad)
         (s->srp_ctx.s == NULL) || (s->srp_ctx.v == NULL))
         return SSL3_AL_FATAL;
 
-    if (RAND_priv_bytes_ex(s->ctx->libctx, b, sizeof(b)) <= 0)
+    if (RAND_priv_bytes_ex(s->ctx->libctx, b, sizeof(b), s->ctx->propq) <= 0)
         return SSL3_AL_FATAL;
     s->srp_ctx.b = BN_bin2bn(b, sizeof(b), NULL);
     OPENSSL_cleanse(b, sizeof(b));
@@ -420,7 +420,7 @@ int ssl_srp_calc_a_param_intern(SSL *s)
 {
     unsigned char rnd[SSL_MAX_MASTER_KEY_LENGTH];
 
-    if (RAND_priv_bytes_ex(s->ctx->libctx, rnd, sizeof(rnd)) <= 0)
+    if (RAND_priv_bytes_ex(s->ctx->libctx, rnd, sizeof(rnd), s->ctx->propq) <= 0)
         return 0;
     s->srp_ctx.a = BN_bin2bn(rnd, sizeof(rnd), s->srp_ctx.a);
     OPENSSL_cleanse(rnd, sizeof(rnd));

--- a/test/acvp_test.c
+++ b/test/acvp_test.c
@@ -531,7 +531,7 @@ static int dsa_pqver_test(int id)
     EVP_PKEY *param_key = NULL;
     const struct dsa_pqver_st *tst = &dsa_pqver_data[id];
 
-    if (!TEST_ptr(bn_ctx = BN_CTX_new_ex(libctx))
+    if (!TEST_ptr(bn_ctx = BN_CTX_new_ex(libctx, NULL))
         || !TEST_true(dsa_create_pkey(&param_key, tst->p, tst->p_len,
                                       tst->q, tst->q_len, NULL, 0,
                                       tst->seed, tst->seed_len, tst->counter,
@@ -988,7 +988,7 @@ static int dh_safe_prime_keyver_test(int id)
     EVP_PKEY *pkey = NULL;
     const struct dh_safe_prime_keyver_st *tst = &dh_safe_prime_keyver_data[id];
 
-    if (!TEST_ptr(bn_ctx = BN_CTX_new_ex(libctx))
+    if (!TEST_ptr(bn_ctx = BN_CTX_new_ex(libctx, NULL))
         || !TEST_true(dh_create_pkey(&pkey, tst->group_name,
                                      tst->pub, tst->pub_len,
                                      tst->priv, tst->priv_len, bn_ctx, 1))

--- a/test/cmp_client_test.c
+++ b/test/cmp_client_test.c
@@ -373,7 +373,7 @@ int setup_tests(void)
             || !TEST_ptr(server_cert = load_cert_pem(server_cert_f, libctx))
             || !TEST_ptr(client_key = load_pkey_pem(client_key_f, libctx))
             || !TEST_ptr(client_cert = load_cert_pem(client_cert_f, libctx))
-            || !TEST_int_eq(1, RAND_bytes_ex(libctx, ref, sizeof(ref)))) {
+            || !TEST_int_eq(1, RAND_bytes_ex(libctx, ref, sizeof(ref), NULL))) {
         cleanup_tests();
         return 0;
     }

--- a/test/cmp_msg_test.c
+++ b/test/cmp_msg_test.c
@@ -149,7 +149,7 @@ static int test_cmp_create_ir_protection_set(void)
     fixture->bodytype = OSSL_CMP_PKIBODY_IR;
     fixture->err_code = -1;
     fixture->expected = 1;
-    if (!TEST_int_eq(1, RAND_bytes_ex(libctx, secret, sizeof(secret)))
+    if (!TEST_int_eq(1, RAND_bytes_ex(libctx, secret, sizeof(secret), NULL))
             || !TEST_true(SET_OPT_UNPROTECTED_SEND(ctx, 0))
             || !TEST_true(set1_newPkey(ctx, newkey))
             || !TEST_true(OSSL_CMP_CTX_set1_secretValue(ctx, secret,
@@ -566,7 +566,7 @@ int setup_tests(void)
 
     if (!TEST_ptr(newkey = load_pkey_pem(newkey_f, libctx))
             || !TEST_ptr(cert = load_cert_pem(server_cert_f, libctx))
-            || !TEST_int_eq(1, RAND_bytes_ex(libctx, ref, sizeof(ref)))) {
+            || !TEST_int_eq(1, RAND_bytes_ex(libctx, ref, sizeof(ref), NULL))) {
         cleanup_tests();
         return 0;
     }

--- a/test/drbgtest.c
+++ b/test/drbgtest.c
@@ -64,12 +64,12 @@ static int gen_bytes(EVP_RAND_CTX *drbg, unsigned char *buf, int num)
 
 static int rand_bytes(unsigned char *buf, int num)
 {
-    return gen_bytes(RAND_get0_public(NULL), buf, num);
+    return gen_bytes(RAND_get0_public(NULL, NULL), buf, num);
 }
 
 static int rand_priv_bytes(unsigned char *buf, int num)
 {
-    return gen_bytes(RAND_get0_private(NULL), buf, num);
+    return gen_bytes(RAND_get0_private(NULL, NULL), buf, num);
 }
 
 
@@ -521,9 +521,9 @@ static int test_rand_fork_safety(int i)
     EVP_RAND_CTX *primary, *public, *private;
 
     /* All three DRBGs should be non-null */
-    if (!TEST_ptr(primary = RAND_get0_primary(NULL))
-        || !TEST_ptr(public = RAND_get0_public(NULL))
-        || !TEST_ptr(private = RAND_get0_private(NULL)))
+    if (!TEST_ptr(primary = RAND_get0_primary(NULL, NULL))
+        || !TEST_ptr(public = RAND_get0_public(NULL, NULL))
+        || !TEST_ptr(private = RAND_get0_private(NULL, NULL)))
         return 0;
 
     /* run the actual test */
@@ -560,9 +560,9 @@ static int test_rand_reseed(void)
 #endif
 
     /* All three DRBGs should be non-null */
-    if (!TEST_ptr(primary = RAND_get0_primary(NULL))
-        || !TEST_ptr(public = RAND_get0_public(NULL))
-        || !TEST_ptr(private = RAND_get0_private(NULL)))
+    if (!TEST_ptr(primary = RAND_get0_primary(NULL, NULL))
+        || !TEST_ptr(public = RAND_get0_public(NULL, NULL))
+        || !TEST_ptr(private = RAND_get0_private(NULL, NULL)))
         return 0;
 
     /* There should be three distinct DRBGs, two of them chained to primary */
@@ -700,8 +700,8 @@ static void run_multi_thread_test(void)
     time_t start = time(NULL);
     EVP_RAND_CTX *public = NULL, *private = NULL;
 
-    if (!TEST_ptr(public = RAND_get0_public(NULL))
-            || !TEST_ptr(private = RAND_get0_private(NULL))
+    if (!TEST_ptr(public = RAND_get0_public(NULL, NULL))
+            || !TEST_ptr(private = RAND_get0_private(NULL, NULL))
             || !TEST_true(set_reseed_time_interval(private, 1))
             || !TEST_true(set_reseed_time_interval(public, 1))) {
         multi_thread_rand_bytes_succeeded = 0;

--- a/test/ecdsatest.c
+++ b/test/ecdsatest.c
@@ -357,7 +357,7 @@ int setup_tests(void)
 #ifdef OPENSSL_NO_EC
     TEST_note("Elliptic curves are disabled.");
 #else
-    fake_rand = fake_rand_start(NULL);
+    fake_rand = fake_rand_start(NULL, NULL);
     if (fake_rand == NULL)
         return 0;
 

--- a/test/endecode_test.c
+++ b/test/endecode_test.c
@@ -1181,7 +1181,7 @@ int setup_tests(void)
     };
 
 #ifndef OPENSSL_NO_EC
-    if (!TEST_ptr(bnctx = BN_CTX_new_ex(NULL))
+    if (!TEST_ptr(bnctx = BN_CTX_new_ex(NULL, NULL))
         || !TEST_ptr(bld_prime_nc = OSSL_PARAM_BLD_new())
         || !TEST_ptr(bld_prime = OSSL_PARAM_BLD_new())
         || !create_ec_explicit_prime_params_namedcurve(bld_prime_nc)

--- a/test/ffc_internal_test.c
+++ b/test/ffc_internal_test.c
@@ -199,35 +199,35 @@ static int ffc_params_validate_g_unverified_test(void)
     ossl_ffc_set_digest(&params, "SHA256", NULL);
 
     if (!TEST_false(ossl_ffc_params_FIPS186_4_validate(NULL, &params,
-                                                       FFC_PARAM_TYPE_DSA,
+                                                       FFC_PARAM_TYPE_DSA, NULL,
                                                        &res, NULL)))
         goto err;
 
     ossl_ffc_params_set0_pqg(&params, p, q, g);
     g = NULL;
     if (!TEST_true(ossl_ffc_params_FIPS186_4_validate(NULL, &params,
-                                                      FFC_PARAM_TYPE_DSA,
+                                                      FFC_PARAM_TYPE_DSA, NULL,
                                                       &res, NULL)))
         goto err;
 
     /* incorrect g */
     BN_add_word(g1, 1);
     if (!TEST_false(ossl_ffc_params_FIPS186_4_validate(NULL, &params,
-                                                       FFC_PARAM_TYPE_DSA,
+                                                       FFC_PARAM_TYPE_DSA, NULL,
                                                        &res, NULL)))
         goto err;
 
     /* fail if g < 2 */
     BN_set_word(g1, 1);
     if (!TEST_false(ossl_ffc_params_FIPS186_4_validate(NULL, &params,
-                                                       FFC_PARAM_TYPE_DSA,
+                                                       FFC_PARAM_TYPE_DSA, NULL,
                                                        &res, NULL)))
         goto err;
 
     BN_copy(g1, p1);
     /* Fail if g >= p */
     if (!TEST_false(ossl_ffc_params_FIPS186_4_validate(NULL, &params,
-                                                       FFC_PARAM_TYPE_DSA,
+                                                       FFC_PARAM_TYPE_DSA, NULL,
                                                        &res, NULL)))
         goto err;
 
@@ -263,7 +263,7 @@ static int ffc_params_validate_pq_test(void)
     ossl_ffc_set_digest(&params, "SHA224", NULL);
 
     if (!TEST_false(ossl_ffc_params_FIPS186_4_validate(NULL, &params,
-                                                       FFC_PARAM_TYPE_DSA,
+                                                       FFC_PARAM_TYPE_DSA, NULL,
                                                        &res, NULL)))
         goto err;
 
@@ -274,7 +274,7 @@ static int ffc_params_validate_pq_test(void)
                                         sizeof(dsa_2048_224_sha224_seed),
                                         dsa_2048_224_sha224_counter);
     if (!TEST_true(ossl_ffc_params_FIPS186_4_validate(NULL, &params,
-                                                      FFC_PARAM_TYPE_DSA,
+                                                      FFC_PARAM_TYPE_DSA, NULL,
                                                       &res, NULL)))
         goto err;
 
@@ -283,7 +283,7 @@ static int ffc_params_validate_pq_test(void)
                                         sizeof(dsa_2048_224_sha224_seed),
                                         1);
     if (!TEST_false(ossl_ffc_params_FIPS186_4_validate(NULL, &params,
-                                                       FFC_PARAM_TYPE_DSA,
+                                                       FFC_PARAM_TYPE_DSA, NULL,
                                                        &res, NULL)))
         goto err;
 
@@ -292,7 +292,7 @@ static int ffc_params_validate_pq_test(void)
                                         sizeof(dsa_2048_224_sha224_seed)-1,
                                         dsa_2048_224_sha224_counter);
     if (!TEST_false(ossl_ffc_params_FIPS186_4_validate(NULL, &params,
-                                                       FFC_PARAM_TYPE_DSA,
+                                                       FFC_PARAM_TYPE_DSA, NULL,
                                                        &res, NULL)))
         goto err;
 
@@ -301,7 +301,7 @@ static int ffc_params_validate_pq_test(void)
                                         sizeof(dsa_2048_224_sha224_bad_seed),
                                         dsa_2048_224_sha224_counter);
     if (!TEST_false(ossl_ffc_params_FIPS186_4_validate(NULL, &params,
-                                                       FFC_PARAM_TYPE_DSA,
+                                                       FFC_PARAM_TYPE_DSA, NULL,
                                                        &res, NULL)))
         goto err;
 
@@ -322,13 +322,13 @@ static int ffc_params_validate_pq_test(void)
                                         dsa_3072_256_sha512_counter);
     /* Q doesn't div P-1 */
     if (!TEST_false(ossl_ffc_params_FIPS186_4_validate(NULL, &params,
-                                                       FFC_PARAM_TYPE_DSA,
+                                                       FFC_PARAM_TYPE_DSA, NULL,
                                                        &res, NULL)))
         goto err;
 
     /* Bad L/N for FIPS DH */
     if (!TEST_false(ossl_ffc_params_FIPS186_4_validate(NULL, &params,
-                                                       FFC_PARAM_TYPE_DH,
+                                                       FFC_PARAM_TYPE_DH, NULL,
                                                        &res, NULL)))
         goto err;
 
@@ -350,10 +350,11 @@ static int ffc_params_gen_test(void)
     ossl_ffc_params_init(&params);
     if (!TEST_true(ossl_ffc_params_FIPS186_4_generate(NULL, &params,
                                                       FFC_PARAM_TYPE_DH,
-                                                      2048, 256, &res, NULL)))
+                                                      2048, 256, NULL,
+                                                      &res, NULL)))
         goto err;
     if (!TEST_true(ossl_ffc_params_FIPS186_4_validate(NULL, &params,
-                                                      FFC_PARAM_TYPE_DH,
+                                                      FFC_PARAM_TYPE_DH, NULL,
                                                       &res, NULL)))
         goto err;
 
@@ -372,10 +373,11 @@ static int ffc_params_gen_canonicalg_test(void)
     params.gindex = 1;
     if (!TEST_true(ossl_ffc_params_FIPS186_4_generate(NULL, &params,
                                                       FFC_PARAM_TYPE_DH,
-                                                      2048, 256, &res, NULL)))
+                                                      2048, 256, NULL,
+                                                      &res, NULL)))
         goto err;
     if (!TEST_true(ossl_ffc_params_FIPS186_4_validate(NULL, &params,
-                                                      FFC_PARAM_TYPE_DH,
+                                                      FFC_PARAM_TYPE_DH, NULL,
                                                       &res, NULL)))
         goto err;
 
@@ -399,10 +401,11 @@ static int ffc_params_fips186_2_gen_validate_test(void)
         goto err;
     if (!TEST_true(ossl_ffc_params_FIPS186_2_generate(NULL, &params,
                                                       FFC_PARAM_TYPE_DH,
-                                                      1024, 160, &res, NULL)))
+                                                      1024, 160, NULL,
+                                                      &res, NULL)))
         goto err;
     if (!TEST_true(ossl_ffc_params_FIPS186_2_validate(NULL, &params,
-                                                      FFC_PARAM_TYPE_DH,
+                                                      FFC_PARAM_TYPE_DH, NULL,
                                                       &res, NULL)))
         goto err;
 
@@ -411,7 +414,7 @@ static int ffc_params_fips186_2_gen_validate_test(void)
      * fips 186-4 given the same seed value. So validation of q will fail.
      */
     if (!TEST_false(ossl_ffc_params_FIPS186_4_validate(NULL, &params,
-                                                       FFC_PARAM_TYPE_DSA,
+                                                       FFC_PARAM_TYPE_DSA, NULL,
                                                        &res, NULL)))
         goto err;
     /* As the params are randomly generated the error is one of the following */
@@ -421,7 +424,7 @@ static int ffc_params_fips186_2_gen_validate_test(void)
     ossl_ffc_params_set_flags(&params, FFC_PARAM_FLAG_VALIDATE_G);
     /* Partially valid g test will still pass */
     if (!TEST_int_eq(ossl_ffc_params_FIPS186_4_validate(NULL, &params,
-                                                        FFC_PARAM_TYPE_DSA,
+                                                        FFC_PARAM_TYPE_DSA, NULL,
                                                         &res, NULL), 2))
         goto err;
 
@@ -455,7 +458,7 @@ static int ffc_public_validate_test(void)
         goto err;
     BN_set_negative(pub, 1);
     /* Fail if public key is negative */
-    if (!TEST_false(ossl_ffc_validate_public_key(params, pub, &res)))
+    if (!TEST_false(ossl_ffc_validate_public_key(NULL, params, pub,  NULL, &res)))
         goto err;
     if (!TEST_int_eq(FFC_ERROR_PUBKEY_TOO_SMALL, res))
         goto err;
@@ -464,25 +467,26 @@ static int ffc_public_validate_test(void)
     if (!TEST_int_eq(FFC_ERROR_PUBKEY_TOO_SMALL, res))
         goto err;
     /* Fail if public key is zero */
-    if (!TEST_false(ossl_ffc_validate_public_key(params, pub, &res)))
+    if (!TEST_false(ossl_ffc_validate_public_key(NULL, params, pub,  NULL, &res)))
         goto err;
     if (!TEST_int_eq(FFC_ERROR_PUBKEY_TOO_SMALL, res))
         goto err;
     /* Fail if public key is 1 */
-    if (!TEST_false(ossl_ffc_validate_public_key(params, BN_value_one(), &res)))
+    if (!TEST_false(ossl_ffc_validate_public_key(NULL, params, BN_value_one(),
+                                                 NULL, &res)))
         goto err;
     if (!TEST_int_eq(FFC_ERROR_PUBKEY_TOO_SMALL, res))
         goto err;
     if (!TEST_true(BN_add_word(pub, 2)))
         goto err;
     /* Pass if public key >= 2 */
-    if (!TEST_true(ossl_ffc_validate_public_key(params, pub, &res)))
+    if (!TEST_true(ossl_ffc_validate_public_key(NULL, params, pub, NULL, &res)))
         goto err;
 
     if (!TEST_ptr(BN_copy(pub, params->p)))
         goto err;
     /* Fail if public key = p */
-    if (!TEST_false(ossl_ffc_validate_public_key(params, pub, &res)))
+    if (!TEST_false(ossl_ffc_validate_public_key(NULL, params, pub, NULL, &res)))
         goto err;
     if (!TEST_int_eq(FFC_ERROR_PUBKEY_TOO_LARGE, res))
         goto err;
@@ -490,7 +494,7 @@ static int ffc_public_validate_test(void)
     if (!TEST_true(BN_sub_word(pub, 1)))
         goto err;
     /* Fail if public key = p - 1 */
-    if (!TEST_false(ossl_ffc_validate_public_key(params, pub, &res)))
+    if (!TEST_false(ossl_ffc_validate_public_key(NULL, params, pub, NULL, &res)))
         goto err;
     if (!TEST_int_eq(FFC_ERROR_PUBKEY_TOO_LARGE, res))
         goto err;
@@ -498,7 +502,7 @@ static int ffc_public_validate_test(void)
     if (!TEST_true(BN_sub_word(pub, 1)))
         goto err;
     /* Fail if public key is not related to p & q */
-    if (!TEST_false(ossl_ffc_validate_public_key(params, pub, &res)))
+    if (!TEST_false(ossl_ffc_validate_public_key(NULL, params, pub, NULL, &res)))
         goto err;
     if (!TEST_int_eq(FFC_ERROR_PUBKEY_INVALID, res))
         goto err;
@@ -506,7 +510,7 @@ static int ffc_public_validate_test(void)
     if (!TEST_true(BN_sub_word(pub, 5)))
         goto err;
     /* Pass if public key is valid */
-    if (!TEST_true(ossl_ffc_validate_public_key(params, pub, &res)))
+    if (!TEST_true(ossl_ffc_validate_public_key(NULL, params, pub, NULL, &res)))
         goto err;
 
     ret = 1;
@@ -581,7 +585,7 @@ static int ffc_private_gen_test(int index)
     DH *dh = NULL;
     BN_CTX *ctx = NULL;
 
-    if (!TEST_ptr(ctx = BN_CTX_new_ex(NULL)))
+    if (!TEST_ptr(ctx = BN_CTX_new_ex(NULL, NULL)))
         goto err;
 
     if (!TEST_ptr(priv = BN_new()))

--- a/test/sm2_internal_test.c
+++ b/test/sm2_internal_test.c
@@ -365,7 +365,7 @@ int setup_tests(void)
 #ifdef OPENSSL_NO_SM2
     TEST_note("SM2 is disabled.");
 #else
-    fake_rand = fake_rand_start(NULL);
+    fake_rand = fake_rand_start(NULL, NULL);
     if (fake_rand == NULL)
         return 0;
 

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -1216,7 +1216,7 @@ static int test_ktls_sendfile(int tls_version, const char *cipher)
         || !TEST_true(BIO_get_ktls_send(serverssl->wbio)))
         goto end;
 
-    if (!TEST_true(RAND_bytes_ex(libctx, buf, SENDFILE_SZ)))
+    if (!TEST_true(RAND_bytes_ex(libctx, buf, SENDFILE_SZ, NULL)))
         goto end;
 
     out = BIO_new_file(tmpfilename, "wb");

--- a/test/testutil.h
+++ b/test/testutil.h
@@ -567,7 +567,7 @@ uint32_t test_random(void);
 void test_random_seed(uint32_t sd);
 
 /* Fake non-secure random number generator */
-OSSL_PROVIDER *fake_rand_start(OSSL_LIB_CTX *libctx);
+OSSL_PROVIDER *fake_rand_start(OSSL_LIB_CTX *libctx, const char *propq);
 void fake_rand_finish(OSSL_PROVIDER *p);
 void fake_rand_set_callback(int (*cb)(unsigned char *out, size_t outlen));
 

--- a/test/testutil/fake_random.c
+++ b/test/testutil/fake_random.c
@@ -167,7 +167,7 @@ static int fake_rand_provider_init(const OSSL_CORE_HANDLE *handle,
     return 1;
 }
 
-OSSL_PROVIDER *fake_rand_start(OSSL_LIB_CTX *libctx)
+OSSL_PROVIDER *fake_rand_start(OSSL_LIB_CTX *libctx, const char *propq)
 {
     OSSL_PROVIDER *p;
 
@@ -178,8 +178,8 @@ OSSL_PROVIDER *fake_rand_start(OSSL_LIB_CTX *libctx)
         return NULL;
 
     /* Ensure that the fake rand is initialized. */
-    if (!TEST_ptr(RAND_get0_private(libctx))
-            || !TEST_ptr(RAND_get0_public(libctx))) {
+    if (!TEST_ptr(RAND_get0_private(libctx, propq))
+            || !TEST_ptr(RAND_get0_public(libctx, propq))) {
         OSSL_PROVIDER_unload(p);
         return NULL;
     }

--- a/test/tls-provider.c
+++ b/test/tls-provider.c
@@ -592,7 +592,7 @@ static void *xor_gen(void *genctx, OSSL_CALLBACK *osslcb, void *cbarg)
         return NULL;
 
     if ((gctx->selection & OSSL_KEYMGMT_SELECT_KEYPAIR) != 0) {
-        if (RAND_bytes_ex(gctx->libctx, key->privkey, XOR_KEY_SIZE) <= 0) {
+        if (RAND_bytes_ex(gctx->libctx, key->privkey, XOR_KEY_SIZE, NULL) <= 0) {
             OPENSSL_free(key);
             return NULL;
         }
@@ -753,7 +753,8 @@ unsigned int randomize_tls_group_id(OSSL_LIB_CTX *libctx)
     int i;
 
  retry:
-    if (!RAND_bytes_ex(libctx, (unsigned char *)&group_id, sizeof(group_id)))
+    if (!RAND_bytes_ex(libctx, (unsigned char *)&group_id, sizeof(group_id),
+                       NULL))
         return 0;
     /*
      * Ensure group_id is within the IANA Reserved for private use range


### PR DESCRIPTION
This PR relates to issue #14286

Open question:
    In this PR - How do we propagate the propq to the keymanager
    dh_newdata() recieves a libctx but does not recieve a propq,
    and then we also have import and export functionality also.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
