### PR TITLE
Runchecker fix for the no-autoerrinit build

### DIFF
--- a/test/errtest.c
+++ b/test/errtest.c
@@ -74,11 +74,12 @@ static int test_print_error_format(void)
         goto err;
     }
 
-# if defined(OPENSSL_NO_AUTOERRINIT)
+# if !defined(OPENSSL_NO_ERR)
+#  if defined(OPENSSL_NO_AUTOERRINIT)
     lib = "lib(2)";
-    reason = strerror(syserr);
-# elif !defined(OPENSSL_NO_ERR)
+#  else
     lib = "system library";
+#  endif
     reason = strerror(syserr);
 # else
     lib = "lib(2)";

--- a/test/errtest.c
+++ b/test/errtest.c
@@ -74,7 +74,10 @@ static int test_print_error_format(void)
         goto err;
     }
 
-# ifndef OPENSSL_NO_ERR
+# if defined(OPENSSL_NO_AUTOERRINIT)
+    lib = "lib(2)";
+    reason = strerror(syserr);
+# elif !defined(OPENSSL_NO_ERR)
     lib = "system library";
     reason = strerror(syserr);
 # else


### PR DESCRIPTION
In this case, there was a slight different error output format that wasn't being accounted for in the error test.

Fixes #14961

- [ ] documentation is added or updated
- [x] tests are added or updated
