### PR TITLE
Clarify the documentation around session usage

### DIFF
--- a/doc/man3/SSL_CTX_set_num_tickets.pod
+++ b/doc/man3/SSL_CTX_set_num_tickets.pod
@@ -27,10 +27,10 @@ the client after a full handshake. Set the desired value (which could be 0) in
 the B<num_tickets> argument. Typically these functions should be called before
 the start of the handshake.
 
-The default number of tickets is 2; the default number of tickets sent following
-a resumption handshake is 1 but this cannot be changed using these functions.
-The number of tickets following a resumption handshake can be reduced to 0 using
-custom session ticket callbacks (see L<SSL_CTX_set_session_ticket_cb(3)>).
+The default number of tickets is 2. Following a resumption the number of tickets
+issued will never be more than 1 regardless of the value set via
+SSL_set_num_tickets() or SSL_CTX_set_num_tickets(). If B<num_tickets> is set to
+0 then no tickets will be issued for either a normal connection or a resumption.
 
 Tickets are also issued on receipt of a post-handshake certificate from the
 client following a request by the server using

--- a/doc/man3/SSL_get_session.pod
+++ b/doc/man3/SSL_get_session.pod
@@ -37,8 +37,11 @@ L<SSL_SESSION_is_resumable(3)> for information on how to determine whether an
 SSL_SESSION object can be used for resumption or not.
 
 Additionally, in TLSv1.3, a server can send multiple messages that establish a
-session for a single connection. In that case the above functions will only
-return information on the last session that was received.
+session for a single connection. In that case, on the client side, the above
+functions will only return information on the last session that was received. On
+the server side they will only return information on the last session that was
+sent, or if no session tickets were sent then the session for the current
+connection.
 
 The preferred way for applications to obtain a resumable SSL_SESSION object is
 to use a new session callback as described in L<SSL_CTX_sess_set_new_cb(3)>.


### PR DESCRIPTION
The documented behaviour for SSL_set_num_tickets() was not quite correct, and the behaviour of SSL_get_session() on the server side was not clear.