### PR TITLE
Fix memory leak in OSSL_CMP_CTX

### DIFF
--- a/crypto/cmp/cmp_ctx.c
+++ b/crypto/cmp/cmp_ctx.c
@@ -179,6 +179,7 @@ void OSSL_CMP_CTX_free(OSSL_CMP_CTX *ctx)
         (void)OSSL_HTTP_close(ctx->http_ctx, 1);
         ossl_cmp_debug(ctx, "disconnected from CMP server");
     }
+    OPENSSL_free(ctx->propq);
     OPENSSL_free(ctx->serverPath);
     OPENSSL_free(ctx->server);
     OPENSSL_free(ctx->proxy);

--- a/crypto/cmp/cmp_local.h
+++ b/crypto/cmp/cmp_local.h
@@ -32,7 +32,7 @@
  */
 struct ossl_cmp_ctx_st {
     OSSL_LIB_CTX *libctx;
-    const char *propq;
+    char *propq;
     OSSL_CMP_log_cb_t log_cb; /* log callback for error/debug/etc. output */
     OSSL_CMP_severity log_verbosity; /* level of verbosity of log output */
 


### PR DESCRIPTION
The `ctx->propq` is `strdup`ed, so it must be `free`d too.