### PR TITLE
testutil: preserve app_malloc()'s failure behaviour

### DIFF
--- a/test/testutil/apps_mem.c
+++ b/test/testutil/apps_mem.c
@@ -7,13 +7,24 @@
  * https://www.openssl.org/source/license.html
  */
 
+#include <stdlib.h>
 #include "apps.h"
+#include "../testutil.h"
 
 /* shim that avoids sucking in too much from apps/apps.c */
 
 void *app_malloc(size_t sz, const char *what)
 {
-    void *vp = OPENSSL_malloc(sz);
+    void *vp;
 
+    /*
+     * This isn't ideal but it is what the app's app_malloc() does on failure.
+     * Instead of exiting with a failure, abort() is called which makes sure
+     * that there will be a good stack trace for debugging purposes.
+     */
+    if (!TEST_ptr(vp = OPENSSL_malloc(sz))) {
+        TEST_info("Could not allocate %zu bytes for %s\n", sz, what);
+        abort();
+    }
     return vp;
 }


### PR DESCRIPTION
This should back port to 1.1.1 cleanly and it seems like it would be useful and low risk there too.

The app_malloc() function terminates execution if the allocation fails.  The tests implement their own app_malloc() in an attempt to reduce the amount of code pulled in.

This version also needs to terminate on failed allocation.  The alternative would be adding failed allocation checks pervasively throughout the apps's commands.

As noted by @lequangloc in #15834.

- [ ] documentation is added or updated
- [x] tests are added or updated
