### PR TITLE
Coverity: dereference after null checks

### DIFF
--- a/crypto/async/async.c
+++ b/crypto/async/async.c
@@ -181,7 +181,7 @@ int ASYNC_start_job(ASYNC_JOB **job, ASYNC_WAIT_CTX *wctx, int *ret,
     if (ctx == NULL)
         return ASYNC_ERR;
 
-    if (*job)
+    if (*job != NULL)
         ctx->currjob = *job;
 
     for (;;) {
@@ -203,7 +203,9 @@ int ASYNC_start_job(ASYNC_JOB **job, ASYNC_WAIT_CTX *wctx, int *ret,
             }
 
             if (ctx->currjob->status == ASYNC_JOB_PAUSED) {
-                ctx->currjob = *job;
+                if ((ctx->currjob = *job) == NULL)
+                    continue;
+
                 /*
                  * Restore the default libctx to what it was the last time the
                  * fibre ran

--- a/crypto/async/async.c
+++ b/crypto/async/async.c
@@ -203,8 +203,9 @@ int ASYNC_start_job(ASYNC_JOB **job, ASYNC_WAIT_CTX *wctx, int *ret,
             }
 
             if (ctx->currjob->status == ASYNC_JOB_PAUSED) {
-                if ((ctx->currjob = *job) == NULL)
-                    continue;
+                if (*job == NULL)
+                    return ASYNC_ERR;
+                ctx->currjob = *job;
 
                 /*
                  * Restore the default libctx to what it was the last time the

--- a/crypto/evp/ctrl_params_translate.c
+++ b/crypto/evp/ctrl_params_translate.c
@@ -1512,10 +1512,13 @@ static int get_payload_group_name(enum state state,
         return 0;
     }
 
-    if (ctx->p2 == NULL) {
-        ERR_raise(ERR_LIB_EVP, EVP_R_UNSUPPORTED_KEY_TYPE);
-        return 0;
-    }
+    /*
+     * Quietly ignoring unknown groups matches the behaviour on the provider
+     * side.
+     */
+    if (ctx->p2 == NULL)
+        return 1;
+
     ctx->p1 = strlen(ctx->p2);
     return default_fixup_args(state, translation, ctx);
 }

--- a/crypto/evp/ctrl_params_translate.c
+++ b/crypto/evp/ctrl_params_translate.c
@@ -1512,8 +1512,11 @@ static int get_payload_group_name(enum state state,
         return 0;
     }
 
-    if (ctx->p2 != NULL)
-        ctx->p1 = strlen(ctx->p2);
+    if (ctx->p2 == NULL) {
+        ERR_raise(ERR_LIB_EVP, EVP_R_UNSUPPORTED_KEY_TYPE);
+        return 0;
+    }
+    ctx->p1 = strlen(ctx->p2);
     return default_fixup_args(state, translation, ctx);
 }
 

--- a/crypto/evp/digest.c
+++ b/crypto/evp/digest.c
@@ -462,7 +462,12 @@ int EVP_DigestFinalXOF(EVP_MD_CTX *ctx, unsigned char *md, size_t size)
     OSSL_PARAM params[2];
     size_t i = 0;
 
-    if (ctx->digest == NULL || ctx->digest->prov == NULL)
+    if (ctx->digest == NULL) {
+        ERR_raise(ERR_LIB_EVP, EVP_R_INVALID_NULL_ALGORITHM);
+        return 0;
+    }
+
+    if (ctx->digest->prov == NULL)
         goto legacy;
 
     if (ctx->digest->dfinal == NULL) {

--- a/crypto/x509/x509_cmp.c
+++ b/crypto/x509/x509_cmp.c
@@ -251,20 +251,20 @@ int X509_NAME_cmp(const X509_NAME *a, const X509_NAME *b)
         return -1;
 
     /* Ensure canonical encoding is present and up to date */
-    if (!a->canon_enc || a->modified) {
+    if (a->canon_enc == NULL || a->modified) {
         ret = i2d_X509_NAME((X509_NAME *)a, NULL);
         if (ret < 0)
             return -2;
     }
 
-    if (!b->canon_enc || b->modified) {
+    if (b->canon_enc == NULL || b->modified) {
         ret = i2d_X509_NAME((X509_NAME *)b, NULL);
         if (ret < 0)
             return -2;
     }
 
     ret = a->canon_enclen - b->canon_enclen;
-    if (ret == 0 && a->canon_enclen != 0)
+    if (ret == 0 && a->canon_enclen != NULL && b->canon_enc != NULL)
         ret = memcmp(a->canon_enc, b->canon_enc, a->canon_enclen);
 
     return ret < 0 ? -1 : ret > 0;

--- a/crypto/x509/x509_cmp.c
+++ b/crypto/x509/x509_cmp.c
@@ -263,8 +263,11 @@ int X509_NAME_cmp(const X509_NAME *a, const X509_NAME *b)
             return -2;
     }
 
+    if (a->canon_enc == NULL || b->canon_enc == NULL)
+        return -2;
+
     ret = a->canon_enclen - b->canon_enclen;
-    if (ret == 0 && a->canon_enclen != NULL && b->canon_enc != NULL)
+    if (ret == 0 && a->canon_enclen != 0)
         ret = memcmp(a->canon_enc, b->canon_enc, a->canon_enclen);
 
     return ret < 0 ? -1 : ret > 0;

--- a/ssl/ssl_rsa.c
+++ b/ssl/ssl_rsa.c
@@ -424,6 +424,9 @@ static int use_certificate_chain_file(SSL_CTX *ctx, SSL *ssl, const char *file)
     void *passwd_callback_userdata;
     SSL_CTX *real_ctx = (ssl == NULL) ? ctx : ssl->ctx;
 
+    if (ctx == NULL && ssl == NULL)
+        return 0;
+
     ERR_clear_error();          /* clear error stack for
                                  * SSL_CTX_use_certificate() */
 

--- a/test/evp_test.c
+++ b/test/evp_test.c
@@ -1460,15 +1460,16 @@ static void pkey_test_cleanup(EVP_TEST *t)
 static int pkey_test_ctrl(EVP_TEST *t, EVP_PKEY_CTX *pctx,
                           const char *value)
 {
-    int rv;
+    int rv = 0;
     char *p, *tmpval;
 
     if (!TEST_ptr(tmpval = OPENSSL_strdup(value)))
         return 0;
     p = strchr(tmpval, ':');
-    if (p != NULL)
+    if (p != NULL) {
         *p++ = '\0';
-    rv = EVP_PKEY_CTX_ctrl_str(pctx, tmpval, p);
+        rv = EVP_PKEY_CTX_ctrl_str(pctx, tmpval, p);
+    }
     if (rv == -2) {
         t->err = "PKEY_CTRL_INVALID";
         rv = 1;

--- a/test/evp_test.c
+++ b/test/evp_test.c
@@ -1115,15 +1115,16 @@ static int mac_test_parse(EVP_TEST *t,
 static int mac_test_ctrl_pkey(EVP_TEST *t, EVP_PKEY_CTX *pctx,
                               const char *value)
 {
-    int rv;
+    int rv = 0;
     char *p, *tmpval;
 
     if (!TEST_ptr(tmpval = OPENSSL_strdup(value)))
         return 0;
     p = strchr(tmpval, ':');
-    if (p != NULL)
+    if (p != NULL) {
         *p++ = '\0';
-    rv = EVP_PKEY_CTX_ctrl_str(pctx, tmpval, p);
+        rv = EVP_PKEY_CTX_ctrl_str(pctx, tmpval, p);
+    }
     if (rv == -2)
         t->err = "PKEY_CTRL_INVALID";
     else if (rv <= 0)

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -8297,7 +8297,7 @@ static EVP_PKEY *get_tmp_dh_params(void)
         OSSL_PARAM_BLD_free_params(params);
     }
 
-    if (!EVP_PKEY_up_ref(tmp_dh_params))
+    if (tmp_dh_params != NULL && !EVP_PKEY_up_ref(tmp_dh_params))
         return NULL;
 
     return tmp_dh_params;

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -625,10 +625,14 @@ static int test_client_cert_verify_cb(void)
 end:
     X509_free(crt1);
     X509_free(crt2);
-    SSL_shutdown(clientssl);
-    SSL_shutdown(serverssl);
-    SSL_free(serverssl);
-    SSL_free(clientssl);
+    if (clientssl != NULL) {
+        SSL_shutdown(clientssl);
+        SSL_free(clientssl);
+    }
+    if (serverssl != NULL) {
+        SSL_shutdown(serverssl);
+        SSL_free(serverssl);
+    }
     SSL_CTX_free(sctx);
     SSL_CTX_free(cctx);
 


### PR DESCRIPTION

- [ ] documentation is added or updated
- [x] tests are added or updated
