### PR TITLE
adds armv7s and arm64e options for iOS build

### DIFF
--- a/Configurations/15-ios.conf
+++ b/Configurations/15-ios.conf
@@ -12,23 +12,45 @@ my %targets = (
         sys_id           => "iOS",
         disable          => [ "engine", "async" ],
     },
-    "ios-xcrun" => {
+    "ios32-common" => {
         inherit_from     => [ "ios-common" ],
-        # It should be possible to go below iOS 6 and even add -arch armv6,
-        # thus targeting iPhone pre-3GS, but it's assumed to be irrelevant
-        # at this point.
         CC               => "xcrun -sdk iphoneos cc",
-        cflags           => add("-arch armv7 -mios-version-min=6.0.0 -fno-common"),
         asm_arch         => 'armv4',
         perlasm_scheme   => "ios32",
     },
-    "ios64-xcrun" => {
+    "ios64-common" => {
         inherit_from     => [ "ios-common" ],
         CC               => "xcrun -sdk iphoneos cc",
-        cflags           => add("-arch arm64 -mios-version-min=7.0.0 -fno-common"),
         bn_ops           => "SIXTY_FOUR_BIT_LONG RC4_CHAR",
         asm_arch         => 'aarch64',
         perlasm_scheme   => "ios64",
+    },
+    "ios-armv7-xcrun" => {
+        inherit_from     => [ "ios32-common" ],
+        # It should be possible to go below iOS 6 and even add -arch armv6,
+        # thus targeting iPhone pre-3GS, but it's assumed to be irrelevant
+        # at this point.
+        cflags           => add("-arch armv7 -mios-version-min=6.0.0 -fno-common"),
+    },
+    "ios-armv7s-xcrun" => {
+        inherit_from     => [ "ios32-common" ],
+        cflags           => add("-arch armv7s -mios-version-min=6.0.0 -fno-common"),
+    },
+    "ios-arm64-xcrun" => {
+        inherit_from     => [ "ios64-common" ],
+        cflags           => add("-arch arm64 -mios-version-min=7.0.0 -fno-common"),
+    },
+    "ios-arm64e-xcrun" => {
+        inherit_from     => [ "ios64-common" ],
+        cflags           => add("-arch arm64e -mios-version-min=12.0.0 -fno-common"),
+    },
+    "ios-xcrun" => {
+        # alias
+        inherit_from     => [ "ios-armv7-xcrun" ],
+    },
+    "ios64-xcrun" => {
+        # alias
+        inherit_from     => [ "ios-arm64-xcrun" ],
     },
     "iossimulator-xcrun" => {
         inherit_from     => [ "ios-common" ],


### PR DESCRIPTION
This change enables armv7s and arm64e architectures to be targeted by iOS build.
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
None applicable
<!-- Not Applicable: - [ ] documentation is added or updated -->
<!-- Not Applicable: - [ ] tests are added or updated -->
