### PR TITLE
deprecate ERR_GET_FUNC()

### DIFF
--- a/crypto/err/err.c
+++ b/crypto/err/err.c
@@ -916,3 +916,10 @@ void err_clear_last_constant_time(int clear)
                                      0, ERR_FLAG_CLEAR);
     es->err_flags[top] |= clear;
 }
+
+#ifndef OPENSSL_NO_DEPRECATED_3_0
+int ERR_GET_FUNC(unsigned long errcode)
+{
+    return -1;
+}
+#endif

--- a/doc/man3/ERR_GET_LIB.pod
+++ b/doc/man3/ERR_GET_LIB.pod
@@ -11,40 +11,45 @@ ERR_GET_LIB, ERR_GET_FUNC, ERR_GET_REASON, ERR_FATAL_ERROR
 
  int ERR_GET_LIB(unsigned long e);
 
- int ERR_GET_FUNC(unsigned long e);
-
  int ERR_GET_REASON(unsigned long e);
 
  int ERR_FATAL_ERROR(unsigned long e);
 
+Deprecated since OpenSSL 3.0, can be hidden entirely by defining
+B<OPENSSL_API_COMPAT> with a suitable version value, see
+L<openssl_user_macros(7)>:
+
+ int ERR_GET_FUNC(unsigned long e);
+
 =head1 DESCRIPTION
 
-The error code returned by ERR_get_error() consists of a library
-number, function code and reason code. ERR_GET_LIB(), ERR_GET_FUNC()
-and ERR_GET_REASON() can be used to extract these.
+The error code returned by ERR_get_error() consists of a library number
+and a reason code.  ERR_GET_LIB() and ERR_GET_REASON() can be used to
+extract these.
 
 ERR_FATAL_ERROR() indicates whether a given error code is a fatal error.
 
-The library number and function code describe where the error
-occurred, the reason code is the information about what went wrong.
+The library number describes where the error occurred and the reason code is
+the information about what went wrong.
 
-Each sub-library of OpenSSL has a unique library number; function and
-reason codes are unique within each sub-library.  Note that different
-libraries may use the same value to signal different functions and
-reasons.
+Each sub-library of OpenSSL has a unique library number and reason codes
+are unique within each sub-library.  Note that different libraries may
+use the same value to signal different reasons.
 
 B<ERR_R_...> reason codes such as B<ERR_R_MALLOC_FAILURE> are globally
 unique. However, when checking for sub-library specific reason codes,
 be sure to also compare the library number.
 
-ERR_GET_LIB(), ERR_GET_FUNC(), ERR_GET_REASON(), and ERR_FATAL_ERROR()
-are macros.
+The ERR_GET_FUNC() function is deprecated and always returns C<-1>.
+The function B<ERR_F_...> macros are defined as C<0>.
+Both the ERR_GET_FUNC() function and the B<ERR_F_...> macros are deprecated
+without replacement.
 
 =head1 RETURN VALUES
 
-The library number, function code, reason code, and whether the error
-is fatal, respectively.
-Starting with OpenSSL 3.0.0, the function code is always set to zero.
+The library number, reason code, and whether the error is fatal, respectively.
+
+ERR_GET_FUNC() always returns C<-1>.
 
 =head1 SEE ALSO
 
@@ -52,12 +57,13 @@ L<ERR_get_error(3)>
 
 =head1 HISTORY
 
-ERR_GET_LIB(), ERR_GET_FUNC() and ERR_GET_REASON() are available in
-all versions of OpenSSL.
+ERR_GET_LIB() and ERR_GET_REASON() are available in all versions of OpenSSL.
+
+ERR_GET_FUNC() was deprecated in OpenSSL 3.0.
 
 =head1 COPYRIGHT
 
-Copyright 2000-2017 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2000-2021 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/doc/man7/migration_guide.pod
+++ b/doc/man7/migration_guide.pod
@@ -1627,6 +1627,15 @@ L<ERR_get_error(3)>.
 
 =item -
 
+ERR_GET_FUNC(), B<ERR_F_*>
+
+There is no replacement.
+
+If available, ERR_GET_FUNC() returns C<-1>.
+The B<ERR_F_...> macros resolve to C<0>.
+
+=item -
+
 EVP_CIPHER_CTX_iv(), EVP_CIPHER_CTX_iv_noconst(), EVP_CIPHER_CTX_original_iv()
 
 Applications should instead use L<EVP_CIPHER_CTX_get_updated_iv(3)>,

--- a/include/openssl/err.h.in
+++ b/include/openssl/err.h.in
@@ -247,10 +247,9 @@ static ossl_unused ossl_inline int ERR_GET_LIB(unsigned long errcode)
     return (errcode >> ERR_LIB_OFFSET) & ERR_LIB_MASK;
 }
 
-static ossl_unused ossl_inline int ERR_GET_FUNC(unsigned long errcode ossl_unused)
-{
-    return 0;
-}
+# ifndef OPENSSL_NO_DEPRECATED_3_0
+OSSL_DEPRECATEDIN_3_0 int ERR_GET_FUNC(unsigned long errcode);
+# endif
 
 static ossl_unused ossl_inline int ERR_GET_RFLAGS(unsigned long errcode)
 {

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5413,3 +5413,4 @@ ASN1_item_d2i_fp_ex                     ?	3_0_0	EXIST::FUNCTION:STDIO
 ASN1_item_d2i_bio_ex                    ?	3_0_0	EXIST::FUNCTION:
 ASN1_item_d2i_ex                        ?	3_0_0	EXIST::FUNCTION:
 ASN1_TIME_print_ex                      ?	3_0_0	EXIST::FUNCTION:
+ERR_GET_FUNC                            ?	3_0_0	EXIST::FUNCTION:DEPRECATEDIN_3_0


### PR DESCRIPTION
Deprecate the ERR_GET_FUNC() function.
Change it's return to -1 so it can't accidentally match one of the ERR_F_ macros.
Update documentation to note the deprecation.
Update documentation so it doesn't claim the ERR_GET_ family are macros.

- [x] documentation is added or updated
- [ ] tests are added or updated

Fixes #15946
