### PR TITLE
Fix Build issue on Oracle Linux x64

### DIFF
--- a/include/crypto/ecx.h
+++ b/include/crypto/ecx.h
@@ -76,8 +76,6 @@ struct ecx_key_st {
     CRYPTO_RWLOCK *lock;
 };
 
-typedef struct ecx_key_st ECX_KEY;
-
 size_t ossl_ecx_key_length(ECX_KEY_TYPE type);
 ECX_KEY *ossl_ecx_key_new(OSSL_LIB_CTX *libctx, ECX_KEY_TYPE type,
                           int haspubkey, const char *propq);


### PR DESCRIPTION
````typedef struct ecx_key_st ECX_KEY```` was defined multiple times.
It is defined inside include/crypto/types.h which is included from include/crypto/ecx.h.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
