### PR TITLE
Doc: be explicit about `NUL` in `max_identity_len`

### DIFF
--- a/doc/man3/SSL_CTX_set_psk_client_callback.pod
+++ b/doc/man3/SSL_CTX_set_psk_client_callback.pod
@@ -107,11 +107,11 @@ the pre-shared key to use during the connection setup phase.
 
 The callback is set using functions SSL_CTX_set_psk_client_callback()
 or SSL_set_psk_client_callback(). The callback function is given the
-connection in parameter B<ssl>, a B<NULL>-terminated PSK identity hint
+connection in parameter B<ssl>, a B<NUL>-terminated PSK identity hint
 sent by the server in parameter B<hint>, a buffer B<identity> of
-length B<max_identity_len> bytes where the resulting
-B<NUL>-terminated identity is to be stored, and a buffer B<psk> of
-length B<max_psk_len> bytes where the resulting pre-shared key is to
+length B<max_identity_len> bytes (including the B<NUL>-terminator) where the
+resulting B<NUL>-terminated identity is to be stored, and a buffer B<psk> 
+of length B<max_psk_len> bytes where the resulting pre-shared key is to
 be stored.
 
 The callback for use in TLSv1.2 will also work in TLSv1.3 although it is


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated

Fixes #10889
Makes it explicit that `NUL` byte is included in `max_identity_len`. 
Also fixed a small inconsistency, `hint` is mentioned as being `NULL-terminated` while `identity` is mentioned as  being `NUL-terminated`. As far as I know there is no technical difference between `NULL-terminated` and `NUL-terminated` and the documentation uses both, so made them same for consistency's sake.