### PR TITLE
APPS/{x509,req}: Fix description and diagnostics of -key, -in, etc. options - port to 3.0

### DIFF
--- a/apps/x509.c
+++ b/apps/x509.c
@@ -676,9 +676,6 @@ int x509_main(int argc, char **argv)
     }
 
     if (reqfile) {
-        if (infile == NULL)
-            BIO_printf(bio_err,
-                       "Warning: Reading cert request from stdin since no -in option is given\n");
         req = load_csr(infile, informat, "certificate request input");
         if (req == NULL)
             goto end;
@@ -728,9 +725,6 @@ int x509_main(int argc, char **argv)
             }
         }
     } else {
-        if (infile == NULL)
-            BIO_printf(bio_err,
-                       "Warning: Reading certificate from stdin since no -in option is given\n");
         x = load_cert_pass(infile, informat, 1, passin, "certificate");
         if (x == NULL)
             goto end;

--- a/doc/man1/openssl-req.pod.in
+++ b/doc/man1/openssl-req.pod.in
@@ -79,9 +79,10 @@ The data is a PKCS#10 object.
 
 =item B<-in> I<filename>
 
-This specifies the input filename to read a request from or standard input
-if this option is not specified. A request is only read if the creation
-options (B<-new> or B<-newkey>) are not specified.
+This specifies the input filename to read a request from.
+This defaults to standard input unless B<-x509> or B<-CA> is specified.
+A request is only read if the creation options
+(B<-new> or B<-newkey> or B<-precert>) are not specified.
 
 =item B<-sigopt> I<nm>:I<v>
 
@@ -156,8 +157,13 @@ else by default an RSA key with 2048 bits length.
 
 =item B<-newkey> I<arg>
 
-This option creates a new certificate request and a new private
-key. The argument takes one of several forms.
+This option is used to generate a new private key unless B<-key> is given.
+It is subsequently used as if it was given using the B<-key> option.
+
+This option implies the B<-new> flag to create a new certificate request
+or a new certificate in case B<-x509> is given.
+
+The argument takes one of several forms.
 
 [B<rsa:>]I<nbits> generates an RSA key I<nbits> in size.
 If I<nbits> is omitted, i.e., B<-newkey> B<rsa> is specified,
@@ -193,9 +199,14 @@ See L<openssl-genpkey(1)/KEY GENERATION OPTIONS> for more details.
 
 =item B<-key> I<filename>|I<uri>
 
-This specifies the key to include and to use for request self-signature
-and for self-signing certificates produced with the B<-x509> option.
-It also accepts PKCS#8 format private keys for PEM format files.
+This option provides the private key for signing a new certificate or
+certificate request.
+Unless B<-in> is given, the corresponding public key is placed in
+the new certificate or certificate request, resulting in a self-signature.
+
+For certificate signing this option is overridden by the B<-CA> option.
+
+This option also accepts PKCS#8 format private keys for PEM format files.
 
 =item B<-keyform> B<DER>|B<PEM>|B<P12>|B<ENGINE>
 
@@ -267,6 +278,8 @@ This option has been deprecated and has no effect.
 This option outputs a certificate instead of a certificate request.
 This is typically used to generate test certificates.
 It is implied by the B<-CA> option.
+
+This option implies the B<-new> flag if B<-in> is not given.
 
 If an existing request is specified with the B<-in> option, it is converted
 to the a certificate; otherwise a request is created from scratch.

--- a/doc/man1/openssl-x509.pod.in
+++ b/doc/man1/openssl-x509.pod.in
@@ -120,14 +120,14 @@ Generate a certificate from scratch, not using an input certificate
 or certificate request. So the B<-in> option must not be used in this case.
 Instead, the B<-subj> option needs to be given.
 The public key to include can be given with the B<-force_pubkey> option
-and defaults to the key given with the B<-key> option,
+and defaults to the key given with the B<-key> (or B<-signkey>) option,
 which implies self-signature.
 
 =item B<-x509toreq>
 
 Output a PKCS#10 certificate request (rather than a certificate).
-The B<-key> option must be used to provide the private key for self-signing;
-the corresponding public key is placed in the subjectPKInfo field.
+The B<-key> (or B<-signkey>) option must be used to provide the private key for
+self-signing; the corresponding public key is placed in the subjectPKInfo field.
 
 X.509 extensions included in a certificate input are not copied by default.
 X.509 extensions to be added can be specified using the B<-extfile> option.
@@ -360,8 +360,9 @@ Check that the certificate matches the specified IP address.
 
 =item B<-set_serial> I<n>
 
-Specifies the serial number to use. This option can be used with either
-the B<-key> or B<-CA> options. If used in conjunction with the B<-CA> option
+Specifies the serial number to use.
+This option can be used with the B<-key>, B<-signkey>, or B<-CA> options.
+If used in conjunction with the B<-CA> option
 the serial number file (as specified by the B<-CAserial> option) is not used.
 
 The serial number can be decimal or hex (if preceded by C<0x>).
@@ -405,7 +406,8 @@ or certificate request.
 =item B<-force_pubkey> I<filename>
 
 When a certificate is created set its public key to the key in I<filename>
-instead of the key contained in the input or given with the B<-key> option.
+instead of the key contained in the input
+or given with the B<-key> (or B<-signkey>) option.
 
 This option is useful for creating self-issued certificates that are not
 self-signed, for instance when the key cannot be used for signing, such as DH.
@@ -451,7 +453,7 @@ for testing.
 
 The digest to use.
 This affects any signing or printing option that uses a message
-digest, such as the B<-fingerprint>, B<-key> and B<-CA> options.
+digest, such as the B<-fingerprint>, B<-key>, and B<-CA> options.
 Any digest supported by the L<openssl-dgst(1)> command can be used.
 If not specified then SHA1 is used with B<-fingerprint> or
 the default digest for the signing algorithm is used, typically SHA256.
@@ -469,7 +471,7 @@ When present, this behaves like a "micro CA" as follows:
 The subject name of the "CA" certificate is placed as issuer name in the new
 certificate, which is then signed using the "CA" key given as detailed below.
 
-This option cannot be used in conjunction with the B<-key> option.
+This option cannot be used in conjunction with B<-key> (or B<-signkey>).
 This option is normally combined with the B<-req> option referencing a CSR.
 Without the B<-req> option the input must be an existing certificate
 unless the B<-new> option is given, which generates a certificate from scratch.

--- a/doc/man1/openssl-x509.pod.in
+++ b/doc/man1/openssl-x509.pod.in
@@ -102,9 +102,11 @@ Print out a usage message.
 
 =item B<-in> I<filename>|I<uri>
 
-If the B<-req> option is not used this specifies the input
-to read a certificate from or standard input if this option is not specified.
-With the B<-req> option this specifies a certificate request file.
+This specifies the input to read a certificate from
+or the input file for reading a certificate request if the B<-req> flag is used.
+In both cases this defaults to standard input.
+
+This option cannot be combined with the B<-new> flag.
 
 =item B<-passin> I<arg>
 
@@ -163,9 +165,12 @@ Names and values of these options are algorithm-specific.
 
 =item B<-key> I<filename>|I<uri>
 
-This option causes the new certificate or certificate request
-to be self-signed using the supplied private key.
-This cannot be used in conjunction with the B<-CA> option.
+This option provides the private key for signing a new certificate or
+certificate request.
+Unless B<-force_pubkey> is given, the corresponding public key is placed in
+the new certificate or certificate request, resulting in a self-signature.
+
+This option cannot be used in conjunction with the B<-CA> option.
 
 It sets the issuer name to the subject name (i.e., makes it self-issued)
 and changes the public key to the supplied value (unless overridden
@@ -466,7 +471,7 @@ certificate, which is then signed using the "CA" key given as detailed below.
 
 This option cannot be used in conjunction with the B<-key> option.
 This option is normally combined with the B<-req> option referencing a CSR.
-Without the B<-req> option the input must be a self-signed certificate
+Without the B<-req> option the input must be an existing certificate
 unless the B<-new> option is given, which generates a certificate from scratch.
 
 =item B<-CAform> B<DER>|B<PEM>|B<P12>,


### PR DESCRIPTION
This is a proposed backport of #16440 (as discussed there) from master to 3.0:

Over the years, the `x509` and `req` app options have become a mess
and their documentation and help output is partly outdated, incomplete, or even wrong.
I recently came across this issue again when extending the tests in #16342.

This PR improves the description of the `-key`, `-in`, and related options
and adds some warnings for useless or problematic option combinations.

Note that this does not change the semantics of the options.

- [x] documentation is added or updated

