### PR TITLE
Add assert.h to threads_pthread.c for NonStop thread compiles.

### DIFF
--- a/crypto/threads_pthread.c
+++ b/crypto/threads_pthread.c
@@ -24,6 +24,8 @@
 #  include <unistd.h>
 #endif
 
+# include <assert.h>
+
 # ifdef PTHREAD_RWLOCK_INITIALIZER
 #  define USE_RWLOCK
 # endif


### PR DESCRIPTION
Fixes #15809

Signed-off-by: Randall S. Becker <rsbecker@nexbridge.com>
