### PR TITLE
HTTP: Rename OSSL_HTTP_REQ_CTX_i2d() 

### DIFF
--- a/crypto/http/http_client.c
+++ b/crypto/http/http_client.c
@@ -247,8 +247,8 @@ BIO *ossl_http_asn1_item2bio(const ASN1_ITEM *it, const ASN1_VALUE *val)
     return res;
 }
 
-int OSSL_HTTP_REQ_CTX_i2d(OSSL_HTTP_REQ_CTX *rctx, const char *content_type,
-                          const ASN1_ITEM *it, ASN1_VALUE *req)
+int OSSL_HTTP_REQ_CTX_set1_req(OSSL_HTTP_REQ_CTX *rctx, const char *content_type,
+                               const ASN1_ITEM *it, ASN1_VALUE *req)
 {
     BIO *mem;
     int res;

--- a/crypto/ocsp/ocsp_http.c
+++ b/crypto/ocsp/ocsp_http.c
@@ -27,9 +27,10 @@ OSSL_HTTP_REQ_CTX *OCSP_sendreq_new(BIO *io, const char *path,
     if (!OSSL_HTTP_REQ_CTX_set_request_line(rctx, NULL, NULL, path))
         goto err;
 
-    if (req != NULL && !OSSL_HTTP_REQ_CTX_i2d(rctx, "application/ocsp-request",
-                                              ASN1_ITEM_rptr(OCSP_REQUEST),
-                                              (ASN1_VALUE *)req))
+    if (req != NULL
+        && !OSSL_HTTP_REQ_CTX_set1_req(rctx, "application/ocsp-request",
+                                       ASN1_ITEM_rptr(OCSP_REQUEST),
+                                       (ASN1_VALUE *)req))
         goto err;
 
     return rctx;

--- a/doc/man3/OCSP_sendreq_new.pod
+++ b/doc/man3/OCSP_sendreq_new.pod
@@ -45,7 +45,7 @@ structure using connection B<BIO> I<io>, the URL path I<path>, the OCSP
 request I<req>, and with a response header maximum line length of I<maxline>.
 If I<maxline> is zero a default value of 4k is used.
 The I<req> may be set to NULL and provided later using OCSP_REQ_CTX_set1_req()
-or L<OSSL_HTTP_REQ_CTX_i2d(3)> .
+or L<OSSL_HTTP_REQ_CTX_set1_req(3)> .
 
 The I<io> and I<path> arguments to OCSP_sendreq_new() correspond to the
 components of the URL.
@@ -65,12 +65,12 @@ for compatibility; use OCSP_sendreq_nbio() instead.
 
 OCSP_REQ_CTX_i2d(rctx, it, req) is equivalent to the following:
 
-  OSSL_HTTP_REQ_CTX_i2d(rctx, "application/ocsp-request", it, req)
+  OSSL_HTTP_REQ_CTX_set1_req(rctx, "application/ocsp-request", it, req)
 
 OCSP_REQ_CTX_set1_req(rctx, req) is equivalent to the following:
 
- OSSL_HTTP_REQ_CTX_i2d(rctx, "application/ocsp-request",
-                       ASN1_ITEM_rptr(OCSP_REQUEST), (ASN1_VALUE *)req)
+ OSSL_HTTP_REQ_CTX_set1_req(rctx, "application/ocsp-request",
+                            ASN1_ITEM_rptr(OCSP_REQUEST), (ASN1_VALUE *)req)
 
 The other deprecated type and functions have been superseded by the
 following equivalents:

--- a/doc/man3/OSSL_HTTP_REQ_CTX.pod
+++ b/doc/man3/OSSL_HTTP_REQ_CTX.pod
@@ -7,7 +7,7 @@ OSSL_HTTP_REQ_CTX_new,
 OSSL_HTTP_REQ_CTX_free,
 OSSL_HTTP_REQ_CTX_set_request_line,
 OSSL_HTTP_REQ_CTX_add1_header,
-OSSL_HTTP_REQ_CTX_i2d,
+OSSL_HTTP_REQ_CTX_set1_req,
 OSSL_HTTP_REQ_CTX_nbio,
 OSSL_HTTP_REQ_CTX_sendreq_d2i,
 OSSL_HTTP_REQ_CTX_get0_mem_bio,
@@ -34,8 +34,8 @@ OSSL_HTTP_REQ_CTX_set_max_response_length
  int OSSL_HTTP_REQ_CTX_add1_header(OSSL_HTTP_REQ_CTX *rctx,
                                    const char *name, const char *value);
 
- int OSSL_HTTP_REQ_CTX_i2d(OSSL_HTTP_REQ_CTX *rctx, const char *content_type,
-                           const ASN1_ITEM *it, ASN1_VALUE *req);
+ int OSSL_HTTP_REQ_CTX_set1_req(OSSL_HTTP_REQ_CTX *rctx, const char *content_type,
+                                const ASN1_ITEM *it, ASN1_VALUE *req);
  int OSSL_HTTP_REQ_CTX_nbio(OSSL_HTTP_REQ_CTX *rctx);
  ASN1_VALUE *OSSL_HTTP_REQ_CTX_sendreq_d2i(OSSL_HTTP_REQ_CTX *rctx,
                                            const ASN1_ITEM *it);
@@ -90,7 +90,7 @@ For example, to add a C<Host> header for C<example.com> you would call:
 
  OSSL_HTTP_REQ_CTX_add1_header(ctx, "Host", "example.com");
 
-OSSL_HTTP_REQ_CTX_i2d() finalizes the HTTP request context by adding
+OSSL_HTTP_REQ_CTX_set1_req() finalizes the HTTP request context by adding
 the DER encoding of I<req>, using the ASN.1 template I<it> to do the encoding.
 The HTTP header C<Content-Length> is automatically filled out, and if
 I<content_type> isn't NULL, the HTTP header C<Content-Type> is also added with
@@ -149,7 +149,7 @@ This is optional and may be done multiple times with different names.
 
 =item 3.
 
-Add C<POST> data with OSSL_HTTP_REQ_CTX_i2d().  This may only be done if
+Add C<POST> data with OSSL_HTTP_REQ_CTX_set1_req().  This may only be done if
 I<method_POST> was 1 in the OSSL_HTTP_REQ_CTX_new() call, and must be done
 exactly once in that case.
 
@@ -167,8 +167,8 @@ OSSL_HTTP_REQ_CTX_free() and OSSL_HTTP_REQ_CTX_set_max_response_length()
 do not return values.
 
 OSSL_HTTP_REQ_CTX_set_request_line(), OSSL_HTTP_REQ_CTX_add1_header(),
-OSSL_HTTP_REQ_CTX_i2d() and OSSL_HTTP_REQ_CTX_nbio return 1 for success and 0
-for failure.
+OSSL_HTTP_REQ_CTX_set1_req() and OSSL_HTTP_REQ_CTX_nbio
+return 1 for success and 0 for failure.
 
 OSSL_HTTP_REQ_CTX_sendreq_d2i() returns a pointer to an B<ASN1_VALUE> for
 success and NULL for failure.

--- a/include/openssl/http.h
+++ b/include/openssl/http.h
@@ -49,8 +49,8 @@ int OSSL_HTTP_REQ_CTX_set_request_line(OSSL_HTTP_REQ_CTX *rctx,
                                        const char *path);
 int OSSL_HTTP_REQ_CTX_add1_header(OSSL_HTTP_REQ_CTX *rctx,
                                   const char *name, const char *value);
-int OSSL_HTTP_REQ_CTX_i2d(OSSL_HTTP_REQ_CTX *rctx, const char *content_type,
-                          const ASN1_ITEM *it, ASN1_VALUE *req);
+int OSSL_HTTP_REQ_CTX_set1_req(OSSL_HTTP_REQ_CTX *rctx, const char *content_type,
+                               const ASN1_ITEM *it, ASN1_VALUE *req);
 int OSSL_HTTP_REQ_CTX_nbio(OSSL_HTTP_REQ_CTX *rctx);
 ASN1_VALUE *OSSL_HTTP_REQ_CTX_sendreq_d2i(OSSL_HTTP_REQ_CTX *rctx,
                                           const ASN1_ITEM *it);

--- a/include/openssl/ocsp.h.in
+++ b/include/openssl/ocsp.h.in
@@ -186,7 +186,7 @@ typedef OSSL_HTTP_REQ_CTX OCSP_REQ_CTX;
 #   define OCSP_REQ_CTX_add1_header(r, n, v) \
         OSSL_HTTP_REQ_CTX_add1_header(r, n, v)
 #   define OCSP_REQ_CTX_i2d(r, i, req) \
-        OSSL_HTTP_REQ_CTX_i2d(r, "application/ocsp-request", i, req)
+        OSSL_HTTP_REQ_CTX_set1_req(r, "application/ocsp-request", i, req)
 #   define OCSP_REQ_CTX_nbio(r) \
         OSSL_HTTP_REQ_CTX_nbio(r)
 #   define OCSP_REQ_CTX_nbio_d2i(r, p, i)        \

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -1577,7 +1577,7 @@ BIO_ADDRINFO_address                    1613	3_0_0	EXIST::FUNCTION:SOCK
 ASN1_STRING_print_ex                    1614	3_0_0	EXIST::FUNCTION:
 i2d_CMS_ReceiptRequest                  1615	3_0_0	EXIST::FUNCTION:CMS
 d2i_TS_REQ_fp                           1616	3_0_0	EXIST::FUNCTION:STDIO,TS
-OSSL_HTTP_REQ_CTX_i2d                   1617	3_0_0	EXIST::FUNCTION:
+OSSL_HTTP_REQ_CTX_set1_req              1617	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_get_default_digest_nid         1618	3_0_0	EXIST::FUNCTION:
 ASIdOrRange_new                         1619	3_0_0	EXIST::FUNCTION:RFC3779
 ASN1_SCTX_new                           1620	3_0_0	EXIST::FUNCTION:


### PR DESCRIPTION
Rename the function `OSSL_HTTP_REQ_CTX_set1_req()`,
which easier to understand and actually more to the point.

This PR has been carved out from #14630 for alleviating reviews,
making this PR trivial.

