### PR TITLE
Runchecker: fix TLS curves test failure with no-tls1_3 option

### DIFF
--- a/test/recipes/80-test_ssl_new.t
+++ b/test/recipes/80-test_ssl_new.t
@@ -98,7 +98,8 @@ my %skip = (
   # special-casing for.
   # TODO(TLS 1.3): We should review this once we have TLS 1.3.
   "13-fragmentation.cnf" => disabled("tls1_2"),
-  "14-curves.cnf" => disabled("tls1_2") || $no_ec || $no_ec2m,
+  "14-curves.cnf" => disabled("tls1_2") || disabled("tls1_3")
+                     || $no_ec || $no_ec2m,
   "15-certstatus.cnf" => $no_tls || $no_ocsp,
   "16-dtls-certstatus.cnf" => $no_dtls || $no_ocsp,
   "17-renegotiate.cnf" => $no_tls_below1_3,


### PR DESCRIPTION
The TLS curves test strong assumes that TLS 1.2 and TLS 1.3 are present.
It is only conditioned out if TLS 1.2 isn't.  This changes also conditions
it out if TLS 1.3 isn't present.

Fixes ##14965

- [ ] documentation is added or updated
- [x] tests are added or updated
