### PR TITLE
Makefile: improve run_tests

### DIFF
--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -506,7 +506,8 @@ build_all_generated: $(GENERATED_MANDATORY) $(GENERATED) build_docs
 all: build_sw build_docs
 
 test: tests
-{- dependmagic('tests'); -}: build_programs_nodep build_modules_nodep link-utils
+{- dependmagic('tests'); -}: build_programs_nodep build_modules_nodep link-utils run_tests
+run_tests:
 	@ : {- output_off() if $disabled{tests}; "" -}
 	( SRCTOP=$(SRCDIR) \
 	  BLDTOP=$(BLDDIR) \
@@ -520,8 +521,7 @@ test: tests
 
 list-tests:
 	@ : {- output_off() if $disabled{tests}; "" -}
-	@SRCTOP="$(SRCDIR)" \
-	 $(PERL) $(SRCDIR)/test/run_tests.pl list
+	$(MAKE) run_tests TESTS=list
 	@ : {- if ($disabled{tests}) { output_on(); } else { output_off(); } "" -}
 	@echo "Tests are not supported with your chosen Configure options"
 	@ : {- output_on() if !$disabled{tests}; "" -}
@@ -1254,10 +1254,7 @@ ordinals: build_generated
                 $(SSLHEADERS)
 
 test_ordinals:
-	( cd test; \
-	  SRCTOP=../$(SRCDIR) \
-	  BLDTOP=../$(BLDDIR) \
-	    $(PERL) ../$(SRCDIR)/test/run_tests.pl test_ordinals )
+	$(MAKE) run_tests TESTS=test_ordinals
 
 tags TAGS: FORCE
 	rm -f TAGS tags

--- a/providers/build.info
+++ b/providers/build.info
@@ -119,7 +119,7 @@ IF[{- !$disabled{fips} -}]
   # the generated commands in build templates are expected to catch that,
   # and thereby keep control over the exact output file location.
   IF[{- !$disabled{tests} -}]
-    DEPEND[|tests|]=fipsmodule.cnf
+    DEPEND[|run_tests|]=fipsmodule.cnf
     GENERATE[fipsmodule.cnf]=../apps/openssl fipsinstall \
           -module providers/$(FIPSMODULENAME) -provider_name fips \
           -mac_name HMAC -section_name fips_sect


### PR DESCRIPTION
Simplify use of `run_tests`, both in the (Unix) Makefile itself, and for external use.

For instance, when selectively running tests, one often uses, e.g.,
```
make tests TESTS=test_x509
```
Yet this re-builds all prerequisites - which is good for basic use, but when doing quick experiments it can be a hassle having to wait untll even unrelated stuff gets re-compiled.
With the new `run_tests` target, experiences users can selectively re-build what they need and then call a pretty lean
```
make run_tests TESTS=test_x509
```

Moreover, after switching branches and re-building without `make clean`, it can happen easily that tests fail as follows:
```
Error loading config from file ../../test/fips-and-base.cnf
40478974377F0000:error:1C8000D6:Provider routines:SELF_TEST_post:module integrity failure:providers/fips/self_test.c:295:
40478974377F0000:error:1C8000E0:Provider routines:ossl_set_error_state:fips module entering error state:providers/fips/self_test.c:368:
40478974377F0000:error:1C8000D8:Provider routines:OSSL_provider_init:self test post failure:providers/fips/fipsprov.c:641:
40478974377F0000:error:078C0105:common libcrypto routines:provider_init:init fail:crypto/provider_core.c:580:name=fips
40478974377F0000:error:0700006D:configuration file routines:module_run:module initialization error:crypto/conf/conf_mod.c:242:module=providers, value=provider_sect retcode=-1      
```
It turns out that this is because `providers/fipsmodule.cnf` has become out of sync for `providers/fips.so`, and this not always fixed properly by `make test`.
To prevent this nuisance, I've made sure that the dependency on `providers/fipsmodule.cnf` is not added to the `tests` target but to the new `run_tests` target:
```
run_tests: providers/fipsmodule.cnf
```