### PR TITLE
Some compilers define __STDC_VERSION__ in c++

### DIFF
--- a/include/openssl/e_os2.h
+++ b/include/openssl/e_os2.h
@@ -274,7 +274,8 @@ typedef unsigned __int64 uint64_t;
 #  define ossl_inline inline
 # endif
 
-# if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
+# if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L && \
+     !defined(__cplusplus) 
 #  define ossl_noreturn _Noreturn
 # elif defined(__GNUC__) && __GNUC__ >= 2
 #  define ossl_noreturn __attribute__((noreturn))


### PR DESCRIPTION
Some compilers(g++ on Solaris/Illumos) define __STDC__VERSION__ in c++ .
This causes c++ code that uses openssl to break on these compilers since
_Noreturn is not a keyword in c++ .

CLA: trivial
