### PR TITLE
Fix return value error in doc, and an error test

### DIFF
--- a/doc/man3/RSA_print.pod
+++ b/doc/man3/RSA_print.pod
@@ -14,8 +14,8 @@ Deprecated since OpenSSL 3.0, can be hidden entirely by defining
 B<OPENSSL_API_COMPAT> with a suitable version value, see
 L<openssl_user_macros(7)>:
 
- int RSA_print(BIO *bp, RSA *x, int offset);
- int RSA_print_fp(FILE *fp, RSA *x, int offset);
+ int RSA_print(BIO *bp, const RSA *x, int offset);
+ int RSA_print_fp(FILE *fp, const RSA *x, int offset);
 
  #include <openssl/dsa.h>
 
@@ -23,10 +23,10 @@ Deprecated since OpenSSL 3.0, can be hidden entirely by defining
 B<OPENSSL_API_COMPAT> with a suitable version value, see
 L<openssl_user_macros(7)>:
 
- int DSAparams_print(BIO *bp, DSA *x);
- int DSAparams_print_fp(FILE *fp, DSA *x);
- int DSA_print(BIO *bp, DSA *x, int offset);
- int DSA_print_fp(FILE *fp, DSA *x, int offset);
+ int DSAparams_print(BIO *bp, const DSA *x);
+ int DSAparams_print_fp(FILE *fp, const DSA *x);
+ int DSA_print(BIO *bp, const DSA *x, int offset);
+ int DSA_print_fp(FILE *fp, const DSA *x, int offset);
 
  #include <openssl/dh.h>
 
@@ -50,7 +50,10 @@ The output lines are indented by B<offset> spaces.
 
 =head1 RETURN VALUES
 
-These functions return 1 on success, 0 on error.
+DSAparams_print(), DSAparams_print_fp(), DSA_print(), and DSA_print_fp() return 1 for success 
+and 0 or a negative value for failure.
+
+DHparams_print() and DHparams_print_fp() return 1 on success, 0 on error.
 
 =head1 SEE ALSO
 

--- a/test/evp_pkey_provided_test.c
+++ b/test/evp_pkey_provided_test.c
@@ -141,7 +141,7 @@ static int test_print_key_using_pem(const char *alg, const EVP_PKEY *pk)
                                             (unsigned char *)"pass", 4,
                                             NULL, NULL))
         /* Private key in text form */
-        || !TEST_true(EVP_PKEY_print_private(membio, pk, 0, NULL))
+        || !TEST_true(EVP_PKEY_print_private(membio, pk, 0, NULL) > 0)
         || !TEST_true(compare_with_file(alg, PRIV_TEXT, membio))
         /* Public key in PEM form */
         || !TEST_true(PEM_write_bio_PUBKEY(membio, pk))


### PR DESCRIPTION
EVP_PKEY_print_private() can return a negative value when fails. 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
