### PR TITLE
Fix the s_server psk_server_cb for use in DTLS

### DIFF
--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -133,10 +133,10 @@ static unsigned int psk_server_cb(SSL *ssl, const char *identity,
 
     if (!SSL_is_dtls(ssl) && SSL_version(ssl) >= TLS1_3_VERSION) {
         /*
-         * This callback is designed for use in (D)TLSv1.2. It is possible to
-         * use a single callback for all protocol versions - but it is preferred
-         * to use a dedicated callback for TLSv1.3. For TLSv1.3 we have
-         * psk_find_session_cb.
+         * This callback is designed for use in (D)TLSv1.2 (or below). It is
+         * possible to use a single callback for all protocol versions - but it
+         * is preferred to use a dedicated callback for TLSv1.3. For TLSv1.3 we
+         * have psk_find_session_cb.
          */
         return 0;
     }


### PR DESCRIPTION
Commit 0007ff257c added a protocol version check to psk_server_cb but
failed to take account of DTLS causing DTLS based psk connections to
fail.

Fixes #16707
