### PR TITLE
Fix PPC64 problems

### DIFF
--- a/crypto/bn/asm/ppc64-mont-fixed.pl
+++ b/crypto/bn/asm/ppc64-mont-fixed.pl
@@ -345,12 +345,12 @@ sub save_registers($)
 	my $n = $self->{n};
 
 	$self->add_code(<<___);
-	mtvsrd	$vsrs[0],$lo
+	std	$lo,-8($sp)
 ___
 
 	for (my $j = 0; $j <= $n+1; $j++) {
 		$self->{code}.=<<___;
-	mtvsrd	$vsrs[$j+1],$tp[$j]
+	std	$tp[$j],-`($j+2)*8`($sp)
 ___
 	}
 
@@ -366,12 +366,12 @@ sub restore_registers($)
 	my $n = $self->{n};
 
 	$self->add_code(<<___);
-	mfvsrd	$lo,$vsrs[0]
+	ld	$lo,-8($sp)
 ___
 
 	for (my $j = 0; $j <= $n+1; $j++) {
 		$self->{code}.=<<___;
-	mfvsrd	$tp[$j],$vsrs[$j+1]
+	ld	$tp[$j],-`($j+2)*8`($sp)
 ___
 	}
 

--- a/crypto/bn/asm/ppc64-mont-fixed.pl
+++ b/crypto/bn/asm/ppc64-mont-fixed.pl
@@ -562,7 +562,6 @@ $code.=<<___;
 .machine "any"
 .text
 .align	5
-.p2align	5,,31
 ___
 
 my $mont;

--- a/crypto/bn/asm/ppc64-mont-fixed.pl
+++ b/crypto/bn/asm/ppc64-mont-fixed.pl
@@ -72,6 +72,7 @@ my $np	= "r6";
 my $n0	= "r7";
 my $num	= "r8";
 
+my $i	= "r9";
 my $c0	= "r10";
 my $bp0	= "r11";
 my $bpi	= "r11";
@@ -81,7 +82,6 @@ my $apj	= "r12";
 my $npj	= "r12";
 my $lo	= "r14";
 my $c1	= "r14";
-my $i	= "r15";
 
 # Non-volatile registers used for tp[i]
 #
@@ -346,12 +346,11 @@ sub save_registers($)
 
 	$self->add_code(<<___);
 	mtvsrd	$vsrs[0],$lo
-	mtvsrd	$vsrs[1],$i
 ___
 
 	for (my $j = 0; $j <= $n+1; $j++) {
 		$self->{code}.=<<___;
-	mtvsrd	$vsrs[$j+2],$tp[$j]
+	mtvsrd	$vsrs[$j+1],$tp[$j]
 ___
 	}
 
@@ -368,12 +367,11 @@ sub restore_registers($)
 
 	$self->add_code(<<___);
 	mfvsrd	$lo,$vsrs[0]
-	mfvsrd	$i,$vsrs[1]
 ___
 
 	for (my $j = 0; $j <= $n+1; $j++) {
 		$self->{code}.=<<___;
-	mfvsrd	$tp[$j],$vsrs[$j+2]
+	mfvsrd	$tp[$j],$vsrs[$j+1]
 ___
 	}
 

--- a/crypto/bn/asm/ppc64-mont-fixed.pl
+++ b/crypto/bn/asm/ppc64-mont-fixed.pl
@@ -186,6 +186,7 @@ sub mul_mont_fixed($)
 	$self->add_code(<<___);
 
 .globl	.${fname}
+.align	5
 .${fname}:
 	mr	$rp,r3
 
@@ -226,6 +227,7 @@ ___
 	mtctr		$num
 	b		$label->{"enter"}
 
+.align	4
 $label->{"outer"}:
 	ldx		$bpi,$bp,$i
 
@@ -247,6 +249,7 @@ ___
 ___
 
 	$self->add_code(<<___);
+.align	4
 $label->{"enter"}:
 	mulld		$bpi,$tp[0],$n0
 
@@ -561,7 +564,6 @@ my $code;
 $code.=<<___;
 .machine "any"
 .text
-.align	5
 ___
 
 my $mont;

--- a/crypto/bn/asm/ppc64-mont-fixed.pl
+++ b/crypto/bn/asm/ppc64-mont-fixed.pl
@@ -72,8 +72,6 @@ my $np	= "r6";
 my $n0	= "r7";
 my $num	= "r8";
 
-$rp	= "r9";	# $rp is reassigned
-
 my $c0	= "r10";
 my $bp0	= "r11";
 my $bpi	= "r11";
@@ -188,7 +186,6 @@ sub mul_mont_fixed($)
 .globl	.${fname}
 .align	5
 .${fname}:
-	mr	$rp,r3
 
 ___
 

--- a/crypto/ec/asm/ecp_nistp521-ppc64.pl
+++ b/crypto/ec/asm/ecp_nistp521-ppc64.pl
@@ -45,6 +45,7 @@ sub startproc($)
 
     $code.=<<___;
     .globl ${name}
+    .align 5
 ${name}:
 
 ___

--- a/crypto/ec/asm/ecp_nistp521-ppc64.pl
+++ b/crypto/ec/asm/ecp_nistp521-ppc64.pl
@@ -46,7 +46,6 @@ sub startproc($)
     $code.=<<___;
     .globl ${name}
 ${name}:
-	.cfi_startproc
 
 ___
 }
@@ -57,7 +56,6 @@ sub endproc($)
 
     $code.=<<___;
 	blr
-	.cfi_endproc
 	    .size	${name},.-${name}
 
 ___

--- a/crypto/ec/build.info
+++ b/crypto/ec/build.info
@@ -30,9 +30,13 @@ IF[{- !$disabled{asm} -}]
   $ECASM_parisc20_64=
 
   $ECASM_ppc32=
-  $ECASM_ppc64=ecp_nistz256.c ecp_nistz256-ppc64.s ecp_nistp521-ppc64.s x25519-ppc64.s
-  $ECDEF_ppc64=ECP_NISTZ256_ASM ECP_NISTP521_ASM X25519_ASM
-  INCLUDE[ecp_nistp521.o]=..
+  $ECASM_ppc64=ecp_nistz256.c ecp_nistz256-ppc64.s x25519-ppc64.s
+  $ECDEF_ppc64=ECP_NISTZ256_ASM X25519_ASM
+  IF[{- !$disabled{'ec_nistp_64_gcc_128'} -}]
+    $ECASM_ppc64=$ECASM_ppc64 ecp_nistp521-ppc64.s
+    $ECDEF_ppc64=$ECDEF_ppc64 ECP_NISTP521_ASM
+    INCLUDE[ecp_nistp521.o]=..
+  ENDIF
 
   $ECASM_c64xplus=
 


### PR DESCRIPTION
This patch set fixes issue #15748 and makes some other minor alignment changes.

It also fixes an issue because the code to save registers into vector registers does not work on ISA < 2.07, reverting to the regular method of saving registers to the stack.  The performance penalty is less than 1%.

Overall performance for `ecdhp384` and `ecdsap384` is pretty much unchanged.

I'm happy to break this up into multiple PRs if necessary.

The commits have been locally reviewed by Amitay and have corresponding `Reviewed-by:` tags.  We're not sure what the convention is for non-maintainer reviewers - please let us know if there is something better (e.g. `Acked-by:` ?).  I can update to whatever is suggested and push again, or the commit summaries can be updated by someone who knows better.  ;-)

This has been tested on Linux running on Power 9 (ISA 3.0) and AIX on Power 7 (ISA 2.06).

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
