### PR TITLE
Add null digest implementation to the default provider

### DIFF
--- a/crypto/evp/digest.c
+++ b/crypto/evp/digest.c
@@ -229,7 +229,10 @@ static int evp_md_init_internal(EVP_MD_CTX *ctx, const EVP_MD *type,
         ERR_raise(ERR_LIB_EVP, EVP_R_INITIALIZATION_ERROR);
         return 0;
 #else
-        EVP_MD *provmd = EVP_MD_fetch(NULL, OBJ_nid2sn(type->type), "");
+        /* The NULL digest is a special case */
+        EVP_MD *provmd = EVP_MD_fetch(NULL,
+                                      type->type != NID_undef ? OBJ_nid2sn(type->type)
+                                                              : "NULL", "");
 
         if (provmd == NULL) {
             ERR_raise(ERR_LIB_EVP, EVP_R_INITIALIZATION_ERROR);

--- a/providers/defltprov.c
+++ b/providers/defltprov.c
@@ -153,6 +153,7 @@ static const OSSL_ALGORITHM deflt_digests[] = {
     { PROV_NAMES_MD5_SHA1, "provider=default", ossl_md5_sha1_functions },
 #endif /* OPENSSL_NO_MD5 */
 
+    { PROV_NAMES_NULL, "provider=default", ossl_nullmd_functions },
     { NULL, NULL, NULL }
 };
 

--- a/providers/implementations/digests/build.info
+++ b/providers/implementations/digests/build.info
@@ -9,6 +9,7 @@ $SHA3_GOAL=../../libdefault.a ../../libfips.a
 $BLAKE2_GOAL=../../libdefault.a
 $SM3_GOAL=../../libdefault.a
 $MD5_GOAL=../../libdefault.a
+$NULL_GOAL=../../libdefault.a
 
 $MD2_GOAL=../../liblegacy.a
 $MD4_GOAL=../../liblegacy.a
@@ -21,6 +22,8 @@ SOURCE[$COMMON_GOAL]=digestcommon.c
 
 SOURCE[$SHA2_GOAL]=sha2_prov.c
 SOURCE[$SHA3_GOAL]=sha3_prov.c
+
+SOURCE[$NULL_GOAL]=null_prov.c
 
 IF[{- !$disabled{blake2} -}]
   SOURCE[$BLAKE2_GOAL]=blake2_prov.c blake2b_prov.c blake2s_prov.c

--- a/providers/implementations/digests/null_prov.c
+++ b/providers/implementations/digests/null_prov.c
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2021 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <openssl/crypto.h>
+#include "prov/digestcommon.h"
+#include "prov/implementations.h"
+
+typedef struct {
+    unsigned char nothing;
+} NULLMD_CTX;
+
+static int null_init(NULLMD_CTX *ctx)
+{
+    return 1;
+}
+
+static int null_update(NULLMD_CTX *ctx, const void *data, size_t datalen)
+{
+    return 1;
+}
+
+static int null_final(unsigned char *md, NULLMD_CTX *ctx)
+{
+    return 1;
+}
+
+#undef PROV_FUNC_DIGEST_FINAL
+#define PROV_FUNC_DIGEST_FINAL(name, dgstsize, fin)                            \
+static OSSL_FUNC_digest_final_fn name##_internal_final;                        \
+static int name##_internal_final(void *ctx, unsigned char *out, size_t *outl,  \
+                                 size_t outsz)                                 \
+{                                                                              \
+    if (ossl_prov_is_running() && fin(out, ctx)) {                             \
+        *outl = dgstsize;                                                      \
+        return 1;                                                              \
+    }                                                                          \
+    return 0;                                                                  \
+}
+
+IMPLEMENT_digest_functions(nullmd, NULLMD_CTX,
+                           0, 0, 0,
+                           null_init, null_update, null_final)

--- a/providers/implementations/digests/null_prov.c
+++ b/providers/implementations/digests/null_prov.c
@@ -30,6 +30,10 @@ static int null_final(unsigned char *md, NULLMD_CTX *ctx)
     return 1;
 }
 
+/*
+ * We must override the PROV_FUNC_DIGEST_FINAL as dgstsize == 0
+ * and that would cause compilation warnings with the default implementation.
+ */
 #undef PROV_FUNC_DIGEST_FINAL
 #define PROV_FUNC_DIGEST_FINAL(name, dgstsize, fin)                            \
 static OSSL_FUNC_digest_final_fn name##_internal_final;                        \

--- a/providers/implementations/include/prov/implementations.h
+++ b/providers/implementations/include/prov/implementations.h
@@ -40,6 +40,7 @@ extern const OSSL_DISPATCH ossl_md4_functions[];
 extern const OSSL_DISPATCH ossl_mdc2_functions[];
 extern const OSSL_DISPATCH ossl_wp_functions[];
 extern const OSSL_DISPATCH ossl_ripemd160_functions[];
+extern const OSSL_DISPATCH ossl_nullmd_functions[];
 
 /* Ciphers */
 extern const OSSL_DISPATCH ossl_null_functions[];

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -1377,6 +1377,35 @@ static int test_EVP_Digest(void)
     return ret;
 }
 
+static int test_EVP_md_null(void)
+{
+    int ret = 0;
+    EVP_MD_CTX *md_ctx = NULL;
+    const EVP_MD *md_null = EVP_md_null();
+    unsigned char md_value[EVP_MAX_MD_SIZE];
+    unsigned int md_len = sizeof(md_value);
+
+    if (nullprov != NULL)
+        return TEST_skip("Test does not support a non-default library context");
+
+    if (!TEST_ptr(md_null)
+        || !TEST_ptr(md_ctx = EVP_MD_CTX_new()))
+        goto out;
+
+    if (!TEST_true(EVP_DigestInit_ex(md_ctx, md_null, NULL))
+        || !TEST_true(EVP_DigestUpdate(md_ctx, "test", 4))
+        || !TEST_true(EVP_DigestFinal_ex(md_ctx, md_value, &md_len)))
+        goto out;
+
+    if (!TEST_uint_eq(md_len, 0))
+        goto out;
+
+    ret = 1;
+ out:
+    EVP_MD_CTX_free(md_ctx);
+    return ret;
+}
+
 static int test_d2i_AutoPrivateKey(int i)
 {
     int ret = 0;
@@ -4178,6 +4207,7 @@ int setup_tests(void)
     ADD_ALL_TESTS(test_EVP_DigestSignInit, 15);
     ADD_TEST(test_EVP_DigestVerifyInit);
     ADD_TEST(test_EVP_Digest);
+    ADD_TEST(test_EVP_md_null);
     ADD_ALL_TESTS(test_EVP_PKEY_sign, 3);
     ADD_ALL_TESTS(test_EVP_Enveloped, 2);
     ADD_ALL_TESTS(test_d2i_AutoPrivateKey, OSSL_NELEM(keydata));


### PR DESCRIPTION
This is necessary to keep compatibility with 1.1.1.

Fixes #16660

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
