### PR TITLE
Avoid NULL+0 UB in bss_mem.c

### DIFF
--- a/crypto/bio/bss_mem.c
+++ b/crypto/bio/bss_mem.c
@@ -254,7 +254,7 @@ static long mem_ctrl(BIO *b, int cmd, long num, void *ptr)
         bm = bbm->readp;
         bo = bbm->buf;
     }
-    off = bm->data - bo->data;
+    off = (bm->data == bo->data) ? 0 : bm->data - bo->data;
     remain = bm->length;
 
     switch (cmd) {
@@ -277,7 +277,7 @@ static long mem_ctrl(BIO *b, int cmd, long num, void *ptr)
         if (num < 0 || num > off + remain)
             return -1;   /* Can't see outside of the current buffer */
 
-        bm->data = bo->data + num;
+        bm->data = (num != 0) ? bo->data + num : bo->data;
         bm->length = bo->length - num;
         bm->max = bo->max - num;
         off = num;


### PR DESCRIPTION
Fixes #16816
