### PR TITLE
Fix d2i_ECPKParameters_fp and i2d_ECPKParameters_fp macroes

### DIFF
--- a/crypto/ec/ec_asn1.c
+++ b/crypto/ec/ec_asn1.c
@@ -485,7 +485,7 @@ ECPKPARAMETERS *EC_GROUP_get_ecpkparameters(const EC_GROUP *group,
             ECPARAMETERS_free(ret->value.parameters);
     }
 
-    if (EC_GROUP_get_asn1_flag(group)) {
+    if (EC_GROUP_get_asn1_flag(group) == OPENSSL_EC_NAMED_CURVE) {
         /*
          * use the asn1 OID to describe the elliptic curve parameters
          */

--- a/crypto/ec/ec_curve.c
+++ b/crypto/ec/ec_curve.c
@@ -3241,7 +3241,7 @@ static EC_GROUP *ec_group_new_from_data(OSSL_LIB_CTX *libctx,
         ASN1_OBJECT *asn1obj = OBJ_nid2obj(curve.nid);
 
         if (asn1obj == NULL) {
-            ECerr(EC_F_EC_GROUP_NEW_FROM_DATA, ERR_R_OBJ_LIB);
+            ERR_raise(ERR_LIB_EC, ERR_R_OBJ_LIB);
             goto err;
         }
         if (OBJ_length(asn1obj) == 0)

--- a/crypto/ec/ec_curve.c
+++ b/crypto/ec/ec_curve.c
@@ -3224,6 +3224,7 @@ static EC_GROUP *ec_group_new_from_data(OSSL_LIB_CTX *libctx,
         }
     }
 
+#ifndef FIPS_MODULE
     if (EC_GROUP_get_asn1_flag(group) == OPENSSL_EC_NAMED_CURVE) {
         /*
          * Some curves don't have an associated OID: for those we should not
@@ -3248,6 +3249,16 @@ static EC_GROUP *ec_group_new_from_data(OSSL_LIB_CTX *libctx,
 
         ASN1_OBJECT_free(asn1obj);
     }
+#else
+    /*
+     * Inside the FIPS module we do not support explicit curves anyway
+     * so the above check is not necessary.
+     *
+     * Skipping it is also necessary because `OBJ_length()` and
+     * `ASN1_OBJECT_free()` are not available within the FIPS module
+     * boundaries.
+     */
+#endif
 
     ok = 1;
  err:

--- a/include/openssl/ec.h
+++ b/include/openssl/ec.h
@@ -915,10 +915,10 @@ int i2d_ECPKParameters(const EC_GROUP *, unsigned char **out);
 #  define i2d_ECPKParameters_bio(bp,x) \
     ASN1_i2d_bio_of(EC_GROUP, i2d_ECPKParameters, bp, x)
 #  define d2i_ECPKParameters_fp(fp,x) \
-    (EC_GROUP *)ASN1_d2i_fp(NULL, (char *(*)())d2i_ECPKParameters, (fp), \
-                            (unsigned char **)(x))
+    (EC_GROUP *)ASN1_d2i_fp(NULL, (d2i_of_void *)d2i_ECPKParameters, (fp), \
+                            (void **)(x))
 #  define i2d_ECPKParameters_fp(fp,x) \
-    ASN1_i2d_fp(i2d_ECPKParameters,(fp), (unsigned char *)(x))
+    ASN1_i2d_fp((i2d_of_void *)i2d_ECPKParameters, (fp), (void *)(x))
 
 #  ifndef OPENSSL_NO_DEPRECATED_3_0
 OSSL_DEPRECATEDIN_3_0 int ECPKParameters_print(BIO *bp, const EC_GROUP *x,

--- a/test/build.info
+++ b/test/build.info
@@ -12,6 +12,11 @@ ENDIF
 IF[{- $config{target} =~ /^vms-/ -}]
   $AUXLIBAPPSSRC=../apps/lib/vms_term_sock.c ../apps/lib/vms_decc_argv.c
 ENDIF
+# Program init source, that don't have direct linkage with the rest of the
+# source, and can therefore not be part of a library.
+IF[{- !$disabled{uplink} -}]
+  $INITSRC=../ms/applink.c
+ENDIF
 $LIBAPPSSRC=../apps/lib/opt.c $AUXLIBAPPSSRC
 
 IF[{- !$disabled{tests} -}]
@@ -708,7 +713,7 @@ IF[{- !$disabled{tests} -}]
     INCLUDE[rc5test]=../include ../apps/include
     DEPEND[rc5test]=../libcrypto.a libtestutil.a
 
-    SOURCE[ec_internal_test]=ec_internal_test.c
+    SOURCE[ec_internal_test]=ec_internal_test.c $INITSRC
     INCLUDE[ec_internal_test]=../include ../crypto/ec ../apps/include
     DEPEND[ec_internal_test]=../libcrypto.a libtestutil.a
 

--- a/test/ec_internal_test.c
+++ b/test/ec_internal_test.c
@@ -359,6 +359,47 @@ static int decoded_flag_test(void)
     return testresult;
 }
 
+static
+int ecpkparams_i2d2i_test(int n)
+{
+    EC_GROUP *g1 = NULL, *g2 = NULL;
+    FILE *fp = NULL;
+    int nid = curves[n].nid;
+    int testresult = 0;
+
+    /* create group */
+    if (!TEST_ptr(g1 = EC_GROUP_new_by_curve_name(nid)))
+        goto end;
+
+    /* encode params to file */
+    if (!TEST_ptr(fp = fopen("params.der", "wb"))
+            || !TEST_true(i2d_ECPKParameters_fp(fp, g1)))
+        goto end;
+
+    /* flush and close file */
+    if (!TEST_int_eq(fclose(fp), 0)) {
+        fp = NULL;
+        goto end;
+    }
+    fp = NULL;
+
+    /* decode params from file */
+    if (!TEST_ptr(fp = fopen("params.der", "rb"))
+            || !TEST_ptr(g2 = d2i_ECPKParameters_fp(fp, NULL)))
+        goto end;
+
+    testresult = 1; /* PASS */
+
+end:
+    if (fp != NULL)
+        fclose(fp);
+
+    EC_GROUP_free(g1);
+    EC_GROUP_free(g2);
+
+    return testresult;
+}
+
 int setup_tests(void)
 {
     crv_len = EC_get_builtin_curves(NULL, 0);
@@ -376,6 +417,8 @@ int setup_tests(void)
     ADD_TEST(underflow_test);
 #endif
     ADD_TEST(decoded_flag_test);
+    ADD_ALL_TESTS(ecpkparams_i2d2i_test, crv_len);
+
     return 1;
 }
 


### PR DESCRIPTION
This PR is the `master` counterpart of #12457, and fixes #12443.

This is the original message for the 1.1.1 commit:

> ## Fix `d2i_ECPKParameters_fp` and `i2d_ECPKParameters_fp` macroes
>
> These functions are part of the public API but we don't have tests
> covering their usage.
> They are actually implemented as macroes and the absence of tests has
> caused them to fall out-of-sync with the latest changes to ASN1 related
> functions and cause compilation warnings.
>
> This commit fixes the public headers to reflect these changes.

In `master` we inherited the defect in the public header.

The test for this uncovered a second bug, dealing with curves without associated OIDs.
This PR (as well as #12457) also includes a fix for this second issue.

## Tasks

- [x] Cherry-pick test from #12457
- [x] Evaluate if #12443 still affects `master`
  - [x] Fix #12433 in `master` if needed
- [x] Pass `*_fp()` tests in Windows