### PR TITLE
enable getauxval on android 10

### DIFF
--- a/crypto/armcap.c
+++ b/crypto/armcap.c
@@ -68,6 +68,12 @@ void OPENSSL_cpuid_setup(void) __attribute__ ((constructor));
 #   include <sys/auxv.h>
 #   define OSSL_IMPLEMENT_GETAUXVAL
 #  endif
+# elif defined(__ANDROID_API__)
+/* see https://developer.android.google.cn/ndk/guides/cpu-features */
+#  if __ANDROID_API__ >= 18
+#   include <sys/auxv.h>
+#   define OSSL_IMPLEMENT_GETAUXVAL
+#  endif
 # endif
 # if defined(__FreeBSD__)
 #  include <sys/param.h>

--- a/crypto/ppccap.c
+++ b/crypto/ppccap.c
@@ -211,6 +211,12 @@ size_t OPENSSL_instrument_bus2(unsigned int *out, size_t cnt, size_t max)
 # if __GLIBC_PREREQ(2, 16)
 #  include <sys/auxv.h>
 #  define OSSL_IMPLEMENT_GETAUXVAL
+# elif defined(__ANDROID_API__)
+/* see https://developer.android.google.cn/ndk/guides/cpu-features */
+#  if __ANDROID_API__ >= 18
+#   include <sys/auxv.h>
+#   define OSSL_IMPLEMENT_GETAUXVAL
+#  endif
 # endif
 #endif
 

--- a/crypto/uid.c
+++ b/crypto/uid.c
@@ -36,6 +36,12 @@ int OPENSSL_issetugid(void)
 #   include <sys/auxv.h>
 #   define OSSL_IMPLEMENT_GETAUXVAL
 #  endif
+# elif defined(__ANDROID_API__)
+/* see https://developer.android.google.cn/ndk/guides/cpu-features */
+#  if __ANDROID_API__ >= 18
+#   include <sys/auxv.h>
+#   define OSSL_IMPLEMENT_GETAUXVAL
+#  endif
 # endif
 
 int OPENSSL_issetugid(void)


### PR DESCRIPTION
Fixes #9498 

1.0.2 use getauxval to get CPU capacibility by default, 
1.1.1 use SIGILL & sigsetjmp by default, only use getauxval on certain condition:
```
# if defined(__GLIBC__) && defined(__GLIBC_PREREQ)
#  if __GLIBC_PREREQ(2, 16)
#   include <sys/auxv.h>
#   define OSSL_IMPLEMENT_GETAUXVAL
#  endif
# endif
```
but NDK with clang does not recognize that, and NDK with api level greater than 18 support getauxval, 
see https://developer.android.google.cn/ndk/guides/cpu-features 
so add it for NDK and walk around SIGILL & sigsetjmp way, which maybe problematic on some android platform...

Signed-off-by: yunhai haihai107@126.com
