### PR TITLE
Prevent recursive call of OPENSSL_INIT_LOAD_CONFIG

### DIFF
--- a/test/sysdefault.cnf
+++ b/test/sysdefault.cnf
@@ -5,6 +5,10 @@ openssl_conf = default_conf
 [ default_conf ]
 
 ssl_conf = ssl_sect
+oid_section = oid_sect
+
+[oid_sect]
+new-sig-oid = 1.1.1.1.1.1.1.1.1.1.1.1.1.1
 
 [ssl_sect]
 


### PR DESCRIPTION
If objects are added in a config file the OPENSSL_INIT_LOAD_CONFIG
will be called recursively which results in hang in RUN_ONCE.

Fixes #16186
