### PR TITLE
Missing link to fips_config documentation

### DIFF
--- a/doc/man7/fips_module.pod
+++ b/doc/man7/fips_module.pod
@@ -452,8 +452,7 @@ L<OSSL_PROVIDER_get0_name(3)>.
 
 =head1 SEE ALSO
 
-L<migration_guide(7)>,
-L<crypto(7)>
+L<migration_guide(7)>, L<crypto(7)>, L<fips_config(5)>
 
 =head1 COPYRIGHT
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
