### PR TITLE
property: default queries create the property values.

### DIFF
--- a/crypto/evp/evp_fetch.c
+++ b/crypto/evp/evp_fetch.c
@@ -403,7 +403,7 @@ int evp_set_default_properties_int(OSSL_LIB_CTX *libctx, const char *propq,
 {
     OSSL_PROPERTY_LIST *pl = NULL;
 
-    if (propq != NULL && (pl = ossl_parse_query(libctx, propq)) == NULL) {
+    if (propq != NULL && (pl = ossl_parse_query(libctx, propq, 1)) == NULL) {
         ERR_raise(ERR_LIB_EVP, EVP_R_DEFAULT_QUERY_PARSE_ERROR);
         return 0;
     }
@@ -424,7 +424,7 @@ static int evp_default_properties_merge(OSSL_LIB_CTX *libctx, const char *propq)
         return 1;
     if (plp == NULL || *plp == NULL)
         return EVP_set_default_properties(libctx, propq);
-    if ((pl1 = ossl_parse_query(libctx, propq)) == NULL) {
+    if ((pl1 = ossl_parse_query(libctx, propq, 1)) == NULL) {
         ERR_raise(ERR_LIB_EVP, EVP_R_DEFAULT_QUERY_PARSE_ERROR);
         return 0;
     }

--- a/crypto/property/property.c
+++ b/crypto/property/property.c
@@ -357,7 +357,7 @@ int ossl_method_store_fetch(OSSL_METHOD_STORE *store, int nid,
     }
 
     if (prop_query != NULL)
-        p2 = pq = ossl_parse_query(store->ctx, prop_query);
+        p2 = pq = ossl_parse_query(store->ctx, prop_query, 0);
     plp = ossl_ctx_global_properties(store->ctx, 0);
     if (plp != NULL && *plp != NULL) {
         if (pq == NULL) {

--- a/crypto/property/property_parse.c
+++ b/crypto/property/property_parse.c
@@ -385,7 +385,8 @@ err:
     return res;
 }
 
-OSSL_PROPERTY_LIST *ossl_parse_query(OSSL_LIB_CTX *ctx, const char *s)
+OSSL_PROPERTY_LIST *ossl_parse_query(OSSL_LIB_CTX *ctx, const char *s,
+                                     int create_values)
 {
     STACK_OF(PROPERTY_DEFINITION) *sk;
     OSSL_PROPERTY_LIST *res = NULL;
@@ -425,7 +426,7 @@ OSSL_PROPERTY_LIST *ossl_parse_query(OSSL_LIB_CTX *ctx, const char *s)
             prop->v.str_val = ossl_property_true;
             goto skip_value;
         }
-        if (!parse_value(ctx, &s, prop, 0))
+        if (!parse_value(ctx, &s, prop, create_values))
             prop->type = PROPERTY_TYPE_VALUE_UNDEFINED;
 
 skip_value:

--- a/include/internal/property.h
+++ b/include/internal/property.h
@@ -23,7 +23,8 @@ int ossl_property_parse_init(OSSL_LIB_CTX *ctx);
 /* Property definition parser */
 OSSL_PROPERTY_LIST *ossl_parse_property(OSSL_LIB_CTX *ctx, const char *defn);
 /* Property query parser */
-OSSL_PROPERTY_LIST *ossl_parse_query(OSSL_LIB_CTX *ctx, const char *s);
+OSSL_PROPERTY_LIST *ossl_parse_query(OSSL_LIB_CTX *ctx, const char *s,
+                                     int create_values);
 /* Property checker of query vs definition */
 int ossl_property_match_count(const OSSL_PROPERTY_LIST *query,
                               const OSSL_PROPERTY_LIST *defn);

--- a/test/property_test.c
+++ b/test/property_test.c
@@ -137,6 +137,7 @@ static int test_property_query_value_create(void)
         && TEST_int_eq(ossl_property_match_count(q, p), -1)
         && TEST_int_eq(ossl_property_match_count(q, o), 1))
         r = 1;
+    ossl_property_free(o);
     ossl_property_free(p);
     ossl_property_free(q);
     ossl_method_store_free(store);

--- a/test/property_test.c
+++ b/test/property_test.c
@@ -114,8 +114,28 @@ static int test_property_parse(int n)
         && add_property_names("sky", "groan", "cold", "today", "tomorrow", "n",
                               NULL)
         && TEST_ptr(p = ossl_parse_property(NULL, parser_tests[n].defn))
-        && TEST_ptr(q = ossl_parse_query(NULL, parser_tests[n].query))
+        && TEST_ptr(q = ossl_parse_query(NULL, parser_tests[n].query, 0))
         && TEST_int_eq(ossl_property_match_count(q, p), parser_tests[n].e))
+        r = 1;
+    ossl_property_free(p);
+    ossl_property_free(q);
+    ossl_method_store_free(store);
+    return r;
+}
+
+static int test_property_query_value_create(void)
+{
+    OSSL_METHOD_STORE *store;
+    OSSL_PROPERTY_LIST *p = NULL, *q = NULL, *o = NULL;
+    int r = 0;
+
+    if (TEST_ptr(store = ossl_method_store_new(NULL))
+        && add_property_names("sky", NULL)
+        && TEST_ptr(p = ossl_parse_query(NULL, "sky=green", 0)) /* undefined */
+        && TEST_ptr(q = ossl_parse_query(NULL, "sky=green", 1)) /* creates */
+        && TEST_ptr(o = ossl_parse_query(NULL, "sky=green", 0)) /* defined */
+        && TEST_int_eq(ossl_property_match_count(q, p), -1)
+        && TEST_int_eq(ossl_property_match_count(q, o), 1))
         r = 1;
     ossl_property_free(p);
     ossl_property_free(q);
@@ -160,8 +180,9 @@ static int test_property_merge(int n)
         && add_property_names("colour", "urn", "clouds", "pot", "day", "night",
                               NULL)
         && TEST_ptr(prop = ossl_parse_property(NULL, merge_tests[n].prop))
-        && TEST_ptr(q_global = ossl_parse_query(NULL, merge_tests[n].q_global))
-        && TEST_ptr(q_local = ossl_parse_query(NULL, merge_tests[n].q_local))
+        && TEST_ptr(q_global = ossl_parse_query(NULL, merge_tests[n].q_global,
+                                                0))
+        && TEST_ptr(q_local = ossl_parse_query(NULL, merge_tests[n].q_local, 0))
         && TEST_ptr(q_combined = ossl_property_merge(q_local, q_global))
         && TEST_int_ge(ossl_property_match_count(q_combined, prop), 0))
         r = 1;
@@ -220,7 +241,7 @@ static int test_definition_compares(int n)
     r = TEST_ptr(store = ossl_method_store_new(NULL))
         && add_property_names("alpha", "omega", NULL)
         && TEST_ptr(d = ossl_parse_property(NULL, definition_tests[n].defn))
-        && TEST_ptr(q = ossl_parse_query(NULL, definition_tests[n].query))
+        && TEST_ptr(q = ossl_parse_query(NULL, definition_tests[n].query, 0))
         && TEST_int_eq(ossl_property_match_count(q, d), definition_tests[n].e);
 
     ossl_property_free(d);
@@ -416,6 +437,7 @@ err:
 int setup_tests(void)
 {
     ADD_TEST(test_property_string);
+    ADD_TEST(test_property_query_value_create);
     ADD_ALL_TESTS(test_property_parse, OSSL_NELEM(parser_tests));
     ADD_ALL_TESTS(test_property_merge, OSSL_NELEM(merge_tests));
     ADD_TEST(test_property_defn_cache);


### PR DESCRIPTION
Without this, it is necessary to query an algorithm before setting the default property query.  With this, the value will be created and the default will work.

Fixes #14516

- [ ] documentation is added or updated
- [x] tests are added or updated
