### PR TITLE
Mirror global properties in a child libctx

### DIFF
--- a/crypto/evp/evp_cnf.c
+++ b/crypto/evp/evp_cnf.c
@@ -51,7 +51,7 @@ static int alg_module_init(CONF_IMODULE *md, const CONF *cnf)
                 return 0;
             }
         } else if (strcmp(oval->name, "default_properties") == 0) {
-            if (!evp_set_default_properties_int(cnf->libctx, oval->value, 0)) {
+            if (!evp_set_default_properties_int(cnf->libctx, oval->value, 0, 0)) {
                 ERR_raise(ERR_LIB_EVP, EVP_R_SET_DEFAULT_PROPERTY_FAILURE);
                 return 0;
             }

--- a/crypto/evp/evp_fetch.c
+++ b/crypto/evp/evp_fetch.c
@@ -409,7 +409,11 @@ int evp_set_default_properties_int(OSSL_LIB_CTX *libctx, const char *propq,
         ERR_raise(ERR_LIB_EVP, EVP_R_DEFAULT_QUERY_PARSE_ERROR);
         return 0;
     }
-    return evp_set_parsed_default_properties(libctx, pl, loadconfig);
+    if (!evp_set_parsed_default_properties(libctx, pl, loadconfig)) {
+        ossl_property_free(pl);
+        return 0;
+    }
+    return 1;
 }
 
 int EVP_set_default_properties(OSSL_LIB_CTX *libctx, const char *propq)
@@ -436,7 +440,11 @@ static int evp_default_properties_merge(OSSL_LIB_CTX *libctx, const char *propq)
         ERR_raise(ERR_LIB_EVP, ERR_R_MALLOC_FAILURE);
         return 0;
     }
-    return evp_set_parsed_default_properties(libctx, pl2, 0);
+    if (!evp_set_parsed_default_properties(libctx, pl2, 0)) {
+        ossl_property_free(pl2);
+        return 0;
+    }
+    return 1;
 }
 
 static int evp_default_property_is_enabled(OSSL_LIB_CTX *libctx,

--- a/crypto/evp/evp_fetch.c
+++ b/crypto/evp/evp_fetch.c
@@ -391,6 +391,7 @@ static int evp_set_parsed_default_properties(OSSL_LIB_CTX *libctx,
     OSSL_PROPERTY_LIST **plp = ossl_ctx_global_properties(libctx, loadconfig);
 
     if (plp != NULL && store != NULL) {
+#ifndef FIPS_MODULE
         char *propstr = NULL;
         size_t strsz;
 
@@ -418,10 +419,11 @@ static int evp_set_parsed_default_properties(OSSL_LIB_CTX *libctx,
             ERR_raise(ERR_LIB_EVP, ERR_R_INTERNAL_ERROR);
             return 0;
         }
-        ossl_property_free(*plp);
-        *plp = def_prop;
         ossl_provider_default_props_update(libctx, propstr);
         OPENSSL_free(propstr);
+#endif
+        ossl_property_free(*plp);
+        *plp = def_prop;
         if (store != NULL)
             return ossl_method_store_flush_cache(store, 0);
     }

--- a/crypto/evp/evp_fetch.c
+++ b/crypto/evp/evp_fetch.c
@@ -498,9 +498,9 @@ int EVP_default_properties_enable_fips(OSSL_LIB_CTX *libctx, int enable)
     return evp_default_properties_merge(libctx, query);
 }
 
-char *evp_get_global_properties_str(OSSL_LIB_CTX *libctx)
+char *evp_get_global_properties_str(OSSL_LIB_CTX *libctx, int loadconfig)
 {
-    OSSL_PROPERTY_LIST **plp = ossl_ctx_global_properties(libctx, 1);
+    OSSL_PROPERTY_LIST **plp = ossl_ctx_global_properties(libctx, loadconfig);
     char *propstr = NULL;
     size_t sz;
 

--- a/crypto/property/property_local.h
+++ b/crypto/property/property_local.h
@@ -16,8 +16,10 @@ typedef int OSSL_PROPERTY_IDX;
 /* Property string functions */
 OSSL_PROPERTY_IDX ossl_property_name(OSSL_LIB_CTX *ctx, const char *s,
                                      int create);
+const char *ossl_property_name_str(OSSL_LIB_CTX *ctx, OSSL_PROPERTY_IDX idx);
 OSSL_PROPERTY_IDX ossl_property_value(OSSL_LIB_CTX *ctx, const char *s,
                                       int create);
+const char *ossl_property_value_str(OSSL_LIB_CTX *ctx, OSSL_PROPERTY_IDX idx);
 
 /* Property list functions */
 void ossl_property_free(OSSL_PROPERTY_LIST *p);

--- a/crypto/property/property_parse.c
+++ b/crypto/property/property_parse.c
@@ -627,9 +627,9 @@ static void put_char(char ch, char **buf, size_t *remain, size_t *needed)
         **buf = '\0';
     else
         **buf = ch;
-    *buf += 1;
-    *needed += 1;
-    *remain -= 1;
+    ++*buf;
+    ++*needed;
+    --*remain;
 }
 
 static void put_str(const char *str, char **buf, size_t *remain, size_t *needed)
@@ -653,8 +653,8 @@ static void put_str(const char *str, char **buf, size_t *remain, size_t *needed)
 
     if(len < olen && *remain == 1) {
         **buf = '\0';
-        *buf += 1;
-        *remain -= 1;
+        ++*buf;
+        --*remain;
     }
 }
 

--- a/crypto/property/property_parse.c
+++ b/crypto/property/property_parse.c
@@ -620,7 +620,7 @@ err:
 static void put_char(char ch, char **buf, size_t *remain, size_t *needed)
 {
     if (*remain == 0) {
-        *needed += 1;
+        ++*needed;
         return;
     }
     if(*remain == 1)

--- a/crypto/property/property_parse.c
+++ b/crypto/property/property_parse.c
@@ -685,7 +685,7 @@ size_t ossl_property_list_to_string(OSSL_LIB_CTX *ctx,
                                     size_t bufsize)
 {
     int i;
-    const PROPERTY_DEFINITION *prop;
+    const PROPERTY_DEFINITION *prop = NULL;
     size_t needed = 0;
     const char *val;
 

--- a/crypto/property/property_string.c
+++ b/crypto/property/property_string.c
@@ -162,6 +162,45 @@ OSSL_PROPERTY_IDX ossl_property_name(OSSL_LIB_CTX *ctx, const char *s,
                                 s);
 }
 
+struct find_str_st {
+    const char *str;
+    OSSL_PROPERTY_IDX idx;
+};
+
+static void find_str_fn(PROPERTY_STRING *prop, void *vfindstr)
+{
+    struct find_str_st *findstr = vfindstr;
+
+    if (prop->idx == findstr->idx)
+        findstr->str = prop->s;
+}
+
+static const char *ossl_property_str(int name, OSSL_LIB_CTX *ctx,
+                                     OSSL_PROPERTY_IDX idx)
+{
+    struct find_str_st findstr;
+    PROPERTY_STRING_DATA *propdata
+        = ossl_lib_ctx_get_data(ctx, OSSL_LIB_CTX_PROPERTY_STRING_INDEX,
+                                &property_string_data_method);
+
+    if (propdata == NULL)
+        return NULL;
+
+    findstr.str = NULL;
+    findstr.idx = idx;
+
+    lh_PROPERTY_STRING_doall_arg(name ? propdata->prop_names
+                                      : propdata->prop_values,
+                                 find_str_fn, &findstr);
+
+    return findstr.str;
+}
+
+const char *ossl_property_name_str(OSSL_LIB_CTX *ctx, OSSL_PROPERTY_IDX idx)
+{
+    return ossl_property_str(1, ctx, idx);
+}
+
 OSSL_PROPERTY_IDX ossl_property_value(OSSL_LIB_CTX *ctx, const char *s,
                                       int create)
 {
@@ -174,4 +213,9 @@ OSSL_PROPERTY_IDX ossl_property_value(OSSL_LIB_CTX *ctx, const char *s,
     return ossl_property_string(propdata->prop_values,
                                 create ? &propdata->prop_value_idx : NULL,
                                 s);
+}
+
+const char *ossl_property_value_str(OSSL_LIB_CTX *ctx, OSSL_PROPERTY_IDX idx)
+{
+    return ossl_property_str(0, ctx, idx);
 }

--- a/crypto/provider_child.c
+++ b/crypto/provider_child.c
@@ -204,7 +204,7 @@ static int provider_global_props_cb(const char *props, void *cbdata)
 {
     OSSL_LIB_CTX *ctx = cbdata;
 
-    return evp_set_default_properties_int(ctx, props, 1, 1);
+    return evp_set_default_properties_int(ctx, props, 0, 1);
 }
 
 int ossl_provider_init_as_child(OSSL_LIB_CTX *ctx,

--- a/crypto/provider_child.c
+++ b/crypto/provider_child.c
@@ -12,6 +12,7 @@
 #include <openssl/core_dispatch.h>
 #include <openssl/core_names.h>
 #include <openssl/provider.h>
+#include <openssl/evp.h>
 #include "internal/provider.h"
 #include "internal/cryptlib.h"
 
@@ -198,6 +199,13 @@ static int provider_remove_child_cb(const OSSL_CORE_HANDLE *prov, void *cbdata)
     return 1;
 }
 
+static int provider_global_props_cb(const char *props, void *cbdata)
+{
+    OSSL_LIB_CTX *ctx = cbdata;
+
+    return EVP_set_default_properties(ctx, props);
+}
+
 int ossl_provider_init_as_child(OSSL_LIB_CTX *ctx,
                                 const OSSL_CORE_HANDLE *handle,
                                 const OSSL_DISPATCH *in)
@@ -265,6 +273,7 @@ int ossl_provider_init_as_child(OSSL_LIB_CTX *ctx,
     if (!gbl->c_provider_register_child_cb(gbl->handle,
                                            provider_create_child_cb,
                                            provider_remove_child_cb,
+                                           provider_global_props_cb,
                                            ctx))
         return 0;
 

--- a/crypto/provider_child.c
+++ b/crypto/provider_child.c
@@ -15,6 +15,7 @@
 #include <openssl/evp.h>
 #include "internal/provider.h"
 #include "internal/cryptlib.h"
+#include "crypto/evp.h"
 
 DEFINE_STACK_OF(OSSL_PROVIDER)
 
@@ -203,7 +204,7 @@ static int provider_global_props_cb(const char *props, void *cbdata)
 {
     OSSL_LIB_CTX *ctx = cbdata;
 
-    return EVP_set_default_properties(ctx, props);
+    return evp_set_default_properties_int(ctx, props, 1, 1);
 }
 
 int ossl_provider_init_as_child(OSSL_LIB_CTX *ctx,

--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -46,8 +46,8 @@ DEFINE_STACK_OF(INFOPAIR)
 typedef struct {
     OSSL_PROVIDER *prov;
     int (*create_cb)(const OSSL_CORE_HANDLE *provider, void *cbdata);
-    void (*remove_cb)(const OSSL_CORE_HANDLE *provider, void *cbdata);
-    void (*global_props_cb)(const char *props, void *cbdata);
+    int (*remove_cb)(const OSSL_CORE_HANDLE *provider, void *cbdata);
+    int (*global_props_cb)(const char *props, void *cbdata);
     void *cbdata;
 } OSSL_PROVIDER_CHILD_CB;
 DEFINE_STACK_OF(OSSL_PROVIDER_CHILD_CB)
@@ -1392,10 +1392,10 @@ static int ossl_provider_register_child_cb(const OSSL_CORE_HANDLE *handle,
                                            int (*create_cb)(
                                                const OSSL_CORE_HANDLE *provider,
                                                void *cbdata),
-                                           void (*remove_cb)(
+                                           int (*remove_cb)(
                                                const OSSL_CORE_HANDLE *provider,
                                                void *cbdata),
-                                           void (*global_props_cb)(
+                                           int (*global_props_cb)(
                                                const char *props,
                                                void *cbdata),
                                            void *cbdata)

--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -1428,7 +1428,7 @@ static int ossl_provider_register_child_cb(const OSSL_CORE_HANDLE *handle,
         OPENSSL_free(child_cb);
         return 0;
     }
-    propsstr = evp_get_global_properties_str(libctx);
+    propsstr = evp_get_global_properties_str(libctx, 0);
 
     if (propsstr != NULL) {
         global_props_cb(propsstr, cbdata);

--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -47,6 +47,7 @@ typedef struct {
     OSSL_PROVIDER *prov;
     int (*create_cb)(const OSSL_CORE_HANDLE *provider, void *cbdata);
     void (*remove_cb)(const OSSL_CORE_HANDLE *provider, void *cbdata);
+    void (*global_props_cb)(const char *props, void *cbdata);
     void *cbdata;
 } OSSL_PROVIDER_CHILD_CB;
 DEFINE_STACK_OF(OSSL_PROVIDER_CHILD_CB)
@@ -1363,12 +1364,39 @@ int ossl_provider_convert_to_child(OSSL_PROVIDER *prov,
     return 1;
 }
 
+int ossl_provider_default_props_update(OSSL_LIB_CTX *libctx, const char *props)
+{
+#ifndef FIPS_MODULE
+    struct provider_store_st *store = NULL;
+    int i, max;
+    OSSL_PROVIDER_CHILD_CB *child_cb;
+
+    if ((store = get_provider_store(libctx)) == NULL)
+        return 0;
+
+    if (!CRYPTO_THREAD_read_lock(store->lock))
+        return 0;
+
+    max = sk_OSSL_PROVIDER_CHILD_CB_num(store->child_cbs);
+    for (i = 0; i < max; i++) {
+        child_cb = sk_OSSL_PROVIDER_CHILD_CB_value(store->child_cbs, i);
+        child_cb->global_props_cb(props, child_cb->cbdata);
+    }
+
+    CRYPTO_THREAD_unlock(store->lock);
+#endif
+    return 1;
+}
+
 static int ossl_provider_register_child_cb(const OSSL_CORE_HANDLE *handle,
                                            int (*create_cb)(
                                                const OSSL_CORE_HANDLE *provider,
                                                void *cbdata),
                                            void (*remove_cb)(
                                                const OSSL_CORE_HANDLE *provider,
+                                               void *cbdata),
+                                           void (*global_props_cb)(
+                                               const char *props,
                                                void *cbdata),
                                            void *cbdata)
 {
@@ -1382,6 +1410,7 @@ static int ossl_provider_register_child_cb(const OSSL_CORE_HANDLE *handle,
     struct provider_store_st *store = NULL;
     int ret = 0, i, max;
     OSSL_PROVIDER_CHILD_CB *child_cb;
+    char *propsstr = NULL;
 
     if ((store = get_provider_store(libctx)) == NULL)
         return 0;
@@ -1392,11 +1421,18 @@ static int ossl_provider_register_child_cb(const OSSL_CORE_HANDLE *handle,
     child_cb->prov = thisprov;
     child_cb->create_cb = create_cb;
     child_cb->remove_cb = remove_cb;
+    child_cb->global_props_cb = global_props_cb;
     child_cb->cbdata = cbdata;
 
     if (!CRYPTO_THREAD_write_lock(store->lock)) {
         OPENSSL_free(child_cb);
         return 0;
+    }
+    propsstr = evp_get_global_properties_str(libctx);
+
+    if (propsstr != NULL) {
+        global_props_cb(propsstr, cbdata);
+        OPENSSL_free(propsstr);
     }
     max = sk_OSSL_PROVIDER_num(store->providers);
     for (i = 0; i < max; i++) {

--- a/doc/internal/man3/ossl_global_properties_no_mirrored.pod
+++ b/doc/internal/man3/ossl_global_properties_no_mirrored.pod
@@ -1,0 +1,56 @@
+=pod
+
+=head1 NAME
+
+ossl_property_list_to_string, ossl_global_properties_no_mirrored
+- internal property routines
+
+=head1 SYNOPSIS
+
+ #include "internal/property.h"
+
+ size_t ossl_property_list_to_string(OSSL_LIB_CTX *ctx,
+                                     const OSSL_PROPERTY_LIST *list, char *buf,
+                                     size_t bufsize);
+
+ int ossl_global_properties_no_mirrored(OSSL_LIB_CTX *libctx);
+ void ossl_global_properties_no_mirrored(OSSL_LIB_CTX *libctx);
+
+
+=head1 DESCRIPTION
+
+ossl_property_list_to_string() takes a given OSSL_PROPERTY_LIST in I<list> and
+converts it to a string. If I<buf> is non NULL then the string will be stored
+in I<buf>. The size of the buffer is provided in I<bufsize>. If I<bufsize> is
+too short then the string will be truncated. If I<buf> is NULL then the length
+of the string is still calculated and returned. If the property list has no
+properties in it then the empty string will be stored in I<buf>.
+
+ossl_global_properties_no_mirrored() checks whether mirroring of global
+properties from a parent library context is allowed for the current library
+context.
+
+ossl_global_properties_no_mirrored() prevents future mirroring of global
+properties from a parent library context for the current library context.
+
+=head1 RETURN VALUES
+
+ossl_property_list_to_string() returns the length of the string, or 0 on error.
+
+ossl_global_properties_no_mirrored() returns 1 if mirroring of global properties
+is not allowed, or 0 otherwise.
+
+=head1 HISTORY
+
+The functions described here were all added in OpenSSL 3.0.
+
+=head1 COPYRIGHT
+
+Copyright 2021 The OpenSSL Project Authors. All Rights Reserved.
+
+Licensed under the Apache License 2.0 (the "License").  You may not use
+this file except in compliance with the License.  You can obtain a copy
+in the file LICENSE in the source distribution or at
+L<https://www.openssl.org/source/license.html>.
+
+=cut

--- a/doc/internal/man3/ossl_provider_new.pod
+++ b/doc/internal/man3/ossl_provider_new.pod
@@ -7,7 +7,7 @@ ossl_provider_free,
 ossl_provider_set_fallback, ossl_provider_set_module_path,
 ossl_provider_add_parameter, ossl_provider_set_child, ossl_provider_get_parent,
 ossl_provider_up_ref_parent, ossl_provider_free_parent,
-ossl_provider_get0_dispatch,
+ossl_provider_default_props_update, ossl_provider_get0_dispatch,
 ossl_provider_init_as_child,
 ossl_provider_activate, ossl_provider_deactivate, ossl_provider_available,
 ossl_provider_ctx,
@@ -46,6 +46,8 @@ ossl_provider_get_capabilities
  const OSSL_CORE_HANDLE *ossl_provider_get_parent(OSSL_PROVIDER *prov);
  int ossl_provider_up_ref_parent(OSSL_PROVIDER *prov, int activate);
  int ossl_provider_free_parent(OSSL_PROVIDER *prov, int deactivate);
+ int ossl_provider_default_props_update(OSSL_LIB_CTX *libctx,
+                                        const char *props);
 
  /*
   * Activate the Provider
@@ -193,6 +195,10 @@ ossl_provider_free_parent() decreases the reference count on the parent
 provider. If I<deactivate> is nonzero then the parent provider is also
 deactivated.
 
+ossl_provider_default_props_update() is responsible for informing any child
+providers of an update to the default properties. The new properties are
+supplied in the I<props> string.
+
 ossl_provider_activate() "activates" the provider for the given
 provider object I<prov> by incrementing its activation count, flagging
 it as activated, and initializing it if it isn't already initialized.
@@ -339,7 +345,8 @@ called for any activated providers.
 
 ossl_provider_set_module_path(), ossl_provider_set_fallback(),
 ossl_provider_activate(), ossl_provider_activate_leave_fallbacks() and
-ossl_provider_deactivate() return 1 on success, or 0 on error.
+ossl_provider_deactivate(), ossl_provider_default_props_update() return 1 on
+success, or 0 on error.
 
 ossl_provider_available() return 1 if the provider is available,
 otherwise 0.

--- a/doc/man3/OSSL_LIB_CTX.pod
+++ b/doc/man3/OSSL_LIB_CTX.pod
@@ -69,6 +69,12 @@ reference count. L<OSSL_PROVIDER_unload(3)> must not be called for a provider in
 the child library context that did not have an earlier L<OSSL_PROVIDER_load(3)>
 call for that provider in that child library context.
 
+In addition to providers, a child library context will also mirror the default
+properties (set via L<EVP_set_default_properties(3)>) from the parent library
+context. If L<EVP_set_default_properties(3)> is called directly from a child
+library context then the new properties will override anything from the parent
+library context and mirroring of the properties will stop.
+
 OSSL_LIB_CTX_new_child() must only be called from within the scope of a
 provider's B<OSSL_provider_init> function (see L<provider-base(7)>). Calling it
 outside of that function may succeed but may not correctly mirror all providers

--- a/doc/man3/OSSL_LIB_CTX.pod
+++ b/doc/man3/OSSL_LIB_CTX.pod
@@ -71,7 +71,7 @@ call for that provider in that child library context.
 
 In addition to providers, a child library context will also mirror the default
 properties (set via L<EVP_set_default_properties(3)>) from the parent library
-context. If L<EVP_set_default_properties(3)> is called directly from a child
+context. If L<EVP_set_default_properties(3)> is called directly on a child
 library context then the new properties will override anything from the parent
 library context and mirroring of the properties will stop.
 

--- a/doc/man7/provider-base.pod
+++ b/doc/man7/provider-base.pod
@@ -298,7 +298,7 @@ the provider being unloaded and this provider's data in I<cbdata>. It should
 return 1 on success or 0 on failure.
 
 I<global_props_cb> is a callback that will be called when the global properties
-from the parent library context are changed.It should return 1 on success
+from the parent library context are changed. It should return 1 on success
 or 0 on failure.
 
 provider_deregister_child_cb() unregisters callbacks previously registered via

--- a/doc/man7/provider-base.pod
+++ b/doc/man7/provider-base.pod
@@ -89,6 +89,7 @@ provider-base
                                       void *cbdata),
                      int (*remove_cb)(const OSSL_CORE_HANDLE *provider,
                                       void *cbdata),
+                     int (*global_props_cb)(const char *props, void *cbdata),
                      void *cbdata);
  void provider_deregister_child_cb(const OSSL_CORE_HANDLE *handle);
  const char *provider_name(const OSSL_CORE_HANDLE *prov);
@@ -289,12 +290,16 @@ I<create_cb> is a callback that will be called when a new provider is loaded
 into the application's library context. It is also called for any providers that
 are already loaded at the point that this callback is registered. The callback
 is passed the handle being used for the new provider being loadded and this
-provider's data in I<cbdata>. It should return 1 on success  or 0 on failure.
+provider's data in I<cbdata>. It should return 1 on success or 0 on failure.
 
 I<remove_cb> is a callback that will be called when a new provider is unloaded
 from the application's library context. It is passed the handle being used for
 the provider being unloaded and this provider's data in I<cbdata>. It should
-return 1 on success  or 0 on failure.
+return 1 on success or 0 on failure.
+
+I<global_props_cb> is a callback that will be called when the global properties
+from the parent library context are changed.It should return 1 on success
+or 0 on failure.
 
 provider_deregister_child_cb() unregisters callbacks previously registered via
 provider_register_child_cb(). If provider_register_child_cb() has been called

--- a/include/crypto/evp.h
+++ b/include/crypto/evp.h
@@ -887,7 +887,7 @@ int evp_pkey_ctx_use_cached_data(EVP_PKEY_CTX *ctx);
 int evp_method_store_flush(OSSL_LIB_CTX *libctx);
 int evp_set_default_properties_int(OSSL_LIB_CTX *libctx, const char *propq,
                                    int loadconfig, int mirrored);
-char *evp_get_global_properties_str(OSSL_LIB_CTX *libctx);
+char *evp_get_global_properties_str(OSSL_LIB_CTX *libctx, int loadconfig);
 
 void evp_md_ctx_clear_digest(EVP_MD_CTX *ctx, int force);
 

--- a/include/crypto/evp.h
+++ b/include/crypto/evp.h
@@ -887,6 +887,7 @@ int evp_pkey_ctx_use_cached_data(EVP_PKEY_CTX *ctx);
 int evp_method_store_flush(OSSL_LIB_CTX *libctx);
 int evp_set_default_properties_int(OSSL_LIB_CTX *libctx, const char *propq,
                                    int loadconfig);
+char *evp_get_global_properties_str(OSSL_LIB_CTX *libctx);
 
 void evp_md_ctx_clear_digest(EVP_MD_CTX *ctx, int force);
 

--- a/include/crypto/evp.h
+++ b/include/crypto/evp.h
@@ -886,7 +886,7 @@ int evp_pkey_ctx_use_cached_data(EVP_PKEY_CTX *ctx);
 
 int evp_method_store_flush(OSSL_LIB_CTX *libctx);
 int evp_set_default_properties_int(OSSL_LIB_CTX *libctx, const char *propq,
-                                   int loadconfig);
+                                   int loadconfig, int mirrored);
 char *evp_get_global_properties_str(OSSL_LIB_CTX *libctx);
 
 void evp_md_ctx_clear_digest(EVP_MD_CTX *ctx, int force);

--- a/include/internal/property.h
+++ b/include/internal/property.h
@@ -64,4 +64,8 @@ __owur int ossl_method_store_flush_cache(OSSL_METHOD_STORE *store, int all);
 OSSL_PROPERTY_LIST *ossl_property_merge(const OSSL_PROPERTY_LIST *a,
                                         const OSSL_PROPERTY_LIST *b);
 
+size_t ossl_property_list_to_string(OSSL_LIB_CTX *ctx,
+                                    const OSSL_PROPERTY_LIST *list, char *buf,
+                                    size_t bufsize);
+
 #endif

--- a/include/internal/property.h
+++ b/include/internal/property.h
@@ -68,4 +68,7 @@ size_t ossl_property_list_to_string(OSSL_LIB_CTX *ctx,
                                     const OSSL_PROPERTY_LIST *list, char *buf,
                                     size_t bufsize);
 
+int ossl_global_properties_no_mirrored(OSSL_LIB_CTX *libctx);
+void ossl_global_properties_stop_mirroring(OSSL_LIB_CTX *libctx);
+
 #endif

--- a/include/internal/provider.h
+++ b/include/internal/provider.h
@@ -50,6 +50,7 @@ int ossl_provider_convert_to_child(OSSL_PROVIDER *prov,
 const OSSL_CORE_HANDLE *ossl_provider_get_parent(OSSL_PROVIDER *prov);
 int ossl_provider_up_ref_parent(OSSL_PROVIDER *prov, int activate);
 int ossl_provider_free_parent(OSSL_PROVIDER *prov, int deactivate);
+int ossl_provider_default_props_update(OSSL_LIB_CTX *libctx, const char *props);
 
 /* Disable fallback loading */
 int ossl_provider_disable_fallback_loading(OSSL_LIB_CTX *libctx);

--- a/include/openssl/core_dispatch.h
+++ b/include/openssl/core_dispatch.h
@@ -196,6 +196,7 @@ OSSL_CORE_MAKE_FUNC(int, provider_register_child_cb,
                     (const OSSL_CORE_HANDLE *handle,
                      int (*create_cb)(const OSSL_CORE_HANDLE *provider, void *cbdata),
                      int (*remove_cb)(const OSSL_CORE_HANDLE *provider, void *cbdata),
+                     int (*global_props_cb)(const char *props, void *cbdata),
                      void *cbdata))
 OSSL_CORE_MAKE_FUNC(void, provider_deregister_child_cb,
                     (const OSSL_CORE_HANDLE *handle))

--- a/include/openssl/lhash.h.in
+++ b/include/openssl/lhash.h.in
@@ -226,6 +226,13 @@ void OPENSSL_LH_node_usage_stats_bio(const OPENSSL_LHASH *lh, BIO *out);
     { \
         OPENSSL_LH_doall((OPENSSL_LHASH *)lh, (OPENSSL_LH_DOALL_FUNC)doall); \
     } \
+    static ossl_unused ossl_inline void lh_##type##_doall_arg(LHASH_OF(type) *lh, \
+                                                              void (*doallarg)(type *, void *), \
+                                                              void *arg) \
+    { \
+        OPENSSL_LH_doall_arg((OPENSSL_LHASH *)lh, \
+                             (OPENSSL_LH_DOALL_FUNCARG)doallarg, arg); \
+    } \
     LHASH_OF(type)
 
 #define IMPLEMENT_LHASH_DOALL_ARG_CONST(type, argtype) \

--- a/test/p_test.c
+++ b/test/p_test.c
@@ -183,6 +183,22 @@ static int p_get_params(void *provctx, OSSL_PARAM params[])
             } else {
                 ok = 0;
             }
+        } else if (strcmp(p->key, "stop-property-mirror") == 0) {
+            /*
+             * Setting the default properties explicitly should stop mirroring
+             * of properties from the parent libctx.
+             */
+            unsigned int stopsuccess = 0;
+
+#ifdef PROVIDER_INIT_FUNCTION_NAME
+            stopsuccess = EVP_set_default_properties(ctx->libctx, NULL);
+#endif
+            if (p->data_size >= sizeof(stopsuccess)) {
+                *(unsigned int *)p->data = stopsuccess;
+                p->return_size = sizeof(stopsuccess);
+            } else {
+                ok = 0;
+            }
         }
     }
     return ok;

--- a/test/p_test.c
+++ b/test/p_test.c
@@ -266,6 +266,18 @@ int OSSL_provider_init(const OSSL_CORE_HANDLE *handle,
         p_teardown(ctx);
         return 0;
     }
+    /*
+     * The default provider is loaded - but the default properties should not
+     * allow its use.
+     */
+    {
+        EVP_MD *sha256 = EVP_MD_fetch(ctx->libctx, "SHA2-256", NULL);
+        if (sha256 != NULL) {
+            EVP_MD_free(sha256);
+            p_teardown(ctx);
+            return 0;
+        }
+    }
 #endif
 
     /*

--- a/test/property_test.c
+++ b/test/property_test.c
@@ -435,6 +435,61 @@ err:
     return ret;
 }
 
+static int test_property_list_to_string(void)
+{
+    OSSL_PROPERTY_LIST *pl = NULL;
+    int ret = 0;
+    struct props_list_str {
+        const char *in;
+        const char *out;
+    } props[] = {
+        { "fips=yes", "fips=yes" },
+        { "fips!=yes", "fips!=yes" },
+        { "fips = yes", "fips=yes" },
+        { "fips", "fips=yes" },
+        { "fips=no", "fips=no" },
+        { "-fips", "-fips" },
+        { "?fips=yes", "?fips=yes" },
+        { "fips=yes,provider=fips", "fips=yes,provider=fips" },
+        { "fips = yes , provider = fips", "fips=yes,provider=fips" },
+        { "fips=yes,provider!=fips", "fips=yes,provider!=fips" },
+        { "fips=yes,?provider=fips", "fips=yes,?provider=fips" },
+        { "fips=yes,-provider", "fips=yes,-provider" },
+          /* foo is an unknown internal name */
+        { "foo=yes,fips=yes", "fips=yes"},
+        { "", "" },
+        { NULL, "" }
+    };
+    size_t i, bufsize;
+    char *buf;
+
+    for (i = 0; i < OSSL_NELEM(props); i++) {
+        if (props[i].in != NULL
+                && !TEST_ptr(pl = ossl_parse_query(NULL, props[i].in, 1)))
+            goto err;
+        bufsize = ossl_property_list_to_string(NULL, pl, NULL, 0);
+        if (!TEST_size_t_gt(bufsize, 0))
+            goto err;
+        buf = OPENSSL_malloc(bufsize);
+        if (!TEST_ptr(buf)
+                || !TEST_size_t_eq(ossl_property_list_to_string(NULL, pl, buf,
+                                                                bufsize),
+                                   bufsize)
+                || !TEST_str_eq(props[i].out, buf)
+                || !TEST_size_t_eq(bufsize, strlen(props[i].out) + 1))
+            goto err;
+        OPENSSL_free(buf);
+        buf = NULL;
+        ossl_property_free(pl);
+        pl = NULL;
+    }
+
+    ret = 1;
+ err:
+    OPENSSL_free(buf);
+    ossl_property_free(pl);
+    return ret;
+}
 
 int setup_tests(void)
 {
@@ -448,5 +503,6 @@ int setup_tests(void)
     ADD_TEST(test_property);
     ADD_TEST(test_query_cache_stochastic);
     ADD_TEST(test_fips_mode);
+    ADD_TEST(test_property_list_to_string);
     return 1;
 }

--- a/test/property_test.c
+++ b/test/property_test.c
@@ -461,7 +461,7 @@ static int test_property_list_to_string(void)
         { NULL, "" }
     };
     size_t i, bufsize;
-    char *buf;
+    char *buf = NULL;
 
     for (i = 0; i < OSSL_NELEM(props); i++) {
         if (props[i].in != NULL

--- a/test/provider_internal_test.c
+++ b/test/provider_internal_test.c
@@ -53,11 +53,23 @@ static int test_builtin_provider(void)
 {
     const char *name = "p_test_builtin";
     OSSL_PROVIDER *prov = NULL;
+    int ret;
 
-    return
+    /*
+     * We set properties that we know the providers we are using don't have.
+     * This should mean that the p_test provider will fail any fetches - which
+     * is something we test inside the provider.
+     */
+    EVP_set_default_properties(NULL, "fips=yes");
+
+    ret =
         TEST_ptr(prov =
                  ossl_provider_new(NULL, name, PROVIDER_INIT_FUNCTION_NAME, 0))
         && test_provider(prov, expected_greeting1(name));
+
+    EVP_set_default_properties(NULL, "");
+
+    return ret;
 }
 
 #ifndef NO_PROVIDER_MODULE


### PR DESCRIPTION
If using a child library context that the global properties from the application library context should be mirrored in the child.
