### PR TITLE
Fix crypto/async/async_wait.c: uniform return values between doc and …

### DIFF
--- a/crypto/async/async_wait.c
+++ b/crypto/async/async_wait.c
@@ -90,6 +90,9 @@ int ASYNC_WAIT_CTX_get_all_fds(ASYNC_WAIT_CTX *ctx, OSSL_ASYNC_FD *fd,
 {
     struct fd_lookup_st *curr;
 
+    if (ctx == NULL) {
+        return 0;
+    }
     curr = ctx->fds;
     *numfds = 0;
     while (curr != NULL) {
@@ -114,6 +117,9 @@ int ASYNC_WAIT_CTX_get_changed_fds(ASYNC_WAIT_CTX *ctx, OSSL_ASYNC_FD *addfd,
 {
     struct fd_lookup_st *curr;
 
+    if (ctx == NULL) {
+        return 0;
+    }
     *numaddfds = ctx->numadd;
     *numdelfds = ctx->numdel;
     if (addfd == NULL && delfd == NULL)
@@ -208,6 +214,9 @@ int ASYNC_WAIT_CTX_get_callback(ASYNC_WAIT_CTX *ctx,
 
 int ASYNC_WAIT_CTX_set_status(ASYNC_WAIT_CTX *ctx, int status)
 {
+      if (ctx == NULL) {
+          return 0;
+      }
       ctx->status = status;
       return 1;
 }


### PR DESCRIPTION
Since documentation says

>  ASYNC_WAIT_CTX_set_wait_fd, ASYNC_WAIT_CTX_get_fd, ASYNC_WAIT_CTX_get_all_fds,
> ASYNC_WAIT_CTX_get_changed_fds, ASYNC_WAIT_CTX_clear_fd,
> ASYNC_WAIT_CTX_set_callback, ASYNC_WAIT_CTX_get_callback and
> ASYNC_WAIT_CTX_set_status all return 1 on success or 0 on error.

and there are codes like `if (!ASYNC_WAIT_CTX_get_all_fds` in apps/speed.c etc. It's better to add a zero return value. 

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
