### PR TITLE
CI windows.yml: Silence 'nmake' builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
     - name: config
       run: ./config --banner=Configured --strict-warnings no-bulk no-pic no-asm -DOPENSSL_NO_SECURE_MEMORY -DOPENSSL_SMALL_FOOTPRINT && perl configdata.pm --dump
     - name: make
-      run: make -s -j4
+      run: make -j4 # verbose, so no -s here
     - name: make test
       run: make test HARNESS_JOBS=${HARNESS_JOBS:-4}
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -29,7 +29,7 @@ jobs:
         perl configdata.pm --dump
     - name: build
       working-directory: _build
-      run: nmake
+      run: nmake /S
     - name: test
       working-directory: _build
       run: nmake test VERBOSE_FAILURE=yes TESTS=-test_fuzz* HARNESS_JOBS=4
@@ -54,7 +54,7 @@ jobs:
         perl configdata.pm --dump
     - name: build
       working-directory: _build
-      run: nmake
+      run: nmake /S
     - name: test
       working-directory: _build
       run: nmake test VERBOSE_FAILURE=yes TESTS=-test_fuzz* HARNESS_JOBS=4
@@ -72,7 +72,7 @@ jobs:
         perl configdata.pm --dump
     - name: build
       working-directory: _build
-      run: nmake
+      run: nmake # verbose, so no /S here
     - name: test
       working-directory: _build
       run: nmake test VERBOSE_FAILURE=yes TESTS=-test_fuzz* HARNESS_JOBS=4


### PR DESCRIPTION
In analogy to the Unix-based CI tests, add `/S` to the Windows-based builds.
