### PR TITLE
Don't crash if the pkeyopt doesn't have a value

### DIFF
--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -1790,17 +1790,21 @@ int bio_to_mem(unsigned char **out, int maxlen, BIO *in)
 
 int pkey_ctrl_string(EVP_PKEY_CTX *ctx, const char *value)
 {
-    int rv;
+    int rv = 0;
     char *stmp, *vtmp = NULL;
+
     stmp = OPENSSL_strdup(value);
-    if (!stmp)
+    if (stmp == NULL)
         return -1;
     vtmp = strchr(stmp, ':');
-    if (vtmp) {
-        *vtmp = 0;
-        vtmp++;
-    }
+    if (vtmp == NULL)
+        goto err;
+
+    *vtmp = 0;
+    vtmp++;
     rv = EVP_PKEY_CTX_ctrl_str(ctx, stmp, vtmp);
+
+ err:
     OPENSSL_free(stmp);
     return rv;
 }


### PR DESCRIPTION
All pkeyopt's must have a ":" and a value for the option. Not supplying
one can cause a crash

Fixes #14494
