### PR TITLE
Remove unused variable 'sctx'

### DIFF
--- a/test/x509_dup_cert_test.c
+++ b/test/x509_dup_cert_test.c
@@ -17,7 +17,6 @@
 static int test_509_dup_cert(int n)
 {
     int ret = 0;
-    X509_STORE_CTX *sctx = NULL;
     X509_STORE *store = NULL;
     X509_LOOKUP *lookup = NULL;
     const char *cert_f = test_get_argument(n);
@@ -28,7 +27,6 @@ static int test_509_dup_cert(int n)
         && TEST_true(X509_load_cert_file(lookup, cert_f, X509_FILETYPE_PEM)))
         ret = 1;
 
-    X509_STORE_CTX_free(sctx);
     X509_STORE_free(store);
     return ret;
 }


### PR DESCRIPTION
In the openssl-3.0.0 and system provided, the variable 'sctx' is unused in test_509_dup_cert.
Therefore, it might be better to remove the definition and operation of it.

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
