### PR TITLE
test/recipes/80-test_cmp_http.t: Kill the mock server brutally

### DIFF
--- a/test/recipes/80-test_cmp_http.t
+++ b/test/recipes/80-test_cmp_http.t
@@ -294,5 +294,5 @@ sub start_mock_server {
 sub stop_mock_server {
     my $pid = $_[0];
     print "Killing mock server with pid=$pid\n";
-    kill('QUIT', $pid);
+    kill('KILL', $pid);
 }


### PR DESCRIPTION
To kill a subprocess with the KILL signal is pretty brutal.  However,
it doesn't seem to be killed completely on some platforms, which makes
this test recipe hang indefinitely when (implicitly) closing the file
handle for this server ($server_fh).  A brutal KILL resolves this
problem.

Fixes #15781
