### PR TITLE
apps: properly initialise arguments to EVP_PKEY_get_bn_param()

### DIFF
--- a/apps/req.c
+++ b/apps/req.c
@@ -994,7 +994,7 @@ int req_main(int argc, char **argv)
         }
         fprintf(stdout, "Modulus=");
         if (EVP_PKEY_is_a(tpubkey, "RSA")) {
-            BIGNUM *n;
+            BIGNUM *n = NULL;
 
             /* Every RSA key has an 'n' */
             EVP_PKEY_get_bn_param(pkey, "n", &n);

--- a/apps/x509.c
+++ b/apps/x509.c
@@ -950,7 +950,7 @@ int x509_main(int argc, char **argv)
                 BN_print(out, n);
                 BN_free(n);
             } else if (EVP_PKEY_is_a(pkey, "DSA")) {
-                BIGNUM *dsapub;
+                BIGNUM *dsapub = NULL;
 
                 /* Every DSA key has a 'pub' */
                 EVP_PKEY_get_bn_param(pkey, "pub", &dsapub);


### PR DESCRIPTION
This avoids use of uninitialised memory.

Follow on to #15900

