### PR TITLE
Fix no-tls1_3 tests

### DIFF
--- a/.github/workflows/run-checker-ci.yml
+++ b/.github/workflows/run-checker-ci.yml
@@ -20,8 +20,7 @@ jobs:
           no-tests,
           no-threads,
           no-tls,
-# no-tls1_3 temporarily disabled due to failures to be investigated separately
-#          no-tls1_3,
+          no-tls1_3,
           no-ts,
           no-ui,
         ]

--- a/.github/workflows/run-checker-daily.yml
+++ b/.github/workflows/run-checker-daily.yml
@@ -50,8 +50,7 @@ jobs:
           no-egd,
           no-engine,
           no-external-tests,
-# no-tls1_3 temporarily disabled due to failures to be investigated separately
-#          no-tls1_3,
+          no-tls1_3,
           no-fuzz-afl,
           no-fuzz-libfuzzer,
           no-gost,

--- a/test/recipes/80-test_ssl_old.t
+++ b/test/recipes/80-test_ssl_old.t
@@ -519,7 +519,7 @@ sub testssl {
 	    skip "skipping auto PSK tests", 1
 	        if ($no_dh || $no_psk || $no_ec);
 
-	    ok(run(test(['ssltest_old', '-psk', '0102030405', '-cipher', '@SECLEVEL=2:DHE-PSK-AES128-CCM'])),
+	    ok(run(test(['ssltest_old', '-dhe2048', '-psk', '0102030405', '-cipher', '@SECLEVEL=2:DHE-PSK-AES128-CCM'])),
 	       'test auto DH meets security strength');
 	  }
 	}


### PR DESCRIPTION
This recently added test needs DH2048 to work without tls1_3.

Fixes: #16335

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
