### PR TITLE
Add missing mention of mandatory function OSSL_FUNC_keymgmt_has

### DIFF
--- a/doc/man7/provider-keymgmt.pod
+++ b/doc/man7/provider-keymgmt.pod
@@ -254,9 +254,10 @@ provider knows how to interpret, but that may come from other operations.
 Outside the provider, this reference is simply an array of bytes.
 
 At least one of OSSL_FUNC_keymgmt_new(), OSSL_FUNC_keymgmt_gen() and
-OSSL_FUNC_keymgmt_load() are mandatory, as well as OSSL_FUNC_keymgmt_free().
-Additionally, if OSSL_FUNC_keymgmt_gen() is present, OSSL_FUNC_keymgmt_gen_init()
-and OSSL_FUNC_keymgmt_gen_cleanup() must be present as well.
+OSSL_FUNC_keymgmt_load() are mandatory, as well as OSSL_FUNC_keymgmt_free() and
+OSSL_FUNC_keymgmt_has(). Additionally, if OSSL_FUNC_keymgmt_gen() is present, 
+OSSL_FUNC_keymgmt_gen_init() and OSSL_FUNC_keymgmt_gen_cleanup() must be
+present as well.
 
 =head2 Key Object Information Functions
 


### PR DESCRIPTION
The manual page provider-keymgmt.pod is missing the mention of the
required function OSSL_FUNC_keymgmt_has. The function
keymgmt_from_algorithm raise EVP_R_INVALID_PROVIDER_FUNCTIONS
if keymgmt->has == NULL

CLA: trivial
Signed-off-by: Arne Schwabe <arne@rfc2549.org>

##### Checklist

- [x] documentation is added or updated
