### PR TITLE
Set FFC_PARAM_FLAG_VALIDATE_LEGACY on params generated with FIPS 186-2

### DIFF
--- a/crypto/ffc/ffc_params_generate.c
+++ b/crypto/ffc/ffc_params_generate.c
@@ -1047,7 +1047,11 @@ int ossl_ffc_params_FIPS186_2_generate(OSSL_LIB_CTX *libctx, FFC_PARAMS *params,
                                        int type, size_t L, size_t N,
                                        int *res, BN_GENCB *cb)
 {
-    return ossl_ffc_params_FIPS186_2_gen_verify(libctx, params,
-                                                FFC_PARAM_MODE_GENERATE,
-                                                type, L, N, res, cb);
+    if (!ossl_ffc_params_FIPS186_2_gen_verify(libctx, params,
+                                              FFC_PARAM_MODE_GENERATE,
+                                              type, L, N, res, cb))
+        return 0;
+
+    ossl_ffc_params_enable_flags(params, FFC_PARAM_FLAG_VALIDATE_LEGACY, 1);
+    return 1;
 }

--- a/test/dsatest.c
+++ b/test/dsatest.c
@@ -108,9 +108,11 @@ static int dsa_test(void)
     if (!TEST_int_eq(i, j) || !TEST_mem_eq(buf, i, out_g, i))
         goto end;
 
-    DSA_generate_key(dsa);
-    DSA_sign(0, str1, 20, sig, &siglen, dsa);
-    if (TEST_true(DSA_verify(0, str1, 20, sig, siglen, dsa)))
+    if (!TEST_true(DSA_generate_key(dsa)))
+        goto end;
+    if (!TEST_true(DSA_sign(0, str1, 20, sig, &siglen, dsa)))
+        goto end;
+    if (TEST_int_gt(DSA_verify(0, str1, 20, sig, siglen, dsa), 0))
         ret = 1;
 
  end:


### PR DESCRIPTION

Fixes #16261