### PR TITLE
Add explicit support in util/shlib_wrap.sh.in for NonStop DLL loading.

### DIFF
--- a/util/shlib_wrap.sh.in
+++ b/util/shlib_wrap.sh.in
@@ -84,6 +84,15 @@ SunOS|IRIX*)
 	eval $rld_var=\"${THERE}'${'$rld_var':+:$'$rld_var'}'\"; export $rld_var
 	unset rld_var
 	;;
+NONSTOP_KERNEL)
+	# HPE NonStop has a proprietary mechanism for specifying
+	# the location of DLLs. It does not use PATH or variables
+	# commonly used on other platforms. The platform has a limited
+	# environment space keeping extraneous variables to a minimum
+	# is recommended.
+	_RLD_LIB_PATH="${THERE}:$LD_LIBRARY_PATH"
+	export _RLD_LIB_PATH
+	;;
 *)	LD_LIBRARY_PATH="${THERE}:$LD_LIBRARY_PATH"	# Linux, ELF HP-UX
 	DYLD_LIBRARY_PATH="${THERE}:$DYLD_LIBRARY_PATH"	# MacOS X
 	SHLIB_PATH="${THERE}:$SHLIB_PATH"		# legacy HP-UX


### PR DESCRIPTION
The NonStop platform uses a proprietary mechanism for specifying DLL locations.

This change permits testers to use a simple 'make test' instead of explicitly configuring the shell environment for the location of the built DLLs.

CLA: Permission is granted by the author to the OpenSSL team to use these modifications.

Fixes #14666

Signed-off-by: Randall S. Becker <rsbecker@nexbridge.com>
