### PR TITLE
Fix 'openssl req' to be able to use provided keytypes

### DIFF
--- a/apps/req.c
+++ b/apps/req.c
@@ -1508,16 +1508,16 @@ static EVP_PKEY_CTX *set_keygen_ctx(const char *gstr,
     int expect_paramfile = 0;
     const char *paramfile = NULL;
 
-    /* Default from input */
-    if (*pkeytype != NULL)
-        keytype = *pkeytype;
-    if (pkeylen != NULL)
-        keylen = *pkeylen;
-
     /* Treat the first part of gstr, and only that */
     if (gstr == NULL) {
+        /*
+         * Special case: when no string given, default to RSA and the
+         * key length given by |*pkeylen|.
+         */
         keytype = "RSA";
+        keylen = *pkeylen;
     } else if (gstr[0] >= '0' && gstr[0] <= '9') {
+        /* Special case: only keylength given from string, so default to RSA */
         keytype = "RSA";
         /* The second part treatment will do the rest */
     } else {

--- a/apps/req.c
+++ b/apps/req.c
@@ -1592,7 +1592,11 @@ static EVP_PKEY_CTX *set_keygen_ctx(const char *gstr,
             return NULL;
         }
 
-        gctx = EVP_PKEY_CTX_new(param, keygen_engine);
+        if (keygen_engine != NULL)
+            gctx = EVP_PKEY_CTX_new(param, keygen_engine);
+        else
+            gctx = EVP_PKEY_CTX_new_from_pkey(app_get0_libctx(),
+                                              param, app_get0_propq());
         keylen = EVP_PKEY_bits(param);
         EVP_PKEY_free(param);
     } else {
@@ -1623,9 +1627,9 @@ static EVP_PKEY_CTX *set_keygen_ctx(const char *gstr,
         size_t bits = keylen;
 
         params[0] =
-            OSSL_PARAM_construct_size_t(OSSL_PKEY_PARAM_RSA_BITS, &bits);
+            OSSL_PARAM_construct_size_t(OSSL_PKEY_PARAM_BITS, &bits);
         if (EVP_PKEY_CTX_set_params(gctx, params) <= 0) {
-            BIO_puts(bio_err, "Error setting RSA keysize\n");
+            BIO_puts(bio_err, "Error setting keysize\n");
             EVP_PKEY_CTX_free(gctx);
             return NULL;
         }

--- a/apps/req.c
+++ b/apps/req.c
@@ -637,6 +637,7 @@ int req_main(int argc, char **argv)
 
         if (newkey_len < MIN_KEY_LENGTH
             && (EVP_PKEY_CTX_is_a(genctx, "RSA")
+                || EVP_PKEY_CTX_is_a(genctx, "RSA-PSS")
                 || EVP_PKEY_CTX_is_a(genctx, "DSA"))) {
             BIO_printf(bio_err, "Private key length is too short,\n");
             BIO_printf(bio_err, "it needs to be at least %d bits, not %ld.\n",
@@ -644,8 +645,9 @@ int req_main(int argc, char **argv)
             goto end;
         }
 
-        if (EVP_PKEY_CTX_is_a(genctx, "RSA")
-                && newkey_len > OPENSSL_RSA_MAX_MODULUS_BITS)
+        if (newkey_len > OPENSSL_RSA_MAX_MODULUS_BITS
+            && (EVP_PKEY_CTX_is_a(genctx, "RSA")
+                || EVP_PKEY_CTX_is_a(genctx, "RSA-PSS")))
             BIO_printf(bio_err,
                        "Warning: It is not recommended to use more than %d bit for RSA keys.\n"
                        "         Your key size is %ld! Larger key size may behave not as expected.\n",

--- a/apps/req.c
+++ b/apps/req.c
@@ -1599,7 +1599,7 @@ static EVP_PKEY_CTX *set_keygen_ctx(const char *gstr,
         else
             gctx = EVP_PKEY_CTX_new_from_pkey(app_get0_libctx(),
                                               param, app_get0_propq());
-        keylen = EVP_PKEY_bits(param);
+        *pkeylen = EVP_PKEY_bits(param);
         EVP_PKEY_free(param);
     } else {
         if (keygen_engine != NULL) {


### PR DESCRIPTION
'openssl req' was still using old APIs that could only deal with
EVP_PKEY_ASN1_METHOD based EVP_PKEYs.  Now modified to use more
generic functions that can handle all forms of EVP_PKEY, this app
should be ready for the future.

Fixes #15388
