### PR TITLE
ci: add a memory sanitiser test run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,12 +125,24 @@ jobs:
     - name: make test
       run: make test HARNESS_JOBS=${HARNESS_JOBS:-4} OPENSSL_TEST_RAND_ORDER=0 TESTS="-test_fuzz* -test_ssl_* -test_evp -test_cmp_http -test_verify -test_cms -test_store -test_enc -[01][0-9]"
 
-  sanitizers:
+  address_ub_sanitizer:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - name: config
       run: ./config --banner=Configured --debug enable-asan enable-ubsan enable-rc5 enable-md2 enable-ec_nistp_64_gcc_128 enable-fips && perl configdata.pm --dump
+    - name: make
+      run: make -s -j4
+    - name: make test
+      run: make test HARNESS_JOBS=${HARNESS_JOBS:-4} OPENSSL_TEST_RAND_ORDER=0
+
+  memory_sanitizer:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: config
+      # --debug -O1 is to produce a debug build that runs in a reasonable amount of time
+      run: CC=clang ./config --banner=Configured --debug -O1 -fsanitize=memory -DOSSL_SANITIZE_MEMORY -fno-optimize-sibling-calls enable-rc5 enable-md2 enable-ec_nistp_64_gcc_128 enable-fips && perl configdata.pm --dump
     - name: make
       run: make -s -j4
     - name: make test

--- a/engines/e_afalg.c
+++ b/engines/e_afalg.c
@@ -324,6 +324,15 @@ static int afalg_fin_cipher_aio(afalg_aio *aio, int sfd, unsigned char *buf,
         }
         if (eval > 0) {
 
+#ifdef OSSL_SANITIZE_MEMORY
+            /*
+             * In a memory sanitiser build, the changes to memory made by the
+             * system call aren't reliably detected.  By initialising the
+             * memory here, the sanitiser is told that they are okay.
+             */
+            memset(events, 0, sizeof(events));
+#endif
+
             /* Get results of AIO read */
             r = io_getevents(aio->aio_ctx, 1, MAX_INFLIGHTS,
                              events, &timeout);

--- a/test/afalgtest.c
+++ b/test/afalgtest.c
@@ -48,27 +48,39 @@ static int test_afalg_aes_cbc(int keysize_idx)
 {
     EVP_CIPHER_CTX *ctx;
     const EVP_CIPHER *cipher;
-    unsigned char key[] = "\x06\xa9\x21\x40\x36\xb8\xa1\x5b"
-                          "\x51\x2e\x03\xd5\x34\x12\x00\x06"
-                          "\x06\xa9\x21\x40\x36\xb8\xa1\x5b"
-                          "\x51\x2e\x03\xd5\x34\x12\x00\x06";
-    unsigned char iv[] = "\x3d\xaf\xba\x42\x9d\x9e\xb4\x30"
-                         "\xb4\x22\xda\x80\x2c\x9f\xac\x41";
-    /* input = "Single block msg\n"  17Bytes*/
-    unsigned char in[BUFFER_SIZE] = "\x53\x69\x6e\x67\x6c\x65\x20\x62"
-                                    "\x6c\x6f\x63\x6b\x20\x6d\x73\x67\x0a";
     unsigned char ebuf[BUFFER_SIZE + 32];
     unsigned char dbuf[BUFFER_SIZE + 32];
-    unsigned char encresult_128[] = "\xe3\x53\x77\x9c\x10\x79\xae\xb8"
-                                    "\x27\x08\x94\x2d\xbe\x77\x18\x1a\x2d";
-    unsigned char encresult_192[] = "\xf7\xe4\x26\xd1\xd5\x4f\x8f\x39"
-                                    "\xb1\x9e\xe0\xdf\x61\xb9\xc2\x55\xeb";
-    unsigned char encresult_256[] = "\xa0\x76\x85\xfd\xc1\x65\x71\x9d"
-                                    "\xc7\xe9\x13\x6e\xae\x55\x49\xb4\x13";
-    unsigned char *enc_result = NULL;
-
+    const unsigned char *enc_result = NULL;
     int encl, encf, decl, decf;
     int ret = 0;
+    static const unsigned char key[] =
+        "\x06\xa9\x21\x40\x36\xb8\xa1\x5b\x51\x2e\x03\xd5\x34\x12\x00\x06"
+        "\x06\xa9\x21\x40\x36\xb8\xa1\x5b\x51\x2e\x03\xd5\x34\x12\x00\x06";
+    static const unsigned char iv[] =
+        "\x3d\xaf\xba\x42\x9d\x9e\xb4\x30\xb4\x22\xda\x80\x2c\x9f\xac\x41";
+    /* input = "Single block msg\n" 17 Bytes*/
+    static const unsigned char in[BUFFER_SIZE] =
+        "\x53\x69\x6e\x67\x6c\x65\x20\x62\x6c\x6f\x63\x6b\x20\x6d\x73\x67"
+        "\x0a";
+    static const unsigned char encresult_128[BUFFER_SIZE] =
+        "\xe3\x53\x77\x9c\x10\x79\xae\xb8\x27\x08\x94\x2d\xbe\x77\x18\x1a"
+        "\x2d";
+    static const unsigned char encresult_192[BUFFER_SIZE] =
+        "\xf7\xe4\x26\xd1\xd5\x4f\x8f\x39\xb1\x9e\xe0\xdf\x61\xb9\xc2\x55"
+        "\xeb";
+    static const unsigned char encresult_256[BUFFER_SIZE] =
+        "\xa0\x76\x85\xfd\xc1\x65\x71\x9d\xc7\xe9\x13\x6e\xae\x55\x49\xb4"
+        "\x13";
+
+#ifdef OSSL_SANITIZE_MEMORY
+    /*
+     * Initialise the encryption & decryption buffers to pacify the memory
+     * sanitiser.  The sanitiser doesn't know that this memory is modified
+     * by the engine, this tells it that all is good.
+     */
+    OPENSSL_cleanse(ebuf, sizeof(ebuf));
+    OPENSSL_cleanse(dbuf, sizeof(dbuf));
+#endif
 
     switch (keysize_idx) {
         case 0:
@@ -91,7 +103,7 @@ static int test_afalg_aes_cbc(int keysize_idx)
 
     if (!TEST_true(EVP_CipherInit_ex(ctx, cipher, e, key, iv, 1))
             || !TEST_true(EVP_CipherUpdate(ctx, ebuf, &encl, in, BUFFER_SIZE))
-            || !TEST_true(EVP_CipherFinal_ex(ctx, ebuf+encl, &encf)))
+            || !TEST_true(EVP_CipherFinal_ex(ctx, ebuf + encl, &encf)))
         goto end;
     encl += encf;
 
@@ -101,7 +113,7 @@ static int test_afalg_aes_cbc(int keysize_idx)
     if (!TEST_true(EVP_CIPHER_CTX_reset(ctx))
             || !TEST_true(EVP_CipherInit_ex(ctx, cipher, e, key, iv, 0))
             || !TEST_true(EVP_CipherUpdate(ctx, dbuf, &decl, ebuf, encl))
-            || !TEST_true(EVP_CipherFinal_ex(ctx, dbuf+decl, &decf)))
+            || !TEST_true(EVP_CipherFinal_ex(ctx, dbuf + decl, &decf)))
         goto end;
     decl += decf;
 


### PR DESCRIPTION
This omission noted in #15950 which includes the RSA test failure fix.  The RSA test failure is thus expected here.

- [ ] documentation is added or updated
- [x] tests are added or updated
