### PR TITLE
asn1_lib.c: ASN1_put_object: Remove comment about "class 0".

### DIFF
--- a/crypto/asn1/asn1_lib.c
+++ b/crypto/asn1/asn1_lib.c
@@ -155,7 +155,7 @@ static int asn1_get_length(const unsigned char **pp, int *inf, long *rl,
 }
 
 /*
- * class 0 is constructed constructed == 2 for indefinite length constructed
+ * constructed == 2 for indefinite length constructed
  */
 void ASN1_put_object(unsigned char **pp, int constructed, int length, int tag,
                      int xclass)


### PR DESCRIPTION
ASN1_put_object() was preceded by the nonsensical comment:

```
/*
 * class 0 is constructed constructed == 2 for indefinite length constructed
 */
```

This is the result of concatenating two sentences in 0f113f3ee4d by
automated reformatting.  The first sentence, "class 0 is constructed",
goes back to d02b48c63a, the import of SSLeay 0.8.1b.  Even in that
context, it made little sense; class 0 means "universal", not
constructed, and there is no special significance to class 0 in this
function in any case.

Therefore I have simply removed that first sentence.

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
