### PR TITLE
EVP: Move setting |keytype| in int_ctx_new() in the legacy section

### DIFF
--- a/crypto/evp/pmeth_lib.c
+++ b/crypto/evp/pmeth_lib.c
@@ -227,8 +227,6 @@ static EVP_PKEY_CTX *int_ctx_new(OSSL_LIB_CTX *libctx,
      */
     if (!ossl_assert(e == NULL || keytype == NULL))
         return NULL;
-    if (e == NULL && (pkey == NULL || pkey->foreign == 0))
-        keytype = OBJ_nid2sn(id);
 
 # ifndef OPENSSL_NO_ENGINE
     if (e == NULL && pkey != NULL)
@@ -254,6 +252,9 @@ static EVP_PKEY_CTX *int_ctx_new(OSSL_LIB_CTX *libctx,
     else
 # endif
         pmeth = evp_pkey_meth_find_added_by_application(id);
+
+    if (e == NULL && pmeth == NULL)
+        keytype = OBJ_nid2sn(id);
 
     /* END legacy */
 #endif /* FIPS_MODULE */


### PR DESCRIPTION
The code that set |keytype| in the legacy section of int_ctx_new() did
so a little too early, before other variables that should be checked
were properly set, such as |pmeth|, thereby create a catch 22 kind of
situation when determining later if the context method should be
provided or legacy.

Simply moving down the code that sets |keytype|, and simplifying the
condition removes the conflicting situation, and hopefully makes the
code clearer.

Fixes #16088
