### PR TITLE
m_len check in rsa_sign()

### DIFF
--- a/crypto/rsa/rsa_sign.c
+++ b/crypto/rsa/rsa_sign.c
@@ -92,14 +92,12 @@ int RSA_sign(int type, const unsigned char *m, unsigned int m_len,
         encoded = m;
     } else {
         const EVP_MD *md = EVP_get_digestbynid(type);
-        if (md == NULL) {
-            RSAerr(RSA_F_RSA_SIGN, RSA_R_UNKNOWN_ALGORITHM_TYPE);
-            return 0;
-        }
-        
-        if (m_len != (size_t)EVP_MD_size(md)) {
-            RSAerr(RSA_F_RSA_SIGN, RSA_R_INVALID_MESSAGE_LENGTH);
-            return 0;
+
+        if (md != NULL) {
+            if (m_len != (size_t)EVP_MD_size(md)) {
+                RSAerr(RSA_F_RSA_SIGN, RSA_R_INVALID_MESSAGE_LENGTH);
+                return 0;
+            }
         }
         
         if (!encode_pkcs1(&tmps, &encoded_len, type, m, m_len))

--- a/crypto/rsa/rsa_sign.c
+++ b/crypto/rsa/rsa_sign.c
@@ -91,6 +91,17 @@ int RSA_sign(int type, const unsigned char *m, unsigned int m_len,
         encoded_len = SSL_SIG_LENGTH;
         encoded = m;
     } else {
+        const EVP_MD *md = EVP_get_digestbynid(type);
+        if (md == NULL) {
+            RSAerr(RSA_F_RSA_SIGN, RSA_R_UNKNOWN_ALGORITHM_TYPE);
+            return 0;
+        }
+        
+        if (m_len != EVP_MD_size(md)) {
+            RSAerr(RSA_F_RSA_SIGN, RSA_R_INVALID_MESSAGE_LENGTH);
+            return 0;
+        }
+        
         if (!encode_pkcs1(&tmps, &encoded_len, type, m, m_len))
             goto err;
         encoded = tmps;

--- a/crypto/rsa/rsa_sign.c
+++ b/crypto/rsa/rsa_sign.c
@@ -97,7 +97,7 @@ int RSA_sign(int type, const unsigned char *m, unsigned int m_len,
             return 0;
         }
         
-        if (m_len != EVP_MD_size(md)) {
+        if (m_len != (size_t)EVP_MD_size(md)) {
             RSAerr(RSA_F_RSA_SIGN, RSA_R_INVALID_MESSAGE_LENGTH);
             return 0;
         }


### PR DESCRIPTION
Technical check of the expected length of m_len in rsa_sign(). I have added a look up on the hash function id using EVP_get_digestbynid(), then a comparison of m_len against the result of a call to EVP_MD_size(). 

Fixes #14594 
