### PR TITLE
When using s_client, connection IP address is displayed

### DIFF
--- a/apps/lib/s_socket.c
+++ b/apps/lib/s_socket.c
@@ -133,7 +133,7 @@ int init_client(int *sock, const char *host, const char *port,
              */
             continue;
         }
-	
+
         if (bi != NULL) {
             if (!BIO_bind(*sock, BIO_ADDRINFO_address(bi),
                           BIO_SOCK_REUSEADDR)) {

--- a/apps/lib/s_socket.c
+++ b/apps/lib/s_socket.c
@@ -133,7 +133,7 @@ int init_client(int *sock, const char *host, const char *port,
              */
             continue;
         }
-
+	
         if (bi != NULL) {
             if (!BIO_bind(*sock, BIO_ADDRINFO_address(bi),
                           BIO_SOCK_REUSEADDR)) {
@@ -171,6 +171,8 @@ int init_client(int *sock, const char *host, const char *port,
         /* Success, don't try any more addresses */
         break;
     }
+	
+    BIO_printf(bio_out, "Connecting to %s\n", BIO_ADDR_hostname_string(BIO_ADDRINFO_address(ai),1));
 
     if (*sock == INVALID_SOCKET) {
         if (bindaddr != NULL && !found) {

--- a/apps/lib/s_socket.c
+++ b/apps/lib/s_socket.c
@@ -172,7 +172,7 @@ int init_client(int *sock, const char *host, const char *port,
         break;
     }
 	
-    BIO_printf(bio_out, "Connecting to %s\n", BIO_ADDR_hostname_string(BIO_ADDRINFO_address(ai),1));
+    BIO_printf(bio_out, "Connecting to %s\n", BIO_ADDR_hostname_string(BIO_ADDRINFO_address(ai), 1));
 
     if (*sock == INVALID_SOCKET) {
         if (bindaddr != NULL && !found) {


### PR DESCRIPTION
This is an attempt to solve issue #16124.
Upon using init_client() from s_socket, "Connecting to [IP]" is printed.
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
