### PR TITLE
Fix EVP_MD_meth_dup and EVP_CIPHER_meth_dup

### DIFF
--- a/crypto/evp/cmeth_lib.c
+++ b/crypto/evp/cmeth_lib.c
@@ -50,6 +50,7 @@ EVP_CIPHER *EVP_CIPHER_meth_dup(const EVP_CIPHER *cipher)
 
         memcpy(to, cipher, sizeof(*to));
         to->lock = lock;
+        to->origin = EVP_ORIG_METH;
     }
     return to;
 }

--- a/crypto/evp/evp_lib.c
+++ b/crypto/evp/evp_lib.c
@@ -823,6 +823,7 @@ EVP_MD *EVP_MD_meth_dup(const EVP_MD *md)
 
         memcpy(to, md, sizeof(*to));
         to->lock = lock;
+        to->origin = EVP_ORIG_METH;
     }
     return to;
 }

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -3690,7 +3690,6 @@ static int test_custom_pmeth(int idx)
     custom_pmeth = NULL;
     return testresult;
 }
-#endif
 
 static int test_evp_md_cipher_meth(void)
 {
@@ -3709,6 +3708,7 @@ static int test_evp_md_cipher_meth(void)
 
     return testresult;
 }
+#endif /* OPENSSL_NO_DEPRECATED_3_0 */
 
 typedef enum OPTION_choice {
     OPT_ERR = -1,
@@ -3832,9 +3832,8 @@ int setup_tests(void)
 
 #ifndef OPENSSL_NO_DEPRECATED_3_0
     ADD_ALL_TESTS(test_custom_pmeth, 12);
-#endif
-
     ADD_TEST(test_evp_md_cipher_meth);
+#endif
 
     return 1;
 }

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -3692,6 +3692,24 @@ static int test_custom_pmeth(int idx)
 }
 #endif
 
+static int test_evp_md_cipher_meth(void)
+{
+    EVP_MD *md = EVP_MD_meth_dup(EVP_sha256());
+    EVP_CIPHER *ciph = EVP_CIPHER_meth_dup(EVP_aes_128_cbc());
+    int testresult = 0;
+
+    if (!TEST_ptr(md) || !TEST_ptr(ciph))
+        goto err;
+
+    testresult = 1;
+
+ err:
+    EVP_MD_meth_free(md);
+    EVP_CIPHER_meth_free(ciph);
+
+    return testresult;
+}
+
 typedef enum OPTION_choice {
     OPT_ERR = -1,
     OPT_EOF = 0,
@@ -3815,6 +3833,8 @@ int setup_tests(void)
 #ifndef OPENSSL_NO_DEPRECATED_3_0
     ADD_ALL_TESTS(test_custom_pmeth, 12);
 #endif
+
+    ADD_TEST(test_evp_md_cipher_meth);
 
     return 1;
 }


### PR DESCRIPTION
Make sure the origin is set correctly when duping an EVP_MD or EVP_CIPHER.

Fixes #16157
