### PR TITLE
Make SSL_OP_NO_RENEGOTATION enabled by default

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,12 @@ OpenSSL 3.0
 
 ### Changes between 1.1.1 and 3.0 [xx XXX xxxx]
 
+ * Client-initiated renegotiation is now disabled by default. To enable it,
+   use SSL_clear_options or SSL_CTX_clear_options to clear the
+   SSL_OP_NO_RENEGOTIATION flag.
+
+   *Rich Salz*
+
  * For the key types DH and DHX the allowed settable parameters are now different.
    Previously (in 1.1.1) these conflicting parameters were allowed, but will now
    result in errors. See EVP_PKEY-DH(7) for further details. This affects the

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -1663,6 +1663,7 @@ int s_client_main(int argc, char **argv)
 #endif
 
     ctx = SSL_CTX_new_ex(app_get0_libctx(), app_get0_propq(), meth);
+    SSL_CTX_clear_options(ctx, SSL_OP_NO_RENEGOTIATION);
     if (ctx == NULL) {
         ERR_print_errors(bio_err);
         goto end;

--- a/doc/man1/openssl-s_server.pod.in
+++ b/doc/man1/openssl-s_server.pod.in
@@ -132,6 +132,7 @@ B<openssl> B<s_server>
 [B<-max_early_data> I<int>]
 [B<-early_data>]
 [B<-stateless>]
+[B<-no_reneg>]
 [B<-anti_replay>]
 [B<-no_anti_replay>]
 [B<-num_tickets>]
@@ -712,6 +713,10 @@ B<-WWW>, B<-HTTP> or B<-rev>.
 =item B<-stateless>
 
 Require TLSv1.3 cookies.
+
+=item B<-noreneg>
+
+Do not allow renegotation.
 
 =item B<-anti_replay>, B<-no_anti_replay>
 

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -3321,7 +3321,8 @@ SSL_CTX *SSL_CTX_new_ex(OSSL_LIB_CTX *libctx, const char *propq,
      * middlebox compatibility by default. This may be disabled by default in
      * a later OpenSSL version.
      */
-    ret->options |= SSL_OP_NO_COMPRESSION | SSL_OP_ENABLE_MIDDLEBOX_COMPAT;
+    ret->options |= SSL_OP_NO_COMPRESSION | SSL_OP_ENABLE_MIDDLEBOX_COMPAT
+        | SSL_OP_NO_RENEGOTIATION;
 
     ret->ext.status_type = TLSEXT_STATUSTYPE_nothing;
 

--- a/test/helpers/ssltestlib.c
+++ b/test/helpers/ssltestlib.c
@@ -697,6 +697,7 @@ int create_ssl_ctx_pair(OSSL_LIB_CTX *libctx, const SSL_METHOD *sm,
             serverctx = *sctx;
         else if (!TEST_ptr(serverctx = SSL_CTX_new_ex(libctx, NULL, sm)))
             goto err;
+        SSL_CTX_clear_options(serverctx, SSL_OP_NO_RENEGOTIATION);
     }
 
     if (cctx != NULL) {
@@ -704,6 +705,7 @@ int create_ssl_ctx_pair(OSSL_LIB_CTX *libctx, const SSL_METHOD *sm,
             clientctx = *cctx;
         else if (!TEST_ptr(clientctx = SSL_CTX_new_ex(libctx, NULL, cm)))
             goto err;
+        SSL_CTX_clear_options(clientctx, SSL_OP_NO_RENEGOTIATION);
     }
 
 #if !defined(OPENSSL_NO_TLS1_3) \

--- a/test/ssl_test.c
+++ b/test/ssl_test.c
@@ -409,6 +409,7 @@ static int test_handshake(int idx)
 #ifndef OPENSSL_NO_DTLS
     if (test_ctx->method == SSL_TEST_METHOD_DTLS) {
         server_ctx = SSL_CTX_new_ex(libctx, NULL, DTLS_server_method());
+        SSL_CTX_clear_options(server_ctx, SSL_OP_NO_RENEGOTIATION);
         if (!TEST_true(SSL_CTX_set_max_proto_version(server_ctx, 0)))
             goto err;
         if (test_ctx->extra.server.servername_callback !=
@@ -416,17 +417,21 @@ static int test_handshake(int idx)
             if (!TEST_ptr(server2_ctx =
                             SSL_CTX_new_ex(libctx, NULL, DTLS_server_method())))
                 goto err;
+            SSL_CTX_clear_options(server2_ctx, SSL_OP_NO_RENEGOTIATION);
         }
         client_ctx = SSL_CTX_new_ex(libctx, NULL, DTLS_client_method());
+        SSL_CTX_clear_options(client_ctx, SSL_OP_NO_RENEGOTIATION);
         if (!TEST_true(SSL_CTX_set_max_proto_version(client_ctx, 0)))
             goto err;
         if (test_ctx->handshake_mode == SSL_TEST_HANDSHAKE_RESUME) {
             resume_server_ctx = SSL_CTX_new_ex(libctx, NULL,
                                                DTLS_server_method());
+            SSL_CTX_clear_options(resume_server_ctx, SSL_OP_NO_RENEGOTIATION);
             if (!TEST_true(SSL_CTX_set_max_proto_version(resume_server_ctx, 0)))
                 goto err;
             resume_client_ctx = SSL_CTX_new_ex(libctx, NULL,
                                                DTLS_client_method());
+            SSL_CTX_clear_options(resume_client_ctx, SSL_OP_NO_RENEGOTIATION);
             if (!TEST_true(SSL_CTX_set_max_proto_version(resume_client_ctx, 0)))
                 goto err;
             if (!TEST_ptr(resume_server_ctx)
@@ -446,6 +451,7 @@ static int test_handshake(int idx)
 #endif
 
         server_ctx = SSL_CTX_new_ex(libctx, NULL, TLS_server_method());
+        SSL_CTX_clear_options(server_ctx, SSL_OP_NO_RENEGOTIATION);
         if (!TEST_true(SSL_CTX_set_max_proto_version(server_ctx, maxversion)))
             goto err;
         /* SNI on resumption isn't supported/tested yet. */
@@ -454,22 +460,26 @@ static int test_handshake(int idx)
             if (!TEST_ptr(server2_ctx =
                             SSL_CTX_new_ex(libctx, NULL, TLS_server_method())))
                 goto err;
+            SSL_CTX_clear_options(server2_ctx, SSL_OP_NO_RENEGOTIATION);
             if (!TEST_true(SSL_CTX_set_max_proto_version(server2_ctx,
                                                          maxversion)))
                 goto err;
         }
         client_ctx = SSL_CTX_new_ex(libctx, NULL, TLS_client_method());
+        SSL_CTX_clear_options(client_ctx, SSL_OP_NO_RENEGOTIATION);
         if (!TEST_true(SSL_CTX_set_max_proto_version(client_ctx, maxversion)))
             goto err;
 
         if (test_ctx->handshake_mode == SSL_TEST_HANDSHAKE_RESUME) {
             resume_server_ctx = SSL_CTX_new_ex(libctx, NULL,
                                                TLS_server_method());
+            SSL_CTX_clear_options(resume_server_ctx, SSL_OP_NO_RENEGOTIATION);
             if (!TEST_true(SSL_CTX_set_max_proto_version(resume_server_ctx,
                                                          maxversion)))
                 goto err;
             resume_client_ctx = SSL_CTX_new_ex(libctx, NULL,
                                                TLS_client_method());
+            SSL_CTX_clear_options(resume_client_ctx, SSL_OP_NO_RENEGOTIATION);
             if (!TEST_true(SSL_CTX_set_max_proto_version(resume_client_ctx,
                                                          maxversion)))
                 goto err;

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -656,6 +656,7 @@ static int test_ssl_build_cert_chain(void)
 
     if (!TEST_ptr(ssl_ctx = SSL_CTX_new_ex(libctx, NULL, TLS_server_method())))
         goto end;
+    SSL_CTX_clear_options(ssl_ctx, SSL_OP_NO_RENEGOTIATION);
     if (!TEST_ptr(ssl = SSL_new(ssl_ctx)))
         goto end;
     /* leaf_chain contains leaf + subinterCA + interCA + rootCA */
@@ -684,6 +685,7 @@ static int test_ssl_ctx_build_cert_chain(void)
 
     if (!TEST_ptr(ctx = SSL_CTX_new_ex(libctx, NULL, TLS_server_method())))
         goto end;
+    SSL_CTX_clear_options(ctx, SSL_OP_NO_RENEGOTIATION);
     /* leaf_chain contains leaf + subinterCA + interCA + rootCA */
     if (!TEST_int_eq(SSL_CTX_use_certificate_chain_file(ctx, leaf_chain), 1)
         || !TEST_int_eq(SSL_CTX_use_PrivateKey_file(ctx, skey,
@@ -2727,6 +2729,7 @@ static int execute_test_ssl_bio(int pop_ssl, bio_change_t change_bio)
             || !TEST_ptr(sslbio = BIO_new(BIO_f_ssl()))
             || !TEST_ptr(membio1 = BIO_new(BIO_s_mem())))
         goto end;
+    SSL_CTX_clear_options(ctx, SSL_OP_NO_RENEGOTIATION);
 
     BIO_set_ssl(sslbio, ssl, BIO_CLOSE);
 
@@ -5457,6 +5460,7 @@ static int test_serverinfo(int tst)
     ctx = SSL_CTX_new_ex(libctx, NULL, TLS_method());
     if (!TEST_ptr(ctx))
         goto end;
+    SSL_CTX_clear_options(ctx, SSL_OP_NO_RENEGOTIATION);
 
     if ((tst & 0x01) == 0x01)
         version = SSL_SERVERINFOV2;
@@ -6760,10 +6764,12 @@ static int int_test_ssl_get_shared_ciphers(int tst, int clnt)
         cctx = SSL_CTX_new_ex(tmplibctx, NULL, TLS_client_method());
         if (!TEST_ptr(cctx))
             goto end;
+        SSL_CTX_clear_options(cctx, SSL_OP_NO_RENEGOTIATION);
     } else {
         sctx = SSL_CTX_new_ex(tmplibctx, NULL, TLS_server_method());
         if (!TEST_ptr(sctx))
             goto end;
+        SSL_CTX_clear_options(sctx, SSL_OP_NO_RENEGOTIATION);
     }
 
     if (!TEST_true(create_ssl_ctx_pair(libctx, TLS_server_method(),
@@ -7447,8 +7453,11 @@ static int test_cert_cb_int(int prot, int tst)
     else
         cert_cb_cnt = 0;
 
-    if (tst == 2)
+    if (tst == 2) {
         snictx = SSL_CTX_new(TLS_server_method());
+        if (snictx != NULL)
+            SSL_CTX_clear_options(snictx, SSL_OP_NO_RENEGOTIATION);
+    }
     SSL_CTX_set_cert_cb(sctx, cert_cb, snictx);
 
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
@@ -8046,6 +8055,8 @@ static int test_sigalgs_available(int idx)
     sctx = SSL_CTX_new_ex(serverctx, NULL, TLS_server_method());
     if (!TEST_ptr(cctx) || !TEST_ptr(sctx))
         goto end;
+    SSL_CTX_clear_options(cctx, SSL_OP_NO_RENEGOTIATION);
+    SSL_CTX_clear_options(sctx, SSL_OP_NO_RENEGOTIATION);
 
     if (!TEST_true(create_ssl_ctx_pair(libctx, TLS_server_method(),
                                        TLS_client_method(),
@@ -8580,6 +8591,7 @@ static int test_sni_tls13(void)
     sctx = SSL_CTX_new_ex(libctx, NULL, TLS_server_method());
     if (!TEST_ptr(sctx))
         goto end;
+    SSL_CTX_clear_options(sctx, SSL_OP_NO_RENEGOTIATION);
     /* Require TLSv1.3 as a minimum */
     if (!TEST_true(create_ssl_ctx_pair(libctx, TLS_server_method(),
                                        TLS_client_method(), TLS1_3_VERSION, 0,
@@ -8636,6 +8648,7 @@ static int test_set_alpn(void)
     ctx = SSL_CTX_new_ex(libctx, NULL, TLS_server_method());
     if (!TEST_ptr(ctx))
         goto end;
+    SSL_CTX_clear_options(ctx, SSL_OP_NO_RENEGOTIATION);
 
     /* the set_alpn functions return 0 (false) on success, non-zero (true) on failure */
     if (!TEST_false(SSL_CTX_set_alpn_protos(ctx, NULL, 2)))
@@ -8701,6 +8714,7 @@ static int test_inherit_verify_param(void)
     ctx = SSL_CTX_new_ex(libctx, NULL, TLS_server_method());
     if (!TEST_ptr(ctx))
         goto end;
+    SSL_CTX_clear_options(ctx, SSL_OP_NO_RENEGOTIATION);
 
     cp = SSL_CTX_get0_param(ctx);
     if (!TEST_ptr(cp))


### PR DESCRIPTION
Changed a bunch of test cases that were depending on that not
being the default.  Added a new option to s_server.

I'm not thrilled with the `-no_reneg` option I added to s_server, but it seemed the cleanest approach.

No new test cases added, since most test (except those explicitly testing various TLS behavior) all worked fine.