### PR TITLE
Add explicit HTTP(S) proxy support to ocsp and s_server apps

### DIFF
--- a/apps/include/apps.h
+++ b/apps/include/apps.h
@@ -175,10 +175,10 @@ const EVP_MD *get_digest_from_engine(const char *name);
 const EVP_CIPHER *get_cipher_from_engine(const char *name);
 
 # ifndef OPENSSL_NO_OCSP
-OCSP_RESPONSE *process_responder(OCSP_REQUEST *req,
-                                 const char *host, const char *path,
-                                 const char *port, int use_ssl,
-                                 STACK_OF(CONF_VALUE) *headers,
+OCSP_RESPONSE *process_responder(OCSP_REQUEST *req, const char *host,
+                                 const char *port, const char *path,
+                                 const char *proxy, const char *no_proxy,
+                                 int use_ssl, STACK_OF(CONF_VALUE) *headers,
                                  int req_timeout);
 # endif
 

--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -522,8 +522,8 @@ static int get_ocsp_resp_from_responder(SSL *s, tlsextstatusctx *srctx,
         if (!OCSP_REQUEST_add_ext(req, ext, -1))
             goto err;
     }
-    *resp = process_responder(req, host, path, port, use_ssl, NULL,
-                             srctx->timeout);
+    *resp = process_responder(req, host, port, path, proxy, no_proxy,
+                              use_ssl, NULL /* headers */, srctx->timeout);
     if (*resp == NULL) {
         BIO_puts(bio_err, "cert_status: error querying responder\n");
         goto done;

--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -438,6 +438,7 @@ typedef struct tlsextstatusctx_st {
     char *respin;
     /* Default responder to use */
     char *host, *path, *port;
+    char *proxy, *no_proxy;
     int use_ssl;
     int verbose;
 } tlsextstatusctx;
@@ -457,6 +458,7 @@ static int get_ocsp_resp_from_responder(SSL *s, tlsextstatusctx *srctx,
                                         OCSP_RESPONSE **resp)
 {
     char *host = NULL, *port = NULL, *path = NULL;
+    char *proxy = NULL, *no_proxy = NULL;
     int use_ssl;
     STACK_OF(OPENSSL_STRING) *aia = NULL;
     X509 *x = NULL;
@@ -491,6 +493,8 @@ static int get_ocsp_resp_from_responder(SSL *s, tlsextstatusctx *srctx,
         port = srctx->port;
         use_ssl = srctx->use_ssl;
     }
+    proxy = srctx->proxy;
+    no_proxy = srctx->no_proxy;
 
     inctx = X509_STORE_CTX_new();
     if (inctx == NULL)
@@ -686,7 +690,8 @@ typedef enum OPTION_choice {
     OPT_CASTORE, OPT_NOCASTORE, OPT_CHAINCASTORE, OPT_VERIFYCASTORE,
     OPT_NBIO, OPT_NBIO_TEST, OPT_IGN_EOF, OPT_NO_IGN_EOF,
     OPT_DEBUG, OPT_TLSEXTDEBUG, OPT_STATUS, OPT_STATUS_VERBOSE,
-    OPT_STATUS_TIMEOUT, OPT_STATUS_URL, OPT_STATUS_FILE, OPT_MSG, OPT_MSGFILE,
+    OPT_STATUS_TIMEOUT, OPT_PROXY, OPT_NO_PROXY, OPT_STATUS_URL,
+    OPT_STATUS_FILE, OPT_MSG, OPT_MSGFILE,
     OPT_TRACE, OPT_SECURITY_DEBUG, OPT_SECURITY_DEBUG_VERBOSE, OPT_STATE,
     OPT_CRLF, OPT_QUIET, OPT_BRIEF, OPT_NO_DHE,
     OPT_NO_RESUME_EPHEMERAL, OPT_PSK_IDENTITY, OPT_PSK_HINT, OPT_PSK,
@@ -833,6 +838,12 @@ const OPTIONS s_server_options[] = {
     {"status_timeout", OPT_STATUS_TIMEOUT, 'n',
      "Status request responder timeout"},
     {"status_url", OPT_STATUS_URL, 's', "Status request fallback URL"},
+    {"proxy", OPT_PROXY, 's',
+     "[http[s]://]host[:port][/path] of HTTP(S) proxy to use; path is ignored"},
+    {"no_proxy", OPT_NO_PROXY, 's',
+     "List of addresses of servers not to use HTTP(S) proxy for"},
+    {OPT_MORE_STR, 0, 0,
+     "Default from environment variable 'no_proxy', else 'NO_PROXY', else none"},
     {"status_file", OPT_STATUS_FILE, '<',
      "File containing DER encoded OCSP Response"},
 #endif
@@ -1333,6 +1344,16 @@ int s_server_main(int argc, char *argv[])
 #ifndef OPENSSL_NO_OCSP
             s_tlsextstatus = 1;
             tlscstatp.timeout = atoi(opt_arg());
+#endif
+            break;
+        case OPT_PROXY:
+#ifndef OPENSSL_NO_OCSP
+            tlscstatp.proxy = opt_arg();
+#endif
+            break;
+        case OPT_NO_PROXY:
+#ifndef OPENSSL_NO_OCSP
+            tlscstatp.no_proxy = opt_arg();
 #endif
             break;
         case OPT_STATUS_URL:

--- a/doc/man1/openssl-ocsp.pod.in
+++ b/doc/man1/openssl-ocsp.pod.in
@@ -30,9 +30,11 @@ B<openssl> B<ocsp>
 [B<-respin> I<file>]
 [B<-url> I<URL>]
 [B<-host> I<host>:I<port>]
+[B<-path>]
+[B<-proxy> I<[http[s]://][userinfo@]host[:port][/path]>]
+[B<-no_proxy> I<addresses>]
 [B<-header>]
 [B<-timeout> I<seconds>]
-[B<-path>]
 [B<-VAfile> I<file>]
 [B<-validity_period> I<n>]
 [B<-status_age> I<n>]
@@ -166,6 +168,23 @@ If the B<-host> option is present then the OCSP request is sent to the host
 I<hostname> on port I<port>. The B<-path> option specifies the HTTP pathname
 to use or "/" by default.  This is equivalent to specifying B<-url> with scheme
 http:// and the given hostname, port, and pathname.
+
+=item B<-proxy> I<[http[s]://][userinfo@]host[:port][/path]>
+
+The HTTP(S) proxy server to use for reaching the OCSP server unless B<-no_proxy>
+applies, see below.
+The proxy port defaults to 80 or 443 if the scheme is C<https>; apart from that
+the optional C<http://> or C<https://> prefix is ignored,
+as well as any userinfo and path components.
+Defaults to the environment variable C<http_proxy> if set, else C<HTTP_PROXY>
+in case no TLS is used, otherwise C<https_proxy> if set, else C<HTTPS_PROXY>.
+
+=item B<-no_proxy> I<addresses>
+
+List of IP addresses and/or DNS names of servers
+not to use an HTTP(S) proxy for, separated by commas and/or whitespace
+(where in the latter case the whole argument must be enclosed in "...").
+Default is from the environment variable C<no_proxy> if set, else C<NO_PROXY>.
 
 =item B<-header> I<name>=I<value>
 

--- a/doc/man1/openssl-s_server.pod.in
+++ b/doc/man1/openssl-s_server.pod.in
@@ -73,6 +73,8 @@ B<openssl> B<s_server>
 [B<-status>]
 [B<-status_verbose>]
 [B<-status_timeout> I<int>]
+[B<-proxy> I<[http[s]://][userinfo@]host[:port][/path]>]
+[B<-no_proxy> I<addresses>]
 [B<-status_url> I<val>]
 [B<-status_file> I<infile>]
 [B<-trace>]
@@ -461,6 +463,23 @@ a verbose printout of the OCSP response.
 =item B<-status_timeout> I<int>
 
 Sets the timeout for OCSP response to I<int> seconds.
+
+=item B<-proxy> I<[http[s]://][userinfo@]host[:port][/path]>
+
+The HTTP(S) proxy server to use for reaching the OCSP server unless B<-no_proxy>
+applies, see below.
+The proxy port defaults to 80 or 443 if the scheme is C<https>; apart from that
+the optional C<http://> or C<https://> prefix is ignored,
+as well as any userinfo and path components.
+Defaults to the environment variable C<http_proxy> if set, else C<HTTP_PROXY>
+in case no TLS is used, otherwise C<https_proxy> if set, else C<HTTPS_PROXY>.
+
+=item B<-no_proxy> I<addresses>
+
+List of IP addresses and/or DNS names of servers
+not to use an HTTP(S) proxy for, separated by commas and/or whitespace
+(where in the latter case the whole argument must be enclosed in "...").
+Default is from the environment variable C<no_proxy> if set, else C<NO_PROXY>.
 
 =item B<-status_url> I<val>
 


### PR DESCRIPTION
This adds the `-proxy` and `-no_proxy` options to the `ocsp` and `s_server` apps,
as well as documentation for them.
Since PR #10667 (commit 29f178bddfdbd11218fbcba0b8060297696968e3), both apps were already implicitly supporting the use of HTTP(S) proxies, triggered via the `http_proxy` etc. environment variables.
    
This is strongly related to feature request #6965 and possibly even fixes it.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
