### PR TITLE
Fix coverity 1449851 & 1449860: overlapping memory copies

### DIFF
--- a/crypto/modes/cbc128.c
+++ b/crypto/modes/cbc128.c
@@ -114,7 +114,8 @@ void CRYPTO_cbc128_decrypt(const unsigned char *in, unsigned char *out,
                 out += 16;
             }
         }
-        memcpy(ivec, iv, 16);
+        if (ivec != iv)
+            memcpy(ivec, iv, 16);
     } else {
         if (STRICT_ALIGNMENT &&
             ((size_t)in | (size_t)out | (size_t)ivec) % sizeof(size_t) != 0) {

--- a/crypto/modes/cbc128.c
+++ b/crypto/modes/cbc128.c
@@ -69,7 +69,8 @@ void CRYPTO_cbc128_encrypt(const unsigned char *in, unsigned char *out,
         in += 16;
         out += 16;
     }
-    memcpy(ivec, iv, 16);
+    if (ivec != iv)
+        memcpy(ivec, iv, 16);
 }
 
 void CRYPTO_cbc128_decrypt(const unsigned char *in, unsigned char *out,


### PR DESCRIPTION

Avoid calling memcpy if the pointers are identical.
