### PR TITLE
BIO_printf.pod: Clarify that output is always null terminated.

### DIFF
--- a/doc/man3/BIO_printf.pod
+++ b/doc/man3/BIO_printf.pod
@@ -40,9 +40,10 @@ buffer is too small.
 
 =head1 NOTES
 
-Except when I<n> is 0, both BIO_snprintf() and BIO_vsnprintf() terminate
-their output with C<'\0'> even when there is insufficient space to output
-the whole string.
+Except when I<n> is 0, both BIO_snprintf() and BIO_vsnprintf() always
+terminate their output with C<'\0'>.  This includes cases where -1 is
+returned, such as when there is insufficient space to output the whole
+string.
 
 =head1 COPYRIGHT
 


### PR DESCRIPTION
The original text was ambiguous about termination for errors other
than insufficient space.  See issue #14772.

The proposed text is what I infer the intended behavior to be based on the conversation in #14772 and the change made in 586d9436c8.  Note, however, that there are syntactic code paths through `BIO_snprintf` that do not add a terminator.  My proposed documentation change implies that all of those paths are impossible to execute in any supported configuration, but I have not verified that to be the case.

I just now emailed my ICLA so that might need time to be processed.

##### Checklist
- [x] documentation is added or updated
