### PR TITLE
Fix windows build compiler issue.

### DIFF
--- a/crypto/http/http_lib.c
+++ b/crypto/http/http_lib.c
@@ -9,6 +9,7 @@
 
 #include <openssl/http.h>
 #include <openssl/httperr.h>
+#include <openssl/bio.h> /* for BIO_snprintf() */
 #include <openssl/err.h>
 #include <string.h>
 #include "internal/cryptlib.h" /* for ossl_assert() */
@@ -164,7 +165,7 @@ int OSSL_parse_url(const char *url, char **pscheme, char **puser, char **phost,
 
         if ((*ppath = OPENSSL_malloc(buflen)) == NULL)
             goto err;
-        snprintf(*ppath, buflen, "/%s", path);
+        BIO_snprintf(*ppath, buflen, "/%s", path);
     }
     return 1;
 


### PR DESCRIPTION
Another case of snprintf() being used.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
