### PR TITLE
util/add-depends.pl: Only add dependencies on existing or generated headers

### DIFF
--- a/util/add-depends.pl
+++ b/util/add-depends.pl
@@ -69,7 +69,41 @@ my %depconv_cache =
     keys %{$unified_info{generate}};
 
 my %procedures = (
-    'gcc' => undef,             # gcc style dependency files needs no mods
+    'gcc' =>
+        sub {
+            (my $objfile = shift) =~ s|\.d$|.o|i;
+            my $line = shift;
+
+            # Remove the original object file
+            $line =~ s|^.*\.o: | |;
+            # All we got now is a dependency, shave off surrounding spaces
+            $line =~ s/^\s+//;
+            $line =~ s/\s+$//;
+            # Also, shave off any continuation
+            $line =~ s/\s*\\$//;
+
+            # Split the line into individual header files, and keep those
+            # that exist in some form
+            my @headers;
+            for (split(/\s+/, $line)) {
+                my $x = rel2abs($_);
+
+                if (!$depconv_cache{$x}) {
+                    if (-f $x) {
+                        $depconv_cache{$x} = $_;
+                    }
+                }
+
+                if ($depconv_cache{$x}) {
+                    push @headers, $_;
+                } else {
+                    print STDERR "DEBUG[$producer]: ignoring $objfile <- $line\n"
+                        if $debug;
+                }
+            }
+            return ($objfile, join(' ', @headers)) if @headers;
+            return undef;
+    },
     'makedepend' =>
         sub {
             # makedepend, in its infinite wisdom, wants to have the object file
@@ -149,7 +183,10 @@ my %procedures = (
                 # mappings for generated headers, we only need to deal
                 # with the source tree.
                 if ($dep =~ s|^\Q$abs_srcdir_shaved\E([\.>\]])?|$srcdir_shaved$1|i) {
-                    $depconv_cache{$line} = $dep;
+                    # Also check that the header actually exists
+                    if (-f $line) {
+                        $depconv_cache{$line} = $dep;
+                    }
                 }
             }
             return ($objfile, $depconv_cache{$line})
@@ -201,7 +238,10 @@ my %procedures = (
                     # mappings for generated headers, we only need to deal
                     # with the source tree.
                     if ($dep =~ s|^\Q$abs_srcdir\E\\|\$(SRCDIR)\\|i) {
-                        $depconv_cache{$tail} = $dep;
+                        # Also check that the header actually exists
+                        if (-f $line) {
+                            $depconv_cache{$tail} = $dep;
+                        }
                     }
                 }
                 return ($objfile, '"'.$depconv_cache{$tail}.'"')
@@ -247,7 +287,10 @@ my %procedures = (
                     # mappings for generated headers, we only need to deal
                     # with the source tree.
                     if ($dep =~ s|^\Q$abs_srcdir\E\\|\$(SRCDIR)\\|i) {
-                        $depconv_cache{$tail} = $dep;
+                        # Also check that the header actually exists
+                        if (-f $line) {
+                            $depconv_cache{$tail} = $dep;
+                        }
                     }
                 }
                 return ($objfile, '"'.$depconv_cache{$tail}.'"')
@@ -260,7 +303,7 @@ my %procedures = (
         },
 );
 my %continuations = (
-    'gcc' => undef,
+    'gcc' => "\\",
     'makedepend' => "\\",
     'VMS C' => "-",
     'VC' => "\\",
@@ -276,16 +319,14 @@ my $continuation = $continuations{$producer};
 my $buildfile_new = "$buildfile-$$";
 
 my %collect = ();
-if (defined $procedure) {
-    foreach my $depfile (@depfiles) {
-        open IDEP,$depfile or die "Trying to read $depfile: $!\n";
-        while (<IDEP>) {
-            s|\R$||;                # The better chomp
-            my ($target, $deps) = $procedure->($depfile, $_);
-            $collect{$target}->{$deps} = 1 if defined $target;
-        }
-        close IDEP;
+foreach my $depfile (@depfiles) {
+    open IDEP,$depfile or die "Trying to read $depfile: $!\n";
+    while (<IDEP>) {
+        s|\R$||;                # The better chomp
+        my ($target, $deps) = $procedure->($depfile, $_);
+        $collect{$target}->{$deps} = 1 if defined $target;
     }
+    close IDEP;
 }
 
 open IBF, $buildfile or die "Trying to read $buildfile: $!\n";
@@ -298,31 +339,21 @@ close IBF;
 
 print OBF "# DO NOT DELETE THIS LINE -- make depend depends on it.\n";
 
-if (defined $procedure) {
-    foreach my $target (sort keys %collect) {
-        my $prefix = $target . ' :';
-        my @deps = sort keys %{$collect{$target}};
+foreach my $target (sort keys %collect) {
+    my $prefix = $target . ' :';
+    my @deps = sort keys %{$collect{$target}};
 
-        while (@deps) {
-            my $buf = $prefix;
-            $prefix = '';
+    while (@deps) {
+        my $buf = $prefix;
+        $prefix = '';
 
-            while (@deps && ($buf eq ''
-                                 || length($buf) + length($deps[0]) <= 77)) {
-                $buf .= ' ' . shift @deps;
-            }
-            $buf .= ' '.$continuation if @deps;
-
-            print OBF $buf,"\n" or die "Trying to print: $!\n"
+        while (@deps && ($buf eq ''
+                         || length($buf) + length($deps[0]) <= 77)) {
+            $buf .= ' ' . shift @deps;
         }
-    }
-} else {
-    foreach my $depfile (@depfiles) {
-        open IDEP,$depfile or die "Trying to read $depfile: $!\n";
-        while (<IDEP>) {
-            print OBF or die "Trying to print: $!\n";
-        }
-        close IDEP;
+        $buf .= ' '.$continuation if @deps;
+
+        print OBF $buf,"\n" or die "Trying to print: $!\n"
     }
 }
 


### PR DESCRIPTION
Headers that fulfill neither of those conditions are skipped.

This avoids build breaks when development has removed a previously
existing header.

Fixes #16360
