### PR TITLE
Fix 3des-wrap encryption bug

### DIFF
--- a/crypto/evp/e_des3.c
+++ b/crypto/evp/e_des3.c
@@ -386,6 +386,8 @@ static int des_ede3_wrap(EVP_CIPHER_CTX *ctx, unsigned char *out,
 static int des_ede3_wrap_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
                                 const unsigned char *in, size_t inl)
 {
+    if (in == NULL || inl == 0)
+        return 0;
     /*
      * Sanity check input length: we typically only wrap keys so EVP_MAXCHUNK
      * is more than will ever be needed. Also input length must be a multiple


### PR DESCRIPTION
According to RFC 3217, when encrypting 24 bytes of data(Triple-DES key),
the length of ciphertext should be 40 bytes, not 56 bytes.
EVP_CipherFinal_ex calls des_ede3_wrap_cipher, when input is empty,
des_ede3_wrap_cipher should return 0, instead of calling des_ede3_wrap
to add extra 16 bytes.