### PR TITLE
OSSL_HTTP_open(): Fix memory leak on TLS connect failure via proxy

### DIFF
--- a/crypto/http/http_client.c
+++ b/crypto/http/http_client.c
@@ -926,7 +926,8 @@ OSSL_HTTP_REQ_CTX *OSSL_HTTP_open(const char *server, const char *port,
 
         cbio = (*bio_update_fn)(cbio, arg, 1 /* connect */, use_ssl);
         if (cbio == NULL) {
-            cbio = orig_bio;
+            if (bio == NULL) /* cbio was not provided by caller */
+                BIO_free_all(orig_bio);
             goto end;
         }
     }


### PR DESCRIPTION
This came up when connecting the CMP client via HTTPS and a proxy to a real server.
Interestingly, the server gave `400 Bad request` already on `OSSL_HTTP_proxy_connect()`:
```
cmpClient:CMPclient_setup_HTTP():src/genericCMPClient.c:446: INFO: will contact
  https://ec2-....compute-1.amazonaws.com:443/ejbca/publicweb/cmp/ECCEndEntity
  via proxy ....net:9400
cmpClient:send_receive_check():crypto/cmp/cmp_client.c:166: INFO: sending IR
CMP client: HTTP CONNECT failed, reason= 400 Bad request
cmpClient:():src/cmpClient.c:1534: ERROR: Failed to perform CMP transaction
cmpClient:():crypto/http/http_client.c:1324: ERROR: connect failure:OSSL_HTTP_proxy_connect():reason= 400 Bad request
cmpClient:():crypto/cmp/cmp_client.c:172: ERROR: transfer error:send_receive_check():request sent: IR, expected response: IP
cmpClient:CMPclient():src/cmpClient.c:1665: ERROR: CMPclient error 159: transfer error
```