### PR TITLE
Remove a TODO from async_delete_thread_state()

### DIFF
--- a/crypto/async/async.c
+++ b/crypto/async/async.c
@@ -393,7 +393,6 @@ err:
     return 0;
 }
 
-/* TODO(3.0): arg ignored for now */
 static void async_delete_thread_state(void *arg)
 {
     async_pool *pool = (async_pool *)CRYPTO_THREAD_get_local(&poolkey);


### PR DESCRIPTION
There is nothing to be done here for the time being. If at some point
we make the async code libctx aware then we might need to make a change
but there are no plans to do that at the moment.

Fixes #14402
