### PR TITLE
Reset the rwstate before calling ASYNC_start_job()

### DIFF
--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -1770,6 +1770,8 @@ static int ssl_start_async_job(SSL *s, struct ssl_async_args *args,
                  (s->waitctx, ssl_async_wait_ctx_cb, s))
             return -1;
     }
+
+    s->rwstate = SSL_NOTHING;
     switch (ASYNC_start_job(&s->job, s->waitctx, &ret, func, args,
                             sizeof(struct ssl_async_args))) {
     case ASYNC_ERR:


### PR DESCRIPTION
If an async job pauses while processing a TLS connection then the
rwstate gets set to SSL_ASYNC_PAUSED. When resuming the job we should
reset the rwstate back to SSL_NOTHING. In fact we can do this
unconditionally since if we're about to call ASYNC_start_job() then either
we are about to start the async job for the first time (in which case the
rwstate should already by SSL_NOTHING), or we are restarting it after a
pause (in which case reseting it to SSL_NOTHING is the correct action).

Fixes #16809
