### PR TITLE
Disable loader_attic on VMS

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1857,7 +1857,7 @@ my %targets = (
         asflags          => sub { vms_info()->{asflags} },
         perlasm_scheme   => sub { vms_info()->{perlasm_scheme} },
 
-        disable          => add('pinshared'),
+        disable          => add('pinshared', 'loadereng'),
 
     },
 

--- a/Configure
+++ b/Configure
@@ -449,6 +449,7 @@ my @disablables = (
     "idea",
     "ktls",
     "legacy",
+    "loadereng",
     "makedepend",
     "md2",
     "md4",

--- a/engines/build.info
+++ b/engines/build.info
@@ -69,8 +69,19 @@ IF[{- !$disabled{"engine"} -}]
         GENERATE[devcrypto.ld]=../util/engines.num
       ENDIF
     ENDIF
+    IF[{- !$disabled{"loadereng"} -}]
+      MODULES{engine}=loader_attic
+      SOURCE[loader_attic]=e_loader_attic.c ../crypto/pem/pvkfmt.c
+      DEFINE[loader_attic]=OPENSSL_NO_PROVIDER_CODE
+      DEPEND[loader_attic]=../libcrypto
+      INCLUDE[loader_attic]=../include
+      IF[{- defined $target{shared_defflag} -}]
+        SOURCE[loader_attic]=loader_attic.ld
+        GENERATE[loader_attic.ld]=../util/engines.num
+      ENDIF
+    ENDIF
 
-    MODULES{noinst,engine}=ossltest dasync loader_attic
+    MODULES{noinst,engine}=ossltest dasync
     SOURCE[dasync]=e_dasync.c
     DEPEND[dasync]=../libcrypto
     INCLUDE[dasync]=../include
@@ -85,15 +96,6 @@ IF[{- !$disabled{"engine"} -}]
     IF[{- defined $target{shared_defflag} -}]
       SOURCE[ossltest]=ossltest.ld
       GENERATE[ossltest.ld]=../util/engines.num
-    ENDIF
-
-    SOURCE[loader_attic]=e_loader_attic.c ../crypto/pem/pvkfmt.c
-    DEFINE[loader_attic]=OPENSSL_NO_PROVIDER_CODE
-    DEPEND[loader_attic]=../libcrypto
-    INCLUDE[loader_attic]=../include
-    IF[{- defined $target{shared_defflag} -}]
-      SOURCE[loader_attic]=loader_attic.ld
-      GENERATE[loader_attic.ld]=../util/engines.num
     ENDIF
   ENDIF
   GENERATE[e_padlock-x86.s]=asm/e_padlock-x86.pl


### PR DESCRIPTION
The reason is that it currently doesn't build properly, due to the of
pvkfmt.c, causing multiply defined symbols since libcrypto exports
them as well.  At the same time, it can't do without that source file,
or it won't have access to certain internal symbols from there.