### PR TITLE
Clean up cmd-nits (find-doc-nits -c)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,8 @@ jobs:
       run: ./config --banner=Configured --strict-warnings enable-fips && perl configdata.pm --dump
     - name: make build_generated
       run: make -s build_generated
-    - name: make doc-nits cmd-nits
-      run: make doc-nits cmd-nits
+    - name: make doc-nits
+      run: make doc-nits
 
   # This checks that we use ANSI C language syntax and semantics.
   # We are not as strict with libraries, but rather adapt to what's

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -567,7 +567,7 @@ clean: libclean
 	-find . -name '*{- platform->depext() -}' \! -name '.*' \! -type d -exec $(RM) {} \;
 	-find . -name '*{- platform->objext() -}' \! -name '.*' \! -type d -exec $(RM) {} \;
 	$(RM) core
-	$(RM) tags TAGS doc-nits cmd-nits md-nits
+	$(RM) tags TAGS doc-nits md-nits
 	$(RM) -r test/test-runs
 	$(RM) providers/fips*.new
 	$(RM) openssl.pc libcrypto.pc libssl.pc
@@ -1062,12 +1062,9 @@ generate: generate_apps generate_crypto_bn generate_crypto_objects \
 
 generate_buildinfo: generate_doc_buildinfo
 
-.PHONY: doc-nits cmd-nits md-nits
+.PHONY: doc-nits md-nits
 doc-nits: build_generated_pods
-	$(PERL) $(SRCDIR)/util/find-doc-nits -n -l -e
-
-cmd-nits: build_generated_pods
-	$(PERL) $(SRCDIR)/util/find-doc-nits -c
+	$(PERL) $(SRCDIR)/util/find-doc-nits -c -n -l -e
 
 # This uses "mdl", the markdownlint application, which is written in ruby.
 # The source is at https://github.com/markdownlint/markdownlint

--- a/apps/list.c
+++ b/apps/list.c
@@ -964,25 +964,6 @@ static void list_keyexchanges(void)
         BIO_printf(bio_out, " -\n");
 }
 
-static void list_missing_help(void)
-{
-    const FUNCTION *fp;
-    const OPTIONS *o;
-
-    for (fp = functions; fp->name != NULL; fp++) {
-        if ((o = fp->help) != NULL) {
-            /* If there is help, list what flags are not documented. */
-            for ( ; o->name != NULL; o++) {
-                if (o->helpstr == NULL)
-                    BIO_printf(bio_out, "%s %s\n", fp->name, o->name);
-            }
-        } else if (fp->func != dgst_main) {
-            /* If not aliased to the dgst command, */
-            BIO_printf(bio_out, "%s *\n", fp->name);
-        }
-    }
-}
-
 static void list_objects(void)
 {
     int max_nid = OBJ_new_nid(0);
@@ -1443,7 +1424,7 @@ typedef enum HELPLIST_CHOICE {
     OPT_ENCODERS, OPT_DECODERS, OPT_KEYMANAGERS, OPT_KEYEXCHANGE_ALGORITHMS,
     OPT_KEM_ALGORITHMS, OPT_SIGNATURE_ALGORITHMS, OPT_ASYM_CIPHER_ALGORITHMS,
     OPT_PROVIDER_INFO,
-    OPT_MISSING_HELP, OPT_OBJECTS, OPT_SELECT_NAME,
+    OPT_OBJECTS, OPT_SELECT_NAME,
 #ifndef OPENSSL_NO_DEPRECATED_3_0
     OPT_ENGINES, 
 #endif
@@ -1503,8 +1484,6 @@ const OPTIONS list_options[] = {
      "List of loaded engines"},
 #endif
     {"disabled", OPT_DISABLED, '-', "List of disabled features"},
-    {"missing-help", OPT_MISSING_HELP, '-',
-     "List missing detailed help strings"},
     {"options", OPT_OPTIONS, 's',
      "List options for specified command"},
     {"objects", OPT_OBJECTS, '-',
@@ -1543,7 +1522,6 @@ int list_main(int argc, char **argv)
         unsigned int engines:1;
 #endif
         unsigned int disabled:1;
-        unsigned int missing_help:1;
         unsigned int objects:1;
         unsigned int options:1;
     } todo = { 0, };
@@ -1629,9 +1607,6 @@ opthelp:
         case OPT_DISABLED:
             todo.disabled = 1;
             break;
-        case OPT_MISSING_HELP:
-            todo.missing_help = 1;
-            break;
         case OPT_OBJECTS:
             todo.objects = 1;
             break;
@@ -1700,8 +1675,6 @@ opthelp:
 #endif
     if (todo.disabled)
         list_disabled();
-    if (todo.missing_help)
-        list_missing_help();
     if (todo.objects)
         list_objects();
 

--- a/doc/man1/openssl-list.pod.in
+++ b/doc/man1/openssl-list.pod.in
@@ -40,7 +40,6 @@ B<openssl list>
 -}[B<-engines>]
 {- output_on() if $disabled{"deprecated-3.0"}; ""
 -}[B<-disabled>]
-[B<-missing-help>]
 [B<-objects>]
 [B<-options> I<command>]
 {- $OpenSSL::safe::opt_provider_synopsis -}
@@ -181,10 +180,6 @@ Display a list of loaded engines.
 
 Display a list of disabled features, those that were compiled out
 of the installation.
-
-=item B<-missing-help>
-
-List missing detailed help strings.
 
 =item B<-objects>
 

--- a/util/find-doc-nits
+++ b/util/find-doc-nits
@@ -1048,7 +1048,8 @@ sub checkflags {
                 next if m/^\s*#\s*if/;
                 err("$cmd does not implement help for -$expect_helpstr") unless m/^\s*"/;
                 $expect_helpstr = "";
-            } elsif (m/\{\s*"([^"]+)"\s*,\s*OPT_[A-Z0-9_]+\s*,\s*('[-\/:<>cEfFlMnNpsuU]'|0)\s*,(.*)$/
+            }
+            if (m/\{\s*"([^"]+)"\s*,\s*OPT_[A-Z0-9_]+\s*,\s*('[-\/:<>cEfFlMnNpsuU]'|0)\s*,(.*)$/
                        && !($cmd eq "s_client" && $1 eq "wdebug")) {
                 push @cmdopts, $1;
                 $expect_helpstr = $1;

--- a/util/find-doc-nits
+++ b/util/find-doc-nits
@@ -1141,8 +1141,6 @@ if ( $opt_c ) {
             checkflags($cmd, @doc);
         }
     }
-
-    exit $status;
 }
 
 # Populate %state


### PR DESCRIPTION
This is a follow-up of #15298, (mostly) as discussed there:

* `unix-Makefile.tmpl` and `ci.yml:` Merge `cmd-nits` target into `doc-nits`
* `apps/list.c:` Remove obsolete `-missing-help` option
* `find-doc-nits -c`: Fix handling in case expected helpstr is not found


