### PR TITLE
Fix heading in random generator man7 page

### DIFF
--- a/doc/man7/RAND.pod
+++ b/doc/man7/RAND.pod
@@ -54,7 +54,7 @@ only in exceptional cases and is not recommended, unless you have a profound
 knowledge of cryptographic principles and understand the implications of your
 changes.
 
-=head1 DEAFULT SETUP
+=head1 DEFAULT SETUP
 
 The default OpenSSL RAND method is based on the EVP_RAND deterministic random
 bit generator (DRBG) classes.


### PR DESCRIPTION
This patch fixes the spelling of "DEFAULT" in a `head1` within the `man7` page `RAND.pod`.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated

