### PR TITLE
Fix some documentation errors

### DIFF
--- a/doc/man3/ASN1_item_d2i_bio.pod
+++ b/doc/man3/ASN1_item_d2i_bio.pod
@@ -10,15 +10,15 @@ ASN1_item_d2i_fp_ex, ASN1_item_d2i_fp, ASN1_item_i2d_mem_bio
 
  #include <openssl/asn1.h>
 
- ASN1_VALUE *ASN1_item_d2i_ex(ASN1_VALUE **val, const unsigned char **in,
+ ASN1_VALUE *ASN1_item_d2i_ex(ASN1_VALUE **pval, const unsigned char **in,
                               long len, const ASN1_ITEM *it,
                               OSSL_LIB_CTX *libctx, const char *propq);
- ASN1_VALUE *ASN1_item_d2i(ASN1_VALUE **val, const unsigned char **in,
+ ASN1_VALUE *ASN1_item_d2i(ASN1_VALUE **pval, const unsigned char **in,
                            long len, const ASN1_ITEM *it);
 
- void *ASN1_item_d2i_bio_ex(const ASN1_ITEM *it, BIO *in, void *pval,
+ void *ASN1_item_d2i_bio_ex(const ASN1_ITEM *it, BIO *in, void *x,
                             OSSL_LIB_CTX *libctx, const char *propq);
- void *ASN1_item_d2i_bio(const ASN1_ITEM *it, BIO *in, void *pval);
+ void *ASN1_item_d2i_bio(const ASN1_ITEM *it, BIO *in, void *x);
 
  void *ASN1_item_d2i_fp_ex(const ASN1_ITEM *it, FILE *in, void *x,
                            OSSL_LIB_CTX *libctx, const char *propq);

--- a/doc/man3/OSSL_CMP_MSG_get0_header.pod
+++ b/doc/man3/OSSL_CMP_MSG_get0_header.pod
@@ -20,7 +20,7 @@ i2d_OSSL_CMP_MSG_bio
   int OSSL_CMP_MSG_get_bodytype(const OSSL_CMP_MSG *msg);
   int OSSL_CMP_MSG_update_transactionID(OSSL_CMP_CTX *ctx, OSSL_CMP_MSG *msg);
   OSSL_CRMF_MSG *OSSL_CMP_CTX_setup_CRM(OSSL_CMP_CTX *ctx, int for_KUR, int rid);
-  OSSL_CMP_MSG *OSSL_CMP_MSG_read(const char *file);
+  OSSL_CMP_MSG *OSSL_CMP_MSG_read(const char *file, OSSL_LIB_CTX *libctx, const char *propq);
   int OSSL_CMP_MSG_write(const char *file, const OSSL_CMP_MSG *msg);
   OSSL_CMP_MSG *d2i_OSSL_CMP_MSG_bio(BIO *bio, OSSL_CMP_MSG **msg);
   int i2d_OSSL_CMP_MSG_bio(BIO *bio, const OSSL_CMP_MSG *msg);

--- a/doc/man3/OSSL_HTTP_REQ_CTX.pod
+++ b/doc/man3/OSSL_HTTP_REQ_CTX.pod
@@ -70,8 +70,7 @@ The allocated context structure is also populated with an internal allocated
 memory B<BIO>, which collects the HTTP request and additional headers as text.
 
 OSSL_HTTP_REQ_CTX_free() frees up the HTTP request context I<rctx>.
-The I<wbio> and I<rbio> are not free'd and it is up to the application
-to do so.
+The I<rbio> is not free'd, I<wbio> will be free'd if I<free_wbio> is set.
 
 OSSL_HTTP_REQ_CTX_set_request_line() adds the HTTP request line to the context.
 The HTTP method is determined by I<method_POST>,


### PR DESCRIPTION
CLA:trivial

There are 3 changes within the pr:

+ Fix documentation: doc/man3/OSSL_HTTP_REQ_CTX.pod

  Function OSSL_HTTP_REQ_CTX_free will free wbio if rctx->free_wbio is set while documentation says The wbio and rbio are not free'd. This may lead to misuse of freed object.

+ Fix documentation: doc/man3/OSSL_CMP_MSG_get0_header.pod

  Old function defination of OSSL_CMP_MSG_read. Note that some other new functions origins from commit c631378 may also need to be added to documentation.

+ Fix documentation: doc/man3/ASN1_item_d2i_bio.pod

  Some parameters' names are not consistent with source code.


<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
