### PR TITLE
Document that EVP_get_cipherbyname() does not work for some new algorithm names.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -41,6 +41,13 @@ breaking changes, and mappings for the large list of deprecated functions.
 
    *OpenSSL team members and many third party contributors*
 
+ * The EVP_get_cipherbyname() function will return NULL for algorithms such as
+   "AES-128-SIV", "AES-128-CBC-CTS" and "CAMELLIA-128-CBC-CTS" which were
+   previously only accessible via low level interfaces. Use EVP_CIPHER_fetch()
+   instead to retrieve these algorithms from a provider.
+
+   *Shane Lontis*
+
  * On build targets where the multilib postfix is set in the build
    configuration the libdir directory was changing based on whether
    the lib directory with the multilib postfix exists on the system

--- a/doc/man3/EVP_EncryptInit.pod
+++ b/doc/man3/EVP_EncryptInit.pod
@@ -447,6 +447,11 @@ EVP_CipherFinal_ex() instead.
 Return an EVP_CIPHER structure when passed a cipher name, a NID or an
 ASN1_OBJECT structure.
 
+EVP_get_cipherbyname() will return NULL for algorithms such as "AES-128-SIV",
+"AES-128-CBC-CTS" and "CAMELLIA-128-CBC-CTS" which were previously only
+accessible via low level interfaces. Use EVP_CIPHER_fetch() instead to retrieve
+these algorithms from a provider.
+
 =item EVP_CIPHER_get_nid() and EVP_CIPHER_CTX_get_nid()
 
 Return the NID of a cipher when passed an B<EVP_CIPHER> or B<EVP_CIPHER_CTX>


### PR DESCRIPTION
These algorithms were added to providers but have no const EVP_CIPHER*
mapping. Ciphers for SIV and CTS were previously only available via low level
function calls that are deprecated.

Reported by @reaperhulk.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
