### PR TITLE
Fix OSSL_STORE 'file:' scheme implementation so it ignores objects in PEM files that the user isn't interested in

### DIFF
--- a/crypto/encode_decode/decoder_pkey.c
+++ b/crypto/encode_decode/decoder_pkey.c
@@ -215,32 +215,6 @@ static void collect_keymgmt(EVP_KEYMGMT *keymgmt, void *arg)
     }
 }
 
-/*
- * The input structure check is only done on the initial decoder
- * implementations.
- */
-static int decoder_check_input_structure(OSSL_DECODER_CTX *ctx,
-                                         OSSL_DECODER_INSTANCE *di)
-{
-    int di_is_was_set = 0;
-    const char *di_is =
-        OSSL_DECODER_INSTANCE_get_input_structure(di, &di_is_was_set);
-
-    /*
-     * If caller didn't give an input structure name, the decoder is accepted
-     * unconditionally with regards to the input structure.
-     */
-    if (ctx->input_structure == NULL)
-        return 1;
-    /*
-     * If the caller did give an input structure name, the decoder must have
-     * a matching input structure to be accepted.
-     */
-    if (di_is != NULL && strcasecmp(ctx->input_structure, di_is) == 0)
-        return 1;
-    return 0;
-}
-
 struct collect_decoder_data_st {
     STACK_OF(OPENSSL_CSTRING) *names;
     OSSL_DECODER_CTX *ctx;
@@ -310,15 +284,6 @@ static void collect_decoder(OSSL_DECODER *decoder, void *arg)
                            OSSL_DECODER_get0_properties(decoder));
             } OSSL_TRACE_END(DECODER);
 
-            if (!decoder_check_input_structure(data->ctx, di)) {
-                OSSL_TRACE_BEGIN(DECODER) {
-                    BIO_printf(trc_out,
-                               "    REJECTED: not the desired input structure\n");
-                } OSSL_TRACE_END(DECODER);
-                ossl_decoder_instance_free(di);
-                /* Not a fatal error. Just return */
-                return;
-            }
             if (!ossl_decoder_ctx_add_decoder_inst(data->ctx, di)) {
                 ossl_decoder_instance_free(di);
                 data->error_occurred = 1;

--- a/providers/encoders.inc
+++ b/providers/encoders.inc
@@ -15,6 +15,7 @@
 #define ENCODER_STRUCTURE_type_specific_params          "type-specific"
 #define ENCODER_STRUCTURE_type_specific                 "type-specific"
 #define ENCODER_STRUCTURE_type_specific_no_pub          "type-specific"
+#define ENCODER_STRUCTURE_EncryptedPrivateKeyInfo       "EncryptedPrivateKeyInfo"
 #define ENCODER_STRUCTURE_PrivateKeyInfo                "PrivateKeyInfo"
 #define ENCODER_STRUCTURE_SubjectPublicKeyInfo          "SubjectPublicKeyInfo"
 #define ENCODER_STRUCTURE_DH                            "dh"
@@ -127,28 +128,36 @@ ENCODER("DSA", dsa, yes, pvk),
 #endif
 
 /*
- * Entries for PKCS#8 (PrivateKeyInfo) and SubjectPublicKeyInfo.
- * The "der" ones are added convenience for any user that wants to use
- * OSSL_ENCODER directly.
+ * Entries for encrypted PKCS#8 (EncryptedPrivateKeyInfo), unencrypted PKCS#8
+ * (PrivateKeyInfo) and SubjectPublicKeyInfo.  The "der" ones are added
+ * convenience for any user that wants to use OSSL_ENCODER directly.
  * The "pem" ones also support PEM_write_bio_PrivateKey() and
  * PEM_write_bio_PUBKEY().
  */
+ENCODER_w_structure("RSA", rsa, yes, der, EncryptedPrivateKeyInfo),
+ENCODER_w_structure("RSA", rsa, yes, pem, EncryptedPrivateKeyInfo),
 ENCODER_w_structure("RSA", rsa, yes, der, PrivateKeyInfo),
 ENCODER_w_structure("RSA", rsa, yes, pem, PrivateKeyInfo),
 ENCODER_w_structure("RSA", rsa, yes, der, SubjectPublicKeyInfo),
 ENCODER_w_structure("RSA", rsa, yes, pem, SubjectPublicKeyInfo),
 
+ENCODER_w_structure("RSA-PSS", rsapss, yes, der, EncryptedPrivateKeyInfo),
+ENCODER_w_structure("RSA-PSS", rsapss, yes, pem, EncryptedPrivateKeyInfo),
 ENCODER_w_structure("RSA-PSS", rsapss, yes, der, PrivateKeyInfo),
 ENCODER_w_structure("RSA-PSS", rsapss, yes, pem, PrivateKeyInfo),
 ENCODER_w_structure("RSA-PSS", rsapss, yes, der, SubjectPublicKeyInfo),
 ENCODER_w_structure("RSA-PSS", rsapss, yes, pem, SubjectPublicKeyInfo),
 
 #ifndef OPENSSL_NO_DH
+ENCODER_w_structure("DH", dh, yes, der, EncryptedPrivateKeyInfo),
+ENCODER_w_structure("DH", dh, yes, pem, EncryptedPrivateKeyInfo),
 ENCODER_w_structure("DH", dh, yes, der, PrivateKeyInfo),
 ENCODER_w_structure("DH", dh, yes, pem, PrivateKeyInfo),
 ENCODER_w_structure("DH", dh, yes, der, SubjectPublicKeyInfo),
 ENCODER_w_structure("DH", dh, yes, pem, SubjectPublicKeyInfo),
 
+ENCODER_w_structure("DHX", dhx, yes, der, EncryptedPrivateKeyInfo),
+ENCODER_w_structure("DHX", dhx, yes, pem, EncryptedPrivateKeyInfo),
 ENCODER_w_structure("DHX", dhx, yes, der, PrivateKeyInfo),
 ENCODER_w_structure("DHX", dhx, yes, pem, PrivateKeyInfo),
 ENCODER_w_structure("DHX", dhx, yes, der, SubjectPublicKeyInfo),
@@ -156,6 +165,8 @@ ENCODER_w_structure("DHX", dhx, yes, pem, SubjectPublicKeyInfo),
 #endif
 
 #ifndef OPENSSL_NO_DSA
+ENCODER_w_structure("DSA", dsa, yes, der, EncryptedPrivateKeyInfo),
+ENCODER_w_structure("DSA", dsa, yes, pem, EncryptedPrivateKeyInfo),
 ENCODER_w_structure("DSA", dsa, yes, der, PrivateKeyInfo),
 ENCODER_w_structure("DSA", dsa, yes, pem, PrivateKeyInfo),
 ENCODER_w_structure("DSA", dsa, yes, der, SubjectPublicKeyInfo),
@@ -163,32 +174,44 @@ ENCODER_w_structure("DSA", dsa, yes, pem, SubjectPublicKeyInfo),
 #endif
 
 #ifndef OPENSSL_NO_EC
+ENCODER_w_structure("EC", ec, yes, der, EncryptedPrivateKeyInfo),
+ENCODER_w_structure("EC", ec, yes, pem, EncryptedPrivateKeyInfo),
 ENCODER_w_structure("EC", ec, yes, der, PrivateKeyInfo),
 ENCODER_w_structure("EC", ec, yes, pem, PrivateKeyInfo),
 ENCODER_w_structure("EC", ec, yes, der, SubjectPublicKeyInfo),
 ENCODER_w_structure("EC", ec, yes, pem, SubjectPublicKeyInfo),
 
+ENCODER_w_structure("X25519", x25519, yes, der, EncryptedPrivateKeyInfo),
+ENCODER_w_structure("X25519", x25519, yes, pem, EncryptedPrivateKeyInfo),
 ENCODER_w_structure("X25519", x25519, yes, der, PrivateKeyInfo),
 ENCODER_w_structure("X25519", x25519, yes, pem, PrivateKeyInfo),
 ENCODER_w_structure("X25519", x25519, yes, der, SubjectPublicKeyInfo),
 ENCODER_w_structure("X25519", x25519, yes, pem, SubjectPublicKeyInfo),
 
+ENCODER_w_structure("X448", x448, yes, der, EncryptedPrivateKeyInfo),
+ENCODER_w_structure("X448", x448, yes, pem, EncryptedPrivateKeyInfo),
 ENCODER_w_structure("X448", x448, yes, der, PrivateKeyInfo),
 ENCODER_w_structure("X448", x448, yes, pem, PrivateKeyInfo),
 ENCODER_w_structure("X448", x448, yes, der, SubjectPublicKeyInfo),
 ENCODER_w_structure("X448", x448, yes, pem, SubjectPublicKeyInfo),
 
+ENCODER_w_structure("ED25519", ed25519, yes, der, EncryptedPrivateKeyInfo),
+ENCODER_w_structure("ED25519", ed25519, yes, pem, EncryptedPrivateKeyInfo),
 ENCODER_w_structure("ED25519", ed25519, yes, der, PrivateKeyInfo),
 ENCODER_w_structure("ED25519", ed25519, yes, pem, PrivateKeyInfo),
 ENCODER_w_structure("ED25519", ed25519, yes, der, SubjectPublicKeyInfo),
 ENCODER_w_structure("ED25519", ed25519, yes, pem, SubjectPublicKeyInfo),
 
+ENCODER_w_structure("ED448", ed448, yes, der, EncryptedPrivateKeyInfo),
+ENCODER_w_structure("ED448", ed448, yes, pem, EncryptedPrivateKeyInfo),
 ENCODER_w_structure("ED448", ed448, yes, der, PrivateKeyInfo),
 ENCODER_w_structure("ED448", ed448, yes, pem, PrivateKeyInfo),
 ENCODER_w_structure("ED448", ed448, yes, der, SubjectPublicKeyInfo),
 ENCODER_w_structure("ED448", ed448, yes, pem, SubjectPublicKeyInfo),
 
 # ifndef OPENSSL_NO_SM2
+ENCODER_w_structure("SM2", sm2, no, der, EncryptedPrivateKeyInfo),
+ENCODER_w_structure("SM2", sm2, no, pem, EncryptedPrivateKeyInfo),
 ENCODER_w_structure("SM2", sm2, no, der, PrivateKeyInfo),
 ENCODER_w_structure("SM2", sm2, no, pem, PrivateKeyInfo),
 ENCODER_w_structure("SM2", sm2, no, der, SubjectPublicKeyInfo),

--- a/providers/implementations/encode_decode/decode_pem2der.c
+++ b/providers/implementations/encode_decode/decode_pem2der.c
@@ -123,10 +123,10 @@ static int pem2der_decode(void *vctx, OSSL_CORE_BIO *cin, int selection,
          * though there is no provider interface to handle such objects, yet.
          * However, this is beneficial for the OSSL_STORE result handler.
          */
-        { PEM_STRING_X509, OSSL_OBJECT_CERT, NULL, NULL },
-        { PEM_STRING_X509_TRUSTED, OSSL_OBJECT_CERT, NULL, NULL },
-        { PEM_STRING_X509_OLD, OSSL_OBJECT_CERT, NULL, NULL },
-        { PEM_STRING_X509_CRL, OSSL_OBJECT_CRL, NULL, NULL }
+        { PEM_STRING_X509, OSSL_OBJECT_CERT, NULL, "Certificate" },
+        { PEM_STRING_X509_TRUSTED, OSSL_OBJECT_CERT, NULL, "Certificate" },
+        { PEM_STRING_X509_OLD, OSSL_OBJECT_CERT, NULL, "Certificate" },
+        { PEM_STRING_X509_CRL, OSSL_OBJECT_CRL, NULL, "CertificateList" }
     };
     struct pem2der_ctx_st *ctx = vctx;
     char *pem_name = NULL, *pem_header = NULL;
@@ -178,6 +178,7 @@ static int pem2der_decode(void *vctx, OSSL_CORE_BIO *cin, int selection,
         char *data_type = (char *)pem_name_map[i].data_type;
         char *data_structure = (char *)pem_name_map[i].data_structure;
 
+        objtype = pem_name_map[i].object_type;
         if (data_type != NULL)
             *p++ =
                 OSSL_PARAM_construct_utf8_string(OSSL_OBJECT_PARAM_DATA_TYPE,

--- a/providers/implementations/include/prov/implementations.h
+++ b/providers/implementations/include/prov/implementations.h
@@ -327,6 +327,8 @@ extern const OSSL_DISPATCH ossl_rsa_asym_kem_functions[];
 /* Encoders */
 extern const OSSL_DISPATCH ossl_rsa_to_PKCS1_der_encoder_functions[];
 extern const OSSL_DISPATCH ossl_rsa_to_PKCS1_pem_encoder_functions[];
+extern const OSSL_DISPATCH ossl_rsa_to_EncryptedPrivateKeyInfo_der_encoder_functions[];
+extern const OSSL_DISPATCH ossl_rsa_to_EncryptedPrivateKeyInfo_pem_encoder_functions[];
 extern const OSSL_DISPATCH ossl_rsa_to_PrivateKeyInfo_der_encoder_functions[];
 extern const OSSL_DISPATCH ossl_rsa_to_PrivateKeyInfo_pem_encoder_functions[];
 extern const OSSL_DISPATCH ossl_rsa_to_RSA_der_encoder_functions[];
@@ -341,6 +343,8 @@ extern const OSSL_DISPATCH ossl_rsa_to_type_specific_keypair_pem_encoder_functio
 
 extern const OSSL_DISPATCH ossl_rsapss_to_PKCS1_der_encoder_functions[];
 extern const OSSL_DISPATCH ossl_rsapss_to_PKCS1_pem_encoder_functions[];
+extern const OSSL_DISPATCH ossl_rsapss_to_EncryptedPrivateKeyInfo_der_encoder_functions[];
+extern const OSSL_DISPATCH ossl_rsapss_to_EncryptedPrivateKeyInfo_pem_encoder_functions[];
 extern const OSSL_DISPATCH ossl_rsapss_to_PrivateKeyInfo_der_encoder_functions[];
 extern const OSSL_DISPATCH ossl_rsapss_to_PrivateKeyInfo_pem_encoder_functions[];
 extern const OSSL_DISPATCH ossl_rsapss_to_SubjectPublicKeyInfo_der_encoder_functions[];
@@ -351,6 +355,8 @@ extern const OSSL_DISPATCH ossl_dh_to_DH_der_encoder_functions[];
 extern const OSSL_DISPATCH ossl_dh_to_DH_pem_encoder_functions[];
 extern const OSSL_DISPATCH ossl_dh_to_PKCS3_der_encoder_functions[];
 extern const OSSL_DISPATCH ossl_dh_to_PKCS3_pem_encoder_functions[];
+extern const OSSL_DISPATCH ossl_dh_to_EncryptedPrivateKeyInfo_der_encoder_functions[];
+extern const OSSL_DISPATCH ossl_dh_to_EncryptedPrivateKeyInfo_pem_encoder_functions[];
 extern const OSSL_DISPATCH ossl_dh_to_PrivateKeyInfo_der_encoder_functions[];
 extern const OSSL_DISPATCH ossl_dh_to_PrivateKeyInfo_pem_encoder_functions[];
 extern const OSSL_DISPATCH ossl_dh_to_SubjectPublicKeyInfo_der_encoder_functions[];
@@ -361,6 +367,8 @@ extern const OSSL_DISPATCH ossl_dh_to_text_encoder_functions[];
 
 extern const OSSL_DISPATCH ossl_dhx_to_DHX_der_encoder_functions[];
 extern const OSSL_DISPATCH ossl_dhx_to_DHX_pem_encoder_functions[];
+extern const OSSL_DISPATCH ossl_dhx_to_EncryptedPrivateKeyInfo_der_encoder_functions[];
+extern const OSSL_DISPATCH ossl_dhx_to_EncryptedPrivateKeyInfo_pem_encoder_functions[];
 extern const OSSL_DISPATCH ossl_dhx_to_PrivateKeyInfo_der_encoder_functions[];
 extern const OSSL_DISPATCH ossl_dhx_to_PrivateKeyInfo_pem_encoder_functions[];
 extern const OSSL_DISPATCH ossl_dhx_to_SubjectPublicKeyInfo_der_encoder_functions[];
@@ -373,6 +381,8 @@ extern const OSSL_DISPATCH ossl_dhx_to_text_encoder_functions[];
 
 extern const OSSL_DISPATCH ossl_dsa_to_DSA_der_encoder_functions[];
 extern const OSSL_DISPATCH ossl_dsa_to_DSA_pem_encoder_functions[];
+extern const OSSL_DISPATCH ossl_dsa_to_EncryptedPrivateKeyInfo_der_encoder_functions[];
+extern const OSSL_DISPATCH ossl_dsa_to_EncryptedPrivateKeyInfo_pem_encoder_functions[];
 extern const OSSL_DISPATCH ossl_dsa_to_PrivateKeyInfo_der_encoder_functions[];
 extern const OSSL_DISPATCH ossl_dsa_to_PrivateKeyInfo_pem_encoder_functions[];
 extern const OSSL_DISPATCH ossl_dsa_to_SubjectPublicKeyInfo_der_encoder_functions[];
@@ -386,6 +396,8 @@ extern const OSSL_DISPATCH ossl_dsa_to_text_encoder_functions[];
 extern const OSSL_DISPATCH ossl_ec_to_EC_der_encoder_functions[];
 extern const OSSL_DISPATCH ossl_ec_to_EC_pem_encoder_functions[];
 extern const OSSL_DISPATCH ossl_ec_to_blob_encoder_functions[];
+extern const OSSL_DISPATCH ossl_ec_to_EncryptedPrivateKeyInfo_der_encoder_functions[];
+extern const OSSL_DISPATCH ossl_ec_to_EncryptedPrivateKeyInfo_pem_encoder_functions[];
 extern const OSSL_DISPATCH ossl_ec_to_PrivateKeyInfo_der_encoder_functions[];
 extern const OSSL_DISPATCH ossl_ec_to_PrivateKeyInfo_pem_encoder_functions[];
 extern const OSSL_DISPATCH ossl_ec_to_SubjectPublicKeyInfo_der_encoder_functions[];
@@ -400,6 +412,8 @@ extern const OSSL_DISPATCH ossl_ec_to_text_encoder_functions[];
 extern const OSSL_DISPATCH ossl_sm2_to_SM2_der_encoder_functions[];
 extern const OSSL_DISPATCH ossl_sm2_to_SM2_pem_encoder_functions[];
 extern const OSSL_DISPATCH ossl_sm2_to_blob_encoder_functions[];
+extern const OSSL_DISPATCH ossl_sm2_to_EncryptedPrivateKeyInfo_der_encoder_functions[];
+extern const OSSL_DISPATCH ossl_sm2_to_EncryptedPrivateKeyInfo_pem_encoder_functions[];
 extern const OSSL_DISPATCH ossl_sm2_to_PrivateKeyInfo_der_encoder_functions[];
 extern const OSSL_DISPATCH ossl_sm2_to_PrivateKeyInfo_pem_encoder_functions[];
 extern const OSSL_DISPATCH ossl_sm2_to_SubjectPublicKeyInfo_der_encoder_functions[];
@@ -409,6 +423,8 @@ extern const OSSL_DISPATCH ossl_sm2_to_type_specific_no_pub_der_encoder_function
 extern const OSSL_DISPATCH ossl_sm2_to_text_encoder_functions[];
 #endif
 
+extern const OSSL_DISPATCH ossl_ed25519_to_EncryptedPrivateKeyInfo_der_encoder_functions[];
+extern const OSSL_DISPATCH ossl_ed25519_to_EncryptedPrivateKeyInfo_pem_encoder_functions[];
 extern const OSSL_DISPATCH ossl_ed25519_to_PrivateKeyInfo_der_encoder_functions[];
 extern const OSSL_DISPATCH ossl_ed25519_to_PrivateKeyInfo_pem_encoder_functions[];
 extern const OSSL_DISPATCH ossl_ed25519_to_SubjectPublicKeyInfo_der_encoder_functions[];
@@ -416,6 +432,8 @@ extern const OSSL_DISPATCH ossl_ed25519_to_SubjectPublicKeyInfo_pem_encoder_func
 extern const OSSL_DISPATCH ossl_ed25519_to_OSSL_current_der_encoder_functions[];
 extern const OSSL_DISPATCH ossl_ed25519_to_text_encoder_functions[];
 
+extern const OSSL_DISPATCH ossl_ed448_to_EncryptedPrivateKeyInfo_der_encoder_functions[];
+extern const OSSL_DISPATCH ossl_ed448_to_EncryptedPrivateKeyInfo_pem_encoder_functions[];
 extern const OSSL_DISPATCH ossl_ed448_to_PrivateKeyInfo_der_encoder_functions[];
 extern const OSSL_DISPATCH ossl_ed448_to_PrivateKeyInfo_pem_encoder_functions[];
 extern const OSSL_DISPATCH ossl_ed448_to_SubjectPublicKeyInfo_der_encoder_functions[];
@@ -423,6 +441,8 @@ extern const OSSL_DISPATCH ossl_ed448_to_SubjectPublicKeyInfo_pem_encoder_functi
 extern const OSSL_DISPATCH ossl_ed448_to_OSSL_current_der_encoder_functions[];
 extern const OSSL_DISPATCH ossl_ed448_to_text_encoder_functions[];
 
+extern const OSSL_DISPATCH ossl_x25519_to_EncryptedPrivateKeyInfo_der_encoder_functions[];
+extern const OSSL_DISPATCH ossl_x25519_to_EncryptedPrivateKeyInfo_pem_encoder_functions[];
 extern const OSSL_DISPATCH ossl_x25519_to_PrivateKeyInfo_der_encoder_functions[];
 extern const OSSL_DISPATCH ossl_x25519_to_PrivateKeyInfo_pem_encoder_functions[];
 extern const OSSL_DISPATCH ossl_x25519_to_SubjectPublicKeyInfo_der_encoder_functions[];
@@ -430,6 +450,8 @@ extern const OSSL_DISPATCH ossl_x25519_to_SubjectPublicKeyInfo_pem_encoder_funct
 extern const OSSL_DISPATCH ossl_x25519_to_OSSL_current_der_encoder_functions[];
 extern const OSSL_DISPATCH ossl_x25519_to_text_encoder_functions[];
 
+extern const OSSL_DISPATCH ossl_x448_to_EncryptedPrivateKeyInfo_der_encoder_functions[];
+extern const OSSL_DISPATCH ossl_x448_to_EncryptedPrivateKeyInfo_pem_encoder_functions[];
 extern const OSSL_DISPATCH ossl_x448_to_PrivateKeyInfo_der_encoder_functions[];
 extern const OSSL_DISPATCH ossl_x448_to_PrivateKeyInfo_pem_encoder_functions[];
 extern const OSSL_DISPATCH ossl_x448_to_SubjectPublicKeyInfo_der_encoder_functions[];

--- a/providers/implementations/storemgmt/file_store.c
+++ b/providers/implementations/storemgmt/file_store.c
@@ -437,6 +437,31 @@ static int file_setup_decoders(struct file_ctx_st *ctx)
             goto err;
         }
 
+        /*
+         * Where applicable, set the outermost structure name.
+         * The goal is to avoid the STORE object types that are
+         * potentially password protected but aren't interesting
+         * for this load.
+         */
+        switch (ctx->expected_type) {
+        case OSSL_STORE_INFO_CERT:
+            if (!OSSL_DECODER_CTX_set_input_structure(ctx->_.file.decoderctx,
+                                                      "Certificate")) {
+                ERR_raise(ERR_LIB_PROV, ERR_R_OSSL_DECODER_LIB);
+                goto err;
+            }
+            break;
+        case OSSL_STORE_INFO_CRL:
+            if (!OSSL_DECODER_CTX_set_input_structure(ctx->_.file.decoderctx,
+                                                      "CertificateList")) {
+                ERR_raise(ERR_LIB_PROV, ERR_R_OSSL_DECODER_LIB);
+                goto err;
+            }
+            break;
+        default:
+            break;
+        }
+
         for (to_algo = ossl_any_to_obj_algorithm;
              to_algo->algorithm_names != NULL;
              to_algo++) {

--- a/test/endecode_test.c
+++ b/test/endecode_test.c
@@ -703,7 +703,7 @@ static int test_protected_via_DER(const char *type, EVP_PKEY *key)
     return test_encode_decode(__FILE__, __LINE__, type, key,
                               OSSL_KEYMGMT_SELECT_KEYPAIR
                               | OSSL_KEYMGMT_SELECT_DOMAIN_PARAMETERS,
-                              "DER", "PrivateKeyInfo",
+                              "DER", "EncryptedPrivateKeyInfo",
                               pass, pass_cipher,
                               encode_EVP_PKEY_prov, decode_EVP_PKEY_prov,
                               test_mem, check_protected_PKCS8_DER,
@@ -726,7 +726,7 @@ static int test_protected_via_PEM(const char *type, EVP_PKEY *key)
     return test_encode_decode(__FILE__, __LINE__, type, key,
                               OSSL_KEYMGMT_SELECT_KEYPAIR
                               | OSSL_KEYMGMT_SELECT_DOMAIN_PARAMETERS,
-                              "PEM", "PrivateKeyInfo",
+                              "PEM", "EncryptedPrivateKeyInfo",
                               pass, pass_cipher,
                               encode_EVP_PKEY_prov, decode_EVP_PKEY_prov,
                               test_text, check_protected_PKCS8_PEM,

--- a/test/recipes/25-test_verify.t
+++ b/test/recipes/25-test_verify.t
@@ -11,6 +11,7 @@ use strict;
 use warnings;
 
 use File::Spec::Functions qw/canonpath/;
+use File::Copy;
 use OpenSSL::Test qw/:DEFAULT srctop_file ok_nofips with/;
 use OpenSSL::Test::Utils;
 
@@ -28,7 +29,7 @@ sub verify {
     run(app([@args]));
 }
 
-plan tests => 157;
+plan tests => 159;
 
 # Canonical success
 ok(verify("ee-cert", "sslserver", ["root-cert"], ["ca-cert"]),
@@ -447,4 +448,34 @@ SKIP: {
        "SM2 ID test");
    ok_nofips(verify("sm2", "", ["sm2-ca-cert"], [], "-vfyopt", "hexdistid:31323334353637383132333435363738"),
        "SM2 hex ID test");
+}
+
+# Mixed content tests
+my $cert_file = srctop_file('test', 'certs', 'root-cert.pem');
+my $rsa_file = srctop_file('test', 'certs', 'key-pass-12345.pem');
+
+SKIP: {
+    my $certplusrsa_file = 'certplusrsa.pem';
+    my $certplusrsa;
+
+    skip "Couldn't create certplusrsa.pem", 1
+        unless ( open $certplusrsa, '>', $certplusrsa_file
+                 and copy($cert_file, $certplusrsa)
+                 and copy($rsa_file, $certplusrsa) );
+
+    ok(run(app([ qw(openssl verify -trusted), $certplusrsa_file, $cert_file ])),
+       'Mixed cert + key file test');
+}
+
+SKIP: {
+    my $rsapluscert_file = 'rsapluscert.pem';
+    my $rsapluscert;
+
+    skip "Couldn't create rsapluscert.pem", 1
+        unless ( open $rsapluscert, '>', $rsapluscert_file
+                 and copy($rsa_file, $rsapluscert)
+                 and copy($cert_file, $rsapluscert) );
+
+    ok(run(app([ qw(openssl verify -trusted), $rsapluscert_file, $cert_file ])),
+       'Mixed key + cert file test');
 }


### PR DESCRIPTION
The gist of the filter is implemented in DECODER, the 'file:' scheme implementation and the PEM to DER decoder only pass extra data to feed the filter.

As a consequence of this change, it was discovered that we don't treat the structure name specified by the user correctly.  The intention was always that it should specify the *outermost* structure, as given by the decoders.  However, we used it to filter the *innermost* structure, and were arguably not even doing that quite right.
So, there are places where EncryptedPrivateKeyInfo need to be specified, rather than PrivateKeyInfo, and by consequence, there's a need for encoders with that output structure (or test_encoder_decoder fails).

See commits for details.

Fixes #16224 