### PR TITLE
Explicitly enable or disable fips if it is or is not relevant for the test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: config
-      run: CPPFLAGS=-ansi ./config no-asm no-makedepend enable-buildtest-c++ --strict-warnings -D_DEFAULT_SOURCE && perl configdata.pm --dump
+      run: CPPFLAGS=-ansi ./config no-asm no-makedepend enable-buildtest-c++ enable-fips --strict-warnings -D_DEFAULT_SOURCE && perl configdata.pm --dump
     - name: make
       run: make -s -j4
 
@@ -53,7 +53,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: config
-      run: ./config --strict-warnings && perl configdata.pm --dump
+      run: ./config enable-fips --strict-warnings && perl configdata.pm --dump
     - name: make
       run: make -s -j4
     - name: make test
@@ -64,7 +64,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: config
-      run: CC=clang ./config --strict-warnings && perl configdata.pm --dump
+      run: CC=clang ./config no-fips --strict-warnings && perl configdata.pm --dump
     - name: make
       run: make -s -j4
     - name: make test
@@ -86,7 +86,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: config
-      run: ./config --strict-warnings no-deprecated && perl configdata.pm --dump
+      run: ./config --strict-warnings no-deprecated enable-fips && perl configdata.pm --dump
     - name: make
       run: make -s -j4
     - name: make test
@@ -100,7 +100,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: config
-      run: ./config --strict-warnings no-shared && perl configdata.pm --dump
+      run: ./config --strict-warnings no-shared no-fips && perl configdata.pm --dump
     - name: make
       run: make -s -j4
     - name: make test
@@ -111,7 +111,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: config
-      run: ./config --debug enable-asan enable-ubsan no-cached-fetch no-dtls no-tls1 no-tls1-method no-tls1_1 no-tls1_1-method no-async && perl configdata.pm --dump
+      run: ./config --debug enable-asan enable-ubsan no-cached-fetch no-fips no-dtls no-tls1 no-tls1-method no-tls1_1 no-tls1_1-method no-async && perl configdata.pm --dump
     - name: make
       run: make -s -j4
     - name: make test
@@ -122,7 +122,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: config
-      run: ./config --debug enable-asan enable-ubsan enable-rc5 enable-md2 enable-ec_nistp_64_gcc_128 && perl configdata.pm --dump
+      run: ./config --debug enable-asan enable-ubsan enable-rc5 enable-md2 enable-ec_nistp_64_gcc_128 enable-fips && perl configdata.pm --dump
     - name: make
       run: make -s -j4
     - name: make test
@@ -133,7 +133,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: config
-      run: CC=clang ./config --strict-warnings -fsanitize=thread && perl configdata.pm --dump
+      run: CC=clang ./config no-fips --strict-warnings -fsanitize=thread && perl configdata.pm --dump
     - name: make
       run: make -s -j4
     - name: make test
@@ -144,7 +144,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: config
-      run: ./config --strict-warnings no-ec enable-ssl-trace enable-zlib enable-zlib-dynamic enable-crypto-mdebug enable-crypto-mdebug-backtrace enable-egd && perl configdata.pm --dump
+      run: ./config --strict-warnings no-ec enable-ssl-trace enable-zlib enable-zlib-dynamic enable-crypto-mdebug enable-crypto-mdebug-backtrace enable-egd enable-fips && perl configdata.pm --dump
     - name: make
       run: make -s -j4
     - name: make test
@@ -155,7 +155,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: config
-      run: ./config --strict-warnings no-legacy && perl configdata.pm --dump
+      run: ./config --strict-warnings no-legacy enable-fips && perl configdata.pm --dump
     - name: make
       run: make -s -j4
     - name: make test
@@ -166,7 +166,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: config
-      run: ./config -Werror --debug no-afalgeng no-shared enable-crypto-mdebug enable-rc5 enable-md2 enable-ssl3 enable-ssl3-method enable-weak-ssl-ciphers enable-zlib enable-ec_nistp_64_gcc_128 && perl configdata.pm --dump
+      run: ./config -Werror --debug no-afalgeng no-shared enable-crypto-mdebug enable-rc5 enable-md2 enable-ssl3 enable-ssl3-method enable-weak-ssl-ciphers enable-zlib enable-ec_nistp_64_gcc_128 no-fips && perl configdata.pm --dump
     - name: make
       run: make -s -j4
     - name: make test
@@ -177,7 +177,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: config
-      run: ./config no-asm no-makedepend enable-buildtest-c++ --strict-warnings -D_DEFAULT_SOURCE && perl configdata.pm --dump
+      run: ./config no-asm no-makedepend enable-buildtest-c++ enable-fips --strict-warnings -D_DEFAULT_SOURCE && perl configdata.pm --dump
     - name: make
       run: make -s -j4
     - name: make test
@@ -195,7 +195,7 @@ jobs:
         mkdir ./build
         mkdir ./install
     - name: config
-      run: ../config --strict-warnings --prefix=$(cd ../install; pwd) && perl configdata.pm --dump
+      run: ../config enable-fips --strict-warnings --prefix=$(cd ../install; pwd) && perl configdata.pm --dump
       working-directory: ./build
     - name: make
       run: make -s -j4
@@ -224,7 +224,7 @@ jobs:
     - name: setup hostname workaround
       run: sudo hostname localhost
     - name: config
-      run: ./config --strict-warnings --debug no-afalgeng enable-rc5 enable-md2 enable-ssl3 enable-ssl3-method enable-weak-ssl-ciphers enable-zlib enable-ec_nistp_64_gcc_128 enable-external-tests && perl configdata.pm --dump
+      run: ./config --strict-warnings --debug no-afalgeng enable-rc5 enable-md2 enable-ssl3 enable-ssl3-method enable-weak-ssl-ciphers enable-zlib enable-ec_nistp_64_gcc_128 enable-external-tests no-fips && perl configdata.pm --dump
     - name: make
       run: make -s -j4
     - name: test external gost-engine

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: config
-      run: ./config --strict-warnings && perl configdata.pm --dump
+      run: ./config --strict-warnings enable-fips && perl configdata.pm --dump
     - name: make build_generated
       run: make -s build_generated
     - name: make update
@@ -30,7 +30,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: config
-      run: ./config --strict-warnings && perl configdata.pm --dump
+      run: ./config --strict-warnings enable-fips && perl configdata.pm --dump
     - name: make build_generated
       run: make -s build_generated
     - name: make doc-nits

--- a/test/recipes/90-test_fipsload.t
+++ b/test/recipes/90-test_fipsload.t
@@ -16,6 +16,7 @@ use lib srctop_dir('Configurations');
 use lib bldtop_dir('.');
 use platform;
 
+plan skip_all => 'Test is disabled with disabled fips' if disabled('fips');
 plan skip_all => 'Test only supported in a shared build' if disabled('shared');
 plan skip_all => 'Test is disabled on AIX' if config('target') =~ m|^aix|;
 plan skip_all => 'Test is disabled on NonStop ia64' if config('target') =~ m|^nonstop-nse|;


### PR DESCRIPTION
We might change the default to not build the fips module. But we still want to build it in most of the CI test builds.

Related to #13684 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
