### PR TITLE
crl2pkcs7 shouldn't include empty optional sets

### DIFF
--- a/apps/crl2p7.c
+++ b/apps/crl2p7.c
@@ -134,19 +134,20 @@ int crl2pkcs7_main(int argc, char **argv)
 
     if (!ASN1_INTEGER_set(p7s->version, 1))
         goto end;
-    if ((crl_stack = sk_X509_CRL_new_null()) == NULL)
-        goto end;
-    p7s->crl = crl_stack;
+
     if (crl != NULL) {
+        if ((crl_stack = sk_X509_CRL_new_null()) == NULL)
+            goto end;
+        p7s->crl = crl_stack;
         sk_X509_CRL_push(crl_stack, crl);
         crl = NULL;             /* now part of p7 for OPENSSL_freeing */
     }
 
-    if ((cert_stack = sk_X509_new_null()) == NULL)
-        goto end;
-    p7s->cert = cert_stack;
+    if (certflst != NULL) {
+        if ((cert_stack = sk_X509_new_null()) == NULL)
+            goto end;
+        p7s->cert = cert_stack;
 
-    if (certflst != NULL)
         for (i = 0; i < sk_OPENSSL_STRING_num(certflst); i++) {
             certfile = sk_OPENSSL_STRING_value(certflst, i);
             if (add_certs_from_file(cert_stack, certfile) < 0) {
@@ -155,6 +156,7 @@ int crl2pkcs7_main(int argc, char **argv)
                 goto end;
             }
         }
+    }
 
     out = bio_open_default(outfile, 'w', outformat);
     if (out == NULL)


### PR DESCRIPTION
If using crl2pkcs7 -nocrl and with no -certfiles, we shouldn't include
the implicitly tagged [0] certs and [1] crls sets as they are marked
optional and would be empty.

I believe if one uses the PKCS7_add_certificate() and PKCS7_add_crl() API functions, the behaviour is correct, and the certs and crls stacks are only created if they are needed.  However, apps/crl2p7.c doesn't, and it was explicitly creating both stacks in all cases, even when they wouldn't be filled.  This leads to implicitly tagged optional structures with no content in the DER encoding, which is debatably wrong and causing a crash in a (someone else's) p7 parser when chasing AIA links during path validation.