### PR TITLE
APPS: Improve diagnostics on missing/extra args and unknown digest

### DIFF
--- a/apps/asn1parse.c
+++ b/apps/asn1parse.c
@@ -159,8 +159,7 @@ int asn1parse_main(int argc, char **argv)
     }
 
     /* No extra args. */
-    argc = opt_num_rest();
-    if (argc != 0)
+    if (!opt_check_rest_arg(NULL))
         goto opthelp;
 
     if (oidfile != NULL) {

--- a/apps/ciphers.c
+++ b/apps/ciphers.c
@@ -174,10 +174,9 @@ int ciphers_main(int argc, char **argv)
 
     /* Optional arg is cipher name. */
     argv = opt_rest();
-    argc = opt_num_rest();
-    if (argc == 1)
+    if (opt_num_rest() == 1)
         ciphers = argv[0];
-    else if (argc != 0)
+    else if (!opt_check_rest_arg(NULL))
         goto opthelp;
 
     if (convert != NULL) {

--- a/apps/cmp.c
+++ b/apps/cmp.c
@@ -2534,9 +2534,7 @@ static int get_opts(int argc, char **argv)
     }
 
     /* No extra args. */
-    argc = opt_num_rest();
-    argv = opt_rest();
-    if (argc != 0)
+    if (!opt_check_rest_arg(NULL))
         goto opthelp;
     return 1;
 }

--- a/apps/cms.c
+++ b/apps/cms.c
@@ -697,10 +697,8 @@ int cms_main(int argc, char **argv)
         if (!opt_md(digestname, &sign_md))
             goto end;
     }
-    if (ciphername != NULL) {
-        if (!opt_cipher_any(ciphername, &cipher))
-            goto end;
-    }
+    if (!opt_cipher_any(ciphername, &cipher))
+        goto end;
     if (wrapname != NULL) {
         if (!opt_cipher_any(wrapname, &wrap_cipher))
             goto end;

--- a/apps/crl.c
+++ b/apps/crl.c
@@ -209,14 +209,11 @@ int crl_main(int argc, char **argv)
     }
 
     /* No remaining args. */
-    argc = opt_num_rest();
-    if (argc != 0)
+    if (!opt_check_rest_arg(NULL))
         goto opthelp;
 
-    if (digestname != NULL) {
-        if (!opt_md(digestname, &digest))
-            goto opthelp;
-    }
+    if (!opt_md(digestname, &digest))
+        goto opthelp;
     x = load_crl(infile, informat, 1, "CRL");
     if (x == NULL)
         goto end;

--- a/apps/crl2pkcs7.c
+++ b/apps/crl2pkcs7.c
@@ -104,8 +104,7 @@ int crl2pkcs7_main(int argc, char **argv)
     }
 
     /* No remaining args. */
-    argc = opt_num_rest();
-    if (argc != 0)
+    if (!opt_check_rest_arg(NULL))
         goto opthelp;
 
     if (!nocrl) {

--- a/apps/dhparam.c
+++ b/apps/dhparam.c
@@ -155,7 +155,7 @@ int dhparam_main(int argc, char **argv)
     if (argc == 1) {
         if (!opt_int(argv[0], &num) || num <= 0)
             goto opthelp;
-    } else if (argc != 0) {
+    } else if (!opt_check_rest_arg(NULL)) {
         goto opthelp;
     }
     if (!app_RAND_load())

--- a/apps/dsa.c
+++ b/apps/dsa.c
@@ -161,14 +161,11 @@ int dsa_main(int argc, char **argv)
     }
 
     /* No extra args. */
-    argc = opt_num_rest();
-    if (argc != 0)
+    if (!opt_check_rest_arg(NULL))
         goto opthelp;
 
-    if (ciphername != NULL) {
-        if (!opt_cipher(ciphername, &enc))
-            goto end;
-    }
+    if (!opt_cipher(ciphername, &enc))
+        goto end;
     private = pubin || pubout ? 0 : 1;
     if (text && !pubin)
         private = 1;

--- a/apps/dsaparam.c
+++ b/apps/dsaparam.c
@@ -133,7 +133,7 @@ int dsaparam_main(int argc, char **argv)
     if (argc == 1) {
         if (!opt_int(argv[0], &num) || num < 0)
             goto opthelp;
-    } else if (argc != 0) {
+    } else if (!opt_check_rest_arg(NULL)) {
         goto opthelp;
     }
     if (!app_RAND_load())

--- a/apps/ec.c
+++ b/apps/ec.c
@@ -157,14 +157,11 @@ int ec_main(int argc, char **argv)
     }
 
     /* No extra arguments. */
-    argc = opt_num_rest();
-    if (argc != 0)
+    if (!opt_check_rest_arg(NULL))
         goto opthelp;
 
-    if (ciphername != NULL) {
-        if (!opt_cipher(ciphername, &enc))
-            goto opthelp;
-    }
+    if (!opt_cipher(ciphername, &enc))
+        goto opthelp;
     private = param_out || pubin || pubout ? 0 : 1;
     if (text && !pubin)
         private = 1;

--- a/apps/ecparam.c
+++ b/apps/ecparam.c
@@ -186,8 +186,7 @@ int ecparam_main(int argc, char **argv)
     }
 
     /* No extra args. */
-    argc = opt_num_rest();
-    if (argc != 0)
+    if (!opt_check_rest_arg(NULL))
         goto opthelp;
 
     if (!app_RAND_load())

--- a/apps/enc.c
+++ b/apps/enc.c
@@ -289,17 +289,14 @@ int enc_main(int argc, char **argv)
     }
 
     /* No extra arguments. */
-    argc = opt_num_rest();
-    if (argc != 0)
+    if (!opt_check_rest_arg(NULL))
         goto opthelp;
     if (!app_RAND_load())
         goto end;
 
     /* Get the cipher name, either from progname (if set) or flag. */
-    if (ciphername != NULL) {
-        if (!opt_cipher(ciphername, &cipher))
-            goto opthelp;
-    }
+    if (!opt_cipher(ciphername, &cipher))
+        goto opthelp;
     if (digestname != NULL) {
         if (!opt_md(digestname, &dgst))
             goto opthelp;

--- a/apps/fipsinstall.c
+++ b/apps/fipsinstall.c
@@ -383,9 +383,12 @@ opthelp:
     }
 
     /* No extra arguments. */
-    argc = opt_num_rest();
-    if (argc != 0 || (verify && in_fname == NULL))
+    if (!opt_check_rest_arg(NULL))
         goto opthelp;
+    if (verify && in_fname == NULL) {
+        BIO_printf(bio_err, "Missing -in option for -verify\n");
+        goto opthelp;
+    }
 
     if (parent_config != NULL) {
         /* Test that a parent config can load the module */

--- a/apps/gendsa.c
+++ b/apps/gendsa.c
@@ -101,19 +101,16 @@ int gendsa_main(int argc, char **argv)
     }
 
     /* One argument, the params file. */
-    argc = opt_num_rest();
-    argv = opt_rest();
-    if (argc != 1)
+    if (!opt_check_rest_arg("params file"))
         goto opthelp;
+    argv = opt_rest();
     dsaparams = argv[0];
 
     if (!app_RAND_load())
         goto end;
 
-    if (ciphername != NULL) {
-        if (!opt_cipher(ciphername, &enc))
-            goto end;
-    }
+    if (!opt_cipher(ciphername, &enc))
+        goto end;
     private = 1;
 
     if (!app_passwd(NULL, passoutarg, NULL, &passout)) {

--- a/apps/genpkey.c
+++ b/apps/genpkey.c
@@ -139,8 +139,7 @@ int genpkey_main(int argc, char **argv)
     }
 
     /* No extra arguments. */
-    argc = opt_num_rest();
-    if (argc != 0)
+    if (!opt_check_rest_arg(NULL))
         goto opthelp;
 
     /* Fetch cipher, etc. */
@@ -163,9 +162,12 @@ int genpkey_main(int argc, char **argv)
             goto end;
         }
     }
-    if (ciphername != NULL)
-        if (!opt_cipher(ciphername, &cipher) || do_param == 1)
-            goto opthelp;
+    if (!opt_cipher(ciphername, &cipher))
+        goto opthelp;
+    if (ciphername != NULL && do_param == 1) {
+        BIO_printf(bio_err, "Cannot use cipher with -genparam option\n");
+        goto opthelp;
+    }
 
     private = do_param ? 0 : 1;
 

--- a/apps/genrsa.c
+++ b/apps/genrsa.c
@@ -157,8 +157,7 @@ opthelp:
                        "Warning: It is not recommended to use more than %d bit for RSA keys.\n"
                        "         Your key size is %d! Larger key size may behave not as expected.\n",
                        OPENSSL_RSA_MAX_MODULUS_BITS, num);
-    } else if (argc > 0) {
-        BIO_printf(bio_err, "Extra arguments given.\n");
+    } else if (!opt_check_rest_arg(NULL)) {
         goto opthelp;
     }
 
@@ -166,10 +165,8 @@ opthelp:
         goto end;
 
     private = 1;
-    if (ciphername != NULL) {
-        if (!opt_cipher(ciphername, &enc))
-            goto end;
-    }
+    if (!opt_cipher(ciphername, &enc))
+        goto end;
     if (!app_passwd(NULL, passoutarg, NULL, &passout)) {
         BIO_printf(bio_err, "Error getting password\n");
         goto end;

--- a/apps/include/opt.h
+++ b/apps/include/opt.h
@@ -368,6 +368,7 @@ char *opt_unknown(void);
 int opt_cipher(const char *name, EVP_CIPHER **cipherp);
 int opt_cipher_any(const char *name, EVP_CIPHER **cipherp);
 int opt_cipher_silent(const char *name, EVP_CIPHER **cipherp);
+int opt_check_md(const char *name);
 int opt_md(const char *name, EVP_MD **mdp);
 int opt_md_silent(const char *name, EVP_MD **mdp);
 
@@ -392,6 +393,7 @@ int opt_provider_option_given(void);
 
 char **opt_rest(void);
 int opt_num_rest(void);
+int opt_check_rest_arg(const char *expected);
 
 /* Returns non-zero if legacy paths are still available */
 int opt_legacy_okay(void);

--- a/apps/info.c
+++ b/apps/info.c
@@ -86,7 +86,7 @@ opthelp:
             break;
         }
     }
-    if (opt_num_rest() != 0)
+    if (!opt_check_rest_arg(NULL))
         goto opthelp;
     if (dirty > 1) {
         BIO_printf(bio_err, "%s: Only one item allowed\n", prog);

--- a/apps/list.c
+++ b/apps/list.c
@@ -1647,7 +1647,7 @@ opthelp:
     }
 
     /* No extra arguments. */
-    if (opt_num_rest() != 0)
+    if (!opt_check_rest_arg(NULL))
         goto opthelp;
 
     if (todo.commands)

--- a/apps/mac.c
+++ b/apps/mac.c
@@ -137,10 +137,9 @@ opthelp:
     }
 
     /* One argument, the MAC name. */
-    argc = opt_num_rest();
-    argv = opt_rest();
-    if (argc != 1)
+    if (!opt_check_rest_arg("MAC name"))
         goto opthelp;
+    argv = opt_rest();
 
     mac = EVP_MAC_fetch(app_get0_libctx(), argv[0], app_get0_propq());
     if (mac == NULL) {

--- a/apps/nseq.c
+++ b/apps/nseq.c
@@ -73,8 +73,7 @@ int nseq_main(int argc, char **argv)
     }
 
     /* No extra arguments. */
-    argc = opt_num_rest();
-    if (argc != 0)
+    if (!opt_check_rest_arg(NULL))
         goto opthelp;
 
     in = bio_open_default(infile, 'r', FORMAT_PEM);

--- a/apps/ocsp.c
+++ b/apps/ocsp.c
@@ -535,8 +535,7 @@ int ocsp_main(int argc, char **argv)
     }
 
     /* No extra arguments. */
-    argc = opt_num_rest();
-    if (argc != 0)
+    if (!opt_check_rest_arg(NULL))
         goto opthelp;
 
     if (trailing_md) {

--- a/apps/openssl.c
+++ b/apps/openssl.c
@@ -354,7 +354,7 @@ int help_main(int argc, char **argv)
         new_argv[2] = NULL;
         return do_cmd(prog_init(), 2, new_argv);
     }
-    if (opt_num_rest() != 0) {
+    if (!opt_check_rest_arg(NULL)) {
         BIO_printf(bio_err, "Usage: %s\n", prog);
         return 1;
     }

--- a/apps/pkcs12.c
+++ b/apps/pkcs12.c
@@ -356,17 +356,14 @@ int pkcs12_main(int argc, char **argv)
     }
 
     /* No extra arguments. */
-    argc = opt_num_rest();
-    if (argc != 0)
+    if (!opt_check_rest_arg(NULL))
         goto opthelp;
 
     if (!app_RAND_load())
         goto end;
 
-    if (ciphername != NULL) {
-        if (!opt_cipher_any(ciphername, &enc))
-            goto opthelp;
-    }
+    if (!opt_cipher_any(ciphername, &enc))
+        goto opthelp;
     if (export_pkcs12) {
         if ((options & INFO) != 0)
             WARN_EXPORT("info");

--- a/apps/pkcs7.c
+++ b/apps/pkcs7.c
@@ -111,8 +111,7 @@ int pkcs7_main(int argc, char **argv)
     }
 
     /* No extra arguments. */
-    argc = opt_num_rest();
-    if (argc != 0)
+    if (!opt_check_rest_arg(NULL))
         goto opthelp;
 
     in = bio_open_default(infile, 'r', informat);

--- a/apps/pkcs8.c
+++ b/apps/pkcs8.c
@@ -193,8 +193,7 @@ int pkcs8_main(int argc, char **argv)
     }
 
     /* No extra arguments. */
-    argc = opt_num_rest();
-    if (argc != 0)
+    if (!opt_check_rest_arg(NULL))
         goto opthelp;
 
     private = 1;

--- a/apps/pkey.c
+++ b/apps/pkey.c
@@ -171,8 +171,7 @@ int pkey_main(int argc, char **argv)
     }
 
     /* No extra arguments. */
-    argc = opt_num_rest();
-    if (argc != 0)
+    if (!opt_check_rest_arg(NULL))
         goto opthelp;
 
     if (text && text_pub)
@@ -190,10 +189,8 @@ int pkey_main(int argc, char **argv)
 
     private = (!noout && !pubout) || (text && !text_pub);
 
-    if (ciphername != NULL) {
-        if (!opt_cipher(ciphername, &cipher))
-            goto opthelp;
-    }
+    if (!opt_cipher(ciphername, &cipher))
+        goto opthelp;
     if (cipher == NULL) {
         if (passoutarg != NULL)
             BIO_printf(bio_err,

--- a/apps/pkeyparam.c
+++ b/apps/pkeyparam.c
@@ -91,8 +91,7 @@ int pkeyparam_main(int argc, char **argv)
     }
 
     /* No extra arguments. */
-    argc = opt_num_rest();
-    if (argc != 0)
+    if (!opt_check_rest_arg(NULL))
         goto opthelp;
 
     in = bio_open_default(infile, 'r', FORMAT_PEM);

--- a/apps/pkeyutl.c
+++ b/apps/pkeyutl.c
@@ -253,8 +253,7 @@ int pkeyutl_main(int argc, char **argv)
     }
 
     /* No extra arguments. */
-    argc = opt_num_rest();
-    if (argc != 0)
+    if (!opt_check_rest_arg(NULL))
         goto opthelp;
 
     if (!app_RAND_load())

--- a/apps/prime.c
+++ b/apps/prime.c
@@ -83,12 +83,12 @@ opthelp:
     }
 
     /* Optional arguments are numbers to check. */
+    if (generate && !opt_check_rest_arg(NULL))
+        goto opthelp;
     argc = opt_num_rest();
     argv = opt_rest();
-    if (generate) {
-        if (argc != 0)
-            goto opthelp;
-    } else if (argc == 0) {
+    if (!generate && argc == 0) {
+        BIO_printf(bio_err, "Missing number (s) to check\n");
         goto opthelp;
     }
 

--- a/apps/rand.c
+++ b/apps/rand.c
@@ -95,7 +95,7 @@ int rand_main(int argc, char **argv)
     if (argc == 1) {
         if (!opt_int(argv[0], &num) || num <= 0)
             goto opthelp;
-    } else if (argc != 0) {
+    } else if (!opt_check_rest_arg(NULL)) {
         goto opthelp;
     }
 

--- a/apps/req.c
+++ b/apps/req.c
@@ -242,7 +242,6 @@ int req_main(int argc, char **argv)
     X509 *new_x509 = NULL, *CAcert = NULL;
     X509_REQ *req = NULL;
     EVP_CIPHER *cipher = NULL;
-    EVP_MD *md = NULL;
     int ext_copy = EXT_COPY_UNSET;
     BIO *addext_bio = NULL;
     char *extensions = NULL;
@@ -476,8 +475,7 @@ int req_main(int argc, char **argv)
     }
 
     /* No extra arguments. */
-    argc = opt_num_rest();
-    if (argc != 0)
+    if (!opt_check_rest_arg(NULL))
         goto opthelp;
 
     if (!app_RAND_load())
@@ -531,11 +529,8 @@ int req_main(int argc, char **argv)
 
     /* Check that any specified digest is fetchable */
     if (digest != NULL) {
-        if (!opt_md(digest, &md)) {
-            ERR_clear_error();
+        if (!opt_check_md(digest))
             goto opthelp;
-        }
-        EVP_MD_free(md);
     } else {
         /* No digest specified, default to configuration */
         p = NCONF_get_string(req_conf, section, "default_md");

--- a/apps/rsa.c
+++ b/apps/rsa.c
@@ -217,14 +217,11 @@ int rsa_main(int argc, char **argv)
     }
 
     /* No extra arguments. */
-    argc = opt_num_rest();
-    if (argc != 0)
+    if (!opt_check_rest_arg(NULL))
         goto opthelp;
 
-    if (ciphername != NULL) {
-        if (!opt_cipher(ciphername, &enc))
-            goto opthelp;
-    }
+    if (!opt_cipher(ciphername, &enc))
+        goto opthelp;
     private = (text && !pubin) || (!pubout && !noout) ? 1 : 0;
 
     if (!app_passwd(passinarg, passoutarg, &passin, &passout)) {

--- a/apps/rsautl.c
+++ b/apps/rsautl.c
@@ -169,8 +169,7 @@ int rsautl_main(int argc, char **argv)
     }
 
     /* No extra arguments. */
-    argc = opt_num_rest();
-    if (argc != 0)
+    if (!opt_check_rest_arg(NULL))
         goto opthelp;
 
     if (!app_RAND_load())

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -1461,8 +1461,7 @@ int s_client_main(int argc, char **argv)
     }
 
     /* Optional argument is connect string if -connect not used. */
-    argc = opt_num_rest();
-    if (argc == 1) {
+    if (opt_num_rest() == 1) {
         /* Don't allow -connect and a separate argument. */
         if (connectstr != NULL) {
             BIO_printf(bio_err,
@@ -1472,7 +1471,7 @@ int s_client_main(int argc, char **argv)
         }
         connect_type = use_inet;
         freeandcopy(&connectstr, *opt_rest());
-    } else if (argc != 0) {
+    } else if (!opt_check_rest_arg(NULL)) {
         goto opthelp;
     }
     if (!app_RAND_load())

--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -1639,8 +1639,7 @@ int s_server_main(int argc, char *argv[])
     }
 
     /* No extra arguments. */
-    argc = opt_num_rest();
-    if (argc != 0)
+    if (!opt_check_rest_arg(NULL))
         goto opthelp;
 
     if (!app_RAND_load())

--- a/apps/s_time.c
+++ b/apps/s_time.c
@@ -234,8 +234,7 @@ int s_time_main(int argc, char **argv)
     }
 
     /* No extra arguments. */
-    argc = opt_num_rest();
-    if (argc != 0)
+    if (!opt_check_rest_arg(NULL))
         goto opthelp;
 
     if (cipher == NULL)

--- a/apps/sess_id.c
+++ b/apps/sess_id.c
@@ -98,8 +98,7 @@ int sess_id_main(int argc, char **argv)
     }
 
     /* No extra arguments. */
-    argc = opt_num_rest();
-    if (argc != 0)
+    if (!opt_check_rest_arg(NULL))
         goto opthelp;
 
     x = load_sess_id(infile, informat);

--- a/apps/smime.c
+++ b/apps/smime.c
@@ -366,10 +366,8 @@ int smime_main(int argc, char **argv)
         if (!opt_md(digestname, &sign_md))
             goto opthelp;
     }
-    if (ciphername != NULL) {
-        if (!opt_cipher_any(ciphername, &cipher))
+    if (!opt_cipher_any(ciphername, &cipher))
             goto opthelp;
-    }
     if (!(operation & SMIME_SIGNERS) && (skkeys != NULL || sksigners != NULL)) {
         BIO_puts(bio_err, "Multiple signers or keys not allowed\n");
         goto opthelp;

--- a/apps/spkac.c
+++ b/apps/spkac.c
@@ -133,8 +133,7 @@ int spkac_main(int argc, char **argv)
     }
 
     /* No extra arguments. */
-    argc = opt_num_rest();
-    if (argc != 0)
+    if (!opt_check_rest_arg(NULL))
         goto opthelp;
 
     if (!app_passwd(passinarg, NULL, &passin, NULL)) {

--- a/apps/storeutl.c
+++ b/apps/storeutl.c
@@ -258,15 +258,12 @@ int storeutl_main(int argc, char *argv[])
     }
 
     /* One argument, the URI */
-    argc = opt_num_rest();
-    argv = opt_rest();
-    if (argc != 1)
+    if (!opt_check_rest_arg("URI"))
         goto opthelp;
+    argv = opt_rest();
 
-    if (digestname != NULL) {
-        if (!opt_md(digestname, &digest))
-            goto opthelp;
-    }
+    if (!opt_md(digestname, &digest))
+        goto opthelp;
 
     if (criterion != 0) {
         switch (criterion) {

--- a/apps/ts.c
+++ b/apps/ts.c
@@ -204,8 +204,10 @@ int ts_main(int argc, char **argv)
         case OPT_QUERY:
         case OPT_REPLY:
         case OPT_VERIFY:
-            if (mode != OPT_ERR)
+            if (mode != OPT_ERR) {
+                BIO_printf(bio_err, "%s: Must give only one of -query, -reply, or -verify\n", prog);
                 goto opthelp;
+            }
             mode = o;
             break;
         case OPT_DATA:
@@ -288,17 +290,18 @@ int ts_main(int argc, char **argv)
     }
 
     /* No extra arguments. */
-    argc = opt_num_rest();
-    if (argc != 0 || mode == OPT_ERR)
+    if (!opt_check_rest_arg(NULL))
         goto opthelp;
+    if (mode == OPT_ERR) {
+        BIO_printf(bio_err, "%s: Must give one of -query, -reply, or -verify\n", prog);
+        goto opthelp;
+    }
 
     if (!app_RAND_load())
         goto end;
 
-    if (digestname != NULL) {
-        if (!opt_md(digestname, &md))
-            goto opthelp;
-    }
+    if (!opt_md(digestname, &md))
+        goto opthelp;
     if (mode == OPT_REPLY && passin &&
         !app_passwd(passin, NULL, &password, NULL)) {
         BIO_printf(bio_err, "Error getting password.\n");

--- a/apps/version.c
+++ b/apps/version.c
@@ -99,8 +99,7 @@ opthelp:
     }
 
     /* No extra arguments. */
-    argc = opt_num_rest();
-    if (argc != 0)
+    if (!opt_check_rest_arg(NULL))
         goto opthelp;
 
     if (!dirty)

--- a/apps/x509.c
+++ b/apps/x509.c
@@ -579,12 +579,14 @@ int x509_main(int argc, char **argv)
     }
 
     /* No extra arguments. */
-    argc = opt_num_rest();
-    if (argc != 0)
+    if (!opt_check_rest_arg(NULL))
         goto opthelp;
 
     if (!app_RAND_load())
         goto end;
+
+    if (!opt_check_md(digest))
+        goto opthelp;
 
     if (preserve_dates && days != UNSET_DAYS) {
         BIO_printf(bio_err, "Cannot use -preserve_dates with -days option\n");


### PR DESCRIPTION
Recently I noticed some glitches (regressions?) on the app diagnostics on missing/extra/wrong options.

For instance, the apps do not show any useful hint on missing args, e.g.,
```
apps/openssl mac
mac: Use -help for summary.
```
or on extra args, e.g.,
```
apps/openssl x509 -in test/testx509.pem WRONG
x509: Use -help for summary.
```

Some error messages are needlessly cryptic, e.g.,
```
apps/openssl x509 -WRONG -new -key test/testrsa.pem -subj /CN=x
00A143BCB07F0000:error:0308010C:digital envelope routines:inner_evp_generic_fetch:unsupported:crypto/evp/evp_fetch.c:346:Global default library context, Algorithm (WRONG : 0), Properties (<null>)
00A143BCB07F0000:error:03000086:digital envelope routines:do_sigver_init:initialization error:crypto/evp/m_sigver.c:188:
```

These are fixed by this PR.
In this occasion I also simplified the use of some related functions from `apps/lib/opt.c`.

After this fix, the output of the above app invocation becomes:
```
mac: Missing argument: MAC name
mac: Use -help for summary.
```
```
x509: Extra option: "WRONG"
x509: Use -help for summary.
```
```
x509: Unknown option or message digest: WRONG
x509: Use -help for summary.
```
