### PR TITLE
Signature algos: allow having identical digest in params

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,7 +215,7 @@ jobs:
         mkdir ./build
         mkdir ./install
     - name: config
-      run: ../config --banner=Configured enable-fips --strict-warnings --prefix=$(cd ../install; pwd) && perl configdata.pm --dump
+      run: ../config --banner=Configured enable-fips enable-acvp-tests --strict-warnings --prefix=$(cd ../install; pwd) && perl configdata.pm --dump
       working-directory: ./build
     - name: make
       run: make -s -j4

--- a/.github/workflows/run-checker-daily.yml
+++ b/.github/workflows/run-checker-daily.yml
@@ -11,7 +11,6 @@ jobs:
       matrix:
         opt: [
           386,
-          enable-acvp-tests,
           no-afalgeng,
           no-aria,
           no-asan,

--- a/providers/implementations/signature/rsa_sig.c
+++ b/providers/implementations/signature/rsa_sig.c
@@ -305,6 +305,17 @@ static int rsa_setup_md(PROV_RSA_CTX *ctx, const char *mdname,
             return 0;
         }
 
+        if (!ctx->flag_allow_md) {
+            if (ctx->mdname[0] != '\0' && !EVP_MD_is_a(md, ctx->mdname)) {
+                ERR_raise_data(ERR_LIB_PROV, PROV_R_DIGEST_NOT_ALLOWED,
+                               "digest %s != %s", mdname, ctx->mdname);
+                EVP_MD_free(md);
+                return 0;
+            }
+            EVP_MD_free(md);
+            return 1;
+        }
+
         if (!ctx->mgf1_md_set) {
             if (!EVP_MD_up_ref(md)) {
                 EVP_MD_free(md);
@@ -826,8 +837,6 @@ static int rsa_digest_signverify_init(void *vprsactx, const char *mdname,
     if (!ossl_prov_is_running())
         return 0;
 
-    if (prsactx != NULL)
-        prsactx->flag_allow_md = 0;
     if (!rsa_signverify_init(vprsactx, vrsa, params, operation))
         return 0;
     if (mdname != NULL
@@ -836,6 +845,7 @@ static int rsa_digest_signverify_init(void *vprsactx, const char *mdname,
         && !rsa_setup_md(prsactx, mdname, prsactx->propq))
         return 0;
 
+    prsactx->flag_allow_md = 0;
     prsactx->mdctx = EVP_MD_CTX_new();
     if (prsactx->mdctx == NULL) {
         ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
@@ -1141,9 +1151,6 @@ static int rsa_set_ctx_params(void *vprsactx, const OSSL_PARAM params[])
     saltlen = prsactx->saltlen;
 
     p = OSSL_PARAM_locate_const(params, OSSL_SIGNATURE_PARAM_DIGEST);
-    /* Not allowed during certain operations */
-    if (p != NULL && !prsactx->flag_allow_md)
-        return 0;
     if (p != NULL) {
         const OSSL_PARAM *propsp =
             OSSL_PARAM_locate_const(params,

--- a/test/acvp_test.c
+++ b/test/acvp_test.c
@@ -1227,10 +1227,10 @@ static int rsa_sigver_test(int id)
         || !TEST_ptr(md_ctx = EVP_MD_CTX_new())
         || !TEST_true(EVP_DigestVerifyInit_ex(md_ctx, &pkey_ctx,
                                               tst->digest_alg, libctx, NULL,
-                                              pkey, NULL)
+                                              pkey, NULL))
         || !TEST_true(EVP_PKEY_CTX_set_params(pkey_ctx, params))
         || !TEST_int_eq(EVP_DigestVerify(md_ctx, tst->sig, tst->sig_len,
-                                         tst->msg, tst->msg_len), tst->pass)))
+                                         tst->msg, tst->msg_len), tst->pass))
         goto err;
     ret = 1;
 err:


### PR DESCRIPTION
The flag_allow_md prevents setting a digest in params however this is unnecessarily strict. If the digest is the same as the one already set, we do not return an error.

Fixes #16071