### PR TITLE
Fix ssl_free() and thus BIO_free() to respect BIO_NOCLOSE

### DIFF
--- a/apps/lib/s_socket.c
+++ b/apps/lib/s_socket.c
@@ -82,6 +82,7 @@ int init_client(int *sock, const char *host, const char *port,
     BIO_ADDRINFO *bindaddr = NULL;
     const BIO_ADDRINFO *ai = NULL;
     const BIO_ADDRINFO *bi = NULL;
+    char *hostname = NULL;
     int found = 0;
     int ret;
 
@@ -172,7 +173,9 @@ int init_client(int *sock, const char *host, const char *port,
         break;
     }
 
-    BIO_printf(bio_out, "Connecting to %s\n", BIO_ADDR_hostname_string(BIO_ADDRINFO_address(ai), 1));
+    hostname = BIO_ADDR_hostname_string(BIO_ADDRINFO_address(ai), 1);
+    BIO_printf(bio_out, "Connecting to %s\n", hostname);
+    OPENSSL_free(hostname);
 
     if (*sock == INVALID_SOCKET) {
         if (bindaddr != NULL && !found) {

--- a/doc/man3/BIO_f_ssl.pod
+++ b/doc/man3/BIO_f_ssl.pod
@@ -54,26 +54,26 @@ The SSL BIO is then reset to the initial accept or connect state.
 If the close flag is set when an SSL BIO is freed then the internal
 SSL structure is also freed using SSL_free().
 
-BIO_set_ssl() sets the internal SSL pointer of BIO B<b> to B<ssl> using
+BIO_set_ssl() sets the internal SSL pointer of SSL BIO B<b> to B<ssl> using
 the close flag B<c>.
 
-BIO_get_ssl() retrieves the SSL pointer of BIO B<b>, it can then be
+BIO_get_ssl() retrieves the SSL pointer of SSL BIO B<b>, it can then be
 manipulated using the standard SSL library functions.
 
 BIO_set_ssl_mode() sets the SSL BIO mode to B<client>. If B<client>
 is 1 client mode is set. If B<client> is 0 server mode is set.
 
-BIO_set_ssl_renegotiate_bytes() sets the renegotiate byte count
+BIO_set_ssl_renegotiate_bytes() sets the renegotiate byte count of SSL BIO B<b>
 to B<num>. When set after every B<num> bytes of I/O (read and write)
 the SSL session is automatically renegotiated. B<num> must be at
 least 512 bytes.
 
-BIO_set_ssl_renegotiate_timeout() sets the renegotiate timeout to
-B<seconds>. When the renegotiate timeout elapses the session is
-automatically renegotiated.
+BIO_set_ssl_renegotiate_timeout() sets the renegotiate timeout of SSL BIO B<b>
+to B<seconds>.
+When the renegotiate timeout elapses the session is automatically renegotiated.
 
 BIO_get_num_renegotiates() returns the total number of session
-renegotiations due to I/O or timeout.
+renegotiations due to I/O or timeout of SSL BIO B<b>.
 
 BIO_new_ssl() allocates an SSL BIO using SSL_CTX B<ctx> and using
 client mode if B<client> is non zero.
@@ -82,8 +82,7 @@ BIO_new_ssl_connect() creates a new BIO chain consisting of an
 SSL BIO (using B<ctx>) followed by a connect BIO.
 
 BIO_new_buffer_ssl_connect() creates a new BIO chain consisting
-of a buffering BIO, an SSL BIO (using B<ctx>) and a connect
-BIO.
+of a buffering BIO, an SSL BIO (using B<ctx>), and a connect BIO.
 
 BIO_ssl_copy_session_id() copies an SSL session id between
 BIO chains B<from> and B<to>. It does this by locating the
@@ -96,7 +95,7 @@ chain and calling SSL_shutdown() on its internal SSL
 pointer.
 
 BIO_do_handshake() attempts to complete an SSL handshake on the
--supplied BIO and establish the SSL connection.
+supplied BIO and establish the SSL connection.
 For non-SSL BIOs the connection is done typically at TCP level.
 If domain name resolution yields multiple IP addresses all of them are tried
 after connect() failures.

--- a/ssl/bio_ssl.c
+++ b/ssl/bio_ssl.c
@@ -76,13 +76,12 @@ static int ssl_free(BIO *a)
     if (a == NULL)
         return 0;
     bs = BIO_get_data(a);
-    if (bs->ssl != NULL)
-        SSL_shutdown(bs->ssl);
     if (BIO_get_shutdown(a)) {
+        if (bs->ssl != NULL)
+            SSL_shutdown(bs->ssl);
         if (BIO_get_init(a))
             SSL_free(bs->ssl);
-        /* Clear all flags */
-        BIO_clear_flags(a, ~0);
+        BIO_clear_flags(a, ~0); /* Clear all flags */
         BIO_set_init(a, 0);
     }
     OPENSSL_free(bs);


### PR DESCRIPTION
I recently integrated the CMP client (alternatively to EST) in a BRSKI implementation in a way that an existing TLS connection  is reused for the HTTP(S) transfer of CMP messages.
To this end, I embedded the SSL connection represented by the variable `SSL *ssl` as follows:
```
     BIO *sbio = BIO_new(BIO_f_ssl());
     if (sbio == NULL || BIO_set_ssl(sbio, ssl,  BIO_NOCLOSE) <= 0
         ...
```
After the CMP exchange is done, I call `BIO_free(sbio)`
Yet after doing so, the `ssl` connection is not more usable for a further BRSKI message exchange,
and it turns out this is because `ssl_free()` and thus `BIO_free()` does not respect `BIO_NOCLOSE`.
(BTW, looking at the overall code base, `BIO_NOCLOSE` seems to have little influence also on other BIOs).

The present PR fixes this bug.