### PR TITLE
doc: fix a mistyped "=item" perldoc marker

### DIFF
--- a/doc/man1/openssl-verification-options.pod
+++ b/doc/man1/openssl-verification-options.pod
@@ -130,7 +130,7 @@ each of its sub-fields equals the corresponding subject key identifier, serial
 number, and issuer field of the candidate issuer certificate,
 as far as the respective fields are present in both certificates.
 
-item *
+=item *
 
 The certificate signature algorithm used to sign the subject certificate
 is supported and


### PR DESCRIPTION
Searching didn't reveal any other similar cases.

CLA: trivial

- [x] documentation is added or updated
