### PR TITLE
rsa: make the maximum key strength check FIPS only.

### DIFF
--- a/crypto/rsa/rsa_sp800_56b_gen.c
+++ b/crypto/rsa/rsa_sp800_56b_gen.c
@@ -195,11 +195,17 @@ static int rsa_validate_rng_strength(EVP_RAND_CTX *rng, int nbits)
 {
     if (rng == NULL)
         return 0;
+#ifdef FIPS_MODULE
+    /*
+     * This should become mainstream once similar tests are added to the other
+     * key generations and once there is a way to disable these checks.
+     */
     if (EVP_RAND_get_strength(rng) < ossl_ifc_ffc_compute_security_bits(nbits)) {
         ERR_raise(ERR_LIB_RSA,
                   RSA_R_RANDOMNESS_SOURCE_STRENGTH_INSUFFICIENT);
         return 0;
     }
+#endif
     return 1;
 }
 

--- a/test/recipes/15-test_genrsa.t
+++ b/test/recipes/15-test_genrsa.t
@@ -24,8 +24,8 @@ use lib bldtop_dir('.');
 my $no_fips = disabled('fips') || ($ENV{NO_FIPS} // 0);
 
 plan tests =>
-    ($no_fips ? 0 : 2)          # Extra FIPS related test
-    + 14;
+    ($no_fips ? 0 : 3)          # Extra FIPS related tests
+    + 13;
 
 # We want to know that an absurdly small number of bits isn't support
 is(run(app([ 'openssl', 'genpkey', '-out', 'genrsatest.pem',
@@ -35,11 +35,13 @@ is(run(app([ 'openssl', 'genpkey', '-out', 'genrsatest.pem',
 is(run(app([ 'openssl', 'genrsa', '-3', '-out', 'genrsatest.pem', '8'])),
            0, "genrsa -3 8");
 
-# We want to know that an absurdly large number of bits fails the RNG check
-is(run(app([ 'openssl', 'genpkey', '-out', 'genrsatest.pem',
-             '-algorithm', 'RSA', '-pkeyopt', 'rsa_keygen_bits:1000000000',
-             '-pkeyopt', 'rsa_keygen_pubexp:3'])),
-           0, "genpkey 1000000000");
+unless ($no_fips) {
+    # We want to know that an absurdly large number of bits fails the RNG check
+    is(run(app([ 'openssl', 'genpkey', '-out', 'genrsatest.pem',
+                 '-algorithm', 'RSA', '-pkeyopt', 'rsa_keygen_bits:1000000000',
+                 '-pkeyopt', 'rsa_keygen_pubexp:3'])),
+               0, "genpkey 1000000000");
+}
 
 # Depending on the shared library, we might have different lower limits.
 # Let's find it!  This is a simple binary search

--- a/test/recipes/15-test_genrsa.t
+++ b/test/recipes/15-test_genrsa.t
@@ -35,14 +35,6 @@ is(run(app([ 'openssl', 'genpkey', '-out', 'genrsatest.pem',
 is(run(app([ 'openssl', 'genrsa', '-3', '-out', 'genrsatest.pem', '8'])),
            0, "genrsa -3 8");
 
-unless ($no_fips) {
-    # We want to know that an absurdly large number of bits fails the RNG check
-    is(run(app([ 'openssl', 'genpkey', '-out', 'genrsatest.pem',
-                 '-algorithm', 'RSA', '-pkeyopt', 'rsa_keygen_bits:1000000000',
-                 '-pkeyopt', 'rsa_keygen_pubexp:3'])),
-               0, "genpkey 1000000000");
-}
-
 # Depending on the shared library, we might have different lower limits.
 # Let's find it!  This is a simple binary search
 # ------------------------------------------------------------
@@ -121,14 +113,22 @@ unless ($no_fips) {
     $ENV{OPENSSL_TEST_LIBCTX} = "1";
     ok(run(app(['openssl', 'genpkey',
                 @prov,
-               '-algorithm', 'RSA',
-               '-pkeyopt', 'bits:2080',
-               '-out', 'genrsatest2080.pem'])),
+                '-algorithm', 'RSA',
+                '-pkeyopt', 'bits:2080',
+                '-out', 'genrsatest2080.pem'])),
        "Generating RSA key with > 2048 bits and < 3072 bits");
     ok(run(app(['openssl', 'genpkey',
                 @prov,
-               '-algorithm', 'RSA',
-               '-pkeyopt', 'bits:3072',
-               '-out', 'genrsatest3072.pem'])),
+                '-algorithm', 'RSA',
+                '-pkeyopt', 'bits:3072',
+                '-out', 'genrsatest3072.pem'])),
        "Generating RSA key with 3072 bits");
+
+    # We want to know that an absurdly large number of bits fails the RNG check
+    is(run(app([ 'openssl', 'genpkey',
+                 @prov,
+                 '-algorithm', 'RSA',
+                 '-pkeyopt', 'bits:1000000000',
+                 '-out', 'genrsatest.pem'])),
+               0, "genpkey 1000000000");
 }


### PR DESCRIPTION
To be reverted once key generation checks are added everywhere and a way to
disable them implemented.

Fixing #15502
