### PR TITLE
Avoid the need for Configure time 128-bit int detection

### DIFF
--- a/Configure
+++ b/Configure
@@ -1573,20 +1573,6 @@ if (!$disabled{asm} && !$predefined_C{__MACH__} && $^O ne 'VMS') {
     }
 }
 
-# Check if __SIZEOF_INT128__ is defined by compiler
-$config{use_int128} = 0;
-{
-    my $cc = $config{CROSS_COMPILE}.$config{CC};
-    open(PIPE, "$cc -E -dM - </dev/null 2>&1 |");
-    while(<PIPE>) {
-        if (m/__SIZEOF_INT128__/) {
-            $config{use_int128} = 1;
-            last;
-        }
-    }
-    close(PIPE);
-}
-
 # Deal with bn_ops ###################################################
 
 $config{bn_ll}                  =0;

--- a/crypto/ec/build.info
+++ b/crypto/ec/build.info
@@ -50,13 +50,8 @@ $COMMON=ec_lib.c ecp_smpl.c ecp_mont.c ecp_nist.c ec_cvt.c ec_mult.c \
         ecdsa_ossl.c ecdsa_sign.c ecdsa_vrf.c curve25519.c \
         curve448/f_generic.c curve448/scalar.c \
         curve448/curve448_tables.c curve448/eddsa.c curve448/curve448.c \
-        $ECASM ec_backend.c ecx_backend.c ecdh_kdf.c
-
-IF[{- $config{'use_int128'} eq "1" -}]
-  $COMMON=$COMMON curve448/arch_64/f_impl.c
-ELSE
-  $COMMON=$COMMON curve448/arch_32/f_impl.c
-ENDIF
+        $ECASM ec_backend.c ecx_backend.c ecdh_kdf.c curve448/arch_64/f_impl64.c \
+        curve448/arch_32/f_impl32.c
 
 IF[{- !$disabled{'ec_nistp_64_gcc_128'} -}]
   $COMMON=$COMMON ecp_nistp224.c ecp_nistp256.c ecp_nistp521.c ecp_nistputil.c

--- a/crypto/ec/curve448/arch_32/f_impl32.c
+++ b/crypto/ec/curve448/arch_32/f_impl32.c
@@ -10,7 +10,15 @@
  * Originally written by Mike Hamburg
  */
 
-#include "../field.h"
+#include "openssl/macros.h"
+#include "internal/numbers.h"
+
+#ifdef UINT128_MAX
+/* We have support for 128 bit ints, so do nothing here */
+NON_EMPTY_TRANSLATION_UNIT
+#else
+
+# include "../field.h"
 
 void gf_mul(gf_s * RESTRICT cs, const gf as, const gf bs)
 {
@@ -93,3 +101,4 @@ void gf_sqr(gf_s * RESTRICT cs, const gf as)
 {
     gf_mul(cs, as, as);         /* Performs better with a dedicated square */
 }
+#endif

--- a/crypto/ec/curve448/arch_64/f_impl64.c
+++ b/crypto/ec/curve448/arch_64/f_impl64.c
@@ -10,7 +10,15 @@
  * Originally written by Mike Hamburg
  */
 
-#include "../field.h"
+#include "openssl/macros.h"
+#include "internal/numbers.h"
+
+#ifndef UINT128_MAX
+/* No support for 128 bit ints, so do nothing here */
+NON_EMPTY_TRANSLATION_UNIT
+#else
+
+# include "../field.h"
 
 void gf_mul(gf_s * RESTRICT cs, const gf as, const gf bs)
 {
@@ -198,3 +206,4 @@ void gf_sqr(gf_s * RESTRICT cs, const gf as)
     c[4] += ((uint64_t)(accum0)) + ((uint64_t)(accum1));
     c[0] += ((uint64_t)(accum1));
 }
+#endif


### PR DESCRIPTION
We just detect this at compile time instead.

This avoids cross-compilation problems where the host platform supports
128-bit ints, but the target platform does not (or vice versa). This was
causing a problem on some platforms where, dependent on the CFLAGS, 128 bit
ints were either supported or not.

Fixes #14804
