### PR TITLE
apps/cmp.c and APP_HTTP_TLS_INFO: Fix use-after-free and add proper free() func

### DIFF
--- a/apps/cmp.c
+++ b/apps/cmp.c
@@ -2851,15 +2851,7 @@ int cmp_main(int argc, char **argv)
         OSSL_CMP_CTX_print_errors(cmp_ctx);
 
     ossl_cmp_mock_srv_free(OSSL_CMP_CTX_get_transfer_cb_arg(cmp_ctx));
-    {
-        APP_HTTP_TLS_INFO *http_tls_info =
-            OSSL_CMP_CTX_get_http_cb_arg(cmp_ctx);
-
-        if (http_tls_info != NULL) {
-            SSL_CTX_free(http_tls_info->ssl_ctx);
-            OPENSSL_free(http_tls_info);
-        }
-    }
+    APP_HTTP_TLS_INFO_free(OSSL_CMP_CTX_get_http_cb_arg(cmp_ctx));
     X509_STORE_free(OSSL_CMP_CTX_get_certConf_cb_arg(cmp_ctx));
     OSSL_CMP_CTX_free(cmp_ctx);
     X509_VERIFY_PARAM_free(vpm);

--- a/apps/include/apps.h
+++ b/apps/include/apps.h
@@ -271,6 +271,7 @@ typedef struct app_http_tls_info_st {
 } APP_HTTP_TLS_INFO;
 BIO *app_http_tls_cb(BIO *hbio, /* APP_HTTP_TLS_INFO */ void *arg,
                      int connect, int detail);
+void APP_HTTP_TLS_INFO_free(APP_HTTP_TLS_INFO *info);
 # ifndef OPENSSL_NO_SOCK
 ASN1_VALUE *app_http_get_asn1(const char *url, const char *proxy,
                               const char *no_proxy, SSL_CTX *ssl_ctx,

--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -2392,12 +2392,12 @@ static const char *tls_error_hint(void)
 /* HTTP callback function that supports TLS connection also via HTTPS proxy */
 BIO *app_http_tls_cb(BIO *hbio, void *arg, int connect, int detail)
 {
-    APP_HTTP_TLS_INFO *info = (APP_HTTP_TLS_INFO *)arg;
-    SSL_CTX *ssl_ctx = info->ssl_ctx;
-    SSL *ssl;
-    BIO *sbio = NULL;
-
     if (connect && detail) { /* connecting with TLS */
+        APP_HTTP_TLS_INFO *info = (APP_HTTP_TLS_INFO *)arg;
+        SSL_CTX *ssl_ctx = info->ssl_ctx;
+        SSL *ssl;
+        BIO *sbio = NULL;
+
         if ((info->use_proxy
              && !OSSL_HTTP_proxy_connect(hbio, info->server, info->port,
                                          NULL, NULL, /* no proxy credentials */
@@ -2418,6 +2418,7 @@ BIO *app_http_tls_cb(BIO *hbio, void *arg, int connect, int detail)
         hbio = BIO_push(sbio, hbio);
     } else if (!connect && !detail) { /* disconnecting after error */
         const char *hint = tls_error_hint();
+
         if (hint != NULL)
             ERR_add_error_data(2, " : ", hint);
         /*
@@ -2426,6 +2427,14 @@ BIO *app_http_tls_cb(BIO *hbio, void *arg, int connect, int detail)
          */
     }
     return hbio;
+}
+
+void APP_HTTP_TLS_INFO_free(APP_HTTP_TLS_INFO *info)
+{
+    if (info != NULL) {
+        SSL_CTX_free(info->ssl_ctx);
+        OPENSSL_free(info);
+    }
 }
 
 ASN1_VALUE *app_http_get_asn1(const char *url, const char *proxy,


### PR DESCRIPTION
This came up while preparing the HTTP client for an implementation of #14004.