### PR TITLE
Check SSL_set1_chain error in set_cert_cb

### DIFF
--- a/apps/lib/s_cb.c
+++ b/apps/lib/s_cb.c
@@ -952,7 +952,8 @@ static int set_cert_cb(SSL *ssl, void *arg)
                 if (!SSL_build_cert_chain(ssl, 0))
                     return 0;
             } else if (exc->chain != NULL) {
-                SSL_set1_chain(ssl, exc->chain);
+                if (!SSL_set1_chain(ssl, exc->chain))
+                    return 0;
             }
         }
         exc = exc->prev;


### PR DESCRIPTION
When it eventually calls `ssl3_ctrl` -> `ssl_cert_set1_chain`, `ssl_cert_set1_chain` might fail due to an allocation error in `X509_chain_up_ref`.