### PR TITLE
fips: fix RNG leak if the POST are run during initialisation

### DIFF
--- a/crypto/initthread.c
+++ b/crypto/initthread.c
@@ -33,7 +33,9 @@ extern OSSL_FUNC_core_thread_start_fn *c_thread_start;
 
 typedef struct thread_event_handler_st THREAD_EVENT_HANDLER;
 struct thread_event_handler_st {
+#ifndef FIPS_MODULE
     const void *index;
+#endif
     void *arg;
     OSSL_thread_stop_handler_fn handfn;
     THREAD_EVENT_HANDLER *next;
@@ -376,7 +378,9 @@ int ossl_init_thread_start(const void *index, void *arg,
 
     hand->handfn = handfn;
     hand->arg = arg;
+#ifndef FIPS_MODULE
     hand->index = index;
+#endif
     hand->next = *hands;
     *hands = hand;
 

--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -1567,7 +1567,8 @@ static OPENSSL_CORE_CTX *core_get_libctx(const OSSL_CORE_HANDLE *handle)
 }
 
 static int core_thread_start(const OSSL_CORE_HANDLE *handle,
-                             OSSL_thread_stop_handler_fn handfn)
+                             OSSL_thread_stop_handler_fn handfn,
+                             void *arg)
 {
     /*
      * We created this object originally and we know it is actually an
@@ -1575,7 +1576,7 @@ static int core_thread_start(const OSSL_CORE_HANDLE *handle,
      */
     OSSL_PROVIDER *prov = (OSSL_PROVIDER *)handle;
 
-    return ossl_init_thread_start(prov, prov->provctx, handfn);
+    return ossl_init_thread_start(prov, arg, handfn);
 }
 
 /*

--- a/doc/man7/provider-base.pod
+++ b/doc/man7/provider-base.pod
@@ -21,7 +21,8 @@ provider-base
 
  typedef void (*OSSL_thread_stop_handler_fn)(void *arg);
  int core_thread_start(const OSSL_CORE_HANDLE *handle,
-                       OSSL_thread_stop_handler_fn handfn);
+                       OSSL_thread_stop_handler_fn handfn,
+                       void *arg);
 
  OPENSSL_CORE_CTX *core_get_libctx(const OSSL_CORE_HANDLE *handle);
  void core_new_error(const OSSL_CORE_HANDLE *handle);
@@ -191,13 +192,14 @@ core_get_params() retrieves parameters from the core for the given I<handle>.
 See L</Core parameters> below for a description of currently known
 parameters.
 
-The core_thread_start() function informs the core that the provider has started
+The core_thread_start() function informs the core that the provider has stated
 an interest in the current thread. The core will inform the provider when the
 thread eventually stops. It must be passed the I<handle> for this provider, as
 well as a callback I<handfn> which will be called when the thread stops. The
-callback will subsequently be called from the thread that is stopping and gets
-passed the provider context as an argument. This may be useful to perform thread
-specific clean up such as freeing thread local variables.
+callback will subsequently be called, with the supplied argument I<arg>, from
+the thread that is stopping and gets passed the provider context as an
+argument. This may be useful to perform thread specific clean up such as
+freeing thread local variables.
 
 core_get_libctx() retrieves the library context in which the library
 object for the current provider is stored, accessible through the I<handle>.

--- a/include/crypto/cryptlib.h
+++ b/include/crypto/cryptlib.h
@@ -21,7 +21,7 @@ int ossl_init_thread_start(const void *index, void *arg,
 int ossl_init_thread_deregister(void *index);
 int ossl_init_thread(void);
 void ossl_cleanup_thread(void);
-void ossl_ctx_thread_stop(void *arg);
+void ossl_ctx_thread_stop(OSSL_LIB_CTX *ctx);
 
 /*
  * OPENSSL_INIT flags. The primary list of these is in crypto.h. Flags below

--- a/include/internal/cryptlib.h
+++ b/include/internal/cryptlib.h
@@ -155,7 +155,9 @@ typedef struct ossl_ex_data_global_st {
 # define OSSL_LIB_CTX_DRBG_INDEX                     5
 # define OSSL_LIB_CTX_DRBG_NONCE_INDEX               6
 # define OSSL_LIB_CTX_RAND_CRNGT_INDEX               7
-# define OSSL_LIB_CTX_THREAD_EVENT_HANDLER_INDEX     8
+# ifdef FIPS_MODULE
+#  define OSSL_LIB_CTX_THREAD_EVENT_HANDLER_INDEX    8
+# endif
 # define OSSL_LIB_CTX_FIPS_PROV_INDEX                9
 # define OSSL_LIB_CTX_ENCODER_STORE_INDEX           10
 # define OSSL_LIB_CTX_DECODER_STORE_INDEX           11

--- a/include/openssl/core_dispatch.h
+++ b/include/openssl/core_dispatch.h
@@ -68,7 +68,8 @@ OSSL_CORE_MAKE_FUNC(int,core_get_params,(const OSSL_CORE_HANDLE *prov,
                                          OSSL_PARAM params[]))
 # define OSSL_FUNC_CORE_THREAD_START           3
 OSSL_CORE_MAKE_FUNC(int,core_thread_start,(const OSSL_CORE_HANDLE *prov,
-                                           OSSL_thread_stop_handler_fn handfn))
+                                           OSSL_thread_stop_handler_fn handfn,
+                                           void *arg))
 # define OSSL_FUNC_CORE_GET_LIBCTX             4
 OSSL_CORE_MAKE_FUNC(OPENSSL_CORE_CTX *,core_get_libctx,
                     (const OSSL_CORE_HANDLE *prov))

--- a/test/build.info
+++ b/test/build.info
@@ -47,7 +47,7 @@ IF[{- !$disabled{tests} -}]
           bio_callback_test bio_memleak_test bio_core_test param_build_test \
           bioprinttest sslapitest dtlstest sslcorrupttest \
           bio_enc_test pkey_meth_test pkey_meth_kdf_test evp_kdf_test uitest \
-          cipherbytes_test \
+          cipherbytes_test threadstest_fips \
           asn1_encode_test asn1_decode_test asn1_string_table_test \
           x509_time_test x509_dup_cert_test x509_check_cert_pkey_test \
           recordlentest drbgtest rand_status_test sslbuffertest \
@@ -270,6 +270,10 @@ IF[{- !$disabled{tests} -}]
   SOURCE[threadstest]=threadstest.c
   INCLUDE[threadstest]=../include ../apps/include
   DEPEND[threadstest]=../libcrypto libtestutil.a
+
+  SOURCE[threadstest_fips]=threadstest_fips.c
+  INCLUDE[threadstest_fips]=../include ../apps/include
+  DEPEND[threadstest_fips]=../libcrypto libtestutil.a
 
   SOURCE[afalgtest]=afalgtest.c
   INCLUDE[afalgtest]=../include ../apps/include

--- a/test/recipes/90-test_threads.t
+++ b/test/recipes/90-test_threads.t
@@ -23,7 +23,7 @@ my $no_fips = disabled('fips') || ($ENV{NO_FIPS} // 0);
 my $config_path = abs_path(srctop_file("test", $no_fips ? "default.cnf"
                                                         : "default-and-fips.cnf"));
 
-plan tests => 1;
+plan tests => 2;
 
 if ($no_fips) {
     ok(run(test(["threadstest", "-config", $config_path, data_dir()])),
@@ -32,3 +32,6 @@ if ($no_fips) {
     ok(run(test(["threadstest", "-fips", "-config", $config_path, data_dir()])),
        "running test_threads with FIPS");
 }
+
+$ENV{OPENSSL_CONF} = $config_path;
+ok(run(test(["threadstest_fips"])), "running test_threads_fips");

--- a/test/threadstest.c
+++ b/test/threadstest.c
@@ -366,7 +366,7 @@ static void thread_provider_load_unload(void)
  * Test 2: Simple fetch worker
  * Test 3: Worker downgrading a shared EVP_PKEY
  * Test 4: Worker using a shared EVP_PKEY
- * Test 5: Workder loading and unloading a provider
+ * Test 5: Worker loading and unloading a provider
  */
 static int test_multi(int idx)
 {

--- a/test/threadstest.c
+++ b/test/threadstest.c
@@ -20,76 +20,11 @@
 #include <openssl/aes.h>
 #include <openssl/rsa.h>
 #include "testutil.h"
+#include "threadstest.h"
 
 static int do_fips = 0;
 static char *privkey;
 static char *config_file = NULL;
-
-#if !defined(OPENSSL_THREADS) || defined(CRYPTO_TDEBUG)
-
-typedef unsigned int thread_t;
-
-static int run_thread(thread_t *t, void (*f)(void))
-{
-    f();
-    return 1;
-}
-
-static int wait_for_thread(thread_t thread)
-{
-    return 1;
-}
-
-#elif defined(OPENSSL_SYS_WINDOWS)
-
-typedef HANDLE thread_t;
-
-static DWORD WINAPI thread_run(LPVOID arg)
-{
-    void (*f)(void);
-
-    *(void **) (&f) = arg;
-
-    f();
-    return 0;
-}
-
-static int run_thread(thread_t *t, void (*f)(void))
-{
-    *t = CreateThread(NULL, 0, thread_run, *(void **) &f, 0, NULL);
-    return *t != NULL;
-}
-
-static int wait_for_thread(thread_t thread)
-{
-    return WaitForSingleObject(thread, INFINITE) == 0;
-}
-
-#else
-
-typedef pthread_t thread_t;
-
-static void *thread_run(void *arg)
-{
-    void (*f)(void);
-
-    *(void **) (&f) = arg;
-
-    f();
-    return NULL;
-}
-
-static int run_thread(thread_t *t, void (*f)(void))
-{
-    return pthread_create(t, NULL, thread_run, *(void **) &f) == 0;
-}
-
-static int wait_for_thread(thread_t thread)
-{
-    return pthread_join(thread, NULL) == 0;
-}
-
-#endif
 
 static int test_lock(void)
 {

--- a/test/threadstest.h
+++ b/test/threadstest.h
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2021 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#if defined(_WIN32)
+# include <windows.h>
+#endif
+
+#include <string.h>
+#include "testutil.h"
+
+#if !defined(OPENSSL_THREADS) || defined(CRYPTO_TDEBUG)
+
+typedef unsigned int thread_t;
+
+static int run_thread(thread_t *t, void (*f)(void))
+{
+    f();
+    return 1;
+}
+
+static int wait_for_thread(thread_t thread)
+{
+    return 1;
+}
+
+#elif defined(OPENSSL_SYS_WINDOWS)
+
+typedef HANDLE thread_t;
+
+static DWORD WINAPI thread_run(LPVOID arg)
+{
+    void (*f)(void);
+
+    *(void **) (&f) = arg;
+
+    f();
+    return 0;
+}
+
+static int run_thread(thread_t *t, void (*f)(void))
+{
+    *t = CreateThread(NULL, 0, thread_run, *(void **) &f, 0, NULL);
+    return *t != NULL;
+}
+
+static int wait_for_thread(thread_t thread)
+{
+    return WaitForSingleObject(thread, INFINITE) == 0;
+}
+
+#else
+
+typedef pthread_t thread_t;
+
+static void *thread_run(void *arg)
+{
+    void (*f)(void);
+
+    *(void **) (&f) = arg;
+
+    f();
+    return NULL;
+}
+
+static int run_thread(thread_t *t, void (*f)(void))
+{
+    return pthread_create(t, NULL, thread_run, *(void **) &f) == 0;
+}
+
+static int wait_for_thread(thread_t thread)
+{
+    return pthread_join(thread, NULL) == 0;
+}
+
+#endif
+

--- a/test/threadstest_fips.c
+++ b/test/threadstest_fips.c
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2021 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#if defined(_WIN32)
+# include <windows.h>
+#endif
+
+#include "testutil.h"
+#include "threadstest.h"
+
+static int success;
+
+static void thread_fips_rand_fetch(void)
+{
+    EVP_MD *md;
+
+    if (!TEST_true(md = EVP_MD_fetch(NULL, "SHA2-256", NULL)))
+        success = 0;
+    EVP_MD_free(md);
+}
+
+static int test_fips_rand_leak(void)
+{
+    thread_t thread;
+
+    success = 1;
+
+    if (!TEST_true(run_thread(&thread, thread_fips_rand_fetch)))
+        return 0;
+    if (!TEST_true(wait_for_thread(thread)))
+        return 0;
+    return TEST_true(success);
+}
+
+int setup_tests(void)
+{
+    /*
+     * This test MUST be run first.  Once the default library context is set
+     * up, this test will always pass.
+     */
+    ADD_TEST(test_fips_rand_leak);
+    return 1;
+}


### PR DESCRIPTION
The FIPS provider leaks a RAND if the POST is run at initialisation time.

The sequence of step to reproduce this:

1. new thread created
1. cause something to configure the default lib ctx
1. this triggers implicit initialization of libcrypto loading the config file
1. this triggers loading the FIPS provider as it is configured to be loaded
1. this runs constructor of the libfips.so
1. this triggers POST routine which initializes a libctx for the FIPS provider and drbg in it

The data from 6 are leaked.

- [x] documentation is added or updated
- [x] tests are added or updated

Fixes #14527
