### PR TITLE
RFC7250 (RPK) support (Fixes #6929)

### DIFF
--- a/.github/workflows/run-checker-ci.yml
+++ b/.github/workflows/run-checker-ci.yml
@@ -21,6 +21,7 @@ jobs:
           no-ec,
           no-ec2m,
           no-legacy,
+          no-rpk,
           no-sock,
           no-srp,
           no-srtp,

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,10 @@ OpenSSL 3.1
 
 ### Changes between 3.0 and 3.1 [xx XXX xxxx]
 
+ * Add Raw Public Key (RFC7250) support.
+
+   *Todd Short*
+
  * Extended Kernel TLS (KTLS) to support TLS 1.3 receive offload.
 
    *Daiki Ueno, John Baldwin and Dmitry Podgorny*

--- a/Configure
+++ b/Configure
@@ -473,6 +473,7 @@ my @disablables = (
     "rdrand",
     "rfc3779",
     "rmd160",
+    "rpk",
     "scrypt",
     "sctp",
     "secure-memory",
@@ -644,7 +645,10 @@ my @disable_cascades = (
 
     "fips"              => [ "fips-securitychecks", "acvp-tests" ],
 
-    "deprecated-3.0"    => [ "engine", "srp" ]
+    "deprecated-3.0"    => [ "engine", "srp" ],
+
+    sub { $disabled{"tls1_2"} && $disabled{"tls1_3"} }
+                        => [ "rpk" ]
     );
 
 # Avoid protocol support holes.  Also disable all versions below N, if version

--- a/NEWS.md
+++ b/NEWS.md
@@ -21,6 +21,7 @@ OpenSSL 3.1
 
 ### Major changes between OpenSSL 3.0 and OpenSSL 3.1 [under development]
 
+  * Add Raw Public Key (RFC7250) support.
   * Subject or issuer names in X.509 objects are now displayed as UTF-8 strings
     by default.
   * TCP Fast Open (RFC7413) support is available on Linux, macOS, and FreeBSD

--- a/apps/lib/s_cb.c
+++ b/apps/lib/s_cb.c
@@ -665,6 +665,10 @@ static STRINT_PAIR tlsext_types[] = {
     {"session ticket", TLSEXT_TYPE_session_ticket},
     {"renegotiation info", TLSEXT_TYPE_renegotiate},
     {"signed certificate timestamps", TLSEXT_TYPE_signed_certificate_timestamp},
+#ifndef OPENSSL_NO_RPK
+    {"client cert type", TLSEXT_TYPE_client_cert_type},
+    {"server cert type", TLSEXT_TYPE_server_cert_type},
+#endif
     {"TLS padding", TLSEXT_TYPE_padding},
 #ifdef TLSEXT_TYPE_next_proto_neg
     {"next protocol", TLSEXT_TYPE_next_proto_neg},

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -467,6 +467,11 @@ typedef enum OPTION_choice {
 #endif
     OPT_DANE_TLSA_RRDATA, OPT_DANE_EE_NO_NAME,
     OPT_ENABLE_PHA,
+#ifndef OPENSSL_NO_RPK
+    OPT_ENABLE_SERVER_RPK,
+    OPT_ENABLE_CLIENT_RPK,
+    OPT_PEER_RPK,
+#endif
     OPT_SCTP_LABEL_BUG,
     OPT_KTLS,
     OPT_R_ENUM, OPT_PROV_ENUM
@@ -657,6 +662,11 @@ const OPTIONS s_client_options[] = {
 #endif
     {"early_data", OPT_EARLY_DATA, '<', "File to send as early data"},
     {"enable_pha", OPT_ENABLE_PHA, '-', "Enable post-handshake-authentication"},
+#ifndef OPENSSL_NO_RPK
+    {"enable_server_rpk", OPT_ENABLE_SERVER_RPK, '-', "Enable raw public keys (RFC7250) from the server"},
+    {"enable_client_rpk", OPT_ENABLE_CLIENT_RPK, '-', "Enable raw public keys (RFC7250) from the client"},
+    {"peer_rpk", OPT_PEER_RPK, '<', "PEM-encoded public-key or certificate with server RPK"},
+#endif
 #ifndef OPENSSL_NO_SRTP
     {"use_srtp", OPT_USE_SRTP, 's',
      "Offer SRTP key management with a colon-separated profile list"},
@@ -896,6 +906,13 @@ int s_client_main(int argc, char **argv)
 #endif
     char *psksessf = NULL;
     int enable_pha = 0;
+#ifndef OPENSSL_NO_RPK
+    int enable_server_rpk = 0;
+    int enable_client_rpk = 0;
+    X509 *peer_rpk_cert = NULL;
+    EVP_PKEY *peer_rpk = NULL;
+    char *peer_rpk_file = NULL;
+#endif
 #ifndef OPENSSL_NO_SCTP
     int sctp_label_bug = 0;
 #endif
@@ -1490,6 +1507,17 @@ int s_client_main(int argc, char **argv)
             enable_ktls = 1;
 #endif
             break;
+#ifndef OPENSSL_NO_RPK
+        case OPT_ENABLE_SERVER_RPK:
+            enable_server_rpk = 1;
+            break;
+        case OPT_ENABLE_CLIENT_RPK:
+            enable_client_rpk = 1;
+            break;
+        case OPT_PEER_RPK:
+            peer_rpk_file = opt_arg();
+            break;
+#endif
         }
     }
 
@@ -1687,6 +1715,23 @@ int s_client_main(int argc, char **argv)
 
     if (!load_excert(&exc))
         goto end;
+
+#ifndef OPENSSL_NO_RPK
+    if (peer_rpk_file != NULL) {
+        peer_rpk = load_pubkey(peer_rpk_file, key_format, 0, pass, e, "server RPK file");
+        if (peer_rpk == NULL) {
+            peer_rpk_cert = load_cert(peer_rpk_file, key_format, "server RPK file");
+            if (peer_rpk_cert != NULL) {
+                peer_rpk = X509_get_pubkey(peer_rpk_cert);
+            }
+        }
+        if (peer_rpk == NULL) {
+            BIO_printf(bio_err, "Error loading server RPK file\n");
+            ERR_print_errors(bio_err);
+            goto end;
+        }
+    }
+#endif
 
     if (bio_c_out == NULL) {
         if (c_quiet && !c_debug) {
@@ -1980,6 +2025,21 @@ int s_client_main(int argc, char **argv)
 
     if (enable_pha)
         SSL_set_post_handshake_auth(con, 1);
+
+#ifndef OPENSSL_NO_RPK
+    if (enable_client_rpk)
+        SSL_set_options(con, SSL_OP_RPK_CLIENT);
+    if (enable_server_rpk) {
+        SSL_set_options(con, SSL_OP_RPK_SERVER);
+        if (peer_rpk != NULL) {
+            if (!SSL_add1_expected_peer_rpk(con, peer_rpk)) {
+                BIO_printf(bio_err, "Error setting expected server RPK\n");
+                ERR_print_errors(bio_err);
+                goto end;
+            }
+        }
+    }
+#endif
 
     if (sess_in != NULL) {
         SSL_SESSION *sess;
@@ -3158,6 +3218,10 @@ int s_client_main(int argc, char **argv)
 #endif
     OPENSSL_free(sname_alloc);
     BIO_ADDR_free(tfo_addr);
+#ifndef OPENSSL_NO_RPK
+    EVP_PKEY_free(peer_rpk);
+    X509_free(peer_rpk_cert);
+#endif
     OPENSSL_free(connectstr);
     OPENSSL_free(bindstr);
     OPENSSL_free(bindhost);
@@ -3244,6 +3308,25 @@ static void print_stuff(BIO *bio, SSL *s, int full)
         } else {
             BIO_printf(bio, "no peer certificate available\n");
         }
+
+#ifndef OPENSSL_NO_RPK
+        /* Only display RPK information if configured */
+        if (SSL_rpk_send_negotiated(s))
+            BIO_printf(bio, "Client-to-server raw public key negotiated\n");
+        if (SSL_rpk_receive_negotiated(s))
+            BIO_printf(bio, "Server-to-client raw public key negotiated\n");
+        if (SSL_get_options(s) & SSL_OP_RPK_SERVER) {
+            EVP_PKEY *peer_rpk = SSL_get0_peer_rpk(s);
+
+            if (peer_rpk != NULL) {
+                BIO_printf(bio, "Server raw public key\n");
+                EVP_PKEY_print_public(bio, peer_rpk, 2, NULL);
+            } else {
+                BIO_printf(bio, "no peer rpk available\n");
+            }
+        }
+#endif
+
         print_ca_names(bio, s);
 
         ssl_print_sigalgs(bio, s);

--- a/doc/build.info
+++ b/doc/build.info
@@ -2367,6 +2367,10 @@ DEPEND[html/man3/SSL_accept.html]=man3/SSL_accept.pod
 GENERATE[html/man3/SSL_accept.html]=man3/SSL_accept.pod
 DEPEND[man/man3/SSL_accept.3]=man3/SSL_accept.pod
 GENERATE[man/man3/SSL_accept.3]=man3/SSL_accept.pod
+DEPEND[html/man3/SSL_add1_expected_peer_rpk.html]=man3/SSL_add1_expected_peer_rpk.pod
+GENERATE[html/man3/SSL_add1_expected_peer_rpk.html]=man3/SSL_add1_expected_peer_rpk.pod
+DEPEND[man/man3/SSL_add1_expected_peer_rpk.3]=man3/SSL_add1_expected_peer_rpk.pod
+GENERATE[man/man3/SSL_add1_expected_peer_rpk.3]=man3/SSL_add1_expected_peer_rpk.pod
 DEPEND[html/man3/SSL_alert_type_string.html]=man3/SSL_alert_type_string.pod
 GENERATE[html/man3/SSL_alert_type_string.html]=man3/SSL_alert_type_string.pod
 DEPEND[man/man3/SSL_alert_type_string.3]=man3/SSL_alert_type_string.pod
@@ -3319,6 +3323,7 @@ html/man3/SSL_SESSION_is_resumable.html \
 html/man3/SSL_SESSION_print.html \
 html/man3/SSL_SESSION_set1_id.html \
 html/man3/SSL_accept.html \
+html/man3/SSL_add1_expected_peer_rpk.html \
 html/man3/SSL_alert_type_string.html \
 html/man3/SSL_alloc_buffers.html \
 html/man3/SSL_check_chain.html \
@@ -3913,6 +3918,7 @@ man/man3/SSL_SESSION_is_resumable.3 \
 man/man3/SSL_SESSION_print.3 \
 man/man3/SSL_SESSION_set1_id.3 \
 man/man3/SSL_accept.3 \
+man/man3/SSL_add1_expected_peer_rpk.3 \
 man/man3/SSL_alert_type_string.3 \
 man/man3/SSL_alloc_buffers.3 \
 man/man3/SSL_check_chain.3 \

--- a/doc/man1/openssl-s_client.pod.in
+++ b/doc/man1/openssl-s_client.pod.in
@@ -129,6 +129,9 @@ B<openssl> B<s_client>
 {- $OpenSSL::safe::opt_provider_synopsis -}
 {- $OpenSSL::safe::opt_engine_synopsis -}[B<-ssl_client_engine> I<id>]
 {- $OpenSSL::safe::opt_v_synopsis -}
+[B<-enable_server_rpk>]
+[B<-enable_client_rpk>]
+[B<-peer_rpk> I<file>]
 [I<host>:I<port>]
 
 =head1 DESCRIPTION
@@ -813,6 +816,18 @@ Specify engine to be used for client certificate operations.
 
 Verification errors are displayed, for debugging, but the command will
 proceed unless the B<-verify_return_error> option is used.
+
+=item B<-enable_server_rpk>
+
+Enable the use of server delivered raw public keys (RFC7250).
+
+=item B<-enable_client_rpk>
+
+Enable the use of client delivered raw public keys (RFC7250).
+
+=item B<-peer_rpk> I<file>
+
+File containing a validated peer raw public key (RFC7250).
 
 =item I<host>:I<port>
 

--- a/doc/man1/openssl-s_server.pod.in
+++ b/doc/man1/openssl-s_server.pod.in
@@ -148,6 +148,9 @@ B<openssl> B<s_server>
 {- $OpenSSL::safe::opt_trust_synopsis -}
 {- $OpenSSL::safe::opt_r_synopsis -}
 {- $OpenSSL::safe::opt_engine_synopsis -}{- $OpenSSL::safe::opt_provider_synopsis -}
+[B<-enable_server_rpk>]
+[B<-enable_client_rpk>]
+[B<-peer_rpk> I<file>]
 
 =head1 DESCRIPTION
 
@@ -843,6 +846,18 @@ Enable acceptance of TCP Fast Open (RFC7413) connections.
 If the server requests a client certificate, then
 verification errors are displayed, for debugging, but the command will
 proceed unless the B<-verify_return_error> option is used.
+
+=item B<-enable_server_rpk>
+
+Enable the use of server delivered raw public keys (RFC7250).
+
+=item B<-enable_client_rpk>
+
+Enable the use of client delivered raw public keys (RFC7250).
+
+=item B<-peer_rpk> I<file>
+
+File containing a validated peer raw public key (RFC7250).
 
 =back
 

--- a/doc/man3/SSL_CONF_cmd.pod
+++ b/doc/man3/SSL_CONF_cmd.pod
@@ -532,6 +532,12 @@ B<KTLS>: Enables kernel TLS if support has been compiled in, and it is supported
 by the negotiated ciphersuites and extensions. Equivalent to
 B<SSL_OP_ENABLE_KTLS>.
 
+B<ClientRPK>: Enables use of raw public keys (RFC7250) by the client for identity.
+Equivalent to B<SSL_OP_RPK_CLIENT>.
+
+B<ServerRPK>: Enables use of raw public keys (RFC7250) by the server for identity.
+Equivalent to B<SSL_OP_RPK_SERVER>.
+
 =item B<VerifyMode>
 
 The B<value> argument is a comma separated list of flags to set.

--- a/doc/man3/SSL_CTX_set_options.pod
+++ b/doc/man3/SSL_CTX_set_options.pod
@@ -305,6 +305,26 @@ those clients (e.g. mobile) use ChaCha20-Poly1305 if that cipher is anywhere
 in the server cipher list; but still allows other clients to use AES and other
 ciphers. Requires B<SSL_OP_CIPHER_SERVER_PREFERENCE>.
 
+=item SSL_OP_RPK_CLIENT
+
+Enable the use of raw public keys (RFC7250) from the client to the server.
+Both ends of the connection must enable this for RPK client-to-server use.
+
+The raw public key is normally taken from the certificate assigned to the
+connection (e.g. via SSL_use_certificate()), but if a certificate is not
+configured, then the public key will be extracted from the assigned
+private key.
+
+=item SSL_OP_RPK_SERVER
+
+Enable the use of raw public keys (RFC7250) from the server to the client.
+Both ends of the connection must enable this for RPK server-to-client use.
+
+The raw public key is normally taken from the certificate assigned to the
+connection (e.g. via SSL_use_certificate()), but if a certificate is not
+configured, then the public key will be extracted from the assigned
+private key.
+
 =item SSL_OP_TLS_ROLLBACK_BUG
 
 Disable version rollback attack detection.

--- a/doc/man3/SSL_add1_expected_peer_rpk.pod
+++ b/doc/man3/SSL_add1_expected_peer_rpk.pod
@@ -1,0 +1,88 @@
+=pod
+
+=head1 NAME
+
+SSL_get0_peer_rpk,
+SSL_rpk_send_negotiated,
+SSL_rpk_receive_negotiated,
+SSL_SESSION_get0_peer_rpk,
+SSL_add1_expected_peer_rpk - raw public key (RFC7250) support
+
+=head1 SYNOPSIS
+
+ #include <openssl/ssl.h>
+
+ EVP_PKEY *SSL_get0_peer_rpk(const SSL *s);
+ EVP_PKEY *SSL_SESSION_get0_peer_rpk(const SSL_SESSION *ss);
+ int SSL_rpk_send_negotiated(const SSL *s);
+ int SSL_rpk_receive_negotiated(const SSL *s);
+ int SSL_add1_expected_peer_rpk(SSL *s, EVP_PKEY *pkey);
+
+=head1 DESCRIPTION
+
+SSL_get0_peer_rpk() returns the peer's raw public key from SSL B<s>.
+
+SSL_rpk_send_negotiated() indicates whether sending a raw public key was
+negotiated with the peer.
+
+SSL_rpk_receive_negotiated() indicates whether receiving a raw public key
+was negotiated with the peer.
+
+SSL_SESSION_get0_peer_rpk() returns the peer's raw public key from
+SSL_SESSION B<ss> in the case of resumption.
+
+SSL_add1_expected_peer_rpk() configures the given B<pkey>
+as a public key that the peer is expected to present after negotiating
+raw public keys (RFC7250). The reference count on the provided B<pkey> is
+incremented when added to the SSL B<s>.
+
+=head1 NOTES
+
+Raw public keys are used in place of certificates when the option is
+negotiated. Adding more than one key is possible to allow for key rotation,
+where a peer might be expected to offer an "old" or "new" key and the endpoint
+must be able to accept either one.  It also enables the use of different
+types of keys along with signature-algorithm negotiation.
+
+When raw public keys are used, the certificate verify callback is not called.
+Raw public keys have no subject, issuer, validity dates nor digital signature.
+The peer's raw public key must be added via SSL_add1_expected_peer_rpk()
+for the handshake to succeed. Multiple public keys may be added to the SSL B<s>.
+
+The SSL_SESSION_get0_peer_rpk() and SSL_get0_peer_rpk() functions can be
+used to retrieve a key that is then used in SSL_add1_expected_peer_rpk().
+
+The following options enable negotiation of raw public keys:
+
+=over 4
+
+=item SSL_OP_RPK_CLIENT
+
+=item SSL_OP_RPK_SERVER
+
+=back
+
+The raw public key is normally taken from the certificate assigned to the
+connection (e.g. via SSL_use_certificate()), but if a certificate is not
+configured, then the public key will be extracted from the assigned
+private key.
+
+=head1 RETURN VALUES
+
+SSL_get0_peer_rpk() and SSL_SESSION_get0_peer_rpk() return the peer's raw
+public key as an EVP_PKEY or NULL when the raw public key is not available.
+
+SSL_rpk_send_negotiated() and SSL_rpk_receive_negotiated() return 0 for false,
+and 1 for true.
+
+SSL_add1_expected_peer_rpk() returns 1 on success and 0 on failure.
+
+=head1 HISTORY
+
+These functions were added in OpenSSL 3.1.0.
+
+=head1 COPYRIGHT
+
+Copyright 2021 The OpenSSL Project Authors. All Rights Reserved.
+
+=cut

--- a/include/openssl/ssl.h.in
+++ b/include/openssl/ssl.h.in
@@ -408,6 +408,8 @@ typedef int (*SSL_async_callback_fn)(SSL *s, void *arg);
      */
 # define SSL_OP_CRYPTOPRO_TLSEXT_BUG                     SSL_OP_BIT(31)
 
+# define SSL_OP_RPK_SERVER                               SSL_OP_BIT(32)
+# define SSL_OP_RPK_CLIENT                               SSL_OP_BIT(33)
 /*
  * Option "collections."
  */
@@ -2525,6 +2527,14 @@ void SSL_set_allow_early_data_cb(SSL *s,
 /* store the default cipher strings inside the library */
 const char *OSSL_default_cipher_list(void);
 const char *OSSL_default_ciphersuites(void);
+
+#  ifndef OPENSSL_NO_RPK
+__owur EVP_PKEY *SSL_get0_peer_rpk(const SSL *s);
+__owur EVP_PKEY *SSL_SESSION_get0_peer_rpk(SSL_SESSION *s);
+__owur int SSL_add1_expected_peer_rpk(SSL *s, EVP_PKEY *pkey);
+__owur int SSL_rpk_send_negotiated(const SSL *s);
+__owur int SSL_rpk_receive_negotiated(const SSL *s);
+#  endif
 
 # ifdef  __cplusplus
 }

--- a/include/openssl/tls1.h
+++ b/include/openssl/tls1.h
@@ -122,6 +122,15 @@ extern "C" {
  */
 # define TLSEXT_TYPE_signed_certificate_timestamp    18
 
+# ifndef OPENSSL_NO_RPK
+/*
+ * Extension type for Raw Public Keys
+ * https://tools.ietf.org/html/rfc7250
+ * https://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml
+ */
+#  define TLSEXT_TYPE_client_cert_type   19
+#  define TLSEXT_TYPE_server_cert_type   20
+# endif
 /*
  * ExtensionType value for TLS padding extension.
  * http://tools.ietf.org/html/draft-agl-tls-padding
@@ -210,6 +219,17 @@ extern "C" {
 # define TLSEXT_max_fragment_length_1024        2
 # define TLSEXT_max_fragment_length_2048        3
 # define TLSEXT_max_fragment_length_4096        4
+
+# ifndef OPENSSL_NO_RPK
+/*
+ * TLS Certificate Type (for RFC7250)
+ * https://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml#tls-extensiontype-values-3
+ */
+#  define TLSEXT_cert_type_x509         0
+#  define TLSEXT_cert_type_pgp          1 /* recognized, but not supported */
+#  define TLSEXT_cert_type_rpk          2
+#  define TLSEXT_cert_type_1609dot2     3 /* recognized, but not supported */
+# endif
 
 int SSL_CTX_set_tlsext_max_fragment_length(SSL_CTX *ctx, uint8_t mode);
 int SSL_set_tlsext_max_fragment_length(SSL *ssl, uint8_t mode);

--- a/ssl/ssl_conf.c
+++ b/ssl/ssl_conf.c
@@ -393,6 +393,10 @@ static int cmd_Options(SSL_CONF_CTX *cctx, const char *value)
         SSL_FLAG_TBL_INV("AntiReplay", SSL_OP_NO_ANTI_REPLAY),
         SSL_FLAG_TBL_INV("ExtendedMasterSecret", SSL_OP_NO_EXTENDED_MASTER_SECRET),
         SSL_FLAG_TBL_INV("CANames", SSL_OP_DISABLE_TLSEXT_CA_NAMES),
+#ifndef OPENSSL_NO_RPK
+        SSL_FLAG_TBL("ServerRPK", SSL_OP_RPK_SERVER),
+        SSL_FLAG_TBL("ClientRPK", SSL_OP_RPK_CLIENT),
+#endif
         SSL_FLAG_TBL("KTLS", SSL_OP_ENABLE_KTLS)
     };
     if (value == NULL)

--- a/ssl/statem/extensions_cust.c
+++ b/ssl/statem/extensions_cust.c
@@ -522,6 +522,10 @@ int SSL_extension_supported(unsigned int ext_type)
     case TLSEXT_TYPE_certificate_authorities:
     case TLSEXT_TYPE_psk:
     case TLSEXT_TYPE_post_handshake_auth:
+#ifndef OPENSSL_NO_RPK
+    case TLSEXT_TYPE_client_cert_type:
+    case TLSEXT_TYPE_server_cert_type:
+#endif
         return 1;
     default:
         return 0;

--- a/ssl/statem/statem_local.h
+++ b/ssl/statem/statem_local.h
@@ -131,6 +131,12 @@ __owur int tls_client_key_exchange_post_work(SSL *s);
 __owur int tls_construct_cert_status_body(SSL *s, WPACKET *pkt);
 __owur int tls_construct_cert_status(SSL *s, WPACKET *pkt);
 __owur MSG_PROCESS_RETURN tls_process_key_exchange(SSL *s, PACKET *pkt);
+#ifndef OPENSSL_NO_RPK
+__owur MSG_PROCESS_RETURN tls_process_server_rpk(SSL *s, PACKET *pkt);
+__owur MSG_PROCESS_RETURN tls_process_client_rpk(SSL *s, PACKET *pkt);
+__owur unsigned long tls_output_rpk(SSL *s, WPACKET *pkt, CERT_PKEY *cpk);
+__owur int tls_process_rpk(SSL *s, PACKET *pkt, EVP_PKEY **match);
+#endif
 __owur MSG_PROCESS_RETURN tls_process_server_certificate(SSL *s, PACKET *pkt);
 __owur WORK_STATE tls_post_process_server_certificate(SSL *s, WORK_STATE wst);
 __owur int ssl3_check_cert_and_algorithm(SSL *s);
@@ -423,3 +429,24 @@ int tls_handle_alpn(SSL *s);
 
 int tls13_save_handshake_digest_for_pha(SSL *s);
 int tls13_restore_handshake_digest_for_pha(SSL *s);
+
+__owur EVP_PKEY* tls_get_peer_pkey(const SSL *s);
+#ifndef OPENSSL_NO_RPK
+/* RFC7250 */
+EXT_RETURN tls_construct_ctos_client_cert_type(SSL *s, WPACKET *pkt, unsigned int context,
+                                               X509 *x, size_t chainidx);
+EXT_RETURN tls_construct_stoc_client_cert_type(SSL *s, WPACKET *pkt, unsigned int context,
+                                               X509 *x, size_t chainidx);
+int tls_parse_ctos_client_cert_type(SSL *s, PACKET *pkt, unsigned int context,
+                                    X509 *x, size_t chainidx);
+int tls_parse_stoc_client_cert_type(SSL *s, PACKET *pkt, unsigned int context,
+                               X509 *x, size_t chainidx);
+EXT_RETURN tls_construct_ctos_server_cert_type(SSL *s, WPACKET *pkt, unsigned int context,
+                                               X509 *x, size_t chainidx);
+EXT_RETURN tls_construct_stoc_server_cert_type(SSL *s, WPACKET *pkt, unsigned int context,
+                                               X509 *x, size_t chainidx);
+int tls_parse_ctos_server_cert_type(SSL *s, PACKET *pkt, unsigned int context,
+                                    X509 *x, size_t chainidx);
+int tls_parse_stoc_server_cert_type(SSL *s, PACKET *pkt, unsigned int context,
+                                    X509 *x, size_t chainidx);
+#endif

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -3099,6 +3099,11 @@ static int tls12_get_cert_sigalg_idx(const SSL *s, const SIGALG_LOOKUP *lu)
                 && (s->s3.tmp.new_cipher->algorithm_mkey & SSL_kRSA) != 0))
         return -1;
 
+#ifndef OPENSSL_NO_RPK
+    /* If doing RPK, the CERT_PKEY won't be "valid" */
+    if (tls12_rpk_and_privkey(s, sig_idx))
+        return sig_idx;
+#endif
     return s->s3.tmp.valid_flags[sig_idx] & CERT_PKEY_VALID ? sig_idx : -1;
 }
 

--- a/ssl/t1_trce.c
+++ b/ssl/t1_trce.c
@@ -475,6 +475,10 @@ static const ssl_trace_tbl ssl_exts_tbl[] = {
     {TLSEXT_TYPE_application_layer_protocol_negotiation,
      "application_layer_protocol_negotiation"},
     {TLSEXT_TYPE_signed_certificate_timestamp, "signed_certificate_timestamps"},
+#ifndef OPENSSL_NO_RPK
+    {TLSEXT_TYPE_client_cert_type, "client_cert_type"},
+    {TLSEXT_TYPE_server_cert_type, "server_cert_type"},
+#endif
     {TLSEXT_TYPE_padding, "padding"},
     {TLSEXT_TYPE_encrypt_then_mac, "encrypt_then_mac"},
     {TLSEXT_TYPE_extended_master_secret, "extended_master_secret"},
@@ -613,6 +617,20 @@ static const ssl_trace_tbl ssl_key_update_tbl[] = {
     {SSL_KEY_UPDATE_NOT_REQUESTED, "update_not_requested"},
     {SSL_KEY_UPDATE_REQUESTED, "update_requested"}
 };
+
+#ifndef OPENSSL_NO_RPK
+/*
+ * "pgp" and "1609dot2" are defined in RFC7250,
+ * although OpenSSL doesn't support them, it can
+ * at least report them in traces
+ */
+static const ssl_trace_tbl ssl_cert_type_tbl[] = {
+    {TLSEXT_cert_type_x509, "x509"},
+    {TLSEXT_cert_type_pgp, "pgp"},
+    {TLSEXT_cert_type_rpk, "rpk"},
+    {TLSEXT_cert_type_1609dot2, "1609dot2"}
+};
+#endif
 
 static void ssl_print_hex(BIO *bio, int indent, const char *name,
                           const unsigned char *msg, size_t msglen)
@@ -888,6 +906,22 @@ static int ssl_print_extension(BIO *bio, int indent, int server,
         BIO_indent(bio, indent + 2, 80);
         BIO_printf(bio, "max_early_data=%u\n", max_early_data);
         break;
+
+#ifndef OPENSSL_NO_RPK
+    case TLSEXT_TYPE_server_cert_type:
+    case TLSEXT_TYPE_client_cert_type:
+        if (server) {
+            if (extlen != 1)
+                return 0;
+            return ssl_trace_list(bio, indent + 2, ext, 1, 1, ssl_cert_type_tbl);
+        }
+        if (extlen < 1)
+            return 0;
+        xlen = ext[0];
+        if (extlen != xlen + 1)
+            return 0;
+        return ssl_trace_list(bio, indent + 2, ext + 1, xlen, 1, ssl_cert_type_tbl);
+#endif
 
     default:
         BIO_dump_indent(bio, (const char *)ext, extlen, indent + 2);
@@ -1254,6 +1288,39 @@ static int ssl_print_certificate(BIO *bio, int indent,
     return 1;
 }
 
+#ifndef OPENSSL_NO_RPK
+static int ssl_print_raw_public_key(BIO *bio, const SSL *ssl, int server,
+                                    int indent, const unsigned char **pmsg,
+                                    size_t *pmsglen)
+{
+    EVP_PKEY *pkey;
+    size_t clen;
+    const unsigned char *msg = *pmsg;
+    size_t msglen = *pmsglen;
+
+    if (msglen < 3)
+        return 0;
+    clen = (msg[0] << 16) | (msg[1] << 8) | msg[2];
+    if (msglen < clen + 3)
+        return 0;
+
+    msg += 3;
+
+    BIO_indent(bio, indent, 80);
+    BIO_printf(bio, "raw_public_key, length=%d\n", (int)clen);
+
+    pkey = d2i_PUBKEY_ex(NULL, &msg, clen, ssl->ctx->libctx, NULL);
+    if (pkey == NULL) {
+        return 0;
+    }
+    EVP_PKEY_print_public(bio, pkey, indent + 2, NULL);
+    EVP_PKEY_free(pkey);
+    *pmsg += clen + 3;
+    *pmsglen -= clen + 3;
+    return 1;
+}
+#endif
+
 static int ssl_print_certificates(BIO *bio, const SSL *ssl, int server,
                                   int indent, const unsigned char *msg,
                                   size_t msglen)
@@ -1270,6 +1337,18 @@ static int ssl_print_certificates(BIO *bio, const SSL *ssl, int server,
     if (msglen != clen + 3)
         return 0;
     msg += 3;
+#ifndef OPENSSL_NO_RPK
+    if ((server && ssl->ext.server_cert_type == TLSEXT_cert_type_rpk)
+            || (!server && ssl->ext.client_cert_type == TLSEXT_cert_type_rpk)) {
+        if (!ssl_print_raw_public_key(bio, ssl, server, indent, &msg, &clen))
+            return 0;
+        if (SSL_IS_TLS13(ssl)
+            && !ssl_print_extensions(bio, indent + 2, server,
+                                     SSL3_MT_CERTIFICATE, &msg, &clen))
+            return 0;
+        return 1;
+    }
+#endif
     BIO_indent(bio, indent, 80);
     BIO_printf(bio, "certificate_list, length=%d\n", (int)clen);
     while (clen > 0) {

--- a/test/build.info
+++ b/test/build.info
@@ -65,6 +65,10 @@ IF[{- !$disabled{tests} -}]
           provfetchtest prov_config_test rand_test ca_internals_test \
           bio_tfo_test
 
+  IF[{- !$disabled{'rpk'} -}]
+    PROGRAMS{noinst}=rpktest
+  ENDIF
+
   IF[{- !$disabled{'deprecated-3.0'} -}]
     PROGRAMS{noinst}=enginetest
   ENDIF
@@ -394,6 +398,10 @@ IF[{- !$disabled{tests} -}]
   SOURCE[sslapitest]=sslapitest.c helpers/ssltestlib.c filterprov.c tls-provider.c
   INCLUDE[sslapitest]=../include ../apps/include ..
   DEPEND[sslapitest]=../libcrypto ../libssl libtestutil.a
+
+  SOURCE[rpktest]=rpktest.c helpers/ssltestlib.c
+  INCLUDE[rpktest]=../include ../apps/include ..
+  DEPEND[rpktest]=../libcrypto ../libssl libtestutil.a
 
   SOURCE[defltfips_test]=defltfips_test.c
   INCLUDE[defltfips_test]=../include  ../apps/include

--- a/test/recipes/90-test_rpk.t
+++ b/test/recipes/90-test_rpk.t
@@ -1,0 +1,23 @@
+#! /usr/bin/env perl
+# Copyright 2016-2021 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+use OpenSSL::Test::Utils;
+use OpenSSL::Test qw/:DEFAULT srctop_dir bldtop_dir/;
+
+BEGIN {
+    setup("test_rpk");
+}
+
+use lib srctop_dir('Configurations');
+use lib bldtop_dir('.');
+
+plan skip_all => "RPK is disabled in this OpenSSL build" if disabled("rpk");
+
+plan tests => 1;
+
+ok(run(test(["rpktest", srctop_dir("test", "certs")])), "running rpktest");

--- a/test/rpktest.c
+++ b/test/rpktest.c
@@ -1,0 +1,640 @@
+/*
+ * Copyright 2016-2021 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+#include <openssl/ssl.h>
+
+#include "helpers/ssltestlib.h"
+#include "testutil.h"
+
+#undef OSSL_NO_USABLE_TLS1_3
+#if defined(OPENSSL_NO_TLS1_3) \
+    || (defined(OPENSSL_NO_EC) && defined(OPENSSL_NO_DH))
+/*
+ * If we don't have ec or dh then there are no built-in groups that are usable
+ * with TLSv1.3
+ */
+# define OSSL_NO_USABLE_TLS1_3
+#endif
+
+static char *certsdir = NULL;
+static char *rootcert = NULL;
+static char *cert = NULL;
+static char *privkey = NULL;
+static char *cert2 = NULL;
+static char *privkey2 = NULL;
+static char *cert448 = NULL;
+static char *privkey448 = NULL;
+static char *cert25519 = NULL;
+static char *privkey25519 = NULL;
+
+static unsigned char SID_CTX[] = { 'r', 'p', 'k' };
+
+static int rpk_verify_cb(int ok, X509_STORE_CTX *ctx)
+{
+    return 1;
+}
+/*
+ * Test dimensions:
+ *   (2) SSL_OP_RPK_SERVER off/on for server
+ *   (2) SSL_OP_RPK_CLIENT off/on for server
+ *   (2) SSL_OP_RPK_SERVER off/on for client
+ *   (2) SSL_OP_RPK_CLIENT off/on for client
+ *   (4) RSA vs ECDSA vs Ed25519 vs Ed448 certificates
+ *   (2) TLSv1.2 vs TLSv1.3
+ *
+ * Tests:
+ * idx = 0 - is the normal success case, certificate, single peer key
+ * idx = 1 - only a private key
+ * idx = 2 - add client authentication
+ * idx = 3 - add second peer key (rootcert.pem)
+ * idx = 4 - add second peer key (different, RSA or ECDSA)
+ * idx = 5 - reverse peer keys (rootcert.pem, different order)
+ * idx = 6 - reverse peer keys (RSA or ECDSA, different order)
+ * idx = 7 - expects failure due to mismatched key (RSA or ECDSA)
+ * idx = 8 - expects failure due to no configured key on client
+ * idx = 9 - add client authentication (PHA)
+ * idx = 10 - add client authentication (privake key only)
+ * idx = 11 - simple resumption
+ * idx = 12 - simple resumption, no ticket
+ * idx = 13 - resumption with client authentication
+ * idx = 14 - resumption with client authentication, no ticket
+ *
+ * 14 * 2 * 4 * 2 * 2 * 2 * 2 = 1920 tests
+ */
+static int test_rpk(int idx)
+{
+# define RPK_TESTS 15
+# define RPK_DIMS (2 * 4 * 2 * 2 * 2 * 2)
+    SSL_CTX *cctx = NULL, *sctx = NULL;
+    SSL *clientssl = NULL, *serverssl = NULL;
+    EVP_PKEY *pkey = NULL, *other_pkey = NULL, *root_pkey = NULL;
+    X509 *x509 = NULL, *other_x509 = NULL, *root_x509 = NULL;
+    int testresult = 0, ret, expected = 1;
+    int tls_version;
+    char *cert_file = NULL;
+    char *privkey_file = NULL;
+    char *other_cert_file = NULL;
+    SSL_SESSION *client_sess = NULL;
+    SSL_SESSION *server_sess = NULL;
+    int idx_server_server_rpk, idx_server_client_rpk;
+    int idx_client_server_rpk, idx_client_client_rpk;
+    int idx_cert, idx_prot;
+    int client_auth = 0;
+    int resumption = 0;
+    uint64_t server_op = 0, client_op = 0;
+
+    if (!TEST_int_le(idx, RPK_TESTS * RPK_DIMS))
+        return 0;
+
+    idx_server_server_rpk = idx / (RPK_TESTS * 2 * 4 * 2 * 2 * 2);
+    idx %= RPK_TESTS * 2 * 4 * 2 * 2 * 2;
+    idx_server_client_rpk = idx / (RPK_TESTS * 2 * 4 * 2 * 2);
+    idx %= RPK_TESTS * 2 * 4 * 2 * 2;
+    idx_client_server_rpk = idx / (RPK_TESTS * 2 * 4 * 2);
+    idx %= RPK_TESTS * 2 * 4 * 2;
+    idx_client_client_rpk = idx / (RPK_TESTS * 2 * 4);
+    idx %= RPK_TESTS * 2 * 4;
+    idx_cert = idx / (RPK_TESTS * 2);
+    idx %= RPK_TESTS * 2;
+    idx_prot = idx / RPK_TESTS;
+    idx %= RPK_TESTS;
+
+    /* Load "root" cert/pubkey */
+    root_x509 = load_cert_pem(rootcert, NULL);
+    if (!TEST_ptr(root_x509))
+        goto end;
+    root_pkey = X509_get0_pubkey(root_x509);
+    if (!TEST_ptr(root_pkey))
+        goto end;
+
+    if (idx_server_server_rpk)
+        server_op |= SSL_OP_RPK_SERVER;
+    if (idx_server_client_rpk)
+        server_op |= SSL_OP_RPK_CLIENT;
+    if (idx_client_server_rpk)
+        client_op |= SSL_OP_RPK_SERVER;
+    if (idx_client_client_rpk)
+        client_op |= SSL_OP_RPK_CLIENT;
+
+    switch (idx_cert) {
+        case 0:
+            /* use RSA */
+            cert_file = cert;
+            privkey_file = privkey;
+            other_cert_file = cert2;
+            break;
+#ifndef OPENSSL_NO_ECDSA
+        case 1:
+            /* use ECDSA */
+            cert_file = cert2;
+            privkey_file = privkey2;
+            other_cert_file = cert;
+            break;
+        case 2:
+            /* use Ed448 */
+            cert_file = cert448;
+            privkey_file = privkey448;
+            other_cert_file = cert;
+            break;
+        case 3:
+            /* use Ed25519 */
+            cert_file = cert25519;
+            privkey_file = privkey25519;
+            other_cert_file = cert;
+            break;
+#endif
+        default:
+            testresult = TEST_skip("EDCSA disabled");
+            goto end;
+    }
+    /* Load primary cert */
+    x509 = load_cert_pem(cert_file, NULL);
+    if (!TEST_ptr(x509))
+        goto end;
+    pkey = X509_get0_pubkey(x509);
+    /* load other cert */
+    other_x509 = load_cert_pem(other_cert_file, NULL);
+    if (!TEST_ptr(other_x509))
+        goto end;
+    other_pkey = X509_get0_pubkey(other_x509);
+#ifdef OPENSSL_NO_ECDSA
+    /* Can't get other_key if it's ECDSA */
+    if (other_pkey == NULL && idx_cert == 0
+            && (idx == 4 || idx == 6 || idx == 7)) {
+        testresult = TEST_skip("EDCSA disabled");
+        goto end;
+    }
+#endif
+
+    switch (idx_prot) {
+    case 0:
+#ifdef OSSL_NO_USABLE_TLS1_3
+        testresult = TEST_skip("TLSv1.3 disabled");
+        goto end;
+#else
+        tls_version = TLS1_3_VERSION;
+        break;
+#endif
+    case 1:
+#ifdef OPENSSL_NO_TLS1_2
+        testresult = TEST_skip("TLSv1.2 disabled");
+        goto end;
+#else
+        tls_version = TLS1_2_VERSION;
+        break;
+#endif
+    default:
+        goto end;
+    }
+
+    if (!TEST_true(create_ssl_ctx_pair(NULL,
+                                       TLS_server_method(), TLS_client_method(),
+                                       tls_version, tls_version,
+                                       &sctx, &cctx, NULL, NULL)))
+        goto end;
+
+    if (!TEST_true(SSL_CTX_set_options(sctx, server_op)))
+        goto end;
+    if (!TEST_true(SSL_CTX_set_options(cctx, client_op)))
+        goto end;
+    if (!TEST_true(SSL_CTX_set_session_id_context(sctx, SID_CTX, sizeof(SID_CTX))))
+        goto end;
+    if (!TEST_true(SSL_CTX_set_session_id_context(cctx, SID_CTX, sizeof(SID_CTX))))
+        goto end;
+
+    if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
+                                      NULL, NULL)))
+        goto end;
+
+    /* Set private key and certificate */
+    if (!TEST_int_eq(SSL_use_PrivateKey_file(serverssl, privkey_file, SSL_FILETYPE_PEM), 1))
+        goto end;
+    /* Only a private key */
+    if (idx == 1) {
+        if (idx_server_server_rpk == 0 || idx_client_server_rpk == 0)
+            expected = 0;
+    } else {
+        /* Add certificate */
+        if (!TEST_int_eq(SSL_use_certificate_file(serverssl, cert_file, SSL_FILETYPE_PEM), 1))
+            goto end;
+        if (!TEST_int_eq(SSL_check_private_key(serverssl), 1))
+            goto end;
+    }
+
+    switch (idx) {
+    default:
+        if (!TEST_true(idx < RPK_TESTS))
+            goto end;
+        break;
+    case 0:
+        if (!TEST_true(SSL_add1_expected_peer_rpk(clientssl, pkey)))
+            goto end;
+        break;
+    case 1:
+        if (!TEST_true(SSL_add1_expected_peer_rpk(clientssl, pkey)))
+            goto end;
+        break;
+    case 2:
+        if (!TEST_true(SSL_add1_expected_peer_rpk(clientssl, pkey)))
+            goto end;
+        if (!TEST_true(SSL_add1_expected_peer_rpk(serverssl, pkey)))
+            goto end;
+        /* Use the same key for client auth */
+        if (!TEST_int_eq(SSL_use_PrivateKey_file(clientssl, privkey_file, SSL_FILETYPE_PEM), 1))
+            goto end;
+        if (!TEST_int_eq(SSL_use_certificate_file(clientssl, cert_file, SSL_FILETYPE_PEM), 1))
+            goto end;
+        if (!TEST_int_eq(SSL_check_private_key(clientssl), 1))
+            goto end;
+        SSL_set_verify(serverssl, SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT, rpk_verify_cb);
+        client_auth = 1;
+        break;
+    case 3:
+        if (!TEST_true(SSL_add1_expected_peer_rpk(clientssl, pkey)))
+            goto end;
+        if (!TEST_true(SSL_add1_expected_peer_rpk(clientssl, root_pkey)))
+            goto end;
+        break;
+    case 4:
+        if (!TEST_true(SSL_add1_expected_peer_rpk(clientssl, pkey)))
+            goto end;
+        if (!TEST_true(SSL_add1_expected_peer_rpk(clientssl, other_pkey)))
+            goto end;
+        break;
+    case 5:
+        if (!TEST_true(SSL_add1_expected_peer_rpk(clientssl, root_pkey)))
+            goto end;
+        if (!TEST_true(SSL_add1_expected_peer_rpk(clientssl, pkey)))
+            goto end;
+        break;
+    case 6:
+        if (!TEST_true(SSL_add1_expected_peer_rpk(clientssl, other_pkey)))
+            goto end;
+        if (!TEST_true(SSL_add1_expected_peer_rpk(clientssl, pkey)))
+            goto end;
+        break;
+    case 7:
+        if (idx_server_server_rpk == 1 && idx_client_server_rpk == 1)
+            expected = 0;
+        if (!TEST_true(SSL_add1_expected_peer_rpk(clientssl, other_pkey)))
+            goto end;
+        break;
+    case 8:
+        if (idx_server_server_rpk == 1 && idx_client_server_rpk == 1)
+            expected = 0;
+        /* no peer keyes */
+        break;
+    case 9:
+        if (tls_version != TLS1_3_VERSION) {
+            testresult = TEST_skip("PHA requires TLSv1.3");
+            goto end;
+        }
+        if (!TEST_true(SSL_add1_expected_peer_rpk(clientssl, pkey)))
+            goto end;
+        if (!TEST_true(SSL_add1_expected_peer_rpk(serverssl, pkey)))
+            goto end;
+        /* Use the same key for client auth */
+        if (!TEST_int_eq(SSL_use_PrivateKey_file(clientssl, privkey_file, SSL_FILETYPE_PEM), 1))
+            goto end;
+        if (!TEST_int_eq(SSL_use_certificate_file(clientssl, cert_file, SSL_FILETYPE_PEM), 1))
+            goto end;
+        if (!TEST_int_eq(SSL_check_private_key(clientssl), 1))
+            goto end;
+        SSL_set_verify(serverssl, SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT | SSL_VERIFY_POST_HANDSHAKE, rpk_verify_cb);
+        SSL_set_post_handshake_auth(clientssl, 1);
+        client_auth = 1;
+        break;
+    case 10:
+        if (!TEST_true(SSL_add1_expected_peer_rpk(clientssl, pkey)))
+            goto end;
+        if (!TEST_true(SSL_add1_expected_peer_rpk(serverssl, pkey)))
+            goto end;
+        /* Use the same key for client auth */
+        if (!TEST_int_eq(SSL_use_PrivateKey_file(clientssl, privkey_file, SSL_FILETYPE_PEM), 1))
+            goto end;
+        /* Since there's no cert, this is expected to fail without RPK support */
+        if ((server_op & client_op & SSL_OP_RPK_CLIENT) == 0)
+            expected = 0;
+        SSL_set_verify(serverssl, SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT, rpk_verify_cb);
+        client_auth = 1;
+        break;
+    case 11:
+        if ((server_op & client_op & SSL_OP_RPK_SERVER) == 0) {
+            testresult = TEST_skip("Only testing resumption with server RPK");
+            goto end;
+        }
+        if (!TEST_true(SSL_add1_expected_peer_rpk(clientssl, pkey)))
+            goto end;
+        resumption = 1;
+        break;
+    case 12:
+        if ((server_op & client_op & SSL_OP_RPK_SERVER) == 0) {
+            testresult = TEST_skip("Only testing resumption with server RPK");
+            goto end;
+        }
+        if (!TEST_true(SSL_add1_expected_peer_rpk(clientssl, pkey)))
+            goto end;
+        SSL_set_options(serverssl, SSL_OP_NO_TICKET);
+        SSL_set_options(clientssl, SSL_OP_NO_TICKET);
+        resumption = 1;
+        break;
+    case 13:
+        if ((server_op & client_op & SSL_OP_RPK_SERVER) == 0) {
+            testresult = TEST_skip("Only testing resumption with server RPK");
+            goto end;
+        }
+        if ((server_op & client_op & SSL_OP_RPK_CLIENT) == 0) {
+            testresult = TEST_skip("Only testing client authentication resumption with client RPK");
+            goto end;
+        }
+        if (!TEST_true(SSL_add1_expected_peer_rpk(clientssl, pkey)))
+            goto end;
+        if (!TEST_true(SSL_add1_expected_peer_rpk(serverssl, pkey)))
+            goto end;
+        /* Use the same key for client auth */
+        if (!TEST_int_eq(SSL_use_PrivateKey_file(clientssl, privkey_file, SSL_FILETYPE_PEM), 1))
+            goto end;
+        if (!TEST_int_eq(SSL_use_certificate_file(clientssl, cert_file, SSL_FILETYPE_PEM), 1))
+            goto end;
+        if (!TEST_int_eq(SSL_check_private_key(clientssl), 1))
+            goto end;
+        SSL_set_verify(serverssl, SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT, rpk_verify_cb);
+        client_auth = 1;
+        resumption = 1;
+        break;
+    case 14:
+        if ((server_op & client_op & SSL_OP_RPK_SERVER) == 0) {
+            testresult = TEST_skip("Only testing resumption with server RPK");
+            goto end;
+        }
+        if ((server_op & client_op & SSL_OP_RPK_CLIENT) == 0) {
+            testresult = TEST_skip("Only testing client authentication resumption with client RPK");
+            goto end;
+        }
+        if (!TEST_true(SSL_add1_expected_peer_rpk(clientssl, pkey)))
+            goto end;
+        if (!TEST_true(SSL_add1_expected_peer_rpk(serverssl, pkey)))
+            goto end;
+        /* Use the same key for client auth */
+        if (!TEST_int_eq(SSL_use_PrivateKey_file(clientssl, privkey_file, SSL_FILETYPE_PEM), 1))
+            goto end;
+        if (!TEST_int_eq(SSL_use_certificate_file(clientssl, cert_file, SSL_FILETYPE_PEM), 1))
+            goto end;
+        if (!TEST_int_eq(SSL_check_private_key(clientssl), 1))
+            goto end;
+        SSL_set_verify(serverssl, SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT, rpk_verify_cb);
+        SSL_set_options(serverssl, SSL_OP_NO_TICKET);
+        SSL_set_options(clientssl, SSL_OP_NO_TICKET);
+        client_auth = 1;
+        resumption = 1;
+        break;
+    }
+
+    ret = create_ssl_connection(serverssl, clientssl, SSL_ERROR_NONE);
+    if (!TEST_int_eq(expected, ret))
+        goto end;
+
+    /* Make sure client gets RPK or certificate as configured */
+    if (expected == 1) {
+        if (server_op & client_op & SSL_OP_RPK_SERVER) {
+            if (!TEST_ptr(SSL_get0_peer_rpk(clientssl)))
+                goto end;
+            if (!TEST_true(SSL_rpk_send_negotiated(serverssl)))
+                goto end;
+            if (!TEST_true(SSL_rpk_receive_negotiated(clientssl)))
+                goto end;
+        } else {
+            if (!TEST_ptr(SSL_get0_peer_certificate(clientssl)))
+                goto end;
+            if (!TEST_false(SSL_rpk_send_negotiated(serverssl)))
+                goto end;
+            if (!TEST_false(SSL_rpk_receive_negotiated(clientssl)))
+                goto end;
+        }
+    }
+
+    if (idx == 9) {
+        /* Make PHA happen... */
+        if (!TEST_true(SSL_verify_client_post_handshake(serverssl)))
+            goto end;
+        if (!TEST_true(SSL_do_handshake(serverssl)))
+            goto end;
+        if (!TEST_int_le(SSL_read(clientssl, NULL, 0), 0))
+            goto end;
+        if (!TEST_int_le(SSL_read(serverssl, NULL, 0), 0))
+            goto end;
+    }
+
+    /* Make sure server gets an RPK or certificate as configured */
+    if (client_auth) {
+        if (server_op & client_op & SSL_OP_RPK_CLIENT) {
+            if (!TEST_ptr(SSL_get0_peer_rpk(serverssl)))
+                goto end;
+            if (!TEST_true(SSL_rpk_send_negotiated(clientssl)))
+                goto end;
+            if (!TEST_true(SSL_rpk_receive_negotiated(serverssl)))
+                goto end;
+        } else {
+            /* only if connection is expected to succeed */
+            if (expected == 1 && !TEST_ptr(SSL_get0_peer_certificate(serverssl)))
+                goto end;
+            if (!TEST_false(SSL_rpk_send_negotiated(clientssl)))
+                goto end;
+            if (!TEST_false(SSL_rpk_receive_negotiated(serverssl)))
+                goto end;
+        }
+    }
+
+    if (resumption) {
+        EVP_PKEY *client_pkey = NULL;
+        EVP_PKEY *server_pkey = NULL;
+
+        if (!TEST_ptr((client_sess = SSL_get1_session(clientssl)))
+                || !TEST_ptr((client_pkey = SSL_SESSION_get0_peer_rpk(client_sess))))
+            goto end;
+        if (client_auth) {
+            if (!TEST_ptr((server_sess = SSL_get1_session(serverssl)))
+                || !TEST_ptr((server_pkey = SSL_SESSION_get0_peer_rpk(server_sess))))
+            goto end;
+        }
+        SSL_shutdown(clientssl);
+        SSL_shutdown(serverssl);
+        SSL_free(clientssl);
+        SSL_free(serverssl);
+        serverssl = clientssl = NULL;
+
+        if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
+                                          NULL, NULL))
+                || !TEST_true(SSL_set_session(clientssl, client_sess)))
+            goto end;
+
+        /* Set private key (and maybe certificate */
+        if (!TEST_int_eq(SSL_use_PrivateKey_file(serverssl, privkey_file, SSL_FILETYPE_PEM), 1))
+            goto end;
+        if (!TEST_int_eq(SSL_use_certificate_file(serverssl, cert_file, SSL_FILETYPE_PEM), 1))
+            goto end;
+        if (!TEST_int_eq(SSL_check_private_key(serverssl), 1))
+            goto end;
+
+        switch (idx) {
+        default:
+            break;
+        case 11:
+            if (!TEST_true(SSL_add1_expected_peer_rpk(clientssl, client_pkey)))
+                goto end;
+            break;
+        case 12:
+            if (!TEST_true(SSL_add1_expected_peer_rpk(clientssl, client_pkey)))
+                goto end;
+            SSL_set_options(clientssl, SSL_OP_NO_TICKET);
+            SSL_set_options(serverssl, SSL_OP_NO_TICKET);
+            break;
+        case 13:
+            if (!TEST_true(SSL_add1_expected_peer_rpk(clientssl, client_pkey)))
+                goto end;
+            if (!TEST_true(SSL_add1_expected_peer_rpk(serverssl, server_pkey)))
+                goto end;
+            /* Use the same key for client auth */
+            if (!TEST_int_eq(SSL_use_PrivateKey_file(clientssl, privkey_file, SSL_FILETYPE_PEM), 1))
+                goto end;
+            if (!TEST_int_eq(SSL_use_certificate_file(clientssl, cert_file, SSL_FILETYPE_PEM), 1))
+                goto end;
+            if (!TEST_int_eq(SSL_check_private_key(clientssl), 1))
+                goto end;
+            SSL_set_verify(serverssl, SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT, rpk_verify_cb);
+            break;
+        case 14:
+            if (!TEST_true(SSL_add1_expected_peer_rpk(clientssl, client_pkey)))
+                goto end;
+            if (!TEST_true(SSL_add1_expected_peer_rpk(serverssl, server_pkey)))
+                goto end;
+            /* Use the same key for client auth */
+            if (!TEST_int_eq(SSL_use_PrivateKey_file(clientssl, privkey_file, SSL_FILETYPE_PEM), 1))
+                goto end;
+            if (!TEST_int_eq(SSL_use_certificate_file(clientssl, cert_file, SSL_FILETYPE_PEM), 1))
+                goto end;
+            if (!TEST_int_eq(SSL_check_private_key(clientssl), 1))
+                goto end;
+            SSL_set_verify(serverssl, SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT, rpk_verify_cb);
+            SSL_set_options(serverssl, SSL_OP_NO_TICKET);
+            SSL_set_options(clientssl, SSL_OP_NO_TICKET);
+            break;
+        }
+
+        ret = create_ssl_connection(serverssl, clientssl, SSL_ERROR_NONE);
+        if (!TEST_int_eq(expected, ret))
+            goto end;
+        if (!TEST_true(SSL_session_reused(clientssl)))
+            goto end;
+
+        if (!TEST_ptr(SSL_get0_peer_rpk(clientssl)))
+            goto end;
+        if (!TEST_true(SSL_rpk_send_negotiated(serverssl)))
+            goto end;
+        if (!TEST_true(SSL_rpk_receive_negotiated(clientssl)))
+            goto end;
+
+        if (client_auth) {
+            if (!TEST_ptr(SSL_get0_peer_rpk(serverssl)))
+                goto end;
+            if (!TEST_true(SSL_rpk_receive_negotiated(serverssl)))
+                goto end;
+            if (!TEST_true(SSL_rpk_send_negotiated(clientssl)))
+                goto end;
+        }
+    }
+
+    testresult = 1;
+
+ end:
+    SSL_SESSION_free(client_sess);
+    SSL_SESSION_free(server_sess);
+    SSL_free(serverssl);
+    SSL_free(clientssl);
+    SSL_CTX_free(sctx);
+    SSL_CTX_free(cctx);
+    X509_free(x509);
+    X509_free(other_x509);
+    X509_free(root_x509);
+
+    if (testresult == 0) {
+        TEST_info("idx_ss_rpk=%d, idx_sc_rpk=%d, idx_cs_rpk=%d, idx_cc_rpk=%d, idx_cert=%d, idx_prot=%d, idx=%d",
+                  idx_server_server_rpk, idx_server_client_rpk,
+                  idx_client_server_rpk, idx_client_client_rpk,
+                  idx_cert, idx_prot, idx);
+    }
+    return testresult;
+}
+
+OPT_TEST_DECLARE_USAGE("certdir\n")
+
+int setup_tests(void)
+{
+    if (!test_skip_common_options()) {
+        TEST_error("Error parsing test options\n");
+        return 0;
+    }
+
+    if (!TEST_ptr(certsdir = test_get_argument(0)))
+        return 0;
+
+    rootcert = test_mk_file_path(certsdir, "rootcert.pem");
+    if (rootcert == NULL)
+        goto err;
+
+    cert = test_mk_file_path(certsdir, "servercert.pem");
+    if (cert == NULL)
+        goto err;
+
+    privkey = test_mk_file_path(certsdir, "serverkey.pem");
+    if (privkey == NULL)
+        goto err;
+
+    cert2 = test_mk_file_path(certsdir, "server-ecdsa-cert.pem");
+    if (cert2 == NULL)
+        goto err;
+
+    privkey2 = test_mk_file_path(certsdir, "server-ecdsa-key.pem");
+    if (privkey2 == NULL)
+        goto err;
+
+    cert448 = test_mk_file_path(certsdir, "server-ed448-cert.pem");
+    if (cert2 == NULL)
+        goto err;
+
+    privkey448 = test_mk_file_path(certsdir, "server-ed448-key.pem");
+    if (privkey2 == NULL)
+        goto err;
+
+    cert25519 = test_mk_file_path(certsdir, "server-ed25519-cert.pem");
+    if (cert2 == NULL)
+        goto err;
+
+    privkey25519 = test_mk_file_path(certsdir, "server-ed25519-key.pem");
+    if (privkey2 == NULL)
+        goto err;
+
+    ADD_ALL_TESTS(test_rpk, RPK_TESTS * RPK_DIMS);
+    return 1;
+
+ err:
+    return 0;
+}
+
+void cleanup_tests(void)
+{
+    OPENSSL_free(rootcert);
+    OPENSSL_free(cert);
+    OPENSSL_free(privkey);
+    OPENSSL_free(cert2);
+    OPENSSL_free(privkey2);
+    OPENSSL_free(cert448);
+    OPENSSL_free(privkey448);
+    OPENSSL_free(cert25519);
+    OPENSSL_free(privkey25519);
+ }

--- a/util/libssl.num
+++ b/util/libssl.num
@@ -521,3 +521,8 @@ SSL_set0_tmp_dh_pkey                    521	3_0_0	EXIST::FUNCTION:
 SSL_CTX_set0_tmp_dh_pkey                522	3_0_0	EXIST::FUNCTION:
 SSL_group_to_name                       523	3_0_0	EXIST::FUNCTION:
 SSL_client_hello_get_extension_order    ?	3_1_0	EXIST::FUNCTION:
+SSL_add1_expected_peer_rpk              ?	3_1_0	EXIST::FUNCTION:RPK
+SSL_get0_peer_rpk                       ?	3_1_0	EXIST::FUNCTION:RPK
+SSL_SESSION_get0_peer_rpk               ?	3_1_0	EXIST::FUNCTION:RPK
+SSL_rpk_send_negotiated                 ?	3_1_0	EXIST::FUNCTION:RPK
+SSL_rpk_receive_negotiated              ?	3_1_0	EXIST::FUNCTION:RPK


### PR DESCRIPTION
Add support for the RFC7250 extensions, allows the use of only private keys for connection (i.e. certs not needed). Fixes #6929 


Configurable with no-rpk
Add SSL_add1_expected_peer_rpk() to add a list of valid keys
Add SSL_get0_peer_rpk() to retrive peer's public key
Add RPK SSL options
Add unit tests
Add documentation
Add s_client/s_server support

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [X] documentation is added or updated
- [X] tests are added or updated
