### PR TITLE
fixup typo

### DIFF
--- a/doc/man7/EVP_KDF-KB.pod
+++ b/doc/man7/EVP_KDF-KB.pod
@@ -102,7 +102,7 @@ Label "label", and Context "context".
  *p++ = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_MAC,
                                          "HMAC", 0);
  *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_KEY,
-                                          "secret", strlen("secret"))
+                                          "secret", strlen("secret"));
  *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_SALT,
                                           "label", strlen("label"));
  *p++ = OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_INFO,


### PR DESCRIPTION
Just a simple fix for a typo in the code example.

##### Checklist
- [x] documentation is added or updated
- [ ] tests are added or updated
