### PR TITLE
Fix CMP mock server w.r.t. use of reference certificate for KUR and RR

### DIFF
--- a/apps/cmp.c
+++ b/apps/cmp.c
@@ -174,6 +174,7 @@ static char *opt_srv_keypass = NULL;
 
 static char *opt_srv_trusted = NULL;
 static char *opt_srv_untrusted = NULL;
+static char *opt_ref_cert = NULL;
 static char *opt_rsp_cert = NULL;
 static char *opt_rsp_extracerts = NULL;
 static char *opt_rsp_capubs = NULL;
@@ -249,7 +250,7 @@ typedef enum OPTION_choice {
     OPT_SRV_REF, OPT_SRV_SECRET,
     OPT_SRV_CERT, OPT_SRV_KEY, OPT_SRV_KEYPASS,
     OPT_SRV_TRUSTED, OPT_SRV_UNTRUSTED,
-    OPT_RSP_CERT, OPT_RSP_EXTRACERTS, OPT_RSP_CAPUBS,
+    OPT_REF_CERT, OPT_RSP_CERT, OPT_RSP_EXTRACERTS, OPT_RSP_CAPUBS,
     OPT_POLL_COUNT, OPT_CHECK_AFTER,
     OPT_GRANT_IMPLICITCONF,
     OPT_PKISTATUS, OPT_FAILURE,
@@ -498,6 +499,8 @@ const OPTIONS cmp_options[] = {
      "Trusted certificates for client authentication"},
     {"srv_untrusted", OPT_SRV_UNTRUSTED, 's',
      "Intermediate certs that may be useful for verifying CMP protection"},
+    {"ref_cert", OPT_RSP_CERT, 's',
+     "Certificate to be expected for rr and any oldCertID in kur messages"},
     {"rsp_cert", OPT_RSP_CERT, 's',
      "Certificate to be returned as mock enrollment result"},
     {"rsp_extracerts", OPT_RSP_EXTRACERTS, 's',
@@ -600,7 +603,7 @@ static varref cmp_vars[] = { /* must be in same order as enumerated above! */
     {&opt_srv_ref}, {&opt_srv_secret},
     {&opt_srv_cert}, {&opt_srv_key}, {&opt_srv_keypass},
     {&opt_srv_trusted}, {&opt_srv_untrusted},
-    {&opt_rsp_cert}, {&opt_rsp_extracerts}, {&opt_rsp_capubs},
+    {&opt_ref_cert}, {&opt_rsp_cert}, {&opt_rsp_extracerts}, {&opt_rsp_capubs},
     {(char **)&opt_poll_count}, {(char **)&opt_check_after},
     {(char **)&opt_grant_implicitconf},
     {(char **)&opt_pkistatus}, {(char **)&opt_failure},
@@ -1074,6 +1077,18 @@ static OSSL_CMP_SRV_CTX *setup_srv_ctx(ENGINE *engine)
                      (add_X509_stack_fn_t)OSSL_CMP_CTX_set1_untrusted))
         goto err;
 
+    if (opt_ref_cert != NULL) {
+        X509 *cert = load_cert_pwd(opt_ref_cert, opt_keypass,
+                                   "reference cert to be expected by the mock server");
+
+        if (cert == NULL)
+            goto err;
+        if (!ossl_cmp_mock_srv_set1_refCert(srv_ctx, cert)) {
+            X509_free(cert);
+            goto err;
+        }
+        X509_free(cert);
+    }
     if (opt_rsp_cert == NULL) {
         CMP_warn("no -rsp_cert given for mock server");
     } else {
@@ -1082,7 +1097,6 @@ static OSSL_CMP_SRV_CTX *setup_srv_ctx(ENGINE *engine)
 
         if (cert == NULL)
             goto err;
-        /* from server perspective the server is the client */
         if (!ossl_cmp_mock_srv_set1_certOut(srv_ctx, cert)) {
             X509_free(cert);
             goto err;
@@ -2569,6 +2583,9 @@ static int get_opts(int argc, char **argv)
             break;
         case OPT_SRV_UNTRUSTED:
             opt_srv_untrusted = opt_str();
+            break;
+        case OPT_REF_CERT:
+            opt_ref_cert = opt_str();
             break;
         case OPT_RSP_CERT:
             opt_rsp_cert = opt_str();

--- a/apps/include/cmp_mock_srv.h
+++ b/apps/include/cmp_mock_srv.h
@@ -20,6 +20,7 @@ OSSL_CMP_SRV_CTX *ossl_cmp_mock_srv_new(OSSL_LIB_CTX *libctx,
                                         const char *propq);
 void ossl_cmp_mock_srv_free(OSSL_CMP_SRV_CTX *srv_ctx);
 
+int ossl_cmp_mock_srv_set1_refCert(OSSL_CMP_SRV_CTX *srv_ctx, X509 *cert);
 int ossl_cmp_mock_srv_set1_certOut(OSSL_CMP_SRV_CTX *srv_ctx, X509 *cert);
 int ossl_cmp_mock_srv_set1_chainOut(OSSL_CMP_SRV_CTX *srv_ctx,
                                     STACK_OF(X509) *chain);

--- a/doc/internal/man3/ossl_cmp_mock_srv_new.pod
+++ b/doc/internal/man3/ossl_cmp_mock_srv_new.pod
@@ -4,6 +4,7 @@
 
 ossl_cmp_mock_srv_new,
 ossl_cmp_mock_srv_free,
+ossl_cmp_mock_srv_set1_refCert,
 ossl_cmp_mock_srv_set1_certOut,
 ossl_cmp_mock_srv_set1_chainOut,
 ossl_cmp_mock_srv_set1_caPubsOut,
@@ -20,6 +21,7 @@ ossl_cmp_mock_srv_set_checkAfterTime
  OSSL_CMP_SRV_CTX *ossl_cmp_mock_srv_new(OSSL_LIB_CTX *libctx, const char *propq);
  void ossl_cmp_mock_srv_free(OSSL_CMP_SRV_CTX *srv_ctx);
 
+ int ossl_cmp_mock_srv_set1_refCert(OSSL_CMP_SRV_CTX *srv_ctx, X509 *cert);
  int ossl_cmp_mock_srv_set1_certOut(OSSL_CMP_SRV_CTX *srv_ctx, X509 *cert);
  int ossl_cmp_mock_srv_set1_chainOut(OSSL_CMP_SRV_CTX *srv_ctx,
                                      STACK_OF(X509) *chain);
@@ -39,12 +41,18 @@ I<propq>, both of which may be NULL to select the defaults.
 
 ossl_cmp_mock_srv_free() deallocates the contexts for the CMP mock server.
 
+OSSL_CMP_SRV_CTX_set1_refCert() sets the reference certificate to be expected
+for rr messages and for any oldCertID included in kur messages.
+
 OSSL_CMP_SRV_CTX_set1_certOut() sets the certificate to be returned in
 cp/ip/kup.
+Note that on each certificate request the mock server does not produce
+a fresh certificate but just returns the same pre-existing certificate.
 
 OSSL_CMP_SRV_CTX_set1_chainOut() sets the certificate chain to be added to
 the extraCerts in a cp/ip/kup.
-It should to useful to validate B<certOut>.
+It should to useful to validate the certificate given via
+OSSL_CMP_SRV_CTX_set1_certOut().
 
 OSSL_CMP_SRV_CTX_set1_caPubsOut() sets the caPubs to be returned in an ip.
 

--- a/doc/internal/man3/ossl_cmp_mock_srv_new.pod
+++ b/doc/internal/man3/ossl_cmp_mock_srv_new.pod
@@ -51,7 +51,7 @@ a fresh certificate but just returns the same pre-existing certificate.
 
 OSSL_CMP_SRV_CTX_set1_chainOut() sets the certificate chain to be added to
 the extraCerts in a cp/ip/kup.
-It should to useful to validate the certificate given via
+It should be useful for the validation of the certificate given via
 OSSL_CMP_SRV_CTX_set1_certOut().
 
 OSSL_CMP_SRV_CTX_set1_caPubsOut() sets the caPubs to be returned in an ip.

--- a/doc/man1/openssl-cmp.pod.in
+++ b/doc/man1/openssl-cmp.pod.in
@@ -123,6 +123,7 @@ Mock server options:
 [B<-srv_keypass> I<arg>]
 [B<-srv_trusted> I<filenames>|I<uris>]
 [B<-srv_untrusted> I<filenames>|I<uris>]
+[B<-ref_cert> I<filename>|I<uri>]
 [B<-rsp_cert> I<filename>|I<uri>]
 [B<-rsp_extracerts> I<filenames>|I<uris>]
 [B<-rsp_capubs> I<filenames>|I<uris>]
@@ -958,6 +959,10 @@ have no effect on the certificate verification enabled via this option.
 =item B<-srv_untrusted> I<filenames>|I<uris>
 
 Intermediate CA certs that may be useful when validating client certificates.
+
+=item B<-ref_cert> I<filename>|I<uri>
+
+Certificate to be expected for RR messages and any oldCertID in KUR messages.
 
 =item B<-rsp_cert> I<filename>|I<uri>
 

--- a/doc/man3/X509_cmp.pod
+++ b/doc/man3/X509_cmp.pod
@@ -29,7 +29,8 @@ I<a> and I<b>. The comparison is based on the B<memcmp> result of the hash
 values of two B<X509> objects and the canonical (DER) encoding values.
 
 The X509_NAME_cmp() function compares two B<X509_NAME> objects indicated by
-parameters I<a> and I<b>. The comparison is based on the B<memcmp> result of the
+parameters I<a> and I<b>, any of which may be NULL.
+The comparison is based on the B<memcmp> result of the
 canonical (DER) encoding values of the two objects using L<i2d_X509_NAME(3)>.
 This procedure adheres to the matching rules for Distinguished Names (DN)
 given in RFC 4517 section 4.2.15 and RFC 5280 section 7.1.

--- a/test/cmp_client_test.c
+++ b/test/cmp_client_test.c
@@ -62,6 +62,7 @@ static CMP_SES_TEST_FIXTURE *set_up(const char *const test_case_name)
     fixture->test_case_name = test_case_name;
     if (!TEST_ptr(fixture->srv_ctx = ossl_cmp_mock_srv_new(libctx, NULL))
             || !OSSL_CMP_SRV_CTX_set_accept_unprotected(fixture->srv_ctx, 1)
+            || !ossl_cmp_mock_srv_set1_refCert(fixture->srv_ctx, client_cert)
             || !ossl_cmp_mock_srv_set1_certOut(fixture->srv_ctx, client_cert)
             || (srv_cmp_ctx =
                 OSSL_CMP_SRV_CTX_get0_cmp_ctx(fixture->srv_ctx)) == NULL

--- a/test/recipes/80-test_cmp_http_data/Mock/server.cnf
+++ b/test/recipes/80-test_cmp_http_data/Mock/server.cnf
@@ -9,6 +9,7 @@ srv_secret = pass:test
 no_check_time = 1
 srv_trusted = signer_root.crt
 
+ref_cert = signer_only.crt
 rsp_cert = signer_only.crt
 rsp_capubs = signer_root.crt
 rsp_extracerts = signer_issuing.crt


### PR DESCRIPTION
* CMP mock server: add `-ref_cert` option and corresponding `ossl_cmp_mock_srv_set1_refCert()` and update tests
   Fixes #16041

* `X509_cmp.pod:` Point out that the `X509_NAME_cmp()` arguments may be `NULL`
  (This was not document yet and is used in the fix.)

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
