### PR TITLE
Remove TODO in rsa_ameth.c

### DIFF
--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -1714,7 +1714,7 @@ void *evp_pkey_export_to_provider(EVP_PKEY *pk, OSSL_LIB_CTX *libctx,
         }
 
         /* Make sure that the keymgmt key type matches the legacy NID */
-        if (!ossl_assert(EVP_KEYMGMT_is_a(tmp_keymgmt, OBJ_nid2sn(pk->type))))
+        if (!EVP_KEYMGMT_is_a(tmp_keymgmt, OBJ_nid2sn(pk->type)))
             goto end;
 
         if ((keydata = evp_keymgmt_newdata(tmp_keymgmt)) == NULL)

--- a/crypto/rsa/rsa_ameth.c
+++ b/crypto/rsa/rsa_ameth.c
@@ -856,15 +856,8 @@ static size_t rsa_pkey_dirty_cnt(const EVP_PKEY *pkey)
 }
 
 /*
- * For the moment, we trust the call path, where keys going through
- * rsa_pkey_export_to() match a KEYMGMT for the "RSA" keytype, while
- * keys going through rsa_pss_pkey_export_to() match a KEYMGMT for the
- * "RSA-PSS" keytype.
- * TODO(3.0) Investigate whether we should simply continue to trust the
- * call path, or if we should strengthen this function by checking that
- * |rsa_type| matches the RSA key subtype.  The latter requires ensuring
- * that the type flag for the RSA key is properly set by other functions
- * in this file.
+ * There is no need to do RSA_test_flags(rsa, RSA_FLAG_TYPE_RSASSAPSS)
+ * checks in this method since the caller tests EVP_KEYMGMT_is_a() first.
  */
 static int rsa_int_export_to(const EVP_PKEY *from, int rsa_type,
                              void *to_keydata, EVP_KEYMGMT *to_keymgmt,


### PR DESCRIPTION
Fixes #14390

The only caller of this function tests EVP_KEYMGMT_is_a() beforehand
which will fail if the RSA key types do not match. So the test is not
necessary. The assert has been removed when it does the test.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
