### PR TITLE
test_cmp_http.t: Improve ACCEPT port reporting and exclude NonStop ia64

### DIFF
--- a/NOTES-NONSTOP.md
+++ b/NOTES-NONSTOP.md
@@ -42,7 +42,7 @@ The TNS/E platform is build using the same set of builds specifying `nse`
 instead of `nsx` in the set above.
 
 You cannot build for TNS/E for FIPS, so you must specify the `no-fips`
-option to `./Configure`
+option to `./Configure`.
 
 About Prefix and OpenSSLDir
 ---------------------------

--- a/apps/lib/s_socket.c
+++ b/apps/lib/s_socket.c
@@ -195,6 +195,8 @@ int report_server_accept(BIO *out, int asock, int with_address)
 {
     int success = 0;
 
+    if (BIO_printf(out, "ACCEPT ") <= 0)
+        return 0;
     if (with_address) {
         union BIO_sock_info_u info;
         char *hostname = NULL;
@@ -206,16 +208,17 @@ int report_server_accept(BIO *out, int asock, int with_address)
             && (service = BIO_ADDR_service_string(info.addr, 1)) != NULL
             && BIO_printf(out,
                           strchr(hostname, ':') == NULL
-                          ? /* IPv4 */ "ACCEPT %s:%s\n"
-                          : /* IPv6 */ "ACCEPT [%s]:%s\n",
+                          ? /* IPv4 */ "%s:%s\n"
+                          : /* IPv6 */ "[%s]:%s\n",
                           hostname, service) > 0)
             success = 1;
+        else
+            (void)BIO_printf(out, "unknown:error\n");
 
         OPENSSL_free(hostname);
         OPENSSL_free(service);
         BIO_ADDR_free(info.addr);
-    } else {
-        (void)BIO_printf(out, "ACCEPT\n");
+    } else if (BIO_printf(out, "none:none\n") > 0) {
         success = 1;
     }
     (void)BIO_flush(out);

--- a/apps/lib/s_socket.c
+++ b/apps/lib/s_socket.c
@@ -195,7 +195,7 @@ int report_server_accept(BIO *out, int asock, int with_address)
 {
     int success = 0;
 
-    if (BIO_printf(out, "ACCEPT ") <= 0)
+    if (BIO_printf(out, "ACCEPT") <= 0)
         return 0;
     if (with_address) {
         union BIO_sock_info_u info;
@@ -208,8 +208,8 @@ int report_server_accept(BIO *out, int asock, int with_address)
             && (service = BIO_ADDR_service_string(info.addr, 1)) != NULL
             && BIO_printf(out,
                           strchr(hostname, ':') == NULL
-                          ? /* IPv4 */ "%s:%s\n"
-                          : /* IPv6 */ "[%s]:%s\n",
+                          ? /* IPv4 */ " %s:%s\n"
+                          : /* IPv6 */ " [%s]:%s\n",
                           hostname, service) > 0)
             success = 1;
         else
@@ -218,7 +218,7 @@ int report_server_accept(BIO *out, int asock, int with_address)
         OPENSSL_free(hostname);
         OPENSSL_free(service);
         BIO_ADDR_free(info.addr);
-    } else if (BIO_printf(out, "none:none\n") > 0) {
+    } else if (BIO_printf(out, "\n") > 0) {
         success = 1;
     }
     (void)BIO_flush(out);

--- a/apps/ocsp.c
+++ b/apps/ocsp.c
@@ -160,7 +160,7 @@ const OPTIONS ocsp_options[] = {
     OPT_SECTION("Client"),
     {"url", OPT_URL, 's', "Responder URL"},
     {"host", OPT_HOST, 's', "TCP/IP hostname:port to connect to"},
-    {"port", OPT_PORT, 'p', "Port to run responder on"},
+    {"port", OPT_PORT, 'n', "Port to run responder on"},
     {"path", OPT_PATH, 's', "Path to use in OCSP request"},
 #ifndef OPENSSL_NO_SOCK
     {"proxy", OPT_PROXY, 's',

--- a/apps/ocsp.c
+++ b/apps/ocsp.c
@@ -160,7 +160,7 @@ const OPTIONS ocsp_options[] = {
     OPT_SECTION("Client"),
     {"url", OPT_URL, 's', "Responder URL"},
     {"host", OPT_HOST, 's', "TCP/IP hostname:port to connect to"},
-    {"port", OPT_PORT, 'n', "Port to run responder on"},
+    {"port", OPT_PORT, 'N', "Port to run responder on"},
     {"path", OPT_PATH, 's', "Path to use in OCSP request"},
 #ifndef OPENSSL_NO_SOCK
     {"proxy", OPT_PROXY, 's',

--- a/crypto/bio/b_addr.c
+++ b/crypto/bio/b_addr.c
@@ -628,8 +628,8 @@ int BIO_lookup(const char *host, const char *service,
 }
 
 /*-
- * BIO_lookup_ex - look up the node and service you want to connect to.
- * @node: the node you want to connect to.
+ * BIO_lookup_ex - look up the host and service you want to connect to.
+ * @host: the host (or node, in case family == AF_UNIX) you want to connect to.
  * @service: the service you want to connect to.
  * @lookup_type: declare intent with the result, client or server.
  * @family: the address family you want to use.  Use AF_UNSPEC for any, or
@@ -642,7 +642,7 @@ int BIO_lookup(const char *host, const char *service,
  *            with 0 for the protocol)
  * @res: Storage place for the resulting list of returned addresses
  *
- * This will do a lookup of the node and service that you want to connect to.
+ * This will do a lookup of the host and service that you want to connect to.
  * It returns a linked list of different addresses you can try to connect to.
  *
  * When no longer needed you should call BIO_ADDRINFO_free() to free the result.

--- a/doc/man1/openssl-ocsp.pod.in
+++ b/doc/man1/openssl-ocsp.pod.in
@@ -371,6 +371,7 @@ subject name.
 
 Port to listen for OCSP requests on. The port may also be specified
 using the B<url> option.
+A `0` argument indicates that any available port shall be chosen automatically.
 
 =item B<-ignore_err>
 

--- a/doc/man3/BIO_ADDRINFO.pod
+++ b/doc/man3/BIO_ADDRINFO.pod
@@ -23,7 +23,7 @@ BIO_lookup
 
  int BIO_lookup_ex(const char *host, const char *service, int lookup_type,
                    int family, int socktype, int protocol, BIO_ADDRINFO **res);
- int BIO_lookup(const char *node, const char *service,
+ int BIO_lookup(const char *host, const char *service,
                 enum BIO_lookup_type lookup_type,
                 int family, int socktype, BIO_ADDRINFO **res);
 
@@ -54,8 +54,7 @@ used. B<res> points at a pointer to hold the start of a B<BIO_ADDRINFO>
 chain.
 
 For the family B<AF_UNIX>, BIO_lookup_ex() will ignore the B<service>
-parameter and expects the B<node> parameter to hold the path to the
-socket file.
+parameter and expects the B<host> parameter to hold the path to the socket file.
 
 BIO_lookup() does the same as BIO_lookup_ex() but does not provide the ability
 to select based on the protocol (any protocol may be returned).

--- a/doc/man3/BIO_s_accept.pod
+++ b/doc/man3/BIO_s_accept.pod
@@ -94,6 +94,12 @@ buffering or SSL BIO is required for each connection. The
 chain of BIOs must not be freed after this call, they will
 be automatically freed when the accept BIO is freed.
 
+BIO_get_accept_ip_family() returns the IP family accepted by the BIO I<b>,
+which may be B<BIO_FAMILY_IPV4>, B<BIO_FAMILY_IPV6>, or B<BIO_FAMILY_IPANY>.
+
+BIO_set_accept_ip_family() sets the IP family I<family> accepted by BIO I<b>.
+The default is B<BIO_FAMILY_IPANY>.
+
 BIO_set_bind_mode() and BIO_get_bind_mode() set and retrieve
 the current bind mode. If B<BIO_BIND_NORMAL> (the default) is set
 then another socket cannot be bound to the same port. If

--- a/doc/man3/BIO_s_accept.pod
+++ b/doc/man3/BIO_s_accept.pod
@@ -73,7 +73,7 @@ connect BIOs, that is it can be a numerical port string or a
 string to lookup using getservbyname() and a string table.
 
 BIO_set_accept_port() uses the string B<port> to set the accept
-port.  "port" has the same syntax as the port specified in
+port of BIO I<b>.  "port" has the same syntax as the port specified in
 BIO_set_conn_port() for connect BIOs, that is it can be a numerical
 port string or a string to lookup using getservbyname() and a string
 table.

--- a/test/recipes/80-test_cmp_http.t
+++ b/test/recipes/80-test_cmp_http.t
@@ -274,9 +274,10 @@ sub start_mock_server {
     my $cmd = bldtop_dir($app) . " -config server.cnf $args";
     print "Current directory is ".getcwd()."\n";
     print "Launching mock server: $cmd\n";
+    die "Invalid port: $server_port" unless $server_port =~ m/^\d+$/;
     my $pid = open($server_fh, "$cmd|") or die "Trying to $cmd";
     print "Pid is: $pid\n";
-    if ($server_port =~ m/^0\D?/) {
+    if ($server_port eq "0") {
         # Find out the actual server port
         while (<$server_fh>) {
             print;

--- a/test/recipes/80-test_cmp_http.t
+++ b/test/recipes/80-test_cmp_http.t
@@ -281,11 +281,9 @@ sub start_mock_server {
     while (<$server_fh>) {
         print;
         s/\R$//;                # Better chomp
-        next unless (/^ACCEPT\s.*:(\d+)$/);
-        $server_port = $1;
-        $server_tls = $1;
-        $kur_port = $1;
-        $pbm_port = $1;
+        next unless (/^ACCEPT/);
+        $server_port = $server_tls = $kur_port = $pbm_port = $1
+            if m/^ACCEPT\s.*:(\d+)$/;
         last;
     }
     return $pid if $server_port =~ m/^(\d+)$/;

--- a/test/recipes/80-test_cmp_http_data/Mock/server.cnf
+++ b/test/recipes/80-test_cmp_http_data/Mock/server.cnf
@@ -1,7 +1,6 @@
 [cmp] # mock server configuration
 
-# port 0 means that a random available port will be used
-port = 0
+port = 0 # 0 means that the server should choose a random available port
 srv_cert = server.crt
 srv_key = server.key
 srv_secret = pass:test

--- a/test/recipes/80-test_cmp_http_data/Mock/test.cnf
+++ b/test/recipes/80-test_cmp_http_data/Mock/test.cnf
@@ -17,6 +17,7 @@ policies = certificatePolicies
 [Mock] # the built-in OpenSSL CMP mock server
 no_check_time = 1
 server_host = 127.0.0.1 # localhost
+# server_port = 0 means that the port is determinend by the server
 server_port = 0
 server_tls = $server_port
 server_cert = server.crt

--- a/test/recipes/80-test_cmp_http_data/Mock/test.cnf
+++ b/test/recipes/80-test_cmp_http_data/Mock/test.cnf
@@ -17,7 +17,7 @@ policies = certificatePolicies
 [Mock] # the built-in OpenSSL CMP mock server
 no_check_time = 1
 server_host = 127.0.0.1 # localhost
-# server_port = 0 means that the port is determinend by the server
+# server_port = 0 means that the port is determined by the server
 server_port = 0
 server_tls = $server_port
 server_cert = server.crt


### PR DESCRIPTION
* BIO `acpt_state():` Allow retrying addresses (e.g., using IPv6 vs. IPv4) on creating accept socket
* `apps/lib/s_socket.c` and `80-test_cmp_http.t:` Make `ACCEPT` port reporting more robust
  which is a fixup of #15281

* ~`80-test_cmp_http.t`: Skip on NonStop `ia64` since not supporting `BIO_set_accept_port(bio, "0")`~
*  `apps/ocsp`: Allow `-port 0`
* `BIO_s_accept.pod:` Add missing documentation for `BIO_{get,set}_accept_ip_family()`
* DOC: Slightly improve the documentation of `BIO_lookup()` and related functions
    
Fixes #15386.

- [x] documentation is added or updated
- [x] tests are added or updated
