### PR TITLE
Fix 128 bit int detection on Android

### DIFF
--- a/Configure
+++ b/Configure
@@ -1577,8 +1577,16 @@ if (!$disabled{asm} && !$predefined_C{__MACH__} && $^O ne 'VMS') {
 $config{use_int128} = 0;
 {
     my $cc = $config{CROSS_COMPILE}.$config{CC};
-    $target{cflags} =~ /(-target (\w|-)+)/;
-    open(PIPE, "$cc $1 -E -dM - </dev/null 2>&1 |");
+    my $cflags = "";
+    $cflags .= $target{lib_cflags} if defined $target{lib_cflags};
+    $cflags .= " ".$target{shared_cflag} if defined $target{shared_cflag};
+    $cflags .= " ".join(' ', @{$config{lib_cflags}}) if defined $config{lib_cflags};
+    $cflags .= " ".join(' ', @{$config{shared_cflag}}) if defined $config{shared_cflag};
+    $cflags .= " ".$target{cflags} if defined $target{cflags};
+    $cflags .= " ".join(' ', @{$config{cflags}}) if defined $config{cflags};
+    $cflags .= " ".join(' ', @{$config{CFLAGS}}) if defined $config{CFLAGS};
+
+    open(PIPE, "$cc $cflags -E -dM - </dev/null 2>&1 |");
     while(<PIPE>) {
         if (m/__SIZEOF_INT128__/) {
             $config{use_int128} = 1;

--- a/Configure
+++ b/Configure
@@ -1577,7 +1577,8 @@ if (!$disabled{asm} && !$predefined_C{__MACH__} && $^O ne 'VMS') {
 $config{use_int128} = 0;
 {
     my $cc = $config{CROSS_COMPILE}.$config{CC};
-    open(PIPE, "$cc -E -dM - </dev/null 2>&1 |");
+    $target{cflags} =~ /(-target (\w|-)+)/;
+    open(PIPE, "$cc $1 -E -dM - </dev/null 2>&1 |");
     while(<PIPE>) {
         if (m/__SIZEOF_INT128__/) {
             $config{use_int128} = 1;


### PR DESCRIPTION
Make sure we use a "-target" flag when probing the compiler for 128 bit
int support.

Fixes #14804