### PR TITLE
Fix libdir path on darwin

### DIFF
--- a/Configurations/shared-info.pl
+++ b/Configurations/shared-info.pl
@@ -43,7 +43,7 @@ my %shared_info;
     'darwin-shared' => {
         module_ldflags        => '-bundle',
         shared_ldflag         => '-dynamiclib -current_version $(SHLIB_VERSION_NUMBER) -compatibility_version $(SHLIB_VERSION_NUMBER)',
-        shared_sonameflag     => '-install_name $(INSTALLTOP)/$(LIBDIR)/',
+        shared_sonameflag     => '-install_name $(libdir)/',
     },
     'cygwin-shared' => {
         shared_ldflag         => '-shared -Wl,--enable-auto-image-base',


### PR DESCRIPTION
In current Configure script, libdir can be specified either an absolute
path or relative, while in Configurations/shared-info.pl, on darwin
system "-install_name" only accepts relative libdir path, and the
program fails when receiving absolute libdir path. This PR is to fix
this and match requirements of scripts.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
