### PR TITLE
[WIP] Test with various crypto engines for 1.1.1

### DIFF
--- a/test/drbgtest.c
+++ b/test/drbgtest.c
@@ -705,7 +705,7 @@ static int test_drbg_reseed_after_fork(RAND_DRBG *master,
     unhook_drbg(master);
     unhook_drbg(public);
     unhook_drbg(private);
-    exit(status);
+    _exit(status);
 }
 #endif
 


### PR DESCRIPTION
Enable these crypto engines always when available:
    
    - afalg
    - padlock
    - dasync
    
    Where dasync will have lowest precedence.
