### PR TITLE
Avoid emitting preprocessed output for dependency info

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1278,7 +1278,9 @@ my %targets = (
         CPP              => '"$(CC)" /EP /C',
         CFLAGS           => "/W3 /wd4090 /nologo",
         coutflag         => "/Fo",
-        cpp_depend_flags => "/Zs /showIncludes",
+        # "/Fitemp.i" here needs the "del temp.i" in windows-makefile.tmpl.
+        # The temp file is necessary as "/FiNUL" turned out to be very slow.
+        cpp_depend_flags => "/Zs /showIncludes /P /Fitemp.i",
         LD               => "link",
         LDFLAGS          => "/nologo /debug",
         ldoutflag        => "/out:",

--- a/Configurations/50-cppbuilder.conf
+++ b/Configurations/50-cppbuilder.conf
@@ -18,7 +18,9 @@ my %targets = (
         bin_cflags       => "-tWC",
         lib_cflags       => shared("-tWD -D_WINDLL -D_DLL"),
         coutflag         => "-o",
-        cpp_depend_flags => "-Hp",
+        # "-motemp.i" is only to satisfy "del temp.i" in windows-makefile.tmpl
+        # -- which in turn is there because MSVC's "/FiNUL" option is too slow.
+        cpp_depend_flags => "-Hp -Sx -motemp.i",
         LD               => "ilink32",
         LDFLAGS          => picker(default => "-x -Gn -q -w-dup",
                                    debug   => '-j"$(BDS)\lib\win32c\debug" ' .

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -836,7 +836,7 @@ $obj: $deps
 	\$(CC) $cflags $defs -c \$(COUTFLAG)\$\@ $srcs
 EOF
      $recipe .= <<"EOF"	unless $disabled{makedepend};
-	cmd /C "\$(CPP) $cflags $defs $target{cpp_depend_flags} $srcs > $dep 2>&1"
+	cmd /C "\$(CPP) $cflags $defs $target{cpp_depend_flags} $srcs > $dep 2>&1 & del temp.i"
 EOF
      return $recipe;
  }


### PR DESCRIPTION
Commit 16f2a44 changed the Windows dependency-generation command to use `$(CPP)` instead of `$(CC)`, in order to use `cpp32` of C++Builder (as `bcc32c` doesn't have `#include`-listing functionality).  Doing so emitted the entire preprocessed output to the `.d` files, which slowed down `add-depends.pl` (part of `nmake test`/`nmake install`) considerably. Add flags to avoid emitting the full preprocessed output in `.d` files.

Fixes #14994

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
