### PR TITLE
free s->pha_dgst when there is an error saving the digest (1.1.1)

### DIFF
--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -2410,6 +2410,8 @@ int tls13_save_handshake_digest_for_pha(SSL *s)
             SSLfatal(s, SSL_AD_INTERNAL_ERROR,
                      SSL_F_TLS13_SAVE_HANDSHAKE_DIGEST_FOR_PHA,
                      ERR_R_INTERNAL_ERROR);
+            EVP_MD_CTX_free(s->pha_dgst);
+            s->pha_dgst = NULL;
             return 0;
         }
     }


### PR DESCRIPTION
This is a backport of [#16917](https://github.com/openssl/openssl/pull/16917) to 1.1.1. 