### PR TITLE
apps: Add maybe_stdin argument to load_certs and set it in pkcs12

### DIFF
--- a/apps/cms.c
+++ b/apps/cms.c
@@ -826,7 +826,7 @@ int cms_main(int argc, char **argv)
     }
 
     if (certfile != NULL) {
-        if (!load_certs(certfile, &other, NULL, "certificate file")) {
+        if (!load_certs(certfile, 0, &other, NULL, "certificate file")) {
             ERR_print_errors(bio_err);
             goto end;
         }

--- a/apps/include/apps.h
+++ b/apps/include/apps.h
@@ -129,7 +129,7 @@ STACK_OF(X509) *load_certs_multifile(char *files, const char *pass,
                                      const char *desc, X509_VERIFY_PARAM *vpm);
 X509_STORE *load_certstore(char *input, const char *pass, const char *desc,
                            X509_VERIFY_PARAM *vpm);
-int load_certs(const char *uri, STACK_OF(X509) **certs,
+int load_certs(const char *uri, int maybe_stdin, STACK_OF(X509) **certs,
                const char *pass, const char *desc);
 int load_crls(const char *uri, STACK_OF(X509_CRL) **crls,
               const char *pass, const char *desc);

--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -877,6 +877,11 @@ int load_key_certs_crls(const char *uri, int maybe_stdin,
         cnt_expectations++;
         expect = OSSL_STORE_INFO_PUBKEY;
     }
+    if (pparams != NULL) {
+        *pparams = NULL;
+        cnt_expectations++;
+        expect = OSSL_STORE_INFO_PARAMS;
+    }
     if (pcert != NULL) {
         *pcert = NULL;
         cnt_expectations++;

--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -800,12 +800,12 @@ X509_STORE *load_certstore(char *input, const char *pass, const char *desc,
  * Initialize or extend, if *certs != NULL, a certificate stack.
  * The caller is responsible for freeing *certs if its value is left not NULL.
  */
-int load_certs(const char *uri, STACK_OF(X509) **certs,
+int load_certs(const char *uri, int maybe_stdin, STACK_OF(X509) **certs,
                const char *pass, const char *desc)
 {
     int was_NULL = *certs == NULL;
-    int ret = load_key_certs_crls(uri, 0, pass, desc, NULL, NULL, NULL,
-                                  NULL, certs, NULL, NULL);
+    int ret = load_key_certs_crls(uri, maybe_stdin, pass, desc, NULL, NULL,
+                                  NULL, NULL, certs, NULL, NULL);
 
     if (!ret && was_NULL) {
         sk_X509_pop_free(*certs, X509_free);

--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -941,7 +941,7 @@ int load_key_certs_crls(const char *uri, int maybe_stdin,
         goto end;
 
     failed = NULL;
-    while (!OSSL_STORE_eof(ctx)) {
+    while (cnt_expectations > 0 && !OSSL_STORE_eof(ctx)) {
         OSSL_STORE_INFO *info = OSSL_STORE_load(ctx);
         int type, ok = 1;
 
@@ -963,28 +963,37 @@ int load_key_certs_crls(const char *uri, int maybe_stdin,
         type = OSSL_STORE_INFO_get_type(info);
         switch (type) {
         case OSSL_STORE_INFO_PKEY:
-            if (ppkey != NULL && *ppkey == NULL)
+            if (ppkey != NULL && *ppkey == NULL) {
                 ok = (*ppkey = OSSL_STORE_INFO_get1_PKEY(info)) != NULL;
-
+                cnt_expectations -= ok;
+            }
             /*
              * An EVP_PKEY with private parts also holds the public parts,
              * so if the caller asked for a public key, and we got a private
              * key, we can still pass it back.
              */
-            if (ok && ppubkey != NULL && *ppubkey == NULL)
+            if (ok && ppubkey != NULL && *ppubkey == NULL) {
                 ok = ((*ppubkey = OSSL_STORE_INFO_get1_PKEY(info)) != NULL);
+                cnt_expectations -= ok;
+            }
             break;
         case OSSL_STORE_INFO_PUBKEY:
-            if (ppubkey != NULL && *ppubkey == NULL)
+            if (ppubkey != NULL && *ppubkey == NULL) {
                 ok = ((*ppubkey = OSSL_STORE_INFO_get1_PUBKEY(info)) != NULL);
+                cnt_expectations -= ok;
+            }
             break;
         case OSSL_STORE_INFO_PARAMS:
-            if (pparams != NULL && *pparams == NULL)
+            if (pparams != NULL && *pparams == NULL) {
                 ok = ((*pparams = OSSL_STORE_INFO_get1_PARAMS(info)) != NULL);
+                cnt_expectations -= ok;
+            }
             break;
         case OSSL_STORE_INFO_CERT:
-            if (pcert != NULL && *pcert == NULL)
+            if (pcert != NULL && *pcert == NULL) {
                 ok = (*pcert = OSSL_STORE_INFO_get1_CERT(info)) != NULL;
+                cnt_expectations -= ok;
+            }
             else if (pcerts != NULL)
                 ok = X509_add_cert(*pcerts,
                                    OSSL_STORE_INFO_get1_CERT(info),
@@ -992,8 +1001,10 @@ int load_key_certs_crls(const char *uri, int maybe_stdin,
             ncerts += ok;
             break;
         case OSSL_STORE_INFO_CRL:
-            if (pcrl != NULL && *pcrl == NULL)
+            if (pcrl != NULL && *pcrl == NULL) {
                 ok = (*pcrl = OSSL_STORE_INFO_get1_CRL(info)) != NULL;
+                cnt_expectations -= ok;
+            }
             else if (pcrls != NULL)
                 ok = sk_X509_CRL_push(*pcrls, OSSL_STORE_INFO_get1_CRL(info));
             ncrls += ok;

--- a/apps/lib/s_cb.c
+++ b/apps/lib/s_cb.c
@@ -1032,7 +1032,7 @@ int load_excert(SSL_EXCERT **pexc)
         if (exc->key == NULL)
             return 0;
         if (exc->chainfile != NULL) {
-            if (!load_certs(exc->chainfile, &exc->chain, NULL, "server chain"))
+            if (!load_certs(exc->chainfile, 0, &exc->chain, NULL, "server chain"))
                 return 0;
         }
     }

--- a/apps/ocsp.c
+++ b/apps/ocsp.c
@@ -574,10 +574,10 @@ int ocsp_main(int argc, char **argv)
             BIO_printf(bio_err, "Error loading responder certificate\n");
             goto end;
         }
-        if (!load_certs(rca_filename, &rca_cert, NULL, "CA certificates"))
+        if (!load_certs(rca_filename, 0, &rca_cert, NULL, "CA certificates"))
             goto end;
         if (rcertfile != NULL) {
-            if (!load_certs(rcertfile, &rother, NULL,
+            if (!load_certs(rcertfile, 0, &rother, NULL,
                             "responder other certificates"))
                 goto end;
         }
@@ -671,7 +671,7 @@ redo_accept:
             goto end;
         }
         if (sign_certfile != NULL) {
-            if (!load_certs(sign_certfile, &sign_other, NULL,
+            if (!load_certs(sign_certfile, 0, &sign_other, NULL,
                             "signer certificates"))
                 goto end;
         }
@@ -780,7 +780,7 @@ redo_accept:
     if (vpmtouched)
         X509_STORE_set1_param(store, vpm);
     if (verify_certfile != NULL) {
-        if (!load_certs(verify_certfile, &verify_other, NULL,
+        if (!load_certs(verify_certfile, 0, &verify_other, NULL,
                         "validator certificates"))
             goto end;
     }

--- a/apps/pkcs12.c
+++ b/apps/pkcs12.c
@@ -525,7 +525,7 @@ int pkcs12_main(int argc, char **argv)
 
         /* Load all certs in input file */
         if (!(options & NOCERTS)) {
-            if (!load_certs(infile, &certs, passin,
+            if (!load_certs(infile, 1, &certs, passin,
                             "certificates from -in file"))
                 goto export_end;
             if (sk_X509_num(certs) < 1) {
@@ -560,7 +560,7 @@ int pkcs12_main(int argc, char **argv)
 
         /* Load any untrusted certificates for chain building */
         if (untrusted != NULL) {
-            if (!load_certs(untrusted, &untrusted_certs, passcerts,
+            if (!load_certs(untrusted, 0, &untrusted_certs, passcerts,
                             "untrusted certificates"))
                 goto export_end;
         }
@@ -605,7 +605,7 @@ int pkcs12_main(int argc, char **argv)
 
         /* Add any extra certificates asked for */
         if (certfile != NULL) {
-            if (!load_certs(certfile, &certs, passcerts,
+            if (!load_certs(certfile, 0, &certs, passcerts,
                             "extra certificates from -certfile"))
                 goto export_end;
         }

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -1625,7 +1625,7 @@ int s_client_main(int argc, char **argv)
     }
 
     if (chain_file != NULL) {
-        if (!load_certs(chain_file, &chain, pass, "client certificate chain"))
+        if (!load_certs(chain_file, 0, &chain, pass, "client certificate chain"))
             goto end;
     }
 

--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -1690,7 +1690,7 @@ int s_server_main(int argc, char *argv[])
         if (s_cert == NULL)
             goto end;
         if (s_chain_file != NULL) {
-            if (!load_certs(s_chain_file, &s_chain, NULL,
+            if (!load_certs(s_chain_file, 0, &s_chain, NULL,
                             "server certificate chain"))
                 goto end;
         }
@@ -1754,7 +1754,7 @@ int s_server_main(int argc, char *argv[])
             goto end;
         }
         if (s_dchain_file != NULL) {
-            if (!load_certs(s_dchain_file, &s_dchain, NULL,
+            if (!load_certs(s_dchain_file, 0, &s_dchain, NULL,
                             "second server certificate chain"))
                 goto end;
         }

--- a/apps/smime.c
+++ b/apps/smime.c
@@ -457,7 +457,7 @@ int smime_main(int argc, char **argv)
     }
 
     if (certfile != NULL) {
-        if (!load_certs(certfile, &other, NULL, "certificates")) {
+        if (!load_certs(certfile, 0, &other, NULL, "certificates")) {
             ERR_print_errors(bio_err);
             goto end;
         }

--- a/apps/verify.c
+++ b/apps/verify.c
@@ -145,7 +145,7 @@ int verify_main(int argc, char **argv)
             break;
         case OPT_UNTRUSTED:
             /* Zero or more times */
-            if (!load_certs(opt_arg(), &untrusted, NULL,
+            if (!load_certs(opt_arg(), 0, &untrusted, NULL,
                             "untrusted certificates"))
                 goto end;
             break;
@@ -154,7 +154,7 @@ int verify_main(int argc, char **argv)
             noCAfile = 1;
             noCApath = 1;
             noCAstore = 1;
-            if (!load_certs(opt_arg(), &trusted, NULL, "trusted certificates"))
+            if (!load_certs(opt_arg(), 0, &trusted, NULL, "trusted certificates"))
                 goto end;
             break;
         case OPT_CRLFILE:


### PR DESCRIPTION
And also make load_key_certs_crls to read only what it is expected to read.

This is one part of the fix for #13826. The other part is #14407 but that still needs some tweaking.