### PR TITLE
Fix Dynamic engine loading

### DIFF
--- a/crypto/engine/eng_list.c
+++ b/crypto/engine/eng_list.c
@@ -369,7 +369,7 @@ ENGINE *ENGINE_by_id(const char *id)
         ENGINEerr(ENGINE_F_ENGINE_BY_ID, ERR_R_PASSED_NULL_PARAMETER);
         return NULL;
     }
-    ENGINE_load_builtin_engines();
+    OPENSSL_init_crypto(OPENSSL_INIT_ENGINE_DYNAMIC, NULL);
 
     if (!RUN_ONCE(&engine_lock_init, do_engine_lock_init)) {
         ENGINEerr(ENGINE_F_ENGINE_BY_ID, ERR_R_MALLOC_FAILURE);

--- a/crypto/engine/eng_list.c
+++ b/crypto/engine/eng_list.c
@@ -369,6 +369,8 @@ ENGINE *ENGINE_by_id(const char *id)
         ENGINEerr(ENGINE_F_ENGINE_BY_ID, ERR_R_PASSED_NULL_PARAMETER);
         return NULL;
     }
+    ENGINE_load_builtin_engines();
+
     if (!RUN_ONCE(&engine_lock_init, do_engine_lock_init)) {
         ENGINEerr(ENGINE_F_ENGINE_BY_ID, ERR_R_MALLOC_FAILURE);
         return NULL;


### PR DESCRIPTION
so that the call to ENGINE_load_builtin_engines() is performed.

Backport of commit a5c864ce (PR #11543) to 1.1.1. See also #16735

Fixes #11510


