### PR TITLE
Refactor XXX_do_all_provided() to behave like XXX_fetch()

### DIFF
--- a/crypto/encode_decode/decoder_pkey.c
+++ b/crypto/encode_decode/decoder_pkey.c
@@ -322,6 +322,12 @@ int ossl_decoder_ctx_setup_for_pkey(OSSL_DECODER_CTX *ctx,
     int ok = 0;
     int isecoid = 0;
 
+    /* Pre-fetch all available decoders */
+    (void)OSSL_DECODER_fetch(libctx, NULL, NULL);
+
+    /* Pre-fetch all available keymgmts */
+    (void)EVP_KEYMGMT_fetch(libctx, NULL, NULL);
+
     if (keytype != NULL
             && (strcmp(keytype, "id-ecPublicKey") == 0
                 || strcmp(keytype, "1.2.840.10045.2.1") == 0))
@@ -401,8 +407,8 @@ int ossl_decoder_ctx_setup_for_pkey(OSSL_DECODER_CTX *ctx,
 
         collect_decoder_data.names = names;
         collect_decoder_data.ctx = ctx;
-        OSSL_DECODER_do_all_provided(libctx,
-                                     collect_decoder, &collect_decoder_data);
+        ossl_decoder_do_all_prefetched(libctx,
+                                       collect_decoder, &collect_decoder_data);
         sk_OPENSSL_CSTRING_free(names);
         names = NULL;
 

--- a/crypto/encode_decode/decoder_pkey.c
+++ b/crypto/encode_decode/decoder_pkey.c
@@ -322,12 +322,6 @@ int ossl_decoder_ctx_setup_for_pkey(OSSL_DECODER_CTX *ctx,
     int ok = 0;
     int isecoid = 0;
 
-    /* Pre-fetch all available decoders */
-    (void)OSSL_DECODER_fetch(libctx, NULL, NULL);
-
-    /* Pre-fetch all available keymgmts */
-    (void)EVP_KEYMGMT_fetch(libctx, NULL, NULL);
-
     if (keytype != NULL
             && (strcmp(keytype, "id-ecPublicKey") == 0
                 || strcmp(keytype, "1.2.840.10045.2.1") == 0))
@@ -407,8 +401,8 @@ int ossl_decoder_ctx_setup_for_pkey(OSSL_DECODER_CTX *ctx,
 
         collect_decoder_data.names = names;
         collect_decoder_data.ctx = ctx;
-        ossl_decoder_do_all_prefetched(libctx,
-                                       collect_decoder, &collect_decoder_data);
+        OSSL_DECODER_do_all_provided(libctx,
+                                     collect_decoder, &collect_decoder_data);
         sk_OPENSSL_CSTRING_free(names);
         names = NULL;
 

--- a/crypto/encode_decode/encoder_meth.c
+++ b/crypto/encode_decode/encoder_meth.c
@@ -331,10 +331,10 @@ inner_ossl_encoder_fetch(struct encoder_data_st *methdata, int id,
     }
 
     /*
-     * If we have been passed neither a name_id or a name, we have an
+     * If we have been passed both an id and a name, we have an
      * internal programming error.
      */
-    if (!ossl_assert(id != 0 || name != NULL)) {
+    if (!ossl_assert(id == 0 || name == NULL)) {
         ERR_raise(ERR_LIB_OSSL_ENCODER, ERR_R_INTERNAL_ERROR);
         return NULL;
     }
@@ -386,7 +386,7 @@ inner_ossl_encoder_fetch(struct encoder_data_st *methdata, int id,
         unsupported = !methdata->flag_construct_error_occurred;
     }
 
-    if (method == NULL) {
+    if ((id != 0 || name != NULL) && method == NULL) {
         int code = unsupported ? ERR_R_UNSUPPORTED : ERR_R_FETCH_FAILED;
 
         if (name == NULL)
@@ -493,47 +493,36 @@ int OSSL_ENCODER_is_a(const OSSL_ENCODER *encoder, const char *name)
     return 0;
 }
 
-struct encoder_do_all_data_st {
-    void (*user_fn)(void *method, void *arg);
+struct do_one_data_st {
+    void (*user_fn)(OSSL_ENCODER *encoder, void *arg);
     void *user_arg;
 };
 
-static void encoder_do_one(OSSL_PROVIDER *provider,
-                           const OSSL_ALGORITHM *algodef,
-                           int no_store, void *vdata)
+static void do_one(ossl_unused int id, void *method, void *arg)
 {
-    struct encoder_do_all_data_st *data = vdata;
-    OSSL_LIB_CTX *libctx = ossl_provider_libctx(provider);
-    OSSL_NAMEMAP *namemap = ossl_namemap_stored(libctx);
-    const char *names = algodef->algorithm_names;
-    int id = ossl_namemap_add_names(namemap, 0, names, NAME_SEPARATOR);
-    void *method = NULL;
+    struct do_one_data_st *data = arg;
 
-    if (id != 0)
-        method =
-            encoder_from_algorithm(id, algodef, provider);
+    data->user_fn(method, data->user_arg);
+}
 
-    if (method != NULL) {
-        data->user_fn(method, data->user_arg);
-        OSSL_ENCODER_free(method);
-    }
+void ossl_encoder_do_all_prefetched(OSSL_LIB_CTX *libctx,
+                                    void (*user_fn)(OSSL_ENCODER *encoder,
+                                                    void *arg),
+                                    void *user_arg)
+{
+    struct do_one_data_st data;
+
+    data.user_fn = user_fn;
+    data.user_arg = user_arg;
+    ossl_method_store_do_all(get_encoder_store(libctx), &do_one, &data);
 }
 
 void OSSL_ENCODER_do_all_provided(OSSL_LIB_CTX *libctx,
                                   void (*fn)(OSSL_ENCODER *encoder, void *arg),
                                   void *arg)
 {
-    struct encoder_do_all_data_st data;
-
-    data.user_fn = (void (*)(void *, void *))fn;
-    data.user_arg = arg;
-
-    /*
-     * No pre- or post-condition for this call, as this only creates methods
-     * temporarly and then promptly destroys them.
-     */
-    ossl_algorithm_do_all(libctx, OSSL_OP_ENCODER, NULL, NULL,
-                          encoder_do_one, NULL, &data);
+    (void)OSSL_ENCODER_fetch(libctx, NULL, NULL);
+    ossl_encoder_do_all_prefetched(libctx, fn, arg);
 }
 
 int OSSL_ENCODER_names_do_all(const OSSL_ENCODER *encoder,

--- a/crypto/evp/asymcipher.c
+++ b/crypto/evp/asymcipher.c
@@ -451,6 +451,7 @@ void EVP_ASYM_CIPHER_do_all_provided(OSSL_LIB_CTX *libctx,
     evp_generic_do_all(libctx, OSSL_OP_ASYM_CIPHER,
                        (void (*)(void *, void *))fn, arg,
                        evp_asym_cipher_from_algorithm,
+                       (int (*)(void *))EVP_ASYM_CIPHER_up_ref,
                        (void (*)(void *))EVP_ASYM_CIPHER_free);
 }
 

--- a/crypto/evp/digest.c
+++ b/crypto/evp/digest.c
@@ -1069,5 +1069,5 @@ void EVP_MD_do_all_provided(OSSL_LIB_CTX *libctx,
 {
     evp_generic_do_all(libctx, OSSL_OP_DIGEST,
                        (void (*)(void *, void *))fn, arg,
-                       evp_md_from_algorithm, evp_md_free);
+                       evp_md_from_algorithm, evp_md_up_ref, evp_md_free);
 }

--- a/crypto/evp/evp_enc.c
+++ b/crypto/evp/evp_enc.c
@@ -1649,5 +1649,6 @@ void EVP_CIPHER_do_all_provided(OSSL_LIB_CTX *libctx,
 {
     evp_generic_do_all(libctx, OSSL_OP_CIPHER,
                        (void (*)(void *, void *))fn, arg,
-                       evp_cipher_from_algorithm, evp_cipher_free);
+                       evp_cipher_from_algorithm, evp_cipher_up_ref,
+                       evp_cipher_free);
 }

--- a/crypto/evp/evp_fetch.c
+++ b/crypto/evp/evp_fetch.c
@@ -87,20 +87,33 @@ static OSSL_METHOD_STORE *get_evp_method_store(OSSL_LIB_CTX *libctx)
 /*
  * To identify the method in the EVP method store, we mix the name identity
  * with the operation identity, under the assumption that we don't have more
- * than 2^24 names or more than 2^8 operation types.
+ * than 2^23 names or more than 2^8 operation types.
  *
- * The resulting identity is a 32-bit integer, composed like this:
+ * The resulting identity is a 31-bit integer, composed like this:
  *
- * +---------24 bits--------+-8 bits-+
+ * +---------23 bits--------+-8 bits-+
  * |      name identity     | op id  |
  * +------------------------+--------+
+ *
+ * We limit this composite number to 31 bits, thus leaving the top uint32_t
+ * bit always zero, to avoid negative sign extension when downshifting after
+ * this number happens to be passed to an int (which happens as soon as it's
+ * passed to ossl_method_store_cache_set(), and it's in that form that it
+ * gets passed along to filter_on_operation_id(), defined further down.
  */
+#define METHOD_ID_OPERATION_MASK        0x000000FF
+#define METHOD_ID_OPERATION_MAX         ((1 << 8) - 1)
+#define METHOD_ID_NAME_MASK             0x7FFFFF00
+#define METHOD_ID_NAME_OFFSET           8
+#define METHOD_ID_NAME_MAX              ((1 << 23) - 1)
 static uint32_t evp_method_id(int name_id, unsigned int operation_id)
 {
-    if (!ossl_assert(name_id > 0 && name_id < (1 << 24))
-        || !ossl_assert(operation_id > 0 && operation_id < (1 << 8)))
+    if (!ossl_assert(name_id > 0 && name_id <= METHOD_ID_NAME_MAX)
+        || !ossl_assert(operation_id > 0
+                        && operation_id <= METHOD_ID_OPERATION_MAX))
         return 0;
-    return ((name_id << 8) & 0xFFFFFF00) | (operation_id & 0x000000FF);
+    return (((name_id << METHOD_ID_NAME_OFFSET) & METHOD_ID_NAME_MASK)
+            | (operation_id & METHOD_ID_OPERATION_MASK));
 }
 
 static void *get_evp_method_from_store(OSSL_LIB_CTX *libctx, void *store,
@@ -108,7 +121,7 @@ static void *get_evp_method_from_store(OSSL_LIB_CTX *libctx, void *store,
 {
     struct evp_method_data_st *methdata = data;
     void *method = NULL;
-    int name_id;
+    int name_id = 0;
     uint32_t meth_id;
 
     /*
@@ -116,7 +129,7 @@ static void *get_evp_method_from_store(OSSL_LIB_CTX *libctx, void *store,
      * that evp_generic_fetch() is asking for, and the operation id as well
      * as the name or name id are passed via methdata.
      */
-    if ((name_id = methdata->name_id) == 0) {
+    if ((name_id = methdata->name_id) == 0 && methdata->names != NULL) {
         OSSL_NAMEMAP *namemap = ossl_namemap_stored(libctx);
         const char *names = methdata->names;
         const char *q = strchr(names, NAME_SEPARATOR);
@@ -253,16 +266,16 @@ inner_evp_generic_fetch(struct evp_method_data_st *methdata, int operation_id,
     }
 
     /*
-     * If we have been passed neither a name_id or a name, we have an
+     * If we have been passed both a name_id and a name, we have an
      * internal programming error.
      */
-    if (!ossl_assert(name_id != 0 || name != NULL)) {
+    if (!ossl_assert(name_id == 0 || name == NULL)) {
         ERR_raise(ERR_LIB_EVP, ERR_R_INTERNAL_ERROR);
         return NULL;
     }
 
     /* If we haven't received a name id yet, try to get one for the name */
-    if (name_id == 0)
+    if (name_id == 0 && name != NULL)
         name_id = ossl_namemap_name2num(namemap, name);
 
     /*
@@ -316,8 +329,9 @@ inner_evp_generic_fetch(struct evp_method_data_st *methdata, int operation_id,
             if (name_id == 0)
                 name_id = ossl_namemap_name2num(namemap, name);
             meth_id = evp_method_id(name_id, operation_id);
-            ossl_method_store_cache_set(store, meth_id, properties, method,
-                                        up_ref_method, free_method);
+            if (name_id != 0)
+                ossl_method_store_cache_set(store, meth_id, properties, method,
+                                            up_ref_method, free_method);
         }
 
         /*
@@ -327,7 +341,7 @@ inner_evp_generic_fetch(struct evp_method_data_st *methdata, int operation_id,
         unsupported = !methdata->flag_construct_error_occurred;
     }
 
-    if (method == NULL) {
+    if ((name_id != 0 || name != NULL) && method == NULL) {
         int code = unsupported ? ERR_R_UNSUPPORTED : ERR_R_FETCH_FAILED;
 
         if (name == NULL)
@@ -542,31 +556,31 @@ char *evp_get_global_properties_str(OSSL_LIB_CTX *libctx, int loadconfig)
     return propstr;
 }
 
-struct do_all_data_st {
+struct filter_data_st {
+    int operation_id;
     void (*user_fn)(void *method, void *arg);
     void *user_arg;
-    void *(*new_method)(const int name_id, const OSSL_ALGORITHM *algodef,
-                        OSSL_PROVIDER *prov);
-    void (*free_method)(void *);
 };
 
-static void do_one(OSSL_PROVIDER *provider, const OSSL_ALGORITHM *algo,
-                   int no_store, void *vdata)
+static void filter_on_operation_id(int id, void *method, void *arg)
 {
-    struct do_all_data_st *data = vdata;
-    OSSL_LIB_CTX *libctx = ossl_provider_libctx(provider);
-    OSSL_NAMEMAP *namemap = ossl_namemap_stored(libctx);
-    int name_id = ossl_namemap_add_names(namemap, 0, algo->algorithm_names,
-                                         NAME_SEPARATOR);
-    void *method = NULL;
+    struct filter_data_st *data = arg;
 
-    if (name_id != 0)
-        method = data->new_method(name_id, algo, provider);
-
-    if (method != NULL) {
+    if ((id & METHOD_ID_OPERATION_MASK) == data->operation_id)
         data->user_fn(method, data->user_arg);
-        data->free_method(method);
-    }
+}
+
+void evp_generic_do_all_prefetched(OSSL_LIB_CTX *libctx, int operation_id,
+                                   void (*user_fn)(void *method, void *arg),
+                                   void *user_arg)
+{
+    struct filter_data_st data;
+
+    data.operation_id = operation_id;
+    data.user_fn = user_fn;
+    data.user_arg = user_arg;
+    ossl_method_store_do_all(get_evp_method_store(libctx),
+                             &filter_on_operation_id, &data);
 }
 
 void evp_generic_do_all(OSSL_LIB_CTX *libctx, int operation_id,
@@ -575,21 +589,12 @@ void evp_generic_do_all(OSSL_LIB_CTX *libctx, int operation_id,
                         void *(*new_method)(int name_id,
                                             const OSSL_ALGORITHM *algodef,
                                             OSSL_PROVIDER *prov),
+                        int (*up_ref_method)(void *),
                         void (*free_method)(void *))
 {
-    struct do_all_data_st data;
-
-    data.new_method = new_method;
-    data.free_method = free_method;
-    data.user_fn = user_fn;
-    data.user_arg = user_arg;
-
-    /*
-     * No pre- or post-condition for this call, as this only creates methods
-     * temporarly and then promptly destroys them.
-     */
-    ossl_algorithm_do_all(libctx, operation_id, NULL, NULL, do_one, NULL,
-                          &data);
+    (void)inner_evp_generic_fetch(libctx, operation_id, 0, NULL, NULL,
+                                  new_method, up_ref_method, free_method);
+    evp_generic_do_all_prefetched(libctx, operation_id, user_fn, user_arg);
 }
 
 int evp_is_a(OSSL_PROVIDER *prov, int number,

--- a/crypto/evp/evp_local.h
+++ b/crypto/evp/evp_local.h
@@ -276,12 +276,16 @@ void *evp_generic_fetch_by_number(OSSL_LIB_CTX *ctx, int operation_id,
                                                       OSSL_PROVIDER *prov),
                                   int (*up_ref_method)(void *),
                                   void (*free_method)(void *));
+void evp_generic_do_all_prefetched(OSSL_LIB_CTX *libctx, int operation_id,
+                                   void (*user_fn)(void *method, void *arg),
+                                   void *user_arg);
 void evp_generic_do_all(OSSL_LIB_CTX *libctx, int operation_id,
                         void (*user_fn)(void *method, void *arg),
                         void *user_arg,
                         void *(*new_method)(int name_id,
                                             const OSSL_ALGORITHM *algodef,
                                             OSSL_PROVIDER *prov),
+                        int (*up_ref_method)(void *),
                         void (*free_method)(void *));
 
 /* Internal fetchers for method types that are to be combined with others */

--- a/crypto/evp/evp_rand.c
+++ b/crypto/evp/evp_rand.c
@@ -489,7 +489,8 @@ void EVP_RAND_do_all_provided(OSSL_LIB_CTX *libctx,
 {
     evp_generic_do_all(libctx, OSSL_OP_RAND,
                        (void (*)(void *, void *))fn, arg,
-                       evp_rand_from_algorithm, evp_rand_free);
+                       evp_rand_from_algorithm, evp_rand_up_ref,
+                       evp_rand_free);
 }
 
 int EVP_RAND_names_do_all(const EVP_RAND *rand,

--- a/crypto/evp/exchange.c
+++ b/crypto/evp/exchange.c
@@ -485,6 +485,7 @@ void EVP_KEYEXCH_do_all_provided(OSSL_LIB_CTX *libctx,
     evp_generic_do_all(libctx, OSSL_OP_KEYEXCH,
                        (void (*)(void *, void *))fn, arg,
                        evp_keyexch_from_algorithm,
+                       (int (*)(void *))EVP_KEYEXCH_up_ref,
                        (void (*)(void *))EVP_KEYEXCH_free);
 }
 

--- a/crypto/evp/kdf_meth.c
+++ b/crypto/evp/kdf_meth.c
@@ -228,5 +228,5 @@ void EVP_KDF_do_all_provided(OSSL_LIB_CTX *libctx,
 {
     evp_generic_do_all(libctx, OSSL_OP_KDF,
                        (void (*)(void *, void *))fn, arg,
-                       evp_kdf_from_algorithm, evp_kdf_free);
+                       evp_kdf_from_algorithm, evp_kdf_up_ref, evp_kdf_free);
 }

--- a/crypto/evp/kem.c
+++ b/crypto/evp/kem.c
@@ -364,6 +364,7 @@ void EVP_KEM_do_all_provided(OSSL_LIB_CTX *libctx,
 {
     evp_generic_do_all(libctx, OSSL_OP_KEM, (void (*)(void *, void *))fn, arg,
                        evp_kem_from_algorithm,
+                       (int (*)(void *))EVP_KEM_up_ref,
                        (void (*)(void *))EVP_KEM_free);
 }
 

--- a/crypto/evp/keymgmt_meth.c
+++ b/crypto/evp/keymgmt_meth.c
@@ -278,6 +278,7 @@ void EVP_KEYMGMT_do_all_provided(OSSL_LIB_CTX *libctx,
     evp_generic_do_all(libctx, OSSL_OP_KEYMGMT,
                        (void (*)(void *, void *))fn, arg,
                        keymgmt_from_algorithm,
+                       (int (*)(void *))EVP_KEYMGMT_up_ref,
                        (void (*)(void *))EVP_KEYMGMT_free);
 }
 

--- a/crypto/evp/mac_meth.c
+++ b/crypto/evp/mac_meth.c
@@ -233,5 +233,5 @@ void EVP_MAC_do_all_provided(OSSL_LIB_CTX *libctx,
 {
     evp_generic_do_all(libctx, OSSL_OP_MAC,
                        (void (*)(void *, void *))fn, arg,
-                       evp_mac_from_algorithm, evp_mac_free);
+                       evp_mac_from_algorithm, evp_mac_up_ref, evp_mac_free);
 }

--- a/crypto/evp/signature.c
+++ b/crypto/evp/signature.c
@@ -342,6 +342,7 @@ void EVP_SIGNATURE_do_all_provided(OSSL_LIB_CTX *libctx,
     evp_generic_do_all(libctx, OSSL_OP_SIGNATURE,
                        (void (*)(void *, void *))fn, arg,
                        evp_signature_from_algorithm,
+                       (int (*)(void *))EVP_SIGNATURE_up_ref,
                        (void (*)(void *))EVP_SIGNATURE_free);
 }
 

--- a/crypto/store/store_meth.c
+++ b/crypto/store/store_meth.c
@@ -288,16 +288,16 @@ inner_loader_fetch(struct loader_data_st *methdata, int id,
     }
 
     /*
-     * If we have been passed neither a scheme_id nor a scheme, we have an
+     * If we have been passed both an id and a scheme, we have an
      * internal programming error.
      */
-    if (!ossl_assert(id != 0 || scheme != NULL)) {
+    if (!ossl_assert(id == 0 || scheme == NULL)) {
         ERR_raise(ERR_LIB_OSSL_STORE, ERR_R_INTERNAL_ERROR);
         return NULL;
     }
 
     /* If we haven't received a name id yet, try to get one for the name */
-    if (id == 0)
+    if (id == 0 && scheme != NULL)
         id = ossl_namemap_name2num(namemap, scheme);
 
     /*
@@ -343,7 +343,7 @@ inner_loader_fetch(struct loader_data_st *methdata, int id,
         unsupported = !methdata->flag_construct_error_occurred;
     }
 
-    if (method == NULL) {
+    if ((id != 0 || scheme != NULL) && method == NULL) {
         int code = unsupported ? ERR_R_UNSUPPORTED : ERR_R_FETCH_FAILED;
 
         if (scheme == NULL)
@@ -436,30 +436,28 @@ int OSSL_STORE_LOADER_is_a(const OSSL_STORE_LOADER *loader, const char *name)
     return 0;
 }
 
-struct loader_do_all_data_st {
-    void (*user_fn)(void *method, void *arg);
+struct do_one_data_st {
+    void (*user_fn)(OSSL_STORE_LOADER *loader, void *arg);
     void *user_arg;
 };
 
-static void loader_do_one(OSSL_PROVIDER *provider,
-                          const OSSL_ALGORITHM *algodef,
-                          int no_store, void *vdata)
+static void do_one(ossl_unused int id, void *method, void *arg)
 {
-    struct loader_do_all_data_st *data = vdata;
-    OSSL_LIB_CTX *libctx = ossl_provider_libctx(provider);
-    OSSL_NAMEMAP *namemap = ossl_namemap_stored(libctx);
-    const char *name = algodef->algorithm_names;
-    int id = ossl_namemap_add_name(namemap, 0, name);
-    void *method = NULL;
+    struct do_one_data_st *data = arg;
 
-    if (id != 0)
-        method =
-            loader_from_algorithm(id, algodef, provider);
+    data->user_fn(method, data->user_arg);
+}
 
-    if (method != NULL) {
-        data->user_fn(method, data->user_arg);
-        OSSL_STORE_LOADER_free(method);
-    }
+void ossl_store_loader_do_all_prefetched(OSSL_LIB_CTX *libctx,
+                                         void (*user_fn)(OSSL_STORE_LOADER *loader,
+                                                         void *arg),
+                                         void *user_arg)
+{
+    struct do_one_data_st data;
+
+    data.user_fn = user_fn;
+    data.user_arg = user_arg;
+    ossl_method_store_do_all(get_loader_store(libctx), &do_one, &data);
 }
 
 void OSSL_STORE_LOADER_do_all_provided(OSSL_LIB_CTX *libctx,
@@ -467,13 +465,8 @@ void OSSL_STORE_LOADER_do_all_provided(OSSL_LIB_CTX *libctx,
                                                   void *arg),
                                        void *arg)
 {
-    struct loader_do_all_data_st data;
-
-    data.user_fn = (void (*)(void *, void *))fn;
-    data.user_arg = arg;
-    ossl_algorithm_do_all(libctx, OSSL_OP_STORE, NULL,
-                          NULL, loader_do_one, NULL,
-                          &data);
+    (void)OSSL_STORE_LOADER_fetch(libctx, NULL, NULL);
+    ossl_store_loader_do_all_prefetched(libctx, fn, arg);
 }
 
 int OSSL_STORE_LOADER_names_do_all(const OSSL_STORE_LOADER *loader,

--- a/include/crypto/decoder.h
+++ b/include/crypto/decoder.h
@@ -16,9 +16,6 @@
 OSSL_DECODER *ossl_decoder_fetch_by_number(OSSL_LIB_CTX *libctx,
                                                      int id,
                                                      const char *properties);
-void ossl_decoder_do_all_prefetched(OSSL_LIB_CTX *libctx,
-                                    void (*fn)(OSSL_DECODER *decoder, void *arg),
-                                    void *arg);
 
 /*
  * These are specially made for the 'file:' provider-native loader, which

--- a/include/crypto/decoder.h
+++ b/include/crypto/decoder.h
@@ -16,6 +16,9 @@
 OSSL_DECODER *ossl_decoder_fetch_by_number(OSSL_LIB_CTX *libctx,
                                                      int id,
                                                      const char *properties);
+void ossl_decoder_do_all_prefetched(OSSL_LIB_CTX *libctx,
+                                    void (*fn)(OSSL_DECODER *decoder, void *arg),
+                                    void *arg);
 
 /*
  * These are specially made for the 'file:' provider-native loader, which
@@ -40,4 +43,3 @@ int ossl_decoder_ctx_setup_for_pkey(OSSL_DECODER_CTX *ctx,
 int ossl_decoder_get_number(const OSSL_DECODER *encoder);
 
 #endif
-

--- a/include/crypto/encoder.h
+++ b/include/crypto/encoder.h
@@ -12,3 +12,7 @@
 OSSL_ENCODER *ossl_encoder_fetch_by_number(OSSL_LIB_CTX *libctx, int id,
                                            const char *properties);
 int ossl_encoder_get_number(const OSSL_ENCODER *encoder);
+void ossl_encoder_do_all_prefetched(OSSL_LIB_CTX *libctx,
+                                    void (*user_fn)(OSSL_ENCODER *encoder,
+                                                    void *arg),
+                                    void *user_arg);

--- a/include/crypto/encoder.h
+++ b/include/crypto/encoder.h
@@ -12,7 +12,3 @@
 OSSL_ENCODER *ossl_encoder_fetch_by_number(OSSL_LIB_CTX *libctx, int id,
                                            const char *properties);
 int ossl_encoder_get_number(const OSSL_ENCODER *encoder);
-void ossl_encoder_do_all_prefetched(OSSL_LIB_CTX *libctx,
-                                    void (*user_fn)(OSSL_ENCODER *encoder,
-                                                    void *arg),
-                                    void *user_arg);

--- a/include/crypto/store.h
+++ b/include/crypto/store.h
@@ -17,9 +17,5 @@
 
 void ossl_store_cleanup_int(void);
 int ossl_store_loader_get_number(const OSSL_STORE_LOADER *loader);
-void ossl_store_loader_do_all_prefetched(OSSL_LIB_CTX *libctx,
-                                         void (*user_fn)(OSSL_STORE_LOADER *loader,
-                                                         void *arg),
-                                         void *user_arg);
 
 #endif

--- a/include/crypto/store.h
+++ b/include/crypto/store.h
@@ -17,5 +17,9 @@
 
 void ossl_store_cleanup_int(void);
 int ossl_store_loader_get_number(const OSSL_STORE_LOADER *loader);
+void ossl_store_loader_do_all_prefetched(OSSL_LIB_CTX *libctx,
+                                         void (*user_fn)(OSSL_STORE_LOADER *loader,
+                                                         void *arg),
+                                         void *user_arg);
 
 #endif

--- a/include/internal/property.h
+++ b/include/internal/property.h
@@ -58,6 +58,9 @@ int ossl_method_store_add(OSSL_METHOD_STORE *store, const OSSL_PROVIDER *prov,
                           void (*method_destruct)(void *));
 int ossl_method_store_remove(OSSL_METHOD_STORE *store, int nid,
                              const void *method);
+void ossl_method_store_do_all(OSSL_METHOD_STORE *store,
+                              void (*fn)(int id, void *method, void *fnarg),
+                              void *fnarg);
 int ossl_method_store_fetch(OSSL_METHOD_STORE *store, int nid,
                             const char *prop_query, void **method);
 

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -1294,7 +1294,7 @@ static int test_EVP_PKCS82PKEY_wrong_tag(void)
         || !TEST_int_gt(BIO_get_mem_data(membio, &membuf), 0)
         || !TEST_ptr(p8inf = d2i_PKCS8_PRIV_KEY_INFO_bio(membio, NULL))
         || !TEST_ptr(pkey2 = EVP_PKCS82PKEY(p8inf))
-        || !TEST_int_eq(ERR_get_error(), 0)) {
+        || !TEST_int_eq(ERR_peek_last_error(), 0)) {
         goto done;
     }
 


### PR DESCRIPTION
This is refactored to use inner_xxx_fetch() without any given
name, which is just there to ensure all decoder implementations are
made into methods, and then use ossl_method_store_do_all() to list
them all.

This also adds the internal xxx_do_all_prefetched(), which
can be used if pre-fetching needs to be done separately from listing
all the decoder implementations, or if listing may happen multiple
times.

Fixes #15538
Fixes #14837
