### PR TITLE
PROV: use EVP_CIPHER_CTX_set_params() rather than EVP_CIPHER_CTX_ctrl()

### DIFF
--- a/providers/implementations/macs/gmac_prov.c
+++ b/providers/implementations/macs/gmac_prov.c
@@ -146,6 +146,7 @@ static int gmac_update(void *vmacctx, const unsigned char *data,
 static int gmac_final(void *vmacctx, unsigned char *out, size_t *outl,
                       size_t outsize)
 {
+    OSSL_PARAM params[2] = { OSSL_PARAM_END, OSSL_PARAM_END };
     struct gmac_data_st *macctx = vmacctx;
     int hlen = 0;
 
@@ -155,10 +156,10 @@ static int gmac_final(void *vmacctx, unsigned char *out, size_t *outl,
     if (!EVP_EncryptFinal_ex(macctx->ctx, out, &hlen))
         return 0;
 
-    /* TODO(3.0) Use params */
     hlen = gmac_size();
-    if (!EVP_CIPHER_CTX_ctrl(macctx->ctx, EVP_CTRL_AEAD_GET_TAG,
-                             hlen, out))
+    params[0] = OSSL_PARAM_construct_octet_string(OSSL_CIPHER_PARAM_AEAD_TAG,
+                                                  out, (size_t)hlen);
+    if (!EVP_CIPHER_CTX_set_params(macctx->ctx, params))
         return 0;
 
     *outl = hlen;

--- a/providers/implementations/macs/gmac_prov.c
+++ b/providers/implementations/macs/gmac_prov.c
@@ -159,7 +159,7 @@ static int gmac_final(void *vmacctx, unsigned char *out, size_t *outl,
     hlen = gmac_size();
     params[0] = OSSL_PARAM_construct_octet_string(OSSL_CIPHER_PARAM_AEAD_TAG,
                                                   out, (size_t)hlen);
-    if (!EVP_CIPHER_CTX_set_params(macctx->ctx, params))
+    if (!EVP_CIPHER_CTX_get_params(macctx->ctx, params))
         return 0;
 
     *outl = hlen;


### PR DESCRIPTION
This is in gmac_final(), where the cipher is known to be fetched.
It's more suitable to use OSSL_PARAMs than _ctrl functions, as the
latter are expected to become obsolete.

Fixes #14359
