### PR TITLE
Fix EVP_PKEY_supports_digest_nid for provider-based keys

### DIFF
--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -1188,6 +1188,26 @@ static int legacy_asn1_ctrl_to_param(EVP_PKEY *pkey, int op,
             }
             return rv;
         }
+    case ASN1_PKEY_CTRL_SUPPORTS_MD_NID:
+        {
+            const OSSL_PARAM *gettable = NULL;
+            OSSL_PARAM params[2];
+
+            if ((gettable = EVP_PKEY_gettable_params(pkey)) == NULL
+                    || OSSL_PARAM_locate_const(gettable,
+                                               OSSL_PKEY_PARAM_DIGEST_SUPPORTED) == NULL)
+                return -2;
+
+            /*
+             * We use EVP_PKEY_get_params to check an "assertion" that a certain
+             * digest is supported. We set the input OSSL_PARAM and expect the
+             * get_params will fail if that hash is not supported.
+             */
+            params[0] = OSSL_PARAM_construct_utf8_string(OSSL_PKEY_PARAM_DIGEST_SUPPORTED,
+                                                         (char *)OBJ_nid2sn(arg1), 0);
+            params[1] = OSSL_PARAM_construct_end();
+            return EVP_PKEY_get_params(pkey, params);
+        }
     default:
         return -2;
     }

--- a/include/openssl/core_names.h
+++ b/include/openssl/core_names.h
@@ -275,6 +275,7 @@ extern "C" {
 #define OSSL_PKEY_PARAM_PROPERTIES          OSSL_ALG_PARAM_PROPERTIES
 #define OSSL_PKEY_PARAM_DEFAULT_DIGEST      "default-digest" /* utf8 string */
 #define OSSL_PKEY_PARAM_MANDATORY_DIGEST    "mandatory-digest" /* utf8 string */
+#define OSSL_PKEY_PARAM_DIGEST_SUPPORTED    "digest-supported" /* utf8 string */
 #define OSSL_PKEY_PARAM_PAD_MODE            "pad-mode"
 #define OSSL_PKEY_PARAM_DIGEST_SIZE         "digest-size"
 #define OSSL_PKEY_PARAM_MASKGENFUNC         "mgf"


### PR DESCRIPTION
Fixes #14343. Adds the missing implementation of EVP_PKEY_supports_digest_nid for provider-based (non-legacy) keys. The ASN1_PKEY_CTRL_SUPPORTS_MD_NID was not handled for non-legacy.

The code uses EVP_PKEY_get_params to "assert" a value, i.e. it sets a value of input OSSL_PARAM and expect the get_params function to fail if the assertion is invalid.
