### PR TITLE
Add config_diagnostics to our configuration files.

### DIFF
--- a/apps/openssl-vms.cnf
+++ b/apps/openssl-vms.cnf
@@ -16,8 +16,7 @@ HOME			= .
  # Use this in order to automatically load providers.
 openssl_conf = openssl_init
 
-# Comment this out if you deliberately want to ignore
-# configuration errors
+# Comment out the next line to ignore configuration errors
 config_diagnostics = 1
 
 # Extra OBJECT IDENTIFIER info:

--- a/apps/openssl.cnf
+++ b/apps/openssl.cnf
@@ -16,8 +16,7 @@ HOME			= .
  # Use this in order to automatically load providers.
 openssl_conf = openssl_init
 
-# Comment this out if you deliberately want to ignore
-# configuration errors
+# Comment out the next line to ignore configuration errors
 config_diagnostics = 1
 
 # Extra OBJECT IDENTIFIER info:

--- a/demos/bio/accept.cnf
+++ b/demos/bio/accept.cnf
@@ -1,10 +1,16 @@
 # Example configuration file
+
+# Comment out the next line to ignore configuration errors
+config_diagnostics = 1
+
 # Port to listen on
 Port = 4433
+
 # Disable TLS v1.2 for test.
 # Protocol = ALL, -TLSv1.2
 # Only support 3 curves
 Curves = P-521:P-384:P-256
+
 # Restricted signature algorithms
 SignatureAlgorithms = RSA+SHA512:ECDSA+SHA512
 Certificate=server.pem

--- a/demos/bio/cmod.cnf
+++ b/demos/bio/cmod.cnf
@@ -4,6 +4,9 @@
 # and section containing configuration
 testapp = test_sect
 
+# Comment out the next line to ignore configuration errors
+config_diagnostics = 1
+
 [test_sect]
 # list of configuration modules
 

--- a/demos/bio/connect.cnf
+++ b/demos/bio/connect.cnf
@@ -1,9 +1,15 @@
 # Example configuration file
+
+# Comment out the next line to ignore configuration errors
+config_diagnostics = 1
+
 # Connects to the default port of s_server
 Connect = localhost:4433
+
 # Disable TLS v1.2 for test.
 # Protocol = ALL, -TLSv1.2
 # Only support 3 curves
 Curves = P-521:P-384:P-256
+
 # Restricted signature algorithms
 SignatureAlgorithms = RSA+SHA512:ECDSA+SHA512

--- a/demos/certs/apps/apps.cnf
+++ b/demos/certs/apps/apps.cnf
@@ -7,6 +7,10 @@
 HOME			= .
 CN			= "Not Defined"
 
+# Comment out the next line to ignore configuration errors
+config_diagnostics = 1
+
+
 ####################################################################
 [ req ]
 default_bits		= 2048

--- a/demos/certs/ca.cnf
+++ b/demos/certs/ca.cnf
@@ -8,6 +8,9 @@ HOME			= .
 CN			= "Not Defined"
 default_ca		= ca
 
+# Comment out the next line to ignore configuration errors
+config_diagnostics = 1
+
 ####################################################################
 [ req ]
 default_bits		= 1024

--- a/test/CAtsa.cnf
+++ b/test/CAtsa.cnf
@@ -3,6 +3,9 @@
 # This config is used by the Time Stamp Authority tests.
 #
 
+# Comment out the next line to ignore configuration errors
+config_diagnostics = 1
+
 # Extra OBJECT IDENTIFIER info:
 oid_section		= new_oids
 

--- a/test/ca-and-certs.cnf
+++ b/test/ca-and-certs.cnf
@@ -1,4 +1,7 @@
 
+# Comment out the next line to ignore configuration errors
+config_diagnostics = 1
+
 CN2 = Brother 2
 
 ####################################################################

--- a/test/ct/log_list.cnf
+++ b/test/ct/log_list.cnf
@@ -1,5 +1,8 @@
 enabled_logs=test,pilot,aviator,rocketeer,digicert,certly,izempe,symantec,venafi
 
+# Comment out the next line to ignore configuration errors
+config_diagnostics = 1
+
 [test]
 description = https://github.com/google/certificate-transparency/tree/99218b6445906a81f219d84e9c6d2683e13e4e58/test/testdata
 key = MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEmXg8sUUzwBYaWrRb+V0IopzQ6o3UyEJ04r5ZrRXGdpYM8K+hB0pXrGRLI0eeWz+3skXrS0IO83AhA3GpRL6s6w==

--- a/test/default-and-fips.cnf
+++ b/test/default-and-fips.cnf
@@ -1,5 +1,8 @@
 openssl_conf = openssl_init
 
+# Comment out the next line to ignore configuration errors
+config_diagnostics = 1
+
 .include fipsmodule.cnf
 
 [openssl_init]

--- a/test/default-and-legacy.cnf
+++ b/test/default-and-legacy.cnf
@@ -1,5 +1,8 @@
 openssl_conf = openssl_init
 
+# Comment out the next line to ignore configuration errors
+config_diagnostics = 1
+
 [openssl_init]
 providers = provider_sect
 

--- a/test/default.cnf
+++ b/test/default.cnf
@@ -1,5 +1,8 @@
 openssl_conf = openssl_init
 
+# Comment out the next line to ignore configuration errors
+config_diagnostics = 1
+
 [openssl_init]
 providers = provider_sect
 

--- a/test/fips-and-base.cnf
+++ b/test/fips-and-base.cnf
@@ -1,5 +1,8 @@
 openssl_conf = openssl_init
 
+# Comment out the next line to ignore configuration errors
+config_diagnostics = 1
+
 .include fipsmodule.cnf
 
 [openssl_init]

--- a/test/fips.cnf
+++ b/test/fips.cnf
@@ -1,5 +1,8 @@
 openssl_conf = openssl_init
 
+# Comment out the next line to ignore configuration errors
+config_diagnostics = 1
+
 .include fipsmodule.cnf
 
 [openssl_init]

--- a/test/legacy.cnf
+++ b/test/legacy.cnf
@@ -1,5 +1,8 @@
 openssl_conf = openssl_init
 
+# Comment out the next line to ignore configuration errors
+config_diagnostics = 1
+
 [openssl_init]
 providers = provider_sect
 

--- a/test/provider_internal_test.cnf.in
+++ b/test/provider_internal_test.cnf.in
@@ -1,3 +1,6 @@
+# Comment out the next line to ignore configuration errors
+config_diagnostics = 1
+
 {- use platform -}
 openssl_conf = openssl_init
 

--- a/test/proxy.cnf
+++ b/test/proxy.cnf
@@ -1,6 +1,9 @@
 
 ## Config file for proxy certificate testing.
 
+# Comment out the next line to ignore configuration errors
+config_diagnostics = 1
+
 [ req ]
 distinguished_name	= req_distinguished_name_p1
 encrypt_rsa_key		= no

--- a/test/smime-certs/ca.cnf
+++ b/test/smime-certs/ca.cnf
@@ -2,6 +2,9 @@
 # OpenSSL example configuration file for automated certificate creation.
 #
 
+# Comment out the next line to ignore configuration errors
+config_diagnostics = 1
+
 # This definition stops the following lines choking if HOME or CN
 # is undefined.
 HOME			= .

--- a/test/sysdefault.cnf
+++ b/test/sysdefault.cnf
@@ -1,5 +1,8 @@
 # Configuration file to test system default SSL configuration
 
+# Comment out the next line to ignore configuration errors
+config_diagnostics = 1
+
 openssl_conf = default_conf
 
 [ default_conf ]


### PR DESCRIPTION
The change to a more configuration based approach to enable FIPS mode operation highlights a shortcoming in the _default should do something_ approach we've taken for bad configuration files.

Currently, a bad configuration file will be automatically loaded and once the badness is detected, it will silently stop processing the configuration and continue normal operations.  This is good for remote servers, allowing changes to be made without bricking things.  It's bad when a user thinks they've configured what they want but got something wrong and it still appears to work.

The bad carries over into things the configuration is trying to do.  E.g. a bad FIPS MAC would cause the configuration to stop loading (until #16168).

Reported in #16163, #16165 and #16166.


- [ ] documentation is added or updated
- [ ] tests are added or updated
