### PR TITLE
[WIP] APPS: break out a number of routines from apps/lib/apps.c, and clean up test/build.info

### DIFF
--- a/apps/asn1parse.c
+++ b/apps/asn1parse.c
@@ -164,17 +164,18 @@ int asn1parse_main(int argc, char **argv)
         goto opthelp;
 
     if (oidfile != NULL) {
-        in = bio_open_default(oidfile, 'r', FORMAT_TEXT);
+        in = app_bio_open_default(oidfile, 'r', FORMAT_TEXT);
         if (in == NULL)
             goto end;
         OBJ_create_objects(in);
         BIO_free(in);
     }
 
-    if ((in = bio_open_default(infile, 'r', informat)) == NULL)
+    if ((in = app_bio_open_default(infile, 'r', informat)) == NULL)
         goto end;
 
-    if (derfile && (derout = bio_open_default(derfile, 'w', FORMAT_ASN1)) == NULL)
+    if (derfile
+        && (derout = app_bio_open_default(derfile, 'w', FORMAT_ASN1)) == NULL)
         goto end;
 
     if ((buf = BUF_MEM_new()) == NULL)

--- a/apps/ca.c
+++ b/apps/ca.c
@@ -1098,8 +1098,8 @@ end_of_options:
             if (verbose)
                 BIO_printf(bio_err, "writing %s\n", new_cert);
 
-            Sout = bio_open_default(outfile, 'w',
-                                    output_der ? FORMAT_ASN1 : FORMAT_TEXT);
+            Sout = app_bio_open_default(outfile, 'w',
+                                        output_der ? FORMAT_ASN1 : FORMAT_TEXT);
             if (Sout == NULL)
                 goto end;
 
@@ -1266,8 +1266,8 @@ end_of_options:
         if (!do_X509_CRL_sign(crl, pkey, dgst, sigopts))
             goto end;
 
-        Sout = bio_open_default(outfile, 'w',
-                                output_der ? FORMAT_ASN1 : FORMAT_TEXT);
+        Sout = app_bio_open_default(outfile, 'w',
+                                    output_der ? FORMAT_ASN1 : FORMAT_TEXT);
         if (Sout == NULL)
             goto end;
 

--- a/apps/cms.c
+++ b/apps/cms.c
@@ -267,7 +267,7 @@ static void warn_binary(const char *file)
     unsigned char linebuf[1024], *cur, *end;
     int len;
 
-    if ((bio = bio_open_default(file, 'r', FORMAT_BINARY)) == NULL)
+    if ((bio = app_bio_open_default(file, 'r', FORMAT_BINARY)) == NULL)
         return; /* cannot give a proper warning since there is an error */
     while ((len = BIO_read(bio, linebuf, sizeof(linebuf))) > 0) {
         end = linebuf + len;

--- a/apps/cms.c
+++ b/apps/cms.c
@@ -887,8 +887,8 @@ int cms_main(int argc, char **argv)
 
     if ((flags & CMS_BINARY) == 0)
         warn_binary(infile);
-    in = bio_open_default(infile, 'r',
-                          (flags & CMS_BINARY) != 0 ? FORMAT_BINARY : informat);
+    in = app_bio_open_default(infile, 'r',
+                              (flags & CMS_BINARY) != 0 ? FORMAT_BINARY : informat);
     if (in == NULL)
         goto end;
 
@@ -931,7 +931,7 @@ int cms_main(int argc, char **argv)
             goto end;
     }
 
-    out = bio_open_default(outfile, 'w', outformat);
+    out = app_bio_open_default(outfile, 'w', outformat);
     if (out == NULL)
         goto end;
 

--- a/apps/crl.c
+++ b/apps/crl.c
@@ -355,7 +355,7 @@ int crl_main(int argc, char **argv)
             }
         }
     }
-    out = bio_open_default(outfile, 'w', outformat);
+    out = app_bio_open_default(outfile, 'w', outformat);
     if (out == NULL)
         goto end;
 

--- a/apps/crl2pkcs7.c
+++ b/apps/crl2pkcs7.c
@@ -109,7 +109,7 @@ int crl2pkcs7_main(int argc, char **argv)
         goto opthelp;
 
     if (!nocrl) {
-        in = bio_open_default(infile, 'r', informat);
+        in = app_bio_open_default(infile, 'r', informat);
         if (in == NULL)
             goto end;
 
@@ -158,7 +158,7 @@ int crl2pkcs7_main(int argc, char **argv)
         }
     }
 
-    out = bio_open_default(outfile, 'w', outformat);
+    out = app_bio_open_default(outfile, 'w', outformat);
     if (out == NULL)
         goto end;
 

--- a/apps/dgst.c
+++ b/apps/dgst.c
@@ -267,7 +267,8 @@ int dgst_main(int argc, char **argv)
             out_bin = 0;
     }
 
-    out = bio_open_default(outfile, 'w', out_bin ? FORMAT_BINARY : FORMAT_TEXT);
+    out = app_bio_open_default(outfile, 'w',
+                               out_bin ? FORMAT_BINARY : FORMAT_TEXT);
     if (out == NULL)
         goto end;
 

--- a/apps/dhparam.c
+++ b/apps/dhparam.c
@@ -170,7 +170,7 @@ int dhparam_main(int argc, char **argv)
         goto end;
     }
 
-    out = bio_open_default(outfile, 'w', outformat);
+    out = app_bio_open_default(outfile, 'w', outformat);
     if (out == NULL)
         goto end;
 
@@ -238,7 +238,7 @@ int dhparam_main(int argc, char **argv)
         const char *keytype = "DH";
         int done;
 
-        in = bio_open_default(infile, 'r', informat);
+        in = app_bio_open_default(infile, 'r', informat);
         if (in == NULL)
             goto end;
 

--- a/apps/dsa.c
+++ b/apps/dsa.c
@@ -194,7 +194,7 @@ int dsa_main(int argc, char **argv)
         goto end;
     }
 
-    out = bio_open_owner(outfile, outformat, private);
+    out = app_bio_open_owner(outfile, outformat, private);
     if (out == NULL)
         goto end;
 

--- a/apps/dsaparam.c
+++ b/apps/dsaparam.c
@@ -142,7 +142,7 @@ int dsaparam_main(int argc, char **argv)
     numbits = num;
     private = genkey ? 1 : 0;
 
-    out = bio_open_owner(outfile, outformat, private);
+    out = app_bio_open_owner(outfile, outformat, private);
     if (out == NULL)
         goto end;
 

--- a/apps/ec.c
+++ b/apps/ec.c
@@ -175,7 +175,7 @@ int ec_main(int argc, char **argv)
     }
 
     if (informat != FORMAT_ENGINE) {
-        in = bio_open_default(infile, 'r', informat);
+        in = app_bio_open_default(infile, 'r', informat);
         if (in == NULL)
             goto end;
     }
@@ -192,7 +192,7 @@ int ec_main(int argc, char **argv)
         goto end;
     }
 
-    out = bio_open_owner(outfile, outformat, private);
+    out = app_bio_open_owner(outfile, outformat, private);
     if (out == NULL)
         goto end;
 

--- a/apps/ecparam.c
+++ b/apps/ecparam.c
@@ -195,10 +195,10 @@ int ecparam_main(int argc, char **argv)
 
     private = genkey ? 1 : 0;
 
-    in = bio_open_default(infile, 'r', informat);
+    in = app_bio_open_default(infile, 'r', informat);
     if (in == NULL)
         goto end;
-    out = bio_open_owner(outfile, outformat, private);
+    out = app_bio_open_owner(outfile, outformat, private);
     if (out == NULL)
         goto end;
 

--- a/apps/enc.c
+++ b/apps/enc.c
@@ -231,7 +231,7 @@ int enc_main(int argc, char **argv)
             str = opt_arg();
             break;
         case OPT_KFILE:
-            in = bio_open_default(opt_arg(), 'r', FORMAT_TEXT);
+            in = app_bio_open_default(opt_arg(), 'r', FORMAT_TEXT);
             if (in == NULL)
                 goto opthelp;
             i = BIO_gets(in, buf, sizeof(buf));
@@ -338,9 +338,9 @@ int enc_main(int argc, char **argv)
     buff = app_malloc(EVP_ENCODE_LENGTH(bsize), "evp buffer");
 
     if (infile == NULL) {
-        in = dup_bio_in(informat);
+        in = app_bio_dup_in(informat);
     } else {
-        in = bio_open_default(infile, 'r', informat);
+        in = app_bio_open_default(infile, 'r', informat);
     }
     if (in == NULL)
         goto end;
@@ -384,7 +384,7 @@ int enc_main(int argc, char **argv)
         }
     }
 
-    out = bio_open_default(outfile, 'w', outformat);
+    out = app_bio_open_default(outfile, 'w', outformat);
     if (out == NULL)
         goto end;
 

--- a/apps/engine.c
+++ b/apps/engine.c
@@ -302,13 +302,11 @@ int engine_main(int argc, char **argv)
     STACK_OF(OPENSSL_CSTRING) *engines = sk_OPENSSL_CSTRING_new_null();
     STACK_OF(OPENSSL_STRING) *pre_cmds = sk_OPENSSL_STRING_new_null();
     STACK_OF(OPENSSL_STRING) *post_cmds = sk_OPENSSL_STRING_new_null();
-    BIO *out;
     const char *indent = "     ";
     OPTION_CHOICE o;
     char *prog;
     char *argv1;
 
-    out = dup_bio_out(FORMAT_TEXT);
     if (engines == NULL || pre_cmds == NULL || post_cmds == NULL)
         goto end;
 
@@ -387,10 +385,10 @@ int engine_main(int argc, char **argv)
             /*
              * Do "id" first, then "name". Easier to auto-parse.
              */
-            BIO_printf(out, "(%s) %s\n", id, name);
-            util_do_cmds(e, pre_cmds, out, indent);
+            BIO_printf(bio_out, "(%s) %s\n", id, name);
+            util_do_cmds(e, pre_cmds, bio_out, indent);
             if (strcmp(ENGINE_get_id(e), id) != 0) {
-                BIO_printf(out, "Loaded: (%s) %s\n",
+                BIO_printf(bio_out, "Loaded: (%s) %s\n",
                            ENGINE_get_id(e), ENGINE_get_name(e));
             }
             if (list_cap) {
@@ -454,24 +452,24 @@ int engine_main(int argc, char **argv)
                         goto end;
                 }
                 if (cap_buf != NULL && (*cap_buf != '\0'))
-                    BIO_printf(out, " [%s]\n", cap_buf);
+                    BIO_printf(bio_out, " [%s]\n", cap_buf);
 
                 OPENSSL_free(cap_buf);
             }
             if (test_avail) {
-                BIO_printf(out, "%s", indent);
+                BIO_printf(bio_out, "%s", indent);
                 if (ENGINE_init(e)) {
-                    BIO_printf(out, "[ available ]\n");
-                    util_do_cmds(e, post_cmds, out, indent);
+                    BIO_printf(bio_out, "[ available ]\n");
+                    util_do_cmds(e, post_cmds, bio_out, indent);
                     ENGINE_finish(e);
                 } else {
-                    BIO_printf(out, "[ unavailable ]\n");
+                    BIO_printf(bio_out, "[ unavailable ]\n");
                     if (test_avail_noise)
-                        ERR_print_errors_fp(stdout);
+                        ERR_print_errors(bio_out);
                     ERR_clear_error();
                 }
             }
-            if ((verbose > 0) && !util_verbose(e, verbose, out, indent))
+            if ((verbose > 0) && !util_verbose(e, verbose, bio_out, indent))
                 goto end;
             ENGINE_free(e);
         } else {
@@ -488,6 +486,5 @@ int engine_main(int argc, char **argv)
     sk_OPENSSL_CSTRING_free(engines);
     sk_OPENSSL_STRING_free(pre_cmds);
     sk_OPENSSL_STRING_free(post_cmds);
-    BIO_free_all(out);
     return ret;
 }

--- a/apps/fipsinstall.c
+++ b/apps/fipsinstall.c
@@ -413,7 +413,7 @@ opthelp:
     if (!gotkey && !sk_OPENSSL_STRING_push(opts, "hexkey:" FIPS_KEY_STRING))
         goto end;
 
-    module_bio = bio_open_default(module_fname, 'r', FORMAT_BINARY);
+    module_bio = app_bio_open_default(module_fname, 'r', FORMAT_BINARY);
     if (module_bio == NULL) {
         BIO_printf(bio_err, "Failed to open module file\n");
         goto end;
@@ -489,8 +489,8 @@ opthelp:
             goto end;
 
         fout =
-            out_fname == NULL ? dup_bio_out(FORMAT_TEXT)
-                              : bio_open_default(out_fname, 'w', FORMAT_TEXT);
+            out_fname == NULL ? app_bio_dup_out(FORMAT_TEXT)
+                              : app_bio_open_default(out_fname, 'w', FORMAT_TEXT);
         if (fout == NULL) {
             BIO_printf(bio_err, "Failed to open file\n");
             goto end;

--- a/apps/gendsa.c
+++ b/apps/gendsa.c
@@ -123,7 +123,7 @@ int gendsa_main(int argc, char **argv)
 
     pkey = load_keyparams(dsaparams, FORMAT_UNDEF, 1, "DSA", "DSA parameters");
 
-    out = bio_open_owner(outfile, FORMAT_PEM, private);
+    out = app_bio_open_owner(outfile, FORMAT_PEM, private);
     if (out == NULL)
         goto end2;
 

--- a/apps/genpkey.c
+++ b/apps/genpkey.c
@@ -181,7 +181,7 @@ int genpkey_main(int argc, char **argv)
         goto end;
     }
 
-    out = bio_open_owner(outfile, outformat, private);
+    out = app_bio_open_owner(outfile, outformat, private);
     if (out == NULL)
         goto end;
 

--- a/apps/genrsa.c
+++ b/apps/genrsa.c
@@ -175,7 +175,7 @@ opthelp:
         goto end;
     }
 
-    out = bio_open_owner(outfile, FORMAT_PEM, private);
+    out = app_bio_open_owner(outfile, FORMAT_PEM, private);
     if (out == NULL)
         goto end;
 

--- a/apps/include/app_bio.h
+++ b/apps/include/app_bio.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2015-2021 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#ifndef OSSL_APP_BIO_H
+# define OSSL_APP_BIO_H
+
+# include <openssl/bio.h>
+
+# include "app_bio_functions.h"
+# include "app_bio_macros.h"
+#endif

--- a/apps/include/app_bio_functions.h
+++ b/apps/include/app_bio_functions.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2015-2021 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#ifndef OSSL_APP_BIO_FUNCTIONS_H
+# define OSSL_APP_BIO_FUNCTIONS_H
+
+# include <openssl/bio.h>
+
+/*
+ * These are used by the macros bio_in, bio_out and bio_err, defined in
+ * app_bio_macros.h.  They are intended for use as lvalues just as much
+ * as rvalues.
+ */
+BIO **app_bio_in_location(void);
+BIO **app_bio_out_location(void);
+BIO **app_bio_err_location(void);
+
+int app_bio_init(void);
+
+BIO *app_bio_dup_in(int format);
+BIO *app_bio_dup_out(int format);
+BIO *app_bio_dup_err(int format);
+BIO *app_bio_open(const char *filename, char mode, int format, int quiet);
+BIO *app_bio_open_owner(const char *filename, int format, int private);
+BIO *app_bio_open_default(const char *filename, char mode, int format);
+BIO *app_bio_open_default_quiet(const char *filename, char mode, int format);
+
+#endif

--- a/apps/include/app_bio_macros.h
+++ b/apps/include/app_bio_macros.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2015-2021 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#ifndef OSSL_APP_BIO_MACROS_H
+# define OSSL_APP_BIO_MACROS_H
+
+/* The functions are declared in app_bio_functions.h */
+# define bio_in (*app_bio_in_location())
+# define bio_out (*app_bio_out_location())
+# define bio_err (*app_bio_err_location())
+
+#endif

--- a/apps/include/apps.h
+++ b/apps/include/apps.h
@@ -33,6 +33,7 @@
 # include <openssl/http.h>
 # include <signal.h>
 # include "apps_ui.h"
+# include "app_bio.h"
 # include "opt.h"
 # include "fmt.h"
 # include "platform.h"
@@ -50,19 +51,10 @@ int app_RAND_write(void);
 int app_RAND_load(void);
 
 extern char *default_config_file; /* may be "" */
-extern BIO *bio_in;
-extern BIO *bio_out;
-extern BIO *bio_err;
 extern const unsigned char tls13_aes128gcmsha256_id[];
 extern const unsigned char tls13_aes256gcmsha384_id[];
 extern BIO_ADDR *ourpeer;
 
-BIO *dup_bio_in(int format);
-BIO *dup_bio_out(int format);
-BIO *dup_bio_err(int format);
-BIO *bio_open_owner(const char *filename, int format, int private);
-BIO *bio_open_default(const char *filename, char mode, int format);
-BIO *bio_open_default_quiet(const char *filename, char mode, int format);
 CONF *app_load_config_bio(BIO *in, const char *filename);
 #define app_load_config(filename) app_load_config_internal(filename, 0)
 #define app_load_config_quiet(filename) app_load_config_internal(filename, 1)

--- a/apps/include/apps_ui.h
+++ b/apps/include/apps_ui.h
@@ -24,6 +24,4 @@ void destroy_ui_method(void);
 int set_base_ui_method(const UI_METHOD *ui_method);
 const UI_METHOD *get_ui_method(void);
 
-extern BIO *bio_err;
-
 #endif

--- a/apps/kdf.c
+++ b/apps/kdf.c
@@ -165,7 +165,8 @@ opthelp:
             goto err;
     }
 
-    out = bio_open_default(outfile, 'w', out_bin ? FORMAT_BINARY : FORMAT_TEXT);
+    out = app_bio_open_default(outfile, 'w',
+                               out_bin ? FORMAT_BINARY : FORMAT_TEXT);
     if (out == NULL)
         goto err;
 

--- a/apps/lib/app_bail.c
+++ b/apps/lib/app_bail.c
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2015-2021 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <stdlib.h>              /* exit() */
+#include <stdarg.h>              /* va_start(), va_end(), ... */
+#include <openssl/bio.h>
+#include <openssl/err.h>
+#include <apps.h>
+
+void app_bail_out(char *fmt, ...)
+{
+    va_list args;
+
+    va_start(args, fmt);
+    BIO_vprintf(bio_err, fmt, args);
+    va_end(args);
+    ERR_print_errors(bio_err);
+    exit(1);
+}

--- a/apps/lib/app_bio.c
+++ b/apps/lib/app_bio.c
@@ -1,0 +1,229 @@
+/*
+ * Copyright 2015-2021 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <errno.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <openssl/bio.h>
+#include <openssl/err.h>
+#include "opt.h"
+#include "fmt.h"
+
+#include "app_bio_functions.h"
+
+static BIO *bio_in = NULL;
+static BIO *bio_out = NULL;
+static BIO *bio_err = NULL;
+
+BIO **app_bio_in_location(void)
+{
+    return &bio_in;
+}
+
+BIO **app_bio_out_location(void)
+{
+    return &bio_out;
+}
+
+BIO **app_bio_err_location(void)
+{
+    return &bio_err;
+}
+
+int app_bio_init()
+{
+    bio_in = app_bio_dup_in(FORMAT_TEXT);
+    bio_out = app_bio_dup_out(FORMAT_TEXT);
+    bio_err = app_bio_dup_err(FORMAT_TEXT);
+
+    return bio_in != NULL && bio_out != NULL && bio_err != NULL;
+}
+
+#include "app_bio_macros.h"
+
+/*
+ * Centralized handling of input and output files with format specification
+ * The format is meant to show what the input and output is supposed to be,
+ * and is therefore a show of intent more than anything else.  However, it
+ * does impact behavior on some platforms, such as differentiating between
+ * text and binary input/output on non-Unix platforms
+ */
+BIO *app_bio_dup_in(int format)
+{
+    return BIO_new_fp(stdin,
+                      BIO_NOCLOSE | (FMT_istext(format) ? BIO_FP_TEXT : 0));
+}
+
+BIO *app_bio_dup_out(int format)
+{
+    BIO *b = BIO_new_fp(stdout,
+                        BIO_NOCLOSE | (FMT_istext(format) ? BIO_FP_TEXT : 0));
+    void *prefix = NULL;
+
+#ifdef OPENSSL_SYS_VMS
+    if (FMT_istext(format))
+        b = BIO_push(BIO_new(BIO_f_linebuffer()), b);
+#endif
+
+    if (FMT_istext(format)
+        && (prefix = getenv("HARNESS_OSSL_PREFIX")) != NULL) {
+        b = BIO_push(BIO_new(BIO_f_prefix()), b);
+        BIO_set_prefix(b, prefix);
+    }
+
+    return b;
+}
+
+BIO *app_bio_dup_err(int format)
+{
+    BIO *b = BIO_new_fp(stderr,
+                        BIO_NOCLOSE | (FMT_istext(format) ? BIO_FP_TEXT : 0));
+#ifdef OPENSSL_SYS_VMS
+    if (FMT_istext(format))
+        b = BIO_push(BIO_new(BIO_f_linebuffer()), b);
+#endif
+    return b;
+}
+
+static const char *modestr(char mode, int format)
+{
+    OPENSSL_assert(mode == 'a' || mode == 'r' || mode == 'w');
+
+    switch (mode) {
+    case 'a':
+        return FMT_istext(format) ? "a" : "ab";
+    case 'r':
+        return FMT_istext(format) ? "r" : "rb";
+    case 'w':
+        return FMT_istext(format) ? "w" : "wb";
+    }
+    /* The assert above should make sure we never reach this point */
+    return NULL;
+}
+
+static const char *modeverb(char mode)
+{
+    switch (mode) {
+    case 'a':
+        return "appending";
+    case 'r':
+        return "reading";
+    case 'w':
+        return "writing";
+    }
+    return "(doing something)";
+}
+
+/*
+ * Open a file for writing, owner-read-only.
+ */
+BIO *app_bio_open_owner(const char *filename, int format, int private)
+{
+    FILE *fp = NULL;
+    BIO *b = NULL;
+    int fd = -1, bflags, mode, textmode;
+
+    if (!private || filename == NULL || strcmp(filename, "-") == 0)
+        return app_bio_open_default(filename, 'w', format);
+
+    mode = O_WRONLY;
+#ifdef O_CREAT
+    mode |= O_CREAT;
+#endif
+#ifdef O_TRUNC
+    mode |= O_TRUNC;
+#endif
+    textmode = FMT_istext(format);
+    if (!textmode) {
+#ifdef O_BINARY
+        mode |= O_BINARY;
+#elif defined(_O_BINARY)
+        mode |= _O_BINARY;
+#endif
+    }
+
+#ifdef OPENSSL_SYS_VMS
+    /* VMS doesn't have O_BINARY, it just doesn't make sense.  But,
+     * it still needs to know that we're going binary, or fdopen()
+     * will fail with "invalid argument"...  so we tell VMS what the
+     * context is.
+     */
+    if (!textmode)
+        fd = open(filename, mode, 0600, "ctx=bin");
+    else
+#endif
+        fd = open(filename, mode, 0600);
+    if (fd < 0)
+        goto err;
+    fp = fdopen(fd, modestr('w', format));
+    if (fp == NULL)
+        goto err;
+    bflags = BIO_CLOSE;
+    if (textmode)
+        bflags |= BIO_FP_TEXT;
+    b = BIO_new_fp(fp, bflags);
+    if (b)
+        return b;
+
+ err:
+    BIO_printf(bio_err, "%s: Can't open \"%s\" for writing, %s\n",
+               opt_getprog(), filename, strerror(errno));
+    ERR_print_errors(bio_err);
+    /* If we have fp, then fdopen took over fd, so don't close both. */
+    if (fp)
+        fclose(fp);
+    else if (fd >= 0)
+        close(fd);
+    return NULL;
+}
+
+BIO *app_bio_open(const char *filename, char mode, int format, int quiet)
+{
+    BIO *ret;
+
+    if (filename == NULL || strcmp(filename, "-") == 0) {
+        ret = mode == 'r' ? app_bio_dup_in(format) : app_bio_dup_out(format);
+        if (quiet) {
+            ERR_clear_error();
+            return ret;
+        }
+        if (ret != NULL)
+            return ret;
+        BIO_printf(bio_err,
+                   "Can't open %s, %s\n",
+                   mode == 'r' ? "stdin" : "stdout", strerror(errno));
+    } else {
+        ret = BIO_new_file(filename, modestr(mode, format));
+        if (quiet) {
+            ERR_clear_error();
+            return ret;
+        }
+        if (ret != NULL)
+            return ret;
+        BIO_printf(bio_err,
+                   "Can't open \"%s\" for %s, %s\n",
+                   filename, modeverb(mode), strerror(errno));
+    }
+    ERR_print_errors(bio_err);
+    return NULL;
+}
+
+BIO *app_bio_open_default(const char *filename, char mode, int format)
+{
+    return app_bio_open(filename, mode, format, 0);
+}
+
+BIO *app_bio_open_default_quiet(const char *filename, char mode, int format)
+{
+    return app_bio_open(filename, mode, format, 1);
+}
+

--- a/apps/lib/app_bio.c
+++ b/apps/lib/app_bio.c
@@ -7,12 +7,15 @@
  * https://www.openssl.org/source/license.html
  */
 
+#include "e_os.h"                /* unistd.h */
+
 #include <errno.h>
 #include <string.h>
-#include <unistd.h>
 #include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
+#ifndef OPENSSL_NO_POSIX_IO
+# include <sys/stat.h>
+# include <fcntl.h>
+#endif
 #include <openssl/bio.h>
 #include <openssl/err.h>
 #include "opt.h"

--- a/apps/lib/app_mem.c
+++ b/apps/lib/app_mem.c
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2015-2021 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <openssl/crypto.h>      /* OPENSSL_malloc() */
+#include "apps.h"
+
+void *app_malloc(size_t sz, const char *what)
+{
+    void *vp = OPENSSL_malloc(sz);
+
+    if (vp == NULL)
+        app_bail_out("%s: Could not allocate %zu bytes for %s\n",
+                     opt_getprog(), sz, what);
+    return vp;
+}
+

--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -55,9 +55,6 @@ static int WIN32_rename(const char *from, const char *to);
 # define _kbhit kbhit
 #endif
 
-static BIO *bio_open_default_(const char *filename, char mode, int format,
-                              int quiet);
-
 #define PASS_SOURCE_SIZE_MAX 4
 
 DEFINE_STACK_OF(CONF)
@@ -293,7 +290,7 @@ static char *app_get_pass(const char *arg, int keepbio)
             pwdbio = BIO_push(btmp, pwdbio);
 #endif
         } else if (strcmp(arg, "stdin") == 0) {
-            pwdbio = dup_bio_in(FORMAT_TEXT);
+            pwdbio = app_bio_dup_in(FORMAT_TEXT);
             if (pwdbio == NULL) {
                 BIO_printf(bio_err, "Can't open BIO for stdin\n");
                 return NULL;
@@ -407,7 +404,7 @@ CONF *app_load_config_internal(const char *filename, int quiet)
     CONF *conf;
 
     if (*filename != '\0'
-        && (in = bio_open_default_(filename, 'r', FORMAT_TEXT, quiet)) == NULL)
+        && (in = app_bio_open(filename, 'r', FORMAT_TEXT, quiet)) == NULL)
         return NULL;
     conf = app_load_config_bio(in, filename);
     BIO_free(in);
@@ -530,7 +527,7 @@ X509_REQ *load_csr(const char *file, int format, const char *desc)
         format = FORMAT_PEM;
     if (desc == NULL)
         desc = "CSR";
-    in = bio_open_default(file, 'r', format);
+    in = app_bio_open_default(file, 'r', format);
     if (in == NULL)
         goto end;
 
@@ -2832,50 +2829,6 @@ int raw_write_stdout(const void *buf, int siz)
 }
 #endif
 
-/*
- * Centralized handling of input and output files with format specification
- * The format is meant to show what the input and output is supposed to be,
- * and is therefore a show of intent more than anything else.  However, it
- * does impact behavior on some platforms, such as differentiating between
- * text and binary input/output on non-Unix platforms
- */
-BIO *dup_bio_in(int format)
-{
-    return BIO_new_fp(stdin,
-                      BIO_NOCLOSE | (FMT_istext(format) ? BIO_FP_TEXT : 0));
-}
-
-BIO *dup_bio_out(int format)
-{
-    BIO *b = BIO_new_fp(stdout,
-                        BIO_NOCLOSE | (FMT_istext(format) ? BIO_FP_TEXT : 0));
-    void *prefix = NULL;
-
-#ifdef OPENSSL_SYS_VMS
-    if (FMT_istext(format))
-        b = BIO_push(BIO_new(BIO_f_linebuffer()), b);
-#endif
-
-    if (FMT_istext(format)
-        && (prefix = getenv("HARNESS_OSSL_PREFIX")) != NULL) {
-        b = BIO_push(BIO_new(BIO_f_prefix()), b);
-        BIO_set_prefix(b, prefix);
-    }
-
-    return b;
-}
-
-BIO *dup_bio_err(int format)
-{
-    BIO *b = BIO_new_fp(stderr,
-                        BIO_NOCLOSE | (FMT_istext(format) ? BIO_FP_TEXT : 0));
-#ifdef OPENSSL_SYS_VMS
-    if (FMT_istext(format))
-        b = BIO_push(BIO_new(BIO_f_linebuffer()), b);
-#endif
-    return b;
-}
-
 void unbuffer(FILE *fp)
 {
 /*
@@ -2893,140 +2846,6 @@ void unbuffer(FILE *fp)
 #if defined(OPENSSL_SYS_VMS) && defined(__DECC)
 # pragma environment restore
 #endif
-}
-
-static const char *modestr(char mode, int format)
-{
-    OPENSSL_assert(mode == 'a' || mode == 'r' || mode == 'w');
-
-    switch (mode) {
-    case 'a':
-        return FMT_istext(format) ? "a" : "ab";
-    case 'r':
-        return FMT_istext(format) ? "r" : "rb";
-    case 'w':
-        return FMT_istext(format) ? "w" : "wb";
-    }
-    /* The assert above should make sure we never reach this point */
-    return NULL;
-}
-
-static const char *modeverb(char mode)
-{
-    switch (mode) {
-    case 'a':
-        return "appending";
-    case 'r':
-        return "reading";
-    case 'w':
-        return "writing";
-    }
-    return "(doing something)";
-}
-
-/*
- * Open a file for writing, owner-read-only.
- */
-BIO *bio_open_owner(const char *filename, int format, int private)
-{
-    FILE *fp = NULL;
-    BIO *b = NULL;
-    int fd = -1, bflags, mode, textmode;
-
-    if (!private || filename == NULL || strcmp(filename, "-") == 0)
-        return bio_open_default(filename, 'w', format);
-
-    mode = O_WRONLY;
-#ifdef O_CREAT
-    mode |= O_CREAT;
-#endif
-#ifdef O_TRUNC
-    mode |= O_TRUNC;
-#endif
-    textmode = FMT_istext(format);
-    if (!textmode) {
-#ifdef O_BINARY
-        mode |= O_BINARY;
-#elif defined(_O_BINARY)
-        mode |= _O_BINARY;
-#endif
-    }
-
-#ifdef OPENSSL_SYS_VMS
-    /* VMS doesn't have O_BINARY, it just doesn't make sense.  But,
-     * it still needs to know that we're going binary, or fdopen()
-     * will fail with "invalid argument"...  so we tell VMS what the
-     * context is.
-     */
-    if (!textmode)
-        fd = open(filename, mode, 0600, "ctx=bin");
-    else
-#endif
-        fd = open(filename, mode, 0600);
-    if (fd < 0)
-        goto err;
-    fp = fdopen(fd, modestr('w', format));
-    if (fp == NULL)
-        goto err;
-    bflags = BIO_CLOSE;
-    if (textmode)
-        bflags |= BIO_FP_TEXT;
-    b = BIO_new_fp(fp, bflags);
-    if (b)
-        return b;
-
- err:
-    BIO_printf(bio_err, "%s: Can't open \"%s\" for writing, %s\n",
-               opt_getprog(), filename, strerror(errno));
-    ERR_print_errors(bio_err);
-    /* If we have fp, then fdopen took over fd, so don't close both. */
-    if (fp)
-        fclose(fp);
-    else if (fd >= 0)
-        close(fd);
-    return NULL;
-}
-
-static BIO *bio_open_default_(const char *filename, char mode, int format,
-                              int quiet)
-{
-    BIO *ret;
-
-    if (filename == NULL || strcmp(filename, "-") == 0) {
-        ret = mode == 'r' ? dup_bio_in(format) : dup_bio_out(format);
-        if (quiet) {
-            ERR_clear_error();
-            return ret;
-        }
-        if (ret != NULL)
-            return ret;
-        BIO_printf(bio_err,
-                   "Can't open %s, %s\n",
-                   mode == 'r' ? "stdin" : "stdout", strerror(errno));
-    } else {
-        ret = BIO_new_file(filename, modestr(mode, format));
-        if (quiet) {
-            ERR_clear_error();
-            return ret;
-        }
-        if (ret != NULL)
-            return ret;
-        BIO_printf(bio_err,
-                   "Can't open \"%s\" for %s, %s\n",
-                   filename, modeverb(mode), strerror(errno));
-    }
-    ERR_print_errors(bio_err);
-    return NULL;
-}
-
-BIO *bio_open_default(const char *filename, char mode, int format)
-{
-    return bio_open_default_(filename, mode, format, 0);
-}
-
-BIO *bio_open_default_quiet(const char *filename, char mode, int format)
-{
-    return bio_open_default_(filename, mode, format, 1);
 }
 
 void wait_for_async(SSL *s)

--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -2993,18 +2993,6 @@ void make_uppercase(char *string)
         string[i] = toupper((unsigned char)string[i]);
 }
 
-/* This function is defined here due to visibility of bio_err */
-int opt_printf_stderr(const char *fmt, ...)
-{
-    va_list ap;
-    int ret;
-
-    va_start(ap, fmt);
-    ret = BIO_vprintf(bio_err, fmt, ap);
-    va_end(ap);
-    return ret;
-}
-
 OSSL_PARAM *app_params_new_from_opts(STACK_OF(OPENSSL_STRING) *opts,
                                      const OSSL_PARAM *paramdefs)
 {

--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -621,27 +621,6 @@ EVP_PKEY *load_keyparams(const char *uri, int format, int maybe_stdin,
     return params;
 }
 
-void app_bail_out(char *fmt, ...)
-{
-    va_list args;
-
-    va_start(args, fmt);
-    BIO_vprintf(bio_err, fmt, args);
-    va_end(args);
-    ERR_print_errors(bio_err);
-    exit(1);
-}
-
-void *app_malloc(size_t sz, const char *what)
-{
-    void *vp = OPENSSL_malloc(sz);
-
-    if (vp == NULL)
-        app_bail_out("%s: Could not allocate %zu bytes for %s\n",
-                     opt_getprog(), sz, what);
-    return vp;
-}
-
 char *next_item(char *opt) /* in list separated by comma and/or space */
 {
     /* advance to separator (comma or whitespace), if any */

--- a/apps/lib/apps_ui.c
+++ b/apps/lib/apps_ui.c
@@ -11,6 +11,7 @@
 #include <openssl/err.h>
 #include <openssl/ui.h>
 #include "apps_ui.h"
+#include "app_bio.h"
 
 static UI_METHOD *ui_method = NULL;
 static const UI_METHOD *ui_base_method = NULL;

--- a/apps/lib/build.info
+++ b/apps/lib/build.info
@@ -10,7 +10,7 @@ ENDIF
 # Source for libapps
 $LIBAPPSSRC=apps.c apps_ui.c opt.c fmt.c s_cb.c s_socket.c app_rand.c \
         columns.c app_params.c names.c app_provider.c app_x509.c http_server.c \
-        engine.c engine_loader.c
+        engine.c engine_loader.c app_bail.c app_mem.c
 
 IF[{- !$disabled{apps} -}]
   LIBS{noinst}=../libapps.a

--- a/apps/lib/build.info
+++ b/apps/lib/build.info
@@ -10,7 +10,7 @@ ENDIF
 # Source for libapps
 $LIBAPPSSRC=apps.c apps_ui.c opt.c fmt.c s_cb.c s_socket.c app_rand.c \
         columns.c app_params.c names.c app_provider.c app_x509.c http_server.c \
-        engine.c engine_loader.c app_bail.c app_mem.c
+        engine.c engine_loader.c app_bail.c app_mem.c app_bio.c
 
 IF[{- !$disabled{apps} -}]
   LIBS{noinst}=../libapps.a

--- a/apps/lib/build.info
+++ b/apps/lib/build.info
@@ -16,6 +16,10 @@ IF[{- !$disabled{apps} -}]
   LIBS{noinst}=../libapps.a
   SOURCE[../libapps.a]=$LIBAPPSSRC $AUXLIBAPPSSRC
   INCLUDE[../libapps.a]=../.. ../../include ../include
+  # The "weak" dependency is only to ensure correct topology.  Each program
+  # that uses libapps.a will have to be set up with dependencies to the library
+  # they actually use.
+  DEPEND[libtestutil.a]{weak}=../libssl ../libcrypto
 ENDIF
 
 IF[{- !$disabled{srp} -}]

--- a/apps/lib/build.info
+++ b/apps/lib/build.info
@@ -8,7 +8,7 @@ IF[{- $config{target} =~ /^vms-/ -}]
 ENDIF
 
 # Source for libapps
-$LIBAPPSSRC=apps.c apps_ui.c opt.c fmt.c s_cb.c s_socket.c app_rand.c \
+$LIBAPPSSRC=apps.c apps_ui.c opt.c opt_err.c fmt.c s_cb.c s_socket.c app_rand.c \
         columns.c app_params.c names.c app_provider.c app_x509.c http_server.c \
         engine.c engine_loader.c app_bail.c app_mem.c app_bio.c
 

--- a/apps/lib/opt.c
+++ b/apps/lib/opt.c
@@ -143,17 +143,6 @@ char *opt_progname(const char *argv0)
 }
 #endif
 
-int opt_printf_stderr(const char *fmt, ...)
-{
-    va_list ap;
-    int ret;
-
-    va_start(ap, fmt);
-    ret = BIO_vprintf(bio_err, fmt, ap);
-    va_end(ap);
-    return ret;
-}
-
 char *opt_appname(const char *argv0)
 {
     size_t len = strlen(prog);

--- a/apps/lib/opt.c
+++ b/apps/lib/opt.c
@@ -26,6 +26,8 @@
 #include <openssl/bio.h>
 #include <openssl/x509v3.h>
 
+#include "app_bio.h"
+
 #define MAX_OPT_HELP_WIDTH 30
 const char OPT_HELP_STR[] = "-H";
 const char OPT_MORE_STR[] = "-M";
@@ -140,6 +142,17 @@ char *opt_progname(const char *argv0)
     return prog;
 }
 #endif
+
+int opt_printf_stderr(const char *fmt, ...)
+{
+    va_list ap;
+    int ret;
+
+    va_start(ap, fmt);
+    ret = BIO_vprintf(bio_err, fmt, ap);
+    va_end(ap);
+    return ret;
+}
 
 char *opt_appname(const char *argv0)
 {

--- a/apps/lib/opt_err.c
+++ b/apps/lib/opt_err.c
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2015-2021 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include "opt.h"
+
+int opt_printf_stderr(const char *fmt, ...)
+{
+    va_list ap;
+    int ret;
+
+    va_start(ap, fmt);
+    ret = BIO_vprintf(bio_err, fmt, ap);
+    va_end(ap);
+    return ret;
+}

--- a/apps/lib/opt_err.c
+++ b/apps/lib/opt_err.c
@@ -8,6 +8,7 @@
  */
 
 #include "opt.h"
+#include "app_bio.h"
 
 int opt_printf_stderr(const char *fmt, ...)
 {

--- a/apps/mac.c
+++ b/apps/mac.c
@@ -173,11 +173,12 @@ opthelp:
     /* Use text mode for stdin */
     if (infile == NULL || strcmp(infile, "-") == 0)
         inform = FORMAT_TEXT;
-    in = bio_open_default(infile, 'r', inform);
+    in = app_bio_open_default(infile, 'r', inform);
     if (in == NULL)
         goto err;
 
-    out = bio_open_default(outfile, 'w', out_bin ? FORMAT_BINARY : FORMAT_TEXT);
+    out = app_bio_open_default(outfile, 'w',
+                               out_bin ? FORMAT_BINARY : FORMAT_TEXT);
     if (out == NULL)
         goto err;
 

--- a/apps/nseq.c
+++ b/apps/nseq.c
@@ -77,10 +77,10 @@ int nseq_main(int argc, char **argv)
     if (argc != 0)
         goto opthelp;
 
-    in = bio_open_default(infile, 'r', FORMAT_PEM);
+    in = app_bio_open_default(infile, 'r', FORMAT_PEM);
     if (in == NULL)
         goto end;
-    out = bio_open_default(outfile, 'w', FORMAT_PEM);
+    out = app_bio_open_default(outfile, 'w', FORMAT_PEM);
     if (out == NULL)
         goto end;
 

--- a/apps/ocsp.c
+++ b/apps/ocsp.c
@@ -547,7 +547,7 @@ int ocsp_main(int argc, char **argv)
         && respin == NULL && !(port != NULL && ridx_filename != NULL))
         goto opthelp;
 
-    out = bio_open_default(outfile, 'w', FORMAT_TEXT);
+    out = app_bio_open_default(outfile, 'w', FORMAT_TEXT);
     if (out == NULL)
         goto end;
 
@@ -555,7 +555,7 @@ int ocsp_main(int argc, char **argv)
         add_nonce = 0;
 
     if (req == NULL && reqin != NULL) {
-        derbio = bio_open_default(reqin, 'r', FORMAT_ASN1);
+        derbio = app_bio_open_default(reqin, 'r', FORMAT_ASN1);
         if (derbio == NULL)
             goto end;
         req = d2i_OCSP_REQUEST_bio(derbio, NULL);
@@ -702,7 +702,7 @@ redo_accept:
         OCSP_REQUEST_print(out, req, 0);
 
     if (reqout != NULL) {
-        derbio = bio_open_default(reqout, 'w', FORMAT_ASN1);
+        derbio = app_bio_open_default(reqout, 'w', FORMAT_ASN1);
         if (derbio == NULL)
             goto end;
         i2d_OCSP_REQUEST_bio(derbio, req);
@@ -727,7 +727,7 @@ redo_accept:
         goto end;
 #endif
     } else if (respin != NULL) {
-        derbio = bio_open_default(respin, 'r', FORMAT_ASN1);
+        derbio = app_bio_open_default(respin, 'r', FORMAT_ASN1);
         if (derbio == NULL)
             goto end;
         resp = d2i_OCSP_RESPONSE_bio(derbio, NULL);
@@ -744,7 +744,7 @@ redo_accept:
  done_resp:
 
     if (respout != NULL) {
-        derbio = bio_open_default(respout, 'w', FORMAT_ASN1);
+        derbio = app_bio_open_default(respout, 'w', FORMAT_ASN1);
         if (derbio == NULL)
             goto end;
         i2d_OCSP_RESPONSE_bio(derbio, resp);

--- a/apps/openssl.c
+++ b/apps/openssl.c
@@ -39,10 +39,6 @@ static LHASH_OF(FUNCTION) *prog_init(void);
 static int do_cmd(LHASH_OF(FUNCTION) *prog, int argc, char *argv[]);
 char *default_config_file = NULL;
 
-BIO *bio_in = NULL;
-BIO *bio_out = NULL;
-BIO *bio_err = NULL;
-
 static void warn_deprecated(const FUNCTION *fp)
 {
     if (fp->deprecated_version != NULL)
@@ -172,7 +168,7 @@ static void setup_trace_category(int category)
     if (OSSL_trace_enabled(category))
         return;
 
-    channel = BIO_push(BIO_new(BIO_f_prefix()), dup_bio_err(FORMAT_TEXT));
+    channel = BIO_push(BIO_new(BIO_f_prefix()), app_bio_dup_err(FORMAT_TEXT));
     trace_data = OPENSSL_zalloc(sizeof(*trace_data));
 
     if (trace_data == NULL
@@ -244,10 +240,7 @@ int main(int argc, char *argv[])
     arg.size = 0;
 
     /* Set up some of the environment. */
-    bio_in = dup_bio_in(FORMAT_TEXT);
-    bio_out = dup_bio_out(FORMAT_TEXT);
-    bio_err = dup_bio_err(FORMAT_TEXT);
-
+    (void)app_bio_init();
 #if defined(OPENSSL_SYS_VMS) && defined(__DECC)
     argv = copy_argv(&argc, argv);
 #elif defined(_WIN32)

--- a/apps/passwd.c
+++ b/apps/passwd.c
@@ -211,9 +211,9 @@ int passwd_main(int argc, char **argv)
     if (infile != NULL || in_stdin) {
         /*
          * If in_stdin is true, we know that infile is NULL, and that
-         * bio_open_default() will give us back an alias for stdin.
+         * app_bio_open_default() will give us back an alias for stdin.
          */
-        in = bio_open_default(infile, 'r', FORMAT_TEXT);
+        in = app_bio_open_default(infile, 'r', FORMAT_TEXT);
         if (in == NULL)
             goto end;
     }

--- a/apps/pkcs12.c
+++ b/apps/pkcs12.c
@@ -685,7 +685,7 @@ int pkcs12_main(int argc, char **argv)
 
         assert(private);
 
-        out = bio_open_owner(outfile, FORMAT_PKCS12, private);
+        out = app_bio_open_owner(outfile, FORMAT_PKCS12, private);
         if (out == NULL)
             goto end;
 
@@ -706,10 +706,10 @@ int pkcs12_main(int argc, char **argv)
 
     }
 
-    in = bio_open_default(infile, 'r', FORMAT_PKCS12);
+    in = app_bio_open_default(infile, 'r', FORMAT_PKCS12);
     if (in == NULL)
         goto end;
-    out = bio_open_owner(outfile, FORMAT_PEM, private);
+    out = app_bio_open_owner(outfile, FORMAT_PEM, private);
     if (out == NULL)
         goto end;
 

--- a/apps/pkcs7.c
+++ b/apps/pkcs7.c
@@ -115,7 +115,7 @@ int pkcs7_main(int argc, char **argv)
     if (argc != 0)
         goto opthelp;
 
-    in = bio_open_default(infile, 'r', informat);
+    in = app_bio_open_default(infile, 'r', informat);
     if (in == NULL)
         goto end;
 
@@ -136,7 +136,7 @@ int pkcs7_main(int argc, char **argv)
         goto end;
     }
 
-    out = bio_open_default(outfile, 'w', outformat);
+    out = app_bio_open_default(outfile, 'w', outformat);
     if (out == NULL)
         goto end;
 

--- a/apps/pkcs8.c
+++ b/apps/pkcs8.c
@@ -214,11 +214,11 @@ int pkcs8_main(int argc, char **argv)
     if ((pbe_nid == -1) && cipher == NULL)
         cipher = (EVP_CIPHER *)EVP_aes_256_cbc();
 
-    in = bio_open_default(infile, 'r',
+    in = app_bio_open_default(infile, 'r',
                           informat == FORMAT_UNDEF ? FORMAT_PEM : informat);
     if (in == NULL)
         goto end;
-    out = bio_open_owner(outfile, outformat, private);
+    out = app_bio_open_owner(outfile, outformat, private);
     if (out == NULL)
         goto end;
 

--- a/apps/pkey.c
+++ b/apps/pkey.c
@@ -206,7 +206,7 @@ int pkey_main(int argc, char **argv)
         goto end;
     }
 
-    out = bio_open_owner(outfile, outformat, private);
+    out = app_bio_open_owner(outfile, outformat, private);
     if (out == NULL)
         goto end;
 

--- a/apps/pkeyparam.c
+++ b/apps/pkeyparam.c
@@ -95,10 +95,10 @@ int pkeyparam_main(int argc, char **argv)
     if (argc != 0)
         goto opthelp;
 
-    in = bio_open_default(infile, 'r', FORMAT_PEM);
+    in = app_bio_open_default(infile, 'r', FORMAT_PEM);
     if (in == NULL)
         goto end;
-    out = bio_open_default(outfile, 'w', FORMAT_PEM);
+    out = app_bio_open_default(outfile, 'w', FORMAT_PEM);
     if (out == NULL)
         goto end;
     pkey = PEM_read_bio_Parameters(in, NULL);

--- a/apps/pkeyutl.c
+++ b/apps/pkeyutl.c
@@ -392,7 +392,7 @@ int pkeyutl_main(int argc, char **argv)
     }
 
     if (pkey_op != EVP_PKEY_OP_DERIVE) {
-        in = bio_open_default(infile, 'r', FORMAT_BINARY);
+        in = app_bio_open_default(infile, 'r', FORMAT_BINARY);
         if (infile != NULL) {
             struct stat st;
 
@@ -402,7 +402,7 @@ int pkeyutl_main(int argc, char **argv)
         if (in == NULL)
             goto end;
     }
-    out = bio_open_default(outfile, 'w', FORMAT_BINARY);
+    out = app_bio_open_default(outfile, 'w', FORMAT_BINARY);
     if (out == NULL)
         goto end;
 

--- a/apps/rand.c
+++ b/apps/rand.c
@@ -102,7 +102,7 @@ int rand_main(int argc, char **argv)
     if (!app_RAND_load())
         goto end;
 
-    out = bio_open_default(outfile, 'w', format);
+    out = app_bio_open_default(outfile, 'w', format);
     if (out == NULL)
         goto end;
 

--- a/apps/req.c
+++ b/apps/req.c
@@ -707,7 +707,7 @@ int req_main(int argc, char **argv)
             BIO_printf(bio_err, "Writing new private key to stdout\n");
         else
             BIO_printf(bio_err, "Writing new private key to '%s'\n", keyout);
-        out = bio_open_owner(keyout, outformat, newreq);
+        out = app_bio_open_owner(keyout, outformat, newreq);
         if (out == NULL)
             goto end;
 
@@ -953,10 +953,10 @@ int req_main(int argc, char **argv)
         goto end;
     }
 
-    out = bio_open_default(outfile,
-                           keyout != NULL && outfile != NULL &&
-                           strcmp(keyout, outfile) == 0 ? 'a' : 'w',
-                           outformat);
+    out = app_bio_open_default(outfile,
+                               keyout != NULL && outfile != NULL &&
+                               strcmp(keyout, outfile) == 0 ? 'a' : 'w',
+                               outformat);
     if (out == NULL)
         goto end;
 

--- a/apps/rsa.c
+++ b/apps/rsa.c
@@ -229,7 +229,7 @@ int rsa_main(int argc, char **argv)
         goto end;
     }
 
-    out = bio_open_owner(outfile, outformat, private);
+    out = app_bio_open_owner(outfile, outformat, private);
     if (out == NULL)
         goto end;
 

--- a/apps/rsautl.c
+++ b/apps/rsautl.c
@@ -207,10 +207,10 @@ int rsautl_main(int argc, char **argv)
     if (pkey == NULL)
         return 1;
 
-    in = bio_open_default(infile, 'r', FORMAT_BINARY);
+    in = app_bio_open_default(infile, 'r', FORMAT_BINARY);
     if (in == NULL)
         goto end;
-    out = bio_open_default(outfile, 'w', FORMAT_BINARY);
+    out = app_bio_open_default(outfile, 'w', FORMAT_BINARY);
     if (out == NULL)
         goto end;
 

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -1655,9 +1655,9 @@ int s_client_main(int argc, char **argv)
         if (c_quiet && !c_debug) {
             bio_c_out = BIO_new(BIO_s_null());
             if (c_msg && bio_c_msg == NULL)
-                bio_c_msg = dup_bio_out(FORMAT_TEXT);
+                bio_c_msg = app_bio_dup_out(FORMAT_TEXT);
         } else if (bio_c_out == NULL)
-            bio_c_out = dup_bio_out(FORMAT_TEXT);
+            bio_c_out = app_bio_dup_out(FORMAT_TEXT);
     }
 #ifndef OPENSSL_NO_SRP
     if (!app_passwd(srppass, NULL, &srp_arg.srppassin, NULL)) {

--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -573,7 +573,7 @@ static int cert_status_cb(SSL *s, void *arg)
         BIO_puts(bio_err, "cert_status: callback called\n");
 
     if (srctx->respin != NULL) {
-        BIO *derbio = bio_open_default(srctx->respin, 'r', FORMAT_ASN1);
+        BIO *derbio = app_bio_open_default(srctx->respin, 'r', FORMAT_ASN1);
         if (derbio == NULL) {
             BIO_puts(bio_err, "cert_status: Cannot open OCSP response file\n");
             goto err;
@@ -1794,10 +1794,10 @@ int s_server_main(int argc, char *argv[])
         if (s_quiet && !s_debug) {
             bio_s_out = BIO_new(BIO_s_null());
             if (s_msg && bio_s_msg == NULL)
-                bio_s_msg = dup_bio_out(FORMAT_TEXT);
+                bio_s_msg = app_bio_dup_out(FORMAT_TEXT);
         } else {
             if (bio_s_out == NULL)
-                bio_s_out = dup_bio_out(FORMAT_TEXT);
+                bio_s_out = app_bio_dup_out(FORMAT_TEXT);
         }
     }
     if (nocert) {

--- a/apps/sess_id.c
+++ b/apps/sess_id.c
@@ -122,7 +122,7 @@ int sess_id_main(int argc, char **argv)
     }
 
     if (!noout || text) {
-        out = bio_open_default(outfile, 'w', outformat);
+        out = app_bio_open_default(outfile, 'w', outformat);
         if (out == NULL)
             goto end;
     }
@@ -179,7 +179,7 @@ static SSL_SESSION *load_sess_id(char *infile, int format)
     SSL_SESSION *x = NULL;
     BIO *in = NULL;
 
-    in = bio_open_default(infile, 'r', format);
+    in = app_bio_open_default(infile, 'r', format);
     if (in == NULL)
         goto end;
     if (format == FORMAT_ASN1)

--- a/apps/smime.c
+++ b/apps/smime.c
@@ -490,7 +490,7 @@ int smime_main(int argc, char **argv)
             goto end;
     }
 
-    in = bio_open_default(infile, 'r', informat);
+    in = app_bio_open_default(infile, 'r', informat);
     if (in == NULL)
         goto end;
 
@@ -526,7 +526,7 @@ int smime_main(int argc, char **argv)
         }
     }
 
-    out = bio_open_default(outfile, 'w', outformat);
+    out = app_bio_open_default(outfile, 'w', outformat);
     if (out == NULL)
         goto end;
 

--- a/apps/spkac.c
+++ b/apps/spkac.c
@@ -160,7 +160,7 @@ int spkac_main(int argc, char **argv)
         if (spkstr == NULL)
             goto end;
 
-        out = bio_open_default(outfile, 'w', FORMAT_TEXT);
+        out = app_bio_open_default(outfile, 'w', FORMAT_TEXT);
         if (out == NULL) {
             OPENSSL_free(spkstr);
             goto end;
@@ -190,7 +190,7 @@ int spkac_main(int argc, char **argv)
         goto end;
     }
 
-    out = bio_open_default(outfile, 'w', FORMAT_TEXT);
+    out = app_bio_open_default(outfile, 'w', FORMAT_TEXT);
     if (out == NULL)
         goto end;
 

--- a/apps/storeutl.c
+++ b/apps/storeutl.c
@@ -314,7 +314,7 @@ int storeutl_main(int argc, char *argv[])
     pw_cb_data.password = passin;
     pw_cb_data.prompt_info = argv[0];
 
-    out = bio_open_default(outfile, 'w', FORMAT_TEXT);
+    out = app_bio_open_default(outfile, 'w', FORMAT_TEXT);
     if (out == NULL)
         goto end;
 

--- a/apps/ts.c
+++ b/apps/ts.c
@@ -403,12 +403,12 @@ static int query_command(const char *data, const char *digest, const EVP_MD *md,
 
     /* Build query object. */
     if (in != NULL) {
-        if ((in_bio = bio_open_default(in, 'r', FORMAT_ASN1)) == NULL)
+        if ((in_bio = app_bio_open_default(in, 'r', FORMAT_ASN1)) == NULL)
             goto end;
         query = d2i_TS_REQ_bio(in_bio, NULL);
     } else {
         if (digest == NULL
-            && (data_bio = bio_open_default(data, 'r', FORMAT_ASN1)) == NULL)
+            && (data_bio = app_bio_open_default(data, 'r', FORMAT_ASN1)) == NULL)
             goto end;
         query = create_query(data_bio, digest, md, policy, no_nonce, cert);
     }
@@ -416,12 +416,12 @@ static int query_command(const char *data, const char *digest, const EVP_MD *md,
         goto end;
 
     if (text) {
-        if ((out_bio = bio_open_default(out, 'w', FORMAT_TEXT)) == NULL)
+        if ((out_bio = app_bio_open_default(out, 'w', FORMAT_TEXT)) == NULL)
             goto end;
         if (!TS_REQ_print_bio(out_bio, query))
             goto end;
     } else {
-        if ((out_bio = bio_open_default(out, 'w', FORMAT_ASN1)) == NULL)
+        if ((out_bio = app_bio_open_default(out, 'w', FORMAT_ASN1)) == NULL)
             goto end;
         if (!i2d_TS_REQ_bio(out_bio, query))
             goto end;
@@ -616,7 +616,7 @@ static int reply_command(CONF *conf, const char *section, const char *engine,
 
     /* Write response. */
     if (text) {
-        if ((out_bio = bio_open_default(out, 'w', FORMAT_TEXT)) == NULL)
+        if ((out_bio = app_bio_open_default(out, 'w', FORMAT_TEXT)) == NULL)
         goto end;
         if (token_out) {
             TS_TST_INFO *tst_info = TS_RESP_get_tst_info(response);
@@ -627,7 +627,7 @@ static int reply_command(CONF *conf, const char *section, const char *engine,
                 goto end;
         }
     } else {
-        if ((out_bio = bio_open_default(out, 'w', FORMAT_ASN1)) == NULL)
+        if ((out_bio = app_bio_open_default(out, 'w', FORMAT_ASN1)) == NULL)
             goto end;
         if (token_out) {
             PKCS7 *token = TS_RESP_get_token(response);

--- a/apps/x509.c
+++ b/apps/x509.c
@@ -739,7 +739,7 @@ int x509_main(int argc, char **argv)
             goto end;
     }
 
-    out = bio_open_default(outfile, 'w', outformat);
+    out = app_bio_open_default(outfile, 'w', outformat);
     if (out == NULL)
         goto end;
 

--- a/test/build.info
+++ b/test/build.info
@@ -1,19 +1,3 @@
-# TODO: use ../apps/libapps.a instead of direct ../apps/lib source.
-# This can't currently be done, because some of its units drag in too many
-# unresolved references that don't apply here.
-# Most of all, ../apps/lib/apps.c needs to be divided in smaller pieces to
-# be useful here.
-#
-# Auxiliary program source (copied from ../apps/build.info)
-IF[{- $config{target} =~ /^(?:VC-|mingw|BC-)/ -}]
-  # It's called 'init', but doesn't have much 'init' in it...
-  $AUXLIBAPPSSRC=../apps/lib/win32_init.c
-ENDIF
-IF[{- $config{target} =~ /^vms-/ -}]
-  $AUXLIBAPPSSRC=../apps/lib/vms_term_sock.c ../apps/lib/vms_decc_argv.c
-ENDIF
-$LIBAPPSSRC=../apps/lib/opt.c $AUXLIBAPPSSRC
-
 IF[{- !$disabled{tests} -}]
   LIBS{noinst,has_main}=libtestutil.a
   SOURCE[libtestutil.a]=testutil/basic_output.c testutil/output.c \
@@ -21,9 +5,9 @@ IF[{- !$disabled{tests} -}]
           testutil/format_output.c testutil/load.c testutil/fake_random.c \
           testutil/test_cleanup.c testutil/main.c testutil/testutil_init.c \
           testutil/options.c testutil/test_options.c testutil/provider.c \
-          testutil/apps_mem.c testutil/random.c $LIBAPPSSRC
+          testutil/apps_mem.c testutil/random.c
   INCLUDE[libtestutil.a]=../include ../apps/include ..
-  DEPEND[libtestutil.a]=../libcrypto
+  DEPEND[libtestutil.a]=../apps/libapps.a ../libcrypto
 
   PROGRAMS{noinst}= \
           confdump \
@@ -831,9 +815,9 @@ IF[{- !$disabled{tests} -}]
   DEPEND[namemap_internal_test]=../libcrypto.a libtestutil.a
 
   PROGRAMS{noinst}=bio_prefix_text
-  SOURCE[bio_prefix_text]=bio_prefix_text.c $LIBAPPSSRC
+  SOURCE[bio_prefix_text]=bio_prefix_text.c
   INCLUDE[bio_prefix_text]=.. ../include ../apps/include
-  DEPEND[bio_prefix_text]=../libcrypto
+  DEPEND[bio_prefix_text]=../apps/libapps.a
 
   IF[{- !$disabled{'deprecated-3.0'} -}]
     PROGRAMS{noinst}=pem_read_depr_test

--- a/test/build.info
+++ b/test/build.info
@@ -817,7 +817,7 @@ IF[{- !$disabled{tests} -}]
   PROGRAMS{noinst}=bio_prefix_text
   SOURCE[bio_prefix_text]=bio_prefix_text.c
   INCLUDE[bio_prefix_text]=.. ../include ../apps/include
-  DEPEND[bio_prefix_text]=../apps/libapps.a
+  DEPEND[bio_prefix_text]=../apps/libapps.a ../libcrypto
 
   IF[{- !$disabled{'deprecated-3.0'} -}]
     PROGRAMS{noinst}=pem_read_depr_test

--- a/test/testutil/testutil_init.c
+++ b/test/testutil/testutil_init.c
@@ -10,7 +10,6 @@
 #include <string.h>
 #include <openssl/opensslconf.h>
 #include <openssl/trace.h>
-#include "apps.h"
 #include "../testutil.h"
 
 #ifndef OPENSSL_NO_TRACE


### PR DESCRIPTION
Break out app_malloc(), app_bail_out() and the apps bio routines from apps/lib/apps.c, so they can be used individually without sucking in everything else that's in apps/lib/apps.c (which is too much for some of the test programs)

Clean up test/build.info, which was selecting specific libapps sources instead of just using libapps.a and letting the linker do its job.