### PR TITLE
Fix the parameter type of gf_serialize

### DIFF
--- a/crypto/ec/curve448/f_generic.c
+++ b/crypto/ec/curve448/f_generic.c
@@ -18,7 +18,7 @@ static const gf MODULUS = {
 };
 
 /* Serialize to wire format. */
-void gf_serialize(uint8_t *serial, const gf x, int with_hibit)
+void gf_serialize(uint8_t serial[SER_BYTES], const gf x, int with_hibit)
 {
     unsigned int j = 0, fill = 0;
     dword_t buffer = 0;

--- a/crypto/ec/curve448/field.h
+++ b/crypto/ec/curve448/field.h
@@ -62,7 +62,7 @@ mask_t gf_eq(const gf x, const gf y);
 mask_t gf_lobit(const gf x);
 mask_t gf_hibit(const gf x);
 
-void gf_serialize(uint8_t *serial, const gf x, int with_highbit);
+void gf_serialize(uint8_t serial[SER_BYTES], const gf x, int with_highbit);
 mask_t gf_deserialize(gf x, const uint8_t serial[SER_BYTES], int with_hibit,
                       uint8_t hi_nmask);
 


### PR DESCRIPTION
It is better to use array bounds for improved
gcc warning checks.

While "uint8_t*" allows arbitrary pointer arithmetic
using "uint8_t[SER_BYTES]" limits the pointer arithmetic
to the range 0..SER_BYTES.
