### PR TITLE
`Makefile`: fix minor issues, add `check-format` target; update but disable `lint` target

### DIFF
--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -1306,6 +1306,14 @@ errors:
    }
    "";
 -}
+SRCS={-
+sub uniq { my %seen; grep !$seen{$_}++, @_; }
+sub flat(@) { return map { ref eq 'ARRAY' ? @$_ : $_ } @_; }
+join(" \\\n" . ' ' x 5, fill_lines(" ", $COLUMNS - 5,
+     uniq(grep /\.(c|cc|cpp)$/,
+          flat (map { $unified_info{sources}->{$_} }
+                (sort keys %{$unified_info{sources}})))))
+-}
 CRYPTOHEADERS={- join(" \\\n" . ' ' x 14,
                       fill_lines(" ", $COLUMNS - 14, sort keys %cryptoheaders)) -}
 SSLHEADERS={- join(" \\\n" . ' ' x 11,

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -1136,6 +1136,11 @@ lint:
            echo splint -DLINT -posixlib -preproc -D__gnuc_va_list=void \
 	   -I. -Iinclude -Iapps/include $(CRYPTOHEADERS) $(SSLHEADERS) $(SRCS) )
 
+.PHONY: check-format
+check-format:
+	( cd $(SRCDIR); $(PERL) util/check-format.pl \
+			$(SRCS) \$(CRYPTOHEADERS) $(SSLHEADERS) )
+
 generate_apps:
 	( cd $(SRCDIR); $(PERL) VMS/VMSify-conf.pl \
 				< apps/openssl.cnf > apps/openssl-vms.cnf )

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -1274,7 +1274,8 @@ errors:
            include/internal/asn1.h
            include/internal/sslconf.h );
    my @cryptoskipheaders = ( @sslheaders_tmpl,
-       qw( include/openssl/conf_api.h
+       qw( include/openssl/asn1_mac.h
+           include/openssl/conf_api.h
            include/openssl/ebcdic.h
            include/openssl/opensslconf.h
            include/openssl/symhacks.h ) );

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -1130,8 +1130,11 @@ md-nits:
 #coverage: $(PROGRAMS) $(TESTPROGRAMS)
 #	...
 
+.PHONY: lint
 lint:
-	lint -DLINT $(INCLUDES) $(SRCS)
+	@( cd $(SRCDIR); \
+           echo splint -DLINT -posixlib -preproc -D__gnuc_va_list=void \
+	   -I. -Iinclude -Iapps/include $(CRYPTOHEADERS) $(SSLHEADERS) $(SRCS) )
 
 generate_apps:
 	( cd $(SRCDIR); $(PERL) VMS/VMSify-conf.pl \

--- a/include/internal/asn1.h
+++ b/include/internal/asn1.h
@@ -11,6 +11,8 @@
 # define OSSL_INTERNAL_ASN1_H
 # pragma once
 
+# include <openssl/bio.h>
+
 int asn1_d2i_read_bio(BIO *in, BUF_MEM **pb);
 
 #endif


### PR DESCRIPTION
These topics came up with #15224; moved them to here.

* `Makefile:` Add `SRCS` list of all `.c` (and any `.cc` and `.cpp)` files
* `Makefile:` Update [**new:** _but disable_] `lint` target, using `splint` with some quirks
* `Makefile:` Exclude dummy header `asn1_mac.h` from `CRYPTOHEADERS`
* `internal/asn1.h:` Add missing `#include <openssl/bio.h>`
* `Makefile:` Add `check-format` target, operating on all `.c` sources and crypto+ssl headers











