### PR TITLE
s_server: make -rev option easier to find (mention echo)

### DIFF
--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -857,7 +857,7 @@ const OPTIONS s_server_options[] = {
     {"brief", OPT_BRIEF, '-',
      "Restrict output to brief summary of connection parameters"},
     {"rev", OPT_REV, '-',
-     "act as a simple test server which just sends back with the received text reversed"},
+     "act as an echo server that sends back received text reversed"},
     {"debug", OPT_DEBUG, '-', "Print more output"},
     {"msg", OPT_MSG, '-', "Show protocol messages"},
     {"msgfile", OPT_MSGFILE, '>',

--- a/doc/man1/openssl-s_server.pod.in
+++ b/doc/man1/openssl-s_server.pod.in
@@ -545,9 +545,8 @@ output.
 
 =item B<-rev>
 
-Simple test server which just reverses the text received from the client
-and sends it back to the server. Also sets B<-brief>. Cannot be used in
-conjunction with B<-early_data>.
+Simple echo server that sends back received text reversed. Also sets B<-brief>.
+Cannot be used in conjunction with B<-early_data>.
 
 =item B<-async>
 


### PR DESCRIPTION
Since the service is echo-like (see TCP port 7 from RFC 862 or
gnutls-serv --echo), make it easier to find by mentioning "echo" in
the description of it in the help message an man page

Also fixes the man page inconsistency ("sends it back to the server")

fixes #15736 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
