### PR TITLE
evp_extra_test: Avoid potential double free of params

### DIFF
--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -688,6 +688,7 @@ static int test_EC_priv_pub(void)
     if (!test_fromdata("EC", params))
         goto err;
     OSSL_PARAM_free(params);
+    params = NULL;
     OSSL_PARAM_BLD_free(bld);
 
     /* Test priv and !pub */
@@ -704,6 +705,7 @@ static int test_EC_priv_pub(void)
     if (!test_fromdata("EC", params))
         goto err;
     OSSL_PARAM_free(params);
+    params = NULL;
     OSSL_PARAM_BLD_free(bld);
 
     /* Test !priv and pub */
@@ -721,6 +723,7 @@ static int test_EC_priv_pub(void)
     if (!test_fromdata("EC", params))
         goto err;
     OSSL_PARAM_free(params);
+    params = NULL;
     OSSL_PARAM_BLD_free(bld);
 
     /* Test priv and pub */


### PR DESCRIPTION
Fixes #14916

This is alternative PR to #14934