### PR TITLE
More user-friendly cipher_list handling

### DIFF
--- a/ssl/ssl_ciph.c
+++ b/ssl/ssl_ciph.c
@@ -1426,6 +1426,51 @@ int SSL_set_ciphersuites(SSL *s, const char *str)
     return ret;
 }
 
+static int ciphersuite13_cb(const char *elem, int len, void *arg)
+{
+    STACK_OF(SSL_CIPHER) *ciphersuites = (STACK_OF(SSL_CIPHER) *)arg;
+    const SSL_CIPHER *cipher;
+    /* Arbitrary sized temp buffer for the cipher name. Should be big enough */
+    char name[80];
+
+    if (len > (int)(sizeof(name) - 1)) {
+        SSLerr(SSL_F_CIPHERSUITE_CB, SSL_R_NO_CIPHER_MATCH);
+        return 0;
+    }
+
+    memcpy(name, elem, len);
+    name[len] = '\0';
+
+    cipher = ssl3_get_cipher_by_std_name(name);
+    if (cipher && cipher->min_tls == TLS1_3_VERSION) {
+        if (!sk_SSL_CIPHER_push(ciphersuites, cipher)) {
+            SSLerr(SSL_F_CIPHERSUITE_CB, ERR_R_INTERNAL_ERROR);
+            return 0;
+        }
+    }
+
+    return 1;
+}
+
+STACK_OF(SSL_CIPHER) *ssl_get_tls13_suites(const char *str)
+{
+    STACK_OF(SSL_CIPHER) *newciphers;
+    if (str == NULL || *str == '\0')
+        return NULL;
+
+    newciphers = sk_SSL_CIPHER_new_null();
+
+    if (newciphers != NULL) {
+        if (!CONF_parse_list(str, ':', 1, ciphersuite13_cb, newciphers) ||
+            !sk_SSL_CIPHER_num(newciphers)) {
+            sk_SSL_CIPHER_free(newciphers);
+            newciphers = NULL;
+        }
+    }
+
+    return newciphers;
+}
+
 STACK_OF(SSL_CIPHER) *ssl_create_cipher_list(SSL_CTX *ctx,
                                              STACK_OF(SSL_CIPHER) *tls13_ciphersuites,
                                              STACK_OF(SSL_CIPHER) **cipher_list,

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -2705,6 +2705,13 @@ static int cipher_list_tls12_num(STACK_OF(SSL_CIPHER) *sk)
 int SSL_CTX_set_cipher_list(SSL_CTX *ctx, const char *str)
 {
     STACK_OF(SSL_CIPHER) *sk;
+    STACK_OF(SSL_CIPHER) *tls13_sk;
+
+    tls13_sk = ssl_get_tls13_suites(str);
+    if (tls13_sk != NULL) {
+        sk_SSL_CIPHER_free(ctx->tls13_ciphersuites);
+        ctx->tls13_ciphersuites = tls13_sk;
+    }
 
     sk = ssl_create_cipher_list(ctx, ctx->tls13_ciphersuites,
                                 &ctx->cipher_list, &ctx->cipher_list_by_id, str,
@@ -2729,6 +2736,13 @@ int SSL_CTX_set_cipher_list(SSL_CTX *ctx, const char *str)
 int SSL_set_cipher_list(SSL *s, const char *str)
 {
     STACK_OF(SSL_CIPHER) *sk;
+    STACK_OF(SSL_CIPHER) *tls13_sk;
+
+    tls13_sk = ssl_get_tls13_suites(str);
+    if (tls13_sk != NULL) {
+        sk_SSL_CIPHER_free(s->tls13_ciphersuites);
+        s->tls13_ciphersuites = tls13_sk;
+    }
 
     sk = ssl_create_cipher_list(s->ctx, s->tls13_ciphersuites,
                                 &s->cipher_list, &s->cipher_list_by_id, str,

--- a/ssl/ssl_local.h
+++ b/ssl/ssl_local.h
@@ -2391,6 +2391,7 @@ __owur STACK_OF(SSL_CIPHER) *ssl_create_cipher_list(SSL_CTX *ctx,
                                                     STACK_OF(SSL_CIPHER) **cipher_list_by_id,
                                                     const char *rule_str,
                                                     CERT *c);
+__owur STACK_OF(SSL_CIPHER) *ssl_get_tls13_suites(const char *str);
 __owur int ssl_cache_cipherlist(SSL *s, PACKET *cipher_suites, int sslv2format);
 __owur int bytes_to_cipher_list(SSL *s, PACKET *cipher_suites,
                                 STACK_OF(SSL_CIPHER) **skp,


### PR DESCRIPTION
Accept TLS1.3 ciphersuites in the cipher_list rule_str. If any
are present, replace the previously configured TLS1.3 suites,
otherwise leave the TLS1.3 suites unchanged.

Same as PR#15161, but against master

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
