### PR TITLE
Make EVP_PKEY_check() an alias for EVP_PKEY_pairwise_check()

### DIFF
--- a/crypto/evp/pmeth_check.c
+++ b/crypto/evp/pmeth_check.c
@@ -152,26 +152,12 @@ int EVP_PKEY_private_check(EVP_PKEY_CTX *ctx)
     return -2;
 }
 
-int EVP_PKEY_pairwise_check(EVP_PKEY_CTX *ctx)
+int EVP_PKEY_check(EVP_PKEY_CTX *ctx)
 {
-    EVP_PKEY *pkey = ctx->pkey;
-    int ok;
-
-    if (pkey == NULL) {
-        ERR_raise(ERR_LIB_EVP, EVP_R_NO_KEY_SET);
-        return 0;
-    }
-
-    if ((ok = try_provided_check(ctx, OSSL_KEYMGMT_SELECT_KEYPAIR,
-                                 OSSL_KEYMGMT_VALIDATE_FULL_CHECK)) != -1)
-        return ok;
-
-    /* not supported for legacy keys */
-    ERR_raise(ERR_LIB_EVP, EVP_R_OPERATION_NOT_SUPPORTED_FOR_THIS_KEYTYPE);
-    return -2;
+    return EVP_PKEY_pairwise_check(ctx);
 }
 
-int EVP_PKEY_check(EVP_PKEY_CTX *ctx)
+int EVP_PKEY_pairwise_check(EVP_PKEY_CTX *ctx)
 {
     EVP_PKEY *pkey = ctx->pkey;
     int ok;

--- a/doc/man3/EVP_PKEY_check.pod
+++ b/doc/man3/EVP_PKEY_check.pod
@@ -44,7 +44,7 @@ EVP_PKEY_private_check() validates the private component of the key given by B<c
 EVP_PKEY_pairwise_check() validates that the public and private components have
 the correct mathematical relationship to each other for the key given by B<ctx>.
 
-EVP_PKEY_check() is an alias of the EVP_PKEY_pairwise_check() function.
+EVP_PKEY_check() is an alias for the EVP_PKEY_pairwise_check() function.
 
 =head1 NOTES
 

--- a/doc/man3/EVP_PKEY_check.pod
+++ b/doc/man3/EVP_PKEY_check.pod
@@ -44,7 +44,7 @@ EVP_PKEY_private_check() validates the private component of the key given by B<c
 EVP_PKEY_pairwise_check() validates that the public and private components have
 the correct mathematical relationship to each other for the key given by B<ctx>.
 
-EVP_PKEY_check() validates all components of a key given by B<ctx>.
+EVP_PKEY_check() is an alias of the EVP_PKEY_pairwise_check() function.
 
 =head1 NOTES
 


### PR DESCRIPTION
The implementation of EVP_PKEY_pairwise_check() is also changed
to handle the legacy keys.

Fixes #16046

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
