### PR TITLE
err: remove ERR_GET_FUNC()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,12 @@ breaking changes, and mappings for the large list of deprecated functions.
 
 ### Changes between 1.1.1 and 3.0 [xx XXX xxxx]
 
+ * The ERR_GET_FUNC() function was removed.  With the loss of meaningful
+   function codes, this function can only cause problems for calling
+   applications.
+
+   *Paul Dale*
+
  * Add a configurable flag to output date formats as ISO 8601. Does not
    change the default date format.
 
@@ -1060,6 +1066,8 @@ breaking changes, and mappings for the large list of deprecated functions.
 
  * Removed the function names from error messages and deprecated the
    xxx_F_xxx define's.
+
+   *Richard Levitte*
 
  * Removed NextStep support and the macro OPENSSL_UNISTD
 

--- a/doc/man3/ERR_GET_LIB.pod
+++ b/doc/man3/ERR_GET_LIB.pod
@@ -2,7 +2,7 @@
 
 =head1 NAME
 
-ERR_GET_LIB, ERR_GET_FUNC, ERR_GET_REASON, ERR_FATAL_ERROR
+ERR_GET_LIB, ERR_GET_REASON, ERR_FATAL_ERROR
 - get information from error codes
 
 =head1 SYNOPSIS
@@ -11,8 +11,6 @@ ERR_GET_LIB, ERR_GET_FUNC, ERR_GET_REASON, ERR_FATAL_ERROR
 
  int ERR_GET_LIB(unsigned long e);
 
- int ERR_GET_FUNC(unsigned long e);
-
  int ERR_GET_REASON(unsigned long e);
 
  int ERR_FATAL_ERROR(unsigned long e);
@@ -20,7 +18,7 @@ ERR_GET_LIB, ERR_GET_FUNC, ERR_GET_REASON, ERR_FATAL_ERROR
 =head1 DESCRIPTION
 
 The error code returned by ERR_get_error() consists of a library
-number, function code and reason code. ERR_GET_LIB(), ERR_GET_FUNC()
+number, function code and reason code. ERR_GET_LIB()
 and ERR_GET_REASON() can be used to extract these.
 
 ERR_FATAL_ERROR() indicates whether a given error code is a fatal error.
@@ -37,8 +35,7 @@ B<ERR_R_...> reason codes such as B<ERR_R_MALLOC_FAILURE> are globally
 unique. However, when checking for sub-library specific reason codes,
 be sure to also compare the library number.
 
-ERR_GET_LIB(), ERR_GET_FUNC(), ERR_GET_REASON(), and ERR_FATAL_ERROR()
-are macros.
+ERR_GET_LIB(), ERR_GET_REASON(), and ERR_FATAL_ERROR() are macros.
 
 =head1 RETURN VALUES
 
@@ -52,8 +49,9 @@ L<ERR_get_error(3)>
 
 =head1 HISTORY
 
-ERR_GET_LIB(), ERR_GET_FUNC() and ERR_GET_REASON() are available in
-all versions of OpenSSL.
+ERR_GET_LIB() and ERR_GET_REASON() are available in all versions of OpenSSL.
+
+ERR_GET_FUNC() was removed in OpenSSL 3.0.
 
 =head1 COPYRIGHT
 

--- a/include/openssl/err.h.in
+++ b/include/openssl/err.h.in
@@ -247,11 +247,6 @@ static ossl_unused ossl_inline int ERR_GET_LIB(unsigned long errcode)
     return (errcode >> ERR_LIB_OFFSET) & ERR_LIB_MASK;
 }
 
-static ossl_unused ossl_inline int ERR_GET_FUNC(unsigned long errcode ossl_unused)
-{
-    return 0;
-}
-
 static ossl_unused ossl_inline int ERR_GET_RFLAGS(unsigned long errcode)
 {
     if (ERR_SYSTEM_ERROR(errcode))

--- a/util/other.syms
+++ b/util/other.syms
@@ -234,7 +234,6 @@ DTLS_get_link_min_mtu                   define
 DTLS_set_link_mtu                       define
 ENGINE_cleanup                          define deprecated 1.1.0
 ERR_FATAL_ERROR                         define
-ERR_GET_FUNC                            define
 ERR_GET_LIB                             define
 ERR_GET_REASON                          define
 ERR_PACK                                define


### PR DESCRIPTION
This is problematic in 3.0 because the function codes are all defined as zero.  This leads to either every error matching or no error ever matching.  Both are problematic for users.  The OTC vote resolved to remove this function completely.

Fixes #15946

- [x] documentation is added or updated
- [ ] tests are added or updated
