### PR TITLE
Only call dtls1_start_timer() once

### DIFF
--- a/ssl/d1_lib.c
+++ b/ssl/d1_lib.c
@@ -342,12 +342,11 @@ int dtls1_is_timer_expired(SSL *s)
     return 1;
 }
 
-void dtls1_double_timeout(SSL *s)
+static void dtls1_double_timeout(SSL *s)
 {
     s->d1->timeout_duration_us *= 2;
     if (s->d1->timeout_duration_us > 60000000)
         s->d1->timeout_duration_us = 60000000;
-    dtls1_start_timer(s);
 }
 
 void dtls1_stop_timer(SSL *s)

--- a/ssl/ssl_local.h
+++ b/ssl/ssl_local.h
@@ -2567,7 +2567,6 @@ __owur int dtls1_handle_timeout(SSL *s);
 void dtls1_start_timer(SSL *s);
 void dtls1_stop_timer(SSL *s);
 __owur int dtls1_is_timer_expired(SSL *s);
-void dtls1_double_timeout(SSL *s);
 __owur int dtls_raw_hello_verify_request(WPACKET *pkt, unsigned char *cookie,
                                          size_t cookie_len);
 __owur size_t dtls1_min_mtu(SSL *s);


### PR DESCRIPTION
The function dtls1_handle_timeout() calls dtls1_double_timeout() which
was calling dtls1_start_timer(). However dtls1_start_timer() is also
called directly by dtls1_handle_timeout(). We only need to start the timer
once.

Fixes #15561

This cherry-pick cleanly to 1.1.1 so I intend to apply this there too.