### PR TITLE
crypto/store/ossl_result.c: Better filtering of errors

### DIFF
--- a/crypto/evp/keymgmt_lib.c
+++ b/crypto/evp/keymgmt_lib.c
@@ -31,12 +31,15 @@ static int match_type(const EVP_KEYMGMT *keymgmt1, const EVP_KEYMGMT *keymgmt2)
 int evp_keymgmt_util_try_import(const OSSL_PARAM params[], void *arg)
 {
     struct evp_keymgmt_util_try_import_data_st *data = arg;
+    int delete_on_error = 0;
 
     /* Just in time creation of keydata */
-    if (data->keydata == NULL
-        && (data->keydata = evp_keymgmt_newdata(data->keymgmt)) == NULL) {
-        ERR_raise(ERR_LIB_EVP, ERR_R_MALLOC_FAILURE);
-        return 0;
+    if (data->keydata == NULL) {
+        if ((data->keydata = evp_keymgmt_newdata(data->keymgmt)) == NULL) {
+            ERR_raise(ERR_LIB_EVP, ERR_R_MALLOC_FAILURE);
+            return 0;
+        }
+        delete_on_error = 1;
     }
 
     /*
@@ -46,8 +49,14 @@ int evp_keymgmt_util_try_import(const OSSL_PARAM params[], void *arg)
     if (params[0].key == NULL)
         return 1;
 
-    return evp_keymgmt_import(data->keymgmt, data->keydata, data->selection,
-                              params);
+    if (evp_keymgmt_import(data->keymgmt, data->keydata, data->selection,
+                           params))
+        return 1;
+    if (delete_on_error) {
+        evp_keymgmt_freedata(data->keymgmt, data->keydata);
+        data->keydata = NULL;
+    }
+    return 0;
 }
 
 int evp_keymgmt_util_assign_pkey(EVP_PKEY *pkey, EVP_KEYMGMT *keymgmt,
@@ -149,11 +158,9 @@ void *evp_keymgmt_util_export_to_provider(EVP_PKEY *pk, EVP_KEYMGMT *keymgmt)
      * which does the import for us.  If successful, we're done.
      */
     if (!evp_keymgmt_util_export(pk, OSSL_KEYMGMT_SELECT_ALL,
-                                 &evp_keymgmt_util_try_import, &import_data)) {
+                                 &evp_keymgmt_util_try_import, &import_data))
         /* If there was an error, bail out */
-        evp_keymgmt_freedata(keymgmt, import_data.keydata);
         return NULL;
-    }
 
     if (!CRYPTO_THREAD_write_lock(pk->lock)) {
         evp_keymgmt_freedata(keymgmt, import_data.keydata);

--- a/test/recipes/30-test_evp_data/evppkey_ecdh.txt
+++ b/test/recipes/30-test_evp_data/evppkey_ecdh.txt
@@ -947,12 +947,14 @@ PrivPubKeyPair = BOB_sect163r1:BOB_sect163r1_PUB
 
 # ECDH Alice with Bob peer
 
+Availablein=default
 Derive=ALICE_sect163r1
 PeerKey=BOB_sect163r1_PUB
 SharedSecret=02355c765bbc07fcc44bb1496e490912f6df56e6d4
 
 # ECDH Bob with Alice peer
 
+Availablein=default
 Derive=BOB_sect163r1
 PeerKey=ALICE_sect163r1_PUB
 SharedSecret=02355c765bbc07fcc44bb1496e490912f6df56e6d4
@@ -993,12 +995,14 @@ PrivPubKeyPair = BOB_sect193r1:BOB_sect193r1_PUB
 
 # ECDH Alice with Bob peer
 
+Availablein=default
 Derive=ALICE_sect193r1
 PeerKey=BOB_sect193r1_PUB
 SharedSecret=00458b4c5ad122de5a377bea0adf1ab87bcb961b24ed764f47
 
 # ECDH Bob with Alice peer
 
+Availablein=default
 Derive=BOB_sect193r1
 PeerKey=ALICE_sect193r1_PUB
 SharedSecret=00458b4c5ad122de5a377bea0adf1ab87bcb961b24ed764f47
@@ -1039,12 +1043,14 @@ PrivPubKeyPair = BOB_sect193r2:BOB_sect193r2_PUB
 
 # ECDH Alice with Bob peer
 
+Availablein=default
 Derive=ALICE_sect193r2
 PeerKey=BOB_sect193r2_PUB
 SharedSecret=019d1f316d204a9cd1b9632cebb4accddb204158be3e435891
 
 # ECDH Bob with Alice peer
 
+Availablein=default
 Derive=BOB_sect193r2
 PeerKey=ALICE_sect193r2_PUB
 SharedSecret=019d1f316d204a9cd1b9632cebb4accddb204158be3e435891
@@ -1085,12 +1091,14 @@ PrivPubKeyPair = BOB_sect239k1:BOB_sect239k1_PUB
 
 # ECDH Alice with Bob peer
 
+Availablein=default
 Derive=ALICE_sect239k1
 PeerKey=BOB_sect239k1_PUB
 SharedSecret=4d1c9a8ae73f754d0a593d6e426114f4f67d7c8082ccc4e04a72b0d2aff8
 
 # ECDH Bob with Alice peer
 
+Availablein=default
 Derive=BOB_sect239k1
 PeerKey=ALICE_sect239k1_PUB
 SharedSecret=4d1c9a8ae73f754d0a593d6e426114f4f67d7c8082ccc4e04a72b0d2aff8


### PR DESCRIPTION
The diverse variants of try_XXX() were filtering errors independently
of each other.  It's better done in ossl_store_handle_load_result()
itself, where we have control over the overall success and failure of
the attempts.

Fixes #14973