### PR TITLE
Remove DB_ERROR_WRONG_NUM_FIELDS and ensure TXT_DB_read always prints a message for an error

### DIFF
--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -1632,8 +1632,10 @@ CA_DB *load_index(const char *dbfile, DB_ATTR *db_attr)
     }
 #endif
 
-    if ((tmpdb = TXT_DB_read(in, DB_NUMBER)) == NULL)
+    if ((tmpdb = TXT_DB_read(in, DB_NUMBER)) == NULL) {
+        BIO_printf(bio_err, "TXT_DB_read failed reading %s\n", dbfile);
         goto err;
+    }
 
 #ifndef OPENSSL_SYS_VMS
     BIO_snprintf(buf, sizeof(buf), "%s.attr", dbfile);

--- a/crypto/txt_db/txt_db.c
+++ b/crypto/txt_db/txt_db.c
@@ -105,7 +105,6 @@ TXT_DB *TXT_DB_read(BIO *in, int num)
         *(p++) = '\0';
         if ((n != num) || (*f != '\0')) {
             OPENSSL_free(pp);
-            ret->error = DB_ERROR_WRONG_NUM_FIELDS;
             goto err;
         }
         pp[n] = p;

--- a/include/openssl/txt_db.h
+++ b/include/openssl/txt_db.h
@@ -27,7 +27,6 @@
 # define DB_ERROR_INDEX_OUT_OF_RANGE     3
 # define DB_ERROR_NO_INDEX               4
 # define DB_ERROR_INSERT_INDEX_CLASH     5
-# define DB_ERROR_WRONG_NUM_FIELDS       6
 
 #ifdef  __cplusplus
 extern "C" {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

This makes two changes in related code for loading index.txt:
1. Removes the `DB_ERROR_WRONG_NUM_FIELDS` define which was never actually returned from `TXT_DB_read` (see commit message for details).
2. Makes sure that all failures in `load_index` print out an error message. The changes introduced in #15360 already ensure that all callers of `load_index` will also print out a message, this just adds another level of detail inside of load_index. Note: I'm not familiar with ERR_raise_data, so I did not follow that pattern that was used elsewhere in this function. Please feel free to further tweak or I'm happy to take suggestions to improve this.

An alternative to this PR is the work I first did in this branch: https://github.com/openssl/openssl/compare/master...deejgregor:fix-txt-db-read-failure-reporting?expand=1 . That, however, feels too verbose for the value added and it seems like a refactoring to use ERR_raise_data would be better to get that level of specificity of errors, and I'm not sure it is worth it for this code (and my lack of familiarity with ERR_raise_data would also make this more complex for me to complete). So, I instead propose the simpler solution in this PR.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
