### PR TITLE
Add missing argname for keymgmt_gettable_params and keymgmt_settable_params prototypes

### DIFF
--- a/include/openssl/core_dispatch.h
+++ b/include/openssl/core_dispatch.h
@@ -552,13 +552,15 @@ OSSL_CORE_MAKE_FUNC(void, keymgmt_free, (void *keydata))
 #define OSSL_FUNC_KEYMGMT_GETTABLE_PARAMS             12
 OSSL_CORE_MAKE_FUNC(int, keymgmt_get_params,
                     (void *keydata, OSSL_PARAM params[]))
-OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, keymgmt_gettable_params, (void *))
+OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, keymgmt_gettable_params,
+                    (void *provctx))
 
 #define OSSL_FUNC_KEYMGMT_SET_PARAMS                  13
 #define OSSL_FUNC_KEYMGMT_SETTABLE_PARAMS             14
 OSSL_CORE_MAKE_FUNC(int, keymgmt_set_params,
                     (void *keydata, const OSSL_PARAM params[]))
-OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, keymgmt_settable_params, (void *))
+OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, keymgmt_settable_params,
+                    (void *provctx))
 
 /* Key checks - discovery of supported operations */
 # define OSSL_FUNC_KEYMGMT_QUERY_OPERATION_NAME       20


### PR DESCRIPTION
For some reason `keymgmt_gettable_params` and `keymgmt_settable_params` seem to be the only prototypes in `core_dispatch.h` without named arguments.

This is annoying if `core_dispatch.h` is being parsed to extract information and also for developers who would like the header to be self-contained, without having to refer to the documentation every time to check what is supposed to be passed.