### PR TITLE
Mark pop/clear error stack in der2key_decode_p8

### DIFF
--- a/providers/implementations/encode_decode/decode_der2key.c
+++ b/providers/implementations/encode_decode/decode_der2key.c
@@ -128,6 +128,7 @@ static void *der2key_decode_p8(const unsigned char **input_der,
     if ((p8 = d2i_X509_SIG(NULL, input_der, input_der_len)) != NULL) {
         char pbuf[PEM_BUFSIZE];
         size_t plen = 0;
+
         ERR_clear_last_mark();
 
         if (!pw_cb(pbuf, sizeof(pbuf), &plen, NULL, pw_cbarg))

--- a/providers/implementations/encode_decode/decode_der2key.c
+++ b/providers/implementations/encode_decode/decode_der2key.c
@@ -124,7 +124,9 @@ static void *der2key_decode_p8(const unsigned char **input_der,
 
     ctx->flag_fatal = 0;
 
+    ERR_set_mark();
     if ((p8 = d2i_X509_SIG(NULL, input_der, input_der_len)) != NULL) {
+        ERR_clear_last_mark();
         char pbuf[PEM_BUFSIZE];
         size_t plen = 0;
 
@@ -136,6 +138,8 @@ static void *der2key_decode_p8(const unsigned char **input_der,
             ctx->flag_fatal = 1;
         X509_SIG_free(p8);
     } else {
+        // Pop any errors that might have been raised by d2i_X509_SIG.
+        ERR_pop_to_mark();
         p8inf = d2i_PKCS8_PRIV_KEY_INFO(NULL, input_der, input_der_len);
     }
     if (p8inf != NULL

--- a/providers/implementations/encode_decode/decode_der2key.c
+++ b/providers/implementations/encode_decode/decode_der2key.c
@@ -126,9 +126,9 @@ static void *der2key_decode_p8(const unsigned char **input_der,
 
     ERR_set_mark();
     if ((p8 = d2i_X509_SIG(NULL, input_der, input_der_len)) != NULL) {
-        ERR_clear_last_mark();
         char pbuf[PEM_BUFSIZE];
         size_t plen = 0;
+        ERR_clear_last_mark();
 
         if (!pw_cb(pbuf, sizeof(pbuf), &plen, NULL, pw_cbarg))
             ERR_raise(ERR_LIB_PROV, PROV_R_UNABLE_TO_GET_PASSPHRASE);
@@ -138,7 +138,7 @@ static void *der2key_decode_p8(const unsigned char **input_der,
             ctx->flag_fatal = 1;
         X509_SIG_free(p8);
     } else {
-        // Pop any errors that might have been raised by d2i_X509_SIG.
+        /* Pop any errors that might have been raised by d2i_X509_SIG. */
         ERR_pop_to_mark();
         p8inf = d2i_PKCS8_PRIV_KEY_INFO(NULL, input_der, input_der_len);
     }

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -1170,6 +1170,7 @@ static int test_EVP_PKCS82PKEY(void)
     return ret;
 }
 
+#endif
 static int test_EVP_PKCS82PKEY_wrong_tag(void)
 {
     OSSL_PROVIDER *provider = OSSL_PROVIDER_load(NULL, "default");
@@ -1206,7 +1207,6 @@ static int test_EVP_PKCS82PKEY_wrong_tag(void)
     OSSL_PROVIDER_unload(provider);
     return ok;
 }
-#endif
 
 /* This uses kExampleRSAKeyDER and kExampleRSAKeyPKCS8 to verify encoding */
 static int test_privatekey_to_pkcs8(void)

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -1173,15 +1173,16 @@ static int test_EVP_PKCS82PKEY(void)
 #endif
 static int test_EVP_PKCS82PKEY_wrong_tag(void)
 {
-    if (testctx != NULL)
-        /* test not supported with non-default context */
-        return 1;
     EVP_PKEY *pkey = NULL;
     EVP_PKEY *pkey2 = NULL;
     BIO *membio = NULL;
     char *membuf = NULL;
     PKCS8_PRIV_KEY_INFO *p8inf = NULL;
     int ok = 0;
+
+    if (testctx != NULL)
+        /* test not supported with non-default context */
+        return 1;
 
     if (!TEST_ptr(membio = BIO_new(BIO_s_mem()))
         || !TEST_ptr(pkey = load_example_rsa_key())

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -1175,6 +1175,7 @@ static int test_EVP_PKCS82PKEY_wrong_tag(void)
 {
     OSSL_PROVIDER *provider = OSSL_PROVIDER_load(NULL, "default");
     EVP_PKEY *pkey = NULL;
+    EVP_PKEY *pkey2 = NULL;
     BIO *membio = NULL;
     char *membuf = NULL;
     PKCS8_PRIV_KEY_INFO *p8inf = NULL;
@@ -1194,7 +1195,7 @@ static int test_EVP_PKCS82PKEY_wrong_tag(void)
                                                       NULL, 0, NULL, NULL),
                         0)
         || !TEST_ptr(p8inf = d2i_PKCS8_PRIV_KEY_INFO_bio(membio, NULL))
-        || !TEST_ptr(pkey = EVP_PKCS82PKEY(p8inf))
+        || !TEST_ptr(pkey2 = EVP_PKCS82PKEY(p8inf))
         || !TEST_int_eq(ERR_get_error(), 0)) {
         goto done;
     }
@@ -1202,6 +1203,7 @@ static int test_EVP_PKCS82PKEY_wrong_tag(void)
     ok = 1;
  done:
     EVP_PKEY_free(pkey);
+    EVP_PKEY_free(pkey2);
     PKCS8_PRIV_KEY_INFO_free(p8inf);
     BIO_free_all(membio);
     OSSL_PROVIDER_unload(provider);


### PR DESCRIPTION
This commit sets the error mark before calling `d2i_X509_SIG`
and clear it if that function call is successful.

The motivation for this is that if `d2i_X509_SIG` returns NULL then the
else clause will be entered and `d2i_PKCS8_PRIV_KEY_INFO` will be
called. If `d2i_X509_SIG` raised any errors those error will be on the
error stack when `d2i_PKCS8_PRIV_KEY_INFO` gets called, and even if it
returns successfully those errors will still be on the error stack.

We ran into this issue when upgrading Node.js to 3.0.0-alpha15.
More details can be found in the ref links below.

Refs: https://github.com/nodejs/node/issues/38373
Refs: https://github.com/danbev/learning-libcrypto/blob/master/notes/wrong-tag-issue2.md


##### Checklist
- [x] tests are added or updated
