### PR TITLE
doc: It is not possible to use SSL_OP_* value in preprocessor conditions

### DIFF
--- a/doc/man3/SSL_CTX_set_options.pod
+++ b/doc/man3/SSL_CTX_set_options.pod
@@ -427,6 +427,12 @@ were added in OpenSSL 1.1.1.
 The B<SSL_OP_NO_EXTENDED_MASTER_SECRET> and B<SSL_OP_IGNORE_UNEXPECTED_EOF>
 options were added in OpenSSL 3.0.
 
+The B<SSL_OP_> constants and the corresponding parameter and return values
+of the affected functions were changed to C<uint64_t> type in OpenSSL 3.0.
+For that reason it is no longer possible use the B<SSL_OP_> macro values
+in preprocessor C<#if> conditions. However it is still possible to test
+whether these macros are defined or not.
+
 =head1 COPYRIGHT
 
 Copyright 2001-2021 The OpenSSL Project Authors. All Rights Reserved.

--- a/doc/man7/migration_guide.pod
+++ b/doc/man7/migration_guide.pod
@@ -2235,7 +2235,9 @@ SSL and SSL_CTX options are now 64 bit instead of 32 bit.
 The signatures of the functions to get and set options on SSL and
 SSL_CTX objects changed from "unsigned long" to "uint64_t" type.
 
-This may require source code changes.
+This may require source code changes. For example it is no longer possible
+to use the B<SSL_OP_> macro values in preprocessor C<#if> conditions.
+However it is still possible to test whether these macros are defined or not.
 
 See L<SSL_CTX_get_options(3)>, L<SSL_CTX_set_options(3)>,
 L<SSL_get_options(3)> and L<SSL_set_options(3)>.


### PR DESCRIPTION
Fixes #16082

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
