### PR TITLE
apps/ciphers: Fix wrong return value when using -convert parameter

### DIFF
--- a/apps/ciphers.c
+++ b/apps/ciphers.c
@@ -183,6 +183,7 @@ int ciphers_main(int argc, char **argv)
     if (convert != NULL) {
         BIO_printf(bio_out, "OpenSSL cipher name: %s\n",
                    OPENSSL_cipher_name(convert));
+        ret = 0;
         goto end;
     }
 


### PR DESCRIPTION
Command 'openssl ciphers -convert <name>' always returns failure,
this patch set the correct return value.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
