### PR TITLE
OpenSSL::Ordinals::set_version() should only be given the short version

### DIFF
--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -267,6 +267,7 @@ VERBOSE=$(V)
 VERBOSE_FAILURE=$(VF)
 
 VERSION={- "$config{full_version}" -}
+VERSION_NUMBER={- "$config{version}" -}
 MAJOR={- $config{major} -}
 MINOR={- $config{minor} -}
 SHLIB_VERSION_NUMBER={- $config{shlib_version} -}
@@ -904,7 +905,7 @@ EOF
           #
           my $target = platform->def($args{src});
           my $mkdef = sourcefile('util', 'mkdef.pl');
-          my $ord_ver = $args{intent} eq 'lib' ? ' --version $(VERSION)' : '';
+          my $ord_ver = $args{intent} eq 'lib' ? ' --version $(VERSION_NUMBER)' : '';
           my $ord_name =
               $args{generator}->[1] || basename($args{product}, '.EXE');
           my $case_insensitive =

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -1530,7 +1530,7 @@ EOF
           #
           my $target = platform->def($args{src});
           (my $mkdef_os = $target{shared_target}) =~ s|-shared$||;
-          my $ord_ver = $args{intent} eq 'lib' ? ' --version (VERSION_NUMBER)' : '';
+          my $ord_ver = $args{intent} eq 'lib' ? ' --version $(VERSION_NUMBER)' : '';
           my $ord_name = $args{generator}->[1] || $args{product};
           return <<"EOF";
 $target: $gen0 $deps \$(SRCDIR)/util/mkdef.pl

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -67,6 +67,7 @@ BLDDIR={- $config{builddir} -}
 FIPSKEY={- $config{FIPSKEY} -}
 
 VERSION={- "$config{full_version}" -}
+VERSION_NUMBER={- "$config{version}" -}
 MAJOR={- $config{major} -}
 MINOR={- $config{minor} -}
 SHLIB_VERSION_NUMBER={- $config{shlib_version} -}
@@ -1305,23 +1306,23 @@ SSLHEADERS={- join(" \\\n" . ' ' x 11,
                    fill_lines(" ", $COLUMNS - 11, sort keys %sslheaders)) -}
 
 renumber: build_generated
-	$(PERL) $(SRCDIR)/util/mknum.pl --version $(VERSION) --no-warnings \
+	$(PERL) $(SRCDIR)/util/mknum.pl --version $(VERSION_NUMBER) --no-warnings \
                 --ordinals $(SRCDIR)/util/libcrypto.num \
                 --symhacks $(SRCDIR)/include/openssl/symhacks.h \
                 --renumber \
                 $(CRYPTOHEADERS)
-	$(PERL) $(SRCDIR)/util/mknum.pl --version $(VERSION) --no-warnings \
+	$(PERL) $(SRCDIR)/util/mknum.pl --version $(VERSION_NUMBER) --no-warnings \
                 --ordinals $(SRCDIR)/util/libssl.num \
                 --symhacks $(SRCDIR)/include/openssl/symhacks.h \
                 --renumber \
                 $(SSLHEADERS)
 
 ordinals: build_generated
-	$(PERL) $(SRCDIR)/util/mknum.pl --version $(VERSION) --no-warnings \
+	$(PERL) $(SRCDIR)/util/mknum.pl --version $(VERSION_NUMBER) --no-warnings \
                 --ordinals $(SRCDIR)/util/libcrypto.num \
                 --symhacks $(SRCDIR)/include/openssl/symhacks.h \
                 $(CRYPTOHEADERS)
-	$(PERL) $(SRCDIR)/util/mknum.pl --version $(VERSION) --no-warnings \
+	$(PERL) $(SRCDIR)/util/mknum.pl --version $(VERSION_NUMBER) --no-warnings \
                 --ordinals $(SRCDIR)/util/libssl.num \
                 --symhacks $(SRCDIR)/include/openssl/symhacks.h \
                 $(SSLHEADERS)
@@ -1529,7 +1530,7 @@ EOF
           #
           my $target = platform->def($args{src});
           (my $mkdef_os = $target{shared_target}) =~ s|-shared$||;
-          my $ord_ver = $args{intent} eq 'lib' ? ' --version $(VERSION)' : '';
+          my $ord_ver = $args{intent} eq 'lib' ? ' --version (VERSION_NUMBER)' : '';
           my $ord_name = $args{generator}->[1] || $args{product};
           return <<"EOF";
 $target: $gen0 $deps \$(SRCDIR)/util/mkdef.pl

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -41,6 +41,7 @@ BLDDIR={- $config{builddir} -}
 FIPSKEY={- $config{FIPSKEY} -}
 
 VERSION={- "$config{full_version}" -}
+VERSION_NUMBER={- "$config{version}" -}
 MAJOR={- $config{major} -}
 MINOR={- $config{minor} -}
 
@@ -727,7 +728,7 @@ EOF
           my $mkdef = abs2rel(rel2abs(catfile($config{sourcedir},
                                               "util", "mkdef.pl")),
                               rel2abs($config{builddir}));
-          my $ord_ver = $args{intent} eq 'lib' ? ' --version $(VERSION)' : '';
+          my $ord_ver = $args{intent} eq 'lib' ? ' --version $(VERSION_NUMBER)' : '';
           my $ord_name =
               $args{generator}->[1] || platform->dsoname($args{product});
           return <<"EOF";

--- a/util/perl/OpenSSL/Ordinals.pm
+++ b/util/perl/OpenSSL/Ordinals.pm
@@ -623,8 +623,6 @@ sub set_version {
     my $version = shift // '*';
     my $baseversion = shift // '*';
 
-    $version =~ s|-.*||g;
-
     if ($baseversion eq '*') {
         $baseversion = $version;
         if ($baseversion ne '*') {


### PR DESCRIPTION
This function tried to shave off the pre-release and build metadata
text from the the version number it gets, but didn't do that quite
right.  Since this isn't even a documented behaviour, the easier, and
arguably more correct path is for that function not to try to shave
off anything, and for the callers to feed it the short version number,
"{MAJOR}.{MINOR}.{PATCH}", nothing more.

The build file templates are adjusted accordingly.

-----

This is an alternative to #16537