### PR TITLE
Be more selective about copying libcrypto symbols into legacy.so

### DIFF
--- a/crypto/build.info
+++ b/crypto/build.info
@@ -81,7 +81,7 @@ SOURCE[../libcrypto]=$UTIL_COMMON \
         punycode.c \
         $UPLINKSRC
 SOURCE[../providers/libfips.a]=$UTIL_COMMON
-SOURCE[../providers/liblegacy.a]=$UTIL_COMMON
+SOURCE[../providers/liblegacy.a]=cryptlib.c $CPUIDASM ctype.c
 
 # Implementations are now spread across several libraries, so the defines
 # need to be applied to all affected libraries and modules.


### PR DESCRIPTION
Some private libcrypto symbols are also included in legacy.so.
Unfortunately this included some files with "RUN_ONCE" functions and
global data. This doesn't get properly cleaned up when OpenSSL exits.
Therefore we are more selective about the symbols we include in legacy.so.

Fixes #13560

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
