### PR TITLE
Add $(PERL) to util/wrap.pl execution to avoid env incompatibilities

### DIFF
--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -1433,9 +1433,10 @@ EOF
           # Also redo $gen0, to ensure that we have the proper extension where
           # necessary.
           $gen0 = platform->bin($gen0);
+          # Use $(PERL) to execute wrap.pl directly to avoid calling env
           return <<"EOF";
 $args{src}: $gen0 $deps \$(BLDDIR)/util/wrap.pl
-	\$(BLDDIR)/util/wrap.pl $gen0$gen_args > \$@
+	\$(PERL) \$(BLDDIR)/util/wrap.pl $gen0$gen_args > \$@
 EOF
       } else {
           #


### PR DESCRIPTION
Using /usr/bin/env on the NonStop ia64 and x86 platforms
causes a translation of - to -i as part of the implicit interpretation
by env of its arguments prior to handing off the arguments to perl.
This causes the FIPS module configuration to be written to a file
named -i instead of going to stdout.

CLA: Trivial

Fixes: #14612

Signed-off-by: Randall S. Becker <rsbecker@nexbridge.com>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
