### PR TITLE
fix coverity deference after null check, uninitialised scalar variabless and dereferences after null checks.

### DIFF
--- a/apps/s_time.c
+++ b/apps/s_time.c
@@ -127,7 +127,7 @@ int s_time_main(int argc, char **argv)
     int maxtime = SECONDS, nConn = 0, perform = 3, ret = 1, i, st_bugs = 0;
     long bytes_read = 0, finishtime = 0;
     OPTION_CHOICE o;
-    int min_version = 0, max_version = 0, ver, buf_len;
+    int min_version = 0, max_version = 0, ver, buf_len, fd;
     size_t buf_size;
 
     meth = TLS_client_method();
@@ -346,7 +346,8 @@ int s_time_main(int argc, char **argv)
             continue;
     }
     SSL_set_shutdown(scon, SSL_SENT_SHUTDOWN | SSL_RECEIVED_SHUTDOWN);
-    BIO_closesocket(SSL_get_fd(scon));
+    if ((fd = SSL_get_fd(scon)) >= 0)
+        BIO_closesocket(fd);
 
     nConn = 0;
     totalTime = 0.0;
@@ -373,7 +374,8 @@ int s_time_main(int argc, char **argv)
                 bytes_read += i;
         }
         SSL_set_shutdown(scon, SSL_SENT_SHUTDOWN | SSL_RECEIVED_SHUTDOWN);
-        BIO_closesocket(SSL_get_fd(scon));
+        if ((fd = SSL_get_fd(scon)) >= 0)
+            BIO_closesocket(fd);
 
         nConn += 1;
         if (SSL_session_reused(scon)) {

--- a/apps/speed.c
+++ b/apps/speed.c
@@ -3613,7 +3613,10 @@ static void multiblock_speed(const EVP_CIPHER *evp_cipher, int lengths_single,
     ctx = EVP_CIPHER_CTX_new();
     EVP_EncryptInit_ex(ctx, evp_cipher, NULL, NULL, no_iv);
 
-    keylen = EVP_CIPHER_CTX_key_length(ctx);
+    if ((keylen = EVP_CIPHER_CTX_key_length(ctx)) < 0) {
+        BIO_printf(bio_err, "Impossible negative key length: %d\n", keylen);
+        return;
+    }
     key = app_malloc(keylen, "evp_cipher key");
     EVP_CIPHER_CTX_rand_key(ctx, key);
     EVP_EncryptInit_ex(ctx, NULL, NULL, key, NULL);

--- a/crypto/err/err_blocks.c
+++ b/crypto/err/err_blocks.c
@@ -92,7 +92,8 @@ void ERR_vset_error(int lib, int reason, const char *fmt, va_list args)
         }
         if (printed_len < 0)
             printed_len = 0;
-        buf[printed_len] = '\0';
+        if (buf != NULL)
+            buf[printed_len] = '\0';
 
         /*
          * Try to reduce the size, but only if we maximized above.  If that
@@ -103,6 +104,7 @@ void ERR_vset_error(int lib, int reason, const char *fmt, va_list args)
         if ((rbuf = OPENSSL_realloc(buf, printed_len + 1)) != NULL) {
             buf = rbuf;
             buf_size = printed_len + 1;
+            buf[printed_len] = '\0';
         }
 
         if (buf != NULL)

--- a/crypto/evp/e_aria.c
+++ b/crypto/evp/e_aria.c
@@ -171,7 +171,7 @@ static int aria_ctr_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
                                const unsigned char *in, size_t len)
 {
     unsigned int num = EVP_CIPHER_CTX_num(ctx);
-    EVP_ARIA_KEY *dat = EVP_C_DATA(EVP_ARIA_KEY,ctx);
+    EVP_ARIA_KEY *dat = EVP_C_DATA(EVP_ARIA_KEY, ctx);
 
     CRYPTO_ctr128_encrypt(in, out, len, &dat->ks, ctx->iv,
                           EVP_CIPHER_CTX_buf_noconst(ctx), &num,

--- a/crypto/evp/e_camellia.c
+++ b/crypto/evp/e_camellia.c
@@ -316,9 +316,13 @@ static int camellia_cfb1_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
 static int camellia_ctr_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
                                const unsigned char *in, size_t len)
 {
-    unsigned int num = EVP_CIPHER_CTX_num(ctx);
+    int snum = EVP_CIPHER_CTX_num(ctx);
+    unsigned int num;
     EVP_CAMELLIA_KEY *dat = EVP_C_DATA(EVP_CAMELLIA_KEY,ctx);
 
+    if (snum < 0)
+        return 0;
+    num = snum;
     if (dat->stream.ctr)
         CRYPTO_ctr128_encrypt_ctr32(in, out, len, &dat->ks, ctx->iv,
                                     EVP_CIPHER_CTX_buf_noconst(ctx), &num,

--- a/crypto/idea/i_cfb64.c
+++ b/crypto/idea/i_cfb64.c
@@ -33,6 +33,11 @@ void IDEA_cfb64_encrypt(const unsigned char *in, unsigned char *out,
     unsigned long ti[2];
     unsigned char *iv, c, cc;
 
+    if (n < 0) {
+        *num = -1;
+        return;
+    }
+
     iv = (unsigned char *)ivec;
     if (encrypt) {
         while (l--) {

--- a/crypto/idea/i_ofb64.c
+++ b/crypto/idea/i_ofb64.c
@@ -35,6 +35,11 @@ void IDEA_ofb64_encrypt(const unsigned char *in, unsigned char *out,
     unsigned char *iv;
     int save = 0;
 
+    if (n < 0) {
+        *num = -1;
+        return;
+    }
+
     iv = (unsigned char *)ivec;
     n2l(iv, v0);
     n2l(iv, v1);

--- a/crypto/modes/cfb128.c
+++ b/crypto/modes/cfb128.c
@@ -30,6 +30,11 @@ void CRYPTO_cfb128_encrypt(const unsigned char *in, unsigned char *out,
     unsigned int n;
     size_t l = 0;
 
+    if (*num < 0) {
+        /* There is no good way to signal an error return from here */
+        *num = -1;
+        return;
+    }
     n = *num;
 
     if (enc) {

--- a/crypto/modes/ctr128.c
+++ b/crypto/modes/ctr128.c
@@ -155,7 +155,7 @@ void CRYPTO_ctr128_encrypt_ctr32(const unsigned char *in, unsigned char *out,
 {
     unsigned int n, ctr32;
 
-    n = *num;
+   n = *num;
 
     while (n && len) {
         *(out++) = *(in++) ^ ecount_buf[n];

--- a/crypto/modes/ofb128.c
+++ b/crypto/modes/ofb128.c
@@ -29,6 +29,11 @@ void CRYPTO_ofb128_encrypt(const unsigned char *in, unsigned char *out,
     unsigned int n;
     size_t l = 0;
 
+    if (*num < 0) {
+        /* There is no good way to signal an error return from here */
+        *num = -1;
+        return;
+    }
     n = *num;
 
 #if !defined(OPENSSL_SMALL_FOOTPRINT)

--- a/crypto/pem/pvkfmt.c
+++ b/crypto/pem/pvkfmt.c
@@ -323,7 +323,7 @@ EVP_PKEY *ossl_b2i_bio(BIO *in, int *ispub)
     const unsigned char *p;
     unsigned char hdr_buf[16], *buf = NULL;
     unsigned int bitlen, magic, length;
-    int isdss;
+    int isdss = -1;
     void *key = NULL;
     EVP_PKEY *pkey = NULL;
 

--- a/test/bad_dtls_test.c
+++ b/test/bad_dtls_test.c
@@ -122,7 +122,8 @@ static int validate_client_hello(BIO *wbio)
     int cookie_found = 0;
     unsigned int u = 0;
 
-    len = BIO_get_mem_data(wbio, (char **)&data);
+    if ((len = BIO_get_mem_data(wbio, (char **)&data)) < 0)
+        return 0;
     if (!PACKET_buf_init(&pkt, data, len))
         return 0;
 
@@ -391,6 +392,9 @@ static int validate_ccs(BIO *wbio)
     unsigned int u;
 
     len = BIO_get_mem_data(wbio, (char **)&data);
+    if (len < 0)
+        return 0;
+
     if (!PACKET_buf_init(&pkt, data, len))
         return 0;
 

--- a/test/clienthellotest.c
+++ b/test/clienthellotest.c
@@ -185,8 +185,8 @@ static int test_client_hello(int currtest)
         goto end;
     }
 
-    len = BIO_get_mem_data(wbio, (char **)&data);
-    if (!TEST_true(PACKET_buf_init(&pkt, data, len))
+    if (!TEST_long_ge(len = BIO_get_mem_data(wbio, (char **)&data), 0)
+            || !TEST_true(PACKET_buf_init(&pkt, data, len))
                /* Skip the record header */
             || !PACKET_forward(&pkt, SSL3_RT_HEADER_LENGTH))
         goto end;

--- a/test/endecoder_legacy_test.c
+++ b/test/endecoder_legacy_test.c
@@ -289,8 +289,9 @@ static int test_membio_str_eq(BIO *bio_provided, BIO *bio_legacy)
     long len_provided = BIO_get_mem_data(bio_provided, &str_provided);
     long len_legacy = BIO_get_mem_data(bio_legacy, &str_legacy);
 
-    return TEST_strn2_eq(str_provided, len_provided,
-                         str_legacy, len_legacy);
+    return TEST_long_ge(len_provided, 0)
+           && TEST_strn2_eq(str_provided, len_provided,
+                            str_legacy, len_legacy);
 }
 
 static int test_protected_PEM(const char *keytype, int evp_type,

--- a/test/servername_test.c
+++ b/test/servername_test.c
@@ -52,8 +52,8 @@ static int get_sni_from_client_hello(BIO *bio, char **sni)
     memset(&pkt4, 0, sizeof(pkt4));
     memset(&pkt5, 0, sizeof(pkt5));
 
-    len = BIO_get_mem_data(bio, (char **)&data);
-    if (!TEST_true(PACKET_buf_init(&pkt, data, len))
+    if (!TEST_long_ge(len = BIO_get_mem_data(bio, (char **)&data), 0)
+            || !TEST_true(PACKET_buf_init(&pkt, data, len))
                /* Skip the record header */
             || !PACKET_forward(&pkt, SSL3_RT_HEADER_LENGTH)
                /* Skip the handshake message header */

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -5960,7 +5960,8 @@ static int get_MFL_from_client_hello(BIO *bio, int *mfl_codemfl_code)
     memset(&pkt2, 0, sizeof(pkt2));
     memset(&pkt3, 0, sizeof(pkt3));
 
-    if (!TEST_true( PACKET_buf_init( &pkt, data, len ) )
+    if (!TEST_long_gt(len, 0)
+            || !TEST_true( PACKET_buf_init( &pkt, data, len ) )
                /* Skip the record header */
             || !PACKET_forward(&pkt, SSL3_RT_HEADER_LENGTH)
                /* Skip the handshake message header */


### PR DESCRIPTION
coverity 1474426: uninitialised scalar variable: based on the value, it would with work properly or produce an error.  Most likely seems to have been the former.

coverity 1452768: dereference after null check

fix coverity 271258:, 1371689, 1371690, 1451499, 1451501, 1451506, 1451507, 1351511, 145151, 1451574:, 1454812, 1469427, 1451534 & 1451544: improper use of negative values

- [ ] documentation is added or updated
- [ ] tests are added or updated
