### PR TITLE
Added guarding #ifndef/#define to avoid duplicate include of crypto/types.h

### DIFF
--- a/include/crypto/types.h
+++ b/include/crypto/types.h
@@ -9,15 +9,21 @@
 
 /* When removal is simulated, we still need the type internally */
 
-#ifdef OPENSSL_NO_DEPRECATED_3_0
+#ifndef OSSL_CRYPTO_TYPES_H
+# define OSSL_CRYPTO_TYPES_H
+# pragma once
+
+# ifdef OPENSSL_NO_DEPRECATED_3_0
 typedef struct rsa_st RSA;
 typedef struct rsa_meth_st RSA_METHOD;
-# ifndef OPENSSL_NO_EC
+#  ifndef OPENSSL_NO_EC
 typedef struct ec_key_st EC_KEY;
 typedef struct ec_key_method_st EC_KEY_METHOD;
+#  endif
 # endif
-#endif
 
-#ifndef OPENSSL_NO_EC
+# ifndef OPENSSL_NO_EC
 typedef struct ecx_key_st ECX_KEY;
+# endif
+
 #endif


### PR DESCRIPTION
Fixes #14730

CLA: The author has the permission to grant the OpenSSL Team the right to use this change.

Signed-off-by: Randall S. Becker <rsbecker@nexbridge.com>
