### PR TITLE
Remove unnecessary BIO_do_handshake()s

### DIFF
--- a/demos/bio/client-arg.c
+++ b/demos/bio/client-arg.c
@@ -94,12 +94,6 @@ int main(int argc, char **argv)
         goto end;
     }
 
-    if (BIO_do_handshake(sbio) <= 0) {
-        fprintf(stderr, "Error establishing SSL connection\n");
-        ERR_print_errors_fp(stderr);
-        goto end;
-    }
-
     /* Could examine ssl here to get connection info */
 
     BIO_puts(sbio, "GET / HTTP/1.0\n\n");

--- a/demos/bio/client-conf.c
+++ b/demos/bio/client-conf.c
@@ -102,12 +102,6 @@ int main(int argc, char **argv)
         goto end;
     }
 
-    if (BIO_do_handshake(sbio) <= 0) {
-        fprintf(stderr, "Error establishing SSL connection\n");
-        ERR_print_errors_fp(stderr);
-        goto end;
-    }
-
     /* Could examine ssl here to get connection info */
 
     BIO_puts(sbio, "GET / HTTP/1.0\n\n");

--- a/doc/man3/BIO_f_ssl.pod
+++ b/doc/man3/BIO_f_ssl.pod
@@ -188,11 +188,6 @@ unencrypted example in L<BIO_s_connect(3)>.
      ERR_print_errors_fp(stderr);
      exit(1);
  }
- if (BIO_do_handshake(sbio) <= 0) {
-     fprintf(stderr, "Error establishing SSL connection\n");
-     ERR_print_errors_fp(stderr);
-     exit(1);
- }
 
  /* XXX Could examine ssl here to get connection info */
 


### PR DESCRIPTION
Since BIO_do_connect() and BIO_do_handshake() are same, no need to invoke BIO_do_handshake() once more after BIO_do_connect().

##### Checklist
- [x] documentation is added or updated
- [ ] tests are added or updated
