### PR TITLE
Configurations/windows-makefile.tmpl: obj2bin(): use the resource file too

### DIFF
--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -983,6 +983,7 @@ EOF
                 @{$args{objs}};
      my @deps = compute_lib_depends(@{$args{deps}});
      my $objs = join($target{ld_resp_delim}, @objs);
+     my $ress = join($target{ld_resp_delim}, @ress);
      my $linklibs = join("", map { "$_$target{ld_resp_delim}" } @deps);
      my $deps = join(" ", @objs, @ress, @deps);
      return <<"EOF";


### PR DESCRIPTION
When remaking how programs were linked, the variable `$ress` was forgotten.
Unfortunately, perl treats this with silence.

Fixes #16870
Fixes #16667
