### PR TITLE
Remove the function EVP_PKEY_set_alias_type

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -426,12 +426,11 @@ OpenSSL 3.0
 
    *Paul Dale*
 
- * Deprecated EVP_PKEY_set_alias_type().  This function was previously
+ * Removed EVP_PKEY_set_alias_type().  This function was previously
    needed as a workaround to recognise SM2 keys.  With OpenSSL 3.0, this key
    type is internally recognised so the workaround is no longer needed.
 
-   Functionality is still retained as it is, but will only work with
-   EVP_PKEYs with a legacy internal key.
+   This is a breaking change from previous OpenSSL versions.
 
    *Richard Levitte*
 
@@ -857,16 +856,16 @@ OpenSSL 3.0
    *Paul Dale*
 
  * Reworked the treatment of EC EVP_PKEYs with the SM2 curve to
-   automatically become EVP_PKEY_SM2 rather than EVP_PKEY_EC.
-   This means that applications don't have to look at the curve NID and
-   `EVP_PKEY_set_alias_type(pkey, EVP_PKEY_SM2)` to get SM2 computations.
-   However, they still can, that `EVP_PKEY_set_alias_type()` call acts as
-   a no-op when the EVP_PKEY is already of the given type.
+   automatically become EVP_PKEY_SM2 rather than EVP_PKEY_EC. This is a breaking
+   change from previous OpenSSL versions.
+
+   Unlike in previous OpenSSL versions, this means that applications must not
+   call `EVP_PKEY_set_alias_type(pkey, EVP_PKEY_SM2)` to get SM2 computations.
+   The `EVP_PKEY_set_alias_type` function has now been removed.
 
    Parameter and key generation is also reworked to make it possible
-   to generate EVP_PKEY_SM2 parameters and keys without having to go
-   through EVP_PKEY_EC generation and then change the EVP_PKEY type.
-   However, code that does the latter will still work as before.
+   to generate EVP_PKEY_SM2 parameters and keys. Applications must now generate
+   SM2 keys directly and must not create an EVP_PKEY_EC key first.
 
    *Richard Levitte*
 

--- a/doc/man3/EVP_PKEY_set1_RSA.pod
+++ b/doc/man3/EVP_PKEY_set1_RSA.pod
@@ -9,7 +9,7 @@ EVP_PKEY_assign_RSA, EVP_PKEY_assign_DSA, EVP_PKEY_assign_DH,
 EVP_PKEY_assign_EC_KEY, EVP_PKEY_assign_POLY1305, EVP_PKEY_assign_SIPHASH,
 EVP_PKEY_get0_hmac, EVP_PKEY_get0_poly1305, EVP_PKEY_get0_siphash,
 EVP_PKEY_get0, EVP_PKEY_type, EVP_PKEY_id, EVP_PKEY_base_id,
-EVP_PKEY_set_alias_type, EVP_PKEY_set1_engine, EVP_PKEY_get0_engine -
+EVP_PKEY_set1_engine, EVP_PKEY_get0_engine -
 EVP_PKEY assignment functions
 
 =head1 SYNOPSIS
@@ -23,8 +23,6 @@ EVP_PKEY assignment functions
 Deprecated since OpenSSL 3.0, can be hidden entirely by defining
 B<OPENSSL_API_COMPAT> with a suitable version value, see
 L<openssl_user_macros(7)>:
-
- int EVP_PKEY_set_alias_type(EVP_PKEY *pkey, int type);
 
  int EVP_PKEY_set1_RSA(EVP_PKEY *pkey, RSA *key);
  int EVP_PKEY_set1_DSA(EVP_PKEY *pkey, DSA *key);
@@ -130,19 +128,12 @@ If I<engine> does not include an B<EVP_PKEY_METHOD> for I<pkey> an
 error occurs. This function is deprecated. Applications should use providers
 instead of engines (see L<provider(7)> for details).
 
-EVP_PKEY_set_alias_type() allows modifying an EVP_PKEY to use a
-different set of algorithms than the default. This function is deprecated and
-was previously needed as a workaround to recognise SM2 keys. From OpenSSL 3.0,
-this key type is internally recognised so the workaround is no longer needed.
-Functionality is still retained as it is, but will only work with EVP_PKEYs
-with a legacy internal key.
-
 =head1 WARNINGS
 
 The following functions are only reliable with B<EVP_PKEY>s that have
 been assigned an internal key with EVP_PKEY_assign_*():
 
-EVP_PKEY_id(), EVP_PKEY_base_id(), EVP_PKEY_type(), EVP_PKEY_set_alias_type()
+EVP_PKEY_id(), EVP_PKEY_base_id(), EVP_PKEY_type()
 
 For EVP_PKEY key type checking purposes, L<EVP_PKEY_is_a(3)> is more generic.
 
@@ -170,12 +161,6 @@ and EVP_PKEY_assign_SIPHASH() are implemented as macros.
 EVP_PKEY_assign_EC_KEY() looks at the curve name id to determine if
 the passed B<EC_KEY> is an L<SM2(7)> key, and will set the B<EVP_PKEY>
 type to B<EVP_PKEY_SM2> in that case, instead of B<EVP_PKEY_EC>.
-
-It's possible to switch back and forth between the types B<EVP_PKEY_EC>
-and B<EVP_PKEY_SM2> with a call to EVP_PKEY_set_alias_type() on keys
-assigned with this macro if it's desirable to do a normal EC
-computations with the SM2 curve instead of the special SM2
-computations, and vice versa.
 
 Most applications wishing to know a key type will simply call
 EVP_PKEY_base_id() and will not care about the actual type:
@@ -206,15 +191,6 @@ type or B<NID_undef> (equivalently B<EVP_PKEY_NONE>) on error.
 
 EVP_PKEY_set1_engine() returns 1 for success and 0 for failure.
 
-EVP_PKEY_set_alias_type() returns 1 for success and 0 for error.
-
-=head1 EXAMPLES
-
-After loading an ECC key, it is possible to convert it to using SM2
-algorithms with EVP_PKEY_set_alias_type:
-
- EVP_PKEY_set_alias_type(pkey, EVP_PKEY_SM2);
-
 =head1 SEE ALSO
 
 L<EVP_PKEY_new(3)>, L<SM2(7)>
@@ -227,11 +203,13 @@ EVP_PKEY_get0_RSA, EVP_PKEY_get0_DSA, EVP_PKEY_get0_DH, EVP_PKEY_get0_EC_KEY,
 EVP_PKEY_assign_RSA, EVP_PKEY_assign_DSA, EVP_PKEY_assign_DH,
 EVP_PKEY_assign_EC_KEY, EVP_PKEY_assign_POLY1305, EVP_PKEY_assign_SIPHASH,
 EVP_PKEY_get0_hmac, EVP_PKEY_get0_poly1305, EVP_PKEY_get0_siphash,
-EVP_PKEY_set_alias_type, EVP_PKEY_set1_engine and EVP_PKEY_get0_engine were
-deprecated in OpenSSL 3.0.
+EVP_PKEY_set1_engine and EVP_PKEY_get0_engine were deprecated in OpenSSL 3.0.
 
 The return value from EVP_PKEY_get0_RSA, EVP_PKEY_get0_DSA, EVP_PKEY_get0_DH,
 EVP_PKEY_get0_EC_KEY were made const in OpenSSL 3.0.
+
+The function EVP_PKEY_set_alias_type() was previously documented on this page.
+It was removed in OpenSSL 3.0.
 
 =head1 COPYRIGHT
 

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -1262,7 +1262,6 @@ int EVP_PKEY_set_type(EVP_PKEY *pkey, int type);
 int EVP_PKEY_set_type_str(EVP_PKEY *pkey, const char *str, int len);
 int EVP_PKEY_set_type_by_keymgmt(EVP_PKEY *pkey, EVP_KEYMGMT *keymgmt);
 # ifndef OPENSSL_NO_DEPRECATED_3_0
-OSSL_DEPRECATEDIN_3_0 int EVP_PKEY_set_alias_type(EVP_PKEY *pkey, int type);
 #  ifndef OPENSSL_NO_ENGINE
 OSSL_DEPRECATEDIN_3_0
 int EVP_PKEY_set1_engine(EVP_PKEY *pkey, ENGINE *e);

--- a/test/ecdsatest.c
+++ b/test/ecdsatest.c
@@ -243,18 +243,6 @@ static int test_builtin(int n, int as)
 
     temp = ECDSA_size(eckey);
 
-    /*
-     * |as| indicates how we want to treat the key, i.e. what sort of
-     * computation we want to do with it.  The two choices are the key
-     * types EVP_PKEY_EC and EVP_PKEY_SM2.  It's perfectly possible to
-     * switch back and forth between those two key types, regardless of
-     * curve, even though the default is to have EVP_PKEY_SM2 for the
-     * SM2 curve and EVP_PKEY_EC for all other curves.
-     */
-    if (!TEST_true(EVP_PKEY_set_alias_type(pkey, as))
-        || !TEST_true(EVP_PKEY_set_alias_type(pkey_neg, as)))
-            goto err;
-
     if (!TEST_int_ge(temp, 0)
         || !TEST_ptr(sig = OPENSSL_malloc(sig_len = (size_t)temp))
         /* create a signature */

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4393,7 +4393,7 @@ EVP_PKEY_get_raw_public_key             4518	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_get_raw_private_key            4519	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_asn1_set_get_priv_key          4520	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_asn1_set_get_pub_key           4521	3_0_0	EXIST::FUNCTION:
-EVP_PKEY_set_alias_type                 4522	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
+EVP_PKEY_set_alias_type                 4522	3_0_0	NOEXIST::FUNCTION:DEPRECATEDIN_3_0
 RAND_keep_random_devices_open           4523	3_0_0	EXIST::FUNCTION:
 EC_POINT_set_compressed_coordinates     4524	3_0_0	EXIST::FUNCTION:EC
 EC_POINT_set_affine_coordinates         4525	3_0_0	EXIST::FUNCTION:EC


### PR DESCRIPTION
OTC recently voted that EVP_PKEY types will be immutable in 3.0. This
means that EVP_PKEY_set_alias_type can no longer work and should be
removed entirely (applications will need to be rewritten not to use it).

It was primarily used for SM2 which no longer needs this call.
Applications should generate SM2 keys directly (without going via an EC
key first), or otherwise when loading keys they should automatically be
detected as SM2 keys.

Fixes #14379
