### PR TITLE
Pass a required strength argument to RNG calls

### DIFF
--- a/crypto/asn1/asn_mime.c
+++ b/crypto/asn1/asn_mime.c
@@ -251,7 +251,7 @@ int SMIME_write_ASN1_ex(BIO *bio, ASN1_VALUE *val, BIO *data, int flags,
     if ((flags & SMIME_DETACHED) && data) {
         /* We want multipart/signed */
         /* Generate a random boundary */
-        if (RAND_bytes_ex(libctx, (unsigned char *)bound, 32) <= 0)
+        if (RAND_bytes_ex(libctx, (unsigned char *)bound, 32, 0) <= 0)
             return 0;
         for (i = 0; i < 32; i++) {
             c = bound[i] & 0xf;

--- a/crypto/asn1/p5_pbe.c
+++ b/crypto/asn1/p5_pbe.c
@@ -55,7 +55,7 @@ int PKCS5_pbe_set0_algor_ex(X509_ALGOR *algor, int alg, int iter,
     }
     if (salt)
         memcpy(sstr, salt, saltlen);
-    else if (RAND_bytes_ex(ctx, sstr, saltlen) <= 0)
+    else if (RAND_bytes_ex(ctx, sstr, saltlen, 0) <= 0)
         goto err;
 
     ASN1_STRING_set0(pbe->salt, sstr, saltlen);

--- a/crypto/asn1/p5_pbev2.c
+++ b/crypto/asn1/p5_pbev2.c
@@ -69,7 +69,8 @@ X509_ALGOR *PKCS5_pbe2_set_iv_ex(const EVP_CIPHER *cipher, int iter,
     if (EVP_CIPHER_iv_length(cipher)) {
         if (aiv)
             memcpy(iv, aiv, EVP_CIPHER_iv_length(cipher));
-        else if (RAND_bytes_ex(libctx, iv, EVP_CIPHER_iv_length(cipher)) <= 0)
+        else if (RAND_bytes_ex(libctx, iv, EVP_CIPHER_iv_length(cipher),
+                               0) <= 0)
             goto err;
     }
 
@@ -187,7 +188,7 @@ X509_ALGOR *PKCS5_pbkdf2_set_ex(int iter, unsigned char *salt, int saltlen,
 
     if (salt)
         memcpy(osalt->data, salt, saltlen);
-    else if (RAND_bytes_ex(libctx, osalt->data, saltlen) <= 0)
+    else if (RAND_bytes_ex(libctx, osalt->data, saltlen, 0) <= 0)
         goto merr;
 
     if (iter <= 0)

--- a/crypto/bn/bn_blind.c
+++ b/crypto/bn/bn_blind.c
@@ -270,7 +270,7 @@ BN_BLINDING *BN_BLINDING_create_param(BN_BLINDING *b,
 
     do {
         int rv;
-        if (!BN_priv_rand_range_ex(ret->A, ret->mod, ctx))
+        if (!BN_priv_rand_range_ex(ret->A, ret->mod, 0, ctx))
             goto err;
         if (int_bn_mod_inverse(ret->Ai, ret->A, ret->mod, ctx, &rv))
             break;

--- a/crypto/bn/bn_gf2m.c
+++ b/crypto/bn/bn_gf2m.c
@@ -742,7 +742,7 @@ int BN_GF2m_mod_inv(BIGNUM *r, const BIGNUM *a, const BIGNUM *p, BN_CTX *ctx)
     /* generate blinding value */
     do {
         if (!BN_priv_rand_ex(b, BN_num_bits(p) - 1,
-                             BN_RAND_TOP_ANY, BN_RAND_BOTTOM_ANY, ctx))
+                             BN_RAND_TOP_ANY, BN_RAND_BOTTOM_ANY, 0, ctx))
             goto err;
     } while (BN_is_zero(b));
 
@@ -1051,7 +1051,7 @@ int BN_GF2m_mod_solve_quad_arr(BIGNUM *r, const BIGNUM *a_, const int p[],
             goto err;
         do {
             if (!BN_priv_rand_ex(rho, p[0], BN_RAND_TOP_ONE, BN_RAND_BOTTOM_ANY,
-                                 ctx))
+                                 0, ctx))
                 goto err;
             if (!BN_GF2m_mod_arr(rho, rho, p))
                 goto err;

--- a/crypto/bn/bn_prime.c
+++ b/crypto/bn/bn_prime.c
@@ -386,7 +386,7 @@ int ossl_bn_miller_rabin_is_prime(const BIGNUM *w, int iterations, BN_CTX *ctx,
     /* (Step 4) */
     for (i = 0; i < iterations; ++i) {
         /* (Step 4.1) obtain a Random string of bits b where 1 < b < w-1 */
-        if (!BN_priv_rand_range_ex(b, w3, ctx)
+        if (!BN_priv_rand_range_ex(b, w3, 0, ctx)
                 || !BN_add_word(b, 2)) /* 1 < b < w-1 */
             goto err;
 
@@ -484,7 +484,8 @@ static int probable_prime(BIGNUM *rnd, int bits, int safe, prime_t *mods,
 
  again:
     /* TODO: Not all primes are private */
-    if (!BN_priv_rand_ex(rnd, bits, BN_RAND_TOP_TWO, BN_RAND_BOTTOM_ODD, ctx))
+    if (!BN_priv_rand_ex(rnd, bits, BN_RAND_TOP_TWO, BN_RAND_BOTTOM_ODD, 0,
+                         ctx))
         return 0;
     if (safe && !BN_set_bit(rnd, 1))
         return 0;
@@ -550,7 +551,7 @@ static int probable_prime_dh(BIGNUM *rnd, int bits, int safe, prime_t *mods,
         maxdelta = BN_MASK2 - BN_get_word(add);
 
  again:
-    if (!BN_rand_ex(rnd, bits, BN_RAND_TOP_ONE, BN_RAND_BOTTOM_ODD, ctx))
+    if (!BN_rand_ex(rnd, bits, BN_RAND_TOP_ONE, BN_RAND_BOTTOM_ODD, 0, ctx))
         goto err;
 
     /* we need ((rnd-rem) % add) == 0 */

--- a/crypto/bn/bn_rsa_fips186_4.c
+++ b/crypto/bn/bn_rsa_fips186_4.c
@@ -178,14 +178,14 @@ int ossl_bn_rsa_fips186_4_gen_prob_primes(BIGNUM *p, BIGNUM *Xpout,
     if (Xp1 == NULL) {
         /* Set the top and bottom bits to make it odd and the correct size */
         if (!BN_priv_rand_ex(Xp1i, bitlen, BN_RAND_TOP_ONE, BN_RAND_BOTTOM_ODD,
-                             ctx))
+                             0, ctx))
             goto err;
     }
     /* (Steps 4.1/5.1): Randomly generate Xp2 if it is not passed in */
     if (Xp2 == NULL) {
         /* Set the top and bottom bits to make it odd and the correct size */
         if (!BN_priv_rand_ex(Xp2i, bitlen, BN_RAND_TOP_ONE, BN_RAND_BOTTOM_ODD,
-                             ctx))
+                             0, ctx))
             goto err;
     }
 
@@ -306,7 +306,7 @@ int ossl_bn_rsa_fips186_4_derive_prime(BIGNUM *Y, BIGNUM *X, const BIGNUM *Xin,
              * (Step 3) Choose Random X such that
              *    sqrt(2) * 2^(nlen/2-1) <= Random X <= (2^(nlen/2)) - 1.
              */
-            if (!BN_priv_rand_range_ex(X, range, ctx) || !BN_add(X, X, base))
+            if (!BN_priv_rand_range_ex(X, range, 0, ctx) || !BN_add(X, X, base))
                 goto end;
         }
         /* (Step 4) Y = X + ((R - X) mod 2r1r2) */

--- a/crypto/bn/bn_sqrt.c
+++ b/crypto/bn/bn_sqrt.c
@@ -182,7 +182,7 @@ BIGNUM *BN_mod_sqrt(BIGNUM *in, const BIGNUM *a, const BIGNUM *p, BN_CTX *ctx)
             if (!BN_set_word(y, i))
                 goto end;
         } else {
-            if (!BN_priv_rand_ex(y, BN_num_bits(p), 0, 0, ctx))
+            if (!BN_priv_rand_ex(y, BN_num_bits(p), 0, 0, 0, ctx))
                 goto end;
             if (BN_ucmp(y, p) >= 0) {
                 if (!(p->neg ? BN_add : BN_sub) (y, y, p))

--- a/crypto/bn/bn_x931p.c
+++ b/crypto/bn/bn_x931p.c
@@ -175,7 +175,8 @@ int BN_X931_generate_Xpq(BIGNUM *Xp, BIGNUM *Xq, int nbits, BN_CTX *ctx)
      * - 1. By setting the top two bits we ensure that the lower bound is
      * exceeded.
      */
-    if (!BN_priv_rand_ex(Xp, nbits, BN_RAND_TOP_TWO, BN_RAND_BOTTOM_ANY, ctx))
+    if (!BN_priv_rand_ex(Xp, nbits, BN_RAND_TOP_TWO, BN_RAND_BOTTOM_ANY, 0,
+                         ctx))
         return 0;
 
     BN_CTX_start(ctx);
@@ -184,7 +185,7 @@ int BN_X931_generate_Xpq(BIGNUM *Xp, BIGNUM *Xq, int nbits, BN_CTX *ctx)
         goto err;
 
     for (i = 0; i < 1000; i++) {
-        if (!BN_priv_rand_ex(Xq, nbits, BN_RAND_TOP_TWO, BN_RAND_BOTTOM_ANY,
+        if (!BN_priv_rand_ex(Xq, nbits, BN_RAND_TOP_TWO, BN_RAND_BOTTOM_ANY, 0,
                              ctx))
             goto err;
 
@@ -230,9 +231,9 @@ int BN_X931_generate_prime_ex(BIGNUM *p, BIGNUM *p1, BIGNUM *p2,
     if (Xp1 == NULL || Xp2 == NULL)
         goto error;
 
-    if (!BN_priv_rand_ex(Xp1, 101, BN_RAND_TOP_ONE, BN_RAND_BOTTOM_ANY, ctx))
+    if (!BN_priv_rand_ex(Xp1, 101, BN_RAND_TOP_ONE, BN_RAND_BOTTOM_ANY, 0, ctx))
         goto error;
-    if (!BN_priv_rand_ex(Xp2, 101, BN_RAND_TOP_ONE, BN_RAND_BOTTOM_ANY, ctx))
+    if (!BN_priv_rand_ex(Xp2, 101, BN_RAND_TOP_ONE, BN_RAND_BOTTOM_ANY, 0, ctx))
         goto error;
     if (!BN_X931_derive_prime_ex(p, p1, p2, Xp, Xp1, Xp2, e, ctx, cb))
         goto error;

--- a/crypto/cmp/cmp_hdr.c
+++ b/crypto/cmp/cmp_hdr.c
@@ -142,7 +142,7 @@ static int set_random(ASN1_OCTET_STRING **tgt, OSSL_CMP_CTX *ctx, size_t len)
     unsigned char *bytes = OPENSSL_malloc(len);
     int res = 0;
 
-    if (bytes == NULL || RAND_bytes_ex(ctx->libctx, bytes, len) <= 0)
+    if (bytes == NULL || RAND_bytes_ex(ctx->libctx, bytes, len, 0) <= 0)
         ERR_raise(ERR_LIB_CMP, CMP_R_FAILURE_OBTAINING_RANDOM);
     else
         res = ossl_cmp_asn1_octet_string_set1_bytes(tgt, bytes, len);

--- a/crypto/cms/cms_enc.c
+++ b/crypto/cms/cms_enc.c
@@ -83,7 +83,7 @@ BIO *ossl_cms_EncryptedContent_init_bio(CMS_EncryptedContentInfo *ec,
         /* Generate a random IV if we need one */
         ivlen = EVP_CIPHER_CTX_iv_length(ctx);
         if (ivlen > 0) {
-            if (RAND_bytes_ex(libctx, iv, ivlen) <= 0)
+            if (RAND_bytes_ex(libctx, iv, ivlen, 0) <= 0)
                 goto err;
             piv = iv;
         }

--- a/crypto/cms/cms_ess.c
+++ b/crypto/cms/cms_ess.c
@@ -128,7 +128,8 @@ CMS_ReceiptRequest *CMS_ReceiptRequest_create0_ex(
     else {
         if (!ASN1_STRING_set(rr->signedContentIdentifier, NULL, 32))
             goto merr;
-        if (RAND_bytes_ex(libctx, rr->signedContentIdentifier->data, 32) <= 0)
+        if (RAND_bytes_ex(libctx, rr->signedContentIdentifier->data, 32,
+                          0) <= 0)
             goto err;
     }
 

--- a/crypto/cms/cms_pwri.c
+++ b/crypto/cms/cms_pwri.c
@@ -94,7 +94,7 @@ CMS_RecipientInfo *CMS_add0_recipient_password(CMS_ContentInfo *cms,
     ivlen = EVP_CIPHER_CTX_iv_length(ctx);
 
     if (ivlen > 0) {
-        if (RAND_bytes_ex(ossl_cms_ctx_get0_libctx(cms_ctx), iv, ivlen) <= 0)
+        if (RAND_bytes_ex(ossl_cms_ctx_get0_libctx(cms_ctx), iv, ivlen, 0) <= 0)
             goto err;
         if (EVP_EncryptInit_ex(ctx, NULL, NULL, NULL, iv) <= 0) {
             ERR_raise(ERR_LIB_CMS, ERR_R_EVP_LIB);
@@ -264,7 +264,7 @@ static int kek_wrap_key(unsigned char *out, size_t *outlen,
         /* Add random padding to end */
         if (olen > inlen + 4
             && RAND_bytes_ex(ossl_cms_ctx_get0_libctx(cms_ctx), out + 4 + inlen,
-                             olen - 4 - inlen) <= 0)
+                             olen - 4 - inlen, 0) <= 0)
             return 0;
         /* Encrypt twice */
         if (!EVP_EncryptUpdate(ctx, out, &dummy, out, olen)

--- a/crypto/crmf/crmf_pbm.c
+++ b/crypto/crmf/crmf_pbm.c
@@ -55,7 +55,7 @@ OSSL_CRMF_PBMPARAMETER *OSSL_CRMF_pbmp_new(OSSL_LIB_CTX *libctx, size_t slen,
      */
     if ((salt = OPENSSL_malloc(slen)) == NULL)
         goto err;
-    if (RAND_bytes_ex(libctx, salt, (int)slen) <= 0) {
+    if (RAND_bytes_ex(libctx, salt, (int)slen, 0) <= 0) {
         ERR_raise(ERR_LIB_CRMF, CRMF_R_FAILURE_OBTAINING_RANDOM);
         goto err;
     }

--- a/crypto/dh/dh_key.c
+++ b/crypto/dh/dh_key.c
@@ -318,7 +318,7 @@ static int generate_key(DH *dh)
                     goto err;
                 l = dh->length ? dh->length : BN_num_bits(dh->params.p) - 1;
                 if (!BN_priv_rand_ex(priv_key, l, BN_RAND_TOP_ONE,
-                                     BN_RAND_BOTTOM_ANY, ctx))
+                                     BN_RAND_BOTTOM_ANY, 0, ctx))
                     goto err;
                 /*
                  * We handle just one known case where g is a quadratic non-residue:

--- a/crypto/dsa/dsa_ossl.c
+++ b/crypto/dsa/dsa_ossl.c
@@ -132,7 +132,7 @@ DSA_SIG *ossl_dsa_do_sign_int(const unsigned char *dgst, int dlen, DSA *dsa)
     /* Generate a blinding value */
     do {
         if (!BN_priv_rand_ex(blind, BN_num_bits(dsa->params.q) - 1,
-                             BN_RAND_TOP_ANY, BN_RAND_BOTTOM_ANY, ctx))
+                             BN_RAND_TOP_ANY, BN_RAND_BOTTOM_ANY, 0, ctx))
             goto err;
     } while (BN_is_zero(blind));
     BN_set_flags(blind, BN_FLG_CONSTTIME);
@@ -250,7 +250,7 @@ static int dsa_sign_setup(DSA *dsa, BN_CTX *ctx_in,
             if (!BN_generate_dsa_nonce(k, dsa->params.q, dsa->priv_key, dgst,
                                        dlen, ctx))
                 goto err;
-        } else if (!BN_priv_rand_range_ex(k, dsa->params.q, ctx))
+        } else if (!BN_priv_rand_range_ex(k, dsa->params.q, 0, ctx))
             goto err;
     } while (BN_is_zero(k));
 

--- a/crypto/ec/ec2_smpl.c
+++ b/crypto/ec/ec2_smpl.c
@@ -730,7 +730,7 @@ int ec_GF2m_simple_ladder_pre(const EC_GROUP *group,
     /* s blinding: make sure lambda (s->Z here) is not zero */
     do {
         if (!BN_priv_rand_ex(s->Z, BN_num_bits(group->field) - 1,
-                             BN_RAND_TOP_ANY, BN_RAND_BOTTOM_ANY, ctx)) {
+                             BN_RAND_TOP_ANY, BN_RAND_BOTTOM_ANY, 0, ctx)) {
             ERR_raise(ERR_LIB_EC, ERR_R_BN_LIB);
             return 0;
         }
@@ -745,7 +745,7 @@ int ec_GF2m_simple_ladder_pre(const EC_GROUP *group,
     /* r blinding: make sure lambda (r->Y here for storage) is not zero */
     do {
         if (!BN_priv_rand_ex(r->Y, BN_num_bits(group->field) - 1,
-                             BN_RAND_TOP_ANY, BN_RAND_BOTTOM_ANY, ctx)) {
+                             BN_RAND_TOP_ANY, BN_RAND_BOTTOM_ANY, 0, ctx)) {
             ERR_raise(ERR_LIB_EC, ERR_R_BN_LIB);
             return 0;
         }

--- a/crypto/ec/ec_key.c
+++ b/crypto/ec/ec_key.c
@@ -298,7 +298,7 @@ static int ec_generate_key(EC_KEY *eckey, int pairwise_test)
     }
 
     do
-        if (!BN_priv_rand_range_ex(priv_key, order, ctx))
+        if (!BN_priv_rand_range_ex(priv_key, order, 0, ctx))
             goto err;
     while (BN_is_zero(priv_key)) ;
 

--- a/crypto/ec/ecdsa_ossl.c
+++ b/crypto/ec/ecdsa_ossl.c
@@ -135,7 +135,7 @@ static int ecdsa_sign_setup(EC_KEY *eckey, BN_CTX *ctx_in,
                     goto err;
                 }
             } else {
-                if (!BN_priv_rand_range_ex(k, order, ctx)) {
+                if (!BN_priv_rand_range_ex(k, order, 0, ctx)) {
                     ERR_raise(ERR_LIB_EC, EC_R_RANDOM_NUMBER_GENERATION_FAILED);
                     goto err;
                 }

--- a/crypto/ec/ecp_s390x_nistp.c
+++ b/crypto/ec/ecp_s390x_nistp.c
@@ -180,7 +180,7 @@ static ECDSA_SIG *ecdsa_s390x_nistp_sign_sig(const unsigned char *dgst,
          * internally implementing counter-measures for RNG weakness.
          */
          if (RAND_priv_bytes_ex(eckey->libctx, param + S390X_OFF_RN(len),
-                                len) != 1) {
+                                len, 0) != 1) {
              ERR_raise(ERR_LIB_EC, EC_R_RANDOM_NUMBER_GENERATION_FAILED);
              goto ret;
          }

--- a/crypto/ec/ecp_smpl.c
+++ b/crypto/ec/ecp_smpl.c
@@ -1396,7 +1396,7 @@ int ossl_ec_GFp_simple_field_inv(const EC_GROUP *group, BIGNUM *r,
         goto err;
 
     do {
-        if (!BN_priv_rand_range_ex(e, group->field, ctx))
+        if (!BN_priv_rand_range_ex(e, group->field, 0, ctx))
         goto err;
     } while (BN_is_zero(e));
 
@@ -1449,7 +1449,7 @@ int ossl_ec_GFp_simple_blind_coordinates(const EC_GROUP *group, EC_POINT *p,
      */
     do {
         ERR_set_mark();
-        ret = BN_priv_rand_range_ex(lambda, group->field, ctx);
+        ret = BN_priv_rand_range_ex(lambda, group->field, 0, ctx);
         ERR_pop_to_mark();
         if (ret == 0) {
             ret = 1;
@@ -1519,13 +1519,13 @@ int ossl_ec_GFp_simple_ladder_pre(const EC_GROUP *group,
 
     /* make sure lambda (r->Y here for storage) is not zero */
     do {
-        if (!BN_priv_rand_range_ex(r->Y, group->field, ctx))
+        if (!BN_priv_rand_range_ex(r->Y, group->field, 0, ctx))
             return 0;
     } while (BN_is_zero(r->Y));
 
     /* make sure lambda (s->Z here for storage) is not zero */
     do {
-        if (!BN_priv_rand_range_ex(s->Z, group->field, ctx))
+        if (!BN_priv_rand_range_ex(s->Z, group->field, 0, ctx))
             return 0;
     } while (BN_is_zero(s->Z));
 

--- a/crypto/ec/ecx_backend.c
+++ b/crypto/ec/ecx_backend.c
@@ -187,7 +187,7 @@ ECX_KEY *ossl_ecx_key_op(const X509_ALGOR *palg,
         }
         if (op == KEY_OP_KEYGEN) {
             if (id != EVP_PKEY_NONE) {
-                if (RAND_priv_bytes_ex(libctx, privkey, KEYLENID(id)) <= 0)
+                if (RAND_priv_bytes_ex(libctx, privkey, KEYLENID(id), 0) <= 0)
                     goto err;
                 if (id == EVP_PKEY_X25519) {
                     privkey[0] &= 248;

--- a/crypto/ec/ecx_meth.c
+++ b/crypto/ec/ecx_meth.c
@@ -937,7 +937,7 @@ static int s390x_pkey_ecx_keygen25519(EVP_PKEY_CTX *ctx, EVP_PKEY *pkey)
         goto err;
     }
 
-    if (RAND_priv_bytes_ex(ctx->libctx, privkey, X25519_KEYLEN) <= 0)
+    if (RAND_priv_bytes_ex(ctx->libctx, privkey, X25519_KEYLEN, 0) <= 0)
         goto err;
 
     privkey[0] &= 248;
@@ -980,7 +980,7 @@ static int s390x_pkey_ecx_keygen448(EVP_PKEY_CTX *ctx, EVP_PKEY *pkey)
         goto err;
     }
 
-    if (RAND_priv_bytes_ex(ctx->libctx, privkey, X448_KEYLEN) <= 0)
+    if (RAND_priv_bytes_ex(ctx->libctx, privkey, X448_KEYLEN, 0) <= 0)
         goto err;
 
     privkey[0] &= 252;
@@ -1029,7 +1029,7 @@ static int s390x_pkey_ecd_keygen25519(EVP_PKEY_CTX *ctx, EVP_PKEY *pkey)
         goto err;
     }
 
-    if (RAND_priv_bytes_ex(ctx->libctx, privkey, ED25519_KEYLEN) <= 0)
+    if (RAND_priv_bytes_ex(ctx->libctx, privkey, ED25519_KEYLEN, 0) <= 0)
         goto err;
 
     md = EVP_MD_fetch(ctx->libctx, "SHA512", ctx->propquery);
@@ -1095,7 +1095,7 @@ static int s390x_pkey_ecd_keygen448(EVP_PKEY_CTX *ctx, EVP_PKEY *pkey)
         goto err;
     }
 
-    if (RAND_priv_bytes_ex(ctx->libctx, privkey, ED448_KEYLEN) <= 0)
+    if (RAND_priv_bytes_ex(ctx->libctx, privkey, ED448_KEYLEN, 0) <= 0)
         goto err;
 
     hashctx = EVP_MD_CTX_new();

--- a/crypto/evp/evp_enc.c
+++ b/crypto/evp/evp_enc.c
@@ -1326,7 +1326,7 @@ int EVP_CIPHER_CTX_rand_key(EVP_CIPHER_CTX *ctx, unsigned char *key)
         OSSL_LIB_CTX *libctx = EVP_CIPHER_CTX_get_libctx(ctx);
 
         kl = EVP_CIPHER_CTX_key_length(ctx);
-        if (kl <= 0 || RAND_priv_bytes_ex(libctx, key, kl) <= 0)
+        if (kl <= 0 || RAND_priv_bytes_ex(libctx, key, kl, 0) <= 0)
             return 0;
         return 1;
     }

--- a/crypto/evp/p_seal.c
+++ b/crypto/evp/p_seal.c
@@ -44,7 +44,7 @@ int EVP_SealInit(EVP_CIPHER_CTX *ctx, const EVP_CIPHER *type,
         return 0;
 
     len = EVP_CIPHER_CTX_iv_length(ctx);
-    if (len < 0 || RAND_priv_bytes_ex(libctx, iv, len) <= 0)
+    if (len < 0 || RAND_priv_bytes_ex(libctx, iv, len, 0) <= 0)
         goto err;
 
     len = EVP_CIPHER_CTX_key_length(ctx);

--- a/crypto/ffc/ffc_key_generate.c
+++ b/crypto/ffc/ffc_key_generate.c
@@ -45,7 +45,7 @@ int ossl_ffc_generate_private_key(BN_CTX *ctx, const FFC_PARAMS *params,
 
     do {
         /* Steps (3, 4 & 7) :  c + 1 = 1 + random[0..2^N - 1] */
-        if (!BN_priv_rand_range_ex(priv, two_powN, ctx)
+        if (!BN_priv_rand_range_ex(priv, two_powN, 0, ctx)
             || !BN_add_word(priv, 1))
             goto err;
         /* Step (6) : loop if c > M - 2 (i.e. c + 1 >= M) */

--- a/crypto/ffc/ffc_params_generate.c
+++ b/crypto/ffc/ffc_params_generate.c
@@ -329,7 +329,7 @@ static int generate_q_fips186_4(BN_CTX *ctx, BIGNUM *q, const EVP_MD *evpmd,
 
         /* A.1.1.2 Step (5) : generate seed with size seed_len */
         if (generate_seed
-                && RAND_bytes_ex(libctx, seed, (int)seedlen) < 0)
+                && RAND_bytes_ex(libctx, seed, (int)seedlen, 0) < 0)
             goto err;
         /*
          * A.1.1.2 Step (6) AND
@@ -399,7 +399,7 @@ static int generate_q_fips186_2(BN_CTX *ctx, BIGNUM *q, const EVP_MD *evpmd,
         if (!BN_GENCB_call(cb, 0, m++))
             goto err;
 
-        if (generate_seed && RAND_bytes_ex(libctx, seed, (int)qsize) <= 0)
+        if (generate_seed && RAND_bytes_ex(libctx, seed, (int)qsize, 0) <= 0)
             goto err;
 
         memcpy(buf, seed, qsize);

--- a/crypto/pkcs12/p12_mutl.c
+++ b/crypto/pkcs12/p12_mutl.c
@@ -260,7 +260,7 @@ int PKCS12_setup_mac(PKCS12 *p12, int iter, unsigned char *salt, int saltlen,
     p12->mac->salt->length = saltlen;
     if (!salt) {
         if (RAND_bytes_ex(p12->authsafes->ctx.libctx, p12->mac->salt->data,
-                          saltlen) <= 0)
+                          saltlen, 0) <= 0)
             return 0;
     } else
         memcpy(p12->mac->salt->data, salt, saltlen);

--- a/crypto/pkcs7/pk7_doit.c
+++ b/crypto/pkcs7/pk7_doit.c
@@ -300,7 +300,7 @@ BIO *PKCS7_dataInit(PKCS7 *p7, BIO *bio)
         ivlen = EVP_CIPHER_iv_length(evp_cipher);
         xalg->algorithm = OBJ_nid2obj(EVP_CIPHER_type(evp_cipher));
         if (ivlen > 0)
-            if (RAND_bytes_ex(libctx, iv, ivlen) <= 0)
+            if (RAND_bytes_ex(libctx, iv, ivlen, 0) <= 0)
                 goto err;
 
         (void)ERR_set_mark();

--- a/crypto/rand/rand_lib.c
+++ b/crypto/rand/rand_lib.c
@@ -315,7 +315,8 @@ const RAND_METHOD *RAND_get_rand_method(void)
  * the default method, then just call RAND_bytes().  Otherwise make
  * sure we're instantiated and use the private DRBG.
  */
-int RAND_priv_bytes_ex(OSSL_LIB_CTX *ctx, unsigned char *buf, int num)
+int RAND_priv_bytes_ex(OSSL_LIB_CTX *ctx, unsigned char *buf, int num,
+                       unsigned int strength)
 {
     EVP_RAND_CTX *rand;
 #ifndef OPENSSL_NO_DEPRECATED_3_0
@@ -331,17 +332,18 @@ int RAND_priv_bytes_ex(OSSL_LIB_CTX *ctx, unsigned char *buf, int num)
 
     rand = RAND_get0_private(ctx);
     if (rand != NULL)
-        return EVP_RAND_generate(rand, buf, num, 0, 0, NULL, 0);
+        return EVP_RAND_generate(rand, buf, num, strength, 0, NULL, 0);
 
     return 0;
 }
 
 int RAND_priv_bytes(unsigned char *buf, int num)
 {
-    return RAND_priv_bytes_ex(NULL, buf, num);
+    return RAND_priv_bytes_ex(NULL, buf, num, 0);
 }
 
-int RAND_bytes_ex(OSSL_LIB_CTX *ctx, unsigned char *buf, int num)
+int RAND_bytes_ex(OSSL_LIB_CTX *ctx, unsigned char *buf, int num,
+                  unsigned int strength)
 {
     EVP_RAND_CTX *rand;
 #ifndef OPENSSL_NO_DEPRECATED_3_0
@@ -357,14 +359,14 @@ int RAND_bytes_ex(OSSL_LIB_CTX *ctx, unsigned char *buf, int num)
 
     rand = RAND_get0_public(ctx);
     if (rand != NULL)
-        return EVP_RAND_generate(rand, buf, num, 0, 0, NULL, 0);
+        return EVP_RAND_generate(rand, buf, num, strength, 0, NULL, 0);
 
     return 0;
 }
 
 int RAND_bytes(unsigned char *buf, int num)
 {
-    return RAND_bytes_ex(NULL, buf, num);
+    return RAND_bytes_ex(NULL, buf, num, 0);
 }
 
 typedef struct rand_global_st {

--- a/crypto/rsa/rsa_oaep.c
+++ b/crypto/rsa/rsa_oaep.c
@@ -103,7 +103,7 @@ int ossl_rsa_padding_add_PKCS1_OAEP_mgf1_ex(OSSL_LIB_CTX *libctx,
     db[emlen - flen - mdlen - 1] = 0x01;
     memcpy(db + emlen - flen - mdlen, from, (unsigned int)flen);
     /* step 3d: generate random byte string */
-    if (RAND_bytes_ex(libctx, seed, mdlen) <= 0)
+    if (RAND_bytes_ex(libctx, seed, mdlen, 0) <= 0)
         goto err;
 
     dbmask_len = emlen - mdlen;

--- a/crypto/rsa/rsa_pk1.c
+++ b/crypto/rsa/rsa_pk1.c
@@ -138,12 +138,12 @@ int ossl_rsa_padding_add_PKCS1_type_2_ex(OSSL_LIB_CTX *libctx, unsigned char *to
     /* pad out with non-zero random data */
     j = tlen - 3 - flen;
 
-    if (RAND_bytes_ex(libctx, p, j) <= 0)
+    if (RAND_bytes_ex(libctx, p, j, 0) <= 0)
         return 0;
     for (i = 0; i < j; i++) {
         if (*p == '\0')
             do {
-                if (RAND_bytes_ex(libctx, p, 1) <= 0)
+                if (RAND_bytes_ex(libctx, p, 1, 0) <= 0)
                     return 0;
             } while (*p == '\0');
         p++;
@@ -315,7 +315,7 @@ int ossl_rsa_padding_check_PKCS1_type_2_TLS(OSSL_LIB_CTX *libctx,
      * to decrypt.
      */
     if (RAND_priv_bytes_ex(libctx, rand_premaster_secret,
-                           sizeof(rand_premaster_secret)) <= 0) {
+                           sizeof(rand_premaster_secret), 0) <= 0) {
         ERR_raise(ERR_LIB_RSA, ERR_R_INTERNAL_ERROR);
         return -1;
     }

--- a/crypto/rsa/rsa_pss.c
+++ b/crypto/rsa/rsa_pss.c
@@ -205,7 +205,7 @@ int RSA_padding_add_PKCS1_PSS_mgf1(RSA *rsa, unsigned char *EM,
             ERR_raise(ERR_LIB_RSA, ERR_R_MALLOC_FAILURE);
             goto err;
         }
-        if (RAND_bytes_ex(rsa->libctx, salt, sLen) <= 0)
+        if (RAND_bytes_ex(rsa->libctx, salt, sLen, 0) <= 0)
             goto err;
     }
     maskedDBLen = emLen - hLen - 1;

--- a/crypto/sm2/sm2_crypt.c
+++ b/crypto/sm2/sm2_crypt.c
@@ -187,7 +187,7 @@ int ossl_sm2_encrypt(const EC_KEY *key,
 
     memset(ciphertext_buf, 0, *ciphertext_len);
 
-    if (!BN_priv_rand_range_ex(k, order, ctx)) {
+    if (!BN_priv_rand_range_ex(k, order, 0, ctx)) {
         ERR_raise(ERR_LIB_SM2, ERR_R_INTERNAL_ERROR);
         goto done;
     }

--- a/crypto/sm2/sm2_sign.c
+++ b/crypto/sm2/sm2_sign.c
@@ -240,7 +240,7 @@ static ECDSA_SIG *sm2_sig_gen(const EC_KEY *key, const BIGNUM *e)
     }
 
     for (;;) {
-        if (!BN_priv_rand_range_ex(k, order, ctx)) {
+        if (!BN_priv_rand_range_ex(k, order, 0, ctx)) {
             ERR_raise(ERR_LIB_SM2, ERR_R_INTERNAL_ERROR);
             goto done;
         }

--- a/crypto/srp/srp_vfy.c
+++ b/crypto/srp/srp_vfy.c
@@ -645,7 +645,7 @@ char *SRP_create_verifier_ex(const char *user, const char *pass, char **salt,
     }
 
     if (*salt == NULL) {
-        if (RAND_bytes_ex(libctx, tmp2, SRP_RANDOM_SALT_LEN) <= 0)
+        if (RAND_bytes_ex(libctx, tmp2, SRP_RANDOM_SALT_LEN, 0) <= 0)
             goto err;
 
         s = BN_bin2bn(tmp2, SRP_RANDOM_SALT_LEN, NULL);
@@ -728,7 +728,7 @@ int SRP_create_verifier_BN_ex(const char *user, const char *pass, BIGNUM **salt,
         goto err;
 
     if (*salt == NULL) {
-        if (RAND_bytes_ex(libctx, tmp2, SRP_RANDOM_SALT_LEN) <= 0)
+        if (RAND_bytes_ex(libctx, tmp2, SRP_RANDOM_SALT_LEN, 0) <= 0)
             goto err;
 
         salttmp = BN_bin2bn(tmp2, SRP_RANDOM_SALT_LEN, NULL);

--- a/doc/man3/BN_rand.pod
+++ b/doc/man3/BN_rand.pod
@@ -11,16 +11,20 @@ BN_pseudo_rand_range
 
  #include <openssl/bn.h>
 
- int BN_rand_ex(BIGNUM *rnd, int bits, int top, int bottom, BN_CTX *ctx);
+ int BN_rand_ex(BIGNUM *rnd, int bits, int top, int bottom,
+                unsigned int strength, BN_CTX *ctx);
  int BN_rand(BIGNUM *rnd, int bits, int top, int bottom);
 
- int BN_priv_rand_ex(BIGNUM *rnd, int bits, int top, int bottom, BN_CTX *ctx);
+ int BN_priv_rand_ex(BIGNUM *rnd, int bits, int top, int bottom,
+                     unsigned int strength, BN_CTX *ctx);
  int BN_priv_rand(BIGNUM *rnd, int bits, int top, int bottom);
 
- int BN_rand_range_ex(BIGNUM *rnd, BIGNUM *range, BN_CTX *ctx);
+ int BN_rand_range_ex(BIGNUM *rnd, BIGNUM *range, unsigned int strength,
+                      BN_CTX *ctx);
  int BN_rand_range(BIGNUM *rnd, BIGNUM *range);
 
- int BN_priv_rand_range_ex(BIGNUM *rnd, BIGNUM *range, BN_CTX *ctx);
+ int BN_priv_rand_range_ex(BIGNUM *rnd, BIGNUM *range, unsigned int strength,
+                           BN_CTX *ctx);
  int BN_priv_rand_range(BIGNUM *rnd, BIGNUM *range);
 
 Deprecated since OpenSSL 3.0, can be hidden entirely by defining
@@ -32,30 +36,32 @@ openssl_user_macros(7):
 
 =head1 DESCRIPTION
 
-BN_rand_ex() generate a cryptographically strong pseudo-random
-number of B<bits> in length and stores it in B<rnd> using the random number
-generator for the library context associated with B<ctx>. The parameter B<ctx>
+BN_rand_ex() generates a cryptographically strong pseudo-random
+number of I<bits> in length and security strength at least I<strength> bits
+using the random number generator for the library context associated with
+I<ctx>. The function stores the generated data in I<rnd>. The parameter I<ctx>
 may be NULL in which case the default library context is used.
-If B<bits> is less than zero, or too small to
-accommodate the requirements specified by the B<top> and B<bottom>
+If I<bits> is less than zero, or too small to
+accommodate the requirements specified by the I<top> and I<bottom>
 parameters, an error is returned.
-The B<top> parameters specifies
+The I<top> parameters specifies
 requirements on the most significant bit of the generated number.
 If it is B<BN_RAND_TOP_ANY>, there is no constraint.
 If it is B<BN_RAND_TOP_ONE>, the top bit must be one.
 If it is B<BN_RAND_TOP_TWO>, the two most significant bits of
 the number will be set to 1, so that the product of two such random
-numbers will always have 2*B<bits> length.
-If B<bottom> is B<BN_RAND_BOTTOM_ODD>, the number will be odd; if it
+numbers will always have 2*I<bits> length.
+If I<bottom> is B<BN_RAND_BOTTOM_ODD>, the number will be odd; if it
 is B<BN_RAND_BOTTOM_ANY> it can be odd or even.
-If B<bits> is 1 then B<top> cannot also be B<BN_RAND_FLG_TOPTWO>.
+If I<bits> is 1 then I<top> cannot also be B<BN_RAND_FLG_TOPTWO>.
 
 BN_rand() is the same as BN_rand_ex() except that the default library context
 is always used.
 
 BN_rand_range_ex() generates a cryptographically strong pseudo-random
-number B<rnd> in the range 0 E<lt>= B<rnd> E<lt> B<range> using the random number
-generator for the library context associated with B<ctx>. The parameter B<ctx>
+number I<rnd>, of security stength at least I<strength> bits,
+in the range 0 E<lt>= I<rnd> E<lt> I<range> using the random number
+generator for the library context associated with I<ctx>. The parameter I<ctx>
 may be NULL in which case the default library context is used.
 
 BN_rand_range() is the same as BN_rand_range_ex() except that the default

--- a/doc/man3/RAND_bytes.pod
+++ b/doc/man3/RAND_bytes.pod
@@ -12,8 +12,10 @@ RAND_pseudo_bytes - generate random data
  int RAND_bytes(unsigned char *buf, int num);
  int RAND_priv_bytes(unsigned char *buf, int num);
 
- int RAND_bytes_ex(OSSL_LIB_CTX *ctx, unsigned char *buf, int num);
- int RAND_priv_bytes_ex(OSSL_LIB_CTX *ctx, unsigned char *buf, int num);
+ int RAND_bytes_ex(OSSL_LIB_CTX *ctx, unsigned char *buf, int num,
+                   unsigned int strength);
+ int RAND_priv_bytes_ex(OSSL_LIB_CTX *ctx, unsigned char *buf, int num,
+                        unsigned int strength);
 
 Deprecated since OpenSSL 1.1.0, can be hidden entirely by defining
 B<OPENSSL_API_COMPAT> with a suitable version value, see
@@ -34,7 +36,9 @@ affect the secrecy of these private values, as described in L<RAND(7)>
 and L<EVP_RAND(7)>.
 
 RAND_bytes_ex() and RAND_priv_bytes_ex() are the same as RAND_bytes() and
-RAND_priv_bytes() except that they both take an additional I<ctx> parameter.
+RAND_priv_bytes() except that they both take additional I<strength> and
+I<ctx> parameters. The bytes genreated will have a security strength of at
+least I<strength> bits.
 The DRBG used for the operation is the public or private DRBG associated with
 the specified I<ctx>. The parameter can be NULL, in which case
 the default library context is used (see L<OSSL_LIB_CTX(3)>.

--- a/include/openssl/bn.h
+++ b/include/openssl/bn.h
@@ -214,13 +214,17 @@ void BN_CTX_free(BN_CTX *c);
 void BN_CTX_start(BN_CTX *ctx);
 BIGNUM *BN_CTX_get(BN_CTX *ctx);
 void BN_CTX_end(BN_CTX *ctx);
-int BN_rand_ex(BIGNUM *rnd, int bits, int top, int bottom, BN_CTX *ctx);
+int BN_rand_ex(BIGNUM *rnd, int bits, int top, int bottom,
+               unsigned int strength, BN_CTX *ctx);
 int BN_rand(BIGNUM *rnd, int bits, int top, int bottom);
-int BN_priv_rand_ex(BIGNUM *rnd, int bits, int top, int bottom, BN_CTX *ctx);
+int BN_priv_rand_ex(BIGNUM *rnd, int bits, int top, int bottom,
+                    unsigned int strength, BN_CTX *ctx);
 int BN_priv_rand(BIGNUM *rnd, int bits, int top, int bottom);
-int BN_rand_range_ex(BIGNUM *r, const BIGNUM *range, BN_CTX *ctx);
+int BN_rand_range_ex(BIGNUM *r, const BIGNUM *range, unsigned int strength,
+                     BN_CTX *ctx);
 int BN_rand_range(BIGNUM *rnd, const BIGNUM *range);
-int BN_priv_rand_range_ex(BIGNUM *r, const BIGNUM *range, BN_CTX *ctx);
+int BN_priv_rand_range_ex(BIGNUM *r, const BIGNUM *range,
+                          unsigned int strength, BN_CTX *ctx);
 int BN_priv_rand_range(BIGNUM *rnd, const BIGNUM *range);
 # ifndef OPENSSL_NO_DEPRECATED_3_0
 OSSL_DEPRECATEDIN_3_0

--- a/include/openssl/rand.h
+++ b/include/openssl/rand.h
@@ -61,11 +61,20 @@ OSSL_DEPRECATEDIN_3_0 RAND_METHOD *RAND_OpenSSL(void);
 int RAND_bytes(unsigned char *buf, int num);
 int RAND_priv_bytes(unsigned char *buf, int num);
 
-/* Equivalent of RAND_priv_bytes() but additionally taking an OSSL_LIB_CTX */
-int RAND_priv_bytes_ex(OSSL_LIB_CTX *ctx, unsigned char *buf, int num);
+/*
+ * Equivalent of RAND_priv_bytes() but additionally taking an OSSL_LIB_CTX and
+ * a strength.
+ */
+int RAND_priv_bytes_ex(OSSL_LIB_CTX *ctx, unsigned char *buf, int num,
+                       unsigned int strength);
 
-/* Equivalent of RAND_bytes() but additionally taking an OSSL_LIB_CTX */
-int RAND_bytes_ex(OSSL_LIB_CTX *ctx, unsigned char *buf, int num);
+/*
+ * Equivalent of RAND_bytes() but additionally taking an OSSL_LIB_CTX and
+ * a strength.
+ */
+int RAND_bytes_ex(OSSL_LIB_CTX *ctx, unsigned char *buf, int num,
+                  unsigned int strength);
+
 # ifndef OPENSSL_NO_DEPRECATED_1_1_0
 OSSL_DEPRECATEDIN_1_1_0 int RAND_pseudo_bytes(unsigned char *buf, int num);
 # endif

--- a/providers/implementations/ciphers/cipher_aes_cbc_hmac_sha1_hw.c
+++ b/providers/implementations/ciphers/cipher_aes_cbc_hmac_sha1_hw.c
@@ -143,7 +143,7 @@ static size_t tls1_multi_block_encrypt(void *vctx,
 #  endif
 
     /* ask for IVs in bulk */
-    if (RAND_bytes_ex(ctx->base.libctx, (IVs = blocks[0].c), 16 * x4) <= 0)
+    if (RAND_bytes_ex(ctx->base.libctx, (IVs = blocks[0].c), 16 * x4, 0) <= 0)
         return 0;
 
     mctx = (SHA1_MB_CTX *) (storage + 32 - ((size_t)storage % 32)); /* align */

--- a/providers/implementations/ciphers/cipher_aes_cbc_hmac_sha256_hw.c
+++ b/providers/implementations/ciphers/cipher_aes_cbc_hmac_sha256_hw.c
@@ -147,7 +147,7 @@ static size_t tls1_multi_block_encrypt(void *vctx,
 #  endif
 
     /* ask for IVs in bulk */
-    if (RAND_bytes_ex(ctx->base.libctx, (IVs = blocks[0].c), 16 * x4) <= 0)
+    if (RAND_bytes_ex(ctx->base.libctx, (IVs = blocks[0].c), 16 * x4, 0) <= 0)
         return 0;
 
     mctx = (SHA256_MB_CTX *) (storage + 32 - ((size_t)storage % 32)); /* align */

--- a/providers/implementations/ciphers/cipher_des.c
+++ b/providers/implementations/ciphers/cipher_des.c
@@ -122,7 +122,7 @@ static int des_generatekey(PROV_CIPHER_CTX *ctx, void *ptr)
     DES_cblock *deskey = ptr;
     size_t kl = ctx->keylen;
 
-    if (kl == 0 || RAND_priv_bytes_ex(ctx->libctx, ptr, kl) <= 0)
+    if (kl == 0 || RAND_priv_bytes_ex(ctx->libctx, ptr, kl, 0) <= 0)
         return 0;
     DES_set_odd_parity(deskey);
     return 1;

--- a/providers/implementations/ciphers/cipher_tdes_common.c
+++ b/providers/implementations/ciphers/cipher_tdes_common.c
@@ -120,7 +120,7 @@ static int tdes_generatekey(PROV_CIPHER_CTX *ctx, void *ptr)
     DES_cblock *deskey = ptr;
     size_t kl = ctx->keylen;
 
-    if (kl == 0 || RAND_priv_bytes_ex(ctx->libctx, ptr, kl) <= 0)
+    if (kl == 0 || RAND_priv_bytes_ex(ctx->libctx, ptr, kl, 0) <= 0)
         return 0;
     DES_set_odd_parity(deskey);
     if (kl >= 16)

--- a/providers/implementations/ciphers/cipher_tdes_wrap.c
+++ b/providers/implementations/ciphers/cipher_tdes_wrap.c
@@ -97,7 +97,7 @@ static int des_ede3_wrap(PROV_CIPHER_CTX *ctx, unsigned char *out,
     memcpy(out + inl + ivlen, sha1tmp, icvlen);
     OPENSSL_cleanse(sha1tmp, SHA_DIGEST_LENGTH);
     /* Generate random IV */
-    if (RAND_bytes_ex(ctx->libctx, ctx->iv, ivlen) <= 0)
+    if (RAND_bytes_ex(ctx->libctx, ctx->iv, ivlen, 0) <= 0)
         return 0;
     memcpy(out, ctx->iv, ivlen);
     /* Encrypt everything after IV in place */

--- a/providers/implementations/ciphers/ciphercommon_gcm.c
+++ b/providers/implementations/ciphers/ciphercommon_gcm.c
@@ -371,7 +371,7 @@ static int gcm_iv_generate(PROV_GCM_CTX *ctx, int offset)
         return 0;
 
     /* Use DRBG to generate random iv */
-    if (RAND_bytes_ex(ctx->libctx, ctx->iv + offset, sz) <= 0)
+    if (RAND_bytes_ex(ctx->libctx, ctx->iv + offset, sz, 0) <= 0)
         return 0;
     ctx->iv_state = IV_STATE_BUFFERED;
     ctx->iv_gen_rand = 1;
@@ -485,7 +485,7 @@ static int gcm_tls_iv_set_fixed(PROV_GCM_CTX *ctx, unsigned char *iv,
     if (len > 0)
         memcpy(ctx->iv, iv, len);
     if (ctx->enc
-        && RAND_bytes_ex(ctx->libctx, ctx->iv + len, ctx->ivlen - len) <= 0)
+        && RAND_bytes_ex(ctx->libctx, ctx->iv + len, ctx->ivlen - len, 0) <= 0)
             return 0;
     ctx->iv_gen = 1;
     ctx->iv_state = IV_STATE_BUFFERED;

--- a/providers/implementations/kem/rsa_kem.c
+++ b/providers/implementations/kem/rsa_kem.c
@@ -229,7 +229,7 @@ static int rsasve_gen_rand_bytes(RSA *rsa_pub,
     ret = (z != NULL
            && (BN_copy(nminus3, RSA_get0_n(rsa_pub)) != NULL)
            && BN_sub_word(nminus3, 3)
-           && BN_priv_rand_range_ex(z, nminus3, bnctx)
+           && BN_priv_rand_range_ex(z, nminus3, 0, bnctx)
            && BN_add_word(z, 2)
            && (BN_bn2binpad(z, out, outlen) == outlen));
     BN_CTX_end(bnctx);

--- a/providers/implementations/keymgmt/ecx_kmgmt.c
+++ b/providers/implementations/keymgmt/ecx_kmgmt.c
@@ -577,7 +577,7 @@ static void *ecx_gen(struct ecx_gen_ctx *gctx)
         ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
         goto err;
     }
-    if (RAND_priv_bytes_ex(gctx->libctx, privkey, key->keylen) <= 0)
+    if (RAND_priv_bytes_ex(gctx->libctx, privkey, key->keylen, 0) <= 0)
         goto err;
     switch (gctx->type) {
     case ECX_KEY_TYPE_X25519:
@@ -836,7 +836,7 @@ static void *s390x_ecx_keygen25519(struct ecx_gen_ctx *gctx)
         goto err;
     }
 
-    if (RAND_priv_bytes_ex(gctx->libctx, privkey, X25519_KEYLEN) <= 0)
+    if (RAND_priv_bytes_ex(gctx->libctx, privkey, X25519_KEYLEN, 0) <= 0)
         goto err;
 
     privkey[0] &= 248;
@@ -882,7 +882,7 @@ static void *s390x_ecx_keygen448(struct ecx_gen_ctx *gctx)
         goto err;
     }
 
-    if (RAND_priv_bytes_ex(gctx->libctx, privkey, X448_KEYLEN) <= 0)
+    if (RAND_priv_bytes_ex(gctx->libctx, privkey, X448_KEYLEN, 0) <= 0)
         goto err;
 
     privkey[0] &= 252;
@@ -934,7 +934,7 @@ static void *s390x_ecd_keygen25519(struct ecx_gen_ctx *gctx)
         goto err;
     }
 
-    if (RAND_priv_bytes_ex(gctx->libctx, privkey, ED25519_KEYLEN) <= 0)
+    if (RAND_priv_bytes_ex(gctx->libctx, privkey, ED25519_KEYLEN, 0) <= 0)
         goto err;
 
     sha = EVP_MD_fetch(gctx->libctx, "SHA512", gctx->propq);
@@ -1004,7 +1004,7 @@ static void *s390x_ecd_keygen448(struct ecx_gen_ctx *gctx)
     shake = EVP_MD_fetch(gctx->libctx, "SHAKE256", gctx->propq);
     if (shake == NULL)
         goto err;
-    if (RAND_priv_bytes_ex(gctx->libctx, privkey, ED448_KEYLEN) <= 0)
+    if (RAND_priv_bytes_ex(gctx->libctx, privkey, ED448_KEYLEN, 0) <= 0)
         goto err;
 
     hashctx = EVP_MD_CTX_new();

--- a/ssl/record/ssl3_record.c
+++ b/ssl/record/ssl3_record.c
@@ -997,7 +997,7 @@ int tls1_enc(SSL *s, SSL3_RECORD *recs, size_t n_recs, int sending,
                         SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
                         return 0;
                     } else if (RAND_bytes_ex(s->ctx->libctx, recs[ctr].input,
-                                             ivlen) <= 0) {
+                                             ivlen, 0) <= 0) {
                         SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
                         return 0;
                     }

--- a/ssl/record/tls_pad.c
+++ b/ssl/record/tls_pad.c
@@ -253,7 +253,7 @@ static int ssl3_cbc_copy_mac(size_t *reclen,
     }
 
     /* Create the random MAC we will emit if padding is bad */
-    if (!RAND_bytes_ex(libctx, randmac, mac_size))
+    if (!RAND_bytes_ex(libctx, randmac, mac_size, 0))
         return 0;
 
     if (!ossl_assert(mac != NULL && alloced != NULL))

--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -4552,9 +4552,9 @@ int ssl_fill_hello_random(SSL *s, int server, unsigned char *result, size_t len,
         unsigned char *p = result;
 
         l2n(Time, p);
-        ret = RAND_bytes_ex(s->ctx->libctx, p, len - 4);
+        ret = RAND_bytes_ex(s->ctx->libctx, p, len - 4, 0);
     } else {
-        ret = RAND_bytes_ex(s->ctx->libctx, result, len);
+        ret = RAND_bytes_ex(s->ctx->libctx, result, len, 0);
     }
 
     if (ret > 0) {

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -3284,15 +3284,15 @@ SSL_CTX *SSL_CTX_new_ex(OSSL_LIB_CTX *libctx, const char *propq,
 
     /* Setup RFC5077 ticket keys */
     if ((RAND_bytes_ex(libctx, ret->ext.tick_key_name,
-                       sizeof(ret->ext.tick_key_name)) <= 0)
+                       sizeof(ret->ext.tick_key_name), 0) <= 0)
         || (RAND_priv_bytes_ex(libctx, ret->ext.secure->tick_hmac_key,
-                               sizeof(ret->ext.secure->tick_hmac_key)) <= 0)
+                               sizeof(ret->ext.secure->tick_hmac_key), 0) <= 0)
         || (RAND_priv_bytes_ex(libctx, ret->ext.secure->tick_aes_key,
-                               sizeof(ret->ext.secure->tick_aes_key)) <= 0))
+                               sizeof(ret->ext.secure->tick_aes_key), 0) <= 0))
         ret->options |= SSL_OP_NO_TICKET;
 
     if (RAND_priv_bytes_ex(libctx, ret->ext.cookie_hmac_key,
-                           sizeof(ret->ext.cookie_hmac_key)) <= 0)
+                           sizeof(ret->ext.cookie_hmac_key), 0) <= 0)
         goto err;
 
 #ifndef OPENSSL_NO_SRP

--- a/ssl/ssl_sess.c
+++ b/ssl/ssl_sess.c
@@ -264,7 +264,7 @@ static int def_generate_session_id(SSL *ssl, unsigned char *id,
 {
     unsigned int retry = 0;
     do
-        if (RAND_bytes_ex(ssl->ctx->libctx, id, *id_len) <= 0)
+        if (RAND_bytes_ex(ssl->ctx->libctx, id, *id_len, 0) <= 0)
             return 0;
     while (SSL_has_matching_session_id(ssl, id, *id_len) &&
            (++retry < MAX_SESS_ID_ATTEMPTS)) ;

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -1191,7 +1191,7 @@ int tls_construct_client_hello(SSL *s, WPACKET *pkt)
             session_id = s->tmp_session_id;
             if (s->hello_retry_request == SSL_HRR_NONE
                     && RAND_bytes_ex(s->ctx->libctx, s->tmp_session_id,
-                                     sess_id_len) <= 0) {
+                                     sess_id_len, 0) <= 0) {
                 SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
                 return 0;
             }
@@ -2853,7 +2853,7 @@ static int tls_construct_cke_rsa(SSL *s, WPACKET *pkt)
     pms[0] = s->client_version >> 8;
     pms[1] = s->client_version & 0xff;
     /* TODO(size_t): Convert this function */
-    if (RAND_bytes_ex(s->ctx->libctx, pms + 2, (int)(pmslen - 2)) <= 0) {
+    if (RAND_bytes_ex(s->ctx->libctx, pms + 2, (int)(pmslen - 2), 0) <= 0) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_MALLOC_FAILURE);
         goto err;
     }
@@ -3060,7 +3060,7 @@ static int tls_construct_cke_gost(SSL *s, WPACKET *pkt)
         /* Generate session key
          * TODO(size_t): Convert this function
          */
-        || RAND_bytes_ex(s->ctx->libctx, pms, (int)pmslen) <= 0) {
+        || RAND_bytes_ex(s->ctx->libctx, pms, (int)pmslen, 0) <= 0) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
         goto err;
     };
@@ -3185,7 +3185,7 @@ static int tls_construct_cke_gost18(SSL *s, WPACKET *pkt)
         goto err;
     }
 
-    if (RAND_bytes_ex(s->ctx->libctx, pms, (int)pmslen) <= 0) {
+    if (RAND_bytes_ex(s->ctx->libctx, pms, (int)pmslen, 0) <= 0) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
         goto err;
     }

--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -2738,7 +2738,7 @@ int tls_construct_certificate_request(SSL *s, WPACKET *pkt)
                 return 0;
             }
             if (RAND_bytes_ex(s->ctx->libctx, s->pha_context,
-                                     s->pha_context_len) <= 0
+                                     s->pha_context_len, 0) <= 0
                     || !WPACKET_sub_memcpy_u8(pkt, s->pha_context,
                                               s->pha_context_len)) {
                 SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
@@ -3778,7 +3778,7 @@ static int construct_stateless_ticket(SSL *s, WPACKET *pkt, uint32_t age_add,
         }
 
         iv_len = EVP_CIPHER_iv_length(cipher);
-        if (RAND_bytes_ex(s->ctx->libctx, iv, iv_len) <= 0
+        if (RAND_bytes_ex(s->ctx->libctx, iv, iv_len, 0) <= 0
                 || !EVP_EncryptInit_ex(ctx, cipher, NULL,
                                        tctx->ext.secure->tick_aes_key, iv)
                 || !ssl_hmac_init(hctx, tctx->ext.secure->tick_hmac_key,
@@ -3905,7 +3905,7 @@ int tls_construct_new_session_ticket(SSL *s, WPACKET *pkt)
             goto err;
         }
         if (RAND_bytes_ex(s->ctx->libctx, age_add_u.age_add_c,
-                          sizeof(age_add_u)) <= 0) {
+                          sizeof(age_add_u), 0) <= 0) {
             SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
             goto err;
         }

--- a/ssl/tls_srp.c
+++ b/ssl/tls_srp.c
@@ -203,7 +203,7 @@ int ssl_srp_server_param_with_username_intern(SSL *s, int *ad)
         (s->srp_ctx.s == NULL) || (s->srp_ctx.v == NULL))
         return SSL3_AL_FATAL;
 
-    if (RAND_priv_bytes_ex(s->ctx->libctx, b, sizeof(b)) <= 0)
+    if (RAND_priv_bytes_ex(s->ctx->libctx, b, sizeof(b), 0) <= 0)
         return SSL3_AL_FATAL;
     s->srp_ctx.b = BN_bin2bn(b, sizeof(b), NULL);
     OPENSSL_cleanse(b, sizeof(b));
@@ -420,7 +420,7 @@ int ssl_srp_calc_a_param_intern(SSL *s)
 {
     unsigned char rnd[SSL_MAX_MASTER_KEY_LENGTH];
 
-    if (RAND_priv_bytes_ex(s->ctx->libctx, rnd, sizeof(rnd)) <= 0)
+    if (RAND_priv_bytes_ex(s->ctx->libctx, rnd, sizeof(rnd), 0) <= 0)
         return 0;
     s->srp_ctx.a = BN_bin2bn(rnd, sizeof(rnd), s->srp_ctx.a);
     OPENSSL_cleanse(rnd, sizeof(rnd));

--- a/test/cmp_client_test.c
+++ b/test/cmp_client_test.c
@@ -373,7 +373,7 @@ int setup_tests(void)
             || !TEST_ptr(server_cert = load_cert_pem(server_cert_f, libctx))
             || !TEST_ptr(client_key = load_pkey_pem(client_key_f, libctx))
             || !TEST_ptr(client_cert = load_cert_pem(client_cert_f, libctx))
-            || !TEST_int_eq(1, RAND_bytes_ex(libctx, ref, sizeof(ref)))) {
+            || !TEST_int_eq(1, RAND_bytes_ex(libctx, ref, sizeof(ref), 0))) {
         cleanup_tests();
         return 0;
     }

--- a/test/cmp_msg_test.c
+++ b/test/cmp_msg_test.c
@@ -149,7 +149,7 @@ static int test_cmp_create_ir_protection_set(void)
     fixture->bodytype = OSSL_CMP_PKIBODY_IR;
     fixture->err_code = -1;
     fixture->expected = 1;
-    if (!TEST_int_eq(1, RAND_bytes_ex(libctx, secret, sizeof(secret)))
+    if (!TEST_int_eq(1, RAND_bytes_ex(libctx, secret, sizeof(secret), 0))
             || !TEST_true(SET_OPT_UNPROTECTED_SEND(ctx, 0))
             || !TEST_true(set1_newPkey(ctx, newkey))
             || !TEST_true(OSSL_CMP_CTX_set1_secretValue(ctx, secret,
@@ -566,7 +566,7 @@ int setup_tests(void)
 
     if (!TEST_ptr(newkey = load_pkey_pem(newkey_f, libctx))
             || !TEST_ptr(cert = load_cert_pem(server_cert_f, libctx))
-            || !TEST_int_eq(1, RAND_bytes_ex(libctx, ref, sizeof(ref)))) {
+            || !TEST_int_eq(1, RAND_bytes_ex(libctx, ref, sizeof(ref), 0))) {
         cleanup_tests();
         return 0;
     }

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -1294,7 +1294,7 @@ static int test_ktls_sendfile(int tls_version, const char *cipher)
         || !TEST_true(BIO_get_ktls_send(serverssl->wbio)))
         goto end;
 
-    if (!TEST_true(RAND_bytes_ex(libctx, buf, SENDFILE_SZ)))
+    if (!TEST_true(RAND_bytes_ex(libctx, buf, SENDFILE_SZ, 0)))
         goto end;
 
     out = BIO_new_file(tmpfilename, "wb");

--- a/test/tls-provider.c
+++ b/test/tls-provider.c
@@ -640,7 +640,7 @@ static void *xor_gen(void *genctx, OSSL_CALLBACK *osslcb, void *cbarg)
         return NULL;
 
     if ((gctx->selection & OSSL_KEYMGMT_SELECT_KEYPAIR) != 0) {
-        if (RAND_bytes_ex(gctx->libctx, key->privkey, XOR_KEY_SIZE) <= 0) {
+        if (RAND_bytes_ex(gctx->libctx, key->privkey, XOR_KEY_SIZE, 0) <= 0) {
             OPENSSL_free(key);
             return NULL;
         }
@@ -813,7 +813,7 @@ unsigned int randomize_tls_group_id(OSSL_LIB_CTX *libctx)
     int i;
 
  retry:
-    if (!RAND_bytes_ex(libctx, (unsigned char *)&group_id, sizeof(group_id)))
+    if (!RAND_bytes_ex(libctx, (unsigned char *)&group_id, sizeof(group_id), 0))
         return 0;
     /*
      * Ensure group_id is within the IANA Reserved for private use range


### PR DESCRIPTION
For the newly introduced RNG calls, it makes sense to include a required strength argument now rather than having to introduce another suite of calls later.  The plumbing and strength checks are already in place in providers, so this is just passing through the argument.

Fixes #15512


- [x] documentation is added or updated
- [x] tests are added or updated
