### PR TITLE
Adapt building OpenSSL 3.0 for VMS

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -134,7 +134,9 @@ sub vms_info {
     }
 
     unless (%$vms_info) {
-        $vms_info->{disable_warns} = [ ];
+        $vms_info->{disable_warns} = [
+            "CXXPRAGMANA",      # Shut up about unknown / unsupported pragmas
+        ];
         $vms_info->{pointer_size} = $pointer_size_str;
         if ($pointer_size_str eq "64") {
             `PIPE CC /NOCROSS_REFERENCE /NOLIST /NOOBJECT /WARNINGS = DISABLE = ( MAYLOSEDATA3, EMPTYFILE ) NL: 2> NL:`;

--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1837,10 +1837,12 @@ my %targets = (
         # and binaries instead.
         bin_cflags       => add("/NAMES=(AS_IS,SHORTENED)/EXTERN_MODEL=STRICT_REFDEF"),
         lib_cflags       => add("/NAMES=(AS_IS,SHORTENED)/EXTERN_MODEL=STRICT_REFDEF"),
-        # For modules specifically, we assume that they only use public
-        # OpenSSL symbols, and therefore don't need to mangle names on
-        # their own.
-        dso_cflags       => "",
+        # Strictly speaking, DSOs should not need to have name shortening,
+        # as all their exported symbols should be short enough to fit the
+        # linker's 31 character per symbol name limit.  However, providers
+        # may be composed of more than one object file, and internal symbols
+        # may and do surpass the 31 character limit.
+        dso_cflags       => add("/NAMES=(SHORTENED)"),
         ex_libs          => add(sub { return vms_info()->{zlib} || (); }),
         shared_target    => "vms-shared",
         # def_flag made to empty string so a .opt file gets generated

--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1822,6 +1822,7 @@ my %targets = (
                               @{vms_info()->{disable_warns}};
                           @warnings
                               ? "/WARNINGS=DISABLE=(".join(",",@warnings).")" : (); }),
+        cflag_incfirst   => '/FIRST_INCLUDE=',
         lib_defines      =>
             add("OPENSSL_USE_NODELETE",
                 sub {

--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -65,6 +65,134 @@
              && $unified_info{attributes}->{scripts}->{$_}->{misc} }
       @{$unified_info{scripts}};
 
+  # Configured flags
+
+  our @cnf_asflags = ($target{asflags} || (), @{$config{asflags}});
+  our @cnf_defines = (@{$target{defines}}, @{$config{defines}});
+  our @cnf_includes = (@{$target{includes}}, @{$config{includes}});
+  our @cnf_cppflags = ($target{cppflags} || (), @{$config{cppflags}});
+  our @cnf_cflags = ($target{cflags} || (), @{$config{cflags}});
+  our @cnf_cxxflags = ($target{cxxflags} || (), @{$config{cxxflags}});
+  our @cnf_ldflags = ($target{lflags} || (), @{$config{lflags}});
+  our @cnf_ex_libs = (map{ ",$_" } @{$target{ex_libs}}, @{$config{ex_libs}});
+
+  # Variables starting with $lib_ are used to build library object files
+  # and shared libraries.
+  # Variables starting with $dso_ are used to build DSOs and their object files.
+  # Variables starting with $bin_ are used to build programs and their object
+  # files.
+
+  # The following array is special and is treated separately from the rest of
+  # the lib_ variables.
+  our @lib_cppincludes = (@{$target{lib_includes}}, @{$target{shared_includes}},
+                          @{$config{lib_includes}}, @{$config{shared_includes}},
+                          @cnf_includes);
+
+  our $lib_cppdefines =
+      join(',', @{$target{lib_defines}}, @{$target{shared_defines}},
+                @{$config{lib_defines}}, @{$config{shared_defines}},
+                @cnf_defines,
+                'OPENSSLDIR="""$(OPENSSLDIR_C)"""',
+                'ENGINESDIR="""$(ENGINESDIR_C)"""',
+                'MODULESDIR="""$(MODULESDIR_C)"""',
+                #'$(DEFINES)'
+                )
+      . "'extradefines'";
+  our $lib_asflags =
+      join(' ', $target{lib_asflags} || (), @{$config{lib_asflags}},
+                @cnf_asflags, '$(ASFLAGS)');
+  our $lib_cppflags =
+      join('', $target{lib_cppflags} || (), $target{shared_cppflags} || (),
+               @{$config{lib_cppflags}}, @{$config{shared_cppflag}},
+               @cnf_cppflags, '/DEFINE=('.$lib_cppdefines.')', '$(CPPFLAGS)');
+  my @lib_cflags = ( $target{lib_cflags} // () );
+  my @lib_cflags_no_inst = ( $target{no_inst_lib_cflags} // @lib_cflags );
+  my @lib_cflags_cont = ( $target{shared_cflag} || (),
+                          @{$config{lib_cflags}}, @{$config{shared_cflag}},
+                          $cnf_cflags, '$(CFLAGS)');
+  our $lib_cflags = join('', @lib_cflags, @lib_cflags_cont );
+  our $lib_cflags_no_inst = join('', @lib_cflags_no_inst, @lib_cflags_cont );
+  our $lib_ldflags =
+      join('', $target{lib_lflags} || (), $target{shared_ldflag} || (),
+               @{$config{lib_lflags}}, @{$config{shared_ldflag}},
+               @cnf_ldflags, '$(LDFLAGS)');
+  our $lib_ex_libs = join('', @cnf_ex_libs, '$(EX_LIBS)');
+
+  # The following array is special and is treated separately from the rest of
+  # the dso_ variables.
+  our @dso_cppincludes = (@{$target{dso_includes}}, @{$target{module_includes}},
+                          @{$config{dso_includes}}, @{$config{module_includes}},
+                          @cnf_includes);
+
+  our $dso_cppdefines =
+      join(',', @{$target{dso_defines}}, @{$target{module_defines}},
+                @{$config{dso_defines}}, @{$config{module_defines}},
+                @cnf_defines,
+                #'$(DEFINES)'
+                )
+      . "'extradefines'";
+  our $dso_asflags =
+      join(' ', $target{dso_asflags} || (), $target{module_asflags} || (),
+                @{$config{dso_asflags}}, @{$config{module_asflags}},
+                @cnf_asflags, '$(ASFLAGS)');
+  our $dso_cppflags =
+      join('', $target{dso_cppflags} || (), $target{module_cppflags} || (),
+               @{$config{dso_cppflags}}, @{$config{module_cppflag}},
+               @cnf_cppflags,
+               '/DEFINE=('.$dso_cppdefines.')',
+               '$(CPPFLAGS)');
+  my @dso_cflags = ( $target{dso_cflags} // () );
+  my @dso_cflags_no_inst = ( $target{no_inst_dso_cflags} // @dso_cflags );
+  my @dso_cflags_cont = ( $target{module_cflag} || (),
+                          @{$config{dso_cflags}}, @{$config{module_cflag}},
+                          $cnf_cflags, '$(CFLAGS)');
+  our $dso_cflags = join('', @dso_cflags, @dso_cflags_cont );
+  our $dso_cflags_no_inst = join('', @dso_cflags_no_inst, @dso_cflags_cont );
+  our $dso_ldflags =
+      join('', $target{dso_lflags} || (), $target{module_ldflag} || (),
+               @{$config{dso_lflags}}, @{$config{module_ldflag}},
+               @cnf_ldflags, '$(LDFLAGS)');
+  our $dso_ex_libs = join('', @cnf_ex_libs, '$(EX_LIBS)');
+
+  # The following array is special and is treated separately from the rest of
+  # the bin_ variables.
+  our @bin_cppincludes = (@{$target{bin_includes}},
+                          @{$config{bin_includes}},
+                          @cnf_includes);
+
+  our $bin_cppdefines =
+      join(',', @{$target{bin_defines}},
+                @{$config{bin_defines}},
+                @cnf_defines,
+                #'$(DEFINES)'
+                )
+      . "'extradefines'";
+  our $bin_asflags =
+      join(' ', $target{bin_asflags} || (),
+                @{$config{bin_asflags}},
+                @cnf_asflags, '$(ASFLAGS)');
+  our $bin_cppflags =
+      join('', $target{bin_cppflags} || (),
+               @{$config{bin_cppflags}},
+               @cnf_cppflags,
+               '/DEFINE=('.$bin_cppdefines.')',
+               '$(CPPFLAGS)');
+  my @bin_cflags = ( $target{bin_cflags} // () );
+  my @bin_cflags_no_inst = ( $target{no_inst_bin_cflags} // @bin_cflags );
+  my @bin_cflags_cont = ( @{$config{bin_cflags}},
+                          $cnf_cflags, '$(CFLAGS)');
+  our $bin_cflags = join('', @bin_cflags, @bin_cflags_cont );
+  our $bin_cflags_no_inst = join('', @bin_cflags_no_inst, @bin_cflags_cont );
+  our $bin_cflags =
+      join('', $target{bin_cflags} || (),
+               @{$config{bin_cflags}},
+               @cnf_cflags, '$(CFLAGS)');
+  our $bin_ldflags =
+      join('', $target{bin_lflags} || (),
+               @{$config{bin_lflags}},
+               @cnf_ldflags, '$(LDFLAGS)');
+  our $bin_ex_libs = join('', @cnf_ex_libs, '$(EX_LIBS)');
+
   # This is a horrible hack, but is needed because recursive inclusion of files
   # in different directories does not work well with HP C.
   my $sd = sourcedir("crypto", "async", "arch");
@@ -91,6 +219,7 @@
           = qq(deassign statem
         deassign record);
   }
+
   # This makes sure things get built in the order they need
   # to. You're welcome.
   sub dependmagic {
@@ -197,9 +326,9 @@ MODULESDIR_C={- platform->osslprefix() -}MODULES{- $sover_dirname.$target{pointe
 
 CC={- $config{CC} -}
 CPP={- $config{CPP} -}
-DEFINES={- our $defines1 = join('', map { ",$_" } @{$config{CPPDEFINES}}) -}
-INCLUDES={- our $includes1 = join(',', @{$config{CPPINCLUDES}}) -}
-CPPFLAGS={- our $cppflags1 = join('', @{$config{CPPFLAGS}}) -}
+DEFINES={- our $defines = join('', map { ",$_" } @{$config{CPPDEFINES}}) -}
+INCLUDES={- our $includes = join(',', @{$config{CPPINCLUDES}}) -}
+CPPFLAGS={- our $cppflags = join('', @{$config{CPPFLAGS}}) -}
 CFLAGS={- join('', @{$config{CFLAGS}}) -}
 LDFLAGS={- join('', @{$config{LFLAGS}}) -}
 EX_LIBS={- join('', map { ",$_" } @{$config{LDLIBS}}) -}
@@ -213,153 +342,12 @@ ASFLAGS={- join(' ', @{$config{ASFLAGS}}) -}
 
 ASOUTFLAG={- $target{asoutflag} -}$(OSSL_EMPTY)
 
-##### Project flags ##################################################
-
-# Variables starting with CNF_ are common variables for all product types
-
-CNF_ASFLAGS={- join('', $target{asflags} || (),
-                        @{$config{asflags}}) -}
-CNF_DEFINES={- our $defines2 = join('', (map { ",$_" } @{$target{defines}},
-                                                       @{$config{defines}}),
-                                        "'extradefines'") -}
-CNF_INCLUDES={- our $includes2 = join(',', @{$target{includes}},
-                                           @{$config{includes}}) -}
-CNF_CPPFLAGS={- our $cppflags2 = join('', $target{cppflags} || (),
-                                          @{$config{cppflags}}) -}
-CNF_CFLAGS={- join('', $target{cflags} || (),
-                       @{$config{cflags}}) -}
-CNF_CXXFLAGS={- join('', $target{cxxflags} || (),
-                         @{$config{cxxflags}}) -}
-CNF_LDFLAGS={- join('', $target{lflags} || (),
-                        @{$config{lflags}}) -}
-CNF_EX_LIBS={- join('', map{ ",$_" } @{$target{ex_libs}},
-                                     @{$config{ex_libs}}) -}
-
-# Variables starting with LIB_ are used to build library object files
-# and shared libraries.
-# Variables starting with DSO_ are used to build DSOs and their object files.
-# Variables starting with BIN_ are used to build programs and their object
-# files.
-
-LIB_ASFLAGS={- join(' ', $target{lib_asflags} || (),
-                         @{$config{lib_asflags}},
-                         '$(CNF_ASFLAGS)', '$(ASFLAGS)') -}
-LIB_DEFINES={- our $lib_defines =
-               join('', (map { ",$_" } @{$target{lib_defines}},
-                                       @{$target{shared_defines}},
-                                       @{$config{lib_defines}},
-                                       @{$config{shared_defines}}));
-               join('', $lib_defines,
-                        (map { ",$_" } 'OPENSSLDIR="""$(OPENSSLDIR_C)"""',
-                                       'ENGINESDIR="""$(ENGINESDIR_C)"""',
-                                       'MODULESDIR="""$(MODULESDIR_C)"""'),
-                        '$(CNF_DEFINES)', '$(DEFINES)') -}
-LIB_INCLUDES={- our $lib_includes =
-                join(',', @{$target{lib_includes}},
-                          @{$target{shared_includes}},
-                          @{$config{lib_includes}},
-                          @{$config{shared_includes}}) -}
-LIB_CPPFLAGS={- our $lib_cppflags =
-                join('', $target{lib_cppflags} || (),
-                         $target{shared_cppflags} || (),
-                         @{$config{lib_cppflags}},
-                         @{$config{shared_cppflag}});
-                join('', "'qual_includes'",
-                         '/DEFINE=(__dummy$(LIB_DEFINES))',
-                         $lib_cppflags,
-                         '$(CNF_CPPFLAGS)', '$(CPPFLAGS)') -}
-LIB_CFLAGS={- join('', $target{lib_cflags} || (),
-                       $target{shared_cflag} || (),
-                       @{$config{lib_cflags}},
-                       @{$config{shared_cflag}},
-                       '$(CNF_CFLAGS)', '$(CFLAGS)') -}
-LIB_LDFLAGS={- join('', $target{lib_lflags} || (),
-                        $target{shared_ldflag} || (),
-                        @{$config{lib_lflags}},
-                        @{$config{shared_ldflag}},
-                        '$(CNF_LDFLAGS)', '$(LDFLAGS)') -}
-LIB_EX_LIBS=$(CNF_EX_LIBS)$(EX_LIBS)
-DSO_ASFLAGS={- join(' ', $target{dso_asflags} || (),
-                         $target{module_asflags} || (),
-                         @{$config{dso_asflags}},
-                         @{$config{module_asflags}},
-                         '$(CNF_ASFLAGS)', '$(ASFLAGS)') -}
-DSO_DEFINES={- join('', (map { ",$_" } @{$target{dso_defines}},
-                                       @{$target{module_defines}},
-                                       @{$config{dso_defines}},
-                                       @{$config{module_defines}}),
-                        '$(CNF_DEFINES)', '$(DEFINES)') -}
-DSO_INCLUDES={- join(',', @{$target{dso_includes}},
-                          @{$target{module_includes}},
-                          @{$config{dso_includes}},
-                          @{$config{module_includes}}) -}
-DSO_CPPFLAGS={- join('', "'qual_includes'",
-                         '/DEFINE=(__dummy$(DSO_DEFINES))',
-                         $target{dso_cppflags} || (),
-                         $target{module_cppflags} || (),
-                         @{$config{dso_cppflags}},
-                         @{$config{module_cppflags}},
-                         '$(CNF_CPPFLAGS)', '$(CPPFLAGS)') -}
-DSO_CFLAGS={- join('', $target{dso_cflags} || (),
-                       $target{module_cflags} || (),
-                       @{$config{dso_cflags}},
-                       @{$config{module_cflags}},
-                       '$(CNF_CFLAGS)', '$(CFLAGS)') -}
-DSO_LDFLAGS={- join('', $target{dso_lflags} || (),
-                        $target{module_ldflags} || (),
-                        @{$config{dso_lflags}},
-                        @{$config{module_ldflags}},
-                        '$(CNF_LDFLAGS)', '$(LDFLAGS)') -}
-DSO_EX_LIBS=$(CNF_EX_LIBS) $(EX_LIBS)
-BIN_ASFLAGS={- join(' ', $target{bin_asflags} || (),
-                         @{$config{bin_asflags}},
-                         '$(CNF_ASFLAGS)', '$(ASFLAGS)') -}
-BIN_DEFINES={- join('', (map { ",$_" } @{$target{bin_defines}},
-                                       @{$config{bin_defines}}),
-                        '$(CNF_DEFINES)', '$(DEFINES)') -}
-BIN_INCLUDES={- join(',', @{$target{bin_includes}},
-                          @{$config{bin_includes}}) -}
-BIN_CPPFLAGS={- join('', "'qual_includes'",
-                         '/DEFINE=(__dummy$(DSO_DEFINES))',
-                         $target{bin_cppflags} || (),
-                         @{$config{bin_cppflag}},
-                         '$(CNF_CPPFLAGS)', '$(CPPFLAGS)') -}
-BIN_CFLAGS={- join('', $target{bin_cflags} || (),
-                       @{$config{bin_cflags}},
-                       '$(CNF_CFLAGS)', '$(CFLAGS)') -}
-BIN_LDFLAGS={- join('', $target{bin_lflags} || (),
-                        @{$config{bin_lflags}} || (),
-                        '$(CNF_LDFLAGS)', '$(LDFLAGS)') -}
-BIN_EX_LIBS=$(CNF_EX_LIBS) $(EX_LIBS)
-NO_INST_LIB_CFLAGS={- join('', $target{no_inst_lib_cflags}
-                               // $target{lib_cflags}
-                               // (),
-                               $target{shared_cflag} || (),
-                               @{$config{lib_cflags}},
-                               @{$config{shared_cflag}},
-                               '$(CNF_CFLAGS)', '$(CFLAGS)') -}
-NO_INST_DSO_CFLAGS={- join('', $target{no_inst_dso_cflags}
-                               // $target{dso_cflags}
-                               // (),
-                               $target{no_inst_module_cflags}
-                               // $target{module_cflags}
-                               // (),
-                               @{$config{dso_cflags}},
-                               @{$config{module_cflags}},
-                               '$(CNF_CFLAGS)', '$(CFLAGS)') -}
-NO_INST_BIN_CFLAGS={- join('', $target{no_inst_bin_cflags}
-                               // $target{bin_cflags}
-                               // (),
-                               @{$config{bin_cflags}},
-                               '$(CNF_CFLAGS)', '$(CFLAGS)') -}
-
 PERLASM_SCHEME={- $target{perlasm_scheme} -}
 
 # CPPFLAGS_Q is used for one thing only: to build up buildinf.h
-CPPFLAGS_Q={- (my $c = $lib_cppflags.$cppflags2.$cppflags1) =~ s|"|""|g;
-              (my $d = $lib_defines.$defines2.$defines1) =~ s|"|""|g;
-              my $i = join(',', $lib_includes || (), $includes2 || (),
-                                $includes1 || ());
+CPPFLAGS_Q={- (my $c = $lib_cppflags.$cppflags) =~ s|"|""|g;
+              (my $d = $lib_cppdefines) =~ s|"|""|g;
+              my $i = join(',', @lib_cppincludes || (), '$(INCLUDES)');
               my $x = $c;
               $x .= "/INCLUDE=($i)" if $i;
               $x .= "/DEFINE=($d)" if $d;
@@ -862,12 +850,11 @@ EOF
           #
           # Assembler generator
           #
-          my $cppflags = {
-              shlib => '$(LIB_CFLAGS) $(LIB_CPPFLAGS)',
-              lib => '$(LIB_CFLAGS) $(LIB_CPPFLAGS)',
-              dso => '$(DSO_CFLAGS) $(DSO_CPPFLAGS)',
-              bin => '$(BIN_CFLAGS) $(BIN_CPPFLAGS)'
-          } -> {$args{intent}};
+          my $cppflags =
+              { shlib => "$lib_cflags $lib_cppflags",
+                lib => "$lib_cflags $lib_cppflags",
+                dso => "$dso_cflags $dso_cppflags",
+                bin => "$bin_cflags $bin_cppflags" } -> {$args{intent}};
           my @incs_cmds = includes({ shlib => '$(LIB_INCLUDES)',
                                      lib => '$(LIB_INCLUDES)',
                                      dso => '$(DSO_INCLUDES)',
@@ -1013,25 +1000,25 @@ EOF
 
       my $cflags;
       if ($args{attrs}->{noinst}) {
-          $cflags = { shlib => '$(NO_INST_LIB_CFLAGS)',
-                      lib => '$(NO_INST_LIB_CFLAGS)',
-                      dso => '$(NO_INST_DSO_CFLAGS)',
-                      bin => '$(NO_INST_BIN_CFLAGS)' } -> {$args{intent}};
+          $cflags .= { shlib => $lib_cflags_no_inst,
+                       lib => $lib_cflags_no_inst,
+                       dso => $dso_cflags_no_inst,
+                       bin => $bin_cflags_no_inst } -> {$args{intent}};
       } else {
-          $cflags = { shlib => '$(LIB_CFLAGS)',
-                      lib => '$(LIB_CFLAGS)',
-                      dso => '$(DSO_CFLAGS)',
-                      bin => '$(BIN_CFLAGS)' } -> {$args{intent}};
+          $cflags .= { shlib => $lib_cflags,
+                       lib => $lib_cflags,
+                       dso => $dso_cflags,
+                       bin => $bin_cflags } -> {$args{intent}};
       }
-      $cflags .= { shlib => '$(LIB_CPPFLAGS)',
-		   lib => '$(LIB_CPPFLAGS)',
-		   dso => '$(DSO_CPPFLAGS)',
-		   bin => '$(BIN_CPPFLAGS)' } -> {$args{intent}};
+      $cflags .= { shlib => $lib_cppflags,
+		   lib => $lib_cppflags,
+		   dso => $dso_cppflags,
+		   bin => $bin_cppflags } -> {$args{intent}};
       my $defs = join("", map { ",".$_ } @{$args{defs}});
-      my $asflags = { shlib => ' $(LIB_ASFLAGS)',
-		      lib => ' $(LIB_ASFLAGS)',
-		      dso => ' $(DSO_ASFLAGS)',
-		      bin => ' $(BIN_ASFLAGS)' } -> {$args{intent}};
+      my $asflags = { shlib => $lib_asflags,
+		      lib => $lib_asflags,
+		      dso => $dso_asflags,
+		      bin => $bin_asflags } -> {$args{intent}};
 
       my @incs_cmds = includes({ shlib => '$(LIB_INCLUDES)',
                                  lib => '$(LIB_INCLUDES)',
@@ -1130,7 +1117,7 @@ $shlib : $deps
         $write_opt1
         $write_opt2
         CLOSE OPT_FILE
-        LINK \$(LIB_LDFLAGS)/SHARE=\$\@ $defs[0]-translated/OPT,-
+        LINK ${lib_ldflags}/SHARE=\$\@ $defs[0]-translated/OPT,-
                 $shlibname-components.OPT/OPT \$(LIB_EX_LIBS)
         DELETE $defs[0]-translated;*,$shlibname-components.OPT;*
         PURGE $shlibname.EXE,$shlibname.MAP
@@ -1175,7 +1162,7 @@ $dso : $deps
         $write_opt1
         $write_opt2
         CLOSE OPT_FILE
-        LINK \$(DSO_LDFLAGS)/SHARE=\$\@ $defs[0]/OPT,-
+        LINK ${dso_ldflags}/SHARE=\$\@ $defs[0]/OPT,-
 		$dsoname-components.OPT/OPT \$(DSO_EX_LIBS)
         - PURGE $dsoname.EXE,$dsoname.OPT,$dsoname.MAP
 EOF
@@ -1274,7 +1261,7 @@ $bin : $deps
         @ CLOSE OPT_FILE
         TYPE $binname.OPT ! For debugging
         - pipe SPAWN/WAIT/NOLOG/OUT=$binname.LINKLOG -
-                    LINK \$(BIN_LDFLAGS)/EXEC=\$\@ $binname.OPT/OPT \$(BIN_EX_LIBS) ; -
+                    LINK ${bin_ldflags}/EXEC=\$\@ $binname.OPT/OPT \$(BIN_EX_LIBS) ; -
                link_status = \$status ; link_severity = link_status .AND. 7
         @ search_severity = 1
         -@ IF link_severity .EQ. 0 THEN -

--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -214,6 +214,19 @@
       $unified_info{after}->{$obj}
           = qq(deassign arch);
   }
+  my $sd32 = sourcedir("crypto", "ec", "curve448", "arch_32");
+  my $sd64 = sourcedir("crypto", "ec", "curve448", "arch_64");
+  foreach (grep /\[\.crypto\.ec\.curve448.*?\].*?\.o$/, keys %{$unified_info{sources}}) {
+      my $obj = platform->obj($_);
+      $unified_info{before}->{$obj}
+          = qq(arch_32_include = F\$PARSE("$sd32","A.;",,,"SYNTAX_ONLY") - "A.;"
+        define arch_32 'arch_32_include'
+        arch_64_include = F\$PARSE("$sd64","A.;",,,"SYNTAX_ONLY") - "A.;"
+        define arch_64 'arch_64_include');
+      $unified_info{after}->{$obj}
+          = qq(deassign arch_64
+        deassign arch_32);
+  }
   my $sd1 = sourcedir("ssl","record");
   my $sd2 = sourcedir("ssl","statem");
   my @ssl_locl_users = grep(/^\[\.(?:ssl\.(?:record|statem)|test)\].*\.o$/,

--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -28,7 +28,6 @@
       (my $x = shift) =~ s|\]$|...]|;
       $x
   }
-  }
 
   # Because we need to make two computations of these data,
   # we store them in arrays for reuse
@@ -138,7 +137,20 @@ DEPS={- our @deps = map { platform->isobj($_) ? platform->dep($_) : $_ }
                     keys %{$unified_info{sources}};
         join(", ", map { "-\n\t".$_ } @deps); -}
 {- output_on() if $disabled{makedepend}; "" -}
-GENERATED_MANDATORY={- join(", ", map { "-\n\t".$_ } @{$unified_info{depends}->{""}} ) -}
+GENERATED_MANDATORY={- join(", ",
+                            map { "-\n\t".$_ } @{$unified_info{depends}->{""}} ) -}
+GENERATED_PODS={- # common0.tmpl provides @generated
+                  join(", ",
+                       map { my $x = $_;
+                             (
+                               grep { 
+                                      $unified_info{attributes}->{depends}
+                                      ->{$x}->{$_}->{pod} // 0
+                                    }
+                                   keys %{$unified_info{attributes}->{depends}->{$x}}
+                             ) ? "-\n\t".$x : ();
+                           }
+                           @generated) -}
 GENERATED={- # common0.tmpl provides @generated
              join(", ", map { platform->convertext($_) } @generated) -}
 
@@ -365,7 +377,7 @@ CPPFLAGS_Q={- (my $c = $lib_cppflags.$cppflags2.$cppflags1) =~ s|"|""|g;
 # given with /INCLUDE is a fantasy, unfortunately.
 NODEBUG=@
 .FIRST :
-        $(NODEBUG) sourcetop = F$PARSE("$(SRCDIR)","[]A.;",,"SYNTAX_ONLY,NO_CONCEAL") - ".][000000" - "[000000." - "][" - "]A.;" + ".]"
+        $(NODEBUG) sourcetop = F$PARSE("$(SRCDIR)","[]A.;",,,"SYNTAX_ONLY,NO_CONCEAL") - ".][000000" - "[000000." - "][" - "]A.;" + ".]"
         $(NODEBUG) DEFINE ossl_sourceroot 'sourcetop'
         $(NODEBUG) !
         $(NODEBUG) openssl_inc1 = F$PARSE("[.include.openssl]","A.;",,,"syntax_only") - "A.;"
@@ -428,13 +440,14 @@ NODEBUG=@
 {- dependmagic('build_modules'); -} : build_modules_nodep
 {- dependmagic('build_programs'); -} : build_programs_nodep
 
+build_generated_pods : $(GENERATED_PODS)
+build_docs : build_html_docs
+build_html_docs : $(HTMLDOCS1) $(HTMLDOCS3) $(HTMLDOCS5) $(HTMLDOCS7)
+
 build_generated : $(GENERATED_MANDATORY)
 build_libs_nodep : $(LIBS), $(SHLIBS)
 build_modules_nodep : $(MODULES)
 build_programs_nodep : $(PROGRAMS), $(SCRIPTS)
-
-build_docs: build_html_docs
-build_html_docs: $(HTMLDOCS1) $(HTMLDOCS3) $(HTMLDOCS5) $(HTMLDOCS7)
 
 # Kept around for backward compatibility
 build_apps build_tests : build_programs
@@ -451,7 +464,8 @@ build_all_generated : $(GENERATED_MANDATORY) $(GENERATED) build_docs
 all : build_sw build_docs
 
 test : tests
-{- dependmagic('tests'); -} : build_programs_nodep, build_modules_nodep copy-utils
+{- dependmagic('tests'); -} : build_programs_nodep, build_modules_nodep copy-utils run_tests
+run_tests :
         @ ! {- output_off() if $disabled{tests}; "" -}
         DEFINE SRCTOP "$(SRCDIR)"
         DEFINE BLDTOP "$(BLDDIR)"
@@ -538,7 +552,7 @@ install_docs : install_html_docs
 
 uninstall_docs : uninstall_html_docs
 
-install_fips: install_sw
+install_fips : install_sw
 	@ WRITE SYS$OUTPUT "*** Installing FIPS module configuration"
 	@ WRITE SYS$OUTPUT "fipsinstall $(DESTDIR)$(MODULESDIR)/$(FIPSMODULENAME).cnf"
 	openssl fipsinstall -
@@ -546,7 +560,7 @@ install_fips: install_sw
 		-out ossl_installroot:[MODULES{- $sover_dirname.$target{pointer_size} -}.'arch']$(FIPSMODULENAME).cnf -
 		-macopt "hexkey:$(FIPSKEY)"
 
-uninstall_fips: uninstall_sw
+uninstall_fips : uninstall_sw
 	@ WRITE SYS$OUTPUT "*** Uninstalling FIPS module configuration"
 	DELETE ossl_installroot:[MODULES{- $sover_dirname.$target{pointer_size} -}.'arch']$(FIPSMODULENAME).cnf;*
 
@@ -820,9 +834,14 @@ EOF
           my $pod = $gen0;
           my $mkpod2html = sourcefile('util', 'mkpod2html.pl');
           return <<"EOF";
-$args{src}: $pod
+$args{src} : $pod
 	\$(PERL) $mkpod2html -i $pod -o \$\@ -t "$title" -r "\$(SRCDIR)/doc"
 EOF
+      } elsif ($args{src} =~ /\.(\d)$/) {
+          #
+          # Man-page generator, on VMS we simply ignore man-pages
+          #
+          return "";
       } elsif (platform->isdef($args{src})) {
           #
           # Linker script-ish generator
@@ -922,7 +941,7 @@ EOF
           @modules = map { '"-M'.basename($_, '.pm').'"' } @modules;
           my $modules = join(' ', '', sort keys %moduleincs, @modules);
           return <<"EOF";
-$target : $gen0 $deps
+$args{src} : $gen0 $deps
 	\$(PERL)$modules $dofile "-o$target{build_file}" $gen0$gen_args > \$\@
 EOF
       } elsif (grep { $_ eq $gen0 } @{$unified_info{programs}}) {
@@ -949,7 +968,7 @@ EOF
           # Also redo $gen0, to ensure that we have the proper extension
           $gen0 = platform->bin($gen0);
           return <<"EOF";
-$args{src}: $gen0 $deps
+$args{src} : $gen0 $deps
 	PIPE $gen0$gen_args > \$@
 EOF
       } else {
@@ -957,7 +976,7 @@ EOF
           # Generic generator using Perl
           #
           return <<"EOF";
-$target : $gen0 $deps
+$args{src} : $gen0 $deps
 	\$(PERL)$gen_incs $gen0$gen_args > \$\@
 EOF
       }

--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -12,6 +12,16 @@
 
   our $sourcedir = $config{sourcedir};
   our $builddir = $config{builddir};
+  sub make_unix_path {
+      # Split the native path
+      (my $vol, my $dirs, my $file) = File::Spec->splitpath($_[0]);
+      my @dirs = File::Spec->splitdir($dirs);
+
+      # Reassemble it as a Unix path
+      $vol =~ s|:$||;
+      return File::Spec::Unix->catpath(
+          '', File::Spec::Unix->catdir('', $vol ? $vol : (), @dirs), $file);
+  }
   sub sourcefile {
       catfile($sourcedir, @_);
   }
@@ -327,7 +337,7 @@ MODULESDIR_C={- platform->osslprefix() -}MODULES{- $sover_dirname.$target{pointe
 CC={- $config{CC} -}
 CPP={- $config{CPP} -}
 DEFINES={- our $defines = join('', map { ",$_" } @{$config{CPPDEFINES}}) -}
-INCLUDES={- our $includes = join(',', @{$config{CPPINCLUDES}}) -}
+#INCLUDES={- our $includes = join(',', @{$config{CPPINCLUDES}}) -}
 CPPFLAGS={- our $cppflags = join('', @{$config{CPPFLAGS}}) -}
 CFLAGS={- join('', @{$config{CFLAGS}}) -}
 LDFLAGS={- join('', @{$config{LFLAGS}}) -}
@@ -368,13 +378,6 @@ NODEBUG=@
         $(NODEBUG) sourcetop = F$PARSE("$(SRCDIR)","[]A.;",,,"SYNTAX_ONLY,NO_CONCEAL") - ".][000000" - "[000000." - "][" - "]A.;" + ".]"
         $(NODEBUG) DEFINE ossl_sourceroot 'sourcetop'
         $(NODEBUG) !
-        $(NODEBUG) openssl_inc1 = F$PARSE("[.include.openssl]","A.;",,,"syntax_only") - "A.;"
-        $(NODEBUG) openssl_inc2 = F$PARSE("{- catdir($config{sourcedir},"[.include.openssl]") -}","A.;",,,"SYNTAX_ONLY") - "A.;"
-        $(NODEBUG) internal_inc1 = F$PARSE("[.crypto.include.internal]","A.;",,,"SYNTAX_ONLY") - "A.;"
-        $(NODEBUG) internal_inc2 = F$PARSE("{- catdir($config{sourcedir},"[.include.internal]") -}","A.;",,,"SYNTAX_ONLY") - "A.;"
-        $(NODEBUG) internal_inc3 = F$PARSE("{- catdir($config{sourcedir},"[.crypto.include.internal]") -}","A.;",,,"SYNTAX_ONLY") - "A.;"
-        $(NODEBUG) DEFINE openssl 'openssl_inc1','openssl_inc2'
-        $(NODEBUG) DEFINE internal 'internal_inc1','internal_inc2','internal_inc3'
         $(NODEBUG) staging_dir = "$(DESTDIR)"
         $(NODEBUG) staging_instdir = ""
         $(NODEBUG) staging_datadir = ""
@@ -403,6 +406,12 @@ NODEBUG=@
         $(NODEBUG) DEFINE ossl_installroot 'installtop'
         $(NODEBUG) DEFINE ossl_dataroot 'datatop'
         $(NODEBUG) !
+        $(NODEBUG) ! Override disturbing system logicals.  We can't deassign
+        $(NODEBUG) ! them, so we create it instead.  This is an unfortunate
+        $(NODEBUG) ! necessity.
+        $(NODEBUG) !
+        $(NODEBUG) DEFINE openssl "{- sourcedir('include/openssl') -}
+        $(NODEBUG) !
         $(NODEBUG) ! Figure out the architecture
         $(NODEBUG) !
         $(NODEBUG) arch = f$edit( f$getsyi( "arch_name"), "upcase")
@@ -416,7 +425,6 @@ NODEBUG=@
         $(NODEBUG) {- join("\n\t\$(NODEBUG) ", map { "DEASSIGN ".uc($_) } @shlibs) || "!" -}
         $(NODEBUG) DEASSIGN ossl_dataroot
         $(NODEBUG) DEASSIGN ossl_installroot
-        $(NODEBUG) DEASSIGN internal
         $(NODEBUG) DEASSIGN openssl
 .DEFAULT :
         @ ! MMS cannot handle no actions...
@@ -743,6 +751,7 @@ reconfigure reconf :
 {-
   use File::Basename;
   use File::Spec::Functions qw/abs2rel rel2abs catfile catdir/;
+  use File::Spec::Unix;
 
   # Helper function to figure out dependencies on libraries
   # It takes a list of library names and outputs a list of dependencies
@@ -757,45 +766,79 @@ reconfigure reconf :
   }
 
   # Helper function to deal with inclusion directory specs.
-  # We have to deal with two things:
-  # 1. comma separation and no possibility of trailing comma
-  # 2. no inclusion directories given at all
-  # 3. long compiler command lines
-  # To resolve 1, we need to iterate through the sources of inclusion
-  # directories, and only add a comma when needed.
-  # To resolve 2, we need to have a variable that will hold the whole
-  # inclusion qualifier, or be the empty string if there are no inclusion
-  # directories.  That's the symbol 'qual_includes' that's used in CPPFLAGS
-  # To resolve 3, we create a logical name TMP_INCLUDES: to hold the list
-  # of inclusion directories.
+  # We're dealing with two issues:
+  # 1. A lot of include directory specs take up a lot of command line real
+  #    estate, and the DCL command line is very limited (2KiB).
+  # 2. For optimal usage, include directory paths must be in Unix form,
+  #    that's the only way the C compiler can merge multiple include paths
+  #    in a sane way (we can stop worrying about 1.h including foo/2.h
+  #    including ../3.h).
   #
-  # This function returns a list of two lists, one being the collection of
-  # commands to execute before the compiler is called, and the other being
-  # the collection of commands to execute after.  It takes as arguments the
-  # collection of strings to include as directory specs.
-  sub includes {
-      my @stuff = ( @_ );
-      my @before = (
-          'qual_includes :=',
-      );
-      my @after = (
-          'DELETE/SYMBOL/LOCAL qual_includes',
-      );
+  # To resolve 1, we need to create a file with include directory pragmas,
+  # and let the compiler use it with /FIRST_INCLUDE=.
+  # To resolve 2, we convert all include directory specs we get to Unix,
+  # with available File::Spec functions.
+  #
+  # We use CRC-24 from https://tools.ietf.org/html/rfc4880#section-6,
+  # reimplemented in Perl to get a workable and constant file name for each
+  # combination of include directory specs.  It is assumed that the order of
+  # these directories don't matter.
+  #
+  # This function takes as input a list of include directories
+  # This function returns a list two things:
+  # 1. The file name to use with /FIRST_INCLUDE=
+  # 2. Text to insert into descrip.mms (may be the empty string)
+  sub crc24 {
+      my $input = shift;
 
-      if (scalar @stuff > 0) {
-          push @before, 'tmp_includes := '.shift(@stuff);
-          while (@stuff) {
-              push @before, 'tmp_add := '.shift(@stuff);
-              push @before, 'IF tmp_includes .NES. "" .AND. tmp_add .NES. "" THEN tmp_includes = tmp_includes + ","';
-              push @before, 'tmp_includes = tmp_includes + tmp_add';
+      my $init_value = 0x00B704CE;
+      my $poly_value = 0x01864CFB;
+
+      my $crc = $init_value;
+
+      foreach my $x (unpack ('C*', $input)) {
+          $crc ^= $x << 16;
+
+          for (my $i; $i < 8; $i++) {
+              $crc <<= 1;
+              if ($crc & 0x01000000) {
+                  $crc ^= $poly_value;
+              }
           }
-          push @before, "IF tmp_includes .NES. \"\" THEN DEFINE tmp_includes 'tmp_includes'";
-          push @before, 'IF tmp_includes .NES. "" THEN qual_includes := /INCLUDE=(tmp_includes:)';
-          push @before, 'DELETE/SYMBOL/LOCAL tmp_includes';
-          push @before, 'DELETE/SYMBOL/LOCAL tmp_add';
-          push @after, 'DEASSIGN tmp_includes:'
       }
-      return ([ @before ], [ @after ]);
+      $crc &= 0xFFFFFF;
+
+      return $crc;
+  }
+  my %includefile_cache;
+  sub make_includefile {
+      my %dirs = map {
+          my $udir = make_unix_path(rel2abs($_));
+
+          $udir => 1;
+      } @_;
+      my @dirs = sort keys %dirs;
+      my $filename = sprintf 'incdirs_%x.h', crc24(join(',', @dirs));
+
+      if ($includefile_cache{$filename}) {
+          return ($filename, "");
+      }
+
+      my $scripture = <<"EOF";
+$filename :
+	open/write inc_output $filename
+EOF
+      foreach (@dirs) {
+          $scripture .= <<"EOF";
+	write inc_output "#pragma include_directory ""$_"""
+EOF
+      }
+      $scripture .= <<"EOF";
+	close inc_output
+EOF
+      $includefile_cache{$filename} = $scripture;
+
+      return ($filename, $scripture);
   }
 
   sub generatetarget {
@@ -855,15 +898,6 @@ EOF
                 lib => "$lib_cflags $lib_cppflags",
                 dso => "$dso_cflags $dso_cppflags",
                 bin => "$bin_cflags $bin_cppflags" } -> {$args{intent}};
-          my @incs_cmds = includes({ shlib => '$(LIB_INCLUDES)',
-                                     lib => '$(LIB_INCLUDES)',
-                                     dso => '$(DSO_INCLUDES)',
-                                     bin => '$(BIN_INCLUDES)' } -> {$args{intent}},
-                                   '$(CNF_INCLUDES)',
-                                   '$(INCLUDES)',
-                                   @{$args{incs}});
-          my $incs_on = join("\n\t\@ ", @{$incs_cmds[0]}) || '!';
-          my $incs_off = join("\n\t\@ ", @{$incs_cmds[1]}) || '!';
           my $defs = join("", map { ",".$_ } @{$args{defs}});
           my $target = platform->asm($args{src});
 
@@ -884,12 +918,10 @@ EOF
                    return <<"EOF";
 $target : $gen0 $deps
 	$generator \$\@-S
-        \@ $incs_on
         \@ extradefines = "$defs"
 	PIPE \$(CPP) $cppflags \$\@-S | -
              \$(PERL) -ne "/^#(\\s*line)?\\s*[0-9]+\\s+""/ or print" > \$\@-i
         \@ DELETE/SYMBOL/LOCAL extradefines
-        \@ $incs_off
         RENAME \$\@-i \$\@
         DELETE \$\@-S;
 EOF
@@ -897,22 +929,17 @@ EOF
               # Otherwise....
               return <<"EOF";
 $target : $gen0 $deps
-        \@ $incs_on
         \@ extradefines = "$defs"
 	$generator \$\@
         \@ DELETE/SYMBOL/LOCAL extradefines
-        \@ $incs_off
 EOF
           }
           return <<"EOF";
 $target : $gen0 $deps
-        \@ $incs_on
         \@ extradefines = "$defs"
-        SHOW SYMBOL qual_includes
         PIPE \$(CPP) $cppflags $gen0 | -
         \$(PERL) "-ne" "/^#(\\s*line)?\\s*[0-9]+\\s+""/ or print" > \$\@
         \@ DELETE/SYMBOL/LOCAL extradefines
-        \@ $incs_off
 EOF
       } elsif ($gen0 =~ m|^.*\.in$|) {
           #
@@ -1020,18 +1047,6 @@ EOF
 		      dso => $dso_asflags,
 		      bin => $bin_asflags } -> {$args{intent}};
 
-      my @incs_cmds = includes({ shlib => '$(LIB_INCLUDES)',
-                                 lib => '$(LIB_INCLUDES)',
-                                 dso => '$(DSO_INCLUDES)',
-                                 bin => '$(BIN_INCLUDES)' } -> {$args{intent}},
-                               '$(INCLUDES)',
-                               map {
-                                   file_name_is_absolute($_)
-                                   ? $_ : catdir($backward,$_)
-                               } @{$args{incs}});
-      my $incs_on = join("\n\t\@ ", @{$incs_cmds[0]}) || '!';
-      my $incs_off = join("\n\t\@ ", @{$incs_cmds[1]}) || '!';
-
       if ($srcs[0] =~ /\Q${asmext}\E$/) {
           return <<"EOF";
 $obj : $deps
@@ -1061,6 +1076,18 @@ $obj : $deps
 EOF
       }
 
+      my ($incdir_filename, $incdir_scripture) =
+          make_includefile(@{ { shlib => [ @lib_cppincludes ],
+                                lib => [ @lib_cppincludes ],
+                                dso => [ @dso_cppincludes ],
+                                bin => [ @bin_cppincludes ] } -> {$args{intent}} },
+                           @{$args{incs}});
+      $deps .= ", -\n\t\t$incdir_filename";
+      $cflags =
+          $target{cflag_incfirst}
+          . '"'.make_unix_path(rel2abs($incdir_filename)).'"'
+          . $cflags;
+
       my $depbuild = $disabled{makedepend} ? ""
           : " /MMS=(FILE=${depd}${depn},TARGET=$obj)";
 
@@ -1076,6 +1103,7 @@ $obj : $deps
         SET DEFAULT $backward
         ${after}
         - PURGE $obj
+$incdir_scripture
 EOF
   }
   sub obj2shlib {

--- a/Configurations/platform/VMS.pm
+++ b/Configurations/platform/VMS.pm
@@ -39,7 +39,8 @@ sub staticname {
     # Non-installed libraries are *always* static, and their names remain
     # the same, except for the mandatory extension
     my $in_libname = platform::BASE->staticname($_[1]);
-    return $in_libname if $unified_info{attributes}->{$_[1]}->{noinst};
+    return $in_libname
+        if $unified_info{attributes}->{libraries}->{$_[1]}->{noinst};
 
     return platform::BASE::__concat($_[0]->osslprefix(),
                                     platform::BASE->staticname($_[1]),

--- a/apps/build.info
+++ b/apps/build.info
@@ -62,8 +62,8 @@ IF[{- !$disabled{apps} -}]
   DEPEND[openssl]=libapps.a ../libssl
 
   DEPEND[${OPENSSLSRC/.c/.o}]=progs.h
-  GENERATE[progs.c]=progs.pl -C $(APPS_OPENSSL)
-  GENERATE[progs.h]=progs.pl -H $(APPS_OPENSSL)
+  GENERATE[progs.c]=progs.pl "-C" $(APPS_OPENSSL)
+  GENERATE[progs.h]=progs.pl "-H" $(APPS_OPENSSL)
   # progs.pl tries to read all 'openssl' sources, including progs.c, so we make
   # sure things are generated in the correct order.
   DEPEND[progs.h]=progs.c

--- a/configdata.pm.in
+++ b/configdata.pm.in
@@ -63,15 +63,26 @@
  # We must make sourcedir() return an absolute path, because configdata.pm
  # may be loaded as a module from any script in any directory, making
  # relative paths untrustable.  Because the result is used with 'use lib',
- # we must ensure that it returns a Unix style path.  Cwd::abs_path does
- # that (File::Spec::Functions::rel2abs return O/S specific paths)
- use File::Spec::Functions;
+ # we must ensure that it returns a Unix style path.  Mixing File::Spec
+ # and File::Spec::Unix does just that.
+ use File::Spec::Unix;
+ use File::Spec;
  use Cwd qw(abs_path);
+ sub _fixup_path {
+     # Split the native path
+     (my $vol, my $dirs, my $file) = File::Spec->splitpath($_[0]);
+     my @dirs = File::Spec->splitdir($dirs);
+
+     # Reassemble it as a Unix path
+     $vol =~ s|:$|| if $^O eq 'VMS';
+     return File::Spec::Unix->catpath(
+         '', File::Spec::Unix->catdir('', $vol ? $vol : (), @dirs), $file);
+ }
  sub sourcedir {
-     return abs_path(catdir($config{sourcedir}, @_));
+     return _fixup_path(abs_path(File::Spec->catdir($config{sourcedir}, @_)))
  }
  sub sourcefile {
-     return abs_path(catfile($config{sourcedir}, @_));
+     return _fixup_path(abs_path(File::Spec->catfile($config{sourcedir}, @_)))
  }
 -}
 package configdata;

--- a/configdata.pm.in
+++ b/configdata.pm.in
@@ -69,20 +69,33 @@
  use File::Spec;
  use Cwd qw(abs_path);
  sub _fixup_path {
-     # Split the native path
-     (my $vol, my $dirs, my $file) = File::Spec->splitpath($_[0]);
-     my @dirs = File::Spec->splitdir($dirs);
+     my $path = shift;
 
-     # Reassemble it as a Unix path
-     $vol =~ s|:$|| if $^O eq 'VMS';
-     return File::Spec::Unix->catpath(
-         '', File::Spec::Unix->catdir('', $vol ? $vol : (), @dirs), $file);
+     # Make the path absolute at all times
+     $path = abs_path($path);
+
+     if ($^O eq 'VMS') {
+         # Convert any path of the VMS form VOLUME:[DIR1.DIR2]FILE to the
+         # Unix form /VOLUME/DIR1/DIR2/FILE, which is what VMS perl supports
+         # for 'use lib'.
+
+         # Start with spliting the native path
+         (my $vol, my $dirs, my $file) = File::Spec->splitpath($path);
+         my @dirs = File::Spec->splitdir($dirs);
+
+         # Reassemble it as a Unix path
+         $vol =~ s|:$||;
+         $dirs = File::Spec::Unix->catdir('', $vol, @dirs)
+         $path = File::Spec::Unix->catpath('', $dirs, $file);
+     }
+
+     return $path;
  }
  sub sourcedir {
-     return _fixup_path(abs_path(File::Spec->catdir($config{sourcedir}, @_)))
+     return _fixup_path(File::Spec->catdir($config{sourcedir}, @_))
  }
  sub sourcefile {
-     return _fixup_path(abs_path(File::Spec->catfile($config{sourcedir}, @_)))
+     return _fixup_path(File::Spec->catfile($config{sourcedir}, @_))
  }
 -}
 package configdata;

--- a/configdata.pm.in
+++ b/configdata.pm.in
@@ -85,7 +85,7 @@
 
          # Reassemble it as a Unix path
          $vol =~ s|:$||;
-         $dirs = File::Spec::Unix->catdir('', $vol, @dirs)
+         $dirs = File::Spec::Unix->catdir('', $vol, @dirs);
          $path = File::Spec::Unix->catpath('', $dirs, $file);
      }
 

--- a/util/perl/OpenSSL/fallback.pm
+++ b/util/perl/OpenSSL/fallback.pm
@@ -89,9 +89,24 @@ sub import {
             while (my $l = <$fh>) {
                 $l =~ s|\R$||;        # Better chomp
                 my $d = "$dir/$l";
+                my $checked = $d;
+
+                if ($^O eq 'VMS') {
+                    # Some VMS unpackers replace periods with underscores
+                    # We must be real careful not to convert the directories
+                    # '.' and '..', though.
+                    $checked =
+                        join('/',
+                             map { my $x = $_;
+                                   $x =~ s|\.|_|g
+                                       if ($x ne '..' && $x ne '.');
+                                   $x }
+                             split(m|/|, $checked))
+                        unless -e $checked && -d $checked;
+                }
                 croak "All lines in $path must be a directory, not a file: $l"
-                    unless -e $d && -d $d;
-                push @INC, $d;
+                    unless -e $checked && -d $checked;
+                push @INC, $checked;
             }
         } else {                # It's a directory
             push @INC, $path;


### PR DESCRIPTION
The biggest part of adapting the build of OpenSSL 3.0 to VMS was to deal with a larger and varying number of inclusion directories.  

With pre-3.0, these directories were relatively few, so its descrip.mms (what Unix folks call "Makefile") did a few dirty hacks using logical names and that was that, and the command line was still kept within the command line length limit (which is pretty short).
With 3.0, the strategy needed to be changed.  Fortunately, the VMS C compiler has the qualifier `/FIRST_INCLUDE` (corresponding to gcc's `-include` flag) and a useful pragma, `#pragma include_directory "/path/to/header/files"`, so what we do is to automatically generate header files with the appropriate inclusion directories for diverse cases, and use them when compiling.

The rest of the changes is simply playing catch-up with what has happened with the Unix and Windows Makefile templates.

A consequence of this is that many of the rather special variables in descrip.mms are removed, as going through them is pretty cumbersome and benefits no one.  Instead, a set of useful perl variables are set up in descrip.mms.tmpl, and are used directly by the perl fragments

Fixes #14247

Note that this does *not* include diverse C source file changes that are needed to build without errors.  Those will come in a separate PR.