### PR TITLE
test: fix thread test config file problem

### DIFF
--- a/test/recipes/90-test_threads.t
+++ b/test/recipes/90-test_threads.t
@@ -25,5 +25,10 @@ my $config_path = abs_path(srctop_file("test", $no_fips ? "default.cnf"
 
 plan tests => 1;
 
-ok(run(test(["threadstest", "-fips", "-config", $config_path, data_dir()])),
-   "running test_threads");
+if ($no_fips) {
+    ok(run(test(["threadstest", "-config", $config_path, data_dir()])),
+       "running test_threads");
+} else {
+    ok(run(test(["threadstest", "-fips", "-config", $config_path, data_dir()])),
+       "running test_threads with FIPS");
+}

--- a/test/recipes/90-test_threads.t
+++ b/test/recipes/90-test_threads.t
@@ -20,13 +20,10 @@ use lib srctop_dir('Configurations');
 use lib bldtop_dir('.');
 
 my $no_fips = disabled('fips') || ($ENV{NO_FIPS} // 0);
+my $config_path = abs_path(srctop_file("test", $no_fips ? "default.cnf"
+                                                        : "default-and-fips.cnf"));
 
 plan tests => 1;
 
-if ($no_fips) {
-    $ENV{OPENSSL_CONF} = abs_path(srctop_file("test", "default.cnf"));
-    ok(run(test(["threadstest", data_dir()])), "running test_threads");
-} else {
-    $ENV{OPENSSL_CONF} = abs_path(srctop_file("test", "default-and-fips.cnf"));
-    ok(run(test(["threadstest", "-fips", data_dir()])), "running test_threads");
-}
+ok(run(test(["threadstest", "-fips", "-config", $config_path, data_dir()])),
+   "running test_threads");


### PR DESCRIPTION
Force the thread test to use the configuration file via a command line arg.
Use the test library support for libctx creation.

Fixes #15243

- [ ] documentation is added or updated
- [x] tests are added or updated
