### PR TITLE
TEST: Display the correct shared library name

### DIFF
--- a/test/recipes/01-test_symbol_presence.t
+++ b/test/recipes/01-test_symbol_presence.t
@@ -21,6 +21,8 @@ use lib bldtop_dir('.');
 use platform;
 
 plan skip_all => "Test is disabled on NonStop" if config('target') =~ m|^nonstop|;
+# MacOS arranges symbol names differently
+plan skip_all => "Test is disabled on MacOS" if config('target') =~ m|^darwin|;
 plan skip_all => "Only useful when building shared libraries"
     if disabled("shared");
 

--- a/test/recipes/01-test_symbol_presence.t
+++ b/test/recipes/01-test_symbol_presence.t
@@ -39,7 +39,8 @@ note
 foreach my $libname (@libnames) {
  SKIP:
     {
-        my $shlibpath = bldtop_file(platform->sharedlib("lib$libname"));
+        my $shlibname = platform->sharedlib("lib$libname");
+        my $shlibpath = bldtop_file($shlibname);
         *OSTDERR = *STDERR;
         *OSTDOUT = *STDOUT;
         open STDERR, ">", devnull();
@@ -107,18 +108,18 @@ foreach my $libname (@libnames) {
         }
 
         if (scalar @missing) {
-            note "The following symbols are missing in lib$libname.so:";
+            note "The following symbols are missing in ${shlibname}:";
             foreach (@missing) {
                 note "  $_";
             }
         }
         if (scalar @extra) {
-            note "The following symbols are extra in lib$libname.so:";
+            note "The following symbols are extra in ${shlibname}:";
             foreach (@extra) {
                 note "  $_";
             }
         }
         ok(scalar @missing == 0,
-           "check that there are no missing symbols in lib$libname.so");
+           "check that there are no missing symbols in ${shlibname}");
     }
 }


### PR DESCRIPTION
In test/recipes/01-test_symbol_presence.t
