### PR TITLE
Don't remove $(TARFILE) when cleaning

### DIFF
--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -561,7 +561,6 @@ clean: libclean
 	$(RM) -r test/test-runs
 	$(RM) openssl.pc libcrypto.pc libssl.pc
 	-find . -type l \! -name '.*' -exec $(RM) {} \;
-	$(RM) $(TARFILE)
 
 distclean: clean
 	$(RM) configdata.pm


### PR DESCRIPTION
This file is outside the source tree, so we have no business removing
it.  This is especially concerning if that was the tarball the user
had to create the source tree.

Fixes #14981
