### PR TITLE
Add -latomic only for architectures where needed

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -764,7 +764,7 @@ my %targets = (
         #
         # ./Configure linux-armv4 -march=armv6 -D__ARM_MAX_ARCH__=8
         #
-        inherit_from     => [ "linux-generic32" ],
+        inherit_from     => [ "linux-latomic" ],
         asm_arch         => 'armv4',
         perlasm_scheme   => "linux32",
     },

--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -677,7 +677,7 @@ my %targets = (
 ####
 # *-generic* is endian-neutral target, but ./config is free to
 # throw in -D[BL]_ENDIAN, whichever appropriate...
-    "linux-generic" => {
+    "linux-generic32" => {
         inherit_from     => [ "BASE_unix" ],
         CC               => "gcc",
         CXX              => "g++",
@@ -699,18 +699,17 @@ my %targets = (
         shared_ldflag    => sub { $disabled{pinshared} ? () : "-Wl,-znodelete" },
         enable           => [ "afalgeng" ],
     },
-    "linux-generic32" => {
-        inherit_from     => [ "linux-generic" ],
+    "linux-latomic" => {
+        inherit_from     => [ "linux-generic32" ],
         ex_libs          => add(threads("-latomic")),
-        bn_ops           => "BN_LLONG RC4_CHAR",
     },
     "linux-generic64" => {
-        inherit_from     => [ "linux-generic" ],
+        inherit_from     => [ "linux-generic32" ],
         bn_ops           => "SIXTY_FOUR_BIT_LONG RC4_CHAR",
     },
 
     "linux-ppc" => {
-        inherit_from     => [ "linux-generic32" ],
+        inherit_from     => [ "linux-latomic" ],
         asm_arch         => 'ppc32',
         perlasm_scheme   => "linux32",
         lib_cppflags     => add("-DB_ENDIAN"),
@@ -786,7 +785,7 @@ my %targets = (
     "linux-mips32" => {
         # Configure script adds minimally required -march for assembly
         # support, if no -march was specified at command line.
-        inherit_from     => [ "linux-generic32" ],
+        inherit_from     => [ "linux-latomic" ],
         cflags           => add("-mabi=32"),
         cxxflags         => add("-mabi=32"),
         asm_arch         => 'mips32',
@@ -795,7 +794,7 @@ my %targets = (
     # mips32 and mips64 below refer to contemporary MIPS Architecture
     # specifications, MIPS32 and MIPS64, rather than to kernel bitness.
     "linux-mips64" => {
-        inherit_from     => [ "linux-generic32" ],
+        inherit_from     => [ "linux-latomic" ],
         cflags           => add("-mabi=n32"),
         cxxflags         => add("-mabi=n32"),
         bn_ops           => "RC4_CHAR",
@@ -929,7 +928,7 @@ my %targets = (
 
     #### SPARC Linux setups
     "linux-sparcv8" => {
-        inherit_from     => [ "linux-generic32" ],
+        inherit_from     => [ "linux-latomic" ],
         cflags           => add("-mcpu=v8"),
         cxxflags         => add("-mcpu=v8"),
         lib_cppflags     => add("-DB_ENDIAN -DBN_DIV2W"),
@@ -939,7 +938,7 @@ my %targets = (
     "linux-sparcv9" => {
         # it's a real mess with -mcpu=ultrasparc option under Linux,
         # but -Wa,-Av8plus should do the trick no matter what.
-        inherit_from     => [ "linux-generic32" ],
+        inherit_from     => [ "linux-latomic" ],
         cflags           => add("-m32 -mcpu=ultrasparc -Wa,-Av8plus"),
         cxxflags         => add("-m32 -mcpu=ultrasparc -Wa,-Av8plus"),
         lib_cppflags     => add("-DB_ENDIAN -DBN_DIV2W"),


### PR DESCRIPTION
Apparently adding -latomic everywhere does not work with older gcc toolchains. We add it only on architectures where it is needed. It still means that on these targets you will need a toolchain which is new enough to include the libatomic.

It would be better to somehow detect that linking with -latomic is needed however the autodetection of features is fairly hard to do correctly for all possible cases and I do not feel like we should attempt to do that.

Another alternative would be to simply document that if you see something like `missing __atomic_fetch_or_8()` when linking you should reconfigure with -latomic added to the config command line. 
