### PR TITLE
Building: Add necessary dependencies for linker scripts and .rc files

### DIFF
--- a/build.info
+++ b/build.info
@@ -77,11 +77,13 @@ IF[{- defined $target{shared_defflag} -}]
 
   GENERATE[libcrypto.ld]=util/libcrypto.num libcrypto
   GENERATE[libssl.ld]=util/libssl.num libssl
+  DEPEND[libcrypto.ld libssl.ld]=configdata.pm util/perl/OpenSSL/Ordinals.pm
 ENDIF
 
 IF[{- $config{target} =~ /^(?:Cygwin|mingw|VC-|BC-)/ -}]
   GENERATE[libcrypto.rc]=util/mkrc.pl libcrypto
   GENERATE[libssl.rc]=util/mkrc.pl libssl
+  DEPEND[libcrypto.rc libssl.rc]=configdata.pm
 
   SHARED_SOURCE[libcrypto]=libcrypto.rc
   SHARED_SOURCE[libssl]=libssl.rc


### PR DESCRIPTION
These files depend on the data from configdata.pm, so need a dependency
on that one to always be properly updated.  The same goes for .rc files.
