### PR TITLE
STORE: Use the 'expect' param to limit the amount of decoders used

### DIFF
--- a/providers/implementations/storemgmt/file_store.c
+++ b/providers/implementations/storemgmt/file_store.c
@@ -467,8 +467,6 @@ static int file_setup_decoders(struct file_ctx_st *ctx)
          * Since we're setting up our own constructor, we don't need to care
          * more than that...
          */
-        fprintf(stderr, "DEBUG[%s]: expect_evp_pkey = %d\n",
-                __func__, expect_evp_pkey);
         if ((expect_evp_pkey
              && !ossl_decoder_ctx_setup_for_pkey(ctx->_.file.decoderctx,
                                                  &dummy, NULL,


### PR DESCRIPTION
In the provider file: scheme loader implementation, the OSSL_DECODER_CTX
was set up with all sorts of implementations, even if the caller has
declared a limited expectation on what should be loaded, which means
that even though a certificate is expected, all the diverse decoders
to produce an EVP_PKEY are added to the decoding change.

This optimization looks more closely at the expected type, and only
adds the EVP_PKEY related decoder implementations to the chain if
there is no expectation, or if the expectation is one of
OSSL_STORE_INFO_PARAMS, OSSL_STORE_INFO_PUBKEY, OSSL_STORE_INFO_PKEY.
