### PR TITLE
Properly restore XMM registers in ChaCha20's AVX-512(VL) assembly

### DIFF
--- a/crypto/chacha/asm/chacha-x86_64.pl
+++ b/crypto/chacha/asm/chacha-x86_64.pl
@@ -473,7 +473,7 @@ sub SSSE3ROUND {	# critical path is 20 "SIMD ticks" per round
 	&por	($b,$t);
 }
 
-my $xframe = $win64 ? 32+8 : 8;
+my $xframe = $win64 ? 160+8 : 8;
 
 $code.=<<___;
 .type	ChaCha20_ssse3,\@function,5
@@ -2501,7 +2501,7 @@ sub AVX512ROUND {	# critical path is 14 "SIMD ticks" per round
 	&vprold	($b,$b,7);
 }
 
-my $xframe = $win64 ? 32+8 : 8;
+my $xframe = $win64 ? 160+8 : 8;
 
 $code.=<<___;
 .type	ChaCha20_avx512,\@function,5
@@ -2517,8 +2517,16 @@ ChaCha20_avx512:
 	sub	\$64+$xframe,%rsp
 ___
 $code.=<<___	if ($win64);
-	movaps	%xmm6,-0x28(%r9)
-	movaps	%xmm7,-0x18(%r9)
+	movaps	%xmm6,-0xa8(%r9)
+	movaps	%xmm7,-0x98(%r9)
+	movaps	%xmm8,-0x88(%r9)
+	movaps	%xmm9,-0x78(%r9)
+	movaps	%xmm10,-0x68(%r9)
+	movaps	%xmm11,-0x58(%r9)
+	movaps	%xmm12,-0x48(%r9)
+	movaps	%xmm13,-0x38(%r9)
+	movaps	%xmm14,-0x28(%r9)
+	movaps	%xmm15,-0x18(%r9)
 .Lavx512_body:
 ___
 $code.=<<___;
@@ -2685,8 +2693,16 @@ $code.=<<___;
 	vzeroall
 ___
 $code.=<<___	if ($win64);
-	movaps	-0x28(%r9),%xmm6
-	movaps	-0x18(%r9),%xmm7
+	movaps	-0xa8(%r9),%xmm6
+	movaps	-0x98(%r9),%xmm7
+	movaps	-0x88(%r9),%xmm8
+	movaps	-0x78(%r9),%xmm9
+	movaps	-0x68(%r9),%xmm10
+	movaps	-0x58(%r9),%xmm11
+	movaps	-0x48(%r9),%xmm12
+	movaps	-0x38(%r9),%xmm13
+	movaps	-0x28(%r9),%xmm14
+	movaps	-0x18(%r9),%xmm15
 ___
 $code.=<<___;
 	lea	(%r9),%rsp
@@ -2713,8 +2729,16 @@ ChaCha20_avx512vl:
 	sub	\$64+$xframe,%rsp
 ___
 $code.=<<___	if ($win64);
-	movaps	%xmm6,-0x28(%r9)
-	movaps	%xmm7,-0x18(%r9)
+	movaps	%xmm6,-0xa8(%r9)
+	movaps	%xmm7,-0x98(%r9)
+	movaps	%xmm8,-0x88(%r9)
+	movaps	%xmm9,-0x78(%r9)
+	movaps	%xmm10,-0x68(%r9)
+	movaps	%xmm11,-0x58(%r9)
+	movaps	%xmm12,-0x48(%r9)
+	movaps	%xmm13,-0x38(%r9)
+	movaps	%xmm14,-0x28(%r9)
+	movaps	%xmm15,-0x18(%r9)
 .Lavx512vl_body:
 ___
 $code.=<<___;
@@ -2838,8 +2862,16 @@ $code.=<<___;
 	vzeroall
 ___
 $code.=<<___	if ($win64);
-	movaps	-0x28(%r9),%xmm6
-	movaps	-0x18(%r9),%xmm7
+	movaps	-0xa8(%r9),%xmm6
+	movaps	-0x98(%r9),%xmm7
+	movaps	-0x88(%r9),%xmm8
+	movaps	-0x78(%r9),%xmm9
+	movaps	-0x68(%r9),%xmm10
+	movaps	-0x58(%r9),%xmm11
+	movaps	-0x48(%r9),%xmm12
+	movaps	-0x38(%r9),%xmm13
+	movaps	-0x28(%r9),%xmm14
+	movaps	-0x18(%r9),%xmm15
 ___
 $code.=<<___;
 	lea	(%r9),%rsp


### PR DESCRIPTION
This is a potential fix for #15314. With this proposed fix, both `ChaCha20_avx512` and `ChaCha20_avx512vl` will be saving all nonvolatile XMM registers on Win64, like the other functions in this file. I did not remove the `vzeroall` as I think the intent here is to clear all used registers from any remaining state. Otherwise, I guess it would be possible to only clear the upper part of the YMM registers, leaving the XMM registers untouched if unused.
