### PR TITLE
apps: When loading just certs or crls do not set password callback

### DIFF
--- a/crypto/store/store_result.c
+++ b/crypto/store/store_result.c
@@ -378,7 +378,7 @@ static int try_key(struct extracted_param_data_st *data, OSSL_STORE_INFO **v,
     if ((ctx->expected_type == 0
          || ctx->expected_type == OSSL_STORE_INFO_PARAMS
          || ctx->expected_type == OSSL_STORE_INFO_PUBKEY
-         || ctx->expected_type == OSSL_STORE_INFO_PARAMS)
+         || ctx->expected_type == OSSL_STORE_INFO_PKEY)
         && (data->object_type == OSSL_OBJECT_UNKNOWN
             || data->object_type == OSSL_OBJECT_PKEY)) {
         EVP_PKEY *pk = NULL;


### PR DESCRIPTION
This is rather a workaround as better fix would require loading only the pem2der decoder in the provided file store if we expect crls or certs only.

Fixes #16224

Also in store_result: Do not try to decode something unexpected.
