### PR TITLE
cross-reference the DH and RSA SECLEVEL to level of security mappings

### DIFF
--- a/crypto/x509/x509_vfy.c
+++ b/crypto/x509/x509_vfy.c
@@ -3364,6 +3364,10 @@ STACK_OF(X509) *X509_build_chain(X509 *target, STACK_OF(X509) *certs,
     return result;
 }
 
+/*
+ * note that there's a corresponding minbits_table in ssl/ssl_cert.c
+ * in ssl_get_security_level_bits that's used for selection of DH parameters
+ */
 static const int minbits_table[] = { 80, 112, 128, 192, 256 };
 static const int NUM_AUTH_LEVELS = OSSL_NELEM(minbits_table);
 

--- a/ssl/ssl_cert.c
+++ b/ssl/ssl_cert.c
@@ -963,6 +963,11 @@ int ssl_cert_set_cert_store(CERT *c, X509_STORE *store, int chain, int ref)
 int ssl_get_security_level_bits(const SSL *s, const SSL_CTX *ctx, int *levelp)
 {
     int level;
+    /*
+     * note that there's a corresponding minbits_table
+     * in crypto/x509/x509_vfy.c that's used for checking the security level
+     * of RSA and DSA keys
+     */
     static const int minbits_table[5 + 1] = { 0, 80, 112, 128, 192, 256 };
 
     if (ctx != NULL)


### PR DESCRIPTION
Since the DH check is used only in DHE-PSK ciphersuites, it's
easy to miss it when updating the RSA mapping. Add cross-references
so that they remain consistent.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
