### PR TITLE
Real-Time GraphViz files using pointillism.io

### DIFF
--- a/doc/life-cycles/README.md
+++ b/doc/life-cycles/README.md
@@ -16,3 +16,19 @@ Running `make` will produce a number of `.txt` and `.png` files.
 These are the rendered `.dot` files.  The `.txt` files require
 additional editing before they can be added to the manual pages in
 `internal/man7/life_cycle-*.pod`.
+
+## diagrams
+
+![cipher hosted on pointillism.io](https://pointillism.io/openssl/openssl/blob/master/doc/life-cycles/cipher.dot)
+
+![digest hosted on pointillism.io](https://pointillism.io/openssl/openssl/blob/master/doc/life-cycles/digest.dot)
+
+![kdf hosted on pointillism.io](https://pointillism.io/openssl/openssl/blob/master/doc/life-cycles/kdf.dot)
+
+![mac hosted on pointillism.io](https://pointillism.io/openssl/openssl/blob/master/doc/life-cycles/mac.dot)
+
+![pkey hosted on pointillism.io](https://pointillism.io/openssl/openssl/blob/master/doc/life-cycles/pkey.dot)
+
+![rand hosted on pointillism.io](https://pointillism.io/openssl/openssl/blob/master/doc/life-cycles/rand.dot)
+
+![cipher hosted on pointillism.io](https://pointillism.io/openssl/openssl/blob/master/doc/life-cycles/cipher.dot)


### PR DESCRIPTION
Documentation update for graphviz files.  This will render the most recent version of the dotfiles in the github README.md.  Maybe this saves you from installing graphviz at some point.

e.g.

README: https://github.com/pointillismio/openssl/tree/master/doc/life-cycles

Linked file: ![thanks for keeping us safe!](https://pointillism.io/pointillismio/openssl/blob/master/doc/life-cycles/cipher.dot)