### PR TITLE
Fix DSA_size in crypto/dsa/dsa_sign.c

### DIFF
--- a/crypto/dsa/dsa_sign.c
+++ b/crypto/dsa/dsa_sign.c
@@ -126,7 +126,7 @@ int DSA_size(const DSA *dsa)
         ret = i2d_DSA_SIG(&sig, NULL);
 
         if (ret < 0)
-            ret = 0;
+            ret = -1;
     }
     return ret;
 }


### PR DESCRIPTION
If i2d_DSA_SIG returns a negative value, it means something wrong happens. So DSA_size should return -1 to indicate that instead of 0 which seems like DSA_size=0.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
