### PR TITLE
Fix test/recipes/01-test_symbol_presence.t to allow for stripped libraries

### DIFF
--- a/test/recipes/01-test_symbol_presence.t
+++ b/test/recipes/01-test_symbol_presence.t
@@ -48,12 +48,12 @@ foreach my $libname (@libnames) {
         *OSTDOUT = *STDOUT;
         open STDERR, ">", devnull();
         open STDOUT, ">", devnull();
-        my @nm_lines = map { s|\R$||; $_ } `nm -Pg $shlibpath 2> /dev/null`;
+        my @nm_lines = map { s|\R$||; $_ } `nm -DPg $shlibpath 2> /dev/null`;
         close STDERR;
         close STDOUT;
         *STDERR = *OSTDERR;
         *STDOUT = *OSTDOUT;
-        skip "Can't run 'nm -Pg $shlibpath' => $?...  ignoring", 2
+        skip "Can't run 'nm -DPg $shlibpath' => $?...  ignoring", 2
             unless $? == 0;
 
         my $bldtop = bldtop_dir();


### PR DESCRIPTION
It's a small change to the 'nm' call, to have it look at dynamic symbols
rather than the normal ones.

Fixes #16810
