### PR TITLE
engines: Add XTS, OFB and CFB AES algorithm for use with openssl speed 

### DIFF
--- a/crypto/evp/evp_enc.c
+++ b/crypto/evp/evp_enc.c
@@ -336,7 +336,6 @@ static int evp_cipher_init_internal(EVP_CIPHER_CTX *ctx,
 
         case EVP_CIPH_CFB_MODE:
         case EVP_CIPH_OFB_MODE:
-        case EVP_CIPH_XTS_MODE:
 
             ctx->num = 0;
             /* fall-through */

--- a/crypto/evp/evp_enc.c
+++ b/crypto/evp/evp_enc.c
@@ -336,6 +336,7 @@ static int evp_cipher_init_internal(EVP_CIPHER_CTX *ctx,
 
         case EVP_CIPH_CFB_MODE:
         case EVP_CIPH_OFB_MODE:
+        case EVP_CIPH_XTS_MODE:
 
             ctx->num = 0;
             /* fall-through */

--- a/engines/e_devcrypto.c
+++ b/engines/e_devcrypto.c
@@ -142,8 +142,14 @@ static const struct cipher_data_st {
     { NID_aes_256_ctr, 16, 256 / 8, 16, EVP_CIPH_CTR_MODE, CRYPTO_AES_CTR },
 #endif
 #if 0                            /* Not yet supported */
-    { NID_aes_128_xts, 16, 128 / 8 * 2, 16, EVP_CIPH_XTS_MODE, CRYPTO_AES_XTS },
-    { NID_aes_256_xts, 16, 256 / 8 * 2, 16, EVP_CIPH_XTS_MODE, CRYPTO_AES_XTS },
+    { NID_aes_128_xts, 16, 128 / 8 * 2, 16, EVP_CIPH_XTS_MODE | EVP_CIPH_CUSTOM_IV, CRYPTO_AES_XTS },
+    { NID_aes_256_xts, 16, 256 / 8 * 2, 16, EVP_CIPH_XTS_MODE | EVP_CIPH_CUSTOM_IV, CRYPTO_AES_XTS },
+    { NID_aes_128_ofb128, 16, 128 / 8, 16, EVP_CIPH_OFB_MODE, CRYPTO_AES_OFB },
+    { NID_aes_192_ofb128, 16, 192 / 8, 16, EVP_CIPH_OFB_MODE, CRYPTO_AES_OFB },
+    { NID_aes_256_ofb128, 16, 256 / 8, 16, EVP_CIPH_OFB_MODE, CRYPTO_AES_OFB },
+    { NID_aes_128_cfb128, 16, 128 / 8, 16, EVP_CIPH_CFB_MODE, CRYPTO_AES_CFB },
+    { NID_aes_192_cfb128, 16, 192 / 8, 16, EVP_CIPH_CFB_MODE, CRYPTO_AES_CFB },
+    { NID_aes_256_cfb128, 16, 256 / 8, 16, EVP_CIPH_CFB_MODE, CRYPTO_AES_CFB },
 #endif
 #if !defined(CHECK_BSD_STYLE_MACROS) || defined(CRYPTO_AES_ECB)
     { NID_aes_128_ecb, 16, 128 / 8, 0, EVP_CIPH_ECB_MODE, CRYPTO_AES_ECB },

--- a/engines/e_devcrypto.c
+++ b/engines/e_devcrypto.c
@@ -141,7 +141,6 @@ static const struct cipher_data_st {
     { NID_aes_192_ctr, 16, 192 / 8, 16, EVP_CIPH_CTR_MODE, CRYPTO_AES_CTR },
     { NID_aes_256_ctr, 16, 256 / 8, 16, EVP_CIPH_CTR_MODE, CRYPTO_AES_CTR },
 #endif
-#if 0                            /* Not yet supported */
     { NID_aes_128_xts, 16, 128 / 8 * 2, 16, EVP_CIPH_XTS_MODE | EVP_CIPH_CUSTOM_IV, CRYPTO_AES_XTS },
     { NID_aes_256_xts, 16, 256 / 8 * 2, 16, EVP_CIPH_XTS_MODE | EVP_CIPH_CUSTOM_IV, CRYPTO_AES_XTS },
     { NID_aes_128_ofb128, 16, 128 / 8, 16, EVP_CIPH_OFB_MODE, CRYPTO_AES_OFB },
@@ -150,7 +149,6 @@ static const struct cipher_data_st {
     { NID_aes_128_cfb128, 16, 128 / 8, 16, EVP_CIPH_CFB_MODE, CRYPTO_AES_CFB },
     { NID_aes_192_cfb128, 16, 192 / 8, 16, EVP_CIPH_CFB_MODE, CRYPTO_AES_CFB },
     { NID_aes_256_cfb128, 16, 256 / 8, 16, EVP_CIPH_CFB_MODE, CRYPTO_AES_CFB },
-#endif
 #if !defined(CHECK_BSD_STYLE_MACROS) || defined(CRYPTO_AES_ECB)
     { NID_aes_128_ecb, 16, 128 / 8, 0, EVP_CIPH_ECB_MODE, CRYPTO_AES_ECB },
     { NID_aes_192_ecb, 16, 192 / 8, 0, EVP_CIPH_ECB_MODE, CRYPTO_AES_ECB },


### PR DESCRIPTION
Based on a PR for cryptodev-linux this change allows to use openssl speed
with HW accelerated XTS AES algorithms that are exposed through
cryptodev-linux.
Without this patch there is an error: EVP_CipherInit_ex failure when trying
to run openssl speed -evp AES-128-XTS when the algorithm is present with
openssl engine -c -t.

Signed-off-by: Daniel Kestrel <kestrel1974@t-online.de>

This PR requires another PR in [cryptodev-linux](https://github.com/cryptodev-linux/cryptodev-linux/pull/63).