### PR TITLE
Fix aes_core to use U64() macro..

### DIFF
--- a/crypto/aes/aes_core.c
+++ b/crypto/aes/aes_core.c
@@ -51,6 +51,15 @@
 #include "aes_local.h"
 
 #if !defined(OPENSSL_NO_AES_CONST_TIME) && !defined(AES_ASM)
+
+# if (defined(_WIN32) || defined(_WIN64)) && !defined(__MINGW32__)
+#  define U64(C) C##UI64
+# elif defined(__arch64__)
+#  define U64(C) C##UL
+# else
+#  define U64(C) C##ULL
+# endif
+
 typedef union {
     unsigned char b[8];
     u32 w[2];
@@ -79,10 +88,10 @@ static void XtimeLong(u64 *w)
     u64 a, b;
 
     a = *w;
-    b = a & 0x8080808080808080u;
+    b = a & U64(0x8080808080808080);
     a ^= b;
     b -= b >> 7;
-    b &= 0x1B1B1B1B1B1B1B1Bu;
+    b &= U64(0x1B1B1B1B1B1B1B1B);
     b ^= a << 1;
     *w = b;
 }
@@ -229,89 +238,89 @@ static void SubLong(u64 *w)
     u64 x, y, a1, a2, a3, a4, a5, a6;
 
     x = *w;
-    y = ((x & 0xFEFEFEFEFEFEFEFEu) >> 1) | ((x & 0x0101010101010101u) << 7);
-    x &= 0xDDDDDDDDDDDDDDDDu;
-    x ^= y & 0x5757575757575757u;
-    y = ((y & 0xFEFEFEFEFEFEFEFEu) >> 1) | ((y & 0x0101010101010101u) << 7);
-    x ^= y & 0x1C1C1C1C1C1C1C1Cu;
-    y = ((y & 0xFEFEFEFEFEFEFEFEu) >> 1) | ((y & 0x0101010101010101u) << 7);
-    x ^= y & 0x4A4A4A4A4A4A4A4Au;
-    y = ((y & 0xFEFEFEFEFEFEFEFEu) >> 1) | ((y & 0x0101010101010101u) << 7);
-    x ^= y & 0x4242424242424242u;
-    y = ((y & 0xFEFEFEFEFEFEFEFEu) >> 1) | ((y & 0x0101010101010101u) << 7);
-    x ^= y & 0x6464646464646464u;
-    y = ((y & 0xFEFEFEFEFEFEFEFEu) >> 1) | ((y & 0x0101010101010101u) << 7);
-    x ^= y & 0xE0E0E0E0E0E0E0E0u;
+    y = ((x & U64(0xFEFEFEFEFEFEFEFE)) >> 1) | ((x & U64(0x0101010101010101)) << 7);
+    x &= U64(0xDDDDDDDDDDDDDDDD);
+    x ^= y & U64(0x5757575757575757);
+    y = ((y & U64(0xFEFEFEFEFEFEFEFE)) >> 1) | ((y & U64(0x0101010101010101)) << 7);
+    x ^= y & U64(0x1C1C1C1C1C1C1C1C);
+    y = ((y & U64(0xFEFEFEFEFEFEFEFE)) >> 1) | ((y & U64(0x0101010101010101)) << 7);
+    x ^= y & U64(0x4A4A4A4A4A4A4A4A);
+    y = ((y & U64(0xFEFEFEFEFEFEFEFE)) >> 1) | ((y & U64(0x0101010101010101)) << 7);
+    x ^= y & U64(0x4242424242424242);
+    y = ((y & U64(0xFEFEFEFEFEFEFEFE)) >> 1) | ((y & U64(0x0101010101010101)) << 7);
+    x ^= y & U64(0x6464646464646464);
+    y = ((y & U64(0xFEFEFEFEFEFEFEFE)) >> 1) | ((y & U64(0x0101010101010101)) << 7);
+    x ^= y & U64(0xE0E0E0E0E0E0E0E0);
     a1 = x;
-    a1 ^= (x & 0xF0F0F0F0F0F0F0F0u) >> 4;
-    a2 = ((x & 0xCCCCCCCCCCCCCCCCu) >> 2) | ((x & 0x3333333333333333u) << 2);
+    a1 ^= (x & U64(0xF0F0F0F0F0F0F0F0)) >> 4;
+    a2 = ((x & U64(0xCCCCCCCCCCCCCCCC)) >> 2) | ((x & U64(0x3333333333333333)) << 2);
     a3 = x & a1;
-    a3 ^= (a3 & 0xAAAAAAAAAAAAAAAAu) >> 1;
-    a3 ^= (((x << 1) & a1) ^ ((a1 << 1) & x)) & 0xAAAAAAAAAAAAAAAAu;
+    a3 ^= (a3 & U64(0xAAAAAAAAAAAAAAAA)) >> 1;
+    a3 ^= (((x << 1) & a1) ^ ((a1 << 1) & x)) & U64(0xAAAAAAAAAAAAAAAA);
     a4 = a2 & a1;
-    a4 ^= (a4 & 0xAAAAAAAAAAAAAAAAu) >> 1;
-    a4 ^= (((a2 << 1) & a1) ^ ((a1 << 1) & a2)) & 0xAAAAAAAAAAAAAAAAu;
-    a5 = (a3 & 0xCCCCCCCCCCCCCCCCu) >> 2;
-    a3 ^= ((a4 << 2) ^ a4) & 0xCCCCCCCCCCCCCCCCu;
-    a4 = a5 & 0x2222222222222222u;
+    a4 ^= (a4 & U64(0xAAAAAAAAAAAAAAAA)) >> 1;
+    a4 ^= (((a2 << 1) & a1) ^ ((a1 << 1) & a2)) & U64(0xAAAAAAAAAAAAAAAA);
+    a5 = (a3 & U64(0xCCCCCCCCCCCCCCCC)) >> 2;
+    a3 ^= ((a4 << 2) ^ a4) & U64(0xCCCCCCCCCCCCCCCC);
+    a4 = a5 & U64(0x2222222222222222);
     a4 |= a4 >> 1;
-    a4 ^= (a5 << 1) & 0x2222222222222222u;
+    a4 ^= (a5 << 1) & U64(0x2222222222222222);
     a3 ^= a4;
-    a5 = a3 & 0xA0A0A0A0A0A0A0A0u;
+    a5 = a3 & U64(0xA0A0A0A0A0A0A0A0);
     a5 |= a5 >> 1;
-    a5 ^= (a3 << 1) & 0xA0A0A0A0A0A0A0A0u;
-    a4 = a5 & 0xC0C0C0C0C0C0C0C0u;
+    a5 ^= (a3 << 1) & U64(0xA0A0A0A0A0A0A0A0);
+    a4 = a5 & U64(0xC0C0C0C0C0C0C0C0);
     a6 = a4 >> 2;
-    a4 ^= (a5 << 2) & 0xC0C0C0C0C0C0C0C0u;
-    a5 = a6 & 0x2020202020202020u;
+    a4 ^= (a5 << 2) & U64(0xC0C0C0C0C0C0C0C0);
+    a5 = a6 & U64(0x2020202020202020);
     a5 |= a5 >> 1;
-    a5 ^= (a6 << 1) & 0x2020202020202020u;
+    a5 ^= (a6 << 1) & U64(0x2020202020202020);
     a4 |= a5;
     a3 ^= a4 >> 4;
-    a3 &= 0x0F0F0F0F0F0F0F0Fu;
+    a3 &= U64(0x0F0F0F0F0F0F0F0F);
     a2 = a3;
-    a2 ^= (a3 & 0x0C0C0C0C0C0C0C0Cu) >> 2;
+    a2 ^= (a3 & U64(0x0C0C0C0C0C0C0C0C)) >> 2;
     a4 = a3 & a2;
-    a4 ^= (a4 & 0x0A0A0A0A0A0A0A0Au) >> 1;
-    a4 ^= (((a3 << 1) & a2) ^ ((a2 << 1) & a3)) & 0x0A0A0A0A0A0A0A0Au;
-    a5 = a4 & 0x0808080808080808u;
+    a4 ^= (a4 & U64(0x0A0A0A0A0A0A0A0A)) >> 1;
+    a4 ^= (((a3 << 1) & a2) ^ ((a2 << 1) & a3)) & U64(0x0A0A0A0A0A0A0A0A);
+    a5 = a4 & U64(0x0808080808080808);
     a5 |= a5 >> 1;
-    a5 ^= (a4 << 1) & 0x0808080808080808u;
+    a5 ^= (a4 << 1) & U64(0x0808080808080808);
     a4 ^= a5 >> 2;
-    a4 &= 0x0303030303030303u;
-    a4 ^= (a4 & 0x0202020202020202u) >> 1;
+    a4 &= U64(0x0303030303030303);
+    a4 ^= (a4 & U64(0x0202020202020202)) >> 1;
     a4 |= a4 << 2;
     a3 = a2 & a4;
-    a3 ^= (a3 & 0x0A0A0A0A0A0A0A0Au) >> 1;
-    a3 ^= (((a2 << 1) & a4) ^ ((a4 << 1) & a2)) & 0x0A0A0A0A0A0A0A0Au;
+    a3 ^= (a3 & U64(0x0A0A0A0A0A0A0A0A)) >> 1;
+    a3 ^= (((a2 << 1) & a4) ^ ((a4 << 1) & a2)) & U64(0x0A0A0A0A0A0A0A0A);
     a3 |= a3 << 4;
-    a2 = ((a1 & 0xCCCCCCCCCCCCCCCCu) >> 2) | ((a1 & 0x3333333333333333u) << 2);
+    a2 = ((a1 & U64(0xCCCCCCCCCCCCCCCC)) >> 2) | ((a1 & U64(0x3333333333333333)) << 2);
     x = a1 & a3;
-    x ^= (x & 0xAAAAAAAAAAAAAAAAu) >> 1;
-    x ^= (((a1 << 1) & a3) ^ ((a3 << 1) & a1)) & 0xAAAAAAAAAAAAAAAAu;
+    x ^= (x & U64(0xAAAAAAAAAAAAAAAA)) >> 1;
+    x ^= (((a1 << 1) & a3) ^ ((a3 << 1) & a1)) & U64(0xAAAAAAAAAAAAAAAA);
     a4 = a2 & a3;
-    a4 ^= (a4 & 0xAAAAAAAAAAAAAAAAu) >> 1;
-    a4 ^= (((a2 << 1) & a3) ^ ((a3 << 1) & a2)) & 0xAAAAAAAAAAAAAAAAu;
-    a5 = (x & 0xCCCCCCCCCCCCCCCCu) >> 2;
-    x ^= ((a4 << 2) ^ a4) & 0xCCCCCCCCCCCCCCCCu;
-    a4 = a5 & 0x2222222222222222u;
+    a4 ^= (a4 & U64(0xAAAAAAAAAAAAAAAA)) >> 1;
+    a4 ^= (((a2 << 1) & a3) ^ ((a3 << 1) & a2)) & U64(0xAAAAAAAAAAAAAAAA);
+    a5 = (x & U64(0xCCCCCCCCCCCCCCCC)) >> 2;
+    x ^= ((a4 << 2) ^ a4) & U64(0xCCCCCCCCCCCCCCCC);
+    a4 = a5 & U64(0x2222222222222222);
     a4 |= a4 >> 1;
-    a4 ^= (a5 << 1) & 0x2222222222222222u;
+    a4 ^= (a5 << 1) & U64(0x2222222222222222);
     x ^= a4;
-    y = ((x & 0xFEFEFEFEFEFEFEFEu) >> 1) | ((x & 0x0101010101010101u) << 7);
-    x &= 0x3939393939393939u;
-    x ^= y & 0x3F3F3F3F3F3F3F3Fu;
-    y = ((y & 0xFCFCFCFCFCFCFCFCu) >> 2) | ((y & 0x0303030303030303u) << 6);
-    x ^= y & 0x9797979797979797u;
-    y = ((y & 0xFEFEFEFEFEFEFEFEu) >> 1) | ((y & 0x0101010101010101u) << 7);
-    x ^= y & 0x9B9B9B9B9B9B9B9Bu;
-    y = ((y & 0xFEFEFEFEFEFEFEFEu) >> 1) | ((y & 0x0101010101010101u) << 7);
-    x ^= y & 0x3C3C3C3C3C3C3C3Cu;
-    y = ((y & 0xFEFEFEFEFEFEFEFEu) >> 1) | ((y & 0x0101010101010101u) << 7);
-    x ^= y & 0xDDDDDDDDDDDDDDDDu;
-    y = ((y & 0xFEFEFEFEFEFEFEFEu) >> 1) | ((y & 0x0101010101010101u) << 7);
-    x ^= y & 0x7272727272727272u;
-    x ^= 0x6363636363636363u;
+    y = ((x & U64(0xFEFEFEFEFEFEFEFE)) >> 1) | ((x & U64(0x0101010101010101)) << 7);
+    x &= U64(0x3939393939393939);
+    x ^= y & U64(0x3F3F3F3F3F3F3F3F);
+    y = ((y & U64(0xFCFCFCFCFCFCFCFC)) >> 2) | ((y & U64(0x0303030303030303)) << 6);
+    x ^= y & U64(0x9797979797979797);
+    y = ((y & U64(0xFEFEFEFEFEFEFEFE)) >> 1) | ((y & U64(0x0101010101010101)) << 7);
+    x ^= y & U64(0x9B9B9B9B9B9B9B9B);
+    y = ((y & U64(0xFEFEFEFEFEFEFEFE)) >> 1) | ((y & U64(0x0101010101010101)) << 7);
+    x ^= y & U64(0x3C3C3C3C3C3C3C3C);
+    y = ((y & U64(0xFEFEFEFEFEFEFEFE)) >> 1) | ((y & U64(0x0101010101010101)) << 7);
+    x ^= y & U64(0xDDDDDDDDDDDDDDDD);
+    y = ((y & U64(0xFEFEFEFEFEFEFEFE)) >> 1) | ((y & U64(0x0101010101010101)) << 7);
+    x ^= y & U64(0x7272727272727272);
+    x ^= U64(0x6363636363636363);
     *w = x;
 }
 
@@ -323,93 +332,93 @@ static void InvSubLong(u64 *w)
     u64 x, y, a1, a2, a3, a4, a5, a6;
 
     x = *w;
-    x ^= 0x6363636363636363u;
-    y = ((x & 0xFEFEFEFEFEFEFEFEu) >> 1) | ((x & 0x0101010101010101u) << 7);
-    x &= 0xFDFDFDFDFDFDFDFDu;
-    x ^= y & 0x5E5E5E5E5E5E5E5Eu;
-    y = ((y & 0xFEFEFEFEFEFEFEFEu) >> 1) | ((y & 0x0101010101010101u) << 7);
-    x ^= y & 0xF3F3F3F3F3F3F3F3u;
-    y = ((y & 0xFEFEFEFEFEFEFEFEu) >> 1) | ((y & 0x0101010101010101u) << 7);
-    x ^= y & 0xF5F5F5F5F5F5F5F5u;
-    y = ((y & 0xFEFEFEFEFEFEFEFEu) >> 1) | ((y & 0x0101010101010101u) << 7);
-    x ^= y & 0x7878787878787878u;
-    y = ((y & 0xFEFEFEFEFEFEFEFEu) >> 1) | ((y & 0x0101010101010101u) << 7);
-    x ^= y & 0x7777777777777777u;
-    y = ((y & 0xFEFEFEFEFEFEFEFEu) >> 1) | ((y & 0x0101010101010101u) << 7);
-    x ^= y & 0x1515151515151515u;
-    y = ((y & 0xFEFEFEFEFEFEFEFEu) >> 1) | ((y & 0x0101010101010101u) << 7);
-    x ^= y & 0xA5A5A5A5A5A5A5A5u;
+    x ^= U64(0x6363636363636363);
+    y = ((x & U64(0xFEFEFEFEFEFEFEFE)) >> 1) | ((x & U64(0x0101010101010101)) << 7);
+    x &= U64(0xFDFDFDFDFDFDFDFD);
+    x ^= y & U64(0x5E5E5E5E5E5E5E5E);
+    y = ((y & U64(0xFEFEFEFEFEFEFEFE)) >> 1) | ((y & U64(0x0101010101010101)) << 7);
+    x ^= y & U64(0xF3F3F3F3F3F3F3F3);
+    y = ((y & U64(0xFEFEFEFEFEFEFEFE)) >> 1) | ((y & U64(0x0101010101010101)) << 7);
+    x ^= y & U64(0xF5F5F5F5F5F5F5F5);
+    y = ((y & U64(0xFEFEFEFEFEFEFEFE)) >> 1) | ((y & U64(0x0101010101010101)) << 7);
+    x ^= y & U64(0x7878787878787878);
+    y = ((y & U64(0xFEFEFEFEFEFEFEFE)) >> 1) | ((y & U64(0x0101010101010101)) << 7);
+    x ^= y & U64(0x7777777777777777);
+    y = ((y & U64(0xFEFEFEFEFEFEFEFE)) >> 1) | ((y & U64(0x0101010101010101)) << 7);
+    x ^= y & U64(0x1515151515151515);
+    y = ((y & U64(0xFEFEFEFEFEFEFEFE)) >> 1) | ((y & U64(0x0101010101010101)) << 7);
+    x ^= y & U64(0xA5A5A5A5A5A5A5A5);
     a1 = x;
-    a1 ^= (x & 0xF0F0F0F0F0F0F0F0u) >> 4;
-    a2 = ((x & 0xCCCCCCCCCCCCCCCCu) >> 2) | ((x & 0x3333333333333333u) << 2);
+    a1 ^= (x & U64(0xF0F0F0F0F0F0F0F0)) >> 4;
+    a2 = ((x & U64(0xCCCCCCCCCCCCCCCC)) >> 2) | ((x & U64(0x3333333333333333)) << 2);
     a3 = x & a1;
-    a3 ^= (a3 & 0xAAAAAAAAAAAAAAAAu) >> 1;
-    a3 ^= (((x << 1) & a1) ^ ((a1 << 1) & x)) & 0xAAAAAAAAAAAAAAAAu;
+    a3 ^= (a3 & U64(0xAAAAAAAAAAAAAAAA)) >> 1;
+    a3 ^= (((x << 1) & a1) ^ ((a1 << 1) & x)) & U64(0xAAAAAAAAAAAAAAAA);
     a4 = a2 & a1;
-    a4 ^= (a4 & 0xAAAAAAAAAAAAAAAAu) >> 1;
-    a4 ^= (((a2 << 1) & a1) ^ ((a1 << 1) & a2)) & 0xAAAAAAAAAAAAAAAAu;
-    a5 = (a3 & 0xCCCCCCCCCCCCCCCCu) >> 2;
-    a3 ^= ((a4 << 2) ^ a4) & 0xCCCCCCCCCCCCCCCCu;
-    a4 = a5 & 0x2222222222222222u;
+    a4 ^= (a4 & U64(0xAAAAAAAAAAAAAAAA)) >> 1;
+    a4 ^= (((a2 << 1) & a1) ^ ((a1 << 1) & a2)) & U64(0xAAAAAAAAAAAAAAAA);
+    a5 = (a3 & U64(0xCCCCCCCCCCCCCCCC)) >> 2;
+    a3 ^= ((a4 << 2) ^ a4) & U64(0xCCCCCCCCCCCCCCCC);
+    a4 = a5 & U64(0x2222222222222222);
     a4 |= a4 >> 1;
-    a4 ^= (a5 << 1) & 0x2222222222222222u;
+    a4 ^= (a5 << 1) & U64(0x2222222222222222);
     a3 ^= a4;
-    a5 = a3 & 0xA0A0A0A0A0A0A0A0u;
+    a5 = a3 & U64(0xA0A0A0A0A0A0A0A0);
     a5 |= a5 >> 1;
-    a5 ^= (a3 << 1) & 0xA0A0A0A0A0A0A0A0u;
-    a4 = a5 & 0xC0C0C0C0C0C0C0C0u;
+    a5 ^= (a3 << 1) & U64(0xA0A0A0A0A0A0A0A0);
+    a4 = a5 & U64(0xC0C0C0C0C0C0C0C0);
     a6 = a4 >> 2;
-    a4 ^= (a5 << 2) & 0xC0C0C0C0C0C0C0C0u;
-    a5 = a6 & 0x2020202020202020u;
+    a4 ^= (a5 << 2) & U64(0xC0C0C0C0C0C0C0C0);
+    a5 = a6 & U64(0x2020202020202020);
     a5 |= a5 >> 1;
-    a5 ^= (a6 << 1) & 0x2020202020202020u;
+    a5 ^= (a6 << 1) & U64(0x2020202020202020);
     a4 |= a5;
     a3 ^= a4 >> 4;
-    a3 &= 0x0F0F0F0F0F0F0F0Fu;
+    a3 &= U64(0x0F0F0F0F0F0F0F0F);
     a2 = a3;
-    a2 ^= (a3 & 0x0C0C0C0C0C0C0C0Cu) >> 2;
+    a2 ^= (a3 & U64(0x0C0C0C0C0C0C0C0C)) >> 2;
     a4 = a3 & a2;
-    a4 ^= (a4 & 0x0A0A0A0A0A0A0A0Au) >> 1;
-    a4 ^= (((a3 << 1) & a2) ^ ((a2 << 1) & a3)) & 0x0A0A0A0A0A0A0A0Au;
-    a5 = a4 & 0x0808080808080808u;
+    a4 ^= (a4 & U64(0x0A0A0A0A0A0A0A0A)) >> 1;
+    a4 ^= (((a3 << 1) & a2) ^ ((a2 << 1) & a3)) & U64(0x0A0A0A0A0A0A0A0A);
+    a5 = a4 & U64(0x0808080808080808);
     a5 |= a5 >> 1;
-    a5 ^= (a4 << 1) & 0x0808080808080808u;
+    a5 ^= (a4 << 1) & U64(0x0808080808080808);
     a4 ^= a5 >> 2;
-    a4 &= 0x0303030303030303u;
-    a4 ^= (a4 & 0x0202020202020202u) >> 1;
+    a4 &= U64(0x0303030303030303);
+    a4 ^= (a4 & U64(0x0202020202020202)) >> 1;
     a4 |= a4 << 2;
     a3 = a2 & a4;
-    a3 ^= (a3 & 0x0A0A0A0A0A0A0A0Au) >> 1;
-    a3 ^= (((a2 << 1) & a4) ^ ((a4 << 1) & a2)) & 0x0A0A0A0A0A0A0A0Au;
+    a3 ^= (a3 & U64(0x0A0A0A0A0A0A0A0A)) >> 1;
+    a3 ^= (((a2 << 1) & a4) ^ ((a4 << 1) & a2)) & U64(0x0A0A0A0A0A0A0A0A);
     a3 |= a3 << 4;
-    a2 = ((a1 & 0xCCCCCCCCCCCCCCCCu) >> 2) | ((a1 & 0x3333333333333333u) << 2);
+    a2 = ((a1 & U64(0xCCCCCCCCCCCCCCCC)) >> 2) | ((a1 & U64(0x3333333333333333)) << 2);
     x = a1 & a3;
-    x ^= (x & 0xAAAAAAAAAAAAAAAAu) >> 1;
-    x ^= (((a1 << 1) & a3) ^ ((a3 << 1) & a1)) & 0xAAAAAAAAAAAAAAAAu;
+    x ^= (x & U64(0xAAAAAAAAAAAAAAAA)) >> 1;
+    x ^= (((a1 << 1) & a3) ^ ((a3 << 1) & a1)) & U64(0xAAAAAAAAAAAAAAAA);
     a4 = a2 & a3;
-    a4 ^= (a4 & 0xAAAAAAAAAAAAAAAAu) >> 1;
-    a4 ^= (((a2 << 1) & a3) ^ ((a3 << 1) & a2)) & 0xAAAAAAAAAAAAAAAAu;
-    a5 = (x & 0xCCCCCCCCCCCCCCCCu) >> 2;
-    x ^= ((a4 << 2) ^ a4) & 0xCCCCCCCCCCCCCCCCu;
-    a4 = a5 & 0x2222222222222222u;
+    a4 ^= (a4 & U64(0xAAAAAAAAAAAAAAAA)) >> 1;
+    a4 ^= (((a2 << 1) & a3) ^ ((a3 << 1) & a2)) & U64(0xAAAAAAAAAAAAAAAA);
+    a5 = (x & U64(0xCCCCCCCCCCCCCCCC)) >> 2;
+    x ^= ((a4 << 2) ^ a4) & U64(0xCCCCCCCCCCCCCCCC);
+    a4 = a5 & U64(0x2222222222222222);
     a4 |= a4 >> 1;
-    a4 ^= (a5 << 1) & 0x2222222222222222u;
+    a4 ^= (a5 << 1) & U64(0x2222222222222222);
     x ^= a4;
-    y = ((x & 0xFEFEFEFEFEFEFEFEu) >> 1) | ((x & 0x0101010101010101u) << 7);
-    x &= 0xB5B5B5B5B5B5B5B5u;
-    x ^= y & 0x4040404040404040u;
-    y = ((y & 0xFEFEFEFEFEFEFEFEu) >> 1) | ((y & 0x0101010101010101u) << 7);
-    x ^= y & 0x8080808080808080u;
-    y = ((y & 0xFEFEFEFEFEFEFEFEu) >> 1) | ((y & 0x0101010101010101u) << 7);
-    x ^= y & 0x1616161616161616u;
-    y = ((y & 0xFEFEFEFEFEFEFEFEu) >> 1) | ((y & 0x0101010101010101u) << 7);
-    x ^= y & 0xEBEBEBEBEBEBEBEBu;
-    y = ((y & 0xFEFEFEFEFEFEFEFEu) >> 1) | ((y & 0x0101010101010101u) << 7);
-    x ^= y & 0x9797979797979797u;
-    y = ((y & 0xFEFEFEFEFEFEFEFEu) >> 1) | ((y & 0x0101010101010101u) << 7);
-    x ^= y & 0xFBFBFBFBFBFBFBFBu;
-    y = ((y & 0xFEFEFEFEFEFEFEFEu) >> 1) | ((y & 0x0101010101010101u) << 7);
-    x ^= y & 0x7D7D7D7D7D7D7D7Du;
+    y = ((x & U64(0xFEFEFEFEFEFEFEFE)) >> 1) | ((x & U64(0x0101010101010101)) << 7);
+    x &= U64(0xB5B5B5B5B5B5B5B5);
+    x ^= y & U64(0x4040404040404040);
+    y = ((y & U64(0xFEFEFEFEFEFEFEFE)) >> 1) | ((y & U64(0x0101010101010101)) << 7);
+    x ^= y & U64(0x8080808080808080);
+    y = ((y & U64(0xFEFEFEFEFEFEFEFE)) >> 1) | ((y & U64(0x0101010101010101)) << 7);
+    x ^= y & U64(0x1616161616161616);
+    y = ((y & U64(0xFEFEFEFEFEFEFEFE)) >> 1) | ((y & U64(0x0101010101010101)) << 7);
+    x ^= y & U64(0xEBEBEBEBEBEBEBEB);
+    y = ((y & U64(0xFEFEFEFEFEFEFEFE)) >> 1) | ((y & U64(0x0101010101010101)) << 7);
+    x ^= y & U64(0x9797979797979797);
+    y = ((y & U64(0xFEFEFEFEFEFEFEFE)) >> 1) | ((y & U64(0x0101010101010101)) << 7);
+    x ^= y & U64(0xFBFBFBFBFBFBFBFB);
+    y = ((y & U64(0xFEFEFEFEFEFEFEFE)) >> 1) | ((y & U64(0x0101010101010101)) << 7);
+    x ^= y & U64(0x7D7D7D7D7D7D7D7D);
     *w = x;
 }
 
@@ -460,10 +469,10 @@ static void MixColumns(u64 *state)
     for (c = 0; c < 2; c++) {
         s1.d = state[c];
         s.d = s1.d;
-        s.d ^= ((s.d & 0xFFFF0000FFFF0000u) >> 16)
-               | ((s.d & 0x0000FFFF0000FFFFu) << 16);
-        s.d ^= ((s.d & 0xFF00FF00FF00FF00u) >> 8)
-               | ((s.d & 0x00FF00FF00FF00FFu) << 8);
+        s.d ^= ((s.d & U64(0xFFFF0000FFFF0000)) >> 16)
+               | ((s.d & U64(0x0000FFFF0000FFFF)) << 16);
+        s.d ^= ((s.d & U64(0xFF00FF00FF00FF00)) >> 8)
+               | ((s.d & U64(0x00FF00FF00FF00FF)) << 8);
         s.d ^= s1.d;
         XtimeLong(&s1.d);
         s.d ^= s1.d;
@@ -488,10 +497,10 @@ static void InvMixColumns(u64 *state)
     for (c = 0; c < 2; c++) {
         s1.d = state[c];
         s.d = s1.d;
-        s.d ^= ((s.d & 0xFFFF0000FFFF0000u) >> 16)
-               | ((s.d & 0x0000FFFF0000FFFFu) << 16);
-        s.d ^= ((s.d & 0xFF00FF00FF00FF00u) >> 8)
-               | ((s.d & 0x00FF00FF00FF00FFu) << 8);
+        s.d ^= ((s.d & U64(0xFFFF0000FFFF0000)) >> 16)
+               | ((s.d & U64(0x0000FFFF0000FFFF)) << 16);
+        s.d ^= ((s.d & U64(0xFF00FF00FF00FF00)) >> 8)
+               | ((s.d & U64(0x00FF00FF00FF00FF)) << 8);
         s.d ^= s1.d;
         XtimeLong(&s1.d);
         s.d ^= s1.d;
@@ -504,12 +513,12 @@ static void InvMixColumns(u64 *state)
         s.b[6] ^= s1.b[7];
         s.b[7] ^= s1.b[4];
         XtimeLong(&s1.d);
-        s1.d ^= ((s1.d & 0xFFFF0000FFFF0000u) >> 16)
-                | ((s1.d & 0x0000FFFF0000FFFFu) << 16);
+        s1.d ^= ((s1.d & U64(0xFFFF0000FFFF0000)) >> 16)
+                | ((s1.d & U64(0x0000FFFF0000FFFF)) << 16);
         s.d ^= s1.d;
         XtimeLong(&s1.d);
-        s1.d ^= ((s1.d & 0xFF00FF00FF00FF00u) >> 8)
-                | ((s1.d & 0x00FF00FF00FF00FFu) << 8);
+        s1.d ^= ((s1.d & U64(0xFF00FF00FF00FF00)) >> 8)
+                | ((s1.d & U64(0x00FF00FF00FF00FF)) << 8);
         s.d ^= s1.d;
         state[c] = s.d;
     }


### PR DESCRIPTION
AIX reported warnings of the form when building with noasm:
1506-207 (W) Integer constant 0x8080808080808080u out of range.

This truncation causes all startup self tests related to AES to fail.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
