### PR TITLE
Runchecker: fix failure with no-autoalginit option by disabling FIPS

### DIFF
--- a/Configure
+++ b/Configure
@@ -601,7 +601,7 @@ my @disable_cascades = (
     "hw"                => [ "padlockeng" ],
 
     # no-autoalginit is only useful when building non-shared
-    "autoalginit"       => [ "shared", "apps" ],
+    "autoalginit"       => [ "shared", "apps", "fips" ],
 
     "stdio"             => [ "apps", "capieng", "egd" ],
     "apps"              => [ "tests" ],


### PR DESCRIPTION
With this option, the `openssl` command line tool is not created.  Without that it is impossible to create the `fipsmodule.cnf` file that the tests would otherwise depend upon.

Fixes #14960

- [ ] documentation is added or updated
- [ ] tests are added or updated
