### PR TITLE
STORE: Fix OSSL_STORE_open_ex() error reporting, take 2

### DIFF
--- a/crypto/store/store_meth.c
+++ b/crypto/store/store_meth.c
@@ -344,11 +344,18 @@ inner_loader_fetch(struct loader_data_st *methdata, int id,
 
     if ((id != 0 || scheme != NULL) && method == NULL) {
         int code = unsupported ? ERR_R_UNSUPPORTED : ERR_R_FETCH_FAILED;
+        const char *helpful_msg =
+            unsupported
+            ? ( "No store loader found. For standard store loaders you need "
+                "at least one of the default or base providers available. "
+                "Did you forget to load them? Info: " )
+            : "";
 
         if (scheme == NULL)
             scheme = ossl_namemap_num2name(namemap, id, 0);
         ERR_raise_data(ERR_LIB_OSSL_STORE, code,
-                       "%s, Scheme (%s : %d), Properties (%s)",
+                       "%s%s, Scheme (%s : %d), Properties (%s)",
+                       helpful_msg,
                        ossl_lib_ctx_get_descriptor(methdata->libctx),
                        scheme = NULL ? "<null>" : scheme, id,
                        properties == NULL ? "<null>" : properties);


### PR DESCRIPTION
OSSL_STORE_open_ex() could result in reports like this:

    80722AA3927F0000:error:80000002:system library:file_open_ex:No such file or directory:engines/e_loader_attic.c:1016:calling stat(file:test/blahdibleh.der)
    80722AA3927F0000:error:41800069:lib(131)::path must be absolute:engines/e_loader_attic.c:1010:test/blahdibleh.der
    80722AA3927F0000:error:1600007B:STORE routines:OSSL_STORE_open_ex:no loaders found:crypto/store/store_lib.c:148:No store loaders were found. For standard store loaders you need at least one of the default or base providers available. Did you forget to load them?

The last one turns out to be a bit too generically reported.  It
should only be reported when no loader were loaded at all, not when
loader_ctx happens to be NULL (which may happen for other reasons).

We also move the helpful message to the OSSL_STORE_LOADER fetcher.

-----

Replaces #15476