### PR TITLE
Change the semantics of OSSL_LIB_CTX_set0_default() NULL handling

### DIFF
--- a/crypto/context.c
+++ b/crypto/context.c
@@ -204,9 +204,11 @@ OSSL_LIB_CTX *OSSL_LIB_CTX_set0_default(OSSL_LIB_CTX *libctx)
 #ifndef FIPS_MODULE
     OSSL_LIB_CTX *current_defctx;
 
-    if ((current_defctx = get_default_context()) != NULL
-        && set_default_context(libctx))
+    if ((current_defctx = get_default_context()) != NULL) {
+        if (libctx != NULL)
+            set_default_context(libctx);
         return current_defctx;
+    }
 #endif
 
     return NULL;

--- a/crypto/context.c
+++ b/crypto/context.c
@@ -207,11 +207,9 @@ OSSL_LIB_CTX *OSSL_LIB_CTX_get0_global_default(void)
 
     return &default_context_int;
 }
-#endif
 
 OSSL_LIB_CTX *OSSL_LIB_CTX_set0_default(OSSL_LIB_CTX *libctx)
 {
-#ifndef FIPS_MODULE
     OSSL_LIB_CTX *current_defctx;
 
     if ((current_defctx = get_default_context()) != NULL) {
@@ -219,10 +217,10 @@ OSSL_LIB_CTX *OSSL_LIB_CTX_set0_default(OSSL_LIB_CTX *libctx)
             set_default_context(libctx);
         return current_defctx;
     }
-#endif
 
     return NULL;
 }
+#endif
 
 OSSL_LIB_CTX *ossl_lib_ctx_get_concrete(OSSL_LIB_CTX *ctx)
 {

--- a/crypto/context.c
+++ b/crypto/context.c
@@ -199,6 +199,15 @@ void OSSL_LIB_CTX_free(OSSL_LIB_CTX *ctx)
     OPENSSL_free(ctx);
 }
 
+OSSL_LIB_CTX *OSSL_LIB_CTX_get0_global_default(void)
+{
+#ifndef FIPS_MODULE
+    return &default_context_int;
+#else
+    return NULL;
+#endif
+}
+
 OSSL_LIB_CTX *OSSL_LIB_CTX_set0_default(OSSL_LIB_CTX *libctx)
 {
 #ifndef FIPS_MODULE

--- a/crypto/context.c
+++ b/crypto/context.c
@@ -199,14 +199,15 @@ void OSSL_LIB_CTX_free(OSSL_LIB_CTX *ctx)
     OPENSSL_free(ctx);
 }
 
+#ifndef FIPS_MODULE
 OSSL_LIB_CTX *OSSL_LIB_CTX_get0_global_default(void)
 {
-#ifndef FIPS_MODULE
+    if (!RUN_ONCE(&default_context_init, default_context_do_init))
+        return NULL;
+
     return &default_context_int;
-#else
-    return NULL;
-#endif
 }
+#endif
 
 OSSL_LIB_CTX *OSSL_LIB_CTX_set0_default(OSSL_LIB_CTX *libctx)
 {

--- a/doc/man3/OSSL_LIB_CTX.pod
+++ b/doc/man3/OSSL_LIB_CTX.pod
@@ -3,7 +3,7 @@
 =head1 NAME
 
 OSSL_LIB_CTX, OSSL_LIB_CTX_new, OSSL_LIB_CTX_free, OSSL_LIB_CTX_load_config,
-OSSL_LIB_CTX_set0_default
+OSSL_LIB_CTX_get0_global_default, OSSL_LIB_CTX_set0_default
 - OpenSSL library context
 
 =head1 SYNOPSIS
@@ -15,6 +15,7 @@ OSSL_LIB_CTX_set0_default
  OSSL_LIB_CTX *OSSL_LIB_CTX_new(void);
  int OSSL_LIB_CTX_load_config(OSSL_LIB_CTX *ctx, const char *config_file);
  void OSSL_LIB_CTX_free(OSSL_LIB_CTX *ctx);
+ OSSL_LIB_CTX *OSSL_LIB_CTX_get0_global_default(void);
  OSSL_LIB_CTX *OSSL_LIB_CTX_set0_default(OSSL_LIB_CTX *ctx);
 
 =head1 DESCRIPTION
@@ -38,12 +39,17 @@ from a configuration.
 OSSL_LIB_CTX_free() frees the given I<ctx>, unless it happens to be the
 default OpenSSL library context.
 
+OSSL_LIB_CTX_get0_global_default() returns a concrete (non NULL) reference to
+the global default library context.
+
 OSSL_LIB_CTX_set0_default() sets the default OpenSSL library context to be
 I<ctx> in the current thread.  The previous default library context is
 returned.  Care should be taken by the caller to restore the previous
 default library context with a subsequent call of this function. If I<ctx> is
 NULL then no change is made to the default library context, but a pointer to
-the current library context is still returned.
+the current library context is still returned. On a successful call of this
+function the returned value will always be a concrete (non NULL) library
+context.
 
 Care should be taken when changing the default library context and starting
 async jobs (see L<ASYNC_start_job(3)>), as the default library context when
@@ -55,15 +61,17 @@ that job has finished.
 
 =head1 RETURN VALUES
 
-OSSL_LIB_CTX_new() and OSSL_LIB_CTX_set0_default() return a library context
-pointer on success, or NULL on error.
+OSSL_LIB_CTX_new(), OSSL_LIB_CTX_get0_global_default() and
+OSSL_LIB_CTX_set0_default() return a library context pointer on success, or NULL
+on error.
 
 OSSL_LIB_CTX_free() doesn't return any value.
 
 =head1 HISTORY
 
-OSSL_LIB_CTX, OSSL_LIB_CTX_new(), OSSL_LIB_CTX_load_config(), OSSL_LIB_CTX_free()
-and OSSL_LIB_CTX_set0_default() were added in OpenSSL 3.0.
+OSSL_LIB_CTX, OSSL_LIB_CTX_new(), OSSL_LIB_CTX_load_config(),
+OSSL_LIB_CTX_free(), OSSL_LIB_CTX_get0_global_default() and
+OSSL_LIB_CTX_set0_default() were added in OpenSSL 3.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/OSSL_LIB_CTX.pod
+++ b/doc/man3/OSSL_LIB_CTX.pod
@@ -41,7 +41,9 @@ default OpenSSL library context.
 OSSL_LIB_CTX_set0_default() sets the default OpenSSL library context to be
 I<ctx> in the current thread.  The previous default library context is
 returned.  Care should be taken by the caller to restore the previous
-default library context with a subsequent call of this function.
+default library context with a subsequent call of this function. If I<ctx> is
+NULL then no change is made to the default library context, but a pointer to
+the current library context is still returned.
 
 Care should be taken when changing the default library context and starting
 async jobs (see L<ASYNC_start_job(3)>), as the default library context when

--- a/include/openssl/crypto.h.in
+++ b/include/openssl/crypto.h.in
@@ -519,6 +519,7 @@ int CRYPTO_THREAD_compare_id(CRYPTO_THREAD_ID a, CRYPTO_THREAD_ID b);
 OSSL_LIB_CTX *OSSL_LIB_CTX_new(void);
 int OSSL_LIB_CTX_load_config(OSSL_LIB_CTX *ctx, const char *config_file);
 void OSSL_LIB_CTX_free(OSSL_LIB_CTX *);
+OSSL_LIB_CTX *OSSL_LIB_CTX_get0_global_default(void);
 OSSL_LIB_CTX *OSSL_LIB_CTX_set0_default(OSSL_LIB_CTX *libctx);
 
 # ifdef  __cplusplus

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5352,3 +5352,4 @@ OSSL_PARAM_merge                        ?	3_0_0	EXIST::FUNCTION:
 OSSL_PARAM_free                         ?	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_todata                         ?	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_export                         ?	3_0_0	EXIST::FUNCTION:
+OSSL_LIB_CTX_get0_global_default        ?	3_0_0	EXIST::FUNCTION:


### PR DESCRIPTION
Change things so that passing NULL to OSSL_LIB_CTX_set0_default() means
keep the current library context unchanged.

This has the advantage of simplifying error handling, e.g. you can call
OSSL_LIB_CTX_set0_default in an error/finalisation block safe in the
knowledge the if the "prevctx" was never set then it will be a no-op (like
calling a "free" function with NULL).

Fixes #14593

