### PR TITLE
BIO_write-ex(): Improve behavior in corner cases and documentation

### DIFF
--- a/doc/man3/BIO_read.pod
+++ b/doc/man3/BIO_read.pod
@@ -25,8 +25,9 @@ BIO_read_ex() attempts to read I<dlen> bytes from BIO I<b> and places the data
 in I<data>. If any bytes were successfully read then the number of bytes read is
 stored in I<*readbytes>.
 
-BIO_write_ex() attempts to write I<dlen> bytes from I<data> to BIO I<b>. If
-successful then the number of bytes written is stored in I<*written>.
+BIO_write_ex() attempts to write I<dlen> bytes from I<data> to BIO I<b>.
+If successful then the number of bytes written is stored in I<*written>
+unless I<written> is NULL. This may be 0 in case I<dlen> is 0 or I<b> is NULL.
 
 BIO_read() attempts to read I<len> bytes from BIO I<b> and places
 the data in I<buf>.
@@ -54,11 +55,13 @@ BIO_write() attempts to write I<len> bytes from I<buf> to BIO I<b>.
 BIO_puts() attempts to write a NUL-terminated string I<buf> to BIO I<b>.
 
 =head1 RETURN VALUES
-
 BIO_read_ex() and BIO_write_ex() return 1 if data was successfully read or
 written, and 0 otherwise.
 
-BIO_write() and BIO_write_ex() return 0 if the BIO I<b> is NULL.
+BIO_write() returns -2 if the "write" operation is not implemented by the BIO
+or -1 on other errors.
+Else it returns the number of bytes written.
+This may be 0 if the BIO I<b> is NULL or I<dlen <= 0>.
 
 BIO_gets() returns -2 if the "gets" operation is not implemented by the BIO
 or -1 on other errors.

--- a/doc/man3/BIO_read.pod
+++ b/doc/man3/BIO_read.pod
@@ -27,7 +27,7 @@ stored in I<*readbytes>.
 
 BIO_write_ex() attempts to write I<dlen> bytes from I<data> to BIO I<b>.
 If successful then the number of bytes written is stored in I<*written>
-unless I<written> is NULL. This may be 0 in case I<dlen> is 0 or I<b> is NULL.
+unless I<written> is NULL. No data is written if I<b> is NULL.
 
 BIO_read() attempts to read I<len> bytes from BIO I<b> and places
 the data in I<buf>.
@@ -55,8 +55,11 @@ BIO_write() attempts to write I<len> bytes from I<buf> to BIO I<b>.
 BIO_puts() attempts to write a NUL-terminated string I<buf> to BIO I<b>.
 
 =head1 RETURN VALUES
-BIO_read_ex() and BIO_write_ex() return 1 if data was successfully read or
-written, and 0 otherwise.
+
+BIO_read_ex() returns 1 if data was successfully read, and 0 otherwise.
+
+BIO_write_ex() returns 1 if no error was encountered writing data, 0 otherwise.
+Write to NULL B<BIO> is not considered as an error.
 
 BIO_write() returns -2 if the "write" operation is not implemented by the BIO
 or -1 on other errors.

--- a/doc/man3/BIO_read.pod
+++ b/doc/man3/BIO_read.pod
@@ -60,7 +60,7 @@ written, and 0 otherwise.
 
 BIO_write() returns -2 if the "write" operation is not implemented by the BIO
 or -1 on other errors.
-Else it returns the number of bytes written.
+Otherwise it returns the number of bytes written.
 This may be 0 if the BIO I<b> is NULL or I<dlen <= 0>.
 
 BIO_gets() returns -2 if the "gets" operation is not implemented by the BIO


### PR DESCRIPTION
As discussed for #15493, the return values of `BIO_write_ex()` are intentionally different from those of `BIO_write()`.
Yet as I mentioned, there are minor bugs/inconsistencies with the return values  of `BIO_write_ex()`:

* If an empty string is to be printed, i.e., `dlen == 0`, this results in a (wrong) error being flagged.
* If `b == NULL`, this is also (needlessly) flagged as error, while for `BIO_write()` this was allowed.

These are fixed in this PR by replacing in
```
int BIO_write_ex(BIO *b, const void *data, size_t dlen, size_t *written)
{
     return bio_write_intern(b, data, dlen, written) > 0;
}
```
the `>` by `>=`.

Moreover, this PR allows `written` to be NULL, which is helpful in case the caller is not interested in how many bytes have been written.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
