### PR TITLE
Add OSSL_PARAM_dup() and OSSL_PARAM_merge()

### DIFF
--- a/apps/dhparam.c
+++ b/apps/dhparam.c
@@ -396,7 +396,7 @@ static EVP_PKEY *dsa_to_dh(EVP_PKEY *dh)
 
  err:
     EVP_PKEY_CTX_free(ctx);
-    OSSL_PARAM_BLD_free_params(params);
+    OSSL_PARAM_free(params);
     OSSL_PARAM_BLD_free(tmpl);
     BN_free(bn_p);
     BN_free(bn_q);

--- a/apps/testdsa.h
+++ b/apps/testdsa.h
@@ -267,7 +267,7 @@ EVP_PKEY *get_dsa(int dsa_bits)
                              params) <= 0)
         pkey = NULL;
 err:
-    OSSL_PARAM_BLD_free_params(params);
+    OSSL_PARAM_free(params);
     OSSL_PARAM_BLD_free(tmpl);
     BN_free(priv_key);
     BN_free(pub_key);

--- a/crypto/build.info
+++ b/crypto/build.info
@@ -95,7 +95,7 @@ $UTIL_COMMON=\
         cryptlib.c params.c params_from_text.c bsearch.c ex_data.c o_str.c \
         threads_pthread.c threads_win.c threads_none.c initthread.c \
         context.c sparse_array.c asn1_dsa.c packet.c param_build.c \
-        param_build_set.c der_writer.c passphrase.c threads_lib.c
+        param_build_set.c der_writer.c passphrase.c threads_lib.c params_dup.c
 
 SOURCE[../libcrypto]=$UTIL_COMMON \
         mem.c mem_sec.c \

--- a/crypto/dh/dh_ameth.c
+++ b/crypto/dh/dh_ameth.c
@@ -497,7 +497,7 @@ static int dh_pkey_export_to(const EVP_PKEY *from, void *to_keydata,
     /* We export, the provider imports */
     rv = evp_keymgmt_import(to_keymgmt, to_keydata, selection, params);
 
-    OSSL_PARAM_BLD_free_params(params);
+    OSSL_PARAM_free(params);
 err:
     OSSL_PARAM_BLD_free(tmpl);
     return rv;

--- a/crypto/dsa/dsa_ameth.c
+++ b/crypto/dsa/dsa_ameth.c
@@ -474,7 +474,7 @@ static int dsa_pkey_export_to(const EVP_PKEY *from, void *to_keydata,
     /* We export, the provider imports */
     rv = evp_keymgmt_import(to_keymgmt, to_keydata, selection, params);
 
-    OSSL_PARAM_BLD_free_params(params);
+    OSSL_PARAM_free(params);
  err:
     OSSL_PARAM_BLD_free(tmpl);
     return rv;

--- a/crypto/ec/ec_ameth.c
+++ b/crypto/ec/ec_ameth.c
@@ -611,7 +611,7 @@ int ec_pkey_export_to(const EVP_PKEY *from, void *to_keydata,
 
  err:
     OSSL_PARAM_BLD_free(tmpl);
-    OSSL_PARAM_BLD_free_params(params);
+    OSSL_PARAM_free(params);
     OPENSSL_free(pub_key_buf);
     OPENSSL_free(gen_buf);
     BN_CTX_end(bnctx);

--- a/crypto/ec/ecx_meth.c
+++ b/crypto/ec/ecx_meth.c
@@ -379,7 +379,7 @@ static int ecx_pkey_export_to(const EVP_PKEY *from, void *to_keydata,
 
  err:
     OSSL_PARAM_BLD_free(tmpl);
-    OSSL_PARAM_BLD_free_params(params);
+    OSSL_PARAM_free(params);
     return rv;
 }
 

--- a/crypto/param_build.c
+++ b/crypto/param_build.c
@@ -377,8 +377,3 @@ OSSL_PARAM *OSSL_PARAM_BLD_to_param(OSSL_PARAM_BLD *bld)
     free_all_params(bld);
     return params;
 }
-
-void OSSL_PARAM_BLD_free_params(OSSL_PARAM *params)
-{
-    OSSL_PARAM_free(params);
-}

--- a/crypto/params.c
+++ b/crypto/params.c
@@ -1291,4 +1291,3 @@ int OSSL_PARAM_get_octet_string_ptr(const OSSL_PARAM *p, const void **val,
     return OSSL_PARAM_get_octet_ptr(p, val, used_len)
         || get_string_ptr_internal(p, val, used_len, OSSL_PARAM_OCTET_STRING);
 }
-

--- a/crypto/params_dup.c
+++ b/crypto/params_dup.c
@@ -155,12 +155,14 @@ OSSL_PARAM *OSSL_PARAM_merge(const OSSL_PARAM *p1, const OSSL_PARAM *p2)
     size_t  list1_sz = 0, list2_sz = 0;
     int diff;
 
-    if (p1 == NULL)
+    if (p1 == NULL && p2 == NULL)
         return NULL;
 
     /* Copy p1 to list1 */
-    for (p = p1; p->key != NULL && list1_sz < OSSL_PARAM_MERGE_LIST_MAX; p++)
-        list1[list1_sz++] = p;
+    if (p1 != NULL) {
+        for (p = p1; p->key != NULL && list1_sz < OSSL_PARAM_MERGE_LIST_MAX; p++)
+            list1[list1_sz++] = p;
+    }
     list1[list1_sz] = NULL;
 
     /* copy p2 to a list2 */

--- a/crypto/params_dup.c
+++ b/crypto/params_dup.c
@@ -1,0 +1,234 @@
+/*
+ * Copyright 2021 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <string.h>
+#include <openssl/params.h>
+#include <openssl/param_build.h>
+#include "internal/param_build_set.h"
+#include "e_os.h" /* strcasecmp */
+
+#define OSSL_PARAM_ALLOCATED_END    127
+#define OSSL_PARAM_MERGE_LIST_MAX   128
+
+#define OSSL_PARAM_BUF_PUBLIC 0
+#define OSSL_PARAM_BUF_SECURE 1
+#define OSSL_PARAM_BUF_MAX    (OSSL_PARAM_BUF_SECURE + 1)
+
+typedef struct {
+    OSSL_PARAM_ALIGNED_BLOCK *alloc; /* The allocated buffer */
+    OSSL_PARAM_ALIGNED_BLOCK *cur;   /* Current position in the allocated buf */
+    size_t blocks;    /* Number of aligned blocks */
+    size_t alloc_sz;  /* The size of the allocated buffer (in bytes) */
+} OSSL_PARAM_BUF;
+
+size_t ossl_param_bytes_to_blocks(size_t bytes)
+{
+    return (bytes + OSSL_PARAM_ALIGN_SIZE - 1) / OSSL_PARAM_ALIGN_SIZE;
+}
+
+static int ossl_param_buf_alloc(OSSL_PARAM_BUF *out, size_t extra_blocks,
+                                int is_secure)
+{
+    size_t sz = OSSL_PARAM_ALIGN_SIZE * (extra_blocks + out->blocks);
+
+    out->alloc = is_secure ? OPENSSL_secure_zalloc(sz) : OPENSSL_zalloc(sz);
+    if (out->alloc == NULL) {
+        ERR_raise(ERR_LIB_CRYPTO, is_secure ? CRYPTO_R_SECURE_MALLOC_FAILURE
+                                            : ERR_R_MALLOC_FAILURE);
+        return 0;
+    }
+    out->alloc_sz = sz;
+    out->cur = out->alloc + extra_blocks;
+    return 1;
+}
+
+void ossl_param_set_secure_block(OSSL_PARAM *last, void *secure_buffer,
+                                 size_t secure_buffer_sz)
+{
+    last->key = NULL;
+    last->data_size = secure_buffer_sz;
+    last->data = secure_buffer;
+    last->data_type = OSSL_PARAM_ALLOCATED_END;
+}
+
+static OSSL_PARAM *ossl_param_dup(const OSSL_PARAM *src, OSSL_PARAM *dst,
+                                  OSSL_PARAM_BUF buf[OSSL_PARAM_BUF_MAX],
+                                  int *param_count)
+{
+    const OSSL_PARAM *in;
+    int has_dst = (dst != NULL);
+    int is_secure;
+    size_t param_sz, blks;
+
+    for (in = src; in->key != NULL; in++) {
+        is_secure = CRYPTO_secure_allocated(in->data);
+        if (has_dst) {
+            *dst = *in;
+            dst->data = buf[is_secure].cur;
+        }
+
+        if (in->data_type == OSSL_PARAM_OCTET_PTR
+            || in->data_type == OSSL_PARAM_UTF8_PTR) {
+            param_sz = sizeof(in->data);
+            if (has_dst)
+                *((const void **)dst->data) = *(const void **)in->data;
+        } else {
+            param_sz = in->data_size;
+            if (has_dst)
+                memcpy(dst->data, in->data, param_sz);
+        }
+        if (in->data_type == OSSL_PARAM_UTF8_STRING)
+            param_sz++; /* NULL terminator */
+        blks = ossl_param_bytes_to_blocks(param_sz);
+
+        if (has_dst) {
+            dst++;
+            buf[is_secure].cur += blks;
+        } else {
+            buf[is_secure].blocks += blks;
+        }
+        if (param_count != NULL)
+            ++*param_count;
+    }
+    return dst;
+}
+
+OSSL_PARAM *OSSL_PARAM_dup(const OSSL_PARAM *src)
+{
+    size_t param_blocks;
+    OSSL_PARAM_BUF buf[OSSL_PARAM_BUF_MAX];
+    OSSL_PARAM *last, *dst;
+    int param_count = 1; /* Include terminator in the count */
+
+    if (src == NULL)
+        return NULL;
+
+    memset(buf, 0, sizeof(buf));
+
+    /* First Pass: get the param_count and block sizes required */
+    (void)ossl_param_dup(src, NULL, buf, &param_count);
+
+    param_blocks = ossl_param_bytes_to_blocks(param_count * sizeof(*src));
+    /*
+     * The allocated buffer consists of an array of OSSL_PARAM followed by
+     * aligned data bytes that the array elements will point to.
+     */
+    if (!ossl_param_buf_alloc(&buf[OSSL_PARAM_BUF_PUBLIC], param_blocks, 0))
+        return NULL;
+
+    /* Allocate a secure memory buffer if required */
+    if (buf[OSSL_PARAM_BUF_SECURE].blocks > 0
+        && !ossl_param_buf_alloc(&buf[OSSL_PARAM_BUF_SECURE], 0, 1)) {
+        OPENSSL_free(buf[OSSL_PARAM_BUF_PUBLIC].alloc);
+        return NULL;
+    }
+
+    dst = (OSSL_PARAM *)buf[OSSL_PARAM_BUF_PUBLIC].alloc;
+    last = ossl_param_dup(src, dst, buf, NULL);
+    /* Store the allocated secure memory buffer in the last param block */
+    ossl_param_set_secure_block(last, buf[OSSL_PARAM_BUF_SECURE].alloc,
+                                buf[OSSL_PARAM_BUF_SECURE].alloc_sz);
+    return dst;
+}
+
+static int compare_params(const void *left, const void *right)
+{
+    const OSSL_PARAM *l = *(const OSSL_PARAM **)left;
+    const OSSL_PARAM *r = *(const OSSL_PARAM **)right;
+
+    return strcasecmp(l->key, r->key);
+}
+
+OSSL_PARAM *OSSL_PARAM_merge(const OSSL_PARAM *p1, const OSSL_PARAM *p2)
+{
+    const OSSL_PARAM *list1[OSSL_PARAM_MERGE_LIST_MAX];
+    const OSSL_PARAM *list2[OSSL_PARAM_MERGE_LIST_MAX];
+    const OSSL_PARAM *p = NULL;
+    const OSSL_PARAM **p1cur, **p2cur;
+    OSSL_PARAM *params, *dst;
+    size_t  list1_sz = 0, list2_sz = 0;
+    int diff;
+
+    if (p1 == NULL)
+        return NULL;
+
+    /* Copy p1 to list1 */
+    for (p = p1; p->key != NULL && list1_sz < OSSL_PARAM_MERGE_LIST_MAX; p++)
+        list1[list1_sz++] = p;
+    list1[list1_sz] = NULL;
+
+    /* copy p2 to a list2 */
+    if (p2 != NULL) {
+        for (p = p2; p->key != NULL && list2_sz < OSSL_PARAM_MERGE_LIST_MAX; p++)
+            list2[list2_sz++] = p;
+    }
+    list2[list2_sz] = NULL;
+    if (list1_sz == 0 && list2_sz == 0)
+        return NULL;
+
+    /* Sort the 2 lists */
+    qsort(list1, list1_sz, sizeof(OSSL_PARAM *), compare_params);
+    qsort(list2, list2_sz, sizeof(OSSL_PARAM *), compare_params);
+
+   /* Allocate enough space to store the merged parameters */
+    params = OPENSSL_zalloc((list1_sz + list2_sz + 1) * sizeof(*p1));
+    if (params == NULL) {
+        ERR_raise(ERR_LIB_CRYPTO, ERR_R_MALLOC_FAILURE);
+        return NULL;
+    }
+    dst = params;
+    p1cur = list1;
+    p2cur = list2;
+    while (1) {
+        /* If list1 is finished just tack list2 onto the end */
+        if (*p1cur == NULL) {
+            do {
+                *dst++ = **p2cur;
+                p2cur++;
+            } while (*p2cur != NULL);
+            break;
+        }
+        /* If list2 is finished just tack list1 onto the end */
+        if (*p2cur == NULL) {
+            do {
+                *dst++ = **p1cur;
+                p1cur++;
+            } while (*p1cur != NULL);
+            break;
+        }
+        /* consume the list element with the smaller key */
+        diff = strcasecmp((*p1cur)->key, (*p2cur)->key);
+        if (diff == 0) {
+            /* If the keys are the same then throw away the list1 element */
+            *dst++ = **p2cur;
+            p2cur++;
+            p1cur++;
+        } else if (diff > 0) {
+            *dst++ = **p2cur;
+            p2cur++;
+        } else {
+            *dst++ = **p1cur;
+            p1cur++;
+        }
+    }
+    return params;
+}
+
+void OSSL_PARAM_free(OSSL_PARAM *params)
+{
+    if (params != NULL) {
+        OSSL_PARAM *p;
+
+        for (p = params; p->key != NULL; p++)
+            ;
+        if (p->data_type == OSSL_PARAM_ALLOCATED_END)
+            OPENSSL_secure_clear_free(p->data, p->data_size);
+        OPENSSL_free(params);
+    }
+}

--- a/crypto/rsa/rsa_ameth.c
+++ b/crypto/rsa/rsa_ameth.c
@@ -781,7 +781,7 @@ static int rsa_int_export_to(const EVP_PKEY *from, int rsa_type,
     rv = evp_keymgmt_import(to_keymgmt, to_keydata, selection, params);
 
  err:
-    OSSL_PARAM_BLD_free_params(params);
+    OSSL_PARAM_free(params);
     OSSL_PARAM_BLD_free(tmpl);
     return rv;
 }

--- a/crypto/store/store_lib.c
+++ b/crypto/store/store_lib.c
@@ -337,7 +337,7 @@ int OSSL_STORE_find(OSSL_STORE_CTX *ctx, const OSSL_STORE_SEARCH *search)
             params = OSSL_PARAM_BLD_to_param(bld);
             ret = ctx->fetched_loader->p_set_ctx_params(ctx->loader_ctx,
                                                         params);
-            OSSL_PARAM_BLD_free_params(params);
+            OSSL_PARAM_free(params);
         }
         OSSL_PARAM_BLD_free(bld);
         OPENSSL_free(name_der);

--- a/doc/build.info
+++ b/doc/build.info
@@ -1626,6 +1626,10 @@ DEPEND[html/man3/OSSL_PARAM_allocate_from_text.html]=man3/OSSL_PARAM_allocate_fr
 GENERATE[html/man3/OSSL_PARAM_allocate_from_text.html]=man3/OSSL_PARAM_allocate_from_text.pod
 DEPEND[man/man3/OSSL_PARAM_allocate_from_text.3]=man3/OSSL_PARAM_allocate_from_text.pod
 GENERATE[man/man3/OSSL_PARAM_allocate_from_text.3]=man3/OSSL_PARAM_allocate_from_text.pod
+DEPEND[html/man3/OSSL_PARAM_dup.html]=man3/OSSL_PARAM_dup.pod
+GENERATE[html/man3/OSSL_PARAM_dup.html]=man3/OSSL_PARAM_dup.pod
+DEPEND[man/man3/OSSL_PARAM_dup.3]=man3/OSSL_PARAM_dup.pod
+GENERATE[man/man3/OSSL_PARAM_dup.3]=man3/OSSL_PARAM_dup.pod
 DEPEND[html/man3/OSSL_PARAM_int.html]=man3/OSSL_PARAM_int.pod
 GENERATE[html/man3/OSSL_PARAM_int.html]=man3/OSSL_PARAM_int.pod
 DEPEND[man/man3/OSSL_PARAM_int.3]=man3/OSSL_PARAM_int.pod
@@ -3048,6 +3052,7 @@ html/man3/OSSL_LIB_CTX.html \
 html/man3/OSSL_PARAM.html \
 html/man3/OSSL_PARAM_BLD.html \
 html/man3/OSSL_PARAM_allocate_from_text.html \
+html/man3/OSSL_PARAM_dup.html \
 html/man3/OSSL_PARAM_int.html \
 html/man3/OSSL_PROVIDER.html \
 html/man3/OSSL_SELF_TEST_new.html \
@@ -3621,6 +3626,7 @@ man/man3/OSSL_LIB_CTX.3 \
 man/man3/OSSL_PARAM.3 \
 man/man3/OSSL_PARAM_BLD.3 \
 man/man3/OSSL_PARAM_allocate_from_text.3 \
+man/man3/OSSL_PARAM_dup.3 \
 man/man3/OSSL_PARAM_int.3 \
 man/man3/OSSL_PROVIDER.3 \
 man/man3/OSSL_SELF_TEST_new.3 \

--- a/doc/man3/EVP_PKEY_fromdata.pod
+++ b/doc/man3/EVP_PKEY_fromdata.pod
@@ -198,7 +198,7 @@ TODO Write a set of cookbook documents and link to them.
 
      EVP_PKEY_free(pkey);
      EVP_PKEY_CTX_free(ctx);
-     OSSL_PARAM_BLD_free_params(params);
+     OSSL_PARAM_free(params);
      OSSL_PARAM_BLD_free(param_bld);
      BN_free(priv);
 

--- a/doc/man3/OSSL_PARAM.pod
+++ b/doc/man3/OSSL_PARAM.pod
@@ -342,7 +342,7 @@ could fill in the parameters like this:
 
 =head1 SEE ALSO
 
-L<openssl-core.h(7)>, L<OSSL_PARAM_get_int(3)>
+L<openssl-core.h(7)>, L<OSSL_PARAM_get_int(3)>, L<OSSL_PARAM_dup(3)>
 
 =head1 HISTORY
 

--- a/doc/man3/OSSL_PARAM_BLD.pod
+++ b/doc/man3/OSSL_PARAM_BLD.pod
@@ -3,7 +3,7 @@
 =head1 NAME
 
 OSSL_PARAM_BLD, OSSL_PARAM_BLD_new, OSSL_PARAM_BLD_to_param,
-OSSL_PARAM_BLD_free_params, OSSL_PARAM_BLD_free, OSSL_PARAM_BLD_push_int,
+OSSL_PARAM_BLD_free, OSSL_PARAM_BLD_push_int,
 OSSL_PARAM_BLD_push_uint, OSSL_PARAM_BLD_push_long,
 OSSL_PARAM_BLD_push_ulong, OSSL_PARAM_BLD_push_int32,
 OSSL_PARAM_BLD_push_uint32, OSSL_PARAM_BLD_push_int64,
@@ -24,7 +24,6 @@ OSSL_PARAM_BLD_push_octet_string, OSSL_PARAM_BLD_push_octet_ptr
 
  OSSL_PARAM_BLD *OSSL_PARAM_BLD_new(void);
  OSSL_PARAM *OSSL_PARAM_BLD_to_param(OSSL_PARAM_BLD *bld);
- void OSSL_PARAM_BLD_free_params(OSSL_PARAM *params);
  void OSSL_PARAM_BLD_free(OSSL_PARAM_BLD *bld);
 
  int OSSL_PARAM_BLD_push_TYPE(OSSL_PARAM_BLD *bld, const char *key, TYPE val);
@@ -58,11 +57,8 @@ OSSL_PARAM_BLD_free() deallocates the memory allocates by OSSL_PARAM_BLD_new().
 OSSL_PARAM_BLD_to_param() converts a built up OSSL_PARAM_BLD structure
 I<bld> into an allocated OSSL_PARAM array.
 The OSSL_PARAM array and all associated storage must be freed by calling
-OSSL_PARAM_BLD_free_params() with the functions return value.
+OSSL_PARAM_free() with the functions return value.
 OSSL_PARAM_BLD_free() can safely be called any time after this function is.
-
-OSSL_PARAM_BLD_free_params() deallocates the memory allocated by
-OSSL_PARAM_BLD_to_param().
 
 =begin comment
 
@@ -155,7 +151,7 @@ private key.
     OSSL_PARAM_BLD_free(bld);
     /* Use params */
     ...
-    OSSL_PARAM_BLD_free_params(params);
+    OSSL_PARAM_free(params);
 
 =head2 Example 2
 
@@ -173,11 +169,11 @@ public key.
     OSSL_PARAM_BLD_free(bld);
     /* Use params */
     ...
-    OSSL_PARAM_BLD_free_params(params);
+    OSSL_PARAM_free(params);
 
 =head1 SEE ALSO
 
-L<OSSL_PARAM_int(3)>, L<OSSL_PARAM(3)>
+L<OSSL_PARAM_int(3)>, L<OSSL_PARAM(3)>, L<OSSL_PARAM_free(3)>
 
 =head1 HISTORY
 

--- a/doc/man3/OSSL_PARAM_dup.pod
+++ b/doc/man3/OSSL_PARAM_dup.pod
@@ -1,0 +1,59 @@
+=pod
+
+=head1 NAME
+
+OSSL_PARAM_dup, OSSL_PARAM_merge, OSSL_PARAM_free
+- OSSL_PARAM array copy functions
+
+=head1 SYNOPSIS
+
+ #include <openssl/params.h>
+
+ OSSL_PARAM *OSSL_PARAM_dup(const OSSL_PARAM *params);
+ OSSL_PARAM *OSSL_PARAM_merge(const OSSL_PARAM *params, const OSSL_PARAM *params1);
+ void OSSL_PARAM_free(OSSL_PARAM *params);
+
+=head1 DESCRIPTION
+
+Algorithm parameters can be exported/imported from/to providers using arrays of
+B<OSSL_PARAM>. The following utility functions allow the parameters to be
+duplicated and merged with other B<OSSL_PARAM> to assist in this process.
+
+OSSL_PARAM_dup() duplicates the parameter array I<params>. This function does a
+deep copy of the data.
+
+OSSL_PARAM_merge() merges the parameter arrays I<params> and I<params1> into a
+new parameter array. If I<params> and I<params1> contain values with the same
+'key' then the value from I<params1> will replace the I<param> value. This
+function does a shallow copy of the parameters. If I<params1> is NULL then a
+copy of I<params> is returned. The behaviour of the merge is unpredictable if
+I<params> and I<params1> contain the same key, and there are multiple entries
+within either array that have the same key.
+
+OSSL_PARAM_free() frees the parameter array I<params> that was created using
+OSSL_PARAM_dup(), OSSL_PARAM_merge() or OSSL_PARAM_BLD_to_param().
+
+=head1 RETURN VALUES
+
+The functions OSSL_PARAM_dup() and OSSL_PARAM_merge() return a newly allocated
+B<OSSL_PARAM> array, or NULL if there was an error. If the parameter I<params>
+is NULL then NULL is returned.
+
+=head1 SEE ALSO
+
+L<OSSL_PARAM(3)>, L<OSSL_PARAM_BLD(3)>
+
+=head1 HISTORY
+
+The functions were added in OpenSSL 3.0.
+
+=head1 COPYRIGHT
+
+Copyright 2021 The OpenSSL Project Authors. All Rights Reserved.
+
+Licensed under the Apache License 2.0 (the "License").  You may not use
+this file except in compliance with the License.  You can obtain a copy
+in the file LICENSE in the source distribution or at
+L<https://www.openssl.org/source/license.html>.
+
+=cut

--- a/doc/man3/OSSL_PARAM_dup.pod
+++ b/doc/man3/OSSL_PARAM_dup.pod
@@ -25,10 +25,10 @@ deep copy of the data.
 OSSL_PARAM_merge() merges the parameter arrays I<params> and I<params1> into a
 new parameter array. If I<params> and I<params1> contain values with the same
 'key' then the value from I<params1> will replace the I<param> value. This
-function does a shallow copy of the parameters. If I<params1> is NULL then a
-copy of I<params> is returned. The behaviour of the merge is unpredictable if
-I<params> and I<params1> contain the same key, and there are multiple entries
-within either array that have the same key.
+function does a shallow copy of the parameters. Either I<params> or I<params1>
+may be NULL. The behaviour of the merge is unpredictable if I<params> and
+I<params1> contain the same key, and there are multiple entries within either
+array that have the same key.
 
 OSSL_PARAM_free() frees the parameter array I<params> that was created using
 OSSL_PARAM_dup(), OSSL_PARAM_merge() or OSSL_PARAM_BLD_to_param().
@@ -36,8 +36,8 @@ OSSL_PARAM_dup(), OSSL_PARAM_merge() or OSSL_PARAM_BLD_to_param().
 =head1 RETURN VALUES
 
 The functions OSSL_PARAM_dup() and OSSL_PARAM_merge() return a newly allocated
-B<OSSL_PARAM> array, or NULL if there was an error. If the parameter I<params>
-is NULL then NULL is returned.
+B<OSSL_PARAM> array, or NULL if there was an error. If both parameters are NULL
+ then NULL is returned.
 
 =head1 SEE ALSO
 

--- a/include/internal/param_build_set.h
+++ b/include/internal/param_build_set.h
@@ -13,6 +13,17 @@
 
 # include <openssl/safestack.h>
 # include <openssl/param_build.h>
+# include "internal/cryptlib.h"
+
+typedef union {
+    OSSL_UNION_ALIGN;
+} OSSL_PARAM_ALIGNED_BLOCK;
+
+# define OSSL_PARAM_ALIGN_SIZE  sizeof(OSSL_PARAM_ALIGNED_BLOCK)
+
+size_t ossl_param_bytes_to_blocks(size_t bytes);
+void ossl_param_set_secure_block(OSSL_PARAM *last, void *secure_buffer,
+                                 size_t secure_buffer_sz);
 
 int ossl_param_build_set_int(OSSL_PARAM_BLD *bld, OSSL_PARAM *p,
                              const char *key, int num);

--- a/include/openssl/param_build.h
+++ b/include/openssl/param_build.h
@@ -22,7 +22,6 @@ extern "C" {
 OSSL_PARAM_BLD *OSSL_PARAM_BLD_new(void);
 OSSL_PARAM *OSSL_PARAM_BLD_to_param(OSSL_PARAM_BLD *bld);
 void OSSL_PARAM_BLD_free(OSSL_PARAM_BLD *bld);
-void OSSL_PARAM_BLD_free_params(OSSL_PARAM *params);
 
 int OSSL_PARAM_BLD_push_int(OSSL_PARAM_BLD *bld, const char *key, int val);
 int OSSL_PARAM_BLD_push_uint(OSSL_PARAM_BLD *bld, const char *key,

--- a/include/openssl/params.h
+++ b/include/openssl/params.h
@@ -150,6 +150,10 @@ int OSSL_PARAM_get_octet_string_ptr(const OSSL_PARAM *p, const void **val,
 int OSSL_PARAM_modified(const OSSL_PARAM *p);
 void OSSL_PARAM_set_all_unmodified(OSSL_PARAM *p);
 
+OSSL_PARAM *OSSL_PARAM_dup(const OSSL_PARAM *p);
+OSSL_PARAM *OSSL_PARAM_merge(const OSSL_PARAM *p1, const OSSL_PARAM *p2);
+void OSSL_PARAM_free(OSSL_PARAM *p);
+
 # ifdef  __cplusplus
 }
 # endif

--- a/providers/fips/self_test_kats.c
+++ b/providers/fips/self_test_kats.c
@@ -233,7 +233,7 @@ err:
     EVP_KDF_free(kdf);
     EVP_KDF_CTX_free(ctx);
     BN_CTX_free(bnctx);
-    OSSL_PARAM_BLD_free_params(params);
+    OSSL_PARAM_free(params);
     OSSL_PARAM_BLD_free(bld);
     OSSL_SELF_TEST_onend(st, ret);
     return ret;
@@ -420,8 +420,8 @@ err:
     EVP_PKEY_free(peerkey);
     EVP_PKEY_CTX_free(kactx);
     EVP_PKEY_CTX_free(dctx);
-    OSSL_PARAM_BLD_free_params(params_peer);
-    OSSL_PARAM_BLD_free_params(params);
+    OSSL_PARAM_free(params_peer);
+    OSSL_PARAM_free(params);
     OSSL_PARAM_BLD_free(bld);
     OSSL_SELF_TEST_onend(st, ret);
     return ret;
@@ -505,8 +505,8 @@ err:
     EVP_PKEY_free(pkey);
     EVP_PKEY_CTX_free(kctx);
     EVP_PKEY_CTX_free(sctx);
-    OSSL_PARAM_BLD_free_params(params);
-    OSSL_PARAM_BLD_free_params(params_sig);
+    OSSL_PARAM_free(params);
+    OSSL_PARAM_free(params_sig);
     OSSL_PARAM_BLD_free(bld);
     OSSL_SELF_TEST_onend(st, ret);
     return ret;
@@ -591,9 +591,9 @@ err:
     EVP_PKEY_free(key);
     EVP_PKEY_CTX_free(encctx);
     EVP_PKEY_CTX_free(keyctx);
-    OSSL_PARAM_BLD_free_params(keyparams);
+    OSSL_PARAM_free(keyparams);
     OSSL_PARAM_BLD_free(keybld);
-    OSSL_PARAM_BLD_free_params(initparams);
+    OSSL_PARAM_free(initparams);
     OSSL_PARAM_BLD_free(initbld);
     OSSL_SELF_TEST_onend(st, ret);
     return ret;

--- a/providers/implementations/keymgmt/dh_kmgmt.c
+++ b/providers/implementations/keymgmt/dh_kmgmt.c
@@ -212,7 +212,7 @@ static int dh_export(void *keydata, int selection, OSSL_CALLBACK *param_cb,
         goto err;
     }
     ok = param_cb(params, cbarg);
-    OSSL_PARAM_BLD_free_params(params);
+    OSSL_PARAM_free(params);
 err:
     OSSL_PARAM_BLD_free(tmpl);
     return ok;

--- a/providers/implementations/keymgmt/dsa_kmgmt.c
+++ b/providers/implementations/keymgmt/dsa_kmgmt.c
@@ -208,7 +208,7 @@ static int dsa_export(void *keydata, int selection, OSSL_CALLBACK *param_cb,
         goto err;;
 
     ok = param_cb(params, cbarg);
-    OSSL_PARAM_BLD_free_params(params);
+    OSSL_PARAM_free(params);
 err:
     OSSL_PARAM_BLD_free(tmpl);
     return ok;

--- a/providers/implementations/keymgmt/ec_kmgmt.c
+++ b/providers/implementations/keymgmt/ec_kmgmt.c
@@ -489,7 +489,7 @@ int ec_export(void *keydata, int selection, OSSL_CALLBACK *param_cb,
     if (ok && (params = OSSL_PARAM_BLD_to_param(tmpl)) != NULL)
         ok = param_cb(params, cbarg);
 end:
-    OSSL_PARAM_BLD_free_params(params);
+    OSSL_PARAM_free(params);
     OSSL_PARAM_BLD_free(tmpl);
     OPENSSL_free(pub_key);
     OPENSSL_free(genbuf);
@@ -1158,7 +1158,7 @@ build:
 
     ret = 1;
 err:
-    OSSL_PARAM_BLD_free_params(params);
+    OSSL_PARAM_free(params);
     OSSL_PARAM_BLD_free(bld);
     return ret;
 }

--- a/providers/implementations/keymgmt/ecx_kmgmt.c
+++ b/providers/implementations/keymgmt/ecx_kmgmt.c
@@ -236,7 +236,7 @@ static int ecx_export(void *keydata, int selection, OSSL_CALLBACK *param_cb,
         goto err;
 
     ret = param_cb(params, cbarg);
-    OSSL_PARAM_BLD_free_params(params);
+    OSSL_PARAM_free(params);
 err:
     OSSL_PARAM_BLD_free(tmpl);
     return ret;

--- a/providers/implementations/keymgmt/mac_legacy_kmgmt.c
+++ b/providers/implementations/keymgmt/mac_legacy_kmgmt.c
@@ -291,7 +291,7 @@ static int mac_export(void *keydata, int selection, OSSL_CALLBACK *param_cb,
         goto err;
 
     ret = param_cb(params, cbarg);
-    OSSL_PARAM_BLD_free_params(params);
+    OSSL_PARAM_free(params);
 err:
     OSSL_PARAM_BLD_free(tmpl);
     return ret;

--- a/providers/implementations/keymgmt/rsa_kmgmt.c
+++ b/providers/implementations/keymgmt/rsa_kmgmt.c
@@ -207,7 +207,7 @@ static int rsa_export(void *keydata, int selection,
         goto err;
 
     ok = param_callback(params, cbarg);
-    OSSL_PARAM_BLD_free_params(params);
+    OSSL_PARAM_free(params);
 err:
     OSSL_PARAM_BLD_free(tmpl);
     return ok;

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -2104,7 +2104,7 @@ static int tls_process_ske_dhe(SSL *s, PACKET *pkt, EVP_PKEY **pkey)
 
  err:
     OSSL_PARAM_BLD_free(tmpl);
-    OSSL_PARAM_BLD_free_params(params);
+    OSSL_PARAM_free(params);
     EVP_PKEY_free(peer_tmp);
     EVP_PKEY_CTX_free(pctx);
     BN_free(p);

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -2916,7 +2916,7 @@ EVP_PKEY *ssl_get_auto_dh(SSL *s)
         goto err;
 
 err:
-    OSSL_PARAM_BLD_free_params(params);
+    OSSL_PARAM_free(params);
     OSSL_PARAM_BLD_free(tmpl);
     EVP_PKEY_CTX_free(pctx);
     BN_free(p);

--- a/test/acvp_test.c
+++ b/test/acvp_test.c
@@ -176,7 +176,7 @@ static int ecdsa_create_pkey(EVP_PKEY **pkey, const char *curve_name,
 
     ret = 1;
 err:
-    OSSL_PARAM_BLD_free_params(params);
+    OSSL_PARAM_free(params);
     OSSL_PARAM_BLD_free(bld);
     EVP_PKEY_CTX_free(ctx);
     return ret;
@@ -517,7 +517,7 @@ static int dsa_create_pkey(EVP_PKEY **pkey,
 
     ret = 1;
 err:
-    OSSL_PARAM_BLD_free_params(params);
+    OSSL_PARAM_free(params);
     OSSL_PARAM_BLD_free(bld);
     EVP_PKEY_CTX_free(ctx);
     return ret;
@@ -939,7 +939,7 @@ static int dh_create_pkey(EVP_PKEY **pkey, const char *group_name,
 
     ret = 1;
 err:
-    OSSL_PARAM_BLD_free_params(params);
+    OSSL_PARAM_free(params);
     OSSL_PARAM_BLD_free(bld);
     EVP_PKEY_CTX_free(ctx);
     return ret;
@@ -1062,7 +1062,7 @@ static int rsa_create_pkey(EVP_PKEY **pkey,
 
     ret = 1;
 err:
-    OSSL_PARAM_BLD_free_params(params);
+    OSSL_PARAM_free(params);
     OSSL_PARAM_BLD_free(bld);
     EVP_PKEY_CTX_free(ctx);
     return ret;
@@ -1170,7 +1170,7 @@ err:
     OPENSSL_free(d);
     EVP_PKEY_free(pkey);
     EVP_PKEY_CTX_free(ctx);
-    OSSL_PARAM_BLD_free_params(params);
+    OSSL_PARAM_free(params);
     OSSL_PARAM_BLD_free(bld);
     return ret;
 }

--- a/test/ectest.c
+++ b/test/ectest.c
@@ -2549,7 +2549,7 @@ err:
     BN_free(a_out);
     BN_free(b_out);
     BN_free(p_out);
-    OSSL_PARAM_BLD_free_params(params);
+    OSSL_PARAM_free(params);
     OSSL_PARAM_BLD_free(bld);
     EVP_PKEY_free(pkeyparam);
     EVP_PKEY_CTX_free(pctx);
@@ -2896,8 +2896,8 @@ static int custom_params_test(int id)
     BN_CTX_end(ctx);
     BN_CTX_free(ctx);
     OSSL_PARAM_BLD_free(param_bld);
-    OSSL_PARAM_BLD_free_params(params1);
-    OSSL_PARAM_BLD_free_params(params2);
+    OSSL_PARAM_free(params1);
+    OSSL_PARAM_free(params2);
     EC_POINT_free(Q1);
     EC_POINT_free(Q2);
     EC_POINT_free(G2);

--- a/test/endecode_test.c
+++ b/test/endecode_test.c
@@ -1332,13 +1332,13 @@ int setup_tests(void)
 void cleanup_tests(void)
 {
 #ifndef OPENSSL_NO_EC
-    OSSL_PARAM_BLD_free_params(ec_explicit_prime_params_nc);
-    OSSL_PARAM_BLD_free_params(ec_explicit_prime_params_explicit);
+    OSSL_PARAM_free(ec_explicit_prime_params_nc);
+    OSSL_PARAM_free(ec_explicit_prime_params_explicit);
     OSSL_PARAM_BLD_free(bld_prime_nc);
     OSSL_PARAM_BLD_free(bld_prime);
 # ifndef OPENSSL_NO_EC2M
-    OSSL_PARAM_BLD_free_params(ec_explicit_tri_params_nc);
-    OSSL_PARAM_BLD_free_params(ec_explicit_tri_params_explicit);
+    OSSL_PARAM_free(ec_explicit_tri_params_nc);
+    OSSL_PARAM_free(ec_explicit_tri_params_explicit);
     OSSL_PARAM_BLD_free(bld_tri_nc);
     OSSL_PARAM_BLD_free(bld_tri);
 # endif

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -574,7 +574,7 @@ static int test_EVP_PKEY_ffc_priv_pub(char *keytype)
 
     if (!test_fromdata(keytype, params))
         goto err;
-    OSSL_PARAM_BLD_free_params(params);
+    OSSL_PARAM_free(params);
     OSSL_PARAM_BLD_free(bld);
 
     /* Test priv and !pub */
@@ -590,7 +590,7 @@ static int test_EVP_PKEY_ffc_priv_pub(char *keytype)
 
     if (!test_fromdata(keytype, params))
         goto err;
-    OSSL_PARAM_BLD_free_params(params);
+    OSSL_PARAM_free(params);
     OSSL_PARAM_BLD_free(bld);
 
     /* Test !priv and pub */
@@ -606,7 +606,7 @@ static int test_EVP_PKEY_ffc_priv_pub(char *keytype)
 
     if (!test_fromdata(keytype, params))
         goto err;
-    OSSL_PARAM_BLD_free_params(params);
+    OSSL_PARAM_free(params);
     OSSL_PARAM_BLD_free(bld);
 
     /* Test priv and pub */
@@ -627,7 +627,7 @@ static int test_EVP_PKEY_ffc_priv_pub(char *keytype)
 
     ret = 1;
  err:
-    OSSL_PARAM_BLD_free_params(params);
+    OSSL_PARAM_free(params);
     OSSL_PARAM_BLD_free(bld);
     BN_free(p);
     BN_free(q);
@@ -683,7 +683,7 @@ static int test_EC_priv_pub(void)
 
     if (!test_fromdata("EC", params))
         goto err;
-    OSSL_PARAM_BLD_free_params(params);
+    OSSL_PARAM_free(params);
     OSSL_PARAM_BLD_free(bld);
 
     /* Test priv and !pub */
@@ -699,7 +699,7 @@ static int test_EC_priv_pub(void)
 
     if (!test_fromdata("EC", params))
         goto err;
-    OSSL_PARAM_BLD_free_params(params);
+    OSSL_PARAM_free(params);
     OSSL_PARAM_BLD_free(bld);
 
     /* Test !priv and pub */
@@ -716,7 +716,7 @@ static int test_EC_priv_pub(void)
 
     if (!test_fromdata("EC", params))
         goto err;
-    OSSL_PARAM_BLD_free_params(params);
+    OSSL_PARAM_free(params);
     OSSL_PARAM_BLD_free(bld);
 
     /* Test priv and pub */
@@ -738,7 +738,7 @@ static int test_EC_priv_pub(void)
 
     ret = 1;
  err:
-    OSSL_PARAM_BLD_free_params(params);
+    OSSL_PARAM_free(params);
     OSSL_PARAM_BLD_free(bld);
     BN_free(priv);
 
@@ -2083,7 +2083,7 @@ static int test_DSA_get_set_params(void)
  err:
     EVP_PKEY_free(pkey);
     EVP_PKEY_CTX_free(pctx);
-    OSSL_PARAM_BLD_free_params(params);
+    OSSL_PARAM_free(params);
     OSSL_PARAM_BLD_free(bld);
     BN_free(p);
     BN_free(q);
@@ -2144,7 +2144,7 @@ static int test_RSA_get_set_params(void)
  err:
     EVP_PKEY_free(pkey);
     EVP_PKEY_CTX_free(pctx);
-    OSSL_PARAM_BLD_free_params(params);
+    OSSL_PARAM_free(params);
     OSSL_PARAM_BLD_free(bld);
     BN_free(n);
     BN_free(e);

--- a/test/evp_pkey_provided_test.c
+++ b/test/evp_pkey_provided_test.c
@@ -446,7 +446,7 @@ static int test_evp_pkey_get_bn_param_large(void)
     EVP_PKEY_free(pk);
     EVP_PKEY_CTX_free(key_ctx);
     EVP_PKEY_CTX_free(ctx);
-    OSSL_PARAM_BLD_free_params(fromdata_params);
+    OSSL_PARAM_free(fromdata_params);
     OSSL_PARAM_BLD_free(bld);
     return ret;
 }
@@ -627,7 +627,7 @@ err:
     EVP_PKEY_free(pk);
     EVP_PKEY_CTX_free(ctx);
     EVP_PKEY_CTX_free(key_ctx);
-    OSSL_PARAM_BLD_free_params(fromdata_params);
+    OSSL_PARAM_free(fromdata_params);
     OSSL_PARAM_BLD_free(bld);
 
     return ret;
@@ -801,7 +801,7 @@ err:
     EVP_PKEY_free(pk);
     EVP_PKEY_CTX_free(ctx);
     EVP_PKEY_CTX_free(key_ctx);
-    OSSL_PARAM_BLD_free_params(fromdata_params);
+    OSSL_PARAM_free(fromdata_params);
     OSSL_PARAM_BLD_free(bld);
 
     return ret;
@@ -1200,7 +1200,7 @@ static int test_fromdata_ec(void)
 err:
     BN_free(bn_priv);
     BN_free(ec_priv_bn);
-    OSSL_PARAM_BLD_free_params(fromdata_params);
+    OSSL_PARAM_free(fromdata_params);
     OSSL_PARAM_BLD_free(bld);
     EVP_PKEY_free(pk);
     EVP_PKEY_free(copy_pk);
@@ -1519,7 +1519,7 @@ static int test_fromdata_dsa_fips186_4(void)
     }
 
  err:
-    OSSL_PARAM_BLD_free_params(fromdata_params);
+    OSSL_PARAM_free(fromdata_params);
     OSSL_PARAM_BLD_free(bld);
     BN_free(p);
     BN_free(q);

--- a/test/helpers/predefined_dhparams.c
+++ b/test/helpers/predefined_dhparams.c
@@ -40,7 +40,7 @@ static EVP_PKEY *get_dh_from_pg_bn(OSSL_LIB_CTX *libctx, const char *type,
 
  err:
     EVP_PKEY_CTX_free(pctx);
-    OSSL_PARAM_BLD_free_params(params);
+    OSSL_PARAM_free(params);
     OSSL_PARAM_BLD_free(tmpl);
     return dhpkey;
 }

--- a/test/param_build_test.c
+++ b/test/param_build_test.c
@@ -435,7 +435,7 @@ int setup_tests(void)
     ADD_ALL_TESTS(template_public_test, 5);
     /* Only run the secure memory testing if we have secure memory available */
     if (CRYPTO_secure_malloc_init(1<<16, 16))
-        ADD_TESTS_ALL(template_private_test, 5);
+        ADD_ALL_TESTS(template_private_test, 5);
     ADD_TEST(builder_limit_test);
     ADD_TEST(builder_merge_test);
     return 1;

--- a/test/param_build_test.c
+++ b/test/param_build_test.c
@@ -14,10 +14,12 @@
 #include "internal/nelem.h"
 #include "testutil.h"
 
-static int template_public_test(void)
+static const OSSL_PARAM params_empty[] = { OSSL_PARAM_END };
+
+static int template_public_test(int tstid)
 {
     OSSL_PARAM_BLD *bld = OSSL_PARAM_BLD_new();
-    OSSL_PARAM *params = NULL, *p;
+    OSSL_PARAM *params = NULL, *params_blt = NULL, *p1 = NULL, *p;
     BIGNUM *bn = NULL, *bn_res = NULL;
     int i;
     long int l;
@@ -30,7 +32,6 @@ static int template_public_test(void)
     int res = 0;
 
     if (!TEST_ptr(bld)
-        || !TEST_true(OSSL_PARAM_BLD_push_int(bld, "i", -6))
         || !TEST_true(OSSL_PARAM_BLD_push_long(bld, "l", 42))
         || !TEST_true(OSSL_PARAM_BLD_push_int32(bld, "i32", 1532))
         || !TEST_true(OSSL_PARAM_BLD_push_int64(bld, "i64", -9999999))
@@ -43,9 +44,31 @@ static int template_public_test(void)
                                                       sizeof("foo")))
         || !TEST_true(OSSL_PARAM_BLD_push_utf8_ptr(bld, "utf8_p", "bar-boom",
                                                    0))
-        || !TEST_ptr(params = OSSL_PARAM_BLD_to_param(bld))
-        /* Check int */
-        || !TEST_ptr(p = OSSL_PARAM_locate(params, "i"))
+        || !TEST_true(OSSL_PARAM_BLD_push_int(bld, "i", -6))
+        || !TEST_ptr(params_blt = OSSL_PARAM_BLD_to_param(bld)))
+        goto err;
+
+    switch(tstid) {
+    case 0:
+        params = params_blt;
+        break;
+    case 1:
+        params = OSSL_PARAM_merge(params_blt, params_empty);
+        break;
+    case 2:
+        params = OSSL_PARAM_dup(params_blt);
+        break;
+    case 3:
+        p1 = OSSL_PARAM_merge(params_blt, params_empty);
+        params = OSSL_PARAM_dup(p1);
+        break;
+    default:
+        p1 = OSSL_PARAM_dup(params_blt);
+        params = OSSL_PARAM_merge(p1, params_empty);
+        break;
+    }
+    /* Check int */
+    if (!TEST_ptr(p = OSSL_PARAM_locate(params, "i"))
         || !TEST_true(OSSL_PARAM_get_int(p, &i))
         || !TEST_str_eq(p->key, "i")
         || !TEST_uint_eq(p->data_type, OSSL_PARAM_INTEGER)
@@ -104,7 +127,10 @@ static int template_public_test(void)
         goto err;
     res = 1;
 err:
-    OSSL_PARAM_BLD_free_params(params);
+    OPENSSL_free(p1);
+    if (params != params_blt)
+        OPENSSL_free(params);
+    OSSL_PARAM_BLD_free_params(params_blt);
     OSSL_PARAM_BLD_free(bld);
     OPENSSL_free(utf);
     BN_free(bn);
@@ -112,7 +138,7 @@ err:
     return res;
 }
 
-static int template_private_test(void)
+static int template_private_test(int tstid)
 {
     int *data1 = NULL, *data2 = NULL, j;
     const int data1_num = 12;
@@ -120,7 +146,7 @@ static int template_private_test(void)
     const int data2_num = 5;
     const int data2_size = data2_num * sizeof(int);
     OSSL_PARAM_BLD *bld = NULL;
-    OSSL_PARAM *params = NULL, *p;
+    OSSL_PARAM *params = NULL, *params_blt = NULL, *p1 = NULL, *p;
     unsigned int i;
     unsigned long int l;
     uint32_t i32;
@@ -151,9 +177,29 @@ static int template_private_test(void)
                                                        data1_size))
         || !TEST_true(OSSL_PARAM_BLD_push_octet_ptr(bld, "oct_p", data2,
                                                     data2_size))
-        || !TEST_ptr(params = OSSL_PARAM_BLD_to_param(bld))
-        /* Check unsigned int */
-        || !TEST_ptr(p = OSSL_PARAM_locate(params, "i"))
+        || !TEST_ptr(params_blt = OSSL_PARAM_BLD_to_param(bld)))
+        goto err;
+    switch(tstid) {
+    case 0:
+        params = params_blt;
+        break;
+    case 1:
+        params = OSSL_PARAM_merge(params_blt, params_empty);
+        break;
+    case 2:
+        params = OSSL_PARAM_dup(params_blt);
+        break;
+    case 3:
+        p1 = OSSL_PARAM_merge(params_blt, params_empty);
+        params = OSSL_PARAM_dup(p1);
+        break;
+    default:
+        p1 = OSSL_PARAM_dup(params_blt);
+        params = OSSL_PARAM_merge(p1, params_empty);
+        break;
+    }
+    /* Check unsigned int */
+    if (!TEST_ptr(p = OSSL_PARAM_locate(params, "i"))
         || !TEST_false(CRYPTO_secure_allocated(p->data))
         || !TEST_true(OSSL_PARAM_get_uint(p, &i))
         || !TEST_str_eq(p->key, "i")
@@ -216,7 +262,10 @@ static int template_private_test(void)
         goto err;
     res = 1;
 err:
-    OSSL_PARAM_BLD_free_params(params);
+    OSSL_PARAM_free(p1);
+    if (params != params_blt)
+        OSSL_PARAM_free(params);
+    OSSL_PARAM_BLD_free_params(params_blt);
     OSSL_PARAM_BLD_free(bld);
     OPENSSL_secure_free(data1);
     OPENSSL_secure_free(data2);
@@ -268,12 +317,126 @@ err:
     return res;
 }
 
+static int builder_merge_test(void)
+{
+    static int data1[] = { 2, 3, 5, 7, 11, 15, 17 };
+    static unsigned char data2[] = { 2, 4, 6, 8, 10 };
+    OSSL_PARAM_BLD *bld = OSSL_PARAM_BLD_new();
+    OSSL_PARAM_BLD *bld2 = OSSL_PARAM_BLD_new();
+    OSSL_PARAM *params = NULL, *params_blt = NULL, *params2_blt = NULL, *p;
+    unsigned int i;
+    unsigned long int l;
+    uint32_t i32;
+    uint64_t i64;
+    size_t st;
+    BIGNUM *bn_priv = NULL, *bn_priv_res = NULL;
+    BIGNUM *bn_pub = NULL, *bn_pub_res = NULL;
+    int res = 0;
+
+    if (!TEST_ptr(bld)
+        || !TEST_true(OSSL_PARAM_BLD_push_uint(bld, "i", 6))
+        || !TEST_true(OSSL_PARAM_BLD_push_ulong(bld, "l", 42))
+        || !TEST_true(OSSL_PARAM_BLD_push_uint32(bld, "i32", 1532))
+        || !TEST_true(OSSL_PARAM_BLD_push_uint64(bld, "i64", 9999999))
+        || !TEST_true(OSSL_PARAM_BLD_push_size_t(bld, "st", 65537))
+        || !TEST_ptr(bn_priv = BN_secure_new())
+        || !TEST_true(BN_set_word(bn_priv, 1729))
+        || !TEST_true(OSSL_PARAM_BLD_push_BN(bld, "bignumber_priv", bn_priv))
+        || !TEST_ptr(params_blt = OSSL_PARAM_BLD_to_param(bld)))
+        goto err;
+
+    if (!TEST_ptr(bld2)
+        || !TEST_true(OSSL_PARAM_BLD_push_octet_string(bld2, "oct_s", data1,
+                                                       sizeof(data1)))
+        || !TEST_true(OSSL_PARAM_BLD_push_octet_ptr(bld2, "oct_p", data2,
+                                                    sizeof(data2)))
+        || !TEST_true(OSSL_PARAM_BLD_push_uint32(bld2, "i32", 99))
+        || !TEST_ptr(bn_pub = BN_new())
+        || !TEST_true(BN_set_word(bn_pub, 0x42))
+        || !TEST_true(OSSL_PARAM_BLD_push_BN(bld2, "bignumber_pub", bn_pub))
+        || !TEST_ptr(params2_blt = OSSL_PARAM_BLD_to_param(bld2)))
+        goto err;
+
+    if (!TEST_ptr(params = OSSL_PARAM_merge(params_blt, params2_blt)))
+        goto err;
+
+    if (!TEST_ptr(p = OSSL_PARAM_locate(params, "i"))
+        || !TEST_true(OSSL_PARAM_get_uint(p, &i))
+        || !TEST_str_eq(p->key, "i")
+        || !TEST_uint_eq(p->data_type, OSSL_PARAM_UNSIGNED_INTEGER)
+        || !TEST_size_t_eq(p->data_size, sizeof(int))
+        || !TEST_uint_eq(i, 6)
+        /* Check unsigned int32 */
+        || !TEST_ptr(p = OSSL_PARAM_locate(params, "i32"))
+        || !TEST_true(OSSL_PARAM_get_uint32(p, &i32))
+        || !TEST_str_eq(p->key, "i32")
+        || !TEST_uint_eq(p->data_type, OSSL_PARAM_UNSIGNED_INTEGER)
+        || !TEST_size_t_eq(p->data_size, sizeof(int32_t))
+        || !TEST_uint_eq((unsigned int)i32, 99)
+        /* Check unsigned int64 */
+        || !TEST_ptr(p = OSSL_PARAM_locate(params, "i64"))
+        || !TEST_str_eq(p->key, "i64")
+        || !TEST_uint_eq(p->data_type, OSSL_PARAM_UNSIGNED_INTEGER)
+        || !TEST_size_t_eq(p->data_size, sizeof(int64_t))
+        || !TEST_true(OSSL_PARAM_get_uint64(p, &i64))
+        || !TEST_ulong_eq((unsigned long)i64, 9999999)
+        /* Check unsigned long int */
+        || !TEST_ptr(p = OSSL_PARAM_locate(params, "l"))
+        || !TEST_str_eq(p->key, "l")
+        || !TEST_uint_eq(p->data_type, OSSL_PARAM_UNSIGNED_INTEGER)
+        || !TEST_size_t_eq(p->data_size, sizeof(unsigned long int))
+        || !TEST_true(OSSL_PARAM_get_ulong(p, &l))
+        || !TEST_ulong_eq(l, 42)
+        /* Check size_t */
+        || !TEST_ptr(p = OSSL_PARAM_locate(params, "st"))
+        || !TEST_str_eq(p->key, "st")
+        || !TEST_uint_eq(p->data_type, OSSL_PARAM_UNSIGNED_INTEGER)
+        || !TEST_size_t_eq(p->data_size, sizeof(size_t))
+        || !TEST_true(OSSL_PARAM_get_size_t(p, &st))
+        || !TEST_size_t_eq(st, 65537)
+        /* Check octet string */
+        || !TEST_ptr(p = OSSL_PARAM_locate(params, "oct_s"))
+        || !TEST_str_eq(p->key, "oct_s")
+        || !TEST_uint_eq(p->data_type, OSSL_PARAM_OCTET_STRING)
+        || !TEST_mem_eq(p->data, p->data_size, data1, sizeof(data1))
+        /* Check octet pointer */
+        || !TEST_ptr(p = OSSL_PARAM_locate(params, "oct_p"))
+        || !TEST_str_eq(p->key, "oct_p")
+        || !TEST_uint_eq(p->data_type, OSSL_PARAM_OCTET_PTR)
+        || !TEST_mem_eq(*(void **)p->data, p->data_size, data2, sizeof(data2))
+        /* Check BN */
+        || !TEST_ptr(p = OSSL_PARAM_locate(params, "bignumber_pub"))
+        || !TEST_str_eq(p->key, "bignumber_pub")
+        || !TEST_uint_eq(p->data_type, OSSL_PARAM_UNSIGNED_INTEGER)
+        || !TEST_true(OSSL_PARAM_get_BN(p, &bn_pub_res))
+        || !TEST_int_eq(BN_cmp(bn_pub_res, bn_pub), 0)
+        || !TEST_ptr(p = OSSL_PARAM_locate(params, "bignumber_priv"))
+        || !TEST_str_eq(p->key, "bignumber_priv")
+        || !TEST_uint_eq(p->data_type, OSSL_PARAM_UNSIGNED_INTEGER)
+        || !TEST_true(OSSL_PARAM_get_BN(p, &bn_priv_res))
+        || !TEST_int_eq(BN_cmp(bn_priv_res, bn_priv), 0))
+        goto err;
+    res = 1;
+err:
+    OSSL_PARAM_free(params);
+    OSSL_PARAM_free(params_blt);
+    OSSL_PARAM_free(params2_blt);
+    OSSL_PARAM_BLD_free(bld);
+    OSSL_PARAM_BLD_free(bld2);
+    BN_free(bn_priv);
+    BN_free(bn_priv_res);
+    BN_free(bn_pub);
+    BN_free(bn_pub_res);
+    return res;
+}
+
 int setup_tests(void)
 {
-    ADD_TEST(template_public_test);
+    ADD_ALL_TESTS(template_public_test, 5);
     /* Only run the secure memory testing if we have secure memory available */
     if (CRYPTO_secure_malloc_init(1<<16, 16))
-        ADD_TEST(template_private_test);
+        ADD_TESTS_ALL(template_private_test, 5);
     ADD_TEST(builder_limit_test);
+    ADD_TEST(builder_merge_test);
     return 1;
 }

--- a/test/param_build_test.c
+++ b/test/param_build_test.c
@@ -130,7 +130,7 @@ err:
     OPENSSL_free(p1);
     if (params != params_blt)
         OPENSSL_free(params);
-    OSSL_PARAM_BLD_free_params(params_blt);
+    OSSL_PARAM_free(params_blt);
     OSSL_PARAM_BLD_free(bld);
     OPENSSL_free(utf);
     BN_free(bn);
@@ -265,7 +265,7 @@ err:
     OSSL_PARAM_free(p1);
     if (params != params_blt)
         OSSL_PARAM_free(params);
-    OSSL_PARAM_BLD_free_params(params_blt);
+    OSSL_PARAM_free(params_blt);
     OSSL_PARAM_BLD_free(bld);
     OPENSSL_secure_free(data1);
     OPENSSL_secure_free(data2);
@@ -300,7 +300,7 @@ static int builder_limit_test(void)
         goto err;
 
     /* Verify that the build, cleared the builder structure */
-    OSSL_PARAM_BLD_free_params(params);
+    OSSL_PARAM_free(params);
     params = NULL;
 
     if (!TEST_true(OSSL_PARAM_BLD_push_int(bld, "g", 2))
@@ -312,7 +312,7 @@ static int builder_limit_test(void)
         goto err;
     res = 1;
 err:
-    OSSL_PARAM_BLD_free_params(params);
+    OSSL_PARAM_free(params);
     OSSL_PARAM_BLD_free(bld);
     return res;
 }

--- a/test/params_api_test.c
+++ b/test/params_api_test.c
@@ -664,11 +664,13 @@ static int test_param_modified(void)
 static int test_param_copy_null(void)
 {
     int ret, val;
-    int a = 1, b = 2;
+    int a = 1, b = 2, i= 0;
     OSSL_PARAM *cp1 = NULL, *cp2 = NULL, *p;
-    OSSL_PARAM param[3] = { OSSL_PARAM_int("a", &a),
-                            OSSL_PARAM_int("b", &b),
-                            OSSL_PARAM_END };
+    OSSL_PARAM param[3];
+
+    param[i++] = OSSL_PARAM_construct_int("a", &a);
+    param[i++] = OSSL_PARAM_construct_int("b", &b);
+    param[i] = OSSL_PARAM_construct_end();
 
     ret = TEST_ptr_null(OSSL_PARAM_dup(NULL))
           && TEST_ptr(cp1 = OSSL_PARAM_merge(NULL, param))

--- a/test/params_api_test.c
+++ b/test/params_api_test.c
@@ -455,7 +455,7 @@ static int test_param_real(void)
            && TEST_double_eq(p, 3.14159);
 }
 
-static int test_param_construct(void)
+static int test_param_construct(int tstid)
 {
     static const char *int_names[] = {
         "int", "long", "int32", "int64"
@@ -466,6 +466,10 @@ static int test_param_construct(void)
     static const unsigned char bn_val[16] = {
         0xac, 0x75, 0x22, 0x7d, 0x81, 0x06, 0x7a, 0x23,
         0xa6, 0xed, 0x87, 0xc7, 0xab, 0xf4, 0x73, 0x22
+    };
+    OSSL_PARAM *p = NULL, *p1 = NULL;
+    static const OSSL_PARAM params_empty[] = {
+        OSSL_PARAM_END
     };
     OSSL_PARAM params[20];
     char buf[100], buf2[100], *bufp, *bufp2;
@@ -501,13 +505,29 @@ static int test_param_construct(void)
     params[n++] = OSSL_PARAM_construct_octet_ptr("octptr", &vp, 0);
     params[n] = OSSL_PARAM_construct_end();
 
+    switch(tstid) {
+    case 0:
+        p = params;
+        break;
+    case 1:
+        p = OSSL_PARAM_merge(params, params_empty);
+        break;
+    case 2:
+        p = OSSL_PARAM_dup(params);
+        break;
+    default:
+        p1 = OSSL_PARAM_dup(params);
+        p = OSSL_PARAM_merge(p1, params_empty);
+        break;
+    }
+
     /* Search failure */
-    if (!TEST_ptr_null(OSSL_PARAM_locate(params, "fnord")))
+    if (!TEST_ptr_null(OSSL_PARAM_locate(p, "fnord")))
         goto err;
 
     /* All signed integral types */
     for (j = 0; j < OSSL_NELEM(int_names); j++) {
-        if (!TEST_ptr(cp = OSSL_PARAM_locate(params, int_names[j]))
+        if (!TEST_ptr(cp = OSSL_PARAM_locate(p, int_names[j]))
             || !TEST_true(OSSL_PARAM_set_int32(cp, (int32_t)(3 + j)))
             || !TEST_true(OSSL_PARAM_get_int64(cp, &i64))
             || !TEST_size_t_eq(cp->data_size, cp->return_size)
@@ -518,7 +538,7 @@ static int test_param_construct(void)
     }
     /* All unsigned integral types */
     for (j = 0; j < OSSL_NELEM(uint_names); j++) {
-        if (!TEST_ptr(cp = OSSL_PARAM_locate(params, uint_names[j]))
+        if (!TEST_ptr(cp = OSSL_PARAM_locate(p, uint_names[j]))
             || !TEST_true(OSSL_PARAM_set_uint32(cp, (uint32_t)(3 + j)))
             || !TEST_true(OSSL_PARAM_get_uint64(cp, &u64))
             || !TEST_size_t_eq(cp->data_size, cp->return_size)
@@ -528,15 +548,16 @@ static int test_param_construct(void)
         }
     }
     /* Real */
-    if (!TEST_ptr(cp = OSSL_PARAM_locate(params, "double"))
+    if (!TEST_ptr(cp = OSSL_PARAM_locate(p, "double"))
         || !TEST_true(OSSL_PARAM_set_double(cp, 3.14))
         || !TEST_true(OSSL_PARAM_get_double(cp, &d2))
         || !TEST_size_t_eq(cp->return_size, sizeof(double))
-        || !TEST_double_eq(d, d2))
+        || !TEST_double_eq(d2, 3.14)
+        || (tstid <= 1 && !TEST_double_eq(d, d2)))
         goto err;
     /* UTF8 string */
     bufp = NULL;
-    if (!TEST_ptr(cp = OSSL_PARAM_locate(params, "utf8str"))
+    if (!TEST_ptr(cp = OSSL_PARAM_locate(p, "utf8str"))
         || !TEST_true(OSSL_PARAM_set_utf8_string(cp, "abcdef"))
         || !TEST_size_t_eq(cp->return_size, sizeof("abcdef") - 1)
         || !TEST_true(OSSL_PARAM_get_utf8_string(cp, &bufp, 0))
@@ -552,15 +573,15 @@ static int test_param_construct(void)
     /* UTF8 pointer */
     /* Note that the size of a UTF8 string does *NOT* include the NUL byte */
     bufp = buf;
-    if (!TEST_ptr(cp = OSSL_PARAM_locate(params, "utf8ptr"))
+    if (!TEST_ptr(cp = OSSL_PARAM_locate(p, "utf8ptr"))
         || !TEST_true(OSSL_PARAM_set_utf8_ptr(cp, "tuvwxyz"))
         || !TEST_size_t_eq(cp->return_size, sizeof("tuvwxyz") - 1)
-        || !TEST_str_eq(bufp, "tuvwxyz")
         || !TEST_true(OSSL_PARAM_get_utf8_ptr(cp, (const char **)&bufp2))
-        || !TEST_ptr_eq(bufp2, bufp))
+        || !TEST_str_eq(bufp2, "tuvwxyz")
+        || (tstid <= 1 && !TEST_ptr_eq(bufp2, bufp)))
         goto err;
     /* OCTET string */
-    if (!TEST_ptr(cp = OSSL_PARAM_locate(params, "octstr"))
+    if (!TEST_ptr(cp = OSSL_PARAM_locate(p, "octstr"))
         || !TEST_true(OSSL_PARAM_set_octet_string(cp, "abcdefghi",
                                                   sizeof("abcdefghi")))
         || !TEST_size_t_eq(cp->return_size, sizeof("abcdefghi")))
@@ -580,19 +601,19 @@ static int test_param_construct(void)
         goto err;
     /* OCTET pointer */
     vp = &l;
-    if (!TEST_ptr(cp = OSSL_PARAM_locate(params, "octptr"))
+    if (!TEST_ptr(cp = OSSL_PARAM_locate(p, "octptr"))
         || !TEST_true(OSSL_PARAM_set_octet_ptr(cp, &ul, sizeof(ul)))
         || !TEST_size_t_eq(cp->return_size, sizeof(ul))
-        || !TEST_ptr_eq(vp, &ul))
+        || (tstid <= 1 && !TEST_ptr_eq(vp, &ul)))
         goto err;
     /* Match the return size to avoid trailing garbage bytes */
     cp->data_size = cp->return_size;
     if (!TEST_true(OSSL_PARAM_get_octet_ptr(cp, (const void **)&vp2, &k))
         || !TEST_size_t_eq(k, sizeof(ul))
-        || !TEST_ptr_eq(vp2, vp))
+        || (tstid <= 1 && !TEST_ptr_eq(vp2, vp)))
         goto err;
     /* BIGNUM */
-    if (!TEST_ptr(cp = OSSL_PARAM_locate(params, "bignum"))
+    if (!TEST_ptr(cp = OSSL_PARAM_locate(p, "bignum"))
         || !TEST_ptr(bn = BN_lebin2bn(bn_val, (int)sizeof(bn_val), NULL))
         || !TEST_true(OSSL_PARAM_set_BN(cp, bn))
         || !TEST_size_t_eq(cp->data_size, cp->return_size))
@@ -604,6 +625,9 @@ static int test_param_construct(void)
         goto err;
     ret = 1;
 err:
+    if (p != params)
+        OPENSSL_free(p);
+    OPENSSL_free(p1);
     OPENSSL_free(vpn);
     BN_free(bn);
     BN_free(bn2);
@@ -637,6 +661,21 @@ static int test_param_modified(void)
     return 1;
 }
 
+static int test_param_copy_null(void)
+{
+    int ret;
+    OSSL_PARAM *cp = NULL;
+    OSSL_PARAM param[3] = { OSSL_PARAM_int("a", NULL),
+                            OSSL_PARAM_int("b", NULL),
+                            OSSL_PARAM_END };
+
+    ret = TEST_ptr_null(OSSL_PARAM_dup(NULL))
+          && TEST_ptr_null(OSSL_PARAM_merge(NULL, param))
+          && TEST_ptr(cp = OSSL_PARAM_merge(param, NULL));
+    OSSL_PARAM_free(cp);
+    return ret;
+}
+
 int setup_tests(void)
 {
     ADD_ALL_TESTS(test_param_int, OSSL_NELEM(raw_values));
@@ -651,7 +690,8 @@ int setup_tests(void)
     ADD_ALL_TESTS(test_param_uint64, OSSL_NELEM(raw_values));
     ADD_ALL_TESTS(test_param_bignum, OSSL_NELEM(raw_values));
     ADD_TEST(test_param_real);
-    ADD_TEST(test_param_construct);
+    ADD_ALL_TESTS(test_param_construct, 4);
     ADD_TEST(test_param_modified);
+    ADD_TEST(test_param_copy_null);
     return 1;
 }

--- a/test/params_api_test.c
+++ b/test/params_api_test.c
@@ -664,7 +664,7 @@ static int test_param_modified(void)
 static int test_param_copy_null(void)
 {
     int ret, val;
-    int a = 1, b = 2, i= 0;
+    int a = 1, b = 2, i = 0;
     OSSL_PARAM *cp1 = NULL, *cp2 = NULL, *p;
     OSSL_PARAM param[3];
 

--- a/test/params_api_test.c
+++ b/test/params_api_test.c
@@ -663,16 +663,31 @@ static int test_param_modified(void)
 
 static int test_param_copy_null(void)
 {
-    int ret;
-    OSSL_PARAM *cp = NULL;
-    OSSL_PARAM param[3] = { OSSL_PARAM_int("a", NULL),
-                            OSSL_PARAM_int("b", NULL),
+    int ret, val;
+    int a = 1, b = 2;
+    OSSL_PARAM *cp1 = NULL, *cp2 = NULL, *p;
+    OSSL_PARAM param[3] = { OSSL_PARAM_int("a", &a),
+                            OSSL_PARAM_int("b", &b),
                             OSSL_PARAM_END };
 
     ret = TEST_ptr_null(OSSL_PARAM_dup(NULL))
-          && TEST_ptr_null(OSSL_PARAM_merge(NULL, param))
-          && TEST_ptr(cp = OSSL_PARAM_merge(param, NULL));
-    OSSL_PARAM_free(cp);
+          && TEST_ptr(cp1 = OSSL_PARAM_merge(NULL, param))
+          && TEST_ptr(p = OSSL_PARAM_locate(cp1, "a"))
+          && TEST_true(OSSL_PARAM_get_int(p, &val))
+          && TEST_int_eq(val, 1)
+          && TEST_ptr(p = OSSL_PARAM_locate(cp1, "b"))
+          && TEST_true(OSSL_PARAM_get_int(p, &val))
+          && TEST_int_eq(val, 2)
+          && TEST_ptr(cp2 = OSSL_PARAM_merge(param, NULL))
+          && TEST_ptr(p = OSSL_PARAM_locate(cp2, "a"))
+          && TEST_true(OSSL_PARAM_get_int(p, &val))
+          && TEST_int_eq(val, 1)
+          && TEST_ptr(p = OSSL_PARAM_locate(cp2, "b"))
+          && TEST_true(OSSL_PARAM_get_int(p, &val))
+          && TEST_int_eq(val, 2)
+          && TEST_ptr_null(OSSL_PARAM_merge(NULL, NULL));
+    OSSL_PARAM_free(cp2);
+    OSSL_PARAM_free(cp1);
     return ret;
 }
 

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -8302,7 +8302,7 @@ static EVP_PKEY *get_tmp_dh_params(void)
         BN_free(p);
         EVP_PKEY_CTX_free(pctx);
         OSSL_PARAM_BLD_free(tmpl);
-        OSSL_PARAM_BLD_free_params(params);
+        OSSL_PARAM_free(params);
     }
 
     if (tmp_dh_params != NULL && !EVP_PKEY_up_ref(tmp_dh_params))

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4956,7 +4956,6 @@ NCONF_new_ex                            ?	3_0_0	EXIST::FUNCTION:
 CONF_modules_load_file_ex               ?	3_0_0	EXIST::FUNCTION:
 OSSL_LIB_CTX_load_config                ?	3_0_0	EXIST::FUNCTION:
 OSSL_PARAM_BLD_to_param                 ?	3_0_0	EXIST::FUNCTION:
-OSSL_PARAM_BLD_free_params              ?	3_0_0	EXIST::FUNCTION:
 OSSL_PARAM_BLD_push_int                 ?	3_0_0	EXIST::FUNCTION:
 OSSL_PARAM_BLD_push_uint                ?	3_0_0	EXIST::FUNCTION:
 OSSL_PARAM_BLD_push_long                ?	3_0_0	EXIST::FUNCTION:

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5348,3 +5348,6 @@ EVP_KEM_description                     ?	3_0_0	EXIST::FUNCTION:
 EVP_KEYEXCH_description                 ?	3_0_0	EXIST::FUNCTION:
 EVP_KDF_description                     ?	3_0_0	EXIST::FUNCTION:
 X509_CRL_new_ex                         ?	3_0_0	EXIST::FUNCTION:
+OSSL_PARAM_dup                          ?	3_0_0	EXIST::FUNCTION:
+OSSL_PARAM_merge                        ?	3_0_0	EXIST::FUNCTION:
+OSSL_PARAM_free                         ?	3_0_0	EXIST::FUNCTION:


### PR DESCRIPTION
These functions are prerequisites for implementing EVP_PKEY_todata().
    
OSSL_PARAM_dup() is required to make a deep copy of the exported
params (since the provider export() uses a OSSL_PARAM_BLD which throws away the
data after the call), and then use OSSL_PARAM_merge() to add some additional params
that can be passed to the EVP_PKEY_todata().

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
