### PR TITLE
runchecker: fix no-sock build by conditioning clean up on the NO_SOCK symbol.

### DIFF
--- a/apps/cmp.c
+++ b/apps/cmp.c
@@ -2855,7 +2855,9 @@ int cmp_main(int argc, char **argv)
         OSSL_CMP_CTX_print_errors(cmp_ctx);
 
     ossl_cmp_mock_srv_free(OSSL_CMP_CTX_get_transfer_cb_arg(cmp_ctx));
+#ifndef OPENSSL_NO_SOCK
     APP_HTTP_TLS_INFO_free(OSSL_CMP_CTX_get_http_cb_arg(cmp_ctx));
+#endif
     X509_STORE_free(OSSL_CMP_CTX_get_certConf_cb_arg(cmp_ctx));
     OSSL_CMP_CTX_free(cmp_ctx);
     X509_VERIFY_PARAM_free(vpm);


### PR DESCRIPTION


Fixes #15054

- [ ] documentation is added or updated
- [ ] tests are added or updated
