### PR TITLE
TESTS: drop explicit quotes from empty command line arguments

### DIFF
--- a/test/recipes/25-test_req.t
+++ b/test/recipes/25-test_req.t
@@ -373,7 +373,7 @@ sub generate_cert {
     my $cn = $is_ca ? "CA" : "EE";
     my $ca_key = srctop_file(@certs, "ca-key.pem");
     my $key = $is_ca ? $ca_key : srctop_file(@certs, "ee-key.pem");
-    my @cmd = ("openssl", "req", "-config", "\"\"", "-x509",
+    my @cmd = ("openssl", "req", "-config", "", "-x509",
                "-key", $key, "-subj", "/CN=$cn", @_, "-out", $cert);
     push(@cmd, ("-CA", $ca_cert, "-CAkey", $ca_key)) unless $ss;
     ok(run(app([@cmd])), "generate $cert");

--- a/test/recipes/81-test_cmp_cli.t
+++ b/test/recipes/81-test_cmp_cli.t
@@ -53,7 +53,7 @@ foreach (@cmp_basic_tests) {
     my $title = $$_[0];
     my $params = $$_[1];
     my $expected = $$_[2];
-    ok($expected == run(cmd([$app, "-config", '""', @$params])),
+    ok($expected == run(cmd([$app, "-config", '', @$params])),
        $title);
 }
 
@@ -66,7 +66,7 @@ foreach (@cmp_server_tests) {
     my $rsp_cert = srctop_file('test',  'certs', 'ee-cert-1024.pem');
     my $outfile = result_file("test.certout.pem");
     ok($expected ==
-       run(cmd([$app, "-config", '""', @$extra_args,
+       run(cmd([$app, "-config", '', @$extra_args,
                 "-use_mock_srv", "-srv_ref", "mock server",
                 "-srv_secret", $secret,
                 "-rsp_cert", $rsp_cert,


### PR DESCRIPTION
Depending on circumstances, something like this:

    ok(run(app(['openssl', 'whatever', '-config', '""', ...])))

might end up with a command like this:

    ./util/wrap.pl apps/openssl whatever -config '""'

Simply use an empty string (i.e. '' instead of '""') and let the
command line fixup functions do their job.
