### PR TITLE
VMS: Compensate for compiler type incompatibility

### DIFF
--- a/crypto/rand/rand_vms.c
+++ b/crypto/rand/rand_vms.c
@@ -484,7 +484,7 @@ int rand_pool_add_nonce_data(RAND_POOL *pool)
     struct {
         pid_t pid;
         CRYPTO_THREAD_ID tid;
-        uint64_t time;
+        unsigned __int64_t time;
     } data = { 0 };
 
     /*
@@ -582,7 +582,7 @@ int rand_pool_add_additional_data(RAND_POOL *pool)
 {
     struct {
         CRYPTO_THREAD_ID tid;
-        uint64_t time;
+        unsigned __int64_t time;
     } data = { 0 };
 
     /*


### PR DESCRIPTION
The compiler says that 'unsigned long long' isn't the same as
'unsigned __int64'.  Sure, and considering that crypto/rand/rand_vms.c
is specific VMS only code, it's easy to just change the type to the
exact same as what's specified in the system headers.
