### PR TITLE
Ensure we use the same provider as keymgmt where appropriate

### DIFF
--- a/crypto/core_algorithm.c
+++ b/crypto/core_algorithm.c
@@ -105,10 +105,23 @@ void ossl_algorithm_do_all(OSSL_LIB_CTX *libctx, int operation_id,
     cbdata.post = post;
     cbdata.data = data;
 
-    if (provider == NULL)
+    if (provider == NULL) {
         ossl_provider_doall_activated(libctx, algorithm_do_this, &cbdata);
-    else
+    } else {
+        OSSL_LIB_CTX *libctx2 = ossl_provider_libctx(provider);
+
+        /*
+         * If a provider is given, its library context MUST match the library
+         * context we're passed.  If this turns out not to be true, there is
+         * a programming error in the functions up the call stack.
+         */
+        if (!ossl_assert(ossl_lib_ctx_get_concrete(libctx)
+                         == ossl_lib_ctx_get_concrete(libctx2)))
+            return;
+
+        cbdata.libctx = libctx2;
         algorithm_do_this(provider, &cbdata);
+    }
 }
 
 char *ossl_algorithm_get1_first_name(const OSSL_ALGORITHM *algo)

--- a/crypto/core_fetch.c
+++ b/crypto/core_fetch.c
@@ -105,7 +105,7 @@ static void ossl_method_construct_this(OSSL_PROVIDER *provider,
 }
 
 void *ossl_method_construct(OSSL_LIB_CTX *libctx, int operation_id,
-                            int force_store,
+                            OSSL_PROVIDER *prov, int force_store,
                             OSSL_METHOD_CONSTRUCT_METHOD *mcm, void *mcm_data)
 {
     void *method = NULL;
@@ -117,7 +117,7 @@ void *ossl_method_construct(OSSL_LIB_CTX *libctx, int operation_id,
         cbdata.force_store = force_store;
         cbdata.mcm = mcm;
         cbdata.mcm_data = mcm_data;
-        ossl_algorithm_do_all(libctx, operation_id, NULL,
+        ossl_algorithm_do_all(libctx, operation_id, prov,
                               ossl_method_construct_precondition,
                               ossl_method_construct_this,
                               ossl_method_construct_postcondition,

--- a/crypto/encode_decode/decoder_meth.c
+++ b/crypto/encode_decode/decoder_meth.c
@@ -380,7 +380,7 @@ inner_ossl_decoder_fetch(struct decoder_data_st *methdata, int id,
         methdata->propquery = properties;
         methdata->flag_construct_error_occurred = 0;
         if ((method = ossl_method_construct(methdata->libctx, OSSL_OP_DECODER,
-                                            0 /* !force_cache */,
+                                            NULL, 0 /* !force_cache */,
                                             &mcm, methdata)) != NULL) {
             /*
              * If construction did create a method for us, we know that

--- a/crypto/encode_decode/encoder_meth.c
+++ b/crypto/encode_decode/encoder_meth.c
@@ -390,7 +390,7 @@ inner_ossl_encoder_fetch(struct encoder_data_st *methdata, int id,
         methdata->propquery = properties;
         methdata->flag_construct_error_occurred = 0;
         if ((method = ossl_method_construct(methdata->libctx, OSSL_OP_ENCODER,
-                                            0 /* !force_cache */,
+                                            NULL, 0 /* !force_cache */,
                                             &mcm, methdata)) != NULL) {
             /*
              * If construction did create a method for us, we know that

--- a/crypto/evp/evp_fetch.c
+++ b/crypto/evp/evp_fetch.c
@@ -379,7 +379,7 @@ void *evp_generic_fetch(OSSL_LIB_CTX *libctx, int operation_id,
  * already known names, i.e. it refuses to work if no name_id can be found
  * (it's considered an internal programming error).
  * This is meant to be used when one method needs to fetch an associated
- * other method.
+ * method.
  */
 void *evp_generic_fetch_by_number(OSSL_LIB_CTX *libctx, int operation_id,
                                   int name_id, const char *properties,
@@ -405,7 +405,7 @@ void *evp_generic_fetch_by_number(OSSL_LIB_CTX *libctx, int operation_id,
  * evp_generic_fetch_from_prov() is special, and only returns methods from
  * the given provider.
  * This is meant to be used when one method needs to fetch an associated
- * other method.
+ * method.
  */
 void *evp_generic_fetch_from_prov(OSSL_PROVIDER *prov, int operation_id,
                                   const char *name, const char *properties,

--- a/crypto/evp/evp_fetch.c
+++ b/crypto/evp/evp_fetch.c
@@ -234,7 +234,8 @@ static void destruct_evp_method(void *method, void *data)
 }
 
 static void *
-inner_evp_generic_fetch(struct evp_method_data_st *methdata, int operation_id,
+inner_evp_generic_fetch(struct evp_method_data_st *methdata,
+                        OSSL_PROVIDER *prov, int operation_id,
                         int name_id, const char *name,
                         const char *properties,
                         void *(*new_method)(int name_id,
@@ -315,7 +316,7 @@ inner_evp_generic_fetch(struct evp_method_data_st *methdata, int operation_id,
         methdata->destruct_method = free_method;
         methdata->flag_construct_error_occurred = 0;
         if ((method = ossl_method_construct(methdata->libctx, operation_id,
-                                            0 /* !force_cache */,
+                                            prov, 0 /* !force_cache */,
                                             &mcm, methdata)) != NULL) {
             /*
              * If construction did create a method for us, we know that
@@ -366,8 +367,8 @@ void *evp_generic_fetch(OSSL_LIB_CTX *libctx, int operation_id,
 
     methdata.libctx = libctx;
     methdata.tmp_store = NULL;
-    method = inner_evp_generic_fetch(&methdata,
-                                     operation_id, 0, name, properties,
+    method = inner_evp_generic_fetch(&methdata, NULL, operation_id,
+                                     0, name, properties,
                                      new_method, up_ref_method, free_method);
     dealloc_tmp_evp_method_store(methdata.tmp_store);
     return method;
@@ -393,8 +394,8 @@ void *evp_generic_fetch_by_number(OSSL_LIB_CTX *libctx, int operation_id,
 
     methdata.libctx = libctx;
     methdata.tmp_store = NULL;
-    method = inner_evp_generic_fetch(&methdata,
-                                     operation_id, name_id, NULL, properties,
+    method = inner_evp_generic_fetch(&methdata, NULL, operation_id,
+                                     name_id, NULL, properties,
                                      new_method, up_ref_method, free_method);
     dealloc_tmp_evp_method_store(methdata.tmp_store);
     return method;
@@ -588,7 +589,7 @@ void evp_generic_do_all(OSSL_LIB_CTX *libctx, int operation_id,
 
     methdata.libctx = libctx;
     methdata.tmp_store = NULL;
-    (void)inner_evp_generic_fetch(&methdata, operation_id, 0, NULL, NULL,
+    (void)inner_evp_generic_fetch(&methdata, NULL, operation_id, 0, NULL, NULL,
                                   new_method, up_ref_method, free_method);
 
     data.operation_id = operation_id;

--- a/crypto/evp/evp_fetch.c
+++ b/crypto/evp/evp_fetch.c
@@ -401,6 +401,32 @@ void *evp_generic_fetch_by_number(OSSL_LIB_CTX *libctx, int operation_id,
     return method;
 }
 
+/*
+ * evp_generic_fetch_from_prov() is special, and only returns methods from
+ * the given provider.
+ * This is meant to be used when one method needs to fetch an associated
+ * other method.
+ */
+void *evp_generic_fetch_from_prov(OSSL_PROVIDER *prov, int operation_id,
+                                  const char *name, const char *properties,
+                                  void *(*new_method)(int name_id,
+                                                      const OSSL_ALGORITHM *algodef,
+                                                      OSSL_PROVIDER *prov),
+                                  int (*up_ref_method)(void *),
+                                  void (*free_method)(void *))
+{
+    struct evp_method_data_st methdata;
+    void *method;
+
+    methdata.libctx = ossl_provider_libctx(prov);
+    methdata.tmp_store = NULL;
+    method = inner_evp_generic_fetch(&methdata, prov, operation_id,
+                                     0, name, properties,
+                                     new_method, up_ref_method, free_method);
+    dealloc_tmp_evp_method_store(methdata.tmp_store);
+    return method;
+}
+
 int evp_method_store_flush(OSSL_LIB_CTX *libctx)
 {
     OSSL_METHOD_STORE *store = get_evp_method_store(libctx);

--- a/crypto/evp/evp_local.h
+++ b/crypto/evp/evp_local.h
@@ -276,6 +276,13 @@ void *evp_generic_fetch_by_number(OSSL_LIB_CTX *ctx, int operation_id,
                                                       OSSL_PROVIDER *prov),
                                   int (*up_ref_method)(void *),
                                   void (*free_method)(void *));
+void *evp_generic_fetch_from_prov(OSSL_PROVIDER *prov, int operation_id,
+                                  const char *name, const char *properties,
+                                  void *(*new_method)(int name_id,
+                                                      const OSSL_ALGORITHM *algodef,
+                                                      OSSL_PROVIDER *prov),
+                                  int (*up_ref_method)(void *),
+                                  void (*free_method)(void *));
 void evp_generic_do_all_prefetched(OSSL_LIB_CTX *libctx, int operation_id,
                                    void (*user_fn)(void *method, void *arg),
                                    void *user_arg);

--- a/crypto/evp/evp_local.h
+++ b/crypto/evp/evp_local.h
@@ -298,6 +298,18 @@ void evp_generic_do_all(OSSL_LIB_CTX *libctx, int operation_id,
 /* Internal fetchers for method types that are to be combined with others */
 EVP_KEYMGMT *evp_keymgmt_fetch_by_number(OSSL_LIB_CTX *ctx, int name_id,
                                          const char *properties);
+EVP_SIGNATURE *evp_signature_fetch_from_prov(OSSL_PROVIDER *prov,
+                                             const char *name,
+                                             const char *properties);
+EVP_ASYM_CIPHER *evp_asym_cipher_fetch_from_prov(OSSL_PROVIDER *prov,
+                                                 const char *name,
+                                                 const char *properties);
+EVP_KEYEXCH *evp_keyexch_fetch_from_prov(OSSL_PROVIDER *prov,
+                                         const char *name,
+                                         const char *properties);
+EVP_KEM *evp_kem_fetch_from_prov(OSSL_PROVIDER *prov,
+                                       const char *name,
+                                       const char *properties);
 
 /* Internal structure constructors for fetched methods */
 EVP_MD *evp_md_new(void);

--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -1085,18 +1085,16 @@ int EVP_PKEY_can_sign(const EVP_PKEY *pkey)
         }
     } else {
         const OSSL_PROVIDER *prov = EVP_KEYMGMT_get0_provider(pkey->keymgmt);
-        OSSL_LIB_CTX *libctx = ossl_provider_libctx(prov);
         const char *supported_sig =
             pkey->keymgmt->query_operation_name != NULL
             ? pkey->keymgmt->query_operation_name(OSSL_OP_SIGNATURE)
             : EVP_KEYMGMT_get0_name(pkey->keymgmt);
         EVP_SIGNATURE *signature = NULL;
 
-        signature = EVP_SIGNATURE_fetch(libctx, supported_sig, NULL);
-        if (signature != NULL) {
-            EVP_SIGNATURE_free(signature);
+        signature = evp_signature_fetch_from_prov((OSSL_PROVIDER *)prov,
+                                                  supported_sig, NULL);
+        if (signature != NULL)
             return 1;
-        }
     }
     return 0;
 }

--- a/crypto/store/store_meth.c
+++ b/crypto/store/store_meth.c
@@ -322,7 +322,7 @@ inner_loader_fetch(struct loader_data_st *methdata, int id,
         methdata->propquery = properties;
         methdata->flag_construct_error_occurred = 0;
         if ((method = ossl_method_construct(methdata->libctx, OSSL_OP_STORE,
-                                            0 /* !force_cache */,
+                                            NULL, 0 /* !force_cache */,
                                             &mcm, methdata)) != NULL) {
             /*
              * If construction did create a method for us, we know that there

--- a/doc/internal/man3/evp_generic_fetch.pod
+++ b/doc/internal/man3/evp_generic_fetch.pod
@@ -29,6 +29,15 @@ evp_generic_fetch, evp_generic_fetch_by_number
                                    void *method_data,
                                    int (*up_ref_method)(void *),
                                    void (*free_method)(void *));
+ void *evp_generic_fetch_from_prov(OSSL_PROVIDER *prov, int operation_id,
+                                   int name_id, const char *properties,
+                                   void *(*new_method)(int name_id,
+                                                       const OSSL_DISPATCH *fns,
+                                                       OSSL_PROVIDER *prov,
+                                                       void *method_data),
+                                   void *method_data,
+                                   int (*up_ref_method)(void *),
+                                   void (*free_method)(void *));
 
 =head1 DESCRIPTION
 
@@ -44,6 +53,11 @@ is considered a programming error.
 This is meant to be used when one method needs to fetch an associated
 other method, and is typically called from inside the given function
 I<new_method>.
+
+evp_generic_fetch_from_prov() does the same thing as evp_generic_fetch(),
+but limits the search of methods to the provider given with I<prov>.
+This is meant to be used when one method needs to fetch an associated
+other method in the same provider.
 
 The three functions I<new_method>, I<up_ref_method>, and
 I<free_method> are supposed to:

--- a/doc/internal/man3/evp_generic_fetch.pod
+++ b/doc/internal/man3/evp_generic_fetch.pod
@@ -51,13 +51,13 @@ but takes a numeric I<name_id> instead of a name.
 I<name_id> must always be nonzero; as a matter of fact, it being zero
 is considered a programming error.
 This is meant to be used when one method needs to fetch an associated
-other method, and is typically called from inside the given function
+method, and is typically called from inside the given function
 I<new_method>.
 
 evp_generic_fetch_from_prov() does the same thing as evp_generic_fetch(),
 but limits the search of methods to the provider given with I<prov>.
 This is meant to be used when one method needs to fetch an associated
-other method in the same provider.
+method in the same provider.
 
 The three functions I<new_method>, I<up_ref_method>, and
 I<free_method> are supposed to:

--- a/doc/internal/man3/evp_generic_fetch.pod
+++ b/doc/internal/man3/evp_generic_fetch.pod
@@ -2,7 +2,7 @@
 
 =head1 NAME
 
-evp_generic_fetch, evp_generic_fetch_by_number
+evp_generic_fetch, evp_generic_fetch_by_number, evp_generic_fetch_from_prov
 - generic algorithm fetchers and method creators for EVP
 
 =head1 SYNOPSIS

--- a/doc/internal/man3/ossl_method_construct.pod
+++ b/doc/internal/man3/ossl_method_construct.pod
@@ -27,7 +27,7 @@ OSSL_METHOD_CONSTRUCT_METHOD, ossl_method_construct
  typedef struct ossl_method_construct_method OSSL_METHOD_CONSTRUCT_METHOD;
 
  void *ossl_method_construct(OSSL_LIB_CTX *ctx, int operation_id,
-                             int force_cache,
+                             OSSL_PROVIDER *prov, int force_cache,
                              OSSL_METHOD_CONSTRUCT_METHOD *mcm, void *mcm_data);
 
 
@@ -57,6 +57,9 @@ providers for a dispatch table given an I<operation_id>, and then
 calling the appropriate functions given by the subsystem specific
 method creator through I<mcm> and the data in I<mcm_data> (which is
 passed by ossl_method_construct()).
+If I<prov> is not NULL, only that provider is considered, which is
+useful in the case a method must be found in that particular
+provider.
 
 This function assumes that the subsystem method creator implements
 reference counting and acts accordingly (i.e. it will call the

--- a/include/internal/core.h
+++ b/include/internal/core.h
@@ -43,7 +43,7 @@ typedef struct ossl_method_construct_method_st {
 } OSSL_METHOD_CONSTRUCT_METHOD;
 
 void *ossl_method_construct(OSSL_LIB_CTX *ctx, int operation_id,
-                            int force_cache,
+                            OSSL_PROVIDER *prov, int force_cache,
                             OSSL_METHOD_CONSTRUCT_METHOD *mcm, void *mcm_data);
 
 void ossl_algorithm_do_all(OSSL_LIB_CTX *libctx, int operation_id,


### PR DESCRIPTION
To ensure that we get a signature, keyexch, etc method from the same
provider as the keymgmt of the passed pkey, we add functionality to
fetch from a specific provider instead of all available providers.

This is much safer than to re-use the same properties and hope for the
best.

Properties are still passed, in case the provider implements the same
algorithm multiple times with different properties.

Fixes #16614

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
