### PR TITLE
use ISO 8601 format for the build date

### DIFF
--- a/util/mkbuildinf.pl
+++ b/util/mkbuildinf.pl
@@ -1,5 +1,5 @@
 #! /usr/bin/env perl
-# Copyright 2014-2017 The OpenSSL Project Authors. All Rights Reserved.
+# Copyright 2014-2021 The OpenSSL Project Authors. All Rights Reserved.
 #
 # Licensed under the Apache License 2.0 (the "License").  You may not use
 # this file except in compliance with the License.  You can obtain a copy

--- a/util/mkbuildinf.pl
+++ b/util/mkbuildinf.pl
@@ -8,11 +8,12 @@
 
 use strict;
 use warnings;
+use Time::Piece;
 
 my ($cflags, $platform) = @ARGV;
 $cflags = "compiler: $cflags";
 
-my $date = gmtime($ENV{'SOURCE_DATE_EPOCH'} || time()) . " UTC";
+my $date = gmtime($ENV{'SOURCE_DATE_EPOCH'} || time())->ymd() . " UTC";
 
 print <<"END_OUTPUT";
 /*


### PR DESCRIPTION
This changes existing build date format to the language-agnostic,
easily parsable, sortable, ISO 8601 format: `YYYY-MM-DD`.

With this commit `openssl version` will show:
`OpenSSL 3.0.0-beta2 2021-07-29`
instead of:
`OpenSSL 3.0.0-beta2 29 Jul 2021`

CLA: trivial