### PR TITLE
evp: Supports getting pkey type from keymgmt

### DIFF
--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -975,12 +975,18 @@ int EVP_PKEY_type(int type)
 
 int EVP_PKEY_get_id(const EVP_PKEY *pkey)
 {
+    if (pkey->type == EVP_PKEY_KEYMGMT) {
+        const char *name = EVP_KEYMGMT_get0_name(pkey->keymgmt);
+        int type = evp_pkey_name2type(name);
+        return type;
+    }
+
     return pkey->type;
 }
 
 int EVP_PKEY_get_base_id(const EVP_PKEY *pkey)
 {
-    return EVP_PKEY_type(pkey->type);
+    return EVP_PKEY_type(EVP_PKEY_get_id(pkey));
 }
 
 /*


### PR DESCRIPTION
If the public key type is EVP_PKEY_KEYMGMT, errors may occur in
some cases. It is necessary to obtain the exact type of the public
key from keymgmt.

Signed-off-by: Tianjia Zhang <tianjia.zhang@linux.alibaba.com>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
