### PR TITLE
HTTP client: v3.0 workaround for #16028 (`BIO_gets` not supported by connect and SSL BIOs)

### DIFF
--- a/crypto/http/http_client.c
+++ b/crypto/http/http_client.c
@@ -474,7 +474,7 @@ int OSSL_HTTP_REQ_CTX_nbio(OSSL_HTTP_REQ_CTX *rctx)
     long n;
     size_t resp_len;
     const unsigned char *p;
-    char *key, *value, *line_end = NULL;
+    char *buf, *key, *value, *line_end = NULL;
 
     if (rctx == NULL) {
         ERR_raise(ERR_LIB_HTTP, ERR_R_PASSED_NULL_PARAMETER);
@@ -487,11 +487,12 @@ int OSSL_HTTP_REQ_CTX_nbio(OSSL_HTTP_REQ_CTX *rctx)
 
     rctx->redirection_url = NULL;
  next_io:
+    buf = (char *)rctx->buf;
     if ((rctx->state & OHS_NOREAD) == 0) {
         if (rctx->expect_asn1)
             n = BIO_read(rctx->rbio, rctx->buf, rctx->buf_size);
-        else
-            n = BIO_gets(rctx->rbio, (char *)rctx->buf, rctx->buf_size);
+        else if ((n = BIO_gets(rctx->rbio, buf, rctx->buf_size)) == -2)
+            n = BIO_get_line(rctx->rbio, buf, rctx->buf_size);
         if (n <= 0) {
             if (BIO_should_retry(rctx->rbio))
                 return -1;
@@ -592,7 +593,7 @@ int OSSL_HTTP_REQ_CTX_nbio(OSSL_HTTP_REQ_CTX *rctx)
             }
             goto next_io;
         }
-        n = BIO_gets(rctx->mem, (char *)rctx->buf, rctx->buf_size);
+        n = BIO_gets(rctx->mem, buf, rctx->buf_size);
 
         if (n <= 0) {
             if (BIO_should_retry(rctx->mem))
@@ -610,7 +611,7 @@ int OSSL_HTTP_REQ_CTX_nbio(OSSL_HTTP_REQ_CTX *rctx)
 
         /* First line */
         if (rctx->state == OHS_FIRSTLINE) {
-            switch (parse_http_line1((char *)rctx->buf, &found_keep_alive)) {
+            switch (parse_http_line1(buf, &found_keep_alive)) {
             case HTTP_STATUS_CODE_OK:
                 rctx->state = OHS_HEADERS;
                 goto next_line;
@@ -628,7 +629,7 @@ int OSSL_HTTP_REQ_CTX_nbio(OSSL_HTTP_REQ_CTX *rctx)
                 return 0;
             }
         }
-        key = (char *)rctx->buf;
+        key = buf;
         value = strchr(key, ':');
         if (value != NULL) {
             *(value++) = '\0';


### PR DESCRIPTION
This uses `BIO_get_line()` as a workaround in version 3.0 for
* connect BIOs not supporting `BIO_read()` (#16028) before 3.1
* SSL BIOs not supporting `BIO_read()`, which will likely be the case also beyond 3.0.

With this fix, the HTTP client can be used for getting via sockets not only ASN.1-encoded contents, but also other types of contents, including plan text and HTML.
