### PR TITLE
Undo passing of params to provider side init/derive/instantiate

### DIFF
--- a/crypto/evp/evp_rand.c
+++ b/crypto/evp/evp_rand.c
@@ -489,8 +489,9 @@ static int evp_rand_instantiate_locked
     (EVP_RAND_CTX *ctx, unsigned int strength, int prediction_resistance,
      const unsigned char *pstr, size_t pstr_len, const OSSL_PARAM params[])
 {
-    return ctx->meth->instantiate(ctx->data, strength, prediction_resistance,
-                                  pstr, pstr_len, params);
+    return evp_rand_set_ctx_params_locked(ctx, params)
+        && ctx->meth->instantiate(ctx->data, strength, prediction_resistance,
+                                  pstr, pstr_len);
 }
 
 int EVP_RAND_instantiate(EVP_RAND_CTX *ctx, unsigned int strength,

--- a/crypto/evp/kdf_lib.c
+++ b/crypto/evp/kdf_lib.c
@@ -143,7 +143,8 @@ int EVP_KDF_derive(EVP_KDF_CTX *ctx, unsigned char *key, size_t keylen,
     if (ctx == NULL)
         return 0;
 
-    return ctx->meth->derive(ctx->data, key, keylen, params);
+    return EVP_KDF_CTX_set_params(ctx, params)
+        && ctx->meth->derive(ctx->data, key, keylen);
 }
 
 /*

--- a/crypto/evp/mac_lib.c
+++ b/crypto/evp/mac_lib.c
@@ -108,7 +108,8 @@ size_t EVP_MAC_CTX_get_mac_size(EVP_MAC_CTX *ctx)
 int EVP_MAC_init(EVP_MAC_CTX *ctx, const unsigned char *key, size_t keylen,
                  const OSSL_PARAM params[])
 {
-    return ctx->meth->init(ctx->data, key, keylen, params);
+    return EVP_MAC_CTX_set_params(ctx, params)
+        && ctx->meth->init(ctx->data, key, keylen);
 }
 
 int EVP_MAC_update(EVP_MAC_CTX *ctx, const unsigned char *data, size_t datalen)

--- a/doc/man3/EVP_KDF.pod
+++ b/doc/man3/EVP_KDF.pod
@@ -101,7 +101,7 @@ I<ctx>.
 EVP_KDF_CTX_reset() resets the context to the default state as if the context
 had just been created.
 
-EVP_KDF_derive() processes any parameters in I<Params> and then derives
+EVP_KDF_derive() processes any parameters in I<params> and then derives
 I<keylen> bytes of key material and places it in the I<key> buffer.
 If the algorithm produces a fixed amount of output then an error will
 occur unless the I<keylen> parameter is equal to that output size,

--- a/doc/man7/provider-kdf.pod
+++ b/doc/man7/provider-kdf.pod
@@ -24,8 +24,7 @@ provider-kdf - The KDF library E<lt>-E<gt> provider functions
 
  /* Encryption/decryption */
  int OSSL_FUNC_kdf_reset(void *kctx);
- int OSSL_FUNC_kdf_derive(void *kctx, unsigned char *key, size_t keylen,
-                          const OSSL_PARAM params[]);
+ int OSSL_FUNC_kdf_derive(void *kctx, unsigned char *key, size_t keylen);
 
  /* KDF parameter descriptors */
  const OSSL_PARAM *OSSL_FUNC_kdf_gettable_params(void *provctx);
@@ -109,8 +108,7 @@ I<kctx> parameter and return the duplicate copy.
 OSSL_FUNC_kdf_reset() initialises a KDF operation given a provider
 side KDF context in the I<kctx> parameter.
 
-OSSL_FUNC_kdf_derive() performs the KDF operation after processing the
-I<params> as per OSSL_FUNC_kdf_set_ctx_params().
+OSSL_FUNC_kdf_derive() performs the KDF operation.
 The I<kctx> parameter contains a pointer to the provider side context.
 The resulting key of the desired I<keylen> should be written to I<key>.
 If the algorithm does not support the requested I<keylen> the function must

--- a/doc/man7/provider-mac.pod
+++ b/doc/man7/provider-mac.pod
@@ -23,8 +23,7 @@ provider-mac - The mac library E<lt>-E<gt> provider functions
  void *OSSL_FUNC_mac_dupctx(void *src);
 
  /* Encryption/decryption */
- int OSSL_FUNC_mac_init(void *mctx, unsigned char *key, size_t keylen,
-                        const OSSL_PARAM params[]);
+ int OSSL_FUNC_mac_init(void *mctx, unsigned char *key, size_t keylen);
  int OSSL_FUNC_mac_update(void *mctx, const unsigned char *in, size_t inl);
  int OSSL_FUNC_mac_final(void *mctx, unsigned char *out, size_t *outl, size_t outsize);
 
@@ -108,9 +107,10 @@ I<mctx> parameter and return the duplicate copy.
 
 =head2 Encryption/Decryption Functions
 
-OSSL_FUNC_mac_init() initialises a mac operation given a newly created provider
-side mac context in the I<mctx> parameter.  The I<params> are set before setting
-the MAC I<key> of I<keylen> bytes.
+OSSL_FUNC_mac_init() initialises a mac operation with they MAC I<key>, given a
+newly created provider side mac context in the I<mctx> parameter.
+Beware that the caller may pass NULL for the I<key> to this function and pass
+the key through OSSL_FUNC_set_ctx_params() instead.
 
 OSSL_FUNC_mac_update() is called to supply data for MAC computation of a previously
 initialised mac operation.

--- a/doc/man7/provider-rand.pod
+++ b/doc/man7/provider-rand.pod
@@ -26,8 +26,7 @@ functions
  /* Random number generator functions: NIST */
  int OSSL_FUNC_rand_instantiate(void *ctx, unsigned int strength,
                                 int prediction_resistance,
-                                const unsigned char *pstr, size_t pstr_len,
-                                const OSSL_PARAM params[]);
+                                const unsigned char *pstr, size_t pstr_len);
  int OSSL_FUNC_rand_uninstantiate(void *ctx);
  int OSSL_FUNC_rand_generate(void *ctx, unsigned char *out, size_t outlen,
                              unsigned int strength, int prediction_resistance,
@@ -98,8 +97,7 @@ These functions correspond to those defined in NIST SP 800-90A and SP 800-90C.
 OSSL_FUNC_rand_instantiate() is used to instantiate the DRBG I<ctx> at a requested
 security I<strength>.  In addition, I<prediction_resistance> can be requested.
 Additional input I<addin> of length I<addin_len> bytes can optionally
-be provided.  The parameters specified in I<params> configure the DRBG and these
-should be processed before instantiation.
+be provided.
 
 OSSL_FUNC_rand_uninstantiate() is used to uninstantiate the DRBG I<ctx>.  After being
 uninstantiated, a DRBG is unable to produce output until it is instantiated

--- a/fuzz/fuzz_rand.c
+++ b/fuzz/fuzz_rand.c
@@ -41,8 +41,7 @@ static int fuzz_rand_instantiate(ossl_unused void *vrng,
                                  ossl_unused unsigned int strength,
                                  ossl_unused int prediction_resistance,
                                  ossl_unused const unsigned char *pstr,
-                                 ossl_unused size_t pstr_len,
-                                 ossl_unused const OSSL_PARAM params[])
+                                 ossl_unused size_t pstr_len)
 {
     *(int *)vrng = EVP_RAND_STATE_READY;
     return 1;

--- a/include/openssl/core_dispatch.h
+++ b/include/openssl/core_dispatch.h
@@ -373,8 +373,8 @@ OSSL_CORE_MAKE_FUNC(void *, kdf_newctx, (void *provctx))
 OSSL_CORE_MAKE_FUNC(void *, kdf_dupctx, (void *src))
 OSSL_CORE_MAKE_FUNC(void, kdf_freectx, (void *kctx))
 OSSL_CORE_MAKE_FUNC(void, kdf_reset, (void *kctx))
-OSSL_CORE_MAKE_FUNC(int, kdf_derive, (void *kctx, unsigned char *key,
-                                      size_t keylen, const OSSL_PARAM params[]))
+OSSL_CORE_MAKE_FUNC(int, kdf_derive,
+                    (void *kctx, unsigned char *key, size_t keylen))
 OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, kdf_gettable_params, (void *provctx))
 OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, kdf_gettable_ctx_params,
                     (void *kctx, void *provctx))

--- a/include/openssl/core_dispatch.h
+++ b/include/openssl/core_dispatch.h
@@ -337,8 +337,8 @@ OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, cipher_gettable_ctx_params,
 OSSL_CORE_MAKE_FUNC(void *, mac_newctx, (void *provctx))
 OSSL_CORE_MAKE_FUNC(void *, mac_dupctx, (void *src))
 OSSL_CORE_MAKE_FUNC(void, mac_freectx, (void *mctx))
-OSSL_CORE_MAKE_FUNC(int, mac_init, (void *mctx, const unsigned char *key,
-                                    size_t keylen, const OSSL_PARAM params[]))
+OSSL_CORE_MAKE_FUNC(int, mac_init,
+                    (void *mctx, const unsigned char *key, size_t keylen))
 OSSL_CORE_MAKE_FUNC(int, mac_update,
                     (void *mctx, const unsigned char *in, size_t inl))
 OSSL_CORE_MAKE_FUNC(int, mac_final,

--- a/include/openssl/core_dispatch.h
+++ b/include/openssl/core_dispatch.h
@@ -415,8 +415,7 @@ OSSL_CORE_MAKE_FUNC(void,rand_freectx, (void *vctx))
 OSSL_CORE_MAKE_FUNC(int,rand_instantiate,
                     (void *vdrbg, unsigned int strength,
                      int prediction_resistance,
-                     const unsigned char *pstr, size_t pstr_len,
-                     const OSSL_PARAM params[]))
+                     const unsigned char *pstr, size_t pstr_len))
 OSSL_CORE_MAKE_FUNC(int,rand_uninstantiate, (void *vdrbg))
 OSSL_CORE_MAKE_FUNC(int,rand_generate,
                     (void *vctx, unsigned char *out, size_t outlen,

--- a/providers/implementations/kdfs/hkdf.c
+++ b/providers/implementations/kdfs/hkdf.c
@@ -123,13 +123,12 @@ static size_t kdf_hkdf_size(KDF_HKDF *ctx)
     return sz;
 }
 
-static int kdf_hkdf_derive(void *vctx, unsigned char *key, size_t keylen,
-                           const OSSL_PARAM params[])
+static int kdf_hkdf_derive(void *vctx, unsigned char *key, size_t keylen)
 {
     KDF_HKDF *ctx = (KDF_HKDF *)vctx;
     const EVP_MD *md;
 
-    if (!ossl_prov_is_running() || !kdf_hkdf_set_ctx_params(ctx, params))
+    if (!ossl_prov_is_running())
         return 0;
 
     md = ossl_prov_digest_md(&ctx->digest);

--- a/providers/implementations/kdfs/kbkdf.c
+++ b/providers/implementations/kdfs/kbkdf.c
@@ -209,8 +209,7 @@ done:
     return ret;
 }
 
-static int kbkdf_derive(void *vctx, unsigned char *key, size_t keylen,
-                        const OSSL_PARAM params[])
+static int kbkdf_derive(void *vctx, unsigned char *key, size_t keylen)
 {
     KBKDF *ctx = (KBKDF *)vctx;
     int ret = 0;
@@ -218,7 +217,7 @@ static int kbkdf_derive(void *vctx, unsigned char *key, size_t keylen,
     uint32_t l = 0;
     size_t h = 0;
 
-    if (!ossl_prov_is_running() || !kbkdf_set_ctx_params(ctx, params))
+    if (!ossl_prov_is_running())
         return 0;
 
     /* label, context, and iv are permitted to be empty.  Check everything

--- a/providers/implementations/kdfs/krb5kdf.c
+++ b/providers/implementations/kdfs/krb5kdf.c
@@ -101,14 +101,13 @@ static int krb5kdf_set_membuf(unsigned char **dst, size_t *dst_len,
     return OSSL_PARAM_get_octet_string(p, (void **)dst, 0, dst_len);
 }
 
-static int krb5kdf_derive(void *vctx, unsigned char *key, size_t keylen,
-                          const OSSL_PARAM params[])
+static int krb5kdf_derive(void *vctx, unsigned char *key, size_t keylen)
 {
     KRB5KDF_CTX *ctx = (KRB5KDF_CTX *)vctx;
     const EVP_CIPHER *cipher;
     ENGINE *engine;
 
-    if (!ossl_prov_is_running() || !krb5kdf_set_ctx_params(ctx, params))
+    if (!ossl_prov_is_running())
         return 0;
 
     cipher = ossl_prov_cipher_cipher(&ctx->cipher);

--- a/providers/implementations/kdfs/pbkdf2.c
+++ b/providers/implementations/kdfs/pbkdf2.c
@@ -139,13 +139,12 @@ static int pbkdf2_set_membuf(unsigned char **buffer, size_t *buflen,
     return 1;
 }
 
-static int kdf_pbkdf2_derive(void *vctx, unsigned char *key, size_t keylen,
-                             const OSSL_PARAM params[])
+static int kdf_pbkdf2_derive(void *vctx, unsigned char *key, size_t keylen)
 {
     KDF_PBKDF2 *ctx = (KDF_PBKDF2 *)vctx;
     const EVP_MD *md;
 
-    if (!ossl_prov_is_running() || !kdf_pbkdf2_set_ctx_params(ctx, params))
+    if (!ossl_prov_is_running())
         return 0;
 
     if (ctx->pass == NULL) {

--- a/providers/implementations/kdfs/pkcs12kdf.c
+++ b/providers/implementations/kdfs/pkcs12kdf.c
@@ -195,13 +195,12 @@ static int pkcs12kdf_set_membuf(unsigned char **buffer, size_t *buflen,
     return 1;
 }
 
-static int kdf_pkcs12_derive(void *vctx, unsigned char *key, size_t keylen,
-                             const OSSL_PARAM params[])
+static int kdf_pkcs12_derive(void *vctx, unsigned char *key, size_t keylen)
 {
     KDF_PKCS12 *ctx = (KDF_PKCS12 *)vctx;
     const EVP_MD *md;
 
-    if (!ossl_prov_is_running() || !kdf_pkcs12_set_ctx_params(ctx, params))
+    if (!ossl_prov_is_running())
         return 0;
 
     if (ctx->pass == NULL) {

--- a/providers/implementations/kdfs/scrypt.c
+++ b/providers/implementations/kdfs/scrypt.c
@@ -147,12 +147,11 @@ static int set_property_query(KDF_SCRYPT *ctx, const char *propq)
     return 1;
 }
 
-static int kdf_scrypt_derive(void *vctx, unsigned char *key, size_t keylen,
-                             const OSSL_PARAM params[])
+static int kdf_scrypt_derive(void *vctx, unsigned char *key, size_t keylen)
 {
     KDF_SCRYPT *ctx = (KDF_SCRYPT *)vctx;
 
-    if (!ossl_prov_is_running() || !kdf_scrypt_set_ctx_params(ctx, params))
+    if (!ossl_prov_is_running())
         return 0;
 
     if (ctx->pass == NULL) {

--- a/providers/implementations/kdfs/sshkdf.c
+++ b/providers/implementations/kdfs/sshkdf.c
@@ -94,13 +94,12 @@ static int sshkdf_set_membuf(unsigned char **dst, size_t *dst_len,
     return OSSL_PARAM_get_octet_string(p, (void **)dst, 0, dst_len);
 }
 
-static int kdf_sshkdf_derive(void *vctx, unsigned char *key, size_t keylen,
-                             const OSSL_PARAM params[])
+static int kdf_sshkdf_derive(void *vctx, unsigned char *key, size_t keylen)
 {
     KDF_SSHKDF *ctx = (KDF_SSHKDF *)vctx;
     const EVP_MD *md;
 
-    if (!ossl_prov_is_running() || !kdf_sshkdf_set_ctx_params(ctx, params))
+    if (!ossl_prov_is_running())
         return 0;
 
     md = ossl_prov_digest_md(&ctx->digest);

--- a/providers/implementations/kdfs/sskdf.c
+++ b/providers/implementations/kdfs/sskdf.c
@@ -342,13 +342,12 @@ static size_t sskdf_size(KDF_SSKDF *ctx)
     return (len <= 0) ? 0 : (size_t)len;
 }
 
-static int sskdf_derive(void *vctx, unsigned char *key, size_t keylen,
-                        const OSSL_PARAM params[])
+static int sskdf_derive(void *vctx, unsigned char *key, size_t keylen)
 {
     KDF_SSKDF *ctx = (KDF_SSKDF *)vctx;
     const EVP_MD *md;
 
-    if (!ossl_prov_is_running() || !sskdf_set_ctx_params(ctx, params))
+    if (!ossl_prov_is_running())
         return 0;
     if (ctx->secret == NULL) {
         ERR_raise(ERR_LIB_PROV, PROV_R_MISSING_SECRET);
@@ -412,13 +411,12 @@ static int sskdf_derive(void *vctx, unsigned char *key, size_t keylen,
     }
 }
 
-static int x963kdf_derive(void *vctx, unsigned char *key, size_t keylen,
-                          const OSSL_PARAM params[])
+static int x963kdf_derive(void *vctx, unsigned char *key, size_t keylen)
 {
     KDF_SSKDF *ctx = (KDF_SSKDF *)vctx;
     const EVP_MD *md;
 
-    if (!ossl_prov_is_running() || !sskdf_set_ctx_params(ctx, params))
+    if (!ossl_prov_is_running())
         return 0;
 
     if (ctx->secret == NULL) {

--- a/providers/implementations/kdfs/tls1_prf.c
+++ b/providers/implementations/kdfs/tls1_prf.c
@@ -131,12 +131,11 @@ static void kdf_tls1_prf_reset(void *vctx)
     ctx->provctx = provctx;
 }
 
-static int kdf_tls1_prf_derive(void *vctx, unsigned char *key, size_t keylen,
-                               const OSSL_PARAM params[])
+static int kdf_tls1_prf_derive(void *vctx, unsigned char *key, size_t keylen)
 {
     TLS1_PRF *ctx = (TLS1_PRF *)vctx;
 
-    if (!ossl_prov_is_running() || !kdf_tls1_prf_set_ctx_params(ctx, params))
+    if (!ossl_prov_is_running())
         return 0;
 
     if (ctx->P_hash == NULL) {

--- a/providers/implementations/kdfs/x942kdf.c
+++ b/providers/implementations/kdfs/x942kdf.c
@@ -392,8 +392,7 @@ static size_t x942kdf_size(KDF_X942 *ctx)
     return (len <= 0) ? 0 : (size_t)len;
 }
 
-static int x942kdf_derive(void *vctx, unsigned char *key, size_t keylen,
-                          const OSSL_PARAM params[])
+static int x942kdf_derive(void *vctx, unsigned char *key, size_t keylen)
 {
     KDF_X942 *ctx = (KDF_X942 *)vctx;
     const EVP_MD *md;
@@ -402,7 +401,7 @@ static int x942kdf_derive(void *vctx, unsigned char *key, size_t keylen,
     unsigned char *der = NULL;
     size_t der_len = 0;
 
-    if (!ossl_prov_is_running() || !x942kdf_set_ctx_params(ctx, params))
+    if (!ossl_prov_is_running())
         return 0;
 
     /*

--- a/providers/implementations/macs/blake2_mac_impl.c
+++ b/providers/implementations/macs/blake2_mac_impl.c
@@ -103,11 +103,11 @@ static int blake2_setkey(struct blake2_mac_data_st *macctx,
 }
 
 static int blake2_mac_init(void *vmacctx, const unsigned char *key,
-                           size_t keylen, const OSSL_PARAM params[])
+                           size_t keylen)
 {
     struct blake2_mac_data_st *macctx = vmacctx;
 
-    if (!ossl_prov_is_running() || !blake2_mac_set_ctx_params(macctx, params))
+    if (!ossl_prov_is_running())
         return 0;
     if (key != NULL) {
         if (!blake2_setkey(macctx, key, keylen))

--- a/providers/implementations/macs/cmac_prov.c
+++ b/providers/implementations/macs/cmac_prov.c
@@ -109,15 +109,14 @@ static int cmac_setkey(struct cmac_data_st *macctx,
                        ossl_prov_cipher_cipher(&macctx->cipher),
                        ossl_prov_cipher_engine(&macctx->cipher));
     ossl_prov_cipher_reset(&macctx->cipher);
-    return rv;    
+    return rv;
 }
 
-static int cmac_init(void *vmacctx, const unsigned char *key,
-                     size_t keylen, const OSSL_PARAM params[])
+static int cmac_init(void *vmacctx, const unsigned char *key, size_t keylen)
 {
     struct cmac_data_st *macctx = vmacctx;
 
-    if (!ossl_prov_is_running() || !cmac_set_ctx_params(macctx, params))
+    if (!ossl_prov_is_running())
         return 0;
     if (key != NULL)
         return cmac_setkey(macctx, key, keylen);

--- a/providers/implementations/macs/gmac_prov.c
+++ b/providers/implementations/macs/gmac_prov.c
@@ -112,12 +112,11 @@ static int gmac_setkey(struct gmac_data_st *macctx,
     return 1;
 }
 
-static int gmac_init(void *vmacctx, const unsigned char *key,
-                     size_t keylen, const OSSL_PARAM params[])
+static int gmac_init(void *vmacctx, const unsigned char *key, size_t keylen)
 {
     struct gmac_data_st *macctx = vmacctx;
 
-    if (!ossl_prov_is_running() || !gmac_set_ctx_params(macctx, params))
+    if (!ossl_prov_is_running())
         return 0;
     if (key != NULL)
         return gmac_setkey(macctx, key, keylen);

--- a/providers/implementations/macs/hmac_prov.c
+++ b/providers/implementations/macs/hmac_prov.c
@@ -163,12 +163,11 @@ static int hmac_setkey(struct hmac_data_st *macctx,
     return 1;
 }
 
-static int hmac_init(void *vmacctx, const unsigned char *key,
-                     size_t keylen, const OSSL_PARAM params[])
+static int hmac_init(void *vmacctx, const unsigned char *key, size_t keylen)
 {
     struct hmac_data_st *macctx = vmacctx;
 
-    if (!ossl_prov_is_running() || !hmac_set_ctx_params(macctx, params))
+    if (!ossl_prov_is_running())
         return 0;
 
     if (key != NULL && !hmac_setkey(macctx, key, keylen))

--- a/providers/implementations/macs/kmac_prov.c
+++ b/providers/implementations/macs/kmac_prov.c
@@ -261,15 +261,14 @@ static int kmac_setkey(struct kmac_data_st *kctx, const unsigned char *key,
  * md, key and custom. Setting the fields afterwards will have no
  * effect on the output mac.
  */
-static int kmac_init(void *vmacctx, const unsigned char *key,
-                     size_t keylen, const OSSL_PARAM params[])
+static int kmac_init(void *vmacctx, const unsigned char *key, size_t keylen)
 {
     struct kmac_data_st *kctx = vmacctx;
     EVP_MD_CTX *ctx = kctx->ctx;
     unsigned char out[KMAC_MAX_BLOCKSIZE];
     int out_len, block_len;
 
-    if (!ossl_prov_is_running() || !kmac_set_ctx_params(kctx, params))
+    if (!ossl_prov_is_running())
         return 0;
     if (key != NULL) {
         if (!kmac_setkey(kctx, key, keylen))

--- a/providers/implementations/macs/poly1305_prov.c
+++ b/providers/implementations/macs/poly1305_prov.c
@@ -88,13 +88,12 @@ static int poly1305_setkey(struct poly1305_data_st *ctx,
     return 1;
 }
 
-static int poly1305_init(void *vmacctx, const unsigned char *key,
-                         size_t keylen, const OSSL_PARAM params[])
+static int poly1305_init(void *vmacctx, const unsigned char *key, size_t keylen)
 {
     struct poly1305_data_st *ctx = vmacctx;
 
     /* initialize the context in MAC_ctrl function */
-    if (!ossl_prov_is_running() || !poly1305_set_ctx_params(ctx, params))
+    if (!ossl_prov_is_running())
         return 0;
     if (key != NULL)
         return poly1305_setkey(ctx, key, keylen);

--- a/providers/implementations/macs/siphash_prov.c
+++ b/providers/implementations/macs/siphash_prov.c
@@ -105,12 +105,11 @@ static int siphash_setkey(struct siphash_data_st *ctx,
     return SipHash_Init(&ctx->siphash, key, crounds(ctx), drounds(ctx));
 }
 
-static int siphash_init(void *vmacctx, const unsigned char *key, size_t keylen,
-                        const OSSL_PARAM params[])
+static int siphash_init(void *vmacctx, const unsigned char *key, size_t keylen)
 {
     struct siphash_data_st *ctx = vmacctx;
 
-    if (!ossl_prov_is_running() || !siphash_set_params(ctx, params))
+    if (!ossl_prov_is_running())
         return 0;
     /* Without a key, there is not much to do here,
      * The actual initialization happens through controls.

--- a/providers/implementations/rands/drbg_ctr.c
+++ b/providers/implementations/rands/drbg_ctr.c
@@ -327,12 +327,11 @@ static int drbg_ctr_instantiate(PROV_DRBG *drbg,
 static int drbg_ctr_instantiate_wrapper(void *vdrbg, unsigned int strength,
                                         int prediction_resistance,
                                         const unsigned char *pstr,
-                                        size_t pstr_len,
-                                        const OSSL_PARAM params[])
+                                        size_t pstr_len)
 {
     PROV_DRBG *drbg = (PROV_DRBG *)vdrbg;
 
-    if (!ossl_prov_is_running() || !drbg_ctr_set_ctx_params(drbg, params))
+    if (!ossl_prov_is_running())
         return 0;
     return ossl_prov_drbg_instantiate(drbg, strength, prediction_resistance,
                                       pstr, pstr_len);

--- a/providers/implementations/rands/drbg_hash.c
+++ b/providers/implementations/rands/drbg_hash.c
@@ -266,12 +266,11 @@ static int drbg_hash_instantiate(PROV_DRBG *drbg,
 static int drbg_hash_instantiate_wrapper(void *vdrbg, unsigned int strength,
                                          int prediction_resistance,
                                          const unsigned char *pstr,
-                                         size_t pstr_len,
-                                         const OSSL_PARAM params[])
+                                         size_t pstr_len)
 {
     PROV_DRBG *drbg = (PROV_DRBG *)vdrbg;
 
-    if (!ossl_prov_is_running() || !drbg_hash_set_ctx_params(drbg, params))
+    if (!ossl_prov_is_running())
         return 0;
     return ossl_prov_drbg_instantiate(drbg, strength, prediction_resistance,
                                       pstr, pstr_len);

--- a/providers/implementations/rands/drbg_hmac.c
+++ b/providers/implementations/rands/drbg_hmac.c
@@ -143,12 +143,11 @@ static int drbg_hmac_instantiate(PROV_DRBG *drbg,
 static int drbg_hmac_instantiate_wrapper(void *vdrbg, unsigned int strength,
                                          int prediction_resistance,
                                          const unsigned char *pstr,
-                                         size_t pstr_len,
-                                         const OSSL_PARAM params[])
+                                         size_t pstr_len)
 {
     PROV_DRBG *drbg = (PROV_DRBG *)vdrbg;
 
-    if (!ossl_prov_is_running() || !drbg_hmac_set_ctx_params(drbg, params))
+    if (!ossl_prov_is_running())
         return 0;
     return ossl_prov_drbg_instantiate(drbg, strength, prediction_resistance,
                                       pstr, pstr_len);

--- a/providers/implementations/rands/seed_src.c
+++ b/providers/implementations/rands/seed_src.c
@@ -70,8 +70,7 @@ static void seed_src_free(void *vseed)
 
 static int seed_src_instantiate(void *vseed, unsigned int strength,
                                 int prediction_resistance,
-                                const unsigned char *pstr, size_t pstr_len,
-                                ossl_unused const OSSL_PARAM params[])
+                                const unsigned char *pstr, size_t pstr_len)
 {
     PROV_SEED_SRC *s = (PROV_SEED_SRC *)vseed;
 

--- a/providers/implementations/rands/test_rng.c
+++ b/providers/implementations/rands/test_rng.c
@@ -79,12 +79,11 @@ static void test_rng_free(void *vtest)
 
 static int test_rng_instantiate(void *vtest, unsigned int strength,
                                 int prediction_resistance,
-                                const unsigned char *pstr, size_t pstr_len,
-                                const OSSL_PARAM params[])
+                                const unsigned char *pstr, size_t pstr_len)
 {
     PROV_TEST_RNG *t = (PROV_TEST_RNG *)vtest;
 
-    if (!test_rng_set_ctx_params(t, params) || strength > t->strength)
+    if (t == NULL || strength > t->strength)
         return 0;
 
     t->state = EVP_RAND_STATE_READY;

--- a/test/testutil/fake_random.c
+++ b/test/testutil/fake_random.c
@@ -50,8 +50,7 @@ static void fake_rand_freectx(void *vrng)
 static int fake_rand_instantiate(void *vrng, ossl_unused unsigned int strength,
                                  ossl_unused  int prediction_resistance,
                                  ossl_unused const unsigned char *pstr,
-                                 size_t pstr_len,
-                                 ossl_unused const OSSL_PARAM params[])
+                                 size_t pstr_len)
 {
     FAKE_RAND *frng = (FAKE_RAND *)vrng;
 


### PR DESCRIPTION
MAC / KDF / RAND: Undo the passing of an OSSL_PARAM array to the provider side init / derive / instantiate

The effect of having the OSSL_PARAM array passed to OSSL_FUNC_mac_init(), OSSL_FUNC_kdf_derive() and OSSL_FUNC_rand_instantiate() is that all providers must add a call to their set_ctx_params() function if they handle params at all.  That call can as well be made in one spot in libcrypto so that providers don't have to.

One small burden less on provider authors.