### PR TITLE
Add BIO_new_from_core_bio() to the public API

### DIFF
--- a/crypto/bio/bio_lib.c
+++ b/crypto/bio/bio_lib.c
@@ -68,7 +68,7 @@ static long bio_call_callback(BIO *b, int oper, const char *argp, size_t len,
     return ret;
 }
 
-BIO *BIO_new(const BIO_METHOD *method)
+BIO *BIO_new_ex(OSSL_LIB_CTX *libctx, const BIO_METHOD *method)
 {
     BIO *bio = OPENSSL_zalloc(sizeof(*bio));
 
@@ -77,6 +77,7 @@ BIO *BIO_new(const BIO_METHOD *method)
         return NULL;
     }
 
+    bio->libctx = libctx;
     bio->method = method;
     bio->shutdown = 1;
     bio->references = 1;
@@ -105,6 +106,11 @@ BIO *BIO_new(const BIO_METHOD *method)
 err:
     OPENSSL_free(bio);
     return NULL;
+}
+
+BIO *BIO_new(const BIO_METHOD *method)
+{
+    return BIO_new_ex(NULL, method);
 }
 
 int BIO_free(BIO *a)

--- a/crypto/bio/bio_local.h
+++ b/crypto/bio/bio_local.h
@@ -113,6 +113,7 @@ typedef struct bio_f_buffer_ctx_struct {
 } BIO_F_BUFFER_CTX;
 
 struct bio_st {
+    OSSL_LIB_CTX *libctx;
     const BIO_METHOD *method;
     /* bio, mode, argp, argi, argl, ret */
     BIO_callback_fn callback;

--- a/crypto/bio/bss_core.c
+++ b/crypto/bio/bss_core.c
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2019-2021 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <openssl/core_dispatch.h>
+#include "bio_local.h"
+#include "internal/cryptlib.h"
+
+typedef struct {
+    OSSL_FUNC_BIO_read_ex_fn *c_bio_read_ex;
+    OSSL_FUNC_BIO_write_ex_fn *c_bio_write_ex;
+    OSSL_FUNC_BIO_gets_fn *c_bio_gets;
+    OSSL_FUNC_BIO_puts_fn *c_bio_puts;
+    OSSL_FUNC_BIO_ctrl_fn *c_bio_ctrl;
+} BIO_CORE_GLOBALS;
+
+static void bio_core_globals_free(void *vbcg)
+{
+    OPENSSL_free(vbcg);
+}
+
+static void *bio_core_globals_new(OSSL_LIB_CTX *ctx)
+{
+    return OPENSSL_zalloc(sizeof(BIO_CORE_GLOBALS));
+}
+
+static const OSSL_LIB_CTX_METHOD bio_core_globals_method = {
+    bio_core_globals_new,
+    bio_core_globals_free,
+};
+
+static ossl_inline BIO_CORE_GLOBALS *get_globals(OSSL_LIB_CTX *libctx)
+{
+    return ossl_lib_ctx_get_data(libctx, OSSL_LIB_CTX_BIO_CORE_INDEX,
+                                 &bio_core_globals_method);
+}
+
+static int bio_core_read_ex(BIO *bio, char *data, size_t data_len,
+                            size_t *bytes_read)
+{
+    BIO_CORE_GLOBALS *bcgbl = get_globals(bio->libctx);
+
+    if (bcgbl->c_bio_read_ex == NULL)
+        return 0;
+    return bcgbl->c_bio_read_ex(BIO_get_data(bio), data, data_len, bytes_read);
+}
+
+static int bio_core_write_ex(BIO *bio, const char *data, size_t data_len,
+                             size_t *written)
+{
+    BIO_CORE_GLOBALS *bcgbl = get_globals(bio->libctx);
+
+    if (bcgbl->c_bio_write_ex == NULL)
+        return 0;
+    return bcgbl->c_bio_write_ex(BIO_get_data(bio), data, data_len, written);
+}
+
+static long bio_core_ctrl(BIO *bio, int cmd, long num, void *ptr)
+{
+    BIO_CORE_GLOBALS *bcgbl = get_globals(bio->libctx);
+
+    if (bcgbl->c_bio_ctrl == NULL)
+        return -1;
+    return bcgbl->c_bio_ctrl(BIO_get_data(bio), cmd, num, ptr);
+}
+
+static int bio_core_gets(BIO *bio, char *buf, int size)
+{
+    BIO_CORE_GLOBALS *bcgbl = get_globals(bio->libctx);
+
+    if (bcgbl->c_bio_gets == NULL)
+        return -1;
+    return bcgbl->c_bio_gets(BIO_get_data(bio), buf, size);
+}
+
+static int bio_core_puts(BIO *bio, const char *str)
+{
+    BIO_CORE_GLOBALS *bcgbl = get_globals(bio->libctx);
+
+    if (bcgbl->c_bio_puts == NULL)
+        return -1;
+    return bcgbl->c_bio_puts(BIO_get_data(bio), str);
+}
+
+static int bio_core_new(BIO *bio)
+{
+    BIO_set_init(bio, 1);
+
+    return 1;
+}
+
+static int bio_core_free(BIO *bio)
+{
+    BIO_set_init(bio, 0);
+
+    return 1;
+}
+
+static const BIO_METHOD corebiometh = {
+    BIO_TYPE_CORE_TO_PROV,
+    "BIO to Core filter",
+    bio_core_write_ex,
+    NULL,
+    bio_core_read_ex,
+    NULL,
+    bio_core_puts,
+    bio_core_gets,
+    bio_core_ctrl,
+    bio_core_new,
+    bio_core_free,
+    NULL,
+};
+
+const BIO_METHOD *BIO_s_core(void)
+{
+    return &corebiometh;
+}
+
+BIO *BIO_new_from_core_bio(OSSL_LIB_CTX *libctx, OSSL_CORE_BIO *corebio)
+{
+    BIO *outbio;
+    BIO_CORE_GLOBALS *bcgbl = get_globals(libctx);
+
+    /* Check the library context has been initialised with the callbacks */
+    if (bcgbl->c_bio_write_ex == NULL && bcgbl->c_bio_read_ex == NULL)
+        return NULL;
+
+    if ((outbio = BIO_new_ex(libctx, BIO_s_core())) == NULL)
+        return NULL;
+
+    BIO_set_data(outbio, corebio);
+    return outbio;
+}
+
+int ossl_bio_init_core(OSSL_LIB_CTX *libctx, const OSSL_DISPATCH *fns)
+{
+    BIO_CORE_GLOBALS *bcgbl = get_globals(libctx);
+
+    for (; fns->function_id != 0; fns++) {
+        switch (fns->function_id) {
+        case OSSL_FUNC_BIO_READ_EX:
+            if (bcgbl->c_bio_read_ex == NULL)
+                bcgbl->c_bio_read_ex = OSSL_FUNC_BIO_read_ex(fns);
+            break;
+        case OSSL_FUNC_BIO_WRITE_EX:
+            if (bcgbl->c_bio_write_ex == NULL)
+                bcgbl->c_bio_write_ex = OSSL_FUNC_BIO_write_ex(fns);
+            break;
+        case OSSL_FUNC_BIO_GETS:
+            if (bcgbl->c_bio_gets == NULL)
+                bcgbl->c_bio_gets = OSSL_FUNC_BIO_gets(fns);
+            break;
+        case OSSL_FUNC_BIO_PUTS:
+            if (bcgbl->c_bio_puts == NULL)
+                bcgbl->c_bio_puts = OSSL_FUNC_BIO_puts(fns);
+            break;
+        case OSSL_FUNC_BIO_CTRL:
+            if (bcgbl->c_bio_ctrl == NULL)
+                bcgbl->c_bio_ctrl = OSSL_FUNC_BIO_ctrl(fns);
+            break;
+        }
+    }
+
+    return 1;
+}

--- a/crypto/bio/build.info
+++ b/crypto/bio/build.info
@@ -11,7 +11,7 @@ SOURCE[../../libcrypto]=\
 SOURCE[../../libcrypto]=\
         bss_null.c bss_mem.c bss_bio.c bss_fd.c bss_file.c \
         bss_sock.c bss_conn.c bss_acpt.c bss_dgram.c \
-        bss_log.c
+        bss_log.c bss_core.c
 
 # Filters
 SOURCE[../../libcrypto]=\

--- a/crypto/context.c
+++ b/crypto/context.c
@@ -12,6 +12,7 @@
 #include "internal/thread_once.h"
 #include "internal/property.h"
 #include "internal/core.h"
+#include "internal/bio.h"
 
 struct ossl_lib_ctx_onfree_list_st {
     ossl_lib_ctx_onfree_fn *fn;
@@ -184,6 +185,21 @@ OSSL_LIB_CTX *OSSL_LIB_CTX_new(void)
 }
 
 #ifndef FIPS_MODULE
+OSSL_LIB_CTX *OSSL_LIB_CTX_new_from_dispatch(const OSSL_DISPATCH *in)
+{
+    OSSL_LIB_CTX *ctx = OSSL_LIB_CTX_new();
+
+    if (ctx == NULL)
+        return NULL;
+
+    if (!ossl_bio_init_core(ctx, in)) {
+        OSSL_LIB_CTX_free(ctx);
+        return NULL;
+    }
+
+    return ctx;
+}
+
 int OSSL_LIB_CTX_load_config(OSSL_LIB_CTX *ctx, const char *config_file)
 {
     return CONF_modules_load_file_ex(ctx, config_file, NULL, 0) > 0;

--- a/doc/build.info
+++ b/doc/build.info
@@ -630,6 +630,10 @@ DEPEND[html/man3/BIO_s_connect.html]=man3/BIO_s_connect.pod
 GENERATE[html/man3/BIO_s_connect.html]=man3/BIO_s_connect.pod
 DEPEND[man/man3/BIO_s_connect.3]=man3/BIO_s_connect.pod
 GENERATE[man/man3/BIO_s_connect.3]=man3/BIO_s_connect.pod
+DEPEND[html/man3/BIO_s_core.html]=man3/BIO_s_core.pod
+GENERATE[html/man3/BIO_s_core.html]=man3/BIO_s_core.pod
+DEPEND[man/man3/BIO_s_core.3]=man3/BIO_s_core.pod
+GENERATE[man/man3/BIO_s_core.3]=man3/BIO_s_core.pod
 DEPEND[html/man3/BIO_s_fd.html]=man3/BIO_s_fd.pod
 GENERATE[html/man3/BIO_s_fd.html]=man3/BIO_s_fd.pod
 DEPEND[man/man3/BIO_s_fd.3]=man3/BIO_s_fd.pod
@@ -2811,6 +2815,7 @@ html/man3/BIO_read.html \
 html/man3/BIO_s_accept.html \
 html/man3/BIO_s_bio.html \
 html/man3/BIO_s_connect.html \
+html/man3/BIO_s_core.html \
 html/man3/BIO_s_fd.html \
 html/man3/BIO_s_file.html \
 html/man3/BIO_s_mem.html \
@@ -3387,6 +3392,7 @@ man/man3/BIO_read.3 \
 man/man3/BIO_s_accept.3 \
 man/man3/BIO_s_bio.3 \
 man/man3/BIO_s_connect.3 \
+man/man3/BIO_s_core.3 \
 man/man3/BIO_s_fd.3 \
 man/man3/BIO_s_file.3 \
 man/man3/BIO_s_mem.3 \

--- a/doc/man3/BIO_new.pod
+++ b/doc/man3/BIO_new.pod
@@ -19,10 +19,10 @@ BIO_new_ex, BIO_new, BIO_up_ref, BIO_free, BIO_vfree, BIO_free_all
 =head1 DESCRIPTION
 
 The BIO_new_ex() function returns a new BIO using method B<type> associated with
-the library context B<libctx> (see OSSL_LIB_CTX(3)). The library context may be
+the library context I<libctx> (see OSSL_LIB_CTX(3)). The library context may be
 NULL to indicate the default library context.
 
-The BIO_new() is the same as BIO_new_ex() excpet the default library context is
+The BIO_new() is the same as BIO_new_ex() except the default library context is
 always used.
 
 BIO_up_ref() increments the reference count associated with the BIO object.
@@ -41,7 +41,7 @@ If B<a> is NULL nothing is done.
 
 =head1 RETURN VALUES
 
-BIO_new() returns a newly created BIO or NULL if the call fails.
+BIO_new_ex() and BIO_new() return a newly created BIO or NULL if the call fails.
 
 BIO_up_ref() and BIO_free() return 1 for success and 0 for failure.
 
@@ -58,6 +58,8 @@ on it other than the discarded return value.
 =head1 HISTORY
 
 BIO_set() was removed in OpenSSL 1.1.0 as BIO type is now opaque.
+
+BIO_new_ex() was added in OpenSSL 3.0.
 
 =head1 EXAMPLES
 

--- a/doc/man3/BIO_new.pod
+++ b/doc/man3/BIO_new.pod
@@ -2,22 +2,28 @@
 
 =head1 NAME
 
-BIO_new, BIO_up_ref, BIO_free, BIO_vfree, BIO_free_all
+BIO_new_ex, BIO_new, BIO_up_ref, BIO_free, BIO_vfree, BIO_free_all
 - BIO allocation and freeing functions
 
 =head1 SYNOPSIS
 
  #include <openssl/bio.h>
 
- BIO *  BIO_new(const BIO_METHOD *type);
- int    BIO_up_ref(BIO *a);
- int    BIO_free(BIO *a);
- void   BIO_vfree(BIO *a);
- void   BIO_free_all(BIO *a);
+ BIO *BIO_new_ex(OSSL_LIB_CTX *libctx, const BIO_METHOD *type);
+ BIO *BIO_new(const BIO_METHOD *type);
+ int BIO_up_ref(BIO *a);
+ int BIO_free(BIO *a);
+ void BIO_vfree(BIO *a);
+ void BIO_free_all(BIO *a);
 
 =head1 DESCRIPTION
 
-The BIO_new() function returns a new BIO using method B<type>.
+The BIO_new_ex() function returns a new BIO using method B<type> associated with
+the library context B<libctx> (see OSSL_LIB_CTX(3)). The library context may be
+NULL to indicate the default library context.
+
+The BIO_new() is the same as BIO_new_ex() excpet the default library context is
+always used.
 
 BIO_up_ref() increments the reference count associated with the BIO object.
 

--- a/doc/man3/BIO_s_core.pod
+++ b/doc/man3/BIO_s_core.pod
@@ -40,6 +40,9 @@ BIO_new_from_core_bio() returns a BIO structure on success or NULL on failure.
 A failure will most commonly be because the library context was not constructed
 using OSSL_LIB_CTX_new_from_dispatch(3).
 
+=head1 HISTORY
+
+BIO_s_core() and BIO_new_from_core_bio() were added in OpenSSL 3.0.
 
 =head1 EXAMPLES
 

--- a/doc/man3/BIO_s_core.pod
+++ b/doc/man3/BIO_s_core.pod
@@ -1,0 +1,69 @@
+=pod
+
+=head1 NAME
+
+BIO_s_core, BIO_new_from_core_bio - OSSL_CORE_BIO functions
+
+=head1 SYNOPSIS
+
+ #include <openssl/bio.h>
+
+ const BIO_METHOD *BIO_s_core(void);
+
+ BIO *BIO_new_from_core_bio(OSSL_LIB_CTX *libctx, OSSL_CORE_BIO *corebio);
+
+=head1 DESCRIPTION
+
+BIO_s_core() returns the core BIO method function.
+
+A core BIO is treated as source/sink BIO which communicates to some external
+BIO. This is primarily useful to provider authors. A number of calls from
+libcrypto into a provider supply an OSSL_CORE_BIO parameter. This represents
+a BIO within libcrypto, but cannot be used directly by a provider. Instead it
+should be wrapped using a BIO_s_core().
+
+Once a BIO is contructed based on BIO_s_core(), the associated OSSL_CORE_BIO
+object should be set on it using BIO_set_data(3). Note that the BIO will only
+operate correctly if it is associated with a library context constructed using
+OSSL_LIB_CTX_new_from_dispatch(3). To associate the BIO with a library context
+construct it using BIO_new_ex(3).
+
+BIO_new_from_core_bio() is a convenience function that constructs a new BIO
+based on BIO_s_core() and that is associated with the given library context. It
+then also sets the OSSL_CORE_BIO object on the BIO using BIO_set_data(3).
+
+=head1 RETURN VALUES
+
+BIO_s_core() return a core BIO B<BIO_METHOD> structure.
+
+BIO_new_from_core_bio() returns a BIO structure on success or NULL on failure.
+A failure will most commonly be because the library context was not constructed
+using OSSL_LIB_CTX_new_from_dispatch(3).
+
+
+=head1 EXAMPLES
+
+Create a core BIO and write some data to it:
+
+ int some_function(OSSL_LIB_CTX *libctx, OSSL_CORE_BIO *corebio) {
+     BIO *cbio = BIO_new_from_core_bio(libctx, corebio);
+
+     if (cbio == NULL)
+         return 0;
+
+     BIO_puts(cbio, "Hello World\n");
+
+     BIO_free(cbio);
+     return 1;
+ }
+
+=head1 COPYRIGHT
+
+Copyright 2021 The OpenSSL Project Authors. All Rights Reserved.
+
+Licensed under the Apache License 2.0 (the "License").  You may not use
+this file except in compliance with the License.  You can obtain a copy
+in the file LICENSE in the source distribution or at
+L<https://www.openssl.org/source/license.html>.
+
+=cut

--- a/doc/man3/OSSL_LIB_CTX.pod
+++ b/doc/man3/OSSL_LIB_CTX.pod
@@ -37,7 +37,7 @@ OSSL_LIB_CTX_new() creates a new OpenSSL library context.
 OSSL_LIB_CTX_new_from_dispatch() creates a new OpenSSL library context
 initialised to use callbacks from the OSSL_DISPATCH structure. This is primarily
 useful for provider authors. The dispatch structure passed should be the same
-one as passed to a provider's OSSL_provider_init function in the B<in> argument.
+one as passed to a provider's OSSL_provider_init function in the I<in> argument.
 Some OpenSSL functions, such as L<BIO_new_from_core_bio(3)>, require the library
 context to be created in this way in order to work.
 
@@ -78,9 +78,7 @@ OSSL_LIB_CTX_free() doesn't return any value.
 
 =head1 HISTORY
 
-OSSL_LIB_CTX, OSSL_LIB_CTX_new(), OSSL_LIB_CTX_load_config(),
-OSSL_LIB_CTX_free(), OSSL_LIB_CTX_get0_global_default() and
-OSSL_LIB_CTX_set0_default() were added in OpenSSL 3.0.
+All of the functions described on this page were added in OpenSSL 3.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/OSSL_LIB_CTX.pod
+++ b/doc/man3/OSSL_LIB_CTX.pod
@@ -2,8 +2,9 @@
 
 =head1 NAME
 
-OSSL_LIB_CTX, OSSL_LIB_CTX_new, OSSL_LIB_CTX_free, OSSL_LIB_CTX_load_config,
-OSSL_LIB_CTX_get0_global_default, OSSL_LIB_CTX_set0_default
+OSSL_LIB_CTX, OSSL_LIB_CTX_new, OSSL_LIB_CTX_new_from_dispatch,
+OSSL_LIB_CTX_free, OSSL_LIB_CTX_load_config, OSSL_LIB_CTX_get0_global_default,
+OSSL_LIB_CTX_set0_default
 - OpenSSL library context
 
 =head1 SYNOPSIS
@@ -13,6 +14,7 @@ OSSL_LIB_CTX_get0_global_default, OSSL_LIB_CTX_set0_default
  typedef struct ossl_lib_ctx_st OSSL_LIB_CTX;
 
  OSSL_LIB_CTX *OSSL_LIB_CTX_new(void);
+ OSSL_LIB_CTX *OSSL_LIB_CTX_new_from_dispatch(const OSSL_DISPATCH *in);
  int OSSL_LIB_CTX_load_config(OSSL_LIB_CTX *ctx, const char *config_file);
  void OSSL_LIB_CTX_free(OSSL_LIB_CTX *ctx);
  OSSL_LIB_CTX *OSSL_LIB_CTX_get0_global_default(void);
@@ -31,6 +33,13 @@ the OSSL_LIB_CTX is freed.
 See L<OPENSSL_thread_stop_ex(3)> for more information.
 
 OSSL_LIB_CTX_new() creates a new OpenSSL library context.
+
+OSSL_LIB_CTX_new_from_dispatch() creates a new OpenSSL library context
+initialised to use callbacks from the OSSL_DISPATCH structure. This is primarily
+useful for provider authors. The dispatch structure passed should be the same
+one as passed to a provider's OSSL_provider_init function in the B<in> argument.
+Some OpenSSL functions, such as L<BIO_new_from_core_bio(3)>, require the library
+context to be created in this way in order to work.
 
 OSSL_LIB_CTX_load_config() loads a configuration file using the given C<ctx>.
 This can be used to associate a library context with providers that are loaded

--- a/include/internal/bio.h
+++ b/include/internal/bio.h
@@ -86,4 +86,6 @@ int ossl_core_bio_up_ref(OSSL_CORE_BIO *cb);
 int ossl_core_bio_free(OSSL_CORE_BIO *cb);
 int ossl_core_bio_vprintf(OSSL_CORE_BIO *cb, const char *format, va_list args);
 
+int ossl_bio_init_core(OSSL_LIB_CTX *libctx, const OSSL_DISPATCH *fns);
+
 #endif

--- a/include/internal/cryptlib.h
+++ b/include/internal/cryptlib.h
@@ -156,14 +156,15 @@ typedef struct ossl_ex_data_global_st {
 # define OSSL_LIB_CTX_RAND_CRNGT_INDEX               7
 # define OSSL_LIB_CTX_THREAD_EVENT_HANDLER_INDEX     8
 # define OSSL_LIB_CTX_FIPS_PROV_INDEX                9
-# define OSSL_LIB_CTX_ENCODER_STORE_INDEX        10
-# define OSSL_LIB_CTX_DECODER_STORE_INDEX      11
+# define OSSL_LIB_CTX_ENCODER_STORE_INDEX           10
+# define OSSL_LIB_CTX_DECODER_STORE_INDEX           11
 # define OSSL_LIB_CTX_SELF_TEST_CB_INDEX            12
 # define OSSL_LIB_CTX_BIO_PROV_INDEX                13
 # define OSSL_LIB_CTX_GLOBAL_PROPERTIES             14
 # define OSSL_LIB_CTX_STORE_LOADER_STORE_INDEX      15
 # define OSSL_LIB_CTX_PROVIDER_CONF_INDEX           16
-# define OSSL_LIB_CTX_MAX_INDEXES                   17
+# define OSSL_LIB_CTX_BIO_CORE_INDEX                17
+# define OSSL_LIB_CTX_MAX_INDEXES                   18
 
 typedef struct ossl_lib_ctx_method {
     void *(*new_func)(OSSL_LIB_CTX *ctx);

--- a/include/openssl/bio.h.in
+++ b/include/openssl/bio.h.in
@@ -30,6 +30,7 @@ use OpenSSL::stackhash qw(generate_stack_macros);
 
 # include <openssl/crypto.h>
 # include <openssl/bioerr.h>
+# include <openssl/core.h>
 
 #ifdef  __cplusplus
 extern "C" {
@@ -66,7 +67,7 @@ extern "C" {
 # ifndef OPENSSL_NO_SCTP
 #  define BIO_TYPE_DGRAM_SCTP    (24|BIO_TYPE_SOURCE_SINK|BIO_TYPE_DESCRIPTOR)
 # endif
-# define BIO_TYPE_CORE_TO_PROV   (25|BIO_TYPE_FILTER)
+# define BIO_TYPE_CORE_TO_PROV   (25|BIO_TYPE_SOURCE_SINK)
 
 #define BIO_TYPE_START           128
 
@@ -590,9 +591,11 @@ int BIO_asn1_get_suffix(BIO *b, asn1_ps_func **psuffix,
 
 const BIO_METHOD *BIO_s_file(void);
 BIO *BIO_new_file(const char *filename, const char *mode);
+BIO *BIO_new_from_core_bio(OSSL_LIB_CTX *libctx, OSSL_CORE_BIO *corebio);
 # ifndef OPENSSL_NO_STDIO
 BIO *BIO_new_fp(FILE *stream, int close_flag);
 # endif
+BIO *BIO_new_ex(OSSL_LIB_CTX *libctx, const BIO_METHOD *method);
 BIO *BIO_new(const BIO_METHOD *type);
 int BIO_free(BIO *a);
 void BIO_set_data(BIO *a, void *ptr);
@@ -651,6 +654,7 @@ const BIO_METHOD *BIO_f_readbuffer(void);
 const BIO_METHOD *BIO_f_linebuffer(void);
 const BIO_METHOD *BIO_f_nbio_test(void);
 const BIO_METHOD *BIO_f_prefix(void);
+const BIO_METHOD *BIO_s_core(void);
 # ifndef OPENSSL_NO_DGRAM
 const BIO_METHOD *BIO_s_datagram(void);
 int BIO_dgram_non_fatal_error(int error);

--- a/include/openssl/crypto.h.in
+++ b/include/openssl/crypto.h.in
@@ -517,6 +517,7 @@ CRYPTO_THREAD_ID CRYPTO_THREAD_get_current_id(void);
 int CRYPTO_THREAD_compare_id(CRYPTO_THREAD_ID a, CRYPTO_THREAD_ID b);
 
 OSSL_LIB_CTX *OSSL_LIB_CTX_new(void);
+OSSL_LIB_CTX *OSSL_LIB_CTX_new_from_dispatch(const OSSL_DISPATCH *in);
 int OSSL_LIB_CTX_load_config(OSSL_LIB_CTX *ctx, const char *config_file);
 void OSSL_LIB_CTX_free(OSSL_LIB_CTX *);
 OSSL_LIB_CTX *OSSL_LIB_CTX_get0_global_default(void);

--- a/test/bio_core_test.c
+++ b/test/bio_core_test.c
@@ -43,7 +43,7 @@ static long tst_bio_core_ctrl(OSSL_CORE_BIO *bio, int cmd, long num, void *ptr)
     return BIO_ctrl(bio->bio, cmd, num, ptr);
 }
 
-const OSSL_DISPATCH biocbs[] = {
+static const OSSL_DISPATCH biocbs[] = {
     { OSSL_FUNC_BIO_READ_EX, (void (*)(void))tst_bio_core_read_ex },
     { OSSL_FUNC_BIO_WRITE_EX, (void (*)(void))tst_bio_core_write_ex },
     { OSSL_FUNC_BIO_GETS, (void (*)(void))tst_bio_core_gets },

--- a/test/bio_core_test.c
+++ b/test/bio_core_test.c
@@ -54,7 +54,7 @@ const OSSL_DISPATCH biocbs[] = {
 
 static int test_bio_core(void)
 {
-    BIO *cbio = NULL, *cbiobad;
+    BIO *cbio = NULL, *cbiobad = NULL;
     OSSL_LIB_CTX *libctx = OSSL_LIB_CTX_new_from_dispatch(biocbs);
     int testresult = 0;
     OSSL_CORE_BIO corebio;

--- a/test/bio_core_test.c
+++ b/test/bio_core_test.c
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2021 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <string.h>
+#include <openssl/bio.h>
+#include "testutil.h"
+
+struct ossl_core_bio_st {
+    int dummy;
+    BIO *bio;
+};
+
+static int tst_bio_core_read_ex(OSSL_CORE_BIO *bio, char *data, size_t data_len,
+                                size_t *bytes_read)
+{
+    return BIO_read_ex(bio->bio, data, data_len, bytes_read);
+}
+
+static int tst_bio_core_write_ex(OSSL_CORE_BIO *bio, const char *data,
+                                 size_t data_len, size_t *written)
+{
+    return BIO_write_ex(bio->bio, data, data_len, written);
+}
+
+static int tst_bio_core_gets(OSSL_CORE_BIO *bio, char *buf, int size)
+{
+    return BIO_gets(bio->bio, buf, size);
+}
+
+static int tst_bio_core_puts(OSSL_CORE_BIO *bio, const char *str)
+{
+    return BIO_puts(bio->bio, str);
+}
+
+static long tst_bio_core_ctrl(OSSL_CORE_BIO *bio, int cmd, long num, void *ptr)
+{
+    return BIO_ctrl(bio->bio, cmd, num, ptr);
+}
+
+const OSSL_DISPATCH biocbs[] = {
+    { OSSL_FUNC_BIO_READ_EX, (void (*)(void))tst_bio_core_read_ex },
+    { OSSL_FUNC_BIO_WRITE_EX, (void (*)(void))tst_bio_core_write_ex },
+    { OSSL_FUNC_BIO_GETS, (void (*)(void))tst_bio_core_gets },
+    { OSSL_FUNC_BIO_PUTS, (void (*)(void))tst_bio_core_puts },
+    { OSSL_FUNC_BIO_CTRL, (void (*)(void))tst_bio_core_ctrl },
+    { 0, NULL }
+};
+
+static int test_bio_core(void)
+{
+    BIO *cbio = NULL, *cbiobad;
+    OSSL_LIB_CTX *libctx = OSSL_LIB_CTX_new_from_dispatch(biocbs);
+    int testresult = 0;
+    OSSL_CORE_BIO corebio;
+    const char *msg = "Hello world";
+    char buf[80];
+
+    corebio.bio = BIO_new(BIO_s_mem());
+    if (!TEST_ptr(corebio.bio)
+            || !TEST_ptr(libctx)
+               /*
+                * Attempting to create a corebio in a libctx that was not
+                * created via OSSL_LIB_CTX_new_from_dispatch() should fail.
+                */
+            || !TEST_ptr_null((cbiobad = BIO_new_from_core_bio(NULL, &corebio)))
+            || !TEST_ptr((cbio = BIO_new_from_core_bio(libctx, &corebio))))
+        goto err;
+
+    if (!TEST_int_gt(BIO_puts(corebio.bio, msg), 0)
+               /* Test a ctrl via BIO_eof */
+            || !TEST_false(BIO_eof(cbio))
+            || !TEST_int_gt(BIO_gets(cbio, buf, sizeof(buf)), 0)
+            || !TEST_true(BIO_eof(cbio))
+            || !TEST_str_eq(buf, msg))
+        goto err;
+
+    buf[0] = '\0';
+    if (!TEST_int_gt(BIO_write(cbio, msg, strlen(msg) + 1), 0)
+            || !TEST_int_gt(BIO_read(cbio, buf, sizeof(buf)), 0)
+            || !TEST_str_eq(buf, msg))
+        goto err;
+
+    testresult = 1;
+ err:
+    BIO_free(cbiobad);
+    BIO_free(cbio);
+    BIO_free(corebio.bio);
+    OSSL_LIB_CTX_free(libctx);
+    return testresult;
+}
+
+int setup_tests(void)
+{
+    if (!test_skip_common_options()) {
+        TEST_error("Error parsing test options\n");
+        return 0;
+    }
+
+    ADD_TEST(test_bio_core);
+    return 1;
+}

--- a/test/build.info
+++ b/test/build.info
@@ -44,7 +44,7 @@ IF[{- !$disabled{tests} -}]
           packettest asynctest secmemtest srptest memleaktest stack_test \
           dtlsv1listentest ct_test threadstest afalgtest d2i_test \
           ssl_test_ctx_test ssl_test x509aux cipherlist_test asynciotest \
-          bio_callback_test bio_memleak_test param_build_test \
+          bio_callback_test bio_memleak_test bio_core_test param_build_test \
           bioprinttest sslapitest dtlstest sslcorrupttest \
           bio_enc_test pkey_meth_test pkey_meth_kdf_test evp_kdf_test uitest \
           cipherbytes_test \
@@ -317,6 +317,10 @@ IF[{- !$disabled{tests} -}]
   SOURCE[bioprinttest]=bioprinttest.c
   INCLUDE[bioprinttest]=../include ../apps/include
   DEPEND[bioprinttest]=../libcrypto libtestutil.a
+
+  SOURCE[bio_core_test]=bio_core_test.c
+  INCLUDE[bio_core_test]=../include ../apps/include
+  DEPEND[bio_core_test]=../libcrypto libtestutil.a
 
   SOURCE[params_api_test]=params_api_test.c
   INCLUDE[params_api_test]=../include ../apps/include

--- a/test/recipes/04-test_bio_core.t
+++ b/test/recipes/04-test_bio_core.t
@@ -1,0 +1,12 @@
+#! /usr/bin/env perl
+# Copyright 2016 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+
+use OpenSSL::Test::Simple;
+
+simple_test("test_bio_core", "bio_core_test");

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5368,3 +5368,7 @@ EVP_SIGNATURE_name                      ?	3_0_0	EXIST::FUNCTION:
 EVP_ASYM_CIPHER_name                    ?	3_0_0	EXIST::FUNCTION:
 EVP_KEM_name                            ?	3_0_0	EXIST::FUNCTION:
 EVP_KEYEXCH_name                        ?	3_0_0	EXIST::FUNCTION:
+BIO_new_from_core_bio                   ?	3_0_0	EXIST::FUNCTION:
+BIO_new_ex                              ?	3_0_0	EXIST::FUNCTION:
+BIO_s_core                              ?	3_0_0	EXIST::FUNCTION:
+OSSL_LIB_CTX_new_from_dispatch          ?	3_0_0	EXIST::FUNCTION:


### PR DESCRIPTION
Previously the concept of wrapping an OSSL_CORE_BIO in a real BIO was an
internal only concept for our own providers. Since this is likely to be
generally useful, we make it a part of the public API.

Fixes #14409
