### PR TITLE
ssl: fix format specifier for size_t argument to BIO_printf

### DIFF
--- a/ssl/t1_enc.c
+++ b/ssl/t1_enc.c
@@ -564,7 +564,7 @@ int tls1_setup_key_block(SSL *s)
     s->s3.tmp.key_block = p;
 
     OSSL_TRACE_BEGIN(TLS) {
-        BIO_printf(trc_out, "key block length: %ld\n", num);
+        BIO_printf(trc_out, "key block length: %zu\n", num);
         BIO_printf(trc_out, "client random\n");
         BIO_dump_indent(trc_out, s->s3.client_random, SSL3_RANDOM_SIZE, 4);
         BIO_printf(trc_out, "server random\n");


### PR DESCRIPTION
Fixes #14519

