### PR TITLE
Fix some TODO(3.0) occurrences in ssl/t1_lib.c

### DIFF
--- a/test/tls-provider.c
+++ b/test/tls-provider.c
@@ -169,7 +169,7 @@ static const OSSL_PARAM xor_kemgroup_params[] = {
 };
 
 #define NUM_DUMMY_GROUPS 50
-char *dummy_group_names[NUM_DUMMY_GROUPS];
+static char *dummy_group_names[NUM_DUMMY_GROUPS];
 
 static int tls_prov_get_capabilities(void *provctx, const char *capability,
                                      OSSL_CALLBACK *cb, void *arg)


### PR DESCRIPTION
One was related to probing for the combination of signature and hash
algorithm together. This is currently not easily possible. The TODO(3.0)
is converted to a normal comment and I've raised the problem as issue
number #14885 as something to resolve post 3.0.

The other TODO was a hard coded limit on the number of groups that could
be registered. This has been amended so that there is no limit.

Fixes #14333

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
