### PR TITLE
 Implement a new flag for running s_client in a non-interactive mode

### DIFF
--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -2949,7 +2949,7 @@ int s_client_main(int argc, char **argv)
             }
         }
 
-        /*don't wait for client input in the non-interactive mode*/
+        /* don't wait for client input in the non-interactive mode */
         if (nointeractive) {
             ret = 0;
             goto shut;

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -2950,7 +2950,7 @@ int s_client_main(int argc, char **argv)
         }
 
         /* don't wait for client input in the non-interactive mode */
-        if (nointeractive) {
+        else if (nointeractive) {
             ret = 0;
             goto shut;
         }

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -434,7 +434,7 @@ typedef enum OPTION_choice {
     OPT_XMPPHOST, OPT_VERIFY, OPT_NAMEOPT,
     OPT_CERT, OPT_CRL, OPT_CRL_DOWNLOAD, OPT_SESS_OUT, OPT_SESS_IN,
     OPT_CERTFORM, OPT_CRLFORM, OPT_VERIFY_RET_ERROR, OPT_VERIFY_QUIET,
-    OPT_BRIEF, OPT_PREXIT, OPT_CRLF, OPT_QUIET, OPT_NBIO,
+    OPT_BRIEF, OPT_PREXIT, OPT_NO_INTERACTIVE, OPT_CRLF, OPT_QUIET, OPT_NBIO,
     OPT_SSL_CLIENT_ENGINE, OPT_IGN_EOF, OPT_NO_IGN_EOF,
     OPT_DEBUG, OPT_TLSEXTDEBUG, OPT_STATUS, OPT_WDEBUG,
     OPT_MSG, OPT_MSGFILE, OPT_ENGINE, OPT_TRACE, OPT_SECURITY_DEBUG,
@@ -569,6 +569,8 @@ const OPTIONS s_client_options[] = {
      "Restrict output to brief summary of connection parameters"},
     {"prexit", OPT_PREXIT, '-',
      "Print session information when the program exits"},
+    {"no-interactive", OPT_NO_INTERACTIVE, '-',
+     "Don't run the client in the interactive mode"},
 
     OPT_SECTION("Debug"),
     {"showcerts", OPT_SHOWCERTS, '-',
@@ -822,6 +824,7 @@ int s_client_main(int argc, char **argv)
     int build_chain = 0, cbuf_len, cbuf_off, cert_format = FORMAT_UNDEF;
     int key_format = FORMAT_UNDEF, crlf = 0, full_log = 1, mbuf_len = 0;
     int prexit = 0;
+    int nointeractive = 0;
     int sdebug = 0;
     int reconnect = 0, verify = SSL_VERIFY_NONE, vpmtouched = 0;
     int ret = 1, in_init = 1, i, nbio_test = 0, sock = -1, k, width, state = 0;
@@ -1078,6 +1081,9 @@ int s_client_main(int argc, char **argv)
             break;
         case OPT_PREXIT:
             prexit = 1;
+            break;
+        case OPT_NO_INTERACTIVE:
+            nointeractive = 1;
             break;
         case OPT_CRLF:
             crlf = 1;
@@ -2942,6 +2948,13 @@ int s_client_main(int argc, char **argv)
                 goto shut;
             }
         }
+
+        /*don't wait for client input in the non-interactive mode*/
+        if (nointeractive) {
+            ret = 0;
+            goto shut;
+        }
+
 /* OPENSSL_SYS_MSDOS includes OPENSSL_SYS_WINDOWS */
 #if defined(OPENSSL_SYS_MSDOS)
         else if (has_stdin_waiting())

--- a/doc/man1/openssl-s_client.pod.in
+++ b/doc/man1/openssl-s_client.pod.in
@@ -48,6 +48,7 @@ B<openssl> B<s_client>
 [B<-reconnect>]
 [B<-showcerts>]
 [B<-prexit>]
+[B<-no-interactive>]
 [B<-debug>]
 [B<-trace>]
 [B<-nocommands>]
@@ -417,6 +418,10 @@ because a client certificate is required or is requested only after an
 attempt is made to access a certain URL. Note: the output produced by this
 option is not always accurate because a connection might never have been
 established.
+
+=item B<-no-interactive>
+
+This flag can be used to run the client in a non-interactive mode.
 
 =item B<-state>
 


### PR DESCRIPTION
Hi,

This task aims to provide a new flag which can be used to run the s_client in a non-interactive mode. This can be helpful to test a  server without providing any user input. The process will be terminated after showing/verifying the server tls data.

Many developers want to test the server certificates or some TLS related stuff without any further interactions with the server. I have seen a lot of workarounds to achieve that, like piping QUIT, etc. But such approaches are not always trivial when switching the OS, executing the commands from different programming languages and so on..

I had to re-open a new pull request due to some branching issues I had.. Old conversations can be found here: https://github.com/openssl/openssl/pull/17096.

- [x] documentation is added or updated

Any feedback would be greatly appreciated. Thank you!

KR,
Rami