### PR TITLE
Tentative fix for the async engine

### DIFF
--- a/engines/e_dasync.c
+++ b/engines/e_dasync.c
@@ -211,7 +211,8 @@ static int bind_dasync(ENGINE *e)
     /* Setup RSA */
     ;
     if ((dasync_rsa_orig = EVP_PKEY_meth_find(EVP_PKEY_RSA)) == NULL
-        || (dasync_rsa = EVP_PKEY_meth_new(EVP_PKEY_RSA, 0)) == NULL)
+        || (dasync_rsa = EVP_PKEY_meth_new(EVP_PKEY_RSA,
+                                           EVP_PKEY_FLAG_AUTOARGLEN)) == NULL)
         return 0;
     EVP_PKEY_meth_set_init(dasync_rsa, dasync_rsa_init);
     EVP_PKEY_meth_set_cleanup(dasync_rsa, dasync_rsa_cleanup);
@@ -312,7 +313,10 @@ static int bind_dasync(ENGINE *e)
 
 static void destroy_pkey(void)
 {
-    EVP_PKEY_meth_free(dasync_rsa);
+    /*
+     * We don't actually need to free the dasync_rsa method since this is
+     * automatically freed for us by libcrypto.
+     */
     dasync_rsa_orig = NULL;
     dasync_rsa = NULL;
 }
@@ -829,7 +833,7 @@ static int dasync_rsa_paramgen_init(EVP_PKEY_CTX *ctx)
 
     if (pparamgen_init == NULL)
         EVP_PKEY_meth_get_paramgen(dasync_rsa_orig, &pparamgen_init, NULL);
-    return pparamgen_init(ctx);
+    return pparamgen_init != NULL ? pparamgen_init(ctx) : 1;
 }
 
 static int dasync_rsa_paramgen(EVP_PKEY_CTX *ctx, EVP_PKEY *pkey)
@@ -838,7 +842,7 @@ static int dasync_rsa_paramgen(EVP_PKEY_CTX *ctx, EVP_PKEY *pkey)
 
     if (pparamgen == NULL)
         EVP_PKEY_meth_get_paramgen(dasync_rsa_orig, NULL, &pparamgen);
-    return pparamgen(ctx, pkey);
+    return pparamgen != NULL ? pparamgen(ctx, pkey) : 1;
 }
 
 static int dasync_rsa_keygen_init(EVP_PKEY_CTX *ctx)
@@ -847,7 +851,7 @@ static int dasync_rsa_keygen_init(EVP_PKEY_CTX *ctx)
 
     if (pkeygen_init == NULL)
         EVP_PKEY_meth_get_keygen(dasync_rsa_orig, &pkeygen_init, NULL);
-    return pkeygen_init(ctx);
+    return pkeygen_init != NULL ? pkeygen_init(ctx) : 1;
 }
 
 static int dasync_rsa_keygen(EVP_PKEY_CTX *ctx, EVP_PKEY *pkey)
@@ -865,7 +869,7 @@ static int dasync_rsa_encrypt_init(EVP_PKEY_CTX *ctx)
 
     if (pencrypt_init == NULL)
         EVP_PKEY_meth_get_encrypt(dasync_rsa_orig, &pencrypt_init, NULL);
-    return pencrypt_init(ctx);
+    return pencrypt_init != NULL ? pencrypt_init(ctx) : 1;
 }
 
 static int dasync_rsa_encrypt(EVP_PKEY_CTX *ctx, unsigned char *out,
@@ -887,7 +891,7 @@ static int dasync_rsa_decrypt_init(EVP_PKEY_CTX *ctx)
 
     if (pdecrypt_init == NULL)
         EVP_PKEY_meth_get_decrypt(dasync_rsa_orig, &pdecrypt_init, NULL);
-    return pdecrypt_init(ctx);
+    return pdecrypt_init != NULL ? pdecrypt_init(ctx) : 1;
 }
 
 static int dasync_rsa_decrypt(EVP_PKEY_CTX *ctx, unsigned char *out,


### PR DESCRIPTION
Related to #16724

It fixes the crashes, but I think it's incorrect fix

As a result of the proposed changes, s_server fails with output
```
Using default temp DH parameters
ACCEPT
ERROR
C0F18AF7FF7F0000:error:02000090:rsa routines:pkey_rsa_ctrl:illegal or unsupported padding mode:crypto/rsa/rsa_pmeth.c:460:
C0F18AF7FF7F0000:error:03000093:digital envelope routines:evp_pkey_ctx_ctrl_int:command not supported:crypto/evp/pmeth_lib.c:1308:
C0F18AF7FF7F0000:error:0A000093:SSL routines:tls_process_cke_rsa:decryption failed:ssl/statem/statem_srvr.c:2911:
```

BTW, the problem is we've lost the pattern 'call `EVP_PKEY_encrypt` with NULL out ptr - get enclen - allocate memory and call `EVP_PKEY_encrypt` again':
https://github.com/openssl/openssl/blob/19e277dd19f2897f6a7b7eb236abe46655e575bf/ssl/statem/statem_clnt.c#L2860-L2870

If we don't change `pkey_rsa_encrypt` and just fix the dasync engine, we get a SEGFAULT with the following stack trace:
```
bn2binpad (endianess=big, tolen=256, to=0xff <error: Cannot access memory at address 0xff>, a=0x5b8658) at crypto/bn/bn_lib.c:522
522	            *--to = val;
(gdb) bt
#0  bn2binpad (endianess=big, tolen=256, to=0xff <error: Cannot access memory at address 0xff>, a=0x5b8658) at crypto/bn/bn_lib.c:522
#1  BN_bn2binpad (a=a@entry=0x5b8658, to=to@entry=0x0, tolen=tolen@entry=256) at crypto/bn/bn_lib.c:535
#2  0x00007ffff7d19ad3 in rsa_ossl_public_encrypt (flen=48, from=0x5b7fc0 "\003\001\247\337\335\027\260Ǿ\200\370\066\354.\t\346\322{\271\264\251\341S\272Mh\346&ے\273\316Ԋ\034T\024\260P\270\223[\372-\254\272̑", to=0x0, rsa=0x58e330, 
    padding=<optimized out>) at crypto/rsa/rsa_ossl.c:154
#3  0x00007ffff7d1c3df in pkey_rsa_encrypt (ctx=0x5b84f0, out=0x0, outlen=0x7fffffffd4e8, 
    in=0x5b7fc0 "\003\001\247\337\335\027\260Ǿ\200\370\066\354.\t\346\322{\271\264\251\341S\272Mh\346&ے\273\316Ԋ\034T\024\260P\270\223[\372-\254\272̑", inlen=48) at crypto/rsa/rsa_pmeth.c:337
#4  0x00007ffff7f8aac1 in tls_construct_cke_rsa (pkt=0x7fffffffd550, s=0x59bda0) at ssl/statem/statem_clnt.c:2862
#5  tls_construct_client_key_exchange (s=0x59bda0, pkt=0x7fffffffd550) at ssl/statem/statem_clnt.c:3287
#6  0x00007ffff7f85a35 in write_state_machine (s=0x59bda0) at ssl/statem/statem.c:852
#7  state_machine (s=0x59bda0, server=0) at ssl/statem/statem.c:451
#8  0x00007ffff7f73b64 in ssl3_write_bytes (s=0x59bda0, type=23, buf_=0x4e6270, len=0, written=0x7fffffffd768) at ssl/record/rec_layer_s3.c:403
#9  0x00007ffff7f55465 in SSL_write (s=s@entry=0x59bda0, buf=buf@entry=0x4e6270, num=num@entry=0) at ssl/ssl_lib.c:2123
#10 0x0000000000457b8c in s_client_main (argc=<optimized out>, argv=<optimized out>) at apps/s_client.c:2793
#11 0x0000000000445086 in do_cmd (prog=prog@entry=0x4e4390, argc=argc@entry=8, argv=argv@entry=0x7fffffffde40) at apps/openssl.c:415
#12 0x0000000000422507 in main (argc=8, argv=0x7fffffffde40) at apps/openssl.c:295
```
