### PR TITLE
Separate fips checksums from make update and apply label on PRs

### DIFF
--- a/.github/workflows/checksums.yml
+++ b/.github/workflows/checksums.yml
@@ -41,11 +41,10 @@ jobs:
         run: make update-fips-checksums
         working-directory: ./build-pristine
       - name: make diff-fips-checksums
-        run: make diff-fips-checksums
+        run: make diff-fips-checksums || echo "fips_changed=1" >> $GITHUB_ENV
         working-directory: ./build
-        continue-on-error: true
       - name: set label
-        if: ${{ failure() }}
+        if: ${{ env.fips_changed }}
         uses: actions/github-script@v4
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/checksums.yml
+++ b/.github/workflows/checksums.yml
@@ -43,6 +43,7 @@ jobs:
       - name: make diff-fips-checksums
         run: make diff-fips-checksums
         working-directory: ./build
+        continue-on-error: true
       - name: set label
         if: ${{ failure() }}
         uses: actions/github-script@v4

--- a/.github/workflows/checksums.yml
+++ b/.github/workflows/checksums.yml
@@ -27,6 +27,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          clean: false
       - name: config
         run: ../config enable-fips && perl configdata.pm --dump
         working-directory: ./build

--- a/.github/workflows/checksums.yml
+++ b/.github/workflows/checksums.yml
@@ -10,7 +10,7 @@ jobs:
             sudo apt-get -yq --no-install-suggests --no-install-recommends --force-yes install unifdef
       - uses: actions/checkout@v2
         with:
-          ref: master
+          ref: ${{ github.event.pull_request.base.sha }}
       - name: create build dirs
         run: |
           mkdir ./build-pristine

--- a/.github/workflows/checksums.yml
+++ b/.github/workflows/checksums.yml
@@ -41,7 +41,7 @@ jobs:
         run: make update-fips-checksums
         working-directory: ./build-pristine
       - name: make diff-fips-checksums
-        run: make diff-fips-checksums || echo "fips_changed=1" >> $GITHUB_ENV
+        run: make diff-fips-checksums && echo "fips_unchanged=1" >> $GITHUB_ENV || echo "fips_changed=1" >> $GITHUB_ENV
         working-directory: ./build
       - name: set label
         if: ${{ env.fips_changed }}
@@ -54,4 +54,16 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               labels: ['severity: fips change']
+            })
+      - name: remove label
+        if: ${{ env.fips_unchanged }}
+        uses: actions/github-script@v4
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            github.issues.removeLabel({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: 'severity: fips change'
             })

--- a/.github/workflows/checksums.yml
+++ b/.github/workflows/checksums.yml
@@ -43,14 +43,15 @@ jobs:
       - name: make diff-fips-checksums
         run: make diff-fips-checksums
         working-directory: ./build
-
-#      - uses: actions/github-script@v4
-#        with:
-#          github-token: ${{secrets.GITHUB_TOKEN}}
-#          script: |
-#            github.issues.addLabels({
-#              issue_number: context.issue.number,
-#              owner: context.repo.owner,
-#              repo: context.repo.repo,
-#              labels: ['Triage']
-#            })
+      - name: set label
+        if: ${{ failure() }}
+        uses: actions/github-script@v4
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            github.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ['severity: fips change']
+            })

--- a/.github/workflows/checksums.yml
+++ b/.github/workflows/checksums.yml
@@ -1,0 +1,55 @@
+name: FIPS Checksums
+on: [pull_request]
+jobs:
+  apply-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: install unifdef
+        run: |
+            sudo apt-get update
+            sudo apt-get -yq --no-install-suggests --no-install-recommends --force-yes install unifdef
+      - uses: actions/checkout@v2
+        with:
+          ref: master
+      - name: create build dirs
+        run: |
+          mkdir ./build-pristine
+          mkdir ./build
+      - name: config pristine
+        run: ../config enable-fips && perl configdata.pm --dump
+        working-directory: ./build-pristine
+      - name: make build_generated pristine
+        run: make -s build_generated
+        working-directory: ./build-pristine
+      - name: make fips-checksums pristine
+        run: make fips-checksums
+        working-directory: ./build-pristine
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: config
+        run: ../config enable-fips && perl configdata.pm --dump
+        working-directory: ./build
+      - name: make build_generated
+        run: make -s build_generated
+        working-directory: ./build
+      - name: make fips-checksums
+        run: make fips-checksums
+        working-directory: ./build
+      - name: update checksums pristine
+        run: make update-fips-checksums
+        working-directory: ./build-pristine
+      - name: make diff-fips-checksums
+        run: make diff-fips-checksums
+        working-directory: ./build
+
+#      - uses: actions/github-script@v4
+#        with:
+#          github-token: ${{secrets.GITHUB_TOKEN}}
+#          script: |
+#            github.issues.addLabels({
+#              issue_number: context.issue.number,
+#              owner: context.repo.owner,
+#              repo: context.repo.repo,
+#              labels: ['Triage']
+#            })

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -1137,8 +1137,8 @@ generate_doc_buildinfo:
                 mv $(SRCDIR)/doc/build.info.new $(SRCDIR)/doc/build.info; \
           fi )
 
-generate_fips_sources: providers/fips.module.sources
-providers/fips.module.sources: \
+generate_fips_sources: providers/fips.module.sources.new
+providers/fips.module.sources.new: \
                 $(SRCDIR)/Configure \
                 {- join(" \\\n" . ' ' x 16,
                         fill_lines(" ", $COLUMNS - 16,
@@ -1167,7 +1167,7 @@ providers/fips.module.sources: \
 		   crypto/sha/asm/*.pl; do \
 	    echo "$$x"; \
 	  done \
-	) | sort | uniq > providers/fips.module.sources
+	) | sort | uniq > providers/fips.module.sources.new
 	rm -rf sources-tmp
 
 # Set to -force to force a rebuild
@@ -1268,29 +1268,25 @@ fips-checksums: generate_fips_sources
 	@which unifdef > /dev/null || \
 	( echo >&2 "ERROR: unifdef not in your \$$PATH, FIPS checksums not calculated"; \
 	  false )
-	( sources=`pwd`/providers/fips.module.sources; \
+	( sources=`pwd`/providers/fips.module.sources.new; \
 	  cd $(SRCDIR) \
 	  && cat $$sources \
 	         | xargs ./util/fips-checksums.sh ) \
-	         > providers/fips-sources.checksums \
-	&& sha256sum providers/fips-sources.checksums \
-	     > providers/fips.checksum
+	         > providers/fips-sources.checksums.new \
+	&& sha256sum providers/fips-sources.checksums.new \
+	     > providers/fips.checksum.new
 
-$(SRCDIR)/providers/fips.checksum: providers/fips.checksum
-	cp -p providers/fips.module.sources \
-	    providers/fips-sources.checksums \
-	    providers/fips.checksum $(SRCDIR)/providers
+$(SRCDIR)/providers/fips.checksum: providers/fips.checksum.new
+	cp -p providers/fips.module.sources.new $(SRCDIR)/providers/fips.module.sources
+	cp -p providers/fips-sources.checksums.new $(SRCDIR)/providers/fips-sources.checksums
+	cp -p providers/fips.checksum.new $(SRCDIR)/providers/fips.checksum
 
 update-fips-checksums: $(SRCDIR)/providers/fips.checksum
 
 diff-fips-checksums: fips-checksums
-	@if [ "$(SRCDIR)" = "$(BLDDIR)" ]; then \
-	    echo >&2 "Nothing to diff as the build and the source tree is the same"; \
-	    false; \
-	fi
-	diff -u $(SRCDIR)/providers/fips.module.sources providers/fips.module.sources
-	diff -u $(SRCDIR)/providers/fips-sources.checksums providers/fips-sources.checksums
-	diff -u $(SRCDIR)/providers/fips.checksum providers/fips.checksum
+	diff -u $(SRCDIR)/providers/fips.module.sources providers/fips.module.sources.new
+	diff -u $(SRCDIR)/providers/fips-sources.checksums providers/fips-sources.checksums.new
+	diff -u $(SRCDIR)/providers/fips.checksum providers/fips.checksum.new
 
 # Release targets (note: only available on Unix) #####################
 

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -1055,9 +1055,6 @@ uninstall_html_docs:
 # It's important that generate_buildinfo comes after ordinals, as ordinals
 # is sensitive to build.info changes.
 update: generate errors ordinals generate_buildinfo
-{- output_off() if $disabled{fips}; "" -}
-update: fips-checksums
-{- output_on() if $disabled{fips}; "" -}
 
 generate: generate_apps generate_crypto_bn generate_crypto_objects \
           generate_crypto_conf generate_crypto_asn1 generate_fuzz_oids
@@ -1140,9 +1137,8 @@ generate_doc_buildinfo:
                 mv $(SRCDIR)/doc/build.info.new $(SRCDIR)/doc/build.info; \
           fi )
 
-{- output_off() if $disabled{fips}; "" -}
-generate_fips_sources: $(SRCDIR)/providers/fips.module.sources
-$(SRCDIR)/providers/fips.module.sources: \
+generate_fips_sources: providers/fips.module.sources
+providers/fips.module.sources: \
                 $(SRCDIR)/Configure \
                 {- join(" \\\n" . ' ' x 16,
                         fill_lines(" ", $COLUMNS - 16,
@@ -1171,9 +1167,8 @@ $(SRCDIR)/providers/fips.module.sources: \
 		   crypto/sha/asm/*.pl; do \
 	    echo "$$x"; \
 	  done \
-	) | sort | uniq > $(SRCDIR)/providers/fips.module.sources
+	) | sort | uniq > providers/fips.module.sources
 	rm -rf sources-tmp
-{- output_on() if $disabled{fips}; "" -}
 
 # Set to -force to force a rebuild
 ERROR_REBUILD=
@@ -1269,19 +1264,24 @@ tags TAGS: FORCE
 	-ctags -R .
 	-etags `find . -name '*.[ch]' -o -name '*.pm'`
 
-{- output_off() if $disabled{fips}; "" -}
 fips-checksums: generate_fips_sources
-	if which unifdef > /dev/null; then \
-	    ( cd $(SRCDIR) \
-	      && cat providers/fips.module.sources \
-	             | xargs ./util/fips-checksums.sh \
-	             > providers/fips-sources.checksums \
-	      && sha256sum providers/fips-sources.checksums \
-	             > providers/fips.checksum ); \
-	else \
-	    echo >&2 "WARNING: unifdef not in your \$$PATH, FIPS checksums not calculated"; \
-	fi
-{- output_on() if $disabled{fips}; "" -}
+	@which unifdef > /dev/null || \
+	( echo >&2 "ERROR: unifdef not in your \$$PATH, FIPS checksums not calculated"; \
+	  false )
+	( sources=`pwd`/providers/fips.module.sources; \
+	  cd $(SRCDIR) \
+	  && cat $$sources \
+	         | xargs ./util/fips-checksums.sh ) \
+	         > providers/fips-sources.checksums \
+	&& sha256sum providers/fips-sources.checksums \
+	     > providers/fips.checksum
+
+$(SRCDIR)/providers/fips.checksum: providers/fips.checksum
+	cp -p providers/fips.module.sources \
+	    providers/fips-sources.checksums \
+	    providers/fips.checksum $(SRCDIR)/providers
+
+update-fips-checksums: $(SRCDIR)/providers/fips.checksum
 
 # Release targets (note: only available on Unix) #####################
 

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -1283,6 +1283,15 @@ $(SRCDIR)/providers/fips.checksum: providers/fips.checksum
 
 update-fips-checksums: $(SRCDIR)/providers/fips.checksum
 
+diff-fips-checksums: fips-checksums
+	@if [ "$(SRCDIR)" = "$(BLDDIR)" ]; then \
+	    echo >&2 "Nothing to diff as the build and the source tree is the same"; \
+	    false; \
+	fi
+	diff -u $(SRCDIR)/providers/fips.module.sources providers/fips.module.sources
+	diff -u $(SRCDIR)/providers/fips-sources.checksums providers/fips-sources.checksums
+	diff -u $(SRCDIR)/providers/fips.checksum providers/fips.checksum
+
 # Release targets (note: only available on Unix) #####################
 
 tar:

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -668,7 +668,7 @@ int OSSL_provider_init(const OSSL_CORE_HANDLE *handle,
 
     if (!fips_get_params_from_core(fgbl)) {
         /* Error already raised */
-        return 0;
+        goto err;
     }
     /*
      * Disable the conditional error check if it's disabled in the fips config


### PR DESCRIPTION
This adds a new CI run that performs the fips checksum checks and applies a label `severity: fips change` to the PR if it modifies the FIPS sources.

There is a small fips provider fix included to demonstrate the action. 

As the master does not have the necessary make targets merged it won't work properly on this PR. To check that it works I've done PR on my personal fork repo here:
https://github.com/t8m/openssl/pull/1

Fixes #15223
