### PR TITLE
Remove TODO in test/acvp_test.c related to setting AES-GCM iv.

### DIFF
--- a/test/acvp_test.c
+++ b/test/acvp_test.c
@@ -837,8 +837,9 @@ static int aes_gcm_enc_dec(const char *alg,
             goto err;
     }
     /*
-     * TODO(3.0): The IV should not be set outside the boundary as it is now.
-     * It needs to be fed in via a dummy entropy source for this test.
+     * For testing purposes the IV it being set here. In a compliant application
+     * the IV would be generated internally. A fake entropy source could also
+     * be used to feed in the random IV bytes (see fake_random.c)
      */
     if (!TEST_true(EVP_CipherInit_ex(ctx, NULL, NULL, key, iv, enc))
         || !TEST_true(EVP_CIPHER_CTX_set_padding(ctx, 0))


### PR DESCRIPTION
Fixes #14330

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
