### PR TITLE
Fix cert creation in the store

### DIFF
--- a/crypto/store/store_result.c
+++ b/crypto/store/store_result.c
@@ -463,14 +463,12 @@ static int try_cert(struct extracted_param_data_st *data, OSSL_STORE_INFO **v,
             ignore_trusted = 0;
 
         if (d2i_X509_AUX(&cert, (const unsigned char **)&data->octet_data,
-                         data->octet_data_size) == NULL) {
-            if (ignore_trusted
-                    && d2i_X509(&cert,
-                                (const unsigned char **)&data->octet_data,
-                                data->octet_data_size) == NULL) {
-                X509_free(cert);
-                cert = NULL;
-            }
+                         data->octet_data_size) == NULL
+            && (!ignore_trusted
+                || d2i_X509(&cert, (const unsigned char **)&data->octet_data,
+                            data->octet_data_size) == NULL)) {
+            X509_free(cert);
+            cert = NULL;
         }
 
         if (cert != NULL) {

--- a/crypto/store/store_result.c
+++ b/crypto/store/store_result.c
@@ -442,8 +442,6 @@ static int try_cert(struct extracted_param_data_st *data, OSSL_STORE_INFO **v,
 {
     if (data->object_type == OSSL_OBJECT_UNKNOWN
         || data->object_type == OSSL_OBJECT_CERT) {
-        X509 *cert;
-
         /*
          * In most cases, we can try to interpret the serialized
          * data as a trusted cert (X509 + X509_AUX) and fall back
@@ -454,31 +452,34 @@ static int try_cert(struct extracted_param_data_st *data, OSSL_STORE_INFO **v,
          * or not (0).
          */
         int ignore_trusted = 1;
+        X509 *cert = X509_new_ex(libctx, propq);
+
+        if (cert == NULL)
+            return 0;
 
         /* If we have a data type, it should be a PEM name */
         if (data->data_type != NULL
             && (strcasecmp(data->data_type, PEM_STRING_X509_TRUSTED) == 0))
             ignore_trusted = 0;
 
-        cert = d2i_X509_AUX(NULL, (const unsigned char **)&data->octet_data,
-                            data->octet_data_size);
-        if (cert == NULL && ignore_trusted)
-            cert = d2i_X509(NULL, (const unsigned char **)&data->octet_data,
-                            data->octet_data_size);
-
-        if (cert != NULL)
-            /* We determined the object type */
-            data->object_type = OSSL_OBJECT_CERT;
-
-        if (cert != NULL && !ossl_x509_set0_libctx(cert, libctx, propq)) {
-            X509_free(cert);
-            cert = NULL;
+        if (d2i_X509_AUX(&cert, (const unsigned char **)&data->octet_data,
+                         data->octet_data_size) == NULL) {
+            if (ignore_trusted
+                    && d2i_X509(&cert,
+                                (const unsigned char **)&data->octet_data,
+                                data->octet_data_size) == NULL) {
+                X509_free(cert);
+                cert = NULL;
+            }
         }
 
-        if (cert != NULL)
+        if (cert != NULL) {
+            /* We determined the object type */
+            data->object_type = OSSL_OBJECT_CERT;
             *v = OSSL_STORE_INFO_new_CERT(cert);
-        if (*v == NULL)
-            X509_free(cert);
+            if (*v == NULL)
+                X509_free(cert);
+        }
     }
 
     return 1;


### PR DESCRIPTION
When we create a cert in the store, make sure we do so with the libctx
and propq associated.

This has been pulled out of #15504 to ease review.