### PR TITLE
Fix CRL app so that stdin works.

### DIFF
--- a/apps/crl.c
+++ b/apps/crl.c
@@ -211,7 +211,7 @@ int crl_main(int argc, char **argv)
         if (!opt_md(digestname, &digest))
             goto opthelp;
     }
-    x = load_crl(infile, "CRL");
+    x = load_crl(infile, 1, "CRL");
     if (x == NULL)
         goto end;
 
@@ -250,13 +250,13 @@ int crl_main(int argc, char **argv)
             BIO_printf(bio_err, "verify OK\n");
     }
 
-    if (crldiff) {
+    if (crldiff != NULL) {
         X509_CRL *newcrl, *delta;
         if (!keyfile) {
             BIO_puts(bio_err, "Missing CRL signing key\n");
             goto end;
         }
-        newcrl = load_crl(crldiff, "other CRL");
+        newcrl = load_crl(crldiff, 0, "other CRL");
         if (!newcrl)
             goto end;
         pkey = load_key(keyfile, keyformat, 0, NULL, NULL, "CRL signing key");

--- a/apps/include/apps.h
+++ b/apps/include/apps.h
@@ -111,7 +111,7 @@ X509_REQ *load_csr(const char *file, int format, const char *desc);
 X509 *load_cert_pass(const char *uri, int maybe_stdin,
                      const char *pass, const char *desc);
 #define load_cert(uri, desc) load_cert_pass(uri, 1, NULL, desc)
-X509_CRL *load_crl(const char *uri, const char *desc);
+X509_CRL *load_crl(const char *uri, int maybe_stdin, const char *desc);
 void cleanse(char *str);
 void clear_free(char *str);
 EVP_PKEY *load_key(const char *uri, int format, int maybe_stdin,

--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -499,7 +499,7 @@ X509 *load_cert_pass(const char *uri, int maybe_stdin,
     return cert;
 }
 
-X509_CRL *load_crl(const char *uri, const char *desc)
+X509_CRL *load_crl(const char *uri, int maybe_stdin, const char *desc)
 {
     X509_CRL *crl = NULL;
 
@@ -510,7 +510,7 @@ X509_CRL *load_crl(const char *uri, const char *desc)
     else if (IS_HTTP(uri))
         crl = X509_CRL_load_http(uri, NULL, NULL, 0 /* timeout */);
     else
-        (void)load_key_certs_crls(uri, 0, NULL, desc,
+        (void)load_key_certs_crls(uri, maybe_stdin, NULL, desc,
                                   NULL, NULL,  NULL, NULL, NULL, &crl, NULL);
     if (crl == NULL) {
         BIO_printf(bio_err, "Unable to load %s\n", desc);
@@ -2318,8 +2318,8 @@ static X509_CRL *load_crl_crldp(STACK_OF(DIST_POINT) *crldp)
     for (i = 0; i < sk_DIST_POINT_num(crldp); i++) {
         DIST_POINT *dp = sk_DIST_POINT_value(crldp, i);
         urlptr = get_dp_url(dp);
-        if (urlptr)
-            return load_crl(urlptr, "CRL via CDP");
+        if (urlptr != NULL)
+            return load_crl(urlptr, 0, "CRL via CDP");
     }
     return NULL;
 }

--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -848,6 +848,7 @@ int load_key_certs_crls(const char *uri, int maybe_stdin,
                         X509 **pcert, STACK_OF(X509) **pcerts,
                         X509_CRL **pcrl, STACK_OF(X509_CRL) **pcrls)
 {
+    BIO *bio = NULL;
     PW_CB_DATA uidata;
     OSSL_STORE_CTX *ctx = NULL;
     OSSL_LIB_CTX *libctx = app_get0_libctx();
@@ -915,8 +916,6 @@ int load_key_certs_crls(const char *uri, int maybe_stdin,
     uidata.prompt_info = uri;
 
     if (uri == NULL) {
-        BIO *bio;
-
         if (!maybe_stdin) {
             BIO_printf(bio_err, "No filename or uri specified for loading");
             goto end;
@@ -1024,6 +1023,7 @@ int load_key_certs_crls(const char *uri, int maybe_stdin,
 
  end:
     OSSL_STORE_close(ctx);
+    BIO_free(bio);
     if (failed == NULL) {
         int any = 0;
 

--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -916,6 +916,7 @@ int load_key_certs_crls(const char *uri, int maybe_stdin,
 
     if (uri == NULL) {
         BIO *bio;
+
         if (!maybe_stdin) {
             BIO_printf(bio_err, "No filename or uri specified for loading");
             goto end;

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -1632,7 +1632,7 @@ int s_client_main(int argc, char **argv)
 
     if (crl_file != NULL) {
         X509_CRL *crl;
-        crl = load_crl(crl_file, "CRL");
+        crl = load_crl(crl_file, 0, "CRL");
         if (crl == NULL)
             goto end;
         crls = sk_X509_CRL_new_null();

--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -1726,7 +1726,7 @@ int s_server_main(int argc, char *argv[])
 
     if (crl_file != NULL) {
         X509_CRL *crl;
-        crl = load_crl(crl_file, "CRL");
+        crl = load_crl(crl_file, 0, "CRL");
         if (crl == NULL)
             goto end;
         crls = sk_X509_CRL_new_null();

--- a/doc/man3/OSSL_STORE_attach.pod
+++ b/doc/man3/OSSL_STORE_attach.pod
@@ -18,7 +18,8 @@ OSSL_STORE_attach - Functions to read objects from a BIO
 
 OSSL_STORE_attach() works like L<OSSL_STORE_open(3)>, except it takes a B<BIO>
 I<bio> instead of a I<uri>, along with a I<scheme> to determine what loader
-should be used to process the data.
+should be used to process the data. The reference count of the B<BIO> object
+is increased by 1 if the call is successful.
 
 =head1 RETURN VALUES
 
@@ -35,7 +36,7 @@ OSSL_STORE_attach() was added in OpenSSL 3.0.
 
 =head1 COPYRIGHT
 
-Copyright 2020 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2020-2021 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/test/recipes/25-test_crl.t
+++ b/test/recipes/25-test_crl.t
@@ -39,6 +39,11 @@ ok(compare1stline([qw{openssl crl -noout -hash -in},
                    srctop_file('test', 'testcrl.pem')],
                   '106cd822'));
 
+ok(compare1stline_stdin([qw{openssl crl -hash -noout}],
+                        srctop_file("test","testcrl.pem"),
+                        'issuer name hash=106cd822'),
+   "crl piped input test");
+
 ok(run(app(["openssl", "crl", "-text", "-in", $pem, "-out", $out,
             "-nameopt", "utf8"])));
 is(cmp_text($out, srctop_file("test/certs", "cyrillic_crl.utf8")),
@@ -47,6 +52,16 @@ is(cmp_text($out, srctop_file("test/certs", "cyrillic_crl.utf8")),
 sub compare1stline {
     my ($cmdarray, $str) = @_;
     my @lines = run(app($cmdarray), capture => 1);
+
+    return 1 if $lines[0] =~ m|^\Q${str}\E\R$|;
+    note "Got      ", $lines[0];
+    note "Expected ", $str;
+    return 0;
+}
+
+sub compare1stline_stdin {
+    my ($cmdarray, $infile, $str) = @_;
+    my @lines = run(app($cmdarray, stdin => $infile), capture => 1);
 
     return 1 if $lines[0] =~ m|^\Q${str}\E\R$|;
     note "Got      ", $lines[0];

--- a/test/recipes/25-test_crl.t
+++ b/test/recipes/25-test_crl.t
@@ -15,7 +15,7 @@ use OpenSSL::Test qw/:DEFAULT srctop_file/;
 
 setup("test_crl");
 
-plan tests => 8;
+plan tests => 9;
 
 require_ok(srctop_file('test','recipes','tconversion.pl'));
 

--- a/test/recipes/25-test_crl.t
+++ b/test/recipes/25-test_crl.t
@@ -41,7 +41,7 @@ ok(compare1stline([qw{openssl crl -noout -hash -in},
 
 ok(compare1stline_stdin([qw{openssl crl -hash -noout}],
                         srctop_file("test","testcrl.pem"),
-                        'issuer name hash=106cd822'),
+                        '106cd822'),
    "crl piped input test");
 
 ok(run(app(["openssl", "crl", "-text", "-in", $pem, "-out", $out,


### PR DESCRIPTION
Fixes #15031

The maybe_stdin flag needed to be passed to load_key_certs_crls().

Note that adding a test found an existing memory leak.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
