### PR TITLE
Fix a use-after-free in the child provider code

### DIFF
--- a/crypto/provider_child.c
+++ b/crypto/provider_child.c
@@ -47,7 +47,7 @@ static void child_prov_ossl_ctx_free(void *vgbl)
 }
 
 static const OSSL_LIB_CTX_METHOD child_prov_ossl_ctx_method = {
-    OSSL_LIB_CTX_METHOD_DEFAULT_PRIORITY,
+    OSSL_LIB_CTX_METHOD_LOW_PRIORITY,
     child_prov_ossl_ctx_new,
     child_prov_ossl_ctx_free,
 };

--- a/include/internal/cryptlib.h
+++ b/include/internal/cryptlib.h
@@ -168,6 +168,7 @@ typedef struct ossl_ex_data_global_st {
 # define OSSL_LIB_CTX_CHILD_PROVIDER_INDEX          18
 # define OSSL_LIB_CTX_MAX_INDEXES                   19
 
+# define OSSL_LIB_CTX_METHOD_LOW_PRIORITY          -1
 # define OSSL_LIB_CTX_METHOD_DEFAULT_PRIORITY       0
 # define OSSL_LIB_CTX_METHOD_PRIORITY_1             1
 # define OSSL_LIB_CTX_METHOD_PRIORITY_2             2


### PR DESCRIPTION
If the child provider context data gets cleaned up before all usage of
providers has finished then a use-after-free can occur. We change the
priority of this data so that it gets freed later.

Fixes #15284