### PR TITLE
Fix segfault in openssl x509 -modulus

### DIFF
--- a/apps/x509.c
+++ b/apps/x509.c
@@ -943,7 +943,7 @@ int x509_main(int argc, char **argv)
         } else if (i == modulus) {
             BIO_printf(out, "Modulus=");
             if (EVP_PKEY_is_a(pkey, "RSA")) {
-                BIGNUM *n;
+                BIGNUM *n = NULL;
 
                 /* Every RSA key has an 'n' */
                 EVP_PKEY_get_bn_param(pkey, "n", &n);


### PR DESCRIPTION
The command ``openssl x509 -noout -modulus -in cert.pem`` used to segfaults
sometimes because an uninitialized variable was passed to
``BN_lebin2bn``. The bug triggered an assertion in bn_expand_internal().

Fixes: https://github.com/openssl/openssl/issues/15899
Signed-off-by: Christian Heimes <christian@python.org>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
