### PR TITLE
Fix small VMS specific test recipe errors

### DIFF
--- a/apps/CA.pl.in
+++ b/apps/CA.pl.in
@@ -209,7 +209,9 @@ if ($WHAT eq '-newcert' ) {
 } elsif ($WHAT eq '-verify' ) {
     my @files = @ARGV ? @ARGV : ( $NEWCERT );
     foreach my $file (@files) {
-        my $status = run("$VERIFY -CAfile ${CATOP}/$CACERT $file $EXTRA{verify}");
+        # -CAfile quoted for VMS, since the C RTL downcases all unquoted
+        # arguments to C programs
+        my $status = run("$VERIFY \"-CAfile\" ${CATOP}/$CACERT $file $EXTRA{verify}");
         $RET = $status if $status != 0;
     }
 } elsif ($WHAT eq '-crl' ) {

--- a/test/ossl_store_test.c
+++ b/test/ossl_store_test.c
@@ -7,6 +7,7 @@
  * https://www.openssl.org/source/license.html
  */
 
+#include <string.h>
 #include <limits.h>
 #include <openssl/store.h>
 #include <openssl/ui.h>
@@ -101,6 +102,7 @@ static int get_params(const char *uri, const char *type)
 static int test_store_get_params(int idx)
 {
     const char *type;
+    const char *urifmt;
     char uri[PATH_MAX];
 
     switch(idx) {
@@ -128,8 +130,16 @@ static int test_store_get_params(int idx)
         return 0;
     }
 
-    if (!TEST_true(BIO_snprintf(uri, sizeof(uri), "%s/%s-params.pem",
-                                datadir, type)))
+    urifmt = "%s/%s-params.pem";
+#ifdef __VMS
+    {
+        char datadir_end = datadir[strlen(datadir) - 1];
+
+        if (datadir_end == ':' || datadir_end == ']' || datadir_end == '>')
+            urifmt = "%s%s-params.pem";
+    }
+#endif
+    if (!TEST_true(BIO_snprintf(uri, sizeof(uri), urifmt, datadir, type)))
         return 0;
 
     TEST_info("Testing uri: %s", uri);

--- a/test/recipes/02-test_errstr.t
+++ b/test/recipes/02-test_errstr.t
@@ -122,7 +122,10 @@ sub match_any {
         $desc = "match '$first' ($desc) with '$strings[0]'";
     }
 
-    return ( scalar( grep { $first eq $_ } @strings ) > 0,
+    return ( scalar(
+                 grep { ref $_ eq 'Regexp' ? $first =~ $_ : $first eq $_ }
+                 @strings
+             ) > 0,
              $desc );
 }
 
@@ -150,6 +153,9 @@ sub match_syserr_reason {
           # ... and $! will give you the error string back
           $!
     };
+    # Occasionally, we get an error code that is simply not translatable
+    # to POSIX semantics on VMS, and we get an error string saying so.
+    push @strings, qr/^non-translatable vms error code:/ if $^O eq 'VMS';
     # The OpenSSL fallback string
     push @strings, "reason($errcode)";
 

--- a/test/recipes/25-test_x509.t
+++ b/test/recipes/25-test_x509.t
@@ -40,6 +40,7 @@ is(cmp_text($out_utf8, $utf),
 
 SKIP: {
     skip "DES disabled", 1 if disabled("des");
+    skip "VMS doesn't support command line UTF-8", 1 if $^O eq 'VMS';
 
     my $p12 = srctop_file("test", "shibboleth.pfx");
     my $p12pass = "σύνθημα γνώρισμα";

--- a/test/recipes/66-test_ossl_store.t
+++ b/test/recipes/66-test_ossl_store.t
@@ -9,6 +9,7 @@
 use strict;
 use warnings;
 
+use File::Spec::Functions;
 use OpenSSL::Test::Simple;
 use OpenSSL::Test qw/:DEFAULT srctop_dir data_dir/;
 
@@ -17,5 +18,5 @@ setup("test_ossl_store");
 plan tests => 1;
 
 ok(run(test(["ossl_store_test", "-dir", srctop_dir("test"),
-             "-in", "testrsa.pem", "-sm2", "certs/sm2-root.crt",
+             "-in", "testrsa.pem", "-sm2", canonpath("certs/sm2-root.crt"),
              "-data", data_dir()])));

--- a/test/recipes/80-test_ca.t
+++ b/test/recipes/80-test_ca.t
@@ -20,7 +20,7 @@ setup("test_ca");
 
 $ENV{OPENSSL} = cmdstr(app(["openssl"]), display => 1);
 
-my $cnf = '"' . srctop_file("test","ca-and-certs.cnf") . '"';;
+my $cnf = srctop_file("test","ca-and-certs.cnf");
 my $std_openssl_cnf = '"'
     . srctop_file("apps", $^O eq "VMS" ? "openssl-vms.cnf" : "openssl.cnf")
     . '"';
@@ -30,19 +30,19 @@ rmtree("demoCA", { safe => 0 });
 plan tests => 15;
  SKIP: {
      my $cakey = srctop_file("test", "certs", "ca-key.pem");
-     $ENV{OPENSSL_CONFIG} = '-config ' . $cnf;
+     $ENV{OPENSSL_CONFIG} = qq(-config "$cnf");
      skip "failed creating CA structure", 4
          if !ok(run(perlapp(["CA.pl","-newca",
                              "-extra-req", "-key $cakey"], stdin => undef)),
                 'creating CA structure');
 
      my $eekey = srctop_file("test", "certs", "ee-key.pem");
-     $ENV{OPENSSL_CONFIG} = '-config ' . $cnf;
+     $ENV{OPENSSL_CONFIG} = qq(-config "$cnf");
      skip "failed creating new certificate request", 3
          if !ok(run(perlapp(["CA.pl","-newreq",
                              '-extra-req', "-outform DER -section userreq -key $eekey"])),
                 'creating certificate request');
-     $ENV{OPENSSL_CONFIG} = '-rand_serial -inform DER -config '.$std_openssl_cnf;
+     $ENV{OPENSSL_CONFIG} = qq(-rand_serial -inform DER -config "$std_openssl_cnf");
      skip "failed to sign certificate request", 2
          if !is(yes(cmdstr(perlapp(["CA.pl", "-sign"]))), 0,
                 'signing certificate request');
@@ -54,7 +54,7 @@ plan tests => 15;
          if disabled("ct");
 
      my $eekey2 = srctop_file("test", "certs", "ee-key-3072.pem");
-     $ENV{OPENSSL_CONFIG} = '-config ' . $cnf;
+     $ENV{OPENSSL_CONFIG} = qq(-config "$cnf");
      ok(run(perlapp(["CA.pl", "-precert", '-extra-req', "-section userreq -key $eekey2"], stderr => undef)),
         'creating new pre-certificate');
 }

--- a/test/recipes/80-test_pkcs12.t
+++ b/test/recipes/80-test_pkcs12.t
@@ -40,7 +40,7 @@ if (eval { require Win32::API; 1; }) {
     }
 } elsif ($^O eq "MSWin32") {
     plan skip_all => "Win32::API unavailable";
-} else {
+} elsif ($^O ne "VMS") {
     # Running MinGW tests transparently under Wine apparently requires
     # UTF-8 locale...
 
@@ -63,11 +63,16 @@ ok(run(test(["pkcs12_format_test", "-legacy"])), "test pkcs12 formats using lega
 # Test with a non-default library context (and no loaded providers in the default context)
 ok(run(test(["pkcs12_format_test", "-context"])), "test pkcs12 formats using a non-default library context");
 
-# just see that we can read shibboleth.pfx protected with $pass
-ok(run(app(["openssl", "pkcs12", "-noout",
-            "-password", "pass:$pass",
-            "-in", srctop_file("test", "shibboleth.pfx")])),
-   "test_load_cert_pkcs12");
+SKIP: {
+     skip "VMS doesn't have command line UTF-8 support yet in DCL", 1
+         if $^O eq "VMS";
+
+     # just see that we can read shibboleth.pfx protected with $pass
+     ok(run(app(["openssl", "pkcs12", "-noout",
+                 "-password", "pass:$pass",
+                 "-in", srctop_file("test", "shibboleth.pfx")])),
+        "test_load_cert_pkcs12");
+}
 
 my @path = qw(test certs);
 my $outfile1 = "out1.p12";

--- a/test/recipes/90-test_includes_data/vms-includes.cnf
+++ b/test/recipes/90-test_includes_data/vms-includes.cnf
@@ -2,4 +2,4 @@
 # Example configuration file using includes.
 #
 
-.include [.cnf-includes]
+.include [.conf-includes]

--- a/test/testutil/driver.c
+++ b/test/testutil/driver.c
@@ -436,13 +436,33 @@ char *test_mk_file_path(const char *dir, const char *file)
     const char *sep = "/";
 # else
     const char *sep = "";
+    char *dir_end;
+    char dir_end_sep;
 # endif
     size_t len = strlen(dir) + strlen(sep) + strlen(file) + 1;
     char *full_file = OPENSSL_zalloc(len);
 
     if (full_file != NULL) {
         OPENSSL_strlcpy(full_file, dir, len);
+# ifdef OPENSSL_SYS_VMS
+        /*
+         * If |file| contains a directory spec, we need to do some careful
+         * merging.
+         * "vol:[dir.dir]" + "[.certs]sm2-root.crt" should become
+         * "vol:[dir.dir.certs]sm2-root.crt"
+         */
+        dir_end_sep = *( dir_end = &full_file[strlen(full_file) - 1] );
+        if ((dir_end_sep == ']' || dir_end_sep == '>')
+            && (file[0] == '[' || file[0] == '<')) {
+            file++;
+            if (file[0] == '.')
+                *dir_end = '\0';
+            else
+                *dir_end = '.';
+        }
+#else
         OPENSSL_strlcat(full_file, sep, len);
+#endif
         OPENSSL_strlcat(full_file, file, len);
     }
 

--- a/test/testutil/driver.c
+++ b/test/testutil/driver.c
@@ -443,27 +443,29 @@ char *test_mk_file_path(const char *dir, const char *file)
     char *full_file = OPENSSL_zalloc(len);
 
     if (full_file != NULL) {
-        OPENSSL_strlcpy(full_file, dir, len);
+        if (dir != NULL && dir[0] != '\0') {
+            OPENSSL_strlcpy(full_file, dir, len);
 # ifdef OPENSSL_SYS_VMS
-        /*
-         * If |file| contains a directory spec, we need to do some careful
-         * merging.
-         * "vol:[dir.dir]" + "[.certs]sm2-root.crt" should become
-         * "vol:[dir.dir.certs]sm2-root.crt"
-         */
-        dir_end = &full_file[strlen(full_file) - 1];
-        dir_end_sep = *dir_end;
-        if ((dir_end_sep == ']' || dir_end_sep == '>')
-            && (file[0] == '[' || file[0] == '<')) {
-            file++;
-            if (file[0] == '.')
-                *dir_end = '\0';
-            else
-                *dir_end = '.';
-        }
+            /*
+             * If |file| contains a directory spec, we need to do some
+             * careful merging.
+             * "vol:[dir.dir]" + "[.certs]sm2-root.crt" should become
+             * "vol:[dir.dir.certs]sm2-root.crt"
+             */
+            dir_end = &full_file[strlen(full_file) - 1];
+            dir_end_sep = *dir_end;
+            if ((dir_end_sep == ']' || dir_end_sep == '>')
+                && (file[0] == '[' || file[0] == '<')) {
+                file++;
+                if (file[0] == '.')
+                    *dir_end = '\0';
+                else
+                    *dir_end = '.';
+            }
 #else
-        OPENSSL_strlcat(full_file, sep, len);
+            OPENSSL_strlcat(full_file, sep, len);
 #endif
+        }
         OPENSSL_strlcat(full_file, file, len);
     }
 

--- a/test/testutil/driver.c
+++ b/test/testutil/driver.c
@@ -451,7 +451,8 @@ char *test_mk_file_path(const char *dir, const char *file)
          * "vol:[dir.dir]" + "[.certs]sm2-root.crt" should become
          * "vol:[dir.dir.certs]sm2-root.crt"
          */
-        dir_end_sep = *( dir_end = &full_file[strlen(full_file) - 1] );
+        dir_end = &full_file[strlen(full_file) - 1];
+        dir_end_sep = *dir_end;
         if ((dir_end_sep == ']' || dir_end_sep == '>')
             && (file[0] == '[' || file[0] == '<')) {
             file++;


### PR DESCRIPTION
This is a collection of small VMS specific errors:

## Fix test_errstr for VMS

Occasionally, we get an error code on VMS that doesn't translate
into POSIX, and the error string reflects that

## UTF-8 not easily supported on VMS command line yet

Some tests are designed to test UTF-8 on the command line.
We simply disable those on VMS.

## test/ossl_store_test.c: Adapt the use of datadir for VMS paths 

## testutil: teach test_mk_file_path() how to merge VMS file specs

This isn't a full solution, it only handles current use cases.

## test/recipes/66-test_ossl_store.t: ensure native paths 

## test/recipes/80-test_ca.t: Don't force quotes around the config file in $cnf

However, when passing it through the OPENSSL_CONFIG environment
variable, we still need the quotes, just to make sure.

## apps/CA.pl.in: restore the quotes around -CAfile, they were there for a reason

## test/recipes/90-test_includes_data/vms-includes.cnf: correct the directory

... to mimic includes.cnf