### PR TITLE
coverity: add a daily coverity build

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,0 +1,42 @@
+# Copyright 2021 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+name: Static Analysis
+
+#Run once a day
+on:
+  schedule:
+    - cron:  '20 0 * * *'
+
+jobs:
+  coverity:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: tool download
+      run: |
+        wget https://scan.coverity.com/download/linux64 \
+             --post-data "token=${{ secrets.COVERITY_TOKEN }}&project=openssl%2Fopenssl" \
+             --progress=dot:giga -O coverity_tool.tgz
+    - name: config
+      run: CC=gcc ./config --banner=Configured --debug enable-fips enable-rc5 enable-md2 enable-ssl3 enable-nextprotoneg enable-ssl3-method enable-weak-ssl-ciphers enable-zlib enable-ec_nistp_64_gcc_128 no-shared enable-buildtest-c++ enable-external-tests -DPEDANTIC -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+    - name: config dump
+      run: ./configdata.pm --dump
+    - name: tool install
+      run: tar xzf coverity_tool.tgz
+    - name: make
+      run: ./cov-analysis*/bin/cov-build --dir cov-int make -s -j4
+    - name: archive
+      run: tar czvf openssl.tgz cov-int
+    - name: Coverity upload
+      run: |
+        curl --form token="${{ secrets.COVERITY_TOKEN }}" \
+             --form email=openssl-commits@openssl.org \
+             --form file=@openssl.tgz \
+             --form version="`date -u -I` `git rev-parse --short HEAD`" \
+             --form description="analysis of `git branch --show-current`" \
+             https://scan.coverity.com/builds?project=openssl%2Fopenssl


### PR DESCRIPTION
The weekly build got lost when we stopped using Travis.

- [ ] documentation is added or updated
- [x] tests are added or updated
