### PR TITLE
Run evp_libctx_test with default and legacy providers

### DIFF
--- a/test/evp_libctx_test.c
+++ b/test/evp_libctx_test.c
@@ -370,10 +370,10 @@ static int test_cipher_reinit(int test_id)
         || !TEST_true(EVP_EncryptInit_ex(ctx, NULL, NULL, key, iv))
         || !TEST_int_eq(EVP_EncryptUpdate(ctx, out2, &out2_len, in, sizeof(in)),
                         ccm ? 0 : 1)
-        || !TEST_true(EVP_EncryptInit_ex(ctx, NULL, NULL, NULL, iv))
-        || (!no_null_key &&
-           !TEST_int_eq(EVP_EncryptUpdate(ctx, out3, &out3_len, in, sizeof(in)),
-                        ccm || siv ? 0 : 1)))
+        || (!no_null_key
+        && (!TEST_true(EVP_EncryptInit_ex(ctx, NULL, NULL, NULL, iv))
+        || !TEST_int_eq(EVP_EncryptUpdate(ctx, out3, &out3_len, in, sizeof(in)),
+                        ccm || siv ? 0 : 1))))
         goto err;
 
     if (ccm == 0) {

--- a/test/evp_libctx_test.c
+++ b/test/evp_libctx_test.c
@@ -314,7 +314,7 @@ err:
 
 static int test_cipher_reinit(int test_id)
 {
-    int ret = 0, diff, ccm, siv;
+    int ret = 0, diff, ccm, siv, no_null_key;
     int out1_len = 0, out2_len = 0, out3_len = 0;
     EVP_CIPHER *cipher = NULL;
     EVP_CIPHER_CTX *ctx = NULL;
@@ -354,6 +354,14 @@ static int test_cipher_reinit(int test_id)
     /* siv cannot be called with NULL key as the iv is irrelevant */
     siv = (EVP_CIPHER_mode(cipher) == EVP_CIPH_SIV_MODE);
 
+    /*
+     * Skip init call with a null key for RC4 as the stream cipher does not
+     * handle reinit (1.1.1 behaviour).
+     */
+    no_null_key = EVP_CIPHER_is_a(cipher, "RC4")
+                  || EVP_CIPHER_is_a(cipher, "RC4-40")
+                  || EVP_CIPHER_is_a(cipher, "RC4-HMAC-MD5");
+
     /* DES3-WRAP uses random every update - so it will give a different value */
     diff = EVP_CIPHER_is_a(cipher, "DES3-WRAP");
 
@@ -363,8 +371,9 @@ static int test_cipher_reinit(int test_id)
         || !TEST_int_eq(EVP_EncryptUpdate(ctx, out2, &out2_len, in, sizeof(in)),
                         ccm ? 0 : 1)
         || !TEST_true(EVP_EncryptInit_ex(ctx, NULL, NULL, NULL, iv))
-        || !TEST_int_eq(EVP_EncryptUpdate(ctx, out3, &out3_len, in, sizeof(in)),
-                        ccm || siv ? 0 : 1))
+        || (!no_null_key &&
+           !TEST_int_eq(EVP_EncryptUpdate(ctx, out3, &out3_len, in, sizeof(in)),
+                        ccm || siv ? 0 : 1)))
         goto err;
 
     if (ccm == 0) {
@@ -375,7 +384,7 @@ static int test_cipher_reinit(int test_id)
                 goto err;
         } else {
             if (!TEST_mem_eq(out1, out1_len, out2, out2_len)
-                || (!siv && !TEST_mem_eq(out1, out1_len, out3, out3_len)))
+                || (!siv && !no_null_key && !TEST_mem_eq(out1, out1_len, out3, out3_len)))
                 goto err;
         }
     }

--- a/test/recipes/30-test_evp_libctx.t
+++ b/test/recipes/30-test_evp_libctx.t
@@ -16,6 +16,7 @@ BEGIN {
     setup("test_evp_libctx");
 }
 
+my $no_legacy = disabled('legacy') || ($ENV{NO_LEGACY} // 0);
 my $no_fips = disabled('fips') || ($ENV{NO_FIPS} // 0);
 
 use lib srctop_dir('Configurations');
@@ -24,7 +25,7 @@ use lib bldtop_dir('.');
 # If no fips then run the test with no extra arguments.
 my @test_args = ( );
 
-plan tests => ($no_fips ? 0 : 1) + 2;
+plan tests => ($no_fips ? 0 : 1) + ($no_legacy ? 0 : 1) + 1;
 
 unless ($no_fips) {
     @test_args = ("-config", srctop_file("test","fips-and-base.cnf"),
@@ -37,7 +38,9 @@ ok(run(test(["evp_libctx_test",
              "-config", srctop_file("test","default.cnf"),])),
    "running default evp_libctx_test");
 
-ok(run(test(["evp_libctx_test",
-             "-config", srctop_file("test","default-and-legacy.cnf"),])),
-   "running default-and-legacy evp_libctx_test");
+unless ($no_legacy) {
+    ok(run(test(["evp_libctx_test",
+                 "-config", srctop_file("test","default-and-legacy.cnf"),])),
+       "running default-and-legacy evp_libctx_test");
+}
 

--- a/test/recipes/30-test_evp_libctx.t
+++ b/test/recipes/30-test_evp_libctx.t
@@ -24,9 +24,7 @@ use lib bldtop_dir('.');
 # If no fips then run the test with no extra arguments.
 my @test_args = ( );
 
-plan tests =>
-    ($no_fips ? 0 : 1)          # FIPS install test
-    + 1;
+plan tests => ($no_fips ? 0 : 1) + 2;
 
 unless ($no_fips) {
     @test_args = ("-config", srctop_file("test","fips-and-base.cnf"),
@@ -37,4 +35,9 @@ unless ($no_fips) {
 
 ok(run(test(["evp_libctx_test",
              "-config", srctop_file("test","default.cnf"),])),
+   "running default evp_libctx_test");
+
+ok(run(test(["evp_libctx_test",
+             "-config", srctop_file("test","default-and-legacy.cnf"),])),
    "running default-and-legacy evp_libctx_test");
+


### PR DESCRIPTION
Add an extra test run for this test with the default-and-legacy.cnf configuration.

Note that some RC4 steps are skipped due to the behaviour of RC4 being different to other ciphers.

- [X] tests are added or updated
