### PR TITLE
Refactor how providers/fipsmodule.cnf is generated

### DIFF
--- a/Configurations/common.tmpl
+++ b/Configurations/common.tmpl
@@ -448,6 +448,15 @@
      $cache{$script} = 1;
  }
 
+ # dofile is responsible for building generic scripts.  It depends entirely
+ # on existing generators, so calls dogenerate().
+ sub dofile {
+     my $file = shift;
+     return "" if $cache{$file};
+     $OUT .= dogenerate($file, undef, undef, intent => "file");
+     $cache{$file} = 1;
+ }
+
  sub dodir {
      my $dir = shift;
      return "" if !exists(&generatedir) or $cache{$dir};
@@ -486,6 +495,7 @@
  foreach (@{$unified_info{modules}})   { domodule($_); }
  foreach (@{$unified_info{programs}})  { dobin($_);    }
  foreach (@{$unified_info{scripts}})   { doscript($_); }
+ foreach (@{$unified_info{files}})     { dofile($_); }
  foreach (sort keys %{$unified_info{htmldocs}}) { dodocs('html', $_); }
  foreach (sort keys %{$unified_info{mandocs}})  { dodocs('man', $_); }
  foreach (sort keys %{$unified_info{dirinfo}})  { dodir($_); }

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -1294,6 +1294,8 @@ tar:
 link-utils: $(BLDDIR)/util/opensslwrap.sh $(BLDDIR)/util/wrap.pl \
             $(BLDDIR)/apps/openssl.cnf
 
+$(BLDDIR)/util/wrap.pl: $(BLDDIR)/util/shlib_wrap.sh
+
 $(BLDDIR)/util/opensslwrap.sh $(BLDDIR)/util/wrap.pl: configdata.pm
 	@if [ "$(SRCDIR)" != "$(BLDDIR)" ]; then \
 	    mkdir -p "$(BLDDIR)/util"; \

--- a/Configure
+++ b/Configure
@@ -1935,6 +1935,7 @@ if ($builder eq "unified") {
         my @libraries = ();
         my @modules = ();
         my @scripts = ();
+        my @files = ();
 
         my %sources = ();
         my %shared_sources = ();
@@ -2155,6 +2156,11 @@ if ($builder eq "unified") {
                                 \$attributes{scripts}, $+{ATTRIBS},
                                 tokenize($expand_variables->($+{VALUE})))
                          if !@skip || $skip[$#skip] > 0; },
+            qr/^\s* FILES ${attribs_re} \s* =  ${value_re} $/x
+            => sub { $push_to->(\@files, undef,
+                                \$attributes{files}, $+{ATTRIBS},
+                                tokenize($expand_variables->($+{VALUE})))
+                         if !@skip || $skip[$#skip] > 0; },
             qr/^\s* HTMLDOCS ${index_re} = ${value_re} $/x
             => sub { $push_to->(\%htmldocs, $expand_variables->($+{INDEX}),
                                 undef, undef,
@@ -2222,7 +2228,8 @@ EOF
             my %infos = ( programs  => [ @programs  ],
                           libraries => [ @libraries ],
                           modules   => [ @modules   ],
-                          scripts   => [ @scripts   ] );
+                          scripts   => [ @scripts   ],
+                          files     => [ @files     ] );
             foreach my $k (keys %infos) {
                 foreach (@{$infos{$k}}) {
                     my $item = cleanfile($buildd, $_, $blddir);
@@ -2574,7 +2581,8 @@ EOF
                 if defined($unified_info{$_});
             delete $unified_info{$_};
         }
-        foreach my $prodtype (('programs', 'libraries', 'modules', 'scripts')) {
+        foreach my $prodtype (('programs', 'libraries', 'modules',
+                               'scripts', 'files')) {
             # $intent serves multi purposes:
             # - give a prefix for the new object files names
             # - in the case of libraries, rearrange the object files so static
@@ -2593,7 +2601,9 @@ EOF
                 modules   => { dso    => { src => [ 'sources' ],
                                            dst => 'sources' } },
                 scripts   => { script => { src => [ 'sources' ],
-                                           dst => 'sources' } }
+                                           dst => 'sources' } },
+                files     => { file   => { src => [ 'sources' ],
+                                           dst => 'sources' } },
                } -> {$prodtype};
             foreach my $kind (keys %$intent) {
                 next if ($intent->{$kind}->{dst} eq 'shared_sources'
@@ -2652,7 +2662,8 @@ EOF
 
     ### Make unified_info a bit more efficient
     # One level structures
-    foreach (("programs", "libraries", "modules", "scripts", "targets")) {
+    foreach (("programs", "libraries", "modules",
+              "scripts", "files", "targets")) {
         $unified_info{$_} = [ sort keys %{$unified_info{$_}} ];
     }
     # Two level structures
@@ -2704,6 +2715,7 @@ EOF
                      "dso" => [ @{$unified_info{modules}} ],
                      "bin" => [ @{$unified_info{programs}} ],
                      "script" => [ @{$unified_info{scripts}} ],
+                     "files" => [ @{$unified_info{files}} ],
                      "docs" => [ (map { @{$unified_info{htmldocs}->{$_} // []} }
                                   keys %{$unified_info{htmldocs} // {}}),
                                  (map { @{$unified_info{mandocs}->{$_} // []} }

--- a/doc/internal/man7/build.info.pod
+++ b/doc/internal/man7/build.info.pod
@@ -24,6 +24,8 @@ B<MODULES=> I<name> ...
 
 B<SCRIPTS=> I<name> ...
 
+B<FILES=> I<name> ...
+
 B<DEPEND[>I<items>B<]=> I<otheritem> ...
 
 B<GENERATE[>I<item>B<]=> I<generator> I<generator-args> ...
@@ -70,8 +72,8 @@ the end.
 
 F<build.info> files are meta data files for OpenSSL's built file
 generators, and are used to specify exactly what end product files
-(programs, libraries, modules or scripts) are to be produced, and from
-what sources.
+(programs, libraries, modules, scripts or files) are to be produced,
+and from what sources.
 
 Intermediate files, such as object files, are seldom referred to at
 all.  They sometimes can be, if there's a need, but this should happen
@@ -426,6 +428,16 @@ scripts given in such a statement.  For example:
 
 With those two lines, the script C<foo> will not have the attribute
 C<noinst>, while the script C<bar> will.
+
+=item B<FILES=> I<name>
+
+Collects names of general files that should be built.  This statement
+is expected to be accompanied by a B<GENERATE> statement that
+specifies how this file is produced.
+
+These files are never installed automatically.  Instead, if any of
+them is to be installed, that must be done explicitly in the build
+file.
 
 =back
 

--- a/providers/build.info
+++ b/providers/build.info
@@ -114,16 +114,16 @@ IF[{- !$disabled{fips} -}]
     GENERATE[fips.ld]=../util/providers.num
   ENDIF
 
-  # For tests that try to use the FIPS module, we need to make a local fips
-  # module installation.  We have the output go to standard output, because
-  # the generated commands in build templates are expected to catch that,
-  # and thereby keep control over the exact output file location.
+  FILES=fipsmodule.cnf
+  GENERATE[fipsmodule.cnf]=../apps/openssl fipsinstall \
+        -module providers/$(FIPSMODULENAME) -provider_name fips \
+        -mac_name HMAC -section_name fips_sect
+  DEPEND[fipsmodule.cnf]=$FIPSGOAL
+
+  # For tests that try to use the FIPS module, we need to make the tests
+  # target depend on fipsmodule.cnf
   IF[{- !$disabled{tests} -}]
     DEPEND[|tests|]=fipsmodule.cnf
-    GENERATE[fipsmodule.cnf]=../apps/openssl fipsinstall \
-          -module providers/$(FIPSMODULENAME) -provider_name fips \
-          -mac_name HMAC -section_name fips_sect
-    DEPEND[fipsmodule.cnf]=$FIPSGOAL
   ENDIF
 ENDIF
 


### PR DESCRIPTION
It was made to only be generated for testing.  However, it was also
referred to from the 'install_fips' target, which suggests that it
should be generated any time the FIPS provider module itself is built.

To do this, we use the FILES build.info statement that's added in this PR.

The 'tests' target is still made to depend conditionally on
providers/fipsmodule.cnf.

Fixes #15166