### PR TITLE
Replace `unsigned int *` by `size_t *` in `EVP_Q_{digest,mac}()` outlen parameter

### DIFF
--- a/apps/lib/s_cb.c
+++ b/apps/lib/s_cb.c
@@ -740,8 +740,8 @@ void tlsext_cb(SSL *s, int client_server, int type,
 }
 
 #ifndef OPENSSL_NO_SOCK
-int generate_cookie_callback(SSL *ssl, unsigned char *cookie,
-                             unsigned int *cookie_len)
+int generate_stateless_cookie_callback(SSL *ssl, unsigned char *cookie,
+                                       size_t *cookie_len)
 {
     unsigned char *buffer = NULL;
     size_t length = 0;
@@ -800,8 +800,8 @@ end:
     return res;
 }
 
-int verify_cookie_callback(SSL *ssl, const unsigned char *cookie,
-                           unsigned int cookie_len)
+int verify_stateless_cookie_callback(SSL *ssl, const unsigned char *cookie,
+                                     size_t cookie_len)
 {
     unsigned char result[EVP_MAX_MD_SIZE];
     unsigned int resultlength;
@@ -817,20 +817,20 @@ int verify_cookie_callback(SSL *ssl, const unsigned char *cookie,
     return 0;
 }
 
-int generate_stateless_cookie_callback(SSL *ssl, unsigned char *cookie,
-                                       size_t *cookie_len)
+int generate_cookie_callback(SSL *ssl, unsigned char *cookie,
+                             unsigned int *cookie_len)
 {
-    unsigned int temp = 0;
+    size_t temp = 0;
 
-    int res = generate_cookie_callback(ssl, cookie, &temp);
+    int res = generate_stateless_cookie_callback(ssl, cookie, &temp);
     *cookie_len = temp;
     return res;
 }
 
-int verify_stateless_cookie_callback(SSL *ssl, const unsigned char *cookie,
-                                     size_t cookie_len)
+int verify_cookie_callback(SSL *ssl, const unsigned char *cookie,
+                           unsigned int cookie_len)
 {
-    return verify_cookie_callback(ssl, cookie, cookie_len);
+    return verify_stateless_cookie_callback(ssl, cookie, cookie_len);
 }
 
 #endif

--- a/crypto/crmf/crmf_pbm.c
+++ b/crypto/crmf/crmf_pbm.c
@@ -140,7 +140,6 @@ int OSSL_CRMF_pbm_new(OSSL_LIB_CTX *libctx, const char *propq,
     unsigned int bklen = EVP_MAX_MD_SIZE;
     int64_t iterations;
     unsigned char *mac_res = 0;
-    unsigned int maclen;
     int ok = 0;
 
     if (out == NULL || pbmp == NULL || pbmp->mac == NULL
@@ -207,10 +206,9 @@ int OSSL_CRMF_pbm_new(OSSL_LIB_CTX *libctx, const char *propq,
         goto err;
     }
     if (EVP_Q_mac(libctx, "HMAC", propq, hmac_mdname, NULL, basekey, bklen,
-                  msg, msglen, mac_res, EVP_MAX_MD_SIZE, &maclen) == NULL)
+                  msg, msglen, mac_res, EVP_MAX_MD_SIZE, outlen) == NULL)
         goto err;
 
-    *outlen = (size_t)maclen;
     ok = 1;
 
  err:

--- a/crypto/evp/digest.c
+++ b/crypto/evp/digest.c
@@ -631,13 +631,16 @@ int EVP_Digest(const void *data, size_t count,
 
 int EVP_Q_digest(OSSL_LIB_CTX *libctx, const char *name, const char *propq,
                  const void *data, size_t count,
-                 unsigned char *md, unsigned int *size)
+                 unsigned char *md, size_t *size)
 {
     EVP_MD *digest = EVP_MD_fetch(libctx, name, propq);
+    unsigned int uint_size;
     int ret = 0;
 
     if (digest != NULL) {
-        ret = EVP_Digest(data, count, md, size, digest, NULL);
+        ret = EVP_Digest(data, count, md, &uint_size, digest, NULL);
+        if (size != NULL)
+            *size = uint_size;
         EVP_MD_free(digest);
     }
     return ret;

--- a/crypto/evp/mac_lib.c
+++ b/crypto/evp/mac_lib.c
@@ -237,7 +237,7 @@ unsigned char *EVP_Q_mac(OSSL_LIB_CTX *libctx, const char *name, const char *pro
                          const char *subalg, const OSSL_PARAM *params,
                          const void *key, size_t keylen,
                          const unsigned char *data, size_t datalen,
-                         unsigned char *out, size_t outsize, unsigned int *outlen)
+                         unsigned char *out, size_t outsize, size_t *outlen)
 {
     EVP_MAC *mac = EVP_MAC_fetch(libctx, name, propq);
     OSSL_PARAM subalg_param[] = { OSSL_PARAM_END, OSSL_PARAM_END };
@@ -286,7 +286,7 @@ unsigned char *EVP_Q_mac(OSSL_LIB_CTX *libctx, const char *name, const char *pro
         }
         res = out;
         if (res != NULL && outlen != NULL)
-            *outlen = (unsigned int)len;
+            *outlen = len;
     }
 
  err:

--- a/crypto/hmac/hmac.c
+++ b/crypto/hmac/hmac.c
@@ -224,12 +224,17 @@ unsigned char *HMAC(const EVP_MD *evp_md, const void *key, int key_len,
 {
     static unsigned char static_md[EVP_MAX_MD_SIZE];
     int size = EVP_MD_get_size(evp_md);
+    size_t outlen;
+    unsigned char *res;
 
     if (size < 0)
         return NULL;
-    return EVP_Q_mac(NULL, "HMAC", NULL, EVP_MD_get0_name(evp_md), NULL,
-                     key, key_len, data, data_len,
-                     md == NULL ? static_md : md, size, md_len);
+    res = EVP_Q_mac(NULL, "HMAC", NULL, EVP_MD_get0_name(evp_md), NULL,
+                    key, key_len, data, data_len,
+                    md == NULL ? static_md : md, size, &outlen);
+    if (md_len != NULL)
+        *md_len = (unsigned int)outlen;
+    return res;
 }
 
 void HMAC_CTX_set_flags(HMAC_CTX *ctx, unsigned long flags)

--- a/doc/man3/EVP_DigestInit.pod
+++ b/doc/man3/EVP_DigestInit.pod
@@ -53,7 +53,7 @@ EVP_MD_CTX_type, EVP_MD_CTX_pkey_ctx, EVP_MD_CTX_md_data
 
  int EVP_Q_digest(OSSL_LIB_CTX *libctx, const char *name, const char *propq,
                   const void *data, size_t count,
-                  unsigned char *md, unsigned int *size);
+                  unsigned char *md, size_t *size);
  int EVP_Digest(const void *data, size_t count, unsigned char *md,
                 unsigned int *size, const EVP_MD *type, ENGINE *impl);
  int EVP_DigestInit_ex2(EVP_MD_CTX *ctx, const EVP_MD *type,

--- a/doc/man3/EVP_MAC.pod
+++ b/doc/man3/EVP_MAC.pod
@@ -46,7 +46,7 @@ EVP_MAC_do_all_provided - EVP MAC routines
                           const char *subalg, const OSSL_PARAM *params,
                           const void *key, size_t keylen,
                           const unsigned char *data, size_t datalen,
-                          unsigned char *out, size_t outsize, unsigned int *outlen);
+                          unsigned char *out, size_t outsize, size_t *outlen);
  int EVP_MAC_init(EVP_MAC_CTX *ctx, const unsigned char *key, size_t keylen,
                   const OSSL_PARAM params[]);
  int EVP_MAC_update(EVP_MAC_CTX *ctx, const unsigned char *data, size_t datalen);

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -716,7 +716,7 @@ __owur int EVP_Digest(const void *data, size_t count,
                           const EVP_MD *type, ENGINE *impl);
 __owur int EVP_Q_digest(OSSL_LIB_CTX *libctx, const char *name,
                         const char *propq, const void *data, size_t count,
-                        unsigned char *md, unsigned int *size);
+                        unsigned char *md, size_t *size);
 
 __owur int EVP_MD_CTX_copy(EVP_MD_CTX *out, const EVP_MD_CTX *in);
 __owur int EVP_DigestInit(EVP_MD_CTX *ctx, const EVP_MD *type);

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -1216,7 +1216,7 @@ unsigned char *EVP_Q_mac(OSSL_LIB_CTX *libctx, const char *name, const char *pro
                          const char *subalg, const OSSL_PARAM *params,
                          const void *key, size_t keylen,
                          const unsigned char *data, size_t datalen,
-                         unsigned char *out, size_t outsize, unsigned int *outlen);
+                         unsigned char *out, size_t outsize, size_t *outlen);
 int EVP_MAC_init(EVP_MAC_CTX *ctx, const unsigned char *key, size_t keylen,
                  const OSSL_PARAM params[]);
 int EVP_MAC_update(EVP_MAC_CTX *ctx, const unsigned char *data, size_t datalen);

--- a/ssl/tls13_enc.c
+++ b/ssl/tls13_enc.c
@@ -309,7 +309,6 @@ size_t tls13_final_finish_mac(SSL *s, const char *str, size_t slen,
     unsigned char hash[EVP_MAX_MD_SIZE];
     unsigned char finsecret[EVP_MAX_MD_SIZE];
     unsigned char *key = NULL;
-    unsigned int len = 0;
     size_t hashlen, ret = 0;
     OSSL_PARAM params[2], *p = params;
 
@@ -340,12 +339,11 @@ size_t tls13_final_finish_mac(SSL *s, const char *str, size_t slen,
     if (!EVP_Q_mac(s->ctx->libctx, "HMAC", s->ctx->propq, mdname,
                    params, key, hashlen, hash, hashlen,
                    /* outsize as per sizeof(peer_finish_md) */
-                   out, EVP_MAX_MD_SIZE * 2, &len)) {
+                   out, EVP_MAX_MD_SIZE * 2, &ret)) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
         goto err;
     }
 
-    ret = len;
  err:
     OPENSSL_cleanse(finsecret, sizeof(finsecret));
     return ret;


### PR DESCRIPTION
As discussed in OTC meeting on Tuesday.

Fixes #15839.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
