### PR TITLE
Remove references to EVP_sha1() and EVP_sha256()

### DIFF
--- a/crypto/asn1/a_digest.c
+++ b/crypto/asn1/a_digest.c
@@ -75,8 +75,8 @@ int ossl_asn1_item_digest_ex(const ASN1_ITEM *it, const EVP_MD *md, void *asn,
 #endif
             fetched_md = EVP_MD_fetch(libctx, EVP_MD_name(md), propq);
     }
-     if (fetched_md == NULL)
-         goto err;
+    if (fetched_md == NULL)
+        goto err;
 
     ret = EVP_Digest(str, i, data, len, fetched_md, NULL);
 err:

--- a/crypto/cms/cms_smime.c
+++ b/crypto/cms/cms_smime.c
@@ -169,6 +169,10 @@ CMS_ContentInfo *CMS_digest_create_ex(BIO *in, const EVP_MD *md,
 {
     CMS_ContentInfo *cms;
 
+    /*
+     * Because the EVP_MD is cached and can be a legacy algorithm, we
+     * cannot fetch the algorithm if it isn't supplied.
+     */
     if (md == NULL)
         md = EVP_sha1();
     cms = ossl_cms_DigestedData_create(md, ctx, propq);

--- a/crypto/dsa/dsa_depr.c
+++ b/crypto/dsa/dsa_depr.c
@@ -18,13 +18,6 @@
  */
 #include "internal/deprecated.h"
 
-/*
- * Parameter generation follows the updated Appendix 2.2 for FIPS PUB 186,
- * also Appendix 2.2 of FIPS PUB 186-1 (i.e. use SHA as defined in FIPS PUB
- * 180-1)
- */
-#define xxxHASH    EVP_sha1()
-
 #include <openssl/opensslconf.h>
 
 #include <stdio.h>

--- a/crypto/evp/p5_crpt2.c
+++ b/crypto/evp/p5_crpt2.c
@@ -92,8 +92,14 @@ int PKCS5_PBKDF2_HMAC_SHA1(const char *pass, int passlen,
                            const unsigned char *salt, int saltlen, int iter,
                            int keylen, unsigned char *out)
 {
-    return PKCS5_PBKDF2_HMAC(pass, passlen, salt, saltlen, iter, EVP_sha1(),
-                             keylen, out);
+    EVP_MD *digest;
+    int r = 0;
+
+    if ((digest = EVP_MD_fetch(NULL, SN_sha1, NULL)) != NULL)
+        r = ossl_pkcs5_pbkdf2_hmac_ex(pass, passlen, salt, saltlen, iter,
+                                      digest, keylen, out, NULL, NULL);
+    EVP_MD_free(digest);
+    return r;
 }
 
 /*

--- a/crypto/ocsp/ocsp_lib.c
+++ b/crypto/ocsp/ocsp_lib.c
@@ -25,6 +25,7 @@ OCSP_CERTID *OCSP_cert_to_id(const EVP_MD *dgst, const X509 *subject,
     const X509_NAME *iname;
     const ASN1_INTEGER *serial;
     ASN1_BIT_STRING *ikey;
+
     if (!dgst)
         dgst = EVP_sha1();
     if (subject) {

--- a/crypto/pem/pvkfmt.c
+++ b/crypto/pem/pvkfmt.c
@@ -795,16 +795,19 @@ static int derive_pvk_key(unsigned char *key,
                           const unsigned char *pass, int passlen)
 {
     EVP_MD_CTX *mctx = EVP_MD_CTX_new();
+    EVP_MD *md = EVP_MD_fetch(NULL, SN_sha1, NULL);
     int rv = 1;
 
-    if (mctx == NULL
-        || !EVP_DigestInit_ex(mctx, EVP_sha1(), NULL)
+    if (md == NULL
+        || mctx == NULL
+        || !EVP_DigestInit_ex(mctx, md, NULL)
         || !EVP_DigestUpdate(mctx, salt, saltlen)
         || !EVP_DigestUpdate(mctx, pass, passlen)
         || !EVP_DigestFinal_ex(mctx, key, NULL))
         rv = 0;
 
     EVP_MD_CTX_free(mctx);
+    EVP_MD_free(md);
     return rv;
 }
 #endif


### PR DESCRIPTION
There are a few remaining references.  These take two forms:

1. legacy APIs that don't know to free the EVP_MD after they finish using it
2. APIs that only use the name or NID of the EVP_MD

Fixes #14387

- [ ] documentation is added or updated
- [ ] tests are added or updated
