### PR TITLE
Document that the openssl fipsinstall self test callback may not be used.

### DIFF
--- a/doc/man1/openssl-fipsinstall.pod.in
+++ b/doc/man1/openssl-fipsinstall.pod.in
@@ -197,6 +197,18 @@ All other options are ignored if '-config' is used.
 
 =back
 
+=head1 NOTES
+
+Self tests results are logged by default if the options B<-quiet> and B<-noout>
+are not specified, or if either of the options B<-corrupt_desc> or
+B<-corrupt_type> are used.
+If the base configuration file is set up to autoload the fips module, then the
+fips module will be loaded and self tested BEFORE the fipsinstall application
+has a chance to set up its own self test callback. As a result of this the self
+test output and the options B<-corrupt_desc> and B<-corrupt_type> will be ignored.
+For normal usage the base configuration file should use the default provider
+when generating the fips configuration file.
+
 =head1 EXAMPLES
 
 Calculate the mac of a FIPS module F<fips.so> and run a FIPS self test


### PR DESCRIPTION
Fixes #16260

If the user autoloads a fips module from a config file, then it will run the self tests early (before the self test callback is set),
and they may not get triggered again during the fipsinstall process.
In order for this to happen there must already be a valid fips config file.
As the main purpose of the application is to generate the fips config file, this case has just been documented.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
