### PR TITLE
Make conf_method_st and conf_st deprecated

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -44,6 +44,11 @@ breaking changes, and mappings for the large list of deprecated functions.
 
    *Rich Salz*
 
+ * The public definitions of conf_method_st and conf_st have been
+   deprecated. They will be made opaque in a future release.
+
+   * Rich Salz *
+
  * Client-initiated renegotiation is disabled by default. To allow it, use
    the -client_renegotiation option, the SSL_OP_ALLOW_CLIENT_RENEGOTIATION
    flag, or the "ClientRenegotiation" config parameter as appropriate.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -47,7 +47,7 @@ breaking changes, and mappings for the large list of deprecated functions.
  * The public definitions of conf_method_st and conf_st have been
    deprecated. They will be made opaque in a future release.
 
-   * Rich Salz *
+   *Rich Salz and Tomáš Mráz*
 
  * Client-initiated renegotiation is disabled by default. To allow it, use
    the -client_renegotiation option, the SSL_OP_ALLOW_CLIENT_RENEGOTIATION

--- a/crypto/conf/conf_api.c
+++ b/crypto/conf/conf_api.c
@@ -20,6 +20,11 @@
 static void value_free_hash(const CONF_VALUE *a, LHASH_OF(CONF_VALUE) *conf);
 static void value_free_stack_doall(CONF_VALUE *a);
 
+OSSL_LIB_CTX *NCONF_get0_libctx(CONF *conf)
+{
+    return conf->libctx;
+}
+
 CONF_VALUE *_CONF_get_section(const CONF *conf, const char *section)
 {
     CONF_VALUE vv;

--- a/crypto/conf/conf_api.c
+++ b/crypto/conf/conf_api.c
@@ -15,6 +15,7 @@
 #include <string.h>
 #include <openssl/conf.h>
 #include <openssl/conf_api.h>
+#include "conf_local.h"
 
 static void value_free_hash(const CONF_VALUE *a, LHASH_OF(CONF_VALUE) *conf);
 static void value_free_stack_doall(CONF_VALUE *a);

--- a/crypto/conf/conf_api.c
+++ b/crypto/conf/conf_api.c
@@ -20,11 +20,6 @@
 static void value_free_hash(const CONF_VALUE *a, LHASH_OF(CONF_VALUE) *conf);
 static void value_free_stack_doall(CONF_VALUE *a);
 
-OSSL_LIB_CTX *NCONF_get0_libctx(CONF *conf)
-{
-    return conf->libctx;
-}
-
 CONF_VALUE *_CONF_get_section(const CONF *conf, const char *section)
 {
     CONF_VALUE vv;

--- a/crypto/conf/conf_def.c
+++ b/crypto/conf/conf_def.c
@@ -21,6 +21,7 @@
 #include <openssl/lhash.h>
 #include <openssl/conf.h>
 #include <openssl/conf_api.h>
+#include "conf_local.h"
 #include "conf_def.h"
 #include <openssl/buffer.h>
 #include <openssl/err.h>

--- a/crypto/conf/conf_lib.c
+++ b/crypto/conf/conf_lib.c
@@ -215,6 +215,38 @@ void NCONF_free_data(CONF *conf)
     conf->meth->destroy_data(conf);
 }
 
+OSSL_LIB_CTX *NCONF_get0_libctx(const CONF *conf)
+{
+    return conf->libctx;
+}
+
+typedef STACK_OF(OPENSSL_CSTRING) SECTION_NAMES;
+
+IMPLEMENT_LHASH_DOALL_ARG_CONST(CONF_VALUE, SECTION_NAMES);
+
+static void collect_section_name(const CONF_VALUE *v, SECTION_NAMES *names)
+{
+    /* A section is a CONF_VALUE with name == NULL */
+    if (v->name == NULL)
+        sk_OPENSSL_CSTRING_push(names, v->section);
+}
+
+static int section_name_cmp(OPENSSL_CSTRING const *a, OPENSSL_CSTRING const *b)
+{
+    return strcmp(*a, *b);
+}
+
+STACK_OF(OPENSSL_CSTRING) *NCONF_get_section_names(const CONF *cnf)
+{
+    SECTION_NAMES *names;
+
+    if ((names = sk_OPENSSL_CSTRING_new(section_name_cmp)) == NULL)
+        return NULL;
+    lh_CONF_VALUE_doall_SECTION_NAMES(cnf->data, collect_section_name, names);
+    sk_OPENSSL_CSTRING_sort(names);
+    return names;
+}
+
 int NCONF_load(CONF *conf, const char *file, long *eline)
 {
     if (conf == NULL) {

--- a/crypto/conf/conf_lib.c
+++ b/crypto/conf/conf_lib.c
@@ -16,6 +16,7 @@
 #include <openssl/err.h>
 #include <openssl/conf.h>
 #include <openssl/conf_api.h>
+#include "conf_local.h"
 #include <openssl/lhash.h>
 
 static CONF_METHOD *default_CONF_method = NULL;

--- a/crypto/conf/conf_local.h
+++ b/crypto/conf/conf_local.h
@@ -7,4 +7,5 @@
  * https://www.openssl.org/source/license.html
  */
 
+#include <openssl/conftypes.h>
 void ossl_config_add_ssl_module(void);

--- a/crypto/conf/conf_mod.c
+++ b/crypto/conf/conf_mod.c
@@ -21,6 +21,7 @@
 #include <openssl/x509.h>
 #include <openssl/trace.h>
 #include <openssl/engine.h>
+#include "conf_local.h"
 
 DEFINE_STACK_OF(CONF_MODULE)
 DEFINE_STACK_OF(CONF_IMODULE)

--- a/crypto/conf/conf_sap.c
+++ b/crypto/conf/conf_sap.c
@@ -11,6 +11,7 @@
 #include <openssl/crypto.h>
 #include "internal/cryptlib.h"
 #include "internal/conf.h"
+#include "conf_local.h"
 #include <openssl/x509.h>
 #include <openssl/asn1.h>
 #include <openssl/engine.h>

--- a/crypto/evp/evp_cnf.c
+++ b/crypto/evp/evp_cnf.c
@@ -46,12 +46,14 @@ static int alg_module_init(CONF_IMODULE *md, const CONF *cnf)
              * fips_mode is deprecated and should not be used in new
              * configurations.
              */
-            if (!EVP_default_properties_enable_fips(cnf->libctx, m > 0)) {
+            if (!EVP_default_properties_enable_fips(NCONF_get0_libctx((CONF *)cnf),
+                        m > 0)) {
                 ERR_raise(ERR_LIB_EVP, EVP_R_SET_DEFAULT_PROPERTY_FAILURE);
                 return 0;
             }
         } else if (strcmp(oval->name, "default_properties") == 0) {
-            if (!evp_set_default_properties_int(cnf->libctx, oval->value, 0, 0)) {
+            if (!evp_set_default_properties_int(NCONF_get0_libctx((CONF *)cnf),
+                        oval->value, 0, 0)) {
                 ERR_raise(ERR_LIB_EVP, EVP_R_SET_DEFAULT_PROPERTY_FAILURE);
                 return 0;
             }

--- a/crypto/provider_conf.c
+++ b/crypto/provider_conf.c
@@ -199,7 +199,8 @@ static int provider_conf_init(CONF_IMODULE *md, const CONF *cnf)
 
     for (i = 0; i < sk_CONF_VALUE_num(elist); i++) {
         cval = sk_CONF_VALUE_value(elist, i);
-        if (!provider_conf_load(cnf->libctx, cval->name, cval->value, cnf))
+        if (!provider_conf_load(NCONF_get0_libctx((CONF *)cnf),
+                    cval->name, cval->value, cnf))
             return 0;
     }
 

--- a/crypto/rand/rand_lib.c
+++ b/crypto/rand/rand_lib.c
@@ -742,7 +742,7 @@ static int random_conf_init(CONF_IMODULE *md, const CONF *cnf)
 {
     STACK_OF(CONF_VALUE) *elist;
     CONF_VALUE *cval;
-    RAND_GLOBAL *dgbl = rand_get_global(cnf->libctx);
+    RAND_GLOBAL *dgbl = rand_get_global(NCONF_get0_libctx((CONF *)cnf));
     int i, r = 1;
 
     OSSL_TRACE1(CONF, "Loading random module: section %s\n",

--- a/crypto/x509/v3_conf.c
+++ b/crypto/x509/v3_conf.c
@@ -480,18 +480,29 @@ int X509V3_set_issuer_pkey(X509V3_CTX *ctx, EVP_PKEY *pkey)
 X509_EXTENSION *X509V3_EXT_conf(LHASH_OF(CONF_VALUE) *conf, X509V3_CTX *ctx,
                                 const char *name, const char *value)
 {
-    CONF ctmp;
+    CONF *ctmp;
+    X509_EXTENSION *ret;
 
-    CONF_set_nconf(&ctmp, conf);
-    return X509V3_EXT_nconf(&ctmp, ctx, name, value);
+    if ((ctmp = NCONF_new(NULL)) == NULL)
+        return NULL;
+    CONF_set_nconf(ctmp, conf);
+    ret = X509V3_EXT_nconf(ctmp, ctx, name, value);
+    NCONF_free(ctmp);
+    return ret;
 }
 
 X509_EXTENSION *X509V3_EXT_conf_nid(LHASH_OF(CONF_VALUE) *conf,
                                     X509V3_CTX *ctx, int ext_nid, const char *value)
 {
-    CONF ctmp;
-    CONF_set_nconf(&ctmp, conf);
-    return X509V3_EXT_nconf_nid(&ctmp, ctx, ext_nid, value);
+    CONF *ctmp;
+    X509_EXTENSION *ret;
+
+    if ((ctmp = NCONF_new(NULL)) == NULL)
+        return NULL;
+    CONF_set_nconf(ctmp, conf);
+    ret = X509V3_EXT_nconf_nid(ctmp, ctx, ext_nid, value);
+    NCONF_free(ctmp);
+    return ret;
 }
 
 static char *conf_lhash_get_string(void *db, const char *section, const char *value)
@@ -524,10 +535,15 @@ void X509V3_set_conf_lhash(X509V3_CTX *ctx, LHASH_OF(CONF_VALUE) *lhash)
 int X509V3_EXT_add_conf(LHASH_OF(CONF_VALUE) *conf, X509V3_CTX *ctx,
                         const char *section, X509 *cert)
 {
-    CONF ctmp;
+    CONF *ctmp;
+    int ret;
 
-    CONF_set_nconf(&ctmp, conf);
-    return X509V3_EXT_add_nconf(&ctmp, ctx, section, cert);
+    if ((ctmp = NCONF_new(NULL)) == NULL)
+        return 0;
+    CONF_set_nconf(ctmp, conf);
+    ret = X509V3_EXT_add_nconf(ctmp, ctx, section, cert);
+    NCONF_free(ctmp);
+    return ret;
 }
 
 /* Same as above but for a CRL */
@@ -535,10 +551,15 @@ int X509V3_EXT_add_conf(LHASH_OF(CONF_VALUE) *conf, X509V3_CTX *ctx,
 int X509V3_EXT_CRL_add_conf(LHASH_OF(CONF_VALUE) *conf, X509V3_CTX *ctx,
                             const char *section, X509_CRL *crl)
 {
-    CONF ctmp;
+    CONF *ctmp;
+    int ret;
 
-    CONF_set_nconf(&ctmp, conf);
-    return X509V3_EXT_CRL_add_nconf(&ctmp, ctx, section, crl);
+    if ((ctmp = NCONF_new(NULL)) == NULL)
+        return 0;
+    CONF_set_nconf(ctmp, conf);
+    ret = X509V3_EXT_CRL_add_nconf(ctmp, ctx, section, crl);
+    NCONF_free(ctmp);
+    return ret;
 }
 
 /* Add extensions to certificate request */
@@ -546,8 +567,13 @@ int X509V3_EXT_CRL_add_conf(LHASH_OF(CONF_VALUE) *conf, X509V3_CTX *ctx,
 int X509V3_EXT_REQ_add_conf(LHASH_OF(CONF_VALUE) *conf, X509V3_CTX *ctx,
                             const char *section, X509_REQ *req)
 {
-    CONF ctmp;
+    CONF *ctmp;
+    int ret;
 
-    CONF_set_nconf(&ctmp, conf);
-    return X509V3_EXT_REQ_add_nconf(&ctmp, ctx, section, req);
+    if ((ctmp = NCONF_new(NULL)) == NULL)
+        return 0;
+    CONF_set_nconf(ctmp, conf);
+    ret = X509V3_EXT_REQ_add_nconf(ctmp, ctx, section, req);
+    NCONF_free(ctmp);
+    return ret;
 }

--- a/doc/man3/NCONF_new_ex.pod
+++ b/doc/man3/NCONF_new_ex.pod
@@ -3,19 +3,28 @@
 =head1 NAME
 
 NCONF_new_ex, NCONF_new, NCONF_free, NCONF_default, NCONF_load,
-NCONF_get0_libctx
+NCONF_get0_libctx, NCONF_get_section, NCONF_get_section_names
 - functionality to Load and parse configuration files manually
 
 =head1 SYNOPSIS
 
  #include <openssl/conf.h>
 
+ typedef struct {
+     char *section;
+     char *name;
+     char *value;
+ } CONF_VALUE;
+
  CONF *NCONF_new_ex(OSSL_LIB_CTX *libctx, CONF_METHOD *meth);
  CONF *NCONF_new(CONF_METHOD *meth);
  void NCONF_free(CONF *conf);
  CONF_METHOD *NCONF_default(void);
  int NCONF_load(CONF *conf, const char *file, long *eline);
- OSSL_LIB_CTX *NCONF_get0_libctx(CONF *conf);
+ OSSL_LIB_CTX *NCONF_get0_libctx(const CONF *conf);
+
+ STACK_OF(CONF_VALUE) *NCONF_get_section(const CONF *conf, const char *name);
+ STACK_OF(OPENSSL_CSTRING) *NCONF_get_section_names(const CONF *conf);
 
 =head1 DESCRIPTION
 
@@ -37,6 +46,16 @@ NCONF_default() gets the default method table for processing a configuration fil
 NCONF_get0_libctx() gets the library context associated with the I<conf>
 parameter.
 
+NCONF_get_section_names() gets the names of the sections associated with
+the I<conf> as B<STACK_OF(OPENSSL_CSTRING)> strings. The individual strings
+are associated with the I<conf> and will be invalid after I<conf> is
+freed. The returned stack must be freed with sk_OPENSSL_CSTRING_free().
+
+NCONF_get_section() gets the config values associated with the I<conf> from
+the config section I<name> as B<STACK_OF(CONF_VALUE)> structures. The returned
+stack is associated with the I<conf> and will be invalid after I<conf>
+is freed. It must not be freed by the caller.
+
 =head1 RETURN VALUES
 
 NCONF_load() returns 1 on success or 0 on error.
@@ -50,11 +69,12 @@ L<CONF_modules_load_file(3)>,
 
 =head1 HISTORY
 
-NCONF_new_ex() was added in OpenSSL 3.0.
+NCONF_new_ex(), NCONF_get0_libctx(), and NCONF_get_section_names() were added
+in OpenSSL 3.0.
 
 =head1 COPYRIGHT
 
-Copyright 2020 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2020-2021 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/doc/man3/NCONF_new_ex.pod
+++ b/doc/man3/NCONF_new_ex.pod
@@ -2,7 +2,8 @@
 
 =head1 NAME
 
-NCONF_new_ex, NCONF_new, NCONF_free, NCONF_default, NCONF_load
+NCONF_new_ex, NCONF_new, NCONF_free, NCONF_default, NCONF_load,
+NCONF_get0_libctx
 - functionality to Load and parse configuration files manually
 
 =head1 SYNOPSIS
@@ -14,6 +15,7 @@ NCONF_new_ex, NCONF_new, NCONF_free, NCONF_default, NCONF_load
  void NCONF_free(CONF *conf);
  CONF_METHOD *NCONF_default(void);
  int NCONF_load(CONF *conf, const char *file, long *eline);
+ OSSL_LIB_CTX *NCONF_get0_libctx(CONF *conf);
 
 =head1 DESCRIPTION
 
@@ -31,6 +33,9 @@ I<conf>. If an error occurs I<file> and I<eline> list the file and line that
 the load failed on if they are not NULL.
 
 NCONF_default() gets the default method table for processing a configuration file.
+
+NCONF_get0_libctx() gets the library context associated with the I<conf>
+parameter.
 
 =head1 RETURN VALUES
 

--- a/include/openssl/conf.h.in
+++ b/include/openssl/conf.h.in
@@ -106,7 +106,7 @@ OSSL_DEPRECATEDIN_1_1_0 void OPENSSL_config(const char *config_name);
  */
 
 CONF *NCONF_new_ex(OSSL_LIB_CTX *libctx, CONF_METHOD *meth);
-OSSL_LIB_CTX *NCONF_get0_libctx(CONF *conf);
+OSSL_LIB_CTX *NCONF_get0_libctx(const CONF *conf);
 CONF *NCONF_new(CONF_METHOD *meth);
 CONF_METHOD *NCONF_default(void);
 #ifndef OPENSSL_NO_DEPRECATED_3_0
@@ -120,6 +120,7 @@ int NCONF_load(CONF *conf, const char *file, long *eline);
 int NCONF_load_fp(CONF *conf, FILE *fp, long *eline);
 # endif
 int NCONF_load_bio(CONF *conf, BIO *bp, long *eline);
+STACK_OF(OPENSSL_CSTRING) *NCONF_get_section_names(const CONF *conf);
 STACK_OF(CONF_VALUE) *NCONF_get_section(const CONF *conf,
                                         const char *section);
 char *NCONF_get_string(const CONF *conf, const char *group, const char *name);

--- a/include/openssl/conf.h.in
+++ b/include/openssl/conf.h.in
@@ -106,6 +106,7 @@ OSSL_DEPRECATEDIN_1_1_0 void OPENSSL_config(const char *config_name);
  */
 
 CONF *NCONF_new_ex(OSSL_LIB_CTX *libctx, CONF_METHOD *meth);
+OSSL_LIB_CTX *NCONF_get0_libctx(CONF *conf);
 CONF *NCONF_new(CONF_METHOD *meth);
 CONF_METHOD *NCONF_default(void);
 #ifndef OPENSSL_NO_DEPRECATED_3_0

--- a/include/openssl/conf.h.in
+++ b/include/openssl/conf.h.in
@@ -48,21 +48,11 @@ struct conf_st;
 struct conf_method_st;
 typedef struct conf_method_st CONF_METHOD;
 
-struct conf_method_st {
-    const char *name;
-    CONF *(*create) (CONF_METHOD *meth);
-    int (*init) (CONF *conf);
-    int (*destroy) (CONF *conf);
-    int (*destroy_data) (CONF *conf);
-    int (*load_bio) (CONF *conf, BIO *bp, long *eline);
-    int (*dump) (const CONF *conf, BIO *bp);
-    int (*is_number) (const CONF *conf, char c);
-    int (*to_int) (const CONF *conf, char c);
-    int (*load) (CONF *conf, const char *name, long *eline);
-};
+# ifndef OPENSSL_NO_DEPRECATED_3_0
+#  include <openssl/conftypes.h>
+# endif
 
 /* Module definitions */
-
 typedef struct conf_imodule_st CONF_IMODULE;
 typedef struct conf_module_st CONF_MODULE;
 
@@ -114,16 +104,6 @@ OSSL_DEPRECATEDIN_1_1_0 void OPENSSL_config(const char *config_name);
  * New conf code.  The semantics are different from the functions above. If
  * that wasn't the case, the above functions would have been replaced
  */
-
-struct conf_st {
-    CONF_METHOD *meth;
-    void *meth_data;
-    LHASH_OF(CONF_VALUE) *data;
-    int flag_dollarid;
-    int flag_abspath;
-    char *includedir;
-    OSSL_LIB_CTX *libctx;
-};
 
 CONF *NCONF_new_ex(OSSL_LIB_CTX *libctx, CONF_METHOD *meth);
 CONF *NCONF_new(CONF_METHOD *meth);

--- a/include/openssl/conftypes.h
+++ b/include/openssl/conftypes.h
@@ -1,0 +1,46 @@
+/*
+ * {- join("\n * ", @autowarntext) -}
+ *
+ * Copyright 1995-2021 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#ifndef  OPENSSL_CONFTYPES_H
+# define OPENSSL_CONFTYPES_H
+# pragma once
+
+#ifndef  OPENSSL_CONF_H
+# include <openssl/conf.h>
+#endif
+
+/*
+ * The contents of this file are deprecated and will be made opaque
+ */
+struct conf_method_st {
+    const char *name;
+    CONF *(*create) (CONF_METHOD *meth);
+    int (*init) (CONF *conf);
+    int (*destroy) (CONF *conf);
+    int (*destroy_data) (CONF *conf);
+    int (*load_bio) (CONF *conf, BIO *bp, long *eline);
+    int (*dump) (const CONF *conf, BIO *bp);
+    int (*is_number) (const CONF *conf, char c);
+    int (*to_int) (const CONF *conf, char c);
+    int (*load) (CONF *conf, const char *name, long *eline);
+};
+
+struct conf_st {
+    CONF_METHOD *meth;
+    void *meth_data;
+    LHASH_OF(CONF_VALUE) *data;
+    int flag_dollarid;
+    int flag_abspath;
+    char *includedir;
+    OSSL_LIB_CTX *libctx;
+};
+
+#endif

--- a/include/openssl/conftypes.h
+++ b/include/openssl/conftypes.h
@@ -1,6 +1,4 @@
 /*
- * {- join("\n * ", @autowarntext) -}
- *
  * Copyright 1995-2021 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use

--- a/test/confdump.c
+++ b/test/confdump.c
@@ -14,27 +14,6 @@
 #include <openssl/safestack.h>
 #include <openssl/err.h>
 
-static STACK_OF(OPENSSL_CSTRING) *section_names = NULL;
-
-static void collect_section_name(CONF_VALUE *v)
-{
-    /* A section is a CONF_VALUE with name == NULL */
-    if (v->name == NULL)
-        sk_OPENSSL_CSTRING_push(section_names, v->section);
-}
-
-static int section_name_cmp(OPENSSL_CSTRING const *a, OPENSSL_CSTRING const *b)
-{
-    return strcmp(*a, *b);
-}
-
-static void collect_all_sections(const CONF *cnf)
-{
-    section_names = sk_OPENSSL_CSTRING_new(section_name_cmp);
-    lh_CONF_VALUE_doall(cnf->data, collect_section_name);
-    sk_OPENSSL_CSTRING_sort(section_names);
-}
-
 static void dump_section(const char *name, const CONF *cnf)
 {
     STACK_OF(CONF_VALUE) *sect = NCONF_get_section(cnf, name);
@@ -53,11 +32,12 @@ int main(int argc, char **argv)
     long eline;
     CONF *conf = NCONF_new(NCONF_default());
     int ret = 1;
+    STACK_OF(OPENSSL_CSTRING) *section_names = NULL;
 
     if (conf != NULL && NCONF_load(conf, argv[1], &eline)) {
         int i;
 
-        collect_all_sections(conf);
+        section_names = NCONF_get_section_names(conf);
         for (i = 0; i < sk_OPENSSL_CSTRING_num(section_names); i++) {
             dump_section(sk_OPENSSL_CSTRING_value(section_names, i), conf);
         }

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5417,3 +5417,4 @@ PKCS5_PBE_keyivgen_ex                   5544	3_0_0	EXIST::FUNCTION:
 EVP_MAC_CTX_get_block_size              5545	3_0_0	EXIST::FUNCTION:
 BIO_debug_callback_ex                   5546	3_0_0	EXIST::FUNCTION:
 NCONF_get0_libctx                       5547	3_0_0	EXIST::FUNCTION:
+NCONF_get_section_names                 5548	3_0_0	EXIST::FUNCTION:

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5416,3 +5416,4 @@ OSSL_PROVIDER_get0_dispatch             5543	3_0_0	EXIST::FUNCTION:
 PKCS5_PBE_keyivgen_ex                   5544	3_0_0	EXIST::FUNCTION:
 EVP_MAC_CTX_get_block_size              5545	3_0_0	EXIST::FUNCTION:
 BIO_debug_callback_ex                   5546	3_0_0	EXIST::FUNCTION:
+NCONF_get0_libctx                       5547	3_0_0	EXIST::FUNCTION:


### PR DESCRIPTION
It's actually make the public definition of the structures deprecated.
