### PR TITLE
Remove a TODO(3.0) from X509_PUBKEY_set

### DIFF
--- a/crypto/x509/x_pubkey.c
+++ b/crypto/x509/x_pubkey.c
@@ -282,14 +282,12 @@ int X509_PUBKEY_set(X509_PUBKEY **x, EVP_PKEY *pkey)
     /*
      * pk->pkey is NULL when using the legacy routine, but is non-NULL when
      * going through the encoder, and for all intents and purposes, it's
-     * a perfect copy of |pkey|, just not the same instance.  In that case,
-     * we could simply return early, right here.
-     * However, in the interest of being cautious leaning on paranoia, some
-     * application might very well depend on the passed |pkey| being used
-     * and none other, so we spend a few more cycles throwing away the newly
-     * created |pk->pkey| and replace it with |pkey|.
-     * TODO(3.0) Investigate if it's safe to change to simply return here
-     * if |pk->pkey != NULL|.
+     * a perfect copy of the public key portions of |pkey|, just not the same
+     * instance.  If that's all there was to pkey then we could simply return
+     * early, right here. However, some application might very well depend on
+     * the passed |pkey| being used and none other, so we spend a few more
+     * cycles throwing away the newly created |pk->pkey| and replace it with
+     * |pkey|.
      */
     if (pk->pkey != NULL)
         EVP_PKEY_free(pk->pkey);


### PR DESCRIPTION
The comment talks about the EVP_PKEY that is contained within an
X509_PUBKEY object and whether it has to be exactly the same as the one
passed by the caller in X509_PUBKEY_set(). IMO it does, so the TODO should
be dropped.

Fixes #14378

