### PR TITLE
apps: better check for AEAD and XTS ciphers where they aren't legal

### DIFF
--- a/apps/cms.c
+++ b/apps/cms.c
@@ -725,11 +725,11 @@ int cms_main(int argc, char **argv)
             goto end;
     }
     if (ciphername != NULL) {
-        if (!opt_cipher(ciphername, &cipher))
+        if (!opt_cipher_any(ciphername, &cipher))
             goto end;
     }
     if (wrapname != NULL) {
-        if (!opt_cipher(wrapname, &wrap_cipher))
+        if (!opt_cipher_any(wrapname, &wrap_cipher))
             goto end;
     }
 

--- a/apps/enc.c
+++ b/apps/enc.c
@@ -300,14 +300,6 @@ int enc_main(int argc, char **argv)
         if (!opt_cipher(ciphername, &cipher))
             goto opthelp;
     }
-    if (cipher && EVP_CIPHER_get_flags(cipher) & EVP_CIPH_FLAG_AEAD_CIPHER) {
-        BIO_printf(bio_err, "%s: AEAD ciphers not supported\n", prog);
-        goto end;
-    }
-    if (cipher && (EVP_CIPHER_get_mode(cipher) == EVP_CIPH_XTS_MODE)) {
-        BIO_printf(bio_err, "%s XTS ciphers not supported\n", prog);
-        goto end;
-    }
     if (digestname != NULL) {
         if (!opt_md(digestname, &dgst))
             goto opthelp;
@@ -660,9 +652,9 @@ static void show_ciphers(const OBJ_NAME *name, void *arg)
 
     /* Filter out ciphers that we cannot use */
     cipher = EVP_get_cipherbyname(name->name);
-    if (cipher == NULL ||
-            (EVP_CIPHER_get_flags(cipher) & EVP_CIPH_FLAG_AEAD_CIPHER) != 0 ||
-            EVP_CIPHER_get_mode(cipher) == EVP_CIPH_XTS_MODE)
+    if (cipher == NULL
+            || (EVP_CIPHER_get_flags(cipher) & EVP_CIPH_FLAG_AEAD_CIPHER) != 0
+            || EVP_CIPHER_get_mode(cipher) == EVP_CIPH_XTS_MODE)
         return;
 
     BIO_printf(dec->bio, "-%-25s", name->name);

--- a/apps/genpkey.c
+++ b/apps/genpkey.c
@@ -70,7 +70,7 @@ int genpkey_main(int argc, char **argv)
     EVP_CIPHER *cipher = NULL;
     OPTION_CHOICE o;
     int outformat = FORMAT_PEM, text = 0, ret = 1, rv, do_param = 0;
-    int private = 0, i, m;
+    int private = 0, i;
     OSSL_LIB_CTX *libctx = app_get0_libctx();
     STACK_OF(OPENSSL_STRING) *keyopt = NULL;
 
@@ -163,16 +163,9 @@ int genpkey_main(int argc, char **argv)
             goto end;
         }
     }
-    if (ciphername != NULL) {
+    if (ciphername != NULL)
         if (!opt_cipher(ciphername, &cipher) || do_param == 1)
             goto opthelp;
-        m = EVP_CIPHER_get_mode(cipher);
-        if (m == EVP_CIPH_GCM_MODE || m == EVP_CIPH_CCM_MODE
-                || m == EVP_CIPH_XTS_MODE || m == EVP_CIPH_OCB_MODE) {
-            BIO_printf(bio_err, "%s: cipher mode not supported\n", prog);
-            goto end;
-        }
-    }
 
     private = do_param ? 0 : 1;
 

--- a/apps/include/opt.h
+++ b/apps/include/opt.h
@@ -365,6 +365,7 @@ char *opt_flag(void);
 char *opt_arg(void);
 char *opt_unknown(void);
 int opt_cipher(const char *name, EVP_CIPHER **cipherp);
+int opt_cipher_any(const char *name, EVP_CIPHER **cipherp);
 int opt_cipher_silent(const char *name, EVP_CIPHER **cipherp);
 int opt_md(const char *name, EVP_MD **mdp);
 int opt_md_silent(const char *name, EVP_MD **mdp);

--- a/apps/lib/opt.c
+++ b/apps/lib/opt.c
@@ -368,7 +368,10 @@ void print_format_error(int format, unsigned long flags)
     (void)opt_format_error(format2str(format), flags);
 }
 
-/* Parse a cipher name, put it in *EVP_CIPHER; return 0 on failure, else 1. */
+/*
+ * Parse a cipher name, put it in *cipherp after freeing what was there, if
+ * cipherp is not NULL.  Return 0 on failure, else 1.
+ */
 int opt_cipher_silent(const char *name, EVP_CIPHER **cipherp)
 {
     EVP_CIPHER *c;
@@ -402,7 +405,7 @@ int opt_cipher(const char *name, EVP_CIPHER **cipherp)
 {
      int mode, ret = 0;
      unsigned long int flags;
-     EVP_CIPHER *c;
+     EVP_CIPHER *c = NULL;
 
      if (opt_cipher_any(name, &c)) {
         mode = EVP_CIPHER_get_mode(c);

--- a/apps/lib/opt.c
+++ b/apps/lib/opt.c
@@ -371,24 +371,52 @@ void print_format_error(int format, unsigned long flags)
 /* Parse a cipher name, put it in *EVP_CIPHER; return 0 on failure, else 1. */
 int opt_cipher_silent(const char *name, EVP_CIPHER **cipherp)
 {
-    EVP_CIPHER_free(*cipherp);
+    EVP_CIPHER *c;
 
     ERR_set_mark();
-    if ((*cipherp = EVP_CIPHER_fetch(NULL, name, NULL)) != NULL
-        || (*cipherp = (EVP_CIPHER *)EVP_get_cipherbyname(name)) != NULL) {
+    if ((c = EVP_CIPHER_fetch(NULL, name, NULL)) != NULL
+        || (c = (EVP_CIPHER *)EVP_get_cipherbyname(name)) != NULL) {
         ERR_pop_to_mark();
+        if (cipherp != NULL) {
+            EVP_CIPHER_free(*cipherp);
+            *cipherp = c;
+        } else {
+            EVP_CIPHER_free(c);
+        }
         return 1;
     }
     ERR_clear_last_mark();
     return 0;
 }
 
-int opt_cipher(const char *name, EVP_CIPHER **cipherp)
+int opt_cipher_any(const char *name, EVP_CIPHER **cipherp)
 {
     int ret;
 
     if ((ret = opt_cipher_silent(name, cipherp)) == 0)
-       opt_printf_stderr("%s: Unknown cipher: %s\n", prog, name);
+        opt_printf_stderr("%s: Unknown cipher: %s\n", prog, name);
+    return ret;
+}
+
+int opt_cipher(const char *name, EVP_CIPHER **cipherp)
+{
+     int mode, ret = 0;
+     unsigned long int flags;
+     EVP_CIPHER *c;
+
+     if (opt_cipher_any(name, &c)) {
+        mode = EVP_CIPHER_get_mode(c);
+        flags = EVP_CIPHER_get_flags(c);
+        if (mode == EVP_CIPH_XTS_MODE) {
+            opt_printf_stderr("%s XTS ciphers not supported\n", prog);
+        } else if ((flags & EVP_CIPH_FLAG_AEAD_CIPHER) != 0) {
+            opt_printf_stderr("%s: AEAD ciphers not supported\n", prog);
+        } else {
+            ret = 1;
+            if (cipherp != NULL)
+                *cipherp = c;
+        }
+    }
     return ret;
 }
 

--- a/apps/pkcs12.c
+++ b/apps/pkcs12.c
@@ -364,7 +364,7 @@ int pkcs12_main(int argc, char **argv)
         goto end;
 
     if (ciphername != NULL) {
-        if (!opt_cipher(ciphername, &enc))
+        if (!opt_cipher_any(ciphername, &enc))
             goto opthelp;
     }
     if (export_pkcs12) {

--- a/apps/smime.c
+++ b/apps/smime.c
@@ -367,7 +367,7 @@ int smime_main(int argc, char **argv)
             goto opthelp;
     }
     if (ciphername != NULL) {
-        if (!opt_cipher(ciphername, &cipher))
+        if (!opt_cipher_any(ciphername, &cipher))
             goto opthelp;
     }
     if (!(operation & SMIME_SIGNERS) && (skkeys != NULL || sksigners != NULL)) {

--- a/doc/internal/man3/OPTIONS.pod
+++ b/doc/internal/man3/OPTIONS.pod
@@ -4,7 +4,7 @@
 
 OPTIONS, OPT_PAIR, OPT_COMMON, OPT_ERR, OPT_EOF, OPT_HELP,
 opt_init, opt_progname, opt_appname, opt_getprog, opt_help,
-opt_begin, opt_next, opt_flag, opt_arg, opt_unknown, opt_cipher_basic,
+opt_begin, opt_next, opt_flag, opt_arg, opt_unknown, opt_cipher,
 opt_cipher_any, opt_cipher_silent, opt_md,
 opt_int, opt_int_arg, opt_long, opt_ulong, opt_intmax, opt_uintmax,
 opt_format, opt_isdir, opt_string, opt_pair,
@@ -33,7 +33,7 @@ opt_num_rest, opt_rest
  char *opt_flag(void);
  char *opt_arg(void);
  char *opt_unknown(void);
- int opt_cipher_basic(const char *name, EVP_CIPHER **cipherp);
+ int opt_cipher(const char *name, EVP_CIPHER **cipherp);
  int opt_cipher_any(const char *name, EVP_CIPHER **cipherp);
  int opt_cipher_silent(const char *name, EVP_CIPHER **cipherp);
  int opt_md(const char *name, EVP_MD **mdp);
@@ -249,7 +249,7 @@ option to be be taken as digest algorithm, like C<-sha1>. The function
 opt_md() takes the specified I<name> and fills in the digest into I<mdp>.
 The functions opt_cipher(), opt_cipher_any() and opt_cipher_silent()
 each takes the specified I<name> and fills in the cipher into I<cipherp>.
-The function opt_cipher_basic() only accepts ciphers which are not
+The function opt_cipher() only accepts ciphers which are not
 AEAD and are not using XTS mode.  The functions opt_cipher_any() and
 opt_cipher_silent() accept any cipher, the latter not emitting an error
 if the cipher is not located.

--- a/doc/internal/man3/OPTIONS.pod
+++ b/doc/internal/man3/OPTIONS.pod
@@ -4,7 +4,7 @@
 
 OPTIONS, OPT_PAIR, OPT_COMMON, OPT_ERR, OPT_EOF, OPT_HELP,
 opt_init, opt_progname, opt_appname, opt_getprog, opt_help,
-opt_begin, opt_next, opt_flag, opt_arg, opt_unknown, opt_cipher_basic.
+opt_begin, opt_next, opt_flag, opt_arg, opt_unknown, opt_cipher_basic,
 opt_cipher_any, opt_cipher_silent, opt_md,
 opt_int, opt_int_arg, opt_long, opt_ulong, opt_intmax, opt_uintmax,
 opt_format, opt_isdir, opt_string, opt_pair,

--- a/doc/internal/man3/OPTIONS.pod
+++ b/doc/internal/man3/OPTIONS.pod
@@ -4,7 +4,8 @@
 
 OPTIONS, OPT_PAIR, OPT_COMMON, OPT_ERR, OPT_EOF, OPT_HELP,
 opt_init, opt_progname, opt_appname, opt_getprog, opt_help,
-opt_begin, opt_next, opt_flag, opt_arg, opt_unknown, opt_cipher, opt_md,
+opt_begin, opt_next, opt_flag, opt_arg, opt_unknown, opt_cipher_basic.
+opt_cipher_any, opt_cipher_silent, opt_md,
 opt_int, opt_int_arg, opt_long, opt_ulong, opt_intmax, opt_uintmax,
 opt_format, opt_isdir, opt_string, opt_pair,
 opt_num_rest, opt_rest
@@ -32,7 +33,9 @@ opt_num_rest, opt_rest
  char *opt_flag(void);
  char *opt_arg(void);
  char *opt_unknown(void);
- int opt_cipher(const char *name, EVP_CIPHER **cipherp);
+ int opt_cipher_basic(const char *name, EVP_CIPHER **cipherp);
+ int opt_cipher_any(const char *name, EVP_CIPHER **cipherp);
+ int opt_cipher_silent(const char *name, EVP_CIPHER **cipherp);
  int opt_md(const char *name, EVP_MD **mdp);
 
  int opt_int(const char *value, int *result);
@@ -242,10 +245,14 @@ The opt_arg() function returns the option's argument value, if there is one.
 The opt_unknown() function returns the unknown option.
 In an option list, there can be at most one option with the empty string.
 This is a "wildcard" or "unknown" option. For example, it allows an
-option to be be taken as digest algorithm, like C<-sha1>. The
-function opt_cipher() takes the specified I<name> and fills in
-the cipher into I<cipherp>.  The function opt_md() does the same
-thing for message digest.
+option to be be taken as digest algorithm, like C<-sha1>. The function
+opt_md() takes the specified I<name> and fills in the digest into I<mdp>.
+The functions opt_cipher(), opt_cipher_any() and opt_cipher_silent()
+each takes the specified I<name> and fills in the cipher into I<cipherp>.
+The function opt_cipher_basic() only accepts ciphers which are not
+AEAD and are not using XTS mode.  The functions opt_cipher_any() and
+opt_cipher_silent() accept any cipher, the latter not emitting an error
+if the cipher is not located.
 
 There are a several useful functions for parsing numbers.  These are
 opt_int(), opt_long(), opt_ulong(), opt_intmax(), and opt_uintmax().  They all


### PR DESCRIPTION
This is done by modifying the app_cipher() function to reject these ciphers/modes.
An additional function is added, app_cipher_any(), which still accepts these.

Fixes #7720

- [x] documentation is added or updated
- [ ] tests are added or updated
