### PR TITLE
Correct the return value on match and mismatch for MAC pkeys

### DIFF
--- a/crypto/hmac/hm_ameth.c
+++ b/crypto/hmac/hm_ameth.c
@@ -47,7 +47,8 @@ static int hmac_pkey_ctrl(EVP_PKEY *pkey, int op, long arg1, void *arg2)
 
 static int hmac_pkey_public_cmp(const EVP_PKEY *a, const EVP_PKEY *b)
 {
-    return ASN1_OCTET_STRING_cmp(EVP_PKEY_get0(a), EVP_PKEY_get0(b));
+    /* the ameth pub_cmp must return 1 on match, 0 on mismatch */
+    return ASN1_OCTET_STRING_cmp(EVP_PKEY_get0(a), EVP_PKEY_get0(b)) == 0;
 }
 
 static int hmac_set_priv_key(EVP_PKEY *pkey, const unsigned char *priv,

--- a/crypto/poly1305/poly1305_ameth.c
+++ b/crypto/poly1305/poly1305_ameth.c
@@ -43,7 +43,7 @@ static int poly1305_pkey_ctrl(EVP_PKEY *pkey, int op, long arg1, void *arg2)
 
 static int poly1305_pkey_public_cmp(const EVP_PKEY *a, const EVP_PKEY *b)
 {
-    return ASN1_OCTET_STRING_cmp(EVP_PKEY_get0(a), EVP_PKEY_get0(b));
+    return ASN1_OCTET_STRING_cmp(EVP_PKEY_get0(a), EVP_PKEY_get0(b)) == 0;
 }
 
 static int poly1305_set_priv_key(EVP_PKEY *pkey, const unsigned char *priv,

--- a/crypto/siphash/siphash_ameth.c
+++ b/crypto/siphash/siphash_ameth.c
@@ -44,7 +44,7 @@ static int siphash_pkey_ctrl(EVP_PKEY *pkey, int op, long arg1, void *arg2)
 
 static int siphash_pkey_public_cmp(const EVP_PKEY *a, const EVP_PKEY *b)
 {
-    return ASN1_OCTET_STRING_cmp(EVP_PKEY_get0(a), EVP_PKEY_get0(b));
+    return ASN1_OCTET_STRING_cmp(EVP_PKEY_get0(a), EVP_PKEY_get0(b)) == 0;
 }
 
 static int siphash_set_priv_key(EVP_PKEY *pkey, const unsigned char *priv,


### PR DESCRIPTION
The pub_cmp function must return 1 on match and 0 otherwise.

Fixes #14147

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
