### PR TITLE
Documentation: SM2 keys can use only the SM2 curve

### DIFF
--- a/doc/man7/EVP_PKEY-SM2.pod
+++ b/doc/man7/EVP_PKEY-SM2.pod
@@ -55,6 +55,9 @@ or EVP_DigestVerifyInit() in such a scenario.
 SM2 can be tested with the L<openssl-speed(1)> application since version 3.0.
 Currently, the only valid algorithm name is B<sm2>.
 
+The SM2 keys can be generated and loaded only in case the domain parameters
+are using the SM2 elliptic curve since version 3.0.
+
 =head1 EXAMPLES
 
 This example demonstrates the calling sequence for using an B<EVP_PKEY> to verify

--- a/doc/man7/EVP_PKEY-SM2.pod
+++ b/doc/man7/EVP_PKEY-SM2.pod
@@ -55,8 +55,8 @@ or EVP_DigestVerifyInit() in such a scenario.
 SM2 can be tested with the L<openssl-speed(1)> application since version 3.0.
 Currently, the only valid algorithm name is B<sm2>.
 
-The SM2 keys can be generated and loaded only in case the domain parameters
-are using the SM2 elliptic curve since version 3.0.
+Since version 3.0, SM2 keys can be generated and loaded only when the domain
+parameters specify the SM2 elliptic curve.
 
 =head1 EXAMPLES
 

--- a/doc/man7/migration_guide.pod
+++ b/doc/man7/migration_guide.pod
@@ -354,9 +354,9 @@ call C<EVP_PKEY_set_alias_type(pkey, EVP_PKEY_SM2)> to get SM2 computations.
 
 Parameter and key generation is also reworked to make it possible
 to generate EVP_PKEY_SM2 parameters and keys. Applications must now generate
-SM2 keys directly and must not create an EVP_PKEY_EC key first. It is also
-not possible to import an SM2 key with other domain parameters than the
-SM2 elliptic curve anymore.
+SM2 keys directly and must not create an EVP_PKEY_EC key first. It is no longer
+possible to import an SM2 key with domain parameters other than the SM2 elliptic
+curve ones.
 
 Validation of SM2 keys has been separated from the validation of regular EC
 keys, allowing to improve the SM2 validation process to reject loaded private

--- a/doc/man7/migration_guide.pod
+++ b/doc/man7/migration_guide.pod
@@ -354,7 +354,9 @@ call C<EVP_PKEY_set_alias_type(pkey, EVP_PKEY_SM2)> to get SM2 computations.
 
 Parameter and key generation is also reworked to make it possible
 to generate EVP_PKEY_SM2 parameters and keys. Applications must now generate
-SM2 keys directly and must not create an EVP_PKEY_EC key first.
+SM2 keys directly and must not create an EVP_PKEY_EC key first. It is also
+not possible to import an SM2 key with other domain parameters than the
+SM2 elliptic curve anymore.
 
 Validation of SM2 keys has been separated from the validation of regular EC
 keys, allowing to improve the SM2 validation process to reject loaded private


### PR DESCRIPTION
Fixes #14411

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
