### PR TITLE
acvp: fix the no-acvp-tests build

### DIFF
--- a/Configure
+++ b/Configure
@@ -379,7 +379,7 @@ my @dtls = qw(dtls1 dtls1_2);
 # For developers: keep it sorted alphabetically
 
 my @disablables = (
-    "acvp_tests",
+    "acvp-tests",
     "afalgeng",
     "aria",
     "asan",

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -521,7 +521,7 @@ never be used in production environments.  It will only work when used with
 gcc or clang and should be used in conjunction with the [no-shared](#no-shared)
 option.
 
-### no-acvp_tests
+### no-acvp-tests
 
 Do not build support for Automated Cryptographic Validation Protocol (ACVP)
 tests.

--- a/test/build.info
+++ b/test/build.info
@@ -34,7 +34,7 @@ IF[{- !$disabled{tests} -}]
           destest mdc2test \
           exptest \
           evp_pkey_provided_test evp_test evp_extra_test evp_extra_test2 \
-          evp_fetch_prov_test acvp_test evp_libctx_test ossl_store_test \
+          evp_fetch_prov_test evp_libctx_test ossl_store_test \
           v3nametest v3ext \
           evp_pkey_provided_test evp_test evp_extra_test evp_extra_test2 \
           evp_fetch_prov_test v3nametest v3ext \
@@ -159,7 +159,9 @@ IF[{- !$disabled{tests} -}]
   INCLUDE[evp_pkey_provided_test]=../include ../apps/include
   DEPEND[evp_pkey_provided_test]=../libcrypto.a libtestutil.a
 
-  IF[{- !$disabled{acvp-tests} -}]
+  IF[{- !$disabled{'acvp-tests'} -}]
+    PROGRAMS{noinst}=acvp_test
+
     SOURCE[acvp_test]=acvp_test.c
     INCLUDE[acvp_test]=../include ../apps/include
     DEPEND[acvp_test]=../libcrypto.a libtestutil.a

--- a/test/recipes/30-test_acvp.t
+++ b/test/recipes/30-test_acvp.t
@@ -19,7 +19,7 @@ setup("test_acvp");
 my $no_fips = disabled('fips') || ($ENV{NO_FIPS} // 0);
 
 plan skip_all => "ACVP is not supported by this test"
-    if $no_fips || disabled("acvp_tests");
+    if $no_fips || disabled("acvp-tests");
 
 use lib srctop_dir('Configurations');
 use lib bldtop_dir('.');


### PR DESCRIPTION
Two of the disabled checks used a different string.  Changed the option from no-acvp_tests to no-acvp-tests.
Also avoid building the test if it is disabled.


- [ ] documentation is added or updated
- [x] tests are added or updated
