### PR TITLE
Increase HKDF_MAXBUF from 1024 to 2048

### DIFF
--- a/providers/implementations/kdfs/hkdf.c
+++ b/providers/implementations/kdfs/hkdf.c
@@ -30,7 +30,7 @@
 #include "prov/provider_util.h"
 #include "e_os.h"
 
-#define HKDF_MAXBUF 1024
+#define HKDF_MAXBUF 2048
 
 static OSSL_FUNC_kdf_newctx_fn kdf_hkdf_new;
 static OSSL_FUNC_kdf_freectx_fn kdf_hkdf_free;


### PR DESCRIPTION
We've encountered some scenarios that need to use more than 1 kB of
data as the HKDF-Expand() "info" argument (which, per RFC 5869,
contains "optional context and application specific information").

Since HKDF_MAXBUF is used to size an array in the HKDF_PKEY_CTX
structure, this adds 1 kB of memory footprint to each EVP_PKEY_CTX
used for HKDF.