### PR TITLE
Make OSSL_PARAM_BLD_push_BN{,_pad}() return an error on negative numbers

### DIFF
--- a/crypto/param_build.c
+++ b/crypto/param_build.c
@@ -204,6 +204,12 @@ int OSSL_PARAM_BLD_push_BN_pad(OSSL_PARAM_BLD *bld, const char *key,
     OSSL_PARAM_BLD_DEF *pd;
 
     if (bn != NULL) {
+        if (BN_is_negative(bn)) {
+            ERR_raise_data(ERR_LIB_CRYPTO, ERR_R_UNSUPPORTED,
+                           "Negative big numbers are unsupported for OSSL_PARAM");
+            return 0;
+        }
+
         n = BN_num_bytes(bn);
         if (n < 0) {
             ERR_raise(ERR_LIB_CRYPTO, CRYPTO_R_ZERO_LENGTH_NUMBER);

--- a/doc/man3/OSSL_PARAM_BLD.pod
+++ b/doc/man3/OSSL_PARAM_BLD.pod
@@ -124,6 +124,11 @@ on error.
 All of the OSSL_PARAM_BLD_push_TYPE functions return 1 on success and 0
 on error.
 
+=head1 NOTES
+
+OSSL_PARAM_BLD_push_BN() and OSSL_PARAM_BLD_push_BN_pad() currently only
+support non-negative B<BIGNUM>s.  They return an error on negative B<BIGNUM>s.
+
 =head1 EXAMPLES
 
 Both examples creating an OSSL_PARAM array that contains an RSA key.

--- a/doc/man3/OSSL_PARAM_BLD.pod
+++ b/doc/man3/OSSL_PARAM_BLD.pod
@@ -127,7 +127,7 @@ on error.
 =head1 NOTES
 
 OSSL_PARAM_BLD_push_BN() and OSSL_PARAM_BLD_push_BN_pad() currently only
-support non-negative B<BIGNUM>s.  They return an error on negative B<BIGNUM>s.
+support nonnegative B<BIGNUM>s.  They return an error on negative B<BIGNUM>s.
 
 =head1 EXAMPLES
 

--- a/doc/man3/OSSL_PARAM_int.pod
+++ b/doc/man3/OSSL_PARAM_int.pod
@@ -331,6 +331,12 @@ representable by the target type or parameter.
 Apart from that, the functions must be used appropriately for the
 expected type of the parameter.
 
+OSSL_PARAM_get_BN() and OSSL_PARAM_set_BN() currently only support
+nonnegative B<BIGNUM>s, and by consequence, only
+B<OSSL_PARAM_UNSIGNED_INTEGER>.  OSSL_PARAM_construct_BN() currently
+constructs an B<OSSL_PARAM> structure with the data type
+B<OSSL_PARAM_UNSIGNED_INTEGER>.
+
 For OSSL_PARAM_construct_utf8_ptr() and OSSL_PARAM_consstruct_octet_ptr(),
 I<bsize> is not relevant if the purpose is to send the B<OSSL_PARAM> array
 to a I<responder>, i.e. to get parameter data back.


### PR DESCRIPTION
Adding documentation to that fact as well.

Fixes #17070
