### PR TITLE
Fix DSA EVP_PKEY_param_check() when defaults are used for param gen.

### DIFF
--- a/crypto/ffc/ffc_params_validate.c
+++ b/crypto/ffc/ffc_params_validate.c
@@ -152,8 +152,12 @@ int ossl_ffc_params_full_validate(OSSL_LIB_CTX *libctx, const FFC_PARAMS *params
                                               res, NULL);
 #else
     if (params->seed != NULL) {
-        return ossl_ffc_params_FIPS186_4_validate(libctx, params, paramstype,
-                                                  res, NULL);
+        if (params->flags & FFC_PARAM_FLAG_VALIDATE_LEGACY)
+            return ossl_ffc_params_FIPS186_2_validate(libctx, params, paramstype,
+                                                      res, NULL);
+        else
+            return ossl_ffc_params_FIPS186_4_validate(libctx, params, paramstype,
+                                                      res, NULL);
     } else {
         int ret = 0;
 

--- a/doc/man7/EVP_PKEY-FFC.pod
+++ b/doc/man7/EVP_PKEY-FFC.pod
@@ -100,7 +100,7 @@ Sets the type of parameter generation. The shared valid values are:
 
 =item "fips186_4"
 
-The current standard. This is the default value.
+The current standard.
 
 =item "fips186_2"
 
@@ -108,8 +108,8 @@ The old standard that should only be used for legacy purposes.
 
 =item "default"
 
-This is an alias to use the latest implemented standard.
-It is currently set to "fips186_4".
+This can choose one of "fips186_4" or "fips186_2" depending on other
+parameters set for parameter generation.
 
 =back
 

--- a/include/crypto/dsa.h
+++ b/include/crypto/dsa.h
@@ -17,6 +17,7 @@
 
 #define DSA_PARAMGEN_TYPE_FIPS_186_4   0   /* Use FIPS186-4 standard */
 #define DSA_PARAMGEN_TYPE_FIPS_186_2   1   /* Use legacy FIPS186-2 standard */
+#define DSA_PARAMGEN_TYPE_FIPS_DEFAULT 2
 
 DSA *ossl_dsa_new(OSSL_LIB_CTX *libctx);
 void ossl_dsa_set0_libctx(DSA *d, OSSL_LIB_CTX *libctx);

--- a/providers/implementations/keymgmt/dsa_kmgmt.c
+++ b/providers/implementations/keymgmt/dsa_kmgmt.c
@@ -78,7 +78,7 @@ static const DSA_GENTYPE_NAME2ID dsatype2id[]=
 #ifdef FIPS_MODULE
     { "default", DSA_PARAMGEN_TYPE_FIPS_186_4 },
 #else
-    { "default", DSA_PARAMGEN_TYPE_FIPS_186_2 },
+    { "default", DSA_PARAMGEN_TYPE_FIPS_DEFAULT },
 #endif
     { "fips186_4", DSA_PARAMGEN_TYPE_FIPS_186_4 },
     { "fips186_2", DSA_PARAMGEN_TYPE_FIPS_186_2 },
@@ -381,7 +381,7 @@ static void *dsa_gen_init(void *provctx, int selection)
 #ifdef FIPS_MODULE
         gctx->gen_type = DSA_PARAMGEN_TYPE_FIPS_186_4;
 #else
-        gctx->gen_type = DSA_PARAMGEN_TYPE_FIPS_186_2;
+        gctx->gen_type = DSA_PARAMGEN_TYPE_FIPS_DEFAULT;
 #endif
         gctx->gindex = -1;
         gctx->pcounter = -1;
@@ -518,6 +518,10 @@ static void *dsa_gen(void *genctx, OSSL_CALLBACK *osslcb, void *cbarg)
     dsa = ossl_dsa_new(gctx->libctx);
     if (dsa == NULL)
         return NULL;
+
+    if (gctx->gen_type == DSA_PARAMGEN_TYPE_FIPS_DEFAULT)
+        gctx->gen_type = (gctx->pbits >= 2048 ? DSA_PARAMGEN_TYPE_FIPS_186_4 :
+                                                DSA_PARAMGEN_TYPE_FIPS_186_2);
 
     gctx->cb = osslcb;
     gctx->cbarg = cbarg;

--- a/test/dsatest.c
+++ b/test/dsatest.c
@@ -302,6 +302,27 @@ end:
     return ret;
 }
 
+static int test_dsa_default_paramgen_validate(int i)
+{
+    int ret;
+    EVP_PKEY_CTX *gen_ctx = NULL;
+    EVP_PKEY_CTX *check_ctx = NULL;
+    EVP_PKEY *params = NULL;
+
+    ret = TEST_ptr(gen_ctx = EVP_PKEY_CTX_new_from_name(NULL, "DSA", NULL))
+          && TEST_int_gt(EVP_PKEY_paramgen_init(gen_ctx), 0)
+          && (i == 0
+              || TEST_true(EVP_PKEY_CTX_set_dsa_paramgen_bits(gen_ctx, 512)))
+          && TEST_int_gt(EVP_PKEY_gen(gen_ctx, &params), 0)
+          && TEST_ptr(check_ctx = EVP_PKEY_CTX_new_from_pkey(NULL, params, NULL))
+          && TEST_int_gt(EVP_PKEY_param_check(check_ctx), 0);
+
+    EVP_PKEY_free(params);
+    EVP_PKEY_CTX_free(check_ctx);
+    EVP_PKEY_CTX_free(gen_ctx);
+    return ret;
+}
+
 #endif /* OPENSSL_NO_DSA */
 
 int setup_tests(void)
@@ -309,6 +330,7 @@ int setup_tests(void)
 #ifndef OPENSSL_NO_DSA
     ADD_TEST(dsa_test);
     ADD_TEST(dsa_keygen_test);
+    ADD_ALL_TESTS(test_dsa_default_paramgen_validate, 2);
 #endif
     return 1;
 }


### PR DESCRIPTION
Fixes #14480

An internal flag that is set during param gen was not being tested, so
the wrong type was used to select the dsa domain param validation method.

In the default provider - if no gen_type is set then by default the fips186_4 gentype
will be selected when pbits >=2048 otherwise it selects fips186_2.
The fips provider ignores the gen_type and always uses fips186_4.

Before this change dsa used fips186_2 by default in the default
provider.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
