### PR TITLE
 Clean up the encoder/decoder/loader stores before providers

### DIFF
--- a/crypto/encode_decode/decoder_meth.c
+++ b/crypto/encode_decode/decoder_meth.c
@@ -78,7 +78,8 @@ static void *decoder_store_new(OSSL_LIB_CTX *ctx)
 
 
 static const OSSL_LIB_CTX_METHOD decoder_store_method = {
-    OSSL_LIB_CTX_METHOD_DEFAULT_PRIORITY,
+    /* We want decoder_store to be cleaned up before the provider store */
+    OSSL_LIB_CTX_METHOD_PRIORITY_2,
     decoder_store_new,
     decoder_store_free,
 };

--- a/crypto/encode_decode/encoder_meth.c
+++ b/crypto/encode_decode/encoder_meth.c
@@ -78,7 +78,8 @@ static void *encoder_store_new(OSSL_LIB_CTX *ctx)
 
 
 static const OSSL_LIB_CTX_METHOD encoder_store_method = {
-    OSSL_LIB_CTX_METHOD_DEFAULT_PRIORITY,
+    /* We want encoder_store to be cleaned up before the provider store */
+    OSSL_LIB_CTX_METHOD_PRIORITY_2,
     encoder_store_new,
     encoder_store_free,
 };

--- a/crypto/store/store_meth.c
+++ b/crypto/store/store_meth.c
@@ -81,7 +81,8 @@ static void *loader_store_new(OSSL_LIB_CTX *ctx)
 
 
 static const OSSL_LIB_CTX_METHOD loader_store_method = {
-    OSSL_LIB_CTX_METHOD_DEFAULT_PRIORITY,
+    /* We want loader_store to be cleaned up before the provider store */
+    OSSL_LIB_CTX_METHOD_PRIORITY_2,
     loader_store_new,
     loader_store_free,
 };

--- a/test/build.info
+++ b/test/build.info
@@ -56,7 +56,7 @@ IF[{- !$disabled{tests} -}]
           sysdefaulttest errtest ssl_ctx_test gosttest \
           context_internal_test aesgcmtest params_test evp_pkey_dparams_test \
           keymgmt_internal_test hexstr_test provider_status_test defltfips_test \
-          bio_readbuffer_test user_property_test pkcs7_test
+          bio_readbuffer_test user_property_test pkcs7_test provfetchtest
 
   IF[{- !$disabled{'deprecated-3.0'} -}]
     PROGRAMS{noinst}=enginetest
@@ -162,6 +162,10 @@ IF[{- !$disabled{tests} -}]
   IF[{- $disabled{fips} || !$target{dso_scheme} -}]
     DEFINE[evp_extra_test]=NO_FIPS_MODULE
   ENDIF
+
+  SOURCE[provfetchtest]=provfetchtest.c
+  INCLUDE[provfetchtest]=../include ../apps/include
+  DEPEND[provfetchtest]=../libcrypto.a libtestutil.a
 
   SOURCE[evp_pkey_provided_test]=evp_pkey_provided_test.c
   INCLUDE[evp_pkey_provided_test]=../include ../apps/include

--- a/test/provfetchtest.c
+++ b/test/provfetchtest.c
@@ -32,9 +32,9 @@ static const OSSL_ALGORITHM dummy_decoders[] = {
 };
 
 static int dummy_encoder_encode(void *ctx, OSSL_CORE_BIO *out,
-                     const void *obj_raw, const OSSL_PARAM obj_abstract[],
-                     int selection,
-                     OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
+                                const void *obj_raw,
+                                const OSSL_PARAM obj_abstract[], int selection,
+                                OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
 {
     return 0;
 }
@@ -54,9 +54,9 @@ static void *dummy_store_open(void *provctx, const char *uri)
     return NULL;
 }
 
-static int dummy_store_load(void *loaderctx,
-                     OSSL_CALLBACK *object_cb, void *object_cbarg,
-                     OSSL_PASSPHRASE_CALLBACK *pw_cb, void *pw_cbarg)
+static int dummy_store_load(void *loaderctx,  OSSL_CALLBACK *object_cb,
+                            void *object_cbarg, OSSL_PASSPHRASE_CALLBACK *pw_cb,
+                            void *pw_cbarg)
 {
     return 0;
 }
@@ -79,14 +79,13 @@ static const OSSL_DISPATCH dummy_store_functions[] = {
     { 0, NULL }
 };
 
-static const OSSL_ALGORITHM dummy_store[] = {                         \
+static const OSSL_ALGORITHM dummy_store[] = {
     { "DUMMY", "provider=dummy", dummy_store_functions },
     { NULL, NULL, NULL }
-#undef STORE
 };
 
 static const OSSL_ALGORITHM *dummy_query(void *provctx, int operation_id,
-                                       int *no_cache)
+                                         int *no_cache)
 {
     *no_cache = 0;
     switch (operation_id) {

--- a/test/provfetchtest.c
+++ b/test/provfetchtest.c
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2021 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <openssl/crypto.h>
+#include <openssl/provider.h>
+#include <openssl/decoder.h>
+#include <openssl/encoder.h>
+#include <openssl/store.h>
+#include "testutil.h"
+
+static int dummy_decoder_decode(void *ctx, OSSL_CORE_BIO *cin, int selection,
+                                OSSL_CALLBACK *object_cb, void *object_cbarg,
+                                OSSL_PASSPHRASE_CALLBACK *pw_cb, void *pw_cbarg)
+{
+    return 0;
+}
+
+static const OSSL_DISPATCH dummy_decoder_functions[] = {
+    { OSSL_FUNC_DECODER_DECODE, (void (*)(void))dummy_decoder_decode },
+    { 0, NULL }
+};
+
+static const OSSL_ALGORITHM dummy_decoders[] = {
+    { "DUMMY", "provider=dummy,input=pem", dummy_decoder_functions },
+    { NULL, NULL, NULL }
+};
+
+static int dummy_encoder_encode(void *ctx, OSSL_CORE_BIO *out,
+                     const void *obj_raw, const OSSL_PARAM obj_abstract[],
+                     int selection,
+                     OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg)
+{
+    return 0;
+}
+
+static const OSSL_DISPATCH dummy_encoder_functions[] = {
+    { OSSL_FUNC_DECODER_DECODE, (void (*)(void))dummy_encoder_encode },
+    { 0, NULL }
+};
+
+static const OSSL_ALGORITHM dummy_encoders[] = {
+    { "DUMMY", "provider=dummy,output=pem", dummy_encoder_functions },
+    { NULL, NULL, NULL }
+};
+
+static void *dummy_store_open(void *provctx, const char *uri)
+{
+    return NULL;
+}
+
+static int dummy_store_load(void *loaderctx,
+                     OSSL_CALLBACK *object_cb, void *object_cbarg,
+                     OSSL_PASSPHRASE_CALLBACK *pw_cb, void *pw_cbarg)
+{
+    return 0;
+}
+
+static int dumm_store_eof(void *loaderctx)
+{
+    return 0;
+}
+
+static int dummy_store_close(void *loaderctx)
+{
+    return 0;
+}
+
+static const OSSL_DISPATCH dummy_store_functions[] = {
+    { OSSL_FUNC_STORE_OPEN, (void (*)(void))dummy_store_open },
+    { OSSL_FUNC_STORE_LOAD, (void (*)(void))dummy_store_load },
+    { OSSL_FUNC_STORE_EOF, (void (*)(void))dumm_store_eof },
+    { OSSL_FUNC_STORE_CLOSE, (void (*)(void))dummy_store_close },
+    { 0, NULL }
+};
+
+static const OSSL_ALGORITHM dummy_store[] = {                         \
+    { "DUMMY", "provider=dummy", dummy_store_functions },
+    { NULL, NULL, NULL }
+#undef STORE
+};
+
+static const OSSL_ALGORITHM *dummy_query(void *provctx, int operation_id,
+                                       int *no_cache)
+{
+    *no_cache = 0;
+    switch (operation_id) {
+    case OSSL_OP_DECODER:
+        return dummy_decoders;
+    case OSSL_OP_ENCODER:
+        return dummy_encoders;
+    case OSSL_OP_STORE:
+        return dummy_store;
+    }
+    return NULL;
+}
+
+static const OSSL_DISPATCH dummy_dispatch_table[] = {
+    { OSSL_FUNC_PROVIDER_QUERY_OPERATION, (void (*)(void))dummy_query },
+    { OSSL_FUNC_PROVIDER_TEARDOWN, (void (*)(void))OSSL_LIB_CTX_free },
+    { 0, NULL }
+};
+
+static int dummy_provider_init(const OSSL_CORE_HANDLE *handle,
+                               const OSSL_DISPATCH *in,
+                               const OSSL_DISPATCH **out,
+                               void **provctx)
+{
+    OSSL_LIB_CTX *libctx = OSSL_LIB_CTX_new_child(handle, in);
+
+    *provctx = (void *)libctx;
+    *out = dummy_dispatch_table;
+
+    return 1;
+}
+
+/*
+ * Try fetching and freeing various things.
+ * Test 0: Decoder
+ * Test 1: Encoder
+ * Test 2: Store loader
+ */
+static int fetch_test(int tst)
+{
+    OSSL_LIB_CTX *libctx = OSSL_LIB_CTX_new();
+    OSSL_PROVIDER *dummyprov = NULL;
+    OSSL_DECODER *decoder = NULL;
+    OSSL_ENCODER *encoder = NULL;
+    OSSL_STORE_LOADER *loader = NULL;
+    int testresult = 0;
+
+    if (!TEST_ptr(libctx))
+        goto err;
+
+    if (!TEST_true(OSSL_PROVIDER_add_builtin(libctx, "dummy-prov",
+                                             dummy_provider_init))
+            || !TEST_ptr(dummyprov = OSSL_PROVIDER_load(libctx, "dummy-prov")))
+        goto err;
+
+    switch(tst) {
+    case 0:
+        decoder = OSSL_DECODER_fetch(libctx, "DUMMY", NULL);
+        if (!TEST_ptr(decoder))
+            goto err;
+        break;
+    case 1:
+        encoder = OSSL_ENCODER_fetch(libctx, "DUMMY", NULL);
+        if (!TEST_ptr(encoder))
+            goto err;
+        break;
+    case 2:
+        loader = OSSL_STORE_LOADER_fetch(libctx, "DUMMY", NULL);
+        if (!TEST_ptr(loader))
+            goto err;
+        break;
+    default:
+        goto err;
+    }
+
+    testresult = 1;
+ err:
+    OSSL_DECODER_free(decoder);
+    OSSL_ENCODER_free(encoder);
+    OSSL_STORE_LOADER_free(loader);
+    OSSL_PROVIDER_unload(dummyprov);
+    OSSL_LIB_CTX_free(libctx);
+    return testresult;
+}
+
+int setup_tests(void)
+{
+    ADD_ALL_TESTS(fetch_test, 3);
+
+    return 1;
+}

--- a/test/recipes/04-test_provfetch.t
+++ b/test/recipes/04-test_provfetch.t
@@ -1,0 +1,12 @@
+#! /usr/bin/env perl
+# Copyright 2015-2016 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+
+use OpenSSL::Test::Simple;
+
+simple_test("test_provfetch", "provfetchtest");


### PR DESCRIPTION
We already had the evp method store being cleaned up before the provider
store was. This prevents issues where the method clean up functions cause
providers to clean up, which then needs access to the provider store. We
extend the same thinking to the encoder/decoder/loader stores.

Fixes #15727
