### PR TITLE
Fix Openssl compilation on Debian with kfreebsd kernels

### DIFF
--- a/crypto/uid.c
+++ b/crypto/uid.c
@@ -17,7 +17,7 @@ int OPENSSL_issetugid(void)
     return 0;
 }
 
-#elif defined(__OpenBSD__) || (defined(__FreeBSD__) && __FreeBSD__ > 2) || defined(__DragonFly__)
+#elif defined(__OpenBSD__) || (defined(__FreeBSD__) && __FreeBSD__ > 2) || defined(__DragonFly__) || (defined(__GLIBC__) && defined(__FreeBSD_kernel__))
 
 # include <unistd.h>
 


### PR DESCRIPTION
Openssl fails to compile on Debian with kfreebsd kernels (kfreebsd-amd64, kfreebsd-i386). The error reported by the compiler is:
```
../crypto/uid.c: In function 'OPENSSL_issetugid':
../crypto/uid.c:50:22: error: 'AT_SECURE' undeclared (first use in this function)
   50 |     return getauxval(AT_SECURE) != 0;
      |                      ^~~~~~~~~
```
This commit changes the code to use the freebsd code in this case.
This fixes the compilation.
