### PR TITLE
aix64-gcc target: Fix build breakage with enable-fips

### DIFF
--- a/providers/fips/self_test.c
+++ b/providers/fips/self_test.c
@@ -71,10 +71,8 @@ DEFINE_RUN_ONCE_STATIC(do_fips_self_test_init)
 #define DEP_INIT_ATTRIBUTE  static
 #define DEP_FINI_ATTRIBUTE  static
 
-#if !defined(__GNUC__)
 static void init(void);
 static void cleanup(void);
-#endif
 
 /*
  * This is the Default Entry Point (DEP) code.


### PR DESCRIPTION
Fixes #15804
