### PR TITLE
Fix some strict gcc-12 warnings

### DIFF
--- a/crypto/ec/curve448/field.h
+++ b/crypto/ec/curve448/field.h
@@ -62,7 +62,7 @@ mask_t gf_eq(const gf x, const gf y);
 mask_t gf_lobit(const gf x);
 mask_t gf_hibit(const gf x);
 
-void gf_serialize(uint8_t *serial, const gf x, int with_highbit);
+void gf_serialize(uint8_t serial[SER_BYTES], const gf x, int with_highbit);
 mask_t gf_deserialize(gf x, const uint8_t serial[SER_BYTES], int with_hibit,
                       uint8_t hi_nmask);
 

--- a/ssl/s3_cbc.c
+++ b/ssl/s3_cbc.c
@@ -128,7 +128,7 @@ char ssl3_cbc_record_digest_supported(const EVP_MD_CTX *ctx)
 int ssl3_cbc_digest_record(const EVP_MD_CTX *ctx,
                            unsigned char *md_out,
                            size_t *md_out_size,
-                           const unsigned char header[13],
+                           const unsigned char *header,
                            const unsigned char *data,
                            size_t data_plus_mac_size,
                            size_t data_plus_mac_plus_padding_size,

--- a/ssl/ssl_local.h
+++ b/ssl/ssl_local.h
@@ -2622,7 +2622,7 @@ __owur char ssl3_cbc_record_digest_supported(const EVP_MD_CTX *ctx);
 __owur int ssl3_cbc_digest_record(const EVP_MD_CTX *ctx,
                                   unsigned char *md_out,
                                   size_t *md_out_size,
-                                  const unsigned char header[13],
+                                  const unsigned char *header,
                                   const unsigned char *data,
                                   size_t data_plus_mac_size,
                                   size_t data_plus_mac_plus_padding_size,


### PR DESCRIPTION
this is for the 1.1.1 branch.
apparently the master branch was already fixed.