### PR TITLE
test: conditionally exclude unused code for no-tls1.2 build

### DIFF
--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -4649,7 +4649,9 @@ static int test_key_exchange(int idx)
     return testresult;
 }
 
-# if !defined(OPENSSL_NO_EC) && !defined(OPENSSL_NO_DH)
+# if !defined(OPENSSL_NO_TLS1_2) \
+     && !defined(OPENSSL_NO_EC)  \
+     && !defined(OPENSSL_NO_DH)
 static int set_ssl_groups(SSL *serverssl, SSL *clientssl, int clientmulti,
                           int isecdhe, int idx)
 {


### PR DESCRIPTION
A missing !defined() is added to exclude an otherwise unused function from the test build.

The remaining run-checker failures are `no-ec2m` ~and the `enable-ecvp-tests`~ builds.  These are being addressed separately.

- [ ] documentation is added or updated
- [x] tests are added or updated
