### PR TITLE
RFC8879 Certificate compression extension implementation

### DIFF
--- a/Configurations/00-base-templates.conf
+++ b/Configurations/00-base-templates.conf
@@ -50,6 +50,8 @@ my %targets=(
                 my @defs = ( 'OPENSSL_BUILDING_OPENSSL' );
                 push @defs, "ZLIB" unless $disabled{zlib};
                 push @defs, "ZLIB_SHARED" unless $disabled{"zlib-dynamic"};
+                push @defs, "BROTLI" unless $disabled{brotli};
+                push @defs, "ZSTD" unless $disabled{zstd};
                 return [ @defs ];
             },
         includes        =>
@@ -57,6 +59,10 @@ my %targets=(
                 my @incs = ();
                 push @incs, $withargs{zlib_include}
                     if !$disabled{zlib} && $withargs{zlib_include};
+                push @incs, $withargs{brotli_include}
+                    if !$disabled{brotli} && $withargs{brotli_include};
+                push @incs, $withargs{zstd_include}
+                    if !$disabled{zstd} && $withargs{zstd_include};
                 return [ @incs ];
             },
     },
@@ -69,11 +75,35 @@ my %targets=(
         ARFLAGS         => "qc",
         CC              => "cc",
         lflags          =>
-            sub { $withargs{zlib_lib} ? "-L".$withargs{zlib_lib} : () },
+            sub {
+                my $libs = "";
+                if ($withargs{zlib_lib}) {
+                    $libs .= " -L".$withargs{zlib_lib}
+                }
+                if ($withargs{brotli_lib}) {
+                    $libs .= " -L".$withargs{brotli_lib}
+                }
+                if ($withargs{zstd_lib}) {
+                    $libs .= " -L".$withargs{zstd_lib}
+                }
+
+                return $libs;
+            },
         ex_libs         =>
-            sub { !defined($disabled{zlib})
-                  && defined($disabled{"zlib-dynamic"})
-                  ? "-lz" : () },
+            sub {
+                my $libs = "";
+                if (!defined($disabled{zlib}) && defined($disabled{"zlib-dynamic"})) {
+                    $libs .= " -lz";
+                }
+                if (!defined($disabled{brotli})) {
+                    $libs .= " -lbrotlicommon -lbrotlienc -lbrotlidec";
+                }
+                if (!defined($disabled{zstd})) {
+                    $libs .= " -lzstd";
+                }
+
+            },
+
         HASHBANGPERL    => "/usr/bin/env perl", # Only Unix actually cares
         RANLIB          => sub { which("$config{cross_compile_prefix}ranlib")
                                      ? "ranlib" : "" },
@@ -130,6 +160,7 @@ my %targets=(
                     # zlib incarnations.
                     push @incs, 'GNV$ZLIB_INCLUDE:'
                         if !$disabled{zlib} && !$withargs{zlib_include};
+                    # TODO: add brotli
                     return [ @incs ];
                 }),
 

--- a/Configure
+++ b/Configure
@@ -27,7 +27,7 @@ use OpenSSL::config;
 my $orig_death_handler = $SIG{__DIE__};
 $SIG{__DIE__} = \&death_handler;
 
-my $usage="Usage: Configure [no-<cipher> ...] [enable-<cipher> ...] [-Dxxx] [-lxxx] [-Lxxx] [-fxxx] [-Kxxx] [no-hw-xxx|no-hw] [[no-]threads] [[no-]shared] [[no-]zlib|zlib-dynamic] [no-asm] [no-egd] [sctp] [386] [--prefix=DIR] [--openssldir=OPENSSLDIR] [--with-xxx[=vvv]] [--config=FILE] os/compiler[:flags]\n";
+my $usage="Usage: Configure [no-<cipher> ...] [enable-<cipher> ...] [-Dxxx] [-lxxx] [-Lxxx] [-fxxx] [-Kxxx] [no-hw-xxx|no-hw] [[no-]threads] [[no-]shared] [[no-]zlib|zlib-dynamic] [[no-]brotli] [[no-]zstd] [no-asm] [no-egd] [sctp] [386] [--prefix=DIR] [--openssldir=OPENSSLDIR] [--with-xxx[=vvv]] [--config=FILE] os/compiler[:flags]\n";
 
 # Options:
 #
@@ -68,6 +68,10 @@ my $usage="Usage: Configure [no-<cipher> ...] [enable-<cipher> ...] [-Dxxx] [-lx
 # [no-]zlib     [don't] compile support for zlib compression.
 # zlib-dynamic  Like "zlib", but the zlib library is expected to be a shared
 #               library and will be loaded in run-time by the OpenSSL library.
+# [no-]brotli   [don't] compile support for brotli compression(used in
+#               certificate compression extension)
+# [no-]zstd     [don't] compile support for zstd compression(used in
+#               certificate compression extension)
 # sctp          include SCTP support
 # no-uplink     Don't build support for UPLINK interface.
 # enable-weak-ssl-ciphers
@@ -483,6 +487,8 @@ my @disablables = (
     "whirlpool",
     "zlib",
     "zlib-dynamic",
+    "brotli",
+    "zstd"
     );
 foreach my $proto ((@tls, @dtls))
         {
@@ -537,6 +543,8 @@ our %disabled = ( # "what"         => "comment"
                   "weak-ssl-ciphers"    => "default",
                   "zlib"                => "default",
                   "zlib-dynamic"        => "default",
+                  "brotli"              => "default",
+                  "zstd"                => "default",
                 );
 
 # Note: => pair form used for aesthetics, not to truly make a hash table
@@ -779,6 +787,8 @@ while (@argvcopy)
         s /^threads$/enable-threads/;
         s /^zlib$/enable-zlib/;
         s /^zlib-dynamic$/enable-zlib-dynamic/;
+        s /^brotli$/enable-brotli/;
+        s /^zstd$/enable-zstd/;
 
         if (/^(no|disable|enable)-(.+)$/)
                 {
@@ -947,6 +957,22 @@ while (@argvcopy)
                 elsif (/^--with-zlib-include=(.*)$/)
                         {
                         $withargs{zlib_include}=$1;
+                        }
+                elsif (/^--with-brotli-lib=(.*)$/)
+                        {
+                        $withargs{brotli_lib}=$1;
+                        }
+                elsif (/^--with-brotli-include=(.*)$/)
+                        {
+                        $withargs{brotli_include}=$1;
+                        }
+                elsif (/^--with-zstd-lib=(.*)$/)
+                        {
+                        $withargs{zstd_lib}=$1;
+                        }
+                elsif (/^--with-zstd-include=(.*)$/)
+                        {
+                        $withargs{zstd_include}=$1;
                         }
                 elsif (/^--with-fuzzer-lib=(.*)$/)
                         {
@@ -1792,7 +1818,8 @@ foreach my $what (sort keys %disabled) {
 
     if (!grep { $what eq $_ } ( 'buildtest-c++', 'fips', 'threads', 'shared',
                                 'module', 'pic', 'dynamic-engine', 'makedepend',
-                                'zlib-dynamic', 'zlib', 'sse2', 'legacy' )) {
+                                'zlib-dynamic', 'zlib', 'sse2', 'legacy', 'brotli',
+                                'zstd' )) {
         (my $WHAT = uc $what) =~ s|-|_|g;
         my $skipdir = $what;
 

--- a/apps/include/opt.h
+++ b/apps/include/opt.h
@@ -160,7 +160,8 @@
         OPT_S_CURVES, OPT_S_NAMEDCURVE, OPT_S_CIPHER, OPT_S_CIPHERSUITES, \
         OPT_S_RECORD_PADDING, OPT_S_DEBUGBROKE, OPT_S_COMP, \
         OPT_S_MINPROTO, OPT_S_MAXPROTO, \
-        OPT_S_NO_RENEGOTIATION, OPT_S_NO_MIDDLEBOX, OPT_S__LAST
+        OPT_S_NO_RENEGOTIATION, OPT_S_NO_MIDDLEBOX, OPT_S_CERT_COMPRESSION, \
+        OPT_S__LAST
 
 # define OPT_S_OPTIONS \
         OPT_SECTION("TLS/SSL"), \
@@ -211,7 +212,8 @@
         {"debug_broken_protocol", OPT_S_DEBUGBROKE, '-', \
             "Perform all sorts of protocol violations for testing purposes"}, \
         {"no_middlebox", OPT_S_NO_MIDDLEBOX, '-', \
-            "Disable TLSv1.3 middlebox compat mode" }
+            "Disable TLSv1.3 middlebox compat mode" },        \
+        {"cert_compression", OPT_S_CERT_COMPRESSION, 's', "Specify certificate compression algorithm"}
 
 # define OPT_S_CASES \
         OPT_S__FIRST: case OPT_S__LAST: break; \
@@ -244,7 +246,8 @@
         case OPT_S_MINPROTO: \
         case OPT_S_MAXPROTO: \
         case OPT_S_DEBUGBROKE: \
-        case OPT_S_NO_MIDDLEBOX
+        case OPT_S_NO_MIDDLEBOX:               \
+        case OPT_S_CERT_COMPRESSION
 
 #define IS_NO_PROT_FLAG(o) \
  (o == OPT_S_NOSSL3 || o == OPT_S_NOTLS1 || o == OPT_S_NOTLS1_1 \

--- a/apps/include/s_apps.h
+++ b/apps/include/s_apps.h
@@ -78,6 +78,7 @@ int ssl_load_stores(SSL_CTX *ctx, const char *vfyCApath,
 void ssl_ctx_security_debug(SSL_CTX *ctx, int verbose);
 int set_keylog_file(SSL_CTX *ctx, const char *keylog_file);
 void print_ca_names(BIO *bio, SSL *s);
+void print_cert_compression_state(BIO *bio, SSL *s);
 
 #ifndef OPENSSL_NO_SRP
 /* The client side SRP context that we pass to all SRP related callbacks */

--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -2897,6 +2897,7 @@ static void print_connection_info(SSL *con)
                SSL_get_secure_renegotiation_support(con) ? "" : " NOT");
     if ((SSL_get_options(con) & SSL_OP_NO_RENEGOTIATION))
         BIO_printf(bio_s_out, "Renegotiation is DISABLED\n");
+    print_cert_compression_state(bio_s_out, con);
 
     if (keymatexportlabel != NULL) {
         BIO_printf(bio_s_out, "Keying material exporter:\n");
@@ -3110,6 +3111,7 @@ static int www_body(int s, int stype, int prot, unsigned char *context)
                        "Secure Renegotiation IS%s supported\n",
                        SSL_get_secure_renegotiation_support(con) ?
                        "" : " NOT");
+            print_cert_compression_state(io, con);
 
             /*
              * The following is evil and should not really be done

--- a/include/openssl/ssl.h.in
+++ b/include/openssl/ssl.h.in
@@ -1064,7 +1064,9 @@ typedef enum {
     TLS_ST_EARLY_DATA,
     TLS_ST_PENDING_EARLY_DATA_END,
     TLS_ST_CW_END_OF_EARLY_DATA,
-    TLS_ST_SR_END_OF_EARLY_DATA
+    TLS_ST_SR_END_OF_EARLY_DATA,
+    TLS_ST_CR_CERT_COMPRESSED,
+    TLS_ST_SW_CERT_COMPRESSED
 } OSSL_HANDSHAKE_STATE;
 
 /*
@@ -1599,6 +1601,11 @@ __owur SSL_verify_cb SSL_get_verify_callback(const SSL *s);
 void SSL_set_verify(SSL *s, int mode, SSL_verify_cb callback);
 void SSL_set_verify_depth(SSL *s, int depth);
 void SSL_set_cert_cb(SSL *s, int (*cb) (SSL *ssl, void *arg), void *arg);
+void SSL_set_cert_compression(SSL *s, uint16_t *ids, size_t len);
+void SSL_get_cert_compression(SSL *s, const uint16_t **ids, size_t *len);
+void SSL_CTX_get_cert_compression(SSL_CTX *ctx, const uint16_t **ids, size_t *len);
+void SSL_CTX_set_cert_compression(SSL_CTX *ctx, uint16_t *ids, size_t len);
+__owur uint16_t SSL_get_cert_compression_selected(SSL *s);
 # ifndef OPENSSL_NO_DEPRECATED_3_0
 OSSL_DEPRECATEDIN_3_0 __owur int SSL_use_RSAPrivateKey(SSL *ssl, RSA *rsa);
 OSSL_DEPRECATEDIN_3_0
@@ -2530,6 +2537,12 @@ void SSL_set_allow_early_data_cb(SSL *s,
 /* store the default cipher strings inside the library */
 const char *OSSL_default_cipher_list(void);
 const char *OSSL_default_ciphersuites(void);
+
+/* RFC 8879 Compression algorithms list */
+#define SSL_CERT_COMPRESSION_NONE           0x0
+#define SSL_CERT_COMPRESSION_ZLIB           0x1
+#define SSL_CERT_COMPRESSION_BROTLI         0x2
+#define SSL_CERT_COMPRESSION_ZSTD           0x3
 
 # ifdef  __cplusplus
 }

--- a/include/openssl/ssl3.h
+++ b/include/openssl/ssl3.h
@@ -317,6 +317,7 @@ extern "C" {
 # define SSL3_MT_CERTIFICATE_STATUS              22
 # define SSL3_MT_SUPPLEMENTAL_DATA               23
 # define SSL3_MT_KEY_UPDATE                      24
+# define SSL3_MT_CERTIFICATE_COMPRESSED          25
 # ifndef OPENSSL_NO_NEXTPROTONEG
 #  define SSL3_MT_NEXT_PROTO                     67
 # endif

--- a/include/openssl/tls1.h
+++ b/include/openssl/tls1.h
@@ -136,6 +136,9 @@ extern "C" {
 /* ExtensionType value from RFC7627 */
 # define TLSEXT_TYPE_extended_master_secret      23
 
+/* ExtensionType value from RFC8879 */
+#define TLSEXT_TYPE_cert_compression 27
+
 /* ExtensionType value from RFC4507 */
 # define TLSEXT_TYPE_session_ticket              35
 

--- a/ssl/ssl_local.h
+++ b/ssl/ssl_local.h
@@ -752,6 +752,7 @@ typedef enum tlsext_index_en {
     TLSEXT_IDX_encrypt_then_mac,
     TLSEXT_IDX_signed_certificate_timestamp,
     TLSEXT_IDX_extended_master_secret,
+    TLSEXT_IDX_cert_compression,
     TLSEXT_IDX_signature_algorithms_cert,
     TLSEXT_IDX_post_handshake_auth,
     TLSEXT_IDX_signature_algorithms,
@@ -1106,6 +1107,10 @@ struct ssl_ctx_st {
 # endif
 
         unsigned char cookie_hmac_key[SHA256_DIGEST_LENGTH];
+
+        /* RFC8879 certificate compression algorithms */
+        uint16_t *supported_cert_compression_ids;
+        size_t supported_cert_compression_ids_len;
     } ext;
 
 # ifndef OPENSSL_NO_PSK
@@ -1664,6 +1669,11 @@ struct ssl_st {
          * selected.
          */
         int tick_identity;
+
+        /* RFC8879 certificate compression algorithms */
+        uint16_t *supported_cert_compression_ids;
+        size_t supported_cert_compression_ids_len;
+        uint16_t selected_cert_compression_id;
     } ext;
 
     /*

--- a/ssl/ssl_stat.c
+++ b/ssl/ssl_stat.c
@@ -113,6 +113,10 @@ const char *SSL_state_string_long(const SSL *s)
         return "TLSv1.3 write end of early data";
     case TLS_ST_SR_END_OF_EARLY_DATA:
         return "TLSv1.3 read end of early data";
+    case TLS_ST_CR_CERT_COMPRESSED:
+        return "TLSv1.3 read compressed server certificate";
+    case TLS_ST_SW_CERT_COMPRESSED:
+        return "TLSv1.3 write compressed server certificate";
     default:
         return "unknown state";
     }
@@ -220,6 +224,10 @@ const char *SSL_state_string(const SSL *s)
         return "TWEOED";
     case TLS_ST_SR_END_OF_EARLY_DATA:
         return "TWEOED";
+    case TLS_ST_CR_CERT_COMPRESSED:
+        return "TRCCC";
+    case TLS_ST_SW_CERT_COMPRESSED:
+        return "TWSCC";
     default:
         return "UNKWN ";
     }

--- a/ssl/statem/extensions.c
+++ b/ssl/statem/extensions.c
@@ -279,6 +279,13 @@ static const EXTENSION_DEFINITION ext_defs[] = {
         tls_construct_stoc_ems, tls_construct_ctos_ems, final_ems
     },
     {
+        TLSEXT_TYPE_cert_compression,
+        SSL_EXT_CLIENT_HELLO | SSL_EXT_TLS1_3_CERTIFICATE_REQUEST |
+        SSL_EXT_TLS1_3_ONLY,
+        NULL, tls_parse_ctos_cert_compression, NULL, NULL,
+        tls_construct_ctos_cert_compression, NULL
+    },
+    {
         TLSEXT_TYPE_signature_algorithms_cert,
         SSL_EXT_CLIENT_HELLO | SSL_EXT_TLS1_3_CERTIFICATE_REQUEST,
         init_sig_algs_cert, tls_parse_ctos_sig_algs_cert,

--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -2403,3 +2403,25 @@ int tls13_restore_handshake_digest_for_pha(SSL *s)
     }
     return 1;
 }
+
+/* Helpers for compression and decompression of certificates.
+ * zlib_zalloc and zlib_zfree already defined in compression
+ * module, but defined as static.
+ */
+
+void *cert_brotli_zalloc(void*opaque, size_t size) {
+    return OPENSSL_zalloc(size);
+}
+void cert_brotli_zfree(void*opaque, void* addr) {
+    OPENSSL_free(addr);
+}
+
+void *cert_zlib_zalloc(void *opaque, unsigned int no, unsigned int size)
+{
+    return OPENSSL_zalloc(no * size);
+}
+
+void cert_zlib_zfree(void *opaque, void *address)
+{
+    OPENSSL_free(address);
+}

--- a/ssl/statem/statem_local.h
+++ b/ssl/statem/statem_local.h
@@ -130,6 +130,7 @@ __owur int tls_construct_cert_status_body(SSL *s, WPACKET *pkt);
 __owur int tls_construct_cert_status(SSL *s, WPACKET *pkt);
 __owur MSG_PROCESS_RETURN tls_process_key_exchange(SSL *s, PACKET *pkt);
 __owur MSG_PROCESS_RETURN tls_process_server_certificate(SSL *s, PACKET *pkt);
+__owur MSG_PROCESS_RETURN tls_process_compressed_server_certificate(SSL *s, PACKET *pkt);
 __owur WORK_STATE tls_post_process_server_certificate(SSL *s, WORK_STATE wst);
 __owur int ssl3_check_cert_and_algorithm(SSL *s);
 #ifndef OPENSSL_NO_NEXTPROTONEG
@@ -145,6 +146,7 @@ __owur WORK_STATE tls_post_process_client_hello(SSL *s, WORK_STATE wst);
 __owur int tls_construct_server_hello(SSL *s, WPACKET *pkt);
 __owur int dtls_construct_hello_verify_request(SSL *s, WPACKET *pkt);
 __owur int tls_construct_server_certificate(SSL *s, WPACKET *pkt);
+__owur int tls_construct_compressed_server_certificate(SSL *s, WPACKET *pkt);
 __owur int tls_construct_server_key_exchange(SSL *s, WPACKET *pkt);
 __owur int tls_construct_certificate_request(SSL *s, WPACKET *pkt);
 __owur int tls_construct_server_done(SSL *s, WPACKET *pkt);
@@ -237,6 +239,8 @@ int tls_parse_ctos_key_share(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
 int tls_parse_ctos_cookie(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
                           size_t chainidx);
 int tls_parse_ctos_ems(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
+                       size_t chainidx);
+int tls_parse_ctos_cert_compression(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
                        size_t chainidx);
 int tls_parse_ctos_psk_kex_modes(SSL *s, PACKET *pkt, unsigned int context,
                                  X509 *x, size_t chainidx);
@@ -355,6 +359,8 @@ EXT_RETURN tls_construct_ctos_sct(SSL *s, WPACKET *pkt, unsigned int context,
 #endif
 EXT_RETURN tls_construct_ctos_ems(SSL *s, WPACKET *pkt, unsigned int context,
                                   X509 *x, size_t chainidx);
+EXT_RETURN tls_construct_ctos_cert_compression(SSL *s, WPACKET *pkt, unsigned int context,
+                                  X509 *x, size_t chainidx);
 EXT_RETURN tls_construct_ctos_supported_versions(SSL *s, WPACKET *pkt,
                                                  unsigned int context, X509 *x,
                                                  size_t chainidx);
@@ -421,3 +427,8 @@ int tls_handle_alpn(SSL *s);
 
 int tls13_save_handshake_digest_for_pha(SSL *s);
 int tls13_restore_handshake_digest_for_pha(SSL *s);
+
+void *cert_brotli_zalloc(void*opaque, size_t size);
+void cert_brotli_zfree(void*opaque, void* addr);
+void *cert_zlib_zalloc(void *opaque, unsigned int no, unsigned int size);
+void cert_zlib_zfree(void *opaque, void *address);


### PR DESCRIPTION
Hello,

It's my first pull request to OpenSSL. I'm not sure that it is a good way to link with zlib, brotli and zstd. RFC8879 defined only those three types of compression algorithms, but maybe it will be better to implement them like classes with compression/decompression callbacks defined by user code. Using callbacks will create chaos of copy-pasted functions in tons of projects.

Another problem that I don't understand how to make tests for cases when some of the libraries were not linked. Any thoughts about how to test cases when some of the libraries were not linked will be helpful for me. 