### PR TITLE
Avoid some MinGW test failures

### DIFF
--- a/test/cmp_hdr_test.c
+++ b/test/cmp_hdr_test.c
@@ -161,21 +161,31 @@ static int test_HDR_set1_recipient(void)
 
 static int execute_HDR_update_messageTime_test(CMP_HDR_TEST_FIXTURE *fixture)
 {
-    struct tm hdrtm;
+    struct tm hdrtm, tmptm;
     time_t hdrtime, before, after, now;
 
     now = time(NULL);
-    before = mktime(gmtime(&now));
+    /*
+     * Trial and error reveals that passing the return value from gmtime
+     * directly to mktime in a mingw 32 bit build gives unexpected results. To
+     * work around this we take a copy of the return value first.
+     */
+    tmptm = *gmtime(&now);
+    before = mktime(&tmptm);
+
     if (!TEST_true(ossl_cmp_hdr_update_messageTime(fixture->hdr)))
         return 0;
     if (!TEST_true(ASN1_TIME_to_tm(fixture->hdr->messageTime, &hdrtm)))
         return 0;
 
     hdrtime = mktime(&hdrtm);
+
     if (!TEST_time_t_le(before, hdrtime))
         return 0;
     now = time(NULL);
-    after = mktime(gmtime(&now));
+    tmptm = *gmtime(&now);
+    after = mktime(&tmptm);
+
     return TEST_time_t_le(hdrtime, after);
 }
 

--- a/test/cmp_hdr_test.c
+++ b/test/cmp_hdr_test.c
@@ -172,11 +172,11 @@ static int execute_HDR_update_messageTime_test(CMP_HDR_TEST_FIXTURE *fixture)
         return 0;
 
     hdrtime = mktime(&hdrtm);
-    if (!TEST_true(before <= hdrtime))
+    if (!TEST_time_t_le(before, hdrtime))
         return 0;
     now = time(NULL);
     after = mktime(gmtime(&now));
-    return TEST_true(hdrtime <= after);
+    return TEST_time_t_le(hdrtime, after);
 }
 
 static int test_HDR_update_messageTime(void)

--- a/test/recipes/01-test_symbol_presence.t
+++ b/test/recipes/01-test_symbol_presence.t
@@ -23,6 +23,7 @@ use platform;
 plan skip_all => "Test is disabled on NonStop" if config('target') =~ m|^nonstop|;
 # MacOS arranges symbol names differently
 plan skip_all => "Test is disabled on MacOS" if config('target') =~ m|^darwin|;
+plan skip_all => "Test is disabled on MinGW" if config('target') =~ m|^mingw|;
 plan skip_all => "Only useful when building shared libraries"
     if disabled("shared");
 

--- a/test/recipes/04-test_conf.t
+++ b/test/recipes/04-test_conf.t
@@ -35,7 +35,12 @@ foreach (sort keys %input_result) {
           unless ok(run(test([ 'confdump', $input_path ],
                              stdout => $result_path)),
                     "dumping $_");
-      is(compare_text($result_path, $expected_path), 0,
-         "comparing the dump of $_ with $input_result{$_}");
+      is(compare_text($result_path, $expected_path, sub {
+            my $in1 = $_[0];
+            my $in2 = $_[1];
+            $in1 =~ s/\r\n/\n/g;
+            $in2 =~ s/\r\n/\n/g;
+            $in1 ne $in2}), 0,
+            "comparing the dump of $_ with $input_result{$_}");
     }
 }

--- a/test/recipes/15-test_ecparam.t
+++ b/test/recipes/15-test_ecparam.t
@@ -50,7 +50,12 @@ sub checkcompare {
         my $testout = "$app.tst";
 
         ok(run(app(['openssl', $app, '-out', $testout, '-in', $_])));
-        ok(!compare_text($_, $testout), "Original file $_ is the same as new one");
+        ok(!compare_text($_, $testout, sub {
+            my $in1 = $_[0];
+            my $in2 = $_[1];
+            $in1 =~ s/\r\n/\n/g;
+            $in2 =~ s/\r\n/\n/g;
+            $in1 ne $in2}), "Original file $_ is the same as new one");
     }
 }
 

--- a/test/recipes/25-test_eai_data.t
+++ b/test/recipes/25-test_eai_data.t
@@ -47,8 +47,12 @@ $out = outname();
 ok(run(app(["openssl", "x509", "-ext", "subjectAltName", "-in", $utf8_pem, "-noout", "-out", $out])));
 is(cmp_text($out, srctop_file($folder, "san.utf8")), 0, 'Comparing othername for IDN domain');
 
-ok(run(app(["openssl", "verify", "-nameopt", "utf8", "-no_check_time", "-verify_email", "学生\@elementary.school.example.com", "-CAfile", $ascii_chain_pem, $ascii_pem])));
-ok(run(app(["openssl", "verify", "-nameopt", "utf8", "-no_check_time", "-verify_email", "医生\@大学.example.com", "-CAfile", $utf8_chain_pem, $utf8_pem])));
+SKIP: {
+    skip "Unicode tests disabled on MingW", 2 if $^O =~ /^msys$/;
+
+    ok(run(app(["openssl", "verify", "-nameopt", "utf8", "-no_check_time", "-verify_email", "学生\@elementary.school.example.com", "-CAfile", $ascii_chain_pem, $ascii_pem])));
+    ok(run(app(["openssl", "verify", "-nameopt", "utf8", "-no_check_time", "-verify_email", "医生\@大学.example.com", "-CAfile", $utf8_chain_pem, $utf8_pem])));
+}
 
 ok(run(app(["openssl", "verify", "-nameopt", "utf8", "-no_check_time", "-CAfile", $ascii_chain_pem, $ascii_pem])));
 ok(run(app(["openssl", "verify", "-nameopt", "utf8", "-no_check_time", "-CAfile", $utf8_chain_pem, $utf8_pem])));

--- a/test/recipes/25-test_req.t
+++ b/test/recipes/25-test_req.t
@@ -31,6 +31,10 @@ if (disabled("rsa")) {
     note("There should not be more that at most 80 per line");
 }
 
+# Prevent MSys2 filename munging for arguments that look like file paths but
+# aren't
+$ENV{MSYS2_ARG_CONV_EXCL} = "/CN=";
+
 # Check for duplicate -addext parameters, and one "working" case.
 my @addext_args = ( "openssl", "req", "-new", "-out", "testreq.pem",
                     "-key",  srctop_file("test", "certs", "ee-key.pem"),

--- a/test/recipes/25-test_x509.t
+++ b/test/recipes/25-test_x509.t
@@ -18,6 +18,10 @@ setup("test_x509");
 
 plan tests => 18;
 
+# Prevent MSys2 filename munging for arguments that look like file paths but
+# aren't
+$ENV{MSYS2_ARG_CONV_EXCL} = "/CN=";
+
 require_ok(srctop_file("test", "recipes", "tconversion.pl"));
 
 my @certs = qw(test certs);
@@ -40,7 +44,7 @@ is(cmp_text($out_utf8, $utf),
 
 SKIP: {
     skip "DES disabled", 1 if disabled("des");
-    skip "VMS doesn't support command line UTF-8", 1 if $^O eq 'VMS';
+    skip "Platform doesn't support command line UTF-8", 1 if $^O =~ /^(VMS|msys)$/;
 
     my $p12 = srctop_file("test", "shibboleth.pfx");
     my $p12pass = "σύνθημα γνώρισμα";

--- a/test/recipes/79-test_http.t
+++ b/test/recipes/79-test_http.t
@@ -19,6 +19,7 @@ SKIP: {
     skip "OCSP disabled", 1 if disabled("ocsp");
     my $cmd = [qw{openssl ocsp -index any -port 0}];
     my @output = run(app($cmd), capture => 1);
+    $output[0] =~ s/\r\n/\n/g;
     ok($output[0] =~ /^ACCEPT (0.0.0.0|\[::\]):(\d+?) PID=(\d+)$/
        && $2 >= 1024 && $3 > 0,
        "HTTP server auto-selects and reports local port >= 1024 and pid > 0");

--- a/test/recipes/80-test_cmp_http.t
+++ b/test/recipes/80-test_cmp_http.t
@@ -32,7 +32,7 @@ plan skip_all => "These tests are not supported in a no-sock build"
     if disabled("sock");
 
 plan skip_all => "Tests involving local HTTP server not available on Windows or VMS"
-    if $^O =~ /^(VMS|MSWin32)$/;
+    if $^O =~ /^(VMS|MSWin32|msys)$/;
 plan skip_all => "Tests involving local HTTP server not available in cross-compile builds"
     if defined $ENV{EXE_SHELL};
 

--- a/test/recipes/81-test_cmp_cli.t
+++ b/test/recipes/81-test_cmp_cli.t
@@ -28,6 +28,10 @@ plan skip_all => "These tests are not supported in a fuzz build"
 plan skip_all => "These tests are not supported in a no-cmp build"
     if disabled("cmp");
 
+# Prevent MSys2 filename munging for arguments that look like file paths but
+# aren't
+$ENV{MSYS2_ARG_CONV_EXCL} = "/CN=";
+
 my @app = qw(openssl cmp);
 
 my @cmp_basic_tests = (

--- a/test/recipes/90-test_store.t
+++ b/test/recipes/90-test_store.t
@@ -16,8 +16,6 @@ use OpenSSL::Test::Utils;
 my $test_name = "test_store";
 setup($test_name);
 
-my $mingw = config('target') =~ m|^mingw|;
-
 my $use_md5 = !disabled("md5");
 my $use_des = !(disabled("des") || disabled("legacy")); # also affects 3des and pkcs12 app
 my $use_dsa = !disabled("dsa");
@@ -112,8 +110,10 @@ my $n = scalar @methods
         + 3
         + 11 );
 
+# Test doesn't work under msys because the file name munging doesn't work
+# correctly with the "ot:" prefix
 my $do_test_ossltest_store =
-    !(disabled("engine") || disabled("dynamic-engine"));
+    !(disabled("engine") || disabled("dynamic-engine") || $^O =~ /^msys$/);
 
 if ($do_test_ossltest_store) {
     # test loading with apps 'org.openssl.engine:' loader, using the
@@ -180,7 +180,7 @@ indir "store_$$" => sub {
                 ok(run(app([@storeutl, "-noout", to_abs_file($file)])));
               SKIP:
                 {
-                    skip "file: tests disabled on MingW", 4 if $mingw;
+                    skip "file: tests disabled on MingW", 4  if $^O =~ /^msys$/;
 
                     ok(run(app([@storeutl, "-noout",
                                 to_abs_file_uri($file)])));
@@ -200,7 +200,7 @@ indir "store_$$" => sub {
 
               SKIP:
                 {
-                    skip "file: tests disabled on MingW", 2 if $mingw;
+                    skip "file: tests disabled on MingW", 2  if $^O =~ /^msys$/;
 
                     ok(run(app([@storeutl, "-noout", "-passin",
                                 "pass:password", to_abs_file_uri($_)])));
@@ -211,7 +211,7 @@ indir "store_$$" => sub {
             foreach (values %generated_file_files) {
               SKIP:
                 {
-                    skip "file: tests disabled on MingW", 1 if $mingw;
+                    skip "file: tests disabled on MingW", 1  if $^O =~ /^msys$/;
 
                     ok(run(app([@storeutl,  "-noout", $_])));
                 }
@@ -219,7 +219,7 @@ indir "store_$$" => sub {
             foreach (@noexist_file_files) {
               SKIP:
                 {
-                    skip "file: tests disabled on MingW", 1 if $mingw;
+                    skip "file: tests disabled on MingW", 1  if $^O =~ /^msys$/;
 
                     ok(!run(app([@storeutl,  "-noout", $_])));
                 }
@@ -231,7 +231,7 @@ indir "store_$$" => sub {
                 ok(run(app([@storeutl,  "-noout", to_abs_file($dir, 1)])));
               SKIP:
                 {
-                    skip "file: tests disabled on MingW", 1 if $mingw;
+                    skip "file: tests disabled on MingW", 1  if $^O =~ /^msys$/;
 
                     ok(run(app([@storeutl,  "-noout",
                                 to_abs_file_uri($dir, 1)])));


### PR DESCRIPTION
There were 4 classes of failure:

- line ending problems;
- unicode problems;
- file path munging problems; and
- a "hang" in test_cmp_http.

The unicode problems appear to be somewhere between wine or msys - they
don't actually appear to be a problem with the built binaries. We just skip
those tests for now.

Fixes #13558
