### PR TITLE
EVP_DigestVerifyFinal: fix test function and invocation

### DIFF
--- a/demos/signature/EVP_Signature_demo.c
+++ b/demos/signature/EVP_Signature_demo.c
@@ -188,7 +188,7 @@ static int demo_verify(OSSL_LIB_CTX *libctx, const char *sig_name,
         fprintf(stderr, "EVP_DigestVerifyUpdate(hamlet_2) failed.\n");
         goto cleanup;
     }
-    if (!EVP_DigestVerifyFinal(verify_context, sig_value, sig_len)) {
+    if (EVP_DigestVerifyFinal(verify_context, sig_value, sig_len) <= 0) {
         fprintf(stderr, "EVP_DigestVerifyFinal failed.\n");
         goto cleanup;
     }

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -1273,11 +1273,11 @@ static int test_EVP_DigestSignInit(int tst)
                                                   sizeof(kMsg))))
                 goto out;
         }
-        if (!TEST_true(EVP_DigestVerifyFinal(md_ctx_verify, sig, sig_len)))
+        if (!TEST_int_gt(EVP_DigestVerifyFinal(md_ctx_verify, sig, sig_len), 0))
             goto out;
 
         /* Multiple calls to EVP_DigestVerifyFinal should work */
-        if (!TEST_true(EVP_DigestVerifyFinal(md_ctx_verify, sig, sig_len)))
+        if (!TEST_int_gt(EVP_DigestVerifyFinal(md_ctx_verify, sig, sig_len), 0))
             goto out;
     } else {
         /*
@@ -1323,15 +1323,15 @@ static int test_EVP_DigestVerifyInit(void)
 
     if (!TEST_true(EVP_DigestVerifyInit(md_ctx, NULL, EVP_sha256(), NULL, pkey))
             || !TEST_true(EVP_DigestVerifyUpdate(md_ctx, kMsg, sizeof(kMsg)))
-            || !TEST_true(EVP_DigestVerifyFinal(md_ctx, kSignature,
-                                                 sizeof(kSignature))))
+            || !TEST_int_gt(EVP_DigestVerifyFinal(md_ctx, kSignature,
+                                                 sizeof(kSignature)), 0))
         goto out;
 
     /* test with reinitialization */
     if (!TEST_true(EVP_DigestVerifyInit(md_ctx, NULL, NULL, NULL, NULL))
             || !TEST_true(EVP_DigestVerifyUpdate(md_ctx, kMsg, sizeof(kMsg)))
-            || !TEST_true(EVP_DigestVerifyFinal(md_ctx, kSignature,
-                                                 sizeof(kSignature))))
+            || !TEST_int_gt(EVP_DigestVerifyFinal(md_ctx, kSignature,
+                                                 sizeof(kSignature)), 0))
         goto out;
     ret = 1;
 
@@ -1757,7 +1757,7 @@ static int test_EVP_SM2_verify(void)
     if (!TEST_true(EVP_DigestVerifyUpdate(mctx, msg, strlen(msg))))
         goto done;
 
-    if (!TEST_true(EVP_DigestVerifyFinal(mctx, signature, sizeof(signature))))
+    if (!TEST_int_gt(EVP_DigestVerifyFinal(mctx, signature, sizeof(signature)), 0))
         goto done;
     rc = 1;
 
@@ -1867,7 +1867,7 @@ static int test_EVP_SM2(void)
     if (!TEST_true(EVP_DigestVerifyUpdate(md_ctx_verify, kMsg, sizeof(kMsg))))
         goto done;
 
-    if (!TEST_true(EVP_DigestVerifyFinal(md_ctx_verify, sig, sig_len)))
+    if (!TEST_int_gt(EVP_DigestVerifyFinal(md_ctx_verify, sig, sig_len), 0))
         goto done;
 
     /* now check encryption/decryption */


### PR DESCRIPTION
EVP_DigestVerifyFinal can return the negative values to indicate errors. 

> EVP_DigestVerifyFinal() and EVP_DigestVerify() return 1 for success; any other
> value indicates failure.  A return value of zero indicates that the signature
> did not verify successfully (that is, B<tbs> did not match the original data or
> the signature had an invalid form), while other values indicate a more serious
> error (and sometimes also indicate an invalid signature form).

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
