### PR TITLE
Two decoder error reporting fixes

### DIFF
--- a/crypto/passphrase.c
+++ b/crypto/passphrase.c
@@ -261,10 +261,8 @@ int ossl_pw_get_passphrase(char *pass, size_t pass_size, size_t *pass_len,
         ui_data = data->_.ui_method.ui_method_data;
     }
 
-    if (ui_method == NULL) {
-        ERR_raise(ERR_LIB_CRYPTO, ERR_R_INTERNAL_ERROR);
+    if (ui_method == NULL)
         return 0;
-    }
 
     ret = do_ui_passphrase(pass, pass_size, pass_len, prompt_info, verify,
                            ui_method, ui_data);

--- a/crypto/passphrase.c
+++ b/crypto/passphrase.c
@@ -261,8 +261,11 @@ int ossl_pw_get_passphrase(char *pass, size_t pass_size, size_t *pass_len,
         ui_data = data->_.ui_method.ui_method_data;
     }
 
-    if (ui_method == NULL)
+    if (ui_method == NULL) {
+        ERR_raise_data(ERR_LIB_CRYPTO, ERR_R_PASSED_INVALID_ARGUMENT,
+                       "No password method specified");
         return 0;
+    }
 
     ret = do_ui_passphrase(pass, pass_size, pass_len, prompt_info, verify,
                            ui_method, ui_data);

--- a/providers/implementations/encode_decode/decode_epki2pki.c
+++ b/providers/implementations/encode_decode/decode_epki2pki.c
@@ -90,6 +90,7 @@ static int epki2pki_decode(void *vctx, OSSL_CORE_BIO *cin, int selection,
 
         if (!pw_cb(pbuf, sizeof(pbuf), &plen, NULL, pw_cbarg)) {
             ERR_raise(ERR_LIB_PROV, PROV_R_UNABLE_TO_GET_PASSPHRASE);
+            ok = 0;
         } else {
             const ASN1_OCTET_STRING *oct;
             unsigned char *new_der = NULL;


### PR DESCRIPTION
We did not report error if the password callback failed in the encrypted pkcs8 decoder.

Also the OSSL_DECODER_bio:unsupported was reported in cases where it just hid the real error. The fix for this is a little bit of hack so if you have a better idea how to fix this...

Fixes #14566
