### PR TITLE
Avoid double-free on unsuccessful getting PRNG seeding

### DIFF
--- a/providers/implementations/rands/seed_src.c
+++ b/providers/implementations/rands/seed_src.c
@@ -201,12 +201,12 @@ static size_t seed_get_seed(void *vseed, unsigned char **pout,
         ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
         return 0;
     }
-    *pout = p;
     if (seed_src_generate(vseed, p, bytes_needed, 0, prediction_resistance,
-                          adin, adin_len) != 0)
+                          adin, adin_len) != 0) {
+        *pout = p;
         return bytes_needed;
+    }
     OPENSSL_secure_clear_free(p, bytes_needed);
-    *pout = NULL;
     return 0;
 }
 

--- a/providers/implementations/rands/seed_src.c
+++ b/providers/implementations/rands/seed_src.c
@@ -206,6 +206,7 @@ static size_t seed_get_seed(void *vseed, unsigned char **pout,
                           adin, adin_len) != 0)
         return bytes_needed;
     OPENSSL_secure_clear_free(p, bytes_needed);
+    *pout = NULL;
     return 0;
 }
 


### PR DESCRIPTION
Fixes #16631

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
