### PR TITLE
Allocates and initializes pubkey in X509_PUBKEY_dup()

### DIFF
--- a/crypto/x509/x_pubkey.c
+++ b/crypto/x509/x_pubkey.c
@@ -207,22 +207,20 @@ IMPLEMENT_ASN1_FUNCTIONS(X509_PUBKEY)
  */
 X509_PUBKEY *X509_PUBKEY_dup(const X509_PUBKEY *a)
 {
-    X509_PUBKEY *pubkey = NULL;
+    X509_PUBKEY *pubkey = OPENSSL_zalloc(sizeof(*pubkey));
 
-    if (!x509_pubkey_ex_new((ASN1_VALUE **)&pubkey,
-                            ASN1_ITEM_rptr(X509_PUBKEY_INTERNAL))
-        || !x509_pubkey_set0_libctx(pubkey, a->libctx, a->propq)
-        || (pubkey->algor = X509_ALGOR_dup(a->algor)) == NULL
-        || (pubkey->public_key = ASN1_BIT_STRING_new()) == NULL
-        || !ASN1_BIT_STRING_set(pubkey->public_key,
-                                a->public_key->data, a->public_key->length)
-        || (a->pkey != NULL && !EVP_PKEY_up_ref(a->pkey))) {
+    if (pubkey == NULL
+            || !x509_pubkey_set0_libctx(pubkey, a->libctx, a->propq)
+            || (pubkey->algor = X509_ALGOR_dup(a->algor)) == NULL
+            || (pubkey->public_key = ASN1_BIT_STRING_new()) == NULL
+            || !ASN1_BIT_STRING_set(pubkey->public_key,
+                                    a->public_key->data, a->public_key->length)
+            || (a->pkey != NULL && !EVP_PKEY_up_ref(a->pkey))) {
         x509_pubkey_ex_free((ASN1_VALUE **)&pubkey,
                             ASN1_ITEM_rptr(X509_PUBKEY_INTERNAL));
         ERR_raise(ERR_LIB_X509, ERR_R_MALLOC_FAILURE);
         return NULL;
-    }
-
+    };
     pubkey->pkey = a->pkey;
     return pubkey;
 }

--- a/crypto/x509/x_pubkey.c
+++ b/crypto/x509/x_pubkey.c
@@ -220,7 +220,7 @@ X509_PUBKEY *X509_PUBKEY_dup(const X509_PUBKEY *a)
                             ASN1_ITEM_rptr(X509_PUBKEY_INTERNAL));
         ERR_raise(ERR_LIB_X509, ERR_R_MALLOC_FAILURE);
         return NULL;
-    };
+    }
     pubkey->pkey = a->pkey;
     return pubkey;
 }

--- a/crypto/x509/x_pubkey.c
+++ b/crypto/x509/x_pubkey.c
@@ -209,7 +209,8 @@ X509_PUBKEY *X509_PUBKEY_dup(const X509_PUBKEY *a)
 {
     X509_PUBKEY *pubkey = NULL;
 
-    if (!x509_pubkey_ex_new(NULL, ASN1_ITEM_rptr(X509_PUBKEY_INTERNAL))
+    if (!x509_pubkey_ex_new((ASN1_VALUE **)&pubkey,
+                            ASN1_ITEM_rptr(X509_PUBKEY_INTERNAL))
         || !x509_pubkey_set0_libctx(pubkey, a->libctx, a->propq)
         || (pubkey->algor = X509_ALGOR_dup(a->algor)) == NULL
         || (pubkey->public_key = ASN1_BIT_STRING_new()) == NULL

--- a/doc/man3/X509_PUBKEY_new.pod
+++ b/doc/man3/X509_PUBKEY_new.pod
@@ -46,6 +46,9 @@ structure defined in RFC5280 and used in certificates and certificate requests.
 
 X509_PUBKEY_new() allocates and initializes an B<X509_PUBKEY> structure.
 
+X509_PUBKEY_dup() creates a duplicate copy of the B<X509_PUBKEY> object
+specified by I<a>.
+
 X509_PUBKEY_free() frees up B<X509_PUBKEY> structure B<a>. If B<a> is NULL
 nothing is done.
 
@@ -102,10 +105,9 @@ directly: they will instead call wrapper functions such as X509_get0_pubkey().
 
 =head1 RETURN VALUES
 
-If the allocation fails, X509_PUBKEY_new() returns B<NULL> and sets an error
-code that can be obtained by L<ERR_get_error(3)>.
-
-Otherwise it returns a pointer to the newly allocated structure.
+If the allocation fails, X509_PUBKEY_new() and X509_PUBKEY_dup() return
+B<NULL> and set an error code that can be obtained by L<ERR_get_error(3)>.
+Otherwise they return a pointer to the newly allocated structure.
 
 X509_PUBKEY_free() does not return a value.
 

--- a/doc/man3/X509_PUBKEY_new.pod
+++ b/doc/man3/X509_PUBKEY_new.pod
@@ -49,14 +49,14 @@ X509_PUBKEY_new() allocates and initializes an B<X509_PUBKEY> structure.
 X509_PUBKEY_dup() creates a duplicate copy of the B<X509_PUBKEY> object
 specified by I<a>.
 
-X509_PUBKEY_free() frees up B<X509_PUBKEY> structure B<a>. If B<a> is NULL
+X509_PUBKEY_free() frees up B<X509_PUBKEY> structure I<a>. If I<a> is NULL
 nothing is done.
 
-X509_PUBKEY_set() sets the public key in B<*x> to the public key contained
-in the B<EVP_PKEY> structure B<pkey>. If B<*x> is not NULL any existing
+X509_PUBKEY_set() sets the public key in I<*x> to the public key contained
+in the B<EVP_PKEY> structure I<pkey>. If I<*x> is not NULL any existing
 public key structure will be freed.
 
-X509_PUBKEY_get0() returns the public key contained in B<key>. The returned
+X509_PUBKEY_get0() returns the public key contained in I<key>. The returned
 value is an internal pointer which B<MUST NOT> be freed after use.
 
 X509_PUBKEY_get() is similar to X509_PUBKEY_get0() except the reference
@@ -77,19 +77,19 @@ d2i_PUBKEY_bio(), d2i_PUBKEY_fp(), i2d_PUBKEY_bio() and i2d_PUBKEY_fp() are
 similar to d2i_PUBKEY() and i2d_PUBKEY() except they decode or encode using a
 B<BIO> or B<FILE> pointer.
 
-X509_PUBKEY_set0_param() sets the public key parameters of B<pub>. The
-OID associated with the algorithm is set to B<aobj>. The type of the
-algorithm parameters is set to B<type> using the structure B<pval>.
-The encoding of the public key itself is set to the B<penclen>
-bytes contained in buffer B<penc>. On success ownership of all the supplied
-parameters is passed to B<pub> so they must not be freed after the
+X509_PUBKEY_set0_param() sets the public key parameters of I<pub>. The
+OID associated with the algorithm is set to I<aobj>. The type of the
+algorithm parameters is set to I<type> using the structure I<pval>.
+The encoding of the public key itself is set to the I<penclen>
+bytes contained in buffer I<penc>. On success ownership of all the supplied
+parameters is passed to I<pub> so they must not be freed after the
 call.
 
-X509_PUBKEY_get0_param() retrieves the public key parameters from B<pub>,
-B<*ppkalg> is set to the associated OID and the encoding consists of
-B<*ppklen> bytes at B<*pk>, B<*pa> is set to the associated
+X509_PUBKEY_get0_param() retrieves the public key parameters from I<pub>,
+I<*ppkalg> is set to the associated OID and the encoding consists of
+I<*ppklen> bytes at I<*pk>, I<*pa> is set to the associated
 AlgorithmIdentifier for the public key. If the value of any of these
-parameters is not required it can be set to B<NULL>. All of the
+parameters is not required it can be set to NULL. All of the
 retrieved pointers are internal and must not be freed after the
 call.
 
@@ -106,13 +106,13 @@ directly: they will instead call wrapper functions such as X509_get0_pubkey().
 =head1 RETURN VALUES
 
 If the allocation fails, X509_PUBKEY_new() and X509_PUBKEY_dup() return
-B<NULL> and set an error code that can be obtained by L<ERR_get_error(3)>.
+NULL and set an error code that can be obtained by L<ERR_get_error(3)>.
 Otherwise they return a pointer to the newly allocated structure.
 
 X509_PUBKEY_free() does not return a value.
 
 X509_PUBKEY_get0() and X509_PUBKEY_get() return a pointer to an B<EVP_PKEY>
-structure or B<NULL> if an error occurs.
+structure or NULL if an error occurs.
 
 X509_PUBKEY_set(), X509_PUBKEY_set0_param() and X509_PUBKEY_get0_param()
 return 1 for success and 0 if an error occurred.

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -1856,31 +1856,31 @@ static int test_emptyikm_HKDF(void)
 #ifndef OPENSSL_NO_EC
 static int test_X509_PUBKEY_inplace(void)
 {
-  int ret = 0;
-  X509_PUBKEY *xp = NULL;
-  const unsigned char *p = kExampleECPubKeyDER;
-  size_t input_len = sizeof(kExampleECPubKeyDER);
+    int ret = 0;
+    X509_PUBKEY *xp = NULL;
+    const unsigned char *p = kExampleECPubKeyDER;
+    size_t input_len = sizeof(kExampleECPubKeyDER);
 
-  if (!TEST_ptr(xp = d2i_X509_PUBKEY(NULL, &p, input_len)))
-    goto done;
+    if (!TEST_ptr(xp = d2i_X509_PUBKEY(NULL, &p, input_len)))
+        goto done;
 
-  if (!TEST_ptr(X509_PUBKEY_get0(xp)))
-    goto done;
+    if (!TEST_ptr(X509_PUBKEY_get0(xp)))
+        goto done;
 
-  p = kExampleBadECPubKeyDER;
-  input_len = sizeof(kExampleBadECPubKeyDER);
+    p = kExampleBadECPubKeyDER;
+    input_len = sizeof(kExampleBadECPubKeyDER);
 
-  if (!TEST_ptr(xp = d2i_X509_PUBKEY(&xp, &p, input_len)))
-    goto done;
+    if (!TEST_ptr(xp = d2i_X509_PUBKEY(&xp, &p, input_len)))
+        goto done;
 
-  if (!TEST_true(X509_PUBKEY_get0(xp) == NULL))
-    goto done;
+    if (!TEST_true(X509_PUBKEY_get0(xp) == NULL))
+        goto done;
 
-  ret = 1;
+    ret = 1;
 
-done:
-  X509_PUBKEY_free(xp);
-  return ret;
+ done:
+    X509_PUBKEY_free(xp);
+    return ret;
 }
 
 static int test_X509_PUBKEY_dup(void)
@@ -2743,6 +2743,7 @@ int setup_tests(void)
 #ifndef OPENSSL_NO_EC
     ADD_TEST(test_X509_PUBKEY_inplace);
     ADD_TEST(test_X509_PUBKEY_dup);
+if(0){
     ADD_ALL_TESTS(test_invalide_ec_char2_pub_range_decode,
                   OSSL_NELEM(ec_der_pub_keys));
 #endif
@@ -2777,7 +2778,7 @@ int setup_tests(void)
 #endif
 
     ADD_TEST(test_names_do_all);
-
+}
     return 1;
 }
 

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -1885,41 +1885,41 @@ static int test_X509_PUBKEY_inplace(void)
 
 static int test_X509_PUBKEY_dup(void)
 {
-  int ret = 0;
-  X509_PUBKEY *xp = NULL, *xq = NULL;
-  const unsigned char *p = kExampleECPubKeyDER;
-  size_t input_len = sizeof(kExampleECPubKeyDER);
+    int ret = 0;
+    X509_PUBKEY *xp = NULL, *xq = NULL;
+    const unsigned char *p = kExampleECPubKeyDER;
+    size_t input_len = sizeof(kExampleECPubKeyDER);
 
-  if (!TEST_ptr(xp = d2i_X509_PUBKEY(NULL, &p, input_len))
-          || !TEST_ptr(xq = X509_PUBKEY_dup(xp))
-          || !TEST_ptr_ne(xp, xq))
-    goto done;
+    if (!TEST_ptr(xp = d2i_X509_PUBKEY(NULL, &p, input_len))
+            || !TEST_ptr(xq = X509_PUBKEY_dup(xp))
+            || !TEST_ptr_ne(xp, xq))
+        goto done;
 
-  if (!TEST_ptr(X509_PUBKEY_get0(xq))
-        || !TEST_ptr(X509_PUBKEY_get0(xp))
-        || !TEST_ptr_eq(X509_PUBKEY_get0(xq), X509_PUBKEY_get0(xp)))
-    goto done;
+    if (!TEST_ptr(X509_PUBKEY_get0(xq))
+            || !TEST_ptr(X509_PUBKEY_get0(xp))
+            || !TEST_ptr_eq(X509_PUBKEY_get0(xq), X509_PUBKEY_get0(xp)))
+        goto done;
 
-  X509_PUBKEY_free(xq);
-  xq = NULL;
-  p = kExampleBadECPubKeyDER;
-  input_len = sizeof(kExampleBadECPubKeyDER);
+    X509_PUBKEY_free(xq);
+    xq = NULL;
+    p = kExampleBadECPubKeyDER;
+    input_len = sizeof(kExampleBadECPubKeyDER);
 
-  if (!TEST_ptr(xp = d2i_X509_PUBKEY(&xp, &p, input_len))
-          || !TEST_ptr(xq = X509_PUBKEY_dup(xp)))
-    goto done;
+    if (!TEST_ptr(xp = d2i_X509_PUBKEY(&xp, &p, input_len))
+            || !TEST_ptr(xq = X509_PUBKEY_dup(xp)))
+        goto done;
 
-  X509_PUBKEY_free(xp);
-  xp = NULL;
-  if (!TEST_true(X509_PUBKEY_get0(xq) == NULL))
-    goto done;
+    X509_PUBKEY_free(xp);
+    xp = NULL;
+    if (!TEST_true(X509_PUBKEY_get0(xq) == NULL))
+        goto done;
 
-  ret = 1;
+    ret = 1;
 
-done:
-  X509_PUBKEY_free(xp);
-  X509_PUBKEY_free(xq);
-  return ret;
+ done:
+    X509_PUBKEY_free(xp);
+    X509_PUBKEY_free(xq);
+    return ret;
 }
 #endif /* OPENSSL_NO_EC */
 
@@ -2743,7 +2743,6 @@ int setup_tests(void)
 #ifndef OPENSSL_NO_EC
     ADD_TEST(test_X509_PUBKEY_inplace);
     ADD_TEST(test_X509_PUBKEY_dup);
-if(0){
     ADD_ALL_TESTS(test_invalide_ec_char2_pub_range_decode,
                   OSSL_NELEM(ec_der_pub_keys));
 #endif
@@ -2778,7 +2777,7 @@ if(0){
 #endif
 
     ADD_TEST(test_names_do_all);
-}
+
     return 1;
 }
 

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -1882,6 +1882,45 @@ done:
   X509_PUBKEY_free(xp);
   return ret;
 }
+
+static int test_X509_PUBKEY_dup(void)
+{
+  int ret = 0;
+  X509_PUBKEY *xp = NULL, *xq = NULL;
+  const unsigned char *p = kExampleECPubKeyDER;
+  size_t input_len = sizeof(kExampleECPubKeyDER);
+
+  if (!TEST_ptr(xp = d2i_X509_PUBKEY(NULL, &p, input_len))
+          || !TEST_ptr(xq = X509_PUBKEY_dup(xp))
+          || !TEST_ptr_ne(xp, xq))
+    goto done;
+
+  if (!TEST_ptr(X509_PUBKEY_get0(xq))
+        || !TEST_ptr(X509_PUBKEY_get0(xp))
+        || !TEST_ptr_eq(X509_PUBKEY_get0(xq), X509_PUBKEY_get0(xp)))
+    goto done;
+
+  X509_PUBKEY_free(xq);
+  xq = NULL;
+  p = kExampleBadECPubKeyDER;
+  input_len = sizeof(kExampleBadECPubKeyDER);
+
+  if (!TEST_ptr(xp = d2i_X509_PUBKEY(&xp, &p, input_len))
+          || !TEST_ptr(xq = X509_PUBKEY_dup(xp)))
+    goto done;
+
+  X509_PUBKEY_free(xp);
+  xp = NULL;
+  if (!TEST_true(X509_PUBKEY_get0(xq) == NULL))
+    goto done;
+
+  ret = 1;
+
+done:
+  X509_PUBKEY_free(xp);
+  X509_PUBKEY_free(xq);
+  return ret;
+}
 #endif /* OPENSSL_NO_EC */
 
 /* Test getting and setting parameters on an EVP_PKEY_CTX */
@@ -2703,6 +2742,7 @@ int setup_tests(void)
     ADD_TEST(test_emptyikm_HKDF);
 #ifndef OPENSSL_NO_EC
     ADD_TEST(test_X509_PUBKEY_inplace);
+    ADD_TEST(test_X509_PUBKEY_dup);
     ADD_ALL_TESTS(test_invalide_ec_char2_pub_range_decode,
                   OSSL_NELEM(ec_der_pub_keys));
 #endif


### PR DESCRIPTION
Allocates and initializes pubkey in X509_PUBKEY_dup()

Fixes #14617

The other approach could be
 x509_pubkey_ex_new((ASN1_VALUE **)&pubkey, .....)
instead of passing NULL?
But now I left that as is and used X509_PUBKEY_new() instead to allocate memory to pubkey.



Signed-off-by: Sahana Prasad <sahana@redhat.com>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
