### PR TITLE
Document that provider name can be a full path

### DIFF
--- a/crypto/dso/dso_dl.c
+++ b/crypto/dso/dso_dl.c
@@ -224,7 +224,7 @@ static char *dl_name_converter(DSO *dso, const char *filename)
     len = strlen(filename);
     rsize = len + 1;
     transform = (strstr(filename, "/") == NULL);
-    {
+    if (transform) {
         /* We will convert this to "%s.s?" or "lib%s.s?" */
         rsize += strlen(DSO_EXTENSION); /* The length of ".s?" */
         if ((DSO_flags(dso) & DSO_FLAG_NAME_TRANSLATION_EXT_ONLY) == 0)

--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -483,6 +483,7 @@ void ossl_provider_free(OSSL_PROVIDER *prov)
 int ossl_provider_set_module_path(OSSL_PROVIDER *prov, const char *module_path)
 {
     OPENSSL_free(prov->path);
+    prov->path = NULL;
     if (module_path == NULL)
         return 1;
     if ((prov->path = OPENSSL_strdup(module_path)) != NULL)

--- a/doc/man1/openssl.pod
+++ b/doc/man1/openssl.pod
@@ -651,7 +651,12 @@ the PKCS#11 URI as defined in RFC 7512 should be possible to use directly:
 
 =item B<-provider> I<name>
 
-Load and initialize the provider identified by I<name>.
+Load and initialize the provider identified by I<name>. The I<name>
+can be also a path to the provider module. In that case the provider name
+will be the specified path and not just the provider module name.
+Interpretation of relative paths is platform specific. The configured
+"MODULESDIR" path, B<OPENSSL_MODULES> environment variable, or the path
+specified by B<-provider-path> is prepended to relative paths.
 See L<provider(7)> for a more detailed description.
 
 =item B<-provider-path> I<path>

--- a/doc/man3/OSSL_PROVIDER.pod
+++ b/doc/man3/OSSL_PROVIDER.pod
@@ -81,9 +81,12 @@ OSSL_PROVIDER_load() loads and initializes a provider.
 This may simply initialize a provider that was previously added with
 OSSL_PROVIDER_add_builtin() and run its given initialization function,
 or load a provider module with the given name and run its provider
-entry point, C<OSSL_provider_init>. The I<name> can be a full path
+entry point, C<OSSL_provider_init>. The I<name> can be a path
 to a provider module, in that case the provider name as returned
-by OSSL_PROVIDER_get0_name() will be the full path.
+by OSSL_PROVIDER_get0_name() will be the path. Interpretation
+of relative paths is platform dependent and they are relative
+to the configured "MODULESDIR" directory or the path set in
+the environment variable OPENSSL_MODULES if set.
 
 OSSL_PROVIDER_try_load() functions like OSSL_PROVIDER_load(), except that
 it does not disable the fallback providers if the provider cannot be

--- a/doc/man3/OSSL_PROVIDER.pod
+++ b/doc/man3/OSSL_PROVIDER.pod
@@ -81,7 +81,9 @@ OSSL_PROVIDER_load() loads and initializes a provider.
 This may simply initialize a provider that was previously added with
 OSSL_PROVIDER_add_builtin() and run its given initialization function,
 or load a provider module with the given name and run its provider
-entry point, C<OSSL_provider_init>.
+entry point, C<OSSL_provider_init>. The I<name> can be a full path
+to a provider module, in that case the provider name as returned
+by OSSL_PROVIDER_get0_name() will be the full path.
 
 OSSL_PROVIDER_try_load() functions like OSSL_PROVIDER_load(), except that
 it does not disable the fallback providers if the provider cannot be


### PR DESCRIPTION
This is related to #15620 although it does not fix the _name is path_ problem. So this is kind of starting point for further discussion.

The problem with changing the name is that the name is supposed to be unique identifier in the stack of all providers. And the unique provider name is needed even before the provider is actually activated (i.e. the DSO is loaded). In a hypothetical situation where we have two different 3rd party providers placed in a different path that have the same base name it would not be possible to load them simultaneously. And even worse, let's suppose the imaginary 3rd party provider module is named `default.so`. In this case, if implemented naively, the `OSSL_PROVIDER_load(libctx, "/path/to/3rd/party/default.so")` would return the OpenSSL default provider instead of the 3rd party default provider.

Given this I propose to keep things as is and just document them. Although a little bit surprising, I do not see why the provider name being a path in such case is a problem.