### PR TITLE
obj: make the OBJ_ calls thread safe

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,10 @@ OpenSSL 3.1
 
 ### Changes between 3.0 and 3.1 [xx XXX xxxx]
 
+ * The various OBJ_* functions have been made thread safe.
+
+   *Paul Dale*
+
  * CCM8 cipher suites in TLS have been downgraded to security level zero
    because they use a short authentication tag which lowers their strength.
 

--- a/crypto/objects/obj_dat.c
+++ b/crypto/objects/obj_dat.c
@@ -11,6 +11,7 @@
 #include "crypto/ctype.h"
 #include <limits.h>
 #include "internal/cryptlib.h"
+#include "internal/thread_once.h"
 #include <openssl/lhash.h>
 #include <openssl/asn1.h>
 #include "crypto/objects.h"
@@ -37,6 +38,43 @@ struct added_obj_st {
 
 static int new_nid = NUM_NID;
 static LHASH_OF(ADDED_OBJ) *added = NULL;
+static CRYPTO_RWLOCK *ossl_obj_lock = NULL;
+
+static CRYPTO_ONCE ossl_obj_lock_init = CRYPTO_ONCE_STATIC_INIT;
+
+DEFINE_RUN_ONCE_STATIC(obj_lock_initialise)
+{
+    /* Make sure we've loaded config before checking for any "added" objects */
+    OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CONFIG, NULL);
+
+    ossl_obj_lock = CRYPTO_THREAD_lock_new();
+    return ossl_obj_lock != NULL;
+}
+
+static ossl_inline int ossl_init_added_lock(void)
+{
+    return RUN_ONCE(&ossl_obj_lock_init, obj_lock_initialise);
+}
+
+static ossl_inline int ossl_obj_write_lock(int lock)
+{
+    if (!ossl_init_added_lock())
+        return 0;
+    return !lock || CRYPTO_THREAD_write_lock(ossl_obj_lock);
+}
+
+static ossl_inline int ossl_obj_read_lock(int lock)
+{
+    if (!ossl_init_added_lock())
+        return 0;
+    return !lock || CRYPTO_THREAD_read_lock(ossl_obj_lock);
+}
+
+static ossl_inline void ossl_obj_unlock(int lock)
+{
+    if (lock)
+        CRYPTO_THREAD_unlock(ossl_obj_lock);
+}
 
 static int sn_cmp(const ASN1_OBJECT *const *a, const unsigned int *b)
 {
@@ -123,14 +161,6 @@ static int added_obj_cmp(const ADDED_OBJ *ca, const ADDED_OBJ *cb)
     }
 }
 
-static int init_added(void)
-{
-    if (added != NULL)
-        return 1;
-    added = lh_ADDED_OBJ_new(added_obj_hash, added_obj_cmp);
-    return added != NULL;
-}
-
 static void cleanup1_doall(ADDED_OBJ *a)
 {
     a->obj->nid = 0;
@@ -152,47 +182,63 @@ static void cleanup3_doall(ADDED_OBJ *a)
 
 void ossl_obj_cleanup_int(void)
 {
-    if (added == NULL)
-        return;
-    lh_ADDED_OBJ_set_down_load(added, 0);
-    lh_ADDED_OBJ_doall(added, cleanup1_doall); /* zero counters */
-    lh_ADDED_OBJ_doall(added, cleanup2_doall); /* set counters */
-    lh_ADDED_OBJ_doall(added, cleanup3_doall); /* free objects */
-    lh_ADDED_OBJ_free(added);
-    added = NULL;
+    if (added != NULL) {
+        lh_ADDED_OBJ_set_down_load(added, 0);
+        lh_ADDED_OBJ_doall(added, cleanup1_doall); /* zero counters */
+        lh_ADDED_OBJ_doall(added, cleanup2_doall); /* set counters */
+        lh_ADDED_OBJ_doall(added, cleanup3_doall); /* free objects */
+        lh_ADDED_OBJ_free(added);
+        added = NULL;
+    }
+    CRYPTO_THREAD_lock_free(ossl_obj_lock);
+    ossl_obj_lock = NULL;
 }
 
-int OBJ_new_nid(int num)
+static int ossl_obj_new_nid(int num, int lock)
 {
     int i;
 
+    if (!CRYPTO_THREAD_write_lock(ossl_obj_nid_lock)) {
+        ERR_raise(ERR_LIB_OBJ, ERR_R_UNABLE_TO_GET_WRITE_LOCK);
+        return NID_undef;
+    }
     i = new_nid;
     new_nid += num;
+    ossl_obj_unlock(lock);
     return i;
 }
 
-int OBJ_add_object(const ASN1_OBJECT *obj)
+static int ossl_obj_add_object(const ASN1_OBJECT *obj, int lock)
 {
-    ASN1_OBJECT *o;
+    ASN1_OBJECT *o = NULL;
     ADDED_OBJ *ao[4] = { NULL, NULL, NULL, NULL }, *aop;
     int i;
 
-    if (added == NULL)
-        if (!init_added())
-            return 0;
     if ((o = OBJ_dup(obj)) == NULL)
-        goto err;
-    if ((ao[ADDED_NID] = OPENSSL_malloc(sizeof(*ao[0]))) == NULL)
+        return NID_undef;
+    if ((ao[ADDED_NID] = OPENSSL_malloc(sizeof(*ao[0]))) == NULL
+            || (o->length != 0
+                && obj->data != NULL
+                && (ao[ADDED_DATA] = OPENSSL_malloc(sizeof(*ao[0]))) == NULL)
+            || (o->sn != NULL
+                && (ao[ADDED_SNAME] = OPENSSL_malloc(sizeof(*ao[0]))) == NULL)
+            || (o->ln != NULL
+                && (ao[ADDED_LNAME] = OPENSSL_malloc(sizeof(*ao[0]))) == NULL)) {
+        ERR_raise(ERR_LIB_OBJ, ERR_R_MALLOC_FAILURE);
         goto err2;
-    if ((o->length != 0) && (obj->data != NULL))
-        if ((ao[ADDED_DATA] = OPENSSL_malloc(sizeof(*ao[0]))) == NULL)
-            goto err2;
-    if (o->sn != NULL)
-        if ((ao[ADDED_SNAME] = OPENSSL_malloc(sizeof(*ao[0]))) == NULL)
-            goto err2;
-    if (o->ln != NULL)
-        if ((ao[ADDED_LNAME] = OPENSSL_malloc(sizeof(*ao[0]))) == NULL)
-            goto err2;
+    }
+
+    if (!ossl_obj_write_lock(lock)) {
+        ERR_raise(ERR_LIB_OBJ, ERR_R_UNABLE_TO_GET_WRITE_LOCK);
+        goto err2;
+    }
+    if (added == NULL) {
+        added = lh_ADDED_OBJ_new(added_obj_hash, added_obj_cmp);
+        if (added == NULL) {
+            ERR_raise(ERR_LIB_OBJ, ERR_R_MALLOC_FAILURE);
+            goto err;
+        }
+    }
 
     for (i = ADDED_DATA; i <= ADDED_NID; i++) {
         if (ao[i] != NULL) {
@@ -207,10 +253,12 @@ int OBJ_add_object(const ASN1_OBJECT *obj)
         ~(ASN1_OBJECT_FLAG_DYNAMIC | ASN1_OBJECT_FLAG_DYNAMIC_STRINGS |
           ASN1_OBJECT_FLAG_DYNAMIC_DATA);
 
+    ossl_obj_unlock(lock);
     return o->nid;
- err2:
-    ERR_raise(ERR_LIB_OBJ, ERR_R_MALLOC_FAILURE);
+
  err:
+    ossl_obj_unlock(lock);
+ err2:
     for (i = ADDED_DATA; i <= ADDED_NID; i++)
         OPENSSL_free(ao[i]);
     ASN1_OBJECT_free(o);
@@ -219,27 +267,24 @@ int OBJ_add_object(const ASN1_OBJECT *obj)
 
 ASN1_OBJECT *OBJ_nid2obj(int n)
 {
-    ADDED_OBJ ad, *adp;
+    ADDED_OBJ ad, *adp = NULL;
     ASN1_OBJECT ob;
 
-    if ((n >= 0) && (n < NUM_NID)) {
-        if ((n != NID_undef) && (nid_objs[n].nid == NID_undef)) {
-            ERR_raise(ERR_LIB_OBJ, OBJ_R_UNKNOWN_NID);
-            return NULL;
-        }
-        return (ASN1_OBJECT *)&(nid_objs[n]);
-    }
-
-    /* Make sure we've loaded config before checking for any "added" objects */
-    OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CONFIG, NULL);
-
-    if (added == NULL)
+    if (n == NID_undef)
         return NULL;
+    if (n >= 0 && n < NUM_NID && nid_objs[n].nid != NID_undef)
+            return (ASN1_OBJECT *)&(nid_objs[n]);
 
     ad.type = ADDED_NID;
     ad.obj = &ob;
     ob.nid = n;
-    adp = lh_ADDED_OBJ_retrieve(added, &ad);
+    if (!ossl_obj_read_lock(1)) {
+        ERR_raise(ERR_LIB_OBJ, ERR_R_UNABLE_TO_GET_READ_LOCK);
+        return NULL;
+    }
+    if (added != NULL)
+        adp = lh_ADDED_OBJ_retrieve(added, &ad);
+    ossl_obj_unlock(1);
     if (adp != NULL)
         return adp->obj;
 
@@ -249,62 +294,16 @@ ASN1_OBJECT *OBJ_nid2obj(int n)
 
 const char *OBJ_nid2sn(int n)
 {
-    ADDED_OBJ ad, *adp;
-    ASN1_OBJECT ob;
+    ASN1_OBJECT *ob = OBJ_nid2obj(n);
 
-    if ((n >= 0) && (n < NUM_NID)) {
-        if ((n != NID_undef) && (nid_objs[n].nid == NID_undef)) {
-            ERR_raise(ERR_LIB_OBJ, OBJ_R_UNKNOWN_NID);
-            return NULL;
-        }
-        return nid_objs[n].sn;
-    }
-
-    /* Make sure we've loaded config before checking for any "added" objects */
-    OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CONFIG, NULL);
-
-    if (added == NULL)
-        return NULL;
-
-    ad.type = ADDED_NID;
-    ad.obj = &ob;
-    ob.nid = n;
-    adp = lh_ADDED_OBJ_retrieve(added, &ad);
-    if (adp != NULL)
-        return adp->obj->sn;
-
-    ERR_raise(ERR_LIB_OBJ, OBJ_R_UNKNOWN_NID);
-    return NULL;
+    return ob == NULL ? NULL : ob->sn;
 }
 
 const char *OBJ_nid2ln(int n)
 {
-    ADDED_OBJ ad, *adp;
-    ASN1_OBJECT ob;
+    ASN1_OBJECT *ob = OBJ_nid2obj(n);
 
-    if ((n >= 0) && (n < NUM_NID)) {
-        if ((n != NID_undef) && (nid_objs[n].nid == NID_undef)) {
-            ERR_raise(ERR_LIB_OBJ, OBJ_R_UNKNOWN_NID);
-            return NULL;
-        }
-        return nid_objs[n].ln;
-    }
-
-    /* Make sure we've loaded config before checking for any "added" objects */
-    OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CONFIG, NULL);
-
-    if (added == NULL)
-        return NULL;
-
-    ad.type = ADDED_NID;
-    ad.obj = &ob;
-    ob.nid = n;
-    adp = lh_ADDED_OBJ_retrieve(added, &ad);
-    if (adp != NULL)
-        return adp->obj->ln;
-
-    ERR_raise(ERR_LIB_OBJ, OBJ_R_UNKNOWN_NID);
-    return NULL;
+    return ob == NULL ? NULL : ob->ln;
 }
 
 static int obj_cmp(const ASN1_OBJECT *const *ap, const unsigned int *bp)
@@ -323,33 +322,35 @@ static int obj_cmp(const ASN1_OBJECT *const *ap, const unsigned int *bp)
 
 IMPLEMENT_OBJ_BSEARCH_CMP_FN(const ASN1_OBJECT *, unsigned int, obj);
 
-int OBJ_obj2nid(const ASN1_OBJECT *a)
+static int ossl_obj_obj2nid(const ASN1_OBJECT *a, const int lock)
 {
+    int nid = NID_undef;
     const unsigned int *op;
     ADDED_OBJ ad, *adp;
 
     if (a == NULL)
         return NID_undef;
-    if (a->nid != 0)
+    if (a->nid != NID_undef)
         return a->nid;
-
     if (a->length == 0)
         return NID_undef;
 
-    /* Make sure we've loaded config before checking for any "added" objects */
-    OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CONFIG, NULL);
-
+    op = OBJ_bsearch_obj(&a, obj_objs, NUM_OBJ);
+    if (op != NULL)
+        return nid_objs[*op].nid;
+    if (!ossl_obj_read_lock(lock)) {
+        ERR_raise(ERR_LIB_OBJ, ERR_R_UNABLE_TO_GET_READ_LOCK);
+        return NID_undef;
+    }
     if (added != NULL) {
         ad.type = ADDED_DATA;
-        ad.obj = (ASN1_OBJECT *)a; /* XXX: ugly but harmless */
+        ad.obj = (ASN1_OBJECT *)a; /* casting away const is harmless here */
         adp = lh_ADDED_OBJ_retrieve(added, &ad);
         if (adp != NULL)
-            return adp->obj->nid;
+            nid = adp->obj->nid;
     }
-    op = OBJ_bsearch_obj(&a, obj_objs, NUM_OBJ);
-    if (op == NULL)
-        return NID_undef;
-    return nid_objs[*op].nid;
+    ossl_obj_unlock(lock);
+    return nid;
 }
 
 /*
@@ -358,20 +359,20 @@ int OBJ_obj2nid(const ASN1_OBJECT *a)
  * into an object: unlike OBJ_txt2nid it can be used with any objects, not
  * just registered ones.
  */
-
 ASN1_OBJECT *OBJ_txt2obj(const char *s, int no_name)
 {
     int nid = NID_undef;
-    ASN1_OBJECT *op;
+    ASN1_OBJECT *op = NULL;
     unsigned char *buf;
     unsigned char *p;
     const unsigned char *cp;
     int i, j;
 
     if (!no_name) {
-        if (((nid = OBJ_sn2nid(s)) != NID_undef) ||
-            ((nid = OBJ_ln2nid(s)) != NID_undef))
+        if ((nid = OBJ_sn2nid(s)) != NID_undef ||
+                (nid = OBJ_ln2nid(s)) != NID_undef) {
             return OBJ_nid2obj(nid);
+        }
         if (!ossl_isdigit(*s)) {
             ERR_raise(ERR_LIB_OBJ, OBJ_R_UNKNOWN_OBJECT_NAME);
             return NULL;
@@ -380,13 +381,9 @@ ASN1_OBJECT *OBJ_txt2obj(const char *s, int no_name)
 
     /* Work out size of content octets */
     i = a2d_ASN1_OBJECT(NULL, 0, s, -1);
-    if (i <= 0) {
-        /* Don't clear the error */
-        /*
-         * ERR_clear_error();
-         */
+    if (i <= 0)
         return NULL;
-    }
+
     /* Work out total size */
     j = ASN1_object_size(0, i, V_ASN1_OBJECT);
     if (j < 0)
@@ -416,24 +413,23 @@ int OBJ_obj2txt(char *buf, int buf_len, const ASN1_OBJECT *a, int no_name)
     unsigned long l;
     const unsigned char *p;
     char tbuf[DECIMAL_SIZE(i) + DECIMAL_SIZE(l) + 2];
+    const char *s;
 
     /* Ensure that, at every state, |buf| is NUL-terminated. */
-    if (buf && buf_len > 0)
+    if (buf != NULL && buf_len > 0)
         buf[0] = '\0';
 
-    if ((a == NULL) || (a->data == NULL))
+    if (a == NULL || a->data == NULL)
         return 0;
 
     if (!no_name && (nid = OBJ_obj2nid(a)) != NID_undef) {
-        const char *s;
         s = OBJ_nid2ln(nid);
         if (s == NULL)
             s = OBJ_nid2sn(nid);
-        if (s) {
-            if (buf)
+        if (s != NULL) {
+            if (buf != NULL)
                 OPENSSL_strlcpy(buf, s, buf_len);
-            n = strlen(s);
-            return n;
+            return (int)strlen(s);
         }
     }
 
@@ -545,11 +541,13 @@ int OBJ_obj2txt(char *buf, int buf_len, const ASN1_OBJECT *a, int no_name)
 
 int OBJ_txt2nid(const char *s)
 {
-    ASN1_OBJECT *obj;
-    int nid;
-    obj = OBJ_txt2obj(s, 0);
-    nid = OBJ_obj2nid(obj);
-    ASN1_OBJECT_free(obj);
+    ASN1_OBJECT *obj = OBJ_txt2obj(s, 0);
+    int nid = NID_undef;
+
+    if (obj != NULL) {
+        nid = OBJ_obj2nid(obj);
+        ASN1_OBJECT_free(obj);
+    }
     return nid;
 }
 
@@ -559,22 +557,25 @@ int OBJ_ln2nid(const char *s)
     const ASN1_OBJECT *oo = &o;
     ADDED_OBJ ad, *adp;
     const unsigned int *op;
-
-    /* Make sure we've loaded config before checking for any "added" objects */
-    OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CONFIG, NULL);
+    int nid = NID_undef;
 
     o.ln = s;
+    op = OBJ_bsearch_ln(&oo, ln_objs, NUM_LN);
+    if (op != NULL)
+        return nid_objs[*op].nid;
+    if (!ossl_obj_read_lock(1)) {
+        ERR_raise(ERR_LIB_OBJ, ERR_R_UNABLE_TO_GET_READ_LOCK);
+        return NID_undef;
+    }
     if (added != NULL) {
         ad.type = ADDED_LNAME;
         ad.obj = &o;
         adp = lh_ADDED_OBJ_retrieve(added, &ad);
         if (adp != NULL)
-            return adp->obj->nid;
+            nid = adp->obj->nid;
     }
-    op = OBJ_bsearch_ln(&oo, ln_objs, NUM_LN);
-    if (op == NULL)
-        return NID_undef;
-    return nid_objs[*op].nid;
+    ossl_obj_unlock(1);
+    return nid;
 }
 
 int OBJ_sn2nid(const char *s)
@@ -583,22 +584,25 @@ int OBJ_sn2nid(const char *s)
     const ASN1_OBJECT *oo = &o;
     ADDED_OBJ ad, *adp;
     const unsigned int *op;
-
-    /* Make sure we've loaded config before checking for any "added" objects */
-    OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CONFIG, NULL);
+    int nid = NID_undef;
 
     o.sn = s;
+    op = OBJ_bsearch_sn(&oo, sn_objs, NUM_SN);
+    if (op != NULL)
+        return nid_objs[*op].nid;
+    if (!ossl_obj_read_lock(1)) {
+        ERR_raise(ERR_LIB_OBJ, ERR_R_UNABLE_TO_GET_READ_LOCK);
+        return NID_undef;
+    }
     if (added != NULL) {
         ad.type = ADDED_SNAME;
         ad.obj = &o;
         adp = lh_ADDED_OBJ_retrieve(added, &ad);
         if (adp != NULL)
-            return adp->obj->nid;
+            nid = adp->obj->nid;
     }
-    op = OBJ_bsearch_sn(&oo, sn_objs, NUM_SN);
-    if (op == NULL)
-        return NID_undef;
-    return nid_objs[*op].nid;
+    ossl_obj_unlock(1);
+    return nid;
 }
 
 const void *OBJ_bsearch_(const void *key, const void *base, int num, int size,
@@ -698,30 +702,36 @@ int OBJ_create(const char *oid, const char *sn, const char *ln)
     if ((sn != NULL && OBJ_sn2nid(sn) != NID_undef)
             || (ln != NULL && OBJ_ln2nid(ln) != NID_undef)) {
         ERR_raise(ERR_LIB_OBJ, OBJ_R_OID_EXISTS);
-        return 0;
+        goto err;
     }
 
     /* Convert numerical OID string to an ASN1_OBJECT structure */
     tmpoid = OBJ_txt2obj(oid, 1);
     if (tmpoid == NULL)
+        goto err;
+
+    if (!ossl_obj_write_lock(1)) {
+        ERR_raise(ERR_LIB_OBJ, ERR_R_UNABLE_TO_GET_WRITE_LOCK);
         return 0;
+    }
 
     /* If NID is not NID_undef then object already exists */
-    if (OBJ_obj2nid(tmpoid) != NID_undef) {
+    if (ossl_obj_obj2nid(tmpoid, 0) != NID_undef) {
         ERR_raise(ERR_LIB_OBJ, OBJ_R_OID_EXISTS);
         goto err;
     }
 
-    tmpoid->nid = OBJ_new_nid(1);
+    tmpoid->nid = ossl_obj_new_nid(1, 0);
     tmpoid->sn = (char *)sn;
     tmpoid->ln = (char *)ln;
 
-    ok = OBJ_add_object(tmpoid);
+    ok = ossl_obj_add_object(tmpoid, 0);
 
     tmpoid->sn = NULL;
     tmpoid->ln = NULL;
 
  err:
+    ossl_obj_unlock(1);
     ASN1_OBJECT_free(tmpoid);
     return ok;
 }
@@ -738,4 +748,19 @@ const unsigned char *OBJ_get0_data(const ASN1_OBJECT *obj)
     if (obj == NULL)
         return NULL;
     return obj->data;
+}
+
+int OBJ_new_nid(int num)
+{
+    return ossl_obj_new_nid(num, 1);
+}
+
+int OBJ_add_object(const ASN1_OBJECT *obj)
+{
+    return ossl_obj_add_object(obj, 1);
+}
+
+int OBJ_obj2nid(const ASN1_OBJECT *a)
+{
+    return ossl_obj_obj2nid(a, 1);
 }

--- a/crypto/objects/obj_xref.c
+++ b/crypto/objects/obj_xref.c
@@ -10,9 +10,11 @@
 #include <openssl/objects.h>
 #include "obj_xref.h"
 #include "internal/nelem.h"
+#include "internal/thread_once.h"
 #include <openssl/err.h>
 
 static STACK_OF(nid_triple) *sig_app, *sigx_app;
+static CRYPTO_RWLOCK *sig_lock;
 
 static int sig_cmp(const nid_triple *a, const nid_triple *b)
 {
@@ -32,62 +34,104 @@ DECLARE_OBJ_BSEARCH_CMP_FN(const nid_triple *, const nid_triple *, sigx);
 static int sigx_cmp(const nid_triple *const *a, const nid_triple *const *b)
 {
     int ret;
+
     ret = (*a)->hash_id - (*b)->hash_id;
-    if (ret)
+    if (ret != 0)
         return ret;
     return (*a)->pkey_id - (*b)->pkey_id;
 }
 
 IMPLEMENT_OBJ_BSEARCH_CMP_FN(const nid_triple *, const nid_triple *, sigx);
 
-int OBJ_find_sigid_algs(int signid, int *pdig_nid, int *ppkey_nid)
+static CRYPTO_ONCE sig_init = CRYPTO_ONCE_STATIC_INIT;
+
+DEFINE_RUN_ONCE_STATIC(o_sig_init)
+{
+    sig_lock = CRYPTO_THREAD_lock_new();
+    return sig_lock != NULL;
+}
+
+static ossl_inline int obj_sig_init(void)
+{
+    return RUN_ONCE(&sig_init, o_sig_init);
+}
+
+static int ossl_obj_find_sigid_algs(int signid, int *pdig_nid, int *ppkey_nid,
+                                    int lock)
 {
     nid_triple tmp;
-    const nid_triple *rv = NULL;
-    tmp.sign_id = signid;
+    const nid_triple *rv;
+    int idx;
 
-    if (sig_app != NULL) {
-        int idx = sk_nid_triple_find(sig_app, &tmp);
-        rv = sk_nid_triple_value(sig_app, idx);
-    }
-#ifndef OBJ_XREF_TEST2
-    if (rv == NULL) {
-        rv = OBJ_bsearch_sig(&tmp, sigoid_srt, OSSL_NELEM(sigoid_srt));
-    }
-#endif
-    if (rv == NULL)
+    if (signid == NID_undef)
         return 0;
-    if (pdig_nid)
+
+    tmp.sign_id = signid;
+    rv = OBJ_bsearch_sig(&tmp, sigoid_srt, OSSL_NELEM(sigoid_srt));
+    if (rv == NULL) {
+        if (!obj_sig_init())
+            return 0;
+        if (lock && !CRYPTO_THREAD_read_lock(sig_lock)) {
+            ERR_raise(ERR_LIB_OBJ, ERR_R_UNABLE_TO_GET_READ_LOCK);
+            return 0;
+        }
+        if (sig_app != NULL) {
+            idx = sk_nid_triple_find(sig_app, &tmp);
+            if (idx >= 0)
+                rv = sk_nid_triple_value(sig_app, idx);
+        }
+        if (lock)
+            CRYPTO_THREAD_unlock(sig_lock);
+        if (rv == NULL)
+            return 0;
+    }
+
+    if (pdig_nid != NULL)
         *pdig_nid = rv->hash_id;
-    if (ppkey_nid)
+    if (ppkey_nid != NULL)
         *ppkey_nid = rv->pkey_id;
     return 1;
+}
+
+int OBJ_find_sigid_algs(int signid, int *pdig_nid, int *ppkey_nid)
+{
+    return ossl_obj_find_sigid_algs(signid, pdig_nid, ppkey_nid, 1);
 }
 
 int OBJ_find_sigid_by_algs(int *psignid, int dig_nid, int pkey_nid)
 {
     nid_triple tmp;
     const nid_triple *t = &tmp;
-    const nid_triple **rv = NULL;
+    const nid_triple **rv;
+    int idx;
+
+    if (dig_nid == NID_undef || pkey_nid == NID_undef)
+        return 0;
 
     tmp.hash_id = dig_nid;
     tmp.pkey_id = pkey_nid;
 
-    if (sigx_app) {
-        int idx = sk_nid_triple_find(sigx_app, &tmp);
-        if (idx >= 0) {
-            t = sk_nid_triple_value(sigx_app, idx);
-            rv = &t;
-        }
-    }
-#ifndef OBJ_XREF_TEST2
+    rv = OBJ_bsearch_sigx(&t, sigoid_srt_xref, OSSL_NELEM(sigoid_srt_xref));
     if (rv == NULL) {
-        rv = OBJ_bsearch_sigx(&t, sigoid_srt_xref, OSSL_NELEM(sigoid_srt_xref));
+        if (!obj_sig_init())
+            return 0;
+        if (!CRYPTO_THREAD_read_lock(sig_lock)) {
+            ERR_raise(ERR_LIB_OBJ, ERR_R_UNABLE_TO_GET_READ_LOCK);
+            return 0;
+        }
+        if (sigx_app != NULL) {
+            idx = sk_nid_triple_find(sigx_app, &tmp);
+            if (idx >= 0) {
+                t = sk_nid_triple_value(sigx_app, idx);
+                rv = &t;
+            }
+        }
+        CRYPTO_THREAD_unlock(sig_lock);
+        if (rv == NULL)
+            return 0;
     }
-#endif
-    if (rv == NULL)
-        return 0;
-    if (psignid)
+
+    if (psignid != NULL)
         *psignid = (*rv)->sign_id;
     return 1;
 }
@@ -95,14 +139,14 @@ int OBJ_find_sigid_by_algs(int *psignid, int dig_nid, int pkey_nid)
 int OBJ_add_sigid(int signid, int dig_id, int pkey_id)
 {
     nid_triple *ntr;
-    if (sig_app == NULL)
-        sig_app = sk_nid_triple_new(sig_sk_cmp);
-    if (sig_app == NULL)
+    int dnid = NID_undef, pnid = NID_undef, ret = 0;
+
+    if (signid == NID_undef || dig_id == NID_undef || pkey_id == NID_undef)
         return 0;
-    if (sigx_app == NULL)
-        sigx_app = sk_nid_triple_new(sigx_cmp);
-    if (sigx_app == NULL)
+
+    if (!obj_sig_init())
         return 0;
+
     if ((ntr = OPENSSL_malloc(sizeof(*ntr))) == NULL) {
         ERR_raise(ERR_LIB_OBJ, ERR_R_MALLOC_FAILURE);
         return 0;
@@ -111,18 +155,49 @@ int OBJ_add_sigid(int signid, int dig_id, int pkey_id)
     ntr->hash_id = dig_id;
     ntr->pkey_id = pkey_id;
 
-    if (!sk_nid_triple_push(sig_app, ntr)) {
+    if (!CRYPTO_THREAD_write_lock(sig_lock)) {
+        ERR_raise(ERR_LIB_OBJ, ERR_R_UNABLE_TO_GET_WRITE_LOCK);
         OPENSSL_free(ntr);
         return 0;
     }
 
-    if (!sk_nid_triple_push(sigx_app, ntr))
-        return 0;
+    /* Check that the entry doesn't exist or exists as desired */
+    if (ossl_obj_find_sigid_algs(signid, &dnid, &pnid, 0)) {
+        ret = dnid == dig_id && pnid == pkey_id;
+        goto err;
+    }
+
+    if (sig_app == NULL) {
+        sig_app = sk_nid_triple_new(sig_sk_cmp);
+        if (sig_app == NULL)
+            goto err;
+    }
+    if (sigx_app == NULL) {
+        sigx_app = sk_nid_triple_new(sigx_cmp);
+        if (sigx_app == NULL)
+            goto err;
+    }
+
+    /*
+     * Better might be to find where to insert the element and insert it there.
+     * This would avoid the sorting steps below.
+     */
+    if (!sk_nid_triple_push(sig_app, ntr))
+        goto err;
+    if (!sk_nid_triple_push(sigx_app, ntr)) {
+        ntr = NULL;             /* This is referenced by sig_app still */
+        goto err;
+    }
 
     sk_nid_triple_sort(sig_app);
     sk_nid_triple_sort(sigx_app);
 
-    return 1;
+    ntr = NULL;
+    ret = 1;
+ err:
+    OPENSSL_free(ntr);
+    CRYPTO_THREAD_unlock(sig_lock);
+    return ret;
 }
 
 static void sid_free(nid_triple *tt)
@@ -133,7 +208,9 @@ static void sid_free(nid_triple *tt)
 void OBJ_sigid_free(void)
 {
     sk_nid_triple_pop_free(sig_app, sid_free);
-    sig_app = NULL;
     sk_nid_triple_free(sigx_app);
+    CRYPTO_THREAD_lock_free(sig_lock);
+    sig_app = NULL;
     sigx_app = NULL;
+    sig_lock = NULL;
 }

--- a/doc/man3/OBJ_nid2obj.pod
+++ b/doc/man3/OBJ_nid2obj.pod
@@ -139,6 +139,8 @@ These functions cannot return B<const> because an B<ASN1_OBJECT> can
 represent both an internal, constant, OID and a dynamically-created one.
 The latter cannot be constant because it needs to be freed after use.
 
+These functions were not thread safe in OpenSSL 3.0 and before.
+
 =head1 RETURN VALUES
 
 OBJ_nid2obj() returns an B<ASN1_OBJECT> structure or B<NULL> is an
@@ -180,10 +182,6 @@ to B<NULL> to determine the amount of data that should be written.
 Instead I<buf> must point to a valid buffer and I<buf_len> should
 be set to a positive value. A buffer length of 80 should be more
 than enough to handle any OID encountered in practice.
-
-Neither OBJ_create() nor OBJ_add_sigid() do any locking and are thus not
-thread safe.  Moreover, none of the other functions should be called while
-concurrent calls to these two functions are possible.
 
 =head1 SEE ALSO
 

--- a/doc/man7/openssl-threads.pod
+++ b/doc/man7/openssl-threads.pod
@@ -73,8 +73,8 @@ For implicit global state or singletons, thread-safety depends on the facility.
 The L<CRYPTO_secure_malloc(3)> and related API's have their own lock,
 while L<CRYPTO_malloc(3)> assumes the underlying platform allocation
 will do any necessary locking.
-Some API's, such as L<NCONF_load(3)> and related, or L<OBJ_create(3)>
-do no locking at all; this can be considered a bug.
+Some API's, such as L<NCONF_load(3)> and related do no locking at all;
+this can be considered a bug.
 
 A separate, although related, issue is modifying "factory" objects
 when other objects have been created from that.

--- a/doc/man7/provider-base.pod
+++ b/doc/man7/provider-base.pod
@@ -269,7 +269,6 @@ It will treat as success the case where the OID already exists (even if the
 short name I<sn> or long name I<ln> provided as arguments differ from those
 associated with the existing OID, in which case the new names are not
 associated).
-This function is not thread safe.
 
 The core_obj_add_sigid() function registers a new composite signature algorithm
 (I<sign_name>) consisting of an underlying signature algorithm (I<pkey_name>)
@@ -283,7 +282,6 @@ to identify the object. It will treat as success the case where the composite
 signature algorithm already exists (even if registered against a different
 underlying signature or digest algorithm). It returns 1 on success or 0 on
 failure.
-This function is not thread safe.
 
 CRYPTO_malloc(), CRYPTO_zalloc(), CRYPTO_memdup(), CRYPTO_strdup(),
 CRYPTO_strndup(), CRYPTO_free(), CRYPTO_clear_free(),
@@ -612,6 +610,11 @@ TLSv1.2 is 0x0303 (771 decimal). A 0 indicates that there is no defined minimum
 or maximum. A -1 indicates that the group should not be used in that protocol.
 
 =back
+
+=head1 NOTES
+
+The core_obj_create() and core_obj_add_sigid() functions were not thread safe
+in OpenSSL 3.0.
 
 =head1 EXAMPLES
 

--- a/include/internal/tsan_assist.h
+++ b/include/internal/tsan_assist.h
@@ -56,8 +56,7 @@
 #  define TSAN_QUALIFIER _Atomic
 #  define tsan_load(ptr) atomic_load_explicit((ptr), memory_order_relaxed)
 #  define tsan_store(ptr, val) atomic_store_explicit((ptr), (val), memory_order_relaxed)
-#  define tsan_counter(ptr) atomic_fetch_add_explicit((ptr), 1, memory_order_relaxed)
-#  define tsan_decr(ptr) atomic_fetch_add_explicit((ptr), -1, memory_order_relaxed)
+#  define tsan_add(ptr, n) atomic_fetch_add_explicit((ptr), (n), memory_order_relaxed)
 #  define tsan_ld_acq(ptr) atomic_load_explicit((ptr), memory_order_acquire)
 #  define tsan_st_rel(ptr, val) atomic_store_explicit((ptr), (val), memory_order_release)
 # endif
@@ -69,8 +68,7 @@
 #  define TSAN_QUALIFIER volatile
 #  define tsan_load(ptr) __atomic_load_n((ptr), __ATOMIC_RELAXED)
 #  define tsan_store(ptr, val) __atomic_store_n((ptr), (val), __ATOMIC_RELAXED)
-#  define tsan_counter(ptr) __atomic_fetch_add((ptr), 1, __ATOMIC_RELAXED)
-#  define tsan_decr(ptr) __atomic_fetch_add((ptr), -1, __ATOMIC_RELAXED)
+#  define tsan_add(ptr, n) __atomic_fetch_add((ptr), (n), __ATOMIC_RELAXED)
 #  define tsan_ld_acq(ptr) __atomic_load_n((ptr), __ATOMIC_ACQUIRE)
 #  define tsan_st_rel(ptr, val) __atomic_store_n((ptr), (val), __ATOMIC_RELEASE)
 # endif
@@ -113,13 +111,10 @@
 # pragma intrinsic(_InterlockedExchangeAdd)
 # ifdef _WIN64
 #  pragma intrinsic(_InterlockedExchangeAdd64)
-#  define tsan_counter(ptr) (sizeof(*(ptr)) == 8 ? _InterlockedExchangeAdd64((ptr), 1) \
-                                                 : _InterlockedExchangeAdd((ptr), 1))
-#  define tsan_decr(ptr) (sizeof(*(ptr)) == 8 ? _InterlockedExchangeAdd64((ptr), -1) \
-                                                 : _InterlockedExchangeAdd((ptr), -1))
+#  define tsan_add(ptr, n) (sizeof(*(ptr)) == 8 ? _InterlockedExchangeAdd64((ptr), (n)) \
+                                                : _InterlockedExchangeAdd((ptr), (n)))
 # else
-#  define tsan_counter(ptr) _InterlockedExchangeAdd((ptr), 1)
-#  define tsan_decr(ptr) _InterlockedExchangeAdd((ptr), -1)
+#  define tsan_add(ptr, n) _InterlockedExchangeAdd((ptr), (n))
 # endif
 # if !defined(_ISO_VOLATILE)
 #  define tsan_ld_acq(ptr) (*(ptr))
@@ -133,8 +128,7 @@
 # define TSAN_QUALIFIER volatile
 # define tsan_load(ptr) (*(ptr))
 # define tsan_store(ptr, val) (*(ptr) = (val))
-# define tsan_counter(ptr) ((*(ptr))++)
-# define tsan_decr(ptr) ((*(ptr))--)
+# define tsan_add(ptr, n) (*(ptr) += (n))
 /*
  * Lack of tsan_ld_acq and tsan_ld_rel means that compiler support is not
  * sophisticated enough to support them. Code that relies on them should be
@@ -142,3 +136,7 @@
  */
 
 #endif
+
+#define tsan_counter(ptr) tsan_add((ptr), 1)
+#define tsan_decr(ptr) tsan_add((ptr), -1)
+


### PR DESCRIPTION
This is done using a single global lock.  The premise for this is that new objects will most frequently be added at start up and never added subsequently.  Thus, the locking will be for read most of the time.

This does, however, introduce the overhead of taking an uncontested read lock when accessing the object database.

An amount of refactoring was also done to make the conversion easier and to simplify the code.

Fixes #15674


- [x] documentation is added or updated
- [ ] tests are added or updated
