### PR TITLE
Added missing '(' int config.pm line 862

### DIFF
--- a/util/perl/OpenSSL/config.pm
+++ b/util/perl/OpenSSL/config.pm
@@ -859,7 +859,7 @@ EOF
                 }
             }
             if ( okrun(
-                       "lsattr -E -O -l `lsdev -c processor|awk '{print \$1;exit}'`",
+                       "(lsattr -E -O -l `lsdev -c processor|awk '{print \$1;exit}'`",
                        'grep -i powerpc) >/dev/null 2>&1') ) {
                 # this applies even to Power3 and later, as they return
                 # PowerPC_POWER[345]


### PR DESCRIPTION
Missing '(' added into a PowerPC-specific command

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
