### PR TITLE
CMS app: Fix new -wrap option

### DIFF
--- a/apps/cms.c
+++ b/apps/cms.c
@@ -705,7 +705,7 @@ int cms_main(int argc, char **argv)
                 goto end;
             break;
         case OPT_WRAP:
-            wrapname = opt_unknown();
+            wrapname = opt_arg();
             break;
         case OPT_AES128_WRAP:
         case OPT_AES192_WRAP:


### PR DESCRIPTION
While improving the diagnostics of the apps on 'unkown' options,
I noticed a bug regarding the `cms` `-wrap` option introduced in #10904.

This issue could have been avoided by adding tests for the new option.