### PR TITLE
`ossl_cmp_error_new()`: Fix Coverity issue 1486534, and consequently also issues 1486536 and 1486533

### DIFF
--- a/crypto/cmp/cmp_msg.c
+++ b/crypto/cmp/cmp_msg.c
@@ -748,7 +748,8 @@ OSSL_CMP_MSG *ossl_cmp_error_new(OSSL_CMP_CTX *ctx, const OSSL_CMP_PKISI *si,
         goto err;
     if (!ASN1_INTEGER_set_int64(msg->body->value.error->errorCode, errorCode))
         goto err;
-    if (errorCode > 0 && errorCode < (ERR_SYSTEM_FLAG << 1)) {
+    if (errorCode > 0
+            && (uint64_t)errorCode < ((uint64_t)ERR_SYSTEM_FLAG << 1)) {
         lib = ERR_lib_error_string((unsigned long)errorCode);
         reason = ERR_reason_error_string((unsigned long)errorCode);
     }


### PR DESCRIPTION
The issues are due to an integer overflow that may happen on `(ERR_SYSTEM_FLAG << 1)`.
