### PR TITLE
QEMU: include more test runs for all bar one cross compilation target

### DIFF
--- a/.github/workflows/cross-compiles.yml
+++ b/.github/workflows/cross-compiles.yml
@@ -48,7 +48,7 @@ jobs:
           }, {
             arch: m68k-linux-gnu,
             libs: libc6-dev-m68k-cross,
-            target: -static no-asm linux-latomic,
+            target: -static -m68040 linux-latomic,
             fips: no,
             tests: -test_includes -test_store -test_x509_store
           }, {
@@ -97,7 +97,7 @@ jobs:
           }, {
             arch: m68k-linux-gnu,
             libs: libc6-dev-m68k-cross,
-            target: no-asm linux-latomic,
+            target: -mcfv4e linux-latomic,
             tests: none
           }, {
             arch: mips-linux-gnu,

--- a/.github/workflows/cross-compiles.yml
+++ b/.github/workflows/cross-compiles.yml
@@ -14,6 +14,8 @@ jobs:
         #   libs: the Debian package for the necessary link/runtime libraries.
         #   target: the OpenSSL configuration target to use, this is passed
         #           directly to the config command line.
+        #   fips:   set to "no" to disable building FIPS, leave unset to
+        #           build the FIPS provider.
         #   tests: omit this to run all the tests using QEMU, set it to "none"
         #          to never run the tests, otherwise it's value is passed to
         #          the "make test" command to allow selectiving disabling of
@@ -40,23 +42,26 @@ jobs:
           }, {
             arch: hppa-linux-gnu,
             libs: libc6-dev-hppa-cross,
-            target: linux-generic32,
-            tests: none #-test_includes -test_store -test_x509_store
+            target: -static linux-generic32,
+            fips: no,
+            tests: -test_includes -test_store -test_x509_store
           }, {
             arch: m68k-linux-gnu,
             libs: libc6-dev-m68k-cross,
-            target: linux-latomic no-asm,
-            tests: none #-test_includes -test_store -test_x509_store -test_includes
+            target: -static no-asm linux-latomic,
+            fips: no,
+            tests: -test_includes -test_store -test_x509_store -test_params_conversion
           }, {
             arch: mips-linux-gnu,
             libs: libc6-dev-mips-cross,
-            target: linux-mips32,
-            tests: none
+            target: -static linux-mips32,
+            fips: no,
+            tests: -test_includes -test_store -test_x509_store
           }, {
             arch: mips64-linux-gnuabi64,
             libs: libc6-dev-mips64-cross,
-            target: linux64-mips64,
-            tests: none
+            target: -static linux64-mips64,
+            fips: no
           }, {
             arch: mipsel-linux-gnu,
             libs: libc6-dev-mipsel-cross,
@@ -79,7 +84,35 @@ jobs:
             libs: libc6-dev-sh4-cross,
             target: linux-latomic,
             tests: -test_includes -test_store -test_x509_store -test_async
+          },
+
+          # These build with shared libraries but they crash when run
+          # They mirror static builds above in order to cover more of the
+          # code base.
+          {
+            arch: hppa-linux-gnu,
+            libs: libc6-dev-hppa-cross,
+            target: linux-generic32,
+            tests: none
           }, {
+            arch: m68k-linux-gnu,
+            libs: libc6-dev-m68k-cross,
+            target: no-asm linux-latomic,
+            tests: none
+          }, {
+            arch: mips-linux-gnu,
+            libs: libc6-dev-mips-cross,
+            target: linux-mips32,
+            tests: none
+          }, {
+            arch: mips64-linux-gnuabi64,
+            libs: libc6-dev-mips64-cross,
+            target: linux64-mips64,
+            tests: none
+          },
+
+          # This build doesn't execute either with or without shared libraries.
+          {
             arch: sparc64-linux-gnu,
             libs: libc6-dev-sparc64-cross,
             target: linux64-sparcv9,
@@ -96,9 +129,16 @@ jobs:
             ${{ matrix.platform.libs }}
     - uses: actions/checkout@v2
 
-    - name: config
+    - name: config with FIPS
+      if: matrix.platform.fips != 'no'
       run: |
         ./config --banner=Configured --strict-warnings enable-fips \
+                 --cross-compile-prefix=${{ matrix.platform.arch }}- \
+                 ${{ matrix.platform.target }}
+    - name: config without FIPS
+      if: matrix.platform.fips == 'no'
+      run: |
+        ./config --banner=Configured --strict-warnings \
                  --cross-compile-prefix=${{ matrix.platform.arch }}- \
                  ${{ matrix.platform.target }}
     - name: config dump

--- a/.github/workflows/cross-compiles.yml
+++ b/.github/workflows/cross-compiles.yml
@@ -50,7 +50,7 @@ jobs:
             libs: libc6-dev-m68k-cross,
             target: -static no-asm linux-latomic,
             fips: no,
-            tests: -test_includes -test_store -test_x509_store -test_params_conversion
+            tests: -test_includes -test_store -test_x509_store
           }, {
             arch: mips-linux-gnu,
             libs: libc6-dev-mips-cross,

--- a/.github/workflows/cross-compiles.yml
+++ b/.github/workflows/cross-compiles.yml
@@ -82,8 +82,8 @@ jobs:
           }, {
             arch: sh4-linux-gnu,
             libs: libc6-dev-sh4-cross,
-            target: linux-latomic,
-            tests: -test_includes -test_store -test_x509_store -test_async
+            target: no-async linux-latomic,
+            tests: -test_includes -test_store -test_x509_store
           },
 
           # These build with shared libraries but they crash when run

--- a/test/params_conversion_test.c
+++ b/test/params_conversion_test.c
@@ -279,8 +279,29 @@ static int param_conversion_test(const PARAM_CONVERSION *pc, int line)
             return 0;
         }
     } else {
-        if (!TEST_true(OSSL_PARAM_get_double(pc->param, &d))
-            || !TEST_true(d == pc->d)) {
+        if (!TEST_true(OSSL_PARAM_get_double(pc->param, &d))) {
+            TEST_note("unable to convert to double on line %d", line);
+            return 0;
+        }
+        /*
+         * Check for not a number (NaN) without using the libm functions.
+         * When d is a NaN, the standard requires d == d to be false.
+         * It's less clear if d != d should be true even though it generally is.
+         * Hence we use the equality test and a not.
+         */
+        if (!(d == d)) {
+            /*
+             * We've encountered a NaN so check it's really meant to be a NaN.
+             * We ignore the case where the two values are both different NaN,
+             * that's not resolvable without knowing the underlying format
+             * or using libm functions.
+             */
+            if (!TEST_false(pc->d == pc->d)) {
+                TEST_note("unexpected NaN on line %d", line);
+                return 0;
+            }
+        } else if (!TEST_true(d == pc->d)) {
+            printf("%20g vs %20g\n", d, pc->d);
             TEST_note("unexpected conversion to double on line %d", line);
             return 0;
         }

--- a/test/params_conversion_test.c
+++ b/test/params_conversion_test.c
@@ -301,7 +301,6 @@ static int param_conversion_test(const PARAM_CONVERSION *pc, int line)
                 return 0;
             }
         } else if (!TEST_true(d == pc->d)) {
-            printf("%20g vs %20g\n", d, pc->d);
             TEST_note("unexpected conversion to double on line %d", line);
             return 0;
         }


### PR DESCRIPTION
For the cross compiles where the tests couldn't be run, most are capable of being run when statically linked. For these, a shared with FIPS build but not test run is also included to maximise compilation coverage. The builds take a couple of minutes so the impact of these extra jobs isn't great.

- [ ] documentation is added or updated
- [x] tests are added or updated
