### PR TITLE
APPS: fix load_certs_multifile() interpreting backslashes in file path names

### DIFF
--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -641,12 +641,8 @@ void* app_malloc(int sz, const char *what)
 char *next_item(char *opt) /* in list separated by comma and/or space */
 {
     /* advance to separator (comma or whitespace), if any */
-    while (*opt != ',' && !isspace(*opt) && *opt != '\0') {
-        if (*opt == '\\' && opt[1] != '\0')
-            /* skip and unescape '\' escaped char */
-            memmove(opt, opt + 1, strlen(opt));
+    while (*opt != ',' && !isspace(*opt) && *opt != '\0')
         opt++;
-    }
     if (*opt != '\0') {
         /* terminate current item */
         *opt++ = '\0';


### PR DESCRIPTION
Fixes #14622
