### PR TITLE
Command line apps use libctx and property query

### DIFF
--- a/apps/fipsinstall.c
+++ b/apps/fipsinstall.c
@@ -431,7 +431,7 @@ opthelp:
     if (read_buffer == NULL)
         goto end;
 
-    mac = EVP_MAC_fetch(NULL, mac_name, NULL);
+    mac = EVP_MAC_fetch(app_get0_libctx(), mac_name, app_get0_propq());
     if (mac == NULL) {
         BIO_printf(bio_err, "Unable to get MAC of type %s\n", mac_name);
         goto end;

--- a/apps/include/app_libctx.h
+++ b/apps/include/app_libctx.h
@@ -10,6 +10,8 @@
 #ifndef OSSL_APPS_LIBCTX_H
 # define OSSL_APPS_LIBCTX_H
 
+#include <openssl/types.h>
+
 OSSL_LIB_CTX *app_create_libctx(void);
 OSSL_LIB_CTX *app_get0_libctx(void);
 int app_set_propq(const char *arg);

--- a/apps/include/app_libctx.h
+++ b/apps/include/app_libctx.h
@@ -10,7 +10,7 @@
 #ifndef OSSL_APPS_LIBCTX_H
 # define OSSL_APPS_LIBCTX_H
 
-#include <openssl/types.h>
+# include <openssl/types.h>
 
 OSSL_LIB_CTX *app_create_libctx(void);
 OSSL_LIB_CTX *app_get0_libctx(void);

--- a/apps/include/app_libctx.h
+++ b/apps/include/app_libctx.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2021 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#ifndef OSSL_APPS_LIBCTX_H
+# define OSSL_APPS_LIBCTX_H
+
+OSSL_LIB_CTX *app_create_libctx(void);
+OSSL_LIB_CTX *app_get0_libctx(void);
+int app_set_propq(const char *arg);
+const char *app_get0_propq(void);
+
+#endif

--- a/apps/include/apps.h
+++ b/apps/include/apps.h
@@ -37,6 +37,7 @@
 # include "fmt.h"
 # include "platform.h"
 # include "engine_loader.h"
+# include "app_libctx.h"
 
 /*
  * quick macro when you need to pass an unsigned char instead of a char.
@@ -326,8 +327,6 @@ typedef struct verify_options_st {
 
 extern VERIFY_CB_ARGS verify_args;
 
-OSSL_LIB_CTX *app_create_libctx(void);
-OSSL_LIB_CTX *app_get0_libctx(void);
 OSSL_PARAM *app_params_new_from_opts(STACK_OF(OPENSSL_STRING) *opts,
                                      const OSSL_PARAM *paramdefs);
 void app_params_free(OSSL_PARAM *params);
@@ -336,9 +335,5 @@ void app_providers_cleanup(void);
 
 EVP_PKEY *app_keygen(EVP_PKEY_CTX *ctx, const char *alg, int bits, int verbose);
 EVP_PKEY *app_paramgen(EVP_PKEY_CTX *ctx, const char *alg);
-
-OSSL_LIB_CTX *app_get0_libctx(void);
-int app_set_propq(const char *arg);
-const char *app_get0_propq(void);
 
 #endif

--- a/apps/kdf.c
+++ b/apps/kdf.c
@@ -138,7 +138,8 @@ opthelp:
     if (argc != 1)
         goto opthelp;
 
-    if ((kdf = EVP_KDF_fetch(NULL, argv[0], NULL)) == NULL) {
+    if ((kdf = EVP_KDF_fetch(app_get0_libctx(), argv[0],
+                             app_get0_propq())) == NULL) {
         BIO_printf(bio_err, "Invalid KDF name %s\n", argv[0]);
         goto opthelp;
     }

--- a/apps/lib/app_libctx.c
+++ b/apps/lib/app_libctx.c
@@ -1,0 +1,48 @@
+/*
+ * Copyright 1995-2021 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+#include "app_libctx.h"
+#include "apps.h"
+
+static OSSL_LIB_CTX *app_libctx = NULL;
+static const char *app_propq = NULL;
+
+int app_set_propq(const char *arg)
+{
+    app_propq = arg;
+    return 1;
+}
+
+const char *app_get0_propq(void)
+{
+    return app_propq;
+}
+
+OSSL_LIB_CTX *app_get0_libctx(void)
+{
+    return app_libctx;
+}
+
+OSSL_LIB_CTX *app_create_libctx(void)
+{
+    /*
+     * Load the NULL provider into the default library context and create a
+     * library context which will then be used for any OPT_PROV options.
+     */
+    if (app_libctx == NULL) {
+        if (!app_provider_load(NULL, "null")) {
+            opt_printf_stderr( "Failed to create null provider\n");
+            return NULL;
+        }
+        app_libctx = OSSL_LIB_CTX_new();
+    }
+    if (app_libctx == NULL)
+        opt_printf_stderr("Failed to create library context\n");
+    return app_libctx;
+}
+

--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -69,8 +69,6 @@ typedef struct {
     unsigned long mask;
 } NAME_EX_TBL;
 
-static OSSL_LIB_CTX *app_libctx = NULL;
-
 static int set_table_opts(unsigned long *flags, const char *arg,
                           const NAME_EX_TBL * in_tbl);
 static int set_multi_opts(unsigned long *flags, const char *arg,
@@ -328,50 +326,13 @@ static char *app_get_pass(const char *arg, int keepbio)
     return OPENSSL_strdup(tpass);
 }
 
-OSSL_LIB_CTX *app_get0_libctx(void)
-{
-    return app_libctx;
-}
-
-static const char *app_propq = NULL;
-
-int app_set_propq(const char *arg)
-{
-    app_propq = arg;
-    return 1;
-}
-
-const char *app_get0_propq(void)
-{
-    return app_propq;
-}
-
-OSSL_LIB_CTX *app_create_libctx(void)
-{
-    /*
-     * Load the NULL provider into the default library context and create a
-     * library context which will then be used for any OPT_PROV options.
-     */
-    if (app_libctx == NULL) {
-
-        if (!app_provider_load(NULL, "null")) {
-            BIO_puts(bio_err, "Failed to create null provider\n");
-            return NULL;
-        }
-        app_libctx = OSSL_LIB_CTX_new();
-    }
-    if (app_libctx == NULL)
-        BIO_puts(bio_err, "Failed to create library context\n");
-    return app_libctx;
-}
-
 CONF *app_load_config_bio(BIO *in, const char *filename)
 {
     long errorline = -1;
     CONF *conf;
     int i;
 
-    conf = NCONF_new_ex(app_libctx, NULL);
+    conf = NCONF_new_ex(app_get0_libctx(), NULL);
     i = NCONF_load_bio(conf, in, &errorline);
     if (i > 0)
         return conf;
@@ -414,7 +375,7 @@ CONF *app_load_config_internal(const char *filename, int quiet)
         BIO_free(in);
     } else {
         /* Return empty config if filename is empty string. */
-        conf = NCONF_new_ex(app_libctx, NULL);
+        conf = NCONF_new_ex(app_get0_libctx(), NULL);
     }
     return conf;
 }

--- a/apps/lib/build.info
+++ b/apps/lib/build.info
@@ -10,7 +10,7 @@ ENDIF
 # Source for libapps
 $LIBAPPSSRC=apps.c apps_ui.c opt.c fmt.c s_cb.c s_socket.c app_rand.c \
         columns.c app_params.c names.c app_provider.c app_x509.c http_server.c \
-        engine.c engine_loader.c
+        engine.c engine_loader.c app_libctx.c
 
 IF[{- !$disabled{apps} -}]
   LIBS{noinst}=../libapps.a

--- a/apps/lib/opt.c
+++ b/apps/lib/opt.c
@@ -12,6 +12,7 @@
  */
 #include "opt.h"
 #include "fmt.h"
+#include "app_libctx.h"
 #include "internal/nelem.h"
 #include <string.h>
 #if !defined(OPENSSL_SYS_MSDOS)

--- a/apps/list.c
+++ b/apps/list.c
@@ -36,10 +36,11 @@ static const char *select_name = NULL;
     {                                                           \
         TYPE *impl;                                             \
         const char *propq = app_get0_propq();                   \
+        OSSL_LIB_CTX *libctx = app_get0_libctx();               \
         const char *name = TYPE ## _get0_name(alg);             \
                                                                 \
         ERR_set_mark();                                         \
-        impl = TYPE ## _fetch(NULL, name, propq);               \
+        impl = TYPE ## _fetch(libctx, name, propq);             \
         ERR_pop_to_mark();                                      \
         if (impl == NULL)                                       \
             return 0;                                           \
@@ -118,7 +119,7 @@ static void list_ciphers(void)
 #endif
 
     BIO_printf(bio_out, "Provided:\n");
-    EVP_CIPHER_do_all_provided(NULL, collect_ciphers, ciphers);
+    EVP_CIPHER_do_all_provided(app_get0_libctx(), collect_ciphers, ciphers);
     sk_EVP_CIPHER_sort(ciphers);
     for (i = 0; i < sk_EVP_CIPHER_num(ciphers); i++) {
         const EVP_CIPHER *c = sk_EVP_CIPHER_value(ciphers, i);
@@ -202,7 +203,7 @@ static void list_digests(void)
 #endif
 
     BIO_printf(bio_out, "Provided:\n");
-    EVP_MD_do_all_provided(NULL, collect_digests, digests);
+    EVP_MD_do_all_provided(app_get0_libctx(), collect_digests, digests);
     sk_EVP_MD_sort(digests);
     for (i = 0; i < sk_EVP_MD_num(digests); i++) {
         const EVP_MD *m = sk_EVP_MD_value(digests, i);
@@ -263,7 +264,7 @@ static void list_macs(void)
         return;
     }
     BIO_printf(bio_out, "Provided MACs:\n");
-    EVP_MAC_do_all_provided(NULL, collect_macs, macs);
+    EVP_MAC_do_all_provided(app_get0_libctx(), collect_macs, macs);
     sk_EVP_MAC_sort(macs);
     for (i = 0; i < sk_EVP_MAC_num(macs); i++) {
         const EVP_MAC *m = sk_EVP_MAC_value(macs, i);
@@ -327,7 +328,7 @@ static void list_kdfs(void)
         return;
     }
     BIO_printf(bio_out, "Provided KDFs and PDFs:\n");
-    EVP_KDF_do_all_provided(NULL, collect_kdfs, kdfs);
+    EVP_KDF_do_all_provided(app_get0_libctx(), collect_kdfs, kdfs);
     sk_EVP_KDF_sort(kdfs);
     for (i = 0; i < sk_EVP_KDF_num(kdfs); i++) {
         const EVP_KDF *k = sk_EVP_KDF_value(kdfs, i);
@@ -397,7 +398,7 @@ static void list_random_generators(void)
         return;
     }
     BIO_printf(bio_out, "Provided RNGs and seed sources:\n");
-    EVP_RAND_do_all_provided(NULL, collect_rands, rands);
+    EVP_RAND_do_all_provided(app_get0_libctx(), collect_rands, rands);
     sk_EVP_RAND_sort(rands);
     for (i = 0; i < sk_EVP_RAND_num(rands); i++) {
         const EVP_RAND *m = sk_EVP_RAND_value(rands, i);
@@ -524,7 +525,8 @@ static void list_encoders(void)
         return;
     }
     BIO_printf(bio_out, "Provided ENCODERs:\n");
-    OSSL_ENCODER_do_all_provided(NULL, collect_encoders, encoders);
+    OSSL_ENCODER_do_all_provided(app_get0_libctx(), collect_encoders,
+                                 encoders);
     sk_OSSL_ENCODER_sort(encoders);
 
     for (i = 0; i < sk_OSSL_ENCODER_num(encoders); i++) {
@@ -588,7 +590,7 @@ static void list_decoders(void)
         return;
     }
     BIO_printf(bio_out, "Provided DECODERs:\n");
-    OSSL_DECODER_do_all_provided(NULL, collect_decoders,
+    OSSL_DECODER_do_all_provided(app_get0_libctx(), collect_decoders,
                                  decoders);
     sk_OSSL_DECODER_sort(decoders);
 
@@ -644,7 +646,8 @@ static void list_keymanagers(void)
     int i;
     STACK_OF(EVP_KEYMGMT) *km_stack = sk_EVP_KEYMGMT_new(keymanager_cmp);
 
-    EVP_KEYMGMT_do_all_provided(NULL, collect_keymanagers, km_stack);
+    EVP_KEYMGMT_do_all_provided(app_get0_libctx(), collect_keymanagers,
+                                km_stack);
     sk_EVP_KEYMGMT_sort(km_stack);
 
     for (i = 0; i < sk_EVP_KEYMGMT_num(km_stack); i++) {
@@ -706,7 +709,8 @@ static void list_signatures(void)
     int i, count = 0;
     STACK_OF(EVP_SIGNATURE) *sig_stack = sk_EVP_SIGNATURE_new(signature_cmp);
 
-    EVP_SIGNATURE_do_all_provided(NULL, collect_signatures, sig_stack);
+    EVP_SIGNATURE_do_all_provided(app_get0_libctx(), collect_signatures,
+                                  sig_stack);
     sk_EVP_SIGNATURE_sort(sig_stack);
 
     for (i = 0; i < sk_EVP_SIGNATURE_num(sig_stack); i++) {
@@ -765,7 +769,7 @@ static void list_kems(void)
     int i, count = 0;
     STACK_OF(EVP_KEM) *kem_stack = sk_EVP_KEM_new(kem_cmp);
 
-    EVP_KEM_do_all_provided(NULL, collect_kem, kem_stack);
+    EVP_KEM_do_all_provided(app_get0_libctx(), collect_kem, kem_stack);
     sk_EVP_KEM_sort(kem_stack);
 
     for (i = 0; i < sk_EVP_KEM_num(kem_stack); i++) {
@@ -825,7 +829,8 @@ static void list_asymciphers(void)
     STACK_OF(EVP_ASYM_CIPHER) *asymciph_stack =
         sk_EVP_ASYM_CIPHER_new(asymcipher_cmp);
 
-    EVP_ASYM_CIPHER_do_all_provided(NULL, collect_asymciph, asymciph_stack);
+    EVP_ASYM_CIPHER_do_all_provided(app_get0_libctx(), collect_asymciph,
+                                    asymciph_stack);
     sk_EVP_ASYM_CIPHER_sort(asymciph_stack);
 
     for (i = 0; i < sk_EVP_ASYM_CIPHER_num(asymciph_stack); i++) {
@@ -885,7 +890,7 @@ static void list_keyexchanges(void)
     int i, count = 0;
     STACK_OF(EVP_KEYEXCH) *kex_stack = sk_EVP_KEYEXCH_new(kex_cmp);
 
-    EVP_KEYEXCH_do_all_provided(NULL, collect_kex, kex_stack);
+    EVP_KEYEXCH_do_all_provided(app_get0_libctx(), collect_kex, kex_stack);
     sk_EVP_KEYEXCH_sort(kex_stack);
 
     for (i = 0; i < sk_EVP_KEYEXCH_num(kex_stack); i++) {
@@ -1013,7 +1018,7 @@ static int is_md_available(const char *name)
 
     /* Look through providers' digests */
     ERR_set_mark();
-    md = EVP_MD_fetch(NULL, name, propq);
+    md = EVP_MD_fetch(app_get0_libctx(), name, propq);
     ERR_pop_to_mark();
     if (md != NULL) {
         EVP_MD_free(md);
@@ -1030,7 +1035,7 @@ static int is_cipher_available(const char *name)
 
     /* Look through providers' ciphers */
     ERR_set_mark();
-    cipher = EVP_CIPHER_fetch(NULL, name, propq);
+    cipher = EVP_CIPHER_fetch(app_get0_libctx(), name, propq);
     ERR_pop_to_mark();
     if (cipher != NULL) {
         EVP_CIPHER_free(cipher);
@@ -1170,7 +1175,8 @@ static void list_store_loaders(void)
         return;
     }
     BIO_printf(bio_out, "Provided STORE LOADERs:\n");
-    OSSL_STORE_LOADER_do_all_provided(NULL, collect_store_loaders, stores);
+    OSSL_STORE_LOADER_do_all_provided(app_get0_libctx(), collect_store_loaders,
+                                      stores);
     sk_OSSL_STORE_LOADER_sort(stores);
     for (i = 0; i < sk_OSSL_STORE_LOADER_num(stores); i++) {
         const OSSL_STORE_LOADER *m = sk_OSSL_STORE_LOADER_value(stores, i);

--- a/apps/pkcs12.c
+++ b/apps/pkcs12.c
@@ -763,7 +763,8 @@ int pkcs12_main(int argc, char **argv)
     if (macver) {
         EVP_KDF *pkcs12kdf;
 
-        pkcs12kdf = EVP_KDF_fetch(NULL, "PKCS12KDF", NULL);
+        pkcs12kdf = EVP_KDF_fetch(app_get0_libctx(), "PKCS12KDF",
+                                  app_get0_propq());
         if (pkcs12kdf == NULL) {
             BIO_printf(bio_err, "Error verifying PKCS12 MAC; no PKCS12KDF support.\n");
             BIO_printf(bio_err, "Use -nomacver if MAC verification is not required.\n");

--- a/apps/speed.c
+++ b/apps/speed.c
@@ -1804,11 +1804,13 @@ int speed_main(int argc, char **argv)
             if (!have_cipher(names[i]))
                 doit[i] = 0;
         }
-        if ((mac = EVP_MAC_fetch(NULL, "GMAC", NULL)) != NULL)
+        if ((mac = EVP_MAC_fetch(app_get0_libctx(), "GMAC",
+                                 app_get0_propq())) != NULL)
             EVP_MAC_free(mac);
         else
             doit[D_GHASH] = 0;
-        if ((mac = EVP_MAC_fetch(NULL, "HMAC", NULL)) != NULL)
+        if ((mac = EVP_MAC_fetch(app_get0_libctx(), "HMAC",
+                                 app_get0_propq())) != NULL)
             EVP_MAC_free(mac);
         else
             doit[D_HMAC] = 0;
@@ -1958,7 +1960,8 @@ int speed_main(int argc, char **argv)
     if (doit[D_HMAC]) {
         static const char hmac_key[] = "This is a key...";
         int len = strlen(hmac_key);
-        EVP_MAC *mac = EVP_MAC_fetch(NULL, "HMAC", NULL);
+        EVP_MAC *mac = EVP_MAC_fetch(app_get0_libctx(), "HMAC",
+                                     app_get0_propq());
         OSSL_PARAM params[3];
 
         if (mac == NULL || evp_mac_mdname == NULL)
@@ -2121,7 +2124,8 @@ int speed_main(int argc, char **argv)
     }
     if (doit[D_GHASH]) {
         static const char gmac_iv[] = "0123456789ab";
-        EVP_MAC *mac = EVP_MAC_fetch(NULL, "GMAC", NULL);
+        EVP_MAC *mac = EVP_MAC_fetch(app_get0_libctx(), "GMAC",
+                                     app_get0_propq());
         OSSL_PARAM params[3];
 
         if (mac == NULL)
@@ -2252,7 +2256,8 @@ int speed_main(int argc, char **argv)
     }
 
     if (doit[D_EVP_CMAC]) {
-        EVP_MAC *mac = EVP_MAC_fetch(NULL, "CMAC", NULL);
+        EVP_MAC *mac = EVP_MAC_fetch(app_get0_libctx(), "CMAC",
+                                     app_get0_propq());
         OSSL_PARAM params[3];
         EVP_CIPHER *cipher = NULL;
 

--- a/doc/man1/openssl-spkac.pod.in
+++ b/doc/man1/openssl-spkac.pod.in
@@ -15,6 +15,7 @@ B<openssl> B<spkac>
 [B<-help>]
 [B<-in> I<filename>]
 [B<-out> I<filename>]
+[B<-digest> I<digest>]
 [B<-key> I<filename>|I<uri>]
 [B<-keyform> B<DER>|B<PEM>|B<P12>|B<ENGINE>]
 [B<-passin> I<arg>]
@@ -49,6 +50,11 @@ option is not specified. Ignored if the B<-key> option is used.
 
 Specifies the output filename to write to or standard output by
 default.
+
+=item B<-digest> I<digest>
+
+Use the specified I<digest> to sign a created SPKAC file.
+The default digest algorithm is MD5.
 
 =item B<-key> I<filename>|I<uri>
 
@@ -148,6 +154,8 @@ L<openssl-ca(1)>
 =head1 HISTORY
 
 The B<-engine> option was deprecated in OpenSSL 3.0.
+
+The B<-digest> option was added in OpenSSL 3.0.
 
 =head1 COPYRIGHT
 

--- a/test/recipes/20-test_spkac.t
+++ b/test/recipes/20-test_spkac.t
@@ -16,23 +16,26 @@ use OpenSSL::Test::Utils;
 
 setup("test_spkac");
 
+plan skip_all => "RSA is not supported by this OpenSSL build"
+    if disabled("rsa");
+
 plan tests => 4;
 
 # For the tests below we use the cert itself as the TBS file
 
 SKIP: {
-    skip "RSA is not supported by this OpenSSL build", 4
-        if disabled("rsa");
+    skip "MD5 is not supported by this OpenSSL build", 2
+        if disabled("md5");
 
     ok(run(app([ 'openssl', 'spkac', '-key', srctop_file("test", "testrsa.pem"),
                  '-out', 'spkac-md5.pem'])),
                "SPKAC MD5");
     ok(run(app([ 'openssl', 'spkac', '-in', 'spkac-md5.pem'])),
                "SPKAC MD5 verify");
-
-    ok(run(app([ 'openssl', 'spkac', '-key', srctop_file("test", "testrsa.pem"),
-                 '-out', 'spkac-sha256.pem', '-digest', 'sha256'])),
-               "SPKAC SHA256");
-    ok(run(app([ 'openssl', 'spkac', '-in', 'spkac-sha256.pem'])),
-               "SPKAC SHA256 verify");
 }
+
+ok(run(app([ 'openssl', 'spkac', '-key', srctop_file("test", "testrsa.pem"),
+             '-out', 'spkac-sha256.pem', '-digest', 'sha256'])),
+           "SPKAC SHA256");
+ok(run(app([ 'openssl', 'spkac', '-in', 'spkac-sha256.pem'])),
+           "SPKAC SHA256 verify");

--- a/test/recipes/20-test_spkac.t
+++ b/test/recipes/20-test_spkac.t
@@ -1,0 +1,38 @@
+#! /usr/bin/env perl
+# Copyright 2021 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+use strict;
+use warnings;
+
+use File::Spec;
+use File::Basename;
+use OpenSSL::Test qw/:DEFAULT srctop_file ok_nofips/;
+use OpenSSL::Test::Utils;
+
+setup("test_spkac");
+
+plan tests => 4;
+
+# For the tests below we use the cert itself as the TBS file
+
+SKIP: {
+    skip "RSA is not supported by this OpenSSL build", 4
+        if disabled("rsa");
+
+    ok(run(app([ 'openssl', 'spkac', '-key', srctop_file("test", "testrsa.pem"),
+                 '-out', 'spkac-md5.pem'])),
+               "SPKAC MD5");
+    ok(run(app([ 'openssl', 'spkac', '-in', 'spkac-md5.pem'])),
+               "SPKAC MD5 verify");
+
+    ok(run(app([ 'openssl', 'spkac', '-key', srctop_file("test", "testrsa.pem"),
+                 '-out', 'spkac-sha256.pem', '-digest', 'sha256'])),
+               "SPKAC SHA256");
+    ok(run(app([ 'openssl', 'spkac', '-in', 'spkac-sha256.pem'])),
+               "SPKAC SHA256 verify");
+}


### PR DESCRIPTION
In many places the command line application was not passing it's library context and property query to `XXX_fetch` and `XXX_do_all_provider`.  This addresses this oversight.

Also added a _-digest_ option to the SPKAC command.

Fixes  #15686 & #15683

- [x] documentation is added or updated
- [x] tests are added or updated
