### PR TITLE
Note that SHA1 and MD5 x509 signatures are also forbidden at seclevel1

### DIFF
--- a/doc/man3/SSL_CTX_set_security_level.pod
+++ b/doc/man3/SSL_CTX_set_security_level.pod
@@ -76,7 +76,9 @@ The security level corresponds to a minimum of 80 bits of security. Any
 parameters offering below 80 bits of security are excluded. As a result RSA,
 DSA and DH keys shorter than 1024 bits and ECC keys shorter than 160 bits
 are prohibited. Any cipher suite using MD5 for the MAC is also prohibited. Any
-cipher suites using CCM with a 64 bit authentication tag are prohibited.
+cipher suites using CCM with a 64 bit authentication tag are prohibited. Note
+that signatures using SHA1 and MD5 are also forbidden at this level as they
+have less than 80 security bits.
 
 =item B<Level 2>
 
@@ -146,10 +148,11 @@ key size or the DH parameter size will abort the handshake with a fatal
 alert.
 
 Attempts to set certificates or parameters with insufficient security are
-also blocked. For example trying to set a certificate using a 512 bit RSA
-key using SSL_CTX_use_certificate() at level 1. Applications which do not
-check the return values for errors will misbehave: for example it might
-appear that a certificate is not set at all because it had been rejected.
+also blocked. For example trying to set a certificate using a 512 bit RSA key
+or a certificate with a signature with SHA1 digest at level 1 using
+SSL_CTX_use_certificate(). Applications which do not check the return values
+for errors will misbehave: for example it might appear that a certificate is
+not set at all because it had been rejected.
 
 =head1 RETURN VALUES
 


### PR DESCRIPTION
This is a cherry-pick of #16828 for the master branch.

The exclusion of SHA1 for X509 signatures is not obvious as the "intuative"
idea is that SHA1 should have 80 security bits. However the security bits
of SHA1 are explicitly set to 63 to avoid the it being strong enough for
security level 1. x509_set.c has the comment:

    /*
     * SHA1 and MD5 are known to be broken. Reduce security bits so that
     * they're no longer accepted at security level 1.
     * The real values don't really matter as long as they're lower than 80,
     * which is our security level 1.
     */

Signed-off-by: Arne Schwabe <arne@rfc2549.org>
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
