### PR TITLE
Rename the field 'provctx and data' to 'algctx' inside some EVP objects.

### DIFF
--- a/crypto/evp/asymcipher.c
+++ b/crypto/evp/asymcipher.c
@@ -99,8 +99,8 @@ static int evp_pkey_asym_cipher_init(EVP_PKEY_CTX *ctx, int operation,
     /* No more legacy from here down to legacy: */
 
     ctx->op.ciph.cipher = cipher;
-    ctx->op.ciph.ciphprovctx = cipher->newctx(ossl_provider_ctx(cipher->prov));
-    if (ctx->op.ciph.ciphprovctx == NULL) {
+    ctx->op.ciph.algctx = cipher->newctx(ossl_provider_ctx(cipher->prov));
+    if (ctx->op.ciph.algctx == NULL) {
         /* The provider key can stay in the cache */
         ERR_raise(ERR_LIB_EVP, EVP_R_INITIALIZATION_ERROR);
         goto err;
@@ -113,7 +113,7 @@ static int evp_pkey_asym_cipher_init(EVP_PKEY_CTX *ctx, int operation,
             ret = -2;
             goto err;
         }
-        ret = cipher->encrypt_init(ctx->op.ciph.ciphprovctx, provkey, params);
+        ret = cipher->encrypt_init(ctx->op.ciph.algctx, provkey, params);
         break;
     case EVP_PKEY_OP_DECRYPT:
         if (cipher->decrypt_init == NULL) {
@@ -121,7 +121,7 @@ static int evp_pkey_asym_cipher_init(EVP_PKEY_CTX *ctx, int operation,
             ret = -2;
             goto err;
         }
-        ret = cipher->decrypt_init(ctx->op.ciph.ciphprovctx, provkey, params);
+        ret = cipher->decrypt_init(ctx->op.ciph.algctx, provkey, params);
         break;
     default:
         ERR_raise(ERR_LIB_EVP, EVP_R_INITIALIZATION_ERROR);
@@ -194,10 +194,10 @@ int EVP_PKEY_encrypt(EVP_PKEY_CTX *ctx,
         return -1;
     }
 
-    if (ctx->op.ciph.ciphprovctx == NULL)
+    if (ctx->op.ciph.algctx == NULL)
         goto legacy;
 
-    ret = ctx->op.ciph.cipher->encrypt(ctx->op.ciph.ciphprovctx, out, outlen,
+    ret = ctx->op.ciph.cipher->encrypt(ctx->op.ciph.algctx, out, outlen,
                                        (out == NULL ? 0 : *outlen), in, inlen);
     return ret;
 
@@ -236,10 +236,10 @@ int EVP_PKEY_decrypt(EVP_PKEY_CTX *ctx,
         return -1;
     }
 
-    if (ctx->op.ciph.ciphprovctx == NULL)
+    if (ctx->op.ciph.algctx == NULL)
         goto legacy;
 
-    ret = ctx->op.ciph.cipher->decrypt(ctx->op.ciph.ciphprovctx, out, outlen,
+    ret = ctx->op.ciph.cipher->decrypt(ctx->op.ciph.algctx, out, outlen,
                                        (out == NULL ? 0 : *outlen), in, inlen);
     return ret;
 

--- a/crypto/evp/ctrl_params_translate.c
+++ b/crypto/evp/ctrl_params_translate.c
@@ -419,13 +419,13 @@ static int default_fixup_args(enum state state,
 
         if (translation->optype != 0) {
             if ((EVP_PKEY_CTX_IS_SIGNATURE_OP(ctx->pctx)
-                 && ctx->pctx->op.sig.sigprovctx == NULL)
+                 && ctx->pctx->op.sig.algctx == NULL)
                 || (EVP_PKEY_CTX_IS_DERIVE_OP(ctx->pctx)
-                    && ctx->pctx->op.kex.exchprovctx == NULL)
+                    && ctx->pctx->op.kex.algctx == NULL)
                 || (EVP_PKEY_CTX_IS_ASYM_CIPHER_OP(ctx->pctx)
-                    && ctx->pctx->op.ciph.ciphprovctx == NULL)
+                    && ctx->pctx->op.ciph.algctx == NULL)
                 || (EVP_PKEY_CTX_IS_KEM_OP(ctx->pctx)
-                    && ctx->pctx->op.encap.kemprovctx == NULL)
+                    && ctx->pctx->op.encap.algctx == NULL)
                 /*
                  * The following may be unnecessary, but we have them
                  * for good measure...

--- a/crypto/evp/digest.c
+++ b/crypto/evp/digest.c
@@ -26,10 +26,10 @@
 
 void evp_md_ctx_clear_digest(EVP_MD_CTX *ctx, int force)
 {
-    if (ctx->provctx != NULL) {
+    if (ctx->algctx != NULL) {
         if (ctx->digest != NULL && ctx->digest->freectx != NULL)
-            ctx->digest->freectx(ctx->provctx);
-        ctx->provctx = NULL;
+            ctx->digest->freectx(ctx->algctx);
+        ctx->algctx = NULL;
         EVP_MD_CTX_set_flags(ctx, EVP_MD_CTX_FLAG_CLEANED);
     }
 
@@ -132,7 +132,7 @@ static int evp_md_init_internal(EVP_MD_CTX *ctx, const EVP_MD *type,
 #if !defined(FIPS_MODULE)
     if (ctx->pctx != NULL
             && EVP_PKEY_CTX_IS_SIGNATURE_OP(ctx->pctx)
-            && ctx->pctx->op.sig.sigprovctx != NULL) {
+            && ctx->pctx->op.sig.algctx != NULL) {
         /*
          * Prior to OpenSSL 3.0 calling EVP_DigestInit_ex() on an mdctx
          * previously initialised with EVP_DigestSignInit() would retain
@@ -150,14 +150,14 @@ static int evp_md_init_internal(EVP_MD_CTX *ctx, const EVP_MD *type,
 
     EVP_MD_CTX_clear_flags(ctx, EVP_MD_CTX_FLAG_CLEANED);
 
-    if (ctx->provctx != NULL) {
+    if (ctx->algctx != NULL) {
         if (!ossl_assert(ctx->digest != NULL)) {
             ERR_raise(ERR_LIB_EVP, EVP_R_INITIALIZATION_ERROR);
             return 0;
         }
         if (ctx->digest->freectx != NULL)
-            ctx->digest->freectx(ctx->provctx);
-        ctx->provctx = NULL;
+            ctx->digest->freectx(ctx->algctx);
+        ctx->algctx = NULL;
     }
 
     if (type != NULL) {
@@ -238,10 +238,10 @@ static int evp_md_init_internal(EVP_MD_CTX *ctx, const EVP_MD *type,
 #endif
     }
 
-    if (ctx->provctx != NULL && ctx->digest != NULL && ctx->digest != type) {
+    if (ctx->algctx != NULL && ctx->digest != NULL && ctx->digest != type) {
         if (ctx->digest->freectx != NULL)
-            ctx->digest->freectx(ctx->provctx);
-        ctx->provctx = NULL;
+            ctx->digest->freectx(ctx->algctx);
+        ctx->algctx = NULL;
     }
     if (type->prov != NULL && ctx->fetched_digest != type) {
         if (!EVP_MD_up_ref((EVP_MD *)type)) {
@@ -252,9 +252,9 @@ static int evp_md_init_internal(EVP_MD_CTX *ctx, const EVP_MD *type,
         ctx->fetched_digest = (EVP_MD *)type;
     }
     ctx->digest = type;
-    if (ctx->provctx == NULL) {
-        ctx->provctx = ctx->digest->newctx(ossl_provider_ctx(type->prov));
-        if (ctx->provctx == NULL) {
+    if (ctx->algctx == NULL) {
+        ctx->algctx = ctx->digest->newctx(ossl_provider_ctx(type->prov));
+        if (ctx->algctx == NULL) {
             ERR_raise(ERR_LIB_EVP, EVP_R_INITIALIZATION_ERROR);
             return 0;
         }
@@ -265,7 +265,7 @@ static int evp_md_init_internal(EVP_MD_CTX *ctx, const EVP_MD *type,
         return 0;
     }
 
-    return ctx->digest->dinit(ctx->provctx, params);
+    return ctx->digest->dinit(ctx->algctx, params);
 
     /* Code below to be removed when legacy support is dropped. */
  legacy:
@@ -359,7 +359,7 @@ int EVP_DigestUpdate(EVP_MD_CTX *ctx, const void *data, size_t count)
 
     if (ctx->pctx != NULL
             && EVP_PKEY_CTX_IS_SIGNATURE_OP(ctx->pctx)
-            && ctx->pctx->op.sig.sigprovctx != NULL) {
+            && ctx->pctx->op.sig.algctx != NULL) {
         /*
          * Prior to OpenSSL 3.0 EVP_DigestSignUpdate() and
          * EVP_DigestVerifyUpdate() were just macros for EVP_DigestUpdate().
@@ -385,7 +385,7 @@ int EVP_DigestUpdate(EVP_MD_CTX *ctx, const void *data, size_t count)
         ERR_raise(ERR_LIB_EVP, EVP_R_UPDATE_ERROR);
         return 0;
     }
-    return ctx->digest->dupdate(ctx->provctx, data, count);
+    return ctx->digest->dupdate(ctx->algctx, data, count);
 
     /* Code below to be removed when legacy support is dropped. */
  legacy:
@@ -423,7 +423,7 @@ int EVP_DigestFinal_ex(EVP_MD_CTX *ctx, unsigned char *md, unsigned int *isize)
         return 0;
     }
 
-    ret = ctx->digest->dfinal(ctx->provctx, md, &size, mdsize);
+    ret = ctx->digest->dfinal(ctx->algctx, md, &size, mdsize);
 
     if (isize != NULL) {
         if (size <= UINT_MAX) {
@@ -473,7 +473,7 @@ int EVP_DigestFinalXOF(EVP_MD_CTX *ctx, unsigned char *md, size_t size)
     params[i++] = OSSL_PARAM_construct_end();
 
     if (EVP_MD_CTX_set_params(ctx, params) > 0)
-        ret = ctx->digest->dfinal(ctx->provctx, md, &size, size);
+        ret = ctx->digest->dfinal(ctx->algctx, md, &size, size);
 
     return ret;
 
@@ -524,14 +524,14 @@ int EVP_MD_CTX_copy_ex(EVP_MD_CTX *out, const EVP_MD_CTX *in)
     *out = *in;
     /* NULL out pointers in case of error */
     out->pctx = NULL;
-    out->provctx = NULL;
+    out->algctx = NULL;
 
     if (in->fetched_digest != NULL)
         EVP_MD_up_ref(in->fetched_digest);
 
-    if (in->provctx != NULL) {
-        out->provctx = in->digest->dupctx(in->provctx);
-        if (out->provctx == NULL) {
+    if (in->algctx != NULL) {
+        out->algctx = in->digest->dupctx(in->algctx);
+        if (out->algctx == NULL) {
             ERR_raise(ERR_LIB_EVP, EVP_R_NOT_ABLE_TO_COPY_CTX);
             return 0;
         }
@@ -666,24 +666,24 @@ int EVP_MD_CTX_set_params(EVP_MD_CTX *ctx, const OSSL_PARAM params[])
     if (pctx != NULL
             && (pctx->operation == EVP_PKEY_OP_VERIFYCTX
                 || pctx->operation == EVP_PKEY_OP_SIGNCTX)
-            && pctx->op.sig.sigprovctx != NULL
+            && pctx->op.sig.algctx != NULL
             && pctx->op.sig.signature->set_ctx_md_params != NULL)
-        return pctx->op.sig.signature->set_ctx_md_params(pctx->op.sig.sigprovctx,
+        return pctx->op.sig.signature->set_ctx_md_params(pctx->op.sig.algctx,
                                                          params);
 
     if (ctx->digest != NULL && ctx->digest->set_ctx_params != NULL)
-        return ctx->digest->set_ctx_params(ctx->provctx, params);
+        return ctx->digest->set_ctx_params(ctx->algctx, params);
 
     return 0;
 }
 
 const OSSL_PARAM *EVP_MD_settable_ctx_params(const EVP_MD *md)
 {
-    void *alg;
+    void *provctx;
 
     if (md != NULL && md->settable_ctx_params != NULL) {
-        alg = ossl_provider_ctx(EVP_MD_provider(md));
-        return md->settable_ctx_params(NULL, alg);
+        provctx = ossl_provider_ctx(EVP_MD_provider(md));
+        return md->settable_ctx_params(NULL, provctx);
     }
     return NULL;
 }
@@ -701,14 +701,14 @@ const OSSL_PARAM *EVP_MD_CTX_settable_params(EVP_MD_CTX *ctx)
     if (pctx != NULL
             && (pctx->operation == EVP_PKEY_OP_VERIFYCTX
                 || pctx->operation == EVP_PKEY_OP_SIGNCTX)
-            && pctx->op.sig.sigprovctx != NULL
+            && pctx->op.sig.algctx != NULL
             && pctx->op.sig.signature->settable_ctx_md_params != NULL)
         return pctx->op.sig.signature->settable_ctx_md_params(
-                   pctx->op.sig.sigprovctx);
+                   pctx->op.sig.algctx);
 
     if (ctx->digest != NULL && ctx->digest->settable_ctx_params != NULL) {
         alg = ossl_provider_ctx(EVP_MD_provider(ctx->digest));
-        return ctx->digest->settable_ctx_params(ctx->provctx, alg);
+        return ctx->digest->settable_ctx_params(ctx->algctx, alg);
     }
 
     return NULL;
@@ -722,24 +722,24 @@ int EVP_MD_CTX_get_params(EVP_MD_CTX *ctx, OSSL_PARAM params[])
     if (pctx != NULL
             && (pctx->operation == EVP_PKEY_OP_VERIFYCTX
                 || pctx->operation == EVP_PKEY_OP_SIGNCTX)
-            && pctx->op.sig.sigprovctx != NULL
+            && pctx->op.sig.algctx != NULL
             && pctx->op.sig.signature->get_ctx_md_params != NULL)
-        return pctx->op.sig.signature->get_ctx_md_params(pctx->op.sig.sigprovctx,
+        return pctx->op.sig.signature->get_ctx_md_params(pctx->op.sig.algctx,
                                                          params);
 
     if (ctx->digest != NULL && ctx->digest->get_params != NULL)
-        return ctx->digest->get_ctx_params(ctx->provctx, params);
+        return ctx->digest->get_ctx_params(ctx->algctx, params);
 
     return 0;
 }
 
 const OSSL_PARAM *EVP_MD_gettable_ctx_params(const EVP_MD *md)
 {
-    void *alg;
+    void *provctx;
 
     if (md != NULL && md->gettable_ctx_params != NULL) {
-        alg = ossl_provider_ctx(EVP_MD_provider(md));
-        return md->gettable_ctx_params(NULL, alg);
+        provctx = ossl_provider_ctx(EVP_MD_provider(md));
+        return md->gettable_ctx_params(NULL, provctx);
     }
     return NULL;
 }
@@ -747,7 +747,7 @@ const OSSL_PARAM *EVP_MD_gettable_ctx_params(const EVP_MD *md)
 const OSSL_PARAM *EVP_MD_CTX_gettable_params(EVP_MD_CTX *ctx)
 {
     EVP_PKEY_CTX *pctx;
-    void *alg;
+    void *provctx;
 
     if (ctx == NULL)
         return NULL;
@@ -757,14 +757,14 @@ const OSSL_PARAM *EVP_MD_CTX_gettable_params(EVP_MD_CTX *ctx)
     if (pctx != NULL
             && (pctx->operation == EVP_PKEY_OP_VERIFYCTX
                 || pctx->operation == EVP_PKEY_OP_SIGNCTX)
-            && pctx->op.sig.sigprovctx != NULL
+            && pctx->op.sig.algctx != NULL
             && pctx->op.sig.signature->gettable_ctx_md_params != NULL)
         return pctx->op.sig.signature->gettable_ctx_md_params(
-                    pctx->op.sig.sigprovctx);
+                    pctx->op.sig.algctx);
 
     if (ctx->digest != NULL && ctx->digest->gettable_ctx_params != NULL) {
-        alg = ossl_provider_ctx(EVP_MD_provider(ctx->digest));
-        return ctx->digest->gettable_ctx_params(ctx->provctx, alg);
+        provctx = ossl_provider_ctx(EVP_MD_provider(ctx->digest));
+        return ctx->digest->gettable_ctx_params(ctx->algctx, provctx);
     }
     return NULL;
 }

--- a/crypto/evp/evp_lib.c
+++ b/crypto/evp/evp_lib.c
@@ -412,16 +412,16 @@ int EVP_Cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
         size_t blocksize = EVP_CIPHER_CTX_block_size(ctx);
 
         if (ctx->cipher->ccipher != NULL)
-            ret =  ctx->cipher->ccipher(ctx->provctx, out, &outl,
+            ret =  ctx->cipher->ccipher(ctx->algctx, out, &outl,
                                         inl + (blocksize == 1 ? 0 : blocksize),
                                         in, (size_t)inl)
                 ? (int)outl : -1;
         else if (in != NULL)
-            ret = ctx->cipher->cupdate(ctx->provctx, out, &outl,
+            ret = ctx->cipher->cupdate(ctx->algctx, out, &outl,
                                        inl + (blocksize == 1 ? 0 : blocksize),
                                        in, (size_t)inl);
         else
-            ret = ctx->cipher->cfinal(ctx->provctx, out, &outl,
+            ret = ctx->cipher->cfinal(ctx->algctx, out, &outl,
                                       blocksize == 1 ? 0 : blocksize);
 
         return ret;
@@ -505,7 +505,7 @@ int EVP_CIPHER_CTX_iv_length(const EVP_CIPHER_CTX *ctx)
     OSSL_PARAM params[2] = { OSSL_PARAM_END, OSSL_PARAM_END };
 
     params[0] = OSSL_PARAM_construct_size_t(OSSL_CIPHER_PARAM_IVLEN, &v);
-    rv = evp_do_ciph_ctx_getparams(ctx->cipher, ctx->provctx, params);
+    rv = evp_do_ciph_ctx_getparams(ctx->cipher, ctx->algctx, params);
     if (rv == EVP_CTRL_RET_UNSUPPORTED)
         goto legacy;
     return rv != 0 ? (int)v : -1;
@@ -526,7 +526,7 @@ int EVP_CIPHER_CTX_tag_length(const EVP_CIPHER_CTX *ctx)
     OSSL_PARAM params[2] = { OSSL_PARAM_END, OSSL_PARAM_END };
 
     params[0] = OSSL_PARAM_construct_size_t(OSSL_CIPHER_PARAM_AEAD_TAGLEN, &v);
-    ret = evp_do_ciph_ctx_getparams(ctx->cipher, ctx->provctx, params);
+    ret = evp_do_ciph_ctx_getparams(ctx->cipher, ctx->algctx, params);
     return ret == 1 ? (int)v : 0;
 }
 
@@ -540,7 +540,7 @@ const unsigned char *EVP_CIPHER_CTX_original_iv(const EVP_CIPHER_CTX *ctx)
     params[0] =
         OSSL_PARAM_construct_octet_ptr(OSSL_CIPHER_PARAM_IV,
                                        (void **)&v, sizeof(ctx->oiv));
-    ok = evp_do_ciph_ctx_getparams(ctx->cipher, ctx->provctx, params);
+    ok = evp_do_ciph_ctx_getparams(ctx->cipher, ctx->algctx, params);
 
     return ok != 0 ? v : NULL;
 }
@@ -557,7 +557,7 @@ const unsigned char *EVP_CIPHER_CTX_iv(const EVP_CIPHER_CTX *ctx)
     params[0] =
         OSSL_PARAM_construct_octet_ptr(OSSL_CIPHER_PARAM_UPDATED_IV,
                                        (void **)&v, sizeof(ctx->iv));
-    ok = evp_do_ciph_ctx_getparams(ctx->cipher, ctx->provctx, params);
+    ok = evp_do_ciph_ctx_getparams(ctx->cipher, ctx->algctx, params);
 
     return ok != 0 ? v : NULL;
 }
@@ -571,7 +571,7 @@ unsigned char *EVP_CIPHER_CTX_iv_noconst(EVP_CIPHER_CTX *ctx)
     params[0] =
         OSSL_PARAM_construct_octet_ptr(OSSL_CIPHER_PARAM_UPDATED_IV,
                                        (void **)&v, sizeof(ctx->iv));
-    ok = evp_do_ciph_ctx_getparams(ctx->cipher, ctx->provctx, params);
+    ok = evp_do_ciph_ctx_getparams(ctx->cipher, ctx->algctx, params);
 
     return ok != 0 ? v : NULL;
 }
@@ -583,7 +583,7 @@ int EVP_CIPHER_CTX_get_updated_iv(EVP_CIPHER_CTX *ctx, void *buf, size_t len)
 
     params[0] =
         OSSL_PARAM_construct_octet_string(OSSL_CIPHER_PARAM_UPDATED_IV, buf, len);
-    return evp_do_ciph_ctx_getparams(ctx->cipher, ctx->provctx, params);
+    return evp_do_ciph_ctx_getparams(ctx->cipher, ctx->algctx, params);
 }
 
 int EVP_CIPHER_CTX_get_original_iv(EVP_CIPHER_CTX *ctx, void *buf, size_t len)
@@ -592,7 +592,7 @@ int EVP_CIPHER_CTX_get_original_iv(EVP_CIPHER_CTX *ctx, void *buf, size_t len)
 
     params[0] =
         OSSL_PARAM_construct_octet_string(OSSL_CIPHER_PARAM_IV, buf, len);
-    return evp_do_ciph_ctx_getparams(ctx->cipher, ctx->provctx, params);
+    return evp_do_ciph_ctx_getparams(ctx->cipher, ctx->algctx, params);
 }
 
 unsigned char *EVP_CIPHER_CTX_buf_noconst(EVP_CIPHER_CTX *ctx)
@@ -607,7 +607,7 @@ int EVP_CIPHER_CTX_num(const EVP_CIPHER_CTX *ctx)
     OSSL_PARAM params[2] = { OSSL_PARAM_END, OSSL_PARAM_END };
 
     params[0] = OSSL_PARAM_construct_uint(OSSL_CIPHER_PARAM_NUM, &v);
-    ok = evp_do_ciph_ctx_getparams(ctx->cipher, ctx->provctx, params);
+    ok = evp_do_ciph_ctx_getparams(ctx->cipher, ctx->algctx, params);
 
     return ok != 0 ? (int)v : EVP_CTRL_RET_UNSUPPORTED;
 }
@@ -619,7 +619,7 @@ int EVP_CIPHER_CTX_set_num(EVP_CIPHER_CTX *ctx, int num)
     OSSL_PARAM params[2] = { OSSL_PARAM_END, OSSL_PARAM_END };
 
     params[0] = OSSL_PARAM_construct_uint(OSSL_CIPHER_PARAM_NUM, &n);
-    ok = evp_do_ciph_ctx_setparams(ctx->cipher, ctx->provctx, params);
+    ok = evp_do_ciph_ctx_setparams(ctx->cipher, ctx->algctx, params);
 
     if (ok != 0)
         ctx->num = (int)n;
@@ -638,7 +638,7 @@ int EVP_CIPHER_CTX_key_length(const EVP_CIPHER_CTX *ctx)
     OSSL_PARAM params[2] = { OSSL_PARAM_END, OSSL_PARAM_END };
 
     params[0] = OSSL_PARAM_construct_size_t(OSSL_CIPHER_PARAM_KEYLEN, &v);
-    ok = evp_do_ciph_ctx_getparams(ctx->cipher, ctx->provctx, params);
+    ok = evp_do_ciph_ctx_getparams(ctx->cipher, ctx->algctx, params);
 
     return ok != 0 ? (int)v : EVP_CTRL_RET_UNSUPPORTED;
 }

--- a/crypto/evp/evp_local.h
+++ b/crypto/evp/evp_local.h
@@ -7,8 +7,6 @@
  * https://www.openssl.org/source/license.html
  */
 
-/* EVP_MD_CTX related stuff */
-
 #include <openssl/core_dispatch.h>
 #include "internal/refcount.h"
 
@@ -27,8 +25,11 @@ struct evp_md_ctx_st {
     /* Update function: usually copied from EVP_MD */
     int (*update) (EVP_MD_CTX *ctx, const void *data, size_t count);
 
-    /* Provider ctx */
-    void *provctx;
+    /*
+     * Opaque ctx returned from a providers digest algorithm implementation
+     * OSSL_FUNC_digest_newctx()
+     */
+    void *algctx;
     EVP_MD *fetched_digest;
 } /* EVP_MD_CTX */ ;
 
@@ -51,24 +52,27 @@ struct evp_cipher_ctx_st {
     int block_mask;
     unsigned char final[EVP_MAX_BLOCK_LENGTH]; /* possible final block */
 
-    /* Provider ctx */
-    void *provctx;
+    /*
+     * Opaque ctx returned from a providers cipher algorithm implementation
+     * OSSL_FUNC_cipher_newctx()
+     */
+    void *algctx;
     EVP_CIPHER *fetched_cipher;
 } /* EVP_CIPHER_CTX */ ;
 
 struct evp_mac_ctx_st {
     EVP_MAC *meth;               /* Method structure */
-    void *data;                  /* Individual method data */
+    void *algctx;                /* Algorithm-specific ctx */
 } /* EVP_MAC_CTX */;
 
 struct evp_kdf_ctx_st {
     EVP_KDF *meth;              /* Method structure */
-    void *data;                 /* Algorithm-specific data */
+    void *algctx;               /* Algorithm-specific ctx */
 } /* EVP_KDF_CTX */ ;
 
 struct evp_rand_ctx_st {
     EVP_RAND *meth;             /* Method structure */
-    void *data;                 /* Algorithm-specific data */
+    void *algctx;               /* Algorithm-specific ctx */
     EVP_RAND_CTX *parent;       /* Parent EVP_RAND or NULL if none */
     CRYPTO_REF_COUNT refcnt;    /* Context reference count */
     CRYPTO_RWLOCK *refcnt_lock;

--- a/crypto/evp/evp_local.h
+++ b/crypto/evp/evp_local.h
@@ -62,17 +62,29 @@ struct evp_cipher_ctx_st {
 
 struct evp_mac_ctx_st {
     EVP_MAC *meth;               /* Method structure */
-    void *algctx;                /* Algorithm-specific ctx */
+    /*
+     * Opaque ctx returned from a providers MAC algorithm implementation
+     * OSSL_FUNC_mac_newctx()
+     */
+    void *algctx;
 } /* EVP_MAC_CTX */;
 
 struct evp_kdf_ctx_st {
     EVP_KDF *meth;              /* Method structure */
-    void *algctx;               /* Algorithm-specific ctx */
+    /*
+     * Opaque ctx returned from a providers KDF algorithm implementation
+     * OSSL_FUNC_kdf_newctx()
+     */
+    void *algctx;
 } /* EVP_KDF_CTX */ ;
 
 struct evp_rand_ctx_st {
     EVP_RAND *meth;             /* Method structure */
-    void *algctx;               /* Algorithm-specific ctx */
+    /*
+     * Opaque ctx returned from a providers rand algorithm implementation
+     * OSSL_FUNC_rand_newctx()
+     */
+    void *algctx;
     EVP_RAND_CTX *parent;       /* Parent EVP_RAND or NULL if none */
     CRYPTO_REF_COUNT refcnt;    /* Context reference count */
     CRYPTO_RWLOCK *refcnt_lock;

--- a/crypto/evp/evp_rand.c
+++ b/crypto/evp/evp_rand.c
@@ -97,7 +97,7 @@ static void *evp_rand_new(void)
 int EVP_RAND_enable_locking(EVP_RAND_CTX *rand)
 {
     if (rand->meth->enable_locking != NULL)
-        return rand->meth->enable_locking(rand->data);
+        return rand->meth->enable_locking(rand->algctx);
     ERR_raise(ERR_LIB_EVP, EVP_R_LOCKING_NOT_SUPPORTED);
     return 0;
 }
@@ -106,7 +106,7 @@ int EVP_RAND_enable_locking(EVP_RAND_CTX *rand)
 static int evp_rand_lock(EVP_RAND_CTX *rand)
 {
     if (rand->meth->lock != NULL)
-        return rand->meth->lock(rand->data);
+        return rand->meth->lock(rand->algctx);
     return 1;
 }
 
@@ -114,7 +114,7 @@ static int evp_rand_lock(EVP_RAND_CTX *rand)
 static void evp_rand_unlock(EVP_RAND_CTX *rand)
 {
     if (rand->meth->unlock != NULL)
-        rand->meth->unlock(rand->data);
+        rand->meth->unlock(rand->algctx);
 }
 
 static void *evp_rand_from_algorithm(int name_id,
@@ -356,14 +356,14 @@ EVP_RAND_CTX *EVP_RAND_CTX_new(EVP_RAND *rand, EVP_RAND_CTX *parent)
             OPENSSL_free(ctx);
             return NULL;
         }
-        parent_ctx = parent->data;
+        parent_ctx = parent->algctx;
         parent_dispatch = parent->meth->dispatch;
     }
-    if ((ctx->data = rand->newctx(ossl_provider_ctx(rand->prov), parent_ctx,
-                                  parent_dispatch)) == NULL
+    if ((ctx->algctx = rand->newctx(ossl_provider_ctx(rand->prov), parent_ctx,
+                                    parent_dispatch)) == NULL
             || !EVP_RAND_up_ref(rand)) {
         ERR_raise(ERR_LIB_EVP, ERR_R_MALLOC_FAILURE);
-        rand->freectx(ctx->data);
+        rand->freectx(ctx->algctx);
         CRYPTO_THREAD_lock_free(ctx->refcnt_lock);
         OPENSSL_free(ctx);
         EVP_RAND_CTX_free(parent);
@@ -387,8 +387,8 @@ void EVP_RAND_CTX_free(EVP_RAND_CTX *ctx)
     if (ref > 0)
         return;
     parent = ctx->parent;
-    ctx->meth->freectx(ctx->data);
-    ctx->data = NULL;
+    ctx->meth->freectx(ctx->algctx);
+    ctx->algctx = NULL;
     EVP_RAND_free(ctx->meth);
     CRYPTO_THREAD_lock_free(ctx->refcnt_lock);
     OPENSSL_free(ctx);
@@ -403,7 +403,7 @@ EVP_RAND *EVP_RAND_CTX_rand(EVP_RAND_CTX *ctx)
 static int evp_rand_get_ctx_params_locked(EVP_RAND_CTX *ctx,
                                           OSSL_PARAM params[])
 {
-    return ctx->meth->get_ctx_params(ctx->data, params);
+    return ctx->meth->get_ctx_params(ctx->algctx, params);
 }
 
 int EVP_RAND_CTX_get_params(EVP_RAND_CTX *ctx, OSSL_PARAM params[])
@@ -421,7 +421,7 @@ static int evp_rand_set_ctx_params_locked(EVP_RAND_CTX *ctx,
                                           const OSSL_PARAM params[])
 {
     if (ctx->meth->set_ctx_params != NULL)
-        return ctx->meth->set_ctx_params(ctx->data, params);
+        return ctx->meth->set_ctx_params(ctx->algctx, params);
     return 1;
 }
 
@@ -470,7 +470,7 @@ const OSSL_PARAM *EVP_RAND_CTX_gettable_params(EVP_RAND_CTX *ctx)
     if (ctx->meth->gettable_ctx_params == NULL)
         return NULL;
     provctx = ossl_provider_ctx(EVP_RAND_provider(ctx->meth));
-    return ctx->meth->gettable_ctx_params(ctx->data, provctx);
+    return ctx->meth->gettable_ctx_params(ctx->algctx, provctx);
 }
 
 const OSSL_PARAM *EVP_RAND_CTX_settable_params(EVP_RAND_CTX *ctx)
@@ -480,7 +480,7 @@ const OSSL_PARAM *EVP_RAND_CTX_settable_params(EVP_RAND_CTX *ctx)
     if (ctx->meth->settable_ctx_params == NULL)
         return NULL;
     provctx = ossl_provider_ctx(EVP_RAND_provider(ctx->meth));
-    return ctx->meth->settable_ctx_params(ctx->data, provctx);
+    return ctx->meth->settable_ctx_params(ctx->algctx, provctx);
 }
 
 void EVP_RAND_do_all_provided(OSSL_LIB_CTX *libctx,
@@ -506,7 +506,7 @@ static int evp_rand_instantiate_locked
     (EVP_RAND_CTX *ctx, unsigned int strength, int prediction_resistance,
      const unsigned char *pstr, size_t pstr_len, const OSSL_PARAM params[])
 {
-    return ctx->meth->instantiate(ctx->data, strength, prediction_resistance,
+    return ctx->meth->instantiate(ctx->algctx, strength, prediction_resistance,
                                   pstr, pstr_len, params);
 }
 
@@ -527,7 +527,7 @@ int EVP_RAND_instantiate(EVP_RAND_CTX *ctx, unsigned int strength,
 
 static int evp_rand_uninstantiate_locked(EVP_RAND_CTX *ctx)
 {
-    return ctx->meth->uninstantiate(ctx->data);
+    return ctx->meth->uninstantiate(ctx->algctx);
 }
 
 int EVP_RAND_uninstantiate(EVP_RAND_CTX *ctx)
@@ -559,7 +559,7 @@ static int evp_rand_generate_locked(EVP_RAND_CTX *ctx, unsigned char *out,
     }
     for (; outlen > 0; outlen -= chunk, out += chunk) {
         chunk = outlen > max_request ? max_request : outlen;
-        if (!ctx->meth->generate(ctx->data, out, chunk, strength,
+        if (!ctx->meth->generate(ctx->algctx, out, chunk, strength,
                                  prediction_resistance, addin, addin_len)) {
             ERR_raise(ERR_LIB_EVP, EVP_R_GENERATE_ERROR);
             return 0;
@@ -592,7 +592,7 @@ static int evp_rand_reseed_locked(EVP_RAND_CTX *ctx, int prediction_resistance,
                                   const unsigned char *addin, size_t addin_len)
 {
     if (ctx->meth->reseed != NULL)
-        return ctx->meth->reseed(ctx->data, prediction_resistance,
+        return ctx->meth->reseed(ctx->algctx, prediction_resistance,
                                  ent, ent_len, addin, addin_len);
     return 1;
 }
@@ -640,7 +640,7 @@ static int evp_rand_nonce_locked(EVP_RAND_CTX *ctx, unsigned char *out,
 
     if (ctx->meth->nonce == NULL)
         return 0;
-    if (ctx->meth->nonce(ctx->data, out, str, outlen, outlen))
+    if (ctx->meth->nonce(ctx->algctx, out, str, outlen, outlen))
         return 1;
     return evp_rand_generate_locked(ctx, out, outlen, str, 0, NULL, 0);
 }
@@ -670,7 +670,7 @@ int EVP_RAND_state(EVP_RAND_CTX *ctx)
 static int evp_rand_verify_zeroization_locked(EVP_RAND_CTX *ctx)
 {
     if (ctx->meth->verify_zeroization != NULL)
-        return ctx->meth->verify_zeroization(ctx->data);
+        return ctx->meth->verify_zeroization(ctx->algctx);
     return 0;
 }
 

--- a/crypto/evp/evp_utils.c
+++ b/crypto/evp/evp_utils.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2019-2021 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -42,10 +42,10 @@ int name (const type *obj, OSSL_PARAM params[])                                \
 }
 
 #define PARAM_CTX_FUNC(name, func, type, err)                                  \
-int name (const type *obj, void *provctx, OSSL_PARAM params[])                 \
+int name (const type *obj, void *algctx, OSSL_PARAM params[])                  \
 {                                                                              \
     PARAM_CHECK(obj, func, err)                                                \
-    return obj->func(provctx, params);                                         \
+    return obj->func(algctx, params);                                          \
 }
 
 #define PARAM_FUNCTIONS(type,                                                  \

--- a/crypto/evp/exchange.c
+++ b/crypto/evp/exchange.c
@@ -284,13 +284,13 @@ int EVP_PKEY_derive_init_ex(EVP_PKEY_CTX *ctx, const OSSL_PARAM params[])
     /* No more legacy from here down to legacy: */
 
     ctx->op.kex.exchange = exchange;
-    ctx->op.kex.exchprovctx = exchange->newctx(ossl_provider_ctx(exchange->prov));
-    if (ctx->op.kex.exchprovctx == NULL) {
+    ctx->op.kex.algctx = exchange->newctx(ossl_provider_ctx(exchange->prov));
+    if (ctx->op.kex.algctx == NULL) {
         /* The provider key can stay in the cache */
         ERR_raise(ERR_LIB_EVP, EVP_R_INITIALIZATION_ERROR);
         goto err;
     }
-    ret = exchange->init(ctx->op.kex.exchprovctx, provkey, params);
+    ret = exchange->init(ctx->op.kex.algctx, provkey, params);
 
     return ret ? 1 : 0;
  err:
@@ -335,7 +335,7 @@ int EVP_PKEY_derive_set_peer_ex(EVP_PKEY_CTX *ctx, EVP_PKEY *peer,
         return -1;
     }
 
-    if (!EVP_PKEY_CTX_IS_DERIVE_OP(ctx) || ctx->op.kex.exchprovctx == NULL)
+    if (!EVP_PKEY_CTX_IS_DERIVE_OP(ctx) || ctx->op.kex.algctx == NULL)
         goto legacy;
 
     if (ctx->op.kex.exchange->set_peer == NULL) {
@@ -361,7 +361,7 @@ int EVP_PKEY_derive_set_peer_ex(EVP_PKEY_CTX *ctx, EVP_PKEY *peer,
      */
     if (provkey == NULL)
         goto legacy;
-    return ctx->op.kex.exchange->set_peer(ctx->op.kex.exchprovctx, provkey);
+    return ctx->op.kex.exchange->set_peer(ctx->op.kex.algctx, provkey);
 
  legacy:
 #ifdef FIPS_MODULE
@@ -447,10 +447,10 @@ int EVP_PKEY_derive(EVP_PKEY_CTX *ctx, unsigned char *key, size_t *pkeylen)
         return -1;
     }
 
-    if (ctx->op.kex.exchprovctx == NULL)
+    if (ctx->op.kex.algctx == NULL)
         goto legacy;
 
-    ret = ctx->op.kex.exchange->derive(ctx->op.kex.exchprovctx, key, pkeylen,
+    ret = ctx->op.kex.exchange->derive(ctx->op.kex.algctx, key, pkeylen,
                                        key != NULL ? *pkeylen : 0);
 
     return ret;

--- a/crypto/evp/kdf_lib.c
+++ b/crypto/evp/kdf_lib.c
@@ -32,11 +32,11 @@ EVP_KDF_CTX *EVP_KDF_CTX_new(EVP_KDF *kdf)
 
     ctx = OPENSSL_zalloc(sizeof(EVP_KDF_CTX));
     if (ctx == NULL
-        || (ctx->data = kdf->newctx(ossl_provider_ctx(kdf->prov))) == NULL
+        || (ctx->algctx = kdf->newctx(ossl_provider_ctx(kdf->prov))) == NULL
         || !EVP_KDF_up_ref(kdf)) {
         ERR_raise(ERR_LIB_EVP, ERR_R_MALLOC_FAILURE);
         if (ctx != NULL)
-            kdf->freectx(ctx->data);
+            kdf->freectx(ctx->algctx);
         OPENSSL_free(ctx);
         ctx = NULL;
     } else {
@@ -49,8 +49,8 @@ void EVP_KDF_CTX_free(EVP_KDF_CTX *ctx)
 {
     if (ctx == NULL)
         return;
-    ctx->meth->freectx(ctx->data);
-    ctx->data = NULL;
+    ctx->meth->freectx(ctx->algctx);
+    ctx->algctx = NULL;
     EVP_KDF_free(ctx->meth);
     OPENSSL_free(ctx);
 }
@@ -59,7 +59,7 @@ EVP_KDF_CTX *EVP_KDF_CTX_dup(const EVP_KDF_CTX *src)
 {
     EVP_KDF_CTX *dst;
 
-    if (src == NULL || src->data == NULL || src->meth->dupctx == NULL)
+    if (src == NULL || src->algctx == NULL || src->meth->dupctx == NULL)
         return NULL;
 
     dst = OPENSSL_malloc(sizeof(*dst));
@@ -75,8 +75,8 @@ EVP_KDF_CTX *EVP_KDF_CTX_dup(const EVP_KDF_CTX *src)
         return NULL;
     }
 
-    dst->data = src->meth->dupctx(src->data);
-    if (dst->data == NULL) {
+    dst->algctx = src->meth->dupctx(src->algctx);
+    if (dst->algctx == NULL) {
         EVP_KDF_CTX_free(dst);
         return NULL;
     }
@@ -119,7 +119,7 @@ void EVP_KDF_CTX_reset(EVP_KDF_CTX *ctx)
         return;
 
     if (ctx->meth->reset != NULL)
-        ctx->meth->reset(ctx->data);
+        ctx->meth->reset(ctx->algctx);
 }
 
 size_t EVP_KDF_CTX_get_kdf_size(EVP_KDF_CTX *ctx)
@@ -132,7 +132,7 @@ size_t EVP_KDF_CTX_get_kdf_size(EVP_KDF_CTX *ctx)
 
     *params = OSSL_PARAM_construct_size_t(OSSL_KDF_PARAM_SIZE, &s);
     if (ctx->meth->get_ctx_params != NULL
-        && ctx->meth->get_ctx_params(ctx->data, params))
+        && ctx->meth->get_ctx_params(ctx->algctx, params))
             return s;
     if (ctx->meth->get_params != NULL
         && ctx->meth->get_params(params))
@@ -146,7 +146,7 @@ int EVP_KDF_derive(EVP_KDF_CTX *ctx, unsigned char *key, size_t keylen,
     if (ctx == NULL)
         return 0;
 
-    return ctx->meth->derive(ctx->data, key, keylen, params);
+    return ctx->meth->derive(ctx->algctx, key, keylen, params);
 }
 
 /*
@@ -165,14 +165,14 @@ int EVP_KDF_get_params(EVP_KDF *kdf, OSSL_PARAM params[])
 int EVP_KDF_CTX_get_params(EVP_KDF_CTX *ctx, OSSL_PARAM params[])
 {
     if (ctx->meth->get_ctx_params != NULL)
-        return ctx->meth->get_ctx_params(ctx->data, params);
+        return ctx->meth->get_ctx_params(ctx->algctx, params);
     return 1;
 }
 
 int EVP_KDF_CTX_set_params(EVP_KDF_CTX *ctx, const OSSL_PARAM params[])
 {
     if (ctx->meth->set_ctx_params != NULL)
-        return ctx->meth->set_ctx_params(ctx->data, params);
+        return ctx->meth->set_ctx_params(ctx->algctx, params);
     return 1;
 }
 

--- a/crypto/evp/kdf_meth.c
+++ b/crypto/evp/kdf_meth.c
@@ -209,7 +209,7 @@ const OSSL_PARAM *EVP_KDF_CTX_gettable_params(EVP_KDF_CTX *ctx)
     if (ctx->meth->gettable_ctx_params == NULL)
         return NULL;
     alg = ossl_provider_ctx(EVP_KDF_provider(ctx->meth));
-    return ctx->meth->gettable_ctx_params(ctx->data, alg);
+    return ctx->meth->gettable_ctx_params(ctx->algctx, alg);
 }
 
 const OSSL_PARAM *EVP_KDF_CTX_settable_params(EVP_KDF_CTX *ctx)
@@ -219,7 +219,7 @@ const OSSL_PARAM *EVP_KDF_CTX_settable_params(EVP_KDF_CTX *ctx)
     if (ctx->meth->settable_ctx_params == NULL)
         return NULL;
     alg = ossl_provider_ctx(EVP_KDF_provider(ctx->meth));
-    return ctx->meth->settable_ctx_params(ctx->data, alg);
+    return ctx->meth->settable_ctx_params(ctx->algctx, alg);
 }
 
 void EVP_KDF_do_all_provided(OSSL_LIB_CTX *libctx,

--- a/crypto/evp/m_sigver.c
+++ b/crypto/evp/m_sigver.c
@@ -50,14 +50,14 @@ static int do_sigver_init(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx,
     void *provkey = NULL;
     int ret;
 
-    if (ctx->provctx != NULL) {
+    if (ctx->algctx != NULL) {
         if (!ossl_assert(ctx->digest != NULL)) {
             ERR_raise(ERR_LIB_EVP, EVP_R_INITIALIZATION_ERROR);
             return 0;
         }
         if (ctx->digest->freectx != NULL)
-            ctx->digest->freectx(ctx->provctx);
-        ctx->provctx = NULL;
+            ctx->digest->freectx(ctx->algctx);
+        ctx->algctx = NULL;
     }
 
     if (ctx->pctx == NULL) {
@@ -146,9 +146,9 @@ static int do_sigver_init(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx,
     locpctx->op.sig.signature = signature;
     locpctx->operation = ver ? EVP_PKEY_OP_VERIFYCTX
                              : EVP_PKEY_OP_SIGNCTX;
-    locpctx->op.sig.sigprovctx
+    locpctx->op.sig.algctx
         = signature->newctx(ossl_provider_ctx(signature->prov), props);
-    if (locpctx->op.sig.sigprovctx == NULL) {
+    if (locpctx->op.sig.algctx == NULL) {
         ERR_raise(ERR_LIB_EVP,  EVP_R_INITIALIZATION_ERROR);
         goto err;
     }
@@ -202,14 +202,14 @@ static int do_sigver_init(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx,
             ERR_raise(ERR_LIB_EVP, EVP_R_INITIALIZATION_ERROR);
             goto err;
         }
-        ret = signature->digest_verify_init(locpctx->op.sig.sigprovctx,
+        ret = signature->digest_verify_init(locpctx->op.sig.algctx,
                                             mdname, provkey, params);
     } else {
         if (signature->digest_sign_init == NULL) {
             ERR_raise(ERR_LIB_EVP, EVP_R_INITIALIZATION_ERROR);
             goto err;
         }
-        ret = signature->digest_sign_init(locpctx->op.sig.sigprovctx,
+        ret = signature->digest_sign_init(locpctx->op.sig.algctx,
                                           mdname, provkey, params);
     }
 
@@ -339,7 +339,7 @@ int EVP_DigestSignUpdate(EVP_MD_CTX *ctx, const void *data, size_t dsize)
 
     if (pctx == NULL
             || pctx->operation != EVP_PKEY_OP_SIGNCTX
-            || pctx->op.sig.sigprovctx == NULL
+            || pctx->op.sig.algctx == NULL
             || pctx->op.sig.signature == NULL)
         goto legacy;
 
@@ -348,7 +348,7 @@ int EVP_DigestSignUpdate(EVP_MD_CTX *ctx, const void *data, size_t dsize)
         return 0;
     }
 
-    return pctx->op.sig.signature->digest_sign_update(pctx->op.sig.sigprovctx,
+    return pctx->op.sig.signature->digest_sign_update(pctx->op.sig.algctx,
                                                       data, dsize);
 
  legacy:
@@ -369,7 +369,7 @@ int EVP_DigestVerifyUpdate(EVP_MD_CTX *ctx, const void *data, size_t dsize)
 
     if (pctx == NULL
             || pctx->operation != EVP_PKEY_OP_VERIFYCTX
-            || pctx->op.sig.sigprovctx == NULL
+            || pctx->op.sig.algctx == NULL
             || pctx->op.sig.signature == NULL)
         goto legacy;
 
@@ -378,7 +378,7 @@ int EVP_DigestVerifyUpdate(EVP_MD_CTX *ctx, const void *data, size_t dsize)
         return 0;
     }
 
-    return pctx->op.sig.signature->digest_verify_update(pctx->op.sig.sigprovctx,
+    return pctx->op.sig.signature->digest_verify_update(pctx->op.sig.algctx,
                                                         data, dsize);
 
  legacy:
@@ -402,11 +402,11 @@ int EVP_DigestSignFinal(EVP_MD_CTX *ctx, unsigned char *sigret,
 
     if (pctx == NULL
             || pctx->operation != EVP_PKEY_OP_SIGNCTX
-            || pctx->op.sig.sigprovctx == NULL
+            || pctx->op.sig.algctx == NULL
             || pctx->op.sig.signature == NULL)
         goto legacy;
 
-    return pctx->op.sig.signature->digest_sign_final(pctx->op.sig.sigprovctx,
+    return pctx->op.sig.signature->digest_sign_final(pctx->op.sig.algctx,
                                                      sigret, siglen, SIZE_MAX);
 
  legacy:
@@ -490,10 +490,10 @@ int EVP_DigestSign(EVP_MD_CTX *ctx, unsigned char *sigret, size_t *siglen,
 
     if (pctx != NULL
             && pctx->operation == EVP_PKEY_OP_SIGNCTX
-            && pctx->op.sig.sigprovctx != NULL
+            && pctx->op.sig.algctx != NULL
             && pctx->op.sig.signature != NULL) {
         if (pctx->op.sig.signature->digest_sign != NULL)
-            return pctx->op.sig.signature->digest_sign(pctx->op.sig.sigprovctx,
+            return pctx->op.sig.signature->digest_sign(pctx->op.sig.algctx,
                                                        sigret, siglen, SIZE_MAX,
                                                        tbs, tbslen);
     } else {
@@ -518,11 +518,11 @@ int EVP_DigestVerifyFinal(EVP_MD_CTX *ctx, const unsigned char *sig,
 
     if (pctx == NULL
             || pctx->operation != EVP_PKEY_OP_VERIFYCTX
-            || pctx->op.sig.sigprovctx == NULL
+            || pctx->op.sig.algctx == NULL
             || pctx->op.sig.signature == NULL)
         goto legacy;
 
-    return pctx->op.sig.signature->digest_verify_final(pctx->op.sig.sigprovctx,
+    return pctx->op.sig.signature->digest_verify_final(pctx->op.sig.algctx,
                                                        sig, siglen);
 
  legacy:
@@ -573,10 +573,10 @@ int EVP_DigestVerify(EVP_MD_CTX *ctx, const unsigned char *sigret,
 
     if (pctx != NULL
             && pctx->operation == EVP_PKEY_OP_VERIFYCTX
-            && pctx->op.sig.sigprovctx != NULL
+            && pctx->op.sig.algctx != NULL
             && pctx->op.sig.signature != NULL) {
         if (pctx->op.sig.signature->digest_verify != NULL)
-            return pctx->op.sig.signature->digest_verify(pctx->op.sig.sigprovctx,
+            return pctx->op.sig.signature->digest_verify(pctx->op.sig.algctx,
                                                          sigret, siglen,
                                                          tbs, tbslen);
     } else {

--- a/crypto/evp/mac_lib.c
+++ b/crypto/evp/mac_lib.c
@@ -24,11 +24,11 @@ EVP_MAC_CTX *EVP_MAC_CTX_new(EVP_MAC *mac)
     EVP_MAC_CTX *ctx = OPENSSL_zalloc(sizeof(EVP_MAC_CTX));
 
     if (ctx == NULL
-        || (ctx->data = mac->newctx(ossl_provider_ctx(mac->prov))) == NULL
+        || (ctx->algctx = mac->newctx(ossl_provider_ctx(mac->prov))) == NULL
         || !EVP_MAC_up_ref(mac)) {
         ERR_raise(ERR_LIB_EVP, ERR_R_MALLOC_FAILURE);
         if (ctx != NULL)
-            mac->freectx(ctx->data);
+            mac->freectx(ctx->algctx);
         OPENSSL_free(ctx);
         ctx = NULL;
     } else {
@@ -41,8 +41,8 @@ void EVP_MAC_CTX_free(EVP_MAC_CTX *ctx)
 {
     if (ctx == NULL)
         return;
-    ctx->meth->freectx(ctx->data);
-    ctx->data = NULL;
+    ctx->meth->freectx(ctx->algctx);
+    ctx->algctx = NULL;
     /* refcnt-- */
     EVP_MAC_free(ctx->meth);
     OPENSSL_free(ctx);
@@ -52,7 +52,7 @@ EVP_MAC_CTX *EVP_MAC_CTX_dup(const EVP_MAC_CTX *src)
 {
     EVP_MAC_CTX *dst;
 
-    if (src->data == NULL)
+    if (src->algctx == NULL)
         return NULL;
 
     dst = OPENSSL_malloc(sizeof(*dst));
@@ -68,8 +68,8 @@ EVP_MAC_CTX *EVP_MAC_CTX_dup(const EVP_MAC_CTX *src)
         return NULL;
     }
 
-    dst->data = src->meth->dupctx(src->data);
-    if (dst->data == NULL) {
+    dst->algctx = src->meth->dupctx(src->algctx);
+    if (dst->algctx == NULL) {
         EVP_MAC_CTX_free(dst);
         return NULL;
     }
@@ -86,12 +86,12 @@ size_t EVP_MAC_CTX_get_mac_size(EVP_MAC_CTX *ctx)
 {
     size_t sz = 0;
 
-    if (ctx->data != NULL) {
+    if (ctx->algctx != NULL) {
         OSSL_PARAM params[2] = { OSSL_PARAM_END, OSSL_PARAM_END };
 
         params[0] = OSSL_PARAM_construct_size_t(OSSL_MAC_PARAM_SIZE, &sz);
         if (ctx->meth->get_ctx_params != NULL) {
-            if (ctx->meth->get_ctx_params(ctx->data, params))
+            if (ctx->meth->get_ctx_params(ctx->algctx, params))
                 return sz;
         } else if (ctx->meth->get_params != NULL) {
             if (ctx->meth->get_params(params))
@@ -108,12 +108,12 @@ size_t EVP_MAC_CTX_get_mac_size(EVP_MAC_CTX *ctx)
 int EVP_MAC_init(EVP_MAC_CTX *ctx, const unsigned char *key, size_t keylen,
                  const OSSL_PARAM params[])
 {
-    return ctx->meth->init(ctx->data, key, keylen, params);
+    return ctx->meth->init(ctx->algctx, key, keylen, params);
 }
 
 int EVP_MAC_update(EVP_MAC_CTX *ctx, const unsigned char *data, size_t datalen)
 {
-    return ctx->meth->update(ctx->data, data, datalen);
+    return ctx->meth->update(ctx->algctx, data, datalen);
 }
 
 static int evp_mac_final(EVP_MAC_CTX *ctx, int xof,
@@ -149,7 +149,7 @@ static int evp_mac_final(EVP_MAC_CTX *ctx, int xof,
             return 0;
         }
     }
-    res = ctx->meth->final(ctx->data, out, &l, outsize);
+    res = ctx->meth->final(ctx->algctx, out, &l, outsize);
     if (outl != NULL)
         *outl = l;
     return res;
@@ -182,14 +182,14 @@ int EVP_MAC_get_params(EVP_MAC *mac, OSSL_PARAM params[])
 int EVP_MAC_CTX_get_params(EVP_MAC_CTX *ctx, OSSL_PARAM params[])
 {
     if (ctx->meth->get_ctx_params != NULL)
-        return ctx->meth->get_ctx_params(ctx->data, params);
+        return ctx->meth->get_ctx_params(ctx->algctx, params);
     return 1;
 }
 
 int EVP_MAC_CTX_set_params(EVP_MAC_CTX *ctx, const OSSL_PARAM params[])
 {
     if (ctx->meth->set_ctx_params != NULL)
-        return ctx->meth->set_ctx_params(ctx->data, params);
+        return ctx->meth->set_ctx_params(ctx->algctx, params);
     return 1;
 }
 

--- a/crypto/evp/mac_meth.c
+++ b/crypto/evp/mac_meth.c
@@ -214,7 +214,7 @@ const OSSL_PARAM *EVP_MAC_CTX_gettable_params(EVP_MAC_CTX *ctx)
     if (ctx->meth->gettable_ctx_params == NULL)
         return NULL;
     alg = ossl_provider_ctx(EVP_MAC_provider(ctx->meth));
-    return ctx->meth->gettable_ctx_params(ctx->data, alg);
+    return ctx->meth->gettable_ctx_params(ctx->algctx, alg);
 }
 
 const OSSL_PARAM *EVP_MAC_CTX_settable_params(EVP_MAC_CTX *ctx)
@@ -224,7 +224,7 @@ const OSSL_PARAM *EVP_MAC_CTX_settable_params(EVP_MAC_CTX *ctx)
     if (ctx->meth->settable_ctx_params == NULL)
         return NULL;
     alg = ossl_provider_ctx(EVP_MAC_provider(ctx->meth));
-    return ctx->meth->settable_ctx_params(ctx->data, alg);
+    return ctx->meth->settable_ctx_params(ctx->algctx, alg);
 }
 
 void EVP_MAC_do_all_provided(OSSL_LIB_CTX *libctx,

--- a/crypto/evp/pmeth_lib.c
+++ b/crypto/evp/pmeth_lib.c
@@ -160,15 +160,15 @@ int evp_pkey_ctx_state(const EVP_PKEY_CTX *ctx)
         return EVP_PKEY_STATE_UNKNOWN;
 
     if ((EVP_PKEY_CTX_IS_DERIVE_OP(ctx)
-         && ctx->op.kex.exchprovctx != NULL)
+         && ctx->op.kex.algctx != NULL)
         || (EVP_PKEY_CTX_IS_SIGNATURE_OP(ctx)
-            && ctx->op.sig.sigprovctx != NULL)
+            && ctx->op.sig.algctx != NULL)
         || (EVP_PKEY_CTX_IS_ASYM_CIPHER_OP(ctx)
-            && ctx->op.ciph.ciphprovctx != NULL)
+            && ctx->op.ciph.algctx != NULL)
         || (EVP_PKEY_CTX_IS_GEN_OP(ctx)
             && ctx->op.keymgmt.genctx != NULL)
         || (EVP_PKEY_CTX_IS_KEM_OP(ctx)
-            && ctx->op.encap.kemprovctx != NULL))
+            && ctx->op.encap.algctx != NULL))
         return EVP_PKEY_STATE_PROVIDER;
 
     return EVP_PKEY_STATE_LEGACY;
@@ -360,29 +360,29 @@ EVP_PKEY_CTX *EVP_PKEY_CTX_new_from_pkey(OSSL_LIB_CTX *libctx, EVP_PKEY *pkey,
 void evp_pkey_ctx_free_old_ops(EVP_PKEY_CTX *ctx)
 {
     if (EVP_PKEY_CTX_IS_SIGNATURE_OP(ctx)) {
-        if (ctx->op.sig.sigprovctx != NULL && ctx->op.sig.signature != NULL)
-            ctx->op.sig.signature->freectx(ctx->op.sig.sigprovctx);
+        if (ctx->op.sig.algctx != NULL && ctx->op.sig.signature != NULL)
+            ctx->op.sig.signature->freectx(ctx->op.sig.algctx);
         EVP_SIGNATURE_free(ctx->op.sig.signature);
-        ctx->op.sig.sigprovctx = NULL;
+        ctx->op.sig.algctx = NULL;
         ctx->op.sig.signature = NULL;
     } else if (EVP_PKEY_CTX_IS_DERIVE_OP(ctx)) {
-        if (ctx->op.kex.exchprovctx != NULL && ctx->op.kex.exchange != NULL)
-            ctx->op.kex.exchange->freectx(ctx->op.kex.exchprovctx);
+        if (ctx->op.kex.algctx != NULL && ctx->op.kex.exchange != NULL)
+            ctx->op.kex.exchange->freectx(ctx->op.kex.algctx);
         EVP_KEYEXCH_free(ctx->op.kex.exchange);
-        ctx->op.kex.exchprovctx = NULL;
+        ctx->op.kex.algctx = NULL;
         ctx->op.kex.exchange = NULL;
     } else if (EVP_PKEY_CTX_IS_KEM_OP(ctx)) {
-        if (ctx->op.encap.kemprovctx != NULL && ctx->op.encap.kem != NULL)
-            ctx->op.encap.kem->freectx(ctx->op.encap.kemprovctx);
+        if (ctx->op.encap.algctx != NULL && ctx->op.encap.kem != NULL)
+            ctx->op.encap.kem->freectx(ctx->op.encap.algctx);
         EVP_KEM_free(ctx->op.encap.kem);
-        ctx->op.encap.kemprovctx = NULL;
+        ctx->op.encap.algctx = NULL;
         ctx->op.encap.kem = NULL;
     }
     else if (EVP_PKEY_CTX_IS_ASYM_CIPHER_OP(ctx)) {
-        if (ctx->op.ciph.ciphprovctx != NULL && ctx->op.ciph.cipher != NULL)
-            ctx->op.ciph.cipher->freectx(ctx->op.ciph.ciphprovctx);
+        if (ctx->op.ciph.algctx != NULL && ctx->op.ciph.cipher != NULL)
+            ctx->op.ciph.cipher->freectx(ctx->op.ciph.algctx);
         EVP_ASYM_CIPHER_free(ctx->op.ciph.cipher);
-        ctx->op.ciph.ciphprovctx = NULL;
+        ctx->op.ciph.algctx = NULL;
         ctx->op.ciph.cipher = NULL;
     } else if (EVP_PKEY_CTX_IS_GEN_OP(ctx)) {
         if (ctx->op.keymgmt.genctx != NULL && ctx->keymgmt != NULL)
@@ -489,12 +489,12 @@ EVP_PKEY_CTX *EVP_PKEY_CTX_dup(const EVP_PKEY_CTX *pctx)
             if (!EVP_KEYEXCH_up_ref(rctx->op.kex.exchange))
                 goto err;
         }
-        if (pctx->op.kex.exchprovctx != NULL) {
+        if (pctx->op.kex.algctx != NULL) {
             if (!ossl_assert(pctx->op.kex.exchange != NULL))
                 goto err;
-            rctx->op.kex.exchprovctx
-                = pctx->op.kex.exchange->dupctx(pctx->op.kex.exchprovctx);
-            if (rctx->op.kex.exchprovctx == NULL) {
+            rctx->op.kex.algctx
+                = pctx->op.kex.exchange->dupctx(pctx->op.kex.algctx);
+            if (rctx->op.kex.algctx == NULL) {
                 EVP_KEYEXCH_free(rctx->op.kex.exchange);
                 goto err;
             }
@@ -506,12 +506,12 @@ EVP_PKEY_CTX *EVP_PKEY_CTX_dup(const EVP_PKEY_CTX *pctx)
             if (!EVP_SIGNATURE_up_ref(rctx->op.sig.signature))
                 goto err;
         }
-        if (pctx->op.sig.sigprovctx != NULL) {
+        if (pctx->op.sig.algctx != NULL) {
             if (!ossl_assert(pctx->op.sig.signature != NULL))
                 goto err;
-            rctx->op.sig.sigprovctx
-                = pctx->op.sig.signature->dupctx(pctx->op.sig.sigprovctx);
-            if (rctx->op.sig.sigprovctx == NULL) {
+            rctx->op.sig.algctx
+                = pctx->op.sig.signature->dupctx(pctx->op.sig.algctx);
+            if (rctx->op.sig.algctx == NULL) {
                 EVP_SIGNATURE_free(rctx->op.sig.signature);
                 goto err;
             }
@@ -523,12 +523,12 @@ EVP_PKEY_CTX *EVP_PKEY_CTX_dup(const EVP_PKEY_CTX *pctx)
             if (!EVP_ASYM_CIPHER_up_ref(rctx->op.ciph.cipher))
                 goto err;
         }
-        if (pctx->op.ciph.ciphprovctx != NULL) {
+        if (pctx->op.ciph.algctx != NULL) {
             if (!ossl_assert(pctx->op.ciph.cipher != NULL))
                 goto err;
-            rctx->op.ciph.ciphprovctx
-                = pctx->op.ciph.cipher->dupctx(pctx->op.ciph.ciphprovctx);
-            if (rctx->op.ciph.ciphprovctx == NULL) {
+            rctx->op.ciph.algctx
+                = pctx->op.ciph.cipher->dupctx(pctx->op.ciph.algctx);
+            if (rctx->op.ciph.algctx == NULL) {
                 EVP_ASYM_CIPHER_free(rctx->op.ciph.cipher);
                 goto err;
             }
@@ -540,12 +540,12 @@ EVP_PKEY_CTX *EVP_PKEY_CTX_dup(const EVP_PKEY_CTX *pctx)
             if (!EVP_KEM_up_ref(rctx->op.encap.kem))
                 goto err;
         }
-        if (pctx->op.encap.kemprovctx != NULL) {
+        if (pctx->op.encap.algctx != NULL) {
             if (!ossl_assert(pctx->op.encap.kem != NULL))
                 goto err;
-            rctx->op.encap.kemprovctx
-                = pctx->op.encap.kem->dupctx(pctx->op.encap.kemprovctx);
-            if (rctx->op.encap.kemprovctx == NULL) {
+            rctx->op.encap.algctx
+                = pctx->op.encap.kem->dupctx(pctx->op.encap.algctx);
+            if (rctx->op.encap.algctx == NULL) {
                 EVP_KEM_free(rctx->op.encap.kem);
                 goto err;
             }
@@ -660,19 +660,19 @@ int EVP_PKEY_CTX_set_params(EVP_PKEY_CTX *ctx, const OSSL_PARAM *params)
             && ctx->op.kex.exchange != NULL
             && ctx->op.kex.exchange->set_ctx_params != NULL)
             return
-                ctx->op.kex.exchange->set_ctx_params(ctx->op.kex.exchprovctx,
+                ctx->op.kex.exchange->set_ctx_params(ctx->op.kex.algctx,
                                                      params);
         if (EVP_PKEY_CTX_IS_SIGNATURE_OP(ctx)
             && ctx->op.sig.signature != NULL
             && ctx->op.sig.signature->set_ctx_params != NULL)
             return
-                ctx->op.sig.signature->set_ctx_params(ctx->op.sig.sigprovctx,
+                ctx->op.sig.signature->set_ctx_params(ctx->op.sig.algctx,
                                                       params);
         if (EVP_PKEY_CTX_IS_ASYM_CIPHER_OP(ctx)
             && ctx->op.ciph.cipher != NULL
             && ctx->op.ciph.cipher->set_ctx_params != NULL)
             return
-                ctx->op.ciph.cipher->set_ctx_params(ctx->op.ciph.ciphprovctx,
+                ctx->op.ciph.cipher->set_ctx_params(ctx->op.ciph.algctx,
                                                     params);
         if (EVP_PKEY_CTX_IS_GEN_OP(ctx)
             && ctx->keymgmt != NULL
@@ -684,7 +684,7 @@ int EVP_PKEY_CTX_set_params(EVP_PKEY_CTX *ctx, const OSSL_PARAM *params)
             && ctx->op.encap.kem != NULL
             && ctx->op.encap.kem->set_ctx_params != NULL)
             return
-                ctx->op.encap.kem->set_ctx_params(ctx->op.encap.kemprovctx,
+                ctx->op.encap.kem->set_ctx_params(ctx->op.encap.algctx,
                                                   params);
         break;
 #ifndef FIPS_MODULE
@@ -704,25 +704,25 @@ int EVP_PKEY_CTX_get_params(EVP_PKEY_CTX *ctx, OSSL_PARAM *params)
             && ctx->op.kex.exchange != NULL
             && ctx->op.kex.exchange->get_ctx_params != NULL)
             return
-                ctx->op.kex.exchange->get_ctx_params(ctx->op.kex.exchprovctx,
+                ctx->op.kex.exchange->get_ctx_params(ctx->op.kex.algctx,
                                                      params);
         if (EVP_PKEY_CTX_IS_SIGNATURE_OP(ctx)
             && ctx->op.sig.signature != NULL
             && ctx->op.sig.signature->get_ctx_params != NULL)
             return
-                ctx->op.sig.signature->get_ctx_params(ctx->op.sig.sigprovctx,
+                ctx->op.sig.signature->get_ctx_params(ctx->op.sig.algctx,
                                                       params);
         if (EVP_PKEY_CTX_IS_ASYM_CIPHER_OP(ctx)
             && ctx->op.ciph.cipher != NULL
             && ctx->op.ciph.cipher->get_ctx_params != NULL)
             return
-                ctx->op.ciph.cipher->get_ctx_params(ctx->op.ciph.ciphprovctx,
+                ctx->op.ciph.cipher->get_ctx_params(ctx->op.ciph.algctx,
                                                     params);
         if (EVP_PKEY_CTX_IS_KEM_OP(ctx)
             && ctx->op.encap.kem != NULL
             && ctx->op.encap.kem->get_ctx_params != NULL)
             return
-                ctx->op.encap.kem->get_ctx_params(ctx->op.encap.kemprovctx,
+                ctx->op.encap.kem->get_ctx_params(ctx->op.encap.algctx,
                                                   params);
         break;
 #ifndef FIPS_MODULE
@@ -743,7 +743,7 @@ const OSSL_PARAM *EVP_PKEY_CTX_gettable_params(const EVP_PKEY_CTX *ctx)
             && ctx->op.kex.exchange != NULL
             && ctx->op.kex.exchange->gettable_ctx_params != NULL) {
         provctx = ossl_provider_ctx(EVP_KEYEXCH_provider(ctx->op.kex.exchange));
-        return ctx->op.kex.exchange->gettable_ctx_params(ctx->op.kex.exchprovctx,
+        return ctx->op.kex.exchange->gettable_ctx_params(ctx->op.kex.algctx,
                                                          provctx);
     }
     if (EVP_PKEY_CTX_IS_SIGNATURE_OP(ctx)
@@ -751,7 +751,7 @@ const OSSL_PARAM *EVP_PKEY_CTX_gettable_params(const EVP_PKEY_CTX *ctx)
             && ctx->op.sig.signature->gettable_ctx_params != NULL) {
         provctx = ossl_provider_ctx(
                       EVP_SIGNATURE_provider(ctx->op.sig.signature));
-        return ctx->op.sig.signature->gettable_ctx_params(ctx->op.sig.sigprovctx,
+        return ctx->op.sig.signature->gettable_ctx_params(ctx->op.sig.algctx,
                                                           provctx);
     }
     if (EVP_PKEY_CTX_IS_ASYM_CIPHER_OP(ctx)
@@ -759,14 +759,14 @@ const OSSL_PARAM *EVP_PKEY_CTX_gettable_params(const EVP_PKEY_CTX *ctx)
             && ctx->op.ciph.cipher->gettable_ctx_params != NULL) {
         provctx = ossl_provider_ctx(
                       EVP_ASYM_CIPHER_provider(ctx->op.ciph.cipher));
-        return ctx->op.ciph.cipher->gettable_ctx_params(ctx->op.ciph.ciphprovctx,
+        return ctx->op.ciph.cipher->gettable_ctx_params(ctx->op.ciph.algctx,
                                                         provctx);
     }
     if (EVP_PKEY_CTX_IS_KEM_OP(ctx)
         && ctx->op.encap.kem != NULL
         && ctx->op.encap.kem->gettable_ctx_params != NULL) {
         provctx = ossl_provider_ctx(EVP_KEM_provider(ctx->op.encap.kem));
-        return ctx->op.encap.kem->gettable_ctx_params(ctx->op.encap.kemprovctx,
+        return ctx->op.encap.kem->gettable_ctx_params(ctx->op.encap.algctx,
                                                       provctx);
     }
     return NULL;
@@ -780,7 +780,7 @@ const OSSL_PARAM *EVP_PKEY_CTX_settable_params(const EVP_PKEY_CTX *ctx)
             && ctx->op.kex.exchange != NULL
             && ctx->op.kex.exchange->settable_ctx_params != NULL) {
         provctx = ossl_provider_ctx(EVP_KEYEXCH_provider(ctx->op.kex.exchange));
-        return ctx->op.kex.exchange->settable_ctx_params(ctx->op.kex.exchprovctx,
+        return ctx->op.kex.exchange->settable_ctx_params(ctx->op.kex.algctx,
                                                          provctx);
     }
     if (EVP_PKEY_CTX_IS_SIGNATURE_OP(ctx)
@@ -788,7 +788,7 @@ const OSSL_PARAM *EVP_PKEY_CTX_settable_params(const EVP_PKEY_CTX *ctx)
             && ctx->op.sig.signature->settable_ctx_params != NULL) {
         provctx = ossl_provider_ctx(
                       EVP_SIGNATURE_provider(ctx->op.sig.signature));
-        return ctx->op.sig.signature->settable_ctx_params(ctx->op.sig.sigprovctx,
+        return ctx->op.sig.signature->settable_ctx_params(ctx->op.sig.algctx,
                                                           provctx);
     }
     if (EVP_PKEY_CTX_IS_ASYM_CIPHER_OP(ctx)
@@ -796,7 +796,7 @@ const OSSL_PARAM *EVP_PKEY_CTX_settable_params(const EVP_PKEY_CTX *ctx)
             && ctx->op.ciph.cipher->settable_ctx_params != NULL) {
         provctx = ossl_provider_ctx(
                       EVP_ASYM_CIPHER_provider(ctx->op.ciph.cipher));
-        return ctx->op.ciph.cipher->settable_ctx_params(ctx->op.ciph.ciphprovctx,
+        return ctx->op.ciph.cipher->settable_ctx_params(ctx->op.ciph.algctx,
                                                         provctx);
     }
     if (EVP_PKEY_CTX_IS_GEN_OP(ctx)
@@ -810,7 +810,7 @@ const OSSL_PARAM *EVP_PKEY_CTX_settable_params(const EVP_PKEY_CTX *ctx)
         && ctx->op.encap.kem != NULL
         && ctx->op.encap.kem->settable_ctx_params != NULL) {
         provctx = ossl_provider_ctx(EVP_KEM_provider(ctx->op.encap.kem));
-        return ctx->op.encap.kem->settable_ctx_params(ctx->op.encap.kemprovctx,
+        return ctx->op.encap.kem->settable_ctx_params(ctx->op.encap.algctx,
                                                       provctx);
     }
     return NULL;
@@ -892,7 +892,7 @@ int EVP_PKEY_CTX_get_signature_md(EVP_PKEY_CTX *ctx, const EVP_MD **md)
         return -2;
     }
 
-    if (ctx->op.sig.sigprovctx == NULL)
+    if (ctx->op.sig.algctx == NULL)
         return EVP_PKEY_CTX_ctrl(ctx, -1, EVP_PKEY_OP_TYPE_SIG,
                                  EVP_PKEY_CTRL_GET_MD, 0, (void *)(md));
 
@@ -952,14 +952,14 @@ static int evp_pkey_ctx_set_md(EVP_PKEY_CTX *ctx, const EVP_MD *md,
 
 int EVP_PKEY_CTX_set_signature_md(EVP_PKEY_CTX *ctx, const EVP_MD *md)
 {
-    return evp_pkey_ctx_set_md(ctx, md, ctx->op.sig.sigprovctx == NULL,
+    return evp_pkey_ctx_set_md(ctx, md, ctx->op.sig.algctx == NULL,
                                OSSL_SIGNATURE_PARAM_DIGEST,
                                EVP_PKEY_OP_TYPE_SIG, EVP_PKEY_CTRL_MD);
 }
 
 int EVP_PKEY_CTX_set_tls1_prf_md(EVP_PKEY_CTX *ctx, const EVP_MD *md)
 {
-    return evp_pkey_ctx_set_md(ctx, md, ctx->op.kex.exchprovctx == NULL,
+    return evp_pkey_ctx_set_md(ctx, md, ctx->op.kex.algctx == NULL,
                                OSSL_KDF_PARAM_DIGEST,
                                EVP_PKEY_OP_DERIVE, EVP_PKEY_CTRL_TLS_MD);
 }
@@ -1002,7 +1002,7 @@ static int evp_pkey_ctx_set1_octet_string(EVP_PKEY_CTX *ctx, int fallback,
 int EVP_PKEY_CTX_set1_tls1_prf_secret(EVP_PKEY_CTX *ctx,
                                       const unsigned char *sec, int seclen)
 {
-    return evp_pkey_ctx_set1_octet_string(ctx, ctx->op.kex.exchprovctx == NULL,
+    return evp_pkey_ctx_set1_octet_string(ctx, ctx->op.kex.algctx == NULL,
                                           OSSL_KDF_PARAM_SECRET,
                                           EVP_PKEY_OP_DERIVE,
                                           EVP_PKEY_CTRL_TLS_SECRET,
@@ -1012,7 +1012,7 @@ int EVP_PKEY_CTX_set1_tls1_prf_secret(EVP_PKEY_CTX *ctx,
 int EVP_PKEY_CTX_add1_tls1_prf_seed(EVP_PKEY_CTX *ctx,
                                     const unsigned char *seed, int seedlen)
 {
-    return evp_pkey_ctx_set1_octet_string(ctx, ctx->op.kex.exchprovctx == NULL,
+    return evp_pkey_ctx_set1_octet_string(ctx, ctx->op.kex.algctx == NULL,
                                           OSSL_KDF_PARAM_SEED,
                                           EVP_PKEY_OP_DERIVE,
                                           EVP_PKEY_CTRL_TLS_SEED,
@@ -1021,7 +1021,7 @@ int EVP_PKEY_CTX_add1_tls1_prf_seed(EVP_PKEY_CTX *ctx,
 
 int EVP_PKEY_CTX_set_hkdf_md(EVP_PKEY_CTX *ctx, const EVP_MD *md)
 {
-    return evp_pkey_ctx_set_md(ctx, md, ctx->op.kex.exchprovctx == NULL,
+    return evp_pkey_ctx_set_md(ctx, md, ctx->op.kex.algctx == NULL,
                                OSSL_KDF_PARAM_DIGEST,
                                EVP_PKEY_OP_DERIVE, EVP_PKEY_CTRL_HKDF_MD);
 }
@@ -1029,7 +1029,7 @@ int EVP_PKEY_CTX_set_hkdf_md(EVP_PKEY_CTX *ctx, const EVP_MD *md)
 int EVP_PKEY_CTX_set1_hkdf_salt(EVP_PKEY_CTX *ctx,
                                 const unsigned char *salt, int saltlen)
 {
-    return evp_pkey_ctx_set1_octet_string(ctx, ctx->op.kex.exchprovctx == NULL,
+    return evp_pkey_ctx_set1_octet_string(ctx, ctx->op.kex.algctx == NULL,
                                           OSSL_KDF_PARAM_SALT,
                                           EVP_PKEY_OP_DERIVE,
                                           EVP_PKEY_CTRL_HKDF_SALT,
@@ -1039,7 +1039,7 @@ int EVP_PKEY_CTX_set1_hkdf_salt(EVP_PKEY_CTX *ctx,
 int EVP_PKEY_CTX_set1_hkdf_key(EVP_PKEY_CTX *ctx,
                                       const unsigned char *key, int keylen)
 {
-    return evp_pkey_ctx_set1_octet_string(ctx, ctx->op.kex.exchprovctx == NULL,
+    return evp_pkey_ctx_set1_octet_string(ctx, ctx->op.kex.algctx == NULL,
                                           OSSL_KDF_PARAM_KEY,
                                           EVP_PKEY_OP_DERIVE,
                                           EVP_PKEY_CTRL_HKDF_KEY,
@@ -1049,7 +1049,7 @@ int EVP_PKEY_CTX_set1_hkdf_key(EVP_PKEY_CTX *ctx,
 int EVP_PKEY_CTX_add1_hkdf_info(EVP_PKEY_CTX *ctx,
                                       const unsigned char *info, int infolen)
 {
-    return evp_pkey_ctx_set1_octet_string(ctx, ctx->op.kex.exchprovctx == NULL,
+    return evp_pkey_ctx_set1_octet_string(ctx, ctx->op.kex.algctx == NULL,
                                           OSSL_KDF_PARAM_INFO,
                                           EVP_PKEY_OP_DERIVE,
                                           EVP_PKEY_CTRL_HKDF_INFO,
@@ -1067,7 +1067,7 @@ int EVP_PKEY_CTX_hkdf_mode(EVP_PKEY_CTX *ctx, int mode)
     }
 
     /* Code below to be removed when legacy support is dropped. */
-    if (ctx->op.kex.exchprovctx == NULL)
+    if (ctx->op.kex.algctx == NULL)
         return EVP_PKEY_CTX_ctrl(ctx, -1, EVP_PKEY_OP_DERIVE,
                                  EVP_PKEY_CTRL_HKDF_MODE, mode, NULL);
     /* end of legacy support */
@@ -1086,7 +1086,7 @@ int EVP_PKEY_CTX_hkdf_mode(EVP_PKEY_CTX *ctx, int mode)
 int EVP_PKEY_CTX_set1_pbe_pass(EVP_PKEY_CTX *ctx, const char *pass,
                                int passlen)
 {
-    return evp_pkey_ctx_set1_octet_string(ctx, ctx->op.kex.exchprovctx == NULL,
+    return evp_pkey_ctx_set1_octet_string(ctx, ctx->op.kex.algctx == NULL,
                                           OSSL_KDF_PARAM_PASSWORD,
                                           EVP_PKEY_OP_DERIVE,
                                           EVP_PKEY_CTRL_PASS,
@@ -1096,7 +1096,7 @@ int EVP_PKEY_CTX_set1_pbe_pass(EVP_PKEY_CTX *ctx, const char *pass,
 int EVP_PKEY_CTX_set1_scrypt_salt(EVP_PKEY_CTX *ctx,
                                   const unsigned char *salt, int saltlen)
 {
-    return evp_pkey_ctx_set1_octet_string(ctx, ctx->op.kex.exchprovctx == NULL,
+    return evp_pkey_ctx_set1_octet_string(ctx, ctx->op.kex.algctx == NULL,
                                           OSSL_KDF_PARAM_SALT,
                                           EVP_PKEY_OP_DERIVE,
                                           EVP_PKEY_CTRL_SCRYPT_SALT,
@@ -1115,7 +1115,7 @@ static int evp_pkey_ctx_set_uint64(EVP_PKEY_CTX *ctx, const char *param,
     }
 
     /* Code below to be removed when legacy support is dropped. */
-    if (ctx->op.kex.exchprovctx == NULL)
+    if (ctx->op.kex.algctx == NULL)
         return EVP_PKEY_CTX_ctrl_uint64(ctx, -1, op, ctrl, val);
     /* end of legacy support */
 

--- a/include/crypto/evp.h
+++ b/include/crypto/evp.h
@@ -58,20 +58,36 @@ struct evp_pkey_ctx_st {
 
         struct {
             EVP_KEYEXCH *exchange;
+            /*
+             * Opaque ctx returned from a providers exchange algorithm
+             * implementation OSSL_FUNC_keyexch_newctx()
+             */
             void *algctx;
         } kex;
 
         struct {
+            /*
+             * Opaque ctx returned from a providers signature algorithm
+             * implementation OSSL_FUNC_signature_newctx()
+             */
             EVP_SIGNATURE *signature;
             void *algctx;
         } sig;
 
         struct {
             EVP_ASYM_CIPHER *cipher;
+            /*
+             * Opaque ctx returned from a providers asymmetric cipher algorithm
+             * implementation OSSL_FUNC_asym_cipher_newctx()
+             */
             void *algctx;
         } ciph;
         struct {
             EVP_KEM *kem;
+            /*
+             * Opaque ctx returned from a providers KEM algorithm
+             * implementation OSSL_FUNC_kem_newctx()
+             */
             void *algctx;
         } encap;
     } op;

--- a/include/crypto/evp.h
+++ b/include/crypto/evp.h
@@ -58,21 +58,21 @@ struct evp_pkey_ctx_st {
 
         struct {
             EVP_KEYEXCH *exchange;
-            void *exchprovctx;
+            void *algctx;
         } kex;
 
         struct {
             EVP_SIGNATURE *signature;
-            void *sigprovctx;
+            void *algctx;
         } sig;
 
         struct {
             EVP_ASYM_CIPHER *cipher;
-            void *ciphprovctx;
+            void *algctx;
         } ciph;
         struct {
             EVP_KEM *kem;
-            void *kemprovctx;
+            void *algctx;
         } encap;
     } op;
 

--- a/include/crypto/evp.h
+++ b/include/crypto/evp.h
@@ -66,11 +66,11 @@ struct evp_pkey_ctx_st {
         } kex;
 
         struct {
+            EVP_SIGNATURE *signature;
             /*
              * Opaque ctx returned from a providers signature algorithm
              * implementation OSSL_FUNC_signature_newctx()
              */
-            EVP_SIGNATURE *signature;
             void *algctx;
         } sig;
 

--- a/test/drbgtest.c
+++ b/test/drbgtest.c
@@ -104,7 +104,7 @@ DRBG_UINT(reseed_counter)
 
 static PROV_DRBG *prov_rand(EVP_RAND_CTX *drbg)
 {
-    return (PROV_DRBG *)drbg->data;
+    return (PROV_DRBG *)drbg->algctx;
 }
 
 static void set_reseed_counter(EVP_RAND_CTX *drbg, unsigned int n)

--- a/test/testutil/fake_random.c
+++ b/test/testutil/fake_random.c
@@ -179,7 +179,7 @@ static int check_rng(EVP_RAND_CTX *rng, const char *name)
         TEST_info("random: %s", name);
         return 0;
     }
-    f = rng->data;
+    f = rng->algctx;
     f->name = name;
     f->ctx = rng;
     return 1;
@@ -216,7 +216,7 @@ void fake_rand_set_callback(EVP_RAND_CTX *rng,
                                       const char *name, EVP_RAND_CTX *ctx))
 {
     if (rng != NULL)
-        ((FAKE_RAND *)rng->data)->cb = cb;
+        ((FAKE_RAND *)rng->algctx)->cb = cb;
 }
 
 void fake_rand_set_public_private_callbacks(OSSL_LIB_CTX *libctx,


### PR DESCRIPTION
Fixes #14284

This was a bit confusing since some objects need an actual provider
context to be passed (e.g. asym_cipher_gettable_ctx_params)
This 'data' field is an opaque ptr returned from new_ctx() operations. The
ptr points to data created inside a providers implementation of an
algorithm. This ptr is then passed to the provider algorithm for all
subsequent operations (such as init(), update(), and free()).

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
