### PR TITLE
Fix repetition in s_server man page

### DIFF
--- a/doc/man1/s_server.pod
+++ b/doc/man1/s_server.pod
@@ -701,7 +701,7 @@ disabling the ephemeral DH cipher suites.
 
 =item B<-alpn val>, B<-nextprotoneg val>
 
-These flags enable the Enable the Application-Layer Protocol Negotiation
+These flags enable the Application-Layer Protocol Negotiation
 or Next Protocol Negotiation (NPN) extension, respectively. ALPN is the
 IETF standard and replaces NPN.
 The B<val> list is a comma-separated list of supported protocol


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->
There is a repetition in description of the `-alpn` option in `s_server` man page, this PR fixes it.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated

since the paths are different I've filed also a master branch PR in #15099 