### PR TITLE
Fixing stack buffer overflow error caused by incorrectly sized array.

### DIFF
--- a/test/params_api_test.c
+++ b/test/params_api_test.c
@@ -390,8 +390,8 @@ static int test_param_size_t(int n)
 static int test_param_time_t(int n)
 {
     time_t in, out;
-    unsigned char buf[MAX_LEN], cmp[sizeof(size_t)];
-    const size_t len = raw_values[n].len >= sizeof(size_t)
+    unsigned char buf[MAX_LEN], cmp[sizeof(time_t)];
+    const size_t len = raw_values[n].len >= sizeof(time_t)
                        ? sizeof(time_t) : raw_values[n].len;
     OSSL_PARAM param = OSSL_PARAM_time_t("a", NULL);
 


### PR DESCRIPTION
`size_t` was used to determine the size of the `cmp` buffer instead of `time_t`. Under some architectures with MSVC, this caused the array to be too small to accommodate the `time_t` objects that are copied into `cmp` further down in the test. This bug was caught by enabling AddressSanitizer with MSVC.

CLA: trivial

##### Checklist
- [x] tests are added or updated
