### PR TITLE
Darwin config and INSTALL doc fixes

### DIFF
--- a/Configure
+++ b/Configure
@@ -63,6 +63,8 @@ EOF
 #               (Default: PREFIX/ssl)
 # --banner=".." Output specified text instead of default completion banner
 #
+# -w            Don't wait after showing a Configure warning
+#
 # --cross-compile-prefix Add specified prefix to binutils components.
 #
 # --api         One of 0.9.8, 1.0.0, 1.0.1, 1.0.2, 1.1.0, 1.1.1, or 3.0
@@ -898,7 +900,7 @@ while (@argvcopy)
                 {
                 $guess_opts{verbose} = 1;
                 }
-        elsif (/^-w$/)          # From older 'config'
+        elsif (/^-w$/)
                 {
                 $guess_opts{nowait} = 1;
                 }

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -592,7 +592,7 @@ configuration.
 On platforms where the choice of 32-bit or 64-bit architecture
 is not explicitly specified, `Configure` will print a warning
 message and wait for a few seconds to let you interrupt the
-configuration. Using thie flag skips the wait.
+configuration. Using this flag skips the wait.
 
 ### no-bulk
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1142,11 +1142,9 @@ Configure OpenSSL
 
 ### Automatic Configuration
 
-On some platform a `config` script is available which attempts to guess
-your operating system (and compiler, if necessary) and calls the `Configure`
-Perl script with appropriate target based on its guess.  Further options can
-be supplied to the `config` script, which will be passed on to the `Configure`
-script.
+In previous version, the `config` script determined the platform type and
+compiler and then called `Configure`. Starting with this release, they are
+the same.
 
 #### Unix / Linux / macOS
 
@@ -1406,10 +1404,28 @@ over the build process.  Typically these should be defined prior to running
                    using this variable. Set it to the compiler executable you wish
                    to use, e.g. gcc or clang.
 
+    CONFIG_NOWAIT
+                   On platforms where the choice of 32-bit or 64-bit architecture
+                   is not explicitly specified, `Configure` will print a warning
+                   message and wait for a few seconds to let you interrupt the
+                   configuration. Setting this variable will skip the wait.
+
     CROSS_COMPILE
                    This environment variable has the same meaning as for the
                    "--cross-compile-prefix" Configure flag described above. If both
                    are set then the Configure flag takes precedence.
+
+    HASHBANGPERL
+                   The command string for the Perl executable to insert in the
+                   #! line of perl scripts that will be publicly installed.
+                   Default: /usr/bin/env perl
+                   Note: the value of this variable is added to the same scripts
+                   on all platforms, but it's only relevant on Unix-like platforms.
+
+    KERNEL_BITS
+                   This can be the value `32` or `64` to specify the architecture
+                   when it is not "obvious" to the configuration. It should generally
+                   not be necessary to specify this environment variable.
 
     NM
                    The name of the nm executable to use.
@@ -1435,12 +1451,8 @@ over the build process.  Typically these should be defined prior to running
                    Only needed if builing should use a different Perl executable
                    than what is used to run the Configure script.
 
-    HASHBANGPERL
-                   The command string for the Perl executable to insert in the
-                   #! line of perl scripts that will be publicly installed.
-                   Default: /usr/bin/env perl
-                   Note: the value of this variable is added to the same scripts
-                   on all platforms, but it's only relevant on Unix-like platforms.
+    RANLIB
+                   The name of the ranlib executable to use.
 
     RC
                    The name of the rc executable to use. The default will be as
@@ -1448,9 +1460,6 @@ over the build process.  Typically these should be defined prior to running
                    defined then "windres" will be used. The WINDRES environment
                    variable is synonymous to this. If both are defined then RC
                    takes precedence.
-
-    RANLIB
-                   The name of the ranlib executable to use.
 
     WINDRES
                    See RC.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -587,6 +587,13 @@ alternative, you can use the language specific variables, `CFLAGS` and `CXXFLAGS
 Use the specified text instead of the default banner at the end of
 configuration.
 
+### --w
+
+On platforms where the choice of 32-bit or 64-bit architecture
+is not explicitly specified, `Configure` will print a warning
+message and wait for a few seconds to let you interrupt the
+configuration. Using thie flag skips the wait.
+
 ### no-bulk
 
 Build only some minimal set of features.
@@ -1403,12 +1410,6 @@ over the build process.  Typically these should be defined prior to running
                    compiler for your platform but this choice can be overridden
                    using this variable. Set it to the compiler executable you wish
                    to use, e.g. gcc or clang.
-
-    CONFIG_NOWAIT
-                   On platforms where the choice of 32-bit or 64-bit architecture
-                   is not explicitly specified, `Configure` will print a warning
-                   message and wait for a few seconds to let you interrupt the
-                   configuration. Setting this variable will skip the wait.
 
     CROSS_COMPILE
                    This environment variable has the same meaning as for the

--- a/util/perl/OpenSSL/config.pm
+++ b/util/perl/OpenSSL/config.pm
@@ -22,8 +22,8 @@ use Carp;
 # These control our behavior.
 my $DRYRUN;
 my $VERBOSE;
-my $WAIT = defined $ENV{'CONFIG_NOWAIT'} ? 0 : 1;
 my $WHERE = dirname($0);
+my $WAIT = 1;
 
 # Machine type, etc., used to determine the platform
 my $MACHINE;

--- a/util/perl/OpenSSL/config.pm
+++ b/util/perl/OpenSSL/config.pm
@@ -22,7 +22,7 @@ use Carp;
 # These control our behavior.
 my $DRYRUN;
 my $VERBOSE;
-my $WAIT = 1;
+my $WAIT = defined $ENV{'CONFIG_NOWAIT'} ? 0 : 1;
 my $WHERE = dirname($0);
 
 # Machine type, etc., used to determine the platform
@@ -452,7 +452,7 @@ EOF
       [ 'ppc-apple-rhapsody',     { target => "rhapsody-ppc" } ],
       [ 'ppc-apple-darwin.*',
         sub {
-            my $KERNEL_BITS = $ENV{KERNEL_BITS};
+            my $KERNEL_BITS = $ENV{KERNEL_BITS} // '';
             my $ISA64 = `sysctl -n hw.optional.64bitops 2>/dev/null`;
             if ( $ISA64 == 1 && $KERNEL_BITS eq '' ) {
                 print <<EOF;
@@ -468,7 +468,7 @@ EOF
       ],
       [ 'i.86-apple-darwin.*',
         sub {
-            my $KERNEL_BITS = $ENV{KERNEL_BITS};
+            my $KERNEL_BITS = $ENV{KERNEL_BITS} // '';
             my $ISA64 = `sysctl -n hw.optional.x86_64 2>/dev/null`;
             if ( $ISA64 == 1 && $KERNEL_BITS eq '' ) {
                 print <<EOF;
@@ -484,7 +484,7 @@ EOF
       ],
       [ 'x86_64-apple-darwin.*',
         sub {
-            my $KERNEL_BITS = $ENV{KERNEL_BITS};
+            my $KERNEL_BITS = $ENV{KERNEL_BITS} // '';
             return { target => "darwin-i386" } if $KERNEL_BITS eq '32';
 
             print <<EOF;
@@ -532,7 +532,7 @@ EOF
       ],
       [ 'ppc64-.*-linux2',
         sub {
-            my $KERNEL_BITS = $ENV{KERNEL_BITS};
+            my $KERNEL_BITS = $ENV{KERNEL_BITS} // '';
             if ( $KERNEL_BITS eq '' ) {
                 print <<EOF;
 WARNING! To build 64-bit package, do this:


### PR DESCRIPTION
Using `[[ options ]]` syntax irks me, since for example every manpage uses single brackets. I'm curious what VMS does about that.

Also, using `{{ something }}` should be fixed since we're now using markdown which can convey things better.
