### PR TITLE
Fix typo about SSL_CONF_FLAG_CMDLINE

### DIFF
--- a/doc/man3/SSL_CONF_cmd.pod
+++ b/doc/man3/SSL_CONF_cmd.pod
@@ -24,8 +24,8 @@ SSL_CONF_cmd_value_type() returns the type of value that B<option> refers to.
 =head1 SUPPORTED COMMAND LINE COMMANDS
 
 Currently supported B<option> names for command lines (i.e. when the
-flag B<SSL_CONF_CMDLINE> is set) are listed below. Note: all B<option> names
-are case sensitive. Unless otherwise stated commands can be used by
+flag B<SSL_CONF_FLAG_CMDLINE> is set) are listed below. Note: all B<option>
+names are case sensitive. Unless otherwise stated commands can be used by
 both clients and servers and the B<value> parameter is not used. The default
 prefix for command line commands is B<-> and that is reflected below.
 


### PR DESCRIPTION
I believe it should be `SSL_CONF_FLAG_CMDLINE` instead of `SSL_CONF_CMDLINE` in the document. The later seems doesn't exists.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated