### PR TITLE
Deprecated BIO_f_zlib

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,12 @@ breaking changes, and mappings for the large list of deprecated functions.
 
 ### Changes between 1.1.1 and 3.0 [xx XXX xxxx]
 
+ * The undocumented function BIO_f_zlib has been deprecated, which
+   forced the deprecation of the "-z" option to the enc command, and
+   the "-compress" and "-uncompress" options to the cms command.
+
+   *Rich Salz*
+
  * Rework and make DEBUG macros consistent. Remove unused -DCONF_DEBUG,
    -DBN_CTX_DEBUG, and REF_PRINT. Add a new tracing category and use it for
    printing reference counts. Rename -DDEBUG_UNUSED to -DUNUSED_RESULT_DEBUG

--- a/apps/cms.c
+++ b/apps/cms.c
@@ -110,9 +110,11 @@ const OPTIONS cms_options[] = {
      "Create a CMS \"DigestedData\" object"},
     {"digest_verify", OPT_DIGEST_VERIFY, '-',
      "Verify a CMS \"DigestedData\" object and output it"},
+#if defined(ZLIB) && !defined(OPENSSL_NO_DEPRECATED_3_0)
     {"compress", OPT_COMPRESS, '-', "Create a CMS \"CompressedData\" object"},
     {"uncompress", OPT_UNCOMPRESS, '-',
      "Uncompress a CMS \"CompressedData\" object"},
+#endif
     {"EncryptedData_encrypt", OPT_ED_ENCRYPT, '-',
      "Create CMS \"EncryptedData\" object using symmetric key"},
     {"EncryptedData_decrypt", OPT_ED_DECRYPT, '-',
@@ -392,12 +394,18 @@ int cms_main(int argc, char **argv)
         case OPT_DIGEST_VERIFY:
             operation = SMIME_DIGEST_VERIFY;
             break;
+#if defined(ZLIB) && !defined(OPENSSL_NO_DEPRECATED_3_0)
         case OPT_COMPRESS:
             operation = SMIME_COMPRESS;
             break;
         case OPT_UNCOMPRESS:
             operation = SMIME_UNCOMPRESS;
             break;
+#else
+        case OPT_COMPRESS:
+        case OPT_UNCOMPRESS:
+            break;
+#endif
         case OPT_ED_ENCRYPT:
             operation = SMIME_ENCRYPTED_ENCRYPT;
             break;
@@ -980,7 +988,9 @@ int cms_main(int argc, char **argv)
     } else if (operation == SMIME_DIGEST_CREATE) {
         cms = CMS_digest_create_ex(in, sign_md, flags, libctx, app_get0_propq());
     } else if (operation == SMIME_COMPRESS) {
+#if defined(ZLIB) && !defined(OPENSSL_NO_DEPRECATED_3_0)
         cms = CMS_compress(in, -1, flags);
+#endif
     } else if (operation == SMIME_ENCRYPT) {
         int i;
         flags |= CMS_PARTIAL;
@@ -1182,8 +1192,10 @@ int cms_main(int argc, char **argv)
         if (!CMS_data(cms, out, flags))
             goto end;
     } else if (operation == SMIME_UNCOMPRESS) {
+#if defined(ZLIB) && !defined(OPENSSL_NO_DEPRECATED_3_0)
         if (!CMS_uncompress(cms, indata, out, flags))
             goto end;
+#endif
     } else if (operation == SMIME_DIGEST_VERIFY) {
         if (CMS_digest_verify(cms, indata, out, flags) > 0) {
             BIO_printf(bio_err, "Verification successful\n");

--- a/apps/enc.c
+++ b/apps/enc.c
@@ -91,7 +91,7 @@ const OPTIONS enc_options[] = {
     {"iter", OPT_ITER, 'p', "Specify the iteration count and force use of PBKDF2"},
     {"pbkdf2", OPT_PBKDF2, '-', "Use password-based key derivation function 2"},
     {"none", OPT_NONE, '-', "Don't encrypt"},
-#ifdef ZLIB
+#if defined(ZLIB) && !defined(OPENSSL_NO_DEPRECATED_3_0)
     {"z", OPT_Z, '-', "Compress or decompress encrypted data using zlib"},
 #endif
     {"", OPT_CIPHER, '-', "Any supported cipher"},
@@ -210,7 +210,7 @@ int enc_main(int argc, char **argv)
             base64 = 1;
             break;
         case OPT_Z:
-#ifdef ZLIB
+#if defined(ZLIB) && !defined(OPENSSL_NO_DEPRECATED_3_0)
             do_zlib = 1;
 #endif
             break;
@@ -398,7 +398,7 @@ int enc_main(int argc, char **argv)
     rbio = in;
     wbio = out;
 
-#ifdef ZLIB
+#if defined(ZLIB) && !defined(OPENSSL_NO_DEPRECATED_3_0)
     if (do_zlib) {
         if ((bzl = BIO_new(BIO_f_zlib())) == NULL)
             goto end;

--- a/apps/lib/http_server.c
+++ b/apps/lib/http_server.c
@@ -17,6 +17,7 @@
 # define _POSIX_C_SOURCE 2
 #endif
 
+#include <openssl/macros.h>
 #include <string.h>
 #include <ctype.h>
 #include "http_server.h"

--- a/crypto/cms/cms_cd.c
+++ b/crypto/cms/cms_cd.c
@@ -62,6 +62,7 @@ CMS_ContentInfo *ossl_cms_CompressedData_create(int comp_nid,
     return NULL;
 }
 
+# ifndef OPENSSL_NO_DEPRECATED_3_0
 BIO *ossl_cms_CompressedData_init_bio(const CMS_ContentInfo *cms)
 {
     CMS_CompressedData *cd;
@@ -79,5 +80,6 @@ BIO *ossl_cms_CompressedData_init_bio(const CMS_ContentInfo *cms)
     }
     return BIO_new(BIO_f_zlib());
 }
+# endif
 
 #endif

--- a/crypto/cms/cms_smime.c
+++ b/crypto/cms/cms_smime.c
@@ -895,7 +895,7 @@ err:
 
 }
 
-#ifdef ZLIB
+#if defined(ZLIB) && !defined(OPENSSL_NO_DEPRECATED_3_0)
 
 int CMS_uncompress(CMS_ContentInfo *cms, BIO *dcont, BIO *out,
                    unsigned int flags)
@@ -938,20 +938,4 @@ CMS_ContentInfo *CMS_compress(BIO *in, int comp_nid, unsigned int flags)
     CMS_ContentInfo_free(cms);
     return NULL;
 }
-
-#else
-
-int CMS_uncompress(CMS_ContentInfo *cms, BIO *dcont, BIO *out,
-                   unsigned int flags)
-{
-    ERR_raise(ERR_LIB_CMS, CMS_R_UNSUPPORTED_COMPRESSION_ALGORITHM);
-    return 0;
-}
-
-CMS_ContentInfo *CMS_compress(BIO *in, int comp_nid, unsigned int flags)
-{
-    ERR_raise(ERR_LIB_CMS, CMS_R_UNSUPPORTED_COMPRESSION_ALGORITHM);
-    return NULL;
-}
-
 #endif

--- a/crypto/comp/c_zlib.c
+++ b/crypto/comp/c_zlib.c
@@ -264,7 +264,7 @@ void ossl_comp_zlib_cleanup(void)
 #endif
 }
 
-#ifdef ZLIB
+#if defined(ZLIB) && !defined(OPENSSL_NO_DEPRECATED_3_0)
 
 /* Zlib based compression/decompression filter BIO */
 

--- a/doc/man1/openssl-cms.pod.in
+++ b/doc/man1/openssl-cms.pod.in
@@ -898,7 +898,8 @@ The -no_alt_chains option was added in OpenSSL 1.0.2b.
 
 The B<-nameopt> option was added in OpenSSL 3.0.0.
 
-The B<-engine> option was deprecated in OpenSSL 3.0.
+The B<-engine>, B<-compress>, and B<-uncompress>  options were
+deprecated in OpenSSL 3.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man1/openssl-enc.pod.in
+++ b/doc/man1/openssl-enc.pod.in
@@ -431,7 +431,7 @@ The default digest was changed from MD5 to SHA256 in OpenSSL 1.1.0.
 
 The B<-list> option was added in OpenSSL 1.1.1e.
 
-The B<-ciphers> and B<-engine> options were deprecated in OpenSSL 3.0.
+The B<-ciphers>, B<-engine>, and B<-z> options were deprecated in OpenSSL 3.0.
 
 =head1 COPYRIGHT
 

--- a/include/openssl/cms.h.in
+++ b/include/openssl/cms.h.in
@@ -248,9 +248,15 @@ CMS_RecipientInfo *CMS_add0_recipient_password(CMS_ContentInfo *cms,
 int CMS_RecipientInfo_decrypt(CMS_ContentInfo *cms, CMS_RecipientInfo *ri);
 int CMS_RecipientInfo_encrypt(const CMS_ContentInfo *cms, CMS_RecipientInfo *ri);
 
+#ifdef ZLIB
+# ifndef OPENSSL_NO_DEPRECATED_3_0
+OSSL_DEPRECATEDIN_3_0
 int CMS_uncompress(CMS_ContentInfo *cms, BIO *dcont, BIO *out,
                    unsigned int flags);
+OSSL_DEPRECATEDIN_3_0
 CMS_ContentInfo *CMS_compress(BIO *in, int comp_nid, unsigned int flags);
+# endif
+#endif
 
 int CMS_set1_eContentType(CMS_ContentInfo *cms, const ASN1_OBJECT *oid);
 const ASN1_OBJECT *CMS_get0_eContentType(CMS_ContentInfo *cms);

--- a/include/openssl/comp.h
+++ b/include/openssl/comp.h
@@ -46,7 +46,8 @@ COMP_METHOD *COMP_zlib(void);
 #endif
 
 # ifdef OPENSSL_BIO_H
-#  ifdef ZLIB
+#  if defined(ZLIB) && !defined(OPENSSL_NO_DEPRECATED_3_0)
+OPENSSL_DEPRECATEDIN_3_0
 const BIO_METHOD *BIO_f_zlib(void);
 #  endif
 # endif

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -1776,7 +1776,7 @@ BIO_sock_info                           1818	3_0_0	EXIST::FUNCTION:SOCK
 OPENSSL_hexstr2buf                      1819	3_0_0	EXIST::FUNCTION:
 EVP_add_cipher                          1820	3_0_0	EXIST::FUNCTION:
 X509V3_EXT_add_list                     1821	3_0_0	EXIST::FUNCTION:
-CMS_compress                            1822	3_0_0	EXIST::FUNCTION:CMS
+CMS_compress                            1822	3_0_0	EXIST::FUNCTION:CMS,DEPRECATEDIN_3_0,ZLIB
 X509_get_ext_by_critical                1823	3_0_0	EXIST::FUNCTION:
 ASYNC_WAIT_CTX_clear_fd                 1824	3_0_0	EXIST::FUNCTION:
 ZLONG_it                                1825	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0
@@ -1846,7 +1846,7 @@ TS_RESP_CTX_set_time_cb                 1889	3_0_0	EXIST::FUNCTION:TS
 IDEA_cbc_encrypt                        1890	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0,IDEA
 BN_CTX_secure_new                       1891	3_0_0	EXIST::FUNCTION:
 OCSP_ONEREQ_add_ext                     1892	3_0_0	EXIST::FUNCTION:OCSP
-CMS_uncompress                          1893	3_0_0	EXIST::FUNCTION:CMS
+CMS_uncompress                          1893	3_0_0	EXIST::FUNCTION:CMS,DEPRECATEDIN_3_0,ZLIB
 CRYPTO_mem_debug_pop                    1895	3_0_0	EXIST::FUNCTION:CRYPTO_MDEBUG,DEPRECATEDIN_3_0
 EVP_aes_192_cfb128                      1896	3_0_0	EXIST::FUNCTION:
 OSSL_HTTP_REQ_CTX_nbio                  1897	3_0_0	EXIST::FUNCTION:


### PR DESCRIPTION
Another step along the way to closing #14506.
Note that deprecating `BIO_f_zlib()` has implications for the enc and cms commands; see CHANGES file.
