### PR TITLE
Add an include of <CommonCrypto/CommonCryptoError.h> before

### DIFF
--- a/providers/implementations/rands/seeding/rand_unix.c
+++ b/providers/implementations/rands/seeding/rand_unix.c
@@ -41,6 +41,7 @@
 # include <sys/random.h>
 #endif
 #if defined(__APPLE__)
+# include <CommonCrypto/CommonCryptoError.h>
 # include <CommonCrypto/CommonRandom.h>
 #endif
 


### PR DESCRIPTION
<CommonCrypto/CommonRandom.h>, as required by older releases of
the macOS developer tools.

Fixes #16248

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
