### PR TITLE
CORE: Do a bit of cleanup of core fetching

### DIFF
--- a/crypto/core_fetch.c
+++ b/crypto/core_fetch.c
@@ -84,8 +84,7 @@ static void ossl_method_construct_this(OSSL_PROVIDER *provider,
 
     if (data->force_store || !no_store) {
         /* If we haven't been told not to store, add to the global store */
-        data->mcm->put(data->libctx, NULL, method, provider,
-                       data->operation_id, algo->algorithm_names,
+        data->mcm->put(NULL, method, provider, algo->algorithm_names,
                        algo->property_definition, data->mcm_data);
     } else {
         /*
@@ -97,8 +96,7 @@ static void ossl_method_construct_this(OSSL_PROVIDER *provider,
         if ((data->store = data->mcm->get_tmp_store(data->mcm_data)) == NULL)
             return;
 
-        data->mcm->put(data->libctx, data->store, method, provider,
-                       data->operation_id, algo->algorithm_names,
+        data->mcm->put(data->store, method, provider, algo->algorithm_names,
                        algo->property_definition, data->mcm_data);
     }
 
@@ -112,12 +110,10 @@ void *ossl_method_construct(OSSL_LIB_CTX *libctx, int operation_id,
 {
     void *method = NULL;
 
-    if ((method = mcm->get(libctx, NULL, mcm_data)) == NULL) {
+    if ((method = mcm->get(NULL, mcm_data)) == NULL) {
         struct construct_data_st cbdata;
 
-        cbdata.libctx = libctx;
         cbdata.store = NULL;
-        cbdata.operation_id = operation_id;
         cbdata.force_store = force_store;
         cbdata.mcm = mcm;
         cbdata.mcm_data = mcm_data;
@@ -129,11 +125,11 @@ void *ossl_method_construct(OSSL_LIB_CTX *libctx, int operation_id,
 
         /* If there is a temporary store, try there first */
         if (cbdata.store != NULL)
-            method = mcm->get(libctx, cbdata.store, mcm_data);
+            method = mcm->get(cbdata.store, mcm_data);
 
         /* If no method was found yet, try the global store */
         if (method == NULL)
-            method = mcm->get(libctx, NULL, mcm_data);
+            method = mcm->get(NULL, mcm_data);
     }
 
     return method;

--- a/crypto/encode_decode/decoder_meth.c
+++ b/crypto/encode_decode/decoder_meth.c
@@ -86,7 +86,6 @@ static const OSSL_LIB_CTX_METHOD decoder_store_method = {
 /* Data to be passed through ossl_method_construct() */
 struct decoder_data_st {
     OSSL_LIB_CTX *libctx;
-    OSSL_METHOD_CONSTRUCT_METHOD *mcm;
     int id;                      /* For get_decoder_from_store() */
     const char *names;           /* For get_decoder_from_store() */
     const char *propquery;       /* For get_decoder_from_store() */
@@ -125,21 +124,20 @@ static OSSL_METHOD_STORE *get_decoder_store(OSSL_LIB_CTX *libctx)
 }
 
 /* Get decoder methods from a store, or put one in */
-static void *get_decoder_from_store(OSSL_LIB_CTX *libctx, void *store,
-                                    void *data)
+static void *get_decoder_from_store(void *store, void *data)
 {
     struct decoder_data_st *methdata = data;
     void *method = NULL;
     int id;
 
     if ((id = methdata->id) == 0) {
-        OSSL_NAMEMAP *namemap = ossl_namemap_stored(libctx);
+        OSSL_NAMEMAP *namemap = ossl_namemap_stored(methdata->libctx);
 
         id = ossl_namemap_name2num(namemap, methdata->names);
     }
 
     if (store == NULL
-        && (store = get_decoder_store(libctx)) == NULL)
+        && (store = get_decoder_store(methdata->libctx)) == NULL)
         return NULL;
 
     if (!ossl_method_store_fetch(store, id, methdata->propquery, &method))
@@ -147,19 +145,20 @@ static void *get_decoder_from_store(OSSL_LIB_CTX *libctx, void *store,
     return method;
 }
 
-static int put_decoder_in_store(OSSL_LIB_CTX *libctx, void *store,
-                                void *method, const OSSL_PROVIDER *prov,
-                                int operation_id, const char *names,
-                                const char *propdef, void *unused)
+static int put_decoder_in_store(void *store, void *method,
+                                const OSSL_PROVIDER *prov,
+                                const char *names, const char *propdef,
+                                void *data)
 {
+    struct decoder_data_st *methdata = data;
     OSSL_NAMEMAP *namemap;
     int id;
 
-    if ((namemap = ossl_namemap_stored(libctx)) == NULL
+    if ((namemap = ossl_namemap_stored(methdata->libctx)) == NULL
         || (id = ossl_namemap_name2num(namemap, names)) == 0)
         return 0;
 
-    if (store == NULL && (store = get_decoder_store(libctx)) == NULL)
+    if (store == NULL && (store = get_decoder_store(methdata->libctx)) == NULL)
         return 0;
 
     return ossl_method_store_add(store, prov, id, propdef, method,
@@ -349,7 +348,6 @@ inner_ossl_decoder_fetch(struct decoder_data_st *methdata, int id,
             destruct_decoder
         };
 
-        methdata->mcm = &mcm;
         methdata->id = id;
         methdata->names = name;
         methdata->propquery = properties;

--- a/include/internal/core.h
+++ b/include/internal/core.h
@@ -31,11 +31,10 @@ typedef struct ossl_method_construct_method_st {
     /* Get a temporary store */
     void *(*get_tmp_store)(void *data);
     /* Get an already existing method from a store */
-    void *(*get)(OSSL_LIB_CTX *libctx, void *store, void *data);
+    void *(*get)(void *store, void *data);
     /* Store a method in a store */
-    int (*put)(OSSL_LIB_CTX *libctx, void *store, void *method,
-               const OSSL_PROVIDER *prov, int operation_id, const char *name,
-               const char *propdef, void *data);
+    int (*put)(void *store, void *method, const OSSL_PROVIDER *prov,
+               const char *name, const char *propdef, void *data);
     /* Construct a new method */
     void *(*construct)(const OSSL_ALGORITHM *algodef, OSSL_PROVIDER *prov,
                        void *data);


### PR DESCRIPTION
Some data, like the library context, were passed both through higher
level callback structures and through arguments to those same higher
level callbacks.  This is a bit unnecessary, so we rearrange the
callback arguments to simply pass that callback structure and rely on
the higher level fetching functionality to pick out what data they
need from that structure.

-----

Only the last commit is part of this PR.  The rest comes from #15604 and #15737