### PR TITLE
Do not duplicate symbols between libcrypto and libssl in static builds

### DIFF
--- a/ssl/build.info
+++ b/ssl/build.info
@@ -15,12 +15,8 @@ IF[{- !$disabled{ktls} -}]
   $KTLSSRC=ktls.c
 ENDIF
 
-# For now we just include the libcrypto packet.c in libssl as well. We
-# could either continue to do it like this, or export all the WPACKET
-# symbols so that libssl can use them like any other. Probably would do
-# this privately so it does not become part of the public API.
 SOURCE[../libssl]=\
-        pqueue.c ../crypto/packet.c \
+        pqueue.c \
         statem/statem_srvr.c statem/statem_clnt.c  s3_lib.c  s3_enc.c record/rec_layer_s3.c \
         statem/statem_lib.c statem/extensions.c statem/extensions_srvr.c \
         statem/extensions_clnt.c statem/extensions_cust.c s3_msg.c \
@@ -32,11 +28,23 @@ SOURCE[../libssl]=\
         ssl_asn1.c ssl_txt.c ssl_init.c ssl_conf.c  ssl_mcnf.c \
         bio_ssl.c ssl_err.c ssl_err_legacy.c tls_srp.c t1_trce.c ssl_utst.c \
         record/ssl3_buffer.c record/ssl3_record.c record/dtls1_bitmap.c \
-        statem/statem.c record/ssl3_record_tls13.c record/tls_pad.c \
+        statem/statem.c record/ssl3_record_tls13.c \
         tls_depr.c $KTLSSRC
 IF[{- !$disabled{'deprecated-3.0'} -}]
-  SOURCE[../libssl]=s3_cbc.c  ssl_rsa_legacy.c
+  SOURCE[../libssl]=ssl_rsa_legacy.c
 ENDIF
+# For shared builds we need to include the libcrypto packet.c and sources
+# needed in providers (s3_cbc.c and record/tls_pad.c) in libssl as well.
+# We can either continue to do it like this, or export all the used
+# symbols so that libssl can use them like any other. Probably would do
+# this privately so it does not become part of the public API.
+IF[{- !$disabled{shared} -}]
+  SOURCE[../libssl]=record/tls_pad.c ../crypto/packet.c
+ENDIF
+IF[{- !$disabled{'deprecated-3.0'} && !$disabled{shared} -}]
+  SOURCE[../libssl]=s3_cbc.c
+ENDIF
+
 DEFINE[../libssl]=$AESDEF
 
 SOURCE[../providers/libcommon.a]=record/tls_pad.c

--- a/ssl/build.info
+++ b/ssl/build.info
@@ -36,8 +36,7 @@ ENDIF
 # For shared builds we need to include the libcrypto packet.c and sources
 # needed in providers (s3_cbc.c and record/tls_pad.c) in libssl as well.
 # We can either continue to do it like this, or export all the used
-# symbols so that libssl can use them like any other. Probably would do
-# this privately so it does not become part of the public API.
+# symbols so that libssl can use them like any other.
 IF[{- !$disabled{shared} -}]
   SOURCE[../libssl]=record/tls_pad.c ../crypto/packet.c
 ENDIF

--- a/ssl/build.info
+++ b/ssl/build.info
@@ -30,18 +30,12 @@ SOURCE[../libssl]=\
         record/ssl3_buffer.c record/ssl3_record.c record/dtls1_bitmap.c \
         statem/statem.c record/ssl3_record_tls13.c \
         tls_depr.c $KTLSSRC
-IF[{- !$disabled{'deprecated-3.0'} -}]
-  SOURCE[../libssl]=ssl_rsa_legacy.c
-ENDIF
 # For shared builds we need to include the libcrypto packet.c and sources
 # needed in providers (s3_cbc.c and record/tls_pad.c) in libssl as well.
-# We can either continue to do it like this, or export all the used
-# symbols so that libssl can use them like any other.
-IF[{- !$disabled{shared} -}]
-  SOURCE[../libssl]=record/tls_pad.c ../crypto/packet.c
-ENDIF
-IF[{- !$disabled{'deprecated-3.0'} && !$disabled{shared} -}]
-  SOURCE[../libssl]=s3_cbc.c
+SHARED_SOURCE[../libssl]=record/tls_pad.c ../crypto/packet.c
+IF[{- !$disabled{'deprecated-3.0'} -}]
+  SHARED_SOURCE[../libssl]=s3_cbc.c
+  SOURCE[../libssl]=ssl_rsa_legacy.c
 ENDIF
 
 DEFINE[../libssl]=$AESDEF

--- a/test/build.info
+++ b/test/build.info
@@ -624,7 +624,7 @@ IF[{- !$disabled{tests} -}]
 
     SOURCE[tls13encryptiontest]=tls13encryptiontest.c
     INCLUDE[tls13encryptiontest]=.. ../include ../apps/include
-    DEPEND[tls13encryptiontest]=../libcrypto ../libssl.a libtestutil.a
+    DEPEND[tls13encryptiontest]=../libcrypto.a ../libssl.a libtestutil.a
 
     SOURCE[ideatest]=ideatest.c
     INCLUDE[ideatest]=../include ../apps/include
@@ -632,7 +632,7 @@ IF[{- !$disabled{tests} -}]
 
     SOURCE[wpackettest]=wpackettest.c
     INCLUDE[wpackettest]=../include ../apps/include
-    DEPEND[wpackettest]=../libcrypto ../libssl.a libtestutil.a
+    DEPEND[wpackettest]=../libcrypto.a ../libssl.a libtestutil.a
 
     SOURCE[property_test]=property_test.c
     INCLUDE[property_test]=.. ../include ../apps/include


### PR DESCRIPTION
Followup to #15704 
This otherwise breaks linking applications to static libssl on some platforms.