### PR TITLE
fix Solaris OS detection in config.pm

### DIFF
--- a/util/perl/OpenSSL/config.pm
+++ b/util/perl/OpenSSL/config.pm
@@ -197,13 +197,15 @@ sub is_sco_uname {
 
     open UNAME, "uname -X 2>/dev/null|" or return '';
     my $line = "";
+    my $os = "";
     while ( <UNAME> ) {
         chop;
         $line = $_ if m@^Release@;
+        $os = $_ if m@^System@;
     }
     close UNAME;
 
-    return undef if $line eq '';
+    return undef if $line eq '' or $os eq 'System = SunOS';
 
     my @fields = split(/\s+/, $line);
     return $fields[2];
@@ -238,7 +240,7 @@ sub get_sco_type {
 sub guess_system {
     ($SYSTEM, undef, $RELEASE, $VERSION, $MACHINE) = POSIX::uname();
     my $sys = "${SYSTEM}:${RELEASE}:${VERSION}:${MACHINE}";
-
+    
     # Special-cases for ISC, SCO, Unixware
     my $REL = is_sco_uname();
     if ( defined $REL ) {
@@ -360,30 +362,21 @@ sub determine_compiler_settings {
         }
 
         if ( $SYSTEM eq "SunOS" ) {
-            # check for WorkShop C, expected output is "cc: blah-blah C x.x"
+            # check for Oracle Developer Studio, expected output is "cc: blah-blah C x.x blah-blah"
             my $v = `(cc -V 2>&1) 2>/dev/null | egrep -e '^cc: .* C [0-9]\.[0-9]'`;
-            chomp $v;
-            $v =~ s/.* C \([0-9]\)\.\([0-9]\).*/$1.$2/;
-            my @numbers = split /\./, $v;
+	    my @numbers = 
+                    ( $v =~ m/^.* C ([0-9]+)\.([0-9]+) .*/ );
             my @factors = (100, 1);
             $v = 0;
             while (@numbers && @factors) {
                 $v += shift(@numbers) * shift(@factors)
             }
 
-            if ( $v > 40000 &&  $MACHINE ne 'i86pc' ) {
+	    if ($v > 500) {
                 $CC = 'cc';
-                $CCVENDOR = ''; # Determine later
+                $CCVENDOR = 'sun';
                 $CCVER = $v;
-
-                if ( $CCVER == 50000 ) {
-                    print <<'EOF';
-WARNING! Found WorkShop C 5.0.
-         Make sure you have patch #107357-01 or later applied.
-EOF
-                    maybe_abort();
-                }
-            }
+	   }
         }
     }
 
@@ -685,11 +678,12 @@ EOF
         sub {
             my $KERNEL_BITS = $ENV{KERNEL_BITS};
             my $ISA64 = `isainfo 2>/dev/null | grep sparcv9`;
-            if ( $ISA64 ne "" && $KERNEL_BITS eq '' ) {
+	    my $KB = $KERNEL_BITS // '64';
+            if ( $ISA64 ne "" && $KB eq '64' ) {
                 if ( $CCVENDOR eq "sun" && $CCVER >= 500 ) {
                     print <<EOF;
-WARNING! To build 64-bit package, do this:
-         $WHERE/Configure solaris64-sparcv9-cc
+WARNING! To build 32-bit package, do this:
+         $WHERE/Configure solaris-sparcv9-cc
 EOF
                     maybe_abort();
                 } elsif ( $CCVENDOR eq "gnu" && $GCC_ARCH eq "-m64" ) {
@@ -702,7 +696,7 @@ WARNING! To build 32-bit package, do this:
          $WHERE/Configure solaris-sparcv9-gcc
 EOF
                     maybe_abort();
-                    return { target => "solaris64-sparcv9" };
+                    return { target => "solaris64-sparcv9-gcc" };
                 } elsif ( $GCC_ARCH eq "-m32" ) {
                     print <<EOF;
 NOTICE! If you *know* that your GNU C supports 64-bit/V9 ABI and you wish
@@ -712,9 +706,9 @@ EOF
                     maybe_abort();
                 }
             }
-            return { target => "solaris64-sparcv9" }
-                if $ISA64 ne "" && $KERNEL_BITS eq '64';
-            return { target => "solaris-sparcv9" };
+            return { target => "solaris64-sparcv9-cc" }
+                if $ISA64 ne "" && $KB eq '64';
+            return { target => "solaris-sparcv9-cc" };
         }
       ],
       [ 'sun4m-.*-solaris2',      { target => "solaris-sparcv8" } ],

--- a/util/perl/OpenSSL/config.pm
+++ b/util/perl/OpenSSL/config.pm
@@ -364,7 +364,7 @@ sub determine_compiler_settings {
         if ( $SYSTEM eq "SunOS" ) {
             # check for Oracle Developer Studio, expected output is "cc: blah-blah C x.x blah-blah"
             my $v = `(cc -V 2>&1) 2>/dev/null | egrep -e '^cc: .* C [0-9]\.[0-9]'`;
-	    my @numbers = 
+            my @numbers = 
                     ( $v =~ m/^.* C ([0-9]+)\.([0-9]+) .*/ );
             my @factors = (100, 1);
             $v = 0;
@@ -372,11 +372,11 @@ sub determine_compiler_settings {
                 $v += shift(@numbers) * shift(@factors)
             }
 
-	    if ($v > 500) {
+            if ($v > 500) {
                 $CC = 'cc';
                 $CCVENDOR = 'sun';
                 $CCVER = $v;
-	   }
+            }
         }
     }
 
@@ -678,7 +678,7 @@ EOF
         sub {
             my $KERNEL_BITS = $ENV{KERNEL_BITS};
             my $ISA64 = `isainfo 2>/dev/null | grep sparcv9`;
-	    my $KB = $KERNEL_BITS // '64';
+            my $KB = $KERNEL_BITS // '64';
             if ( $ISA64 ne "" && $KB eq '64' ) {
                 if ( $CCVENDOR eq "sun" && $CCVER >= 500 ) {
                     print <<EOF;


### PR DESCRIPTION
This fixes openssl/openssl#15435 issue.

This change also fixes the Sun compiler detection - Oracle Developer Studio is the current name for the compilers that were known as Sun Workshop long ago.
