### PR TITLE
security: increase default security level from 1 to 2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,15 @@ breaking changes, and mappings for the large list of deprecated functions.
 
 ### Changes between 1.1.1 and 3.0 [xx XXX xxxx]
 
+ * Increase the default security level from 1 to 2, which provides 112
+   bits of security. This means that RSA keys of at least 2048 bits
+   are required, and ECC keys of at least 224 bits are required. This
+   is inline with current minimum requirement from all major
+   Certificate Authorities and Operating System vendors in server,
+   desktop, iot and mobile space.
+
+   *Dimitri John Ledkov*
+
  * The ERR_GET_FUNC() function was removed.  With the loss of meaningful
    function codes, this function can only cause problems for calling
    applications.

--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,7 @@ OpenSSL 3.0
 
 ### Major changes between OpenSSL 1.1.1 and OpenSSL 3.0 [under development]
 
+  * Increase default Security Level from 1 to 2
   * Added migration guide to man7
   * Implemented support for fully "pluggable" TLSv1.3 groups
   * Added suport for Kernel TLS (KTLS)

--- a/doc/man3/SSL_CTX_set_security_level.pod
+++ b/doc/man3/SSL_CTX_set_security_level.pod
@@ -115,7 +115,7 @@ I<Documentation to be provided.>
 =head1 NOTES
 
 The default security level can be configured when OpenSSL is compiled by
-setting B<-DOPENSSL_TLS_SECURITY_LEVEL=level>. If not set then 1 is used.
+setting B<-DOPENSSL_TLS_SECURITY_LEVEL=level>. If not set then 2 is used.
 
 The security framework disables or reject parameters inconsistent with the
 set security level. In the past this was difficult as applications had to set

--- a/include/openssl/tls1.h
+++ b/include/openssl/tls1.h
@@ -28,7 +28,7 @@ extern "C" {
 
 /* Default security level if not overridden at config time */
 # ifndef OPENSSL_TLS_SECURITY_LEVEL
-#  define OPENSSL_TLS_SECURITY_LEVEL 1
+#  define OPENSSL_TLS_SECURITY_LEVEL 2
 # endif
 
 /* TLS*_VERSION constants are defined in prov_ssl.h */


### PR DESCRIPTION
Increase the default security level from 1 to 2, which provides 112
bits of security. This means that RSA keys of at least 2048 bits are
required, and ECC keys of at least 224 bits are required. This is
inline with current minimum requirement from all major Certificate
Authorities and Operating System vendors in server, desktop, iot and
mobile space.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated

TODO: fix tests