### PR TITLE
params: avoid using intmax_t since it's not well supported

### DIFF
--- a/crypto/params.c
+++ b/crypto/params.c
@@ -1010,7 +1010,7 @@ int OSSL_PARAM_set_double(OSSL_PARAM *p, double val)
             return 1;
         }
     } else if (p->data_type == OSSL_PARAM_UNSIGNED_INTEGER
-               && val == (ossl_uintmax_t)val) {
+               && val == (uint64_t)val) {
         p->return_size = sizeof(double);
         if (p->data == NULL)
             return 1;
@@ -1035,7 +1035,7 @@ int OSSL_PARAM_set_double(OSSL_PARAM *p, double val)
                 return 1;
             }
             break;            }
-    } else if (p->data_type == OSSL_PARAM_INTEGER && val == (ossl_intmax_t)val) {
+    } else if (p->data_type == OSSL_PARAM_INTEGER && val == (int64_t)val) {
         p->return_size = sizeof(double);
         if (p->data == NULL)
             return 1;


### PR DESCRIPTION
Converting doubles to integers used to go via intmax_t which isn't properly
defined on some platforms.  The alternative is to go via int64_t.

Fixes #15815
Alternative to #15816

