### PR TITLE
Allow applications to send NewSessionTicket without application data

### DIFF
--- a/doc/man3/SSL_CTX_set_num_tickets.pod
+++ b/doc/man3/SSL_CTX_set_num_tickets.pod
@@ -45,17 +45,22 @@ sent.
 To issue tickets after other events (such as application-layer changes),
 SSL_new_session_ticket() is used by a server application to request that a new
 ticket be sent when it is safe to do so.  New tickets are only allowed to be
-sent in this manner after the initial handshake has completed, and only for TLS
-1.3 connections.  The ticket generation and transmission are delayed until the
-server is starting a new write operation, so that it is bundled with other
-application data being written and properly aligned to a record boundary.
-SSL_new_session_ticket() can be called more than once to request additional
-tickets be sent; all such requests are queued and written together when it is
-safe to do so.  Note that a successful return from SSL_new_session_ticket()
-indicates only that the request to send a ticket was processed, not that the
-ticket itself was sent.  To be notified when the ticket itself is sent, a
-new-session callback can be registered with L<SSL_CTX_sess_set_new_cb(3)> that
-will be invoked as the ticket or tickets are generated.
+sent in this manner after the initial handshake has completed, and only for
+TLS 1.3 connections.  By default, the ticket generation and transmission are
+delayed until the server is starting a new write operation, so that it is
+bundled with other application data being written and properly aligned to a
+record boundary.  If the connection was at a record boundary when
+SSL_new_session_ticket() was called, the ticket can be sent immediately
+(without waiting for the next application write) by calling
+SSL_do_handshake().  SSL_new_session_ticket() can be called more than once to
+request additional tickets be sent; all such requests are queued and written
+together when it is safe to do so and triggered by SSL_write() or
+SSL_do_handshake().  Note that a successful return from
+SSL_new_session_ticket() indicates only that the request to send a ticket was
+processed, not that the ticket itself was sent.  To be notified when the
+ticket itself is sent, a new-session callback can be registered with
+L<SSL_CTX_sess_set_new_cb(3)> that will be invoked as the ticket or tickets
+are generated.
 
 SSL_CTX_get_num_tickets() and SSL_get_num_tickets() return the number of
 tickets set by a previous call to SSL_CTX_set_num_tickets() or

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -2327,10 +2327,14 @@ int SSL_renegotiate_pending(const SSL *s)
 
 int SSL_new_session_ticket(SSL *s)
 {
-    if (SSL_in_init(s) || SSL_IS_FIRST_HANDSHAKE(s) || !s->server
+    /* If we are in init because we're sending tickets, okay to send more. */
+    if ((SSL_in_init(s) && s->ext.extra_tickets_expected == 0)
+            || SSL_IS_FIRST_HANDSHAKE(s) || !s->server
             || !SSL_IS_TLS13(s))
         return 0;
     s->ext.extra_tickets_expected++;
+    if (s->rlayer.wbuf[0].left == 0 && !SSL_in_init(s))
+        ossl_statem_set_in_init(s, 1);
     return 1;
 }
 


### PR DESCRIPTION
The initial implementation of `SSL_new_session_ticket()` from #11416 deferred the generation of the requested ticket(s) until the next application write, but this means that the ticket cannot be written at all until there is application data ready to write or a dummy zero-length write call is performed.  This is a conceptual mismatch for the actual act of sending a ticket, which is a TLS handshake operation that should be drivable by `SSL_do_handshake()`.  Change things around a little so that (when already at a record boundary) we allow the application to explicitly call SSL_do_handshake() after SSL_new_session_ticket() to force an immediate write of the ticket, without need for a (real or otherwise) application-data write.  The default behavior remains to defer the generation of the ticket and coalesce the network traffic for the ticket and application data.

Update tests and documentation accordingly.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
