### PR TITLE
BIO_lookup_ex: use AI_ADDRCONFIG only if explicit host name is given [1.1.1]

### DIFF
--- a/crypto/bio/b_addr.c
+++ b/crypto/bio/b_addr.c
@@ -689,7 +689,7 @@ int BIO_lookup_ex(const char *host, const char *service, int lookup_type,
         hints.ai_protocol = protocol;
 # ifdef AI_ADDRCONFIG
 #  ifdef AF_UNSPEC
-        if (family == AF_UNSPEC)
+        if (host != NULL && family == AF_UNSPEC)
 #  endif
             hints.ai_flags |= AI_ADDRCONFIG;
 # endif


### PR DESCRIPTION
Backport of #16033 to the 1.1.1 branch.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
