### PR TITLE
ERR: exempt flags from fallback decimal reason code printing

### DIFF
--- a/crypto/err/err.c
+++ b/crypto/err/err.c
@@ -527,7 +527,8 @@ void ossl_err_string_int(unsigned long e, const char *func,
     }
 #endif
     if (rs == NULL) {
-        BIO_snprintf(rsbuf, sizeof(rsbuf), "reason(%lu)", r);
+        BIO_snprintf(rsbuf, sizeof(rsbuf), "reason(%lu)",
+                     r & ~(ERR_RFLAGS_MASK << ERR_RFLAGS_OFFSET));
         rs = rsbuf;
     }
 


### PR DESCRIPTION
Extracted from #17056 as discussed there.

This exempts flags from the fallback decimal reason code printing,
such that, e.g., `reason(524550)` becomes `reason(262)`, which I consider much more readable/helpful.