### PR TITLE
X509_NAME_cmp: if canon_enclen is 0 for both names return 0

### DIFF
--- a/crypto/x509/x509_cmp.c
+++ b/crypto/x509/x509_cmp.c
@@ -269,11 +269,14 @@ int X509_NAME_cmp(const X509_NAME *a, const X509_NAME *b)
             return -2;
     }
 
+    ret = a->canon_enclen - b->canon_enclen;
+    if (ret == 0 && a->canon_enclen == 0)
+        return 0;
+
     if (a->canon_enc == NULL || b->canon_enc == NULL)
         return -2;
 
-    ret = a->canon_enclen - b->canon_enclen;
-    if (ret == 0 && a->canon_enclen != 0)
+    if (ret == 0)
         ret = memcmp(a->canon_enc, b->canon_enc, a->canon_enclen);
 
     return ret < 0 ? -1 : ret > 0;

--- a/crypto/x509/x_name.c
+++ b/crypto/x509/x_name.c
@@ -298,6 +298,7 @@ static int x509_name_ex_print(BIO *out, const ASN1_VALUE **pval,
  * comparison of Name structures can be rapidly performed by just using
  * memcmp() of the canonical encoding. By omitting the leading SEQUENCE name
  * constraints of type dirName can also be checked with a simple memcmp().
+ * NOTE: For empty X509_NAME (NULL-DN), canon_enclen == 0 && canon_enc == NULL
  */
 
 static int x509_name_canon(X509_NAME *a)


### PR DESCRIPTION
We do not care whether canon_enc is NULL in this case.

Fixes #14813

This is less invasive alternative to #14819