### PR TITLE
Fix Ordinals.pm when BUILD_METADATA non-empty

### DIFF
--- a/util/perl/OpenSSL/Ordinals.pm
+++ b/util/perl/OpenSSL/Ordinals.pm
@@ -624,6 +624,8 @@ sub set_version {
     my $baseversion = shift // '*';
 
     $version =~ s|-.*||g;
+    # Remove anything past the '+' (i.e. BUILD_METADATA from VERSION.dat)
+    $version =~ s|\+.*||g;
 
     if ($baseversion eq '*') {
         $baseversion = $version;


### PR DESCRIPTION
When BUILD_METADATA in VERSION.dat is non-empty, then `make update`
fails. Prevously, removing the PRE_RELEASE_TAG would also remove
the BUILD_METADATA. When the PRE_RELEASE_TAG is empty (as it is for
3.0.0 release), the code to remove the PRE_RELEASE_TAG fails to
remove the BUILD_METADATA.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
