### PR TITLE
test: never run fipsinstall if the tests are not enabled.

### DIFF
--- a/providers/build.info
+++ b/providers/build.info
@@ -147,11 +147,13 @@ IF[{- !$disabled{fips} -}]
   # module installation.  We have the output go to standard output, because
   # the generated commands in build templates are expected to catch that,
   # and thereby keep control over the exact output file location.
-  DEPEND[|tests|]=fipsmodule.cnf
-  GENERATE[fipsmodule.cnf]=../apps/openssl fipsinstall \
-        -module providers/$(FIPSMODULENAME) -provider_name fips \
-        -mac_name HMAC -section_name fips_sect
-  DEPEND[fipsmodule.cnf]=$FIPSGOAL
+  IF[{- !$disabled{tests} -}]
+    DEPEND[|tests|]=fipsmodule.cnf
+    GENERATE[fipsmodule.cnf]=../apps/openssl fipsinstall \
+          -module providers/$(FIPSMODULENAME) -provider_name fips \
+          -mac_name HMAC -section_name fips_sect
+    DEPEND[fipsmodule.cnf]=$FIPSGOAL
+  ENDIF
 ENDIF
 
 #


### PR DESCRIPTION
Fixes #15056

The dependency for fipsinstall was being added to the makefile regardless of
it being used.  This means that a subsequent `make test` would fail if the
command line application wasn't present.  Rather than fix the instance in question,
it is better to leave out this part of the makefile if the tests cannot be
run.

- [ ] documentation is added or updated
- [ ] tests are added or updated
