### PR TITLE
 DECODER & ENCODER: use property definitions instead of getting implementation parameters

### DIFF
--- a/crypto/encode_decode/decoder_lib.c
+++ b/crypto/encode_decode/decoder_lib.c
@@ -226,14 +226,24 @@ OSSL_DECODER_INSTANCE *ossl_decoder_instance_new(OSSL_DECODER *decoder,
     prov = OSSL_DECODER_get0_provider(decoder);
     libctx = ossl_provider_libctx(prov);
     props = ossl_decoder_parsed_properties(decoder);
-    if (props == NULL)
+    if (props == NULL) {
+        ERR_raise_data(ERR_LIB_OSSL_DECODER, ERR_R_INVALID_PROPERTY_DEFINITION,
+                       "there are no property definitions with decoder %s",
+                       OSSL_DECODER_get0_name(decoder));
         goto err;
+    }
 
     /* The "input" property is mandatory */
     prop = ossl_property_find_property(props, libctx, "input");
     decoder_inst->input_type = ossl_property_get_string_value(libctx, prop);
-    if (decoder_inst->input_type == NULL)
+    if (decoder_inst->input_type == NULL) {
+        ERR_raise_data(ERR_LIB_OSSL_DECODER, ERR_R_INVALID_PROPERTY_DEFINITION,
+                       "the mandatory 'input' property is missing "
+                       "for decoder %s (properties: %s)",
+                       OSSL_DECODER_get0_name(decoder),
+                       OSSL_DECODER_get0_properties(decoder));
         goto err;
+    }
 
     /* The "structure" property is optional */
     prop = ossl_property_find_property(props, libctx, "structure");

--- a/crypto/encode_decode/decoder_meth.c
+++ b/crypto/encode_decode/decoder_meth.c
@@ -59,6 +59,7 @@ void OSSL_DECODER_free(OSSL_DECODER *decoder)
     if (ref > 0)
         return;
     OPENSSL_free(decoder->base.name);
+    ossl_property_free(decoder->base.parsed_propdef);
     ossl_provider_free(decoder->base.prov);
     CRYPTO_THREAD_lock_free(decoder->base.lock);
     OPENSSL_free(decoder);

--- a/crypto/encode_decode/decoder_meth.c
+++ b/crypto/encode_decode/decoder_meth.c
@@ -166,6 +166,7 @@ void *ossl_decoder_from_algorithm(int id, const OSSL_ALGORITHM *algodef,
 {
     OSSL_DECODER *decoder = NULL;
     const OSSL_DISPATCH *fns = algodef->implementation;
+    OSSL_LIB_CTX *libctx = ossl_provider_libctx(prov);
 
     if ((decoder = ossl_decoder_new()) == NULL)
         return NULL;
@@ -176,6 +177,8 @@ void *ossl_decoder_from_algorithm(int id, const OSSL_ALGORITHM *algodef,
     }
     decoder->base.propdef = algodef->property_definition;
     decoder->base.description = algodef->algorithm_description;
+    decoder->base.parsed_propdef
+        = ossl_parse_property(libctx, algodef->property_definition);
 
     for (; fns->function_id != 0; fns++) {
         switch (fns->function_id) {
@@ -419,6 +422,17 @@ const char *OSSL_DECODER_get0_properties(const OSSL_DECODER *decoder)
     }
 
     return decoder->base.propdef;
+}
+
+const OSSL_PROPERTY_LIST *
+ossl_decoder_parsed_properties(const OSSL_DECODER *decoder)
+{
+    if (!ossl_assert(decoder != NULL)) {
+        ERR_raise(ERR_LIB_OSSL_DECODER, ERR_R_PASSED_NULL_PARAMETER);
+        return 0;
+    }
+
+    return decoder->base.parsed_propdef;
 }
 
 int ossl_decoder_get_number(const OSSL_DECODER *decoder)

--- a/crypto/encode_decode/encoder_lib.c
+++ b/crypto/encode_decode/encoder_lib.c
@@ -16,6 +16,7 @@
 #include <openssl/provider.h>
 #include <openssl/trace.h>
 #include "internal/bio.h"
+#include "internal/provider.h"
 #include "encoder_local.h"
 
 struct encoder_process_data_st {
@@ -180,16 +181,13 @@ static OSSL_ENCODER_INSTANCE *ossl_encoder_instance_new(OSSL_ENCODER *encoder,
                                                         void *encoderctx)
 {
     OSSL_ENCODER_INSTANCE *encoder_inst = NULL;
-    OSSL_PARAM params[4];
+    const OSSL_PROVIDER *prov;
+    OSSL_LIB_CTX *libctx;
+    const OSSL_PROPERTY_LIST *props;
+    const OSSL_PROPERTY_DEFINITION *prop;
 
     if (!ossl_assert(encoder != NULL)) {
         ERR_raise(ERR_LIB_OSSL_ENCODER, ERR_R_PASSED_NULL_PARAMETER);
-        return 0;
-    }
-
-    if (encoder->get_params == NULL) {
-        ERR_raise(ERR_LIB_OSSL_ENCODER,
-                  OSSL_ENCODER_R_MISSING_GET_PARAMS);
         return 0;
     }
 
@@ -198,27 +196,28 @@ static OSSL_ENCODER_INSTANCE *ossl_encoder_instance_new(OSSL_ENCODER *encoder,
         return 0;
     }
 
-    /*
-     * Cache the input and output types for this encoder.  The output type
-     * is mandatory.
-     */
-    params[0] =
-        OSSL_PARAM_construct_utf8_ptr(OSSL_ENCODER_PARAM_OUTPUT_TYPE,
-                                      (char **)&encoder_inst->output_type, 0);
-    params[1] =
-        OSSL_PARAM_construct_utf8_ptr(OSSL_ENCODER_PARAM_OUTPUT_STRUCTURE,
-                                      (char **)&encoder_inst->output_structure,
-                                      0);
-    params[2] = OSSL_PARAM_construct_end();
-
-    if (!encoder->get_params(params)
-        || !OSSL_PARAM_modified(&params[0]))
-        goto err;
-
     if (!OSSL_ENCODER_up_ref(encoder)) {
         ERR_raise(ERR_LIB_OSSL_ENCODER, ERR_R_INTERNAL_ERROR);
         goto err;
     }
+
+    prov = OSSL_ENCODER_get0_provider(encoder);
+    libctx = ossl_provider_libctx(prov);
+    props = ossl_encoder_parsed_properties(encoder);
+    if (props == NULL)
+        goto err;
+
+    /* The "output" property is mandatory */
+    prop = ossl_property_find_property(props, libctx, "output");
+    encoder_inst->output_type = ossl_property_get_string_value(libctx, prop);
+    if (encoder_inst->output_type == NULL)
+        goto err;
+
+    /* The "structure" property is optional */
+    prop = ossl_property_find_property(props, libctx, "structure");
+    if (prop != NULL)
+        encoder_inst->output_structure
+            = ossl_property_get_string_value(libctx, prop);
 
     encoder_inst->encoder = encoder;
     encoder_inst->encoderctx = encoderctx;

--- a/crypto/encode_decode/encoder_lib.c
+++ b/crypto/encode_decode/encoder_lib.c
@@ -204,14 +204,24 @@ static OSSL_ENCODER_INSTANCE *ossl_encoder_instance_new(OSSL_ENCODER *encoder,
     prov = OSSL_ENCODER_get0_provider(encoder);
     libctx = ossl_provider_libctx(prov);
     props = ossl_encoder_parsed_properties(encoder);
-    if (props == NULL)
+    if (props == NULL) {
+        ERR_raise_data(ERR_LIB_OSSL_DECODER, ERR_R_INVALID_PROPERTY_DEFINITION,
+                       "there are no property definitions with encoder %s",
+                       OSSL_ENCODER_get0_name(encoder));
         goto err;
+    }
 
     /* The "output" property is mandatory */
     prop = ossl_property_find_property(props, libctx, "output");
     encoder_inst->output_type = ossl_property_get_string_value(libctx, prop);
-    if (encoder_inst->output_type == NULL)
+    if (encoder_inst->output_type == NULL) {
+        ERR_raise_data(ERR_LIB_OSSL_DECODER, ERR_R_INVALID_PROPERTY_DEFINITION,
+                       "the mandatory 'output' property is missing "
+                       "for encoder %s (properties: %s)",
+                       OSSL_ENCODER_get0_name(encoder),
+                       OSSL_ENCODER_get0_properties(encoder));
         goto err;
+    }
 
     /* The "structure" property is optional */
     prop = ossl_property_find_property(props, libctx, "structure");

--- a/crypto/encode_decode/encoder_local.h
+++ b/crypto/encode_decode/encoder_local.h
@@ -14,6 +14,7 @@
 #include <openssl/decoder.h>
 #include "internal/cryptlib.h"
 #include "internal/passphrase.h"
+#include "internal/property.h"
 #include "internal/refcount.h"
 
 struct ossl_endecode_base_st {
@@ -22,6 +23,7 @@ struct ossl_endecode_base_st {
     char *name;
     const char *propdef;
     const char *description;
+    OSSL_PROPERTY_LIST *parsed_propdef;
 
     CRYPTO_REF_COUNT refcnt;
     CRYPTO_RWLOCK *lock;
@@ -157,3 +159,7 @@ struct ossl_decoder_ctx_st {
     /* For any function that needs a passphrase reader */
     struct ossl_passphrase_data_st pwdata;
 };
+
+
+const OSSL_PROPERTY_LIST *
+ossl_decoder_parsed_properties(const OSSL_DECODER *decoder);

--- a/crypto/encode_decode/encoder_local.h
+++ b/crypto/encode_decode/encoder_local.h
@@ -162,3 +162,5 @@ struct ossl_decoder_ctx_st {
 
 const OSSL_PROPERTY_LIST *
 ossl_decoder_parsed_properties(const OSSL_DECODER *decoder);
+const OSSL_PROPERTY_LIST *
+ossl_encoder_parsed_properties(const OSSL_ENCODER *encoder);

--- a/crypto/encode_decode/encoder_local.h
+++ b/crypto/encode_decode/encoder_local.h
@@ -159,7 +159,6 @@ struct ossl_decoder_ctx_st {
     struct ossl_passphrase_data_st pwdata;
 };
 
-
 const OSSL_PROPERTY_LIST *
 ossl_decoder_parsed_properties(const OSSL_DECODER *decoder);
 const OSSL_PROPERTY_LIST *

--- a/crypto/encode_decode/encoder_local.h
+++ b/crypto/encode_decode/encoder_local.h
@@ -59,7 +59,6 @@ struct ossl_decoder_st {
 struct ossl_encoder_instance_st {
     OSSL_ENCODER *encoder;        /* Never NULL */
     void *encoderctx;             /* Never NULL */
-    const char *input_type;       /* May be NULL */
     const char *output_type;      /* Never NULL */
     const char *output_structure; /* May be NULL */
 };

--- a/crypto/encode_decode/encoder_meth.c
+++ b/crypto/encode_decode/encoder_meth.c
@@ -59,6 +59,7 @@ void OSSL_ENCODER_free(OSSL_ENCODER *encoder)
     if (ref > 0)
         return;
     OPENSSL_free(encoder->base.name);
+    ossl_property_free(encoder->base.parsed_propdef);
     ossl_provider_free(encoder->base.prov);
     CRYPTO_THREAD_lock_free(encoder->base.lock);
     OPENSSL_free(encoder);

--- a/crypto/err/err.c
+++ b/crypto/err/err.c
@@ -125,6 +125,8 @@ static ERR_STRING_DATA ERR_str_reasons[] = {
      * unsupported.
      */
     {ERR_R_FETCH_FAILED, "fetch failed"},
+
+    {ERR_R_INVALID_PROPERTY_DEFINITION, "invalid property definition"},
     {0, NULL},
 };
 #endif

--- a/crypto/property/build.info
+++ b/crypto/property/build.info
@@ -1,5 +1,5 @@
 LIBS=../../libcrypto
-$COMMON=property_string.c property_parse.c property.c defn_cache.c
+$COMMON=property_string.c property_parse.c property_query.c property.c defn_cache.c
 SOURCE[../../libcrypto]=$COMMON property_err.c
 SOURCE[../../providers/libfips.a]=$COMMON
 SOURCE[../../providers/liblegacy.a]=$COMMON

--- a/crypto/property/property_local.h
+++ b/crypto/property/property_local.h
@@ -13,6 +13,27 @@
 
 typedef int OSSL_PROPERTY_IDX;
 
+typedef enum {
+    OSSL_PROPERTY_OPER_EQ, OSSL_PROPERTY_OPER_NE, OSSL_PROPERTY_OVERRIDE
+} OSSL_PROPERTY_OPER;
+
+struct ossl_property_definition_st {
+    OSSL_PROPERTY_IDX name_idx;
+    OSSL_PROPERTY_TYPE type;
+    OSSL_PROPERTY_OPER oper;
+    unsigned int optional : 1;
+    union {
+        int64_t             int_val;     /* Signed integer */
+        OSSL_PROPERTY_IDX   str_val;     /* String */
+    } v;
+};
+
+struct ossl_property_list_st {
+    int n;
+    unsigned int has_optional : 1;
+    OSSL_PROPERTY_DEFINITION properties[1];
+};
+
 /* Property string functions */
 OSSL_PROPERTY_IDX ossl_property_name(OSSL_LIB_CTX *ctx, const char *s,
                                      int create);

--- a/crypto/property/property_parse.c
+++ b/crypto/property/property_parse.c
@@ -19,35 +19,9 @@
 #include "property_local.h"
 #include "e_os.h"
 
-typedef enum {
-    PROPERTY_TYPE_STRING, PROPERTY_TYPE_NUMBER,
-    PROPERTY_TYPE_VALUE_UNDEFINED
-} PROPERTY_TYPE;
-
-typedef enum {
-    PROPERTY_OPER_EQ, PROPERTY_OPER_NE, PROPERTY_OVERRIDE
-} PROPERTY_OPER;
-
-typedef struct {
-    OSSL_PROPERTY_IDX name_idx;
-    PROPERTY_TYPE type;
-    PROPERTY_OPER oper;
-    unsigned int optional : 1;
-    union {
-        int64_t             int_val;     /* Signed integer */
-        OSSL_PROPERTY_IDX   str_val;     /* String */
-    } v;
-} PROPERTY_DEFINITION;
-
-struct ossl_property_list_st {
-    int n;
-    unsigned int has_optional : 1;
-    PROPERTY_DEFINITION properties[1];
-};
-
 static OSSL_PROPERTY_IDX ossl_property_true, ossl_property_false;
 
-DEFINE_STACK_OF(PROPERTY_DEFINITION)
+DEFINE_STACK_OF(OSSL_PROPERTY_DEFINITION)
 
 static const char *skip_space(const char *s)
 {
@@ -120,7 +94,7 @@ static int parse_name(OSSL_LIB_CTX *ctx, const char *t[], int create,
     return 1;
 }
 
-static int parse_number(const char *t[], PROPERTY_DEFINITION *res)
+static int parse_number(const char *t[], OSSL_PROPERTY_DEFINITION *res)
 {
     const char *s = *t;
     int64_t v = 0;
@@ -136,12 +110,12 @@ static int parse_number(const char *t[], PROPERTY_DEFINITION *res)
         return 0;
     }
     *t = skip_space(s);
-    res->type = PROPERTY_TYPE_NUMBER;
+    res->type = OSSL_PROPERTY_TYPE_NUMBER;
     res->v.int_val = v;
     return 1;
 }
 
-static int parse_hex(const char *t[], PROPERTY_DEFINITION *res)
+static int parse_hex(const char *t[], OSSL_PROPERTY_DEFINITION *res)
 {
     const char *s = *t;
     int64_t v = 0;
@@ -161,12 +135,12 @@ static int parse_hex(const char *t[], PROPERTY_DEFINITION *res)
         return 0;
     }
     *t = skip_space(s);
-    res->type = PROPERTY_TYPE_NUMBER;
+    res->type = OSSL_PROPERTY_TYPE_NUMBER;
     res->v.int_val = v;
     return 1;
 }
 
-static int parse_oct(const char *t[], PROPERTY_DEFINITION *res)
+static int parse_oct(const char *t[], OSSL_PROPERTY_DEFINITION *res)
 {
     const char *s = *t;
     int64_t v = 0;
@@ -182,13 +156,13 @@ static int parse_oct(const char *t[], PROPERTY_DEFINITION *res)
         return 0;
     }
     *t = skip_space(s);
-    res->type = PROPERTY_TYPE_NUMBER;
+    res->type = OSSL_PROPERTY_TYPE_NUMBER;
     res->v.int_val = v;
     return 1;
 }
 
 static int parse_string(OSSL_LIB_CTX *ctx, const char *t[], char delim,
-                        PROPERTY_DEFINITION *res, const int create)
+                        OSSL_PROPERTY_DEFINITION *res, const int create)
 {
     char v[1000];
     const char *s = *t;
@@ -214,12 +188,12 @@ static int parse_string(OSSL_LIB_CTX *ctx, const char *t[], char delim,
         res->v.str_val = ossl_property_value(ctx, v, create);
     }
     *t = skip_space(s + 1);
-    res->type = PROPERTY_TYPE_STRING;
+    res->type = OSSL_PROPERTY_TYPE_STRING;
     return !err;
 }
 
 static int parse_unquoted(OSSL_LIB_CTX *ctx, const char *t[],
-                          PROPERTY_DEFINITION *res, const int create)
+                          OSSL_PROPERTY_DEFINITION *res, const int create)
 {
     char v[1000];
     const char *s = *t;
@@ -247,12 +221,12 @@ static int parse_unquoted(OSSL_LIB_CTX *ctx, const char *t[],
         res->v.str_val = ossl_property_value(ctx, v, create);
     }
     *t = skip_space(s);
-    res->type = PROPERTY_TYPE_STRING;
+    res->type = OSSL_PROPERTY_TYPE_STRING;
     return !err;
 }
 
 static int parse_value(OSSL_LIB_CTX *ctx, const char *t[],
-                       PROPERTY_DEFINITION *res, int create)
+                       OSSL_PROPERTY_DEFINITION *res, int create)
 {
     const char *s = *t;
     int r = 0;
@@ -282,11 +256,11 @@ static int parse_value(OSSL_LIB_CTX *ctx, const char *t[],
     return r;
 }
 
-static int pd_compare(const PROPERTY_DEFINITION *const *p1,
-                      const PROPERTY_DEFINITION *const *p2)
+static int pd_compare(const OSSL_PROPERTY_DEFINITION *const *p1,
+                      const OSSL_PROPERTY_DEFINITION *const *p2)
 {
-    const PROPERTY_DEFINITION *pd1 = *p1;
-    const PROPERTY_DEFINITION *pd2 = *p2;
+    const OSSL_PROPERTY_DEFINITION *pd1 = *p1;
+    const OSSL_PROPERTY_DEFINITION *pd2 = *p2;
 
     if (pd1->name_idx < pd2->name_idx)
         return -1;
@@ -295,7 +269,7 @@ static int pd_compare(const PROPERTY_DEFINITION *const *p1,
     return 0;
 }
 
-static void pd_free(PROPERTY_DEFINITION *pd)
+static void pd_free(OSSL_PROPERTY_DEFINITION *pd)
 {
     OPENSSL_free(pd);
 }
@@ -304,21 +278,21 @@ static void pd_free(PROPERTY_DEFINITION *pd)
  * Convert a stack of property definitions and queries into a fixed array.
  * The items are sorted for efficient query.  The stack is not freed.
  */
-static OSSL_PROPERTY_LIST *stack_to_property_list(STACK_OF(PROPERTY_DEFINITION)
-                                                  *sk)
+static OSSL_PROPERTY_LIST *
+stack_to_property_list(STACK_OF(OSSL_PROPERTY_DEFINITION) *sk)
 {
-    const int n = sk_PROPERTY_DEFINITION_num(sk);
+    const int n = sk_OSSL_PROPERTY_DEFINITION_num(sk);
     OSSL_PROPERTY_LIST *r;
     int i;
 
     r = OPENSSL_malloc(sizeof(*r)
                        + (n <= 0 ? 0 : n - 1) * sizeof(r->properties[0]));
     if (r != NULL) {
-        sk_PROPERTY_DEFINITION_sort(sk);
+        sk_OSSL_PROPERTY_DEFINITION_sort(sk);
 
         r->has_optional = 0;
         for (i = 0; i < n; i++) {
-            r->properties[i] = *sk_PROPERTY_DEFINITION_value(sk, i);
+            r->properties[i] = *sk_OSSL_PROPERTY_DEFINITION_value(sk, i);
             r->has_optional |= r->properties[i].optional;
         }
         r->n = n;
@@ -328,13 +302,13 @@ static OSSL_PROPERTY_LIST *stack_to_property_list(STACK_OF(PROPERTY_DEFINITION)
 
 OSSL_PROPERTY_LIST *ossl_parse_property(OSSL_LIB_CTX *ctx, const char *defn)
 {
-    PROPERTY_DEFINITION *prop = NULL;
+    OSSL_PROPERTY_DEFINITION *prop = NULL;
     OSSL_PROPERTY_LIST *res = NULL;
-    STACK_OF(PROPERTY_DEFINITION) *sk;
+    STACK_OF(OSSL_PROPERTY_DEFINITION) *sk;
     const char *s = defn;
     int done;
 
-    if (s == NULL || (sk = sk_PROPERTY_DEFINITION_new(&pd_compare)) == NULL)
+    if (s == NULL || (sk = sk_OSSL_PROPERTY_DEFINITION_new(&pd_compare)) == NULL)
         return NULL;
 
     s = skip_space(s);
@@ -349,7 +323,7 @@ OSSL_PROPERTY_LIST *ossl_parse_property(OSSL_LIB_CTX *ctx, const char *defn)
         prop->optional = 0;
         if (!parse_name(ctx, &s, 1, &prop->name_idx))
             goto err;
-        prop->oper = PROPERTY_OPER_EQ;
+        prop->oper = OSSL_PROPERTY_OPER_EQ;
         if (prop->name_idx == 0) {
             ERR_raise_data(ERR_LIB_PROP, PROP_R_PARSE_FAILED,
                            "Unknown name HERE-->%s", start);
@@ -363,11 +337,11 @@ OSSL_PROPERTY_LIST *ossl_parse_property(OSSL_LIB_CTX *ctx, const char *defn)
             }
         } else {
             /* A name alone means a true Boolean */
-            prop->type = PROPERTY_TYPE_STRING;
+            prop->type = OSSL_PROPERTY_TYPE_STRING;
             prop->v.str_val = ossl_property_true;
         }
 
-        if (!sk_PROPERTY_DEFINITION_push(sk, prop))
+        if (!sk_OSSL_PROPERTY_DEFINITION_push(sk, prop))
             goto err;
         prop = NULL;
         done = !match_ch(&s, ',');
@@ -381,19 +355,19 @@ OSSL_PROPERTY_LIST *ossl_parse_property(OSSL_LIB_CTX *ctx, const char *defn)
 
 err:
     OPENSSL_free(prop);
-    sk_PROPERTY_DEFINITION_pop_free(sk, &pd_free);
+    sk_OSSL_PROPERTY_DEFINITION_pop_free(sk, &pd_free);
     return res;
 }
 
 OSSL_PROPERTY_LIST *ossl_parse_query(OSSL_LIB_CTX *ctx, const char *s,
                                      int create_values)
 {
-    STACK_OF(PROPERTY_DEFINITION) *sk;
+    STACK_OF(OSSL_PROPERTY_DEFINITION) *sk;
     OSSL_PROPERTY_LIST *res = NULL;
-    PROPERTY_DEFINITION *prop = NULL;
+    OSSL_PROPERTY_DEFINITION *prop = NULL;
     int done;
 
-    if (s == NULL || (sk = sk_PROPERTY_DEFINITION_new(&pd_compare)) == NULL)
+    if (s == NULL || (sk = sk_OSSL_PROPERTY_DEFINITION_new(&pd_compare)) == NULL)
         return NULL;
 
     s = skip_space(s);
@@ -405,7 +379,7 @@ OSSL_PROPERTY_LIST *ossl_parse_query(OSSL_LIB_CTX *ctx, const char *s,
         memset(&prop->v, 0, sizeof(prop->v));
 
         if (match_ch(&s, '-')) {
-            prop->oper = PROPERTY_OVERRIDE;
+            prop->oper = OSSL_PROPERTY_OVERRIDE;
             prop->optional = 0;
             if (!parse_name(ctx, &s, 1, &prop->name_idx))
                 goto err;
@@ -416,21 +390,21 @@ OSSL_PROPERTY_LIST *ossl_parse_query(OSSL_LIB_CTX *ctx, const char *s,
             goto err;
 
         if (match_ch(&s, '=')) {
-            prop->oper = PROPERTY_OPER_EQ;
+            prop->oper = OSSL_PROPERTY_OPER_EQ;
         } else if (MATCH(&s, "!=")) {
-            prop->oper = PROPERTY_OPER_NE;
+            prop->oper = OSSL_PROPERTY_OPER_NE;
         } else {
             /* A name alone is a Boolean comparison for true */
-            prop->oper = PROPERTY_OPER_EQ;
-            prop->type = PROPERTY_TYPE_STRING;
+            prop->oper = OSSL_PROPERTY_OPER_EQ;
+            prop->type = OSSL_PROPERTY_TYPE_STRING;
             prop->v.str_val = ossl_property_true;
             goto skip_value;
         }
         if (!parse_value(ctx, &s, prop, create_values))
-            prop->type = PROPERTY_TYPE_VALUE_UNDEFINED;
+            prop->type = OSSL_PROPERTY_TYPE_VALUE_UNDEFINED;
 
 skip_value:
-        if (!sk_PROPERTY_DEFINITION_push(sk, prop))
+        if (!sk_OSSL_PROPERTY_DEFINITION_push(sk, prop))
             goto err;
         prop = NULL;
         done = !match_ch(&s, ',');
@@ -444,7 +418,7 @@ skip_value:
 
 err:
     OPENSSL_free(prop);
-    sk_PROPERTY_DEFINITION_pop_free(sk, &pd_free);
+    sk_OSSL_PROPERTY_DEFINITION_pop_free(sk, &pd_free);
     return res;
 }
 
@@ -459,7 +433,7 @@ int ossl_property_is_enabled(OSSL_LIB_CTX *ctx,  const char *property_name,
 {
     int i;
     OSSL_PROPERTY_IDX name_id;
-    const PROPERTY_DEFINITION *prop = NULL;
+    const OSSL_PROPERTY_DEFINITION *prop = NULL;
 
     if (prop_list == NULL)
         return 0;
@@ -471,12 +445,12 @@ int ossl_property_is_enabled(OSSL_LIB_CTX *ctx,  const char *property_name,
     for (i = 0; i < prop_list->n; ++i) {
         if (prop[i].name_idx == name_id) {
             /* Do a separate check for override as it does not set type */
-            if (prop[i].optional || prop[i].oper == PROPERTY_OVERRIDE)
+            if (prop[i].optional || prop[i].oper == OSSL_PROPERTY_OVERRIDE)
                 return 0;
-            return (prop[i].type == PROPERTY_TYPE_STRING
-                    && ((prop[i].oper == PROPERTY_OPER_EQ
+            return (prop[i].type == OSSL_PROPERTY_TYPE_STRING
+                    && ((prop[i].oper == OSSL_PROPERTY_OPER_EQ
                              && prop[i].v.str_val == ossl_property_true)
-                         || (prop[i].oper == PROPERTY_OPER_NE
+                         || (prop[i].oper == OSSL_PROPERTY_OPER_NE
                              && prop[i].v.str_val != ossl_property_true)));
         }
     }
@@ -490,13 +464,13 @@ int ossl_property_is_enabled(OSSL_LIB_CTX *ctx,  const char *property_name,
 int ossl_property_match_count(const OSSL_PROPERTY_LIST *query,
                               const OSSL_PROPERTY_LIST *defn)
 {
-    const PROPERTY_DEFINITION *const q = query->properties;
-    const PROPERTY_DEFINITION *const d = defn->properties;
+    const OSSL_PROPERTY_DEFINITION *const q = query->properties;
+    const OSSL_PROPERTY_DEFINITION *const d = defn->properties;
     int i = 0, j = 0, matches = 0;
-    PROPERTY_OPER oper;
+    OSSL_PROPERTY_OPER oper;
 
     while (i < query->n) {
-        if ((oper = q[i].oper) == PROPERTY_OVERRIDE) {
+        if ((oper = q[i].oper) == OSSL_PROPERTY_OVERRIDE) {
             i++;
             continue;
         }
@@ -509,8 +483,8 @@ int ossl_property_match_count(const OSSL_PROPERTY_LIST *query,
                 const int eq = q[i].type == d[j].type
                                && memcmp(&q[i].v, &d[j].v, sizeof(q[i].v)) == 0;
 
-                if ((eq && oper == PROPERTY_OPER_EQ)
-                    || (!eq && oper == PROPERTY_OPER_NE))
+                if ((eq && oper == OSSL_PROPERTY_OPER_EQ)
+                    || (!eq && oper == OSSL_PROPERTY_OPER_NE))
                     matches++;
                 else if (!q[i].optional)
                     return -1;
@@ -525,15 +499,15 @@ int ossl_property_match_count(const OSSL_PROPERTY_LIST *query,
          * definition.  The former fails for any comparison except inequality,
          * the latter is treated as a comparison against the Boolean false.
          */
-        if (q[i].type == PROPERTY_TYPE_VALUE_UNDEFINED) {
-            if (oper == PROPERTY_OPER_NE)
+        if (q[i].type == OSSL_PROPERTY_TYPE_VALUE_UNDEFINED) {
+            if (oper == OSSL_PROPERTY_OPER_NE)
                 matches++;
             else if (!q[i].optional)
                 return -1;
-        } else if (q[i].type != PROPERTY_TYPE_STRING
-                   || (oper == PROPERTY_OPER_EQ
+        } else if (q[i].type != OSSL_PROPERTY_TYPE_STRING
+                   || (oper == OSSL_PROPERTY_OPER_EQ
                        && q[i].v.str_val != ossl_property_false)
-                   || (oper == PROPERTY_OPER_NE
+                   || (oper == OSSL_PROPERTY_OPER_NE
                        && q[i].v.str_val == ossl_property_false)) {
             if (!q[i].optional)
                 return -1;
@@ -557,9 +531,9 @@ void ossl_property_free(OSSL_PROPERTY_LIST *p)
 OSSL_PROPERTY_LIST *ossl_property_merge(const OSSL_PROPERTY_LIST *a,
                                         const OSSL_PROPERTY_LIST *b)
 {
-    const PROPERTY_DEFINITION *const ap = a->properties;
-    const PROPERTY_DEFINITION *const bp = b->properties;
-    const PROPERTY_DEFINITION *copy;
+    const OSSL_PROPERTY_DEFINITION *const ap = a->properties;
+    const OSSL_PROPERTY_DEFINITION *const bp = b->properties;
+    const OSSL_PROPERTY_DEFINITION *copy;
     OSSL_PROPERTY_LIST *r;
     int i, j, n;
     const int t = a->n + b->n;
@@ -689,7 +663,7 @@ size_t ossl_property_list_to_string(OSSL_LIB_CTX *ctx,
                                     size_t bufsize)
 {
     int i;
-    const PROPERTY_DEFINITION *prop = NULL;
+    const OSSL_PROPERTY_DEFINITION *prop = NULL;
     size_t needed = 0;
     const char *val;
 
@@ -710,7 +684,7 @@ size_t ossl_property_list_to_string(OSSL_LIB_CTX *ctx,
 
         if (prop->optional)
             put_char('?', &buf, &bufsize, &needed);
-        else if (prop->oper == PROPERTY_OVERRIDE)
+        else if (prop->oper == OSSL_PROPERTY_OVERRIDE)
             put_char('-', &buf, &bufsize, &needed);
 
         val = ossl_property_name_str(ctx, prop->name_idx);
@@ -719,21 +693,21 @@ size_t ossl_property_list_to_string(OSSL_LIB_CTX *ctx,
         put_str(val, &buf, &bufsize, &needed);
 
         switch (prop->oper) {
-            case PROPERTY_OPER_NE:
+            case OSSL_PROPERTY_OPER_NE:
                 put_char('!', &buf, &bufsize, &needed);
                 /* fall through */
-            case PROPERTY_OPER_EQ:
+            case OSSL_PROPERTY_OPER_EQ:
                 put_char('=', &buf, &bufsize, &needed);
                 /* put value */
                 switch (prop->type) {
-                case PROPERTY_TYPE_STRING:
+                case OSSL_PROPERTY_TYPE_STRING:
                     val = ossl_property_value_str(ctx, prop->v.str_val);
                     if (val == NULL)
                         return 0;
                     put_str(val, &buf, &bufsize, &needed);
                     break;
 
-                case PROPERTY_TYPE_NUMBER:
+                case OSSL_PROPERTY_TYPE_NUMBER:
                     put_num(prop->v.int_val, &buf, &bufsize, &needed);
                     break;
 

--- a/crypto/property/property_query.c
+++ b/crypto/property/property_query.c
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2021 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include "internal/propertyerr.h"
+#include "internal/property.h"
+#include "property_local.h"
+
+const OSSL_PROPERTY_DEFINITION *
+ossl_property_find_property(const OSSL_PROPERTY_LIST *list,
+                            OSSL_LIB_CTX *libctx, const char *name)
+{
+    OSSL_PROPERTY_IDX name_idx;
+    int i;
+
+    if (list == NULL || name == NULL
+        || (name_idx = ossl_property_name(libctx, name, 0)) == 0)
+        return NULL;
+
+    for (i = 0; i < list->n; i++)
+        if (list->properties[i].name_idx == name_idx)
+            return &list->properties[i];
+    return NULL;
+}
+
+OSSL_PROPERTY_TYPE ossl_property_get_type(const OSSL_PROPERTY_DEFINITION *prop)
+{
+    return prop->type;
+}
+
+const char *ossl_property_get_string_value(OSSL_LIB_CTX *libctx,
+                                           const OSSL_PROPERTY_DEFINITION *prop)
+{
+    const char *value = NULL;
+
+    if (prop != NULL && prop->type == OSSL_PROPERTY_TYPE_STRING)
+        value = ossl_property_value_str(libctx, prop->v.str_val);
+    return value;
+}
+
+int64_t ossl_property_get_number_value(const OSSL_PROPERTY_DEFINITION *prop)
+{
+    int64_t value = 0;
+
+    if (prop != NULL && prop->type == OSSL_PROPERTY_TYPE_NUMBER)
+        value = prop->v.int_val;
+    return value;
+}

--- a/doc/man3/OSSL_ENCODER_CTX.pod
+++ b/doc/man3/OSSL_ENCODER_CTX.pod
@@ -16,7 +16,6 @@ OSSL_ENCODER_CTX_get_num_encoders,
 OSSL_ENCODER_INSTANCE,
 OSSL_ENCODER_INSTANCE_get_encoder,
 OSSL_ENCODER_INSTANCE_get_encoder_ctx,
-OSSL_ENCODER_INSTANCE_get_input_type,
 OSSL_ENCODER_INSTANCE_get_output_type,
 OSSL_ENCODER_INSTANCE_get_output_structure,
 OSSL_ENCODER_CONSTRUCT,
@@ -54,8 +53,6 @@ OSSL_ENCODER_CTX_set_cleanup
  OSSL_ENCODER_INSTANCE_get_encoder(OSSL_ENCODER_INSTANCE *encoder_inst);
  void *
  OSSL_ENCODER_INSTANCE_get_encoder_ctx(OSSL_ENCODER_INSTANCE *encoder_inst);
- const char *
- OSSL_ENCODER_INSTANCE_get_input_type(OSSL_ENCODER_INSTANCE *encoder_inst);
  const char *
  OSSL_ENCODER_INSTANCE_get_output_type(OSSL_ENCODER_INSTANCE *encoder_inst);
  const char *
@@ -160,14 +157,6 @@ implementation of the encoder instance I<encoder_inst>.
 
 OSSL_ENCODER_INSTANCE_get_encoder_ctx() can be used to get the encoder
 implementation's provider context of the encoder instance I<encoder_inst>.
-
-OSSL_ENCODER_INSTANCE_get_input_type() can be used to get the input type for
-the encoder implementation of the encoder instance I<encoder_inst>.
-This may be NULL.
-
-OSSL_ENCODER_INSTANCE_get_output_type() can be used to get the output type
-for the encoder implementation of the encoder instance I<encoder_inst>.
-This will never be NULL.
 
 OSSL_ENCODER_INSTANCE_get_output_type() can be used to get the output type
 for the encoder implementation of the encoder instance I<encoder_inst>.

--- a/doc/man7/provider-decoder.pod
+++ b/doc/man7/provider-decoder.pod
@@ -117,7 +117,11 @@ Properties can be used to further specify details about an implementation:
 =item input
 
 This property is used to specify what format of input the implementation
-can decode.  OpenSSL providers recognize the following input types:
+can decode.
+
+This property is I<mandatory>.
+
+OpenSSL providers recognize the following input types:
 
 =over 4
 
@@ -142,9 +146,25 @@ An implementation with that input type decodes PVK formatted data.
 =item structure
 
 This property is used to specify the structure that the decoded data is
-expected to have. An example could be C<pkcs8>, to specify explicitly that
-the object to be decoded (presumably an asymmetric key pair, in this case)
-is wrapped in a PKCS#8 structure.
+expected to have.
+
+This property is I<optional>.
+
+Structures currently recognised by built-in decoders:
+
+=over 4
+
+=item "type-specific"
+
+Type specific structure.
+
+=item "pkcs8"
+
+Structure according to the PKCS#8 specification.
+
+=item "SubjectPublicKeyInfo"
+
+Encoding of public keys according to the Subject Public Key Info of RFC 5280.
 
 =back
 
@@ -235,80 +255,6 @@ possible for some other decoder implementation to get a different result.
 
 The conditions to stop the decoding process are at the discretion of the
 implementation.
-
-=head2 Decoder parameters
-
-The decoder implementation itself has parameters that can be used to
-determine how it fits in a chain of decoders:
-
-=over 4
-
-=item "input-type" (B<OSSL_DECODER_PARAM_INPUT_TYPE>) <UTF8 string>
-
-This is used to specify the input type for a decoder implementation.
-
-This parameter is I<mandatory>.
-
-Input types currently recognized by built-in decoders:
-
-=over 4
-
-=item "DER"
-
-ASN.1 DER encoded binary data
-
-=item "PEM"
-
-Base64 encoded data with PEM headers
-
-=item "MSBLOB"
-
-Private or public key encoding according to Microsoft specification
-
-=item "PVK"
-
-Encrypted private key encoding according to Microsoft specification
-
-=back
-
-=for comment If we had functionality to get the value of a specific property
-in a set of properties, it would be possible to determine the input type
-from the C<input> property.
-
-=item "input-structure" (B<OSSL_ENCODER_PARAM_INPUT_STRUCTURE>) <UTF8 string>
-
-This is used to specify the outermost input structure for a decoder
-implementation.
-
-For example, an input of type "DER" for a key pair could be structured
-using PKCS#8, or a key type specific structure, such as PKCS#1 for RSA
-keys.
-
-This parameter is I<optional>.
-
-Input structures currently recognized by built-in decoders:
-
-=over 4
-
-=item "type-specific"
-
-Type specific structure.
-
-=item "PKCS8"
-
-Structure according to the PKCS#8 specification.
-
-=item "SubjectPublicKeyInfo"
-
-Encoding of public keys according to the Subject Public Key Info of RFC 5280.
-
-=back
-
-=for comment If we had functionality to get the value of a specific property
-in a set of properties, it would be possible to determine the input
-structure from the C<structure> property.
-
-=back
 
 =head2 Decoder operation parameters
 

--- a/doc/man7/provider-decoder.pod
+++ b/doc/man7/provider-decoder.pod
@@ -168,6 +168,8 @@ Encoding of public keys according to the Subject Public Key Info of RFC 5280.
 
 =back
 
+=back
+
 The possible values of both these properties is open ended.  A provider may
 very well specify input types and structures that libcrypto doesn't know
 anything about.

--- a/doc/man7/provider-encoder.pod
+++ b/doc/man7/provider-encoder.pod
@@ -247,15 +247,6 @@ determine how it fits in a chain of encoders:
 
 =over 4
 
-=item "input-type" (B<OSSL_ENCODER_PARAM_INPUT_TYPE>) <UTF8 string>
-
-This is used to specify a distinct type name for the object passed as
-I<obj_raw> to OSSL_FUNC_encoder_encode.
-
-This parameter is an optional parameter, to be used if the name of the
-implementation can be ambiguous because of aliases, and something more
-deterministic is needed.
-
 =item "output-type" (B<OSSL_ENCODER_PARAM_OUTPUT_TYPE>) <UTF8 string>
 
 This is used to specify the output type for an ENCODER implementation.

--- a/doc/man7/provider-encoder.pod
+++ b/doc/man7/provider-encoder.pod
@@ -133,7 +133,7 @@ Properties can be used to further specify details about an implementation:
 
 =item output
 
-This property is used to specify what type of output implementation
+This property is used to specify what type of output the implementation
 produces.
 
 This property is I<mandatory>.

--- a/doc/man7/provider-encoder.pod
+++ b/doc/man7/provider-encoder.pod
@@ -134,7 +134,11 @@ Properties can be used to further specify details about an implementation:
 =item output
 
 This property is used to specify what type of output implementation
-produces.  OpenSSL providers recognize the following output types:
+produces.
+
+This property is I<mandatory>.
+
+OpenSSL providers recognize the following output types:
 
 =over 4
 
@@ -168,6 +172,8 @@ This property is used to specify the structure that is used for the encoded
 object.  An example could be C<pkcs8>, to specify explicitly that an object
 (presumably an asymmetric key pair, in this case) will be wrapped in a
 PKCS#8 structure as part of the encoding.
+
+This property is I<optional>.
 
 =back
 
@@ -239,38 +245,6 @@ if relevant, should determine in greater detail what will be output.
 The encoding functions also take an B<OSSL_PASSPHRASE_CALLBACK> function
 pointer along with a pointer to application data I<cbarg>, which should be
 used when a pass phrase prompt is needed.
-
-=head2 Encoder parameters
-
-The ENCODER implementation itself has parameters that can be used to
-determine how it fits in a chain of encoders:
-
-=over 4
-
-=item "output-type" (B<OSSL_ENCODER_PARAM_OUTPUT_TYPE>) <UTF8 string>
-
-This is used to specify the output type for an ENCODER implementation.
-
-This parameter is I<mandatory>.
-
-=for comment If we had functionality to get the value of a specific property
-in a set of properties, it would be possible to determine the output type
-from the C<output> property.
-
-=item "output-structure" (B<OSSL_ENCODER_PARAM_OUTPUT_STRUCTURE>) <UTF8 string>
-
-This is used to specify the outermost output structure for an ENCODER
-implementation.
-
-For example, an output of type "DER" for a key pair could be structured
-using PKCS#8, or a key type specific structure, such as PKCS#1 for RSA
-keys.
-
-=for comment If we had functionality to get the value of a specific property
-in a set of properties, it would be possible to determine the output
-structure from the C<structure> property.
-
-=back
 
 =head2 Encoder operation parameters
 

--- a/include/internal/property.h
+++ b/include/internal/property.h
@@ -17,6 +17,12 @@
 typedef struct ossl_method_store_st OSSL_METHOD_STORE;
 typedef struct ossl_property_list_st OSSL_PROPERTY_LIST;
 
+typedef enum {
+    OSSL_PROPERTY_TYPE_STRING, OSSL_PROPERTY_TYPE_NUMBER,
+    OSSL_PROPERTY_TYPE_VALUE_UNDEFINED
+} OSSL_PROPERTY_TYPE;
+typedef struct ossl_property_definition_st OSSL_PROPERTY_DEFINITION;
+
 /* Initialisation */
 int ossl_property_parse_init(OSSL_LIB_CTX *ctx);
 
@@ -32,6 +38,15 @@ int ossl_property_is_enabled(OSSL_LIB_CTX *ctx,  const char *property_name,
                              const OSSL_PROPERTY_LIST *prop_list);
 /* Free a parsed property list */
 void ossl_property_free(OSSL_PROPERTY_LIST *p);
+
+/* Get a property from a property list */
+const OSSL_PROPERTY_DEFINITION *
+ossl_property_find_property(const OSSL_PROPERTY_LIST *list,
+                            OSSL_LIB_CTX *libctx, const char *name);
+OSSL_PROPERTY_TYPE ossl_property_get_type(const OSSL_PROPERTY_DEFINITION *prop);
+const char *ossl_property_get_string_value(OSSL_LIB_CTX *libctx,
+                                           const OSSL_PROPERTY_DEFINITION *prop);
+int64_t ossl_property_get_number_value(const OSSL_PROPERTY_DEFINITION *prop);
 
 
 /* Implementation store functions */

--- a/include/openssl/core_names.h
+++ b/include/openssl/core_names.h
@@ -475,8 +475,6 @@ extern "C" {
 #define OSSL_ENCODER_PARAM_SAVE_PARAMETERS  "save-parameters" /* integer */
 
 #define OSSL_DECODER_PARAM_PROPERTIES       OSSL_ALG_PARAM_PROPERTIES
-#define OSSL_DECODER_PARAM_INPUT_TYPE       "input-type"
-#define OSSL_DECODER_PARAM_INPUT_STRUCTURE  "input-structure"
 
 /* Passphrase callback parameters */
 #define OSSL_PASSPHRASE_PARAM_INFO      "info"

--- a/include/openssl/core_names.h
+++ b/include/openssl/core_names.h
@@ -468,8 +468,6 @@ extern "C" {
  */
 #define OSSL_ENCODER_PARAM_CIPHER           OSSL_ALG_PARAM_CIPHER
 #define OSSL_ENCODER_PARAM_PROPERTIES       OSSL_ALG_PARAM_PROPERTIES
-#define OSSL_ENCODER_PARAM_OUTPUT_TYPE      "output-type"
-#define OSSL_ENCODER_PARAM_OUTPUT_STRUCTURE "output-structure"
 /* Currently PVK only, but reusable for others as needed */
 #define OSSL_ENCODER_PARAM_ENCRYPT_LEVEL    "encrypt-level"
 #define OSSL_ENCODER_PARAM_SAVE_PARAMETERS  "save-parameters" /* integer */

--- a/include/openssl/core_names.h
+++ b/include/openssl/core_names.h
@@ -468,7 +468,6 @@ extern "C" {
  */
 #define OSSL_ENCODER_PARAM_CIPHER           OSSL_ALG_PARAM_CIPHER
 #define OSSL_ENCODER_PARAM_PROPERTIES       OSSL_ALG_PARAM_PROPERTIES
-#define OSSL_ENCODER_PARAM_INPUT_TYPE       "input-type"
 #define OSSL_ENCODER_PARAM_OUTPUT_TYPE      "output-type"
 #define OSSL_ENCODER_PARAM_OUTPUT_STRUCTURE "output-structure"
 /* Currently PVK only, but reusable for others as needed */

--- a/include/openssl/encoder.h
+++ b/include/openssl/encoder.h
@@ -84,8 +84,6 @@ OSSL_ENCODER_INSTANCE_get_encoder(OSSL_ENCODER_INSTANCE *encoder_inst);
 void *
 OSSL_ENCODER_INSTANCE_get_encoder_ctx(OSSL_ENCODER_INSTANCE *encoder_inst);
 const char *
-OSSL_ENCODER_INSTANCE_get_input_type(OSSL_ENCODER_INSTANCE *encoder_inst);
-const char *
 OSSL_ENCODER_INSTANCE_get_output_type(OSSL_ENCODER_INSTANCE *encoder_inst);
 const char *
 OSSL_ENCODER_INSTANCE_get_output_structure(OSSL_ENCODER_INSTANCE *encoder_inst);

--- a/include/openssl/err.h.in
+++ b/include/openssl/err.h.in
@@ -357,6 +357,7 @@ static ossl_unused ossl_inline int ERR_COMMON_ERROR(unsigned long errcode)
 # define ERR_R_MISSING_ASN1_EOS                  (267|ERR_RFLAG_COMMON)
 # define ERR_R_UNSUPPORTED                       (268|ERR_RFLAG_COMMON)
 # define ERR_R_FETCH_FAILED                      (269|ERR_RFLAG_COMMON)
+# define ERR_R_INVALID_PROPERTY_DEFINITION       (270|ERR_RFLAG_COMMON)
 
 typedef struct ERR_string_data_st {
     unsigned long error;

--- a/providers/implementations/encode_decode/decode_der2key.c
+++ b/providers/implementations/encode_decode/decode_der2key.c
@@ -177,39 +177,6 @@ static void der2key_freectx(void *vctx)
     OPENSSL_free(ctx);
 }
 
-static const OSSL_PARAM *
-der2key_gettable_params(void *provctx, const struct keytype_desc_st *desc)
-{
-    static const OSSL_PARAM gettables[] = {
-        { OSSL_DECODER_PARAM_INPUT_TYPE, OSSL_PARAM_UTF8_PTR, NULL, 0, 0 },
-        OSSL_PARAM_END,
-    };
-    static const OSSL_PARAM gettables_w_structure[] = {
-        { OSSL_DECODER_PARAM_INPUT_TYPE, OSSL_PARAM_UTF8_PTR, NULL, 0, 0 },
-        { OSSL_DECODER_PARAM_INPUT_STRUCTURE, OSSL_PARAM_UTF8_PTR, NULL, 0, 0 },
-        OSSL_PARAM_END,
-    };
-
-    return desc->structure_name != NULL ? gettables_w_structure :  gettables;
-}
-
-static int der2key_get_params(OSSL_PARAM params[],
-                              const struct keytype_desc_st *desc)
-{
-    OSSL_PARAM *p;
-
-    p = OSSL_PARAM_locate(params, OSSL_DECODER_PARAM_INPUT_TYPE);
-    if (p != NULL && !OSSL_PARAM_set_utf8_ptr(p, "DER"))
-        return 0;
-    if (desc->structure_name != NULL) {
-        p = OSSL_PARAM_locate(params, OSSL_DECODER_PARAM_INPUT_STRUCTURE);
-        if (p != NULL && !OSSL_PARAM_set_utf8_ptr(p, desc->structure_name))
-            return 0;
-    }
-
-    return 1;
-}
-
 static int der2key_check_selection(int selection,
                                    const struct keytype_desc_st *desc)
 {
@@ -791,24 +758,10 @@ static void rsa_adjust(void *key, struct der2key_ctx_st *ctx)
           DO_##kind(keytype) };                                         \
                                                                         \
     static OSSL_FUNC_decoder_newctx_fn kind##_der2##keytype##_newctx;   \
-    static OSSL_FUNC_decoder_gettable_params_fn                         \
-    kind##_der2##keytype##_gettable_params;                             \
-    static OSSL_FUNC_decoder_get_params_fn                              \
-    kind##_der2##keytype##_get_params;                                  \
                                                                         \
     static void *kind##_der2##keytype##_newctx(void *provctx)           \
     {                                                                   \
         return der2key_newctx(provctx, &kind##_##keytype##_desc);       \
-    }                                                                   \
-    static const OSSL_PARAM *                                           \
-    kind##_der2##keytype##_gettable_params(void *provctx)               \
-    {                                                                   \
-        return                                                          \
-            der2key_gettable_params(provctx, &kind##_##keytype##_desc); \
-    }                                                                   \
-    static int kind##_der2##keytype##_get_params(OSSL_PARAM params[])   \
-    {                                                                   \
-        return der2key_get_params(params, &kind##_##keytype##_desc);    \
     }                                                                   \
     static int kind##_der2##keytype##_does_selection(void *provctx,     \
                                                      int selection)     \
@@ -822,10 +775,6 @@ static void rsa_adjust(void *key, struct der2key_ctx_st *ctx)
           (void (*)(void))kind##_der2##keytype##_newctx },              \
         { OSSL_FUNC_DECODER_FREECTX,                                    \
           (void (*)(void))der2key_freectx },                            \
-        { OSSL_FUNC_DECODER_GETTABLE_PARAMS,                            \
-          (void (*)(void))kind##_der2##keytype##_gettable_params },     \
-        { OSSL_FUNC_DECODER_GET_PARAMS,                                 \
-          (void (*)(void))kind##_der2##keytype##_get_params },          \
         { OSSL_FUNC_DECODER_DOES_SELECTION,                             \
           (void (*)(void))kind##_der2##keytype##_does_selection },      \
         { OSSL_FUNC_DECODER_DECODE,                                     \

--- a/providers/implementations/encode_decode/decode_msblob2key.c
+++ b/providers/implementations/encode_decode/decode_msblob2key.c
@@ -47,8 +47,6 @@ struct keytype_desc_st {
 };
 
 static OSSL_FUNC_decoder_freectx_fn msblob2key_freectx;
-static OSSL_FUNC_decoder_gettable_params_fn msblob2key_gettable_params;
-static OSSL_FUNC_decoder_get_params_fn msblob2key_get_params;
 static OSSL_FUNC_decoder_decode_fn msblob2key_decode;
 static OSSL_FUNC_decoder_export_object_fn msblob2key_export_object;
 
@@ -77,27 +75,6 @@ static void msblob2key_freectx(void *vctx)
     struct msblob2key_ctx_st *ctx = vctx;
 
     OPENSSL_free(ctx);
-}
-
-static const OSSL_PARAM *msblob2key_gettable_params(ossl_unused void *provctx)
-{
-    static const OSSL_PARAM gettables[] = {
-        { OSSL_DECODER_PARAM_INPUT_TYPE, OSSL_PARAM_UTF8_PTR, NULL, 0, 0 },
-        OSSL_PARAM_END,
-    };
-
-    return gettables;
-}
-
-static int msblob2key_get_params(OSSL_PARAM params[])
-{
-    OSSL_PARAM *p;
-
-    p = OSSL_PARAM_locate(params, OSSL_DECODER_PARAM_INPUT_TYPE);
-    if (p != NULL && !OSSL_PARAM_set_utf8_ptr(p, "MSBLOB"))
-        return 0;
-
-    return 1;
 }
 
 static int msblob2key_decode(void *vctx, OSSL_CORE_BIO *cin, int selection,
@@ -278,10 +255,6 @@ static void rsa_adjust(void *key, struct msblob2key_ctx_st *ctx)
           (void (*)(void))msblob2##keytype##_newctx },                  \
         { OSSL_FUNC_DECODER_FREECTX,                                    \
           (void (*)(void))msblob2key_freectx },                         \
-        { OSSL_FUNC_DECODER_GETTABLE_PARAMS,                            \
-          (void (*)(void))msblob2key_gettable_params },                 \
-        { OSSL_FUNC_DECODER_GET_PARAMS,                                 \
-          (void (*)(void))msblob2key_get_params },                      \
         { OSSL_FUNC_DECODER_DECODE,                                     \
           (void (*)(void))msblob2key_decode },                          \
         { OSSL_FUNC_DECODER_EXPORT_OBJECT,                              \

--- a/providers/implementations/encode_decode/decode_pem2der.c
+++ b/providers/implementations/encode_decode/decode_pem2der.c
@@ -41,8 +41,6 @@ static int read_pem(PROV_CTX *provctx, OSSL_CORE_BIO *cin,
 
 static OSSL_FUNC_decoder_newctx_fn pem2der_newctx;
 static OSSL_FUNC_decoder_freectx_fn pem2der_freectx;
-static OSSL_FUNC_decoder_gettable_params_fn pem2der_gettable_params;
-static OSSL_FUNC_decoder_get_params_fn pem2der_get_params;
 static OSSL_FUNC_decoder_decode_fn pem2der_decode;
 
 /*
@@ -66,27 +64,6 @@ static void pem2der_freectx(void *vctx)
     struct pem2der_ctx_st *ctx = vctx;
 
     OPENSSL_free(ctx);
-}
-
-static const OSSL_PARAM *pem2der_gettable_params(void *provctx)
-{
-    static const OSSL_PARAM gettables[] = {
-        { OSSL_DECODER_PARAM_INPUT_TYPE, OSSL_PARAM_UTF8_PTR, NULL, 0, 0 },
-        OSSL_PARAM_END,
-    };
-
-    return gettables;
-}
-
-static int pem2der_get_params(OSSL_PARAM params[])
-{
-    OSSL_PARAM *p;
-
-    p = OSSL_PARAM_locate(params, OSSL_DECODER_PARAM_INPUT_TYPE);
-    if (p != NULL && !OSSL_PARAM_set_utf8_ptr(p, "PEM"))
-        return 0;
-
-    return 1;
 }
 
 /* pem_password_cb compatible function */
@@ -262,10 +239,6 @@ static int pem2der_decode(void *vctx, OSSL_CORE_BIO *cin, int selection,
 const OSSL_DISPATCH ossl_pem_to_der_decoder_functions[] = {
     { OSSL_FUNC_DECODER_NEWCTX, (void (*)(void))pem2der_newctx },
     { OSSL_FUNC_DECODER_FREECTX, (void (*)(void))pem2der_freectx },
-    { OSSL_FUNC_DECODER_GETTABLE_PARAMS,
-      (void (*)(void))pem2der_gettable_params },
-    { OSSL_FUNC_DECODER_GET_PARAMS,
-      (void (*)(void))pem2der_get_params },
     { OSSL_FUNC_DECODER_DECODE, (void (*)(void))pem2der_decode },
     { 0, NULL }
 };

--- a/providers/implementations/encode_decode/decode_pvk2key.c
+++ b/providers/implementations/encode_decode/decode_pvk2key.c
@@ -47,8 +47,6 @@ struct keytype_desc_st {
 };
 
 static OSSL_FUNC_decoder_freectx_fn pvk2key_freectx;
-static OSSL_FUNC_decoder_gettable_params_fn pvk2key_gettable_params;
-static OSSL_FUNC_decoder_get_params_fn pvk2key_get_params;
 static OSSL_FUNC_decoder_decode_fn pvk2key_decode;
 static OSSL_FUNC_decoder_export_object_fn pvk2key_export_object;
 
@@ -77,27 +75,6 @@ static void pvk2key_freectx(void *vctx)
     struct pvk2key_ctx_st *ctx = vctx;
 
     OPENSSL_free(ctx);
-}
-
-static const OSSL_PARAM *pvk2key_gettable_params(ossl_unused void *provctx)
-{
-    static const OSSL_PARAM gettables[] = {
-        { OSSL_DECODER_PARAM_INPUT_TYPE, OSSL_PARAM_UTF8_PTR, NULL, 0, 0 },
-        OSSL_PARAM_END,
-    };
-
-    return gettables;
-}
-
-static int pvk2key_get_params(OSSL_PARAM params[])
-{
-    OSSL_PARAM *p;
-
-    p = OSSL_PARAM_locate(params, OSSL_DECODER_PARAM_INPUT_TYPE);
-    if (p != NULL && !OSSL_PARAM_set_utf8_ptr(p, "PVK"))
-        return 0;
-
-    return 1;
 }
 
 static int pvk2key_decode(void *vctx, OSSL_CORE_BIO *cin, int selection,
@@ -243,10 +220,6 @@ static void rsa_adjust(void *key, struct pvk2key_ctx_st *ctx)
           (void (*)(void))pvk2##keytype##_newctx },                     \
         { OSSL_FUNC_DECODER_FREECTX,                                    \
           (void (*)(void))pvk2key_freectx },                            \
-        { OSSL_FUNC_DECODER_GETTABLE_PARAMS,                            \
-          (void (*)(void))pvk2key_gettable_params },                    \
-        { OSSL_FUNC_DECODER_GET_PARAMS,                                 \
-          (void (*)(void))pvk2key_get_params },                         \
         { OSSL_FUNC_DECODER_DECODE,                                     \
           (void (*)(void))pvk2key_decode },                             \
         { OSSL_FUNC_DECODER_EXPORT_OBJECT,                              \

--- a/providers/implementations/encode_decode/encode_key2any.c
+++ b/providers/implementations/encode_decode/encode_key2any.c
@@ -884,13 +884,11 @@ static void key2any_freectx(void *vctx)
 static const OSSL_PARAM *key2any_gettable_params(void *provctx, int structure)
 {
     static const OSSL_PARAM gettables[] = {
-        { OSSL_ENCODER_PARAM_INPUT_TYPE, OSSL_PARAM_UTF8_PTR, NULL, 0, 0 },
         { OSSL_ENCODER_PARAM_OUTPUT_TYPE, OSSL_PARAM_UTF8_PTR, NULL, 0, 0 },
         OSSL_PARAM_END,
     };
 
     static const OSSL_PARAM gettables_w_structure[] = {
-        { OSSL_ENCODER_PARAM_INPUT_TYPE, OSSL_PARAM_UTF8_PTR, NULL, 0, 0 },
         { OSSL_ENCODER_PARAM_OUTPUT_TYPE, OSSL_PARAM_UTF8_PTR, NULL, 0, 0 },
         { OSSL_ENCODER_PARAM_OUTPUT_STRUCTURE, OSSL_PARAM_UTF8_PTR, NULL, 0, 0 },
         OSSL_PARAM_END,
@@ -899,15 +897,10 @@ static const OSSL_PARAM *key2any_gettable_params(void *provctx, int structure)
     return structure ? gettables_w_structure : gettables;
 }
 
-static int key2any_get_params(OSSL_PARAM params[], const char *input_type,
-                              const char *output_type,
+static int key2any_get_params(OSSL_PARAM params[], const char *output_type,
                               const char *output_struct)
 {
     OSSL_PARAM *p;
-
-    p = OSSL_PARAM_locate(params, OSSL_ENCODER_PARAM_INPUT_TYPE);
-    if (p != NULL && !OSSL_PARAM_set_utf8_ptr(p, input_type))
-        return 0;
 
     p = OSSL_PARAM_locate(params, OSSL_ENCODER_PARAM_OUTPUT_TYPE);
     if (p != NULL && !OSSL_PARAM_set_utf8_ptr(p, output_type))
@@ -1234,8 +1227,7 @@ static int key2any_encode(struct key2any_ctx_st *ctx, OSSL_CORE_BIO *cout,
     static int                                                              \
     impl##_to_##kind##_##output##_get_params(OSSL_PARAM params[])           \
     {                                                                       \
-        return key2any_get_params(params, impl##_input_type,                \
-                                  output##_output_type,                     \
+        return key2any_get_params(params, output##_output_type,             \
                                   kind##_output_structure);                 \
     }                                                                       \
     static void *                                                           \

--- a/providers/implementations/encode_decode/encode_key2blob.c
+++ b/providers/implementations/encode_decode/encode_key2blob.c
@@ -38,8 +38,6 @@ static int write_blob(void *provctx, OSSL_CORE_BIO *cout,
 
 static OSSL_FUNC_encoder_newctx_fn key2blob_newctx;
 static OSSL_FUNC_encoder_freectx_fn key2blob_freectx;
-static OSSL_FUNC_encoder_gettable_params_fn key2blob_gettable_params;
-static OSSL_FUNC_encoder_get_params_fn key2blob_get_params;
 
 static void *key2blob_newctx(void *provctx)
 {
@@ -48,27 +46,6 @@ static void *key2blob_newctx(void *provctx)
 
 static void key2blob_freectx(void *vctx)
 {
-}
-
-static const OSSL_PARAM *key2blob_gettable_params(ossl_unused void *provctx)
-{
-    static const OSSL_PARAM gettables[] = {
-        { OSSL_ENCODER_PARAM_OUTPUT_TYPE, OSSL_PARAM_UTF8_PTR, NULL, 0, 0 },
-        OSSL_PARAM_END,
-    };
-
-    return gettables;
-}
-
-static int key2blob_get_params(OSSL_PARAM params[])
-{
-    OSSL_PARAM *p;
-
-    p = OSSL_PARAM_locate(params, OSSL_ENCODER_PARAM_OUTPUT_TYPE);
-    if (p != NULL && !OSSL_PARAM_set_utf8_ptr(p, "blob"))
-        return 0;
-
-    return 1;
 }
 
 static int key2blob_check_selection(int selection, int selection_mask)
@@ -179,10 +156,6 @@ static int key2blob_encode(void *vctx, const void *key, int selection,
           (void (*)(void))key2blob_newctx },                            \
         { OSSL_FUNC_ENCODER_FREECTX,                                    \
           (void (*)(void))key2blob_freectx },                           \
-        { OSSL_FUNC_ENCODER_GETTABLE_PARAMS,                            \
-          (void (*)(void))key2blob_gettable_params },                   \
-        { OSSL_FUNC_ENCODER_GET_PARAMS,                                 \
-          (void (*)(void))key2blob_get_params },                        \
         { OSSL_FUNC_ENCODER_DOES_SELECTION,                             \
           (void (*)(void))impl##2blob_does_selection },                 \
         { OSSL_FUNC_ENCODER_IMPORT_OBJECT,                              \

--- a/providers/implementations/encode_decode/encode_key2ms.c
+++ b/providers/implementations/encode_decode/encode_key2ms.c
@@ -63,7 +63,6 @@ static int write_pvk(struct key2ms_ctx_st *ctx, OSSL_CORE_BIO *cout,
 }
 
 static OSSL_FUNC_encoder_freectx_fn key2ms_freectx;
-static OSSL_FUNC_encoder_gettable_params_fn key2ms_gettable_params;
 static OSSL_FUNC_encoder_does_selection_fn key2ms_does_selection;
 
 static struct key2ms_ctx_st *key2ms_newctx(void *provctx)
@@ -83,38 +82,6 @@ static void key2ms_freectx(void *vctx)
     struct key2ms_ctx_st *ctx = vctx;
 
     OPENSSL_free(ctx);
-}
-
-static const OSSL_PARAM *key2ms_gettable_params(ossl_unused void *provctx)
-{
-    static const OSSL_PARAM gettables[] = {
-        { OSSL_ENCODER_PARAM_OUTPUT_TYPE, OSSL_PARAM_UTF8_PTR, NULL, 0, 0 },
-        OSSL_PARAM_END,
-    };
-
-    return gettables;
-}
-
-static int key2msblob_get_params(OSSL_PARAM params[])
-{
-    OSSL_PARAM *p;
-
-    p = OSSL_PARAM_locate(params, OSSL_ENCODER_PARAM_OUTPUT_TYPE);
-    if (p != NULL && !OSSL_PARAM_set_utf8_ptr(p, "MSBLOB"))
-        return 0;
-
-    return 1;
-}
-
-static int key2pvk_get_params(OSSL_PARAM params[])
-{
-    OSSL_PARAM *p;
-
-    p = OSSL_PARAM_locate(params, OSSL_ENCODER_PARAM_OUTPUT_TYPE);
-    if (p != NULL && !OSSL_PARAM_set_utf8_ptr(p, "PVK"))
-        return 0;
-
-    return 1;
 }
 
 static const OSSL_PARAM *key2pvk_settable_ctx_params(ossl_unused void *provctx)
@@ -240,10 +207,6 @@ static int key2pvk_encode(void *vctx, const void *key, int selection,
           (void (*)(void))key2ms_newctx },                                    \
         { OSSL_FUNC_ENCODER_FREECTX,                                          \
           (void (*)(void))key2ms_freectx },                                   \
-        { OSSL_FUNC_ENCODER_GETTABLE_PARAMS,                                  \
-          (void (*)(void))key2ms_gettable_params },                           \
-        { OSSL_FUNC_ENCODER_GET_PARAMS,                                       \
-          (void (*)(void))key2##output##_get_params },                        \
         output##_set_params                                                   \
         { OSSL_FUNC_ENCODER_DOES_SELECTION,                                   \
           (void (*)(void))key2ms_does_selection },                            \

--- a/providers/implementations/encode_decode/encode_key2text.c
+++ b/providers/implementations/encode_decode/encode_key2text.c
@@ -805,13 +805,9 @@ static const OSSL_PARAM *key2text_gettable_params(void *provctx)
     return gettables;
 }
 
-static int key2text_get_params(OSSL_PARAM params[], const char *input_type)
+static int key2text_get_params(OSSL_PARAM params[])
 {
     OSSL_PARAM *p;
-
-    p = OSSL_PARAM_locate(params, OSSL_ENCODER_PARAM_INPUT_TYPE);
-    if (p != NULL && !OSSL_PARAM_set_utf8_ptr(p, input_type))
-        return 0;
 
     p = OSSL_PARAM_locate(params, OSSL_ENCODER_PARAM_OUTPUT_TYPE);
     if (p != NULL && !OSSL_PARAM_set_utf8_ptr(p, "TEXT"))
@@ -847,10 +843,6 @@ static int key2text_encode(void *vctx, const void *key, int selection,
     impl##2text_free_object;                                            \
     static OSSL_FUNC_encoder_encode_fn impl##2text_encode;              \
                                                                         \
-    static int impl##2text_get_params(OSSL_PARAM params[])              \
-    {                                                                   \
-        return key2text_get_params(params, impl##_input_type);          \
-    }                                                                   \
     static void *impl##2text_import_object(void *ctx, int selection,    \
                                            const OSSL_PARAM params[])   \
     {                                                                   \
@@ -884,7 +876,7 @@ static int key2text_encode(void *vctx, const void *key, int selection,
         { OSSL_FUNC_ENCODER_GETTABLE_PARAMS,                            \
           (void (*)(void))key2text_gettable_params },                   \
         { OSSL_FUNC_ENCODER_GET_PARAMS,                                 \
-          (void (*)(void))impl##2text_get_params },                     \
+          (void (*)(void))key2text_get_params },                        \
         { OSSL_FUNC_ENCODER_IMPORT_OBJECT,                              \
           (void (*)(void))impl##2text_import_object },                  \
         { OSSL_FUNC_ENCODER_FREE_OBJECT,                                \

--- a/providers/implementations/encode_decode/encode_key2text.c
+++ b/providers/implementations/encode_decode/encode_key2text.c
@@ -795,27 +795,6 @@ static void key2text_freectx(ossl_unused void *vctx)
 {
 }
 
-static const OSSL_PARAM *key2text_gettable_params(void *provctx)
-{
-    static const OSSL_PARAM gettables[] = {
-        { OSSL_ENCODER_PARAM_OUTPUT_TYPE, OSSL_PARAM_UTF8_PTR, NULL, 0, 0 },
-        OSSL_PARAM_END,
-    };
-
-    return gettables;
-}
-
-static int key2text_get_params(OSSL_PARAM params[])
-{
-    OSSL_PARAM *p;
-
-    p = OSSL_PARAM_locate(params, OSSL_ENCODER_PARAM_OUTPUT_TYPE);
-    if (p != NULL && !OSSL_PARAM_set_utf8_ptr(p, "TEXT"))
-        return 0;
-
-    return 1;
-}
-
 static int key2text_encode(void *vctx, const void *key, int selection,
                            OSSL_CORE_BIO *cout,
                            int (*key2text)(BIO *out, const void *key,
@@ -835,8 +814,6 @@ static int key2text_encode(void *vctx, const void *key, int selection,
 }
 
 #define MAKE_TEXT_ENCODER(impl, type)                                   \
-    static OSSL_FUNC_encoder_get_params_fn                              \
-    impl##2text_get_params;                                             \
     static OSSL_FUNC_encoder_import_object_fn                           \
     impl##2text_import_object;                                          \
     static OSSL_FUNC_encoder_free_object_fn                             \
@@ -873,10 +850,6 @@ static int key2text_encode(void *vctx, const void *key, int selection,
           (void (*)(void))key2text_newctx },                            \
         { OSSL_FUNC_ENCODER_FREECTX,                                    \
           (void (*)(void))key2text_freectx },                           \
-        { OSSL_FUNC_ENCODER_GETTABLE_PARAMS,                            \
-          (void (*)(void))key2text_gettable_params },                   \
-        { OSSL_FUNC_ENCODER_GET_PARAMS,                                 \
-          (void (*)(void))key2text_get_params },                        \
         { OSSL_FUNC_ENCODER_IMPORT_OBJECT,                              \
           (void (*)(void))impl##2text_import_object },                  \
         { OSSL_FUNC_ENCODER_FREE_OBJECT,                                \

--- a/providers/implementations/storemgmt/file_store_der2obj.c
+++ b/providers/implementations/storemgmt/file_store_der2obj.c
@@ -52,30 +52,7 @@ static void der2obj_freectx(void *vctx)
 {
 }
 
-static OSSL_FUNC_decoder_gettable_params_fn der2obj_gettable_params;
-static OSSL_FUNC_decoder_get_params_fn der2obj_get_params;
 static OSSL_FUNC_decoder_decode_fn der2obj_decode;
-
-static const OSSL_PARAM *der2obj_gettable_params(void *provctx)
-{
-    static const OSSL_PARAM gettables[] = {
-        { OSSL_DECODER_PARAM_INPUT_TYPE, OSSL_PARAM_UTF8_PTR, NULL, 0, 0 },
-        OSSL_PARAM_END,
-    };
-
-    return gettables;
-}
-
-static int der2obj_get_params(OSSL_PARAM params[])
-{
-    OSSL_PARAM *p;
-
-    p = OSSL_PARAM_locate(params, OSSL_DECODER_PARAM_INPUT_TYPE);
-    if (p != NULL && !OSSL_PARAM_set_utf8_ptr(p, "DER"))
-        return 0;
-
-    return 1;
-}
 
 static int der2obj_decode(void *provctx, OSSL_CORE_BIO *cin, int selection,
                           OSSL_CALLBACK *data_cb, void *data_cbarg,
@@ -124,12 +101,9 @@ static int der2obj_decode(void *provctx, OSSL_CORE_BIO *cin, int selection,
 static const OSSL_DISPATCH der_to_obj_decoder_functions[] = {
     { OSSL_FUNC_DECODER_NEWCTX, (void (*)(void))der2obj_newctx },
     { OSSL_FUNC_DECODER_FREECTX, (void (*)(void))der2obj_freectx },
-    { OSSL_FUNC_DECODER_GETTABLE_PARAMS,
-      (void (*)(void))der2obj_gettable_params },
-    { OSSL_FUNC_DECODER_GET_PARAMS, (void (*)(void))der2obj_get_params },
     { OSSL_FUNC_DECODER_DECODE, (void (*)(void))der2obj_decode },
     { 0, NULL }
 };
 
 const OSSL_ALGORITHM ossl_der_to_obj_algorithm =
-    { "obj", NULL, der_to_obj_decoder_functions };
+    { "obj", "input=DER", der_to_obj_decoder_functions };

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5249,7 +5249,6 @@ OSSL_ENCODER_CTX_get_num_encoders       ?	3_0_0	EXIST::FUNCTION:
 OSSL_ENCODER_CTX_set_selection          ?	3_0_0	EXIST::FUNCTION:
 OSSL_ENCODER_INSTANCE_get_encoder       ?	3_0_0	EXIST::FUNCTION:
 OSSL_ENCODER_INSTANCE_get_encoder_ctx   ?	3_0_0	EXIST::FUNCTION:
-OSSL_ENCODER_INSTANCE_get_input_type    ?	3_0_0	EXIST::FUNCTION:
 OSSL_ENCODER_INSTANCE_get_output_type   ?	3_0_0	EXIST::FUNCTION:
 OSSL_ENCODER_CTX_set_construct          ?	3_0_0	EXIST::FUNCTION:
 OSSL_ENCODER_CTX_set_construct_data     ?	3_0_0	EXIST::FUNCTION:


### PR DESCRIPTION
The OSSL_DECODER and OSSL_ENCODER libraries used to ask each decoder implementation for certain data in form of parameters to place them correctly in the decoder chain, if at all.  These parameters were duplicates of properties of those same implementations, and therefore unnecessarily redundant.

Since we're adding functionality to query property definition values, those duplicates are no longer needed, and are therefore not looked at any more.

Fixes #15500