### PR TITLE
Fixes ERR_error_string crash

### DIFF
--- a/crypto/err/err.c
+++ b/crypto/err/err.c
@@ -545,17 +545,14 @@ void ERR_error_string_n(unsigned long e, char *buf, size_t len)
 }
 
 /*
- * ERR_error_string_n should be used instead for ret != NULL as
  * ERR_error_string cannot know how large the buffer is
  */
-char *ERR_error_string(unsigned long e, char *ret)
+char *ERR_error_string(unsigned long e)
 {
     static char buf[256];
 
-    if (ret == NULL)
-        ret = buf;
-    ERR_error_string_n(e, ret, (int)sizeof(buf));
-    return ret;
+    ERR_error_string_n(e, buf, (int)sizeof(buf));
+    return buf;
 }
 
 const char *ERR_lib_error_string(unsigned long e)

--- a/doc/man3/ERR_error_string.pod
+++ b/doc/man3/ERR_error_string.pod
@@ -10,7 +10,7 @@ error message
 
  #include <openssl/err.h>
 
- char *ERR_error_string(unsigned long e, char *buf);
+ char *ERR_error_string(unsigned long e);
  void ERR_error_string_n(unsigned long e, char *buf, size_t len);
 
  const char *ERR_lib_error_string(unsigned long e);

--- a/include/openssl/err.h.in
+++ b/include/openssl/err.h.in
@@ -429,7 +429,7 @@ unsigned long ERR_peek_last_error_line_data(const char **file, int *line,
 
 void ERR_clear_error(void);
 
-char *ERR_error_string(unsigned long e, char *buf);
+char *ERR_error_string(unsigned long e);
 void ERR_error_string_n(unsigned long e, char *buf, size_t len);
 const char *ERR_lib_error_string(unsigned long e);
 # ifndef OPENSSL_NO_DEPRECATED_3_0


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->
when ret==NULL be assigned will crash. ERR_error_string only provides a recommended cache size to store error information. The cache size should not be passed in. If you need a specific cache to store error information, you can use ERR_error_string_n
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
