### PR TITLE
Update krb5 module and re-enable pkinit tests

### DIFF
--- a/test/recipes/95-test_external_krb5_data/krb5.sh
+++ b/test/recipes/95-test_external_krb5_data/krb5.sh
@@ -13,7 +13,7 @@ CFLAGS="-I`pwd`/$BLDTOP/include -I`pwd`/$SRCTOP/include"
 
 cd $SRCTOP/krb5/src
 autoreconf
-./configure --with-ldap --with-prng-alg=os --disable-pkinit \
+./configure --with-ldap --with-prng-alg=os --enable-pkinit \
             --with-crypto-impl=openssl --with-tls-impl=openssl \
             CFLAGS="$CFLAGS" LDFLAGS="$LDFLAGS"
 


### PR DESCRIPTION
pkinit tests were disabled in cd0aca532091de4dfadf2f12b18dd99e9cba7615

Signed-off-by: Robbie Harwood <rharwood@redhat.com>

~~[This is a proof-of-concept right now - it needs https://github.com/krb5/krb5/pull/1187 to merge first, and then I'll drop the reference to my own fork.]~~ PR has merged.
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
