### PR TITLE
Add --multilib configure option to override the multilib suffix

### DIFF
--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -297,7 +297,9 @@ OPENSSLDIR={- #
               $openssldir -}
 LIBDIR={- our $libdir = $config{libdir};
           unless ($libdir) {
-              $libdir = "lib$target{multilib}";
+              our $multilib = defined($config{multilib}) ?
+                  $config{multilib} : $target{multilib};
+              $libdir = "lib$multilib";
           }
           file_name_is_absolute($libdir) ? "" : $libdir -}
 # $(libdir) is chosen to be compatible with the GNU coding standards

--- a/Configure
+++ b/Configure
@@ -71,6 +71,9 @@ EOF
 #               given, do not compile support for interfaces deprecated
 #               up to and including the specified OpenSSL version.
 #
+# --multilib    Override the libdir multilib postfix from the target.
+#               For example use --multilib='' to use empty postfix.
+#
 # no-hw-xxx     do not compile support for specific crypto hardware.
 #               Generic OpenSSL-style methods relating to this support
 #               are always compiled but return NULL if the hardware
@@ -947,6 +950,10 @@ while (@argvcopy)
                 elsif (/^--libdir=(.*)$/)
                         {
                         $config{libdir}=$1;
+                        }
+                elsif (/^--multilib=(.*)$/)
+                        {
+                        $config{multilib}=$1;
                         }
                 elsif (/^--openssldir=(.*)$/)
                         {

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -378,6 +378,14 @@ The top of the installation directory tree.  Defaults are:
     Windows:        C:\Program Files\OpenSSL
     OpenVMS:        SYS$COMMON:[OPENSSL]
 
+### multilib
+
+    --multilib=STRING
+
+The STRING will be used as a postfix of the libdir name when the default libdir
+is used overriding eventual multilib value from the configuration targets.
+Applies only to Unix systems.
+
 Compiler Warnings
 -----------------
 


### PR DESCRIPTION
The 74b7f33 removed the 'ignore multilib if the directory does not
exist already' hack. Provide a replacement for the hack when the
default multilib suffix from the build target is not right.

Fixes #16244

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
