### PR TITLE
Rework how providers/fipsmodule.cnf is produced, and have a separate test/fipsmodule.cnf

### DIFF
--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -269,15 +269,23 @@ SHLIB_TARGET={- $target{shared_target} -}
 
 LIBS={- join(", ", map { "-\n\t".$_.".OLB" } @libs) -}
 SHLIBS={- join(", ", map { "-\n\t".$_.".EXE" } @shlibs) -}
-FIPSMODULENAME={- # We do some extra checking here, as there should be only one
-                  use File::Basename;
-                  my @fipsmodules =
-                      grep { !$unified_info{attributes}->{modules}->{$_}->{noinst}
-                             && $unified_info{attributes}->{modules}->{$_}->{fips} }
-                      @{$unified_info{modules}};
-                  die "More that one FIPS module" if scalar @fipsmodules > 1;
+MODULES={- join(", ", map { "-\n\t".$_.".EXE" }
+                      # Drop all modules that are dependencies, they will
+                      # be processed through their dependents
+                      grep { my $x = $_;
+                             !grep { grep { $_ eq $x } @$_ }
+                                   values %{$unified_info{depends}} }
+                      @{$unified_info{modules}}) -}
+FIPSMODULE={- # We do some extra checking here, as there should be only one
+              use File::Basename;
+              our @fipsmodules =
+                  grep { !$unified_info{attributes}->{modules}->{$_}->{noinst}
+                         && $unified_info{attributes}->{modules}->{$_}->{fips} }
+                  @{$unified_info{modules}};
+              die "More that one FIPS module" if scalar @fipsmodules > 1;
+              join(" ", map { platform->dso($_) } @fipsmodules) -}
+FIPSMODULENAME={- die "More that one FIPS module" if scalar @fipsmodules > 1;
                   join(", ", map { basename(platform->dso($_)) } @fipsmodules) -}
-MODULES={- join(", ", map { "-\n\t".$_.".EXE" } @{$unified_info{modules}}) -}
 PROGRAMS={- join(", ", map { "-\n\t".$_.".EXE" } @{$unified_info{programs}}) -}
 SCRIPTS={- join(", ", map { "-\n\t".$_ } @{$unified_info{scripts}}) -}
 {- output_off() if $disabled{makedepend}; "" -}

--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -62,7 +62,12 @@
       @{$unified_info{modules}};
   our @install_modules =
       grep { !$unified_info{attributes}->{modules}->{$_}->{noinst}
-             && !$unified_info{attributes}->{modules}->{$_}->{engine} }
+             && !$unified_info{attributes}->{modules}->{$_}->{engine}
+             && !$unified_info{attributes}->{modules}->{$_}->{fips} }
+      @{$unified_info{modules}};
+  our @install_fipsmodules =
+      grep { !$unified_info{attributes}->{modules}->{$_}->{noinst}
+             && $unified_info{attributes}->{modules}->{$_}->{fips} }
       @{$unified_info{modules}};
   our @install_programs =
       grep { !$unified_info{attributes}->{programs}->{$_}->{noinst} }
@@ -315,6 +320,8 @@ INSTALL_LIBS={- join(", ", map { "-\n\t".$_.".OLB" } @install_libs) -}
 INSTALL_SHLIBS={- join(", ", map { "-\n\t".$_.".EXE" } @install_shlibs) -}
 INSTALL_ENGINES={- join(", ", map { "-\n\t".$_.".EXE" } @install_engines) -}
 INSTALL_MODULES={- join(", ", map { "-\n\t".$_.".EXE" } @install_modules) -}
+INSTALL_FIPSMODULE={- join(", ", map { "-\n\t".$_.".EXE" } @install_fipsmodules) -}
+INSTALL_FIPSMODULECONF=[.providers]fipsmodule.cnf
 INSTALL_PROGRAMS={- join(", ", map { "-\n\t".$_.".EXE" } @install_programs) -}
 BIN_SCRIPTS={- join(", ", @install_bin_scripts) -}
 MISC_SCRIPTS={- join(", ", @install_misc_scripts) -}
@@ -557,17 +564,20 @@ install_docs : install_html_docs
 
 uninstall_docs : uninstall_html_docs
 
-install_fips : install_sw
+{- output_off() if $disabled{fips}; "" -}
+install_fips : install_sw $(INSTALL_FIPSMODULECONF)
+	@ WRITE SYS$OUTPUT "*** Installing FIPS module"
+	COPY/PROT=W:RE $(INSTALL_FIPSMODULES) -
+                ossl_installroot:[MODULES{- $sover_dirname.$target{pointer_size} -}.'arch']$(FIPSMODULENAME)
 	@ WRITE SYS$OUTPUT "*** Installing FIPS module configuration"
-	@ WRITE SYS$OUTPUT "fipsinstall $(DESTDIR)$(MODULESDIR)/$(FIPSMODULENAME).cnf"
-	openssl fipsinstall -
-		-module ossl_installroot:[MODULES{- $sover_dirname.$target{pointer_size} -}.'arch']$(FIPSMODULENAME) -
-		-out ossl_installroot:[MODULES{- $sover_dirname.$target{pointer_size} -}.'arch']$(FIPSMODULENAME).cnf -
-		-macopt "hexkey:$(FIPSKEY)"
+	COPY/PROT=W:RE $(INSTALL_FIPSMODULESCONF) OSSL_DATAROOT:[000000]
 
 uninstall_fips : uninstall_sw
 	@ WRITE SYS$OUTPUT "*** Uninstalling FIPS module configuration"
-	DELETE ossl_installroot:[MODULES{- $sover_dirname.$target{pointer_size} -}.'arch']$(FIPSMODULENAME).cnf;*
+	DELETE OSSL_DATAROOT:[000000]fipsmodule.cnf;*
+	@ WRITE SYS$OUTPUT "*** Uninstalling FIPS module"
+	DELETE ossl_installroot:[MODULES{- $sover_dirname.$target{pointer_size} -}.'arch']$(FIPSMODULENAME);*
+{- output_on() if $disabled{fips}; "" -}
 
 install_ssldirs : check_INSTALLTOP
         - CREATE/DIR/PROT=(S:RWED,O:RWE,G:RE,W:RE) OSSL_DATAROOT:[000000]

--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -873,7 +873,7 @@ EOF
 
   sub generatetarget {
       my %args = @_;
-      my $deps = join(" ", compute_lib_depends(@{$args{deps}}));
+      my $deps = join(" ", compute_platform_depends(@{$args{deps}}));
       return <<"EOF";
 $args{target} : $deps
 EOF

--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -762,6 +762,17 @@ reconfigure reconf :
   use File::Spec::Functions qw/abs2rel rel2abs catfile catdir/;
   use File::Spec::Unix;
 
+  # Helper function to convert dependencies in platform agnostic form to
+  # dependencies in platform form.
+  sub compute_platform_depends {
+      map { my $x = $_;
+
+            grep { $x eq $_ } @{$unified_info{programs}} and platform->bin($x)
+            or grep { $x eq $_ } @{$unified_info{modules}} and platform->dso($x)
+            or grep { $x eq $_ } @{$unified_info{libraries}} and platform->lib($x)
+            or platform->convertext($x); } @_;
+  }
+
   # Helper function to figure out dependencies on libraries
   # It takes a list of library names and outputs a list of dependencies
   sub compute_lib_depends {
@@ -852,7 +863,7 @@ EOF
 
   sub generatetarget {
       my %args = @_;
-      my $deps = join(" ", @{$args{deps}});
+      my $deps = join(" ", compute_lib_depends(@{$args{deps}}));
       return <<"EOF";
 $args{target} : $deps
 EOF
@@ -864,7 +875,9 @@ EOF
       my $gen_args = join('', map { " $_" }
                               @{$args{generator}}[1..$#{$args{generator}}]);
       my $gen_incs = join("", map { ' "-I'.$_.'"' } @{$args{generator_incs}});
-      my $deps = join(", -\n\t\t", @{$args{generator_deps}}, @{$args{deps}});
+      my $deps = join(", -\n\t\t",
+                      compute_platform_depends(@{$args{generator_deps}},
+                                               @{$args{deps}}));
 
       if ($args{src} =~ /\.html$/) {
           #
@@ -957,38 +970,22 @@ EOF
           my $dofile = abs2rel(rel2abs(catfile($config{sourcedir},
                                                "util", "dofile.pl")),
                                rel2abs($config{builddir}));
-          my @modules = ( 'configdata.pm',
-                          grep { $_ =~ m|\.pm$| } @{$args{deps}} );
-          my %moduleincs = map { '"-I'.dirname($_).'"' => 1 } @modules;
-          $deps = join(' ', $deps, @modules);
-          @modules = map { '"-M'.basename($_, '.pm').'"' } @modules;
-          my $modules = join(' ', '', sort keys %moduleincs, @modules);
+          my @perlmodules = ( 'configdata.pm',
+                              grep { $_ =~ m|\.pm$| } @{$args{deps}} );
+          my %perlmoduleincs = map { '"-I'.dirname($_).'"' => 1 } @perlmodules;
+          $deps = join(' ', $deps, compute_platform_depends(@perlmodules));
+          @perlmodules = map { '"-M'.basename($_, '.pm').'"' } @perlmodules;
+          my $perlmodules = join(' ', '', sort keys %perlmoduleincs, @perlmodules);
           return <<"EOF";
 $args{src} : $gen0 $deps
-	\$(PERL)$modules $dofile "-o$target{build_file}" $gen0$gen_args > \$\@
+	\$(PERL)$perlmodules $dofile "-o$target{build_file}" $gen0$gen_args > \$\@
 EOF
       } elsif (grep { $_ eq $gen0 } @{$unified_info{programs}}) {
           #
           # Generic generator using OpenSSL programs
           #
 
-          # Redo $deps, because programs aren't expected to have deps of their
-          # own.  This is a little more tricky, though, because running programs
-          # may have dependencies on all sorts of files, so we search through
-          # our database of programs and modules to see if our dependencies
-          # are one of those.
-          $deps = join(' ', map { my $x = $_;
-                                  if (grep { $x eq $_ }
-                                          @{$unified_info{programs}}) {
-                                      platform->bin($x);
-                                  } elsif (grep { $x eq $_ }
-                                          @{$unified_info{modules}}) {
-                                      platform->dso($x);
-                                  } else {
-                                      $x;
-                                  }
-                                } @{$args{deps}});
-          # Also redo $gen0, to ensure that we have the proper extension
+          # Redo $gen0, to ensure that we have the proper extension
           $gen0 = platform->bin($gen0);
           return <<"EOF";
 $args{src} : $gen0 $deps

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -1477,6 +1477,17 @@ reconfigure reconf:
   use File::Basename;
   use File::Spec::Functions qw/:DEFAULT abs2rel rel2abs/;
 
+  # Helper function to convert dependencies in platform agnostic form to
+  # dependencies in platform form.
+  sub compute_platform_depends {
+      map { my $x = $_;
+
+            grep { $x eq $_ } @{$unified_info{programs}} and platform->bin($x)
+            or grep { $x eq $_ } @{$unified_info{modules}} and platform->dso($x)
+            or grep { $x eq $_ } @{$unified_info{libraries}} and platform->lib($x)
+            or platform->convertext($x); } @_;
+  }
+
   # Helper function to figure out dependencies on libraries
   # It takes a list of library names and outputs a list of dependencies
   sub compute_lib_depends {
@@ -1491,7 +1502,7 @@ reconfigure reconf:
 
   sub generatetarget {
       my %args = @_;
-      my $deps = join(" ", @{$args{deps}});
+      my $deps = join(" ", compute_lib_depends(@{$args{deps}}));
       return <<"EOF";
 $args{target}: $deps
 EOF
@@ -1505,7 +1516,8 @@ EOF
       my $gen_incs = join("", map { " -I".$_ } @{$args{generator_incs}});
       my $incs = join("", map { " -I".$_ } @{$args{incs}});
       my $defs = join("", map { " -D".$_ } @{$args{defs}});
-      my $deps = join(" ", @{$args{generator_deps}}, @{$args{deps}});
+      my $deps = join(" ", compute_platform_depends(@{$args{generator_deps}},
+                                                    @{$args{deps}}));
 
       if ($args{src} =~ /\.html$/) {
           #
@@ -1582,38 +1594,22 @@ EOF
           my $dofile = abs2rel(rel2abs(catfile($config{sourcedir},
                                                "util", "dofile.pl")),
                                rel2abs($config{builddir}));
-          my @modules = ( 'configdata.pm',
-                          grep { $_ =~ m|\.pm$| } @{$args{deps}} );
-          my %moduleincs = map { '"-I'.dirname($_).'"' => 1 } @modules;
-          $deps = join(' ', $deps, @modules);
-          @modules = map { "-M".basename($_, '.pm') } @modules;
-          my $modules = join(' ', '', sort keys %moduleincs, @modules);
+          my @perlmodules = ( 'configdata.pm',
+                              grep { $_ =~ m|\.pm$| } @{$args{deps}} );
+          my %perlmoduleincs = map { '"-I'.dirname($_).'"' => 1 } @perlmodules;
+          $deps = join(' ', $deps, compute_platform_depends(@perlmodules));
+          @perlmodules = map { "-M".basename($_, '.pm') } @perlmodules;
+          my $perlmodules = join(' ', '', sort keys %perlmoduleincs, @perlmodules);
           return <<"EOF";
 $args{src}: $gen0 $deps
-	\$(PERL)$modules "$dofile" "-o$target{build_file}" $gen0$gen_args > \$@
+	\$(PERL)$perlmodules "$dofile" "-o$target{build_file}" $gen0$gen_args > \$@
 EOF
       } elsif (grep { $_ eq $gen0 } @{$unified_info{programs}}) {
           #
           # Generic generator using OpenSSL programs
           #
 
-          # Redo $deps, because programs aren't expected to have deps of their
-          # own.  This is a little more tricky, though, because running programs
-          # may have dependencies on all sorts of files, so we search through
-          # our database of programs and modules to see if our dependencies
-          # are one of those.
-          $deps = join(' ', map { my $x = $_;
-                                  if (grep { $x eq $_ }
-                                          @{$unified_info{programs}}) {
-                                      platform->bin($x);
-                                  } elsif (grep { $x eq $_ }
-                                          @{$unified_info{modules}}) {
-                                      platform->dso($x);
-                                  } else {
-                                      $x;
-                                  }
-                                } @{$args{deps}});
-          # Also redo $gen0, to ensure that we have the proper extension where
+          # Redo $gen0, to ensure that we have the proper extension where
           # necessary.
           $gen0 = platform->bin($gen0);
           # Use $(PERL) to execute wrap.pl directly to avoid calling env
@@ -1960,11 +1956,8 @@ EOF
   sub generatedir {
       my %args = @_;
       my $dir = $args{dir};
-      my @deps = map { platform->convertext($_) } @{$args{deps}};
+      my @deps = compute_platform_depends(@{$args{deps}});
       my @comments = ();
-      my %extinfo = ( dso => platform->dsoext(),
-                      lib => platform->libext(),
-                      bin => platform->binext() );
 
       # We already have a 'test' target, and the top directory is just plain
       # silly
@@ -1979,7 +1972,7 @@ EOF
           if ($type ne "lib") {
               foreach my $prod (@{$unified_info{dirinfo}->{$dir}->{products}->{$type}}) {
                   if (dirname($prod) eq $dir) {
-                      push @deps, $prod.$extinfo{$type};
+                      push @deps, compute_platform_depends($prod);
                   } else {
                       push @comments, "# No support to produce $type ".join(", ", @{$unified_info{dirinfo}->{$dir}->{products}->{$type}});
                   }

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -1503,7 +1503,7 @@ reconfigure reconf:
 
   sub generatetarget {
       my %args = @_;
-      my $deps = join(" ", compute_lib_depends(@{$args{deps}}));
+      my $deps = join(" ", compute_platform_depends(@{$args{deps}}));
       return <<"EOF";
 $args{target}: $deps
 EOF

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -173,14 +173,6 @@ INSTALL_ENGINES={-
                                && $unified_info{attributes}->{modules}->{$_}->{engine} }
                         @{$unified_info{modules}}))
 -}
-INSTALL_FIPS={-
-        join(" \\\n" . ' ' x 16,
-             fill_lines(" ", $COLUMNS - 16,
-                        map { platform->dso($_) }
-                        grep { !$unified_info{attributes}->{modules}->{$_}->{noinst}
-                               && $unified_info{attributes}->{modules}->{$_}->{fips} }
-                        @{$unified_info{modules}}))
--}
 INSTALL_MODULES={-
         join(" \\\n" . ' ' x 16,
              fill_lines(" ", $COLUMNS - 16,
@@ -190,6 +182,15 @@ INSTALL_MODULES={-
                                && !$unified_info{attributes}->{modules}->{$_}->{fips} }
                         @{$unified_info{modules}}))
 -}
+INSTALL_FIPSMODULE={-
+        join(" \\\n" . ' ' x 16,
+             fill_lines(" ", $COLUMNS - 16,
+                        map { platform->dso($_) }
+                        grep { !$unified_info{attributes}->{modules}->{$_}->{noinst}
+                               && $unified_info{attributes}->{modules}->{$_}->{fips} }
+                        @{$unified_info{modules}}))
+-}
+INSTALL_FIPSMODULECONF=providers/fipsmodule.cnf
 INSTALL_PROGRAMS={-
         join(" \\\n" . ' ' x 16,
              fill_lines(" ", $COLUMNS - 16, map { platform->bin($_) }
@@ -621,18 +622,18 @@ uninstall_docs: uninstall_man_docs uninstall_html_docs
 	$(RM) -r $(DESTDIR)$(DOCDIR)
 
 {- output_off() if $disabled{fips}; "" -}
-install_fips: build_sw providers/fipsmodule.cnf
+install_fips: build_sw $(INSTALL_FIPSMODULECONF)
 	@[ -n "$(INSTALLTOP)" ] || (echo INSTALLTOP should not be empty; exit 1)
 	@$(PERL) $(SRCDIR)/util/mkdir-p.pl $(DESTDIR)$(MODULESDIR)
 	@$(ECHO) "*** Installing FIPS module"
-	@$(ECHO) "install $(INSTALL_FIPS) -> $(DESTDIR)$(MODULESDIR)/$(FIPSMODULENAME)"
-	@cp "$(INSTALL_FIPS)" $(DESTDIR)$(MODULESDIR)/$(FIPSMODULENAME).new
+	@$(ECHO) "install $(INSTALL_FIPSMODULE) -> $(DESTDIR)$(MODULESDIR)/$(FIPSMODULENAME)"
+	@cp "$(INSTALL_FIPSMODULE)" $(DESTDIR)$(MODULESDIR)/$(FIPSMODULENAME).new
 	@chmod 755 $(DESTDIR)$(MODULESDIR)/$(FIPSMODULENAME).new
 	@mv -f $(DESTDIR)$(MODULESDIR)/$(FIPSMODULENAME).new \
 	       $(DESTDIR)$(MODULESDIR)/$(FIPSMODULENAME)
 	@$(ECHO) "*** Installing FIPS module configuration"
-	@$(ECHO) "install providers/fipsmodule.cnf -> $(DESTDIR)$(OPENSSLDIR)/fipsmodule.cnf"
-	@cp providers/fipsmodule.cnf $(DESTDIR)$(OPENSSLDIR)/fipsmodule.cnf
+	@$(ECHO) "install $(INSTALL_FIPSMODULECONF) -> $(DESTDIR)$(OPENSSLDIR)/fipsmodule.cnf"
+	@cp $(INSTALL_FIPSMODULECONF) $(DESTDIR)$(OPENSSLDIR)/fipsmodule.cnf
 
 uninstall_fips:
 	@$(ECHO) "*** Uninstalling FIPS module configuration"

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -90,14 +90,21 @@ SHLIB_INFO={- join(" \\\n" . ' ' x 11,
 MODULES={- join(" \\\n" . ' ' x 8,
                 fill_lines(" ", $COLUMNS - 8,
                            map { platform->dso($_) }
+                           # Drop all modules that are dependencies, they will
+                           # be processed through their dependents
+                           grep { my $x = $_;
+                                  !grep { grep { $_ eq $x } @$_ }
+                                        values %{$unified_info{depends}} }
                            @{$unified_info{modules}})) -}
-FIPSMODULENAME={- # We do some extra checking here, as there should be only one
-                  use File::Basename;
-                  my @fipsmodules =
-                      grep { !$unified_info{attributes}->{modules}->{$_}->{noinst}
-                             && $unified_info{attributes}->{modules}->{$_}->{fips} }
-                      @{$unified_info{modules}};
-                  die "More that one FIPS module" if scalar @fipsmodules > 1;
+FIPSMODULE={- # We do some extra checking here, as there should be only one
+              use File::Basename;
+              our @fipsmodules =
+                  grep { !$unified_info{attributes}->{modules}->{$_}->{noinst}
+                         && $unified_info{attributes}->{modules}->{$_}->{fips} }
+                  @{$unified_info{modules}};
+              die "More that one FIPS module" if scalar @fipsmodules > 1;
+              join(" ", map { platform->dso($_) } @fipsmodules) -}
+FIPSMODULENAME={- die "More that one FIPS module" if scalar @fipsmodules > 1;
                   join(" ", map { basename(platform->dso($_)) } @fipsmodules) -}
 
 PROGRAMS={- join(" \\\n" . ' ' x 9,

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -678,6 +678,17 @@ reconfigure reconf:
  use File::Basename;
  use File::Spec::Functions qw/:DEFAULT abs2rel rel2abs file_name_is_absolute/;
 
+  # Helper function to convert dependencies in platform agnostic form to
+  # dependencies in platform form.
+  sub compute_platform_depends {
+      map { my $x = $_;
+
+            grep { $x eq $_ } @{$unified_info{programs}} and platform->bin($x)
+            or grep { $x eq $_ } @{$unified_info{modules}} and platform->dso($x)
+            or grep { $x eq $_ } @{$unified_info{libraries}} and platform->lib($x)
+            or platform->convertext($x); } @_;
+  }
+
  # Helper function to figure out dependencies on libraries
  # It takes a list of library names and outputs a list of dependencies
  sub compute_lib_depends {
@@ -689,7 +700,7 @@ reconfigure reconf:
 
   sub generatetarget {
       my %args = @_;
-      my $deps = join(" ", @{$args{deps}});
+      my $deps = join(" ", compute_lib_depends(@{$args{deps}}));
       return <<"EOF";
 $args{target}: $deps
 EOF
@@ -707,11 +718,10 @@ EOF
       my $gen_incs = join("", map { " -I\"$_\"" } @{$args{generator_incs}});
       my $incs = join("", map { " -I\"$_\"" } @{$args{incs}});
       my $defs = join("", map { " -D".$_ } @{$args{defs}});
-      my $deps = @{$args{deps}} ?
-          join(' ',
-               map { file_name_is_absolute($_) || ($_ =~ m|^../|) ? "\"$_\"" : $_ }
-               (@{$args{generator_deps}}, @{$args{deps}}))
-          : '';
+      my $deps = join(' ',
+                      map { file_name_is_absolute($_) || ($_ =~ m|^../|) ? "\"$_\"" : $_ }
+                      compute_platform_depends(@{$args{generator_deps}},
+                                               @{$args{deps}}));
 
       if ($args{src} =~ /\.html$/) {
           #
@@ -790,38 +800,22 @@ EOF
           my $dofile = abs2rel(rel2abs(catfile($config{sourcedir},
                                                "util", "dofile.pl")),
                                rel2abs($config{builddir}));
-          my @modules = ( 'configdata.pm',
-                          grep { $_ =~ m|\.pm$| } @{$args{deps}} );
-          my %moduleincs = map { '"-I'.dirname($_).'"' => 1 } @modules;
-          $deps = join(' ', $deps, @modules);
-          @modules = map { "-M".basename($_, '.pm') } @modules;
-          my $modules = join(' ', '', sort keys %moduleincs, @modules);
+          my @perlmodules = ( 'configdata.pm',
+                              grep { $_ =~ m|\.pm$| } @{$args{deps}} );
+          my %perlmoduleincs = map { '"-I'.dirname($_).'"' => 1 } @perlmodules;
+          $deps = join(' ', $deps, compute_platform_depends(@perlmodules));
+          @perlmodules = map { "-M".basename($_, '.pm') } @perlmodules;
+          my $perlmodules = join(' ', '', sort keys %perlmoduleincs, @perlmodules);
           return <<"EOF";
 $args{src}: "$gen0" $deps
-	"\$(PERL)"$modules "$dofile" "-o$target{build_file}" "$gen0"$gen_args > \$@
+	"\$(PERL)"$perlmodules "$dofile" "-o$target{build_file}" "$gen0"$gen_args > \$@
 EOF
       } elsif (grep { $_ eq $gen0 } @{$unified_info{programs}}) {
           #
           # Generic generator using OpenSSL programs
           #
 
-          # Redo $deps, because programs aren't expected to have deps of their
-          # own.  This is a little more tricky, though, because running programs
-          # may have dependencies on all sorts of files, so we search through
-          # our database of programs and modules to see if our dependencies
-          # are one of those.
-          $deps = join(' ', map { my $x = $_;
-                                  if (grep { $x eq $_ }
-                                          @{$unified_info{programs}}) {
-                                      platform->bin($x);
-                                  } elsif (grep { $x eq $_ }
-                                          @{$unified_info{modules}}) {
-                                      platform->dso($x);
-                                  } else {
-                                      $x;
-                                  }
-                                } @{$args{deps}});
-          # Also redo $gen0, to ensure that we have the proper extension.
+          # Redo $gen0, to ensure that we have the proper extension.
           $gen0 = platform->bin($gen0);
           return <<"EOF";
 $args{src}: $gen0 $deps "\$(BLDDIR)\\util\\wrap.pl"

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -701,7 +701,7 @@ reconfigure reconf:
 
   sub generatetarget {
       my %args = @_;
-      my $deps = join(" ", compute_lib_depends(@{$args{deps}}));
+      my $deps = join(" ", compute_platform_depends(@{$args{deps}}));
       return <<"EOF";
 $args{target}: $deps
 EOF

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -49,17 +49,25 @@ SHLIB_VERSION_NUMBER={- $config{shlib_version} -}
 LIBS={- join(" ", map { ( platform->sharedlib_import($_), platform->staticlib($_) ) } @{$unified_info{libraries}}) -}
 SHLIBS={- join(" ", map { platform->sharedlib($_) // () } @{$unified_info{libraries}}) -}
 SHLIBPDBS={- join(" ", map { platform->sharedlibpdb($_) // () } @{$unified_info{libraries}}) -}
-MODULES={- our @MODULES = map { platform->dso($_) } @{$unified_info{modules}};
+MODULES={- our @MODULES = map { platform->dso($_) }
+                          # Drop all modules that are dependencies, they will
+                          # be processed through their dependents
+                          grep { my $x = $_;
+                                 !grep { grep { $_ eq $x } @$_ }
+                                       values %{$unified_info{depends}} }
+                          @{$unified_info{modules}};
            join(" ", @MODULES) -}
 MODULEPDBS={- join(" ", map { platform->dsopdb($_) } @{$unified_info{modules}}) -}
-FIPSMODULENAME={- # We do some extra checking here, as there should be only one
-                  use File::Basename;
-                  my @fipsmodules =
-                      grep { !$unified_info{attributes}->{modules}->{$_}->{noinst}
-                             && $unified_info{attributes}->{modules}->{$_}->{fips} }
-                      @{$unified_info{modules}};
-                  die "More that one FIPS module" if scalar @fipsmodules > 1;
-                  join(" ", map { basename(platform->dso($_)) } @fipsmodules) -}
+FIPSMODULE={- # We do some extra checking here, as there should be only one
+              use File::Basename;
+              our @fipsmodules =
+                  grep { !$unified_info{attributes}->{modules}->{$_}->{noinst}
+                         && $unified_info{attributes}->{modules}->{$_}->{fips} }
+                  @{$unified_info{modules}};
+              die "More that one FIPS module" if scalar @fipsmodules > 1;
+              join(" ", map { basename(platform->dso($_)) } @fipsmodules) -}
+FIPSMODULENAME={- die "More that one FIPS module" if scalar @fipsmodules > 1;
+                  join(", ", map { basename(platform->dso($_)) } @fipsmodules) -}
 PROGRAMS={- our @PROGRAMS = map { platform->bin($_) } @{$unified_info{programs}}; join(" ", @PROGRAMS) -}
 PROGRAMPDBS={- join(" ", map { $_.".pdb" } @{$unified_info{programs}}) -}
 SCRIPTS={- our @SCRIPTS = @{$unified_info{scripts}}; join(" ", @SCRIPTS) -}

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -112,12 +112,6 @@ INSTALL_ENGINEPDBS={-
                          && $unified_info{attributes}->{modules}->{$_}->{engine} }
                   @{$unified_info{modules}})
 -}
-INSTALL_FIPS={-
-        join(" ", map { quotify1(platform->dso($_)) }
-                  grep { !$unified_info{attributes}->{modules}->{$_}->{noinst}
-                          && $unified_info{attributes}->{modules}->{$_}->{fips} }
-                  @{$unified_info{modules}})
--}
 INSTALL_MODULES={-
         join(" ", map { quotify1(platform->dso($_)) }
                   grep { !$unified_info{attributes}->{modules}->{$_}->{noinst}
@@ -131,6 +125,13 @@ INSTALL_MODULEPDBS={-
                          && !$unified_info{attributes}->{modules}->{$_}->{engine} }
                   @{$unified_info{modules}})
 -}
+INSTALL_FIPSMODULE={-
+        join(" ", map { quotify1(platform->dso($_)) }
+                  grep { !$unified_info{attributes}->{modules}->{$_}->{noinst}
+                          && $unified_info{attributes}->{modules}->{$_}->{fips} }
+                  @{$unified_info{modules}})
+-}
+INSTALL_FIPSMODULECONF=providers\fipsmodule.cnf
 INSTALL_PROGRAMS={-
         join(" ", map { quotify1(platform->bin($_)) }
                   grep { !$unified_info{attributes}->{programs}->{$_}->{noinst} }
@@ -499,13 +500,13 @@ install_fips: build_sw providers\fipsmodule.cnf
 #	@[ -n "$(INSTALLTOP)" ] || (echo INSTALLTOP should not be empty; exit 1)
 	@$(PERL) $(SRCDIR)\util\mkdir-p.pl $(MODULESDIR)
 	@$(ECHO) "*** Installing FIPS module"
-	@$(ECHO) "install $(INSTALL_FIPS) -> $(MODULESDIR)\$(FIPSMODULENAME)"
-	@copy "$(INSTALL_FIPS)" $(MODULESDIR)\$(FIPSMODULENAME).new
+	@$(ECHO) "install $(INSTALL_FIPSMODULE) -> $(MODULESDIR)\$(FIPSMODULENAME)"
+	@copy "$(INSTALL_FIPSMODULE)" $(MODULESDIR)\$(FIPSMODULENAME).new
 	@move /Y $(MODULESDIR)\$(FIPSMODULENAME).new \
 	       $(MODULESDIR)\$(FIPSMODULENAME)
 	@$(ECHO) "*** Installing FIPS module configuration"
-	@$(ECHO) "install providers\fipsmodule.cnf -> $(OPENSSLDIR)\fipsmodule.cnf"
-    @copy providers\fipsmodule.cnf "$(OPENSSLDIR)\fipsmodule.cnf"
+	@$(ECHO) "install $(INSTALL_FIPSMODULECONF) -> $(OPENSSLDIR)\fipsmodule.cnf"
+	@copy $(INSTALL_FIPSMODULECONF) "$(OPENSSLDIR)\fipsmodule.cnf"
 
 uninstall_fips:
 	@$(ECHO) "*** Uninstalling FIPS module configuration"

--- a/providers/build.info
+++ b/providers/build.info
@@ -114,17 +114,10 @@ IF[{- !$disabled{fips} -}]
     GENERATE[fips.ld]=../util/providers.num
   ENDIF
 
-  # For tests that try to use the FIPS module, we need to make a local fips
-  # module installation.  We have the output go to standard output, because
-  # the generated commands in build templates are expected to catch that,
-  # and thereby keep control over the exact output file location.
-  IF[{- !$disabled{tests} -}]
-    DEPEND[|run_tests|]=fipsmodule.cnf
-    GENERATE[fipsmodule.cnf]=../apps/openssl fipsinstall \
-          -module providers/$(FIPSMODULENAME) -provider_name fips \
-          -mac_name HMAC -section_name fips_sect
-    DEPEND[fipsmodule.cnf]=$FIPSGOAL
-  ENDIF
+  DEPEND[|build_modules_nodep|]=fipsmodule.cnf
+  GENERATE[fipsmodule.cnf]=../util/mk-fipsmodule-cnf.pl \
+          -module $(FIPSMODULE) -section_name fips_sect -key $(FIPSKEY)
+  DEPEND[fipsmodule.cnf]=$FIPSGOAL
 ENDIF
 
 #

--- a/test/recipes/00-prep_fipsmodule_cnf.t
+++ b/test/recipes/00-prep_fipsmodule_cnf.t
@@ -6,9 +6,6 @@
 # in the file LICENSE in the source distribution or at
 # https://www.openssl.org/source/license.html
 
-# This is a sanity checker to see that the fipsmodule.cnf that's been
-# generated for testing is valid.
-
 use strict;
 use warnings;
 
@@ -16,7 +13,7 @@ use OpenSSL::Test qw/:DEFAULT srctop_dir bldtop_dir bldtop_file srctop_file data
 use OpenSSL::Test::Utils;
 
 BEGIN {
-    setup("test_fipsmodule");
+    setup("prep_fipsmodule");
 }
 
 use lib srctop_dir('Configurations');
@@ -24,14 +21,16 @@ use lib bldtop_dir('.');
 use platform;
 
 my $no_check = disabled("fips");
-plan skip_all => "Test only supported in a fips build"
+plan skip_all => "FIPS module config file only supported in a fips build"
     if $no_check;
-plan tests => 1;
 
 my $fipsmodule = bldtop_file('providers', platform->dso('fips'));
 my $fipsmoduleconf = bldtop_file('test', 'fipsmodule.cnf');
 
-# verify the $fipsconf file
+plan tests => 1;
+
+# Create the $fipsmoduleconf file
 ok(run(app(['openssl', 'fipsinstall',
-            '-in',  $fipsmoduleconf, '-module', $fipsmodule, '-verify'])),
-   "fipsinstall verify");
+            '-module', $fipsmodule, '-provider_name', 'fips',
+            '-section_name', 'fips_sect', '-out', $fipsmoduleconf])),
+   "fips install");

--- a/test/recipes/90-test_threads.t
+++ b/test/recipes/90-test_threads.t
@@ -38,7 +38,7 @@ if ($no_fips) {
 # status is required.
 
 open CFGBASE, '<', $config_path;
-open CFGINC, '<', bldtop_file('/providers/fipsmodule.cnf');
+open CFGINC, '<', bldtop_file('/test/fipsmodule.cnf');
 open CFGOUT, '>', 'thread.cnf';
 
 while (<CFGBASE>) {

--- a/test/run_tests.pl
+++ b/test/run_tests.pl
@@ -34,7 +34,7 @@ my $libdir = rel2abs(catdir($srctop, "util", "perl"));
 my $jobs = $ENV{HARNESS_JOBS} // 1;
 
 $ENV{OPENSSL_CONF} = rel2abs(catdir($srctop, "apps", "openssl.cnf"));
-$ENV{OPENSSL_CONF_INCLUDE} = rel2abs(catdir($bldtop, "providers"));
+$ENV{OPENSSL_CONF_INCLUDE} = rel2abs(catdir($bldtop, "test"));
 $ENV{OPENSSL_MODULES} = rel2abs(catdir($bldtop, "providers"));
 $ENV{OPENSSL_ENGINES} = rel2abs(catdir($bldtop, "engines"));
 $ENV{CTLOG_FILE} = rel2abs(catdir($srctop, "test", "ct", "log_list.cnf"));
@@ -134,10 +134,15 @@ foreach my $arg (@ARGV ? @ARGV : ('alltests')) {
 sub find_matching_tests {
     my ($glob) = @_;
 
+    # prep recipes are mandatory
+    my @recipes = glob(catfile($recipesdir,"00-prep_*.t"));
+
     if ($glob =~ m|^[\d\[\]\?\-]+$|) {
-        return glob(catfile($recipesdir,"$glob-*.t"));
+        push @recipes, glob(catfile($recipesdir,"$glob-*.t"));
+    } else {
+        push @recipes, glob(catfile($recipesdir,"*-$glob.t"));
     }
-    return glob(catfile($recipesdir,"*-$glob.t"));
+    return @recipes;
 }
 
 # The following is quite a bit of hackery to adapt to both TAP::Harness

--- a/util/mk-fipsmodule-cnf.pl
+++ b/util/mk-fipsmodule-cnf.pl
@@ -1,0 +1,44 @@
+#! /usr/bin/env perl
+# Copyright 2021 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+use Getopt::Long;
+
+my $activate = 1;
+my $conditional_errors = 1;
+my $security_checks = 1;
+my $mac_key;
+my $module_name;
+my $section_name = "fips_sect";
+
+GetOptions("key=s"              => \$mac_key,
+           "module=s"           => \$module_name,
+           "section_name=s"     => \$section_name)
+    or die "Error when getting command line arguments";
+
+my $mac_keylen = length($mac_key);
+
+use Digest::SHA qw(hmac_sha256_hex);
+my $module_size = [ stat($module_name) ]->[7];
+
+open my $fh, "<:raw", $module_name or die "Trying to open $module_name: $!";
+read $fh, my $data, $module_size or die "Trying to read $module_name: $!";
+close $fh;
+
+# Calculate HMAC-SHA256 in hex, and split it into a list of two character
+# chunks, and join the chunks with colons.
+my @module_mac
+    = ( uc(hmac_sha256_hex($data, pack("H$mac_keylen", $mac_key))) =~ m/../g );
+my $module_mac = join(':', @module_mac);
+
+print <<_____;
+[$section_name]
+activate = $activate
+conditional-errors = $conditional_errors
+security-checks = $security_checks
+module-mac = $module_mac
+_____


### PR DESCRIPTION
`providers/fipsmodule.cnf` has the integrity checksum but not the installation checksum, and is installed alongside the FIPS module itself.  It's up to the security officer to run `openssl fipsinstall` to add the installation checksum.

`test/fipsmodule.cnf`, on the other hand, is produced with both an integrity checksum and installation checksum, so is installed locally for testing purposes.

Fixes #15166