### PR TITLE
apps/openssl: make index.txt errors more verbose

### DIFF
--- a/apps/ca.c
+++ b/apps/ca.c
@@ -544,8 +544,10 @@ end_of_options:
             goto end;
 
         db = load_index(dbfile, &db_attr);
-        if (db == NULL)
+        if (db == NULL) {
+            BIO_printf(bio_err, "Problem with index file: %s (could not load/parse file)\n", dbfile);
             goto end;
+        }
 
         if (index_index(db) <= 0)
             goto end;
@@ -673,8 +675,10 @@ end_of_options:
         goto end;
 
     db = load_index(dbfile, &db_attr);
-    if (db == NULL)
+    if (db == NULL) {
+        BIO_printf(bio_err, "Problem with index file: %s (could not load/parse file)\n", dbfile);
         goto end;
+    }
 
     /* Lets check some fields */
     for (i = 0; i < sk_OPENSSL_PSTRING_num(db->db->data); i++) {

--- a/apps/ocsp.c
+++ b/apps/ocsp.c
@@ -623,6 +623,9 @@ int ocsp_main(int argc, char **argv)
     if (ridx_filename != NULL) {
         rdb = load_index(ridx_filename, NULL);
         if (rdb == NULL || index_index(rdb) <= 0) {
+            BIO_printf(bio_err,
+                "Problem with index file: %s (could not load/parse file)\n",
+                ridx_filename);
             ret = 1;
             goto end;
         }

--- a/apps/srp.c
+++ b/apps/srp.c
@@ -372,8 +372,10 @@ int srp_main(int argc, char **argv)
                    srpvfile);
 
     db = load_index(srpvfile, NULL);
-    if (db == NULL)
+    if (db == NULL) {
+        BIO_printf(bio_err, "Problem with index file: %s (could not load/parse file)\n", srpvfile);
         goto end;
+    }
 
     /* Lets check some fields */
     for (i = 0; i < sk_OPENSSL_PSTRING_num(db->db->data); i++) {


### PR DESCRIPTION
openssl ca was  a little bit too silent, when it couldnt parse index.txt ... 


steps to reproduce: create index.txt with 
 > echo "" > index.txt

which creates 

> hexdump index.txt
0000000 000a                                   
0000001


-> a "trivial" change, tested with openssl ca to sign a csr
-> the ocsp and svr changes were only compile tested by me, but seemed to make sense. ?

#### History:

- Earlier Pull Request with erronous "CLA:Trivial Line": https://github.com/openssl/openssl/pull/10818  
  - Sadly i used the master branch for that earlier one, which i force pushed to in order to update and rebase to current master. 
  - This time I used a separate branch which I will not mess about with. 
  - I removed the CLA:Trivial line from them and send in an ICLA.


<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

@paulidale @t8m 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->