### PR TITLE
Clarify use of `X509V3_set_ctx()`

### DIFF
--- a/crypto/x509/v3_san.c
+++ b/crypto/x509/v3_san.c
@@ -393,11 +393,11 @@ static GENERAL_NAMES *v2i_subject_alt(X509V3_EXT_METHOD *method,
 
     for (i = 0; i < num; i++) {
         cnf = sk_CONF_VALUE_value(nval, i);
-        if (!ossl_v3_name_cmp(cnf->name, "email")
+        if (ossl_v3_name_cmp(cnf->name, "email") == 0
             && cnf->value && strcmp(cnf->value, "copy") == 0) {
             if (!copy_email(ctx, gens, 0))
                 goto err;
-        } else if (!ossl_v3_name_cmp(cnf->name, "email")
+        } else if (ossl_v3_name_cmp(cnf->name, "email") == 0
                    && cnf->value && strcmp(cnf->value, "move") == 0) {
             if (!copy_email(ctx, gens, 1))
                 goto err;
@@ -434,10 +434,9 @@ static int copy_email(X509V3_CTX *ctx, GENERAL_NAMES *gens, int move_p)
         return 0;
     }
     /* Find the subject name */
-    if (ctx->subject_cert)
-        nm = X509_get_subject_name(ctx->subject_cert);
-    else
-        nm = X509_REQ_get_subject_name(ctx->subject_req);
+    nm = ctx->subject_cert != NULL ?
+        X509_get_subject_name(ctx->subject_cert) :
+        X509_REQ_get_subject_name(ctx->subject_req);
 
     /* Now add any email address(es) to STACK */
     while ((i = X509_NAME_get_index_by_NID(nm,

--- a/crypto/x509/v3_skid.c
+++ b/crypto/x509/v3_skid.c
@@ -105,7 +105,7 @@ static ASN1_OCTET_STRING *s2i_skey_id(X509V3_EXT_METHOD *method,
         return NULL;
     }
 
-    return ossl_x509_pubkey_hash(ctx->subject_req != NULL ?
-                                 ctx->subject_req->req_info.pubkey :
-                                 ctx->subject_cert->cert_info.key);
+    return ossl_x509_pubkey_hash(ctx->subject_cert != NULL ?
+                                 ctx->subject_cert->cert_info.key :
+                                 ctx->subject_req->req_info.pubkey);
 }

--- a/doc/man3/X509V3_set_ctx.pod
+++ b/doc/man3/X509V3_set_ctx.pod
@@ -18,12 +18,14 @@ X509V3_set_issuer_pkey - X.509 v3 extension generation utilities
 X509V3_set_ctx() fills in the basic fields of I<ctx> of type B<X509V3_CTX>,
 providing details potentially needed by functions producing X509 v3 extensions,
 e.g., to look up values for filling in authority key identifiers.
-Any of I<subj>, I<req>, or I<crl> may be provided, pointing to a certificate,
+Any of I<subject>, I<req>, or I<crl> may be provided, pointing to a certificate,
 certification request, or certificate revocation list, respectively.
-If I<subj> or I<crl> is provided, I<issuer> should point to its issuer,
+When constructing the subject key identifier of a certificate by computing a
+hash value of its public key, the public key is taken from I<subject> or I<req>.
+If I<subject> or I<crl> is provided, I<issuer> should point to its issuer,
 for instance to help generating an authority key identifier extension.
-Note that if I<subj> is provided, I<issuer> may be the same as I<subj>,
-which means that I<subj> is self-issued (or even self-signed).
+Note that if I<subject> is provided, I<issuer> may be the same as I<subject>,
+which means that I<subject> is self-issued (or even self-signed).
 I<flags> may be 0
 or contain B<X509V3_CTX_TEST>, which means that just the syntax of
 extension definitions is to be checked without actually producing an extension,

--- a/doc/man3/X509V3_set_ctx.pod
+++ b/doc/man3/X509V3_set_ctx.pod
@@ -22,6 +22,8 @@ Any of I<subject>, I<req>, or I<crl> may be provided, pointing to a certificate,
 certification request, or certificate revocation list, respectively.
 When constructing the subject key identifier of a certificate by computing a
 hash value of its public key, the public key is taken from I<subject> or I<req>.
+Similarly, when constructing subject alternative names from any email addresses
+contained in a subject DN, the subject DN is taken from I<subject> or I<req>.
 If I<subject> or I<crl> is provided, I<issuer> should point to its issuer,
 for instance to help generating an authority key identifier extension.
 Note that if I<subject> is provided, I<issuer> may be the same as I<subject>,

--- a/doc/man5/x509v3_config.pod
+++ b/doc/man5/x509v3_config.pod
@@ -229,9 +229,11 @@ B<dirName> (a distinguished name),
 and B<otherName>.
 The syntax of each is described in the following paragraphs.
 
-The B<email> option has a special C<copy> value, which will automatically
-include any email addresses contained in the certificate subject name in
-the extension.
+The B<email> option has two special values.
+C<copy> will automatically include any email addresses
+contained in the certificate subject name in the extension.
+C<move> will automatically move any email addresses
+from the certificate subject name to the extension.
 
 The IP address used in the B<IP> option can be in either IPv4 or IPv6 format.
 


### PR DESCRIPTION
This has been carved out from #16998 because it should be mergeable earlier.

This brings clarifications to the documentation and the code regarding the use of the `subject` and `req` parameters of `X509V3_set_ctx()`.

Also document the `email:move config` option value, which so far was missing from `x509v3_config.pod`.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
