### PR TITLE
x509: remove dead call to strlen()

### DIFF
--- a/crypto/x509/v3_sxnet.c
+++ b/crypto/x509/v3_sxnet.c
@@ -177,8 +177,6 @@ int SXNET_add_id_INTEGER(SXNET **psx, ASN1_INTEGER *zone, const char *user,
 
     if ((id = SXNETID_new()) == NULL)
         goto err;
-    if (userlen == -1)
-        userlen = strlen(user);
 
     if (!ASN1_OCTET_STRING_set(id->user, (const unsigned char *)user, userlen))
         goto err;


### PR DESCRIPTION
The condition `userlen == -1` isn't possible because this is already checked
on line 159 above and the subsequent strlen(3) call guarantees that it's value
is positive.


- [ ] documentation is added or updated
- [ ] tests are added or updated
