### PR TITLE
drbg: allow the ctr derivation function to be disabled in FIPS mode

### DIFF
--- a/crypto/err/openssl.txt
+++ b/crypto/err/openssl.txt
@@ -1084,8 +1084,6 @@ RAND_R_ADDITIONAL_INPUT_TOO_LONG:102:additional input too long
 RAND_R_ALREADY_INSTANTIATED:103:already instantiated
 RAND_R_ARGUMENT_OUT_OF_RANGE:105:argument out of range
 RAND_R_CANNOT_OPEN_FILE:121:Cannot open file
-RAND_R_DERIVATION_FUNCTION_MANDATORY_FOR_FIPS:137:\
-	derivation function mandatory for fips
 RAND_R_DRBG_ALREADY_INITIALIZED:129:drbg already initialized
 RAND_R_DRBG_NOT_INITIALISED:104:drbg not initialised
 RAND_R_ENTROPY_INPUT_TOO_LONG:106:entropy input too long

--- a/crypto/rand/rand_err.c
+++ b/crypto/rand/rand_err.c
@@ -22,8 +22,6 @@ static const ERR_STRING_DATA RAND_str_reasons[] = {
     {ERR_PACK(ERR_LIB_RAND, 0, RAND_R_ARGUMENT_OUT_OF_RANGE),
     "argument out of range"},
     {ERR_PACK(ERR_LIB_RAND, 0, RAND_R_CANNOT_OPEN_FILE), "Cannot open file"},
-    {ERR_PACK(ERR_LIB_RAND, 0, RAND_R_DERIVATION_FUNCTION_MANDATORY_FOR_FIPS),
-    "derivation function mandatory for fips"},
     {ERR_PACK(ERR_LIB_RAND, 0, RAND_R_DRBG_ALREADY_INITIALIZED),
     "drbg already initialized"},
     {ERR_PACK(ERR_LIB_RAND, 0, RAND_R_DRBG_NOT_INITIALISED),

--- a/doc/man7/EVP_RAND-CTR-DRBG.pod
+++ b/doc/man7/EVP_RAND-CTR-DRBG.pod
@@ -54,8 +54,7 @@ These parameters work as described in L<EVP_RAND(3)/PARAMETERS>.
 
 This Boolean indicates if a derivation function should be used or not.
 A nonzero value (the default) uses the derivation function.  A zero value
-does not.  The FIPS provider always uses the derivation function and attempts
-to set this value result in an error.
+does not.
 
 =back
 

--- a/include/openssl/randerr.h
+++ b/include/openssl/randerr.h
@@ -25,7 +25,6 @@
 # define RAND_R_ALREADY_INSTANTIATED                      103
 # define RAND_R_ARGUMENT_OUT_OF_RANGE                     105
 # define RAND_R_CANNOT_OPEN_FILE                          121
-# define RAND_R_DERIVATION_FUNCTION_MANDATORY_FOR_FIPS    137
 # define RAND_R_DRBG_ALREADY_INITIALIZED                  129
 # define RAND_R_DRBG_NOT_INITIALISED                      104
 # define RAND_R_ENTROPY_INPUT_TOO_LONG                    106

--- a/providers/implementations/rands/drbg_ctr.c
+++ b/providers/implementations/rands/drbg_ctr.c
@@ -496,13 +496,6 @@ static int drbg_ctr_init_lengths(PROV_DRBG *drbg)
     PROV_DRBG_CTR *ctr = (PROV_DRBG_CTR *)drbg->data;
     int res = 1;
 
-#ifdef FIPS_MODULE
-    if (!ctr->use_df) {
-        ERR_raise(ERR_LIB_PROV, RAND_R_DERIVATION_FUNCTION_MANDATORY_FOR_FIPS);
-        ctr->use_df = 1;
-        res = 0;
-    }
-#endif
     /* Maximum number of bits per request = 2^19  = 2^16 bytes */
     drbg->max_request = 1 << 16;
     if (ctr->use_df) {
@@ -730,14 +723,7 @@ static const OSSL_PARAM *drbg_ctr_settable_ctx_params(ossl_unused void *vctx,
     static const OSSL_PARAM known_settable_ctx_params[] = {
         OSSL_PARAM_utf8_string(OSSL_DRBG_PARAM_PROPERTIES, NULL, 0),
         OSSL_PARAM_utf8_string(OSSL_DRBG_PARAM_CIPHER, NULL, 0),
-#ifndef FIPS_MODULE
-        /*
-         * Don't advertise this for FIPS, it isn't allowed to change.
-         * The parameter can still be passed and will be processed but errors
-         * out.
-         */
         OSSL_PARAM_int(OSSL_DRBG_PARAM_USE_DF, NULL),
-#endif
         OSSL_PARAM_DRBG_SETTABLE_CTX_COMMON,
         OSSL_PARAM_END
     };


### PR DESCRIPTION
Word from the lab is:

> The use of the derivation function is optional if either an approved RBG or an entropy source provides full entropy output when entropy input is requested by the DRBG mechanism. Otherwise, the derivation function shall be used.

So our disallowing it's use was more than required.

Note that the use of the derivation function remains on by default.


- [x] documentation is added or updated
- [x] tests are added or updated
