### PR TITLE
80-test_cmp_http.t: Use random port number, 1024 <= n < 65536, for Mock server

### DIFF
--- a/test/recipes/80-test_cmp_http_data/Mock/server.cnf
+++ b/test/recipes/80-test_cmp_http_data/Mock/server.cnf
@@ -1,6 +1,6 @@
 [cmp] # mock server configuration
 
-port = 1700
+port = any
 srv_cert = server.crt
 srv_key = server.key
 srv_secret = pass:test

--- a/test/recipes/80-test_cmp_http_data/Mock/test.cnf
+++ b/test/recipes/80-test_cmp_http_data/Mock/test.cnf
@@ -17,7 +17,7 @@ policies = certificatePolicies
 [Mock] # the built-in OpenSSL CMP mock server
 no_check_time = 1
 server_host = 127.0.0.1 # localhost
-server_port = 1700
+server_port = any
 server_tls = 0
 server_cert = server.crt
 server = $server_host:$server_port
@@ -30,8 +30,8 @@ expect_sender = $server_dn
 subject = "/C=AU/ST=Some-State/O=Internet Widgits Pty Ltd/CN=leaf"
 newkey = signer.key
 out_trusted = signer_root.crt
-kur_port = 1700
-pbm_port = 1700
+kur_port = any
+pbm_port = any
 pbm_ref =
 pbm_secret = pass:test
 cert = signer.crt


### PR DESCRIPTION
Fixes #14694

- [x] tests are added or updated
