### PR TITLE
pkcs12: check for zero length digest to avoid division by zero

### DIFF
--- a/providers/implementations/kdfs/pkcs12kdf.c
+++ b/providers/implementations/kdfs/pkcs12kdf.c
@@ -64,7 +64,7 @@ static int pkcs12kdf_derive(const unsigned char *pass, size_t passlen,
     }
     vi = EVP_MD_get_block_size(md_type);
     ui = EVP_MD_get_size(md_type);
-    if (ui < 0 || vi <= 0) {
+    if (ui <= 0 || vi <= 0) {
         ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_DIGEST_SIZE);
         goto end;
     }


### PR DESCRIPTION
Fixes #16331
