### PR TITLE
evp: detect and raise an error if no digest is found for a sign/verify operation

### DIFF
--- a/crypto/evp/m_sigver.c
+++ b/crypto/evp/m_sigver.c
@@ -208,7 +208,13 @@ static int do_sigver_init(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx,
                                           mdname, provkey, params);
     }
 
-    goto end;
+    /*
+     * If the operation was not a success and no digest was found, an error
+     * needs to be raised.
+     */
+    if (ret > 0 || mdname != NULL)
+        goto end;
+    ERR_raise(ERR_LIB_EVP, EVP_R_NO_DEFAULT_DIGEST);
 
  err:
     evp_pkey_ctx_free_old_ops(locpctx);

--- a/crypto/evp/m_sigver.c
+++ b/crypto/evp/m_sigver.c
@@ -214,7 +214,8 @@ static int do_sigver_init(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx,
      */
     if (ret > 0 || mdname != NULL)
         goto end;
-    ERR_raise(ERR_LIB_EVP, EVP_R_NO_DEFAULT_DIGEST);
+    if (type == NULL)   /* This check is redundant but clarifies matters */
+        ERR_raise(ERR_LIB_EVP, EVP_R_NO_DEFAULT_DIGEST);
 
  err:
     evp_pkey_ctx_free_old_ops(locpctx);


### PR DESCRIPTION

If no digest is specified, the code looks for a default digest per PKEY via the `evp_keymgmt_util_get_deflt_digest_name()` call.  If this call returns NULL, indicating no digest found, the code continues regardless.  If the verify/sign init later fails, it returns an error without raising one.  This change raises an error in this case.

Fixes #15372


- [ ] documentation is added or updated
- [ ] tests are added or updated
