### PR TITLE
check-format.pl: various small improvements, new --eol-comment option

### DIFF
--- a/util/check-format-test-negatives.c
+++ b/util/check-format-test-negatives.c
@@ -15,7 +15,7 @@
  */
 
 /*-
- * allow double space  in format-tagged multi-line comment
+ * allow extra SPC  in format-tagged multi-line comment
  */
 int f(void) /*
              * trailing multi-line comment

--- a/util/check-format-test-negatives.c
+++ b/util/check-format-test-negatives.c
@@ -273,11 +273,12 @@ static varref cmp_vars[] = { /* comment.  comment?  comment!  */
         /* comment */ \
     }
 
-/* 'struct' in function header */
-static int f(struct pem_pass_data *pass_data)
+union un var; /* struct/union/enum in variable type */
+struct provider_store_st *f() /* struct/union/enum in function return type */
 {
-    if (pass_data == NULL)
-        return 0;
+}
+static void f(struct pem_pass_data *data) /* struct/union/enum in arg list */
+{
 }
 
 static void *fun(void)

--- a/util/check-format-test-negatives.c
+++ b/util/check-format-test-negatives.c
@@ -15,7 +15,7 @@
  */
 
 /*-
- * allow extra SPC  in format-tagged multi-line comment
+ * allow extra SPC in format-tagged multi-line comment
  */
 int f(void) /*
              * trailing multi-line comment

--- a/util/check-format-test-negatives.c
+++ b/util/check-format-test-negatives.c
@@ -150,7 +150,7 @@ int f(void) /*
         hanging_stmt;
 }
 
-/* not: constant on LHS of comparison or assignment operator */
+/* should not trigger: constant on LHS of comparison or assignment operator */
 X509 *x509 = NULL;
 int y = a + 1 < b;
 

--- a/util/check-format-test-negatives.c
+++ b/util/check-format-test-negatives.c
@@ -150,6 +150,10 @@ int f(void) /*
         hanging_stmt;
 }
 
+/* not: constant on LHS of comparison or assignment operator */
+X509 *x509 = NULL;
+int y = a + 1 < b;
+
 const OPTIONS passwd_options[] = {
     {"aixmd5", OPT_AIXMD5, '-', "AIX MD5-based password algorithm"},
 #if !defined(OPENSSL_NO_DES) && !defined(OPENSSL_NO_DEPRECATED_3_0)

--- a/util/check-format-test-negatives.c
+++ b/util/check-format-test-negatives.c
@@ -21,7 +21,7 @@ int f(void) /*
              * trailing multi-line comment
              */
 {
-    if (ctx == NULL) { /* non-leading intra-line comment */
+    if (ctx == NULL) {    /* non-leading end-of-line comment */
         if (/* comment after '(' */ pem_name != NULL /* comment before ')' */)
             /* entire-line comment indent usually like for the following line */
             return NULL; /* hanging indent also for this line after comment */

--- a/util/check-format-test-positives.c
+++ b/util/check-format-test-positives.c
@@ -75,7 +75,8 @@ int f (int a,       /*@ space after fn before '(', reported unless sloppy-spc */
        long l)      /*@ one-letter name 'l' */
 { int               /*@ code after '{' opening a block */
     xx = 1) +       /*@ unexpected closing parenthesis */
-        2] -        /*@ unexpected closing bracket */
+        0L <        /*@ constant on LHS of comparison operator */
+        a] -        /*@ unexpected closing bracket */
         3: *        /*@ unexpected ':' (without preceding '?') within expr */
         4};         /*@ unexpected closing brace within expression */
     char y[] = {    /*@0 unclosed brace within initializer/enum expression */
@@ -91,7 +92,7 @@ int f (int a,       /*@ space after fn before '(', reported unless sloppy-spc */
            b,       /*@ expr indent as on line above, accepted if sloppy-hang */
     b, /*@ expr indent off -8 but @ extra indent accepted if sloppy-hang */
    "again aligned" /*@ expr indent off by -9 (left of stmt indent, */ "right",
-            123 == /*@ .. so reported also with sloppy-hang; this line is too long */ 456
+            abc == /*@ .. so reported also with sloppy-hang; this line is too long */ 456
 # define MAC(A) (A) /*@ nesting indent of preprocessor directive off by 1 */
              ? 1    /*@ hanging expr indent off by 1 */
               : 2); /*@ hanging expr indent off by 2, or 1 for leading ':' */

--- a/util/check-format-test-positives.c
+++ b/util/check-format-test-positives.c
@@ -52,7 +52,7 @@
  #define Y  2       /*@ indent of preprocessor directive off by 1 (must be 0) */
 typedef struct  {   /*@0 extra space in code, reported unless sloppy-spc */
     enum {          /*@1 extra space  in comment, reported unless sloppy-spc */
-           w = 0 /*@2 hanging expr indent off by 1, or 3 for lines after '{' */
+           w = 0 /*@ hanging expr indent off by 1, or 3 for lines after '{' */
              && 1,  /*@ hanging expr indent off by 3, or -1 for leading '&&' */
          x = 1,     /*@ hanging expr indent off by -1 */
           y,z       /*@ no space after ',', reported unless sloppy-spc */

--- a/util/check-format-test-positives.c
+++ b/util/check-format-test-positives.c
@@ -72,7 +72,7 @@ void main(int n) {  /*@ opening brace at end of function definition header */
 #endif              /*@ unexpected #endif */
 int f (int a,       /*@ space after fn before '(', reported unless sloppy-spc */
       int b,        /*@ hanging expr indent off by -1 */
-       long l)      /*@ one-letter name 'l' */
+       long I)      /*@ single-letter name 'I' */
 { int               /*@ code after '{' opening a block */
     xx = 1) +       /*@ unexpected closing parenthesis */
         0L <        /*@ constant on LHS of comparison operator */

--- a/util/check-format-test-positives.c
+++ b/util/check-format-test-positives.c
@@ -48,10 +48,10 @@
 */ /*@ unexpected comment ending delimiter outside comment */
 /*@ comment line is 4 columns tooooooooooooooooo wide, reported unless sloppy-len */
 /*@ comment line is 5 columns toooooooooooooooooooooooooooooooooooooooooooooo wide */
-#define X   1       /*@0 double space false negative due to coincidence */
+#define X   1       /*@0 extra space false negative due to coincidence */
  #define Y  2       /*@ indent of preprocessor directive off by 1 (must be 0) */
-typedef struct  {   /*@0 double space in code, reported unless sloppy-spc */
-    enum {          /*@1 double space  in comment, reported unless sloppy-spc */
+typedef struct  {   /*@0 extra space in code, reported unless sloppy-spc */
+    enum {          /*@1 extra space  in comment, reported unless sloppy-spc */
            w = 0 /*@2 hanging expr indent off by 1, or 3 for lines after '{' */
              && 1,  /*@ hanging expr indent off by 3, or -1 for leading '&&' */
          x = 1,     /*@ hanging expr indent off by -1 */

--- a/util/check-format.pl
+++ b/util/check-format.pl
@@ -13,9 +13,9 @@
 #
 # usage:
 #   check-format.pl [-l|--sloppy-len] [-l|--sloppy-bodylen]
-#                   [-s|--sloppy-space] [-c|--sloppy-cmt]
+#                   [-s|--sloppy-space] [-c|--sloppy-comment]
 #                   [-m|--sloppy-macro] [-h|--sloppy-hang]
-#                   [-e|--eol-cmt] [-1|--1-stmt]
+#                   [-e|--eol-comment] [-1|--1-stmt]
 #                   <files>
 #
 # run self-tests:
@@ -28,24 +28,24 @@
 # Still it should be useful for detecting most typical glitches.
 #
 # options:
-#  -l | --sloppy-len   increase accepted max line length from 80 to 84
+#  -l | --sloppy-len     increase accepted max line length from 80 to 84
 #  -l | --sloppy-bodylen do not report function body length > 200
-#  -s | --sloppy-space do not report whitespace nits
-#  -c | --sloppy-cmt   do not report indentation of comments
-#                      Otherwise for each multi-line comment the indentation of
-#                      its lines is checked for consistency. For each comment
-#                      that does not begin to the right of normal code its
-#                      indentation must be as for normal code, while in case it
-#                      also has no normal code to its right it is considered to
-#                      refer to the following line and may be indented equally.
-#  -m | --sloppy-macro allow missing extra indentation of macro bodies
-#  -h | --sloppy-hang  when checking hanging indentation, do not report
-#                      * same indentation as on line before
-#                      * same indentation as non-hanging indent level
-#                      * indentation moved left (not beyond non-hanging indent)
-#                        just to fit contents within the line length limit
-#  -e | --eol-cmt      report needless intermediate multiple consecutive spaces also before end-of-line comments
-#  -1 | --1-stmt       do more aggressive checks for { 1 stmt } - see below
+#  -s | --sloppy-space   do not report whitespace nits
+#  -c | --sloppy-comment do not report indentation of comments
+#                        Otherwise for each multi-line comment the indentation of
+#                        its lines is checked for consistency. For each comment
+#                        that does not begin to the right of normal code its
+#                        indentation must be as for normal code, while in case it
+#                        also has no normal code to its right it is considered to
+#                        refer to the following line and may be indented equally.
+#  -m | --sloppy-macro   allow missing extra indentation of macro bodies
+#  -h | --sloppy-hang    when checking hanging indentation, do not report
+#                        * same indentation as on line before
+#                        * same indentation as non-hanging indent level
+#                        * indentation moved left (not beyond non-hanging indent)
+#                          just to fit contents within the line length limit
+#  -e | --eol-comment    report needless intermediate multiple consecutive spaces also before end-of-line comments
+#  -1 | --1-stmt         do more aggressive checks for { 1 stmt } - see below
 #
 # There are non-trivial false positives and negatives such as the following.
 #
@@ -67,7 +67,7 @@
 #   False negatives occur if the braces are more than two non-empty lines apart.
 #
 # * The presence of multiple consecutive spaces is regarded a coding style nit
-#   except when this is before end-of-line comments (unless the --eol-cmt is given) and
+#   except when this is before end-of-line comments (unless the --eol-comment is given) and
 #   except when done in order to align certain columns over multiple lines, e.g.:
 #   # define AB  1
 #   # define CDE 22
@@ -116,13 +116,13 @@ while ($ARGV[0] =~ m/^-(\w|-[\w\-]+)$/) {
         $sloppy_bodylen = 1;
     } elsif ($arg =~ m/^(s|-sloppy-space)$/) {
         $sloppy_SPC= 1;
-    } elsif ($arg =~ m/^(c|-sloppy-cmt)$/) {
+    } elsif ($arg =~ m/^(c|-sloppy-comment)$/) {
         $sloppy_cmt = 1;
     } elsif ($arg =~ m/^(m|-sloppy-macro)$/) {
         $sloppy_macro = 1;
     } elsif ($arg =~ m/^(h|-sloppy-hang)$/) {
         $sloppy_hang = 1;
-    } elsif ($arg =~ m/^(e|-eol-cmt)$/) {
+    } elsif ($arg =~ m/^(e|-eol-comment)$/) {
         $eol_cmt = 1;
     } elsif ($arg =~ m/^(1|-1-stmt)$/) {
         $extended_1_stmt = 1;

--- a/util/check-format.pl
+++ b/util/check-format.pl
@@ -846,7 +846,12 @@ while (<>) { # loop over all lines of all input files
         }
     }
 
-    report("one-letter name '$2'") if (m/(^|.*\W)([lIO])(\W.*|$)/); # single-letter name 'l', 'I', or 'O'
+    report("single-letter name '$2'") if (m/(^|.*\W)([IO])(\W.*|$)/); # single-letter name 'I' or 'O' # maybe re-add 'l'?
+    # constant on LHS of comparison or assignment, e.g., NULL != x or 'a' < c, but not a + 1 == b
+    report("constant on LHS of '$2'")
+        if (m/(['"]|([\+\-\*\/\/%\&\|\^<>]\s*)?\W[0-9]+L?|NULL)\s*([\!<>=]=|[<=>][^<>])/ && $2 eq "");
+
+    # TODO report #if 0 and #if 1
 
     # TODO report empty line within local variable definitions
 

--- a/util/check-format.pl
+++ b/util/check-format.pl
@@ -929,10 +929,12 @@ while (<>) { # loop over all lines of all input files
     }
 
     # set $in_typedecl and potentially $hanging_offset for type declaration
-    if (!$in_expr && @nested_indents == 0 && # not in expression
-        m/(^|^.*\W)(typedef|struct|union|enum)(\W.*|$)$/ &&
-        parens_balance($1) == 0) { # not in newly started expression
-        # not needed: $keyword_opening_brace = $2 if $3 =~ m/\{/;
+    if (!$in_expr && @nested_indents == 0 # not in expression
+        && m/(^|^.*\W)(typedef|struct|union|enum)(\W.*|$)$/
+        && parens_balance($1) == 0 # not in newly started expression or function arg list
+        && ($2 eq "typedef" || !($3 =~ m/\s*\w++\s*(.)/ && $1 ne "{")) # 'struct'/'union'/'enum' <name> not followed by '{'
+        # not needed: && $keyword_opening_brace = $2 if $3 =~ m/\{/;
+        ) {
         $in_typedecl++;
         $hanging_offset += INDENT_LEVEL if m/\*.*\(/; # '*' followed by '(' - seems consistent with Emacs C mode
     }

--- a/util/check-format.pl
+++ b/util/check-format.pl
@@ -683,7 +683,7 @@ while (<>) { # loop over all lines of all input files
         # TODO ternary ':' without preceding SPC, while allowing no SPC before ':' after 'case'
         report("no SPC before binary '$1'")  if $intra_line =~ m/[^\s{()\[]([+\-])/;# +/- without preceding space or {()[
                                                                              # or ')' (which is used f type casts)
-        report("no SPC before binary '$1'")  if $intra_line =~ m/[^\s{()\[*]([*])/; # '*' without preceding space or {()[*
+        report("no SPC before binary '$1'")  if $intra_line =~ m/[^\s{()\[*!]([*])/; # '*' without preceding space or {()[*!
         report("no SPC before binary '$1'")  if $intra_line =~ m/[^\s{()\[]([&])/;  # '&' without preceding space or {()[
         report("no SPC after ternary '$1'") if $intra_line =~ m/(:)[^\s\d]/; # ':' without following space or digit
         report("no SPC after '$1'")   if $intra_line =~ m/([,;=|\/%<>^\?])\S/; # ,;=|/%<>^? without following space


### PR DESCRIPTION
Due to review comment https://github.com/openssl/openssl/pull/15029#discussion_r620287437 that I received recently,
added to the list in #10725 the rule
* In comparisons with constants (including `NULL`) the constant should be on the right-hand side of the comparison operator.

and added a corresponding check to `check-format.pl`.

Moreover,
* Fix false positive on struct/union/enum in func return type
* Fix false positive "no SPC before binary '*'" for '!*'
* Allow extra space before end-of-line comments unless `-e` (or equivalent `--eol-comment`) option given
* Replace 'SPC' and 'spc' by 'space' in reports and option names
* Rename `*-cmt` options to `*-comment`
* Rename "one-letter" to "single-letter", do not report variable name '`l`' (el)

- [x] tests are added or updated
