### PR TITLE
Support multibin to allow multiple binary models to co-exist.

### DIFF
--- a/Configurations/50-nonstop.conf
+++ b/Configurations/50-nonstop.conf
@@ -204,6 +204,7 @@
                               'nonstop-efloat-x86_64',
                               'nonstop-model-put' ],
         multilib         => '-put',
+        multibin         => '-put',
     },
     'nonstop-nsx_64' => {
         inherit_from     => [ 'nonstop-common',
@@ -211,6 +212,7 @@
                               'nonstop-lp64-x86_64',
                               'nonstop-efloat-x86_64' ],
         multilib         => '64',
+        multibin         => '64',
         disable          => ['threads'],
     },
     'nonstop-nsx_64_put' => {
@@ -220,6 +222,7 @@
                               'nonstop-efloat-x86_64',
                               'nonstop-model-put' ],
         multilib         => '64-put',
+        multibin         => '64-put',
     },
     'nonstop-nsx_spt' => {
         inherit_from     => [ 'nonstop-common',
@@ -228,6 +231,7 @@
                               'nonstop-efloat-x86_64',
                               'nonstop-model-spt' ],
         multilib         => '-spt',
+        multibin         => '-spt',
     },
     'nonstop-nsx_spt_floss' => {
         inherit_from     => [ 'nonstop-common',
@@ -237,6 +241,7 @@
                               'nonstop-model-floss',
                               'nonstop-model-spt'],
         multilib         => '-spt',
+        multibin         => '-spt',
     },
     'nonstop-nsx_g' => {
         inherit_from     => [ 'nonstop-common',
@@ -267,6 +272,7 @@
                               'nonstop-efloat-itanium',
                               'nonstop-model-put' ],
         multilib         => '-put',
+        multibin         => '-put',
     },
     'nonstop-nse_64' => {
         inherit_from     => [ 'nonstop-common',
@@ -274,6 +280,7 @@
                               'nonstop-lp64-itanium',
                               'nonstop-efloat-itanium' ],
         multilib         => '64',
+        multibin         => '64',
         disable          => ['threads'],
     },
     'nonstop-nse_64_put' => {
@@ -283,6 +290,7 @@
                               'nonstop-efloat-itanium',
                               'nonstop-model-put' ],
         multilib         => '64-put',
+        multibin         => '64-put',
     },
     'nonstop-nse_spt' => {
         inherit_from     => [ 'nonstop-common',
@@ -291,6 +299,7 @@
                               'nonstop-efloat-itanium',
                               'nonstop-model-spt' ],
         multilib         => '-spt',
+        multibin         => '-spt',
     },
     'nonstop-nse_spt_floss' => {
         inherit_from     => [ 'nonstop-common',
@@ -299,6 +308,7 @@
                               'nonstop-efloat-itanium',
                               'nonstop-model-floss', 'nonstop-model-spt' ],
         multilib         => '-spt',
+        multibin         => '-spt',
     },
     'nonstop-nse_g' => {
         inherit_from     => [ 'nonstop-common',

--- a/Configurations/README.md
+++ b/Configurations/README.md
@@ -203,6 +203,13 @@ In each table entry, the following keys are significant:
                            to have the different variants in different
                            directories.
 
+        multibin        => On systems that support having multiple
+                           implementations of a library and binaries
+                           (typically a 32-bit and a 64-bit variant),
+                           this is used to have the different variants
+                           in different binary directories. This setting
+                           works in conjunction with multilib.
+
         bn_ops          => Building options (was just bignum options in
                            the earlier history of this option, hence the
                            name). This is a string of words that describe

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -310,6 +310,14 @@ MODULESDIR=$(libdir)/ossl-modules
 # libraries and applications
 LIBRPATH=$(libdir)
 
+BINDIR={- our $bindir = $config{bindir};
+          unless ($bindir) {
+              $bindir = "bin$target{multibin}";
+          }
+          file_name_is_absolute($bindir) ? "" : $bindir -}
+bindir={- file_name_is_absolute($bindir)
+          ? $bindir : '$(INSTALLTOP)/$(BINDIR)' -}
+
 MANDIR=$(INSTALLTOP)/share/man
 DOCDIR=$(INSTALLTOP)/share/doc/$(BASENAME)
 HTMLDIR=$(DOCDIR)/html
@@ -868,18 +876,18 @@ install_runtime_libs: build_libs
 	@ : {- output_off() if windowsdll(); "" -}
 	@$(PERL) $(SRCDIR)/util/mkdir-p.pl $(DESTDIR)$(libdir)
 	@ : {- output_on() if windowsdll(); output_off() unless windowsdll(); "" -}
-	@$(PERL) $(SRCDIR)/util/mkdir-p.pl $(DESTDIR)$(INSTALLTOP)/bin
+	@$(PERL) $(SRCDIR)/util/mkdir-p.pl $(DESTDIR)$(bindir)/
 	@ : {- output_on() unless windowsdll(); "" -}
 	@$(ECHO) "*** Installing runtime libraries"
 	@set -e; for s in dummy $(INSTALL_SHLIBS); do \
 		if [ "$$s" = "dummy" ]; then continue; fi; \
 		fn=`basename $$s`; \
 		: {- output_off() unless windowsdll(); "" -}; \
-		$(ECHO) "install $$s -> $(DESTDIR)$(INSTALLTOP)/bin/$$fn"; \
-		cp $$s $(DESTDIR)$(INSTALLTOP)/bin/$$fn.new; \
-		chmod 755 $(DESTDIR)$(INSTALLTOP)/bin/$$fn.new; \
-		mv -f $(DESTDIR)$(INSTALLTOP)/bin/$$fn.new \
-		      $(DESTDIR)$(INSTALLTOP)/bin/$$fn; \
+		$(ECHO) "install $$s -> $(DESTDIR)$(bindir)/$$fn"; \
+		cp $$s $(DESTDIR)$(bindir)/$$fn.new; \
+		chmod 755 $(DESTDIR)$(bindir)/$$fn.new; \
+		mv -f $(DESTDIR)$(bindir)/$$fn.new \
+		      $(DESTDIR)$(bindir)/$$fn; \
 		: {- output_on() unless windowsdll(); "" -}{- output_off() if windowsdll(); "" -}; \
 		$(ECHO) "install $$s -> $(DESTDIR)$(libdir)/$$fn"; \
 		cp $$s $(DESTDIR)$(libdir)/$$fn.new; \
@@ -891,25 +899,25 @@ install_runtime_libs: build_libs
 
 install_programs: install_runtime_libs build_programs
 	@[ -n "$(INSTALLTOP)" ] || (echo INSTALLTOP should not be empty; exit 1)
-	@$(PERL) $(SRCDIR)/util/mkdir-p.pl $(DESTDIR)$(INSTALLTOP)/bin
+	@$(PERL) $(SRCDIR)/util/mkdir-p.pl $(DESTDIR)$(bindir)
 	@$(ECHO) "*** Installing runtime programs"
 	@set -e; for x in dummy $(INSTALL_PROGRAMS); do \
 		if [ "$$x" = "dummy" ]; then continue; fi; \
 		fn=`basename $$x`; \
-		$(ECHO) "install $$x -> $(DESTDIR)$(INSTALLTOP)/bin/$$fn"; \
-		cp $$x $(DESTDIR)$(INSTALLTOP)/bin/$$fn.new; \
-		chmod 755 $(DESTDIR)$(INSTALLTOP)/bin/$$fn.new; \
-		mv -f $(DESTDIR)$(INSTALLTOP)/bin/$$fn.new \
-		      $(DESTDIR)$(INSTALLTOP)/bin/$$fn; \
+		$(ECHO) "install $$x -> $(DESTDIR)$(bindir)/$$fn"; \
+		cp $$x $(DESTDIR)$(bindir)/$$fn.new; \
+		chmod 755 $(DESTDIR)$(bindir)/$$fn.new; \
+		mv -f $(DESTDIR)$(bindir)/$$fn.new \
+		      $(DESTDIR)$(bindir)/$$fn; \
 	done
 	@set -e; for x in dummy $(BIN_SCRIPTS); do \
 		if [ "$$x" = "dummy" ]; then continue; fi; \
 		fn=`basename $$x`; \
-		$(ECHO) "install $$x -> $(DESTDIR)$(INSTALLTOP)/bin/$$fn"; \
-		cp $$x $(DESTDIR)$(INSTALLTOP)/bin/$$fn.new; \
-		chmod 755 $(DESTDIR)$(INSTALLTOP)/bin/$$fn.new; \
-		mv -f $(DESTDIR)$(INSTALLTOP)/bin/$$fn.new \
-		      $(DESTDIR)$(INSTALLTOP)/bin/$$fn; \
+		$(ECHO) "install $$x -> $(DESTDIR)$(bindir)/$$fn"; \
+		cp $$x $(DESTDIR)$(bindir)/$$fn.new; \
+		chmod 755 $(DESTDIR)$(bindir)/$$fn.new; \
+		mv -f $(DESTDIR)$(bindir)/$$fn.new \
+		      $(DESTDIR)$(bindir)/$$fn; \
 	done
 
 uninstall_runtime: uninstall_programs uninstall_runtime_libs
@@ -920,17 +928,17 @@ uninstall_programs:
 	do  \
 		if [ "$$x" = "dummy" ]; then continue; fi; \
 		fn=`basename $$x`; \
-		$(ECHO) "$(RM) $(DESTDIR)$(INSTALLTOP)/bin/$$fn"; \
-		$(RM) $(DESTDIR)$(INSTALLTOP)/bin/$$fn; \
+		$(ECHO) "$(RM) $(DESTDIR)$(bindir)/$$fn"; \
+		$(RM) $(DESTDIR)$(bindir)/$$fn; \
 	done;
 	@set -e; for x in dummy $(BIN_SCRIPTS); \
 	do  \
 		if [ "$$x" = "dummy" ]; then continue; fi; \
 		fn=`basename $$x`; \
-		$(ECHO) "$(RM) $(DESTDIR)$(INSTALLTOP)/bin/$$fn"; \
-		$(RM) $(DESTDIR)$(INSTALLTOP)/bin/$$fn; \
+		$(ECHO) "$(RM) $(DESTDIR)$(bindir)/$$fn"; \
+		$(RM) $(DESTDIR)$(bindir)/$$fn; \
 	done
-	-$(RMDIR) $(DESTDIR)$(INSTALLTOP)/bin
+	-$(RMDIR) $(DESTDIR)$(bindir)
 
 uninstall_runtime_libs:
 	@$(ECHO) "*** Uninstalling runtime libraries"
@@ -938,8 +946,8 @@ uninstall_runtime_libs:
 	@set -e; for s in dummy $(INSTALL_SHLIBS); do \
 		if [ "$$s" = "dummy" ]; then continue; fi; \
 		fn=`basename $$s`; \
-		$(ECHO) "$(RM) $(DESTDIR)$(INSTALLTOP)/bin/$$fn"; \
-		$(RM) $(DESTDIR)$(INSTALLTOP)/bin/$$fn; \
+		$(ECHO) "$(RM) $(DESTDIR)$(bindir)/$$fn"; \
+		$(RM) $(DESTDIR)$(bindir)/$$fn; \
 	done
 	@ : {- output_on() unless windowsdll(); "" -}
 


### PR DESCRIPTION
This change parallels the implementation of multilib and initially
only applies to the NonStop platform's DLL loader limitations.

Fixes: #16460

Signed-off-by: Randall S. Becker <rsbecker@nexbridge.com>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
