### PR TITLE
HTTP client: Fix GET request handling with keep-alive, update related docs

### DIFF
--- a/crypto/http/http_client.c
+++ b/crypto/http/http_client.c
@@ -944,11 +944,11 @@ OSSL_HTTP_REQ_CTX *OSSL_HTTP_open(const char *server, const char *port,
     return rctx;
 }
 
-int OSSL_HTTP_set_request(OSSL_HTTP_REQ_CTX *rctx, const char *path,
-                          const STACK_OF(CONF_VALUE) *headers,
-                          const char *content_type, BIO *req,
-                          const char *expected_content_type, int expect_asn1,
-                          size_t max_resp_len, int timeout, int keep_alive)
+int OSSL_HTTP_set1_request(OSSL_HTTP_REQ_CTX *rctx, const char *path,
+                           const STACK_OF(CONF_VALUE) *headers,
+                           const char *content_type, BIO *req,
+                           const char *expected_content_type, int expect_asn1,
+                           size_t max_resp_len, int timeout, int keep_alive)
 {
     int use_http_proxy;
 
@@ -1087,12 +1087,12 @@ BIO *OSSL_HTTP_get(const char *url, const char *proxy, const char *no_proxy,
                               buf_size, timeout);
     new_rpath:
         if (rctx != NULL) {
-            if (!OSSL_HTTP_set_request(rctx, path, headers,
-                                       NULL /* content_type */,
-                                       NULL /* req */,
-                                       expected_ct, expect_asn1, max_resp_len,
-                                       -1 /* use same max time (timeout) */,
-                                       0 /* no keep_alive */))
+            if (!OSSL_HTTP_set1_request(rctx, path, headers,
+                                        NULL /* content_type */,
+                                        NULL /* req */,
+                                        expected_ct, expect_asn1, max_resp_len,
+                                        -1 /* use same max time (timeout) */,
+                                        0 /* no keep_alive */))
                 OSSL_HTTP_REQ_CTX_free(rctx);
             else
                 resp = OSSL_HTTP_exchange(rctx, &redirection_url);
@@ -1149,9 +1149,9 @@ BIO *OSSL_HTTP_transfer(OSSL_HTTP_REQ_CTX **prctx,
         timeout = -1; /* Already set during opening the connection */
     }
     if (rctx != NULL) {
-        if (OSSL_HTTP_set_request(rctx, path, headers, content_type, req,
-                                  expected_ct, expect_asn1,
-                                  max_resp_len, timeout, keep_alive))
+        if (OSSL_HTTP_set1_request(rctx, path, headers, content_type, req,
+                                   expected_ct, expect_asn1,
+                                   max_resp_len, timeout, keep_alive))
             resp = OSSL_HTTP_exchange(rctx, NULL);
         if (resp == NULL || !OSSL_HTTP_is_alive(rctx)) {
             if (!OSSL_HTTP_close(rctx, resp != NULL)) {

--- a/doc/man3/OSSL_HTTP_REQ_CTX.pod
+++ b/doc/man3/OSSL_HTTP_REQ_CTX.pod
@@ -111,12 +111,16 @@ If the value is 1 or 2 then a persistent connection is requested.
 If the value is 2 then a persistent connection is required,
 i.e., an error occurs in case the server does not grant it.
 
-OSSL_HTTP_REQ_CTX_set1_req() is to be used if and only if the I<method_POST>
-parameter in the OSSL_HTTP_REQ_CTX_set_request_line() call was 1
-and an ASN.1-encoded request should be sent, which does not support streaming.
-It finalizes the HTTP request context by adding the DER encoding of I<req>,
-using the ASN.1 template I<it> to do the encoding.
+OSSL_HTTP_REQ_CTX_set1_req() finalizes the HTTP request context.
+It is needed if the I<method_POST> parameter in the
+OSSL_HTTP_REQ_CTX_set_request_line() call was 1
+and an ASN.1-encoded request should be sent.
+It must also be used when requesting "keep-alive",
+even if a GET request is going to be sent, in which case I<req> must be NULL.
+Unless I<req> is NULL, the function adds the DER encoding of I<req> using
+the ASN.1 template I<it> to do the encoding (which does not support streaming.
 The HTTP header C<Content-Length> is filled out with the length of the request.
+I<content_type> must be NULL if I<req> is NULL.
 If I<content_type> isn't NULL,
 the HTTP header C<Content-Type> is also added with the given string value.
 All of this ends up in the internal memory B<BIO>.
@@ -188,7 +192,7 @@ Then, the HTTP request must be prepared with request data:
 
 =item 1.
 
-Calling OSSL_HTTP_REQ_CTX_set_request_line().  This must be done exactly once.
+Calling OSSL_HTTP_REQ_CTX_set_request_line().
 
 =item 2.
 
@@ -197,9 +201,8 @@ This is optional and may be done multiple times with different names.
 
 =item 3.
 
-Add C<POST> data with OSSL_HTTP_REQ_CTX_set1_req().  This may only be done if
-I<method_POST> was 1 in the OSSL_HTTP_REQ_CTX_set_request_line() call,
-and must be done exactly once in that case.
+Finalize the request using OSSL_HTTP_REQ_CTX_set1_req().
+This may be omitted if the GET method is used and "keep-alive" is not requested.
 
 =back
 

--- a/doc/man3/OSSL_HTTP_REQ_CTX.pod
+++ b/doc/man3/OSSL_HTTP_REQ_CTX.pod
@@ -118,7 +118,7 @@ and an ASN.1-encoded request should be sent.
 It must also be used when requesting "keep-alive",
 even if a GET request is going to be sent, in which case I<req> must be NULL.
 Unless I<req> is NULL, the function adds the DER encoding of I<req> using
-the ASN.1 template I<it> to do the encoding (which does not support streaming.
+the ASN.1 template I<it> to do the encoding (which does not support streaming).
 The HTTP header C<Content-Length> is filled out with the length of the request.
 I<content_type> must be NULL if I<req> is NULL.
 If I<content_type> isn't NULL,

--- a/doc/man3/OSSL_HTTP_transfer.pod
+++ b/doc/man3/OSSL_HTTP_transfer.pod
@@ -5,7 +5,7 @@
 OSSL_HTTP_open,
 OSSL_HTTP_bio_cb_t,
 OSSL_HTTP_proxy_connect,
-OSSL_HTTP_set_request,
+OSSL_HTTP_set1_request,
 OSSL_HTTP_exchange,
 OSSL_HTTP_get,
 OSSL_HTTP_transfer,
@@ -26,11 +26,11 @@ OSSL_HTTP_close
  int OSSL_HTTP_proxy_connect(BIO *bio, const char *server, const char *port,
                              const char *proxyuser, const char *proxypass,
                              int timeout, BIO *bio_err, const char *prog);
- int OSSL_HTTP_set_request(OSSL_HTTP_REQ_CTX *rctx, const char *path,
-                           const STACK_OF(CONF_VALUE) *headers,
-                           const char *content_type, BIO *req,
-                           const char *expected_content_type, int expect_asn1,
-                           size_t max_resp_len, int timeout, int keep_alive);
+ int OSSL_HTTP_set1_request(OSSL_HTTP_REQ_CTX *rctx, const char *path,
+                            const STACK_OF(CONF_VALUE) *headers,
+                            const char *content_type, BIO *req,
+                            const char *expected_content_type, int expect_asn1,
+                            size_t max_resp_len, int timeout, int keep_alive);
  BIO *OSSL_HTTP_exchange(OSSL_HTTP_REQ_CTX *rctx, char **redirection_url);
  BIO *OSSL_HTTP_get(const char *url, const char *proxy, const char *no_proxy,
                     BIO *bio, BIO *rbio,
@@ -145,7 +145,7 @@ Since this function is typically called by applications such as
 L<openssl-s_client(1)> it uses the I<bio_err> and I<prog> parameters (unless
 NULL) to print additional diagnostic information in a user-oriented way.
 
-OSSL_HTTP_set_request() sets up in I<rctx> the request header and content data
+OSSL_HTTP_set1_request() sets up in I<rctx> the request header and content data
 and expectations on the response using the following parameters.
 If I<path> is NULL it defaults to "/".
 If I<req> is NULL the HTTP GET method will be used to send the request
@@ -174,7 +174,7 @@ i.e., an error occurs in case the server does not grant it.
 
 OSSL_HTTP_exchange() exchanges any form of HTTP request and response
 as specified by I<rctx>, which must include both connection and request data,
-typically set up using OSSL_HTTP_open() and OSSL_HTTP_set_request().
+typically set up using OSSL_HTTP_open() and OSSL_HTTP_set1_request().
 It implements the core of the functions described below.
 If the HTTP method is GET and I<redirection_url>
 is not NULL the latter pointer is used to provide any new location that
@@ -201,18 +201,18 @@ Any query component is handled as part of the path component.
 If the scheme component of the I<url> is C<https> a TLS connection is requested
 and the I<bio_update_fn>, as described for OSSL_HTTP_open(), must be provided.
 Also the remaining parameters are interpreted as described for OSSL_HTTP_open()
-and OSSL_HTTP_set_request(), respectively.
+and OSSL_HTTP_set1_request(), respectively.
 
 OSSL_HTTP_transfer() exchanges an HTTP request and response
 over a connection managed via I<prctx> without supporting redirection.
-It combines OSSL_HTTP_open(), OSSL_HTTP_set_request(), OSSL_HTTP_exchange(),
+It combines OSSL_HTTP_open(), OSSL_HTTP_set1_request(), OSSL_HTTP_exchange(),
 and OSSL_HTTP_close().
 If I<prctx> is not NULL it reuses any open connection represented by a non-NULL
 I<*prctx>.  It keeps the connection open if a persistent connection is requested
 or required and this was granted by the server, else it closes the connection
 and assigns NULL to I<*prctx>.
 The remaining parameters are interpreted as described for OSSL_HTTP_open()
-and OSSL_HTTP_set_request(), respectively.
+and OSSL_HTTP_set1_request(), respectively.
 
 OSSL_HTTP_close() closes the connection and releases I<rctx>.
 The I<ok> parameter is passed to any BIO update function
@@ -229,7 +229,7 @@ other HTTP client implementations such as wget, curl, and git.
 
 OSSL_HTTP_open() returns on success a B<OSSL_HTTP_REQ_CTX>, else NULL.
 
-OSSL_HTTP_proxy_connect() and OSSL_HTTP_set_request()
+OSSL_HTTP_proxy_connect() and OSSL_HTTP_set1_request()
 return 1 on success, 0 on error.
 
 On success, OSSL_HTTP_exchange(), OSSL_HTTP_get(), and OSSL_HTTP_transfer()

--- a/include/openssl/http.h
+++ b/include/openssl/http.h
@@ -69,11 +69,11 @@ OSSL_HTTP_REQ_CTX *OSSL_HTTP_open(const char *server, const char *port,
 int OSSL_HTTP_proxy_connect(BIO *bio, const char *server, const char *port,
                             const char *proxyuser, const char *proxypass,
                             int timeout, BIO *bio_err, const char *prog);
-int OSSL_HTTP_set_request(OSSL_HTTP_REQ_CTX *rctx, const char *path,
-                          const STACK_OF(CONF_VALUE) *headers,
-                          const char *content_type, BIO *req,
-                          const char *expected_content_type, int expect_asn1,
-                          size_t max_resp_len, int timeout, int keep_alive);
+int OSSL_HTTP_set1_request(OSSL_HTTP_REQ_CTX *rctx, const char *path,
+                           const STACK_OF(CONF_VALUE) *headers,
+                           const char *content_type, BIO *req,
+                           const char *expected_content_type, int expect_asn1,
+                           size_t max_resp_len, int timeout, int keep_alive);
 BIO *OSSL_HTTP_exchange(OSSL_HTTP_REQ_CTX *rctx, char **redirection_url);
 BIO *OSSL_HTTP_get(const char *url, const char *proxy, const char *no_proxy,
                    BIO *bio, BIO *rbio,

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4878,7 +4878,7 @@ OSSL_HTTP_REQ_CTX_set_expected          ?	3_0_0	EXIST::FUNCTION:
 OSSL_HTTP_is_alive                      ?	3_0_0	EXIST::FUNCTION:
 OSSL_HTTP_open                          ?	3_0_0	EXIST::FUNCTION:
 OSSL_HTTP_proxy_connect                 ?	3_0_0	EXIST::FUNCTION:
-OSSL_HTTP_set_request                   ?	3_0_0	EXIST::FUNCTION:
+OSSL_HTTP_set1_request                  ?	3_0_0	EXIST::FUNCTION:
 OSSL_HTTP_exchange                      ?	3_0_0	EXIST::FUNCTION:
 OSSL_HTTP_get                           ?	3_0_0	EXIST::FUNCTION:
 OSSL_HTTP_transfer                      ?	3_0_0	EXIST::FUNCTION:


### PR DESCRIPTION
This is a follow-up on #15648 as discussed there: https://github.com/openssl/openssl/pull/15648#discussion_r648001126.

* HTTP client: Fix GET request handling when `rctx` is reused (keep-alive)
* Update the documentation of `OSSL_HTTP_REQ_CTX_set1_req().`
* Rename `OSSL_HTTP_set_request()` to `OSSL_HTTP_set1_request()` for clarity

