### PR TITLE
TEST: Run AppVeyor only on pushes to master

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,15 +16,6 @@ configuration:
 
 for:
     -
-        only_commits:
-            message: /\[extended tests\]/
-        configuration:
-            - shared
-            - plain
-            - minimal
-        environment:
-            EXTENDED_TESTS: yes
-    -
         branches:
             only:
                 - master
@@ -36,6 +27,12 @@ for:
             EXTENDED_TESTS: yes
 
 before_build:
+    - ps: >-
+        $merge = (cmd /c "git rev-list -1 --merges HEAD~1..HEAD")
+    - ps: >-
+        If ($merge) {
+            Exit-AppveyorBuild
+        }
     - ps: >-
         Install-Module VSSetup -Scope CurrentUser
     - ps: >-


### PR DESCRIPTION
It is too slow to run it on every pull request.

Exit early if the top-level commit is a merge indicating
we are in a pull request build.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
