### PR TITLE
test/recipes/02-test_errstr.t: Do not test negative system error codes

### DIFF
--- a/test/recipes/02-test_errstr.t
+++ b/test/recipes/02-test_errstr.t
@@ -69,8 +69,8 @@ foreach my $errname (@Errno::EXPORT_OK) {
       # is to skip this errcode.
       skip "perl error strings and ssystem error strings for errcode 0 differ", 1
           if $errcode == 0;
-      # On some systems, there are negative error codes.  These are currently
-      # unsupported in OpenSSL error reports.
+      # On some systems (for example Hurd), there are negative error codes.
+      # These are currently unsupported in OpenSSL error reports.
       skip "negative error codes are not supported in OpenSSL", 1
           if $errcode < 0;
 

--- a/test/recipes/02-test_errstr.t
+++ b/test/recipes/02-test_errstr.t
@@ -69,6 +69,10 @@ foreach my $errname (@Errno::EXPORT_OK) {
       # is to skip this errcode.
       skip "perl error strings and ssystem error strings for errcode 0 differ", 1
           if $errcode == 0;
+      # On some systems, there are negative error codes.  These are currently
+      # unsupported in OpenSSL error reports.
+      skip "negative error codes are not supported in OpenSSL", 1
+          if $errcode < 0;
 
       &ok(match_syserr_reason($errcode));
     }


### PR DESCRIPTION
It's been deemed unlikely that these will end up in OpenSSL error
records, so we simply don't test them if they happen to be among the
error codes that perl has support for.

Fixes #14763
