### PR TITLE
EVP_PKEY_new_raw_private_key: Allow zero length keys

### DIFF
--- a/providers/implementations/keymgmt/mac_legacy_kmgmt.c
+++ b/providers/implementations/keymgmt/mac_legacy_kmgmt.c
@@ -190,7 +190,7 @@ static int mac_key_fromdata(MAC_KEY *key, const OSSL_PARAM params[])
             return 0;
         }
         OPENSSL_secure_clear_free(key->priv_key, key->priv_key_len);
-        key->priv_key = OPENSSL_secure_malloc(p->data_size);
+        key->priv_key = OPENSSL_secure_malloc(p->data_size > 0 ? p->data_size : 1);
         if (key->priv_key == NULL) {
             ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
             return 0;

--- a/providers/implementations/keymgmt/mac_legacy_kmgmt.c
+++ b/providers/implementations/keymgmt/mac_legacy_kmgmt.c
@@ -190,6 +190,7 @@ static int mac_key_fromdata(MAC_KEY *key, const OSSL_PARAM params[])
             return 0;
         }
         OPENSSL_secure_clear_free(key->priv_key, key->priv_key_len);
+        /* allocate at least one byte to distinguish empty key from no key set */
         key->priv_key = OPENSSL_secure_malloc(p->data_size > 0 ? p->data_size : 1);
         if (key->priv_key == NULL) {
             ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -1592,6 +1592,9 @@ static struct keys_st {
 } keys[] = {
     {
         EVP_PKEY_HMAC, "0123456789", NULL
+    },
+    {
+        EVP_PKEY_HMAC, "", NULL
 #ifndef OPENSSL_NO_POLY1305
     }, {
         EVP_PKEY_POLY1305, "01234567890123456789012345678901", NULL


### PR DESCRIPTION
Allocate at least one byte to distinguish a zero length key
from an unset key.

Fixes #15632

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
