### PR TITLE
Fix compiling error on arm

### DIFF
--- a/test/p_test.c
+++ b/test/p_test.c
@@ -115,11 +115,15 @@ static int p_get_params(void *provctx, OSSL_PARAM params[])
 }
 
 static void p_set_error(int lib, int reason, const char *file, int line,
-                        const char *func)
+                        const char *func, const char *fmt, ...)
 {
+    va_list ap;
+
+    va_start(ap, fmt);
     c_new_error(NULL);
     c_set_error_debug(NULL, file, line, func);
-    c_vset_error(NULL, ERR_PACK(lib, 0, reason), NULL, NULL);
+    c_vset_error(NULL, ERR_PACK(lib, 0, reason), fmt, ap);
+    va_end(ap);
 }
 
 static const OSSL_ITEM *p_get_reason_strings(void *_)
@@ -192,7 +196,7 @@ int OSSL_provider_init(const OSSL_CORE_HANDLE *handle,
      * Set a spurious error to check error handling works correctly. This will
      * be ignored
      */
-    p_set_error(ERR_LIB_PROV, 1, ctx->thisfile, OPENSSL_LINE, ctx->thisfunc);
+    p_set_error(ERR_LIB_PROV, 1, ctx->thisfile, OPENSSL_LINE, ctx->thisfunc, NULL);
 
     *provctx = (void *)ctx;
     *out = p_test_table;


### PR DESCRIPTION
Fixes #14313

Building with master branch on arm, the error is reported as below

test/p_test.c: In function 'p_set_error':
test/p_test.c:122:56: error: incompatible type for argument 4 of 'c_vset_error'
c_vset_error(NULL, ERR_PACK(lib, 0, reason), NULL, NULL);
                                                                                    ^~~~
test/p_test.c:122:56: note: expected 'va_list {aka __va_list}' but argument is of type 'void *'
Makefile:23428: recipe for target 'test/p_test-dso-p_test.o' failed

This fix simply replaces NULL with va_list variable.