### PR TITLE
test: better test BN_mod()

### DIFF
--- a/test/bntest.c
+++ b/test/bntest.c
@@ -308,16 +308,66 @@ static int test_div_recip(void)
     return st;
 }
 
+static struct {
+    int n, divisor, result, remainder;
+} signed_mod_tests[] = {
+    {  10,   3,   3,   1 },
+    { -10,   3,  -3,  -1 },
+    {  10,  -3,  -3,   1 },
+    { -10,  -3,   3,  -1 },
+};
+
+static BIGNUM *set_signed_bn(int value)
+{
+    BIGNUM *bn = BN_new();
+    const int abs = value < 0 ? -value : value;
+
+    if (bn == NULL)
+        return NULL;
+    if (!BN_set_word(bn, abs)) {
+        BN_free(bn);
+        return NULL;
+    }
+    BN_set_negative(bn, value < 0);
+    return bn;
+}
+
+static int test_signed_mod(int n)
+{
+    BIGNUM *a = NULL, *b = NULL, *c = NULL, *d = NULL;
+    int st = 0;
+
+    if (!TEST_ptr(a = set_signed_bn(signed_mod_tests[n].n))
+            || !TEST_ptr(b = set_signed_bn(signed_mod_tests[n].divisor))
+            || !TEST_ptr(c = set_signed_bn(signed_mod_tests[n].result))
+            || !TEST_ptr(d = set_signed_bn(signed_mod_tests[n].remainder)))
+        goto err;
+
+    if (TEST_true(BN_div(b, a, a, b, ctx))
+            && TEST_true(BN_sub(b, b, c))
+            && TEST_BN_eq_zero(b)
+            && TEST_true(BN_sub(d, a, d))
+            && TEST_BN_eq_zero(d))
+        st = 1;
+ err:
+    BN_free(a);
+    BN_free(b);
+    BN_free(c);
+    BN_free(d);
+    return st;
+}
+
 static int test_mod(void)
 {
-    BIGNUM *a = NULL, *b = NULL, *c = NULL, *d = NULL, *e = NULL;
+    BIGNUM *a = NULL, *b = NULL, *c = NULL, *d = NULL, *e = NULL, *f = NULL;
     int st = 0, i;
 
     if (!TEST_ptr(a = BN_new())
             || !TEST_ptr(b = BN_new())
             || !TEST_ptr(c = BN_new())
             || !TEST_ptr(d = BN_new())
-            || !TEST_ptr(e = BN_new()))
+            || !TEST_ptr(e = BN_new())
+            || !TEST_ptr(f = BN_new()))
         goto err;
 
     if (!(TEST_true(BN_bntest_rand(a, 1024, 0, 0))))
@@ -329,8 +379,12 @@ static int test_mod(void)
         BN_set_negative(b, rand_neg());
         if (!(TEST_true(BN_mod(c, a, b, ctx))
                 && TEST_true(BN_div(d, e, a, b, ctx))
-                && TEST_true(BN_sub(e, e, c))
-                && TEST_BN_eq_zero(e)))
+                && TEST_true(BN_sub(f, e, c))
+                && TEST_BN_eq_zero(f)
+                && TEST_true(BN_mul(c, d, b, ctx))
+                && TEST_true(BN_add(d, c, e))
+                && TEST_true(BN_sub(f, d, a))
+                && TEST_BN_eq_zero(f)))
             goto err;
     }
     st = 1;
@@ -340,6 +394,7 @@ static int test_mod(void)
     BN_free(c);
     BN_free(d);
     BN_free(e);
+    BN_free(f);
     return st;
 }
 
@@ -2875,6 +2930,7 @@ int setup_tests(void)
     if (n == 0) {
         ADD_TEST(test_sub);
         ADD_TEST(test_div_recip);
+        ADD_ALL_TESTS(test_signed_mod, OSSL_NELEM(signed_mod_tests));
         ADD_TEST(test_mod);
         ADD_TEST(test_modexp_mont5);
         ADD_TEST(test_kronecker);

--- a/test/bntest.c
+++ b/test/bntest.c
@@ -320,11 +320,11 @@ static struct {
 static BIGNUM *set_signed_bn(int value)
 {
     BIGNUM *bn = BN_new();
-    const int abs = value < 0 ? -value : value;
+    const int abs_value = value < 0 ? -value : value;
 
     if (bn == NULL)
         return NULL;
-    if (!BN_set_word(bn, abs)) {
+    if (!BN_set_word(bn, abs_value)) {
         BN_free(bn);
         return NULL;
     }


### PR DESCRIPTION
The BN_mod() test was testing BN_div() == BN_div() which isn't all that helpful.  Add an extra step that verifies the output of BN_div() by multiplying back to the original numbers.

Also add a quick test for BN_div() against small known constants to ensure correct operation.


- [ ] documentation is added or updated
- [x] tests are added or updated
