### PR TITLE
Fix DER encoder implementations for output structures "EC" and "SM2"

### DIFF
--- a/providers/implementations/encode_decode/encode_key2any.c
+++ b/providers/implementations/encode_decode/encode_key2any.c
@@ -731,7 +731,7 @@ static int ec_pki_priv_to_der(const void *veckey, unsigned char **pder)
 # define ec_epki_priv_to_der ec_pki_priv_to_der
 
 # define ec_type_specific_params_to_der (i2d_of_void *)i2d_ECParameters
-# define ec_type_specific_pub_to_der    (i2d_of_void *)i2o_ECPublicKey
+/* No ec_type_specific_pub_to_der, there simply is no such thing */
 # define ec_type_specific_priv_to_der   (i2d_of_void *)i2d_ECPrivateKey
 
 # define ec_check_key_type      NULL
@@ -1190,11 +1190,11 @@ static int key2any_encode(struct key2any_ctx_st *ctx, OSSL_CORE_BIO *cout,
 #define DO_DSA_selection_mask DO_type_specific_selection_mask
 #define DO_DSA(impl, type, output) DO_type_specific(impl, type, output)
 
-#define DO_EC_selection_mask DO_type_specific_selection_mask
-#define DO_EC(impl, type, output) DO_type_specific(impl, type, output)
+#define DO_EC_selection_mask DO_type_specific_no_pub_selection_mask
+#define DO_EC(impl, type, output) DO_type_specific_no_pub(impl, type, output)
 
-#define DO_SM2_selection_mask DO_type_specific_selection_mask
-#define DO_SM2(impl, type, output) DO_type_specific(impl, type, output)
+#define DO_SM2_selection_mask DO_type_specific_no_pub_selection_mask
+#define DO_SM2(impl, type, output) DO_type_specific_no_pub(impl, type, output)
 
 /* PKCS#1 defines a structure for RSA private and public keys */
 #define DO_PKCS1_selection_mask DO_RSA_selection_mask


### PR DESCRIPTION
These DER encoder implementations are supposed to be aliases for the
"type-specific" output structure, but were made different in so far
that they would output a "type specific" public key, which turns out
to be garbage (it called i2o_ECPublicKey()).  The "type-specific"
output structure doesn't support that, and shouldn't.

Fixes #16977
