### PR TITLE
Add some additional NULL checks to prevent segfaults.

### DIFF
--- a/crypto/evp/evp_lib.c
+++ b/crypto/evp/evp_lib.c
@@ -701,6 +701,8 @@ const char *EVP_MD_description(const EVP_MD *md)
 
 const char *EVP_MD_name(const EVP_MD *md)
 {
+    if (md == NULL)
+        return NULL;
     if (md->prov != NULL)
         return evp_first_name(md->prov, md->name_id);
 #ifndef FIPS_MODULE

--- a/crypto/ocsp/ocsp_srv.c
+++ b/crypto/ocsp/ocsp_srv.c
@@ -278,6 +278,8 @@ int OCSP_RESPID_set_by_key_ex(OCSP_RESPID *respid, X509 *cert,
 
 int OCSP_RESPID_set_by_key(OCSP_RESPID *respid, X509 *cert)
 {
+    if (cert == NULL)
+        return 0;
     return OCSP_RESPID_set_by_key_ex(respid, cert, cert->libctx, cert->propq);
 }
 
@@ -319,5 +321,7 @@ int OCSP_RESPID_match_ex(OCSP_RESPID *respid, X509 *cert, OSSL_LIB_CTX *libctx,
 
 int OCSP_RESPID_match(OCSP_RESPID *respid, X509 *cert)
 {
+    if (cert == NULL)
+        return 0;
     return OCSP_RESPID_match_ex(respid, cert, cert->libctx, cert->propq);
 }

--- a/crypto/x509/x_crl.c
+++ b/crypto/x509/x_crl.c
@@ -393,9 +393,9 @@ int X509_CRL_get0_by_cert(X509_CRL *crl, X509_REVOKED **ret, X509 *x)
 
 static int def_crl_verify(X509_CRL *crl, EVP_PKEY *r)
 {
-    return (ASN1_item_verify_ex(ASN1_ITEM_rptr(X509_CRL_INFO),
-                                &crl->sig_alg, &crl->signature, &crl->crl, NULL,
-                                r, crl->libctx, crl->propq));
+    return ASN1_item_verify_ex(ASN1_ITEM_rptr(X509_CRL_INFO),
+                               &crl->sig_alg, &crl->signature, &crl->crl, NULL,
+                               r, crl->libctx, crl->propq);
 }
 
 static int crl_revoked_issuer_match(X509_CRL *crl, const X509_NAME *nm,


### PR DESCRIPTION
Fixes #14809

PR #14752 attempted to pass the libctx, propq in a few places related to
X509 signing. There were a few places that needed additional NULL checks so that they behavethe same as they did before.

OCSP_basic_sign() was changed to call EVP_DigestSignInit_ex() which passed the parameter EVP_MD_name(dgst). Since dgst can be NULL EVP_MD_name() was segfaulting.
Adding an additional NULL check EVP_MD_name() resolves this issue.

The other NULL checks are required to produce errors rather than
segfaults if the certificate is NULL.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
