### PR TITLE
Additional FIPS Checksums CI fixes

### DIFF
--- a/.github/workflows/fips-checksums.yml
+++ b/.github/workflows/fips-checksums.yml
@@ -9,16 +9,19 @@ jobs:
         run: |
             sudo apt-get update
             sudo apt-get -yq --no-install-suggests --no-install-recommends --force-yes install unifdef
-      - uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.pull_request.base.sha }}
       - name: create build dirs
         run: |
           mkdir ./build-pristine
+          mkdir ./source-pristine
           mkdir ./build
+          mkdir ./source
           mkdir ./artifact
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: source-pristine
       - name: config pristine
-        run: ../config enable-fips && perl configdata.pm --dump
+        run: ../source-pristine/config enable-fips && perl configdata.pm --dump
         working-directory: ./build-pristine
       - name: make build_generated pristine
         run: make -s build_generated
@@ -28,9 +31,9 @@ jobs:
         working-directory: ./build-pristine
       - uses: actions/checkout@v2
         with:
-          clean: false
+          path: source
       - name: config
-        run: ../config enable-fips && perl configdata.pm --dump
+        run: ../source/config enable-fips && perl configdata.pm --dump
         working-directory: ./build
       - name: make build_generated
         run: make -s build_generated
@@ -38,9 +41,11 @@ jobs:
       - name: make fips-checksums
         run: make fips-checksums
         working-directory: ./build
-      - name: update checksums pristine
-        run: touch providers/fips.checksum.new && make update-fips-checksums
-        working-directory: ./build-pristine
+      - name: update checksums
+        run: |
+          cp -a build-pristine/providers/fips.module.sources.new source/providers/fips.module.sources
+          cp -a build-pristine/providers/fips-sources.checksums.new source/providers/fips-sources.checksums
+          cp -a build-pristine/providers/fips.checksum.new source/providers/fips.checksum
       - name: make diff-fips-checksums
         run: make diff-fips-checksums && touch ../artifact/fips_unchanged || ( touch ../artifact/fips_changed ; echo FIPS CHANGED )
         working-directory: ./build

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -1212,12 +1212,6 @@ providers/fips.module.sources.new: \
 	     | sed -e 's/^.*: *//' -e 's/  */ /g' \
 	     | fgrep -f sources-tmp/sources | tr ' ' '\n' \
 	     | sed -E -e '/^include/s:$$:.in:' -e 's:^ *([.][.]/)*$(SRCDIR)::' -e 's:^/::' ; \
-	  for x in providers/common/include/prov/*.h; do \
-	    echo providers/common/der/`basename "$$x"`.in; \
-	  done ; \
-	  for x in providers/common/der/*.c; do \
-	    echo "$$x".in; \
-	  done ; \
 	  for x in `cat sources-tmp/sources`; do \
 	    if [ -f "$(SRCDIR)$$x" ]; then echo $$x | sed 's:^/::' ; fi ; \
 	  done ; \
@@ -1227,7 +1221,8 @@ providers/fips.module.sources.new: \
 		   crypto/ec/asm/*.pl \
 		   crypto/modes/asm/*.pl \
 		   crypto/sha/asm/*.pl \
-		   crypto/x86_64cpuid.pl; do \
+		   crypto/x86_64cpuid.pl \
+	           providers/common/der/*.in; do \
 	    echo "$$x"; \
 	  done \
 	) | sed -e 's:/[^/]*/[^/]*/[.][.]/[.][.]/:/:g' -e 's:/[^/]*/[.][.]/:/:g' \


### PR DESCRIPTION
The providers/common/der/*.in were not included correctly.

The fips-checksums CI workflow was not working properly when checking pristine and merged sources into the same directory.
