### PR TITLE
Add -static-libgcc to solaris-sparcv7-gcc shared_ldflag to match x86/x86_64

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -317,7 +317,7 @@ my %targets = (
         ex_libs          => add(threads("-pthread")),
         bn_ops           => "BN_LLONG RC4_CHAR",
         shared_cflag     => "-fPIC",
-        shared_ldflag    => add_before("-shared"),
+        shared_ldflag    => add_before("-shared -static-libgcc"),
     },
     "solaris-sparcv8-gcc" => {
         inherit_from     => [ "solaris-sparcv7-gcc" ],


### PR DESCRIPTION
This avoids a run-time dependency on libgcc_s.so which may not be present on all systems.  OpenSSL already uses -static-libgcc for the solaris-x86-gcc and solaris64-x86_64-gcc configurations.
