### PR TITLE
Fix return value of BIO_free

### DIFF
--- a/crypto/bio/bio_lib.c
+++ b/crypto/bio/bio_lib.c
@@ -140,7 +140,7 @@ int BIO_free(BIO *a)
     if (HAS_CALLBACK(a)) {
         ret = (int)bio_call_callback(a, BIO_CB_FREE, NULL, 0, 0, 0L, 1L, NULL);
         if (ret <= 0)
-            return ret;
+            return 0;
     }
 
     if ((a->method != NULL) && (a->method->destroy != NULL))


### PR DESCRIPTION
CLA: trivial

Since the docuementation says **_BIO_free() return 1 for success and 0 for failure_** and some other applications who use openssl library are used to use **_if(!BIO_free) {_**, it's better to unify return value. 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
