### PR TITLE
doc: remove references to undepreciated commands being deprecated.

### DIFF
--- a/doc/man1/openssl-dsa.pod.in
+++ b/doc/man1/openssl-dsa.pod.in
@@ -129,10 +129,13 @@ a public key.
 
 =back
 
+The L<openssl-pkey(1)> command is capable of performing all the operations
+this command can, as well as supporting other public key types.
+
 =head1 EXAMPLES
 
-Examples equivalent to these can be found in the documentation for the
-non-deprecated L<openssl-pkey(1)> command.
+The documentation for the L<openssl-pkey(1)> command contains examples
+equivalent to the ones listed here.
 
 To remove the pass phrase on a DSA private key:
 

--- a/doc/man1/openssl-ec.pod.in
+++ b/doc/man1/openssl-ec.pod.in
@@ -147,10 +147,13 @@ This option checks the consistency of an EC private or public key.
 
 =back
 
+The L<openssl-pkey(1)> command is capable of performing all the operations
+this command can, as well as supporting other public key types.
+
 =head1 EXAMPLES
 
-Examples equivalent to these can be found in the documentation for the
-non-deprecated L<openssl-pkey(1)> command.
+The documentation for the L<openssl-pkey(1)> command contains examples
+equivalent to the ones listed here.
 
 To encrypt a private key using triple DES:
 

--- a/doc/man1/openssl-ecparam.pod.in
+++ b/doc/man1/openssl-ecparam.pod.in
@@ -129,10 +129,14 @@ This option will generate an EC private key using the specified parameters.
 
 =back
 
+The L<openssl-genpkey(1)> and L<openssl-pkeyparam(1)> commands are capable
+of performing all the operations this command can, as well as supporting
+other public key types.
+
 =head1 EXAMPLES
 
-Examples equivalent to these can be found in the documentation for the
-non-deprecated L<openssl-genpkey(1)> and L<openssl-pkeyparam(1)> commands.
+The documentation for the L<openssl-genpkey(1)> and L<openssl-pkeyparam(1)>
+commands contains examples equivalent to the ones listed here.
 
 To create EC parameters with the group 'prime192v1':
 

--- a/doc/man1/openssl-rsa.pod.in
+++ b/doc/man1/openssl-rsa.pod.in
@@ -57,7 +57,6 @@ various forms and their components printed out.
 
 Print out a usage message.
 
-
 =item B<-inform> B<DER>|B<PEM>|B<P12>|B<ENGINE>
 
 The key input format; unspecified by default.
@@ -140,10 +139,15 @@ Like B<-pubin> and B<-pubout> except B<RSAPublicKey> format is used instead.
 
 =back
 
+=head1 NOTES
+
+The L<openssl-pkey(1)> command is capable of performing all the operations
+this command can, as well as supporting other public key types.
+
 =head1 EXAMPLES
 
-Examples equivalent to these can be found in the documentation for the
-non-deprecated L<openssl-pkey(1)> command.
+The documentation for the L<openssl-pkey(1)> command contains examples
+equivalent to the ones listed here.
 
 To remove the pass phrase on an RSA private key:
 


### PR DESCRIPTION
The dsa, ec, ecparam, and rsa manual pages refer to themselves are being
deprecated which they aren't.  Address this and add a note pointing to
the pkey command equivalents albeit without recommending it.


- [x] documentation is added or updated
- [ ] tests are added or updated
