### PR TITLE
Update dependencies for krb5 external test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,7 +224,7 @@ jobs:
     - name: package installs
       run: |
         sudo apt-get update
-        sudo apt-get -yq install bison dejagnu gettext keyutils ldap-utils libldap2-dev libkeyutils-dev python3 python3-paste python3-pyrad slapd tcl-dev tcl-thread tcsh python3-virtualenv virtualenv
+        sudo apt-get -yq install bison gettext keyutils ldap-utils libldap2-dev libkeyutils-dev python3 python3-paste python3-pyrad slapd tcsh python3-virtualenv virtualenv python3-kdcproxy
     - name: install cpanm and Test2::V0 for gost_engine testing
       uses: perl-actions/install-with-cpanm@v1
       with:


### PR DESCRIPTION
Dejagnu/TCL are no longer needed.  Installing kdcproxy enables krb5's
proxying tests, which exercise the krb5 TLS integration.

Signed-off-by: Robbie Harwood <rharwood@redhat.com>

[Corresponding merged krb5 PR for proxy-related changes: https://github.com/krb5/krb5/pull/1196 .  This should conclude our openssl-3 readiness work; we don't plan to merge KDF integration until after the full release.]

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
