### PR TITLE
WIP: Do not install libkeyutils-dev in the external test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,7 +202,7 @@ jobs:
     - name: package installs
       run: |
         sudo apt-get update
-        sudo apt-get -yq install bison dejagnu gettext keyutils ldap-utils libldap2-dev libkeyutils-dev python3 python3-paste python3-pyrad slapd tcl-dev tcl-thread tcsh python3-virtualenv virtualenv
+        sudo apt-get -yq install bison dejagnu gettext ldap-utils libldap2-dev python3 python3-paste python3-pyrad slapd tcl-dev tcl-thread tcsh python3-virtualenv virtualenv
     - name: install cpanm and Test2::V0 for gost_engine testing
       uses: perl-actions/install-with-cpanm@v1
       with:


### PR DESCRIPTION
This might help workarounding the intermittent krb5 test failures seen recently.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
