### PR TITLE
Avoid using undefined value in generate_stateless_cookie_callback

### DIFF
--- a/apps/lib/s_cb.c
+++ b/apps/lib/s_cb.c
@@ -823,7 +823,8 @@ int generate_cookie_callback(SSL *ssl, unsigned char *cookie,
     size_t temp = 0;
     int res = generate_stateless_cookie_callback(ssl, cookie, &temp);
 
-    *cookie_len = (unsigned int)temp;
+    if (res != 0)
+        *cookie_len = (unsigned int)temp;
     return res;
 }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
