### PR TITLE
Reduce the runtime/output from the gmdiff test

### DIFF
--- a/test/gmdifftest.c
+++ b/test/gmdifftest.c
@@ -49,10 +49,12 @@ static int check_time(long offset)
 
 static int test_gmtime(int offset)
 {
-    return check_time(offset) &&
-           check_time(-offset) &&
-           check_time(offset * 1000L) &&
-           check_time(-offset * 1000L);
+    return check_time(offset)
+           && check_time(-offset)
+           && check_time(offset * 1000L)
+           && check_time(-offset * 1000L)
+           && check_time(offset * 1000000L)
+           && check_time(-offset * 1000000L);
 }
 
 int setup_tests(void)
@@ -60,6 +62,6 @@ int setup_tests(void)
     if (sizeof(time_t) < 8)
         TEST_info("Skipping; time_t is less than 64-bits");
     else
-        ADD_ALL_TESTS_NOSUBTEST(test_gmtime, 1000000);
+        ADD_ALL_TESTS_NOSUBTEST(test_gmtime, 1000);
     return 1;
 }


### PR DESCRIPTION
Reduce from 1e6 iterations to 1e3.  Add additional cases to cover the same range although most intermediate values will be skipped.

40+ Mbytes of output in verbose mode seems excessive.  This reduces the output to about 40kbytes.

Fixes #15185

- [ ] documentation is added or updated
- [x] tests are added or updated
