### PR TITLE
Add OSSL_ALGORITHM description field + API to use them

### DIFF
--- a/apps/ca.c
+++ b/apps/ca.c
@@ -821,7 +821,7 @@ end_of_options:
         }
         if (verbose)
             BIO_printf(bio_err, "message digest is %s\n",
-                       OBJ_nid2ln(EVP_MD_type(dgst)));
+                       EVP_MD_description(dgst));
         if (policy == NULL
             && (policy = lookup_conf(conf, section, ENV_POLICY)) == NULL)
             goto end;

--- a/apps/ca.c
+++ b/apps/ca.c
@@ -821,7 +821,7 @@ end_of_options:
         }
         if (verbose)
             BIO_printf(bio_err, "message digest is %s\n",
-                       EVP_MD_description(dgst));
+                       OBJ_nid2ln(EVP_MD_type(dgst)));
         if (policy == NULL
             && (policy = lookup_conf(conf, section, ENV_POLICY)) == NULL)
             goto end;

--- a/apps/enc.c
+++ b/apps/enc.c
@@ -360,8 +360,8 @@ int enc_main(int argc, char **argv)
                 char prompt[200];
 
                 BIO_snprintf(prompt, sizeof(prompt), "enter %s %s password:",
-                        OBJ_nid2ln(EVP_CIPHER_nid(cipher)),
-                        (enc) ? "encryption" : "decryption");
+                             EVP_CIPHER_description(cipher),
+                             (enc) ? "encryption" : "decryption");
                 strbuf[0] = '\0';
                 i = EVP_read_pw_string((char *)strbuf, SIZE, prompt, enc);
                 if (i == 0) {

--- a/apps/enc.c
+++ b/apps/enc.c
@@ -360,8 +360,8 @@ int enc_main(int argc, char **argv)
                 char prompt[200];
 
                 BIO_snprintf(prompt, sizeof(prompt), "enter %s %s password:",
-                             EVP_CIPHER_description(cipher),
-                             (enc) ? "encryption" : "decryption");
+                        OBJ_nid2ln(EVP_CIPHER_nid(cipher)),
+                        (enc) ? "encryption" : "decryption");
                 strbuf[0] = '\0';
                 i = EVP_read_pw_string((char *)strbuf, SIZE, prompt, enc);
                 if (i == 0) {

--- a/apps/list.c
+++ b/apps/list.c
@@ -96,15 +96,19 @@ static void list_ciphers(void)
             print_names(bio_out, names);
 
             BIO_printf(bio_out, " @ %s\n",
-                    OSSL_PROVIDER_name(EVP_CIPHER_provider(c)));
+                       OSSL_PROVIDER_name(EVP_CIPHER_provider(c)));
 
             if (verbose) {
+                const char *desc = EVP_CIPHER_description(c);
+
+                if (desc != NULL)
+                    BIO_printf(bio_out, "    description: %s\n", desc);
                 print_param_types("retrievable algorithm parameters",
-                                EVP_CIPHER_gettable_params(c), 4);
+                                  EVP_CIPHER_gettable_params(c), 4);
                 print_param_types("retrievable operation parameters",
-                                EVP_CIPHER_gettable_ctx_params(c), 4);
+                                  EVP_CIPHER_gettable_ctx_params(c), 4);
                 print_param_types("settable operation parameters",
-                                EVP_CIPHER_settable_ctx_params(c), 4);
+                                  EVP_CIPHER_settable_ctx_params(c), 4);
             }
         }
         sk_OPENSSL_CSTRING_free(names);
@@ -176,6 +180,10 @@ static void list_digests(void)
             BIO_printf(bio_out, " @ %s\n", OSSL_PROVIDER_name(EVP_MD_provider(m)));
 
             if (verbose) {
+                const char *desc = EVP_MD_description(m);
+
+                if (desc != NULL)
+                    BIO_printf(bio_out, "    description: %s\n", desc);
                 print_param_types("retrievable algorithm parameters",
                                 EVP_MD_gettable_params(m), 4);
                 print_param_types("retrievable operation parameters",
@@ -236,6 +244,10 @@ static void list_macs(void)
             BIO_printf(bio_out, " @ %s\n", OSSL_PROVIDER_name(EVP_MAC_provider(m)));
 
             if (verbose) {
+                const char *desc = EVP_MAC_description(m);
+
+                if (desc != NULL)
+                    BIO_printf(bio_out, "    description: %s\n", desc);
                 print_param_types("retrievable algorithm parameters",
                                 EVP_MAC_gettable_params(m), 4);
                 print_param_types("retrievable operation parameters",
@@ -299,6 +311,10 @@ static void list_kdfs(void)
             BIO_printf(bio_out, " @ %s\n", OSSL_PROVIDER_name(EVP_KDF_provider(k)));
 
             if (verbose) {
+                const char *desc = EVP_KDF_description(k);
+
+                if (desc != NULL)
+                    BIO_printf(bio_out, "    description: %s\n", desc);
                 print_param_types("retrievable algorithm parameters",
                                 EVP_KDF_gettable_params(k), 4);
                 print_param_types("retrievable operation parameters",
@@ -358,6 +374,10 @@ static void list_random_generators(void)
         BIO_printf(bio_out, " @ %s\n", OSSL_PROVIDER_name(EVP_RAND_provider(m)));
 
         if (verbose) {
+            const char *desc = EVP_RAND_description(m);
+
+            if (desc != NULL)
+                BIO_printf(bio_out, "    description: %s\n", desc);
             print_param_types("retrievable algorithm parameters",
                               EVP_RAND_gettable_params(m), 4);
             print_param_types("retrievable operation parameters",
@@ -491,6 +511,10 @@ static void list_encoders(void)
                     OSSL_ENCODER_properties(k));
 
             if (verbose) {
+                const char *desc = OSSL_ENCODER_description(k);
+
+                if (desc != NULL)
+                    BIO_printf(bio_out, "    description: %s\n", desc);
                 print_param_types("settable operation parameters",
                                 OSSL_ENCODER_settable_ctx_params(k), 4);
             }
@@ -555,6 +579,10 @@ static void list_decoders(void)
                     OSSL_DECODER_properties(k));
 
             if (verbose) {
+                const char *desc = OSSL_DECODER_description(k);
+
+                if (desc != NULL)
+                    BIO_printf(bio_out, "    description: %s\n", desc);
                 print_param_types("settable operation parameters",
                                 OSSL_DECODER_settable_ctx_params(k), 4);
             }
@@ -601,9 +629,17 @@ static void list_keymanagers(void)
 
         names = sk_OPENSSL_CSTRING_new(name_cmp);
         if (names != NULL && EVP_KEYMGMT_names_do_all(k, collect_names, names)) {
-            BIO_printf(bio_out, "  ");
-            print_names(bio_out, names);
+            const char *desc = EVP_KEYMGMT_description(k);
 
+            BIO_printf(bio_out, "  Name: ");
+            if (desc != NULL)
+                BIO_printf(bio_out, "%s", desc);
+            else
+                BIO_printf(bio_out, "%s", sk_OPENSSL_CSTRING_value(names, 0));
+            BIO_printf(bio_out, "\n");
+            BIO_printf(bio_out, "    Type: Provider Algorithm\n");
+            BIO_printf(bio_out, "    IDs: ");
+            print_names(bio_out, names);
             BIO_printf(bio_out, " @ %s\n",
                     OSSL_PROVIDER_name(EVP_KEYMGMT_provider(k)));
 
@@ -666,6 +702,10 @@ static void list_signatures(void)
                     OSSL_PROVIDER_name(EVP_SIGNATURE_provider(k)));
 
             if (verbose) {
+                const char *desc = EVP_SIGNATURE_description(k);
+
+                if (desc != NULL)
+                    BIO_printf(bio_out, "    description: %s\n", desc);
                 print_param_types("settable operation parameters",
                                 EVP_SIGNATURE_settable_ctx_params(k), 4);
                 print_param_types("retrievable operation parameters",
@@ -723,6 +763,10 @@ static void list_kems(void)
             BIO_printf(bio_out, " @ %s\n", OSSL_PROVIDER_name(EVP_KEM_provider(k)));
 
             if (verbose) {
+                const char *desc = EVP_KEM_description(k);
+
+                if (desc != NULL)
+                    BIO_printf(bio_out, "    description: %s\n", desc);
                 print_param_types("settable operation parameters",
                                 EVP_KEM_settable_ctx_params(k), 4);
                 print_param_types("retrievable operation parameters",
@@ -783,6 +827,10 @@ static void list_asymciphers(void)
                     OSSL_PROVIDER_name(EVP_ASYM_CIPHER_provider(k)));
 
             if (verbose) {
+                const char *desc = EVP_ASYM_CIPHER_description(k);
+
+                if (desc != NULL)
+                    BIO_printf(bio_out, "    description: %s\n", desc);
                 print_param_types("settable operation parameters",
                                 EVP_ASYM_CIPHER_settable_ctx_params(k), 4);
                 print_param_types("retrievable operation parameters",
@@ -841,6 +889,10 @@ static void list_keyexchanges(void)
                     OSSL_PROVIDER_name(EVP_KEYEXCH_provider(k)));
 
             if (verbose) {
+                const char *desc = EVP_KEYEXCH_description(k);
+
+                if (desc != NULL)
+                    BIO_printf(bio_out, "    description: %s\n", desc);
                 print_param_types("settable operation parameters",
                                 EVP_KEYEXCH_settable_ctx_params(k), 4);
                 print_param_types("retrievable operation parameters",

--- a/crypto/core_namemap.c
+++ b/crypto/core_namemap.c
@@ -467,41 +467,6 @@ static void get_legacy_md_names(const OBJ_NAME *on, void *arg)
     /* We know that the EVP_MD long names are used as descriptions */
     get_legacy_evp_names(nid, nid, OBJ_nid2ln(nid), arg);
 }
-
-static void get_legacy_pkey_meth_names(const EVP_PKEY_ASN1_METHOD *ameth,
-                                       void *arg)
-{
-    int nid = 0, base_nid = 0, flags = 0;
-    const char *pinfo = NULL;
-
-    EVP_PKEY_asn1_get0_info(&nid, &base_nid, &flags, &pinfo, NULL, ameth);
-    if (nid != NID_undef) {
-        if ((flags & ASN1_PKEY_ALIAS) == 0) {
-            get_legacy_evp_names(nid, nid, pinfo, arg);
-        } else {
-            /*
-             * Treat aliases carefully, some of them are undesirable, or
-             * should not be treated as such for providers.
-             */
-
-            switch (nid) {
-            case EVP_PKEY_SM2:
-            case EVP_PKEY_DHX:
-                /*
-                 * SM2 is a separate keytype with providers, not an alias for
-                 * EC.
-                 * DHX is a separate keytype with providers, not an alias for
-                 * DH.
-                 */
-                get_legacy_evp_names(nid, nid, OBJ_nid2ln(nid), arg);
-                break;
-            default:
-                /* Use the short name of the base nid as the common reference */
-                get_legacy_evp_names(base_nid, nid, NULL, arg);
-            }
-        }
-    }
-}
 #endif
 
 /*-
@@ -531,8 +496,6 @@ OSSL_NAMEMAP *ossl_namemap_stored(OSSL_LIB_CTX *libctx)
         return NULL;
     }
     if (nms == 1) {
-        int i, end;
-
         /* Before pilfering, we make sure the legacy database is populated */
         OPENSSL_init_crypto(OPENSSL_INIT_ADD_ALL_CIPHERS
                             | OPENSSL_INIT_ADD_ALL_DIGESTS, NULL);
@@ -541,10 +504,6 @@ OSSL_NAMEMAP *ossl_namemap_stored(OSSL_LIB_CTX *libctx)
                         get_legacy_cipher_names, namemap);
         OBJ_NAME_do_all(OBJ_NAME_TYPE_MD_METH,
                         get_legacy_md_names, namemap);
-
-        /* We also pilfer data from the legacy EVP_PKEY_ASN1_METHODs */
-        for (i = 0, end = EVP_PKEY_asn1_get_count(); i < end; i++)
-            get_legacy_pkey_meth_names(EVP_PKEY_asn1_get0(i), namemap);
     }
 #endif
 

--- a/crypto/core_namemap.c
+++ b/crypto/core_namemap.c
@@ -34,8 +34,7 @@ struct ossl_namemap_st {
     unsigned int stored:1; /* If 1, it's stored in a library context */
 
     CRYPTO_RWLOCK *lock;
-    LHASH_OF(NAMENUM_ENTRY) *namenum;    /* Name->number mapping */
-    STACK_OF(OPENSSL_STRING) *namedesc; /* Number->description mapping */
+    LHASH_OF(NAMENUM_ENTRY) *namenum;  /* Name->number mapping */
 
 #ifdef tsan_ld_acq
     TSAN_QUALIFIER int max_number;     /* Current max number TSAN version */
@@ -245,11 +244,6 @@ const char *ossl_namemap_num2name(const OSSL_NAMEMAP *namemap, int number,
     return data.name;
 }
 
-const char *ossl_namemap_num2desc(const OSSL_NAMEMAP *namemap, int number)
-{
-    return sk_OPENSSL_STRING_value(namemap->namedesc, number);
-}
-
 static int namemap_add_name_n(OSSL_NAMEMAP *namemap, int number,
                               const char *name, size_t name_len)
 {
@@ -274,32 +268,6 @@ static int namemap_add_name_n(OSSL_NAMEMAP *namemap, int number,
 
  err:
     namenum_free(namenum);
-    return 0;
-}
-
-static int namemap_add_desc(OSSL_NAMEMAP *namemap, int number, const char *desc)
-{
-    char *curdesc = NULL;
-    char *newdesc = NULL;
-    int n;
-
-    if (number == 0 || desc == NULL || desc[0] == '\0')
-        goto err;
-
-    if ((curdesc = sk_OPENSSL_STRING_value(namemap->namedesc, number)) != NULL
-        && strcasecmp(curdesc, desc) != 0)
-        goto err;
-    if ((newdesc = OPENSSL_strdup(desc)) == NULL)
-        goto err;
-    n = sk_OPENSSL_STRING_num(namemap->namedesc);
-    if (n <= number)
-        sk_OPENSSL_STRING_reserve(namemap->namedesc, number - n + 1);
-    sk_OPENSSL_STRING_set(namemap->namedesc, number, newdesc);
-    OPENSSL_free(curdesc);
-    return 1;
-
- err:
-    OPENSSL_free(newdesc);
     return 0;
 }
 
@@ -329,20 +297,6 @@ int ossl_namemap_add_name(OSSL_NAMEMAP *namemap, int number, const char *name)
         return 0;
 
     return ossl_namemap_add_name_n(namemap, number, name, strlen(name));
-}
-
-int ossl_namemap_add_desc(OSSL_NAMEMAP *namemap, int number, const char *desc)
-{
-    int ret;
-
-    if (namemap == NULL)
-        return 0;
-
-    if (!CRYPTO_THREAD_write_lock(namemap->lock))
-        return 0;
-    ret = namemap_add_desc(namemap, number, desc);
-    CRYPTO_THREAD_unlock(namemap->lock);
-    return ret;
 }
 
 int ossl_namemap_add_names(OSSL_NAMEMAP *namemap, int number,
@@ -424,48 +378,45 @@ int ossl_namemap_add_names(OSSL_NAMEMAP *namemap, int number,
 #include <openssl/evp.h>
 
 /* Creates an initial namemap with names found in the legacy method db */
-static void get_legacy_evp_names(int base_nid, int alias_nid,
-                                 const char *desc, void *arg)
+static void get_legacy_evp_names(const char *main_name, const char *alias,
+                                 void *arg)
 {
-    const char *base_sn = OBJ_nid2sn(base_nid);
-    const char *base_ln = OBJ_nid2ln(base_nid);
-    const char *alias_sn = OBJ_nid2sn(base_nid);
-    const char *alias_ln = OBJ_nid2ln(base_nid);
-    int num = 0;
+    int main_id = ossl_namemap_add_name(arg, 0, main_name);
 
-    if (base_nid == NID_undef)
-        return;
-
-    num = ossl_namemap_add_name(arg, 0, base_sn);
-    if (base_ln != NULL)
-        (void)ossl_namemap_add_name(arg, num, base_ln);
-
-    if (base_nid != alias_nid && alias_nid != NID_undef) {
-        (void)ossl_namemap_add_name(arg, num, alias_sn);
-        if (alias_ln != NULL)
-            (void)ossl_namemap_add_name(arg, num, alias_ln);
+    /*
+     * We could check that the returned value is the same as main_id,
+     * but since this is a void function, there's no sane way to report
+     * the error.  The best we can do is trust ourselve to keep the legacy
+     * method database conflict free.
+     *
+     * This registers any alias with the same number as the main name.
+     * Should it be that the current |on| *has* the main name, this is
+     * simply a no-op.
+     */
+    if (alias != NULL) {
+        (void)ossl_namemap_add_name(arg, main_id, alias);
     }
-
-    if (desc != NULL)
-        (void)ossl_namemap_add_desc(arg, num, desc);
 }
 
 static void get_legacy_cipher_names(const OBJ_NAME *on, void *arg)
 {
     const EVP_CIPHER *cipher = (void *)OBJ_NAME_get(on->name, on->type);
-    int nid = EVP_CIPHER_type(cipher);
 
-    /* We know that the EVP_CIPHER long names are used as descriptions */
-    get_legacy_evp_names(nid, nid, OBJ_nid2ln(nid), arg);
+    get_legacy_evp_names(EVP_CIPHER_name(cipher), on->name, arg);
 }
 
 static void get_legacy_md_names(const OBJ_NAME *on, void *arg)
 {
     const EVP_MD *md = (void *)OBJ_NAME_get(on->name, on->type);
-    int nid = EVP_MD_type(md);
+    /* We don't want the pkey_type names, so we need some extra care */
+    int snid, lnid;
 
-    /* We know that the EVP_MD long names are used as descriptions */
-    get_legacy_evp_names(nid, nid, OBJ_nid2ln(nid), arg);
+    snid = OBJ_sn2nid(on->name);
+    lnid = OBJ_ln2nid(on->name);
+    if (snid != EVP_MD_pkey_type(md) && lnid != EVP_MD_pkey_type(md))
+        get_legacy_evp_names(EVP_MD_name(md), on->name, arg);
+    else
+        get_legacy_evp_names(EVP_MD_name(md), NULL, arg);
 }
 #endif
 
@@ -517,8 +468,7 @@ OSSL_NAMEMAP *ossl_namemap_new(void)
     if ((namemap = OPENSSL_zalloc(sizeof(*namemap))) != NULL
         && (namemap->lock = CRYPTO_THREAD_lock_new()) != NULL
         && (namemap->namenum =
-            lh_NAMENUM_ENTRY_new(namenum_hash, namenum_cmp)) != NULL
-        && (namemap->namedesc = sk_OPENSSL_STRING_new_null()) != NULL)
+            lh_NAMENUM_ENTRY_new(namenum_hash, namenum_cmp)) != NULL)
         return namemap;
 
     ossl_namemap_free(namemap);
@@ -532,7 +482,6 @@ void ossl_namemap_free(OSSL_NAMEMAP *namemap)
 
     lh_NAMENUM_ENTRY_doall(namemap->namenum, namenum_free);
     lh_NAMENUM_ENTRY_free(namemap->namenum);
-    sk_OPENSSL_STRING_free(namemap->namedesc);
 
     CRYPTO_THREAD_lock_free(namemap->lock);
     OPENSSL_free(namemap);

--- a/crypto/encode_decode/decoder_meth.c
+++ b/crypto/encode_decode/decoder_meth.c
@@ -159,8 +159,8 @@ static int put_decoder_in_store(OSSL_LIB_CTX *libctx, void *store,
 }
 
 /* Create and populate a decoder method */
-void *ossl_decoder_from_dispatch(int id, const OSSL_ALGORITHM *algodef,
-                                 OSSL_PROVIDER *prov)
+void *ossl_decoder_from_algorithm(int id, const OSSL_ALGORITHM *algodef,
+                                  OSSL_PROVIDER *prov)
 {
     OSSL_DECODER *decoder = NULL;
     const OSSL_DISPATCH *fns = algodef->implementation;
@@ -242,7 +242,7 @@ void *ossl_decoder_from_dispatch(int id, const OSSL_ALGORITHM *algodef,
 /*
  * The core fetching functionality passes the names of the implementation.
  * This function is responsible to getting an identity number for them,
- * then call ossl_decoder_from_dispatch() with that identity number.
+ * then call ossl_decoder_from_algorithm() with that identity number.
  */
 static void *construct_decoder(const OSSL_ALGORITHM *algodef,
                                OSSL_PROVIDER *prov, void *data)
@@ -261,7 +261,7 @@ static void *construct_decoder(const OSSL_ALGORITHM *algodef,
     void *method = NULL;
 
     if (id != 0)
-        method = ossl_decoder_from_dispatch(id, algodef, prov);
+        method = ossl_decoder_from_algorithm(id, algodef, prov);
 
     /*
      * Flag to indicate that there was actual construction errors.  This
@@ -458,7 +458,7 @@ static void decoder_do_one(OSSL_PROVIDER *provider,
     void *method = NULL;
 
     if (id != 0)
-        method = ossl_decoder_from_dispatch(id, algodef, provider);
+        method = ossl_decoder_from_algorithm(id, algodef, provider);
 
     if (method != NULL) {
         data->user_fn(method, data->user_arg);

--- a/crypto/encode_decode/decoder_meth.c
+++ b/crypto/encode_decode/decoder_meth.c
@@ -259,8 +259,13 @@ static void *construct_decoder(const OSSL_ALGORITHM *algodef,
     int id = ossl_namemap_add_names(namemap, 0, names, NAME_SEPARATOR);
     void *method = NULL;
 
-    if (id != 0)
-        method = ossl_decoder_from_dispatch(id, algodef, prov);
+    if (id == 0)
+        return NULL;
+
+    if (algodef->algorithm_description != NULL)
+        (void)ossl_namemap_add_desc(namemap, id,
+                                    algodef->algorithm_description);
+    method = ossl_decoder_from_dispatch(id, algodef, prov);
 
     /*
      * Flag to indicate that there was actual construction errors.  This

--- a/crypto/encode_decode/decoder_meth.c
+++ b/crypto/encode_decode/decoder_meth.c
@@ -429,6 +429,17 @@ int OSSL_DECODER_number(const OSSL_DECODER *decoder)
     return decoder->base.id;
 }
 
+const char *OSSL_DECODER_description(const OSSL_DECODER *decoder)
+{
+    if (decoder->base.prov != NULL) {
+        OSSL_LIB_CTX *libctx = ossl_provider_libctx(decoder->base.prov);
+        OSSL_NAMEMAP *namemap = ossl_namemap_stored(libctx);
+
+        return ossl_namemap_num2desc(namemap, decoder->base.id);
+    }
+    return NULL;
+}
+
 int OSSL_DECODER_is_a(const OSSL_DECODER *decoder, const char *name)
 {
     if (decoder->base.prov != NULL) {

--- a/crypto/encode_decode/decoder_meth.c
+++ b/crypto/encode_decode/decoder_meth.c
@@ -427,13 +427,7 @@ int OSSL_DECODER_number(const OSSL_DECODER *decoder)
 
 const char *OSSL_DECODER_description(const OSSL_DECODER *decoder)
 {
-    if (decoder->base.prov != NULL) {
-        OSSL_LIB_CTX *libctx = ossl_provider_libctx(decoder->base.prov);
-        OSSL_NAMEMAP *namemap = ossl_namemap_stored(libctx);
-
-        return ossl_namemap_num2desc(namemap, decoder->base.id);
-    }
-    return NULL;
+    return decoder->base.description;
 }
 
 int OSSL_DECODER_is_a(const OSSL_DECODER *decoder, const char *name)

--- a/crypto/encode_decode/decoder_meth.c
+++ b/crypto/encode_decode/decoder_meth.c
@@ -169,6 +169,7 @@ void *ossl_decoder_from_dispatch(int id, const OSSL_ALGORITHM *algodef,
         return NULL;
     decoder->base.id = id;
     decoder->base.propdef = algodef->property_definition;
+    decoder->base.description = algodef->algorithm_description;
 
     for (; fns->function_id != 0; fns++) {
         switch (fns->function_id) {
@@ -259,13 +260,8 @@ static void *construct_decoder(const OSSL_ALGORITHM *algodef,
     int id = ossl_namemap_add_names(namemap, 0, names, NAME_SEPARATOR);
     void *method = NULL;
 
-    if (id == 0)
-        return NULL;
-
-    if (algodef->algorithm_description != NULL)
-        (void)ossl_namemap_add_desc(namemap, id,
-                                    algodef->algorithm_description);
-    method = ossl_decoder_from_dispatch(id, algodef, prov);
+    if (id != 0)
+        method = ossl_decoder_from_dispatch(id, algodef, prov);
 
     /*
      * Flag to indicate that there was actual construction errors.  This

--- a/crypto/encode_decode/encoder_local.h
+++ b/crypto/encode_decode/encoder_local.h
@@ -20,6 +20,7 @@ struct ossl_endecode_base_st {
     OSSL_PROVIDER *prov;
     int id;
     const char *propdef;
+    const char *description;
 
     CRYPTO_REF_COUNT refcnt;
     CRYPTO_RWLOCK *lock;

--- a/crypto/encode_decode/encoder_meth.c
+++ b/crypto/encode_decode/encoder_meth.c
@@ -441,6 +441,17 @@ int OSSL_ENCODER_number(const OSSL_ENCODER *encoder)
     return encoder->base.id;
 }
 
+const char *OSSL_ENCODER_description(const OSSL_ENCODER *encoder)
+{
+    if (encoder->base.prov != NULL) {
+        OSSL_LIB_CTX *libctx = ossl_provider_libctx(encoder->base.prov);
+        OSSL_NAMEMAP *namemap = ossl_namemap_stored(libctx);
+
+        return ossl_namemap_num2desc(namemap, encoder->base.id);
+    }
+    return NULL;
+}
+
 int OSSL_ENCODER_is_a(const OSSL_ENCODER *encoder, const char *name)
 {
     if (encoder->base.prov != NULL) {

--- a/crypto/encode_decode/encoder_meth.c
+++ b/crypto/encode_decode/encoder_meth.c
@@ -169,6 +169,7 @@ static void *encoder_from_dispatch(int id, const OSSL_ALGORITHM *algodef,
         return NULL;
     encoder->base.id = id;
     encoder->base.propdef = algodef->property_definition;
+    encoder->base.description = algodef->algorithm_description;
 
     for (; fns->function_id != 0; fns++) {
         switch (fns->function_id) {
@@ -271,13 +272,8 @@ static void *construct_encoder(const OSSL_ALGORITHM *algodef,
     int id = ossl_namemap_add_names(namemap, 0, names, NAME_SEPARATOR);
     void *method = NULL;
 
-    if (id == 0)
-        return NULL;
-
-    if (algodef->algorithm_description != NULL)
-        (void)ossl_namemap_add_desc(namemap, id,
-                                    algodef->algorithm_description);
-    method = encoder_from_dispatch(id, algodef, prov);
+    if (id != 0)
+        method = encoder_from_dispatch(id, algodef, prov);
 
     /*
      * Flag to indicate that there was actual construction errors.  This

--- a/crypto/encode_decode/encoder_meth.c
+++ b/crypto/encode_decode/encoder_meth.c
@@ -159,8 +159,8 @@ static int put_encoder_in_store(OSSL_LIB_CTX *libctx, void *store,
 }
 
 /* Create and populate a encoder method */
-static void *encoder_from_dispatch(int id, const OSSL_ALGORITHM *algodef,
-                                   OSSL_PROVIDER *prov)
+static void *encoder_from_algorithm(int id, const OSSL_ALGORITHM *algodef,
+                                    OSSL_PROVIDER *prov)
 {
     OSSL_ENCODER *encoder = NULL;
     const OSSL_DISPATCH *fns = algodef->implementation;
@@ -254,7 +254,7 @@ static void *encoder_from_dispatch(int id, const OSSL_ALGORITHM *algodef,
 /*
  * The core fetching functionality passes the names of the implementation.
  * This function is responsible to getting an identity number for them,
- * then call encoder_from_dispatch() with that identity number.
+ * then call encoder_from_algorithm() with that identity number.
  */
 static void *construct_encoder(const OSSL_ALGORITHM *algodef,
                                OSSL_PROVIDER *prov, void *data)
@@ -273,7 +273,7 @@ static void *construct_encoder(const OSSL_ALGORITHM *algodef,
     void *method = NULL;
 
     if (id != 0)
-        method = encoder_from_dispatch(id, algodef, prov);
+        method = encoder_from_algorithm(id, algodef, prov);
 
     /*
      * Flag to indicate that there was actual construction errors.  This
@@ -471,7 +471,7 @@ static void encoder_do_one(OSSL_PROVIDER *provider,
 
     if (id != 0)
         method =
-            encoder_from_dispatch(id, algodef, provider);
+            encoder_from_algorithm(id, algodef, provider);
 
     if (method != NULL) {
         data->user_fn(method, data->user_arg);

--- a/crypto/encode_decode/encoder_meth.c
+++ b/crypto/encode_decode/encoder_meth.c
@@ -271,8 +271,13 @@ static void *construct_encoder(const OSSL_ALGORITHM *algodef,
     int id = ossl_namemap_add_names(namemap, 0, names, NAME_SEPARATOR);
     void *method = NULL;
 
-    if (id != 0)
-        method = encoder_from_dispatch(id, algodef, prov);
+    if (id == 0)
+        return NULL;
+
+    if (algodef->algorithm_description != NULL)
+        (void)ossl_namemap_add_desc(namemap, id,
+                                    algodef->algorithm_description);
+    method = encoder_from_dispatch(id, algodef, prov);
 
     /*
      * Flag to indicate that there was actual construction errors.  This

--- a/crypto/encode_decode/encoder_meth.c
+++ b/crypto/encode_decode/encoder_meth.c
@@ -439,13 +439,7 @@ int OSSL_ENCODER_number(const OSSL_ENCODER *encoder)
 
 const char *OSSL_ENCODER_description(const OSSL_ENCODER *encoder)
 {
-    if (encoder->base.prov != NULL) {
-        OSSL_LIB_CTX *libctx = ossl_provider_libctx(encoder->base.prov);
-        OSSL_NAMEMAP *namemap = ossl_namemap_stored(libctx);
-
-        return ossl_namemap_num2desc(namemap, encoder->base.id);
-    }
-    return NULL;
+    return encoder->base.description;
 }
 
 int OSSL_ENCODER_is_a(const OSSL_ENCODER *encoder, const char *name)

--- a/crypto/evp/asymcipher.c
+++ b/crypto/evp/asymcipher.c
@@ -275,9 +275,10 @@ static EVP_ASYM_CIPHER *evp_asym_cipher_new(OSSL_PROVIDER *prov)
 }
 
 static void *evp_asym_cipher_from_dispatch(int name_id,
-                                           const OSSL_DISPATCH *fns,
+                                           const OSSL_ALGORITHM *algodef,
                                            OSSL_PROVIDER *prov)
 {
+    const OSSL_DISPATCH *fns = algodef->implementation;
     EVP_ASYM_CIPHER *cipher = NULL;
     int ctxfncnt = 0, encfncnt = 0, decfncnt = 0;
     int gparamfncnt = 0, sparamfncnt = 0;
@@ -288,6 +289,7 @@ static void *evp_asym_cipher_from_dispatch(int name_id,
     }
 
     cipher->name_id = name_id;
+    cipher->description = algodef->algorithm_description;
 
     for (; fns->function_id != 0; fns++) {
         switch (fns->function_id) {

--- a/crypto/evp/asymcipher.c
+++ b/crypto/evp/asymcipher.c
@@ -437,9 +437,7 @@ int EVP_ASYM_CIPHER_number(const EVP_ASYM_CIPHER *cipher)
 
 const char *EVP_ASYM_CIPHER_description(const EVP_ASYM_CIPHER *cipher)
 {
-    if (cipher->prov != NULL)
-        return evp_description(cipher->prov, cipher->name_id);
-    return NULL;
+    return cipher->description;
 }
 
 void EVP_ASYM_CIPHER_do_all_provided(OSSL_LIB_CTX *libctx,

--- a/crypto/evp/asymcipher.c
+++ b/crypto/evp/asymcipher.c
@@ -274,9 +274,9 @@ static EVP_ASYM_CIPHER *evp_asym_cipher_new(OSSL_PROVIDER *prov)
     return cipher;
 }
 
-static void *evp_asym_cipher_from_dispatch(int name_id,
-                                           const OSSL_ALGORITHM *algodef,
-                                           OSSL_PROVIDER *prov)
+static void *evp_asym_cipher_from_algorithm(int name_id,
+                                            const OSSL_ALGORITHM *algodef,
+                                            OSSL_PROVIDER *prov)
 {
     const OSSL_DISPATCH *fns = algodef->implementation;
     EVP_ASYM_CIPHER *cipher = NULL;
@@ -420,7 +420,7 @@ EVP_ASYM_CIPHER *EVP_ASYM_CIPHER_fetch(OSSL_LIB_CTX *ctx, const char *algorithm,
                                        const char *properties)
 {
     return evp_generic_fetch(ctx, OSSL_OP_ASYM_CIPHER, algorithm, properties,
-                             evp_asym_cipher_from_dispatch,
+                             evp_asym_cipher_from_algorithm,
                              (int (*)(void *))EVP_ASYM_CIPHER_up_ref,
                              (void (*)(void *))EVP_ASYM_CIPHER_free);
 }
@@ -447,7 +447,7 @@ void EVP_ASYM_CIPHER_do_all_provided(OSSL_LIB_CTX *libctx,
 {
     evp_generic_do_all(libctx, OSSL_OP_ASYM_CIPHER,
                        (void (*)(void *, void *))fn, arg,
-                       evp_asym_cipher_from_dispatch,
+                       evp_asym_cipher_from_algorithm,
                        (void (*)(void *))EVP_ASYM_CIPHER_free);
 }
 

--- a/crypto/evp/asymcipher.c
+++ b/crypto/evp/asymcipher.c
@@ -433,6 +433,13 @@ int EVP_ASYM_CIPHER_number(const EVP_ASYM_CIPHER *cipher)
     return cipher->name_id;
 }
 
+const char *EVP_ASYM_CIPHER_description(const EVP_ASYM_CIPHER *cipher)
+{
+    if (cipher->prov != NULL)
+        return evp_description(cipher->prov, cipher->name_id);
+    return NULL;
+}
+
 void EVP_ASYM_CIPHER_do_all_provided(OSSL_LIB_CTX *libctx,
                                      void (*fn)(EVP_ASYM_CIPHER *cipher,
                                                 void *arg),

--- a/crypto/evp/digest.c
+++ b/crypto/evp/digest.c
@@ -884,9 +884,10 @@ static int evp_md_cache_constants(EVP_MD *md)
 }
 
 static void *evp_md_from_dispatch(int name_id,
-                                  const OSSL_DISPATCH *fns,
+                                  const OSSL_ALGORITHM *algodef,
                                   OSSL_PROVIDER *prov)
 {
+    const OSSL_DISPATCH *fns = algodef->implementation;
     EVP_MD *md = NULL;
     int fncnt = 0;
 
@@ -907,6 +908,7 @@ static void *evp_md_from_dispatch(int name_id,
 #endif
 
     md->name_id = name_id;
+    md->description = algodef->algorithm_description;
 
     for (; fns->function_id != 0; fns++) {
         switch (fns->function_id) {

--- a/crypto/evp/digest.c
+++ b/crypto/evp/digest.c
@@ -883,9 +883,9 @@ static int evp_md_cache_constants(EVP_MD *md)
     return ok;
 }
 
-static void *evp_md_from_dispatch(int name_id,
-                                  const OSSL_ALGORITHM *algodef,
-                                  OSSL_PROVIDER *prov)
+static void *evp_md_from_algorithm(int name_id,
+                                   const OSSL_ALGORITHM *algodef,
+                                   OSSL_PROVIDER *prov)
 {
     const OSSL_DISPATCH *fns = algodef->implementation;
     EVP_MD *md = NULL;
@@ -1019,7 +1019,7 @@ EVP_MD *EVP_MD_fetch(OSSL_LIB_CTX *ctx, const char *algorithm,
 {
     EVP_MD *md =
         evp_generic_fetch(ctx, OSSL_OP_DIGEST, algorithm, properties,
-                          evp_md_from_dispatch, evp_md_up_ref, evp_md_free);
+                          evp_md_from_algorithm, evp_md_up_ref, evp_md_free);
 
     return md;
 }
@@ -1053,5 +1053,5 @@ void EVP_MD_do_all_provided(OSSL_LIB_CTX *libctx,
 {
     evp_generic_do_all(libctx, OSSL_OP_DIGEST,
                        (void (*)(void *, void *))fn, arg,
-                       evp_md_from_dispatch, evp_md_free);
+                       evp_md_from_algorithm, evp_md_free);
 }

--- a/crypto/evp/evp_enc.c
+++ b/crypto/evp/evp_enc.c
@@ -1441,9 +1441,10 @@ static void set_legacy_nid(const char *name, void *vlegacy_nid)
 #endif
 
 static void *evp_cipher_from_dispatch(const int name_id,
-                                      const OSSL_DISPATCH *fns,
+                                      const OSSL_ALGORITHM *algodef,
                                       OSSL_PROVIDER *prov)
 {
+    const OSSL_DISPATCH *fns = algodef->implementation;
     EVP_CIPHER *cipher = NULL;
     int fnciphcnt = 0, fnctxcnt = 0;
 
@@ -1464,6 +1465,7 @@ static void *evp_cipher_from_dispatch(const int name_id,
 #endif
 
     cipher->name_id = name_id;
+    cipher->description = algodef->algorithm_description;
 
     for (; fns->function_id != 0; fns++) {
         switch (fns->function_id) {

--- a/crypto/evp/evp_enc.c
+++ b/crypto/evp/evp_enc.c
@@ -1440,9 +1440,9 @@ static void set_legacy_nid(const char *name, void *vlegacy_nid)
 }
 #endif
 
-static void *evp_cipher_from_dispatch(const int name_id,
-                                      const OSSL_ALGORITHM *algodef,
-                                      OSSL_PROVIDER *prov)
+static void *evp_cipher_from_algorithm(const int name_id,
+                                       const OSSL_ALGORITHM *algodef,
+                                       OSSL_PROVIDER *prov)
 {
     const OSSL_DISPATCH *fns = algodef->implementation;
     EVP_CIPHER *cipher = NULL;
@@ -1590,7 +1590,7 @@ EVP_CIPHER *EVP_CIPHER_fetch(OSSL_LIB_CTX *ctx, const char *algorithm,
 {
     EVP_CIPHER *cipher =
         evp_generic_fetch(ctx, OSSL_OP_CIPHER, algorithm, properties,
-                          evp_cipher_from_dispatch, evp_cipher_up_ref,
+                          evp_cipher_from_algorithm, evp_cipher_up_ref,
                           evp_cipher_free);
 
     return cipher;
@@ -1625,5 +1625,5 @@ void EVP_CIPHER_do_all_provided(OSSL_LIB_CTX *libctx,
 {
     evp_generic_do_all(libctx, OSSL_OP_CIPHER,
                        (void (*)(void *, void *))fn, arg,
-                       evp_cipher_from_dispatch, evp_cipher_free);
+                       evp_cipher_from_algorithm, evp_cipher_free);
 }

--- a/crypto/evp/evp_fetch.c
+++ b/crypto/evp/evp_fetch.c
@@ -519,6 +519,14 @@ const char *evp_first_name(const OSSL_PROVIDER *prov, int name_id)
     return ossl_namemap_num2name(namemap, name_id, 0);
 }
 
+const char *evp_description(const OSSL_PROVIDER *prov, int name_id)
+{
+    OSSL_LIB_CTX *libctx = ossl_provider_libctx(prov);
+    OSSL_NAMEMAP *namemap = ossl_namemap_stored(libctx);
+
+    return ossl_namemap_num2desc(namemap, name_id);
+}
+
 int evp_is_a(OSSL_PROVIDER *prov, int number,
              const char *legacy_name, const char *name)
 {

--- a/crypto/evp/evp_fetch.c
+++ b/crypto/evp/evp_fetch.c
@@ -194,6 +194,9 @@ static void *construct_evp_method(const OSSL_ALGORITHM *algodef,
     if (name_id == 0)
         return NULL;
 
+    if (algodef->algorithm_description != NULL)
+        (void)ossl_namemap_add_desc(namemap, name_id,
+                                    algodef->algorithm_description);
     method = methdata->method_from_dispatch(name_id, algodef->implementation,
                                             prov);
 

--- a/crypto/evp/evp_fetch.c
+++ b/crypto/evp/evp_fetch.c
@@ -515,14 +515,6 @@ const char *evp_first_name(const OSSL_PROVIDER *prov, int name_id)
     return ossl_namemap_num2name(namemap, name_id, 0);
 }
 
-const char *evp_description(const OSSL_PROVIDER *prov, int name_id)
-{
-    OSSL_LIB_CTX *libctx = ossl_provider_libctx(prov);
-    OSSL_NAMEMAP *namemap = ossl_namemap_stored(libctx);
-
-    return ossl_namemap_num2desc(namemap, name_id);
-}
-
 int evp_is_a(OSSL_PROVIDER *prov, int number,
              const char *legacy_name, const char *name)
 {

--- a/crypto/evp/evp_fetch.c
+++ b/crypto/evp/evp_fetch.c
@@ -50,8 +50,8 @@ struct evp_method_data_st {
 
     unsigned int flag_construct_error_occurred : 1;
 
-    void *(*method_from_dispatch)(int name_id, const OSSL_ALGORITHM *,
-                                  OSSL_PROVIDER *);
+    void *(*method_from_algorithm)(int name_id, const OSSL_ALGORITHM *,
+                                   OSSL_PROVIDER *);
     int (*refcnt_up_method)(void *method);
     void (*destruct_method)(void *method);
 };
@@ -194,7 +194,7 @@ static void *construct_evp_method(const OSSL_ALGORITHM *algodef,
     if (name_id == 0)
         return NULL;
 
-    method = methdata->method_from_dispatch(name_id, algodef, prov);
+    method = methdata->method_from_algorithm(name_id, algodef, prov);
 
     /*
      * Flag to indicate that there was actual construction errors.  This
@@ -295,7 +295,7 @@ inner_evp_generic_fetch(OSSL_LIB_CTX *libctx, int operation_id,
         mcmdata.name_id = name_id;
         mcmdata.names = name;
         mcmdata.propquery = properties;
-        mcmdata.method_from_dispatch = new_method;
+        mcmdata.method_from_algorithm = new_method;
         mcmdata.refcnt_up_method = up_ref_method;
         mcmdata.destruct_method = free_method;
         mcmdata.flag_construct_error_occurred = 0;

--- a/crypto/evp/evp_lib.c
+++ b/crypto/evp/evp_lib.c
@@ -647,8 +647,8 @@ const char *EVP_CIPHER_name(const EVP_CIPHER *cipher)
 
 const char *EVP_CIPHER_description(const EVP_CIPHER *cipher)
 {
-    if (cipher->prov != NULL)
-        return evp_description(cipher->prov, cipher->name_id);
+    if (cipher->description != NULL)
+        return cipher->description;
 #ifndef FIPS_MODULE
     return OBJ_nid2ln(EVP_CIPHER_nid(cipher));
 #else
@@ -690,8 +690,8 @@ int EVP_MD_number(const EVP_MD *md)
 
 const char *EVP_MD_description(const EVP_MD *md)
 {
-    if (md->prov != NULL)
-        return evp_description(md->prov, md->name_id);
+    if (md->description != NULL)
+        return md->description;
 #ifndef FIPS_MODULE
     return OBJ_nid2ln(EVP_MD_nid(md));
 #else

--- a/crypto/evp/evp_lib.c
+++ b/crypto/evp/evp_lib.c
@@ -645,6 +645,17 @@ const char *EVP_CIPHER_name(const EVP_CIPHER *cipher)
 #endif
 }
 
+const char *EVP_CIPHER_description(const EVP_CIPHER *cipher)
+{
+    if (cipher->prov != NULL)
+        return evp_description(cipher->prov, cipher->name_id);
+#ifndef FIPS_MODULE
+    return OBJ_nid2ln(EVP_CIPHER_nid(cipher));
+#else
+    return NULL;
+#endif
+}
+
 int EVP_CIPHER_names_do_all(const EVP_CIPHER *cipher,
                             void (*fn)(const char *name, void *data),
                             void *data)
@@ -675,6 +686,17 @@ int EVP_MD_is_a(const EVP_MD *md, const char *name)
 int EVP_MD_number(const EVP_MD *md)
 {
     return md->name_id;
+}
+
+const char *EVP_MD_description(const EVP_MD *md)
+{
+    if (md->prov != NULL)
+        return evp_description(md->prov, md->name_id);
+#ifndef FIPS_MODULE
+    return OBJ_nid2ln(EVP_MD_nid(md));
+#else
+    return NULL;
+#endif
 }
 
 const char *EVP_MD_name(const EVP_MD *md)

--- a/crypto/evp/evp_local.h
+++ b/crypto/evp/evp_local.h
@@ -315,6 +315,7 @@ void evp_pkey_ctx_free_old_ops(EVP_PKEY_CTX *ctx);
 
 /* OSSL_PROVIDER * is only used to get the library context */
 const char *evp_first_name(const OSSL_PROVIDER *prov, int name_id);
+const char *evp_description(const OSSL_PROVIDER *prov, int name_id);
 int evp_is_a(OSSL_PROVIDER *prov, int number,
              const char *legacy_name, const char *name);
 int evp_names_do_all(OSSL_PROVIDER *prov, int number,

--- a/crypto/evp/evp_local.h
+++ b/crypto/evp/evp_local.h
@@ -320,7 +320,6 @@ void evp_pkey_ctx_free_old_ops(EVP_PKEY_CTX *ctx);
 
 /* OSSL_PROVIDER * is only used to get the library context */
 const char *evp_first_name(const OSSL_PROVIDER *prov, int name_id);
-const char *evp_description(const OSSL_PROVIDER *prov, int name_id);
 int evp_is_a(OSSL_PROVIDER *prov, int number,
              const char *legacy_name, const char *name);
 int evp_names_do_all(OSSL_PROVIDER *prov, int number,

--- a/crypto/evp/evp_local.h
+++ b/crypto/evp/evp_local.h
@@ -78,6 +78,7 @@ struct evp_keymgmt_st {
     int id;                      /* libcrypto internal */
 
     int name_id;
+    const char *description;
     OSSL_PROVIDER *prov;
     CRYPTO_REF_COUNT refcnt;
     CRYPTO_RWLOCK *lock;
@@ -116,6 +117,7 @@ struct evp_keymgmt_st {
 
 struct evp_keyexch_st {
     int name_id;
+    const char *description;
     OSSL_PROVIDER *prov;
     CRYPTO_REF_COUNT refcnt;
     CRYPTO_RWLOCK *lock;
@@ -134,6 +136,7 @@ struct evp_keyexch_st {
 
 struct evp_signature_st {
     int name_id;
+    const char *description;
     OSSL_PROVIDER *prov;
     CRYPTO_REF_COUNT refcnt;
     CRYPTO_RWLOCK *lock;
@@ -167,6 +170,7 @@ struct evp_signature_st {
 
 struct evp_asym_cipher_st {
     int name_id;
+    const char *description;
     OSSL_PROVIDER *prov;
     CRYPTO_REF_COUNT refcnt;
     CRYPTO_RWLOCK *lock;
@@ -186,6 +190,7 @@ struct evp_asym_cipher_st {
 
 struct evp_kem_st {
     int name_id;
+    const char *description;
     OSSL_PROVIDER *prov;
     CRYPTO_REF_COUNT refcnt;
     CRYPTO_RWLOCK *lock;
@@ -235,14 +240,14 @@ int ossl_is_partially_overlapping(const void *ptr1, const void *ptr2, int len);
 void *evp_generic_fetch(OSSL_LIB_CTX *ctx, int operation_id,
                         const char *name, const char *properties,
                         void *(*new_method)(int name_id,
-                                            const OSSL_DISPATCH *fns,
+                                            const OSSL_ALGORITHM *algodef,
                                             OSSL_PROVIDER *prov),
                         int (*up_ref_method)(void *),
                         void (*free_method)(void *));
 void *evp_generic_fetch_by_number(OSSL_LIB_CTX *ctx, int operation_id,
                                   int name_id, const char *properties,
                                   void *(*new_method)(int name_id,
-                                                      const OSSL_DISPATCH *fns,
+                                                      const OSSL_ALGORITHM *algodef,
                                                       OSSL_PROVIDER *prov),
                                   int (*up_ref_method)(void *),
                                   void (*free_method)(void *));
@@ -250,7 +255,7 @@ void evp_generic_do_all(OSSL_LIB_CTX *libctx, int operation_id,
                         void (*user_fn)(void *method, void *arg),
                         void *user_arg,
                         void *(*new_method)(int name_id,
-                                            const OSSL_DISPATCH *fns,
+                                            const OSSL_ALGORITHM *algodef,
                                             OSSL_PROVIDER *prov),
                         void (*free_method)(void *));
 

--- a/crypto/evp/evp_rand.c
+++ b/crypto/evp/evp_rand.c
@@ -297,9 +297,7 @@ const char *EVP_RAND_name(const EVP_RAND *rand)
 
 const char *EVP_RAND_description(const EVP_RAND *rand)
 {
-    if (rand->prov != NULL)
-        return evp_description(rand->prov, rand->name_id);
-    return NULL;
+    return rand->description;
 }
 
 int EVP_RAND_is_a(const EVP_RAND *rand, const char *name)

--- a/crypto/evp/evp_rand.c
+++ b/crypto/evp/evp_rand.c
@@ -28,6 +28,7 @@
 struct evp_rand_st {
     OSSL_PROVIDER *prov;
     int name_id;
+    const char *description;
     CRYPTO_REF_COUNT refcnt;
     CRYPTO_RWLOCK *refcnt_lock;
 
@@ -113,9 +114,10 @@ static void evp_rand_unlock(EVP_RAND_CTX *rand)
 }
 
 static void *evp_rand_from_dispatch(int name_id,
-                                    const OSSL_DISPATCH *fns,
+                                    const OSSL_ALGORITHM *algodef,
                                     OSSL_PROVIDER *prov)
 {
+    const OSSL_DISPATCH *fns = algodef->implementation;
     EVP_RAND *rand = NULL;
     int fnrandcnt = 0, fnctxcnt = 0, fnlockcnt = 0, fnenablelockcnt = 0;
 #ifdef FIPS_MODULE
@@ -127,6 +129,7 @@ static void *evp_rand_from_dispatch(int name_id,
         return NULL;
     }
     rand->name_id = name_id;
+    rand->description = algodef->algorithm_description;
     rand->dispatch = fns;
     for (; fns->function_id != 0; fns++) {
         switch (fns->function_id) {

--- a/crypto/evp/evp_rand.c
+++ b/crypto/evp/evp_rand.c
@@ -113,9 +113,9 @@ static void evp_rand_unlock(EVP_RAND_CTX *rand)
         rand->meth->unlock(rand->data);
 }
 
-static void *evp_rand_from_dispatch(int name_id,
-                                    const OSSL_ALGORITHM *algodef,
-                                    OSSL_PROVIDER *prov)
+static void *evp_rand_from_algorithm(int name_id,
+                                     const OSSL_ALGORITHM *algodef,
+                                     OSSL_PROVIDER *prov)
 {
     const OSSL_DISPATCH *fns = algodef->implementation;
     EVP_RAND *rand = NULL;
@@ -271,7 +271,7 @@ EVP_RAND *EVP_RAND_fetch(OSSL_LIB_CTX *libctx, const char *algorithm,
                          const char *properties)
 {
     return evp_generic_fetch(libctx, OSSL_OP_RAND, algorithm, properties,
-                             evp_rand_from_dispatch, evp_rand_up_ref,
+                             evp_rand_from_algorithm, evp_rand_up_ref,
                              evp_rand_free);
 }
 
@@ -480,7 +480,7 @@ void EVP_RAND_do_all_provided(OSSL_LIB_CTX *libctx,
 {
     evp_generic_do_all(libctx, OSSL_OP_RAND,
                        (void (*)(void *, void *))fn, arg,
-                       evp_rand_from_dispatch, evp_rand_free);
+                       evp_rand_from_algorithm, evp_rand_free);
 }
 
 int EVP_RAND_names_do_all(const EVP_RAND *rand,

--- a/crypto/evp/evp_rand.c
+++ b/crypto/evp/evp_rand.c
@@ -292,6 +292,13 @@ const char *EVP_RAND_name(const EVP_RAND *rand)
     return evp_first_name(rand->prov, rand->name_id);
 }
 
+const char *EVP_RAND_description(const EVP_RAND *rand)
+{
+    if (rand->prov != NULL)
+        return evp_description(rand->prov, rand->name_id);
+    return NULL;
+}
+
 int EVP_RAND_is_a(const EVP_RAND *rand, const char *name)
 {
     return evp_is_a(rand->prov, rand->name_id, NULL, name);

--- a/crypto/evp/exchange.c
+++ b/crypto/evp/exchange.c
@@ -38,9 +38,9 @@ static EVP_KEYEXCH *evp_keyexch_new(OSSL_PROVIDER *prov)
     return exchange;
 }
 
-static void *evp_keyexch_from_dispatch(int name_id,
-                                       const OSSL_ALGORITHM *algodef,
-                                       OSSL_PROVIDER *prov)
+static void *evp_keyexch_from_algorithm(int name_id,
+                                        const OSSL_ALGORITHM *algodef,
+                                        OSSL_PROVIDER *prov)
 {
     const OSSL_DISPATCH *fns = algodef->implementation;
     EVP_KEYEXCH *exchange = NULL;
@@ -171,7 +171,7 @@ EVP_KEYEXCH *EVP_KEYEXCH_fetch(OSSL_LIB_CTX *ctx, const char *algorithm,
                                const char *properties)
 {
     return evp_generic_fetch(ctx, OSSL_OP_KEYEXCH, algorithm, properties,
-                             evp_keyexch_from_dispatch,
+                             evp_keyexch_from_algorithm,
                              (int (*)(void *))EVP_KEYEXCH_up_ref,
                              (void (*)(void *))EVP_KEYEXCH_free);
 }
@@ -464,7 +464,7 @@ void EVP_KEYEXCH_do_all_provided(OSSL_LIB_CTX *libctx,
 {
     evp_generic_do_all(libctx, OSSL_OP_KEYEXCH,
                        (void (*)(void *, void *))fn, arg,
-                       evp_keyexch_from_dispatch,
+                       evp_keyexch_from_algorithm,
                        (void (*)(void *))EVP_KEYEXCH_free);
 }
 

--- a/crypto/evp/exchange.c
+++ b/crypto/evp/exchange.c
@@ -446,6 +446,13 @@ int EVP_KEYEXCH_number(const EVP_KEYEXCH *keyexch)
     return keyexch->name_id;
 }
 
+const char *EVP_KEYEXCH_description(const EVP_KEYEXCH *keyexch)
+{
+    if (keyexch->prov != NULL)
+        return evp_description(keyexch->prov, keyexch->name_id);
+    return NULL;
+}
+
 int EVP_KEYEXCH_is_a(const EVP_KEYEXCH *keyexch, const char *name)
 {
     return evp_is_a(keyexch->prov, keyexch->name_id, NULL, name);

--- a/crypto/evp/exchange.c
+++ b/crypto/evp/exchange.c
@@ -39,9 +39,10 @@ static EVP_KEYEXCH *evp_keyexch_new(OSSL_PROVIDER *prov)
 }
 
 static void *evp_keyexch_from_dispatch(int name_id,
-                                       const OSSL_DISPATCH *fns,
+                                       const OSSL_ALGORITHM *algodef,
                                        OSSL_PROVIDER *prov)
 {
+    const OSSL_DISPATCH *fns = algodef->implementation;
     EVP_KEYEXCH *exchange = NULL;
     int fncnt = 0, sparamfncnt = 0, gparamfncnt = 0;
 
@@ -51,6 +52,7 @@ static void *evp_keyexch_from_dispatch(int name_id,
     }
 
     exchange->name_id = name_id;
+    exchange->description = algodef->algorithm_description;
 
     for (; fns->function_id != 0; fns++) {
         switch (fns->function_id) {

--- a/crypto/evp/exchange.c
+++ b/crypto/evp/exchange.c
@@ -450,9 +450,7 @@ int EVP_KEYEXCH_number(const EVP_KEYEXCH *keyexch)
 
 const char *EVP_KEYEXCH_description(const EVP_KEYEXCH *keyexch)
 {
-    if (keyexch->prov != NULL)
-        return evp_description(keyexch->prov, keyexch->name_id);
-    return NULL;
+    return keyexch->description;
 }
 
 int EVP_KEYEXCH_is_a(const EVP_KEYEXCH *keyexch, const char *name)

--- a/crypto/evp/kdf_lib.c
+++ b/crypto/evp/kdf_lib.c
@@ -97,9 +97,7 @@ const char *EVP_KDF_name(const EVP_KDF *kdf)
 
 const char *EVP_KDF_description(const EVP_KDF *kdf)
 {
-    if (kdf->prov != NULL)
-        return evp_description(kdf->prov, kdf->name_id);
-    return NULL;
+    return kdf->description;
 }
 
 int EVP_KDF_is_a(const EVP_KDF *kdf, const char *name)

--- a/crypto/evp/kdf_lib.c
+++ b/crypto/evp/kdf_lib.c
@@ -95,6 +95,13 @@ const char *EVP_KDF_name(const EVP_KDF *kdf)
     return NULL;
 }
 
+const char *EVP_KDF_description(const EVP_KDF *kdf)
+{
+    if (kdf->prov != NULL)
+        return evp_description(kdf->prov, kdf->name_id);
+    return NULL;
+}
+
 int EVP_KDF_is_a(const EVP_KDF *kdf, const char *name)
 {
     return evp_is_a(kdf->prov, kdf->name_id, NULL, name);

--- a/crypto/evp/kdf_meth.c
+++ b/crypto/evp/kdf_meth.c
@@ -53,9 +53,10 @@ static void *evp_kdf_new(void)
 }
 
 static void *evp_kdf_from_dispatch(int name_id,
-                                   const OSSL_DISPATCH *fns,
+                                   const OSSL_ALGORITHM *algodef,
                                    OSSL_PROVIDER *prov)
 {
+    const OSSL_DISPATCH *fns = algodef->implementation;
     EVP_KDF *kdf = NULL;
     int fnkdfcnt = 0, fnctxcnt = 0;
 
@@ -64,6 +65,7 @@ static void *evp_kdf_from_dispatch(int name_id,
         return NULL;
     }
     kdf->name_id = name_id;
+    kdf->description = algodef->algorithm_description;
 
     for (; fns->function_id != 0; fns++) {
         switch (fns->function_id) {

--- a/crypto/evp/kdf_meth.c
+++ b/crypto/evp/kdf_meth.c
@@ -52,9 +52,9 @@ static void *evp_kdf_new(void)
     return kdf;
 }
 
-static void *evp_kdf_from_dispatch(int name_id,
-                                   const OSSL_ALGORITHM *algodef,
-                                   OSSL_PROVIDER *prov)
+static void *evp_kdf_from_algorithm(int name_id,
+                                    const OSSL_ALGORITHM *algodef,
+                                    OSSL_PROVIDER *prov)
 {
     const OSSL_DISPATCH *fns = algodef->implementation;
     EVP_KDF *kdf = NULL;
@@ -153,7 +153,7 @@ EVP_KDF *EVP_KDF_fetch(OSSL_LIB_CTX *libctx, const char *algorithm,
                        const char *properties)
 {
     return evp_generic_fetch(libctx, OSSL_OP_KDF, algorithm, properties,
-                             evp_kdf_from_dispatch, evp_kdf_up_ref,
+                             evp_kdf_from_algorithm, evp_kdf_up_ref,
                              evp_kdf_free);
 }
 
@@ -220,5 +220,5 @@ void EVP_KDF_do_all_provided(OSSL_LIB_CTX *libctx,
 {
     evp_generic_do_all(libctx, OSSL_OP_KDF,
                        (void (*)(void *, void *))fn, arg,
-                       evp_kdf_from_dispatch, evp_kdf_free);
+                       evp_kdf_from_algorithm, evp_kdf_free);
 }

--- a/crypto/evp/kem.c
+++ b/crypto/evp/kem.c
@@ -345,9 +345,7 @@ int EVP_KEM_number(const EVP_KEM *kem)
 
 const char *EVP_KEM_description(const EVP_KEM *kem)
 {
-    if (kem->prov != NULL)
-        return evp_description(kem->prov, kem->name_id);
-    return NULL;
+    return kem->description;
 }
 
 void EVP_KEM_do_all_provided(OSSL_LIB_CTX *libctx,

--- a/crypto/evp/kem.c
+++ b/crypto/evp/kem.c
@@ -341,6 +341,13 @@ int EVP_KEM_number(const EVP_KEM *kem)
     return kem->name_id;
 }
 
+const char *EVP_KEM_description(const EVP_KEM *kem)
+{
+    if (kem->prov != NULL)
+        return evp_description(kem->prov, kem->name_id);
+    return NULL;
+}
+
 void EVP_KEM_do_all_provided(OSSL_LIB_CTX *libctx,
                              void (*fn)(EVP_KEM *kem, void *arg),
                              void *arg)

--- a/crypto/evp/kem.c
+++ b/crypto/evp/kem.c
@@ -183,8 +183,8 @@ static EVP_KEM *evp_kem_new(OSSL_PROVIDER *prov)
     return kem;
 }
 
-static void *evp_kem_from_dispatch(int name_id, const OSSL_ALGORITHM *algodef,
-                                   OSSL_PROVIDER *prov)
+static void *evp_kem_from_algorithm(int name_id, const OSSL_ALGORITHM *algodef,
+                                    OSSL_PROVIDER *prov)
 {
     const OSSL_DISPATCH *fns = algodef->implementation;
     EVP_KEM *kem = NULL;
@@ -328,7 +328,7 @@ EVP_KEM *EVP_KEM_fetch(OSSL_LIB_CTX *ctx, const char *algorithm,
                        const char *properties)
 {
     return evp_generic_fetch(ctx, OSSL_OP_KEM, algorithm, properties,
-                             evp_kem_from_dispatch,
+                             evp_kem_from_algorithm,
                              (int (*)(void *))EVP_KEM_up_ref,
                              (void (*)(void *))EVP_KEM_free);
 }
@@ -353,7 +353,7 @@ void EVP_KEM_do_all_provided(OSSL_LIB_CTX *libctx,
                              void *arg)
 {
     evp_generic_do_all(libctx, OSSL_OP_KEM, (void (*)(void *, void *))fn, arg,
-                       evp_kem_from_dispatch,
+                       evp_kem_from_algorithm,
                        (void (*)(void *))EVP_KEM_free);
 }
 

--- a/crypto/evp/kem.c
+++ b/crypto/evp/kem.c
@@ -183,9 +183,10 @@ static EVP_KEM *evp_kem_new(OSSL_PROVIDER *prov)
     return kem;
 }
 
-static void *evp_kem_from_dispatch(int name_id, const OSSL_DISPATCH *fns,
+static void *evp_kem_from_dispatch(int name_id, const OSSL_ALGORITHM *algodef,
                                    OSSL_PROVIDER *prov)
 {
+    const OSSL_DISPATCH *fns = algodef->implementation;
     EVP_KEM *kem = NULL;
     int ctxfncnt = 0, encfncnt = 0, decfncnt = 0;
     int gparamfncnt = 0, sparamfncnt = 0;
@@ -196,6 +197,7 @@ static void *evp_kem_from_dispatch(int name_id, const OSSL_DISPATCH *fns,
     }
 
     kem->name_id = name_id;
+    kem->description = algodef->algorithm_description;
 
     for (; fns->function_id != 0; fns++) {
         switch (fns->function_id) {

--- a/crypto/evp/keymgmt_meth.c
+++ b/crypto/evp/keymgmt_meth.c
@@ -32,9 +32,9 @@ static void *keymgmt_new(void)
     return keymgmt;
 }
 
-static void *keymgmt_from_dispatch(int name_id,
-                                   const OSSL_ALGORITHM *algodef,
-                                   OSSL_PROVIDER *prov)
+static void *keymgmt_from_algorithm(int name_id,
+                                    const OSSL_ALGORITHM *algodef,
+                                    OSSL_PROVIDER *prov)
 {
     const OSSL_DISPATCH *fns = algodef->implementation;
     EVP_KEYMGMT *keymgmt = NULL;
@@ -204,7 +204,7 @@ EVP_KEYMGMT *evp_keymgmt_fetch_by_number(OSSL_LIB_CTX *ctx, int name_id,
 {
     return evp_generic_fetch_by_number(ctx,
                                        OSSL_OP_KEYMGMT, name_id, properties,
-                                       keymgmt_from_dispatch,
+                                       keymgmt_from_algorithm,
                                        (int (*)(void *))EVP_KEYMGMT_up_ref,
                                        (void (*)(void *))EVP_KEYMGMT_free);
 }
@@ -213,7 +213,7 @@ EVP_KEYMGMT *EVP_KEYMGMT_fetch(OSSL_LIB_CTX *ctx, const char *algorithm,
                                const char *properties)
 {
     return evp_generic_fetch(ctx, OSSL_OP_KEYMGMT, algorithm, properties,
-                             keymgmt_from_dispatch,
+                             keymgmt_from_algorithm,
                              (int (*)(void *))EVP_KEYMGMT_up_ref,
                              (void (*)(void *))EVP_KEYMGMT_free);
 }
@@ -272,7 +272,7 @@ void EVP_KEYMGMT_do_all_provided(OSSL_LIB_CTX *libctx,
 {
     evp_generic_do_all(libctx, OSSL_OP_KEYMGMT,
                        (void (*)(void *, void *))fn, arg,
-                       keymgmt_from_dispatch,
+                       keymgmt_from_algorithm,
                        (void (*)(void *))EVP_KEYMGMT_free);
 }
 

--- a/crypto/evp/keymgmt_meth.c
+++ b/crypto/evp/keymgmt_meth.c
@@ -33,9 +33,10 @@ static void *keymgmt_new(void)
 }
 
 static void *keymgmt_from_dispatch(int name_id,
-                                   const OSSL_DISPATCH *fns,
+                                   const OSSL_ALGORITHM *algodef,
                                    OSSL_PROVIDER *prov)
 {
+    const OSSL_DISPATCH *fns = algodef->implementation;
     EVP_KEYMGMT *keymgmt = NULL;
     int setparamfncnt = 0, getparamfncnt = 0;
     int setgenparamfncnt = 0;
@@ -46,6 +47,7 @@ static void *keymgmt_from_dispatch(int name_id,
         return NULL;
     }
     keymgmt->name_id = name_id;
+    keymgmt->description = algodef->algorithm_description;
 
     for (; fns->function_id != 0; fns++) {
         switch (fns->function_id) {

--- a/crypto/evp/keymgmt_meth.c
+++ b/crypto/evp/keymgmt_meth.c
@@ -249,6 +249,11 @@ int EVP_KEYMGMT_number(const EVP_KEYMGMT *keymgmt)
     return keymgmt->name_id;
 }
 
+const char *EVP_KEYMGMT_description(const EVP_KEYMGMT *keymgmt)
+{
+    return evp_description(keymgmt->prov, keymgmt->name_id);
+}
+
 const char *EVP_KEYMGMT_get0_first_name(const EVP_KEYMGMT *keymgmt)
 {
     return evp_first_name(keymgmt->prov, keymgmt->name_id);

--- a/crypto/evp/keymgmt_meth.c
+++ b/crypto/evp/keymgmt_meth.c
@@ -253,7 +253,7 @@ int EVP_KEYMGMT_number(const EVP_KEYMGMT *keymgmt)
 
 const char *EVP_KEYMGMT_description(const EVP_KEYMGMT *keymgmt)
 {
-    return evp_description(keymgmt->prov, keymgmt->name_id);
+    return keymgmt->description;
 }
 
 const char *EVP_KEYMGMT_get0_first_name(const EVP_KEYMGMT *keymgmt)

--- a/crypto/evp/mac_lib.c
+++ b/crypto/evp/mac_lib.c
@@ -172,9 +172,7 @@ const char *EVP_MAC_name(const EVP_MAC *mac)
 
 const char *EVP_MAC_description(const EVP_MAC *mac)
 {
-    if (mac->prov != NULL)
-        return evp_description(mac->prov, mac->name_id);
-    return NULL;
+    return mac->description;
 }
 
 int EVP_MAC_is_a(const EVP_MAC *mac, const char *name)

--- a/crypto/evp/mac_lib.c
+++ b/crypto/evp/mac_lib.c
@@ -170,6 +170,13 @@ const char *EVP_MAC_name(const EVP_MAC *mac)
     return NULL;
 }
 
+const char *EVP_MAC_description(const EVP_MAC *mac)
+{
+    if (mac->prov != NULL)
+        return evp_description(mac->prov, mac->name_id);
+    return NULL;
+}
+
 int EVP_MAC_is_a(const EVP_MAC *mac, const char *name)
 {
     return evp_is_a(mac->prov, mac->name_id, NULL, name);

--- a/crypto/evp/mac_meth.c
+++ b/crypto/evp/mac_meth.c
@@ -47,9 +47,10 @@ static void *evp_mac_new(void)
 }
 
 static void *evp_mac_from_dispatch(int name_id,
-                                   const OSSL_DISPATCH *fns,
+                                   const OSSL_ALGORITHM *algodef,
                                    OSSL_PROVIDER *prov)
 {
+    const OSSL_DISPATCH *fns = algodef->implementation;
     EVP_MAC *mac = NULL;
     int fnmaccnt = 0, fnctxcnt = 0;
 
@@ -58,6 +59,7 @@ static void *evp_mac_from_dispatch(int name_id,
         return NULL;
     }
     mac->name_id = name_id;
+    mac->description = algodef->algorithm_description;
 
     for (; fns->function_id != 0; fns++) {
         switch (fns->function_id) {

--- a/crypto/evp/mac_meth.c
+++ b/crypto/evp/mac_meth.c
@@ -46,9 +46,9 @@ static void *evp_mac_new(void)
     return mac;
 }
 
-static void *evp_mac_from_dispatch(int name_id,
-                                   const OSSL_ALGORITHM *algodef,
-                                   OSSL_PROVIDER *prov)
+static void *evp_mac_from_algorithm(int name_id,
+                                    const OSSL_ALGORITHM *algodef,
+                                    OSSL_PROVIDER *prov)
 {
     const OSSL_DISPATCH *fns = algodef->implementation;
     EVP_MAC *mac = NULL;
@@ -155,7 +155,7 @@ EVP_MAC *EVP_MAC_fetch(OSSL_LIB_CTX *libctx, const char *algorithm,
                        const char *properties)
 {
     return evp_generic_fetch(libctx, OSSL_OP_MAC, algorithm, properties,
-                             evp_mac_from_dispatch, evp_mac_up_ref,
+                             evp_mac_from_algorithm, evp_mac_up_ref,
                              evp_mac_free);
 }
 
@@ -227,5 +227,5 @@ void EVP_MAC_do_all_provided(OSSL_LIB_CTX *libctx,
 {
     evp_generic_do_all(libctx, OSSL_OP_MAC,
                        (void (*)(void *, void *))fn, arg,
-                       evp_mac_from_dispatch, evp_mac_free);
+                       evp_mac_from_algorithm, evp_mac_free);
 }

--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -1723,6 +1723,20 @@ int EVP_PKEY_size(const EVP_PKEY *pkey)
     return size < 0 ? 0 : size;
 }
 
+const char *EVP_PKEY_description(const EVP_PKEY *pkey)
+{
+    if (!evp_pkey_is_assigned(pkey))
+        return NULL;
+
+    if (evp_pkey_is_provided(pkey))
+        return evp_description(pkey->keymgmt->prov, pkey->keymgmt->name_id);
+#ifndef FIPS_MODULE
+    return pkey->ameth->info;
+#else
+    return NULL;
+#endif
+}
+
 void *evp_pkey_export_to_provider(EVP_PKEY *pk, OSSL_LIB_CTX *libctx,
                                   EVP_KEYMGMT **keymgmt,
                                   const char *propquery)

--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -1728,13 +1728,13 @@ const char *EVP_PKEY_description(const EVP_PKEY *pkey)
     if (!evp_pkey_is_assigned(pkey))
         return NULL;
 
-    if (evp_pkey_is_provided(pkey))
-        return evp_description(pkey->keymgmt->prov, pkey->keymgmt->name_id);
+    if (evp_pkey_is_provided(pkey) && pkey->keymgmt->description != NULL)
+        return pkey->keymgmt->description;
 #ifndef FIPS_MODULE
-    return pkey->ameth->info;
-#else
-    return NULL;
+    if (pkey->ameth != NULL)
+        return pkey->ameth->info;
 #endif
+    return NULL;
 }
 
 void *evp_pkey_export_to_provider(EVP_PKEY *pk, OSSL_LIB_CTX *libctx,

--- a/crypto/evp/signature.c
+++ b/crypto/evp/signature.c
@@ -38,9 +38,9 @@ static EVP_SIGNATURE *evp_signature_new(OSSL_PROVIDER *prov)
     return signature;
 }
 
-static void *evp_signature_from_dispatch(int name_id,
-                                         const OSSL_ALGORITHM *algodef,
-                                         OSSL_PROVIDER *prov)
+static void *evp_signature_from_algorithm(int name_id,
+                                          const OSSL_ALGORITHM *algodef,
+                                          OSSL_PROVIDER *prov)
 {
     const OSSL_DISPATCH *fns = algodef->implementation;
     EVP_SIGNATURE *signature = NULL;
@@ -304,7 +304,7 @@ EVP_SIGNATURE *EVP_SIGNATURE_fetch(OSSL_LIB_CTX *ctx, const char *algorithm,
                                    const char *properties)
 {
     return evp_generic_fetch(ctx, OSSL_OP_SIGNATURE, algorithm, properties,
-                             evp_signature_from_dispatch,
+                             evp_signature_from_algorithm,
                              (int (*)(void *))EVP_SIGNATURE_up_ref,
                              (void (*)(void *))EVP_SIGNATURE_free);
 }
@@ -331,7 +331,7 @@ void EVP_SIGNATURE_do_all_provided(OSSL_LIB_CTX *libctx,
 {
     evp_generic_do_all(libctx, OSSL_OP_SIGNATURE,
                        (void (*)(void *, void *))fn, arg,
-                       evp_signature_from_dispatch,
+                       evp_signature_from_algorithm,
                        (void (*)(void *))EVP_SIGNATURE_free);
 }
 

--- a/crypto/evp/signature.c
+++ b/crypto/evp/signature.c
@@ -321,9 +321,7 @@ int EVP_SIGNATURE_number(const EVP_SIGNATURE *signature)
 
 const char *EVP_SIGNATURE_description(const EVP_SIGNATURE *signature)
 {
-    if (signature->prov != NULL)
-        return evp_description(signature->prov, signature->name_id);
-    return NULL;
+    return signature->description;
 }
 
 void EVP_SIGNATURE_do_all_provided(OSSL_LIB_CTX *libctx,

--- a/crypto/evp/signature.c
+++ b/crypto/evp/signature.c
@@ -317,6 +317,13 @@ int EVP_SIGNATURE_number(const EVP_SIGNATURE *signature)
     return signature->name_id;
 }
 
+const char *EVP_SIGNATURE_description(const EVP_SIGNATURE *signature)
+{
+    if (signature->prov != NULL)
+        return evp_description(signature->prov, signature->name_id);
+    return NULL;
+}
+
 void EVP_SIGNATURE_do_all_provided(OSSL_LIB_CTX *libctx,
                                    void (*fn)(EVP_SIGNATURE *signature,
                                               void *arg),

--- a/crypto/evp/signature.c
+++ b/crypto/evp/signature.c
@@ -39,9 +39,10 @@ static EVP_SIGNATURE *evp_signature_new(OSSL_PROVIDER *prov)
 }
 
 static void *evp_signature_from_dispatch(int name_id,
-                                         const OSSL_DISPATCH *fns,
+                                         const OSSL_ALGORITHM *algodef,
                                          OSSL_PROVIDER *prov)
 {
+    const OSSL_DISPATCH *fns = algodef->implementation;
     EVP_SIGNATURE *signature = NULL;
     int ctxfncnt = 0, signfncnt = 0, verifyfncnt = 0, verifyrecfncnt = 0;
     int digsignfncnt = 0, digverifyfncnt = 0;
@@ -53,6 +54,7 @@ static void *evp_signature_from_dispatch(int name_id,
     }
 
     signature->name_id = name_id;
+    signature->description = algodef->algorithm_description;
 
     for (; fns->function_id != 0; fns++) {
         switch (fns->function_id) {

--- a/crypto/store/store_local.h
+++ b/crypto/store/store_local.h
@@ -100,6 +100,7 @@ struct ossl_store_loader_st {
     OSSL_PROVIDER *prov;
     int scheme_id;
     const char *propdef;
+    const char *description;
 
     CRYPTO_REF_COUNT refcnt;
     CRYPTO_RWLOCK *lock;

--- a/crypto/store/store_meth.c
+++ b/crypto/store/store_meth.c
@@ -244,8 +244,13 @@ static void *construct_loader(const OSSL_ALGORITHM *algodef,
     int id = ossl_namemap_add_name(namemap, 0, scheme);
     void *method = NULL;
 
-    if (id != 0)
-        method = loader_from_dispatch(id, algodef, prov);
+    if (id == 0)
+        return NULL;
+
+    if (algodef->algorithm_description != NULL)
+        (void)ossl_namemap_add_desc(namemap, id,
+                                    algodef->algorithm_description);
+    method = loader_from_dispatch(id, algodef, prov);
 
     /*
      * Flag to indicate that there was actual construction errors.  This

--- a/crypto/store/store_meth.c
+++ b/crypto/store/store_meth.c
@@ -162,8 +162,8 @@ static int put_loader_in_store(OSSL_LIB_CTX *libctx, void *store,
                                  up_ref_loader, free_loader);
 }
 
-static void *loader_from_dispatch(int scheme_id, const OSSL_ALGORITHM *algodef,
-                                  OSSL_PROVIDER *prov)
+static void *loader_from_algorithm(int scheme_id, const OSSL_ALGORITHM *algodef,
+                                   OSSL_PROVIDER *prov)
 {
     OSSL_STORE_LOADER *loader = NULL;
     const OSSL_DISPATCH *fns = algodef->implementation;
@@ -227,7 +227,7 @@ static void *loader_from_dispatch(int scheme_id, const OSSL_ALGORITHM *algodef,
 /*
  * The core fetching functionality passes the scheme of the implementation.
  * This function is responsible to getting an identity number for them,
- * then call loader_from_dispatch() with that identity number.
+ * then call loader_from_algorithm() with that identity number.
  */
 static void *construct_loader(const OSSL_ALGORITHM *algodef,
                               OSSL_PROVIDER *prov, void *data)
@@ -246,7 +246,7 @@ static void *construct_loader(const OSSL_ALGORITHM *algodef,
     void *method = NULL;
 
     if (id != 0)
-        method = loader_from_dispatch(id, algodef, prov);
+        method = loader_from_algorithm(id, algodef, prov);
 
     /*
      * Flag to indicate that there was actual construction errors.  This
@@ -436,7 +436,7 @@ static void loader_do_one(OSSL_PROVIDER *provider,
 
     if (id != 0)
         method =
-            loader_from_dispatch(id, algodef, provider);
+            loader_from_algorithm(id, algodef, provider);
 
     if (method != NULL) {
         data->user_fn(method, data->user_arg);

--- a/crypto/store/store_meth.c
+++ b/crypto/store/store_meth.c
@@ -404,13 +404,7 @@ int OSSL_STORE_LOADER_number(const OSSL_STORE_LOADER *loader)
 
 const char *OSSL_STORE_LOADER_description(const OSSL_STORE_LOADER *loader)
 {
-    if (loader->prov != NULL) {
-        OSSL_LIB_CTX *libctx = ossl_provider_libctx(loader->prov);
-        OSSL_NAMEMAP *namemap = ossl_namemap_stored(libctx);
-
-        return ossl_namemap_num2desc(namemap, loader->scheme_id);
-    }
-    return NULL;
+    return loader->description;
 }
 
 int OSSL_STORE_LOADER_is_a(const OSSL_STORE_LOADER *loader, const char *name)

--- a/crypto/store/store_meth.c
+++ b/crypto/store/store_meth.c
@@ -406,6 +406,17 @@ int OSSL_STORE_LOADER_number(const OSSL_STORE_LOADER *loader)
     return loader->scheme_id;
 }
 
+const char *OSSL_STORE_LOADER_description(const OSSL_STORE_LOADER *loader)
+{
+    if (loader->prov != NULL) {
+        OSSL_LIB_CTX *libctx = ossl_provider_libctx(loader->prov);
+        OSSL_NAMEMAP *namemap = ossl_namemap_stored(libctx);
+
+        return ossl_namemap_num2desc(namemap, loader->scheme_id);
+    }
+    return NULL;
+}
+
 int OSSL_STORE_LOADER_is_a(const OSSL_STORE_LOADER *loader, const char *name)
 {
     if (loader->prov != NULL) {

--- a/crypto/store/store_meth.c
+++ b/crypto/store/store_meth.c
@@ -172,6 +172,7 @@ static void *loader_from_dispatch(int scheme_id, const OSSL_ALGORITHM *algodef,
         return NULL;
     loader->scheme_id = scheme_id;
     loader->propdef = algodef->property_definition;
+    loader->description = algodef->algorithm_description;
 
     for (; fns->function_id != 0; fns++) {
         switch (fns->function_id) {
@@ -244,13 +245,8 @@ static void *construct_loader(const OSSL_ALGORITHM *algodef,
     int id = ossl_namemap_add_name(namemap, 0, scheme);
     void *method = NULL;
 
-    if (id == 0)
-        return NULL;
-
-    if (algodef->algorithm_description != NULL)
-        (void)ossl_namemap_add_desc(namemap, id,
-                                    algodef->algorithm_description);
-    method = loader_from_dispatch(id, algodef, prov);
+    if (id != 0)
+        method = loader_from_dispatch(id, algodef, prov);
 
     /*
      * Flag to indicate that there was actual construction errors.  This

--- a/doc/internal/man3/evp_generic_fetch.pod
+++ b/doc/internal/man3/evp_generic_fetch.pod
@@ -114,10 +114,10 @@ And here's the implementation of the FOO method fetcher:
      * In this example, we have a public method creator and destructor.
      * It's not absolutely necessary, but is in the spirit of OpenSSL.
      */
-    EVP_FOO *EVP_FOO_meth_from_dispatch(int name_id,
-                                        const OSSL_DISPATCH *fns,
-                                        OSSL_PROVIDER *prov,
-                                        void *data)
+    EVP_FOO *EVP_FOO_meth_from_algorithm(int name_id,
+                                         const OSSL_DISPATCH *fns,
+                                         OSSL_PROVIDER *prov,
+                                         void *data)
     {
         EVP_FOO *foo = NULL;
 
@@ -162,10 +162,10 @@ And here's the implementation of the FOO method fetcher:
         }
     }
 
-    static void *foo_from_dispatch(const OSSL_DISPATCH *fns,
-                                   OSSL_PROVIDER *prov)
+    static void *foo_from_algorithm(const OSSL_DISPATCH *fns,
+                                    OSSL_PROVIDER *prov)
     {
-        return EVP_FOO_meth_from_dispatch(fns, prov);
+        return EVP_FOO_meth_from_algorithm(fns, prov);
     }
 
     static int foo_up_ref(void *vfoo)
@@ -188,7 +188,7 @@ And here's the implementation of the FOO method fetcher:
     {
         EVP_FOO *foo =
             evp_generic_fetch(ctx, OSSL_OP_FOO, name, properties,
-                              foo_from_dispatch, foo_up_ref, foo_free);
+                              foo_from_algorithm, foo_up_ref, foo_free);
 
         /*
          * If this method exists in legacy form, with a constant NID for the

--- a/doc/man3/EVP_ASYM_CIPHER_free.pod
+++ b/doc/man3/EVP_ASYM_CIPHER_free.pod
@@ -5,6 +5,7 @@
 EVP_ASYM_CIPHER_fetch, EVP_ASYM_CIPHER_free, EVP_ASYM_CIPHER_up_ref,
 EVP_ASYM_CIPHER_number, EVP_ASYM_CIPHER_is_a, EVP_ASYM_CIPHER_provider,
 EVP_ASYM_CIPHER_do_all_provided, EVP_ASYM_CIPHER_names_do_all,
+EVP_ASYM_CIPHER_description,
 EVP_ASYM_CIPHER_gettable_ctx_params, EVP_ASYM_CIPHER_settable_ctx_params
 - Functions to manage EVP_ASYM_CIPHER algorithm objects
 
@@ -26,6 +27,7 @@ EVP_ASYM_CIPHER_gettable_ctx_params, EVP_ASYM_CIPHER_settable_ctx_params
  int EVP_ASYM_CIPHER_names_do_all(const EVP_ASYM_CIPHER *cipher,
                                   void (*fn)(const char *name, void *data),
                                   void *data);
+ const char *EVP_ASYM_CIPHER_description(const EVP_ASYM_CIPHER *cipher);
  const OSSL_PARAM *EVP_ASYM_CIPHER_gettable_ctx_params(const EVP_ASYM_CIPHER *cip);
  const OSSL_PARAM *EVP_ASYM_CIPHER_settable_ctx_params(const EVP_ASYM_CIPHER *cip);
 
@@ -63,6 +65,10 @@ I<cipher>.
 
 EVP_ASYM_CIPHER_names_do_all() traverses all names for I<cipher>, and calls
 I<fn> with each name and I<data>.
+
+EVP_ASYM_CIPHER_description() returns a description of the I<cipher>, meant
+for display and human consumption.  The description is at the discretion of
+the I<cipher> implementation.
 
 EVP_ASYM_CIPHER_gettable_ctx_params() and EVP_ASYM_CIPHER_settable_ctx_params()
 return a constant B<OSSL_PARAM> array that describes the names and types of key

--- a/doc/man3/EVP_DigestInit.pod
+++ b/doc/man3/EVP_DigestInit.pod
@@ -12,7 +12,8 @@ EVP_MD_CTX_settable_params, EVP_MD_CTX_gettable_params,
 EVP_MD_CTX_set_flags, EVP_MD_CTX_clear_flags, EVP_MD_CTX_test_flags,
 EVP_Digest, EVP_DigestInit_ex2, EVP_DigestInit_ex, EVP_DigestInit,
 EVP_DigestUpdate, EVP_DigestFinal_ex, EVP_DigestFinalXOF, EVP_DigestFinal,
-EVP_MD_is_a, EVP_MD_name, EVP_MD_number, EVP_MD_names_do_all, EVP_MD_provider,
+EVP_MD_is_a, EVP_MD_name, EVP_MD_description, EVP_MD_number,
+EVP_MD_names_do_all, EVP_MD_provider,
 EVP_MD_type, EVP_MD_pkey_type, EVP_MD_size, EVP_MD_block_size, EVP_MD_flags,
 EVP_MD_CTX_name,
 EVP_MD_CTX_md, EVP_MD_CTX_type, EVP_MD_CTX_size, EVP_MD_CTX_block_size,
@@ -64,6 +65,7 @@ EVP_MD_do_all_provided
  int EVP_MD_CTX_copy(EVP_MD_CTX *out, EVP_MD_CTX *in);
 
  const char *EVP_MD_name(const EVP_MD *md);
+ const char *EVP_MD_description(const EVP_MD *md);
  int EVP_MD_number(const EVP_MD *md);
  int EVP_MD_is_a(const EVP_MD *md, const char *name);
  int EVP_MD_names_do_all(const EVP_MD *md,
@@ -313,6 +315,11 @@ recommended to use EVP_MD_names_do_all() instead.
 
 Traverses all names for the I<md>, and calls I<fn> with each name and
 I<data>.  This is only useful with fetched B<EVP_MD>s.
+
+=item EVP_MD_description()
+
+Returns a description of the digest, meant for display and human consumption.
+The description is at the discretion of the digest implementation.
 
 =item EVP_MD_provider()
 

--- a/doc/man3/EVP_EncryptInit.pod
+++ b/doc/man3/EVP_EncryptInit.pod
@@ -34,6 +34,7 @@ EVP_get_cipherbynid,
 EVP_get_cipherbyobj,
 EVP_CIPHER_is_a,
 EVP_CIPHER_name,
+EVP_CIPHER_description,
 EVP_CIPHER_number,
 EVP_CIPHER_names_do_all,
 EVP_CIPHER_provider,
@@ -143,6 +144,7 @@ EVP_CIPHER_do_all_provided
                              void (*fn)(const char *name, void *data),
                              void *data);
  const char *EVP_CIPHER_name(const EVP_CIPHER *cipher);
+ const char *EVP_CIPHER_description(const EVP_CIPHER *cipher);
  const OSSL_PROVIDER *EVP_CIPHER_provider(const EVP_CIPHER *cipher);
  int EVP_CIPHER_block_size(const EVP_CIPHER *e);
  int EVP_CIPHER_key_length(const EVP_CIPHER *e);
@@ -407,6 +409,10 @@ instead.
 EVP_CIPHER_names_do_all() traverses all names for the I<cipher>, and
 calls I<fn> with each name and I<data>.  This is only useful with
 fetched B<EVP_CIPHER>s.
+
+EVP_CIPHER_description() returns a description of the cipher, meant for
+display and human consumption.  The description is at the discretion of the
+cipher implementation.
 
 EVP_CIPHER_provider() returns an B<OSSL_PROVIDER> pointer to the provider
 that implements the given B<EVP_CIPHER>.

--- a/doc/man3/EVP_KDF.pod
+++ b/doc/man3/EVP_KDF.pod
@@ -6,7 +6,7 @@ EVP_KDF, EVP_KDF_fetch, EVP_KDF_free, EVP_KDF_up_ref,
 EVP_KDF_CTX, EVP_KDF_CTX_new, EVP_KDF_CTX_free, EVP_KDF_CTX_dup,
 EVP_KDF_CTX_reset, EVP_KDF_derive,
 EVP_KDF_CTX_get_kdf_size, EVP_KDF_provider, EVP_KDF_CTX_kdf, EVP_KDF_is_a,
-EVP_KDF_number, EVP_KDF_name, EVP_KDF_names_do_all,
+EVP_KDF_number, EVP_KDF_name, EVP_KDF_names_do_all, EVP_KDF_description,
 EVP_KDF_CTX_get_params, EVP_KDF_CTX_set_params, EVP_KDF_do_all_provided,
 EVP_KDF_get_params, EVP_KDF_gettable_params,
 EVP_KDF_gettable_ctx_params, EVP_KDF_settable_ctx_params,
@@ -34,6 +34,7 @@ EVP_KDF_CTX_gettable_params, EVP_KDF_CTX_settable_params - EVP KDF routines
  int EVP_KDF_number(const EVP_KDF *kdf);
  int EVP_KDF_is_a(const EVP_KDF *kdf, const char *name);
  const char *EVP_KDF_name(const EVP_KDF *kdf);
+ const char *EVP_KDF_description(const EVP_KDF *kdf);
  const OSSL_PROVIDER *EVP_KDF_provider(const EVP_KDF *kdf);
  void EVP_KDF_do_all_provided(OSSL_LIB_CTX *libctx,
                               void (*fn)(EVP_KDF *kdf, void *arg),
@@ -178,6 +179,10 @@ recommended to use EVP_KDF_names_do_all() instead.
 
 EVP_KDF_names_do_all() traverses all names for I<kdf>, and calls
 I<fn> with each name and I<data>.
+
+EVP_KDF_description() returns a description of the I<kdf>, meant for display
+and human consumption.  The description is at the discretion of the I<kdf>
+implementation.
 
 =head1 PARAMETERS
 

--- a/doc/man3/EVP_KEM_free.pod
+++ b/doc/man3/EVP_KEM_free.pod
@@ -4,7 +4,7 @@
 
 EVP_KEM_fetch, EVP_KEM_free, EVP_KEM_up_ref,
 EVP_KEM_number, EVP_KEM_is_a, EVP_KEM_provider,
-EVP_KEM_do_all_provided, EVP_KEM_names_do_all,
+EVP_KEM_do_all_provided, EVP_KEM_names_do_all, EVP_KEM_description,
 EVP_KEM_gettable_ctx_params, EVP_KEM_settable_ctx_params
 - Functions to manage EVP_KEM algorithm objects
 
@@ -23,6 +23,7 @@ EVP_KEM_gettable_ctx_params, EVP_KEM_settable_ctx_params
                               void (*fn)(EVP_KEM *kem, void *arg), void *arg);
  int EVP_KEM_names_do_all(const EVP_KEM *kem,
                           void (*fn)(const char *name, void *data), void *data);
+ const char *EVP_KEM_description(const EVP_KEM *kem);
  const OSSL_PARAM *EVP_KEM_gettable_ctx_params(const EVP_KEM *kem);
  const OSSL_PARAM *EVP_KEM_settable_ctx_params(const EVP_KEM *kem);
 
@@ -57,6 +58,10 @@ EVP_KEM_number() returns the internal dynamic number assigned to I<kem>.
 
 EVP_KEM_names_do_all() traverses all names for I<kem>, and calls I<fn> with
 each name and I<data>.
+
+EVP_KEM_description() returns a description of the I<kem>, meant for display
+and human consumption.  The description is at the discretion of the I<kem>
+implementation.
 
 EVP_KEM_gettable_ctx_params() and EVP_KEM_settable_ctx_params() return
 a constant B<OSSL_PARAM> array that describes the names and types of key

--- a/doc/man3/EVP_KEYEXCH_free.pod
+++ b/doc/man3/EVP_KEYEXCH_free.pod
@@ -5,6 +5,7 @@
 EVP_KEYEXCH_fetch, EVP_KEYEXCH_free, EVP_KEYEXCH_up_ref, EVP_KEYEXCH_provider,
 EVP_KEYEXCH_is_a, EVP_KEYEXCH_do_all_provided,
 EVP_KEYEXCH_number, EVP_KEYEXCH_names_do_all,
+EVP_KEYEXCH_description,
 EVP_KEYEXCH_gettable_ctx_params, EVP_KEYEXCH_settable_ctx_params
 - Functions to manage EVP_KEYEXCH algorithm objects
 
@@ -25,6 +26,7 @@ EVP_KEYEXCH_gettable_ctx_params, EVP_KEYEXCH_settable_ctx_params
  int EVP_KEYEXCH_names_do_all(const EVP_KEYEXCH *exchange,
                               void (*fn)(const char *name, void *data),
                               void *data);
+ const char *EVP_KEYEXCH_description(const EVP_KEYEXCH *keyexch);
  const OSSL_PARAM *EVP_KEYEXCH_gettable_ctx_params(const EVP_KEYEXCH *keyexch);
  const OSSL_PARAM *EVP_KEYEXCH_settable_ctx_params(const EVP_KEYEXCH *keyexch);
 
@@ -55,6 +57,10 @@ the I<exchange>.
 
 EVP_KEYEXCH_names_do_all() traverses all names for the I<exchange>, and
 calls I<fn> with each name and I<data>.
+
+EVP_KEYEXCH_description() returns a description of the I<keyexch>, meant for
+display and human consumption.  The description is at the discretion of the
+I<keyexch> implementation.
 
 EVP_KEYEXCH_do_all_provided() traverses all key exchange implementations by
 all activated providers in the library context I<libctx>, and for each

--- a/doc/man3/EVP_KEYMGMT.pod
+++ b/doc/man3/EVP_KEYMGMT.pod
@@ -9,6 +9,7 @@ EVP_KEYMGMT_free,
 EVP_KEYMGMT_provider,
 EVP_KEYMGMT_is_a,
 EVP_KEYMGMT_number,
+EVP_KEYMGMT_description,
 EVP_KEYMGMT_get0_first_name,
 EVP_KEYMGMT_do_all_provided,
 EVP_KEYMGMT_names_do_all,
@@ -31,6 +32,7 @@ EVP_KEYMGMT_gen_settable_params
  int EVP_KEYMGMT_is_a(const EVP_KEYMGMT *keymgmt, const char *name);
  int EVP_KEYMGMT_number(const EVP_KEYMGMT *keymgmt);
  const char *EVP_KEYMGMT_get0_first_name(const EVP_KEYMGMT *keymgmt);
+ const char *EVP_KEYMGMT_description(const EVP_KEYMGMT *keymgmt);
 
  void EVP_KEYMGMT_do_all_provided(OSSL_LIB_CTX *libctx,
                                   void (*fn)(EVP_KEYMGMT *keymgmt, void *arg),
@@ -81,6 +83,10 @@ not be freed by the caller.
 EVP_KEYMGMT_names_do_all() traverses all names for the I<keymgmt>, and
 calls I<fn> with each name and I<data>.
 
+EVP_KEYMGMT_description() returns a description of the I<keymgmt>, meant for
+display and human consumption.  The description is at the discretion of the
+I<keymgmt> implementation.
+
 EVP_KEYMGMT_do_all_provided() traverses all key keymgmt implementations by
 all activated providers in the library context I<libctx>, and for each
 of the implementations, calls I<fn> with the implementation method and
@@ -124,6 +130,9 @@ otherwise 0.
 EVP_KEYMGMT_number() returns an integer.
 
 EVP_KEYMGMT_get0_first_name() returns the name that is found or NULL on error.
+
+EVP_KEYMGMT_description() returns a pointer to a decription, or NULL if
+there isn't one.
 
 EVP_KEYMGMT_gettable_params(), EVP_KEYMGMT_settable_params() and
 EVP_KEYMGMT_gen_settable_params() return a constant B<OSSL_PARAM> array or

--- a/doc/man3/EVP_MAC.pod
+++ b/doc/man3/EVP_MAC.pod
@@ -2,8 +2,8 @@
 
 =head1 NAME
 
-EVP_MAC, EVP_MAC_fetch, EVP_MAC_up_ref, EVP_MAC_free,
-EVP_MAC_is_a, EVP_MAC_number, EVP_MAC_name, EVP_MAC_names_do_all,
+EVP_MAC, EVP_MAC_fetch, EVP_MAC_up_ref, EVP_MAC_free, EVP_MAC_is_a,
+EVP_MAC_number, EVP_MAC_name, EVP_MAC_names_do_all, EVP_MAC_description,
 EVP_MAC_provider, EVP_MAC_get_params, EVP_MAC_gettable_params,
 EVP_MAC_CTX, EVP_MAC_CTX_new, EVP_MAC_CTX_free, EVP_MAC_CTX_dup,
 EVP_MAC_CTX_mac, EVP_MAC_CTX_get_params, EVP_MAC_CTX_set_params,
@@ -29,6 +29,7 @@ EVP_MAC_do_all_provided - EVP MAC routines
  int EVP_MAC_names_do_all(const EVP_MAC *mac,
                           void (*fn)(const char *name, void *data),
                           void *data);
+ const char *EVP_MAC_description(const EVP_MAC *mac);
  const OSSL_PROVIDER *EVP_MAC_provider(const EVP_MAC *mac);
  int EVP_MAC_get_params(EVP_MAC *mac, OSSL_PARAM params[]);
 
@@ -204,6 +205,10 @@ recommended to use EVP_MAC_names_do_all() instead.
 
 EVP_MAC_names_do_all() traverses all names for I<mac>, and calls
 I<fn> with each name and I<data>.
+
+EVP_MAC_description() returns a description of the I<mac>, meant for display
+and human consumption.  The description is at the discretion of the mac
+implementation.
 
 =head1 PARAMETERS
 

--- a/doc/man3/EVP_PKEY_new.pod
+++ b/doc/man3/EVP_PKEY_new.pod
@@ -7,6 +7,7 @@ EVP_PKEY_new,
 EVP_PKEY_up_ref,
 EVP_PKEY_dup,
 EVP_PKEY_free,
+EVP_PKEY_description,
 EVP_PKEY_new_raw_private_key_ex,
 EVP_PKEY_new_raw_private_key,
 EVP_PKEY_new_raw_public_key_ex,
@@ -27,6 +28,7 @@ EVP_PKEY_get_raw_public_key
  int EVP_PKEY_up_ref(EVP_PKEY *key);
  EVP_PKEY *EVP_PKEY_dup(EVP_PKEY *key);
  void EVP_PKEY_free(EVP_PKEY *key);
+ const char *EVP_PKEY_description(const EVP_PKEY *key);
 
  EVP_PKEY *EVP_PKEY_new_raw_private_key_ex(OSSL_LIB_CTX *libctx,
                                            const char *keytype,
@@ -89,6 +91,10 @@ a raw key, otherwise the duplication will fail.
 
 EVP_PKEY_free() decrements the reference count of I<key> and, if the reference
 count is zero, frees it up. If I<key> is NULL, nothing is done.
+
+EVP_PKEY_description() returns a description of the type of B<EVP_PKEY>, meant
+for display and human consumption.  The description is at the discretion of the
+key type implementation.
 
 EVP_PKEY_new_raw_private_key_ex() allocates a new B<EVP_PKEY>. Unless an
 engine should be used for the key type, a provider for the key is found using

--- a/doc/man3/EVP_RAND.pod
+++ b/doc/man3/EVP_RAND.pod
@@ -4,11 +4,12 @@
 
 EVP_RAND, EVP_RAND_fetch, EVP_RAND_free, EVP_RAND_up_ref, EVP_RAND_CTX,
 EVP_RAND_CTX_new, EVP_RAND_CTX_free, EVP_RAND_instantiate,
-EVP_RAND_uninstantiate, EVP_RAND_generate, EVP_RAND_reseed,
-EVP_RAND_nonce, EVP_RAND_enable_locking,
-EVP_RAND_verify_zeroization, EVP_RAND_strength, EVP_RAND_state,
+EVP_RAND_uninstantiate, EVP_RAND_generate, EVP_RAND_reseed, EVP_RAND_nonce,
+EVP_RAND_enable_locking, EVP_RAND_verify_zeroization, EVP_RAND_strength,
+EVP_RAND_state,
 EVP_RAND_provider, EVP_RAND_CTX_rand, EVP_RAND_is_a, EVP_RAND_number,
-EVP_RAND_name, EVP_RAND_names_do_all, EVP_RAND_get_ctx_params,
+EVP_RAND_name, EVP_RAND_names_do_all, EVP_RAND_description,
+EVP_RAND_get_ctx_params,
 EVP_RAND_set_ctx_params, EVP_RAND_do_all_provided, EVP_RAND_get_params,
 EVP_RAND_gettable_ctx_params, EVP_RAND_settable_ctx_params,
 EVP_RAND_CTX_gettable_params, EVP_RAND_CTX_settable_params,
@@ -39,6 +40,7 @@ EVP_RAND_STATE_ERROR - EVP RAND routines
  const OSSL_PARAM *EVP_RAND_CTX_settable_params(EVP_RAND_CTX *ctx);
  int EVP_RAND_number(const EVP_RAND *rand);
  const char *EVP_RAND_name(const EVP_RAND *rand);
+ const char *EVP_RAND_description(const EVP_RAND *rand);
  int EVP_RAND_is_a(const EVP_RAND *rand, const char *name);
  const OSSL_PROVIDER *EVP_RAND_provider(const EVP_RAND *rand);
  void EVP_RAND_do_all_provided(OSSL_LIB_CTX *libctx,
@@ -247,6 +249,10 @@ EVP_RAND_name() returns the canonical name of I<rand>.
 
 EVP_RAND_names_do_all() traverses all names for I<rand>, and calls
 I<fn> with each name and I<data>.
+
+EVP_RAND_description() returns a description of the rand, meant for display
+and human consumption.  The description is at the discretion of the rand
+implementation.
 
 EVP_RAND_verify_zeroization() confirms if the internal DRBG state is
 currently zeroed.  This is used by the FIPS provider to support the mandatory

--- a/doc/man3/EVP_SIGNATURE_free.pod
+++ b/doc/man3/EVP_SIGNATURE_free.pod
@@ -5,6 +5,7 @@
 EVP_SIGNATURE_fetch, EVP_SIGNATURE_free, EVP_SIGNATURE_up_ref,
 EVP_SIGNATURE_number, EVP_SIGNATURE_is_a, EVP_SIGNATURE_provider,
 EVP_SIGNATURE_do_all_provided, EVP_SIGNATURE_names_do_all,
+EVP_SIGNATURE_description,
 EVP_SIGNATURE_gettable_ctx_params, EVP_SIGNATURE_settable_ctx_params
 - Functions to manage EVP_SIGNATURE algorithm objects
 
@@ -26,6 +27,7 @@ EVP_SIGNATURE_gettable_ctx_params, EVP_SIGNATURE_settable_ctx_params
  int EVP_SIGNATURE_names_do_all(const EVP_SIGNATURE *signature,
                                 void (*fn)(const char *name, void *data),
                                 void *data);
+ const char *EVP_SIGNATURE_description(const EVP_SIGNATURE *signature);
  const OSSL_PARAM *EVP_SIGNATURE_gettable_ctx_params(const EVP_SIGNATURE *sig);
  const OSSL_PARAM *EVP_SIGNATURE_settable_ctx_params(const EVP_SIGNATURE *sig);
 
@@ -63,6 +65,10 @@ I<signature>.
 
 EVP_SIGNATURE_names_do_all() traverses all names for I<signature>, and calls
 I<fn> with each name and I<data>.
+
+EVP_SIGNATURE_description() returns a description of the I<signature>, meant
+for display and human consumption.  The description is at the discretion of
+the I<signature> implementation.
 
 EVP_SIGNATURE_gettable_ctx_params() and EVP_SIGNATURE_settable_ctx_params()
 return a constant B<OSSL_PARAM> array that describes the names and types of key

--- a/doc/man3/OSSL_DECODER.pod
+++ b/doc/man3/OSSL_DECODER.pod
@@ -10,6 +10,7 @@ OSSL_DECODER_provider,
 OSSL_DECODER_properties,
 OSSL_DECODER_is_a,
 OSSL_DECODER_number,
+OSSL_DECODER_description,
 OSSL_DECODER_do_all_provided,
 OSSL_DECODER_names_do_all,
 OSSL_DECODER_gettable_params,
@@ -30,6 +31,7 @@ OSSL_DECODER_get_params
  const char *OSSL_DECODER_properties(const OSSL_DECODER *decoder);
  int OSSL_DECODER_is_a(const OSSL_DECODER *decoder, const char *name);
  int OSSL_DECODER_number(const OSSL_DECODER *decoder);
+ const char *OSSL_DECODER_description(const OSSL_DECODER *decoder);
  void OSSL_DECODER_do_all_provided(OSSL_LIB_CTX *libctx,
                                    void (*fn)(OSSL_DECODER *decoder, void *arg),
                                    void *arg);
@@ -72,6 +74,10 @@ of an algorithm that's identifiable with I<name>.
 OSSL_DECODER_number() returns the internal dynamic number assigned
 to the given I<decoder>.
 
+OSSL_DECODER_description() returns a description of the I<decoder>, meant
+for display and human consumption.  The description is at the discretion
+of the I<decoder> implementation.
+
 OSSL_DECODER_names_do_all() traverses all names for the given
 I<decoder>, and calls I<fn> with each name and I<data> as arguments.
 
@@ -106,6 +112,9 @@ OSSL_DECODER_is_a() returns 1 if I<decoder> was identifiable,
 otherwise 0.
 
 OSSL_DECODER_number() returns an integer.
+
+OSSL_DECODER_description() returns a pointer to a decription, or NULL if
+there isn't one.
 
 OSSL_DECODER_names_do_all() returns 1 if the callback was called for all
 names. A return value of 0 means that the callback was not called for any names.

--- a/doc/man3/OSSL_ENCODER.pod
+++ b/doc/man3/OSSL_ENCODER.pod
@@ -10,6 +10,7 @@ OSSL_ENCODER_provider,
 OSSL_ENCODER_properties,
 OSSL_ENCODER_is_a,
 OSSL_ENCODER_number,
+OSSL_ENCODER_description,
 OSSL_ENCODER_do_all_provided,
 OSSL_ENCODER_names_do_all,
 OSSL_ENCODER_gettable_params,
@@ -30,6 +31,7 @@ OSSL_ENCODER_get_params
  const char *OSSL_ENCODER_properties(const OSSL_ENCODER *encoder);
  int OSSL_ENCODER_is_a(const OSSL_ENCODER *encoder, const char *name);
  int OSSL_ENCODER_number(const OSSL_ENCODER *encoder);
+ const char *OSSL_ENCODER_description(const OSSL_ENCODER *encoder);
  void OSSL_ENCODER_do_all_provided(OSSL_LIB_CTX *libctx,
                                    void (*fn)(OSSL_ENCODER *encoder, void *arg),
                                    void *arg);
@@ -72,6 +74,10 @@ algorithm that's identifiable with I<name>.
 OSSL_ENCODER_number() returns the internal dynamic number assigned to
 the given I<encoder>.
 
+OSSL_ENCODER_description() returns a description of the I<loader>, meant
+for display and human consumption.  The description is at the discretion of the
+I<loader> implementation.
+
 OSSL_ENCODER_names_do_all() traverses all names for the given
 I<encoder>, and calls I<fn> with each name and I<data> as arguments.
 
@@ -107,6 +113,9 @@ OSSL_ENCODER_is_a() returns 1 of I<encoder> was identifiable,
 otherwise 0.
 
 OSSL_ENCODER_number() returns an integer.
+
+OSSL_ENCODER_description() returns a pointer to a decription, or NULL if
+there isn't one.
 
 OSSL_ENCODER_names_do_all() returns 1 if the callback was called for all
 names. A return value of 0 means that the callback was not called for any names.

--- a/doc/man3/OSSL_STORE_LOADER.pod
+++ b/doc/man3/OSSL_STORE_LOADER.pod
@@ -10,6 +10,7 @@ OSSL_STORE_LOADER_provider,
 OSSL_STORE_LOADER_properties,
 OSSL_STORE_LOADER_is_a,
 OSSL_STORE_LOADER_number,
+OSSL_STORE_LOADER_description,
 OSSL_STORE_LOADER_do_all_provided,
 OSSL_STORE_LOADER_names_do_all,
 OSSL_STORE_LOADER_CTX, OSSL_STORE_LOADER_new,
@@ -42,6 +43,7 @@ unregister STORE loaders for different URI schemes
                                                  loader);
  const char *OSSL_STORE_LOADER_properties(const OSSL_STORE_LOADER *loader);
  int OSSL_STORE_LOADER_number(const OSSL_STORE_LOADER *loader);
+ const char *OSSL_STORE_LOADER_description(const OSSL_STORE_LOADER *loader);
  int OSSL_STORE_LOADER_is_a(const OSSL_STORE_LOADER *loader,
                             const char *scheme);
  void OSSL_STORE_LOADER_do_all_provided(OSSL_LIB_CTX *libctx,
@@ -138,6 +140,10 @@ of an algorithm that's identifiable with I<scheme>.
 
 OSSL_STORE_LOADER_number() returns the internal dynamic number assigned
 to the given I<loader>.
+
+OSSL_STORE_LOADER_description() returns a description of the I<loader>, meant
+for display and human consumption.  The description is at the discretion of the
+I<loader> implementation.
 
 OSSL_STORE_LOADER_do_all_provided() traverses all store implementations
 by all activated providers in the library context I<libctx>, and for each
@@ -327,6 +333,9 @@ OSSL_STORE_LOADER_is_a() returns 1 if I<loader> was identifiable,
 otherwise 0.
 
 OSSL_STORE_LOADER_number() returns an integer.
+
+OSSL_STORE_LOADER_description() returns a pointer to a decription, or NULL if
+there isn't one.
 
 The functions with the types B<OSSL_STORE_open_fn>,
 B<OSSL_STORE_open_ex_fn>, B<OSSL_STORE_ctrl_fn>,

--- a/include/crypto/decoder.h
+++ b/include/crypto/decoder.h
@@ -23,8 +23,8 @@ OSSL_DECODER *ossl_decoder_fetch_by_number(OSSL_LIB_CTX *libctx,
  * except read a DER blob and pass it on as a provider object abstraction
  * (provider-object(7)).
  */
-void *ossl_decoder_from_dispatch(int id, const OSSL_ALGORITHM *algodef,
-                                 OSSL_PROVIDER *prov);
+void *ossl_decoder_from_algorithm(int id, const OSSL_ALGORITHM *algodef,
+                                  OSSL_PROVIDER *prov);
 
 OSSL_DECODER_INSTANCE *
 ossl_decoder_instance_new(OSSL_DECODER *decoder, void *decoderctx);

--- a/include/crypto/evp.h
+++ b/include/crypto/evp.h
@@ -193,6 +193,7 @@ const EVP_PKEY_METHOD *ossl_rsa_pss_pkey_method(void);
 struct evp_mac_st {
     OSSL_PROVIDER *prov;
     int name_id;
+    const char *description;
 
     CRYPTO_REF_COUNT refcnt;
     CRYPTO_RWLOCK *lock;
@@ -214,6 +215,7 @@ struct evp_mac_st {
 struct evp_kdf_st {
     OSSL_PROVIDER *prov;
     int name_id;
+    const char *description;
     CRYPTO_REF_COUNT refcnt;
     CRYPTO_RWLOCK *lock;
 
@@ -251,6 +253,7 @@ struct evp_md_st {
     /* New structure members */
     /* Above comment to be removed when legacy has gone */
     int name_id;
+    const char *description;
     OSSL_PROVIDER *prov;
     CRYPTO_REF_COUNT refcnt;
     CRYPTO_RWLOCK *lock;
@@ -303,6 +306,7 @@ struct evp_cipher_st {
     /* New structure members */
     /* Above comment to be removed when legacy has gone */
     int name_id;
+    const char *description;
     OSSL_PROVIDER *prov;
     CRYPTO_REF_COUNT refcnt;
     CRYPTO_RWLOCK *lock;

--- a/include/internal/namemap.h
+++ b/include/internal/namemap.h
@@ -18,7 +18,6 @@ void ossl_namemap_free(OSSL_NAMEMAP *namemap);
 int ossl_namemap_empty(OSSL_NAMEMAP *namemap);
 
 int ossl_namemap_add_name(OSSL_NAMEMAP *namemap, int number, const char *name);
-int ossl_namemap_add_desc(OSSL_NAMEMAP *namemap, int number, const char *desc);
 int ossl_namemap_add_name_n(OSSL_NAMEMAP *namemap, int number,
                             const char *name, size_t name_len);
 
@@ -32,7 +31,6 @@ int ossl_namemap_name2num_n(const OSSL_NAMEMAP *namemap,
                             const char *name, size_t name_len);
 const char *ossl_namemap_num2name(const OSSL_NAMEMAP *namemap, int number,
                                   size_t idx);
-const char *ossl_namemap_num2desc(const OSSL_NAMEMAP *namemap, int number);
 int ossl_namemap_doall_names(const OSSL_NAMEMAP *namemap, int number,
                              void (*fn)(const char *name, void *data),
                              void *data);

--- a/include/internal/namemap.h
+++ b/include/internal/namemap.h
@@ -18,6 +18,7 @@ void ossl_namemap_free(OSSL_NAMEMAP *namemap);
 int ossl_namemap_empty(OSSL_NAMEMAP *namemap);
 
 int ossl_namemap_add_name(OSSL_NAMEMAP *namemap, int number, const char *name);
+int ossl_namemap_add_desc(OSSL_NAMEMAP *namemap, int number, const char *desc);
 int ossl_namemap_add_name_n(OSSL_NAMEMAP *namemap, int number,
                             const char *name, size_t name_len);
 
@@ -31,6 +32,7 @@ int ossl_namemap_name2num_n(const OSSL_NAMEMAP *namemap,
                             const char *name, size_t name_len);
 const char *ossl_namemap_num2name(const OSSL_NAMEMAP *namemap, int number,
                                   size_t idx);
+const char *ossl_namemap_num2desc(const OSSL_NAMEMAP *namemap, int number);
 int ossl_namemap_doall_names(const OSSL_NAMEMAP *namemap, int number,
                              void (*fn)(const char *name, void *data),
                              void *data);

--- a/include/openssl/core.h
+++ b/include/openssl/core.h
@@ -70,6 +70,7 @@ struct ossl_algorithm_st {
     const char *algorithm_names;     /* key */
     const char *property_definition; /* key */
     const OSSL_DISPATCH *implementation;
+    const char *algorithm_description;
 };
 
 /*

--- a/include/openssl/decoder.h
+++ b/include/openssl/decoder.h
@@ -34,6 +34,7 @@ void OSSL_DECODER_free(OSSL_DECODER *encoder);
 const OSSL_PROVIDER *OSSL_DECODER_provider(const OSSL_DECODER *encoder);
 const char *OSSL_DECODER_properties(const OSSL_DECODER *encoder);
 int OSSL_DECODER_number(const OSSL_DECODER *encoder);
+const char *OSSL_DECODER_description(const OSSL_DECODER *decoder);
 int OSSL_DECODER_is_a(const OSSL_DECODER *encoder, const char *name);
 
 void OSSL_DECODER_do_all_provided(OSSL_LIB_CTX *libctx,

--- a/include/openssl/encoder.h
+++ b/include/openssl/encoder.h
@@ -34,6 +34,7 @@ void OSSL_ENCODER_free(OSSL_ENCODER *encoder);
 const OSSL_PROVIDER *OSSL_ENCODER_provider(const OSSL_ENCODER *encoder);
 const char *OSSL_ENCODER_properties(const OSSL_ENCODER *encoder);
 int OSSL_ENCODER_number(const OSSL_ENCODER *encoder);
+const char *OSSL_ENCODER_description(const OSSL_ENCODER *kdf);
 int OSSL_ENCODER_is_a(const OSSL_ENCODER *encoder, const char *name);
 
 void OSSL_ENCODER_do_all_provided(OSSL_LIB_CTX *libctx,

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -526,6 +526,7 @@ typedef int (EVP_PBE_KEYGEN) (EVP_CIPHER_CTX *ctx, const char *pass,
 int EVP_MD_type(const EVP_MD *md);
 # define EVP_MD_nid(e)                   EVP_MD_type(e)
 const char *EVP_MD_name(const EVP_MD *md);
+const char *EVP_MD_description(const EVP_MD *md);
 int EVP_MD_number(const EVP_MD *md);
 int EVP_MD_is_a(const EVP_MD *md, const char *name);
 int EVP_MD_names_do_all(const EVP_MD *md,
@@ -557,6 +558,7 @@ void *EVP_MD_CTX_md_data(const EVP_MD_CTX *ctx);
 
 int EVP_CIPHER_nid(const EVP_CIPHER *cipher);
 const char *EVP_CIPHER_name(const EVP_CIPHER *cipher);
+const char *EVP_CIPHER_description(const EVP_CIPHER *cipher);
 int EVP_CIPHER_number(const EVP_CIPHER *cipher);
 int EVP_CIPHER_is_a(const EVP_CIPHER *cipher, const char *name);
 int EVP_CIPHER_names_do_all(const EVP_CIPHER *cipher,
@@ -1151,6 +1153,7 @@ int EVP_MAC_up_ref(EVP_MAC *mac);
 void EVP_MAC_free(EVP_MAC *mac);
 int EVP_MAC_number(const EVP_MAC *mac);
 const char *EVP_MAC_name(const EVP_MAC *mac);
+const char *EVP_MAC_description(const EVP_MAC *mac);
 int EVP_MAC_is_a(const EVP_MAC *mac, const char *name);
 const OSSL_PROVIDER *EVP_MAC_provider(const EVP_MAC *mac);
 int EVP_MAC_get_params(EVP_MAC *mac, OSSL_PARAM params[]);
@@ -1188,6 +1191,7 @@ int EVP_RAND_up_ref(EVP_RAND *rand);
 void EVP_RAND_free(EVP_RAND *rand);
 int EVP_RAND_number(const EVP_RAND *rand);
 const char *EVP_RAND_name(const EVP_RAND *rand);
+const char *EVP_RAND_description(const EVP_RAND *md);
 int EVP_RAND_is_a(const EVP_RAND *rand, const char *name);
 const OSSL_PROVIDER *EVP_RAND_provider(const EVP_RAND *rand);
 int EVP_RAND_get_params(EVP_RAND *rand, OSSL_PARAM params[]);
@@ -1320,6 +1324,7 @@ EVP_PKEY *EVP_PKEY_new(void);
 int EVP_PKEY_up_ref(EVP_PKEY *pkey);
 EVP_PKEY *EVP_PKEY_dup(EVP_PKEY *pkey);
 void EVP_PKEY_free(EVP_PKEY *pkey);
+const char *EVP_PKEY_description(const EVP_PKEY *pkey);
 
 EVP_PKEY *d2i_PublicKey(int type, EVP_PKEY **a, const unsigned char **pp,
                         long length);
@@ -1671,6 +1676,7 @@ int EVP_KEYMGMT_up_ref(EVP_KEYMGMT *keymgmt);
 void EVP_KEYMGMT_free(EVP_KEYMGMT *keymgmt);
 const OSSL_PROVIDER *EVP_KEYMGMT_provider(const EVP_KEYMGMT *keymgmt);
 const char *EVP_KEYMGMT_get0_first_name(const EVP_KEYMGMT *keymgmt);
+const char *EVP_KEYMGMT_description(const EVP_KEYMGMT *keymgmt);
 int EVP_KEYMGMT_number(const EVP_KEYMGMT *keymgmt);
 int EVP_KEYMGMT_is_a(const EVP_KEYMGMT *keymgmt, const char *name);
 void EVP_KEYMGMT_do_all_provided(OSSL_LIB_CTX *libctx,
@@ -1755,6 +1761,7 @@ EVP_SIGNATURE *EVP_SIGNATURE_fetch(OSSL_LIB_CTX *ctx, const char *algorithm,
                                    const char *properties);
 int EVP_SIGNATURE_is_a(const EVP_SIGNATURE *signature, const char *name);
 int EVP_SIGNATURE_number(const EVP_SIGNATURE *signature);
+const char *EVP_SIGNATURE_description(const EVP_SIGNATURE *signature);
 void EVP_SIGNATURE_do_all_provided(OSSL_LIB_CTX *libctx,
                                    void (*fn)(EVP_SIGNATURE *signature,
                                               void *data),
@@ -1772,6 +1779,7 @@ EVP_ASYM_CIPHER *EVP_ASYM_CIPHER_fetch(OSSL_LIB_CTX *ctx, const char *algorithm,
                                        const char *properties);
 int EVP_ASYM_CIPHER_is_a(const EVP_ASYM_CIPHER *cipher, const char *name);
 int EVP_ASYM_CIPHER_number(const EVP_ASYM_CIPHER *cipher);
+const char *EVP_ASYM_CIPHER_description(const EVP_ASYM_CIPHER *cipher);
 void EVP_ASYM_CIPHER_do_all_provided(OSSL_LIB_CTX *libctx,
                                      void (*fn)(EVP_ASYM_CIPHER *cipher,
                                                 void *arg),
@@ -1789,6 +1797,7 @@ EVP_KEM *EVP_KEM_fetch(OSSL_LIB_CTX *ctx, const char *algorithm,
                        const char *properties);
 int EVP_KEM_is_a(const EVP_KEM *wrap, const char *name);
 int EVP_KEM_number(const EVP_KEM *wrap);
+const char *EVP_KEM_description(const EVP_KEM *wrap);
 void EVP_KEM_do_all_provided(OSSL_LIB_CTX *libctx,
                              void (*fn)(EVP_KEM *wrap, void *arg), void *arg);
 int EVP_KEM_names_do_all(const EVP_KEM *wrap,
@@ -2043,6 +2052,7 @@ EVP_KEYEXCH *EVP_KEYEXCH_fetch(OSSL_LIB_CTX *ctx, const char *algorithm,
 OSSL_PROVIDER *EVP_KEYEXCH_provider(const EVP_KEYEXCH *exchange);
 int EVP_KEYEXCH_is_a(const EVP_KEYEXCH *keyexch, const char *name);
 int EVP_KEYEXCH_number(const EVP_KEYEXCH *keyexch);
+const char *EVP_KEYEXCH_description(const EVP_KEYEXCH *keyexch);
 void EVP_KEYEXCH_do_all_provided(OSSL_LIB_CTX *libctx,
                                  void (*fn)(EVP_KEYEXCH *keyexch, void *data),
                                  void *data);

--- a/include/openssl/kdf.h
+++ b/include/openssl/kdf.h
@@ -34,6 +34,7 @@ EVP_KDF_CTX *EVP_KDF_CTX_new(EVP_KDF *kdf);
 void EVP_KDF_CTX_free(EVP_KDF_CTX *ctx);
 EVP_KDF_CTX *EVP_KDF_CTX_dup(const EVP_KDF_CTX *src);
 int EVP_KDF_number(const EVP_KDF *kdf);
+const char *EVP_KDF_description(const EVP_KDF *kdf);
 int EVP_KDF_is_a(const EVP_KDF *kdf, const char *name);
 const char *EVP_KDF_name(const EVP_KDF *kdf);
 const OSSL_PROVIDER *EVP_KDF_provider(const EVP_KDF *kdf);

--- a/include/openssl/store.h
+++ b/include/openssl/store.h
@@ -260,6 +260,7 @@ const OSSL_PROVIDER *OSSL_STORE_LOADER_provider(const OSSL_STORE_LOADER *
                                                 loader);
 const char *OSSL_STORE_LOADER_properties(const OSSL_STORE_LOADER *loader);
 int OSSL_STORE_LOADER_number(const OSSL_STORE_LOADER *loader);
+const char *OSSL_STORE_LOADER_description(const OSSL_STORE_LOADER *loader);
 int OSSL_STORE_LOADER_is_a(const OSSL_STORE_LOADER *loader,
                            const char *scheme);
 void OSSL_STORE_LOADER_do_all_provided(OSSL_LIB_CTX *libctx,

--- a/providers/defltprov.c
+++ b/providers/defltprov.c
@@ -408,35 +408,52 @@ static const OSSL_ALGORITHM deflt_asym_kem[] = {
 
 static const OSSL_ALGORITHM deflt_keymgmt[] = {
 #ifndef OPENSSL_NO_DH
-    { "DH:dhKeyAgreement", "provider=default", ossl_dh_keymgmt_functions },
+    { "DH:dhKeyAgreement", "provider=default", ossl_dh_keymgmt_functions,
+      "OpenSSL PKCS#3 DH implementation" },
     { "DHX:X9.42 DH:dhpublicnumber", "provider=default",
-      ossl_dhx_keymgmt_functions },
+      ossl_dhx_keymgmt_functions, "OpenSSL X9.42 DH implementation" },
 #endif
 #ifndef OPENSSL_NO_DSA
-    { "DSA:dsaEncryption", "provider=default", ossl_dsa_keymgmt_functions },
+    { "DSA:dsaEncryption", "provider=default", ossl_dsa_keymgmt_functions,
+      "OpenSSL DSA implementation" },
 #endif
-    { "RSA:rsaEncryption", "provider=default", ossl_rsa_keymgmt_functions },
-    { "RSA-PSS:RSASSA-PSS", "provider=default", ossl_rsapss_keymgmt_functions },
+    { "RSA:rsaEncryption", "provider=default", ossl_rsa_keymgmt_functions,
+      "OpenSSL RSA implementation" },
+    { "RSA-PSS:RSASSA-PSS", "provider=default", ossl_rsapss_keymgmt_functions,
+      "OpenSSL RSA-PSS implementation" },
 #ifndef OPENSSL_NO_EC
-    { "EC:id-ecPublicKey", "provider=default", ossl_ec_keymgmt_functions },
-    { "X25519", "provider=default", ossl_x25519_keymgmt_functions },
-    { "X448", "provider=default", ossl_x448_keymgmt_functions },
-    { "ED25519", "provider=default", ossl_ed25519_keymgmt_functions },
-    { "ED448", "provider=default", ossl_ed448_keymgmt_functions },
+    { "EC:id-ecPublicKey", "provider=default", ossl_ec_keymgmt_functions,
+      "OpenSSL EC implementation" },
+    { "X25519", "provider=default", ossl_x25519_keymgmt_functions,
+      "OpenSSL X25519 implementation" },
+    { "X448", "provider=default", ossl_x448_keymgmt_functions,
+      "OpenSSL X448 implementation" },
+    { "ED25519", "provider=default", ossl_ed25519_keymgmt_functions,
+      "OpenSSL ED25519 implementation" },
+    { "ED448", "provider=default", ossl_ed448_keymgmt_functions,
+      "OpenSSL ED448 implementation" },
 #endif
-    { "TLS1-PRF", "provider=default", ossl_kdf_keymgmt_functions },
-    { "HKDF", "provider=default", ossl_kdf_keymgmt_functions },
-    { "SCRYPT:id-scrypt", "provider=default", ossl_kdf_keymgmt_functions },
-    { "HMAC", "provider=default", ossl_mac_legacy_keymgmt_functions },
-    { "SIPHASH", "provider=default", ossl_mac_legacy_keymgmt_functions },
+    { "TLS1-PRF", "provider=default", ossl_kdf_keymgmt_functions,
+      "OpenSSL TLS1-PRF via EVP_PKEY implementation" },
+    { "HKDF", "provider=default", ossl_kdf_keymgmt_functions,
+      "OpenSSL HKDF via EVP_PKEY implementation" },
+    { "SCRYPT:id-scrypt", "provider=default", ossl_kdf_keymgmt_functions,
+      "OpenSSL SCRYPT via EVP_PKEY implementation" },
+    { "HMAC", "provider=default", ossl_mac_legacy_keymgmt_functions,
+      "OpenSSL HMAC via EVP_PKEY implementation" },
+    { "SIPHASH", "provider=default", ossl_mac_legacy_keymgmt_functions,
+      "OpenSSL SIPHASH via EVP_PKEY implementation" },
 #ifndef OPENSSL_NO_POLY1305
-    { "POLY1305", "provider=default", ossl_mac_legacy_keymgmt_functions },
+    { "POLY1305", "provider=default", ossl_mac_legacy_keymgmt_functions,
+      "OpenSSL POLY1305 via EVP_PKEY implementation" },
 #endif
 #ifndef OPENSSL_NO_CMAC
-    { "CMAC", "provider=default", ossl_cossl_mac_legacy_keymgmt_functions },
+    { "CMAC", "provider=default", ossl_cossl_mac_legacy_keymgmt_functions,
+      "OpenSSL CMAC via EVP_PKEY implementation" },
 #endif
 #ifndef OPENSSL_NO_SM2
-    { "SM2", "provider=default", ossl_sm2_keymgmt_functions },
+    { "SM2", "provider=default", ossl_sm2_keymgmt_functions,
+      "OpenSSL SM2 implementation" },
 #endif
     { NULL, NULL, NULL }
 };

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -394,30 +394,40 @@ static const OSSL_ALGORITHM fips_asym_kem[] = {
 
 static const OSSL_ALGORITHM fips_keymgmt[] = {
 #ifndef OPENSSL_NO_DH
-    { "DH:dhKeyAgreement", FIPS_DEFAULT_PROPERTIES, ossl_dh_keymgmt_functions },
+    { "DH:dhKeyAgreement", FIPS_DEFAULT_PROPERTIES, ossl_dh_keymgmt_functions,
+      "OpenSSL PKCS#3 DH FIPS implementation" },
     { "DHX:X9.42 DH:dhpublicnumber", FIPS_DEFAULT_PROPERTIES,
-      ossl_dhx_keymgmt_functions },
+      ossl_dhx_keymgmt_functions, "OpenSSL X9.42 DH FIPS implementation" },
 #endif
 #ifndef OPENSSL_NO_DSA
-    { "DSA", FIPS_DEFAULT_PROPERTIES, ossl_dsa_keymgmt_functions },
+    { "DSA", FIPS_DEFAULT_PROPERTIES, ossl_dsa_keymgmt_functions,
+      "OpenSSL DSA FIPS implementation" },
 #endif
     { "RSA:rsaEncryption", FIPS_DEFAULT_PROPERTIES,
-      ossl_rsa_keymgmt_functions },
+      ossl_rsa_keymgmt_functions, "OpenSSL RSA FIPS implementation" },
     { "RSA-PSS:RSASSA-PSS", FIPS_DEFAULT_PROPERTIES,
-      ossl_rsapss_keymgmt_functions },
+      ossl_rsapss_keymgmt_functions, "OpenSSL RSA-PSS FIPS implementation" },
 #ifndef OPENSSL_NO_EC
-    { "EC:id-ecPublicKey", FIPS_DEFAULT_PROPERTIES, ossl_ec_keymgmt_functions },
-    { "X25519", FIPS_DEFAULT_PROPERTIES, ossl_x25519_keymgmt_functions },
-    { "X448", FIPS_DEFAULT_PROPERTIES, ossl_x448_keymgmt_functions },
-    { "ED25519", FIPS_DEFAULT_PROPERTIES, ossl_ed25519_keymgmt_functions },
-    { "ED448", FIPS_DEFAULT_PROPERTIES, ossl_ed448_keymgmt_functions },
+    { "EC:id-ecPublicKey", FIPS_DEFAULT_PROPERTIES, ossl_ec_keymgmt_functions,
+      "OpenSSL EC FIPS implementation" },
+    { "X25519", FIPS_DEFAULT_PROPERTIES, ossl_x25519_keymgmt_functions,
+      "OpenSSL X25519 FIPS implementation" },
+    { "X448", FIPS_DEFAULT_PROPERTIES, ossl_x448_keymgmt_functions,
+      "OpenSSL X448 FIPS implementation" },
+    { "ED25519", FIPS_DEFAULT_PROPERTIES, ossl_ed25519_keymgmt_functions,
+      "OpenSSL ED25519 FIPS implementation" },
+    { "ED448", FIPS_DEFAULT_PROPERTIES, ossl_ed448_keymgmt_functions,
+      "OpenSSL ED448 FIPS implementation" },
 #endif
-    { "TLS1-PRF", FIPS_DEFAULT_PROPERTIES, ossl_kdf_keymgmt_functions },
-    { "HKDF", FIPS_DEFAULT_PROPERTIES, ossl_kdf_keymgmt_functions },
-    { "HMAC", FIPS_DEFAULT_PROPERTIES, ossl_mac_legacy_keymgmt_functions },
+    { "TLS1-PRF", FIPS_DEFAULT_PROPERTIES, ossl_kdf_keymgmt_functions,
+      "OpenSSL TLS1-PRF via EVP_PKEY FIPS implementation" },
+    { "HKDF", FIPS_DEFAULT_PROPERTIES, ossl_kdf_keymgmt_functions,
+      "OpenSSL HKDF via EVP_PKEY FIPS implementation" },
+    { "HMAC", FIPS_DEFAULT_PROPERTIES, ossl_mac_legacy_keymgmt_functions,
+      "OpenSSL HMAC via EVP_PKEY FIPS implementation" },
 #ifndef OPENSSL_NO_CMAC
-    { "CMAC", FIPS_DEFAULT_PROPERTIES,
-      ossl_cossl_mac_legacy_keymgmt_functions },
+    { "CMAC", FIPS_DEFAULT_PROPERTIES, ossl_cossl_mac_legacy_keymgmt_functions,
+      "OpenSSL CMAC via EVP_PKEY FIPS implementation" },
 #endif
     { NULL, NULL, NULL }
 };

--- a/providers/implementations/storemgmt/file_store.c
+++ b/providers/implementations/storemgmt/file_store.c
@@ -437,8 +437,8 @@ static int file_setup_decoders(struct file_ctx_st *ctx)
          * The decoder doesn't need any identification or to be attached to
          * any provider, since it's only used locally.
          */
-        to_obj = ossl_decoder_from_dispatch(0, &ossl_der_to_obj_algorithm,
-                                            NULL);
+        to_obj = ossl_decoder_from_algorithm(0, &ossl_der_to_obj_algorithm,
+                                             NULL);
         if (to_obj == NULL)
             goto err;
         to_obj_inst = ossl_decoder_instance_new(to_obj, ctx->provctx);

--- a/providers/implementations/storemgmt/file_store_der2obj.c
+++ b/providers/implementations/storemgmt/file_store_der2obj.c
@@ -36,7 +36,7 @@
 
 /*
  * newctx and freectx are not strictly necessary.  However, the method creator,
- * ossl_decoder_from_dispatch(), demands that they exist, so we make sure to
+ * ossl_decoder_from_algorithm(), demands that they exist, so we make sure to
  * oblige.
  */
 

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5334,3 +5334,4 @@ EVP_PKEY_dup                            ?	3_0_0	EXIST::FUNCTION:
 RSA_PSS_PARAMS_dup                      ?	3_0_0	EXIST::FUNCTION:
 OSSL_DECODER_description                ?	3_0_0	EXIST::FUNCTION:
 OSSL_ENCODER_description                ?	3_0_0	EXIST::FUNCTION:
+OSSL_STORE_LOADER_description           ?	3_0_0	EXIST::FUNCTION:

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5332,3 +5332,5 @@ TS_RESP_CTX_new_ex                      ?	3_0_0	EXIST::FUNCTION:TS
 X509_REQ_new_ex                         ?	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_dup                            ?	3_0_0	EXIST::FUNCTION:
 RSA_PSS_PARAMS_dup                      ?	3_0_0	EXIST::FUNCTION:
+OSSL_DECODER_description                ?	3_0_0	EXIST::FUNCTION:
+OSSL_ENCODER_description                ?	3_0_0	EXIST::FUNCTION:

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5335,3 +5335,14 @@ RSA_PSS_PARAMS_dup                      ?	3_0_0	EXIST::FUNCTION:
 OSSL_DECODER_description                ?	3_0_0	EXIST::FUNCTION:
 OSSL_ENCODER_description                ?	3_0_0	EXIST::FUNCTION:
 OSSL_STORE_LOADER_description           ?	3_0_0	EXIST::FUNCTION:
+EVP_MD_description                      ?	3_0_0	EXIST::FUNCTION:
+EVP_CIPHER_description                  ?	3_0_0	EXIST::FUNCTION:
+EVP_MAC_description                     ?	3_0_0	EXIST::FUNCTION:
+EVP_RAND_description                    ?	3_0_0	EXIST::FUNCTION:
+EVP_PKEY_description                    ?	3_0_0	EXIST::FUNCTION:
+EVP_KEYMGMT_description                 ?	3_0_0	EXIST::FUNCTION:
+EVP_SIGNATURE_description               ?	3_0_0	EXIST::FUNCTION:
+EVP_ASYM_CIPHER_description             ?	3_0_0	EXIST::FUNCTION:
+EVP_KEM_description                     ?	3_0_0	EXIST::FUNCTION:
+EVP_KEYEXCH_description                 ?	3_0_0	EXIST::FUNCTION:
+EVP_KDF_description                     ?	3_0_0	EXIST::FUNCTION:


### PR DESCRIPTION
This adds a description field in OSSL_ALGORITHM, and add suitable functions to get them from fetched implementations.

Additionally, the output of provider side implementations for `-public-key-algorithms` is modified to look a little more like the legacy implementation output.

Fixes #14514