### PR TITLE
Ensure that we check the ASN.1 type of an "otherName" before using it

### DIFF
--- a/crypto/x509/v3_utl.c
+++ b/crypto/x509/v3_utl.c
@@ -903,7 +903,7 @@ static int do_x509_check(X509 *x, const char *chk, size_t chklen,
                     san_present = 1;
 
                     /*
-                     * If its not a UTF8String then that is unexpected and we
+                     * If it is not a UTF8String then that is unexpected and we
                      * treat it as no match
                      */
                     if (gen->d.otherName->value->type == V_ASN1_UTF8STRING) {

--- a/crypto/x509/v3_utl.c
+++ b/crypto/x509/v3_utl.c
@@ -901,12 +901,19 @@ static int do_x509_check(X509 *x, const char *chk, size_t chklen,
                 if (OBJ_obj2nid(gen->d.otherName->type_id) ==
                     NID_id_on_SmtpUTF8Mailbox) {
                     san_present = 1;
-                    cstr = gen->d.otherName->value->value.utf8string;
 
-                    /* Positive on success, negative on error! */
-                    if ((rv = do_check_string(cstr, 0, equal, flags,
-                                              chk, chklen, peername)) != 0)
-                        break;
+                    /*
+                     * If its not a UTF8String then that is unexpected and we
+                     * treat it as no match
+                     */
+                    if (gen->d.otherName->value->type == V_ASN1_UTF8STRING) {
+                        cstr = gen->d.otherName->value->value.utf8string;
+
+                        /* Positive on success, negative on error! */
+                        if ((rv = do_check_string(cstr, 0, equal, flags,
+                                                chk, chklen, peername)) != 0)
+                            break;
+                    }
                 } else
                     continue;
             } else {

--- a/test/recipes/25-test_eai_data.t
+++ b/test/recipes/25-test_eai_data.t
@@ -12,7 +12,7 @@ use warnings;
 
 use File::Spec;
 use OpenSSL::Test::Utils;
-use OpenSSL::Test qw/:DEFAULT srctop_file/;
+use OpenSSL::Test qw/:DEFAULT srctop_file with/;
 
 setup("test_eai_data");
 
@@ -21,7 +21,7 @@ setup("test_eai_data");
 #./util/wrap.pl apps/openssl verify -nameopt utf8 -no_check_time -CAfile test/recipes/25-test_eai_data/utf8_chain.pem test/recipes/25-test_eai_data/ascii_leaf.pem
 #./util/wrap.pl apps/openssl verify -nameopt utf8 -no_check_time -CAfile test/recipes/25-test_eai_data/ascii_chain.pem test/recipes/25-test_eai_data/utf8_leaf.pem
 
-plan tests => 11;
+plan tests => 12;
 
 require_ok(srctop_file('test','recipes','tconversion.pl'));
 my $folder = "test/recipes/25-test_eai_data";
@@ -59,4 +59,14 @@ ok(run(app(["openssl", "verify", "-nameopt", "utf8", "-no_check_time", "-CAfile"
 
 ok(!run(app(["openssl", "verify", "-nameopt", "utf8", "-no_check_time", "-CAfile", $ascii_chain_pem, $utf8_pem])));
 ok(!run(app(["openssl", "verify", "-nameopt", "utf8", "-no_check_time", "-CAfile", $utf8_chain_pem,  $ascii_pem])));
+
+#Check that we get the expected failure return code
+with({ exit_checker => sub { return shift == 2; } },
+     sub {
+        ok(run(app(["openssl", "verify", "-CAfile",
+                    srctop_file("test", "certs", "bad-othername-namec.pem"),
+                    "-partial_chain", "-no_check_time", "-verify_email",
+                    'foo@example.com',
+                    srctop_file("test", "certs", "bad-othername-namec.pem")])));
+     });
 


### PR DESCRIPTION
We should not assume that the type of an ASN.1 value is UTF8String as
expected. We must actually check it, otherwise we could get a NULL ptr
deref, or worse memory errors.

Reported by David Benjamin.