### PR TITLE
ec: Fail build on big-endian with enable-ec_nistp_64_gcc_128

### DIFF
--- a/crypto/ec/ec_local.h
+++ b/crypto/ec/ec_local.h
@@ -508,6 +508,10 @@ int ossl_ec_GF2m_simple_field_div(const EC_GROUP *, BIGNUM *r, const BIGNUM *a,
                                  const BIGNUM *b, BN_CTX *);
 
 #ifndef OPENSSL_NO_EC_NISTP_64_GCC_128
+# ifdef B_ENDIAN
+#  error "Can not enable ec_nistp_64_gcc_128 on big-endian systems"
+# endif
+
 /* method functions in ecp_nistp224.c */
 int ossl_ec_GFp_nistp224_group_init(EC_GROUP *group);
 int ossl_ec_GFp_nistp224_group_set_curve(EC_GROUP *group, const BIGNUM *p,


### PR DESCRIPTION
I can't see way of making Configure fail but this at least makes the
build fail.

Fixes #15821

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
