### PR TITLE
EVP: Change the output size type of EVP_Q_digest() and EVP_Q_mac()

### DIFF
--- a/apps/lib/s_cb.c
+++ b/apps/lib/s_cb.c
@@ -740,8 +740,8 @@ void tlsext_cb(SSL *s, int client_server, int type,
 }
 
 #ifndef OPENSSL_NO_SOCK
-int generate_cookie_callback(SSL *ssl, unsigned char *cookie,
-                             unsigned int *cookie_len)
+int generate_stateless_cookie_callback(SSL *ssl, unsigned char *cookie,
+                                       size_t *cookie_len)
 {
     unsigned char *buffer = NULL;
     size_t length = 0;
@@ -800,16 +800,16 @@ end:
     return res;
 }
 
-int verify_cookie_callback(SSL *ssl, const unsigned char *cookie,
-                           unsigned int cookie_len)
+int verify_stateless_cookie_callback(SSL *ssl, const unsigned char *cookie,
+                                     size_t cookie_len)
 {
     unsigned char result[EVP_MAX_MD_SIZE];
-    unsigned int resultlength;
+    size_t resultlength;
 
     /* Note: we check cookie_initialized because if it's not,
      * it cannot be valid */
     if (cookie_initialized
-        && generate_cookie_callback(ssl, result, &resultlength)
+        && generate_stateless_cookie_callback(ssl, result, &resultlength)
         && cookie_len == resultlength
         && memcmp(result, cookie, resultlength) == 0)
         return 1;
@@ -817,20 +817,20 @@ int verify_cookie_callback(SSL *ssl, const unsigned char *cookie,
     return 0;
 }
 
-int generate_stateless_cookie_callback(SSL *ssl, unsigned char *cookie,
-                                       size_t *cookie_len)
+int generate_cookie_callback(SSL *ssl, unsigned char *cookie,
+                             unsigned int *cookie_len)
 {
-    unsigned int temp = 0;
+    size_t temp = 0;
+    int res = generate_stateless_cookie_callback(ssl, cookie, &temp);
 
-    int res = generate_cookie_callback(ssl, cookie, &temp);
-    *cookie_len = temp;
+    *cookie_len = (unsigned int)temp;
     return res;
 }
 
-int verify_stateless_cookie_callback(SSL *ssl, const unsigned char *cookie,
-                                     size_t cookie_len)
+int verify_cookie_callback(SSL *ssl, const unsigned char *cookie,
+                           unsigned int cookie_len)
 {
-    return verify_cookie_callback(ssl, cookie, cookie_len);
+    return verify_stateless_cookie_callback(ssl, cookie, cookie_len);
 }
 
 #endif

--- a/crypto/crmf/crmf_pbm.c
+++ b/crypto/crmf/crmf_pbm.c
@@ -140,7 +140,6 @@ int OSSL_CRMF_pbm_new(OSSL_LIB_CTX *libctx, const char *propq,
     unsigned int bklen = EVP_MAX_MD_SIZE;
     int64_t iterations;
     unsigned char *mac_res = 0;
-    unsigned int maclen;
     int ok = 0;
 
     if (out == NULL || pbmp == NULL || pbmp->mac == NULL
@@ -207,10 +206,9 @@ int OSSL_CRMF_pbm_new(OSSL_LIB_CTX *libctx, const char *propq,
         goto err;
     }
     if (EVP_Q_mac(libctx, "HMAC", propq, hmac_mdname, NULL, basekey, bklen,
-                  msg, msglen, mac_res, EVP_MAX_MD_SIZE, &maclen) == NULL)
+                  msg, msglen, mac_res, EVP_MAX_MD_SIZE, outlen) == NULL)
         goto err;
 
-    *outlen = (size_t)maclen;
     ok = 1;
 
  err:

--- a/crypto/evp/digest.c
+++ b/crypto/evp/digest.c
@@ -630,16 +630,19 @@ int EVP_Digest(const void *data, size_t count,
 }
 
 int EVP_Q_digest(OSSL_LIB_CTX *libctx, const char *name, const char *propq,
-                 const void *data, size_t count,
-                 unsigned char *md, unsigned int *size)
+                 const void *data, size_t datalen,
+                 unsigned char *md, size_t *mdlen)
 {
     EVP_MD *digest = EVP_MD_fetch(libctx, name, propq);
+    unsigned int temp = 0;
     int ret = 0;
 
     if (digest != NULL) {
-        ret = EVP_Digest(data, count, md, size, digest, NULL);
+        ret = EVP_Digest(data, datalen, md, &temp, digest, NULL);
         EVP_MD_free(digest);
     }
+    if (mdlen != NULL)
+        *mdlen = temp;
     return ret;
 }
 

--- a/crypto/evp/mac_lib.c
+++ b/crypto/evp/mac_lib.c
@@ -233,16 +233,17 @@ int EVP_MAC_names_do_all(const EVP_MAC *mac,
     return 1;
 }
 
-unsigned char *EVP_Q_mac(OSSL_LIB_CTX *libctx, const char *name, const char *propq,
+unsigned char *EVP_Q_mac(OSSL_LIB_CTX *libctx,
+                         const char *name, const char *propq,
                          const char *subalg, const OSSL_PARAM *params,
                          const void *key, size_t keylen,
                          const unsigned char *data, size_t datalen,
-                         unsigned char *out, size_t outsize, unsigned int *outlen)
+                         unsigned char *out, size_t outsize, size_t *outlen)
 {
     EVP_MAC *mac = EVP_MAC_fetch(libctx, name, propq);
     OSSL_PARAM subalg_param[] = { OSSL_PARAM_END, OSSL_PARAM_END };
     EVP_MAC_CTX *ctx  = NULL;
-    size_t len;
+    size_t len = 0;
     unsigned char *res = NULL;
 
     if (outlen != NULL)
@@ -286,7 +287,7 @@ unsigned char *EVP_Q_mac(OSSL_LIB_CTX *libctx, const char *name, const char *pro
         }
         res = out;
         if (res != NULL && outlen != NULL)
-            *outlen = (unsigned int)len;
+            *outlen = len;
     }
 
  err:

--- a/crypto/hmac/hmac.c
+++ b/crypto/hmac/hmac.c
@@ -231,7 +231,8 @@ unsigned char *HMAC(const EVP_MD *evp_md, const void *key, int key_len,
         ret = EVP_Q_mac(NULL, "HMAC", NULL, EVP_MD_get0_name(evp_md), NULL,
                         key, key_len, data, data_len,
                         md == NULL ? static_md : md, size, &temp_md_len);
-        *md_len = (unsigned int)temp_md_len;
+        if (md_len != NULL)
+            *md_len = (unsigned int)temp_md_len;
     }
     return ret;
 }

--- a/crypto/hmac/hmac.c
+++ b/crypto/hmac/hmac.c
@@ -224,12 +224,16 @@ unsigned char *HMAC(const EVP_MD *evp_md, const void *key, int key_len,
 {
     static unsigned char static_md[EVP_MAX_MD_SIZE];
     int size = EVP_MD_get_size(evp_md);
+    size_t temp_md_len = 0;
+    unsigned char *ret = NULL;
 
-    if (size < 0)
-        return NULL;
-    return EVP_Q_mac(NULL, "HMAC", NULL, EVP_MD_get0_name(evp_md), NULL,
-                     key, key_len, data, data_len,
-                     md == NULL ? static_md : md, size, md_len);
+    if (size >= 0) {
+        ret = EVP_Q_mac(NULL, "HMAC", NULL, EVP_MD_get0_name(evp_md), NULL,
+                        key, key_len, data, data_len,
+                        md == NULL ? static_md : md, size, &temp_md_len);
+        *md_len = (unsigned int)temp_md_len;
+    }
+    return ret;
 }
 
 void HMAC_CTX_set_flags(HMAC_CTX *ctx, unsigned long flags)

--- a/doc/man3/EVP_DigestInit.pod
+++ b/doc/man3/EVP_DigestInit.pod
@@ -52,8 +52,8 @@ EVP_MD_CTX_type, EVP_MD_CTX_pkey_ctx, EVP_MD_CTX_md_data
  int EVP_MD_CTX_test_flags(const EVP_MD_CTX *ctx, int flags);
 
  int EVP_Q_digest(OSSL_LIB_CTX *libctx, const char *name, const char *propq,
-                  const void *data, size_t count,
-                  unsigned char *md, unsigned int *size);
+                  const void *data, size_t datalen,
+                  unsigned char *md, size_t *mdlen);
  int EVP_Digest(const void *data, size_t count, unsigned char *md,
                 unsigned int *size, const EVP_MD *type, ENGINE *impl);
  int EVP_DigestInit_ex2(EVP_MD_CTX *ctx, const EVP_MD *type,
@@ -234,9 +234,10 @@ as a parameter descriptor.
 Sets, clears and tests I<ctx> flags.  See L</FLAGS> below for more information.
 
 =item EVP_Q_digest() is a quick one-shot digest function.
-It hashes I<count> bytes of data at I<data> using the digest algorithm I<name>,
-which is fetched using the optional I<libctx> and I<propq> parameters.
-The digest value is placed in I<md> and its length is written at I<size>
+
+It hashes I<datalen> bytes of data at I<data> using the digest algorithm
+I<name>, which is fetched using the optional I<libctx> and I<propq> parameters.
+The digest value is placed in I<md> and its length is written at I<mdlen>
 if the pointer is not NULL. At most B<EVP_MAX_MD_SIZE> bytes will be written.
 
 =item EVP_Digest()

--- a/doc/man3/EVP_MAC.pod
+++ b/doc/man3/EVP_MAC.pod
@@ -46,7 +46,7 @@ EVP_MAC_do_all_provided - EVP MAC routines
                           const char *subalg, const OSSL_PARAM *params,
                           const void *key, size_t keylen,
                           const unsigned char *data, size_t datalen,
-                          unsigned char *out, size_t outsize, unsigned int *outlen);
+                          unsigned char *out, size_t outsize, size_t *outlen);
  int EVP_MAC_init(EVP_MAC_CTX *ctx, const unsigned char *key, size_t keylen,
                   const OSSL_PARAM params[]);
  int EVP_MAC_update(EVP_MAC_CTX *ctx, const unsigned char *data, size_t datalen);

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -715,8 +715,8 @@ __owur int EVP_Digest(const void *data, size_t count,
                           unsigned char *md, unsigned int *size,
                           const EVP_MD *type, ENGINE *impl);
 __owur int EVP_Q_digest(OSSL_LIB_CTX *libctx, const char *name,
-                        const char *propq, const void *data, size_t count,
-                        unsigned char *md, unsigned int *size);
+                        const char *propq, const void *data, size_t datalen,
+                        unsigned char *md, size_t *mdlen);
 
 __owur int EVP_MD_CTX_copy(EVP_MD_CTX *out, const EVP_MD_CTX *in);
 __owur int EVP_DigestInit(EVP_MD_CTX *ctx, const EVP_MD *type);
@@ -1216,7 +1216,7 @@ unsigned char *EVP_Q_mac(OSSL_LIB_CTX *libctx, const char *name, const char *pro
                          const char *subalg, const OSSL_PARAM *params,
                          const void *key, size_t keylen,
                          const unsigned char *data, size_t datalen,
-                         unsigned char *out, size_t outsize, unsigned int *outlen);
+                         unsigned char *out, size_t outsize, size_t *outlen);
 int EVP_MAC_init(EVP_MAC_CTX *ctx, const unsigned char *key, size_t keylen,
                  const OSSL_PARAM params[]);
 int EVP_MAC_update(EVP_MAC_CTX *ctx, const unsigned char *data, size_t datalen);

--- a/ssl/tls13_enc.c
+++ b/ssl/tls13_enc.c
@@ -309,8 +309,7 @@ size_t tls13_final_finish_mac(SSL *s, const char *str, size_t slen,
     unsigned char hash[EVP_MAX_MD_SIZE];
     unsigned char finsecret[EVP_MAX_MD_SIZE];
     unsigned char *key = NULL;
-    unsigned int len = 0;
-    size_t hashlen, ret = 0;
+    size_t len = 0, hashlen;
     OSSL_PARAM params[2], *p = params;
 
     /* Safe to cast away const here since we're not "getting" any data */
@@ -345,10 +344,9 @@ size_t tls13_final_finish_mac(SSL *s, const char *str, size_t slen,
         goto err;
     }
 
-    ret = len;
  err:
     OPENSSL_cleanse(finsecret, sizeof(finsecret));
-    return ret;
+    return len;
 }
 
 /*


### PR DESCRIPTION
This makes them more consistent with other new interfaces.

Fixes #15839