### PR TITLE
property: add locking to the property string database

### DIFF
--- a/crypto/err/err.c
+++ b/crypto/err/err.c
@@ -127,6 +127,8 @@ static ERR_STRING_DATA ERR_str_reasons[] = {
     {ERR_R_FETCH_FAILED, "fetch failed"},
 
     {ERR_R_INVALID_PROPERTY_DEFINITION, "invalid property definition"},
+    {ERR_R_UNABLE_TO_GET_READ_LOCK, "unable to get read lock"},
+    {ERR_R_UNABLE_TO_GET_WRITE_LOCK, "unable to get write lock"},
     {0, NULL},
 };
 #endif

--- a/crypto/property/property.c
+++ b/crypto/property/property.c
@@ -273,12 +273,7 @@ int ossl_method_store_add(OSSL_METHOD_STORE *store, const OSSL_PROVIDER *prov,
     }
     impl->provider = prov;
 
-    /*
-     * Insert into the hash table if required.
-     *
-     * A write lock is used unconditionally because we wend our way down to the
-     * property string code which isn't locking friendly.
-     */
+    /* Insert into the hash table if required */
     if (!ossl_property_write_lock(store)) {
         OPENSSL_free(impl);
         return 0;
@@ -418,10 +413,7 @@ int ossl_method_store_fetch(OSSL_METHOD_STORE *store, int nid,
     if (nid <= 0 || method == NULL || store == NULL)
         return 0;
 
-    /*
-     * This only needs to be a read lock, because queries never create property
-     * names or value and thus don't modify any of the property string layer.
-     */
+    /* This only needs to be a read lock, because the query won't create anything */
     if (!ossl_property_read_lock(store))
         return 0;
     alg = ossl_method_store_retrieve(store, nid);

--- a/include/openssl/err.h.in
+++ b/include/openssl/err.h.in
@@ -358,6 +358,8 @@ static ossl_unused ossl_inline int ERR_COMMON_ERROR(unsigned long errcode)
 # define ERR_R_UNSUPPORTED                       (268|ERR_RFLAG_COMMON)
 # define ERR_R_FETCH_FAILED                      (269|ERR_RFLAG_COMMON)
 # define ERR_R_INVALID_PROPERTY_DEFINITION       (270|ERR_RFLAG_COMMON)
+# define ERR_R_UNABLE_TO_GET_READ_LOCK           (271|ERR_R_FATAL)
+# define ERR_R_UNABLE_TO_GET_WRITE_LOCK          (272|ERR_R_FATAL)
 
 typedef struct ERR_string_data_st {
     unsigned long error;


### PR DESCRIPTION
The precondition that the caller to the property string routines held a lock over the property string store is no longer met in several places.  Instead of relying on the caller locking correctly, the property string database now contains locks which prevent threading issues.
    
Fixes #15866

- [ ] documentation is added or updated
- [ ] tests are added or updated
