### PR TITLE
Rename symbols so they are in our reserved global namespace

### DIFF
--- a/crypto/aes/asm/bsaes-armv7.pl
+++ b/crypto/aes/asm/bsaes-armv7.pl
@@ -1119,10 +1119,10 @@ $code.=<<___;
 .extern AES_cbc_encrypt
 .extern AES_decrypt
 
-.global	bsaes_cbc_encrypt
-.type	bsaes_cbc_encrypt,%function
+.global	ossl_bsaes_cbc_encrypt
+.type	ossl_bsaes_cbc_encrypt,%function
 .align	5
-bsaes_cbc_encrypt:
+ossl_bsaes_cbc_encrypt:
 #ifndef	__KERNEL__
 	cmp	$len, #128
 #ifndef	__thumb__
@@ -1384,7 +1384,7 @@ bsaes_cbc_encrypt:
 	vst1.8	{@XMM[15]}, [$ivp]		@ return IV
 	VFP_ABI_POP
 	ldmia	sp!, {r4-r10, pc}
-.size	bsaes_cbc_encrypt,.-bsaes_cbc_encrypt
+.size	ossl_bsaes_cbc_encrypt,.-ossl_bsaes_cbc_encrypt
 ___
 }
 {
@@ -1394,10 +1394,10 @@ my $keysched = "sp";
 
 $code.=<<___;
 .extern	AES_encrypt
-.global	bsaes_ctr32_encrypt_blocks
-.type	bsaes_ctr32_encrypt_blocks,%function
+.global	ossl_bsaes_ctr32_encrypt_blocks
+.type	ossl_bsaes_ctr32_encrypt_blocks,%function
 .align	5
-bsaes_ctr32_encrypt_blocks:
+ossl_bsaes_ctr32_encrypt_blocks:
 	cmp	$len, #8			@ use plain AES for
 	blo	.Lctr_enc_short			@ small sizes
 
@@ -1620,7 +1620,7 @@ bsaes_ctr32_encrypt_blocks:
 	vstmia		sp!, {q0-q1}
 
 	ldmia	sp!, {r4-r8, pc}
-.size	bsaes_ctr32_encrypt_blocks,.-bsaes_ctr32_encrypt_blocks
+.size	ossl_bsaes_ctr32_encrypt_blocks,.-ossl_bsaes_ctr32_encrypt_blocks
 ___
 }
 {
@@ -1635,10 +1635,10 @@ my $twmask=@XMM[5];
 my @T=@XMM[6..7];
 
 $code.=<<___;
-.globl	bsaes_xts_encrypt
-.type	bsaes_xts_encrypt,%function
+.globl	ossl_bsaes_xts_encrypt
+.type	ossl_bsaes_xts_encrypt,%function
 .align	4
-bsaes_xts_encrypt:
+ossl_bsaes_xts_encrypt:
 	mov	ip, sp
 	stmdb	sp!, {r4-r10, lr}		@ 0x20
 	VFP_ABI_PUSH
@@ -2037,12 +2037,12 @@ $code.=<<___;
 	VFP_ABI_POP
 	ldmia		sp!, {r4-r10, pc}	@ return
 
-.size	bsaes_xts_encrypt,.-bsaes_xts_encrypt
+.size	ossl_bsaes_xts_encrypt,.-ossl_bsaes_xts_encrypt
 
-.globl	bsaes_xts_decrypt
-.type	bsaes_xts_decrypt,%function
+.globl	ossl_bsaes_xts_decrypt
+.type	ossl_bsaes_xts_decrypt,%function
 .align	4
-bsaes_xts_decrypt:
+ossl_bsaes_xts_decrypt:
 	mov	ip, sp
 	stmdb	sp!, {r4-r10, lr}		@ 0x20
 	VFP_ABI_PUSH
@@ -2472,7 +2472,7 @@ $code.=<<___;
 	VFP_ABI_POP
 	ldmia		sp!, {r4-r10, pc}	@ return
 
-.size	bsaes_xts_decrypt,.-bsaes_xts_decrypt
+.size	ossl_bsaes_xts_decrypt,.-ossl_bsaes_xts_decrypt
 ___
 }
 $code.=<<___;

--- a/crypto/aes/asm/bsaes-x86_64.pl
+++ b/crypto/aes/asm/bsaes-x86_64.pl
@@ -1611,10 +1611,10 @@ ___
 }
 $code.=<<___;
 .extern	asm_AES_cbc_encrypt
-.globl	bsaes_cbc_encrypt
-.type	bsaes_cbc_encrypt,\@abi-omnipotent
+.globl	ossl_bsaes_cbc_encrypt
+.type	ossl_bsaes_cbc_encrypt,\@abi-omnipotent
 .align	16
-bsaes_cbc_encrypt:
+ossl_bsaes_cbc_encrypt:
 .cfi_startproc
 	endbranch
 ___
@@ -1915,12 +1915,12 @@ $code.=<<___;
 .Lcbc_dec_epilogue:
 	ret
 .cfi_endproc
-.size	bsaes_cbc_encrypt,.-bsaes_cbc_encrypt
+.size	ossl_bsaes_cbc_encrypt,.-ossl_bsaes_cbc_encrypt
 
-.globl	bsaes_ctr32_encrypt_blocks
-.type	bsaes_ctr32_encrypt_blocks,\@abi-omnipotent
+.globl	ossl_bsaes_ctr32_encrypt_blocks
+.type	ossl_bsaes_ctr32_encrypt_blocks,\@abi-omnipotent
 .align	16
-bsaes_ctr32_encrypt_blocks:
+ossl_bsaes_ctr32_encrypt_blocks:
 .cfi_startproc
 	endbranch
 	mov	%rsp, %rax
@@ -2166,7 +2166,7 @@ $code.=<<___;
 .Lctr_enc_epilogue:
 	ret
 .cfi_endproc
-.size	bsaes_ctr32_encrypt_blocks,.-bsaes_ctr32_encrypt_blocks
+.size	ossl_bsaes_ctr32_encrypt_blocks,.-ossl_bsaes_ctr32_encrypt_blocks
 ___
 ######################################################################
 # void bsaes_xts_[en|de]crypt(const char *inp,char *out,size_t len,
@@ -2177,10 +2177,10 @@ my ($twmask,$twres,$twtmp)=@XMM[13..15];
 $arg6=~s/d$//;
 
 $code.=<<___;
-.globl	bsaes_xts_encrypt
-.type	bsaes_xts_encrypt,\@abi-omnipotent
+.globl	ossl_bsaes_xts_encrypt
+.type	ossl_bsaes_xts_encrypt,\@abi-omnipotent
 .align	16
-bsaes_xts_encrypt:
+ossl_bsaes_xts_encrypt:
 .cfi_startproc
 	mov	%rsp, %rax
 .Lxts_enc_prologue:
@@ -2574,12 +2574,12 @@ $code.=<<___;
 .Lxts_enc_epilogue:
 	ret
 .cfi_endproc
-.size	bsaes_xts_encrypt,.-bsaes_xts_encrypt
+.size	ossl_bsaes_xts_encrypt,.-ossl_bsaes_xts_encrypt
 
-.globl	bsaes_xts_decrypt
-.type	bsaes_xts_decrypt,\@abi-omnipotent
+.globl	ossl_bsaes_xts_decrypt
+.type	ossl_bsaes_xts_decrypt,\@abi-omnipotent
 .align	16
-bsaes_xts_decrypt:
+ossl_bsaes_xts_decrypt:
 .cfi_startproc
 	mov	%rsp, %rax
 .Lxts_dec_prologue:
@@ -2998,7 +2998,7 @@ $code.=<<___;
 .Lxts_dec_epilogue:
 	ret
 .cfi_endproc
-.size	bsaes_xts_decrypt,.-bsaes_xts_decrypt
+.size	ossl_bsaes_xts_decrypt,.-ossl_bsaes_xts_decrypt
 ___
 }
 $code.=<<___;

--- a/crypto/bn/asm/rsaz-avx512.pl
+++ b/crypto/bn/asm/rsaz-avx512.pl
@@ -514,10 +514,10 @@ ___
 #
 # Extracted value (output) is 20 digit number in 2^52 radix.
 #
-# void extract_multiplier_2x20_win5(BN_ULONG *red_Y,
-#                                   const BN_ULONG red_table[1 << EXP_WIN_SIZE][2][20],
-#                                   int red_table_idx,
-#                                   int tbl_idx);           # 0 or 1
+# void ossl_extract_multiplier_2x20_win5(BN_ULONG *red_Y,
+#                                        const BN_ULONG red_table[1 << EXP_WIN_SIZE][2][20],
+#                                        int red_table_idx,
+#                                        int tbl_idx);           # 0 or 1
 #
 # EXP_WIN_SIZE = 5
 ###############################################################################
@@ -535,9 +535,9 @@ $code.=<<___;
 .text
 
 .align 32
-.globl  extract_multiplier_2x20_win5
-.type   extract_multiplier_2x20_win5,\@function,4
-extract_multiplier_2x20_win5:
+.globl  ossl_extract_multiplier_2x20_win5
+.type   ossl_extract_multiplier_2x20_win5,\@function,4
+ossl_extract_multiplier_2x20_win5:
 .cfi_startproc
     endbranch
     leaq    ($tbl_idx,$tbl_idx,4), %rax
@@ -581,7 +581,7 @@ extract_multiplier_2x20_win5:
 
     ret
 .cfi_endproc
-.size   extract_multiplier_2x20_win5, .-extract_multiplier_2x20_win5
+.size   ossl_extract_multiplier_2x20_win5, .-ossl_extract_multiplier_2x20_win5
 ___
 $code.=<<___;
 .data
@@ -696,9 +696,9 @@ rsaz_def_handler:
     .rva    .LSEH_end_RSAZ_amm52x20_x2_256
     .rva    .LSEH_info_RSAZ_amm52x20_x2_256
 
-    .rva    .LSEH_begin_extract_multiplier_2x20_win5
-    .rva    .LSEH_end_extract_multiplier_2x20_win5
-    .rva    .LSEH_info_extract_multiplier_2x20_win5
+    .rva    .LSEH_begin_ossl_extract_multiplier_2x20_win5
+    .rva    .LSEH_end_ossl_extract_multiplier_2x20_win5
+    .rva    .LSEH_info_ossl_extract_multiplier_2x20_win5
 
 .section    .xdata
 .align  8
@@ -710,10 +710,10 @@ rsaz_def_handler:
     .byte   9,0,0,0
     .rva    rsaz_def_handler
     .rva    .Lrsaz_amm52x20_x2_256_body,.Lrsaz_amm52x20_x2_256_epilogue
-.LSEH_info_extract_multiplier_2x20_win5:
+.LSEH_info_ossl_extract_multiplier_2x20_win5:
     .byte   9,0,0,0
     .rva    rsaz_def_handler
-    .rva    .LSEH_begin_extract_multiplier_2x20_win5,.LSEH_begin_extract_multiplier_2x20_win5
+    .rva    .LSEH_begin_ossl_extract_multiplier_2x20_win5,.LSEH_begin_ossl_extract_multiplier_2x20_win5
 ___
 }
 }}} else {{{                # fallback for old assembler
@@ -729,11 +729,11 @@ rsaz_avx512ifma_eligible:
 
 .globl  RSAZ_amm52x20_x1_256
 .globl  RSAZ_amm52x20_x2_256
-.globl  extract_multiplier_2x20_win5
+.globl  ossl_extract_multiplier_2x20_win5
 .type   RSAZ_amm52x20_x1_256,\@abi-omnipotent
 RSAZ_amm52x20_x1_256:
 RSAZ_amm52x20_x2_256:
-extract_multiplier_2x20_win5:
+ossl_extract_multiplier_2x20_win5:
     .byte   0x0f,0x0b    # ud2
     ret
 .size   RSAZ_amm52x20_x1_256, .-RSAZ_amm52x20_x1_256

--- a/crypto/bn/asm/rsaz-avx512.pl
+++ b/crypto/bn/asm/rsaz-avx512.pl
@@ -61,17 +61,17 @@ if ($avx512ifma>0) {{{
 
 $code.=<<___;
 .extern OPENSSL_ia32cap_P
-.globl  rsaz_avx512ifma_eligible
-.type   rsaz_avx512ifma_eligible,\@abi-omnipotent
+.globl  ossl_rsaz_avx512ifma_eligible
+.type   ossl_rsaz_avx512ifma_eligible,\@abi-omnipotent
 .align  32
-rsaz_avx512ifma_eligible:
+ossl_rsaz_avx512ifma_eligible:
     mov OPENSSL_ia32cap_P+8(%rip), %ecx
     xor %eax,%eax
     and \$`1<<31|1<<21|1<<17|1<<16`, %ecx     # avx512vl + avx512ifma + avx512dq + avx512f
     cmp \$`1<<31|1<<21|1<<17|1<<16`, %ecx
     cmove %ecx,%eax
     ret
-.size   rsaz_avx512ifma_eligible, .-rsaz_avx512ifma_eligible
+.size   ossl_rsaz_avx512ifma_eligible, .-ossl_rsaz_avx512ifma_eligible
 ___
 
 ###############################################################################
@@ -92,7 +92,7 @@ ___
 # This post-condition is true, provided the correct parameter |s| is choosen, i.e.
 # s >= n + 2 * k, which matches our case: 1040 > 1024 + 2 * 1.
 #
-# void RSAZ_amm52x20_x1_256(BN_ULONG *res,
+# void ossl_rsaz_amm52x20_x1_256(BN_ULONG *res,
 #                           const BN_ULONG *a,
 #                           const BN_ULONG *b,
 #                           const BN_ULONG *m,
@@ -305,10 +305,10 @@ ___
 $code.=<<___;
 .text
 
-.globl  RSAZ_amm52x20_x1_256
-.type   RSAZ_amm52x20_x1_256,\@function,5
+.globl  ossl_rsaz_amm52x20_x1_256
+.type   ossl_rsaz_amm52x20_x1_256,\@function,5
 .align 32
-RSAZ_amm52x20_x1_256:
+ossl_rsaz_amm52x20_x1_256:
 .cfi_startproc
     endbranch
     push    %rbx
@@ -381,7 +381,7 @@ $code.=<<___;
 .Lrsaz_amm52x20_x1_256_epilogue:
     ret
 .cfi_endproc
-.size   RSAZ_amm52x20_x1_256, .-RSAZ_amm52x20_x1_256
+.size   ossl_rsaz_amm52x20_x1_256, .-ossl_rsaz_amm52x20_x1_256
 ___
 
 $code.=<<___;
@@ -397,12 +397,12 @@ ___
 ###############################################################################
 # Dual Almost Montgomery Multiplication for 20-digit number in radix 2^52
 #
-# See description of RSAZ_amm52x20_x1_256() above for details about Almost
+# See description of ossl_rsaz_amm52x20_x1_256() above for details about Almost
 # Montgomery Multiplication algorithm and function input parameters description.
 #
 # This function does two AMMs for two independent inputs, hence dual.
 #
-# void RSAZ_amm52x20_x2_256(BN_ULONG out[2][20],
+# void ossl_rsaz_amm52x20_x2_256(BN_ULONG out[2][20],
 #                           const BN_ULONG a[2][20],
 #                           const BN_ULONG b[2][20],
 #                           const BN_ULONG m[2][20],
@@ -412,10 +412,10 @@ ___
 $code.=<<___;
 .text
 
-.globl  RSAZ_amm52x20_x2_256
-.type   RSAZ_amm52x20_x2_256,\@function,5
+.globl  ossl_rsaz_amm52x20_x2_256
+.type   ossl_rsaz_amm52x20_x2_256,\@function,5
 .align 32
-RSAZ_amm52x20_x2_256:
+ossl_rsaz_amm52x20_x2_256:
 .cfi_startproc
     endbranch
     push    %rbx
@@ -500,7 +500,7 @@ $code.=<<___;
 .Lrsaz_amm52x20_x2_256_epilogue:
     ret
 .cfi_endproc
-.size   RSAZ_amm52x20_x2_256, .-RSAZ_amm52x20_x2_256
+.size   ossl_rsaz_amm52x20_x2_256, .-ossl_rsaz_amm52x20_x2_256
 ___
 }
 
@@ -688,13 +688,13 @@ rsaz_def_handler:
 
 .section    .pdata
 .align  4
-    .rva    .LSEH_begin_RSAZ_amm52x20_x1_256
-    .rva    .LSEH_end_RSAZ_amm52x20_x1_256
-    .rva    .LSEH_info_RSAZ_amm52x20_x1_256
+    .rva    .LSEH_begin_ossl_rsaz_amm52x20_x1_256
+    .rva    .LSEH_end_ossl_rsaz_amm52x20_x1_256
+    .rva    .LSEH_info_ossl_rsaz_amm52x20_x1_256
 
-    .rva    .LSEH_begin_RSAZ_amm52x20_x2_256
-    .rva    .LSEH_end_RSAZ_amm52x20_x2_256
-    .rva    .LSEH_info_RSAZ_amm52x20_x2_256
+    .rva    .LSEH_begin_ossl_rsaz_amm52x20_x2_256
+    .rva    .LSEH_end_ossl_rsaz_amm52x20_x2_256
+    .rva    .LSEH_info_ossl_rsaz_amm52x20_x2_256
 
     .rva    .LSEH_begin_ossl_extract_multiplier_2x20_win5
     .rva    .LSEH_end_ossl_extract_multiplier_2x20_win5
@@ -702,11 +702,11 @@ rsaz_def_handler:
 
 .section    .xdata
 .align  8
-.LSEH_info_RSAZ_amm52x20_x1_256:
+.LSEH_info_ossl_rsaz_amm52x20_x1_256:
     .byte   9,0,0,0
     .rva    rsaz_def_handler
     .rva    .Lrsaz_amm52x20_x1_256_body,.Lrsaz_amm52x20_x1_256_epilogue
-.LSEH_info_RSAZ_amm52x20_x2_256:
+.LSEH_info_ossl_rsaz_amm52x20_x2_256:
     .byte   9,0,0,0
     .rva    rsaz_def_handler
     .rva    .Lrsaz_amm52x20_x2_256_body,.Lrsaz_amm52x20_x2_256_epilogue
@@ -720,23 +720,23 @@ ___
 $code.=<<___;
 .text
 
-.globl  rsaz_avx512ifma_eligible
-.type   rsaz_avx512ifma_eligible,\@abi-omnipotent
-rsaz_avx512ifma_eligible:
+.globl  ossl_rsaz_avx512ifma_eligible
+.type   ossl_rsaz_avx512ifma_eligible,\@abi-omnipotent
+ossl_rsaz_avx512ifma_eligible:
     xor     %eax,%eax
     ret
-.size   rsaz_avx512ifma_eligible, .-rsaz_avx512ifma_eligible
+.size   ossl_rsaz_avx512ifma_eligible, .-ossl_rsaz_avx512ifma_eligible
 
-.globl  RSAZ_amm52x20_x1_256
-.globl  RSAZ_amm52x20_x2_256
+.globl  ossl_rsaz_amm52x20_x1_256
+.globl  ossl_rsaz_amm52x20_x2_256
 .globl  ossl_extract_multiplier_2x20_win5
-.type   RSAZ_amm52x20_x1_256,\@abi-omnipotent
-RSAZ_amm52x20_x1_256:
-RSAZ_amm52x20_x2_256:
+.type   ossl_rsaz_amm52x20_x1_256,\@abi-omnipotent
+ossl_rsaz_amm52x20_x1_256:
+ossl_rsaz_amm52x20_x2_256:
 ossl_extract_multiplier_2x20_win5:
     .byte   0x0f,0x0b    # ud2
     ret
-.size   RSAZ_amm52x20_x1_256, .-RSAZ_amm52x20_x1_256
+.size   ossl_rsaz_amm52x20_x1_256, .-ossl_rsaz_amm52x20_x1_256
 ___
 }}}
 

--- a/crypto/bn/bn_depr.c
+++ b/crypto/bn/bn_depr.c
@@ -49,7 +49,7 @@ int BN_is_prime(const BIGNUM *a, int checks,
 {
     BN_GENCB cb;
     BN_GENCB_set_old(&cb, callback, cb_arg);
-    return bn_check_prime_int(a, checks, ctx_passed, 0, &cb);
+    return ossl_bn_check_prime(a, checks, ctx_passed, 0, &cb);
 }
 
 int BN_is_prime_fasttest(const BIGNUM *a, int checks,
@@ -59,5 +59,5 @@ int BN_is_prime_fasttest(const BIGNUM *a, int checks,
 {
     BN_GENCB cb;
     BN_GENCB_set_old(&cb, callback, cb_arg);
-    return bn_check_prime_int(a, checks, ctx_passed, do_trial_division, &cb);
+    return ossl_bn_check_prime(a, checks, ctx_passed, do_trial_division, &cb);
 }

--- a/crypto/bn/bn_exp.c
+++ b/crypto/bn/bn_exp.c
@@ -1410,7 +1410,7 @@ int BN_mod_exp_mont_consttime_x2(BIGNUM *rr1, const BIGNUM *a1, const BIGNUM *p1
     BN_MONT_CTX *mont1 = NULL;
     BN_MONT_CTX *mont2 = NULL;
 
-    if (rsaz_avx512ifma_eligible() &&
+    if (ossl_rsaz_avx512ifma_eligible() &&
         ((a1->top == 16) && (p1->top == 16) && (BN_num_bits(m1) == 1024) &&
          (a2->top == 16) && (p2->top == 16) && (BN_num_bits(m2) == 1024))) {
 
@@ -1437,11 +1437,11 @@ int BN_mod_exp_mont_consttime_x2(BIGNUM *rr1, const BIGNUM *a1, const BIGNUM *p1
                 goto err;
         }
 
-        ret = RSAZ_mod_exp_avx512_x2(rr1->d, a1->d, p1->d, m1->d, mont1->RR.d,
-                                     mont1->n0[0],
-                                     rr2->d, a2->d, p2->d, m2->d, mont2->RR.d,
-                                     mont2->n0[0],
-                                     1024 /* factor bit size */);
+        ret = ossl_rsaz_mod_exp_avx512_x2(rr1->d, a1->d, p1->d, m1->d,
+                                          mont1->RR.d, mont1->n0[0],
+                                          rr2->d, a2->d, p2->d, m2->d,
+                                          mont2->RR.d, mont2->n0[0],
+                                          1024 /* factor bit size */);
 
         rr1->top = 16;
         rr1->neg = 0;

--- a/crypto/bn/bn_local.h
+++ b/crypto/bn/bn_local.h
@@ -667,7 +667,7 @@ static ossl_inline BIGNUM *bn_expand(BIGNUM *a, int bits)
     return bn_expand2((a),(bits+BN_BITS2-1)/BN_BITS2);
 }
 
-int bn_check_prime_int(const BIGNUM *w, int checks, BN_CTX *ctx,
-                      int do_trial_division, BN_GENCB *cb);
+int ossl_bn_check_prime(const BIGNUM *w, int checks, BN_CTX *ctx,
+                        int do_trial_division, BN_GENCB *cb);
 
 #endif

--- a/crypto/bn/bn_prime.c
+++ b/crypto/bn/bn_prime.c
@@ -230,19 +230,19 @@ int BN_generate_prime_ex(BIGNUM *ret, int bits, int safe,
 int BN_is_prime_ex(const BIGNUM *a, int checks, BN_CTX *ctx_passed,
                    BN_GENCB *cb)
 {
-    return bn_check_prime_int(a, checks, ctx_passed, 0, cb);
+    return ossl_bn_check_prime(a, checks, ctx_passed, 0, cb);
 }
 
 int BN_is_prime_fasttest_ex(const BIGNUM *w, int checks, BN_CTX *ctx,
                             int do_trial_division, BN_GENCB *cb)
 {
-    return bn_check_prime_int(w, checks, ctx, do_trial_division, cb);
+    return ossl_bn_check_prime(w, checks, ctx, do_trial_division, cb);
 }
 #endif
 
 /* Wrapper around bn_is_prime_int that sets the minimum number of checks */
-int bn_check_prime_int(const BIGNUM *w, int checks, BN_CTX *ctx,
-                       int do_trial_division, BN_GENCB *cb)
+int ossl_bn_check_prime(const BIGNUM *w, int checks, BN_CTX *ctx,
+                        int do_trial_division, BN_GENCB *cb)
 {
     int min_checks = bn_mr_min_checks(BN_num_bits(w));
 
@@ -254,7 +254,7 @@ int bn_check_prime_int(const BIGNUM *w, int checks, BN_CTX *ctx,
 
 int BN_check_prime(const BIGNUM *p, BN_CTX *ctx, BN_GENCB *cb)
 {
-    return bn_check_prime_int(p, 0, ctx, 1, cb);
+    return ossl_bn_check_prime(p, 0, ctx, 1, cb);
 }
 
 /*

--- a/crypto/bn/rsaz_exp.h
+++ b/crypto/bn/rsaz_exp.h
@@ -36,21 +36,21 @@ void RSAZ_512_mod_exp(BN_ULONG result[8],
                       const BN_ULONG RR[8]);
 
 
-int rsaz_avx512ifma_eligible(void);
+int ossl_rsaz_avx512ifma_eligible(void);
 
-int RSAZ_mod_exp_avx512_x2(BN_ULONG *res1,
-                           const BN_ULONG *base1,
-                           const BN_ULONG *exponent1,
-                           const BN_ULONG *m1,
-                           const BN_ULONG *RR1,
-                           BN_ULONG k0_1,
-                           BN_ULONG *res2,
-                           const BN_ULONG *base2,
-                           const BN_ULONG *exponent2,
-                           const BN_ULONG *m2,
-                           const BN_ULONG *RR2,
-                           BN_ULONG k0_2,
-                           int factor_size);
+int ossl_rsaz_mod_exp_avx512_x2(BN_ULONG *res1,
+                                const BN_ULONG *base1,
+                                const BN_ULONG *exponent1,
+                                const BN_ULONG *m1,
+                                const BN_ULONG *RR1,
+                                BN_ULONG k0_1,
+                                BN_ULONG *res2,
+                                const BN_ULONG *base2,
+                                const BN_ULONG *exponent2,
+                                const BN_ULONG *m2,
+                                const BN_ULONG *RR2,
+                                BN_ULONG k0_2,
+                                int factor_size);
 
 # endif
 

--- a/crypto/bn/rsaz_exp_x2.c
+++ b/crypto/bn/rsaz_exp_x2.c
@@ -73,15 +73,15 @@ typedef void (*EXP52_x2)(BN_ULONG *res, const BN_ULONG *base,
  */
 
 /*AMM = Almost Montgomery Multiplication. */
-void RSAZ_amm52x20_x1_256(BN_ULONG *res, const BN_ULONG *base,
-                          const BN_ULONG *exp, const BN_ULONG *m,
-                          BN_ULONG k0);
-void RSAZ_exp52x20_x2_256(BN_ULONG *res, const BN_ULONG *base,
-                      const BN_ULONG *exp[2], const BN_ULONG *m,
-                      const BN_ULONG *rr, const BN_ULONG k0[2]);
-void RSAZ_amm52x20_x2_256(BN_ULONG *out, const BN_ULONG *a,
-                          const BN_ULONG *b, const BN_ULONG *m,
-                          const BN_ULONG k0[2]);
+void ossl_rsaz_amm52x20_x1_256(BN_ULONG *res, const BN_ULONG *base,
+                               const BN_ULONG *exp, const BN_ULONG *m,
+                               BN_ULONG k0);
+static void RSAZ_exp52x20_x2_256(BN_ULONG *res, const BN_ULONG *base,
+                                 const BN_ULONG *exp[2], const BN_ULONG *m,
+                                 const BN_ULONG *rr, const BN_ULONG k0[2]);
+void ossl_rsaz_amm52x20_x2_256(BN_ULONG *out, const BN_ULONG *a,
+                               const BN_ULONG *b, const BN_ULONG *m,
+                               const BN_ULONG k0[2]);
 void ossl_extract_multiplier_2x20_win5(BN_ULONG *red_Y,
                                        const BN_ULONG *red_table,
                                        int red_table_idx, int tbl_idx);
@@ -112,19 +112,19 @@ void ossl_extract_multiplier_2x20_win5(BN_ULONG *red_Y,
  * \return 0 in case of failure,
  *         1 in case of success.
  */
-int RSAZ_mod_exp_avx512_x2(BN_ULONG *res1,
-                           const BN_ULONG *base1,
-                           const BN_ULONG *exp1,
-                           const BN_ULONG *m1,
-                           const BN_ULONG *rr1,
-                           BN_ULONG k0_1,
-                           BN_ULONG *res2,
-                           const BN_ULONG *base2,
-                           const BN_ULONG *exp2,
-                           const BN_ULONG *m2,
-                           const BN_ULONG *rr2,
-                           BN_ULONG k0_2,
-                           int factor_size)
+int ossl_rsaz_mod_exp_avx512_x2(BN_ULONG *res1,
+                                const BN_ULONG *base1,
+                                const BN_ULONG *exp1,
+                                const BN_ULONG *m1,
+                                const BN_ULONG *rr1,
+                                BN_ULONG k0_1,
+                                BN_ULONG *res2,
+                                const BN_ULONG *base2,
+                                const BN_ULONG *exp2,
+                                const BN_ULONG *m2,
+                                const BN_ULONG *rr2,
+                                BN_ULONG k0_2,
+                                int factor_size)
 {
     int ret = 0;
 
@@ -152,7 +152,7 @@ int RSAZ_mod_exp_avx512_x2(BN_ULONG *res1,
     /* Only 1024-bit factor size is supported now */
     switch (factor_size) {
     case 1024:
-        amm = RSAZ_amm52x20_x1_256;
+        amm = ossl_rsaz_amm52x20_x1_256;
         exp_x2 = RSAZ_exp52x20_x2_256;
         break;
     default:
@@ -247,12 +247,12 @@ err:
  *
  * \return (void).
  */
-void RSAZ_exp52x20_x2_256(BN_ULONG *out,          /* [2][20] */
-                          const BN_ULONG *base,   /* [2][20] */
-                          const BN_ULONG *exp[2], /* 2x16    */
-                          const BN_ULONG *m,      /* [2][20] */
-                          const BN_ULONG *rr,     /* [2][20] */
-                          const BN_ULONG k0[2])
+static void RSAZ_exp52x20_x2_256(BN_ULONG *out,          /* [2][20] */
+                                 const BN_ULONG *base,   /* [2][20] */
+                                 const BN_ULONG *exp[2], /* 2x16    */
+                                 const BN_ULONG *m,      /* [2][20] */
+                                 const BN_ULONG *rr,     /* [2][20] */
+                                 const BN_ULONG k0[2])
 {
 # define BITSIZE_MODULUS (1024)
 # define EXP_WIN_SIZE (5)
@@ -263,13 +263,13 @@ void RSAZ_exp52x20_x2_256(BN_ULONG *out,          /* [2][20] */
  */
 # define RED_DIGITS (20)
 # define EXP_DIGITS (16)
-# define DAMM RSAZ_amm52x20_x2_256
+# define DAMM ossl_rsaz_amm52x20_x2_256
 /*
  * Squaring is done using multiplication now. That can be a subject of
  * optimization in future.
  */
 # define DAMS(r,a,m,k0) \
-              RSAZ_amm52x20_x2_256((r),(a),(a),(m),(k0))
+              ossl_rsaz_amm52x20_x2_256((r),(a),(a),(m),(k0))
 
     /* Allocate stack for red(undant) result Y and multiplier X */
     ALIGN64 BN_ULONG red_Y[2][RED_DIGITS];

--- a/crypto/bn/rsaz_exp_x2.c
+++ b/crypto/bn/rsaz_exp_x2.c
@@ -82,9 +82,9 @@ void RSAZ_exp52x20_x2_256(BN_ULONG *res, const BN_ULONG *base,
 void RSAZ_amm52x20_x2_256(BN_ULONG *out, const BN_ULONG *a,
                           const BN_ULONG *b, const BN_ULONG *m,
                           const BN_ULONG k0[2]);
-void extract_multiplier_2x20_win5(BN_ULONG *red_Y,
-                                  const BN_ULONG *red_table,
-                                  int red_table_idx, int tbl_idx);
+void ossl_extract_multiplier_2x20_win5(BN_ULONG *red_Y,
+                                       const BN_ULONG *red_table,
+                                       int red_table_idx, int tbl_idx);
 
 /*
  * Dual Montgomery modular exponentiation using prime moduli of the
@@ -328,8 +328,10 @@ void RSAZ_exp52x20_x2_256(BN_ULONG *out,          /* [2][20] */
         red_table_idx_0 >>= exp_chunk_shift;
         red_table_idx_1 >>= exp_chunk_shift;
 
-        extract_multiplier_2x20_win5(red_Y[0], (const BN_ULONG*)red_table, (int)red_table_idx_0, 0);
-        extract_multiplier_2x20_win5(red_Y[1], (const BN_ULONG*)red_table, (int)red_table_idx_1, 1);
+        ossl_extract_multiplier_2x20_win5(red_Y[0], (const BN_ULONG*)red_table,
+                                          (int)red_table_idx_0, 0);
+        ossl_extract_multiplier_2x20_win5(red_Y[1], (const BN_ULONG*)red_table,
+                                          (int)red_table_idx_1, 1);
 
         /* Process other exp windows */
         for (exp_bit_no -= EXP_WIN_SIZE; exp_bit_no >= 0; exp_bit_no -= EXP_WIN_SIZE) {
@@ -354,7 +356,9 @@ void RSAZ_exp52x20_x2_256(BN_ULONG *out,          /* [2][20] */
                     }
                     red_table_idx_0 &= table_idx_mask;
 
-                    extract_multiplier_2x20_win5(red_X[0], (const BN_ULONG*)red_table, (int)red_table_idx_0, 0);
+                    ossl_extract_multiplier_2x20_win5(red_X[0],
+                                                      (const BN_ULONG*)red_table,
+                                                      (int)red_table_idx_0, 0);
                 }
                 {
                     red_table_idx_1 = expz[1][exp_chunk_no];
@@ -371,7 +375,9 @@ void RSAZ_exp52x20_x2_256(BN_ULONG *out,          /* [2][20] */
                     }
                     red_table_idx_1 &= table_idx_mask;
 
-                    extract_multiplier_2x20_win5(red_X[1], (const BN_ULONG*)red_table, (int)red_table_idx_1, 1);
+                    ossl_extract_multiplier_2x20_win5(red_X[1],
+                                                      (const BN_ULONG*)red_table,
+                                                      (int)red_table_idx_1, 1);
                 }
             }
 

--- a/crypto/evp/e_aes.c
+++ b/crypto/evp/e_aes.c
@@ -2323,7 +2323,7 @@ static int aes_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
             ret = AES_set_decrypt_key(key, EVP_CIPHER_CTX_key_length(ctx) * 8,
                                       &dat->ks.ks);
             dat->block = (block128_f) AES_decrypt;
-            dat->stream.cbc = (cbc128_f) bsaes_cbc_encrypt;
+            dat->stream.cbc = (cbc128_f) ossl_bsaes_cbc_encrypt;
         } else
 #endif
 #ifdef VPAES_CAPABLE
@@ -2369,7 +2369,7 @@ static int aes_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
         ret = AES_set_encrypt_key(key, EVP_CIPHER_CTX_key_length(ctx) * 8,
                                   &dat->ks.ks);
         dat->block = (block128_f) AES_encrypt;
-        dat->stream.ctr = (ctr128_f) bsaes_ctr32_encrypt_blocks;
+        dat->stream.ctr = (ctr128_f) ossl_bsaes_ctr32_encrypt_blocks;
     } else
 #endif
 #ifdef VPAES_CAPABLE
@@ -2711,7 +2711,7 @@ static int aes_gcm_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
                 AES_set_encrypt_key(key, ctx->key_len * 8, &gctx->ks.ks);
                 CRYPTO_gcm128_init(&gctx->gcm, &gctx->ks,
                                    (block128_f) AES_encrypt);
-                gctx->ctr = (ctr128_f) bsaes_ctr32_encrypt_blocks;
+                gctx->ctr = (ctr128_f) ossl_bsaes_ctr32_encrypt_blocks;
                 break;
             } else
 #endif
@@ -3168,7 +3168,7 @@ static int aes_xts_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
 #endif
 #ifdef BSAES_CAPABLE
             if (BSAES_CAPABLE)
-                xctx->stream = enc ? bsaes_xts_encrypt : bsaes_xts_decrypt;
+                xctx->stream = enc ? ossl_bsaes_xts_encrypt : ossl_bsaes_xts_decrypt;
             else
 #endif
 #ifdef VPAES_CAPABLE

--- a/include/crypto/aes_platform.h
+++ b/include/crypto/aes_platform.h
@@ -29,18 +29,19 @@ void vpaes_cbc_encrypt(const unsigned char *in,
 # endif /* VPAES_ASM */
 
 # ifdef BSAES_ASM
-void bsaes_cbc_encrypt(const unsigned char *in, unsigned char *out,
-                       size_t length, const AES_KEY *key,
-                       unsigned char ivec[16], int enc);
-void bsaes_ctr32_encrypt_blocks(const unsigned char *in, unsigned char *out,
-                                size_t len, const AES_KEY *key,
-                                const unsigned char ivec[16]);
-void bsaes_xts_encrypt(const unsigned char *inp, unsigned char *out,
-                       size_t len, const AES_KEY *key1,
-                       const AES_KEY *key2, const unsigned char iv[16]);
-void bsaes_xts_decrypt(const unsigned char *inp, unsigned char *out,
-                       size_t len, const AES_KEY *key1,
-                       const AES_KEY *key2, const unsigned char iv[16]);
+void ossl_bsaes_cbc_encrypt(const unsigned char *in, unsigned char *out,
+                            size_t length, const AES_KEY *key,
+                            unsigned char ivec[16], int enc);
+void ossl_bsaes_ctr32_encrypt_blocks(const unsigned char *in,
+                                     unsigned char *out, size_t len,
+                                     const AES_KEY *key,
+                                     const unsigned char ivec[16]);
+void ossl_bsaes_xts_encrypt(const unsigned char *inp, unsigned char *out,
+                            size_t len, const AES_KEY *key1,
+                            const AES_KEY *key2, const unsigned char iv[16]);
+void ossl_bsaes_xts_decrypt(const unsigned char *inp, unsigned char *out,
+                            size_t len, const AES_KEY *key1,
+                            const AES_KEY *key2, const unsigned char iv[16]);
 # endif /* BSAES_ASM */
 
 # ifdef AES_CTR_ASM

--- a/providers/implementations/ciphers/cipher_aes_gcm_hw.c
+++ b/providers/implementations/ciphers/cipher_aes_gcm_hw.c
@@ -37,7 +37,7 @@ static int aes_gcm_initkey(PROV_GCM_CTX *ctx, const unsigned char *key,
 # ifdef BSAES_CAPABLE
     if (BSAES_CAPABLE) {
         GCM_HW_SET_KEY_CTR_FN(ks, AES_set_encrypt_key, AES_encrypt,
-                              bsaes_ctr32_encrypt_blocks);
+                              ossl_bsaes_ctr32_encrypt_blocks);
     } else
 # endif /* BSAES_CAPABLE */
 

--- a/providers/implementations/ciphers/cipher_aes_hw.c
+++ b/providers/implementations/ciphers/cipher_aes_hw.c
@@ -46,7 +46,7 @@ static int cipher_hw_aes_initkey(PROV_CIPHER_CTX *dat,
         if (BSAES_CAPABLE && dat->mode == EVP_CIPH_CBC_MODE) {
             ret = AES_set_decrypt_key(key, keylen * 8, ks);
             dat->block = (block128_f)AES_decrypt;
-            dat->stream.cbc = (cbc128_f)bsaes_cbc_encrypt;
+            dat->stream.cbc = (cbc128_f)ossl_bsaes_cbc_encrypt;
         } else
 #endif
 #ifdef VPAES_CAPABLE
@@ -91,7 +91,7 @@ static int cipher_hw_aes_initkey(PROV_CIPHER_CTX *dat,
     if (BSAES_CAPABLE && dat->mode == EVP_CIPH_CTR_MODE) {
         ret = AES_set_encrypt_key(key, keylen * 8, ks);
         dat->block = (block128_f)AES_encrypt;
-        dat->stream.ctr = (ctr128_f)bsaes_ctr32_encrypt_blocks;
+        dat->stream.ctr = (ctr128_f)ossl_bsaes_ctr32_encrypt_blocks;
     } else
 #endif
 #ifdef VPAES_CAPABLE

--- a/providers/implementations/ciphers/cipher_aes_xts_hw.c
+++ b/providers/implementations/ciphers/cipher_aes_xts_hw.c
@@ -65,8 +65,8 @@ static int cipher_hw_aes_xts_generic_initkey(PROV_CIPHER_CTX *ctx,
 
 #ifdef BSAES_CAPABLE
     if (BSAES_CAPABLE) {
-        stream_enc = bsaes_xts_encrypt;
-        stream_dec = bsaes_xts_decrypt;
+        stream_enc = ossl_bsaes_xts_encrypt;
+        stream_dec = ossl_bsaes_xts_decrypt;
     } else
 #endif /* BSAES_CAPABLE */
 #ifdef VPAES_CAPABLE


### PR DESCRIPTION
The following symbols are renamed:
```
bn_check_prime_int           ➯ ossl_bn_check_prime
bsaes_cbc_encrypt            ➯ ossl_bsaes_cbc_encrypt
bsaes_ctr32_encrypt_blocks   ➯ ossl_bsaes_ctr32_encrypt_blocks
bsaes_xts_decrypt            ➯ ossl_bsaes_xts_decrypt
bsaes_xts_encrypt            ➯ ossl_bsaes_xts_encrypt
extract_multiplier_2x20_win5 ➯ ossl_extract_multiplier_2x20_win5
RSAZ_amm52x20_x1_256         ➯ ossl_rsaz_amm52x20_x1_256
RSAZ_amm52x20_x2_256         ➯ ossl_rsaz_amm52x20_x2_256
rsaz_avx512ifma_eligible     ➯ ossl_rsaz_avx512ifma_eligible
RSAZ_mod_exp_avx512_x2       ➯ ossl_rsaz_mod_exp_avx512_x2
```

The function `RSAZ_exp52x20_x2_256` was made static.


This only impacts static builds.

- [ ] documentation is added or updated
- [ ] tests are added or updated
