### PR TITLE
Run AppVeyor only on pushes to master

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,15 +16,6 @@ configuration:
 
 for:
     -
-        only_commits:
-            message: /\[extended tests\]/
-        configuration:
-            - shared
-            - plain
-            - minimal
-        environment:
-            EXTENDED_TESTS: yes
-    -
         branches:
             only:
                 - master
@@ -36,6 +27,12 @@ for:
             EXTENDED_TESTS: yes
 
 before_build:
+    - ps: >-
+        $merge = (cmd /c "git rev-list -1 --merges HEAD~1..HEAD")
+    - ps: >-
+        If ($merge) {
+            Exit-AppveyorBuild
+        }
     - ps: >-
         Install-Module VSSetup -Scope CurrentUser
     - ps: >-


### PR DESCRIPTION
It is too slow to run it on every pull request.

This hopefully partially fixes the #15003 

The other part - disabling "rolling builds" has to be done in AppVeyor UI.
