### PR TITLE
Fix AIX FIPS DEP.

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1180,7 +1180,7 @@ my %targets = (
         module_ldflags   => "-Wl,-G,-bsymbolic,-bnoentry",
         shared_ldflag    => "-Wl,-G,-bsymbolic,-bnoentry",
         shared_defflag   => "-Wl,-bE:",
-        shared_fipsflag  => "-Wl,-binitfini:init:cleanup",
+        shared_fipsflag  => "-Wl,-binitfini:_init:_cleanup",
         perl_platform    => 'AIX',
     },
     "aix-gcc" => {

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -1838,7 +1838,7 @@ EOF
       my @deps = compute_lib_depends(@{$args{deps}});
       my $shared_def = join("", map { ' '.$target{shared_defflag}.$_ } @defs);
       # Next line needs to become "less magic" (see PR #11950)
-      $shared_def .= ' '.$target{shared_fipsflag} if (m/providers\/fips/ && defined $target{shared_fipsflag});
+      $shared_def .= ' '.$target{shared_fipsflag} if (defined $target{shared_fipsflag} && $shared_def =~ m/providers\/fips/);
       my $objs = join(" \\\n\t\t", fill_lines(' ', $COLUMNS - 16, @objs));
       my $deps = join(" \\\n" . ' ' x (length($dso) + 2),
                       fill_lines(' ', $COLUMNS - length($dso) - 2,

--- a/providers/fips/self_test.c
+++ b/providers/fips/self_test.c
@@ -105,9 +105,23 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
     }
     return TRUE;
 }
-#elif defined(__sun) || defined(_AIX)
+#elif defined(__sun)
 # pragma init(init)
 # pragma fini(cleanup)
+
+#elif defined(_AIX)
+void _init(void);
+void _cleanup(void);
+# pragma init(_init)
+# pragma fini(_cleanup)
+void _init(void)
+{
+    init();
+}
+void _cleanup(void)
+{
+    cleanup();
+}
 
 #elif defined(__hpux)
 # pragma init "init"


### PR DESCRIPTION
The entry point needs the option 'binitfini', but it was not being
added since the perl code to detect the match did not work.

The entry point for AIX is no longer static - so a wrapper has been
added to call the static version.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
