### PR TITLE
Separate winsock.h inclusion, add more direct includes

### DIFF
--- a/apps/ca.c
+++ b/apps/ca.c
@@ -6,6 +6,8 @@
  * in the file LICENSE in the source distribution or at
  * https://www.openssl.org/source/license.html
  */
+#include "internal/e_os.h"
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/apps/cmp.c
+++ b/apps/cmp.c
@@ -10,6 +10,7 @@
  */
 
 /* This app is disabled when OPENSSL_NO_CMP is defined. */
+#include "internal/e_os.h"
 
 #include <string.h>
 #include <ctype.h>

--- a/apps/include/apps.h
+++ b/apps/include/apps.h
@@ -10,10 +10,8 @@
 #ifndef OSSL_APPS_H
 # define OSSL_APPS_H
 
-# include "internal/e_os.h" /* struct timeval for DTLS */
 # include "internal/common.h" /* for HAS_PREFIX */
 # include "internal/nelem.h"
-# include "internal/sockets.h" /* for openssl_fdset() */
 # include <assert.h>
 
 # include <stdarg.h>

--- a/apps/lib/app_rand.c
+++ b/apps/lib/app_rand.c
@@ -7,6 +7,7 @@
  * https://www.openssl.org/source/license.html
  */
 
+#include "internal/e_os.h" /* LIST_SEPARATOR_CHAR */
 #include "apps.h"
 #include <openssl/bio.h>
 #include <openssl/err.h>

--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -48,6 +48,9 @@
 #include "s_apps.h"
 #include "apps.h"
 
+#include "internal/sockets.h" /* for openssl_fdset() */
+#include "internal/e_os.h"
+
 #ifdef _WIN32
 static int WIN32_rename(const char *from, const char *to);
 # define rename(from, to) WIN32_rename((from), (to))

--- a/apps/lib/engine_loader.c
+++ b/apps/lib/engine_loader.c
@@ -14,6 +14,7 @@
  */
 #define OPENSSL_SUPPRESS_DEPRECATED
 
+#include "internal/e_os.h"
 #include "apps.h"
 
 #ifndef OPENSSL_NO_ENGINE

--- a/apps/lib/http_server.c
+++ b/apps/lib/http_server.c
@@ -18,8 +18,10 @@
 #endif
 
 #include <ctype.h>
+#include "internal/e_os.h"
 #include "http_server.h"
-#include "internal/sockets.h"
+#include "internal/sockets.h" /* for openssl_fdset() */
+
 #include <openssl/err.h>
 #include <openssl/trace.h>
 #include <openssl/rand.h>

--- a/apps/lib/s_socket.c
+++ b/apps/lib/s_socket.c
@@ -37,9 +37,10 @@ typedef unsigned int u_int;
 
 #ifndef OPENSSL_NO_SOCK
 
+# include "internal/e_os.h"
 # include "apps.h"
 # include "s_apps.h"
-# include "internal/sockets.h"
+# include "internal/sockets.h" /* for openssl_fdset() */
 
 # include <openssl/bio.h>
 # include <openssl/err.h>

--- a/apps/list.c
+++ b/apps/list.c
@@ -10,6 +10,8 @@
 /* We need to use some deprecated APIs */
 #define OPENSSL_SUPPRESS_DEPRECATED
 
+#include "internal/e_os.h"
+
 #include <string.h>
 #include <openssl/evp.h>
 #include <openssl/err.h>

--- a/apps/openssl.c
+++ b/apps/openssl.c
@@ -7,6 +7,8 @@
  * https://www.openssl.org/source/license.html
  */
 
+#include "internal/e_os.h"
+
 #include <stdio.h>
 #include <stdlib.h>
 #include "internal/common.h"

--- a/apps/rehash.c
+++ b/apps/rehash.c
@@ -8,6 +8,7 @@
  * https://www.openssl.org/source/license.html
  */
 
+#include "internal/e_os.h" /* LIST_SEPARATOR_CHAR */
 #include "apps.h"
 #include "progs.h"
 

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -16,6 +16,7 @@
 #include <errno.h>
 #include <openssl/e_os2.h>
 #include "internal/nelem.h"
+#include "internal/sockets.h" /* for openssl_fdset() */
 
 #ifndef OPENSSL_NO_SOCK
 

--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -9,6 +9,8 @@
  * https://www.openssl.org/source/license.html
  */
 
+#include "internal/e_os.h"
+
 #include <ctype.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -22,6 +24,7 @@
 #include <openssl/async.h>
 #include <openssl/ssl.h>
 #include <openssl/decoder.h>
+#include "internal/sockets.h" /* for openssl_fdset() */
 
 #ifndef OPENSSL_NO_SOCK
 

--- a/apps/speed.c
+++ b/apps/speed.c
@@ -26,6 +26,7 @@
 
 /* We need to use some deprecated APIs */
 #define OPENSSL_SUPPRESS_DEPRECATED
+#include "internal/e_os.h"
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/crypto/bio/bio_sock.c
+++ b/crypto/bio/bio_sock.c
@@ -10,6 +10,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include "bio_local.h"
+
 #ifndef OPENSSL_NO_SOCK
 # define SOCKET_PROTOCOL IPPROTO_TCP
 # ifdef SO_MAXCONN
@@ -38,6 +39,7 @@ static int wsa_init_done = 0;
 #   include <sys/select.h>
 #  endif
 # endif
+# include "internal/sockets.h" /* for openssl_fdset() */
 
 # ifndef OPENSSL_NO_DEPRECATED_1_1_0
 int BIO_get_host_ip(const char *str, unsigned char *ip)

--- a/crypto/time.c
+++ b/crypto/time.c
@@ -10,6 +10,7 @@
 #include <errno.h>
 #include <openssl/err.h>
 #include "internal/time.h"
+#include "internal/e_os.h"
 
 OSSL_TIME ossl_time_now(void)
 {

--- a/include/internal/bio_addr.h
+++ b/include/internal/bio_addr.h
@@ -11,6 +11,7 @@
 # define OSSL_BIO_ADDR_H
 
 # include "internal/e_os.h"
+# include "internal/e_winsock.h"
 # include "internal/sockets.h"
 
 # ifndef OPENSSL_NO_SOCK

--- a/include/internal/e_os.h
+++ b/include/internal/e_os.h
@@ -98,26 +98,6 @@
         */
 #    define _WIN32_WINNT 0x0501
 #   endif
-#   if defined(_WIN32_WINNT) || defined(_WIN32_WCE)
-       /*
-        * Just like defining _WIN32_WINNT including winsock2.h implies
-        * certain "discipline" for maintaining [broad] binary compatibility.
-        * As long as structures are invariant among Winsock versions,
-        * it's sufficient to check for specific Winsock2 API availability
-        * at run-time [DSO_global_lookup is recommended]...
-        */
-#    include <winsock2.h>
-#    include <ws2tcpip.h>
-       /*
-        * Clang-based C++Builder 10.3.3 toolchains cannot find C inline
-        * definitions at link-time.  This header defines WspiapiLoad() as an
-        * __inline function.  https://quality.embarcadero.com/browse/RSP-33806
-        */
-#    if !defined(__BORLANDC__) || !defined(__clang__)
-#     include <wspiapi.h>
-#    endif
-       /* yes, they have to be #included prior to <windows.h> */
-#   endif
 #   include <windows.h>
 #   include <stdio.h>
 #   include <stddef.h>
@@ -136,7 +116,7 @@ static __inline unsigned int _strlen31(const char *str)
         str++, len++;
     return len & 0x7FFFFFFF;
 }
-#   endif
+#   endif   /* def(_WIN64) */
 #   include <malloc.h>
 #   if defined(_MSC_VER) && !defined(_WIN32_WCE) && !defined(_DLL) && defined(stdin)
 #    if _MSC_VER>=1300 && _MSC_VER<1600
@@ -150,6 +130,7 @@ FILE *__iob_func(void);
 #    endif
 #   endif
 #  endif
+
 #  include <io.h>
 #  include <fcntl.h>
 

--- a/include/internal/e_winsock.h
+++ b/include/internal/e_winsock.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2022 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#ifndef OSSL_E_WINSOCK_H
+# define OSSL_E_WINSOCK_H
+# pragma once
+
+# ifdef WINDOWS
+#  if !defined(_WIN32_WCE) && !defined(_WIN32_WINNT)
+      /*
+       * Defining _WIN32_WINNT here in e_winsock.h implies certain "discipline."
+       * Most notably we ought to check for availability of each specific
+       * routine that was introduced after denoted _WIN32_WINNT with
+       * GetProcAddress(). Normally newer functions are masked with higher
+       * _WIN32_WINNT in SDK headers. So that if you wish to use them in
+       * some module, you'd need to override _WIN32_WINNT definition in
+       * the target module in order to "reach for" prototypes, but replace
+       * calls to new functions with indirect calls. Alternatively it
+       * might be possible to achieve the goal by /DELAYLOAD-ing .DLLs
+       * and check for current OS version instead.
+       */
+#   define _WIN32_WINNT 0x0501
+#  endif
+#  if defined(_WIN32_WINNT) || defined(_WIN32_WCE)
+      /*
+       * Just like defining _WIN32_WINNT including winsock2.h implies
+       * certain "discipline" for maintaining [broad] binary compatibility.
+       * As long as structures are invariant among Winsock versions,
+       * it's sufficient to check for specific Winsock2 API availability
+       * at run-time [DSO_global_lookup is recommended]...
+       */
+#   include <winsock2.h>
+#   include <ws2tcpip.h>
+      /*
+       * Clang-based C++Builder 10.3.3 toolchains cannot find C inline
+       * definitions at link-time.  This header defines WspiapiLoad() as an
+       * __inline function.  https://quality.embarcadero.com/browse/RSP-33806
+       */
+#   if !defined(__BORLANDC__) || !defined(__clang__)
+#       include <wspiapi.h>
+#   endif
+      /* yes, they have to be #included prior to <windows.h> */
+#  endif
+#  include <windows.h>
+# endif
+#endif /* !(OSSL_E_WINSOCK_H) */

--- a/include/internal/e_winsock.h
+++ b/include/internal/e_winsock.h
@@ -43,7 +43,7 @@
        * __inline function.  https://quality.embarcadero.com/browse/RSP-33806
        */
 #   if !defined(__BORLANDC__) || !defined(__clang__)
-#       include <wspiapi.h>
+#    include <wspiapi.h>
 #   endif
       /* yes, they have to be #included prior to <windows.h> */
 #  endif

--- a/include/internal/sockets.h
+++ b/include/internal/sockets.h
@@ -41,7 +41,7 @@
 #  endif
 #  if !defined(IPPROTO_IP)
     /* winsock[2].h was included already? */
-#   include <winsock.h>
+#   include "internal/e_winsock.h"
 #  endif
 #  ifdef getservbyname
      /* this is used to be wcecompat/include/winsock_extras.h */

--- a/include/internal/time.h
+++ b/include/internal/time.h
@@ -12,7 +12,8 @@
 # pragma once
 
 # include <openssl/e_os2.h>     /* uint64_t */
-# include "internal/e_os.h"     /* for struct timeval */
+# include "internal/e_os.h"
+# include "internal/e_winsock.h" /* for struct timeval */
 # include "internal/safe_math.h"
 
 /*

--- a/ssl/d1_lib.c
+++ b/ssl/d1_lib.c
@@ -8,6 +8,7 @@
  */
 
 #include "internal/e_os.h"
+#include "internal/e_winsock.h"          /* struct timeval for DTLS_CTRL_GET_TIMEOUT */
 #include <stdio.h>
 #include <openssl/objects.h>
 #include <openssl/rand.h>

--- a/ssl/record/rec_layer_s3.c
+++ b/ssl/record/rec_layer_s3.c
@@ -7,6 +7,8 @@
  * https://www.openssl.org/source/license.html
  */
 
+#include "internal/e_os.h"
+
 #include <stdio.h>
 #include <limits.h>
 #include <errno.h>

--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -9,7 +9,8 @@
  * https://www.openssl.org/source/license.html
  */
 
-#include <stdio.h>
+#include "internal/e_os.h"
+
 #include <openssl/objects.h>
 #include "internal/nelem.h"
 #include "ssl_local.h"

--- a/ssl/ssl_cert.c
+++ b/ssl/ssl_cert.c
@@ -8,6 +8,8 @@
  * https://www.openssl.org/source/license.html
  */
 
+#include "internal/e_os.h"
+
 #include <stdio.h>
 #include <sys/types.h>
 

--- a/ssl/ssl_conf.c
+++ b/ssl/ssl_conf.c
@@ -7,6 +7,8 @@
  * https://www.openssl.org/source/license.html
  */
 
+#include "internal/e_os.h"
+
 #include <stdio.h>
 #include "ssl_local.h"
 #include <openssl/conf.h>

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -9,8 +9,10 @@
  * https://www.openssl.org/source/license.html
  */
 
-#include "ssl_local.h"
 #include "internal/e_os.h"
+#include "internal/e_winsock.h"
+#include "ssl_local.h"
+
 #include <openssl/objects.h>
 #include <openssl/x509v3.h>
 #include <openssl/rand.h>

--- a/ssl/ssl_local.h
+++ b/ssl/ssl_local.h
@@ -12,7 +12,6 @@
 #ifndef OSSL_SSL_LOCAL_H
 # define OSSL_SSL_LOCAL_H
 
-# include "internal/e_os.h"              /* struct timeval for DTLS */
 # include <stdlib.h>
 # include <time.h>
 # include <errno.h>

--- a/ssl/statem/statem.c
+++ b/ssl/statem/statem.c
@@ -7,6 +7,8 @@
  * https://www.openssl.org/source/license.html
  */
 
+#include "internal/e_os.h"
+
 #if defined(__TANDEM) && defined(_SPT_MODEL_)
 # include <spthread.h>
 # include <spt_extensions.h> /* timeval */

--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -9,6 +9,8 @@
  * https://www.openssl.org/source/license.html
  */
 
+#include "internal/e_os.h"
+
 #include <stdio.h>
 #include "../ssl_local.h"
 #include "statem_local.h"

--- a/test/helpers/ssltestlib.c
+++ b/test/helpers/ssltestlib.c
@@ -25,6 +25,7 @@
 
 #if (!defined(OPENSSL_NO_KTLS) || !defined(OPENSSL_NO_QUIC)) && !defined(OPENSSL_NO_POSIX_IO) && !defined(OPENSSL_NO_SOCK)
 # define OSSL_USE_SOCKETS 1
+# include "internal/e_winsock.h"
 # include "internal/sockets.h"
 # include <openssl/bio.h>
 #endif


### PR DESCRIPTION
This PR improves Windows compilation time.

One more step to help fixing #14055

Kind of Follow-up of an old PR #4188 :
> Replace usage of  `struct timeval` by struct OPENSSL_timeval.

I measure a small compile time improvement : around 1 minute less per build.
Lets compare AppVeyor timing.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
