### PR TITLE
Memory leak in i2d_ASN1_bio_stream when using SMIME_write_CMS

### DIFF
--- a/crypto/asn1/bio_asn1.c
+++ b/crypto/asn1/bio_asn1.c
@@ -138,12 +138,10 @@ static int asn1_bio_free(BIO *b)
     if (ctx == NULL)
         return 0;
 
-    if (ctx->prefix_free != NULL) {
+    if (ctx->prefix_free != NULL)
         ctx->prefix_free(b, &ctx->ex_buf, &ctx->ex_len, &ctx->ex_arg);
-    }
-    if (ctx->suffix_free != NULL) {
+    if (ctx->suffix_free != NULL)
         ctx->suffix_free(b, &ctx->ex_buf, &ctx->ex_len, &ctx->ex_arg);
-    }
 
     OPENSSL_free(ctx->buf);
     OPENSSL_free(ctx);

--- a/crypto/asn1/bio_asn1.c
+++ b/crypto/asn1/bio_asn1.c
@@ -138,6 +138,13 @@ static int asn1_bio_free(BIO *b)
     if (ctx == NULL)
         return 0;
 
+    if (ctx->prefix_free != NULL) {
+        ctx->prefix_free(b, &ctx->ex_buf, &ctx->ex_len, &ctx->ex_arg);
+    }
+    if (ctx->suffix_free != NULL) {
+        ctx->suffix_free(b, &ctx->ex_buf, &ctx->ex_len, &ctx->ex_arg);
+    }
+
     OPENSSL_free(ctx->buf);
     OPENSSL_free(ctx);
     BIO_set_data(b, NULL);

--- a/crypto/asn1/bio_ndef.c
+++ b/crypto/asn1/bio_ndef.c
@@ -143,6 +143,9 @@ static int ndef_prefix_free(BIO *b, unsigned char **pbuf, int *plen,
 
     ndef_aux = *(NDEF_SUPPORT **)parg;
 
+    if (ndef_aux == NULL)
+        return 0;
+
     OPENSSL_free(ndef_aux->derbuf);
 
     ndef_aux->derbuf = NULL;

--- a/test/bio_memleak_test.c
+++ b/test/bio_memleak_test.c
@@ -62,7 +62,7 @@ static int test_bio_get_mem(void)
         goto finish;
     ok = 1;
 
-finish:
+ finish:
     BIO_free(bio);
     BUF_MEM_free(bufmem);
     return ok;
@@ -98,7 +98,7 @@ static int test_bio_new_mem_buf(void)
         goto finish;
     ok = 1;
 
-finish:
+ finish:
     BIO_free(bio);
     return ok;
 }
@@ -139,7 +139,7 @@ static int test_bio_rdonly_mem_buf(void)
         goto finish;
     ok = 1;
 
-finish:
+ finish:
     BIO_free(bio);
     BIO_free(bio2);
     return ok;
@@ -176,7 +176,7 @@ static int test_bio_rdwr_rdonly(void)
 
     ok = 1;
 
-finish:
+ finish:
     BIO_free(bio);
     return ok;
 }
@@ -216,7 +216,7 @@ static int test_bio_nonclear_rst(void)
 
     ok = 1;
 
-finish:
+ finish:
     BIO_free(bio);
     return ok;
 }
@@ -279,7 +279,7 @@ static int test_bio_i2d_ASN1_mime(void)
 
     ok = 1;
 
-finish:
+ finish:
     BIO_free(bio);
     BIO_free(out);
     PKCS7_free(p7);

--- a/test/bio_memleak_test.c
+++ b/test/bio_memleak_test.c
@@ -267,9 +267,8 @@ static int test_bio_i2d_ASN1_mime(void)
      */
     if (!TEST_true(i2d_ASN1_bio_stream(out, (ASN1_VALUE*) p7, bio,
                                        SMIME_STREAM | SMIME_BINARY,
-                                       ASN1_ITEM_rptr(PKCS7)))) {
+                                       ASN1_ITEM_rptr(PKCS7))))
         goto finish;
-    }
 
     if (!TEST_int_eq(error_callback_fired, 1))
         goto finish;


### PR DESCRIPTION
When creating a signed S/MIME message using SMIME_write_CMS(), the state machine in the background does not handle error cases completely. This results in a small memory leak in i2d_ASN1_bio_stream / asn_mime.c

In BIO_new_NDEF, ndef_aux is initialized and set to the bio stream via 
`ndef_aux = OPENSSL_zalloc(sizeof(*ndef_aux));`
to bio->ex_arg

This memory is normally freed in asn1_bio_flush_ex (bio_asn1.c, cleanup parameter set to true).

This call is triggered via BIO_flush() which ends up in the asn1_bio_ctrl (bio_asn1.c) in the case the cmd is BIO_CTRL_FLUSH and state is ASN1_STATE_POST_COPY.

The state is also updated in the same function and asn1_bio_write.

In our use case the reading from the bio fails, the state is therefore still ASN1_STATE_START when BIO_flush() is called by i2d_ASN1_bio_stream. This results in calling asn1_bio_flush_ex cleanup but will only reset retry flags as the state is not ASN1_STATE_POST_COPY. Therefore 48 bytes (Linux x86_64) leaked since the ndef_prefix_free / ndef_suffix_free callbacks are not executed and the ndef_aux structure is not freed.

Patch is attached which makes sure the free callbacks are called. Another option would be to improve the state machine but this looks harder to get it right.

CLA: trivial