### PR TITLE
Fix OSSL_DECODER_new_for_pkey() selection parameter documentation

### DIFF
--- a/doc/man3/OSSL_DECODER_CTX_new_for_pkey.pod
+++ b/doc/man3/OSSL_DECODER_CTX_new_for_pkey.pod
@@ -108,6 +108,13 @@ C<type-specific>.  This is the structure used for keys encoded
 according to key type specific specifications.  For example, RSA keys
 encoded according to PKCS#1.
 
+=head2 Selections
+
+I<selection> can be any one of the values described in
+L<EVP_PKEY_fromdata(3)/Selections>.
+Additionally I<selection> can also be set to B<0> to indicate that the code will
+auto detect the selection.
+
 =head1 RETURN VALUES
 
 OSSL_DECODER_CTX_new_for_pkey() returns a pointer to a

--- a/doc/man3/OSSL_ENCODER_CTX_new_for_pkey.pod
+++ b/doc/man3/OSSL_ENCODER_CTX_new_for_pkey.pod
@@ -108,38 +108,10 @@ The output is the I<selection> of the I<pkey> in PEM format.
 
 =head2 Selections
 
-=begin comment
+I<selection> can be any one of the values described in
+L<EVP_PKEY_fromdata(3)/Selections>.
 
-These constants should really be documented among the EVP manuals, but this
-will have to do for now.
-
-=end comment
-
-The following constants can be used for standard I<selection>:
-
-=over 4
-
-=item B<EVP_PKEY_KEY_PARAMETERS>
-
-Indicates that only the key parameters should be included in the output.
-Where it matters, the data type in the output will indicate that the data is
-parameters, not a key.
-
-=item B<EVP_PKEY_PUBLIC_KEY>
-
-Indicates that the public key and eventual key parameters will be included
-in the output.  Where it matters, the data type in the output will indicate
-that the data is a public key.
-
-=item B<EVP_PKEY_KEYPAIR>
-
-Indicates that the private key, the public key and eventual key parameters
-should be included in the output.  Where it matters, the data type in the
-output will indicate that the data is a private key.
-
-=back
-
-These are only indications, the encoder implementations are free to
+These are only 'hints' since the encoder implementations are free to
 determine what makes sense to include in the output, and this may depend on
 the desired output.  For example, an EC key in a PKCS#8 structure doesn't
 usually include the public key.


### PR DESCRIPTION
Fixes #14518

EVP_PKEY_fromdata() already defines this value so we link to this
documentation, 0 is also added as a possible input value.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
