### PR TITLE
Make apps/progs.pl not look at apps/progs.c

### DIFF
--- a/Configure
+++ b/Configure
@@ -2186,14 +2186,14 @@ if ($builder eq "unified") {
                                 undef, undef,
                                 tokenize($expand_variables->($+{VALUE})))
                          if !@skip || $skip[$#skip] > 0; },
-            qr/^\s* SOURCE ${index_re} = ${value_re} $/x
+            qr/^\s* SOURCE ${index_re} ${attribs_re} = ${value_re} $/x
             => sub { $push_to->(\%sources, $expand_variables->($+{INDEX}),
-                                undef, undef,
+                                \$attributes{sources}, $+{ATTRIBS},
                                 tokenize($expand_variables->($+{VALUE})))
                          if !@skip || $skip[$#skip] > 0; },
-            qr/^\s* SHARED_SOURCE ${index_re} = ${value_re} $/x
+            qr/^\s* SHARED_SOURCE ${index_re} ${attribs_re} = ${value_re} $/x
             => sub { $push_to->(\%shared_sources, $expand_variables->($+{INDEX}),
-                                undef, undef,
+                                \$attributes{sources}, $+{ATTRIBS},
                                 tokenize($expand_variables->($+{VALUE})))
                          if !@skip || $skip[$#skip] > 0; },
             qr/^\s* INCLUDE ${index_re} = ${value_re} $/x
@@ -2279,10 +2279,10 @@ EOF
                 if ($s eq $src_configdata || $generate{$_} || ! -f $s) {
                     $s = cleanfile($buildd, $_, $blddir);
                 }
+                my $o = $_;
                 # We recognise C++, C and asm files
                 if ($s =~ /\.(cc|cpp|c|s|S)$/) {
                     push @{$check_exist{$s}}, $ddest;
-                    my $o = $_;
                     $o =~ s/\.[csS]$/.o/; # C and assembler
                     $o =~ s/\.(cc|cpp)$/_cc.o/; # C++
                     $o = cleanfile($buildd, $o, $blddir);
@@ -2291,7 +2291,6 @@ EOF
                 } elsif ($s =~ /\.rc$/) {
                     # We also recognise resource files
                     push @{$check_exist{$s}}, $ddest;
-                    my $o = $_;
                     $o =~ s/\.rc$/.res/; # Resource configuration
                     $o = cleanfile($buildd, $o, $blddir);
                     $unified_info{sources}->{$ddest}->{$o} = -1;
@@ -2299,6 +2298,17 @@ EOF
                 } else {
                     push @{$check_exist{$s}}, $ddest;
                     $unified_info{sources}->{$ddest}->{$s} = 1;
+                }
+                # Fix up associated attributes
+                if ($o ne $_) {
+                    $unified_info{attributes}->{sources}->{$ddest}->{$o} =
+                        $unified_info{attributes}->{sources}->{$o}->{$s} =
+                        $attributes{sources}->{$dest}->{$_}
+                        if defined $attributes{sources}->{$dest}->{$_};
+                } else {
+                    $unified_info{attributes}->{sources}->{$ddest}->{$s} =
+                        $attributes{sources}->{$dest}->{$_}
+                        if defined $attributes{sources}->{$dest}->{$_};
                 }
             }
         }
@@ -2315,10 +2325,10 @@ EOF
                     $s = cleanfile($buildd, $_, $blddir);
                 }
 
+                my $o = $_;
                 if ($s =~ /\.(cc|cpp|c|s|S)$/) {
                     # We recognise C++, C and asm files
                     push @{$check_exist{$s}}, $ddest;
-                    my $o = $_;
                     $o =~ s/\.[csS]$/.o/; # C and assembler
                     $o =~ s/\.(cc|cpp)$/_cc.o/; # C++
                     $o = cleanfile($buildd, $o, $blddir);
@@ -2327,7 +2337,6 @@ EOF
                 } elsif ($s =~ /\.rc$/) {
                     # We also recognise resource files
                     push @{$check_exist{$s}}, $ddest;
-                    my $o = $_;
                     $o =~ s/\.rc$/.res/; # Resource configuration
                     $o = cleanfile($buildd, $o, $blddir);
                     $unified_info{shared_sources}->{$ddest}->{$o} = -1;
@@ -2336,10 +2345,21 @@ EOF
                     # We also recognise linker scripts (or corresponding)
                     # We know they are generated files
                     push @{$check_exist{$s}}, $ddest;
-                    my $ld = cleanfile($buildd, $_, $blddir);
-                    $unified_info{shared_sources}->{$ddest}->{$ld} = 1;
+                    $o = cleanfile($buildd, $_, $blddir);
+                    $unified_info{shared_sources}->{$ddest}->{$o} = 1;
                 } else {
                     die "unrecognised source file type for shared library: $s\n";
+                }
+                # Fix up associated attributes
+                if ($o ne $_) {
+                    $unified_info{attributes}->{shared_sources}->{$ddest}->{$o} =
+                        $unified_info{attributes}->{sources}->{$o}->{$s} =
+                        $attributes{sources}->{$dest}->{$_}
+                        if defined $attributes{sources}->{$dest}->{$_};
+                } else {
+                    $unified_info{attributes}->{shared_sources}->{$ddest}->{$o} =
+                        $attributes{sources}->{$dest}->{$_}
+                        if defined $attributes{sources}->{$dest}->{$_};
                 }
             }
         }
@@ -2644,6 +2664,19 @@ EOF
                             $unified_info{$dst}->{$prod}->{$newobj} = 1;
                             foreach my $src (@{$prod_sources{$_}}) {
                                 $unified_info{sources}->{$newobj}->{$src} = 1;
+                                # Adjust source attributes
+                                my $attrs = $unified_info{attributes}->{sources};
+                                if (defined $attrs->{$prod}
+                                    && defined $attrs->{$prod}->{$_}) {
+                                    $attrs->{$prod}->{$newobj} =
+                                        $attrs->{$prod}->{$_};
+                                    delete $attrs->{$prod}->{$_};
+                                }
+                                foreach my $objsrc (keys %{$attrs->{$_} // {}}) {
+                                    $attrs->{$newobj}->{$objsrc} =
+                                        $attrs->{$_}->{$objsrc};
+                                    delete $attrs->{$_}->{$objsrc};
+                                }
                             }
                             # Adjust dependencies
                             foreach my $deps (keys %{$unified_info{depends}->{$_}}) {

--- a/apps/build.info
+++ b/apps/build.info
@@ -11,7 +11,7 @@ ENDIF
 
 # Source for the 'openssl' program
 $OPENSSLSRC=\
-        openssl.c progs.c \
+        openssl.c \
         asn1parse.c ca.c ciphers.c crl.c crl2pkcs7.c dgst.c \
         enc.c errstr.c \
         genpkey.c kdf.c mac.c nseq.c passwd.c pkcs7.c \
@@ -61,7 +61,12 @@ IF[{- !$disabled{apps} -}]
   INCLUDE[openssl]=.. ../include include
   DEPEND[openssl]=libapps.a ../libssl
 
-  DEPEND[${OPENSSLSRC/.c/.o}]=progs.h
+  # The nocheck attribute is picked up by progs.pl as a signal not to look
+  # at that file; some systems may have locked it as the output file, and
+  # therefore don't allow it to be read at the same time, making progs.pl
+  # fail.
+  SOURCE[openssl]{nocheck}=progs.c
+  DEPEND[${OPENSSLSRC/.c/.o} progs.o]=progs.h
   GENERATE[progs.c]=progs.pl "-C" $(APPS_OPENSSL)
   GENERATE[progs.h]=progs.pl "-H" $(APPS_OPENSSL)
   # progs.pl tries to read all 'openssl' sources, including progs.c, so we make

--- a/apps/progs.pl
+++ b/apps/progs.pl
@@ -28,7 +28,8 @@ my $YEAR         = [localtime()]->[5] + 1900;
 # the lookups in %unified_info
 my @openssl_source =
     map { @{$unified_info{sources}->{$_}} }
-    grep { /\.o$/ }
+    grep { /\.o$/
+           && !$unified_info{attributes}->{sources}->{$apps_openssl}->{$_}->{nocheck} }
         @{$unified_info{sources}->{$apps_openssl}};
 
 foreach my $filename (@openssl_source) {

--- a/doc/internal/man7/build.info.pod
+++ b/doc/internal/man7/build.info.pod
@@ -492,6 +492,17 @@ Static libraries may be sources.  In that case, its object files are
 used directly when building I<item> instead of relying on library
 dependency and symbol resolution (through B<DEPEND> statements).
 
+B<SOURCE> statements may have attributes, which apply to each
+individual dependency in such a statement.  For example:
+
+    SOURCE[prog]=prog_a.c
+    SOURCE[prog]{check}=prog_b.c prog_c.c
+
+With those statements, the association between C<prog> and C<prog_a.c>
+comes with no extra attributes, while the association between C<prog>
+and C<prog_b.c> as well as C<prog_c.c> comes with the extra attribute
+C<check>.
+
 =item B<SHARED_SOURCE[>I<item>B<]> B<=> I<file> ...
 
 Collects filenames that will be used as source files for I<item>.
@@ -500,6 +511,9 @@ The I<item> must be a singular item, and may be any library or module
 given with B<LIBS> or B<MODULES>.  For libraries, the given filenames
 are only used for their shared form, so if the item is a library name
 ending with C<.a>, the filenames will be ignored.
+
+B<SHARED_SOURCE> statements may have attributes, just as B<SOURCE>
+statements.
 
 =item B<DEFINE[>I<items>B<]> B<=> I<name>[B<=>I<value>] ...
 


### PR DESCRIPTION
apps/progs.pl will have apps/progs.c as output, and on some systems,
the output file of a program is locked against reading.
Unfortunately, apps/progs.c is also part of the sources that make up
apps/openssl, so it's necessary to mark that file in a way that makes
progs.pl skip over it.

Fortunately, this is easily done with a special attribute in
apps/build.info and a simple adaptation of apps/progs.pl.