### PR TITLE
test: fix failure with FIPS and no-des configured.

### DIFF
--- a/test/recipes/80-test_pkcs12.t
+++ b/test/recipes/80-test_pkcs12.t
@@ -96,7 +96,7 @@ SKIP: {
 }
 
 SKIP: {
-    skip "Skipping legacy PKCS#12 test because RC2 is disabled in this build", 1
+    skip "Skipping legacy PKCS#12 test because the required algorithms are disabled", 1
         if disabled("des") || disabled("rc2") || disabled("legacy");
     # Test reading legacy PKCS#12 file
     ok(run(app(["openssl", "pkcs12", "-export",

--- a/test/recipes/80-test_pkcs12.t
+++ b/test/recipes/80-test_pkcs12.t
@@ -97,7 +97,7 @@ SKIP: {
 
 SKIP: {
     skip "Skipping legacy PKCS#12 test because RC2 is disabled in this build", 1
-        if disabled("rc2") || disabled("legacy");
+        if disabled("des") || disabled("rc2") || disabled("legacy");
     # Test reading legacy PKCS#12 file
     ok(run(app(["openssl", "pkcs12", "-export",
                 "-in", srctop_file(@path, "v3-certs-RC2.p12"),


### PR DESCRIPTION
Using DES in a no-des build is kind of bad.

- [ ] documentation is added or updated
- [x] tests are added or updated
