### PR TITLE
VMS: Fix run of generic generator programs in descrip.mms.tmpl

### DIFF
--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -997,7 +997,7 @@ EOF
           $gen0 = platform->bin($gen0);
           return <<"EOF";
 $args{src} : $gen0 $deps
-	PIPE $gen0$gen_args > \$@
+	PIPE MCR $gen0$gen_args > \$@
 EOF
       } else {
           #


### PR DESCRIPTION
For a generic program, always go through the MCR utility.
