### PR TITLE
Minor additions to EVP_DigestSignInit.pod and BIO_s_accept.pod

### DIFF
--- a/doc/man3/BIO_s_accept.pod
+++ b/doc/man3/BIO_s_accept.pod
@@ -77,6 +77,8 @@ port.  "port" has the same syntax as the port specified in
 BIO_set_conn_port() for connect BIOs, that is it can be a numerical
 port string or a string to lookup using getservbyname() and a string
 table.
+If the given port is C<0> then a random available port is chosen.
+It may be queried using BIO_sock_info() and L<BIO_ADDR_service_string(3)>.
 
 BIO_new_accept() combines BIO_new() and BIO_set_accept_name() into
 a single call: that is it creates a new accept BIO with port

--- a/doc/man3/EVP_DigestSignInit.pod
+++ b/doc/man3/EVP_DigestSignInit.pod
@@ -118,7 +118,8 @@ EVP_DigestSignUpdate() hashes I<cnt> bytes of data at I<d> into the
 signature context I<ctx>. This function can be called several times on the
 same I<ctx> to include additional data.
 
-EVP_DigestSignFinal() signs the data in I<ctx> and places the signature in I<sig>.
+EVP_DigestSignFinal() can be used to query the maximum size of the signature
+or to actually sign the data in I<ctx> and places the signature in I<sig>.
 If I<sig> is NULL then the maximum size of the output buffer is written to
 the I<siglen> parameter. If I<sig> is not NULL then before the call the
 I<siglen> parameter should contain the length of the I<sig> buffer. If the

--- a/doc/man3/EVP_DigestSignInit.pod
+++ b/doc/man3/EVP_DigestSignInit.pod
@@ -118,9 +118,9 @@ EVP_DigestSignUpdate() hashes I<cnt> bytes of data at I<d> into the
 signature context I<ctx>. This function can be called several times on the
 same I<ctx> to include additional data.
 
-EVP_DigestSignFinal() can be used to query the maximum size of the signature
-or to actually sign the data in I<ctx> and places the signature in I<sig>.
-If I<sig> is NULL then the maximum size of the output buffer is written to
+Unless I<sig> is NULL EVP_DigestSignFinal() signs the data in I<ctx>
+and places the signature in I<sig>.
+Otherwise the maximum necessary size of the output buffer is written to
 the I<siglen> parameter. If I<sig> is not NULL then before the call the
 I<siglen> parameter should contain the length of the I<sig> buffer. If the
 call is successful the signature is written to I<sig> and the amount of data


### PR DESCRIPTION
* `BIO_s_accept.pod:` Document port auto-selection feature of `BIO_set_accept_port()`
  motivated by https://github.com/openssl/openssl/pull/15281#discussion_r632460444
* `EVP_DigestSignInit.pod:` Clarification in `EVP_DigestSignFinal()` parameter '`sig`'
  motivated by https://github.com/openssl/openssl/pull/12095#discussion_r635261951


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated

