### PR TITLE
80-test_cms.t: Disable new tests for binary input in Windows

### DIFF
--- a/test/recipes/80-test_cms.t
+++ b/test/recipes/80-test_cms.t
@@ -818,6 +818,7 @@ subtest "CMS binary input tests\n" => sub {
     my $cert = srctop_file("test", "certs", "ee-self-signed.pem");
     my $key = srctop_file("test", "certs", "ee-key.pem");
 
+    plan skip_all => "Binary input tests currently disabled on Windows" if $^O =~ /^MSWin32$/;
     plan tests => 11;
 
     ok(run(app(["openssl", "cms", "-sign", "-md", "sha256",


### PR DESCRIPTION
This is a quick workaround for #15347.

- [x] tests are added or updated
