### PR TITLE
TEST: Avoid using just 'example.com'  - test_cmp_http

### DIFF
--- a/test/recipes/80-test_cmp_http_data/Mock/test.cnf
+++ b/test/recipes/80-test_cmp_http_data/Mock/test.cnf
@@ -135,6 +135,6 @@ subjectAltName = @alt_names_3
 
 [alt_names_3]
 DNS.0 = localhost
-DNS.1 = example.com
-DNS.2 = example2.com
-DNS__3 = example3.com
+DNS.1 = xn--rksmrgs-5wao1o.example.com
+DNS.2 = xn--rkmacka-5wa.example.com
+DNS__3 = xn--rksallad-0za.example.com

--- a/test/recipes/80-test_cmp_http_data/test_connection.csv
+++ b/test/recipes/80-test_cmp_http_data/test_connection.csv
@@ -5,7 +5,7 @@ expected,description, -section,val, -server,val, -proxy,val, -no_proxy,val, -tls
 TBD,Domain name, -section,, -server,_SERVER_CN:_SERVER_PORT,,,,,,,,,,,,,,
 TBD,IP address, -section,, -server,_SERVER_IP:_SERVER_PORT,,,,,,,,,,,,,,
 ,,,,,,,,,,,,,,,,,,,
-1,wrong server, -section,, -server,example.com:_SERVER_PORT,,,,,BLANK,,,, -msg_timeout,1,BLANK,,BLANK,
+1,wrong server, -section,, -server,xn--rksmrgs-5wao1o.example.com:_SERVER_PORT,,,,,BLANK,,,, -msg_timeout,1,BLANK,,BLANK,
 1,wrong server port, -section,, -server,_SERVER_HOST:99,,,,,BLANK,,,, -msg_timeout,1,BLANK,,BLANK,
 1,server default port, -section,, -server,_SERVER_HOST,,,,,BLANK,,,, -msg_timeout,1,BLANK,,BLANK,
 1,server port out of range, -section,, -server,_SERVER_HOST:65536,,,,,BLANK,,,,BLANK,,BLANK,,BLANK,


### PR DESCRIPTION
We have reports that some are using example.com in their /etc/hosts
for testing purposes, so we can't necessarily assume that those will
fail.

We fix it by using "random" hosts in that domain.

Fixes #15395
