### PR TITLE
Deal with explicit NULL dereferences from Coverity

### DIFF
--- a/apps/gendsa.c
+++ b/apps/gendsa.c
@@ -60,8 +60,7 @@ int gendsa_main(int argc, char **argv)
     char *dsaparams = NULL, *ciphername = NULL;
     char *outfile = NULL, *passoutarg = NULL, *passout = NULL, *prog;
     OPTION_CHOICE o;
-    int ret = 1, private = 0, verbose = 0;
-    const BIGNUM *p = NULL;
+    int ret = 1, private = 0, verbose = 0, nbits;
 
     prog = opt_init(argc, argv, gendsa_options);
     while ((o = opt_next()) != OPT_EOF) {
@@ -126,7 +125,8 @@ int gendsa_main(int argc, char **argv)
     if (out == NULL)
         goto end2;
 
-    if (EVP_PKEY_bits(pkey) > OPENSSL_DSA_MAX_MODULUS_BITS)
+    nbits = EVP_PKEY_bits(pkey);
+    if (nbits > OPENSSL_DSA_MAX_MODULUS_BITS)
         BIO_printf(bio_err,
                    "Warning: It is not recommended to use more than %d bit for DSA keys.\n"
                    "         Your key size is %d! Larger key size may behave not as expected.\n",
@@ -144,7 +144,7 @@ int gendsa_main(int argc, char **argv)
         goto end;
     }
     if (verbose)
-        BIO_printf(bio_err, "Generating DSA key, %d bits\n", BN_num_bits(p));
+        BIO_printf(bio_err, "Generating DSA key, %d bits\n", nbits);
     if (EVP_PKEY_keygen(ctx, &pkey) <= 0) {
         BIO_printf(bio_err, "unable to generate key\n");
         goto end;

--- a/crypto/encode_decode/encoder_pkey.c
+++ b/crypto/encode_decode/encoder_pkey.c
@@ -261,7 +261,7 @@ static int ossl_encoder_ctx_setup_for_pkey(OSSL_ENCODER_CTX *ctx,
         }
     }
 
-    if (OSSL_ENCODER_CTX_get_num_encoders(ctx) != 0) {
+    if (data != NULL && OSSL_ENCODER_CTX_get_num_encoders(ctx) != 0) {
         if (!OSSL_ENCODER_CTX_set_construct(ctx, encoder_construct_pkey)
             || !OSSL_ENCODER_CTX_set_construct_data(ctx, data)
             || !OSSL_ENCODER_CTX_set_cleanup(ctx, encoder_destruct_pkey))

--- a/providers/implementations/keymgmt/rsa_kmgmt.c
+++ b/providers/implementations/keymgmt/rsa_kmgmt.c
@@ -434,16 +434,15 @@ static void *gen_init(void *provctx, int selection, int rsa_type,
             || !BN_set_word(gctx->pub_exp, RSA_F4)) {
             BN_free(gctx->pub_exp);
             OPENSSL_free(gctx);
-            gctx = NULL;
-        } else {
-            gctx->nbits = 2048;
-            gctx->primes = RSA_DEFAULT_PRIME_NUM;
-            gctx->rsa_type = rsa_type;
+            return NULL;
         }
+        gctx->nbits = 2048;
+        gctx->primes = RSA_DEFAULT_PRIME_NUM;
+        gctx->rsa_type = rsa_type;
     }
-    if (gctx != NULL && !rsa_gen_set_params(gctx, params)) {
+    if (!rsa_gen_set_params(gctx, params)) {
         OPENSSL_free(gctx);
-        gctx = NULL;
+        return NULL;
     }
     return gctx;
 }

--- a/providers/implementations/keymgmt/rsa_kmgmt.c
+++ b/providers/implementations/keymgmt/rsa_kmgmt.c
@@ -441,7 +441,7 @@ static void *gen_init(void *provctx, int selection, int rsa_type,
             gctx->rsa_type = rsa_type;
         }
     }
-    if (!rsa_gen_set_params(gctx, params)) {
+    if (gctx != NULL && !rsa_gen_set_params(gctx, params)) {
         OPENSSL_free(gctx);
         gctx = NULL;
     }

--- a/providers/implementations/signature/sm2sig.c
+++ b/providers/implementations/signature/sm2sig.c
@@ -105,8 +105,8 @@ static void *sm2sig_newctx(void *provctx, const char *propq)
     ctx->libctx = PROV_LIBCTX_OF(provctx);
     if (propq != NULL && (ctx->propq = OPENSSL_strdup(propq)) == NULL) {
         OPENSSL_free(ctx);
-        ctx = NULL;
         ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
+        return NULL;
     }
     /* don't allow to change MD, and in fact there is no such need */
     ctx->flag_allow_md = 0;

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -625,10 +625,14 @@ static int test_client_cert_verify_cb(void)
 end:
     X509_free(crt1);
     X509_free(crt2);
-    SSL_shutdown(clientssl);
-    SSL_shutdown(serverssl);
-    SSL_free(serverssl);
-    SSL_free(clientssl);
+    if (clientssl != NULL) {
+        SSL_shutdown(clientssl);
+        SSL_free(clientssl);
+    }
+    if (serverssl != NULL) {
+        SSL_shutdown(serverssl);
+        SSL_free(serverssl);
+    }
     SSL_CTX_free(sctx);
     SSL_CTX_free(cctx);
 


### PR DESCRIPTION

- [ ] documentation is added or updated
- [x] tests are added or updated
