### PR TITLE
prov: remove unused field flag_fallback and function ossl_provider_set_fallback

### DIFF
--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -67,7 +67,7 @@
  * The locks available are:
  *
  * The provider flag_lock: Used to control updates to the various provider
- * "flags" (flag_initialized, flag_activated, flag_fallback) and associated
+ * "flags" (flag_initialized and flag_activated) and associated
  * "counts" (activatecnt).
  *
  * The provider refcnt_lock: Only ever used to control updates to the provider
@@ -137,7 +137,6 @@ struct ossl_provider_st {
     /* Flag bits */
     unsigned int flag_initialized:1;
     unsigned int flag_activated:1;
-    unsigned int flag_fallback:1; /* Can be used as fallback */
 
     /* Getting and setting the flags require synchronization */
     CRYPTO_RWLOCK *flag_lock;
@@ -1391,16 +1390,6 @@ int OSSL_PROVIDER_available(OSSL_LIB_CTX *libctx, const char *name)
         ossl_provider_free(prov);
     }
     return available;
-}
-
-/* Setters of Provider Object data */
-int ossl_provider_set_fallback(OSSL_PROVIDER *prov)
-{
-    if (prov == NULL)
-        return 0;
-
-    prov->flag_fallback = 1;
-    return 1;
 }
 
 /* Getters of Provider Object data */

--- a/doc/internal/man3/ossl_provider_new.pod
+++ b/doc/internal/man3/ossl_provider_new.pod
@@ -4,7 +4,7 @@
 
 ossl_provider_find, ossl_provider_new, ossl_provider_up_ref,
 ossl_provider_free,
-ossl_provider_set_fallback, ossl_provider_set_module_path,
+ossl_provider_set_module_path,
 ossl_provider_add_parameter, ossl_provider_set_child, ossl_provider_get_parent,
 ossl_provider_up_ref_parent, ossl_provider_free_parent,
 ossl_provider_default_props_update, ossl_provider_get0_dispatch,
@@ -35,7 +35,6 @@ ossl_provider_get_capabilities
  void ossl_provider_free(OSSL_PROVIDER *prov);
 
  /* Setters */
- int ossl_provider_set_fallback(OSSL_PROVIDER *prov);
  int ossl_provider_set_module_path(OSSL_PROVIDER *prov, const char *path);
  int ossl_provider_add_parameter(OSSL_PROVIDER *prov, const char *name,
                                  const char *value);
@@ -159,11 +158,6 @@ reference count; when it drops to zero, the provider object is assumed
 to have fallen out of use and will be deinitialized (its I<teardown>
 function is called), and the associated module will be unloaded if one
 was loaded, and I<prov> itself will be freed.
-
-ossl_provider_set_fallback() marks an available provider I<prov> as
-fallback.
-Note that after this call, the provider object pointer that was
-used can simply be dropped, but not freed.
 
 ossl_provider_set_module_path() sets the module path to load the
 provider module given the provider object I<prov>.
@@ -348,7 +342,7 @@ ossl_provider_doall_activated() returns 1 if the callback was called for all
 activated providers.  A return value of 0 means that the callback was not
 called for any activated providers.
 
-ossl_provider_set_module_path(), ossl_provider_set_fallback(),
+ossl_provider_set_module_path(),
 ossl_provider_activate(), ossl_provider_activate_leave_fallbacks() and
 ossl_provider_deactivate(), ossl_provider_add_to_store(),
 ossl_provider_default_props_update() return 1 on success, or 0 on error.

--- a/include/internal/provider.h
+++ b/include/internal/provider.h
@@ -37,7 +37,6 @@ int ossl_provider_up_ref(OSSL_PROVIDER *prov);
 void ossl_provider_free(OSSL_PROVIDER *prov);
 
 /* Setters */
-int ossl_provider_set_fallback(OSSL_PROVIDER *prov);
 int ossl_provider_set_module_path(OSSL_PROVIDER *prov, const char *module_path);
 int ossl_provider_add_parameter(OSSL_PROVIDER *prov, const char *name,
                                 const char *value);


### PR DESCRIPTION

These are legacy of older versions of the code and are currently not used
anywhere.


- [x] documentation is added or updated
- [ ] tests are added or updated
