### PR TITLE
APPS: Restore the possibility to combine -pubout with -text

### DIFF
--- a/apps/pkey.c
+++ b/apps/pkey.c
@@ -175,15 +175,19 @@ int pkey_main(int argc, char **argv)
     if (argc != 0)
         goto opthelp;
 
-    if (noout && pubout)
-        BIO_printf(bio_err,
-                   "Warning: The -pubout option is ignored with -noout\n");
     if (text && text_pub)
         BIO_printf(bio_err,
                    "Warning: The -text option is ignored with -text_pub\n");
     if (traditional && (noout || outformat != FORMAT_PEM))
         BIO_printf(bio_err,
                    "Warning: The -traditional is ignored since there is no PEM output\n");
+
+    /* -pubout and -text is the same as -text_pub */
+    if (!text_pub && pubout && text) {
+        text = 0;
+        text_pub = 1;
+    }
+
     private = (!noout && !pubout) || (text && !text_pub);
 
     if (ciphername != NULL) {

--- a/doc/man1/openssl-pkey.pod.in
+++ b/doc/man1/openssl-pkey.pod.in
@@ -131,9 +131,11 @@ option is specified then the older "traditional" format is used instead.
 
 =item B<-pubout>
 
-By default the encoded private and public key is output;
-this option restricts the encoded output to the public components.
+By default the private and public key is output;
+this option restricts the output to the public components.
 This option is automatically set if the input is a public key.
+
+When combined with B<-text>, this is equivalent to B<-text_pub>.
 
 =item B<-noout>
 


### PR DESCRIPTION
This applies to the 'openssl pkey' command.

Fixes #15645
