### PR TITLE
Fix HTTP server port output and allow dynamic verbosity setting

### DIFF
--- a/apps/cmp.c
+++ b/apps/cmp.c
@@ -2553,7 +2553,7 @@ static int cmp_server(OSSL_CMP_CTX *srv_cmp_ctx) {
     int retry = 1;
     int ret = 1;
 
-    if ((acbio = http_server_init_bio(prog, opt_port)) == NULL)
+    if ((acbio = http_server_init(prog, opt_port, opt_verbosity)) == NULL)
         return 0;
     while (opt_max_msgs <= 0 || msgs < opt_max_msgs) {
         char *path = NULL;
@@ -2563,7 +2563,7 @@ static int cmp_server(OSSL_CMP_CTX *srv_cmp_ctx) {
         ret = http_server_get_asn1_req(ASN1_ITEM_rptr(OSSL_CMP_MSG),
                                        (ASN1_VALUE **)&req, &path,
                                        &cbio, acbio, &keep_alive,
-                                       prog, opt_port, 0, 0);
+                                       prog, 0, 0);
         if (ret == 0) { /* no request yet */
             if (retry) {
                 ossl_sleep(1000);

--- a/apps/include/http_server.h
+++ b/apps/include/http_server.h
@@ -34,16 +34,18 @@
 #  include <syslog.h>
 #  include <signal.h>
 #  define MAXERRLEN 1000 /* limit error text sent to syslog to 1000 bytes */
-# else
-#  undef LOG_DEBUG
-#  undef LOG_INFO
-#  undef LOG_WARNING
-#  undef LOG_ERR
-#  define LOG_DEBUG     7
-#  define LOG_INFO      6
-#  define LOG_WARNING   4
-#  define LOG_ERR       3
 # endif
+
+# undef LOG_TRACE
+# undef LOG_DEBUG
+# undef LOG_INFO
+# undef LOG_WARNING
+# undef LOG_ERR
+# define LOG_TRACE     8
+# define LOG_DEBUG     7
+# define LOG_INFO      6
+# define LOG_WARNING   4
+# define LOG_ERR       3
 
 /*-
  * Log a message to syslog if multi-threaded HTTP_DAEMON, else to bio_err
@@ -56,12 +58,13 @@ void log_message(const char *prog, int level, const char *fmt, ...);
 
 # ifndef OPENSSL_NO_SOCK
 /*-
- * Initialize an HTTP server by setting up its listening BIO
+ * Initialize an HTTP server, setting up its listening BIO
  * prog: the name of the current app
  * port: the port to listen on
+ * verbosity: the level of verbosity to use, or -1 for default: LOG_INFO
  * returns a BIO for accepting requests, NULL on error
  */
-BIO *http_server_init_bio(const char *prog, const char *port);
+BIO *http_server_init(const char *prog, const char *port, int verbosity);
 
 /*-
  * Accept an ASN.1-formatted HTTP request
@@ -72,7 +75,6 @@ BIO *http_server_init_bio(const char *prog, const char *port);
  * acbio: the listening bio (typically as returned by http_server_init_bio())
  * found_keep_alive: for returning flag if client requests persistent connection
  * prog: the name of the current app, for diagnostics only
- * port: the local port listening to, for diagnostics only
  * accept_get: whether to accept GET requests (in addition to POST requests)
  * timeout: connection timeout (in seconds), or 0 for none/infinite
  * returns 0 in case caller should retry, then *preq == *ppath == *pcbio == NULL
@@ -86,8 +88,7 @@ BIO *http_server_init_bio(const char *prog, const char *port);
 int http_server_get_asn1_req(const ASN1_ITEM *it, ASN1_VALUE **preq,
                              char **ppath, BIO **pcbio, BIO *acbio,
                              int *found_keep_alive,
-                             const char *prog, const char *port,
-                             int accept_get, int timeout);
+                             const char *prog, int accept_get, int timeout);
 
 /*-
  * Send an ASN.1-formatted HTTP response

--- a/apps/include/s_apps.h
+++ b/apps/include/s_apps.h
@@ -16,6 +16,7 @@
 #define PROTOCOL        "tcp"
 
 typedef int (*do_server_cb)(int s, int stype, int prot, unsigned char *context);
+void get_sock_info_address(int asock, char **hostname, char **service);
 int report_server_accept(BIO *out, int asock, int with_address, int with_pid);
 int do_server(int *accept_sock, const char *host, const char *port,
               int family, int type, int protocol, do_server_cb cb,

--- a/apps/lib/s_socket.c
+++ b/apps/lib/s_socket.c
@@ -200,6 +200,25 @@ out:
     return ret;
 }
 
+void get_sock_info_address(int asock, char **hostname, char **service)
+{
+    union BIO_sock_info_u info;
+
+    if (hostname != NULL)
+        *hostname = NULL;
+    if (service != NULL)
+        *service = NULL;
+
+    if ((info.addr = BIO_ADDR_new()) != NULL
+            && BIO_sock_info(asock, BIO_SOCK_INFO_ADDRESS, &info)) {
+        if (hostname != NULL)
+            *hostname = BIO_ADDR_hostname_string(info.addr, 1);
+        if (service != NULL)
+            *service = BIO_ADDR_service_string(info.addr, 1);
+    }
+    BIO_ADDR_free(info.addr);
+}
+
 int report_server_accept(BIO *out, int asock, int with_address, int with_pid)
 {
     int success = 1;
@@ -207,30 +226,24 @@ int report_server_accept(BIO *out, int asock, int with_address, int with_pid)
     if (BIO_printf(out, "ACCEPT") <= 0)
         return 0;
     if (with_address) {
-        union BIO_sock_info_u info;
-        char *hostname = NULL;
-        char *service = NULL;
+        char *hostname, *service;
 
-        if ((info.addr = BIO_ADDR_new()) != NULL
-            && BIO_sock_info(asock, BIO_SOCK_INFO_ADDRESS, &info)
-            && (hostname = BIO_ADDR_hostname_string(info.addr, 1)) != NULL
-            && (service = BIO_ADDR_service_string(info.addr, 1)) != NULL) {
+        get_sock_info_address(asock, &hostname, &service);
+        success = hostname != NULL && service != NULL;
+        if (success)
             success = BIO_printf(out,
                                  strchr(hostname, ':') == NULL
                                  ? /* IPv4 */ " %s:%s"
                                  : /* IPv6 */ " [%s]:%s",
                                  hostname, service) > 0;
-        } else {
+        else
             (void)BIO_printf(out, "unknown:error\n");
-            success = 0;
-        }
         OPENSSL_free(hostname);
         OPENSSL_free(service);
-        BIO_ADDR_free(info.addr);
     }
     if (with_pid)
-        success = success && BIO_printf(out, " PID=%d", getpid()) > 0;
-    success = success && BIO_printf(out, "\n") > 0;
+        success *= BIO_printf(out, " PID=%d", getpid()) > 0;
+    success *= BIO_printf(out, "\n") > 0;
     (void)BIO_flush(out);
 
     return success;

--- a/apps/ocsp.c
+++ b/apps/ocsp.c
@@ -76,7 +76,7 @@ static void make_ocsp_response(BIO *err, OCSP_RESPONSE **resp, OCSP_REQUEST *req
 
 static char **lookup_serial(CA_DB *db, ASN1_INTEGER *ser);
 static int do_responder(OCSP_REQUEST **preq, BIO **pcbio, BIO *acbio,
-                        const char *port, int timeout);
+                        int timeout);
 static int send_ocsp_response(BIO *cbio, const OCSP_RESPONSE *resp);
 static char *prog;
 
@@ -576,7 +576,7 @@ int ocsp_main(int argc, char **argv)
 
     if (req == NULL && port != NULL) {
 #ifndef OPENSSL_NO_SOCK
-        acbio = http_server_init_bio(prog, port);
+        acbio = http_server_init(prog, port, -1);
         if (acbio == NULL)
             goto end;
 #else
@@ -657,7 +657,7 @@ redo_accept:
 #endif
 
         req = NULL;
-        res = do_responder(&req, &cbio, acbio, port, req_timeout);
+        res = do_responder(&req, &cbio, acbio, req_timeout);
         if (res == 0)
             goto redo_accept;
 
@@ -1188,13 +1188,13 @@ static char **lookup_serial(CA_DB *db, ASN1_INTEGER *ser)
 }
 
 static int do_responder(OCSP_REQUEST **preq, BIO **pcbio, BIO *acbio,
-                        const char *port, int timeout)
+                        int timeout)
 {
 #ifndef OPENSSL_NO_SOCK
     return http_server_get_asn1_req(ASN1_ITEM_rptr(OCSP_REQUEST),
                                     (ASN1_VALUE **)preq, NULL, pcbio, acbio,
                                     NULL /* found_keep_alive */,
-                                    prog, port, 1 /* accept_get */, timeout);
+                                    prog, 1 /* accept_get */, timeout);
 #else
     BIO_printf(bio_err,
                "Error getting OCSP request - sockets not supported\n");


### PR DESCRIPTION
Fix various minor issues with the HTTP server:

* Fix the port output of the HTTP server. 
So far, on automatic local port selection, `Awaiting new connection on port 0...` was printed.
* Make the verbosity setting of the HTTP server dynamic.

This has been extracted from #16051 for separate treatment.