### PR TITLE
Document only "double" for FLOAT params

### DIFF
--- a/doc/man3/OSSL_PARAM.pod
+++ b/doc/man3/OSSL_PARAM.pod
@@ -160,6 +160,8 @@ systems.
 =item B<OSSL_PARAM_REAL>
 
 The parameter data is a floating point value in native form.
+The OpenSSL providers and helper functions support only C<double>-sized
+values.
 
 =item B<OSSL_PARAM_UTF8_STRING>
 


### PR DESCRIPTION
Fixes: #11165
