### PR TITLE
Fix change in behaviour of EVP_PKEY_CTRL_RSA_KEYGEN_BITS

### DIFF
--- a/crypto/rsa/rsa_local.h
+++ b/crypto/rsa/rsa_local.h
@@ -14,7 +14,6 @@
 #include "crypto/rsa.h"
 
 #define RSA_MAX_PRIME_NUM       5
-#define RSA_MIN_MODULUS_BITS    512
 
 typedef struct rsa_prime_info_st {
     BIGNUM *r;

--- a/include/crypto/rsa.h
+++ b/include/crypto/rsa.h
@@ -16,6 +16,8 @@
 # include <openssl/x509.h>
 # include "crypto/types.h"
 
+#define RSA_MIN_MODULUS_BITS    512
+
 typedef struct rsa_pss_params_30_st {
     int hash_algorithm_nid;
     struct {

--- a/test/recipes/30-test_evp_data/evppkey_rsa.txt
+++ b/test/recipes/30-test_evp_data/evppkey_rsa.txt
@@ -614,5 +614,5 @@ Title = Test RSA keygen
 KeyGen = rsaEncryption
 Ctrl = rsa_keygen_bits:128
 KeyName = tmprsa
-Result = KEYGEN_GENERATE_ERROR
+Result = PKEY_CTRL_ERROR
 Reason = key size too small


### PR DESCRIPTION
In 1.1.1 the ctrl EVP_PKEY_CTRL_RSA_KEYGEN_BITS would fail immediately
if the number of bits was too small. In 3.0 it always succeeds, and only
fails later during the key generation stage.

We fix that so that it fails early like it used to in 1.1.1.

Note that in 1.1.1 it fails with a -2 return code. That is not the case
in 3.0 and has not been addressed here (see #14442)

Fixes #14443
