### PR TITLE
APPS/x509: Fix generation of AKID via v2i_AUTHORITY_KEYID()

### DIFF
--- a/apps/x509.c
+++ b/apps/x509.c
@@ -799,7 +799,12 @@ int x509_main(int argc, char **argv)
             goto end;
     }
 
-    X509V3_set_ctx(&ext_ctx, issuer_cert, x, req, NULL, X509V3_CTX_REPLACE);
+    X509V3_set_ctx(&ext_ctx, issuer_cert, x, NULL, NULL, X509V3_CTX_REPLACE);
+    /* prepare fallback for AKID, but only if issuer cert equals subject cert */
+    if (CAfile == NULL) {
+        if (!X509V3_set_issuer_pkey(&ext_ctx, privkey))
+            goto end;
+    }
     if (extconf != NULL && !x509toreq) {
         X509V3_set_nconf(&ext_ctx, extconf);
         if (!X509V3_EXT_add_nconf(extconf, &ext_ctx, extsect, x)) {

--- a/doc/man5/x509v3_config.pod
+++ b/doc/man5/x509v3_config.pod
@@ -194,13 +194,16 @@ Otherwise it may have the value B<keyid> or B<issuer>
 or both of them, separated by C<,>.
 Either or both can have the option B<always>,
 indicated by putting a colon C<:> between the value and this option.
+For self-signed certificates the AKID is suppressed unless B<always> is present.
 By default the B<x509>, B<req>, and B<ca> apps behave as if
 "none" was given for self-signed certificates and "keyid, issuer" otherwise.
 
-If B<keyid> is present, an attempt is made to compute the hash of the public key
-corresponding to the signing key in case the certificate is self-signed,
-or else to copy the subject key identifier (SKID) from the issuer certificate.
-If this fails and the option B<always> is present, an error is returned.
+If B<keyid> is present, an attempt is made to
+copy the subject key identifier (SKID) from the issuer certificate except if
+the issuer certificate is the same as the current one and it is not self-signed.
+The hash of the public key related to the signing key is taken as fallback
+if the issuer certificate is the same as the current certificate.
+If B<always> is present but no value can be obtained, an error is returned.
 
 If B<issuer> is present, and in addition it has the option B<always> specified
 or B<keyid> is not present,

--- a/test/recipes/25-test_req.t
+++ b/test/recipes/25-test_req.t
@@ -433,7 +433,7 @@ cert_ext_has_n_different_lines($cert, 0, $SKID_AKID); # no SKID and no AKID
 
 $cert = "self-signed_v3_CA_both_KIDs.pem";
 generate_cert($cert, @v3_ca, "-addext", "subjectKeyIdentifier = hash",
-            "-addext", "authorityKeyIdentifier = keyid");
+            "-addext", "authorityKeyIdentifier = keyid:always");
 cert_ext_has_n_different_lines($cert, 3, $SKID_AKID); # SKID == AKID
 strict_verify($cert, 1);
 


### PR DESCRIPTION
This provides a simplified fix (compared to #16342) of issue #16300, 
which as been marked important, regarding the generation of the AKID of a cert.

It takes into account a convention from RFC 5280:
* For self-signed certs the AKID should be suppressed
  (unless forced using `authorityKeyIdentifier = keyid:always`).

and some tricky corner cases:
* Prefer any pre-existing subject key identifier of the issuer cert
  except if issuer cert is same as subject cert and is not self-signed.
* The hash of the public key related to the signing key is taken as fallback
  if the issuer certificate is the same as the current certificate.

Moreover, it corrects the SKID generation in case `-force_pubkey` is used.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated - more tests will be added as part of #16342
