### PR TITLE
speed: range check the argument given to -multi

### DIFF
--- a/apps/speed.c
+++ b/apps/speed.c
@@ -1541,9 +1541,7 @@ int speed_main(int argc, char **argv)
 #ifndef NO_FORK
             multi = atoi(opt_arg());
             if ((size_t)multi >= SIZE_MAX / sizeof(int)) {
-                BIO_printf(bio_err,
-                           "%s: multi argument too large [limit is %zu]\n",
-                           prog, SIZE_MAX / sizeof(int) - 1);
+                BIO_printf(bio_err, "%s: multi argument too large\n", prog);
                 return 0;
             }
 #endif


### PR DESCRIPTION
For machines where sizeof(size_t) == sizeof(int) there is a possible overflow which could cause a crash.
For machines where sizeof(size_t) > sizeof(int), the existing checks adequately detect the situation.

Fixes #16899

- [ ] documentation is added or updated
- [ ] tests are added or updated
