### PR TITLE
Fix confused error code SSL_get_error in async mode

### DIFF
--- a/ssl/record/rec_layer_s3.c
+++ b/ssl/record/rec_layer_s3.c
@@ -1576,6 +1576,7 @@ int ssl3_read_bytes(SSL *s, int type, int *recvd_type, unsigned char *buf,
             goto start;
         } else if (alert_descr == SSL_AD_CLOSE_NOTIFY
                 && (is_tls13 || alert_level == SSL3_AL_WARNING)) {
+            s->rwstate = SSL_NOTHING;
             s->shutdown |= SSL_RECEIVED_SHUTDOWN;
             return 0;
         } else if (alert_level == SSL3_AL_FATAL || is_tls13) {


### PR DESCRIPTION
Fix error code SSL_get_error() when recv the SSL_shutdown msg in async mode

Fixed: #16809

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
