### PR TITLE
Add basic HTTP server ACCEPT test

### DIFF
--- a/test/recipes/79-test_http.t
+++ b/test/recipes/79-test_http.t
@@ -12,10 +12,15 @@ use OpenSSL::Test::Utils;
 
 setup("test_http");
 
-plan tests => 1;
+plan tests => 2;
 
 SKIP: {
     skip "sockets disabled", 1 if disabled("sock");
-    ok(run(test(["http_test",
-                 srctop_file("test", "certs", "ca-cert.pem")])));
+    skip "OCSP disabled", 1 if disabled("ocsp");
+    my $cmd = [qw{openssl ocsp -index any -port 0}];
+    my @output = run(app($cmd), capture => 1);
+    ok($output[0] =~ /^ACCEPT (0.0.0.0|\[::\]):(\d+?)$/ && $2 >= 1024,
+       "HTTP server auto-selects and reports local port >= 1024");
 }
+
+ok(run(test(["http_test", srctop_file("test", "certs", "ca-cert.pem")])));

--- a/test/recipes/80-test_cmp_http.t
+++ b/test/recipes/80-test_cmp_http.t
@@ -277,7 +277,7 @@ sub start_mock_server {
     die "Invalid port: $server_port" unless $server_port =~ m/^\d+$/;
     my $pid = open($server_fh, "$cmd|") or die "Trying to $cmd";
     print "Pid is: $pid\n";
-    if ($server_port eq "0") {
+    if ($server_port == 0) {
         # Find out the actual server port
         while (<$server_fh>) {
             print;


### PR DESCRIPTION
After several issues with `80-test_cmp_http.t` that were actually independent of CMP but due to some problem with the HTTP test server,
this adds an independent test for the server to properly claim and report a local port
before any other HTTP-based tests (for OCSP and CMP) are executed.

- [x] tests are added or updated
