### PR TITLE
Fix reason code: EVP_R_OPERATON_NOT_INITIALIZED

### DIFF
--- a/crypto/err/openssl.txt
+++ b/crypto/err/openssl.txt
@@ -2596,7 +2596,7 @@ EVP_R_NULL_MAC_PKEY_CTX:208:null mac pkey ctx
 EVP_R_ONLY_ONESHOT_SUPPORTED:177:only oneshot supported
 EVP_R_OPERATION_NOT_SUPPORTED_FOR_THIS_KEYTYPE:150:\
 	operation not supported for this keytype
-EVP_R_OPERATON_NOT_INITIALIZED:151:operation not initialized
+EVP_R_OPERATION_NOT_INITIALIZED:151:operation not initialized
 EVP_R_PARAMETER_TOO_LARGE:187:parameter too large
 EVP_R_PARTIALLY_OVERLAPPING:162:partially overlapping buffers
 EVP_R_PBKDF2_ERROR:181:pbkdf2 error

--- a/crypto/evp/asymcipher.c
+++ b/crypto/evp/asymcipher.c
@@ -183,7 +183,7 @@ int EVP_PKEY_encrypt(EVP_PKEY_CTX *ctx,
     }
 
     if (ctx->operation != EVP_PKEY_OP_ENCRYPT) {
-        EVPerr(0, EVP_R_OPERATON_NOT_INITIALIZED);
+        EVPerr(0, EVP_R_OPERATION_NOT_INITIALIZED);
         return -1;
     }
 
@@ -221,7 +221,7 @@ int EVP_PKEY_decrypt(EVP_PKEY_CTX *ctx,
     }
 
     if (ctx->operation != EVP_PKEY_OP_DECRYPT) {
-        EVPerr(0, EVP_R_OPERATON_NOT_INITIALIZED);
+        EVPerr(0, EVP_R_OPERATION_NOT_INITIALIZED);
         return -1;
     }
 

--- a/crypto/evp/evp_err.c
+++ b/crypto/evp/evp_err.c
@@ -133,7 +133,7 @@ static const ERR_STRING_DATA EVP_str_reasons[] = {
     "only oneshot supported"},
     {ERR_PACK(ERR_LIB_EVP, 0, EVP_R_OPERATION_NOT_SUPPORTED_FOR_THIS_KEYTYPE),
     "operation not supported for this keytype"},
-    {ERR_PACK(ERR_LIB_EVP, 0, EVP_R_OPERATON_NOT_INITIALIZED),
+    {ERR_PACK(ERR_LIB_EVP, 0, EVP_R_OPERATION_NOT_INITIALIZED),
     "operation not initialized"},
     {ERR_PACK(ERR_LIB_EVP, 0, EVP_R_PARAMETER_TOO_LARGE),
     "parameter too large"},

--- a/crypto/evp/exchange.c
+++ b/crypto/evp/exchange.c
@@ -364,7 +364,7 @@ int EVP_PKEY_derive_set_peer(EVP_PKEY_CTX *ctx, EVP_PKEY *peer)
         && ctx->operation != EVP_PKEY_OP_ENCRYPT
         && ctx->operation != EVP_PKEY_OP_DECRYPT) {
         EVPerr(EVP_F_EVP_PKEY_DERIVE_SET_PEER,
-               EVP_R_OPERATON_NOT_INITIALIZED);
+               EVP_R_OPERATION_NOT_INITIALIZED);
         return -1;
     }
 
@@ -425,7 +425,7 @@ int EVP_PKEY_derive(EVP_PKEY_CTX *ctx, unsigned char *key, size_t *pkeylen)
     }
 
     if (!EVP_PKEY_CTX_IS_DERIVE_OP(ctx)) {
-        EVPerr(EVP_F_EVP_PKEY_DERIVE, EVP_R_OPERATON_NOT_INITIALIZED);
+        EVPerr(EVP_F_EVP_PKEY_DERIVE, EVP_R_OPERATION_NOT_INITIALIZED);
         return -1;
     }
 

--- a/crypto/evp/kem.c
+++ b/crypto/evp/kem.c
@@ -117,7 +117,7 @@ int EVP_PKEY_encapsulate(EVP_PKEY_CTX *ctx,
         return 0;
 
     if (ctx->operation != EVP_PKEY_OP_ENCAPSULATE) {
-        EVPerr(0, EVP_R_OPERATON_NOT_INITIALIZED);
+        EVPerr(0, EVP_R_OPERATION_NOT_INITIALIZED);
         return -1;
     }
 
@@ -148,7 +148,7 @@ int EVP_PKEY_decapsulate(EVP_PKEY_CTX *ctx,
         return 0;
 
     if (ctx->operation != EVP_PKEY_OP_DECAPSULATE) {
-        EVPerr(0, EVP_R_OPERATON_NOT_INITIALIZED);
+        EVPerr(0, EVP_R_OPERATION_NOT_INITIALIZED);
         return -1;
     }
 

--- a/crypto/evp/pmeth_gn.c
+++ b/crypto/evp/pmeth_gn.c
@@ -235,7 +235,7 @@ int EVP_PKEY_gen(EVP_PKEY_CTX *ctx, EVP_PKEY **ppkey)
     ret = -2;
     goto end;
  not_initialized:
-    ERR_raise(ERR_LIB_EVP, EVP_R_OPERATON_NOT_INITIALIZED);
+    ERR_raise(ERR_LIB_EVP, EVP_R_OPERATION_NOT_INITIALIZED);
     ret = -1;
     goto end;
 #ifndef FIPS_MODULE
@@ -249,7 +249,7 @@ int EVP_PKEY_gen(EVP_PKEY_CTX *ctx, EVP_PKEY **ppkey)
 int EVP_PKEY_paramgen(EVP_PKEY_CTX *ctx, EVP_PKEY **ppkey)
 {
     if (ctx->operation != EVP_PKEY_OP_PARAMGEN) {
-        ERR_raise(ERR_LIB_EVP, EVP_R_OPERATON_NOT_INITIALIZED);
+        ERR_raise(ERR_LIB_EVP, EVP_R_OPERATION_NOT_INITIALIZED);
         return -1;
     }
     return EVP_PKEY_gen(ctx, ppkey);
@@ -258,7 +258,7 @@ int EVP_PKEY_paramgen(EVP_PKEY_CTX *ctx, EVP_PKEY **ppkey)
 int EVP_PKEY_keygen(EVP_PKEY_CTX *ctx, EVP_PKEY **ppkey)
 {
     if (ctx->operation != EVP_PKEY_OP_KEYGEN) {
-        ERR_raise(ERR_LIB_EVP, EVP_R_OPERATON_NOT_INITIALIZED);
+        ERR_raise(ERR_LIB_EVP, EVP_R_OPERATION_NOT_INITIALIZED);
         return -1;
     }
     return EVP_PKEY_gen(ctx, ppkey);

--- a/crypto/evp/signature.c
+++ b/crypto/evp/signature.c
@@ -553,7 +553,7 @@ int EVP_PKEY_sign(EVP_PKEY_CTX *ctx,
     }
 
     if (ctx->operation != EVP_PKEY_OP_SIGN) {
-        EVPerr(0, EVP_R_OPERATON_NOT_INITIALIZED);
+        EVPerr(0, EVP_R_OPERATION_NOT_INITIALIZED);
         return -1;
     }
 
@@ -592,7 +592,7 @@ int EVP_PKEY_verify(EVP_PKEY_CTX *ctx,
     }
 
     if (ctx->operation != EVP_PKEY_OP_VERIFY) {
-        EVPerr(0, EVP_R_OPERATON_NOT_INITIALIZED);
+        EVPerr(0, EVP_R_OPERATION_NOT_INITIALIZED);
         return -1;
     }
 
@@ -629,7 +629,7 @@ int EVP_PKEY_verify_recover(EVP_PKEY_CTX *ctx,
     }
 
     if (ctx->operation != EVP_PKEY_OP_VERIFYRECOVER) {
-        EVPerr(0, EVP_R_OPERATON_NOT_INITIALIZED);
+        EVPerr(0, EVP_R_OPERATION_NOT_INITIALIZED);
         return -1;
     }
 


### PR DESCRIPTION
The reason code EVP_R_OPERATON_NOT_INITIALIZED should read EVP_R_OPERATION_NOT_INITIALIZED.

CLA: trivial
