### PR TITLE
[WIP] Add RedHat keyfile-corpus as an external test

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,6 +10,11 @@
 	path = gost-engine
 	url = https://github.com/gost-engine/engine
 	update = rebase
+
 [submodule "wycheproof"]
 	path = wycheproof
 	url = https://github.com/google/wycheproof
+
+[submodule "keyfile-corpus"]
+	path = keyfile-corpus
+	url = https://github.com/redhat-qe-security/keyfile-corpus.git

--- a/test/recipes/95-test_external_keyfiles.t
+++ b/test/recipes/95-test_external_keyfiles.t
@@ -1,0 +1,61 @@
+#! /usr/bin/env perl
+# Copyright 2015-2021 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+use File::Copy;
+use OpenSSL::Test;
+use OpenSSL::Test::Utils;
+use OpenSSL::Test qw/:DEFAULT data_file bldtop_dir bldtop_file srctop_dir srctop_file cmdstr/;
+
+setup("test_external_keyfiles");
+
+plan skip_all => "No external tests in this configuration"
+    if disabled("external-tests");
+
+my @p12_files = glob(srctop_file("keyfile-corpus", "*.p12"));
+
+# Skip malformed files
+@p12_files = grep(!/malformed/, @p12_files);
+
+# Skip files with separate cipher/mac passwords
+@p12_files = grep(!/pass-cipher/, @p12_files);
+
+# Skip files with an empty password - pkcs12 app cannot handle this
+@p12_files = grep(!/pass\(empty/, @p12_files);
+
+@p12_files = grep(!/MD2/, @p12_files) if disabled("md2");
+
+plan tests => scalar(@p12_files) * 2;
+
+my $fnum = 1;
+
+foreach my $p12 ( @p12_files ) {
+
+    my $passfile = srctop_file("keyfile-corpus", "password-ascii.txt");
+    my $provider_path = bldtop_dir("providers");
+
+    # Some files specify a different password
+    $passfile = srctop_file("keyfile-corpus", "password-unicode.txt") if $p12 =~ /pass\(unicode/;
+    $passfile = srctop_file("keyfile-corpus", "password-empty.txt") if $p12 =~ /pass\(empty/;
+
+    ok(copy($p12, "kf-$fnum.p12"));
+
+    ok(run(app(["openssl", "pkcs12",
+                 "-noout",
+                 #"-info",
+                 "-in", "kf-$fnum.p12",
+                 "-provider-path=$provider_path",
+                 "-provider", "legacy",
+                 "-provider", "default",
+                 #"-nokeys",  NOTE: pkcs12 app does not allow key password as an argument, yet.
+                 "-password", "file:$passfile"])),
+       "running openssl pkcs12 with file kf-$fnum.p12 ($p12)");
+
+    $fnum = $fnum + 1;
+}
+
+


### PR DESCRIPTION
Check that we can read/decode each of the PKCS#12 files in the repo:

https://github.com/redhat-qe-security/keyfile-corpus

The tests run as part of the external test suite. Keyfile-corpus is added as a git submodule which needs to be init'ed before the tests can be run (external test system does this).

Currently there are failures due to:

- RC2 AI encoding issue #15070
- A failure in a single file (keyfile-corpus/rsa(2048,sha256),cert&key(PBES2(PBKDF2(salt(8),iter(2048),keyLen(default),prf(default)),aes-128-cbc(IV(16)))),mac(sha1,salt(8),iter(2048)),pass(unicode,openssl-1.0.2k-1.fc24).p12), to be investigated.

Also, the tests are not yet comprehensive. They do not:

- Check any contents (e.g. certificates) against the reference data
- Decrypt and check private keys

The above would require either additions to the pkcs12 app or some other means of reading/verifying the files.

- [X] tests are added or updated
