### PR TITLE
Treat sleepless Windoze

### DIFF
--- a/apps/cmp.c
+++ b/apps/cmp.c
@@ -2705,7 +2705,7 @@ int cmp_main(int argc, char **argv)
                                            prog, opt_port, 0, 0);
             if (ret == 0) { /* no request yet */
                 if (retry) {
-                    sleep(1);
+                    ossl_sleep(1000);
                     retry = 0;
                     continue;
                 }

--- a/apps/lib/http_server.c
+++ b/apps/lib/http_server.c
@@ -96,7 +96,7 @@ static void killall(int ret, pid_t *kidpids)
         if (kidpids[i] != 0)
             (void)kill(kidpids[i], SIGTERM);
     OPENSSL_free(kidpids);
-    sleep(1);
+    ossl_sleep(1000);
     exit(ret);
 }
 
@@ -166,7 +166,7 @@ void spawn_loop(const char *prog)
                                WCOREDUMP(status) ? " (core dumped)" :
 # endif
                                "");
-                    sleep(1);
+                    ossl_sleep(1000);
                 }
                 break;
             } else if (errno != EINTR) {
@@ -180,7 +180,7 @@ void spawn_loop(const char *prog)
         switch (fpid = fork()) {
         case -1: /* error */
             /* System critically low on memory, pause and try again later */
-            sleep(30);
+            ossl_sleep(30000);
             break;
         case 0: /* child */
             OPENSSL_free(kidpids);

--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -3036,9 +3036,7 @@ static int www_body(int s, int stype, int prot, unsigned char *context)
                     continue;
                 }
 #endif
-#if !defined(OPENSSL_SYS_MSDOS)
-                sleep(1);
-#endif
+                ossl_sleep(1000);
                 continue;
             }
         } else if (i == 0) {    /* end of input */
@@ -3465,9 +3463,7 @@ static int rev_body(int s, int stype, int prot, unsigned char *context)
                     continue;
                 }
 #endif
-#if !defined(OPENSSL_SYS_MSDOS)
-                sleep(1);
-#endif
+                ossl_sleep(1000);
                 continue;
             }
         } else if (i == 0) {    /* end of input */

--- a/crypto/bio/bio_lib.c
+++ b/crypto/bio/bio_lib.c
@@ -11,7 +11,6 @@
 #include <errno.h>
 #include <openssl/crypto.h>
 #include "bio_local.h"
-#include "internal/cryptlib.h"
 
 /*
  * Helper macro for the callback to determine whether an operator expects a

--- a/crypto/cmp/cmp_client.c
+++ b/crypto/cmp/cmp_client.c
@@ -11,6 +11,7 @@
 
 #include "cmp_local.h"
 #include "internal/cryptlib.h"
+#include "e_os.h" /* ossl_sleep() */
 
 /* explicit #includes not strictly needed since implied by the above: */
 #include <openssl/bio.h>

--- a/e_os.h
+++ b/e_os.h
@@ -303,6 +303,54 @@ struct servent *getservbyname(const char *name, const char *proto);
 # endif
 /* end vxworks */
 
+/* system-specific variants defining ossl_sleep() */
+#ifdef OPENSSL_SYS_UNIX
+# include <unistd.h>
+static ossl_inline void ossl_sleep(unsigned long millis)
+{
+# ifdef OPENSSL_SYS_VXWORKS
+    struct timespec ts;
+    ts.tv_sec = (long int) (millis / 1000);
+    ts.tv_nsec = (long int) (millis % 1000) * 1000000ul;
+    nanosleep(&ts, NULL);
+# elif defined(__TANDEM)
+#  if !defined(_REENTRANT)
+#   include <cextdecs.h(PROCESS_DELAY_)>
+    /* HPNS does not support usleep for non threaded apps */
+    PROCESS_DELAY_(millis * 1000);
+#  elif defined(_SPT_MODEL_)
+#   include <spthread.h>
+#   include <spt_extensions.h>
+    usleep(millis * 1000);
+#  else
+    usleep(millis * 1000);
+#  endif
+# else
+    usleep(millis * 1000);
+# endif
+}
+#elif defined(_WIN32)
+# include <windows.h>
+static ossl_inline void ossl_sleep(unsigned long millis)
+{
+    Sleep(millis);
+}
+#else
+/* Fallback to a busy wait */
+static ossl_inline void ossl_sleep(unsigned long millis)
+{
+    struct timeval start, now;
+    unsigned long elapsedms;
+
+    gettimeofday(&start, NULL);
+    do {
+        gettimeofday(&now, NULL);
+        elapsedms = (((now.tv_sec - start.tv_sec) * 1000000)
+                     + now.tv_usec - start.tv_usec) / 1000;
+    } while (elapsedms < millis);
+}
+#endif /* defined OPENSSL_SYS_UNIX */
+
 /* ----------------------------- HP NonStop -------------------------------- */
 /* Required to support platform variant without getpid() and pid_t. */
 # if defined(__TANDEM) && defined(_GUARDIAN_TARGET)

--- a/include/internal/cryptlib.h
+++ b/include/internal/cryptlib.h
@@ -218,54 +218,6 @@ const void *ossl_bsearch(const void *key, const void *base, int num,
                          int size, int (*cmp) (const void *, const void *),
                          int flags);
 
-/* system-specific variants defining ossl_sleep() */
-#ifdef OPENSSL_SYS_UNIX
-# include <unistd.h>
-static ossl_inline void ossl_sleep(unsigned long millis)
-{
-# ifdef OPENSSL_SYS_VXWORKS
-    struct timespec ts;
-    ts.tv_sec = (long int) (millis / 1000);
-    ts.tv_nsec = (long int) (millis % 1000) * 1000000ul;
-    nanosleep(&ts, NULL);
-# elif defined(__TANDEM)
-#  if !defined(_REENTRANT)
-#   include <cextdecs.h(PROCESS_DELAY_)>
-    /* HPNS does not support usleep for non threaded apps */
-    PROCESS_DELAY_(millis * 1000);
-#  elif defined(_SPT_MODEL_)
-#   include <spthread.h>
-#   include <spt_extensions.h>
-    usleep(millis * 1000);
-#  else
-    usleep(millis * 1000);
-#  endif
-# else
-    usleep(millis * 1000);
-# endif
-}
-#elif defined(_WIN32)
-# include <windows.h>
-static ossl_inline void ossl_sleep(unsigned long millis)
-{
-    Sleep(millis);
-}
-#else
-/* Fallback to a busy wait */
-static ossl_inline void ossl_sleep(unsigned long millis)
-{
-    struct timeval start, now;
-    unsigned long elapsedms;
-
-    gettimeofday(&start, NULL);
-    do {
-        gettimeofday(&now, NULL);
-        elapsedms = (((now.tv_sec - start.tv_sec) * 1000000)
-                     + now.tv_usec - start.tv_usec) / 1000;
-    } while (elapsedms < millis);
-}
-#endif /* defined OPENSSL_SYS_UNIX */
-
 char *ossl_sk_ASN1_UTF8STRING2text(STACK_OF(ASN1_UTF8STRING) *text,
                                    const char *sep, size_t max_len);
 char *ossl_ipaddr_to_asc(unsigned char *p, int len);

--- a/test/helpers/ssltestlib.c
+++ b/test/helpers/ssltestlib.c
@@ -10,10 +10,9 @@
 #include <string.h>
 
 #include "internal/nelem.h"
-#include "internal/cryptlib.h" /* for ossl_sleep() */
 #include "ssltestlib.h"
 #include "../testutil.h"
-#include "e_os.h"
+#include "e_os.h" /* for ossl_sleep() etc. */
 
 #ifdef OPENSSL_SYS_UNIX
 # include <unistd.h>


### PR DESCRIPTION
Move `ossl_sleep()` to where it fits much better: `e_os.h` and use it in apps.

Fixes #15304: 
```
openssl-bin-cmp.obj : error LNK2019: unresolved external symbol sleep referenced in function cmp_main
```