### PR TITLE
Configurations/platform/Unix.pm: account for variants in sharedlib_simple()

### DIFF
--- a/Configurations/platform/Unix.pm
+++ b/Configurations/platform/Unix.pm
@@ -76,7 +76,7 @@ sub sharedlib_simple {
     my $simpleext = $_[0]->shlibextsimple();
 
     return undef unless defined $simplename && defined $name;
-    return undef if ($name eq $simplename && $ext eq $extsimple);
+    return undef if ($name eq $simplename && $ext eq $simpleext);
     return platform::BASE::__concat($simplename, $simpleext);
 }
 

--- a/Configurations/platform/Unix.pm
+++ b/Configurations/platform/Unix.pm
@@ -63,11 +63,21 @@ sub sharedname_simple {
 }
 
 sub sharedlib_simple {
-    return undef
-        if ($_[0]->sharedname($_[1]) eq $_[0]->sharedname_simple($_[1])
-            && $_[0]->shlibext() eq $_[0]->shlibextsimple());
-    return platform::BASE::__concat($_[0]->sharedname_simple($_[1]),
-                                    $_[0]->shlibextsimple());
+    # This function returns the simplified shared library name (no version
+    # or variant in the shared library file name) if the simple variants of
+    # the base name or the suffix differ from the full variants of the same.
+
+    # Note: if $_[1] isn't a shared library name, then $_[0]->sharedname()
+    # and $_[0]->sharedname_simple() will return undef.  This needs being
+    # accounted for.
+    my $name = $_[0]->sharedname($_[1]);
+    my $simplename = $_[0]->sharedname_simple($_[1]);
+    my $ext = $_[0]->shlibext();
+    my $simpleext = $_[0]->shlibextsimple();
+
+    return undef unless defined $simplename && defined $name;
+    return undef if ($name eq $simplename && $ext eq $extsimple);
+    return platform::BASE::__concat($simplename, $simpleext);
 }
 
 sub sharedlib_import {

--- a/Configurations/platform/Unix.pm
+++ b/Configurations/platform/Unix.pm
@@ -63,7 +63,9 @@ sub sharedname_simple {
 }
 
 sub sharedlib_simple {
-    return undef if $_[0]->shlibext() eq $_[0]->shlibextsimple();
+    return undef
+        if ($_[0]->sharedname($_[1] eq $_[0]->sharedname_simple($_[1]))
+            && $_[0]->shlibext() eq $_[0]->shlibextsimple());
     return platform::BASE::__concat($_[0]->sharedname_simple($_[1]),
                                     $_[0]->shlibextsimple());
 }

--- a/Configurations/platform/Unix.pm
+++ b/Configurations/platform/Unix.pm
@@ -64,7 +64,7 @@ sub sharedname_simple {
 
 sub sharedlib_simple {
     return undef
-        if ($_[0]->sharedname($_[1] eq $_[0]->sharedname_simple($_[1]))
+        if ($_[0]->sharedname($_[1]) eq $_[0]->sharedname_simple($_[1])
             && $_[0]->shlibext() eq $_[0]->shlibextsimple());
     return platform::BASE::__concat($_[0]->sharedname_simple($_[1]),
                                     $_[0]->shlibextsimple());


### PR DESCRIPTION
OpenSSL 1.1.1 links the simple libcrypto.so to libcrypto_variant.so,
this was inadvertently dropped.

Fixes #16605
