### PR TITLE
Rename EVP_PKEY_get0_first_alg_name to EVP_PKEY_get0_type_name

### DIFF
--- a/apps/dgst.c
+++ b/apps/dgst.c
@@ -427,7 +427,7 @@ int dgst_main(int argc, char **argv)
         const char *sig_name = NULL;
         if (!out_bin) {
             if (sigkey != NULL)
-                sig_name = EVP_PKEY_get0_first_alg_name(sigkey);
+                sig_name = EVP_PKEY_get0_type_name(sigkey);
         }
         ret = 0;
         for (i = 0; i < argc; i++) {

--- a/crypto/encode_decode/encoder_pkey.c
+++ b/crypto/encode_decode/encoder_pkey.c
@@ -316,7 +316,7 @@ OSSL_ENCODER_CTX *OSSL_ENCODER_CTX_new_for_pkey(const EVP_PKEY *pkey,
     OSSL_TRACE_BEGIN(ENCODER) {
         BIO_printf(trc_out,
                    "(ctx %p) Looking for %s encoders with selection %d\n",
-                   (void *)ctx, EVP_PKEY_get0_first_alg_name(pkey), selection);
+                   (void *)ctx, EVP_PKEY_get0_type_name(pkey), selection);
         BIO_printf(trc_out, "    output type: %s, output structure: %s\n",
                    output_type, output_struct);
     } OSSL_TRACE_END(ENCODER);

--- a/crypto/evp/evp_pkey.c
+++ b/crypto/evp/evp_pkey.c
@@ -219,7 +219,7 @@ int EVP_PKEY_add1_attr_by_txt(EVP_PKEY *key,
     return 0;
 }
 
-const char *EVP_PKEY_get0_first_alg_name(const EVP_PKEY *key)
+const char *EVP_PKEY_get0_type_name(const EVP_PKEY *key)
 {
     const EVP_PKEY_ASN1_METHOD *ameth;
     const char *name = NULL;

--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -970,9 +970,9 @@ int EVP_PKEY_is_a(const EVP_PKEY *pkey, const char *name)
     return EVP_KEYMGMT_is_a(pkey->keymgmt, name);
 }
 
-int EVP_PKEY_typenames_do_all(const EVP_PKEY *pkey,
-                              void (*fn)(const char *name, void *data),
-                              void *data)
+int EVP_PKEY_type_names_do_all(const EVP_PKEY *pkey,
+                               void (*fn)(const char *name, void *data),
+                               void *data)
 {
     if (!evp_pkey_is_typed(pkey))
         return 0;

--- a/doc/man3/EVP_PKEY_is_a.pod
+++ b/doc/man3/EVP_PKEY_is_a.pod
@@ -31,7 +31,7 @@ be named both C<RSA> and C<rsaEncryption>.
 The order of the names depends on the provider implementation that holds
 the key.
 
-EVP_PKEY_get0_type_name() returns the first algorithm type name that is found
+EVP_PKEY_get0_type_name() returns the first key type name that is found
 for the given I<pkey>. Note that the I<pkey> may have multiple synonyms
 associated with it. In this case it depends on the provider implementation
 that holds the key which one will be returned.

--- a/doc/man3/EVP_PKEY_is_a.pod
+++ b/doc/man3/EVP_PKEY_is_a.pod
@@ -2,8 +2,8 @@
 
 =head1 NAME
 
-EVP_PKEY_is_a, EVP_PKEY_can_sign, EVP_PKEY_typenames_do_all,
-EVP_PKEY_get0_first_alg_name
+EVP_PKEY_is_a, EVP_PKEY_can_sign, EVP_PKEY_type_names_do_all,
+EVP_PKEY_get0_type_name
 - key type and capabilities functions
 
 =head1 SYNOPSIS
@@ -12,10 +12,10 @@ EVP_PKEY_get0_first_alg_name
 
  int EVP_PKEY_is_a(const EVP_PKEY *pkey, const char *name);
  int EVP_PKEY_can_sign(const EVP_PKEY *pkey);
- int EVP_PKEY_typenames_do_all(const EVP_PKEY *pkey,
-                               void (*fn)(const char *name, void *data),
-                               void *data);
- const char *EVP_PKEY_get0_first_alg_name(const EVP_PKEY *key);
+ int EVP_PKEY_type_names_do_all(const EVP_PKEY *pkey,
+                                void (*fn)(const char *name, void *data),
+                                void *data);
+ const char *EVP_PKEY_get0_type_name(const EVP_PKEY *key);
 
 =head1 DESCRIPTION
 
@@ -25,14 +25,16 @@ EVP_PKEY_can_sign() checks if the functionality for the key type of
 I<pkey> supports signing.  No other check is done, such as whether
 I<pkey> contains a private key.
 
-EVP_PKEY_typenames_do_all() traverses all names for I<pkey>'s key type, and
+EVP_PKEY_type_names_do_all() traverses all names for I<pkey>'s key type, and
 calls I<fn> with each name and I<data>.  For example, an RSA B<EVP_PKEY> may
 be named both C<RSA> and C<rsaEncryption>.
-The order of the names is undefined.
+The order of the names depends on the provider implementation that holds
+the key.
 
-EVP_PKEY_get0_first_alg_name() returns the first algorithm name that is found
+EVP_PKEY_get0_type_name() returns the first algorithm type name that is found
 for the given I<pkey>. Note that the I<pkey> may have multiple synonyms
-associated with it. In this case it is undefined which one will be returned.
+associated with it. In this case it depends on the provider implementation
+that holds the key which one will be returned.
 Ownership of the returned string is retained by the I<pkey> object and should
 not be freed by the caller.
 
@@ -44,10 +46,11 @@ otherwise 0.
 EVP_PKEY_can_sign() returns 1 if the I<pkey> key type functionality
 supports signing, otherwise 0.
 
-EVP_PKEY_get0_first_alg_name() returns the name that is found or NULL on error.
+EVP_PKEY_get0_type_name() returns the name that is found or NULL on error.
 
-EVP_PKEY_typenames_do_all() returns 1 if the callback was called for all names.
-A return value of 0 means that the callback was not called for any names.
+EVP_PKEY_type_names_do_all() returns 1 if the callback was called for all
+names. A return value of 0 means that the callback was not called for any
+names.
 
 =head1 EXAMPLES
 

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -1248,9 +1248,9 @@ OSSL_DEPRECATEDIN_3_0 int EVP_PKEY_encrypt_old(unsigned char *enc_key,
                                           int key_len, EVP_PKEY *pub_key);
 #endif
 int EVP_PKEY_is_a(const EVP_PKEY *pkey, const char *name);
-int EVP_PKEY_typenames_do_all(const EVP_PKEY *pkey,
-                              void (*fn)(const char *name, void *data),
-                              void *data);
+int EVP_PKEY_type_names_do_all(const EVP_PKEY *pkey,
+                               void (*fn)(const char *name, void *data),
+                               void *data);
 int EVP_PKEY_type(int type);
 int EVP_PKEY_id(const EVP_PKEY *pkey);
 int EVP_PKEY_base_id(const EVP_PKEY *pkey);
@@ -1595,7 +1595,7 @@ int EVP_PKEY_CTX_get1_id_len(EVP_PKEY_CTX *ctx, size_t *id_len);
 
 int EVP_PKEY_CTX_set_kem_op(EVP_PKEY_CTX *ctx, const char *op);
 
-const char *EVP_PKEY_get0_first_alg_name(const EVP_PKEY *key);
+const char *EVP_PKEY_get0_type_name(const EVP_PKEY *key);
 
 # define EVP_PKEY_OP_UNDEFINED           0
 # define EVP_PKEY_OP_PARAMGEN            (1<<1)

--- a/test/algorithmid_test.c
+++ b/test/algorithmid_test.c
@@ -152,7 +152,7 @@ static int test_x509_sig_aid(X509 *eecert, const char *ee_filename,
                   ca_filename, ee_filename);
         TEST_info("Signature algorithm is %s (pkey type %s, hash type %s)",
                   OBJ_nid2sn(sig_nid), OBJ_nid2sn(pkey_nid), OBJ_nid2sn(dig_nid));
-        TEST_info("Pkey key type is %s", EVP_PKEY_get0_first_alg_name(pkey));
+        TEST_info("Pkey key type is %s", EVP_PKEY_get0_type_name(pkey));
         goto end;
     }
 

--- a/test/endecode_test.c
+++ b/test/endecode_test.c
@@ -494,7 +494,7 @@ static int check_unprotected_PKCS8_DER(const char *file, const int line,
 
         if (TEST_FL_ptr(pkey)) {
             if (!(ok = TEST_FL_true(EVP_PKEY_is_a(pkey, type)))) {
-                EVP_PKEY_typenames_do_all(pkey, collect_name, &namelist);
+                EVP_PKEY_type_names_do_all(pkey, collect_name, &namelist);
                 if (namelist != NULL)
                     TEST_note("%s isn't any of %s", type, namelist);
                 OPENSSL_free(namelist);

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5228,7 +5228,7 @@ EVP_PKEY_CTX_get1_id_len                ?	3_0_0	EXIST::FUNCTION:
 CMS_AuthEnvelopedData_create            ?	3_0_0	EXIST::FUNCTION:CMS
 CMS_AuthEnvelopedData_create_ex         ?	3_0_0	EXIST::FUNCTION:CMS
 EVP_PKEY_CTX_set_ec_param_enc           ?	3_0_0	EXIST::FUNCTION:
-EVP_PKEY_get0_first_alg_name            ?	3_0_0	EXIST::FUNCTION:
+EVP_PKEY_get0_type_name                 ?	3_0_0	EXIST::FUNCTION:
 EVP_KEYMGMT_get0_first_name             ?	3_0_0	EXIST::FUNCTION:
 EC_KEY_decoded_from_explicit_params     ?	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,EC
 EVP_KEM_free                            ?	3_0_0	EXIST::FUNCTION:
@@ -5259,7 +5259,7 @@ OSSL_ENCODER_CTX_set_construct          ?	3_0_0	EXIST::FUNCTION:
 OSSL_ENCODER_CTX_set_construct_data     ?	3_0_0	EXIST::FUNCTION:
 OSSL_ENCODER_CTX_set_cleanup            ?	3_0_0	EXIST::FUNCTION:
 OSSL_ENCODER_CTX_set_passphrase_cb      ?	3_0_0	EXIST::FUNCTION:
-EVP_PKEY_typenames_do_all               ?	3_0_0	EXIST::FUNCTION:
+EVP_PKEY_type_names_do_all              ?	3_0_0	EXIST::FUNCTION:
 OSSL_DECODER_INSTANCE_get_input_type    ?	3_0_0	EXIST::FUNCTION:
 EVP_ASYM_CIPHER_gettable_ctx_params     ?	3_0_0	EXIST::FUNCTION:
 EVP_ASYM_CIPHER_settable_ctx_params     ?	3_0_0	EXIST::FUNCTION:


### PR DESCRIPTION
We use type elsewhere and documenting the 'first' in the
name of the call is a little bit superfluous making the
name too mouthful.

Also rename EVP_PKEY_typenames_do_all to
EVP_PKEY_type_names_do_all to keep the words separated by
underscore.

Fixes #14701
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
