### PR TITLE
Set default properties for OpenSSL command-line programs

### DIFF
--- a/apps/include/app_libctx.h
+++ b/apps/include/app_libctx.h
@@ -14,7 +14,7 @@
 
 OSSL_LIB_CTX *app_create_libctx(void);
 OSSL_LIB_CTX *app_get0_libctx(void);
-int app_set_propq(const char *arg);
+int app_set_propq(OSSL_LIB_CTX *libctx, const char *arg);
 const char *app_get0_propq(void);
 
 #endif

--- a/apps/lib/app_libctx.c
+++ b/apps/lib/app_libctx.c
@@ -14,8 +14,11 @@ static const char *app_propq = NULL;
 
 int app_set_propq(OSSL_LIB_CTX *libctx, const char *arg)
 {
+    if (!EVP_set_default_properties(libctx, arg)) {
+        opt_printf_stderr("Failed to set property query: %s\n", arg);
+        return 0;
+    }
     app_propq = arg;
-    EVP_set_default_properties(libctx, app_propq);
     return 1;
 }
 

--- a/apps/lib/app_libctx.c
+++ b/apps/lib/app_libctx.c
@@ -12,9 +12,10 @@
 static OSSL_LIB_CTX *app_libctx = NULL;
 static const char *app_propq = NULL;
 
-int app_set_propq(const char *arg)
+int app_set_propq(OSSL_LIB_CTX *libctx, const char *arg)
 {
     app_propq = arg;
+    EVP_set_default_properties(libctx, app_propq);
     return 1;
 }
 

--- a/apps/lib/app_provider.c
+++ b/apps/lib/app_provider.c
@@ -79,7 +79,7 @@ int opt_provider(int opt)
     case OPT_PROV_PROVIDER_PATH:
         return opt_provider_path(opt_arg());
     case OPT_PROV_PROPQUERY:
-        return app_set_propq(opt_arg());
+        return app_set_propq(app_get0_libctx(), opt_arg());
     }
     /* Should never get here but if we do, undo what we did earlier */
     provider_option_given = given;


### PR DESCRIPTION
OpenSSL command-line programs should set default properties for all future EVP algorithm fetches.
The TLS_CHACHA20_POLY1305_SHA256 ciphersiute is disabled in the FIPS mode, but openssl-ciphers supports this ciphersiute in the FIPS mode:
```
$ openssl ciphers -tls1_3 -s -v -provider fips -propquery fips=yes
TLS_AES_256_GCM_SHA384         TLSv1.3 Kx=any      Au=any   Enc=AESGCM(256)            Mac=AEAD
TLS_CHACHA20_POLY1305_SHA256   TLSv1.3 Kx=any      Au=any   Enc=CHACHA20/POLY1305(256) Mac=AEAD
TLS_AES_128_GCM_SHA256         TLSv1.3 Kx=any      Au=any   Enc=AESGCM(128)            Mac=AEAD
```
Expected result is:
```
$ openssl ciphers -tls1_3 -s -v -provider fips -propquery fips=yes
TLS_AES_256_GCM_SHA384         TLSv1.3 Kx=any      Au=any   Enc=AESGCM(256)            Mac=AEAD
TLS_AES_128_GCM_SHA256         TLSv1.3 Kx=any      Au=any   Enc=AESGCM(128)            Mac=AEAD
```

CLA: regular