### PR TITLE
apps: add mac, cipher and digest arguments to the kdf applet.

### DIFF
--- a/apps/kdf.c
+++ b/apps/kdf.c
@@ -59,9 +59,6 @@ static char *alloc_kdf_algorithm_name(STACK_OF(OPENSSL_STRING) **optp,
     if (*optp == NULL)
         return NULL;
 
-    res = app_malloc(len, "algorithm name");
-    if (res == NULL)
-        return NULL;
     BIO_snprintf(res, len, "%s:%s", name, arg);
     if (sk_OPENSSL_STRING_push(*optp, res))
         return res;

--- a/apps/kdf.c
+++ b/apps/kdf.c
@@ -107,16 +107,19 @@ opthelp:
                 goto opthelp;
             break;
         case OPT_CIPHER:
+            OPENSSL_free(cipher);
             cipher = alloc_kdf_algorithm_name(&opts, "cipher", opt_arg());
             if (cipher == NULL)
                 goto opthelp;
             break;
         case OPT_DIGEST:
+            OPENSSL_free(digest);
             digest = alloc_kdf_algorithm_name(&opts, "digest", opt_arg());
             if (digest == NULL)
                 goto opthelp;
             break;
         case OPT_MAC:
+            OPENSSL_free(mac);
             mac = alloc_kdf_algorithm_name(&opts, "mac", opt_arg());
             if (mac == NULL)
                 goto opthelp;

--- a/apps/kdf.c
+++ b/apps/kdf.c
@@ -20,6 +20,7 @@
 typedef enum OPTION_choice {
     OPT_COMMON,
     OPT_KDFOPT, OPT_BIN, OPT_KEYLEN, OPT_OUT,
+    OPT_CIPHER, OPT_DIGEST, OPT_MAC,
     OPT_PROV_ENUM
 } OPTION_CHOICE;
 
@@ -29,6 +30,9 @@ const OPTIONS kdf_options[] = {
     OPT_SECTION("General"),
     {"help", OPT_HELP, '-', "Display this summary"},
     {"kdfopt", OPT_KDFOPT, 's', "KDF algorithm control parameters in n:v form"},
+    {"cipher", OPT_CIPHER, 's', "Cipher"},
+    {"digest", OPT_DIGEST, 's', "Digest"},
+    {"mac", OPT_MAC, 's', "MAC"},
     {OPT_MORE_STR, 1, '-', "See 'Supported Controls' in the EVP_KDF_ docs\n"},
     {"keylen", OPT_KEYLEN, 's', "The size of the output derived key"},
 
@@ -44,6 +48,27 @@ const OPTIONS kdf_options[] = {
     {NULL}
 };
 
+static char *alloc_kdf_algorithm_name(STACK_OF(OPENSSL_STRING) **optp,
+                                      const char *name, const char *arg)
+{
+    size_t len = strlen(name) + strlen(arg) + 2;
+    char *res = app_malloc(len, "algorithm name");
+
+    if (*optp == NULL)
+        *optp = sk_OPENSSL_STRING_new_null();
+    if (*optp == NULL)
+        return NULL;
+
+    res = app_malloc(len, "algorithm name");
+    if (res == NULL)
+        return NULL;
+    BIO_snprintf(res, len, "%s:%s", name, arg);
+    if (sk_OPENSSL_STRING_push(*optp, res))
+        return res;
+    OPENSSL_free(res);
+    return NULL;
+}
+
 int kdf_main(int argc, char **argv)
 {
     int ret = 1, out_bin = 0;
@@ -56,6 +81,7 @@ int kdf_main(int argc, char **argv)
     BIO *out = NULL;
     EVP_KDF *kdf = NULL;
     EVP_KDF_CTX *ctx = NULL;
+    char *digest = NULL, *cipher = NULL, *mac = NULL;
 
     prog = opt_init(argc, argv, kdf_options);
     while ((o = opt_next()) != OPT_EOF) {
@@ -81,6 +107,21 @@ opthelp:
             if (opts == NULL)
                 opts = sk_OPENSSL_STRING_new_null();
             if (opts == NULL || !sk_OPENSSL_STRING_push(opts, opt_arg()))
+                goto opthelp;
+            break;
+        case OPT_CIPHER:
+            cipher = alloc_kdf_algorithm_name(&opts, "cipher", opt_arg());
+            if (cipher == NULL)
+                goto opthelp;
+            break;
+        case OPT_DIGEST:
+            digest = alloc_kdf_algorithm_name(&opts, "digest", opt_arg());
+            if (digest == NULL)
+                goto opthelp;
+            break;
+        case OPT_MAC:
+            mac = alloc_kdf_algorithm_name(&opts, "mac", opt_arg());
+            if (mac == NULL)
                 goto opthelp;
             break;
         case OPT_PROV_CASES:
@@ -161,5 +202,8 @@ err:
     EVP_KDF_CTX_free(ctx);
     BIO_free(out);
     OPENSSL_free(hexout);
+    OPENSSL_free(cipher);
+    OPENSSL_free(digest);
+    OPENSSL_free(mac);
     return ret;
 }

--- a/doc/man1/openssl-kdf.pod.in
+++ b/doc/man1/openssl-kdf.pod.in
@@ -9,6 +9,9 @@ openssl-kdf - perform Key Derivation Function operations
 
 B<openssl kdf>
 [B<-help>]
+[B<-cipher>]
+[B<-digest>]
+[B<-mac>]
 [B<-kdfopt> I<nm>:I<v>]
 [B<-keylen> I<num>]
 [B<-out> I<filename>]
@@ -40,6 +43,25 @@ Filename to output to, or standard output by default.
 =item B<-binary>
 
 Output the derived key in binary form. Uses hexadecimal text format if not specified.
+
+=item B<-cipher> I<name>
+
+Specify the cipher to be used by the KDF.
+Not all KDFs require a cipher and it is an error to use this option in such
+cases.
+
+=item B<-digest> I<name>
+
+Specify the digest to be used by the KDF.
+Not all KDFs require a digest and it is an error to use this option in such
+cases.
+To see the list of supported digests, use C<openssl list -digest-commands>.
+
+=item B<-mac> I<name>
+
+Specify the MAC to be used by the KDF.
+Not all KDFs require a MAC and it is an error to use this option in such
+cases.
 
 =item B<-kdfopt> I<nm>:I<v>
 
@@ -76,8 +98,15 @@ The password must be specified for PBKDF2 and scrypt.
 
 =item B<digest:>I<string>
 
-Specifies the name of a digest as an alphanumeric string.
-To see the list of supported digests, use the command I<list -digest-commands>.
+This option is identical to the B<-digest> option.
+
+=item B<cipher:>I<string>
+
+This option is identical to the B<-cipher> option.
+
+=item B<mac:>I<string>
+
+This option is identical to the B<-mac> option.
 
 =back
 

--- a/test/recipes/20-test_kdf.t
+++ b/test/recipes/20-test_kdf.t
@@ -16,6 +16,32 @@ use OpenSSL::Test::Utils;
 setup("test_kdf");
 
 my @kdf_tests = (
+    { cmd => [qw{openssl kdf -keylen 16 -digest SHA256 -kdfopt secret:secret -kdfopt seed:seed TLS1-PRF}],
+      expected => '8E:4D:93:25:30:D7:65:A0:AA:E9:74:C3:04:73:5E:CC',
+      desc => 'TLS1-PRF SHA256' },
+    { cmd => [qw{openssl kdf -keylen 16 -digest MD5-SHA1 -kdfopt secret:secret -kdfopt seed:seed TLS1-PRF}],
+      expected => '65:6F:31:CB:04:03:D6:51:E2:E8:71:F8:20:04:AB:BA',
+      desc => 'TLS1-PRF MD5-SHA1' },
+    { cmd => [qw{openssl kdf -keylen 10 -digest SHA256 -kdfopt key:secret -kdfopt salt:salt -kdfopt info:label HKDF}],
+      expected => '2a:c4:36:9f:52:59:96:f8:de:13',
+      desc => 'HKDF SHA256' },
+    { cmd => [qw{openssl kdf -keylen 25 -digest SHA256 -kdfopt pass:passwordPASSWORDpassword -kdfopt salt:saltSALTsaltSALTsaltSALTsaltSALTsalt -kdfopt iter:4096 PBKDF2}],
+      expected => '34:8C:89:DB:CB:D3:2B:2F:32:D8:14:B8:11:6E:84:CF:2B:17:34:7E:BC:18:00:18:1C',
+      desc => 'PBKDF2 SHA256'},
+    { cmd => [qw{openssl kdf -keylen 64 -mac KMAC128 -kdfopt maclen:20 -kdfopt hexkey:b74a149a161546f8c20b06ac4ed4 -kdfopt hexinfo:348a37a27ef1282f5f020dcc -kdfopt hexsalt:3638271ccd68a25dc24ecddd39ef3f89 SSKDF}],
+      expected => 'e9:c1:84:53:a0:62:b5:3b:db:fc:bb:5a:34:bd:b8:e5:e7:07:ee:bb:5d:d1:34:42:43:d8:cf:c2:c2:e6:33:2f:91:bd:a5:86:f3:7d:e4:8a:65:d4:c5:14:fd:ef:aa:1e:67:54:f3:73:d2:38:e1:95:ae:15:7e:1d:e8:14:98:03',
+      desc => 'SSKDF KMAC128'},
+    { cmd => [qw{openssl kdf -keylen 16 -mac HMAC -digest SHA256 -kdfopt hexkey:b74a149a161546f8c20b06ac4ed4 -kdfopt hexinfo:348a37a27ef1282f5f020dcc -kdfopt hexsalt:3638271ccd68a25dc24ecddd39ef3f89 SSKDF}],
+      expected => '44:f6:76:e8:5c:1b:1a:8b:bc:3d:31:92:18:63:1c:a3',
+      desc => 'SSKDF HMAC SHA256'},
+    { cmd => [qw{openssl kdf -keylen 14 -digest SHA224 -kdfopt hexkey:6dbdc23f045488e4062757b06b9ebae183fc5a5946d80db93fec6f62ec07e3727f0126aed12ce4b262f47d48d54287f81d474c7c3b1850e9 -kdfopt hexinfo:a1b2c3d4e54341565369643c832e9849dcdba71e9a3139e606e095de3c264a66e98a165854cd07989b1ee0ec3f8dbe SSKDF}],
+      expected => 'a4:62:de:16:a8:9d:e8:46:6e:f5:46:0b:47:b8',
+      desc => 'SSKDF HASH SHA224'},
+    { cmd => [qw{openssl kdf -keylen 16 -digest SHA256 -kdfopt hexkey:0102030405 -kdfopt hexxcghash:06090A -kdfopt hexsession_id:01020304 -kdfopt type:A SSHKDF}],
+    expected => '5C:49:94:47:3B:B1:53:3A:58:EB:19:42:04:D3:78:16',
+    desc => 'SSHKDF SHA256'},
+
+    # Using the -kdfopt digest: option instead of -digest
     { cmd => [qw{openssl kdf -keylen 16 -kdfopt digest:SHA256 -kdfopt secret:secret -kdfopt seed:seed TLS1-PRF}],
       expected => '8E:4D:93:25:30:D7:65:A0:AA:E9:74:C3:04:73:5E:CC',
       desc => 'TLS1-PRF SHA256' },
@@ -28,10 +54,10 @@ my @kdf_tests = (
     { cmd => [qw{openssl kdf -keylen 25 -kdfopt digest:SHA256 -kdfopt pass:passwordPASSWORDpassword -kdfopt salt:saltSALTsaltSALTsaltSALTsaltSALTsalt -kdfopt iter:4096 PBKDF2}],
       expected => '34:8C:89:DB:CB:D3:2B:2F:32:D8:14:B8:11:6E:84:CF:2B:17:34:7E:BC:18:00:18:1C',
       desc => 'PBKDF2 SHA256'},
-    { cmd => [qw{openssl kdf -keylen 64 -kdfopt mac:KMAC128 -kdfopt maclen:20 -kdfopt hexkey:b74a149a161546f8c20b06ac4ed4 -kdfopt hexinfo:348a37a27ef1282f5f020dcc -kdfopt hexsalt:3638271ccd68a25dc24ecddd39ef3f89 SSKDF}],
+    { cmd => [qw{openssl kdf -keylen 64 -mac KMAC128 -kdfopt maclen:20 -kdfopt hexkey:b74a149a161546f8c20b06ac4ed4 -kdfopt hexinfo:348a37a27ef1282f5f020dcc -kdfopt hexsalt:3638271ccd68a25dc24ecddd39ef3f89 SSKDF}],
       expected => 'e9:c1:84:53:a0:62:b5:3b:db:fc:bb:5a:34:bd:b8:e5:e7:07:ee:bb:5d:d1:34:42:43:d8:cf:c2:c2:e6:33:2f:91:bd:a5:86:f3:7d:e4:8a:65:d4:c5:14:fd:ef:aa:1e:67:54:f3:73:d2:38:e1:95:ae:15:7e:1d:e8:14:98:03',
       desc => 'SSKDF KMAC128'},
-    { cmd => [qw{openssl kdf -keylen 16 -kdfopt mac:HMAC -kdfopt digest:SHA256 -kdfopt hexkey:b74a149a161546f8c20b06ac4ed4 -kdfopt hexinfo:348a37a27ef1282f5f020dcc -kdfopt hexsalt:3638271ccd68a25dc24ecddd39ef3f89 SSKDF}],
+    { cmd => [qw{openssl kdf -keylen 16 -mac HMAC -kdfopt digest:SHA256 -kdfopt hexkey:b74a149a161546f8c20b06ac4ed4 -kdfopt hexinfo:348a37a27ef1282f5f020dcc -kdfopt hexsalt:3638271ccd68a25dc24ecddd39ef3f89 SSKDF}],
       expected => '44:f6:76:e8:5c:1b:1a:8b:bc:3d:31:92:18:63:1c:a3',
       desc => 'SSKDF HMAC SHA256'},
     { cmd => [qw{openssl kdf -keylen 14 -kdfopt digest:SHA224 -kdfopt hexkey:6dbdc23f045488e4062757b06b9ebae183fc5a5946d80db93fec6f62ec07e3727f0126aed12ce4b262f47d48d54287f81d474c7c3b1850e9 -kdfopt hexinfo:a1b2c3d4e54341565369643c832e9849dcdba71e9a3139e606e095de3c264a66e98a165854cd07989b1ee0ec3f8dbe SSKDF}],
@@ -40,6 +66,14 @@ my @kdf_tests = (
     { cmd => [qw{openssl kdf -keylen 16 -kdfopt digest:SHA256 -kdfopt hexkey:0102030405 -kdfopt hexxcghash:06090A -kdfopt hexsession_id:01020304 -kdfopt type:A SSHKDF}],
     expected => '5C:49:94:47:3B:B1:53:3A:58:EB:19:42:04:D3:78:16',
     desc => 'SSHKDF SHA256'},
+
+    # Additionally using -kdfopt mac: instead of -mac
+    { cmd => [qw{openssl kdf -keylen 64 -kdfopt mac:KMAC128 -kdfopt maclen:20 -kdfopt hexkey:b74a149a161546f8c20b06ac4ed4 -kdfopt hexinfo:348a37a27ef1282f5f020dcc -kdfopt hexsalt:3638271ccd68a25dc24ecddd39ef3f89 SSKDF}],
+      expected => 'e9:c1:84:53:a0:62:b5:3b:db:fc:bb:5a:34:bd:b8:e5:e7:07:ee:bb:5d:d1:34:42:43:d8:cf:c2:c2:e6:33:2f:91:bd:a5:86:f3:7d:e4:8a:65:d4:c5:14:fd:ef:aa:1e:67:54:f3:73:d2:38:e1:95:ae:15:7e:1d:e8:14:98:03',
+      desc => 'SSKDF KMAC128'},
+    { cmd => [qw{openssl kdf -keylen 16 -kdfopt mac:HMAC -kdfopt digest:SHA256 -kdfopt hexkey:b74a149a161546f8c20b06ac4ed4 -kdfopt hexinfo:348a37a27ef1282f5f020dcc -kdfopt hexsalt:3638271ccd68a25dc24ecddd39ef3f89 SSKDF}],
+      expected => '44:f6:76:e8:5c:1b:1a:8b:bc:3d:31:92:18:63:1c:a3',
+      desc => 'SSKDF HMAC SHA256'},
 );
 
 my @scrypt_tests = (


### PR DESCRIPTION
This adds -digest, -mac and -cipher options to reduce the use of -kdfopt

- [x] documentation is added or updated
- [x] tests are added or updated
