### PR TITLE
Put init_ec_point_formats() inside #ifndef OPENSSL_NO_EC

### DIFF
--- a/ssl/statem/extensions.c
+++ b/ssl/statem/extensions.c
@@ -1028,6 +1028,15 @@ static int final_server_name(SSL *s, unsigned int context, int sent)
 }
 
 #ifndef OPENSSL_NO_EC
+static int init_ec_point_formats(SSL *s, unsigned int context)
+{
+    OPENSSL_free(s->ext.peer_ecpointformats);
+    s->ext.peer_ecpointformats = NULL;
+    s->ext.peer_ecpointformats_len = 0;
+
+    return 1;
+}
+
 static int final_ec_pt_formats(SSL *s, unsigned int context, int sent)
 {
     unsigned long alg_k, alg_a;
@@ -1165,15 +1174,6 @@ static int init_srp(SSL *s, unsigned int context)
     return 1;
 }
 #endif
-
-static int init_ec_point_formats(SSL *s, unsigned int context)
-{
-    OPENSSL_free(s->ext.peer_ecpointformats);
-    s->ext.peer_ecpointformats = NULL;
-    s->ext.peer_ecpointformats_len = 0;
-
-    return 1;
-}
 
 static int init_etm(SSL *s, unsigned int context)
 {

--- a/ssl/statem/extensions.c
+++ b/ssl/statem/extensions.c
@@ -18,6 +18,7 @@ static int final_renegotiate(SSL *s, unsigned int context, int sent);
 static int init_server_name(SSL *s, unsigned int context);
 static int final_server_name(SSL *s, unsigned int context, int sent);
 #ifndef OPENSSL_NO_EC
+static int init_ec_point_formats(SSL *s, unsigned int context);
 static int final_ec_pt_formats(SSL *s, unsigned int context, int sent);
 #endif
 static int init_session_ticket(SSL *s, unsigned int context);
@@ -42,7 +43,6 @@ static int tls_parse_certificate_authorities(SSL *s, PACKET *pkt,
 #ifndef OPENSSL_NO_SRP
 static int init_srp(SSL *s, unsigned int context);
 #endif
-static int init_ec_point_formats(SSL *s, unsigned int context);
 static int init_etm(SSL *s, unsigned int context);
 static int init_ems(SSL *s, unsigned int context);
 static int final_ems(SSL *s, unsigned int context, int sent);


### PR DESCRIPTION
This fixes a recent regression of no-ec build on the 1.1.1 branch.
