### PR TITLE
Fix compile warning with GCC 11.

### DIFF
--- a/crypto/evp/ctrl_params_translate.c
+++ b/crypto/evp/ctrl_params_translate.c
@@ -1353,8 +1353,8 @@ static int fix_rsa_pss_saltlen(enum state state,
         if (i == OSSL_NELEM(str_value_map)) {
             BIO_snprintf(ctx->name_buf, sizeof(ctx->name_buf), "%d", ctx->p1);
         } else {
-            strncpy(ctx->name_buf, str_value_map[i].ptr, sizeof(ctx->name_buf));
             /* This won't truncate but it will quiet static analysers */
+            strncpy(ctx->name_buf, str_value_map[i].ptr, sizeof(ctx->name_buf) - 1);
             ctx->name_buf[sizeof(ctx->name_buf) - 1] = '\0';
         }
         ctx->p2 = ctx->name_buf;


### PR DESCRIPTION
When configured with strict warnings, GCC 11 complains about a possible
stringop-translation:

Config:

/usr/bin/perl ./Configure enable-asan enable-ubsan enable-zlib-dynamic \
enable-unit-test enable-md2 enable-rc5 enable-buildtest-c++ \
enable-weak-ssl-ciphers enable-ssl3 enable-ssl3-method enable-fips -w \
--strict-warnings

Warning:

crypto/evp/ctrl_params_translate.c: In function 'fix_rsa_pss_saltlen':
crypto/evp/ctrl_params_translate.c:1356:13: error: 'strncpy' specified bound 50 equals destination size [-Werror=stringop-truncation]
 1356 |             strncpy(ctx->name_buf, str_value_map[i].ptr, sizeof(ctx->name_buf));
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

Fix by copying one byte less than the buffer size.  We anyway overwrite the
last byte.

Signed-off-by: Juergen Christ <jchrist@linux.ibm.com>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

