### PR TITLE
Avoid duplicating prov_running.o in libdefault and libcrypto

### DIFF
--- a/providers/build.info
+++ b/providers/build.info
@@ -162,5 +162,3 @@ ENDIF
 # include all the object files that are needed.
 $NULLGOAL=../libcrypto
 SOURCE[$NULLGOAL]=nullprov.c prov_running.c
-
-SOURCE[$LIBDEFAULT]=prov_running.c


### PR DESCRIPTION
Otherwise this is causing linkage errors when linking to a static libcrypto on some platforms.
