### PR TITLE
Fix FIPS related config issues

### DIFF
--- a/crypto/evp/evp_cnf.c
+++ b/crypto/evp/evp_cnf.c
@@ -46,8 +46,8 @@ static int alg_module_init(CONF_IMODULE *md, const CONF *cnf)
              * fips_mode is deprecated and should not be used in new
              * configurations.
              */
-            if (!EVP_default_properties_enable_fips(NCONF_get0_libctx((CONF *)cnf),
-                        m > 0)) {
+            if (!evp_default_properties_enable_fips_int(
+                    NCONF_get0_libctx((CONF *)cnf), m > 0, 0)) {
                 ERR_raise(ERR_LIB_EVP, EVP_R_SET_DEFAULT_PROPERTY_FAILURE);
                 return 0;
             }

--- a/crypto/evp/evp_fetch.c
+++ b/crypto/evp/evp_fetch.c
@@ -479,15 +479,16 @@ int EVP_set_default_properties(OSSL_LIB_CTX *libctx, const char *propq)
     return evp_set_default_properties_int(libctx, propq, 1, 0);
 }
 
-static int evp_default_properties_merge(OSSL_LIB_CTX *libctx, const char *propq)
+static int evp_default_properties_merge(OSSL_LIB_CTX *libctx, const char *propq,
+                                        int loadconfig)
 {
-    OSSL_PROPERTY_LIST **plp = ossl_ctx_global_properties(libctx, 1);
+    OSSL_PROPERTY_LIST **plp = ossl_ctx_global_properties(libctx, loadconfig);
     OSSL_PROPERTY_LIST *pl1, *pl2;
 
     if (propq == NULL)
         return 1;
     if (plp == NULL || *plp == NULL)
-        return EVP_set_default_properties(libctx, propq);
+        return evp_set_default_properties_int(libctx, propq, 0, 0);
     if ((pl1 = ossl_parse_query(libctx, propq, 1)) == NULL) {
         ERR_raise(ERR_LIB_EVP, EVP_R_DEFAULT_QUERY_PARSE_ERROR);
         return 0;
@@ -518,11 +519,17 @@ int EVP_default_properties_is_fips_enabled(OSSL_LIB_CTX *libctx)
     return evp_default_property_is_enabled(libctx, "fips");
 }
 
-int EVP_default_properties_enable_fips(OSSL_LIB_CTX *libctx, int enable)
+int evp_default_properties_enable_fips_int(OSSL_LIB_CTX *libctx, int enable,
+                                           int loadconfig)
 {
     const char *query = (enable != 0) ? "fips=yes" : "-fips";
 
-    return evp_default_properties_merge(libctx, query);
+    return evp_default_properties_merge(libctx, query, loadconfig);
+}
+
+int EVP_default_properties_enable_fips(OSSL_LIB_CTX *libctx, int enable)
+{
+    return evp_default_properties_enable_fips_int(libctx, enable, 1);
 }
 
 char *evp_get_global_properties_str(OSSL_LIB_CTX *libctx, int loadconfig)

--- a/crypto/provider_conf.c
+++ b/crypto/provider_conf.c
@@ -156,6 +156,16 @@ static int provider_conf_load(OSSL_LIB_CTX *libctx, const char *name,
     }
 
     if (activate) {
+        /*
+        * There is an attempt to activate a provider, so we should disable
+        * loading of fallbacks. Otherwise a misconfiguration could mean the
+        * intended provider does not get loaded. Subsequent fetches could then
+        * fallback to the default provider - which may be the wrong thing.
+        */
+        if (!ossl_provider_disable_fallback_loading(NULL)) {
+            ERR_raise(ERR_LIB_CRYPTO, ERR_R_INTERNAL_ERROR);
+            return 0;
+        }
         prov = ossl_provider_find(libctx, name, 1);
         if (prov == NULL)
             prov = ossl_provider_new(libctx, name, NULL, 1);
@@ -215,7 +225,11 @@ static int provider_conf_load(OSSL_LIB_CTX *libctx, const char *name,
 
     }
 
-    return ok;
+    /*
+     * Even if ok is 0, we still return success. Failure to load a provider is
+     * not fatal. We want to continue to load the rest of the config file.
+     */
+    return 1;
 }
 
 static int provider_conf_init(CONF_IMODULE *md, const CONF *cnf)

--- a/crypto/provider_conf.c
+++ b/crypto/provider_conf.c
@@ -162,7 +162,7 @@ static int provider_conf_load(OSSL_LIB_CTX *libctx, const char *name,
         * intended provider does not get loaded. Subsequent fetches could then
         * fallback to the default provider - which may be the wrong thing.
         */
-        if (!ossl_provider_disable_fallback_loading(NULL)) {
+        if (!ossl_provider_disable_fallback_loading(libctx)) {
             ERR_raise(ERR_LIB_CRYPTO, ERR_R_INTERNAL_ERROR);
             return 0;
         }

--- a/include/crypto/evp.h
+++ b/include/crypto/evp.h
@@ -891,6 +891,8 @@ int evp_pkey_ctx_use_cached_data(EVP_PKEY_CTX *ctx);
 # endif /* !defined(FIPS_MODULE) */
 
 int evp_method_store_flush(OSSL_LIB_CTX *libctx);
+int evp_default_properties_enable_fips_int(OSSL_LIB_CTX *libctx, int enable,
+                                           int loadconfig);
 int evp_set_default_properties_int(OSSL_LIB_CTX *libctx, const char *propq,
                                    int loadconfig, int mirrored);
 char *evp_get_global_properties_str(OSSL_LIB_CTX *libctx, int loadconfig);

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -712,6 +712,7 @@ int OSSL_provider_init_int(const OSSL_CORE_HANDLE *handle,
     return 1;
  err:
     fips_teardown(*provctx);
+    OSSL_LIB_CTX_free(libctx);
     *provctx = NULL;
     return 0;
 }

--- a/test/fips-alt.cnf
+++ b/test/fips-alt.cnf
@@ -1,0 +1,16 @@
+openssl_conf = openssl_init
+
+.include fipsmodule.cnf
+
+[openssl_init]
+providers = provider_sect
+alg_section = evp_properties
+
+[evp_properties]
+# Ensure FIPS non-approved algorithms in the FIPS module are suppressed (e.g.
+# TEST-RAND). This also means that EVP_default_properties_is_fips_enabled()
+# returns the expected value
+fips_mode = true
+
+[provider_sect]
+fips = fips_sect

--- a/test/recipes/30-test_defltfips.t
+++ b/test/recipes/30-test_defltfips.t
@@ -10,12 +10,12 @@
 use strict;
 use warnings;
 
-use OpenSSL::Test qw/:DEFAULT srctop_file srctop_dir bldtop_file bldtop_dir/;
+use OpenSSL::Test qw/:DEFAULT srctop_file srctop_dir bldtop_file bldtop_dir data_dir/;
 use OpenSSL::Test::Utils;
 use Cwd qw(abs_path);
 
 BEGIN {
-    setup("test_evp");
+    setup("test_defltfips");
 }
 
 use lib srctop_dir('Configurations');
@@ -24,11 +24,24 @@ use lib bldtop_dir('.');
 my $no_fips = disabled('fips') || ($ENV{NO_FIPS} // 0);
 
 plan tests =>
-    ($no_fips ? 1 : 2);
+    ($no_fips ? 1 : 5);
 
 unless ($no_fips) {
     $ENV{OPENSSL_CONF} = abs_path(srctop_file("test", "fips.cnf"));
     ok(run(test(["defltfips_test", "fips"])), "running defltfips_test fips");
+
+    #Test an alternative way of configuring fips
+    $ENV{OPENSSL_CONF} = abs_path(srctop_file("test", "fips-alt.cnf"));
+    ok(run(test(["defltfips_test", "fips"])), "running defltfips_test fips");
+
+    #Configured to run FIPS but the module-mac is bad
+    $ENV{OPENSSL_CONF} = abs_path(srctop_file("test", "fips.cnf"));
+    $ENV{OPENSSL_CONF_INCLUDE} = srctop_file("test", "recipes", "30-test_defltfips");
+    ok(run(test(["defltfips_test", "badfips"])), "running defltfips_test badfips");
+
+    #Test an alternative way of configuring fips (but still with bad module-mac)
+    $ENV{OPENSSL_CONF} = abs_path(srctop_file("test", "fips-alt.cnf"));
+    ok(run(test(["defltfips_test", "badfips"])), "running defltfips_test badfips");
 }
 
 $ENV{OPENSSL_CONF} = abs_path(srctop_file("test", "default.cnf"));

--- a/test/recipes/30-test_defltfips/fipsmodule.cnf
+++ b/test/recipes/30-test_defltfips/fipsmodule.cnf
@@ -1,5 +1,7 @@
+#The MAC here is meant to be incorrect, do not modify it
+
 [fips_sect]
 activate = 1
 conditional-errors = 1
 security-checks = 1
-module-mac = B9:C9:E1:F5:B7:49:18:1B:BF:63:68:DF:1A:66:40:2E:04:2A:8F:E2:B1:D9:F7:7C:08:6F:80:A0:1D:47:F2:00
+module-mac = 00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00

--- a/test/recipes/30-test_defltfips/fipsmodule.cnf
+++ b/test/recipes/30-test_defltfips/fipsmodule.cnf
@@ -1,0 +1,5 @@
+[fips_sect]
+activate = 1
+conditional-errors = 1
+security-checks = 1
+module-mac = B9:C9:E1:F5:B7:49:18:1B:BF:63:68:DF:1A:66:40:2E:04:2A:8F:E2:B1:D9:F7:7C:08:6F:80:A0:1D:47:F2:00


### PR DESCRIPTION
This PR fixes 3 issues:

- A mem leak in the event that a mis-configuration causes the FIPS module to fail to load
- A failure to apply "default_properties" in the config file in the event that a provider fails to load
- A hang when trying to use "fips_mode=yes" from inside a config file

This also adds a test case for the above issues which includes negative testing to ensure proper behaviour in the event that the FIPS provider fails to load.

Fixes #16166
Fixes #16163
Fixes #16165