### PR TITLE
doc/man3/SSL_set_fd.pod: add note about Windows compiler warning

### DIFF
--- a/doc/man3/SSL_set_fd.pod
+++ b/doc/man3/SSL_set_fd.pod
@@ -45,6 +45,17 @@ The operation succeeded.
 
 =back
 
+=head1 NOTES
+
+On Windows, a socket handle is a 64-bit data type (UINT_PTR), which leads to a
+compiler warning (conversion from 'SOCKET' to 'int', possible loss of data) when
+passing the socket handle to SSL_set_*fd(). For the time being, this warning can
+safely be ignored, because although the Microsoft documentation claims that the
+upper limit is INVALID_SOCKET-1 (2^64 - 2), in practice the current socket()
+implementation returns an index into the kernel handle table, the size of which
+is limited to 2^24.
+
+
 =head1 SEE ALSO
 
 L<SSL_get_fd(3)>, L<SSL_set_bio(3)>,


### PR DESCRIPTION
According to an old stackoverflow thread [1], citing an even older comment by
Andy Polyakov (1875e6db29, Pull up Win64 support from 0.9.8., 2005-07-05),
a cast of 'SOCKET' (UINT_PTR) to 'int' does not create a problem, because although
the documentation [2] claims that the upper limit is INVALID_SOCKET-1 (2^64 - 2),
in practice the socket() implementation on Windows returns an index into the kernel
handle table, the size of which is limited to 2^24 [3].

Add this note to the manual page to avoid unnecessary roundtrips to StackOverflow.

[1] https://stackoverflow.com/questions/1953639/is-it-safe-to-cast-socket-to-int-under-win64
[2] https://docs.microsoft.com/en-us/windows/win32/winsock/socket-data-type-2
[3] https://docs.microsoft.com/en-us/windows/win32/sysinfo/kernel-objects


_This patch applies cleanly to 3.0 and 1.1.1 as well, so I will cherry-pick it if there are no objections._

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
