### PR TITLE
WIP: openssl/openssl#16147 Enhancements to Windows 32-bit for CFG

### DIFF
--- a/crypto/build.info
+++ b/crypto/build.info
@@ -1,7 +1,7 @@
 LIBS=../libcrypto
 SOURCE[../libcrypto]=\
         cryptlib.c mem.c mem_dbg.c cversion.c ex_data.c cpt_err.c \
-        ebcdic.c uid.c o_time.c o_str.c o_dir.c o_fopen.c ctype.c \
+        ebcdic.c uid.c o_time.c o_str.c o_dir.c o_fopen.c ctype.c cfg_export.c \
         threads_pthread.c threads_win.c threads_none.c getenv.c \
         o_init.c o_fips.c mem_sec.c init.c {- $target{cpuid_asm_src} -} \
         {- $target{uplink_aux_src} -}

--- a/crypto/cfg_export.c
+++ b/crypto/cfg_export.c
@@ -1,0 +1,71 @@
+#if !defined(_WIN64) && defined(_WIN32)
+#ifndef OPENSSL_NO_BF
+#include <openssl/blowfish.h>
+#endif
+
+#ifndef OPENSSL_NO_CAMELLIA
+# include <openssl/camellia.h>
+#endif
+
+#ifndef OPENSSL_NO_DES
+# include <openssl/des.h>
+#endif
+
+#ifndef OPENSSL_NO_RC4
+# include <openssl/rc4.h>
+#endif
+
+#include <openssl/crypto.h>
+#include <openssl/evp.h>
+
+void poly1305_blocks_sse2();
+void poly1305_emit_sse2();
+void poly1305_init();
+void poly1305_blocks();
+void poly1305_emit();
+void poly1305_blocks_avx2();
+
+void cfg_export(void *fp[64]) {
+
+size_t idx = 0;
+
+#ifndef OPENSSL_NO_BF
+    fp[idx++] = (void*)(uintptr_t)BF_encrypt;
+    fp[idx++] = (void*)(uintptr_t)BF_decrypt;
+    fp[idx++] = (void*)(uintptr_t)BF_cbc_encrypt;
+#endif
+
+#ifndef OPENSSL_NO_CAMELLIA
+    fp[idx++] = (void*)(uintptr_t)Camellia_set_key;
+#endif
+
+#ifndef OPENSSL_NO_DES
+    fp[idx++] = (void*)(uintptr_t)DES_encrypt1;
+    fp[idx++] = (void*)(uintptr_t)DES_encrypt2;
+    fp[idx++] = (void*)(uintptr_t)DES_encrypt3;
+    fp[idx++] = (void*)(uintptr_t)DES_decrypt3;
+    fp[idx++] = (void*)(uintptr_t)DES_ncbc_encrypt;
+    fp[idx++] = (void*)(uintptr_t)DES_ede3_cbc_encrypt;
+
+    fp[idx++] = (void*)(uintptr_t)EVP_des_ede3_cfb64;
+    fp[idx++] = (void*)(uintptr_t)EVP_CIPHER_CTX_iv_noconst;
+#endif
+
+#ifndef OPENSSL_NO_RC4
+    fp[idx++] = (void*)(uintptr_t)RC4;
+    fp[idx++] = (void*)(uintptr_t)RC4_set_key;
+    fp[idx++] = (void*)(uintptr_t)RC4_options;
+#endif
+
+    fp[idx++] = (void*)(uintptr_t)OPENSSL_cleanse;
+    fp[idx++] = (void*)(uintptr_t)CRYPTO_memcmp;
+
+    fp[idx++] = (void*)(uintptr_t)poly1305_init;
+    fp[idx++] = (void*)(uintptr_t)poly1305_blocks;
+    fp[idx++] = (void*)(uintptr_t)poly1305_emit;
+    fp[idx++] = (void*)(uintptr_t)poly1305_blocks_avx2;
+
+    fp[idx++] = (void*)(uintptr_t)poly1305_blocks_sse2;
+    fp[idx++] = (void*)(uintptr_t)poly1305_emit_sse2;
+}
+#endif

--- a/crypto/poly1305/asm/poly1305-x86.pl
+++ b/crypto/poly1305/asm/poly1305-x86.pl
@@ -114,15 +114,15 @@ if ($sse2) {
 	&cmp	("ecx",1<<26|1<<24);		# SSE2 and XMM?
 	&jne	(&label("no_sse2"));
 
-	&lea	("eax",&DWP("_poly1305_blocks_sse2-".&label("pic_point"),"ebx"));
-	&lea	("edx",&DWP("_poly1305_emit_sse2-".&label("pic_point"),"ebx"));
+	&lea	("eax",&DWP("poly1305_blocks_sse2-".&label("pic_point"),"ebx"));
+	&lea	("edx",&DWP("poly1305_emit_sse2-".&label("pic_point"),"ebx"));
 
       if ($avx>1) {
 	&mov	("ecx",&DWP(8,"edi"));
 	&test	("ecx",1<<5);			# AVX2?
 	&jz	(&label("no_sse2"));
 
-	&lea	("eax",&DWP("_poly1305_blocks_avx2-".&label("pic_point"),"ebx"));
+	&lea	("eax",&DWP("poly1305_blocks_avx2-".&label("pic_point"),"ebx"));
       }
     &set_label("no_sse2");
 	&mov	("edi",&wparam(0));		# reload context
@@ -651,7 +651,7 @@ my $extra = shift;
 &function_end_B("_poly1305_init_sse2");
 
 &align	(32);
-&function_begin("_poly1305_blocks_sse2");
+&function_begin("poly1305_blocks_sse2");
 	&mov	("edi",&wparam(0));			# ctx
 	&mov	("esi",&wparam(1));			# inp
 	&mov	("ecx",&wparam(2));			# len
@@ -1133,10 +1133,10 @@ my $addr = shift;
 	&movd		(&DWP(-16*3+4*4,"edi"),$D4);
 	&mov	("esp","ebp");
 &set_label("nodata");
-&function_end("_poly1305_blocks_sse2");
+&function_end("poly1305_blocks_sse2");
 
 &align	(32);
-&function_begin("_poly1305_emit_sse2");
+&function_begin("poly1305_emit_sse2");
 	&mov	("ebp",&wparam(0));		# context
 
 	&cmp	(&DWP(4*5,"ebp"),0);		# is_base2_26?
@@ -1227,7 +1227,7 @@ my $addr = shift;
 	&adc	("edx",&DWP(4*3,"ebp"));
 	&mov	(&DWP(4*2,"edi"),"ecx");
 	&mov	(&DWP(4*3,"edi"),"edx");
-&function_end("_poly1305_emit_sse2");
+&function_end("poly1305_emit_sse2");
 
 if ($avx>1) {
 ########################################################################
@@ -1441,7 +1441,7 @@ my $MASK=$T2;
 sub X { my $reg=shift; $reg=~s/^ymm/xmm/; $reg; }
 
 &align	(32);
-&function_begin("_poly1305_blocks_avx2");
+&function_begin("poly1305_blocks_avx2");
 	&mov	("edi",&wparam(0));			# ctx
 	&mov	("esi",&wparam(1));			# inp
 	&mov	("ecx",&wparam(2));			# len
@@ -1799,7 +1799,7 @@ sub vlazy_reduction {
 	&vzeroupper	();
 	&mov	("esp","ebp");
 &set_label("nodata");
-&function_end("_poly1305_blocks_avx2");
+&function_end("poly1305_blocks_avx2");
 }
 &set_label("const_sse2",64);
 	&data_word(1<<24,0,	1<<24,0,	1<<24,0,	1<<24,0);

--- a/crypto/poly1305/poly1305.c
+++ b/crypto/poly1305/poly1305.c
@@ -14,6 +14,9 @@
 #include "crypto/poly1305.h"
 #include "poly1305_local.h"
 
+extern cfg_export(void *fp[64]);
+void *force_import = cfg_export;
+
 size_t Poly1305_ctx_size(void)
 {
     return sizeof(struct poly1305_context);


### PR DESCRIPTION
This is a work-in-progress change that allows CFG to be included in 32 bit processors.  It does pass `make test`.  See openssl/openssl#16147 for details.

Fixes openssl/openssl#16147

##### Checklist
- [ ] documentation is added or updated
- [ ] tests are added or updated
