### PR TITLE
Disallow ASN.1 enumerated types to be treated as strings.

### DIFF
--- a/crypto/asn1/tasn_dec.c
+++ b/crypto/asn1/tasn_dec.c
@@ -66,7 +66,7 @@ static const unsigned long tag2bit[32] = {
     /* tags  4- 7 */
     B_ASN1_OCTET_STRING, 0, 0, B_ASN1_UNKNOWN,
     /* tags  8-11 */
-    B_ASN1_UNKNOWN, B_ASN1_UNKNOWN, B_ASN1_UNKNOWN, B_ASN1_UNKNOWN,
+    B_ASN1_UNKNOWN, B_ASN1_UNKNOWN, 0, B_ASN1_UNKNOWN,
     /* tags 12-15 */
     B_ASN1_UTF8STRING, B_ASN1_UNKNOWN, B_ASN1_UNKNOWN, B_ASN1_UNKNOWN,
     /* tags 16-19 */


### PR DESCRIPTION
They are actually integers.

Problem reported by Scott McPeak <scott.g.mcpeak@gmail.com>:
```
Any structure declared to have an ASN1_PRINTABLE (CHOICE of printable
STRING types) field will accept an ENUMERATED value where the STRING
should be.  One example of such a field is the 'value' member of
X509_NAME_ENTRY.  Consequently, the following DER will be accepted as
a valid X509_NAME_ENTRY:

  unsigned char const der[] = {
    0x30, 0x09,              // SEQUENCE with 9 octets
      0x06, 0x03,              // OBJECT IDENTIFIER with 3 octets
        0x55, 0x04, 0x06,        // countryName
      0x0a, 0x02,              // ENUMERATED(!) with 2 octets
        0x55, 0x53,              // "US", except will be treated as a number
  };

After parsing, the ASN1_STRING object has the invalid tag 0x10A which
is V_ASN1_ENUMERATED|V_ASN1_NEG.  This has at least two possible
adverse consequences:

1. An application that relies on OpenSSL to validate DER input will
mistakenly accept malformed input.

2. The application is likely to proceed with processing of the parsed
data, assuming that it conforms to the usual invariants (like having
valid tag values) and that the PRINTABLE field is in fact populated
with a string.

Either could have security implications, although I am not aware of
any specific examples.

The impact also depends on where ASN1_PRINTABLE fields are.  The only
one I see in OpenSSL is the 'value' member of X509_NAME_ENTRY, but I
could be overlooking something.

I have attached a complete program demonstrating the problem.  When
run on Windows with OpenSSL 1.1.1k, it prints:

  object: countryName
  value:   len=2 type=0x13 flags=0x40 data: "US"
  object: countryName
  value:   len=2 type=0x10A flags=0x40 data: "US"
  X509_NAME_ENTRY_dup ...
  X509_NAME_ENTRY_dup failed

The cause of the bug is somewhat subtle.  asn1_item_embed_d2i() is
supposed to check that the tag of the parsed data is one of those
allowable for the MSTRING:

  /* Check tag matches bit map */
  if (!(ASN1_tag2bit(otag) & it->utype)) {
      /* If OPTIONAL, assume this is OK */
      if (opt)
          return -1;
      ASN1err(ASN1_F_ASN1_ITEM_EMBED_D2I, ASN1_R_MSTRING_WRONG_TAG);
      goto err;
  }

ASN1_tag2bit() consults the tag2bit[] table, which has B_ASN1_UNKNOWN
in entry 0xA.  B_ASN1_UNKNOWN is included in B_ASN1_PRINTABLE, which
provides the bitmap for ASN1_PRINTABLE.

I believe the bug is the tag2bit[] entry.  B_ASN1_UNKNOWN appears to
be meant for string-like types that OpenSSL does not otherwise
understand, but of course ENUMERATED is not a string and not unknown
to OpenSSL.  Its entry in this table should instead be 0, like
INTEGER.  As far as I can tell, that is the only wrong entry in that
table.

Separately, the reason V_ASN1_NEG gets added is the tag for an MSTRING
is -1, and the integer parsing code misinterprets that as having the
V_ASN1_NEG flag set, which it preserves.  The preservation is itself a
bug, which I've already reported on this list ("d2i_ASN1_INTEGER
incorrectly yields a negative integer in some object reuse cases",
sent March 26), and which is addressed by PR 14768.  With the change
in that PR added, the tag after parsing is 0xA, which is at least
valid, but of course not a STRING.
```

