### PR TITLE
define SSL_OP_NO_ANTI_REPLAY for clients

### DIFF
--- a/doc/man3/SSL_CTX_sess_set_get_cb.pod
+++ b/doc/man3/SSL_CTX_sess_set_get_cb.pod
@@ -76,8 +76,12 @@ be established with a single connection. In these case the new_session_cb()
 function will be invoked multiple times.
 
 In TLSv1.3 it is recommended that each SSL_SESSION object is only used for
-resumption once. One way of enforcing that is for applications to call
-L<SSL_CTX_remove_session(3)> after a session has been used.
+resumption once. One way for servers to enforce that is for applications to call
+L<SSL_CTX_remove_session(3)> after a session has been used.  Single use of
+SSL_SESSION objects is the default behavior for the OpenSSL session cache on
+a TLS client.  This client-side single-use behavior can be overridden by
+using the SSL_OP_NO_ANTI_REPLAY option with
+L<SSL_CTX_set_options(3)> or L<SSL_set_options(3)>.
 
 The remove_session_cb() is called whenever the SSL engine removes a session
 from the internal cache. This can happen when the session is removed because

--- a/doc/man3/SSL_CTX_set_options.pod
+++ b/doc/man3/SSL_CTX_set_options.pod
@@ -205,14 +205,28 @@ B<only>. See the B<SECURE RENEGOTIATION> section for more details.
 
 =item SSL_OP_NO_ANTI_REPLAY
 
+This option is interpreted differently by clients and servers.
+
 By default, when a server is configured for early data (i.e., max_early_data > 0),
 OpenSSL will switch on replay protection. See L<SSL_read_early_data(3)> for a
 description of the replay protection feature. Anti-replay measures are required
 to comply with the TLSv1.3 specification. Some applications may be able to
 mitigate the replay risks in other ways and in such cases the built in OpenSSL
 functionality is not required. Those applications can turn this feature off by
-setting this option. This is a server-side opton only. It is ignored by
-clients.
+setting this option.
+
+By default, when a client is using a session cache and performs TLSv1.3 session
+resumption, the cache entry that was used to perform resumption is removed from
+the cache at the end of the handshake, even for successful resumption.  This
+"single-use ticket" behavior is recommended by RFC 8446 (and is in effect
+required when the client sends early data) because it provides privacy benefit
+(unlinkability of resumed sessions); likewise, the specification recommends
+that servers send one or more new tickets on each successful TLSv1.3
+connection.  (OpenSSL servers send two tickets on successful full handshakes
+and one ticket on successful resumption handshakes, by default.)  Applications
+that want to use a session ticket multiple times from a client's session cache
+can set this option to have OpenSSL leave the session in the cache after
+successful resumption.
 
 =item SSL_OP_NO_COMPRESSION
 

--- a/include/openssl/ssl.h.in
+++ b/include/openssl/ssl.h.in
@@ -388,8 +388,9 @@ typedef int (*SSL_async_callback_fn)(SSL *s, void *arg);
      */
 # define SSL_OP_TLS_ROLLBACK_BUG                         SSL_OP_BIT(23)
     /*
-     * Switches off automatic TLSv1.3 anti-replay protection for early data.
-     * This is a server-side option only (no effect on the client).
+     * For servers: switches off automatic TLSv1.3 anti-replay protection
+     * for early data.
+     * For clients: switches off single-use tickets from cache.
      */
 # define SSL_OP_NO_ANTI_REPLAY                           SSL_OP_BIT(24)
 # define SSL_OP_NO_SSLv3                                 SSL_OP_BIT(25)

--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -1105,8 +1105,10 @@ WORK_STATE tls_finish_handshake(SSL *s, ossl_unused WORK_STATE wst,
                  * so we remove this one from the cache.
                  */
                 if ((s->session_ctx->session_cache_mode
-                     & SSL_SESS_CACHE_CLIENT) != 0)
+                     & SSL_SESS_CACHE_CLIENT) != 0
+                        && (s->options & SSL_OP_NO_ANTI_REPLAY) == 0) {
                     SSL_CTX_remove_session(s->session_ctx, s->session);
+                }
             } else {
                 /*
                  * In TLSv1.3 we update the cache as part of processing the


### PR DESCRIPTION
Currently, `SSL_OP_NO_ANTI_REPLAY` is only defined for server use (and only for TLS 1.3 at that), for removing the in-openssl checks that enforce single-use tickets [for early data].  (It's documented that if you set this option for servers, you promise to provide replay protection at some other layer.)

We also have default behavior in libssl that removes sessions from client-side session caches after the handshake, thus strongly suggesting single-use tickets on the client side as well.  (Technically you could keep a reference to the session in the application and use it again, so it's not quite "enforcing" single-use tickets.)  This PR expands the scope of `SSL_OP_NO_ANTI_REPLAY` so that it's disabling the "single-use ticket" behavior for both client and server sides.

This is more useful in practice when combined with something like #5932 but can stand on its own.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
