### PR TITLE
[1.1.1] Inherit hostflags verify params even without hosts

### DIFF
--- a/crypto/x509/x509_vpm.c
+++ b/crypto/x509/x509_vpm.c
@@ -199,7 +199,8 @@ int X509_VERIFY_PARAM_inherit(X509_VERIFY_PARAM *dest,
             return 0;
     }
 
-    /* Copy the host flags if and only if we're copying the host list */
+    x509_verify_param_copy(hostflags, 0);
+
     if (test_x509_verify_param_copy(hosts, NULL)) {
         sk_OPENSSL_STRING_pop_free(dest->hosts, str_free);
         dest->hosts = NULL;
@@ -208,7 +209,6 @@ int X509_VERIFY_PARAM_inherit(X509_VERIFY_PARAM *dest,
                 sk_OPENSSL_STRING_deep_copy(src->hosts, str_copy, str_free);
             if (dest->hosts == NULL)
                 return 0;
-            dest->hostflags = src->hostflags;
         }
     }
 


### PR DESCRIPTION
X509_VERIFY_PARAM_inherit() now copies hostflags independently of hosts.

Previously hostflags were only copied when at least one host was set.
Typically applications don't configure hosts on SSL_CTX. The change
enables applications to configure hostflags on SSL_CTX and have OpenSSL
copy the flags from SSL_CTX to SSL.

Fixes: https://github.com/openssl/openssl/issues/14579
Signed-off-by: Christian Heimes <christian@python.org>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [X] tests are added or updated
