### PR TITLE
doc: Document that incomplete certificates return error

### DIFF
--- a/doc/man3/X509_check_ca.pod
+++ b/doc/man3/X509_check_ca.pod
@@ -13,7 +13,8 @@ X509_check_ca - check if given certificate is CA certificate
 =head1 DESCRIPTION
 
 This function checks if given certificate is CA certificate (can be used
-to sign other certificates).
+to sign other certificates). The certificate must be a complete certificate
+otherwise an error is returned.
 
 =head1 RETURN VALUES
 

--- a/doc/man3/X509_check_issued.pod
+++ b/doc/man3/X509_check_issued.pod
@@ -21,7 +21,8 @@ but also compares all sub-fields of the B<authorityKeyIdentifier> extension of
 I<subject>, as far as present, with the respective B<subjectKeyIdentifier>,
 serial number, and issuer fields of I<issuer>, as far as present. It also checks
 if the B<keyUsage> field (if present) of I<issuer> allows certificate signing.
-It does not actually check the certificate signature.
+It does not actually check the certificate signature. An error is returned
+if the I<issuer> or the I<subject> are incomplete certificates.
 
 =head1 RETURN VALUES
 

--- a/doc/man3/X509_check_purpose.pod
+++ b/doc/man3/X509_check_purpose.pod
@@ -15,7 +15,8 @@ X509_check_purpose - Check the purpose of a certificate
 This function checks if certificate I<x> was created with the purpose
 represented by I<id>. If I<ca> is nonzero, then certificate I<x> is
 checked to determine if it's a possible CA with various levels of certainty
-possibly returned.
+possibly returned. The certificate I<x> must be a complete certificate
+otherwise the function returns an error.
 
 Below are the potential ID's that can be checked:
 

--- a/doc/man3/X509_verify.pod
+++ b/doc/man3/X509_verify.pod
@@ -25,7 +25,7 @@ X509_verify() verifies the signature of certificate I<x> using public key
 I<pkey>. Only the signature is checked: no other checks (such as certificate
 chain validity) are performed.
 
-X509_self_signed() checks whether a certificate is self-signed.
+X509_self_signed() checks whether certificate I<cert> is self-signed.
 For success the issuer and subject names must match, the components of the
 authority key identifier (if present) must match the subject key identifier etc.
 The signature itself is actually verified only if B<verify_signature> is 1, as
@@ -39,8 +39,9 @@ verify the signatures of certificate requests and CRLs, respectively.
 X509_verify(),
 X509_REQ_verify_ex(), X509_REQ_verify() and X509_CRL_verify()
 return 1 if the signature is valid and 0 if the signature check fails.
-If the signature could not be checked at all because it was ill-formed
-or some other error occurred then -1 is returned.
+If the signature could not be checked at all because it was ill-formed,
+the certificate or the request was not complete or some other error occurred
+then -1 is returned.
 
 X509_self_signed() returns the same values but also returns 1
 if all respective fields match and B<verify_signature> is 0.


### PR DESCRIPTION
Fixes #16065

It is actually not true that this is completely new behavior in 3.0 (except maybe in 1.1.1 some of invalid certificates did not generate the error).

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
