### PR TITLE
Don't delete the doc/html directories when cleaning

### DIFF
--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -462,10 +462,10 @@ libclean:
 	-del /Q /F $(LIBS) libcrypto.* libssl.* ossl_static.pdb
 
 clean: libclean
-	-rd /Q /S $(HTMLDOCS1_BLDDIRS)
-	-rd /Q /S $(HTMLDOCS3_BLDDIRS)
-	-rd /Q /S $(HTMLDOCS5_BLDDIRS)
-	-rd /Q /S $(HTMLDOCS7_BLDDIRS)
+	{- join("\n\t", map { "-del /Q /F $_" } @HTMLDOCS1) || "\@rem" -}
+	{- join("\n\t", map { "-del /Q /F $_" } @HTMLDOCS3) || "\@rem" -}
+	{- join("\n\t", map { "-del /Q /F $_" } @HTMLDOCS5) || "\@rem" -}
+	{- join("\n\t", map { "-del /Q /F $_" } @HTMLDOCS7) || "\@rem" -}
 	{- join("\n\t", map { "-del /Q /F $_" } @PROGRAMS) || "\@rem" -}
 	{- join("\n\t", map { "-del /Q /F $_" } @MODULES) || "\@rem" -}
 	{- join("\n\t", map { "-del /Q /F $_" } @SCRIPTS) || "\@rem" -}


### PR DESCRIPTION
The doc/html sub-dirs get created by Configure. Therefore they should
not be cleaned away by "nmake clean". Otherwise the following sequence
fails:

 perl Configure VC-WIN64A
 nmake clean
 nmake
 nmake install

Fixes #17114
