### PR TITLE
Replace some of the ERR_clear_error() calls in libcrypto with mark calls

### DIFF
--- a/crypto/asn1/a_d2i_fp.c
+++ b/crypto/asn1/a_d2i_fp.c
@@ -115,7 +115,7 @@ int asn1_d2i_read_bio(BIO *in, BUF_MEM **pb)
         return -1;
     }
 
-    ERR_clear_error();
+    ERR_set_mark();
     for (;;) {
         diff = len - off;
         if (want >= diff) {
@@ -149,10 +149,10 @@ int asn1_d2i_read_bio(BIO *in, BUF_MEM **pb)
         if (inf & 0x80) {
             unsigned long e;
 
-            e = ERR_GET_REASON(ERR_peek_error());
+            e = ERR_GET_REASON(ERR_peek_last_error());
             if (e != ASN1_R_TOO_LONG)
                 goto err;
-            ERR_clear_error();
+            ERR_pop_to_mark();
         }
         i = q - p;            /* header length */
         off += i;               /* end of data */
@@ -235,6 +235,7 @@ int asn1_d2i_read_bio(BIO *in, BUF_MEM **pb)
     *pb = b;
     return off;
  err:
+    ERR_clear_last_mark();
     BUF_MEM_free(b);
     return -1;
 }

--- a/crypto/asn1/p5_pbev2.c
+++ b/crypto/asn1/p5_pbev2.c
@@ -88,11 +88,12 @@ X509_ALGOR *PKCS5_pbe2_set_iv_ex(const EVP_CIPHER *cipher, int iter,
      * If prf NID unspecified see if cipher has a preference. An error is OK
      * here: just means use default PRF.
      */
+    ERR_set_mark();
     if ((prf_nid == -1) &&
         EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_PBE_PRF_NID, 0, &prf_nid) <= 0) {
-        ERR_clear_error();
         prf_nid = NID_hmacWithSHA256;
     }
+    ERR_pop_to_mark();
     EVP_CIPHER_CTX_free(ctx);
     ctx = NULL;
 

--- a/crypto/bio/bss_conn.c
+++ b/crypto/bio/bss_conn.c
@@ -155,6 +155,7 @@ static int conn_state(BIO *b, BIO_CONNECT *c)
 
         case BIO_CONN_S_CONNECT:
             BIO_clear_retry_flags(b);
+            ERR_set_mark();
             ret = BIO_connect(b->num, BIO_ADDRINFO_address(c->addr_iter),
                               BIO_SOCK_KEEPALIVE | c->connect_mode);
             b->retry_reason = 0;
@@ -163,7 +164,7 @@ static int conn_state(BIO *b, BIO_CONNECT *c)
                     BIO_set_retry_special(b);
                     c->state = BIO_CONN_S_BLOCKED_CONNECT;
                     b->retry_reason = BIO_RR_CONNECT;
-                    ERR_clear_error();
+                    ERR_pop_to_mark();
                 } else if ((c->addr_iter = BIO_ADDRINFO_next(c->addr_iter))
                            != NULL) {
                     /*
@@ -171,9 +172,10 @@ static int conn_state(BIO *b, BIO_CONNECT *c)
                      */
                     BIO_closesocket(b->num);
                     c->state = BIO_CONN_S_CREATE_SOCKET;
-                    ERR_clear_error();
+                    ERR_pop_to_mark();
                     break;
                 } else {
+                    ERR_clear_last_mark();
                     ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
                                    "calling connect(%s, %s)",
                                     c->param_hostname, c->param_service);
@@ -182,6 +184,7 @@ static int conn_state(BIO *b, BIO_CONNECT *c)
                 }
                 goto exit_loop;
             } else {
+                ERR_clear_last_mark();
                 c->state = BIO_CONN_S_OK;
             }
             break;
@@ -196,7 +199,6 @@ static int conn_state(BIO *b, BIO_CONNECT *c)
                      */
                     BIO_closesocket(b->num);
                     c->state = BIO_CONN_S_CREATE_SOCKET;
-                    ERR_clear_error();
                     break;
                 }
                 ERR_raise_data(ERR_LIB_SYS, i,

--- a/crypto/pkcs12/p12_add.c
+++ b/crypto/pkcs12/p12_add.c
@@ -102,14 +102,15 @@ PKCS7 *PKCS12_pack_p7encdata_ex(int pbe_nid, const char *pass, int passlen,
         goto err;
     }
 
+    ERR_set_mark();
     pbe_ciph = pbe_ciph_fetch = EVP_CIPHER_fetch(ctx, OBJ_nid2sn(pbe_nid), propq);
     if (pbe_ciph == NULL)
         pbe_ciph = EVP_get_cipherbynid(pbe_nid);
+    ERR_pop_to_mark();
 
     if (pbe_ciph != NULL) {
         pbe = PKCS5_pbe2_set_iv_ex(pbe_ciph, iter, salt, saltlen, NULL, -1, ctx);
     } else {
-        ERR_clear_error();
         pbe = PKCS5_pbe_set_ex(pbe_nid, iter, salt, saltlen, ctx);
     }
 

--- a/crypto/x509/by_file.c
+++ b/crypto/x509/by_file.c
@@ -113,16 +113,18 @@ int X509_load_cert_file_ex(X509_LOOKUP *ctx, const char *file, int type,
 
     if (type == X509_FILETYPE_PEM) {
         for (;;) {
+            ERR_set_mark();
             if (PEM_read_bio_X509_AUX(in, &x, NULL, "") == NULL) {
                 if ((ERR_GET_REASON(ERR_peek_last_error()) ==
                      PEM_R_NO_START_LINE) && (count > 0)) {
-                    ERR_clear_error();
+                    ERR_pop_to_mark();
                     break;
                 } else {
-                    ERR_raise(ERR_LIB_X509, ERR_R_PEM_LIB);
+                    ERR_clear_last_mark();
                     goto err;
                 }
             }
+            ERR_clear_last_mark();
             i = X509_STORE_add_cert(ctx->store_ctx, x);
             if (!i)
                 goto err;


### PR DESCRIPTION
Fixes #15219

This does not replace all of them as removal of some of the ERR_clear_error() would require more substantial changes or might be potentially a security problem.
