### PR TITLE
Deprecate X509{,_CRL}_http_nbio() and simplify their definition

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -341,6 +341,11 @@ OpenSSL 3.0
 
    *Rich Salz and Richard Levitte*
 
+ * Deprecated `X509_http_nbio()` and `X509_CRL_http_nbio()`,
+   which are superseded by `X509_load_http()` and `X509_CRL_load_http()`.
+
+   *David von Oheimb*
+
  * Deprecated `OCSP_parse_url()`, which is replaced with `OSSL_HTTP_parse_url`.
 
    *David von Oheimb*

--- a/doc/man3/X509_load_http.pod
+++ b/doc/man3/X509_load_http.pod
@@ -15,6 +15,10 @@ X509_CRL_http_nbio
  X509 *X509_load_http(const char *url, BIO *bio, BIO *rbio, int timeout);
  X509_CRL *X509_CRL_load_http(const char *url, BIO *bio, BIO *rbio, int timeout);
 
+Deprecated since OpenSSL 3.0, can be hidden entirely by defining
+B<OPENSSL_API_COMPAT> with a suitable version value, see
+L<openssl_user_macros(7)>:
+
  #define X509_http_nbio(rctx, pcert)
  #define X509_CRL_http_nbio(rctx, pcrl)
 
@@ -50,6 +54,7 @@ L<OSSL_HTTP_get_asn1(3)>
 =head1 HISTORY
 
 X509_load_http() and X509_CRL_load_http() were added in OpenSSL 3.0.
+X509_http_nbio() and X509_CRL_http_nbio() were deprecated in OpenSSL 3.0.
 
 =head1 COPYRIGHT
 

--- a/include/openssl/x509.h.in
+++ b/include/openssl/x509.h.in
@@ -403,13 +403,14 @@ int X509_NAME_digest(const X509_NAME *data, const EVP_MD *type,
                      unsigned char *md, unsigned int *len);
 
 X509 *X509_load_http(const char *url, BIO *bio, BIO *rbio, int timeout);
-# define X509_http_nbio(rctx, pcert)                                    \
-    ((*(pcert) =                                                        \
-      OSSL_HTTP_REQ_CTX_sendreq_d2i(rctx, ASN1_ITEM_rptr(X509))) != NULL)
 X509_CRL *X509_CRL_load_http(const char *url, BIO *bio, BIO *rbio, int timeout);
-# define X509_CRL_http_nbio(rctx, pcrl)                                 \
-    ((*(pcrl) =                                                         \
-      OSSL_HTTP_REQ_CTX_sendreq_d2i(rctx, ASN1_ITEM_rptr(X509_CRL))) != NULL)
+# ifndef OPENSSL_NO_DEPRECATED_3_0
+#  include <openssl/ocsp.h> /* OCSP_REQ_CTX_nbio_d2i */
+#  define X509_http_nbio(rctx, pcert) \
+      OCSP_REQ_CTX_nbio_d2i(rctx, pcert, ASN1_ITEM_rptr(X509))
+#  define X509_CRL_http_nbio(rctx, pcrl) \
+      OCSP_REQ_CTX_nbio_d2i(rctx, pcrl, ASN1_ITEM_rptr(X509_CRL))
+# endif
 
 # ifndef OPENSSL_NO_STDIO
 X509 *d2i_X509_fp(FILE *fp, X509 **x509);

--- a/util/other.syms
+++ b/util/other.syms
@@ -588,8 +588,8 @@ SSLv23_client_method                    define
 SSLv23_method                           define
 SSLv23_server_method                    define
 TLS_DEFAULT_CIPHERSUITES                define deprecated 3.0.0
-X509_CRL_http_nbio                      define
-X509_http_nbio                          define
+X509_CRL_http_nbio                      define deprecated 3.0.0
+X509_http_nbio                          define deprecated 3.0.0
 X509_LOOKUP_add_dir                     define
 X509_LOOKUP_add_store                   define
 X509_LOOKUP_add_store_ex                define


### PR DESCRIPTION
This is achieved by making use of `OCSP_REQ_CTX_nbio_d2i()`.

This PR has been carved out of #15053.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated

