### PR TITLE
apps/pkcs12: Usability fixes related to MAC and PKCS12KDF support

### DIFF
--- a/apps/pkcs12.c
+++ b/apps/pkcs12.c
@@ -655,7 +655,11 @@ int pkcs12_main(int argc, char **argv)
         }
 
         if (maciter != -1)
-            PKCS12_set_mac(p12, mpass, -1, NULL, 0, maciter, macmd);
+            if (!PKCS12_set_mac(p12, mpass, -1, NULL, 0, maciter, macmd)) {
+                BIO_printf(bio_err, "Error creating PKCS12 MAC; no PKCS12KDF support?\n");
+                BIO_printf(bio_err, "Use -nomac if MAC not required and PKCS12KDF support not available.\n");
+                goto export_end;
+            }
 
         assert(private);
 

--- a/apps/pkcs12.c
+++ b/apps/pkcs12.c
@@ -756,6 +756,14 @@ int pkcs12_main(int argc, char **argv)
              */
             unsigned char *utmp;
             int utmplen;
+            unsigned long err = ERR_peek_error();
+
+            if (ERR_GET_LIB(err) == ERR_LIB_PKCS12
+                && ERR_GET_REASON(err) == PKCS12_R_MAC_ABSENT) {
+                BIO_printf(bio_err, "Warning: MAC is absent!\n");
+                goto dump;
+            }
+
             utmp = OPENSSL_asc2uni(mpass, -1, NULL, &utmplen);
             if (utmp == NULL)
                 goto end;
@@ -773,6 +781,7 @@ int pkcs12_main(int argc, char **argv)
         }
     }
 
+ dump:
     assert(private);
     if (!dump_certs_keys_p12(out, p12, cpass, -1, options, passout, enc)) {
         BIO_printf(bio_err, "Error outputting keys and certificates\n");

--- a/apps/pkcs12.c
+++ b/apps/pkcs12.c
@@ -19,6 +19,7 @@
 #include <openssl/pem.h>
 #include <openssl/pkcs12.h>
 #include <openssl/provider.h>
+#include <openssl/kdf.h>
 
 #define NOKEYS          0x1
 #define NOCERTS         0x2
@@ -733,6 +734,15 @@ int pkcs12_main(int argc, char **argv)
                    tsalt != NULL ? ASN1_STRING_length(tsalt) : 0L);
     }
     if (macver) {
+        EVP_KDF *pkcs12kdf;
+
+        pkcs12kdf = EVP_KDF_fetch(NULL, "PKCS12KDF", NULL);
+        if (pkcs12kdf == NULL) {
+            BIO_printf(bio_err, "Error verifying PKCS12 MAC; no PKCS12KDF support.\n");
+            BIO_printf(bio_err, "Use -nomacver if MAC verification is not required.\n");
+            goto end;
+        }
+        EVP_KDF_free(pkcs12kdf);
         /* If we enter empty password try no password first */
         if (!mpass[0] && PKCS12_verify_mac(p12, NULL, 0)) {
             /* If mac and crypto pass the same set it to NULL too */

--- a/doc/man1/openssl-pkcs12.pod.in
+++ b/doc/man1/openssl-pkcs12.pod.in
@@ -362,7 +362,7 @@ to be needed to use MAC iterations counts but they are now used by default.
 
 =item B<-nomac>
 
-Don't attempt to provide the MAC integrity. This can be useful with FIPS
+Don't attempt to provide the MAC integrity. This can be useful with the FIPS
 provider as the PKCS12 MAC requires PKCS12KDF which is not an approved FIPS
 algorithm and cannot be supported by the FIPS provider.
 

--- a/doc/man1/openssl-pkcs12.pod.in
+++ b/doc/man1/openssl-pkcs12.pod.in
@@ -333,7 +333,7 @@ then both, the private key and the certificates are encrypted using triple DES.
 
 =item B<-macalg> I<digest>
 
-Specify the MAC digest algorithm. If not included them SHA1 will be used.
+Specify the MAC digest algorithm. If not included SHA1 will be used.
 
 =item B<-iter> I<count>
 
@@ -362,7 +362,9 @@ to be needed to use MAC iterations counts but they are now used by default.
 
 =item B<-nomac>
 
-Don't attempt to provide the MAC integrity.
+Don't attempt to provide the MAC integrity. This can be useful with FIPS
+provider as the PKCS12 MAC requires PKCS12KDF which is not an approved FIPS
+algorithm and cannot be supported by the FIPS provider.
 
 =back
 

--- a/doc/man1/openssl-pkcs12.pod.in
+++ b/doc/man1/openssl-pkcs12.pod.in
@@ -362,7 +362,7 @@ to be needed to use MAC iterations counts but they are now used by default.
 
 =item B<-nomac>
 
-Don't attempt to provide the MAC integrity. This can be useful with the FIPS
+Do not attempt to provide the MAC integrity. This can be useful with the FIPS
 provider as the PKCS12 MAC requires PKCS12KDF which is not an approved FIPS
 algorithm and cannot be supported by the FIPS provider.
 


### PR DESCRIPTION
This improves the usability of the pkcs12 app when the PKCS12KDF support is missing or MAC is not present in the imported pkcs12 file.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
