### PR TITLE
Make `ERR_str_reasons` in `err.c` consistent again with `err.h`

### DIFF
--- a/crypto/err/err.c
+++ b/crypto/err/err.c
@@ -80,6 +80,10 @@ static ERR_STRING_DATA ERR_str_libraries[] = {
     {0, NULL},
 };
 
+/*
+ * Should make sure that all ERR_R_ reasons defined in include/openssl/err.h.in
+ * are listed.  For maintainability, please keep all reasons in the same order.
+ */
 static ERR_STRING_DATA ERR_str_reasons[] = {
     {ERR_R_SYS_LIB, "system lib"},
     {ERR_R_BN_LIB, "BN lib"},
@@ -92,17 +96,16 @@ static ERR_STRING_DATA ERR_str_reasons[] = {
     {ERR_R_DSA_LIB, "DSA lib"},
     {ERR_R_X509_LIB, "X509 lib"},
     {ERR_R_ASN1_LIB, "ASN1 lib"},
+    {ERR_R_CRYPTO_LIB, "CRYPTO lib"},
     {ERR_R_EC_LIB, "EC lib"},
     {ERR_R_BIO_LIB, "BIO lib"},
     {ERR_R_PKCS7_LIB, "PKCS7 lib"},
     {ERR_R_X509V3_LIB, "X509V3 lib"},
     {ERR_R_ENGINE_LIB, "ENGINE lib"},
     {ERR_R_UI_LIB, "UI lib"},
-    {ERR_R_OSSL_STORE_LIB, "STORE lib"},
     {ERR_R_ECDSA_LIB, "ECDSA lib"},
-
-    {ERR_R_NESTED_ASN1_ERROR, "nested asn1 error"},
-    {ERR_R_MISSING_ASN1_EOS, "missing asn1 eos"},
+    {ERR_R_OSSL_STORE_LIB, "OSSL_STORE lib"},
+    {ERR_R_OSSL_DECODER_LIB, "OSSL_DECODER lib"},
 
     {ERR_R_FATAL, "fatal"},
     {ERR_R_MALLOC_FAILURE, "malloc failure"},
@@ -112,10 +115,12 @@ static ERR_STRING_DATA ERR_str_reasons[] = {
     {ERR_R_INTERNAL_ERROR, "internal error"},
     {ERR_R_DISABLED, "called a function that was disabled at compile-time"},
     {ERR_R_INIT_FAIL, "init fail"},
+    {ERR_R_PASSED_INVALID_ARGUMENT, "passed invalid argument"},
     {ERR_R_OPERATION_FAIL, "operation fail"},
     {ERR_R_INVALID_PROVIDER_FUNCTIONS, "invalid provider functions"},
     {ERR_R_INTERRUPTED_OR_CANCELLED, "interrupted or cancelled"},
-
+    {ERR_R_NESTED_ASN1_ERROR, "nested asn1 error"},
+    {ERR_R_MISSING_ASN1_EOS, "missing asn1 eos"},
     /*
      * Something is unsupported, exactly what is expressed with additional data
      */
@@ -125,7 +130,6 @@ static ERR_STRING_DATA ERR_str_reasons[] = {
      * unsupported.
      */
     {ERR_R_FETCH_FAILED, "fetch failed"},
-
     {ERR_R_INVALID_PROPERTY_DEFINITION, "invalid property definition"},
     {ERR_R_UNABLE_TO_GET_READ_LOCK, "unable to get read lock"},
     {ERR_R_UNABLE_TO_GET_WRITE_LOCK, "unable to get write lock"},

--- a/test/recipes/02-test_errstr.t
+++ b/test/recipes/02-test_errstr.t
@@ -139,7 +139,7 @@ sub match_opensslerr_reason {
     $reason =~ s|\R$||;
     $reason = ( split_error($reason) )[3];
 
-    return match_any($reason, $errcode, @strings);
+    return match_any($reason, $errcode_hex, @strings);
 }
 
 sub match_syserr_reason {


### PR DESCRIPTION
For various generic reason codes, their string conversion goes wrong, e.g.: 
```
    # 80B26552927F0000:error:1E8C0102:HTTP routines:foo:reason(786690):test/http_test.c:424:
    # 80B26552927F0000:error:1E880106:HTTP routines:foo:reason(524550):test/http_test.c:424:
```

I found that this is because some entries defined in `include/openssl/err.h{,in}` are missing from `ERR_str_reasons` in `crypto/err/err.c`
and that their order easily goes wrong there because they need to be sorted by _their numerical reason code **including** any flags_ such as `ERR_RFLAG_COMMON`. 

After fixing the entries, the above becomes:
```
    # 8032C819DE7F0000:error:1E8C0102:HTTP routines:foo:passed a null parameter:test/http_test.c:424:
    # 8032C819DE7F0000:error:1E880106:HTTP routines:foo:passed an invalid argument:test/http_test.c:424:
```
