### PR TITLE
Fix memory allocation problems in e_loader_attic.c

### DIFF
--- a/crypto/x509/x_x509.c
+++ b/crypto/x509/x_x509.c
@@ -131,8 +131,10 @@ X509 *d2i_X509(X509 **a, const unsigned char **in, long len)
     /* Only cache the extensions if the cert object was passed in */
     if (cert != NULL && a != NULL) { /* then cert == *a */
         if (!ossl_x509v3_cache_extensions(cert)) {
-            if (free_on_error)
+            if (free_on_error) {
+                *a = NULL;
                 X509_free(cert);
+            }
             cert = NULL;
         }
     }

--- a/engines/e_loader_attic.c
+++ b/engines/e_loader_attic.c
@@ -199,6 +199,7 @@ static OSSL_STORE_INFO *new_EMBEDDED(const char *new_pem_name,
         return NULL;
     }
 
+    data->blob = embedded;
     data->pem_name =
         new_pem_name == NULL ? NULL : OPENSSL_strdup(new_pem_name);
 
@@ -207,7 +208,6 @@ static OSSL_STORE_INFO *new_EMBEDDED(const char *new_pem_name,
         store_info_free(info);
         info = NULL;
     }
-    data->blob = embedded;
 
     return info;
 }


### PR DESCRIPTION
There are a double free and a use after free problem.
This fixes both.
Refer to the PRs for a description of what the problem is.

Fixes #15115 and #15116
