### PR TITLE
EVP_PKEY-X25519.pod: Correct EVP_PKEY_Q_keygen function name in example

### DIFF
--- a/doc/man7/EVP_PKEY-X25519.pod
+++ b/doc/man7/EVP_PKEY-X25519.pod
@@ -86,7 +86,7 @@ An B<EVP_PKEY> context can be obtained by calling:
 
 An B<X25519> key can be generated like this:
 
-    pkey = EVP_Q_keygen(NULL, NULL, "X25519");
+    pkey = EVP_PKEY_Q_keygen(NULL, NULL, "X25519");
 
 An B<X448>, B<ED25519>, or B<ED448> key can be generated likewise.
 


### PR DESCRIPTION
doc nit fixup for #14695

- [x] documentation is added or updated

