### PR TITLE
80-test_cmp_http.t: Improve fuzzing exclusion pattern - fixup!

### DIFF
--- a/test/recipes/80-test_cmp_http.t
+++ b/test/recipes/80-test_cmp_http.t
@@ -22,7 +22,7 @@ use lib srctop_dir('Configurations');
 use lib bldtop_dir('.');
 
 plan skip_all => "These tests are not supported in a fuzz build"
-    if config('options') =~ /-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION|fuzz-afl/;
+    if config('options') =~ /-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION|enable-fuzz-afl/;
 
 plan skip_all => "These tests are not supported in a no-cmp build"
     if disabled("cmp");


### PR DESCRIPTION
It turns out that my fix in #15158 was wrong - it lead to disabling `test_cmp_http` unconditionally.

This now correctly fixes #14966.

- [x] tests are added or updated
