### PR TITLE
Require secure renegotiation support by default

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -77,6 +77,14 @@ OpenSSL 3.0
 
    *Boris Pismenny, John Baldwin and Andrew Gallatin*
 
+ * Support for RFC 5746 secure renegotiation is now required by default for
+   SSL or TLS connections to succeed.  Applications that require the ability
+   to connect to legacy peers will need to explicitly set
+   SSL_OP_LEGACY_SERVER_CONNECT.  Accordingly, SSL_OP_LEGACY_SERVER_CONNECT
+   is no longer set as part of SSL_OP_ALL.
+
+   *Benjamin Kaduk*
+
  * The signature of the `copy` functional parameter of the
    EVP_PKEY_meth_set_copy() function has changed so its `src` argument is
    now `const EVP_PKEY_CTX *` instead of `EVP_PKEY_CTX *`. Similarly

--- a/doc/man1/openssl-s_client.pod.in
+++ b/doc/man1/openssl-s_client.pod.in
@@ -83,6 +83,7 @@ B<openssl> B<s_client>
 [B<-comp>]
 [B<-no_comp>]
 [B<-brief>]
+[B<-legacy_server_connect>]
 [B<-allow_no_dhe_kex>]
 [B<-sigalgs> I<sigalglist>]
 [B<-curves> I<curvelist>]

--- a/doc/man1/openssl-s_server.pod.in
+++ b/doc/man1/openssl-s_server.pod.in
@@ -94,7 +94,6 @@ B<openssl> B<s_server>
 [B<-serverpref>]
 [B<-legacy_renegotiation>]
 [B<-no_renegotiation>]
-[B<-legacy_server_connect>]
 [B<-no_resumption_on_reneg>]
 [B<-no_legacy_server_connect>]
 [B<-allow_no_dhe_kex>]

--- a/doc/man3/SSL_CONF_cmd.pod
+++ b/doc/man3/SSL_CONF_cmd.pod
@@ -76,7 +76,6 @@ set SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION flag. Only used by servers.
 
 permits or prohibits the use of unsafe legacy renegotiation for OpenSSL
 clients only. Equivalent to setting or clearing B<SSL_OP_LEGACY_SERVER_CONNECT>.
-Set by default.
 
 =item B<-prioritize_chacha>
 

--- a/doc/man3/SSL_CTX_set_options.pod
+++ b/doc/man3/SSL_CTX_set_options.pod
@@ -88,8 +88,7 @@ implementations.
 
 =item SSL_OP_ALL
 
-All of the above bug workarounds plus B<SSL_OP_LEGACY_SERVER_CONNECT> as
-mentioned below.
+All of the above bug workarounds.
 
 =back
 
@@ -193,8 +192,7 @@ servers. See the B<SECURE RENEGOTIATION> section for more details.
 =item SSL_OP_LEGACY_SERVER_CONNECT
 
 Allow legacy insecure renegotiation between OpenSSL and unpatched servers
-B<only>: this option is currently set by default. See the
-B<SECURE RENEGOTIATION> section for more details.
+B<only>. See the B<SECURE RENEGOTIATION> section for more details.
 
 =item SSL_OP_NO_ENCRYPT_THEN_MAC
 
@@ -378,15 +376,10 @@ and renegotiation between patched OpenSSL clients and unpatched servers
 succeeds. If neither option is set then initial connections to unpatched
 servers will fail.
 
-The option B<SSL_OP_LEGACY_SERVER_CONNECT> is currently set by default even
-though it has security implications: otherwise it would be impossible to
-connect to unpatched servers (i.e. all of them initially) and this is clearly
-not acceptable. Renegotiation is permitted because this does not add any
-additional security issues: during an attack clients do not see any
-renegotiations anyway.
-
-As more servers become patched the option B<SSL_OP_LEGACY_SERVER_CONNECT> will
-B<not> be set by default in a future version of OpenSSL.
+Setting the option B<SSL_OP_LEGACY_SERVER_CONNECT> has security implications;
+clients that are willing to connect to servers that do not implement
+RFC 5746 secure renegotiation are subject to attacks such as
+CVE-2009-3555.
 
 OpenSSL client applications wishing to ensure they can connect to unpatched
 servers should always B<set> B<SSL_OP_LEGACY_SERVER_CONNECT>

--- a/include/openssl/ssl.h.in
+++ b/include/openssl/ssl.h.in
@@ -425,7 +425,6 @@ typedef int (*SSL_async_callback_fn)(SSL *s, void *arg);
  */
 # define SSL_OP_ALL        (SSL_OP_CRYPTOPRO_TLSEXT_BUG|\
                             SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS|\
-                            SSL_OP_LEGACY_SERVER_CONNECT|\
                             SSL_OP_TLSEXT_PADDING|\
                             SSL_OP_SAFARI_ECDHE_ECDSA_BUG)
 

--- a/ssl/ssl_conf.c
+++ b/ssl/ssl_conf.c
@@ -684,7 +684,7 @@ static const ssl_conf_cmd_tbl ssl_conf_cmds[] = {
     SSL_CONF_CMD_SWITCH("no_ticket", 0),
     SSL_CONF_CMD_SWITCH("serverpref", SSL_CONF_FLAG_SERVER),
     SSL_CONF_CMD_SWITCH("legacy_renegotiation", 0),
-    SSL_CONF_CMD_SWITCH("legacy_server_connect", SSL_CONF_FLAG_SERVER),
+    SSL_CONF_CMD_SWITCH("legacy_server_connect", SSL_CONF_FLAG_CLIENT),
     SSL_CONF_CMD_SWITCH("no_renegotiation", 0),
     SSL_CONF_CMD_SWITCH("no_resumption_on_reneg", SSL_CONF_FLAG_SERVER),
     SSL_CONF_CMD_SWITCH("no_legacy_server_connect", SSL_CONF_FLAG_SERVER),

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -3311,11 +3311,6 @@ SSL_CTX *SSL_CTX_new_ex(OSSL_LIB_CTX *libctx, const char *propq,
 # endif
 #endif
     /*
-     * Default is to connect to non-RI servers. When RI is more widely
-     * deployed might change this.
-     */
-    ret->options |= SSL_OP_LEGACY_SERVER_CONNECT;
-    /*
      * Disable compression by default to prevent CRIME. Applications can
      * re-enable compression by configuring
      * SSL_CTX_clear_options(ctx, SSL_OP_NO_COMPRESSION);

--- a/test/bad_dtls_test.c
+++ b/test/bad_dtls_test.c
@@ -494,6 +494,8 @@ static int test_bad_dtls(void)
     if (!TEST_ptr(ctx)
             || !TEST_true(SSL_CTX_set_min_proto_version(ctx, DTLS1_BAD_VER))
             || !TEST_true(SSL_CTX_set_max_proto_version(ctx, DTLS1_BAD_VER))
+            || !TEST_true(SSL_CTX_set_options(ctx,
+                                              SSL_OP_LEGACY_SERVER_CONNECT))
             || !TEST_true(SSL_CTX_set_cipher_list(ctx, "AES128-SHA")))
         goto end;
 

--- a/test/recipes/70-test_sslrecords.t
+++ b/test/recipes/70-test_sslrecords.t
@@ -96,7 +96,7 @@ my $sslv2testtype = TLSV1_2_IN_SSLV2;
 $proxy->clear();
 $proxy->filter(\&add_sslv2_filter);
 $proxy->serverflags("-tls1_2");
-$proxy->clientflags("-no_tls1_3");
+$proxy->clientflags("-no_tls1_3 -legacy_renegotiation");
 $proxy->ciphers("AES128-SHA:\@SECLEVEL=0");
 $proxy->start();
 ok(TLSProxy::Message->success(), "TLSv1.2 in SSLv2 ClientHello test");


### PR DESCRIPTION
Per #14848 , stop setting `SSL_OP_LEGACY_SERVER_CONNECT` by default, and don't include it in `SSL_OP_ALL`.
Deal with fallout in docs and tests (including fixing a bug in `SSL_CONF` that only lets you set the flag for servers, when the flag is only useful on clients!).

@davidben please remind me if there were any issues with other implementations thinking that advertising renegotiation-info support implies a willingness to support renegotiation at all, that we might need to consider.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
