### PR TITLE
Fix use of uninitialized memory in test_rsa_oaep

### DIFF
--- a/test/rsa_test.c
+++ b/test/rsa_test.c
@@ -283,7 +283,6 @@ static int test_rsa_oaep(int idx)
     int ret = 0;
     RSA *key = NULL;
     unsigned char ptext[256];
-    unsigned char ctext[256];
     static unsigned char ptext_ex[] = "\x54\x85\x9b\x34\x2c\x49\xea\x2a";
     unsigned char ctext_ex[256];
     int plen;
@@ -305,17 +304,17 @@ static int test_rsa_oaep(int idx)
 
     /* Try decrypting corrupted ciphertexts. */
     for (n = 0; n < clen; ++n) {
-        ctext[n] ^= 1;
-        num = RSA_private_decrypt(clen, ctext, ptext, key,
+        ctext_ex[n] ^= 1;
+        num = RSA_private_decrypt(clen, ctext_ex, ptext, key,
                                       RSA_PKCS1_OAEP_PADDING);
         if (!TEST_int_le(num, 0))
             goto err;
-        ctext[n] ^= 1;
+        ctext_ex[n] ^= 1;
     }
 
     /* Test truncated ciphertexts, as well as negative length. */
     for (n = -1; n < clen; ++n) {
-        num = RSA_private_decrypt(n, ctext, ptext, key,
+        num = RSA_private_decrypt(n, ctext_ex, ptext, key,
                                   RSA_PKCS1_OAEP_PADDING);
         if (!TEST_int_le(num, 0))
             goto err;


### PR DESCRIPTION
Do you all have MSan or valgrind in OpenSSL CI? Given how long this has been there, it seems no one's run OpenSSL tests under either for a while?

48f1739600f33c92387debce2002acec6e365f1d did not convert the RSA OAEP tests correctly. The corrupted ciphertext and truncation tests were really decrypting uninitialized memory, rather than the sample ciphertext. This results in an error in tools like MSan.

The test is somewhat roundabout. In the original version, before the conversion, ctext_ex was an OAEP test vector from key1(), etc., functions. The test would:

1. Encrypt ptext_ex as ctext.
2. Decrypt ctext and check it gives ptext_ex.
3. Decrypt ctext_ex and check it gives ptext_ex.
4. Try corrupted and truncated versions of ctext.

48f1739600f33c92387debce2002acec6e365f1d then moved steps 1 and 2 into test_rsa_simple, which meant ctext is no longer available for step 4. It then mistakenly left the variable around, but uninitialized, so the test wasn't testing anything. (Confusingly, test_rsa_simple outputs ctext_ex to the caller, but doesn't do anything with it. The ctext_ex output is also only usable for OAEP, not PKCS#1 v1.5.)

It doesn't really matter whether we use ctext or ctext_ex for step 4, so this PR fixes it by using ctext_ex instead.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
