### PR TITLE
Add find-include-nits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,8 @@ jobs:
       run: |
           sudo gem install mdl
           make md-nits
+    - name: make include-nits
+      run: make include-nits
 
   # This checks that we use ANSI C language syntax and semantics.
   # We are not as strict with libraries, but rather adapt to what's

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -123,6 +123,9 @@ DEPS={- join(" \\\n" . ' ' x 5,
 GENERATED_MANDATORY={- join(" \\\n" . ' ' x 20,
                             fill_lines(" ", $COLUMNS - 20,
                                        @{$unified_info{depends}->{""}})) -}
+GENERATED_FIPS_FILES={- join(" \\\n" . ' ' x 20,
+                            fill_lines(" ", $COLUMNS - 20,
+                                       @{$unified_info{depends}->{"providers/common/der/GENFIPSFILES"}})) -}
 GENERATED_PODS={- # common0.tmpl provides @generated
                   join(" \\\n" . ' ' x 15,
                        fill_lines(" ", $COLUMNS - 15,
@@ -1127,16 +1130,11 @@ doc-nits: build_generated_pods
 md-nits:
 	mdl -s util/markdownlint.rb .
 
-GENERATED_FIPS_HEADERS = \
-     providers/common/include/prov/der_digests.h \
-     providers/common/include/prov/der_dsa.h \
-     providers/common/include/prov/der_ec.h \
-     providers/common/include/prov/der_ecx.h \
-     providers/common/include/prov/der_rsa.h \
-     providers/common/include/prov/der_sm2.h
-
-include-nits: build_generated $(GENERATED_FIPS_HEADERS)
+# First check the source tree (via 'get ls-files') then check the
+# generated files
+include-nits: build_generated $(GENERATED_FIPS_FILES)
 	$(PERL) $(SRCDIR)/util/find-include-nits
+	$(PERL) $(SRCDIR)/util/find-include-nits $(GENERATED_FIPS_FILES)
 
 # Test coverage is a good idea for the future
 #coverage: $(PROGRAMS) $(TESTPROGRAMS)

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -1114,7 +1114,7 @@ generate: generate_apps generate_crypto_bn generate_crypto_objects \
 
 generate_buildinfo: generate_doc_buildinfo
 
-.PHONY: doc-nits md-nits
+.PHONY: doc-nits md-nits include-nits
 doc-nits: build_generated_pods
 	$(PERL) $(SRCDIR)/util/find-doc-nits -c -n -l -e
 
@@ -1126,6 +1126,17 @@ doc-nits: build_generated_pods
 # can be found at https://github.com/DavidAnson/markdownlint
 md-nits:
 	mdl -s util/markdownlint.rb .
+
+GENERATED_FIPS_HEADERS = \
+     providers/common/include/prov/der_digests.h \
+     providers/common/include/prov/der_dsa.h \
+     providers/common/include/prov/der_ec.h \
+     providers/common/include/prov/der_ecx.h \
+     providers/common/include/prov/der_rsa.h \
+     providers/common/include/prov/der_sm2.h
+
+include-nits: build_generated $(GENERATED_FIPS_HEADERS)
+	$(PERL) $(SRCDIR)/util/find-include-nits
 
 # Test coverage is a good idea for the future
 #coverage: $(PROGRAMS) $(TESTPROGRAMS)

--- a/providers/common/der/build.info
+++ b/providers/common/der/build.info
@@ -5,10 +5,12 @@ $DER_DIGESTS_H=$INCDIR/der_digests.h
 $DER_DIGESTS_GEN=der_digests_gen.c
 
 GENERATE[$DER_DIGESTS_GEN]=der_digests_gen.c.in
+DEPEND[GENFIPSFILES]=$DER_DIGESTS_GEN
 DEPEND[$DER_DIGESTS_GEN]=oids_to_c.pm NIST.asn1 DIGESTS.asn1
 
 DEPEND[${DER_DIGESTS_GEN/.c/.o}]=$DER_DIGESTS_H
 GENERATE[$DER_DIGESTS_H]=$INCDIR/der_digests.h.in
+DEPEND[GENFIPSFILES]=$DER_DIGESTS_H
 DEPEND[$DER_DIGESTS_H]=oids_to_c.pm NIST.asn1 DIGESTS.asn1
 
 #----- RSA
@@ -19,11 +21,13 @@ $DER_RSA_COMMON=$DER_RSA_GEN der_rsa_key.c
 $DER_RSA_FIPSABLE=der_rsa_sig.c
 
 GENERATE[$DER_RSA_GEN]=der_rsa_gen.c.in
+DEPEND[GENFIPSFILES]=$DER_RSA_GEN
 DEPEND[$DER_RSA_GEN]=oids_to_c.pm NIST.asn1 RSA.asn1
 
 DEPEND[${DER_RSA_AUX/.c/.o}]=$DER_RSA_H $DER_DIGESTS_H
 DEPEND[${DER_RSA_GEN/.c/.o}]=$DER_RSA_H
 GENERATE[$DER_RSA_H]=$INCDIR/der_rsa.h.in
+DEPEND[GENFIPSFILES]=$DER_RSA_H
 DEPEND[$DER_RSA_H]=oids_to_c.pm NIST.asn1 RSA.asn1
 
 #----- DSA
@@ -33,11 +37,13 @@ IF[{- !$disabled{dsa} -}]
   $DER_DSA_AUX=der_dsa_key.c der_dsa_sig.c
 
   GENERATE[$DER_DSA_GEN]=der_dsa_gen.c.in
+  DEPEND[GENFIPSFILES]=$DER_DSA_GEN
   DEPEND[$DER_DSA_GEN]=oids_to_c.pm DSA.asn1
 
   DEPEND[${DER_DSA_AUX/.c/.o}]=$DER_DSA_H $DER_DIGESTS_H
   DEPEND[${DER_DSA_GEN/.c/.o}]=$DER_DSA_H
   GENERATE[$DER_DSA_H]=$INCDIR/der_dsa.h.in
+  DEPEND[GENFIPSFILES]=$DER_DSA_H
   DEPEND[$DER_DSA_H]=oids_to_c.pm DSA.asn1
 ENDIF
 
@@ -48,11 +54,13 @@ IF[{- !$disabled{ec} -}]
   $DER_EC_AUX=der_ec_key.c der_ec_sig.c
 
   GENERATE[$DER_EC_GEN]=der_ec_gen.c.in
+  DEPEND[GENFIPSFILES]=$DER_EC_GEN
   DEPEND[$DER_EC_GEN]=oids_to_c.pm EC.asn1
 
   DEPEND[${DER_EC_AUX/.c/.o}]=$DER_EC_H $DER_DIGESTS_H
   DEPEND[${DER_EC_GEN/.c/.o}]=$DER_EC_H
   GENERATE[$DER_EC_H]=$INCDIR/der_ec.h.in
+  DEPEND[GENFIPSFILES]=$DER_EC_H
   DEPEND[$DER_EC_H]=oids_to_c.pm EC.asn1
 ENDIF
 
@@ -63,11 +71,13 @@ IF[{- !$disabled{ec} -}]
   $DER_ECX_AUX=der_ecx_key.c
 
   GENERATE[$DER_ECX_GEN]=der_ecx_gen.c.in
+  DEPEND[GENFIPSFILES]=$DER_ECX_GEN
   DEPEND[$DER_ECX_GEN]=oids_to_c.pm ECX.asn1
 
   DEPEND[${DER_ECX_AUX/.c/.o}]=$DER_ECX_H
   DEPEND[${DER_ECX_GEN/.c/.o}]=$DER_ECX_H
   GENERATE[$DER_ECX_H]=$INCDIR/der_ecx.h.in
+  DEPEND[GENFIPSFILES]=$DER_ECX_H
   DEPEND[$DER_ECX_H]=oids_to_c.pm ECX.asn1
 ENDIF
 
@@ -76,10 +86,12 @@ $DER_WRAP_H=$INCDIR/der_wrap.h
 $DER_WRAP_GEN=der_wrap_gen.c
 
 GENERATE[$DER_WRAP_GEN]=der_wrap_gen.c.in
+DEPEND[GENFIPSFILES]=$DER_WRAP_GEN
 DEPEND[$DER_WRAP_GEN]=oids_to_c.pm wrap.asn1
 
 DEPEND[${DER_WRAP_GEN/.c/.o}]=$DER_WRAP_H
 GENERATE[$DER_WRAP_H]=$INCDIR/der_wrap.h.in
+DEPEND[GENFIPSFILES]=$DER_WRAP_H
 DEPEND[$DER_WRAP_H]=oids_to_c.pm wrap.asn1
 
 #----- SM2
@@ -89,11 +101,13 @@ IF[{- !$disabled{sm2} -}]
   $DER_SM2_AUX=der_sm2_key.c der_sm2_sig.c
 
   GENERATE[$DER_SM2_GEN]=der_sm2_gen.c.in
+  DEPEND[GENFIPSFILES]=$DER_SM2_GEN
   DEPEND[$DER_SM2_GEN]=oids_to_c.pm SM2.asn1
 
   DEPEND[${DER_SM2_AUX/.c/.o}]=$DER_SM2_H $DER_EC_H
   DEPEND[${DER_SM2_GEN/.c/.o}]=$DER_SM2_H
   GENERATE[$DER_SM2_H]=$INCDIR/der_sm2.h.in
+  DEPEND[GENFIPSFILES]=$DER_SM2_H
   DEPEND[$DER_SM2_H]=oids_to_c.pm SM2.asn1
 ENDIF
 

--- a/util/find-include-nits
+++ b/util/find-include-nits
@@ -31,10 +31,6 @@ process
     my $infile = $file;
     $infile =~ s/\.in$//;
 
-    # Some FIPS generated files end up elsewhere :(
-    $infile = $file
-        if ! -f $infile && $file =~ m@providers/common/der/@;
-
     my $IN;
     if ( !open($IN, '<', $infile) ) {
         err("Can't open $infile, $!");
@@ -53,6 +49,7 @@ process
             err($infile, "use quotes for include", $included)
                 if $included =~ m@crypto/@
                     || $included =~ m@internal/@
+                    || $included =~ m@provider/@
                     || $included =~ m@prov/@;
         } elsif ( $quotes eq '"' ) {
             err($infile, "Use <> for include", $included)

--- a/util/find-include-nits
+++ b/util/find-include-nits
@@ -1,0 +1,82 @@
+#! /usr/bin/env perl
+# Copyright 2021 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+# Run this program like this:
+#       perl util/find-include-nits [files...]
+#
+# If given no arguments, will open a pipe to 'git ls-files'
+
+use strict;
+use warnings;
+
+my $status = 0;
+
+# Print error message, set $status.
+sub err {
+    print join(" ", @_), "\n";
+    $status = 1
+}
+
+sub
+process
+{
+    my $file = shift;
+
+    # If it's foo.in, reach foo
+    my $infile = $file;
+    $infile =~ s/\.in$//;
+
+    # Some FIPS generated files end up elsewhere :(
+    $infile = $file
+        if ! -f $infile && $file =~ m@providers/common/der/@;
+
+    my $IN;
+    if ( !open($IN, '<', $infile) ) {
+        err("Can't open $infile, $!");
+        return;
+    }
+
+    while ( <$IN> ) {
+        chomp;
+        next unless /^#\s*include(\s+)(["<])([^">]+)/;
+        my $spaces = $1;
+        my $quotes = $2;
+        my $included = $3;
+        err($infile, "excess spaces after include")
+            if $spaces =~ /  /;
+        if ( $quotes eq '<' ) {
+            err($infile, "use quotes for include", $included)
+                if $included =~ m@crypto/@
+                    || $included =~ m@internal/@
+                    || $included =~ m@prov/@;
+        } elsif ( $quotes eq '"' ) {
+            err($infile, "Use <> for include", $included)
+                if $included =~ m@openssl/@;
+        }
+    }
+
+    close $IN;
+}
+
+## MAIN
+
+if ( @ARGV ) {
+    foreach my $f ( @ARGV ) {
+        process($f);
+    }
+} else {
+    open my $PIPE, "git ls-files|" or die "Can't open git, $!";
+
+    while ( <$PIPE> ) {
+        chomp;
+        next unless /\.[ch]$/ or /\.[ch]\.in$/;
+        process($_);
+    }
+}
+
+exit $status;


### PR DESCRIPTION
This is a new perl script to find nits about `#include` statements.  Mainly errors in `"` and `<>`.
