### PR TITLE
Fix 'openssl req' to correctly use the algorithm from '-newkey algo:nnnn'

### DIFF
--- a/apps/req.c
+++ b/apps/req.c
@@ -1615,14 +1615,14 @@ static EVP_PKEY_CTX *set_keygen_ctx(const char *gstr,
         EVP_PKEY_free(param);
     } else {
         if (keygen_engine != NULL) {
-            int pkey_id = get_legacy_pkey_id(app_get0_libctx(), keytype,
+            int pkey_id = get_legacy_pkey_id(app_get0_libctx(), *pkeytype,
                                              keygen_engine);
 
             if (pkey_id != NID_undef)
                 gctx = EVP_PKEY_CTX_new_id(pkey_id, keygen_engine);
         } else {
             gctx = EVP_PKEY_CTX_new_from_name(app_get0_libctx(),
-                                              keytype, app_get0_propq());
+                                              *pkeytype, app_get0_propq());
         }
     }
 


### PR DESCRIPTION
We used the original string, which meant fetching for, for example,
'rsa:2048'.  That was, of course, doomed to fail.
