### PR TITLE
CRYPTO: Remove the check for built-in methods in the export_to function

### DIFF
--- a/crypto/dh/dh_ameth.c
+++ b/crypto/dh/dh_ameth.c
@@ -453,13 +453,6 @@ static int dh_pkey_export_to(const EVP_PKEY *from, void *to_keydata,
     int selection = 0;
     int rv = 0;
 
-    /*
-     * If the DH method is foreign, then we can't be sure of anything, and
-     * can therefore not export or pretend to export.
-     */
-    if (ossl_dh_get_method(dh) != DH_OpenSSL())
-        return 0;
-
     if (p == NULL || g == NULL)
         return 0;
 

--- a/crypto/dsa/dsa_ameth.c
+++ b/crypto/dsa/dsa_ameth.c
@@ -436,13 +436,6 @@ static int dsa_pkey_export_to(const EVP_PKEY *from, void *to_keydata,
     int selection = 0;
     int rv = 0;
 
-    /*
-     * If the DSA method is foreign, then we can't be sure of anything, and
-     * can therefore not export or pretend to export.
-     */
-    if (DSA_get_method(dsa) != DSA_OpenSSL())
-        return 0;
-
     if (p == NULL || q == NULL || g == NULL)
         return 0;
 

--- a/crypto/ec/ec_ameth.c
+++ b/crypto/ec/ec_ameth.c
@@ -498,13 +498,6 @@ int ec_pkey_export_to(const EVP_PKEY *from, void *to_keydata,
             || (ecg = EC_KEY_get0_group(eckey)) == NULL)
         return 0;
 
-    /*
-     * If the EC_KEY method is foreign, then we can't be sure of anything,
-     * and can therefore not export or pretend to export.
-     */
-    if (EC_KEY_get_method(eckey) != EC_KEY_OpenSSL())
-        return 0;
-
     tmpl = OSSL_PARAM_BLD_new();
     if (tmpl == NULL)
         return 0;

--- a/crypto/rsa/rsa_ameth.c
+++ b/crypto/rsa/rsa_ameth.c
@@ -738,13 +738,6 @@ static int rsa_int_export_to(const EVP_PKEY *from, int rsa_type,
 
     if (tmpl == NULL)
         return 0;
-    /*
-     * If the RSA method is foreign, then we can't be sure of anything, and
-     * can therefore not export or pretend to export.
-     */
-    if (RSA_get_method(rsa) != RSA_PKCS1_OpenSSL())
-        goto err;
-
     /* Public parameters must always be present */
     if (RSA_get0_n(rsa) == NULL || RSA_get0_e(rsa) == NULL)
         goto err;


### PR DESCRIPTION
That check was seen as necessary at the time, but other changes have
been made since, so we now have better control on when we're handling
legacy structures and methods, making it safe to run the export_to
function on keys with foreign methods.

The basic message is that foreign methods must set key structure
values according to our standards no matter what, or not set them at
all.  This has really always been the case, but was harder to see at
the time because of interaction with other bugs.

Fixes #15927