### PR TITLE
BIO_lookup_ex: use AI_ADDRCONFIG only if explicit host name is given

### DIFF
--- a/crypto/bio/bio_addr.c
+++ b/crypto/bio/bio_addr.c
@@ -696,7 +696,7 @@ int BIO_lookup_ex(const char *host, const char *service, int lookup_type,
         hints.ai_protocol = protocol;
 # ifdef AI_ADDRCONFIG
 #  ifdef AF_UNSPEC
-        if (family == AF_UNSPEC)
+        if (host != NULL && family == AF_UNSPEC)
 #  endif
             hints.ai_flags |= AI_ADDRCONFIG;
 # endif


### PR DESCRIPTION
The flag only affects which record types are queried via DNS (A or
AAAA, or both).  When node is NULL and AF_UNSPEC is used, it prevents
getaddrinfo returning the right address associated with the loopback
interface.

Signed-off-by: Daiki Ueno <dueno@redhat.com>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
