### PR TITLE
Make openssl speed aes use the -decrypt option

### DIFF
--- a/apps/speed.c
+++ b/apps/speed.c
@@ -821,6 +821,7 @@ static int DES_ede3_cbc_encrypt_loop(void *args)
 
 #define MAX_BLOCK_SIZE 128
 
+static int decrypt = 0;
 static unsigned char iv[2 * MAX_BLOCK_SIZE / 8];
 static AES_KEY aes_ks1, aes_ks2, aes_ks3;
 static int AES_cbc_128_encrypt_loop(void *args)
@@ -830,7 +831,8 @@ static int AES_cbc_128_encrypt_loop(void *args)
     int count;
     for (count = 0; COND(c[D_CBC_128_AES][testnum]); count++)
         AES_cbc_encrypt(buf, buf,
-                        (size_t)lengths[testnum], &aes_ks1, iv, AES_ENCRYPT);
+                        (size_t)lengths[testnum], &aes_ks1, iv,
+                        decrypt ? AES_DECRYPT : AES_ENCRYPT);
     return count;
 }
 
@@ -841,7 +843,8 @@ static int AES_cbc_192_encrypt_loop(void *args)
     int count;
     for (count = 0; COND(c[D_CBC_192_AES][testnum]); count++)
         AES_cbc_encrypt(buf, buf,
-                        (size_t)lengths[testnum], &aes_ks2, iv, AES_ENCRYPT);
+                        (size_t)lengths[testnum], &aes_ks2, iv,
+                        decrypt ? AES_DECRYPT : AES_ENCRYPT);
     return count;
 }
 
@@ -852,7 +855,8 @@ static int AES_cbc_256_encrypt_loop(void *args)
     int count;
     for (count = 0; COND(c[D_CBC_256_AES][testnum]); count++)
         AES_cbc_encrypt(buf, buf,
-                        (size_t)lengths[testnum], &aes_ks3, iv, AES_ENCRYPT);
+                        (size_t)lengths[testnum], &aes_ks3, iv,
+                        decrypt ? AES_DECRYPT : AES_ENCRYPT);
     return count;
 }
 
@@ -864,7 +868,8 @@ static int AES_ige_128_encrypt_loop(void *args)
     int count;
     for (count = 0; COND(c[D_IGE_128_AES][testnum]); count++)
         AES_ige_encrypt(buf, buf2,
-                        (size_t)lengths[testnum], &aes_ks1, iv, AES_ENCRYPT);
+                        (size_t)lengths[testnum], &aes_ks1, iv,
+                        decrypt ? AES_DECRYPT : AES_ENCRYPT);
     return count;
 }
 
@@ -876,7 +881,8 @@ static int AES_ige_192_encrypt_loop(void *args)
     int count;
     for (count = 0; COND(c[D_IGE_192_AES][testnum]); count++)
         AES_ige_encrypt(buf, buf2,
-                        (size_t)lengths[testnum], &aes_ks2, iv, AES_ENCRYPT);
+                        (size_t)lengths[testnum], &aes_ks2, iv,
+                        decrypt ? AES_DECRYPT : AES_ENCRYPT);
     return count;
 }
 
@@ -888,7 +894,8 @@ static int AES_ige_256_encrypt_loop(void *args)
     int count;
     for (count = 0; COND(c[D_IGE_256_AES][testnum]); count++)
         AES_ige_encrypt(buf, buf2,
-                        (size_t)lengths[testnum], &aes_ks3, iv, AES_ENCRYPT);
+                        (size_t)lengths[testnum], &aes_ks3, iv,
+                        decrypt ? AES_DECRYPT : AES_ENCRYPT);
     return count;
 }
 
@@ -915,7 +922,6 @@ static int RAND_bytes_loop(void *args)
 }
 
 static long save_count = 0;
-static int decrypt = 0;
 static int EVP_Update_loop(void *args)
 {
     loopargs_t *tempargs = *(loopargs_t **) args;


### PR DESCRIPTION
with this patch openssl speed -decrypt aes / aes-128-cbc / aes-128-ige
uses AES_DECRYPT mode instead of AES_ENCRYPT mode.
Previously this was only usable for the -evp cipher command.

This is for 1.1.1 only, in master everything uses -evp already.