### PR TITLE
Windows Github CI: test in Windows 2016 as well

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -28,7 +28,7 @@ jobs:
       working-directory: _build
       run: |
         if ( "${{ matrix.arch }}" -eq "win32" ) { $target = "VC-WIN32" ; $fips = "no-fips" } else { $target = "VC-WIN64A" ; $fips = "enable-fips" }
-        perl ..\Configure --banner=Configured no-makedepend $fips $target
+        perl ..\Configure --banner=Configured --strict-warnings no-makedepend $fips $target
         perl configdata.pm --dump
     - name: build
       working-directory: _build
@@ -58,7 +58,7 @@ jobs:
     - name: config
       working-directory: _build
       run: |
-        perl ..\Configure --banner=Configured no-makedepend no-shared no-fips VC-WIN64A-masm
+        perl ..\Configure --banner=Configured --strict-warnings no-makedepend no-shared no-fips VC-WIN64A-masm
         perl configdata.pm --dump
     - name: build
       working-directory: _build
@@ -81,7 +81,7 @@ jobs:
     - name: config
       working-directory: _build
       run: |
-        perl ..\Configure --banner=Configured no-makedepend no-bulk no-deprecated no-fips no-asm -DOPENSSL_SMALL_FOOTPRINT VC-WIN64A
+        perl ..\Configure --banner=Configured --strict-warnings no-makedepend no-bulk no-deprecated no-fips no-asm -DOPENSSL_SMALL_FOOTPRINT VC-WIN64A
         perl configdata.pm --dump
     - name: build
       working-directory: _build

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -10,25 +10,26 @@ jobs:
         os:
           - windows-latest
           - windows-2016
-        arch:
-          - win64
-          - win32
+        platform:
+          - arch: win64
+            config: VC-WIN32 --strict-warnings no-fips
+          - arch: win32
+            config: VC-WIN64A enable-fips
     runs-on: ${{matrix.os}}
     steps:
     - uses: actions/checkout@v2
     - uses: ilammy/msvc-dev-cmd@v1
       with:
-        arch: ${{ matrix.arch }}
+        arch: ${{ matrix.platform.arch }}
     - uses: ilammy/setup-nasm@v1
       with:
-        platform: ${{ matrix.arch }}
+        platform: ${{ matrix.platform.arch }}
     - name: prepare the build directory
       run: mkdir _build
     - name: config
       working-directory: _build
       run: |
-        if ( "${{ matrix.arch }}" -eq "win32" ) { $target = "VC-WIN32" ; $fips = "no-fips" } else { $target = "VC-WIN64A" ; $fips = "enable-fips" }
-        perl ..\Configure --banner=Configured --strict-warnings no-makedepend $fips $target
+        perl ..\Configure --banner=Configured no-makedepend ${{ matric.platform.config }}
         perl configdata.pm --dump
     - name: build
       working-directory: _build
@@ -38,7 +39,7 @@ jobs:
       run: nmake test VERBOSE_FAILURE=yes TESTS=-test_fuzz* HARNESS_JOBS=4
     - name: install
       # Run on 64 bit only as 32 bit is slow enough already
-      if: $${{ matrix.arch == 'win64' }}
+      if: $${{ matrix.platform.arch == 'win64' }}
       run: |
         mkdir _dest
         nmake install DESTDIR=_dest

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -12,9 +12,9 @@ jobs:
           - windows-2016
         platform:
           - arch: win64
-            config: VC-WIN32 --strict-warnings no-fips
-          - arch: win32
             config: VC-WIN64A enable-fips
+          - arch: win32
+            config: VC-WIN32 --strict-warnings no-fips
     runs-on: ${{matrix.os}}
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -29,7 +29,7 @@ jobs:
     - name: config
       working-directory: _build
       run: |
-        perl ..\Configure --banner=Configured no-makedepend ${{ matric.platform.config }}
+        perl ..\Configure --banner=Configured no-makedepend ${{ matrix.platform.config }}
         perl configdata.pm --dump
     - name: build
       working-directory: _build

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -4,13 +4,16 @@ on: [pull_request, push]
 
 jobs:
   shared:
-    runs-on: [ windows-latest, windows-2016 ]
     # Run a job for each of the specified target architectures:
     strategy:
       matrix:
+        os:
+          - windows-latest
+          - windows-2016
         arch:
           - win64
           - win32
+    runs-on: ${{matrix.os}}
     steps:
     - uses: actions/checkout@v2
     - uses: ilammy/msvc-dev-cmd@v1
@@ -41,7 +44,12 @@ jobs:
         nmake install DESTDIR=_dest
       working-directory: _build
   plain:
-    runs-on: [ windows-latest, windows-2016 ]
+    strategy:
+      matrix:
+        os:
+          - windows-latest
+          - windows-2016
+    runs-on: ${{matrix.os}}
     steps:
     - uses: actions/checkout@v2
     - uses: ilammy/msvc-dev-cmd@v1
@@ -59,7 +67,12 @@ jobs:
       working-directory: _build
       run: nmake test VERBOSE_FAILURE=yes HARNESS_JOBS=4
   minimal:
-    runs-on: [ windows-latest, windows-2016 ]
+    strategy:
+      matrix:
+        os:
+          - windows-latest
+          - windows-2016
+    runs-on: ${{matrix.os}}
     steps:
     - uses: actions/checkout@v2
     - uses: ilammy/msvc-dev-cmd@v1

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -4,7 +4,7 @@ on: [pull_request, push]
 
 jobs:
   shared:
-    runs-on: windows-latest
+    runs-on: [ windows-latest, windows-2016 ]
     # Run a job for each of the specified target architectures:
     strategy:
       matrix:
@@ -41,7 +41,7 @@ jobs:
         nmake install DESTDIR=_dest
       working-directory: _build
   plain:
-    runs-on: windows-latest
+    runs-on: [ windows-latest, windows-2016 ]
     steps:
     - uses: actions/checkout@v2
     - uses: ilammy/msvc-dev-cmd@v1
@@ -59,7 +59,7 @@ jobs:
       working-directory: _build
       run: nmake test VERBOSE_FAILURE=yes HARNESS_JOBS=4
   minimal:
-    runs-on: windows-latest
+    runs-on: [ windows-latest, windows-2016 ]
     steps:
     - uses: actions/checkout@v2
     - uses: ilammy/msvc-dev-cmd@v1

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -59,7 +59,7 @@ jobs:
     - name: config
       working-directory: _build
       run: |
-        perl ..\Configure --banner=Configured --strict-warnings no-makedepend no-shared no-fips VC-WIN64A-masm
+        perl ..\Configure --banner=Configured no-makedepend no-shared no-fips VC-WIN64A-masm
         perl configdata.pm --dump
     - name: build
       working-directory: _build
@@ -82,7 +82,7 @@ jobs:
     - name: config
       working-directory: _build
       run: |
-        perl ..\Configure --banner=Configured --strict-warnings no-makedepend no-bulk no-deprecated no-fips no-asm -DOPENSSL_SMALL_FOOTPRINT VC-WIN64A
+        perl ..\Configure --banner=Configured no-makedepend no-bulk no-deprecated no-fips no-asm -DOPENSSL_SMALL_FOOTPRINT VC-WIN64A
         perl configdata.pm --dump
     - name: build
       working-directory: _build


### PR DESCRIPTION
This brings an older version of MSVC, which may bring some "interesting"
failures.

We also introduce the use of `--strict-warnings`