### PR TITLE
Make util/wrap.pl work better on VMS

### DIFF
--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -447,7 +447,7 @@ NODEBUG=@
 
 # The main targets ###################################################
 
-{- dependmagic('build_sw'); -} : build_libs_nodep, build_modules_nodep, build_programs_nodep copy-utils
+{- dependmagic('build_sw'); -} : build_libs_nodep, build_modules_nodep, build_programs_nodep
 {- dependmagic('build_libs'); -} : build_libs_nodep
 {- dependmagic('build_modules'); -} : build_modules_nodep
 {- dependmagic('build_programs'); -} : build_programs_nodep
@@ -476,7 +476,7 @@ build_all_generated : $(GENERATED_MANDATORY) $(GENERATED) build_docs
 all : build_sw build_docs
 
 test : tests
-{- dependmagic('tests'); -} : build_programs_nodep, build_modules_nodep copy-utils run_tests
+{- dependmagic('tests'); -} : build_programs_nodep, build_modules_nodep run_tests
 run_tests :
         @ ! {- output_off() if $disabled{tests}; "" -}
         DEFINE SRCTOP "$(SRCDIR)"
@@ -737,16 +737,6 @@ check_INSTALLTOP :
                 WRITE SYS$ERROR "INSTALLTOP should not be empty"
         @ IF "$(INSTALLTOP)" .EQS. "" THEN -
                 EXIT %x10000002
-
-# Helper targets #####################################################
-
-copy-utils : [.util]wrap.pl
-
-[.util]wrap.pl : configdata.pm
-	@ IF "$(SRCDIR)" .NES. "$(BLDDIR)" THEN -
-		CREATE/DIR/LOG [.util]
-	@ IF "$(SRCDIR)" .NES. "$(BLDDIR)" THEN -
-		COPY/LOG ossl_sourceroot:[util]wrap.pl [.util]
 
 # Developer targets ##################################################
 

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -1361,10 +1361,9 @@ tar:
 
 # Helper targets #####################################################
 
-link-utils: $(BLDDIR)/util/opensslwrap.sh $(BLDDIR)/util/wrap.pl \
-            $(BLDDIR)/apps/openssl.cnf
+link-utils: $(BLDDIR)/util/opensslwrap.sh $(BLDDIR)/apps/openssl.cnf
 
-$(BLDDIR)/util/opensslwrap.sh $(BLDDIR)/util/wrap.pl: configdata.pm
+$(BLDDIR)/util/opensslwrap.sh: configdata.pm
 	@if [ "$(SRCDIR)" != "$(BLDDIR)" ]; then \
 	    mkdir -p "$(BLDDIR)/util"; \
 	    ln -sf "../$(SRCDIR)/util/`basename "$@"`" "$(BLDDIR)/util"; \
@@ -1924,6 +1923,7 @@ EOF
                            rel2abs($config{builddir}));
       return <<"EOF";
 $script: $sources configdata.pm
+	\$(RM) "$script"
 	\$(PERL) "-I\$(BLDDIR)" -Mconfigdata "$dofile" \\
 	    "-o$target{build_file}" $sources > "$script"
 	chmod a+x $script

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -641,11 +641,7 @@ uninstall_image_docs:
 
 # Helper targets #####################################################
 
-copy-utils: $(BLDDIR)\util\wrap.pl $(BLDDIR)\apps\openssl.cnf
-
-$(BLDDIR)\util\wrap.pl: configdata.pm
-	@if NOT EXIST "$(BLDDIR)\util" mkdir "$(BLDDIR)\util"
-	@if NOT "$(SRCDIR)"=="$(BLDDIR)" copy "$(SRCDIR)\util\$(@F)" "$(BLDDIR)\util"
+copy-utils: $(BLDDIR)\apps\openssl.cnf
 
 $(BLDDIR)\apps\openssl.cnf: configdata.pm
 	@if NOT EXIST "$(BLDDIR)\apps" mkdir "$(BLDDIR)\apps"

--- a/util/build.info
+++ b/util/build.info
@@ -6,3 +6,6 @@ ELSIF[{- $target{build_scheme}->[1] eq "unix" -}]
  SCRIPTS{noinst}=shlib_wrap.sh
  SOURCE[shlib_wrap.sh]=shlib_wrap.sh.in
 ENDIF
+SCRIPTS{noinst}=wrap.pl
+SOURCE[wrap.pl]=wrap.pl.in
+DEPEND[wrap.pl]=../configdata.pm

--- a/util/wrap.pl.in
+++ b/util/wrap.pl.in
@@ -1,10 +1,22 @@
-#! /usr/bin/env perl
+#! {- $config{HASHBANGPERL} -}
 
 use strict;
 use warnings;
 
 use File::Basename;
 use File::Spec::Functions;
+
+BEGIN {
+    # This method corresponds exactly to 'use OpenSSL::Util',
+    # but allows us to use a platform specific file spec.
+    require {-
+         use Cwd qw(abs_path);
+
+         "'" . abs_path(catfile($config{sourcedir},
+                                'util', 'perl', 'OpenSSL', 'Util.pm')) . "'";
+         -};
+    OpenSSL::Util->import();
+}
 
 my $there = canonpath(catdir(dirname($0), updir()));
 my $std_engines = catdir($there, 'engines');
@@ -22,7 +34,10 @@ $ENV{OPENSSL_CONF} = $std_openssl_conf
 my $use_system = 0;
 my @cmd;
 
-if (-x $unix_shlib_wrap) {
+if ($^O eq 'VMS') {
+    # VMS needs the command to be appropriately quotified
+    @cmd = fixup_cmd(@ARGV);
+} elsif (-x $unix_shlib_wrap) {
     @cmd = ( $unix_shlib_wrap, @ARGV );
 } else {
     # Hope for the best


### PR DESCRIPTION
Perl's system() on VMS needs to have the command line properly fixed
up, even with arguments passed in list form.  We arrange that by
having util/wrap.pl use the same command line fixups as OpenSSL::Test.

As a consequence, util/wrap.pl needs to be generated, to easily pick
up data from configdata.pm.  This also removes yet another file
copying hack from the build file templates.