### PR TITLE
cms: Do not try to check binary format on stdin and -rctform fix

### DIFF
--- a/apps/cms.c
+++ b/apps/cms.c
@@ -484,13 +484,9 @@ int cms_main(int argc, char **argv)
             rr_allorfirst = 1;
             break;
         case OPT_RCTFORM:
-            if (rctformat == FORMAT_ASN1) {
-                if (!opt_format(opt_arg(),
-                                OPT_FMT_PEMDER | OPT_FMT_SMIME, &rctformat))
-                    goto opthelp;
-            } else {
-                rcms = load_content_info(rctformat, rctin, 0, NULL, "recipient");
-            }
+            if (!opt_format(opt_arg(),
+                            OPT_FMT_PEMDER | OPT_FMT_SMIME, &rctformat))
+                goto opthelp;
             break;
         case OPT_CERTFILE:
             certfile = opt_arg();
@@ -956,7 +952,7 @@ int cms_main(int argc, char **argv)
             goto end;
         }
 
-        rcms = load_content_info(rctformat, rctin, 0, NULL, "recipient");
+        rcms = load_content_info(rctformat, rctin, 0, NULL, "receipt");
         if (rcms == NULL)
             goto end;
     }

--- a/apps/cms.c
+++ b/apps/cms.c
@@ -278,6 +278,8 @@ static void warn_binary(const char *file)
     unsigned char linebuf[1024], *cur, *end;
     int len;
 
+    if (file == NULL)
+        return; /* cannot give a warning for stdin input */
     if ((bio = bio_open_default(file, 'r', FORMAT_BINARY)) == NULL)
         return; /* cannot give a proper warning since there is an error */
     while ((len = BIO_read(bio, linebuf, sizeof(linebuf))) > 0) {


### PR DESCRIPTION
Two issues in the cms application are fixed by this PR.

Fixes #16195
