### PR TITLE
test output correctness: Always wait for both threads to finish

### DIFF
--- a/test/threadstest.c
+++ b/test/threadstest.c
@@ -441,12 +441,16 @@ static int test_multi(int idx)
 
     worker();
 
-    if (!TEST_true(wait_for_thread(thread1))
-            || !TEST_true(wait_for_thread(thread2))
-            || !TEST_true(multi_success))
-        goto err;
-
     testresult = 1;
+    /*
+     * Don't combine these into one if statement; must wait for both threads.
+     */
+    if (!TEST_true(wait_for_thread(thread1)))
+        testresult = 0;
+    if (!TEST_true(wait_for_thread(thread2)))
+        testresult = 0;
+    if (!TEST_true(multi_success))
+        testresult = 0;
 
  err:
     EVP_MD_free(sha256);


### PR DESCRIPTION
Trying to fix why 'no-cache' runs fail some times.

Here is what the sanitizers say:
```
; make 'TESTS=test_threads' 'VFE=1' tests
make depend && make _tests
make[1]: Entering directory '/home/rsalz/openssl/github'
make[1]: Leaving directory '/home/rsalz/openssl/github'
make[1]: Entering directory '/home/rsalz/openssl/github'
( SRCTOP=. \
  BLDTOP=. \
  PERL="/usr/bin/perl" \
  FIPSKEY="f4556650ac31d35461610bac4ed81b1a181b2d8a43ea2854cbae22ca74560813" \
  EXE_EXT= \
  /usr/bin/perl ./test/run_tests.pl test_threads )
Using HARNESS_JOBS=4
00-prep_fipsmodule_cnf.t .. skipped: FIPS module config file only supported in a fips build
Files=1, Tests=0,  0 wallclock secs ( 0.01 usr  0.00 sys +  0.08 cusr  0.01 csys =  0.10 CPU)
Result: NOTESTS

==21882==Processing thread 21860.
==21882==Stack at 0x7ffc17e4a000-0x7ffc1864a000 (SP = 0x7ffc18646838).
==21882==TLS at 0x7f234aea5000-0x7f234aea60c0.
=================================================================
==21860==ERROR: LeakSanitizer: detected memory leaks
Direct leak of 24 byte(s) in 1 object(s) allocated from:
    #0 0x7f2349dc6b40 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb40)
    #1 0x7f2348ad38f7 in CRYPTO_malloc crypto/mem.c:184
    #2 0x7f2348abf285 in OPENSSL_LH_insert crypto/lhash/lhash.c:118
    #3 0x7f2348b8c277 in lh_PROPERTY_STRING_insert crypto/property/property_string.c:34
    #4 0x7f2348b8cbf3 in ossl_property_string crypto/property/property_string.c:141
    #5 0x7f2348b8d27a in ossl_property_value crypto/property/property_string.c:213
    #6 0x7f2348b86e6f in parse_unquoted crypto/property/property_parse.c:221
    #7 0x7f2348b87856 in parse_value crypto/property/property_parse.c:253
    #8 0x7f2348b88422 in ossl_parse_property crypto/property/property_parse.c:333
    #9 0x7f2348b81d2d in ossl_method_store_add crypto/property/property.c:288
    #10 0x7f2348a331f3 in put_evp_method_in_store crypto/evp/evp_fetch.c:170
    #11 0x7f2348ac84aa in ossl_method_construct_this crypto/core_fetch.c:95
    #12 0x7f2348ac7256 in algorithm_do_this crypto/core_algorithm.c:65
    #13 0x7f2348af9056 in ossl_provider_doall_activated crypto/provider_core.c:1061
    #14 0x7f2348ac784f in ossl_algorithm_do_all crypto/core_algorithm.c:109
    #15 0x7f2348ac88da in ossl_method_construct crypto/core_fetch.c:124
    #16 0x7f2348a33b04 in inner_evp_generic_fetch crypto/evp/evp_fetch.c:304
    #17 0x7f2348a33e8e in evp_generic_fetch crypto/evp/evp_fetch.c:350
    #18 0x7f23489db5a9 in EVP_MD_fetch crypto/evp/digest.c:1037
    #19 0x55d437760805 in thread_multi_simple_fetch test/threadstest.c:280
    #20 0x55d43775e4d9 in thread_run test/threadstest.h:67
    #21 0x7f2346ed46da in start_thread (/lib/x86_64-linux-gnu/libpthread.so.0+0x76da)
Indirect leak of 23 byte(s) in 1 object(s) allocated from:
    #0 0x7f2349dc6b40 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb40)
    #1 0x7f2348ad38f7 in CRYPTO_malloc crypto/mem.c:184
    #2 0x7f2348b8c879 in new_property_string crypto/property/property_string.c:117
    #3 0x7f2348b8cbc9 in ossl_property_string crypto/property/property_string.c:140
    #4 0x7f2348b8d27a in ossl_property_value crypto/property/property_string.c:213
    #5 0x7f2348b86e6f in parse_unquoted crypto/property/property_parse.c:221
    #6 0x7f2348b87856 in parse_value crypto/property/property_parse.c:253
    #7 0x7f2348b88422 in ossl_parse_property crypto/property/property_parse.c:333
    #8 0x7f2348b81d2d in ossl_method_store_add crypto/property/property.c:288
    #9 0x7f2348a331f3 in put_evp_method_in_store crypto/evp/evp_fetch.c:170
    #10 0x7f2348ac84aa in ossl_method_construct_this crypto/core_fetch.c:95
    #11 0x7f2348ac7256 in algorithm_do_this crypto/core_algorithm.c:65
    #12 0x7f2348af9056 in ossl_provider_doall_activated crypto/provider_core.c:1061
    #13 0x7f2348ac784f in ossl_algorithm_do_all crypto/core_algorithm.c:109
    #14 0x7f2348ac88da in ossl_method_construct crypto/core_fetch.c:124
    #15 0x7f2348a33b04 in inner_evp_generic_fetch crypto/evp/evp_fetch.c:304
    #16 0x7f2348a33e8e in evp_generic_fetch crypto/evp/evp_fetch.c:350
    #17 0x7f23489db5a9 in EVP_MD_fetch crypto/evp/digest.c:1037
    #18 0x55d437760805 in thread_multi_simple_fetch test/threadstest.c:280
    #19 0x55d43775e4d9 in thread_run test/threadstest.h:67
    #20 0x7f2346ed46da in start_thread (/lib/x86_64-linux-gnu/libpthread.so.0+0x76da)
SUMMARY: AddressSanitizer: 47 byte(s) leaked in 2 allocation(s).
../../util/wrap.pl ../../test/threadstest -config /home/rsalz/openssl/github/test/default.cnf ../../test/recipes/90-test_threads_data => 1
not ok 1 - running test_threads
90-test_threads.t .. 1/2 -------------------------------------------------------
90-test_threads.t .. Dubious, test returned 1 (wstat 256, 0x100)
Failed 1/2 subtests 

Test Summary Report
-------------------
90-test_threads.t (Wstat: 256 Tests: 2 Failed: 1)
  Failed test:  1
  Non-zero exit status: 1
Files=1, Tests=2,  0 wallclock secs ( 0.00 usr  0.00 sys +  0.43 cusr  0.05 csys =  0.48 CPU)
Result: FAIL
Makefile:3274: recipe for target 'run_tests' failed
make[1]: *** [run_tests] Error 1
make[1]: Leaving directory '/home/rsalz/openssl/github'
Makefile:3271: recipe for target 'tests' failed
make: *** [tests] Error 2
        exit 2
; 
```
