### PR TITLE
ci: separate the config dump from the configuration command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: config
-      run: ./config --banner=Configured enable-fips --strict-warnings && perl configdata.pm --dump
+      run: CC=gcc ./config --banner=Configured enable-fips --strict-warnings && perl configdata.pm --dump
     - name: make
       run: make -s -j4
     - name: make test

--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -14,7 +14,10 @@ jobs:
       run: |
         sudo apt-get -yq install lcov
     - name: config
-      run: CC=gcc ./config --banner=Configured --debug --coverage no-asm enable-fips enable-rc5 enable-md2 enable-ssl3 enable-nextprotoneg enable-ssl3-method enable-weak-ssl-ciphers enable-zlib enable-ec_nistp_64_gcc_128 no-shared enable-buildtest-c++ enable-external-tests -DPEDANTIC -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION && perl configdata.pm --dump
+      run: CC=gcc ./config --banner=Configured --debug --coverage no-asm enable-fips enable-rc5 enable-md2 enable-ssl3 enable-nextprotoneg enable-ssl3-method enable-weak-ssl-ciphers enable-zlib enable-ec_nistp_64_gcc_128 no-shared enable-buildtest-c++ enable-external-tests -DPEDANTIC -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+    - name: config dump
+      run: ./configdata.pm --dump
+
     - name: make
       run: make -s -j4
     - name: make test

--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -17,7 +17,6 @@ jobs:
       run: CC=gcc ./config --banner=Configured --debug --coverage no-asm enable-fips enable-rc5 enable-md2 enable-ssl3 enable-nextprotoneg enable-ssl3-method enable-weak-ssl-ciphers enable-zlib enable-ec_nistp_64_gcc_128 no-shared enable-buildtest-c++ enable-external-tests -DPEDANTIC -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
     - name: config dump
       run: ./configdata.pm --dump
-
     - name: make
       run: make -s -j4
     - name: make test

--- a/.github/workflows/fips-checksums.yml
+++ b/.github/workflows/fips-checksums.yml
@@ -21,14 +21,12 @@ jobs:
           repository: ${{ github.event.pull_request.base.repo.full_name }}
           ref: ${{ github.event.pull_request.base.ref }}
           path: source-pristine
-
       - name: config pristine
         run: ../source-pristine/config enable-fips
         working-directory: ./build-pristine
       - name: config pristine dump
         run: ./configdata.pm --dump
         working-directory: ./build-pristine
-
       - name: make build_generated pristine
         run: make -s build_generated
         working-directory: ./build-pristine
@@ -38,14 +36,12 @@ jobs:
       - uses: actions/checkout@v2
         with:
           path: source
-
       - name: config
         run: ../source/config enable-fips
         working-directory: ./build
       - name: config dump
         run: ./configdata.pm --dump
         working-directory: ./build
-
       - name: make build_generated
         run: make -s build_generated
         working-directory: ./build

--- a/.github/workflows/fips-checksums.yml
+++ b/.github/workflows/fips-checksums.yml
@@ -21,9 +21,14 @@ jobs:
           repository: ${{ github.event.pull_request.base.repo.full_name }}
           ref: ${{ github.event.pull_request.base.ref }}
           path: source-pristine
+
       - name: config pristine
-        run: ../source-pristine/config enable-fips && perl configdata.pm --dump
+        run: ../source-pristine/config enable-fips
         working-directory: ./build-pristine
+      - name: config pristine dump
+        run: ./configdata.pm --dump
+        working-directory: ./build-pristine
+
       - name: make build_generated pristine
         run: make -s build_generated
         working-directory: ./build-pristine
@@ -33,9 +38,14 @@ jobs:
       - uses: actions/checkout@v2
         with:
           path: source
+
       - name: config
-        run: ../source/config enable-fips && perl configdata.pm --dump
+        run: ../source/config enable-fips
         working-directory: ./build
+      - name: config dump
+        run: ./configdata.pm --dump
+        working-directory: ./build
+
       - name: make build_generated
         run: make -s build_generated
         working-directory: ./build

--- a/.github/workflows/run-checker-ci.yml
+++ b/.github/workflows/run-checker-ci.yml
@@ -31,7 +31,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: config
-      run: CC=clang ./config --banner=Configured --strict-warnings ${{ matrix.opt }} && perl configdata.pm --dump
+      run: CC=clang ./config --banner=Configured --strict-warnings ${{ matrix.opt }}
+    - name: config dump
+      run: ./configdata.pm --dump
+
     - name: make
       run: make -s -j4
     - name: make test

--- a/.github/workflows/run-checker-ci.yml
+++ b/.github/workflows/run-checker-ci.yml
@@ -34,7 +34,6 @@ jobs:
       run: CC=clang ./config --banner=Configured --strict-warnings ${{ matrix.opt }}
     - name: config dump
       run: ./configdata.pm --dump
-
     - name: make
       run: make -s -j4
     - name: make test

--- a/.github/workflows/run-checker-daily.yml
+++ b/.github/workflows/run-checker-daily.yml
@@ -125,7 +125,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: config
-      run: CC=clang ./config --banner=Configured --strict-warnings ${{ matrix.opt }} && perl configdata.pm --dump
+      run: CC=clang ./config --banner=Configured --strict-warnings ${{ matrix.opt }}
+    - name: config dump
+      run: ./configdata.pm --dump
+
     - name: make
       run: make -s -j4
     - name: make test

--- a/.github/workflows/run-checker-daily.yml
+++ b/.github/workflows/run-checker-daily.yml
@@ -128,7 +128,6 @@ jobs:
       run: CC=clang ./config --banner=Configured --strict-warnings ${{ matrix.opt }}
     - name: config dump
       run: ./configdata.pm --dump
-
     - name: make
       run: make -s -j4
     - name: make test

--- a/.github/workflows/run-checker-merge.yml
+++ b/.github/workflows/run-checker-merge.yml
@@ -24,7 +24,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: config
-      run: CC=clang ./config --banner=Configured --strict-warnings ${{ matrix.opt }} && perl configdata.pm --dump
+      run: CC=clang ./config --banner=Configured --strict-warnings ${{ matrix.opt }}
+    - name: config dump
+      run: ./configdata.pm --dump
+
     - name: make
       run: make -s -j4
     - name: make test

--- a/.github/workflows/run-checker-merge.yml
+++ b/.github/workflows/run-checker-merge.yml
@@ -27,7 +27,6 @@ jobs:
       run: CC=clang ./config --banner=Configured --strict-warnings ${{ matrix.opt }}
     - name: config dump
       run: ./configdata.pm --dump
-
     - name: make
       run: make -s -j4
     - name: make test


### PR DESCRIPTION
This avoids using the shell's `&&` and shortens the lines a bit.
It also makes for less scrolling when looking for the config command line.


- [ ] documentation is added or updated
- [x] tests are added or updated
