### PR TITLE
APPS: Remove an unreachable statement in s_client.c

### DIFF
--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -2991,7 +2991,6 @@ int s_client_main(int argc, char **argv)
         }
     }
 
-    ret = 0;
  shut:
     if (in_init)
         print_stuff(bio_c_out, con, full_log);


### PR DESCRIPTION
A Solaris compiler complains:

    "apps/s_client.c", line 2994: statement not reached

It takes a bit of scrutiny to see that this is true, on all platforms.
