### PR TITLE
provider_core: Remove two TODO 3.0

### DIFF
--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -1104,6 +1104,7 @@ static OPENSSL_CORE_CTX *core_get_libctx(const OSSL_CORE_HANDLE *handle)
      * that does not apply here. Here |prov| == NULL can happen only in
      * case of coding error.
      */
+    (void)ossl_assert(prov != NULL);
     return (OPENSSL_CORE_CTX *)prov->libctx;
 }
 
@@ -1129,6 +1130,8 @@ static int core_thread_start(const OSSL_CORE_HANDLE *handle,
  * These error functions should use |handle| to select the proper
  * library context to report in the correct error stack if error
  * stacks become tied to the library context.
+ * We cannot currently do that since there's no support for it in the
+ * ERR subsystem.
  */
 static void core_new_error(const OSSL_CORE_HANDLE *handle)
 {

--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -899,7 +899,6 @@ void *ossl_provider_prov_ctx(const OSSL_PROVIDER *prov)
 
 OSSL_LIB_CTX *ossl_provider_libctx(const OSSL_PROVIDER *prov)
 {
-    /* TODO(3.0) just: return prov->libctx; */
     return prov != NULL ? prov->libctx : NULL;
 }
 
@@ -1099,7 +1098,13 @@ static OPENSSL_CORE_CTX *core_get_libctx(const OSSL_CORE_HANDLE *handle)
      */
     OSSL_PROVIDER *prov = (OSSL_PROVIDER *)handle;
 
-    return (OPENSSL_CORE_CTX *)ossl_provider_libctx(prov);
+    /*
+     * Using ossl_provider_libctx would be wrong as that returns
+     * NULL for |prov| == NULL and NULL libctx has a special meaning
+     * that does not apply here. Here |prov| == NULL can happen only in
+     * case of coding error.
+     */
+    return (OPENSSL_CORE_CTX *)prov->libctx;
 }
 
 static int core_thread_start(const OSSL_CORE_HANDLE *handle,
@@ -1121,11 +1126,9 @@ static int core_thread_start(const OSSL_CORE_HANDLE *handle,
  */
 #ifndef FIPS_MODULE
 /*
- * TODO(3.0) These error functions should use |handle| to select the proper
- * library context to report in the correct error stack, at least if error
+ * These error functions should use |handle| to select the proper
+ * library context to report in the correct error stack if error
  * stacks become tied to the library context.
- * We cannot currently do that since there's no support for it in the
- * ERR subsystem.
  */
 static void core_new_error(const OSSL_CORE_HANDLE *handle)
 {

--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -1102,7 +1102,7 @@ static OPENSSL_CORE_CTX *core_get_libctx(const OSSL_CORE_HANDLE *handle)
      * Using ossl_provider_libctx would be wrong as that returns
      * NULL for |prov| == NULL and NULL libctx has a special meaning
      * that does not apply here. Here |prov| == NULL can happen only in
-     * case of coding error.
+     * case of a coding error.
      */
     (void)ossl_assert(prov != NULL);
     return (OPENSSL_CORE_CTX *)prov->libctx;


### PR DESCRIPTION
We need to keep the check for prov == NULL in ossl_provider_libctx
but it is not needed in core_get_libctx as there it can happen only when
there is a serious coding error in a third party provider and returning
NULL as libctx would be seriously wrong as that has a special meaning.

The second TODO is valid but not something that is relevant
for 3.0. Change it into a normal comment.

Fixes #14377
