### PR TITLE
Android config targets: don't include the SO version in the shlib file name

### DIFF
--- a/Configurations/15-android.conf
+++ b/Configurations/15-android.conf
@@ -191,6 +191,7 @@ my %targets = (
         bin_cflags       => "-fPIE",
         bin_lflags       => "-pie",
         enable           => [ ],
+        shared_extension => ".so",
     },
     "android-arm" => {
         ################################################################


### PR DESCRIPTION
Reports say that the Android platform(s) don't have the SO version
number in the shared library file name.  Reportedly, Android package
managers do complain that our shared libraries do include the SO
version number.  That's easy enough to fix.

Fixes #14711
