### PR TITLE
keymgmt_meth: remove two TODO 3.0

### DIFF
--- a/crypto/evp/keymgmt_meth.c
+++ b/crypto/evp/keymgmt_meth.c
@@ -287,9 +287,9 @@ void *evp_keymgmt_newdata(const EVP_KEYMGMT *keymgmt)
     void *provctx = ossl_provider_ctx(EVP_KEYMGMT_provider(keymgmt));
 
     /*
-     * TODO(3.0) 'new' is currently mandatory on its own, but when new
-     * constructors appear, it won't be quite as mandatory, so we have
-     * a check for future cases.
+     * 'new' is currently mandatory on its own, but when new
+     * constructors appear, it won't be quite as mandatory,
+     * so we have a check for future cases.
      */
     if (keymgmt->new == NULL)
         return NULL;
@@ -320,7 +320,6 @@ int evp_keymgmt_gen_set_template(const EVP_KEYMGMT *keymgmt, void *genctx,
      * it allows the caller to set a template key, which is then ignored.
      * However, this is how the legacy methods (EVP_PKEY_METHOD) operate,
      * so we do this in the interest of backward compatibility.
-     * TODO(3.0) Investigate if we should change this behaviour.
      */
     if (keymgmt->gen_set_template == NULL)
         return 1;


### PR DESCRIPTION
The first TODO 3.0 is not really a TODO, just a comment.

The second one is something that is needed for compatibility
with existing applications. There is no major reason in
trying to change this behavior right now.

Fixes #14400
