### PR TITLE
add a check for the return value of OPENSSL_strdup in app_rand.c:112

### DIFF
--- a/apps/lib/app_rand.c
+++ b/apps/lib/app_rand.c
@@ -110,6 +110,8 @@ int opt_rand(int opt)
     case OPT_R_WRITERAND:
         OPENSSL_free(save_rand_file);
         save_rand_file = OPENSSL_strdup(opt_arg());
+        if (save_rand_file == NULL)
+            return 0;
         break;
     }
     return 1;


### PR DESCRIPTION
check the return value of OPENSSL_strdup(CRYPTO_strdup) in app_rand.c:112 to prevent potential memory access error.