### PR TITLE
OpenSSL::Util::fixup_cmd_elements(): Include '!' among the VMS chars to process

### DIFF
--- a/util/perl/OpenSSL/Util.pm
+++ b/util/perl/OpenSSL/Util.pm
@@ -154,7 +154,7 @@ sub fixup_cmd_elements {
     if ( $^O eq "VMS") {        # VMS setup
         $arg_formatter = sub {
             $_ = shift;
-            if ($_ eq '' || /\s|["[:upper:]]/) {
+            if ($_ eq '' || /\s|[!"[:upper:]]/) {
                 s/"/""/g;
                 '"'.$_.'"';
             } else {


### PR DESCRIPTION
! is the DCL character that starts a comment, and therefore acts as a
cut-off if not quoted.
