### PR TITLE
Fix spurious error queue entries while loading private keys

### DIFF
--- a/providers/implementations/encode_decode/decode_der2key.c
+++ b/providers/implementations/encode_decode/decode_der2key.c
@@ -206,34 +206,51 @@ static int der2key_decode(void *vctx, OSSL_CORE_BIO *cin, int selection,
 
     ok = 0;                      /* Assume that we fail */
 
+    ERR_set_mark();
     if ((selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) != 0) {
         derp = der;
         if (ctx->desc->d2i_PKCS8 != NULL) {
             key = ctx->desc->d2i_PKCS8(NULL, &derp, der_len, ctx);
-            if (ctx->flag_fatal)
+            if (ctx->flag_fatal) {
+                ERR_clear_last_mark();
                 goto end;
+            }
         } else if (ctx->desc->d2i_private_key != NULL) {
             key = ctx->desc->d2i_private_key(NULL, &derp, der_len);
         }
-        if (key == NULL && ctx->selection != 0)
+        if (key == NULL && ctx->selection != 0) {
+            ERR_clear_last_mark();
             goto next;
+        }
     }
     if (key == NULL && (selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY) != 0) {
+        ERR_pop_to_mark();
+        ERR_set_mark();
         derp = der;
         if (ctx->desc->d2i_PUBKEY != NULL)
             key = ctx->desc->d2i_PUBKEY(NULL, &derp, der_len);
         else
             key = ctx->desc->d2i_public_key(NULL, &derp, der_len);
-        if (key == NULL && ctx->selection != 0)
+        if (key == NULL && ctx->selection != 0) {
+            ERR_clear_last_mark();
             goto next;
+        }
     }
     if (key == NULL && (selection & OSSL_KEYMGMT_SELECT_ALL_PARAMETERS) != 0) {
+        ERR_pop_to_mark();
+        ERR_set_mark();
         derp = der;
         if (ctx->desc->d2i_key_params != NULL)
             key = ctx->desc->d2i_key_params(NULL, &derp, der_len);
-        if (key == NULL && ctx->selection != 0)
+        if (key == NULL && ctx->selection != 0) {
+            ERR_clear_last_mark();
             goto next;
+        }
     }
+    if (key == NULL)
+        ERR_clear_last_mark();
+    else
+        ERR_pop_to_mark();
 
     /*
      * Last minute check to see if this was the correct type of key.  This

--- a/providers/implementations/encode_decode/decode_der2key.c
+++ b/providers/implementations/encode_decode/decode_der2key.c
@@ -204,7 +204,7 @@ static int der2key_decode(void *vctx, OSSL_CORE_BIO *cin, int selection,
     if (!ok)
         goto next;
 
-    ok = 0;                      /* Assume that we fail */
+    ok = 0; /* Assume that we fail */
 
     ERR_set_mark();
     if ((selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) != 0) {
@@ -224,8 +224,6 @@ static int der2key_decode(void *vctx, OSSL_CORE_BIO *cin, int selection,
         }
     }
     if (key == NULL && (selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY) != 0) {
-        ERR_pop_to_mark();
-        ERR_set_mark();
         derp = der;
         if (ctx->desc->d2i_PUBKEY != NULL)
             key = ctx->desc->d2i_PUBKEY(NULL, &derp, der_len);
@@ -237,8 +235,6 @@ static int der2key_decode(void *vctx, OSSL_CORE_BIO *cin, int selection,
         }
     }
     if (key == NULL && (selection & OSSL_KEYMGMT_SELECT_ALL_PARAMETERS) != 0) {
-        ERR_pop_to_mark();
-        ERR_set_mark();
         derp = der;
         if (ctx->desc->d2i_key_params != NULL)
             key = ctx->desc->d2i_key_params(NULL, &derp, der_len);


### PR DESCRIPTION
This removes spurious error queue entries such as
```
ossl_store_handle_load_result:crypto/store/store_result.c:151:error: unsupported:
asn1_check_tlen:crypto/asn1/tasn_dec.c:1156:error: wrong tag:
asn1_item_embed_d2i:crypto/asn1/tasn_dec.c:322:error: nested asn1 error:Type=EC_PRIVATEKEY
```
when loading private keys via OSSL_STORE: .
The underlying issue was revealed by a recent improvement in #15253.

~On this occasion, also~
* ~Make `OSSL_CRMF_ENCRYPTEDVALUE_get1_encCert()` conservative on the error queue~
* ~`crypto/{http,cmp}`: Remove obsolete comments w.r.t. `ERR_clear_error()`~