### PR TITLE
Threading fix when populating the default library context.

### DIFF
--- a/crypto/context.c
+++ b/crypto/context.c
@@ -11,6 +11,7 @@
 #include <openssl/conf.h>
 #include "internal/thread_once.h"
 #include "internal/property.h"
+#include "internal/core.h"
 
 struct ossl_lib_ctx_onfree_list_st {
     ossl_lib_ctx_onfree_fn *fn;
@@ -38,6 +39,21 @@ struct ossl_lib_ctx_st {
     int run_once_ret[OSSL_LIB_CTX_MAX_RUN_ONCE];
     struct ossl_lib_ctx_onfree_list_st *onfreelist;
 };
+
+int ossl_lib_ctx_write_lock(OSSL_LIB_CTX *ctx)
+{
+    return CRYPTO_THREAD_write_lock(ossl_lib_ctx_get_concrete(ctx)->lock);
+}
+
+int ossl_lib_ctx_read_lock(OSSL_LIB_CTX *ctx)
+{
+    return CRYPTO_THREAD_read_lock(ossl_lib_ctx_get_concrete(ctx)->lock);
+}
+
+int ossl_lib_ctx_unlock(OSSL_LIB_CTX *ctx)
+{
+    return CRYPTO_THREAD_unlock(ossl_lib_ctx_get_concrete(ctx)->lock);
+}
 
 static int context_init(OSSL_LIB_CTX *ctx)
 {

--- a/crypto/evp/evp_fetch.c
+++ b/crypto/evp/evp_fetch.c
@@ -371,12 +371,13 @@ void *evp_generic_fetch_by_number(OSSL_LIB_CTX *libctx, int operation_id,
                                    free_method);
 }
 
-void evp_method_store_flush(OSSL_LIB_CTX *libctx)
+int evp_method_store_flush(OSSL_LIB_CTX *libctx)
 {
     OSSL_METHOD_STORE *store = get_evp_method_store(libctx);
 
     if (store != NULL)
-        ossl_method_store_flush_cache(store, 1);
+        return ossl_method_store_flush_cache(store, 1);
+    return 1;
 }
 
 static int evp_set_parsed_default_properties(OSSL_LIB_CTX *libctx,
@@ -390,7 +391,7 @@ static int evp_set_parsed_default_properties(OSSL_LIB_CTX *libctx,
         ossl_property_free(*plp);
         *plp = def_prop;
         if (store != NULL)
-            ossl_method_store_flush_cache(store, 0);
+            return ossl_method_store_flush_cache(store, 0);
         return 1;
     }
     ERR_raise(ERR_LIB_EVP, ERR_R_INTERNAL_ERROR);

--- a/crypto/property/defn_cache.c
+++ b/crypto/property/defn_cache.c
@@ -13,6 +13,7 @@
 #include <openssl/lhash.h>
 #include "internal/propertyerr.h"
 #include "internal/property.h"
+#include "internal/core.h"
 #include "property_local.h"
 
 /*
@@ -74,11 +75,12 @@ OSSL_PROPERTY_LIST *ossl_prop_defn_get(OSSL_LIB_CTX *ctx, const char *prop)
     property_defns = ossl_lib_ctx_get_data(ctx,
                                            OSSL_LIB_CTX_PROPERTY_DEFN_INDEX,
                                            &property_defns_method);
-    if (property_defns == NULL)
+    if (property_defns == NULL || !ossl_lib_ctx_read_lock(ctx))
         return NULL;
 
     elem.prop = prop;
     r = lh_PROPERTY_DEFN_ELEM_retrieve(property_defns, &elem);
+    ossl_lib_ctx_unlock(ctx);
     return r != NULL ? r->defn : NULL;
 }
 
@@ -88,6 +90,7 @@ int ossl_prop_defn_set(OSSL_LIB_CTX *ctx, const char *prop,
     PROPERTY_DEFN_ELEM elem, *old, *p = NULL;
     size_t len;
     LHASH_OF(PROPERTY_DEFN_ELEM) *property_defns;
+    int res = 1;
 
     property_defns = ossl_lib_ctx_get_data(ctx,
                                            OSSL_LIB_CTX_PROPERTY_DEFN_INDEX,
@@ -98,10 +101,12 @@ int ossl_prop_defn_set(OSSL_LIB_CTX *ctx, const char *prop,
     if (prop == NULL)
         return 1;
 
+    if (!ossl_lib_ctx_write_lock(ctx))
+        return 0;
     if (pl == NULL) {
         elem.prop = prop;
         lh_PROPERTY_DEFN_ELEM_delete(property_defns, &elem);
-        return 1;
+        goto end;
     }
     len = strlen(prop);
     p = OPENSSL_malloc(sizeof(*p) + len);
@@ -112,11 +117,14 @@ int ossl_prop_defn_set(OSSL_LIB_CTX *ctx, const char *prop,
         old = lh_PROPERTY_DEFN_ELEM_insert(property_defns, p);
         if (old != NULL) {
             property_defn_free(old);
-            return 1;
+            goto end;
         }
         if (!lh_PROPERTY_DEFN_ELEM_error(property_defns))
-            return 1;
+            goto end;
     }
     OPENSSL_free(p);
-    return 0;
+    res = 0;
+ end:
+    ossl_lib_ctx_unlock(ctx);
+    return res;
 }

--- a/crypto/property/property_local.h
+++ b/crypto/property/property_local.h
@@ -27,9 +27,3 @@ int ossl_property_has_optional(const OSSL_PROPERTY_LIST *query);
 OSSL_PROPERTY_LIST *ossl_prop_defn_get(OSSL_LIB_CTX *ctx, const char *prop);
 int ossl_prop_defn_set(OSSL_LIB_CTX *ctx, const char *prop,
                        OSSL_PROPERTY_LIST *pl);
-
-/* Property cache lock / unlock */
-int ossl_property_write_lock(OSSL_METHOD_STORE *);
-int ossl_property_read_lock(OSSL_METHOD_STORE *);
-int ossl_property_unlock(OSSL_METHOD_STORE *);
-

--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -941,7 +941,7 @@ int ossl_provider_self_test(const OSSL_PROVIDER *prov)
         return 1;
     ret = prov->self_test(prov->provctx);
     if (ret == 0)
-        evp_method_store_flush(ossl_provider_libctx(prov));
+        (void)evp_method_store_flush(ossl_provider_libctx(prov));
     return ret;
 }
 

--- a/doc/internal/man3/OSSL_METHOD_STORE.pod
+++ b/doc/internal/man3/OSSL_METHOD_STORE.pod
@@ -104,8 +104,8 @@ ossl_method_store_new() returns a new method store object or NULL on failure.
 
 ossl_method_store_free(), ossl_method_store_add(),
 ossl_method_store_remove(), ossl_method_store_fetch(),
-ossl_method_store_cache_get()
-and ossl_method_store_cache_set() return B<1> on success and B<0> on error.
+ossl_method_store_cache_get(), ossl_method_store_cache_set() and
+ossl_method_store_flush_cache() return B<1> on success and B<0> on error.
 
 ossl_method_store_free() and ossl_method_store_cleanup() do not return any value.
 

--- a/include/crypto/evp.h
+++ b/include/crypto/evp.h
@@ -868,7 +868,7 @@ int evp_pkey_ctx_get1_id_len_prov(EVP_PKEY_CTX *ctx, size_t *id_len);
 int evp_pkey_ctx_use_cached_data(EVP_PKEY_CTX *ctx);
 # endif /* !defined(FIPS_MODULE) */
 
-void evp_method_store_flush(OSSL_LIB_CTX *libctx);
+int evp_method_store_flush(OSSL_LIB_CTX *libctx);
 int evp_set_default_properties_int(OSSL_LIB_CTX *libctx, const char *propq,
                                    int loadconfig);
 

--- a/include/internal/core.h
+++ b/include/internal/core.h
@@ -60,4 +60,8 @@ void ossl_algorithm_do_all(OSSL_LIB_CTX *libctx, int operation_id,
                                        int no_store, void *data, int *result),
                            void *data);
 
+__owur int ossl_lib_ctx_write_lock(OSSL_LIB_CTX *ctx);
+__owur int ossl_lib_ctx_read_lock(OSSL_LIB_CTX *ctx);
+int ossl_lib_ctx_unlock(OSSL_LIB_CTX *ctx);
+
 #endif

--- a/include/internal/property.h
+++ b/include/internal/property.h
@@ -58,7 +58,7 @@ int ossl_method_store_cache_set(OSSL_METHOD_STORE *store, int nid,
                                 int (*method_up_ref)(void *),
                                 void (*method_destruct)(void *));
 
-void ossl_method_store_flush_cache(OSSL_METHOD_STORE *store, int all);
+__owur int ossl_method_store_flush_cache(OSSL_METHOD_STORE *store, int all);
 
 /* Merge two property queries together */
 OSSL_PROPERTY_LIST *ossl_property_merge(const OSSL_PROPERTY_LIST *a,


### PR DESCRIPTION
I'm not convinced that property definition locking is the right solution.
The test change fixes what was almost certainly a typo.

- [ ] documentation is added or updated
- [x] tests are added or updated

Fixes #14720
