### PR TITLE
Add testcases for SSL_key_update problems

### DIFF
--- a/doc/man3/SSL_get_error.pod
+++ b/doc/man3/SSL_get_error.pod
@@ -85,7 +85,9 @@ protocol level.
 It is safe to call SSL_read() or SSL_read_ex() when more data is available
 even when the call that set this error was an SSL_write() or SSL_write_ex().
 However, if the call was an SSL_write() or SSL_write_ex(), it should be called
-again to continue sending the application data.
+again to continue sending the application data. If you get B<SSL_ERROR_WANT_WRITE>
+from SSL_write() or SSL_write_ex() then you should not do any other operation
+that could trigger B<IO> other than to repeat the previous SSL_write() call.
 
 For socket B<BIO>s (e.g. when SSL_set_fd() was used), select() or
 poll() on the underlying socket can be used to find out when the

--- a/doc/man3/SSL_key_update.pod
+++ b/doc/man3/SSL_key_update.pod
@@ -32,10 +32,11 @@ peer to additionally update its sending keys. It is an error if B<updatetype> is
 set to B<SSL_KEY_UPDATE_NONE>.
 
 SSL_key_update() must only be called after the initial handshake has been
-completed and TLSv1.3 has been negotiated. The key update will not take place
-until the next time an IO operation such as SSL_read_ex() or SSL_write_ex()
-takes place on the connection. Alternatively SSL_do_handshake() can be called to
-force the update to take place immediately.
+completed and TLSv1.3 has been negotiated, at the same time, the application
+needs to ensure that the writing of data has been completed. The key update
+will not take place until the next time an IO operation such as SSL_read_ex()
+or SSL_write_ex() takes place on the connection. Alternatively SSL_do_handshake()
+can be called to force the update to take place immediately.
 
 SSL_get_key_update_type() can be used to determine whether a key update
 operation has been scheduled but not yet performed. The type of the pending key


### PR DESCRIPTION
Add testcases for SSL_key_update() corner case calls

Test that SSL_key_update() is not allowed if there are writes pending.
Test that there is no reset of the packet pointer in ssl3_setup_read_buffer().

Fix https://github.com/openssl/openssl/pull/16077
Discuss https://github.com/openssl/openssl/pull/16021

- [x] documentation is added or updated
- [x] tests are added or updated
