### PR TITLE
RSA-PSS: When printing parameters, always print the trailerfield ASN.1 value

### DIFF
--- a/crypto/rsa/rsa_ameth.c
+++ b/crypto/rsa/rsa_ameth.c
@@ -280,7 +280,7 @@ static int rsa_pss_param_print(BIO *bp, int pss_key, RSA_PSS_PARAMS *pss,
     if (pss->trailerField) {
         if (i2a_ASN1_INTEGER(bp, pss->trailerField) <= 0)
             goto err;
-    } else if (BIO_puts(bp, "BC (default)") <= 0) {
+    } else if (BIO_puts(bp, "01 (default)") <= 0) {
         goto err;
     }
     BIO_puts(bp, "\n");

--- a/providers/implementations/encode_decode/encode_key2text.c
+++ b/providers/implementations/encode_decode/encode_key2text.c
@@ -764,13 +764,6 @@ static int rsa_to_text(BIO *out, const void *key, int selection)
                                saltlen,
                                (saltlen == 20 ? " (default)" : "")) <= 0)
                     goto err;
-                /*
-                 * TODO(3.0) Should we show the ASN.1 trailerField value, or
-                 * the actual trailerfield byte (i.e. 0xBC for 1)?
-                 * crypto/rsa/rsa_ameth.c isn't very clear on that, as it
-                 * does display 0xBC when the default applies, but the ASN.1
-                 * trailerField value otherwise...
-                 */
                 if (BIO_printf(out, "  Trailer Field: 0x%x%s\n",
                                trailerfield,
                                (trailerfield == 1 ? " (default)" : "")) <= 0)


### PR DESCRIPTION
The legacy implementation would print the ASN.1 value of the trailerfield,
except when it wasn't set (i.e. is default).

For better consistency, we now always print the ASN.1 value, both in the
legacy and the provided implementation.

Fixes #14363
