### PR TITLE
free s->pha_dgst when there is an error saving the digest

### DIFF
--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -2381,6 +2381,8 @@ int tls13_save_handshake_digest_for_pha(SSL *s)
         if (!EVP_MD_CTX_copy_ex(s->pha_dgst,
                                 s->s3.handshake_dgst)) {
             SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
+            EVP_MD_CTX_free(s->pha_dgst);
+            s->pha_dgst = NULL;
             return 0;
         }
     }


### PR DESCRIPTION
Free the Post-Handshake Auth digest when there is an error saving the digest to prevent memory leak or wrongly memory access in tls13_restore_handshake_digest_for_pha().