### PR TITLE
Fix CMP client and server diagnostics

### DIFF
--- a/apps/cmp.c
+++ b/apps/cmp.c
@@ -613,6 +613,12 @@ static int print_to_bio_out(const char *func, const char *file, int line,
     return OSSL_CMP_print_to_bio(bio_out, func, file, line, level, msg);
 }
 
+static int print_to_bio_err(const char *func, const char *file, int line,
+                            OSSL_CMP_severity level, const char *msg)
+{
+    return OSSL_CMP_print_to_bio(bio_err, func, file, line, level, msg);
+}
+
 static int set_verbosity(int level)
 {
     if (level < OSSL_CMP_LOG_EMERG || level > OSSL_CMP_LOG_MAX) {
@@ -2068,16 +2074,16 @@ static int read_config(void)
     long num = 0;
     char *txt = NULL;
     const OPTIONS *opt;
-    int start = OPT_VERBOSITY;
+    int start_opt = OPT_VERBOSITY - OPT_HELP;
+    int start_idx = OPT_VERBOSITY - 2;
     /*
      * starting with offset OPT_VERBOSITY because OPT_CONFIG and OPT_SECTION
      * would not make sense within the config file.
-     * Moreover, these two options and OPT_VERBOSITY have already been handled.
      */
     int n_options = OSSL_NELEM(cmp_options) - 1;
 
-    for (i = start - OPT_HELP, opt = &cmp_options[start];
-         opt->name; i++, opt++)
+    for (opt = &cmp_options[start_opt], i = start_idx;
+         opt->name != NULL; i++, opt++)
         if (!strcmp(opt->name, OPT_SECTION_STR)
                 || !strcmp(opt->name, OPT_MORE_STR))
             n_options--;
@@ -2085,8 +2091,8 @@ static int read_config(void)
                  + OPT_PROV__FIRST + 1 - OPT_PROV__LAST
                  + OPT_R__FIRST + 1 - OPT_R__LAST
                  + OPT_V__FIRST + 1 - OPT_V__LAST);
-    for (i = start - OPT_HELP, opt = &cmp_options[start];
-         opt->name; i++, opt++) {
+    for (opt = &cmp_options[start_opt], i = start_idx;
+         opt->name != NULL; i++, opt++) {
         int provider_option = (OPT_PROV__FIRST <= opt->retval
                                && opt->retval < OPT_PROV__LAST);
         int rand_state_option = (OPT_R__FIRST <= opt->retval
@@ -2116,7 +2122,7 @@ static int read_config(void)
                                   num, opt->name);
                 return -1;
             }
-            if (opt->valtype == 'N' && num <= 0) {
+            if (opt->valtype == 'N' && num < 0) {
                 opt_printf_stderr("Negative number \"%ld\" for config option -%s\n",
                                   num, opt->name);
                 return -1;
@@ -2226,7 +2232,10 @@ static int get_opts(int argc, char **argv)
             return -1;
         case OPT_CONFIG: /* has already been handled */
         case OPT_SECTION: /* has already been handled */
-        case OPT_VERBOSITY: /* has already been handled */
+            break;
+        case OPT_VERBOSITY:
+            if (!set_verbosity(opt_int_arg()))
+                goto opthelp;
             break;
         case OPT_SERVER:
             opt_server = opt_str();
@@ -2697,6 +2706,8 @@ int cmp_main(int argc, char **argv)
                 }
             }
             ret = read_config();
+            if (!set_verbosity(opt_verbosity)) /* just for checking range */
+                ret = -1;
             if (ret <= 0) {
                 if (ret == -1)
                     BIO_printf(bio_err, "Use -help for summary.\n");
@@ -2750,7 +2761,7 @@ int cmp_main(int argc, char **argv)
             goto err;
         srv_cmp_ctx = OSSL_CMP_SRV_CTX_get0_cmp_ctx(srv_ctx);
         OSSL_CMP_CTX_set_transfer_cb_arg(cmp_ctx, srv_ctx);
-        if (!OSSL_CMP_CTX_set_log_cb(srv_cmp_ctx, print_to_bio_out)) {
+        if (!OSSL_CMP_CTX_set_log_cb(srv_cmp_ctx, print_to_bio_err)) {
             CMP_err1("cannot set up error reporting and logging for %s", prog);
             goto err;
         }

--- a/crypto/cmp/cmp_server.c
+++ b/crypto/cmp/cmp_server.c
@@ -457,6 +457,9 @@ OSSL_CMP_MSG *OSSL_CMP_SRV_process_request(OSSL_CMP_SRV_CTX *srv_ctx,
     }
     ctx = srv_ctx->ctx;
     backup_secret = ctx->secretValue;
+    req_type = OSSL_CMP_MSG_get_bodytype(req);
+    ossl_cmp_log1(DEBUG, ctx,
+                  "received %s", ossl_cmp_bodytype_to_string(req_type));
 
     /*
      * Some things need to be done already before validating the message in
@@ -469,7 +472,6 @@ OSSL_CMP_MSG *OSSL_CMP_SRV_process_request(OSSL_CMP_SRV_CTX *srv_ctx,
     if (!OSSL_CMP_CTX_set1_recipient(ctx, hdr->sender->d.directoryName))
         goto err;
 
-    req_type = OSSL_CMP_MSG_get_bodytype(req);
     switch (req_type) {
     case OSSL_CMP_PKIBODY_IR:
     case OSSL_CMP_PKIBODY_CR:
@@ -503,8 +505,6 @@ OSSL_CMP_MSG *OSSL_CMP_SRV_process_request(OSSL_CMP_SRV_CTX *srv_ctx,
 #endif
         }
     }
-    ossl_cmp_log1(DEBUG, ctx,
-                  "received %s", ossl_cmp_bodytype_to_string(req_type));
 
     res = ossl_cmp_msg_check_update(ctx, req, unprotected_exception,
                                     srv_ctx->acceptUnprotected);

--- a/test/recipes/80-test_cmp_http_data/Mock/server.cnf
+++ b/test/recipes/80-test_cmp_http_data/Mock/server.cnf
@@ -12,3 +12,5 @@ srv_trusted = signer_root.crt
 rsp_cert = signer_only.crt
 rsp_capubs = signer_root.crt
 rsp_extracerts = signer_issuing.crt
+
+verbosity = 7


### PR DESCRIPTION
Fix various minor bugs in the CMP client and test server ~and underlying HTTP server~:
* Correct the handling of the `-verbosity` option of the CMP app: So far, `verbosity` settings in config file were ignored.
* So far, CMP server logging was not actually visible; this is fixed by sending it to `stderr` rather than `stdout`.
* Make sure that logging of CMP server on received request type is done before checking details,
  such that it is given also for the case that a check fails, where it typically is most interesting.
* Make server diagnostics by `80-test_cmp_http` more verbose: by default, print message types received and responded.
* ~Fix the port output of the HTTP server. So far, on automatic local port selection,
`Awaiting new connection on port 0...` was printed.~
* ~Make the verbosity setting of the HTTP server dynamic~

This has been extracted from #16050 for separate reviewing.