### PR TITLE
pkcs12: check for zero length digest to avoid division by zero

### DIFF
--- a/crypto/pkcs12/p12_key.c
+++ b/crypto/pkcs12/p12_key.c
@@ -101,7 +101,7 @@ int PKCS12_key_gen_uni(unsigned char *pass, int passlen, unsigned char *salt,
 #endif
     v = EVP_MD_block_size(md_type);
     u = EVP_MD_size(md_type);
-    if (u < 0 || v <= 0)
+    if (u <= 0 || v <= 0)
         goto err;
     D = OPENSSL_malloc(v);
     Ai = OPENSSL_malloc(u);


### PR DESCRIPTION
Fixes #16331 for 1.1.1.


- [ ] documentation is added or updated
- [ ] tests are added or updated
