### PR TITLE
Use build.info not file-wide ifndef

### DIFF
--- a/apps/build.info
+++ b/apps/build.info
@@ -12,7 +12,7 @@ ENDIF
 # Source for the 'openssl' program
 $OPENSSLSRC=\
         openssl.c progs.c \
-        asn1pars.c ca.c ciphers.c cms.c crl.c crl2p7.c dgst.c \
+        asn1pars.c ca.c ciphers.c crl.c crl2p7.c dgst.c \
         enc.c errstr.c \
         genpkey.c kdf.c mac.c nseq.c passwd.c pkcs7.c \
         pkcs8.c pkey.c pkeyparam.c pkeyutl.c prime.c rand.c req.c \
@@ -50,6 +50,9 @@ IF[{- !$disabled{'deprecated-3.0'} -}]
   IF[{- !$disabled{'rsa'} -}]
     $OPENSSLSRC=$OPENSSLSRC rsautl.c
   ENDIF
+ENDIF
+IF[{- !$disabled{'cms'} -}]
+  $OPENSSLSRC=$OPENSSLSRC cms.c
 ENDIF
 IF[{- !$disabled{'cmp'} -}]
   $OPENSSLSRC=$OPENSSLSRC cmp.c cmp_mock_srv.c

--- a/apps/cms.c
+++ b/apps/cms.c
@@ -274,7 +274,6 @@ int cms_main(int argc, char **argv)
     CMS_ReceiptRequest *rr = NULL;
     ENGINE *e = NULL;
     EVP_PKEY *key = NULL;
-    char *wrapname = NULL;
     const EVP_CIPHER *cipher = NULL, *wrap_cipher = NULL;
     const EVP_MD *sign_md = NULL;
     STACK_OF(OPENSSL_STRING) *rr_to = NULL, *rr_from = NULL;
@@ -691,7 +690,8 @@ int cms_main(int argc, char **argv)
             wrap_cipher = EVP_aes_256_wrap();
             break;
         case OPT_WRAP:
-            wrapname = opt_unknown();
+            if (!opt_cipher(opt_unknown(), &wrap_cipher))
+                goto end;
             break;
         }
     }
@@ -704,10 +704,6 @@ int cms_main(int argc, char **argv)
     }
     if (ciphername != NULL) {
         if (!opt_cipher(ciphername, &cipher))
-            goto end;
-    }
-    if (wrapname != NULL) {
-        if (!opt_cipher(wrapname, &wrap_cipher))
             goto end;
     }
 

--- a/apps/cms.c
+++ b/apps/cms.c
@@ -14,14 +14,12 @@
 #include "apps.h"
 #include "progs.h"
 
-#ifndef OPENSSL_NO_CMS
-
-# include <openssl/crypto.h>
-# include <openssl/pem.h>
-# include <openssl/err.h>
-# include <openssl/x509_vfy.h>
-# include <openssl/x509v3.h>
-# include <openssl/cms.h>
+#include <openssl/crypto.h>
+#include <openssl/pem.h>
+#include <openssl/err.h>
+#include <openssl/x509_vfy.h>
+#include <openssl/x509v3.h>
+#include <openssl/cms.h>
 
 static int save_certs(char *signerfile, STACK_OF(X509) *signers);
 static int cms_cb(int ok, X509_STORE_CTX *ctx);
@@ -32,25 +30,25 @@ static CMS_ReceiptRequest *make_receipt_request(
 static int cms_set_pkey_param(EVP_PKEY_CTX *pctx,
                               STACK_OF(OPENSSL_STRING) *param);
 
-# define SMIME_OP        0x10
-# define SMIME_IP        0x20
-# define SMIME_SIGNERS   0x40
-# define SMIME_ENCRYPT           (1 | SMIME_OP)
-# define SMIME_DECRYPT           (2 | SMIME_IP)
-# define SMIME_SIGN              (3 | SMIME_OP | SMIME_SIGNERS)
-# define SMIME_VERIFY            (4 | SMIME_IP)
-# define SMIME_CMSOUT            (5 | SMIME_IP | SMIME_OP)
-# define SMIME_RESIGN            (6 | SMIME_IP | SMIME_OP | SMIME_SIGNERS)
-# define SMIME_DATAOUT           (7 | SMIME_IP)
-# define SMIME_DATA_CREATE       (8 | SMIME_OP)
-# define SMIME_DIGEST_VERIFY     (9 | SMIME_IP)
-# define SMIME_DIGEST_CREATE     (10 | SMIME_OP)
-# define SMIME_UNCOMPRESS        (11 | SMIME_IP)
-# define SMIME_COMPRESS          (12 | SMIME_OP)
-# define SMIME_ENCRYPTED_DECRYPT (13 | SMIME_IP)
-# define SMIME_ENCRYPTED_ENCRYPT (14 | SMIME_OP)
-# define SMIME_SIGN_RECEIPT      (15 | SMIME_IP | SMIME_OP)
-# define SMIME_VERIFY_RECEIPT    (16 | SMIME_IP)
+#define SMIME_OP        0x10
+#define SMIME_IP        0x20
+#define SMIME_SIGNERS   0x40
+#define SMIME_ENCRYPT           (1 | SMIME_OP)
+#define SMIME_DECRYPT           (2 | SMIME_IP)
+#define SMIME_SIGN              (3 | SMIME_OP | SMIME_SIGNERS)
+#define SMIME_VERIFY            (4 | SMIME_IP)
+#define SMIME_CMSOUT            (5 | SMIME_IP | SMIME_OP)
+#define SMIME_RESIGN            (6 | SMIME_IP | SMIME_OP | SMIME_SIGNERS)
+#define SMIME_DATAOUT           (7 | SMIME_IP)
+#define SMIME_DATA_CREATE       (8 | SMIME_OP)
+#define SMIME_DIGEST_VERIFY     (9 | SMIME_IP)
+#define SMIME_DIGEST_CREATE     (10 | SMIME_OP)
+#define SMIME_UNCOMPRESS        (11 | SMIME_IP)
+#define SMIME_COMPRESS          (12 | SMIME_OP)
+#define SMIME_ENCRYPTED_DECRYPT (13 | SMIME_IP)
+#define SMIME_ENCRYPTED_ENCRYPT (14 | SMIME_OP)
+#define SMIME_SIGN_RECEIPT      (15 | SMIME_IP | SMIME_OP)
+#define SMIME_VERIFY_RECEIPT    (16 | SMIME_IP)
 
 static int verify_err = 0;
 
@@ -276,6 +274,7 @@ int cms_main(int argc, char **argv)
     CMS_ReceiptRequest *rr = NULL;
     ENGINE *e = NULL;
     EVP_PKEY *key = NULL;
+    char *wrapname = NULL;
     const EVP_CIPHER *cipher = NULL, *wrap_cipher = NULL;
     const EVP_MD *sign_md = NULL;
     STACK_OF(OPENSSL_STRING) *rr_to = NULL, *rr_from = NULL;
@@ -692,8 +691,7 @@ int cms_main(int argc, char **argv)
             wrap_cipher = EVP_aes_256_wrap();
             break;
         case OPT_WRAP:
-            if (!opt_cipher(opt_unknown(), &wrap_cipher))
-                goto end;
+            wrapname = opt_unknown();
             break;
         }
     }
@@ -706,6 +704,10 @@ int cms_main(int argc, char **argv)
     }
     if (ciphername != NULL) {
         if (!opt_cipher(ciphername, &cipher))
+            goto end;
+    }
+    if (wrapname != NULL) {
+        if (!opt_cipher(wrapname, &wrap_cipher))
             goto end;
     }
 
@@ -972,7 +974,7 @@ int cms_main(int argc, char **argv)
                 goto end;
 
             if (CMS_RecipientInfo_type(ri) == CMS_RECIPINFO_AGREE
-                && wrap_cipher) {
+                    && wrap_cipher != NULL) {
                 EVP_CIPHER_CTX *wctx;
                 wctx = CMS_RecipientInfo_kari_get0_ctx(ri);
                 EVP_EncryptInit_ex(wctx, wrap_cipher, NULL, NULL, NULL);
@@ -1436,5 +1438,3 @@ static int cms_set_pkey_param(EVP_PKEY_CTX *pctx,
     }
     return 1;
 }
-
-#endif


### PR DESCRIPTION
If configured with no-cms, handle it in build.info like the other options.
I guess I missed doing this file in PR #11250
