### PR TITLE
Use getauxval on Android with API level > 18

### DIFF
--- a/crypto/armcap.c
+++ b/crypto/armcap.c
@@ -88,6 +88,15 @@ static unsigned long getauxval(unsigned long key)
 # endif
 
 /*
+ * Android: according to https://developer.android.com/ndk/guides/cpu-features,
+ * getauxval is supported starting with API level 18
+ */
+#  if defined(__ANDROID__) && defined(__ANDROID_API__) && __ANDROID_API__ >= 18
+#   include <sys/auxv.h>
+#   define OSSL_IMPLEMENT_GETAUXVAL
+#  endif
+
+/*
  * ARM puts the feature bits for Crypto Extensions in AT_HWCAP2, whereas
  * AArch64 used AT_HWCAP.
  */


### PR DESCRIPTION
We received analytics that devices of the device family Oppo A37x
are crashing with SIGILL when trying to load libcrypto.so.
These crashes were fixed by using the system-supplied getauxval function.

(This is the PR https://github.com/openssl/openssl/pull/11257 against OpenSSL_1_1_1)
