### PR TITLE
Fix compile errors when building with --api=1.1.0 no-deprecated.

### DIFF
--- a/crypto/bn/build.info
+++ b/crypto/bn/build.info
@@ -108,8 +108,11 @@ $COMMON=bn_add.c bn_div.c bn_exp.c bn_lib.c bn_ctx.c bn_mul.c \
         bn_intern.c bn_dh.c bn_rsa_fips186_4.c bn_const.c
 SOURCE[../../libcrypto]=$COMMON $BNASM bn_print.c bn_err.c bn_srp.c
 DEFINE[../../libcrypto]=$BNDEF
+IF[{- !$disabled{'deprecated-0.9.8'} -}]
+  SOURCE[../../libcrypto]=bn_depr.c
+ENDIF
 IF[{- !$disabled{'deprecated-3.0'} -}]
-  SOURCE[../../libcrypto]=bn_depr.c bn_x931p.c
+  SOURCE[../../libcrypto]=bn_x931p.c
 ENDIF
 SOURCE[../../providers/libfips.a]=$COMMON $BNASM
 DEFINE[../../providers/libfips.a]=$BNDEF

--- a/test/pem_read_depr_test.c
+++ b/test/pem_read_depr_test.c
@@ -15,6 +15,9 @@
 
 #include <openssl/pem.h>
 #include <openssl/bio.h>
+#include <openssl/dh.h>
+#include <openssl/dsa.h>
+#include <openssl/rsa.h>
 
 #include "testutil.h"
 

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -32,6 +32,7 @@
 #include <openssl/provider.h>
 #include <openssl/param_build.h>
 #include <openssl/x509v3.h>
+#include <openssl/dh.h>
 
 #include "helpers/ssltestlib.h"
 #include "testutil.h"


### PR DESCRIPTION
Fixes #15963

INSTALL.md uses these exact options as an example so it should work.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
