### PR TITLE
Do not call RAND_get0_public from within the FIPS provider initialization

### DIFF
--- a/crypto/bio/b_addr.c
+++ b/crypto/bio/b_addr.c
@@ -31,7 +31,6 @@
 #include <openssl/err.h>
 #include <openssl/buffer.h>
 #include "internal/thread_once.h"
-#include "crypto/cryptlib.h"
 
 CRYPTO_RWLOCK *bio_lookup_lock;
 static CRYPTO_ONCE bio_lookup_init = CRYPTO_ONCE_STATIC_INIT;
@@ -617,8 +616,6 @@ static int addrinfo_wrap(int family, int socktype,
 
 DEFINE_RUN_ONCE_STATIC(do_bio_lookup_init)
 {
-    if (!OPENSSL_init_crypto(OPENSSL_INIT_BASE_ONLY, NULL))
-        return 0;
     bio_lookup_lock = CRYPTO_THREAD_lock_new();
     return bio_lookup_lock != NULL;
 }

--- a/crypto/bio/b_addr.c
+++ b/crypto/bio/b_addr.c
@@ -31,6 +31,7 @@
 #include <openssl/err.h>
 #include <openssl/buffer.h>
 #include "internal/thread_once.h"
+#include "crypto/cryptlib.h"
 
 CRYPTO_RWLOCK *bio_lookup_lock;
 static CRYPTO_ONCE bio_lookup_init = CRYPTO_ONCE_STATIC_INIT;
@@ -616,7 +617,7 @@ static int addrinfo_wrap(int family, int socktype,
 
 DEFINE_RUN_ONCE_STATIC(do_bio_lookup_init)
 {
-    if (!OPENSSL_init_crypto(0, NULL))
+    if (!OPENSSL_init_crypto(OPENSSL_INIT_BASE_ONLY, NULL))
         return 0;
     bio_lookup_lock = CRYPTO_THREAD_lock_new();
     return bio_lookup_lock != NULL;

--- a/crypto/engine/eng_lib.c
+++ b/crypto/engine/eng_lib.c
@@ -11,6 +11,7 @@
 #include "eng_local.h"
 #include <openssl/rand.h>
 #include "internal/refcount.h"
+#include "crypto/cryptlib.h"
 
 CRYPTO_RWLOCK *global_engine_lock;
 
@@ -20,7 +21,7 @@ CRYPTO_ONCE engine_lock_init = CRYPTO_ONCE_STATIC_INIT;
 
 DEFINE_RUN_ONCE(do_engine_lock_init)
 {
-    if (!OPENSSL_init_crypto(0, NULL))
+    if (!OPENSSL_init_crypto(OPENSSL_INIT_BASE_ONLY, NULL))
         return 0;
     global_engine_lock = CRYPTO_THREAD_lock_new();
     return global_engine_lock != NULL;

--- a/crypto/engine/eng_lib.c
+++ b/crypto/engine/eng_lib.c
@@ -11,7 +11,6 @@
 #include "eng_local.h"
 #include <openssl/rand.h>
 #include "internal/refcount.h"
-#include "crypto/cryptlib.h"
 
 CRYPTO_RWLOCK *global_engine_lock;
 
@@ -21,8 +20,6 @@ CRYPTO_ONCE engine_lock_init = CRYPTO_ONCE_STATIC_INIT;
 
 DEFINE_RUN_ONCE(do_engine_lock_init)
 {
-    if (!OPENSSL_init_crypto(OPENSSL_INIT_BASE_ONLY, NULL))
-        return 0;
     global_engine_lock = CRYPTO_THREAD_lock_new();
     return global_engine_lock != NULL;
 }

--- a/crypto/err/err.c
+++ b/crypto/err/err.c
@@ -197,7 +197,7 @@ static void ERR_STATE_free(ERR_STATE *s)
 
 DEFINE_RUN_ONCE_STATIC(do_err_strings_init)
 {
-    if (!OPENSSL_init_crypto(0, NULL))
+    if (!OPENSSL_init_crypto(OPENSSL_INIT_BASE_ONLY, NULL))
         return 0;
     err_string_lock = CRYPTO_THREAD_lock_new();
     if (err_string_lock == NULL)

--- a/crypto/rand/rand_lib.c
+++ b/crypto/rand/rand_lib.c
@@ -429,7 +429,7 @@ static void *rand_ossl_ctx_new(OSSL_LIB_CTX *libctx)
      * We need to ensure that base libcrypto thread handling has been
      * initialised.
      */
-     OPENSSL_init_crypto(0, NULL);
+     OPENSSL_init_crypto(OPENSSL_INIT_BASE_ONLY, NULL);
 #endif
 
     dgbl->lock = CRYPTO_THREAD_lock_new();

--- a/crypto/store/store_init.c
+++ b/crypto/store/store_init.c
@@ -8,14 +8,13 @@
  */
 
 #include <openssl/err.h>
-#include "crypto/cryptlib.h"
 #include "crypto/store.h"
 #include "store_local.h"
 
 static CRYPTO_ONCE store_init = CRYPTO_ONCE_STATIC_INIT;
 DEFINE_RUN_ONCE_STATIC(do_store_init)
 {
-    return OPENSSL_init_crypto(OPENSSL_INIT_BASE_ONLY, NULL);
+    return 1;
 }
 
 int ossl_store_init_once(void)

--- a/crypto/store/store_init.c
+++ b/crypto/store/store_init.c
@@ -8,13 +8,14 @@
  */
 
 #include <openssl/err.h>
+#include "crypto/cryptlib.h"
 #include "crypto/store.h"
 #include "store_local.h"
 
 static CRYPTO_ONCE store_init = CRYPTO_ONCE_STATIC_INIT;
 DEFINE_RUN_ONCE_STATIC(do_store_init)
 {
-    return OPENSSL_init_crypto(0, NULL);
+    return OPENSSL_init_crypto(OPENSSL_INIT_BASE_ONLY, NULL);
 }
 
 int ossl_store_init_once(void)

--- a/crypto/store/store_init.c
+++ b/crypto/store/store_init.c
@@ -7,24 +7,8 @@
  * https://www.openssl.org/source/license.html
  */
 
-#include <openssl/err.h>
 #include "crypto/store.h"
 #include "store_local.h"
-
-static CRYPTO_ONCE store_init = CRYPTO_ONCE_STATIC_INIT;
-DEFINE_RUN_ONCE_STATIC(do_store_init)
-{
-    return 1;
-}
-
-int ossl_store_init_once(void)
-{
-    if (!RUN_ONCE(&store_init, do_store_init)) {
-        ERR_raise(ERR_LIB_OSSL_STORE, ERR_R_MALLOC_FAILURE);
-        return 0;
-    }
-    return 1;
-}
 
 void ossl_store_cleanup_int(void)
 {

--- a/crypto/store/store_local.h
+++ b/crypto/store/store_local.h
@@ -153,13 +153,6 @@ struct ossl_store_ctx_st {
 };
 
 /*-
- *  OSSL_STORE init stuff
- *  ---------------------
- */
-
-int ossl_store_init_once(void);
-
-/*-
  *  'file' scheme stuff
  *  -------------------
  */

--- a/crypto/store/store_register.c
+++ b/crypto/store/store_register.c
@@ -207,8 +207,6 @@ int ossl_store_register_loader_int(OSSL_STORE_LOADER *loader)
 }
 int OSSL_STORE_register_loader(OSSL_STORE_LOADER *loader)
 {
-    if (!ossl_store_init_once())
-        return 0;
     return ossl_store_register_loader_int(loader);
 }
 
@@ -223,9 +221,6 @@ const OSSL_STORE_LOADER *ossl_store_get0_loader_int(const char *scheme)
     template.eof = NULL;
     template.close = NULL;
     template.open_ex = NULL;
-
-    if (!ossl_store_init_once())
-        return NULL;
 
     if (!RUN_ONCE(&registry_init, do_registry_init)) {
         ERR_raise(ERR_LIB_OSSL_STORE, ERR_R_MALLOC_FAILURE);
@@ -275,8 +270,6 @@ OSSL_STORE_LOADER *ossl_store_unregister_loader_int(const char *scheme)
 }
 OSSL_STORE_LOADER *OSSL_STORE_unregister_loader(const char *scheme)
 {
-    if (!ossl_store_init_once())
-        return 0;
     return ossl_store_unregister_loader_int(scheme);
 }
 

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -632,9 +632,6 @@ int OSSL_provider_init(const OSSL_CORE_HANDLE *handle,
         goto err;
     }
 
-    /* TODO(3.0): Tests will hang if this is removed */
-    (void)RAND_get0_public(libctx);
-
     *out = fips_dispatch_table;
     return 1;
  err:

--- a/test/acvp_test.c
+++ b/test/acvp_test.c
@@ -127,7 +127,7 @@ static int ecdsa_keygen_test(int id)
         || !TEST_int_gt(EVP_PKEY_keygen_init(ctx), 0)
         || !TEST_true(EVP_PKEY_CTX_set_group_name(ctx, tst->curve_name))
         || !TEST_int_gt(EVP_PKEY_keygen(ctx, &pkey), 0)
-        || !TEST_int_eq(self_test_args.called, 3)
+        || !TEST_int_ge(self_test_args.called, 3)
         || !TEST_true(pkey_get_bn_bytes(pkey, OSSL_PKEY_PARAM_PRIV_KEY, &priv,
                                         &priv_len))
         || !TEST_true(pkey_get_bn_bytes(pkey, OSSL_PKEY_PARAM_EC_PUB_X, &pubx,


### PR DESCRIPTION
This is necessary to avoid leaks on exit when the FIPS provider is initialized first in other thread than the main one.

Fixes #14437
