### PR TITLE
Configure: check all DEPEND values against GENERATE, not just .h files

### DIFF
--- a/Configure
+++ b/Configure
@@ -2349,16 +2349,16 @@ EOF
             }
             foreach (@{$depends{$dest}}) {
                 my $d = cleanfile($sourced, $_, $blddir);
+                my $d2 = cleanfile($buildd, $_, $blddir);
 
                 # If we know it's generated, or assume it is because we can't
                 # find it in the source tree, we set file we depend on to be
                 # in the build tree rather than the source tree.
                 if ($d eq $src_configdata
-                    || (grep { $d eq $_ }
-                        map { cleanfile($srcdir, $_, $blddir) }
+                    || (grep { $d2 eq $_ }
                         keys %{$unified_info{generate}})
                     || ! -f $d) {
-                    $d = cleanfile($buildd, $_, $blddir);
+                    $d = $d2;
                 }
                 $unified_info{depends}->{$ddest}->{$d} = 1;
 

--- a/Configure
+++ b/Configure
@@ -2356,7 +2356,7 @@ EOF
                 if ($d eq $src_configdata
                     || (grep { $d eq $_ }
                         map { cleanfile($srcdir, $_, $blddir) }
-                        grep { /\.h$/ } keys %{$unified_info{generate}})
+                        keys %{$unified_info{generate}})
                     || ! -f $d) {
                     $d = cleanfile($buildd, $_, $blddir);
                 }


### PR DESCRIPTION
All files that are given to DEPEND statements in build.info files are
being checked against GENERATE statements, to see if it's reasonable
to look for them in the source tree or not.  This was only done for .h
files, for reasons that are lost in history.  We now change that check
to look at all files instead.
