### PR TITLE
simpledynamic: Add missing include for AIX builds

### DIFF
--- a/test/simpledynamic.c
+++ b/test/simpledynamic.c
@@ -7,6 +7,7 @@
  * https://www.openssl.org/source/license.html
  */
 
+#include <string.h>
 #include <stdlib.h>              /* For NULL */
 #include <openssl/macros.h>      /* For NON_EMPTY_TRANSLATION_UNIT */
 #include <openssl/e_os2.h>


### PR DESCRIPTION
Fixes warnings about using implicit declaration for strlen() on AIX.
