### PR TITLE
Fix provider library build wrt. AES

### DIFF
--- a/crypto/aes/build.info
+++ b/crypto/aes/build.info
@@ -71,6 +71,13 @@ SOURCE[../../providers/libfips.a]=$COMMON
 DEFINE[../../libcrypto]=$AESDEF
 DEFINE[../../providers/libfips.a]=$AESDEF
 DEFINE[../../providers/libdefault.a]=$AESDEF
+# We only need to include the AESDEF stuff in the legacy provider when it's a
+# separate module and it's dynamically linked with libcrypto.  Otherwise, it
+# already gets everything that the static libcrypto.a has, and doesn't need it
+# added again.
+IF[{- !$disabled{module} && !$disabled{shared} -}]
+  DEFINE[../providers/liblegacy.a]=$AESDEF
+ENDIF
 
 GENERATE[aes-ia64.s]=asm/aes-ia64.S
 GENERATE[bsaes-armv8.S]=asm/bsaes-armv8.S


### PR DESCRIPTION
Commit c7978e506b2d1300accd9e696656f9cc94196e6d ("Fix missing $CPUIDDEF in
libdefault.a") revealed another problem in the build system on s390.  The
build of the provider libraries includes the AES system without the proper
defines.  This causes a build error on s390 now since the CPUIDDEF is present
but the prototypes for various AES functions implemented in assembler are
missing due to missing preprocessor defines.  Fix this by adding the missing
defines to all provider libraries.

Signed-off-by: Juergen Christ <jchrist@linux.ibm.com>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

