### PR TITLE
Angle brackets

### DIFF
--- a/apps/s_time.c
+++ b/apps/s_time.c
@@ -22,7 +22,7 @@
 #include <openssl/pem.h>
 #include "s_apps.h"
 #include <openssl/err.h>
-#include <internal/sockets.h>
+#include "internal/sockets.h"
 #if !defined(OPENSSL_SYS_MSDOS)
 # include <unistd.h>
 #endif

--- a/crypto/asn1/n_pkey.c
+++ b/crypto/asn1/n_pkey.c
@@ -7,8 +7,7 @@
  * https://www.openssl.org/source/license.html
  */
 
-#include "openssl/opensslconf.h"
-
+#include <openssl/opensslconf.h>
 #include "internal/cryptlib.h"
 #include <stdio.h>
 #include <openssl/rsa.h>

--- a/crypto/cmp/cmp_client.c
+++ b/crypto/cmp/cmp_client.c
@@ -19,8 +19,7 @@
 #include <openssl/err.h>
 #include <openssl/evp.h>
 #include <openssl/x509v3.h>
-
-#include "openssl/cmp_util.h"
+#include <openssl/cmp_util.h>
 
 #define IS_CREP(t) ((t) == OSSL_CMP_PKIBODY_IP || (t) == OSSL_CMP_PKIBODY_CP \
                         || (t) == OSSL_CMP_PKIBODY_KUP)

--- a/crypto/cmp/cmp_http.c
+++ b/crypto/cmp/cmp_http.c
@@ -16,7 +16,7 @@
 #include <openssl/http.h>
 #include "internal/sockets.h"
 
-#include "openssl/cmp.h"
+#include <openssl/cmp.h>
 #include "cmp_local.h"
 
 /* explicit #includes not strictly needed since implied by the above: */

--- a/crypto/conf/conf_mod.c
+++ b/crypto/conf/conf_mod.c
@@ -15,7 +15,7 @@
 #include <ctype.h>
 #include <openssl/crypto.h>
 #include "internal/conf.h"
-#include "openssl/conf_api.h"
+#include <openssl/conf_api.h>
 #include "internal/dso.h"
 #include "internal/thread_once.h"
 #include <openssl/x509.h>

--- a/crypto/ctype.c
+++ b/crypto/ctype.c
@@ -10,7 +10,7 @@
 #include <string.h>
 #include <stdio.h>
 #include "crypto/ctype.h"
-#include "openssl/ebcdic.h"
+#include <openssl/ebcdic.h>
 
 /*
  * Define the character classes for each character in the seven bit ASCII

--- a/crypto/dh/dh_kdf.c
+++ b/crypto/dh/dh_kdf.c
@@ -22,7 +22,7 @@
 #include <openssl/asn1.h>
 #include <openssl/kdf.h>
 #include "internal/provider.h"
-#include <crypto/dh.h>
+#include "crypto/dh.h"
 
 /* Key derivation function from X9.63/SECG */
 int ossl_dh_kdf_X9_42_asn1(unsigned char *out, size_t outlen,

--- a/crypto/dh/dh_kdf.c
+++ b/crypto/dh/dh_kdf.c
@@ -21,7 +21,7 @@
 #include <openssl/evp.h>
 #include <openssl/asn1.h>
 #include <openssl/kdf.h>
-#include <internal/provider.h>
+#include "internal/provider.h"
 #include <crypto/dh.h>
 
 /* Key derivation function from X9.63/SECG */

--- a/crypto/ec/curve448/arch_32/f_impl32.c
+++ b/crypto/ec/curve448/arch_32/f_impl32.c
@@ -11,7 +11,7 @@
  */
 
 #include "e_os.h"
-#include "openssl/macros.h"
+#include <openssl/macros.h>
 #include "internal/numbers.h"
 
 #ifdef UINT128_MAX

--- a/crypto/ec/curve448/arch_64/f_impl64.c
+++ b/crypto/ec/curve448/arch_64/f_impl64.c
@@ -11,7 +11,7 @@
  */
 
 #include "e_os.h"
-#include "openssl/macros.h"
+#include <openssl/macros.h>
 #include "internal/numbers.h"
 
 #ifndef UINT128_MAX

--- a/crypto/ec/ec_ameth.c
+++ b/crypto/ec/ec_ameth.c
@@ -23,7 +23,7 @@
 #include "crypto/evp.h"
 #include "crypto/x509.h"
 #include <openssl/core_names.h>
-#include "openssl/param_build.h"
+#include <openssl/param_build.h>
 #include "ec_local.h"
 
 static int eckey_param2type(int *pptype, void **ppval, const EC_KEY *ec_key)

--- a/crypto/evp/e_rc4_hmac_md5.c
+++ b/crypto/evp/e_rc4_hmac_md5.c
@@ -13,7 +13,7 @@
  */
 #include "internal/deprecated.h"
 
-#include <internal/cryptlib.h>
+#include "internal/cryptlib.h"
 #include <openssl/opensslconf.h>
 
 #include <stdio.h>

--- a/crypto/ppccap.c
+++ b/crypto/ppccap.c
@@ -28,7 +28,7 @@
 #endif
 #include <openssl/crypto.h>
 #include <openssl/bn.h>
-#include <internal/cryptlib.h>
+#include "internal/cryptlib.h"
 #include <crypto/chacha.h>
 #include "bn/bn_local.h"
 

--- a/crypto/ppccap.c
+++ b/crypto/ppccap.c
@@ -29,7 +29,7 @@
 #include <openssl/crypto.h>
 #include <openssl/bn.h>
 #include "internal/cryptlib.h"
-#include <crypto/chacha.h>
+#include "crypto/chacha.h"
 #include "bn/bn_local.h"
 
 #include "ppc_arch.h"

--- a/crypto/seed/seed_local.h
+++ b/crypto/seed/seed_local.h
@@ -35,7 +35,7 @@
 #ifndef OSSL_CRYPTO_SEED_LOCAL_H
 # define OSSL_CRYPTO_SEED_LOCAL_H
 
-# include "openssl/e_os2.h"
+# include <openssl/e_os2.h>
 # include <openssl/seed.h>
 
 # ifdef SEED_LONG               /* need 32-bit type */

--- a/engines/e_devcrypto.c
+++ b/engines/e_devcrypto.c
@@ -24,7 +24,7 @@
 #include <openssl/err.h>
 #include <openssl/engine.h>
 #include <openssl/objects.h>
-#include <crypto/cryptodev.h>
+#include "crypto/cryptodev.h"
 
 /* #define ENGINE_DEVCRYPTO_DEBUG */
 

--- a/fuzz/asn1.c
+++ b/fuzz/asn1.c
@@ -37,7 +37,7 @@
 #include <openssl/bio.h>
 #include <openssl/evp.h>
 #include <openssl/ssl.h>
-#include <internal/nelem.h>
+#include "internal/nelem.h"
 #include "fuzzer.h"
 
 static ASN1_ITEM_EXP *item_type[] = {

--- a/include/crypto/aes_platform.h
+++ b/include/crypto/aes_platform.h
@@ -11,7 +11,7 @@
 # define OSSL_AES_PLATFORM_H
 # pragma once
 
-# include "openssl/aes.h"
+# include <openssl/aes.h>
 
 # ifdef VPAES_ASM
 int vpaes_set_encrypt_key(const unsigned char *userKey, int bits,

--- a/include/internal/ktls.h
+++ b/include/internal/ktls.h
@@ -32,7 +32,7 @@
 #   include <sys/ktls.h>
 #   include <netinet/in.h>
 #   include <netinet/tcp.h>
-#   include "openssl/ssl3.h"
+#   include <openssl/ssl3.h>
 
 #   ifndef TCP_RXTLS_ENABLE
 #    define OPENSSL_NO_KTLS_RX
@@ -232,9 +232,9 @@ static ossl_inline ossl_ssize_t ktls_sendfile(int s, int fd, off_t off,
 #   include <sys/sendfile.h>
 #   include <netinet/tcp.h>
 #   include <linux/socket.h>
-#   include "openssl/ssl3.h"
-#   include "openssl/tls1.h"
-#   include "openssl/evp.h"
+#   include <openssl/ssl3.h>
+#   include <openssl/tls1.h>
+#   include <openssl/evp.h>
 
 #   ifndef SOL_TLS
 #    define SOL_TLS 282

--- a/providers/fips/self_test.c
+++ b/providers/fips/self_test.c
@@ -11,7 +11,7 @@
 #include <openssl/evp.h>
 #include <openssl/params.h>
 #include <openssl/crypto.h>
-#include <internal/cryptlib.h>
+#include "internal/cryptlib.h"
 #include <openssl/fipskey.h>
 #include <openssl/err.h>
 #include <openssl/proverr.h>
@@ -25,7 +25,7 @@
  * it should be run once regardless of the number of OSSL_LIB_CTXs we have.
  */
 #define ALLOW_RUN_ONCE_IN_FIPS
-#include <internal/thread_once.h>
+#include "internal/thread_once.h"
 #include "self_test.h"
 
 #define FIPS_STATE_INIT     0

--- a/providers/implementations/asymciphers/sm2_enc.c
+++ b/providers/implementations/asymciphers/sm2_enc.c
@@ -16,7 +16,7 @@
 #include <openssl/params.h>
 #include <openssl/err.h>
 #include <openssl/proverr.h>
-#include <crypto/sm2.h>
+#include "crypto/sm2.h"
 #include "prov/provider_ctx.h"
 #include "prov/implementations.h"
 #include "prov/provider_util.h"

--- a/providers/implementations/ciphers/cipher_camellia.h
+++ b/providers/implementations/ciphers/cipher_camellia.h
@@ -7,7 +7,7 @@
  * https://www.openssl.org/source/license.html
  */
 
-#include "openssl/camellia.h"
+#include <openssl/camellia.h>
 #include "prov/ciphercommon.h"
 #include "crypto/cmll_platform.h"
 

--- a/providers/implementations/kem/rsa_kem.c
+++ b/providers/implementations/kem/rsa_kem.c
@@ -21,7 +21,7 @@
 #include <openssl/rsa.h>
 #include <openssl/params.h>
 #include <openssl/err.h>
-#include <crypto/rsa.h>
+#include "crypto/rsa.h"
 #include <openssl/proverr.h>
 #include "prov/provider_ctx.h"
 #include "prov/implementations.h"

--- a/providers/implementations/keymgmt/ecx_kmgmt.c
+++ b/providers/implementations/keymgmt/ecx_kmgmt.c
@@ -19,7 +19,7 @@
 #include <openssl/evp.h>
 #include <openssl/rand.h>
 #include "internal/param_build_set.h"
-#include "openssl/param_build.h"
+#include <openssl/param_build.h>
 #include "crypto/ecx.h"
 #include "prov/implementations.h"
 #include "prov/providercommon.h"

--- a/providers/implementations/keymgmt/mac_legacy_kmgmt.c
+++ b/providers/implementations/keymgmt/mac_legacy_kmgmt.c
@@ -17,7 +17,7 @@
 #include <openssl/err.h>
 #include <openssl/evp.h>
 #include <openssl/proverr.h>
-#include "openssl/param_build.h"
+#include <openssl/param_build.h>
 #include "internal/param_build_set.h"
 #include "prov/implementations.h"
 #include "prov/providercommon.h"

--- a/ssl/ktls.c
+++ b/ssl/ktls.c
@@ -11,7 +11,7 @@
 #include "internal/ktls.h"
 
 #if defined(__FreeBSD__)
-# include <crypto/cryptodev.h>
+# include "crypto/cryptodev.h"
 
 /*-
  * Check if a given cipher is supported by the KTLS interface.

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -26,7 +26,7 @@
 #include <openssl/trace.h>
 #include <openssl/core_names.h>
 #include <openssl/param_build.h>
-#include <internal/cryptlib.h>
+#include "internal/cryptlib.h"
 
 static MSG_PROCESS_RETURN tls_process_as_hello_retry_request(SSL *s, PACKET *pkt);
 static MSG_PROCESS_RETURN tls_process_encrypted_extensions(SSL *s, PACKET *pkt);

--- a/test/ectest.c
+++ b/test/ectest.c
@@ -28,9 +28,9 @@
 #include <openssl/rand.h>
 #include <openssl/bn.h>
 #include <openssl/opensslconf.h>
-#include "openssl/core_names.h"
-#include "openssl/param_build.h"
-#include "openssl/evp.h"
+#include <openssl/core_names.h>
+#include <openssl/param_build.h>
+#include <openssl/evp.h>
 
 static size_t crv_len = 0;
 static EC_builtin_curve *curves = NULL;

--- a/test/param_build_test.c
+++ b/test/param_build_test.c
@@ -10,7 +10,7 @@
 
 #include <string.h>
 #include <openssl/params.h>
-#include "openssl/param_build.h"
+#include <openssl/param_build.h>
 #include "internal/nelem.h"
 #include "testutil.h"
 

--- a/test/sparse_array_test.c
+++ b/test/sparse_array_test.c
@@ -13,8 +13,7 @@
 #include <limits.h>
 
 #include <openssl/crypto.h>
-#include <internal/nelem.h>
-
+#include "internal/nelem.h"
 #include "crypto/sparse_array.h"
 #include "testutil.h"
 

--- a/test/tls-provider.c
+++ b/test/tls-provider.c
@@ -14,7 +14,7 @@
 #include <openssl/params.h>
 /* For TLS1_3_VERSION */
 #include <openssl/ssl.h>
-#include <internal/nelem.h>
+#include "internal/nelem.h"
 
 static OSSL_FUNC_keymgmt_import_fn xor_import;
 static OSSL_FUNC_keymgmt_import_types_fn xor_import_types;


### PR DESCRIPTION
Be consistent in includes
- For include crypto/xxx always use quotes
- For include openssl/xxx always use angle brackets
- For include internal/xxx always use quotes