### PR TITLE
Fixed 16 Null pointer errors and memory leaks

### DIFF
--- a/apps/lib/s_cb.c
+++ b/apps/lib/s_cb.c
@@ -956,6 +956,8 @@ static int ssl_excert_prepend(SSL_EXCERT **pexc)
 {
     SSL_EXCERT *exc = app_malloc(sizeof(*exc), "prepend cert");
 
+    if (exc == NULL)
+        return 0;
     memset(exc, 0, sizeof(*exc));
 
     exc->next = *pexc;

--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -3377,6 +3377,7 @@ static int www_body(int s, int stype, int prot, unsigned char *context)
  err:
     OPENSSL_free(buf);
     BIO_free_all(io);
+    BIO_free(ssl_bio);
     return ret;
 }
 
@@ -3420,6 +3421,7 @@ static int rev_body(int s, int stype, int prot, unsigned char *context)
     /* No need to free |con| after this. Done by BIO_free(ssl_bio) */
     BIO_set_ssl(ssl_bio, con, BIO_CLOSE);
     BIO_push(io, ssl_bio);
+    ssl_bio = NULL;
 #ifdef CHARSET_EBCDIC
     io = BIO_push(BIO_new(BIO_f_ebcdic_filter()), io);
 #endif
@@ -3571,6 +3573,8 @@ static int add_session(SSL *ssl, SSL_SESSION *session)
     simple_ssl_session *sess = app_malloc(sizeof(*sess), "get session");
     unsigned char *p;
 
+    if (sess == NULL)
+        return 0;
     SSL_SESSION_get_id(session, &sess->idlen);
     sess->derlen = i2d_SSL_SESSION(session, NULL);
     if (sess->derlen < 0) {

--- a/crypto/passphrase.c
+++ b/crypto/passphrase.c
@@ -262,7 +262,8 @@ int ossl_pw_get_passphrase(char *pass, size_t pass_size, size_t *pass_len,
     }
 
     if (ui_method == NULL) {
-        ERR_raise(ERR_LIB_CRYPTO, ERR_R_INTERNAL_ERROR);
+        ERR_raise_data(ERR_LIB_CRYPTO, ERR_R_PASSED_INVALID_ARGUMENT,
+                       "No password method specified");
         return 0;
     }
 

--- a/crypto/provider.c
+++ b/crypto/provider.c
@@ -94,29 +94,6 @@ int OSSL_PROVIDER_get_capabilities(const OSSL_PROVIDER *prov,
     return ossl_provider_get_capabilities(prov, capability, cb, arg);
 }
 
-int OSSL_PROVIDER_add_builtin(OSSL_LIB_CTX *libctx, const char *name,
-                              OSSL_provider_init_fn *init_fn)
-{
-    OSSL_PROVIDER *prov = NULL;
-
-    if (name == NULL || init_fn == NULL) {
-        ERR_raise(ERR_LIB_CRYPTO, ERR_R_PASSED_NULL_PARAMETER);
-        return 0;
-    }
-
-    /* Create it */
-    if ((prov = ossl_provider_new(libctx, name, init_fn, 0)) == NULL)
-        return 0;
-
-    /*
-     * It's safely stored in the internal store at this point,
-     * free the returned extra reference
-     */
-    ossl_provider_free(prov);
-
-    return 1;
-}
-
 const char *OSSL_PROVIDER_get0_name(const OSSL_PROVIDER *prov)
 {
     return ossl_provider_name(prov);

--- a/crypto/provider.c
+++ b/crypto/provider.c
@@ -18,7 +18,7 @@
 OSSL_PROVIDER *OSSL_PROVIDER_try_load(OSSL_LIB_CTX *libctx, const char *name,
                                       int retain_fallbacks)
 {
-    OSSL_PROVIDER *prov = NULL;
+    OSSL_PROVIDER *prov = NULL, *actual;
     int isnew = 0;
 
     /* Find it or create it */
@@ -33,13 +33,14 @@ OSSL_PROVIDER *OSSL_PROVIDER_try_load(OSSL_LIB_CTX *libctx, const char *name,
         return NULL;
     }
 
-    if (isnew && !ossl_provider_add_to_store(prov, retain_fallbacks)) {
+    actual = prov;
+    if (isnew && !ossl_provider_add_to_store(prov, &actual, retain_fallbacks)) {
         ossl_provider_deactivate(prov);
         ossl_provider_free(prov);
         return NULL;
     }
 
-    return prov;
+    return actual;
 }
 
 OSSL_PROVIDER *OSSL_PROVIDER_load(OSSL_LIB_CTX *libctx, const char *name)

--- a/crypto/provider.c
+++ b/crypto/provider.c
@@ -26,7 +26,7 @@ OSSL_PROVIDER *OSSL_PROVIDER_try_load(OSSL_LIB_CTX *libctx, const char *name,
         isnew = 1;
     }
 
-    if (!ossl_provider_activate(prov, 1)) {
+    if (!ossl_provider_activate(prov, 1, 0)) {
         ossl_provider_free(prov);
         return NULL;
     }

--- a/crypto/provider.c
+++ b/crypto/provider.c
@@ -47,18 +47,6 @@ int OSSL_PROVIDER_unload(OSSL_PROVIDER *prov)
     return 1;
 }
 
-int OSSL_PROVIDER_available(OSSL_LIB_CTX *libctx, const char *name)
-{
-    OSSL_PROVIDER *prov = NULL;
-    int available = 0;
-
-    /* Find it or create it */
-    prov = ossl_provider_find(libctx, name, 0);
-    available = ossl_provider_available(prov);
-    ossl_provider_free(prov);
-    return available;
-}
-
 const OSSL_PARAM *OSSL_PROVIDER_gettable_params(const OSSL_PROVIDER *prov)
 {
     return ossl_provider_gettable_params(prov);

--- a/crypto/provider.c
+++ b/crypto/provider.c
@@ -26,12 +26,12 @@ OSSL_PROVIDER *OSSL_PROVIDER_try_load(OSSL_LIB_CTX *libctx, const char *name,
         isnew = 1;
     }
 
-    if (!ossl_provider_activate(prov, retain_fallbacks, 1)) {
+    if (!ossl_provider_activate(prov, 1)) {
         ossl_provider_free(prov);
         return NULL;
     }
 
-    if (isnew && !ossl_provider_add_to_store(prov)) {
+    if (isnew && !ossl_provider_add_to_store(prov, retain_fallbacks)) {
         ossl_provider_deactivate(prov);
         ossl_provider_free(prov);
         return NULL;

--- a/crypto/provider_child.c
+++ b/crypto/provider_child.c
@@ -150,19 +150,21 @@ static int provider_create_child_cb(const OSSL_CORE_HANDLE *prov, void *cbdata)
                                        1)) == NULL)
             goto err;
 
+        if (!ossl_provider_activate(cprov, 0, 0))
+            goto err;
+
+        if (!ossl_provider_set_child(cprov, prov)
+            || !ossl_provider_add_to_store(cprov)) {
+            ossl_provider_deactivate(cprov);
+            ossl_provider_free(cprov);
+            goto err;
+        }
+
         /*
         * We free the newly created ref. We rely on the provider sticking around
         * in the provider store.
         */
         ossl_provider_free(cprov);
-
-        if (!ossl_provider_activate(cprov, 0, 0))
-            goto err;
-
-        if (!ossl_provider_set_child(cprov, prov)) {
-            ossl_provider_deactivate(cprov);
-            goto err;
-        }
     }
 
     ret = 1;

--- a/crypto/provider_child.c
+++ b/crypto/provider_child.c
@@ -127,9 +127,9 @@ static int provider_create_child_cb(const OSSL_CORE_HANDLE *prov, void *cbdata)
 
     if ((cprov = ossl_provider_find(ctx, provname, 1)) != NULL) {
         /*
-        * We free the newly created ref. We rely on the provider sticking around
-        * in the provider store.
-        */
+         * We free the newly created ref. We rely on the provider sticking around
+         * in the provider store.
+         */
         ossl_provider_free(cprov);
 
         /*
@@ -152,17 +152,11 @@ static int provider_create_child_cb(const OSSL_CORE_HANDLE *prov, void *cbdata)
             goto err;
 
         if (!ossl_provider_set_child(cprov, prov)
-            || !ossl_provider_add_to_store(cprov, 0)) {
+            || !ossl_provider_add_to_store(cprov, NULL, 0)) {
             ossl_provider_deactivate(cprov);
             ossl_provider_free(cprov);
             goto err;
         }
-
-        /*
-        * We free the newly created ref. We rely on the provider sticking around
-        * in the provider store.
-        */
-        ossl_provider_free(cprov);
     }
 
     ret = 1;

--- a/crypto/provider_child.c
+++ b/crypto/provider_child.c
@@ -148,11 +148,11 @@ static int provider_create_child_cb(const OSSL_CORE_HANDLE *prov, void *cbdata)
                                        1)) == NULL)
             goto err;
 
-        if (!ossl_provider_activate(cprov, 0, 0))
+        if (!ossl_provider_activate(cprov, 0))
             goto err;
 
         if (!ossl_provider_set_child(cprov, prov)
-            || !ossl_provider_add_to_store(cprov)) {
+            || !ossl_provider_add_to_store(cprov, 0)) {
             ossl_provider_deactivate(cprov);
             ossl_provider_free(cprov);
             goto err;

--- a/crypto/provider_child.c
+++ b/crypto/provider_child.c
@@ -133,13 +133,11 @@ static int provider_create_child_cb(const OSSL_CORE_HANDLE *prov, void *cbdata)
         ossl_provider_free(cprov);
 
         /*
-         * The provider already exists. It could be an unused built-in, or a
-         * previously created child, or it could have been explicitly loaded. If
-         * explicitly loaded it cannot be converted to a child and we ignore it
-         * - i.e. we don't start treating it like a child.
+         * The provider already exists. It could be a previously created child,
+         * or it could have been explicitly loaded. If explicitly loaded we
+         * ignore it - i.e. we don't start treating it like a child.
          */
-        if (!ossl_provider_convert_to_child(cprov, prov,
-                                            ossl_child_provider_init))
+        if (!ossl_provider_activate_child(cprov, prov, ossl_child_provider_init))
             goto err;
     } else {
         /*

--- a/crypto/provider_child.c
+++ b/crypto/provider_child.c
@@ -137,7 +137,7 @@ static int provider_create_child_cb(const OSSL_CORE_HANDLE *prov, void *cbdata)
          * or it could have been explicitly loaded. If explicitly loaded we
          * ignore it - i.e. we don't start treating it like a child.
          */
-        if (!ossl_provider_activate_child(cprov, prov, ossl_child_provider_init))
+        if (!ossl_provider_activate(cprov, 0, 1))
             goto err;
     } else {
         /*
@@ -148,7 +148,7 @@ static int provider_create_child_cb(const OSSL_CORE_HANDLE *prov, void *cbdata)
                                        1)) == NULL)
             goto err;
 
-        if (!ossl_provider_activate(cprov, 0))
+        if (!ossl_provider_activate(cprov, 0, 0))
             goto err;
 
         if (!ossl_provider_set_child(cprov, prov)

--- a/crypto/provider_conf.c
+++ b/crypto/provider_conf.c
@@ -171,7 +171,7 @@ static int provider_conf_load(OSSL_LIB_CTX *libctx, const char *name,
         ok = provider_conf_params(prov, NULL, NULL, value, cnf);
 
         if (ok) {
-            if (!ossl_provider_activate(prov, 1)) {
+            if (!ossl_provider_activate(prov, 1, 0)) {
                 ok = 0;
             } else if (!ossl_provider_add_to_store(prov, 0)) {
                 ossl_provider_deactivate(prov);

--- a/crypto/provider_conf.c
+++ b/crypto/provider_conf.c
@@ -14,6 +14,7 @@
 #include <openssl/safestack.h>
 #include "internal/provider.h"
 #include "internal/cryptlib.h"
+#include "provider_local.h"
 
 DEFINE_STACK_OF(OSSL_PROVIDER)
 
@@ -61,6 +62,7 @@ static const char *skip_dot(const char *name)
 }
 
 static int provider_conf_params(OSSL_PROVIDER *prov,
+                                struct provider_info_st *provinfo,
                                 const char *name, const char *value,
                                 const CONF *cnf)
 {
@@ -88,14 +90,18 @@ static int provider_conf_params(OSSL_PROVIDER *prov,
                 return 0;
             buffer[buffer_len] = '\0';
             OPENSSL_strlcat(buffer, sectconf->name, sizeof(buffer));
-            if (!provider_conf_params(prov, buffer, sectconf->value, cnf))
+            if (!provider_conf_params(prov, provinfo, buffer, sectconf->value,
+                                      cnf))
                 return 0;
         }
 
         OSSL_TRACE1(CONF, "Provider params: finish section %s\n", value);
     } else {
         OSSL_TRACE2(CONF, "Provider params: %s = %s\n", name, value);
-        ok = ossl_provider_add_parameter(prov, name, value);
+        if (prov != NULL)
+            ok = ossl_provider_add_parameter(prov, name, value);
+        else
+            ok = ossl_provider_info_add_parameter(provinfo, name, value);
     }
 
     return ok;
@@ -149,33 +155,62 @@ static int provider_conf_load(OSSL_LIB_CTX *libctx, const char *name,
             activate = 1;
     }
 
-    prov = ossl_provider_find(libctx, name, 1);
-    if (prov == NULL)
-        prov = ossl_provider_new(libctx, name, NULL, 1);
-    if (prov == NULL) {
-        if (soft)
-            ERR_clear_error();
-        return 0;
-    }
-
-    if (path != NULL)
-        ossl_provider_set_module_path(prov, path);
-
-    ok = provider_conf_params(prov, NULL, value, cnf);
-
-    if (ok && activate) {
-        if (!ossl_provider_activate(prov, 0, 1)) {
-            ok = 0;
-        } else {
-            if (pcgbl->activated_providers == NULL)
-                pcgbl->activated_providers = sk_OSSL_PROVIDER_new_null();
-            sk_OSSL_PROVIDER_push(pcgbl->activated_providers, prov);
-            ok = 1;
+    if (activate) {
+        prov = ossl_provider_find(libctx, name, 1);
+        if (prov == NULL)
+            prov = ossl_provider_new(libctx, name, NULL, 1);
+        if (prov == NULL) {
+            if (soft)
+                ERR_clear_error();
+            return 0;
         }
-    }
 
-    if (!(activate && ok))
-        ossl_provider_free(prov);
+        if (path != NULL)
+            ossl_provider_set_module_path(prov, path);
+
+        ok = provider_conf_params(prov, NULL, NULL, value, cnf);
+
+        if (ok) {
+            if (!ossl_provider_activate(prov, 0, 1)) {
+                ok = 0;
+            } else {
+                if (pcgbl->activated_providers == NULL)
+                    pcgbl->activated_providers = sk_OSSL_PROVIDER_new_null();
+                sk_OSSL_PROVIDER_push(pcgbl->activated_providers, prov);
+                ok = 1;
+            }
+        }
+
+        if (!(activate && ok))
+            ossl_provider_free(prov);
+    } else {
+        struct provider_info_st entry;
+
+        memset(&entry, 0, sizeof(entry));
+        ok = 1;
+        if (name != NULL) {
+            entry.name = OPENSSL_strdup(name);
+            if (entry.name == NULL) {
+                ERR_raise(ERR_LIB_CRYPTO, ERR_R_MALLOC_FAILURE);
+                ok = 0;
+            }
+        }
+        if (ok && path != NULL) {
+            entry.path = OPENSSL_strdup(path);
+            if (entry.path == NULL) {
+                ERR_raise(ERR_LIB_CRYPTO, ERR_R_MALLOC_FAILURE);
+                ok = 0;
+            }
+        }
+        if (ok)
+            ok = provider_conf_params(NULL, &entry, NULL, value, cnf);
+        if (ok && (entry.path != NULL || entry.parameters != NULL))
+            ok = ossl_provider_info_add_to_store(libctx, &entry);
+        if (!ok || (entry.path == NULL && entry.parameters == NULL)) {
+            ossl_provider_info_clear(&entry);
+        }
+
+    }
 
     return ok;
 }

--- a/crypto/provider_conf.c
+++ b/crypto/provider_conf.c
@@ -62,7 +62,7 @@ static const char *skip_dot(const char *name)
 }
 
 static int provider_conf_params(OSSL_PROVIDER *prov,
-                                struct provider_info_st *provinfo,
+                                OSSL_PROVIDER_INFO *provinfo,
                                 const char *name, const char *value,
                                 const CONF *cnf)
 {
@@ -187,7 +187,7 @@ static int provider_conf_load(OSSL_LIB_CTX *libctx, const char *name,
         if (!ok)
             ossl_provider_free(prov);
     } else {
-        struct provider_info_st entry;
+        OSSL_PROVIDER_INFO entry;
 
         memset(&entry, 0, sizeof(entry));
         ok = 1;

--- a/crypto/provider_conf.c
+++ b/crypto/provider_conf.c
@@ -173,6 +173,9 @@ static int provider_conf_load(OSSL_LIB_CTX *libctx, const char *name,
         if (ok) {
             if (!ossl_provider_activate(prov, 0, 1)) {
                 ok = 0;
+            } else if (!ossl_provider_add_to_store(prov)) {
+                ossl_provider_deactivate(prov);
+                ok = 0;
             } else {
                 if (pcgbl->activated_providers == NULL)
                     pcgbl->activated_providers = sk_OSSL_PROVIDER_new_null();
@@ -181,7 +184,7 @@ static int provider_conf_load(OSSL_LIB_CTX *libctx, const char *name,
             }
         }
 
-        if (!(activate && ok))
+        if (!ok)
             ossl_provider_free(prov);
     } else {
         struct provider_info_st entry;

--- a/crypto/provider_conf.c
+++ b/crypto/provider_conf.c
@@ -171,9 +171,9 @@ static int provider_conf_load(OSSL_LIB_CTX *libctx, const char *name,
         ok = provider_conf_params(prov, NULL, NULL, value, cnf);
 
         if (ok) {
-            if (!ossl_provider_activate(prov, 0, 1)) {
+            if (!ossl_provider_activate(prov, 1)) {
                 ok = 0;
-            } else if (!ossl_provider_add_to_store(prov)) {
+            } else if (!ossl_provider_add_to_store(prov, 0)) {
                 ossl_provider_deactivate(prov);
                 ok = 0;
             } else {

--- a/crypto/provider_conf.c
+++ b/crypto/provider_conf.c
@@ -113,7 +113,7 @@ static int provider_conf_load(OSSL_LIB_CTX *libctx, const char *name,
     int i;
     STACK_OF(CONF_VALUE) *ecmds;
     int soft = 0;
-    OSSL_PROVIDER *prov = NULL;
+    OSSL_PROVIDER *prov = NULL, *actual = NULL;
     const char *path = NULL;
     long activate = 0;
     int ok = 0;
@@ -173,13 +173,13 @@ static int provider_conf_load(OSSL_LIB_CTX *libctx, const char *name,
         if (ok) {
             if (!ossl_provider_activate(prov, 1, 0)) {
                 ok = 0;
-            } else if (!ossl_provider_add_to_store(prov, 0)) {
+            } else if (!ossl_provider_add_to_store(prov, &actual, 0)) {
                 ossl_provider_deactivate(prov);
                 ok = 0;
             } else {
                 if (pcgbl->activated_providers == NULL)
                     pcgbl->activated_providers = sk_OSSL_PROVIDER_new_null();
-                sk_OSSL_PROVIDER_push(pcgbl->activated_providers, prov);
+                sk_OSSL_PROVIDER_push(pcgbl->activated_providers, actual);
                 ok = 1;
             }
         }

--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -498,7 +498,6 @@ OSSL_PROVIDER *ossl_provider_new(OSSL_LIB_CTX *libctx, const char *name,
         return NULL;
 
     prov->libctx = libctx;
-    prov->store = store;
 #ifndef FIPS_MODULE
     prov->error_lib = ERR_get_next_error_library();
 #endif
@@ -530,6 +529,7 @@ int ossl_provider_add_to_store(OSSL_PROVIDER *prov, int retain_fallbacks)
         ossl_provider_free(prov);
         ret = 0;
     }
+    prov->store = store;
     if (!retain_fallbacks)
         store->use_fallbacks = 0;
     CRYPTO_THREAD_unlock(store->lock);
@@ -1102,7 +1102,6 @@ static int provider_activate_fallbacks(struct provider_store_st *store)
         if (prov == NULL)
             goto err;
         prov->libctx = store->libctx;
-        prov->store = store;
 #ifndef FIPS_MODULE
         prov->error_lib = ERR_get_next_error_library();
 #endif
@@ -1113,8 +1112,12 @@ static int provider_activate_fallbacks(struct provider_store_st *store)
          * we try to avoid calling a user callback while holding a lock.
          * However, fallbacks are never third party providers so we accept this.
          */
-        if (provider_activate(prov, 0, 0) < 0
-                || sk_OSSL_PROVIDER_push(store->providers, prov) == 0) {
+        if (provider_activate(prov, 0, 0) < 0) {
+            ossl_provider_free(prov);
+            goto err;
+        }
+        prov->store = store;
+        if (sk_OSSL_PROVIDER_push(store->providers, prov) == 0) {
             ossl_provider_free(prov);
             goto err;
         }

--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -1550,13 +1550,7 @@ static int ossl_provider_register_child_cb(const OSSL_CORE_HANDLE *handle,
     max = sk_OSSL_PROVIDER_num(store->providers);
     for (i = 0; i < max; i++) {
         prov = sk_OSSL_PROVIDER_value(store->providers, i);
-        /*
-         * We require register_child_cb to be called during a provider init
-         * function. The currently initing provider will never be activated yet
-         * and we we should not attempt to aquire the flag_lock for it.
-         */
-        if (prov == thisprov)
-            continue;
+
         if (!CRYPTO_THREAD_read_lock(prov->flag_lock))
             break;
         /*

--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -319,29 +319,6 @@ int ossl_provider_info_add_to_store(OSSL_LIB_CTX *libctx,
     return ret;
 }
 
-int OSSL_PROVIDER_add_builtin(OSSL_LIB_CTX *libctx, const char *name,
-                              OSSL_provider_init_fn *init_fn)
-{
-    OSSL_PROVIDER_INFO entry;
-
-    if (name == NULL || init_fn == NULL) {
-        ERR_raise(ERR_LIB_CRYPTO, ERR_R_PASSED_NULL_PARAMETER);
-        return 0;
-    }
-    memset(&entry, 0, sizeof(entry));
-    entry.name = OPENSSL_strdup(name);
-    if (entry.name == NULL) {
-        ERR_raise(ERR_LIB_CRYPTO, ERR_R_MALLOC_FAILURE);
-        return 0;
-    }
-    entry.init = init_fn;
-    if (!ossl_provider_info_add_to_store(libctx, &entry)) {
-        ossl_provider_info_clear(&entry);
-        return 0;
-    }
-    return 1;
-}
-
 OSSL_PROVIDER *ossl_provider_find(OSSL_LIB_CTX *libctx, const char *name,
                                   int noconfig)
 {

--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -511,6 +511,29 @@ OSSL_PROVIDER *ossl_provider_new(OSSL_LIB_CTX *libctx, const char *name,
     return prov;
 }
 
+/* Assumes that the store lock is held */
+static int create_provider_children(OSSL_PROVIDER *prov)
+{
+    int ret = 1;
+#ifndef FIPS_MODULE
+    struct provider_store_st *store = prov->store;
+    OSSL_PROVIDER_CHILD_CB *child_cb;
+    int i, max;
+
+    max = sk_OSSL_PROVIDER_CHILD_CB_num(store->child_cbs);
+    for (i = 0; i < max; i++) {
+        /*
+         * This is newly activated (activatecnt == 1), so we need to
+         * create child providers as necessary.
+         */
+        child_cb = sk_OSSL_PROVIDER_CHILD_CB_value(store->child_cbs, i);
+        ret &= child_cb->create_cb((OSSL_CORE_HANDLE *)prov, child_cb->cbdata);
+    }
+#endif
+
+    return ret;
+}
+
 int ossl_provider_add_to_store(OSSL_PROVIDER *prov, int retain_fallbacks)
 {
     struct provider_store_st *store = NULL;
@@ -532,6 +555,9 @@ int ossl_provider_add_to_store(OSSL_PROVIDER *prov, int retain_fallbacks)
     prov->store = store;
     if (!retain_fallbacks)
         store->use_fallbacks = 0;
+    if (!create_provider_children(prov)) {
+        ret = 0;
+    }
     CRYPTO_THREAD_unlock(store->lock);
 
     return ret;
@@ -688,7 +714,7 @@ int OSSL_PROVIDER_set_default_search_path(OSSL_LIB_CTX *libctx,
  * locking.  Direct callers must remember to set the store flags when
  * appropriate.
  */
-static int provider_init(OSSL_PROVIDER *prov, int flag_lock)
+static int provider_init(OSSL_PROVIDER *prov)
 {
     const OSSL_DISPATCH *provider_dispatch = NULL;
     void *tmp_provctx = NULL;    /* safety measure */
@@ -699,16 +725,8 @@ static int provider_init(OSSL_PROVIDER *prov, int flag_lock)
 #endif
     int ok = 0;
 
-    /*
-     * The flag lock is used to lock init, not only because the flag is
-     * checked here and set at the end, but also because this function
-     * modifies a number of things in the provider structure that this
-     * function needs to perform under lock anyway.
-     */
-    if (flag_lock && !CRYPTO_THREAD_write_lock(prov->flag_lock))
-        goto end;
-    if (prov->flag_initialized) {
-        ok = 1;
+    if (!ossl_assert(!prov->flag_initialized)) {
+        ERR_raise(ERR_LIB_CRYPTO, ERR_R_INTERNAL_ERROR);
         goto end;
     }
 
@@ -885,8 +903,6 @@ static int provider_init(OSSL_PROVIDER *prov, int flag_lock)
     ok = 1;
 
  end:
-    if (flag_lock)
-        CRYPTO_THREAD_unlock(prov->flag_lock);
     return ok;
 }
 
@@ -952,59 +968,47 @@ static int provider_deactivate(OSSL_PROVIDER *prov)
 static int provider_activate(OSSL_PROVIDER *prov, int lock, int upcalls)
 {
     int count = -1;
+    struct provider_store_st *store;
+    int ret = 1;
 
-    if (provider_init(prov, lock)) {
-        int ret = 1;
-        struct provider_store_st *store;
-
-        store = get_provider_store(prov->libctx);
-        if (store == NULL)
-            return -1;
-
-        if (lock && !CRYPTO_THREAD_read_lock(store->lock))
-            return -1;
-
-        if (lock && !CRYPTO_THREAD_write_lock(prov->flag_lock)) {
-            CRYPTO_THREAD_unlock(store->lock);
-            return -1;
-        }
-
-#ifndef FIPS_MODULE
-        if (prov->ischild && upcalls)
-            ret = ossl_provider_up_ref_parent(prov, 1);
-#endif
-
-        if (ret) {
-            count = ++prov->activatecnt;
-            prov->flag_activated = 1;
-
-#ifndef FIPS_MODULE
-            if (prov->activatecnt == 1) {
-                OSSL_PROVIDER_CHILD_CB *child_cb;
-                int i, max;
-
-                max = sk_OSSL_PROVIDER_CHILD_CB_num(store->child_cbs);
-                for (i = 0; i < max; i++) {
-                    /*
-                     * This is newly activated (activatecnt == 1), so we need to
-                     * create child providers as necessary.
-                     */
-                    child_cb = sk_OSSL_PROVIDER_CHILD_CB_value(store->child_cbs,
-                                                               i);
-                    ret &= child_cb->create_cb((OSSL_CORE_HANDLE *)prov,
-                                               child_cb->cbdata);
-                }
-            }
-#endif
-        }
-
-        if (lock) {
-            CRYPTO_THREAD_unlock(prov->flag_lock);
-            CRYPTO_THREAD_unlock(store->lock);
-        }
-        if (!ret)
+    store = prov->store;
+    /*
+    * If the provider hasn't been added to the store, then we don't need
+    * any locks because we've not shared it with other threads.
+    */
+    if (store == NULL) {
+        lock = 0;
+        if (!provider_init(prov))
             return -1;
     }
+
+    if (lock && !CRYPTO_THREAD_read_lock(store->lock))
+        return -1;
+
+    if (lock && !CRYPTO_THREAD_write_lock(prov->flag_lock)) {
+        CRYPTO_THREAD_unlock(store->lock);
+        return -1;
+    }
+
+#ifndef FIPS_MODULE
+    if (prov->ischild && upcalls)
+        ret = ossl_provider_up_ref_parent(prov, 1);
+#endif
+
+    if (ret) {
+        count = ++prov->activatecnt;
+        prov->flag_activated = 1;
+
+        if (prov->activatecnt == 1 && store != NULL)
+            ret = create_provider_children(prov);
+    }
+
+    if (lock) {
+        CRYPTO_THREAD_unlock(prov->flag_lock);
+        CRYPTO_THREAD_unlock(store->lock);
+    }
+    if (!ret)
+        return -1;
 
     return count;
 }

--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -131,7 +131,7 @@ struct provider_store_st {
     CRYPTO_RWLOCK *default_path_lock;
     CRYPTO_RWLOCK *lock;
     char *default_path;
-    struct provider_info_st *provinfo;
+    OSSL_PROVIDER_INFO *provinfo;
     size_t numprovinfo;
     size_t provinfosz;
     unsigned int use_fallbacks:1;
@@ -188,7 +188,7 @@ static INFOPAIR *infopair_copy(const INFOPAIR *src)
     return NULL;
 }
 
-void ossl_provider_info_clear(struct provider_info_st *info)
+void ossl_provider_info_clear(OSSL_PROVIDER_INFO *info)
 {
     OPENSSL_free(info->name);
     OPENSSL_free(info->path);
@@ -272,7 +272,7 @@ int ossl_provider_disable_fallback_loading(OSSL_LIB_CTX *libctx)
 #define BUILTINS_BLOCK_SIZE     10
 
 int ossl_provider_info_add_to_store(OSSL_LIB_CTX *libctx,
-                                    const struct provider_info_st *entry)
+                                    OSSL_PROVIDER_INFO *entry)
 {
     struct provider_store_st *store = get_provider_store(libctx);
     int ret = 0;
@@ -298,7 +298,7 @@ int ossl_provider_info_add_to_store(OSSL_LIB_CTX *libctx,
         }
         store->provinfosz = BUILTINS_BLOCK_SIZE;
     } else if (store->numprovinfo == store->provinfosz) {
-        struct provider_info_st *tmpbuiltins;
+        OSSL_PROVIDER_INFO *tmpbuiltins;
         size_t newsz = store->provinfosz + BUILTINS_BLOCK_SIZE;
 
         tmpbuiltins = OPENSSL_realloc(store->provinfo,
@@ -322,7 +322,7 @@ int ossl_provider_info_add_to_store(OSSL_LIB_CTX *libctx,
 int OSSL_PROVIDER_add_builtin(OSSL_LIB_CTX *libctx, const char *name,
                               OSSL_provider_init_fn *init_fn)
 {
-    struct provider_info_st entry;
+    OSSL_PROVIDER_INFO entry;
 
     if (name == NULL || init_fn == NULL) {
         ERR_raise(ERR_LIB_CRYPTO, ERR_R_PASSED_NULL_PARAMETER);
@@ -451,7 +451,7 @@ OSSL_PROVIDER *ossl_provider_new(OSSL_LIB_CTX *libctx, const char *name,
                                  int noconfig)
 {
     struct provider_store_st *store = NULL;
-    struct provider_info_st template;
+    OSSL_PROVIDER_INFO template;
     OSSL_PROVIDER *prov = NULL;
 
     if ((store = get_provider_store(libctx)) == NULL)
@@ -467,7 +467,7 @@ OSSL_PROVIDER *ossl_provider_new(OSSL_LIB_CTX *libctx, const char *name,
 
     memset(&template, 0, sizeof(template));
     if (init_function == NULL) {
-        const struct provider_info_st *p;
+        const OSSL_PROVIDER_INFO *p;
         size_t i;
 
         /* Check if this is a predefined builtin provider */
@@ -664,7 +664,7 @@ int ossl_provider_add_parameter(OSSL_PROVIDER *prov,
     return infopair_add(&prov->parameters, name, value);
 }
 
-int ossl_provider_info_add_parameter(struct provider_info_st *provinfo,
+int ossl_provider_info_add_parameter(OSSL_PROVIDER_INFO *provinfo,
                                      const char *name,
                                      const char *value)
 {
@@ -1075,7 +1075,7 @@ static int provider_activate_fallbacks(struct provider_store_st *store)
     int use_fallbacks;
     int activated_fallback_count = 0;
     int ret = 0;
-    const struct provider_info_st *p;
+    const OSSL_PROVIDER_INFO *p;
 
     if (!CRYPTO_THREAD_read_lock(store->lock))
         return 0;

--- a/crypto/provider_local.h
+++ b/crypto/provider_local.h
@@ -9,10 +9,10 @@
 
 #include <openssl/core.h>
 
-struct predefined_providers_st {
-    const char *name;
+struct provider_info_st {
+    char *name;
     OSSL_provider_init_fn *init;
     unsigned int is_fallback:1;
 };
 
-extern const struct predefined_providers_st ossl_predefined_providers[];
+extern const struct provider_info_st ossl_predefined_providers[];

--- a/crypto/provider_local.h
+++ b/crypto/provider_local.h
@@ -15,19 +15,19 @@ typedef struct {
 } INFOPAIR;
 DEFINE_STACK_OF(INFOPAIR)
 
-struct provider_info_st {
+typedef struct {
     char *name;
     char *path;
     OSSL_provider_init_fn *init;
     STACK_OF(INFOPAIR) *parameters;
     unsigned int is_fallback:1;
-};
+} OSSL_PROVIDER_INFO;
 
-extern const struct provider_info_st ossl_predefined_providers[];
+extern const OSSL_PROVIDER_INFO ossl_predefined_providers[];
 
-void ossl_provider_info_clear(struct provider_info_st *info);
+void ossl_provider_info_clear(OSSL_PROVIDER_INFO *info);
 int ossl_provider_info_add_to_store(OSSL_LIB_CTX *libctx,
-                                    const struct provider_info_st *entry);
-int ossl_provider_info_add_parameter(struct provider_info_st *provinfo,
+                                    OSSL_PROVIDER_INFO *entry);
+int ossl_provider_info_add_parameter(OSSL_PROVIDER_INFO *provinfo,
                                      const char *name,
                                      const char *value);

--- a/crypto/provider_local.h
+++ b/crypto/provider_local.h
@@ -9,10 +9,25 @@
 
 #include <openssl/core.h>
 
+typedef struct {
+    char *name;
+    char *value;
+} INFOPAIR;
+DEFINE_STACK_OF(INFOPAIR)
+
 struct provider_info_st {
     char *name;
+    char *path;
     OSSL_provider_init_fn *init;
+    STACK_OF(INFOPAIR) *parameters;
     unsigned int is_fallback:1;
 };
 
 extern const struct provider_info_st ossl_predefined_providers[];
+
+void ossl_provider_info_clear(struct provider_info_st *info);
+int ossl_provider_info_add_to_store(OSSL_LIB_CTX *libctx,
+                                    const struct provider_info_st *entry);
+int ossl_provider_info_add_parameter(struct provider_info_st *provinfo,
+                                     const char *name,
+                                     const char *value);

--- a/crypto/provider_predefined.c
+++ b/crypto/provider_predefined.c
@@ -17,7 +17,7 @@ OSSL_provider_init_fn ossl_fips_intern_provider_init;
 #ifdef STATIC_LEGACY
 OSSL_provider_init_fn ossl_legacy_provider_init;
 #endif
-const struct predefined_providers_st ossl_predefined_providers[] = {
+const struct provider_info_st ossl_predefined_providers[] = {
 #ifdef FIPS_MODULE
     { "fips", ossl_fips_intern_provider_init, 1 },
 #else

--- a/crypto/provider_predefined.c
+++ b/crypto/provider_predefined.c
@@ -17,7 +17,7 @@ OSSL_provider_init_fn ossl_fips_intern_provider_init;
 #ifdef STATIC_LEGACY
 OSSL_provider_init_fn ossl_legacy_provider_init;
 #endif
-const struct provider_info_st ossl_predefined_providers[] = {
+const OSSL_PROVIDER_INFO ossl_predefined_providers[] = {
 #ifdef FIPS_MODULE
     { "fips", NULL, ossl_fips_intern_provider_init, NULL, 1 },
 #else

--- a/crypto/provider_predefined.c
+++ b/crypto/provider_predefined.c
@@ -19,14 +19,14 @@ OSSL_provider_init_fn ossl_legacy_provider_init;
 #endif
 const struct provider_info_st ossl_predefined_providers[] = {
 #ifdef FIPS_MODULE
-    { "fips", ossl_fips_intern_provider_init, 1 },
+    { "fips", NULL, ossl_fips_intern_provider_init, NULL, 1 },
 #else
-    { "default", ossl_default_provider_init, 1 },
+    { "default", NULL, ossl_default_provider_init, NULL, 1 },
 # ifdef STATIC_LEGACY
-    { "legacy", ossl_legacy_provider_init, 0 },
+    { "legacy", NULL, ossl_legacy_provider_init, NULL, 0 },
 # endif
-    { "base", ossl_base_provider_init, 0 },
-    { "null", ossl_null_provider_init, 0 },
+    { "base", NULL, ossl_base_provider_init, NULL, 0 },
+    { "null", NULL, ossl_null_provider_init, NULL, 0 },
 #endif
-    { NULL, NULL, 0 }
+    { NULL, NULL, NULL, NULL, 0 }
 };

--- a/crypto/ui/ui_lib.c
+++ b/crypto/ui/ui_lib.c
@@ -43,7 +43,7 @@ UI *UI_new_method(const UI_METHOD *method)
     ret->meth = method;
 
     if (!CRYPTO_new_ex_data(CRYPTO_EX_INDEX_UI, ret, &ret->ex_data)) {
-        OPENSSL_free(ret);
+        UI_free(ret);
         return NULL;
     }
     return ret;

--- a/crypto/x509/x_pubkey.c
+++ b/crypto/x509/x_pubkey.c
@@ -86,6 +86,9 @@ static void x509_pubkey_ex_free(ASN1_VALUE **pval, const ASN1_ITEM *it)
 {
     X509_PUBKEY *pubkey = (X509_PUBKEY *)*pval;
 
+    if (pubkey == NULL)
+        return;
+
     X509_ALGOR_free(pubkey->algor);
     ASN1_BIT_STRING_free(pubkey->public_key);
     EVP_PKEY_free(pubkey->pkey);

--- a/crypto/x509/x_x509a.c
+++ b/crypto/x509/x_x509a.c
@@ -125,6 +125,8 @@ int X509_add1_reject_object(X509 *x, const ASN1_OBJECT *obj)
 {
     X509_CERT_AUX *aux;
     ASN1_OBJECT *objtmp;
+    int ret;
+    
     if ((objtmp = OBJ_dup(obj)) == NULL)
         return 0;
     if ((aux = aux_get(x)) == NULL)
@@ -132,7 +134,9 @@ int X509_add1_reject_object(X509 *x, const ASN1_OBJECT *obj)
     if (aux->reject == NULL
         && (aux->reject = sk_ASN1_OBJECT_new_null()) == NULL)
         goto err;
-    return sk_ASN1_OBJECT_push(aux->reject, objtmp);
+    ret = sk_ASN1_OBJECT_push(aux->reject, objtmp);
+    if (ret > 0)
+        return ret;
  err:
     ASN1_OBJECT_free(objtmp);
     return 0;

--- a/doc/internal/man3/ossl_provider_new.pod
+++ b/doc/internal/man3/ossl_provider_new.pod
@@ -55,7 +55,8 @@ ossl_provider_get_capabilities
   */
  int ossl_provider_activate(OSSL_PROVIDER *prov, int upcalls, int aschild);
  int ossl_provider_deactivate(OSSL_PROVIDER *prov);
- int ossl_provider_add_to_store(OSSL_PROVIDER *prov, int retain_fallbacks);
+ int ossl_provider_add_to_store(OSSL_PROVIDER *prov, OSSL_PROVIDER **actualprov,
+                                int retain_fallbacks);
 
  /* Return pointer to the provider's context */
  void *ossl_provider_ctx(const OSSL_PROVIDER *prov);
@@ -229,7 +230,13 @@ that count reaches zero, the activation flag is cleared.
 
 ossl_provider_add_to_store() adds the provider I<prov> to the provider store and
 makes it available to other threads. This will prevent future automatic loading
-of fallback providers, unless I<retain_fallbacks> is true.
+of fallback providers, unless I<retain_fallbacks> is true. If a provider of the
+same name already exists in the store then it is not added but this function
+still returns success. On success the I<actualprov> value is populated with a
+pointer to the provider of the given name that is now in the store. The
+reference passed in the I<prov> argument is consumed by this function. A
+reference to the provider that should be used is passed back in the
+I<actualprov> argument.
 
 ossl_provider_ctx() returns a context created by the provider.
 Outside of the provider, it's completely opaque, but it needs to be

--- a/doc/internal/man3/ossl_provider_new.pod
+++ b/doc/internal/man3/ossl_provider_new.pod
@@ -9,7 +9,7 @@ ossl_provider_add_parameter, ossl_provider_set_child, ossl_provider_get_parent,
 ossl_provider_up_ref_parent, ossl_provider_free_parent,
 ossl_provider_default_props_update, ossl_provider_get0_dispatch,
 ossl_provider_init_as_child,
-ossl_provider_activate, ossl_provider_deactivate, ossl_provider_available,
+ossl_provider_activate, ossl_provider_deactivate,
 ossl_provider_ctx,
 ossl_provider_doall_activated,
 ossl_provider_name, ossl_provider_dso,
@@ -56,8 +56,6 @@ ossl_provider_get_capabilities
  int ossl_provider_activate(OSSL_PROVIDER *prov, int retain_fallbacks,
                             int upcalls);
  int ossl_provider_deactivate(OSSL_PROVIDER *prov);
- /* Check if provider is available (activated) */
- int ossl_provider_available(OSSL_PROVIDER *prov);
 
  /* Return pointer to the provider's context */
  void *ossl_provider_ctx(const OSSL_PROVIDER *prov);
@@ -229,10 +227,6 @@ ossl_provider_deactivate() "deactivates" the provider for the given
 provider object I<prov> by decrementing its activation count.  When
 that count reaches zero, the activation flag is cleared.
 
-ossl_provider_available() activates all fallbacks if no provider is
-activated yet, then checks if given provider object I<prov> is
-activated.
-
 ossl_provider_ctx() returns a context created by the provider.
 Outside of the provider, it's completely opaque, but it needs to be
 passed back to some of the provider functions.
@@ -347,9 +341,6 @@ ossl_provider_set_module_path(), ossl_provider_set_fallback(),
 ossl_provider_activate(), ossl_provider_activate_leave_fallbacks() and
 ossl_provider_deactivate(), ossl_provider_default_props_update() return 1 on
 success, or 0 on error.
-
-ossl_provider_available() return 1 if the provider is available,
-otherwise 0.
 
 ossl_provider_name(), ossl_provider_dso(),
 ossl_provider_module_name(), and ossl_provider_module_path() return a

--- a/doc/internal/man3/ossl_provider_new.pod
+++ b/doc/internal/man3/ossl_provider_new.pod
@@ -53,8 +53,7 @@ ossl_provider_get_capabilities
   * Activate the Provider
   * If the Provider is a module, the module will be loaded
   */
- int ossl_provider_activate(OSSL_PROVIDER *prov, int retain_fallbacks,
-                            int upcalls);
+ int ossl_provider_activate(OSSL_PROVIDER *prov, int upcalls);
  int ossl_provider_deactivate(OSSL_PROVIDER *prov);
 
  /* Return pointer to the provider's context */
@@ -218,10 +217,8 @@ be located in that module, and called.
 
 =back
 
-If I<retain_fallbacks> is zero, fallbacks are disabled.  If it is nonzero,
-fallbacks are left unchanged. If I<upcalls> is nonzero then, if this is a child
-provider, upcalls to the parent libctx will be made to inform it of an
-up-ref.
+If I<upcalls> is nonzero then, if this is a child provider, upcalls to the
+parent libctx will be made to inform it of an up-ref.
 
 ossl_provider_deactivate() "deactivates" the provider for the given
 provider object I<prov> by decrementing its activation count.  When

--- a/doc/internal/man3/ossl_provider_new.pod
+++ b/doc/internal/man3/ossl_provider_new.pod
@@ -9,7 +9,7 @@ ossl_provider_add_parameter, ossl_provider_set_child, ossl_provider_get_parent,
 ossl_provider_up_ref_parent, ossl_provider_free_parent,
 ossl_provider_default_props_update, ossl_provider_get0_dispatch,
 ossl_provider_init_as_child,
-ossl_provider_activate, ossl_provider_deactivate,
+ossl_provider_activate, ossl_provider_deactivate, ossl_provider_add_to_store,
 ossl_provider_ctx,
 ossl_provider_doall_activated,
 ossl_provider_name, ossl_provider_dso,
@@ -53,8 +53,9 @@ ossl_provider_get_capabilities
   * Activate the Provider
   * If the Provider is a module, the module will be loaded
   */
- int ossl_provider_activate(OSSL_PROVIDER *prov, int upcalls);
+ int ossl_provider_activate(OSSL_PROVIDER *prov, int upcalls, int aschild);
  int ossl_provider_deactivate(OSSL_PROVIDER *prov);
+ int ossl_provider_add_to_store(OSSL_PROVIDER *prov, int retain_fallbacks);
 
  /* Return pointer to the provider's context */
  void *ossl_provider_ctx(const OSSL_PROVIDER *prov);
@@ -218,11 +219,17 @@ be located in that module, and called.
 =back
 
 If I<upcalls> is nonzero then, if this is a child provider, upcalls to the
-parent libctx will be made to inform it of an up-ref.
+parent libctx will be made to inform it of an up-ref. If I<aschild> is nonzero
+then the provider will only be activated if it is a child provider. Otherwise
+no action is taken and ossl_provider_activate() returns success.
 
 ossl_provider_deactivate() "deactivates" the provider for the given
 provider object I<prov> by decrementing its activation count.  When
 that count reaches zero, the activation flag is cleared.
+
+ossl_provider_add_to_store() adds the provider I<prov> to the provider store and
+makes it available to other threads. This will prevent future automatic loading
+of fallback providers, unless I<retain_fallbacks> is true.
 
 ossl_provider_ctx() returns a context created by the provider.
 Outside of the provider, it's completely opaque, but it needs to be
@@ -336,8 +343,8 @@ called for any activated providers.
 
 ossl_provider_set_module_path(), ossl_provider_set_fallback(),
 ossl_provider_activate(), ossl_provider_activate_leave_fallbacks() and
-ossl_provider_deactivate(), ossl_provider_default_props_update() return 1 on
-success, or 0 on error.
+ossl_provider_deactivate(), ossl_provider_add_to_store(),
+ossl_provider_default_props_update() return 1 on success, or 0 on error.
 
 ossl_provider_name(), ossl_provider_dso(),
 ossl_provider_module_name(), and ossl_provider_module_path() return a

--- a/doc/man3/OSSL_LIB_CTX.pod
+++ b/doc/man3/OSSL_LIB_CTX.pod
@@ -75,19 +75,13 @@ context. If L<EVP_set_default_properties(3)> is called directly on a child
 library context then the new properties will override anything from the parent
 library context and mirroring of the properties will stop.
 
-OSSL_LIB_CTX_new_child() must only be called from within the scope of a
-provider's B<OSSL_provider_init> function (see L<provider-base(7)>). Calling it
-outside of that function may succeed but may not correctly mirror all providers
-and is considered undefined behaviour. When called from within the scope of a
-provider's B<OSSL_provider_init> function the currently initialising provider is
-not yet available in the application's library context and therefore will
-similarly not yet be available in the newly constructed child library context.
-As soon as the B<OSSL_provider_init> function returns then the new provider is
-available in the application's library context and will be similarly mirrored in
-the child library context. Since the current provider is still initialising
-the provider should not attempt to perform fetches, or call any function that
-performs a fetch using the child library context until after the initialisation
-function has completed.
+When OSSL_LIB_CTX_new_child() is called from within the scope of a provider's
+B<OSSL_provider_init> function the currently initialising provider is not yet
+available in the application's library context and therefore will similarly not
+yet be available in the newly constructed child library context. As soon as the
+B<OSSL_provider_init> function returns then the new provider is available in the
+application's library context and will be similarly mirrored in the child
+library context.
 
 OSSL_LIB_CTX_load_config() loads a configuration file using the given C<ctx>.
 This can be used to associate a library context with providers that are loaded

--- a/doc/man7/EVP_PKEY-SM2.pod
+++ b/doc/man7/EVP_PKEY-SM2.pod
@@ -55,6 +55,9 @@ or EVP_DigestVerifyInit() in such a scenario.
 SM2 can be tested with the L<openssl-speed(1)> application since version 3.0.
 Currently, the only valid algorithm name is B<sm2>.
 
+Since version 3.0, SM2 keys can be generated and loaded only when the domain
+parameters specify the SM2 elliptic curve.
+
 =head1 EXAMPLES
 
 This example demonstrates the calling sequence for using an B<EVP_PKEY> to verify

--- a/doc/man7/migration_guide.pod
+++ b/doc/man7/migration_guide.pod
@@ -360,7 +360,9 @@ call C<EVP_PKEY_set_alias_type(pkey, EVP_PKEY_SM2)> to get SM2 computations.
 
 Parameter and key generation is also reworked to make it possible
 to generate EVP_PKEY_SM2 parameters and keys. Applications must now generate
-SM2 keys directly and must not create an EVP_PKEY_EC key first.
+SM2 keys directly and must not create an EVP_PKEY_EC key first. It is no longer
+possible to import an SM2 key with domain parameters other than the SM2 elliptic
+curve ones.
 
 Validation of SM2 keys has been separated from the validation of regular EC
 keys, allowing to improve the SM2 validation process to reject loaded private

--- a/doc/man7/provider.pod
+++ b/doc/man7/provider.pod
@@ -69,6 +69,9 @@ the provider multiple simultaneous uses.
 This pointer will be passed to various operation functions offered by
 the provider.
 
+Note that the provider will not be made available for applications to use until
+the initialization function has completed and returned successfully.
+
 One of the functions the provider offers to the OpenSSL libraries is
 the central mechanism for the OpenSSL libraries to get access to
 operation implementations for diverse algorithms.

--- a/include/internal/provider.h
+++ b/include/internal/provider.h
@@ -62,6 +62,7 @@ int ossl_provider_disable_fallback_loading(OSSL_LIB_CTX *libctx);
 int ossl_provider_activate(OSSL_PROVIDER *prov, int retain_fallbacks,
                            int upcalls);
 int ossl_provider_deactivate(OSSL_PROVIDER *prov);
+int ossl_provider_add_to_store(OSSL_PROVIDER *prov);
 
 /* Return pointer to the provider's context */
 void *ossl_provider_ctx(const OSSL_PROVIDER *prov);

--- a/include/internal/provider.h
+++ b/include/internal/provider.h
@@ -59,10 +59,9 @@ int ossl_provider_disable_fallback_loading(OSSL_LIB_CTX *libctx);
  * Activate the Provider
  * If the Provider is a module, the module will be loaded
  */
-int ossl_provider_activate(OSSL_PROVIDER *prov, int retain_fallbacks,
-                           int upcalls);
+int ossl_provider_activate(OSSL_PROVIDER *prov, int upcalls);
 int ossl_provider_deactivate(OSSL_PROVIDER *prov);
-int ossl_provider_add_to_store(OSSL_PROVIDER *prov);
+int ossl_provider_add_to_store(OSSL_PROVIDER *prov, int retain_fallbacks);
 
 /* Return pointer to the provider's context */
 void *ossl_provider_ctx(const OSSL_PROVIDER *prov);

--- a/include/internal/provider.h
+++ b/include/internal/provider.h
@@ -62,8 +62,6 @@ int ossl_provider_disable_fallback_loading(OSSL_LIB_CTX *libctx);
 int ossl_provider_activate(OSSL_PROVIDER *prov, int retain_fallbacks,
                            int upcalls);
 int ossl_provider_deactivate(OSSL_PROVIDER *prov);
-/* Check if the provider is available (activated) */
-int ossl_provider_available(OSSL_PROVIDER *prov);
 
 /* Return pointer to the provider's context */
 void *ossl_provider_ctx(const OSSL_PROVIDER *prov);

--- a/include/internal/provider.h
+++ b/include/internal/provider.h
@@ -58,7 +58,8 @@ int ossl_provider_disable_fallback_loading(OSSL_LIB_CTX *libctx);
  */
 int ossl_provider_activate(OSSL_PROVIDER *prov, int upcalls, int aschild);
 int ossl_provider_deactivate(OSSL_PROVIDER *prov);
-int ossl_provider_add_to_store(OSSL_PROVIDER *prov, int retain_fallbacks);
+int ossl_provider_add_to_store(OSSL_PROVIDER *prov, OSSL_PROVIDER **actualprov,
+                               int retain_fallbacks);
 
 /* Return pointer to the provider's context */
 void *ossl_provider_ctx(const OSSL_PROVIDER *prov);

--- a/include/internal/provider.h
+++ b/include/internal/provider.h
@@ -44,9 +44,6 @@ int ossl_provider_add_parameter(OSSL_PROVIDER *prov, const char *name,
 
 int ossl_provider_is_child(const OSSL_PROVIDER *prov);
 int ossl_provider_set_child(OSSL_PROVIDER *prov, const OSSL_CORE_HANDLE *handle);
-int ossl_provider_activate_child(OSSL_PROVIDER *prov,
-                                 const OSSL_CORE_HANDLE *handle,
-                                 OSSL_provider_init_fn *init_function);
 const OSSL_CORE_HANDLE *ossl_provider_get_parent(OSSL_PROVIDER *prov);
 int ossl_provider_up_ref_parent(OSSL_PROVIDER *prov, int activate);
 int ossl_provider_free_parent(OSSL_PROVIDER *prov, int deactivate);
@@ -59,7 +56,7 @@ int ossl_provider_disable_fallback_loading(OSSL_LIB_CTX *libctx);
  * Activate the Provider
  * If the Provider is a module, the module will be loaded
  */
-int ossl_provider_activate(OSSL_PROVIDER *prov, int upcalls);
+int ossl_provider_activate(OSSL_PROVIDER *prov, int upcalls, int aschild);
 int ossl_provider_deactivate(OSSL_PROVIDER *prov);
 int ossl_provider_add_to_store(OSSL_PROVIDER *prov, int retain_fallbacks);
 

--- a/include/internal/provider.h
+++ b/include/internal/provider.h
@@ -44,9 +44,9 @@ int ossl_provider_add_parameter(OSSL_PROVIDER *prov, const char *name,
 
 int ossl_provider_is_child(const OSSL_PROVIDER *prov);
 int ossl_provider_set_child(OSSL_PROVIDER *prov, const OSSL_CORE_HANDLE *handle);
-int ossl_provider_convert_to_child(OSSL_PROVIDER *prov,
-                                   const OSSL_CORE_HANDLE *handle,
-                                   OSSL_provider_init_fn *init_function);
+int ossl_provider_activate_child(OSSL_PROVIDER *prov,
+                                 const OSSL_CORE_HANDLE *handle,
+                                 OSSL_provider_init_fn *init_function);
 const OSSL_CORE_HANDLE *ossl_provider_get_parent(OSSL_PROVIDER *prov);
 int ossl_provider_up_ref_parent(OSSL_PROVIDER *prov, int activate);
 int ossl_provider_free_parent(OSSL_PROVIDER *prov, int deactivate);

--- a/include/internal/symhacks.h
+++ b/include/internal/symhacks.h
@@ -15,9 +15,6 @@
 
 # if defined(OPENSSL_SYS_VMS)
 
-/* ossl_provider_available vs OSSL_PROVIDER_available */
-#  undef ossl_provider_available
-#  define ossl_provider_available                 ossl_int_prov_available
 /* ossl_provider_gettable_params vs OSSL_PROVIDER_gettable_params */
 #  undef ossl_provider_gettable_params
 #  define ossl_provider_gettable_params            ossl_int_prov_gettable_params

--- a/providers/implementations/encode_decode/decode_epki2pki.c
+++ b/providers/implementations/encode_decode/decode_epki2pki.c
@@ -90,6 +90,7 @@ static int epki2pki_decode(void *vctx, OSSL_CORE_BIO *cin, int selection,
 
         if (!pw_cb(pbuf, sizeof(pbuf), &plen, NULL, pw_cbarg)) {
             ERR_raise(ERR_LIB_PROV, PROV_R_UNABLE_TO_GET_PASSPHRASE);
+            ok = 0;
         } else {
             const ASN1_OCTET_STRING *oct;
             unsigned char *new_der = NULL;

--- a/test/conf_include_test.c
+++ b/test/conf_include_test.c
@@ -50,8 +50,10 @@ static int change_path(const char *file)
     while ((p = strpbrk(p, DIRSEP)) != NULL) {
         last = p++;
     }
-    if (last == NULL)
+    if (last == NULL) {
+        OPENSSL_free(s);
         return 0;
+    }
     last[DIRSEP_PRESERVE] = 0;
 
     TEST_note("changing path to %s", s);

--- a/test/evp_test.c
+++ b/test/evp_test.c
@@ -1967,8 +1967,12 @@ static int pbe_test_init(EVP_TEST *t, const char *alg)
         pbe_type = PBE_TYPE_PKCS12;
     } else {
         TEST_error("Unknown pbe algorithm %s", alg);
+        return 0;
     }
     pdat = OPENSSL_zalloc(sizeof(*pdat));
+    if (!TEST_ptr(pdat))
+        return 0;
+
     pdat->pbe_type = pbe_type;
     t->data = pdat;
     return 1;

--- a/test/helpers/handshake.c
+++ b/test/helpers/handshake.c
@@ -278,8 +278,10 @@ static int server_ocsp_cb(SSL *s, void *arg)
      * For the purposes of testing we just send back a dummy OCSP response
      */
     *resp = *(unsigned char *)arg;
-    if (!SSL_set_tlsext_status_ocsp_resp(s, resp, 1))
+    if (!SSL_set_tlsext_status_ocsp_resp(s, resp, 1)) {
+        OPENSSL_free(resp);
         return SSL_TLSEXT_ERR_ALERT_FATAL;
+    }
 
     return SSL_TLSEXT_ERR_OK;
 }

--- a/test/hmactest.c
+++ b/test/hmactest.c
@@ -132,7 +132,9 @@ static int test_hmac_run(void)
     unsigned int len;
     int ret = 0;
 
-    ctx = HMAC_CTX_new();
+    if (!TEST_ptr(ctx = HMAC_CTX_new()))
+        return 0;
+
     HMAC_CTX_reset(ctx);
 
     if (!TEST_ptr(ctx)

--- a/test/params_test.c
+++ b/test/params_test.c
@@ -99,6 +99,9 @@ static void *init_object(void)
 {
     struct object_st *obj = OPENSSL_zalloc(sizeof(*obj));
 
+    if (!TEST_ptr(obj))
+        return 0;
+
     obj->p1 = p1_init;
     obj->p2 = p2_init;
     if (!TEST_true(BN_hex2bn(&obj->p3, p3_init)))

--- a/test/provider_internal_test.c
+++ b/test/provider_internal_test.c
@@ -26,7 +26,7 @@ static int test_provider(OSSL_PROVIDER *prov, const char *expected_greeting)
     int ret = 0;
 
     ret =
-        TEST_true(ossl_provider_activate(prov, 1))
+        TEST_true(ossl_provider_activate(prov, 1, 0))
         && TEST_true(ossl_provider_get_params(prov, greeting_request))
         && TEST_ptr(greeting = greeting_request[0].data)
         && TEST_size_t_gt(greeting_request[0].data_size, 0)

--- a/test/provider_internal_test.c
+++ b/test/provider_internal_test.c
@@ -26,7 +26,7 @@ static int test_provider(OSSL_PROVIDER *prov, const char *expected_greeting)
     int ret = 0;
 
     ret =
-        TEST_true(ossl_provider_activate(prov, 0, 1))
+        TEST_true(ossl_provider_activate(prov, 1))
         && TEST_true(ossl_provider_get_params(prov, greeting_request))
         && TEST_ptr(greeting = greeting_request[0].data)
         && TEST_size_t_gt(greeting_request[0].data_size, 0)

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -1644,7 +1644,11 @@ static int ocsp_server_cb(SSL *s, void *arg)
     if (!TEST_ptr(copy = OPENSSL_memdup(orespder, sizeof(orespder))))
         return SSL_TLSEXT_ERR_ALERT_FATAL;
 
-    SSL_set_tlsext_status_ocsp_resp(s, copy, sizeof(orespder));
+    if (!TEST_true(SSL_set_tlsext_status_ocsp_resp(s, copy, sizeof(orespder)))) {
+        OPENSSL_free(copy);
+        return SSL_TLSEXT_ERR_ALERT_FATAL;
+    }
+    
     ocsp_server_called = 1;
     return SSL_TLSEXT_ERR_OK;
 }


### PR DESCRIPTION
Hello,

these 16 null dereference and memory leak reports, included with comments
below, were found by running

Facebook's Infer static analyzer (https://fbinfer.com/, Pulse.ISL checker) on openssl-3.0.0.

regards,
Loc

-------------------------------------
1.
File: crypto/ui/ui_lib.c

REPORT: PISL found a potential memory leak.
Memory dynamically allocated at line 32 by `CRYPTO_malloc`, indirectly via call to `CRYPTO_THREAD_lock_new()` is not freed after the last access at line 50.

REMARK: pointer ret->lock is allocated on line 32.
On line 46, pointer ret is freed but ret->lock is not freed and is not reachable after line 47.


FIX:
 add the following code right before line 46:

```
  CRYPTO_THREAD_lock_free(ret->lock);
  ret->lock = NULL;
```
 


-------------------------------
2.
File: test/conf_include_test.c

REPORT: PISL found a potential memory leak.

REMARK: pointer s is allocated by calling OPENSSL_strdup() on line 42.
It is freed before the return on line 60 but
 is not freed before the return on line 54.

FIX:
 add the following code before line 53 as follows.
```
     OPENSSL_free(s);
```

-------------------------------

3. This issue has been FIXED before reported
File: providers/implementations/macs/cmac_prov.c

REPORT: PISL found a potential null pointer dereference on line 90.
```
  88. 
  89.     dst = cmac_new(src->provctx);
  90.     if (!CMAC_CTX_copy(dst->ctx, src->ctx)
                             ^
  91.         || !ossl_prov_cipher_copy(&dst->cipher, &src->cipher)) {
  92.         cmac_free(dst);
  ```
REMARK:
 pointer dst is last assigned by calling cmac_new() on line 89
  - in the implementation of cmac_new(), on line 60 in the same file
  it calls CMAC_CTX_new() which is a wrapper of CRYPTO_malloc() and could return NULL.
  If it is the case, dst could be NULL.
  
 Consequently, dst is dereferenced on line 90; this raises an NPE.

FIX:
 Add the following code right before line 90:
```
  if (dst == NULL)
    return NULL;
```

-------------------------------
4.
File: crypto/x509/x_pubkey.c

REPORT: crypto/x509/x_pubkey.c:116: error: Nullptr Dereference
  PISL found a potential null pointer dereference on line 116 indirectly during the call to `x509_pubkey_ex_free()` in call to `x509_pubkey_ex_free()`.
```
  114.         || !x509_pubkey_ex_populate((ASN1_VALUE **)&ret, NULL)
  115.         || !x509_pubkey_set0_libctx(ret, libctx, propq)) {
  116.         x509_pubkey_ex_free((ASN1_VALUE **)&ret, NULL);
               ^
  117.         ERR_raise(ERR_LIB_ASN1, ERR_R_MALLOC_FAILURE);
  118.     } else {
```

REMARK:
 - pointer ret is allocated by calling OPENSSL_zalloc() on line 113 and it might be NULL.
   OPENSSL_zalloc() is implemented in file crypto/mem.c, lines 187-197.
     It is a wrapper of CRYPTO_malloc() and could return NULL.
 - ret is dereferenced by calling x509_pubkey_ex_free().
   + if ret is NULL, the condition on line 113 is true and ret is passed as
     the first parameter of the calling x509_pubkey_ex_free()
   + x509_pubkey_ex_free() is implemented in file crypto/x509/x_pubkey.c, lines 85-95
   + on line 89, pointer pubkey is assigned to ret
   + on line 89, pubkey is dereferenced. This raises an Null Pointer Error.

FIX:
 Modify the code of x509_pubkey_ex_free(), replace the code between lines 89-95 by the following one.
```
   if (pubkey) {
      X509_ALGOR_free(pubkey->algor);
      ASN1_BIT_STRING_free(pubkey->public_key);
      EVP_PKEY_free(pubkey->pkey);
      OPENSSL_free(pubkey->propq);
      OPENSSL_free(pubkey);
      *pval = NULL;
  }
```
 
------------------------
5.
File: test/params_test.c

REPORT: PISL found a potential null pointer dereference on line 102.
```
   99.     struct object_st *obj = OPENSSL_zalloc(sizeof(*obj));
  100. 
  101.     obj->p1 = p1_init;
           ^
  102.     obj->p2 = p2_init;
  103.     if (!TEST_true(BN_hex2bn(&obj->p3, p3_init)))
```
REMARK:
  - pointer obj is last assigned by calling OPENSSL_zalloc() on line 100 and could be NULL;
     OPENSSL_zalloc() is implemented in file crypto/mem.c, lines 187-197.
     It is a wrapper of CRYPTO_malloc() and could return NULL.
  - obj is dereferenced on line 102. This raises an NPE.

FIX:
 Add the following code right before line 102:
```
  if (obj == NULL) 
    return 0;
```
 
-------------------------------
6.
File: crypto/x509/x_x509a.c:139

REPORT:
  PISL found a potential memory leak. Memory dynamically allocated at line 128 by `CRYPTO_malloc`, indirectly via call to `OBJ_dup()` is not freed after the last access at line 139.

REMAKR:
 - objtmp is allocated by calling OBJ_dup() on line 128 and it could be NULL.
  + OBJ_dup() is implemented in file crypto/objects/obj_lib.c, lines 16-55; it allocates
   a new object via the call chain ASN1_OBJECT_new() -> OPENSSL_zalloc() -> CRYPTO_malloc()
 - On line 135, objtmp is pushed on the stack aux (which is got from the first parameter x/aux->reject)
   by calling sk_ASN1_OBJECT_push().
    If this push is failed, the memory pointed to by objtmp is not freed.
   + sk_ASN1_OBJECT_push is an instance of OPENSSL_sk_push() which is implemented in file
    crypto/stack/stack.c, lines 364-369
    - OPENSSL_sk_push() calls OPENSSL_sk_insert() on line 368 to do the push.
     - OPENSSL_sk_insert() is implemented in file crypto/stack/stack.c, lines 249-267
     - On line 251, if the number of nodes in the stack is max, it fails to push
       objtmp into the stack.
      In this case, the memory pointed to by objtmp is not freed.

 - this issue also affects openssl-1.1.1
 
 FIX:
 - Declare a new variable ret right after line 127:
```
   int ret;
  }
```
 - Modify the code online 135 as follows.
```
  ret = sk_ASN1_OBJECT_push(aux->reject, objtmp);
  if (ret > 0)
  return ret;
```

-------------------------
7.
File: test/hmactest.c

REPORT:
  PISL found a potential null pointer dereference on line 136 indirectly during the call to `HMAC_CTX_reset()` in call to `HMAC_CTX_reset()`.
```
  134. 
  135.     ctx = HMAC_CTX_new();
  136.     HMAC_CTX_reset(ctx);
           ^
  137. 
  138.     if (!TEST_ptr(ctx)
```

REMARK:
 - pointer ctx is allocated by calling HMAC_CTX_new() on line 135 and might be NULL;
   HMAC_CTX_new() is implemented in file crypto/hmac/hmac.c, lines 145-156; it allocates
    a new object via the call chain OPENSSL_zalloc() -> CRYPTO_malloc() on line 147.
    Hence, this function might return NULL.
 - ctx is dereferenced by calling HMAC_CTX_reset() on line 136 and might
   raises an NPE.
   + HMAC_CTX_reset() is implemented in file crypto/hmac/hmac.c, lines 194-202.
     On line 196, it passes ctx as the first parameter of the calling hmac_ctx_cleanup();
   + hmac_ctx_cleanup is implemented in file crypto/hmac/hmac.c, lines 158-164.
     It dereferences ctx on line 160.

FIX:
 Add the following code right before line 136:
```
  if (ctx == NULL)
    return ret;
```

-------------------------------
8.
File: crypto/x509/x_pubkey.c

REPORT: PISL found a potential null pointer dereference on line 291 indirectly during the call to `x509_pubkey_ex_free()` in call to `x509_pubkey_ex_free()`.
```
  289.                                     a->public_key->data, a->public_key->length)
  290.             || (a->pkey != NULL && !EVP_PKEY_up_ref(a->pkey))) {
  291.         x509_pubkey_ex_free((ASN1_VALUE **)&pubkey,
               ^
  292.                             ASN1_ITEM_rptr(X509_PUBKEY_INTERNAL));
  293.         ERR_raise(ERR_LIB_X509, ERR_R_MALLOC_FAILURE);
```

REMARK:
 - pointer pubkey is allocated by calling OPENSSL_zalloc() on line 284 and it might be NULL.
   OPENSSL_zalloc() is implemented in file crypto/mem.c, lines 187-197.
     It is a wrapper of CRYPTO_malloc() and could return NULL.
 - pubkey is dereferenced by calling x509_pubkey_ex_free().
   + if pubkey is NULL, the condition on line 286 is true and pubkey is passed as
     the first parameter of the calling x509_pubkey_ex_free()
   + x509_pubkey_ex_free() is implemented in file crypto/x509/x_pubkey.c, lines 85-95
   + on line 89, pointer pubkey is assigned to ret
   + on line 89, pubkey is dereferenced. This raises an Null Pointer Error.

FIX:
 similarly to Issue#4
 
------------------------------
9.
File: test/helpers/handshake.c

REPORT: PISL found a potential memory leak. Memory dynamically allocated at line 274 by `CRYPTO_malloc` is not freed after the last access at line 285.

REMARK:
 - pointer resp is allocated by calling OPENSSL_malloc() on line 274.
 - As resp is not freed before the return on line 284, the memory pointed to by resp is unreachable.

FIX:
 - Modify the code on lines 281-282 as follows.
```
    if (!SSL_set_tlsext_status_ocsp_resp(s, resp, 1)) {
         OPENSSL_free(resp);
        return SSL_TLSEXT_ERR_ALERT_FATAL;
    }
```
 - Add the following code right before line 286
 ```
    OPENSSL_free(resp);
```

------------------------------
10.
File: apps/lib/s_cb.c

REPORT: PISL found a potential null pointer dereference on line 959.
```
  957.     SSL_EXCERT *exc = app_malloc(sizeof(*exc), "prepend cert");
  958. 
  959.     memset(exc, 0, sizeof(*exc));
           ^
  960. 
  961.     exc->next = *pexc;
```
REMARK:
 - pointer exc is last assigned by calling app_malloc on line 957
   app_malloc is implemented in file test/testutil/apps_mem.c, lines 14-19;
   it is a wrapper of OPENSSL_malloc() and could return NULL.
 - exc is dereferenced by calling memset() on line 959.
  This might raise an NPE.

FIX:
 - Add the following code right before line 959:
```
    if (exc == NULL)
         return 0;
```

----------------------------
11.
File: test/sslapitest.c

REPORT:
  PISL found a potential memory leak. Memory dynamically allocated at line 1618 by `CRYPTO_malloc`, indirectly via call to `CRYPTO_memdup()` is not freed after the last access at line 1624.

REMARK:
  - pointer copy is allocated by calling OPENSSL_memdup() on line 1618.
    + OPENSSL_memdup() is implemented in file crypto/o_str.c, lines 48-61; it
    calls CRYPTO_malloc() on line 55 to allocate and return a new memory.
  - copy is not freed before the return on line 1623; hence the memory pointed to by this
    pointer is leaked.

FIX:
 - Add the following code right before line 1623:
```
    CRYPTO_free(copy);
```

----------------------------------------
12.
File: test/evp_test.c

REPORT:
  PISL found a potential null pointer dereference on line 1894.
```
  1892.     }
  1893.     pdat = OPENSSL_zalloc(sizeof(*pdat));
  1894.     pdat->pbe_type = pbe_type;
            ^
  1895.     t->data = pdat;
  1896.     return 1;
```
REMARK:
  - pointer pdat is last assigned by calling OPENSSL_zalloc() on line 1893 and it might be NULL.
   OPENSSL_zalloc() is implemented in file crypto/mem.c, lines 187-197.
     It is a wrapper of CRYPTO_malloc() and could return NULL.
  - pdat is dereferenced on line 1894. This raises an NPE.

FIX:
 - Add the following code right before line 1894:
```
    if (pdat == NULL)
      return 0;
```

----------------------------------------
13.
File: apps/s_server.c

REPORT:
  PISL found a potential memory leak. Memory dynamically allocated at line 2980 by `CRYPTO_malloc`, indirectly via call to `BIO_new()` is not freed after the last access at line 3385.

REMARK:
 - pointer ssl_bio is last assigned by calling BIO_new() on line 2980.
   BIO_new() is implemented in file crypto/bio/bio_lib.cm, lines 120-123;
    it allocates a new heaps by calling BIO_new_ex().
      BIO_new_ex() is implemented in file crypto/bio/bio_lib.c, lines 80-118;
       it returns new memory pointed by both bio - allocated on line 82 by calling OPENSSL_zalloc() -
        and bio->lock - allocated on line 97 by calling CRYPTO_THREAD_lock_new().
 - after the label err: on line 3381 (for example, the conditional on line 2995 is true, the control will lead to err:) both buf and io are freed, but ssl_bio and ssl_bio->lock are not freed;
  the latter are not reachable after line 3385.
 - this issue also affects openssl-1.1.1

FIX:
 - Add the following code right before line 3381:
```
     if (ssl_bio != NULL)
       BIO_free_all(ssl_bio);
```

----------------------------------------
14.
File: apps/s_server.c

REPORT:
  PISL found a potential memory leak. Memory dynamically allocated at line 3397 by `CRYPTO_malloc`, indirectly via call to `BIO_new()` is not freed after the last access at line 3526.

REMARK:
 - pointer ssl_bio is last assigned by calling BIO_new() on line 3397.
   BIO_new() is implemented in file crypto/bio/bio_lib.cm, lines 120-123;
    it allocates a new heaps by calling BIO_new_ex().
      BIO_new_ex() is implemented in file crypto/bio/bio_lib.c, lines 80-118;
       it returns new memory pointed by both bio - allocated on line 82 by calling OPENSSL_zalloc() -
        and bio->lock - allocated on line 97 by calling CRYPTO_THREAD_lock_new().
 - after the label err: on line 3521 (for example, the conditional on line 3405 is true, the control will lead to err:) both buf and io are freed, but ssl_bio and ssl_bio->lock are not freed;
  the latter are not reachable after line 3526.
 - this issue also affects openssl-1.1.1

FIX:
 - Add the following code right before line 3522:
```
    if (ssl_bio != NULL)
       BIO_free_all(ssl_bio);
```

----------------------------------------
15.
File: apps/s_server.c

REPORT:
  PISL found a potential null pointer dereference on line 3578.
```
  3575      simple_ssl_session *sess = app_malloc(sizeof(*sess), "get session");
  3576.     unsigned char *p;
  3577. 
  3578.     SSL_SESSION_get_id(session, &sess->idlen);
            ^
  3579.     sess->derlen = i2d_SSL_SESSION(session, NULL);
  3580.     if (sess->derlen < 0) {
```

REMARK:
 - pointer sess is last assigned by calling app_malloc() on line 3573 and could be NULL.
    app_malloc() is implemented in file test/testutil/apps_mem.c, lines 14-19;
    it is a wrapper of OPENSSL_malloc() and could return NULL.
 -  pointer sess is dereferenced at on line 3576. This raises an NPE.
 - this issue also affects openssl-1.1.1
 
FIX:
 Add the following code right before line 3576:
```
  if (sess == NULL)
    return 0;
```
----------------------------------------
16.
File: crypto/ex_data.c

REPORT:
  PISL found a potential memory leak. Memory dynamically allocated at line 21 by `CRYPTO_malloc`, indirectly via call to `CRYPTO_THREAD_lock_new()` is not freed after the last access at line 23


REMARK:
 - pointer global->ex_data_lock is last assigned by calling CRYPTO_THREAD_lock_new() on line 21 and could be NULL.
    CRYPTO_THREAD_lock_new() is implemented in file crypto/threads_pthread.c, lines 31-74;
    it allocates a new heap on line 36 by calling OPENSSL_zalloc() which is a wrapper of
     CRYPTO_malloc().
 -  pointer global->ex_data_lock is not freed before the return at line 22
   and not reachable after that line.
   
FIX:
  - declare
  ```
   int ret
```
  - modify the code on line 23:
```
  ret = global->ex_data_lock != NULL;
  CRYPTO_THREAD_lock_free(global->ex_data_lock);
  return ret;
```



