### PR TITLE
80-test_cmp_http.t: Prevent hangs on server not launching/behaving correctly, Improve the way the test server is launched and killed

### DIFF
--- a/apps/include/s_apps.h
+++ b/apps/include/s_apps.h
@@ -16,7 +16,7 @@
 #define PROTOCOL        "tcp"
 
 typedef int (*do_server_cb)(int s, int stype, int prot, unsigned char *context);
-int report_server_accept(BIO *out, int asock, int with_address);
+int report_server_accept(BIO *out, int asock, int with_address, int with_pid);
 int do_server(int *accept_sock, const char *host, const char *port,
               int family, int type, int protocol, do_server_cb cb,
               unsigned char *context, int naccept, BIO *bio_s_out);

--- a/apps/lib/http_server.c
+++ b/apps/lib/http_server.c
@@ -241,7 +241,7 @@ BIO *http_server_init_bio(const char *prog, const char *port)
 
     /* Report back what address and port are used */
     BIO_get_fd(acbio, &asock);
-    if (!report_server_accept(bio_out, asock, 1)) {
+    if (!report_server_accept(bio_out, asock, 1, 1)) {
         log_message(prog, LOG_ERR, "Error printing ACCEPT string");
         goto err;
     }

--- a/test/recipes/79-test_http.t
+++ b/test/recipes/79-test_http.t
@@ -19,8 +19,9 @@ SKIP: {
     skip "OCSP disabled", 1 if disabled("ocsp");
     my $cmd = [qw{openssl ocsp -index any -port 0}];
     my @output = run(app($cmd), capture => 1);
-    ok($output[0] =~ /^ACCEPT (0.0.0.0|\[::\]):(\d+?)$/ && $2 >= 1024,
-       "HTTP server auto-selects and reports local port >= 1024");
+    ok($output[0] =~ /^ACCEPT (0.0.0.0|\[::\]):(\d+?) PID=(\d+)$/
+       && $2 >= 1024 && $3 > 0,
+       "HTTP server auto-selects and reports local port >= 1024 and pid > 0");
 }
 
 ok(run(test(["http_test", srctop_file("test", "certs", "ca-cert.pem")])));

--- a/test/recipes/80-test_cmp_http.t
+++ b/test/recipes/80-test_cmp_http.t
@@ -12,7 +12,7 @@ use strict;
 use warnings;
 
 use POSIX;
-use OpenSSL::Test qw/:DEFAULT data_file data_dir srctop_dir bldtop_dir result_dir/;
+use OpenSSL::Test qw/:DEFAULT cmdstr data_file data_dir srctop_dir bldtop_dir result_dir/;
 use OpenSSL::Test::Utils;
 
 BEGIN {
@@ -266,10 +266,8 @@ sub load_tests {
 
 sub start_mock_server {
     my $args = $_[0]; # optional further CLI arguments
-    my $dir = bldtop_dir("");
-    local $ENV{LD_LIBRARY_PATH} = $dir;
-    local $ENV{DYLD_LIBRARY_PATH} = $dir;
-    my $cmd = bldtop_dir($app) . " -config server.cnf $args";
+    my $cmd = cmdstr(app(['openssl', 'cmp', '-config', 'server.cnf',
+                          $args ? $args : ()]), display => 1);
     print "Current directory is ".getcwd()."\n";
     print "Launching mock server: $cmd\n";
     die "Invalid port: $server_port" unless $server_port =~ m/^\d+$/;
@@ -281,7 +279,7 @@ sub start_mock_server {
             print "Server output: $_";
             next if m/using section/;
             s/\R$//;                # Better chomp
-            $server_port = $1 if /^ACCEPT\s.*:(\d+)$/;
+            ($server_port, $pid) = ($1, $2) if /^ACCEPT\s.*:(\d+) PID=(\d+)$/;
             last; # Do not loop further to prevent hangs on server misbehavior
         }
     }
@@ -296,5 +294,5 @@ sub start_mock_server {
 sub stop_mock_server {
     my $pid = $_[0];
     print "Killing mock server with pid=$pid\n";
-    kill('QUIT', $pid) if $pid;
+    kill('QUIT', $pid);
 }

--- a/util/perl/OpenSSL/Test.pm
+++ b/util/perl/OpenSSL/Test.pm
@@ -65,8 +65,7 @@ C<$SRCTOP/test/recipes/99-foo_data/>.
 
 use File::Copy;
 use File::Spec::Functions qw/file_name_is_absolute curdir canonpath splitdir
-                             catdir catfile splitpath catpath devnull abs2rel
-                             rel2abs/;
+                             catdir catfile splitpath catpath devnull abs2rel/;
 use File::Path 2.00 qw/rmtree mkpath/;
 use File::Basename;
 use Cwd qw/getcwd abs_path/;
@@ -1117,8 +1116,8 @@ sub __data_dir {
 sub __cwd {
     my $dir = catdir(shift);
     my %opts = @_;
-    my $abscurdir = rel2abs(curdir());
-    my $absdir = rel2abs($dir);
+    my $abscurdir = abs_path(curdir());
+    my $absdir = abs_path($dir);
     my $reverse = abs2rel($abscurdir, $absdir);
 
     # PARANOIA: if we're not moving anywhere, we do nothing more
@@ -1152,7 +1151,14 @@ sub __cwd {
     my @dirtags = sort keys %directories;
     foreach (@dirtags) {
 	if (!file_name_is_absolute($directories{$_})) {
-	    my $newpath = abs2rel(rel2abs($directories{$_}), rel2abs($dir));
+	    my $oldpath = abs_path($directories{$_});
+	    my $newbase = abs_path($dir);
+	    my $newpath = abs2rel($oldpath, $newbase);
+	    if ($debug) {
+		print STDERR "DEBUG: [dir $_] old path: $oldpath\n";
+		print STDERR "DEBUG: [dir $_] new base: $newbase\n";
+		print STDERR "DEBUG: [dir $_] resulting new path: $newpath\n";
+	    }
 	    $tmp_directories{$_} = $newpath;
 	}
     }
@@ -1162,7 +1168,14 @@ sub __cwd {
     # process can use their values properly as well
     foreach (@direnv) {
 	if (!file_name_is_absolute($ENV{$_})) {
-	    my $newpath = abs2rel(rel2abs($ENV{$_}), rel2abs($dir));
+	    my $oldpath = abs_path($ENV{$_});
+	    my $newbase = abs_path($dir);
+	    my $newpath = abs2rel($oldpath, $newbase);
+	    if ($debug) {
+		print STDERR "DEBUG: [env $_] old path: $oldpath\n";
+		print STDERR "DEBUG: [env $_] new base: $newbase\n";
+		print STDERR "DEBUG: [env $_] resulting new path: $newpath\n";
+	    }
 	    $tmp_ENV{$_} = $newpath;
 	}
     }
@@ -1182,16 +1195,18 @@ sub __cwd {
 
     if ($debug) {
 	print STDERR "DEBUG: __cwd(), directories and files:\n";
-	print STDERR "  \$directories{BLDTEST} = \"$directories{BLDTEST}\"\n";
-	print STDERR "  \$directories{SRCTEST} = \"$directories{SRCTEST}\"\n";
-	print STDERR "  \$directories{SRCDATA} = \"$directories{SRCDATA}\"\n";
-	print STDERR "  \$directories{RESULTS} = \"$directories{RESULTS}\"\n";
-	print STDERR "  \$directories{BLDAPPS} = \"$directories{BLDAPPS}\"\n";
-	print STDERR "  \$directories{SRCAPPS} = \"$directories{SRCAPPS}\"\n";
-	print STDERR "  \$directories{SRCTOP}  = \"$directories{SRCTOP}\"\n";
-	print STDERR "  \$directories{BLDTOP}  = \"$directories{BLDTOP}\"\n";
+	print STDERR "	Moving from $abscurdir\n";
+	print STDERR "	Moving to $absdir\n";
 	print STDERR "\n";
-	print STDERR "  current directory is \"",curdir(),"\"\n";
+	print STDERR "	\$directories{BLDTEST} = \"$directories{BLDTEST}\"\n";
+	print STDERR "	\$directories{SRCTEST} = \"$directories{SRCTEST}\"\n";
+	print STDERR "	\$directories{SRCDATA} = \"$directories{SRCDATA}\"\n";
+	print STDERR "	\$directories{RESULTS} = \"$directories{RESULTS}\"\n";
+	print STDERR "	\$directories{BLDAPPS} = \"$directories{BLDAPPS}\"\n";
+	print STDERR "	\$directories{SRCAPPS} = \"$directories{SRCAPPS}\"\n";
+	print STDERR "	\$directories{SRCTOP}  = \"$directories{SRCTOP}\"\n";
+	print STDERR "	\$directories{BLDTOP}  = \"$directories{BLDTOP}\"\n";
+	print STDERR "\n";
 	print STDERR "  the way back is \"$reverse\"\n";
     }
 


### PR DESCRIPTION
This is a follow-up of #15580, picking up loose ends discussed there.
* 80-test_cmp_http.t: Simplify and prevent hangs on server not launching/behaving correctly.
This should have help diagnosing tricky issues such as #15557 and #15571.
* 80-test_cmp_http.t: Improve the way the test server is launched and killed
This should fix https://github.com/openssl/openssl/pull/15580#issuecomment-854339457.

- [x] tests are added or updated
