### PR TITLE
Fix no-dtls1_2

### DIFF
--- a/test/dtlstest.c
+++ b/test/dtlstest.c
@@ -67,8 +67,16 @@ static int test_dtls_unprocessed(int testidx)
                                        &sctx, &cctx, cert, privkey)))
         return 0;
 
+#ifndef OPENSSL_NO_DTLS1_2
     if (!TEST_true(SSL_CTX_set_cipher_list(cctx, "AES128-SHA")))
         goto end;
+#else
+    /* Default sigalgs are SHA1 based in <DTLS1.2 which is in security level 0 */
+    if (!TEST_true(SSL_CTX_set_cipher_list(sctx, "AES128-SHA:@SECLEVEL=0"))
+            || !TEST_true(SSL_CTX_set_cipher_list(cctx,
+                                                  "AES128-SHA:@SECLEVEL=0")))
+        goto end;
+#endif
 
     c_to_s_fbio = BIO_new(bio_f_tls_dump_filter());
     if (!TEST_ptr(c_to_s_fbio))
@@ -166,6 +174,14 @@ static int test_dtls_drop_records(int idx)
                                        DTLS1_VERSION, 0,
                                        &sctx, &cctx, cert, privkey)))
         return 0;
+
+#ifdef OPENSSL_NO_DTLS1_2
+    /* Default sigalgs are SHA1 based in <DTLS1.2 which is in security level 0 */
+    if (!TEST_true(SSL_CTX_set_cipher_list(sctx, "DEFAULT:@SECLEVEL=0"))
+            || !TEST_true(SSL_CTX_set_cipher_list(cctx,
+                                                  "DEFAULT:@SECLEVEL=0")))
+        goto end;
+#endif
 
     if (!TEST_true(SSL_CTX_set_dh_auto(sctx, 1)))
         goto end;
@@ -286,6 +302,14 @@ static int test_cookie(void)
     SSL_CTX_set_cookie_generate_cb(sctx, generate_cookie_cb);
     SSL_CTX_set_cookie_verify_cb(sctx, verify_cookie_cb);
 
+#ifdef OPENSSL_NO_DTLS1_2
+    /* Default sigalgs are SHA1 based in <DTLS1.2 which is in security level 0 */
+    if (!TEST_true(SSL_CTX_set_cipher_list(sctx, "DEFAULT:@SECLEVEL=0"))
+            || !TEST_true(SSL_CTX_set_cipher_list(cctx,
+                                                  "DEFAULT:@SECLEVEL=0")))
+        goto end;
+#endif
+
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
                                       NULL, NULL))
             || !TEST_true(create_ssl_connection(serverssl, clientssl,
@@ -313,6 +337,14 @@ static int test_dtls_duplicate_records(void)
                                        DTLS1_VERSION, 0,
                                        &sctx, &cctx, cert, privkey)))
         return 0;
+
+#ifdef OPENSSL_NO_DTLS1_2
+    /* Default sigalgs are SHA1 based in <DTLS1.2 which is in security level 0 */
+    if (!TEST_true(SSL_CTX_set_cipher_list(sctx, "DEFAULT:@SECLEVEL=0"))
+            || !TEST_true(SSL_CTX_set_cipher_list(cctx,
+                                                  "DEFAULT:@SECLEVEL=0")))
+        goto end;
+#endif
 
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
                                       NULL, NULL)))

--- a/test/ssl-tests/16-dtls-certstatus.cnf
+++ b/test/ssl-tests/16-dtls-certstatus.cnf
@@ -15,11 +15,11 @@ client = 0-certstatus-good-client
 
 [0-certstatus-good-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [0-certstatus-good-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -43,11 +43,11 @@ client = 1-certstatus-bad-client
 
 [1-certstatus-bad-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [1-certstatus-bad-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 

--- a/test/ssl-tests/16-dtls-certstatus.cnf.in
+++ b/test/ssl-tests/16-dtls-certstatus.cnf.in
@@ -15,15 +15,22 @@ use warnings;
 package ssltests;
 use OpenSSL::Test::Utils;
 
-our @tests = (
+our $fips_mode;
+
+our @tests = ();
+
+our @tests_standard = (
     {
         name => "certstatus-good",
         server => {
+            "CipherString" => "DEFAULT:\@SECLEVEL=0",
             extra => {
-                "CertStatus" => "GoodResponse",
+                "CertStatus" => "GoodResponse"
             },
         },
-        client => {},
+        client => {
+            "CipherString" => "DEFAULT:\@SECLEVEL=0",
+        },
         test => {
             "Method" => "DTLS",
             "ExpectedResult" => "Success"
@@ -32,11 +39,14 @@ our @tests = (
     {
         name => "certstatus-bad",
         server => {
+            "CipherString" => "DEFAULT:\@SECLEVEL=0",
             extra => {
                 "CertStatus" => "BadResponse",
             },
         },
-        client => {},
+        client => {
+            "CipherString" => "DEFAULT:\@SECLEVEL=0",
+        },
         test => {
             "Method" => "DTLS",
             "ExpectedResult" => "ClientFail"
@@ -48,11 +58,14 @@ our @tests_sctp = (
     {
         name => "certstatus-good",
         server => {
+            "CipherString" => "DEFAULT:\@SECLEVEL=0",
             extra => {
                 "CertStatus" => "GoodResponse",
             },
         },
-        client => {},
+        client => {
+            "CipherString" => "DEFAULT:\@SECLEVEL=0",
+        },
         test => {
             "Method" => "DTLS",
             "UseSCTP" => "Yes",
@@ -62,11 +75,14 @@ our @tests_sctp = (
     {
         name => "certstatus-bad",
         server => {
+            "CipherString" => "DEFAULT:\@SECLEVEL=0",
             extra => {
                 "CertStatus" => "BadResponse",
             },
         },
-        client => {},
+        client => {
+            "CipherString" => "DEFAULT:\@SECLEVEL=0",
+        },
         test => {
             "Method" => "DTLS",
             "UseSCTP" => "Yes",
@@ -75,4 +91,7 @@ our @tests_sctp = (
     },
 );
 
-push @tests, @tests_sctp unless disabled("sctp") || disabled("sock");
+if  (!$fips_mode || !disabled("dtls1_2")) {
+    push @tests, @tests_standard;
+    push @tests, @tests_sctp unless disabled("sctp") || disabled("sock");
+}

--- a/test/ssl-tests/18-dtls-renegotiate.cnf
+++ b/test/ssl-tests/18-dtls-renegotiate.cnf
@@ -22,12 +22,12 @@ client = 0-renegotiate-client-no-resume-client
 
 [0-renegotiate-client-no-resume-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 Options = NoResumptionOnRenegotiation
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [0-renegotiate-client-no-resume-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -50,11 +50,11 @@ client = 1-renegotiate-client-resume-client
 
 [1-renegotiate-client-resume-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [1-renegotiate-client-resume-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -77,11 +77,11 @@ client = 2-renegotiate-server-resume-client
 
 [2-renegotiate-server-resume-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
 [2-renegotiate-server-resume-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
@@ -104,14 +104,14 @@ client = 3-renegotiate-client-auth-require-client
 
 [3-renegotiate-client-auth-require-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 VerifyMode = Require
 
 [3-renegotiate-client-auth-require-client]
 Certificate = ${ENV::TEST_CERTS_DIR}/ee-client-chain.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-key.pem
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
@@ -135,14 +135,14 @@ client = 4-renegotiate-client-auth-once-client
 
 [4-renegotiate-client-auth-once-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
 VerifyMode = Once
 
 [4-renegotiate-client-auth-once-client]
 Certificate = ${ENV::TEST_CERTS_DIR}/ee-client-chain.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-key.pem
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer

--- a/test/ssl-tests/18-dtls-renegotiate.cnf.in
+++ b/test/ssl-tests/18-dtls-renegotiate.cnf.in
@@ -15,20 +15,26 @@ use warnings;
 package ssltests;
 use OpenSSL::Test::Utils;
 
+our $fips_mode;
+
 our @tests = ();
 
 foreach my $sctp ("No", "Yes")
 {
     next if disabled("sctp") && $sctp eq "Yes";
+    next if disabled("dtls1_2") && $fips_mode;
 
     my $suffix = ($sctp eq "No") ? "" : "-sctp";
     our @tests_basic = (
         {
             name => "renegotiate-client-no-resume".$suffix,
             server => {
+                "CipherString" => 'DEFAULT:@SECLEVEL=0',
                 "Options" => "NoResumptionOnRenegotiation"
             },
-            client => {},
+            client => {
+                "CipherString" => 'DEFAULT:@SECLEVEL=0'
+            },
             test => {
                 "Method" => "DTLS",
                 "UseSCTP" => $sctp,
@@ -39,8 +45,12 @@ foreach my $sctp ("No", "Yes")
         },
         {
             name => "renegotiate-client-resume".$suffix,
-            server => {},
-            client => {},
+            server => {
+                "CipherString" => 'DEFAULT:@SECLEVEL=0'
+            },
+            client => {
+                "CipherString" => 'DEFAULT:@SECLEVEL=0'
+            },
             test => {
                 "Method" => "DTLS",
                 "UseSCTP" => $sctp,
@@ -60,8 +70,12 @@ foreach my $sctp ("No", "Yes")
         # and if so, what to?
         {
             name => "renegotiate-server-resume".$suffix,
-            server => {},
-            client => {},
+            server => {
+                "CipherString" => 'DEFAULT:@SECLEVEL=0'
+            },
+            client => {
+                "CipherString" => 'DEFAULT:@SECLEVEL=0'
+            },
             test => {
                 "Method" => "DTLS",
                 "UseSCTP" => $sctp,
@@ -75,10 +89,12 @@ foreach my $sctp ("No", "Yes")
             server => {
                 "VerifyCAFile" => test_pem("root-cert.pem"),
                 "VerifyMode" => "Require",
+                "CipherString" => 'DEFAULT:@SECLEVEL=0'
             },
             client => {
                 "Certificate" => test_pem("ee-client-chain.pem"),
                 "PrivateKey"  => test_pem("ee-key.pem"),
+                "CipherString" => 'DEFAULT:@SECLEVEL=0'
             },
             test => {
                 "Method" => "DTLS",
@@ -93,10 +109,12 @@ foreach my $sctp ("No", "Yes")
             server => {
                 "VerifyCAFile" => test_pem("root-cert.pem"),
                 "VerifyMode" => "Once",
+                "CipherString" => 'DEFAULT:@SECLEVEL=0'
             },
             client => {
                 "Certificate" => test_pem("ee-client-chain.pem"),
                 "PrivateKey"  => test_pem("ee-key.pem"),
+                "CipherString" => 'DEFAULT:@SECLEVEL=0'
             },
             test => {
                 "Method" => "DTLS",

--- a/test/ssl-tests/protocol_version.pm
+++ b/test/ssl-tests/protocol_version.pm
@@ -102,7 +102,10 @@ $min_dtls_enabled_fips = min_prot_enabled(\@dtls_protocols_fips, \@is_dtls_disab
 $max_dtls_enabled_fips = max_prot_enabled(\@dtls_protocols_fips, \@is_dtls_disabled_fips);
 
 sub no_tests {
-    my ($dtls) = @_;
+    my ($dtls, $fips) = @_;
+    if ($dtls && $fips) {
+        return disabled("dtls1_2");
+    }
     return $dtls ? alldisabled("dtls1", "dtls1_2") :
       alldisabled("ssl3", "tls1", "tls1_1", "tls1_2", "tls1_3");
 }
@@ -134,7 +137,7 @@ sub generate_version_tests {
         $max_enabled  = $dtls ? $max_dtls_enabled : $max_tls_enabled;
     }
 
-    if (no_tests($dtls)) {
+    if (no_tests($dtls, $fips)) {
         return;
     }
 


### PR DESCRIPTION
SHA1 is now in security level 0. SHA1 is required for DTLSv1.1. Therefore
various tests needed some adjustments in the event that DTLSv1.2 is disabled.

There are also adjustments required if using the FIPS module and DTLSv1.2
is disabled. The only DTLS version supported by the FIPS module is
DTLSv1.2.

Fixes #14956