### PR TITLE
Don't worry about magic in the Makefile for 3.0

### DIFF
--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -1696,7 +1696,7 @@ EOF
                  @{$args{objs}};
       my @deps = compute_lib_depends(@{$args{deps}});
       my $shared_def = join("", map { ' '.$target{shared_defflag}.$_ } @defs);
-      # TODO(3.0): next line needs to become "less magic" (see PR #11950)
+      # Next line needs to become "less magic" (see PR #11950)
       $shared_def .= ' '.$target{shared_fipsflag} if (m/providers\/fips/ && defined $target{shared_fipsflag});
       my $objs = join(" \\\n\t\t", fill_lines(' ', $COLUMNS - 16, @objs));
       my $deps = join(" \\\n" . ' ' x (length($dso) + 2),


### PR DESCRIPTION
We remove a TODO(3.0) from the unix Makefile template. The current
approach works. It can be improved later.

Fixes #14403

