### PR TITLE
ECDSA_SIG_set0: r and s parameters cannot be NULL

### DIFF
--- a/doc/man3/ECDSA_SIG_new.pod
+++ b/doc/man3/ECDSA_SIG_new.pod
@@ -46,26 +46,25 @@ L<openssl_user_macros(7)>:
 =head1 DESCRIPTION
 
 B<ECDSA_SIG> is an opaque structure consisting of two BIGNUMs for the
-B<r> and B<s> value of an ECDSA signature (see X9.62 or FIPS 186-2).
+I<r> and I<s> value of an ECDSA signature (see X9.62 or FIPS 186-2).
 
 ECDSA_SIG_new() allocates an empty B<ECDSA_SIG> structure. Note: before
-OpenSSL 1.1.0 the: the B<r> and B<s> components were initialised.
+OpenSSL 1.1.0 the: the I<r> and I<s> components were initialised.
 
-ECDSA_SIG_free() frees the B<ECDSA_SIG> structure B<sig>.
+ECDSA_SIG_free() frees the B<ECDSA_SIG> structure I<sig>.
 
-ECDSA_SIG_get0() returns internal pointers the B<r> and B<s> values contained
-in B<sig> and stores them in B<*pr> and B<*ps>, respectively.
-The pointer B<pr> or B<ps> can be NULL, in which case the corresponding value
+ECDSA_SIG_get0() returns internal pointers the I<r> and I<s> values contained
+in I<sig> and stores them in I<*pr> and I<*ps>, respectively.
+The pointer I<pr> or I<ps> can be NULL, in which case the corresponding value
 is not returned.
 
-The values B<r>, B<s> can also be retrieved separately by the corresponding
+The values I<r>, I<s> can also be retrieved separately by the corresponding
 function ECDSA_SIG_get0_r() and ECDSA_SIG_get0_s(), respectively.
 
-The B<r> and B<s> values can be set by calling ECDSA_SIG_set0() and passing the
-new values for B<r> and B<s> as parameters to the function. Calling this
-function transfers the memory management of the values to the ECDSA_SIG object,
-and therefore the values that have been passed in should not be freed directly
-after this function has been called.
+Non-NULL I<r> and I<s> values can be set on the I<sig> by calling
+ECDSA_SIG_set0(). Calling this function transfers the memory management of the
+values to the B<ECDSA_SIG> object, and therefore the values that have been
+passed in should not be freed by the caller.
 
 See L<i2d_ECDSA_SIG(3)> and L<d2i_ECDSA_SIG(3)> for information about encoding
 and decoding ECDSA signatures to/from DER.
@@ -75,43 +74,43 @@ use the higher level B<EVP> interface such as L<EVP_DigestSignInit(3)>
 or L<EVP_DigestVerifyInit(3)> instead.
 
 ECDSA_size() returns the maximum length of a DER encoded ECDSA signature
-created with the private EC key B<eckey>. To obtain the actual signature
-size use L<EVP_PKEY_sign(3)> with a NULL B<sig> parameter.
+created with the private EC key I<eckey>. To obtain the actual signature
+size use L<EVP_PKEY_sign(3)> with a NULL I<sig> parameter.
 
-ECDSA_sign() computes a digital signature of the B<dgstlen> bytes hash value
-B<dgst> using the private EC key B<eckey>. The DER encoded signatures is
-stored in B<sig> and its length is returned in B<sig_len>. Note: B<sig> must
-point to ECDSA_size(eckey) bytes of memory. The parameter B<type> is currently
-ignored. ECDSA_sign() is wrapper function for ECDSA_sign_ex() with B<kinv>
-and B<rp> set to NULL.
+ECDSA_sign() computes a digital signature of the I<dgstlen> bytes hash value
+I<dgst> using the private EC key I<eckey>. The DER encoded signatures is
+stored in I<sig> and its length is returned in I<sig_len>. Note: I<sig> must
+point to ECDSA_size(eckey) bytes of memory. The parameter I<type> is currently
+ignored. ECDSA_sign() is wrapper function for ECDSA_sign_ex() with I<kinv>
+and I<rp> set to NULL.
 
 ECDSA_do_sign() is similar to ECDSA_sign() except the signature is returned
 as a newly allocated B<ECDSA_SIG> structure (or NULL on error). ECDSA_do_sign()
-is a wrapper function for ECDSA_do_sign_ex() with B<kinv> and B<rp> set to
+is a wrapper function for ECDSA_do_sign_ex() with I<kinv> and I<rp> set to
 NULL.
 
-ECDSA_verify() verifies that the signature in B<sig> of size B<siglen> is a
-valid ECDSA signature of the hash value B<dgst> of size B<dgstlen> using the
-public key B<eckey>.  The parameter B<type> is ignored.
+ECDSA_verify() verifies that the signature in I<sig> of size I<siglen> is a
+valid ECDSA signature of the hash value I<dgst> of size I<dgstlen> using the
+public key I<eckey>.  The parameter I<type> is ignored.
 
 ECDSA_do_verify() is similar to ECDSA_verify() except the signature is
 presented in the form of a pointer to an B<ECDSA_SIG> structure.
 
-The remaining functions utilise the internal B<kinv> and B<r> values used
+The remaining functions utilise the internal I<kinv> and I<r> values used
 during signature computation. Most applications will never need to call these
 and some external ECDSA ENGINE implementations may not support them at all if
-either B<kinv> or B<r> is not B<NULL>.
+either I<kinv> or I<r> is not NULL.
 
 ECDSA_sign_setup() may be used to precompute parts of the signing operation.
-B<eckey> is the private EC key and B<ctx> is a pointer to B<BN_CTX> structure
-(or NULL). The precomputed values or returned in B<kinv> and B<rp> and can be
+I<eckey> is the private EC key and I<ctx> is a pointer to B<BN_CTX> structure
+(or NULL). The precomputed values or returned in I<kinv> and I<rp> and can be
 used in a later call to ECDSA_sign_ex() or ECDSA_do_sign_ex().
 
-ECDSA_sign_ex() computes a digital signature of the B<dgstlen> bytes hash value
-B<dgst> using the private EC key B<eckey> and the optional pre-computed values
-B<kinv> and B<rp>. The DER encoded signature is stored in B<sig> and its
-length is returned in B<sig_len>. Note: B<sig> must point to ECDSA_size(eckey)
-bytes of memory. The parameter B<type> is ignored.
+ECDSA_sign_ex() computes a digital signature of the I<dgstlen> bytes hash value
+I<dgst> using the private EC key I<eckey> and the optional pre-computed values
+I<kinv> and I<rp>. The DER encoded signature is stored in I<sig> and its
+length is returned in I<sig_len>. Note: I<sig> must point to ECDSA_size(eckey)
+bytes of memory. The parameter I<type> is ignored.
 
 ECDSA_do_sign_ex() is similar to ECDSA_sign_ex() except the signature is
 returned as a newly allocated B<ECDSA_SIG> structure (or NULL on error).

--- a/include/openssl/ec.h
+++ b/include/openssl/ec.h
@@ -1347,8 +1347,8 @@ const BIGNUM *ECDSA_SIG_get0_s(const ECDSA_SIG *sig);
 
 /** Setter for r and s fields of ECDSA_SIG
  *  \param  sig  pointer to ECDSA_SIG structure
- *  \param  r    pointer to BIGNUM for r (may be NULL)
- *  \param  s    pointer to BIGNUM for s (may be NULL)
+ *  \param  r    pointer to BIGNUM for r
+ *  \param  s    pointer to BIGNUM for s
  */
 int ECDSA_SIG_set0(ECDSA_SIG *sig, BIGNUM *r, BIGNUM *s);
 


### PR DESCRIPTION
Fix the comment accordingly.

Fixes #7731
