### PR TITLE
Add wrap.pl to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,6 +124,7 @@ providers/common/include/prov/der_sm2.h
 /tools/c_rehash
 /tools/c_rehash.pl
 /util/shlib_wrap.sh
+/util/wrap.pl
 /tags
 /TAGS
 *.map


### PR DESCRIPTION
This file is now auto-generated from a template (wrap.pl.in). Therefore
it should be ignored by git.
