### PR TITLE
ssl: do not choose auto DH groups that are weaker than the security level

### DIFF
--- a/ssl/ssl_cert.c
+++ b/ssl/ssl_cert.c
@@ -960,18 +960,36 @@ int ssl_cert_set_cert_store(CERT *c, X509_STORE *store, int chain, int ref)
     return 1;
 }
 
+int ssl_get_security_level_bits(const SSL *s, const SSL_CTX *ctx, int *levelp)
+{
+    int level;
+    static const int minbits_table[5 + 1] = { 0, 80, 112, 128, 192, 256 };
+
+    if (ctx != NULL)
+        level = SSL_CTX_get_security_level(ctx);
+    else
+        level = SSL_get_security_level(s);
+
+    if (level > 5)
+        level = 5;
+    else if (level < 0)
+        level = 0;
+
+    if (levelp != NULL)
+        *levelp = level;
+
+    return minbits_table[level];
+}
+
 static int ssl_security_default_callback(const SSL *s, const SSL_CTX *ctx,
                                          int op, int bits, int nid, void *other,
                                          void *ex)
 {
     int level, minbits;
-    static const int minbits_table[5] = { 80, 112, 128, 192, 256 };
-    if (ctx)
-        level = SSL_CTX_get_security_level(ctx);
-    else
-        level = SSL_get_security_level(s);
 
-    if (level <= 0) {
+    minbits = ssl_get_security_level_bits(s, ctx, &level);
+
+    if (level == 0) {
         /*
          * No EDH keys weaker than 1024-bits even at level 0, otherwise,
          * anything goes.
@@ -980,9 +998,6 @@ static int ssl_security_default_callback(const SSL *s, const SSL_CTX *ctx,
             return 0;
         return 1;
     }
-    if (level > 5)
-        level = 5;
-    minbits = minbits_table[level - 1];
     switch (op) {
     case SSL_SECOP_CIPHER_SUPPORTED:
     case SSL_SECOP_CIPHER_SHARED:

--- a/ssl/ssl_local.h
+++ b/ssl/ssl_local.h
@@ -2436,6 +2436,7 @@ __owur int ssl_cert_set_cert_store(CERT *c, X509_STORE *store, int chain,
 __owur int ssl_security(const SSL *s, int op, int bits, int nid, void *other);
 __owur int ssl_ctx_security(const SSL_CTX *ctx, int op, int bits, int nid,
                             void *other);
+int ssl_get_security_level_bits(const SSL *s, const SSL_CTX *ctx, int *levelp);
 
 __owur int ssl_cert_lookup_by_nid(int nid, size_t *pidx);
 __owur const SSL_CERT_LOOKUP *ssl_cert_lookup_by_pkey(const EVP_PKEY *pk,

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -2884,7 +2884,7 @@ EVP_PKEY *ssl_get_auto_dh(SSL *s)
 {
     EVP_PKEY *dhp = NULL;
     BIGNUM *p;
-    int dh_secbits = 80;
+    int dh_secbits = 80, sec_level_bits;
     EVP_PKEY_CTX *pctx = NULL;
     OSSL_PARAM_BLD *tmpl = NULL;
     OSSL_PARAM *params = NULL;
@@ -2901,6 +2901,11 @@ EVP_PKEY *ssl_get_auto_dh(SSL *s)
             dh_secbits = EVP_PKEY_get_security_bits(s->s3.tmp.cert->privatekey);
         }
     }
+
+    /* Do not pick a prime that is too weak for the current security level */
+    sec_level_bits = ssl_get_security_level_bits(s, NULL, NULL);
+    if (dh_secbits < sec_level_bits)
+        dh_secbits = sec_level_bits;
 
     if (dh_secbits >= 192)
         p = BN_get_rfc3526_prime_8192(NULL);

--- a/test/recipes/80-test_ssl_old.t
+++ b/test/recipes/80-test_ssl_old.t
@@ -520,10 +520,10 @@ sub testssl {
     subtest 'RSA/(EC)DHE/PSK tests' => sub {
 	######################################################################
 
-	plan tests => 5;
+	plan tests => 6;
 
       SKIP: {
-	  skip "TLSv1.0 is not supported by this OpenSSL build", 5
+	  skip "TLSv1.0 is not supported by this OpenSSL build", 6
 	      if $no_tls1 || $provider eq "fips";
 
 	SKIP: {
@@ -549,7 +549,7 @@ sub testssl {
 	  }
 
 	SKIP: {
-	    skip "skipping PSK tests", 2
+	    skip "skipping PSK tests", 3
 	        if ($no_psk);
 
 	    ok(run(test([@ssltest, "-tls1", "-cipher", "PSK", "-psk", "abc123"])),
@@ -557,6 +557,9 @@ sub testssl {
 
 	    ok(run(test([@ssltest, "-bio_pair", "-tls1", "-cipher", "PSK", "-psk", "abc123"])),
 	       'test tls1 with PSK via BIO pair');
+
+            ok(run(test(['ssl_old_test', '-psk', '0102030405', '-cipher', '@SECLEVEL=2:DHE-PSK-AES128-CCM'])),
+               'test auto DH meets security strength');
 	  }
 	}
 


### PR DESCRIPTION
I'm not sure if this is sensible for 1.1.1 or not.

Fixes #15808

- [ ] documentation is added or updated
- [ ] tests are added or updated
