### PR TITLE
Add CI to error on FIPS checksum changes

### DIFF
--- a/.github/workflows/fips-checksums.yml
+++ b/.github/workflows/fips-checksums.yml
@@ -57,3 +57,29 @@ jobs:
         with:
           name: fips_checksum
           path: artifact/
+  verify-checksums:
+    runs-on: ubuntu-latest
+    steps:
+      - name: install unifdef
+        run: |
+            sudo apt-get update
+            sudo apt-get -yq --no-install-suggests --no-install-recommends --force-yes install unifdef
+      - uses: actions/checkout@v2
+      - name: create build dirs
+        run: |
+          mkdir ./build
+      - name: config
+        run: ../config enable-fips && perl configdata.pm --dump
+        working-directory: ./build
+      - name: make build_generated
+        run: make -s build_generated
+        working-directory: ./build
+      - name: make fips-checksums
+        run: make fips-checksums
+        working-directory: ./build
+      - name: make fips-checksums
+        run: make fips-checksums
+        working-directory: ./build
+      - name: make diff-fips-checksums
+        run: make diff-fips-checksums
+        working-directory: ./build


### PR DESCRIPTION
The current CI workflow for FIPS checksums (compute-checksums) does not
error out when FIPS checksum files need to be updated.

This CI workflow errors out when the checksum files change; indicating
that the PR needs to update those files.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [X] tests are added or updated
