### PR TITLE
Add "save-parameters" encoder parameter

### DIFF
--- a/crypto/encode_decode/encoder_pkey.c
+++ b/crypto/encode_decode/encoder_pkey.c
@@ -327,6 +327,14 @@ OSSL_ENCODER_CTX *OSSL_ENCODER_CTX_new_for_pkey(const EVP_PKEY *pkey,
         && OSSL_ENCODER_CTX_set_selection(ctx, selection)
         && ossl_encoder_ctx_setup_for_pkey(ctx, pkey, selection, propquery)
         && OSSL_ENCODER_CTX_add_extra(ctx, libctx, propquery)) {
+        OSSL_PARAM params[2] = { OSSL_PARAM_END, OSSL_PARAM_END };
+        int save_parameters = pkey->save_parameters;
+
+        params[0] = OSSL_PARAM_construct_int(OSSL_ENCODER_PARAM_SAVE_PARAMETERS,
+                                             &save_parameters);
+        /* ignoring error as this is only auxiliary parameter */
+        (void)OSSL_ENCODER_CTX_set_params(ctx, params);
+
         OSSL_TRACE_BEGIN(ENCODER) {
             BIO_printf(trc_out, "(ctx %p) Got %d encoders\n",
                        (void *)ctx, OSSL_ENCODER_CTX_get_num_encoders(ctx));

--- a/doc/man7/provider-encoder.pod
+++ b/doc/man7/provider-encoder.pod
@@ -303,6 +303,11 @@ However, it is recommended that implementations that do not handle
 property strings return an error on receiving this parameter unless
 its value NULL or the empty string.
 
+=item "save-parameters" (B<OSSL_ENCODER_PARAM_SAVE_PARAMETERS>) <integer>
+
+If set to 0 disables saving of key domain parameters. Default is 1.
+It currently has an effect only on DSA keys.
+
 =back
 
 Parameters currently recognised by the built-in pass phrase callback:

--- a/include/openssl/core_names.h
+++ b/include/openssl/core_names.h
@@ -473,6 +473,7 @@ extern "C" {
 #define OSSL_ENCODER_PARAM_OUTPUT_STRUCTURE "output-structure"
 /* Currently PVK only, but reusable for others as needed */
 #define OSSL_ENCODER_PARAM_ENCRYPT_LEVEL    "encrypt-level"
+#define OSSL_ENCODER_PARAM_SAVE_PARAMETERS  "save-parameters" /* integer */
 
 #define OSSL_DECODER_PARAM_PROPERTIES       OSSL_ALG_PARAM_PROPERTIES
 #define OSSL_DECODER_PARAM_INPUT_TYPE       "input-type"


### PR DESCRIPTION
The parameter makes the dsa key encoder to skip saving the DSA
key parameters similarly to what the legacy dsa key encoder did.

Fixes #14362

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
