### PR TITLE
perlasm/ppc-xlate.pl: Fix build on OS X

### DIFF
--- a/crypto/perlasm/ppc-xlate.pl
+++ b/crypto/perlasm/ppc-xlate.pl
@@ -153,13 +153,14 @@ my $quad = sub {
 # vs<N> -> v<N-32> if N > 32
 sub vsr2vr1 {
     my $in = shift;
+    my ($prefix, $reg) = ($in =~ m/(\D*)(\d+)/);
 
-    my $n = int($in);
+    my $n = int($reg);
     if ($n >= 32) {
 	    $n -= 32;
     }
 
-    return "$n";
+    return "${prefix}${n}";
 }
 # As above for first $num register args, returns list
 sub _vsr2vr {


### PR DESCRIPTION
vsr2vr1() fails on OS X because the main loop doesn't strip the
non-numeric register prefixes for OS X.

Strip any non-numeric prefix (likely just "v") from registers before
doing numeric calculation, then put the prefix back on the result.

Fixes: #16995

Signed-off-by: Martin Schwenke <martin@meltin.net>

Personal CLA - no longer with IBM.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
