### PR TITLE
Print correct error message in utils/mkdir-p.pl

### DIFF
--- a/util/mkdir-p.pl
+++ b/util/mkdir-p.pl
@@ -34,11 +34,12 @@ sub do_mkdir_p {
   }
 
   unless (mkdir($dir, 0777)) {
+    local($err) = $!;
     if (-d $dir) {
       # We raced against another instance doing the same thing.
       return;
     }
-    die "Cannot create directory $dir: $!\n";
+    die "Cannot create directory $dir: $err\n";
   }
   print "created directory `$dir'\n";
 }


### PR DESCRIPTION
Commit 70a56b914772e6b21cda2a5742817ae4bb7290f1 introduced a regression.

If utils/mkdir-p.pl fails to create a target dir because of insufficient file system
permissions, the subsequent test for dir existence always fails and overwrites
the system error. As a result, a user is presented with a misleading error message.

E.g. if a user tries to create a dir under /usr/local and does not have permissions
for it, the reported error message is "Cannot create directory /usr/local/lib: No such file or directory",
whereas the expected error message is "Cannot create directory /usr/local/lib: Permission denied".

This commit introduces a fix by declaring an additional local variable to cache
the original error message from mkdir. If -d check fails and overwrites the system
error, the user is still presented with the original error from mkdir.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
