### PR TITLE
Fix s390x AES OFB/CFB cipher implementation on updating IV

### DIFF
--- a/crypto/evp/e_aes.c
+++ b/crypto/evp/e_aes.c
@@ -1010,9 +1010,12 @@ static int s390x_aes_ofb_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
                                 const unsigned char *in, size_t len)
 {
     S390X_AES_OFB_CTX *cctx = EVP_C_DATA(S390X_AES_OFB_CTX, ctx);
+    const int ivlen = EVP_CIPHER_CTX_get_iv_length(ctx);
+    unsigned char *iv = EVP_CIPHER_CTX_iv_noconst(ctx);
     int n = cctx->res;
     int rem;
 
+    memcpy(cctx->kmo.param.cv, iv, ivlen);
     while (n && len) {
         *out = *in ^ cctx->kmo.param.cv[n];
         n = (n + 1) & 0xf;
@@ -1041,6 +1044,7 @@ static int s390x_aes_ofb_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
         }
     }
 
+    memcpy(iv, cctx->kmo.param.cv, ivlen);
     cctx->res = n;
     return 1;
 }
@@ -1071,10 +1075,13 @@ static int s390x_aes_cfb_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
     S390X_AES_CFB_CTX *cctx = EVP_C_DATA(S390X_AES_CFB_CTX, ctx);
     const int keylen = EVP_CIPHER_CTX_get_key_length(ctx);
     const int enc = EVP_CIPHER_CTX_is_encrypting(ctx);
+    const int ivlen = EVP_CIPHER_CTX_get_iv_length(ctx);
+    unsigned char *iv = EVP_CIPHER_CTX_iv_noconst(ctx);
     int n = cctx->res;
     int rem;
     unsigned char tmp;
 
+    memcpy(cctx->kmf.param.cv, iv, ivlen);
     while (n && len) {
         tmp = *in;
         *out = cctx->kmf.param.cv[n] ^ tmp;
@@ -1107,6 +1114,7 @@ static int s390x_aes_cfb_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
         }
     }
 
+    memcpy(iv, cctx->kmf.param.cv, ivlen);
     cctx->res = n;
     return 1;
 }
@@ -1134,8 +1142,12 @@ static int s390x_aes_cfb8_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
                                  const unsigned char *in, size_t len)
 {
     S390X_AES_CFB_CTX *cctx = EVP_C_DATA(S390X_AES_CFB_CTX, ctx);
+    const int ivlen = EVP_CIPHER_CTX_get_iv_length(ctx);
+    unsigned char *iv = EVP_CIPHER_CTX_iv_noconst(ctx);
 
+    memcpy(cctx->kmf.param.cv, iv, ivlen);
     s390x_kmf(in, len, out, cctx->fc, &cctx->kmf.param);
+    memcpy(iv, cctx->kmf.param.cv, ivlen);
     return 1;
 }
 


### PR DESCRIPTION
The s390x specific implementation in `crypto/evp/e_aes.c` does not update the cipher context's IV field during an operation for AES OFB and CFB. 

An application that uses `EVP_CIPHER_CTX_iv()` to get the updated IV would thus always get the original IV value on s390x. Other platforms are not affected as far as I can tell. 

Please note that the provider based implementation in `providers/implementations/ciphers/cipher_aes_hw_s390x.inc` does it correctly already. The fix in `e_aes.c` aligns the code to the code in `cipher_aes_hw_s390x.inc`.

Because the provider based implementation is correct, an application using OpenSSL 3.0 will not see the error. However, the same error is in the OpenSSL 1.1.1 branch, and with OpenSSL 1.1.1 the error can be seen by an application (on s390x). I would suggest to fix this anyway in the master branch, since the code in `e_aes.c` is wrong, too.

I have added a testcase in `test/evp_extra_test.c` to reproduce this error. Of course, it won't fail with OpenSSL 3.0, because the code goes the provider path. I don't know how the code in `e_aes.c` could be tested in OpenSSL 3.0.... 

I will submit another PR for the same fix in the OpenSSL 1.1.1 branch.

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
