### PR TITLE
test_sslextension: skip test that cannot work with no-tls1_2

### DIFF
--- a/test/recipes/70-test_sslextension.t
+++ b/test/recipes/70-test_sslextension.t
@@ -194,15 +194,15 @@ $proxy->start() or plan skip_all => "Unable to start up Proxy for tests";
 plan tests => 8;
 ok($fatal_alert, "Duplicate ClientHello extension");
 
-$fatal_alert = 0;
-$proxy->clear();
-$proxy->filter(\&inject_duplicate_extension_serverhello);
-$proxy->clientflags("-no_tls1_3");
-$proxy->start();
-ok($fatal_alert, "Duplicate ServerHello extension");
-
 SKIP: {
-    skip "TLS <= 1.2 disabled", 2 if $no_below_tls13;
+    skip "TLS <= 1.2 disabled", 4 if $no_below_tls13;
+
+    $fatal_alert = 0;
+    $proxy->clear();
+    $proxy->filter(\&inject_duplicate_extension_serverhello);
+    $proxy->clientflags("-no_tls1_3");
+    $proxy->start();
+    ok($fatal_alert, "Duplicate ServerHello extension");
 
     #Test 3: Sending a zero length extension block should pass
     $proxy->clear();
@@ -220,11 +220,21 @@ SKIP: {
     $proxy->clientflags("-no_tls1_3 -noservername");
     $proxy->start();
     ok($fatal_alert, "Unsolicited server name extension");
+
+    #Test 5: Send the cryptopro extension in a ClientHello. Normally this is an
+    #        unsolicited extension only ever seen in the ServerHello. We should
+    #        ignore it in a ClientHello
+    $proxy->clear();
+    $proxy->filter(\&inject_cryptopro_extension);
+    $proxy->clientflags("-no_tls1_3");
+    $proxy->start();
+    ok(TLSProxy::Message->success(), "Cryptopro extension in ClientHello");
 }
+
 SKIP: {
     skip "TLS <= 1.2 disabled or EC disabled", 1
         if $no_below_tls13 || disabled("ec");
-    #Test 5: Inject a noncompliant supported_groups extension (<= TLSv1.2)
+    #Test 6: Inject a noncompliant supported_groups extension (<= TLSv1.2)
     $proxy->clear();
     $proxy->filter(\&inject_unsolicited_extension);
     $testtype = NONCOMPLIANT_SUPPORTED_GROUPS;
@@ -236,9 +246,10 @@ SKIP: {
 SKIP: {
     skip "TLS <= 1.2 or CT disabled", 1
         if $no_below_tls13 || disabled("ct");
-    #Test 6: Same as above for the SCT extension which has special handling
+    #Test 7: Same as above for the SCT extension which has special handling
     $fatal_alert = 0;
     $proxy->clear();
+    $proxy->filter(\&inject_unsolicited_extension);
     $testtype = UNSOLICITED_SCT;
     $proxy->clientflags("-no_tls1_3");
     $proxy->start();
@@ -248,7 +259,7 @@ SKIP: {
 SKIP: {
     skip "TLS 1.3 disabled", 1
         if disabled("tls1_3") || (disabled("ec") && disabled("dh"));
-    #Test 7: Inject an unsolicited extension (TLSv1.3)
+    #Test 8: Inject an unsolicited extension (TLSv1.3)
     $fatal_alert = 0;
     $proxy->clear();
     $proxy->filter(\&inject_unsolicited_extension);
@@ -257,12 +268,3 @@ SKIP: {
     $proxy->start();
     ok($fatal_alert, "Unsolicited server name extension (TLSv1.3)");
 }
-
-#Test 8: Send the cryptopro extension in a ClientHello. Normally this is an
-#        unsolicited extension only ever seen in the ServerHello. We should
-#        ignore it in a ClientHello
-$proxy->clear();
-$proxy->filter(\&inject_cryptopro_extension);
-$proxy->clientflags("-no_tls1_3");
-$proxy->start();
-ok(TLSProxy::Message->success(), "Cryptopro extension in ClientHello");


### PR DESCRIPTION
Fixes runchecker failure of no-tls1_2 build.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
