### PR TITLE
Fix unsafe return check of EVP_PKEY_fromdata_init and EVP_PKEY_fromdata

### DIFF
--- a/apps/dhparam.c
+++ b/apps/dhparam.c
@@ -384,7 +384,7 @@ static EVP_PKEY *dsa_to_dh(EVP_PKEY *dh)
     ctx = EVP_PKEY_CTX_new_from_name(NULL, "DHX", NULL);
     if (ctx == NULL
             || EVP_PKEY_fromdata_init(ctx) <= 0
-            || !EVP_PKEY_fromdata(ctx, &pkey, EVP_PKEY_KEY_PARAMETERS, params)) {
+            || EVP_PKEY_fromdata(ctx, &pkey, EVP_PKEY_KEY_PARAMETERS, params) <= 0) {
         BIO_printf(bio_err, "Error, failed to set DH parameters\n");
         goto err;
     }

--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -649,7 +649,7 @@ static EVP_PKEY *new_cmac_key_int(const unsigned char *priv, size_t len,
 #  endif
     *p = OSSL_PARAM_construct_end();
 
-    if (!EVP_PKEY_fromdata(ctx, &pkey, EVP_PKEY_KEYPAIR, params)) {
+    if (EVP_PKEY_fromdata(ctx, &pkey, EVP_PKEY_KEYPAIR, params) <= 0) {
         ERR_raise(ERR_LIB_EVP, EVP_R_KEY_SETUP_FAILED);
         goto err;
     }

--- a/test/helpers/predefined_dhparams.c
+++ b/test/helpers/predefined_dhparams.c
@@ -35,7 +35,7 @@ static EVP_PKEY *get_dh_from_pg_bn(OSSL_LIB_CTX *libctx, const char *type,
 
     params = OSSL_PARAM_BLD_to_param(tmpl);
     if (params == NULL
-        || !EVP_PKEY_fromdata(pctx, &dhpkey, EVP_PKEY_KEY_PARAMETERS, params))
+        || EVP_PKEY_fromdata(pctx, &dhpkey, EVP_PKEY_KEY_PARAMETERS, params) <= 0)
         goto err;
 
  err:


### PR DESCRIPTION


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
