### PR TITLE
providers: Do not use global EVP_CIPHERs and EVP_MDs

### DIFF
--- a/providers/common/provider_util.c
+++ b/providers/common/provider_util.c
@@ -16,10 +16,10 @@
 #include <openssl/proverr.h>
 #ifndef FIPS_MODULE
 # include <openssl/engine.h>
+# include "crypto/evp.h"
 #endif
 #include "prov/provider_util.h"
 #include "internal/nelem.h"
-#include "crypto/evp.h"
 
 void ossl_prov_cipher_reset(PROV_CIPHER *pc)
 {

--- a/providers/common/provider_util.c
+++ b/providers/common/provider_util.c
@@ -96,7 +96,7 @@ int ossl_prov_cipher_load_from_params(PROV_CIPHER *pc,
 
         cipher = EVP_get_cipherbyname(p->data);
         /* Do not use global EVP_CIPHERs */
-        if (cipher->origin != EVP_ORIG_GLOBAL)
+        if (cipher != NULL && cipher->origin != EVP_ORIG_GLOBAL)
             pc->cipher = cipher;
     }
 #endif
@@ -171,7 +171,7 @@ int ossl_prov_digest_load_from_params(PROV_DIGEST *pd,
 
         md = EVP_get_digestbyname(p->data);
         /* Do not use global EVP_MDs */
-        if (md->origin != EVP_ORIG_GLOBAL)
+        if (md != NULL && md->origin != EVP_ORIG_GLOBAL)
             pd->md = md;
     }
 #endif

--- a/providers/common/provider_util.c
+++ b/providers/common/provider_util.c
@@ -19,6 +19,7 @@
 #endif
 #include "prov/provider_util.h"
 #include "internal/nelem.h"
+#include "crypto/evp.h"
 
 void ossl_prov_cipher_reset(PROV_CIPHER *pc)
 {
@@ -90,8 +91,14 @@ int ossl_prov_cipher_load_from_params(PROV_CIPHER *pc,
     ERR_set_mark();
     pc->cipher = pc->alloc_cipher = EVP_CIPHER_fetch(ctx, p->data, propquery);
 #ifndef FIPS_MODULE /* Inside the FIPS module, we don't support legacy ciphers */
-    if (pc->cipher == NULL)
-        pc->cipher = EVP_get_cipherbyname(p->data);
+    if (pc->cipher == NULL) {
+        const EVP_CIPHER *cipher;
+
+        cipher = EVP_get_cipherbyname(p->data);
+        /* Do not use global EVP_CIPHERs */
+        if (cipher->origin != EVP_ORIG_GLOBAL)
+            pc->cipher = cipher;
+    }
 #endif
     if (pc->cipher != NULL)
         ERR_pop_to_mark();
@@ -159,8 +166,14 @@ int ossl_prov_digest_load_from_params(PROV_DIGEST *pd,
     ERR_set_mark();
     ossl_prov_digest_fetch(pd, ctx, p->data, propquery);
 #ifndef FIPS_MODULE /* Inside the FIPS module, we don't support legacy digests */
-    if (pd->md == NULL)
-        pd->md = EVP_get_digestbyname(p->data);
+    if (pd->md == NULL) {
+        const EVP_MD *md;
+
+        md = EVP_get_digestbyname(p->data);
+        /* Do not use global EVP_MDs */
+        if (md->origin != EVP_ORIG_GLOBAL)
+            pd->md = md;
+    }
 #endif
     if (pd->md != NULL)
         ERR_pop_to_mark();


### PR DESCRIPTION
This ensures that only application or engine-based EVP_CIPHERs and EVP_MDs are used as a fallback. Otherwise we can get surprising results like PBKDF2 working with whirlpool hash in a separate library context where no legacy provider is loaded if there is a default configuration file loading the legacy provider.
