### PR TITLE
Add aix64-gcc-as architecture and p2align callback

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1212,6 +1212,10 @@ my %targets = (
         AR               => add("-X64"),
         RANLIB           => add("-X64"),
     },
+    "aix64-gcc-as" => {
+        inherit_from     => [ "aix64-gcc" ],
+        perlasm_scheme   => "aix64-as",
+    },
     "aix-cc" => {
         inherit_from     => [ "aix-common" ],
         CC               => "cc",

--- a/crypto/perlasm/ppc-xlate.pl
+++ b/crypto/perlasm/ppc-xlate.pl
@@ -83,6 +83,10 @@ my $text = sub {
     $ret = ".abiversion	2\n".$ret	if ($flavour =~ /linux.*64(le|v2)/);
     $ret;
 };
+my $p2align = sub {
+    my $ret = ($flavour =~ /aix64-as/) ? "" : ".p2align $line";
+    $ret;
+};
 my $machine = sub {
     my $junk = shift;
     my $arch = shift;


### PR DESCRIPTION
This commit adds an architecture named aix64-gcc-as which can generate
assembler source code compatible with AIX assembler (as) instead of the
GNU Assembler (gas). This architecture name is then used in a callback
for the .p2align directive which is not available in AIX as.

The motivation for this addition came out of an issue we ran into when
working on upgrading OpenSSL in Node.js. We ran into the following
compilation error on one of the CI machines that uses AIX:
```console
  05:39:05 Assembler:
  05:39:05 crypto/bn/ppc64-mont-fixed.s: line 4: Error In Syntax
```
This machine is using AIX Version 7.2 and does not have gas installed
and the .p2align directive is causing this error. After asking around if
it would be possible to install GAS on this machine I learned that AIX
GNU utils are not maintained as well as the native AIX ones and we
(Red Hat/IBM) have run into issues with the GNU utils in the past and if
possible it would be preferable to be able to use the AIX native
assembler.

Refs: https://github.com/nodejs/node/pull/38512

