### PR TITLE
crypto/arm_arch.h: add a variable declaration

### DIFF
--- a/crypto/arm_arch.h
+++ b/crypto/arm_arch.h
@@ -72,6 +72,7 @@
 # ifndef __ASSEMBLER__
 extern unsigned int OPENSSL_armcap_P;
 extern unsigned int OPENSSL_arm_midr;
+extern unsigned int OPENSSL_armv8_rsa_neonized;
 # endif
 
 # define ARMV7_NEON      (1<<0)


### PR DESCRIPTION
Add this variable declaration to prevent
"-Werror,-Wmissing-variable-declarations" error from compiler.
This error currently only happens on clang.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
