### PR TITLE
bn_ppc: Move the extern functions to global scope and add ifdef

### DIFF
--- a/crypto/bn/bn_ppc.c
+++ b/crypto/bn/bn_ppc.c
@@ -12,20 +12,22 @@
 #include "crypto/ppc_arch.h"
 #include "bn_local.h"
 
+int bn_mul_mont_int(BN_ULONG *rp, const BN_ULONG *ap, const BN_ULONG *bp,
+                    const BN_ULONG *np, const BN_ULONG *n0, int num);
+int bn_mul4x_mont_int(BN_ULONG *rp, const BN_ULONG *ap, const BN_ULONG *bp,
+                      const BN_ULONG *np, const BN_ULONG *n0, int num);
+#if defined(_ARCH_PPC64)
+int bn_mul_mont_fixed_n6(BN_ULONG *rp, const BN_ULONG *ap,
+                         const BN_ULONG *bp, const BN_ULONG *np,
+                         const BN_ULONG *n0, int num);
+int bn_mul_mont_300_fixed_n6(BN_ULONG *rp, const BN_ULONG *ap,
+                             const BN_ULONG *bp, const BN_ULONG *np,
+                             const BN_ULONG *n0, int num);
+#endif
+
 int bn_mul_mont(BN_ULONG *rp, const BN_ULONG *ap, const BN_ULONG *bp,
                 const BN_ULONG *np, const BN_ULONG *n0, int num)
 {
-    int bn_mul_mont_int(BN_ULONG *rp, const BN_ULONG *ap, const BN_ULONG *bp,
-                        const BN_ULONG *np, const BN_ULONG *n0, int num);
-    int bn_mul4x_mont_int(BN_ULONG *rp, const BN_ULONG *ap, const BN_ULONG *bp,
-                          const BN_ULONG *np, const BN_ULONG *n0, int num);
-    int bn_mul_mont_fixed_n6(BN_ULONG *rp, const BN_ULONG *ap,
-                             const BN_ULONG *bp, const BN_ULONG *np,
-                             const BN_ULONG *n0, int num);
-    int bn_mul_mont_300_fixed_n6(BN_ULONG *rp, const BN_ULONG *ap,
-                                 const BN_ULONG *bp, const BN_ULONG *np,
-                                 const BN_ULONG *n0, int num);
-
     if (num < 4)
         return 0;
 


### PR DESCRIPTION
It seems some AIX compilers do not cope with them correctly otherwise.

Fixes #17087
