### PR TITLE
OSSL_STORE and APPS: minor improvements on credential loading and docs

### DIFF
--- a/crypto/encode_decode/decoder_lib.c
+++ b/crypto/encode_decode/decoder_lib.c
@@ -79,10 +79,11 @@ int OSSL_DECODER_from_bio(OSSL_DECODER_CTX *ctx, BIO *in)
         const char *input_structure
             = ctx->input_structure != NULL ? ctx->input_structure : "";
 
-        ERR_raise_data(ERR_LIB_OSSL_DECODER, ERR_R_UNSUPPORTED,
-                       "No supported for the data to decode.%s%s%s%s%s%s",
-                       spaces, input_type_label, input_type, comma,
-                       input_structure_label, input_structure);
+        if (BIO_eof(in) == 0 /* Prevent spurious decoding error */)
+            ERR_raise_data(ERR_LIB_OSSL_DECODER, ERR_R_UNSUPPORTED,
+                           "Not supported for the data to decode.%s%s%s%s%s%s",
+                           spaces, input_type_label, input_type, comma,
+                           input_structure_label, input_structure);
         ok = 0;
     }
 

--- a/crypto/store/store_lib.c
+++ b/crypto/store/store_lib.c
@@ -240,6 +240,11 @@ int OSSL_STORE_expect(OSSL_STORE_CTX *ctx, int expected_type)
 {
     int ret = 1;
 
+    if (ctx == NULL
+            || expected_type < 0 || expected_type > OSSL_STORE_INFO_CRL) {
+        ERR_raise(ERR_LIB_OSSL_STORE, ERR_R_PASSED_INVALID_ARGUMENT);
+        return 0;
+    }
     if (ctx->loading) {
         ERR_raise(ERR_LIB_OSSL_STORE, OSSL_STORE_R_LOADING_STARTED);
         return 0;

--- a/crypto/store/store_lib.c
+++ b/crypto/store/store_lib.c
@@ -459,7 +459,7 @@ int OSSL_STORE_eof(OSSL_STORE_CTX *ctx)
     if (ctx->fetched_loader == NULL)
         ret = ctx->loader->eof(ctx->loader_ctx);
 #endif
-    return ret;
+    return ret != 0;
 }
 
 static int ossl_store_close_it(OSSL_STORE_CTX *ctx)

--- a/doc/man3/BIO_ctrl.pod
+++ b/doc/man3/BIO_ctrl.pod
@@ -92,7 +92,7 @@ for success and -1 for failure.
 
 BIO_flush() returns 1 for success and 0 or -1 for failure.
 
-BIO_eof() returns 1 if EOF has been reached or an error occurred, 0 otherwise.
+BIO_eof() returns 1 if EOF has been reached, 0 if not, or -1 for failure.
 
 BIO_set_close() always returns 1.
 

--- a/doc/man3/BIO_ctrl.pod
+++ b/doc/man3/BIO_ctrl.pod
@@ -92,7 +92,7 @@ for success and -1 for failure.
 
 BIO_flush() returns 1 for success and 0 or -1 for failure.
 
-BIO_eof() returns 1 if EOF has been reached 0 otherwise.
+BIO_eof() returns 1 if EOF has been reached or an error occurred, 0 otherwise.
 
 BIO_set_close() always returns 1.
 

--- a/doc/man3/OSSL_STORE_expect.pod
+++ b/doc/man3/OSSL_STORE_expect.pod
@@ -21,11 +21,13 @@ OSSL_STORE_find
 
 OSSL_STORE_expect() helps applications filter what OSSL_STORE_load() returns
 by specifying a B<OSSL_STORE_INFO> type.
-For example, if C<file:/foo/bar/store.pem> contains several different objects
-and only the certificates are interesting, the application can simply say
+By default, no expectations on the types of objects to be loaded are made.
+I<expected_type> may be 0 to indicate explicitly that no expectation is made,
+or it may be any of the known object types (see
+L<OSSL_STORE_INFO(3)/SUPPORTED OBJECTS>) except for B<OSSL_STORE_INFO_NAME>.
+For example, if C<file:/foo/bar/store.pem> contains several objects of different
+type and only certificates are interesting, the application can simply say
 that it expects the type B<OSSL_STORE_INFO_CERT>.
-All known object types (see L<OSSL_STORE_INFO(3)/SUPPORTED OBJECTS>)
-except for B<OSSL_STORE_INFO_NAME> are supported.
 
 OSSL_STORE_find() helps applications specify a criterion for a more fine
 grained search of objects.

--- a/doc/man3/OSSL_STORE_open.pod
+++ b/doc/man3/OSSL_STORE_open.pod
@@ -143,8 +143,8 @@ on error or when end of data is reached.
 Use OSSL_STORE_error() and OSSL_STORE_eof() to determine the meaning of a
 returned NULL.
 
-OSSL_STORE_eof() returns 1 if the end of data has been reached, otherwise
-0.
+OSSL_STORE_eof() returns 1 if the end of data has been reached
+or an error occurred, 0 otherwise.
 
 OSSL_STORE_error() returns 1 if an error occurred in an OSSL_STORE_load() call,
 otherwise 0.

--- a/include/openssl/bio.h.in
+++ b/include/openssl/bio.h.in
@@ -520,7 +520,7 @@ int BIO_read_filename(BIO *b, const char *name);
 # define BIO_dup_state(b,ret)    BIO_ctrl(b,BIO_CTRL_DUP,0,(char *)(ret))
 
 # define BIO_reset(b)            (int)BIO_ctrl(b,BIO_CTRL_RESET,0,NULL)
-# define BIO_eof(b)              (BIO_ctrl(b,BIO_CTRL_EOF,0,NULL) != 0)
+# define BIO_eof(b)              (int)BIO_ctrl(b,BIO_CTRL_EOF,0,NULL)
 # define BIO_set_close(b,c)      (int)BIO_ctrl(b,BIO_CTRL_SET_CLOSE,(c),NULL)
 # define BIO_get_close(b)        (int)BIO_ctrl(b,BIO_CTRL_GET_CLOSE,0,NULL)
 # define BIO_pending(b)          (int)BIO_ctrl(b,BIO_CTRL_PENDING,0,NULL)

--- a/include/openssl/bio.h.in
+++ b/include/openssl/bio.h.in
@@ -520,7 +520,7 @@ int BIO_read_filename(BIO *b, const char *name);
 # define BIO_dup_state(b,ret)    BIO_ctrl(b,BIO_CTRL_DUP,0,(char *)(ret))
 
 # define BIO_reset(b)            (int)BIO_ctrl(b,BIO_CTRL_RESET,0,NULL)
-# define BIO_eof(b)              (int)BIO_ctrl(b,BIO_CTRL_EOF,0,NULL)
+# define BIO_eof(b)              (BIO_ctrl(b,BIO_CTRL_EOF,0,NULL) != 0)
 # define BIO_set_close(b,c)      (int)BIO_ctrl(b,BIO_CTRL_SET_CLOSE,(c),NULL)
 # define BIO_get_close(b)        (int)BIO_ctrl(b,BIO_CTRL_GET_CLOSE,0,NULL)
 # define BIO_pending(b)          (int)BIO_ctrl(b,BIO_CTRL_PENDING,0,NULL)


### PR DESCRIPTION
* APPS `load_key_certs_crls()`: Correct the `expect` arg calculation for `OSSL_STORE_expect()`
* `OSSL_STORE_expect()`: Improve error handling and documentation
* `BIO_eof()` and `OSSL_STORE_eof()`: Correct doc and use of return value < 0 in `store_lib.c`
* `OSSL_DECODER_from_bio()`: Prevent spurious decoding error at EOF


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
