### PR TITLE
Fixing memleaktest for MSVC's AddressSanitizer

### DIFF
--- a/test/memleaktest.c
+++ b/test/memleaktest.c
@@ -20,7 +20,10 @@
 # endif
 #endif
 /* If __SANITIZE_ADDRESS__ isn't defined, define it to be false */
-#ifndef __SANITIZE_ADDRESS__
+/* Leak detection is not yet supported with MSVC on Windows, so */
+/* set __SANITIZE_ADDRESS__ to false in this case as well.      */
+#if !defined(__SANITIZE_ADDRESS__) || defined(_MSC_VER)
+# undef __SANITIZE_ADDRESS__
 # define __SANITIZE_ADDRESS__ 0
 #endif
 


### PR DESCRIPTION
`memleaktest` assumes that a memory leak will be detected when AddressSanitizer is turned on. However, the new AddressSanitizer support for MSVC does not include memory leak detection as of now. This change fixes `memleaktest` to not expect an error when using MSVC's AddressSanitizer.

##### Checklist
- [x] tests are added or updated
