### PR TITLE
Fix the "Out of memory" EVP KDF scrypt test

### DIFF
--- a/test/evp_test.c
+++ b/test/evp_test.c
@@ -2664,7 +2664,7 @@ static int kdf_test_run(EVP_TEST *t)
         t->err = "KDF_CTRL_ERROR";
         return 1;
     }
-    if (!TEST_ptr(got = OPENSSL_malloc(got_len))) {
+    if (!TEST_ptr(got = OPENSSL_malloc(got_len == 0 ? 1 : got_len))) {
         t->err = "INTERNAL_ERROR";
         goto err;
     }

--- a/test/evp_test.c
+++ b/test/evp_test.c
@@ -2760,7 +2760,7 @@ static int pkey_kdf_test_run(EVP_TEST *t)
     unsigned char *got = NULL;
     size_t got_len = expected->output_len;
 
-    if (!TEST_ptr(got = OPENSSL_malloc(got_len))) {
+    if (!TEST_ptr(got = OPENSSL_malloc(got_len == 0 ? 1 : got_len))) {
         t->err = "INTERNAL_ERROR";
         goto err;
     }

--- a/test/recipes/30-test_evp_data/evpkdf_scrypt.txt
+++ b/test/recipes/30-test_evp_data/evpkdf_scrypt.txt
@@ -60,4 +60,4 @@ Ctrl.salt = salt:SodiumChloride
 Ctrl.N = n:1048576
 Ctrl.r = r:8
 Ctrl.p = p:1
-Result = INTERNAL_ERROR
+Result = KDF_MISMATCH

--- a/test/recipes/30-test_evp_data/evppkey_kdf_scrypt.txt
+++ b/test/recipes/30-test_evp_data/evppkey_kdf_scrypt.txt
@@ -60,4 +60,4 @@ Ctrl.salt = salt:SodiumChloride
 Ctrl.N = N:1048576
 Ctrl.r = r:8
 Ctrl.p = p:1
-Result = INTERNAL_ERROR
+Result = KDF_MISMATCH


### PR DESCRIPTION
This test did not really execute, since usually
the OPENSSL_malloc(0) will fail and prevent the
execution of the KDF.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
