### PR TITLE
CMP: Enhance error reporting; clean up internal message creation API and doc

### DIFF
--- a/crypto/asn1/asn1_lib.c
+++ b/crypto/asn1/asn1_lib.c
@@ -413,9 +413,9 @@ unsigned char *ASN1_STRING_data(ASN1_STRING *x)
 }
 #endif
 
+/* |max_len| excludes NUL terminator and may be 0 to indicate no restriction */
 char *ossl_sk_ASN1_UTF8STRING2text(STACK_OF(ASN1_UTF8STRING) *text,
-                                   const char *sep,
-                                   size_t max_len /* excluding NUL terminator */)
+                                   const char *sep, size_t max_len)
 {
     int i;
     ASN1_UTF8STRING *current;
@@ -423,26 +423,27 @@ char *ossl_sk_ASN1_UTF8STRING2text(STACK_OF(ASN1_UTF8STRING) *text,
     char *result = NULL;
     char *p;
 
-    if (!ossl_assert(sep != NULL))
-        return NULL;
+    if (sep == NULL)
+        sep = "";
     sep_len = strlen(sep);
 
-    for (i = 0; i < sk_ASN1_UTF8STRING_num(text); ++i) {
+    for (i = 0; i < sk_ASN1_UTF8STRING_num(text); i++) {
         current = sk_ASN1_UTF8STRING_value(text, i);
         if (i > 0)
             length += sep_len;
         length += ASN1_STRING_length(current);
-        if (length > max_len)
+        if (max_len != 0 && length > max_len)
             return NULL;
     }
     if ((result = OPENSSL_malloc(length + 1)) == NULL)
         return NULL;
 
-    for (i = 0, p = result; i < sk_ASN1_UTF8STRING_num(text); ++i) {
+    p = result;
+    for (i = 0; i < sk_ASN1_UTF8STRING_num(text); i++) {
         current = sk_ASN1_UTF8STRING_value(text, i);
         length = ASN1_STRING_length(current);
         if (i > 0 && sep_len > 0) {
-            strncpy(p, sep, sep_len + 1);
+            strncpy(p, sep, sep_len + 1); /* using + 1 to silence gcc warning */
             p += sep_len;
         }
         strncpy(p, (const char *)ASN1_STRING_get0_data(current), length);

--- a/crypto/cmp/cmp_client.c
+++ b/crypto/cmp/cmp_client.c
@@ -216,14 +216,14 @@ static int send_receive_check(OSSL_CMP_CTX *ctx, const OSSL_CMP_MSG *req,
                                                   sizeof(buf)) != NULL)
             ERR_add_error_data(1, buf);
         if (emc->errorCode != NULL
-                && BIO_snprintf(buf, sizeof(buf), "; errorCode: %ld",
+                && BIO_snprintf(buf, sizeof(buf), "; errorCode: %08lX",
                                 ASN1_INTEGER_get(emc->errorCode)) > 0)
             ERR_add_error_data(1, buf);
         if (emc->errorDetails != NULL) {
             char *text = ossl_sk_ASN1_UTF8STRING2text(emc->errorDetails, ", ",
                                                       OSSL_CMP_PKISI_BUFLEN - 1);
 
-            if (text != NULL)
+            if (text != NULL && *text != '\0')
                 ERR_add_error_data(2, "; errorDetails: ", text);
             OPENSSL_free(text);
         }

--- a/crypto/cmp/cmp_local.h
+++ b/crypto/cmp/cmp_local.h
@@ -882,7 +882,7 @@ OSSL_CMP_MSG *ossl_cmp_genm_new(OSSL_CMP_CTX *ctx);
 OSSL_CMP_MSG *ossl_cmp_genp_new(OSSL_CMP_CTX *ctx,
                                 const STACK_OF(OSSL_CMP_ITAV) *itavs);
 OSSL_CMP_MSG *ossl_cmp_error_new(OSSL_CMP_CTX *ctx, const OSSL_CMP_PKISI *si,
-                                 int errorCode, const char *details,
+                                 int64_t errorCode, const char *details,
                                  int unprotected);
 int ossl_cmp_certstatus_set0_certHash(OSSL_CMP_CERTSTATUS *certStatus,
                                       ASN1_OCTET_STRING *hash);

--- a/crypto/cmp/cmp_local.h
+++ b/crypto/cmp/cmp_local.h
@@ -864,13 +864,14 @@ OSSL_CMP_MSG *ossl_cmp_msg_create(OSSL_CMP_CTX *ctx, int bodytype);
 OSSL_CMP_MSG *ossl_cmp_certreq_new(OSSL_CMP_CTX *ctx, int bodytype,
                                    const OSSL_CRMF_MSG *crm);
 OSSL_CMP_MSG *ossl_cmp_certrep_new(OSSL_CMP_CTX *ctx, int bodytype,
-                                   int certReqId, OSSL_CMP_PKISI *si,
-                                   X509 *cert, STACK_OF(X509) *chain,
-                                   STACK_OF(X509) *caPubs, int encrypted,
+                                   int certReqId, const OSSL_CMP_PKISI *si,
+                                   X509 *cert, const X509 *encryption_recip,
+                                   STACK_OF(X509) *chain, STACK_OF(X509) *caPubs,
                                    int unprotectedErrors);
 OSSL_CMP_MSG *ossl_cmp_rr_new(OSSL_CMP_CTX *ctx);
-OSSL_CMP_MSG *ossl_cmp_rp_new(OSSL_CMP_CTX *ctx, OSSL_CMP_PKISI *si,
-                              OSSL_CRMF_CERTID *certId, int unprot_err);
+OSSL_CMP_MSG *ossl_cmp_rp_new(OSSL_CMP_CTX *ctx, const OSSL_CMP_PKISI *si,
+                              const OSSL_CRMF_CERTID *cid,
+                              int unprotectedErrors);
 OSSL_CMP_MSG *ossl_cmp_pkiconf_new(OSSL_CMP_CTX *ctx);
 OSSL_CMP_MSG *ossl_cmp_pollRep_new(OSSL_CMP_CTX *ctx, int crid,
                                    int64_t poll_after);
@@ -880,9 +881,9 @@ int ossl_cmp_msg_gen_push1_ITAVs(OSSL_CMP_MSG *msg,
 OSSL_CMP_MSG *ossl_cmp_genm_new(OSSL_CMP_CTX *ctx);
 OSSL_CMP_MSG *ossl_cmp_genp_new(OSSL_CMP_CTX *ctx,
                                 const STACK_OF(OSSL_CMP_ITAV) *itavs);
-OSSL_CMP_MSG *ossl_cmp_error_new(OSSL_CMP_CTX *ctx, OSSL_CMP_PKISI *si,
-                                 int errorCode,
-                                 const char *details, int unprotected);
+OSSL_CMP_MSG *ossl_cmp_error_new(OSSL_CMP_CTX *ctx, const OSSL_CMP_PKISI *si,
+                                 int errorCode, const char *details,
+                                 int unprotected);
 int ossl_cmp_certstatus_set0_certHash(OSSL_CMP_CERTSTATUS *certStatus,
                                       ASN1_OCTET_STRING *hash);
 OSSL_CMP_MSG *ossl_cmp_certConf_new(OSSL_CMP_CTX *ctx, int fail_info,

--- a/crypto/cmp/cmp_msg.c
+++ b/crypto/cmp/cmp_msg.c
@@ -454,9 +454,9 @@ OSSL_CMP_MSG *ossl_cmp_certreq_new(OSSL_CMP_CTX *ctx, int type,
 }
 
 OSSL_CMP_MSG *ossl_cmp_certrep_new(OSSL_CMP_CTX *ctx, int bodytype,
-                                   int certReqId, OSSL_CMP_PKISI *si,
-                                   X509 *cert, STACK_OF(X509) *chain,
-                                   STACK_OF(X509) *caPubs, int encrypted,
+                                   int certReqId, const OSSL_CMP_PKISI *si,
+                                   X509 *cert, const X509 *encryption_recip,
+                                   STACK_OF(X509) *chain, STACK_OF(X509) *caPubs,
                                    int unprotectedErrors)
 {
     OSSL_CMP_MSG *msg = NULL;
@@ -486,8 +486,8 @@ OSSL_CMP_MSG *ossl_cmp_certrep_new(OSSL_CMP_CTX *ctx, int bodytype,
     status = ossl_cmp_pkisi_get_status(resp->status);
     if (status != OSSL_CMP_PKISTATUS_rejection
             && status != OSSL_CMP_PKISTATUS_waiting && cert != NULL) {
-        if (encrypted) {
-            ERR_raise(ERR_LIB_CMP, CMP_R_INVALID_ARGS);
+        if (encryption_recip != NULL) {
+            ERR_raise(ERR_LIB_CMP, ERR_R_UNSUPPORTED);
             goto err;
         }
 
@@ -579,8 +579,8 @@ OSSL_CMP_MSG *ossl_cmp_rr_new(OSSL_CMP_CTX *ctx)
     return NULL;
 }
 
-OSSL_CMP_MSG *ossl_cmp_rp_new(OSSL_CMP_CTX *ctx, OSSL_CMP_PKISI *si,
-                              OSSL_CRMF_CERTID *cid, int unprot_err)
+OSSL_CMP_MSG *ossl_cmp_rp_new(OSSL_CMP_CTX *ctx, const OSSL_CMP_PKISI *si,
+                              const OSSL_CRMF_CERTID *cid, int unprotectedErrors)
 {
     OSSL_CMP_REVREPCONTENT *rep = NULL;
     OSSL_CMP_PKISI *si1 = NULL;
@@ -613,7 +613,7 @@ OSSL_CMP_MSG *ossl_cmp_rp_new(OSSL_CMP_CTX *ctx, OSSL_CMP_PKISI *si,
         }
     }
 
-    if (!unprot_err
+    if (!unprotectedErrors
             || ossl_cmp_pkisi_get_status(si) != OSSL_CMP_PKISTATUS_rejection)
         if (!ossl_cmp_msg_protect(ctx, msg))
             goto err;
@@ -726,9 +726,9 @@ OSSL_CMP_MSG *ossl_cmp_genp_new(OSSL_CMP_CTX *ctx,
                    OSSL_CMP_PKIBODY_GENP, CMP_R_ERROR_CREATING_GENP);
 }
 
-OSSL_CMP_MSG *ossl_cmp_error_new(OSSL_CMP_CTX *ctx, OSSL_CMP_PKISI *si,
-                                 int errorCode,
-                                 const char *details, int unprotected)
+OSSL_CMP_MSG *ossl_cmp_error_new(OSSL_CMP_CTX *ctx, const OSSL_CMP_PKISI *si,
+                                 int errorCode, const char *details,
+                                 int unprotected)
 {
     OSSL_CMP_MSG *msg = NULL;
     OSSL_CMP_PKIFREETEXT *ft;

--- a/crypto/cmp/cmp_server.c
+++ b/crypto/cmp/cmp_server.c
@@ -226,7 +226,7 @@ static OSSL_CMP_MSG *process_cert_request(OSSL_CMP_SRV_CTX *srv_ctx,
     }
 
     msg = ossl_cmp_certrep_new(srv_ctx->ctx, bodytype, certReqId, si,
-                               certOut, chainOut, caPubs, 0 /* encrypted */,
+                               certOut, NULL /* enc */, chainOut, caPubs,
                                srv_ctx->sendUnprotectedErrors);
     if (msg == NULL)
         ERR_raise(ERR_LIB_CMP, CMP_R_ERROR_CREATING_CERTREP);

--- a/crypto/cmp/cmp_server.c
+++ b/crypto/cmp/cmp_server.c
@@ -561,7 +561,7 @@ OSSL_CMP_MSG *OSSL_CMP_SRV_process_request(OSSL_CMP_SRV_CTX *srv_ctx,
  err:
     if (rsp == NULL) {
         /* on error, try to respond with CMP error message to client */
-        const char *data = NULL;
+        const char *data = NULL, *reason = NULL;
         int flags = 0;
         unsigned long err = ERR_peek_error_data(&data, &flags);
         int fail_info = 1 << OSSL_CMP_PKIFAILUREINFO_badRequest;
@@ -573,12 +573,12 @@ OSSL_CMP_MSG *OSSL_CMP_SRV_process_request(OSSL_CMP_SRV_CTX *srv_ctx,
             (void)ossl_cmp_ctx_set1_recipNonce(ctx, hdr->senderNonce);
         }
 
+        if ((flags & ERR_TXT_STRING) == 0 || *data == '\0')
+            data = NULL;
+        reason = ERR_reason_error_string(err);
         if ((si = OSSL_CMP_STATUSINFO_new(OSSL_CMP_PKISTATUS_rejection,
-                                          fail_info, data)) != NULL) {
-            if (err != 0 && (flags & ERR_TXT_STRING) != 0)
-                data = ERR_reason_error_string(err);
-            rsp = ossl_cmp_error_new(srv_ctx->ctx, si,
-                                     err != 0 ? ERR_GET_REASON(err) : -1,
+                                          fail_info, reason)) != NULL) {
+            rsp = ossl_cmp_error_new(srv_ctx->ctx, si, err,
                                      data, srv_ctx->sendUnprotectedErrors);
             OSSL_CMP_PKISI_free(si);
         }

--- a/doc/internal/man3/ossl_cmp_certreq_new.pod
+++ b/doc/internal/man3/ossl_cmp_certreq_new.pod
@@ -17,46 +17,19 @@ ossl_cmp_error_new
 
 =head1 SYNOPSIS
 
- #include <openssl/cmp.h>
-
-# define OSSL_CMP_PKIBODY_IR        0
-# define OSSL_CMP_PKIBODY_IP        1
-# define OSSL_CMP_PKIBODY_CR        2
-# define OSSL_CMP_PKIBODY_CP        3
-# define OSSL_CMP_PKIBODY_P10CR     4
-# define OSSL_CMP_PKIBODY_POPDECC   5
-# define OSSL_CMP_PKIBODY_POPDECR   6
-# define OSSL_CMP_PKIBODY_KUR       7
-# define OSSL_CMP_PKIBODY_KUP       8
-# define OSSL_CMP_PKIBODY_KRR       9
-# define OSSL_CMP_PKIBODY_KRP      10
-# define OSSL_CMP_PKIBODY_RR       11
-# define OSSL_CMP_PKIBODY_RP       12
-# define OSSL_CMP_PKIBODY_CCR      13
-# define OSSL_CMP_PKIBODY_CCP      14
-# define OSSL_CMP_PKIBODY_CKUANN   15
-# define OSSL_CMP_PKIBODY_CANN     16
-# define OSSL_CMP_PKIBODY_RANN     17
-# define OSSL_CMP_PKIBODY_CRLANN   18
-# define OSSL_CMP_PKIBODY_PKICONF  19
-# define OSSL_CMP_PKIBODY_NESTED   20
-# define OSSL_CMP_PKIBODY_GENM     21
-# define OSSL_CMP_PKIBODY_GENP     22
-# define OSSL_CMP_PKIBODY_ERROR    23
-# define OSSL_CMP_PKIBODY_CERTCONF 24
-# define OSSL_CMP_PKIBODY_POLLREQ  25
-# define OSSL_CMP_PKIBODY_POLLREP  26
+ #include "cmp_local.h"
 
  OSSL_ossl_cmp_MSG *ossl_cmp_certreq_new(OSSL_CMP_CTX *ctx, int bodytype,
                                          const OSSL_CRMF_MSG *crm);
  OSSL_CMP_MSG *ossl_cmp_certrep_new(OSSL_CMP_CTX *ctx, int bodytype,
-                                    int certReqId, OSSL_CMP_PKISI *si,
-                                    X509 *cert, STACK_OF(X509) *chain,
-                                    STACK_OF(X509) *caPubs,
-                                    int encrypted, int unprotectedErrors);
+                                    int certReqId, const OSSL_CMP_PKISI *si,
+                                    X509 *cert, const X509 *encryption_recip,
+                                    STACK_OF(X509) *chain, STACK_OF(X509) *caPubs,
+                                    int unprotectedErrors);
  OSSL_CMP_MSG *ossl_cmp_rr_new(OSSL_CMP_CTX *ctx);
- OSSL_CMP_MSG *ossl_cmp_rp_new(OSSL_CMP_CTX *ctx, OSSL_CMP_PKISI *si,
-                               OSSL_CRMF_CERTID *cid, int unprot_err);
+ OSSL_CMP_MSG *ossl_cmp_rp_new(OSSL_CMP_CTX *ctx, const OSSL_CMP_PKISI *si,
+                               const OSSL_CRMF_CERTID *cid,
+                               int unprotectedErrors);
  OSSL_CMP_MSG *ossl_cmp_certConf_new(OSSL_CMP_CTX *ctx, int fail_info,
                                      const char *text);
  OSSL_CMP_MSG *ossl_cmp_pkiconf_new(OSSL_CMP_CTX *ctx);
@@ -64,23 +37,23 @@ ossl_cmp_error_new
  OSSL_CMP_MSG *ossl_cmp_pollRep_new(OSSL_CMP_CTX *ctx, int crid, int poll_after);
  OSSL_CMP_MSG *ossl_cmp_genm_new(OSSL_CMP_CTX *ctx);
  OSSL_CMP_MSG *ossl_cmp_genp_new(OSSL_CMP_CTX *ctx);
- OSSL_CMP_MSG *ossl_cmp_error_new(OSSL_CMP_CTX *ctx, OSSL_CMP_PKISI *si,
-                                  int errorCode,
-                                  OSSL_CMP_PKIFREETEXT *errorDetails,
+ OSSL_CMP_MSG *ossl_cmp_error_new(OSSL_CMP_CTX *ctx, const OSSL_CMP_PKISI *si,
+                                  int errorCode, const char *details,
                                   int unprotected);
 
 =head1 DESCRIPTION
 
-This is the API for creating various CMP PKIMESSAGES. The
-functions allocate a new message, fill it with the relevant data derived from
-the given OSSL_CMP_CTX, and create the applicable protection.
+This is the internal API for creating various CMP PKIMESSAGES.
+All functions are based on L<ossl_cmp_msg_create(3)>.
+The allocate a new message, fill it with the relevant data derived from
+the given B<OSSL_CMP_CTX>, and create the applicable protection.
 
 ossl_cmp_certreq_new() creates a PKIMessage for requesting a certificate,
-which can be either of IR/CR/KUR/P10CR, depending on the given B<bodytype>.
-The CRMF message to use may be given via the B<crm> argument;
-else (if B<crm> is NULL) it is created from the information in the B<ctx>.
+which can be either of IR/CR/KUR/P10CR, depending on the given I<bodytype>.
+The CRMF message to use may be given explicitly via a non-NULL I<crm> argument,
+otherwise it is created from the information in the I<ctx>.
 
-Available CMP certificate request PKIMessage B<bodytype>s are:
+Available CMP certificate request PKIMessage I<bodytype>s are:
 
 =over 4
 
@@ -94,10 +67,16 @@ Available CMP certificate request PKIMessage B<bodytype>s are:
 
 =back
 
-ossl_cmp_certrep_new() creates a PKIMessage for certificate response, which can
-be either of IP/CP/KUP, depending on the given B<bodytype>.
+ossl_cmp_certrep_new() creates a PKIMessage for certificate response,
+which can be either of IP/CP/KUP, depending on the given I<bodytype>,
+with the given I<certReqId> and I<si> values and optionally with I<cert>,
+I<chain>, and I<caPubs>. The I<cert>, I<chain>, and I<caPubs> arguments
+are not consumed if present but their internal reference counter is increased.
+The I<encryption_recip> is currently unsupported.
+The function does not protect the message if the B<status> value in I<si>
+is B<rejected> and I<unprotectedErrors> is nonzero.
 
-Available CMP certificate response PKIMessage B<bodytype>s are:
+Available CMP certificate response PKIMessage I<bodytype>s are:
 
 =over 4
 
@@ -109,7 +88,7 @@ Available CMP certificate response PKIMessage B<bodytype>s are:
 
 =back
 
-The list of all CMP PKIMessage B<bodytype>s is:
+The list of all CMP PKIMessage I<bodytype>s is:
 
  #define OSSL_CMP_PKIBODY_IR        0
  #define OSSL_CMP_PKIBODY_IP        1
@@ -140,29 +119,30 @@ The list of all CMP PKIMessage B<bodytype>s is:
 ossl_cmp_rr_new() creates a Revocation Request message from the
 information set via OSSL_CMP_CTX_set1_oldClCert().
 
-ossl_cmp_rp_new() creates a Revocation Response message with status set to
-B<si> and CertID set to B<cid>. Consumes B<cid>.
-Accepts unprotected errors if B<uprot_err> != 0.
+ossl_cmp_rp_new() creates a Revocation Response message with I<si> and I<cid>.
+It does not protect the message if the B<status> value in I<si> is B<rejected>
+and I<unprotectedErrors> is nonzero.
 
 ossl_cmp_certConf_new() creates a Certificate Confirmation message for the last
-received certificate. PKIStatus defaults to B<accepted> if the B<fail_info> bit
+received certificate. PKIStatus defaults to B<accepted> if the I<fail_info> bit
 field is 0. Else it is taken as the failInfo of the PKIStatusInfo, PKIStatus is
-set to B<rejected>, and B<text> is copied to statusString unless it is NULL.
+set to B<rejected>, and I<text> is copied to statusString unless it is NULL.
 
 ossl_cmp_pkiconf_new() creates a PKI Confirmation message.
 
 ossl_cmp_pollReq_new() creates a Polling Request message with certReqId set to
-B<crid>.
+I<crid>.
 
 ossl_cmp_pollRep_new() creates a Polling Response message with certReqId set to
-B<crid> and pollAfter to B<poll_after>.
+I<crid> and pollAfter to I<poll_after>.
 
 ossl_cmp_genm_new() creates a new General Message with an empty ITAV stack.
 
 ossl_cmp_genp_new() creates a new General Response with an empty ITAV stack.
 
-ossl_cmp_error_new() creates a new Error Message with the given contents,
-copying B<si> and B<errorDetails>.
+ossl_cmp_error_new() creates a new Error Message with the given contents
+with the given I<si>, I<errorCode> (if nonnegative), and optional I<details>.
+It does not protect the message if I<unprotectedErrors> is nonzero.
 
 =head1 NOTES
 
@@ -175,6 +155,7 @@ the generated message on success, or NULL on error.
 
 =head1 SEE ALSO
 
+L<ossl_cmp_msg_create(3)>,
 L<OSSL_CMP_CTX_new(3)>, L<ERR_load_strings(3)>
 
 =head1 HISTORY

--- a/doc/internal/man3/ossl_cmp_certreq_new.pod
+++ b/doc/internal/man3/ossl_cmp_certreq_new.pod
@@ -142,8 +142,8 @@ ossl_cmp_genp_new() creates a new General Response with an empty ITAV stack.
 
 ossl_cmp_error_new() creates a new Error Message with the given contents
 I<si>, I<errorCode>, and optional I<details>.
-If I<errorCode> is positive and in the range of an OpenSSL error code, the
-respective library and reason strings are included in the B<errorDetails> field.
+If I<errorCode> is positive and in the range of an OpenSSL error code,
+the library and reason strings are included in the B<errorDetails> field.
 If given, the I<details> are added to the contents of the B<errorDetails> field.
 The function does not protect the message if I<unprotectedErrors> is nonzero.
 

--- a/doc/internal/man3/ossl_cmp_certreq_new.pod
+++ b/doc/internal/man3/ossl_cmp_certreq_new.pod
@@ -38,7 +38,7 @@ ossl_cmp_error_new
  OSSL_CMP_MSG *ossl_cmp_genm_new(OSSL_CMP_CTX *ctx);
  OSSL_CMP_MSG *ossl_cmp_genp_new(OSSL_CMP_CTX *ctx);
  OSSL_CMP_MSG *ossl_cmp_error_new(OSSL_CMP_CTX *ctx, const OSSL_CMP_PKISI *si,
-                                  int errorCode, const char *details,
+                                  int64_t errorCode, const char *details,
                                   int unprotected);
 
 =head1 DESCRIPTION
@@ -141,8 +141,11 @@ ossl_cmp_genm_new() creates a new General Message with an empty ITAV stack.
 ossl_cmp_genp_new() creates a new General Response with an empty ITAV stack.
 
 ossl_cmp_error_new() creates a new Error Message with the given contents
-with the given I<si>, I<errorCode> (if nonnegative), and optional I<details>.
-It does not protect the message if I<unprotectedErrors> is nonzero.
+I<si>, I<errorCode>, and optional I<details>.
+If I<errorCode> is positive and in the range of an OpenSSL error code, the
+respective library and reason strings are included in the B<errorDetails> field.
+If given, the I<details> are added to the contents of the B<errorDetails> field.
+The function does not protect the message if I<unprotectedErrors> is nonzero.
 
 =head1 NOTES
 

--- a/doc/internal/man3/ossl_cmp_hdr_init.pod
+++ b/doc/internal/man3/ossl_cmp_hdr_init.pod
@@ -17,8 +17,9 @@ ossl_cmp_hdr_generalinfo_item_push0,
 ossl_cmp_hdr_generalinfo_items_push1,
 ossl_cmp_hdr_set_implicitConfirm,
 ossl_cmp_hdr_has_implicitConfirm,
+ossl_cmp_hdr_set_transactionID,
 ossl_cmp_hdr_init
-- functions manipulating CMP message headers
+- functions handling CMP message headers
 
 =head1 SYNOPSIS
 
@@ -46,6 +47,7 @@ ossl_cmp_hdr_init
                                   ASN1_UTF8STRING *text);
   int ossl_cmp_hdr_set_implicitConfirm(OSSL_CMP_PKIHEADER *hdr);
   int ossl_cmp_hdr_has_implicitConfirm(OSSL_CMP_PKIHEADER *hdr);
+  int ossl_cmp_hdr_set_transactionID(OSSL_CMP_CTX *ctx, OSSL_CMP_PKIHEADER *hdr);
   int ossl_cmp_hdr_init(OSSL_CMP_CTX *ctx, OSSL_CMP_PKIHEADER *hdr);
 
 =head1 DESCRIPTION
@@ -98,6 +100,10 @@ of the PKIMessage header.
 ossl_cmp_hdr_has_implicitConfirm() returns 1 if implicitConfirm is
 set int generalInfo field of the given PKIMessage header, 0 if not.
 
+ossl_cmp_hdr_set_transactionID() sets the B<transactionID> field in C<hdr>.
+In case ctx->transactionID is NULL, it starts a new transaction
+by creating and storing a new random valuee with 128 bits length.
+
 ossl_cmp_hdr_init() initializes a PKIHeader structure based on the
 values in the given OSSL_CMP_CTX structure.
 This starts a new transaction in case ctx->transactionID is NULL.
@@ -124,6 +130,10 @@ ossl_cmp_general_name_is_NULL_DN() returns 1 given a NULL-DN, else 0.
 All other functions return 1 on success, 0 on error.
 
 See the individual functions above.
+
+=head1 SEE ALSO
+
+L<ossl_cmp_msg_create(3)>
 
 =head1 HISTORY
 

--- a/doc/internal/man3/ossl_cmp_msg_create.pod
+++ b/doc/internal/man3/ossl_cmp_msg_create.pod
@@ -2,17 +2,72 @@
 
 =head1 NAME
 
+OSSL_CMP_PKIBODY_IR,
+OSSL_CMP_PKIBODY_IP,
+OSSL_CMP_PKIBODY_CR,
+OSSL_CMP_PKIBODY_CP,
+OSSL_CMP_PKIBODY_P10CR,
+OSSL_CMP_PKIBODY_POPDECC,
+OSSL_CMP_PKIBODY_POPDECR,
+OSSL_CMP_PKIBODY_KUR,
+OSSL_CMP_PKIBODY_KUP,
+OSSL_CMP_PKIBODY_KRR,
+OSSL_CMP_PKIBODY_KRP,
+OSSL_CMP_PKIBODY_RR,
+OSSL_CMP_PKIBODY_RP,
+OSSL_CMP_PKIBODY_CCR,
+OSSL_CMP_PKIBODY_CCP,
+OSSL_CMP_PKIBODY_CKUANN,
+OSSL_CMP_PKIBODY_CANN,
+OSSL_CMP_PKIBODY_RANN,
+OSSL_CMP_PKIBODY_CRLANN,
+OSSL_CMP_PKIBODY_PKICONF,
+OSSL_CMP_PKIBODY_NESTED,
+OSSL_CMP_PKIBODY_GENM,
+OSSL_CMP_PKIBODY_GENP,
+OSSL_CMP_PKIBODY_ERROR,
+OSSL_CMP_PKIBODY_CERTCONF,
+OSSL_CMP_PKIBODY_POLLREQ,
+OSSL_CMP_PKIBODY_POLLREP,
 ossl_cmp_bodytype_to_string,
 ossl_cmp_msg_get_bodytype,
 ossl_cmp_msg_set_bodytype,
 ossl_cmp_msg_create,
 ossl_cmp_msg_gen_ITAV_push0,
 ossl_cmp_msg_gen_ITAVs_push1
-- functions manipulating CMP messages
+- functions handling CMP messages
 
 =head1 SYNOPSIS
 
-  #include "cmp_local.h"
+ #include "cmp_local.h"
+
+ #define OSSL_CMP_PKIBODY_IR        0
+ #define OSSL_CMP_PKIBODY_IP        1
+ #define OSSL_CMP_PKIBODY_CR        2
+ #define OSSL_CMP_PKIBODY_CP        3
+ #define OSSL_CMP_PKIBODY_P10CR     4
+ #define OSSL_CMP_PKIBODY_POPDECC   5
+ #define OSSL_CMP_PKIBODY_POPDECR   6
+ #define OSSL_CMP_PKIBODY_KUR       7
+ #define OSSL_CMP_PKIBODY_KUP       8
+ #define OSSL_CMP_PKIBODY_KRR       9
+ #define OSSL_CMP_PKIBODY_KRP      10
+ #define OSSL_CMP_PKIBODY_RR       11
+ #define OSSL_CMP_PKIBODY_RP       12
+ #define OSSL_CMP_PKIBODY_CCR      13
+ #define OSSL_CMP_PKIBODY_CCP      14
+ #define OSSL_CMP_PKIBODY_CKUANN   15
+ #define OSSL_CMP_PKIBODY_CANN     16
+ #define OSSL_CMP_PKIBODY_RANN     17
+ #define OSSL_CMP_PKIBODY_CRLANN   18
+ #define OSSL_CMP_PKIBODY_PKICONF  19
+ #define OSSL_CMP_PKIBODY_NESTED   20
+ #define OSSL_CMP_PKIBODY_GENM     21
+ #define OSSL_CMP_PKIBODY_GENP     22
+ #define OSSL_CMP_PKIBODY_ERROR    23
+ #define OSSL_CMP_PKIBODY_CERTCONF 24
+ #define OSSL_CMP_PKIBODY_POLLREQ  25
+ #define OSSL_CMP_PKIBODY_POLLREP  26
 
   const char *ossl_cmp_bodytype_to_string(int type);
   int ossl_cmp_msg_get_bodytype(const OSSL_CMP_MSG *msg);
@@ -34,9 +89,12 @@ ossl_cmp_msg_set_bodytype() sets the type of the message contained in
 the PKIMessage body field.
 Returns 1 on success, 0 on error.
 
-ossl_cmp_msg_create() creates and initializes a OSSL_CMP_MSG structure,
-using B<ctx> for the header and B<bodytype> for the body.
-Returns pointer to created OSSL_CMP_MSG on success, NULL on error.
+ossl_cmp_msg_create() creates and initializes an B<OSSL_CMP_MSG> structure,
+using fields of B<ctx> for the header and B<bodytype> for the body.
+If the current B<transactionID> field in I<ctx> indicates that there is no
+current transaction, it creates and stores random one with 128 bits length.
+Thus the I<ctx> may be modified by this and related ossl_cmp_*_new() functions.
+Returns pointer to created B<OSSL_CMP_MSG> on success, NULL on error.
 
 ossl_cmp_msg_gen_ITAV_push0() pushes the B<itav> to the body of the
 PKIMessage B<msg> of GenMsg or GenRep type. Consumes the B<itavs> pointer.
@@ -57,6 +115,7 @@ See the individual functions above.
 
 =head1 SEE ALSO
 
+L<ossl_cmp_hdr_init(3)>,
 L<OSSL_CMP_CTX_new(3)>, L<OSSL_CMP_exec_certreq(3)>
 
 =head1 HISTORY

--- a/doc/internal/man3/ossl_cmp_msg_create.pod
+++ b/doc/internal/man3/ossl_cmp_msg_create.pod
@@ -92,8 +92,8 @@ Returns 1 on success, 0 on error.
 ossl_cmp_msg_create() creates and initializes an B<OSSL_CMP_MSG> structure,
 using fields of B<ctx> for the header and B<bodytype> for the body.
 If the current B<transactionID> field in I<ctx> indicates that there is no
-current transaction, it creates and stores random one with 128 bits length.
-Thus the I<ctx> may be modified by this and related ossl_cmp_*_new() functions.
+current transaction, it creates and stores a random one with 128 bits length.
+Thus, the I<ctx> may be modified by this and related ossl_cmp_*_new() functions.
 Returns pointer to created B<OSSL_CMP_MSG> on success, NULL on error.
 
 ossl_cmp_msg_gen_ITAV_push0() pushes the B<itav> to the body of the

--- a/test/cmp_server_test.c
+++ b/test/cmp_server_test.c
@@ -98,7 +98,7 @@ static int execute_test_handle_request(CMP_SRV_TEST_FIXTURE *fixture)
                             OSSL_CMP_PKIBODY_ERROR)
             || !TEST_ptr(errorContent = rsp->body->value.error)
             || !TEST_int_eq(ASN1_INTEGER_get(errorContent->errorCode),
-                            dummy_errorCode))
+                            ERR_PACK(ERR_LIB_CMP, 0, dummy_errorCode)))
         goto end;
 
     res = 1;


### PR DESCRIPTION
While re-working #15790 and testing the new check I found that 
* there were some minor bugs in reporting error reason codes via CMP `error` messages
* the internal CMP message creation API and its documentation deserved some cleanup and corrections

This PR fixes both, and enhances the related internal function `ossl_sk_ASN1_UTF8STRING2text()`.

- [x] documentation is added or updated
- [x] tests are added or updated
