### PR TITLE
test/evp_extra_test2.c: Try EVP_PKEY_export() with a legacy RSA key

### DIFF
--- a/test/evp_extra_test2.c
+++ b/test/evp_extra_test2.c
@@ -20,6 +20,9 @@
 #include <openssl/evp.h>
 #include <openssl/pem.h>
 #include <openssl/provider.h>
+#ifndef OPENSSL_NO_DEPRECATED_3_0
+# include <openssl/rsa.h>
+#endif
 #include <openssl/core_names.h>
 #include "testutil.h"
 #include "internal/nelem.h"
@@ -728,7 +731,9 @@ static int test_pkey_export_null(void)
 static int test_pkey_export(void)
 {
     EVP_PKEY *pkey = NULL;
+#ifndef OPENSSL_NO_DEPRECATED_3_0
     RSA *rsa = NULL;
+#endif
     int ret = 1;
     const unsigned char *pdata = keydata[0].kder;
     int pdata_len = keydata[0].size;

--- a/test/evp_extra_test2.c
+++ b/test/evp_extra_test2.c
@@ -742,6 +742,7 @@ static int test_pkey_export(void)
         ret = 0;
     EVP_PKEY_free(pkey);
 
+#ifndef OPENSSL_NO_DEPRECATED_3_0
     /* Now, try with a legacy key */
     pdata = keydata[0].kder;
     pdata_len = keydata[0].size;
@@ -754,6 +755,7 @@ static int test_pkey_export(void)
                                        test_pkey_export_cb, NULL)))
         ret = 0;
     EVP_PKEY_free(pkey);
+#endif
     return ret;
 }
 

--- a/test/evp_extra_test2.c
+++ b/test/evp_extra_test2.c
@@ -7,6 +7,9 @@
  * https://www.openssl.org/source/license.html
  */
 
+/* We need to use some deprecated APIs */
+#define OPENSSL_SUPPRESS_DEPRECATED
+
 /*
  * Really these tests should be in evp_extra_test - but that doesn't
  * yet support testing with a non-default libctx. Once it does we should move
@@ -725,15 +728,31 @@ static int test_pkey_export_null(void)
 static int test_pkey_export(void)
 {
     EVP_PKEY *pkey = NULL;
-    int ret = 0;
+    RSA *rsa = NULL;
+    int ret = 1;
     const unsigned char *pdata = keydata[0].kder;
+    int pdata_len = keydata[0].size;
 
-    ret = TEST_ptr(pkey = d2i_AutoPrivateKey_ex(NULL, &pdata, keydata[0].size,
-                                                mainctx, NULL))
-          && TEST_int_eq(EVP_PKEY_export(pkey, EVP_PKEY_KEYPAIR,
-                                         test_pkey_export_cb, pkey), 1)
-          && TEST_int_eq(EVP_PKEY_export(pkey, EVP_PKEY_KEYPAIR,
-                                         test_pkey_export_cb, NULL), 0);
+    if (!TEST_ptr(pkey = d2i_AutoPrivateKey_ex(NULL, &pdata, pdata_len,
+                                               mainctx, NULL))
+        || !TEST_true(EVP_PKEY_export(pkey, EVP_PKEY_KEYPAIR,
+                                       test_pkey_export_cb, pkey))
+        || !TEST_false(EVP_PKEY_export(pkey, EVP_PKEY_KEYPAIR,
+                                       test_pkey_export_cb, NULL)))
+        ret = 0;
+    EVP_PKEY_free(pkey);
+
+    /* Now, try with a legacy key */
+    pdata = keydata[0].kder;
+    pdata_len = keydata[0].size;
+    if (!TEST_ptr(rsa = d2i_RSAPrivateKey(NULL, &pdata, pdata_len))
+        || !TEST_ptr(pkey = EVP_PKEY_new())
+        || !TEST_true(EVP_PKEY_assign_RSA(pkey, rsa))
+        || !TEST_true(EVP_PKEY_export(pkey, EVP_PKEY_KEYPAIR,
+                                      test_pkey_export_cb, pkey))
+        || !TEST_false(EVP_PKEY_export(pkey, EVP_PKEY_KEYPAIR,
+                                       test_pkey_export_cb, NULL)))
+        ret = 0;
     EVP_PKEY_free(pkey);
     return ret;
 }


### PR DESCRIPTION
This is a test to demonstrate #15290.  The fix will be in a different PR, which will include this test.