### PR TITLE
Update 15-ios.conf

### DIFF
--- a/Configurations/15-ios.conf
+++ b/Configurations/15-ios.conf
@@ -10,7 +10,7 @@ my %targets = (
         template         => 1,
         inherit_from     => [ "darwin-common" ],
         sys_id           => "iOS",
-        disable          => [ "engine", "async" ],
+        disable          => [ "shared", "async" ],
     },
     "ios-xcrun" => {
         inherit_from     => [ "ios-common" ],


### PR DESCRIPTION
CLA: trivial

I assume this has been an error in the initial ios conf file. In order to build for ios the shared engine library, needs to be disabled because iOS doesn't have the concept of shared libraries. But instead of only disabling `dynamic-engine` (or like in this commit disabled the `shared`) option the previous config did disable `engine` and with that the `static-engine` compilation as well. This restores the `static-engine` option being enabled by default, but keeping compilation going on iOS.

Cheers!

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
