### PR TITLE
s_server: fix read_from_terminal behavior

### DIFF
--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -2544,7 +2544,7 @@ static int sv_body(int s, int stype, int prot, unsigned char *context)
             }
 
             if (!s_quiet && !s_brief) {
-                if ((i <= 0) || (buf[0] == 'Q')) {
+                if ((i > 0) && (buf[0] == 'Q')) {
                     BIO_printf(bio_s_out, "DONE\n");
                     (void)BIO_flush(bio_s_out);
                     BIO_closesocket(s);
@@ -2552,7 +2552,7 @@ static int sv_body(int s, int stype, int prot, unsigned char *context)
                     ret = -11;
                     goto err;
                 }
-                if ((i <= 0) || (buf[0] == 'q')) {
+                if ((i > 0) && (buf[0] == 'q')) {
                     BIO_printf(bio_s_out, "DONE\n");
                     (void)BIO_flush(bio_s_out);
                     if (SSL_version(con) != DTLS1_VERSION)


### PR DESCRIPTION
s_server closes accept socket and then terminates after reading EOF from
terminal.

This commit fixes this behavior: now, the only proper way to do that is
explicit q or Q command.

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->
