### PR TITLE
Fix the behavior of do_X509_REQ_verify

### DIFF
--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -2317,8 +2317,8 @@ int do_X509_REQ_verify(X509_REQ *x, EVP_PKEY *pkey,
     int rv = 0;
 
     if (do_x509_req_init(x, vfyopts) > 0)
-        rv = (X509_REQ_verify_ex(x, pkey,
-                                 app_get0_libctx(), app_get0_propq()) > 0);
+        rv = X509_REQ_verify_ex(x, pkey,
+                                 app_get0_libctx(), app_get0_propq());
     return rv;
 }
 

--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -2302,31 +2302,31 @@ int do_X509_CRL_sign(X509_CRL *x, EVP_PKEY *pkey, const char *md,
     return rv;
 }
 
+/* 
+ * do_X509_verify returns 1 if the signature is valid, 
+ * 0 if the signature check fails, or -1 if error occurs. 
+ */
 int do_X509_verify(X509 *x, EVP_PKEY *pkey, STACK_OF(OPENSSL_STRING) *vfyopts)
 {
     int rv = 0;
 
     if (do_x509_init(x, vfyopts) > 0)
-        /* 
-         * X509_verify returns 1 if the signature is valid, 
-         * 0 if the signature check fails, or -1 if error occurs. 
-         */
         rv = X509_verify(x, pkey);
     else
         rv = -1;
     return rv;
 }
 
+/* 
+ * do_X509_REQ_verify returns 1 if the signature is valid, 
+ * 0 if the signature check fails, or -1 if error occurs. 
+ */
 int do_X509_REQ_verify(X509_REQ *x, EVP_PKEY *pkey,
                        STACK_OF(OPENSSL_STRING) *vfyopts)
 {
     int rv = 0;
 
     if (do_x509_req_init(x, vfyopts) > 0)
-        /* 
-         * X509_REQ_verify_ex returns 1 if the signature is valid, 
-         * 0 if the signature check fails, or -1 if error occurs. 
-         */
         rv = X509_REQ_verify_ex(x, pkey,
                                  app_get0_libctx(), app_get0_propq());
     else

--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -2307,7 +2307,13 @@ int do_X509_verify(X509 *x, EVP_PKEY *pkey, STACK_OF(OPENSSL_STRING) *vfyopts)
     int rv = 0;
 
     if (do_x509_init(x, vfyopts) > 0)
-        rv = (X509_verify(x, pkey) > 0);
+        /* 
+         * X509_verify returns 1 if the signature is valid, 
+         * 0 if the signature check fails, or -1 if error occurs. 
+         */
+        rv = X509_verify(x, pkey);
+    else
+        rv = -1;
     return rv;
 }
 
@@ -2317,8 +2323,14 @@ int do_X509_REQ_verify(X509_REQ *x, EVP_PKEY *pkey,
     int rv = 0;
 
     if (do_x509_req_init(x, vfyopts) > 0)
+        /* 
+         * X509_REQ_verify_ex returns 1 if the signature is valid, 
+         * 0 if the signature check fails, or -1 if error occurs. 
+         */
         rv = X509_REQ_verify_ex(x, pkey,
                                  app_get0_libctx(), app_get0_propq());
+    else
+        rv = -1;
     return rv;
 }
 


### PR DESCRIPTION
In this pr, the behavior of **do_X509_REQ_verify** is changed since many other places rely on the new behavior. 

+ apps/ca.c:1390
+ apps/cmp.c:664
+ apps/req.c:930
+ apps/x509.c:705

If it's more reasonable to fix the above invoking places, I can reopen another pr. 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
