### PR TITLE
Fix two typos in OSSL_trace_enabled.pod

### DIFF
--- a/doc/man3/OSSL_trace_enabled.pod
+++ b/doc/man3/OSSL_trace_enabled.pod
@@ -234,7 +234,7 @@ The macro B<OPENSSL_NO_TRACE> is defined in F<< <openssl/opensslconf.h> >>.
 
 =item *
 
-all functions are still present, bu OSSL_trace_enabled() will always
+all functions are still present, but OSSL_trace_enabled() will always
 report the categories as disabled, and all other functions will do
 nothing.
 
@@ -278,7 +278,7 @@ otherwise NULL.
 
 =head1 HISTORY
 
-The OpenSSL Tracing API was added ino OpenSSL 3.0.
+The OpenSSL Tracing API was added in OpenSSL 3.0.
 
 =head1 COPYRIGHT
 


### PR DESCRIPTION
bu -> but
ino -> in

- [x] documentation is added or updated
