### PR TITLE
Fix OSSL_PARAM_allocate_from_text() to do sign extension

### DIFF
--- a/crypto/cpt_err.c
+++ b/crypto/cpt_err.c
@@ -29,6 +29,8 @@ static const ERR_STRING_DATA CRYPTO_str_reasons[] = {
     "insufficient param size"},
     {ERR_PACK(ERR_LIB_CRYPTO, 0, CRYPTO_R_INSUFFICIENT_SECURE_DATA_SPACE),
     "insufficient secure data space"},
+    {ERR_PACK(ERR_LIB_CRYPTO, 0, CRYPTO_R_INVALID_NEGATIVE_VALUE),
+    "invalid negative value"},
     {ERR_PACK(ERR_LIB_CRYPTO, 0, CRYPTO_R_INVALID_NULL_ARGUMENT),
     "invalid null argument"},
     {ERR_PACK(ERR_LIB_CRYPTO, 0, CRYPTO_R_INVALID_OSSL_PARAM_TYPE),

--- a/crypto/err/openssl.txt
+++ b/crypto/err/openssl.txt
@@ -434,6 +434,7 @@ CRYPTO_R_ILLEGAL_HEX_DIGIT:102:illegal hex digit
 CRYPTO_R_INSUFFICIENT_DATA_SPACE:106:insufficient data space
 CRYPTO_R_INSUFFICIENT_PARAM_SIZE:107:insufficient param size
 CRYPTO_R_INSUFFICIENT_SECURE_DATA_SPACE:108:insufficient secure data space
+CRYPTO_R_INVALID_NEGATIVE_VALUE:122:invalid negative value
 CRYPTO_R_INVALID_NULL_ARGUMENT:109:invalid null argument
 CRYPTO_R_INVALID_OSSL_PARAM_TYPE:110:invalid ossl param type
 CRYPTO_R_ODD_NUMBER_OF_DIGITS:103:odd number of digits

--- a/crypto/params_from_text.c
+++ b/crypto/params_from_text.c
@@ -54,6 +54,12 @@ static int prepare_from_text(const OSSL_PARAM *paramdefs, const char *key,
         if (r == 0 || *tmpbn == NULL)
             return 0;
 
+        if (p->data_type == OSSL_PARAM_UNSIGNED_INTEGER
+            && BN_is_negative(*tmpbn)) {
+            ERR_raise(ERR_LIB_CRYPTO, CRYPTO_R_INVALID_NEGATIVE_VALUE);
+            return 0;
+        }
+
         /*
          * 2s complement negate, part 1
          *

--- a/crypto/params_from_text.c
+++ b/crypto/params_from_text.c
@@ -61,7 +61,7 @@ static int prepare_from_text(const OSSL_PARAM *paramdefs, const char *key,
         }
 
         /*
-         * 2s complement negate, part 1
+         * 2's complement negate, part 1
          *
          * BN_bn2nativepad puts the absolute value of the number in the
          * buffer, i.e. if it's negative, we need to deal with it.  We do
@@ -76,6 +76,20 @@ static int prepare_from_text(const OSSL_PARAM *paramdefs, const char *key,
         }
 
         buf_bits = (size_t)BN_num_bits(*tmpbn);
+
+        /*
+         * Compensate for cases where the most significant bit in
+         * the resulting OSSL_PARAM buffer will be set after the
+         * BN_bn2nativepad() call, as the implied sign may not be
+         * correct after the second part of the 2's complement
+         * negation has been performed.
+         * We fix these cases by extending the buffer by one byte
+         * (8 bits), which will give some padding.  The second part
+         * of the 2's complement negation will do the rest.
+         */
+        if (p->data_type == OSSL_PARAM_INTEGER && buf_bits % 8 == 0)
+            buf_bits += 8;
+
         *buf_n = (buf_bits + 7) / 8;
 
         /*
@@ -83,9 +97,7 @@ static int prepare_from_text(const OSSL_PARAM *paramdefs, const char *key,
          * range checking if a size is specified.
          */
         if (p->data_size > 0) {
-            if (buf_bits > p->data_size * 8
-                || (p->data_type == OSSL_PARAM_INTEGER
-                    && buf_bits == p->data_size * 8)) {
+            if (buf_bits > p->data_size * 8) {
                 ERR_raise(ERR_LIB_CRYPTO, CRYPTO_R_TOO_SMALL_BUFFER);
                 /* Since this is a different error, we don't break */
                 return 0;
@@ -135,7 +147,7 @@ static int construct_from_text(OSSL_PARAM *to, const OSSL_PARAM *paramdef,
             BN_bn2nativepad(tmpbn, buf, buf_n);
 
             /*
-             * 2s complement negate, part two.
+             * 2's complement negation, part two.
              *
              * Because we did the first part on the BIGNUM itself, we can just
              * invert all the bytes here and be done with it.

--- a/include/openssl/cryptoerr.h
+++ b/include/openssl/cryptoerr.h
@@ -28,6 +28,7 @@
 # define CRYPTO_R_INSUFFICIENT_DATA_SPACE                 106
 # define CRYPTO_R_INSUFFICIENT_PARAM_SIZE                 107
 # define CRYPTO_R_INSUFFICIENT_SECURE_DATA_SPACE          108
+# define CRYPTO_R_INVALID_NEGATIVE_VALUE                  122
 # define CRYPTO_R_INVALID_NULL_ARGUMENT                   109
 # define CRYPTO_R_INVALID_OSSL_PARAM_TYPE                 110
 # define CRYPTO_R_ODD_NUMBER_OF_DIGITS                    103


### PR DESCRIPTION
OSSL_PARAM_allocate_from_text() doesn't do sign extension when it should.
See #17103.
