### PR TITLE
Fix windows compiler error in kmac_prov.c

### DIFF
--- a/providers/implementations/macs/kmac_prov.c
+++ b/providers/implementations/macs/kmac_prov.c
@@ -59,6 +59,7 @@
 #include "prov/provider_ctx.h"
 #include "prov/provider_util.h"
 #include "prov/providercommon.h"
+#include "internal/cryptlib.h" /* ossl_assert */
 
 /*
  * Forward declaration of everything implemented here.  This is not strictly
@@ -497,7 +498,7 @@ static int encode_string(unsigned char *out, size_t *out_len,
             return 0;
         }
 
-        out[0] = len;
+        out[0] = (unsigned char)len;
         for (i = len; i > 0; --i) {
             out[i] = (bits & 0xFF);
             bits >>= 8;
@@ -534,9 +535,12 @@ static int bytepad(unsigned char *out, size_t *out_len,
         return 1;
     }
 
+    if (!ossl_assert(w <= 255))
+        return 0;
+
     /* Left encoded w */
     *p++ = 1;
-    *p++ = w;
+    *p++ = (unsigned char)w;
     /* || in1 */
     memcpy(p, in1, in1_len);
     p += in1_len;


### PR DESCRIPTION
Error is seen here: https://ci.appveyor.com/project/openssl/openssl/builds/38653748

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
