### PR TITLE
HTTP client: simplify and improve HTTP(S) proxy support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -370,6 +370,14 @@ OpenSSL Releases
 
    *David von Oheimb*
 
+ * Streamlined the workaround for the connection callback function of type
+   `OSSL_HTTP_bio_cb_t` not having a `OSSL_HTTP_REQ_CTX *` parameter,
+   by adding `OSSL_HTTP_REQ_CTX_proxy_connect()` called on SSL/TLS connect.
+
+   This work was sponsored by Siemens AG.
+
+   *David von Oheimb*
+
  * Added support for RFC 8701 GREASE (Generate Random Extensions And Sustain
    Extensibility). When `SSL_OP_GREASE` is set, the TLS client injects
    reserved GREASE values into cipher suites, supported versions, supported

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -243,6 +243,14 @@ OpenSSL Releases
 
    *David von Oheimb*
 
+ * Streamlined the workaround for the connection callback function of type
+   `OSSL_HTTP_bio_cb_t` not having a `OSSL_HTTP_REQ_CTX *` parameter,
+   by adding `OSSL_HTTP_REQ_CTX_proxy_connect()` called on SSL/TLS connect.
+
+   This work was sponsored by Siemens AG.
+
+   *David von Oheimb*
+
  * Added support for RFC 8701 GREASE (Generate Random Extensions And Sustain
    Extensibility). When `SSL_OP_GREASE` is set, the TLS client injects
    reserved GREASE values into cipher suites, supported versions, supported

--- a/apps/cmp.c
+++ b/apps/cmp.c
@@ -1499,6 +1499,7 @@ static SSL_CTX *setup_ssl_ctx(OSSL_CMP_CTX *ctx, const char *host)
     EVP_PKEY *pkey = NULL;
     X509_STORE *trust_store = NULL;
     SSL_CTX *ssl_ctx;
+    char *host_copy;
     int i;
 
     ssl_ctx = SSL_CTX_new(TLS_client_method());
@@ -1634,12 +1635,18 @@ static SSL_CTX *setup_ssl_ctx(OSSL_CMP_CTX *ctx, const char *host)
         if (!truststore_set_host_etc(trust_store, host))
             goto err;
     }
+    if ((host_copy = OPENSSL_strdup(host)) == NULL)
+        goto err;
+    if (!app_SSL_CTX_set_tls_server_ex_data(ssl_ctx, host_copy)) {
+        OPENSSL_free(host_copy);
+        goto err;
+    }
     return ssl_ctx;
 err:
     SSL_CTX_free(ssl_ctx);
     return NULL;
 }
-#endif /* OPENSSL_NO_SOCK */
+#endif
 
 /*
  * set up protection aspects of OSSL_CMP_CTX based on options from config
@@ -2399,7 +2406,7 @@ set_path:
 
 #if !defined(OPENSSL_NO_SOCK) && !defined(OPENSSL_NO_HTTP)
     if (opt_tls_used) {
-        APP_HTTP_TLS_INFO *info;
+        SSL_CTX *ssl_ctx, *old_ssl_ctx;
 
         if (opt_tls_cert != NULL
             || opt_tls_key != NULL || opt_tls_keypass != NULL) {
@@ -2412,21 +2419,14 @@ set_path:
             }
         }
 
-        if ((info = OPENSSL_zalloc(sizeof(*info))) == NULL)
+        if ((ssl_ctx = setup_ssl_ctx(ctx, host)) == NULL)
             goto err;
-        APP_HTTP_TLS_INFO_free(OSSL_CMP_CTX_get_http_cb_arg(ctx));
-        (void)OSSL_CMP_CTX_set_http_cb_arg(ctx, info);
-        info->ssl_ctx = setup_ssl_ctx(ctx, opt_tls_host != NULL ? opt_tls_host : host);
-        info->server = host;
-        host = NULL; /* ownership has been transferred to info structure */
-        if ((info->port = OPENSSL_strdup(server_port)) == NULL)
-            goto err;
-        /* workaround for callback design flaw, see #17088: */
-        info->use_proxy = proxy_host != NULL;
-        info->timeout = OSSL_CMP_CTX_get_option(ctx, OSSL_CMP_OPT_MSG_TIMEOUT);
-
-        if (info->ssl_ctx == NULL)
-            goto err;
+        old_ssl_ctx = OSSL_CMP_CTX_get_http_cb_arg(ctx);
+        if (old_ssl_ctx != NULL) {
+            OPENSSL_free(app_SSL_CTX_get_tls_server_ex_data(old_ssl_ctx));
+            SSL_CTX_free(old_ssl_ctx);
+        }
+        (void)OSSL_CMP_CTX_set_http_cb_arg(ctx, ssl_ctx);
         (void)OSSL_CMP_CTX_set_http_cb(ctx, app_http_tls_cb);
     }
 #endif
@@ -4044,16 +4044,18 @@ err:
 
     if (cmp_ctx != NULL) {
 #if !defined(OPENSSL_NO_SOCK) && !defined(OPENSSL_NO_HTTP)
-        APP_HTTP_TLS_INFO *info = OSSL_CMP_CTX_get_http_cb_arg(cmp_ctx);
+        SSL_CTX *ssl_ctx = OSSL_CMP_CTX_get_http_cb_arg(cmp_ctx);
 
-        (void)OSSL_CMP_CTX_set_http_cb_arg(cmp_ctx, NULL);
 #endif
         ossl_cmp_mock_srv_free(OSSL_CMP_CTX_get_transfer_cb_arg(cmp_ctx));
         X509_STORE_free(OSSL_CMP_CTX_get_certConf_cb_arg(cmp_ctx));
-        /* cannot free info already here, as it may be used indirectly by: */
+        /* cannot free ssl_ctx already above, as it may be used in OSSL_HTTP_close() called by: */
         OSSL_CMP_CTX_free(cmp_ctx);
 #if !defined(OPENSSL_NO_SOCK) && !defined(OPENSSL_NO_HTTP)
-        APP_HTTP_TLS_INFO_free(info);
+        if (ssl_ctx != NULL) {
+            OPENSSL_free(app_SSL_CTX_get_tls_server_ex_data(ssl_ctx));
+            SSL_CTX_free(ssl_ctx);
+        }
 #endif
     }
     X509_VERIFY_PARAM_free(vpm);

--- a/apps/cmp.c
+++ b/apps/cmp.c
@@ -2271,7 +2271,7 @@ static int setup_client_ctx(OSSL_CMP_CTX *ctx)
 #if !defined(OPENSSL_NO_SOCK) && !defined(OPENSSL_NO_HTTP)
     int portnum, use_ssl;
     static char server_port[32] = { '\0' };
-    const char *proxy_host = NULL;
+    const char *proxy, *proxy_host;
 #endif
     char server_buf[200] = "mock server";
     char proxy_buf[200] = "";
@@ -2323,9 +2323,16 @@ static int setup_client_ctx(OSSL_CMP_CTX *ctx)
         opt_tls_used ? "s" : "", host, port,
         *used_path == '/' ? used_path + 1 : used_path);
 
-    proxy_host = OSSL_HTTP_adapt_proxy(opt_proxy, opt_no_proxy, host, use_ssl);
-    if (proxy_host != NULL)
+    proxy = OSSL_HTTP_adapt_proxy(opt_proxy, opt_no_proxy, host, opt_tls_used);
+    if (proxy != NULL) {
+        /* show proxy without any given user:pass@ prefix */
+        proxy_host = strchr(proxy, '@');
+        if (proxy_host == NULL)
+            proxy_host = proxy;
+        else
+            proxy_host++;
         (void)BIO_snprintf(proxy_buf, sizeof(proxy_buf), " via %s", proxy_host);
+    }
 
 set_path:
 #endif

--- a/apps/cmp.c
+++ b/apps/cmp.c
@@ -2272,7 +2272,7 @@ static int setup_client_ctx(OSSL_CMP_CTX *ctx)
 #if !defined(OPENSSL_NO_SOCK) && !defined(OPENSSL_NO_HTTP)
     int portnum, use_ssl;
     static char server_port[32] = { '\0' };
-    const char *proxy_host = NULL;
+    const char *proxy, *proxy_host;
 #endif
     char server_buf[200] = "mock server";
     char proxy_buf[200] = "";
@@ -2324,9 +2324,16 @@ static int setup_client_ctx(OSSL_CMP_CTX *ctx)
         opt_tls_used ? "s" : "", host, port,
         *used_path == '/' ? used_path + 1 : used_path);
 
-    proxy_host = OSSL_HTTP_adapt_proxy(opt_proxy, opt_no_proxy, host, use_ssl);
-    if (proxy_host != NULL)
+    proxy = OSSL_HTTP_adapt_proxy(opt_proxy, opt_no_proxy, host, opt_tls_used);
+    if (proxy != NULL) {
+        /* show proxy without any given user:pass@ prefix */
+        proxy_host = strchr(proxy, '@');
+        if (proxy_host == NULL)
+            proxy_host = proxy;
+        else
+            proxy_host++;
         (void)snprintf(proxy_buf, sizeof(proxy_buf), " via %s", proxy_host);
+    }
 
 set_path:
 #endif

--- a/apps/cmp.c
+++ b/apps/cmp.c
@@ -1498,6 +1498,7 @@ static SSL_CTX *setup_ssl_ctx(OSSL_CMP_CTX *ctx, const char *host)
     EVP_PKEY *pkey = NULL;
     X509_STORE *trust_store = NULL;
     SSL_CTX *ssl_ctx;
+    char *host_copy;
     int i;
 
     ssl_ctx = SSL_CTX_new(TLS_client_method());
@@ -1633,12 +1634,18 @@ static SSL_CTX *setup_ssl_ctx(OSSL_CMP_CTX *ctx, const char *host)
         if (!truststore_set_host_etc(trust_store, host))
             goto err;
     }
+    if ((host_copy = OPENSSL_strdup(host)) == NULL)
+        goto err;
+    if (!app_SSL_CTX_set_tls_server_ex_data(ssl_ctx, host_copy)) {
+        OPENSSL_free(host_copy);
+        goto err;
+    }
     return ssl_ctx;
 err:
     SSL_CTX_free(ssl_ctx);
     return NULL;
 }
-#endif /* OPENSSL_NO_SOCK */
+#endif
 
 /*
  * set up protection aspects of OSSL_CMP_CTX based on options from config
@@ -2398,7 +2405,7 @@ set_path:
 
 #if !defined(OPENSSL_NO_SOCK) && !defined(OPENSSL_NO_HTTP)
     if (opt_tls_used) {
-        APP_HTTP_TLS_INFO *info;
+        SSL_CTX *ssl_ctx, *old_ssl_ctx;
 
         if (opt_tls_cert != NULL
             || opt_tls_key != NULL || opt_tls_keypass != NULL) {
@@ -2411,21 +2418,14 @@ set_path:
             }
         }
 
-        if ((info = OPENSSL_zalloc(sizeof(*info))) == NULL)
+        if ((ssl_ctx = setup_ssl_ctx(ctx, host)) == NULL)
             goto err;
-        APP_HTTP_TLS_INFO_free(OSSL_CMP_CTX_get_http_cb_arg(ctx));
-        (void)OSSL_CMP_CTX_set_http_cb_arg(ctx, info);
-        info->ssl_ctx = setup_ssl_ctx(ctx, opt_tls_host != NULL ? opt_tls_host : host);
-        info->server = host;
-        host = NULL; /* ownership has been transferred to info structure */
-        if ((info->port = OPENSSL_strdup(server_port)) == NULL)
-            goto err;
-        /* workaround for callback design flaw, see #17088: */
-        info->use_proxy = proxy_host != NULL;
-        info->timeout = OSSL_CMP_CTX_get_option(ctx, OSSL_CMP_OPT_MSG_TIMEOUT);
-
-        if (info->ssl_ctx == NULL)
-            goto err;
+        old_ssl_ctx = OSSL_CMP_CTX_get_http_cb_arg(ctx);
+        if (old_ssl_ctx != NULL) {
+            OPENSSL_free(app_SSL_CTX_get_tls_server_ex_data(old_ssl_ctx));
+            SSL_CTX_free(old_ssl_ctx);
+        }
+        (void)OSSL_CMP_CTX_set_http_cb_arg(ctx, ssl_ctx);
         (void)OSSL_CMP_CTX_set_http_cb(ctx, app_http_tls_cb);
     }
 #endif
@@ -4039,16 +4039,18 @@ err:
 
     if (cmp_ctx != NULL) {
 #if !defined(OPENSSL_NO_SOCK) && !defined(OPENSSL_NO_HTTP)
-        APP_HTTP_TLS_INFO *info = OSSL_CMP_CTX_get_http_cb_arg(cmp_ctx);
+        SSL_CTX *ssl_ctx = OSSL_CMP_CTX_get_http_cb_arg(cmp_ctx);
 
-        (void)OSSL_CMP_CTX_set_http_cb_arg(cmp_ctx, NULL);
 #endif
         ossl_cmp_mock_srv_free(OSSL_CMP_CTX_get_transfer_cb_arg(cmp_ctx));
         X509_STORE_free(OSSL_CMP_CTX_get_certConf_cb_arg(cmp_ctx));
-        /* cannot free info already here, as it may be used indirectly by: */
+        /* cannot free ssl_ctx already above, as it may be used in OSSL_HTTP_close() called by: */
         OSSL_CMP_CTX_free(cmp_ctx);
 #if !defined(OPENSSL_NO_SOCK) && !defined(OPENSSL_NO_HTTP)
-        APP_HTTP_TLS_INFO_free(info);
+        if (ssl_ctx != NULL) {
+            OPENSSL_free(app_SSL_CTX_get_tls_server_ex_data(ssl_ctx));
+            SSL_CTX_free(ssl_ctx);
+        }
 #endif
     }
     X509_VERIFY_PARAM_free(vpm);

--- a/apps/include/apps.h
+++ b/apps/include/apps.h
@@ -325,17 +325,20 @@ void store_setup_crl_download(X509_STORE *st);
 
 int host_is_ip_address(const char *host);
 
-typedef struct app_http_tls_info_st {
-    const char *server;
-    const char *port;
-    int use_proxy;
-    long timeout;
-    SSL_CTX *ssl_ctx;
-} APP_HTTP_TLS_INFO;
-BIO *app_http_tls_cb(BIO *hbio, /* APP_HTTP_TLS_INFO */ void *arg,
-    int connect, int detail);
-void APP_HTTP_TLS_INFO_free(APP_HTTP_TLS_INFO *info);
-#ifndef OPENSSL_NO_SOCK
+#if !defined(OPENSSL_NO_SOCK) && !defined(OPENSSL_NO_HTTP)
+/*
+ * Note on function argument ownership and lifetime:
+ * - app_SSL_CTX_set_tls_server_ex_data() does NOT transfer ownership of
+ *   |host| to |ssl_ctx|. The caller must ensure that |host| remains valid
+ *   for as long as it may be accessed via |ssl_ctx| and is responsible for
+ *   freeing it when no longer needed.
+ * - app_SSL_CTX_get_tls_server_ex_data() returns a non-owning pointer.
+ *   Callers must not free the returned pointer unless they also own it via
+ *   other means and have ensured it is no longer used by |ssl_ctx|.
+ */
+int app_SSL_CTX_set_tls_server_ex_data(SSL_CTX *ssl_ctx, const char *host);
+char *app_SSL_CTX_get_tls_server_ex_data(SSL_CTX *ssl_ctx);
+BIO *app_http_tls_cb(BIO *hbio, /* SSL_CTX */ void *arg, int connect, int detail);
 ASN1_VALUE *app_http_get_asn1(const char *url, const char *proxy,
     const char *no_proxy, SSL_CTX *ssl_ctx,
     const STACK_OF(CONF_VALUE) *headers,

--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -2979,36 +2979,54 @@ static BIO *http_tls_shutdown(BIO *bio)
     return bio;
 }
 
+static int app_tls_server_ex_data_idx = -1;
+int app_SSL_CTX_set_tls_server_ex_data(SSL_CTX *ssl_ctx, const char *host)
+{
+    if (app_tls_server_ex_data_idx == -1
+        && (app_tls_server_ex_data_idx = SSL_CTX_get_ex_new_index(0, NULL, NULL, NULL, NULL)) == -1)
+        return 0;
+    if (ssl_ctx == NULL) {
+        BIO_printf(bio_err, "Internal app error: called app_SSL_CTX_set_tls_server_ex_data() with NULL argument\n");
+        return 0;
+    }
+    return SSL_CTX_set_ex_data(ssl_ctx, app_tls_server_ex_data_idx, (void *)host);
+}
+
+char *app_SSL_CTX_get_tls_server_ex_data(SSL_CTX *ssl_ctx)
+{
+    if (ssl_ctx == NULL || app_tls_server_ex_data_idx < 0) {
+        BIO_printf(bio_err, "Internal app error: called app_SSL_CTX_get_tls_server_ex_data() with NULL argument or without calling app_SSL_CTX_set_tls_server_ex_data() before\n");
+        return NULL;
+    }
+    return SSL_CTX_get_ex_data(ssl_ctx, app_tls_server_ex_data_idx);
+}
+
 /* HTTP callback function that supports TLS connection also via HTTPS proxy */
 BIO *app_http_tls_cb(BIO *bio, void *arg, int connect, int detail)
 {
-    APP_HTTP_TLS_INFO *info = (APP_HTTP_TLS_INFO *)arg;
-    SSL_CTX *ssl_ctx = info->ssl_ctx;
     BIO *sbio = NULL;
+    SSL_CTX *ssl_ctx = (SSL_CTX *)arg;
 
     if (ssl_ctx == NULL) /* not using TLS */
         return bio;
+    if (app_tls_server_ex_data_idx < 0) {
+        BIO_printf(bio_err, "Internal app error: should have successfully called app_SSL_CTX_set_tls_server_ex_data() before\n");
+        return NULL;
+    }
+
     if (connect) {
         SSL *ssl;
+        const char *server = SSL_CTX_get_ex_data(ssl_ctx, app_tls_server_ex_data_idx);
 
-        /* adapt after fixing callback design flaw, see #17088 */
-        if ((info->use_proxy
-                && !OSSL_HTTP_proxy_connect(bio, info->server, info->port,
-                    NULL, NULL, /* no proxy credentials */
-                    info->timeout, bio_err, opt_getprog()))
-            || (sbio = BIO_new(BIO_f_ssl())) == NULL) {
+        if ((sbio = BIO_new(BIO_f_ssl())) == NULL)
             return NULL;
-        }
         if ((ssl = SSL_new(ssl_ctx)) == NULL)
             goto err;
 
         SSL_set_connect_state(ssl);
-        if (BIO_set_ssl(sbio, ssl, BIO_CLOSE) <= 0) {
-            SSL_free(ssl);
-            goto err;
-        }
-        if (!host_is_ip_address(info->server)) {
-            if (!SSL_set_tlsext_host_name(ssl, info->server)) /* set SNI */
+        BIO_set_ssl(sbio, ssl, BIO_CLOSE);
+        if (!host_is_ip_address(server)) { /* server may be NULL */
+            if (!SSL_set_tlsext_host_name(ssl, server)) /* set SNI */
                 goto err;
         }
 
@@ -3023,23 +3041,12 @@ err:
     return NULL;
 }
 
-void APP_HTTP_TLS_INFO_free(APP_HTTP_TLS_INFO *info)
-{
-    if (info != NULL) {
-        OPENSSL_free((char *)info->server);
-        OPENSSL_free((char *)info->port);
-        SSL_CTX_free(info->ssl_ctx);
-        OPENSSL_free(info);
-    }
-}
-
 ASN1_VALUE *app_http_get_asn1(const char *url, const char *proxy,
     const char *no_proxy, SSL_CTX *ssl_ctx,
     const STACK_OF(CONF_VALUE) *headers,
     long timeout, const char *expected_content_type,
     const ASN1_ITEM *it)
 {
-    APP_HTTP_TLS_INFO info;
     char *server;
     char *port;
     int use_ssl;
@@ -3054,10 +3061,13 @@ ASN1_VALUE *app_http_get_asn1(const char *url, const char *proxy,
     if (!OSSL_HTTP_parse_url(url, &use_ssl, NULL /* userinfo */, &server, &port,
             NULL /* port_num, */, NULL, NULL, NULL))
         return NULL;
-    if (use_ssl && ssl_ctx == NULL) {
-        ERR_raise_data(ERR_LIB_HTTP, ERR_R_PASSED_NULL_PARAMETER,
-            "missing SSL_CTX");
-        goto end;
+    if (use_ssl) {
+        if (ssl_ctx == NULL) {
+            ERR_raise_data(ERR_LIB_HTTP, ERR_R_PASSED_NULL_PARAMETER, "missing SSL_CTX");
+            goto end;
+        }
+        if (!app_SSL_CTX_set_tls_server_ex_data(ssl_ctx, server))
+            goto end;
     }
     if (!use_ssl && ssl_ctx != NULL) {
         ERR_raise_data(ERR_LIB_HTTP, ERR_R_PASSED_INVALID_ARGUMENT,
@@ -3065,14 +3075,8 @@ ASN1_VALUE *app_http_get_asn1(const char *url, const char *proxy,
         goto end;
     }
 
-    info.server = server;
-    info.port = port;
-    info.use_proxy = /* workaround for callback design flaw, see #17088 */
-        OSSL_HTTP_adapt_proxy(proxy, no_proxy, server, use_ssl) != NULL;
-    info.timeout = timeout;
-    info.ssl_ctx = ssl_ctx;
     mem = OSSL_HTTP_get(url, proxy, no_proxy, NULL /* bio */, NULL /* rbio */,
-        app_http_tls_cb, &info, 0 /* buf_size */, headers,
+        app_http_tls_cb, ssl_ctx, 0 /* buf_size */, headers,
         expected_content_type, 1 /* expect_asn1 */,
         OSSL_HTTP_DEFAULT_MAX_RESP_LEN, timeout);
     resp = ASN1_item_d2i_bio(it, mem, NULL);
@@ -3093,23 +3097,17 @@ ASN1_VALUE *app_http_post_asn1(const char *host, const char *port,
     const char *expected_content_type,
     long timeout, const ASN1_ITEM *rsp_it)
 {
-    int use_ssl = ssl_ctx != NULL;
-    APP_HTTP_TLS_INFO info;
-    BIO *rsp, *req_mem = ASN1_item_i2d_mem_bio(req_it, req);
+    BIO *rsp, *req_mem;
     ASN1_VALUE *res;
 
-    if (req_mem == NULL)
+    if (ssl_ctx != NULL && !app_SSL_CTX_set_tls_server_ex_data(ssl_ctx, host))
+        return NULL;
+    if ((req_mem = ASN1_item_i2d_mem_bio(req_it, req)) == NULL)
         return NULL;
 
-    info.server = host;
-    info.port = port;
-    info.use_proxy = /* workaround for callback design flaw, see #17088 */
-        OSSL_HTTP_adapt_proxy(proxy, no_proxy, host, use_ssl) != NULL;
-    info.timeout = timeout;
-    info.ssl_ctx = ssl_ctx;
-    rsp = OSSL_HTTP_transfer(NULL, host, port, path, use_ssl,
+    rsp = OSSL_HTTP_transfer(NULL, host, port, path, ssl_ctx != NULL,
         proxy, no_proxy, NULL /* bio */, NULL /* rbio */,
-        app_http_tls_cb, &info,
+        app_http_tls_cb, ssl_ctx,
         0 /* buf_size */, headers, content_type, req_mem,
         expected_content_type, 1 /* expect_asn1 */,
         OSSL_HTTP_DEFAULT_MAX_RESP_LEN, timeout,

--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -2980,36 +2980,54 @@ static BIO *http_tls_shutdown(BIO *bio)
     return bio;
 }
 
+static int app_tls_server_ex_data_idx = -1;
+int app_SSL_CTX_set_tls_server_ex_data(SSL_CTX *ssl_ctx, const char *host)
+{
+    if (app_tls_server_ex_data_idx == -1
+        && (app_tls_server_ex_data_idx = SSL_CTX_get_ex_new_index(0, NULL, NULL, NULL, NULL)) == -1)
+        return 0;
+    if (ssl_ctx == NULL) {
+        BIO_printf(bio_err, "Internal app error: called app_SSL_CTX_set_tls_server_ex_data() with NULL argument\n");
+        return 0;
+    }
+    return SSL_CTX_set_ex_data(ssl_ctx, app_tls_server_ex_data_idx, (void *)host);
+}
+
+char *app_SSL_CTX_get_tls_server_ex_data(SSL_CTX *ssl_ctx)
+{
+    if (ssl_ctx == NULL || app_tls_server_ex_data_idx < 0) {
+        BIO_printf(bio_err, "Internal app error: called app_SSL_CTX_get_tls_server_ex_data() with NULL argument or without calling app_SSL_CTX_set_tls_server_ex_data() before\n");
+        return NULL;
+    }
+    return SSL_CTX_get_ex_data(ssl_ctx, app_tls_server_ex_data_idx);
+}
+
 /* HTTP callback function that supports TLS connection also via HTTPS proxy */
 BIO *app_http_tls_cb(BIO *bio, void *arg, int connect, int detail)
 {
-    APP_HTTP_TLS_INFO *info = (APP_HTTP_TLS_INFO *)arg;
-    SSL_CTX *ssl_ctx = info->ssl_ctx;
     BIO *sbio = NULL;
+    SSL_CTX *ssl_ctx = (SSL_CTX *)arg;
 
     if (ssl_ctx == NULL) /* not using TLS */
         return bio;
+    if (app_tls_server_ex_data_idx < 0) {
+        BIO_printf(bio_err, "Internal app error: should have successfully called app_SSL_CTX_set_tls_server_ex_data() before\n");
+        return NULL;
+    }
+
     if (connect) {
         SSL *ssl;
+        const char *server = SSL_CTX_get_ex_data(ssl_ctx, app_tls_server_ex_data_idx);
 
-        /* adapt after fixing callback design flaw, see #17088 */
-        if ((info->use_proxy
-                && !OSSL_HTTP_proxy_connect(bio, info->server, info->port,
-                    NULL, NULL, /* no proxy credentials */
-                    info->timeout, bio_err, opt_getprog()))
-            || (sbio = BIO_new(BIO_f_ssl())) == NULL) {
+        if ((sbio = BIO_new(BIO_f_ssl())) == NULL)
             return NULL;
-        }
         if ((ssl = SSL_new(ssl_ctx)) == NULL)
             goto err;
 
         SSL_set_connect_state(ssl);
-        if (BIO_set_ssl(sbio, ssl, BIO_CLOSE) <= 0) {
-            SSL_free(ssl);
-            goto err;
-        }
-        if (!host_is_ip_address(info->server)) {
-            if (!SSL_set_tlsext_host_name(ssl, info->server)) /* set SNI */
+        BIO_set_ssl(sbio, ssl, BIO_CLOSE);
+        if (!host_is_ip_address(server)) { /* server may be NULL */
+            if (!SSL_set_tlsext_host_name(ssl, server)) /* set SNI */
                 goto err;
         }
 
@@ -3024,23 +3042,12 @@ err:
     return NULL;
 }
 
-void APP_HTTP_TLS_INFO_free(APP_HTTP_TLS_INFO *info)
-{
-    if (info != NULL) {
-        OPENSSL_free((char *)info->server);
-        OPENSSL_free((char *)info->port);
-        SSL_CTX_free(info->ssl_ctx);
-        OPENSSL_free(info);
-    }
-}
-
 ASN1_VALUE *app_http_get_asn1(const char *url, const char *proxy,
     const char *no_proxy, SSL_CTX *ssl_ctx,
     const STACK_OF(CONF_VALUE) *headers,
     long timeout, const char *expected_content_type,
     const ASN1_ITEM *it)
 {
-    APP_HTTP_TLS_INFO info;
     char *server;
     char *port;
     int use_ssl;
@@ -3055,10 +3062,13 @@ ASN1_VALUE *app_http_get_asn1(const char *url, const char *proxy,
     if (!OSSL_HTTP_parse_url(url, &use_ssl, NULL /* userinfo */, &server, &port,
             NULL /* port_num, */, NULL, NULL, NULL))
         return NULL;
-    if (use_ssl && ssl_ctx == NULL) {
-        ERR_raise_data(ERR_LIB_HTTP, ERR_R_PASSED_NULL_PARAMETER,
-            "missing SSL_CTX");
-        goto end;
+    if (use_ssl) {
+        if (ssl_ctx == NULL) {
+            ERR_raise_data(ERR_LIB_HTTP, ERR_R_PASSED_NULL_PARAMETER, "missing SSL_CTX");
+            goto end;
+        }
+        if (!app_SSL_CTX_set_tls_server_ex_data(ssl_ctx, server))
+            goto end;
     }
     if (!use_ssl && ssl_ctx != NULL) {
         ERR_raise_data(ERR_LIB_HTTP, ERR_R_PASSED_INVALID_ARGUMENT,
@@ -3066,14 +3076,8 @@ ASN1_VALUE *app_http_get_asn1(const char *url, const char *proxy,
         goto end;
     }
 
-    info.server = server;
-    info.port = port;
-    info.use_proxy = /* workaround for callback design flaw, see #17088 */
-        OSSL_HTTP_adapt_proxy(proxy, no_proxy, server, use_ssl) != NULL;
-    info.timeout = timeout;
-    info.ssl_ctx = ssl_ctx;
     mem = OSSL_HTTP_get(url, proxy, no_proxy, NULL /* bio */, NULL /* rbio */,
-        app_http_tls_cb, &info, 0 /* buf_size */, headers,
+        app_http_tls_cb, ssl_ctx, 0 /* buf_size */, headers,
         expected_content_type, 1 /* expect_asn1 */,
         OSSL_HTTP_DEFAULT_MAX_RESP_LEN, timeout);
     resp = ASN1_item_d2i_bio(it, mem, NULL);
@@ -3094,23 +3098,17 @@ ASN1_VALUE *app_http_post_asn1(const char *host, const char *port,
     const char *expected_content_type,
     long timeout, const ASN1_ITEM *rsp_it)
 {
-    int use_ssl = ssl_ctx != NULL;
-    APP_HTTP_TLS_INFO info;
-    BIO *rsp, *req_mem = ASN1_item_i2d_mem_bio(req_it, req);
+    BIO *rsp, *req_mem;
     ASN1_VALUE *res;
 
-    if (req_mem == NULL)
+    if (ssl_ctx != NULL && !app_SSL_CTX_set_tls_server_ex_data(ssl_ctx, host))
+        return NULL;
+    if ((req_mem = ASN1_item_i2d_mem_bio(req_it, req)) == NULL)
         return NULL;
 
-    info.server = host;
-    info.port = port;
-    info.use_proxy = /* workaround for callback design flaw, see #17088 */
-        OSSL_HTTP_adapt_proxy(proxy, no_proxy, host, use_ssl) != NULL;
-    info.timeout = timeout;
-    info.ssl_ctx = ssl_ctx;
-    rsp = OSSL_HTTP_transfer(NULL, host, port, path, use_ssl,
+    rsp = OSSL_HTTP_transfer(NULL, host, port, path, ssl_ctx != NULL,
         proxy, no_proxy, NULL /* bio */, NULL /* rbio */,
-        app_http_tls_cb, &info,
+        app_http_tls_cb, ssl_ctx,
         0 /* buf_size */, headers, content_type, req_mem,
         expected_content_type, 1 /* expect_asn1 */,
         OSSL_HTTP_DEFAULT_MAX_RESP_LEN, timeout,

--- a/crypto/http/http_client.c
+++ b/crypto/http/http_client.c
@@ -1162,17 +1162,17 @@ OSSL_HTTP_REQ_CTX *OSSL_HTTP_open(const char *server, const char *port,
         ERR_raise(ERR_LIB_HTTP, HTTP_R_TLS_NOT_ENABLED);
         return NULL;
     }
-    if (rbio != NULL && (bio == NULL || bio_update_fn != NULL)) {
+    if (bio == NULL && rbio != NULL) {
         ERR_raise(ERR_LIB_HTTP, ERR_R_PASSED_INVALID_ARGUMENT);
         return NULL;
     }
 
+    if (port != NULL && *port == '\0')
+        port = NULL;
+    proxy = OSSL_HTTP_adapt_proxy(proxy, no_proxy, server, use_ssl);
+
     if (bio != NULL) {
         cbio = bio;
-        if (proxy != NULL || no_proxy != NULL) {
-            ERR_raise(ERR_LIB_HTTP, ERR_R_PASSED_INVALID_ARGUMENT);
-            return NULL;
-        }
     } else {
 #ifndef OPENSSL_NO_SOCK
         char *proxy_host = NULL, *proxy_port = NULL;
@@ -1181,9 +1181,6 @@ OSSL_HTTP_REQ_CTX *OSSL_HTTP_open(const char *server, const char *port,
             ERR_raise(ERR_LIB_HTTP, ERR_R_PASSED_NULL_PARAMETER);
             return NULL;
         }
-        if (port != NULL && *port == '\0')
-            port = NULL;
-        proxy = OSSL_HTTP_adapt_proxy(proxy, no_proxy, server, use_ssl);
         if (proxy != NULL
             && !OSSL_HTTP_parse_url(proxy, NULL /* use_ssl */, NULL /* user */,
                 &proxy_host, &proxy_port, NULL /* num */,

--- a/crypto/http/http_client.c
+++ b/crypto/http/http_client.c
@@ -105,6 +105,8 @@ static int no_crlf(const char *component, const char *value)
     return 1;
 }
 
+static char *base64encode(const void *buf, size_t len);
+
 OSSL_HTTP_REQ_CTX *OSSL_HTTP_REQ_CTX_new(BIO *wbio, BIO *rbio, int buf_size)
 {
     OSSL_HTTP_REQ_CTX *rctx;
@@ -146,7 +148,8 @@ void OSSL_HTTP_REQ_CTX_free(OSSL_HTTP_REQ_CTX *rctx)
     BIO_free(rctx->mem);
     BIO_free(rctx->req);
     OPENSSL_free(rctx->buf);
-    OPENSSL_free(rctx->proxy);
+    if (rctx->proxy != NULL)
+        OPENSSL_clear_free(rctx->proxy, strlen(rctx->proxy));
     OPENSSL_free(rctx->server);
     OPENSSL_free(rctx->port);
     OPENSSL_free(rctx->expected_ct);
@@ -1203,11 +1206,30 @@ int OSSL_HTTP_set1_request(OSSL_HTTP_REQ_CTX *rctx, const char *path,
     }
     rctx->max_resp_len = max_resp_len; /* allows for 0: indefinite */
 
-    return OSSL_HTTP_REQ_CTX_set_request_line(rctx, req != NULL,
-               use_http_proxy ? rctx->server
-                              : NULL,
-               rctx->port, path)
-        && add1_headers(rctx, headers, rctx->server)
+    if (!OSSL_HTTP_REQ_CTX_set_request_line(rctx, req != NULL,
+            use_http_proxy ? rctx->server : NULL, rctx->port, path))
+        return 0;
+    if (use_http_proxy) {
+        char *userinfo = NULL, *enc;
+        size_t len = 0;
+        int ret = 1;
+
+        if (!OSSL_HTTP_parse_url(rctx->proxy, NULL, &userinfo, NULL, NULL, NULL, NULL, NULL, NULL))
+            return 0;
+        if (userinfo != NULL && *userinfo != '\0') {
+            len = strlen(userinfo);
+            enc = base64encode(userinfo, len);
+            ret = 0;
+            if (enc != NULL) {
+                ret = BIO_printf(rctx->mem, "Proxy-Authorization: Basic %s\r\n", enc);
+                OPENSSL_clear_free(enc, strlen(enc));
+            }
+        }
+        OPENSSL_clear_free(userinfo, len);
+        if (ret <= 0)
+            return 0;
+    }
+    return add1_headers(rctx, headers, rctx->server)
         && OSSL_HTTP_REQ_CTX_set_expected(rctx, expected_content_type,
             expect_asn1, timeout, keep_alive)
         && set1_content(rctx, content_type, req);
@@ -1530,17 +1552,19 @@ int OSSL_HTTP_proxy_connect(BIO *bio, const char *server, const char *port,
             goto proxy_end;
         proxyauthenc = base64encode(proxyauth, len);
         if (proxyauthenc != NULL) {
-            BIO_printf(fbio, "Proxy-Authorization: Basic %s\r\n", proxyauthenc);
+            ret = BIO_printf(fbio, "Proxy-Authorization: Basic %s\r\n", proxyauthenc);
             OPENSSL_clear_free(proxyauthenc, strlen(proxyauthenc));
         }
     proxy_end:
         OPENSSL_clear_free(proxyauth, len);
-        if (proxyauthenc == NULL)
+        if (ret <= 0)
             goto end;
     }
+    ret = 0;
 
     /* Terminate the HTTP CONNECT request */
-    BIO_printf(fbio, "\r\n");
+    if (BIO_printf(fbio, "\r\n") <= 0)
+        goto end;
 
     for (;;) {
         if (BIO_flush(fbio) != 0)
@@ -1640,6 +1664,9 @@ int OSSL_HTTP_REQ_CTX_proxy_connect(OSSL_HTTP_REQ_CTX *rctx,
 {
     time_t time_diff = 0;
     int timeout = 0;
+    char *userinfo = NULL, *colon;
+    size_t len = 0;
+    int ret;
 
     if (rctx == NULL) {
         ERR_raise(ERR_LIB_HTTP, ERR_R_PASSED_NULL_PARAMETER);
@@ -1658,6 +1685,20 @@ int OSSL_HTTP_REQ_CTX_proxy_connect(OSSL_HTTP_REQ_CTX *rctx,
         ERR_raise(ERR_LIB_BIO, BIO_R_CONNECT_TIMEOUT);
         return 0;
     }
-    return OSSL_HTTP_proxy_connect(rctx->wbio, rctx->server, rctx->port,
+
+    if (!OSSL_HTTP_parse_url(rctx->proxy, NULL, &userinfo, NULL, NULL, NULL, NULL, NULL, NULL))
+        return 0;
+    if (userinfo != NULL && *userinfo != '\0') {
+        len = strlen(userinfo);
+        user = userinfo;
+        pass = colon = strchr(userinfo, ':');
+        if (colon != NULL) {
+            *colon = '\0';
+            pass = colon + 1;
+        }
+    }
+    ret = OSSL_HTTP_proxy_connect(rctx->wbio, rctx->server, rctx->port,
         user, pass, timeout, bio_err, prog);
+    OPENSSL_clear_free(userinfo, len);
+    return ret;
 }

--- a/crypto/http/http_client.c
+++ b/crypto/http/http_client.c
@@ -24,6 +24,7 @@
 #include "internal/sockets.h"
 #include "internal/common.h" /* for ossl_assert() */
 
+#define OSSL_HTTP_DEFAULT_PORT(use_ssl) ((use_ssl) ? OSSL_HTTPS_PORT : OSSL_HTTP_PORT)
 #define HTTP_PREFIX "HTTP/"
 #define HTTP_VERSION_PATT "1." /* allow 1.x */
 #define HTTP_VERSION_STR_LEN sizeof(HTTP_VERSION_PATT) /* == strlen("1.0") */
@@ -216,7 +217,8 @@ int OSSL_HTTP_REQ_CTX_set_request_line(OSSL_HTTP_REQ_CTX *rctx, int method_POST,
          */
         if (BIO_printf(rctx->mem, OSSL_HTTP_PREFIX "%s", server) <= 0)
             return 0;
-        if (port != NULL && BIO_printf(rctx->mem, ":%s", port) <= 0)
+        if (port != NULL && strcmp(port, OSSL_HTTP_DEFAULT_PORT(rctx->use_ssl)) != 0
+            && BIO_printf(rctx->mem, ":%s", port) <= 0)
             return 0;
     }
 
@@ -392,22 +394,41 @@ void OSSL_HTTP_REQ_CTX_set_max_response_hdr_lines(OSSL_HTTP_REQ_CTX *rctx,
 }
 
 static int add1_headers(OSSL_HTTP_REQ_CTX *rctx,
-    const STACK_OF(CONF_VALUE) *headers, const char *host)
+    const STACK_OF(CONF_VALUE) *headers, const char *host, const char *port)
 {
     int i;
-    int add_host = host != NULL && *host != '\0';
+    char buf[300];
+    size_t len;
     CONF_VALUE *hdr;
+
+    /* according to RFC 7230 section 5.4, should place Host header first */
+    for (i = 0; i < sk_CONF_VALUE_num(headers); i++) {
+        hdr = sk_CONF_VALUE_value(headers, i);
+        if (OPENSSL_strcasecmp("Host", hdr->name) == 0) {
+            host = hdr->value; /* user-supplied header value takes precedence */
+            port = NULL;
+        }
+    }
+    if (host != NULL
+        && port != NULL && strcmp(port, OSSL_HTTP_DEFAULT_PORT(rctx->use_ssl)) != 0) {
+        len = strlen(host) + 1 + strlen(port);
+        if (len > INT_MAX
+            || BIO_snprintf(buf, sizeof(buf), "%s:%s", host, port) != (int)len) {
+            ERR_raise(ERR_LIB_HTTP, ERR_R_PASSED_INVALID_ARGUMENT);
+            return 0;
+        }
+        host = buf;
+    }
+    if (host != NULL && *host != '\0'
+        && !OSSL_HTTP_REQ_CTX_add1_header(rctx, "Host", host))
+        return 0;
 
     for (i = 0; i < sk_CONF_VALUE_num(headers); i++) {
         hdr = sk_CONF_VALUE_value(headers, i);
-        if (add_host && OPENSSL_strcasecmp("host", hdr->name) == 0)
-            add_host = 0;
-        if (!OSSL_HTTP_REQ_CTX_add1_header(rctx, hdr->name, hdr->value))
+        if (OPENSSL_strcasecmp("Host", hdr->name) != 0
+            && !OSSL_HTTP_REQ_CTX_add1_header(rctx, hdr->name, hdr->value))
             return 0;
     }
-
-    if (add_host && !OSSL_HTTP_REQ_CTX_add1_header(rctx, "Host", host))
-        return 0;
     return 1;
 }
 
@@ -1012,7 +1033,7 @@ static const char *explict_or_default_port(const char *hostserv, const char *por
         if (!BIO_parse_hostserv(hostserv, NULL, &service, BIO_PARSE_PRIO_HOST))
             return NULL;
         if (service == NULL) /* implicit port */
-            port = use_ssl ? OSSL_HTTPS_PORT : OSSL_HTTP_PORT;
+            port = OSSL_HTTP_DEFAULT_PORT(use_ssl);
         OPENSSL_free(service);
     } /* otherwise take the explicitly given port */
     return port;
@@ -1152,9 +1173,12 @@ OSSL_HTTP_REQ_CTX *OSSL_HTTP_open(const char *server, const char *port,
     rctx = http_req_ctx_new(bio == NULL, cbio, rbio != NULL ? rbio : cbio,
         bio_update_fn, arg, use_ssl, proxy, server, port,
         buf_size, overall_timeout);
-    if (rctx != NULL && use_ssl
-        && !OSSL_HTTP_REQ_CTX_proxy_connect(rctx, NULL, NULL, /* no default proxy user and passwd */
-            NULL, NULL))
+    if (rctx == NULL) {
+        if (bio == NULL) /* cbio was not provided by caller */
+            BIO_free(cbio);
+        goto err;
+    }
+    if (use_ssl && !OSSL_HTTP_REQ_CTX_proxy_connect(rctx, NULL, NULL /* no default proxy user and passwd */, NULL, NULL))
         goto err;
 
     /* callback can be used to wrap or prepend TLS session */
@@ -1209,11 +1233,15 @@ int OSSL_HTTP_set1_request(OSSL_HTTP_REQ_CTX *rctx, const char *path,
     if (!OSSL_HTTP_REQ_CTX_set_request_line(rctx, req != NULL,
             use_http_proxy ? rctx->server : NULL, rctx->port, path))
         return 0;
+    if (!add1_headers(rctx, headers, rctx->server, rctx->port))
+        return 0;
     if (use_http_proxy) {
         char *userinfo = NULL, *enc;
         size_t len = 0;
         int ret = 1;
 
+        if (BIO_printf(rctx->mem, "Proxy-Connection: Keep-Alive\r\n") <= 0)
+            return 0;
         if (!OSSL_HTTP_parse_url(rctx->proxy, NULL, &userinfo, NULL, NULL, NULL, NULL, NULL, NULL))
             return 0;
         if (userinfo != NULL && *userinfo != '\0') {
@@ -1229,9 +1257,8 @@ int OSSL_HTTP_set1_request(OSSL_HTTP_REQ_CTX *rctx, const char *path,
         if (ret <= 0)
             return 0;
     }
-    return add1_headers(rctx, headers, rctx->server)
-        && OSSL_HTTP_REQ_CTX_set_expected(rctx, expected_content_type,
-            expect_asn1, timeout, keep_alive)
+    return OSSL_HTTP_REQ_CTX_set_expected(rctx, expected_content_type,
+               expect_asn1, timeout, keep_alive)
         && set1_content(rctx, content_type, req);
 }
 

--- a/crypto/http/http_client.c
+++ b/crypto/http/http_client.c
@@ -1110,6 +1110,44 @@ int OSSL_HTTP_is_alive(const OSSL_HTTP_REQ_CTX *rctx)
 
 /* High-level HTTP API implementation */
 
+static void http_add_error_data(OSSL_HTTP_REQ_CTX *rctx)
+{
+    char buf[200];
+    unsigned long err = ERR_peek_error();
+    int lib = ERR_GET_LIB(err);
+    int reason = ERR_GET_REASON(err);
+
+    if (lib == ERR_LIB_SSL || lib == ERR_LIB_HTTP
+        || (lib == ERR_LIB_BIO && (reason == BIO_R_CONNECT_TIMEOUT || reason == BIO_R_CONNECT_ERROR || reason == BIO_R_TRANSFER_TIMEOUT || reason == BIO_R_TRANSFER_ERROR))
+#ifndef OPENSSL_NO_CMP
+        || (lib == ERR_LIB_CMP
+            && reason == CMP_R_POTENTIALLY_INVALID_CERTIFICATE)
+#endif
+    ) {
+        if (rctx->server != NULL && *rctx->server != '\0') {
+            BIO_snprintf(buf, sizeof(buf), "server=http%s://%s%s%s",
+                rctx->use_ssl ? "s" : "", rctx->server,
+                rctx->port != NULL ? ":" : "",
+                rctx->port != NULL ? rctx->port : "");
+            ERR_add_error_data(1, buf);
+        }
+        if (rctx->proxy != NULL) {
+            /* show proxy without any given user:pass@ prefix */
+            char *proxy_host = strchr(rctx->proxy, '@');
+
+            if (proxy_host == NULL)
+                proxy_host = rctx->proxy;
+            else
+                proxy_host++;
+            ERR_add_error_data(2, " proxy=", proxy_host);
+        }
+    } else if (err == 0) {
+        BIO_snprintf(buf, sizeof(buf), " peer has disconnected%s",
+            rctx->use_ssl ? " violating the protocol" : ", likely because it requires the use of TLS");
+        ERR_add_error_data(1, buf);
+    }
+}
+
 /* Initiate an HTTP session using bio, else use given server, proxy, etc. */
 OSSL_HTTP_REQ_CTX *OSSL_HTTP_open(const char *server, const char *port,
     const char *proxy, const char *no_proxy,
@@ -1161,23 +1199,20 @@ OSSL_HTTP_REQ_CTX *OSSL_HTTP_open(const char *server, const char *port,
         return NULL;
 #endif
     }
-
-    (void)ERR_set_mark(); /* prepare removing any spurious libssl errors */
-    if (rbio == NULL && BIO_do_connect_retry(cbio, overall_timeout, -1) <= 0) {
-        if (bio == NULL) /* cbio was not provided by caller */
-            BIO_free(cbio);
-        goto err;
-    }
-    /* now overall_timeout is guaranteed to be >= 0 */
-
     rctx = http_req_ctx_new(bio == NULL, cbio, rbio != NULL ? rbio : cbio,
         bio_update_fn, arg, use_ssl, proxy, server, port,
         buf_size, overall_timeout);
     if (rctx == NULL) {
         if (bio == NULL) /* cbio was not provided by caller */
             BIO_free(cbio);
-        goto err;
+        return NULL;
     }
+
+    (void)ERR_set_mark(); /* prepare removing any spurious libssl errors */
+    if (rbio == NULL && BIO_do_connect_retry(cbio, overall_timeout, -1) <= 0)
+        goto err;
+    /* now overall_timeout is guaranteed to be >= 0 */
+
     if (use_ssl && !OSSL_HTTP_REQ_CTX_proxy_connect(rctx, NULL, NULL /* no default proxy user and passwd */, NULL, NULL))
         goto err;
 
@@ -1198,6 +1233,7 @@ OSSL_HTTP_REQ_CTX *OSSL_HTTP_open(const char *server, const char *port,
     goto end;
 
 err:
+    http_add_error_data(rctx);
     OSSL_HTTP_REQ_CTX_free(rctx);
     rctx = NULL;
 
@@ -1288,34 +1324,7 @@ BIO *OSSL_HTTP_exchange(OSSL_HTTP_REQ_CTX *rctx, char **redirection_url)
                 /* may be NULL if out of memory: */
                 *redirection_url = OPENSSL_strdup(rctx->redirection_url);
         } else {
-            char buf[200];
-            unsigned long err = ERR_peek_error();
-            int lib = ERR_GET_LIB(err);
-            int reason = ERR_GET_REASON(err);
-
-            if (lib == ERR_LIB_SSL || lib == ERR_LIB_HTTP
-                || (lib == ERR_LIB_BIO && reason == BIO_R_CONNECT_TIMEOUT)
-                || (lib == ERR_LIB_BIO && reason == BIO_R_CONNECT_ERROR)
-#ifndef OPENSSL_NO_CMP
-                || (lib == ERR_LIB_CMP
-                    && reason == CMP_R_POTENTIALLY_INVALID_CERTIFICATE)
-#endif
-            ) {
-                if (rctx->server != NULL && *rctx->server != '\0') {
-                    BIO_snprintf(buf, sizeof(buf), "server=http%s://%s%s%s",
-                        rctx->use_ssl ? "s" : "", rctx->server,
-                        rctx->port != NULL ? ":" : "",
-                        rctx->port != NULL ? rctx->port : "");
-                    ERR_add_error_data(1, buf);
-                }
-                if (rctx->proxy != NULL)
-                    ERR_add_error_data(2, " proxy=", rctx->proxy);
-                if (err == 0) {
-                    BIO_snprintf(buf, sizeof(buf), " peer has disconnected%s",
-                        rctx->use_ssl ? " violating the protocol" : ", likely because it requires the use of TLS");
-                    ERR_add_error_data(1, buf);
-                }
-            }
+            http_add_error_data(rctx);
         }
     }
 

--- a/crypto/http/http_client.c
+++ b/crypto/http/http_client.c
@@ -1141,12 +1141,19 @@ OSSL_HTTP_REQ_CTX *OSSL_HTTP_open(const char *server, const char *port,
     (void)ERR_set_mark(); /* prepare removing any spurious libssl errors */
     if (rbio == NULL && BIO_do_connect_retry(cbio, overall_timeout, -1) <= 0) {
         if (bio == NULL) /* cbio was not provided by caller */
-            BIO_free_all(cbio);
-        goto end;
+            BIO_free(cbio);
+        goto err;
     }
     /* now overall_timeout is guaranteed to be >= 0 */
 
-    /* adapt in order to fix callback design flaw, see #17088 */
+    rctx = http_req_ctx_new(bio == NULL, cbio, rbio != NULL ? rbio : cbio,
+        bio_update_fn, arg, use_ssl, proxy, server, port,
+        buf_size, overall_timeout);
+    if (rctx != NULL && use_ssl
+        && !OSSL_HTTP_REQ_CTX_proxy_connect(rctx, NULL, NULL, /* no default proxy user and passwd */
+            NULL, NULL))
+        goto err;
+
     /* callback can be used to wrap or prepend TLS session */
     if (bio_update_fn != NULL) {
         BIO *orig_bio = cbio;
@@ -1154,14 +1161,18 @@ OSSL_HTTP_REQ_CTX *OSSL_HTTP_open(const char *server, const char *port,
         cbio = (*bio_update_fn)(cbio, arg, 1 /* connect */, use_ssl != 0);
         if (cbio == NULL) {
             if (bio == NULL) /* cbio was not provided by caller */
-                BIO_free_all(orig_bio);
-            goto end;
+                rctx->wbio = orig_bio;
+            goto err;
         }
+        rctx->wbio = cbio;
+        if (rbio == NULL)
+            rctx->rbio = cbio;
     }
+    goto end;
 
-    rctx = http_req_ctx_new(bio == NULL, cbio, rbio != NULL ? rbio : cbio,
-        bio_update_fn, arg, use_ssl, proxy, server, port,
-        buf_size, overall_timeout);
+err:
+    OSSL_HTTP_REQ_CTX_free(rctx);
+    rctx = NULL;
 
 end:
     if (rctx != NULL)
@@ -1412,10 +1423,9 @@ int OSSL_HTTP_close(OSSL_HTTP_REQ_CTX *rctx, int ok)
     BIO *wbio;
     int ret = 1;
 
-    /* callback can be used to finish TLS session and free its BIO */
+    /* callback can be used to clean up TLS session on disconnect */
     if (rctx != NULL && rctx->upd_fn != NULL) {
-        wbio = (*rctx->upd_fn)(rctx->wbio, rctx->upd_arg,
-            0 /* disconnect */, ok);
+        wbio = (*rctx->upd_fn)(rctx->wbio, rctx->upd_arg, 0 /* disconnect */, ok);
         ret = wbio != NULL;
         if (ret)
             rctx->wbio = wbio;
@@ -1452,8 +1462,8 @@ static char *base64encode(const void *buf, size_t len)
 
 /*
  * Promote the given connection BIO using the CONNECT method for a TLS proxy.
- * This is typically called by an app, so bio_err and prog are used unless NULL
- * to print additional diagnostic information in a user-oriented way.
+ * This can be directly called by an app, so bio_err and prog are used unless NULL
+ * to print diagnostic information in a user-oriented way.
  */
 int OSSL_HTTP_proxy_connect(BIO *bio, const char *server, const char *port,
     const char *proxyuser, const char *proxypass,
@@ -1481,22 +1491,28 @@ int OSSL_HTTP_proxy_connect(BIO *bio, const char *server, const char *port,
 
     if ((mbuf = OPENSSL_malloc(BUF_SIZE)) == NULL
         || (fbio = BIO_new(BIO_f_buffer())) == NULL) {
-        BIO_printf(bio_err /* may be NULL */, "%s: out of memory", prog);
+        if (bio_err != NULL)
+            BIO_printf(bio_err, "%s: out of memory", prog);
+        else
+            ERR_raise(ERR_LIB_HTTP, ERR_R_MALLOC_FAILURE);
         goto end;
     }
     BIO_push(fbio, bio);
 
     /* Add square brackets around a naked IPv6 address */
     if (server[0] != '[' && strchr(server, ':') != NULL)
-        BIO_printf(fbio, "CONNECT [%s]:%s " HTTP_1_0 "\r\n", server, port);
+        rv = BIO_printf(fbio, "CONNECT [%s]:%s " HTTP_1_0 "\r\n", server, port);
     else
-        BIO_printf(fbio, "CONNECT %s:%s " HTTP_1_0 "\r\n", server, port);
+        rv = BIO_printf(fbio, "CONNECT %s:%s " HTTP_1_0 "\r\n", server, port);
+    if (rv <= 0)
+        goto end;
 
     /*
      * Workaround for broken proxies which would otherwise close
      * the connection when entering tunnel mode (e.g., Squid 2.6)
      */
-    BIO_printf(fbio, "Proxy-Connection: Keep-Alive\r\n");
+    if (BIO_printf(fbio, "Proxy-Connection: Keep-Alive\r\n") <= 0)
+        goto end;
 
     /* Support for basic (base64) proxy authentication */
     if (proxyuser != NULL) {
@@ -1538,8 +1554,12 @@ int OSSL_HTTP_proxy_connect(BIO *bio, const char *server, const char *port,
         /* will not actually wait if timeout == 0 */
         rv = BIO_wait(fbio, max_time, 100 /* milliseconds */);
         if (rv <= 0) {
-            BIO_printf(bio_err, "%s: HTTP CONNECT %s\n", prog,
-                rv == 0 ? "timed out" : "failed waiting for data");
+            const char *details = rv == 0 ? "timed out" : "failed waiting for data";
+
+            if (bio_err != NULL)
+                BIO_printf(bio_err, "%s: HTTPS proxy CONNECT %s\n", prog, details);
+            else
+                ERR_raise_data(ERR_LIB_HTTP, HTTP_R_CONNECT_FAILURE, "via HTTPS proxy, %s", details);
             goto end;
         }
 
@@ -1556,17 +1576,21 @@ int OSSL_HTTP_proxy_connect(BIO *bio, const char *server, const char *port,
         /* Check for HTTP/1.x */
         mbufp = mbuf;
         if (!CHECK_AND_SKIP_PREFIX(mbufp, HTTP_PREFIX)) {
-            ERR_raise(ERR_LIB_HTTP, HTTP_R_HEADER_PARSE_ERROR);
-            BIO_printf(bio_err, "%s: HTTP CONNECT failed, non-HTTP response\n",
-                prog);
+            if (bio_err != NULL)
+                BIO_printf(bio_err, "%s: HTTPS proxy CONNECT failed, non-HTTP response\n", prog);
+            else
+                ERR_raise_data(ERR_LIB_HTTP, HTTP_R_HEADER_PARSE_ERROR, "non-HTTP response on CONNECT via HTTPS proxy");
             /* Wrong protocol, not even HTTP, so stop reading headers */
             goto end;
         }
         if (!HAS_PREFIX(mbufp, HTTP_VERSION_PATT)) {
-            ERR_raise(ERR_LIB_HTTP, HTTP_R_RECEIVED_WRONG_HTTP_VERSION);
-            BIO_printf(bio_err,
-                "%s: HTTP CONNECT failed, bad HTTP version %.*s\n",
-                prog, (int)HTTP_VERSION_STR_LEN, mbufp);
+            if (bio_err != NULL)
+                BIO_printf(bio_err,
+                    "%s: HTTPS proxy CONNECT failed, bad HTTP version %.*s\n",
+                    prog, (int)HTTP_VERSION_STR_LEN, mbufp);
+            else
+                ERR_raise_data(ERR_LIB_HTTP, HTTP_R_RECEIVED_WRONG_HTTP_VERSION,
+                    "%.*s on HTTPS proxy CONNECT", (int)HTTP_VERSION_STR_LEN, mbufp);
             goto end;
         }
         mbufp += HTTP_VERSION_STR_LEN;
@@ -1579,10 +1603,11 @@ int OSSL_HTTP_proxy_connect(BIO *bio, const char *server, const char *port,
             while (read_len > 0 && ossl_isspace(mbuf[read_len - 1]))
                 read_len--;
             mbuf[read_len] = '\0';
-            ERR_raise_data(ERR_LIB_HTTP, HTTP_R_CONNECT_FAILURE,
-                "reason=%s", mbufp);
-            BIO_printf(bio_err, "%s: HTTP CONNECT failed, reason=%s\n",
-                prog, mbufp);
+            if (bio_err != NULL)
+                BIO_printf(bio_err, "%s: HTTP CONNECT failed, reason=%s\n", prog, mbufp);
+            else
+                ERR_raise_data(ERR_LIB_HTTP, HTTP_R_CONNECT_FAILURE,
+                    "via HTTPS proxy, reason=%s", mbufp);
             goto end;
         }
         ret = 1;
@@ -1607,4 +1632,32 @@ end:
     OPENSSL_free(mbuf);
     return ret;
 #undef BUF_SIZE
+}
+
+int OSSL_HTTP_REQ_CTX_proxy_connect(OSSL_HTTP_REQ_CTX *rctx,
+    const char *user, const char *pass,
+    BIO *bio_err, const char *prog)
+{
+    time_t time_diff = 0;
+    int timeout = 0;
+
+    if (rctx == NULL) {
+        ERR_raise(ERR_LIB_HTTP, ERR_R_PASSED_NULL_PARAMETER);
+        return 0;
+    }
+    if (rctx->proxy == NULL || !rctx->use_ssl) /* proceed only on HTTPS proxy use */
+        return 1;
+
+    if (rctx->max_total_time != 0) {
+        time_diff = rctx->max_total_time - time(NULL);
+        if (time_diff > INT_MAX)
+            time_diff = INT_MAX;
+        timeout = (int)time_diff;
+    }
+    if (timeout < 0) {
+        ERR_raise(ERR_LIB_BIO, BIO_R_CONNECT_TIMEOUT);
+        return 0;
+    }
+    return OSSL_HTTP_proxy_connect(rctx->wbio, rctx->server, rctx->port,
+        user, pass, timeout, bio_err, prog);
 }

--- a/crypto/http/http_client.c
+++ b/crypto/http/http_client.c
@@ -413,7 +413,7 @@ static int add1_headers(OSSL_HTTP_REQ_CTX *rctx,
         && port != NULL && strcmp(port, OSSL_HTTP_DEFAULT_PORT(rctx->use_ssl)) != 0) {
         len = strlen(host) + 1 + strlen(port);
         if (len > INT_MAX
-            || BIO_snprintf(buf, sizeof(buf), "%s:%s", host, port) != (int)len) {
+            || snprintf(buf, sizeof(buf), "%s:%s", host, port) != (int)len) {
             ERR_raise(ERR_LIB_HTTP, ERR_R_PASSED_INVALID_ARGUMENT);
             return 0;
         }
@@ -1110,6 +1110,44 @@ int OSSL_HTTP_is_alive(const OSSL_HTTP_REQ_CTX *rctx)
 
 /* High-level HTTP API implementation */
 
+static void http_add_error_data(OSSL_HTTP_REQ_CTX *rctx)
+{
+    char buf[200];
+    unsigned long err = ERR_peek_error();
+    int lib = ERR_GET_LIB(err);
+    int reason = ERR_GET_REASON(err);
+
+    if (lib == ERR_LIB_SSL || lib == ERR_LIB_HTTP
+        || (lib == ERR_LIB_BIO && (reason == BIO_R_CONNECT_TIMEOUT || reason == BIO_R_CONNECT_ERROR || reason == BIO_R_TRANSFER_TIMEOUT || reason == BIO_R_TRANSFER_ERROR))
+#ifndef OPENSSL_NO_CMP
+        || (lib == ERR_LIB_CMP
+            && reason == CMP_R_POTENTIALLY_INVALID_CERTIFICATE)
+#endif
+    ) {
+        if (rctx->server != NULL && *rctx->server != '\0') {
+            snprintf(buf, sizeof(buf), "server=http%s://%s%s%s",
+                rctx->use_ssl ? "s" : "", rctx->server,
+                rctx->port != NULL ? ":" : "",
+                rctx->port != NULL ? rctx->port : "");
+            ERR_add_error_data(1, buf);
+        }
+        if (rctx->proxy != NULL) {
+            /* show proxy without any given user:pass@ prefix */
+            char *proxy_host = strchr(rctx->proxy, '@');
+
+            if (proxy_host == NULL)
+                proxy_host = rctx->proxy;
+            else
+                proxy_host++;
+            ERR_add_error_data(2, " proxy=", proxy_host);
+        }
+    } else if (err == 0) {
+        snprintf(buf, sizeof(buf), " peer has disconnected%s",
+            rctx->use_ssl ? " violating the protocol" : ", likely because it requires the use of TLS");
+        ERR_add_error_data(1, buf);
+    }
+}
+
 /* Initiate an HTTP session using bio, else use given server, proxy, etc. */
 OSSL_HTTP_REQ_CTX *OSSL_HTTP_open(const char *server, const char *port,
     const char *proxy, const char *no_proxy,
@@ -1161,23 +1199,20 @@ OSSL_HTTP_REQ_CTX *OSSL_HTTP_open(const char *server, const char *port,
         return NULL;
 #endif
     }
-
-    (void)ERR_set_mark(); /* prepare removing any spurious libssl errors */
-    if (rbio == NULL && BIO_do_connect_retry(cbio, overall_timeout, -1) <= 0) {
-        if (bio == NULL) /* cbio was not provided by caller */
-            BIO_free(cbio);
-        goto err;
-    }
-    /* now overall_timeout is guaranteed to be >= 0 */
-
     rctx = http_req_ctx_new(bio == NULL, cbio, rbio != NULL ? rbio : cbio,
         bio_update_fn, arg, use_ssl, proxy, server, port,
         buf_size, overall_timeout);
     if (rctx == NULL) {
         if (bio == NULL) /* cbio was not provided by caller */
             BIO_free(cbio);
-        goto err;
+        return NULL;
     }
+
+    (void)ERR_set_mark(); /* prepare removing any spurious libssl errors */
+    if (rbio == NULL && BIO_do_connect_retry(cbio, overall_timeout, -1) <= 0)
+        goto err;
+    /* now overall_timeout is guaranteed to be >= 0 */
+
     if (use_ssl && !OSSL_HTTP_REQ_CTX_proxy_connect(rctx, NULL, NULL /* no default proxy user and passwd */, NULL, NULL))
         goto err;
 
@@ -1198,6 +1233,7 @@ OSSL_HTTP_REQ_CTX *OSSL_HTTP_open(const char *server, const char *port,
     goto end;
 
 err:
+    http_add_error_data(rctx);
     OSSL_HTTP_REQ_CTX_free(rctx);
     rctx = NULL;
 
@@ -1288,34 +1324,7 @@ BIO *OSSL_HTTP_exchange(OSSL_HTTP_REQ_CTX *rctx, char **redirection_url)
                 /* may be NULL if out of memory: */
                 *redirection_url = OPENSSL_strdup(rctx->redirection_url);
         } else {
-            char buf[200];
-            unsigned long err = ERR_peek_error();
-            int lib = ERR_GET_LIB(err);
-            int reason = ERR_GET_REASON(err);
-
-            if (lib == ERR_LIB_SSL || lib == ERR_LIB_HTTP
-                || (lib == ERR_LIB_BIO && reason == BIO_R_CONNECT_TIMEOUT)
-                || (lib == ERR_LIB_BIO && reason == BIO_R_CONNECT_ERROR)
-#ifndef OPENSSL_NO_CMP
-                || (lib == ERR_LIB_CMP
-                    && reason == CMP_R_POTENTIALLY_INVALID_CERTIFICATE)
-#endif
-            ) {
-                if (rctx->server != NULL && *rctx->server != '\0') {
-                    snprintf(buf, sizeof(buf), "server=http%s://%s%s%s",
-                        rctx->use_ssl ? "s" : "", rctx->server,
-                        rctx->port != NULL ? ":" : "",
-                        rctx->port != NULL ? rctx->port : "");
-                    ERR_add_error_data(1, buf);
-                }
-                if (rctx->proxy != NULL)
-                    ERR_add_error_data(2, " proxy=", rctx->proxy);
-                if (err == 0) {
-                    snprintf(buf, sizeof(buf), " peer has disconnected%s",
-                        rctx->use_ssl ? " violating the protocol" : ", likely because it requires the use of TLS");
-                    ERR_add_error_data(1, buf);
-                }
-            }
+            http_add_error_data(rctx);
         }
     }
 

--- a/crypto/http/http_lib.c
+++ b/crypto/http/http_lib.c
@@ -265,8 +265,8 @@ static int use_proxy(const char *no_proxy, const char *server)
     const char *found = NULL;
     char host[NI_MAXHOST];
 
-    if (!ossl_assert(server != NULL))
-        return 0;
+    if (server == NULL)
+        return 1;
     sl = strlen(server);
     if (sl >= 2 && sl < sizeof(host) + 2 && server[0] == '[' && server[sl - 1] == ']') {
         /* strip leading '[' and trailing ']' from escaped IPv6 address */

--- a/crypto/http/http_lib.c
+++ b/crypto/http/http_lib.c
@@ -264,8 +264,8 @@ static int use_proxy(const char *no_proxy, const char *server)
     const char *found = NULL;
     char host[NI_MAXHOST];
 
-    if (!ossl_assert(server != NULL))
-        return 0;
+    if (server == NULL)
+        return 1;
     sl = strlen(server);
     if (sl >= 2 && sl < sizeof(host) + 2 && server[0] == '[' && server[sl - 1] == ']') {
         /* strip leading '[' and trailing ']' from escaped IPv6 address */

--- a/doc/man1/openssl-cmp.pod.in
+++ b/doc/man1/openssl-cmp.pod.in
@@ -554,7 +554,8 @@ If the host string is an IPv6 address, it must be enclosed in C<[> and C<]>.
 The proxy port defaults to 80 or 443 if the scheme is C<https>; apart from that
 the optional C<http://> or C<https://> prefix is ignored (note that using TLS
 may be required by B<-tls_used> or B<-server> with the prefix C<https>),
-as well as any path, userinfo, and query, and fragment components.
+as well as any path, and query, and fragment components.
+Any given userinfo is taken as HTTP(S) proxy client credentials.
 
 Defaults to the environment variable C<http_proxy> if set, else C<HTTP_PROXY>
 in case no TLS is used, otherwise C<https_proxy> if set, else C<HTTPS_PROXY>.

--- a/doc/man3/OSSL_CMP_CTX_new.pod
+++ b/doc/man3/OSSL_CMP_CTX_new.pod
@@ -415,7 +415,8 @@ Otherwise defaults to the value of C<https_proxy> if set, else C<HTTPS_PROXY>.
 An empty proxy string specifies not to use a proxy.
 Otherwise the format is
 C<[http[s]://][userinfo@]host[:port][/path][?query][#fragment]>,
-where any given userinfo, path, query, and fragment is ignored.
+where any given path, query, and fragment is ignored.
+Any given userinfo will be taken as HTTP(S) proxy client credentials.
 If the host string is an IPv6 address, it must be enclosed in C<[> and C<]>.
 The default port number is 80, or 443 in case C<https:> is given.
 

--- a/doc/man3/OSSL_HTTP_parse_url.pod
+++ b/doc/man3/OSSL_HTTP_parse_url.pod
@@ -35,14 +35,14 @@ see L<openssl_user_macros(7)>:
 OSSL_HTTP_adapt_proxy() determines whether a proxy should be used
 when connecting to the given I<server>.
 It takes an optional proxy hostname I<proxy>
-and returns it transformed according to the optional I<no_proxy> parameter,
-I<server>, I<use_ssl>, and the applicable environment variable, as follows.
+and returns it transformed according to the optional I<no_proxy> and I<server>
+parameters, I<use_ssl>, and the applicable environment variable, as follows.
 If I<proxy> is NULL, take any default value from the C<http_proxy>
 environment variable, or from C<https_proxy> if I<use_ssl> is nonzero.
 If this still does not yield a proxy hostname,
 take any further default value from the C<HTTP_PROXY>
 environment variable, or from C<HTTPS_PROXY> if I<use_ssl> is nonzero.
-Return the determined proxy host if I<server> is the empty string
+Return the determined proxy host if I<server> is NULL or the empty string
 or I<server> is not in the exclusion list.
 The exclusion list is a list of server hosts separated by C<,>
 and/or whitespace.

--- a/doc/man3/OSSL_HTTP_transfer.pod
+++ b/doc/man3/OSSL_HTTP_transfer.pod
@@ -74,10 +74,9 @@ I<bio> and I<rbio> may be memory BIOs for instance.
 As soon as the client has finished writing to I<bio> and flushed I<bio>,
 the server must be ready to provide a response or indicate a waiting condition
 because then the client starts reading from I<rbio> (or from I<bio> taken as its default).
+Even when I<bio> is given, the I<server> (and the optional I<port>) argument should
+still be given for supporting proper HTTP request header setup and diagnostic output.
 
-If I<bio> is given,
-it is an error to provide non-NULL I<proxy> or I<no_proxy> arguments,
-while I<server> and I<port> arguments may be given to support diagnostic output.
 If I<bio> is NULL the optional I<proxy> parameter can be used to set an
 HTTP(S) proxy to use (unless overridden by "no_proxy" settings).
 If TLS is not used this defaults to the environment variable C<http_proxy>

--- a/doc/man3/OSSL_HTTP_transfer.pod
+++ b/doc/man3/OSSL_HTTP_transfer.pod
@@ -67,12 +67,13 @@ defaulting to 80 for HTTP or 443 for HTTPS.
 Then this internal BIO is used for setting up a connection
 and for exchanging one or more request and response.
 
-If I<bio> is given and I<rbio> is NULL then this I<bio> is used instead.
-If both I<bio> and I<rbio> are given (which may be memory BIOs for instance)
-then no explicit connection is set up, but
-I<bio> is used for writing requests and I<rbio> for reading responses.
-As soon as the client has flushed I<bio> the server must be ready to provide
-a response or indicate a waiting condition via I<rbio>.
+Alternatively, if I<bio> is given, OSSL_HTTP_open() does not set up a socket connection
+but uses I<bio> for writing requests and I<rbio> for reading responses,
+where in case I<rbio> is NULL it defaults to I<bio>.
+I<bio> and I<rbio> may be memory BIOs for instance.
+As soon as the client has finished writing to I<bio> and flushed I<bio>,
+the server must be ready to provide a response or indicate a waiting condition
+because then the client starts reading from I<rbio> (or from I<bio> taken as its default).
 
 If I<bio> is given,
 it is an error to provide non-NULL I<proxy> or I<no_proxy> arguments,

--- a/doc/man3/OSSL_HTTP_transfer.pod
+++ b/doc/man3/OSSL_HTTP_transfer.pod
@@ -85,7 +85,9 @@ If I<use_ssl> != 0 it defaults to C<https_proxy> if set, else C<HTTPS_PROXY>.
 An empty proxy string C<""> forbids using a proxy.
 Otherwise, the format is
 C<[http[s]://][userinfo@]host[:port][/path][?query][#fragment]>,
-where any userinfo, path, query, and fragment given is ignored.
+where any path, query, and fragment given is ignored
+and any given userinfo is taken as HTTP(S) proxy client credentials by calling
+OSSL_HTTP_REQ_CTX_proxy_connect() on SSL connection setup just before using I<bio_update_fn>.
 If the host string is an IPv6 address, it must be enclosed in C<[> and C<]>.
 The default proxy port number is 80, or 443 in case "https:" is given.
 The HTTP client functions connect via the given proxy unless the I<server>
@@ -161,7 +163,7 @@ OSSL_HTTP_proxy_connect() may be used by an above BIO connect callback function
 to set up an SSL/TLS connection via an HTTPS proxy.
 It promotes the given BIO I<bio> representing a connection
 pre-established with a TLS proxy using the HTTP CONNECT method,
-optionally using proxy client credentials I<proxyuser> and I<proxypass>,
+optionally using HTTPS proxy client credentials I<proxyuser> and I<proxypass>,
 to connect with TLS protection ultimately to I<server> and I<port>.
 If the I<port> argument is NULL or the empty string it defaults to "443".
 The I<server> and I<port> arguments must not contain CR or LF characters.
@@ -175,13 +177,17 @@ NULL) to print diagnostic information in a user-oriented way.
 OSSL_HTTP_REQ_CTX_proxy_connect() improves OSSL_HTTP_proxy_connect() as follows.
 It does nothing if I<rctx> indicates that no proxy is used or SSL/TLS is not used.
 Otherwise it calls OSSL_HTTP_proxy_connect(),
-taking the needed BIO, server, port, and timeout information from I<rctx>.
+taking the needed BIO, server, port, and timeout information from I<rctx>
+and passing on the I<bio_err> and I<prog> parameters.
+The proxy user and password information is taken if present from the proxy URL
+in I<rctx> and otherwise defaults to the optional I<user> and I<pass> parameters.
 
 OSSL_HTTP_set1_request() sets up in I<rctx> the request header and content data
 and expectations on the response using the following parameters.
 If <rctx> indicates using a proxy for HTTP (but not HTTPS), the server host
 (and optionally port) needs to be placed in the header; thus it must be present
-in I<rctx>.
+in I<rctx>. When an HTTP proxy is used, any userinfo given as part of the proxy URL
+is placed in the HTTP request header as proxy client credentials.
 For backward compatibility, the server (and optional port) may also be given in
 the I<path> argument beginning with C<http://> (thus giving an absoluteURI).
 If I<path> is NULL it defaults to "/".

--- a/doc/man3/OSSL_HTTP_transfer.pod
+++ b/doc/man3/OSSL_HTTP_transfer.pod
@@ -5,6 +5,7 @@
 OSSL_HTTP_open,
 OSSL_HTTP_bio_cb_t,
 OSSL_HTTP_proxy_connect,
+OSSL_HTTP_REQ_CTX_proxy_connect,
 OSSL_HTTP_set1_request,
 OSSL_HTTP_exchange,
 OSSL_HTTP_get,
@@ -26,6 +27,9 @@ OSSL_HTTP_close
  int OSSL_HTTP_proxy_connect(BIO *bio, const char *server, const char *port,
                              const char *proxyuser, const char *proxypass,
                              int timeout, BIO *bio_err, const char *prog);
+ int OSSL_HTTP_REQ_CTX_proxy_connect(OSSL_HTTP_REQ_CTX *rctx,
+                                     const char *user, const char *pass,
+                                     BIO *bio_err, const char *prog);
  int OSSL_HTTP_set1_request(OSSL_HTTP_REQ_CTX *rctx, const char *path,
                             const STACK_OF(CONF_VALUE) *headers,
                             const char *content_type, BIO *req,
@@ -89,8 +93,8 @@ is found in the optional list I<no_proxy> of proxy hostnames or IP addresses
 separated by C<,> and/or whitespace (if not NULL;
 default is the environment variable C<no_proxy> if set, else C<NO_PROXY>).
 Proxying plain HTTP is supported directly,
-while using a proxy for HTTPS connections requires a suitable callback function
-such as OSSL_HTTP_proxy_connect(), described below.
+while using a proxy for HTTPS connections requires a suitable helper function
+such as OSSL_HTTP_REQ_CTX_proxy_connect(), described below.
 
 If I<use_ssl> is nonzero a TLS connection is requested
 and the I<bio_update_fn> parameter must be provided.
@@ -105,10 +109,12 @@ I<bio_update_fn> is a BIO connect/disconnect callback function with prototype
 The callback function may modify the BIO provided in the I<bio> argument,
 whereby it may use an optional custom defined argument I<arg>,
 which can for instance point to an B<SSL_CTX> structure.
-During connection establishment, just after calling BIO_do_connect_retry(), the
+During connection establishment, just after calling BIO_do_connect_retry()
+(and calling OSSL_HTTP_REQ_CTX_proxy_connect() in case I<use_ssl> is nonzero), the
 callback function is invoked with the I<connect> argument being 1 and
 I<detail> being 1 if I<use_ssl> is nonzero (i.e., HTTPS is requested), else 0.
 On disconnect I<connect> is 0 and I<detail> is 1 if no error occurred, else 0.
+
 For instance, on connect the callback may push an SSL BIO to implement HTTPS;
 after disconnect it may do some diagnostic output and pop and free the SSL BIO.
 
@@ -162,9 +168,14 @@ The I<server> and I<port> arguments must not contain CR or LF characters.
 If the I<timeout> parameter is > 0 this indicates the maximum number of
 seconds the connection setup is allowed to take.
 A value <= 0 enables waiting indefinitely, i.e., no timeout.
-Since this function is typically called by applications such as
+Since this function can be directly called by applications such as
 L<openssl-s_client(1)> it uses the I<bio_err> and I<prog> parameters (unless
-NULL) to print additional diagnostic information in a user-oriented way.
+NULL) to print diagnostic information in a user-oriented way.
+
+OSSL_HTTP_REQ_CTX_proxy_connect() improves OSSL_HTTP_proxy_connect() as follows.
+It does nothing if I<rctx> indicates that no proxy is used or SSL/TLS is not used.
+Otherwise it calls OSSL_HTTP_proxy_connect(),
+taking the needed BIO, server, port, and timeout information from I<rctx>.
 
 OSSL_HTTP_set1_request() sets up in I<rctx> the request header and content data
 and expectations on the response using the following parameters.
@@ -251,7 +262,8 @@ See also L<OSSL_trace_enabled(3)> and L<openssl-env(7)>.
 
 OSSL_HTTP_open() returns on success a B<OSSL_HTTP_REQ_CTX>, else NULL.
 
-OSSL_HTTP_proxy_connect() and OSSL_HTTP_set1_request()
+OSSL_HTTP_proxy_connect(), OSSL_HTTP_REQ_CTX_proxy_connect(),
+and OSSL_HTTP_set1_request()
 return 1 on success, 0 on error.
 
 On success, OSSL_HTTP_exchange(), OSSL_HTTP_get(), and OSSL_HTTP_transfer()
@@ -274,7 +286,9 @@ L<OSSL_trace_enabled(3)>, and L<openssl-env(7)>.
 
 =head1 HISTORY
 
-All the functions described here were added in OpenSSL 3.0.
+OSSL_HTTP_REQ_CTX_proxy_connect() was added in OpenSSL 4.0.
+
+All other functions described here were added in OpenSSL 3.0.
 
 =head1 COPYRIGHT
 

--- a/include/openssl/http.h
+++ b/include/openssl/http.h
@@ -79,6 +79,9 @@ OSSL_HTTP_REQ_CTX *OSSL_HTTP_open(const char *server, const char *port,
 int OSSL_HTTP_proxy_connect(BIO *bio, const char *server, const char *port,
     const char *proxyuser, const char *proxypass,
     int timeout, BIO *bio_err, const char *prog);
+int OSSL_HTTP_REQ_CTX_proxy_connect(OSSL_HTTP_REQ_CTX *rctx,
+    const char *proxyuser, const char *proxypass,
+    BIO *bio_err, const char *prog);
 int OSSL_HTTP_set1_request(OSSL_HTTP_REQ_CTX *rctx, const char *path,
     const STACK_OF(CONF_VALUE) *headers,
     const char *content_type, BIO *req,

--- a/test/http_test.c
+++ b/test/http_test.c
@@ -240,53 +240,30 @@ err:
     return res;
 }
 
+/*
+ * Workaround for strnstr() not being available on all platforms.
+ * This variant searches also past any intermediate '\0' in haystack.
+ */
+static const char *my_strnstr(const char *haystack, const char *needle, size_t len)
+{
+    size_t needle_len = strlen(needle);
+    size_t i;
+
+    if (len < needle_len)
+        return NULL;
+    for (i = 0; i <= len - needle_len; i++) {
+        if (memcmp(haystack, needle, needle_len) == 0)
+            return haystack;
+        haystack++;
+    }
+    return NULL;
+}
+
+#define HTTP_TEST_SERVER "dummy-server.com"
 /* test proxy user credentials as in the example in RFC 7617 section 2.1 */
 #define HTTP_TEST_PROXY_USER "test"
 #define HTTP_TEST_PROXY_PASS "123\xC2\xA3" /* last char is UTF8-encoded pound symbol */
 #define HTTP_TEST_PROXY_AUTH "Proxy-Authorization: Basic dGVzdDoxMjPCow=="
-
-/* Initiate a dummy HTTP session, basically following OSSL_HTTP_open(), with focus on initialization of proxy use */
-static BIO *dummy_HTTP_open(const char *server, const char *port,
-    const char *proxy, const char *no_proxy, int use_ssl,
-    OSSL_HTTP_bio_cb_t bio_update_fn, void *arg)
-{
-    BIO *cbio;
-    char *proxy_host = NULL, *proxy_port = NULL;
-
-    proxy = OSSL_HTTP_adapt_proxy(proxy, no_proxy, server, use_ssl);
-    if (proxy != NULL
-        && !OSSL_HTTP_parse_url(proxy, NULL /* use_ssl */, NULL /* user */,
-            &proxy_host, &proxy_port, NULL /* num */,
-            NULL /* path */, NULL, NULL))
-        return NULL;
-    cbio = BIO_new(BIO_s_mem());
-    OPENSSL_free(proxy_host);
-    OPENSSL_free(proxy_port);
-    if (cbio == NULL)
-        return NULL;
-    if (use_ssl) {
-        BIO_puts(cbio, "HTTP/1.0 200\r\n\r\n"); /* fake HTTPS proxy CONNECT response */
-
-        if (!OSSL_HTTP_proxy_connect(cbio, server, port, HTTP_TEST_PROXY_USER,
-                HTTP_TEST_PROXY_PASS, 0, NULL, NULL))
-            goto err;
-    }
-
-    if (bio_update_fn != NULL) {
-        BIO *orig_bio = cbio;
-
-        cbio = (*bio_update_fn)(cbio, arg, 1 /* connect */, use_ssl != 0);
-        if (cbio == NULL) {
-            cbio = orig_bio;
-            goto err;
-        }
-    }
-    return cbio;
-
-err:
-    BIO_free(cbio);
-    return NULL;
-}
 
 static int bio_update_fn_detail = -1; /* initial value indicates function not yet called */
 static BIO *bio_update_fn(BIO *bio, void *arg, int connect, int detail)
@@ -298,19 +275,66 @@ static BIO *bio_update_fn(BIO *bio, void *arg, int connect, int detail)
     return connect == 1 && use_ssl == (my_ctx != NULL) ? bio : NULL;
 }
 
-static int test_http_open_requesting_proxy(int use_ssl)
+static long https_proxy_cb_ex(BIO *bio, int oper, const char *argp, size_t len,
+    int argi, long argl, int ret, size_t *processed)
+{
+    int *found_https_proxy_auth = (int *)BIO_get_callback_arg(bio);
+
+    if ((oper & BIO_CB_WRITE) == BIO_CB_WRITE && ((oper & BIO_CB_RETURN) == 0)
+        && my_strnstr(argp, HTTP_TEST_PROXY_AUTH, len) != NULL)
+        *found_https_proxy_auth = 1;
+    return ret;
+}
+
+static int test_http_using_proxy(int use_ssl)
 {
     int dummy_ctx[1];
     void *my_ctx = use_ssl ? dummy_ctx : NULL;
-    BIO *bio = dummy_HTTP_open("dummy-server.com", NULL /* port */,
+    BIO *mbio, *wbio = BIO_new(BIO_s_mem()), *rbio = BIO_new(BIO_s_mem());
+    OSSL_HTTP_REQ_CTX *rctx = NULL;
+    char buf[1000];
+    int len, found_https_proxy_auth = 0, ret = 0;
+
+    if (wbio == NULL || rbio == NULL)
+        goto err;
+    if (use_ssl) {
+        BIO_puts(wbio, "HTTP/1.0 200\r\n\r\n"); /* fake HTTPS proxy CONNECT response */
+        BIO_set_callback_ex(wbio, https_proxy_cb_ex);
+        BIO_set_callback_arg(wbio, (char *)&found_https_proxy_auth);
+    }
+    rctx = OSSL_HTTP_open(HTTP_TEST_SERVER, NULL /* port */,
         HTTP_TEST_PROXY_USER ":" HTTP_TEST_PROXY_PASS "@dummy-proxy.org",
-        "dummy-no_proxy.com", use_ssl, bio_update_fn, my_ctx);
+        "dummy-no_proxy.com", use_ssl, wbio, rbio, bio_update_fn, my_ctx, 0, 0);
+    if (!TEST_ptr(rctx) || !TEST_int_eq(bio_update_fn_detail, use_ssl))
+        goto err;
 
-    if (TEST_ptr(bio) == 0 || !TEST_int_eq(bio_update_fn_detail, use_ssl))
-        return 0;
+    if (!OSSL_HTTP_set1_request(rctx, "path", NULL /* headers */, NULL /* content_type */,
+            NULL /* req */, NULL /* expected_ct */, 0 /* expect_asn1 */,
+            0 /* max_resp_len */, -1 /* timeout */, 0 /* no keep_alive */))
+        goto err;
 
-    BIO_free(bio);
-    return 1;
+    mbio = OSSL_HTTP_REQ_CTX_get0_mem_bio(rctx);
+    if (!TEST_ptr(mbio))
+        goto err;
+
+    len = BIO_read(mbio, buf, sizeof(buf) - 1);
+    if (!TEST_int_gt(len, 0))
+        goto err;
+    buf[len] = '\0';
+    if (!TEST_ptr(strstr(buf, "Host: " HTTP_TEST_SERVER)))
+        goto err;
+    if (use_ssl
+            ? !TEST_true(found_https_proxy_auth)
+            : !TEST_ptr(strstr(buf, HTTP_TEST_PROXY_AUTH)))
+        goto err;
+
+    ret = 1;
+
+err:
+    OSSL_HTTP_REQ_CTX_free(rctx);
+    BIO_free(wbio);
+    BIO_free(rbio);
+    return ret;
 }
 
 static int test_http_keep_alive(char version, int keep_alive, int kept_alive)
@@ -613,14 +637,14 @@ static int test_http_post_x509_error_status(void)
     return test_http_method(0 /* POST */, 0, HTTP_STATUS_CODES_NONFATAL_ERROR);
 }
 
-static int test_http_open_requesting_HTTP_proxy(void)
+static int test_http_using_HTTP_proxy(void)
 {
-    return test_http_open_requesting_proxy(0);
+    return test_http_using_proxy(0);
 }
 
-static int test_http_open_requesting_HTTPS_proxy(void)
+static int test_http_using_HTTPS_proxy(void)
 {
-    return test_http_open_requesting_proxy(1);
+    return test_http_using_proxy(1);
 }
 
 static int test_http_keep_alive_0_no_no(void)
@@ -774,8 +798,8 @@ int setup_tests(void)
     ADD_TEST(test_http_post_x509_fatal_status);
     ADD_TEST(test_http_post_x509_error_status);
 
-    ADD_TEST(test_http_open_requesting_HTTP_proxy);
-    ADD_TEST(test_http_open_requesting_HTTPS_proxy);
+    ADD_TEST(test_http_using_HTTP_proxy);
+    ADD_TEST(test_http_using_HTTPS_proxy);
 
     ADD_TEST(test_http_keep_alive_0_no_no);
     ADD_TEST(test_http_keep_alive_1_no_no);

--- a/test/http_test.c
+++ b/test/http_test.c
@@ -240,6 +240,79 @@ err:
     return res;
 }
 
+/* test proxy user credentials as in the example in RFC 7617 section 2.1 */
+#define HTTP_TEST_PROXY_USER "test"
+#define HTTP_TEST_PROXY_PASS "123\xC2\xA3" /* last char is UTF8-encoded pound symbol */
+#define HTTP_TEST_PROXY_AUTH "Proxy-Authorization: Basic dGVzdDoxMjPCow=="
+
+/* Initiate a dummy HTTP session, basically following OSSL_HTTP_open(), with focus on initialization of proxy use */
+static BIO *dummy_HTTP_open(const char *server, const char *port,
+    const char *proxy, const char *no_proxy, int use_ssl,
+    OSSL_HTTP_bio_cb_t bio_update_fn, void *arg)
+{
+    BIO *cbio;
+    char *proxy_host = NULL, *proxy_port = NULL;
+
+    proxy = OSSL_HTTP_adapt_proxy(proxy, no_proxy, server, use_ssl);
+    if (proxy != NULL
+        && !OSSL_HTTP_parse_url(proxy, NULL /* use_ssl */, NULL /* user */,
+            &proxy_host, &proxy_port, NULL /* num */,
+            NULL /* path */, NULL, NULL))
+        return NULL;
+    cbio = BIO_new(BIO_s_mem());
+    OPENSSL_free(proxy_host);
+    OPENSSL_free(proxy_port);
+    if (cbio == NULL)
+        return NULL;
+    if (use_ssl) {
+        BIO_puts(cbio, "HTTP/1.0 200\r\n\r\n"); /* fake HTTPS proxy CONNECT response */
+
+        if (!OSSL_HTTP_proxy_connect(cbio, server, port, HTTP_TEST_PROXY_USER,
+                HTTP_TEST_PROXY_PASS, 0, NULL, NULL))
+            goto err;
+    }
+
+    if (bio_update_fn != NULL) {
+        BIO *orig_bio = cbio;
+
+        cbio = (*bio_update_fn)(cbio, arg, 1 /* connect */, use_ssl != 0);
+        if (cbio == NULL) {
+            cbio = orig_bio;
+            goto err;
+        }
+    }
+    return cbio;
+
+err:
+    BIO_free(cbio);
+    return NULL;
+}
+
+static int bio_update_fn_detail = -1; /* initial value indicates function not yet called */
+static BIO *bio_update_fn(BIO *bio, void *arg, int connect, int detail)
+{
+    void *my_ctx = arg;
+    int use_ssl = detail;
+
+    bio_update_fn_detail = use_ssl;
+    return connect == 1 && use_ssl == (my_ctx != NULL) ? bio : NULL;
+}
+
+static int test_http_open_requesting_proxy(int use_ssl)
+{
+    int dummy_ctx[1];
+    void *my_ctx = use_ssl ? dummy_ctx : NULL;
+    BIO *bio = dummy_HTTP_open("dummy-server.com", NULL /* port */,
+        HTTP_TEST_PROXY_USER ":" HTTP_TEST_PROXY_PASS "@dummy-proxy.org",
+        "dummy-no_proxy.com", use_ssl, bio_update_fn, my_ctx);
+
+    if (TEST_ptr(bio) == 0 || !TEST_int_eq(bio_update_fn_detail, use_ssl))
+        return 0;
+
+    BIO_free(bio);
+    return 1;
+}
+
 static int test_http_keep_alive(char version, int keep_alive, int kept_alive)
 {
     BIO *wbio = BIO_new(BIO_s_mem());
@@ -540,6 +613,16 @@ static int test_http_post_x509_error_status(void)
     return test_http_method(0 /* POST */, 0, HTTP_STATUS_CODES_NONFATAL_ERROR);
 }
 
+static int test_http_open_requesting_HTTP_proxy(void)
+{
+    return test_http_open_requesting_proxy(0);
+}
+
+static int test_http_open_requesting_HTTPS_proxy(void)
+{
+    return test_http_open_requesting_proxy(1);
+}
+
 static int test_http_keep_alive_0_no_no(void)
 {
     return test_http_keep_alive('0', 0, 0);
@@ -690,6 +773,9 @@ int setup_tests(void)
     ADD_TEST(test_http_post_x509);
     ADD_TEST(test_http_post_x509_fatal_status);
     ADD_TEST(test_http_post_x509_error_status);
+
+    ADD_TEST(test_http_open_requesting_HTTP_proxy);
+    ADD_TEST(test_http_open_requesting_HTTPS_proxy);
 
     ADD_TEST(test_http_keep_alive_0_no_no);
     ADD_TEST(test_http_keep_alive_1_no_no);

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5716,6 +5716,7 @@ ASN1_BIT_STRING_set1                    5713	4_0_0	EXIST::FUNCTION:
 OSSL_ESS_check_signing_certs_ex         5714	4_0_0	EXIST::FUNCTION:
 X509v3_delete_extension                 5715	4_0_0	EXIST::FUNCTION:
 CTLOG_STORE_add0_log                    ?	4_1_0	EXIST::FUNCTION:CT
+OSSL_HTTP_REQ_CTX_proxy_connect         ?	4_1_0	EXIST::FUNCTION:HTTP
 CRYPTO_atomic_load_ptr                  ?	4_1_0	EXIST::FUNCTION:
 CRYPTO_atomic_store_ptr                 ?	4_1_0	EXIST::FUNCTION:
 CRYPTO_atomic_cmp_exch_ptr              ?	4_1_0	EXIST::FUNCTION:

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5718,6 +5718,7 @@ X509v3_delete_extension                 5715	4_0_0	EXIST::FUNCTION:
 CMS_SignerInfo_get0_signer_cert         ?	4_1_0	EXIST::FUNCTION:CMS
 CMS_SignerInfo_get_verification_result  ?	4_1_0	EXIST::FUNCTION:CMS
 CTLOG_STORE_add0_log                    ?	4_1_0	EXIST::FUNCTION:CT
+OSSL_HTTP_REQ_CTX_proxy_connect         ?	4_1_0	EXIST::FUNCTION:HTTP
 CRYPTO_atomic_load_ptr                  ?	4_1_0	EXIST::FUNCTION:
 CRYPTO_atomic_store_ptr                 ?	4_1_0	EXIST::FUNCTION:
 CRYPTO_atomic_cmp_exch_ptr              ?	4_1_0	EXIST::FUNCTION:


### PR DESCRIPTION
This fixes minor bugs and handles a design flaw with the `bio_update_fn` connect/disconnect callback function of type `OSSL_HTTP_bio_cb_t` not having a parameter of type `OSSL_HTTP_REQ_CTX *`, which causes trouble with connecting via an HTTPS proxy during TLS connection setup because this needs access to the proxy and no_proxy information. Moreover, the callback needs access to the `SSL_CTX` and to the server hostname for setting the Server Name Indication (SNI). All of this has been done so far in a pretty cumbersome and not entirely correct way.

~Make sure that `OSSL_HTTP_proxy_connect()` is called if and only if needed with TLS.
   So far, this did not correctly take into account the environment variables `https_proxy` and `no_proxy`.
   Doing this fix unfortunately requires generalizing the callback function such that it can take into account whether a proxy is actually being used during connection setup.
   This is done in a binary backward compatible way: by adding to `OSSL_HTTP_bio_cb_t` an `rtcx` parameter that can be used unless the `details` parameter is `1` on connect, which is tried first for compatibility with OpenSSL 3.0.
 The generalization also makes the design of `OSSL_HTTP_bio_cb_t` more future-proof.~

~Also introduce `OSSL_HTTP_REQ_CTX_proxy_connect()`, an improved variant of `OSSL_HTTP_proxy_connect()`, which strongly simplifies the use of the callback function, e.g., in `apps/`.~

**Update of Feb 9, 2026:** 
I recently found a way of working around the  missing `OSSL_HTTP_REQ_CTX` pointer that does not require adding a parameter to `OSSL_HTTP_bio_cb_t`, which would have incurred an API break.
This is possible by introducing `OSSL_HTTP_REQ_CTX_proxy_connect()`, a variant of `OSSL_HTTP_proxy_connect()`
 that uses a `OSSL_HTTP_REQ_CTX` pointer, and calling this function (in case an SSL/TLS connection is being opened)
already from `OSSL_HTTP_open()`, where the pointer is available, rather than letting the callback do this.
Moreover, using `SSL_CTX_{set,get}_ex_data()` to convey the server host name via the `SSL_CTX`
to the callback function avoids having to pass the server name via the generic callback arg.
As a result, the callback arg can be reduced to the bare minimum: a pointer to the `SSL_CTX`.

Implementing this improvement I noticed that that userinfo (user name and password) that can be provided with the proxy URI was not used, neither for the HTTP nor the HTTPS proxy case. I added this. 

This PR also includes several fixes:
* added several missing failure checks to `OSSL_HTTP_proxy_connect()`
* fix `OSSL_HTTP_open()` to include in the `Host:` header line the server port, which is needed for non-default ports
* fix the CMP app to provide the right proxy usage info

* ~Fix cleanup of TLS BIO via `bio_update_fn` callback function.
   Make `app_http_tls_cb()` tidy up on disconnect the SSL BIO it pushes on connect.
   Make `OSSL_HTTP_close()` respect this.~

* ~`OSSL_HTTP_proxy_connect()`: Fix glitch in response HTTP header parsing.~

~It would be good to have CI tests for using an HTTP(S) proxy, but this would require providing within OpenSSL a test proxy that supports HTTP and HTTPS connections.~
This PR meanwhile contains client-side unit tests for the provided improvements of HTTP(S) proxy use,
which has become possible after lifting some not really needed argument restrictions of `OSSL_HTTP_open()`.
I tested the improved implementation also with external both HTTP and HTTPS proxies, including proxy client credential (user name and password) usage.

~This PR also includes a commit that fixes an omission documenting the `ok` parameter of `OSSL_HTTP_close()`.~
