### PR TITLE
doc: Fix ECX FIPS documentation

### DIFF
--- a/doc/man7/EVP_PKEY-X25519.pod
+++ b/doc/man7/EVP_PKEY-X25519.pod
@@ -13,8 +13,6 @@ implemented in OpenSSL's default and FIPS providers.  These implementations
 support the associated key, containing the public key I<pub> and the
 private key I<priv>.
 
-In the FIPS provider they are non-approved algorithms and do not have the
-"fips=yes" property set.
 No additional parameters can be set during key generation.
 
 

--- a/doc/man7/OSSL_PROVIDER-FIPS.pod
+++ b/doc/man7/OSSL_PROVIDER-FIPS.pod
@@ -116,11 +116,7 @@ The OpenSSL FIPS provider supports these operations and algorithms:
 
 =item X25519, see L<EVP_KEYEXCH-X25519(7)>
 
-This has the property "provider=fips,fips=no"
-
 =item X448, see L<EVP_KEYEXCH-X448(7)>
-
-This has the property "provider=fips,fips=no"
 
 =back
 
@@ -131,6 +127,10 @@ This has the property "provider=fips,fips=no"
 =item DSA, see L<EVP_KEYEXCH-DSA(7)>
 
 =item RSA, see L<EVP_SIGNATURE-RSA(7)>
+
+=item X25519, see L<EVP_SIGNATURE-ED25519(7)>
+
+=item X448, see L<EVP_SIGNATURE-ED448(7)>
 
 =item HMAC, see L<EVP_SIGNATURE-HMAC(7)>
 


### PR DESCRIPTION
Both Ed448 and Ed25519 were omitted from the signature list.
X448 and X25519 were flagged as not FIPS valid which wasn't correct.

Fixes #16234


- [x] documentation is added or updated
- [ ] tests are added or updated
