### PR TITLE
FIPS label CI: Save PR number and use it

### DIFF
--- a/.github/workflows/fips-checksums.yml
+++ b/.github/workflows/fips-checksums.yml
@@ -16,8 +16,7 @@ jobs:
         run: |
           mkdir ./build-pristine
           mkdir ./build
-          mkdir ./empty
-          touch ./empty/placeholder
+          mkdir ./artifact
       - name: config pristine
         run: ../config enable-fips && perl configdata.pm --dump
         working-directory: ./build-pristine
@@ -44,17 +43,12 @@ jobs:
         run: touch providers/fips.checksum.new && make update-fips-checksums
         working-directory: ./build-pristine
       - name: make diff-fips-checksums
-        run: make diff-fips-checksums && echo "fips_unchanged=1" >> $GITHUB_ENV || echo "fips_changed=1" >> $GITHUB_ENV
+        run: make diff-fips-checksums && touch ../artifact/fips_unchanged || ( touch ../artifact/fips_changed ; echo FIPS CHANGED )
         working-directory: ./build
-      - name: save artifact fips_changed
-        if: ${{ env.fips_changed }}
+      - name: save PR number
+        run: echo ${{ github.event.number }} > ./artifact/pr_num
+      - name: save artifact
         uses: actions/upload-artifact@v2
         with:
-          name: fips_changed
-          path: empty/
-      - name: save artifact fips_unchanged
-        if: ${{ env.fips_unchanged }}
-        uses: actions/upload-artifact@v2
-        with:
-          name: fips_unchanged
-          path: empty/
+          name: fips_checksum
+          path: artifact/

--- a/.github/workflows/fips-label.yml
+++ b/.github/workflows/fips-label.yml
@@ -10,27 +10,47 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.event == 'pull_request' }}
     steps:
+      - name: 'Download artifact'
+        if: ${{ github.event.workflow_run.conclusion == 'success' }}
+        uses: actions/github-script@v4
+        with:
+          script: |
+            var artifacts = await github.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: ${{github.event.workflow_run.id }},
+            });
+            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "fips_checksum"
+            })[0];
+            var download = await github.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            var fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/artifact.zip', Buffer.from(download.data));
+      - run: unzip artifact.zip
+        if: ${{ github.event.workflow_run.conclusion == 'success' }}
       - name: 'Check artifact and apply'
         if: ${{ github.event.workflow_run.conclusion == 'success' }}
         uses: actions/github-script@v4
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            var artifacts = await github.actions.listWorkflowRunArtifacts({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              run_id: ${{ github.event.workflow_run.id }}
-            });
-            if ( artifacts.data.artifacts[0].name == 'fips_changed' ) {
+            var fs = require('fs');
+            var pr_num = Number(fs.readFileSync('./pr_num'));
+            if ( fs.existsSync('./fips_changed') ) {
               github.issues.addLabels({
-                issue_number: ${{ github.event.workflow_run.pull_requests[0].number }},
+                issue_number: pr_num,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 labels: ['severity: fips change']
               });
-            } else if ( artifacts.data.artifacts[0].name == 'fips_unchanged' ) {
+            } else if ( fs.existsSync('./fips_unchanged') ) {
               var labels = await github.issues.listLabelsOnIssue({
-                issue_number: ${{ github.event.workflow_run.pull_requests[0].number }},
+                issue_number: pr_num,
                 owner: context.repo.owner,
                 repo: context.repo.repo
               });
@@ -38,7 +58,7 @@ jobs:
               for ( var label in labels.data ) {
                 if (labels.data[label].name == 'severity: fips change') {
                   github.issues.removeLabel({
-                    issue_number: ${{ github.event.workflow_run.pull_requests[0].number }},
+                    issue_number: pr_num,
                     owner: context.repo.owner,
                     repo: context.repo.repo,
                     name: 'severity: fips change'


### PR DESCRIPTION
This is a workaround for the current problem with FIPS Label CI job. The PR number has to be saved into an artifact and used from there. Of course this in theory allows maliciously changing the 'severity: fips change' label on other PRs but that would not provide the attacker any real gain. And we have to approve CI runs for first time contributors anyway.
