### PR TITLE
HTTP: Fix BIO_mem_d2i() on NULL mem BIO input

### DIFF
--- a/crypto/http/http_client.c
+++ b/crypto/http/http_client.c
@@ -736,9 +736,12 @@ static ASN1_VALUE *BIO_mem_d2i(BIO *mem, const ASN1_ITEM *it)
 {
     const unsigned char *p;
     long len = BIO_get_mem_data(mem, &p);
-    ASN1_VALUE *resp = ASN1_item_d2i(NULL, &p, len, it);
+    ASN1_VALUE *resp;
 
-    if (resp == NULL)
+    if (mem == NULL)
+        return NULL;
+
+    if ((resp = ASN1_item_d2i(NULL, &p, len, it)) == NULL)
         ERR_raise(ERR_LIB_HTTP, HTTP_R_RESPONSE_PARSE_ERROR);
     return resp;
 }
@@ -1056,11 +1059,10 @@ ASN1_VALUE *OSSL_HTTP_get_asn1(const char *url,
         ERR_raise(ERR_LIB_HTTP, ERR_R_PASSED_NULL_PARAMETER);
         return NULL;
     }
-    if ((mem = OSSL_HTTP_get(url, proxy, no_proxy, bio, rbio, bio_update_fn,
-                             arg, headers, maxline, max_resp_len, timeout,
-                             expected_ct, 1 /* expect_asn1 */))
-        != NULL)
-        resp = BIO_mem_d2i(mem, rsp_it);
+    mem = OSSL_HTTP_get(url, proxy, no_proxy, bio, rbio, bio_update_fn,
+                        arg, headers, maxline, max_resp_len, timeout,
+                        expected_ct, 1 /* expect_asn1 */);
+    resp = BIO_mem_d2i(mem /* may be NULL */, rsp_it);
     BIO_free(mem);
     return resp;
 }
@@ -1096,8 +1098,7 @@ ASN1_VALUE *OSSL_HTTP_post_asn1(const char *server, const char *port,
                                  max_resp_len, timeout,
                                  expected_ct, 1 /* expect_asn1 */, NULL);
     BIO_free(req_mem);
-    if (res_mem != NULL)
-        resp = BIO_mem_d2i(res_mem, rsp_it);
+    resp = BIO_mem_d2i(res_mem /* may be NULL */, rsp_it);
     BIO_free(res_mem);
     return resp;
 }

--- a/crypto/http/http_local.h
+++ b/crypto/http/http_local.h
@@ -23,14 +23,6 @@ OSSL_HTTP_REQ_CTX *HTTP_REQ_CTX_new(BIO *wbio, BIO *rbio, int use_http_proxy,
                                     int timeout,
                                     const char *expected_content_type,
                                     int expect_asn1);
-ASN1_VALUE *HTTP_sendreq_bio(BIO *bio, OSSL_HTTP_bio_cb_t bio_update_fn,
-                             void *arg, const char *server, const char *port,
-                             const char *path, int use_ssl, int use_proxy,
-                             const STACK_OF(CONF_VALUE) *headers,
-                             const char *content_type,
-                             ASN1_VALUE *req, const ASN1_ITEM *req_it,
-                             int maxline, unsigned long max_resp_len,
-                             int timeout, const ASN1_ITEM *rsp_it);
 int http_use_proxy(const char *no_proxy, const char *server);
 const char *http_adapt_proxy(const char *proxy, const char *no_proxy,
                              const char *server, int use_ssl);

--- a/crypto/ocsp/ocsp_http.c
+++ b/crypto/ocsp/ocsp_http.c
@@ -50,17 +50,16 @@ OCSP_RESPONSE *OCSP_sendreq_bio(BIO *b, const char *path, OCSP_REQUEST *req)
 {
     OCSP_RESPONSE *resp = NULL;
     OSSL_HTTP_REQ_CTX *ctx;
-    int rv;
 
     ctx = OCSP_sendreq_new(b, path, req, -1 /* default max resp line length */);
     if (ctx == NULL)
         return NULL;
 
-    rv = OCSP_sendreq_nbio(&resp, ctx);
+    OCSP_sendreq_nbio(&resp, ctx);
 
     /* this indirectly calls ERR_clear_error(): */
     OSSL_HTTP_REQ_CTX_free(ctx);
 
-    return rv == 1 ? resp : NULL;
+    return resp;
 }
 #endif /* !defined(OPENSSL_NO_OCSP) */


### PR DESCRIPTION
This fixes `BIO_mem_d2i()` on NULL `mem` BIO input and 
related failure behavior of `OSSL_HTTP_REQ_CTX_sendreq_d2i()`, `OCSP_sendreq_nbio()`, etc.

Also removes the unused declaration of `HTTP_sendreq_bio()` from `http_local.h`
and simplifies `OCSP_sendreq_bio()`.

Fixes #14322
