### PR TITLE
Disable acvp-test by default

### DIFF
--- a/Configure
+++ b/Configure
@@ -513,6 +513,7 @@ my %deprecated_disablables = (
 
 our %disabled = ( # "what"         => "comment"
                   "fips"                => "default",
+                  "acvp-tests"          => "default",
                   "asan"                => "default",
                   "buildtest-c++"       => "default",
                   "crypto-mdebug"       => "default",

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -521,9 +521,9 @@ never be used in production environments.  It will only work when used with
 gcc or clang and should be used in conjunction with the [no-shared](#no-shared)
 option.
 
-### no-acvp-tests
+### enable-acvp-tests
 
-Do not build support for Automated Cryptographic Validation Protocol (ACVP)
+Build support for Automated Cryptographic Validation Protocol (ACVP)
 tests.
 
 This is required for FIPS validation purposes. Certain ACVP tests require


### PR DESCRIPTION

The code to allow the ACVP testing is only useful to a FIPS lab and shouldn't be in production.

This is based off of #15082 and won't be merged until after it is.
