### PR TITLE
Remove '=for openssl ifdef'

### DIFF
--- a/doc/man1/openssl-ca.pod.in
+++ b/doc/man1/openssl-ca.pod.in
@@ -65,8 +65,6 @@ B<openssl> B<ca>
 {- $OpenSSL::safe::opt_engine_synopsis -}{- $OpenSSL::safe::opt_provider_synopsis -}
 [I<certreq>...]
 
-=for openssl ifdef engine
-
 =head1 DESCRIPTION
 
 This command emulates a CA application.

--- a/doc/man1/openssl-ciphers.pod.in
+++ b/doc/man1/openssl-ciphers.pod.in
@@ -26,8 +26,6 @@ B<openssl> B<ciphers>
 {- $OpenSSL::safe::opt_provider_synopsis -}
 [I<cipherlist>]
 
-=for openssl ifdef ssl3 tls1 tls1_1 tls1_2 tls1_3 psk srp
-
 =head1 DESCRIPTION
 
 This command converts textual OpenSSL cipher lists into

--- a/doc/man1/openssl-cmp.pod.in
+++ b/doc/man1/openssl-cmp.pod.in
@@ -144,8 +144,6 @@ Certificate verification options, for both CMP and TLS:
 
 {- $OpenSSL::safe::opt_v_synopsis -}
 
-=for openssl ifdef engine
-
 =head1 DESCRIPTION
 
 The B<cmp> command is a client implementation for the Certificate

--- a/doc/man1/openssl-cms.pod.in
+++ b/doc/man1/openssl-cms.pod.in
@@ -85,8 +85,6 @@ B<openssl> B<cms>
 {- $OpenSSL::safe::opt_config_synopsis -}
 [I<recipient-cert> ...]
 
-=for openssl ifdef des-wrap engine
-
 =head1 DESCRIPTION
 
 This command handles S/MIME v3.1 mail. It can encrypt, decrypt,

--- a/doc/man1/openssl-crl.pod.in
+++ b/doc/man1/openssl-crl.pod.in
@@ -31,8 +31,6 @@ B<openssl> B<crl>
 {- $OpenSSL::safe::opt_trust_synopsis -}
 {- $OpenSSL::safe::opt_provider_synopsis -}
 
-=for openssl ifdef hash_old
-
 =head1 DESCRIPTION
 
 This command processes CRL files in DER or PEM format.

--- a/doc/man1/openssl-dhparam.pod.in
+++ b/doc/man1/openssl-dhparam.pod.in
@@ -24,8 +24,6 @@ B<openssl dhparam>
 {- $OpenSSL::safe::opt_provider_synopsis -}
 [I<numbits>]
 
-=for openssl ifdef dsaparam engine
-
 =head1 DESCRIPTION
 
 This command is used to manipulate DH parameter files.

--- a/doc/man1/openssl-dsa.pod.in
+++ b/doc/man1/openssl-dsa.pod.in
@@ -38,8 +38,6 @@ B<openssl> B<dsa>
 [B<-pubout>]
 {- $OpenSSL::safe::opt_engine_synopsis -}{- $OpenSSL::safe::opt_provider_synopsis -}
 
-=for openssl ifdef pvk-string pvk-weak pvk-none engine
-
 =head1 DESCRIPTION
 
 This command processes DSA keys. They can be converted between various

--- a/doc/man1/openssl-ec.pod.in
+++ b/doc/man1/openssl-ec.pod.in
@@ -33,8 +33,6 @@ B<openssl> B<ec>
 [B<-check>]
 {- $OpenSSL::safe::opt_engine_synopsis -}{- $OpenSSL::safe::opt_provider_synopsis -}
 
-=for openssl ifdef engine
-
 =head1 DESCRIPTION
 
 The L<openssl-ec(1)> command processes EC keys. They can be converted between

--- a/doc/man1/openssl-ecparam.pod.in
+++ b/doc/man1/openssl-ecparam.pod.in
@@ -26,8 +26,6 @@ B<openssl ecparam>
 {- $OpenSSL::safe::opt_engine_synopsis -}{- $OpenSSL::safe::opt_r_synopsis -}
 {- $OpenSSL::safe::opt_provider_synopsis -}
 
-=for openssl ifdef engine
-
 =head1 DESCRIPTION
 
 This command is used to manipulate or generate EC parameter files.

--- a/doc/man1/openssl-enc.pod.in
+++ b/doc/man1/openssl-enc.pod.in
@@ -41,8 +41,6 @@ B<openssl> B<enc>|I<cipher>
 {- $OpenSSL::safe::opt_engine_synopsis -}{- $OpenSSL::safe::opt_r_synopsis -}
 {- $OpenSSL::safe::opt_provider_synopsis -}
 
-=for openssl ifdef z engine ciphers
-
 B<openssl> I<cipher> [B<...>]
 
 =head1 DESCRIPTION

--- a/doc/man1/openssl-gendsa.pod.in
+++ b/doc/man1/openssl-gendsa.pod.in
@@ -28,8 +28,6 @@ B<openssl> B<gendsa>
 {- $OpenSSL::safe::opt_engine_synopsis -}{- $OpenSSL::safe::opt_provider_synopsis -}
 [I<paramfile>]
 
-=for openssl ifdef engine
-
 =head1 DESCRIPTION
 
 This command generates a DSA private key from a DSA parameter file

--- a/doc/man1/openssl-genpkey.pod.in
+++ b/doc/man1/openssl-genpkey.pod.in
@@ -25,8 +25,6 @@ B<openssl> B<genpkey>
 {- $OpenSSL::safe::opt_engine_synopsis -}{- $OpenSSL::safe::opt_provider_synopsis -}
 {- $OpenSSL::safe::opt_config_synopsis -}
 
-=for openssl ifdef engine
-
 =head1 DESCRIPTION
 
 This command generates a private key.

--- a/doc/man1/openssl-genrsa.pod.in
+++ b/doc/man1/openssl-genrsa.pod.in
@@ -33,8 +33,6 @@ B<openssl> B<genrsa>
 {- $OpenSSL::safe::opt_engine_synopsis -}{- $OpenSSL::safe::opt_provider_synopsis -}
 [B<numbits>]
 
-=for openssl ifdef engine 3
-
 =head1 DESCRIPTION
 
 This command has been deprecated.

--- a/doc/man1/openssl-ocsp.pod.in
+++ b/doc/man1/openssl-ocsp.pod.in
@@ -72,8 +72,6 @@ B<openssl> B<ocsp>
 {- $OpenSSL::safe::opt_v_synopsis -}
 {- $OpenSSL::safe::opt_provider_synopsis -}
 
-=for openssl ifdef multi
-
 =head1 DESCRIPTION
 
 The Online Certificate Status Protocol (OCSP) enables applications to

--- a/doc/man1/openssl-passwd.pod.in
+++ b/doc/man1/openssl-passwd.pod.in
@@ -25,8 +25,6 @@ B<openssl passwd>
 {- $OpenSSL::safe::opt_provider_synopsis -}
 [I<password>]
 
-=for openssl ifdef crypt
-
 =head1 DESCRIPTION
 
 This command computes the hash of a password typed at

--- a/doc/man1/openssl-pkcs12.pod.in
+++ b/doc/man1/openssl-pkcs12.pod.in
@@ -68,8 +68,6 @@ PKCS#12 output (export) options:
 [B<-maciter>]
 [B<-nomac>]
 
-=for openssl ifdef engine
-
 =head1 DESCRIPTION
 
 This command allows PKCS#12 files (sometimes referred to as

--- a/doc/man1/openssl-pkcs7.pod.in
+++ b/doc/man1/openssl-pkcs7.pod.in
@@ -23,8 +23,6 @@ B<openssl> B<pkcs7>
 [B<-noout>]
 {- $OpenSSL::safe::opt_engine_synopsis -}{- $OpenSSL::safe::opt_provider_synopsis -}
 
-=for openssl ifdef engine
-
 =head1 DESCRIPTION
 
 This command processes PKCS#7 files.  Note that it only understands PKCS#7

--- a/doc/man1/openssl-pkcs8.pod.in
+++ b/doc/man1/openssl-pkcs8.pod.in
@@ -30,8 +30,6 @@ B<openssl> B<pkcs8>
 {- $OpenSSL::safe::opt_r_synopsis -}
 {- $OpenSSL::safe::opt_engine_synopsis -}{- $OpenSSL::safe::opt_provider_synopsis -}
 
-=for openssl ifdef engine scrypt scrypt_N scrypt_r scrypt_p
-
 =head1 DESCRIPTION
 
 This command processes private keys in PKCS#8 format. It can handle

--- a/doc/man1/openssl-pkey.pod.in
+++ b/doc/man1/openssl-pkey.pod.in
@@ -32,8 +32,6 @@ B<openssl> B<pkey>
 [B<-ec_conv_form> I<arg>]
 [B<-ec_param_enc> I<arg>]
 
-=for openssl ifdef engine
-
 =head1 DESCRIPTION
 
 This command processes public or private keys. They can be

--- a/doc/man1/openssl-pkeyparam.pod.in
+++ b/doc/man1/openssl-pkeyparam.pod.in
@@ -20,8 +20,6 @@ B<openssl> B<pkeyparam>
 [B<-check>]
 {- $OpenSSL::safe::opt_engine_synopsis -}{- $OpenSSL::safe::opt_provider_synopsis -}
 
-=for openssl ifdef engine
-
 =head1 DESCRIPTION
 
 This command processes public key algorithm parameters.

--- a/doc/man1/openssl-pkeyutl.pod.in
+++ b/doc/man1/openssl-pkeyutl.pod.in
@@ -39,8 +39,6 @@ B<openssl> B<pkeyutl>
 {- $OpenSSL::safe::opt_provider_synopsis -}
 {- $OpenSSL::safe::opt_config_synopsis -}
 
-=for openssl ifdef engine engine_impl
-
 =head1 DESCRIPTION
 
 This command can be used to perform low-level public key

--- a/doc/man1/openssl-rand.pod.in
+++ b/doc/man1/openssl-rand.pod.in
@@ -16,8 +16,6 @@ B<openssl rand>
 {- $OpenSSL::safe::opt_provider_synopsis -}
 I<num>
 
-=for openssl ifdef engine
-
 =head1 DESCRIPTION
 
 This command generates I<num> random bytes using a cryptographically

--- a/doc/man1/openssl-req.pod.in
+++ b/doc/man1/openssl-req.pod.in
@@ -56,8 +56,6 @@ B<openssl> B<req>
 {- $OpenSSL::safe::opt_r_synopsis -}
 {- $OpenSSL::safe::opt_engine_synopsis -}{- $OpenSSL::safe::opt_provider_synopsis -}
 
-=for openssl ifdef engine keygen_engine
-
 =head1 DESCRIPTION
 
 This command primarily creates and processes certificate requests (CSRs)

--- a/doc/man1/openssl-rsa.pod.in
+++ b/doc/man1/openssl-rsa.pod.in
@@ -42,8 +42,6 @@ B<openssl> B<rsa>
 [B<-RSAPublicKey_out>]
 {- $OpenSSL::safe::opt_engine_synopsis -}{- $OpenSSL::safe::opt_provider_synopsis -}
 
-=for openssl ifdef pvk-strong pvk-weak pvk-none engine
-
 =head1 DESCRIPTION
 
 This command processes RSA keys. They can be converted between

--- a/doc/man1/openssl-rsautl.pod.in
+++ b/doc/man1/openssl-rsautl.pod.in
@@ -30,8 +30,6 @@ B<openssl> B<rsautl>
 {- $OpenSSL::safe::opt_engine_synopsis -}{- $OpenSSL::safe::opt_r_synopsis -}
 {- $OpenSSL::safe::opt_provider_synopsis -}
 
-=for openssl ifdef engine
-
 =head1 DESCRIPTION
 
 This command has been deprecated.

--- a/doc/man1/openssl-s_client.pod.in
+++ b/doc/man1/openssl-s_client.pod.in
@@ -126,16 +126,6 @@ B<openssl> B<s_client>
 {- $OpenSSL::safe::opt_v_synopsis -}
 [I<host>:I<port>]
 
-=for openssl ifdef engine ssl_client_engine ct noct ctlogfile
-
-=for openssl ifdef ssl3 unix 4 6 use_srtp status trace wdebug nextprotoneg
-
-=for openssl ifdef ssl3 tls1 tls1_1 tls1_2 tls1_3 dtls mtu dtls1 dtls1_2
-
-=for openssl ifdef sctp_label_bug sctp
-
-=for openssl ifdef srpuser srppass srp_lateuser srp_moregroups srp_strength
-
 =head1 DESCRIPTION
 
 This command implements a generic SSL/TLS client which

--- a/doc/man1/openssl-s_server.pod.in
+++ b/doc/man1/openssl-s_server.pod.in
@@ -143,18 +143,6 @@ B<openssl> B<s_server>
 {- $OpenSSL::safe::opt_r_synopsis -}
 {- $OpenSSL::safe::opt_engine_synopsis -}{- $OpenSSL::safe::opt_provider_synopsis -}
 
-=for openssl ifdef unix 4 6 unlink no_dhe nextprotoneg use_srtp engine
-
-=for openssl ifdef status status_verbose status_timeout status_url status_file
-
-=for openssl ifdef psk_hint srpvfile srpuserseed sctp sctp_label_bug
-
-=for openssl ifdef sctp sctp_label_bug trace mtu timeout listen
-
-=for openssl ifdef ssl3 tls1 tls1_1 tls1_2 tls1_3 dtls mtu dtls1 dtls1_2
-
-=for openssl ifdef sendfile
-
 =head1 DESCRIPTION
 
 This command implements a generic SSL/TLS server which

--- a/doc/man1/openssl-s_time.pod.in
+++ b/doc/man1/openssl-s_time.pod.in
@@ -30,8 +30,6 @@ B<openssl> B<s_time>
 {- $OpenSSL::safe::opt_trust_synopsis -}
 {- $OpenSSL::safe::opt_provider_synopsis -}
 
-=for openssl ifdef ssl3 tls1 tls1_1 tls1_2 tls1_3
-
 =head1 DESCRIPTION
 
 This command implements a generic SSL/TLS client which

--- a/doc/man1/openssl-smime.pod.in
+++ b/doc/man1/openssl-smime.pod.in
@@ -52,8 +52,6 @@ B<openssl> B<smime>
 {- $OpenSSL::safe::opt_config_synopsis -}
 I<recipcert> ...
 
-=for openssl ifdef engine
-
 =head1 DESCRIPTION
 
 This command handles S/MIME mail. It can encrypt, decrypt, sign

--- a/doc/man1/openssl-speed.pod.in
+++ b/doc/man1/openssl-speed.pod.in
@@ -27,8 +27,6 @@ B<openssl speed>
 {- $OpenSSL::safe::opt_engine_synopsis -}{- $OpenSSL::safe::opt_provider_synopsis -}
 [I<algorithm> ...]
 
-=for openssl ifdef hmac cmac multi async_jobs engine
-
 =head1 DESCRIPTION
 
 This command is used to test the performance of cryptographic algorithms.

--- a/doc/man1/openssl-spkac.pod.in
+++ b/doc/man1/openssl-spkac.pod.in
@@ -26,8 +26,6 @@ B<openssl> B<spkac>
 [B<-verify>]
 {- $OpenSSL::safe::opt_engine_synopsis -}{- $OpenSSL::safe::opt_provider_synopsis -}
 
-=for openssl ifdef engine
-
 =head1 DESCRIPTION
 
 This command processes Netscape signed public key and challenge

--- a/doc/man1/openssl-srp.pod.in
+++ b/doc/man1/openssl-srp.pod.in
@@ -25,8 +25,6 @@ B<openssl srp>
 {- $OpenSSL::safe::opt_provider_synopsis -}
 [I<user> ...]
 
-=for openssl ifdef engine
-
 =head1 DESCRIPTION
 
 This command is deprecated. It is used to maintain an SRP (secure remote

--- a/doc/man1/openssl-ts.pod.in
+++ b/doc/man1/openssl-ts.pod.in
@@ -57,8 +57,6 @@ B<-verify>
 {- $OpenSSL::safe::opt_v_synopsis -}
 {- $OpenSSL::safe::opt_provider_synopsis -}
 
-=for openssl ifdef engine
-
 =head1 DESCRIPTION
 
 This command is a basic Time Stamping Authority (TSA) client and

--- a/doc/man1/openssl-verify.pod.in
+++ b/doc/man1/openssl-verify.pod.in
@@ -23,8 +23,6 @@ B<openssl> B<verify>
 [B<-->]
 [I<certificate> ...]
 
-=for openssl ifdef engine
-
 =head1 DESCRIPTION
 
 This command verifies certificate chains. If a certificate chain has multiple

--- a/doc/man1/openssl-x509.pod.in
+++ b/doc/man1/openssl-x509.pod.in
@@ -78,8 +78,6 @@ B<openssl> B<x509>
 {- $OpenSSL::safe::opt_r_synopsis -}
 {- $OpenSSL::safe::opt_engine_synopsis -}{- $OpenSSL::safe::opt_provider_synopsis -}
 
-=for openssl ifdef engine subject_hash_old issuer_hash_old
-
 =head1 DESCRIPTION
 
 This command is a multi-purposes certificate handling command.

--- a/util/find-doc-nits
+++ b/util/find-doc-nits
@@ -1035,7 +1035,6 @@ sub checkflags {
     my $doc = shift;
     my %cmdopts;
     my %docopts;
-    my %localskips;
 
     # Get the list of options in the command.
     open CFH, "$openssl list --options $cmd|"
@@ -1053,12 +1052,6 @@ sub checkflags {
     while ( <CFH> ) {
         chop;
         last if /DESCRIPTION/;
-        if ( /=for openssl ifdef (.*)/ ) {
-            foreach my $f ( split / /, $1 ) {
-                $localskips{$f} = 1;
-            }
-            next;
-        }
         my $opt;
         if ( /\[B<-([^ >]+)/ ) {
             $opt = $1;
@@ -1082,7 +1075,7 @@ sub checkflags {
     # See what's in the command not the manpage.
     my @unimpl = sort grep { !defined $cmdopts{$_} } keys %docopts;
     foreach ( @unimpl ) {
-        next if defined $skips{$_} || defined $localskips{$_};
+        next if defined $skips{$_};
         err("$doc: $cmd does not implement -$_");
     }
 }


### PR DESCRIPTION
No longer needed after rewrite of cmd-nits

Depends on #15298 
