### PR TITLE
CORE: Move away the allocation of the temporary no_cache method store

### DIFF
--- a/crypto/core_fetch.c
+++ b/crypto/core_fetch.c
@@ -83,18 +83,24 @@ static void ossl_method_construct_this(OSSL_PROVIDER *provider,
      */
 
     if (data->force_store || !no_store) {
-        /*
-         * If we haven't been told not to store,
-         * add to the global store
-         */
+        /* If we haven't been told not to store, add to the global store */
         data->mcm->put(data->libctx, NULL, method, provider,
                        data->operation_id, algo->algorithm_names,
                        algo->property_definition, data->mcm_data);
-    }
+    } else {
+        /*
+         * If we have been told not to store the method "permanently", we
+         * ask for a temporary store, and store the method there.
+         * The owner of |data->mcm| is completely responsible for managing
+         * that temporary store.
+         */
+        if ((data->store = data->mcm->get_tmp_store(data->mcm_data)) == NULL)
+            return;
 
-    data->mcm->put(data->libctx, data->store, method, provider,
-                   data->operation_id, algo->algorithm_names,
-                   algo->property_definition, data->mcm_data);
+        data->mcm->put(data->libctx, data->store, method, provider,
+                       data->operation_id, algo->algorithm_names,
+                       algo->property_definition, data->mcm_data);
+    }
 
     /* refcnt-- because we're dropping the reference */
     data->mcm->destruct(method, data->mcm_data);
@@ -109,13 +115,6 @@ void *ossl_method_construct(OSSL_LIB_CTX *libctx, int operation_id,
     if ((method = mcm->get(libctx, NULL, mcm_data)) == NULL) {
         struct construct_data_st cbdata;
 
-        /*
-         * We have a temporary store to be able to easily search among new
-         * items, or items that should find themselves in the global store.
-         */
-        if ((cbdata.store = mcm->alloc_tmp_store(libctx)) == NULL)
-            goto fin;
-
         cbdata.libctx = libctx;
         cbdata.operation_id = operation_id;
         cbdata.force_store = force_store;
@@ -127,20 +126,14 @@ void *ossl_method_construct(OSSL_LIB_CTX *libctx, int operation_id,
                               ossl_method_construct_postcondition,
                               &cbdata);
 
-        method = mcm->get(libctx, cbdata.store, mcm_data);
-        if (method == NULL) {
-            /*
-             * If we get here then we did not construct the method that we
-             * attempted to construct. It's possible that another thread got
-             * there first and so we skipped construction (pre-condition
-             * failed). We check the global store again to see if it has
-             * appeared by now.
-             */
+        /* If there is a temporary store, try there first */
+        if (cbdata.store != NULL)
+            method = mcm->get(libctx, cbdata.store, mcm_data);
+
+        /* If no method was found yet, try the global store */
+        if (method == NULL)
             method = mcm->get(libctx, NULL, mcm_data);
-        }
-        mcm->dealloc_tmp_store(cbdata.store);
     }
 
- fin:
     return method;
 }

--- a/crypto/core_fetch.c
+++ b/crypto/core_fetch.c
@@ -116,6 +116,7 @@ void *ossl_method_construct(OSSL_LIB_CTX *libctx, int operation_id,
         struct construct_data_st cbdata;
 
         cbdata.libctx = libctx;
+        cbdata.store = NULL;
         cbdata.operation_id = operation_id;
         cbdata.force_store = force_store;
         cbdata.mcm = mcm;

--- a/crypto/encode_decode/decoder_meth.c
+++ b/crypto/encode_decode/decoder_meth.c
@@ -91,6 +91,8 @@ struct decoder_data_st {
     const char *names;           /* For get_decoder_from_store() */
     const char *propquery;       /* For get_decoder_from_store() */
 
+    OSSL_METHOD_STORE *tmp_store; /* For get_tmp_decoder_store() */
+
     unsigned int flag_construct_error_occurred : 1;
 };
 
@@ -100,9 +102,13 @@ struct decoder_data_st {
  */
 
 /* Temporary decoder method store, constructor and destructor */
-static void *alloc_tmp_decoder_store(OSSL_LIB_CTX *ctx)
+static void *get_tmp_decoder_store(void *data)
 {
-    return ossl_method_store_new(ctx);
+    struct decoder_data_st *methdata = data;
+
+    if (methdata->tmp_store == NULL)
+        methdata->tmp_store = ossl_method_store_new(methdata->libctx);
+    return methdata->tmp_store;
 }
 
 static void dealloc_tmp_decoder_store(void *store)
@@ -300,12 +306,12 @@ static void free_decoder(void *method)
 }
 
 /* Fetching support.  Can fetch by numeric identity or by name */
-static OSSL_DECODER *inner_ossl_decoder_fetch(OSSL_LIB_CTX *libctx, int id,
-                                              const char *name,
-                                              const char *properties)
+static OSSL_DECODER *
+inner_ossl_decoder_fetch(struct decoder_data_st *methdata, int id,
+                         const char *name, const char *properties)
 {
-    OSSL_METHOD_STORE *store = get_decoder_store(libctx);
-    OSSL_NAMEMAP *namemap = ossl_namemap_stored(libctx);
+    OSSL_METHOD_STORE *store = get_decoder_store(methdata->libctx);
+    OSSL_NAMEMAP *namemap = ossl_namemap_stored(methdata->libctx);
     void *method = NULL;
     int unsupported = 0;
 
@@ -336,24 +342,21 @@ static OSSL_DECODER *inner_ossl_decoder_fetch(OSSL_LIB_CTX *libctx, int id,
     if (id == 0
         || !ossl_method_store_cache_get(store, id, properties, &method)) {
         OSSL_METHOD_CONSTRUCT_METHOD mcm = {
-            alloc_tmp_decoder_store,
-            dealloc_tmp_decoder_store,
+            get_tmp_decoder_store,
             get_decoder_from_store,
             put_decoder_in_store,
             construct_decoder,
             destruct_decoder
         };
-        struct decoder_data_st mcmdata;
 
-        mcmdata.libctx = libctx;
-        mcmdata.mcm = &mcm;
-        mcmdata.id = id;
-        mcmdata.names = name;
-        mcmdata.propquery = properties;
-        mcmdata.flag_construct_error_occurred = 0;
-        if ((method = ossl_method_construct(libctx, OSSL_OP_DECODER,
+        methdata->mcm = &mcm;
+        methdata->id = id;
+        methdata->names = name;
+        methdata->propquery = properties;
+        methdata->flag_construct_error_occurred = 0;
+        if ((method = ossl_method_construct(methdata->libctx, OSSL_OP_DECODER,
                                             0 /* !force_cache */,
-                                            &mcm, &mcmdata)) != NULL) {
+                                            &mcm, methdata)) != NULL) {
             /*
              * If construction did create a method for us, we know that
              * there is a correct name_id and meth_id, since those have
@@ -370,7 +373,7 @@ static OSSL_DECODER *inner_ossl_decoder_fetch(OSSL_LIB_CTX *libctx, int id,
          * If we never were in the constructor, the algorithm to be fetched
          * is unsupported.
          */
-        unsupported = !mcmdata.flag_construct_error_occurred;
+        unsupported = !methdata->flag_construct_error_occurred;
     }
 
     if (method == NULL) {
@@ -380,7 +383,7 @@ static OSSL_DECODER *inner_ossl_decoder_fetch(OSSL_LIB_CTX *libctx, int id,
             name = ossl_namemap_num2name(namemap, id, 0);
         ERR_raise_data(ERR_LIB_OSSL_DECODER, code,
                        "%s, Name (%s : %d), Properties (%s)",
-                       ossl_lib_ctx_get_descriptor(libctx),
+                       ossl_lib_ctx_get_descriptor(methdata->libctx),
                        name = NULL ? "<null>" : name, id,
                        properties == NULL ? "<null>" : properties);
     }
@@ -391,13 +394,27 @@ static OSSL_DECODER *inner_ossl_decoder_fetch(OSSL_LIB_CTX *libctx, int id,
 OSSL_DECODER *OSSL_DECODER_fetch(OSSL_LIB_CTX *libctx, const char *name,
                                  const char *properties)
 {
-    return inner_ossl_decoder_fetch(libctx, 0, name, properties);
+    struct decoder_data_st methdata;
+    void *method;
+
+    methdata.libctx = libctx;
+    methdata.tmp_store = NULL;
+    method = inner_ossl_decoder_fetch(&methdata, 0, name, properties);
+    dealloc_tmp_decoder_store(methdata.tmp_store);
+    return method;
 }
 
 OSSL_DECODER *ossl_decoder_fetch_by_number(OSSL_LIB_CTX *libctx, int id,
                                            const char *properties)
 {
-    return inner_ossl_decoder_fetch(libctx, id, NULL, properties);
+    struct decoder_data_st methdata;
+    void *method;
+
+    methdata.libctx = libctx;
+    methdata.tmp_store = NULL;
+    method = inner_ossl_decoder_fetch(&methdata, id, NULL, properties);
+    dealloc_tmp_decoder_store(methdata.tmp_store);
+    return method;
 }
 
 /*

--- a/crypto/store/store_meth.c
+++ b/crypto/store/store_meth.c
@@ -94,6 +94,8 @@ struct loader_data_st {
     const char *scheme;          /* For get_loader_from_store() */
     const char *propquery;       /* For get_loader_from_store() */
 
+    OSSL_METHOD_STORE *tmp_store; /* For get_tmp_encoder_store() */
+
     unsigned int flag_construct_error_occurred : 1;
 };
 
@@ -103,9 +105,13 @@ struct loader_data_st {
  */
 
 /* Temporary loader method store, constructor and destructor */
-static void *alloc_tmp_loader_store(OSSL_LIB_CTX *ctx)
+static void *get_tmp_loader_store(void *data)
 {
-    return ossl_method_store_new(ctx);
+    struct loader_data_st *methdata = data;
+
+    if (methdata->tmp_store == NULL)
+        methdata->tmp_store = ossl_method_store_new(methdata->libctx);
+    return methdata->tmp_store;
 }
 
  static void dealloc_tmp_loader_store(void *store)
@@ -267,12 +273,12 @@ static void destruct_loader(void *method, void *data)
 }
 
 /* Fetching support.  Can fetch by numeric identity or by scheme */
-static OSSL_STORE_LOADER *inner_loader_fetch(OSSL_LIB_CTX *libctx,
-                                             int id, const char *scheme,
-                                             const char *properties)
+static OSSL_STORE_LOADER *
+inner_loader_fetch(struct loader_data_st *methdata, int id,
+                   const char *scheme, const char *properties)
 {
-    OSSL_METHOD_STORE *store = get_loader_store(libctx);
-    OSSL_NAMEMAP *namemap = ossl_namemap_stored(libctx);
+    OSSL_METHOD_STORE *store = get_loader_store(methdata->libctx);
+    OSSL_NAMEMAP *namemap = ossl_namemap_stored(methdata->libctx);
     void *method = NULL;
     int unsupported = 0;
 
@@ -304,24 +310,21 @@ static OSSL_STORE_LOADER *inner_loader_fetch(OSSL_LIB_CTX *libctx,
     if (id == 0
         || !ossl_method_store_cache_get(store, id, properties, &method)) {
         OSSL_METHOD_CONSTRUCT_METHOD mcm = {
-            alloc_tmp_loader_store,
-            dealloc_tmp_loader_store,
+            get_tmp_loader_store,
             get_loader_from_store,
             put_loader_in_store,
             construct_loader,
             destruct_loader
         };
-        struct loader_data_st mcmdata;
 
-        mcmdata.libctx = libctx;
-        mcmdata.mcm = &mcm;
-        mcmdata.scheme_id = id;
-        mcmdata.scheme = scheme;
-        mcmdata.propquery = properties;
-        mcmdata.flag_construct_error_occurred = 0;
-        if ((method = ossl_method_construct(libctx, OSSL_OP_STORE,
+        methdata->mcm = &mcm;
+        methdata->scheme_id = id;
+        methdata->scheme = scheme;
+        methdata->propquery = properties;
+        methdata->flag_construct_error_occurred = 0;
+        if ((method = ossl_method_construct(methdata->libctx, OSSL_OP_STORE,
                                             0 /* !force_cache */,
-                                            &mcm, &mcmdata)) != NULL) {
+                                            &mcm, methdata)) != NULL) {
             /*
              * If construction did create a method for us, we know that there
              * is a correct scheme_id, since those have already been calculated
@@ -337,7 +340,7 @@ static OSSL_STORE_LOADER *inner_loader_fetch(OSSL_LIB_CTX *libctx,
          * If we never were in the constructor, the algorithm to be fetched
          * is unsupported.
          */
-        unsupported = !mcmdata.flag_construct_error_occurred;
+        unsupported = !methdata->flag_construct_error_occurred;
     }
 
     if (method == NULL) {
@@ -347,7 +350,7 @@ static OSSL_STORE_LOADER *inner_loader_fetch(OSSL_LIB_CTX *libctx,
             scheme = ossl_namemap_num2name(namemap, id, 0);
         ERR_raise_data(ERR_LIB_OSSL_STORE, code,
                        "%s, Scheme (%s : %d), Properties (%s)",
-                       ossl_lib_ctx_get_descriptor(libctx),
+                       ossl_lib_ctx_get_descriptor(methdata->libctx),
                        scheme = NULL ? "<null>" : scheme, id,
                        properties == NULL ? "<null>" : properties);
     }
@@ -359,14 +362,28 @@ OSSL_STORE_LOADER *OSSL_STORE_LOADER_fetch(OSSL_LIB_CTX *libctx,
                                            const char *scheme,
                                            const char *properties)
 {
-    return inner_loader_fetch(libctx, 0, scheme, properties);
+    struct loader_data_st methdata;
+    void *method;
+
+    methdata.libctx = libctx;
+    methdata.tmp_store = NULL;
+    method = inner_loader_fetch(&methdata, 0, scheme, properties);
+    dealloc_tmp_loader_store(methdata.tmp_store);
+    return method;
 }
 
 OSSL_STORE_LOADER *ossl_store_loader_fetch_by_number(OSSL_LIB_CTX *libctx,
                                                      int scheme_id,
                                                      const char *properties)
 {
-    return inner_loader_fetch(libctx, scheme_id, NULL, properties);
+    struct loader_data_st methdata;
+    void *method;
+
+    methdata.libctx = libctx;
+    methdata.tmp_store = NULL;
+    method = inner_loader_fetch(&methdata, scheme_id, NULL, properties);
+    dealloc_tmp_loader_store(methdata.tmp_store);
+    return method;
 }
 
 /*

--- a/crypto/store/store_meth.c
+++ b/crypto/store/store_meth.c
@@ -94,7 +94,7 @@ struct loader_data_st {
     const char *scheme;          /* For get_loader_from_store() */
     const char *propquery;       /* For get_loader_from_store() */
 
-    OSSL_METHOD_STORE *tmp_store; /* For get_tmp_encoder_store() */
+    OSSL_METHOD_STORE *tmp_store; /* For get_tmp_loader_store() */
 
     unsigned int flag_construct_error_occurred : 1;
 };

--- a/include/internal/core.h
+++ b/include/internal/core.h
@@ -28,10 +28,8 @@
  * says (for example, because the application knows better).
  */
 typedef struct ossl_method_construct_method_st {
-    /* Create store */
-    void *(*alloc_tmp_store)(OSSL_LIB_CTX *ctx);
-    /* Remove a store */
-    void (*dealloc_tmp_store)(void *store);
+    /* Get a temporary store */
+    void *(*get_tmp_store)(void *data);
     /* Get an already existing method from a store */
     void *(*get)(OSSL_LIB_CTX *libctx, void *store, void *data);
     /* Store a method in a store */


### PR DESCRIPTION
The responsibility for managine the temporary store for methods from
algorithm implementations flaged "no_store" is moved up to the diverse
method fetching functions.  This allows them to allocate it "just in
time", or in other words not at all if there is not such algorithm
implementation.

This makes this temporary store more flexible if it's needed outside
of the core fetching functionality, and slightly faster when this
temporary store isn't necessary at all.
