### PR TITLE
Only enable KTLS if it is explicitly configured

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,12 @@ OpenSSL 3.0
 
 ### Changes between 1.1.1 and 3.0 [xx XXX xxxx]
 
+ * Added support for Kernel TLS (KTLS). In order to use KTLS, support for it
+   must be compiled in using the "enable-ktls" compile time option. It must
+   also be enabled at run time using the SSL_OP_ENABLE_KTLS option.
+
+   *Boris Pismenny, John Baldwin and Andrew Gallatin*
+
  * A public key check is now performed during EVP_PKEY_derive_set_peer().
    Previously DH was internally doing this during EVP_PKEY_derive().
    To disable this check use EVP_PKEY_derive_set_peer_ex(dh, peer, 0). This

--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,7 @@ OpenSSL 3.0
 
 ### Major changes between OpenSSL 1.1.1 and OpenSSL 3.0 [under development]
 
+  * Added suport for Kernal TLS (KTLS)
   * Changed the license to the Apache License v2.0.
   * Moved all variations of the EVP ciphers CAST5, BF, IDEA, SEED, RC2,
     RC4, RC5, and DES to the legacy provider.

--- a/NEWS.md
+++ b/NEWS.md
@@ -20,7 +20,7 @@ OpenSSL 3.0
 
 ### Major changes between OpenSSL 1.1.1 and OpenSSL 3.0 [under development]
 
-  * Added suport for Kernal TLS (KTLS)
+  * Added suport for Kernel TLS (KTLS)
   * Changed the license to the Apache License v2.0.
   * Moved all variations of the EVP ciphers CAST5, BF, IDEA, SEED, RC2,
     RC4, RC5, and DES to the legacy provider.

--- a/doc/man3/SSL_CONF_cmd.pod
+++ b/doc/man3/SSL_CONF_cmd.pod
@@ -524,6 +524,10 @@ B<CANames>: use CA names extension, enabled by
 default. Inverse of B<SSL_OP_DISABLE_TLSEXT_CA_NAMES>: that is,
 B<-CANames> is the same as setting B<SSL_OP_DISABLE_TLSEXT_CA_NAMES>.
 
+B<KTLS>: Enables kernel TLS if support has been compiled in, and it is supported
+by the negotiated ciphersuites and extensions. Equivalent to
+B<SSL_OP_ENABLE_KTLS>.
+
 =item B<VerifyMode>
 
 The B<value> argument is a comma separated list of flags to set.

--- a/doc/man3/SSL_CTX_set_mode.pod
+++ b/doc/man3/SSL_CTX_set_mode.pod
@@ -105,22 +105,6 @@ Enable asynchronous processing. TLS I/O operations may indicate a retry with
 SSL_ERROR_WANT_ASYNC with this mode set if an asynchronous capable engine is
 used to perform cryptographic operations. See L<SSL_get_error(3)>.
 
-=item SSL_MODE_NO_KTLS_TX
-
-Disable the use of the kernel TLS egress data-path.
-By default kernel TLS is enabled if it is supported by the negotiated ciphersuites
-and extensions and OpenSSL has been compiled with support for it.
-The kernel TLS data-path implements the record layer,
-and the crypto algorithm. The kernel will utilize the best hardware
-available for crypto. Using the kernel data-path should reduce the memory
-footprint of OpenSSL because no buffering is required. Also, the throughput
-should improve because data copy is avoided when user data is encrypted into
-kernel memory instead of the usual encrypt than copy to kernel.
-
-Kernel TLS might not support all the features of OpenSSL. For instance,
-renegotiation, and setting the maximum fragment size is not possible as of
-Linux 4.20.
-
 =item SSL_MODE_DTLS_SCTP_LABEL_LENGTH_BUG
 
 Older versions of OpenSSL had a bug in the computation of the label length
@@ -150,7 +134,6 @@ L<SSL_write(3)>, L<SSL_get_error(3)>
 =head1 HISTORY
 
 SSL_MODE_ASYNC was added in OpenSSL 1.1.0.
-SSL_MODE_NO_KTLS_TX was added in OpenSSL 3.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/SSL_CTX_set_options.pod
+++ b/doc/man3/SSL_CTX_set_options.pod
@@ -291,7 +291,7 @@ algorithm. The kernel will utilize the best hardware
 available for encryption. Using the kernel data-path should reduce the memory
 footprint of OpenSSL because no buffering is required. Also, the throughput
 should improve because data copy is avoided when user data is encrypted into
-kernel memory instead of the usual encrypt than copy to kernel.
+kernel memory instead of the usual encrypt then copy to kernel.
 
 Kernel TLS might not support all the features of OpenSSL. For instance,
 renegotiation, and setting the maximum fragment size is not possible as of
@@ -300,7 +300,7 @@ Linux 4.20.
 Note that with kernel TLS enabled some cryptographic operations are performed
 by the kernel directly and not via any available OpenSSL Providers. This might
 be undesirable if, for example, the application requires all cryptographic
-operations to be performmed by the FIPS provider.
+operations to be performed by the FIPS provider.
 
 =back
 

--- a/doc/man3/SSL_CTX_set_options.pod
+++ b/doc/man3/SSL_CTX_set_options.pod
@@ -279,6 +279,29 @@ responsible for cleansing all other buffers. Most notably, this
 applies to buffers passed to functions like L<SSL_read(3)>,
 L<SSL_peek(3)> but also like L<SSL_write(3)>.
 
+=item SSL_OP_ENABLE_KTLS
+
+Enable the use of kernel TLS. In order to benefit from kernel TLS OpenSSL must
+have been compiled with support for it, and it must be supported by the
+negotiated ciphersuites and extensions. The specific ciphersuites and extensions
+that are supported may vary by platform and kernel version.
+
+The kernel TLS data-path implements the record layer, and the encryption
+algorithm. The kernel will utilize the best hardware
+available for encryption. Using the kernel data-path should reduce the memory
+footprint of OpenSSL because no buffering is required. Also, the throughput
+should improve because data copy is avoided when user data is encrypted into
+kernel memory instead of the usual encrypt than copy to kernel.
+
+Kernel TLS might not support all the features of OpenSSL. For instance,
+renegotiation, and setting the maximum fragment size is not possible as of
+Linux 4.20.
+
+Note that with kernel TLS enabled some cryptographic operations are performed
+by the kernel directly and not via any available OpenSSL Providers. This might
+be undesirable if, for example, the application requires all cryptographic
+operations to be performmed by the FIPS provider.
+
 =back
 
 The following options no longer have any effect but their identifiers are

--- a/include/openssl/ssl.h.in
+++ b/include/openssl/ssl.h.in
@@ -316,11 +316,6 @@ typedef int (*SSL_verify_cb)(int preverify_ok, X509_STORE_CTX *x509_ctx);
 /* Typedef for SSL async callback */
 typedef int (*SSL_async_callback_fn)(SSL *s, void *arg);
 
-/*
- * Some values are reserved until OpenSSL 3.0.0 because they were previously
- * included in SSL_OP_ALL in a 1.1.x release.
- */
-
 /* Disable Extended master secret */
 # define SSL_OP_NO_EXTENDED_MASTER_SECRET                0x00000001U
 
@@ -329,6 +324,9 @@ typedef int (*SSL_async_callback_fn)(SSL *s, void *arg);
 
 /* Allow initial connection to servers that don't support RI */
 # define SSL_OP_LEGACY_SERVER_CONNECT                    0x00000004U
+
+/* Enable support for Kernel TLS */
+# define SSL_OP_ENABLE_KTLS                              0x00000008U
 
 # define SSL_OP_TLSEXT_PADDING                           0x00000010U
 # define SSL_OP_SAFARI_ECDHE_ECDSA_BUG                   0x00000040U

--- a/include/openssl/ssl.h.in
+++ b/include/openssl/ssl.h.in
@@ -514,10 +514,7 @@ typedef int (*SSL_async_callback_fn)(SSL *s, void *arg);
  * Support Asynchronous operation
  */
 # define SSL_MODE_ASYNC 0x00000100U
-/*
- * Don't use the kernel TLS data-path for sending.
- */
-# define SSL_MODE_NO_KTLS_TX 0x00000200U
+
 /*
  * When using DTLS/SCTP, include the terminating zero in the label
  * used for computing the endpoint-pair shared secret. Required for
@@ -530,10 +527,6 @@ typedef int (*SSL_async_callback_fn)(SSL *s, void *arg);
  * - OpenSSL 1.1.1 and 1.1.1a
  */
 # define SSL_MODE_DTLS_SCTP_LABEL_LENGTH_BUG 0x00000400U
-/*
- * Don't use the kernel TLS data-path for receiving.
- */
-# define SSL_MODE_NO_KTLS_RX 0x00000800U
 
 /* Cert related flags */
 /*

--- a/ssl/ktls.c
+++ b/ssl/ktls.c
@@ -137,6 +137,7 @@ int ktls_check_supported_cipher(const SSL *s, const EVP_CIPHER *c,
           return 0;
 # endif
 # ifdef OPENSSL_KTLS_AES_GCM_128
+        /* Fall through */
     case NID_aes_128_gcm:
 # endif
 # ifdef OPENSSL_KTLS_AES_GCM_256

--- a/ssl/ssl_conf.c
+++ b/ssl/ssl_conf.c
@@ -387,7 +387,7 @@ static int cmd_Options(SSL_CONF_CTX *cctx, const char *value)
         SSL_FLAG_TBL_INV("AntiReplay", SSL_OP_NO_ANTI_REPLAY),
         SSL_FLAG_TBL_INV("ExtendedMasterSecret", SSL_OP_NO_EXTENDED_MASTER_SECRET),
         SSL_FLAG_TBL_INV("CANames", SSL_OP_DISABLE_TLSEXT_CA_NAMES),
-        SSL_FLAG_TBL("KTLS", SSL_OP_ENABLE_KTLS),
+        SSL_FLAG_TBL("KTLS", SSL_OP_ENABLE_KTLS)
     };
     if (value == NULL)
         return -3;

--- a/ssl/ssl_conf.c
+++ b/ssl/ssl_conf.c
@@ -386,7 +386,8 @@ static int cmd_Options(SSL_CONF_CTX *cctx, const char *value)
         SSL_FLAG_TBL("MiddleboxCompat", SSL_OP_ENABLE_MIDDLEBOX_COMPAT),
         SSL_FLAG_TBL_INV("AntiReplay", SSL_OP_NO_ANTI_REPLAY),
         SSL_FLAG_TBL_INV("ExtendedMasterSecret", SSL_OP_NO_EXTENDED_MASTER_SECRET),
-        SSL_FLAG_TBL_INV("CANames", SSL_OP_DISABLE_TLSEXT_CA_NAMES)
+        SSL_FLAG_TBL_INV("CANames", SSL_OP_DISABLE_TLSEXT_CA_NAMES),
+        SSL_FLAG_TBL("KTLS", SSL_OP_ENABLE_KTLS),
     };
     if (value == NULL)
         return -3;

--- a/ssl/t1_enc.c
+++ b/ssl/t1_enc.c
@@ -434,11 +434,7 @@ int tls1_change_cipher_state(SSL *s, int which)
     }
 
 #ifndef OPENSSL_NO_KTLS
-    if (s->compress)
-        goto skip_ktls;
-
-    if (((which & SSL3_CC_READ) && (s->mode & SSL_MODE_NO_KTLS_RX))
-        || ((which & SSL3_CC_WRITE) && (s->mode & SSL_MODE_NO_KTLS_TX)))
+    if (s->compress || (s->options & SSL_OP_ENABLE_KTLS) == 0)
         goto skip_ktls;
 
     /* ktls supports only the maximum fragment size */

--- a/ssl/tls13_enc.c
+++ b/ssl/tls13_enc.c
@@ -751,8 +751,9 @@ int tls13_change_cipher_state(SSL *s, int which)
         s->statem.enc_write_state = ENC_WRITE_STATE_VALID;
 #ifndef OPENSSL_NO_KTLS
 # if defined(OPENSSL_KTLS_TLS13)
-    if (!(which & SSL3_CC_WRITE) || !(which & SSL3_CC_APPLICATION)
-        || ((which & SSL3_CC_WRITE) && (s->mode & SSL_MODE_NO_KTLS_TX)))
+    if (!(which & SSL3_CC_WRITE)
+            || !(which & SSL3_CC_APPLICATION)
+            || (s->options & SSL_OP_ENABLE_KTLS) == 0)
         goto skip_ktls;
 
     /* ktls supports only the maximum fragment size */

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -1082,7 +1082,7 @@ static int ping_pong_query(SSL *clientssl, SSL *serverssl, int cfd, int sfd, int
         goto end;
 
     /* ktls is used then kernel sequences are used instead of OpenSSL sequences */
-    if (clientssl->mode & SSL_MODE_NO_KTLS_TX) {
+    if ((SSL_get_options(clientssl) & SSL_OP_ENABLE_KTLS) == 0) {
         if (!TEST_mem_ne(crec_wseq_before, rec_seq_size,
                          crec_wseq_after, rec_seq_size))
             goto end;
@@ -1092,7 +1092,7 @@ static int ping_pong_query(SSL *clientssl, SSL *serverssl, int cfd, int sfd, int
             goto end;
     }
 
-    if (serverssl->mode & SSL_MODE_NO_KTLS_TX) {
+    if ((SSL_get_options(serverssl) & SSL_OP_ENABLE_KTLS) == 0) {
         if (!TEST_mem_ne(srec_wseq_before, rec_seq_size,
                          srec_wseq_after, rec_seq_size))
             goto end;
@@ -1102,7 +1102,11 @@ static int ping_pong_query(SSL *clientssl, SSL *serverssl, int cfd, int sfd, int
             goto end;
     }
 
-    if (clientssl->mode & SSL_MODE_NO_KTLS_RX) {
+    if ((SSL_get_options(clientssl) & SSL_OP_ENABLE_KTLS) == 0
+#if defined(OPENSSL_NO_KTLS_RX)
+        || 1
+#endif
+       ) {
         if (!TEST_mem_ne(crec_rseq_before, rec_seq_size,
                          crec_rseq_after, rec_seq_size))
             goto end;
@@ -1112,7 +1116,11 @@ static int ping_pong_query(SSL *clientssl, SSL *serverssl, int cfd, int sfd, int
             goto end;
     }
 
-    if (serverssl->mode & SSL_MODE_NO_KTLS_RX) {
+    if ((SSL_get_options(serverssl) & SSL_OP_ENABLE_KTLS) == 0
+#if defined(OPENSSL_NO_KTLS_RX)
+        || 1
+#endif
+       ) {
         if (!TEST_mem_ne(srec_rseq_before, rec_seq_size,
                          srec_rseq_after, rec_seq_size))
             goto end;
@@ -1127,8 +1135,7 @@ end:
     return 0;
 }
 
-static int execute_test_ktls(int cis_ktls_tx, int cis_ktls_rx,
-                             int sis_ktls_tx, int sis_ktls_rx,
+static int execute_test_ktls(int cis_ktls, int sis_ktls,
                              int tls_version, const char *cipher,
                              int rec_seq_size)
 {
@@ -1155,23 +1162,13 @@ static int execute_test_ktls(int cis_ktls_tx, int cis_ktls_rx,
                                           &clientssl, sfd, cfd)))
         goto end;
 
-    if (!cis_ktls_tx) {
-        if (!TEST_true(SSL_set_mode(clientssl, SSL_MODE_NO_KTLS_TX)))
+    if (cis_ktls) {
+        if (!TEST_true(SSL_set_options(clientssl, SSL_OP_ENABLE_KTLS)))
             goto end;
     }
 
-    if (!sis_ktls_tx) {
-        if (!TEST_true(SSL_set_mode(serverssl, SSL_MODE_NO_KTLS_TX)))
-            goto end;
-    }
-
-    if (!cis_ktls_rx) {
-        if (!TEST_true(SSL_set_mode(clientssl, SSL_MODE_NO_KTLS_RX)))
-            goto end;
-    }
-
-    if (!sis_ktls_rx) {
-        if (!TEST_true(SSL_set_mode(serverssl, SSL_MODE_NO_KTLS_RX)))
+    if (sis_ktls) {
+        if (!TEST_true(SSL_set_mode(serverssl, SSL_OP_ENABLE_KTLS)))
             goto end;
     }
 
@@ -1179,7 +1176,7 @@ static int execute_test_ktls(int cis_ktls_tx, int cis_ktls_rx,
                                                 SSL_ERROR_NONE)))
         goto end;
 
-    if (!cis_ktls_tx) {
+    if (!cis_ktls) {
         if (!TEST_false(BIO_get_ktls_send(clientssl->wbio)))
             goto end;
     } else {
@@ -1187,7 +1184,7 @@ static int execute_test_ktls(int cis_ktls_tx, int cis_ktls_rx,
             goto end;
     }
 
-    if (!sis_ktls_tx) {
+    if (!sis_ktls) {
         if (!TEST_false(BIO_get_ktls_send(serverssl->wbio)))
             goto end;
     } else {
@@ -1195,7 +1192,11 @@ static int execute_test_ktls(int cis_ktls_tx, int cis_ktls_rx,
             goto end;
     }
 
-    if (!cis_ktls_rx) {
+    if (!cis_ktls
+#if defined(OPENSSL_NO_KTLS_RX)
+        || 1
+#endif
+       ) {
         if (!TEST_false(BIO_get_ktls_recv(clientssl->rbio)))
             goto end;
     } else {
@@ -1203,7 +1204,11 @@ static int execute_test_ktls(int cis_ktls_tx, int cis_ktls_rx,
             goto end;
     }
 
-    if (!sis_ktls_rx) {
+    if (!sis_ktls
+#if defined(OPENSSL_NO_KTLS_RX)
+        || 1
+#endif
+       ) {
         if (!TEST_false(BIO_get_ktls_recv(serverssl->rbio)))
             goto end;
     } else {
@@ -1341,14 +1346,14 @@ end:
 #if !defined(OPENSSL_NO_TLS1_2) || !defined(OSSL_NO_USABLE_TLS1_3)
 static int test_ktls(int test)
 {
-    int cis_ktls_tx, cis_ktls_rx, sis_ktls_tx, sis_ktls_rx;
+    int cis_ktls, sis_ktls;
     int tlsver, testresult;
 
-    if (test > 15) {
+    if (test > 3) {
 #if defined(OSSL_NO_USABLE_TLS1_3)
         return 1;
 #else
-        test -= 16;
+        test -= 4;
         tlsver = TLS1_3_VERSION;
 #endif
     } else {
@@ -1359,34 +1364,22 @@ static int test_ktls(int test)
 #endif
     }
 
-    cis_ktls_tx = (test & 1) != 0;
-    cis_ktls_rx = (test & 2) != 0;
-    sis_ktls_tx = (test & 4) != 0;
-    sis_ktls_rx = (test & 8) != 0;
-
-#if defined(OPENSSL_NO_KTLS_RX)
-    if (cis_ktls_rx || sis_ktls_rx)
-        return 1;
-#endif
-#if !defined(OSSL_NO_USABLE_TLS1_3)
-    if (tlsver == TLS1_3_VERSION && (cis_ktls_rx || sis_ktls_rx))
-        return 1;
-#endif
+    cis_ktls = (test & 1) != 0;
+    sis_ktls = (test & 2) != 0;
 
     testresult = 1;
 #ifdef OPENSSL_KTLS_AES_GCM_128
-    testresult &= execute_test_ktls(cis_ktls_tx, cis_ktls_rx, sis_ktls_tx,
-                                    sis_ktls_rx, tlsver, "AES128-GCM-SHA256",
+    testresult &= execute_test_ktls(cis_ktls, sis_ktls, tlsver,
+                                    "AES128-GCM-SHA256",
                                     TLS_CIPHER_AES_GCM_128_REC_SEQ_SIZE);
 #endif
 #ifdef OPENSSL_KTLS_AES_CCM_128
-    testresult &= execute_test_ktls(cis_ktls_tx, cis_ktls_rx, sis_ktls_tx,
-                                    sis_ktls_rx, tlsver, "AES128-CCM",
+    testresult &= execute_test_ktls(cis_ktls, sis_ktls, tlsver, "AES128-CCM",
                                     TLS_CIPHER_AES_CCM_128_REC_SEQ_SIZE);
 #endif
 #ifdef OPENSSL_KTLS_AES_GCM_256
-    testresult &= execute_test_ktls(cis_ktls_tx, cis_ktls_rx, sis_ktls_tx,
-                                    sis_ktls_rx, tlsver, "AES256-GCM-SHA384",
+    testresult &= execute_test_ktls(cis_ktls, sis_ktls, tlsver,
+                                    "AES256-GCM-SHA384",
                                     TLS_CIPHER_AES_GCM_256_REC_SEQ_SIZE);
 #endif
     return testresult;
@@ -8746,7 +8739,7 @@ int setup_tests(void)
 
 #if !defined(OPENSSL_NO_KTLS) && !defined(OPENSSL_NO_SOCK)
 # if !defined(OPENSSL_NO_TLS1_2) || !defined(OSSL_NO_USABLE_TLS1_3)
-    ADD_ALL_TESTS(test_ktls, 32);
+    ADD_ALL_TESTS(test_ktls, 8);
     ADD_ALL_TESTS(test_ktls_sendfile_anytls, 6);
 # endif
 #endif


### PR DESCRIPTION
It has always been the case that KTLS is not compiled by default. However
if it is compiled then it was automatically used unless specifically
configured not to. This is problematic because it avoids any crypto
implementations from providers. A user who configures all crypto to use
the FIPS provider may unexpectedly find that TLS related crypto is actually
being performed outside of the FIPS boundary.

Instead we change KTLS so that it is disabled by default.

We also swap to using a single "option" (i.e. SSL_OP_ENABLE_KTLS) rather
than two separate "modes", (i.e. SSL_MODE_NO_KTLS_RX and
SSL_MODE_NO_KTLS_TX).

Fixes #13794