### PR TITLE
Initialise cipher/digest deprecation structures better

### DIFF
--- a/apps/openssl.c
+++ b/apps/openssl.c
@@ -395,6 +395,7 @@ static int do_cmd(LHASH_OF(FUNCTION) *prog, int argc, char *argv[])
 
     if (argc <= 0 || argv[0] == NULL)
         return 0;
+    memset(&f, 0, sizeof(f));
     f.name = argv[0];
     fp = lh_FUNCTION_retrieve(prog, &f);
     if (fp == NULL) {


### PR DESCRIPTION
This avoids a crash in e.g. `openssl chacha20` as reported by
Steffen Nurpmeso on openssl-users.

Resolves: #16713
