### PR TITLE
Use --debug with no-caching build as sanitizers need it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,11 +85,11 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: config
-      run: ./config enable-asan enable-ubsan no-cached-fetch && perl configdata.pm --dump
+      run: ./config --debug enable-asan enable-ubsan no-cached-fetch no-dtls no-tls1 no-tls1-method no-tls1_1 no-tls1_1-method no-async && perl configdata.pm --dump
     - name: make
       run: make -s -j4
     - name: make test
-      run: make test HARNESS_JOBS=${HARNESS_JOBS:-4} OPENSSL_TEST_RAND_ORDER=0 TESTS="-test_fuzz* -test_ssl_* -test_evp -test_cmp_http -test_store -test_enc -[01][0-9]"
+      run: make test HARNESS_JOBS=${HARNESS_JOBS:-4} OPENSSL_TEST_RAND_ORDER=0 TESTS="-test_fuzz* -test_ssl_* -test_evp -test_cmp_http -test_verify -test_cms -test_store -test_enc -[01][0-9]"
 
   sanitizers:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The memleak test otherwise fails.

Also disable async, dtls, and old tls versions to test some
different combination of disableables and speed up tests.

Fixes #14337
