### PR TITLE
KTLS: Enable KTLS for receiving as well in TLS 1.3

### DIFF
--- a/ssl/tls13_enc.c
+++ b/ssl/tls13_enc.c
@@ -688,8 +688,7 @@ int tls13_change_cipher_state(SSL *s, int which)
         s->statem.enc_write_state = ENC_WRITE_STATE_VALID;
 #ifndef OPENSSL_NO_KTLS
 # if defined(OPENSSL_KTLS_TLS13)
-    if (!(which & SSL3_CC_WRITE)
-            || !(which & SSL3_CC_APPLICATION)
+    if (!(which & SSL3_CC_APPLICATION)
             || (s->options & SSL_OP_ENABLE_KTLS) == 0)
         goto skip_ktls;
 
@@ -723,8 +722,10 @@ int tls13_change_cipher_state(SSL *s, int which)
         goto skip_ktls;
 
     /* ktls works with user provided buffers directly */
-    if (BIO_set_ktls(bio, &crypto_info, which & SSL3_CC_WRITE))
-        ssl3_release_write_buffer(s);
+    if (BIO_set_ktls(bio, &crypto_info, which & SSL3_CC_WRITE)) {
+        if (which & SSL3_CC_WRITE)
+            ssl3_release_write_buffer(s);
+    }
 skip_ktls:
 # endif
 #endif

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -1221,7 +1221,7 @@ static int execute_test_ktls(int cis_ktls, int sis_ktls,
 #if defined(OPENSSL_NO_KTLS_RX)
     rx_supported = 0;
 #else
-    rx_supported = (tls_version != TLS1_3_VERSION);
+    rx_supported = 1;
 #endif
     if (!cis_ktls || !rx_supported) {
         if (!TEST_false(BIO_get_ktls_recv(clientssl->rbio)))


### PR DESCRIPTION
This series removes the restriction of not enabling KTLS for receiving in TLS 1.3. Some adjustments to `ssl3_get_record` are needed to handle unprotected records provided by the kernel properly.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
