### PR TITLE
Remove unnecessary setting SSL_MODE_AUTO_RETRY

### DIFF
--- a/apps/cmp.c
+++ b/apps/cmp.c
@@ -1191,8 +1191,6 @@ static SSL_CTX *setup_ssl_ctx(OSSL_CMP_CTX *ctx, ENGINE *engine)
     if (ssl_ctx == NULL)
         return NULL;
 
-    SSL_CTX_set_mode(ssl_ctx, SSL_MODE_AUTO_RETRY);
-
     if (opt_tls_trusted != NULL) {
         trust_store = load_certstore(opt_tls_trusted, opt_otherpass,
                                      "trusted TLS certificates", vpm);

--- a/apps/ocsp.c
+++ b/apps/ocsp.c
@@ -1202,7 +1202,6 @@ OCSP_RESPONSE *process_responder(OCSP_REQUEST *req,
             BIO_printf(bio_err, "Error creating SSL context.\n");
             goto end;
         }
-        SSL_CTX_set_mode(ctx, SSL_MODE_AUTO_RETRY);
     }
 
     resp = (OCSP_RESPONSE *)

--- a/apps/s_time.c
+++ b/apps/s_time.c
@@ -246,7 +246,6 @@ int s_time_main(int argc, char **argv)
     if ((ctx = SSL_CTX_new(meth)) == NULL)
         goto end;
 
-    SSL_CTX_set_mode(ctx, SSL_MODE_AUTO_RETRY);
     SSL_CTX_set_quiet_shutdown(ctx, 1);
     if (SSL_CTX_set_min_proto_version(ctx, min_version) == 0)
         goto end;

--- a/demos/bio/client-arg.c
+++ b/demos/bio/client-arg.c
@@ -80,9 +80,6 @@ int main(int argc, char **argv)
         goto end;
     }
 
-    /* Don't want any retries */
-    SSL_set_mode(ssl, SSL_MODE_AUTO_RETRY);
-
     /* We might want to do other things with ssl here */
 
     BIO_set_conn_hostname(sbio, connect_str);

--- a/demos/bio/client-conf.c
+++ b/demos/bio/client-conf.c
@@ -88,9 +88,6 @@ int main(int argc, char **argv)
         goto end;
     }
 
-    /* Don't want any retries */
-    SSL_set_mode(ssl, SSL_MODE_AUTO_RETRY);
-
     /* We might want to do other things with ssl here */
 
     BIO_set_conn_hostname(sbio, connect_str);

--- a/doc/man3/BIO_f_ssl.pod
+++ b/doc/man3/BIO_f_ssl.pod
@@ -174,9 +174,6 @@ unencrypted example in L<BIO_s_connect(3)>.
      exit(1);
  }
 
- /* Don't want any retries */
- SSL_set_mode(ssl, SSL_MODE_AUTO_RETRY);
-
  /* XXX We might want to do other things with ssl here */
 
  /* An empty host part means the loopback address */
@@ -239,7 +236,6 @@ a client and also echoes the request to standard output.
      exit(1);
  }
 
- SSL_set_mode(ssl, SSL_MODE_AUTO_RETRY);
  bbio = BIO_new(BIO_f_buffer());
  sbio = BIO_push(bbio, sbio);
  acpt = BIO_new_accept("4433");


### PR DESCRIPTION
Since SSL_MODE_AUTO_RETRY is enabled by default, no need to set it explicitly.

##### Checklist
- [x] documentation is added or updated
