### PR TITLE
e_os.h: Include wspiapi.h to improve Windows backward compatibility

### DIFF
--- a/e_os.h
+++ b/e_os.h
@@ -108,6 +108,7 @@
         */
 #    include <winsock2.h>
 #    include <ws2tcpip.h>
+#    include <wspiapi.h>
        /* yes, they have to be #included prior to <windows.h> */
 #   endif
 #   include <windows.h>


### PR DESCRIPTION
This patch is a trivial one-liner.

According to [getaddrinfo function (ws2tcpip.h) - Win32 apps | Microsoft Docs](https://docs.microsoft.com/en-us/windows/win32/api/ws2tcpip/nf-ws2tcpip-getaddrinfo#support-for-getaddrinfo-on-windows-2000-and-older-versions):

> The <b>getaddrinfo</b> function was added to the Ws2_32.dll on Windows XP and later. To execute an application that uses this function on earlier versions of Windows, then you need to include the <i>Ws2tcpip.h</i> and <i>Wspiapi.h</i> files. When the <i>Wspiapi.h</i> include file is added, the <b>getaddrinfo</b> function is defined to the <b>WspiapiGetAddrInfo</b> inline function in the <i>Wspiapi.h</i> file. At runtime, the <b>WspiapiGetAddrInfo</b> function is implemented in such a way that if the Ws2_32.dll or the Wship6.dll (the file containing <b>getaddrinfo</b> in the IPv6 Technology Preview for Windows 2000) does not include <b>getaddrinfo</b>, then a version of  <b>getaddrinfo</b> is implemented inline based on code in the Wspiapi.h header file. This inline code will be used on older Windows platforms that do not natively support the <b>getaddrinfo</b> function.

Current functionalities remain unchanged, since the exported `getaddrinfo` and `freeaddrinfo` symbols are still used on higher versions of Windows through dynamic loading. This patch enables inline fallback implementations on Windows 2000 and Windows 9x operating systems, which would otherwise generate an error message running applications linked to OpenSSL:

<p align="center"><img src="https://user-images.githubusercontent.com/7923857/111057128-ed501300-84bf-11eb-9160-e6f1d0bdc19a.png"></p>

It does not solve all Windows 9x compatibility problems, but this error will go away and programs will run.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] ~~documentation is added or updated~~
- [ ] ~~tests are added or updated~~
