### PR TITLE
Bump HMAC_MAX_MD_CBLOCK to 200 due to SHA-3

### DIFF
--- a/include/openssl/hmac.h
+++ b/include/openssl/hmac.h
@@ -21,7 +21,7 @@
 # include <openssl/evp.h>
 
 # ifndef OPENSSL_NO_DEPRECATED_3_0
-#  define HMAC_MAX_MD_CBLOCK      128    /* Deprecated */
+#  define HMAC_MAX_MD_CBLOCK      200    /* Deprecated */
 # endif
 
 # ifdef  __cplusplus


### PR DESCRIPTION
The maximum (theoretical) block size of SHA3 is 200 bytes.

Replacement of bitrot PR #4338