### PR TITLE
doc: fix OPENSSL_VERSION_NUMBER length in the synopsis

### DIFF
--- a/doc/man3/OpenSSL_version.pod
+++ b/doc/man3/OpenSSL_version.pod
@@ -41,7 +41,7 @@ OpenSSL_version_num, OPENSSL_info
 Deprecated:
 
  /* from openssl/opensslv.h */
- #define OPENSSL_VERSION_NUMBER 0xnnnnnnnnnL
+ #define OPENSSL_VERSION_NUMBER 0xnnnnnnnnL
 
  /* from openssl/crypto.h */
  unsigned long OpenSSL_version_num();


### PR DESCRIPTION
Just a nit: the OPENSSL_VERSION_NUMBER has 8 digits (not 9). It is a single integer `0xMNN00PP0L`.

##### Checklist
- [x] documentation is added or updated
