### PR TITLE
Ensure ordinals are created during release process

### DIFF
--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -1109,6 +1109,9 @@ uninstall_image_docs:
 # is sensitive to build.info changes.
 update: generate errors ordinals generate_buildinfo
 
+release-update: generate errors renumber generate_buildinfo \
+                update-fips-checksums
+
 generate: generate_apps generate_crypto_bn generate_crypto_objects \
           generate_crypto_conf generate_crypto_asn1 generate_fuzz_oids
 
@@ -1310,6 +1313,19 @@ CRYPTOHEADERS={- join(" \\\n" . ' ' x 14,
                       fill_lines(" ", $COLUMNS - 14, sort keys %cryptoheaders)) -}
 SSLHEADERS={- join(" \\\n" . ' ' x 11,
                    fill_lines(" ", $COLUMNS - 11, sort keys %sslheaders)) -}
+
+renumber: build_generated
+	$(PERL) $(SRCDIR)/util/mknum.pl --version $(VERSION) --no-warnings \
+                --ordinals $(SRCDIR)/util/libcrypto.num \
+                --symhacks $(SRCDIR)/include/openssl/symhacks.h \
+                --renumber \
+                $(CRYPTOHEADERS)
+	$(PERL) $(SRCDIR)/util/mknum.pl --version $(VERSION) --no-warnings \
+                --ordinals $(SRCDIR)/util/libssl.num \
+                --symhacks $(SRCDIR)/include/openssl/symhacks.h \
+                --renumber \
+                $(SSLHEADERS)
+
 ordinals: build_generated
 	$(PERL) $(SRCDIR)/util/mknum.pl --version $(VERSION) --no-warnings \
                 --ordinals $(SRCDIR)/util/libcrypto.num \

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -1109,9 +1109,6 @@ uninstall_image_docs:
 # is sensitive to build.info changes.
 update: generate errors ordinals generate_buildinfo
 
-release-update: generate errors renumber generate_buildinfo \
-                update-fips-checksums
-
 generate: generate_apps generate_crypto_bn generate_crypto_objects \
           generate_crypto_conf generate_crypto_asn1 generate_fuzz_oids
 

--- a/dev/release.sh
+++ b/dev/release.sh
@@ -321,9 +321,7 @@ echo "== Configuring OpenSSL for update and release.  This may take a bit of tim
 
 $VERBOSE "== Checking source file updates and fips checksums"
 
-make update >&42
-
-make update-fips-checksums >&42
+make release-update >&42
 
 if [ -n "$(git status --porcelain)" ]; then
     $VERBOSE "== Committing updates"

--- a/dev/release.sh
+++ b/dev/release.sh
@@ -321,7 +321,14 @@ echo "== Configuring OpenSSL for update and release.  This may take a bit of tim
 
 $VERBOSE "== Checking source file updates and fips checksums"
 
-make release-update >&42
+make update >&42
+# As long as we're doing an alpha release, we can have symbols without specific
+# numbers assigned. In a beta or final release, all symbols MUST have an
+# assigned number.
+if [ "$next_method" != 'alpha' ]; then
+    make renumber >&42
+fi
+make update-fips-checksums >&42
 
 if [ -n "$(git status --porcelain)" ]; then
     $VERBOSE "== Committing updates"

--- a/util/mknum.pl
+++ b/util/mknum.pl
@@ -22,6 +22,7 @@ my $symhacks_file = undef;      # a symbol hacking file (optional)
 my $version = undef;            # the version to use for added symbols
 my $checkexist = 0;             # (unsure yet)
 my $warnings = 1;
+my $renumber = 0;
 my $verbose = 0;
 my $debug = 0;
 
@@ -29,6 +30,7 @@ GetOptions('ordinals=s' => \$ordinals_file,
            'symhacks=s' => \$symhacks_file,
            'version=s'  => \$version,
            'exist'      => \$checkexist,
+           'renumber'   => \$renumber,
            'warnings!'  => \$warnings,
            'verbose'    => \$verbose,
            'debug'      => \$debug)
@@ -88,12 +90,7 @@ foreach my $f (($symhacks_file // (), @ARGV)) {
     close IN;
 }
 
-# As long as we're running in development or alpha releases, we can have
-# symbols without specific numbers assigned.  In beta or final release, all
-# symbols MUST have an assigned number.
-if ($version !~ m/^\d+\.\d+\.\d+(?:-alpha|(?:-.*?)?-dev$)/) {
-    $ordinals->renumber();
-}
+$ordinals->renumber() if $renumber;
 
 if ($checkexist) {
     my %new_names = map { $_->name() => 1 }


### PR DESCRIPTION
We introduce a new makefile target "make release-update" that forces
ordinal file renumbering, and also does the fips checksum updates. We
then call that  from the release script.

Fixes #15806

