### PR TITLE
Fix definition of ossl_intmax_t and ossl_uintmax_t

### DIFF
--- a/apps/include/opt.h
+++ b/apps/include/opt.h
@@ -375,17 +375,8 @@ int opt_int(const char *arg, int *result);
 int opt_int_arg(void);
 int opt_long(const char *arg, long *result);
 int opt_ulong(const char *arg, unsigned long *result);
-#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L && \
-    defined(INTMAX_MAX) && defined(UINTMAX_MAX) && \
-    !defined(OPENSSL_NO_INTTYPES_H)
-int opt_intmax(const char *arg, intmax_t *result);
-int opt_uintmax(const char *arg, uintmax_t *result);
-#else
-# define opt_intmax opt_long
-# define opt_uintmax opt_ulong
-# define intmax_t long
-# define uintmax_t unsigned long
-#endif
+int opt_intmax(const char *arg, ossl_intmax_t *result);
+int opt_uintmax(const char *arg, ossl_uintmax_t *result);
 
 int opt_isdir(const char *name);
 int opt_format(const char *s, unsigned long flags, int *result);

--- a/apps/lib/opt.c
+++ b/apps/lib/opt.c
@@ -14,6 +14,7 @@
 #include "fmt.h"
 #include "app_libctx.h"
 #include "internal/nelem.h"
+#include "internal/numbers.h"
 #include <string.h>
 #if !defined(OPENSSL_SYS_MSDOS)
 # include <unistd.h>
@@ -555,7 +556,7 @@ int opt_long(const char *value, long *result)
     !defined(OPENSSL_NO_INTTYPES_H)
 
 /* Parse an intmax_t, put it into *result; return 0 on failure, else 1. */
-int opt_intmax(const char *value, intmax_t *result)
+int opt_intmax(const char *value, ossl_intmax_t *result)
 {
     int oerrno = errno;
     intmax_t m;
@@ -565,7 +566,8 @@ int opt_intmax(const char *value, intmax_t *result)
     m = strtoimax(value, &endp, 0);
     if (*endp
             || endp == value
-            || ((m == INTMAX_MAX || m == INTMAX_MIN) && errno == ERANGE)
+            || ((m == OSSL_INTMAX_MAX || m == OSSL_INTMAX_MIN)
+                && errno == ERANGE)
             || (m == 0 && errno != 0)) {
         opt_number_error(value);
         errno = oerrno;
@@ -577,7 +579,7 @@ int opt_intmax(const char *value, intmax_t *result)
 }
 
 /* Parse a uintmax_t, put it into *result; return 0 on failure, else 1. */
-int opt_uintmax(const char *value, uintmax_t *result)
+int opt_uintmax(const char *value, ossl_uintmax_t *result)
 {
     int oerrno = errno;
     uintmax_t m;
@@ -587,7 +589,7 @@ int opt_uintmax(const char *value, uintmax_t *result)
     m = strtoumax(value, &endp, 0);
     if (*endp
             || endp == value
-            || (m == UINTMAX_MAX && errno == ERANGE)
+            || (m == OSSL_UINTMAX_MAX && errno == ERANGE)
             || (m == 0 && errno != 0)) {
         opt_number_error(value);
         errno = oerrno;
@@ -596,6 +598,27 @@ int opt_uintmax(const char *value, uintmax_t *result)
     *result = m;
     errno = oerrno;
     return 1;
+}
+#else
+/* Fallback implementations based on long */
+int opt_intmax(const char *value, ossl_intmax_t *result)
+{
+    long m;
+    int ret;
+
+    if ((ret = opt_long(value, &m)))
+        *result = m;
+    return ret;
+}
+
+int opt_uintmax(const char *value, ossl_uintmax_t *result)
+{
+    unsigned long m;
+    int ret;
+
+    if ((ret = opt_ulong(value, &m)))
+        *result = m;
+    return ret;
 }
 #endif
 

--- a/apps/lib/opt.c
+++ b/apps/lib/opt.c
@@ -607,7 +607,7 @@ int opt_uintmax(const char *value, ossl_uintmax_t *result)
         opt_number_error(value);
         return 0;
     }
-    *result = (ossl_intmax_ut)m;
+    *result = (ossl_intmax_t)m;
     errno = oerrno;
     return 1;
 }

--- a/apps/lib/opt.c
+++ b/apps/lib/opt.c
@@ -566,14 +566,20 @@ int opt_intmax(const char *value, ossl_intmax_t *result)
     m = strtoimax(value, &endp, 0);
     if (*endp
             || endp == value
-            || ((m == OSSL_INTMAX_MAX || m == OSSL_INTMAX_MIN)
+            || ((m == INTMAX_MAX || m == INTMAX_MIN)
                 && errno == ERANGE)
             || (m == 0 && errno != 0)) {
         opt_number_error(value);
         errno = oerrno;
         return 0;
     }
-    *result = m;
+    /* Ensure that the value in |m| is never too big for |*result| */
+    if (sizeof(m) > sizeof(*result)
+        && (m < OSSL_INTMAX_MIN || m > OSSL_INTMAX_MAX)) {
+        opt_number_error(value);
+        return 0;
+    }
+    *result = (ossl_intmax_t)m;
     errno = oerrno;
     return 1;
 }
@@ -589,13 +595,19 @@ int opt_uintmax(const char *value, ossl_uintmax_t *result)
     m = strtoumax(value, &endp, 0);
     if (*endp
             || endp == value
-            || (m == OSSL_UINTMAX_MAX && errno == ERANGE)
+            || (m == UINTMAX_MAX && errno == ERANGE)
             || (m == 0 && errno != 0)) {
         opt_number_error(value);
         errno = oerrno;
         return 0;
     }
-    *result = m;
+    /* Ensure that the value in |m| is never too big for |*result| */
+    if (sizeof(m) > sizeof(*result)
+        && m > OSSL_UINTMAX_MAX) {
+        opt_number_error(value);
+        return 0;
+    }
+    *result = (ossl_intmax_ut)m;
     errno = oerrno;
     return 1;
 }

--- a/apps/x509.c
+++ b/apps/x509.c
@@ -553,11 +553,11 @@ int x509_main(int argc, char **argv)
         case OPT_CHECKEND:
             checkend = 1;
             {
-                intmax_t temp = 0;
+                ossl_intmax_t temp = 0;
                 if (!opt_intmax(opt_arg(), &temp))
                     goto opthelp;
                 checkoffset = (time_t)temp;
-                if ((intmax_t)checkoffset != temp) {
+                if ((ossl_intmax_t)checkoffset != temp) {
                     BIO_printf(bio_err, "%s: Checkend time out of range %s\n",
                                prog, opt_arg());
                     goto opthelp;

--- a/include/internal/numbers.h
+++ b/include/internal/numbers.h
@@ -75,5 +75,11 @@ typedef __uint128_t uint128_t;
 #  define SIZE_MAX __MAXUINT__(size_t)
 # endif
 
+# ifndef OSSL_INTMAX_MAX
+#  define OSSL_INTMAX_MIN __MININT__(ossl_intmax_t)
+#  define OSSL_INTMAX_MAX __MAXINT__(ossl_intmax_t)
+#  define OSSL_UINTMAX_MAX __MAXUINT__(ossl_uintmax_t)
+# endif
+
 #endif
 

--- a/include/openssl/e_os2.h
+++ b/include/openssl/e_os2.h
@@ -252,6 +252,15 @@ typedef unsigned __int64 uint64_t;
 #  include <stdint.h>
 #  undef OPENSSL_NO_STDINT_H
 # endif
+# if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L && \
+    defined(INTMAX_MAX) && defined(UINTMAX_MAX)
+typedef intmax_t ossl_intmax_t;
+typedef uintmax_t ossl_uintmax_t;
+# else
+/* Fall back to the largest we know we require and can handle */
+typedef int64_t ossl_intmax_t;
+typedef uint64_t ossl_uintmax_t;
+# endif
 
 /* ossl_inline: portable inline definition usable in public headers */
 # if !defined(inline) && !defined(__cplusplus)

--- a/include/openssl/types.h
+++ b/include/openssl/types.h
@@ -229,21 +229,6 @@ typedef struct ossl_decoder_ctx_st OSSL_DECODER_CTX;
 
 typedef struct ossl_self_test_st OSSL_SELF_TEST;
 
-#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L && \
-    defined(INTMAX_MAX) && defined(UINTMAX_MAX)
-typedef intmax_t ossl_intmax_t;
-typedef uintmax_t ossl_uintmax_t;
-#else
-/*
- * Not long long, because the C-library can only be expected to provide
- * strtoll(), strtoull() at the same time as intmax_t and strtoimax(),
- * strtoumax().  Since we use these for parsing arguments, we need the
- * conversion functions, not just the sizes.
- */
-typedef long ossl_intmax_t;
-typedef unsigned long ossl_uintmax_t;
-#endif
-
 #ifdef  __cplusplus
 }
 #endif

--- a/test/ecstresstest.c
+++ b/test/ecstresstest.c
@@ -18,7 +18,7 @@
 
 #define NUM_REPEATS "1000000"
 
-static intmax_t num_repeats;
+static ossl_intmax_t num_repeats;
 static int print_mode = 0;
 
 #ifndef OPENSSL_NO_EC
@@ -39,10 +39,11 @@ static const char *kP256DefaultResult =
  * point multiplication.
  * Returns the X-coordinate of the end result or NULL on error.
  */
-static BIGNUM *walk_curve(const EC_GROUP *group, EC_POINT *point, intmax_t num)
+static BIGNUM *walk_curve(const EC_GROUP *group, EC_POINT *point,
+                          ossl_intmax_t num)
 {
     BIGNUM *scalar = NULL;
-    intmax_t i;
+    ossl_intmax_t i;
 
     if (!TEST_ptr(scalar = BN_new())
             || !TEST_true(EC_POINT_get_affine_coordinates(group, point, scalar,


### PR DESCRIPTION
These definitions were located away from our definitions of other
sized int and uint types.  Also, the fallback typedef wasn't quite
correct, and this changes it to be aliases for int64_t and uint64_t,
since those are the largest integers we commonly handle.
