### PR TITLE
ASN1: Fix i2d_provided() return value

### DIFF
--- a/crypto/asn1/i2d_evp.c
+++ b/crypto/asn1/i2d_evp.c
@@ -48,6 +48,7 @@ static int i2d_provided(const EVP_PKEY *a, int selection,
          * down, when pp != NULL.
          */
         size_t len = INT_MAX;
+        int pp_was_NULL = (pp == NULL || *pp == NULL);
 
         ctx = OSSL_ENCODER_CTX_new_for_pkey(a, selection,
                                             output_info->output_type,
@@ -56,7 +57,7 @@ static int i2d_provided(const EVP_PKEY *a, int selection,
         if (ctx == NULL)
             return -1;
         if (OSSL_ENCODER_to_data(ctx, pp, &len)) {
-            if (pp == NULL)
+            if (pp_was_NULL)
                 ret = (int)len;
             else
                 ret = INT_MAX - (int)len;


### PR DESCRIPTION
i2d_provided() - which is the internal provider data function for
i2d_KeyParams(), i2d_PrivateKey(), i2d_PublicKey() - didn't treat the
returned length from OSSL_ENCODER_to_data() quite as well as it should
have.  A simple added flag that records the state of |*pp| before
calling OSSL_ENCODER_to_data() fixes the problem.

Fixes #14655
