### PR TITLE
Deprecate ERR_GET_FUNC() function

### DIFF
--- a/doc/man3/ERR_GET_LIB.pod
+++ b/doc/man3/ERR_GET_LIB.pod
@@ -55,6 +55,8 @@ L<ERR_get_error(3)>
 ERR_GET_LIB(), ERR_GET_FUNC() and ERR_GET_REASON() are available in
 all versions of OpenSSL.
 
+The ERR_GET_FUNC() function was deprecated in OpenSSL 3.0.
+
 =head1 COPYRIGHT
 
 Copyright 2000-2017 The OpenSSL Project Authors. All Rights Reserved.

--- a/include/openssl/err.h.in
+++ b/include/openssl/err.h.in
@@ -247,10 +247,13 @@ static ossl_unused ossl_inline int ERR_GET_LIB(unsigned long errcode)
     return (errcode >> ERR_LIB_OFFSET) & ERR_LIB_MASK;
 }
 
+# ifndef OPENSSL_NO_DEPRECATED_3_0
+OSSL_DEPRECATEDIN_3_0
 static ossl_unused ossl_inline int ERR_GET_FUNC(unsigned long errcode ossl_unused)
 {
     return 0;
 }
+# endif
 
 static ossl_unused ossl_inline int ERR_GET_RFLAGS(unsigned long errcode)
 {

--- a/util/other.syms
+++ b/util/other.syms
@@ -234,7 +234,7 @@ DTLS_get_link_min_mtu                   define
 DTLS_set_link_mtu                       define
 ENGINE_cleanup                          define deprecated 1.1.0
 ERR_FATAL_ERROR                         define
-ERR_GET_FUNC                            define
+ERR_GET_FUNC                            define deprecated 3.0
 ERR_GET_LIB                             define
 ERR_GET_REASON                          define
 ERR_PACK                                define


### PR DESCRIPTION
The applications might depend on the function returning a significant
func code value instead of the return being always 0.

Fixes #15946

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
