### PR TITLE
do_sigver_init: Allow reinitialization of an existing operation.

### DIFF
--- a/doc/man3/EVP_DigestSignInit.pod
+++ b/doc/man3/EVP_DigestSignInit.pod
@@ -167,9 +167,10 @@ The call to EVP_DigestSignFinal() internally finalizes a copy of the digest
 context. This means that calls to EVP_DigestSignUpdate() and
 EVP_DigestSignFinal() can be called later to digest and sign additional data.
 
-Since only a copy of the digest context is ever finalized, the context must
-be cleaned up after use by calling EVP_MD_CTX_free() or a memory leak
-will occur.
+EVP_DigestSignInit() and EVP_DigestSignInit_ex() functions can be called
+multiple times on a context and the parameters set by previous calls should be
+preserved if the I<pkey> parameter is NULL. The call then just resets the state
+of the I<ctx>.
 
 The use of EVP_PKEY_get_size() with these functions is discouraged because some
 signature operations may have a signature length which depends on the

--- a/doc/man3/EVP_DigestVerifyInit.pod
+++ b/doc/man3/EVP_DigestVerifyInit.pod
@@ -57,7 +57,7 @@ EVP_MD_CTX is freed). If the EVP_PKEY_CTX to be used is created by
 EVP_DigestVerifyInit_ex then it will use the B<OSSL_LIB_CTX> specified
 in I<libctx> and the property query string specified in I<props>.
 
-No B<EVP_PKEY_CTX> will be created by EVP_DigestSignInit_ex() if the
+No B<EVP_PKEY_CTX> will be created by EVP_DigestVerifyInit_ex() if the
 passed B<ctx> has already been assigned one via L<EVP_MD_CTX_set_pkey_ctx(3)>.
 See also L<SM2(7)>.
 
@@ -156,9 +156,10 @@ The call to EVP_DigestVerifyFinal() internally finalizes a copy of the digest
 context. This means that EVP_VerifyUpdate() and EVP_VerifyFinal() can
 be called later to digest and verify additional data.
 
-Since only a copy of the digest context is ever finalized, the context must
-be cleaned up after use by calling EVP_MD_CTX_free() or a memory leak
-will occur.
+EVP_DigestVerifyInit() and EVP_DigestVerifyInit_ex() functions can be called
+multiple times on a context and the parameters set by previous calls should be
+preserved if the I<pkey> parameter is NULL. The call then just resets the state
+of the I<ctx>.
 
 =head1 SEE ALSO
 

--- a/providers/implementations/signature/dsa_sig.c
+++ b/providers/implementations/signature/dsa_sig.c
@@ -189,22 +189,31 @@ static int dsa_signverify_init(void *vpdsactx, void *vdsa,
     PROV_DSA_CTX *pdsactx = (PROV_DSA_CTX *)vpdsactx;
 
     if (!ossl_prov_is_running()
-            || pdsactx == NULL
-            || vdsa == NULL
-            || !DSA_up_ref(vdsa))
+            || pdsactx == NULL)
         return 0;
-    DSA_free(pdsactx->dsa);
-    pdsactx->dsa = vdsa;
+
+    if (vdsa == NULL && pdsactx->dsa == NULL) {
+        ERR_raise(ERR_LIB_PROV, PROV_R_NO_KEY_SET);
+        return 0;
+    }
+
+    if (vdsa != NULL) {
+        if (!ossl_dsa_check_key(pdsactx->libctx, vdsa,
+                                operation == EVP_PKEY_OP_SIGN)) {
+            ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_KEY_LENGTH);
+            return 0;
+        }
+        if (!DSA_up_ref(vdsa))
+            return 0;
+        DSA_free(pdsactx->dsa);
+        pdsactx->dsa = vdsa;
+    }
+
     pdsactx->operation = operation;
 
     if (!dsa_set_ctx_params(pdsactx, params))
         return 0;
 
-    if (!ossl_dsa_check_key(pdsactx->libctx, vdsa,
-                            operation == EVP_PKEY_OP_SIGN)) {
-        ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_KEY_LENGTH);
-        return 0;
-    }
     return 1;
 }
 
@@ -278,9 +287,12 @@ static int dsa_digest_signverify_init(void *vpdsactx, const char *mdname,
         return 0;
 
     pdsactx->flag_allow_md = 0;
-    pdsactx->mdctx = EVP_MD_CTX_new();
-    if (pdsactx->mdctx == NULL)
-        goto error;
+
+    if (pdsactx->mdctx == NULL) {
+        pdsactx->mdctx = EVP_MD_CTX_new();
+        if (pdsactx->mdctx == NULL)
+            goto error;
+    }
 
     if (!EVP_DigestInit_ex2(pdsactx->mdctx, pdsactx->md, params))
         goto error;
@@ -289,9 +301,7 @@ static int dsa_digest_signverify_init(void *vpdsactx, const char *mdname,
 
  error:
     EVP_MD_CTX_free(pdsactx->mdctx);
-    EVP_MD_free(pdsactx->md);
     pdsactx->mdctx = NULL;
-    pdsactx->md = NULL;
     return 0;
 }
 

--- a/providers/implementations/signature/eddsa_sig.c
+++ b/providers/implementations/signature/eddsa_sig.c
@@ -100,6 +100,14 @@ static int eddsa_digest_signverify_init(void *vpeddsactx, const char *mdname,
         return 0;
     }
 
+    if (edkey == NULL) {
+        if (peddsactx->key != NULL)
+            /* there is nothing to do on reinit */
+            return 1;
+        ERR_raise(ERR_LIB_PROV, PROV_R_NO_KEY_SET);
+        return 0;
+    }
+
     if (!ossl_ecx_key_up_ref(edkey)) {
         ERR_raise(ERR_LIB_PROV, ERR_R_INTERNAL_ERROR);
         return 0;
@@ -124,6 +132,7 @@ static int eddsa_digest_signverify_init(void *vpeddsactx, const char *mdname,
     default:
         /* Should never happen */
         ERR_raise(ERR_LIB_PROV, ERR_R_INTERNAL_ERROR);
+        ossl_ecx_key_free(edkey);
         return 0;
     }
     if (ret && WPACKET_finish(&pkt)) {

--- a/providers/implementations/signature/mac_legacy_sig.c
+++ b/providers/implementations/signature/mac_legacy_sig.c
@@ -101,13 +101,16 @@ static int mac_digest_sign_init(void *vpmacctx, const char *mdname, void *vkey,
     const char *ciphername = NULL, *engine = NULL;
 
     if (!ossl_prov_is_running()
-            || pmacctx == NULL
-            || vkey == NULL
-            || !ossl_mac_key_up_ref(vkey))
+        || pmacctx == NULL
+        || (pmacctx->key == NULL && vkey == NULL))
         return 0;
 
-    ossl_mac_key_free(pmacctx->key);
-    pmacctx->key = vkey;
+    if (vkey != NULL) {
+        if (!ossl_mac_key_up_ref(vkey))
+            return 0;
+        ossl_mac_key_free(pmacctx->key);
+        pmacctx->key = vkey;
+    }
 
     if (pmacctx->key->cipher.cipher != NULL)
         ciphername = (char *)EVP_CIPHER_get0_name(pmacctx->key->cipher.cipher);

--- a/providers/implementations/signature/mac_legacy_sig.c
+++ b/providers/implementations/signature/mac_legacy_sig.c
@@ -16,6 +16,7 @@
 #include <openssl/core_names.h>
 #include <openssl/params.h>
 #include <openssl/err.h>
+#include <openssl/proverr.h>
 #ifndef FIPS_MODULE
 # include <openssl/engine.h>
 #endif
@@ -101,9 +102,13 @@ static int mac_digest_sign_init(void *vpmacctx, const char *mdname, void *vkey,
     const char *ciphername = NULL, *engine = NULL;
 
     if (!ossl_prov_is_running()
-        || pmacctx == NULL
-        || (pmacctx->key == NULL && vkey == NULL))
+        || pmacctx == NULL)
         return 0;
+
+    if (pmacctx->key == NULL && vkey == NULL) {
+        ERR_raise(ERR_LIB_PROV, PROV_R_NO_KEY_SET);
+        return 0;
+    }
 
     if (vkey != NULL) {
         if (!ossl_mac_key_up_ref(vkey))

--- a/providers/implementations/signature/rsa_sig.c
+++ b/providers/implementations/signature/rsa_sig.c
@@ -386,19 +386,24 @@ static int rsa_signverify_init(void *vprsactx, void *vrsa,
 {
     PROV_RSA_CTX *prsactx = (PROV_RSA_CTX *)vprsactx;
 
-    if (!ossl_prov_is_running())
+    if (!ossl_prov_is_running() || prsactx == NULL)
         return 0;
 
-    if (prsactx == NULL || vrsa == NULL)
+    if (vrsa == NULL && prsactx->rsa == NULL) {
+        ERR_raise(ERR_LIB_PROV, PROV_R_NO_KEY_SET);
         return 0;
+    }
 
-    if (!ossl_rsa_check_key(prsactx->libctx, vrsa, operation))
-        return 0;
+    if (vrsa != NULL) {
+        if (!ossl_rsa_check_key(prsactx->libctx, vrsa, operation))
+            return 0;
 
-    if (!RSA_up_ref(vrsa))
-        return 0;
-    RSA_free(prsactx->rsa);
-    prsactx->rsa = vrsa;
+        if (!RSA_up_ref(vrsa))
+            return 0;
+        RSA_free(prsactx->rsa);
+        prsactx->rsa = vrsa;
+    }
+
     prsactx->operation = operation;
 
     if (!rsa_set_ctx_params(prsactx, params))
@@ -842,6 +847,7 @@ static int rsa_digest_signverify_init(void *vprsactx, const char *mdname,
 
     if (!rsa_signverify_init(vprsactx, vrsa, params, operation))
         return 0;
+
     if (mdname != NULL
         /* was rsa_setup_md already called in rsa_signverify_init()? */
         && (mdname[0] == '\0' || strcasecmp(prsactx->mdname, mdname) != 0)
@@ -849,10 +855,11 @@ static int rsa_digest_signverify_init(void *vprsactx, const char *mdname,
         return 0;
 
     prsactx->flag_allow_md = 0;
-    prsactx->mdctx = EVP_MD_CTX_new();
+
     if (prsactx->mdctx == NULL) {
-        ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
-        goto error;
+        prsactx->mdctx = EVP_MD_CTX_new();
+        if (prsactx->mdctx == NULL)
+            goto error;
     }
 
     if (!EVP_DigestInit_ex2(prsactx->mdctx, prsactx->md, params))
@@ -862,9 +869,7 @@ static int rsa_digest_signverify_init(void *vprsactx, const char *mdname,
 
  error:
     EVP_MD_CTX_free(prsactx->mdctx);
-    EVP_MD_free(prsactx->md);
     prsactx->mdctx = NULL;
-    prsactx->md = NULL;
     return 0;
 }
 

--- a/providers/implementations/signature/sm2_sig.c
+++ b/providers/implementations/signature/sm2_sig.c
@@ -27,6 +27,7 @@
 #include "internal/cryptlib.h"
 #include "internal/sm3.h"
 #include "prov/implementations.h"
+#include "prov/providercommon.h"
 #include "prov/provider_ctx.h"
 #include "crypto/ec.h"
 #include "crypto/sm2.h"
@@ -97,6 +98,9 @@ static int sm2sig_set_mdname(PROV_SM2_CTX *psm2ctx, const char *mdname)
     if (psm2ctx->md == NULL)
         return 0;
 
+    if (mdname == NULL)
+        return 1;
+
     if (strlen(mdname) >= sizeof(psm2ctx->mdname)
         || !EVP_MD_is_a(psm2ctx->md, mdname)) {
         ERR_raise_data(ERR_LIB_PROV, PROV_R_INVALID_DIGEST, "digest=%s",
@@ -131,10 +135,22 @@ static int sm2sig_signature_init(void *vpsm2ctx, void *ec,
 {
     PROV_SM2_CTX *psm2ctx = (PROV_SM2_CTX *)vpsm2ctx;
 
-    if (psm2ctx == NULL || ec == NULL || !EC_KEY_up_ref(ec))
+    if (!ossl_prov_is_running()
+            || psm2ctx == NULL)
         return 0;
-    EC_KEY_free(psm2ctx->ec);
-    psm2ctx->ec = ec;
+
+    if (ec == NULL && psm2ctx->ec == NULL) {
+        ERR_raise(ERR_LIB_PROV, PROV_R_NO_KEY_SET);
+        return 0;
+    }
+
+    if (ec != NULL) {
+        if (!EC_KEY_up_ref(ec))
+            return 0;
+        EC_KEY_free(psm2ctx->ec);
+        psm2ctx->ec = ec;
+    }
+
     return sm2sig_set_ctx_params(psm2ctx, params);
 }
 
@@ -197,10 +213,11 @@ static int sm2sig_digest_signverify_init(void *vpsm2ctx, const char *mdname,
         || !sm2sig_set_mdname(ctx, mdname))
         return ret;
 
-    EVP_MD_CTX_free(ctx->mdctx);
-    ctx->mdctx = EVP_MD_CTX_new();
-    if (ctx->mdctx == NULL)
-        goto error;
+    if (ctx->mdctx == NULL) {
+        ctx->mdctx = EVP_MD_CTX_new();
+        if (ctx->mdctx == NULL)
+            goto error;
+    }
 
     md_nid = EVP_MD_get_type(ctx->md);
 
@@ -228,8 +245,6 @@ static int sm2sig_digest_signverify_init(void *vpsm2ctx, const char *mdname,
     ret = 1;
 
  error:
-    if (!ret)
-        free_md(ctx);
     return ret;
 }
 

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -1143,6 +1143,7 @@ err:
  * Test 12: Use EVP_DigestSign (Implicit fetch digest, RSA)
  * Test 13: Use EVP_DigestSign (Implicit fetch digest, DSA)
  * Test 14: Use EVP_DigestSign (Implicit fetch digest, HMAC)
+ * Test 15-29: Same as above with reinitialization
  */
 static int test_EVP_DigestSignInit(int tst)
 {
@@ -1156,9 +1157,15 @@ static int test_EVP_DigestSignInit(int tst)
     size_t written;
     const EVP_MD *md;
     EVP_MD *mdexp = NULL;
+    int reinit = 0;
 
     if (nullprov != NULL)
         return TEST_skip("Test does not support a non-default library context");
+
+    if (tst >= 15) {
+        reinit = 1;
+        tst -= 15;
+    }
 
     if (tst >= 6 && tst <= 8) {
         membio = BIO_new(BIO_s_mem());
@@ -1196,6 +1203,9 @@ static int test_EVP_DigestSignInit(int tst)
         md = EVP_sha256();
 
     if (!TEST_true(EVP_DigestSignInit(md_ctx, NULL, md, NULL, pkey)))
+        goto out;
+
+    if (reinit && !TEST_true(EVP_DigestSignInit(md_ctx, NULL, NULL, NULL, NULL)))
         goto out;
 
     if (tst >= 6 && tst <= 8) {
@@ -4182,7 +4192,7 @@ int setup_tests(void)
     }
 
     ADD_TEST(test_EVP_set_default_properties);
-    ADD_ALL_TESTS(test_EVP_DigestSignInit, 15);
+    ADD_ALL_TESTS(test_EVP_DigestSignInit, 30);
     ADD_TEST(test_EVP_DigestVerifyInit);
     ADD_TEST(test_EVP_Digest);
     ADD_ALL_TESTS(test_EVP_PKEY_sign, 3);

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -1359,8 +1359,8 @@ static int test_siphash_digestsign(void)
     if (nullprov != NULL)
         return TEST_skip("Test does not support a non-default library context");
 
-    memset (buf, 0, 8);
-    memset (key, 1, 16);
+    memset(buf, 0, 8);
+    memset(key, 1, 16);
     if (!TEST_ptr(pkey = EVP_PKEY_new_raw_private_key(EVP_PKEY_SIPHASH, NULL,
                                                       key, 16)))
         goto out;

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -1316,6 +1316,13 @@ static int test_EVP_DigestVerifyInit(void)
             || !TEST_true(EVP_DigestVerifyFinal(md_ctx, kSignature,
                                                  sizeof(kSignature))))
         goto out;
+
+    /* test with reinitialization */
+    if (!TEST_true(EVP_DigestVerifyInit(md_ctx, NULL, NULL, NULL, NULL))
+            || !TEST_true(EVP_DigestVerifyUpdate(md_ctx, kMsg, sizeof(kMsg)))
+            || !TEST_true(EVP_DigestVerifyFinal(md_ctx, kSignature,
+                                                 sizeof(kSignature))))
+        goto out;
     ret = 1;
 
  out:


### PR DESCRIPTION
Fixes #16936

This is a draft because IMO documentation and some tests need to be added. And perhaps some more fixing/finetunning is also needed.

The question is, do we want this? The current behavior is definitely a regression from 1.1.1 though.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
