### PR TITLE
Don't include any TLSv1.3 ciphersuites that are disabled

### DIFF
--- a/ssl/ssl_ciph.c
+++ b/ssl/ssl_ciph.c
@@ -1370,7 +1370,8 @@ static int update_cipher_list_by_id(STACK_OF(SSL_CIPHER) **cipher_list_by_id,
     return 1;
 }
 
-static int update_cipher_list(STACK_OF(SSL_CIPHER) **cipher_list,
+static int update_cipher_list(SSL_CTX *ctx,
+                              STACK_OF(SSL_CIPHER) **cipher_list,
                               STACK_OF(SSL_CIPHER) **cipher_list_by_id,
                               STACK_OF(SSL_CIPHER) *tls13_ciphersuites)
 {
@@ -1390,9 +1391,17 @@ static int update_cipher_list(STACK_OF(SSL_CIPHER) **cipher_list,
         (void)sk_SSL_CIPHER_delete(tmp_cipher_list, 0);
 
     /* Insert the new TLSv1.3 ciphersuites */
-    for (i = 0; i < sk_SSL_CIPHER_num(tls13_ciphersuites); i++)
-        sk_SSL_CIPHER_insert(tmp_cipher_list,
-                             sk_SSL_CIPHER_value(tls13_ciphersuites, i), i);
+    for (i = sk_SSL_CIPHER_num(tls13_ciphersuites) - 1; i >= 0; i--) {
+        const SSL_CIPHER *sslc = sk_SSL_CIPHER_value(tls13_ciphersuites, i);
+
+        /* Don't include any TLSv1.3 ciphersuites that are disabled */
+        if ((sslc->algorithm_enc & ctx->disabled_enc_mask) == 0
+                && (ssl_cipher_table_mac[sslc->algorithm2
+                                         & SSL_HANDSHAKE_MAC_MASK].mask
+                    & ctx->disabled_mac_mask) == 0) {
+            sk_SSL_CIPHER_unshift(tmp_cipher_list, sslc);
+        }
+    }
 
     if (!update_cipher_list_by_id(cipher_list_by_id, tmp_cipher_list)) {
         sk_SSL_CIPHER_free(tmp_cipher_list);
@@ -1410,7 +1419,7 @@ int SSL_CTX_set_ciphersuites(SSL_CTX *ctx, const char *str)
     int ret = set_ciphersuites(&(ctx->tls13_ciphersuites), str);
 
     if (ret && ctx->cipher_list != NULL)
-        return update_cipher_list(&ctx->cipher_list, &ctx->cipher_list_by_id,
+        return update_cipher_list(ctx, &ctx->cipher_list, &ctx->cipher_list_by_id,
                                   ctx->tls13_ciphersuites);
 
     return ret;
@@ -1426,7 +1435,7 @@ int SSL_set_ciphersuites(SSL *s, const char *str)
             s->cipher_list = sk_SSL_CIPHER_dup(cipher_list);
     }
     if (ret && s->cipher_list != NULL)
-        return update_cipher_list(&s->cipher_list, &s->cipher_list_by_id,
+        return update_cipher_list(s->ctx, &s->cipher_list, &s->cipher_list_by_id,
                                   s->tls13_ciphersuites);
 
     return ret;


### PR DESCRIPTION
The CHACHA20_POLY1305 cipher is disabled in the FIPS mode, but s_server is able to send TLS_CHACHA20_POLY1305_SHA256 cipher suite in the ServerHello message:
```
$ openssl s_server -accept 127.0.0.1:4433 -cert cert.pem -provider fips -propquery fips=yes -ciphersuites TLS_CHACHA20_POLY1305_SHA256
Using default temp DH parameters
ACCEPT
ERROR
shutting down SSL
CONNECTION CLOSED
```
```
$ openssl s_client -connect 127.0.0.1:4433
Connecting to 127.0.0.1
CONNECTED(00000003)
40970115F87F0000:error:0A0001BB:SSL routines:ssl3_get_record:bad record type:ssl/record/ssl3_record.c:371:
---
no peer certificate available
---
No client certificate CA names sent
Server Temp Key: X25519, 253 bits
---
SSL handshake has read 138 bytes and written 304 bytes
Verification: OK
---
New, TLSv1.3, Cipher is TLS_CHACHA20_POLY1305_SHA256
Secure Renegotiation IS NOT supported
Compression: NONE
Expansion: NONE
No ALPN negotiated
Early data was not sent
Verify return code: 0 (ok)
```
This patch ensures that all modified ciphersuites must be from the FIPS provider (if enabled) and any unsupported ciphersuites are rejected.

Expected result:
```
$ openssl s_server -accept 127.0.0.1:4433 -cert cert.pem -provider fips -propquery fips=yes -ciphersuites TLS_CHACHA20_POLY1305_SHA256
Using default temp DH parameters
ACCEPT
ERROR
40A7902A967F0000:error:0A0000B5:SSL routines:tls_setup_handshake:no ciphers available:ssl/statem/statem_lib.c:170:No ciphers enabled for max supported SSL/TLS version
shutting down SSL
CONNECTION CLOSED
```
```
$ LD_LIBRARY_PATH=/opt/openssl-3.1.0/lib64 /opt/openssl-3.1.0/bin/openssl s_client -connect 127.0.0.1:4433 
Connecting to 127.0.0.1
CONNECTED(00000003)
40E752849F7F0000:error:0A000410:SSL routines:ssl3_read_bytes:sslv3 alert handshake failure:ssl/record/rec_layer_s3.c:1584:SSL alert number 40
---
no peer certificate available
---
No client certificate CA names sent
---
SSL handshake has read 7 bytes and written 297 bytes
Verification: OK
---
New, (NONE), Cipher is (NONE)
Secure Renegotiation IS NOT supported
Compression: NONE
Expansion: NONE
No ALPN negotiated
Early data was not sent
Verify return code: 0 (ok)
```
CLA: regular