### PR TITLE
Memory errors

### DIFF
--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -3016,6 +3016,7 @@ static int www_body(int s, int stype, int prot, unsigned char *context)
     /* No need to free |con| after this. Done by BIO_free(ssl_bio) */
     BIO_set_ssl(ssl_bio, con, BIO_CLOSE);
     BIO_push(io, ssl_bio);
+    ssl_bio = NULL;
 #ifdef CHARSET_EBCDIC
     io = BIO_push(BIO_new(BIO_f_ebcdic_filter()), io);
 #endif
@@ -3376,6 +3377,7 @@ static int www_body(int s, int stype, int prot, unsigned char *context)
 
  err:
     OPENSSL_free(buf);
+    BIO_free(ssl_bio);
     BIO_free_all(io);
     return ret;
 }
@@ -3420,6 +3422,7 @@ static int rev_body(int s, int stype, int prot, unsigned char *context)
     /* No need to free |con| after this. Done by BIO_free(ssl_bio) */
     BIO_set_ssl(ssl_bio, con, BIO_CLOSE);
     BIO_push(io, ssl_bio);
+    ssl_bio = NULL;
 #ifdef CHARSET_EBCDIC
     io = BIO_push(BIO_new(BIO_f_ebcdic_filter()), io);
 #endif
@@ -3517,6 +3520,7 @@ static int rev_body(int s, int stype, int prot, unsigned char *context)
  err:
 
     OPENSSL_free(buf);
+    BIO_free(ssl_bio);
     BIO_free_all(io);
     return ret;
 }

--- a/crypto/ui/ui_lib.c
+++ b/crypto/ui/ui_lib.c
@@ -43,7 +43,7 @@ UI *UI_new_method(const UI_METHOD *method)
     ret->meth = method;
 
     if (!CRYPTO_new_ex_data(CRYPTO_EX_INDEX_UI, ret, &ret->ex_data)) {
-        OPENSSL_free(ret);
+        UI_free(ret);
         return NULL;
     }
     return ret;

--- a/crypto/x509/x_pubkey.c
+++ b/crypto/x509/x_pubkey.c
@@ -84,14 +84,16 @@ void ossl_X509_PUBKEY_INTERNAL_free(X509_PUBKEY *xpub)
 
 static void x509_pubkey_ex_free(ASN1_VALUE **pval, const ASN1_ITEM *it)
 {
-    X509_PUBKEY *pubkey = (X509_PUBKEY *)*pval;
+    X509_PUBKEY *pubkey;
 
-    X509_ALGOR_free(pubkey->algor);
-    ASN1_BIT_STRING_free(pubkey->public_key);
-    EVP_PKEY_free(pubkey->pkey);
-    OPENSSL_free(pubkey->propq);
-    OPENSSL_free(pubkey);
-    *pval = NULL;
+    if (pval != NULL && (pubkey = (X509_PUBKEY *)*pval) != NULL) {
+        X509_ALGOR_free(pubkey->algor);
+        ASN1_BIT_STRING_free(pubkey->public_key);
+        EVP_PKEY_free(pubkey->pkey);
+        OPENSSL_free(pubkey->propq);
+        OPENSSL_free(pubkey);
+        *pval = NULL;
+    }
 }
 
 static int x509_pubkey_ex_populate(ASN1_VALUE **pval, const ASN1_ITEM *it)

--- a/crypto/x509/x_x509a.c
+++ b/crypto/x509/x_x509a.c
@@ -125,6 +125,8 @@ int X509_add1_reject_object(X509 *x, const ASN1_OBJECT *obj)
 {
     X509_CERT_AUX *aux;
     ASN1_OBJECT *objtmp;
+    int res = 0;
+
     if ((objtmp = OBJ_dup(obj)) == NULL)
         return 0;
     if ((aux = aux_get(x)) == NULL)
@@ -132,10 +134,13 @@ int X509_add1_reject_object(X509 *x, const ASN1_OBJECT *obj)
     if (aux->reject == NULL
         && (aux->reject = sk_ASN1_OBJECT_new_null()) == NULL)
         goto err;
-    return sk_ASN1_OBJECT_push(aux->reject, objtmp);
+    if (sk_ASN1_OBJECT_push(aux->reject, objtmp) > 0)
+        res = 1;
+
  err:
-    ASN1_OBJECT_free(objtmp);
-    return 0;
+    if (!res)
+        ASN1_OBJECT_free(objtmp);
+    return res;
 }
 
 void X509_trust_clear(X509 *x)

--- a/test/conf_include_test.c
+++ b/test/conf_include_test.c
@@ -42,7 +42,7 @@ static int change_path(const char *file)
     char *s = OPENSSL_strdup(file);
     char *p = s;
     char *last = NULL;
-    int ret;
+    int ret = 0;
 
     if (s == NULL)
         return -1;
@@ -51,11 +51,12 @@ static int change_path(const char *file)
         last = p++;
     }
     if (last == NULL)
-        return 0;
+        goto err;
     last[DIRSEP_PRESERVE] = 0;
 
     TEST_note("changing path to %s", s);
     ret = chdir(s);
+ err:
     OPENSSL_free(s);
     return ret;
 }

--- a/test/evp_test.c
+++ b/test/evp_test.c
@@ -1967,8 +1967,10 @@ static int pbe_test_init(EVP_TEST *t, const char *alg)
         pbe_type = PBE_TYPE_PKCS12;
     } else {
         TEST_error("Unknown pbe algorithm %s", alg);
+        return 0;
     }
-    pdat = OPENSSL_zalloc(sizeof(*pdat));
+    if (!TEST_ptr(pdat = OPENSSL_zalloc(sizeof(*pdat))))
+        return 0;
     pdat->pbe_type = pbe_type;
     t->data = pdat;
     return 1;

--- a/test/helpers/handshake.c
+++ b/test/helpers/handshake.c
@@ -278,8 +278,10 @@ static int server_ocsp_cb(SSL *s, void *arg)
      * For the purposes of testing we just send back a dummy OCSP response
      */
     *resp = *(unsigned char *)arg;
-    if (!SSL_set_tlsext_status_ocsp_resp(s, resp, 1))
+    if (!SSL_set_tlsext_status_ocsp_resp(s, resp, 1)) {
+        OPENSSL_free(resp);
         return SSL_TLSEXT_ERR_ALERT_FATAL;
+    }
 
     return SSL_TLSEXT_ERR_OK;
 }

--- a/test/hmactest.c
+++ b/test/hmactest.c
@@ -132,7 +132,8 @@ static int test_hmac_run(void)
     unsigned int len;
     int ret = 0;
 
-    ctx = HMAC_CTX_new();
+    if (!TEST_ptr(ctx = HMAC_CTX_new()))
+        return 0;
     HMAC_CTX_reset(ctx);
 
     if (!TEST_ptr(ctx)

--- a/test/params_test.c
+++ b/test/params_test.c
@@ -97,7 +97,10 @@ static void cleanup_object(void *vobj)
 
 static void *init_object(void)
 {
-    struct object_st *obj = OPENSSL_zalloc(sizeof(*obj));
+    struct object_st *obj;
+
+    if (!TEST_ptr(obj = OPENSSL_zalloc(sizeof(*obj))))
+        return NULL;
 
     obj->p1 = p1_init;
     obj->p2 = p2_init;

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -1644,7 +1644,11 @@ static int ocsp_server_cb(SSL *s, void *arg)
     if (!TEST_ptr(copy = OPENSSL_memdup(orespder, sizeof(orespder))))
         return SSL_TLSEXT_ERR_ALERT_FATAL;
 
-    SSL_set_tlsext_status_ocsp_resp(s, copy, sizeof(orespder));
+    if (!TEST_true(SSL_set_tlsext_status_ocsp_resp(s, copy,
+                                                   sizeof(orespder)))) {
+        OPENSSL_free(copy);
+        return SSL_TLSEXT_ERR_ALERT_FATAL;
+    }
     ocsp_server_called = 1;
     return SSL_TLSEXT_ERR_OK;
 }


### PR DESCRIPTION
Fix a number of:
- potential memory leaks on error paths
- unchecked returns from memory allocation functions
- improve the error return in evp_test

Alternative to #15906 and #15834.

Issues reported by @lequangloc using Facebook's Infer static analyzer (https://fbinfer.com/, Pulse.ISL checker) 

- [ ] documentation is added or updated
- [x] tests are added or updated
