### PR TITLE
PPC build fixes

### DIFF
--- a/crypto/bn/asm/ppc64-mont-fixed.pl
+++ b/crypto/bn/asm/ppc64-mont-fixed.pl
@@ -322,7 +322,7 @@ ___
 	$self->add_code(<<___);
 	li		r3,1
 	blr
-.size ${fname},.-${fname}
+.size .${fname},.-.${fname}
 ___
 
 }

--- a/crypto/bn/asm/ppc64-mont-fixed.pl
+++ b/crypto/bn/asm/ppc64-mont-fixed.pl
@@ -267,7 +267,7 @@ ___
 	addze		$tp[$n],$tp[$n+1]
 
 	addi		$i,$i,$SIZE_T
-	bc		25,0,$label->{"outer"}
+	bdnz		$label->{"outer"}
 
 	and.		$tp[$n],$tp[$n],$tp[$n]
 	bne		$label->{"sub"}

--- a/crypto/bn/bn_ppc.c
+++ b/crypto/bn/bn_ppc.c
@@ -40,12 +40,14 @@ int bn_mul_mont(BN_ULONG *rp, const BN_ULONG *ap, const BN_ULONG *bp,
      * no opportunity to figure it out...
      */
 
+#if defined(_ARCH_PPC64)
     if (num == 6) {
         if (OPENSSL_ppccap_P & PPC_MADD300)
             return bn_mul_mont_300_fixed_n6(rp, ap, bp, np, n0, num);
         else
             return bn_mul_mont_fixed_n6(rp, ap, bp, np, n0, num);
     }
+#endif
 
     return bn_mul_mont_int(rp, ap, bp, np, n0, num);
 }


### PR DESCRIPTION
2 of these commits should fix the (big-endian and 32-bit PPC) build problems seen in Issue #15923.  The other seems to be required to build with an ancient version of binutils.

Testing:
* Tested on IBM 64-bit little-endian Power 9 LPAR with gcc-11.1.1 and binutils-2.35.1. Builds, runs (`LD_LIBRARY_PATH=. openssl speed ecdhp384 ecdsap384`), no visible performance penalty due to the change of branch instruction.
* Tested on IBM 64-bit big-endian Power 7 LPAR with gcc-8.3.1 and binutils-2.29.1. Builds, runs .
* The 32-bit (powerpc) fix is untested. However, it seems quite obvious given that building the code is conditional on 64-bit but the function calls were built unconditionally.
* I'm unable to test the build on AIX because the compiler is complaining about type conflicts between gcc and system headers (even on code that built fine 2 weeks ago). Not sure what has changed on this machine... sorry about that!

I'm running `make test` on the test machines I have and will confirm results in a comment a bit later...
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
