### PR TITLE
ci: add copyright header to CI scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,10 @@
+# Copyright 2021 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
 name: GitHub CI
 
 on: [pull_request, push]

--- a/.github/workflows/compiler-zoo.yml
+++ b/.github/workflows/compiler-zoo.yml
@@ -1,3 +1,10 @@
+# Copyright 2021 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
 name: Compiler Zoo CI
 
 on: [push]

--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -1,3 +1,10 @@
+# Copyright 2021 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
 name: Coverage
 
 #Run once a day

--- a/.github/workflows/cross-compiles.yml
+++ b/.github/workflows/cross-compiles.yml
@@ -1,3 +1,10 @@
+# Copyright 2021 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
 name: Cross Compile
 
 on: [pull_request, push]

--- a/.github/workflows/fips-checksums.yml
+++ b/.github/workflows/fips-checksums.yml
@@ -1,3 +1,10 @@
+# Copyright 2021 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
 name: FIPS Checksums
 on: [pull_request]
 

--- a/.github/workflows/fips-label.yml
+++ b/.github/workflows/fips-label.yml
@@ -1,3 +1,10 @@
+# Copyright 2021 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
 name: FIPS Changed Label
 on:
   workflow_run:

--- a/.github/workflows/fuzz-checker.yml
+++ b/.github/workflows/fuzz-checker.yml
@@ -1,3 +1,10 @@
+# Copyright 2021 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
 name: Fuzz-checker CI
 
 on: [push]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,3 +1,10 @@
+# Copyright 2021 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
 name: CIFuzz
 on: [pull_request, push]
 jobs:

--- a/.github/workflows/run-checker-ci.yml
+++ b/.github/workflows/run-checker-ci.yml
@@ -1,3 +1,10 @@
+# Copyright 2021 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
 # Jobs run per pull request submission
 name: Run-checker CI
 on: [pull_request, push]

--- a/.github/workflows/run-checker-daily.yml
+++ b/.github/workflows/run-checker-daily.yml
@@ -1,3 +1,10 @@
+# Copyright 2021 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
 name: Run-checker daily
 # Jobs run daily
 

--- a/.github/workflows/run-checker-merge.yml
+++ b/.github/workflows/run-checker-merge.yml
@@ -1,3 +1,10 @@
+# Copyright 2021 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
 name: Run-checker merge
 # Jobs run per merge to master
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,3 +1,10 @@
+# Copyright 2021 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
 name: Windows GitHub CI
 
 on: [pull_request, push]


### PR DESCRIPTION
There is quite a bit of creative effort in these and even more trouble-shooting effort.  I.e. they are non-trivial from a copyright perspective.
