### PR TITLE
prov: tag SM2 encoders and decoders as non-FIPS

### DIFF
--- a/providers/decoders.inc
+++ b/providers/decoders.inc
@@ -67,8 +67,8 @@ DECODER_w_structure("X25519", der, SubjectPublicKeyInfo, x25519, yes),
 DECODER_w_structure("X448", der, PrivateKeyInfo, x448, yes),
 DECODER_w_structure("X448", der, SubjectPublicKeyInfo, x448, yes),
 # ifndef OPENSSL_NO_SM2
-DECODER_w_structure("SM2", der, PrivateKeyInfo, sm2, yes),
-DECODER_w_structure("SM2", der, SubjectPublicKeyInfo, sm2, yes),
+DECODER_w_structure("SM2", der, PrivateKeyInfo, sm2, no),
+DECODER_w_structure("SM2", der, SubjectPublicKeyInfo, sm2, no),
 # endif
 #endif
 DECODER_w_structure("RSA", der, PrivateKeyInfo, rsa, yes),

--- a/providers/encoders.inc
+++ b/providers/encoders.inc
@@ -61,7 +61,7 @@ ENCODER_TEXT("ED448", ed448, yes),
 ENCODER_TEXT("X25519", x25519, yes),
 ENCODER_TEXT("X448", x448, yes),
 # ifndef OPENSSL_NO_SM2
-ENCODER_TEXT("SM2", sm2, yes),
+ENCODER_TEXT("SM2", sm2, no),
 # endif
 #endif
 
@@ -110,9 +110,9 @@ ENCODER_w_structure("EC", ec, yes, pem, type_specific_no_pub),
 /* EC supports blob output for the public key */
 ENCODER("EC", ec, yes, blob),
 # ifndef OPENSSL_NO_SM2
-ENCODER_w_structure("SM2", sm2, yes, der, type_specific_no_pub),
-ENCODER_w_structure("SM2", sm2, yes, pem, type_specific_no_pub),
-ENCODER("SM2", sm2, yes, blob),
+ENCODER_w_structure("SM2", sm2, no, der, type_specific_no_pub),
+ENCODER_w_structure("SM2", sm2, no, pem, type_specific_no_pub),
+ENCODER("SM2", sm2, no, blob),
 # endif
 #endif
 
@@ -189,10 +189,10 @@ ENCODER_w_structure("ED448", ed448, yes, der, SubjectPublicKeyInfo),
 ENCODER_w_structure("ED448", ed448, yes, pem, SubjectPublicKeyInfo),
 
 # ifndef OPENSSL_NO_SM2
-ENCODER_w_structure("SM2", sm2, yes, der, PrivateKeyInfo),
-ENCODER_w_structure("SM2", sm2, yes, pem, PrivateKeyInfo),
-ENCODER_w_structure("SM2", sm2, yes, der, SubjectPublicKeyInfo),
-ENCODER_w_structure("SM2", sm2, yes, pem, SubjectPublicKeyInfo),
+ENCODER_w_structure("SM2", sm2, no, der, PrivateKeyInfo),
+ENCODER_w_structure("SM2", sm2, no, pem, PrivateKeyInfo),
+ENCODER_w_structure("SM2", sm2, no, der, SubjectPublicKeyInfo),
+ENCODER_w_structure("SM2", sm2, no, pem, SubjectPublicKeyInfo),
 # endif
 #endif
 


### PR DESCRIPTION
They're impossible to use in a FIPS environment, so they shouldn't be flagged
as compatible.
