### PR TITLE
providers: SM2 support ECDH

### DIFF
--- a/providers/implementations/keymgmt/ec_kmgmt.c
+++ b/providers/implementations/keymgmt/ec_kmgmt.c
@@ -93,6 +93,8 @@ static
 const char *sm2_query_operation_name(int operation_id)
 {
     switch (operation_id) {
+    case OSSL_OP_KEYEXCH:
+        return "ECDH";
     case OSSL_OP_SIGNATURE:
         return "SM2";
     }


### PR DESCRIPTION
According to the rfc8998 specification, ECDH supports key exchange
using SM2 curve.

Signed-off-by: Tianjia Zhang <tianjia.zhang@linux.alibaba.com>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
