### PR TITLE
Fix legacy `OCSP_REQ_CTX_http()` to expect ASN.1 formatted input

### DIFF
--- a/crypto/http/http_client.c
+++ b/crypto/http/http_client.c
@@ -257,7 +257,7 @@ int OSSL_HTTP_REQ_CTX_set_expected(OSSL_HTTP_REQ_CTX *rctx,
     rctx->expect_asn1 = asn1;
     if (timeout >= 0)
         rctx->max_time = timeout > 0 ? time(NULL) + timeout : 0;
-    else
+    else /* take over any |overall_timeout| arg of OSSL_HTTP_open(), else 0 */
         rctx->max_time = rctx->max_total_time;
     rctx->keep_alive = keep_alive;
     return 1;

--- a/doc/man3/OSSL_HTTP_REQ_CTX.pod
+++ b/doc/man3/OSSL_HTTP_REQ_CTX.pod
@@ -97,14 +97,16 @@ If the I<asn1> parameter is nonzero a structure in ASN.1 encoding will be
 expected as the response content and input streaming is disabled.  This means
 that an ASN.1 sequence header is required, its length field is checked, and
 OSSL_HTTP_REQ_CTX_get0_mem_bio() should be used to get the buffered response.
-Else any form of input is allowed without length checks, which is the default.
+Otherwise any input format is allowed without length checks, which is the default.
 In this case the BIO given as I<rbio> argument to OSSL_HTTP_REQ_CTX_new() should
 be used directly to read the response contents, which may support streaming.
 If the I<timeout> parameter is > 0 this indicates the maximum number of seconds
 the subsequent HTTP transfer (sending the request and receiving a response)
 is allowed to take.
-A value <= 0 enables waiting indefinitely, i.e., no timeout can occur.
+I<timeout> == 0 enables waiting indefinitely, i.e., no timeout can occur.
 This is the default.
+I<timeout> < 0 takes over any value set via the I<overall_timeout> argument of
+L<OSSL_HTTP_open(3)> with the default being 0, which means no timeout.
 If the I<keep_alive> parameter is 0, which is the default, the connection is not
 kept open after receiving a response. This is the default behavior for HTTP 1.0.
 If the value is 1 or 2 then a persistent connection is requested.

--- a/include/openssl/ocsp.h.in
+++ b/include/openssl/ocsp.h.in
@@ -180,8 +180,9 @@ typedef OSSL_HTTP_REQ_CTX OCSP_REQ_CTX;
         OSSL_HTTP_REQ_CTX_new(io, io, buf_size)
 #   define OCSP_REQ_CTX_free OSSL_HTTP_REQ_CTX_free
 #   define OCSP_REQ_CTX_http(rctx, op, path) \
-        OSSL_HTTP_REQ_CTX_set_request_line(rctx, strcmp(op, "POST") == 0, \
-                                           NULL, NULL, path)
+        (OSSL_HTTP_REQ_CTX_set_expected(rctx, NULL, 1 /* asn1 */, 0, 0) && \
+         OSSL_HTTP_REQ_CTX_set_request_line(rctx, strcmp(op, "POST") == 0, \
+                                            NULL, NULL, path))
 #   define OCSP_REQ_CTX_add1_header OSSL_HTTP_REQ_CTX_add1_header
 #   define OCSP_REQ_CTX_i2d(r, it, req) \
         OSSL_HTTP_REQ_CTX_set1_req(r, "application/ocsp-request", it, req)


### PR DESCRIPTION
This fixes a subtle bug in the compatibility declaration of the undocumented legacy OCSP HTTP API function `OCSP_REQ_CTX_http()`, which must always expect ASN.1 formatted input. 
This also is a workaround for the strange situation described in #16028 that connect BIOs do not support `BIO_gets()`.

Also improve the documentation of `OSSL_HTTP_REQ_CTX_set_expected()` for the corner case `timeout` param < 0.

- [x] documentation is added or updated
