### PR TITLE
fips: remove unnecessary commas to get CI working

### DIFF
--- a/.github/workflows/fips-label.yml
+++ b/.github/workflows/fips-label.yml
@@ -19,7 +19,7 @@ jobs:
             var artifacts = await github.actions.listWorkflowRunArtifacts({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              run_id: ${{ github.event.workflow_run.id }},
+              run_id: ${{ github.event.workflow_run.id }}
             });
             if ( artifacts.data.artifacts[0].name == 'fips_changed' ) {
               github.issues.addLabels({
@@ -32,7 +32,7 @@ jobs:
               var labels = await github.issues.listLabelsOnIssue({
                 issue_number: ${{ github.event.workflow_run.pull_requests[0].number }},
                 owner: context.repo.owner,
-                repo: context.repo.repo,
+                repo: context.repo.repo
               });
 
               for ( var label in labels.data ) {


### PR DESCRIPTION
The FIPS labeling CI is broken with a spurious comma error.  This removes all the unnecessary commas in the hopes that it fixes the problem.


- [ ] documentation is added or updated
- [x] tests are added or updated
