### PR TITLE
Separate FIPS checksum and labelling into different workflows

### DIFF
--- a/.github/workflows/fips-checksums.yml
+++ b/.github/workflows/fips-checksums.yml
@@ -1,0 +1,60 @@
+name: FIPS Checksums
+on: [pull_request]
+
+jobs:
+  compute-checksums:
+    runs-on: ubuntu-latest
+    steps:
+      - name: install unifdef
+        run: |
+            sudo apt-get update
+            sudo apt-get -yq --no-install-suggests --no-install-recommends --force-yes install unifdef
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+      - name: create build dirs
+        run: |
+          mkdir ./build-pristine
+          mkdir ./build
+          mkdir ./empty
+          touch ./empty/placeholder
+      - name: config pristine
+        run: ../config enable-fips && perl configdata.pm --dump
+        working-directory: ./build-pristine
+      - name: make build_generated pristine
+        run: make -s build_generated
+        working-directory: ./build-pristine
+      - name: make fips-checksums pristine
+        run: make fips-checksums
+        working-directory: ./build-pristine
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          clean: false
+      - name: config
+        run: ../config enable-fips && perl configdata.pm --dump
+        working-directory: ./build
+      - name: make build_generated
+        run: make -s build_generated
+        working-directory: ./build
+      - name: make fips-checksums
+        run: make fips-checksums
+        working-directory: ./build
+      - name: update checksums pristine
+        run: touch providers/fips.checksum.new && make update-fips-checksums
+        working-directory: ./build-pristine
+      - name: make diff-fips-checksums
+        run: make diff-fips-checksums && echo "fips_unchanged=1" >> $GITHUB_ENV || echo "fips_changed=1" >> $GITHUB_ENV
+        working-directory: ./build
+      - name: save artifact fips_changed
+        if: ${{ env.fips_changed }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: fips_changed
+          path: empty/
+      - name: save artifact fips_unchanged
+        if: ${{ env.fips_unchanged }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: fips_unchanged
+          path: empty/

--- a/.github/workflows/fips-label.yml
+++ b/.github/workflows/fips-label.yml
@@ -1,0 +1,38 @@
+name: FIPS Changed Label
+on:
+  workflow_run:
+    workflows: ["FIPS Checksums"]
+    types:
+      - completed
+
+jobs:
+  apply-label:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.event == 'pull_request' }}
+    steps:
+      - name: 'Check artifact and apply'
+        if: ${{ github.event.workflow_run.conclusion == 'success' }}
+        uses: actions/github-script@v4
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            var artifacts = await github.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: ${{github.event.workflow_run.id }},
+            });
+            if ( artifacts.data.artifacts[0].name == 'fips_changed' ) {
+              github.issues.addLabels({
+                issue_number: ${{ github.event.workflow_run.pull_requests[0].number }},
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                labels: ['severity: fips change']
+              });
+            } else if ( artifacts.data.artifacts[0].name == 'fips_unchanged' ) {
+              github.issues.removeLabel({
+                issue_number: ${{ github.event.workflow_run.pull_requests[0].number }},
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: 'severity: fips change'
+              });
+            }

--- a/.github/workflows/fips-label.yml
+++ b/.github/workflows/fips-label.yml
@@ -19,7 +19,7 @@ jobs:
             var artifacts = await github.actions.listWorkflowRunArtifacts({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              run_id: ${{github.event.workflow_run.id }},
+              run_id: ${{ github.event.workflow_run.id }},
             });
             if ( artifacts.data.artifacts[0].name == 'fips_changed' ) {
               github.issues.addLabels({
@@ -29,10 +29,20 @@ jobs:
                 labels: ['severity: fips change']
               });
             } else if ( artifacts.data.artifacts[0].name == 'fips_unchanged' ) {
-              github.issues.removeLabel({
+              var labels = await github.issues.listLabelsOnIssue({
                 issue_number: ${{ github.event.workflow_run.pull_requests[0].number }},
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                name: 'severity: fips change'
               });
+
+              for ( var label in labels.data ) {
+                if (labels.data[label].name == 'severity: fips change') {
+                  github.issues.removeLabel({
+                    issue_number: ${{ github.event.workflow_run.pull_requests[0].number }},
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    name: 'severity: fips change'
+                  });
+                }
+              }
             }


### PR DESCRIPTION
This separates the checksumming and labelling into separate workflows where checksumming is done on pull_request which has just read only access.

The labelling just checks presence of the 'fips_changed' or 'fips_unchanged' artifact and applies label accordingly.