### PR TITLE
CMP app: add generic rand options, etc.

### DIFF
--- a/apps/cmp.c
+++ b/apps/cmp.c
@@ -222,6 +222,7 @@ typedef enum OPTION_choice {
     OPT_ENGINE,
 #endif
     OPT_PROV_ENUM,
+    OPT_R_ENUM,
 
     OPT_TLS_USED, OPT_TLS_CERT, OPT_TLS_KEY,
     OPT_TLS_KEYPASS,
@@ -412,6 +413,7 @@ const OPTIONS cmp_options[] = {
      "Engines may also be defined in OpenSSL config file engine section."},
 #endif
     OPT_PROV_OPTIONS,
+    OPT_R_OPTIONS,
 
     OPT_SECTION("TLS connection"),
     {"tls_used", OPT_TLS_USED, '-',
@@ -2058,8 +2060,6 @@ static int read_config(void)
     long num = 0;
     char *txt = NULL;
     const OPTIONS *opt;
-    int provider_option;
-    int verification_option;
     int start = OPT_VERBOSITY;
     /*
      * starting with offset OPT_VERBOSITY because OPT_CONFIG and OPT_SECTION
@@ -2075,19 +2075,23 @@ static int read_config(void)
             n_options--;
     OPENSSL_assert(OSSL_NELEM(cmp_vars) == n_options
                  + OPT_PROV__FIRST + 1 - OPT_PROV__LAST
+                 + OPT_R__FIRST + 1 - OPT_R__LAST
                  + OPT_V__FIRST + 1 - OPT_V__LAST);
     for (i = start - OPT_HELP, opt = &cmp_options[start];
          opt->name; i++, opt++) {
-        if (!strcmp(opt->name, OPT_SECTION_STR)
-                || !strcmp(opt->name, OPT_MORE_STR)) {
+        int provider_option = (OPT_PROV__FIRST <= opt->retval
+                               && opt->retval < OPT_PROV__LAST);
+        int rand_state_option = (OPT_R__FIRST <= opt->retval
+                                 && opt->retval < OPT_R__LAST);
+        int verification_option = (OPT_V__FIRST <= opt->retval
+                                   && opt->retval < OPT_V__LAST);
+
+        if (strcmp(opt->name, OPT_SECTION_STR) == 0
+                || strcmp(opt->name, OPT_MORE_STR) == 0) {
             i--;
             continue;
         }
-        provider_option = (OPT_PROV__FIRST <= opt->retval
-                               && opt->retval < OPT_PROV__LAST);
-        verification_option = (OPT_V__FIRST <= opt->retval
-                                   && opt->retval < OPT_V__LAST);
-        if (provider_option || verification_option)
+        if (provider_option || rand_state_option || verification_option)
             i--;
         switch (opt->valtype) {
         case '-':
@@ -2099,6 +2103,7 @@ static int read_config(void)
             }
             break;
         case 's':
+        case '>':
         case 'M':
             txt = conf_get_string(conf, opt_section, opt->name);
             if (txt == NULL) {
@@ -2415,6 +2420,10 @@ static int get_opts(int argc, char **argv)
             if (!opt_provider(o))
                 goto opthelp;
             break;
+        case OPT_R_CASES:
+            if (!opt_rand(o))
+                goto opthelp;
+            break;
 
         case OPT_BATCH:
             opt_batch = 1;
@@ -2603,6 +2612,8 @@ int cmp_main(int argc, char **argv)
     if (ret <= 0)
         goto err;
     ret = 0;
+    if (!app_RAND_load())
+        goto err;
 
     if (opt_batch)
         set_base_ui_method(UI_null());

--- a/crypto/cmp/cmp_util.c
+++ b/crypto/cmp/cmp_util.c
@@ -22,6 +22,9 @@
 
 int OSSL_CMP_log_open(void) /* is designed to be idempotent */
 {
+#ifdef OPENSSL_NO_TRACE
+    return 1;
+#endif
 #ifndef OPENSSL_NO_STDIO
     BIO *bio = BIO_new_fp(stdout, BIO_NOCLOSE);
 

--- a/crypto/cmp/cmp_util.c
+++ b/crypto/cmp/cmp_util.c
@@ -24,16 +24,17 @@ int OSSL_CMP_log_open(void) /* is designed to be idempotent */
 {
 #ifdef OPENSSL_NO_TRACE
     return 1;
-#endif
-#ifndef OPENSSL_NO_STDIO
+#else
+# ifndef OPENSSL_NO_STDIO
     BIO *bio = BIO_new_fp(stdout, BIO_NOCLOSE);
 
     if (bio != NULL && OSSL_trace_set_channel(OSSL_TRACE_CATEGORY_CMP, bio))
         return 1;
     BIO_free(bio);
-#endif
+# endif
     ERR_raise(ERR_LIB_CMP, CMP_R_NO_STDIO);
     return 0;
+#endif
 }
 
 void OSSL_CMP_log_close(void) /* is designed to be idempotent */

--- a/doc/man1/openssl-cmp.pod.in
+++ b/doc/man1/openssl-cmp.pod.in
@@ -743,8 +743,6 @@ L<openssl-passphrase-options(1)>.
 
 {- $OpenSSL::safe::opt_engine_item -}
 
-=back
-
 {- output_off() if $disabled{"deprecated-3.0"}; "" -}
 As an alternative to using this combination:
 
@@ -758,6 +756,16 @@ like this:
 This applies to all options specifying keys: B<-key>, B<-newkey>, and
 B<-tls_key>.
 {- output_on() if $disabled{"deprecated-3.0"}; "" -}
+
+=back
+
+=head2 Provider options
+
+=over 4
+
+{- $OpenSSL::safe::opt_provider_item -}
+
+=back
 
 =head2 TLS connection options
 

--- a/doc/man1/openssl-cmp.pod.in
+++ b/doc/man1/openssl-cmp.pod.in
@@ -86,6 +86,10 @@ Credentials format options:
 [B<-otherpass> I<arg>]
 {- $OpenSSL::safe::opt_engine_synopsis -}{- $OpenSSL::safe::opt_provider_synopsis -}
 
+Random state options:
+
+{- $OpenSSL::safe::opt_r_synopsis -}
+
 TLS connection options:
 
 [B<-tls_used>]
@@ -764,6 +768,14 @@ B<-tls_key>.
 =over 4
 
 {- $OpenSSL::safe::opt_provider_item -}
+
+=back
+
+=head2 Random state options
+
+=over 4
+
+{- $OpenSSL::safe::opt_r_item -}
 
 =back
 


### PR DESCRIPTION
* `apps/cmp.c`: Add generic random state options, e.g., for nonce generation
* `openssl-cmp.pod.in`: Fix missing provider options description
  Also correct layout of engines description
* `cmp_util.c`: Fix `OSSL_CMP_log_open()` in case `OPENSSL_NO_TRACE`
