### PR TITLE
Fix copy commands for windows install

### DIFF
--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -488,7 +488,7 @@ uninstall_docs: uninstall_html_docs
 
 {- output_off() if $disabled{fips}; "" -}
 install_fips: build_sw providers\fipsmodule.cnf
-#	@[ -n "$(INSTALLTOP)" ] || (echo INSTALLTOP should not be empty; exit 1)
+#	@[ -n "$(INSTALLTOP)" ] || ( $(ECHO) "INSTALLTOP should not be empty" & exit 1)
 	@$(PERL) $(SRCDIR)\util\mkdir-p.pl $(MODULESDIR)
 	@$(ECHO) "*** Installing FIPS module"
 	@$(ECHO) "install $(INSTALL_FIPS) -> $(MODULESDIR)\$(FIPSMODULENAME)"
@@ -604,8 +604,8 @@ install_programs: install_runtime_libs build_programs
 uninstall_runtime:
 
 install_html_docs: install_image_docs build_html_docs
-	@if "$(INSTALLTOP)"=="" ( echo INSTALLTOP should not be empty & exit 1 )
-	@echo *** Installing HTML docs
+	@if "$(INSTALLTOP)"=="" ( $(ECHO) "INSTALLTOP should not be empty" & exit 1 )
+	@$(ECHO) "*** Installing HTML docs"
 	@"$(PERL)" "$(SRCDIR)\util\mkdir-p.pl" "$(INSTALLTOP)\html\man1"
 	@"$(PERL)" "$(SRCDIR)\util\mkdir-p.pl" "$(INSTALLTOP)\html\man3"
 	@"$(PERL)" "$(SRCDIR)\util\mkdir-p.pl" "$(INSTALLTOP)\html\man5"
@@ -622,20 +622,24 @@ install_html_docs: install_image_docs build_html_docs
 uninstall_html_docs: uninstall_image_docs
 
 install_image_docs:
-	@if "$(INSTALLTOP)"=="" ( echo INSTALLTOP should not be empty & exit 1 )
-	@echo *** Installing HTML images
+	@if "$(INSTALLTOP)"=="" ( $(ECHO) "INSTALLTOP should not be empty" & exit 1 )
+	@$(ECHO) "*** Installing HTML images"
 	@"$(PERL)" "$(SRCDIR)\util\mkdir-p.pl" "$(INSTALLTOP)\html\man1\img"
 	@"$(PERL)" "$(SRCDIR)\util\mkdir-p.pl" "$(INSTALLTOP)\html\man3\img"
 	@"$(PERL)" "$(SRCDIR)\util\mkdir-p.pl" "$(INSTALLTOP)\html\man5\img"
 	@"$(PERL)" "$(SRCDIR)\util\mkdir-p.pl" "$(INSTALLTOP)\html\man7\img"
-	@"$(PERL)" "$(SRCDIR)\util\copy.pl" $(SRCDIR)\doc\man1\img\*.png \
-                                        "$(INSTALLTOP)\html\man1\img"
-	@"$(PERL)" "$(SRCDIR)\util\copy.pl" $(SRCDIR)\doc\man3\img\*.png \
-                                        "$(INSTALLTOP)\html\man3\img"
-	@"$(PERL)" "$(SRCDIR)\util\copy.pl" $(SRCDIR)\doc\man5\img\*.png \
-                                        "$(INSTALLTOP)\html\man5\img"
-	@"$(PERL)" "$(SRCDIR)\util\copy.pl" $(SRCDIR)\doc\man7\img\*.png \
-                                        "$(INSTALLTOP)\html\man7\img"
+	@if exist $(SRCDIR)\doc\man1\img\*.png \
+            "$(PERL)" "$(SRCDIR)\util\copy.pl" $(SRCDIR)\doc\man1\img\*.png \
+                                              "$(INSTALLTOP)\html\man1\img"
+	@if exist $(SRCDIR)\doc\man3\img\*.png \
+            "$(PERL)" "$(SRCDIR)\util\copy.pl" $(SRCDIR)\doc\man3\img\*.png \
+                                              "$(INSTALLTOP)\html\man3\img"
+	@if exist $(SRCDIR)\doc\man5\img\*.png \
+            "$(PERL)" "$(SRCDIR)\util\copy.pl" $(SRCDIR)\doc\man5\img\*.png \
+                                              "$(INSTALLTOP)\html\man5\img"
+	@if exist $(SRCDIR)\doc\man7\img\*.png \
+            "$(PERL)" "$(SRCDIR)\util\copy.pl" $(SRCDIR)\doc\man7\img\*.png \
+                                              "$(INSTALLTOP)\html\man7\img"
 
 uninstall_image_docs:
 


### PR DESCRIPTION
The windows install currently fails due to the copy.pl utility being run with no input files:

```
*** Installing runtime programs
Copying: apps//openssl.exe to C:/jenkins/workspace/openssl-windows_x64_msvc/install-win/bin/openssl.exe
Copying: apps//openssl.pdb to C:/jenkins/workspace/openssl-windows_x64_msvc/install-win/bin/openssl.pdb
Copying: tools//c_rehash.pl to C:/jenkins/workspace/openssl-windows_x64_msvc/install-win/bin/c_rehash.pl
created directory `C:/jenkins/workspace/openssl-windows_x64_msvc/install-win/ssl'
created directory `C:/jenkins/workspace/openssl-windows_x64_msvc/install-win/ssl/certs'
created directory `C:/jenkins/workspace/openssl-windows_x64_msvc/install-win/ssl/private'
created directory `C:/jenkins/workspace/openssl-windows_x64_msvc/install-win/ssl/misc'
Copying: ../apps/openssl.cnf to C:/jenkins/workspace/openssl-windows_x64_msvc/install-win/ssl/openssl.cnf.dist
Copying: ../apps/openssl.cnf to C:/jenkins/workspace/openssl-windows_x64_msvc/install-win/ssl/openssl.cnf
Copying: apps//CA.pl to C:/jenkins/workspace/openssl-windows_x64_msvc/install-win/ssl/misc/CA.pl
Copying: apps//tsget.pl to C:/jenkins/workspace/openssl-windows_x64_msvc/install-win/ssl/misc/tsget.pl
Copying: ../apps/ct_log_list.cnf to C:/jenkins/workspace/openssl-windows_x64_msvc/install-win/ssl/ct_log_list.cnf.dist
Copying: ../apps/ct_log_list.cnf to C:/jenkins/workspace/openssl-windows_x64_msvc/install-win/ssl/ct_log_list.cnf
app.pdb apps configdata.pm crypto doc dso.pdb engines fuzz include libcrypto-3-x64.dll libcrypto-3-x64.ilk libcrypto-3-x64.pdb libcrypto-shlib-libcrypto.res libcrypto.def libcrypto.exp libcrypto.lib libcrypto.rc libcrypto_static.lib libssl-3-x64.dll libssl-3-x64.ilk libssl-3-x64.pdb libssl-shlib-libssl.res libssl.def libssl.exp libssl.lib libssl.rc libssl_static.lib makefile makefile.in ms ossl_static.pdb providers ssl test tools util Installing HTML images
created directory `C:/jenkins/workspace/openssl-windows_x64_msvc/install-win/html'
created directory `C:/jenkins/workspace/openssl-windows_x64_msvc/install-win/html/man1'
created directory `C:/jenkins/workspace/openssl-windows_x64_msvc/install-win/html/man1/img'
created directory `C:/jenkins/workspace/openssl-windows_x64_msvc/install-win/html/man3'
created directory `C:/jenkins/workspace/openssl-windows_x64_msvc/install-win/html/man3/img'
created directory `C:/jenkins/workspace/openssl-windows_x64_msvc/install-win/html/man5'
created directory `C:/jenkins/workspace/openssl-windows_x64_msvc/install-win/html/man5/img'
created directory `C:/jenkins/workspace/openssl-windows_x64_msvc/install-win/html/man7'
created directory `C:/jenkins/workspace/openssl-windows_x64_msvc/install-win/html/man7/img'
Need at least two filenames at ..\util\copy.pl line 46.
NMAKE : fatal error U1077: 'C:\Strawberry\perl\bin\perl.exe' : return code '0x2'
Stop.
nmake -f makefile install
Command 'nmake -f makefile install' returned non-zero exit status 2
```

This commit skips the copy if no files are found. It also fixes some echo commands to use the $(ECHO) variable.

PS - It would be useful to have a test for out-of-source build and install on Windows. I'm not sure the CI currently does this.