### PR TITLE
Increment the OSSL_DYNAMIC_VERSION

### DIFF
--- a/include/openssl/engine.h
+++ b/include/openssl/engine.h
@@ -717,12 +717,12 @@ OSSL_DEPRECATEDIN_3_0 void ENGINE_add_conf_module(void);
 /**************************/
 
 /* Binary/behaviour compatibility levels */
-#  define OSSL_DYNAMIC_VERSION            (unsigned long)0x00030000
+#  define OSSL_DYNAMIC_VERSION            (unsigned long)0x00040000
 /*
  * Binary versions older than this are too old for us (whether we're a loader
  * or a loadee)
  */
-#  define OSSL_DYNAMIC_OLDEST             (unsigned long)0x00030000
+#  define OSSL_DYNAMIC_OLDEST             (unsigned long)0x00040000
 
 /*
  * When compiling an ENGINE entirely as an external shared library, loadable


### PR DESCRIPTION
Engines built using OpenSSL 1.1.1
are not compatible with OpenSSL 3.0.

Fixes #17103
