### PR TITLE
Defined out MUTEX attributes not available on NonStop SPT Threads.

### DIFF
--- a/crypto/store/store_lib.c
+++ b/crypto/store/store_lib.c
@@ -513,7 +513,7 @@ static int ossl_store_close_it(OSSL_STORE_CTX *ctx)
         ret = ctx->loader->p_close(ctx->loader_ctx);
 #ifndef OPENSSL_NO_DEPRECATED_3_0
     if (ctx->fetched_loader == NULL)
-        ret = ctx->loader->close(ctx->loader_ctx);
+        ret = ctx->loader->closefn(ctx->loader_ctx);
 #endif
 
     sk_OSSL_STORE_INFO_pop_free(ctx->cached_info, OSSL_STORE_INFO_free);

--- a/crypto/store/store_local.h
+++ b/crypto/store/store_local.h
@@ -92,7 +92,7 @@ struct ossl_store_loader_st {
     OSSL_STORE_load_fn load;
     OSSL_STORE_eof_fn eof;
     OSSL_STORE_error_fn error;
-    OSSL_STORE_close_fn close;
+    OSSL_STORE_close_fn closefn;
     OSSL_STORE_open_ex_fn open_ex;
 #endif
 

--- a/crypto/store/store_register.c
+++ b/crypto/store/store_register.c
@@ -130,7 +130,7 @@ int OSSL_STORE_LOADER_set_error(OSSL_STORE_LOADER *loader,
 int OSSL_STORE_LOADER_set_close(OSSL_STORE_LOADER *loader,
                                 OSSL_STORE_close_fn close_function)
 {
-    loader->close = close_function;
+    loader->closefn = close_function;
     return 1;
 }
 
@@ -185,7 +185,7 @@ int ossl_store_register_loader_int(OSSL_STORE_LOADER *loader)
 
     /* Check that functions we absolutely require are present */
     if (loader->open == NULL || loader->load == NULL || loader->eof == NULL
-        || loader->error == NULL || loader->close == NULL) {
+        || loader->error == NULL || loader->closefn == NULL) {
         ERR_raise(ERR_LIB_OSSL_STORE, OSSL_STORE_R_LOADER_INCOMPLETE);
         return 0;
     }
@@ -220,7 +220,7 @@ const OSSL_STORE_LOADER *ossl_store_get0_loader_int(const char *scheme)
     template.open = NULL;
     template.load = NULL;
     template.eof = NULL;
-    template.close = NULL;
+    template.closefn = NULL;
     template.open_ex = NULL;
 
     if (!RUN_ONCE(&registry_init, do_registry_init)) {
@@ -251,7 +251,7 @@ OSSL_STORE_LOADER *ossl_store_unregister_loader_int(const char *scheme)
     template.open = NULL;
     template.load = NULL;
     template.eof = NULL;
-    template.close = NULL;
+    template.closefn = NULL;
 
     if (!RUN_ONCE(&registry_init, do_registry_init)) {
         ERR_raise(ERR_LIB_OSSL_STORE, ERR_R_MALLOC_FAILURE);

--- a/crypto/threads_pthread.c
+++ b/crypto/threads_pthread.c
@@ -57,10 +57,14 @@ CRYPTO_RWLOCK *CRYPTO_THREAD_lock_new(void)
      * We don't use recursive mutexes, but try to catch errors if we do.
      */
     pthread_mutexattr_init(&attr);
-#  if !defined(NDEBUG) && !defined(OPENSSL_NO_MUTEX_ERRORCHECK)
+#  if !defined (__TANDEM) && !defined (_SPT_MODEL_)
+#   if !defined(NDEBUG) && !defined(OPENSSL_NO_MUTEX_ERRORCHECK)
     pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_ERRORCHECK);
-# else
+#   else
     pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_NORMAL);
+#   endif
+#  else
+    /* The SPT Thread Library does not define MUTEX attributes. */
 #  endif
 
     if (pthread_mutex_init(lock, &attr) != 0) {


### PR DESCRIPTION
Standard Posix Threads (SPT) Threads are an older separate branch of
pthreads that do not support some of the capabilities in the current
Posix User Threads (PUT).

Fixes #15885

Signed-off-by: Randall S. Becker <rsbecker@nexbridge.com>