### PR TITLE
Fix Coverity 1493746: constant expression result

### DIFF
--- a/crypto/stack/stack.c
+++ b/crypto/stack/stack.c
@@ -168,7 +168,7 @@ static ossl_inline int compute_growth(int target, int current)
         current = safe_muldiv_int(current, 8, 5, &err);
         if (err)
             return 0;
-        if (current > max_nodes)
+        if (current >= max_nodes)
             current = max_nodes;
     }
     return current;


### PR DESCRIPTION
Turning an always false expression into a real test that doesn't do anything apart from appease the compiler.

- [ ] documentation is added or updated
- [ ] tests are added or updated
