### PR TITLE
Fix missing $CPUIDDEF in libdefault.a

### DIFF
--- a/crypto/build.info
+++ b/crypto/build.info
@@ -81,6 +81,7 @@ ENDIF
 # Implementations are now spread across several libraries, so the CPUID define
 # need to be applied to all affected libraries and modules.
 DEFINE[../providers/libcommon.a]=$CPUIDDEF
+DEFINE[../providers/libdefault.a]=$CPUIDDEF
 
 # The Core
 $CORE_COMMON=provider_core.c provider_predefined.c \


### PR DESCRIPTION
This fixes a build error caused by missing $CPUIDDEF when
compiling libdefault.a, and some functions(like armv8_aes_gcm_encrypt)
become undefined.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
