### PR TITLE
DOCS: Fix provider-mac.pod and the docs of our implementations

### DIFF
--- a/doc/man7/EVP_MAC-BLAKE2.pod
+++ b/doc/man7/EVP_MAC-BLAKE2.pod
@@ -36,25 +36,28 @@ The length of the "size" parameter should not exceed that of a B<size_t>.
 
 =item "key" (B<OSSL_MAC_PARAM_KEY>) <octet string>
 
-This may be at most 64 bytes for BLAKE2BMAC or 32 for BLAKE2SMAC and
-at least 1 byte in both cases.
+Sets the MAC key.
+It may be at most 64 bytes for BLAKE2BMAC or 32 for BLAKE2SMAC and at
+least 1 byte in both cases.
+Setting this parameter is identical to passing a I<key> to L<EVP_MAC_init(3)>.
 
 =item "custom" (B<OSSL_MAC_PARAM_CUSTOM>) <octet string>
 
-This is an optional value of at most 16 bytes for BLAKE2BMAC or 8 for
-BLAKE2SMAC.
-It is empty by default.
+Sets the custom value.
+It is an optional value of at most 16 bytes for BLAKE2BMAC or 8 for
+BLAKE2SMAC, and is empty by default.
 
 =item "salt" (B<OSSL_MAC_PARAM_SALT>) <octet string>
 
-This is an optional value of at most 16 bytes for BLAKE2BMAC or 8 for
-BLAKE2SMAC.
-It is empty by default.
+Sets the salt.
+It is an optional value of at most 16 bytes for BLAKE2BMAC or 8 for
+BLAKE2SMAC, and is empty by default.
 
 =item "size" (B<OSSL_MAC_PARAM_SIZE>) <unsigned integer>
 
-When set, this can be any number between between 1 and 32 for
-EVP_MAC_BLAKE2S or 64 for EVP_MAC_BLAKE2B.
+Sets the MAC size.
+This can be any number between between 1 and 32 for EVP_MAC_BLAKE2S or
+between 1 and 64 for EVP_MAC_BLAKE2B.
 It is 32 and 64 respectively by default.
 
 =back

--- a/doc/man7/EVP_MAC-BLAKE2.pod
+++ b/doc/man7/EVP_MAC-BLAKE2.pod
@@ -56,8 +56,8 @@ BLAKE2SMAC, and is empty by default.
 =item "size" (B<OSSL_MAC_PARAM_SIZE>) <unsigned integer>
 
 Sets the MAC size.
-It can be any number between between 1 and 32 for EVP_MAC_BLAKE2S or
-between 1 and 64 for EVP_MAC_BLAKE2B.
+It can be any number between 1 and 32 for EVP_MAC_BLAKE2S or between 1
+and 64 for EVP_MAC_BLAKE2B.
 It is 32 and 64 respectively by default.
 
 =back

--- a/doc/man7/EVP_MAC-BLAKE2.pod
+++ b/doc/man7/EVP_MAC-BLAKE2.pod
@@ -56,7 +56,7 @@ BLAKE2SMAC, and is empty by default.
 =item "size" (B<OSSL_MAC_PARAM_SIZE>) <unsigned integer>
 
 Sets the MAC size.
-This can be any number between between 1 and 32 for EVP_MAC_BLAKE2S or
+It can be any number between between 1 and 32 for EVP_MAC_BLAKE2S or
 between 1 and 64 for EVP_MAC_BLAKE2B.
 It is 32 and 64 respectively by default.
 

--- a/doc/man7/EVP_MAC-CMAC.pod
+++ b/doc/man7/EVP_MAC-CMAC.pod
@@ -8,6 +8,9 @@ EVP_MAC-CMAC - The CMAC EVP_MAC implementation
 
 Support for computing CMAC MACs through the B<EVP_MAC> API.
 
+This implementation uses EVP_CIPHER functions to get access to the underlying
+cipher.
+
 =head2 Identity
 
 This implementation is identified with this name and properties, to be
@@ -30,9 +33,18 @@ The following parameter can be set with EVP_MAC_CTX_set_params():
 
 =item "key" (B<OSSL_MAC_PARAM_KEY>) <octet string>
 
+Sets the MAC key.
+Setting this parameter is identical to passing a I<key> to L<EVP_MAC_init(3)>.
+
 =item "cipher" (B<OSSL_MAC_PARAM_CIPHER>) <UTF8 string>
 
+Sets the name of the underlying cipher to be used.
+
 =item "properties" (B<OSSL_MAC_PARAM_PROPERTIES>) <UTF8 string>
+
+Sets the properties to be queried when trying to fetch the underlying cipher.
+This must be given together with the cipher naming parameter to be considered
+valid.
 
 =back
 

--- a/doc/man7/EVP_MAC-GMAC.pod
+++ b/doc/man7/EVP_MAC-GMAC.pod
@@ -8,6 +8,9 @@ EVP_MAC-GMAC - The GMAC EVP_MAC implementation
 
 Support for computing GMAC MACs through the B<EVP_MAC> API.
 
+This implementation uses EVP_CIPHER functions to get access to the underlying
+cipher.
+
 =head2 Identity
 
 This implementation is identified with this name and properties, to be
@@ -30,11 +33,22 @@ The following parameter can be set with EVP_MAC_CTX_set_params():
 
 =item "key" (B<OSSL_MAC_PARAM_KEY>) <octet string>
 
+Sets the MAC key.
+Setting this parameter is identical to passing a I<key> to L<EVP_MAC_init(3)>.
+
 =item "iv" (B<OSSL_MAC_PARAM_IV>) <octet string>
+
+Sets the IV of the underlying cipher, when applicable.
 
 =item "cipher" (B<OSSL_MAC_PARAM_CIPHER>) <UTF8 string>
 
+Sets the name of the underlying cipher to be used.
+
 =item "properties" (B<OSSL_MAC_PARAM_PROPERTIES>) <UTF8 string>
+
+Sets the properties to be queried when trying to fetch the underlying cipher.
+This must be given together with the cipher naming parameter to be considered
+valid.
 
 =back
 
@@ -44,6 +58,8 @@ EVP_MAC_CTX_get_params():
 =over 4
 
 =item "size" (B<OSSL_MAC_PARAM_SIZE>) <unsigned integer>
+
+Gets the MAC size.
 
 =back
 

--- a/doc/man7/EVP_MAC-HMAC.pod
+++ b/doc/man7/EVP_MAC-HMAC.pod
@@ -9,7 +9,7 @@ EVP_MAC-HMAC - The HMAC EVP_MAC implementation
 Support for computing HMAC MACs through the B<EVP_MAC> API.
 
 This implementation uses EVP_MD functions to get access to the underlying
-cipher.
+digest.
 
 =head2 Identity
 
@@ -43,27 +43,27 @@ Sets the name of the underlying digest to be used.
 =item "properties" (B<OSSL_MAC_PARAM_PROPERTIES>) <UTF8 string>
 
 Sets the properties to be queried when trying to fetch the underlying digest.
-This must be given together with the digest naming parameter to be considered
-valid.
+This must be given together with the digest naming parameter ("digest", or
+B<OSSL_MAC_PARAM_DIGEST>) to be considered valid.
 
 =item "digest-noinit" (B<OSSL_MAC_PARAM_DIGEST_NOINIT>) <integer>
 
-A simple flag to set the MAC digest to not initialise the
-implementation specific data. The value 0 or 1 is expected.
+A flag to set the MAC digest to not initialise the implementation
+specific data.
+The value 0 or 1 is expected.
 
 =item "digest-oneshot" (B<OSSL_MAC_PARAM_DIGEST_ONESHOT>) <integer>
 
-A simple flag to set the MAC digest to be a oneshot operation.
+A flag to set the MAC digest to be a oneshot operation.
 The value 0 or 1 is expected.
 
 =item "tls-data-size" (B<OSSL_MAC_PARAM_TLS_DATA_SIZE>) <unsigned integer>
 
 =back
 
-The "flags" parameter is passed directly to HMAC_CTX_set_flags().
+=for comment The "flags" parameter is passed directly to HMAC_CTX_set_flags().
 
-The following parameter can be retrieved with
-EVP_MAC_CTX_get_params():
+The following parameter can be retrieved with EVP_MAC_CTX_get_params():
 
 =over 4
 

--- a/doc/man7/EVP_MAC-HMAC.pod
+++ b/doc/man7/EVP_MAC-HMAC.pod
@@ -54,7 +54,7 @@ The value 0 or 1 is expected.
 
 =item "digest-oneshot" (B<OSSL_MAC_PARAM_DIGEST_ONESHOT>) <integer>
 
-A flag to set the MAC digest to be a oneshot operation.
+A flag to set the MAC digest to be a one-shot operation.
 The value 0 or 1 is expected.
 
 =item "tls-data-size" (B<OSSL_MAC_PARAM_TLS_DATA_SIZE>) <unsigned integer>

--- a/doc/man7/EVP_MAC-HMAC.pod
+++ b/doc/man7/EVP_MAC-HMAC.pod
@@ -8,6 +8,9 @@ EVP_MAC-HMAC - The HMAC EVP_MAC implementation
 
 Support for computing HMAC MACs through the B<EVP_MAC> API.
 
+This implementation uses EVP_MD functions to get access to the underlying
+cipher.
+
 =head2 Identity
 
 This implementation is identified with this name and properties, to be
@@ -30,13 +33,28 @@ The following parameter can be set with EVP_MAC_CTX_set_params():
 
 =item "key" (B<OSSL_MAC_PARAM_KEY>) <octet string>
 
+Sets the MAC key.
+Setting this parameter is identical to passing a I<key> to L<EVP_MAC_init(3)>.
+
 =item "digest" (B<OSSL_MAC_PARAM_DIGEST>) <UTF8 string>
+
+Sets the name of the underlying digest to be used.
+
+=item "properties" (B<OSSL_MAC_PARAM_PROPERTIES>) <UTF8 string>
+
+Sets the properties to be queried when trying to fetch the underlying digest.
+This must be given together with the digest naming parameter to be considered
+valid.
 
 =item "digest-noinit" (B<OSSL_MAC_PARAM_DIGEST_NOINIT>) <integer>
 
+A simple flag to set the MAC digest to not initialise the
+implementation specific data. The value 0 or 1 is expected.
+
 =item "digest-oneshot" (B<OSSL_MAC_PARAM_DIGEST_ONESHOT>) <integer>
 
-=item "properties" (B<OSSL_MAC_PARAM_PROPERTIES>) <UTF8 string>
+A simple flag to set the MAC digest to be a oneshot operation.
+The value 0 or 1 is expected.
 
 =item "tls-data-size" (B<OSSL_MAC_PARAM_TLS_DATA_SIZE>) <unsigned integer>
 

--- a/doc/man7/EVP_MAC-KMAC.pod
+++ b/doc/man7/EVP_MAC-KMAC.pod
@@ -36,9 +36,18 @@ The length of the "size" parameter should not exceed that of a B<size_t>.
 
 =item "key" (B<OSSL_MAC_PARAM_KEY>) <octet string>
 
+Sets the MAC key.
+Setting this parameter is identical to passing a I<key> to L<EVP_MAC_init(3)>.
+
 =item "custom" (B<OSSL_MAC_PARAM_CUSTOM>) <octet string>
 
+Sets the custom value.
+It is an optional value of at most 127 bytes, and is empty by default.
+
 =item "size" (B<OSSL_MAC_PARAM_SIZE>) <unsigned integer>
+
+Sets the MAC size.
+By default, it is 16 for C<KMAC-128> and 32 for C<KMAC-256>.
 
 =item "xof" (B<OSSL_MAC_PARAM_XOF>) <integer>
 

--- a/doc/man7/EVP_MAC-Poly1305.pod
+++ b/doc/man7/EVP_MAC-Poly1305.pod
@@ -30,6 +30,9 @@ The following parameter can be set with EVP_MAC_CTX_set_params():
 
 =item "key" (B<OSSL_MAC_PARAM_KEY>) <octet string>
 
+Sets the MAC key.
+Setting this parameter is identical to passing a I<key> to L<EVP_MAC_init(3)>.
+
 =back
 
 The following parameters can be retrieved with
@@ -38,6 +41,8 @@ EVP_MAC_CTX_get_params():
 =over 4
 
 =item "size" (B<OSSL_MAC_PARAM_SIZE>) <unsigned integer>
+
+Gets the MAC size.
 
 =back
 

--- a/doc/man7/EVP_MAC-Siphash.pod
+++ b/doc/man7/EVP_MAC-Siphash.pod
@@ -34,7 +34,12 @@ The length of the "size" parameter should not exceed that of a B<size_t>.
 
 =item "key" (B<OSSL_MAC_PARAM_KEY>) <octet string>
 
+Sets the MAC key.
+Setting this parameter is identical to passing a I<key> to L<EVP_MAC_init(3)>.
+
 =item "size" (B<OSSL_MAC_PARAM_SIZE>) <unsigned integer>
+
+Sets the MAC size.
 
 =item "c-rounds" (B<OSSL_MAC_PARAM_C_ROUNDS>) <unsigned integer>
 

--- a/doc/man7/provider-mac.pod
+++ b/doc/man7/provider-mac.pod
@@ -181,6 +181,8 @@ should have as well, see the documentation of the implementation.
 
 =back
 
+=back
+
 =head1 RETURN VALUES
 
 OSSL_FUNC_mac_newctx() and OSSL_FUNC_mac_dupctx() should return the newly created
@@ -197,8 +199,9 @@ array, or NULL if none is offered.
 =head1 SEE ALSO
 
 L<provider(7)>,
-L<EVP_MAC-CMAC(7)>, L<EVP_MAC-GMAC(7)>, L<EVP_MAC-HMAC(7)>, L<EVP_MAC-KMAC(7)>,
-L<EVP_MAC-Poly1305(7)>, L<EVP_MAC-Siphash(7)>
+L<EVP_MAC-BLAKE2(7)>, L<EVP_MAC-CMAC(7)>, L<EVP_MAC-GMAC(7)>,
+L<EVP_MAC-HMAC(7)>, L<EVP_MAC-KMAC(7)>, L<EVP_MAC-Poly1305(7)>,
+L<EVP_MAC-Siphash(7)>
 
 
 =head1 HISTORY

--- a/doc/man7/provider-mac.pod
+++ b/doc/man7/provider-mac.pod
@@ -152,9 +152,11 @@ with the provider side context I<mctx> in its current state if it is
 not NULL.  Otherwise, they return the parameters associated with the
 provider side algorithm I<provctx>.
 
+All MAC implementations are expected to handle the following parameters:
 
-Parameters currently recognised by built-in macs are as follows. Not all
-parameters are relevant to, or are understood by all macs:
+=over 4
+
+=item with OSSL_FUNC_set_ctx_params():
 
 =over 4
 
@@ -163,56 +165,19 @@ parameters are relevant to, or are understood by all macs:
 Sets the key in the associated MAC ctx.  This is identical to passing a I<key>
 argument to the OSSL_FUNC_mac_init() function.
 
-=item "iv" (B<OSSL_MAC_PARAM_IV>) <octet string>
+=back
 
-Sets the IV of the underlying cipher, when applicable.
+=item with OSSL_FUNC_get_params():
 
-=item "custom" (B<OSSL_MAC_PARAM_CUSTOM>) <UTF8 string>
-
-Sets the custom string in the associated MAC ctx.
-
-=item "salt" (B<OSSL_MAC_PARAM_SALT>) <octet string>
-
-Sets the salt of the underlying cipher, when applicable.
-
-=item "xof" (B<OSSL_MAC_PARAM_BLOCK_XOF>) <integer>
-
-Sets XOF mode in the associated MAC ctx.
-0 means no XOF mode, 1 means XOF mode.
-
-=item "digest-noinit" (B<OSSL_MAC_PARAM_DIGEST_NOINIT>) <integer>
-
-A simple flag to set the MAC digest to not initialise the
-implementation specific data. The value 0 or 1 is expected.
-
-=item "digest-oneshot" (B<OSSL_MAC_PARAM_DIGEST_ONESHOT>) <integer>
-
-A simple flag to set the MAC digest to be a oneshot operation.
-The value 0 or 1 is expected.
-
-
-=for comment We need to investigate if this is the right approach
-
-=item "cipher" (B<OSSL_MAC_PARAM_CIPHER>) <UTF8 string>
-
-=item "digest" (B<OSSL_MAC_PARAM_DIGEST>) <UTF8 string>
-
-Sets the name of the underlying cipher or digest to be used.
-It must name a suitable algorithm for the MAC that's being used.
-
-=item "properties" (B<OSSL_MAC_PARAM_PROPERTIES>) <UTF8 string>
-
-Sets the properties to be queried when trying to fetch the underlying algorithm.
-This must be given together with the algorithm naming parameter to be
-considered valid.
+=over 4
 
 =item "size" (B<OSSL_MAC_PARAM_SIZE>) <integer>
 
-Can be used to get the resulting MAC size.
+Can be used to get the default MAC size (which might be the only allowable
+MAC size for the implementation).
 
-With some MAC algorithms, it can also be used to set the size that the
-resulting MAC should have.
-Allowable sizes are decided within each implementation.
+Note that some implementations allow setting the size that the resulting MAC
+should have as well, see the documentation of the implementation.
 
 =back
 
@@ -231,7 +196,10 @@ array, or NULL if none is offered.
 
 =head1 SEE ALSO
 
-L<provider(7)>, L<EVP_MAC_init(3)>
+L<provider(7)>,
+L<EVP_MAC-CMAC(7)>, L<EVP_MAC-GMAC(7)>, L<EVP_MAC-HMAC(7)>, L<EVP_MAC-KMAC(7)>,
+L<EVP_MAC-Poly1305(7)>, L<EVP_MAC-Siphash(7)>
+
 
 =head1 HISTORY
 


### PR DESCRIPTION
The idea being that doc/man7/provider-mac.pod is for provider authors,
while provider users find the documentation for each implementation in
doc/man7/EVP_MAC-*.pod, the documentation of parameters wasn't quite
aligned.  This change re-arranges the parameter documentation to be
more aligned with this idea.
