### PR TITLE
Fix s_server app to not report an error when using a non DH certificate.

### DIFF
--- a/apps/include/apps.h
+++ b/apps/include/apps.h
@@ -121,6 +121,9 @@ EVP_PKEY *load_pubkey(const char *uri, int format, int maybe_stdin,
                       const char *pass, ENGINE *e, const char *desc);
 EVP_PKEY *load_keyparams(const char *uri, int format, int maybe_stdin,
                          const char *keytype, const char *desc);
+EVP_PKEY *load_keyparams_suppress(const char *uri, int format, int maybe_stdin,
+                                  const char *keytype, const char *desc,
+                                  int suppress_decode_errors);
 char *next_item(char *opt); /* in list separated by comma and/or space */
 int load_cert_certs(const char *uri,
                     X509 **pcert, STACK_OF(X509) **pcerts,

--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -2003,7 +2003,8 @@ int s_server_main(int argc, char *argv[])
         if (dhfile != NULL)
             dhpkey = load_keyparams(dhfile, FORMAT_UNDEF, 0, "DH", "DH parameters");
         else if (s_cert_file != NULL)
-            dhpkey = load_keyparams(s_cert_file, FORMAT_UNDEF, 0, "DH", "DH parameters");
+            dhpkey = load_keyparams_suppress(s_cert_file, FORMAT_UNDEF, 0, "DH",
+                                             "DH parameters", 1);
 
         if (dhpkey != NULL) {
             BIO_printf(bio_s_out, "Setting temp DH parameters\n");
@@ -2035,9 +2036,10 @@ int s_server_main(int argc, char *argv[])
 
         if (ctx2 != NULL) {
             if (dhfile != NULL) {
-                EVP_PKEY *dhpkey2 = load_keyparams(s_cert_file2, FORMAT_UNDEF,
-                                                   0, "DH",
-                                                   "DH parameters");
+                EVP_PKEY *dhpkey2 = load_keyparams_suppress(s_cert_file2,
+                                                            FORMAT_UNDEF,
+                                                            0, "DH",
+                                                            "DH parameters", 1);
 
                 if (dhpkey2 != NULL) {
                     BIO_printf(bio_s_out, "Setting temp DH parameters\n");


### PR DESCRIPTION
Fixes #15071

It always tries loading the cert as DH which previously did not produce
an error. The errors are not suppressed for these operations.
The output now matches previous versions of OpenSSL.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
