### PR TITLE
Fix `file_name_check()` in `storemgmt/file_store.c` and `e_loader_attic.c`

### DIFF
--- a/engines/e_loader_attic.c
+++ b/engines/e_loader_attic.c
@@ -9,6 +9,8 @@
 
 /* THIS ENGINE IS FOR TESTING PURPOSES ONLY. */
 
+/* This file has quite some overlap with providers/implementations/storemgmt/file_store.c */
+
 /* We need to use some engine deprecated APIs */
 #define OPENSSL_SUPPRESS_DEPRECATED
 
@@ -1449,6 +1451,7 @@ static int file_name_to_uri(OSSL_STORE_LOADER_CTX *ctx, const char *name,
 static int file_name_check(OSSL_STORE_LOADER_CTX *ctx, const char *name)
 {
     const char *p = NULL;
+    size_t len = strlen(ctx->_.dir.search_name);
 
     /* If there are no search criteria, all names are accepted */
     if (ctx->_.dir.search_name[0] == '\0')
@@ -1463,11 +1466,9 @@ static int file_name_check(OSSL_STORE_LOADER_CTX *ctx, const char *name)
     /*
      * First, check the basename
      */
-    if (strncasecmp(name, ctx->_.dir.search_name,
-                    sizeof(ctx->_.dir.search_name) - 1) != 0
-        || name[sizeof(ctx->_.dir.search_name) - 1] != '.')
+    if (strncasecmp(name, ctx->_.dir.search_name, len) != 0 || name[len] != '.')
         return 0;
-    p = &name[sizeof(ctx->_.dir.search_name)];
+    p = &name[len + 1];
 
     /*
      * Then, if the expected type is a CRL, check that the extension starts

--- a/providers/implementations/storemgmt/file_store.c
+++ b/providers/implementations/storemgmt/file_store.c
@@ -7,6 +7,8 @@
  * https://www.openssl.org/source/license.html
  */
 
+/* This file has quite some overlap with engines/e_loader_attic.c */
+
 #include "e_os.h"                /* To get strncasecmp() on Windows */
 
 #include <string.h>
@@ -577,6 +579,7 @@ static char *file_name_to_uri(struct file_ctx_st *ctx, const char *name)
 static int file_name_check(struct file_ctx_st *ctx, const char *name)
 {
     const char *p = NULL;
+    size_t len = strlen(ctx->_.dir.search_name);
 
     /* If there are no search criteria, all names are accepted */
     if (ctx->_.dir.search_name[0] == '\0')
@@ -591,11 +594,9 @@ static int file_name_check(struct file_ctx_st *ctx, const char *name)
     /*
      * First, check the basename
      */
-    if (strncasecmp(name, ctx->_.dir.search_name,
-                    sizeof(ctx->_.dir.search_name) - 1) != 0
-        || name[sizeof(ctx->_.dir.search_name) - 1] != '.')
+    if (strncasecmp(name, ctx->_.dir.search_name, len) != 0 || name[len] != '.')
         return 0;
-    p = &name[sizeof(ctx->_.dir.search_name)];
+    p = &name[len + 1];
 
     /*
      * Then, if the expected type is a CRL, check that the extension starts


### PR DESCRIPTION
Extending #15847 I spotted a bug in `file_name_check()`, which is fixed here.

BTW, there is pretty strong code overlap of `storemgmt/file_store.c` and `e_loader_attic.c`,
which makes maintenance of these files tedious and error-prone.
