### PR TITLE
Fix a few tests that fail on VMS

### DIFF
--- a/test/recipes/25-test_verify.t
+++ b/test/recipes/25-test_verify.t
@@ -461,7 +461,8 @@ SKIP: {
     skip "Couldn't create certplusrsa.pem", 1
         unless ( open $certplusrsa, '>', $certplusrsa_file
                  and copy($cert_file, $certplusrsa)
-                 and copy($rsa_file, $certplusrsa) );
+                 and copy($rsa_file, $certplusrsa)
+                 and close $certplusrsa );
 
     ok(run(app([ qw(openssl verify -trusted), $certplusrsa_file, $cert_file ])),
        'Mixed cert + key file test');
@@ -474,7 +475,8 @@ SKIP: {
     skip "Couldn't create rsapluscert.pem", 1
         unless ( open $rsapluscert, '>', $rsapluscert_file
                  and copy($rsa_file, $rsapluscert)
-                 and copy($cert_file, $rsapluscert) );
+                 and copy($cert_file, $rsapluscert)
+                 and close $rsapluscert );
 
     ok(run(app([ qw(openssl verify -trusted), $rsapluscert_file, $cert_file ])),
        'Mixed key + cert file test');

--- a/test/recipes/30-test_defltfips.t
+++ b/test/recipes/30-test_defltfips.t
@@ -36,7 +36,7 @@ unless ($no_fips) {
 
     #Configured to run FIPS but the module-mac is bad
     $ENV{OPENSSL_CONF} = abs_path(srctop_file("test", "fips.cnf"));
-    $ENV{OPENSSL_CONF_INCLUDE} = srctop_file("test", "recipes", "30-test_defltfips");
+    $ENV{OPENSSL_CONF_INCLUDE} = srctop_dir("test", "recipes", "30-test_defltfips");
     ok(run(test(["defltfips_test", "badfips"])), "running defltfips_test badfips");
 
     #Test an alternative way of configuring fips (but still with bad module-mac)


### PR DESCRIPTION
In one spot, files aren't properly closed, so the sub-process program
that's supposed to read them can't, because it's locked out.

In another spot, srctop_file() was used where srctop_dir() should be
used to properly format a directory specification.
