### PR TITLE
Redefine getpid() -> _getpid() only on MSVC

### DIFF
--- a/apps/lib/s_socket.c
+++ b/apps/lib/s_socket.c
@@ -27,12 +27,12 @@ typedef unsigned int u_int;
 #endif
 
 #ifdef _WIN32
-/*
- * With MSVC, certain POSIX functions have been renamed to have an underscore
- * prefix.
- */
 # include <process.h>
-# define getpid _getpid
+
+/* MSVC renamed some POSIX functions to have an underscore prefix. */
+# ifdef _MSC_VER
+#  define getpid _getpid
+# endif
 #endif
 
 #ifndef OPENSSL_NO_SOCK


### PR DESCRIPTION
This was introduced in 814b5133e for MSVC. C++Builder [doesn't need it](http://docwiki.embarcadero.com/RADStudio/Rio/en/Getpid), and in fact suffers a link error:

```
        "ilink32" -x -Gn -q -w-dup -j"C:\Program Files (x86)\Embarcadero\Studio\20.0\lib\win32c\release" -L"C:\Program Files (x86)\Embarcadero\Studio\20.0\lib\win32c\release" -ap -Tpe c0x32.obj wildargs.obj  -x -Gn -q -w-dup -j"C:\Program Files (x86)\Embarcadero\Studio\20.0\lib\win32c\release" -L"C:\Program Files (x86)\Embarcadero\Studio\20.0\lib\win32c\release" @MAKE0016.@@@
Error: Unresolved external '__getpid' referenced from C:\USERS\T_17_\SOURCE\REPOS\CRYPTOPALS\OPENSSL_ANOTHER\APPS\LIBAPPS.LIB|libapps-lib-s_socket
Error: Unable to perform link
```