### PR TITLE
add check for the return value of OPENSSL_strdup(CRYPTO_strdup)

### DIFF
--- a/apps/lib/engine_loader.c
+++ b/apps/lib/engine_loader.c
@@ -91,7 +91,7 @@ static OSSL_STORE_LOADER_CTX *engine_open(const OSSL_STORE_LOADER *loader,
         keyid = OPENSSL_strdup(q + 1);
     }
 
-    if (e != NULL)
+    if (e != NULL && keyid != NULL)
         ctx = OSSL_STORE_LOADER_CTX_new(e, keyid);
 
     if (ctx == NULL) {


### PR DESCRIPTION
check the return value of OPENSSL_strdup to prevent potential memory access error.