### PR TITLE
Fix warning in gf_serialize

### DIFF
--- a/crypto/ec/curve448/f_generic.c
+++ b/crypto/ec/curve448/f_generic.c
@@ -18,7 +18,7 @@ static const gf MODULUS = {
 };
 
 /* Serialize to wire format. */
-void gf_serialize(uint8_t serial[SER_BYTES], const gf x, int with_hibit)
+void gf_serialize(uint8_t *serial, const gf x, int with_hibit)
 {
     unsigned int j = 0, fill = 0;
     dword_t buffer = 0;


### PR DESCRIPTION
Compiling under -Werror fails in gf_serialize:

```
crypto/ec/curve448/f_generic.c:21:27: error: argument 1 of type 'uint8_t[56]' {aka 'unsigned char[56]'} with mismatched bound [-Werror=array-parameter=]
   21 | void gf_serialize(uint8_t serial[SER_BYTES], const gf x, int with_hibit)
      |                   ~~~~~~~~^~~~~~~~~~~~~~~~~
In file included from crypto/ec/curve448/f_generic.c:12:
crypto/ec/curve448/field.h:65:28: note: previously declared as 'uint8_t *' {aka 'unsigned char *'}
void gf_serialize(uint8_t *serial, const gf x, int with_highbit);
                  ~~~~~~~~~^~~~~~
```

Changed parameter to pointer to fix this warning.

Signed-off-by: Juergen Christ <jchrist@linux.ibm.com>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
