### PR TITLE
Detect low-level engine based keys

### DIFF
--- a/crypto/dh/dh_backend.c
+++ b/crypto/dh/dh_backend.c
@@ -118,6 +118,15 @@ int ossl_dh_key_todata(DH *dh, OSSL_PARAM_BLD *bld, OSSL_PARAM params[])
     return 1;
 }
 
+int ossl_dh_is_foreign(const DH *dh)
+{
+#ifndef FIPS_MODULE
+    if (dh->engine != NULL || ossl_dh_get_method(dh) != DH_OpenSSL())
+        return 1;
+#endif
+    return 0;
+}
+
 static ossl_inline int dh_bn_dup_check(BIGNUM **out, const BIGNUM *f)
 {
     if (f != NULL && (*out = BN_dup(f)) == NULL)
@@ -129,11 +138,9 @@ DH *ossl_dh_dup(const DH *dh, int selection)
 {
     DH *dupkey = NULL;
 
-#ifndef FIPS_MODULE
     /* Do not try to duplicate foreign DH keys */
-    if (ossl_dh_get_method(dh) != DH_OpenSSL())
+    if (ossl_dh_is_foreign(dh))
         return NULL;
-#endif
 
     if ((dupkey = ossl_dh_new_ex(dh->libctx)) == NULL)
         return NULL;

--- a/crypto/ec/ec_backend.c
+++ b/crypto/ec/ec_backend.c
@@ -520,6 +520,16 @@ int ossl_ec_key_otherparams_fromdata(EC_KEY *ec, const OSSL_PARAM params[])
     return 1;
 }
 
+int ossl_ec_key_is_foreign(const EC_KEY *ec)
+{
+#ifndef FIPS_MODULE
+    if (ec->engine != NULL || EC_KEY_get_method(ec) != EC_KEY_OpenSSL())
+        return 1;
+#endif
+    return 0;
+
+}
+
 EC_KEY *ossl_ec_key_dup(const EC_KEY *src, int selection)
 {
     EC_KEY *ret = ossl_ec_key_new_method_int(src->libctx, src->propq,

--- a/crypto/evp/pmeth_lib.c
+++ b/crypto/evp/pmeth_lib.c
@@ -224,7 +224,7 @@ static EVP_PKEY_CTX *int_ctx_new(OSSL_LIB_CTX *libctx,
      */
     if (!ossl_assert(e == NULL || keytype == NULL))
         return NULL;
-    if (e == NULL)
+    if (e == NULL && (pkey == NULL || pkey->foreign == 0))
         keytype = OBJ_nid2sn(id);
 
 # ifndef OPENSSL_NO_ENGINE
@@ -246,6 +246,8 @@ static EVP_PKEY_CTX *int_ctx_new(OSSL_LIB_CTX *libctx,
      */
     if (e != NULL)
         pmeth = ENGINE_get_pkey_meth(e, id);
+    else if (pkey != NULL && pkey->foreign)
+        pmeth = EVP_PKEY_meth_find(id);
     else
 # endif
         pmeth = evp_pkey_meth_find_added_by_application(id);

--- a/include/crypto/dh.h
+++ b/include/crypto/dh.h
@@ -56,6 +56,7 @@ int ossl_dh_kdf_X9_42_asn1(unsigned char *out, size_t outlen,
                            const unsigned char *ukm, size_t ukmlen,
                            const EVP_MD *md,
                            OSSL_LIB_CTX *libctx, const char *propq);
+int ossl_dh_is_foreign(const DH *dh);
 DH *ossl_dh_dup(const DH *dh, int selection);
 
 #endif  /* OSSL_CRYPTO_DH_H */

--- a/include/crypto/dsa.h
+++ b/include/crypto/dsa.h
@@ -43,6 +43,7 @@ int ossl_dsa_check_pub_key_partial(const DSA *dsa, const BIGNUM *pub_key,
                                    int *ret);
 int ossl_dsa_check_priv_key(const DSA *dsa, const BIGNUM *priv_key, int *ret);
 int ossl_dsa_check_pairwise(const DSA *dsa);
+int ossl_dsa_is_foreign(const DSA *dsa);
 DSA *ossl_dsa_dup(const DSA *dsa, int selection);
 
 #endif

--- a/include/crypto/ec.h
+++ b/include/crypto/ec.h
@@ -79,6 +79,7 @@ int ossl_ec_group_set_params(EC_GROUP *group, const OSSL_PARAM params[]);
 int ossl_ec_key_fromdata(EC_KEY *ecx, const OSSL_PARAM params[],
                          int include_private);
 int ossl_ec_key_otherparams_fromdata(EC_KEY *ec, const OSSL_PARAM params[]);
+int ossl_ec_key_is_foreign(const EC_KEY *ec);
 EC_KEY *ossl_ec_key_dup(const EC_KEY *key, int selection);
 EC_KEY *ossl_ec_key_param_from_x509_algor(const X509_ALGOR *palg,
                                           OSSL_LIB_CTX *libctx,

--- a/include/crypto/evp.h
+++ b/include/crypto/evp.h
@@ -651,9 +651,10 @@ struct evp_pkey_st {
     /* == Common attributes == */
     CRYPTO_REF_COUNT references;
     CRYPTO_RWLOCK *lock;
+#ifndef FIPS_MODULE
     STACK_OF(X509_ATTRIBUTE) *attributes; /* [ 0 ] */
     int save_parameters;
-#ifndef FIPS_MODULE
+    int foreign:1; /* the low-level key is using an engine or an app-method */
     CRYPTO_EX_DATA ex_data;
 #endif
 

--- a/include/crypto/rsa.h
+++ b/include/crypto/rsa.h
@@ -63,6 +63,7 @@ int ossl_rsa_set0_all_params(RSA *r, const STACK_OF(BIGNUM) *primes,
 int ossl_rsa_get0_all_params(RSA *r, STACK_OF(BIGNUM_const) *primes,
                              STACK_OF(BIGNUM_const) *exps,
                              STACK_OF(BIGNUM_const) *coeffs);
+int ossl_rsa_is_foreign(const RSA *rsa);
 RSA *ossl_rsa_dup(const RSA *rsa, int selection);
 
 int ossl_rsa_todata(RSA *rsa, OSSL_PARAM_BLD *bld, OSSL_PARAM params[]);


### PR DESCRIPTION
The low-level engine based keys have to be treated as not
exportable to providers and used with old legacy pmeths.

Fixes #14632
