### PR TITLE
EVP_PKEY_paramgen_init: fix return check

### DIFF
--- a/apps/dhparam.c
+++ b/apps/dhparam.c
@@ -194,7 +194,7 @@ int dhparam_main(int argc, char **argv)
                     "Generating %s parameters, %d bit long %sprime\n",
                     alg, num, dsaparam ? "" : "safe ");
 
-        if (!EVP_PKEY_paramgen_init(ctx)) {
+        if (EVP_PKEY_paramgen_init(ctx) <= 0) {
             BIO_printf(bio_err,
                         "Error, unable to initialise %s parameters\n",
                         alg);

--- a/test/acvp_test.c
+++ b/test/acvp_test.c
@@ -340,7 +340,7 @@ static EVP_PKEY *dsa_paramgen(int L, int N)
     EVP_PKEY *param_key = NULL;
 
     if (!TEST_ptr(paramgen_ctx = EVP_PKEY_CTX_new_from_name(libctx, "DSA", NULL))
-        || !TEST_true(EVP_PKEY_paramgen_init(paramgen_ctx))
+        || !TEST_int_gt(EVP_PKEY_paramgen_init(paramgen_ctx), 0)
         || !TEST_true(EVP_PKEY_CTX_set_dsa_paramgen_bits(paramgen_ctx, L))
         || !TEST_true(EVP_PKEY_CTX_set_dsa_paramgen_q_bits(paramgen_ctx, N))
         || !TEST_true(EVP_PKEY_paramgen(paramgen_ctx, &param_key)))
@@ -416,7 +416,7 @@ static int dsa_paramgen_test(int id)
     const struct dsa_paramgen_st *tst = &dsa_paramgen_data[id];
 
     if (!TEST_ptr(paramgen_ctx = EVP_PKEY_CTX_new_from_name(libctx, "DSA", NULL))
-        || !TEST_true(EVP_PKEY_paramgen_init(paramgen_ctx))
+        || !TEST_int_gt(EVP_PKEY_paramgen_init(paramgen_ctx), 0)
         || !TEST_true(EVP_PKEY_CTX_set_dsa_paramgen_bits(paramgen_ctx, tst->L))
         || !TEST_true(EVP_PKEY_CTX_set_dsa_paramgen_q_bits(paramgen_ctx, tst->N))
         || !TEST_true(EVP_PKEY_paramgen(paramgen_ctx, &param_key))

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -1666,7 +1666,7 @@ static int test_EC_keygen_with_enc(int idx)
 
     /* Create key parameters */
     if (!TEST_ptr(pctx = EVP_PKEY_CTX_new_from_name(testctx, "EC", NULL))
-        || !TEST_true(EVP_PKEY_paramgen_init(pctx))
+        || !TEST_int_gt(EVP_PKEY_paramgen_init(pctx), 0)
         || !TEST_true(EVP_PKEY_CTX_set_group_name(pctx, "P-256"))
         || !TEST_true(EVP_PKEY_CTX_set_ec_param_enc(pctx, enc))
         || !TEST_true(EVP_PKEY_paramgen(pctx, &params))


### PR DESCRIPTION
EVP_PKEY_keygen_init(), EVP_PKEY_paramgen_init(), EVP_PKEY_keygen() and
EVP_PKEY_paramgen() return 1 for success and 0 or a negative value for failure.
In particular a return value of -2 indicates the operation is not supported by
the public key algorithm.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
