### PR TITLE
Explicitly #include <synchapi.h> is unnecessary

### DIFF
--- a/crypto/threads_win.c
+++ b/crypto/threads_win.c
@@ -10,7 +10,6 @@
 #if defined(_WIN32)
 # include <windows.h>
 # if defined(_WIN32_WINNT) && _WIN32_WINNT >= 0x600
-#  include <synchapi.h>
 #  define USE_RWLOCK
 # endif
 #endif


### PR DESCRIPTION
The header is already included by <windows.h> for WinSDK 8 or later. Actually this causes problem for WinSDK 7.1 (defaults for VS2010) that it does not have this header while SRW Locks do exist for Windows 7.

CLA: trivial
