### PR TITLE
Remove dated term and fixed typo anther

### DIFF
--- a/crypto/rc2/rc2_skey.c
+++ b/crypto/rc2/rc2_skey.c
@@ -47,8 +47,8 @@ static const unsigned char key_table[256] = {
 
 /*
  * It has come to my attention that there are 2 versions of the RC2 key
- * schedule.  One which is normal, and anther which has a hook to use a
- * reduced key length. BSAFE uses the 'retarded' version.  What I previously
+ * schedule.  One which is normal, and another which has a hook to use a
+ * reduced key length. BSAFE uses the latter version.  What I previously
  * shipped is the same as specifying 1024 for the 'bits' parameter.  Bsafe
  * uses a version where the bits parameter is the same as len*8
  */


### PR DESCRIPTION
Just something I noticed while reading this code.
This was probably committed a very long time ago.
Fixed typo anther -> another.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
