### PR TITLE
Get rid of warn_binary

### DIFF
--- a/apps/cms.c
+++ b/apps/cms.c
@@ -272,31 +272,6 @@ static CMS_ContentInfo *load_content_info(int informat, BIO *in, int flags,
     return NULL;
 }
 
-static void warn_binary(const char *file)
-{
-    BIO *bio;
-    unsigned char linebuf[1024], *cur, *end;
-    int len;
-
-    if (file == NULL)
-        return; /* cannot give a warning for stdin input */
-    if ((bio = bio_open_default(file, 'r', FORMAT_BINARY)) == NULL)
-        return; /* cannot give a proper warning since there is an error */
-    while ((len = BIO_read(bio, linebuf, sizeof(linebuf))) > 0) {
-        end = linebuf + len;
-        for (cur = linebuf; cur < end; cur++) {
-            if (*cur == '\0' || *cur >= 0x80) {
-                BIO_printf(bio_err, "Warning: input file '%s' contains %s"
-                           " character; better use -binary option\n",
-                           file, *cur == '\0' ? "NUL" : "8-bit");
-                goto end;
-            }
-        }
-    }
- end:
-    BIO_free(bio);
-}
-
 int cms_main(int argc, char **argv)
 {
     CONF *conf = NULL;
@@ -911,8 +886,6 @@ int cms_main(int argc, char **argv)
             goto end;
     }
 
-    if ((flags & CMS_BINARY) == 0)
-        warn_binary(infile);
     in = bio_open_default(infile, 'r',
                           binary_files ? FORMAT_BINARY : informat);
     if (in == NULL)
@@ -924,8 +897,6 @@ int cms_main(int argc, char **argv)
             goto end;
         if (contfile != NULL) {
             BIO_free(indata);
-            if ((flags & CMS_BINARY) == 0)
-                warn_binary(contfile);
             if ((indata = BIO_new_file(contfile, "rb")) == NULL) {
                 BIO_printf(bio_err, "Can't read content file %s\n", contfile);
                 goto end;


### PR DESCRIPTION
Current implementation of warn_binary introduces a regression
when the content is passed in /dev/stdin as an explicit file name
and reads the file to be processed twice otherwise.

I suggest to reimplement this functionality after 3.0 if necessary.

Fixes #16359

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
