### PR TITLE
Fix `EVP_PKEY_CTX_set0_rsa_oaep_label` signature

### DIFF
--- a/crypto/rsa/rsa_lib.c
+++ b/crypto/rsa/rsa_lib.c
@@ -1081,7 +1081,7 @@ int EVP_PKEY_CTX_get_rsa_mgf1_md(EVP_PKEY_CTX *ctx, const EVP_MD **md)
                              EVP_PKEY_CTRL_GET_RSA_MGF1_MD, 0, (void *)(md));
 }
 
-int EVP_PKEY_CTX_set0_rsa_oaep_label(EVP_PKEY_CTX *ctx, void *label, int llen)
+int EVP_PKEY_CTX_set0_rsa_oaep_label(EVP_PKEY_CTX *ctx, unsigned char *label, int llen)
 {
     OSSL_PARAM rsa_params[2], *p = rsa_params;
 

--- a/include/openssl/rsa.h
+++ b/include/openssl/rsa.h
@@ -161,7 +161,7 @@ int EVP_PKEY_CTX_set_rsa_oaep_md_name(EVP_PKEY_CTX *ctx, const char *mdname,
 int EVP_PKEY_CTX_get_rsa_oaep_md(EVP_PKEY_CTX *ctx, const EVP_MD **md);
 int EVP_PKEY_CTX_get_rsa_oaep_md_name(EVP_PKEY_CTX *ctx, char *name,
                                       size_t namelen);
-int EVP_PKEY_CTX_set0_rsa_oaep_label(EVP_PKEY_CTX *ctx, void *label, int llen);
+int EVP_PKEY_CTX_set0_rsa_oaep_label(EVP_PKEY_CTX *ctx, unsigned char *label, int llen);
 int EVP_PKEY_CTX_get0_rsa_oaep_label(EVP_PKEY_CTX *ctx, unsigned char **label);
 
 # define EVP_PKEY_CTRL_RSA_PADDING       (EVP_PKEY_ALG_CTRL + 1)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated


Fixes #10619 
The function prototype was 
```
int EVP_PKEY_CTX_set0_rsa_oaep_label(EVP_PKEY_CTX *ctx, void *label,
                                     int llen);
```
While the docs list it as 
```
int EVP_PKEY_CTX_set0_rsa_oaep_label(EVP_PKEY_CTX *ctx, unsigned char *label, int len);
```
I looked through the codebase and found 2 examples [cms_rsa.c](https://github.com/openssl/openssl/blob/643ce3108f88751c44348335bed91e475d50677d/crypto/cms/cms_rsa.c#L100) and [rsa_pmeth.c](https://github.com/openssl/openssl/blob/a983764e17551b2988bd684279ac9e9077d84601/crypto/rsa/rsa_pmeth.c#L709) in both these files label is declared as `unsigned char *` and not `void char *`.
Furthermore in the function definition in [`rsa_lib.c`](https://github.com/openssl/openssl/blob/2f61bc17d42bce0d5958cabc971f4f1343353fb3/crypto/rsa/rsa_lib.c#L1100) `label` is cast to `(void *)` anyway so based on this the documentation was correct and I've changed the type of `label` to `unsigned char *` wherever possible. I built the project again and ran all the tests and everything passed.