### PR TITLE
test/ec_internal_test: link with libapps.a too

### DIFF
--- a/test/build.info
+++ b/test/build.info
@@ -519,7 +519,7 @@ INCLUDE_MAIN___test_libtestutil_OLB = /INCLUDE=MAIN
                              {- rebase_files("../apps",
                                   split(/\s+/, $target{apps_init_src})) -}
     INCLUDE[ec_internal_test]=../include ../crypto/ec
-    DEPEND[ec_internal_test]=../libcrypto.a libtestutil.a
+    DEPEND[ec_internal_test]=../apps/libapps.a ../libcrypto.a libtestutil.a
 
     SOURCE[curve448_internal_test]=curve448_internal_test.c
     INCLUDE[curve448_internal_test]=.. ../include ../crypto/ec/curve448


### PR DESCRIPTION
Whenever the source from $target{apps_init_src} is added to the source
of a test program, it needs to be linked with libapps.a as well.  Some
init sources depend on that.

Without this, builds break on VMS because of the unresolved symbol
'app_malloc'.

On platforms that do not need anything from libapps.a, adding it is a
no-op.

This is for OpenSSL 1.1.1 only.  OpenSSL 3.0 and beyond have a
different solution.
