### PR TITLE
Don't hold any locks while calling the provider init function

### DIFF
--- a/crypto/provider.c
+++ b/crypto/provider.c
@@ -94,29 +94,6 @@ int OSSL_PROVIDER_get_capabilities(const OSSL_PROVIDER *prov,
     return ossl_provider_get_capabilities(prov, capability, cb, arg);
 }
 
-int OSSL_PROVIDER_add_builtin(OSSL_LIB_CTX *libctx, const char *name,
-                              OSSL_provider_init_fn *init_fn)
-{
-    OSSL_PROVIDER *prov = NULL;
-
-    if (name == NULL || init_fn == NULL) {
-        ERR_raise(ERR_LIB_CRYPTO, ERR_R_PASSED_NULL_PARAMETER);
-        return 0;
-    }
-
-    /* Create it */
-    if ((prov = ossl_provider_new(libctx, name, init_fn, 0)) == NULL)
-        return 0;
-
-    /*
-     * It's safely stored in the internal store at this point,
-     * free the returned extra reference
-     */
-    ossl_provider_free(prov);
-
-    return 1;
-}
-
 const char *OSSL_PROVIDER_get0_name(const OSSL_PROVIDER *prov)
 {
     return ossl_provider_name(prov);

--- a/crypto/provider.c
+++ b/crypto/provider.c
@@ -18,7 +18,7 @@
 OSSL_PROVIDER *OSSL_PROVIDER_try_load(OSSL_LIB_CTX *libctx, const char *name,
                                       int retain_fallbacks)
 {
-    OSSL_PROVIDER *prov = NULL;
+    OSSL_PROVIDER *prov = NULL, *actual;
     int isnew = 0;
 
     /* Find it or create it */
@@ -33,13 +33,14 @@ OSSL_PROVIDER *OSSL_PROVIDER_try_load(OSSL_LIB_CTX *libctx, const char *name,
         return NULL;
     }
 
-    if (isnew && !ossl_provider_add_to_store(prov, retain_fallbacks)) {
+    actual = prov;
+    if (isnew && !ossl_provider_add_to_store(prov, &actual, retain_fallbacks)) {
         ossl_provider_deactivate(prov);
         ossl_provider_free(prov);
         return NULL;
     }
 
-    return prov;
+    return actual;
 }
 
 OSSL_PROVIDER *OSSL_PROVIDER_load(OSSL_LIB_CTX *libctx, const char *name)

--- a/crypto/provider.c
+++ b/crypto/provider.c
@@ -26,7 +26,7 @@ OSSL_PROVIDER *OSSL_PROVIDER_try_load(OSSL_LIB_CTX *libctx, const char *name,
         isnew = 1;
     }
 
-    if (!ossl_provider_activate(prov, 1)) {
+    if (!ossl_provider_activate(prov, 1, 0)) {
         ossl_provider_free(prov);
         return NULL;
     }

--- a/crypto/provider.c
+++ b/crypto/provider.c
@@ -47,18 +47,6 @@ int OSSL_PROVIDER_unload(OSSL_PROVIDER *prov)
     return 1;
 }
 
-int OSSL_PROVIDER_available(OSSL_LIB_CTX *libctx, const char *name)
-{
-    OSSL_PROVIDER *prov = NULL;
-    int available = 0;
-
-    /* Find it or create it */
-    prov = ossl_provider_find(libctx, name, 0);
-    available = ossl_provider_available(prov);
-    ossl_provider_free(prov);
-    return available;
-}
-
 const OSSL_PARAM *OSSL_PROVIDER_gettable_params(const OSSL_PROVIDER *prov)
 {
     return ossl_provider_gettable_params(prov);

--- a/crypto/provider.c
+++ b/crypto/provider.c
@@ -26,12 +26,12 @@ OSSL_PROVIDER *OSSL_PROVIDER_try_load(OSSL_LIB_CTX *libctx, const char *name,
         isnew = 1;
     }
 
-    if (!ossl_provider_activate(prov, retain_fallbacks, 1)) {
+    if (!ossl_provider_activate(prov, 1)) {
         ossl_provider_free(prov);
         return NULL;
     }
 
-    if (isnew && !ossl_provider_add_to_store(prov)) {
+    if (isnew && !ossl_provider_add_to_store(prov, retain_fallbacks)) {
         ossl_provider_deactivate(prov);
         ossl_provider_free(prov);
         return NULL;

--- a/crypto/provider_child.c
+++ b/crypto/provider_child.c
@@ -150,19 +150,21 @@ static int provider_create_child_cb(const OSSL_CORE_HANDLE *prov, void *cbdata)
                                        1)) == NULL)
             goto err;
 
+        if (!ossl_provider_activate(cprov, 0, 0))
+            goto err;
+
+        if (!ossl_provider_set_child(cprov, prov)
+            || !ossl_provider_add_to_store(cprov)) {
+            ossl_provider_deactivate(cprov);
+            ossl_provider_free(cprov);
+            goto err;
+        }
+
         /*
         * We free the newly created ref. We rely on the provider sticking around
         * in the provider store.
         */
         ossl_provider_free(cprov);
-
-        if (!ossl_provider_activate(cprov, 0, 0))
-            goto err;
-
-        if (!ossl_provider_set_child(cprov, prov)) {
-            ossl_provider_deactivate(cprov);
-            goto err;
-        }
     }
 
     ret = 1;

--- a/crypto/provider_child.c
+++ b/crypto/provider_child.c
@@ -134,7 +134,7 @@ static int provider_create_child_cb(const OSSL_CORE_HANDLE *prov, void *cbdata)
 
         /*
          * The provider already exists. It could be a previously created child,
-         * or it could have been explicitly loaded. If explicitly loaded it we
+         * or it could have been explicitly loaded. If explicitly loaded we
          * ignore it - i.e. we don't start treating it like a child.
          */
         if (!ossl_provider_activate(cprov, 0, 1))

--- a/crypto/provider_child.c
+++ b/crypto/provider_child.c
@@ -137,7 +137,7 @@ static int provider_create_child_cb(const OSSL_CORE_HANDLE *prov, void *cbdata)
          * or it could have been explicitly loaded. If explicitly loaded it we
          * ignore it - i.e. we don't start treating it like a child.
          */
-        if (!ossl_provider_activate_child(cprov, prov, ossl_child_provider_init))
+        if (!ossl_provider_activate(cprov, 0, 1))
             goto err;
     } else {
         /*
@@ -148,7 +148,7 @@ static int provider_create_child_cb(const OSSL_CORE_HANDLE *prov, void *cbdata)
                                        1)) == NULL)
             goto err;
 
-        if (!ossl_provider_activate(cprov, 0))
+        if (!ossl_provider_activate(cprov, 0, 0))
             goto err;
 
         if (!ossl_provider_set_child(cprov, prov)

--- a/crypto/provider_child.c
+++ b/crypto/provider_child.c
@@ -133,13 +133,11 @@ static int provider_create_child_cb(const OSSL_CORE_HANDLE *prov, void *cbdata)
         ossl_provider_free(cprov);
 
         /*
-         * The provider already exists. It could be an unused built-in, or a
-         * previously created child, or it could have been explicitly loaded. If
-         * explicitly loaded it cannot be converted to a child and we ignore it
-         * - i.e. we don't start treating it like a child.
+         * The provider already exists. It could be a previously created child,
+         * or it could have been explicitly loaded. If explicitly loaded it we
+         * ignore it - i.e. we don't start treating it like a child.
          */
-        if (!ossl_provider_convert_to_child(cprov, prov,
-                                            ossl_child_provider_init))
+        if (!ossl_provider_activate_child(cprov, prov, ossl_child_provider_init))
             goto err;
     } else {
         /*

--- a/crypto/provider_child.c
+++ b/crypto/provider_child.c
@@ -127,9 +127,9 @@ static int provider_create_child_cb(const OSSL_CORE_HANDLE *prov, void *cbdata)
 
     if ((cprov = ossl_provider_find(ctx, provname, 1)) != NULL) {
         /*
-        * We free the newly created ref. We rely on the provider sticking around
-        * in the provider store.
-        */
+         * We free the newly created ref. We rely on the provider sticking around
+         * in the provider store.
+         */
         ossl_provider_free(cprov);
 
         /*
@@ -152,17 +152,11 @@ static int provider_create_child_cb(const OSSL_CORE_HANDLE *prov, void *cbdata)
             goto err;
 
         if (!ossl_provider_set_child(cprov, prov)
-            || !ossl_provider_add_to_store(cprov, 0)) {
+            || !ossl_provider_add_to_store(cprov, NULL, 0)) {
             ossl_provider_deactivate(cprov);
             ossl_provider_free(cprov);
             goto err;
         }
-
-        /*
-        * We free the newly created ref. We rely on the provider sticking around
-        * in the provider store.
-        */
-        ossl_provider_free(cprov);
     }
 
     ret = 1;

--- a/crypto/provider_child.c
+++ b/crypto/provider_child.c
@@ -148,11 +148,11 @@ static int provider_create_child_cb(const OSSL_CORE_HANDLE *prov, void *cbdata)
                                        1)) == NULL)
             goto err;
 
-        if (!ossl_provider_activate(cprov, 0, 0))
+        if (!ossl_provider_activate(cprov, 0))
             goto err;
 
         if (!ossl_provider_set_child(cprov, prov)
-            || !ossl_provider_add_to_store(cprov)) {
+            || !ossl_provider_add_to_store(cprov, 0)) {
             ossl_provider_deactivate(cprov);
             ossl_provider_free(cprov);
             goto err;

--- a/crypto/provider_conf.c
+++ b/crypto/provider_conf.c
@@ -171,7 +171,7 @@ static int provider_conf_load(OSSL_LIB_CTX *libctx, const char *name,
         ok = provider_conf_params(prov, NULL, NULL, value, cnf);
 
         if (ok) {
-            if (!ossl_provider_activate(prov, 1)) {
+            if (!ossl_provider_activate(prov, 1, 0)) {
                 ok = 0;
             } else if (!ossl_provider_add_to_store(prov, 0)) {
                 ossl_provider_deactivate(prov);

--- a/crypto/provider_conf.c
+++ b/crypto/provider_conf.c
@@ -14,6 +14,7 @@
 #include <openssl/safestack.h>
 #include "internal/provider.h"
 #include "internal/cryptlib.h"
+#include "provider_local.h"
 
 DEFINE_STACK_OF(OSSL_PROVIDER)
 
@@ -61,6 +62,7 @@ static const char *skip_dot(const char *name)
 }
 
 static int provider_conf_params(OSSL_PROVIDER *prov,
+                                struct provider_info_st *provinfo,
                                 const char *name, const char *value,
                                 const CONF *cnf)
 {
@@ -88,14 +90,18 @@ static int provider_conf_params(OSSL_PROVIDER *prov,
                 return 0;
             buffer[buffer_len] = '\0';
             OPENSSL_strlcat(buffer, sectconf->name, sizeof(buffer));
-            if (!provider_conf_params(prov, buffer, sectconf->value, cnf))
+            if (!provider_conf_params(prov, provinfo, buffer, sectconf->value,
+                                      cnf))
                 return 0;
         }
 
         OSSL_TRACE1(CONF, "Provider params: finish section %s\n", value);
     } else {
         OSSL_TRACE2(CONF, "Provider params: %s = %s\n", name, value);
-        ok = ossl_provider_add_parameter(prov, name, value);
+        if (prov != NULL)
+            ok = ossl_provider_add_parameter(prov, name, value);
+        else
+            ok = ossl_provider_info_add_parameter(provinfo, name, value);
     }
 
     return ok;
@@ -149,33 +155,62 @@ static int provider_conf_load(OSSL_LIB_CTX *libctx, const char *name,
             activate = 1;
     }
 
-    prov = ossl_provider_find(libctx, name, 1);
-    if (prov == NULL)
-        prov = ossl_provider_new(libctx, name, NULL, 1);
-    if (prov == NULL) {
-        if (soft)
-            ERR_clear_error();
-        return 0;
-    }
-
-    if (path != NULL)
-        ossl_provider_set_module_path(prov, path);
-
-    ok = provider_conf_params(prov, NULL, value, cnf);
-
-    if (ok && activate) {
-        if (!ossl_provider_activate(prov, 0, 1)) {
-            ok = 0;
-        } else {
-            if (pcgbl->activated_providers == NULL)
-                pcgbl->activated_providers = sk_OSSL_PROVIDER_new_null();
-            sk_OSSL_PROVIDER_push(pcgbl->activated_providers, prov);
-            ok = 1;
+    if (activate) {
+        prov = ossl_provider_find(libctx, name, 1);
+        if (prov == NULL)
+            prov = ossl_provider_new(libctx, name, NULL, 1);
+        if (prov == NULL) {
+            if (soft)
+                ERR_clear_error();
+            return 0;
         }
-    }
 
-    if (!(activate && ok))
-        ossl_provider_free(prov);
+        if (path != NULL)
+            ossl_provider_set_module_path(prov, path);
+
+        ok = provider_conf_params(prov, NULL, NULL, value, cnf);
+
+        if (ok) {
+            if (!ossl_provider_activate(prov, 0, 1)) {
+                ok = 0;
+            } else {
+                if (pcgbl->activated_providers == NULL)
+                    pcgbl->activated_providers = sk_OSSL_PROVIDER_new_null();
+                sk_OSSL_PROVIDER_push(pcgbl->activated_providers, prov);
+                ok = 1;
+            }
+        }
+
+        if (!(activate && ok))
+            ossl_provider_free(prov);
+    } else {
+        struct provider_info_st entry;
+
+        memset(&entry, 0, sizeof(entry));
+        ok = 1;
+        if (name != NULL) {
+            entry.name = OPENSSL_strdup(name);
+            if (entry.name == NULL) {
+                ERR_raise(ERR_LIB_CRYPTO, ERR_R_MALLOC_FAILURE);
+                ok = 0;
+            }
+        }
+        if (ok && path != NULL) {
+            entry.path = OPENSSL_strdup(path);
+            if (entry.path == NULL) {
+                ERR_raise(ERR_LIB_CRYPTO, ERR_R_MALLOC_FAILURE);
+                ok = 0;
+            }
+        }
+        if (ok)
+            ok = provider_conf_params(NULL, &entry, NULL, value, cnf);
+        if (ok && (entry.path != NULL || entry.parameters != NULL))
+            ok = ossl_provider_info_add_to_store(libctx, &entry);
+        if (!ok || (entry.path == NULL || entry.parameters == NULL)) {
+            ossl_provider_info_clear(&entry);
+        }
+
+    }
 
     return ok;
 }

--- a/crypto/provider_conf.c
+++ b/crypto/provider_conf.c
@@ -62,7 +62,7 @@ static const char *skip_dot(const char *name)
 }
 
 static int provider_conf_params(OSSL_PROVIDER *prov,
-                                struct provider_info_st *provinfo,
+                                OSSL_PROVIDER_INFO *provinfo,
                                 const char *name, const char *value,
                                 const CONF *cnf)
 {
@@ -187,7 +187,7 @@ static int provider_conf_load(OSSL_LIB_CTX *libctx, const char *name,
         if (!ok)
             ossl_provider_free(prov);
     } else {
-        struct provider_info_st entry;
+        OSSL_PROVIDER_INFO entry;
 
         memset(&entry, 0, sizeof(entry));
         ok = 1;

--- a/crypto/provider_conf.c
+++ b/crypto/provider_conf.c
@@ -173,6 +173,9 @@ static int provider_conf_load(OSSL_LIB_CTX *libctx, const char *name,
         if (ok) {
             if (!ossl_provider_activate(prov, 0, 1)) {
                 ok = 0;
+            } else if (!ossl_provider_add_to_store(prov)) {
+                ossl_provider_deactivate(prov);
+                ok = 0;
             } else {
                 if (pcgbl->activated_providers == NULL)
                     pcgbl->activated_providers = sk_OSSL_PROVIDER_new_null();
@@ -181,7 +184,7 @@ static int provider_conf_load(OSSL_LIB_CTX *libctx, const char *name,
             }
         }
 
-        if (!(activate && ok))
+        if (!ok)
             ossl_provider_free(prov);
     } else {
         struct provider_info_st entry;

--- a/crypto/provider_conf.c
+++ b/crypto/provider_conf.c
@@ -209,7 +209,7 @@ static int provider_conf_load(OSSL_LIB_CTX *libctx, const char *name,
             ok = provider_conf_params(NULL, &entry, NULL, value, cnf);
         if (ok && (entry.path != NULL || entry.parameters != NULL))
             ok = ossl_provider_info_add_to_store(libctx, &entry);
-        if (!ok || (entry.path == NULL || entry.parameters == NULL)) {
+        if (!ok || (entry.path == NULL && entry.parameters == NULL)) {
             ossl_provider_info_clear(&entry);
         }
 

--- a/crypto/provider_conf.c
+++ b/crypto/provider_conf.c
@@ -171,9 +171,9 @@ static int provider_conf_load(OSSL_LIB_CTX *libctx, const char *name,
         ok = provider_conf_params(prov, NULL, NULL, value, cnf);
 
         if (ok) {
-            if (!ossl_provider_activate(prov, 0, 1)) {
+            if (!ossl_provider_activate(prov, 1)) {
                 ok = 0;
-            } else if (!ossl_provider_add_to_store(prov)) {
+            } else if (!ossl_provider_add_to_store(prov, 0)) {
                 ossl_provider_deactivate(prov);
                 ok = 0;
             } else {

--- a/crypto/provider_conf.c
+++ b/crypto/provider_conf.c
@@ -113,7 +113,7 @@ static int provider_conf_load(OSSL_LIB_CTX *libctx, const char *name,
     int i;
     STACK_OF(CONF_VALUE) *ecmds;
     int soft = 0;
-    OSSL_PROVIDER *prov = NULL;
+    OSSL_PROVIDER *prov = NULL, *actual = NULL;
     const char *path = NULL;
     long activate = 0;
     int ok = 0;
@@ -173,13 +173,13 @@ static int provider_conf_load(OSSL_LIB_CTX *libctx, const char *name,
         if (ok) {
             if (!ossl_provider_activate(prov, 1, 0)) {
                 ok = 0;
-            } else if (!ossl_provider_add_to_store(prov, 0)) {
+            } else if (!ossl_provider_add_to_store(prov, &actual, 0)) {
                 ossl_provider_deactivate(prov);
                 ok = 0;
             } else {
                 if (pcgbl->activated_providers == NULL)
                     pcgbl->activated_providers = sk_OSSL_PROVIDER_new_null();
-                sk_OSSL_PROVIDER_push(pcgbl->activated_providers, prov);
+                sk_OSSL_PROVIDER_push(pcgbl->activated_providers, actual);
                 ok = 1;
             }
         }

--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -500,13 +500,11 @@ static int create_provider_children(OSSL_PROVIDER *prov)
     max = sk_OSSL_PROVIDER_CHILD_CB_num(store->child_cbs);
     for (i = 0; i < max; i++) {
         /*
-            * This is newly activated (activatecnt == 1), so we need to
-            * create child providers as necessary.
-            */
-        child_cb = sk_OSSL_PROVIDER_CHILD_CB_value(store->child_cbs,
-                                                    i);
-        ret &= child_cb->create_cb((OSSL_CORE_HANDLE *)prov,
-                                    child_cb->cbdata);
+         * This is newly activated (activatecnt == 1), so we need to
+         * create child providers as necessary.
+         */
+        child_cb = sk_OSSL_PROVIDER_CHILD_CB_value(store->child_cbs, i);
+        ret &= child_cb->create_cb((OSSL_CORE_HANDLE *)prov, child_cb->cbdata);
     }
 #endif
 
@@ -978,12 +976,12 @@ static int provider_activate(OSSL_PROVIDER *prov, int lock, int upcalls)
 {
     int count = -1;
     struct provider_store_st *store;
-        int ret = 1;
+    int ret = 1;
 
     store = prov->store;
     /*
     * If the provider hasn't been added to the store, then we don't need
-    * any locks because we've not shared it without other threads.
+    * any locks because we've not shared it with other threads.
     */
     if (store == NULL) {
         lock = 0;

--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -131,7 +131,7 @@ struct provider_store_st {
     CRYPTO_RWLOCK *default_path_lock;
     CRYPTO_RWLOCK *lock;
     char *default_path;
-    struct provider_info_st *provinfo;
+    OSSL_PROVIDER_INFO *provinfo;
     size_t numprovinfo;
     size_t provinfosz;
     unsigned int use_fallbacks:1;
@@ -188,7 +188,7 @@ static INFOPAIR *infopair_copy(const INFOPAIR *src)
     return NULL;
 }
 
-void ossl_provider_info_clear(struct provider_info_st *info)
+void ossl_provider_info_clear(OSSL_PROVIDER_INFO *info)
 {
     OPENSSL_free(info->name);
     OPENSSL_free(info->path);
@@ -272,7 +272,7 @@ int ossl_provider_disable_fallback_loading(OSSL_LIB_CTX *libctx)
 #define BUILTINS_BLOCK_SIZE     10
 
 int ossl_provider_info_add_to_store(OSSL_LIB_CTX *libctx,
-                                    const struct provider_info_st *entry)
+                                    OSSL_PROVIDER_INFO *entry)
 {
     struct provider_store_st *store = get_provider_store(libctx);
     int ret = 0;
@@ -298,7 +298,7 @@ int ossl_provider_info_add_to_store(OSSL_LIB_CTX *libctx,
         }
         store->provinfosz = BUILTINS_BLOCK_SIZE;
     } else if (store->numprovinfo == store->provinfosz) {
-        struct provider_info_st *tmpbuiltins;
+        OSSL_PROVIDER_INFO *tmpbuiltins;
         size_t newsz = store->provinfosz + BUILTINS_BLOCK_SIZE;
 
         tmpbuiltins = OPENSSL_realloc(store->provinfo,
@@ -322,7 +322,7 @@ int ossl_provider_info_add_to_store(OSSL_LIB_CTX *libctx,
 int OSSL_PROVIDER_add_builtin(OSSL_LIB_CTX *libctx, const char *name,
                               OSSL_provider_init_fn *init_fn)
 {
-    struct provider_info_st entry;
+    OSSL_PROVIDER_INFO entry;
 
     if (name == NULL || init_fn == NULL) {
         ERR_raise(ERR_LIB_CRYPTO, ERR_R_PASSED_NULL_PARAMETER);
@@ -451,7 +451,7 @@ OSSL_PROVIDER *ossl_provider_new(OSSL_LIB_CTX *libctx, const char *name,
                                  int noconfig)
 {
     struct provider_store_st *store = NULL;
-    struct provider_info_st template;
+    OSSL_PROVIDER_INFO template;
     OSSL_PROVIDER *prov = NULL;
 
     if ((store = get_provider_store(libctx)) == NULL)
@@ -467,7 +467,7 @@ OSSL_PROVIDER *ossl_provider_new(OSSL_LIB_CTX *libctx, const char *name,
 
     memset(&template, 0, sizeof(template));
     if (init_function == NULL) {
-        const struct provider_info_st *p;
+        const OSSL_PROVIDER_INFO *p;
         size_t i;
 
         /* Check if this is a predefined builtin provider */
@@ -666,7 +666,7 @@ int ossl_provider_add_parameter(OSSL_PROVIDER *prov,
     return infopair_add(&prov->parameters, name, value);
 }
 
-int ossl_provider_info_add_parameter(struct provider_info_st *provinfo,
+int ossl_provider_info_add_parameter(OSSL_PROVIDER_INFO *provinfo,
                                      const char *name,
                                      const char *value)
 {
@@ -1075,7 +1075,7 @@ static int provider_activate_fallbacks(struct provider_store_st *store)
     int use_fallbacks;
     int activated_fallback_count = 0;
     int ret = 0;
-    const struct provider_info_st *p;
+    const OSSL_PROVIDER_INFO *p;
 
     if (!CRYPTO_THREAD_read_lock(store->lock))
         return 0;

--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -515,8 +515,8 @@ OSSL_PROVIDER *ossl_provider_new(OSSL_LIB_CTX *libctx, const char *name,
 static int create_provider_children(OSSL_PROVIDER *prov)
 {
     int ret = 1;
-    struct provider_store_st *store = prov->store;
 #ifndef FIPS_MODULE
+    struct provider_store_st *store = prov->store;
     OSSL_PROVIDER_CHILD_CB *child_cb;
     int i, max;
 

--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -1039,12 +1039,14 @@ int ossl_provider_activate(OSSL_PROVIDER *prov, int upcalls, int aschild)
 
     if (prov == NULL)
         return 0;
+#ifndef FIPS_MODULE
     /*
      * If aschild is true, then we only actually do the activation if the
      * provider is a child. If its not, this is still success.
      */
     if (aschild && !prov->ischild)
         return 1;
+#endif
     if ((count = provider_activate(prov, 1, upcalls)) > 0)
         return count == 1 ? provider_flush_store_cache(prov) : 1;
 

--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -1550,13 +1550,7 @@ static int ossl_provider_register_child_cb(const OSSL_CORE_HANDLE *handle,
     max = sk_OSSL_PROVIDER_num(store->providers);
     for (i = 0; i < max; i++) {
         prov = sk_OSSL_PROVIDER_value(store->providers, i);
-        /*
-         * We require register_child_cb to be called during a provider init
-         * function. The currently initing provider will never be activated yet
-         * and we we should not attempt to aquire the flag_lock for it.
-         */
-        if (prov == thisprov)
-            continue;
+
         if (!CRYPTO_THREAD_read_lock(prov->flag_lock))
             break;
         /*

--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -513,33 +513,63 @@ static int create_provider_children(OSSL_PROVIDER *prov)
     return ret;
 }
 
-int ossl_provider_add_to_store(OSSL_PROVIDER *prov, int retain_fallbacks)
+int ossl_provider_add_to_store(OSSL_PROVIDER *prov, OSSL_PROVIDER **actualprov,
+                               int retain_fallbacks)
 {
-    struct provider_store_st *store = NULL;
-    int ret = 1;
+    struct provider_store_st *store;
+    int idx;
+    OSSL_PROVIDER tmpl = { 0, };
+    OSSL_PROVIDER *actualtmp = NULL;
 
     if ((store = get_provider_store(prov->libctx)) == NULL)
         return 0;
 
-
-    if (!ossl_provider_up_ref(prov)) {
-        ERR_raise(ERR_LIB_CRYPTO, ERR_R_MALLOC_FAILURE);
+    if (!CRYPTO_THREAD_write_lock(store->lock))
         return 0;
+
+    tmpl.name = (char *)prov->name;
+    idx = sk_OSSL_PROVIDER_find(store->providers, &tmpl);
+    if (idx == -1) {
+        if (sk_OSSL_PROVIDER_push(store->providers, prov) == 0)
+            goto err;
+        prov->store = store;
+        if (!create_provider_children(prov)) {
+            sk_OSSL_PROVIDER_delete_ptr(store->providers, prov);
+            goto err;
+        }
+        actualtmp = prov;
+        if (!retain_fallbacks)
+            store->use_fallbacks = 0;
+    } else {
+        actualtmp = sk_OSSL_PROVIDER_value(store->providers, idx);
     }
-    if (!CRYPTO_THREAD_write_lock(store->lock)
-            || sk_OSSL_PROVIDER_push(store->providers, prov) == 0) {
-        ossl_provider_free(prov);
-        ret = 0;
-    }
-    prov->store = store;
-    if (!retain_fallbacks)
-        store->use_fallbacks = 0;
-    if (!create_provider_children(prov)) {
-        ret = 0;
-    }
+
     CRYPTO_THREAD_unlock(store->lock);
 
-    return ret;
+    if (actualtmp != prov) {
+        /*
+         * The provider is already in the store. Probably two threads
+         * independently initialised their own provider objects with the same
+         * name and raced to put them in the store. This thread lost. We
+         * deactivate the one we just created and use the one that already
+         * exists instead.
+         */
+        ossl_provider_deactivate(prov);
+        ossl_provider_free(prov);
+    }
+
+    if (actualprov != NULL) {
+        if (!ossl_provider_up_ref(actualtmp)) {
+            ERR_raise(ERR_LIB_CRYPTO, ERR_R_MALLOC_FAILURE);
+            return 0;
+        }
+        *actualprov = actualtmp;
+    }
+    return 1;
+
+ err:
+    CRYPTO_THREAD_unlock(store->lock);
+    return 0;
 }
 
 void ossl_provider_free(OSSL_PROVIDER *prov)

--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -319,29 +319,6 @@ int ossl_provider_info_add_to_store(OSSL_LIB_CTX *libctx,
     return ret;
 }
 
-int OSSL_PROVIDER_add_builtin(OSSL_LIB_CTX *libctx, const char *name,
-                              OSSL_provider_init_fn *init_fn)
-{
-    OSSL_PROVIDER_INFO entry;
-
-    if (name == NULL || init_fn == NULL) {
-        ERR_raise(ERR_LIB_CRYPTO, ERR_R_PASSED_NULL_PARAMETER);
-        return 0;
-    }
-    memset(&entry, 0, sizeof(entry));
-    entry.name = OPENSSL_strdup(name);
-    if (entry.name == NULL) {
-        ERR_raise(ERR_LIB_CRYPTO, ERR_R_MALLOC_FAILURE);
-        return 0;
-    }
-    entry.init = init_fn;
-    if (!ossl_provider_info_add_to_store(libctx, &entry)) {
-        ossl_provider_info_clear(&entry);
-        return 0;
-    }
-    return 1;
-}
-
 OSSL_PROVIDER *ossl_provider_find(OSSL_LIB_CTX *libctx, const char *name,
                                   int noconfig)
 {

--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -431,7 +431,7 @@ int ossl_provider_up_ref(OSSL_PROVIDER *prov)
 static int provider_up_ref_intern(OSSL_PROVIDER *prov, int activate)
 {
     if (activate)
-        return ossl_provider_activate(prov, 1);
+        return ossl_provider_activate(prov, 1, 0);
 
     return ossl_provider_up_ref(prov);
 }
@@ -1027,12 +1027,18 @@ static int provider_flush_store_cache(const OSSL_PROVIDER *prov)
     return 1;
 }
 
-int ossl_provider_activate(OSSL_PROVIDER *prov, int upcalls)
+int ossl_provider_activate(OSSL_PROVIDER *prov, int upcalls, int aschild)
 {
     int count;
 
     if (prov == NULL)
         return 0;
+    /*
+     * If aschild is true, then we only actually do the activation if the
+     * provider is a child. If its not, this is still success.
+     */
+    if (aschild && !prov->ischild)
+        return 1;
     if ((count = provider_activate(prov, 1, upcalls)) > 0)
         return count == 1 ? provider_flush_store_cache(prov) : 1;
 
@@ -1459,39 +1465,6 @@ int ossl_provider_set_child(OSSL_PROVIDER *prov, const OSSL_CORE_HANDLE *handle)
     prov->handle = handle;
     prov->ischild = 1;
 
-    return 1;
-}
-
-int ossl_provider_activate_child(OSSL_PROVIDER *prov,
-                                 const OSSL_CORE_HANDLE *handle,
-                                 OSSL_provider_init_fn *init_function)
-{
-    int flush = 0;
-
-    if (!CRYPTO_THREAD_write_lock(prov->store->lock))
-        return 0;
-    if (!CRYPTO_THREAD_write_lock(prov->flag_lock)) {
-        CRYPTO_THREAD_unlock(prov->store->lock);
-        return 0;
-    }
-    /*
-     * The provider could be in one of two states: (1) Already a child,
-     * (2) Not a child (not eligible to be one).
-     */
-    if (prov->ischild && provider_activate(prov, 0, 0))
-        flush = 1;
-
-    CRYPTO_THREAD_unlock(prov->flag_lock);
-    CRYPTO_THREAD_unlock(prov->store->lock);
-
-    if (flush)
-        provider_flush_store_cache(prov);
-
-    /*
-     * We report success whether or not the provider was a child. If its not
-     * a child then it has been explicitly loaded as a non child provider and
-     * we should keep it like that.
-     */
     return 1;
 }
 

--- a/crypto/provider_local.h
+++ b/crypto/provider_local.h
@@ -9,10 +9,10 @@
 
 #include <openssl/core.h>
 
-struct predefined_providers_st {
-    const char *name;
+struct provider_info_st {
+    char *name;
     OSSL_provider_init_fn *init;
     unsigned int is_fallback:1;
 };
 
-extern const struct predefined_providers_st ossl_predefined_providers[];
+extern const struct provider_info_st ossl_predefined_providers[];

--- a/crypto/provider_local.h
+++ b/crypto/provider_local.h
@@ -15,19 +15,19 @@ typedef struct {
 } INFOPAIR;
 DEFINE_STACK_OF(INFOPAIR)
 
-struct provider_info_st {
+typedef struct {
     char *name;
     char *path;
     OSSL_provider_init_fn *init;
     STACK_OF(INFOPAIR) *parameters;
     unsigned int is_fallback:1;
-};
+} OSSL_PROVIDER_INFO;
 
-extern const struct provider_info_st ossl_predefined_providers[];
+extern const OSSL_PROVIDER_INFO ossl_predefined_providers[];
 
-void ossl_provider_info_clear(struct provider_info_st *info);
+void ossl_provider_info_clear(OSSL_PROVIDER_INFO *info);
 int ossl_provider_info_add_to_store(OSSL_LIB_CTX *libctx,
-                                    const struct provider_info_st *entry);
-int ossl_provider_info_add_parameter(struct provider_info_st *provinfo,
+                                    OSSL_PROVIDER_INFO *entry);
+int ossl_provider_info_add_parameter(OSSL_PROVIDER_INFO *provinfo,
                                      const char *name,
                                      const char *value);

--- a/crypto/provider_local.h
+++ b/crypto/provider_local.h
@@ -9,10 +9,25 @@
 
 #include <openssl/core.h>
 
+typedef struct {
+    char *name;
+    char *value;
+} INFOPAIR;
+DEFINE_STACK_OF(INFOPAIR)
+
 struct provider_info_st {
     char *name;
+    char *path;
     OSSL_provider_init_fn *init;
+    STACK_OF(INFOPAIR) *parameters;
     unsigned int is_fallback:1;
 };
 
 extern const struct provider_info_st ossl_predefined_providers[];
+
+void ossl_provider_info_clear(struct provider_info_st *info);
+int ossl_provider_info_add_to_store(OSSL_LIB_CTX *libctx,
+                                    const struct provider_info_st *entry);
+int ossl_provider_info_add_parameter(struct provider_info_st *provinfo,
+                                     const char *name,
+                                     const char *value);

--- a/crypto/provider_predefined.c
+++ b/crypto/provider_predefined.c
@@ -17,7 +17,7 @@ OSSL_provider_init_fn ossl_fips_intern_provider_init;
 #ifdef STATIC_LEGACY
 OSSL_provider_init_fn ossl_legacy_provider_init;
 #endif
-const struct predefined_providers_st ossl_predefined_providers[] = {
+const struct provider_info_st ossl_predefined_providers[] = {
 #ifdef FIPS_MODULE
     { "fips", ossl_fips_intern_provider_init, 1 },
 #else

--- a/crypto/provider_predefined.c
+++ b/crypto/provider_predefined.c
@@ -17,7 +17,7 @@ OSSL_provider_init_fn ossl_fips_intern_provider_init;
 #ifdef STATIC_LEGACY
 OSSL_provider_init_fn ossl_legacy_provider_init;
 #endif
-const struct provider_info_st ossl_predefined_providers[] = {
+const OSSL_PROVIDER_INFO ossl_predefined_providers[] = {
 #ifdef FIPS_MODULE
     { "fips", NULL, ossl_fips_intern_provider_init, NULL, 1 },
 #else

--- a/crypto/provider_predefined.c
+++ b/crypto/provider_predefined.c
@@ -19,14 +19,14 @@ OSSL_provider_init_fn ossl_legacy_provider_init;
 #endif
 const struct provider_info_st ossl_predefined_providers[] = {
 #ifdef FIPS_MODULE
-    { "fips", ossl_fips_intern_provider_init, 1 },
+    { "fips", NULL, ossl_fips_intern_provider_init, NULL, 1 },
 #else
-    { "default", ossl_default_provider_init, 1 },
+    { "default", NULL, ossl_default_provider_init, NULL, 1 },
 # ifdef STATIC_LEGACY
-    { "legacy", ossl_legacy_provider_init, 0 },
+    { "legacy", NULL, ossl_legacy_provider_init, NULL, 0 },
 # endif
-    { "base", ossl_base_provider_init, 0 },
-    { "null", ossl_null_provider_init, 0 },
+    { "base", NULL, ossl_base_provider_init, NULL, 0 },
+    { "null", NULL, ossl_null_provider_init, NULL, 0 },
 #endif
-    { NULL, NULL, 0 }
+    { NULL, NULL, NULL, NULL, 0 }
 };

--- a/doc/internal/man3/ossl_provider_new.pod
+++ b/doc/internal/man3/ossl_provider_new.pod
@@ -9,7 +9,7 @@ ossl_provider_add_parameter, ossl_provider_set_child, ossl_provider_get_parent,
 ossl_provider_up_ref_parent, ossl_provider_free_parent,
 ossl_provider_default_props_update, ossl_provider_get0_dispatch,
 ossl_provider_init_as_child,
-ossl_provider_activate, ossl_provider_deactivate,
+ossl_provider_activate, ossl_provider_deactivate, ossl_provider_add_to_store,
 ossl_provider_ctx,
 ossl_provider_doall_activated,
 ossl_provider_name, ossl_provider_dso,
@@ -53,8 +53,9 @@ ossl_provider_get_capabilities
   * Activate the Provider
   * If the Provider is a module, the module will be loaded
   */
- int ossl_provider_activate(OSSL_PROVIDER *prov, int upcalls);
+ int ossl_provider_activate(OSSL_PROVIDER *prov, int upcalls, int aschild);
  int ossl_provider_deactivate(OSSL_PROVIDER *prov);
+ int ossl_provider_add_to_store(OSSL_PROVIDER *prov, int retain_fallbacks);
 
  /* Return pointer to the provider's context */
  void *ossl_provider_ctx(const OSSL_PROVIDER *prov);
@@ -218,11 +219,17 @@ be located in that module, and called.
 =back
 
 If I<upcalls> is nonzero then, if this is a child provider, upcalls to the
-parent libctx will be made to inform it of an up-ref.
+parent libctx will be made to inform it of an up-ref. If I<aschild> is nonzero
+then the provider will only be activated if it is a child provider. Otherwise
+no action is take and ossl_provider_activate() returns success.
 
 ossl_provider_deactivate() "deactivates" the provider for the given
 provider object I<prov> by decrementing its activation count.  When
 that count reaches zero, the activation flag is cleared.
+
+ossl_provider_add_to_store() adds the provider I<prov> to the provider store and
+makes it available to other threads. This will prevent future automatic loading
+of fallback providers, unless I<retain_fallbacks> is true.
 
 ossl_provider_ctx() returns a context created by the provider.
 Outside of the provider, it's completely opaque, but it needs to be
@@ -336,8 +343,8 @@ called for any activated providers.
 
 ossl_provider_set_module_path(), ossl_provider_set_fallback(),
 ossl_provider_activate(), ossl_provider_activate_leave_fallbacks() and
-ossl_provider_deactivate(), ossl_provider_default_props_update() return 1 on
-success, or 0 on error.
+ossl_provider_deactivate(), ossl_provider_add_to_store(),
+ossl_provider_default_props_update() return 1 on success, or 0 on error.
 
 ossl_provider_name(), ossl_provider_dso(),
 ossl_provider_module_name(), and ossl_provider_module_path() return a

--- a/doc/internal/man3/ossl_provider_new.pod
+++ b/doc/internal/man3/ossl_provider_new.pod
@@ -221,7 +221,7 @@ be located in that module, and called.
 If I<upcalls> is nonzero then, if this is a child provider, upcalls to the
 parent libctx will be made to inform it of an up-ref. If I<aschild> is nonzero
 then the provider will only be activated if it is a child provider. Otherwise
-no action is take and ossl_provider_activate() returns success.
+no action is taken and ossl_provider_activate() returns success.
 
 ossl_provider_deactivate() "deactivates" the provider for the given
 provider object I<prov> by decrementing its activation count.  When

--- a/doc/internal/man3/ossl_provider_new.pod
+++ b/doc/internal/man3/ossl_provider_new.pod
@@ -9,7 +9,7 @@ ossl_provider_add_parameter, ossl_provider_set_child, ossl_provider_get_parent,
 ossl_provider_up_ref_parent, ossl_provider_free_parent,
 ossl_provider_default_props_update, ossl_provider_get0_dispatch,
 ossl_provider_init_as_child,
-ossl_provider_activate, ossl_provider_deactivate, ossl_provider_available,
+ossl_provider_activate, ossl_provider_deactivate,
 ossl_provider_ctx,
 ossl_provider_doall_activated,
 ossl_provider_name, ossl_provider_dso,
@@ -56,8 +56,6 @@ ossl_provider_get_capabilities
  int ossl_provider_activate(OSSL_PROVIDER *prov, int retain_fallbacks,
                             int upcalls);
  int ossl_provider_deactivate(OSSL_PROVIDER *prov);
- /* Check if provider is available (activated) */
- int ossl_provider_available(OSSL_PROVIDER *prov);
 
  /* Return pointer to the provider's context */
  void *ossl_provider_ctx(const OSSL_PROVIDER *prov);
@@ -229,10 +227,6 @@ ossl_provider_deactivate() "deactivates" the provider for the given
 provider object I<prov> by decrementing its activation count.  When
 that count reaches zero, the activation flag is cleared.
 
-ossl_provider_available() activates all fallbacks if no provider is
-activated yet, then checks if given provider object I<prov> is
-activated.
-
 ossl_provider_ctx() returns a context created by the provider.
 Outside of the provider, it's completely opaque, but it needs to be
 passed back to some of the provider functions.
@@ -347,9 +341,6 @@ ossl_provider_set_module_path(), ossl_provider_set_fallback(),
 ossl_provider_activate(), ossl_provider_activate_leave_fallbacks() and
 ossl_provider_deactivate(), ossl_provider_default_props_update() return 1 on
 success, or 0 on error.
-
-ossl_provider_available() return 1 if the provider is available,
-otherwise 0.
 
 ossl_provider_name(), ossl_provider_dso(),
 ossl_provider_module_name(), and ossl_provider_module_path() return a

--- a/doc/internal/man3/ossl_provider_new.pod
+++ b/doc/internal/man3/ossl_provider_new.pod
@@ -53,8 +53,7 @@ ossl_provider_get_capabilities
   * Activate the Provider
   * If the Provider is a module, the module will be loaded
   */
- int ossl_provider_activate(OSSL_PROVIDER *prov, int retain_fallbacks,
-                            int upcalls);
+ int ossl_provider_activate(OSSL_PROVIDER *prov, int upcalls);
  int ossl_provider_deactivate(OSSL_PROVIDER *prov);
 
  /* Return pointer to the provider's context */
@@ -218,10 +217,8 @@ be located in that module, and called.
 
 =back
 
-If I<retain_fallbacks> is zero, fallbacks are disabled.  If it is nonzero,
-fallbacks are left unchanged. If I<upcalls> is nonzero then, if this is a child
-provider, upcalls to the parent libctx will be made to inform it of an
-up-ref.
+If I<upcalls> is nonzero then, if this is a child provider, upcalls to the
+parent libctx will be made to inform it of an up-ref.
 
 ossl_provider_deactivate() "deactivates" the provider for the given
 provider object I<prov> by decrementing its activation count.  When

--- a/doc/internal/man3/ossl_provider_new.pod
+++ b/doc/internal/man3/ossl_provider_new.pod
@@ -55,7 +55,8 @@ ossl_provider_get_capabilities
   */
  int ossl_provider_activate(OSSL_PROVIDER *prov, int upcalls, int aschild);
  int ossl_provider_deactivate(OSSL_PROVIDER *prov);
- int ossl_provider_add_to_store(OSSL_PROVIDER *prov, int retain_fallbacks);
+ int ossl_provider_add_to_store(OSSL_PROVIDER *prov, OSSL_PROVIDER **actualprov,
+                                int retain_fallbacks)
 
  /* Return pointer to the provider's context */
  void *ossl_provider_ctx(const OSSL_PROVIDER *prov);
@@ -229,7 +230,10 @@ that count reaches zero, the activation flag is cleared.
 
 ossl_provider_add_to_store() adds the provider I<prov> to the provider store and
 makes it available to other threads. This will prevent future automatic loading
-of fallback providers, unless I<retain_fallbacks> is true.
+of fallback providers, unless I<retain_fallbacks> is true. If a provider of the
+same name already exists in the store then it is not added but this function
+still returns success. On success the I<actualprov> value is populated with a
+pointer to the provider of the given name that is now in the store.
 
 ossl_provider_ctx() returns a context created by the provider.
 Outside of the provider, it's completely opaque, but it needs to be

--- a/doc/internal/man3/ossl_provider_new.pod
+++ b/doc/internal/man3/ossl_provider_new.pod
@@ -56,7 +56,7 @@ ossl_provider_get_capabilities
  int ossl_provider_activate(OSSL_PROVIDER *prov, int upcalls, int aschild);
  int ossl_provider_deactivate(OSSL_PROVIDER *prov);
  int ossl_provider_add_to_store(OSSL_PROVIDER *prov, OSSL_PROVIDER **actualprov,
-                                int retain_fallbacks)
+                                int retain_fallbacks);
 
  /* Return pointer to the provider's context */
  void *ossl_provider_ctx(const OSSL_PROVIDER *prov);

--- a/doc/internal/man3/ossl_provider_new.pod
+++ b/doc/internal/man3/ossl_provider_new.pod
@@ -233,7 +233,10 @@ makes it available to other threads. This will prevent future automatic loading
 of fallback providers, unless I<retain_fallbacks> is true. If a provider of the
 same name already exists in the store then it is not added but this function
 still returns success. On success the I<actualprov> value is populated with a
-pointer to the provider of the given name that is now in the store.
+pointer to the provider of the given name that is now in the store. The
+reference passed in the I<prov> argument is consumed by this function. A
+reference to the provider that should be used is passed back in the
+I<actualprov> argument.
 
 ossl_provider_ctx() returns a context created by the provider.
 Outside of the provider, it's completely opaque, but it needs to be

--- a/doc/man3/OSSL_LIB_CTX.pod
+++ b/doc/man3/OSSL_LIB_CTX.pod
@@ -75,19 +75,13 @@ context. If L<EVP_set_default_properties(3)> is called directly on a child
 library context then the new properties will override anything from the parent
 library context and mirroring of the properties will stop.
 
-OSSL_LIB_CTX_new_child() must only be called from within the scope of a
-provider's B<OSSL_provider_init> function (see L<provider-base(7)>). Calling it
-outside of that function may succeed but may not correctly mirror all providers
-and is considered undefined behaviour. When called from within the scope of a
-provider's B<OSSL_provider_init> function the currently initialising provider is
-not yet available in the application's library context and therefore will
-similarly not yet be available in the newly constructed child library context.
-As soon as the B<OSSL_provider_init> function returns then the new provider is
-available in the application's library context and will be similarly mirrored in
-the child library context. Since the current provider is still initialising
-the provider should not attempt to perform fetches, or call any function that
-performs a fetch using the child library context until after the initialisation
-function has completed.
+When OSSL_LIB_CTX_new_child() is called from within the scope of a provider's
+B<OSSL_provider_init> function the currently initialising provider is not yet
+available in the application's library context and therefore will similarly not
+yet be available in the newly constructed child library context. As soon as the
+B<OSSL_provider_init> function returns then the new provider is available in the
+application's library context and will be similarly mirrored in the child
+library context.
 
 OSSL_LIB_CTX_load_config() loads a configuration file using the given C<ctx>.
 This can be used to associate a library context with providers that are loaded

--- a/doc/man7/provider.pod
+++ b/doc/man7/provider.pod
@@ -69,6 +69,9 @@ the provider multiple simultaneous uses.
 This pointer will be passed to various operation functions offered by
 the provider.
 
+Note that the provider will not be made available for applications to use until
+the initialization function has completed and returned successfully.
+
 One of the functions the provider offers to the OpenSSL libraries is
 the central mechanism for the OpenSSL libraries to get access to
 operation implementations for diverse algorithms.

--- a/include/internal/provider.h
+++ b/include/internal/provider.h
@@ -62,6 +62,7 @@ int ossl_provider_disable_fallback_loading(OSSL_LIB_CTX *libctx);
 int ossl_provider_activate(OSSL_PROVIDER *prov, int retain_fallbacks,
                            int upcalls);
 int ossl_provider_deactivate(OSSL_PROVIDER *prov);
+int ossl_provider_add_to_store(OSSL_PROVIDER *prov);
 
 /* Return pointer to the provider's context */
 void *ossl_provider_ctx(const OSSL_PROVIDER *prov);

--- a/include/internal/provider.h
+++ b/include/internal/provider.h
@@ -59,10 +59,9 @@ int ossl_provider_disable_fallback_loading(OSSL_LIB_CTX *libctx);
  * Activate the Provider
  * If the Provider is a module, the module will be loaded
  */
-int ossl_provider_activate(OSSL_PROVIDER *prov, int retain_fallbacks,
-                           int upcalls);
+int ossl_provider_activate(OSSL_PROVIDER *prov, int upcalls);
 int ossl_provider_deactivate(OSSL_PROVIDER *prov);
-int ossl_provider_add_to_store(OSSL_PROVIDER *prov);
+int ossl_provider_add_to_store(OSSL_PROVIDER *prov, int retain_fallbacks);
 
 /* Return pointer to the provider's context */
 void *ossl_provider_ctx(const OSSL_PROVIDER *prov);

--- a/include/internal/provider.h
+++ b/include/internal/provider.h
@@ -62,8 +62,6 @@ int ossl_provider_disable_fallback_loading(OSSL_LIB_CTX *libctx);
 int ossl_provider_activate(OSSL_PROVIDER *prov, int retain_fallbacks,
                            int upcalls);
 int ossl_provider_deactivate(OSSL_PROVIDER *prov);
-/* Check if the provider is available (activated) */
-int ossl_provider_available(OSSL_PROVIDER *prov);
 
 /* Return pointer to the provider's context */
 void *ossl_provider_ctx(const OSSL_PROVIDER *prov);

--- a/include/internal/provider.h
+++ b/include/internal/provider.h
@@ -58,7 +58,8 @@ int ossl_provider_disable_fallback_loading(OSSL_LIB_CTX *libctx);
  */
 int ossl_provider_activate(OSSL_PROVIDER *prov, int upcalls, int aschild);
 int ossl_provider_deactivate(OSSL_PROVIDER *prov);
-int ossl_provider_add_to_store(OSSL_PROVIDER *prov, int retain_fallbacks);
+int ossl_provider_add_to_store(OSSL_PROVIDER *prov, OSSL_PROVIDER **actualprov,
+                               int retain_fallbacks);
 
 /* Return pointer to the provider's context */
 void *ossl_provider_ctx(const OSSL_PROVIDER *prov);

--- a/include/internal/provider.h
+++ b/include/internal/provider.h
@@ -44,9 +44,6 @@ int ossl_provider_add_parameter(OSSL_PROVIDER *prov, const char *name,
 
 int ossl_provider_is_child(const OSSL_PROVIDER *prov);
 int ossl_provider_set_child(OSSL_PROVIDER *prov, const OSSL_CORE_HANDLE *handle);
-int ossl_provider_activate_child(OSSL_PROVIDER *prov,
-                                 const OSSL_CORE_HANDLE *handle,
-                                 OSSL_provider_init_fn *init_function);
 const OSSL_CORE_HANDLE *ossl_provider_get_parent(OSSL_PROVIDER *prov);
 int ossl_provider_up_ref_parent(OSSL_PROVIDER *prov, int activate);
 int ossl_provider_free_parent(OSSL_PROVIDER *prov, int deactivate);
@@ -59,7 +56,7 @@ int ossl_provider_disable_fallback_loading(OSSL_LIB_CTX *libctx);
  * Activate the Provider
  * If the Provider is a module, the module will be loaded
  */
-int ossl_provider_activate(OSSL_PROVIDER *prov, int upcalls);
+int ossl_provider_activate(OSSL_PROVIDER *prov, int upcalls, int aschild);
 int ossl_provider_deactivate(OSSL_PROVIDER *prov);
 int ossl_provider_add_to_store(OSSL_PROVIDER *prov, int retain_fallbacks);
 

--- a/include/internal/provider.h
+++ b/include/internal/provider.h
@@ -44,9 +44,9 @@ int ossl_provider_add_parameter(OSSL_PROVIDER *prov, const char *name,
 
 int ossl_provider_is_child(const OSSL_PROVIDER *prov);
 int ossl_provider_set_child(OSSL_PROVIDER *prov, const OSSL_CORE_HANDLE *handle);
-int ossl_provider_convert_to_child(OSSL_PROVIDER *prov,
-                                   const OSSL_CORE_HANDLE *handle,
-                                   OSSL_provider_init_fn *init_function);
+int ossl_provider_activate_child(OSSL_PROVIDER *prov,
+                                 const OSSL_CORE_HANDLE *handle,
+                                 OSSL_provider_init_fn *init_function);
 const OSSL_CORE_HANDLE *ossl_provider_get_parent(OSSL_PROVIDER *prov);
 int ossl_provider_up_ref_parent(OSSL_PROVIDER *prov, int activate);
 int ossl_provider_free_parent(OSSL_PROVIDER *prov, int deactivate);

--- a/include/internal/symhacks.h
+++ b/include/internal/symhacks.h
@@ -15,9 +15,6 @@
 
 # if defined(OPENSSL_SYS_VMS)
 
-/* ossl_provider_available vs OSSL_PROVIDER_available */
-#  undef ossl_provider_available
-#  define ossl_provider_available                 ossl_int_prov_available
 /* ossl_provider_gettable_params vs OSSL_PROVIDER_gettable_params */
 #  undef ossl_provider_gettable_params
 #  define ossl_provider_gettable_params            ossl_int_prov_gettable_params

--- a/test/provider_internal_test.c
+++ b/test/provider_internal_test.c
@@ -26,7 +26,7 @@ static int test_provider(OSSL_PROVIDER *prov, const char *expected_greeting)
     int ret = 0;
 
     ret =
-        TEST_true(ossl_provider_activate(prov, 1))
+        TEST_true(ossl_provider_activate(prov, 1, 0))
         && TEST_true(ossl_provider_get_params(prov, greeting_request))
         && TEST_ptr(greeting = greeting_request[0].data)
         && TEST_size_t_gt(greeting_request[0].data_size, 0)

--- a/test/provider_internal_test.c
+++ b/test/provider_internal_test.c
@@ -26,7 +26,7 @@ static int test_provider(OSSL_PROVIDER *prov, const char *expected_greeting)
     int ret = 0;
 
     ret =
-        TEST_true(ossl_provider_activate(prov, 0, 1))
+        TEST_true(ossl_provider_activate(prov, 1))
         && TEST_true(ossl_provider_get_params(prov, greeting_request))
         && TEST_ptr(greeting = greeting_request[0].data)
         && TEST_size_t_gt(greeting_request[0].data_size, 0)


### PR DESCRIPTION
Previously providers were added to the store first, and then subsequently initialised. This meant that during initialisation the provider object could be shared between multiple threads and hence the locks needed to be held. However this causes problems because the provider init function is essentially a user callback and could do virtually anything. There are many API calls that could be invoked that could subsequently attempt to acquire the locks. This will fail because the locks are already held.

This PR refactors things so that the provider is created and initialised before being added to the store. Therefore at the point of initialisation the provider object is not shared with other threads and so no locks need to be held.

In order to achieve this we no longer create the predefined providers up front, and we don't create provider objects for providers loaded from config that aren't activated. Instead we store this information away in a table for future reference. We already had a structure that did most of the job for this table, that was used for holding information about the predefined providers. This PR just expands that structure out a bit, and makes it possible for user code to add new entries.

Fixes #15793
Fixes #15712
