### PR TITLE
Disable tracing within the FIPS module

### DIFF
--- a/.github/workflows/run-checker-ci.yml
+++ b/.github/workflows/run-checker-ci.yml
@@ -26,6 +26,7 @@ jobs:
           enable-trace,
           no-ts,
           no-ui,
+          enable-fips,
         ]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/run-checker-ci.yml
+++ b/.github/workflows/run-checker-ci.yml
@@ -23,10 +23,9 @@ jobs:
           no-threads,
           no-tls,
           no-tls1_3,
-          enable-trace,
+          enable-trace enable-fips,
           no-ts,
           no-ui,
-          enable-fips,
         ]
     runs-on: ubuntu-latest
     steps:

--- a/include/openssl/trace.h
+++ b/include/openssl/trace.h
@@ -198,7 +198,7 @@ void OSSL_trace_end(int category, BIO *channel);
  * call OSSL_TRACE_CANCEL(category).
  */
 
-# ifndef OPENSSL_NO_TRACE
+# if !defined OPENSSL_NO_TRACE && !defined FIPS_MODULE
 
 #  define OSSL_TRACE_BEGIN(category) \
     do { \
@@ -237,7 +237,7 @@ void OSSL_trace_end(int category, BIO *channel);
  *         ...
  *     }
  */
-# ifndef OPENSSL_NO_TRACE
+# if !defined OPENSSL_NO_TRACE && !defined FIPS_MODULE
 
 #  define OSSL_TRACE_ENABLED(category) \
     OSSL_trace_enabled(OSSL_TRACE_CATEGORY_##category)


### PR DESCRIPTION
Building master was recently broken if the config includes both 'enable-trace' and 'enable-fips'. Here's some of the errors:

```
providers/libfips.a(libfips-lib-p_lib.o): In function `EVP_PKEY_free':
/home/jon/work/jaffa/openssl/openssl-vanilla/crypto/evp/p_lib.c:1750: undefined reference to `OSSL_trace_begin'
/home/jon/work/jaffa/openssl/openssl-vanilla/crypto/evp/p_lib.c:1750: undefined reference to `BIO_printf'
/home/jon/work/jaffa/openssl/openssl-vanilla/crypto/evp/p_lib.c:1750: undefined reference to `OSSL_trace_end'
providers/libfips.a(libfips-lib-rsa_lib.o): In function `RSA_free':
/home/jon/work/jaffa/openssl/openssl-vanilla/crypto/rsa/rsa_lib.c:139: undefined reference to `OSSL_trace_begin'
/home/jon/work/jaffa/openssl/openssl-vanilla/crypto/rsa/rsa_lib.c:139: undefined reference to `BIO_printf'
/home/jon/work/jaffa/openssl/openssl-vanilla/crypto/rsa/rsa_lib.c:139: undefined reference to `OSSL_trace_end'
providers/libfips.a(libfips-lib-rsa_lib.o): In function `RSA_up_ref':
/home/jon/work/jaffa/openssl/openssl-vanilla/crypto/rsa/rsa_lib.c:185: undefined reference to `OSSL_trace_begin'
/home/jon/work/jaffa/openssl/openssl-vanilla/crypto/rsa/rsa_lib.c:185: undefined reference to `BIO_printf'
/home/jon/work/jaffa/openssl/openssl-vanilla/crypto/rsa/rsa_lib.c:185: undefined reference to `OSSL_trace_end'
```

This change removes trace code if FIPS_MODULE is defined, avoiding any missing symbols.
