### PR TITLE
Adapt shlibloadtest for VMS

### DIFF
--- a/test/recipes/90-test_shlibload.t
+++ b/test/recipes/90-test_shlibload.t
@@ -8,7 +8,6 @@
 
 use OpenSSL::Test qw/:DEFAULT srctop_dir bldtop_dir/;
 use OpenSSL::Test::Utils;
-use File::Temp qw(tempfile);
 
 #Load configdata.pm
 
@@ -29,35 +28,44 @@ plan tests => 10;
 
 my $libcrypto = platform->sharedlib('libcrypto');
 my $libssl = platform->sharedlib('libssl');
+my $atexit_outfile;
 
-(my $fh, my $filename) = tempfile();
-ok(run(test(["shlibloadtest", "-crypto_first", $libcrypto, $libssl, $filename])),
-   "running shlibloadtest -crypto_first $filename");
-ok(check_atexit($fh));
-unlink $filename;
-($fh, $filename) = tempfile();
-ok(run(test(["shlibloadtest", "-ssl_first", $libcrypto, $libssl, $filename])),
-   "running shlibloadtest -ssl_first $filename");
-ok(check_atexit($fh));
-unlink $filename;
-($fh, $filename) = tempfile();
-ok(run(test(["shlibloadtest", "-just_crypto", $libcrypto, $libssl, $filename])),
-   "running shlibloadtest -just_crypto $filename");
-ok(check_atexit($fh));
-unlink $filename;
-($fh, $filename) = tempfile();
-ok(run(test(["shlibloadtest", "-dso_ref", $libcrypto, $libssl, $filename])),
-   "running shlibloadtest -dso_ref $filename");
-ok(check_atexit($fh));
-unlink $filename;
-($fh, $filename) = tempfile();
-ok(run(test(["shlibloadtest", "-no_atexit", $libcrypto, $libssl, $filename])),
-   "running shlibloadtest -no_atexit $filename");
-ok(!check_atexit($fh));
-unlink $filename;
+$atexit_outfile = 'atexit-cryptofirst.txt';
+1 while unlink $atexit_outfile;
+ok(run(test(["shlibloadtest", "-crypto_first", $libcrypto, $libssl, $atexit_outfile])),
+   "running shlibloadtest -crypto_first $atexit_");
+ok(check_atexit($atexit_outfile));
+
+$atexit_outfile = 'atexit-sslfirst.txt';
+1 while unlink $atexit_outfile;
+ok(run(test(["shlibloadtest", "-ssl_first", $libcrypto, $libssl, $atexit_outfile])),
+   "running shlibloadtest -ssl_first $atexit_outfile");
+ok(check_atexit($atexit_outfile));
+
+$atexit_outfile = 'atexit-justcrypto.txt';
+1 while unlink $atexit_outfile;
+ok(run(test(["shlibloadtest", "-just_crypto", $libcrypto, $libssl, $atexit_outfile])),
+   "running shlibloadtest -just_crypto $atexit_outfile");
+ok(check_atexit($atexit_outfile));
+
+$atexit_outfile = 'atexit-dsoref.txt';
+1 while unlink $atexit_outfile;
+ok(run(test(["shlibloadtest", "-dso_ref", $libcrypto, $libssl, $atexit_outfile])),
+   "running shlibloadtest -dso_ref $atexit_outfile");
+ok(check_atexit($atexit_outfile));
+
+$atexit_outfile = 'atexit-noatexit.txt';
+1 while unlink $atexit_outfile;
+ok(run(test(["shlibloadtest", "-no_atexit", $libcrypto, $libssl, $atexit_outfile])),
+   "running shlibloadtest -no_atexit $atexit_outfile");
+ok(!check_atexit($atexit_outfile));
 
 sub check_atexit {
-    my $fh = shift;
+    my $filename = shift;
+
+    open my $fh, '<', $filename;
+    return 0 unless defined $fh;
+
     my $data = <$fh>;
 
     return 1 if (defined $data && $data =~ m/atexit\(\) run/);

--- a/test/recipes/90-test_shlibload.t
+++ b/test/recipes/90-test_shlibload.t
@@ -33,7 +33,7 @@ my $atexit_outfile;
 $atexit_outfile = 'atexit-cryptofirst.txt';
 1 while unlink $atexit_outfile;
 ok(run(test(["shlibloadtest", "-crypto_first", $libcrypto, $libssl, $atexit_outfile])),
-   "running shlibloadtest -crypto_first $atexit_");
+   "running shlibloadtest -crypto_first $atexit_outfile");
 ok(check_atexit($atexit_outfile));
 
 $atexit_outfile = 'atexit-sslfirst.txt';

--- a/test/simpledynamic.c
+++ b/test/simpledynamic.c
@@ -12,7 +12,7 @@
 #include <openssl/e_os2.h>
 #include "simpledynamic.h"
 
-#if defined(DSO_DLFCN)
+#if defined(DSO_DLFCN) || defined(DSO_VMS)
 
 int sd_load(const char *filename, SD *lib, int type)
 {

--- a/test/simpledynamic.h
+++ b/test/simpledynamic.h
@@ -12,13 +12,18 @@
 
 # include "crypto/dso_conf.h"
 
-# if defined(DSO_DLFCN)
+# if defined(DSO_DLFCN) || defined(DSO_VMS)
 
 #  include <dlfcn.h>
 
 #  define SD_INIT       NULL
-#  define SD_SHLIB      (RTLD_GLOBAL|RTLD_LAZY)
-#  define SD_MODULE     (RTLD_LOCAL|RTLD_NOW)
+#  ifdef DSO_VMS
+#   define SD_SHLIB     0
+#   define SD_MODULE    0
+#  else
+#   define SD_SHLIB     (RTLD_GLOBAL|RTLD_LAZY)
+#   define SD_MODULE    (RTLD_LOCAL|RTLD_NOW)
+#  endif
 
 typedef void *SD;
 typedef void *SD_SYM;
@@ -36,7 +41,7 @@ typedef void *SD_SYM;
 
 # endif
 
-# if defined(DSO_DLFCN) || defined(DSO_WIN32)
+# if defined(DSO_DLFCN) || defined(DSO_WIN32) || defined(DSO_VMS)
 int sd_load(const char *filename, SD *sd, int type);
 int sd_sym(SD sd, const char *symname, SD_SYM *sym);
 int sd_close(SD lib);


### PR DESCRIPTION
This includes a slight modification of test/simpledynamic.[ch], but most of all, this change to the test recipe:

## test/recipes/90-test_shlibload.t: Modify to work with known file names

Using File::Temp::tempfile() is admirable, but isn't necessary for the
sort of thing we use it for.

Furthermore, since tempfile() returns an opened file handle for
reading for the file in question, it may have effect that the file
becomes unwritable.  This is the default on VMS, and since tempfile()
doesn't seem to have any option to affect this, it means that
test/shlibloadtest.c can't write the magic line to that file.

Also, if we consider forensics, to be able to see what a test produced
to determine what went wrong, it's better to use specific and known
file names.

Therefore, this test is modified to use well known file names, and to
open them for reading after the shlibloadtest program has been run
instead of before.