### PR TITLE
Clarify where dispatch functions/ids are defined

### DIFF
--- a/include/openssl/core.h
+++ b/include/openssl/core.h
@@ -32,8 +32,8 @@ typedef struct openssl_core_ctx_st OPENSSL_CORE_CTX;
 typedef struct ossl_core_bio_st OSSL_CORE_BIO;
 
 /*
- * Dispatch table element.  function_id numbers are defined further down,
- * see macros with '_FUNC' in their names.
+ * Dispatch table element.  function_id numbers and the functions are defined
+ * in core_dispatch.h, see macros with 'OSSL_CORE_MAKE_FUNC' in their names.
  *
  * An array of these is always terminated by function_id == 0
  */


### PR DESCRIPTION
When reading the comment for `ossl_dispatch_st` it seems to indicate that
the function_id numbers are defined further down in the same file. But I
was not able to find them there, but instead in `core_dispatch.h`.

This commit suggests updating the comment to point to `core_dispatch.h`.

