### PR TITLE
doc: add a note to the RAND_get0_ calls indicating how to set the DRBG type.

### DIFF
--- a/doc/man3/RAND_get0_primary.pod
+++ b/doc/man3/RAND_get0_primary.pod
@@ -57,9 +57,14 @@ During initialization, it is possible to change the reseed interval
 and reseed time interval.
 It is also possible to exchange the reseeding callbacks entirely.
 
+To set the type of DRBG that will be instantiated, use the
+L<RAND_set_DRBG_type(3)> call before accessing the random number generation
+infrastructure.
+
 =head1 SEE ALSO
 
-L<EVP_RAND(3)>
+L<EVP_RAND(3)>,
+L<RAND_set_DRBG_type(3)>
 
 =head1 HISTORY
 


### PR DESCRIPTION

The type needs to be set before the DRBGs are created.

- [x] documentation is added or updated

