### PR TITLE
Remove engine_table_select_int

### DIFF
--- a/crypto/engine/eng_local.h
+++ b/crypto/engine/eng_local.h
@@ -62,10 +62,7 @@ int engine_table_register(ENGINE_TABLE **table, ENGINE_CLEANUP_CB *cleanup,
                           int setdefault);
 void engine_table_unregister(ENGINE_TABLE **table, ENGINE *e);
 void engine_table_cleanup(ENGINE_TABLE **table);
-ENGINE *engine_table_select_int(ENGINE_TABLE **table, int nid, const char *f,
-                                int l);
-# define engine_table_select(t,n)                               \
-    engine_table_select_int(t,n,OPENSSL_FILE,OPENSSL_LINE)
+ENGINE *engine_table_select(ENGINE_TABLE **table, int nid, const char *f, int l);
 typedef void (engine_table_doall_cb) (int nid, STACK_OF(ENGINE) *sk,
                                       ENGINE *def, void *arg);
 void engine_table_doall(ENGINE_TABLE *table, engine_table_doall_cb *cb,

--- a/crypto/engine/eng_local.h
+++ b/crypto/engine/eng_local.h
@@ -62,7 +62,8 @@ int engine_table_register(ENGINE_TABLE **table, ENGINE_CLEANUP_CB *cleanup,
                           int setdefault);
 void engine_table_unregister(ENGINE_TABLE **table, ENGINE *e);
 void engine_table_cleanup(ENGINE_TABLE **table);
-ENGINE *engine_table_select(ENGINE_TABLE **table, int nid, const char *f, int l);
+ENGINE *ossl_engine_table_select(ENGINE_TABLE **table, int nid,
+                                 const char *f, int l);
 typedef void (engine_table_doall_cb) (int nid, STACK_OF(ENGINE) *sk,
                                       ENGINE *def, void *arg);
 void engine_table_doall(ENGINE_TABLE *table, engine_table_doall_cb *cb,

--- a/crypto/engine/eng_table.c
+++ b/crypto/engine/eng_table.c
@@ -194,7 +194,8 @@ void engine_table_cleanup(ENGINE_TABLE **table)
 }
 
 /* return a functional reference for a given 'nid' */
-ENGINE *engine_table_select(ENGINE_TABLE **table, int nid, const char *f, int l)
+ENGINE *ossl_engine_table_select(ENGINE_TABLE **table, int nid,
+                                 const char *f, int l)
 {
     ENGINE *ret = NULL;
     ENGINE_PILE tmplate, *fnd = NULL;

--- a/crypto/engine/eng_table.c
+++ b/crypto/engine/eng_table.c
@@ -194,8 +194,7 @@ void engine_table_cleanup(ENGINE_TABLE **table)
 }
 
 /* return a functional reference for a given 'nid' */
-ENGINE *engine_table_select_int(ENGINE_TABLE **table, int nid, const char *f,
-                                int l)
+ENGINE *engine_table_select(ENGINE_TABLE **table, int nid, const char *f, int l)
 {
     ENGINE *ret = NULL;
     ENGINE_PILE tmplate, *fnd = NULL;

--- a/crypto/engine/tb_asnmth.c
+++ b/crypto/engine/tb_asnmth.c
@@ -76,7 +76,7 @@ int ENGINE_set_default_pkey_asn1_meths(ENGINE *e)
  */
 ENGINE *ENGINE_get_pkey_asn1_meth_engine(int nid)
 {
-    return engine_table_select(&pkey_asn1_meth_table, nid);
+    return engine_table_select(&pkey_asn1_meth_table, nid, OPENSSL_FILE, OPENSSL_LINE);
 }
 
 /*

--- a/crypto/engine/tb_asnmth.c
+++ b/crypto/engine/tb_asnmth.c
@@ -76,7 +76,8 @@ int ENGINE_set_default_pkey_asn1_meths(ENGINE *e)
  */
 ENGINE *ENGINE_get_pkey_asn1_meth_engine(int nid)
 {
-    return engine_table_select(&pkey_asn1_meth_table, nid, OPENSSL_FILE, OPENSSL_LINE);
+    return ossl_engine_table_select(&pkey_asn1_meth_table, nid,
+                                    OPENSSL_FILE, OPENSSL_LINE);
 }
 
 /*

--- a/crypto/engine/tb_cipher.c
+++ b/crypto/engine/tb_cipher.c
@@ -65,7 +65,8 @@ int ENGINE_set_default_ciphers(ENGINE *e)
  */
 ENGINE *ENGINE_get_cipher_engine(int nid)
 {
-    return engine_table_select(&cipher_table, nid, OPENSSL_FILE, OPENSSL_LINE);
+    return ossl_engine_table_select(&cipher_table, nid,
+                                    OPENSSL_FILE, OPENSSL_LINE);
 }
 
 /* Obtains a cipher implementation from an ENGINE functional reference */

--- a/crypto/engine/tb_cipher.c
+++ b/crypto/engine/tb_cipher.c
@@ -65,7 +65,7 @@ int ENGINE_set_default_ciphers(ENGINE *e)
  */
 ENGINE *ENGINE_get_cipher_engine(int nid)
 {
-    return engine_table_select(&cipher_table, nid);
+    return engine_table_select(&cipher_table, nid, OPENSSL_FILE, OPENSSL_LINE);
 }
 
 /* Obtains a cipher implementation from an ENGINE functional reference */

--- a/crypto/engine/tb_dh.c
+++ b/crypto/engine/tb_dh.c
@@ -58,7 +58,7 @@ int ENGINE_set_default_DH(ENGINE *e)
  */
 ENGINE *ENGINE_get_default_DH(void)
 {
-    return engine_table_select(&dh_table, dummy_nid);
+    return engine_table_select(&dh_table, dummy_nid, OPENSSL_FILE, OPENSSL_LINE);
 }
 
 /* Obtains an DH implementation from an ENGINE functional reference */

--- a/crypto/engine/tb_dh.c
+++ b/crypto/engine/tb_dh.c
@@ -58,7 +58,8 @@ int ENGINE_set_default_DH(ENGINE *e)
  */
 ENGINE *ENGINE_get_default_DH(void)
 {
-    return engine_table_select(&dh_table, dummy_nid, OPENSSL_FILE, OPENSSL_LINE);
+    return ossl_engine_table_select(&dh_table, dummy_nid,
+                                    OPENSSL_FILE, OPENSSL_LINE);
 }
 
 /* Obtains an DH implementation from an ENGINE functional reference */

--- a/crypto/engine/tb_digest.c
+++ b/crypto/engine/tb_digest.c
@@ -65,7 +65,8 @@ int ENGINE_set_default_digests(ENGINE *e)
  */
 ENGINE *ENGINE_get_digest_engine(int nid)
 {
-    return engine_table_select(&digest_table, nid, OPENSSL_FILE, OPENSSL_LINE);
+    return ossl_engine_table_select(&digest_table, nid,
+                                    OPENSSL_FILE, OPENSSL_LINE);
 }
 
 /* Obtains a digest implementation from an ENGINE functional reference */

--- a/crypto/engine/tb_digest.c
+++ b/crypto/engine/tb_digest.c
@@ -65,7 +65,7 @@ int ENGINE_set_default_digests(ENGINE *e)
  */
 ENGINE *ENGINE_get_digest_engine(int nid)
 {
-    return engine_table_select(&digest_table, nid);
+    return engine_table_select(&digest_table, nid, OPENSSL_FILE, OPENSSL_LINE);
 }
 
 /* Obtains a digest implementation from an ENGINE functional reference */

--- a/crypto/engine/tb_dsa.c
+++ b/crypto/engine/tb_dsa.c
@@ -58,7 +58,8 @@ int ENGINE_set_default_DSA(ENGINE *e)
  */
 ENGINE *ENGINE_get_default_DSA(void)
 {
-    return engine_table_select(&dsa_table, dummy_nid, OPENSSL_FILE, OPENSSL_LINE);
+    return ossl_engine_table_select(&dsa_table, dummy_nid,
+                                    OPENSSL_FILE, OPENSSL_LINE);
 }
 
 /* Obtains an DSA implementation from an ENGINE functional reference */

--- a/crypto/engine/tb_dsa.c
+++ b/crypto/engine/tb_dsa.c
@@ -58,7 +58,7 @@ int ENGINE_set_default_DSA(ENGINE *e)
  */
 ENGINE *ENGINE_get_default_DSA(void)
 {
-    return engine_table_select(&dsa_table, dummy_nid);
+    return engine_table_select(&dsa_table, dummy_nid, OPENSSL_FILE, OPENSSL_LINE);
 }
 
 /* Obtains an DSA implementation from an ENGINE functional reference */

--- a/crypto/engine/tb_eckey.c
+++ b/crypto/engine/tb_eckey.c
@@ -58,7 +58,7 @@ int ENGINE_set_default_EC(ENGINE *e)
  */
 ENGINE *ENGINE_get_default_EC(void)
 {
-    return engine_table_select(&dh_table, dummy_nid);
+    return engine_table_select(&dh_table, dummy_nid, OPENSSL_FILE, OPENSSL_LINE);
 }
 
 /* Obtains an EC_KEY implementation from an ENGINE functional reference */

--- a/crypto/engine/tb_eckey.c
+++ b/crypto/engine/tb_eckey.c
@@ -58,7 +58,8 @@ int ENGINE_set_default_EC(ENGINE *e)
  */
 ENGINE *ENGINE_get_default_EC(void)
 {
-    return engine_table_select(&dh_table, dummy_nid, OPENSSL_FILE, OPENSSL_LINE);
+    return ossl_engine_table_select(&dh_table, dummy_nid,
+                                    OPENSSL_FILE, OPENSSL_LINE);
 }
 
 /* Obtains an EC_KEY implementation from an ENGINE functional reference */

--- a/crypto/engine/tb_pkmeth.c
+++ b/crypto/engine/tb_pkmeth.c
@@ -66,7 +66,7 @@ int ENGINE_set_default_pkey_meths(ENGINE *e)
  */
 ENGINE *ENGINE_get_pkey_meth_engine(int nid)
 {
-    return engine_table_select(&pkey_meth_table, nid);
+    return engine_table_select(&pkey_meth_table, nid, OPENSSL_FILE, OPENSSL_LINE);
 }
 
 /* Obtains a pkey_meth implementation from an ENGINE functional reference */

--- a/crypto/engine/tb_pkmeth.c
+++ b/crypto/engine/tb_pkmeth.c
@@ -66,7 +66,8 @@ int ENGINE_set_default_pkey_meths(ENGINE *e)
  */
 ENGINE *ENGINE_get_pkey_meth_engine(int nid)
 {
-    return engine_table_select(&pkey_meth_table, nid, OPENSSL_FILE, OPENSSL_LINE);
+    return ossl_engine_table_select(&pkey_meth_table, nid,
+                                    OPENSSL_FILE, OPENSSL_LINE);
 }
 
 /* Obtains a pkey_meth implementation from an ENGINE functional reference */

--- a/crypto/engine/tb_rand.c
+++ b/crypto/engine/tb_rand.c
@@ -58,7 +58,8 @@ int ENGINE_set_default_RAND(ENGINE *e)
  */
 ENGINE *ENGINE_get_default_RAND(void)
 {
-    return engine_table_select(&rand_table, dummy_nid, OPENSSL_FILE, OPENSSL_LINE);
+    return ossl_engine_table_select(&rand_table, dummy_nid,
+                                    OPENSSL_FILE, OPENSSL_LINE);
 }
 
 /* Obtains an RAND implementation from an ENGINE functional reference */

--- a/crypto/engine/tb_rand.c
+++ b/crypto/engine/tb_rand.c
@@ -58,7 +58,7 @@ int ENGINE_set_default_RAND(ENGINE *e)
  */
 ENGINE *ENGINE_get_default_RAND(void)
 {
-    return engine_table_select(&rand_table, dummy_nid);
+    return engine_table_select(&rand_table, dummy_nid, OPENSSL_FILE, OPENSSL_LINE);
 }
 
 /* Obtains an RAND implementation from an ENGINE functional reference */

--- a/crypto/engine/tb_rsa.c
+++ b/crypto/engine/tb_rsa.c
@@ -58,7 +58,7 @@ int ENGINE_set_default_RSA(ENGINE *e)
  */
 ENGINE *ENGINE_get_default_RSA(void)
 {
-    return engine_table_select(&rsa_table, dummy_nid);
+    return engine_table_select(&rsa_table, dummy_nid, OPENSSL_FILE, OPENSSL_LINE);
 }
 
 /* Obtains an RSA implementation from an ENGINE functional reference */

--- a/crypto/engine/tb_rsa.c
+++ b/crypto/engine/tb_rsa.c
@@ -58,7 +58,8 @@ int ENGINE_set_default_RSA(ENGINE *e)
  */
 ENGINE *ENGINE_get_default_RSA(void)
 {
-    return engine_table_select(&rsa_table, dummy_nid, OPENSSL_FILE, OPENSSL_LINE);
+    return ossl_engine_table_select(&rsa_table, dummy_nid,
+                                    OPENSSL_FILE, OPENSSL_LINE);
 }
 
 /* Obtains an RSA implementation from an ENGINE functional reference */


### PR DESCRIPTION
Add missing file/line args and call it engine_table_select. Yes this finesses one name for another.  But, since the function is mentioned in `doc/man3/OSSL_trace_set_channel.pod` should it be renamed to `ENGINE_table_select`?

This partially addresses #15344.
