### PR TITLE
Add version info to ossl-modules directory

### DIFF
--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -311,7 +311,7 @@ LIBDIR={- our $libdir = $config{libdir};
 libdir={- file_name_is_absolute($libdir)
           ? $libdir : '$(INSTALLTOP)/$(LIBDIR)' -}
 ENGINESDIR=$(libdir)/engines-{- $sover_dirname -}
-MODULESDIR=$(libdir)/ossl-modules
+MODULESDIR=$(libdir)/ossl-modules-{- $sover_dirname -}
 
 # Convenience variable for those who want to set the rpath in shared
 # libraries and applications

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -222,7 +222,7 @@ MODULESDIR_dev={- use File::Spec::Functions qw(:DEFAULT splitpath catpath);
                       splitpath($modulesprefix, 1);
                   our $modulesdir_dev = $modulesprefix_dev;
                   our $modulesdir_dir =
-                      catdir($modulesprefix_dir, "ossl-modules");
+                      catdir($modulesprefix_dir, "ossl-modules-$sover_dirname");
                   our $modulesdir = catpath($modulesdir_dev, $modulesdir_dir);
                   our $enginesdir_dev = $modulesprefix_dev;
                   our $enginesdir_dir =

--- a/README-FIPS.md
+++ b/README-FIPS.md
@@ -36,8 +36,8 @@ the FIPS provider independently, without installing the rest of OpenSSL.
 The Installation of the FIPS provider consists of two steps. In the first step,
 the shared library is copied to its installed location, which by default is
 
-    /usr/local/lib/ossl-modules/fips.so                  on Unix, and
-    C:\Program Files\OpenSSL\lib\ossl-modules\fips.dll   on Windows.
+    /usr/local/lib/ossl-modules-3.0/fips.so                  on Unix, and
+    C:\Program Files\OpenSSL\lib\ossl-modules-3.0\fips.dll   on Windows.
 
 In the second step, the `openssl fipsinstall` command is executed, which completes
 the installation by doing the following two things:


### PR DESCRIPTION
The OpenSSL shared libraies (libcrypto and libssl) have version info
embedded in their SONAME and filenames.
The engines directory has version information embedded in it.
The ossl-modules (where FIPS and legacy providers reside) does not
have any versioning information. This may cause problems when newer
non-ABI compatible versions of openssl (4.x in this case) become
available.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
