### PR TITLE
test: Fix memory leak of asynctest

### DIFF
--- a/test/asynctest.c
+++ b/test/asynctest.c
@@ -409,6 +409,7 @@ static int test_ASYNC_start_job_ex(void)
     ret = 1;
  err:
     ASYNC_WAIT_CTX_free(waitctx);
+    ASYNC_cleanup_thread();
     OSSL_LIB_CTX_free(libctx);
     return ret;
 }


### PR DESCRIPTION
ASYNC_init_thread() will be called automatically by ASYNC_start_job(),
so ASYNC_cleanup_thread() must be called at last, otherwise it will
cause memory leak.

Signed-off-by: Tianjia Zhang <tianjia.zhang@linux.alibaba.com>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
