### PR TITLE
DECODER & ENCODER: Make sure to pass around the original selection bits

### DIFF
--- a/crypto/encode_decode/decoder_pkey.c
+++ b/crypto/encode_decode/decoder_pkey.c
@@ -57,6 +57,7 @@ DEFINE_STACK_OF(EVP_KEYMGMT)
 struct decoder_pkey_data_st {
     OSSL_LIB_CTX *libctx;
     char *propq;
+    int selection;
 
     char *object_type;           /* recorded object data type, may be NULL */
     void **object;               /* Where the result should end up */
@@ -126,7 +127,7 @@ static int decoder_construct_pkey(OSSL_DECODER_INSTANCE *decoder_inst,
 
             import_data.keymgmt = keymgmt;
             import_data.keydata = NULL;
-            import_data.selection = OSSL_KEYMGMT_SELECT_ALL;
+            import_data.selection = data->selection;
 
             /*
              * No need to check for errors here, the value of
@@ -350,6 +351,7 @@ int ossl_decoder_ctx_setup_for_pkey(OSSL_DECODER_CTX *ctx,
 
     process_data->object = (void **)pkey;
     process_data->libctx = libctx;
+    process_data->selection = ctx->selection;
 
     /* First, find all keymgmts to form goals */
     EVP_KEYMGMT_do_all_provided(libctx, collect_keymgmt, keymgmts);

--- a/crypto/evp/evp_pkey.c
+++ b/crypto/evp/evp_pkey.c
@@ -70,6 +70,7 @@ EVP_PKEY *EVP_PKCS82PKEY_ex(const PKCS8_PRIV_KEY_INFO *p8, OSSL_LIB_CTX *libctx,
     const unsigned char *p8_data = NULL;
     unsigned char *encoded_data = NULL;
     int encoded_len;
+    int selection;
     size_t len;
     OSSL_DECODER_CTX *dctx = NULL;
 
@@ -79,8 +80,9 @@ EVP_PKEY *EVP_PKCS82PKEY_ex(const PKCS8_PRIV_KEY_INFO *p8, OSSL_LIB_CTX *libctx,
 
     p8_data = encoded_data;
     len = encoded_len;
+    selection = EVP_PKEY_KEYPAIR | EVP_PKEY_KEY_PARAMETERS;
     dctx = OSSL_DECODER_CTX_new_for_pkey(&pkey, "DER", "PrivateKeyInfo",
-                                         EVP_PKEY_NONE, 0, libctx, propq);
+                                         NULL, selection, libctx, propq);
     if (dctx == NULL
         || !OSSL_DECODER_from_data(dctx, &p8_data, &len))
         /* try legacy */

--- a/providers/implementations/encode_decode/decode_msblob2key.c
+++ b/providers/implementations/encode_decode/decode_msblob2key.c
@@ -56,6 +56,8 @@ static OSSL_FUNC_decoder_export_object_fn msblob2key_export_object;
 struct msblob2key_ctx_st {
     PROV_CTX *provctx;
     const struct keytype_desc_st *desc;
+    /* The selection that is passed to msblob2key_decode() */
+    int selection;
 };
 
 static struct msblob2key_ctx_st *
@@ -102,6 +104,7 @@ static int msblob2key_decode(void *vctx, OSSL_CORE_BIO *cin, int selection,
     if (!ok)
         goto next;
 
+    ctx->selection = selection;
     ok = 0;                      /* Assume that we fail */
 
     if ((isdss && ctx->desc->type != EVP_PKEY_DSA)
@@ -208,8 +211,7 @@ msblob2key_export_object(void *vctx,
         /* The contents of the reference is the address to our object */
         keydata = *(void **)reference;
 
-        return export(keydata, OSSL_KEYMGMT_SELECT_ALL,
-                      export_cb, export_cbarg);
+        return export(keydata, ctx->selection, export_cb, export_cbarg);
     }
     return 0;
 }

--- a/providers/implementations/encode_decode/decode_pvk2key.c
+++ b/providers/implementations/encode_decode/decode_pvk2key.c
@@ -56,6 +56,8 @@ static OSSL_FUNC_decoder_export_object_fn pvk2key_export_object;
 struct pvk2key_ctx_st {
     PROV_CTX *provctx;
     const struct keytype_desc_st *desc;
+    /* The selection that is passed to der2key_decode() */
+    int selection;
 };
 
 static struct pvk2key_ctx_st *
@@ -85,6 +87,8 @@ static int pvk2key_decode(void *vctx, OSSL_CORE_BIO *cin, int selection,
     BIO *in = ossl_bio_new_from_core_bio(ctx->provctx, cin);
     void *key = NULL;
     int ok = 0;
+
+    ctx->selection = selection;
 
     if ((selection == 0
          || (selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) != 0)
@@ -175,8 +179,7 @@ static int pvk2key_export_object(void *vctx,
         /* The contents of the reference is the address to our object */
         keydata = *(void **)reference;
 
-        return export(keydata, OSSL_KEYMGMT_SELECT_ALL,
-                      export_cb, export_cbarg);
+        return export(keydata, ctx->selection, export_cb, export_cbarg);
     }
     return 0;
 }


### PR DESCRIPTION
When decoding a key and asking the keymgmt to import the key data, it
was told that the key data includes everything.  This may not be true,
since the user may have specified a different selection, and some
keymgmts may want to be informed.

Our key decoders' export function, on the other hand, didn't care
either, and simply export anything they could, regardless.

In both cases, the selection that was specified by the user is now
passed all the way.
