### PR TITLE
cpp: fix included files to avoid failure in no-deprecated builds

### DIFF
--- a/include/crypto/x509.h
+++ b/include/crypto/x509.h
@@ -14,6 +14,7 @@
 # include "internal/refcount.h"
 # include <openssl/asn1.h>
 # include <openssl/x509.h>
+# include <openssl/conf.h>
 # include "crypto/types.h"
 
 /* Internal X509 structures and functions: not for application use */
@@ -343,7 +344,7 @@ DH *ossl_d2i_DH_PUBKEY(DH **a, const unsigned char **pp, long length);
 int ossl_i2d_DH_PUBKEY(const DH *a, unsigned char **pp);
 DH *ossl_d2i_DHx_PUBKEY(DH **a, const unsigned char **pp, long length);
 int ossl_i2d_DHx_PUBKEY(const DH *a, unsigned char **pp);
-# endif
+# endif /* OPENSSL_NO_DH */
 # ifndef OPENSSL_NO_EC
 ECX_KEY *ossl_d2i_ED25519_PUBKEY(ECX_KEY **a,
                                  const unsigned char **pp, long length);
@@ -357,10 +358,10 @@ int ossl_i2d_X25519_PUBKEY(const ECX_KEY *a, unsigned char **pp);
 ECX_KEY *ossl_d2i_X448_PUBKEY(ECX_KEY **a,
                               const unsigned char **pp, long length);
 int ossl_i2d_X448_PUBKEY(const ECX_KEY *a, unsigned char **pp);
-# endif
+# endif /* OPENSSL_NO_EC */
 EVP_PKEY *ossl_d2i_PUBKEY_legacy(EVP_PKEY **a, const unsigned char **pp,
                                  long length);
-#endif
 
 int x509v3_add_len_value_uchar(const char *name, const unsigned char *value,
                                size_t vallen, STACK_OF(CONF_VALUE) **extlist);
+#endif  /* OSSL_CRYPTO_X509_H */


### PR DESCRIPTION
A header file was missing but only in no-deprecated builds.
Also add some ending comments for #if preprocessor statements.
Move function declaration inside #ifdef guard for header.

Urgent because the no-deprecated builds are broken without this.