### PR TITLE
Enable ktls

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -695,7 +695,7 @@ my %targets = (
         shared_target    => "linux-shared",
         shared_cflag     => "-fPIC",
         shared_ldflag    => sub { $disabled{pinshared} ? () : "-Wl,-znodelete" },
-        enable           => [ "afalgeng" ],
+        enable           => [ "afalgeng", "ktls" ],
     },
     "linux-generic64" => {
         inherit_from     => [ "linux-generic32" ],

--- a/Configure
+++ b/Configure
@@ -1687,7 +1687,7 @@ unless ($disabled{devcryptoeng}) {
 
 unless ($disabled{ktls}) {
     $config{ktls}="";
-    if ($target =~ m/^linux/) {
+    if (grep { $_ eq 'afalgeng' } @{$target{enable}}) {
         my $usr = "/usr/$config{cross_compile_prefix}";
         chop($usr);
         if ($config{cross_compile_prefix} eq "") {

--- a/include/internal/ktls.h
+++ b/include/internal/ktls.h
@@ -262,7 +262,7 @@ struct tls_crypto_info_all {
 #   ifdef OPENSSL_KTLS_CHACHA20_POLY1305
         struct tls12_crypto_info_chacha20_poly1305 chacha20poly1305;
 #   endif
-    };
+    } u;
     size_t tls_crypto_info_len;
 };
 

--- a/ssl/ktls.c
+++ b/ssl/ktls.c
@@ -137,12 +137,15 @@ int ktls_check_supported_cipher(const SSL *s, const EVP_CIPHER *c,
           return 0;
 # endif
 # ifdef OPENSSL_KTLS_AES_GCM_128
+        /* fall thru */
     case NID_aes_128_gcm:
 # endif
 # ifdef OPENSSL_KTLS_AES_GCM_256
+        /* fall thru */
     case NID_aes_256_gcm:
 # endif
 # ifdef OPENSSL_KTLS_CHACHA20_POLY1305
+        /* fall thru */
     case NID_chacha20_poly1305:
 # endif
         return 1;

--- a/ssl/ktls.c
+++ b/ssl/ktls.c
@@ -178,47 +178,47 @@ int ktls_configure_crypto(const SSL *s, const EVP_CIPHER *c, EVP_CIPHER_CTX *dd,
     {
 # ifdef OPENSSL_KTLS_AES_GCM_128
     case NID_aes_128_gcm:
-        crypto_info->gcm128.info.cipher_type = TLS_CIPHER_AES_GCM_128;
-        crypto_info->gcm128.info.version = s->version;
-        crypto_info->tls_crypto_info_len = sizeof(crypto_info->gcm128);
-        memcpy(crypto_info->gcm128.iv, iiv + EVP_GCM_TLS_FIXED_IV_LEN,
+        crypto_info->u.gcm128.info.cipher_type = TLS_CIPHER_AES_GCM_128;
+        crypto_info->u.gcm128.info.version = s->version;
+        crypto_info->tls_crypto_info_len = sizeof(crypto_info->u.gcm128);
+        memcpy(crypto_info->u.gcm128.iv, iiv + EVP_GCM_TLS_FIXED_IV_LEN,
                 TLS_CIPHER_AES_GCM_128_IV_SIZE);
-        memcpy(crypto_info->gcm128.salt, iiv, TLS_CIPHER_AES_GCM_128_SALT_SIZE);
-        memcpy(crypto_info->gcm128.key, key, EVP_CIPHER_key_length(c));
-        memcpy(crypto_info->gcm128.rec_seq, rl_sequence,
+        memcpy(crypto_info->u.gcm128.salt, iiv, TLS_CIPHER_AES_GCM_128_SALT_SIZE);
+        memcpy(crypto_info->u.gcm128.key, key, EVP_CIPHER_key_length(c));
+        memcpy(crypto_info->u.gcm128.rec_seq, rl_sequence,
                 TLS_CIPHER_AES_GCM_128_REC_SEQ_SIZE);
         if (rec_seq != NULL)
-            *rec_seq = crypto_info->gcm128.rec_seq;
+            *rec_seq = crypto_info->u.gcm128.rec_seq;
         return 1;
 # endif
 # ifdef OPENSSL_KTLS_AES_GCM_256
     case NID_aes_256_gcm:
-        crypto_info->gcm256.info.cipher_type = TLS_CIPHER_AES_GCM_256;
-        crypto_info->gcm256.info.version = s->version;
-        crypto_info->tls_crypto_info_len = sizeof(crypto_info->gcm256);
-        memcpy(crypto_info->gcm256.iv, iiv + EVP_GCM_TLS_FIXED_IV_LEN,
+        crypto_info->u.gcm256.info.cipher_type = TLS_CIPHER_AES_GCM_256;
+        crypto_info->u.gcm256.info.version = s->version;
+        crypto_info->tls_crypto_info_len = sizeof(crypto_info->u.gcm256);
+        memcpy(crypto_info->u.gcm256.iv, iiv + EVP_GCM_TLS_FIXED_IV_LEN,
                 TLS_CIPHER_AES_GCM_256_IV_SIZE);
-        memcpy(crypto_info->gcm256.salt, iiv, TLS_CIPHER_AES_GCM_256_SALT_SIZE);
-        memcpy(crypto_info->gcm256.key, key, EVP_CIPHER_key_length(c));
-        memcpy(crypto_info->gcm256.rec_seq, rl_sequence,
+        memcpy(crypto_info->u.gcm256.salt, iiv, TLS_CIPHER_AES_GCM_256_SALT_SIZE);
+        memcpy(crypto_info->u.gcm256.key, key, EVP_CIPHER_key_length(c));
+        memcpy(crypto_info->u.gcm256.rec_seq, rl_sequence,
                 TLS_CIPHER_AES_GCM_256_REC_SEQ_SIZE);
         if (rec_seq != NULL)
-            *rec_seq = crypto_info->gcm256.rec_seq;
+            *rec_seq = crypto_info->u.gcm256.rec_seq;
         return 1;
 # endif
 # ifdef OPENSSL_KTLS_AES_CCM_128
     case NID_aes_128_ccm:
-        crypto_info->ccm128.info.cipher_type = TLS_CIPHER_AES_CCM_128;
-        crypto_info->ccm128.info.version = s->version;
-        crypto_info->tls_crypto_info_len = sizeof(crypto_info->ccm128);
-        memcpy(crypto_info->ccm128.iv, iiv + EVP_CCM_TLS_FIXED_IV_LEN,
+        crypto_info->u.ccm128.info.cipher_type = TLS_CIPHER_AES_CCM_128;
+        crypto_info->u.ccm128.info.version = s->version;
+        crypto_info->tls_crypto_info_len = sizeof(crypto_info->u.ccm128);
+        memcpy(crypto_info->u.ccm128.iv, iiv + EVP_CCM_TLS_FIXED_IV_LEN,
                 TLS_CIPHER_AES_CCM_128_IV_SIZE);
-        memcpy(crypto_info->ccm128.salt, iiv, TLS_CIPHER_AES_CCM_128_SALT_SIZE);
-        memcpy(crypto_info->ccm128.key, key, EVP_CIPHER_key_length(c));
-        memcpy(crypto_info->ccm128.rec_seq, rl_sequence,
+        memcpy(crypto_info->u.ccm128.salt, iiv, TLS_CIPHER_AES_CCM_128_SALT_SIZE);
+        memcpy(crypto_info->u.ccm128.key, key, EVP_CIPHER_key_length(c));
+        memcpy(crypto_info->u.ccm128.rec_seq, rl_sequence,
                 TLS_CIPHER_AES_CCM_128_REC_SEQ_SIZE);
         if (rec_seq != NULL)
-            *rec_seq = crypto_info->ccm128.rec_seq;
+            *rec_seq = crypto_info->u.ccm128.rec_seq;
         return 1;
 # endif
 # ifdef OPENSSL_KTLS_CHACHA20_POLY1305


### PR DESCRIPTION
The last commit enables ktls on Debian build target which do not begin with linux (like debian-amd64).
The first two commits popped up in the CI due to anonymous unions and a missing fall-through statement.