### PR TITLE
Fix -static builds on master

### DIFF
--- a/Configure
+++ b/Configure
@@ -1386,6 +1386,10 @@ foreach (keys %useradd) {
 # At this point, we can forget everything about %user and %useradd,
 # because it's now all been merged into the corresponding $config entry
 
+if (grep { $_ =~ /(?:^|\s)-static(?:\s|$)/ } @{$config{LDFLAGS}}) {
+    disable('static', 'pic', 'threads');
+}
+
 # Allow overriding the build file name
 $config{build_file} = env('BUILDFILE') || $target{build_file} || "Makefile";
 
@@ -1673,10 +1677,6 @@ if ($strict_warnings)
                 warn "WARNING --strict-warnings requires gcc[>=4] or gcc-alike, or MSVC"
                 }
         }
-
-if (grep { $_ =~ /(?:^|\s)-static(?:\s|$)/ } @{$config{LDFLAGS}}) {
-    disable('static', 'pic', 'threads');
-}
 
 $config{CFLAGS} = [ map { $_ eq '--ossl-strict-warnings'
                               ? @strict_warnings_collection


### PR DESCRIPTION
Pull in Todd Short's fix cfd7225fbb from 1.1.1, which moves the disabling
of pic, threads and statics to before they are checked.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->
