### PR TITLE
Fix s_server PSK handling

### DIFF
--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -130,6 +130,17 @@ static unsigned int psk_server_cb(SSL *ssl, const char *identity,
 
     if (s_debug)
         BIO_printf(bio_s_out, "psk_server_cb\n");
+
+    if (SSL_version(ssl) >= TLS1_3_VERSION) {
+        /*
+         * This callback is designed for use in TLSv1.2. It is possible to use
+         * a single callback for all protocol versions - but it is preferred to
+         * use a dedicated callback for TLSv1.3. For TLSv1.3 we have
+         * psk_find_session_cb.
+         */
+        return 0;
+    }
+
     if (identity == NULL) {
         BIO_printf(bio_err, "Error: client did not send PSK identity\n");
         goto out_err;


### PR DESCRIPTION
Issue #15951 describes a scenario which causes s_server to fail when using
a PSK. In the originally described issue this only impacted master and not
1.1.1. However, in fact this issue does also impact 1.1.1 - but only if you
additionally supply the option "-no_ticket" to the s_server command line.

The difference between the behaviour in master and 1.1.1 is due to 9c13b49,
which changed PSK_MAX_IDENTITY_LEN from 128 to 256. It just so happens that
a default OpenSSL TLSv1.3 ticket length happens to fall between those 2
values. Tickets are presented in TLSv1.3 as a PSK "identity". Passing
"no_ticket" doesn't actually stop TLSv1.3 tickets completely, it just
forces the use of "session ids as a ticket" instead. This significantly
reduces the ticket size to below 128 in 1.1.1.

The problem was due to s_server setting a TLSv1.2 PSK callback and a
TLSv1.3 PSK callback. For backwards compat reasons the TLSv1.2 PSK
callbacks also work in TLSv1.3 but are not preferred. In the described
scenario we use a PSK to create the initial connection. Subsequent to that
we attempt a resumption using a TLSv1.3 ticket (psk). If the psk length is
below PSK_MAX_IDENTITY_LEN then we first call the TLSv1.2 PSK callback.
Subsequently we call the TLSv1.3 PSK callback. Unfortunately s_server's
TLSv1.2 PSK callback accepts the identity regardless, even though it is an
unexpected value, and hence the binder subsequently fails to verify.

The fix is to bail early in the TLSv1.2 callback if we detect we are being
called from a TLSv1.3 connection.

Fixes #15951
