### PR TITLE
Fix threading issues in crypto/provider_core.c

### DIFF
--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -201,7 +201,9 @@ int ossl_provider_disable_fallback_loading(OSSL_LIB_CTX *libctx)
     struct provider_store_st *store;
 
     if ((store = get_provider_store(libctx)) != NULL) {
+        CRYPTO_THREAD_write_lock(store->lock);
         store->use_fallbacks = 0;
+        CRYPTO_THREAD_unlock(store->lock);
         return 1;
     }
     return 0;

--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -480,7 +480,7 @@ static int provider_init(OSSL_PROVIDER *prov)
 
     /*
      * The flag lock is used to lock init, not only because the flag is
-     * checked here and set at the end, but also because this functions
+     * checked here and set at the end, but also because this function
      * modifies a number of things in the provider structure that this
      * function needs to perform under lock anyway.
      */

--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -381,6 +381,7 @@ void ossl_provider_free(OSSL_PROVIDER *prov)
             OPENSSL_free(prov->path);
             sk_INFOPAIR_pop_free(prov->parameters, free_infopair);
             CRYPTO_THREAD_lock_free(prov->opbits_lock);
+            CRYPTO_THREAD_lock_free(prov->flag_lock);
 #ifndef HAVE_ATOMICS
             CRYPTO_THREAD_lock_free(prov->refcnt_lock);
             CRYPTO_THREAD_lock_free(prov->activatecnt_lock);


### PR DESCRIPTION
## Make ossl_provider_disable_fallback_loading() thread safe 

-----

##  Make provider provider_init thread safe, and flag checking/setting too

provider_init() makes changes in the provider structure, and needs a
bit of protection to ensure that doesn't happen concurrently with race
conditions.

This also demands a bit of protection of the flags, since they are
bits and presumably occupy the same byte in memory.