### PR TITLE
Configure: variable expand GENERATE values too

### DIFF
--- a/Configure
+++ b/Configure
@@ -2212,7 +2212,7 @@ if ($builder eq "unified") {
                          if !@skip || $skip[$#skip] > 0; },
             qr/^\s* GENERATE ${index_re} = ${value_re} $/x
             => sub { $push_to->(\%generate, $expand_variables->($+{INDEX}),
-                                undef, undef, $+{VALUE})
+                                undef, undef, $expand_variables->($+{VALUE}))
                          if !@skip || $skip[$#skip] > 0; },
             qr/^\s* (?:\#.*)? $/x => sub { },
             "OTHERWISE" => sub { die "Something wrong with this line:\n$_\nat $sourced/$f" },

--- a/providers/common/der/build.info
+++ b/providers/common/der/build.info
@@ -1,16 +1,18 @@
+$INCDIR=../include/prov
+
 #----- Digests
-$DER_DIGESTS_H=../include/prov/der_digests.h
+$DER_DIGESTS_H=$INCDIR/der_digests.h
 $DER_DIGESTS_GEN=der_digests_gen.c
 
 GENERATE[$DER_DIGESTS_GEN]=der_digests_gen.c.in
 DEPEND[$DER_DIGESTS_GEN]=oids_to_c.pm NIST.asn1 DIGESTS.asn1
 
 DEPEND[${DER_DIGESTS_GEN/.c/.o}]=$DER_DIGESTS_H
-GENERATE[$DER_DIGESTS_H]=../include/prov/der_digests.h.in
+GENERATE[$DER_DIGESTS_H]=$INCDIR/der_digests.h.in
 DEPEND[$DER_DIGESTS_H]=oids_to_c.pm NIST.asn1 DIGESTS.asn1
 
 #----- RSA
-$DER_RSA_H=../include/prov/der_rsa.h
+$DER_RSA_H=$INCDIR/der_rsa.h
 $DER_RSA_GEN=der_rsa_gen.c
 $DER_RSA_AUX=der_rsa_key.c der_rsa_sig.c
 $DER_RSA_COMMON=$DER_RSA_GEN der_rsa_key.c
@@ -21,12 +23,12 @@ DEPEND[$DER_RSA_GEN]=oids_to_c.pm NIST.asn1 RSA.asn1
 
 DEPEND[${DER_RSA_AUX/.c/.o}]=$DER_RSA_H $DER_DIGESTS_H
 DEPEND[${DER_RSA_GEN/.c/.o}]=$DER_RSA_H
-GENERATE[$DER_RSA_H]=../include/prov/der_rsa.h.in
+GENERATE[$DER_RSA_H]=$INCDIR/der_rsa.h.in
 DEPEND[$DER_RSA_H]=oids_to_c.pm NIST.asn1 RSA.asn1
 
 #----- DSA
 IF[{- !$disabled{dsa} -}]
-  $DER_DSA_H=../include/prov/der_dsa.h
+  $DER_DSA_H=$INCDIR/der_dsa.h
   $DER_DSA_GEN=der_dsa_gen.c
   $DER_DSA_AUX=der_dsa_key.c der_dsa_sig.c
 
@@ -35,13 +37,13 @@ IF[{- !$disabled{dsa} -}]
 
   DEPEND[${DER_DSA_AUX/.c/.o}]=$DER_DSA_H $DER_DIGESTS_H
   DEPEND[${DER_DSA_GEN/.c/.o}]=$DER_DSA_H
-  GENERATE[$DER_DSA_H]=../include/prov/der_dsa.h.in
+  GENERATE[$DER_DSA_H]=$INCDIR/der_dsa.h.in
   DEPEND[$DER_DSA_H]=oids_to_c.pm DSA.asn1
 ENDIF
 
 #----- EC
 IF[{- !$disabled{ec} -}]
-  $DER_EC_H=../include/prov/der_ec.h
+  $DER_EC_H=$INCDIR/der_ec.h
   $DER_EC_GEN=der_ec_gen.c
   $DER_EC_AUX=der_ec_key.c der_ec_sig.c
 
@@ -50,13 +52,13 @@ IF[{- !$disabled{ec} -}]
 
   DEPEND[${DER_EC_AUX/.c/.o}]=$DER_EC_H $DER_DIGESTS_H
   DEPEND[${DER_EC_GEN/.c/.o}]=$DER_EC_H
-  GENERATE[$DER_EC_H]=../include/prov/der_ec.h.in
+  GENERATE[$DER_EC_H]=$INCDIR/der_ec.h.in
   DEPEND[$DER_EC_H]=oids_to_c.pm EC.asn1
 ENDIF
 
 #----- ECX
 IF[{- !$disabled{ec} -}]
-  $DER_ECX_H=../include/prov/der_ecx.h
+  $DER_ECX_H=$INCDIR/der_ecx.h
   $DER_ECX_GEN=der_ecx_gen.c
   $DER_ECX_AUX=der_ecx_key.c
 
@@ -65,24 +67,24 @@ IF[{- !$disabled{ec} -}]
 
   DEPEND[${DER_ECX_AUX/.c/.o}]=$DER_ECX_H
   DEPEND[${DER_ECX_GEN/.c/.o}]=$DER_ECX_H
-  GENERATE[$DER_ECX_H]=../include/prov/der_ecx.h.in
+  GENERATE[$DER_ECX_H]=$INCDIR/der_ecx.h.in
   DEPEND[$DER_ECX_H]=oids_to_c.pm ECX.asn1
 ENDIF
 
 #----- KEY WRAP
-$DER_WRAP_H=../include/prov/der_wrap.h
+$DER_WRAP_H=$INCDIR/der_wrap.h
 $DER_WRAP_GEN=der_wrap_gen.c
 
 GENERATE[$DER_WRAP_GEN]=der_wrap_gen.c.in
 DEPEND[$DER_WRAP_GEN]=oids_to_c.pm wrap.asn1
 
 DEPEND[${DER_WRAP_GEN/.c/.o}]=$DER_WRAP_H
-GENERATE[$DER_WRAP_H]=../include/prov/der_wrap.h.in
+GENERATE[$DER_WRAP_H]=$INCDIR/der_wrap.h.in
 DEPEND[$DER_WRAP_H]=oids_to_c.pm wrap.asn1
 
 #----- SM2
 IF[{- !$disabled{sm2} -}]
-  $DER_SM2_H=../include/prov/der_sm2.h
+  $DER_SM2_H=$INCDIR/der_sm2.h
   $DER_SM2_GEN=der_sm2_gen.c
   $DER_SM2_AUX=der_sm2_key.c der_sm2_sig.c
 
@@ -91,7 +93,7 @@ IF[{- !$disabled{sm2} -}]
 
   DEPEND[${DER_SM2_AUX/.c/.o}]=$DER_SM2_H $DER_EC_H
   DEPEND[${DER_SM2_GEN/.c/.o}]=$DER_SM2_H
-  GENERATE[$DER_SM2_H]=../include/prov/der_sm2.h.in
+  GENERATE[$DER_SM2_H]=$INCDIR/der_sm2.h.in
   DEPEND[$DER_SM2_H]=oids_to_c.pm SM2.asn1
 ENDIF
 


### PR DESCRIPTION
Internal documentation doesn't allow for any exception...  Therefore,
even GENERATE values should be variable expanded.

(there are historical reasons why GENERATE was excepted from variable
expansion, that aren't applicable any more)