### PR TITLE
APPS/req: Fix misconception on new -CA/-CAkey options and AKID generation with -CA option

### DIFF
--- a/doc/man1/openssl-req.pod.in
+++ b/doc/man1/openssl-req.pod.in
@@ -103,7 +103,7 @@ which supports both options for good reasons.
 
 =item B<-passin> I<arg>
 
-The password source for the request input file and the certificate input.
+The password source for private key and certificate input.
 For more information about the format of B<arg>
 see L<openssl-passphrase-options(1)>.
 
@@ -124,7 +124,7 @@ Prints out the certificate request in text form.
 =item B<-subject>
 
 Prints out the certificate request subject
-(or certificate subject if B<-x509> is specified).
+(or certificate subject if B<-x509> is in use).
 
 =item B<-pubkey>
 
@@ -193,8 +193,8 @@ See L<openssl-genpkey(1)/KEY GENERATION OPTIONS> for more details.
 
 =item B<-key> I<filename>|I<uri>
 
-This specifies the private key to use for request self-signature
-and signing certificates produced using the B<-x509> option.
+This specifies the key to include and to use for request self-signature
+and for self-signing certificates produced with the B<-x509> option.
 It also accepts PKCS#8 format private keys for PEM format files.
 
 =item B<-keyform> B<DER>|B<PEM>|B<P12>|B<ENGINE>
@@ -266,6 +266,7 @@ This option has been deprecated and has no effect.
 
 This option outputs a certificate instead of a certificate request.
 This is typically used to generate test certificates.
+It is implied by the B<-CA> option.
 
 If an existing request is specified with the B<-in> option, it is converted
 to the a certificate; otherwise a request is created from scratch.
@@ -281,7 +282,8 @@ or using the B<-addext> option.
 
 =item B<-CA> I<filename>|I<uri>
 
-Specifies the "CA" certificate to be used for signing with the B<-x509> option.
+Specifies the "CA" certificate to be used for signing a new certificate
+and implies use of B<-x509>.
 When present, this behaves like a "micro CA" as follows:
 The subject name of the "CA" certificate is placed as issuer name in the new
 certificate, which is then signed using the "CA" key given as specified below.
@@ -294,7 +296,7 @@ If this option is not provided then the key must be present in the B<-CA> input.
 
 =item B<-days> I<n>
 
-When the B<-x509> option is being used this specifies the number of
+When B<-x509> is in use this specifies the number of
 days to certify the certificate for, otherwise it is ignored. I<n> should
 be a positive integer. The default is 30 days.
 
@@ -307,7 +309,7 @@ If not given, a large random number will be used.
 =item B<-copy_extensions> I<arg>
 
 Determines how X.509 extensions in certificate requests should be handled
-when B<-x509> is given.
+when B<-x509> is in use.
 If I<arg> is B<none> or this option is not present then extensions are ignored.
 If I<arg> is B<copy> or B<copyall> then
 all extensions in the request are copied to the certificate.
@@ -317,8 +319,8 @@ values for certain extensions such as subjectAltName.
 
 =item B<-addext> I<ext>
 
-Add a specific extension to the certificate (if the B<-x509> option is
-present) or certificate request.  The argument must have the form of
+Add a specific extension to the certificate (if B<-x509> is in use)
+or certificate request.  The argument must have the form of
 a key=value pair as it would appear in a config file.
 
 This option can be given multiple times.
@@ -328,8 +330,8 @@ This option can be given multiple times.
 =item B<-reqexts> I<section>
 
 These options specify alternative sections to include certificate
-extensions (if the B<-x509> option is present) or certificate
-request extensions. This allows several different sections to
+extensions (if B<-x509> is in use) or certificate request extensions.
+This allows several different sections to
 be used in the same configuration file to specify requests for
 a variety of purposes.
 
@@ -399,7 +401,8 @@ The options available are described in detail below.
 
 =over 4
 
-=item B<input_password output_password>
+=item B<input_password>
+=item B<output_password>
 
 The passwords for the input private key file (if present) and
 the output private key file (if one will be created). The
@@ -479,8 +482,8 @@ extension section format.
 =item B<x509_extensions>
 
 This specifies the configuration file section containing a list of
-extensions to add to certificate generated when the B<-x509> switch
-is used. It can be overridden by the B<-extensions> command line switch.
+extensions to add to certificate generated when B<-x509> is in use.
+It can be overridden by the B<-extensions> command line switch.
 
 =item B<prompt>
 


### PR DESCRIPTION
When further extending the tests in #16342, I found two issues with the `req` app:
* In #13658, which - among others - added the `-CA` and `-CAkey` options, I introduced a misconception.
  These two new options should not be ignored if `-x509` is not given, but they should imply `-x509`.
* In commit 41e597a01d95540f52e8bc4d69f88c3d93a093ce I made a mistake such that AKID generation goes wrong if `-CA` is in use.

Both issues are fixed here.

- [x] documentation is added or updated
- [ ] tests are added or updated: they are part of #16342
