### PR TITLE
Fix: invoking BN_check_prime improperly

### DIFF
--- a/crypto/bn/bn_rsa_fips186_4.c
+++ b/crypto/bn/bn_rsa_fips186_4.c
@@ -116,7 +116,7 @@ static int bn_rsa_fips186_4_find_aux_prob_prime(const BIGNUM *Xp1,
         i++;
         BN_GENCB_call(cb, 0, i);
         /* MR test with trial division */
-        if (BN_check_prime(p1, ctx, cb))
+        if (BN_check_prime(p1, ctx, cb) > 0)
             break;
         /* Get next odd number */
         if (!BN_add_word(p1, 2))
@@ -329,7 +329,7 @@ int ossl_bn_rsa_fips186_4_derive_prime(BIGNUM *Y, BIGNUM *X, const BIGNUM *Xin,
                     || !BN_sub_word(y1, 1)
                     || !BN_gcd(tmp, y1, e, ctx))
                 goto err;
-            if (BN_is_one(tmp) && BN_check_prime(Y, ctx, cb))
+            if (BN_is_one(tmp) && BN_check_prime(Y, ctx, cb) > 0)
                 goto end;
             /* (Step 8-10) */
             if (++i >= imax || !BN_add(Y, Y, r1r2x2))

--- a/crypto/bn/bn_rsa_fips186_4.c
+++ b/crypto/bn/bn_rsa_fips186_4.c
@@ -329,8 +329,12 @@ int ossl_bn_rsa_fips186_4_derive_prime(BIGNUM *Y, BIGNUM *X, const BIGNUM *Xin,
                     || !BN_sub_word(y1, 1)
                     || !BN_gcd(tmp, y1, e, ctx))
                 goto err;
-            if (BN_is_one(tmp) && BN_check_prime(Y, ctx, cb) > 0)
-                goto end;
+            if (BN_is_one(tmp)) {
+                if (BN_check_prime(Y, ctx, cb) > 0)
+                    goto end;
+                else
+                    goto err;
+            }
             /* (Step 8-10) */
             if (++i >= imax || !BN_add(Y, Y, r1r2x2))
                 goto err;


### PR DESCRIPTION
BN_is_prime_fasttest() and BN_check_prime return 0 if the number is composite,
1 if it is prime with an error probability of less than 0.25^B<nchecks>, and
-1 on error.

Binary check of BN_check_prime will mix -1 and 1. 

In fact, I am not that confident this is wrong, just suspicious. Say sorry for bothering beforehand if it's not a bug. 



##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
