### PR TITLE
OCSP_sendreq_bio: Avoid doublefree of mem BIO

### DIFF
--- a/crypto/ocsp/ocsp_http.c
+++ b/crypto/ocsp/ocsp_http.c
@@ -58,12 +58,11 @@ OCSP_RESPONSE *OCSP_sendreq_bio(BIO *b, const char *path, OCSP_REQUEST *req)
     if (ctx == NULL)
         return NULL;
     mem = OSSL_HTTP_REQ_CTX_exchange(ctx);
-    if (mem != NULL)
-        resp = (OCSP_RESPONSE *)ASN1_item_d2i_bio(ASN1_ITEM_rptr(OCSP_RESPONSE),
-                                                  mem, NULL);
+    /* ASN1_item_d2i_bio handles NULL bio gracefully */
+    resp = (OCSP_RESPONSE *)ASN1_item_d2i_bio(ASN1_ITEM_rptr(OCSP_RESPONSE),
+                                              mem, NULL);
 
     OSSL_HTTP_REQ_CTX_free(ctx);
-
     return resp;
 }
 #endif /* !defined(OPENSSL_NO_OCSP) */


### PR DESCRIPTION
This should fix the crash mentioned in #14547

Unfortunately we do not have any tests for OCSP_sendreq_bio() so that is the reason it went through unnoticed.
