### PR TITLE
Fix no-ec build

### DIFF
--- a/ssl/statem/extensions.c
+++ b/ssl/statem/extensions.c
@@ -42,7 +42,9 @@ static int tls_parse_certificate_authorities(SSL *s, PACKET *pkt,
 #ifndef OPENSSL_NO_SRP
 static int init_srp(SSL *s, unsigned int context);
 #endif
+#ifndef OPENSSL_NO_EC
 static int init_ec_point_formats(SSL *s, unsigned int context);
+#endif
 static int init_etm(SSL *s, unsigned int context);
 static int init_ems(SSL *s, unsigned int context);
 static int final_ems(SSL *s, unsigned int context, int sent);
@@ -1166,6 +1168,7 @@ static int init_srp(SSL *s, unsigned int context)
 }
 #endif
 
+#ifndef OPENSSL_NO_EC
 static int init_ec_point_formats(SSL *s, unsigned int context)
 {
     OPENSSL_free(s->ext.peer_ecpointformats);
@@ -1174,6 +1177,7 @@ static int init_ec_point_formats(SSL *s, unsigned int context)
 
     return 1;
 }
+#endif
 
 static int init_etm(SSL *s, unsigned int context)
 {


### PR DESCRIPTION
After #15383 was cherry-picked to 1.1.1, no-ec builds have been
failing.  On master, we build EC support into libssl and detect
at runtime whether providers are able to implement the necessary
ECC functionality, so no include guards are present around the
EC point formats entryin the array of extensions.  On 1.1.1,
the support for the TLS extension is gated on OPENSSL_NO_EC,
so the newly added init_ec_point_formats function must be
similarly gated as well.  (The build failure results from the
init function trying to access fields that are not present
in struct_ssl.)

