### PR TITLE
Remove an unused parameter

### DIFF
--- a/apps/cms.c
+++ b/apps/cms.c
@@ -1415,7 +1415,7 @@ static CMS_ReceiptRequest *make_receipt_request(
         rct_from = NULL;
     }
     rr = CMS_ReceiptRequest_create0_ex(NULL, -1, rr_allorfirst, rct_from,
-                                       rct_to, libctx, app_get0_propq());
+                                       rct_to, libctx);
     return rr;
  err:
     sk_GENERAL_NAMES_pop_free(rct_to, GENERAL_NAMES_free);

--- a/crypto/cms/cms_ess.c
+++ b/crypto/cms/cms_ess.c
@@ -63,7 +63,7 @@ int ossl_cms_check_signing_certs(const CMS_SignerInfo *si,
 CMS_ReceiptRequest *CMS_ReceiptRequest_create0_ex(
     unsigned char *id, int idlen, int allorfirst,
     STACK_OF(GENERAL_NAMES) *receiptList, STACK_OF(GENERAL_NAMES) *receiptsTo,
-    OSSL_LIB_CTX *libctx, const char *propq)
+    OSSL_LIB_CTX *libctx)
 {
     CMS_ReceiptRequest *rr;
 
@@ -106,7 +106,7 @@ CMS_ReceiptRequest *CMS_ReceiptRequest_create0(
     STACK_OF(GENERAL_NAMES) *receiptList, STACK_OF(GENERAL_NAMES) *receiptsTo)
 {
     return CMS_ReceiptRequest_create0_ex(id, idlen, allorfirst, receiptList,
-                                         receiptsTo, NULL, NULL);
+                                         receiptsTo, NULL);
 }
 
 int CMS_add1_ReceiptRequest(CMS_SignerInfo *si, CMS_ReceiptRequest *rr)

--- a/doc/man3/CMS_get1_ReceiptRequest.pod
+++ b/doc/man3/CMS_get1_ReceiptRequest.pod
@@ -13,7 +13,7 @@ CMS_add1_ReceiptRequest, CMS_get1_ReceiptRequest, CMS_ReceiptRequest_get0_values
  CMS_ReceiptRequest *CMS_ReceiptRequest_create0_ex(
      unsigned char *id, int idlen, int allorfirst,
      STACK_OF(GENERAL_NAMES) *receiptList, STACK_OF(GENERAL_NAMES) *receiptsTo,
-     OSSL_LIB_CTX *libctx, const char *propq);
+     OSSL_LIB_CTX *libctx);
  CMS_ReceiptRequest *CMS_ReceiptRequest_create0(
      unsigned char *id, int idlen, int allorfirst,
      STACK_OF(GENERAL_NAMES) *receiptList, STACK_OF(GENERAL_NAMES) *receiptsTo);
@@ -33,11 +33,11 @@ If I<receiptList> is NULL the allOrFirstTier option in I<receiptsFrom> is used
 and set to the value of the I<allorfirst> parameter. If I<receiptList> is not
 NULL the I<receiptList> option in I<receiptsFrom> is used. The I<receiptsTo>
 parameter specifies the I<receiptsTo> field value. The library context I<libctx>
-and the property query I<propq> are used when retrieving algorithms from providers.
+is used to find the public random generator.
 
 CMS_ReceiptRequest_create0() is similar to
 CMS_ReceiptRequest_create0_ex() but uses default values of NULL for the
-library context I<libctx> and the property query I<propq>.
+library context I<libctx>.
 
 The CMS_add1_ReceiptRequest() function adds a signed receipt request B<rr>
 to SignerInfo structure B<si>.

--- a/include/openssl/cms.h.in
+++ b/include/openssl/cms.h.in
@@ -343,7 +343,7 @@ CMS_ReceiptRequest *CMS_ReceiptRequest_create0_ex(
     unsigned char *id, int idlen, int allorfirst,
     STACK_OF(GENERAL_NAMES) *receiptList,
     STACK_OF(GENERAL_NAMES) *receiptsTo,
-    OSSL_LIB_CTX *ctx, const char *propq);
+    OSSL_LIB_CTX *ctx);
 
 int CMS_add1_ReceiptRequest(CMS_SignerInfo *si, CMS_ReceiptRequest *rr);
 void CMS_ReceiptRequest_get0_values(CMS_ReceiptRequest *rr,


### PR DESCRIPTION
In reply to https://github.com/openssl/openssl/pull/14064#issuecomment-823118200

All that changes is documenting the one, existing, parameter.

 Fixes #13943 
