### PR TITLE
MacOS prior to 10.12 does not support random API correctly [branch openssl-3.0]

### DIFF
--- a/include/crypto/rand.h
+++ b/include/crypto/rand.h
@@ -24,7 +24,7 @@
 
 # if defined(__APPLE__) && !defined(OPENSSL_NO_APPLE_CRYPTO_RANDOM)
 #  include <Availability.h>
-#  if (defined(__MAC_OS_X_VERSION_MIN_REQUIRED) && __MAC_OS_X_VERSION_MIN_REQUIRED >= 101000) || \
+#  if (defined(__MAC_OS_X_VERSION_MIN_REQUIRED) && __MAC_OS_X_VERSION_MIN_REQUIRED >= 101200) || \
      (defined(__IPHONE_OS_VERSION_MIN_REQUIRED) && __IPHONE_OS_VERSION_MIN_REQUIRED >= 80000)
 #   define OPENSSL_APPLE_CRYPTO_RANDOM 1
 #   include <CommonCrypto/CommonCryptoError.h>


### PR DESCRIPTION
Fixes issue #16517

3.0 branch of PR #16587 