### PR TITLE
Add a test case for duplicate engine loading

### DIFF
--- a/test/data.bin
+++ b/test/data.bin
@@ -1,0 +1,4 @@
+TEST DATA
+
+Please note that if a test involves a new testing executable,
+you will need to do some additions in test/build.info.

--- a/test/recipes/20-test_dgst.t
+++ b/test/recipes/20-test_dgst.t
@@ -11,12 +11,12 @@ use strict;
 use warnings;
 
 use File::Spec;
-use OpenSSL::Test qw/:DEFAULT with srctop_file/;
+use OpenSSL::Test qw/:DEFAULT with srctop_file bldtop_file/;
 use OpenSSL::Test::Utils;
 
 setup("test_dgst");
 
-plan tests => 5;
+plan tests => 6;
 
 sub tsignverify {
     my $testtext = shift;
@@ -101,4 +101,23 @@ SKIP: {
                     srctop_file("test","tested448.pem"),
                     srctop_file("test","tested448pub.pem"));
     };
+}
+
+SKIP: {
+    skip "dgst with engine is not supported by this OpenSSL build", 1
+        if disabled("engine") || disabled("dynamic-engine");
+
+    subtest "SHA1 generation by engine with `dgst` CLI" => sub {
+        plan tests => 1;
+
+        my $testdata = srctop_file('test', 'data.bin');
+        # intentionally using -engine twice, please do not remove the duplicate line
+        my @macdata = run(app(['openssl', 'dgst', '-sha1',
+                               '-engine', $^O eq 'linux' ? bldtop_file("engines", "ossltest.so") : "ossltest",
+                               '-engine', $^O eq 'linux' ? bldtop_file("engines", "ossltest.so") : "ossltest",
+                               $testdata]), capture => 1);
+        chomp(@macdata);
+        my $expected = qr/SHA1\(\Q$testdata\E\)= 000102030405060708090a0b0c0d0e0f10111213/;
+        ok($macdata[0] =~ $expected, "SHA1: Check HASH value is as expected ($macdata[0]) vs ($expected)");
+    }
 }


### PR DESCRIPTION
This is just the test case from #17073 ported to 1.1.1,
The fixing part of #17073 cherry-picks cleanly, just the test
case had a non-tivial merge conflict.
It is expected that the CI will fail, that will be fixed when #17073
is merged.