### PR TITLE
ci: add additional operating system specific builds

### DIFF
--- a/.github/workflows/os-zoo.yml
+++ b/.github/workflows/os-zoo.yml
@@ -7,9 +7,9 @@
 
 name: OS Zoo CI
 
-on: [pull_request]
-#  schedule:
-#    - cron: '0 5 * * *'
+on:
+  schedule:
+    - cron: '0 5 * * *'
 
 jobs:
   unix:

--- a/.github/workflows/os-zoo.yml
+++ b/.github/workflows/os-zoo.yml
@@ -1,0 +1,66 @@
+# Copyright 2021 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+name: OS Zoo CI
+
+on: [pull_request]
+#  schedule:
+#    - cron: '0 5 * * *'
+
+jobs:
+  unix:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [
+          macos-10.15,
+          macos-11,
+          ubuntu-18.04,
+          ubuntu-20.04,
+        ]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v2
+    - name: config
+      run: |
+        CC=${{ matrix.zoo.cc }} ./config --banner=Configured \
+            -Wall -Werror --strict-warnings enable-fips
+    - name: config dump
+      run: ./configdata.pm --dump
+    - name: make
+      run: make -s -j4
+    - name: make test
+      run: make test HARNESS_JOBS=${HARNESS_JOBS:-4}
+  windows:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [
+          windows-2016,
+          windows-2019,
+          #windows-2022,    # Perl issues, doesn't finish configure step
+        ]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ilammy/msvc-dev-cmd@v1
+    - uses: ilammy/setup-nasm@v1
+    - name: prepare the build directory
+      run: mkdir _build
+    - name: config
+      working-directory: _build
+      run: |
+        perl ..\Configure --banner=Configured no-makedepend enable-fips
+    - name: config dump
+      working-directory: _build
+      run: ./configdata.pm --dump
+    - name: build
+      working-directory: _build
+      run: nmake /S
+    - name: test
+      working-directory: _build
+      run: nmake test VERBOSE_FAILURE=yes HARNESS_JOBS=4


### PR DESCRIPTION
These are an attempt to cover off on older OS versions that the main CIs do not cover.
Currently, this is two older Ubuntu and one MacOS version.  The current latest are also include but using specific version numbers.

- [ ] documentation is added or updated
- [x] tests are added or updated
