### PR TITLE
update-fips-checksums: Make the dependency on source list work

### DIFF
--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -569,6 +569,7 @@ clean: libclean
 	$(RM) core
 	$(RM) tags TAGS doc-nits cmd-nits md-nits
 	$(RM) -r test/test-runs
+	$(RM) providers/fips*.new
 	$(RM) openssl.pc libcrypto.pc libssl.pc
 	-find . -type l \! -name '.*' -exec $(RM) {} \;
 
@@ -1261,7 +1262,7 @@ tags TAGS: FORCE
 	-ctags -R .
 	-etags `find . -name '*.[ch]' -o -name '*.pm'`
 
-providers/fips.checksum.new: generate_fips_sources
+providers/fips.checksum.new: providers/fips.module.sources.new
 	@which unifdef > /dev/null || \
 	( echo >&2 "ERROR: unifdef not in your \$$PATH, FIPS checksums not calculated"; \
 	  false )


### PR DESCRIPTION
Also clean the generated checksums with make clean
Not sure if this one is urgent as the job is not failing anymore it just fails to do what it is expected to do.
