### PR TITLE
document params arguments to EVP_DigestSignInit_ex and EVP_DigestSignVerify_ex

### DIFF
--- a/crypto/evp/m_sigver.c
+++ b/crypto/evp/m_sigver.c
@@ -40,7 +40,7 @@ static int do_sigver_init(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx,
                           const EVP_MD *type, const char *mdname,
                           OSSL_LIB_CTX *libctx, const char *props,
                           ENGINE *e, EVP_PKEY *pkey, int ver,
-                          OSSL_PARAM params[])
+                          const OSSL_PARAM params[])
 {
     EVP_PKEY_CTX *locpctx = NULL;
     EVP_SIGNATURE *signature = NULL;
@@ -304,7 +304,7 @@ static int do_sigver_init(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx,
 int EVP_DigestSignInit_ex(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx,
                           const char *mdname, OSSL_LIB_CTX *libctx,
                           const char *props, EVP_PKEY *pkey,
-                          OSSL_PARAM params[])
+                          const OSSL_PARAM params[])
 {
     return do_sigver_init(ctx, pctx, NULL, mdname, libctx, props, NULL, pkey, 0,
                           params);
@@ -320,7 +320,7 @@ int EVP_DigestSignInit(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx,
 int EVP_DigestVerifyInit_ex(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx,
                             const char *mdname, OSSL_LIB_CTX *libctx,
                             const char *props, EVP_PKEY *pkey,
-                            OSSL_PARAM params[])
+                            const OSSL_PARAM params[])
 {
     return do_sigver_init(ctx, pctx, NULL, mdname, libctx, props, NULL, pkey, 1,
                           params);

--- a/doc/man3/EVP_DigestSignInit.pod
+++ b/doc/man3/EVP_DigestSignInit.pod
@@ -11,7 +11,8 @@ EVP_DigestSignFinal, EVP_DigestSign - EVP signing functions
 
  int EVP_DigestSignInit_ex(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx,
                            const char *mdname, OSSL_LIB_CTX *libctx,
-                           const char *props, EVP_PKEY *pkey);
+                           const char *props, EVP_PKEY *pkey,
+                           const OSSL_PARAM params[]);
  int EVP_DigestSignInit(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx,
                         const EVP_MD *type, ENGINE *e, EVP_PKEY *pkey);
  int EVP_DigestSignUpdate(EVP_MD_CTX *ctx, const void *d, size_t cnt);
@@ -33,7 +34,8 @@ provider interprets the digest name is provider specific. The provider may
 implement that digest directly itself or it may (optionally) choose to fetch it
 (which could result in a digest from a different provider being selected). If the
 provider supports fetching the digest then it may use the I<props> argument for
-the properties to be used during the fetch.
+the properties to be used during the fetch. Finally, the passed parameters
+I<params>, if not NULL, are set on the context before returning.
 
 The I<pkey> algorithm is used to fetch a B<EVP_SIGNATURE> method implicitly, to
 be used for the actual signing. See L<provider(7)/Implicit fetch> for

--- a/doc/man3/EVP_DigestVerifyInit.pod
+++ b/doc/man3/EVP_DigestVerifyInit.pod
@@ -11,7 +11,8 @@ EVP_DigestVerifyFinal, EVP_DigestVerify - EVP signature verification functions
 
  int EVP_DigestVerifyInit_ex(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx,
                              const char *mdname, OSSL_LIB_CTX *libctx,
-                             const char *props, EVP_PKEY *pkey);
+                             const char *props, EVP_PKEY *pkey,
+                             const OSSL_PARAM params[]);
  int EVP_DigestVerifyInit(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx,
                           const EVP_MD *type, ENGINE *e, EVP_PKEY *pkey);
  int EVP_DigestVerifyUpdate(EVP_MD_CTX *ctx, const void *d, size_t cnt);
@@ -32,7 +33,8 @@ provider interprets the digest name is provider specific. The provider may
 implement that digest directly itself or it may (optionally) choose to fetch it
 (which could result in a digest from a different provider being selected). If
 the provider supports fetching the digest then it may use the B<props> argument
-for the properties to be used during the fetch.
+for the properties to be used during the fetch. Finally, the passed parameters
+I<params>, if not NULL, are set on the context before returning.
 
 The I<pkey> algorithm is used to fetch a B<EVP_SIGNATURE> method implicitly, to
 be used for the actual signing. See L<provider(7)/Implicit fetch> for

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -820,7 +820,7 @@ __owur int EVP_DigestVerify(EVP_MD_CTX *ctx, const unsigned char *sigret,
 int EVP_DigestSignInit_ex(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx,
                           const char *mdname, OSSL_LIB_CTX *libctx,
                           const char *props, EVP_PKEY *pkey,
-                          OSSL_PARAM params[]);
+                          const OSSL_PARAM params[]);
 /*__owur*/ int EVP_DigestSignInit(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx,
                                   const EVP_MD *type, ENGINE *e,
                                   EVP_PKEY *pkey);
@@ -831,7 +831,7 @@ __owur int EVP_DigestSignFinal(EVP_MD_CTX *ctx, unsigned char *sigret,
 int EVP_DigestVerifyInit_ex(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx,
                             const char *mdname, OSSL_LIB_CTX *libctx,
                             const char *props, EVP_PKEY *pkey,
-                            OSSL_PARAM params[]);
+                            const OSSL_PARAM params[]);
 __owur int EVP_DigestVerifyInit(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx,
                                 const EVP_MD *type, ENGINE *e,
                                 EVP_PKEY *pkey);


### PR DESCRIPTION
The documentation for these was accidentally missed in the PR that introduced them.
Also made the param arrays const since they should have been.

Fixes #16067

- [x] documentation is added or updated
- [ ] tests are added or updated
