### PR TITLE
Mark the EVP_PKEY_METHOD arg as const on some EVP_PKEY_meth_get_*() funcs

### DIFF
--- a/crypto/evp/pmeth_lib.c
+++ b/crypto/evp/pmeth_lib.c
@@ -1963,7 +1963,7 @@ void EVP_PKEY_meth_get_ctrl(const EVP_PKEY_METHOD *pmeth,
         *pctrl_str = pmeth->ctrl_str;
 }
 
-void EVP_PKEY_meth_get_digestsign(EVP_PKEY_METHOD *pmeth,
+void EVP_PKEY_meth_get_digestsign(const EVP_PKEY_METHOD *pmeth,
     int (**digestsign) (EVP_MD_CTX *ctx, unsigned char *sig, size_t *siglen,
                         const unsigned char *tbs, size_t tbslen))
 {
@@ -1971,7 +1971,7 @@ void EVP_PKEY_meth_get_digestsign(EVP_PKEY_METHOD *pmeth,
         *digestsign = pmeth->digestsign;
 }
 
-void EVP_PKEY_meth_get_digestverify(EVP_PKEY_METHOD *pmeth,
+void EVP_PKEY_meth_get_digestverify(const EVP_PKEY_METHOD *pmeth,
     int (**digestverify) (EVP_MD_CTX *ctx, const unsigned char *sig,
                           size_t siglen, const unsigned char *tbs,
                           size_t tbslen))
@@ -2001,7 +2001,7 @@ void EVP_PKEY_meth_get_param_check(const EVP_PKEY_METHOD *pmeth,
         *pcheck = pmeth->param_check;
 }
 
-void EVP_PKEY_meth_get_digest_custom(EVP_PKEY_METHOD *pmeth,
+void EVP_PKEY_meth_get_digest_custom(const EVP_PKEY_METHOD *pmeth,
                                      int (**pdigest_custom) (EVP_PKEY_CTX *ctx,
                                                              EVP_MD_CTX *mctx))
 {

--- a/doc/man3/EVP_PKEY_meth_new.pod
+++ b/doc/man3/EVP_PKEY_meth_new.pod
@@ -220,13 +220,13 @@ L<openssl_user_macros(7)>:
                              int (**pctrl_str) (EVP_PKEY_CTX *ctx,
                                                 const char *type,
                                                 const char *value));
- void EVP_PKEY_meth_get_digestsign(EVP_PKEY_METHOD *pmeth,
+ void EVP_PKEY_meth_get_digestsign(const EVP_PKEY_METHOD *pmeth,
                                    int (**digestsign) (EVP_MD_CTX *ctx,
                                                        unsigned char *sig,
                                                        size_t *siglen,
                                                        const unsigned char *tbs,
                                                        size_t tbslen));
- void EVP_PKEY_meth_get_digestverify(EVP_PKEY_METHOD *pmeth,
+ void EVP_PKEY_meth_get_digestverify(const EVP_PKEY_METHOD *pmeth,
                                      int (**digestverify) (EVP_MD_CTX *ctx,
                                                            const unsigned char *sig,
                                                            size_t siglen,
@@ -238,7 +238,7 @@ L<openssl_user_macros(7)>:
                                      int (**pcheck) (EVP_PKEY *pkey));
  void EVP_PKEY_meth_get_param_check(const EVP_PKEY_METHOD *pmeth,
                                     int (**pcheck) (EVP_PKEY *pkey));
- void EVP_PKEY_meth_get_digest_custom(EVP_PKEY_METHOD *pmeth,
+ void EVP_PKEY_meth_get_digest_custom(const EVP_PKEY_METHOD *pmeth,
                                      int (**pdigest_custom) (EVP_PKEY_CTX *ctx,
                                                              EVP_MD_CTX *mctx));
 

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -2116,11 +2116,11 @@ OSSL_DEPRECATEDIN_3_0 void EVP_PKEY_meth_get_ctrl
      int (**pctrl_str) (EVP_PKEY_CTX *ctx, const char *type,
                         const char *value));
 OSSL_DEPRECATEDIN_3_0 void EVP_PKEY_meth_get_digestsign
-    (EVP_PKEY_METHOD *pmeth,
+    (const EVP_PKEY_METHOD *pmeth,
      int (**digestsign) (EVP_MD_CTX *ctx, unsigned char *sig, size_t *siglen,
                          const unsigned char *tbs, size_t tbslen));
 OSSL_DEPRECATEDIN_3_0 void EVP_PKEY_meth_get_digestverify
-    (EVP_PKEY_METHOD *pmeth,
+    (const EVP_PKEY_METHOD *pmeth,
      int (**digestverify) (EVP_MD_CTX *ctx, const unsigned char *sig,
                            size_t siglen, const unsigned char *tbs,
                            size_t tbslen));
@@ -2131,7 +2131,7 @@ OSSL_DEPRECATEDIN_3_0 void EVP_PKEY_meth_get_public_check
 OSSL_DEPRECATEDIN_3_0 void EVP_PKEY_meth_get_param_check
     (const EVP_PKEY_METHOD *pmeth, int (**pcheck) (EVP_PKEY *pkey));
 OSSL_DEPRECATEDIN_3_0 void EVP_PKEY_meth_get_digest_custom
-    (EVP_PKEY_METHOD *pmeth,
+    (const EVP_PKEY_METHOD *pmeth,
      int (**pdigest_custom) (EVP_PKEY_CTX *ctx, EVP_MD_CTX *mctx));
 # endif
 

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -3478,7 +3478,7 @@ static int custom_pmeth_digestsign(EVP_MD_CTX *ctx, unsigned char *sig,
     int (*pdigestsign)(EVP_MD_CTX *ctx, unsigned char *sig, size_t *siglen,
                        const unsigned char *tbs, size_t tbslen);
 
-    EVP_PKEY_meth_get_digestsign((EVP_PKEY_METHOD *)orig_pmeth, &pdigestsign);
+    EVP_PKEY_meth_get_digestsign(orig_pmeth, &pdigestsign);
     return pdigestsign(ctx, sig, siglen, tbs, tbslen);
 }
 


### PR DESCRIPTION
Most EVP_PKEY_meth_get_*() functions mark the EVP_PKEY_METHOD argument as
const. But 3 did not. We fix those to be consistent.

This is pulled out of #16118 because it is an API change and requires a vote. This means #16118 will need to cast away a const for now. Once #16118 I will update this PR to remove those casts.