### PR TITLE
Add a missing RUN_ONCE in rand_lib.c

### DIFF
--- a/crypto/rand/rand_lib.c
+++ b/crypto/rand/rand_lib.c
@@ -436,7 +436,7 @@ RAND_POOL *rand_pool_new(int entropy_requested, int secure,
     size_t min_alloc_size = RAND_POOL_MIN_ALLOCATION(secure);
 
     if (!RUN_ONCE(&rand_init, do_rand_init))
-        return 0;
+        return NULL;
 
     pool = OPENSSL_zalloc(sizeof(*pool));
     if (pool == NULL) {

--- a/crypto/rand/rand_lib.c
+++ b/crypto/rand/rand_lib.c
@@ -432,9 +432,13 @@ err:
 RAND_POOL *rand_pool_new(int entropy_requested, int secure,
                          size_t min_len, size_t max_len)
 {
-    RAND_POOL *pool = OPENSSL_zalloc(sizeof(*pool));
+    RAND_POOL *pool;
     size_t min_alloc_size = RAND_POOL_MIN_ALLOCATION(secure);
 
+    if (!RUN_ONCE(&rand_init, do_rand_init))
+        return 0;
+
+    pool = OPENSSL_zalloc(sizeof(*pool));
     if (pool == NULL) {
         RANDerr(RAND_F_RAND_POOL_NEW, ERR_R_MALLOC_FAILURE);
         return NULL;


### PR DESCRIPTION
Some of the callbacks in rand_lib.c were being invoked without the
RUN_ONCE for that file being called. We add it during rand_pool_new
which should cover all cases.

Fixes #7870
Fixes #11144

Note that this is 1.1.1 only. This fix isn't relevant in master.