### PR TITLE
ssl: adjust default security callback to match minbits  changes of SHA1

### DIFF
--- a/doc/man3/SSL_CTX_set_security_level.pod
+++ b/doc/man3/SSL_CTX_set_security_level.pod
@@ -76,30 +76,28 @@ The security level corresponds to a minimum of 80 bits of security. Any
 parameters offering below 80 bits of security are excluded. As a result RSA,
 DSA and DH keys shorter than 1024 bits and ECC keys shorter than 160 bits
 are prohibited. All export cipher suites are prohibited since they all offer
-less than 80 bits of security. SSL version 2 is prohibited. Any cipher suite
-using MD5 for the MAC is also prohibited.
+less than 80 bits of security. TLS and DTLS versions below 1.2 are not permitted.
+Any cipher suite using MD5 and SHA1 for the MAC is also prohibited.
 
 =item B<Level 2>
 
 Security level set to 112 bits of security. As a result RSA, DSA and DH keys
 shorter than 2048 bits and ECC keys shorter than 224 bits are prohibited.
 In addition to the level 1 exclusions any cipher suite using RC4 is also
-prohibited. SSL version 3 is also not allowed. Compression is disabled.
+prohibited. Compression is disabled.
 
 =item B<Level 3>
 
 Security level set to 128 bits of security. As a result RSA, DSA and DH keys
 shorter than 3072 bits and ECC keys shorter than 256 bits are prohibited.
 In addition to the level 2 exclusions cipher suites not offering forward
-secrecy are prohibited. TLS versions below 1.1 are not permitted. Session
-tickets are disabled.
+secrecy are prohibited. Session tickets are disabled.
 
 =item B<Level 4>
 
 Security level set to 192 bits of security. As a result RSA, DSA and
 DH keys shorter than 7680 bits and ECC keys shorter than 384 bits are
-prohibited.  Cipher suites using SHA1 for the MAC are prohibited. TLS
-versions below 1.2 are not permitted.
+prohibited.
 
 =item B<Level 5>
 

--- a/ssl/ssl_cert.c
+++ b/ssl/ssl_cert.c
@@ -1032,18 +1032,12 @@ static int ssl_security_default_callback(const SSL *s, const SSL_CTX *ctx,
         }
     case SSL_SECOP_VERSION:
         if (!SSL_IS_DTLS(s)) {
-            /* SSLv3 not allowed at level 2 */
-            if (nid <= SSL3_VERSION && level >= 2)
-                return 0;
-            /* TLS v1.1 and above only for level 3 */
-            if (nid <= TLS1_VERSION && level >= 3)
-                return 0;
-            /* TLS v1.2 only for level 4 and above */
-            if (nid <= TLS1_1_VERSION && level >= 4)
+            /* TLS v1.2+ for level 1 and above */
+            if (nid <= TLS1_1_VERSION && level >= 1)
                 return 0;
         } else {
-            /* DTLS v1.2 only for level 4 and above */
-            if (DTLS_VERSION_LT(nid, DTLS1_2_VERSION) && level >= 4)
+            /* DTLS v1.2 only for level 1 and above */
+            if (DTLS_VERSION_LT(nid, DTLS1_2_VERSION) && level >= 1)
                 return 0;
         }
         break;


### PR DESCRIPTION
Previously, SHA1 security bits were lowered resulting in TLS and DTLS versions below v1.2 only working at security level 0. Adjust the security callback and documentation to match reality.

@kroeckx 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
