### PR TITLE
FIPS and KTLS may interfere

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,6 +179,19 @@ jobs:
     - name: make test
       run: make test HARNESS_JOBS=${HARNESS_JOBS:-4}
 
+  fips_and_ktls:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: modprobe tls
+      run: sudo modprobe tls
+    - name: config
+      run: ./config --banner=Configured --strict-warnings enable-ktls enable-fips && perl configdata.pm --dump
+    - name: make
+      run: make -s -j4
+    - name: make test
+      run: make test HARNESS_JOBS=${HARNESS_JOBS:-4}
+
   no-legacy:
     runs-on: ubuntu-latest
     steps:

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -1158,6 +1158,11 @@ static int execute_test_ktls(int cis_ktls, int sis_ktls,
         goto end;
     }
 
+    if (is_fips && strstr(cipher, "CHACHA") != NULL) {
+        testresult = TEST_skip("CHACHA is not supported in FIPS");
+        goto end;
+    }
+
     /* Create a session based on SHA-256 */
     if (!TEST_true(create_ssl_ctx_pair(libctx, TLS_server_method(),
                                        TLS_client_method(),
@@ -1289,6 +1294,11 @@ static int execute_test_ktls_sendfile(int tls_version, const char *cipher)
     /* Skip this test if the platform does not support ktls */
     if (!ktls_chk_platform(sfd)) {
         testresult = TEST_skip("Kernel does not support KTLS");
+        goto end;
+    }
+
+    if (is_fips && strstr(cipher, "CHACHA") != NULL) {
+        testresult = TEST_skip("CHACHA is not supported in FIPS");
         goto end;
     }
 


### PR DESCRIPTION
New Linux kernels (>= 5.11) enable KTLS CHACHA which is not FIPS-suitable.

Fixes #16657

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
