### PR TITLE
Init the child providers immediately on creation of the child libctx 

### DIFF
--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -276,9 +276,6 @@ OSSL_PROVIDER *ossl_provider_find(OSSL_LIB_CTX *libctx, const char *name,
         if (!noconfig) {
             if (ossl_lib_ctx_is_default(libctx))
                 OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CONFIG, NULL);
-            if (ossl_lib_ctx_is_child(libctx)
-                    && !ossl_provider_init_child_providers(libctx))
-                return NULL;
         }
 #endif
 
@@ -1007,9 +1004,6 @@ int ossl_provider_doall_activated(OSSL_LIB_CTX *ctx,
      */
     if (ossl_lib_ctx_is_default(ctx))
         OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CONFIG, NULL);
-    if (ossl_lib_ctx_is_child(ctx)
-            && !ossl_provider_init_child_providers(ctx))
-        return 0;
 #endif
 
     if (store == NULL)

--- a/doc/internal/man3/ossl_provider_new.pod
+++ b/doc/internal/man3/ossl_provider_new.pod
@@ -7,7 +7,7 @@ ossl_provider_free,
 ossl_provider_set_fallback, ossl_provider_set_module_path,
 ossl_provider_add_parameter, ossl_provider_set_child, ossl_provider_get_parent,
 ossl_provider_up_ref_parent, ossl_provider_free_parent,
-ossl_provider_get0_dispatch, ossl_provider_init_child_providers,
+ossl_provider_get0_dispatch,
 ossl_provider_init_as_child,
 ossl_provider_activate, ossl_provider_deactivate, ossl_provider_available,
 ossl_provider_ctx,
@@ -95,7 +95,6 @@ ossl_provider_get_capabilities
                                       int *result);
  int ossl_provider_clear_all_operation_bits(OSSL_LIB_CTX *libctx);
 
- int ossl_provider_init_child_providers(OSSL_LIB_CTX *ctx);
  int ossl_provider_init_as_child(OSSL_LIB_CTX *ctx,
                                  const OSSL_CORE_HANDLE *handle,
                                  const OSSL_DISPATCH *in);
@@ -290,10 +289,6 @@ I<*result> to 1 or 0 accorddingly.
 
 ossl_provider_clear_all_operation_bits() clears all of the operation bits
 to (0) for all providers in the library context I<libctx>.
-
-ossl_provider_init_child_providers() registers the callbacks required to
-receive notifications about loading and unloading of providers in the parent
-library context.
 
 ossl_provider_init_as_child() stores in the library context I<ctx> references to
 the necessary upcalls for managing child providers. The I<handle> and I<in>

--- a/include/internal/provider.h
+++ b/include/internal/provider.h
@@ -108,7 +108,6 @@ int ossl_provider_clear_all_operation_bits(OSSL_LIB_CTX *libctx);
 void ossl_provider_add_conf_module(void);
 
 /* Child providers */
-int ossl_provider_init_child_providers(OSSL_LIB_CTX *ctx);
 int ossl_provider_init_as_child(OSSL_LIB_CTX *ctx,
                                 const OSSL_CORE_HANDLE *handle,
                                 const OSSL_DISPATCH *in);

--- a/test/p_test.c
+++ b/test/p_test.c
@@ -61,6 +61,18 @@ static OSSL_FUNC_provider_get_params_fn p_get_params;
 static OSSL_FUNC_provider_get_reason_strings_fn p_get_reason_strings;
 static OSSL_FUNC_provider_teardown_fn p_teardown;
 
+static void p_set_error(int lib, int reason, const char *file, int line,
+                        const char *func, const char *fmt, ...)
+{
+    va_list ap;
+
+    va_start(ap, fmt);
+    c_new_error(NULL);
+    c_set_error_debug(NULL, file, line, func);
+    c_vset_error(NULL, ERR_PACK(lib, 0, reason), fmt, ap);
+    va_end(ap);
+}
+
 static const OSSL_PARAM *p_gettable_params(void *_)
 {
     return p_param_types;
@@ -130,12 +142,26 @@ static int p_get_params(void *provctx, OSSL_PARAM params[])
             unsigned char out[16];
 
             /*
+            * "default" has not been loaded into the parent libctx. We should be able
+            * to explicitly load it as a non-child provider.
+            */
+            ctx->deflt = OSSL_PROVIDER_load(ctx->libctx, "default");
+            if (ctx->deflt == NULL
+                    || !OSSL_PROVIDER_available(ctx->libctx, "default")) {
+                /* We set error "3" for a failure to load the default provider */
+                p_set_error(ERR_LIB_PROV, 3, ctx->thisfile, OPENSSL_LINE,
+                            ctx->thisfunc, NULL);
+                ok = 0;
+            }
+
+            /*
              * We should have the default provider available that we loaded
              * ourselves, and the base and legacy providers which we inherit
              * from the parent libctx. We should also have "this" provider
              * available.
              */
-            if (OSSL_PROVIDER_available(ctx->libctx, "default")
+            if (ok
+                    && OSSL_PROVIDER_available(ctx->libctx, "default")
                     && OSSL_PROVIDER_available(ctx->libctx, "base")
                     && OSSL_PROVIDER_available(ctx->libctx, "legacy")
                     && OSSL_PROVIDER_available(ctx->libctx, "p_test")
@@ -144,7 +170,7 @@ static int p_get_params(void *provctx, OSSL_PARAM params[])
                 if (EVP_DigestInit_ex(mdctx, md4, NULL)
                         && EVP_DigestUpdate(mdctx, (const unsigned char *)msg,
                                             strlen(msg))
-                        &&EVP_DigestFinal(mdctx, out, NULL))
+                        && EVP_DigestFinal(mdctx, out, NULL))
                     digestsuccess = 1;
             }
             EVP_MD_CTX_free(mdctx);
@@ -159,18 +185,6 @@ static int p_get_params(void *provctx, OSSL_PARAM params[])
         }
     }
     return ok;
-}
-
-static void p_set_error(int lib, int reason, const char *file, int line,
-                        const char *func, const char *fmt, ...)
-{
-    va_list ap;
-
-    va_start(ap, fmt);
-    c_new_error(NULL);
-    c_set_error_debug(NULL, file, line, func);
-    c_vset_error(NULL, ERR_PACK(lib, 0, reason), fmt, ap);
-    va_end(ap);
 }
 
 static const OSSL_ITEM *p_get_reason_strings(void *_)
@@ -247,19 +261,6 @@ int OSSL_provider_init(const OSSL_CORE_HANDLE *handle,
     if (ctx->libctx == NULL) {
         /* We set error "2" for a failure to create the child libctx*/
         p_set_error(ERR_LIB_PROV, 2, ctx->thisfile, OPENSSL_LINE, ctx->thisfunc,
-                    NULL);
-        p_teardown(ctx);
-        return 0;
-    }
-    /*
-     * "default" has not been loaded into the parent libctx. We should be able
-     * to explicitly load it as a non-child provider.
-     */
-    ctx->deflt = OSSL_PROVIDER_load(ctx->libctx, "default");
-    if (ctx->deflt == NULL
-            || !OSSL_PROVIDER_available(ctx->libctx, "default")) {
-        /* We set error "3" for a failure to load the default provider */
-        p_set_error(ERR_LIB_PROV, 3, ctx->thisfile, OPENSSL_LINE, ctx->thisfunc,
                     NULL);
         p_teardown(ctx);
         return 0;


### PR DESCRIPTION
We were deferring the initial creation of the child providers until the
first fetch. This is a carry over from an earlier iteration of the child
lib ctx development and is no longer necessary. In fact we need to init
the child providers immediately otherwise not all providers quite init
correctly.

This should fix the issues currently being experienced in #14326.