### PR TITLE
Small 3.0 C source fixes, needed for VMS

### DIFF
--- a/crypto/bio/b_sock.c
+++ b/crypto/bio/b_sock.c
@@ -29,11 +29,15 @@ static int wsa_init_done = 0;
 #  if defined(OPENSSL_TANDEM_FLOSS)
 #   include <floss.h(floss_select)>
 #  endif
-# elif !defined _WIN32
-#  include <unistd.h>
-#  include <sys/select.h>
-# else
+# elif defined _WIN32
 #  include <winsock.h> /* for type fd_set */
+# else
+#  include <unistd.h>
+#  if defined __VMS
+#   include <sys/socket.h>
+#  else
+#   include <sys/select.h>
+#  endif
 # endif
 
 # ifndef OPENSSL_NO_DEPRECATED_1_1_0

--- a/crypto/evp/m_sigver.c
+++ b/crypto/evp/m_sigver.c
@@ -14,6 +14,7 @@
 #include <openssl/x509.h>
 #include "crypto/evp.h"
 #include "internal/provider.h"
+#include "internal/numbers.h"   /* includes SIZE_MAX */
 #include "evp_local.h"
 
 #ifndef FIPS_MODULE

--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -34,6 +34,7 @@
 #include <openssl/encoder.h>
 #include <openssl/core_names.h>
 
+#include "internal/numbers.h"   /* includes SIZE_MAX */
 #include "internal/ffc.h"
 #include "crypto/asn1.h"
 #include "crypto/evp.h"

--- a/crypto/evp/signature.c
+++ b/crypto/evp/signature.c
@@ -11,6 +11,7 @@
 #include <stdlib.h>
 #include <openssl/objects.h>
 #include <openssl/evp.h>
+#include "internal/numbers.h"   /* includes SIZE_MAX */
 #include "internal/cryptlib.h"
 #include "internal/provider.h"
 #include "internal/core.h"

--- a/engines/e_loader_attic.c
+++ b/engines/e_loader_attic.c
@@ -31,9 +31,9 @@
 #include <openssl/engine.h>
 #include <openssl/x509.h>        /* For the PKCS8 stuff o.O */
 #include "internal/asn1.h"       /* For asn1_d2i_read_bio */
-#include "internal/ctype.h"      /* For ossl_isdigit */
 #include "internal/o_dir.h"
 #include "internal/cryptlib.h"
+#include "crypto/ctype.h"        /* For ossl_isdigit */
 #include "crypto/pem.h"          /* For PVK and "blob" PEM headers */
 
 #include "e_loader_attic_err.c"

--- a/engines/e_loader_attic.c
+++ b/engines/e_loader_attic.c
@@ -31,6 +31,7 @@
 #include <openssl/engine.h>
 #include <openssl/x509.h>        /* For the PKCS8 stuff o.O */
 #include "internal/asn1.h"       /* For asn1_d2i_read_bio */
+#include "internal/ctype.h"      /* For ossl_isdigit */
 #include "internal/o_dir.h"
 #include "internal/cryptlib.h"
 #include "crypto/pem.h"          /* For PVK and "blob" PEM headers */

--- a/include/internal/sockets.h
+++ b/include/internal/sockets.h
@@ -7,10 +7,11 @@
  * https://www.openssl.org/source/license.html
  */
 
-
 #ifndef OSSL_INTERNAL_SOCKETS_H
 # define OSSL_INTERNAL_SOCKETS_H
 # pragma once
+
+# include <openssl/opensslconf.h>
 
 # if defined(OPENSSL_SYS_VXWORKS) || defined(OPENSSL_SYS_UEFI)
 #  define NO_SYS_PARAM_H

--- a/include/openssl/e_os2.h
+++ b/include/openssl/e_os2.h
@@ -102,11 +102,11 @@ extern "C" {
 # endif
 
 /* ------------------------------- OpenVMS -------------------------------- */
-# if defined(__VMS) || defined(VMS) || defined(OPENSSL_SYS_VMS)
+# if defined(__VMS) || defined(VMS)
 #  if !defined(OPENSSL_SYS_VMS)
 #   undef OPENSSL_SYS_UNIX
+#   define OPENSSL_SYS_VMS
 #  endif
-#  define OPENSSL_SYS_VMS
 #  if defined(__DECC)
 #   define OPENSSL_SYS_VMS_DECC
 #  elif defined(__DECCXX)

--- a/providers/implementations/storemgmt/file_store.c
+++ b/providers/implementations/storemgmt/file_store.c
@@ -26,6 +26,7 @@
 #include "internal/cryptlib.h"
 #include "internal/o_dir.h"
 #include "crypto/decoder.h"
+#include "crypto/ctype.h"        /* ossl_isdigit() */
 #include "prov/implementations.h"
 #include "prov/bio.h"
 #include "file_store_local.h"


### PR DESCRIPTION
A number of inclusions were missing...
(interestingly, `SIZE_MAX` is so taken for granted that we keep forgetting to include our "internal/numbers.h" whenever we use it)