### PR TITLE
Fix a copy&paste error in evp_extra_test

### DIFF
--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -700,9 +700,8 @@ static int test_EC_priv_pub(void)
         || !TEST_true(OSSL_PARAM_BLD_push_octet_string(bld,
                                                        OSSL_PKEY_PARAM_PUB_KEY,
                                                        ec_pub, sizeof(ec_pub)))
-        || !TEST_true(OSSL_PARAM_BLD_push_octet_string(bld,
-                                                       OSSL_PKEY_PARAM_PUB_KEY,
-                                                       ec_pub, sizeof(ec_pub))))
+        || !TEST_true(OSSL_PARAM_BLD_push_BN(bld, OSSL_PKEY_PARAM_PRIV_KEY,
+                                             priv)))
         goto err;
     if (!TEST_ptr(params = OSSL_PARAM_BLD_to_param(bld)))
         goto err;


### PR DESCRIPTION
test_EC_priv_pub fails to test the case where both a private and public key have been supplied.

Fixes #14349
