### PR TITLE
Refer to the migration guide rather than the wiki in our announcements

### DIFF
--- a/dev/release-aux/openssl-announce-pre-release.tmpl
+++ b/dev/release-aux/openssl-announce-pre-release.tmpl
@@ -12,10 +12,10 @@
    Note: This OpenSSL pre-release has been provided for testing ONLY.
    It should NOT be used for security critical purposes.
 
-   Specific notes on upgrading to OpenSSL $series from previous versions, as well
-   as known issues are available on the OpenSSL Wiki, here:
+   Specific notes on upgrading to OpenSSL $series from previous versions are
+   available in the OpenSSL Migration Guide, here:
 
-        https://wiki.openssl.org/index.php/OpenSSL_$series
+        https://www.openssl.org/docs/manmaster/man7/migration_guide.html
 
    The $label release is available for download via HTTPS and FTP from the
    following master locations (you can find the various FTP mirrors under

--- a/dev/release-aux/openssl-announce-release.tmpl
+++ b/dev/release-aux/openssl-announce-release.tmpl
@@ -11,10 +11,10 @@
 
         https://www.openssl.org/news/openssl-$series-notes.html
 
-   Specific notes on upgrading to OpenSSL $series from previous versions, as well
-   as known issues are available on the OpenSSL Wiki, here:
+   Specific notes on upgrading to OpenSSL $series from previous versions are
+   available in the OpenSSL Migration Guide, here:
 
-        https://wiki.openssl.org/index.php/OpenSSL_$series
+        https://www.openssl.org/docs/man$series/man7/migration_guide.html
 
    OpenSSL $release is available for download via HTTPS and FTP from the
    following master locations (you can find the various FTP mirrors under


### PR DESCRIPTION
We now have a migration guide which should be the definitive source of
information for upgrading from a previous version of OpenSSL.

Fixes #15186

I consider this urgent since it affects the release announcement text that will be used for today's release.
