### PR TITLE
DOCS: Fixups of the migration guide and the FIPS module manual

### DIFF
--- a/doc/man7/fips_module.pod
+++ b/doc/man7/fips_module.pod
@@ -14,17 +14,29 @@ This guide details different ways that OpenSSL can be used in conjunction
 with the FIPS module. Which is the correct approach to use will depend on your
 own specific circumstances and what you are attempting to achieve.
 
-Note that the old functions 'FIPS_mode()` and `FIPS_mode_set()` are no longer
+Note that the old functions FIPS_mode() and FIPS_mode_set() are no longer
 present so you must remove them from your application if you use them.
 
 Applications written to use the OpenSSL 3.0 FIPS module should not use any
 legacy APIs or features that avoid the FIPS module. Specifically this includes:
 
-- Low level cryptographic APIs (use the high level APIs, such as EVP, instead)
-- Engines
-- Any functions that create or modify custom "METHODS" (for example
-`EVP_MD_meth_new`, `EVP_CIPHER_meth_new`, `EVP_PKEY_meth_new`, `RSA_meth_new`,
-`EC_KEY_METHOD_new`, etc.)
+=over 4
+
+=item -
+
+Low level cryptographic APIs (use the high level APIs, such as EVP, instead)
+
+=item -
+
+Engines
+
+=item -
+
+Any functions that create or modify custom "METHODS" (for example
+EVP_MD_meth_new(), EVP_CIPHER_meth_new(), EVP_PKEY_meth_new(), RSA_meth_new(),
+EC_KEY_METHOD_new(), etc.)
+
+=back
 
 All of the above APIs are deprecated in OpenSSL 3.0 - so a simple rule is to
 avoid using all deprecated functions. See L<migration_guide(7)> for a list of
@@ -55,9 +67,9 @@ running an OpenSSL 3.0 version like this:
     $ openssl version -v
     OpenSSL 3.0.0-dev xx XXX xxxx (Library: OpenSSL 3.0.0-dev xx XXX xxxx)
 
-The OPENSSLDIR value above gives the directory name for where the default config
-file is stored. So in this case the default config file will be called
-`/usr/local/ssl/openssl.cnf`
+The B<OPENSSLDIR> value above gives the directory name for where the default
+config file is stored. So in this case the default config file will be called
+F</usr/local/ssl/openssl.cnf>.
 
 Edit the config file to add the following lines near the beginning:
 
@@ -93,23 +105,31 @@ some disadvantages to this approach:
 
 =over 4
 
-=item You may not want all applications to use the FIPS module.
+=item -
+
+You may not want all applications to use the FIPS module.
 
 It may be the case that some applications should and some should not use the
 FIPS module.
 
-=item If applications take explicit steps to not load the default config file or
+=item -
+
+If applications take explicit steps to not load the default config file or
 set different settings.
 
 This method will not work for these cases.
 
-=item The algorithms available in the FIPS module are a subset of the algorithms
+=item -
+
+The algorithms available in the FIPS module are a subset of the algorithms
 that are available in the default OpenSSL Provider.
 
 If any applications attempt to use any algorithms that are not present,
 then they will fail.
 
--=item Usage of certain deprecated APIs avoids the use of the FIPS module.
+=item -
+
+Usage of certain deprecated APIs avoids the use of the FIPS module.
 
 If any applications use those APIs then the FIPS module will not be used.
 
@@ -119,8 +139,8 @@ If any applications use those APIs then the FIPS module will not be used.
 
 A variation on the above approach is to do the same thing on an individual
 application basis. The default OpenSSL config file depends on the compiled in
-value for OPENSSLDIR as described in the section above. However it is also
-possible to override the config file to be used via the `OPENSSL_CONF`
+value for B<OPENSSLDIR> as described in the section above. However it is also
+possible to override the config file to be used via the B<OPENSSL_CONF>
 environment variable. For example the following, on Unix, will cause the
 application to be executed with a non-standard config file location:
 
@@ -143,8 +163,8 @@ file.
 
 To do things this way configure as per
 L</Making all applications use the FIPS module by default> above, but edit the
-`fipsmodule.cnf` file to remove or comment out the line which says
-`activate = 1` (note that setting this value to 0 is I<not> sufficient).
+F<fipsmodule.cnf> file to remove or comment out the line which says
+C<activate = 1> (note that setting this value to 0 is I<not> sufficient).
 This means all the required config information will be available to load the
 FIPS module, but it is not automatically loaded when the application starts. The
 FIPS provider can then be loaded programmatically like this:
@@ -205,7 +225,7 @@ can use a property query string during algorithm fetches to specify which
 implementation you would like to use.
 
 For example to fetch an implementation of SHA256 which conforms to FIPS
-standards you can specify the property query `fips=yes` like this:
+standards you can specify the property query C<fips=yes> like this:
 
     EVP_MD *sha256;
 
@@ -223,8 +243,8 @@ default provider:
     sha256 = EVP_MD_fetch(NULL, "SHA2-256", "provider=default");
 
 It is also possible to set a default property query string. The following
-example sets the default property query of "fips=yes" for all fetches within the
-default library context:
+example sets the default property query of C<fips=yes> for all fetches within
+the default library context:
 
     EVP_set_default_properties(NULL, "fips=yes");
 
@@ -236,12 +256,12 @@ same property name is specified in both.
 There are two important built-in properties that you should be aware of:
 
 The "provider" property enables you to specify which provider you want an
-implementation to be fetched from, e.g. `provider=default` or `provider=fips`.
+implementation to be fetched from, e.g. C<provider=default> or C<provider=fips>.
 All algorithms implemented in a provider have this property set on them.
 
-There is also the `fips` property. All FIPS algorithms match against the
-property query `fips=yes`. There are also some non-cryptographic algorithms
-available in the default and base providers that also have the `fips=yes`
+There is also the C<fips> property. All FIPS algorithms match against the
+property query C<fips=yes>. There are also some non-cryptographic algorithms
+available in the default and base providers that also have the C<fips=yes>
 property defined for them. These are the encoder and decoder algorithms that
 can (for example) be used to write out a key generated in the FIPS provider to a
 file. The encoder and decoder algorithms are not in the FIPS module itself but
@@ -249,7 +269,7 @@ are allowed to be used in conjunction with the FIPS algorithms.
 
 It is possible to specify default properties within a config file. For example
 the following config file automatically loads the default and fips providers and
-sets the default property value to be `fips=yes`. Note that this config file
+sets the default property value to be C<fips=yes>. Note that this config file
 does not load the "base" provider. All supporting algorithms that are in "base"
 are also in "default", so it is unnecessary in this case:
 
@@ -276,7 +296,7 @@ are also in "default", so it is unnecessary in this case:
 In addition to using properties to separate usage of the FIPS module from other
 usages this can also be achieved using library contexts. In this example we
 create two library contexts. In one we assume the existence of a config file
-called "openssl-fips.cnf" that automatically loads and configures the FIPS and
+called F<openssl-fips.cnf> that automatically loads and configures the FIPS and
 base providers. The other library context will just use the default provider.
 
     OSSL_LIB_CTX *fips_libctx, *nonfips_libctx;
@@ -285,8 +305,8 @@ base providers. The other library context will just use the default provider.
     int ret = 1;
 
     /*
-     * Create two nondefault library contexts. One for fips usage and one for
-     * non-fips usage
+     * Create two nondefault library contexts. One for fips usage and
+     * one for non-fips usage
      */
     fips_libctx = OSSL_LIB_CTX_new();
     nonfips_libctx = OSSL_LIB_CTX_new();
@@ -297,17 +317,18 @@ base providers. The other library context will just use the default provider.
     defctxnull = OSSL_PROVIDER_load(NULL, "null");
 
     /*
-     * Load config file for the FIPS library context. We assume that this
-     * config file will automatically activate the FIPS and base providers so we
-     * don't need to explicitly load them here.
+     * Load config file for the FIPS library context. We assume that
+     * this config file will automatically activate the FIPS and base
+     * providers so we don't need to explicitly load them here.
      */
     if (!OSSL_LIB_CTX_load_config(fips_libctx, "openssl-fips.cnf"))
         goto err;
 
     /*
-     * We don't need to do anything special to load the default provider into
-     * nonfips_libctx. This happens automatically if no other providers are
-     * loaded. Because we don't call OSSL_LIB_CTX_load_config() explicitly for
+     * We don't need to do anything special to load the default
+     * provider into nonfips_libctx. This happens automatically if no
+     * other providers are loaded.
+     * Because we don't call OSSL_LIB_CTX_load_config() explicitly for
      * nonfips_libctx it will just use the default config file.
      */
 
@@ -368,7 +389,7 @@ the key or parameter object. The built-in OpenSSL encoders and decoders are
 implemented in both the default and base providers and are not in the FIPS
 module boundary. However since they are not cryptographic algorithms themselves
 it is still possible to use them in conjunction with the FIPS module, and
-therefore these encoders/decoders have the "fips=yes" property against them.
+therefore these encoders/decoders have the C<fips=yes> property against them.
 You should ensure that either the default or base provider is loaded into the
 library context in this case.
 
@@ -389,13 +410,13 @@ In this first example we create two SSL_CTX objects using two different library
 contexts.
 
     /*
-     * We assume that a nondefault library context with the FIPS provider
-     * loaded has been created called fips_libctx.
-     /
+     * We assume that a nondefault library context with the FIPS
+     * provider loaded has been created called fips_libctx.
+     */
     SSL_CTX *fips_ssl_ctx = SSL_CTX_new_ex(fips_libctx, NULL, TLS_method());
     /*
-     * We assume that a nondefault library context with the default provider
-     * loaded has been created called non_fips_libctx.
+     * We assume that a nondefault library context with the default
+     * provider loaded has been created called non_fips_libctx.
      */
     SSL_CTX *non_fips_ssl_ctx = SSL_CTX_new_ex(non_fips_libctx, NULL,
                                                TLS_method());
@@ -404,14 +425,15 @@ In this second example we create two SSL_CTX objects using different properties
 to specify FIPS usage:
 
     /*
-     * The "fips=yes" property includes all FIPS approved algorithms as well as
-     * encoders from the default provider that are allowed to be used. The NULL
-     * below indicates that we are using the default library context.
+     * The "fips=yes" property includes all FIPS approved algorithms
+     * as well as encoders from the default provider that are allowed
+     * to be used. The NULL below indicates that we are using the
+     * default library context.
      */
     SSL_CTX *fips_ssl_ctx = SSL_CTX_new_ex(NULL, "fips=yes", TLS_method());
     /*
-     * The "provider!=fips" property allows algorithms from any provider except
-     * the FIPS provider
+     * The "provider!=fips" property allows algorithms from any
+     * provider except the FIPS provider
      */
     SSL_CTX *non_fips_ssl_ctx = SSL_CTX_new_ex(NULL, "provider!=fips",
                                                TLS_method());

--- a/doc/man7/migration_guide.pod
+++ b/doc/man7/migration_guide.pod
@@ -16,7 +16,7 @@ L<https://github.com/openssl/openssl/blob/master/CHANGES.md>.
 For an overview of some of the key concepts introduced in OpenSSL 3.0 see
 L<crypto(7)>.
 
-=head1 OPENSSL 3_0
+=head1 OPENSSL 3.0
 
 =head2 Main Changes from OpenSSL 1.1.1
 
@@ -47,15 +47,16 @@ config file, which providers you want to use for any given application.
 OpenSSL 3.0 comes with 5 different providers as standard. Over time third
 parties may distribute additional providers that can be plugged into OpenSSL.
 All algorithm implementations available via providers are accessed through the
-"high level" APIs (for example those functions prefixed with "EVP"). They cannot
+"high level" APIs (for example those functions prefixed with C<EVP>). They cannot
 be accessed using the L</Low Level APIs>.
+
 One of the standard providers available is the FIPS provider. This makes
 available FIPS validated cryptographic algorithms.
 The FIPS provider is disabled by default and needs to be enabled explicitly
-at configuration time using the `enable-fips` option. If it is enabled,
+at configuration time using the C<enable-fips> option. If it is enabled,
 the FIPS provider gets built and installed in addition to the other standard
 providers. No separate installation procedure is necessary.
-There is however a dedicated `install_fips` make target, which serves the
+There is however a dedicated C<install_fips> make target, which serves the
 special purpose of installing only the FIPS provider into an existing
 OpenSSL installation.
 
@@ -67,7 +68,7 @@ L</Using the FIPS Module in applications>.
 =head3 Low Level APIs
 
 OpenSSL has historically provided two sets of APIs for invoking cryptographic
-algorithms: the "high level" APIs (such as the "EVP" APIs) and the "low level"
+algorithms: the "high level" APIs (such as the C<EVP> APIs) and the "low level"
 APIs. The high level APIs are typically designed to work across all algorithm
 types. The "low level" APIs are targeted at a specific algorithm implementation.
 For example, the EVP APIs provide the functions L<EVP_EncryptInit_ex(3)>,
@@ -128,6 +129,8 @@ change in the second (MINOR) number indicates that new features may have been
 added. OpenSSL versions with the same major number are API and ABI compatible.
 If the major number changes then API and ABI compatibility is not guaranteed. 
 
+For more information, see L<OpenSSL_version(3)>.
+
 =head3 Other major new features
 
 =head4 Certificate Management Protocol (CMP, RFC 4210)
@@ -167,31 +170,41 @@ and L<OSSL_PROVIDER-FIPS(7)/Message Authentication Code (MAC)>.
 
 =head4 Support for Linux Kernel TLS
 
-In order to use KTLS, support for it must be compiled in using the 'enable-ktls'
-compile time option. It must also be enabled at run time using the
-B<SSL_OP_ENABLE_KTLS> option.
+In order to use KTLS, support for it must be compiled in using the
+C<enable-ktls> configuration option. It must also be enabled at run time using
+the B<SSL_OP_ENABLE_KTLS> option.
 
 =head4 New Algorithms
 
 =over 4
 
-=item KDF algorithms "SINGLE STEP" and "SSH"
+=item -
+
+KDF algorithms "SINGLE STEP" and "SSH"
 
 See L<EVP_KDF-SS(7)> and L<EVP_KDF-SSHKDF(7)>
 
-=item MAC Algorithms "GMAC" and "KMAC"
+=item -
+
+MAC Algorithms "GMAC" and "KMAC"
 
 See L<EVP_MAC-GMAC(7)> and L<EVP_MAC-KMAC(7)>.
 
-=item KEM Algorithm "RSASVE"
+=item -
+
+KEM Algorithm "RSASVE"
 
 See L<EVP_KEM-RSA(7)>.
 
-=item Cipher Algorithm "AES-SIV"
+=item -
+
+Cipher Algorithm "AES-SIV"
 
 See L<EVP_EncryptInit(3)/SIV Mode>.
 
-=item AES Key Wrap inverse ciphers supported by EVP layer.
+=item -
+
+AES Key Wrap inverse ciphers supported by EVP layer.
 
 The inverse ciphers use AES decryption for wrapping, and AES encryption for
 unwrapping. The algorithms are: "AES-128-WRAP-INV", "AES-192-WRAP-INV",
@@ -209,17 +222,25 @@ CS1, CS2 and CS3 variants are supported.
 
 =over 4
 
-=item Added CAdES-BES signature verification support.
+=item -
 
-=item Added CAdES-BES signature scheme and attributes support (RFC 5126) to CMS API.
+Added CAdES-BES signature verification support.
 
-=item Added AuthEnvelopedData content type structure (RFC 5083) using AES_GCM
+=item -
+
+Added CAdES-BES signature scheme and attributes support (RFC 5126) to CMS API.
+
+=item -
+
+Added AuthEnvelopedData content type structure (RFC 5083) using AES_GCM
 
 This uses the AES-GCM parameter (RFC 5084) for the Cryptographic Message Syntax.
 Its purpose is to support encryption and decryption of a digital envelope that
 is both authenticated and encrypted using AES GCM mode.
 
-=item L<PKCS7_get_octet_string(3)> and L<PKCS7_type_is_other(3)> were made public.
+=item -
+
+L<PKCS7_get_octet_string(3)> and L<PKCS7_type_is_other(3)> were made public.
 
 =back
 
@@ -233,7 +254,7 @@ algorithm for the MAC computation was changed to SHA-256. The pkcs12
 application now supports -legacy option that restores the previous
 default algorithms to support interoperability with legacy systems.
 
-Added enhanced PKCS#12 APIs which accept a library context `OSSL_LIB_CTX`
+Added enhanced PKCS#12 APIs which accept a library context B<OSSL_LIB_CTX>
 and (where relevant) a property query. Other APIs which handle PKCS#7 and
 PKCS#8 objects have also been enhanced where required. This includes:
 
@@ -262,7 +283,7 @@ supported by the OS, otherwise CriticalSection continues to be used.
 A new generic trace API has been added which provides support for enabling
 instrumentation through trace output. This feature is mainly intended as an aid
 for developers and is disabled by default. To utilize it, OpenSSL needs to be
-configured with the `enable-trace` option.
+configured with the C<enable-trace> option.
 
 If the tracing API is enabled, the application can activate trace output by
 registering BIOs as trace channels for a number of tracing and debugging
@@ -281,7 +302,7 @@ parameters then L<EVP_PKEY_param_check(3)> will always return 1.
 
 This code is now always set to zero. Related functions are deprecated.
 
-=head4 STACK and HASH macro's have been cleaned up
+=head4 STACK and HASH macros have been cleaned up
 
 The type-safe wrappers are declared everywhere and implemented once.
 See L<DEFINE_STACK_OF(3)> and L<DECLARE_LHASH_OF(3)>.
@@ -329,7 +350,7 @@ EC EVP_PKEYs with the SM2 curve have been reworked to automatically become
 EVP_PKEY_SM2 rather than EVP_PKEY_EC.
 
 Unlike in previous OpenSSL versions, this means that applications cannot
-call `EVP_PKEY_set_alias_type(pkey, EVP_PKEY_SM2)` to get SM2 computations.
+call C<EVP_PKEY_set_alias_type(pkey, EVP_PKEY_SM2)> to get SM2 computations.
 
 Parameter and key generation is also reworked to make it possible
 to generate EVP_PKEY_SM2 parameters and keys. Applications must now generate
@@ -384,12 +405,12 @@ To disable this check use EVP_PKEY_derive_set_peer_ex(dh, peer, 0).
 The output from numerous "printing" functions such as L<X509_signature_print(3)>,
 L<X509_print_ex(3)>, L<X509_CRL_print_ex(3)>, and other similar functions has been
 amended such that there may be cosmetic differences between the output
-observed in 1.1.1 and 3.0. This also applies to the "-text" output from the
-x509 and crl applications.
+observed in 1.1.1 and 3.0. This also applies to the B<-text> output from the
+B<openssl x509> and B<openssl crl> applications.
 
-=head4 Interactive mode from the `openssl` program has been removed
+=head4 Interactive mode from the B<openssl> program has been removed
 
-From now on, running it without arguments is equivalent to `openssl help`.
+From now on, running it without arguments is equivalent to B<openssl help>.
 
 =head4 The error return values from some control calls (ctrl) have changed
 
@@ -418,11 +439,17 @@ application. If this happens you have 3 options:
 
 =over 4
 
-=item 1) Ignore the warnings. They are just warnings. The deprecated functions are still present and you may still use them. However be aware that they may be removed from a future version of OpenSSL.
+=item 1)
 
-=item 2) Suppress the warnings. Refer to your compiler documentation on how to do this.
+Ignore the warnings. They are just warnings. The deprecated functions are still present and you may still use them. However be aware that they may be removed from a future version of OpenSSL.
 
-=item 3) Remove your usage of the low level APIs. In this case you will need to rewrite your code to use the high level APIs instead
+=item 2)
+
+Suppress the warnings. Refer to your compiler documentation on how to do this.
+
+=item 3)
+
+Remove your usage of the low level APIs. In this case you will need to rewrite your code to use the high level APIs instead
 
 =back
 
@@ -434,18 +461,22 @@ L</Upgrading from OpenSSL 1.1.1>, the main things to be aware of are:
 
 =over 4
 
-=item 1) The build and installation procedure has changed significantly.
+=item 1)
+
+The build and installation procedure has changed significantly.
 
 Check the file INSTALL.md in the top of the installation for instructions on how
 to build and install OpenSSL for your platform. Also read the various NOTES
 files in the same directory, as applicable for your platform.
 
-=item 2) Many structures have been made opaque in OpenSSL 3.0.
+=item 2)
+
+Many structures have been made opaque in OpenSSL 3.0.
 
 The structure definitions have been removed from the public header files and
 moved to internal header files. In practice this means that you can no longer
 stack allocate some structures. Instead they must be heap allocated through some
-function call (typically those function names have a `_new` suffix to them).
+function call (typically those function names have a C<_new> suffix to them).
 Additionally you must use "setter" or "getter" functions to access the fields
 within those structures.
 
@@ -464,7 +495,9 @@ For example code that previously looked like this:
  ...
  EVP_MD_CTX_free(md_ctx);
 
-=item 3) Support for TLSv1.3 has been added.
+=item 3)
+
+Support for TLSv1.3 has been added.
 
 This has a number of implications for SSL/TLS applications. See the 
 L<TLS1.3 page|https://wiki.openssl.org/index.php/TLS1.3> for further details.
@@ -483,7 +516,7 @@ In OpenSSL 3.0 the FIPS support is fully integrated into the mainline version of
 OpenSSL and is no longer a separate download. For further information see
 L</Completing the installation of the FIPS Module>.
 
-The function calls 'FIPS_mode()' and 'FIPS_mode_set()' have been removed
+The function calls FIPS_mode() and FIPS_mode_set() have been removed
 from OpenSSL 3.0. You should rewrite your application to not use them.
 See L<fips_module(7)> and L<OSSL_PROVIDER-FIPS(7)> for details.
 
@@ -534,93 +567,165 @@ mappings are listed along with the respective name.
 
 =over 4
 
-=item L<ASN1_item_sign(3)> and L<ASN1_item_verify(3)>
+=item -
 
-=item L<BN_CTX_new(3)> and L<BN_CTX_secure_new(3)>
+L<ASN1_item_sign(3)> and L<ASN1_item_verify(3)>
 
-=item L<CMS_AuthEnvelopedData_create(3)>, L<CMS_ContentInfo_new(3)>, L<CMS_data_create(3)>,
+=item -
+
+L<BN_CTX_new(3)> and L<BN_CTX_secure_new(3)>
+
+=item -
+
+L<CMS_AuthEnvelopedData_create(3)>, L<CMS_ContentInfo_new(3)>, L<CMS_data_create(3)>,
 L<CMS_digest_create(3)>, L<CMS_EncryptedData_encrypt(3)>, L<CMS_encrypt(3)>,
 L<CMS_EnvelopedData_create(3)>, L<CMS_ReceiptRequest_create0(3)> and L<CMS_sign(3)>
 
-=item L<CONF_modules_load_file(3)>
+=item -
 
-=item L<CTLOG_new(3)>, L<CTLOG_new_from_base64(3)> and L<CTLOG_STORE_new(3)>
+L<CONF_modules_load_file(3)>
 
-=item L<CT_POLICY_EVAL_CTX_new(3)>
+=item -
 
-=item L<d2i_AutoPrivateKey(3)>, L<d2i_PrivateKey(3)> and L<d2i_PUBKEY(3)>
+L<CTLOG_new(3)>, L<CTLOG_new_from_base64(3)> and L<CTLOG_STORE_new(3)>
 
-=item L<d2i_PrivateKey_bio(3)> and L<d2i_PrivateKey_fp(3)>
+=item -
+
+L<CT_POLICY_EVAL_CTX_new(3)>
+
+=item -
+
+L<d2i_AutoPrivateKey(3)>, L<d2i_PrivateKey(3)> and L<d2i_PUBKEY(3)>
+
+=item -
+
+L<d2i_PrivateKey_bio(3)> and L<d2i_PrivateKey_fp(3)>
 
 Use L<d2i_PrivateKey_ex_bio(3)> and L<d2i_PrivateKey_ex_fp(3)>
 
-=item L<EC_GROUP_new(3)>
+=item -
+
+L<EC_GROUP_new(3)>
 
 Use L<EC_GROUP_new_by_curve_name_ex(3)> or L<EC_GROUP_new_from_params(3)>.
 
-=item L<EVP_DigestSignInit(3)> and L<EVP_DigestVerifyInit(3)>
+=item -
 
-=item L<EVP_PBE_CipherInit(3)>, L<EVP_PBE_find(3)> and L<EVP_PBE_scrypt(3)>
+L<EVP_DigestSignInit(3)> and L<EVP_DigestVerifyInit(3)>
 
-=item L<EVP_PKCS82PKEY(3)>
+=item -
 
-=item L<EVP_PKEY_CTX_new_id(3)>
+L<EVP_PBE_CipherInit(3)>, L<EVP_PBE_find(3)> and L<EVP_PBE_scrypt(3)>
+
+=item -
+
+L<EVP_PKCS82PKEY(3)>
+
+=item -
+
+L<EVP_PKEY_CTX_new_id(3)>
 
 Use L<EVP_PKEY_CTX_new_from_name(3)>
 
-=item L<EVP_PKEY_derive_set_peer(3)>, L<EVP_PKEY_new_raw_private_key(3)>
+=item -
+
+L<EVP_PKEY_derive_set_peer(3)>, L<EVP_PKEY_new_raw_private_key(3)>
 and L<EVP_PKEY_new_raw_public_key(3)>
 
-=item L<EVP_SignFinal(3)> and L<EVP_VerifyFinal(3)>
+=item -
 
-=item L<NCONF_new(3)>
+L<EVP_SignFinal(3)> and L<EVP_VerifyFinal(3)>
 
-=item L<OCSP_RESPID_match(3)> and L<OCSP_RESPID_set_by_key(3)>
+=item -
 
-=item L<OPENSSL_thread_stop(3)>
+L<NCONF_new(3)>
 
-=item L<OSSL_STORE_open(3)>
+=item -
 
-=item L<PEM_read_bio_Parameters(3)>, L<PEM_read_bio_PrivateKey(3)>, L<PEM_read_bio_PUBKEY(3)>,
+L<OCSP_RESPID_match(3)> and L<OCSP_RESPID_set_by_key(3)>
+
+=item -
+
+L<OPENSSL_thread_stop(3)>
+
+=item -
+
+L<OSSL_STORE_open(3)>
+
+=item -
+
+L<PEM_read_bio_Parameters(3)>, L<PEM_read_bio_PrivateKey(3)>, L<PEM_read_bio_PUBKEY(3)>,
 L<PEM_read_PrivateKey(3)> and L<PEM_read_PUBKEY(3)>
 
-=item L<PEM_write_bio_PrivateKey(3)>, L<PEM_write_bio_PUBKEY(3)>, L<PEM_write_PrivateKey(3)>
+=item -
+
+L<PEM_write_bio_PrivateKey(3)>, L<PEM_write_bio_PUBKEY(3)>, L<PEM_write_PrivateKey(3)>
 and L<PEM_write_PUBKEY(3)>
 
-=item L<PEM_X509_INFO_read_bio(3)> and L<PEM_X509_INFO_read(3)>
+=item -
 
-=item L<PKCS12_add_key(3)>, L<PKCS12_add_safe(3)>, L<PKCS12_add_safes(3)>,
+L<PEM_X509_INFO_read_bio(3)> and L<PEM_X509_INFO_read(3)>
+
+=item -
+
+L<PKCS12_add_key(3)>, L<PKCS12_add_safe(3)>, L<PKCS12_add_safes(3)>,
 L<PKCS12_create(3)>, L<PKCS12_decrypt_skey(3)>, L<PKCS12_init(3)>, L<PKCS12_item_decrypt_d2i(3)>,
 L<PKCS12_item_i2d_encrypt(3)>, L<PKCS12_key_gen_asc(3)>, L<PKCS12_key_gen_uni(3)>,
 L<PKCS12_key_gen_utf8(3)>, L<PKCS12_pack_p7encdata(3)>, L<PKCS12_pbe_crypt(3)>,
 L<PKCS12_PBE_keyivgen(3)>, L<PKCS12_SAFEBAG_create_pkcs8_encrypt(3)>
 
-=item L<PKCS5_pbe_set0_algor(3)>, L<PKCS5_pbe_set(3)>, L<PKCS5_pbe2_set_iv(3)>,
+=item -
+
+L<PKCS5_pbe_set0_algor(3)>, L<PKCS5_pbe_set(3)>, L<PKCS5_pbe2_set_iv(3)>,
 L<PKCS5_pbkdf2_set(3)> and L<PKCS5_v2_scrypt_keyivgen(3)>
 
-=item L<PKCS7_encrypt(3)>, L<PKCS7_new(3)> and L<PKCS7_sign(3)>
+=item -
 
-=item L<PKCS8_decrypt(3)>, L<PKCS8_encrypt(3)> and L<PKCS8_set0_pbe(3)>
+L<PKCS7_encrypt(3)>, L<PKCS7_new(3)> and L<PKCS7_sign(3)>
 
-=item L<RAND_bytes(3)> and L<RAND_priv_bytes(3)>
+=item -
 
-=item L<SMIME_write_ASN1(3)>
+L<PKCS8_decrypt(3)>, L<PKCS8_encrypt(3)> and L<PKCS8_set0_pbe(3)>
 
-=item L<TS_RESP_CTX_new(3)>
+=item -
 
-=item L<X509_CRL_new(3)>
+L<RAND_bytes(3)> and L<RAND_priv_bytes(3)>
 
-=item L<X509_load_cert_crl_file(3)> and L<X509_load_cert_file(3)>
+=item -
 
-=item L<X509_LOOKUP_by_subject(3)> and L<X509_LOOKUP_ctrl(3)>
+L<SMIME_write_ASN1(3)>
 
-=item L<X509_NAME_hash(3)>
+=item -
 
-=item L<X509_new(3)>
+L<TS_RESP_CTX_new(3)>
 
-=item L<X509_REQ_new(3)> and L<X509_REQ_verify(3)>
+=item -
 
-=item L<X509_STORE_CTX_new(3)>, L<X509_STORE_set_default_paths(3)>, L<X509_STORE_load_file(3)>,
+L<X509_CRL_new(3)>
+
+=item -
+
+L<X509_load_cert_crl_file(3)> and L<X509_load_cert_file(3)>
+
+=item -
+
+L<X509_LOOKUP_by_subject(3)> and L<X509_LOOKUP_ctrl(3)>
+
+=item -
+
+L<X509_NAME_hash(3)>
+
+=item -
+
+L<X509_new(3)>
+
+=item -
+
+L<X509_REQ_new(3)> and L<X509_REQ_verify(3)>
+
+=item -
+
+L<X509_STORE_CTX_new(3)>, L<X509_STORE_set_default_paths(3)>, L<X509_STORE_load_file(3)>,
 L<X509_STORE_load_locations(3)> and L<X509_STORE_load_store(3)>
 
 =back
@@ -632,66 +737,124 @@ Passing NULL will use the default library context.
 
 =over 4
 
-=item L<EVP_ASYM_CIPHER_fetch(3)> and L<EVP_ASYM_CIPHER_do_all_provided(3)>
+=item -
 
-=item L<EVP_CIPHER_fetch(3)> and L<EVP_CIPHER_do_all_provided(3)>
+L<EVP_ASYM_CIPHER_fetch(3)> and L<EVP_ASYM_CIPHER_do_all_provided(3)>
 
-=item L<EVP_default_properties_enable_fips(3)> and
+=item -
+
+L<EVP_CIPHER_fetch(3)> and L<EVP_CIPHER_do_all_provided(3)>
+
+=item -
+
+L<EVP_default_properties_enable_fips(3)> and
 L<EVP_default_properties_is_fips_enabled(3)>
 
-=item L<EVP_KDF_fetch(3)> and L<EVP_KDF_do_all_provided(3)>
+=item -
 
-=item L<EVP_KEM_fetch(3)> and L<EVP_KEM_do_all_provided(3)>
+L<EVP_KDF_fetch(3)> and L<EVP_KDF_do_all_provided(3)>
 
-=item L<EVP_KEYEXCH_fetch(3)> and L<EVP_KEYEXCH_do_all_provided(3)>
+=item -
 
-=item L<EVP_KEYMGMT_fetch(3)> and L<EVP_KEYMGMT_do_all_provided(3)>
+L<EVP_KEM_fetch(3)> and L<EVP_KEM_do_all_provided(3)>
 
-=item L<EVP_MAC_fetch(3)> and L<EVP_MAC_do_all_provided(3)>
+=item -
 
-=item L<EVP_MD_fetch(3)> and L<EVP_MD_do_all_provided(3)>
+L<EVP_KEYEXCH_fetch(3)> and L<EVP_KEYEXCH_do_all_provided(3)>
 
-=item L<EVP_PKEY_CTX_new_from_pkey(3)>
+=item -
 
-=item L<EVP_PKEY_Q_keygen(3)>
+L<EVP_KEYMGMT_fetch(3)> and L<EVP_KEYMGMT_do_all_provided(3)>
 
-=item L<EVP_Q_mac(3)> and L<EVP_Q_digest(3)>
+=item -
 
-=item L<EVP_RAND(3)> and L<EVP_RAND_do_all_provided(3)>
+L<EVP_MAC_fetch(3)> and L<EVP_MAC_do_all_provided(3)>
 
-=item L<EVP_set_default_properties(3)>
+=item -
 
-=item L<EVP_SIGNATURE_fetch(3)> and L<EVP_SIGNATURE_do_all_provided(3)>
+L<EVP_MD_fetch(3)> and L<EVP_MD_do_all_provided(3)>
 
-=item L<OSSL_CMP_CTX_new(3)> and L<OSSL_CMP_SRV_CTX_new(3)>
+=item -
 
-=item L<OSSL_CRMF_ENCRYPTEDVALUE_get1_encCert(3)>
+L<EVP_PKEY_CTX_new_from_pkey(3)>
 
-=item L<OSSL_CRMF_MSG_create_popo(3)> and L<OSSL_CRMF_MSGS_verify_popo(3)>
+=item -
 
-=item L<OSSL_CRMF_pbm_new(3)> and L<OSSL_CRMF_pbmp_new(3)>
+L<EVP_PKEY_Q_keygen(3)>
 
-=item L<OSSL_DECODER_CTX_add_extra(3)> and L<OSSL_DECODER_CTX_new_for_pkey(3)>
+=item -
 
-=item L<OSSL_DECODER_fetch(3)> and L<OSSL_DECODER_do_all_provided(3)>
+L<EVP_Q_mac(3)> and L<EVP_Q_digest(3)>
 
-=item L<OSSL_ENCODER_CTX_add_extra(3)>
+=item -
 
-=item L<OSSL_ENCODER_fetch(3)> and L<OSSL_ENCODER_do_all_provided(3)>
+L<EVP_RAND(3)> and L<EVP_RAND_do_all_provided(3)>
 
-=item L<OSSL_LIB_CTX_free(3)>, L<OSSL_LIB_CTX_load_config(3)> and L<OSSL_LIB_CTX_set0_default(3)>
+=item -
 
-=item L<OSSL_PROVIDER_add_builtin(3)>, L<OSSL_PROVIDER_available(3)>,
+L<EVP_set_default_properties(3)>
+
+=item -
+
+L<EVP_SIGNATURE_fetch(3)> and L<EVP_SIGNATURE_do_all_provided(3)>
+
+=item -
+
+L<OSSL_CMP_CTX_new(3)> and L<OSSL_CMP_SRV_CTX_new(3)>
+
+=item -
+
+L<OSSL_CRMF_ENCRYPTEDVALUE_get1_encCert(3)>
+
+=item -
+
+L<OSSL_CRMF_MSG_create_popo(3)> and L<OSSL_CRMF_MSGS_verify_popo(3)>
+
+=item -
+
+L<OSSL_CRMF_pbm_new(3)> and L<OSSL_CRMF_pbmp_new(3)>
+
+=item -
+
+L<OSSL_DECODER_CTX_add_extra(3)> and L<OSSL_DECODER_CTX_new_for_pkey(3)>
+
+=item -
+
+L<OSSL_DECODER_fetch(3)> and L<OSSL_DECODER_do_all_provided(3)>
+
+=item -
+
+L<OSSL_ENCODER_CTX_add_extra(3)>
+
+=item -
+
+L<OSSL_ENCODER_fetch(3)> and L<OSSL_ENCODER_do_all_provided(3)>
+
+=item -
+
+L<OSSL_LIB_CTX_free(3)>, L<OSSL_LIB_CTX_load_config(3)> and L<OSSL_LIB_CTX_set0_default(3)>
+
+=item -
+
+L<OSSL_PROVIDER_add_builtin(3)>, L<OSSL_PROVIDER_available(3)>,
 L<OSSL_PROVIDER_do_all(3)>, L<OSSL_PROVIDER_load(3)>,
 L<OSSL_PROVIDER_set_default_search_path(3)> and L<OSSL_PROVIDER_try_load(3)>
 
-=item L<OSSL_SELF_TEST_get_callback(3)> and L<OSSL_SELF_TEST_set_callback(3)>
+=item -
 
-=item L<OSSL_STORE_attach(3)>
+L<OSSL_SELF_TEST_get_callback(3)> and L<OSSL_SELF_TEST_set_callback(3)>
 
-=item L<OSSL_STORE_LOADER_fetch(3)> and L<OSSL_STORE_LOADER_do_all_provided(3)>
+=item -
 
-=item L<RAND_get0_primary(3)>, L<RAND_get0_private(3)>, L<RAND_get0_public(3)>,
+L<OSSL_STORE_attach(3)>
+
+=item -
+
+L<OSSL_STORE_LOADER_fetch(3)> and L<OSSL_STORE_LOADER_do_all_provided(3)>
+
+=item -
+
+L<RAND_get0_primary(3)>, L<RAND_get0_private(3)>, L<RAND_get0_public(3)>,
 L<RAND_set_DRBG_type(3)> and L<RAND_set_seed_source_type(3)>
 
 =back
@@ -768,7 +931,7 @@ high-level EVP_PKEY APIs, e.g. L<EVP_PKEY_new(3)>, L<EVP_PKEY_up_ref(3)> and
 L<EVP_PKEY_free(3)>.
 See also L<EVP_PKEY_CTX_new_from_name(3)> and L<EVP_PKEY_CTX_new_from_pkey(3)>.
 
-EVP_PKEY's may be created in a variety of ways:
+EVP_PKEYs may be created in a variety of ways:
 See also L</Deprecated low-level key generation functions>,
 L</Deprecated low-level key reading and writing functions> and
 L</Deprecated low-level key parameter setters>.
@@ -860,7 +1023,9 @@ The following functions have been deprecated in 3.0.
 
 =over 4
 
-=item AES_bi_ige_encrypt and AES_ige_encrypt
+=item -
+
+AES_bi_ige_encrypt() and AES_ige_encrypt()
 
 There is no replacement for the IGE functions. New code should not use these modes.
 These undocumented functions were never integrated into the EVP layer.
@@ -871,270 +1036,377 @@ AES_bi_ige_encrypt() has a known bug. It accepts 2 AES keys, but only one
 is ever used. The security implications are believed to be minimal, but
 this issue was never fixed for backwards compatibility reasons. 
 
-=item AES_encrypt, AES_decrypt, AES_set_encrypt_key, AES_set_decrypt_key,
-AES_cbc_encrypt, AES_cfb128_encrypt, AES_cfb1_encrypt, AES_cfb8_encrypt,
-AES_ecb_encrypt and AES_ofb128_encrypt
+=item -
 
-=item AES_unwrap_key, AES_wrap_key
+AES_encrypt(), AES_decrypt(), AES_set_encrypt_key(), AES_set_decrypt_key(),
+AES_cbc_encrypt(), AES_cfb128_encrypt(), AES_cfb1_encrypt(), AES_cfb8_encrypt(),
+AES_ecb_encrypt(), AES_ofb128_encrypt()
+
+=item -
+
+AES_unwrap_key(), AES_wrap_key()
 
 See L</Deprecated low-level encryption functions>
 
-=item AES_options
+=item -
+
+AES_options()
 
 There is no replacement. It returned a string indicating if the AES code was unrolled.
 
-=item ASN1_digest, ASN1_sign and ASN1_verify
+=item -
+
+ASN1_digest(), ASN1_sign(), ASN1_verify()
 
 There are no replacements. These old functions are not used, and could be
 disabled with the macro NO_ASN1_OLD since OpenSSL 0.9.7.
 
-=item ASN1_STRING_length_set
+=item -
+
+ASN1_STRING_length_set()
 
 Use L<ASN1_STRING_set(3)> or L<ASN1_STRING_set0(3)> instead.
 This was a potentially unsafe function that could change the bounds of a
 previously passed in pointer.
 
-=item BF_encrypt, BF_decrypt, BF_set_key, BF_cbc_encrypt, BF_cfb64_encrypt,
-BF_ecb_encrypt and BF_ofb64_encrypt
+=item -
+
+BF_encrypt(), BF_decrypt(), BF_set_key(), BF_cbc_encrypt(), BF_cfb64_encrypt(),
+BF_ecb_encrypt(), BF_ofb64_encrypt()
 
 See L</Deprecated low-level encryption functions>.
 The Blowfish algorithm has been moved to the L<Legacy Provider|/Legacy Algorithms>.
 
-=item BF_options
+=item -
+
+BF_options()
 
 There is no replacement. This option returned a constant string.
 
-=item BN_is_prime_ex and BN_is_prime_fasttest_ex
+=item -
+
+BN_is_prime_ex(), BN_is_prime_fasttest_ex()
 
 Use L<BN_check_prime(3)> which that avoids possible misuse and always uses at least
 64 rounds of the Miller-Rabin primality test.
 
-=item BN_pseudo_rand and BN_pseudo_rand_range
+=item -
+
+BN_pseudo_rand(), BN_pseudo_rand_range()
 
 Use L<BN_rand(3)> and L<BN_rand_range(3)>.
 
-=item BN_X931_derive_prime_ex, BN_X931_generate_prime_ex and BN_X931_generate_Xpq
+=item -
+
+BN_X931_derive_prime_ex(), BN_X931_generate_prime_ex(), BN_X931_generate_Xpq()
 
 There are no replacements for these low-level functions. They were used internally
 by RSA_X931_derive_ex() and RSA_X931_generate_key_ex() which are also deprecated.
 Use L<EVP_PKEY_keygen(3)> instead.
 
-=item Camellia_encrypt, Camellia_decrypt, Camellia_set_key,
-Camellia_cbc_encrypt, Camellia_cfb128_encrypt, Camellia_cfb1_encrypt,
-Camellia_cfb8_encrypt, Camellia_ctr128_encrypt, Camellia_ecb_encrypt and
-Camellia_ofb128_encrypt.
+=item -
+
+Camellia_encrypt(), Camellia_decrypt(), Camellia_set_key(),
+Camellia_cbc_encrypt(), Camellia_cfb128_encrypt(), Camellia_cfb1_encrypt(),
+Camellia_cfb8_encrypt(), Camellia_ctr128_encrypt(), Camellia_ecb_encrypt(),
+Camellia_ofb128_encrypt()
 
 See L</Deprecated low-level encryption functions>.
 
-=item CAST_encrypt, CAST_decrypt, CAST_set_key, CAST_cbc_encrypt,
-CAST_cfb64_encrypt, CAST_ecb_encrypt and CAST_ofb64_encrypt
+=item -
+
+CAST_encrypt(), CAST_decrypt(), CAST_set_key(), CAST_cbc_encrypt(),
+CAST_cfb64_encrypt(), CAST_ecb_encrypt(), CAST_ofb64_encrypt()
 
 See L</Deprecated low-level encryption functions>.
 The CAST algorithm has been moved to the L<Legacy Provider|/Legacy Algorithms>.
 
-=item CMAC_CTX_new, CMAC_CTX_cleanup, CMAC_CTX_copy, CMAC_CTX_free and
-CMAC_CTX_get0_cipher_ctx
+=item -
+
+CMAC_CTX_new(), CMAC_CTX_cleanup(), CMAC_CTX_copy(), CMAC_CTX_free(),
+CMAC_CTX_get0_cipher_ctx()
 
 See L</Deprecated low-level MAC functions>.
 
-=item CMAC_Init, CMAC_Update, CMAC_Final and CMAC_resume.
+=item -
+
+CMAC_Init(), CMAC_Update(), CMAC_Final(), CMAC_resume()
 
 See L</Deprecated low-level MAC functions>.
 
-=item CRYPTO_mem_ctrl, CRYPTO_mem_debug_free, CRYPTO_mem_debug_malloc,
-CRYPTO_mem_debug_pop, CRYPTO_mem_debug_push, CRYPTO_mem_debug_realloc,
-CRYPTO_mem_leaks, CRYPTO_mem_leaks_cb, CRYPTO_mem_leaks_fp and
-CRYPTO_set_mem_debug
+=item -
+
+CRYPTO_mem_ctrl(), CRYPTO_mem_debug_free(), CRYPTO_mem_debug_malloc(),
+CRYPTO_mem_debug_pop(), CRYPTO_mem_debug_push(), CRYPTO_mem_debug_realloc(),
+CRYPTO_mem_leaks(), CRYPTO_mem_leaks_cb(), CRYPTO_mem_leaks_fp(),
+CRYPTO_set_mem_debug()
 
 Memory-leak checking has been deprecated in favor of more modern development
 tools, such as compiler memory and leak sanitizers or Valgrind.
 
-=item d2i_DHparams, d2i_DHxparams, d2i_DSAparams, d2i_DSAPrivateKey,
-d2i_DSAPrivateKey_bio, d2i_DSAPrivateKey_fp, d2i_DSA_PUBKEY, d2i_DSA_PUBKEY_bio,
-d2i_DSA_PUBKEY_fp, d2i_DSAPublicKey,
-d2i_ECParameters, d2i_ECPrivateKey, d2i_ECPrivateKey_bio, d2i_ECPrivateKey_fp,
-d2i_EC_PUBKEY, d2i_EC_PUBKEY_bio, d2i_EC_PUBKEY_fp, o2i_ECPublicKey,
-d2i_RSAPrivateKey, d2i_RSAPrivateKey_bio, d2i_RSAPrivateKey_fp,
-d2i_RSA_PUBKEY, d2i_RSA_PUBKEY_bio, d2i_RSA_PUBKEY_fp, d2i_RSAPublicKey,
-d2i_RSAPublicKey_bio and d2i_RSAPublicKey_fp
+=item -
+
+d2i_DHparams(), d2i_DHxparams(), d2i_DSAparams(), d2i_DSAPrivateKey(),
+d2i_DSAPrivateKey_bio(), d2i_DSAPrivateKey_fp(), d2i_DSA_PUBKEY(),
+d2i_DSA_PUBKEY_bio(), d2i_DSA_PUBKEY_fp(), d2i_DSAPublicKey(),
+d2i_ECParameters(), d2i_ECPrivateKey(), d2i_ECPrivateKey_bio(),
+d2i_ECPrivateKey_fp(), d2i_EC_PUBKEY(), d2i_EC_PUBKEY_bio(),
+d2i_EC_PUBKEY_fp(), o2i_ECPublicKey(), d2i_RSAPrivateKey(),
+d2i_RSAPrivateKey_bio(), d2i_RSAPrivateKey_fp(), d2i_RSA_PUBKEY(),
+d2i_RSA_PUBKEY_bio(), d2i_RSA_PUBKEY_fp(), d2i_RSAPublicKey(),
+d2i_RSAPublicKey_bio(), d2i_RSAPublicKey_fp()
 
 See L</Deprecated i2d and d2i functions for low-level key types>
 
-=item DES_crypt, DES_fcrypt, DES_encrypt1, DES_encrypt2, DES_encrypt3,
-DES_decrypt3, DES_ede3_cbc_encrypt, DES_ede3_cfb64_encrypt,
-DES_ede3_cfb_encrypt,DES_ede3_ofb64_encrypt,
-DES_ecb_encrypt, DES_ecb3_encrypt, DES_ofb64_encrypt, DES_ofb_encrypt,
-DES_cfb64_encrypt DES_cfb_encrypt, DES_cbc_encrypt, DES_ncbc_encrypt,
-DES_pcbc_encrypt, DES_xcbc_encrypt, DES_cbc_cksum, DES_quad_cksum, 
-DES_check_key_parity, DES_is_weak_key, DES_key_sched, DES_options,
-DES_random_key, DES_set_key, DES_set_key_checked, DES_set_key_unchecked,
-DES_set_odd_parity, DES_string_to_2keys, DES_string_to_key
+=item -
+
+DES_crypt(), DES_fcrypt(), DES_encrypt1(), DES_encrypt2(), DES_encrypt3(),
+DES_decrypt3(), DES_ede3_cbc_encrypt(), DES_ede3_cfb64_encrypt(),
+DES_ede3_cfb_encrypt(),DES_ede3_ofb64_encrypt(),
+DES_ecb_encrypt(), DES_ecb3_encrypt(), DES_ofb64_encrypt(), DES_ofb_encrypt(),
+DES_cfb64_encrypt DES_cfb_encrypt(), DES_cbc_encrypt(), DES_ncbc_encrypt(),
+DES_pcbc_encrypt(), DES_xcbc_encrypt(), DES_cbc_cksum(), DES_quad_cksum(), 
+DES_check_key_parity(), DES_is_weak_key(), DES_key_sched(), DES_options(),
+DES_random_key(), DES_set_key(), DES_set_key_checked(), DES_set_key_unchecked(),
+DES_set_odd_parity(), DES_string_to_2keys(), DES_string_to_key()
 
 See L</Deprecated low-level encryption functions>.
 Algorithms for "DESX-CBC", "DES-ECB", "DES-CBC", "DES-OFB", "DES-CFB",
 "DES-CFB1" and "DES-CFB8" have been moved to the L<Legacy Provider|/Legacy Algorithms>.
 
-=item DH_bits, DH_security_bits and DH_size
+=item -
+
+DH_bits(), DH_security_bits(), DH_size()
 
 Use L<EVP_PKEY_bits(3)>, L<EVP_PKEY_security_bits(3)> and L<EVP_PKEY_size(3)>.
 
-=item DH_check, DH_check_ex, DH_check_params, DH_check_params_ex,
-DH_check_pub_key and DH_check_pub_key_ex
+=item -
+
+DH_check(), DH_check_ex(), DH_check_params(), DH_check_params_ex(),
+DH_check_pub_key(), DH_check_pub_key_ex()
 
 See L</Deprecated low-level validation functions>
 
-=item DH_clear_flags, DH_test_flags and DH_set_flags
+=item -
 
-The DH_FLAG_CACHE_MONT_P flag has been deprecated without replacement.
-The DH_FLAG_TYPE_DH and DH_FLAG_TYPE_DHX have been deprecated.
+DH_clear_flags(), DH_test_flags(), DH_set_flags()
+
+The B<DH_FLAG_CACHE_MONT_P> flag has been deprecated without replacement.
+The B<DH_FLAG_TYPE_DH> and B<DH_FLAG_TYPE_DHX> have been deprecated.
 Use EVP_PKEY_is_a() to determine the type of a key.
 There is no replacement for setting these flags.
 
-=item DH_compute_key and DH_compute_key_padded
+=item -
+
+DH_compute_key() DH_compute_key_padded()
 
 See L</Deprecated low-level key exchange functions>.
 
-=item DH_new, DH_new_by_nid, DH_free, DH_up_ref
+=item -
+
+DH_new(), DH_new_by_nid(), DH_free(), DH_up_ref()
 
 See L</Deprecated low-level object creation>
 
-=item DH_generate_key and DH_generate_parameters_ex
+=item -
+
+DH_generate_key(), DH_generate_parameters_ex()
 
 See L</Deprecated low-level key generation functions>.
 
-=item DH_get0_pqg, DH_get0_p, DH_get0_q, DH_get0_g, DH_get0_key,
-DH_get0_priv_key, DH_get0_pub_key, DH_get_length and DH_get_nid
+=item -
+
+DH_get0_pqg(), DH_get0_p(), DH_get0_q(), DH_get0_g(), DH_get0_key(),
+DH_get0_priv_key(), DH_get0_pub_key(), DH_get_length(), DH_get_nid()
 
 See L</Deprecated low-level key parameter getters>
 
-=item DH_get_1024_160, DH_get_2048_224 and DH_get_2048_256
+=item -
+
+DH_get_1024_160(), DH_get_2048_224(), DH_get_2048_256()
 
 Applications should instead set the B<OSSL_PKEY_PARAM_GROUP_NAME> as specified in
 L<EVP_PKEY-DH(7)/DH parameters>) to one of "dh_1024_160", "dh_2048_224" or
 "dh_2048_256" when generating a DH key.
 
-=item DH_KDF_X9_42
+=item -
+
+DH_KDF_X9_42()
 
 Applications should use L<EVP_PKEY_CTX_set_dh_kdf_type(3)> instead.
 
-=item DH_get_default_method, DH_get0_engine, DH_meth_*, DH_new_method, DH_OpenSSL,
-DH_get_ex_data, DH_set_default_method, DH_set_method and DH_set_ex_data
+=item -
+
+DH_get_default_method(), DH_get0_engine(), DH_meth_*(), DH_new_method(),
+DH_OpenSSL(), DH_get_ex_data(), DH_set_default_method(), DH_set_method(),
+DH_set_ex_data()
 
 See L</Providers are a replacement for engines and low-level method overrides>
 
-=item DHparams_print and DHparams_print_fp
+=item -
+
+DHparams_print(), DHparams_print_fp()
 
 See L</Deprecated low-level key printing functions>
 
-=item DH_set0_key, DH_set0_pqg, DH_set_length
+=item -
+
+DH_set0_key(), DH_set0_pqg(), DH_set_length()
 
 See L</Deprecated low-level key parameter setters>
 
-=item DSA_bits, DSA_security_bits and DSA_size
+=item -
+
+DSA_bits(), DSA_security_bits(), DSA_size()
 
 Use L<EVP_PKEY_bits(3)>, L<EVP_PKEY_security_bits(3)> and L<EVP_PKEY_size(3)>.
 
-=item DHparams_dup, DSA_dup_DH
+=item -
+
+DHparams_dup(), DSA_dup_DH()
 
 There is no direct replacement. Applications may use L<EVP_PKEY_copy_parameters(3)>
 and L<EVP_PKEY_dup(3)> instead.
 
-=item DSA_generate_key and DSA_generate_parameters_ex
+=item -
+
+DSA_generate_key(), DSA_generate_parameters_ex()
 
 See L</Deprecated low-level key generation functions>.
 
-=item DSA_get0_engine, DSA_get_default_method, DSA_get_ex_data, DSA_get_method,
-DSA_meth_*, DSA_new_method, DSA_OpenSSL, DSA_set_default_method, DSA_set_ex_data
-and DSA_set_method
+=item -
+
+DSA_get0_engine(), DSA_get_default_method(), DSA_get_ex_data(),
+DSA_get_method(), DSA_meth_*(), DSA_new_method(), DSA_OpenSSL(),
+DSA_set_default_method(), DSA_set_ex_data(), DSA_set_method()
 
 See L</Providers are a replacement for engines and low-level method overrides>.
 
-=item DSA_get0_p,  DSA_get0_q, DSA_get0_g, DSA_get0_pqg, DSA_get0_key,
-DSA_get0_priv_key and DSA_get0_pub_key
+=item -
+
+DSA_get0_p(), DSA_get0_q(), DSA_get0_g(), DSA_get0_pqg(), DSA_get0_key(),
+DSA_get0_priv_key(), DSA_get0_pub_key()
 
 See L</Deprecated low-level key parameter getters>.
 
-=item DSA_new, DSA_free, DSA_up_ref
+=item -
+
+DSA_new(), DSA_free(), DSA_up_ref()
 
 See L</Deprecated low-level object creation>
 
-=item DSAparams_dup
+=item -
+
+DSAparams_dup()
 
 There is no direct replacement. Applications may use L<EVP_PKEY_copy_parameters(3)>
 and L<EVP_PKEY_dup(3)> instead.
 
-=item DSAparams_print, DSAparams_print_fp, DSA_print and DSA_print_fp
+=item -
+
+DSAparams_print(), DSAparams_print_fp(), DSA_print(), DSA_print_fp()
 
 See L</Deprecated low-level key printing functions>
 
-=item DSA_set0_key, DSA_set0_pqg
+=item -
+
+DSA_set0_key(), DSA_set0_pqg()
 
 See L</Deprecated low-level key parameter setters>
 
-=item DSA_set_flags, DSA_clear_flags, DSA_test_flags
+=item -
 
-The DSA_FLAG_CACHE_MONT_P flag has been deprecated without replacement.
+DSA_set_flags(), DSA_clear_flags(), DSA_test_flags()
 
-=item DSA_sign, DSA_do_sign, DSA_sign_setup, DSA_verify and DSA_do_verify
+The B<DSA_FLAG_CACHE_MONT_P> flag has been deprecated without replacement.
+
+=item -
+
+DSA_sign(), DSA_do_sign(), DSA_sign_setup(), DSA_verify(), DSA_do_verify()
 
 See L</Deprecated low-level signing functions>.
 
-=item ECDH_compute_key
+=item -
+
+ECDH_compute_key()
 
 See L</Deprecated low-level key exchange functions>.
 
-=item ECDH_KDF_X9_62
+=item -
+
+ECDH_KDF_X9_62()
 
 Applications may either set this using the helper function
 L<EVP_PKEY_CTX_set_ecdh_kdf_type(3)> or by setting an B<OSSL_PARAM> using the
 "kdf-type" as shown in L<EVP_KEYEXCH-ECDH(7)/EXAMPLES>
 
-=item ECDSA_sign, ECDSA_sign_ex, ECDSA_sign_setup, ECDSA_do_sign, ECDSA_do_sign_ex,
-ECDSA_verify and ECDSA_do_verify
+=item -
+
+ECDSA_sign(), ECDSA_sign_ex(), ECDSA_sign_setup(), ECDSA_do_sign(),
+ECDSA_do_sign_ex(), ECDSA_verify(), ECDSA_do_verify()
 
 See L</Deprecated low-level signing functions>.
 
-=item ECDSA_size
+=item -
+
+ECDSA_size()
 
 Applications should use L<EVP_PKEY_size(3)>.
 
-=item EC_GF2m_simple_method, EC_GFp_mont_method, EC_GFp_nist_method,
-EC_GFp_nistp224_method, EC_GFp_nistp256_method, EC_GFp_nistp521_method and
-EC_GFp_simple_method
+=item -
+
+EC_GF2m_simple_method(), EC_GFp_mont_method(), EC_GFp_nist_method(),
+EC_GFp_nistp224_method(), EC_GFp_nistp256_method(), EC_GFp_nistp521_method(),
+EC_GFp_simple_method()
 
 There are no replacements for these functions. Applications should rely on the
 library automatically assigning a suitable method internally when an EC_GROUP
 is constructed.
 
-=item EC_GROUP_clear_free
+=item -
+
+EC_GROUP_clear_free()
 
 Use L<EC_GROUP_free(3)> instead.
 
-=item EC_GROUP_get_curve_GF2m, EC_GROUP_get_curve_GFp, EC_GROUP_set_curve_GF2m
-and EC_GROUP_set_curve_GFp
+=item -
+
+EC_GROUP_get_curve_GF2m(), EC_GROUP_get_curve_GFp(), EC_GROUP_set_curve_GF2m(),
+EC_GROUP_set_curve_GFp()
 
 Applications should use L<EC_GROUP_get_curve(3)> and L<EC_GROUP_set_curve(3)>.
 
-=item EC_GROUP_have_precompute_mult, EC_GROUP_precompute_mult and EC_KEY_precompute_mult
+=item -
+
+EC_GROUP_have_precompute_mult(), EC_GROUP_precompute_mult(),
+EC_KEY_precompute_mult()
 
 These functions are not widely used. Applications should instead switch to
 named curves which OpenSSL has hardcoded lookup tables for.
 
-=item EC_GROUP_new, EC_GROUP_method_of, EC_POINT_method_of
+=item -
+
+EC_GROUP_new(), EC_GROUP_method_of(), EC_POINT_method_of()
 
 EC_METHOD is now an internal-only concept and a suitable EC_METHOD is assigned
 internally without application intervention.
 Users of EC_GROUP_new() should switch to a different suitable constructor.
 
-=item EC_KEY_can_sign
+=item -
+
+EC_KEY_can_sign()
 
 Applications should use L<EVP_PKEY_can_sign(3)> instead.
 
-=item EC_KEY_check_key
+=item -
+
+EC_KEY_check_key()
 
 See L</Deprecated low-level validation functions>
 
-=item EC_KEY_set_flags, EC_KEY_get_flags and EC_KEY_clear_flags
+=item -
+
+EC_KEY_set_flags(), EC_KEY_get_flags(), EC_KEY_clear_flags()
 
 See L<EVP_PKEY-EC(7)/Common EC parameters> which handles flags as seperate
 parameters for B<OSSL_PKEY_PARAM_EC_POINT_CONVERSION_FORMAT>,
@@ -1143,102 +1415,147 @@ B<OSSL_PKEY_PARAM_USE_COFACTOR_ECDH> and
 B<OSSL_PKEY_PARAM_EC_INCLUDE_PUBLIC>.
 See also L<EVP_PKEY-EC(7)/EXAMPLES>
 
-=item EC_KEY_dup, EC_KEY_copy
+=item -
+
+EC_KEY_dup(), EC_KEY_copy()
 
 There is no direct replacement. Applications may use L<EVP_PKEY_copy_parameters(3)>
 and L<EVP_PKEY_dup(3)> instead.
 
-=item EC_KEY_decoded_from_explicit_params
+=item -
+
+EC_KEY_decoded_from_explicit_params()
 
 There is no replacement.
 
-=item EC_KEY_generate_key
+=item -
+
+EC_KEY_generate_key()
 
 See L</Deprecated low-level key generation functions>.
 
-=item EC_KEY_get0_group, EC_KEY_get0_private_key, EC_KEY_get0_public_key,
-EC_KEY_get_conv_form and EC_KEY_get_enc_flags
+=item -
+
+EC_KEY_get0_group(), EC_KEY_get0_private_key(), EC_KEY_get0_public_key(),
+EC_KEY_get_conv_form(), EC_KEY_get_enc_flags()
 
 See L</Deprecated low-level key parameter getters>.
 
-=item EC_KEY_get0_engine, EC_KEY_get_default_method, EC_KEY_get_method,
-EC_KEY_new_method, EC_KEY_get_ex_data, EC_KEY_OpenSSL, EC_KEY_set_ex_data,
-EC_KEY_set_default_method, EC_KEY_METHOD_*, EC_KEY_set_method
+=item -
+
+EC_KEY_get0_engine(), EC_KEY_get_default_method(), EC_KEY_get_method(),
+EC_KEY_new_method(), EC_KEY_get_ex_data(), EC_KEY_OpenSSL(),
+EC_KEY_set_ex_data(), EC_KEY_set_default_method(), EC_KEY_METHOD_*(),
+EC_KEY_set_method()
 
 See L</Providers are a replacement for engines and low-level method overrides>
 
-=item EC_METHOD_get_field_type
+=item -
+
+EC_METHOD_get_field_type()
 
 Use L<EC_GROUP_get_field_type(3)> instead.
 See L</Providers are a replacement for engines and low-level method overrides>
 
-=item EC_KEY_key2buf, EC_KEY_oct2key, EC_KEY_oct2priv, EC_KEY_priv2buf and EC_KEY_priv2oct
+=item -
+
+EC_KEY_key2buf(), EC_KEY_oct2key(), EC_KEY_oct2priv(), EC_KEY_priv2buf(),
+EC_KEY_priv2oct()
 
 There are no replacements for these.
 
-=item EC_KEY_new, EC_KEY_new_by_curve_name, EC_KEY_free, EC_KEY_up_ref
+=item -
+
+EC_KEY_new(), EC_KEY_new_by_curve_name(), EC_KEY_free(), EC_KEY_up_ref()
 
 See L</Deprecated low-level object creation>
 
-=item EC_KEY_print, EC_KEY_print_fp
+=item -
+
+EC_KEY_print(), EC_KEY_print_fp()
 
 See L</Deprecated low-level key printing functions>
 
-=item EC_KEY_set_asn1_flag, EC_KEY_set_conv_form, EC_KEY_set_enc_flags
+=item -
+
+EC_KEY_set_asn1_flag(), EC_KEY_set_conv_form(), EC_KEY_set_enc_flags()
 
 See L</Deprecated low-level key parameter setters>.
 
-=item EC_KEY_set_group, EC_KEY_set_private_key, EC_KEY_set_public_key, EC_KEY_set_public_key_affine_coordinates
+=item -
+
+EC_KEY_set_group(), EC_KEY_set_private_key(), EC_KEY_set_public_key(),
+EC_KEY_set_public_key_affine_coordinates()
 
 See L</Deprecated low-level key parameter setters>.
 
-=item ECParameters_print, ECParameters_print_fp, ECPKParameters_print and
-ECPKParameters_print_fp
+=item -
+
+ECParameters_print(), ECParameters_print_fp(), ECPKParameters_print(),
+ECPKParameters_print_fp()
 
 See L</Deprecated low-level key printing functions>
 
-=item EC_POINT_bn2point and EC_POINT_point2bn
+=item -
+
+EC_POINT_bn2point(), EC_POINT_point2bn()
 
 These functions were not particularly useful, since EC point serialization
 formats are not individual big-endian integers.
 
-=item EC_POINT_get_affine_coordinates_GF2m, EC_POINT_get_affine_coordinates_GFp,
-EC_POINT_set_affine_coordinates_GF2m and EC_POINT_set_affine_coordinates_GFp
+=item -
+
+EC_POINT_get_affine_coordinates_GF2m(), EC_POINT_get_affine_coordinates_GFp(),
+EC_POINT_set_affine_coordinates_GF2m(), EC_POINT_set_affine_coordinates_GFp()
 
 Applications should use L<EC_POINT_get_affine_coordinates(3)> and
 L<EC_POINT_set_affine_coordinates(3)> instead.
 
-=item EC_POINT_get_Jprojective_coordinates_GFp and EC_POINT_set_Jprojective_coordinates_GFp
+=item -
+
+EC_POINT_get_Jprojective_coordinates_GFp(), EC_POINT_set_Jprojective_coordinates_GFp()
 
 These functions are not widely used. Applications should instead use the
 L<EC_POINT_set_affine_coordinates(3)> and L<EC_POINT_get_affine_coordinates(3)>
 functions.
 
-=item EC_POINT_make_affine and EC_POINTs_make_affine
+=item -
+
+EC_POINT_make_affine(), EC_POINTs_make_affine()
 
 There is no replacement. These functions were not widely used, and OpenSSL
 automatically performs this conversion when needed.
 
-=item EC_POINT_set_compressed_coordinates_GF2m and EC_POINT_set_compressed_coordinates_GFp
+=item -
+
+EC_POINT_set_compressed_coordinates_GF2m(), EC_POINT_set_compressed_coordinates_GFp()
 
 Applications should use L<EC_POINT_set_compressed_coordinates(3)> instead.
 
-=item EC_POINTs_mul
+=item -
+
+EC_POINTs_mul()
 
 This function is not widely used. Applications should instead use the
 L<EC_POINT_mul(3)> function.
 
-=item ENGINE_*
+=item -
+
+B<ENGINE_*()>
 
 All engine functions are deprecated. An engine should be rewritten as a provider.
 See L</Providers are a replacement for engines and low-level method overrides>.
 
-=item ERR_load_*, ERR_func_error_string, ERR_get_error_line,
-ERR_get_error_line_data and ERR_get_state
+=item -
+
+B<ERR_load_*()>, ERR_func_error_string(), ERR_get_error_line(),
+ERR_get_error_line_data(), ERR_get_state()
 
 OpenSSL now loads error strings automatically so these functions are not needed.
 
-=item ERR_peek_error_line_data and ERR_peek_last_error_line_data
+=item -
+
+ERR_peek_error_line_data(), ERR_peek_last_error_line_data()
 
 The new functions are L<ERR_peek_error_func(3)>, L<ERR_peek_last_error_func(3)>,
 L<ERR_peek_error_data(3)>, L<ERR_peek_last_error_data(3)>, L<ERR_get_error_all(3)>,
@@ -1247,68 +1564,96 @@ Applications should use L<ERR_get_error_all(3)>, or pick information
 with ERR_peek functions and finish off with getting the error code by using
 L<ERR_get_error(3)>.
 
-=item EVP_CIPHER_CTX_iv, EVP_CIPHER_CTX_iv_noconst and EVP_CIPHER_CTX_original_iv
+=item -
+
+EVP_CIPHER_CTX_iv(), EVP_CIPHER_CTX_iv_noconst(), EVP_CIPHER_CTX_original_iv()
 
 Applications should instead use L<EVP_CIPHER_CTX_get_updated_iv(3)>,
 L<EVP_CIPHER_CTX_get_updated_iv(3)> and L<EVP_CIPHER_CTX_get_original_iv(3)>
 respectively.
 See L<EVP_CIPHER_CTX_get_original_iv(3)> for further information.
 
-=item EVP_CIPHER_meth_*, EVP_MD_CTX_set_update_fn, EVP_MD_CTX_update_fn, and EVP_MD_meth_*
+=item -
+
+B<EVP_CIPHER_meth_*()>, EVP_MD_CTX_set_update_fn(), EVP_MD_CTX_update_fn(),
+B<EVP_MD_meth_*()>
 
 See L</Providers are a replacement for engines and low-level method overrides>.
 
-=item EVP_PKEY_CTRL_PKCS7_ENCRYPT, EVP_PKEY_CTRL_PKCS7_DECRYPT,
-EVP_PKEY_CTRL_PKCS7_SIGN, EVP_PKEY_CTRL_CMS_ENCRYPT,
-EVP_PKEY_CTRL_CMS_DECRYPT, and EVP_PKEY_CTRL_CMS_SIGN.
+=item -
+
+EVP_PKEY_CTRL_PKCS7_ENCRYPT(), EVP_PKEY_CTRL_PKCS7_DECRYPT(),
+EVP_PKEY_CTRL_PKCS7_SIGN(), EVP_PKEY_CTRL_CMS_ENCRYPT(),
+EVP_PKEY_CTRL_CMS_DECRYPT(), and EVP_PKEY_CTRL_CMS_SIGN()
 
 These control operations are not invoked by the OpenSSL library anymore and
 are replaced by direct checks of the key operation against the key type
 when the operation is initialized.
 
-=item EVP_PKEY_CTX_get0_dh_kdf_ukm and EVP_PKEY_CTX_get0_ecdh_kdf_ukm
+=item -
+
+EVP_PKEY_CTX_get0_dh_kdf_ukm(), EVP_PKEY_CTX_get0_ecdh_kdf_ukm()
 
 See the "kdf-ukm" item in L<EVP_KEYEXCH-DH(7)/DH key exchange parameters> and
 L<EVP_KEYEXCH-ECDH(7)/ECDH Key Exchange parameters>.
 These functions are obsolete and should not be required.
 
-=item EVP_PKEY_CTX_set_rsa_keygen_pubexp
+=item -
+
+EVP_PKEY_CTX_set_rsa_keygen_pubexp()
 
 Applications should use L<EVP_PKEY_CTX_set1_rsa_keygen_pubexp(3)> instead.
 
-=item EVP_PKEY_cmp and EVP_PKEY_cmp_parameters()
+=item -
+
+EVP_PKEY_cmp(), EVP_PKEY_cmp_parameters()
 
 Applications should use L<EVP_PKEY_eq(3)> and L<EVP_PKEY_parameters_eq(3)> instead.
 See L<EVP_PKEY_copy_parameters(3)> for further details.
 
-=item EVP_PKEY_encrypt_old, EVP_PKEY_decrypt_old, 
+=item -
+
+EVP_PKEY_encrypt_old(), EVP_PKEY_decrypt_old(), 
 
 Applications should use L<EVP_PKEY_encrypt_init(3)> and L<EVP_PKEY_encrypt(3)> or
 L<EVP_PKEY_decrypt_init(3)> and L<EVP_PKEY_decrypt(3)> instead.
 
-=item EVP_PKEY_get0
+=item -
+
+EVP_PKEY_get0()
 
 This function returns NULL if the key comes from a provider.
 
-=item EVP_PKEY_get0_DH, EVP_PKEY_get0_DSA, EVP_PKEY_get0_EC_KEY, EVP_PKEY_get0_RSA,
-EVP_PKEY_get1_DH, EVP_PKEY_get1_DSA, EVP_PKEY_get1_EC_KEY and EVP_PKEY_get1_RSA,
-EVP_PKEY_get0_hmac, EVP_PKEY_get0_poly1305 and EVP_PKEY_get0_siphash
+=item -
+
+EVP_PKEY_get0_DH(), EVP_PKEY_get0_DSA(), EVP_PKEY_get0_EC_KEY(), EVP_PKEY_get0_RSA(),
+EVP_PKEY_get1_DH(), EVP_PKEY_get1_DSA(), EVP_PKEY_get1_EC_KEY and EVP_PKEY_get1_RSA(),
+EVP_PKEY_get0_hmac(), EVP_PKEY_get0_poly1305(), EVP_PKEY_get0_siphash()
 
 See L</Functions that return an internal key should be treated as read only>.
 
-=item EVP_PKEY_meth_*
+=item -
+
+B<EVP_PKEY_meth_*()>
 
 See L</Providers are a replacement for engines and low-level method overrides>.
 
-=item EVP_PKEY_new_CMAC_key
+=item -
+
+EVP_PKEY_new_CMAC_key()
 
 See L</Deprecated low-level MAC functions>.
 
-=item EVP_PKEY_assign, EVP_PKEY_set1_DH, EVP_PKEY_set1_DSA, EVP_PKEY_set1_EC_KEY and EVP_PKEY_set1_RSA
+=item -
+
+EVP_PKEY_assign(), EVP_PKEY_set1_DH(), EVP_PKEY_set1_DSA(),
+EVP_PKEY_set1_EC_KEY(), EVP_PKEY_set1_RSA()
 
 See L</Deprecated low-level key object getters and setters>
 
-=item EVP_PKEY_set1_tls_encodedpoint() and EVP_PKEY_get1_tls_encodedpoint().
+=item -
+
+EVP_PKEY_set1_tls_encodedpoint() EVP_PKEY_get1_tls_encodedpoint()
 
 These functions were previously used by libssl to set or get an encoded public
 key into/from an EVP_PKEY object. With OpenSSL 3.0 these are replaced by the more
@@ -1317,277 +1662,384 @@ L<EVP_PKEY_get1_encoded_public_key(3)>.
 The old versions have been converted to deprecated macros that just call the
 new functions.
 
-=item EVP_PKEY_set1_engine and EVP_PKEY_get0_engine
+=item -
+
+EVP_PKEY_set1_engine(), EVP_PKEY_get0_engine()
 
 See L</Providers are a replacement for engines and low-level method overrides>.
 
-=item EVP_PKEY_set_alias_type
+=item -
+
+EVP_PKEY_set_alias_type()
 
 This function has been removed. There is no replacement.
 See L</EVP_PKEY_set_alias_type() method has been removed>
 
-=item HMAC_Init_ex, HMAC_Update, HMAC_Final, HMAC_size
+=item -
+
+HMAC_Init_ex(), HMAC_Update(), HMAC_Final(), HMAC_size()
 
 See L</Deprecated low-level MAC functions>.
 
-=item HMAC_CTX_new, HMAC_CTX_free, HMAC_CTX_copy, HMAC_CTX_reset,
-HMAC_CTX_set_flags and HMAC_CTX_get_md
+=item -
+
+HMAC_CTX_new(), HMAC_CTX_free(), HMAC_CTX_copy(), HMAC_CTX_reset(),
+HMAC_CTX_set_flags(), HMAC_CTX_get_md()
 
 See L</Deprecated low-level MAC functions>.
 
-=item i2d_DHparams, i2d_DHxparams
+=item -
+
+i2d_DHparams(), i2d_DHxparams()
 
 See L</Deprecated low-level key reading and writing functions>
 and L<d2i_RSAPrivateKey(3)/Migration> 
 
-=item i2d_DSAparams, i2d_DSAPrivateKey, i2d_DSAPrivateKey_bio,
-i2d_DSAPrivateKey_fp, i2d_DSA_PUBKEY, i2d_DSA_PUBKEY_bio, i2d_DSA_PUBKEY_fp and
-i2d_DSAPublicKey
+=item -
+
+i2d_DSAparams(), i2d_DSAPrivateKey(), i2d_DSAPrivateKey_bio(),
+i2d_DSAPrivateKey_fp(), i2d_DSA_PUBKEY(), i2d_DSA_PUBKEY_bio(),
+i2d_DSA_PUBKEY_fp(), i2d_DSAPublicKey()
 
 See L</Deprecated low-level key reading and writing functions>
 and L<d2i_RSAPrivateKey(3)/Migration> 
 
-=item i2d_ECParameters, i2d_ECPrivateKey, i2d_ECPrivateKey_bio,
-i2d_ECPrivateKey_fp, i2d_EC_PUBKEY, i2d_EC_PUBKEY_bio, i2d_EC_PUBKEY_fp and
-i2o_ECPublicKey.
+=item -
+
+i2d_ECParameters(), i2d_ECPrivateKey(), i2d_ECPrivateKey_bio(),
+i2d_ECPrivateKey_fp(), i2d_EC_PUBKEY(), i2d_EC_PUBKEY_bio(),
+i2d_EC_PUBKEY_fp(), i2o_ECPublicKey()
 
 See L</Deprecated low-level key reading and writing functions>
 and L<d2i_RSAPrivateKey(3)/Migration> 
 
-=item i2d_RSAPrivateKey, i2d_RSAPrivateKey_bio, i2d_RSAPrivateKey_fp.
-i2d_RSA_PUBKEY, i2d_RSA_PUBKEY_bio, i2d_RSA_PUBKEY_fp, i2d_RSAPublicKey
-i2d_RSAPublicKey_bio and i2d_RSAPublicKey_fp
+=item -
+
+i2d_RSAPrivateKey(), i2d_RSAPrivateKey_bio(), i2d_RSAPrivateKey_fp(),
+i2d_RSA_PUBKEY(), i2d_RSA_PUBKEY_bio(), i2d_RSA_PUBKEY_fp(),
+i2d_RSAPublicKey(), i2d_RSAPublicKey_bio(), i2d_RSAPublicKey_fp()
 
 See L</Deprecated low-level key reading and writing functions>
 and L<d2i_RSAPrivateKey(3)/Migration> 
 
-=item IDEA_encrypt, IDEA_set_decrypt_key, IDEA_set_encrypt_key,
-IDEA_cbc_encrypt, IDEA_cfb64_encrypt, IDEA_ecb_encrypt and IDEA_ofb64_encrypt
+=item -
+
+IDEA_encrypt(), IDEA_set_decrypt_key(), IDEA_set_encrypt_key(),
+IDEA_cbc_encrypt(), IDEA_cfb64_encrypt(), IDEA_ecb_encrypt(),
+IDEA_ofb64_encrypt()
 
 See L</Deprecated low-level encryption functions>.
 IDEA has been moved to the L<Legacy Provider|/Legacy Algorithms>.
 
-=item IDEA_options
+=item -
+
+IDEA_options()
 
 There is no replacement. This function returned a constant string.
 
-=item MD2, MD2_Init, MD2_Update and MD2_Final
+=item -
+
+MD2(), MD2_Init(), MD2_Update(), MD2_Final()
 
 See L</Deprecated low-level encryption functions>.
 MD2 has been moved to the L<Legacy Provider|/Legacy Algorithms>.
 
-=item MD2_options
+=item -
+
+MD2_options()
 
 There is no replacement. This function returned a constant string.
 
-=item MD4, MD4_Init, MD4_Update, MD4_Final and MD4_Transform
+=item -
+
+MD4(), MD4_Init(), MD4_Update(), MD4_Final(), MD4_Transform()
 
 See L</Deprecated low-level encryption functions>.
 MD4 has been moved to the L<Legacy Provider|/Legacy Algorithms>.
 
-=item MDC2, MDC2_Init, MDC2_Update and MDC2_Final
+=item -
+
+MDC2(), MDC2_Init(), MDC2_Update(), MDC2_Final()
 
 See L</Deprecated low-level encryption functions>.
 MDC2 has been moved to the L<Legacy Provider|/Legacy Algorithms>.
 
-=item MD5, MD5_Init, MD5_Update, MD5_Final and MD5_Transform
+=item -
+
+MD5(), MD5_Init(), MD5_Update(), MD5_Final(), MD5_Transform()
 
 See L</Deprecated low-level encryption functions>.
 
-=item NCONF_WIN32
+=item -
+
+NCONF_WIN32()
 
 This undocumented function has no replacement.
 See L<config(5)/HISTORY> for more details.
 
-=item OCSP_parse_url()
+=item -
+
+OCSP_parse_url()
 
 Use L<OSSL_HTTP_parse_url(3)> instead.
 
-=item OCSP_REQ_CTX type and OCSP_REQ_CTX_*() methods.
+=item -
+
+B<OCSP_REQ_CTX> type and B<OCSP_REQ_CTX_*()> functions
 
 These methods were used to collect all necessary data to form a HTTP request,
 and to perform the HTTP transfer with that request.  With OpenSSL 3.0, the
-type is OSSL_HTTP_REQ_CTX, and the deprecated functions are replaced
-with OSSL_HTTP_REQ_CTX_*(). See L<OSSL_HTTP_REQ_CTX(3)> for additional details.
+type is B<OSSL_HTTP_REQ_CTX>, and the deprecated functions are replaced
+with B<OSSL_HTTP_REQ_CTX_*()>. See L<OSSL_HTTP_REQ_CTX(3)> for additional
+details.
 
-=item OPENSSL_fork_child, OPENSSL_fork_parent and OPENSSL_fork_prepare
+=item -
+
+OPENSSL_fork_child(), OPENSSL_fork_parent(), OPENSSL_fork_prepare()
 
 There is no replacement for these functions. These pthread fork support methods
 were unused by OpenSSL.
 
-=item OSSL_STORE_ctrl, OSSL_STORE_do_all_loaders, OSSL_STORE_LOADER_get0_engine,
-OSSL_STORE_LOADER_get0_scheme, OSSL_STORE_LOADER_new,
-OSSL_STORE_LOADER_set_attach, OSSL_STORE_LOADER_set_close,
-OSSL_STORE_LOADER_set_ctrl, OSSL_STORE_LOADER_set_eof
-OSSL_STORE_LOADER_set_error, OSSL_STORE_LOADER_set_expect,
-OSSL_STORE_LOADER_set_find, OSSL_STORE_LOADER_set_load,
-OSSL_STORE_LOADER_set_open, OSSL_STORE_LOADER_set_open_ex,
-OSSL_STORE_register_loader, OSSL_STORE_unregister_loader and OSSL_STORE_vctrl
+=item -
+
+OSSL_STORE_ctrl(), OSSL_STORE_do_all_loaders(), OSSL_STORE_LOADER_get0_engine(),
+OSSL_STORE_LOADER_get0_scheme(), OSSL_STORE_LOADER_new(),
+OSSL_STORE_LOADER_set_attach(), OSSL_STORE_LOADER_set_close(),
+OSSL_STORE_LOADER_set_ctrl(), OSSL_STORE_LOADER_set_eof(),
+OSSL_STORE_LOADER_set_error(), OSSL_STORE_LOADER_set_expect(),
+OSSL_STORE_LOADER_set_find(), OSSL_STORE_LOADER_set_load(),
+OSSL_STORE_LOADER_set_open(), OSSL_STORE_LOADER_set_open_ex(),
+OSSL_STORE_register_loader(), OSSL_STORE_unregister_loader(),
+OSSL_STORE_vctrl()
 
 These functions helped applications and engines create loaders for
 schemes they supported.  These are all deprecated and discouraged in favour of
 provider implementations, see L<provider-storemgmt(7)>.
 
-=item PEM_read_DHparams, PEM_read_bio_DHparams,
-PEM_read_DSAparams, PEM_read_bio_DSAparams,
-PEM_read_DSAPrivateKey, PEM_read_DSA_PUBKEY,
-PEM_read_bio_DSAPrivateKey and PEM_read_bio_DSA_PUBKEY,
-PEM_read_ECPKParameters, PEM_read_ECPrivateKey, PEM_read_EC_PUBKEY,
-PEM_read_bio_ECPKParameters, PEM_read_bio_ECPrivateKey, PEM_read_bio_EC_PUBKEY,
-PEM_read_RSAPrivateKey, PEM_read_RSA_PUBKEY, PEM_read_RSAPublicKey,
-PEM_read_bio_RSAPrivateKey, PEM_read_bio_RSA_PUBKEY, PEM_read_bio_RSAPublicKey,
-PEM_write_bio_DHparams, PEM_write_bio_DHxparams, PEM_write_DHparams, PEM_write_DHxparams,
-PEM_write_DSAparams, PEM_write_DSAPrivateKey, PEM_write_DSA_PUBKEY,
-PEM_write_bio_DSAparams, PEM_write_bio_DSAPrivateKey, PEM_write_bio_DSA_PUBKEY,
-PEM_write_ECPKParameters, PEM_write_ECPrivateKey, PEM_write_EC_PUBKEY,
-PEM_write_bio_ECPKParameters, PEM_write_bio_ECPrivateKey, PEM_write_bio_EC_PUBKEY,
-PEM_write_RSAPrivateKey, PEM_write_RSA_PUBKEY, PEM_write_RSAPublicKey,
-PEM_write_bio_RSAPrivateKey, PEM_write_bio_RSA_PUBKEY and PEM_write_bio_RSAPublicKey.
+=item -
+
+PEM_read_DHparams(), PEM_read_bio_DHparams(),
+PEM_read_DSAparams(), PEM_read_bio_DSAparams(),
+PEM_read_DSAPrivateKey(), PEM_read_DSA_PUBKEY(),
+PEM_read_bio_DSAPrivateKey and PEM_read_bio_DSA_PUBKEY(),
+PEM_read_ECPKParameters(), PEM_read_ECPrivateKey(), PEM_read_EC_PUBKEY(),
+PEM_read_bio_ECPKParameters(), PEM_read_bio_ECPrivateKey(), PEM_read_bio_EC_PUBKEY(),
+PEM_read_RSAPrivateKey(), PEM_read_RSA_PUBKEY(), PEM_read_RSAPublicKey(),
+PEM_read_bio_RSAPrivateKey(), PEM_read_bio_RSA_PUBKEY(), PEM_read_bio_RSAPublicKey(),
+PEM_write_bio_DHparams(), PEM_write_bio_DHxparams(), PEM_write_DHparams(), PEM_write_DHxparams(),
+PEM_write_DSAparams(), PEM_write_DSAPrivateKey(), PEM_write_DSA_PUBKEY(),
+PEM_write_bio_DSAparams(), PEM_write_bio_DSAPrivateKey(), PEM_write_bio_DSA_PUBKEY(),
+PEM_write_ECPKParameters(), PEM_write_ECPrivateKey(), PEM_write_EC_PUBKEY(),
+PEM_write_bio_ECPKParameters(), PEM_write_bio_ECPrivateKey(), PEM_write_bio_EC_PUBKEY(),
+PEM_write_RSAPrivateKey(), PEM_write_RSA_PUBKEY(), PEM_write_RSAPublicKey(),
+PEM_write_bio_RSAPrivateKey(), PEM_write_bio_RSA_PUBKEY(),
+PEM_write_bio_RSAPublicKey(),
 
 See L</Deprecated low-level key reading and writing functions>
 
-=item PKCS1_MGF1
+=item -
+
+PKCS1_MGF1()
 
 See L</Deprecated low-level encryption functions>.
 
-=item RAND_get_rand_method, RAND_set_rand_method, RAND_OpenSSL and RAND_set_rand_engine
+=item -
+
+RAND_get_rand_method(), RAND_set_rand_method(), RAND_OpenSSL(),
+RAND_set_rand_engine()
 
 Applications should instead use L<RAND_set_DRBG_type(3)>,
 L<EVP_RAND(3)> and L<EVP_RAND(7)>.
 See L<RAND_set_rand_method(3)> for more details.
 
-=item RC2_encrypt, RC2_decrypt, RC2_set_key, RC2_cbc_encrypt, RC2_cfb64_encrypt,
-RC2_ecb_encrypt, RC2_ofb64_encrypt,
-RC4, RC4_set_key, RC4_options,
-RC5_32_encrypt, RC5_32_set_key, RC5_32_decrypt, RC5_32_cbc_encrypt,
-RC5_32_cfb64_encrypt, RC5_32_ecb_encrypt and RC5_32_ofb64_encrypt
+=item -
+
+RC2_encrypt(), RC2_decrypt(), RC2_set_key(), RC2_cbc_encrypt(), RC2_cfb64_encrypt(),
+RC2_ecb_encrypt(), RC2_ofb64_encrypt(),
+RC4(), RC4_set_key(), RC4_options(),
+RC5_32_encrypt(), RC5_32_set_key(), RC5_32_decrypt(), RC5_32_cbc_encrypt(),
+RC5_32_cfb64_encrypt(), RC5_32_ecb_encrypt(), RC5_32_ofb64_encrypt()
 
 See L</Deprecated low-level encryption functions>.
 The Algorithms "RC2", "RC4" and "RC5" have been moved to the L<Legacy Provider|/Legacy Algorithms>.
 
-=item RIPEMD160, RIPEMD160_Init, RIPEMD160_Update, RIPEMD160_Final and RIPEMD160_Transform
+=item -
+
+RIPEMD160(), RIPEMD160_Init(), RIPEMD160_Update(), RIPEMD160_Final(),
+RIPEMD160_Transform()
 
 See L</Deprecated low-level digest functions>.
 The RIPE algorithm has been moved to the L<Legacy Provider|/Legacy Algorithms>.
 
-=item RSA_bits, RSA_security_bits and RSA_size
+=item -
+
+RSA_bits(), RSA_security_bits(), RSA_size()
 
 Use L<EVP_PKEY_bits(3)>, L<EVP_PKEY_security_bits(3)> and L<EVP_PKEY_size(3)>.
 
-=item RSA_check_key and RSA_check_key_ex
+=item -
+
+RSA_check_key(), RSA_check_key_ex()
 
 See L</Deprecated low-level validation functions>
 
-=item RSA_clear_flags, RSA_flags, RSA_set_flags, RSA_test_flags,
-RSA_setup_blinding, RSA_blinding_off and RSA_blinding_on
+=item -
+
+RSA_clear_flags(), RSA_flags(), RSA_set_flags(), RSA_test_flags(),
+RSA_setup_blinding(), RSA_blinding_off(), RSA_blinding_on()
 
 All of these RSA flags have been deprecated without replacement:
 
-RSA_FLAG_BLINDING, RSA_FLAG_CACHE_PRIVATE, RSA_FLAG_CACHE_PUBLIC,
-RSA_FLAG_EXT_PKEY, RSA_FLAG_NO_BLINDING, RSA_FLAG_THREAD_SAFE and
-RSA_METHOD_FLAG_NO_CHECK.
+B<RSA_FLAG_BLINDING>, B<RSA_FLAG_CACHE_PRIVATE>, B<RSA_FLAG_CACHE_PUBLIC>,
+B<RSA_FLAG_EXT_PKEY>, B<RSA_FLAG_NO_BLINDING>, B<RSA_FLAG_THREAD_SAFE>
+B<RSA_METHOD_FLAG_NO_CHECK>
 
-=item RSA_generate_key_ex, RSA_generate_multi_prime_key
+=item -
+
+RSA_generate_key_ex(), RSA_generate_multi_prime_key()
 
 See L</Deprecated low-level key generation functions>.
 
-=item RSA_get0_engine
+=item -
+
+RSA_get0_engine()
 
 See L</Providers are a replacement for engines and low-level method overrides>
 
-=item RSA_get0_crt_params, RSA_get0_d, RSA_get0_dmp1, RSA_get0_dmq1,
-RSA_get0_e, RSA_get0_factors, RSA_get0_iqmp, RSA_get0_key,
-RSA_get0_multi_prime_crt_params, RSA_get0_multi_prime_factors, RSA_get0_n,
-RSA_get0_p, RSA_get0_pss_params, RSA_get0_q and RSA_get_multi_prime_extra_count.
+=item -
+
+RSA_get0_crt_params(), RSA_get0_d(), RSA_get0_dmp1(), RSA_get0_dmq1(),
+RSA_get0_e(), RSA_get0_factors(), RSA_get0_iqmp(), RSA_get0_key(),
+RSA_get0_multi_prime_crt_params(), RSA_get0_multi_prime_factors(), RSA_get0_n(),
+RSA_get0_p(), RSA_get0_pss_params(), RSA_get0_q(),
+RSA_get_multi_prime_extra_count()
 
 See L</Deprecated low-level key parameter getters>
 
-=item RSA_new, RSA_free and RSA_up_ref
+=item -
+
+RSA_new(), RSA_free(), RSA_up_ref()
 
 See L</Deprecated low-level object creation>.
 
-=item RSA_get_default_method, RSA_get_ex_data and RSA_get_method
+=item -
+
+RSA_get_default_method(), RSA_get_ex_data and RSA_get_method()
 
 See L</Providers are a replacement for engines and low-level method overrides>.
 
-=item RSA_get_version
+=item -
+
+RSA_get_version()
 
 There is no replacement.
 
-=item RSA_meth_*, RSA_new_method, RSA_null_method and RSA_PKCS1_OpenSSL
+=item -
+
+B<RSA_meth_*()>, RSA_new_method(), RSA_null_method and RSA_PKCS1_OpenSSL()
 
 See L</Providers are a replacement for engines and low-level method overrides>.
 
-=item RSA_padding_add_* and RSA_padding_check_*
+=item -
+
+B<RSA_padding_add_*()>, B<RSA_padding_check_*()>
 
 See L</Deprecated low-level signing functions> and
 L</Deprecated low-level encryption functions>.
 
-=item RSA_print and RSA_print_fp
+=item -
+
+RSA_print(), RSA_print_fp()
 
 See L</Deprecated low-level key printing functions>
 
-=item RSA_public_encrypt and RSA_private_decrypt
+=item -
+
+RSA_public_encrypt(), RSA_private_decrypt()
 
 See L</Deprecated low-level encryption functions>
 
-=item RSA_private_encrypt and RSA_public_decrypt
+=item -
+
+RSA_private_encrypt(), RSA_public_decrypt()
 
 This is equivalent to doing sign and verify operations (with a padding mode
 of none). See L</Deprecated low-level signing functions>.
 
-=item RSAPrivateKey_dup, RSAPublicKey_dup
+=item -
+
+RSAPrivateKey_dup(), RSAPublicKey_dup()
 
 There is no direct replacement. Applications may use L<EVP_PKEY_dup(3)>.
 
-=item RSAPublicKey_it and RSAPrivateKey_it
+=item -
+
+RSAPublicKey_it(), RSAPrivateKey_it()
 
 See L</Deprecated low-level key reading and writing functions>
 
-=item RSA_set0_crt_params, RSA_set0_factors, RSA_set0_key and RSA_set0_multi_prime_params
+=item -
+
+RSA_set0_crt_params(), RSA_set0_factors(), RSA_set0_key(),
+RSA_set0_multi_prime_params()
 
 See L</Deprecated low-level key parameter setters>.
 
-=item RSA_set_default_method, RSA_set_method, RSA_set_ex_data
+=item -
+
+RSA_set_default_method(), RSA_set_method(), RSA_set_ex_data()
 
 See L</Providers are a replacement for engines and low-level method overrides>
 
-=item RSA_sign, RSA_sign_ASN1_OCTET_STRING, RSA_verify, RSA_verify_ASN1_OCTET_STRING,
-RSA_verify_PKCS1_PSS and RSA_verify_PKCS1_PSS_mgf1
+=item -
+
+RSA_sign(), RSA_sign_ASN1_OCTET_STRING(), RSA_verify(),
+RSA_verify_ASN1_OCTET_STRING(), RSA_verify_PKCS1_PSS(),
+RSA_verify_PKCS1_PSS_mgf1()
 
 See L</Deprecated low-level signing functions>.
 
-=item RSA_X931_derive_ex, RSA_X931_generate_key_ex and RSA_X931_hash_id.
+=item -
+
+RSA_X931_derive_ex(), RSA_X931_generate_key_ex(), RSA_X931_hash_id()
 
 There are no replacements for these functions.
 X931 padding can be set using L<EVP_SIGNATURE-RSA(7)/Signature Parameters>.
 See B<OSSL_SIGNATURE_PARAM_PAD_MODE>.
 
-=item SEED_encrypt, SEED_decrypt, SEED_set_key, SEED_cbc_encrypt,
-SEED_cfb128_encrypt, SEED_ecb_encrypt and SEED_ofb128_encrypt.
+=item -
+
+SEED_encrypt(), SEED_decrypt(), SEED_set_key(), SEED_cbc_encrypt(),
+SEED_cfb128_encrypt(), SEED_ecb_encrypt(), SEED_ofb128_encrypt()
 
 See L</Deprecated low-level encryption functions>.
 The SEED algorithm has been moved to the L<Legacy Provider|/Legacy Algorithms>.
 
-=item SHA1_Init, SHA1_Update, SHA1_Final, SHA1_Transform,
-SHA224_Init, SHA224_Update, SHA224_Final,
-SHA256_Init, SHA256_Update, SHA256_Final, SHA256_Transform,
-SHA384_Init, SHA384_Update, SHA384_Final,
-SHA512_Init, SHA512_Update, SHA512_Final and SHA512_Transform
+=item -
+
+SHA1_Init(), SHA1_Update(), SHA1_Final(), SHA1_Transform(),
+SHA224_Init(), SHA224_Update(), SHA224_Final(),
+SHA256_Init(), SHA256_Update(), SHA256_Final(), SHA256_Transform(),
+SHA384_Init(), SHA384_Update(), SHA384_Final(),
+SHA512_Init(), SHA512_Update(), SHA512_Final(), SHA512_Transform()
 
 See L</Deprecated low-level digest functions>.
 
-=item SRP_Calc_A, SRP_Calc_B, SRP_Calc_client_key, SRP_Calc_server_key,
-SRP_Calc_u, SRP_Calc_x, SRP_check_known_gN_param, SRP_create_verifier,
-SRP_create_verifier_BN, SRP_get_default_gN, SRP_user_pwd_free, SRP_user_pwd_new,
-SRP_user_pwd_set0_sv, SRP_user_pwd_set1_ids, SRP_user_pwd_set_gN,
-SRP_VBASE_add0_user, SRP_VBASE_free, SRP_VBASE_get1_by_user, SRP_VBASE_init,
-SRP_VBASE_new, SRP_Verify_A_mod_N, SRP_Verify_B_mod_N
+=item -
+
+SRP_Calc_A(), SRP_Calc_B(), SRP_Calc_client_key(), SRP_Calc_server_key(),
+SRP_Calc_u(), SRP_Calc_x(), SRP_check_known_gN_param(), SRP_create_verifier(),
+SRP_create_verifier_BN(), SRP_get_default_gN(), SRP_user_pwd_free(), SRP_user_pwd_new(),
+SRP_user_pwd_set0_sv(), SRP_user_pwd_set1_ids(), SRP_user_pwd_set_gN(),
+SRP_VBASE_add0_user(), SRP_VBASE_free(), SRP_VBASE_get1_by_user(), SRP_VBASE_init(),
+SRP_VBASE_new(), SRP_Verify_A_mod_N(), SRP_Verify_B_mod_N()
 
 There are no replacements for the SRP functions.
 
-=item SSL_CTX_set_tmp_dh_callback, SSL_set_tmp_dh_callback,
-SSL_CTX_set_tmp_dh and SSL_set_tmp_dh.
+=item -
+
+SSL_CTX_set_tmp_dh_callback(), SSL_set_tmp_dh_callback(),
+SSL_CTX_set_tmp_dh(), SSL_set_tmp_dh()
 
 These are used to set the Diffie-Hellman (DH) parameters that are to be used by
 servers requiring ephemeral DH keys. Instead applications should consider using
@@ -1600,21 +2052,30 @@ parameters for export and non-export ciphersuites. Export ciphersuites are no
 longer supported by OpenSSL. Use of the callback functions should be replaced
 by one of the other methods described above.
 
-=item SSL_CTX_set_tlsext_ticket_key_cb.
+=item -
+
+SSL_CTX_set_tlsext_ticket_key_cb()
 
 Use the new L<SSL_CTX_set_tlsext_ticket_key_evp_cb(3)> function instead.
 
-=item WHIRLPOOL, WHIRLPOOL_Init, WHIRLPOOL_Update, WHIRLPOOL_Final and WHIRLPOOL_BitUpdate
+=item -
+
+WHIRLPOOL(), WHIRLPOOL_Init(), WHIRLPOOL_Update(), WHIRLPOOL_Final(),
+WHIRLPOOL_BitUpdate()
 
 See L</Deprecated low-level digest functions>.
 The Whirlpool algorithm has been moved to the L<Legacy Provider|/Legacy Algorithms>.
 
-=item X509_certificate_type
+=item -
+
+X509_certificate_type()
 
 This was an undocumented function. Applications can use L<X509_get0_pubkey(3)>
 and L<X509_get0_signature(3)> instead.
 
-=item X509_http_nbio and X509_CRL_http_nbio
+=item -
+
+X509_http_nbio(), X509_CRL_http_nbio()
 
 Use L<X509_load_http(3)> and L<X509_CRL_load_http(3)> instead.
 
@@ -1628,77 +2089,86 @@ See L<fips_module(7)> and L<OSSL_PROVIDER-FIPS(7)> for details.
 
 =head3 New applications
 
-L<'kdf'|openssl-kdf(1)> uses the new L<EVP_KDF(3)> API.
-L<'mac'|openssl-mac(1)> uses the new L<EVP_MAC(3)> API.
+L<B<openssl kdf>|openssl-kdf(1)> uses the new L<EVP_KDF(3)> API.
+L<B<openssl kdf>|openssl-mac(1)> uses the new L<EVP_MAC(3)> API.
 
 =head3 Added options
 
-'-provider_path' and '-provider' are available to all apps and can be used
-multiple times to load any providers, such as the 'legacy' provider or
-third party providers. If used then the 'default' provider would also need to be
-specified if required. The '-provider_path' must be specified before the
-'-provider' option. 
+B<-provider_path> and B<-provider> are available to all apps and can be used
+multiple times to load any providers, such as the 'legacy' provider or third
+party providers. If used then the 'default' provider would also need to be
+specified if required. The B<-provider_path> must be specified before the
+B<-provider> option. 
 
-The 'list' app has many new options. See L<openssl-list(1)> for more information.
+The B<list> app has many new options. See L<openssl-list(1)> for more
+information.
 
-`-crl_lastupdate` and `-crl_nextupdate` used by 'ca' allows explicit setting of
-fields in the generated CRL.
+B<-crl_lastupdate> and B<-crl_nextupdate> used by B<openssl ca> allows
+explicit setting of fields in the generated CRL.
 
 =head3 Removed options
 
 Interactive mode is not longer available.
 
-The `-crypt` option used by `passwd`.
-The '-c' option used by `x509`, `dhparam`, `dsaparam`, and `ecparam`.
+The B<-crypt> option used by B<openssl passwd>.
+The B<-c> option used by B<openssl x509>, B<openssl dhparam>,
+B<openssl dsaparam>, and B<openssl ecparam>.
 
 =head3 Other Changes
 
 The output of Command line applications may have minor changes.
 These are primarily changes in capitalisation and white space.  However, in some
 cases, there are additional differences.
-For example, the DH parameters output from `dhparam` now lists 'P', 'Q', 'G' and
-'pcounter' instead of 'prime', 'generator', 'subgroup order' and 'counter'
-respectively.
+For example, the DH parameters output from B<openssl dhparam> now lists 'P',
+'Q', 'G' and 'pcounter' instead of 'prime', 'generator', 'subgroup order' and
+'counter' respectively.
 
-The openssl commands that read keys, certificates, and CRLs now
+The B<openssl> commands that read keys, certificates, and CRLs now
 automatically detect the PEM or DER format of the input files so it is not
 necessary to explicitly specify the input format anymore. However if the
 input format option is used the specified format will be required.
 
-`speed` no longer uses low-level API calls.
+B<openssl speed> no longer uses low-level API calls.
 This implies some of the performance numbers might not be comparable with the
 previous releases due to higher overhead. This applies particularly to
 measuring performance on smaller data chunks.
 
-'dhparam', 'dsa', 'gendsa', 'dsaparam', 'genrsa' and 'rsa' have been
-modified to use PKEY APIs.
-'genrsa' and 'rsa' now write PKCS #8 keys by default.
+b<openssl dhparam>, B<openssl dsa>, B<openssl gendsa>, B<openssl dsaparam>,
+B<openssl genrsa> and B<openssl rsa> have been modified to use PKEY APIs.
+B<openssl genrsa> and B<openssl rsa> now write PKCS #8 keys by default.
 
 =head3 Default settings
 
-"SHA256" is now the default digest for TS query used by `ts`.
+"SHA256" is now the default digest for TS query used by B<openssl ts>.
 
 =head3 Deprecated apps
 
-'rsautl' has been deprecated, use 'pkeyutl' instead.
-'dhparam', 'dsa', 'gendsa', 'dsaparam', 'genrsa', 'rsa', 'genrsa' and 'rsa' are
+B<openssl rsautl> is deprecated, use B<openssl pkeyutl> instead.
+B<openssl dhparam>, B<openssl dsa>, B<openssl gendsa>, B<openssl dsaparam>,
+B<openssl genrsa>, B<openssl rsa>, B<openssl genrsa> and B<openssl rsa> are
 now in maintenance mode and no new features will be added to them.
 
 =head2 TLS Changes
 
 =over 4
 
-=item TLS 1.3 FFDHE key exchange support added
+=item -
+
+TLS 1.3 FFDHE key exchange support added
 
 This uses DH safe prime named groups.
 
-=item Support for fully "pluggable" TLSv1.3 groups.
+=item -
+
+Support for fully "pluggable" TLSv1.3 groups.
 
 This means that providers may supply their own group implementations (using
 either the "key exchange" or the "key encapsulation" methods) which will
 automatically be detected and used by libssl.
 
-=item SSL and SSL_CTX options are now 64 bit instead of 32 bit.
+=item -
+
+SSL and SSL_CTX options are now 64 bit instead of 32 bit.
 
 The signatures of the functions to get and set options on SSL and
 SSL_CTX objects changed from "unsigned long" to "uint64_t" type.
@@ -1708,24 +2178,32 @@ This may require source code changes.
 See L<SSL_CTX_get_options(3)>, L<SSL_CTX_set_options(3)>,
 L<SSL_get_options(3)> and L<SSL_set_options(3)>.
 
-=item SSL_set1_host() and SSL_add1_host() Changes
+=item -
+
+SSL_set1_host() and SSL_add1_host() Changes
 
 These functions now take IP literal addresses as well as actual hostnames.
 
-=item Added SSL option SSL_OP_CLEANSE_PLAINTEXT
+=item -
+
+Added SSL option SSL_OP_CLEANSE_PLAINTEXT
 
 If the option is set, openssl cleanses (zeroizes) plaintext bytes from
 internal buffers after delivering them to the application. Note,
 the application is still responsible for cleansing other copies
 (e.g.: data received by L<SSL_read(3)>).
 
-=item Client-initiated renegotiation is disabled by default.
+=item -
 
-To allow it, use the '-client_renegotiation' option,
-the B<SSL_OP_ALLOW_CLIENT_RENEGOTIATION> flag, or the "ClientRenegotiation"
+Client-initiated renegotiation is disabled by default.
+
+To allow it, use the B<-client_renegotiation> option,
+the B<SSL_OP_ALLOW_CLIENT_RENEGOTIATION> flag, or the C<ClientRenegotiation>
 config parameter as appropriate.
 
-=item Secure renegotiation is now required by default for TLS connections
+=item -
+
+Secure renegotiation is now required by default for TLS connections
 
 Support for RFC 5746 secure renegotiation is now required by default for
 SSL or TLS connections to succeed.  Applications that require the ability
@@ -1733,7 +2211,9 @@ to connect to legacy peers will need to explicitly set
 SSL_OP_LEGACY_SERVER_CONNECT.  Accordingly, SSL_OP_LEGACY_SERVER_CONNECT
 is no longer set as part of SSL_OP_ALL.
 
-=item Combining the Configure options no-ec and no-dh no longer disables TLSv1.3
+=item -
+
+Combining the Configure options no-ec and no-dh no longer disables TLSv1.3
 
 Typically if OpenSSL has no EC or DH algorithms then it cannot support
 connections with TLSv1.3. However OpenSSL now supports "pluggable" groups
@@ -1743,11 +2223,15 @@ TLS connections in such a build without also disabling TLSv1.3 at run time or
 using third party provider groups may result in handshake failures. TLSv1.3
 can be disabled at compile time using the "no-tls1_3" Configure option.
 
-=item SSL_CTX_set_ciphersuites() and SSL_set_ciphersuites() changes.
+=item -
+
+SSL_CTX_set_ciphersuites() and SSL_set_ciphersuites() changes.
 
 The methods now ignore unknown ciphers.
 
-=item Security callback change.
+=item -
+
+Security callback change.
 
 The security callback, which can be customised by application code, supports
 the security operation SSL_SECOP_TMP_DH. This is defined to take an EVP_PKEY
@@ -1758,32 +2242,38 @@ according to the definition of SSL_SECOP_TMP_DH, and is inconsistent with all
 of the other locations. Therefore this client side call has been changed to
 pass an EVP_PKEY instead.
 
-=item New SSL option SSL_OP_IGNORE_UNEXPECTED_EOF
+=item -
+
+New SSL option SSL_OP_IGNORE_UNEXPECTED_EOF
 
 The SSL option SSL_OP_IGNORE_UNEXPECTED_EOF is introduced. If that option
 is set, an unexpected EOF is ignored, it pretends a close notify was received
 instead and so the returned error becomes SSL_ERROR_ZERO_RETURN.
 
-=item The security strength of SHA1 and MD5 based signatures in TLS has been reduced.
+=item -
+
+The security strength of SHA1 and MD5 based signatures in TLS has been reduced.
 
 This results in SSL 3, TLS 1.0, TLS 1.1 and DTLS 1.0 no longer
 working at the default security level of 1 and instead requires security
 level 0. The security level can be changed either using the cipher string
-with `@SECLEVEL`, or calling L<SSL_CTX_set_security_level(3)>. This also means
+with `C<@SECLEVEL>, or calling L<SSL_CTX_set_security_level(3)>. This also means
 that where the signature algorithms extension is missing from a ClientHello
 then the handshake will fail in TLS 1.2 at security level 1. This is because,
 although this extension is optional, failing to provide one means that
 OpenSSL will fallback to a default set of signature algorithms. This default
 set requires the availability of SHA1.
 
-=item X509 certificates signed using SHA1 are no longer allowed at security level 1 and above.
+=item -
+
+X509 certificates signed using SHA1 are no longer allowed at security level 1 and above.
 
 In TLS/SSL the default security level is 1. It can be set either using the cipher
-string with `@SECLEVEL`, or calling L<SSL_CTX_set_security_level(3)>. If the
+string with C<@SECLEVEL>, or calling L<SSL_CTX_set_security_level(3)>. If the
 leaf certificate is signed with SHA-1, a call to L<SSL_CTX_use_certificate(3)>
 will fail if the security level is not lowered first.
 Outside TLS/SSL, the default security level is -1 (effectively 0). It can
-be set using L<X509_VERIFY_PARAM_set_auth_level(3)> or using the `-auth_level`
+be set using L<X509_VERIFY_PARAM_set_auth_level(3)> or using the B<-auth_level>
 options of the commands.
 
 =back


### PR DESCRIPTION
The markup needed a few touch-ups
