### PR TITLE
VMS: don't use app_malloc() in apps/lib/vms_decc_argv.c

### DIFF
--- a/apps/lib/vms_decc_argv.c
+++ b/apps/lib/vms_decc_argv.c
@@ -55,7 +55,7 @@ char **copy_argv(int *argc, char *argv[])
      * symbol name clashes in test programs that would otherwise get them
      * when linking with all of libapps.a.  See comment in test/build.info.
      */
-    newargv = malloc(sizeof(*newargv) * (count + 1), "argv copy");
+    newargv = OPENSSL_malloc(sizeof(*newargv) * (count + 1));
     if (newargv == NULL)
         return NULL;
 

--- a/apps/lib/vms_decc_argv.c
+++ b/apps/lib/vms_decc_argv.c
@@ -10,7 +10,6 @@
 #include <stdlib.h>
 #include <openssl/crypto.h>
 #include "platform.h"            /* for copy_argv() */
-#include "apps.h"                /* for app_malloc() */
 
 char **newargv = NULL;
 
@@ -51,7 +50,12 @@ char **copy_argv(int *argc, char *argv[])
 
     cleanup_argv();
 
-    newargv = app_malloc(sizeof(*newargv) * (count + 1), "argv copy");
+    /*
+     * We purposefully use malloc() rather than app_malloc() here, to avoid
+     * symbol name clashes in test programs that would otherwise get them
+     * when linking with all of libapps.a.  See comment in test/build.info.
+     */
+    newargv = malloc(sizeof(*newargv) * (count + 1), "argv copy");
     if (newargv == NULL)
         return NULL;
 

--- a/apps/lib/vms_decc_argv.c
+++ b/apps/lib/vms_decc_argv.c
@@ -51,9 +51,10 @@ char **copy_argv(int *argc, char *argv[])
     cleanup_argv();
 
     /*
-     * We purposefully use malloc() rather than app_malloc() here, to avoid
-     * symbol name clashes in test programs that would otherwise get them
-     * when linking with all of libapps.a.  See comment in test/build.info.
+     * We purposefully use OPENSSL_malloc() rather than app_malloc() here,
+     * to avoid symbol name clashes in test programs that would otherwise
+     * get them when linking with all of libapps.a.
+     * See comment in test/build.info.
      */
     newargv = OPENSSL_malloc(sizeof(*newargv) * (count + 1));
     if (newargv == NULL)


### PR DESCRIPTION
The reason being that it would otherwise force test programs to link
with all of libapps.a, which unfortunately causes multiple symbol
definition issues.

The quick and dirty fix is to use malloc() instead of app_malloc() in
apps/lib/vms_decc_argv.c, and clean up libapps.a later.

-----

This is a quick'n'dirty alternative to #15342 