### PR TITLE
Fix up O/S name for AIX so we can correctly skip the CMP http test

### DIFF
--- a/test/recipes/80-test_cmp_http.t
+++ b/test/recipes/80-test_cmp_http.t
@@ -32,7 +32,7 @@ plan skip_all => "These tests are not supported in a no-sock build"
     if disabled("sock");
 
 plan skip_all => "Tests involving local HTTP server not available on Windows, AIX or VMS"
-    if $^O =~ /^(VMS|MSWin32|AIX)$/;
+    if $^O =~ /^(VMS|MSWin32|aix)$/;
 plan skip_all => "Tests involving local HTTP server not available in cross-compile builds"
     if defined $ENV{EXE_SHELL};
 


### PR DESCRIPTION
The O/S name for AIX was being incorrectly matched to 'AIX'. I checked the actual value returned on an AIX box:

```
bash-4.2$ perl -e "print \"O/S is: $^O\n\""
O/S is: aix
```

This fits with what is listed in the perl docs here:

https://perldoc.perl.org/perlport#PLATFORMS

It seems the O/S name for most platforms is the string returned by 'uname -a' lowercased, with a few exceptions (MSWin, VMS, MacOS).

- [X] tests are added or updated
