### PR TITLE
Fix SSL_key_update() problems

### DIFF
--- a/ssl/record/ssl3_buffer.c
+++ b/ssl/record/ssl3_buffer.c
@@ -73,7 +73,6 @@ int ssl3_setup_read_buffer(SSL *s)
         b->len = len;
     }
 
-    RECORD_LAYER_set_packet(&s->rlayer, &(b->buf[0]));
     return 1;
 }
 

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -2262,6 +2262,11 @@ int SSL_key_update(SSL *s, int updatetype)
         return 0;
     }
 
+    if (RECORD_LAYER_write_pending(&s->rlayer)) {
+        ERR_raise(ERR_LIB_SSL, SSL_R_BAD_WRITE_RETRY);
+        return 0;
+    }
+
     ossl_statem_set_in_init(s, 1);
     s->key_update = updatetype;
     return 1;


### PR DESCRIPTION
This contains 2 fixes affecting SSL_key_update():

- Don't reset the packet pointer in ssl3_setup_read_buffer

Sometimes this function gets called when the buffers have already been
set up. If there is already a partial packet in the read buffer then the
packet pointer will be set to an incorrect value. The packet pointer already
gets reset to the correct value when we first read a packet anyway, so we
don't also need to do it in ssl3_setup_read_buffer.

- Disallow SSL_key_update() if there are writes pending

If an application is halfway through writing application data it should
not be allowed to attempt an SSL_key_update() operation. Instead the
SSL_write() operation should be completed.

The former issue can result in a "bad record mac" problem if a partial record read occurs around the same time as a key update.

Fixes #13729
Fixes #12485

PR #16021 will provide tests for these scenarios.

This should also be applied to 1.1.1, but I will wait until this is approved to create a PR there since it requires some minor adjustment there.