### PR TITLE
Fix possible infinite loop in pem_read_bio_key_decoder()

### DIFF
--- a/crypto/encode_decode/decoder_lib.c
+++ b/crypto/encode_decode/decoder_lib.c
@@ -87,9 +87,10 @@ int OSSL_DECODER_from_bio(OSSL_DECODER_CTX *ctx, BIO *in)
         const char *input_structure
             = ctx->input_structure != NULL ? ctx->input_structure : "";
 
-        if (BIO_eof(in) == 0 /* Prevent spurious decoding error */)
+        if (BIO_eof(in) == 0 || ERR_peek_error() == 0)
+            /* Prevent spurious decoding error */
             ERR_raise_data(ERR_LIB_OSSL_DECODER, ERR_R_UNSUPPORTED,
-                           "Not supported for the data to decode.%s%s%s%s%s%s",
+                           "No supported data to decode. %s%s%s%s%s%s",
                            spaces, input_type_label, input_type, comma,
                            input_structure_label, input_structure);
         ok = 0;


### PR DESCRIPTION
There could be an infinite loop if no read happened.

Fixes #15426
