### PR TITLE
Fix compilation under -Werror

### DIFF
--- a/crypto/ec/ecx_meth.c
+++ b/crypto/ec/ecx_meth.c
@@ -18,6 +18,7 @@
 #include <openssl/ec.h>
 #include <openssl/core_names.h>
 #include <openssl/param_build.h>
+#include <openssl/rand.h>
 #include "internal/cryptlib.h"
 #include "internal/provider.h"
 #include "crypto/asn1.h"


### PR DESCRIPTION
With strict warnings and warnings as error, openssl currently does not compile
due to a missing include.

Signed-off-by: Juergen Christ <jchrist@linux.ibm.com>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->