### PR TITLE
ci: omit tests that consume too much memory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,7 @@ jobs:
     - name: make
       run: make -s -j4
     - name: make test
-      run: make test HARNESS_JOBS=${HARNESS_JOBS:-4} OPENSSL_TEST_RAND_ORDER=0 TESTS="-test_fuzz* -test_ssl_* -test_evp -test_cmp_http -test_verify -test_cms -test_store -test_enc -[01][0-9]"
+      run: make test HARNESS_JOBS=${HARNESS_JOBS:-4} OPENSSL_TEST_RAND_ORDER=0 TESTS="-test_fuzz* -test_ssl_* -test_sslapi -test_passwd -test_evp -test_cmp_http -test_verify -test_cms -test_store -test_enc -[01][0-9]"
 
   address_ub_sanitizer:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The SSL API tests and the passwd command test trigger memory leakage in the address sanitizer.  This does not appear to be a real problem.

Fixes #16116

- [ ] documentation is added or updated
- [x] tests are added or updated
