### PR TITLE
Fix: invoking x509_name_cannon improperly

### DIFF
--- a/crypto/x509/x_name.c
+++ b/crypto/x509/x_name.c
@@ -219,8 +219,8 @@ static int x509_name_ex_i2d(const ASN1_VALUE **val, unsigned char **out,
         if (ret < 0)
             return ret;
         ret = x509_name_canon(a);
-        if (ret < 0)
-            return ret;
+        if (!ret)
+            return -1;
     }
     ret = a->bytes->length;
     if (out != NULL) {


### PR DESCRIPTION
x509_name_canon returns 0 for failure and 1 for success. 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
