### PR TITLE
params_dup: fix off by one error that allows array overreach.

### DIFF
--- a/crypto/params_dup.c
+++ b/crypto/params_dup.c
@@ -147,8 +147,8 @@ static int compare_params(const void *left, const void *right)
 
 OSSL_PARAM *OSSL_PARAM_merge(const OSSL_PARAM *p1, const OSSL_PARAM *p2)
 {
-    const OSSL_PARAM *list1[OSSL_PARAM_MERGE_LIST_MAX];
-    const OSSL_PARAM *list2[OSSL_PARAM_MERGE_LIST_MAX];
+    const OSSL_PARAM *list1[OSSL_PARAM_MERGE_LIST_MAX + 1];
+    const OSSL_PARAM *list2[OSSL_PARAM_MERGE_LIST_MAX + 1];
     const OSSL_PARAM *p = NULL;
     const OSSL_PARAM **p1cur, **p2cur;
     OSSL_PARAM *params, *dst;


### PR DESCRIPTION
The end of loop test allows the index to go one step too far to be able to
terminate the param array but the end of list record is still added.
