### PR TITLE
apps: call ERR_print_errors when OSSL_PROVIDER_load fails

### DIFF
--- a/apps/lib/app_provider.c
+++ b/apps/lib/app_provider.c
@@ -35,6 +35,7 @@ int app_provider_load(OSSL_LIB_CTX *libctx, const char *provider_name)
     if (prov == NULL) {
         opt_printf_stderr("%s: unable to load provider %s\n",
                           opt_getprog(), provider_name);
+        ERR_print_errors(bio_err);
         return 0;
     }
     if (app_providers == NULL)


### PR DESCRIPTION
The ERR_print_errors often displays the reason why the provider couldn't be loaded. Hence it is quite important for debugging.