### PR TITLE
Convert a TODO(3.0) in OPENSSL_thread_stop_ex to a comment

### DIFF
--- a/crypto/initthread.c
+++ b/crypto/initthread.c
@@ -214,9 +214,9 @@ void OPENSSL_thread_stop_ex(OSSL_LIB_CTX *ctx)
 {
     ctx = ossl_lib_ctx_get_concrete(ctx);
     /*
-     * TODO(3.0). It would be nice if we could figure out a way to do this on
-     * all threads that have used the OSSL_LIB_CTX when the context is freed.
-     * This is currently not possible due to the use of thread local variables.
+     * It would be nice if we could figure out a way to do this on all threads
+     * that have used the OSSL_LIB_CTX when the context is freed. This is
+     * currently not possible due to the use of thread local variables.
      */
     ossl_ctx_thread_stop(ctx);
 }


### PR DESCRIPTION
The TODO is describing something that would be nice to fix. In fact the
problem exists even in 1.1.1. It would be nice to fix it, but it does
not need to be done in the 3.0 timeframe.

Fixes #14376

