### PR TITLE
OpenSSL::Test: When prefixing command with $^X on Windows, fix it up!

### DIFF
--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -686,7 +686,7 @@ EOF
           my $pod = $gen0;
           return <<"EOF";
 $args{src}: "$pod"
-	\$(PERL) \$(SRCDIR)/util/mkpod2html.pl -i "$pod" -o \$\@ -t "$title" -r "\$(SRCDIR)/doc"
+	"\$(PERL)" "\$(SRCDIR)/util/mkpod2html.pl" -i "$pod" -o \$\@ -t "$title" -r "\$(SRCDIR)/doc"
 EOF
       } elsif (platform->isdef($args{src})) {
           #

--- a/util/perl/OpenSSL/Test.pm
+++ b/util/perl/OpenSSL/Test.pm
@@ -1232,7 +1232,7 @@ sub __wrap_cmd {
             # In the Windows case, we run perl explicitly.  We might not
             # need it, but that depends on if the user has associated the
             # '.pl' extension with a perl interpreter, so better be safe.
-            @prefix = ( $^X, $std_wrapper );
+            @prefix = ( __fixup_prg($^X), $std_wrapper );
         } else {
             # Otherwise, we assume Unix semantics, and trust that the #!
             # line activates perl for us.


### PR DESCRIPTION
The perl interpreter name itself might contain spaces and need quoting.
__fixup_prg() does this for us.

Fixes #14256

Co-authored-by: Tomáš Mráz <tomas@openssl.org>