### PR TITLE
Add -latomic to threads enabled 32bit linux builds

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -675,7 +675,7 @@ my %targets = (
 ####
 # *-generic* is endian-neutral target, but ./config is free to
 # throw in -D[BL]_ENDIAN, whichever appropriate...
-    "linux-generic32" => {
+    "linux-generic" => {
         inherit_from     => [ "BASE_unix" ],
         CC               => "gcc",
         CXX              => "g++",
@@ -697,8 +697,13 @@ my %targets = (
         shared_ldflag    => sub { $disabled{pinshared} ? () : "-Wl,-znodelete" },
         enable           => [ "afalgeng" ],
     },
+    "linux-generic32" => {
+        inherit_from     => [ "linux-generic" ],
+        ex_libs          => add(threads("-latomic")),
+        bn_ops           => "BN_LLONG RC4_CHAR",
+    },
     "linux-generic64" => {
-        inherit_from     => [ "linux-generic32" ],
+        inherit_from     => [ "linux-generic" ],
         bn_ops           => "SIXTY_FOUR_BIT_LONG RC4_CHAR",
     },
 
@@ -945,6 +950,7 @@ my %targets = (
         cflags           => add("-m64 -mcpu=ultrasparc"),
         cxxflags         => add("-m64 -mcpu=ultrasparc"),
         lib_cppflags     => add("-DB_ENDIAN"),
+        ex_libs          => add(threads("-latomic")),
         bn_ops           => "BN_LLONG RC4_CHAR",
         asm_arch         => 'sparcv9',
         perlasm_scheme   => 'void',


### PR DESCRIPTION
It might not be necessary with the most recent toolchain versions
but apparently many 32bit linux architectures and commonly used
toolchain versions require this.

It is also harmless to include even on architectures that do not
need it.

Fixes #14083

This is alternative to #14766