### PR TITLE
apps: Fix the mismatch of SM2 keys keymgmt

### DIFF
--- a/apps/ecparam.c
+++ b/apps/ecparam.c
@@ -228,7 +228,11 @@ int ecparam_main(int argc, char **argv)
                        OSSL_PKEY_PARAM_EC_POINT_CONVERSION_FORMAT,
                        point_format, 0);
         *p = OSSL_PARAM_construct_end();
-        gctx_params = EVP_PKEY_CTX_new_from_name(NULL, "ec", NULL);
+
+        if (strcasecmp(curve_name, "SM2") == 0)
+            gctx_params = EVP_PKEY_CTX_new_from_name(NULL, "sm2", NULL);
+        else
+            gctx_params = EVP_PKEY_CTX_new_from_name(NULL, "ec", NULL);
         if (gctx_params == NULL
             || EVP_PKEY_keygen_init(gctx_params) <= 0
             || EVP_PKEY_CTX_set_params(gctx_params, params) <= 0


### PR DESCRIPTION
The SM2 key has a separate keymgmt, which is independent of the
EC. The key generated by the subcommand ecparam is wrong. Using
'openssl ec -in sm2.key -noout -text' will also encounter some
errors.

When using the ecparam subcommand to generate the SM2 key, use
the correct keymgmt to solve this problem.

Signed-off-by: Tianjia Zhang <tianjia.zhang@linux.alibaba.com>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
