### PR TITLE
Allow cipher strings to be given using its standard name

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -56,6 +56,11 @@ breaking changes, and mappings for the large list of deprecated functions.
 
 ### Changes between 1.1.1 and 3.0 [xx XXX xxxx]
 
+ * The SSL_CTX_set_cipher_list family functions now accept ciphers using their
+   standard names.
+
+   *Erik Lax*
+
  * TLS_MAX_VERSION, DTLS_MAX_VERSION and DTLS_MIN_VERSION constants are now
    deprecated.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,11 @@ OpenSSL 3.1
 
 ### Changes between 3.0 and 3.1 [xx XXX xxxx]
 
+ * The SSL_CTX_set_cipher_list family functions now accept ciphers using their
+   IANA standard names.
+
+   *Erik Lax*
+
  * The PVK key derivation function has been moved from b2i_PVK_bio_ex() into
    the legacy crypto provider as an EVP_KDF. Applications requiring this KDF
    will need to load the legacy crypto provider.
@@ -55,11 +60,6 @@ breaking changes, and mappings for the large list of deprecated functions.
 [Migration guide]: https://github.com/openssl/openssl/tree/master/doc/man7/migration_guide.pod
 
 ### Changes between 1.1.1 and 3.0 [xx XXX xxxx]
-
- * The SSL_CTX_set_cipher_list family functions now accept ciphers using their
-   standard names.
-
-   *Erik Lax*
 
  * TLS_MAX_VERSION, DTLS_MAX_VERSION and DTLS_MIN_VERSION constants are now
    deprecated.

--- a/doc/man1/openssl-ciphers.pod.in
+++ b/doc/man1/openssl-ciphers.pod.in
@@ -115,7 +115,9 @@ used. The format is described below.
 The cipher list consists of one or more I<cipher strings> separated by colons.
 Commas or spaces are also acceptable separators but colons are normally used.
 
-The cipher string may reference a cipher using its standard name.
+The cipher string may reference a cipher using its standard name from
+the IANA TLS Cipher Suites Registry
+(L<https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-4>).
 
 The actual cipher string can take several different forms.
 

--- a/doc/man1/openssl-ciphers.pod.in
+++ b/doc/man1/openssl-ciphers.pod.in
@@ -115,6 +115,8 @@ used. The format is described below.
 The cipher list consists of one or more I<cipher strings> separated by colons.
 Commas or spaces are also acceptable separators but colons are normally used.
 
+The cipher string may reference a cipher using its standard name.
+
 The actual cipher string can take several different forms.
 
 It can consist of a single cipher suite such as B<RC4-SHA>.

--- a/ssl/ssl_ciph.c
+++ b/ssl/ssl_ciph.c
@@ -1095,7 +1095,7 @@ static int ssl_cipher_process_rulestr(const char *rule_str,
                     && (ca_list[j]->name[buflen] == '\0')) {
                     found = 1;
                     break;
-                } else if (ca_list[j]->stdname && strncmp(buf, ca_list[j]->stdname, buflen) == 0
+                } else if (ca_list[j]->stdname != NULL && strncmp(buf, ca_list[j]->stdname, buflen) == 0
                     && (ca_list[j]->stdname[buflen] == '\0')) {
                     found = 1;
                     break;

--- a/ssl/ssl_ciph.c
+++ b/ssl/ssl_ciph.c
@@ -1095,8 +1095,9 @@ static int ssl_cipher_process_rulestr(const char *rule_str,
                     && (ca_list[j]->name[buflen] == '\0')) {
                     found = 1;
                     break;
-                } else if (ca_list[j]->stdname != NULL && strncmp(buf, ca_list[j]->stdname, buflen) == 0
-                    && (ca_list[j]->stdname[buflen] == '\0')) {
+                } else if (ca_list[j]->stdname != NULL
+                           && strncmp(buf, ca_list[j]->stdname, buflen) == 0
+                           && ca_list[j]->stdname[buflen] == '\0') {
                     found = 1;
                     break;
                 } else

--- a/ssl/ssl_ciph.c
+++ b/ssl/ssl_ciph.c
@@ -1042,9 +1042,9 @@ static int ssl_cipher_process_rulestr(const char *rule_str,
             while (((ch >= 'A') && (ch <= 'Z')) ||
                    ((ch >= '0') && (ch <= '9')) ||
                    ((ch >= 'a') && (ch <= 'z')) ||
-                   (ch == '-') || (ch == '.') || (ch == '='))
+                   (ch == '-') || (ch == '_') || (ch == '.') || (ch == '='))
 #else
-            while (isalnum((unsigned char)ch) || (ch == '-') || (ch == '.')
+            while (isalnum((unsigned char)ch) || (ch == '-') || (ch == '_') || (ch == '.')
                    || (ch == '='))
 #endif
             {
@@ -1093,6 +1093,10 @@ static int ssl_cipher_process_rulestr(const char *rule_str,
             while (ca_list[j]) {
                 if (strncmp(buf, ca_list[j]->name, buflen) == 0
                     && (ca_list[j]->name[buflen] == '\0')) {
+                    found = 1;
+                    break;
+                } else if (ca_list[j]->stdname && strncmp(buf, ca_list[j]->stdname, buflen) == 0
+                    && (ca_list[j]->stdname[buflen] == '\0')) {
                     found = 1;
                     break;
                 } else

--- a/test/cipherlist_test.c
+++ b/test/cipherlist_test.c
@@ -248,8 +248,8 @@ end:
 static int test_stdname_cipherlist(void)
 {
     SETUP_CIPHERLIST_TEST_FIXTURE();
-    if (!TEST_true(SSL_CTX_set_cipher_list(fixture->server, TLS1_RFC_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384))
-            || !TEST_true(SSL_CTX_set_cipher_list(fixture->client, TLS1_RFC_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384))) {
+    if (!TEST_true(SSL_CTX_set_cipher_list(fixture->server, TLS1_RFC_RSA_WITH_AES_128_SHA))
+            || !TEST_true(SSL_CTX_set_cipher_list(fixture->client, TLS1_RFC_RSA_WITH_AES_128_SHA))) {
         goto end;
     }
     result = 1;

--- a/test/cipherlist_test.c
+++ b/test/cipherlist_test.c
@@ -244,10 +244,26 @@ end:
     return result;
 }
 
+/* SSL_CTX_set_cipher_list matching with cipher standard name */
+static int test_stdname_cipherlist(void)
+{
+    SETUP_CIPHERLIST_TEST_FIXTURE();
+    if (!TEST_true(SSL_CTX_set_cipher_list(fixture->server, TLS1_RFC_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384))
+            || !TEST_true(SSL_CTX_set_cipher_list(fixture->client, TLS1_RFC_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384))) {
+        goto end;
+    }
+    result = 1;
+end:
+    tear_down(fixture);
+    fixture = NULL;
+    return result;
+}
+
 int setup_tests(void)
 {
     ADD_TEST(test_default_cipherlist_implicit);
     ADD_TEST(test_default_cipherlist_explicit);
     ADD_TEST(test_default_cipherlist_clear);
+    ADD_TEST(test_stdname_cipherlist);
     return 1;
 }


### PR DESCRIPTION
Added pull request for issue #16169

- [x] documentation is added or updated
- [x] tests are added or updated
