### PR TITLE
Fix DH private key check.

### DIFF
--- a/crypto/dh/dh_check.c
+++ b/crypto/dh/dh_check.c
@@ -262,7 +262,7 @@ int ossl_dh_check_priv_key(const DH *dh, const BIGNUM *priv_key, int *ret)
     upper = dh->params.q;
 
     /* Is it from an approved Safe prime group ?*/
-    if (DH_get_nid((DH *)dh) != NID_undef) {
+    if (DH_get_nid((DH *)dh) != NID_undef && dh->length != 0) {
         if (!BN_lshift(two_powN, BN_value_one(), dh->length))
             goto err;
         if (BN_cmp(two_powN, dh->params.q) < 0)

--- a/crypto/dh/dh_lib.c
+++ b/crypto/dh/dh_lib.c
@@ -202,6 +202,7 @@ int DH_size(const DH *dh)
 int DH_security_bits(const DH *dh)
 {
     int N;
+
     if (dh->params.q != NULL)
         N = BN_num_bits(dh->params.q);
     else if (dh->length)


### PR DESCRIPTION
A recent addition removed setting the dh private key length when
a safe prime group is used. The private key validation check was relying on this
being set for safe primes. Setting the upper bound no longer checks the
length if the value is zero.

This caused a failure in the daily build of acvp_tests.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
