### PR TITLE
test/recipes/80-test_cmp_http.t: use app() rather than cmd()

### DIFF
--- a/test/recipes/80-test_cmp_http.t
+++ b/test/recipes/80-test_cmp_http.t
@@ -47,7 +47,7 @@ $proxy = chop_dblquot($ENV{http_proxy} // $ENV{HTTP_PROXY} // $proxy);
 $proxy =~ s{^https?://}{}i;
 my $no_proxy = $ENV{no_proxy} // $ENV{NO_PROXY};
 
-my $app = "apps/openssl cmp";
+my @app = qw(openssl cmp);
 
 # the CMP server configuration consists of:
 my $ca_dn;      # The CA's Distinguished Name
@@ -129,16 +129,14 @@ sub test_cmp_http {
     my $title = shift;
     my $params = shift;
     my $expected_result = shift;
-    my $path_app = bldtop_dir($app);
     $params = [ '-server', "127.0.0.1:$server_port", @$params ]
         unless grep { $_ eq '-server' } @$params;
+    my $cmd = app([@app, @$params]);
 
-    unless (is(my $actual_result = run(cmd([$path_app, @$params,])),
-               $expected_result,
-               $title)) {
+    unless (is(my $actual_result = run($cmd), $expected_result, $title)) {
         if ($faillog) {
             my $quote_spc_empty = sub { $_ eq "" ? '""' : $_ =~ m/ / ? '"'.$_.'"' : $_ };
-            my $invocation = "$path_app ".join(' ', map $quote_spc_empty->($_), @$params);
+            my $invocation = cmdstr($cmd, display => 1);
             print $faillog "$server_name $aspect \"$title\" ($i/$n)".
                 " expected=$expected_result actual=$actual_result\n";
             print $faillog "$invocation\n\n";
@@ -266,7 +264,7 @@ sub load_tests {
 
 sub start_mock_server {
     my $args = $_[0]; # optional further CLI arguments
-    my $cmd = cmdstr(app(['openssl', 'cmp', '-config', 'server.cnf',
+    my $cmd = cmdstr(app([@app, '-config', 'server.cnf',
                           $args ? $args : ()]), display => 1);
     print "Current directory is ".getcwd()."\n";
     print "Launching mock server: $cmd\n";

--- a/test/recipes/81-test_cmp_cli.t
+++ b/test/recipes/81-test_cmp_cli.t
@@ -28,7 +28,7 @@ plan skip_all => "These tests are not supported in a fuzz build"
 plan skip_all => "These tests are not supported in a no-cmp build"
     if disabled("cmp");
 
-my $app = bldtop_dir("apps/openssl cmp");
+my @app = qw(openssl cmp);
 
 my @cmp_basic_tests = (
     [ "show help",                        [ "-help"               ], 1 ],
@@ -53,7 +53,7 @@ foreach (@cmp_basic_tests) {
     my $title = $$_[0];
     my $params = $$_[1];
     my $expected = $$_[2];
-    ok($expected == run(cmd([$app, "-config", '', @$params])),
+    ok($expected == run(app([@app, "-config", '', @$params])),
        $title);
 }
 
@@ -66,7 +66,7 @@ foreach (@cmp_server_tests) {
     my $rsp_cert = srctop_file('test',  'certs', 'ee-cert-1024.pem');
     my $outfile = result_file("test.certout.pem");
     ok($expected ==
-       run(cmd([$app, "-config", '', @$extra_args,
+       run(app([@app, "-config", '', @$extra_args,
                 "-use_mock_srv", "-srv_ref", "mock server",
                 "-srv_secret", $secret,
                 "-rsp_cert", $rsp_cert,


### PR DESCRIPTION
OpenSSL::Test::cmd() should be used with caution, as it is for special
cases only.
It's preferable to use OpenSSL::Test::app() or OpenSSL::Test::test().

Fixes #15833
