### PR TITLE
tls: reduce the security strength of the CCM8 cipher suites

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,11 @@ OpenSSL 3.1
 
 ### Changes between 3.0 and 3.1 [xx XXX xxxx]
 
+ * CCM8 cipher suites in TLS have been downgraded to security level 1 because
+   they use a short tag which lowers their strength.
+
+   *Paul Dale*
+
  * Subject or issuer names in X.509 objects are now displayed as UTF-8 strings
    by default.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,8 +24,8 @@ OpenSSL 3.1
 
 ### Changes between 3.0 and 3.1 [xx XXX xxxx]
 
- * CCM8 cipher suites in TLS have been downgraded to security level 1 because
-   they use a short tag which lowers their strength.
+ * CCM8 cipher suites in TLS have been downgraded to security level zero
+   because they use a short authentication tag which lowers their strength.
 
    *Paul Dale*
 

--- a/doc/man3/SSL_CTX_set_security_level.pod
+++ b/doc/man3/SSL_CTX_set_security_level.pod
@@ -83,8 +83,9 @@ using MD5 for the MAC is also prohibited.
 
 Security level set to 112 bits of security. As a result RSA, DSA and DH keys
 shorter than 2048 bits and ECC keys shorter than 224 bits are prohibited.
-In addition to the level 1 exclusions any cipher suite using RC4 is also
-prohibited. SSL version 3 is also not allowed. Compression is disabled.
+In addition to the level 1 exclusions any cipher suite using RC4 and any
+cipher suite using CCM with a 64 bit authentication tag are also prohibited.
+SSL version 3 is also not allowed. Compression is disabled.
 
 =item B<Level 3>
 

--- a/doc/man3/SSL_CTX_set_security_level.pod
+++ b/doc/man3/SSL_CTX_set_security_level.pod
@@ -77,15 +77,15 @@ parameters offering below 80 bits of security are excluded. As a result RSA,
 DSA and DH keys shorter than 1024 bits and ECC keys shorter than 160 bits
 are prohibited. All export cipher suites are prohibited since they all offer
 less than 80 bits of security. SSL version 2 is prohibited. Any cipher suite
-using MD5 for the MAC is also prohibited.
+using MD5 for the MAC is also prohibited. Any cipher suites using CCM with
+a 64 bit authentication tag are prohibited.
 
 =item B<Level 2>
 
 Security level set to 112 bits of security. As a result RSA, DSA and DH keys
 shorter than 2048 bits and ECC keys shorter than 224 bits are prohibited.
-In addition to the level 1 exclusions any cipher suite using RC4 and any
-cipher suite using CCM with a 64 bit authentication tag are also prohibited.
-SSL version 3 is also not allowed. Compression is disabled.
+In addition to the level 1 exclusions any cipher suite using RC4 is also
+prohibited. SSL version 3 is also not allowed. Compression is disabled.
 
 =item B<Level 3>
 

--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -108,9 +108,9 @@ static SSL_CIPHER tls13_ciphers[] = {
         SSL_AEAD,
         TLS1_3_VERSION, TLS1_3_VERSION,
         0, 0,
-        SSL_NOT_DEFAULT | SSL_HIGH,
+        SSL_NOT_DEFAULT | SSL_MEDIUM,
         SSL_HANDSHAKE_MAC_SHA256,
-        128,
+        64, /* CCM8 uses a short tag, so we have a low security strength */
         128,
     }
 };
@@ -699,9 +699,9 @@ static SSL_CIPHER ssl3_ciphers[] = {
      SSL_AEAD,
      TLS1_2_VERSION, TLS1_2_VERSION,
      DTLS1_2_VERSION, DTLS1_2_VERSION,
-     SSL_NOT_DEFAULT | SSL_HIGH,
+     SSL_NOT_DEFAULT | SSL_MEDIUM,
      SSL_HANDSHAKE_MAC_SHA256 | TLS1_PRF_SHA256,
-     128,
+     64, /* CCM8 uses a short tag, so we have a low security strength */
      128,
      },
     {
@@ -715,9 +715,9 @@ static SSL_CIPHER ssl3_ciphers[] = {
      SSL_AEAD,
      TLS1_2_VERSION, TLS1_2_VERSION,
      DTLS1_2_VERSION, DTLS1_2_VERSION,
-     SSL_NOT_DEFAULT | SSL_HIGH,
+     SSL_NOT_DEFAULT | SSL_MEDIUM,
      SSL_HANDSHAKE_MAC_SHA256 | TLS1_PRF_SHA256,
-     256,
+     64, /* CCM8 uses a short tag, so we have a low security strength */
      256,
      },
     {
@@ -731,9 +731,9 @@ static SSL_CIPHER ssl3_ciphers[] = {
      SSL_AEAD,
      TLS1_2_VERSION, TLS1_2_VERSION,
      DTLS1_2_VERSION, DTLS1_2_VERSION,
-     SSL_NOT_DEFAULT | SSL_HIGH,
+     SSL_NOT_DEFAULT | SSL_MEDIUM,
      SSL_HANDSHAKE_MAC_SHA256 | TLS1_PRF_SHA256,
-     128,
+     64, /* CCM8 uses a short tag, so we have a low security strength */
      128,
      },
     {
@@ -747,9 +747,9 @@ static SSL_CIPHER ssl3_ciphers[] = {
      SSL_AEAD,
      TLS1_2_VERSION, TLS1_2_VERSION,
      DTLS1_2_VERSION, DTLS1_2_VERSION,
-     SSL_NOT_DEFAULT | SSL_HIGH,
+     SSL_NOT_DEFAULT | SSL_MEDIUM,
      SSL_HANDSHAKE_MAC_SHA256 | TLS1_PRF_SHA256,
-     256,
+     64, /* CCM8 uses a short tag, so we have a low security strength */
      256,
      },
     {
@@ -827,9 +827,9 @@ static SSL_CIPHER ssl3_ciphers[] = {
      SSL_AEAD,
      TLS1_2_VERSION, TLS1_2_VERSION,
      DTLS1_2_VERSION, DTLS1_2_VERSION,
-     SSL_NOT_DEFAULT | SSL_HIGH,
+     SSL_NOT_DEFAULT | SSL_MEDIUM,
      SSL_HANDSHAKE_MAC_SHA256 | TLS1_PRF_SHA256,
-     128,
+     64, /* CCM8 uses a short tag, so we have a low security strength */
      128,
      },
     {
@@ -843,9 +843,9 @@ static SSL_CIPHER ssl3_ciphers[] = {
      SSL_AEAD,
      TLS1_2_VERSION, TLS1_2_VERSION,
      DTLS1_2_VERSION, DTLS1_2_VERSION,
-     SSL_NOT_DEFAULT | SSL_HIGH,
+     SSL_NOT_DEFAULT | SSL_MEDIUM,
      SSL_HANDSHAKE_MAC_SHA256 | TLS1_PRF_SHA256,
-     256,
+     64, /* CCM8 uses a short tag, so we have a low security strength */
      256,
      },
     {
@@ -859,9 +859,9 @@ static SSL_CIPHER ssl3_ciphers[] = {
      SSL_AEAD,
      TLS1_2_VERSION, TLS1_2_VERSION,
      DTLS1_2_VERSION, DTLS1_2_VERSION,
-     SSL_NOT_DEFAULT | SSL_HIGH,
+     SSL_NOT_DEFAULT | SSL_MEDIUM,
      SSL_HANDSHAKE_MAC_SHA256 | TLS1_PRF_SHA256,
-     128,
+     64, /* CCM8 uses a short tag, so we have a low security strength */
      128,
      },
     {
@@ -875,9 +875,9 @@ static SSL_CIPHER ssl3_ciphers[] = {
      SSL_AEAD,
      TLS1_2_VERSION, TLS1_2_VERSION,
      DTLS1_2_VERSION, DTLS1_2_VERSION,
-     SSL_NOT_DEFAULT | SSL_HIGH,
+     SSL_NOT_DEFAULT | SSL_MEDIUM,
      SSL_HANDSHAKE_MAC_SHA256 | TLS1_PRF_SHA256,
-     256,
+     64, /* CCM8 uses a short tag, so we have a low security strength */
      256,
      },
     {
@@ -923,9 +923,9 @@ static SSL_CIPHER ssl3_ciphers[] = {
      SSL_AEAD,
      TLS1_2_VERSION, TLS1_2_VERSION,
      DTLS1_2_VERSION, DTLS1_2_VERSION,
-     SSL_NOT_DEFAULT | SSL_HIGH,
+     SSL_NOT_DEFAULT | SSL_MEDIUM,
      SSL_HANDSHAKE_MAC_SHA256 | TLS1_PRF_SHA256,
-     128,
+     64, /* CCM8 uses a short tag, so we have a low security strength */
      128,
      },
     {
@@ -939,9 +939,9 @@ static SSL_CIPHER ssl3_ciphers[] = {
      SSL_AEAD,
      TLS1_2_VERSION, TLS1_2_VERSION,
      DTLS1_2_VERSION, DTLS1_2_VERSION,
-     SSL_NOT_DEFAULT | SSL_HIGH,
+     SSL_NOT_DEFAULT | SSL_MEDIUM,
      SSL_HANDSHAKE_MAC_SHA256 | TLS1_PRF_SHA256,
-     256,
+     64, /* CCM8 uses a short tag, so we have a low security strength */
      256,
      },
     {

--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -110,7 +110,7 @@ static SSL_CIPHER tls13_ciphers[] = {
         0, 0,
         SSL_NOT_DEFAULT | SSL_MEDIUM,
         SSL_HANDSHAKE_MAC_SHA256,
-        80, /* CCM8 uses a short tag, so we have a low security strength */
+        64, /* CCM8 uses a short tag, so we have a low security strength */
         128,
     }
 };
@@ -701,7 +701,7 @@ static SSL_CIPHER ssl3_ciphers[] = {
      DTLS1_2_VERSION, DTLS1_2_VERSION,
      SSL_NOT_DEFAULT | SSL_MEDIUM,
      SSL_HANDSHAKE_MAC_SHA256 | TLS1_PRF_SHA256,
-     80, /* CCM8 uses a short tag, so we have a low security strength */
+     64, /* CCM8 uses a short tag, so we have a low security strength */
      128,
      },
     {
@@ -717,7 +717,7 @@ static SSL_CIPHER ssl3_ciphers[] = {
      DTLS1_2_VERSION, DTLS1_2_VERSION,
      SSL_NOT_DEFAULT | SSL_MEDIUM,
      SSL_HANDSHAKE_MAC_SHA256 | TLS1_PRF_SHA256,
-     80, /* CCM8 uses a short tag, so we have a low security strength */
+     64, /* CCM8 uses a short tag, so we have a low security strength */
      256,
      },
     {
@@ -733,7 +733,7 @@ static SSL_CIPHER ssl3_ciphers[] = {
      DTLS1_2_VERSION, DTLS1_2_VERSION,
      SSL_NOT_DEFAULT | SSL_MEDIUM,
      SSL_HANDSHAKE_MAC_SHA256 | TLS1_PRF_SHA256,
-     80, /* CCM8 uses a short tag, so we have a low security strength */
+     64, /* CCM8 uses a short tag, so we have a low security strength */
      128,
      },
     {
@@ -749,7 +749,7 @@ static SSL_CIPHER ssl3_ciphers[] = {
      DTLS1_2_VERSION, DTLS1_2_VERSION,
      SSL_NOT_DEFAULT | SSL_MEDIUM,
      SSL_HANDSHAKE_MAC_SHA256 | TLS1_PRF_SHA256,
-     80, /* CCM8 uses a short tag, so we have a low security strength */
+     64, /* CCM8 uses a short tag, so we have a low security strength */
      256,
      },
     {
@@ -829,7 +829,7 @@ static SSL_CIPHER ssl3_ciphers[] = {
      DTLS1_2_VERSION, DTLS1_2_VERSION,
      SSL_NOT_DEFAULT | SSL_MEDIUM,
      SSL_HANDSHAKE_MAC_SHA256 | TLS1_PRF_SHA256,
-     80, /* CCM8 uses a short tag, so we have a low security strength */
+     64, /* CCM8 uses a short tag, so we have a low security strength */
      128,
      },
     {
@@ -845,7 +845,7 @@ static SSL_CIPHER ssl3_ciphers[] = {
      DTLS1_2_VERSION, DTLS1_2_VERSION,
      SSL_NOT_DEFAULT | SSL_MEDIUM,
      SSL_HANDSHAKE_MAC_SHA256 | TLS1_PRF_SHA256,
-     80, /* CCM8 uses a short tag, so we have a low security strength */
+     64, /* CCM8 uses a short tag, so we have a low security strength */
      256,
      },
     {
@@ -861,7 +861,7 @@ static SSL_CIPHER ssl3_ciphers[] = {
      DTLS1_2_VERSION, DTLS1_2_VERSION,
      SSL_NOT_DEFAULT | SSL_MEDIUM,
      SSL_HANDSHAKE_MAC_SHA256 | TLS1_PRF_SHA256,
-     80, /* CCM8 uses a short tag, so we have a low security strength */
+     64, /* CCM8 uses a short tag, so we have a low security strength */
      128,
      },
     {
@@ -877,7 +877,7 @@ static SSL_CIPHER ssl3_ciphers[] = {
      DTLS1_2_VERSION, DTLS1_2_VERSION,
      SSL_NOT_DEFAULT | SSL_MEDIUM,
      SSL_HANDSHAKE_MAC_SHA256 | TLS1_PRF_SHA256,
-     80, /* CCM8 uses a short tag, so we have a low security strength */
+     64, /* CCM8 uses a short tag, so we have a low security strength */
      256,
      },
     {
@@ -925,7 +925,7 @@ static SSL_CIPHER ssl3_ciphers[] = {
      DTLS1_2_VERSION, DTLS1_2_VERSION,
      SSL_NOT_DEFAULT | SSL_MEDIUM,
      SSL_HANDSHAKE_MAC_SHA256 | TLS1_PRF_SHA256,
-     80, /* CCM8 uses a short tag, so we have a low security strength */
+     64, /* CCM8 uses a short tag, so we have a low security strength */
      128,
      },
     {
@@ -941,7 +941,7 @@ static SSL_CIPHER ssl3_ciphers[] = {
      DTLS1_2_VERSION, DTLS1_2_VERSION,
      SSL_NOT_DEFAULT | SSL_MEDIUM,
      SSL_HANDSHAKE_MAC_SHA256 | TLS1_PRF_SHA256,
-     80, /* CCM8 uses a short tag, so we have a low security strength */
+     64, /* CCM8 uses a short tag, so we have a low security strength */
      256,
      },
     {

--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -110,7 +110,7 @@ static SSL_CIPHER tls13_ciphers[] = {
         0, 0,
         SSL_NOT_DEFAULT | SSL_MEDIUM,
         SSL_HANDSHAKE_MAC_SHA256,
-        64, /* CCM8 uses a short tag, so we have a low security strength */
+        80, /* CCM8 uses a short tag, so we have a low security strength */
         128,
     }
 };
@@ -701,7 +701,7 @@ static SSL_CIPHER ssl3_ciphers[] = {
      DTLS1_2_VERSION, DTLS1_2_VERSION,
      SSL_NOT_DEFAULT | SSL_MEDIUM,
      SSL_HANDSHAKE_MAC_SHA256 | TLS1_PRF_SHA256,
-     64, /* CCM8 uses a short tag, so we have a low security strength */
+     80, /* CCM8 uses a short tag, so we have a low security strength */
      128,
      },
     {
@@ -717,7 +717,7 @@ static SSL_CIPHER ssl3_ciphers[] = {
      DTLS1_2_VERSION, DTLS1_2_VERSION,
      SSL_NOT_DEFAULT | SSL_MEDIUM,
      SSL_HANDSHAKE_MAC_SHA256 | TLS1_PRF_SHA256,
-     64, /* CCM8 uses a short tag, so we have a low security strength */
+     80, /* CCM8 uses a short tag, so we have a low security strength */
      256,
      },
     {
@@ -733,7 +733,7 @@ static SSL_CIPHER ssl3_ciphers[] = {
      DTLS1_2_VERSION, DTLS1_2_VERSION,
      SSL_NOT_DEFAULT | SSL_MEDIUM,
      SSL_HANDSHAKE_MAC_SHA256 | TLS1_PRF_SHA256,
-     64, /* CCM8 uses a short tag, so we have a low security strength */
+     80, /* CCM8 uses a short tag, so we have a low security strength */
      128,
      },
     {
@@ -749,7 +749,7 @@ static SSL_CIPHER ssl3_ciphers[] = {
      DTLS1_2_VERSION, DTLS1_2_VERSION,
      SSL_NOT_DEFAULT | SSL_MEDIUM,
      SSL_HANDSHAKE_MAC_SHA256 | TLS1_PRF_SHA256,
-     64, /* CCM8 uses a short tag, so we have a low security strength */
+     80, /* CCM8 uses a short tag, so we have a low security strength */
      256,
      },
     {
@@ -829,7 +829,7 @@ static SSL_CIPHER ssl3_ciphers[] = {
      DTLS1_2_VERSION, DTLS1_2_VERSION,
      SSL_NOT_DEFAULT | SSL_MEDIUM,
      SSL_HANDSHAKE_MAC_SHA256 | TLS1_PRF_SHA256,
-     64, /* CCM8 uses a short tag, so we have a low security strength */
+     80, /* CCM8 uses a short tag, so we have a low security strength */
      128,
      },
     {
@@ -845,7 +845,7 @@ static SSL_CIPHER ssl3_ciphers[] = {
      DTLS1_2_VERSION, DTLS1_2_VERSION,
      SSL_NOT_DEFAULT | SSL_MEDIUM,
      SSL_HANDSHAKE_MAC_SHA256 | TLS1_PRF_SHA256,
-     64, /* CCM8 uses a short tag, so we have a low security strength */
+     80, /* CCM8 uses a short tag, so we have a low security strength */
      256,
      },
     {
@@ -861,7 +861,7 @@ static SSL_CIPHER ssl3_ciphers[] = {
      DTLS1_2_VERSION, DTLS1_2_VERSION,
      SSL_NOT_DEFAULT | SSL_MEDIUM,
      SSL_HANDSHAKE_MAC_SHA256 | TLS1_PRF_SHA256,
-     64, /* CCM8 uses a short tag, so we have a low security strength */
+     80, /* CCM8 uses a short tag, so we have a low security strength */
      128,
      },
     {
@@ -877,7 +877,7 @@ static SSL_CIPHER ssl3_ciphers[] = {
      DTLS1_2_VERSION, DTLS1_2_VERSION,
      SSL_NOT_DEFAULT | SSL_MEDIUM,
      SSL_HANDSHAKE_MAC_SHA256 | TLS1_PRF_SHA256,
-     64, /* CCM8 uses a short tag, so we have a low security strength */
+     80, /* CCM8 uses a short tag, so we have a low security strength */
      256,
      },
     {
@@ -925,7 +925,7 @@ static SSL_CIPHER ssl3_ciphers[] = {
      DTLS1_2_VERSION, DTLS1_2_VERSION,
      SSL_NOT_DEFAULT | SSL_MEDIUM,
      SSL_HANDSHAKE_MAC_SHA256 | TLS1_PRF_SHA256,
-     64, /* CCM8 uses a short tag, so we have a low security strength */
+     80, /* CCM8 uses a short tag, so we have a low security strength */
      128,
      },
     {
@@ -941,7 +941,7 @@ static SSL_CIPHER ssl3_ciphers[] = {
      DTLS1_2_VERSION, DTLS1_2_VERSION,
      SSL_NOT_DEFAULT | SSL_MEDIUM,
      SSL_HANDSHAKE_MAC_SHA256 | TLS1_PRF_SHA256,
-     64, /* CCM8 uses a short tag, so we have a low security strength */
+     80, /* CCM8 uses a short tag, so we have a low security strength */
      256,
      },
     {

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -4112,6 +4112,12 @@ static int test_early_data_psk_with_all_ciphers(int idx)
                                         &serverssl, &sess, 2)))
         goto end;
 
+    if (idx == 4) {
+        /* CCM8 ciphers are considered low security due to their short tag */
+        SSL_set_security_level(clientssl, 0);
+        SSL_set_security_level(serverssl, 0);
+    }
+
     if (!TEST_true(SSL_set_ciphersuites(clientssl, cipher_str[idx]))
             || !TEST_true(SSL_set_ciphersuites(serverssl, cipher_str[idx])))
         goto end;
@@ -4399,9 +4405,11 @@ static int test_ciphersuite_change(void)
                                                    "TLS_AES_256_GCM_SHA384:"
                                                    "TLS_AES_128_CCM_SHA256"))
             || !TEST_true(SSL_CTX_set_ciphersuites(cctx,
-                                                   "TLS_AES_128_GCM_SHA256"))
-            || !TEST_true(create_ssl_objects(sctx, cctx, &serverssl,
-                                          &clientssl, NULL, NULL))
+                                                   "TLS_AES_128_GCM_SHA256")))
+        goto end;
+
+    if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
+                                      NULL, NULL))
             || !TEST_true(create_ssl_connection(serverssl, clientssl,
                                                 SSL_ERROR_NONE)))
         goto end;
@@ -4928,16 +4936,19 @@ static int test_tls13_ciphersuite(int idx)
     static const struct {
         const char *ciphername;
         int fipscapable;
+        int low_security;
     } t13_ciphers[] = {
-        { TLS1_3_RFC_AES_128_GCM_SHA256, 1 },
-        { TLS1_3_RFC_AES_256_GCM_SHA384, 1 },
-        { TLS1_3_RFC_AES_128_CCM_SHA256, 1 },
+        { TLS1_3_RFC_AES_128_GCM_SHA256, 1, 0 },
+        { TLS1_3_RFC_AES_256_GCM_SHA384, 1, 0 },
+        { TLS1_3_RFC_AES_128_CCM_SHA256, 1, 0 },
 # if !defined(OPENSSL_NO_CHACHA) && !defined(OPENSSL_NO_POLY1305)
-        { TLS1_3_RFC_CHACHA20_POLY1305_SHA256, 0 },
+        { TLS1_3_RFC_CHACHA20_POLY1305_SHA256, 0, 0 },
         { TLS1_3_RFC_AES_256_GCM_SHA384
-          ":" TLS1_3_RFC_CHACHA20_POLY1305_SHA256, 0 },
+          ":" TLS1_3_RFC_CHACHA20_POLY1305_SHA256, 0, 0 },
 # endif
-        { TLS1_3_RFC_AES_128_CCM_8_SHA256 ":" TLS1_3_RFC_AES_128_CCM_SHA256, 1 }
+        /* CCM8 ciphers are considered low security due to their short tag */
+        { TLS1_3_RFC_AES_128_CCM_8_SHA256
+          ":" TLS1_3_RFC_AES_128_CCM_SHA256, 1, 1 }
     };
     const char *t13_cipher = NULL;
     const char *t12_cipher = NULL;
@@ -4980,6 +4991,11 @@ static int test_tls13_ciphersuite(int idx)
                                                TLS1_VERSION, max_ver,
                                                &sctx, &cctx, cert, privkey)))
                 goto end;
+
+            if (t13_ciphers[i].low_security) {
+                SSL_CTX_set_security_level(sctx, 0);
+                SSL_CTX_set_security_level(cctx, 0);
+            }
 
             if (set_at_ctx) {
                 if (!TEST_true(SSL_CTX_set_ciphersuites(sctx, t13_cipher))


### PR DESCRIPTION
Alternative to #16160

CCM8 suites have a 64 bit authentication tag which is pretty short.

The changes reduces these cipher suites to security levels below 2.

Fixes #16154

- [x] documentation is added or updated
- [ ] tests are added or updated
