### PR TITLE
doc: remove end of line whitespace

### DIFF
--- a/doc/build.info.in
+++ b/doc/build.info.in
@@ -14,7 +14,7 @@ SUBDIRS = man1
          map { $_ => 1 } glob catfile($sourcedir, "man$section", "img", "*.png");
      my %podfiles =
          map { $_ => 1 } glob catfile($sourcedir, "man$section", "*.pod");
-     my %podinfiles = 
+     my %podinfiles =
          map { $_ => 1 } glob catfile($sourcedir, "man$section", "*.pod.in");
 
      foreach (keys %podinfiles) {

--- a/doc/internal/man3/OPTIONS.pod
+++ b/doc/internal/man3/OPTIONS.pod
@@ -189,7 +189,7 @@ B<OPT_PARAMETERS> macro:
     OPT_PARAMETERS()
     {OPT_PARAM_STR, 1, '-', "Parameters:\n"}
 
-Every "option" after after this should contain the parameter and 
+Every "option" after after this should contain the parameter and
 the help string:
 
     {"text", 0, 0, "Words to display (optional)"},

--- a/doc/internal/man3/cms_add1_signing_cert.pod
+++ b/doc/internal/man3/cms_add1_signing_cert.pod
@@ -31,7 +31,7 @@ For a fuller description see L<openssl-cms(1)>).
 
 =head1 RETURN VALUES
 
-cms_add1_signing_cert() and cms_add1_signing_cert_v2() return 1 if attribute 
+cms_add1_signing_cert() and cms_add1_signing_cert_v2() return 1 if attribute
 is added or 0 if an error occurred.
 
 =head1 COPYRIGHT

--- a/doc/internal/man3/evp_generic_fetch.pod
+++ b/doc/internal/man3/evp_generic_fetch.pod
@@ -37,7 +37,7 @@ I<libctx>, I<operation_id>, I<name>, and I<properties> and uses
 it to create an EVP method with the help of the functions
 I<new_method>, I<up_ref_method>, and I<free_method>.
 
-evp_generic_fetch_by_number() does the same thing as evp_generic_fetch(), 
+evp_generic_fetch_by_number() does the same thing as evp_generic_fetch(),
 but takes a numeric I<name_id> instead of a name.
 I<name_id> must always be nonzero; as a matter of fact, it being zero
 is considered a programming error.

--- a/doc/internal/man3/ossl_lib_ctx_get_data.pod
+++ b/doc/internal/man3/ossl_lib_ctx_get_data.pod
@@ -91,7 +91,7 @@ and a destructor to an index.
  }
 
  /*
-  * Include a reference to this in the methods table in context.c 
+  * Include a reference to this in the methods table in context.c
   * OSSL_LIB_CTX_FOO_INDEX should be added to internal/cryptlib.h
   * Priorities can be OSSL_LIB_CTX_METHOD_DEFAULT_PRIORITY,
   * OSSL_LIB_CTX_METHOD_PRIORITY_1, OSSL_LIB_CTX_METHOD_PRIORITY_2, etc.

--- a/doc/internal/man3/ossl_provider_new.pod
+++ b/doc/internal/man3/ossl_provider_new.pod
@@ -296,7 +296,7 @@ in a bitstring that's internal to I<provider>.
 
 ossl_provider_test_operation_bit() checks if the bit operation I<bitnum>
 is set (1) or not (0) in the internal I<provider> bitstring, and sets
-I<*result> to 1 or 0 accorddingly. 
+I<*result> to 1 or 0 accorddingly.
 
 ossl_provider_clear_all_operation_bits() clears all of the operation bits
 to (0) for all providers in the library context I<libctx>.

--- a/doc/internal/man7/DERlib.pod
+++ b/doc/internal/man7/DERlib.pod
@@ -81,7 +81,7 @@ As a reminder, the AlgorithmIdentifier is specified like this:
     -- From RFC 3280, section 4.1.1.2
     AlgorithmIdentifier  ::=  SEQUENCE  {
          algorithm               OBJECT IDENTIFIER,
-         parameters              ANY DEFINED BY algorithm OPTIONAL  }    
+         parameters              ANY DEFINED BY algorithm OPTIONAL  }
 
 And the RSASSA-PSS OID and parameters are specified like this:
 

--- a/doc/internal/man7/build.info.pod
+++ b/doc/internal/man7/build.info.pod
@@ -574,7 +574,7 @@ appear in a linking command line (because of recursive dependencies
 through other libraries), they will be ordered in such a way that this
 dependency is maintained:
 
-    DEPEND[libfoo.a]{weak}=libfoo.a libcookie.a 
+    DEPEND[libfoo.a]{weak}=libfoo.a libcookie.a
 
 This is useful in complex dependency trees where two libraries can be
 used as alternatives for each other.  In this example, C<lib1.a> and

--- a/doc/life-cycles/digest.dot
+++ b/doc/life-cycles/digest.dot
@@ -30,4 +30,4 @@ digraph digest {
     finaled -> initialised [label="EVP_DigestInit", style=dashed,
                             color="#034f84", fontcolor="#034f84"];
 }
- 
+

--- a/doc/life-cycles/kdf.dot
+++ b/doc/life-cycles/kdf.dot
@@ -13,4 +13,4 @@ strict digraph kdf {
     deriving -> newed [label="EVP_KDF_CTX_reset", style=dashed,
                       color="#034f84", fontcolor="#034f84"];
 }
- 
+

--- a/doc/life-cycles/mac.dot
+++ b/doc/life-cycles/mac.dot
@@ -25,4 +25,4 @@ digraph mac {
     finaled -> initialised [label="EVP_MAC_init", style=dashed,
                             color="#034f84", fontcolor="#034f84"];
 }
- 
+

--- a/doc/life-cycles/rand.dot
+++ b/doc/life-cycles/rand.dot
@@ -14,4 +14,4 @@ strict digraph rand {
     uninstantiated -> end [label="EVP_RAND_CTX_free"];
     uninstantiated -> instantiated [label="EVP_RAND_instantiate", style=dashed, color="#034f84", fontcolor="#034f84"];
 }
- 
+

--- a/doc/man1/openssl-cmp.pod.in
+++ b/doc/man1/openssl-cmp.pod.in
@@ -835,7 +835,7 @@ have no effect on the certificate verification enabled via this option.
 
 =item B<-tls_host> I<name>
 
-Address to be checked during hostname validation. 
+Address to be checked during hostname validation.
 This may be a DNS name or an IP address.
 If not given it defaults to the B<-server> address.
 

--- a/doc/man3/CMS_add1_recipient_cert.pod
+++ b/doc/man3/CMS_add1_recipient_cert.pod
@@ -9,7 +9,7 @@ CMS_add1_recipient, CMS_add1_recipient_cert, CMS_add0_recipient_key - add recipi
  #include <openssl/cms.h>
 
  CMS_RecipientInfo *CMS_add1_recipient(CMS_ContentInfo *cms, X509 *recip,
-                                       EVP_PKEY *originatorPrivKey, 
+                                       EVP_PKEY *originatorPrivKey,
                                        X509 *originator, unsigned int flags);
 
  CMS_RecipientInfo *CMS_add1_recipient_cert(CMS_ContentInfo *cms,

--- a/doc/man3/CMS_get0_RecipientInfos.pod
+++ b/doc/man3/CMS_get0_RecipientInfos.pod
@@ -140,7 +140,7 @@ L<ERR_get_error(3)>, L<CMS_decrypt(3)>
 
 =head1 HISTORY
 
-B<CMS_RecipientInfo_kari_set0_pkey_and_peer> and B<CMS_RecipientInfo_kari_set0_pkey> 
+B<CMS_RecipientInfo_kari_set0_pkey_and_peer> and B<CMS_RecipientInfo_kari_set0_pkey>
 were added in OpenSSL 3.0.
 
 =head1 COPYRIGHT

--- a/doc/man3/CMS_verify.pod
+++ b/doc/man3/CMS_verify.pod
@@ -71,7 +71,7 @@ verified, unless CMS_CADES flag is also set.
 If B<CMS_NO_ATTR_VERIFY> is set the signed attributes signature is not
 verified, unless CMS_CADES flag is also set.
 
-If B<CMS_CADES> is set, each signer certificate is checked against the 
+If B<CMS_CADES> is set, each signer certificate is checked against the
 ESS signingCertificate or ESS signingCertificateV2 extension
 that is required in the signed attributes of the signature.
 

--- a/doc/man3/CRYPTO_get_ex_new_index.pod
+++ b/doc/man3/CRYPTO_get_ex_new_index.pod
@@ -152,7 +152,7 @@ will fail.
 CRYPTO_get_ex_new_index() returns a new index or -1 on failure.
 
 CRYPTO_free_ex_index(), CRYPTO_alloc_ex_data() and CRYPTO_set_ex_data()
-return 1 on success or 0 on failure. 
+return 1 on success or 0 on failure.
 
 CRYPTO_get_ex_data() returns the application data or NULL on failure;
 note that NULL may be a valid value.

--- a/doc/man3/ERR_get_error.pod
+++ b/doc/man3/ERR_get_error.pod
@@ -78,14 +78,14 @@ is valid until the respective entry is overwritten in the error queue.
 ERR_peek_error_line() and ERR_peek_last_error_line() are the same as
 ERR_peek_error() and ERR_peek_last_error(), but on success they additionally
 store the filename and line number where the error occurred in *I<file> and
-*I<line>, as far as they are not NULL. 
+*I<line>, as far as they are not NULL.
 An unset filename is indicated as "", i.e., an empty string.
 An unset line number is indicated as 0.
 
 ERR_peek_error_func() and ERR_peek_last_error_func() are the same as
 ERR_peek_error() and ERR_peek_last_error(), but on success they additionally
 store the name of the function where the error occurred in *I<func>, unless
-it is NULL. 
+it is NULL.
 An unset function name is indicated as "".
 
 ERR_peek_error_data() and ERR_peek_last_error_data() are the same as

--- a/doc/man3/ERR_put_error.pod
+++ b/doc/man3/ERR_put_error.pod
@@ -35,7 +35,7 @@ record.
 
 ERR_raise_data() does the same thing as ERR_raise(), but also lets the
 caller specify additional information as a format string B<fmt> and an
-arbitrary number of values, which are processed with L<BIO_snprintf(3)>.  
+arbitrary number of values, which are processed with L<BIO_snprintf(3)>.
 
 ERR_put_error() adds an error code to the thread's error queue. It
 signals that the error of reason code B<reason> occurred in function

--- a/doc/man3/EVP_EncryptInit.pod
+++ b/doc/man3/EVP_EncryptInit.pod
@@ -1330,7 +1330,7 @@ Sets the CCM B<L> value. If not set a default is used (8 for AES).
 
 =item EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_AEAD_SET_IVLEN, ivlen, NULL)
 
-Sets the CCM nonce (IV) length. This call can only be made before specifying a 
+Sets the CCM nonce (IV) length. This call can only be made before specifying a
 nonce value. The nonce length is given by B<15 - L> so it is 7 by default for
 AES.
 

--- a/doc/man3/EVP_PKEY_copy_parameters.pod
+++ b/doc/man3/EVP_PKEY_copy_parameters.pod
@@ -64,7 +64,7 @@ doesn't use parameters.
 These functions EVP_PKEY_copy_parameters() returns 1 for success and 0 for
 failure.
 
-The functions EVP_PKEY_cmp_parameters(), EVP_PKEY_parameters_eq(), 
+The functions EVP_PKEY_cmp_parameters(), EVP_PKEY_parameters_eq(),
 EVP_PKEY_cmp() and EVP_PKEY_eq() return 1 if their
 inputs match, 0 if they don't match, -1 if the key types are different and
 -2 if the operation is not supported.

--- a/doc/man3/EVP_PKEY_encapsulate.pod
+++ b/doc/man3/EVP_PKEY_encapsulate.pod
@@ -75,7 +75,7 @@ Encapsulate an RSASVE key (for RSA keys).
  /*
   * The generated 'secret' can be used as key material.
   * The encapsulated 'out' can be sent to another party who can
-  * decapsulate it using their private key to retrieve the 'secret'. 
+  * decapsulate it using their private key to retrieve the 'secret'.
   */
  if (EVP_PKEY_encapsulate(ctx, out, &outlen, secret, &secretlen) <= 0)
      /* Error */

--- a/doc/man3/EVP_PKEY_encrypt.pod
+++ b/doc/man3/EVP_PKEY_encrypt.pod
@@ -2,7 +2,7 @@
 
 =head1 NAME
 
-EVP_PKEY_encrypt_init_ex, 
+EVP_PKEY_encrypt_init_ex,
 EVP_PKEY_encrypt_init, EVP_PKEY_encrypt - encrypt using a public key algorithm
 
 =head1 SYNOPSIS

--- a/doc/man3/EVP_PKEY_fromdata.pod
+++ b/doc/man3/EVP_PKEY_fromdata.pod
@@ -80,7 +80,7 @@ public key and key parameters.
 These functions only work with key management methods coming from a provider.
 This is the mirror function to L<EVP_PKEY_todata(3)>.
 
-=for comment We may choose to make this available for legacy methods too... 
+=for comment We may choose to make this available for legacy methods too...
 
 =head1 RETURN VALUES
 

--- a/doc/man3/OSSL_CMP_SRV_CTX_new.pod
+++ b/doc/man3/OSSL_CMP_SRV_CTX_new.pod
@@ -100,7 +100,7 @@ in the same way as L<OSSL_CMP_MSG_http_perform(3)>.
 The B<OSSL_CMP_SRV_CTX> must be set as I<transfer_cb_arg> of I<client_ctx>.
 
 OSSL_CMP_SRV_CTX_new() creates and initializes an B<OSSL_CMP_SRV_CTX> structure
-associated with the library context I<libctx> and property query string 
+associated with the library context I<libctx> and property query string
 I<propq>, both of which may be NULL to select the defaults.
 
 OSSL_CMP_SRV_CTX_free() deletes the given I<srv_ctx>.

--- a/doc/man3/OSSL_DECODER_CTX.pod
+++ b/doc/man3/OSSL_DECODER_CTX.pod
@@ -159,7 +159,7 @@ OSSL_DECODER_CTX_set_cleanup() respectively.
 
 OSSL_DECODER_export() is a fallback function for constructors that cannot
 use the data they get directly for diverse reasons.  It takes the same
-decode instance I<decoder_inst> that the constructor got and an object 
+decode instance I<decoder_inst> that the constructor got and an object
 I<reference>, unpacks the object which it refers to, and exports it by
 creating an L<OSSL_PARAM(3)> array that it then passes to I<export_cb>,
 along with I<export_arg>.

--- a/doc/man3/PKCS12_SAFEBAG_create_cert.pod
+++ b/doc/man3/PKCS12_SAFEBAG_create_cert.pod
@@ -3,7 +3,7 @@
 =head1 NAME
 
 PKCS12_SAFEBAG_create_cert, PKCS12_SAFEBAG_create_crl,
-PKCS12_SAFEBAG_create_secret, PKCS12_SAFEBAG_create0_p8inf, 
+PKCS12_SAFEBAG_create_secret, PKCS12_SAFEBAG_create0_p8inf,
 PKCS12_SAFEBAG_create0_pkcs8, PKCS12_SAFEBAG_create_pkcs8_encrypt,
 PKCS12_SAFEBAG_create_pkcs8_encrypt_ex - Create PKCS#12 safeBag objects
 
@@ -52,7 +52,7 @@ containing the supplied PKCS8 structure.
 PKCS12_SAFEBAG_create0_pkcs8() creates a new B<PKCS12_SAFEBAG> of type
 B<NID_pkcs8ShroudedKeyBag> containing the supplied PKCS8 structure.
 
-PKCS12_SAFEBAG_create_pkcs8_encrypt() creates a new B<PKCS12_SAFEBAG> of type 
+PKCS12_SAFEBAG_create_pkcs8_encrypt() creates a new B<PKCS12_SAFEBAG> of type
 B<NID_pkcs8ShroudedKeyBag> by encrypting the supplied PKCS8 I<p8inf>.
 If I<pbe_nid> is 0, a default encryption algorithm is used. I<pass> is the
 passphrase and I<iter> is the iteration count. If I<iter> is zero then a default

--- a/doc/man3/PKCS12_SAFEBAG_get0_attrs.pod
+++ b/doc/man3/PKCS12_SAFEBAG_get0_attrs.pod
@@ -16,7 +16,7 @@ PKCS12_SAFEBAG_get0_attrs, PKCS12_get_attr_gen
 
 =head1 DESCRIPTION
 
-PKCS12_SAFEBAG_get0_attrs() retrieves the stack of B<X509_ATTRIBUTE>s from a 
+PKCS12_SAFEBAG_get0_attrs() retrieves the stack of B<X509_ATTRIBUTE>s from a
 PKCS#12 safeBag. I<bag> is the B<PKCS12_SAFEBAG> to retrieve the attributes from.
 
 PKCS12_get_attr_gen() retrieves an attribute by NID from a stack of
@@ -24,10 +24,10 @@ B<X509_ATTRIBUTE>s. I<attr_nid> is the NID of the attribute to retrieve.
 
 =head1 RETURN VALUES
 
-PKCS12_SAFEBAG_get0_attrs() returns the stack of B<X509_ATTRIBUTE>s from a 
+PKCS12_SAFEBAG_get0_attrs() returns the stack of B<X509_ATTRIBUTE>s from a
 PKCS#12 safeBag, which could be empty.
 
-PKCS12_get_attr_gen() returns an B<ASN1_TYPE> object containing the attribute, 
+PKCS12_get_attr_gen() returns an B<ASN1_TYPE> object containing the attribute,
 or NULL if the attribute was either not present or an error occurred.
 
 PKCS12_get_attr_gen() does not allocate a new attribute. The returned attribute

--- a/doc/man3/PKCS12_SAFEBAG_get1_cert.pod
+++ b/doc/man3/PKCS12_SAFEBAG_get1_cert.pod
@@ -48,7 +48,7 @@ PKCS12_SAFEBAG_get0_p8inf() and PKCS12_SAFEBAG_get0_pkcs8() return the PKCS8 obj
 from a PKCS8shroudedKeyBag or a keyBag.
 
 PKCS12_SAFEBAG_get0_safes() retrieves the set of B<safeBags> contained within a
-safeContentsBag. 
+safeContentsBag.
 
 =head1 RETURN VALUES
 

--- a/doc/man3/PKCS12_decrypt_skey.pod
+++ b/doc/man3/PKCS12_decrypt_skey.pod
@@ -21,7 +21,7 @@ decrypt functions
 PKCS12_decrypt_skey() Decrypt the PKCS#8 shrouded keybag contained within I<bag>
 using the supplied password I<pass> of length I<passlen>.
 
-PKCS12_decrypt_skey_ex() is similar to the above but allows for a library contex 
+PKCS12_decrypt_skey_ex() is similar to the above but allows for a library contex
 I<ctx> and property query I<propq> to be used to select algorithm implementations.
 
 =head1 RETURN VALUES

--- a/doc/man3/SSL_set_async_callback.pod
+++ b/doc/man3/SSL_set_async_callback.pod
@@ -55,7 +55,7 @@ An example of the above functions would be the following:
 
 =item 1.
 
-Application sets the async callback and callback data on an SSL connection 
+Application sets the async callback and callback data on an SSL connection
 by calling SSL_set_async_callback().
 
 =item 2.

--- a/doc/man3/SSL_set_bio.pod
+++ b/doc/man3/SSL_set_bio.pod
@@ -78,7 +78,7 @@ and no references are consumed for the B<wbio>.
 If the B<rbio> and B<wbio> parameters are different and the B<wbio>
 is the same as the
 previously set value and the old B<rbio> and B<wbio> values were different
-to each other, then one reference is consumed for the B<rbio> and one 
+to each other, then one reference is consumed for the B<rbio> and one
 reference is consumed for the B<wbio>.
 
 =back

--- a/doc/man3/X509_get0_signature.pod
+++ b/doc/man3/X509_get0_signature.pod
@@ -3,8 +3,8 @@
 =head1 NAME
 
 X509_get0_signature, X509_REQ_set0_signature, X509_REQ_set1_signature_algo,
-X509_get_signature_nid, X509_get0_tbs_sigalg, X509_REQ_get0_signature, 
-X509_REQ_get_signature_nid, X509_CRL_get0_signature, X509_CRL_get_signature_nid, 
+X509_get_signature_nid, X509_get0_tbs_sigalg, X509_REQ_get0_signature,
+X509_REQ_get_signature_nid, X509_CRL_get0_signature, X509_CRL_get_signature_nid,
 X509_get_signature_info, X509_SIG_INFO_get, X509_SIG_INFO_set - signature information
 
 =head1 SYNOPSIS

--- a/doc/man3/d2i_RSAPrivateKey.pod
+++ b/doc/man3/d2i_RSAPrivateKey.pod
@@ -172,13 +172,13 @@ There are two migration paths:
 =item *
 
 Replace
-b<d2i_I<TYPE>PrivateKey()> with L<d2i_PrivateKey(3)>, 
-b<d2i_I<TYPE>PublicKey()> with L<d2i_PublicKey(3)>, 
-b<d2i_I<TYPE>params()> with L<d2i_KeyParams(3)>, 
-b<d2i_I<TYPE>_PUBKEY()> with L<d2i_PUBKEY(3)>, 
-b<i2d_I<TYPE>PrivateKey()> with L<i2d_PrivateKey(3)>, 
-b<i2d_I<TYPE>PublicKey()> with L<i2d_PublicKey(3)>, 
-b<i2d_I<TYPE>params()> with L<i2d_KeyParams(3)>, 
+b<d2i_I<TYPE>PrivateKey()> with L<d2i_PrivateKey(3)>,
+b<d2i_I<TYPE>PublicKey()> with L<d2i_PublicKey(3)>,
+b<d2i_I<TYPE>params()> with L<d2i_KeyParams(3)>,
+b<d2i_I<TYPE>_PUBKEY()> with L<d2i_PUBKEY(3)>,
+b<i2d_I<TYPE>PrivateKey()> with L<i2d_PrivateKey(3)>,
+b<i2d_I<TYPE>PublicKey()> with L<i2d_PublicKey(3)>,
+b<i2d_I<TYPE>params()> with L<i2d_KeyParams(3)>,
 b<i2d_I<TYPE>_PUBKEY()> with L<i2d_PUBKEY(3)>.
 A caveat is that L<i2d_PrivateKey(3)> may output a DER encoded PKCS#8
 outermost structure instead of the type specific structure, and that

--- a/doc/man5/x509v3_config.pod
+++ b/doc/man5/x509v3_config.pod
@@ -289,8 +289,8 @@ B<access_id;location>, where B<access_id> is an object identifier
 syntax as subject alternative name (except that B<email:copy> is not supported).
 
 Possible values for access_id include B<OCSP> (OCSP responder),
-B<caIssuers> (CA Issuers), 
-B<ad_timestamping> (AD Time Stamping), 
+B<caIssuers> (CA Issuers),
+B<ad_timestamping> (AD Time Stamping),
 B<AD_DVCS> (ad dvcs),
 B<caRepository> (CA Repository).
 

--- a/doc/man7/EVP_KEYEXCH-ECDH.pod
+++ b/doc/man7/EVP_KEYEXCH-ECDH.pod
@@ -74,7 +74,7 @@ Keys for the host and peer must be generated as shown in
 L<EVP_PKEY-EC(7)/Examples> using the same curve name.
 
 The code to generate a shared secret for the normal case is identical to
-L<EVP_KEYEXCH-DH(7)/Examples>. 
+L<EVP_KEYEXCH-DH(7)/Examples>.
 
 To derive a shared secret on the host using the host's key and the peer's public
 key but also using X963KDF with a user key material:

--- a/doc/man7/EVP_PKEY-DH.pod
+++ b/doc/man7/EVP_PKEY-DH.pod
@@ -74,7 +74,7 @@ See EVP_PKEY_set1_encoded_public_key() and EVP_PKEY_get1_encoded_public_key().
 Used for DH generation of safe primes using the old safe prime generator code.
 The default value is 2.
 It is recommended to use a named safe prime group instead, if domain parameter
-validation is required. 
+validation is required.
 
 Randomly generated safe primes are not allowed by FIPS, so setting this value
 for the OpenSSL FIPS provider will instead choose a named safe prime group

--- a/doc/man7/EVP_PKEY-EC.pod
+++ b/doc/man7/EVP_PKEY-EC.pod
@@ -71,7 +71,7 @@ I<order> multiplied by the I<cofactor> gives the number of points on the curve.
 =item  "decoded-from-explicit" (B<OSSL_PKEY_PARAM_EC_DECODED_FROM_EXPLICIT_PARAMS>) <integer>
 
 Gets a flag indicating wether the key or parameters were decoded from explicit
-curve parameters. Set to 1 if so or 0 if a named curve was used. 
+curve parameters. Set to 1 if so or 0 if a named curve was used.
 
 =item "use-cofactor-flag" (B<OSSL_PKEY_PARAM_USE_COFACTOR_ECDH>) <integer>
 

--- a/doc/man7/EVP_PKEY-FFC.pod
+++ b/doc/man7/EVP_PKEY-FFC.pod
@@ -92,7 +92,7 @@ of I<p>. This value must be saved if domain parameter validation is required.
 
 =item "hindex" (B<OSSL_PKEY_PARAM_FFC_H>) <integer>
 
-For unverifiable generation of the generator I<g> this value is output during 
+For unverifiable generation of the generator I<g> this value is output during
 generation of I<g>. Its value is the first integer larger than one that
 satisfies g = h^j mod p (where g != 1 and "j" is the cofactor).
 

--- a/doc/man7/EVP_SIGNATURE-DSA.pod
+++ b/doc/man7/EVP_SIGNATURE-DSA.pod
@@ -14,7 +14,7 @@ See L<EVP_PKEY-DSA(7)> for information related to DSA keys.
 
 The following signature parameters can be set using EVP_PKEY_CTX_set_params().
 This may be called after EVP_PKEY_sign_init() or EVP_PKEY_verify_init(),
-and before calling EVP_PKEY_sign() or EVP_PKEY_verify(). 
+and before calling EVP_PKEY_sign() or EVP_PKEY_verify().
 
 =over 4
 

--- a/doc/man7/EVP_SIGNATURE-ECDSA.pod
+++ b/doc/man7/EVP_SIGNATURE-ECDSA.pod
@@ -13,7 +13,7 @@ See L<EVP_PKEY-EC(7)> for information related to EC keys.
 
 The following signature parameters can be set using EVP_PKEY_CTX_set_params().
 This may be called after EVP_PKEY_sign_init() or EVP_PKEY_verify_init(),
-and before calling EVP_PKEY_sign() or EVP_PKEY_verify(). 
+and before calling EVP_PKEY_sign() or EVP_PKEY_verify().
 
 =over 4
 

--- a/doc/man7/EVP_SIGNATURE-RSA.pod
+++ b/doc/man7/EVP_SIGNATURE-RSA.pod
@@ -14,7 +14,7 @@ See L<EVP_PKEY-RSA(7)> for information related to RSA keys.
 
 The following signature parameters can be set using EVP_PKEY_CTX_set_params().
 This may be called after EVP_PKEY_sign_init() or EVP_PKEY_verify_init(),
-and before calling EVP_PKEY_sign() or EVP_PKEY_verify(). 
+and before calling EVP_PKEY_sign() or EVP_PKEY_verify().
 
 =over 4
 
@@ -32,11 +32,11 @@ The type of padding to be used. Its value can be one of the following:
 
 =item "none" (B<OSSL_PKEY_RSA_PAD_MODE_NONE>)
 
-=item "pkcs1" (B<OSSL_PKEY_RSA_PAD_MODE_PKCSV15>) 
+=item "pkcs1" (B<OSSL_PKEY_RSA_PAD_MODE_PKCSV15>)
 
 =item "x931" (B<OSSL_PKEY_RSA_PAD_MODE_X931>)
 
-=item "pss" (B<OSSL_PKEY_RSA_PAD_MODE_PSS>) 
+=item "pss" (B<OSSL_PKEY_RSA_PAD_MODE_PSS>)
 
 =back
 

--- a/doc/man7/OSSL_PROVIDER-FIPS.pod
+++ b/doc/man7/OSSL_PROVIDER-FIPS.pod
@@ -6,7 +6,7 @@ OSSL_PROVIDER-FIPS - OpenSSL FIPS provider
 
 =head1 DESCRIPTION
 
-The OpenSSL FIPS provider is a special provider that conforms to the Federal 
+The OpenSSL FIPS provider is a special provider that conforms to the Federal
 Information Processing Standards (FIPS) specified in FIPS 140-2. This 'module'
 contains an approved set of cryptographic algorithms that is validated by an
 accredited testing laboratory.
@@ -214,7 +214,7 @@ Known answer test for a digest.
 
 Known answer test for a signature.
 
-=item "PCT_Signature" (B<OSSL_SELF_TEST_TYPE_PCT_SIGNATURE>)      
+=item "PCT_Signature" (B<OSSL_SELF_TEST_TYPE_PCT_SIGNATURE>)
 
 Pairwise Consistency check for a signature.
 

--- a/doc/man7/bio.pod
+++ b/doc/man7/bio.pod
@@ -49,7 +49,7 @@ BIO_free() on it other than the discarded return value.
 
 Normally the I<type> argument is supplied by a function which returns a
 pointer to a BIO_METHOD. There is a naming convention for such functions:
-a source/sink BIO typically starts with I<BIO_s_> and 
+a source/sink BIO typically starts with I<BIO_s_> and
 a filter BIO with I<BIO_f_>.
 
 =head1 EXAMPLES

--- a/doc/man7/life_cycle-cipher.pod
+++ b/doc/man7/life_cycle-cipher.pod
@@ -126,12 +126,12 @@ This is the canonical list.
  Function Call                ---------------------------------------------- Current State -----------------------------------------------
                               start   newed    initialised   updated     finaled   initialised   updated    initialised   updated    freed
                                                                                     decryption  decryption   encryption  encryption
- EVP_CIPHER_CTX_new           newed           
+ EVP_CIPHER_CTX_new           newed
  EVP_CipherInit                    initialised initialised initialised initialised initialised initialised  initialised initialised
  EVP_DecryptInit                   initialised initialised initialised initialised initialised initialised  initialised initialised
-                                    decryption  decryption  decryption  decryption  decryption  decryption  decryption  decryption  
+                                    decryption  decryption  decryption  decryption  decryption  decryption  decryption  decryption
  EVP_EncryptInit                   initialised initialised initialised initialised initialised initialised  initialised initialised
-                                    encryption  encryption  encryption  encryption  encryption  encryption  encryption  encryption  
+                                    encryption  encryption  encryption  encryption  encryption  encryption  encryption  encryption
  EVP_CipherUpdate                                updated     updated
  EVP_DecryptUpdate                                                                   updated     updated
                                                                                     decryption  decryption

--- a/doc/man7/life_cycle-digest.pod
+++ b/doc/man7/life_cycle-digest.pod
@@ -93,7 +93,7 @@ This is the canonical list.
 
  Function Call                --------------------- Current State ----------------------
                               start   newed    initialised   updated     finaled   freed
- EVP_MD_CTX_new               newed           
+ EVP_MD_CTX_new               newed
  EVP_DigestInit                    initialised initialised initialised initialised
  EVP_DigestUpdate                                updated     updated
  EVP_DigestFinal                                             finaled

--- a/doc/man7/life_cycle-kdf.pod
+++ b/doc/man7/life_cycle-kdf.pod
@@ -75,7 +75,7 @@ This is the canonical list.
 
  Function Call                   ------------- Current State -------------
                                  start       newed       deriving    freed
- EVP_KDF_CTX_new                 newed           
+ EVP_KDF_CTX_new                 newed
  EVP_KDF_derive                             deriving     deriving
  EVP_KDF_CTX_free                freed       freed        freed
  EVP_KDF_CTX_reset                           newed        newed

--- a/doc/man7/life_cycle-mac.pod
+++ b/doc/man7/life_cycle-mac.pod
@@ -94,7 +94,7 @@ This is the canonical list.
 
  Function Call                   --------------------- Current State ----------------------
                                  start   newed    initialised   updated     finaled   freed
- EVP_MAC_CTX_new                 newed           
+ EVP_MAC_CTX_new                 newed
  EVP_MAC_init                         initialised initialised initialised initialised
  EVP_MAC_update                                     updated     updated
  EVP_MAC_final                                                  finaled

--- a/doc/man7/life_cycle-rand.pod
+++ b/doc/man7/life_cycle-rand.pod
@@ -87,7 +87,7 @@ This is the canonical list.
 
  Function Call              ------------------ Current State ------------------
                             start   newed   instantiated  uninstantiated  freed
- EVP_RAND_CTX_new           newed       
+ EVP_RAND_CTX_new           newed
  EVP_RAND_instantiate            instantiated
  EVP_RAND_generate                          instantiated
  EVP_RAND_uninstantiate                    uninstantiated

--- a/doc/man7/migration_guide.pod
+++ b/doc/man7/migration_guide.pod
@@ -119,7 +119,7 @@ bypass provider selection and configuration, with unintended consequences.
 This is particularly relevant for applications written to use the OpenSSL 3.0
 FIPS module, as detailed below. Authors and maintainers of external engines are
 strongly encouraged to refactor their code transforming engines into providers
-using the new Provider API and avoiding deprecated methods. 
+using the new Provider API and avoiding deprecated methods.
 
 =head3 Versioning Scheme
 
@@ -133,7 +133,7 @@ at the end of the release version number. This will no longer be used and
 instead the patch level is indicated by the final number in the version. A
 change in the second (MINOR) number indicates that new features may have been
 added. OpenSSL versions with the same major number are API and ABI compatible.
-If the major number changes then API and ABI compatibility is not guaranteed. 
+If the major number changes then API and ABI compatibility is not guaranteed.
 
 For more information, see L<OpenSSL_version(3)>.
 
@@ -409,7 +409,7 @@ enable them to be "freed". However they should also be treated as read-only.
 
 This may mean result in an error in L<EVP_PKEY_derive_set_peer(3)> rather than
 during L<EVP_PKEY_derive(3)>.
-To disable this check use EVP_PKEY_derive_set_peer_ex(dh, peer, 0). 
+To disable this check use EVP_PKEY_derive_set_peer_ex(dh, peer, 0).
 
 =head4 The print format has cosmetic changes for some functions
 
@@ -541,14 +541,14 @@ The code needs to be amended to look like this:
 
 Support for TLSv1.3 has been added.
 
-This has a number of implications for SSL/TLS applications. See the 
+This has a number of implications for SSL/TLS applications. See the
 L<TLS1.3 page|https://wiki.openssl.org/index.php/TLS1.3> for further details.
 
 =back
 
 More details about the breaking changes between OpenSSL versions 1.0.2 and 1.1.0
 can be found on the
-L<OpenSSL 1.1.0 Changes page|https://wiki.openssl.org/index.php/OpenSSL_1.1.0_Changes>. 
+L<OpenSSL 1.1.0 Changes page|https://wiki.openssl.org/index.php/OpenSSL_1.1.0_Changes>.
 
 =head3 Upgrading from the OpenSSL 2.0 FIPS Object Module
 
@@ -985,7 +985,7 @@ APIs, or alternatively use L<EVP_PKEY_fromdata(3)> or L<EVP_PKEY_todata(3)>.
 Functions that access low-level objects directly such as L<RSA_get0_n(3)> are now
 deprecated. Applications should use one of L<EVP_PKEY_get_bn_param(3)>,
 L<EVP_PKEY_get_int_param(3)>, l<EVP_PKEY_get_size_t_param(3)>,
-L<EVP_PKEY_get_utf8_string_param(3)>, L<EVP_PKEY_get_octet_string_param(3)> or 
+L<EVP_PKEY_get_utf8_string_param(3)>, L<EVP_PKEY_get_octet_string_param(3)> or
 L<EVP_PKEY_get_params(3)> to access fields from an EVP_PKEY.
 Gettable parameters are listed in L<EVP_PKEY-RSA(7)/Common RSA parameters>,
 L<EVP_PKEY-DH(7)/DH parameters>, L<EVP_PKEY-DSA(7)/DSA parameters>,
@@ -1115,7 +1115,7 @@ Bi-directional IGE mode. These modes were never formally standardised and
 usage of these functions is believed to be very small. In particular
 AES_bi_ige_encrypt() has a known bug. It accepts 2 AES keys, but only one
 is ever used. The security implications are believed to be minimal, but
-this issue was never fixed for backwards compatibility reasons. 
+this issue was never fixed for backwards compatibility reasons.
 
 =item *
 
@@ -1265,7 +1265,7 @@ DES_decrypt3(), DES_ede3_cbc_encrypt(), DES_ede3_cfb64_encrypt(),
 DES_ede3_cfb_encrypt(),DES_ede3_ofb64_encrypt(),
 DES_ecb_encrypt(), DES_ecb3_encrypt(), DES_ofb64_encrypt(), DES_ofb_encrypt(),
 DES_cfb64_encrypt DES_cfb_encrypt(), DES_cbc_encrypt(), DES_ncbc_encrypt(),
-DES_pcbc_encrypt(), DES_xcbc_encrypt(), DES_cbc_cksum(), DES_quad_cksum(), 
+DES_pcbc_encrypt(), DES_xcbc_encrypt(), DES_cbc_cksum(), DES_quad_cksum(),
 DES_check_key_parity(), DES_is_weak_key(), DES_key_sched(), DES_options(),
 DES_random_key(), DES_set_key(), DES_set_key_checked(), DES_set_key_unchecked(),
 DES_set_odd_parity(), DES_string_to_2keys(), DES_string_to_key()
@@ -1513,7 +1513,7 @@ EC_KEY_set_flags(), EC_KEY_get_flags(), EC_KEY_clear_flags()
 See L<EVP_PKEY-EC(7)/Common EC parameters> which handles flags as seperate
 parameters for B<OSSL_PKEY_PARAM_EC_POINT_CONVERSION_FORMAT>,
 B<OSSL_PKEY_PARAM_EC_GROUP_CHECK_TYPE>, B<OSSL_PKEY_PARAM_EC_ENCODING>,
-B<OSSL_PKEY_PARAM_USE_COFACTOR_ECDH> and 
+B<OSSL_PKEY_PARAM_USE_COFACTOR_ECDH> and
 B<OSSL_PKEY_PARAM_EC_INCLUDE_PUBLIC>.
 See also L<EVP_PKEY-EC(7)/EXAMPLES>
 
@@ -1715,7 +1715,7 @@ See L<EVP_PKEY_copy_parameters(3)> for further details.
 
 =item *
 
-EVP_PKEY_encrypt_old(), EVP_PKEY_decrypt_old(), 
+EVP_PKEY_encrypt_old(), EVP_PKEY_decrypt_old(),
 
 Applications should use L<EVP_PKEY_encrypt_init(3)> and L<EVP_PKEY_encrypt(3)> or
 L<EVP_PKEY_decrypt_init(3)> and L<EVP_PKEY_decrypt(3)> instead.
@@ -1795,7 +1795,7 @@ See L</Deprecated low-level MAC functions>.
 i2d_DHparams(), i2d_DHxparams()
 
 See L</Deprecated low-level key reading and writing functions>
-and L<d2i_RSAPrivateKey(3)/Migration> 
+and L<d2i_RSAPrivateKey(3)/Migration>
 
 =item *
 
@@ -1804,7 +1804,7 @@ i2d_DSAPrivateKey_fp(), i2d_DSA_PUBKEY(), i2d_DSA_PUBKEY_bio(),
 i2d_DSA_PUBKEY_fp(), i2d_DSAPublicKey()
 
 See L</Deprecated low-level key reading and writing functions>
-and L<d2i_RSAPrivateKey(3)/Migration> 
+and L<d2i_RSAPrivateKey(3)/Migration>
 
 =item *
 
@@ -1813,7 +1813,7 @@ i2d_ECPrivateKey_fp(), i2d_EC_PUBKEY(), i2d_EC_PUBKEY_bio(),
 i2d_EC_PUBKEY_fp(), i2o_ECPublicKey()
 
 See L</Deprecated low-level key reading and writing functions>
-and L<d2i_RSAPrivateKey(3)/Migration> 
+and L<d2i_RSAPrivateKey(3)/Migration>
 
 =item *
 
@@ -1822,7 +1822,7 @@ i2d_RSA_PUBKEY(), i2d_RSA_PUBKEY_bio(), i2d_RSA_PUBKEY_fp(),
 i2d_RSAPublicKey(), i2d_RSAPublicKey_bio(), i2d_RSAPublicKey_fp()
 
 See L</Deprecated low-level key reading and writing functions>
-and L<d2i_RSAPrivateKey(3)/Migration> 
+and L<d2i_RSAPrivateKey(3)/Migration>
 
 =item *
 
@@ -2201,7 +2201,7 @@ B<-provider_path> and B<-provider> are available to all apps and can be used
 multiple times to load any providers, such as the 'legacy' provider or third
 party providers. If used then the 'default' provider would also need to be
 specified if required. The B<-provider_path> must be specified before the
-B<-provider> option. 
+B<-provider> option.
 
 The B<list> app has many new options. See L<openssl-list(1)> for more
 information.

--- a/doc/man7/openssl-core.h.pod
+++ b/doc/man7/openssl-core.h.pod
@@ -67,7 +67,7 @@ or canonical name, on a per algorithm implementation basis.
 
 This type is a structure that allows passing arbitrary object data
 between two parties that have no or very little shared knowledge about
-their respective internal structures for that object. 
+their respective internal structures for that object.
 It's normally passed in arrays, where the array is terminated with an
 element where all fields are zero (for non-pointers) or NULL (for
 pointers).

--- a/doc/man7/openssl-glossary.pod
+++ b/doc/man7/openssl-glossary.pod
@@ -132,7 +132,7 @@ L<OSSL_PROVIDER-null(7)>
 
 =item Operation
 
-An operation is a group of OpenSSL functions with a common purpose such as 
+An operation is a group of OpenSSL functions with a common purpose such as
 encryption, or digesting.
 
 L<crypto(7)>

--- a/doc/man7/property.pod
+++ b/doc/man7/property.pod
@@ -144,7 +144,7 @@ setting.
 
 The lexical syntax in EBNF is given by:
 
- Definition     ::= PropertyName ( '=' Value )? 
+ Definition     ::= PropertyName ( '=' Value )?
                         ( ',' PropertyName ( '=' Value )? )*
  Query          ::= PropertyQuery ( ',' PropertyQuery )*
  PropertyQuery  ::= '-' PropertyName

--- a/doc/man7/provider-base.pod
+++ b/doc/man7/provider-base.pod
@@ -443,7 +443,7 @@ different for any third party provider.
 This returns 0 if the provider has entered an error state, otherwise it returns
 1.
 
-=back 
+=back
 
 provider_gettable_params() should return the above parameters.
 

--- a/doc/man7/provider-keyexch.pod
+++ b/doc/man7/provider-keyexch.pod
@@ -43,7 +43,7 @@ This documentation is primarily aimed at provider authors. See L<provider(7)>
 for further information.
 
 The key exchange (OSSL_OP_KEYEXCH) operation enables providers to implement key
-exchange algorithms and make them available to applications via 
+exchange algorithms and make them available to applications via
 L<EVP_PKEY_derive(3)> and
 other related functions).
 

--- a/doc/man7/provider-keymgmt.pod
+++ b/doc/man7/provider-keymgmt.pod
@@ -237,7 +237,7 @@ OSSL_FUNC_keymgmt_gen_set_params() should set additional parameters from
 I<params> in the key object generation context I<genctx>.
 
 OSSL_FUNC_keymgmt_gen_settable_params() should return a constant array of
-descriptor B<OSSL_PARAM>, for parameters that OSSL_FUNC_keymgmt_gen_set_params() 
+descriptor B<OSSL_PARAM>, for parameters that OSSL_FUNC_keymgmt_gen_set_params()
 can handle.
 
 OSSL_FUNC_keymgmt_gen() should perform the key object generation itself, and
@@ -255,7 +255,7 @@ Outside the provider, this reference is simply an array of bytes.
 
 At least one of OSSL_FUNC_keymgmt_new(), OSSL_FUNC_keymgmt_gen() and
 OSSL_FUNC_keymgmt_load() are mandatory, as well as OSSL_FUNC_keymgmt_free() and
-OSSL_FUNC_keymgmt_has(). Additionally, if OSSL_FUNC_keymgmt_gen() is present, 
+OSSL_FUNC_keymgmt_has(). Additionally, if OSSL_FUNC_keymgmt_gen() is present,
 OSSL_FUNC_keymgmt_gen_init() and OSSL_FUNC_keymgmt_gen_cleanup() must be
 present as well.
 

--- a/doc/man7/provider-signature.pod
+++ b/doc/man7/provider-signature.pod
@@ -371,7 +371,7 @@ Sets a flag to modify the sign operation to return an error if the initial
 calculated signature is invalid.
 In the normal mode of operation - new random values are chosen until the
 signature operation succeeds.
-By default it retries until a signature is calculated. 
+By default it retries until a signature is calculated.
 Setting the value to 0 causes the sign operation to retry,
 otherwise the sign operation is only tried once and returns whether or not it
 was successful.

--- a/doc/man7/proxy-certificates.pod
+++ b/doc/man7/proxy-certificates.pod
@@ -215,7 +215,7 @@ The following skeleton code can be used as a starting point:
              * bottom.  You get the CA root first, followed by the
              * possible chain of intermediate CAs, followed by the EE
              * certificate, followed by the possible proxy
-             * certificates. 
+             * certificates.
              */
             X509 *xs = X509_STORE_CTX_get_current_cert(ctx);
 
@@ -234,7 +234,7 @@ The following skeleton code can be used as a starting point:
                      * by pulling them from some database.  If there
                      * are none to be found, clear all rights (making
                      * this and any subsequent proxy certificate void
-                     * of any rights). 
+                     * of any rights).
                      */
                     memset(rights->rights, 0, sizeof(rights->rights));
                     break;


### PR DESCRIPTION
Some spaces at the end of lines have crept in.  Now they are gone.

3.0 is tentative, happy either way but including this avoids making merges trickier for little reason.

- [x] documentation is added or updated
- [ ] tests are added or updated
