### PR TITLE
Drop bare ossl_assert() call as it causes build failure

### DIFF
--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -1118,7 +1118,7 @@ static OPENSSL_CORE_CTX *core_get_libctx(const OSSL_CORE_HANDLE *handle)
      * that does not apply here. Here |prov| == NULL can happen only in
      * case of a coding error.
      */
-    (void)ossl_assert(prov != NULL);
+    assert(prov != NULL);
     return (OPENSSL_CORE_CTX *)prov->libctx;
 }
 

--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -7,6 +7,7 @@
  * https://www.openssl.org/source/license.html
  */
 
+#include <assert.h>
 #include <openssl/core.h>
 #include <openssl/core_dispatch.h>
 #include <openssl/core_names.h>


### PR DESCRIPTION
With --strict-warnings this fails to build because the
ossl_assert is declared with warn_unused_result.

This is causing CI failure in the external tests because of the --strict-warnings and --debug used together.