### PR TITLE
Fix for a segv in fix_dh_rfc5114

### DIFF
--- a/crypto/evp/ctrl_params_translate.c
+++ b/crypto/evp/ctrl_params_translate.c
@@ -1026,10 +1026,23 @@ static int fix_dh_nid5114(enum state state,
     if (ctx->action_type != SET)
         return 0;
 
-    if (state == PRE_CTRL_STR_TO_PARAMS) {
+    switch (state) {
+    case PRE_CTRL_TO_PARAMS:
+        ctx->p2 = (char *)ossl_ffc_named_group_get_name
+            (ossl_ffc_uid_to_dh_named_group(ctx->p1));
+        ctx->p1 = 0;
+        break;
+
+    case PRE_CTRL_STR_TO_PARAMS:
+        if (ctx->p2 == NULL)
+            return 0;
         ctx->p2 = (char *)ossl_ffc_named_group_get_name
             (ossl_ffc_uid_to_dh_named_group(atoi(ctx->p2)));
         ctx->p1 = 0;
+        break;
+
+    default:
+        break;
     }
 
     return default_fixup_args(state, translation, ctx);
@@ -2741,4 +2754,3 @@ int evp_pkey_get_params_to_ctrl(const EVP_PKEY *pkey, OSSL_PARAM *params)
 {
     return evp_pkey_setget_params_to_ctrl(pkey, GET, params);
 }
-

--- a/test/dhtest.c
+++ b/test/dhtest.c
@@ -730,6 +730,27 @@ err:
     return ok;
 }
 
+static int dh_rfc5114_fix_nid_test(void)
+{
+    int ok = 0;
+    EVP_PKEY_CTX *paramgen_ctx;
+
+    /* Run the test. Success is any time the test does not cause a SIGSEGV interrupt */
+    paramgen_ctx = EVP_PKEY_CTX_new_id(EVP_PKEY_DHX, 0);
+    if (!TEST_ptr(paramgen_ctx))
+        goto err;
+    if (!TEST_int_eq(EVP_PKEY_paramgen_init(paramgen_ctx), 1))
+        goto err;
+    /* Tested function is called here */
+    if (!TEST_int_eq(EVP_PKEY_CTX_set_dhx_rfc5114(paramgen_ctx, 3), 1))
+        goto err;
+    /* If we're still running then the test passed. */
+    ok = 1;
+err:
+    EVP_PKEY_CTX_free(paramgen_ctx);
+    return ok;
+}
+
 static int dh_get_nid(void)
 {
     int ok = 0;
@@ -876,6 +897,7 @@ int setup_tests(void)
     ADD_ALL_TESTS(dh_test_prime_groups, OSSL_NELEM(prime_groups));
     ADD_TEST(dh_get_nid);
     ADD_TEST(dh_load_pkcs3_namedgroup_privlen_test);
+    ADD_TEST(dh_rfc5114_fix_nid_test);
 #endif
     return 1;
 }


### PR DESCRIPTION
I found that when a call stack starting with EVP_PKEY_CTX_set_dhx_rfc5114 is invoked. The function in question, fix_dh_rfc5114() evaluates the value ctx->p2 using atoi(). However in this case p2 is null, triggering a segv interrupt, crashing the program.  Further, fix_dh_rfc5114() is called by evp_pkey_ctx_ctrl_to_param() which explicitly sets the state parameter to PRE_CTRL_TO_PARAM but fix_dh_rfc5114() only evaluates the ctx values of p1 and p2 when the supplied state is PRE_CTRL_STR_TO_PARAM. This patch addresses these issues.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
