### PR TITLE
Fix upgrading docs for RSA_private_encrypt/RSA_public_decrypt

### DIFF
--- a/doc/man3/RSA_private_encrypt.pod
+++ b/doc/man3/RSA_private_encrypt.pod
@@ -21,9 +21,9 @@ L<openssl_user_macros(7)>:
 =head1 DESCRIPTION
 
 Both of the functions described on this page are deprecated.
-Applications should instead use L<EVP_PKEY_encrypt_init_ex(3)>,
-L<EVP_PKEY_encrypt(3)>, L<EVP_PKEY_decrypt_init_ex(3)> and
-L<EVP_PKEY_decrypt(3)>.
+Applications should instead use L<EVP_PKEY_sign_init_ex(3)>,
+L<EVP_PKEY_sign(3)>, L<EVP_PKEY_verify_init_ex(3)> and
+L<EVP_PKEY_verify(3)>.
 
 These functions handle RSA signatures at a low-level.
 


### PR DESCRIPTION
Despite the name, these functions manipulate signatures, which means
that their replacements are the EVP_PKEY_sign/EVP_PKEY_verify family.

Signed-off-by: Robbie Harwood <rharwood@redhat.com>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
