### PR TITLE
err: rename err_load_xxx_strings_int functions

### DIFF
--- a/crypto/asn1/asn1_err.c
+++ b/crypto/asn1/asn1_err.c
@@ -202,7 +202,7 @@ static const ERR_STRING_DATA ASN1_str_reasons[] = {
 
 #endif
 
-int err_load_ASN1_strings_int(void)
+int ossl_err_load_ASN1_strings(void)
 {
 #ifndef OPENSSL_NO_ERR
     if (ERR_reason_error_string(ASN1_str_reasons[0].error) == NULL)

--- a/crypto/async/async_err.c
+++ b/crypto/async/async_err.c
@@ -27,7 +27,7 @@ static const ERR_STRING_DATA ASYNC_str_reasons[] = {
 
 #endif
 
-int err_load_ASYNC_strings_int(void)
+int ossl_err_load_ASYNC_strings(void)
 {
 #ifndef OPENSSL_NO_ERR
     if (ERR_reason_error_string(ASYNC_str_reasons[0].error) == NULL)

--- a/crypto/bio/bio_err.c
+++ b/crypto/bio/bio_err.c
@@ -76,7 +76,7 @@ static const ERR_STRING_DATA BIO_str_reasons[] = {
 
 #endif
 
-int err_load_BIO_strings_int(void)
+int ossl_err_load_BIO_strings(void)
 {
 #ifndef OPENSSL_NO_ERR
     if (ERR_reason_error_string(BIO_str_reasons[0].error) == NULL)

--- a/crypto/bn/bn_err.c
+++ b/crypto/bn/bn_err.c
@@ -45,7 +45,7 @@ static const ERR_STRING_DATA BN_str_reasons[] = {
 
 #endif
 
-int err_load_BN_strings_int(void)
+int ossl_err_load_BN_strings(void)
 {
 #ifndef OPENSSL_NO_ERR
     if (ERR_reason_error_string(BN_str_reasons[0].error) == NULL)

--- a/crypto/buffer/buf_err.c
+++ b/crypto/buffer/buf_err.c
@@ -20,7 +20,7 @@ static const ERR_STRING_DATA BUF_str_reasons[] = {
 
 #endif
 
-int err_load_BUF_strings_int(void)
+int ossl_err_load_BUF_strings(void)
 {
 #ifndef OPENSSL_NO_ERR
     if (ERR_reason_error_string(BUF_str_reasons[0].error) == NULL)

--- a/crypto/cmp/cmp_err.c
+++ b/crypto/cmp/cmp_err.c
@@ -160,7 +160,7 @@ static const ERR_STRING_DATA CMP_str_reasons[] = {
 
 # endif
 
-int err_load_CMP_strings_int(void)
+int ossl_err_load_CMP_strings(void)
 {
 # ifndef OPENSSL_NO_ERR
     if (ERR_reason_error_string(CMP_str_reasons[0].error) == NULL)

--- a/crypto/cms/cms_err.c
+++ b/crypto/cms/cms_err.c
@@ -163,7 +163,7 @@ static const ERR_STRING_DATA CMS_str_reasons[] = {
 
 # endif
 
-int err_load_CMS_strings_int(void)
+int ossl_err_load_CMS_strings(void)
 {
 # ifndef OPENSSL_NO_ERR
     if (ERR_reason_error_string(CMS_str_reasons[0].error) == NULL)

--- a/crypto/comp/comp_err.c
+++ b/crypto/comp/comp_err.c
@@ -28,7 +28,7 @@ static const ERR_STRING_DATA COMP_str_reasons[] = {
 
 # endif
 
-int err_load_COMP_strings_int(void)
+int ossl_err_load_COMP_strings(void)
 {
 # ifndef OPENSSL_NO_ERR
     if (ERR_reason_error_string(COMP_str_reasons[0].error) == NULL)

--- a/crypto/conf/conf_err.c
+++ b/crypto/conf/conf_err.c
@@ -62,7 +62,7 @@ static const ERR_STRING_DATA CONF_str_reasons[] = {
 
 #endif
 
-int err_load_CONF_strings_int(void)
+int ossl_err_load_CONF_strings(void)
 {
 #ifndef OPENSSL_NO_ERR
     if (ERR_reason_error_string(CONF_str_reasons[0].error) == NULL)

--- a/crypto/cpt_err.c
+++ b/crypto/cpt_err.c
@@ -58,7 +58,7 @@ static const ERR_STRING_DATA CRYPTO_str_reasons[] = {
 
 #endif
 
-int err_load_CRYPTO_strings_int(void)
+int ossl_err_load_CRYPTO_strings(void)
 {
 #ifndef OPENSSL_NO_ERR
     if (ERR_reason_error_string(CRYPTO_str_reasons[0].error) == NULL)

--- a/crypto/crmf/crmf_err.c
+++ b/crypto/crmf/crmf_err.c
@@ -61,7 +61,7 @@ static const ERR_STRING_DATA CRMF_str_reasons[] = {
 
 # endif
 
-int err_load_CRMF_strings_int(void)
+int ossl_err_load_CRMF_strings(void)
 {
 # ifndef OPENSSL_NO_ERR
     if (ERR_reason_error_string(CRMF_str_reasons[0].error) == NULL)

--- a/crypto/ct/ct_err.c
+++ b/crypto/ct/ct_err.c
@@ -48,7 +48,7 @@ static const ERR_STRING_DATA CT_str_reasons[] = {
 
 # endif
 
-int err_load_CT_strings_int(void)
+int ossl_err_load_CT_strings(void)
 {
 # ifndef OPENSSL_NO_ERR
     if (ERR_reason_error_string(CT_str_reasons[0].error) == NULL)

--- a/crypto/dh/dh_err.c
+++ b/crypto/dh/dh_err.c
@@ -62,7 +62,7 @@ static const ERR_STRING_DATA DH_str_reasons[] = {
 
 # endif
 
-int err_load_DH_strings_int(void)
+int ossl_err_load_DH_strings(void)
 {
 # ifndef OPENSSL_NO_ERR
     if (ERR_reason_error_string(DH_str_reasons[0].error) == NULL)

--- a/crypto/dsa/dsa_err.c
+++ b/crypto/dsa/dsa_err.c
@@ -41,7 +41,7 @@ static const ERR_STRING_DATA DSA_str_reasons[] = {
 
 # endif
 
-int err_load_DSA_strings_int(void)
+int ossl_err_load_DSA_strings(void)
 {
 # ifndef OPENSSL_NO_ERR
     if (ERR_reason_error_string(DSA_str_reasons[0].error) == NULL)

--- a/crypto/dso/dso_err.c
+++ b/crypto/dso/dso_err.c
@@ -46,7 +46,7 @@ static const ERR_STRING_DATA DSO_str_reasons[] = {
 
 #endif
 
-int err_load_DSO_strings_int(void)
+int ossl_err_load_DSO_strings(void)
 {
 #ifndef OPENSSL_NO_ERR
     if (ERR_reason_error_string(DSO_str_reasons[0].error) == NULL)

--- a/crypto/ec/ec_err.c
+++ b/crypto/ec/ec_err.c
@@ -119,7 +119,7 @@ static const ERR_STRING_DATA EC_str_reasons[] = {
 
 # endif
 
-int err_load_EC_strings_int(void)
+int ossl_err_load_EC_strings(void)
 {
 # ifndef OPENSSL_NO_ERR
     if (ERR_reason_error_string(EC_str_reasons[0].error) == NULL)

--- a/crypto/encode_decode/decoder_err.c
+++ b/crypto/encode_decode/decoder_err.c
@@ -26,7 +26,7 @@ static const ERR_STRING_DATA OSSL_DECODER_str_reasons[] = {
 
 #endif
 
-int err_load_OSSL_DECODER_strings_int(void)
+int ossl_err_load_OSSL_DECODER_strings(void)
 {
 #ifndef OPENSSL_NO_ERR
     if (ERR_reason_error_string(OSSL_DECODER_str_reasons[0].error) == NULL)

--- a/crypto/encode_decode/encoder_err.c
+++ b/crypto/encode_decode/encoder_err.c
@@ -26,7 +26,7 @@ static const ERR_STRING_DATA OSSL_ENCODER_str_reasons[] = {
 
 #endif
 
-int err_load_OSSL_ENCODER_strings_int(void)
+int ossl_err_load_OSSL_ENCODER_strings(void)
 {
 #ifndef OPENSSL_NO_ERR
     if (ERR_reason_error_string(OSSL_ENCODER_str_reasons[0].error) == NULL)

--- a/crypto/engine/eng_err.c
+++ b/crypto/engine/eng_err.c
@@ -81,7 +81,7 @@ static const ERR_STRING_DATA ENGINE_str_reasons[] = {
 
 # endif
 
-int err_load_ENGINE_strings_int(void)
+int ossl_err_load_ENGINE_strings(void)
 {
 # ifndef OPENSSL_NO_ERR
     if (ERR_reason_error_string(ENGINE_str_reasons[0].error) == NULL)

--- a/crypto/err/err.c
+++ b/crypto/err/err.c
@@ -248,7 +248,7 @@ static int err_load_strings(const ERR_STRING_DATA *str)
     return 1;
 }
 
-int err_load_ERR_strings_int(void)
+int ossl_err_load_ERR_strings(void)
 {
 #ifndef OPENSSL_NO_ERR
     if (!RUN_ONCE(&err_string_init, do_err_strings_init))
@@ -262,7 +262,7 @@ int err_load_ERR_strings_int(void)
 
 int ERR_load_strings(int lib, ERR_STRING_DATA *str)
 {
-    if (err_load_ERR_strings_int() == 0)
+    if (ossl_err_load_ERR_strings() == 0)
         return 0;
 
     err_patch(lib, str);
@@ -272,7 +272,7 @@ int ERR_load_strings(int lib, ERR_STRING_DATA *str)
 
 int ERR_load_strings_const(const ERR_STRING_DATA *str)
 {
-    if (err_load_ERR_strings_int() == 0)
+    if (ossl_err_load_ERR_strings() == 0)
         return 0;
     err_load_strings(str);
     return 1;

--- a/crypto/err/err_all.c
+++ b/crypto/err/err_all.c
@@ -45,66 +45,66 @@
 #include "internal/propertyerr.h"
 #include "prov/proverr.h"
 
-int err_load_crypto_strings_int(void)
+int ossl_err_load_crypto_strings(void)
 {
     if (0
 #ifndef OPENSSL_NO_ERR
-        || err_load_ERR_strings_int() == 0 /* include error strings for SYSerr */
-        || err_load_BN_strings_int() == 0
-        || err_load_RSA_strings_int() == 0
+        || ossl_err_load_ERR_strings() == 0 /* include error strings for SYSerr */
+        || ossl_err_load_BN_strings() == 0
+        || ossl_err_load_RSA_strings() == 0
 # ifndef OPENSSL_NO_DH
-        || err_load_DH_strings_int() == 0
+        || ossl_err_load_DH_strings() == 0
 # endif
-        || err_load_EVP_strings_int() == 0
-        || err_load_BUF_strings_int() == 0
-        || err_load_OBJ_strings_int() == 0
-        || err_load_PEM_strings_int() == 0
+        || ossl_err_load_EVP_strings() == 0
+        || ossl_err_load_BUF_strings() == 0
+        || ossl_err_load_OBJ_strings() == 0
+        || ossl_err_load_PEM_strings() == 0
 # ifndef OPENSSL_NO_DSA
-        || err_load_DSA_strings_int() == 0
+        || ossl_err_load_DSA_strings() == 0
 # endif
-        || err_load_X509_strings_int() == 0
-        || err_load_ASN1_strings_int() == 0
-        || err_load_CONF_strings_int() == 0
-        || err_load_CRYPTO_strings_int() == 0
+        || ossl_err_load_X509_strings() == 0
+        || ossl_err_load_ASN1_strings() == 0
+        || ossl_err_load_CONF_strings() == 0
+        || ossl_err_load_CRYPTO_strings() == 0
 # ifndef OPENSSL_NO_COMP
-        || err_load_COMP_strings_int() == 0
+        || ossl_err_load_COMP_strings() == 0
 # endif
 # ifndef OPENSSL_NO_EC
-        || err_load_EC_strings_int() == 0
+        || ossl_err_load_EC_strings() == 0
 # endif
-        /* skip err_load_SSL_strings_int() because it is not in this library */
-        || err_load_BIO_strings_int() == 0
-        || err_load_PKCS7_strings_int() == 0
-        || err_load_X509V3_strings_int() == 0
-        || err_load_PKCS12_strings_int() == 0
-        || err_load_RAND_strings_int() == 0
-        || err_load_DSO_strings_int() == 0
+        /* skip ossl_err_load_SSL_strings() because it is not in this library */
+        || ossl_err_load_BIO_strings() == 0
+        || ossl_err_load_PKCS7_strings() == 0
+        || ossl_err_load_X509V3_strings() == 0
+        || ossl_err_load_PKCS12_strings() == 0
+        || ossl_err_load_RAND_strings() == 0
+        || ossl_err_load_DSO_strings() == 0
 # ifndef OPENSSL_NO_TS
-        || err_load_TS_strings_int() == 0
+        || ossl_err_load_TS_strings() == 0
 # endif
 # ifndef OPENSSL_NO_ENGINE
-        || err_load_ENGINE_strings_int() == 0
+        || ossl_err_load_ENGINE_strings() == 0
 # endif
-        || err_load_HTTP_strings_int() == 0
+        || ossl_err_load_HTTP_strings() == 0
 # ifndef OPENSSL_NO_OCSP
-        || err_load_OCSP_strings_int() == 0
+        || ossl_err_load_OCSP_strings() == 0
 # endif
-        || err_load_UI_strings_int() == 0
+        || ossl_err_load_UI_strings() == 0
 # ifndef OPENSSL_NO_CMS
-        || err_load_CMS_strings_int() == 0
+        || ossl_err_load_CMS_strings() == 0
 # endif
 # ifndef OPENSSL_NO_CRMF
-        || err_load_CRMF_strings_int() == 0
-        || err_load_CMP_strings_int() == 0
+        || ossl_err_load_CRMF_strings() == 0
+        || ossl_err_load_CMP_strings() == 0
 # endif
 # ifndef OPENSSL_NO_CT
-        || err_load_CT_strings_int() == 0
+        || ossl_err_load_CT_strings() == 0
 # endif
-        || err_load_ESS_strings_int() == 0
-        || err_load_ASYNC_strings_int() == 0
-        || err_load_OSSL_STORE_strings_int() == 0
-        || err_load_PROP_strings_int() == 0
-        || err_load_PROV_strings_int() == 0
+        || ossl_err_load_ESS_strings() == 0
+        || ossl_err_load_ASYNC_strings() == 0
+        || ossl_err_load_OSSL_STORE_strings() == 0
+        || ossl_err_load_PROP_strings() == 0
+        || ossl_err_load_PROV_strings() == 0
 #endif
         )
         return 0;

--- a/crypto/err/err_all_legacy.c
+++ b/crypto/err/err_all_legacy.c
@@ -44,16 +44,16 @@
 # include "crypto/x509v3err.h"
 
 # ifdef OPENSSL_NO_ERR
-#  define IMPLEMENT_LEGACY_ERR_LOAD(lib)         \
+#  define IMPLEMENT_LEGACY_ERR_LOAD(lib)        \
     int ERR_load_##lib##_strings(void)          \
     {                                           \
         return 1;                               \
     }
 # else
-#  define IMPLEMENT_LEGACY_ERR_LOAD(lib)         \
+#  define IMPLEMENT_LEGACY_ERR_LOAD(lib)        \
     int ERR_load_##lib##_strings(void)          \
     {                                           \
-        return err_load_##lib##_strings_int();  \
+        return ossl_err_load_##lib##_strings(); \
     }
 # endif
 

--- a/crypto/ess/ess_err.c
+++ b/crypto/ess/ess_err.c
@@ -38,7 +38,7 @@ static const ERR_STRING_DATA ESS_str_reasons[] = {
 
 #endif
 
-int err_load_ESS_strings_int(void)
+int ossl_err_load_ESS_strings(void)
 {
 #ifndef OPENSSL_NO_ERR
     if (ERR_reason_error_string(ESS_str_reasons[0].error) == NULL)

--- a/crypto/evp/evp_err.c
+++ b/crypto/evp/evp_err.c
@@ -198,7 +198,7 @@ static const ERR_STRING_DATA EVP_str_reasons[] = {
 
 #endif
 
-int err_load_EVP_strings_int(void)
+int ossl_err_load_EVP_strings(void)
 {
 #ifndef OPENSSL_NO_ERR
     if (ERR_reason_error_string(EVP_str_reasons[0].error) == NULL)

--- a/crypto/http/http_err.c
+++ b/crypto/http/http_err.c
@@ -71,7 +71,7 @@ static const ERR_STRING_DATA HTTP_str_reasons[] = {
 
 #endif
 
-int err_load_HTTP_strings_int(void)
+int ossl_err_load_HTTP_strings(void)
 {
 #ifndef OPENSSL_NO_ERR
     if (ERR_reason_error_string(HTTP_str_reasons[0].error) == NULL)

--- a/crypto/init.c
+++ b/crypto/init.c
@@ -174,8 +174,8 @@ DEFINE_RUN_ONCE_STATIC(ossl_init_load_crypto_strings)
      * pulling in all the error strings during static linking
      */
 #if !defined(OPENSSL_NO_ERR) && !defined(OPENSSL_NO_AUTOERRINIT)
-    OSSL_TRACE(INIT, "err_load_crypto_strings_int()\n");
-    ret = err_load_crypto_strings_int();
+    OSSL_TRACE(INIT, "ossl_err_load_crypto_strings()\n");
+    ret = ossl_err_load_crypto_strings();
     load_crypto_strings_inited = 1;
 #endif
     return ret;

--- a/crypto/objects/obj_err.c
+++ b/crypto/objects/obj_err.c
@@ -24,7 +24,7 @@ static const ERR_STRING_DATA OBJ_str_reasons[] = {
 
 #endif
 
-int err_load_OBJ_strings_int(void)
+int ossl_err_load_OBJ_strings(void)
 {
 #ifndef OPENSSL_NO_ERR
     if (ERR_reason_error_string(OBJ_str_reasons[0].error) == NULL)

--- a/crypto/ocsp/ocsp_err.c
+++ b/crypto/ocsp/ocsp_err.c
@@ -62,7 +62,7 @@ static const ERR_STRING_DATA OCSP_str_reasons[] = {
 
 # endif
 
-int err_load_OCSP_strings_int(void)
+int ossl_err_load_OCSP_strings(void)
 {
 # ifndef OPENSSL_NO_ERR
     if (ERR_reason_error_string(OCSP_str_reasons[0].error) == NULL)

--- a/crypto/pem/pem_err.c
+++ b/crypto/pem/pem_err.c
@@ -64,7 +64,7 @@ static const ERR_STRING_DATA PEM_str_reasons[] = {
 
 #endif
 
-int err_load_PEM_strings_int(void)
+int ossl_err_load_PEM_strings(void)
 {
 #ifndef OPENSSL_NO_ERR
     if (ERR_reason_error_string(PEM_str_reasons[0].error) == NULL)

--- a/crypto/pkcs12/pk12err.c
+++ b/crypto/pkcs12/pk12err.c
@@ -51,7 +51,7 @@ static const ERR_STRING_DATA PKCS12_str_reasons[] = {
 
 #endif
 
-int err_load_PKCS12_strings_int(void)
+int ossl_err_load_PKCS12_strings(void)
 {
 #ifndef OPENSSL_NO_ERR
     if (ERR_reason_error_string(PKCS12_str_reasons[0].error) == NULL)

--- a/crypto/pkcs7/pkcs7err.c
+++ b/crypto/pkcs7/pkcs7err.c
@@ -88,7 +88,7 @@ static const ERR_STRING_DATA PKCS7_str_reasons[] = {
 
 #endif
 
-int err_load_PKCS7_strings_int(void)
+int ossl_err_load_PKCS7_strings(void)
 {
 #ifndef OPENSSL_NO_ERR
     if (ERR_reason_error_string(PKCS7_str_reasons[0].error) == NULL)

--- a/crypto/property/property_err.c
+++ b/crypto/property/property_err.c
@@ -36,7 +36,7 @@ static const ERR_STRING_DATA PROP_str_reasons[] = {
 
 #endif
 
-int err_load_PROP_strings_int(void)
+int ossl_err_load_PROP_strings(void)
 {
 #ifndef OPENSSL_NO_ERR
     if (ERR_reason_error_string(PROP_str_reasons[0].error) == NULL)

--- a/crypto/rand/rand_err.c
+++ b/crypto/rand/rand_err.c
@@ -99,7 +99,7 @@ static const ERR_STRING_DATA RAND_str_reasons[] = {
 
 #endif
 
-int err_load_RAND_strings_int(void)
+int ossl_err_load_RAND_strings(void)
 {
 #ifndef OPENSSL_NO_ERR
     if (ERR_reason_error_string(RAND_str_reasons[0].error) == NULL)

--- a/crypto/rsa/rsa_err.c
+++ b/crypto/rsa/rsa_err.c
@@ -153,7 +153,7 @@ static const ERR_STRING_DATA RSA_str_reasons[] = {
 
 #endif
 
-int err_load_RSA_strings_int(void)
+int ossl_err_load_RSA_strings(void)
 {
 #ifndef OPENSSL_NO_ERR
     if (ERR_reason_error_string(RSA_str_reasons[0].error) == NULL)

--- a/crypto/sm2/sm2_err.c
+++ b/crypto/sm2/sm2_err.c
@@ -37,7 +37,7 @@ static const ERR_STRING_DATA SM2_str_reasons[] = {
 
 # endif
 
-int err_load_SM2_strings_int(void)
+int ossl_err_load_SM2_strings(void)
 {
 # ifndef OPENSSL_NO_ERR
     if (ERR_reason_error_string(SM2_str_reasons[0].error) == NULL)

--- a/crypto/store/store_err.c
+++ b/crypto/store/store_err.c
@@ -65,7 +65,7 @@ static const ERR_STRING_DATA OSSL_STORE_str_reasons[] = {
 
 #endif
 
-int err_load_OSSL_STORE_strings_int(void)
+int ossl_err_load_OSSL_STORE_strings(void)
 {
 #ifndef OPENSSL_NO_ERR
     if (ERR_reason_error_string(OSSL_STORE_str_reasons[0].error) == NULL)

--- a/crypto/ts/ts_err.c
+++ b/crypto/ts/ts_err.c
@@ -78,7 +78,7 @@ static const ERR_STRING_DATA TS_str_reasons[] = {
 
 # endif
 
-int err_load_TS_strings_int(void)
+int ossl_err_load_TS_strings(void)
 {
 # ifndef OPENSSL_NO_ERR
     if (ERR_reason_error_string(TS_str_reasons[0].error) == NULL)

--- a/crypto/ui/ui_err.c
+++ b/crypto/ui/ui_err.c
@@ -37,7 +37,7 @@ static const ERR_STRING_DATA UI_str_reasons[] = {
 
 #endif
 
-int err_load_UI_strings_int(void)
+int ossl_err_load_UI_strings(void)
 {
 #ifndef OPENSSL_NO_ERR
     if (ERR_reason_error_string(UI_str_reasons[0].error) == NULL)

--- a/crypto/x509/v3err.c
+++ b/crypto/x509/v3err.c
@@ -137,7 +137,7 @@ static const ERR_STRING_DATA X509V3_str_reasons[] = {
 
 #endif
 
-int err_load_X509V3_strings_int(void)
+int ossl_err_load_X509V3_strings(void)
 {
 #ifndef OPENSSL_NO_ERR
     if (ERR_reason_error_string(X509V3_str_reasons[0].error) == NULL)

--- a/crypto/x509/x509_err.c
+++ b/crypto/x509/x509_err.c
@@ -84,7 +84,7 @@ static const ERR_STRING_DATA X509_str_reasons[] = {
 
 #endif
 
-int err_load_X509_strings_int(void)
+int ossl_err_load_X509_strings(void)
 {
 #ifndef OPENSSL_NO_ERR
     if (ERR_reason_error_string(X509_str_reasons[0].error) == NULL)

--- a/include/crypto/asn1err.h
+++ b/include/crypto/asn1err.h
@@ -19,7 +19,7 @@
 extern "C" {
 # endif
 
-int err_load_ASN1_strings_int(void);
+int ossl_err_load_ASN1_strings(void);
 
 # ifdef  __cplusplus
 }

--- a/include/crypto/asyncerr.h
+++ b/include/crypto/asyncerr.h
@@ -19,7 +19,7 @@
 extern "C" {
 # endif
 
-int err_load_ASYNC_strings_int(void);
+int ossl_err_load_ASYNC_strings(void);
 
 # ifdef  __cplusplus
 }

--- a/include/crypto/bioerr.h
+++ b/include/crypto/bioerr.h
@@ -19,7 +19,7 @@
 extern "C" {
 # endif
 
-int err_load_BIO_strings_int(void);
+int ossl_err_load_BIO_strings(void);
 
 # ifdef  __cplusplus
 }

--- a/include/crypto/bnerr.h
+++ b/include/crypto/bnerr.h
@@ -19,7 +19,7 @@
 extern "C" {
 # endif
 
-int err_load_BN_strings_int(void);
+int ossl_err_load_BN_strings(void);
 
 # ifdef  __cplusplus
 }

--- a/include/crypto/buffererr.h
+++ b/include/crypto/buffererr.h
@@ -19,7 +19,7 @@
 extern "C" {
 # endif
 
-int err_load_BUF_strings_int(void);
+int ossl_err_load_BUF_strings(void);
 
 # ifdef  __cplusplus
 }

--- a/include/crypto/cmperr.h
+++ b/include/crypto/cmperr.h
@@ -21,7 +21,7 @@ extern "C" {
 
 # ifndef OPENSSL_NO_CMP
 
-int err_load_CMP_strings_int(void);
+int ossl_err_load_CMP_strings(void);
 # endif
 
 # ifdef  __cplusplus

--- a/include/crypto/cmserr.h
+++ b/include/crypto/cmserr.h
@@ -21,7 +21,7 @@ extern "C" {
 
 # ifndef OPENSSL_NO_CMS
 
-int err_load_CMS_strings_int(void);
+int ossl_err_load_CMS_strings(void);
 # endif
 
 # ifdef  __cplusplus

--- a/include/crypto/comperr.h
+++ b/include/crypto/comperr.h
@@ -21,7 +21,7 @@ extern "C" {
 
 # ifndef OPENSSL_NO_COMP
 
-int err_load_COMP_strings_int(void);
+int ossl_err_load_COMP_strings(void);
 # endif
 
 # ifdef  __cplusplus

--- a/include/crypto/conferr.h
+++ b/include/crypto/conferr.h
@@ -19,7 +19,7 @@
 extern "C" {
 # endif
 
-int err_load_CONF_strings_int(void);
+int ossl_err_load_CONF_strings(void);
 
 # ifdef  __cplusplus
 }

--- a/include/crypto/crmferr.h
+++ b/include/crypto/crmferr.h
@@ -21,7 +21,7 @@ extern "C" {
 
 # ifndef OPENSSL_NO_CRMF
 
-int err_load_CRMF_strings_int(void);
+int ossl_err_load_CRMF_strings(void);
 # endif
 
 # ifdef  __cplusplus

--- a/include/crypto/cryptoerr.h
+++ b/include/crypto/cryptoerr.h
@@ -19,7 +19,7 @@
 extern "C" {
 # endif
 
-int err_load_CRYPTO_strings_int(void);
+int ossl_err_load_CRYPTO_strings(void);
 
 # ifdef  __cplusplus
 }

--- a/include/crypto/cterr.h
+++ b/include/crypto/cterr.h
@@ -21,7 +21,7 @@ extern "C" {
 
 # ifndef OPENSSL_NO_CT
 
-int err_load_CT_strings_int(void);
+int ossl_err_load_CT_strings(void);
 # endif
 
 # ifdef  __cplusplus

--- a/include/crypto/decodererr.h
+++ b/include/crypto/decodererr.h
@@ -19,7 +19,7 @@
 extern "C" {
 # endif
 
-int err_load_OSSL_DECODER_strings_int(void);
+int ossl_err_load_OSSL_DECODER_strings(void);
 
 # ifdef  __cplusplus
 }

--- a/include/crypto/dherr.h
+++ b/include/crypto/dherr.h
@@ -21,7 +21,7 @@ extern "C" {
 
 # ifndef OPENSSL_NO_DH
 
-int err_load_DH_strings_int(void);
+int ossl_err_load_DH_strings(void);
 # endif
 
 # ifdef  __cplusplus

--- a/include/crypto/dsaerr.h
+++ b/include/crypto/dsaerr.h
@@ -21,7 +21,7 @@ extern "C" {
 
 # ifndef OPENSSL_NO_DSA
 
-int err_load_DSA_strings_int(void);
+int ossl_err_load_DSA_strings(void);
 # endif
 
 # ifdef  __cplusplus

--- a/include/crypto/ecerr.h
+++ b/include/crypto/ecerr.h
@@ -21,7 +21,7 @@ extern "C" {
 
 # ifndef OPENSSL_NO_EC
 
-int err_load_EC_strings_int(void);
+int ossl_err_load_EC_strings(void);
 # endif
 
 # ifdef  __cplusplus

--- a/include/crypto/encodererr.h
+++ b/include/crypto/encodererr.h
@@ -19,7 +19,7 @@
 extern "C" {
 # endif
 
-int err_load_OSSL_ENCODER_strings_int(void);
+int ossl_err_load_OSSL_ENCODER_strings(void);
 
 # ifdef  __cplusplus
 }

--- a/include/crypto/engineerr.h
+++ b/include/crypto/engineerr.h
@@ -21,7 +21,7 @@ extern "C" {
 
 # ifndef OPENSSL_NO_ENGINE
 
-int err_load_ENGINE_strings_int(void);
+int ossl_err_load_ENGINE_strings(void);
 # endif
 
 # ifdef  __cplusplus

--- a/include/crypto/err.h
+++ b/include/crypto/err.h
@@ -11,8 +11,8 @@
 # define OSSL_CRYPTO_ERR_H
 # pragma once
 
-int err_load_ERR_strings_int(void);
-int err_load_crypto_strings_int(void);
+int ossl_err_load_ERR_strings(void);
+int ossl_err_load_crypto_strings(void);
 void err_cleanup(void);
 int err_shelve_state(void **);
 void err_unshelve_state(void *);

--- a/include/crypto/esserr.h
+++ b/include/crypto/esserr.h
@@ -19,7 +19,7 @@
 extern "C" {
 # endif
 
-int err_load_ESS_strings_int(void);
+int ossl_err_load_ESS_strings(void);
 
 # ifdef  __cplusplus
 }

--- a/include/crypto/evperr.h
+++ b/include/crypto/evperr.h
@@ -19,7 +19,7 @@
 extern "C" {
 # endif
 
-int err_load_EVP_strings_int(void);
+int ossl_err_load_EVP_strings(void);
 
 # ifdef  __cplusplus
 }

--- a/include/crypto/httperr.h
+++ b/include/crypto/httperr.h
@@ -19,7 +19,7 @@
 extern "C" {
 # endif
 
-int err_load_HTTP_strings_int(void);
+int ossl_err_load_HTTP_strings(void);
 
 # ifdef  __cplusplus
 }

--- a/include/crypto/objectserr.h
+++ b/include/crypto/objectserr.h
@@ -19,7 +19,7 @@
 extern "C" {
 # endif
 
-int err_load_OBJ_strings_int(void);
+int ossl_err_load_OBJ_strings(void);
 
 # ifdef  __cplusplus
 }

--- a/include/crypto/ocsperr.h
+++ b/include/crypto/ocsperr.h
@@ -21,7 +21,7 @@ extern "C" {
 
 # ifndef OPENSSL_NO_OCSP
 
-int err_load_OCSP_strings_int(void);
+int ossl_err_load_OCSP_strings(void);
 # endif
 
 # ifdef  __cplusplus

--- a/include/crypto/pemerr.h
+++ b/include/crypto/pemerr.h
@@ -19,7 +19,7 @@
 extern "C" {
 # endif
 
-int err_load_PEM_strings_int(void);
+int ossl_err_load_PEM_strings(void);
 
 # ifdef  __cplusplus
 }

--- a/include/crypto/pkcs12err.h
+++ b/include/crypto/pkcs12err.h
@@ -19,7 +19,7 @@
 extern "C" {
 # endif
 
-int err_load_PKCS12_strings_int(void);
+int ossl_err_load_PKCS12_strings(void);
 
 # ifdef  __cplusplus
 }

--- a/include/crypto/pkcs7err.h
+++ b/include/crypto/pkcs7err.h
@@ -19,7 +19,7 @@
 extern "C" {
 # endif
 
-int err_load_PKCS7_strings_int(void);
+int ossl_err_load_PKCS7_strings(void);
 
 # ifdef  __cplusplus
 }

--- a/include/crypto/randerr.h
+++ b/include/crypto/randerr.h
@@ -19,7 +19,7 @@
 extern "C" {
 # endif
 
-int err_load_RAND_strings_int(void);
+int ossl_err_load_RAND_strings(void);
 
 # ifdef  __cplusplus
 }

--- a/include/crypto/rsaerr.h
+++ b/include/crypto/rsaerr.h
@@ -19,7 +19,7 @@
 extern "C" {
 # endif
 
-int err_load_RSA_strings_int(void);
+int ossl_err_load_RSA_strings(void);
 
 # ifdef  __cplusplus
 }

--- a/include/crypto/sm2err.h
+++ b/include/crypto/sm2err.h
@@ -21,7 +21,7 @@ extern "C" {
 
 # ifndef OPENSSL_NO_SM2
 
-int err_load_SM2_strings_int(void);
+int ossl_err_load_SM2_strings(void);
 
 /*
  * SM2 reason codes.

--- a/include/crypto/storeerr.h
+++ b/include/crypto/storeerr.h
@@ -19,7 +19,7 @@
 extern "C" {
 # endif
 
-int err_load_OSSL_STORE_strings_int(void);
+int ossl_err_load_OSSL_STORE_strings(void);
 
 # ifdef  __cplusplus
 }

--- a/include/crypto/tserr.h
+++ b/include/crypto/tserr.h
@@ -21,7 +21,7 @@ extern "C" {
 
 # ifndef OPENSSL_NO_TS
 
-int err_load_TS_strings_int(void);
+int ossl_err_load_TS_strings(void);
 # endif
 
 # ifdef  __cplusplus

--- a/include/crypto/uierr.h
+++ b/include/crypto/uierr.h
@@ -19,7 +19,7 @@
 extern "C" {
 # endif
 
-int err_load_UI_strings_int(void);
+int ossl_err_load_UI_strings(void);
 
 # ifdef  __cplusplus
 }

--- a/include/crypto/x509err.h
+++ b/include/crypto/x509err.h
@@ -19,7 +19,7 @@
 extern "C" {
 # endif
 
-int err_load_X509_strings_int(void);
+int ossl_err_load_X509_strings(void);
 
 # ifdef  __cplusplus
 }

--- a/include/crypto/x509v3err.h
+++ b/include/crypto/x509v3err.h
@@ -19,7 +19,7 @@
 extern "C" {
 # endif
 
-int err_load_X509V3_strings_int(void);
+int ossl_err_load_X509V3_strings(void);
 
 # ifdef  __cplusplus
 }

--- a/include/internal/dsoerr.h
+++ b/include/internal/dsoerr.h
@@ -19,7 +19,7 @@
 extern "C" {
 # endif
 
-int err_load_DSO_strings_int(void);
+int ossl_err_load_DSO_strings(void);
 
 /*
  * DSO reason codes.

--- a/include/internal/propertyerr.h
+++ b/include/internal/propertyerr.h
@@ -19,7 +19,7 @@
 extern "C" {
 # endif
 
-int err_load_PROP_strings_int(void);
+int ossl_err_load_PROP_strings(void);
 
 /*
  * PROP reason codes.

--- a/providers/common/include/prov/proverr.h
+++ b/providers/common/include/prov/proverr.h
@@ -19,7 +19,7 @@
 extern "C" {
 # endif
 
-int err_load_PROV_strings_int(void);
+int ossl_err_load_PROV_strings(void);
 
 # ifdef  __cplusplus
 }

--- a/providers/common/provider_err.c
+++ b/providers/common/provider_err.c
@@ -217,7 +217,7 @@ static const ERR_STRING_DATA PROV_str_reasons[] = {
 
 #endif
 
-int err_load_PROV_strings_int(void)
+int ossl_err_load_PROV_strings(void)
 {
 #ifndef OPENSSL_NO_ERR
     if (ERR_reason_error_string(PROV_str_reasons[0].error) == NULL)

--- a/ssl/ssl_err.c
+++ b/ssl/ssl_err.c
@@ -559,7 +559,7 @@ static const ERR_STRING_DATA SSL_str_reasons[] = {
 
 #endif
 
-int err_load_SSL_strings_int(void)
+int ossl_err_load_SSL_strings(void)
 {
 #ifndef OPENSSL_NO_ERR
     if (ERR_reason_error_string(SSL_str_reasons[0].error) == NULL)

--- a/ssl/ssl_err_legacy.c
+++ b/ssl/ssl_err_legacy.c
@@ -14,7 +14,7 @@
 #ifndef OPENSSL_NO_DEPRECATED_3_0
 int ERR_load_SSL_strings(void)
 {
-    return err_load_SSL_strings_int();
+    return ossl_err_load_SSL_strings();
 }
 #else
 NON_EMPTY_TRANSLATION_UNIT

--- a/ssl/ssl_init.c
+++ b/ssl/ssl_init.c
@@ -54,8 +54,8 @@ DEFINE_RUN_ONCE_STATIC(ossl_init_load_ssl_strings)
      * pulling in all the error strings during static linking
      */
 #if !defined(OPENSSL_NO_ERR) && !defined(OPENSSL_NO_AUTOERRINIT)
-    OSSL_TRACE(INIT, "ossl_init_load_ssl_strings: err_load_SSL_strings_int()\n");
-    err_load_SSL_strings_int();
+    OSSL_TRACE(INIT, "ossl_init_load_ssl_strings: ossl_err_load_SSL_strings()\n");
+    ossl_err_load_SSL_strings();
     ssl_strings_inited = 1;
 #endif
     return 1;

--- a/ssl/sslerr.h
+++ b/ssl/sslerr.h
@@ -19,7 +19,7 @@
 extern "C" {
 # endif
 
-int err_load_SSL_strings_int(void);
+int ossl_err_load_SSL_strings(void);
 
 # ifdef  __cplusplus
 }

--- a/util/mkerr.pl
+++ b/util/mkerr.pl
@@ -358,7 +358,7 @@ EOF
             $indent = "  ";
         }
         print OUT <<"EOF";
-int err_load_${lib}_strings_int(void);
+int ossl_err_load_${lib}_strings(void);
 EOF
 
         # If this library doesn't have a public header file, we write all
@@ -581,7 +581,7 @@ EOF
         if ( $internal ) {
             print OUT <<"EOF";
 
-int err_load_${lib}_strings_int(void)
+int ossl_err_load_${lib}_strings(void)
 {
 #${indent}ifndef OPENSSL_NO_ERR
     if (ERR_reason_error_string(${lib}_str_reasons[0].error) == NULL)


### PR DESCRIPTION
The new names are `ossl_err_load_xxx_strings`.


- [ ] documentation is added or updated
- [ ] tests are added or updated
