### PR TITLE
Fix a gcc 11.2.0 warning

### DIFF
--- a/test/packettest.c
+++ b/test/packettest.c
@@ -302,7 +302,7 @@ static int test_PACKET_forward(void)
 
 static int test_PACKET_buf_init(void)
 {
-    unsigned char buf1[BUF_LEN] = { '\0' };
+    unsigned char buf1[BUF_LEN] = { 0 };
     PACKET pkt;
 
     /* Also tests PACKET_remaining() */


### PR DESCRIPTION
gcc 11.2.0 is the default on Ubuntu 21.10. It emits a (spurious) warning
when compiling test/packettest.c, which causes --strict-warnings builds
to fail. A simple fix avoids the warning.

