### PR TITLE
Add return value NULL checks that were missing

### DIFF
--- a/crypto/async/async.c
+++ b/crypto/async/async.c
@@ -138,6 +138,10 @@ static void async_release_job(ASYNC_JOB *job) {
     async_pool *pool;
 
     pool = (async_pool *)CRYPTO_THREAD_get_local(&poolkey);
+    if (pool == NULL) {
+        ERR_raise(ERR_LIB_ASYNC, ERR_R_INTERNAL_ERROR);
+        return;
+    }
     OPENSSL_free(job->funcargs);
     job->funcargs = NULL;
     sk_ASYNC_JOB_push(pool->jobs, job);
@@ -148,6 +152,10 @@ void async_start_func(void)
     ASYNC_JOB *job;
     async_ctx *ctx = async_get_ctx();
 
+    if (ctx == NULL) {
+        ERR_raise(ERR_LIB_ASYNC, ERR_R_INTERNAL_ERROR);
+        return;
+    }
     while (1) {
         /* Run the job */
         job = ctx->currjob;

--- a/crypto/cms/cms_smime.c
+++ b/crypto/cms/cms_smime.c
@@ -608,6 +608,8 @@ CMS_ContentInfo *CMS_sign_receipt(CMS_SignerInfo *si,
 
     /* Set embedded content */
     pos = CMS_get0_content(cms);
+    if (pos == NULL)
+        goto err;
     *pos = os;
 
     r = 1;

--- a/crypto/property/property.c
+++ b/crypto/property/property.c
@@ -118,7 +118,7 @@ OSSL_PROPERTY_LIST **ossl_ctx_global_properties(OSSL_LIB_CTX *libctx,
     globp = ossl_lib_ctx_get_data(libctx, OSSL_LIB_CTX_GLOBAL_PROPERTIES,
                                   &ossl_ctx_global_properties_method);
 
-    return &globp->list;
+    return globp != NULL ? &globp->list : NULL;
 }
 
 #ifndef FIPS_MODULE
@@ -128,7 +128,7 @@ int ossl_global_properties_no_mirrored(OSSL_LIB_CTX *libctx)
         = ossl_lib_ctx_get_data(libctx, OSSL_LIB_CTX_GLOBAL_PROPERTIES,
                                 &ossl_ctx_global_properties_method);
 
-    return globp->no_mirrored ? 1 : 0;
+    return globp != NULL && globp->no_mirrored ? 1 : 0;
 }
 
 void ossl_global_properties_stop_mirroring(OSSL_LIB_CTX *libctx)
@@ -137,7 +137,8 @@ void ossl_global_properties_stop_mirroring(OSSL_LIB_CTX *libctx)
         = ossl_lib_ctx_get_data(libctx, OSSL_LIB_CTX_GLOBAL_PROPERTIES,
                                 &ossl_ctx_global_properties_method);
 
-    globp->no_mirrored = 1;
+    if (globp != NULL)
+        globp->no_mirrored = 1;
 }
 #endif
 

--- a/crypto/provider_conf.c
+++ b/crypto/provider_conf.c
@@ -146,9 +146,6 @@ static int provider_conf_load(OSSL_LIB_CTX *libctx, const char *name,
     const char *path = NULL;
     long activate = 0;
     int ok = 0;
-    PROVIDER_CONF_GLOBAL *pcgbl
-        = ossl_lib_ctx_get_data(libctx, OSSL_LIB_CTX_PROVIDER_CONF_INDEX,
-                                &provider_conf_ossl_ctx_method);
 
     name = skip_dot(name);
     OSSL_TRACE1(CONF, "Configuring provider %s\n", name);
@@ -185,7 +182,11 @@ static int provider_conf_load(OSSL_LIB_CTX *libctx, const char *name,
     }
 
     if (activate) {
-        if (!CRYPTO_THREAD_write_lock(pcgbl->lock)) {
+        PROVIDER_CONF_GLOBAL *pcgbl
+            = ossl_lib_ctx_get_data(libctx, OSSL_LIB_CTX_PROVIDER_CONF_INDEX,
+                                    &provider_conf_ossl_ctx_method);
+
+        if (pcgbl == NULL || !CRYPTO_THREAD_write_lock(pcgbl->lock)) {
             ERR_raise(ERR_LIB_CRYPTO, ERR_R_INTERNAL_ERROR);
             return 0;
         }

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -1267,6 +1267,8 @@ static const SIGALG_LOOKUP *tls1_get_legacy_sigalg(const SSL *s, int idx)
             for (i = 0; i < SSL_PKEY_NUM; i++) {
                 const SSL_CERT_LOOKUP *clu = ssl_cert_lookup_by_idx(i);
 
+                if (clu == NULL)
+                    continue;
                 if (clu->amask & s->s3.tmp.new_cipher->algorithm_auth) {
                     idx = i;
                     break;


### PR DESCRIPTION
It isn't clear if all of these are possible, but it is still better to verify the returns.  The seemingly major change in provider_conf.c is reducing the scope of the variable and only checking for NULL in that block.

Issues located by Brian Carpenter of Geeknik's Farm.


- [ ] documentation is added or updated
- [ ] tests are added or updated
