### PR TITLE
Prevent crash with engine using different openssl runtime

### DIFF
--- a/crypto/engine/eng_dyn.c
+++ b/crypto/engine/eng_dyn.c
@@ -451,8 +451,17 @@ static int dynamic_load(ENGINE *e, dynamic_data_ctx *ctx)
          * We fail if the version checker veto'd the load *or* if it is
          * deferring to us (by returning its version) and we think it is too
          * old.
+         * Unfortunately the version checker does not distinguish between
+         * engines built for openssl 1.1.x and openssl 3.x, but loading
+         * an engine that is built for openssl 1.1.x will cause a fatal
+         * error.  Detect such engines, since EVP_PKEY_base_id is exported
+         * as a function in openssl 1.1.x, while it is a macro in openssl 3.x,
+         * and therefore only the symbol EVP_PKEY_get_base_id is available
+         * in openssl 3.x.
          */
-        if (vcheck_res < OSSL_DYNAMIC_OLDEST) {
+        if (vcheck_res < OSSL_DYNAMIC_OLDEST
+                || DSO_bind_func(ctx->dynamic_dso,
+                                 "EVP_PKEY_base_id") != NULL) {
             /* Fail */
             ctx->bind_engine = NULL;
             ctx->v_check = NULL;

--- a/include/openssl/engine.h
+++ b/include/openssl/engine.h
@@ -801,6 +801,7 @@ typedef int (*dynamic_bind_engine) (ENGINE *e, const char *id,
             CRYPTO_set_mem_functions(fns->mem_fns.malloc_fn, \
                                      fns->mem_fns.realloc_fn, \
                                      fns->mem_fns.free_fn); \
+            OPENSSL_init_crypto(OPENSSL_INIT_NO_ATEXIT, NULL); \
         skip_cbs: \
             if (!fn(e, id)) return 0; \
             return 1; }


### PR DESCRIPTION
This problem happens usually because an application
links libcrypto and/or libssl statically which
installs an atexit handler, but later an engine using
a shared instance of libcrypto is installed.
The problem is in simple words that both instances
of libcrypto have an atexit handler installed,
but both are unable to coordinate with each other,
which causes a crash, typically a use-after-free
in the engine's destroy function.

Work around that by preventing the engine's
libcrypto to install the atexit handler.
This may result in a small memory leak, but that
memory is still reachable.

Fixes #15898
