### PR TITLE
s390x: cipher must set EVP_CIPH_ALWAYS_CALL_INIT flag

### DIFF
--- a/crypto/evp/e_aes.c
+++ b/crypto/evp/e_aes.c
@@ -1168,9 +1168,9 @@ typedef struct {
 static int s390x_aes_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
                               const unsigned char *iv, int enc);
 
-# define S390X_aes_128_cbc_CAPABLE	1	/* checked by callee */
-# define S390X_aes_192_cbc_CAPABLE	1
-# define S390X_aes_256_cbc_CAPABLE	1
+# define S390X_aes_128_cbc_CAPABLE	0	/* checked by callee */
+# define S390X_aes_192_cbc_CAPABLE	0
+# define S390X_aes_256_cbc_CAPABLE	0
 # define S390X_AES_CBC_CTX		EVP_AES_KEY
 
 # define s390x_aes_cbc_init_key aes_init_key
@@ -1190,11 +1190,11 @@ static int s390x_aes_ecb_init_key(EVP_CIPHER_CTX *ctx,
     S390X_AES_ECB_CTX *cctx = EVP_C_DATA(S390X_AES_ECB_CTX, ctx);
     const int keylen = EVP_CIPHER_CTX_key_length(ctx);
 
-    cctx->fc = S390X_AES_FC(keylen);
-    if (!enc)
-        cctx->fc |= S390X_DECRYPT;
+    cctx->fc = S390X_AES_FC(keylen) | (enc ? 0 : S390X_DECRYPT);
 
-    memcpy(cctx->km.param.k, key, keylen);
+    if (key != NULL)
+        memcpy(cctx->km.param.k, key, keylen);
+
     return 1;
 }
 
@@ -1222,14 +1222,17 @@ static int s390x_aes_ofb_init_key(EVP_CIPHER_CTX *ctx,
                                   const unsigned char *ivec, int enc)
 {
     S390X_AES_OFB_CTX *cctx = EVP_C_DATA(S390X_AES_OFB_CTX, ctx);
-    const unsigned char *iv = EVP_CIPHER_CTX_original_iv(ctx);
+    const unsigned char *oiv = EVP_CIPHER_CTX_original_iv(ctx);
     const int keylen = EVP_CIPHER_CTX_key_length(ctx);
     const int ivlen = EVP_CIPHER_CTX_iv_length(ctx);
 
-    memcpy(cctx->kmo.param.cv, iv, ivlen);
-    memcpy(cctx->kmo.param.k, key, keylen);
     cctx->fc = S390X_AES_FC(keylen);
+
+    if (key != NULL)
+        memcpy(cctx->kmo.param.k, key, keylen);
+
     cctx->res = 0;
+    memcpy(cctx->kmo.param.cv, oiv, ivlen);
     return 1;
 }
 
@@ -1287,18 +1290,18 @@ static int s390x_aes_cfb_init_key(EVP_CIPHER_CTX *ctx,
                                   const unsigned char *ivec, int enc)
 {
     S390X_AES_CFB_CTX *cctx = EVP_C_DATA(S390X_AES_CFB_CTX, ctx);
-    const unsigned char *iv = EVP_CIPHER_CTX_original_iv(ctx);
+    const unsigned char *oiv = EVP_CIPHER_CTX_original_iv(ctx);
     const int keylen = EVP_CIPHER_CTX_key_length(ctx);
     const int ivlen = EVP_CIPHER_CTX_iv_length(ctx);
 
-    cctx->fc = S390X_AES_FC(keylen);
-    cctx->fc |= 16 << 24;   /* 16 bytes cipher feedback */
-    if (!enc)
-        cctx->fc |= S390X_DECRYPT;
+    cctx->fc = S390X_AES_FC(keylen) | (enc ? 0 : S390X_DECRYPT)
+               | (16 << 24); /* 16 bytes cipher feedback */
+
+    if (key != NULL)
+        memcpy(cctx->kmf.param.k, key, keylen);
 
     cctx->res = 0;
-    memcpy(cctx->kmf.param.cv, iv, ivlen);
-    memcpy(cctx->kmf.param.k, key, keylen);
+    memcpy(cctx->kmf.param.cv, oiv, ivlen);
     return 1;
 }
 
@@ -1360,17 +1363,18 @@ static int s390x_aes_cfb8_init_key(EVP_CIPHER_CTX *ctx,
                                    const unsigned char *ivec, int enc)
 {
     S390X_AES_CFB_CTX *cctx = EVP_C_DATA(S390X_AES_CFB_CTX, ctx);
-    const unsigned char *iv = EVP_CIPHER_CTX_original_iv(ctx);
+    const unsigned char *oiv = EVP_CIPHER_CTX_original_iv(ctx);
     const int keylen = EVP_CIPHER_CTX_key_length(ctx);
     const int ivlen = EVP_CIPHER_CTX_iv_length(ctx);
 
-    cctx->fc = S390X_AES_FC(keylen);
-    cctx->fc |= 1 << 24;   /* 1 byte cipher feedback */
-    if (!enc)
-        cctx->fc |= S390X_DECRYPT;
+    cctx->fc = S390X_AES_FC(keylen) | (enc ? 0 : S390X_DECRYPT)
+               | (1 << 24); /* 1 byte cipher feedback flag */
 
-    memcpy(cctx->kmf.param.cv, iv, ivlen);
-    memcpy(cctx->kmf.param.k, key, keylen);
+    if (key != NULL)
+        memcpy(cctx->kmf.param.k, key, keylen);
+
+    cctx->res = 0;
+    memcpy(cctx->kmf.param.cv, oiv, ivlen);
     return 1;
 }
 
@@ -1393,9 +1397,9 @@ static int s390x_aes_cfb8_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
 static int s390x_aes_cfb1_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
                                  const unsigned char *in, size_t len);
 
-# define S390X_aes_128_ctr_CAPABLE	1	/* checked by callee */
-# define S390X_aes_192_ctr_CAPABLE	1
-# define S390X_aes_256_ctr_CAPABLE	1
+# define S390X_aes_128_ctr_CAPABLE	0	/* checked by callee */
+# define S390X_aes_192_ctr_CAPABLE	0
+# define S390X_aes_256_ctr_CAPABLE	0
 # define S390X_AES_CTR_CTX		EVP_AES_KEY
 
 # define s390x_aes_ctr_init_key aes_init_key
@@ -1563,8 +1567,7 @@ static int s390x_aes_gcm(S390X_AES_GCM_CTX *ctx, const unsigned char *in,
 /*-
  * Initialize context structure. Code is big-endian.
  */
-static void s390x_aes_gcm_setiv(S390X_AES_GCM_CTX *ctx,
-                                const unsigned char *iv)
+static void s390x_aes_gcm_setiv(S390X_AES_GCM_CTX *ctx)
 {
     ctx->kma.param.t.g[0] = 0;
     ctx->kma.param.t.g[1] = 0;
@@ -1575,12 +1578,11 @@ static void s390x_aes_gcm_setiv(S390X_AES_GCM_CTX *ctx,
     ctx->kreslen = 0;
 
     if (ctx->ivlen == 12) {
-        memcpy(&ctx->kma.param.j0, iv, ctx->ivlen);
+        memcpy(&ctx->kma.param.j0, ctx->iv, ctx->ivlen);
         ctx->kma.param.j0.w[3] = 1;
         ctx->kma.param.cv.w = 1;
     } else {
         /* ctx->iv has the right size and is already padded. */
-        memcpy(ctx->iv, iv, ctx->ivlen);
         s390x_kma(ctx->iv, S390X_gcm_ivpadlen(ctx->ivlen), NULL, 0, NULL,
                   ctx->fc, &ctx->kma.param);
         ctx->fc |= S390X_KMA_HS;
@@ -1694,7 +1696,7 @@ static int s390x_aes_gcm_ctrl(EVP_CIPHER_CTX *c, int type, int arg, void *ptr)
         if (gctx->iv_gen == 0 || gctx->key_set == 0)
             return 0;
 
-        s390x_aes_gcm_setiv(gctx, gctx->iv);
+        s390x_aes_gcm_setiv(gctx);
 
         if (arg <= 0 || arg > gctx->ivlen)
             arg = gctx->ivlen;
@@ -1714,7 +1716,7 @@ static int s390x_aes_gcm_ctrl(EVP_CIPHER_CTX *c, int type, int arg, void *ptr)
             return 0;
 
         memcpy(gctx->iv + gctx->ivlen - arg, ptr, arg);
-        s390x_aes_gcm_setiv(gctx, gctx->iv);
+        s390x_aes_gcm_setiv(gctx);
         gctx->iv_set = 1;
         return 1;
 
@@ -1770,43 +1772,36 @@ static int s390x_aes_gcm_ctrl(EVP_CIPHER_CTX *c, int type, int arg, void *ptr)
 }
 
 /*-
- * Set key and/or iv. Returns 1 on success. Otherwise 0 is returned.
+ * Set key or iv or enc/dec. Returns 1 on success. Otherwise 0 is returned.
  */
 static int s390x_aes_gcm_init_key(EVP_CIPHER_CTX *ctx,
                                   const unsigned char *key,
                                   const unsigned char *iv, int enc)
 {
     S390X_AES_GCM_CTX *gctx = EVP_C_DATA(S390X_AES_GCM_CTX, ctx);
-    int keylen;
+    const int keylen = EVP_CIPHER_CTX_key_length(ctx);
 
-    if (iv == NULL && key == NULL)
-        return 1;
+    gctx->fc = S390X_AES_FC(keylen) | (enc ? 0 : S390X_DECRYPT);
 
     if (key != NULL) {
-        keylen = EVP_CIPHER_CTX_key_length(ctx);
+        gctx->fc &= ~S390X_KMA_HS;
         memcpy(&gctx->kma.param.k, key, keylen);
-
-        gctx->fc = S390X_AES_FC(keylen);
-        if (!enc)
-            gctx->fc |= S390X_DECRYPT;
-
-        if (iv == NULL && gctx->iv_set)
-            iv = gctx->iv;
-
-        if (iv != NULL) {
-            s390x_aes_gcm_setiv(gctx, iv);
-            gctx->iv_set = 1;
-        }
         gctx->key_set = 1;
-    } else {
-        if (gctx->key_set)
-            s390x_aes_gcm_setiv(gctx, iv);
-        else
-            memcpy(gctx->iv, iv, gctx->ivlen);
-
-        gctx->iv_set = 1;
-        gctx->iv_gen = 0;
     }
+
+    if (iv != NULL) {
+        memcpy(gctx->iv, iv, gctx->ivlen);
+        gctx->iv_gen = 0;
+        gctx->iv_set = 1;
+    }
+
+    if (gctx->key_set && gctx->iv_set)
+            s390x_aes_gcm_setiv(gctx);
+
+    gctx->fc &= ~(S390X_KMA_LPC | S390X_KMA_LAAD);
+    gctx->areslen = 0;
+    gctx->mreslen = 0;
+    gctx->kreslen = 0;
     return 1;
 }
 
@@ -1895,7 +1890,6 @@ static int s390x_aes_gcm_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
         /* recall that we already did en-/decrypt gctx->mres
          * and returned it to caller... */
         OPENSSL_cleanse(tmp, gctx->mreslen);
-        gctx->iv_set = 0;
 
         enc = EVP_CIPHER_CTX_encrypting(ctx);
         if (enc) {
@@ -1929,8 +1923,8 @@ static int s390x_aes_gcm_cleanup(EVP_CIPHER_CTX *c)
 }
 
 # define S390X_AES_XTS_CTX		EVP_AES_XTS_CTX
-# define S390X_aes_128_xts_CAPABLE	1	/* checked by callee */
-# define S390X_aes_256_xts_CAPABLE	1
+# define S390X_aes_128_xts_CAPABLE	0	/* checked by callee */
+# define S390X_aes_256_xts_CAPABLE	0
 
 # define s390x_aes_xts_init_key aes_xts_init_key
 static int s390x_aes_xts_init_key(EVP_CIPHER_CTX *ctx,
@@ -2134,9 +2128,10 @@ static int s390x_aes_ccm_tls_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
                                     const unsigned char *in, size_t len)
 {
     S390X_AES_CCM_CTX *cctx = EVP_C_DATA(S390X_AES_CCM_CTX, ctx);
-    unsigned char *ivec = EVP_CIPHER_CTX_iv_noconst(ctx);
+    const unsigned char *ivec = EVP_CIPHER_CTX_iv(ctx);
     unsigned char *buf = EVP_CIPHER_CTX_buf_noconst(ctx);
     const int enc = EVP_CIPHER_CTX_encrypting(ctx);
+    unsigned char iv[EVP_MAX_IV_LENGTH];
 
     if (out != in
             || len < (EVP_CCM_TLS_EXPLICIT_IV_LEN + (size_t)cctx->aes.ccm.m))
@@ -2152,8 +2147,9 @@ static int s390x_aes_ccm_tls_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
      * Get explicit iv (sequence number). We already have fixed iv
      * (server/client_write_iv) here.
      */
-    memcpy(ivec + EVP_CCM_TLS_FIXED_IV_LEN, in, EVP_CCM_TLS_EXPLICIT_IV_LEN);
-    s390x_aes_ccm_setiv(cctx, ivec, len);
+    memcpy(iv, ivec, sizeof(iv));
+    memcpy(iv + EVP_CCM_TLS_FIXED_IV_LEN, in, EVP_CCM_TLS_EXPLICIT_IV_LEN);
+    s390x_aes_ccm_setiv(cctx, iv, len);
 
     /* Process aad (sequence number|type|version|length) */
     s390x_aes_ccm_aad(cctx, buf, cctx->aes.ccm.tls_aad_len);
@@ -2180,42 +2176,35 @@ static int s390x_aes_ccm_tls_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
 }
 
 /*-
- * Set key and flag field and/or iv. Returns 1 if successful. Otherwise 0 is
- * returned.
+ * Set key or iv or enc/dec. Returns 1 if successful.
+ * Otherwise 0 is returned.
  */
 static int s390x_aes_ccm_init_key(EVP_CIPHER_CTX *ctx,
                                   const unsigned char *key,
                                   const unsigned char *iv, int enc)
 {
     S390X_AES_CCM_CTX *cctx = EVP_C_DATA(S390X_AES_CCM_CTX, ctx);
-    unsigned char *ivec;
-    int keylen;
+    const int keylen  = EVP_CIPHER_CTX_key_length(ctx);
+    unsigned char *ivec = EVP_CIPHER_CTX_iv_noconst(ctx);
 
-    if (iv == NULL && key == NULL)
-        return 1;
+    cctx->aes.ccm.fc = S390X_AES_FC(keylen);
 
     if (key != NULL) {
-        keylen = EVP_CIPHER_CTX_key_length(ctx);
-        cctx->aes.ccm.fc = S390X_AES_FC(keylen);
         memcpy(cctx->aes.ccm.kmac_param.k, key, keylen);
-
-        /* Store encoded m and l. */
-        cctx->aes.ccm.nonce.b[0] = ((cctx->aes.ccm.l - 1) & 0x7)
-                                 | (((cctx->aes.ccm.m - 2) >> 1) & 0x7) << 3;
-        memset(cctx->aes.ccm.nonce.b + 1, 0,
-               sizeof(cctx->aes.ccm.nonce.b));
-        cctx->aes.ccm.blocks = 0;
-
         cctx->aes.ccm.key_set = 1;
     }
-
     if (iv != NULL) {
-        ivec = EVP_CIPHER_CTX_iv_noconst(ctx);
         memcpy(ivec, iv, 15 - cctx->aes.ccm.l);
-
         cctx->aes.ccm.iv_set = 1;
     }
 
+    /* Store encoded m and l. */
+    cctx->aes.ccm.nonce.b[0] = ((cctx->aes.ccm.l - 1) & 0x7)
+                             | (((cctx->aes.ccm.m - 2) >> 1) & 0x7) << 3;
+    memset(cctx->aes.ccm.nonce.b + 1, 0, sizeof(cctx->aes.ccm.nonce.b) - 1);
+
+    cctx->aes.ccm.blocks = 0;
+    cctx->aes.ccm.len_set = 0;
     return 1;
 }
 
@@ -2230,8 +2219,9 @@ static int s390x_aes_ccm_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
 {
     S390X_AES_CCM_CTX *cctx = EVP_C_DATA(S390X_AES_CCM_CTX, ctx);
     const int enc = EVP_CIPHER_CTX_encrypting(ctx);
+    const unsigned char *ivec = EVP_CIPHER_CTX_iv(ctx);
+    unsigned char *buf;
     int rv;
-    unsigned char *buf, *ivec;
 
     if (!cctx->aes.ccm.key_set)
         return -1;
@@ -2253,7 +2243,6 @@ static int s390x_aes_ccm_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
     if (out == NULL) {
         /* Update(): Pass message length. */
         if (in == NULL) {
-            ivec = EVP_CIPHER_CTX_iv_noconst(ctx);
             s390x_aes_ccm_setiv(cctx, ivec, len);
 
             cctx->aes.ccm.len_set = 1;
@@ -2279,7 +2268,6 @@ static int s390x_aes_ccm_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
          * In case message length was not previously set explicitly via
          * Update(), set it now.
          */
-        ivec = EVP_CIPHER_CTX_iv_noconst(ctx);
         s390x_aes_ccm_setiv(cctx, ivec, len);
 
         cctx->aes.ccm.len_set = 1;
@@ -2304,9 +2292,6 @@ static int s390x_aes_ccm_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
         if (rv == -1)
             OPENSSL_cleanse(out, len);
 
-        cctx->aes.ccm.iv_set = 0;
-        cctx->aes.ccm.tag_set = 0;
-        cctx->aes.ccm.len_set = 0;
         return rv;
     }
 }
@@ -2414,9 +2399,6 @@ static int s390x_aes_ccm_ctrl(EVP_CIPHER_CTX *c, int type, int arg, void *ptr)
             return 0;
 
         memcpy(ptr, cctx->aes.ccm.kmac_param.icv.b, cctx->aes.ccm.m);
-        cctx->aes.ccm.tag_set = 0;
-        cctx->aes.ccm.iv_set = 0;
-        cctx->aes.ccm.len_set = 0;
         return 1;
 
     case EVP_CTRL_COPY:
@@ -2453,7 +2435,7 @@ static const EVP_CIPHER s390x_aes_##keylen##_##mode = {			\
     nid##_##keylen##_##nmode,blocksize,					\
     keylen / 8,								\
     ivlen,								\
-    flags | EVP_CIPH_##MODE##_MODE,					\
+    flags | EVP_CIPH_ALWAYS_CALL_INIT | EVP_CIPH_##MODE##_MODE,		\
     s390x_aes_##mode##_init_key,					\
     s390x_aes_##mode##_cipher,						\
     NULL,								\
@@ -2490,7 +2472,7 @@ static const EVP_CIPHER s390x_aes_##keylen##_##mode = {			\
     blocksize,								\
     (EVP_CIPH_##MODE##_MODE == EVP_CIPH_XTS_MODE ? 2 : 1) * keylen / 8,	\
     ivlen,								\
-    flags | EVP_CIPH_##MODE##_MODE,					\
+    flags | EVP_CIPH_ALWAYS_CALL_INIT | EVP_CIPH_##MODE##_MODE,		\
     s390x_aes_##mode##_init_key,					\
     s390x_aes_##mode##_cipher,						\
     s390x_aes_##mode##_cleanup,						\

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -320,6 +320,96 @@ static const unsigned char pExampleECParamDER[] = {
 };
 #endif
 
+static const unsigned char kCFBDefaultKey[] = {
+    0x2B, 0x7E, 0x15, 0x16, 0x28, 0xAE, 0xD2, 0xA6, 0xAB, 0xF7, 0x15, 0x88,
+    0x09, 0xCF, 0x4F, 0x3C
+};
+
+static const unsigned char kGCMDefaultKey[32] = { 0 };
+
+static const unsigned char kGCMResetKey[] = {
+    0xfe, 0xff, 0xe9, 0x92, 0x86, 0x65, 0x73, 0x1c, 0x6d, 0x6a, 0x8f, 0x94,
+    0x67, 0x30, 0x83, 0x08, 0xfe, 0xff, 0xe9, 0x92, 0x86, 0x65, 0x73, 0x1c,
+    0x6d, 0x6a, 0x8f, 0x94, 0x67, 0x30, 0x83, 0x08
+};
+
+static const unsigned char iCFBIV[] = {
+    0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B,
+    0x0C, 0x0D, 0x0E, 0x0F
+};
+
+static const unsigned char iGCMDefaultIV[12] = { 0 };
+
+static const unsigned char iGCMResetIV1[] = {
+    0xca, 0xfe, 0xba, 0xbe, 0xfa, 0xce, 0xdb, 0xad
+};
+
+static const unsigned char iGCMResetIV2[] = {
+    0xca, 0xfe, 0xba, 0xbe, 0xfa, 0xce, 0xdb, 0xad, 0xde, 0xca, 0xf8, 0x88
+};
+
+static const unsigned char cfbPlaintext[] = {
+    0x6B, 0xC1, 0xBE, 0xE2, 0x2E, 0x40, 0x9F, 0x96, 0xE9, 0x3D, 0x7E, 0x11,
+    0x73, 0x93, 0x17, 0x2A
+};
+
+static const unsigned char gcmDefaultPlaintext[16] = { 0 };
+
+static const unsigned char gcmResetPlaintext[] = {
+    0xd9, 0x31, 0x32, 0x25, 0xf8, 0x84, 0x06, 0xe5, 0xa5, 0x59, 0x09, 0xc5,
+    0xaf, 0xf5, 0x26, 0x9a, 0x86, 0xa7, 0xa9, 0x53, 0x15, 0x34, 0xf7, 0xda,
+    0x2e, 0x4c, 0x30, 0x3d, 0x8a, 0x31, 0x8a, 0x72, 0x1c, 0x3c, 0x0c, 0x95,
+    0x95, 0x68, 0x09, 0x53, 0x2f, 0xcf, 0x0e, 0x24, 0x49, 0xa6, 0xb5, 0x25,
+    0xb1, 0x6a, 0xed, 0xf5, 0xaa, 0x0d, 0xe6, 0x57, 0xba, 0x63, 0x7b, 0x39
+};
+
+static const unsigned char cfbCiphertext[] = {
+    0x3B, 0x3F, 0xD9, 0x2E, 0xB7, 0x2D, 0xAD, 0x20, 0x33, 0x34, 0x49, 0xF8,
+    0xE8, 0x3C, 0xFB, 0x4A
+};
+
+static const unsigned char gcmDefaultCiphertext[] = {
+    0xce, 0xa7, 0x40, 0x3d, 0x4d, 0x60, 0x6b, 0x6e, 0x07, 0x4e, 0xc5, 0xd3,
+    0xba, 0xf3, 0x9d, 0x18
+};
+
+static const unsigned char gcmResetCiphertext1[] = {
+    0xc3, 0x76, 0x2d, 0xf1, 0xca, 0x78, 0x7d, 0x32, 0xae, 0x47, 0xc1, 0x3b,
+    0xf1, 0x98, 0x44, 0xcb, 0xaf, 0x1a, 0xe1, 0x4d, 0x0b, 0x97, 0x6a, 0xfa,
+    0xc5, 0x2f, 0xf7, 0xd7, 0x9b, 0xba, 0x9d, 0xe0, 0xfe, 0xb5, 0x82, 0xd3,
+    0x39, 0x34, 0xa4, 0xf0, 0x95, 0x4c, 0xc2, 0x36, 0x3b, 0xc7, 0x3f, 0x78,
+    0x62, 0xac, 0x43, 0x0e, 0x64, 0xab, 0xe4, 0x99, 0xf4, 0x7c, 0x9b, 0x1f
+};
+
+static const unsigned char gcmResetCiphertext2[] = {
+    0x52, 0x2d, 0xc1, 0xf0, 0x99, 0x56, 0x7d, 0x07, 0xf4, 0x7f, 0x37, 0xa3,
+    0x2a, 0x84, 0x42, 0x7d, 0x64, 0x3a, 0x8c, 0xdc, 0xbf, 0xe5, 0xc0, 0xc9,
+    0x75, 0x98, 0xa2, 0xbd, 0x25, 0x55, 0xd1, 0xaa, 0x8c, 0xb0, 0x8e, 0x48,
+    0x59, 0x0d, 0xbb, 0x3d, 0xa7, 0xb0, 0x8b, 0x10, 0x56, 0x82, 0x88, 0x38,
+    0xc5, 0xf6, 0x1e, 0x63, 0x93, 0xba, 0x7a, 0x0a, 0xbc, 0xc9, 0xf6, 0x62
+};
+
+static const unsigned char gcmAAD[] = {
+    0xfe, 0xed, 0xfa, 0xce, 0xde, 0xad, 0xbe, 0xef, 0xfe, 0xed, 0xfa, 0xce,
+    0xde, 0xad, 0xbe, 0xef, 0xab, 0xad, 0xda, 0xd2
+};
+
+static const unsigned char gcmDefaultTag[] = {
+    0xd0, 0xd1, 0xc8, 0xa7, 0x99, 0x99, 0x6b, 0xf0, 0x26, 0x5b, 0x98, 0xb5,
+    0xd4, 0x8a, 0xb9, 0x19
+};
+
+static const unsigned char gcmResetTag1[] = {
+    0x3a, 0x33, 0x7d, 0xbf, 0x46, 0xa7, 0x92, 0xc4, 0x5e, 0x45, 0x49, 0x13,
+    0xfe, 0x2e, 0xa8, 0xf2
+};
+
+static const unsigned char gcmResetTag2[] = {
+    0x76, 0xfc, 0x6e, 0xce, 0x0f, 0x4e, 0x17, 0x68, 0xcd, 0xdf, 0x88, 0x53,
+    0xbb, 0x2d, 0x55, 0x1b
+};
+
+
 typedef struct APK_DATA_st {
     const unsigned char *kder;
     size_t size;
@@ -329,6 +419,385 @@ typedef struct APK_DATA_st {
     int param_check;
     int type; /* 0 for private, 1 for public, 2 for params */
 } APK_DATA;
+
+typedef struct {
+    const char *cipher;
+    const unsigned char *key;
+    const unsigned char *iv;
+    const unsigned char *input;
+    const unsigned char *expected;
+    const unsigned char *tag;
+    size_t ivlen; /* 0 if we do not need to set a specific IV len */
+    size_t inlen;
+    size_t expectedlen;
+    size_t taglen;
+    int keyfirst;
+    int initenc;
+    int finalenc;
+} EVP_INIT_TEST_st;
+
+static const EVP_INIT_TEST_st evp_init_tests[] = {
+    {
+        "aes-128-cfb", kCFBDefaultKey, iCFBIV, cfbPlaintext,
+        cfbCiphertext, NULL, 0, sizeof(cfbPlaintext), sizeof(cfbCiphertext),
+        0, 1, 0, 1
+    },
+    {
+        "aes-256-gcm", kGCMDefaultKey, iGCMDefaultIV, gcmDefaultPlaintext,
+        gcmDefaultCiphertext, gcmDefaultTag, sizeof(iGCMDefaultIV),
+        sizeof(gcmDefaultPlaintext), sizeof(gcmDefaultCiphertext),
+        sizeof(gcmDefaultTag), 1, 0, 1
+    },
+    {
+        "aes-128-cfb", kCFBDefaultKey, iCFBIV, cfbPlaintext,
+        cfbCiphertext, NULL, 0, sizeof(cfbPlaintext), sizeof(cfbCiphertext),
+        0, 0, 0, 1
+    },
+    {
+        "aes-256-gcm", kGCMDefaultKey, iGCMDefaultIV, gcmDefaultPlaintext,
+        gcmDefaultCiphertext, gcmDefaultTag, sizeof(iGCMDefaultIV),
+        sizeof(gcmDefaultPlaintext), sizeof(gcmDefaultCiphertext),
+        sizeof(gcmDefaultTag), 0, 0, 1
+    },
+    {
+        "aes-128-cfb", kCFBDefaultKey, iCFBIV, cfbCiphertext,
+        cfbPlaintext, NULL, 0, sizeof(cfbCiphertext), sizeof(cfbPlaintext),
+        0, 1, 1, 0
+    },
+    {
+        "aes-256-gcm", kGCMDefaultKey, iGCMDefaultIV, gcmDefaultCiphertext,
+        gcmDefaultPlaintext, gcmDefaultTag, sizeof(iGCMDefaultIV),
+        sizeof(gcmDefaultCiphertext), sizeof(gcmDefaultPlaintext),
+        sizeof(gcmDefaultTag), 1, 1, 0
+    },
+    {
+        "aes-128-cfb", kCFBDefaultKey, iCFBIV, cfbCiphertext,
+        cfbPlaintext, NULL, 0, sizeof(cfbCiphertext), sizeof(cfbPlaintext),
+        0, 0, 1, 0
+    },
+    {
+        "aes-256-gcm", kGCMDefaultKey, iGCMDefaultIV, gcmDefaultCiphertext,
+        gcmDefaultPlaintext, gcmDefaultTag, sizeof(iGCMDefaultIV),
+        sizeof(gcmDefaultCiphertext), sizeof(gcmDefaultPlaintext),
+        sizeof(gcmDefaultTag), 0, 1, 0
+    }
+};
+
+static int evp_init_seq_set_iv(EVP_CIPHER_CTX *ctx, const EVP_INIT_TEST_st *t)
+{
+    int res = 0;
+
+    if (t->ivlen != 0) {
+        if (!TEST_true(EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_IVLEN, t->ivlen, NULL)))
+            goto err;
+    }
+    if (!TEST_true(EVP_CipherInit_ex(ctx, NULL, NULL, NULL, t->iv, -1)))
+        goto err;
+    res = 1;
+ err:
+    return res;
+}
+
+/*
+ * Test step-wise cipher initialization via EVP_CipherInit_ex where the
+ * arguments are given one at a time and a final adjustment to the enc
+ * parameter sets the correct operation.
+ */
+static int test_evp_init_seq(int idx)
+{
+    int outlen1, outlen2;
+    int testresult = 0;
+    unsigned char outbuf[1024];
+    unsigned char tag[16];
+    const EVP_INIT_TEST_st *t = &evp_init_tests[idx];
+    EVP_CIPHER_CTX *ctx = NULL;
+    const EVP_CIPHER *type = NULL;
+    size_t taglen = sizeof(tag);
+    char *errmsg = NULL;
+
+    ctx = EVP_CIPHER_CTX_new();
+    if (ctx == NULL) {
+        errmsg = "CTX_ALLOC";
+        goto err;
+    }
+    if (!TEST_ptr(type = EVP_get_cipherbyname(t->cipher))) {
+        errmsg = "GET_CIPHERBYNAME";
+        goto err;
+    }
+    if (!TEST_true(EVP_CipherInit_ex(ctx, type, NULL, NULL, NULL, t->initenc))) {
+        errmsg = "EMPTY_ENC_INIT";
+        goto err;
+    }
+    if (!TEST_true(EVP_CIPHER_CTX_set_padding(ctx, 0))) {
+        errmsg = "PADDING";
+        goto err;
+    }
+    if (t->keyfirst && !TEST_true(EVP_CipherInit_ex(ctx, NULL, NULL, t->key, NULL, -1))) {
+        errmsg = "KEY_INIT (before iv)";
+        goto err;
+    }
+    if (!evp_init_seq_set_iv(ctx, t)) {
+        errmsg = "IV_INIT";
+        goto err;
+    }
+    if (t->keyfirst == 0 &&  !TEST_true(EVP_CipherInit_ex(ctx, NULL, NULL, t->key, NULL, -1))) {
+        errmsg = "KEY_INIT (after iv)";
+        goto err;
+    }
+    if (!TEST_true(EVP_CipherInit_ex(ctx, NULL, NULL, NULL, NULL, t->finalenc))) {
+        errmsg = "FINAL_ENC_INIT";
+        goto err;
+    }
+    if (!TEST_true(EVP_CipherUpdate(ctx, outbuf, &outlen1, t->input, t->inlen))) {
+        errmsg = "CIPHER_UPDATE";
+        goto err;
+    }
+    if (t->finalenc == 0 && t->tag != NULL) {
+        /* Set expected tag */
+        if (!TEST_true(EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_AEAD_SET_TAG,
+                                           t->taglen, (void *)t->tag))) {
+            errmsg = "SET_TAG";
+            goto err;
+        }
+    }
+    if (!TEST_true(EVP_CipherFinal_ex(ctx, outbuf + outlen1, &outlen2))) {
+        errmsg = "CIPHER_FINAL";
+        goto err;
+    }
+    if (!TEST_mem_eq(t->expected, t->expectedlen, outbuf, outlen1 + outlen2)) {
+        errmsg = "WRONG_RESULT";
+        goto err;
+    }
+    if (t->finalenc != 0 && t->tag != NULL) {
+        if (!TEST_true(EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_AEAD_GET_TAG, taglen, tag))) {
+            errmsg = "GET_TAG";
+            goto err;
+        }
+        if (!TEST_mem_eq(t->tag, t->taglen, tag, taglen)) {
+            errmsg = "TAG_ERROR";
+            goto err;
+        }
+    }
+    testresult = 1;
+ err:
+    if (errmsg != NULL)
+        TEST_info("evp_init_test %d: %s", idx, errmsg);
+    EVP_CIPHER_CTX_free(ctx);
+    return testresult;
+}
+
+typedef struct {
+    const unsigned char *input;
+    const unsigned char *expected;
+    size_t inlen;
+    size_t expectedlen;
+    int enc;
+} EVP_RESET_TEST_st;
+
+static const EVP_RESET_TEST_st evp_reset_tests[] = {
+    {
+        cfbPlaintext, cfbCiphertext,
+        sizeof(cfbPlaintext), sizeof(cfbCiphertext), 1
+    },
+    {
+        cfbCiphertext, cfbPlaintext,
+        sizeof(cfbCiphertext), sizeof(cfbPlaintext), 0
+    }
+};
+
+/*
+ * Test a reset of a cipher via EVP_CipherInit_ex after the cipher has already
+ * been used.
+ */
+static int test_evp_reset(int idx)
+{
+    const EVP_RESET_TEST_st *t = &evp_reset_tests[idx];
+    int outlen1, outlen2;
+    int testresult = 0;
+    unsigned char outbuf[1024];
+    EVP_CIPHER_CTX *ctx = NULL;
+    const EVP_CIPHER *type = NULL;
+    char *errmsg = NULL;
+
+    if (!TEST_ptr(ctx = EVP_CIPHER_CTX_new())) {
+        errmsg = "CTX_ALLOC";
+        goto err;
+    }
+    if (!TEST_ptr(type = EVP_get_cipherbyname("aes-128-cfb"))) {
+        errmsg = "GET_CIPHERBYNAME";
+        goto err;
+    }
+    if (!TEST_true(EVP_CipherInit_ex(ctx, type, NULL, kCFBDefaultKey, iCFBIV, t->enc))) {
+        errmsg = "CIPHER_INIT";
+        goto err;
+    }
+    if (!TEST_true(EVP_CIPHER_CTX_set_padding(ctx, 0))) {
+        errmsg = "PADDING";
+        goto err;
+    }
+    if (!TEST_true(EVP_CipherUpdate(ctx, outbuf, &outlen1, t->input, t->inlen))) {
+        errmsg = "CIPHER_UPDATE";
+        goto err;
+    }
+    if (!TEST_true(EVP_CipherFinal_ex(ctx, outbuf + outlen1, &outlen2))) {
+        errmsg = "CIPHER_FINAL";
+        goto err;
+    }
+    if (!TEST_mem_eq(t->expected, t->expectedlen, outbuf, outlen1 + outlen2)) {
+        errmsg = "WRONG_RESULT";
+        goto err;
+    }
+    if (!TEST_true(EVP_CipherInit_ex(ctx, NULL, NULL, NULL, NULL, -1))) {
+        errmsg = "CIPHER_REINIT";
+        goto err;
+    }
+    if (!TEST_true(EVP_CipherUpdate(ctx, outbuf, &outlen1, t->input, t->inlen))) {
+        errmsg = "CIPHER_UPDATE (reinit)";
+        goto err;
+    }
+    if (!TEST_true(EVP_CipherFinal_ex(ctx, outbuf + outlen1, &outlen2))) {
+        errmsg = "CIPHER_FINAL (reinit)";
+        goto err;
+    }
+    if (!TEST_mem_eq(t->expected, t->expectedlen, outbuf, outlen1 + outlen2)) {
+        errmsg = "WRONG_RESULT (reinit)";
+        goto err;
+    }
+    testresult = 1;
+ err:
+    if (errmsg != NULL)
+        TEST_info("test_evp_reset %d: %s", idx, errmsg);
+    EVP_CIPHER_CTX_free(ctx);
+    return testresult;
+}
+
+typedef struct {
+    const unsigned char *iv1;
+    const unsigned char *iv2;
+    const unsigned char *expected1;
+    const unsigned char *expected2;
+    const unsigned char *tag1;
+    const unsigned char *tag2;
+    size_t ivlen1;
+    size_t ivlen2;
+    size_t expectedlen1;
+    size_t expectedlen2;
+} TEST_GCM_IV_REINIT_st;
+
+static const TEST_GCM_IV_REINIT_st gcm_reinit_tests[] = {
+    {
+        iGCMResetIV1, iGCMResetIV2, gcmResetCiphertext1, gcmResetCiphertext2,
+        gcmResetTag1, gcmResetTag2, sizeof(iGCMResetIV1), sizeof(iGCMResetIV2),
+        sizeof(gcmResetCiphertext1), sizeof(gcmResetCiphertext2)
+    },
+    {
+        iGCMResetIV2, iGCMResetIV1, gcmResetCiphertext2, gcmResetCiphertext1,
+        gcmResetTag2, gcmResetTag1, sizeof(iGCMResetIV2), sizeof(iGCMResetIV1),
+        sizeof(gcmResetCiphertext2), sizeof(gcmResetCiphertext1)
+    }
+};
+
+static int test_gcm_reinit(int idx)
+{
+    int outlen1, outlen2, outlen3;
+    int testresult = 0;
+    unsigned char outbuf[1024];
+    unsigned char tag[16];
+    const TEST_GCM_IV_REINIT_st *t = &gcm_reinit_tests[idx];
+    EVP_CIPHER_CTX *ctx = NULL;
+    const EVP_CIPHER *type = NULL;
+    size_t taglen = sizeof(tag);
+    char *errmsg = NULL;
+
+    if (!TEST_ptr(ctx = EVP_CIPHER_CTX_new())) {
+        errmsg = "CTX_ALLOC";
+        goto err;
+    }
+    if (!TEST_ptr(type = EVP_get_cipherbyname("aes-256-gcm"))) {
+        errmsg = "GET_CIPHERBYNAME";
+        goto err;
+    }
+    if (!TEST_true(EVP_CipherInit_ex(ctx, type, NULL, NULL, NULL, 1))) {
+        errmsg = "ENC_INIT";
+        goto err;
+    }
+    if (!TEST_true(EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_IVLEN, t->ivlen1, NULL))) {
+        errmsg = "SET_IVLEN1";
+        goto err;
+    }
+    if (!TEST_true(EVP_CipherInit_ex(ctx, NULL, NULL, kGCMResetKey, t->iv1, 1))) {
+        errmsg = "SET_IV1";
+        goto err;
+    }
+    if (!TEST_true(EVP_CipherUpdate(ctx, NULL, &outlen3, gcmAAD, sizeof(gcmAAD)))) {
+        errmsg = "AAD1";
+        goto err;
+    }
+    EVP_CIPHER_CTX_set_padding(ctx, 0);
+    if (!TEST_true(EVP_CipherUpdate(ctx, outbuf, &outlen1, gcmResetPlaintext,
+                                    sizeof(gcmResetPlaintext)))) {
+        errmsg = "CIPHER_UPDATE1";
+        goto err;
+    }
+    if (!TEST_true(EVP_CipherFinal_ex(ctx, outbuf + outlen1, &outlen2))) {
+        errmsg = "CIPHER_FINAL1";
+        goto err;
+    }
+    if (!TEST_mem_eq(t->expected1, t->expectedlen1, outbuf, outlen1 + outlen2)) {
+        errmsg = "WRONG_RESULT1";
+        goto err;
+    }
+    if (!TEST_true(EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_AEAD_GET_TAG, taglen, tag))) {
+        errmsg = "GET_TAG1";
+        goto err;
+    }
+    if (!TEST_mem_eq(t->tag1, taglen, tag, taglen)) {
+        errmsg = "TAG_ERROR1";
+        goto err;
+    }
+    /* Now reinit */
+    if (!TEST_true(EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_IVLEN, t->ivlen2, NULL))) {
+        errmsg = "SET_IVLEN2";
+        goto err;
+    }
+    if (!TEST_true(EVP_CipherInit_ex(ctx, NULL, NULL, NULL, t->iv2, -1))) {
+        errmsg = "SET_IV2";
+        goto err;
+    }
+    if (!TEST_true(EVP_CipherUpdate(ctx, NULL, &outlen3, gcmAAD, sizeof(gcmAAD)))) {
+        errmsg = "AAD2";
+        goto err;
+    }
+    if (!TEST_true(EVP_CipherUpdate(ctx, outbuf, &outlen1, gcmResetPlaintext,
+                                    sizeof(gcmResetPlaintext)))) {
+        errmsg = "CIPHER_UPDATE2";
+        goto err;
+    }
+    if (!TEST_true(EVP_CipherFinal_ex(ctx, outbuf + outlen1, &outlen2))) {
+        errmsg = "CIPHER_FINAL2";
+        goto err;
+    }
+    if (!TEST_mem_eq(t->expected2, t->expectedlen2, outbuf, outlen1 + outlen2)) {
+        errmsg = "WRONG_RESULT2";
+        goto err;
+    }
+    if (!TEST_true(EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_AEAD_GET_TAG, taglen, tag))) {
+        errmsg = "GET_TAG2";
+        goto err;
+    }
+    if (!TEST_mem_eq(t->tag2, taglen, tag, taglen)) {
+        errmsg = "TAG_ERROR2";
+        goto err;
+    }
+    testresult = 1;
+ err:
+    if (errmsg != NULL)
+        TEST_info("evp_init_test %d: %s", idx, errmsg);
+    EVP_CIPHER_CTX_free(ctx);
+    return testresult;
+}
+
+
 
 static APK_DATA keydata[] = {
     {kExampleRSAKeyDER, sizeof(kExampleRSAKeyDER), EVP_PKEY_RSA},
@@ -1208,6 +1677,10 @@ int setup_tests(void)
 #ifndef OPENSSL_NO_DH
     ADD_TEST(test_EVP_PKEY_set1_DH);
 #endif
+
+    ADD_ALL_TESTS(test_evp_init_seq, OSSL_NELEM(evp_init_tests));
+    ADD_ALL_TESTS(test_evp_reset, OSSL_NELEM(evp_reset_tests));
+    ADD_ALL_TESTS(test_gcm_reinit, OSSL_NELEM(gcm_reinit_tests));
 
     return 1;
 }


### PR DESCRIPTION
The s390x cipher implementations must call their init function
even if the key argument is NULL to allow initializing the
cipher operation's context in any order.


Note that the same issue is present on master but im still looking for a way to fix it since the EVP_CIPH_ALWAYS_CALL_INIT flag (and flags in general) are now legacy members of the EVP_CIPHER structure and not checked anymore in the new code paths.