### PR TITLE
HTTP client.c: fix OSSL_HTTP_proxy_connect() for HTTPS proxy use

### DIFF
--- a/crypto/http/http_client.c
+++ b/crypto/http/http_client.c
@@ -27,8 +27,7 @@
 #define HTTP_VERSION_PATT "1." /* allow 1.x */
 #define HTTP_PREFIX_VERSION HTTP_PREFIX""HTTP_VERSION_PATT
 #define HTTP_1_0 HTTP_PREFIX_VERSION"0" /* "HTTP/1.0" */
-#define HTTP_VERSION_PATT_LEN strlen(HTTP_PREFIX_VERSION)
-#define HTTP_VERSION_STR_LEN (HTTP_VERSION_PATT_LEN + 1)
+#define HTTP_VERSION_STR_LEN (strlen(HTTP_PREFIX_VERSION) + 1)
 #define HTTP_LINE1_MINLEN ((int)strlen(HTTP_PREFIX_VERSION "x 200\n"))
 #define HTTP_VERSION_MAX_REDIRECTIONS 50
 
@@ -377,10 +376,10 @@ static int parse_http_line1(char *line, int *found_keep_alive)
     int i, retcode;
     char *code, *reason, *end;
 
-    if (strncmp(line, HTTP_PREFIX_VERSION, HTTP_VERSION_PATT_LEN) != 0)
+    if (strncmp(line, HTTP_PREFIX_VERSION, strlen(HTTP_PREFIX_VERSION)) != 0)
         goto err;
     /* above HTTP 1.0, connection persistence is the default */
-    *found_keep_alive = line[HTTP_VERSION_PATT_LEN] > '0';
+    *found_keep_alive = line[strlen(HTTP_PREFIX_VERSION)] > '0';
 
     /* Skip to first whitespace (past protocol info) */
     for (code = line; *code != '\0' && !ossl_isspace(*code); code++)
@@ -1306,7 +1305,7 @@ int OSSL_HTTP_proxy_connect(BIO *bio, const char *server, const char *port,
             goto end;
         }
         mbufp = mbuf + strlen(HTTP_PREFIX);
-        if (strncmp(mbufp, HTTP_VERSION_PATT, HTTP_VERSION_PATT_LEN) != 0) {
+        if (strncmp(mbufp, HTTP_VERSION_PATT, strlen(HTTP_VERSION_PATT)) != 0) {
             ERR_raise(ERR_LIB_HTTP, HTTP_R_RECEIVED_WRONG_HTTP_VERSION);
             BIO_printf(bio_err,
                        "%s: HTTP CONNECT failed, bad HTTP version %.*s\n",

--- a/crypto/http/http_client.c
+++ b/crypto/http/http_client.c
@@ -26,9 +26,9 @@
 #define HAS_PREFIX(str, prefix) (strncmp(str, prefix, sizeof(prefix) - 1) == 0)
 #define HTTP_PREFIX "HTTP/"
 #define HTTP_VERSION_PATT "1." /* allow 1.x */
+#define HTTP_VERSION_STR_LEN sizeof(HTTP_VERSION_PATT) /* == strlen("1.0") */
 #define HTTP_PREFIX_VERSION HTTP_PREFIX""HTTP_VERSION_PATT
 #define HTTP_1_0 HTTP_PREFIX_VERSION"0" /* "HTTP/1.0" */
-#define HTTP_VERSION_STR_LEN (strlen(HTTP_PREFIX_VERSION) + 1)
 #define HTTP_LINE1_MINLEN (sizeof(HTTP_PREFIX_VERSION "x 200\n") - 1)
 #define HTTP_VERSION_MAX_REDIRECTIONS 50
 

--- a/crypto/http/http_client.c
+++ b/crypto/http/http_client.c
@@ -29,7 +29,7 @@
 #define HTTP_PREFIX_VERSION HTTP_PREFIX""HTTP_VERSION_PATT
 #define HTTP_1_0 HTTP_PREFIX_VERSION"0" /* "HTTP/1.0" */
 #define HTTP_VERSION_STR_LEN (strlen(HTTP_PREFIX_VERSION) + 1)
-#define HTTP_LINE1_MINLEN ((int)strlen(HTTP_PREFIX_VERSION "x 200\n"))
+#define HTTP_LINE1_MINLEN (sizeof(HTTP_PREFIX_VERSION "x 200\n") - 1)
 #define HTTP_VERSION_MAX_REDIRECTIONS 50
 
 #define HTTP_STATUS_CODE_OK                200
@@ -1292,7 +1292,7 @@ int OSSL_HTTP_proxy_connect(BIO *bio, const char *server, const char *port,
          */
         read_len = BIO_gets(fbio, mbuf, BUF_SIZE);
         /* the BIO may not block, so we must wait for the 1st line to come in */
-        if (read_len < HTTP_LINE1_MINLEN)
+        if (read_len < (int)HTTP_LINE1_MINLEN)
             continue;
 
         /* Check for HTTP/1.x */

--- a/crypto/http/http_client.c
+++ b/crypto/http/http_client.c
@@ -434,10 +434,10 @@ static int parse_http_line1(char *line, int *found_keep_alive)
         else
             retcode = HTTP_R_RECEIVED_ERROR;
         if (*reason == '\0')
-            ERR_raise_data(ERR_LIB_HTTP, retcode, "Code=%s", code);
+            ERR_raise_data(ERR_LIB_HTTP, retcode, "code=%s", code);
         else
             ERR_raise_data(ERR_LIB_HTTP, retcode,
-                           "Code=%s, Reason=%s", code, reason);
+                           "code=%s, reason=%s", code, reason);
         return 0;
     }
 
@@ -1289,7 +1289,7 @@ int OSSL_HTTP_proxy_connect(BIO *bio, const char *server, const char *port,
         /*-
          * The first line is the HTTP response.
          * According to RFC 7230, it is formatted exactly like this:
-         * HTTP/d.d ddd Reason text\r\n
+         * HTTP/d.d ddd reason text\r\n
          */
         read_len = BIO_gets(fbio, mbuf, BUF_SIZE);
         /* the BIO may not block, so we must wait for the 1st line to come in */
@@ -1316,14 +1316,13 @@ int OSSL_HTTP_proxy_connect(BIO *bio, const char *server, const char *port,
 
         /* RFC 7231 4.3.6: any 2xx status code is valid */
         if (strncmp(mbufp, " 2", strlen(" 2")) != 0) {
-            mbufp += 1;
             /* chop any trailing whitespace */
             while (read_len > 0 && ossl_isspace(mbuf[read_len - 1]))
                 read_len--;
             mbuf[read_len] = '\0';
             ERR_raise_data(ERR_LIB_HTTP, HTTP_R_CONNECT_FAILURE,
-                           "Reason=%s", mbufp);
-            BIO_printf(bio_err, "%s: HTTP CONNECT failed, Reason=%s\n",
+                           "reason=%s", mbufp);
+            BIO_printf(bio_err, "%s: HTTP CONNECT failed, reason=%s\n",
                        prog, mbufp);
             goto end;
         }


### PR DESCRIPTION
I was not happy that many TODOs also for CMP code were removed (during my vacation) in PR #15539 without actually solving them.
I've started tracing those TODOs for which I feel responsible.

I just found out that the answer on the TODO `is the server host name correct for TLS via proxy?`, which  was removed from `apps/cmp.c`, is "yes",
but while experimenting on this I encountered a bug that leads to connection failure (with the misleading error: `received wrong http version`) when the HTTP client tries to CONNECT using TLS via a proxy. This is fixed by the present PR.