### PR TITLE
Fixup support for io_pgetevents_time64 syscall

### DIFF
--- a/engines/e_afalg.c
+++ b/engines/e_afalg.c
@@ -124,27 +124,58 @@ static ossl_inline int io_read(aio_context_t ctx, long n, struct iocb **iocb)
     return syscall(__NR_io_submit, ctx, n, iocb);
 }
 
+/* A version of 'struct timespec' with 32-bit time_t
+   and nanoseconds.  */
+struct __timespec32
+{
+  __kernel_long_t tv_sec;
+  __kernel_long_t tv_nsec;
+};
+
+
 static ossl_inline int io_getevents(aio_context_t ctx, long min, long max,
                                struct io_event *events,
                                struct timespec *timeout)
 {
-#if defined(__NR_io_getevents)
-    return syscall(__NR_io_getevents, ctx, min, max, events, timeout);
-#elif defined(__NR_io_pgetevents_time64)
-    /* Let's only support the 64 suffix syscalls for 64-bit time_t.
-     * This simplifies the code for us as we don't need to use a 64-bit
-     * version of timespec with a 32-bit time_t and handle converting
-     * between 64-bit and 32-bit times and check for overflows.
-     */
-    if (sizeof(timeout->tv_sec) == 8)
-        return syscall(__NR_io_pgetevents_time64, ctx, min, max, events, timeout, NULL);
-    else {
-        errno = ENOSYS;
-        return -1;
+#if defined(__NR_io_pgetevents_time64)
+    /* Check if we are a 32-bit architecture with a 64-bit time_t */
+    if (sizeof(*timeout) != sizeof(struct __timespec32)) {
+        int ret = syscall(__NR_io_pgetevents_time64, ctx, min, max, events,
+                          timeout, NULL);
+        if (ret == 0 || errno != ENOSYS)
+            return ret;
     }
-#else
-# error "We require either the io_getevents syscall or __NR_io_pgetevents_time64."
 #endif
+
+#if defined(__NR_io_getevents)
+    if (sizeof(*timeout) == sizeof(struct __timespec32))
+        /*
+         * time_t matches our architecture length, we can just use
+         * __NR_io_getevents
+         */
+        return syscall(__NR_io_getevents, ctx, min, max, events, timeout);
+    else {
+        /*
+         * We don't have __NR_io_pgetevents_time64, but we are using a
+         * 64-bit time_t on a 32-bit architecture. If we can fit the
+         * timeout value in a 32-bit time_t, then let's do that
+         * and then use the __NR_io_getevents syscall.
+         */
+        if (timeout && timeout->tv_sec == (long)timeout->tv_sec) {
+            struct __timespec32 ts32;
+
+            ts32.tv_sec = (__kernel_long_t) timeout->tv_sec;
+            ts32.tv_nsec = (__kernel_long_t) timeout->tv_nsec;
+
+            return syscall(__NR_io_getevents, ctx, min, max, events, ts32);
+        } else {
+            return syscall(__NR_io_getevents, ctx, min, max, events, NULL);
+        }
+    }
+#endif
+
+    errno = ENOSYS;
+    return -1;
 }
 
 static void afalg_waitfd_cleanup(ASYNC_WAIT_CTX *ctx, const void *key,


### PR DESCRIPTION
This is a fixup for the original commit 5b5e2985f355c8e99c196d9ce5d02c15bebadfbc
"Add support for io_pgetevents_time64 syscall" that didn't correctly
work for 32-bit architecutres with a 64-bit time_t that aren't RISC-V.

For a full discussion of the issue see https://github.com/openssl/openssl/commit/5b5e2985f355c8e99c196d9ce5d02c15bebadfbc

Signed-off-by: Alistair Francis <alistair.francis@wdc.com>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [X] documentation is added or updated
- [X] tests are added or updated
