### PR TITLE
doc: fix enc -z option documentation

### DIFF
--- a/apps/enc.c
+++ b/apps/enc.c
@@ -92,7 +92,7 @@ const OPTIONS enc_options[] = {
     {"pbkdf2", OPT_PBKDF2, '-', "Use password-based key derivation function 2"},
     {"none", OPT_NONE, '-', "Don't encrypt"},
 #ifdef ZLIB
-    {"z", OPT_Z, '-', "Use zlib as the 'encryption'"},
+    {"z", OPT_Z, '-', "Compress or decompress encrypted data using zlib"},
 #endif
     {"", OPT_CIPHER, '-', "Any supported cipher"},
 

--- a/doc/man1/openssl-enc.pod.in
+++ b/doc/man1/openssl-enc.pod.in
@@ -187,8 +187,8 @@ Debug the BIOs used for I/O.
 
 =item B<-z>
 
-Compress or decompress clear text using zlib before encryption or after
-decryption. This option exists only if OpenSSL with compiled with zlib
+Compress or decompress encrypted data using zlib after encryption or before
+decryption. This option exists only if OpenSSL was compiled with the zlib
 or zlib-dynamic option.
 
 =item B<-none>


### PR DESCRIPTION
The documentation for the `enc -z` option seems to be wrong. Compression happens after data is encrypted:

    echo hello | openssl aes256 -z -pass 'pass:' | openssl zlib -d | openssl aes256 -d -pass 'pass:'

##### Checklist
- [x] documentation is added or updated
