### PR TITLE
DSO: Fix the VMS DSO name converter to actually do something

### DIFF
--- a/crypto/dso/dso_vms.c
+++ b/crypto/dso/dso_vms.c
@@ -464,15 +464,13 @@ static char *vms_name_converter(DSO *dso, const char *filename)
         transform = 0;
     } else {
         p = filename;
-        transform = (strrchr(p, '>') == NULL || strrchr(p, ']') == NULL);
+        transform = (strrchr(p, '>') == NULL && strrchr(p, ']') == NULL);
     }
 
     if (transform) {
         int rsize = len + sizeof(DSO_EXTENSION);
 
-        translated = OPENSSL_malloc(rsize);
-
-        if (translated != NULL) {
+        if ((translated = OPENSSL_malloc(rsize)) != NULL) {
             p = strrchr(filename, ';');
             if (p != NULL)
                 len = p - filename;

--- a/crypto/dso/dso_vms.c
+++ b/crypto/dso/dso_vms.c
@@ -453,11 +453,39 @@ static char *vms_merger(DSO *dso, const char *filespec1,
 
 static char *vms_name_converter(DSO *dso, const char *filename)
 {
-    int len = strlen(filename);
-    char *not_translated = OPENSSL_malloc(len + 1);
-    if (not_translated != NULL)
-        strcpy(not_translated, filename);
-    return not_translated;
+    char *translated;
+    int len, transform;
+    const char *p;
+
+    len = strlen(filename);
+
+    p = strchr(filename, ':');
+    if (p != NULL) {
+        transform = 0;
+    } else {
+        p = filename;
+        transform = (strrchr(p, '>') == NULL || strrchr(p, ']') == NULL);
+    }
+
+    if (transform) {
+        int rsize = len + sizeof(DSO_EXTENSION);
+
+        translated = OPENSSL_malloc(rsize);
+
+        if (translated != NULL) {
+            p = strrchr(filename, ';');
+            if (p != NULL)
+                len = p - filename;
+            strncpy(translated, filename, len);
+            translated[len] = '\0';
+            strcat(translated, DSO_EXTENSION);
+            if (p != NULL)
+                strcat(translated, p);
+        }
+    } else {
+        translated = OPENSSL_strdup(filename);
+    }
+    return translated;
 }
 
 #endif                          /* OPENSSL_SYS_VMS */


### PR DESCRIPTION
This function has never before actually done its work.  This wasn't
discovered before, because its output wasn't important before the FIPS
provider self test started using its value.

This function is now made to insert the VMS DSO extension (".EXE") at
the end of the filename, being careful to make sure what can be a
typical VMS generation number (separated from the file name with a
';') remains at the end.
