### PR TITLE
Configuration: support building for OpenVMS for x86_64

### DIFF
--- a/Configurations/50-vms-x86_64.conf
+++ b/Configurations/50-vms-x86_64.conf
@@ -1,0 +1,20 @@
+## -*- mode: perl; -*-
+
+# OpenVMS for x86_64 is currently out on a field test.  A native C compiler
+# is currently not available, but there are cross-compilation tools for
+# OpenVMS for Itanium.  This configuration file holds the necessary target(s)
+# to make that useful.
+#
+# The assumption is that *building* is done on Itanium, and then the source
+# tree and build tree are transferred to x86_64, where tests can be performed,
+# and installation can be done.
+
+(
+ 'vms-x86_64' => {
+     inherit_from   => [ 'vms-generic' ],
+     CC             => 'XCC',
+     bn_ops         => 'SIXTY_FOUR_BIT',
+     pointer_size   => '',
+     setup_commands => [ '@SYS$MANAGER:X86_XTOOLS$SYLOGIN.COM' ],
+ }
+);

--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -391,6 +391,8 @@ CPPFLAGS_Q={- (my $c = $lib_cppflags.$cppflags) =~ s|"|""|g;
 # .FIRST and .LAST are special targets with MMS and MMK.
 NODEBUG=@
 .FIRST :
+        {- join( "\n        \$(NODEBUG) ", @{ $target{setup_commands} // [] },
+                                           '!' ) -}
         $(NODEBUG) sourcetop = F$PARSE("$(SRCDIR)","[]A.;",,,"SYNTAX_ONLY,NO_CONCEAL") - ".][000000" - "[000000." - "][" - "]A.;" + ".]"
         $(NODEBUG) DEFINE ossl_sourceroot 'sourcetop'
         $(NODEBUG) !


### PR DESCRIPTION
OpenVMS for x86_64 is currently out on a field test.  Building
programs for it is currently done with cross compilation on Itanium.
The cross compilation tools are made available by running a script,
which makes cross-compilation variants of most commands available, and
adds the cross-compilation C compiler XCC.
