### PR TITLE
Document the API breaking constification changes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,6 +40,15 @@ OpenSSL 3.0
 
    *Boris Pismenny, John Baldwin and Andrew Gallatin*
 
+ * The signature of the `copy` functional parameter of the
+   EVP_PKEY_meth_set_copy() function has changed so its `src` argument is
+   now `const EVP_PKEY_CTX *` instead of `EVP_PKEY_CTX *`. Similarly
+   the signature of the `pub_decode` functional parameter of the
+   EVP_PKEY_asn1_set_public() function has changed so its `pub` argument is
+   now `const X509_PUBKEY *` instead of `X509_PUBKEY *`.
+
+   *David von Oheimb*
+
  * The error return values from some control calls (ctrl) have changed.
    One significant change is that controls which used to return -2 for
    invalid inputs, now return -1 indicating a generic error condition instead.

--- a/doc/man3/EVP_PKEY_ASN1_METHOD.pod
+++ b/doc/man3/EVP_PKEY_ASN1_METHOD.pod
@@ -156,7 +156,7 @@ L<EVP_PKEY_asn1_add0(3)>.
 The methods are the underlying implementations of a particular public
 key algorithm present by the B<EVP_PKEY> object.
 
- int (*pub_decode) (EVP_PKEY *pk, X509_PUBKEY *pub);
+ int (*pub_decode) (EVP_PKEY *pk, const X509_PUBKEY *pub);
  int (*pub_encode) (X509_PUBKEY *pub, const EVP_PKEY *pk);
  int (*pub_cmp) (const EVP_PKEY *a, const EVP_PKEY *b);
  int (*pub_print) (BIO *out, const EVP_PKEY *pkey, int indent,
@@ -431,6 +431,12 @@ or 1 on success.
 
 EVP_PKEY_get0_asn1() returns NULL on error, or a pointer to a constant
 B<EVP_PKEY_ASN1_METHOD> object otherwise.
+
+=head1 HISTORY
+
+The signature of the I<pub_decode> functional argument of
+EVP_PKEY_asn1_set_public() has changed in OpenSSL 3.0 so its I<pub>
+parameter is now constified.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/EVP_PKEY_meth_new.pod
+++ b/doc/man3/EVP_PKEY_meth_new.pod
@@ -46,7 +46,7 @@ L<openssl_user_macros(7)>:
                              int (*init) (EVP_PKEY_CTX *ctx));
  void EVP_PKEY_meth_set_copy(EVP_PKEY_METHOD *pmeth,
                              int (*copy) (EVP_PKEY_CTX *dst,
-                                          EVP_PKEY_CTX *src));
+                                          const EVP_PKEY_CTX *src));
  void EVP_PKEY_meth_set_cleanup(EVP_PKEY_METHOD *pmeth,
                                 void (*cleanup) (EVP_PKEY_CTX *ctx));
  void EVP_PKEY_meth_set_paramgen(EVP_PKEY_METHOD *pmeth,
@@ -266,7 +266,7 @@ The methods are the underlying implementations of a particular public key
 algorithm present by the B<EVP_PKEY_CTX> object.
 
  int (*init) (EVP_PKEY_CTX *ctx);
- int (*copy) (EVP_PKEY_CTX *dst, EVP_PKEY_CTX *src);
+ int (*copy) (EVP_PKEY_CTX *dst, const EVP_PKEY_CTX *src);
  void (*cleanup) (EVP_PKEY_CTX *ctx);
 
 The init() method is called to initialize algorithm-specific data when a new
@@ -450,6 +450,9 @@ arguments.
 =head1 HISTORY
 
 All of these functions were deprecated in OpenSSL 3.0.
+
+The signature of the I<copy> functional argument of EVP_PKEY_meth_set_copy()
+has changed in OpenSSL 3.0 so its I<src> parameter is now constified.
 
 =head1 COPYRIGHT
 


### PR DESCRIPTION
The EVP_PKEY_asn1_set_public and EVP_PKEY_meth_set_copy have
some API breaking constification changes in 3.0.

Fixes #9296

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
