### PR TITLE
check the return value of OPENSSL_strdup(CRYPTO_strdup) in app_rand.c:32

### DIFF
--- a/apps/lib/app_rand.c
+++ b/apps/lib/app_rand.c
@@ -28,8 +28,14 @@ void app_RAND_load_conf(CONF *c, const char *section)
         BIO_printf(bio_err, "Can't load %s into RNG\n", randfile);
         ERR_print_errors(bio_err);
     }
-    if (save_rand_file == NULL)
+    if (save_rand_file == NULL) {
         save_rand_file = OPENSSL_strdup(randfile);
+        /* If some internal memory errors have occurred */
+        if (save_rand_file == NULL) {
+            BIO_printf(bio_err, "Can't duplicate %s\n", randfile);
+            ERR_print_errors(bio_err);
+        }
+    }
 }
 
 static int loadfiles(char *name)


### PR DESCRIPTION
Add a check for the the return value of OPENSSL_strdup(CRYPTO_strdup) in app_rand.c:32.
After further analysis, I find that this will not result in incorrect access to `save_rand_file` as app_rank.c:79 has a check for it in the current version.
However, once some internal memory allocation errors occur here, it means that there are other unknown memory risks in the subsequent running. So I think it is necessary to throw the error in time.