### PR TITLE
APPS: Fix behavior of `print_name()` on `out==NULL` and result type of `dump_cert_text()`

### DIFF
--- a/apps/include/apps.h
+++ b/apps/include/apps.h
@@ -94,7 +94,7 @@ typedef struct args_st {
 int wrap_password_callback(char *buf, int bufsiz, int verify, void *cb_data);
 
 int chopup_args(ARGS *arg, char *buf);
-int dump_cert_text(BIO *out, X509 *x);
+void dump_cert_text(BIO *out, X509 *x);
 void print_name(BIO *out, const char *title, const X509_NAME *nm);
 void print_bignum_var(BIO *, const BIGNUM *, const char*,
                       int, unsigned char *);

--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -200,14 +200,10 @@ unsigned long get_nameopt(void)
     return (nmflag_set) ? nmflag : XN_FLAG_ONELINE;
 }
 
-int dump_cert_text(BIO *out, X509 *x)
+void dump_cert_text(BIO *out, X509 *x)
 {
     print_name(out, "subject=", X509_get_subject_name(x));
-    BIO_puts(out, "\n");
     print_name(out, "issuer=", X509_get_issuer_name(x));
-    BIO_puts(out, "\n");
-
-    return 0;
 }
 
 int wrap_password_callback(char *buf, int bufsiz, int verify, void *userdata)
@@ -1289,6 +1285,8 @@ void print_name(BIO *out, const char *title, const X509_NAME *nm)
     int indent = 0;
     unsigned long lflags = get_nameopt();
 
+    if (out == NULL)
+        return;
     if (title != NULL)
         BIO_puts(out, title);
     if ((lflags & XN_FLAG_SEP_MASK) == XN_FLAG_SEP_MULTILINE) {


### PR DESCRIPTION
This fixes spurious error queue entries like
```
007E7E0D01000000:error:100C0102:BIO routines:BIO_puts:passed a null parameter:../openssl/crypto/bio/bio_lib.c:406:
007E7E0D01000000:error:100C0102:BIO routines:BIO_puts:passed a null parameter:../openssl/crypto/bio/bio_lib.c:406:
```
mentioned in https://github.com/openssl/openssl/issues/16300#issue-967625058.

These are due to the IMHO unfortunate design decison that `BIO_puts(NULL, ...)`, takes a NULL BIO input as an error,
while most/all other BIO print functions simply are no-ops in this case.
