### PR TITLE
Fix malloc failure handling of `X509_ALGOR_set0()`

### DIFF
--- a/crypto/asn1/a_sign.c
+++ b/crypto/asn1/a_sign.c
@@ -247,16 +247,14 @@ int ASN1_item_sign_ctx(const ASN1_ITEM *it, X509_ALGOR *algor1,
             goto err;
         }
 
-        if (pkey->ameth->pkey_flags & ASN1_PKEY_SIGPARAM_NULL)
-            paramtype = V_ASN1_NULL;
-        else
-            paramtype = V_ASN1_UNDEF;
-
-        if (algor1)
-            X509_ALGOR_set0(algor1, OBJ_nid2obj(signid), paramtype, NULL);
-        if (algor2)
-            X509_ALGOR_set0(algor2, OBJ_nid2obj(signid), paramtype, NULL);
-
+        paramtype = pkey->ameth->pkey_flags & ASN1_PKEY_SIGPARAM_NULL ?
+            V_ASN1_NULL : V_ASN1_UNDEF;
+        if (algor1 != NULL
+            && !X509_ALGOR_set0(algor1, OBJ_nid2obj(signid), paramtype, NULL))
+            goto err;
+        if (algor2 != NULL
+            && !X509_ALGOR_set0(algor2, OBJ_nid2obj(signid), paramtype, NULL))
+            goto err;
     }
 
     buf_len = ASN1_item_i2d(data, &buf_in, it);

--- a/crypto/cms/cms_cd.c
+++ b/crypto/cms/cms_cd.c
@@ -50,8 +50,9 @@ CMS_ContentInfo *ossl_cms_CompressedData_create(int comp_nid,
 
     cd->version = 0;
 
-    X509_ALGOR_set0(cd->compressionAlgorithm,
-                    OBJ_nid2obj(NID_zlib_compression), V_ASN1_UNDEF, NULL);
+    (void)X509_ALGOR_set0(cd->compressionAlgorithm,
+                          OBJ_nid2obj(NID_zlib_compression),
+                          V_ASN1_UNDEF, NULL); /* cannot fail */
 
     cd->encapContentInfo->eContentType = OBJ_nid2obj(NID_pkcs7_data);
 

--- a/crypto/cms/cms_dh.c
+++ b/crypto/cms/cms_dh.c
@@ -238,8 +238,8 @@ static int dh_cms_encrypt(CMS_RecipientInfo *ri)
         pubkey->flags |= ASN1_STRING_FLAG_BITS_LEFT;
 
         penc = NULL;
-        X509_ALGOR_set0(talg, OBJ_nid2obj(NID_dhpublicnumber),
-                        V_ASN1_UNDEF, NULL);
+        (void)X509_ALGOR_set0(talg, OBJ_nid2obj(NID_dhpublicnumber),
+                              V_ASN1_UNDEF, NULL); /* cannot fail */
     }
 
     /* See if custom parameters set */
@@ -316,10 +316,10 @@ static int dh_cms_encrypt(CMS_RecipientInfo *ri)
         goto err;
     ASN1_STRING_set0(wrap_str, penc, penclen);
     penc = NULL;
-    X509_ALGOR_set0(talg, OBJ_nid2obj(NID_id_smime_alg_ESDH),
-                    V_ASN1_SEQUENCE, wrap_str);
-
-    rv = 1;
+    rv = X509_ALGOR_set0(talg, OBJ_nid2obj(NID_id_smime_alg_ESDH),
+                         V_ASN1_SEQUENCE, wrap_str);
+    if (!rv)
+        ASN1_STRING_free(wrap_str);
 
  err:
     OPENSSL_free(penc);

--- a/crypto/cms/cms_ec.c
+++ b/crypto/cms/cms_ec.c
@@ -281,8 +281,8 @@ static int ecdh_cms_encrypt(CMS_RecipientInfo *ri)
         pubkey->flags |= ASN1_STRING_FLAG_BITS_LEFT;
 
         penc = NULL;
-        X509_ALGOR_set0(talg, OBJ_nid2obj(NID_X9_62_id_ecPublicKey),
-                        V_ASN1_UNDEF, NULL);
+        (void)X509_ALGOR_set0(talg, OBJ_nid2obj(NID_X9_62_id_ecPublicKey),
+                              V_ASN1_UNDEF, NULL); /* cannot fail */
     }
 
     /* See if custom parameters set */
@@ -365,9 +365,9 @@ static int ecdh_cms_encrypt(CMS_RecipientInfo *ri)
         goto err;
     ASN1_STRING_set0(wrap_str, penc, penclen);
     penc = NULL;
-    X509_ALGOR_set0(talg, OBJ_nid2obj(kdf_nid), V_ASN1_SEQUENCE, wrap_str);
-
-    rv = 1;
+    rv = X509_ALGOR_set0(talg, OBJ_nid2obj(kdf_nid), V_ASN1_SEQUENCE, wrap_str);
+    if (!rv)
+        ASN1_STRING_free(wrap_str);
 
  err:
     OPENSSL_free(penc);
@@ -394,7 +394,7 @@ int ossl_cms_ecdsa_dsa_sign(CMS_SignerInfo *si, int verify)
 {
     assert(verify == 0 || verify == 1);
 
-    if (verify == 0) {
+    if (!verify) {
         int snid, hnid;
         X509_ALGOR *alg1, *alg2;
         EVP_PKEY *pkey = si->pkey;
@@ -407,7 +407,7 @@ int ossl_cms_ecdsa_dsa_sign(CMS_SignerInfo *si, int verify)
             return -1;
         if (!OBJ_find_sigid_by_algs(&snid, hnid, EVP_PKEY_get_id(pkey)))
             return -1;
-        X509_ALGOR_set0(alg2, OBJ_nid2obj(snid), V_ASN1_UNDEF, 0);
+        return X509_ALGOR_set0(alg2, OBJ_nid2obj(snid), V_ASN1_UNDEF, NULL);
     }
     return 1;
 }

--- a/crypto/cms/cms_env.c
+++ b/crypto/cms/cms_env.c
@@ -730,8 +730,8 @@ CMS_RecipientInfo *CMS_add0_recipient_key(CMS_ContentInfo *cms, int nid,
         kekri->kekid->other->keyAttr = otherType;
     }
 
-    X509_ALGOR_set0(kekri->keyEncryptionAlgorithm,
-                    OBJ_nid2obj(nid), V_ASN1_UNDEF, NULL);
+    (void)X509_ALGOR_set0(kekri->keyEncryptionAlgorithm, OBJ_nid2obj(nid),
+                          V_ASN1_UNDEF, NULL); /* cannot fail */
 
     return ri;
 

--- a/crypto/cms/cms_sd.c
+++ b/crypto/cms/cms_sd.c
@@ -354,6 +354,7 @@ CMS_SignerInfo *CMS_add1_signer(CMS_ContentInfo *cms,
 
     if (md == NULL) {
         int def_nid;
+
         if (EVP_PKEY_get_default_digest_nid(pk, &def_nid) <= 0)
             goto err;
         md = EVP_get_digestbynid(def_nid);
@@ -361,11 +362,6 @@ CMS_SignerInfo *CMS_add1_signer(CMS_ContentInfo *cms,
             ERR_raise(ERR_LIB_CMS, CMS_R_NO_DEFAULT_DIGEST);
             goto err;
         }
-    }
-
-    if (!md) {
-        ERR_raise(ERR_LIB_CMS, CMS_R_NO_DIGEST_SET);
-        goto err;
     }
 
     if (md == NULL) {
@@ -388,8 +384,7 @@ CMS_SignerInfo *CMS_add1_signer(CMS_ContentInfo *cms,
     }
 
     if (i == sk_X509_ALGOR_num(sd->digestAlgorithms)) {
-        alg = X509_ALGOR_new();
-        if (alg == NULL)
+        if ((alg = X509_ALGOR_new()) == NULL)
             goto merr;
         X509_ALGOR_set_md(alg, md);
         if (!sk_X509_ALGOR_push(sd->digestAlgorithms, alg)) {

--- a/crypto/ec/ecx_meth.c
+++ b/crypto/ec/ecx_meth.c
@@ -561,17 +561,23 @@ static int ecd_item_verify(EVP_MD_CTX *ctx, const ASN1_ITEM *it,
     return 2;
 }
 
+static int ecd_item_sign(X509_ALGOR *alg1, X509_ALGOR *alg2, int nid)
+{
+    /* Note that X509_ALGOR_set0(..., ..., V_ASN1_UNDEF, ...) cannot fail */
+    /* Set algorithms identifiers */
+    (void)X509_ALGOR_set0(alg1, OBJ_nid2obj(nid), V_ASN1_UNDEF, NULL);
+    if (alg2 != NULL)
+        (void)X509_ALGOR_set0(alg2, OBJ_nid2obj(nid), V_ASN1_UNDEF, NULL);
+    /* Algorithm identifiers set: carry on as normal */
+    return 3;
+}
+
 static int ecd_item_sign25519(EVP_MD_CTX *ctx, const ASN1_ITEM *it,
                               const void *asn,
                               X509_ALGOR *alg1, X509_ALGOR *alg2,
                               ASN1_BIT_STRING *str)
 {
-    /* Set algorithms identifiers */
-    X509_ALGOR_set0(alg1, OBJ_nid2obj(NID_ED25519), V_ASN1_UNDEF, NULL);
-    if (alg2)
-        X509_ALGOR_set0(alg2, OBJ_nid2obj(NID_ED25519), V_ASN1_UNDEF, NULL);
-    /* Algorithm identifiers set: carry on as normal */
-    return 3;
+    return ecd_item_sign(alg1, alg2, NID_ED25519);
 }
 
 static int ecd_sig_info_set25519(X509_SIG_INFO *siginf, const X509_ALGOR *alg,
@@ -587,12 +593,7 @@ static int ecd_item_sign448(EVP_MD_CTX *ctx, const ASN1_ITEM *it,
                             X509_ALGOR *alg1, X509_ALGOR *alg2,
                             ASN1_BIT_STRING *str)
 {
-    /* Set algorithm identifier */
-    X509_ALGOR_set0(alg1, OBJ_nid2obj(NID_ED448), V_ASN1_UNDEF, NULL);
-    if (alg2 != NULL)
-        X509_ALGOR_set0(alg2, OBJ_nid2obj(NID_ED448), V_ASN1_UNDEF, NULL);
-    /* Algorithm identifier set: carry on as normal */
-    return 3;
+    return ecd_item_sign(alg1, alg2, NID_ED448);
 }
 
 static int ecd_sig_info_set448(X509_SIG_INFO *siginf, const X509_ALGOR *alg,

--- a/crypto/pkcs7/pk7_lib.c
+++ b/crypto/pkcs7/pk7_lib.c
@@ -305,7 +305,7 @@ int PKCS7_add_crl(PKCS7 *p7, X509_CRL *crl)
 static int pkcs7_ecdsa_or_dsa_sign_verify_setup(PKCS7_SIGNER_INFO *si,
                                                 int verify)
 {
-    if (verify == 0) {
+    if (!verify) {
         int snid, hnid;
         X509_ALGOR *alg1, *alg2;
         EVP_PKEY *pkey = si->pkey;
@@ -318,19 +318,20 @@ static int pkcs7_ecdsa_or_dsa_sign_verify_setup(PKCS7_SIGNER_INFO *si,
             return -1;
         if (!OBJ_find_sigid_by_algs(&snid, hnid, EVP_PKEY_get_id(pkey)))
             return -1;
-        X509_ALGOR_set0(alg2, OBJ_nid2obj(snid), V_ASN1_UNDEF, 0);
+        return X509_ALGOR_set0(alg2, OBJ_nid2obj(snid), V_ASN1_UNDEF, NULL);
     }
     return 1;
 }
 
 static int pkcs7_rsa_sign_verify_setup(PKCS7_SIGNER_INFO *si, int verify)
 {
-    if (verify == 0) {
+    if (!verify) {
         X509_ALGOR *alg = NULL;
 
         PKCS7_SIGNER_INFO_get0_algs(si, NULL, NULL, &alg);
         if (alg != NULL)
-            X509_ALGOR_set0(alg, OBJ_nid2obj(NID_rsaEncryption), V_ASN1_NULL, 0);
+            return X509_ALGOR_set0(alg, OBJ_nid2obj(NID_rsaEncryption),
+                                   V_ASN1_NULL, NULL);
     }
     return 1;
 }
@@ -342,10 +343,10 @@ int PKCS7_SIGNER_INFO_set(PKCS7_SIGNER_INFO *p7i, X509 *x509, EVP_PKEY *pkey,
 
     /* We now need to add another PKCS7_SIGNER_INFO entry */
     if (!ASN1_INTEGER_set(p7i->version, 1))
-        goto err;
+        return 0;
     if (!X509_NAME_set(&p7i->issuer_and_serial->issuer,
                        X509_get_issuer_name(x509)))
-        goto err;
+        return 0;
 
     /*
      * because ASN1_INTEGER_set is used to set a 'long' we will do things the
@@ -354,7 +355,7 @@ int PKCS7_SIGNER_INFO_set(PKCS7_SIGNER_INFO *p7i, X509 *x509, EVP_PKEY *pkey,
     ASN1_INTEGER_free(p7i->issuer_and_serial->serial);
     if (!(p7i->issuer_and_serial->serial =
           ASN1_INTEGER_dup(X509_get0_serialNumber(x509))))
-        goto err;
+        return 0;
 
     /* lets keep the pkey around for a while */
     EVP_PKEY_up_ref(pkey);
@@ -362,8 +363,9 @@ int PKCS7_SIGNER_INFO_set(PKCS7_SIGNER_INFO *p7i, X509 *x509, EVP_PKEY *pkey,
 
     /* Set the algorithms */
 
-    X509_ALGOR_set0(p7i->digest_alg, OBJ_nid2obj(EVP_MD_get_type(dgst)),
-                    V_ASN1_NULL, NULL);
+    if (!X509_ALGOR_set0(p7i->digest_alg, OBJ_nid2obj(EVP_MD_get_type(dgst)),
+                         V_ASN1_NULL, NULL))
+        return 0;
 
     if (EVP_PKEY_is_a(pkey, "EC") || EVP_PKEY_is_a(pkey, "DSA"))
         return pkcs7_ecdsa_or_dsa_sign_verify_setup(p7i, 0);
@@ -380,7 +382,6 @@ int PKCS7_SIGNER_INFO_set(PKCS7_SIGNER_INFO *p7i, X509 *x509, EVP_PKEY *pkey,
         }
     }
     ERR_raise(ERR_LIB_PKCS7, PKCS7_R_SIGNING_NOT_SUPPORTED_FOR_THIS_KEY_TYPE);
- err:
     return 0;
 }
 
@@ -598,10 +599,11 @@ static int pkcs7_rsa_encrypt_decrypt_setup(PKCS7_RECIP_INFO *ri, int decrypt)
 {
     X509_ALGOR *alg = NULL;
 
-    if (decrypt == 0) {
+    if (!decrypt) {
         PKCS7_RECIP_INFO_get0_alg(ri, &alg);
         if (alg != NULL)
-            X509_ALGOR_set0(alg, OBJ_nid2obj(NID_rsaEncryption), V_ASN1_NULL, 0);
+            return X509_ALGOR_set0(alg, OBJ_nid2obj(NID_rsaEncryption),
+                                   V_ASN1_NULL, NULL);
     }
     return 1;
 }

--- a/crypto/rsa/rsa_ameth.c
+++ b/crypto/rsa/rsa_ameth.c
@@ -636,23 +636,29 @@ static int rsa_item_sign(EVP_MD_CTX *ctx, const ASN1_ITEM *it, const void *asn,
     if (pad_mode == RSA_PKCS1_PADDING)
         return 2;
     if (pad_mode == RSA_PKCS1_PSS_PADDING) {
-        ASN1_STRING *os1 = NULL;
-        os1 = ossl_rsa_ctx_to_pss_string(pkctx);
-        if (!os1)
+        ASN1_STRING *os1 = ossl_rsa_ctx_to_pss_string(pkctx);
+
+        if (os1 == NULL)
             return 0;
         /* Duplicate parameters if we have to */
-        if (alg2) {
+        if (alg2 != NULL) {
             ASN1_STRING *os2 = ASN1_STRING_dup(os1);
-            if (!os2) {
-                ASN1_STRING_free(os1);
-                return 0;
+
+            if (os2 == NULL)
+                goto err;
+            if (!X509_ALGOR_set0(alg2, OBJ_nid2obj(EVP_PKEY_RSA_PSS),
+                                 V_ASN1_SEQUENCE, os2)) {
+                ASN1_STRING_free(os2);
+                goto err;
             }
-            X509_ALGOR_set0(alg2, OBJ_nid2obj(EVP_PKEY_RSA_PSS),
-                            V_ASN1_SEQUENCE, os2);
         }
-        X509_ALGOR_set0(alg1, OBJ_nid2obj(EVP_PKEY_RSA_PSS),
-                        V_ASN1_SEQUENCE, os1);
+        if (!X509_ALGOR_set0(alg1, OBJ_nid2obj(EVP_PKEY_RSA_PSS),
+                             V_ASN1_SEQUENCE, os1))
+            goto err;
         return 3;
+    err:
+        ASN1_STRING_free(os1);
+        return 0;
     }
     return 2;
 }

--- a/doc/man3/X509_ALGOR_dup.pod
+++ b/doc/man3/X509_ALGOR_dup.pod
@@ -2,7 +2,10 @@
 
 =head1 NAME
 
-X509_ALGOR_dup, X509_ALGOR_set0, X509_ALGOR_get0, X509_ALGOR_set_md, X509_ALGOR_cmp, X509_ALGOR_copy - AlgorithmIdentifier functions
+X509_ALGOR_dup,
+X509_ALGOR_set0, X509_ALGOR_get0,
+X509_ALGOR_set_md, X509_ALGOR_cmp,
+X509_ALGOR_copy - AlgorithmIdentifier functions
 
 =head1 SYNOPSIS
 
@@ -18,23 +21,24 @@ X509_ALGOR_dup, X509_ALGOR_set0, X509_ALGOR_get0, X509_ALGOR_set_md, X509_ALGOR_
 
 =head1 DESCRIPTION
 
-X509_ALGOR_dup() returns a copy of B<alg>.
+X509_ALGOR_dup() returns a copy of I<alg>.
 
-X509_ALGOR_set0() sets the algorithm OID of B<alg> to B<aobj> and the
-associated parameter type to B<ptype> with value B<pval>. If B<ptype> is
-B<V_ASN1_UNDEF> the parameter is omitted, otherwise B<ptype> and B<pval> have
-the same meaning as the B<type> and B<value> parameters to ASN1_TYPE_set().
+X509_ALGOR_set0() sets the algorithm OID of I<alg> to I<aobj> and the
+associated parameter type to I<ptype> with value I<pval>. If I<ptype> is
+B<V_ASN1_UNDEF> the parameter is omitted, otherwise I<ptype> and I<pval> have
+the same meaning as the I<type> and I<value> parameters to ASN1_TYPE_set().
 All the supplied parameters are used internally so must B<NOT> be freed after
-this call.
+this call succeeded;
+otherwise ownership remains with the caller and I<alg> remains untouched.
 
 X509_ALGOR_get0() is the inverse of X509_ALGOR_set0(): it returns the
-algorithm OID in B<*paobj> and the associated parameter in B<*pptype>
-and B<*ppval> from the B<AlgorithmIdentifier> B<alg>.
+algorithm OID in I<*paobj> and the associated parameter in I<*pptype>
+and I<*ppval> from the B<AlgorithmIdentifier> I<alg>.
 
-X509_ALGOR_set_md() sets the B<AlgorithmIdentifier> B<alg> to appropriate
-values for the message digest B<md>.
+X509_ALGOR_set_md() sets the B<AlgorithmIdentifier> I<alg> to appropriate
+values for the message digest I<md>.
 
-X509_ALGOR_cmp() compares B<a> and B<b> and returns 0 if they have identical
+X509_ALGOR_cmp() compares I<a> and I<b> and returns 0 if they have identical
 encodings and nonzero otherwise.
 
 X509_ALGOR_copy() copies the source values into the dest structs; making


### PR DESCRIPTION
Also update and slightly extend the respective documentation and simplify some code.
~and add  internal `ossl_x509_algor_from_nid()` for simplifying code.~

This is all minor stuff, so I'd say can wait until after 3.0 release.