### PR TITLE
More user-friendly cipher_list handling

### DIFF
--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -2549,6 +2549,13 @@ static int cipher_list_tls12_num(STACK_OF(SSL_CIPHER) *sk)
 int SSL_CTX_set_cipher_list(SSL_CTX *ctx, const char *str)
 {
     STACK_OF(SSL_CIPHER) *sk;
+    STACK_OF(SSL_CIPHER) *tls13_sk;
+
+    tls13_sk = ssl_get_tls13_suites(str);
+    if (tls13_sk != NULL) {
+        sk_SSL_CIPHER_free(ctx->tls13_ciphersuites);
+        ctx->tls13_ciphersuites = tls13_sk;
+    }
 
     sk = ssl_create_cipher_list(ctx->method, ctx->tls13_ciphersuites,
                                 &ctx->cipher_list, &ctx->cipher_list_by_id, str,
@@ -2573,6 +2580,13 @@ int SSL_CTX_set_cipher_list(SSL_CTX *ctx, const char *str)
 int SSL_set_cipher_list(SSL *s, const char *str)
 {
     STACK_OF(SSL_CIPHER) *sk;
+    STACK_OF(SSL_CIPHER) *tls13_sk;
+
+    tls13_sk = ssl_get_tls13_suites(str);
+    if (tls13_sk != NULL) {
+        sk_SSL_CIPHER_free(s->tls13_ciphersuites);
+        s->tls13_ciphersuites = tls13_sk;
+    }
 
     sk = ssl_create_cipher_list(s->ctx->method, s->tls13_ciphersuites,
                                 &s->cipher_list, &s->cipher_list_by_id, str,

--- a/ssl/ssl_local.h
+++ b/ssl/ssl_local.h
@@ -2272,6 +2272,7 @@ __owur STACK_OF(SSL_CIPHER) *ssl_create_cipher_list(const SSL_METHOD *ssl_method
                                                     STACK_OF(SSL_CIPHER) **cipher_list_by_id,
                                                     const char *rule_str,
                                                     CERT *c);
+__owur STACK_OF(SSL_CIPHER) *ssl_get_tls13_suites(const char *str);
 __owur int ssl_cache_cipherlist(SSL *s, PACKET *cipher_suites, int sslv2format);
 __owur int bytes_to_cipher_list(SSL *s, PACKET *cipher_suites,
                                 STACK_OF(SSL_CIPHER) **skp,


### PR DESCRIPTION
Accept TLS1.3 ciphersuites in the cipher_list rule_str. If any
are present, replace the previously configured TLS1.3 suites,
otherwise leave the TLS1.3 suites unchanged.

The current API/behavior for configuring TLS1.3 cipher suites breaks backward compatibility
for existing apps. It's also confusing since the set_cipher_list() API doesn't set TLS1.3 suites
but the get_ciphers() API includes them.

This patch changes the set_cipher_list() API to set the TLS1.3 suites if any are specified in
the rule_str, otherwise leaving them unchanged. This allows existing apps that may have
been configured with TLS1.2 suites to keep working without any other code changes.

Patch is against OpenSSL 1.1.1k    replaces #15161

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
