### PR TITLE
Improve the test fake_random RNG

### DIFF
--- a/test/ecdsatest.c
+++ b/test/ecdsatest.c
@@ -25,6 +25,8 @@
 # include "internal/nelem.h"
 # include "ecdsatest.h"
 
+static fake_random_generate_cb fbytes;
+
 static const char *numbers[2];
 static size_t crv_len = 0;
 static EC_builtin_curve *curves = NULL;

--- a/test/sm2_internal_test.c
+++ b/test/sm2_internal_test.c
@@ -28,6 +28,8 @@
 
 # include "crypto/sm2.h"
 
+static fake_random_generate_cb get_faked_bytes;
+
 static OSSL_PROVIDER *fake_rand = NULL;
 static uint8_t *fake_rand_bytes = NULL;
 static size_t fake_rand_bytes_offset = 0;

--- a/test/sm2_internal_test.c
+++ b/test/sm2_internal_test.c
@@ -33,7 +33,9 @@ static uint8_t *fake_rand_bytes = NULL;
 static size_t fake_rand_bytes_offset = 0;
 static size_t fake_rand_size = 0;
 
-static int get_faked_bytes(unsigned char *buf, size_t num)
+static int get_faked_bytes(unsigned char *buf, size_t num,
+                           ossl_unused const char *name,
+                           ossl_unused EVP_RAND_CTX *ctx)
 {
     if (!TEST_ptr(fake_rand_bytes) || !TEST_size_t_gt(fake_rand_size, 0))
         return 0;
@@ -56,14 +58,16 @@ static int start_fake_rand(const char *hex_bytes)
         return 0;
 
     /* use own random function */
-    fake_rand_set_callback(get_faked_bytes);
+    fake_rand_set_callback(RAND_get0_private(NULL), get_faked_bytes);
+    fake_rand_set_callback(RAND_get0_public(NULL), get_faked_bytes);
     return 1;
 
 }
 
 static void restore_rand(void)
 {
-    fake_rand_set_callback(NULL);
+    fake_rand_set_callback(RAND_get0_private(NULL), NULL);
+    fake_rand_set_callback(RAND_get0_public(NULL), NULL);
     OPENSSL_free(fake_rand_bytes);
     fake_rand_bytes = NULL;
     fake_rand_bytes_offset = 0;

--- a/test/sm2_internal_test.c
+++ b/test/sm2_internal_test.c
@@ -58,16 +58,14 @@ static int start_fake_rand(const char *hex_bytes)
         return 0;
 
     /* use own random function */
-    fake_rand_set_callback(RAND_get0_private(NULL), get_faked_bytes);
-    fake_rand_set_callback(RAND_get0_public(NULL), get_faked_bytes);
+    fake_rand_set_public_private_callbacks(NULL, get_faked_bytes);
     return 1;
 
 }
 
 static void restore_rand(void)
 {
-    fake_rand_set_callback(RAND_get0_private(NULL), NULL);
-    fake_rand_set_callback(RAND_get0_public(NULL), NULL);
+    fake_rand_set_public_private_callbacks(NULL, NULL);
     OPENSSL_free(fake_rand_bytes);
     fake_rand_bytes = NULL;
     fake_rand_bytes_offset = 0;

--- a/test/testutil.h
+++ b/test/testutil.h
@@ -569,7 +569,9 @@ void test_random_seed(uint32_t sd);
 /* Fake non-secure random number generator */
 OSSL_PROVIDER *fake_rand_start(OSSL_LIB_CTX *libctx);
 void fake_rand_finish(OSSL_PROVIDER *p);
-void fake_rand_set_callback(int (*cb)(unsigned char *out, size_t outlen));
+void fake_rand_set_callback(EVP_RAND_CTX *ctx,
+                            int (*cb)(unsigned char *out, size_t outlen,
+                                      const char *name, EVP_RAND_CTX *ctx));
 
 /* Create a file path from a directory and a filename */
 char *test_mk_file_path(const char *dir, const char *file);

--- a/test/testutil.h
+++ b/test/testutil.h
@@ -567,16 +567,16 @@ uint32_t test_random(void);
 void test_random_seed(uint32_t sd);
 
 /* Fake non-secure random number generator */
+typedef int fake_random_generate_cb(unsigned char *out, size_t outlen,
+                                    const char *name, EVP_RAND_CTX *ctx);
+
 OSSL_PROVIDER *fake_rand_start(OSSL_LIB_CTX *libctx);
 void fake_rand_finish(OSSL_PROVIDER *p);
 void fake_rand_set_callback(EVP_RAND_CTX *ctx,
                             int (*cb)(unsigned char *out, size_t outlen,
                                       const char *name, EVP_RAND_CTX *ctx));
 void fake_rand_set_public_private_callbacks(OSSL_LIB_CTX *libctx,
-                                            int (*cb)(unsigned char *out,
-                                                      size_t outlen,
-                                                      const char *name,
-                                                      EVP_RAND_CTX *ctx));
+                                            fake_random_generate_cb *cb);
 
 /* Create a file path from a directory and a filename */
 char *test_mk_file_path(const char *dir, const char *file);

--- a/test/testutil.h
+++ b/test/testutil.h
@@ -572,6 +572,11 @@ void fake_rand_finish(OSSL_PROVIDER *p);
 void fake_rand_set_callback(EVP_RAND_CTX *ctx,
                             int (*cb)(unsigned char *out, size_t outlen,
                                       const char *name, EVP_RAND_CTX *ctx));
+void fake_rand_set_public_private_callbacks(OSSL_LIB_CTX *libctx,
+                                            int (*cb)(unsigned char *out,
+                                                      size_t outlen,
+                                                      const char *name,
+                                                      EVP_RAND_CTX *ctx));
 
 /* Create a file path from a directory and a filename */
 char *test_mk_file_path(const char *dir, const char *file);

--- a/test/testutil/fake_random.c
+++ b/test/testutil/fake_random.c
@@ -215,8 +215,17 @@ void fake_rand_set_callback(EVP_RAND_CTX *rng,
                             int (*cb)(unsigned char *out, size_t outlen,
                                       const char *name, EVP_RAND_CTX *ctx))
 {
-    FAKE_RAND *f = rng->data;
+    if (rng != NULL)
+        ((FAKE_RAND *)rng->data)->cb = cb;
+}
 
-    f->cb = cb;
+void fake_rand_set_public_private_callbacks(OSSL_LIB_CTX *libctx,
+                                            int (*cb)(unsigned char *out,
+                                                      size_t outlen,
+                                                      const char *name,
+                                                      EVP_RAND_CTX *ctx))
+{
+    fake_rand_set_callback(RAND_get0_private(libctx), cb);
+    fake_rand_set_callback(RAND_get0_public(libctx), cb);
 }
 

--- a/test/testutil/fake_random.c
+++ b/test/testutil/fake_random.c
@@ -17,8 +17,7 @@
 #include "../testutil.h"
 
 typedef struct {
-    int (*cb)(unsigned char *out, size_t outlen,
-              const char *name, EVP_RAND_CTX *ctx);
+    fake_random_generate_cb *cb;
     int state;
     const char *name;
     EVP_RAND_CTX *ctx;


### PR DESCRIPTION
The fake_random RNG used a single global context that was shared between all instances created.  This change makes each instance separate and independently doctorable.

This would have prevented the problems surrounding #14299 from occurring.

- [ ] documentation is added or updated
- [x] tests are added or updated
