### PR TITLE
platform->sharedlib_simple(): return undef when same as platform->sharedlib()

### DIFF
--- a/Configurations/platform/Unix.pm
+++ b/Configurations/platform/Unix.pm
@@ -63,6 +63,7 @@ sub sharedname_simple {
 }
 
 sub sharedlib_simple {
+    return undef if $_[0]->shlibext() eq $_[0]->shlibextsimple();
     return platform::BASE::__concat($_[0]->sharedname_simple($_[1]),
                                     $_[0]->shlibextsimple());
 }

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -1392,7 +1392,7 @@ FORCE:
 
 # Building targets ###################################################
 
-libcrypto.pc libssl.pc openssl.pc: configdata.pm $(LIBS) {- join(" ",map { platform->sharedlib_simple($_) // platform->sharedlib_import($_) // () } @{$unified_info{libraries}}) -}
+libcrypto.pc libssl.pc openssl.pc: configdata.pm $(LIBS) {- join(" ",map { platform->sharedlib_simple($_) // platform->sharedlib_import($_) // platform->sharedlib($_) // () } @{$unified_info{libraries}}) -}
 libcrypto.pc:
 	@ ( echo 'prefix=$(INSTALLTOP)'; \
 	    echo 'exec_prefix=$${prefix}'; \
@@ -1484,6 +1484,7 @@ reconfigure reconf:
       # On Unix platforms, we depend on {shlibname}.so
       return map { platform->sharedlib_simple($_)
                    // platform->sharedlib_import($_)
+                   // platform->sharedlib($_)
                    // platform->staticlib($_)
                  } @_;
   }


### PR DESCRIPTION
On some Unix-like platforms, there is no such thing as versioned shared
libraries.  In this case, platform->sharedlib_simple() should simply
return undef.  Among others, this avoids the shared libraries to be
installed as symlinks on themselves.

Fixes #16012
