### PR TITLE
Add enable-ktls to the non-default options CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,8 +163,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - name: modprobe tls
+      run: sudo modprobe tls
     - name: config
-      run: ./config --banner=Configured --strict-warnings no-ec enable-ssl-trace enable-zlib enable-zlib-dynamic enable-crypto-mdebug enable-crypto-mdebug-backtrace enable-egd enable-fips && perl configdata.pm --dump
+      run: ./config --banner=Configured --strict-warnings no-ec enable-ssl-trace enable-zlib enable-zlib-dynamic enable-crypto-mdebug enable-crypto-mdebug-backtrace enable-egd enable-ktls enable-fips && perl configdata.pm --dump
     - name: make
       run: make -s -j4
     - name: make test

--- a/.github/workflows/run-checker-daily.yml
+++ b/.github/workflows/run-checker-daily.yml
@@ -62,7 +62,6 @@ jobs:
           no-hw,
           no-hw-padlock,
           no-idea,
-          no-ktls,
           no-makedepend,
           enable-md2,
           no-md2,

--- a/ssl/ktls.c
+++ b/ssl/ktls.c
@@ -133,7 +133,8 @@ int ktls_check_supported_cipher(const SSL *s, const EVP_CIPHER *c,
     {
 # ifdef OPENSSL_KTLS_AES_CCM_128
     case NID_aes_128_ccm:
-        if (EVP_CIPHER_CTX_get_tag_length(dd) != EVP_CCM_TLS_TAG_LEN)
+        if (s->version == TLS_1_3_VERSION /* broken on 5.x kernels */
+            || EVP_CIPHER_CTX_get_tag_length(dd) != EVP_CCM_TLS_TAG_LEN)
           return 0;
 # endif
 # ifdef OPENSSL_KTLS_AES_GCM_128


### PR DESCRIPTION
Also disable the AES-CCM in TLS-1.3 which is broken on current kernels.

Fixes #16089
