### PR TITLE
Let `openssl crl` support the use of engines.

### DIFF
--- a/apps/crl.c
+++ b/apps/crl.c
@@ -201,11 +201,11 @@ int crl_main(int argc, char **argv)
         case OPT_MD:
             digestname = opt_unknown();
             break;
-#ifndef OPENSSL_NO_ENGINE
         case OPT_ENGINE:
+#ifndef OPENSSL_NO_ENGINE
             e = setup_engine(opt_arg(), 0);
-            break;
 #endif
+            break;
         case OPT_PROV_CASES:
             if (!opt_provider(o))
                 goto end;

--- a/apps/crl.c
+++ b/apps/crl.c
@@ -24,13 +24,16 @@ typedef enum OPTION_choice {
     OPT_ISSUER, OPT_LASTUPDATE, OPT_NEXTUPDATE, OPT_FINGERPRINT,
     OPT_CRLNUMBER, OPT_BADSIG, OPT_GENDELTA, OPT_CAPATH, OPT_CAFILE, OPT_CASTORE,
     OPT_NOCAPATH, OPT_NOCAFILE, OPT_NOCASTORE, OPT_VERIFY, OPT_TEXT, OPT_HASH,
-    OPT_HASH_OLD, OPT_NOOUT, OPT_NAMEOPT, OPT_MD, OPT_PROV_ENUM
+    OPT_HASH_OLD, OPT_NOOUT, OPT_NAMEOPT, OPT_MD, OPT_PROV_ENUM, OPT_ENGINE
 } OPTION_CHOICE;
 
 const OPTIONS crl_options[] = {
     OPT_SECTION("General"),
     {"help", OPT_HELP, '-', "Display this summary"},
     {"verify", OPT_VERIFY, '-', "Verify CRL signature"},
+#ifndef OPENSSL_NO_ENGINE
+    {"engine", OPT_ENGINE, 's', "Use engine, possibly a hardware device"},
+#endif
 
     OPT_SECTION("Input"),
     {"in", OPT_IN, '<', "Input file - default stdin"},
@@ -94,6 +97,9 @@ int crl_main(int argc, char **argv)
     int i;
 #ifndef OPENSSL_NO_MD5
     int hash_old = 0;
+#endif
+#ifndef OPENSSL_NO_ENGINE
+    ENGINE *e = NULL;
 #endif
 
     prog = opt_init(argc, argv, crl_options);
@@ -195,6 +201,11 @@ int crl_main(int argc, char **argv)
         case OPT_MD:
             digestname = opt_unknown();
             break;
+#ifndef OPENSSL_NO_ENGINE
+        case OPT_ENGINE:
+            e = setup_engine(opt_arg(), 0);
+            break;
+#endif
         case OPT_PROV_CASES:
             if (!opt_provider(o))
                 goto end;
@@ -385,5 +396,8 @@ int crl_main(int argc, char **argv)
     X509_CRL_free(x);
     X509_STORE_CTX_free(ctx);
     X509_STORE_free(store);
+#ifndef OPENSSL_NO_ENGINE
+    release_engine(e);
+#endif
     return ret;
 }

--- a/doc/man1/openssl-crl.pod.in
+++ b/doc/man1/openssl-crl.pod.in
@@ -29,6 +29,7 @@ B<openssl> B<crl>
 [B<-nextupdate>]
 {- $OpenSSL::safe::opt_name_synopsis -}
 {- $OpenSSL::safe::opt_trust_synopsis -}
+{- $OpenSSL::safe::opt_engine_synopsis -}
 {- $OpenSSL::safe::opt_provider_synopsis -}
 
 =head1 DESCRIPTION
@@ -127,6 +128,8 @@ Output the nextUpdate field.
 
 {- $OpenSSL::safe::opt_trust_item -}
 
+{- $OpenSSL::safe::opt_engine_item -}
+
 {- $OpenSSL::safe::opt_provider_item -}
 
 =back
@@ -153,6 +156,10 @@ L<openssl-crl2pkcs7(1)>,
 L<openssl-ca(1)>,
 L<openssl-x509(1)>,
 L<ossl_store-file(7)>
+
+=head1 HISTORY
+
+The B<-engine> option was deprecated in OpenSSL 3.0.
 
 =head1 COPYRIGHT
 


### PR DESCRIPTION
Fixes #11751
