### PR TITLE
DOCS: Update the page for 'openssl passwd' to not duplicate some info

### DIFF
--- a/doc/man1/openssl-passwd.pod.in
+++ b/doc/man1/openssl-passwd.pod.in
@@ -31,8 +31,6 @@ This command computes the hash of a password typed at
 run-time or the hash of each password in a list.  The password list is
 taken from the named file for option B<-in>, from stdin for
 option B<-stdin>, or from the command line, or from the terminal otherwise.
-The MD5-based BSD password algorithm B<-1>, its Apache variant B<-apr1>,
-and its AIX variant are available.
 
 =head1 OPTIONS
 


### PR DESCRIPTION
The options -1 and -apr1 were mentioned in DESCRIPTION, not mentioning
any other options or even mentioning that there are more algorithms.
The simple fix is to remove that sentence and let the OPTIONS section
speak for itself.

Fixes #16529
