### PR TITLE
doc: Document that the OBJ creation functions don't lock.

### DIFF
--- a/doc/man3/OBJ_nid2obj.pod
+++ b/doc/man3/OBJ_nid2obj.pod
@@ -181,6 +181,10 @@ Instead I<buf> must point to a valid buffer and I<buf_len> should
 be set to a positive value. A buffer length of 80 should be more
 than enough to handle any OID encountered in practice.
 
+Neither OBJ_create() nor OBJ_add_sigid() do any locking and are thus not
+thread safe.  Moreover, none of the other functions should be called while
+concurrent calls to these two functions are possible.
+
 =head1 SEE ALSO
 
 L<ERR_get_error(3)>

--- a/doc/man7/provider-base.pod
+++ b/doc/man7/provider-base.pod
@@ -264,6 +264,7 @@ It will treat as success the case where the OID already exists (even if the
 short name I<sn> or long name I<ln> provided as arguments differ from those
 associated with the existing OID, in which case the new names are not
 associated).
+This function is not thread safe.
 
 The core_obj_add_sigid() function registers a new composite signature algorithm
 (I<sign_name>) consisting of an underlying signature algorithm (I<pkey_name>)
@@ -277,6 +278,7 @@ to identify the object. It will treat as success the case where the composite
 signature algorithm already exists (even if registered against a different
 underlying signature or digest algorithm). It returns 1 on success or 0 on
 failure.
+This function is not thread safe.
 
 CRYPTO_malloc(), CRYPTO_zalloc(), CRYPTO_memdup(), CRYPTO_strdup(),
 CRYPTO_strndup(), CRYPTO_free(), CRYPTO_clear_free(),


### PR DESCRIPTION
With #15713 not being part of 3.0, the documentation about thread safety and the OBJ functions should be more prominent.


- [x] documentation is added or updated
- [ ] tests are added or updated
