### PR TITLE
ASN1: Ensure that d2i_ASN1_OBJECT() frees the strings on ASN1_OBJECT reuse

### DIFF
--- a/crypto/asn1/a_object.c
+++ b/crypto/asn1/a_object.c
@@ -286,16 +286,13 @@ ASN1_OBJECT *c2i_ASN1_OBJECT(ASN1_OBJECT **a, const unsigned char **pp,
         }
     }
 
-    /*
-     * only the ASN1_OBJECTs from the 'table' will have values for ->sn or
-     * ->ln
-     */
     if ((a == NULL) || ((*a) == NULL) ||
         !((*a)->flags & ASN1_OBJECT_FLAG_DYNAMIC)) {
         if ((ret = ASN1_OBJECT_new()) == NULL)
             return NULL;
-    } else
+    } else {
         ret = (*a);
+    }
 
     p = *pp;
     /* detach data from object */
@@ -313,6 +310,12 @@ ASN1_OBJECT *c2i_ASN1_OBJECT(ASN1_OBJECT **a, const unsigned char **pp,
         ret->flags |= ASN1_OBJECT_FLAG_DYNAMIC_DATA;
     }
     memcpy(data, p, length);
+    /* If there are dynamic strings, free them here, and clear the flag */
+    if ((ret->flags & ASN1_OBJECT_FLAG_DYNAMIC_STRINGS) != 0) {
+        OPENSSL_free(ret->sn);
+        OPENSSL_free(ret->ln);
+        ret->flags &= ~ASN1_OBJECT_FLAG_DYNAMIC_STRINGS;
+    }
     /* reattach data to object, after which it remains const */
     ret->data = data;
     ret->length = length;

--- a/crypto/asn1/a_object.c
+++ b/crypto/asn1/a_object.c
@@ -312,8 +312,8 @@ ASN1_OBJECT *c2i_ASN1_OBJECT(ASN1_OBJECT **a, const unsigned char **pp,
     memcpy(data, p, length);
     /* If there are dynamic strings, free them here, and clear the flag */
     if ((ret->flags & ASN1_OBJECT_FLAG_DYNAMIC_STRINGS) != 0) {
-        OPENSSL_free(ret->sn);
-        OPENSSL_free(ret->ln);
+        OPENSSL_free((char *)ret->sn);
+        OPENSSL_free((char *)ret->ln);
         ret->flags &= ~ASN1_OBJECT_FLAG_DYNAMIC_STRINGS;
     }
     /* reattach data to object, after which it remains const */

--- a/test/asn1_decode_test.c
+++ b/test/asn1_decode_test.c
@@ -195,6 +195,30 @@ static int test_invalid_template(void)
     return 0;
 }
 
+static int test_reuse_asn1_object(void)
+{
+    static unsigned char cn_der[] = { 0x06, 0x03, 0x55, 0x04, 0x06 };
+    static unsigned char oid_der[] = {
+        0x06, 0x06, 0x2a, 0x03, 0x04, 0x05, 0x06, 0x07
+    };
+    int ret = 0;
+    ASN1_OBJECT *obj;
+    unsigned char const *p = oid_der;
+
+    /* Create an object that owns dynamically allocated 'sn' and 'ln' fields */
+
+    if (!TEST_ptr(obj = ASN1_OBJECT_create(NID_undef, cn_der, sizeof(cn_der),
+                                           "C", "countryName")))
+        goto err;
+    /* reuse obj - this should not leak sn and ln */
+    if (!TEST_ptr(d2i_ASN1_OBJECT(&obj, &p, sizeof(oid_der))))
+        goto err;
+    ret = 1;
+err:
+    ASN1_OBJECT_free(obj);
+    return ret;
+}
+
 int setup_tests(void)
 {
 #if OPENSSL_API_COMPAT < 0x10200000L
@@ -205,5 +229,6 @@ int setup_tests(void)
     ADD_TEST(test_int64);
     ADD_TEST(test_uint64);
     ADD_TEST(test_invalid_template);
+    ADD_TEST(test_reuse_asn1_object);
     return 1;
 }

--- a/test/asn1_decode_test.c
+++ b/test/asn1_decode_test.c
@@ -12,6 +12,7 @@
 
 #include <openssl/rand.h>
 #include <openssl/asn1t.h>
+#include <openssl/obj_mac.h>
 #include "internal/numbers.h"
 #include "testutil.h"
 


### PR DESCRIPTION
The 'sn' and 'ln' strings may be dynamically allocated, and the
ASN1_OBJECT flags have a bit set to say this.  If an ASN1_OBJECT with
such strings is passed to d2i_ASN1_OBJECT() for reuse, the strings
must be freed, or there is a memory leak.

Fixes #14667
