### PR TITLE
Force public key to be included unless explicitly excluded

### DIFF
--- a/apps/ec.c
+++ b/apps/ec.c
@@ -211,10 +211,16 @@ int ec_main(int argc, char **argv)
         goto end;
     }
 
-    if (no_public
-        && !EVP_PKEY_set_int_param(eckey, OSSL_PKEY_PARAM_EC_INCLUDE_PUBLIC, 0)) {
-        BIO_printf(bio_err, "unable to disable public key encoding\n");
-        goto end;
+    if (no_public) {
+        if (!EVP_PKEY_set_int_param(eckey, OSSL_PKEY_PARAM_EC_INCLUDE_PUBLIC, 0)) {
+            BIO_printf(bio_err, "unable to disable public key encoding\n");
+            goto end;
+        }
+    } else {
+        if (!EVP_PKEY_set_int_param(eckey, OSSL_PKEY_PARAM_EC_INCLUDE_PUBLIC, 1)) {
+            BIO_printf(bio_err, "unable to enable public key encoding\n");
+            goto end;
+        }
     }
 
     if (text) {


### PR DESCRIPTION
If the public key is not included in an EC private key file there is no way to re-enable it; this patch makes the public key component be included by default unless the -no_public flag is explicitly present.

Fixes #5979 in a lighter touch method directly in the EC tool after PR #5980 was abandoned for multiple years without a CLA or responding to feedback.

CLA PDF has been filed via e-mail from the address associated with commit / this github account.