### PR TITLE
man: s_server: fix text repetition in -alpn description

### DIFF
--- a/doc/man1/openssl-s_server.pod.in
+++ b/doc/man1/openssl-s_server.pod.in
@@ -672,7 +672,7 @@ disabling the ephemeral DH cipher suites.
 
 =item B<-alpn> I<val>, B<-nextprotoneg> I<val>
 
-These flags enable the Enable the Application-Layer Protocol Negotiation
+These flags enable the Application-Layer Protocol Negotiation
 or Next Protocol Negotiation (NPN) extension, respectively. ALPN is the
 IETF standard and replaces NPN.
 The I<val> list is a comma-separated list of supported protocol


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->
Fix the repetition in the description of `-alpn` option in `s_server` man page

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated


since the paths are different I've filed also a 1.1.1 branch PR in #15098