### PR TITLE
convert tabs to spaces in two distributed Perl scripts

### DIFF
--- a/apps/tsget.in
+++ b/apps/tsget.in
@@ -53,8 +53,8 @@ sub create_curl {
     $curl->setopt(CURLOPT_UPLOAD, 1);
     $curl->setopt(CURLOPT_CUSTOMREQUEST, "POST");
     $curl->setopt(CURLOPT_HTTPHEADER,
-                ["Content-Type: application/timestamp-query",
-                "Accept: application/timestamp-reply,application/timestamp-response"]);
+        ["Content-Type: application/timestamp-query",
+        "Accept: application/timestamp-reply,application/timestamp-response"]);
     $curl->setopt(CURLOPT_READFUNCTION, \&read_body);
     $curl->setopt(CURLOPT_HEADERFUNCTION, sub { return length($_[0]); });
 
@@ -63,8 +63,8 @@ sub create_curl {
 
     # SSL related options.
     $curl->setopt(CURLOPT_SSLKEYTYPE, "PEM");
-    $curl->setopt(CURLOPT_SSL_VERIFYPEER, 1);        # Verify server's certificate.
-    $curl->setopt(CURLOPT_SSL_VERIFYHOST, 2);        # Check server's CN.
+    $curl->setopt(CURLOPT_SSL_VERIFYPEER, 1);    # Verify server's certificate.
+    $curl->setopt(CURLOPT_SSL_VERIFYHOST, 2);    # Check server's CN.
     $curl->setopt(CURLOPT_SSLKEY, $options{k}) if defined($options{k});
     $curl->setopt(CURLOPT_SSLKEYPASSWD, $options{p}) if defined($options{p});
     $curl->setopt(CURLOPT_SSLCERT, $options{c}) if defined($options{c});

--- a/apps/tsget.in
+++ b/apps/tsget.in
@@ -21,10 +21,10 @@ sub read_body {
     my $return_data = "";
     my $data_len = length ${$state->{data}};
     if ($state->{bytes} < $data_len) {
-	$data_len = $data_len - $state->{bytes};
-	$data_len = $maxlength if $data_len > $maxlength;
-	$return_data = substr ${$state->{data}}, $state->{bytes}, $data_len;
-	$state->{bytes} += $data_len;
+        $data_len = $data_len - $state->{bytes};
+        $data_len = $maxlength if $data_len > $maxlength;
+        $return_data = substr ${$state->{data}}, $state->{bytes}, $data_len;
+        $state->{bytes} += $data_len;
     }
     return $return_data;
 }
@@ -53,8 +53,8 @@ sub create_curl {
     $curl->setopt(CURLOPT_UPLOAD, 1);
     $curl->setopt(CURLOPT_CUSTOMREQUEST, "POST");
     $curl->setopt(CURLOPT_HTTPHEADER,
-		["Content-Type: application/timestamp-query",
-		"Accept: application/timestamp-reply,application/timestamp-response"]);
+                ["Content-Type: application/timestamp-query",
+                "Accept: application/timestamp-reply,application/timestamp-response"]);
     $curl->setopt(CURLOPT_READFUNCTION, \&read_body);
     $curl->setopt(CURLOPT_HEADERFUNCTION, sub { return length($_[0]); });
 
@@ -63,8 +63,8 @@ sub create_curl {
 
     # SSL related options.
     $curl->setopt(CURLOPT_SSLKEYTYPE, "PEM");
-    $curl->setopt(CURLOPT_SSL_VERIFYPEER, 1);	# Verify server's certificate.
-    $curl->setopt(CURLOPT_SSL_VERIFYHOST, 2);	# Check server's CN.
+    $curl->setopt(CURLOPT_SSL_VERIFYPEER, 1);        # Verify server's certificate.
+    $curl->setopt(CURLOPT_SSL_VERIFYHOST, 2);        # Check server's CN.
     $curl->setopt(CURLOPT_SSLKEY, $options{k}) if defined($options{k});
     $curl->setopt(CURLOPT_SSLKEYPASSWD, $options{p}) if defined($options{p});
     $curl->setopt(CURLOPT_SSLCERT, $options{c}) if defined($options{c});
@@ -101,15 +101,15 @@ sub get_timestamp {
     my $error_string;
     if ($error_code != 0) {
         my $http_code = $curl->getinfo(CURLINFO_HTTP_CODE);
-	$error_string = "could not get timestamp";
-	$error_string .= ", http code: $http_code" unless $http_code == 0;
-	$error_string .= ", curl code: $error_code";
-	$error_string .= " ($::error_buf)" if defined($::error_buf);
+        $error_string = "could not get timestamp";
+        $error_string .= ", http code: $http_code" unless $http_code == 0;
+        $error_string .= ", curl code: $error_code";
+        $error_string .= " ($::error_buf)" if defined($::error_buf);
     } else {
         my $ct = $curl->getinfo(CURLINFO_CONTENT_TYPE);
-	if (lc($ct) ne "application/timestamp-reply"
-	    && lc($ct) ne "application/timestamp-response") {
-	    $error_string = "unexpected content type returned: $ct";
+        if (lc($ct) ne "application/timestamp-reply"
+            && lc($ct) ne "application/timestamp-response") {
+            $error_string = "unexpected content type returned: $ct";
         }
     }
     return ($ts_body, $error_string);
@@ -163,15 +163,15 @@ REQUEST: foreach (@ARGV) {
     # Read request.
     my $body;
     if ($input eq "-") {
-	# Read the request from STDIN;
-	$body = <STDIN>;
+        # Read the request from STDIN;
+        $body = <STDIN>;
     } else {
-	# Read the request from file.
+        # Read the request from file.
         open INPUT, "<" . $input
-	    or warn("$input: could not open input file: $!\n"), next REQUEST;
+            or warn("$input: could not open input file: $!\n"), next REQUEST;
         $body = <INPUT>;
         close INPUT
-	    or warn("$input: could not close input file: $!\n"), next REQUEST;
+            or warn("$input: could not close input file: $!\n"), next REQUEST;
     }
 
     # Send request.
@@ -179,21 +179,21 @@ REQUEST: foreach (@ARGV) {
 
     my ($ts_body, $error) = get_timestamp $curl, \$body;
     if (defined($error)) {
-	die "$input: fatal error: $error\n";
+        die "$input: fatal error: $error\n";
     }
     STDERR->printflush(", reply received") if $options{v};
 
     # Write response.
     if ($output eq "-") {
-	# Write to STDOUT.
+        # Write to STDOUT.
         print $ts_body;
     } else {
-	# Write to file.
+        # Write to file.
         open OUTPUT, ">", $output
-	    or warn("$output: could not open output file: $!\n"), next REQUEST;
+            or warn("$output: could not open output file: $!\n"), next REQUEST;
         print OUTPUT $ts_body;
         close OUTPUT
-	    or warn("$output: could not close output file: $!\n"), next REQUEST;
+            or warn("$output: could not close output file: $!\n"), next REQUEST;
     }
     STDERR->printflush(", $output written.\n") if $options{v};
 }

--- a/tools/c_rehash.in
+++ b/tools/c_rehash.in
@@ -28,35 +28,35 @@ while ( $ARGV[0] =~ /^-/ ) {
     my $flag = shift @ARGV;
     last if ( $flag eq '--');
     if ( $flag eq '-old') {
-	    $x509hash = "-subject_hash_old";
-	    $crlhash = "-hash_old";
+        $x509hash = "-subject_hash_old";
+        $crlhash = "-hash_old";
     } elsif ( $flag eq '-h' || $flag eq '-help' ) {
-	    help();
+        help();
     } elsif ( $flag eq '-n' ) {
-	    $removelinks = 0;
+        $removelinks = 0;
     } elsif ( $flag eq '-v' ) {
-	    $verbose++;
+        $verbose++;
     }
     else {
-	    print STDERR "Usage error; try -h.\n";
-	    exit 1;
+        print STDERR "Usage error; try -h.\n";
+        exit 1;
     }
 }
 
 sub help {
-	print "Usage: c_rehash [-old] [-h] [-help] [-v] [dirs...]\n";
-	print "   -old use old-style digest\n";
-	print "   -h or -help print this help text\n";
-	print "   -v print files removed and linked\n";
-	exit 0;
+    print "Usage: c_rehash [-old] [-h] [-help] [-v] [dirs...]\n";
+    print "   -old use old-style digest\n";
+    print "   -h or -help print this help text\n";
+    print "   -v print files removed and linked\n";
+    exit 0;
 }
 
 eval "require Cwd";
 if (defined(&Cwd::getcwd)) {
-	$pwd=Cwd::getcwd();
+    $pwd=Cwd::getcwd();
 } else {
-	$pwd=`pwd`;
-	chomp($pwd);
+    $pwd=`pwd`;
+    chomp($pwd);
 }
 
 # DOS/Win32 or Unix delimiter?  Prefix our installdir, then search.
@@ -64,92 +64,92 @@ my $path_delim = ($pwd =~ /^[a-z]\:/i) ? ';' : ':';
 $ENV{PATH} = "$prefix/bin" . ($ENV{PATH} ? $path_delim . $ENV{PATH} : "");
 
 if (! -x $openssl) {
-	my $found = 0;
-	foreach (split /$path_delim/, $ENV{PATH}) {
-		if (-x "$_/$openssl") {
-			$found = 1;
-			$openssl = "$_/$openssl";
-			last;
-		}	
-	}
-	if ($found == 0) {
-		print STDERR "c_rehash: rehashing skipped ('openssl' program not available)\n";
-		exit 0;
-	}
+    my $found = 0;
+    foreach (split /$path_delim/, $ENV{PATH}) {
+        if (-x "$_/$openssl") {
+            $found = 1;
+            $openssl = "$_/$openssl";
+            last;
+        }
+    }
+    if ($found == 0) {
+        print STDERR "c_rehash: rehashing skipped ('openssl' program not available)\n";
+        exit 0;
+    }
 }
 
 if (@ARGV) {
-	@dirlist = @ARGV;
+    @dirlist = @ARGV;
 } elsif ($ENV{SSL_CERT_DIR}) {
-	@dirlist = split /$path_delim/, $ENV{SSL_CERT_DIR};
+    @dirlist = split /$path_delim/, $ENV{SSL_CERT_DIR};
 } else {
-	$dirlist[0] = "$dir/certs";
+    $dirlist[0] = "$dir/certs";
 }
 
 if (-d $dirlist[0]) {
-	chdir $dirlist[0];
-	$openssl="$pwd/$openssl" if (!-x $openssl);
-	chdir $pwd;
+    chdir $dirlist[0];
+    $openssl="$pwd/$openssl" if (!-x $openssl);
+    chdir $pwd;
 }
 
 foreach (@dirlist) {
-	if (-d $_ ) {
-            if ( -w $_) {
-		hash_dir($_);
-            } else {
-                print "Skipping $_, can't write\n";
-                $errorcount++;
-            }
-	}
+    if (-d $_ ) {
+        if ( -w $_) {
+            hash_dir($_);
+        } else {
+            print "Skipping $_, can't write\n";
+            $errorcount++;
+        }
+    }
 }
 exit($errorcount);
 
 sub hash_dir {
-	my %hashlist;
-	print "Doing $_[0]\n";
-	chdir $_[0];
-	opendir(DIR, ".");
-	my @flist = sort readdir(DIR);
-	closedir DIR;
-	if ( $removelinks ) {
-		# Delete any existing symbolic links
-		foreach (grep {/^[\da-f]+\.r{0,1}\d+$/} @flist) {
-			if (-l $_) {
-				print "unlink $_" if $verbose;
-				unlink $_ || warn "Can't unlink $_, $!\n";
-			}
-		}
-	}
-	FILE: foreach $fname (grep {/\.(pem)|(crt)|(cer)|(crl)$/} @flist) {
-		# Check to see if certificates and/or CRLs present.
-		my ($cert, $crl) = check_file($fname);
-		if (!$cert && !$crl) {
-			print STDERR "WARNING: $fname does not contain a certificate or CRL: skipping\n";
-			next;
-		}
-		link_hash_cert($fname) if ($cert);
-		link_hash_crl($fname) if ($crl);
-	}
+    my %hashlist;
+    print "Doing $_[0]\n";
+    chdir $_[0];
+    opendir(DIR, ".");
+    my @flist = sort readdir(DIR);
+    closedir DIR;
+    if ( $removelinks ) {
+        # Delete any existing symbolic links
+        foreach (grep {/^[\da-f]+\.r{0,1}\d+$/} @flist) {
+            if (-l $_) {
+                print "unlink $_" if $verbose;
+                unlink $_ || warn "Can't unlink $_, $!\n";
+            }
+        }
+    }
+    FILE: foreach $fname (grep {/\.(pem)|(crt)|(cer)|(crl)$/} @flist) {
+        # Check to see if certificates and/or CRLs present.
+        my ($cert, $crl) = check_file($fname);
+        if (!$cert && !$crl) {
+            print STDERR "WARNING: $fname does not contain a certificate or CRL: skipping\n";
+            next;
+        }
+        link_hash_cert($fname) if ($cert);
+        link_hash_crl($fname) if ($crl);
+    }
 }
 
 sub check_file {
-	my ($is_cert, $is_crl) = (0,0);
-	my $fname = $_[0];
-	open IN, $fname;
-	while(<IN>) {
-		if (/^-----BEGIN (.*)-----/) {
-			my $hdr = $1;
-			if ($hdr =~ /^(X509 |TRUSTED |)CERTIFICATE$/) {
-				$is_cert = 1;
-				last if ($is_crl);
-			} elsif ($hdr eq "X509 CRL") {
-				$is_crl = 1;
-				last if ($is_cert);
-			}
-		}
-	}
-	close IN;
-	return ($is_cert, $is_crl);
+    my ($is_cert, $is_crl) = (0,0);
+    my $fname = $_[0];
+    open IN, $fname;
+    while(<IN>) {
+        if (/^-----BEGIN (.*)-----/) {
+            my $hdr = $1;
+            if ($hdr =~ /^(X509 |TRUSTED |)CERTIFICATE$/) {
+                $is_cert = 1;
+                last if ($is_crl);
+            } elsif ($hdr eq "X509 CRL") {
+                $is_crl = 1;
+                last if ($is_cert);
+            }
+        }
+    }
+    close IN;
+    return ($is_cert, $is_crl);
 }
 
 
@@ -160,72 +160,72 @@ sub check_file {
 # certificate fingerprints
 
 sub link_hash_cert {
-		my $fname = $_[0];
-		$fname =~ s/\"/\\\"/g;
-		my ($hash, $fprint) = `"$openssl" x509 $x509hash -fingerprint -noout -in "$fname"`;
-		chomp $hash;
-		chomp $fprint;
-		$fprint =~ s/^.*=//;
-		$fprint =~ tr/://d;
-		my $suffix = 0;
-		# Search for an unused hash filename
-		while(exists $hashlist{"$hash.$suffix"}) {
-			# Hash matches: if fingerprint matches its a duplicate cert
-			if ($hashlist{"$hash.$suffix"} eq $fprint) {
-				print STDERR "WARNING: Skipping duplicate certificate $fname\n";
-				return;
-			}
-			$suffix++;
-		}
-		$hash .= ".$suffix";
-		if ($symlink_exists) {
-			print "link $fname -> $hash\n" if $verbose;
-			symlink $fname, $hash || warn "Can't symlink, $!";
-		} else {
-			print "copy $fname -> $hash\n" if $verbose;
-                        if (open($in, "<", $fname)) {
-                            if (open($out,">", $hash)) {
-                                print $out $_ while (<$in>);
-                                close $out;
-                            } else {
-                                warn "can't open $hash for write, $!";
-                            }
-                            close $in;
-                        } else {
-                            warn "can't open $fname for read, $!";
-                        }
-		}
-		$hashlist{$hash} = $fprint;
+    my $fname = $_[0];
+    $fname =~ s/\"/\\\"/g;
+    my ($hash, $fprint) = `"$openssl" x509 $x509hash -fingerprint -noout -in "$fname"`;
+    chomp $hash;
+    chomp $fprint;
+    $fprint =~ s/^.*=//;
+    $fprint =~ tr/://d;
+    my $suffix = 0;
+    # Search for an unused hash filename
+    while(exists $hashlist{"$hash.$suffix"}) {
+        # Hash matches: if fingerprint matches its a duplicate cert
+        if ($hashlist{"$hash.$suffix"} eq $fprint) {
+            print STDERR "WARNING: Skipping duplicate certificate $fname\n";
+            return;
+        }
+        $suffix++;
+    }
+    $hash .= ".$suffix";
+    if ($symlink_exists) {
+        print "link $fname -> $hash\n" if $verbose;
+        symlink $fname, $hash || warn "Can't symlink, $!";
+    } else {
+        print "copy $fname -> $hash\n" if $verbose;
+        if (open($in, "<", $fname)) {
+            if (open($out,">", $hash)) {
+                print $out $_ while (<$in>);
+                close $out;
+            } else {
+                warn "can't open $hash for write, $!";
+            }
+            close $in;
+        } else {
+            warn "can't open $fname for read, $!";
+        }
+    }
+    $hashlist{$hash} = $fprint;
 }
 
 # Same as above except for a CRL. CRL links are of the form <hash>.r<n>
 
 sub link_hash_crl {
-		my $fname = $_[0];
-		$fname =~ s/'/'\\''/g;
-		my ($hash, $fprint) = `"$openssl" crl $crlhash -fingerprint -noout -in '$fname'`;
-		chomp $hash;
-		chomp $fprint;
-		$fprint =~ s/^.*=//;
-		$fprint =~ tr/://d;
-		my $suffix = 0;
-		# Search for an unused hash filename
-		while(exists $hashlist{"$hash.r$suffix"}) {
-			# Hash matches: if fingerprint matches its a duplicate cert
-			if ($hashlist{"$hash.r$suffix"} eq $fprint) {
-				print STDERR "WARNING: Skipping duplicate CRL $fname\n";
-				return;
-			}
-			$suffix++;
-		}
-		$hash .= ".r$suffix";
-		if ($symlink_exists) {
-			print "link $fname -> $hash\n" if $verbose;
-			symlink $fname, $hash || warn "Can't symlink, $!";
-		} else {
-			print "cp $fname -> $hash\n" if $verbose;
-			system ("cp", $fname, $hash);
-                        warn "Can't copy, $!" if ($? >> 8) != 0;
-		}
-		$hashlist{$hash} = $fprint;
+    my $fname = $_[0];
+    $fname =~ s/'/'\\''/g;
+    my ($hash, $fprint) = `"$openssl" crl $crlhash -fingerprint -noout -in '$fname'`;
+    chomp $hash;
+    chomp $fprint;
+    $fprint =~ s/^.*=//;
+    $fprint =~ tr/://d;
+    my $suffix = 0;
+    # Search for an unused hash filename
+    while(exists $hashlist{"$hash.r$suffix"}) {
+        # Hash matches: if fingerprint matches its a duplicate cert
+        if ($hashlist{"$hash.r$suffix"} eq $fprint) {
+            print STDERR "WARNING: Skipping duplicate CRL $fname\n";
+            return;
+        }
+        $suffix++;
+    }
+    $hash .= ".r$suffix";
+    if ($symlink_exists) {
+        print "link $fname -> $hash\n" if $verbose;
+        symlink $fname, $hash || warn "Can't symlink, $!";
+    } else {
+        print "cp $fname -> $hash\n" if $verbose;
+        system ("cp", $fname, $hash);
+        warn "Can't copy, $!" if ($? >> 8) != 0;
+    }
+    $hashlist{$hash} = $fprint;
 }


### PR DESCRIPTION
Also fix indentation in `c_rehash.in` to 4 spaces, where a mixture of 4 and 8 spaces was used before, in addition to tabs.

CLA: trivial

This PR without whitespace changes:
https://github.com/openssl/openssl/pull/16459/files?w=1
