### PR TITLE
Sync 1.1.1 GitHub CI with master

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,40 @@
+## Rationale about our design for the GitHub Actions CI
+
+The balance is between the time taken and the number of jobs.
+We're allowed 180 concurrent jobs in total across the entire project.
+Currently we're running about 60 on pull_request, a few more on push and
+a pile per day.
+So three simultaneous PRs should finish quickly enough.
+Given that most jobs run quickly, this could scale up to 5 or 6 without
+problem.
+
+Moving more jobs into the `pull_request` category will limit the number
+of parallel builds (from different PRs) we can handle.
+We got into quite some strife over this with our older CI hosts
+-- remember builds taking the best part of a day to run.
+We really want to avoid that again.
+
+I've been trying to limit total job time per job to around 20-30 minutes
+(there are some longer ones I know of), with most jobs running in the
+sub 5 minute range.
+There are some longer lived CIs -- up to an hour and I try to delegate
+these to push or daily rather than pull_request.
+
+Still, there is no hard and fast rule about what runs when or where.
+Make a suggestion about bettering the CIs -- Ideally I'd like the
+`pull_request` jobs to be the ones catching most of the problems and the
+push and daily being predictably boring successes.
+Just make an effort to rationally justify the inclusions/changes.
+
+Things like the sanitiser builds, we know catch problems often.
+So even though they are slow they are worthwhile on `pull_request`.
+A lot of the daily builds are unlikely to catch much since they are
+checking options can be turned off and on, so they are fine not running
+as much.
+The demarkation between `pull_request` and `pull_request + push` is the
+difficult choice.
+I believe we should do all pull_request jobs as part of push too.
+The question is how many more should there be.
+
+I don't have a good answer but I think we're converging on a practical
+number and we should get better as we gain experience.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,5 @@
-name: GitHub CI
+---
+name: GitHub CI for 1.1.1
 
 on: [pull_request, push]
 
@@ -22,7 +23,7 @@ jobs:
     - name: make build_generated
       run: make -s build_generated
     - name: make update
-      run: make -s update
+      run: make update
     - name: git diff
       run: git diff --exit-code
 
@@ -37,111 +38,242 @@ jobs:
     - name: make doc-nits
       run: make doc-nits
 
+  # This checks that we use ANSI C language syntax and semantics.
+  # We are not as strict with libraries, but rather adapt to what's
+  # expected to be available in a certain version of each platform.
+  check-ansi:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: config
+      run: CPPFLAGS=-ansi ./config no-asm no-makedepend enable-buildtest-c++ --strict-warnings -D_DEFAULT_SOURCE && perl configdata.pm --dump
+    - name: make
+      run: make -s -j4
+
   basic_gcc:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: config
-        run: ./config --strict-warnings && perl configdata.pm --dump
-      - name: make
-        run: make -s -j4
-      - name: make test
-        run: make test
+    - uses: actions/checkout@v2
+    - name: config
+      run: CC=gcc ./config --strict-warnings && perl configdata.pm --dump
+    - name: make
+      run: make -s -j4
+    - name: make test
+      run: make test
 
   basic_clang:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: config
-        run: CC=clang ./config --strict-warnings && perl configdata.pm --dump
-      - name: make
-        run: make -s -j4
-      - name: make test
-        run: make test
+    - uses: actions/checkout@v2
+    - name: config
+      run: CC=clang ./config --strict-warnings && perl configdata.pm --dump
+    - name: make
+      run: make -s -j4
+    - name: make test
+      run: make test
 
   minimal:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: config
-        run: ./config --strict-warnings no-shared no-dso no-pic no-aria no-async no-autoload-config no-blake2 no-bf no-camellia no-cast no-chacha no-cmac no-cms no-comp no-ct no-des no-dgram no-dh no-dsa no-dtls no-ec2m no-engine no-filenames no-gost no-idea no-mdc2 no-md4 no-multiblock no-nextprotoneg no-ocsp no-ocb no-poly1305 no-psk no-rc2 no-rc4 no-rmd160 no-seed no-siphash no-sm2 no-sm3 no-sm4 no-srp no-srtp no-ssl3 no-ssl3-method no-ts no-ui-console no-whirlpool no-asm -DOPENSSL_NO_SECURE_MEMORY -DOPENSSL_SMALL_FOOTPRINT && perl configdata.pm --dump
-      - name: make
-        run: make -s -j4
-      - name: make test
-        run: make test
-
-  out-of-tree_build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: setup build dir
-        run: |
-            set -eux
-            mkdir -p ${myblddir:=../_build/nest/a/little/more}
-            echo "mysrcdir=$(realpath .)" | tee -a $GITHUB_ENV
-            echo "myblddir=$(realpath $myblddir)" | tee -a $GITHUB_ENV
-      - name: config
-        run: set -eux ; cd ${{ env.myblddir }} && ${{ env.mysrcdir }}/config --strict-warnings && perl configdata.pm --dump
-      - name: make build_generated
-        run: set -eux; cd ${{ env.myblddir }} && make -s build_generated
-      - name: make update
-        run: set -eux; cd ${{ env.myblddir }} && make update
-      - name: make
-        run: set -eux; cd ${{ env.myblddir }} && make -s -j4
-      - name: make test (minimal subset)
-        run: set -eux; cd ${{ env.myblddir }} && make test TESTS='0[0-9]'
+    - uses: actions/checkout@v2
+    - name: config
+      run: ./config --strict-warnings no-shared no-dso no-pic no-aria no-async no-autoload-config no-blake2 no-bf no-camellia no-cast no-chacha no-cmac no-cms no-comp no-ct no-des no-dgram no-dh no-dsa no-dtls no-ec2m no-engine no-filenames no-gost no-idea no-mdc2 no-md4 no-multiblock no-nextprotoneg no-ocsp no-ocb no-poly1305 no-psk no-rc2 no-rc4 no-rmd160 no-seed no-siphash no-sm2 no-sm3 no-sm4 no-srp no-srtp no-ssl3 no-ssl3-method no-ts no-ui-console no-whirlpool no-asm -DOPENSSL_NO_SECURE_MEMORY -DOPENSSL_SMALL_FOOTPRINT && perl configdata.pm --dump
+    - name: make
+      run: make -j4  # verbose, so no -s here
+    - name: make test
+      run: make test
 
   no-deprecated:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: config
-        run: ./config --strict-warnings no-deprecated && perl configdata.pm --dump
-      - name: make
-        run: make -s -j4
-      - name: make test
-        run: make test
+    - uses: actions/checkout@v2
+    - name: config
+      run: ./config --strict-warnings no-deprecated && perl configdata.pm --dump
+    - name: make
+      run: make -s -j4
+    - name: make test
+      run: make test
 
-  sanitizers:
+  no-shared:
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, macos-latest ]
+    runs-on: ${{matrix.os}}
+    steps:
+    - uses: actions/checkout@v2
+    - name: config
+      run: ./config --strict-warnings no-shared && perl configdata.pm --dump
+    - name: make
+      run: make -s -j4
+    - name: make test
+      run: make test
+
+  address_ub_sanitizer:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: config
-        run: ./config --debug enable-asan enable-ubsan enable-rc5 enable-md2 enable-ec_nistp_64_gcc_128 && perl configdata.pm --dump
-      - name: make
-        run: make -s -j4
-      - name: make test
-        run: make test OPENSSL_TEST_RAND_ORDER=0
+    - uses: actions/checkout@v2
+    - name: config
+      run: ./config --debug enable-asan enable-ubsan enable-rc5 enable-md2 enable-ec_nistp_64_gcc_128 && perl configdata.pm --dump
+    - name: make
+      run: make -s -j4
+    - name: make test
+      run: make test OPENSSL_TEST_RAND_ORDER=0
+
+  memory_sanitizer:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: config
+      # --debug -O1 is to produce a debug build that runs in a reasonable amount of time
+      run: CC=clang ./config --debug -O1 -fsanitize=memory -DOSSL_SANITIZE_MEMORY -fno-optimize-sibling-calls enable-rc5 enable-md2 enable-ec_nistp_64_gcc_128 && perl configdata.pm --dump
+    - name: make
+      run: make -s -j4
+    - name: make test
+      run: make test
+
+  threads_sanitizer:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: config
+      run: CC=clang ./config --strict-warnings -fsanitize=thread && perl configdata.pm --dump
+    - name: make
+      run: make -s -j4
+    - name: make test
+      run: make TESTS=test_threads test
 
   enable_non-default_options:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: config
-        run: ./config --strict-warnings no-ec enable-ssl-trace enable-zlib enable-zlib-dynamic enable-crypto-mdebug enable-crypto-mdebug-backtrace enable-egd && perl configdata.pm --dump
-      - name: make
-        run: make -s -j4
-      - name: make test
-        run: make test
+    - uses: actions/checkout@v2
+    - name: config
+      run: ./config --strict-warnings no-ec enable-ssl-trace enable-zlib enable-zlib-dynamic enable-crypto-mdebug enable-crypto-mdebug-backtrace enable-egd && perl configdata.pm --dump
+    - name: make
+      run: make -s -j4
+    - name: make test
+      run: make test
 
   legacy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: config
-        run: ./config -Werror --debug no-afalgeng no-shared enable-crypto-mdebug enable-rc5 enable-md2 enable-ssl3 enable-ssl3-method enable-weak-ssl-ciphers enable-zlib enable-ec_nistp_64_gcc_128 && perl configdata.pm --dump
-      - name: make
-        run: make -s -j4
-      - name: make test
-        run: make test
+    - uses: actions/checkout@v2
+    - name: config
+      run: ./config -Werror --debug no-afalgeng no-shared enable-crypto-mdebug enable-rc5 enable-md2 enable-ssl3 enable-ssl3-method enable-weak-ssl-ciphers enable-zlib enable-ec_nistp_64_gcc_128 && perl configdata.pm --dump
+    - name: make
+      run: make -s -j4
+    - name: make test
+      run: make test
 
   buildtest:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: config
-        run: ./config no-makedepend enable-buildtest-c++ --strict-warnings -D_DEFAULT_SOURCE && perl configdata.pm --dump
-      - name: make
-        run: make -s -j4
-      - name: make test
-        run: make test
+    - uses: actions/checkout@v2
+    - name: config
+      run: ./config no-asm no-makedepend enable-buildtest-c++ --strict-warnings -D_DEFAULT_SOURCE && perl configdata.pm --dump
+    - name: make
+      run: make -s -j4
+    - name: make test
+      run: make test
+
+  out-of-tree_build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: setup build dir
+      run: |
+          set -eux
+          mkdir -p ${myblddir:=../_build/nest/a/little/more}
+          echo "mysrcdir=$(realpath .)" | tee -a $GITHUB_ENV
+          echo "myblddir=$(realpath $myblddir)" | tee -a $GITHUB_ENV
+    - name: config
+      run: set -eux ; cd ${{ env.myblddir }} && ${{ env.mysrcdir }}/config --strict-warnings && perl configdata.pm --dump
+    - name: make build_generated
+      run: set -eux; cd ${{ env.myblddir }} && make -s build_generated
+    - name: make update
+      run: set -eux; cd ${{ env.myblddir }} && make update
+    - name: make
+      run: set -eux; cd ${{ env.myblddir }} && make -s -j4
+    - name: make test (minimal subset)
+      run: set -eux; cd ${{ env.myblddir }} && make test TESTS='0[0-9]'
+
+  out-of-source-and-install:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest ]
+    runs-on: ${{matrix.os}}
+    steps:
+    - uses: actions/checkout@v2
+    - name: extra preparations
+      run: |
+        mkdir ./build
+        mkdir ./install_dir
+    - name: config
+      run: ../config --strict-warnings --prefix=$(cd ../install_dir; pwd) && perl configdata.pm --dump
+      working-directory: ./build
+    - name: make
+      run: make -s -j4
+      working-directory: ./build
+    - name: make test
+      run: make test
+      working-directory: ./build
+    - name: make install
+      run: make install
+      working-directory: ./build
+
+  external-tests:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+    - name: package installs
+      run: |
+        sudo apt-get update
+        sudo apt-get -yq install bison gettext keyutils ldap-utils libldap2-dev libkeyutils-dev python3 python3-paste python3-pyrad slapd tcsh python3-virtualenv virtualenv python3-kdcproxy
+    - name: install cpanm and Test2::V0 for gost_engine testing
+      uses: perl-actions/install-with-cpanm@v1
+      with:
+        install: Test2::V0
+    - name: setup hostname workaround
+      run: sudo hostname localhost
+    - name: config
+      run: ./config --strict-warnings --debug no-afalgeng enable-rc5 enable-md2 enable-ssl3 enable-ssl3-method enable-weak-ssl-ciphers enable-zlib enable-ec_nistp_64_gcc_128 enable-external-tests && perl configdata.pm --dump
+    - name: make
+      run: make -s -j4
+    - name: test external gost-engine
+      run: make test TESTS="test_external_gost_engine" VERBOSE=1
+    - name: test external krb5
+      run: make test TESTS="test_external_krb5" VERBOSE=1
+
+  external-test-pyca:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        RUST:
+        - 1.51.0
+        PYTHON:
+        - 3.9
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+    - name: package installs
+      run: |
+        sudo apt-get update
+        sudo apt-get -yq install python3-virtualenv virtualenv
+    - name: Configure OpenSSL
+      run: ./config --strict-warnings --debug enable-external-tests && perl configdata.pm --dump
+    - name: make
+      run: make -s -j4
+    - name: Setup Python
+      uses: actions/setup-python@v2.2.2
+      with:
+        python-version: ${{ matrix.PYTHON }}
+    - uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: ${{ matrix.RUST }}
+        override: true
+        default: true
+    - name: test external pyca
+      run: make test TESTS="test_external_pyca" VERBOSE=1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,8 +242,9 @@ jobs:
       run: make -s -j4
     - name: test external gost-engine
       run: make test TESTS="test_external_gost_engine" VERBOSE=1
-    - name: test external krb5
-      run: make test TESTS="test_external_krb5" VERBOSE=1
+# krb5 testing temporarily disabled due to failures to be investigated separately
+#    - name: test external krb5
+#      run: make test TESTS="test_external_krb5" VERBOSE=1
 
   external-test-pyca:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,35 +246,36 @@ jobs:
 #    - name: test external krb5
 #      run: make test TESTS="test_external_krb5" VERBOSE=1
 
-  external-test-pyca:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        RUST:
-        - 1.51.0
-        PYTHON:
-        - 3.9
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        submodules: recursive
-    - name: package installs
-      run: |
-        sudo apt-get update
-        sudo apt-get -yq install python3-virtualenv virtualenv
-    - name: Configure OpenSSL
-      run: ./config --strict-warnings --debug enable-external-tests && perl configdata.pm --dump
-    - name: make
-      run: make -s -j4
-    - name: Setup Python
-      uses: actions/setup-python@v2.2.2
-      with:
-        python-version: ${{ matrix.PYTHON }}
-    - uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: ${{ matrix.RUST }}
-        override: true
-        default: true
-    - name: test external pyca
-      run: make test TESTS="test_external_pyca" VERBOSE=1
+# pyca testing temporarily disabled due to failures to be investigated separately
+#  external-test-pyca:
+#    runs-on: ubuntu-latest
+#    strategy:
+#      matrix:
+#        RUST:
+#        - 1.51.0
+#        PYTHON:
+#        - 3.9
+#    steps:
+#    - uses: actions/checkout@v2
+#      with:
+#        submodules: recursive
+#    - name: package installs
+#      run: |
+#        sudo apt-get update
+#        sudo apt-get -yq install python3-virtualenv virtualenv
+#    - name: Configure OpenSSL
+#      run: ./config --strict-warnings --debug enable-external-tests && perl configdata.pm --dump
+#    - name: make
+#      run: make -s -j4
+#    - name: Setup Python
+#      uses: actions/setup-python@v2.2.2
+#      with:
+#        python-version: ${{ matrix.PYTHON }}
+#    - uses: actions-rs/toolchain@v1
+#      with:
+#        profile: minimal
+#        toolchain: ${{ matrix.RUST }}
+#        override: true
+#        default: true
+#    - name: test external pyca
+#      run: make test TESTS="test_external_pyca" VERBOSE=1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,17 +119,20 @@ jobs:
     - name: make test
       run: make test OPENSSL_TEST_RAND_ORDER=0
 
-  memory_sanitizer:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: config
-      # --debug -O1 is to produce a debug build that runs in a reasonable amount of time
-      run: CC=clang ./config --debug -O1 -fsanitize=memory -DOSSL_SANITIZE_MEMORY -fno-optimize-sibling-calls enable-rc5 enable-md2 enable-ec_nistp_64_gcc_128 && perl configdata.pm --dump
-    - name: make
-      run: make -s -j4
-    - name: make test
-      run: make test
+# The memory sanitizer build is temporarily disabled as in 1.1.1 we do
+# not support running tests in parallel and this build configuration
+# requires more than 3h to run all tests sequentially.
+#  memory_sanitizer:
+#    runs-on: ubuntu-latest
+#    steps:
+#    - uses: actions/checkout@v2
+#    - name: config
+#      # --debug -O1 is to produce a debug build that runs in a reasonable amount of time
+#      run: CC=clang ./config --debug -O1 -fsanitize=memory -DOSSL_SANITIZE_MEMORY -fno-optimize-sibling-calls enable-rc5 enable-md2 enable-ec_nistp_64_gcc_128 && perl configdata.pm --dump
+#    - name: make
+#      run: make -s -j4
+#    - name: make test
+#      run: make test
 
   threads_sanitizer:
     runs-on: ubuntu-latest

--- a/.github/workflows/cross-compiles.yml
+++ b/.github/workflows/cross-compiles.yml
@@ -1,0 +1,152 @@
+---
+name: Cross Compile for 1.1.1
+
+on: [pull_request, push]
+
+jobs:
+  cross-compilation:
+    strategy:
+      fail-fast: false
+      matrix:
+        # The platform matrix specifies:
+        #   arch: the architecture to build for, this defines the tool-chain
+        #         prefix {arch}- and the Debian compiler package gcc-{arch}
+        #         name.
+        #   libs: the Debian package for the necessary link/runtime libraries.
+        #   target: the OpenSSL configuration target to use, this is passed
+        #           directly to the config command line.
+        #   tests: omit this to run all the tests using QEMU, set it to "none"
+        #          to never run the tests, otherwise it's value is passed to
+        #          the "make test" command to allow selectiving disabling of
+        #          tests.
+        platform: [
+          {
+            arch: aarch64-linux-gnu,
+            libs: libc6-dev-arm64-cross,
+            target: linux-aarch64
+          }, {
+            arch: alpha-linux-gnu,
+            libs: libc6.1-dev-alpha-cross,
+            target: linux-alpha-gcc
+          }, {
+            arch: arm-linux-gnueabi,
+            libs: libc6-dev-armel-cross,
+            target: linux-armv4,
+            tests: -test_includes -test_store -test_x509_store
+          }, {
+            arch: arm-linux-gnueabihf,
+            libs: libc6-dev-armhf-cross,
+            target: linux-armv4,
+            tests: -test_includes -test_store -test_x509_store
+          }, {
+            arch: hppa-linux-gnu,
+            libs: libc6-dev-hppa-cross,
+            target: -static linux-generic32,
+            tests: -test_includes -test_store -test_x509_store
+          }, {
+            arch: m68k-linux-gnu,
+            libs: libc6-dev-m68k-cross,
+            target: -static -m68040 linux-generic32,
+            tests: -test_includes -test_store -test_x509_store
+          }, {
+            arch: mips-linux-gnu,
+            libs: libc6-dev-mips-cross,
+            target: -static linux-mips32,
+            tests: -test_includes -test_store -test_x509_store
+          }, {
+            arch: mips64-linux-gnuabi64,
+            libs: libc6-dev-mips64-cross,
+            target: -static linux64-mips64,
+          }, {
+            arch: mipsel-linux-gnu,
+            libs: libc6-dev-mipsel-cross,
+            target: linux-mips32,
+            tests: -test_includes -test_store -test_x509_store
+          }, {
+            arch: powerpc64le-linux-gnu,
+            libs: libc6-dev-ppc64el-cross,
+            target: linux-ppc64le
+          }, {
+            arch: riscv64-linux-gnu,
+            libs: libc6-dev-riscv64-cross,
+            target: linux64-riscv64
+          }, {
+            arch: s390x-linux-gnu,
+            libs: libc6-dev-s390x-cross,
+            target: linux64-s390x
+          }, {
+            arch: sh4-linux-gnu,
+            libs: libc6-dev-sh4-cross,
+            target: no-async linux-generic32,
+            tests: -test_includes -test_store -test_x509_store
+          },
+
+          # These build with shared libraries but they crash when run
+          # They mirror static builds above in order to cover more of the
+          # code base.
+          {
+            arch: hppa-linux-gnu,
+            libs: libc6-dev-hppa-cross,
+            target: linux-generic32,
+            tests: none
+          }, {
+            arch: m68k-linux-gnu,
+            libs: libc6-dev-m68k-cross,
+            target: -mcfv4e linux-generic32,
+            tests: none
+          }, {
+            arch: mips-linux-gnu,
+            libs: libc6-dev-mips-cross,
+            target: linux-mips32,
+            tests: none
+          }, {
+            arch: mips64-linux-gnuabi64,
+            libs: libc6-dev-mips64-cross,
+            target: linux64-mips64,
+            tests: none
+          },
+
+          # This build doesn't execute either with or without shared libraries.
+          {
+            arch: sparc64-linux-gnu,
+            libs: libc6-dev-sparc64-cross,
+            target: linux64-sparcv9,
+            tests: none
+          }
+        ]
+    runs-on: ubuntu-latest
+    steps:
+    - name: install packages
+      run: |
+        sudo apt-get update
+        sudo apt-get -yq --force-yes install \
+            gcc-${{ matrix.platform.arch }} \
+            ${{ matrix.platform.libs }}
+    - uses: actions/checkout@v2
+
+    - name: config
+      run: |
+        ./Configure --strict-warnings \
+                 --cross-compile-prefix=${{ matrix.platform.arch }}- \
+                 ${{ matrix.platform.target }}
+    - name: config dump
+      run: ./configdata.pm --dump
+
+    - name: make
+      run: make -s -j4
+
+    - name: install qemu
+      if: github.event_name == 'push' && matrix.platform.tests != 'none'
+      run: sudo apt-get -yq --force-yes install qemu-user
+
+    - name: make all tests
+      if: github.event_name == 'push' && matrix.platform.tests == ''
+      run: |
+        make test \
+                  QEMU_LD_PREFIX=/usr/${{ matrix.platform.arch }}
+    - name: make some tests
+      if: github.event_name == 'push' && matrix.platform.tests != 'none' && matrix.platform.tests != ''
+      run: |
+        make test \
+                  TESTS="${{ matrix.platform.tests }}" \
+                  QEMU_LD_PREFIX=/usr/${{ matrix.platform.arch }}

--- a/.github/workflows/cross-compiles.yml
+++ b/.github/workflows/cross-compiles.yml
@@ -137,16 +137,16 @@ jobs:
       run: make -s -j4
 
     - name: install qemu
-      if: github.event_name == 'push' && matrix.platform.tests != 'none'
+      if: matrix.platform.tests != 'none'
       run: sudo apt-get -yq --force-yes install qemu-user
 
     - name: make all tests
-      if: github.event_name == 'push' && matrix.platform.tests == ''
+      if: matrix.platform.tests == ''
       run: |
         make test \
                   QEMU_LD_PREFIX=/usr/${{ matrix.platform.arch }}
     - name: make some tests
-      if: github.event_name == 'push' && matrix.platform.tests != 'none' && matrix.platform.tests != ''
+      if: matrix.platform.tests != 'none' && matrix.platform.tests != ''
       run: |
         make test \
                   TESTS="${{ matrix.platform.tests }}" \

--- a/.github/workflows/cross-compiles.yml
+++ b/.github/workflows/cross-compiles.yml
@@ -106,13 +106,14 @@ jobs:
             tests: none
           },
 
-          # This build doesn't execute either with or without shared libraries.
-          {
-            arch: sparc64-linux-gnu,
-            libs: libc6-dev-sparc64-cross,
-            target: linux64-sparcv9,
-            tests: none
-          }
+          # sparcv9 is temporarily disabled due to failures during compilation
+          # # This build doesn't execute either with or without shared libraries.
+          # {
+          #   arch: sparc64-linux-gnu,
+          #   libs: libc6-dev-sparc64-cross,
+          #   target: linux64-sparcv9,
+          #   tests: none
+          # }
         ]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/run-checker-ci.yml
+++ b/.github/workflows/run-checker-ci.yml
@@ -1,0 +1,37 @@
+---
+name: Run-checker CI for 1.1.1
+# Jobs run per pull request submission
+on: [pull_request, push]
+jobs:
+  run-checker:
+    strategy:
+      fail-fast: false
+      matrix:
+        opt: [
+          no-cms,
+          no-ct,
+          no-dtls,
+          no-ec,
+          no-ec2m,
+          no-sock,
+          no-srp,
+          no-srtp,
+          enable-ssl-trace,
+          no-tests,
+          no-threads,
+          no-tls,
+          no-tls1_3,
+          no-ts,
+          no-ui,
+        ]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: config
+      run: CC=clang ./config --strict-warnings ${{ matrix.opt }}
+    - name: config dump
+      run: ./configdata.pm --dump
+    - name: make
+      run: make -s -j4
+    - name: make test
+      run: make test

--- a/.github/workflows/run-checker-ci.yml
+++ b/.github/workflows/run-checker-ci.yml
@@ -20,7 +20,8 @@ jobs:
           no-tests,
           no-threads,
           no-tls,
-          no-tls1_3,
+# no-tls1_3 temporarily disabled due to failures to be investigated separately
+#          no-tls1_3,
           no-ts,
           no-ui,
         ]

--- a/.github/workflows/run-checker-daily.yml
+++ b/.github/workflows/run-checker-daily.yml
@@ -1,0 +1,125 @@
+---
+name: Run-checker daily for 1.1.1
+# Jobs run daily on 1.1.1
+
+on:
+  schedule:
+  - cron: '42 6 * * *'
+jobs:
+  run-checker:
+    strategy:
+      fail-fast: false
+      matrix:
+        opt: [
+          386,
+          no-afalgeng,
+          no-aria,
+          no-asan,
+          no-asm,
+          no-async,
+          no-autoalginit,
+          no-autoerrinit,
+          no-autoload-config,
+          no-bf,
+          no-blake2,
+          no-buildtest-c++,
+          no-camellia,
+          no-capieng,
+          no-cast,
+          no-chacha,
+          no-cmac,
+          no-comp,
+          enable-crypto-mdebug,
+          no-crypto-mdebug,
+          enable-crypto-mdebug-backtrace,
+          no-crypto-mdebug-backtrace,
+          no-deprecated,
+          no-des,
+          no-devcryptoeng,
+          no-dh,
+          no-dsa,
+          no-dtls1,
+          no-dtls1_2,
+          no-dtls1_2-method,
+          no-dtls1-method,
+          no-ecdh,
+          no-ecdsa,
+          enable-ec_nistp_64_gcc_128,
+          no-ec_nistp_64_gcc_128,
+          enable-egd,
+          no-egd,
+          no-engine,
+          no-external-tests,
+          no-tls1_3,
+          no-fuzz-afl,
+          no-fuzz-libfuzzer,
+          no-gost,
+          enable-heartbeats,
+          no-heartbeats,
+          no-hw,
+          no-hw-padlock,
+          no-idea,
+          no-makedepend,
+          enable-md2,
+          no-md2,
+          no-md4,
+          no-mdc2,
+          no-msan,
+          no-multiblock,
+          no-nextprotoneg,
+          no-ocb,
+          no-ocsp,
+          no-pic,
+          no-pinshared,
+          no-poly1305,
+          no-posix-io,
+          no-psk,
+          no-rc2,
+          no-rc4,
+          enable-rc5,
+          no-rc5,
+          no-rdrand,
+          no-rfc3779,
+          no-ripemd,
+          no-rmd160,
+          no-scrypt,
+          no-sctp,
+          no-seed,
+          no-shared,
+          no-siphash,
+          no-sm2,
+          no-sm3,
+          no-sm4,
+          no-sse2,
+          no-ssl,
+          no-ssl3,
+          no-ssl3-method,
+          no-ssl-trace,
+          no-static-engine no-shared,
+          no-stdio,
+          no-tls1,
+          no-tls1_1,
+          no-tls1_1-method,
+          no-tls1_2,
+          no-tls1_2-method,
+          no-tls1-method,
+          no-ubsan,
+          no-ui-console,
+          enable-unit-test,
+          no-weak-ssl-ciphers,
+          no-whirlpool,
+          no-zlib,
+          enable-zlib-dynamic,
+          no-zlib-dynamic,
+        ]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: config
+      run: CC=clang ./config --strict-warnings ${{ matrix.opt }}
+    - name: config dump
+      run: ./configdata.pm --dump
+    - name: make
+      run: make -s -j4
+    - name: make test
+      run: make test

--- a/.github/workflows/run-checker-daily.yml
+++ b/.github/workflows/run-checker-daily.yml
@@ -2,9 +2,10 @@
 name: Run-checker daily for 1.1.1
 # Jobs run daily on 1.1.1
 
-on:
-  schedule:
-  - cron: '42 6 * * *'
+# on:
+#   schedule:
+#   - cron: '42 6 * * *'
+on: [pull_request, push]
 jobs:
   run-checker:
     strategy:

--- a/.github/workflows/run-checker-daily.yml
+++ b/.github/workflows/run-checker-daily.yml
@@ -50,7 +50,8 @@ jobs:
           no-egd,
           no-engine,
           no-external-tests,
-          no-tls1_3,
+# no-tls1_3 temporarily disabled due to failures to be investigated separately
+#          no-tls1_3,
           no-fuzz-afl,
           no-fuzz-libfuzzer,
           no-gost,

--- a/.github/workflows/run-checker-merge.yml
+++ b/.github/workflows/run-checker-merge.yml
@@ -1,0 +1,34 @@
+---
+name: Run-checker merge for 1.1.1
+# Jobs run per merge to 1.1.1
+
+on: [push]
+jobs:
+  run-checker:
+    strategy:
+      fail-fast: false
+      matrix:
+        opt: [
+          enable-asan no-shared no-asm -DOPENSSL_SMALL_FOOTPRINT,
+          no-dgram,
+          no-dso,
+          no-dynamic-engine,
+          no-engine no-shared,
+          no-err,
+          no-filenames,
+          enable-ubsan no-asm -DPEDANTIC -DOPENSSL_SMALL_FOOTPRINT -fno-sanitize=alignment,
+          no-unit-test,
+          enable-weak-ssl-ciphers,
+          enable-zlib,
+        ]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: config
+      run: CC=clang ./config --strict-warnings ${{ matrix.opt }}
+    - name: config dump
+      run: ./configdata.pm --dump
+    - name: make
+      run: make -s -j4
+    - name: make test
+      run: make test

--- a/.github/workflows/run-checker-merge.yml
+++ b/.github/workflows/run-checker-merge.yml
@@ -2,7 +2,7 @@
 name: Run-checker merge for 1.1.1
 # Jobs run per merge to 1.1.1
 
-on: [push]
+on: [pull_request, push]
 jobs:
   run-checker:
     strategy:

--- a/.github/workflows/run-checker-merge.yml
+++ b/.github/workflows/run-checker-merge.yml
@@ -16,7 +16,8 @@ jobs:
           no-engine no-shared,
           no-err,
           no-filenames,
-          enable-ubsan no-asm -DPEDANTIC -DOPENSSL_SMALL_FOOTPRINT -fno-sanitize=alignment,
+# ubsan build is temporarily disabled, due to failures to be investigated separately
+#          enable-ubsan no-asm -DPEDANTIC -DOPENSSL_SMALL_FOOTPRINT -fno-sanitize=alignment,
           no-unit-test,
           enable-weak-ssl-ciphers,
           enable-zlib,

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,93 @@
+---
+name: Windows GitHub CI for 1.1.1
+
+on: [pull_request, push]
+
+jobs:
+  shared:
+    # Run a job for each of the specified target architectures:
+    strategy:
+      matrix:
+        os:
+        - windows-latest
+        - windows-2016
+        platform:
+        - arch: win64
+          config: VC-WIN64A
+        - arch: win32
+          config: VC-WIN32 --strict-warnings
+    runs-on: ${{matrix.os}}
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ilammy/msvc-dev-cmd@v1
+      with:
+        arch: ${{ matrix.platform.arch }}
+    - uses: ilammy/setup-nasm@v1
+      with:
+        platform: ${{ matrix.platform.arch }}
+    - name: prepare the build directory
+      run: mkdir _build
+    - name: config
+      working-directory: _build
+      run: |
+        perl ..\Configure no-makedepend ${{ matrix.platform.config }}
+        perl configdata.pm --dump
+    - name: build
+      working-directory: _build
+      run: nmake /S
+    - name: test
+      working-directory: _build
+      run: nmake test VERBOSE_FAILURE=yes TESTS=-test_fuzz*
+    - name: install
+      # Run on 64 bit only as 32 bit is slow enough already
+      if: $${{ matrix.platform.arch == 'win64' }}
+      run: |
+        mkdir _dest
+        nmake install DESTDIR=_dest
+      working-directory: _build
+  plain:
+    strategy:
+      matrix:
+        os:
+        - windows-latest
+        - windows-2016
+    runs-on: ${{matrix.os}}
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ilammy/msvc-dev-cmd@v1
+    - name: prepare the build directory
+      run: mkdir _build
+    - name: config
+      working-directory: _build
+      run: |
+        perl ..\Configure no-makedepend no-shared VC-WIN64A-masm
+        perl configdata.pm --dump
+    - name: build
+      working-directory: _build
+      run: nmake /S
+    - name: test
+      working-directory: _build
+      run: nmake test VERBOSE_FAILURE=yes
+  minimal:
+    strategy:
+      matrix:
+        os:
+        - windows-latest
+        - windows-2016
+    runs-on: ${{matrix.os}}
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ilammy/msvc-dev-cmd@v1
+    - name: prepare the build directory
+      run: mkdir _build
+    - name: config
+      working-directory: _build
+      run: |
+        perl ..\Configure no-makedepend no-deprecated no-asm -DOPENSSL_SMALL_FOOTPRINT VC-WIN64A
+        perl configdata.pm --dump
+    - name: build
+      working-directory: _build
+      run: nmake # verbose, so no /S here
+    - name: test
+      working-directory: _build
+      run: nmake test VERBOSE_FAILURE=yes TESTS=-test_fuzz*


### PR DESCRIPTION
This is an attempt at syncing the GitHub CI infrastructure for the 1.1.1 branch with what we do in `master`

# Tasks

- [x] Sync `ci.yml` file
  - [x] Ensure tests are running
- [x] Import `windows.yml`
  - [x] Ensure tests are running
- [x] Import `cross-compiles.yml`
  - [x] Ensure tests are running
- [x] Import run-checker workflows
  - [x] Ensure tests are running
- [x] Disable problematic tests (they will be dealt with in separate PRs)
  - 9c3a9ab176 `[cross-compiles.yml] Disable sparcv9`
    - [x] Dedicated PR: #16336
  - f73c3720e1 `[ci.yml] Disable krb5 external tests`
    - [x] Dedicated PR: #16339
  - 850ed18505 `[ci.yml] Disable pyca external tests`  
    - [x] Dedicated PR: #16340
  - f9c3c9cdff `[run-checker-ci.yml] Disable no-tls1_3 tests`
    - [x] Dedicated PR: #16335
  - e88314973a `[ci.yml] Disable memory sanitizer build` (fails due to timeout)
    - [x] Dedicated PR: #16338
  - 111244dec5 `[run-checker-merge.yml] Disable ubsan build`
    - [x] Dedicated PR: #16337
- [x] Evaluate `run-checker-daily.yml`
