### PR TITLE
EVP_MD_CTX_copy_ex: Allow copying uninitialized digest contexts

### DIFF
--- a/crypto/evp/digest.c
+++ b/crypto/evp/digest.c
@@ -510,9 +510,18 @@ int EVP_MD_CTX_copy_ex(EVP_MD_CTX *out, const EVP_MD_CTX *in)
 {
     unsigned char *tmp_buf;
 
-    if (in == NULL || in->digest == NULL) {
-        ERR_raise(ERR_LIB_EVP, EVP_R_INPUT_NOT_INITIALIZED);
+    if (in == NULL) {
+        ERR_raise(ERR_LIB_EVP, ERR_R_PASSED_NULL_PARAMETER);
         return 0;
+    }
+
+    if (in->digest == NULL) {
+        /* copying uninitialized digest context */
+        EVP_MD_CTX_reset(out);
+        if (out->fetched_digest != NULL)
+            EVP_MD_free(out->fetched_digest);
+        *out = *in;
+        return 1;
     }
 
     if (in->digest->prov == NULL

--- a/test/evp_extra_test2.c
+++ b/test/evp_extra_test2.c
@@ -853,6 +853,22 @@ static int test_rsa_pss_sign(void)
     return ret;
 }
 
+static int test_evp_md_ctx_copy(void)
+{
+    EVP_MD_CTX *mdctx = NULL;
+    EVP_MD_CTX *copyctx = NULL;
+    int ret;
+
+    /* test copying freshly initialized context */
+    ret = TEST_ptr(mdctx = EVP_MD_CTX_new())
+          && TEST_ptr(copyctx = EVP_MD_CTX_new())
+          && TEST_true(EVP_MD_CTX_copy_ex(copyctx, mdctx));
+
+    EVP_MD_CTX_free(mdctx);
+    EVP_MD_CTX_free(copyctx);
+    return ret;
+}
+
 int setup_tests(void)
 {
     if (!test_get_libctx(&mainctx, &nullprov, NULL, NULL, NULL)) {
@@ -879,6 +895,7 @@ int setup_tests(void)
 #endif
     ADD_ALL_TESTS(test_PEM_read_bio_negative, OSSL_NELEM(keydata));
     ADD_TEST(test_rsa_pss_sign);
+    ADD_TEST(test_evp_md_ctx_copy);
     return 1;
 }
 


### PR DESCRIPTION
There is no point it should not be allowed and it is causing problems like:
https://github.com/openssl/openssl/issues/17064#issuecomment-975781950

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
