### PR TITLE
EVP_PKEY_CTX_get/settable_params: pass provider operation context

### DIFF
--- a/crypto/evp/asymcipher.c
+++ b/crypto/evp/asymcipher.c
@@ -452,7 +452,7 @@ const OSSL_PARAM *EVP_ASYM_CIPHER_gettable_ctx_params(const EVP_ASYM_CIPHER *cip
         return NULL;
 
     provctx = ossl_provider_ctx(EVP_ASYM_CIPHER_provider(cip));
-    return cip->gettable_ctx_params(provctx);
+    return cip->gettable_ctx_params(NULL, provctx);
 }
 
 const OSSL_PARAM *EVP_ASYM_CIPHER_settable_ctx_params(const EVP_ASYM_CIPHER *cip)
@@ -463,5 +463,5 @@ const OSSL_PARAM *EVP_ASYM_CIPHER_settable_ctx_params(const EVP_ASYM_CIPHER *cip
         return NULL;
 
     provctx = ossl_provider_ctx(EVP_ASYM_CIPHER_provider(cip));
-    return cip->settable_ctx_params(provctx);
+    return cip->settable_ctx_params(NULL, provctx);
 }

--- a/crypto/evp/exchange.c
+++ b/crypto/evp/exchange.c
@@ -478,7 +478,7 @@ const OSSL_PARAM *EVP_KEYEXCH_gettable_ctx_params(const EVP_KEYEXCH *keyexch)
         return NULL;
 
     provctx = ossl_provider_ctx(EVP_KEYEXCH_provider(keyexch));
-    return keyexch->gettable_ctx_params(provctx);
+    return keyexch->gettable_ctx_params(NULL, provctx);
 }
 
 const OSSL_PARAM *EVP_KEYEXCH_settable_ctx_params(const EVP_KEYEXCH *keyexch)
@@ -488,5 +488,5 @@ const OSSL_PARAM *EVP_KEYEXCH_settable_ctx_params(const EVP_KEYEXCH *keyexch)
     if (keyexch == NULL || keyexch->settable_ctx_params == NULL)
         return NULL;
     provctx = ossl_provider_ctx(EVP_KEYEXCH_provider(keyexch));
-    return keyexch->settable_ctx_params(provctx);
+    return keyexch->settable_ctx_params(NULL, provctx);
 }

--- a/crypto/evp/kem.c
+++ b/crypto/evp/kem.c
@@ -367,7 +367,7 @@ const OSSL_PARAM *EVP_KEM_gettable_ctx_params(const EVP_KEM *kem)
         return NULL;
 
     provctx = ossl_provider_ctx(EVP_KEM_provider(kem));
-    return kem->gettable_ctx_params(provctx);
+    return kem->gettable_ctx_params(NULL, provctx);
 }
 
 const OSSL_PARAM *EVP_KEM_settable_ctx_params(const EVP_KEM *kem)
@@ -378,5 +378,5 @@ const OSSL_PARAM *EVP_KEM_settable_ctx_params(const EVP_KEM *kem)
         return NULL;
 
     provctx = ossl_provider_ctx(EVP_KEM_provider(kem));
-    return kem->settable_ctx_params(provctx);
+    return kem->settable_ctx_params(NULL, provctx);
 }

--- a/crypto/evp/keymgmt_meth.c
+++ b/crypto/evp/keymgmt_meth.c
@@ -340,7 +340,7 @@ const OSSL_PARAM *EVP_KEYMGMT_gen_settable_params(const EVP_KEYMGMT *keymgmt)
 
     if (keymgmt->gen_settable_params == NULL)
         return NULL;
-    return keymgmt->gen_settable_params(provctx);
+    return keymgmt->gen_settable_params(NULL, provctx);
 }
 
 void *evp_keymgmt_gen(const EVP_KEYMGMT *keymgmt, void *genctx,

--- a/crypto/evp/pmeth_lib.c
+++ b/crypto/evp/pmeth_lib.c
@@ -744,27 +744,31 @@ const OSSL_PARAM *EVP_PKEY_CTX_gettable_params(EVP_PKEY_CTX *ctx)
             && ctx->op.kex.exchange != NULL
             && ctx->op.kex.exchange->gettable_ctx_params != NULL) {
         provctx = ossl_provider_ctx(EVP_KEYEXCH_provider(ctx->op.kex.exchange));
-        return ctx->op.kex.exchange->gettable_ctx_params(provctx);
+        return ctx->op.kex.exchange->gettable_ctx_params(ctx->op.kex.exchprovctx,
+                                                         provctx);
     }
     if (EVP_PKEY_CTX_IS_SIGNATURE_OP(ctx)
             && ctx->op.sig.signature != NULL
             && ctx->op.sig.signature->gettable_ctx_params != NULL) {
         provctx = ossl_provider_ctx(
                       EVP_SIGNATURE_provider(ctx->op.sig.signature));
-        return ctx->op.sig.signature->gettable_ctx_params(provctx);
+        return ctx->op.sig.signature->gettable_ctx_params(ctx->op.sig.sigprovctx,
+                                                          provctx);
     }
     if (EVP_PKEY_CTX_IS_ASYM_CIPHER_OP(ctx)
             && ctx->op.ciph.cipher != NULL
             && ctx->op.ciph.cipher->gettable_ctx_params != NULL) {
         provctx = ossl_provider_ctx(
                       EVP_ASYM_CIPHER_provider(ctx->op.ciph.cipher));
-        return ctx->op.ciph.cipher->gettable_ctx_params(provctx);
+        return ctx->op.ciph.cipher->gettable_ctx_params(ctx->op.ciph.ciphprovctx,
+                                                        provctx);
     }
     if (EVP_PKEY_CTX_IS_KEM_OP(ctx)
         && ctx->op.encap.kem != NULL
         && ctx->op.encap.kem->gettable_ctx_params != NULL) {
         provctx = ossl_provider_ctx(EVP_KEM_provider(ctx->op.encap.kem));
-        return ctx->op.encap.kem->gettable_ctx_params(provctx);
+        return ctx->op.encap.kem->gettable_ctx_params(ctx->op.encap.kemprovctx,
+                                                      provctx);
     }
     return NULL;
 }
@@ -777,30 +781,38 @@ const OSSL_PARAM *EVP_PKEY_CTX_settable_params(EVP_PKEY_CTX *ctx)
             && ctx->op.kex.exchange != NULL
             && ctx->op.kex.exchange->settable_ctx_params != NULL) {
         provctx = ossl_provider_ctx(EVP_KEYEXCH_provider(ctx->op.kex.exchange));
-        return ctx->op.kex.exchange->settable_ctx_params(provctx);
+        return ctx->op.kex.exchange->settable_ctx_params(ctx->op.kex.exchprovctx,
+                                                         provctx);
     }
     if (EVP_PKEY_CTX_IS_SIGNATURE_OP(ctx)
             && ctx->op.sig.signature != NULL
             && ctx->op.sig.signature->settable_ctx_params != NULL) {
         provctx = ossl_provider_ctx(
                       EVP_SIGNATURE_provider(ctx->op.sig.signature));
-        return ctx->op.sig.signature->settable_ctx_params(provctx);
+        return ctx->op.sig.signature->settable_ctx_params(ctx->op.sig.sigprovctx,
+                                                          provctx);
     }
     if (EVP_PKEY_CTX_IS_ASYM_CIPHER_OP(ctx)
             && ctx->op.ciph.cipher != NULL
             && ctx->op.ciph.cipher->settable_ctx_params != NULL) {
         provctx = ossl_provider_ctx(
                       EVP_ASYM_CIPHER_provider(ctx->op.ciph.cipher));
-        return ctx->op.ciph.cipher->settable_ctx_params(provctx);
+        return ctx->op.ciph.cipher->settable_ctx_params(ctx->op.ciph.ciphprovctx,
+                                                        provctx);
     }
     if (EVP_PKEY_CTX_IS_GEN_OP(ctx)
-            && ctx->keymgmt != NULL)
-        return EVP_KEYMGMT_gen_settable_params(ctx->keymgmt);
+            && ctx->keymgmt != NULL
+            && ctx->keymgmt->gen_settable_params != NULL) {
+        provctx = ossl_provider_ctx(EVP_KEYMGMT_provider(ctx->keymgmt));
+        return ctx->keymgmt->gen_settable_params(ctx->op.keymgmt.genctx,
+                                                 provctx);
+    }
     if (EVP_PKEY_CTX_IS_KEM_OP(ctx)
         && ctx->op.encap.kem != NULL
         && ctx->op.encap.kem->settable_ctx_params != NULL) {
         provctx = ossl_provider_ctx(EVP_KEM_provider(ctx->op.encap.kem));
-        return ctx->op.encap.kem->settable_ctx_params(provctx);
+        return ctx->op.encap.kem->settable_ctx_params(ctx->op.encap.kemprovctx,
+                                                      provctx);
     }
     return NULL;
 }

--- a/crypto/evp/signature.c
+++ b/crypto/evp/signature.c
@@ -347,7 +347,7 @@ const OSSL_PARAM *EVP_SIGNATURE_gettable_ctx_params(const EVP_SIGNATURE *sig)
         return NULL;
 
     provctx = ossl_provider_ctx(EVP_SIGNATURE_provider(sig));
-    return sig->gettable_ctx_params(provctx);
+    return sig->gettable_ctx_params(NULL, provctx);
 }
 
 const OSSL_PARAM *EVP_SIGNATURE_settable_ctx_params(const EVP_SIGNATURE *sig)
@@ -358,7 +358,7 @@ const OSSL_PARAM *EVP_SIGNATURE_settable_ctx_params(const EVP_SIGNATURE *sig)
         return NULL;
 
     provctx = ossl_provider_ctx(EVP_SIGNATURE_provider(sig));
-    return sig->settable_ctx_params(provctx);
+    return sig->settable_ctx_params(NULL, provctx);
 }
 
 static int evp_pkey_signature_init(EVP_PKEY_CTX *ctx, int operation)

--- a/doc/man7/provider-kem.pod
+++ b/doc/man7/provider-kem.pod
@@ -34,9 +34,9 @@ provider-kem - The kem library E<lt>-E<gt> provider functions
 
  /* KEM parameters */
  int OSSL_FUNC_kem_get_ctx_params(void *ctx, OSSL_PARAM params[]);
- const OSSL_PARAM *OSSL_FUNC_kem_gettable_ctx_params(void *provctx);
+ const OSSL_PARAM *OSSL_FUNC_kem_gettable_ctx_params(void *ctx, void *provctx);
  int OSSL_FUNC_kem_set_ctx_params(void *ctx, const OSSL_PARAM params[]);
- const OSSL_PARAM *OSSL_FUNC_kem_settable_ctx_params(void *provctx);
+ const OSSL_PARAM *OSSL_FUNC_kem_settable_ctx_params(void *ctx, void *provctx);
 
 =head1 DESCRIPTION
 

--- a/doc/man7/provider-keyexch.pod
+++ b/doc/man7/provider-keyexch.pod
@@ -30,9 +30,11 @@ provider-keyexch - The keyexch library E<lt>-E<gt> provider functions
 
  /* Key Exchange parameters */
  int OSSL_FUNC_keyexch_set_ctx_params(void *ctx, const OSSL_PARAM params[]);
- const OSSL_PARAM *OSSL_FUNC_keyexch_settable_ctx_params(void *provctx);
+ const OSSL_PARAM *OSSL_FUNC_keyexch_settable_ctx_params(void *ctx,
+                                                         void *provctx);
  int OSSL_FUNC_keyexch_get_ctx_params(void *ctx, OSSL_PARAM params[]);
- const OSSL_PARAM *OSSL_FUNC_keyexch_gettable_ctx_params(void *provctx);
+ const OSSL_PARAM *OSSL_FUNC_keyexch_gettable_ctx_params(void *ctx,
+                                                         void *provctx);
 
 =head1 DESCRIPTION
 

--- a/doc/man7/provider-keymgmt.pod
+++ b/doc/man7/provider-keymgmt.pod
@@ -22,7 +22,8 @@ provider-keymgmt - The KEYMGMT library E<lt>-E<gt> provider functions
  void *OSSL_FUNC_keymgmt_gen_init(void *provctx, int selection);
  int OSSL_FUNC_keymgmt_gen_set_template(void *genctx, void *template);
  int OSSL_FUNC_keymgmt_gen_set_params(void *genctx, const OSSL_PARAM params[]);
- const OSSL_PARAM *OSSL_FUNC_keymgmt_gen_settable_params(void *provctx);
+ const OSSL_PARAM *OSSL_FUNC_keymgmt_gen_settable_params(void *genctx,
+                                                         void *provctx);
  void *OSSL_FUNC_keymgmt_gen(void *genctx, OSSL_CALLBACK *cb, void *cbarg);
  void OSSL_FUNC_keymgmt_gen_cleanup(void *genctx);
 

--- a/doc/man7/provider-signature.pod
+++ b/doc/man7/provider-signature.pod
@@ -64,10 +64,11 @@ provider-signature - The signature library E<lt>-E<gt> provider functions
 
  /* Signature parameters */
  int OSSL_FUNC_signature_get_ctx_params(void *ctx, OSSL_PARAM params[]);
- const OSSL_PARAM *OSSL_FUNC_signature_gettable_ctx_params(void *provctx);
+ const OSSL_PARAM *OSSL_FUNC_signature_gettable_ctx_params(void *ctx,
+                                                           void *provctx);
  int OSSL_FUNC_signature_set_ctx_params(void *ctx, const OSSL_PARAM params[]);
- const OSSL_PARAM *OSSL_FUNC_signature_settable_ctx_params(void *provctx);
-
+ const OSSL_PARAM *OSSL_FUNC_signature_settable_ctx_params(void *ctx,
+                                                           void *provctx);
  /* MD parameters */
  int OSSL_FUNC_signature_get_ctx_md_params(void *ctx, OSSL_PARAM params[]);
  const OSSL_PARAM * OSSL_FUNC_signature_gettable_ctx_md_params(void *ctx);

--- a/include/openssl/core_dispatch.h
+++ b/include/openssl/core_dispatch.h
@@ -526,11 +526,8 @@ OSSL_CORE_MAKE_FUNC(int, keymgmt_gen_set_template,
 OSSL_CORE_MAKE_FUNC(int, keymgmt_gen_set_params,
                     (void *genctx, const OSSL_PARAM params[]))
 OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *,
-                    keymgmt_gen_settable_params, (void *provctx))
-OSSL_CORE_MAKE_FUNC(int, keymgmt_gen_get_params,
-                    (void *genctx, OSSL_PARAM params[]))
-OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *,
-                    keymgmt_gen_gettable_params, (void *provctx))
+                    keymgmt_gen_settable_params,
+                    (void *genctx, void *provctx))
 OSSL_CORE_MAKE_FUNC(void *, keymgmt_gen,
                     (void *genctx, OSSL_CALLBACK *cb, void *cbarg))
 OSSL_CORE_MAKE_FUNC(void, keymgmt_gen_cleanup, (void *genctx))
@@ -621,11 +618,11 @@ OSSL_CORE_MAKE_FUNC(void *, keyexch_dupctx, (void *ctx))
 OSSL_CORE_MAKE_FUNC(int, keyexch_set_ctx_params, (void *ctx,
                                                      const OSSL_PARAM params[]))
 OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, keyexch_settable_ctx_params,
-                    (void *provctx))
+                    (void *ctx, void *provctx))
 OSSL_CORE_MAKE_FUNC(int, keyexch_get_ctx_params, (void *ctx,
                                                      OSSL_PARAM params[]))
 OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, keyexch_gettable_ctx_params,
-                    (void *provctx))
+                    (void *ctx, void *provctx))
 
 /* Signature */
 
@@ -700,11 +697,11 @@ OSSL_CORE_MAKE_FUNC(void *, signature_dupctx, (void *ctx))
 OSSL_CORE_MAKE_FUNC(int, signature_get_ctx_params,
                     (void *ctx, OSSL_PARAM params[]))
 OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, signature_gettable_ctx_params,
-                    (void *provctx))
+                    (void *ctx, void *provctx))
 OSSL_CORE_MAKE_FUNC(int, signature_set_ctx_params,
                     (void *ctx, const OSSL_PARAM params[]))
 OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, signature_settable_ctx_params,
-                    (void *provctx))
+                    (void *ctx, void *provctx))
 OSSL_CORE_MAKE_FUNC(int, signature_get_ctx_md_params,
                     (void *ctx, OSSL_PARAM params[]))
 OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, signature_gettable_ctx_md_params,
@@ -747,11 +744,11 @@ OSSL_CORE_MAKE_FUNC(void *, asym_cipher_dupctx, (void *ctx))
 OSSL_CORE_MAKE_FUNC(int, asym_cipher_get_ctx_params,
                     (void *ctx, OSSL_PARAM params[]))
 OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, asym_cipher_gettable_ctx_params,
-                    (void *provctx))
+                    (void *ctx, void *provctx))
 OSSL_CORE_MAKE_FUNC(int, asym_cipher_set_ctx_params,
                     (void *ctx, const OSSL_PARAM params[]))
 OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, asym_cipher_settable_ctx_params,
-                    (void *provctx))
+                    (void *ctx, void *provctx))
 
 /* Asymmetric Key encapsulation */
 # define OSSL_FUNC_KEM_NEWCTX                  1
@@ -779,10 +776,12 @@ OSSL_CORE_MAKE_FUNC(int, kem_decapsulate, (void *ctx,
 OSSL_CORE_MAKE_FUNC(void, kem_freectx, (void *ctx))
 OSSL_CORE_MAKE_FUNC(void *, kem_dupctx, (void *ctx))
 OSSL_CORE_MAKE_FUNC(int, kem_get_ctx_params, (void *ctx, OSSL_PARAM params[]))
-OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, kem_gettable_ctx_params, (void *provctx))
+OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, kem_gettable_ctx_params,
+                    (void *ctx, void *provctx))
 OSSL_CORE_MAKE_FUNC(int, kem_set_ctx_params,
                     (void *ctx, const OSSL_PARAM params[]))
-OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, kem_settable_ctx_params, (void *provctx))
+OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, kem_settable_ctx_params,
+                    (void *ctx, void *provctx))
 
 /* Encoders and decoders */
 # define OSSL_FUNC_ENCODER_NEWCTX                      1

--- a/providers/implementations/asymciphers/rsa_enc.c
+++ b/providers/implementations/asymciphers/rsa_enc.c
@@ -409,7 +409,8 @@ static const OSSL_PARAM known_gettable_ctx_params[] = {
     OSSL_PARAM_END
 };
 
-static const OSSL_PARAM *rsa_gettable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *rsa_gettable_ctx_params(ossl_unused void *vprsactx,
+                                                 ossl_unused void *provctx)
 {
     return known_gettable_ctx_params;
 }
@@ -553,7 +554,8 @@ static const OSSL_PARAM known_settable_ctx_params[] = {
     OSSL_PARAM_END
 };
 
-static const OSSL_PARAM *rsa_settable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *rsa_settable_ctx_params(ossl_unused void *vprsactx,
+                                                 ossl_unused void *provctx)
 {
     return known_settable_ctx_params;
 }

--- a/providers/implementations/asymciphers/sm2_enc.c
+++ b/providers/implementations/asymciphers/sm2_enc.c
@@ -176,7 +176,8 @@ static const OSSL_PARAM known_gettable_ctx_params[] = {
     OSSL_PARAM_END
 };
 
-static const OSSL_PARAM *sm2_gettable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *sm2_gettable_ctx_params(ossl_unused void *vpsm2ctx,
+                                                 ossl_unused void *provctx)
 {
     return known_gettable_ctx_params;
 }
@@ -202,7 +203,8 @@ static const OSSL_PARAM known_settable_ctx_params[] = {
     OSSL_PARAM_END
 };
 
-static const OSSL_PARAM *sm2_settable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *sm2_settable_ctx_params(ossl_unused void *vpsm2ctx,
+                                                 ossl_unused void *provctx)
 {
     return known_settable_ctx_params;
 }

--- a/providers/implementations/exchange/dh_exch.c
+++ b/providers/implementations/exchange/dh_exch.c
@@ -383,7 +383,8 @@ static const OSSL_PARAM known_settable_ctx_params[] = {
     OSSL_PARAM_END
 };
 
-static const OSSL_PARAM *dh_settable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *dh_settable_ctx_params(ossl_unused void *vpdhctx,
+                                                ossl_unused void *provctx)
 {
     return known_settable_ctx_params;
 }
@@ -398,7 +399,8 @@ static const OSSL_PARAM known_gettable_ctx_params[] = {
     OSSL_PARAM_END
 };
 
-static const OSSL_PARAM *dh_gettable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *dh_gettable_ctx_params(ossl_unused void *vpdhctx,
+                                                ossl_unused void *provctx)
 {
     return known_gettable_ctx_params;
 }

--- a/providers/implementations/exchange/ecdh_exch.c
+++ b/providers/implementations/exchange/ecdh_exch.c
@@ -297,7 +297,8 @@ static const OSSL_PARAM known_settable_ctx_params[] = {
 };
 
 static
-const OSSL_PARAM *ecdh_settable_ctx_params(ossl_unused void *provctx)
+const OSSL_PARAM *ecdh_settable_ctx_params(ossl_unused void *vpecdhctx,
+                                           ossl_unused void *provctx)
 {
     return known_settable_ctx_params;
 }
@@ -374,7 +375,8 @@ static const OSSL_PARAM known_gettable_ctx_params[] = {
 };
 
 static
-const OSSL_PARAM *ecdh_gettable_ctx_params(ossl_unused void *provctx)
+const OSSL_PARAM *ecdh_gettable_ctx_params(ossl_unused void *vpecdhctx,
+                                           ossl_unused void *provctx)
 {
     return known_gettable_ctx_params;
 }

--- a/providers/implementations/exchange/kdf_exch.c
+++ b/providers/implementations/exchange/kdf_exch.c
@@ -149,7 +149,8 @@ static int kdf_set_ctx_params(void *vpkdfctx, const OSSL_PARAM params[])
     return EVP_KDF_CTX_set_params(pkdfctx->kdfctx, params);
 }
 
-static const OSSL_PARAM *kdf_settable_ctx_params(void *provctx,
+static const OSSL_PARAM *kdf_settable_ctx_params(ossl_unused void *vpkdfctx,
+                                                 void *provctx,
                                                  const char *kdfname)
 {
     EVP_KDF *kdf = EVP_KDF_fetch(PROV_LIBCTX_OF(provctx), kdfname,
@@ -166,9 +167,10 @@ static const OSSL_PARAM *kdf_settable_ctx_params(void *provctx,
 }
 
 #define KDF_SETTABLE_CTX_PARAMS(funcname, kdfname) \
-    static const OSSL_PARAM *kdf_##funcname##_settable_ctx_params(void *provctx) \
+    static const OSSL_PARAM *kdf_##funcname##_settable_ctx_params(void *vpkdfctx, \
+                                                                  void *provctx) \
     { \
-        return kdf_settable_ctx_params(provctx, kdfname); \
+        return kdf_settable_ctx_params(vpkdfctx, provctx, kdfname); \
     }
 
 KDF_SETTABLE_CTX_PARAMS(tls1_prf, "TLS1-PRF")

--- a/providers/implementations/kem/rsa_kem.c
+++ b/providers/implementations/kem/rsa_kem.c
@@ -156,7 +156,8 @@ static const OSSL_PARAM known_gettable_rsakem_ctx_params[] = {
     OSSL_PARAM_END
 };
 
-static const OSSL_PARAM *rsakem_gettable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *rsakem_gettable_ctx_params(ossl_unused void *vprsactx,
+                                                    ossl_unused void *provctx)
 {
     return known_gettable_rsakem_ctx_params;
 }
@@ -187,7 +188,8 @@ static const OSSL_PARAM known_settable_rsakem_ctx_params[] = {
     OSSL_PARAM_END
 };
 
-static const OSSL_PARAM *rsakem_settable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *rsakem_settable_ctx_params(ossl_unused void *vprsactx,
+                                                    ossl_unused void *provctx)
 {
     return known_settable_rsakem_ctx_params;
 }

--- a/providers/implementations/keymgmt/dh_kmgmt.c
+++ b/providers/implementations/keymgmt/dh_kmgmt.c
@@ -558,7 +558,8 @@ static int dh_gen_set_params(void *genctx, const OSSL_PARAM params[])
     return 1;
 }
 
-static const OSSL_PARAM *dh_gen_settable_params(void *provctx)
+static const OSSL_PARAM *dh_gen_settable_params(ossl_unused void *genctx,
+                                                ossl_unused void *provctx)
 {
     static OSSL_PARAM settable[] = {
         OSSL_PARAM_utf8_string(OSSL_PKEY_PARAM_GROUP_NAME, NULL, 0),

--- a/providers/implementations/keymgmt/dsa_kmgmt.c
+++ b/providers/implementations/keymgmt/dsa_kmgmt.c
@@ -476,7 +476,8 @@ static int dsa_gen_set_params(void *genctx, const OSSL_PARAM params[])
     return 1;
 }
 
-static const OSSL_PARAM *dsa_gen_settable_params(void *provctx)
+static const OSSL_PARAM *dsa_gen_settable_params(ossl_unused void *genctx,
+                                                 ossl_unused void *provctx)
 {
     static OSSL_PARAM settable[] = {
         OSSL_PARAM_utf8_string(OSSL_PKEY_PARAM_FFC_TYPE, NULL, 0),

--- a/providers/implementations/keymgmt/ec_kmgmt.c
+++ b/providers/implementations/keymgmt/ec_kmgmt.c
@@ -1121,7 +1121,8 @@ err:
     return ret;
 }
 
-static const OSSL_PARAM *ec_gen_settable_params(void *provctx)
+static const OSSL_PARAM *ec_gen_settable_params(ossl_unused void *genctx,
+                                                ossl_unused void *provctx)
 {
     static OSSL_PARAM settable[] = {
         OSSL_PARAM_utf8_string(OSSL_PKEY_PARAM_GROUP_NAME, NULL, 0),

--- a/providers/implementations/keymgmt/ecx_kmgmt.c
+++ b/providers/implementations/keymgmt/ecx_kmgmt.c
@@ -529,7 +529,8 @@ static int ecx_gen_set_params(void *genctx, const OSSL_PARAM params[])
     return 1;
 }
 
-static const OSSL_PARAM *ecx_gen_settable_params(void *provctx)
+static const OSSL_PARAM *ecx_gen_settable_params(ossl_unused void *genctx,
+                                                 ossl_unused void *provctx)
 {
     static OSSL_PARAM settable[] = {
         OSSL_PARAM_utf8_string(OSSL_PKEY_PARAM_GROUP_NAME, NULL, 0),

--- a/providers/implementations/keymgmt/mac_legacy_kmgmt.c
+++ b/providers/implementations/keymgmt/mac_legacy_kmgmt.c
@@ -428,7 +428,8 @@ static int cmac_gen_set_params(void *genctx, const OSSL_PARAM params[])
     return 1;
 }
 
-static const OSSL_PARAM *mac_gen_settable_params(void *provctx)
+static const OSSL_PARAM *mac_gen_settable_params(ossl_unused void *genctx,
+                                                 ossl_unused void *provctx)
 {
     static OSSL_PARAM settable[] = {
         OSSL_PARAM_octet_string(OSSL_PKEY_PARAM_PRIV_KEY, NULL, 0),
@@ -437,7 +438,8 @@ static const OSSL_PARAM *mac_gen_settable_params(void *provctx)
     return settable;
 }
 
-static const OSSL_PARAM *cmac_gen_settable_params(void *provctx)
+static const OSSL_PARAM *cmac_gen_settable_params(ossl_unused void *genctx,
+                                                  ossl_unused void *provctx)
 {
     static OSSL_PARAM settable[] = {
         OSSL_PARAM_octet_string(OSSL_PKEY_PARAM_PRIV_KEY, NULL, 0),

--- a/providers/implementations/keymgmt/rsa_kmgmt.c
+++ b/providers/implementations/keymgmt/rsa_kmgmt.c
@@ -502,7 +502,8 @@ static int rsa_gen_set_params(void *genctx, const OSSL_PARAM params[])
     OSSL_PARAM_utf8_string(OSSL_PKEY_PARAM_RSA_MGF1_DIGEST, NULL, 0),   \
     OSSL_PARAM_int(OSSL_PKEY_PARAM_RSA_PSS_SALTLEN, NULL)
 
-static const OSSL_PARAM *rsa_gen_settable_params(void *provctx)
+static const OSSL_PARAM *rsa_gen_settable_params(ossl_unused void *genctx,
+                                                 ossl_unused void *provctx)
 {
     static OSSL_PARAM settable[] = {
         rsa_gen_basic,
@@ -512,7 +513,8 @@ static const OSSL_PARAM *rsa_gen_settable_params(void *provctx)
     return settable;
 }
 
-static const OSSL_PARAM *rsapss_gen_settable_params(void *provctx)
+static const OSSL_PARAM *rsapss_gen_settable_params(ossl_unused void *genctx,
+                                                    ossl_unused void *provctx)
 {
     static OSSL_PARAM settable[] = {
         rsa_gen_basic,

--- a/providers/implementations/signature/dsa.c
+++ b/providers/implementations/signature/dsa.c
@@ -471,9 +471,13 @@ static int dsa_set_ctx_params(void *vpdsactx, const OSSL_PARAM params[])
     return 1;
 }
 
-static const OSSL_PARAM known_settable_ctx_params[] = {
+static const OSSL_PARAM settable_ctx_params[] = {
     OSSL_PARAM_utf8_string(OSSL_SIGNATURE_PARAM_DIGEST, NULL, 0),
     OSSL_PARAM_utf8_string(OSSL_SIGNATURE_PARAM_PROPERTIES, NULL, 0),
+    OSSL_PARAM_END
+};
+
+static const OSSL_PARAM settable_ctx_params_no_digest[] = {
     OSSL_PARAM_END
 };
 
@@ -483,8 +487,8 @@ static const OSSL_PARAM *dsa_settable_ctx_params(void *vpdsactx,
     PROV_DSA_CTX *pdsactx = (PROV_DSA_CTX *)vpdsactx;
 
     if (pdsactx != NULL && !pdsactx->flag_allow_md)
-        return &known_settable_ctx_params[2];
-    return known_settable_ctx_params;
+        return settable_ctx_params_no_digest;
+    return settable_ctx_params;
 }
 
 static int dsa_get_ctx_md_params(void *vpdsactx, OSSL_PARAM *params)

--- a/providers/implementations/signature/dsa.c
+++ b/providers/implementations/signature/dsa.c
@@ -434,7 +434,8 @@ static const OSSL_PARAM known_gettable_ctx_params[] = {
     OSSL_PARAM_END
 };
 
-static const OSSL_PARAM *dsa_gettable_ctx_params(ossl_unused void *vctx)
+static const OSSL_PARAM *dsa_gettable_ctx_params(ossl_unused void *ctx,
+                                                 ossl_unused void *provctx)
 {
     return known_gettable_ctx_params;
 }
@@ -476,20 +477,13 @@ static const OSSL_PARAM known_settable_ctx_params[] = {
     OSSL_PARAM_END
 };
 
-static const OSSL_PARAM *dsa_settable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *dsa_settable_ctx_params(void *vpdsactx,
+                                                 ossl_unused void *provctx)
 {
-    /*
-     * TODO(3.0): Should this function return a different set of settable ctx
-     * params if the ctx is being used for a DigestSign/DigestVerify? In that
-     * case it is not allowed to set the digest size/digest name because the
-     * digest is explicitly set as part of the init.
-     * NOTE: Ideally we would check pdsactx->flag_allow_md, but this is
-     * problematic because there is no nice way of passing the
-     * PROV_DSA_CTX down to this function...
-     * Because we have API's that dont know about their parent..
-     * e.g: EVP_SIGNATURE_gettable_ctx_params(const EVP_SIGNATURE *sig).
-     * We could pass NULL for that case (but then how useful is the check?).
-     */
+    PROV_DSA_CTX *pdsactx = (PROV_DSA_CTX *)vpdsactx;
+
+    if (pdsactx != NULL && !pdsactx->flag_allow_md)
+        return &known_settable_ctx_params[2];
     return known_settable_ctx_params;
 }
 

--- a/providers/implementations/signature/ecdsa.c
+++ b/providers/implementations/signature/ecdsa.c
@@ -433,7 +433,8 @@ static const OSSL_PARAM known_gettable_ctx_params[] = {
     OSSL_PARAM_END
 };
 
-static const OSSL_PARAM *ecdsa_gettable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *ecdsa_gettable_ctx_params(ossl_unused void *vctx,
+                                                   ossl_unused void *provctx)
 {
     return known_gettable_ctx_params;
 }
@@ -482,15 +483,21 @@ static int ecdsa_set_ctx_params(void *vctx, const OSSL_PARAM params[])
 }
 
 static const OSSL_PARAM known_settable_ctx_params[] = {
-    OSSL_PARAM_size_t(OSSL_SIGNATURE_PARAM_DIGEST_SIZE, NULL),
+    /* the first three will be skipped if md setting is not allowed */
     OSSL_PARAM_utf8_string(OSSL_SIGNATURE_PARAM_DIGEST, NULL, 0),
+    OSSL_PARAM_size_t(OSSL_SIGNATURE_PARAM_DIGEST_SIZE, NULL),
     OSSL_PARAM_utf8_string(OSSL_SIGNATURE_PARAM_PROPERTIES, NULL, 0),
     OSSL_PARAM_uint(OSSL_SIGNATURE_PARAM_KAT, NULL),
     OSSL_PARAM_END
 };
 
-static const OSSL_PARAM *ecdsa_settable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *ecdsa_settable_ctx_params(void *vctx,
+                                                   ossl_unused void *provctx)
 {
+    PROV_ECDSA_CTX *ctx = (PROV_ECDSA_CTX *)vctx;
+
+    if (ctx != NULL && !ctx->flag_allow_md)
+        return &known_settable_ctx_params[3];
     return known_settable_ctx_params;
 }
 

--- a/providers/implementations/signature/ecdsa.c
+++ b/providers/implementations/signature/ecdsa.c
@@ -482,11 +482,15 @@ static int ecdsa_set_ctx_params(void *vctx, const OSSL_PARAM params[])
     return 1;
 }
 
-static const OSSL_PARAM known_settable_ctx_params[] = {
-    /* the first three will be skipped if md setting is not allowed */
+static const OSSL_PARAM settable_ctx_params[] = {
     OSSL_PARAM_utf8_string(OSSL_SIGNATURE_PARAM_DIGEST, NULL, 0),
     OSSL_PARAM_size_t(OSSL_SIGNATURE_PARAM_DIGEST_SIZE, NULL),
     OSSL_PARAM_utf8_string(OSSL_SIGNATURE_PARAM_PROPERTIES, NULL, 0),
+    OSSL_PARAM_uint(OSSL_SIGNATURE_PARAM_KAT, NULL),
+    OSSL_PARAM_END
+};
+
+static const OSSL_PARAM settable_ctx_params_no_digest[] = {
     OSSL_PARAM_uint(OSSL_SIGNATURE_PARAM_KAT, NULL),
     OSSL_PARAM_END
 };
@@ -497,8 +501,8 @@ static const OSSL_PARAM *ecdsa_settable_ctx_params(void *vctx,
     PROV_ECDSA_CTX *ctx = (PROV_ECDSA_CTX *)vctx;
 
     if (ctx != NULL && !ctx->flag_allow_md)
-        return &known_settable_ctx_params[3];
-    return known_settable_ctx_params;
+        return settable_ctx_params_no_digest;
+    return settable_ctx_params;
 }
 
 static int ecdsa_get_ctx_md_params(void *vctx, OSSL_PARAM *params)

--- a/providers/implementations/signature/eddsa.c
+++ b/providers/implementations/signature/eddsa.c
@@ -293,7 +293,8 @@ static const OSSL_PARAM known_gettable_ctx_params[] = {
     OSSL_PARAM_END
 };
 
-static const OSSL_PARAM *eddsa_gettable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *eddsa_gettable_ctx_params(ossl_unused void *vpeddsactx,
+                                                   ossl_unused void *provctx)
 {
     return known_gettable_ctx_params;
 }

--- a/providers/implementations/signature/mac_legacy.c
+++ b/providers/implementations/signature/mac_legacy.c
@@ -202,7 +202,8 @@ static int mac_set_ctx_params(void *vpmacctx, const OSSL_PARAM params[])
     return EVP_MAC_CTX_set_params(ctx->macctx, params);
 }
 
-static const OSSL_PARAM *mac_settable_ctx_params(void *provctx,
+static const OSSL_PARAM *mac_settable_ctx_params(ossl_unused void *ctx,
+                                                 void *provctx,
                                                  const char *macname)
 {
     EVP_MAC *mac = EVP_MAC_fetch(PROV_LIBCTX_OF(provctx), macname,
@@ -219,9 +220,10 @@ static const OSSL_PARAM *mac_settable_ctx_params(void *provctx,
 }
 
 #define MAC_SETTABLE_CTX_PARAMS(funcname, macname) \
-    static const OSSL_PARAM *mac_##funcname##_settable_ctx_params(void *provctx) \
+    static const OSSL_PARAM *mac_##funcname##_settable_ctx_params(void *ctx, \
+                                                                  void *provctx) \
     { \
-        return mac_settable_ctx_params(provctx, macname); \
+        return mac_settable_ctx_params(ctx, provctx, macname); \
     }
 
 MAC_SETTABLE_CTX_PARAMS(hmac, "HMAC")

--- a/providers/implementations/signature/rsa.c
+++ b/providers/implementations/signature/rsa.c
@@ -1329,10 +1329,17 @@ static int rsa_set_ctx_params(void *vprsactx, const OSSL_PARAM params[])
     return 1;
 }
 
-static const OSSL_PARAM known_settable_ctx_params[] = {
-    /* digest and properties must be first to be able to skip it */
+static const OSSL_PARAM settable_ctx_params[] = {
     OSSL_PARAM_utf8_string(OSSL_SIGNATURE_PARAM_DIGEST, NULL, 0),
     OSSL_PARAM_utf8_string(OSSL_SIGNATURE_PARAM_PROPERTIES, NULL, 0),
+    OSSL_PARAM_utf8_string(OSSL_SIGNATURE_PARAM_PAD_MODE, NULL, 0),
+    OSSL_PARAM_utf8_string(OSSL_SIGNATURE_PARAM_MGF1_DIGEST, NULL, 0),
+    OSSL_PARAM_utf8_string(OSSL_SIGNATURE_PARAM_MGF1_PROPERTIES, NULL, 0),
+    OSSL_PARAM_utf8_string(OSSL_SIGNATURE_PARAM_PSS_SALTLEN, NULL, 0),
+    OSSL_PARAM_END
+};
+
+static const OSSL_PARAM settable_ctx_params_no_digest[] = {
     OSSL_PARAM_utf8_string(OSSL_SIGNATURE_PARAM_PAD_MODE, NULL, 0),
     OSSL_PARAM_utf8_string(OSSL_SIGNATURE_PARAM_MGF1_DIGEST, NULL, 0),
     OSSL_PARAM_utf8_string(OSSL_SIGNATURE_PARAM_MGF1_PROPERTIES, NULL, 0),
@@ -1346,8 +1353,8 @@ static const OSSL_PARAM *rsa_settable_ctx_params(void *vprsactx,
     PROV_RSA_CTX *prsactx = (PROV_RSA_CTX *)vprsactx;
 
     if (prsactx != NULL && !prsactx->flag_allow_md)
-        return &known_settable_ctx_params[2];
-    return known_settable_ctx_params;
+        return settable_ctx_params_no_digest;
+    return settable_ctx_params;
 }
 
 static int rsa_get_ctx_md_params(void *vprsactx, OSSL_PARAM *params)

--- a/providers/implementations/signature/rsa.c
+++ b/providers/implementations/signature/rsa.c
@@ -1098,7 +1098,8 @@ static const OSSL_PARAM known_gettable_ctx_params[] = {
     OSSL_PARAM_END
 };
 
-static const OSSL_PARAM *rsa_gettable_ctx_params(ossl_unused void *vctx)
+static const OSSL_PARAM *rsa_gettable_ctx_params(ossl_unused void *vprsactx,
+                                                 ossl_unused void *provctx)
 {
     return known_gettable_ctx_params;
 }
@@ -1329,23 +1330,23 @@ static int rsa_set_ctx_params(void *vprsactx, const OSSL_PARAM params[])
 }
 
 static const OSSL_PARAM known_settable_ctx_params[] = {
-    OSSL_PARAM_utf8_string(OSSL_SIGNATURE_PARAM_PAD_MODE, NULL, 0),
+    /* digest and properties must be first to be able to skip it */
     OSSL_PARAM_utf8_string(OSSL_SIGNATURE_PARAM_DIGEST, NULL, 0),
     OSSL_PARAM_utf8_string(OSSL_SIGNATURE_PARAM_PROPERTIES, NULL, 0),
+    OSSL_PARAM_utf8_string(OSSL_SIGNATURE_PARAM_PAD_MODE, NULL, 0),
     OSSL_PARAM_utf8_string(OSSL_SIGNATURE_PARAM_MGF1_DIGEST, NULL, 0),
     OSSL_PARAM_utf8_string(OSSL_SIGNATURE_PARAM_MGF1_PROPERTIES, NULL, 0),
     OSSL_PARAM_utf8_string(OSSL_SIGNATURE_PARAM_PSS_SALTLEN, NULL, 0),
     OSSL_PARAM_END
 };
 
-static const OSSL_PARAM *rsa_settable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *rsa_settable_ctx_params(void *vprsactx,
+                                                 ossl_unused void *provctx)
 {
-    /*
-     * TODO(3.0): Should this function return a different set of settable ctx
-     * params if the ctx is being used for a DigestSign/DigestVerify? In that
-     * case it is not allowed to set the digest size/digest name because the
-     * digest is explicitly set as part of the init.
-     */
+    PROV_RSA_CTX *prsactx = (PROV_RSA_CTX *)vprsactx;
+
+    if (prsactx != NULL && !prsactx->flag_allow_md)
+        return &known_settable_ctx_params[2];
     return known_settable_ctx_params;
 }
 

--- a/providers/implementations/signature/sm2sig.c
+++ b/providers/implementations/signature/sm2sig.c
@@ -381,7 +381,8 @@ static const OSSL_PARAM known_gettable_ctx_params[] = {
     OSSL_PARAM_END
 };
 
-static const OSSL_PARAM *sm2sig_gettable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *sm2sig_gettable_ctx_params(ossl_unused void *vpsm2ctx,
+                                                    ossl_unused void *provctx)
 {
     return known_gettable_ctx_params;
 }
@@ -446,7 +447,8 @@ static const OSSL_PARAM known_settable_ctx_params[] = {
     OSSL_PARAM_END
 };
 
-static const OSSL_PARAM *sm2sig_settable_ctx_params(ossl_unused void *provctx)
+static const OSSL_PARAM *sm2sig_settable_ctx_params(ossl_unused void *vpsm2ctx,
+                                                    ossl_unused void *provctx)
 {
     /*
      * TODO(3.0): Should this function return a different set of settable ctx

--- a/test/tls-provider.c
+++ b/test/tls-provider.c
@@ -573,7 +573,8 @@ static int xor_gen_set_params(void *genctx, const OSSL_PARAM params[])
     return 1;
 }
 
-static const OSSL_PARAM *xor_gen_settable_params(void *provctx)
+static const OSSL_PARAM *xor_gen_settable_params(ossl_unused void *genctx,
+                                                 ossl_unused void *provctx)
 {
     static OSSL_PARAM settable[] = {
         OSSL_PARAM_utf8_string(OSSL_PKEY_PARAM_GROUP_NAME, NULL, 0),


### PR DESCRIPTION
This allows making the signature operations return different
settable params when the context is initialized with
EVP_DigestSign/VerifyInit.
