### PR TITLE
Corrected missing definitions from NonStop SPT build.

### DIFF
--- a/Configurations/50-nonstop.conf
+++ b/Configurations/50-nonstop.conf
@@ -168,13 +168,13 @@
     'nonstop-model-put' => {
         template         => 1,
         defines          => ['_PUT_MODEL_',
-                             '_REENTRANT', '_ENABLE_FLOSS_THREADS'],
+                             '_REENTRANT', '_THREAD_SUPPORT_FUNCTIONS'],
         ex_libs          => '-lput',
     },
     'nonstop-model-spt' => {
         template         => 1,
         defines          => ['_SPT_MODEL_',
-                             '_REENTRANT', '_THREAD_SUPPORT_FUNCTIONS'],
+                             '_REENTRANT', '_ENABLE_FLOSS_THREADS'],
         ex_libs          => '-lspt',
     },
 

--- a/crypto/conf/conf_def.c
+++ b/crypto/conf/conf_def.c
@@ -13,6 +13,8 @@
 #include <string.h>
 #ifdef __TANDEM
 # include <strings.h> /* strcasecmp */
+# include <sys/types.h> /* needed for stat.h */
+# include <sys/stat.h> /* struct stat */
 #endif
 #include "internal/cryptlib.h"
 #include "internal/o_dir.h"

--- a/crypto/rand/randfile.c
+++ b/crypto/rand/randfile.c
@@ -7,6 +7,15 @@
  * https://www.openssl.org/source/license.html
  */
 
+#if defined (__TANDEM) && defined (_SPT_MODEL_)
+/*
+ * These definitions have to come first in SPT due to scoping of the
+ * declarations in c99 associated with SPT use of stat.
+ */
+# include <sys/types.h>
+# include <sys/stat.h>
+#endif
+
 #include "internal/cryptlib.h"
 
 #include <errno.h>

--- a/crypto/ui/ui_openssl.c
+++ b/crypto/ui/ui_openssl.c
@@ -127,7 +127,7 @@
 #  define TTY_set(tty,data)      ioctl(tty,TIOCSETP,data)
 # endif
 
-# if !defined(_LIBC) && !defined(OPENSSL_SYS_MSDOS) && !defined(OPENSSL_SYS_VMS)
+# if !defined(_LIBC) && !defined(OPENSSL_SYS_MSDOS) && !defined(OPENSSL_SYS_VMS) && ! (defined(OPENSSL_SYS_TANDEM) && defined(_SPT_MODEL_))
 #  include <sys/ioctl.h>
 # endif
 

--- a/crypto/x509/by_dir.c
+++ b/crypto/x509/by_dir.c
@@ -7,6 +7,15 @@
  * https://www.openssl.org/source/license.html
  */
 
+#if defined (__TANDEM) && defined (_SPT_MODEL_)
+  /*
+   * These definitions have to come first in SPT due to scoping of the
+   * declarations in c99 associated with SPT use of stat.
+   */
+# include <sys/types.h>
+# include <sys/stat.h>
+#endif
+
 #include "e_os.h"
 #include "internal/cryptlib.h"
 #include <stdio.h>

--- a/e_os.h
+++ b/e_os.h
@@ -297,7 +297,7 @@ struct servent *getservbyname(const char *name, const char *proto);
 
 /* ----------------------------- HP NonStop -------------------------------- */
 /* Required to support platform variant without getpid() and pid_t. */
-# ifdef __TANDEM
+# if defined(__TANDEM) && defined(_GUARDIAN_TARGET)
 #  include <strings.h>
 #  include <netdb.h>
 #  define getservbyname(name,proto)          getservbyname((char*)name,proto)

--- a/include/internal/cryptlib.h
+++ b/include/internal/cryptlib.h
@@ -217,10 +217,18 @@ static ossl_inline void ossl_sleep(unsigned long millis)
     ts.tv_sec = (long int) (millis / 1000);
     ts.tv_nsec = (long int) (millis % 1000) * 1000000ul;
     nanosleep(&ts, NULL);
-# elif defined(__TANDEM) && !defined(_REENTRANT)
-#  include <cextdecs.h(PROCESS_DELAY_)>
+# elif defined(__TANDEM)
+#  if !defined(_REENTRANT)
+#   include <cextdecs.h(PROCESS_DELAY_)>
     /* HPNS does not support usleep for non threaded apps */
     PROCESS_DELAY_(millis * 1000);
+#  elif defined(_SPT_MODEL_)
+#   include <spthread.h>
+#   include <spt_extensions.h>
+    usleep(millis * 1000);
+#  else
+    usleep(millis * 1000);
+#  endif
 # else
     usleep(millis * 1000);
 # endif

--- a/ssl/ssl_sess.c
+++ b/ssl/ssl_sess.c
@@ -8,6 +8,10 @@
  * https://www.openssl.org/source/license.html
  */
 
+#if defined(__TANDEM) && defined(_SPT_MODEL_)
+# include <spthread.h>
+# include <spt_extensions.h> /* timeval */
+#endif
 #include <stdio.h>
 #include <openssl/rand.h>
 #include <openssl/engine.h>

--- a/ssl/statem/extensions.c
+++ b/ssl/statem/extensions.c
@@ -7,6 +7,11 @@
  * https://www.openssl.org/source/license.html
  */
 
+#if defined(__TANDEM) && defined(_SPT_MODEL_)
+# include <spthread.h>
+# include <spt_extensions.h> /* timeval */
+#endif
+
 #include <string.h>
 #include "internal/nelem.h"
 #include "internal/cryptlib.h"

--- a/ssl/statem/statem.c
+++ b/ssl/statem/statem.c
@@ -7,6 +7,11 @@
  * https://www.openssl.org/source/license.html
  */
 
+#if defined(__TANDEM) && defined(_SPT_MODEL_)
+# include <spthread.h>
+# include <spt_extensions.h> /* timeval */
+#endif
+
 #include "internal/cryptlib.h"
 #include <openssl/rand.h>
 #include "../ssl_local.h"


### PR DESCRIPTION
This change includes swapping the PUT and SPT configuration,
includes of sys/stat.h and sys/types.h in the correct scope
to be picked up by SPT definitions.

Fixes: #14698
Fixes: #14734

CLA: The author has the permission to grant the OpenSSL Team the right to use th
is change.

Signed-off-by: Randall S. Becker <rsbecker@nexbridge.com>
