### PR TITLE
req: fix Coverity 1485137 Explicit null dereference

### DIFF
--- a/apps/req.c
+++ b/apps/req.c
@@ -1576,6 +1576,7 @@ static EVP_PKEY_CTX *set_keygen_ctx(const char *gstr,
         if (keytype == NULL) {
             keytype = EVP_PKEY_get0_type_name(param);
             if (keytype == NULL) {
+                EVP_PKEY_free(param);
                 BIO_puts(bio_err, "Unable to determine key type\n");
                 return NULL;
             }

--- a/apps/req.c
+++ b/apps/req.c
@@ -1522,6 +1522,12 @@ static EVP_PKEY_CTX *set_keygen_ctx(const char *gstr,
 
         if (strncmp(gstr, "param", len) == 0) {
             expect_paramfile = 1;
+            if (p == NULL) {
+                BIO_printf(bio_err,
+                           "Parameter file requested but no path given: %s\n",
+                           gstr);
+                return NULL;
+            }
         } else {
             keytype = gstr;
             keytypelen = len;
@@ -1569,6 +1575,10 @@ static EVP_PKEY_CTX *set_keygen_ctx(const char *gstr,
         }
         if (keytype == NULL) {
             keytype = EVP_PKEY_get0_type_name(param);
+            if (keytype == NULL) {
+                BIO_puts(bio_err, "Unable to determine key type\n");
+                return NULL;
+            }
         }
     }
 


### PR DESCRIPTION
Add a check for a non-existent file name when specifying params via file.
Add a check for a failure to determine key type.

