### PR TITLE
Fix util/mkpod2html.pl to call pod2html with absolute paths

### DIFF
--- a/util/mkpod2html.pl
+++ b/util/mkpod2html.pl
@@ -12,7 +12,7 @@ use warnings;
 use lib ".";
 use Getopt::Std;
 use Pod::Html;
-use Cwd qw(:DEFAULT realpath);
+use File::Spec::Functions qw(:DEFAULT rel2abs);
 
 # Options.
 our($opt_i);    # -i INFILE
@@ -26,9 +26,13 @@ die "-o flag missing" unless $opt_o;
 die "-t flag missing" unless $opt_t;
 die "-r flag missing" unless $opt_r;
 
-$opt_i = realpath($opt_i) or die "Can't convert to real path: $!";
-$opt_o = realpath($opt_o) or die "Can't convert to real path: $!";
-$opt_r = realpath($opt_r) or die "Can't convert to real path: $!";
+# We originally used realpath() here, but the Windows implementation appears
+# to require that the directory or file exist to be able to process the input,
+# so we use rel2abs() instead, which only processes the string without
+# looking further.
+$opt_i = rel2abs($opt_i) or die "Can't convert to real path: $!";
+$opt_o = rel2abs($opt_o) or die "Can't convert to real path: $!";
+$opt_r = rel2abs($opt_r) or die "Can't convert to real path: $!";
 
 pod2html
     "--infile=$opt_i",

--- a/util/mkpod2html.pl
+++ b/util/mkpod2html.pl
@@ -12,6 +12,7 @@ use warnings;
 use lib ".";
 use Getopt::Std;
 use Pod::Html;
+use Cwd qw(:DEFAULT realpath);
 
 # Options.
 our($opt_i);    # -i INFILE
@@ -24,6 +25,10 @@ die "-i flag missing" unless $opt_i;
 die "-o flag missing" unless $opt_o;
 die "-t flag missing" unless $opt_t;
 die "-r flag missing" unless $opt_r;
+
+$opt_i = realpath($opt_i);
+$opt_o = realpath($opt_o);
+$opt_r = realpath($opt_r);
 
 pod2html
     "--infile=$opt_i",

--- a/util/mkpod2html.pl
+++ b/util/mkpod2html.pl
@@ -26,9 +26,9 @@ die "-o flag missing" unless $opt_o;
 die "-t flag missing" unless $opt_t;
 die "-r flag missing" unless $opt_r;
 
-$opt_i = realpath($opt_i);
-$opt_o = realpath($opt_o);
-$opt_r = realpath($opt_r);
+$opt_i = realpath($opt_i) or die "Can't convert to real path: $!";
+$opt_o = realpath($opt_o) or die "Can't convert to real path: $!";
+$opt_r = realpath($opt_r) or die "Can't convert to real path: $!";
 
 pod2html
     "--infile=$opt_i",


### PR DESCRIPTION
It turns out that on VMS, pod2html only recognises VMS directory
specifications if they contain a device name, which is accomplished by
making them absolute.  Otherwise, a VMS build that includes building
the document HTML files ends up with an error like this:

    $ perl [---.downloads.openssl-3_0-snap-20210916.util]mkpod2html.pl -i [---.downloads.openssl-3_0-snap-20210916.doc.man1]CA.pl.pod -o [.DOC.HTML.MAN1]CA.PL.HTML -t "CA.pl" -r "[---.downloads.openssl-3_0-snap-20210916.doc]"
    [---.downloads.openssl-3_0-snap-20210916.util]mkpod2html.pl: error changing to directory -/-/-/downloads/openssl-3_0-snap-20210916/doc/: no such file or directory
    %SYSTEM-F-ABORT, abort
