### PR TITLE
doc: remove non-existent callbacks

### DIFF
--- a/doc/man7/provider-base.pod
+++ b/doc/man7/provider-base.pod
@@ -42,11 +42,6 @@ provider-base
   */
  void *CRYPTO_malloc(size_t num, const char *file, int line);
  void *CRYPTO_zalloc(size_t num, const char *file, int line);
- void *CRYPTO_memdup(const void *str, size_t siz,
-                     const char *file, int line);
- char *CRYPTO_strdup(const char *str, const char *file, int line);
- char *CRYPTO_strndup(const char *str, size_t s,
-                      const char *file, int line);
  void CRYPTO_free(void *ptr, const char *file, int line);
  void CRYPTO_clear_free(void *ptr, size_t num,
                         const char *file, int line);
@@ -153,9 +148,6 @@ provider):
  core_obj_create                OSSL_FUNC_CORE_OBJ_CREATE
  CRYPTO_malloc                  OSSL_FUNC_CRYPTO_MALLOC
  CRYPTO_zalloc                  OSSL_FUNC_CRYPTO_ZALLOC
- CRYPTO_memdup                  OSSL_FUNC_CRYPTO_MEMDUP
- CRYPTO_strdup                  OSSL_FUNC_CRYPTO_STRDUP
- CRYPTO_strndup                 OSSL_FUNC_CRYPTO_STRNDUP
  CRYPTO_free                    OSSL_FUNC_CRYPTO_FREE
  CRYPTO_clear_free              OSSL_FUNC_CRYPTO_CLEAR_FREE
  CRYPTO_realloc                 OSSL_FUNC_CRYPTO_REALLOC
@@ -288,8 +280,7 @@ underlying signature or digest algorithm). For I<digest_name>, NULL or an
 empty string is permissible for signature algorithms that do not need a digest
 to operate correctly. The function returns 1 on success or 0 on failure.
 
-CRYPTO_malloc(), CRYPTO_zalloc(), CRYPTO_memdup(), CRYPTO_strdup(),
-CRYPTO_strndup(), CRYPTO_free(), CRYPTO_clear_free(),
+CRYPTO_malloc(), CRYPTO_zalloc(), CRYPTO_free(), CRYPTO_clear_free(),
 CRYPTO_realloc(), CRYPTO_clear_realloc(), CRYPTO_secure_malloc(),
 CRYPTO_secure_zalloc(), CRYPTO_secure_free(),
 CRYPTO_secure_clear_free(), CRYPTO_secure_allocated(),


### PR DESCRIPTION
These used to exist but were removed before release.
Updating the documentation was missed.

Fixes #17138

- [x] documentation is added or updated
- [ ] tests are added or updated
