### PR TITLE
Disable cmp_http test on AIX

### DIFF
--- a/test/recipes/80-test_cmp_http.t
+++ b/test/recipes/80-test_cmp_http.t
@@ -29,8 +29,8 @@ plan skip_all => "These tests are not supported in a no-cmp build"
 plan skip_all => "These tests are not supported in a no-ec build"
     if disabled("ec");
 
-plan skip_all => "Tests involving local HTTP server not available on Windows or VMS"
-    if $^O =~ /^(VMS|MSWin32)$/;
+plan skip_all => "Tests involving local HTTP server not available on Windows, AIX or VMS"
+    if $^O =~ /^(VMS|MSWin32|AIX)$/;
 plan skip_all => "Tests involving local HTTP server not available in cross-compile builds"
     if defined $ENV{EXE_SHELL};
 plan skip_all => "Tests involving local HTTP server require 'kill' command"


### PR DESCRIPTION
AIX has permission problems of the form:

lsof: can't open /dev/mem: Permission denied
lsof: can't open /dev/kmem: Permission denied

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
