### PR TITLE
Deprecate SSL_COMP_xxx API

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,12 @@ breaking changes, and mappings for the large list of deprecated functions.
 
 ### Changes between 1.1.1 and 3.0 [xx XXX xxxx]
 
+ * The SSL_COMP API, that enables compression in TLS/SSL, has been
+   deprecated. Compression has a history of security vulnerabilities,
+   and is not defined for TLS 1.3.
+
+   *Rich Salz*
+
  * Rework and make DEBUG macros consistent. Remove unused -DCONF_DEBUG,
    -DBN_CTX_DEBUG, and REF_PRINT. Add a new tracing category and use it for
    printing reference counts. Rename -DDEBUG_UNUSED to -DUNUSED_RESULT_DEBUG

--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -25,6 +25,7 @@
 #endif
 #include <ctype.h>
 #include <errno.h>
+#include <openssl/macros.h>
 #include <openssl/err.h>
 #include <openssl/x509.h>
 #include <openssl/x509v3.h>

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -8,6 +8,7 @@
  * https://www.openssl.org/source/license.html
  */
 
+#define OPENSSL_SUPPRESS_DEPRECATED
 #include "e_os.h"
 #include <ctype.h>
 #include <stdio.h>
@@ -3073,9 +3074,6 @@ static void print_stuff(BIO *bio, SSL *s, int full)
     EVP_PKEY *public_key;
     int i, istls13 = (SSL_version(s) == TLS1_3_VERSION);
     long verify_result;
-#ifndef OPENSSL_NO_COMP
-    const COMP_METHOD *comp, *expansion;
-#endif
     unsigned char *exportedkeymat;
 #ifndef OPENSSL_NO_CT
     const SSL_CTX *ctx = SSL_get_SSL_CTX(s);
@@ -3184,13 +3182,16 @@ static void print_stuff(BIO *bio, SSL *s, int full)
     }
     BIO_printf(bio, "Secure Renegotiation IS%s supported\n",
                SSL_get_secure_renegotiation_support(s) ? "" : " NOT");
-#ifndef OPENSSL_NO_COMP
-    comp = SSL_get_current_compression(s);
-    expansion = SSL_get_current_expansion(s);
-    BIO_printf(bio, "Compression: %s\n",
-               comp ? SSL_COMP_get_name(comp) : "NONE");
-    BIO_printf(bio, "Expansion: %s\n",
-               expansion ? SSL_COMP_get_name(expansion) : "NONE");
+#if !defined(OPENSSL_NO_COMP) && !defined(OPENSSL_NO_DEPRECATED_3_0)
+    {
+        const COMP_METHOD *comp = SSL_get_current_compression(s);
+        const COMP_METHOD *expansion = SSL_get_current_expansion(s);
+
+        BIO_printf(bio, "Compression: %s\n",
+                comp ? SSL_COMP_get_name(comp) : "NONE");
+        BIO_printf(bio, "Expansion: %s\n",
+                expansion ? SSL_COMP_get_name(expansion) : "NONE");
+    }
 #endif
 #ifndef OPENSSL_NO_KTLS
     if (BIO_get_ktls_send(SSL_get_wbio(s)))

--- a/doc/man3/SSL_COMP_add_compression_method.pod
+++ b/doc/man3/SSL_COMP_add_compression_method.pod
@@ -10,15 +10,14 @@ SSL_COMP_get0_name, SSL_COMP_get_id, SSL_COMP_free_compression_methods
 
  #include <openssl/ssl.h>
 
- int SSL_COMP_add_compression_method(int id, COMP_METHOD *cm);
- STACK_OF(SSL_COMP) *SSL_COMP_get_compression_methods(void);
- const char *SSL_COMP_get0_name(const SSL_COMP *comp);
- int SSL_COMP_get_id(const SSL_COMP *comp);
-
 Deprecated since OpenSSL 1.1.0, can be hidden entirely by defining
 B<OPENSSL_API_COMPAT> with a suitable version value, see
 L<openssl_user_macros(7)>:
 
+ int SSL_COMP_add_compression_method(int id, COMP_METHOD *cm);
+ STACK_OF(SSL_COMP) *SSL_COMP_get_compression_methods(void);
+ const char *SSL_COMP_get0_name(const SSL_COMP *comp);
+ int SSL_COMP_get_id(const SSL_COMP *comp);
  void SSL_COMP_free_compression_methods(void);
 
 =head1 DESCRIPTION
@@ -40,7 +39,7 @@ maintain the internal table of compression methods.
 
 =head1 NOTES
 
-The TLS standard (or SSLv3) allows the integration of compression methods
+Some versions of TLS (and SSLv3) allow the integration of compression methods
 into the communication. The TLS RFC does however not specify compression
 methods or their corresponding identifiers, so there is currently no compatible
 way to integrate compression with unknown peers. It is therefore currently not
@@ -90,6 +89,12 @@ SSL_COMP_get_id() returns the name of the compression method or -1 on error.
 L<ssl(7)>
 
 =head1 HISTORY
+
+SSL_COMP_add_compression_method(),
+SSL_COMP_get_compression_methods(),
+SSL_COMP_get0_name(), and
+SSL_COMP_get_id()
+functions were deprecated in OpenSSL 3.0.
 
 The SSL_COMP_free_compression_methods() function was deprecated in OpenSSL 1.1.0.
 The SSL_COMP_get0_name() and SSL_comp_get_id() functions were added in OpenSSL 1.1.0d.

--- a/fuzz/client.c
+++ b/fuzz/client.c
@@ -8,6 +8,7 @@
  * or in the file LICENSE in the source distribution.
  */
 
+#define OPENSSL_SUPPRESS_DEPRECATED /* For SSL_COMP_xxx API */
 #include <time.h>
 #include <openssl/rand.h>
 #include <openssl/ssl.h>
@@ -38,17 +39,20 @@ time_t time(time_t *t) TIME_IMPL(t)
 
 int FuzzerInitialize(int *argc, char ***argv)
 {
-    STACK_OF(SSL_COMP) *comp_methods;
-
     FuzzerSetRand();
     OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CRYPTO_STRINGS | OPENSSL_INIT_ASYNC, NULL);
     OPENSSL_init_ssl(OPENSSL_INIT_LOAD_SSL_STRINGS, NULL);
     ERR_clear_error();
     CRYPTO_free_ex_index(0, -1);
     idx = SSL_get_ex_data_X509_STORE_CTX_idx();
-    comp_methods = SSL_COMP_get_compression_methods();
-    if (comp_methods != NULL)
-        sk_SSL_COMP_sort(comp_methods);
+#if !defined(OPENSSL_NO_COMP) && !defined(OPENSSL_NO_DEPRECATED_3_0)
+    {
+        STACK_OF(SSL_COMP) *comp_methods = SSL_COMP_get_compression_methods();
+
+        if (comp_methods != NULL)
+            sk_SSL_COMP_sort(comp_methods);
+    }
+#endif
 
     return 1;
 }

--- a/fuzz/server.c
+++ b/fuzz/server.c
@@ -491,17 +491,21 @@ time_t time(time_t *t) TIME_IMPL(t)
 
 int FuzzerInitialize(int *argc, char ***argv)
 {
-    STACK_OF(SSL_COMP) *comp_methods;
-
     FuzzerSetRand();
     OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CRYPTO_STRINGS | OPENSSL_INIT_ASYNC, NULL);
     OPENSSL_init_ssl(OPENSSL_INIT_LOAD_SSL_STRINGS, NULL);
     ERR_clear_error();
     CRYPTO_free_ex_index(0, -1);
     idx = SSL_get_ex_data_X509_STORE_CTX_idx();
-    comp_methods = SSL_COMP_get_compression_methods();
-    if (comp_methods != NULL)
-        sk_SSL_COMP_sort(comp_methods);
+
+#if !defined(OPENSSL_NO_COMP) && !defined(OPENSSL_NO_DEPRECATED_3_0)
+    {
+        STACK_OF(SSL_COMP) *comp_methods = SSL_COMP_get_compression_methods();
+
+        if (comp_methods != NULL)
+            sk_SSL_COMP_sort(comp_methods);
+    }
+#endif
 
     return 1;
 }

--- a/include/openssl/ssl.h.in
+++ b/include/openssl/ssl.h.in
@@ -2147,18 +2147,28 @@ void SSL_set_tmp_dh_callback(SSL *ssl,
 #  endif
 # endif
 
-__owur const COMP_METHOD *SSL_get_current_compression(const SSL *s);
-__owur const COMP_METHOD *SSL_get_current_expansion(const SSL *s);
-__owur const char *SSL_COMP_get_name(const COMP_METHOD *comp);
-__owur const char *SSL_COMP_get0_name(const SSL_COMP *comp);
-__owur int SSL_COMP_get_id(const SSL_COMP *comp);
-STACK_OF(SSL_COMP) *SSL_COMP_get_compression_methods(void);
-__owur STACK_OF(SSL_COMP) *SSL_COMP_set0_compression_methods(STACK_OF(SSL_COMP)
-                                                             *meths);
 # ifndef OPENSSL_NO_DEPRECATED_1_1_0
 #  define SSL_COMP_free_compression_methods() while(0) continue
 # endif
-__owur int SSL_COMP_add_compression_method(int id, COMP_METHOD *cm);
+# if !defined(OPENSSL_NO_COMP) && !defined(OPENSSL_NO_DEPRECATED_3_0)
+OSSL_DEPRECATEDIN_3_0
+STACK_OF(SSL_COMP) *SSL_COMP_set0_compression_methods(STACK_OF(SSL_COMP)
+                                                             *meths);
+OSSL_DEPRECATEDIN_3_0
+const COMP_METHOD *SSL_get_current_expansion(const SSL *s);
+OSSL_DEPRECATEDIN_3_0
+const COMP_METHOD *SSL_get_current_compression(const SSL *s);
+OSSL_DEPRECATEDIN_3_0
+int SSL_COMP_get_id(const SSL_COMP *comp);
+OSSL_DEPRECATEDIN_3_0
+const char *SSL_COMP_get_name(const COMP_METHOD *comp);
+OSSL_DEPRECATEDIN_3_0
+const char *SSL_COMP_get0_name(const SSL_COMP *comp);
+OSSL_DEPRECATEDIN_3_0
+STACK_OF(SSL_COMP) *SSL_COMP_get_compression_methods(void);
+OSSL_DEPRECATEDIN_3_0
+int SSL_COMP_add_compression_method(int id, COMP_METHOD *cm);
+#endif
 
 const SSL_CIPHER *SSL_CIPHER_find(SSL *ssl, const unsigned char *ptr);
 int SSL_CIPHER_get_cipher_nid(const SSL_CIPHER *c);

--- a/ssl/ssl_ciph.c
+++ b/ssl/ssl_ciph.c
@@ -1948,6 +1948,7 @@ uint16_t SSL_CIPHER_get_protocol_id(const SSL_CIPHER *c)
     return c->id & 0xFFFF;
 }
 
+#if !defined(OPENSSL_NO_COMP) && !defined(OPENSSL_NO_DEPRECATED_3_0)
 SSL_COMP *ssl3_comp_find(STACK_OF(SSL_COMP) *sk, int n)
 {
     SSL_COMP *ctmp;
@@ -1964,24 +1965,6 @@ SSL_COMP *ssl3_comp_find(STACK_OF(SSL_COMP) *sk, int n)
     return NULL;
 }
 
-#ifdef OPENSSL_NO_COMP
-STACK_OF(SSL_COMP) *SSL_COMP_get_compression_methods(void)
-{
-    return NULL;
-}
-
-STACK_OF(SSL_COMP) *SSL_COMP_set0_compression_methods(STACK_OF(SSL_COMP)
-                                                      *meths)
-{
-    return meths;
-}
-
-int SSL_COMP_add_compression_method(int id, COMP_METHOD *cm)
-{
-    return 1;
-}
-
-#else
 STACK_OF(SSL_COMP) *SSL_COMP_get_compression_methods(void)
 {
     load_builtin_compressions();
@@ -2049,34 +2032,34 @@ int SSL_COMP_add_compression_method(int id, COMP_METHOD *cm)
     }
     return 0;
 }
-#endif
 
 const char *SSL_COMP_get_name(const COMP_METHOD *comp)
 {
-#ifndef OPENSSL_NO_COMP
+# ifndef OPENSSL_NO_COMP
     return comp ? COMP_get_name(comp) : NULL;
-#else
+# else
     return NULL;
-#endif
+# endif
 }
 
 const char *SSL_COMP_get0_name(const SSL_COMP *comp)
 {
-#ifndef OPENSSL_NO_COMP
+# ifndef OPENSSL_NO_COMP
     return comp->name;
-#else
+# else
     return NULL;
-#endif
+# endif
 }
 
 int SSL_COMP_get_id(const SSL_COMP *comp)
 {
-#ifndef OPENSSL_NO_COMP
+# ifndef OPENSSL_NO_COMP
     return comp->id;
-#else
+# else
     return -1;
-#endif
+# endif
 }
+#endif
 
 const SSL_CIPHER *ssl_get_cipher_by_char(SSL *ssl, const unsigned char *ptr,
                                          int all)

--- a/ssl/ssl_init.c
+++ b/ssl/ssl_init.c
@@ -7,6 +7,7 @@
  * https://www.openssl.org/source/license.html
  */
 
+#define OPENSSL_SUPPRESS_DEPRECATED /* For SSL_COMP_xxx API */
 #include "e_os.h"
 
 #include "internal/err.h"
@@ -25,7 +26,7 @@ static CRYPTO_ONCE ssl_base = CRYPTO_ONCE_STATIC_INIT;
 static int ssl_base_inited = 0;
 DEFINE_RUN_ONCE_STATIC(ossl_init_ssl_base)
 {
-#ifndef OPENSSL_NO_COMP
+#if !defined(OPENSSL_NO_COMP) && !defined(OPENSSL_NO_DEPRECATED_3_0)
     OSSL_TRACE(INIT, "ossl_init_ssl_base: "
                "SSL_COMP_get_compression_methods()\n");
     /*
@@ -76,7 +77,7 @@ static void ssl_library_stop(void)
     stopped = 1;
 
     if (ssl_base_inited) {
-#ifndef OPENSSL_NO_COMP
+#if !defined(OPENSSL_NO_COMP) && !defined(OPENSSL_NO_DEPRECATED_3_0)
         OSSL_TRACE(INIT, "ssl_library_stop: "
                    "ssl_comp_free_compression_methods_int()\n");
         ssl_comp_free_compression_methods_int();

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -9,6 +9,7 @@
  * https://www.openssl.org/source/license.html
  */
 
+#include <internal/deprecated.h>
 #include <stdio.h>
 #include "ssl_local.h"
 #include "e_os.h"
@@ -3270,9 +3271,13 @@ SSL_CTX *SSL_CTX_new_ex(OSSL_LIB_CTX *libctx, const char *propq,
     if ((ret->ext.secure = OPENSSL_secure_zalloc(sizeof(*ret->ext.secure))) == NULL)
         goto err;
 
+#ifndef OPENSSL_NO_DEPRECATED_3_0
+# ifndef OPENSSL_NO_COMP
     /* No compression for DTLS */
     if (!(meth->ssl3_enc->enc_flags & SSL_ENC_FLAG_DTLS))
         ret->comp_methods = SSL_COMP_get_compression_methods();
+# endif
+#endif
 
     ret->max_send_fragment = SSL3_RT_MAX_PLAIN_LENGTH;
     ret->split_send_fragment = SSL3_RT_MAX_PLAIN_LENGTH;
@@ -4166,23 +4171,17 @@ const SSL_CIPHER *SSL_get_pending_cipher(const SSL *s)
     return s->s3.tmp.new_cipher;
 }
 
+#if !defined(OPENSSL_NO_COMP) && !defined(OPENSSL_NO_DEPRECATED_3_0)
 const COMP_METHOD *SSL_get_current_compression(const SSL *s)
 {
-#ifndef OPENSSL_NO_COMP
     return s->compress ? COMP_CTX_get_method(s->compress) : NULL;
-#else
-    return NULL;
-#endif
 }
 
 const COMP_METHOD *SSL_get_current_expansion(const SSL *s)
 {
-#ifndef OPENSSL_NO_COMP
     return s->expand ? COMP_CTX_get_method(s->expand) : NULL;
-#else
-    return NULL;
-#endif
 }
+#endif
 
 int ssl_init_wbio_buffer(SSL *s)
 {

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -1380,7 +1380,7 @@ MSG_PROCESS_RETURN tls_process_server_hello(SSL *s, PACKET *pkt)
     unsigned int sversion;
     unsigned int context;
     RAW_EXTENSION *extensions = NULL;
-#ifndef OPENSSL_NO_COMP
+#if !defined(OPENSSL_NO_COMP) && !defined(OPENSSL_NO_DEPRECATED_3_0)
     SSL_COMP *comp;
 #endif
 
@@ -1609,7 +1609,7 @@ MSG_PROCESS_RETURN tls_process_server_hello(SSL *s, PACKET *pkt)
         goto err;
     }
 
-#ifdef OPENSSL_NO_COMP
+#if defined(OPENSSL_NO_COMP) || defined(OPENSSL_NO_DEPRECATED_3_0)
     if (compression != 0) {
         SSLfatal(s, SSL_AD_ILLEGAL_PARAMETER,
                  SSL_R_UNSUPPORTED_COMPRESSION_ALGORITHM);

--- a/test/helpers/handshake.c
+++ b/test/helpers/handshake.c
@@ -7,6 +7,7 @@
  * https://www.openssl.org/source/license.html
  */
 
+#define OPENSSL_SUPPRESS_DEPRECATED /* For SSL_get_current_compression */
 #include <string.h>
 
 #include <openssl/bio.h>
@@ -1620,9 +1621,13 @@ static HANDSHAKE_RESULT *do_handshake_internal(
         ret->session_ticket = SSL_TEST_SESSION_TICKET_NO;
     else
         ret->session_ticket = SSL_TEST_SESSION_TICKET_YES;
+#ifndef OPENSSL_NO_DEPRECATED_3_0
     ret->compression = (SSL_get_current_compression(client.ssl) == NULL)
                        ? SSL_TEST_COMPRESSION_NO
                        : SSL_TEST_COMPRESSION_YES;
+#else
+    ret->compression = SSL_TEST_COMPRESSION_NO;
+#endif
     if (sess_id == NULL || sess_id_len == 0)
         ret->session_id = SSL_TEST_SESSION_ID_NO;
     else

--- a/test/ssl_old_test.c
+++ b/test/ssl_old_test.c
@@ -9,6 +9,7 @@
  * https://www.openssl.org/source/license.html
  */
 
+#define OPENSSL_SUPPRESS_DEPRECATED /* For SSL_COMP_xxx API */
 #include "e_os.h"
 
 /* Or gethostname won't be declared properly on Linux and GNU platforms. */
@@ -890,7 +891,7 @@ int main(int argc, char *argv[])
     int no_psk = 0;
     int print_time = 0;
     clock_t s_time = 0, c_time = 0;
-#ifndef OPENSSL_NO_COMP
+#if !defined(OPENSSL_NO_COMP) && !defined(OPENSSL_NO_DEPRECATED_3_0)
     int n, comp = 0;
     COMP_METHOD *cm = NULL;
     STACK_OF(SSL_COMP) *ssl_comp_methods = NULL;
@@ -1063,7 +1064,7 @@ int main(int argc, char *argv[])
             ct_validation = 1;
         }
 #endif
-#ifndef OPENSSL_NO_COMP
+#if !defined(OPENSSL_NO_COMP) && !defined(OPENSSL_NO_DEPRECATED_3_0)
         else if (strcmp(*argv, "-zlib") == 0) {
             comp = COMP_ZLIB;
         }
@@ -1279,7 +1280,7 @@ int main(int argc, char *argv[])
                     "Warning: For accurate timings, use more connections (e.g. -num 1000)\n");
     }
 
-#ifndef OPENSSL_NO_COMP
+#if !defined(OPENSSL_NO_COMP) && !defined(OPENSSL_NO_DEPRECATED_3_0)
     if (comp == COMP_ZLIB)
         cm = COMP_zlib();
     if (cm != NULL) {

--- a/util/libssl.num
+++ b/util/libssl.num
@@ -24,7 +24,7 @@ SSL_set_generate_session_id             24	3_0_0	EXIST::FUNCTION:
 SSL_get_ex_data_X509_STORE_CTX_idx      25	3_0_0	EXIST::FUNCTION:
 SSL_get_quiet_shutdown                  26	3_0_0	EXIST::FUNCTION:
 SSL_dane_enable                         27	3_0_0	EXIST::FUNCTION:
-SSL_COMP_add_compression_method         28	3_0_0	EXIST::FUNCTION:
+SSL_COMP_add_compression_method         28	3_0_0	EXIST::FUNCTION:COMP,DEPRECATED_3_0
 SSL_CTX_use_RSAPrivateKey               29	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
 SSL_CTX_sess_get_new_cb                 30	3_0_0	EXIST::FUNCTION:
 d2i_SSL_SESSION                         31	3_0_0	EXIST::FUNCTION:
@@ -150,7 +150,7 @@ SSL_CTX_SRP_CTX_init                    150	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3
 SSL_SESSION_set_time                    151	3_0_0	EXIST::FUNCTION:
 i2d_SSL_SESSION                         152	3_0_0	EXIST::FUNCTION:
 SSL_SESSION_get_master_key              153	3_0_0	EXIST::FUNCTION:
-SSL_COMP_get_compression_methods        154	3_0_0	EXIST::FUNCTION:
+SSL_COMP_get_compression_methods        154	3_0_0	EXIST::FUNCTION:COMP,DEPRECATED_3_0
 SSL_CTX_set_alpn_select_cb              155	3_0_0	EXIST::FUNCTION:
 SSL_CTX_set_tmp_dh_callback             156	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,DH
 SSL_CTX_get_default_passwd_cb           157	3_0_0	EXIST::FUNCTION:
@@ -224,7 +224,7 @@ SSL_set_alpn_protos                     224	3_0_0	EXIST::FUNCTION:
 SSL_set_ex_data                         225	3_0_0	EXIST::FUNCTION:
 SSL_rstate_string_long                  226	3_0_0	EXIST::FUNCTION:
 SSL_ctrl                                227	3_0_0	EXIST::FUNCTION:
-SSL_get_current_compression             228	3_0_0	EXIST::FUNCTION:
+SSL_get_current_compression             228	3_0_0	EXIST::FUNCTION:COMP,DEPRECATED_3_0
 SSL_SESSION_has_ticket                  229	3_0_0	EXIST::FUNCTION:
 SSL_CTX_set_cert_verify_callback        230	3_0_0	EXIST::FUNCTION:
 SSL_set_session_secret_cb               231	3_0_0	EXIST::FUNCTION:
@@ -291,7 +291,7 @@ SSL_get0_alpn_selected                  291	3_0_0	EXIST::FUNCTION:
 SSL_get0_next_proto_negotiated          292	3_0_0	EXIST::FUNCTION:NEXTPROTONEG
 SSL_set0_security_ex_data               293	3_0_0	EXIST::FUNCTION:
 SSL_CTX_set_tlsext_use_srtp             294	3_0_0	EXIST::FUNCTION:SRTP
-SSL_COMP_set0_compression_methods       295	3_0_0	EXIST::FUNCTION:
+SSL_COMP_set0_compression_methods       295	3_0_0	EXIST::FUNCTION:COMP,DEPRECATED_3_0
 SSL_CTX_set_not_resumable_session_callback 296	3_0_0	EXIST::FUNCTION:
 SSL_accept                              297	3_0_0	EXIST::FUNCTION:
 SSL_use_psk_identity_hint               298	3_0_0	EXIST::FUNCTION:PSK
@@ -315,7 +315,7 @@ SSL_CTX_get_timeout                     315	3_0_0	EXIST::FUNCTION:
 SSL_use_certificate_chain_file          316	3_0_0	EXIST::FUNCTION:
 SSL_set_not_resumable_session_callback  317	3_0_0	EXIST::FUNCTION:
 SSL_CTX_SRP_CTX_free                    318	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,SRP
-SSL_get_current_expansion               319	3_0_0	EXIST::FUNCTION:
+SSL_get_current_expansion               319	3_0_0	EXIST::FUNCTION:COMP,DEPRECATED_3_0
 SSL_clear_options                       320	3_0_0	EXIST::FUNCTION:
 SSL_CTX_use_PrivateKey                  321	3_0_0	EXIST::FUNCTION:
 SSL_get_info_callback                   322	3_0_0	EXIST::FUNCTION:
@@ -338,7 +338,7 @@ SSL_add_file_cert_subjects_to_stack     338	3_0_0	EXIST::FUNCTION:
 SSL_get_default_passwd_cb_userdata      339	3_0_0	EXIST::FUNCTION:
 SSL_get_security_callback               340	3_0_0	EXIST::FUNCTION:
 SSL_CTX_set_srp_username                341	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,SRP
-SSL_COMP_get_name                       342	3_0_0	EXIST::FUNCTION:
+SSL_COMP_get_name                       342	3_0_0	EXIST::FUNCTION:COMP,DEPRECATED_3_0
 SSL_CTX_set_default_passwd_cb_userdata  343	3_0_0	EXIST::FUNCTION:
 SSL_set_verify                          344	3_0_0	EXIST::FUNCTION:
 SSL_in_before                           345	3_0_0	EXIST::FUNCTION:
@@ -408,8 +408,8 @@ DTLS_get_data_mtu                       408	3_0_0	EXIST::FUNCTION:
 SSL_read_ex                             409	3_0_0	EXIST::FUNCTION:
 SSL_peek_ex                             410	3_0_0	EXIST::FUNCTION:
 SSL_write_ex                            411	3_0_0	EXIST::FUNCTION:
-SSL_COMP_get_id                         412	3_0_0	EXIST::FUNCTION:
-SSL_COMP_get0_name                      413	3_0_0	EXIST::FUNCTION:
+SSL_COMP_get_id                         412	3_0_0	EXIST::FUNCTION:COMP,DEPRECATED_3_0
+SSL_COMP_get0_name                      413	3_0_0	EXIST::FUNCTION:COMP,DEPRECATED_3_0
 SSL_CTX_set_keylog_callback             414	3_0_0	EXIST::FUNCTION:
 SSL_CTX_get_keylog_callback             415	3_0_0	EXIST::FUNCTION:
 SSL_get_peer_signature_type_nid         416	3_0_0	EXIST::FUNCTION:


### PR DESCRIPTION
This deprecates compression from the TLS/SSL layer.  It is the first part of addressing #14506.  A separate PR will deprecate the COMP API after this is reviewed.
