### PR TITLE
Minor cleanup of CMP tests

### DIFF
--- a/test/cmp_client_test.c
+++ b/test/cmp_client_test.c
@@ -13,8 +13,6 @@
 
 #include "cmp_mock_srv.h"
 
-#ifndef NDEBUG /* tests need mock server, which is available only if !NDEBUG */
-
 static const char *server_key_f;
 static const char *server_cert_f;
 static const char *client_key_f;
@@ -344,7 +342,7 @@ void cleanup_tests(void)
     return;
 }
 
-# define USAGE "server.key server.crt client.key client.crt client.csr module_name [module_conf_file]\n"
+#define USAGE "server.key server.crt client.key client.crt client.csr module_name [module_conf_file]\n"
 OPT_TEST_DECLARE_USAGE(USAGE)
 
 int setup_tests(void)
@@ -391,13 +389,3 @@ int setup_tests(void)
     ADD_TEST(test_exchange_error);
     return 1;
 }
-
-#else /* !defined (NDEBUG) */
-
-int setup_tests(void)
-{
-    TEST_note("CMP session tests are disabled in this build (NDEBUG).");
-    return 1;
-}
-
-#endif

--- a/test/recipes/80-test_cmp_http.t
+++ b/test/recipes/80-test_cmp_http.t
@@ -242,7 +242,8 @@ sub load_tests {
         } else {
             $line =~ s{-section,,}{-section,,-proxy,$proxy,};
         }
-        $line =~ s{-section,,}{-section,,-certout,$result_dir/test.cert.pem,};
+        $line =~ s{-section,,}{-section,,-certout,$result_dir/test.cert.pem,}
+            if $aspect ne "commands" || $line =~ m/,\s*-cmd\s*,\s*(ir|cr|p10cr|kur)\s*,/;
         $line =~ s{-section,,}{-config,../$test_config,-section,$server_name $aspect,};
 
         my @fields = grep /\S/, split ",", $line;

--- a/test/recipes/80-test_cmp_http_data/Mock/test.cnf
+++ b/test/recipes/80-test_cmp_http_data/Mock/test.cnf
@@ -84,6 +84,7 @@ extracertsout =
 
 [commands]
 cmd =
+certout =
 cacertsout =
 infotype =
 oldcert =


### PR DESCRIPTION
* `80-test_cmp_http.t:` Remove `-certout` option where not needed
* `cmp_client_test.c:` Remove needless dependency on `NDEBUG`

- [x] tests are added or updated

This has been extracted from #16050 for separate reviewing.