### PR TITLE
Fix nc_email to check ASN1 strings with NULL byte in the middle

### DIFF
--- a/crypto/x509/v3_ncons.c
+++ b/crypto/x509/v3_ncons.c
@@ -714,6 +714,9 @@ static int nc_email(ASN1_IA5STRING *eml, ASN1_IA5STRING *base)
         if (baseat != baseptr) {
             if ((baseat - baseptr) != (emlat - emlptr))
                 return X509_V_ERR_PERMITTED_VIOLATION;
+            if (memchr(baseptr, 0, baseat - baseptr) ||
+            	memchr(emlptr, 0, emlat - emlptr))
+            	return X509_V_ERR_UNSUPPORTED_NAME_SYNTAX;
             /* Case sensitive match of local part */
             if (strncmp(baseptr, emlptr, emlat - emlptr))
                 return X509_V_ERR_PERMITTED_VIOLATION;


### PR DESCRIPTION
This fix is an addition to sequence of commits fixing CVE-2021-3712

CLA: trivial