### PR TITLE
Add multilib to the NonStop configuration definitions.

### DIFF
--- a/Configurations/50-nonstop.conf
+++ b/Configurations/50-nonstop.conf
@@ -117,12 +117,14 @@
         template         => 1,
         cflags           => '-Wlp64',
         bn_ops           => 'SIXTY_FOUR_BIT_LONG RC4_CHAR RC4_CHUNK DES_INT DES_UNROLL BF_PTR',
+        multilib         => '64',
     },
     'nonstop-lp64-x86_64' => {
         template         => 1,
         cflags           => '-Wlp64',
         lflags           => '-Wxld="-set data_model lp64"',
         bn_ops           => 'SIXTY_FOUR_BIT',
+        multilib         => '64',
     },
 
     # Float variants
@@ -170,12 +172,14 @@
         defines          => ['_PUT_MODEL_',
                              '_REENTRANT', '_THREAD_SUPPORT_FUNCTIONS'],
         ex_libs          => '-lput',
+        multilib         => '-put',
     },
     'nonstop-model-spt' => {
         template         => 1,
         defines          => ['_SPT_MODEL_',
                              '_REENTRANT', '_ENABLE_FLOSS_THREADS'],
         ex_libs          => '-lspt',
+        multilib         => '-spt',
     },
 
     # Additional floss model that can be combined with any of the other models.

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -298,6 +298,7 @@ OPENSSLDIR={- #
 LIBDIR={- our $libdir = $config{libdir};
           unless ($libdir) {
               $libdir = "lib$target{multilib}";
+              $libdir =~ s/\s+//g;
           }
           file_name_is_absolute($libdir) ? "" : $libdir -}
 # $(libdir) is chosen to be compatible with the GNU coding standards

--- a/NOTES-NONSTOP.md
+++ b/NOTES-NONSTOP.md
@@ -56,8 +56,14 @@ options, and keeping your memory and float options consistent, for example:
 
  * For 1.1 `--prefix=/usr/local-ssl1.1 --openssldir=/usr/local-ssl1.1/ssl`
  * For 1.1 PUT `--prefix=/usr/local-ssl1.1_put --openssldir=/usr/local-ssl1.1_put/ssl`
+
+As of 3.0, the NonStop configurations use the multilib attribute to distinguish
+between different models:
+
  * For 3.0 `--prefix=/usr/local-ssl3.0 --openssldir=/usr/local-ssl3.0/ssl`
- * For 3.0 PUT `--prefix=/usr/local-ssl3.0_put --openssldir=/usr/local-ssl3.0_put/ssl`
+
+The PUT model is placed in `${prefix}/lib-put` for 32-bit models and
+`${prefix}/lib64-put` for 64-bit models.
 
 Use the `_RLD_LIB_PATH` environment variable in OSS to select the appropriate
 directory containing `libcrypto.so` and `libssl.so`. In GUARDIAN, use the


### PR DESCRIPTION
This change also modifies NOTES-NONSTOP.md and unix-Makefile.tmpl to
account for extra spaces in multiple multilib attributes.

Fixes: #16373

Signed-off-by: Randall S. Becker <rsbecker@nexbridge.com>
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
