### PR TITLE
Improve CMP HTTP test server

### DIFF
--- a/apps/cmp_mock_srv.c
+++ b/apps/cmp_mock_srv.c
@@ -251,7 +251,8 @@ static OSSL_CMP_PKISI *process_rr(OSSL_CMP_SRV_CTX *srv_ctx,
     if (X509_NAME_cmp(issuer, X509_get_issuer_name(ctx->certOut)) != 0
             || ASN1_INTEGER_cmp(serial,
                                 X509_get0_serialNumber(ctx->certOut)) != 0) {
-        ERR_raise(ERR_LIB_CMP, CMP_R_REQUEST_NOT_ACCEPTED);
+        ERR_raise_data(ERR_LIB_CMP, CMP_R_REQUEST_NOT_ACCEPTED,
+                       "wrong certificate to revoke");
         return NULL;
     }
     return OSSL_CMP_PKISI_dup(ctx->statusOut);

--- a/apps/include/http_server.h
+++ b/apps/include/http_server.h
@@ -38,9 +38,11 @@
 #  undef LOG_INFO
 #  undef LOG_WARNING
 #  undef LOG_ERR
-#  define LOG_INFO      0
-#  define LOG_WARNING   1
-#  define LOG_ERR       2
+#  undef LOG_DEBUG
+#  define LOG_ERR       3
+#  define LOG_WARNING   4
+#  define LOG_INFO      6
+#  define LOG_DEBUG     7
 # endif
 
 /*-

--- a/crypto/cmp/cmp_server.c
+++ b/crypto/cmp/cmp_server.c
@@ -588,6 +588,7 @@ OSSL_CMP_MSG *OSSL_CMP_SRV_process_request(OSSL_CMP_SRV_CTX *srv_ctx,
             OSSL_CMP_PKISI_free(si);
         }
     }
+    OSSL_CMP_CTX_print_errors(ctx);
     ctx->secretValue = backup_secret;
 
     /* possibly close the transaction */

--- a/crypto/cmp/cmp_server.c
+++ b/crypto/cmp/cmp_server.c
@@ -581,7 +581,7 @@ OSSL_CMP_MSG *OSSL_CMP_SRV_process_request(OSSL_CMP_SRV_CTX *srv_ctx,
         }
 
         if ((si = OSSL_CMP_STATUSINFO_new(OSSL_CMP_PKISTATUS_rejection,
-                                          fail_info, NULL)) != NULL) {
+                                          fail_info, data)) != NULL) {
             if (err != 0 && (flags & ERR_TXT_STRING) != 0)
                 data = ERR_reason_error_string(err);
             rsp = ossl_cmp_error_new(srv_ctx->ctx, si,


### PR DESCRIPTION
This is a further excerpt from #15053 to ease reviewing.

* CMP test server: Extend error reporting on cert rejected for revocation
* HTTP test server: Improve connection management and logging
* `cmp_server.c`: Improve transaction management and logging
* `OSSL_CMP_SRV_process_request()`: Log any error queue entries, which also increases stability

