### PR TITLE
VMS: Compensate for x86_64 cross compiler type incompatibility

### DIFF
--- a/providers/implementations/rands/seeding/rand_vms.c
+++ b/providers/implementations/rands/seeding/rand_vms.c
@@ -479,7 +479,7 @@ int ossl_pool_add_nonce_data(RAND_POOL *pool)
     struct {
         pid_t pid;
         CRYPTO_THREAD_ID tid;
-        uint64_t time;
+        unsigned __int64 time;
     } data;
 
     /* Erase the entire structure including any padding */
@@ -580,7 +580,7 @@ int ossl_rand_pool_add_additional_data(RAND_POOL *pool)
 {
     struct {
         CRYPTO_THREAD_ID tid;
-        uint64_t time;
+        unsigned __int64 time;
     } data;
 
     /* Erase the entire structure including any padding */


### PR DESCRIPTION
The x86_64 cross compiler says that 'unsigned long long' isn't the
same as 'unsigned __int64'.  Sure, and considering that
providers/implementations/rands/seeding/rand_vms.c is specific VMS
only code, it's easy to just change the type to the exact same as
what's specified in the system headers.
