### PR TITLE
[1.1.1] Fix out-of-tree build failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,25 @@ jobs:
       - name: make test
         run: make test
 
+  out-of-tree_build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: setup build dir
+        run: |
+            set -eux
+            mkdir -p ${myblddir:=../_build/nest/a/little/more}
+            echo "mysrcdir=$(realpath .)" | tee -a $GITHUB_ENV
+            echo "myblddir=$(realpath $myblddir)" | tee -a $GITHUB_ENV
+      - name: config
+        run: set -eux ; cd ${{ env.myblddir }} && ${{ env.mysrcdir }}/config --strict-warnings && perl configdata.pm --dump
+      - name: make build_generated
+        run: set -eux; cd ${{ env.myblddir }} && make -s build_generated
+      - name: make update
+        run: set -eux; cd ${{ env.myblddir }} && make update
+      - name: make
+        run: set -eux; cd ${{ env.myblddir }} && make -s -j4
+
   no-deprecated:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,8 @@ jobs:
         run: set -eux; cd ${{ env.myblddir }} && make update
       - name: make
         run: set -eux; cd ${{ env.myblddir }} && make -s -j4
+      - name: make test (minimal subset)
+        run: set -eux; cd ${{ env.myblddir }} && make test TESTS='0[0-9]'
 
   no-deprecated:
     runs-on: ubuntu-latest

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -917,8 +917,8 @@ errors:
           done )
 
 ordinals:
-	( b=`pwd`; cd $(SRCDIR); $(PERL) -I$$b util/mkdef.pl crypto update )
-	( b=`pwd`; cd $(SRCDIR); $(PERL) -I$$b util/mkdef.pl ssl update )
+	$(PERL) $(SRCDIR)/util/mkdef.pl crypto update
+	$(PERL) $(SRCDIR)/util/mkdef.pl ssl update
 
 test_ordinals:
 	( cd test; \


### PR DESCRIPTION
**Note: this PR is ready for review**

This was originally a PR to just trigger the issue described in #11940 , but I have reworked it to include the fix authored by @levitte and to keep the extra CI job (as it does not take too much time and this is not the first time we accidentally break out-of-tree builds).

## Checklist

- [x] Fixes #11940
- [x] Add CI job for #11940

<details>
<summary>Original description</summary>

# THIS PR SHOULD NOT BE MERGED

This PR is just meant to exercise the issue reported in #11940 using the new CI infrastructure, so that all it takes to verify if it is solved is to rebase this branch.

Note that one of the commits is dropping some jobs as they take longer and are not relevant for this issue.
</details>