### PR TITLE
Restore GOST macros compatibility with 1.1.1

### DIFF
--- a/include/openssl/tls1.h
+++ b/include/openssl/tls1.h
@@ -1121,6 +1121,11 @@ int SSL_CTX_set_tlsext_ticket_key_evp_cb
 # define TLS_CT_GOST12_LEGACY_SIGN       238
 # define TLS_CT_GOST12_LEGACY_512_SIGN   239
 
+# ifndef OPENSSL_NO_DEPRECATED_3_0
+#  define TLS_CT_GOST12_SIGN TLS_CT_GOST12_LEGACY_SIGN
+#  define TLS_CT_GOST12_512_SIGN TLS_CT_GOST12_LEGACY_512_SIGN
+# endif
+
 /*
  * when correcting this number, correct also SSL3_CT_NUMBER in ssl3.h (see
  * comment there)


### PR DESCRIPTION
Fixes #14440

Before IANA assigned the official codes for the GOST signature
algorithms in TLS, the values from the Reserved for Private Use range
were in use in Russia. The old values were renamed.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
