### PR TITLE
permitting no/empty digest in core_obj_add_sigid

### DIFF
--- a/crypto/objects/obj_xref.c
+++ b/crypto/objects/obj_xref.c
@@ -141,7 +141,7 @@ int OBJ_add_sigid(int signid, int dig_id, int pkey_id)
     nid_triple *ntr;
     int dnid = NID_undef, pnid = NID_undef, ret = 0;
 
-    if (signid == NID_undef || dig_id == NID_undef || pkey_id == NID_undef)
+    if (signid == NID_undef || pkey_id == NID_undef)
         return 0;
 
     if (!obj_sig_init())

--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -1933,7 +1933,7 @@ static int core_obj_add_sigid(const OSSL_CORE_HANDLE *prov,
                               const char *pkey_name)
 {
     int sign_nid = OBJ_txt2nid(sign_name);
-    int digest_nid = OBJ_txt2nid(digest_name);
+    int digest_nid = digest_name?OBJ_txt2nid(digest_name):NID_undef;
     int pkey_nid = OBJ_txt2nid(pkey_name);
 
     if (sign_nid == NID_undef)

--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -1933,8 +1933,12 @@ static int core_obj_add_sigid(const OSSL_CORE_HANDLE *prov,
                               const char *pkey_name)
 {
     int sign_nid = OBJ_txt2nid(sign_name);
-    int digest_nid = digest_name?OBJ_txt2nid(digest_name):NID_undef;
+    int digest_nid = NID_undef;
     int pkey_nid = OBJ_txt2nid(pkey_name);
+
+    if (digest_name != NULL && digest_name[0] != '\0'
+        && (digest_nid = OBJ_txt2nid(digest_name)) == NID_undef)
+            return 0;
 
     if (sign_nid == NID_undef)
         return 0;

--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -1946,8 +1946,7 @@ static int core_obj_add_sigid(const OSSL_CORE_HANDLE *prov,
     if (OBJ_find_sigid_algs(sign_nid, NULL, NULL))
         return 1;
 
-    if (digest_nid == NID_undef
-            || pkey_nid == NID_undef)
+    if (pkey_nid == NID_undef)
         return 0;
 
     return OBJ_add_sigid(sign_nid, digest_nid, pkey_nid);

--- a/doc/man3/OBJ_nid2obj.pod
+++ b/doc/man3/OBJ_nid2obj.pod
@@ -99,7 +99,8 @@ given NID with two other NIDs - one representing the underlying signature
 algorithm and the other representing a digest algorithm to be used in
 conjunction with it. I<signid> represents the NID for the composite "Signature
 Algorithm", I<dig_id> is the NID for the digest algorithm and I<pkey_id> is the
-NID for the underlying signature algorithm.
+NID for the underlying signature algorithm. As there are signature algorithms
+that do not require a digest, NID_undef is a valid I<dig_id>.
 
 OBJ_cleanup() releases any resources allocated by creating new objects.
 

--- a/doc/man7/provider-base.pod
+++ b/doc/man7/provider-base.pod
@@ -280,9 +280,9 @@ function L<OBJ_add_sigid(3)>, except that the objects are identified by name
 rather than a numeric NID. Any name (OID, short name or long name) can be used
 to identify the object. It will treat as success the case where the composite
 signature algorithm already exists (even if registered against a different
-underlying signature or digest algorithm). For I<digest_name>, an empty string
-is permissible for signature algorithms that do not need a digest to operate
-correctly. The function returns 1 on success or 0 on failure.
+underlying signature or digest algorithm). For I<digest_name>, NULL or an
+empty string is permissible for signature algorithms that do not need a digest
+to operate correctly. The function returns 1 on success or 0 on failure.
 
 CRYPTO_malloc(), CRYPTO_zalloc(), CRYPTO_memdup(), CRYPTO_strdup(),
 CRYPTO_strndup(), CRYPTO_free(), CRYPTO_clear_free(),

--- a/doc/man7/provider-base.pod
+++ b/doc/man7/provider-base.pod
@@ -280,8 +280,9 @@ function L<OBJ_add_sigid(3)>, except that the objects are identified by name
 rather than a numeric NID. Any name (OID, short name or long name) can be used
 to identify the object. It will treat as success the case where the composite
 signature algorithm already exists (even if registered against a different
-underlying signature or digest algorithm). It returns 1 on success or 0 on
-failure.
+underlying signature or digest algorithm). For I<digest_name>, an empty string
+is permissible for signature algorithms that do not need a digest to operate
+correctly. The function returns 1 on success or 0 on failure.
 
 CRYPTO_malloc(), CRYPTO_zalloc(), CRYPTO_memdup(), CRYPTO_strdup(),
 CRYPTO_strndup(), CRYPTO_free(), CRYPTO_clear_free(),

--- a/test/upcallstest.c
+++ b/test/upcallstest.c
@@ -68,12 +68,12 @@ static int obj_provider_init(const OSSL_CORE_HANDLE *handle,
     if (!c_obj_add_sigid(handle, SIGALG_OID, DIGEST_SN, SIG_LN))
         return 0;
 
-    // additional tests checking empty digest algs are accepted, too
+    /* additional tests checking empty digest algs are accepted, too */
     if (!c_obj_add_sigid(handle, SIGALG_OID, "", SIG_LN))
         return 0;
     if (!c_obj_add_sigid(handle, SIGALG_OID, NULL, SIG_LN))
         return 0;
-    // checking wrong digest alg name is rejected:
+    /* checking wrong digest alg name is rejected: */
     if (c_obj_add_sigid(handle, SIGALG_OID, "NonsenseAlg", SIG_LN))
         return 0;
 

--- a/test/upcallstest.c
+++ b/test/upcallstest.c
@@ -68,6 +68,15 @@ static int obj_provider_init(const OSSL_CORE_HANDLE *handle,
     if (!c_obj_add_sigid(handle, SIGALG_OID, DIGEST_SN, SIG_LN))
         return 0;
 
+    // additional tests checking empty digest algs are accepted, too
+    if (!c_obj_add_sigid(handle, SIGALG_OID, "", SIG_LN))
+        return 0;
+    if (!c_obj_add_sigid(handle, SIGALG_OID, NULL, SIG_LN))
+        return 0;
+    // checking wrong digest alg name is rejected:
+    if (c_obj_add_sigid(handle, SIGALG_OID, "NonsenseAlg", SIG_LN))
+        return 0;
+
     return 1;
 }
 


### PR DESCRIPTION
Fixes #16761 (and resolves https://github.com/open-quantum-safe/oqs-provider/issues/2#issuecomment-936343557 ).
