### PR TITLE
Fix CMP mock server polling

### DIFF
--- a/crypto/cmp/cmp_server.c
+++ b/crypto/cmp/cmp_server.c
@@ -337,7 +337,8 @@ static OSSL_CMP_MSG *process_certConf(OSSL_CMP_SRV_CTX *srv_ctx,
     ccc = req->body->value.certConf;
     num = sk_OSSL_CMP_CERTSTATUS_num(ccc);
 
-    if (OSSL_CMP_CTX_get_option(ctx, OSSL_CMP_OPT_IMPLICIT_CONFIRM) == 1) {
+    if (OSSL_CMP_CTX_get_option(ctx, OSSL_CMP_OPT_IMPLICIT_CONFIRM) == 1
+            || ctx->status != -2 /* transaction not open */) {
         ERR_raise(ERR_LIB_CMP, CMP_R_ERROR_UNEXPECTED_CERTCONF);
         return NULL;
     }


### PR DESCRIPTION
Upon user feedback I found that the test/mock CMP server implemented `-poll_count` insufficiently: only for the first request.
Moreover, the CMP client diagnostic output of the `checkAfter` value received from the server was not always right.
This PR fixes both issues.
