### PR TITLE
Makefile: speed up 'make ordinals' and 'make update'

### DIFF
--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -1130,44 +1130,67 @@ md-nits:
 lint:
 	lint -DLINT $(INCLUDES) $(SRCS)
 
-generate_apps:
+$(SRCDIR)/apps/openssl-vms.cnf: $(SRCDIR)/apps/openssl.cnf
 	( cd $(SRCDIR); $(PERL) VMS/VMSify-conf.pl \
 				< apps/openssl.cnf > apps/openssl-vms.cnf )
+.PHONY: generate_apps
+generate_apps: $(SRCDIR)/apps/openssl-vms.cnf
 
-generate_crypto_bn:
+$(SRCDIR)/crypto/bn/bn_prime.h: $(SRCDIR)/crypto/bn/bn_prime.pl
 	( cd $(SRCDIR); $(PERL) crypto/bn/bn_prime.pl > crypto/bn/bn_prime.h )
+.PHONY: generate_crypto_bn
+generate_crypto_bn: $(SRCDIR)/crypto/bn/bn_prime.h
 
-generate_crypto_objects:
+$(SRCDIR)/crypto/objects/obj_mac.num: $(SRCDIR)/crypto/objects/objects.pl \
+                                      $(SRCDIR)/crypto/objects/objects.txt
 	( cd $(SRCDIR); $(PERL) crypto/objects/objects.pl -n \
 				crypto/objects/objects.txt \
 				crypto/objects/obj_mac.num \
 				> crypto/objects/obj_mac.new && \
 	    mv crypto/objects/obj_mac.new crypto/objects/obj_mac.num )
+$(SRCDIR)/include/openssl/obj_mac.h: $(SRCDIR)/crypto/objects/objects.pl \
+                                     $(SRCDIR)/crypto/objects/obj_dat.pl \
+                                     $(SRCDIR)/crypto/objects/obj_mac.num \
+                                     $(SRCDIR)/crypto/objects/obj_compat.h
 	( cd $(SRCDIR); $(PERL) crypto/objects/objects.pl \
 				crypto/objects/objects.txt \
 				crypto/objects/obj_mac.num \
-				> include/openssl/obj_mac.h )
-	( cd $(SRCDIR); $(PERL) crypto/objects/obj_dat.pl \
+				> include/openssl/obj_mac.h && \
+			$(PERL) crypto/objects/obj_dat.pl \
 				include/openssl/obj_mac.h \
-				> crypto/objects/obj_dat.h )
+				> crypto/objects/obj_dat.h && \
+			sed -e '1,8d' crypto/objects/obj_compat.h \
+				>> include/openssl/obj_mac.h )
+$(SRCDIR)/crypto/objects/obj_dat.h: $(SRCDIR)/include/openssl/obj_mac.h
+$(SRCDIR)/crypto/objects/obj_xref.h: $(SRCDIR)/crypto/objects/objxref.pl \
+                                     $(SRCDIR)/crypto/objects/obj_mac.num \
+                                     $(SRCDIR)/crypto/objects/obj_xref.txt
 	( cd $(SRCDIR); $(PERL) crypto/objects/objxref.pl \
 				crypto/objects/obj_mac.num \
 				crypto/objects/obj_xref.txt \
 				> crypto/objects/obj_xref.h )
-	( cd $(SRCDIR);	sed -e '1,8d' crypto/objects/obj_compat.h >> include/openssl/obj_mac.h )
+.PHONY: generate_crypto_objects
+generate_crypto_objects: $(SRCDIR)/crypto/objects/obj_dat.h \
+                         $(SRCDIR)/crypto/objects/obj_xref.h
 
-generate_crypto_conf:
+$(SRCDIR)/crypto/conf/conf_def.h: $(SRCDIR)/crypto/conf/keysets.pl
 	( cd $(SRCDIR); $(PERL) crypto/conf/keysets.pl \
 			        > crypto/conf/conf_def.h )
+.PHONY: generate_crypto_conf
+generate_crypto_conf: $(SRCDIR)/crypto/conf/conf_def.h
 
-generate_crypto_asn1:
+$(SRCDIR)/crypto/asn1/charmap.h: $(SRCDIR)/crypto/asn1/charmap.pl
 	( cd $(SRCDIR); $(PERL) crypto/asn1/charmap.pl \
 			        > crypto/asn1/charmap.h )
+.PHONY: generate_crypto_asn1
+generate_crypto_asn1: $(SRCDIR)/crypto/asn1/charmap.h
 
-generate_fuzz_oids:
+$(SRCDIR)/fuzz/oids.txt: $(SRCDIR)/fuzz/mkfuzzoids.pl $(SRCDIR)/crypto/objects/obj_dat.h
 	( cd $(SRCDIR); $(PERL) fuzz/mkfuzzoids.pl \
 				crypto/objects/obj_dat.h \
 				> fuzz/oids.txt )
+.PHONY: generate_fuzz_oids
+generate_fuzz_oids: $(SRCDIR)/fuzz/oids.txt
 
 generate_doc_buildinfo:
 	( $(PERL) -I$(BLDDIR) -Mconfigdata \

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -1320,15 +1320,18 @@ renumber: build_generated
                 --renumber \
                 $(SSLHEADERS)
 
-ordinals: build_generated
+$(SRCDIR)/util/libcrypto.num: $(CRYPTOHEADERS) $(SRCDIR)/include/openssl/symhacks.h
 	$(PERL) $(SRCDIR)/util/mknum.pl --version $(VERSION_NUMBER) --no-warnings \
                 --ordinals $(SRCDIR)/util/libcrypto.num \
                 --symhacks $(SRCDIR)/include/openssl/symhacks.h \
                 $(CRYPTOHEADERS)
+$(SRCDIR)/util/libssl.num: $(SSLHEADERS) $(SRCDIR)/include/openssl/symhacks.h
 	$(PERL) $(SRCDIR)/util/mknum.pl --version $(VERSION_NUMBER) --no-warnings \
                 --ordinals $(SRCDIR)/util/libssl.num \
                 --symhacks $(SRCDIR)/include/openssl/symhacks.h \
                 $(SSLHEADERS)
+.PHONY: ordinals
+ordinals: build_generated $(SRCDIR)/util/libcrypto.num $(SRCDIR)/util/libssl.num
 
 test_ordinals:
 	$(MAKE) run_tests TESTS=test_ordinals

--- a/crypto/objects/obj_dat.c
+++ b/crypto/objects/obj_dat.c
@@ -20,7 +20,7 @@
 #include "crypto/asn1.h"
 #include "obj_local.h"
 
-/* obj_dat.h is generated from objects.h by obj_dat.pl */
+/* obj_dat.h is generated from objects.txt and obj_mac.{num,h} by obj_dat.pl */
 #include "obj_dat.h"
 
 DECLARE_OBJ_BSEARCH_CMP_FN(const ASN1_OBJECT *, unsigned int, sn);


### PR DESCRIPTION
`make ordinals` so far is awkward to use because it unconditionally calls `mknum.pl`, which is very inefficient.
This is particularly annoying if `make update` etc. needs to be called often. 

This PR makes sure that `mknum.pl` gets called only if one of its input files changes.
