### PR TITLE
update solaris64-sparcv9-cc build target cflags, fixes #15507

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -373,7 +373,7 @@ my %targets = (
     },
     "solaris64-sparcv9-cc" => {
         inherit_from     => [ "solaris-sparcv7-cc" ],
-        cflags           => add_before("-xarch=v9"),
+        cflags           => add_before("-m64 -xarch=sparc"),
         bn_ops           => "BN_LLONG RC4_CHAR",
         asm_arch         => 'sparcv9',
         perlasm_scheme   => 'void',


### PR DESCRIPTION
the impact of the change should be only a significantly smaller number of warnings in the solaris64 sparc build logs.