### PR TITLE
Allow TLS13_AD_MISSING_EXTENSION for older versions

### DIFF
--- a/ssl/s3_enc.c
+++ b/ssl/s3_enc.c
@@ -590,7 +590,7 @@ int ssl3_alert_code(int code)
     case SSL_AD_CERTIFICATE_REQUIRED:
         return SSL_AD_HANDSHAKE_FAILURE;
     case TLS13_AD_MISSING_EXTENSION:
-        return TLS13_AD_MISSING_EXTENSION;
+        return SSL_AD_HANDSHAKE_FAILURE;
     default:
         return -1;
     }

--- a/ssl/s3_enc.c
+++ b/ssl/s3_enc.c
@@ -589,6 +589,8 @@ int ssl3_alert_code(int code)
         return TLS1_AD_NO_APPLICATION_PROTOCOL;
     case SSL_AD_CERTIFICATE_REQUIRED:
         return SSL_AD_HANDSHAKE_FAILURE;
+    case TLS13_AD_MISSING_EXTENSION:
+        return TLS13_AD_MISSING_EXTENSION;
     default:
         return -1;
     }

--- a/ssl/t1_enc.c
+++ b/ssl/t1_enc.c
@@ -849,7 +849,7 @@ int tls1_alert_code(int code)
     case SSL_AD_CERTIFICATE_REQUIRED:
         return SSL_AD_HANDSHAKE_FAILURE;
     case TLS13_AD_MISSING_EXTENSION:
-        return TLS13_AD_MISSING_EXTENSION;
+        return SSL_AD_HANDSHAKE_FAILURE;
     default:
         return -1;
     }

--- a/ssl/t1_enc.c
+++ b/ssl/t1_enc.c
@@ -848,6 +848,8 @@ int tls1_alert_code(int code)
         return TLS1_AD_NO_APPLICATION_PROTOCOL;
     case SSL_AD_CERTIFICATE_REQUIRED:
         return SSL_AD_HANDSHAKE_FAILURE;
+    case TLS13_AD_MISSING_EXTENSION:
+        return TLS13_AD_MISSING_EXTENSION;
     default:
         return -1;
     }


### PR DESCRIPTION
Add a pass-through switch case for TLS13_AD_MISSING_EXTENSION in
ssl3_alert_code() and tls1_alert_code(), so that the call to
SSLfatal() in final_psk() will always actually generate an alert,
even for non-TLS1.3 protocol versions.

Fixes #15375

