### PR TITLE
Elimination of some sources not needed in the FIPS_MODULE

### DIFF
--- a/crypto/rand/build.info
+++ b/crypto/rand/build.info
@@ -7,7 +7,7 @@ IF[{- !$disabled{'egd'} -}]
   $CRYPTO=$CRYPTO rand_egd.c
 ENDIF
 IF[{- !$disabled{'deprecated-3.0'} -}]
-  $COMMON=$COMMON  rand_meth.c
+  $CRYPTO=$CRYPTO rand_meth.c
 ENDIF
 
 SOURCE[../../libcrypto]=$COMMON $CRYPTO

--- a/crypto/rand/rand_lib.c
+++ b/crypto/rand/rand_lib.c
@@ -10,25 +10,25 @@
 /* We need to use some engine deprecated APIs */
 #define OPENSSL_SUPPRESS_DEPRECATED
 
-#include <stdio.h>
-#include <time.h>
-#include <limits.h>
-#include <openssl/trace.h>
 #include <openssl/err.h>
-#include <openssl/conf.h>
-#include "internal/cryptlib.h"
 #include <openssl/opensslconf.h>
+#include <openssl/core_names.h>
+#include "internal/cryptlib.h"
+#include "internal/thread_once.h"
 #include "crypto/rand.h"
 #include "crypto/cryptlib.h"
-#include <openssl/engine.h>
-#include <openssl/core_names.h>
-#include "internal/thread_once.h"
 #include "rand_local.h"
-#include "e_os.h"
 
 #ifndef FIPS_MODULE
+# include <stdio.h>
+# include <time.h>
+# include <limits.h>
+# include <openssl/conf.h>
+# include <openssl/trace.h>
+# include <openssl/engine.h>
 # include "crypto/rand_pool.h"
 # include "prov/seeding.h"
+# include "e_os.h"
 
 # ifndef OPENSSL_NO_ENGINE
 /* non-NULL if default_RAND_meth is ENGINE-provided */
@@ -319,7 +319,7 @@ int RAND_priv_bytes_ex(OSSL_LIB_CTX *ctx, unsigned char *buf, size_t num,
                        unsigned int strength)
 {
     EVP_RAND_CTX *rand;
-#ifndef OPENSSL_NO_DEPRECATED_3_0
+#if !defined(OPENSSL_NO_DEPRECATED_3_0) && !defined(FIPS_MODULE)
     const RAND_METHOD *meth = RAND_get_rand_method();
 
     if (meth != NULL && meth != RAND_OpenSSL()) {
@@ -348,7 +348,7 @@ int RAND_bytes_ex(OSSL_LIB_CTX *ctx, unsigned char *buf, size_t num,
                   unsigned int strength)
 {
     EVP_RAND_CTX *rand;
-#ifndef OPENSSL_NO_DEPRECATED_3_0
+#if !defined(OPENSSL_NO_DEPRECATED_3_0) && !defined(FIPS_MODULE)
     const RAND_METHOD *meth = RAND_get_rand_method();
 
     if (meth != NULL && meth != RAND_OpenSSL()) {

--- a/crypto/rand/rand_local.h
+++ b/crypto/rand/rand_local.h
@@ -25,7 +25,9 @@
 # define PRIMARY_RESEED_TIME_INTERVAL            (60 * 60) /* 1 hour */
 # define SECONDARY_RESEED_TIME_INTERVAL          (7 * 60)  /* 7 minutes */
 
+# ifndef FIPS_MODULE
 /* The global RAND method, and the global buffer and DRBG instance. */
 extern RAND_METHOD ossl_rand_meth;
+# endif
 
 #endif

--- a/crypto/rand/rand_meth.c
+++ b/crypto/rand/rand_meth.c
@@ -61,9 +61,5 @@ RAND_METHOD ossl_rand_meth = {
 
 RAND_METHOD *RAND_OpenSSL(void)
 {
-#ifndef FIPS_MODULE
     return &ossl_rand_meth;
-#else
-    return NULL;
-#endif
 }

--- a/include/crypto/sm2.h
+++ b/include/crypto/sm2.h
@@ -15,7 +15,7 @@
 
 # include <openssl/opensslconf.h>
 
-# ifndef OPENSSL_NO_SM2
+# if !defined(OPENSSL_NO_SM2) && !defined(FIPS_MODULE)
 
 #  include <openssl/ec.h>
 #  include "crypto/types.h"


### PR DESCRIPTION
Unfortunately in terms of fips.sources this does not mean much
given the way how the .h files are added via the dependency
information from the compiler.

This eliminates only crypto/rand/rand_meth.c from fips.module.sources.