### PR TITLE
EVP_PKCS82PKEY: Create provided keys if possible

### DIFF
--- a/crypto/asn1/d2i_pr.c
+++ b/crypto/asn1/d2i_pr.c
@@ -106,7 +106,7 @@ d2i_PrivateKey_legacy(int keytype, EVP_PKEY **a, const unsigned char **pp,
                 ERR_clear_last_mark();
                 goto err;
             }
-            tmp = EVP_PKCS82PKEY_ex(p8, libctx, propq);
+            tmp = evp_pkcs82pkey_legacy(p8, libctx, propq);
             PKCS8_PRIV_KEY_INFO_free(p8);
             if (tmp == NULL) {
                 ERR_clear_last_mark();
@@ -190,7 +190,7 @@ static EVP_PKEY *d2i_AutoPrivateKey_legacy(EVP_PKEY **a,
             ERR_raise(ERR_LIB_ASN1, ASN1_R_UNSUPPORTED_PUBLIC_KEY_TYPE);
             return NULL;
         }
-        ret = EVP_PKCS82PKEY_ex(p8, libctx, propq);
+        ret = evp_pkcs82pkey_legacy(p8, libctx, propq);
         PKCS8_PRIV_KEY_INFO_free(p8);
         if (ret == NULL)
             return NULL;

--- a/include/crypto/evp.h
+++ b/include/crypto/evp.h
@@ -727,6 +727,8 @@ void *evp_pkey_export_to_provider(EVP_PKEY *pk, OSSL_LIB_CTX *libctx,
 int evp_pkey_copy_downgraded(EVP_PKEY **dest, const EVP_PKEY *src);
 void *evp_pkey_get_legacy(EVP_PKEY *pk);
 void evp_pkey_free_legacy(EVP_PKEY *x);
+EVP_PKEY *evp_pkcs82pkey_legacy(const PKCS8_PRIV_KEY_INFO *p8inf,
+                                OSSL_LIB_CTX *libctx, const char *propq);
 #endif
 
 /*

--- a/test/endecode_test.c
+++ b/test/endecode_test.c
@@ -21,6 +21,7 @@
 
 #include "internal/cryptlib.h"   /* ossl_assert */
 #include "crypto/pem.h"          /* For PVK and "blob" PEM headers */
+#include "crypto/evp.h"          /* For evp_pkey_is_provided() */
 
 #include "helpers/predefined_dhparams.h"
 #include "testutil.h"
@@ -498,6 +499,7 @@ static int check_unprotected_PKCS8_DER(const char *file, const int line,
                     TEST_note("%s isn't any of %s", type, namelist);
                 OPENSSL_free(namelist);
             }
+            ok = ok && TEST_FL_true(evp_pkey_is_provided(pkey));
             EVP_PKEY_free(pkey);
         }
     }


### PR DESCRIPTION
Use OSSL_DECODER to decode the PKCS8 data to create provided keys.

If that fails fallback to the legacy implementation.

Fixes #14302

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
