### PR TITLE
Fix i2d_PKCS8PrivateKey_nid_bio() regression.

### DIFF
--- a/crypto/pem/pem_pk8.c
+++ b/crypto/pem/pem_pk8.c
@@ -93,7 +93,7 @@ static int do_pk8pkey(BIO *bp, const EVP_PKEY *x, int isder, int nid,
         }
     }
 
-    if (OSSL_ENCODER_CTX_get_num_encoders(ctx) != 0) {
+    if (nid == -1 && OSSL_ENCODER_CTX_get_num_encoders(ctx) != 0) {
         ret = 1;
         if (enc != NULL) {
             ret = 0;

--- a/crypto/pem/pem_pk8.c
+++ b/crypto/pem/pem_pk8.c
@@ -93,6 +93,12 @@ static int do_pk8pkey(BIO *bp, const EVP_PKEY *x, int isder, int nid,
         }
     }
 
+    /*
+     * NOTE: There is no attempt to do a EVP_CIPHER_fetch() using the nid,
+     * since the nid is a PBE algorithm which can't be fetched currently.
+     * (e.g. NID_pbe_WithSHA1And2_Key_TripleDES_CBC). Just use the legacy
+     * path if the NID is passed.
+     */
     if (nid == -1 && OSSL_ENCODER_CTX_get_num_encoders(ctx) != 0) {
         ret = 1;
         if (enc != NULL) {

--- a/test/evp_extra_test2.c
+++ b/test/evp_extra_test2.c
@@ -290,6 +290,7 @@ done:
     return ret;
 }
 
+#ifndef OPENSSL_NO_DES
 static int test_pkcs8key_nid_bio(void)
 {
     int ret;
@@ -313,11 +314,15 @@ static int test_pkcs8key_nid_bio(void)
           && TEST_ptr(pkey_dec = d2i_PKCS8PrivateKey_bio(enc_bio, NULL, NULL,
                                                          (void *)pwd))
           && TEST_true(EVP_PKEY_eq(pkey, pkey_dec));
-    BIO_free(enc_bio);
+
+    EVP_PKEY_free(pkey_dec);
+    EVP_PKEY_free(pkey);
     BIO_free(in);
+    BIO_free(enc_bio);
     OSSL_PROVIDER_unload(provider);
     return ret;
 }
+#endif /* OPENSSL_NO_DES */
 
 static int test_alternative_default(void)
 {
@@ -756,7 +761,9 @@ int setup_tests(void)
     ADD_TEST(test_pkey_todata_null);
     ADD_TEST(test_pkey_export_null);
     ADD_TEST(test_pkey_export);
+#ifndef OPENSSL_NO_DES
     ADD_TEST(test_pkcs8key_nid_bio);
+#endif
     return 1;
 }
 


### PR DESCRIPTION
This method ignores the nid and could end up saving out the private key unencrypted.

In earlier alpha releases OSSL_num_encoders() returned 0 for this test
case, which then meant that the legacy path was run, and the key was
then correctly encrypted.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
