### PR TITLE
Remove a TODO(3.0) from keymgmt_lib.c

### DIFF
--- a/crypto/evp/keymgmt_lib.c
+++ b/crypto/evp/keymgmt_lib.c
@@ -121,10 +121,6 @@ void *evp_keymgmt_util_export_to_provider(EVP_PKEY *pk, EVP_KEYMGMT *keymgmt)
     CRYPTO_THREAD_unlock(pk->lock);
 
     /* If the "origin" |keymgmt| doesn't support exporting, give up */
-    /*
-     * TODO(3.0) consider an evp_keymgmt_export() return value that indicates
-     * that the method is unsupported.
-     */
     if (pk->keymgmt->export == NULL)
         return NULL;
 


### PR DESCRIPTION
The TODO suggest a possible refactoring. The refactoring doesn't seem
necessary at this stage. If it is required later it can be done without
affecting external APIs - so just remove the TODO.

Fixes #14397
