### PR TITLE
fake_rand_finish should be called if "OPENSSL_NO_SM2" is NOT defined

### DIFF
--- a/test/sm2_internal_test.c
+++ b/test/sm2_internal_test.c
@@ -381,7 +381,7 @@ int setup_tests(void)
 
 void cleanup_tests(void)
 {
-#ifdef OPENSSL_NO_SM2
+#ifndef OPENSSL_NO_SM2
     fake_rand_finish(fake_rand);
 #endif
 }


### PR DESCRIPTION
Since I am getting errors of sanitizers / non-caching CI I think my changes are not related to, I looked at the failing test. 
I think this might me a negation error. It seems as currently `fake_rand_finish` is only called when SM2 is disabled and I think it should be called when it is enabled.