### PR TITLE
Fix a read buffer overrun in X509_aux_print().

### DIFF
--- a/crypto/x509/t_x509.c
+++ b/crypto/x509/t_x509.c
@@ -380,9 +380,9 @@ int X509_aux_print(BIO *out, X509 *x, int indent)
         BIO_puts(out, "\n");
     } else
         BIO_printf(out, "%*sNo Rejected Uses.\n", indent, "");
-    alias = X509_alias_get0(x, NULL);
+    alias = X509_alias_get0(x, &i);
     if (alias)
-        BIO_printf(out, "%*sAlias: %s\n", indent, "", alias);
+        BIO_printf(out, "%*sAlias: %.*s\n", indent, "", i, alias);
     keyid = X509_keyid_get0(x, &keyidlen);
     if (keyid) {
         BIO_printf(out, "%*sKey Id: ", indent, "");


### PR DESCRIPTION
The function X509_aux_print() assumes that the return value from X509_alias_get0(3) is NUL-terminated but neither the invariants of the ASN1_STRING data type nor the X509_alias_set1(3) function guarantee that, resulting in a read buffer overrun.

I did not test the patch in the OpenSSL codebase, i merely wrote it in analogy to my LibreSSL commit referenced below.

Note that when Dr. Steve Henson heavily refactored all the surrounding code in September 2015 (commit 699f1635), the bug was preserved in all its details even though the code looks completely different now.  In a nutshell, adding the explicit NULL argument to X509_alias_get0(3) was the lifebelt that saved the bug's life.


Suggested commit message follows:

The ASN1_STRING_get0_data(3) manual explitely cautions the reader
that the data is not necessarily NUL-terminated, and the function
X509_alias_set1(3) does not sanitize the data passed into it in any
way either, so we must assume the return value from X509_alias_get0(3)
is merely a byte array and not necessarily a string in the sense
of the C language.

I found this bug while writing manual pages for X509_print_ex(3)
and related functions.  Theo Buehler <tb@openbsd.org> checked my
patch to fix the same bug in LibreSSL, see

http://cvsweb.openbsd.org/src/lib/libcrypto/asn1/t_x509a.c#rev1.9

As an aside, note that the function still produces incomplete and
misleading results when the data contains a NUL byte in the middle
and that error handling is consistently absent throughout, even
though the function provides an "int" return value obviously intended
to be 1 for success and 0 for failure, and even though this function
is called by another function that also wants to return 1 for success
and 0 for failure and even does so in many of its code paths, though
not in others.  But let's stay focussed.  Many things would be nice
to have in the wide wild world, but a buffer overflow must not be
allowed to remain in our backyard.

CLA: trivial