### PR TITLE
KTLS test fixes

### DIFF
--- a/include/internal/ktls.h
+++ b/include/internal/ktls.h
@@ -41,12 +41,6 @@
 #   define OPENSSL_KTLS_AES_GCM_256
 #   define OPENSSL_KTLS_TLS13
 
-/*
- * Only used by the tests in sslapitest.c.
- */
-#   define TLS_CIPHER_AES_GCM_128_REC_SEQ_SIZE             8
-#   define TLS_CIPHER_AES_GCM_256_REC_SEQ_SIZE             8
-
 typedef struct tls_enable ktls_crypto_info_t;
 
 /*

--- a/test/helpers/ssltestlib.c
+++ b/test/helpers/ssltestlib.c
@@ -774,16 +774,13 @@ static int set_nb(int fd)
     return flags;
 }
 
-int create_test_sockets(int *cfd, int *sfd)
+int create_test_sockets(int *cfdp, int *sfdp)
 {
     struct sockaddr_in sin;
     const char *host = "127.0.0.1";
     int cfd_connected = 0, ret = 0;
     socklen_t slen = sizeof(sin);
-    int afd = -1;
-
-    *cfd = -1;
-    *sfd = -1;
+    int afd = -1, cfd = -1, sfd = -1;
 
     memset ((char *) &sin, 0, sizeof(sin));
     sin.sin_family = AF_INET;
@@ -802,37 +799,39 @@ int create_test_sockets(int *cfd, int *sfd)
     if (listen(afd, 1) < 0)
         goto out;
 
-    *cfd = socket(AF_INET, SOCK_STREAM, 0);
-    if (*cfd < 0)
+    cfd = socket(AF_INET, SOCK_STREAM, 0);
+    if (cfd < 0)
         goto out;
 
     if (set_nb(afd) == -1)
         goto out;
 
-    while (*sfd == -1 || !cfd_connected ) {
-        *sfd = accept(afd, NULL, 0);
-        if (*sfd == -1 && errno != EAGAIN)
+    while (sfd == -1 || !cfd_connected ) {
+        sfd = accept(afd, NULL, 0);
+        if (sfd == -1 && errno != EAGAIN)
             goto out;
 
-        if (!cfd_connected && connect(*cfd, (struct sockaddr*)&sin, sizeof(sin)) < 0)
+        if (!cfd_connected && connect(cfd, (struct sockaddr*)&sin, sizeof(sin)) < 0)
             goto out;
         else
             cfd_connected = 1;
     }
 
-    if (set_nb(*cfd) == -1 || set_nb(*sfd) == -1)
+    if (set_nb(cfd) == -1 || set_nb(sfd) == -1)
         goto out;
     ret = 1;
+    *cfdp = cfd;
+    *sfdp = sfd;
     goto success;
 
 out:
-        if (*cfd != -1)
-            close(*cfd);
-        if (*sfd != -1)
-            close(*sfd);
+    if (cfd != -1)
+        close(cfd);
+    if (sfd != -1)
+        close(sfd);
 success:
-        if (afd != -1)
-            close(afd);
+    if (afd != -1)
+        close(afd);
     return ret;
 }
 

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -1407,6 +1407,9 @@ static struct ktls_test_cipher {
 #  ifdef OPENSSL_KTLS_AES_GCM_256
     { TLS1_2_VERSION, "AES256-GCM-SHA384"},
 #  endif
+#  ifdef OPENSSL_KTLS_CHACHA20_POLY1305
+    { TLS1_2_VERSION, "ECDHE-RSA-CHACHA20-POLY1305"},
+#  endif
 # endif
 # if !defined(OSSL_NO_USABLE_TLS1_3)
 #  ifdef OPENSSL_KTLS_AES_GCM_128
@@ -1417,6 +1420,9 @@ static struct ktls_test_cipher {
 #  endif
 #  ifdef OPENSSL_KTLS_AES_GCM_256
     { TLS1_3_VERSION, "TLS_AES_256_GCM_SHA384" },
+#  endif
+#  ifdef OPENSSL_KTLS_CHACHA20_POLY1305
+    { TLS1_3_VERSION, "TLS_CHACHA20_POLY1305_SHA256" },
 #  endif
 # endif
 };

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -1034,7 +1034,6 @@ static int execute_test_large_message(const SSL_METHOD *smeth,
 
 #if !defined(OPENSSL_NO_SOCK) && !defined(OPENSSL_NO_KTLS) && \
     !(defined(OSSL_NO_USABLE_TLS1_3) && defined(OPENSSL_NO_TLS1_2))
-#define TLS_CIPHER_MAX_REC_SEQ_SIZE 8
 /* sock must be connected */
 static int ktls_chk_platform(int sock)
 {
@@ -1043,26 +1042,26 @@ static int ktls_chk_platform(int sock)
     return 1;
 }
 
-static int ping_pong_query(SSL *clientssl, SSL *serverssl, int cfd, int sfd, int rec_seq_size)
+static int ping_pong_query(SSL *clientssl, SSL *serverssl)
 {
     static char count = 1;
     unsigned char cbuf[16000] = {0};
     unsigned char sbuf[16000];
     size_t err = 0;
-    char crec_wseq_before[TLS_CIPHER_MAX_REC_SEQ_SIZE];
-    char crec_wseq_after[TLS_CIPHER_MAX_REC_SEQ_SIZE];
-    char crec_rseq_before[TLS_CIPHER_MAX_REC_SEQ_SIZE];
-    char crec_rseq_after[TLS_CIPHER_MAX_REC_SEQ_SIZE];
-    char srec_wseq_before[TLS_CIPHER_MAX_REC_SEQ_SIZE];
-    char srec_wseq_after[TLS_CIPHER_MAX_REC_SEQ_SIZE];
-    char srec_rseq_before[TLS_CIPHER_MAX_REC_SEQ_SIZE];
-    char srec_rseq_after[TLS_CIPHER_MAX_REC_SEQ_SIZE];
+    char crec_wseq_before[SEQ_NUM_SIZE];
+    char crec_wseq_after[SEQ_NUM_SIZE];
+    char crec_rseq_before[SEQ_NUM_SIZE];
+    char crec_rseq_after[SEQ_NUM_SIZE];
+    char srec_wseq_before[SEQ_NUM_SIZE];
+    char srec_wseq_after[SEQ_NUM_SIZE];
+    char srec_rseq_before[SEQ_NUM_SIZE];
+    char srec_rseq_after[SEQ_NUM_SIZE];
 
     cbuf[0] = count++;
-    memcpy(crec_wseq_before, &clientssl->rlayer.write_sequence, rec_seq_size);
-    memcpy(crec_rseq_before, &clientssl->rlayer.read_sequence, rec_seq_size);
-    memcpy(srec_wseq_before, &serverssl->rlayer.write_sequence, rec_seq_size);
-    memcpy(srec_rseq_before, &serverssl->rlayer.read_sequence, rec_seq_size);
+    memcpy(crec_wseq_before, &clientssl->rlayer.write_sequence, SEQ_NUM_SIZE);
+    memcpy(crec_rseq_before, &clientssl->rlayer.read_sequence, SEQ_NUM_SIZE);
+    memcpy(srec_wseq_before, &serverssl->rlayer.write_sequence, SEQ_NUM_SIZE);
+    memcpy(srec_rseq_before, &serverssl->rlayer.read_sequence, SEQ_NUM_SIZE);
 
     if (!TEST_true(SSL_write(clientssl, cbuf, sizeof(cbuf)) == sizeof(cbuf)))
         goto end;
@@ -1082,61 +1081,56 @@ static int ping_pong_query(SSL *clientssl, SSL *serverssl, int cfd, int sfd, int
         }
     }
 
-    memcpy(crec_wseq_after, &clientssl->rlayer.write_sequence, rec_seq_size);
-    memcpy(crec_rseq_after, &clientssl->rlayer.read_sequence, rec_seq_size);
-    memcpy(srec_wseq_after, &serverssl->rlayer.write_sequence, rec_seq_size);
-    memcpy(srec_rseq_after, &serverssl->rlayer.read_sequence, rec_seq_size);
+    memcpy(crec_wseq_after, &clientssl->rlayer.write_sequence, SEQ_NUM_SIZE);
+    memcpy(crec_rseq_after, &clientssl->rlayer.read_sequence, SEQ_NUM_SIZE);
+    memcpy(srec_wseq_after, &serverssl->rlayer.write_sequence, SEQ_NUM_SIZE);
+    memcpy(srec_rseq_after, &serverssl->rlayer.read_sequence, SEQ_NUM_SIZE);
 
     /* verify the payload */
     if (!TEST_mem_eq(cbuf, sizeof(cbuf), sbuf, sizeof(sbuf)))
         goto end;
 
-    /* ktls is used then kernel sequences are used instead of OpenSSL sequences */
-    if ((SSL_get_options(clientssl) & SSL_OP_ENABLE_KTLS) == 0) {
-        if (!TEST_mem_ne(crec_wseq_before, rec_seq_size,
-                         crec_wseq_after, rec_seq_size))
+    /*
+     * If ktls is used then kernel sequences are used instead of
+     * OpenSSL sequences
+     */
+    if (!BIO_get_ktls_send(clientssl->wbio)) {
+        if (!TEST_mem_ne(crec_wseq_before, SEQ_NUM_SIZE,
+                         crec_wseq_after, SEQ_NUM_SIZE))
             goto end;
     } else {
-        if (!TEST_mem_eq(crec_wseq_before, rec_seq_size,
-                         crec_wseq_after, rec_seq_size))
+        if (!TEST_mem_eq(crec_wseq_before, SEQ_NUM_SIZE,
+                         crec_wseq_after, SEQ_NUM_SIZE))
             goto end;
     }
 
-    if ((SSL_get_options(serverssl) & SSL_OP_ENABLE_KTLS) == 0) {
-        if (!TEST_mem_ne(srec_wseq_before, rec_seq_size,
-                         srec_wseq_after, rec_seq_size))
+    if (!BIO_get_ktls_send(serverssl->wbio)) {
+        if (!TEST_mem_ne(srec_wseq_before, SEQ_NUM_SIZE,
+                         srec_wseq_after, SEQ_NUM_SIZE))
             goto end;
     } else {
-        if (!TEST_mem_eq(srec_wseq_before, rec_seq_size,
-                         srec_wseq_after, rec_seq_size))
+        if (!TEST_mem_eq(srec_wseq_before, SEQ_NUM_SIZE,
+                         srec_wseq_after, SEQ_NUM_SIZE))
             goto end;
     }
 
-    if ((SSL_get_options(clientssl) & SSL_OP_ENABLE_KTLS) == 0
-#if defined(OPENSSL_NO_KTLS_RX)
-        || 1
-#endif
-       ) {
-        if (!TEST_mem_ne(crec_rseq_before, rec_seq_size,
-                         crec_rseq_after, rec_seq_size))
+    if (!BIO_get_ktls_recv(clientssl->wbio)) {
+        if (!TEST_mem_ne(crec_rseq_before, SEQ_NUM_SIZE,
+                         crec_rseq_after, SEQ_NUM_SIZE))
             goto end;
     } else {
-        if (!TEST_mem_eq(crec_rseq_before, rec_seq_size,
-                         crec_rseq_after, rec_seq_size))
+        if (!TEST_mem_eq(crec_rseq_before, SEQ_NUM_SIZE,
+                         crec_rseq_after, SEQ_NUM_SIZE))
             goto end;
     }
 
-    if ((SSL_get_options(serverssl) & SSL_OP_ENABLE_KTLS) == 0
-#if defined(OPENSSL_NO_KTLS_RX)
-        || 1
-#endif
-       ) {
-        if (!TEST_mem_ne(srec_rseq_before, rec_seq_size,
-                         srec_rseq_after, rec_seq_size))
+    if (!BIO_get_ktls_recv(serverssl->wbio)) {
+        if (!TEST_mem_ne(srec_rseq_before, SEQ_NUM_SIZE,
+                         srec_rseq_after, SEQ_NUM_SIZE))
             goto end;
     } else {
-        if (!TEST_mem_eq(srec_rseq_before, rec_seq_size,
-                         srec_rseq_after, rec_seq_size))
+        if (!TEST_mem_eq(srec_rseq_before, SEQ_NUM_SIZE,
+                         srec_rseq_after, SEQ_NUM_SIZE))
             goto end;
     }
 
@@ -1146,30 +1140,42 @@ end:
 }
 
 static int execute_test_ktls(int cis_ktls, int sis_ktls,
-                             int tls_version, const char *cipher,
-                             int rec_seq_size)
+                             int tls_version, const char *cipher)
 {
     SSL_CTX *cctx = NULL, *sctx = NULL;
     SSL *clientssl = NULL, *serverssl = NULL;
-    int testresult = 0;
-    int cfd, sfd;
+    int ktls_used = 0, testresult = 0;
+    int cfd = -1, sfd = -1;
+    int rx_supported;
 
     if (!TEST_true(create_test_sockets(&cfd, &sfd)))
         goto end;
 
     /* Skip this test if the platform does not support ktls */
-    if (!ktls_chk_platform(cfd))
-        return 1;
+    if (!ktls_chk_platform(cfd)) {
+        testresult = TEST_skip("Kernel does not support KTLS");
+        goto end;
+    }
 
     /* Create a session based on SHA-256 */
     if (!TEST_true(create_ssl_ctx_pair(libctx, TLS_server_method(),
                                        TLS_client_method(),
                                        tls_version, tls_version,
-                                       &sctx, &cctx, cert, privkey))
-            || !TEST_true(SSL_CTX_set_cipher_list(cctx, cipher))
-            || !TEST_true(SSL_CTX_set_cipher_list(sctx, cipher))
-            || !TEST_true(create_ssl_objects2(sctx, cctx, &serverssl,
-                                          &clientssl, sfd, cfd)))
+                                       &sctx, &cctx, cert, privkey)))
+        goto end;
+
+    if (tls_version == TLS1_3_VERSION) {
+        if (!TEST_true(SSL_CTX_set_ciphersuites(cctx, cipher))
+            || !TEST_true(SSL_CTX_set_ciphersuites(sctx, cipher)))
+            goto end;
+    } else {
+        if (!TEST_true(SSL_CTX_set_cipher_list(cctx, cipher))
+            || !TEST_true(SSL_CTX_set_cipher_list(sctx, cipher)))
+            goto end;
+    }
+
+    if (!TEST_true(create_ssl_objects2(sctx, cctx, &serverssl,
+                                       &clientssl, sfd, cfd)))
         goto end;
 
     if (cis_ktls) {
@@ -1178,56 +1184,63 @@ static int execute_test_ktls(int cis_ktls, int sis_ktls,
     }
 
     if (sis_ktls) {
-        if (!TEST_true(SSL_set_mode(serverssl, SSL_OP_ENABLE_KTLS)))
+        if (!TEST_true(SSL_set_options(serverssl, SSL_OP_ENABLE_KTLS)))
             goto end;
     }
 
-    if (!TEST_true(create_ssl_connection(serverssl, clientssl,
-                                                SSL_ERROR_NONE)))
+    if (!TEST_true(create_ssl_connection(serverssl, clientssl, SSL_ERROR_NONE)))
         goto end;
 
+    /*
+     * The running kernel may not support a given cipher suite
+     * or direction, so just check that KTLS isn't used when it
+     * isn't enabled.
+     */
     if (!cis_ktls) {
         if (!TEST_false(BIO_get_ktls_send(clientssl->wbio)))
             goto end;
     } else {
-        if (!TEST_true(BIO_get_ktls_send(clientssl->wbio)))
-            goto end;
+        if (BIO_get_ktls_send(clientssl->wbio))
+            ktls_used = 1;
     }
 
     if (!sis_ktls) {
         if (!TEST_false(BIO_get_ktls_send(serverssl->wbio)))
             goto end;
     } else {
-        if (!TEST_true(BIO_get_ktls_send(serverssl->wbio)))
-            goto end;
+        if (BIO_get_ktls_send(serverssl->wbio))
+            ktls_used = 1;
     }
 
-    if (!cis_ktls
 #if defined(OPENSSL_NO_KTLS_RX)
-        || 1
+    rx_supported = 0;
+#else
+    rx_supported = (tls_version != TLS1_3_VERSION);
 #endif
-       ) {
+    if (!cis_ktls || !rx_supported) {
         if (!TEST_false(BIO_get_ktls_recv(clientssl->rbio)))
             goto end;
     } else {
-        if (!TEST_true(BIO_get_ktls_recv(clientssl->rbio)))
-            goto end;
+        if (BIO_get_ktls_send(clientssl->rbio))
+            ktls_used = 1;
     }
 
-    if (!sis_ktls
-#if defined(OPENSSL_NO_KTLS_RX)
-        || 1
-#endif
-       ) {
+    if (!sis_ktls || !rx_supported) {
         if (!TEST_false(BIO_get_ktls_recv(serverssl->rbio)))
             goto end;
     } else {
-        if (!TEST_true(BIO_get_ktls_recv(serverssl->rbio)))
-            goto end;
+        if (BIO_get_ktls_send(serverssl->rbio))
+            ktls_used = 1;
     }
 
-    if (!TEST_true(ping_pong_query(clientssl, serverssl, cfd, sfd,
-				   rec_seq_size)))
+    if ((cis_ktls || sis_ktls) && !ktls_used) {
+        testresult = TEST_skip("KTLS not supported for %s cipher %s",
+                               tls_version == TLS1_3_VERSION ? "TLS 1.3" :
+                               "TLS 1.2", cipher);
+        goto end;
+    }
+
+    if (!TEST_true(ping_pong_query(clientssl, serverssl)))
         goto end;
 
     testresult = 1;
@@ -1243,6 +1256,10 @@ end:
     SSL_CTX_free(sctx);
     SSL_CTX_free(cctx);
     serverssl = clientssl = NULL;
+    if (cfd != -1)
+        close(cfd);
+    if (sfd != -1)
+        close(sfd);
     return testresult;
 }
 
@@ -1250,13 +1267,13 @@ end:
 #define SENDFILE_CHUNK                  (4 * 4096)
 #define min(a,b)                        ((a) > (b) ? (b) : (a))
 
-static int test_ktls_sendfile(int tls_version, const char *cipher)
+static int execute_test_ktls_sendfile(int tls_version, const char *cipher)
 {
     SSL_CTX *cctx = NULL, *sctx = NULL;
     SSL *clientssl = NULL, *serverssl = NULL;
     unsigned char *buf, *buf_dst;
     BIO *out = NULL, *in = NULL;
-    int cfd, sfd, ffd, err;
+    int cfd = -1, sfd = -1, ffd, err;
     ssize_t chunk_size = 0;
     off_t chunk_off = 0;
     int testresult = 0;
@@ -1270,7 +1287,7 @@ static int test_ktls_sendfile(int tls_version, const char *cipher)
 
     /* Skip this test if the platform does not support ktls */
     if (!ktls_chk_platform(sfd)) {
-        testresult = 1;
+        testresult = TEST_skip("Kernel does not support KTLS");
         goto end;
     }
 
@@ -1278,17 +1295,36 @@ static int test_ktls_sendfile(int tls_version, const char *cipher)
     if (!TEST_true(create_ssl_ctx_pair(libctx, TLS_server_method(),
                                        TLS_client_method(),
                                        tls_version, tls_version,
-                                       &sctx, &cctx, cert, privkey))
-        || !TEST_true(SSL_CTX_set_cipher_list(cctx, cipher))
-        || !TEST_true(SSL_CTX_set_cipher_list(sctx, cipher))
-        || !TEST_true(create_ssl_objects2(sctx, cctx, &serverssl,
-                                          &clientssl, sfd, cfd)))
+                                       &sctx, &cctx, cert, privkey)))
+        goto end;
+
+    if (tls_version == TLS1_3_VERSION) {
+        if (!TEST_true(SSL_CTX_set_ciphersuites(cctx, cipher))
+            || !TEST_true(SSL_CTX_set_ciphersuites(sctx, cipher)))
+            goto end;
+    } else {
+        if (!TEST_true(SSL_CTX_set_cipher_list(cctx, cipher))
+            || !TEST_true(SSL_CTX_set_cipher_list(sctx, cipher)))
+            goto end;
+    }
+
+    if (!TEST_true(create_ssl_objects2(sctx, cctx, &serverssl,
+                                       &clientssl, sfd, cfd)))
+        goto end;
+
+    if (!TEST_true(SSL_set_options(serverssl, SSL_OP_ENABLE_KTLS)))
         goto end;
 
     if (!TEST_true(create_ssl_connection(serverssl, clientssl,
-                                         SSL_ERROR_NONE))
-        || !TEST_true(BIO_get_ktls_send(serverssl->wbio)))
+                                         SSL_ERROR_NONE)))
         goto end;
+
+    if (!BIO_get_ktls_send(serverssl->wbio)) {
+        testresult = TEST_skip("Failed to enable KTLS for %s cipher %s",
+                               tls_version == TLS1_3_VERSION ? "TLS 1.3" :
+                               "TLS 1.2", cipher);
+        goto end;
+    }
 
     if (!TEST_true(RAND_bytes_ex(libctx, buf, SENDFILE_SZ, 0)))
         goto end;
@@ -1348,86 +1384,70 @@ end:
     serverssl = clientssl = NULL;
     BIO_free(out);
     BIO_free(in);
+    if (cfd != -1)
+        close(cfd);
+    if (sfd != -1)
+        close(sfd);
     OPENSSL_free(buf);
     OPENSSL_free(buf_dst);
     return testresult;
 }
 
-#if !defined(OPENSSL_NO_TLS1_2) || !defined(OSSL_NO_USABLE_TLS1_3)
+static struct ktls_test_cipher {
+    int tls_version;
+    const char *cipher;
+} ktls_test_ciphers[] = {
+# if !defined(OPENSSL_NO_TLS1_2)
+#  ifdef OPENSSL_KTLS_AES_GCM_128
+    { TLS1_2_VERSION, "AES128-GCM-SHA256" },
+#  endif
+#  ifdef OPENSSL_KTLS_AES_CCM_128
+    { TLS1_2_VERSION, "AES128-CCM"},
+#  endif
+#  ifdef OPENSSL_KTLS_AES_GCM_256
+    { TLS1_2_VERSION, "AES256-GCM-SHA384"},
+#  endif
+# endif
+# if !defined(OSSL_NO_USABLE_TLS1_3)
+#  ifdef OPENSSL_KTLS_AES_GCM_128
+    { TLS1_3_VERSION, "TLS_AES_128_GCM_SHA256" },
+#  endif
+#  ifdef OPENSSL_KTLS_AES_CCM_128
+    { TLS1_3_VERSION, "TLS_AES_128_CCM_SHA256" },
+#  endif
+#  ifdef OPENSSL_KTLS_AES_GCM_256
+    { TLS1_3_VERSION, "TLS_AES_256_GCM_SHA384" },
+#  endif
+# endif
+};
+
+#define NUM_KTLS_TEST_CIPHERS \
+    (sizeof(ktls_test_ciphers) / sizeof(ktls_test_ciphers[0]))
+
 static int test_ktls(int test)
 {
+    struct ktls_test_cipher *cipher;
     int cis_ktls, sis_ktls;
-    int tlsver, testresult;
 
-    if (test > 3) {
-#if defined(OSSL_NO_USABLE_TLS1_3)
-        return 1;
-#else
-        test -= 4;
-        tlsver = TLS1_3_VERSION;
-#endif
-    } else {
-#if defined(OPENSSL_NO_TLS1_2)
-        return 1;
-#else
-        tlsver = TLS1_2_VERSION;
-#endif
-    }
+    OPENSSL_assert(test / 4 < NUM_KTLS_TEST_CIPHERS);
+    cipher = &ktls_test_ciphers[test / 4];
 
     cis_ktls = (test & 1) != 0;
     sis_ktls = (test & 2) != 0;
 
-    testresult = 1;
-#ifdef OPENSSL_KTLS_AES_GCM_128
-    testresult &= execute_test_ktls(cis_ktls, sis_ktls, tlsver,
-                                    "AES128-GCM-SHA256",
-                                    TLS_CIPHER_AES_GCM_128_REC_SEQ_SIZE);
-#endif
-#ifdef OPENSSL_KTLS_AES_CCM_128
-    testresult &= execute_test_ktls(cis_ktls, sis_ktls, tlsver, "AES128-CCM",
-                                    TLS_CIPHER_AES_CCM_128_REC_SEQ_SIZE);
-#endif
-#ifdef OPENSSL_KTLS_AES_GCM_256
-    testresult &= execute_test_ktls(cis_ktls, sis_ktls, tlsver,
-                                    "AES256-GCM-SHA384",
-                                    TLS_CIPHER_AES_GCM_256_REC_SEQ_SIZE);
-#endif
-    return testresult;
+    return execute_test_ktls(cis_ktls, sis_ktls, cipher->tls_version,
+                             cipher->cipher);
 }
 
-static int test_ktls_sendfile_anytls(int tst)
+static int test_ktls_sendfile(int tst)
 {
-    char *cipher[] = {"AES128-GCM-SHA256","AES128-CCM","AES256-GCM-SHA384"};
-    int tlsver;
+    struct ktls_test_cipher *cipher;
 
-    if (tst > 2) {
-#if defined(OSSL_NO_USABLE_TLS1_3)
-        return 1;
-#else
-        tst -= 3;
-        tlsver = TLS1_3_VERSION;
-#endif
-    } else {
-#if defined(OPENSSL_NO_TLS1_2)
-        return 1;
-#else
-        tlsver = TLS1_2_VERSION;
-#endif
-    }
+    OPENSSL_assert(tst < NUM_KTLS_TEST_CIPHERS);
+    cipher = &ktls_test_ciphers[tst];
 
-#ifndef OPENSSL_KTLS_AES_GCM_128
-   if(tst == 0) return 1;
-#endif
-#ifndef OPENSSL_KTLS_AES_CCM_128
-   if(tst == 1) return 1;
-#endif
-#ifndef OPENSSL_KTLS_AES_GCM_256
-   if(tst == 2) return 1;
-#endif
-   return test_ktls_sendfile(tlsver, cipher[tst]);
+    return execute_test_ktls_sendfile(cipher->tls_version, cipher->cipher);
 }
-
-#endif
 #endif
 
 static int test_large_message_tls(void)
@@ -9277,8 +9297,8 @@ int setup_tests(void)
 
 #if !defined(OPENSSL_NO_KTLS) && !defined(OPENSSL_NO_SOCK)
 # if !defined(OPENSSL_NO_TLS1_2) || !defined(OSSL_NO_USABLE_TLS1_3)
-    ADD_ALL_TESTS(test_ktls, 8);
-    ADD_ALL_TESTS(test_ktls_sendfile_anytls, 6);
+    ADD_ALL_TESTS(test_ktls, NUM_KTLS_TEST_CIPHERS * 4);
+    ADD_ALL_TESTS(test_ktls_sendfile, NUM_KTLS_TEST_CIPHERS);
 # endif
 #endif
     ADD_TEST(test_large_message_tls);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated

Mostly these changes seek to fix testing of TLS 1.3 with KTLS.  Previously since the cipher suites were never set, the TLS 1.3 tests always tested the default cipher instead of the requested cipher.  While fixing this I also cleaned up some other bits of the KTLS tests (including fixing a small regression in #14799 where it still used SSL_set_mode for the serverssl) to make them a bit more robust in the face of varying kernel support and to make it easier to add new cipher suites.  Patch 2 adds TLS 1.2 and TLS 1.3 Chacha20-Poly1305 test suites for supported platforms (currently only for Linux).