### PR TITLE
test/ssl_old_test.c: Fix wrong check

### DIFF
--- a/test/ssl_old_test.c
+++ b/test/ssl_old_test.c
@@ -1896,9 +1896,9 @@ int doit_localhost(SSL *s_ssl, SSL *c_ssl, int family, long count,
     BIO_snprintf(addr_str, sizeof(addr_str), ":%s", BIO_get_accept_port(acpt));
 
     client = BIO_new_connect(addr_str);
-    BIO_set_conn_ip_family(client, family);
     if (!client)
         goto err;
+    BIO_set_conn_ip_family(client, family);
 
     if (BIO_set_nbio(client, 1) <= 0)
         goto err;


### PR DESCRIPTION
In openssl-3.0.0 and system provided, it is not reasonalbe to check null pointer after use.
Maybe the order is accidentally reversed.
Therefore, it is better to correct it.

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
