### PR TITLE
Shared memory allocated check doesn't need to be locked.

### DIFF
--- a/crypto/mem_sec.c
+++ b/crypto/mem_sec.c
@@ -212,7 +212,7 @@ int CRYPTO_secure_allocated(const void *ptr)
 
     if (!secure_mem_initialized)
         return 0;
-    if (!CRYPTO_THREAD_write_lock(sec_malloc_lock))
+    if (!CRYPTO_THREAD_read_lock(sec_malloc_lock))
         return 0;
     ret = sh_allocated(ptr);
     CRYPTO_THREAD_unlock(sec_malloc_lock);

--- a/crypto/mem_sec.c
+++ b/crypto/mem_sec.c
@@ -208,15 +208,14 @@ void CRYPTO_secure_clear_free(void *ptr, size_t num,
 int CRYPTO_secure_allocated(const void *ptr)
 {
 #ifndef OPENSSL_NO_SECURE_MEMORY
-    int ret;
-
     if (!secure_mem_initialized)
         return 0;
-    if (!CRYPTO_THREAD_read_lock(sec_malloc_lock))
-        return 0;
-    ret = sh_allocated(ptr);
-    CRYPTO_THREAD_unlock(sec_malloc_lock);
-    return ret;
+    /*
+     * Only read accesses to the arena take place in sh_allocated() and this
+     * is only changed by the sh_init() and sh_done() calls which are not
+     * locked.  Hence, it is safe to make this check without a lock too.
+     */
+    return sh_allocated(ptr);
 #else
     return 0;
 #endif /* OPENSSL_NO_SECURE_MEMORY */


### PR DESCRIPTION
The check for being in secure memory is against the arena.  The arena is only ever modified by `sh_init()` and `sh_done()`.  in both cases, it is done without locking.  Thus, it is safe for the `CRYPTO_secure_allocated()` to not lock when checking if the pointer is inside this block.
