### PR TITLE
Documentation fix for openssl-verify certificates

### DIFF
--- a/doc/man1/openssl-verify.pod.in
+++ b/doc/man1/openssl-verify.pod.in
@@ -99,9 +99,9 @@ with a B<->.
 
 =item I<certificate> ...
 
-One or more target certificates to verify. If no certificates are given,
-this command will attempt to read a certificate from standard input.
-If a certificate chain has multiple problems, this program attempts to
+One or more target certificates to verify, one per file. If no certificates are
+given, this command will attempt to read a single certificate from standard
+input. If a certificate chain has multiple problems, this program attempts to
 display all of them.
 
 =back

--- a/doc/man1/openssl-verify.pod.in
+++ b/doc/man1/openssl-verify.pod.in
@@ -27,7 +27,8 @@ B<openssl> B<verify>
 
 =head1 DESCRIPTION
 
-This command verifies certificate chains.
+This command verifies certificate chains. If a certificate chain has multiple
+problems, this program attempts to display all of them.
 
 =head1 OPTIONS
 
@@ -101,8 +102,7 @@ with a B<->.
 
 One or more target certificates to verify, one per file. If no certificates are
 given, this command will attempt to read a single certificate from standard
-input. If a certificate chain has multiple problems, this program attempts to
-display all of them.
+input.
 
 =back
 


### PR DESCRIPTION
`openssl verify` silently ignores any but the first certificate in the
`certificates` argument.

See #14675

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
