### PR TITLE
doc: OPENSSL_CORE_CTX should never be cast to OSSL_LIB_CTX

### DIFF
--- a/doc/man7/provider-base.pod
+++ b/doc/man7/provider-base.pod
@@ -223,11 +223,11 @@ freeing thread local variables.
 core_get_libctx() retrieves the core context in which the library
 object for the current provider is stored, accessible through the I<handle>.
 This function is useful only for built-in providers such as the default
-provider. Never cast this to OSSL_LIB_CTX as the OSSL_LIB_CTX of the library
-loading the provider might be a completely different structure than the
-OSSL_LIB_CTX of the library the provider is linked to. Use
-L<OSSL_LIB_CTX_new_child(3)> instead to obtain a proper library context that
-is linked to the application library context.
+provider. Never cast this to OSSL_LIB_CTX in a provider that is not
+built-in as the OSSL_LIB_CTX of the library loading the provider might be
+a completely different structure than the OSSL_LIB_CTX of the library the
+provider is linked to. Use  L<OSSL_LIB_CTX_new_child(3)> instead to obtain
+a proper library context that is linked to the application library context.
 
 core_new_error(), core_set_error_debug() and core_vset_error() are
 building blocks for reporting an error back to the core, with


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
