### PR TITLE
Don't call EVP_fetchbyname if provider options used.

### DIFF
--- a/apps/cms.c
+++ b/apps/cms.c
@@ -721,15 +721,15 @@ int cms_main(int argc, char **argv)
         goto end;
 
     if (digestname != NULL) {
-        if (!opt_md(digestname, &sign_md))
+        if (!opt_md(app_get0_libctx(), digestname, app_get0_propq(), &sign_md))
             goto end;
     }
     if (ciphername != NULL) {
-        if (!opt_cipher(ciphername, &cipher))
+        if (!opt_cipher(app_get0_libctx(), ciphername, app_get0_propq(), &cipher))
             goto end;
     }
     if (wrapname != NULL) {
-        if (!opt_cipher(wrapname, &wrap_cipher))
+        if (!opt_cipher(app_get0_libctx(), wrapname, app_get0_propq(), &wrap_cipher))
             goto end;
     }
 

--- a/apps/crl.c
+++ b/apps/crl.c
@@ -208,7 +208,7 @@ int crl_main(int argc, char **argv)
         goto opthelp;
 
     if (digestname != NULL) {
-        if (!opt_md(digestname, &digest))
+        if (!opt_md(app_get0_libctx(), digestname, app_get0_propq(), &digest))
             goto opthelp;
     }
     x = load_crl(infile, informat, 1, "CRL");

--- a/apps/dgst.c
+++ b/apps/dgst.c
@@ -230,7 +230,7 @@ int dgst_main(int argc, char **argv)
         goto end;
 
     if (digestname != NULL) {
-        if (!opt_md(digestname, &md))
+        if (!opt_md(app_get0_libctx(), digestname, app_get0_propq(), &md))
             goto opthelp;
     }
 

--- a/apps/dsa.c
+++ b/apps/dsa.c
@@ -166,7 +166,7 @@ int dsa_main(int argc, char **argv)
         goto opthelp;
 
     if (ciphername != NULL) {
-        if (!opt_cipher(ciphername, &enc))
+        if (!opt_cipher(app_get0_libctx(), ciphername, app_get0_propq(), &enc))
             goto end;
     }
     private = pubin || pubout ? 0 : 1;

--- a/apps/ec.c
+++ b/apps/ec.c
@@ -162,7 +162,7 @@ int ec_main(int argc, char **argv)
         goto opthelp;
 
     if (ciphername != NULL) {
-        if (!opt_cipher(ciphername, &enc))
+        if (!opt_cipher(app_get0_libctx(), ciphername, app_get0_propq(), &enc))
             goto opthelp;
     }
     private = param_out || pubin || pubout ? 0 : 1;

--- a/apps/enc.c
+++ b/apps/enc.c
@@ -297,7 +297,7 @@ int enc_main(int argc, char **argv)
 
     /* Get the cipher name, either from progname (if set) or flag. */
     if (ciphername != NULL) {
-        if (!opt_cipher(ciphername, &cipher))
+        if (!opt_cipher(app_get0_libctx(), ciphername, app_get0_propq(), &cipher))
             goto opthelp;
     }
     if (cipher && EVP_CIPHER_flags(cipher) & EVP_CIPH_FLAG_AEAD_CIPHER) {
@@ -309,7 +309,7 @@ int enc_main(int argc, char **argv)
         goto end;
     }
     if (digestname != NULL) {
-        if (!opt_md(digestname, &dgst))
+        if (!opt_md(app_get0_libctx(), digestname, app_get0_propq(), &dgst))
             goto opthelp;
     }
     if (dgst == NULL)

--- a/apps/gendsa.c
+++ b/apps/gendsa.c
@@ -111,7 +111,7 @@ int gendsa_main(int argc, char **argv)
         goto end;
 
     if (ciphername != NULL) {
-        if (!opt_cipher(ciphername, &enc))
+        if (!opt_cipher(app_get0_libctx(), ciphername, app_get0_propq(), &enc))
             goto end;
     }
     private = 1;

--- a/apps/genpkey.c
+++ b/apps/genpkey.c
@@ -164,7 +164,7 @@ int genpkey_main(int argc, char **argv)
         }
     }
     if (ciphername != NULL) {
-        if (!opt_cipher(ciphername, &cipher) || do_param == 1)
+        if (!opt_cipher(app_get0_libctx(), ciphername, app_get0_propq(), &cipher) || do_param == 1)
             goto opthelp;
         m = EVP_CIPHER_mode(cipher);
         if (m == EVP_CIPH_GCM_MODE || m == EVP_CIPH_CCM_MODE

--- a/apps/genrsa.c
+++ b/apps/genrsa.c
@@ -167,7 +167,7 @@ opthelp:
 
     private = 1;
     if (ciphername != NULL) {
-        if (!opt_cipher(ciphername, &enc))
+        if (!opt_cipher(app_get0_libctx(), ciphername, app_get0_propq(), &enc))
             goto end;
     }
     if (!app_passwd(NULL, passoutarg, NULL, &passout)) {

--- a/apps/include/opt.h
+++ b/apps/include/opt.h
@@ -368,6 +368,7 @@ int opt_cipher(const char *name, EVP_CIPHER **cipherp);
 int opt_cipher_silent(const char *name, EVP_CIPHER **cipherp);
 int opt_md(const char *name, EVP_MD **mdp);
 int opt_md_silent(const char *name, EVP_MD **mdp);
+int opt_incr_provider_options(int);
 
 int opt_int(const char *arg, int *result);
 int opt_int_arg(void);

--- a/apps/include/opt.h
+++ b/apps/include/opt.h
@@ -364,10 +364,14 @@ int opt_next(void);
 char *opt_flag(void);
 char *opt_arg(void);
 char *opt_unknown(void);
-int opt_cipher(const char *name, EVP_CIPHER **cipherp);
-int opt_cipher_silent(const char *name, EVP_CIPHER **cipherp);
-int opt_md(const char *name, EVP_MD **mdp);
-int opt_md_silent(const char *name, EVP_MD **mdp);
+int opt_cipher(OSSL_LIB_CTX *libctx, const char *name, const char *propq,
+               EVP_CIPHER **cipherp);
+int opt_cipher_silent(OSSL_LIB_CTX *libctx, const char *name, const char *propq,
+                      EVP_CIPHER **cipherp);
+int opt_md(OSSL_LIB_CTX *libctx, const char *name, const char *propq,
+           EVP_MD **mdp);
+int opt_md_silent(OSSL_LIB_CTX *libctx, const char *name, const char *propq,
+                  EVP_MD **mdp);
 int opt_incr_provider_options(int);
 
 int opt_int(const char *arg, int *result);

--- a/apps/lib/app_provider.c
+++ b/apps/lib/app_provider.c
@@ -64,6 +64,7 @@ static int opt_provider_path(const char *path)
 
 int opt_provider(int opt)
 {
+    opt_incr_provider_options(1);
     switch ((enum prov_range)opt) {
     case OPT_PROV__FIRST:
     case OPT_PROV__LAST:

--- a/apps/lib/opt.c
+++ b/apps/lib/opt.c
@@ -381,12 +381,14 @@ int opt_incr_provider_options(int x)
 }
 
 /* Parse a cipher name, put it in *EVP_CIPHER; return 0 on failure, else 1. */
-int opt_cipher_silent(const char *name, EVP_CIPHER **cipherp)
+int opt_cipher_silent(OSSL_LIB_CTX *libctx,
+                      const char *name, const char *propq,
+                      EVP_CIPHER **cipherp)
 {
     EVP_CIPHER_free(*cipherp);
 
     ERR_set_mark();
-    if ((*cipherp = EVP_CIPHER_fetch(NULL, name, NULL)) != NULL
+    if ((*cipherp = EVP_CIPHER_fetch(libctx, name, propq)) != NULL
             || (!opt_incr_provider_options(0)
                 && (*cipherp =
                         (EVP_CIPHER *)EVP_get_cipherbyname(name)) != NULL)) {
@@ -397,11 +399,12 @@ int opt_cipher_silent(const char *name, EVP_CIPHER **cipherp)
     return 0;
 }
 
-int opt_cipher(const char *name, EVP_CIPHER **cipherp)
+int opt_cipher(OSSL_LIB_CTX *libctx, const char *name, const char *propq,
+               EVP_CIPHER **cipherp)
 {
     int ret;
 
-    if ((ret = opt_cipher_silent(name, cipherp)) == 0)
+    if ((ret = opt_cipher_silent(libctx, name, propq, cipherp)) == 0)
        opt_printf_stderr("%s: Unknown cipher: %s\n", prog, name);
     return ret;
 }
@@ -409,12 +412,13 @@ int opt_cipher(const char *name, EVP_CIPHER **cipherp)
 /*
  * Parse message digest name, put it in *EVP_MD; return 0 on failure, else 1.
  */
-int opt_md_silent(const char *name, EVP_MD **mdp)
+int opt_md_silent(OSSL_LIB_CTX *libctx, const char *name, const char *propq,
+                  EVP_MD **mdp)
 {
     EVP_MD_free(*mdp);
 
     ERR_set_mark();
-    if ((*mdp = EVP_MD_fetch(NULL, name, NULL)) != NULL
+    if ((*mdp = EVP_MD_fetch(libctx, name, propq)) != NULL
             || (!opt_incr_provider_options(0)
                 && (*mdp = (EVP_MD *)EVP_get_digestbyname(name)) != NULL)) {
         ERR_pop_to_mark();
@@ -424,11 +428,12 @@ int opt_md_silent(const char *name, EVP_MD **mdp)
     return 0;
 }
 
-int opt_md(const char *name, EVP_MD **mdp)
+int opt_md(OSSL_LIB_CTX *libctx, const char *name, const char *propq,
+           EVP_MD **mdp)
 {
     int ret;
 
-    if ((ret = opt_md_silent(name, mdp)) == 0)
+    if ((ret = opt_md_silent(libctx, name, propq, mdp)) == 0)
         opt_printf_stderr("%s: Unknown option or message digest: %s\n", prog,
                           name != NULL ? name : "\"\"");
     return ret;

--- a/apps/ocsp.c
+++ b/apps/ocsp.c
@@ -508,7 +508,7 @@ int ocsp_main(int argc, char **argv)
                 goto end;
             break;
         case OPT_RCID:
-            if (!opt_md(opt_arg(), &resp_certid_md))
+            if (!opt_md(app_get0_libctx(), opt_arg(), app_get0_propq(), &resp_certid_md))
                 goto opthelp;
             break;
         case OPT_MD:
@@ -518,7 +518,7 @@ int ocsp_main(int argc, char **argv)
                            prog);
                 goto opthelp;
             }
-            if (!opt_md(opt_unknown(), &cert_id_md))
+            if (!opt_md(app_get0_libctx(), opt_unknown(), app_get0_propq(), &cert_id_md))
                 goto opthelp;
             trailing_md = 1;
             break;
@@ -546,7 +546,7 @@ int ocsp_main(int argc, char **argv)
     }
 
     if (respdigname != NULL) {
-        if (!opt_md(respdigname, &rsign_md))
+        if (!opt_md(app_get0_libctx(), respdigname, app_get0_propq(), &rsign_md))
             goto end;
     }
 

--- a/apps/pkcs12.c
+++ b/apps/pkcs12.c
@@ -364,7 +364,7 @@ int pkcs12_main(int argc, char **argv)
         goto end;
 
     if (ciphername != NULL) {
-        if (!opt_cipher(ciphername, &enc))
+        if (!opt_cipher(app_get0_libctx(), ciphername, app_get0_propq(), &enc))
             goto opthelp;
     }
     if (export_pkcs12) {
@@ -672,7 +672,7 @@ int pkcs12_main(int argc, char **argv)
         }
 
         if (macalg != NULL) {
-            if (!opt_md(macalg, &macmd))
+            if (!opt_md(app_get0_libctx(), macalg, app_get0_propq(), &macmd))
                 goto opthelp;
         }
 

--- a/apps/pkcs8.c
+++ b/apps/pkcs8.c
@@ -202,7 +202,7 @@ int pkcs8_main(int argc, char **argv)
         goto end;
 
     if (ciphername != NULL) {
-        if (!opt_cipher(ciphername, &cipher))
+        if (!opt_cipher(app_get0_libctx(), ciphername, app_get0_propq(), &cipher))
             goto opthelp;
     }
 

--- a/apps/pkey.c
+++ b/apps/pkey.c
@@ -187,7 +187,7 @@ int pkey_main(int argc, char **argv)
     private = (!noout && !pubout) || (text && !text_pub);
 
     if (ciphername != NULL) {
-        if (!opt_cipher(ciphername, &cipher))
+        if (!opt_cipher(app_get0_libctx(), ciphername, app_get0_propq(), &cipher))
             goto opthelp;
     }
     if (cipher == NULL) {

--- a/apps/rsa.c
+++ b/apps/rsa.c
@@ -189,7 +189,7 @@ int rsa_main(int argc, char **argv)
         goto opthelp;
 
     if (ciphername != NULL) {
-        if (!opt_cipher(ciphername, &enc))
+        if (!opt_cipher(app_get0_libctx(), ciphername, app_get0_propq(), &enc))
             goto opthelp;
     }
     private = (text && !pubin) || (!pubout && !noout) ? 1 : 0;

--- a/apps/smime.c
+++ b/apps/smime.c
@@ -363,11 +363,11 @@ int smime_main(int argc, char **argv)
         goto end;
 
     if (digestname != NULL) {
-        if (!opt_md(digestname, &sign_md))
+        if (!opt_md(app_get0_libctx(), digestname, app_get0_propq(), &sign_md))
             goto opthelp;
     }
     if (ciphername != NULL) {
-        if (!opt_cipher(ciphername, &cipher))
+        if (!opt_cipher(app_get0_libctx(), ciphername, app_get0_propq(), &cipher))
             goto opthelp;
     }
     if (!(operation & SMIME_SIGNERS) && (skkeys != NULL || sksigners != NULL)) {

--- a/apps/speed.c
+++ b/apps/speed.c
@@ -507,7 +507,7 @@ static int have_md(const char *name)
     int ret = 0;
     EVP_MD *md = NULL;
 
-    if (opt_md_silent(name, &md)) {
+    if (opt_md_silent(app_get0_libctx(), name, app_get0_propq(), &md)) {
         EVP_MD_CTX *ctx = EVP_MD_CTX_new();
 
         if (ctx != NULL && EVP_DigestInit(ctx, md) > 0)
@@ -523,7 +523,7 @@ static int have_cipher(const char *name)
     int ret = 0;
     EVP_CIPHER *cipher = NULL;
 
-    if (opt_cipher_silent(name, &cipher)) {
+    if (opt_cipher_silent(app_get0_libctx(), name, app_get0_propq(), &cipher)) {
         EVP_CIPHER_CTX *ctx = EVP_CIPHER_CTX_new();
 
         if (ctx != NULL
@@ -543,7 +543,7 @@ static int EVP_Digest_loop(const char *mdname, int algindex, void *args)
     int count;
     EVP_MD *md = NULL;
 
-    if (!opt_md_silent(mdname, &md))
+    if (!opt_md_silent(app_get0_libctx(), mdname, app_get0_propq(), &md))
         return -1;
     for (count = 0; COND(c[algindex][testnum]); count++) {
         if (!EVP_Digest(buf, (size_t)lengths[testnum], digest, NULL, md,
@@ -677,7 +677,7 @@ static EVP_CIPHER_CTX *init_evp_cipher_ctx(const char *ciphername,
     EVP_CIPHER_CTX *ctx = NULL;
     EVP_CIPHER *cipher = NULL;
 
-    if (!opt_cipher_silent(ciphername, &cipher))
+    if (!opt_cipher_silent(app_get0_libctx(), ciphername, app_get0_propq(), &cipher))
         return NULL;
 
     if ((ctx = EVP_CIPHER_CTX_new()) == NULL)
@@ -1492,7 +1492,7 @@ int speed_main(int argc, char **argv)
                 goto opterr;
             }
             ERR_set_mark();
-            if (!opt_cipher_silent(opt_arg(), &evp_cipher)) {
+            if (!opt_cipher_silent(app_get0_libctx(), opt_arg(), app_get0_propq(), &evp_cipher)) {
                 if (have_md(opt_arg()))
                     evp_md_name = opt_arg();
             }
@@ -2258,7 +2258,7 @@ int speed_main(int argc, char **argv)
 
         if (mac == NULL || evp_mac_ciphername == NULL)
             goto end;
-        if (!opt_cipher(evp_mac_ciphername, &cipher))
+        if (!opt_cipher(app_get0_libctx(), evp_mac_ciphername, app_get0_propq(), &cipher))
             goto end;
 
         keylen = EVP_CIPHER_key_length(cipher);

--- a/apps/storeutl.c
+++ b/apps/storeutl.c
@@ -264,7 +264,7 @@ int storeutl_main(int argc, char *argv[])
         goto opthelp;
 
     if (digestname != NULL) {
-        if (!opt_md(digestname, &digest))
+        if (!opt_md(app_get0_libctx(), digestname, app_get0_propq(), &digest))
             goto opthelp;
     }
 

--- a/apps/ts.c
+++ b/apps/ts.c
@@ -296,7 +296,7 @@ int ts_main(int argc, char **argv)
         goto end;
 
     if (digestname != NULL) {
-        if (!opt_md(digestname, &md))
+        if (!opt_md(app_get0_libctx(), digestname, app_get0_propq(), &md))
             goto opthelp;
     }
     if (mode == OPT_REPLY && passin &&

--- a/doc/internal/man3/OPTIONS.pod
+++ b/doc/internal/man3/OPTIONS.pod
@@ -5,6 +5,7 @@
 OPTIONS, OPT_PAIR, OPT_COMMON, OPT_ERR, OPT_EOF, OPT_HELP,
 opt_init, opt_progname, opt_appname, opt_getprog, opt_help,
 opt_begin, opt_next, opt_flag, opt_arg, opt_unknown, opt_cipher, opt_md,
+opt_cipher_silent, opt_md_silent,
 opt_int, opt_int_arg, opt_long, opt_ulong, opt_intmax, opt_uintmax,
 opt_format, opt_isdir, opt_string, opt_pair,
 opt_num_rest, opt_rest
@@ -34,6 +35,8 @@ opt_num_rest, opt_rest
  char *opt_unknown(void);
  int opt_cipher(const char *name, EVP_CIPHER **cipherp);
  int opt_md(const char *name, EVP_MD **mdp);
+ int opt_cipher_silent(const char *name, EVP_CIPHER **cipherp);
+ int opt_md_silent(const char *name, EVP_MD **mdp);
 
  int opt_int(const char *value, int *result);
  int opt_int_arg(void);
@@ -246,6 +249,9 @@ option to be be taken as digest algorithm, like C<-sha1>. The
 function opt_cipher() takes the specified I<name> and fills in
 the cipher into I<cipherp>.  The function opt_md() does the same
 thing for message digest.
+Both print an error message if the cipher cannot be loaded.
+The functions opt_cipher_silent() and opt_md_silent() do the same
+thing, but clear the stack and do not print an error message on error.
 
 There are a several useful functions for parsing numbers.  These are
 opt_int(), opt_long(), opt_ulong(), opt_intmax(), and opt_uintmax().  They all

--- a/doc/man1/openssl.pod
+++ b/doc/man1/openssl.pod
@@ -647,6 +647,11 @@ the PKCS#11 URI as defined in RFC 7512 should be possible to use directly:
 
 =head2 Provider Options
 
+If any of these options are given, then the default location for
+ciphers and digests (e.g., EVP_get_cipherbyname(3) and
+EVP_get_digestbyname(3))
+are not used.
+
 =over 4
 
 =item B<-provider> I<name>


### PR DESCRIPTION
This is an attempt to fix #15372.  If any provider flags are specified, only call `EVP_fetch`

Everything passes except the CMS tests.  I am not surprised. :)  I would also appreciate help, maybe from @ddvo once he's done hleping fix NonStop :)
