### PR TITLE
evp: Simplify aead cipher definition and use functions instead of direct structure field references

### DIFF
--- a/crypto/evp/e_aes.c
+++ b/crypto/evp/e_aes.c
@@ -1580,7 +1580,7 @@ static int s390x_aes_gcm_tls_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
      * communication to fail after 2^64 - 1 keys.  We do this on the encrypting
      * side only.
      */
-    if (ctx->encrypt && ++gctx->tls_enc_records == 0) {
+    if (enc && ++gctx->tls_enc_records == 0) {
         ERR_raise(ERR_LIB_EVP, EVP_R_TOO_MANY_RECORDS);
         goto err;
     }
@@ -2803,7 +2803,7 @@ static int aes_gcm_tls_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
      * communication to fail after 2^64 - 1 keys.  We do this on the encrypting
      * side only.
      */
-    if (ctx->encrypt && ++gctx->tls_enc_records == 0) {
+    if (EVP_CIPHER_CTX_is_encrypting(ctx) && ++gctx->tls_enc_records == 0) {
         ERR_raise(ERR_LIB_EVP, EVP_R_TOO_MANY_RECORDS);
         goto err;
     }
@@ -2812,18 +2812,20 @@ static int aes_gcm_tls_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
      * Set IV from start of buffer or generate IV and write to start of
      * buffer.
      */
-    if (EVP_CIPHER_CTX_ctrl(ctx, ctx->encrypt ? EVP_CTRL_GCM_IV_GEN
-                                              : EVP_CTRL_GCM_SET_IV_INV,
+    if (EVP_CIPHER_CTX_ctrl(ctx,
+                            EVP_CIPHER_CTX_is_encrypting(ctx) ?
+                                EVP_CTRL_GCM_IV_GEN : EVP_CTRL_GCM_SET_IV_INV,
                             EVP_GCM_TLS_EXPLICIT_IV_LEN, out) <= 0)
         goto err;
     /* Use saved AAD */
-    if (CRYPTO_gcm128_aad(&gctx->gcm, ctx->buf, gctx->tls_aad_len))
+    if (CRYPTO_gcm128_aad(&gctx->gcm, EVP_CIPHER_CTX_buf_noconst(ctx),
+                          gctx->tls_aad_len))
         goto err;
     /* Fix buffer and length to point to payload */
     in += EVP_GCM_TLS_EXPLICIT_IV_LEN;
     out += EVP_GCM_TLS_EXPLICIT_IV_LEN;
     len -= EVP_GCM_TLS_EXPLICIT_IV_LEN + EVP_GCM_TLS_TAG_LEN;
-    if (ctx->encrypt) {
+    if (EVP_CIPHER_CTX_is_encrypting(ctx)) {
         /* Encrypt payload */
         if (gctx->ctr) {
             size_t bulk = 0;
@@ -2902,9 +2904,11 @@ static int aes_gcm_tls_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
                 goto err;
         }
         /* Retrieve tag */
-        CRYPTO_gcm128_tag(&gctx->gcm, ctx->buf, EVP_GCM_TLS_TAG_LEN);
+        CRYPTO_gcm128_tag(&gctx->gcm, EVP_CIPHER_CTX_buf_noconst(ctx),
+                          EVP_GCM_TLS_TAG_LEN);
         /* If tag mismatch wipe buffer */
-        if (CRYPTO_memcmp(ctx->buf, in + len, EVP_GCM_TLS_TAG_LEN)) {
+        if (CRYPTO_memcmp(EVP_CIPHER_CTX_buf_noconst(ctx), in + len,
+                          EVP_GCM_TLS_TAG_LEN)) {
             OPENSSL_cleanse(out, len);
             goto err;
         }
@@ -2961,7 +2965,7 @@ static int aes_gcm_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
      * where setting the IV externally is the only option available.
      */
     if (!gctx->iv_set) {
-        if (!ctx->encrypt || !aes_gcm_iv_generate(gctx, 0))
+        if (!EVP_CIPHER_CTX_is_encrypting(ctx) || !aes_gcm_iv_generate(gctx, 0))
             return -1;
         CRYPTO_gcm128_setiv(&gctx->gcm, gctx->iv, gctx->ivlen);
         gctx->iv_set = 1;
@@ -2976,7 +2980,7 @@ static int aes_gcm_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
         if (out == NULL) {
             if (CRYPTO_gcm128_aad(&gctx->gcm, in, len))
                 return -1;
-        } else if (ctx->encrypt) {
+        } else if (EVP_CIPHER_CTX_is_encrypting(ctx)) {
             if (gctx->ctr) {
                 size_t bulk = 0;
 #if defined(AES_GCM_ASM)
@@ -3067,15 +3071,17 @@ static int aes_gcm_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
         }
         return len;
     } else {
-        if (!ctx->encrypt) {
+        if (!EVP_CIPHER_CTX_is_encrypting(ctx)) {
             if (gctx->taglen < 0)
                 return -1;
-            if (CRYPTO_gcm128_finish(&gctx->gcm, ctx->buf, gctx->taglen) != 0)
+            if (CRYPTO_gcm128_finish(&gctx->gcm,
+                                     EVP_CIPHER_CTX_buf_noconst(ctx),
+                                     gctx->taglen) != 0)
                 return -1;
             gctx->iv_set = 0;
             return 0;
         }
-        CRYPTO_gcm128_tag(&gctx->gcm, ctx->buf, 16);
+        CRYPTO_gcm128_tag(&gctx->gcm, EVP_CIPHER_CTX_buf_noconst(ctx), 16);
         gctx->taglen = 16;
         /* Don't reuse the IV */
         gctx->iv_set = 0;

--- a/crypto/evp/e_aria.c
+++ b/crypto/evp/e_aria.c
@@ -765,10 +765,10 @@ static int aria_ccm_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
                           | EVP_CIPH_CUSTOM_COPY | EVP_CIPH_FLAG_AEAD_CIPHER \
                           | EVP_CIPH_CUSTOM_IV_LENGTH)
 
-#define BLOCK_CIPHER_aead(nid,keylen,blocksize,ivlen,nmode,mode,MODE,flags) \
+#define BLOCK_CIPHER_aead(keylen,mode,MODE)        \
 static const EVP_CIPHER aria_##keylen##_##mode = { \
-        nid##_##keylen##_##nmode,                  \
-        blocksize, keylen/8, ivlen,                \
+        NID_aria_##keylen##_##mode,                \
+        1, keylen/8, 12,                           \
         ARIA_AUTH_FLAGS|EVP_CIPH_##MODE##_MODE,    \
         EVP_ORIG_GLOBAL,                           \
         aria_##mode##_init_key,                    \
@@ -779,12 +779,12 @@ static const EVP_CIPHER aria_##keylen##_##mode = { \
 const EVP_CIPHER *EVP_aria_##keylen##_##mode(void) \
 { return (EVP_CIPHER*)&aria_##keylen##_##mode; }
 
-BLOCK_CIPHER_aead(NID_aria, 128, 1, 12, gcm, gcm, GCM, 0)
-BLOCK_CIPHER_aead(NID_aria, 192, 1, 12, gcm, gcm, GCM, 0)
-BLOCK_CIPHER_aead(NID_aria, 256, 1, 12, gcm, gcm, GCM, 0)
+BLOCK_CIPHER_aead(128, gcm, GCM)
+BLOCK_CIPHER_aead(192, gcm, GCM)
+BLOCK_CIPHER_aead(256, gcm, GCM)
 
-BLOCK_CIPHER_aead(NID_aria, 128, 1, 12, ccm, ccm, CCM, 0)
-BLOCK_CIPHER_aead(NID_aria, 192, 1, 12, ccm, ccm, CCM, 0)
-BLOCK_CIPHER_aead(NID_aria, 256, 1, 12, ccm, ccm, CCM, 0)
+BLOCK_CIPHER_aead(128, ccm, CCM)
+BLOCK_CIPHER_aead(192, ccm, CCM)
+BLOCK_CIPHER_aead(256, ccm, CCM)
 
 #endif

--- a/crypto/evp/e_chacha20_poly1305.c
+++ b/crypto/evp/e_chacha20_poly1305.c
@@ -239,7 +239,7 @@ static int chacha20_poly1305_tls_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
         actx->len.text = plen;
 
         if (plen) {
-            if (ctx->encrypt)
+            if (EVP_CIPHER_CTX_is_encrypting(ctx))
                 ctr = xor128_encrypt_n_pad(out, in, ctr, plen);
             else
                 ctr = xor128_decrypt_n_pad(out, in, ctr, plen);
@@ -263,7 +263,7 @@ static int chacha20_poly1305_tls_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
         actx->len.aad = EVP_AEAD_TLS1_AAD_LEN;
         actx->len.text = plen;
 
-        if (ctx->encrypt) {
+        if (EVP_CIPHER_CTX_is_encrypting(ctx)) {
             for (i = 0; i < plen; i++) {
                 out[i] = ctr[i] ^= in[i];
             }
@@ -297,7 +297,7 @@ static int chacha20_poly1305_tls_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
         actx->len.aad = EVP_AEAD_TLS1_AAD_LEN;
         actx->len.text = plen;
 
-        if (ctx->encrypt) {
+        if (EVP_CIPHER_CTX_is_encrypting(ctx)) {
             ChaCha20_ctr32(out, in, plen, actx->key.key.d, actx->key.counter);
             Poly1305_Update(POLY1305_ctx(actx), out, plen);
         } else {
@@ -340,12 +340,12 @@ static int chacha20_poly1305_tls_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
 
     Poly1305_Update(POLY1305_ctx(actx), tohash, tohash_len);
     OPENSSL_cleanse(buf, buf_len);
-    Poly1305_Final(POLY1305_ctx(actx), ctx->encrypt ? actx->tag
-                                                    : tohash);
+    Poly1305_Final(POLY1305_ctx(actx),
+                   EVP_CIPHER_CTX_is_encrypting(ctx) ? actx->tag : tohash);
 
     actx->tls_payload_length = NO_TLS_PAYLOAD_LENGTH;
 
-    if (ctx->encrypt) {
+    if (EVP_CIPHER_CTX_is_encrypting(ctx)) {
         memcpy(out, actx->tag, POLY1305_BLOCK_SIZE);
     } else {
         if (CRYPTO_memcmp(tohash, in, POLY1305_BLOCK_SIZE)) {
@@ -408,7 +408,7 @@ static int chacha20_poly1305_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
             else if (len != plen + POLY1305_BLOCK_SIZE)
                 return -1;
 
-            if (ctx->encrypt) {                 /* plaintext */
+            if (EVP_CIPHER_CTX_is_encrypting(ctx)) {    /* plaintext */
                 chacha_cipher(ctx, out, in, plen);
                 Poly1305_Update(POLY1305_ctx(actx), out, plen);
                 in += plen;
@@ -463,12 +463,12 @@ static int chacha20_poly1305_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
 
             Poly1305_Update(POLY1305_ctx(actx), temp, POLY1305_BLOCK_SIZE);
         }
-        Poly1305_Final(POLY1305_ctx(actx), ctx->encrypt ? actx->tag
-                                                        : temp);
+        Poly1305_Final(POLY1305_ctx(actx),
+                       EVP_CIPHER_CTX_is_encrypting(ctx) ? actx->tag : temp);
         actx->mac_inited = 0;
 
         if (in != NULL && len != plen) {        /* tls mode */
-            if (ctx->encrypt) {
+            if (EVP_CIPHER_CTX_is_encrypting(ctx)) {
                 memcpy(out, actx->tag, POLY1305_BLOCK_SIZE);
             } else {
                 if (CRYPTO_memcmp(temp, in, POLY1305_BLOCK_SIZE)) {
@@ -477,7 +477,7 @@ static int chacha20_poly1305_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
                 }
             }
         }
-        else if (!ctx->encrypt) {
+        else if (!EVP_CIPHER_CTX_is_encrypting(ctx)) {
             if (CRYPTO_memcmp(temp, actx->tag, actx->tag_len))
                 return -1;
         }
@@ -561,7 +561,8 @@ static int chacha20_poly1305_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg,
         return 1;
 
     case EVP_CTRL_AEAD_GET_TAG:
-        if (arg <= 0 || arg > POLY1305_BLOCK_SIZE || !ctx->encrypt)
+        if (arg <= 0 || arg > POLY1305_BLOCK_SIZE ||
+                !EVP_CIPHER_CTX_is_encrypting(ctx))
             return 0;
         memcpy(ptr, actx->tag, arg);
         return 1;
@@ -577,7 +578,7 @@ static int chacha20_poly1305_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg,
             len = aad[EVP_AEAD_TLS1_AAD_LEN - 2] << 8 |
                   aad[EVP_AEAD_TLS1_AAD_LEN - 1];
             aad = actx->tls_aad;
-            if (!ctx->encrypt) {
+            if (!EVP_CIPHER_CTX_is_encrypting(ctx)) {
                 if (len < POLY1305_BLOCK_SIZE)
                     return 0;
                 len -= POLY1305_BLOCK_SIZE;     /* discount attached tag */


### PR DESCRIPTION
ARIA: Remove fixed macro variables, only keep the cipher mode name and key length.

AES and chacha20poly1305 also have some codes that directly reference the fields in the EVP_CIPHER_CTX structure, such as 'ctx->buf' and 'ctx->encrypt', in order to make the code style uniform, use the corresponding interface API instead of direct field references.