### PR TITLE
property: convert integers to strings properly.

### DIFF
--- a/crypto/property/property_parse.c
+++ b/crypto/property/property_parse.c
@@ -658,11 +658,15 @@ static void put_str(const char *str, char **buf, size_t *remain, size_t *needed)
     }
 }
 
-static void put_num(int val, char **buf, size_t *remain, size_t *needed)
+static void put_num(int64_t val, char **buf, size_t *remain, size_t *needed)
 {
-    int tmpval = val;
+    int64_t tmpval = val;
     size_t len = 1;
 
+    if (tmpval < 0) {
+        len++;
+        tmpval = -tmpval;
+    }
     for (; tmpval > 9; len++, tmpval /= 10);
 
     *needed += len;
@@ -670,7 +674,7 @@ static void put_num(int val, char **buf, size_t *remain, size_t *needed)
     if (*remain == 0)
         return;
 
-    BIO_snprintf(*buf, *remain, "%d", val);
+    BIO_snprintf(*buf, *remain, "%lld", (long long int)val);
     if (*remain < len) {
         *buf += *remain;
         *remain = 0;

--- a/test/property_test.c
+++ b/test/property_test.c
@@ -1,4 +1,4 @@
-;/*
+/*
  * Copyright 2019-2021 The OpenSSL Project Authors. All Rights Reserved.
  * Copyright (c) 2019, Oracle and/or its affiliates.  All rights reserved.
  *

--- a/test/property_test.c
+++ b/test/property_test.c
@@ -1,4 +1,4 @@
-/*
+;/*
  * Copyright 2019-2021 The OpenSSL Project Authors. All Rights Reserved.
  * Copyright (c) 2019, Oracle and/or its affiliates.  All rights reserved.
  *
@@ -500,7 +500,6 @@ int setup_tests(void)
     ADD_TEST(test_property);
     ADD_TEST(test_query_cache_stochastic);
     ADD_TEST(test_fips_mode);
-    printf("hi\n");
     ADD_ALL_TESTS(test_property_list_to_string, OSSL_NELEM(to_string_tests));
     return 1;
 }

--- a/test/property_test.c
+++ b/test/property_test.c
@@ -435,54 +435,51 @@ err:
     return ret;
 }
 
-static int test_property_list_to_string(void)
+static struct {
+    const char *in;
+    const char *out;
+} to_string_tests[] = {
+    { "fips=yes", "fips=yes" },
+    { "fips!=yes", "fips!=yes" },
+    { "fips = yes", "fips=yes" },
+    { "fips", "fips=yes" },
+    { "fips=no", "fips=no" },
+    { "-fips", "-fips" },
+    { "?fips=yes", "?fips=yes" },
+    { "fips=yes,provider=fips", "fips=yes,provider=fips" },
+    { "fips = yes , provider = fips", "fips=yes,provider=fips" },
+    { "fips=yes,provider!=fips", "fips=yes,provider!=fips" },
+    { "fips=yes,?provider=fips", "fips=yes,?provider=fips" },
+    { "fips=yes,-provider", "fips=yes,-provider" },
+      /* foo is an unknown internal name */
+    { "foo=yes,fips=yes", "fips=yes"},
+    { "", "" },
+    { "fips=3", "fips=3" },
+    { "fips=-3", "fips=-3" },
+    { NULL, "" }
+};
+
+static int test_property_list_to_string(int i)
 {
     OSSL_PROPERTY_LIST *pl = NULL;
     int ret = 0;
-    struct props_list_str {
-        const char *in;
-        const char *out;
-    } props[] = {
-        { "fips=yes", "fips=yes" },
-        { "fips!=yes", "fips!=yes" },
-        { "fips = yes", "fips=yes" },
-        { "fips", "fips=yes" },
-        { "fips=no", "fips=no" },
-        { "-fips", "-fips" },
-        { "?fips=yes", "?fips=yes" },
-        { "fips=yes,provider=fips", "fips=yes,provider=fips" },
-        { "fips = yes , provider = fips", "fips=yes,provider=fips" },
-        { "fips=yes,provider!=fips", "fips=yes,provider!=fips" },
-        { "fips=yes,?provider=fips", "fips=yes,?provider=fips" },
-        { "fips=yes,-provider", "fips=yes,-provider" },
-          /* foo is an unknown internal name */
-        { "foo=yes,fips=yes", "fips=yes"},
-        { "", "" },
-        { NULL, "" }
-    };
-    size_t i, bufsize;
+    size_t bufsize;
     char *buf = NULL;
 
-    for (i = 0; i < OSSL_NELEM(props); i++) {
-        if (props[i].in != NULL
-                && !TEST_ptr(pl = ossl_parse_query(NULL, props[i].in, 1)))
-            goto err;
-        bufsize = ossl_property_list_to_string(NULL, pl, NULL, 0);
-        if (!TEST_size_t_gt(bufsize, 0))
-            goto err;
-        buf = OPENSSL_malloc(bufsize);
-        if (!TEST_ptr(buf)
-                || !TEST_size_t_eq(ossl_property_list_to_string(NULL, pl, buf,
-                                                                bufsize),
-                                   bufsize)
-                || !TEST_str_eq(props[i].out, buf)
-                || !TEST_size_t_eq(bufsize, strlen(props[i].out) + 1))
-            goto err;
-        OPENSSL_free(buf);
-        buf = NULL;
-        ossl_property_free(pl);
-        pl = NULL;
-    }
+    if (to_string_tests[i].in != NULL
+            && !TEST_ptr(pl = ossl_parse_query(NULL, to_string_tests[i].in, 1)))
+        goto err;
+    bufsize = ossl_property_list_to_string(NULL, pl, NULL, 0);
+    if (!TEST_size_t_gt(bufsize, 0))
+        goto err;
+    buf = OPENSSL_malloc(bufsize);
+    if (!TEST_ptr(buf)
+            || !TEST_size_t_eq(ossl_property_list_to_string(NULL, pl, buf,
+                                                            bufsize),
+                               bufsize)
+            || !TEST_str_eq(to_string_tests[i].out, buf)
+            || !TEST_size_t_eq(bufsize, strlen(to_string_tests[i].out) + 1))
+        goto err;
 
     ret = 1;
  err:
@@ -503,6 +500,7 @@ int setup_tests(void)
     ADD_TEST(test_property);
     ADD_TEST(test_query_cache_stochastic);
     ADD_TEST(test_fips_mode);
-    ADD_TEST(test_property_list_to_string);
+    printf("hi\n");
+    ADD_ALL_TESTS(test_property_list_to_string, OSSL_NELEM(to_string_tests));
     return 1;
 }


### PR DESCRIPTION
The int64_t type was converted to int (truncation).
Negative values were not handled at all.

This addresses the current AppVeyor failure.

- [ ] documentation is added or updated
- [x] tests are added or updated
