### PR TITLE
Cms: new flag and option to omit signing time attribute

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -95,6 +95,18 @@ OpenSSL 3.5
 
    *Ramkumar*
 
+ * Add CMS_NO_SIGNING_TIME flag to CMS_sign(), CMS_add1_signer()
+
+   Previously there was no way to create a CMS SignedData signature without a
+   signing time attribute, because CMS_SignerInfo_sign added it unconditionally.
+   However, there is a use case (PAdES signatures [ETSI EN 319 142-1](https://www.etsi.org/deliver/etsi_en/319100_319199/31914201/01.01.01_60/en_31914201v010101p.pdf) )
+   where this attribute is not allowed, so a new flag was added to the CMS API
+   that causes this attribute to be omitted at signing time.
+
+   The new `-no_signing_time` option of the `cms` command enables this flag.
+
+   *Juhász Péter*
+
 OpenSSL 3.4
 -----------
 

--- a/apps/cms.c
+++ b/apps/cms.c
@@ -69,7 +69,8 @@ typedef enum OPTION_choice {
     OPT_DIGEST, OPT_DIGEST_CREATE, OPT_COMPRESS, OPT_UNCOMPRESS,
     OPT_ED_DECRYPT, OPT_ED_ENCRYPT, OPT_DEBUG_DECRYPT, OPT_TEXT,
     OPT_ASCIICRLF, OPT_NOINTERN, OPT_NOVERIFY, OPT_NOCERTS,
-    OPT_NOATTR, OPT_NODETACH, OPT_NOSMIMECAP, OPT_BINARY, OPT_KEYID,
+    OPT_NOATTR, OPT_NODETACH, OPT_NOSMIMECAP, OPT_NO_SIGNING_TIME,
+    OPT_BINARY, OPT_KEYID,
     OPT_NOSIGS, OPT_NO_CONTENT_VERIFY, OPT_NO_ATTR_VERIFY, OPT_INDEF,
     OPT_NOINDEF, OPT_CRLFEOL, OPT_NOOUT, OPT_RR_PRINT,
     OPT_RR_ALL, OPT_RR_FIRST, OPT_RCTFORM, OPT_CERTFILE, OPT_CAFILE,
@@ -186,6 +187,8 @@ const OPTIONS cms_options[] = {
      "Don't include signer's certificate when signing"},
     {"noattr", OPT_NOATTR, '-', "Don't include any signed attributes"},
     {"nosmimecap", OPT_NOSMIMECAP, '-', "Omit the SMIMECapabilities attribute"},
+    {"no_signing_time", OPT_NO_SIGNING_TIME, '-',
+     "Omit the signing time attribute"},
     {"receipt_request_all", OPT_RR_ALL, '-',
      "When signing, create a receipt request for all recipients"},
     {"receipt_request_first", OPT_RR_FIRST, '-',
@@ -428,6 +431,9 @@ int cms_main(int argc, char **argv)
             break;
         case OPT_NOSMIMECAP:
             flags |= CMS_NOSMIMECAP;
+            break;
+        case OPT_NO_SIGNING_TIME:
+            flags |= CMS_NO_SIGNING_TIME;
             break;
         case OPT_BINARY:
             flags |= CMS_BINARY;

--- a/crypto/cms/cms_local.h
+++ b/crypto/cms/cms_local.h
@@ -100,6 +100,8 @@ struct CMS_SignerInfo_st {
     EVP_MD_CTX *mctx;
     EVP_PKEY_CTX *pctx;
     const CMS_CTX *cms_ctx;
+    /* Set to 1 if signing time attribute is to be omitted */
+    int omit_signing_time;
 };
 
 struct CMS_SignerIdentifier_st {

--- a/crypto/cms/cms_sd.c
+++ b/crypto/cms/cms_sd.c
@@ -849,7 +849,7 @@ int CMS_SignerInfo_sign(CMS_SignerInfo *si)
         return 0;
 
     if (!si->omit_signing_time
-        && (CMS_signed_get_attr_by_NID(si, NID_pkcs9_signingTime, -1) < 0)) {
+        && CMS_signed_get_attr_by_NID(si, NID_pkcs9_signingTime, -1) < 0) {
         if (!cms_add1_signingTime(si, NULL))
             goto err;
     }

--- a/crypto/cms/cms_sd.c
+++ b/crypto/cms/cms_sd.c
@@ -457,7 +457,7 @@ CMS_SignerInfo *CMS_add1_signer(CMS_ContentInfo *cms,
                 goto err;
             }
         }
-        if (flags & CMS_NO_SIGNING_TIME) {
+        if ((flags & CMS_NO_SIGNING_TIME) != 0) {
             /*
              * The signing-time signed attribute (NID_pkcs9_signingTime)
              * would normally be added later, in CMS_SignerInfo_sign(),
@@ -848,7 +848,7 @@ int CMS_SignerInfo_sign(CMS_SignerInfo *si)
                     si->digestAlgorithm->algorithm, 0) <= 0)
         return 0;
 
-    if ((!si->omit_signing_time)
+    if (!si->omit_signing_time
         && (CMS_signed_get_attr_by_NID(si, NID_pkcs9_signingTime, -1) < 0)) {
         if (!cms_add1_signingTime(si, NULL))
             goto err;

--- a/crypto/cms/cms_sd.c
+++ b/crypto/cms/cms_sd.c
@@ -458,9 +458,11 @@ CMS_SignerInfo *CMS_add1_signer(CMS_ContentInfo *cms,
             }
         }
         if (flags & CMS_NO_SIGNING_TIME) {
-            /* The signing-time signed attribute (NID_pkcs9_signingTime)
+            /*
+             * The signing-time signed attribute (NID_pkcs9_signingTime)
              * would normally be added later, in CMS_SignerInfo_sign(),
-             * unless we set this flag here */
+             * unless we set this flag here
+             */
             si->omit_signing_time = 1;
         }
         if (flags & CMS_CADES) {
@@ -846,7 +848,8 @@ int CMS_SignerInfo_sign(CMS_SignerInfo *si)
                     si->digestAlgorithm->algorithm, 0) <= 0)
         return 0;
 
-    if ((!si->omit_signing_time) && (CMS_signed_get_attr_by_NID(si, NID_pkcs9_signingTime, -1) < 0)) {
+    if ((!si->omit_signing_time)
+        && (CMS_signed_get_attr_by_NID(si, NID_pkcs9_signingTime, -1) < 0)) {
         if (!cms_add1_signingTime(si, NULL))
             goto err;
     }

--- a/crypto/cms/cms_sd.c
+++ b/crypto/cms/cms_sd.c
@@ -364,6 +364,7 @@ CMS_SignerInfo *CMS_add1_signer(CMS_ContentInfo *cms,
     si->signer = signer;
     si->mctx = EVP_MD_CTX_new();
     si->pctx = NULL;
+    si->omit_signing_time = 0;
 
     if (si->mctx == NULL) {
         ERR_raise(ERR_LIB_CMS, ERR_R_EVP_LIB);
@@ -455,6 +456,12 @@ CMS_SignerInfo *CMS_add1_signer(CMS_ContentInfo *cms,
                 ERR_raise(ERR_LIB_CMS, ERR_R_CMS_LIB);
                 goto err;
             }
+        }
+        if (flags & CMS_NO_SIGNING_TIME) {
+            /* The signing-time signed attribute (NID_pkcs9_signingTime)
+             * would normally be added later, in CMS_SignerInfo_sign(),
+             * unless we set this flag here */
+            si->omit_signing_time = 1;
         }
         if (flags & CMS_CADES) {
             ESS_SIGNING_CERT *sc = NULL;
@@ -839,7 +846,7 @@ int CMS_SignerInfo_sign(CMS_SignerInfo *si)
                     si->digestAlgorithm->algorithm, 0) <= 0)
         return 0;
 
-    if (CMS_signed_get_attr_by_NID(si, NID_pkcs9_signingTime, -1) < 0) {
+    if ((!si->omit_signing_time) && (CMS_signed_get_attr_by_NID(si, NID_pkcs9_signingTime, -1) < 0)) {
         if (!cms_add1_signingTime(si, NULL))
             goto err;
     }

--- a/doc/man1/openssl-cms.pod.in
+++ b/doc/man1/openssl-cms.pod.in
@@ -83,6 +83,7 @@ Signing options:
 [B<-nocerts>]
 [B<-noattr>]
 [B<-nosmimecap>]
+[B<-no_signing_time>]
 [B<-receipt_request_all>]
 [B<-receipt_request_first>]
 [B<-receipt_request_from> I<emailaddress>]
@@ -492,7 +493,12 @@ option they are not included.
 =item B<-nosmimecap>
 
 Exclude the list of supported algorithms from signed attributes, other options
-such as signing time and content type are still included.
+such as content type and (optionally) signing time are still included.
+
+=item B<-no_signing_time>
+
+Exclude the signing time from signed attributes, other options
+such as content type are still included.
 
 =item B<-receipt_request_all>, B<-receipt_request_first>
 

--- a/doc/man3/CMS_add1_signer.pod
+++ b/doc/man3/CMS_add1_signer.pod
@@ -67,7 +67,8 @@ previously signed message.
 The SignedData structure includes several CMS signedAttributes including the
 signing time, the CMS content type and the supported list of ciphers in an
 SMIMECapabilities attribute. If B<CMS_NOATTR> is set then no signedAttributes
-will be used. If B<CMS_NOSMIMECAP> is set then just the SMIMECapabilities are
+will be used at all. If B<CMS_NOSMIMECAP> is set then the SMIMECapabilities
+will be omitted. If B<CMS_NO_SIGNING_TIME> is set then the signing time will be
 omitted.
 
 OpenSSL will by default identify signing certificates using issuer name

--- a/doc/man3/CMS_sign.pod
+++ b/doc/man3/CMS_sign.pod
@@ -60,7 +60,8 @@ otherwise the translation will corrupt it.
 The SignedData structure includes several CMS signedAttributes including the
 signing time, the CMS content type and the supported list of ciphers in an
 SMIMECapabilities attribute. If B<CMS_NOATTR> is set then no signedAttributes
-will be used. If B<CMS_NOSMIMECAP> is set then just the SMIMECapabilities are
+will be used at all. If B<CMS_NOSMIMECAP> is set then the SMIMECapabilities
+will be omitted. If B<CMS_NO_SIGNING_TIME> is set then the signing time will be
 omitted.
 
 If present the SMIMECapabilities attribute indicates support for the following

--- a/include/openssl/cms.h.in
+++ b/include/openssl/cms.h.in
@@ -96,6 +96,7 @@ CMS_ContentInfo *CMS_ContentInfo_new_ex(OSSL_LIB_CTX *libctx, const char *propq)
 # define CMS_ASCIICRLF                   0x80000
 # define CMS_CADES                       0x100000
 # define CMS_USE_ORIGINATOR_KEYID        0x200000
+# define CMS_NO_SIGNING_TIME             0x400000
 
 const ASN1_OBJECT *CMS_get0_type(const CMS_ContentInfo *cms);
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated

These commits implement feature request #15777.

It was more complicated than I've first thought, I had to add a new member to the SignerInfo struct, but I hope that's acceptable.

I've updated the documentation and the cms command line application as well (in a separate commit). I haven't found any relevant tests.