### PR TITLE
Don't create an ECX key with short keys

### DIFF
--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -4202,6 +4202,28 @@ static int test_cipher_with_engine(void)
 # endif /* OPENSSL_NO_DYNAMIC_ENGINE */
 #endif /* OPENSSL_NO_DEPRECATED_3_0 */
 
+static int ecxnids[] = {
+    NID_X25519,
+    NID_X448,
+    NID_ED25519,
+    NID_ED448
+};
+
+/* Test that creating ECX keys with a short private key fails as expected */
+static int test_ecx_short_keys(int tst)
+{
+    unsigned char ecxkeydata = 1;
+    EVP_PKEY *pkey;
+
+
+    pkey = EVP_PKEY_new_raw_private_key(ecxnids[tst], NULL, &ecxkeydata, 1);
+    if (!TEST_ptr_null(pkey)) {
+        EVP_PKEY_free(pkey);
+        return 0;
+    }
+    return 1;
+}
+
 typedef enum OPTION_choice {
     OPT_ERR = -1,
     OPT_EOF = 0,
@@ -4343,6 +4365,8 @@ int setup_tests(void)
     }
 # endif
 #endif
+
+    ADD_ALL_TESTS(test_ecx_short_keys, OSSL_NELEM(ecxnids));
 
     return 1;
 }


### PR DESCRIPTION
If an ECX key is created and the private key is too short, a `fromdata`
call would create the key, and then later detect the error and report it
after freeing the key. However freeing the key was calling
`OPENSSL_secure_clear_free()` and assuming that the private key was of the
correct length. If it was actually too short this will write over memory
that it shouldn't.

Fixes #17017
