### PR TITLE
Remove redundant RAND_get0_private() call

### DIFF
--- a/test/rand_test.c
+++ b/test/rand_test.c
@@ -21,9 +21,6 @@ static int test_rand(void)
     unsigned char entropy2[] = { 0xff, 0xfe, 0xfd };
     unsigned char outbuf[3];
 
-    if (!TEST_ptr(privctx = RAND_get0_private(NULL)))
-        return 0;
-
     *p++ = OSSL_PARAM_construct_octet_string(OSSL_RAND_PARAM_TEST_ENTROPY,
                                              entropy1, sizeof(entropy1));
     *p = OSSL_PARAM_construct_end();


### PR DESCRIPTION
The test called this twice which doesn't hurt but isn't ideal.

Noted by @bernd-edlinger: https://github.com/openssl/openssl/pull/16905#discussion_r736434396

- [ ] documentation is added or updated
- [x] tests are added or updated
