### PR TITLE
APPS: Set a default passphrase UI for the "ec" command

### DIFF
--- a/apps/dsa.c
+++ b/apps/dsa.c
@@ -267,6 +267,20 @@ int dsa_main(int argc, char **argv)
         goto end;
     }
 
+    /* Passphrase setup */
+    if (enc != NULL)
+        OSSL_ENCODER_CTX_set_cipher(ectx, EVP_CIPHER_name(enc), NULL);
+
+    /* Default passphrase prompter */
+    if (enc != NULL || outformat == FORMAT_PVK) {
+        OSSL_ENCODER_CTX_set_passphrase_ui(ectx, get_ui_method(), NULL);
+        if (passout != NULL)
+            /* When passout given, override the passphrase prompter */
+            OSSL_ENCODER_CTX_set_passphrase(ectx,
+                                            (const unsigned char *)passout,
+                                            strlen(passout));
+    }
+
     /* PVK requires a bit more */
     if (outformat == FORMAT_PVK) {
         OSSL_PARAM params[2] = { OSSL_PARAM_END, OSSL_PARAM_END };

--- a/apps/ec.c
+++ b/apps/ec.c
@@ -267,7 +267,10 @@ int ec_main(int argc, char **argv)
                                              NULL);
         if (enc != NULL) {
             OSSL_ENCODER_CTX_set_cipher(ectx, EVP_CIPHER_name(enc), NULL);
+            /* Default passphrase prompter */
+            OSSL_ENCODER_CTX_set_passphrase_ui(ectx, get_ui_method(), NULL);
             if (passout != NULL)
+                /* When passout given, override the passphrase prompter */
                 OSSL_ENCODER_CTX_set_passphrase(ectx,
                                                 (const unsigned char *)passout,
                                                 strlen(passout));

--- a/apps/rsa.c
+++ b/apps/rsa.c
@@ -335,6 +335,20 @@ int rsa_main(int argc, char **argv)
         goto end;
     }
 
+    /* Passphrase setup */
+    if (enc != NULL)
+        OSSL_ENCODER_CTX_set_cipher(ectx, EVP_CIPHER_name(enc), NULL);
+
+    /* Default passphrase prompter */
+    if (enc != NULL || outformat == FORMAT_PVK) {
+        OSSL_ENCODER_CTX_set_passphrase_ui(ectx, get_ui_method(), NULL);
+        if (passout != NULL)
+            /* When passout given, override the passphrase prompter */
+            OSSL_ENCODER_CTX_set_passphrase(ectx,
+                                            (const unsigned char *)passout,
+                                            strlen(passout));
+    }
+
     /* PVK is a bit special... */
     if (outformat == FORMAT_PVK) {
         OSSL_PARAM params[2] = { OSSL_PARAM_END, OSSL_PARAM_END };


### PR DESCRIPTION
Fixes #15114

Also fixing the `openssl rsa` and `openssl dsa` commands, which ignored all passphrase related settings