### PR TITLE
Fix for -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION backported to 1.1.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: config
-      run: ./config --debug enable-asan enable-ubsan enable-rc5 enable-md2 enable-ec_nistp_64_gcc_128 && perl configdata.pm --dump
+      run: ./config --debug enable-asan enable-ubsan enable-rc5 enable-md2 enable-ec_nistp_64_gcc_128 -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION && perl configdata.pm --dump
     - name: make
       run: make -s -j4
     - name: make test

--- a/crypto/asn1/a_print.c
+++ b/crypto/asn1/a_print.c
@@ -21,7 +21,7 @@ int ASN1_PRINTABLE_type(const unsigned char *s, int len)
     if (s == NULL)
         return V_ASN1_PRINTABLESTRING;
 
-    if (len <= 0)
+    if (len < 0)
         len = strlen((const char *)s);
 
     while (len-- > 0) {

--- a/crypto/asn1/a_print.c
+++ b/crypto/asn1/a_print.c
@@ -18,12 +18,13 @@ int ASN1_PRINTABLE_type(const unsigned char *s, int len)
     int ia5 = 0;
     int t61 = 0;
 
-    if (len <= 0)
-        len = -1;
     if (s == NULL)
         return V_ASN1_PRINTABLESTRING;
 
-    while ((*s) && (len-- != 0)) {
+    if (len <= 0)
+        len = strlen((const char *)s);
+
+    while (len-- > 0) {
         c = *(s++);
         if (!ossl_isasn1print(c))
             ia5 = 1;

--- a/crypto/asn1/asn1_lib.c
+++ b/crypto/asn1/asn1_lib.c
@@ -294,31 +294,31 @@ int ASN1_STRING_set(ASN1_STRING *str, const void *_data, int len_in)
         c = str->data;
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
         /* No NUL terminator in fuzzing builds */
-        str->data = OPENSSL_realloc(c, len);
-        if (str->data == NULL && len != 0) {
+        str->data = OPENSSL_realloc(c, len != 0 ? len : 1);
 #else
         str->data = OPENSSL_realloc(c, len + 1);
-        if (str->data == NULL) {
 #endif
+        if (str->data == NULL) {
             ASN1err(ASN1_F_ASN1_STRING_SET, ERR_R_MALLOC_FAILURE);
             str->data = c;
             return 0;
         }
     }
     str->length = len;
-#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
-    if (data != NULL && len != 0)
-        memcpy(str->data, data, len);
-#else
     if (data != NULL) {
         memcpy(str->data, data, len);
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+        /* Set the unused byte to something non NUL and printable. */
+        if (len == 0)
+            str->data[len] = '~';
+#else
         /*
          * Add a NUL terminator. This should not be necessary - but we add it as
          * a safety precaution
          */
         str->data[len] = '\0';
-    }
 #endif
+    }
     return 1;
 }
 

--- a/ssl/ssl_asn1.c
+++ b/ssl/ssl_asn1.c
@@ -225,7 +225,7 @@ static int ssl_session_strndup(char **pdst, ASN1_OCTET_STRING *src)
 static int ssl_session_memcpy(unsigned char *dst, size_t *pdstlen,
                               ASN1_OCTET_STRING *src, size_t maxlen)
 {
-    if (src == NULL) {
+    if (src == NULL || src->length == 0) {
         *pdstlen = 0;
         return 1;
     }


### PR DESCRIPTION
This is the 1.1.1 version of #16433

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
