### PR TITLE
No EtM for GOST ciphers in TLS 1.2

### DIFF
--- a/ssl/statem/extensions_clnt.c
+++ b/ssl/statem/extensions_clnt.c
@@ -1695,7 +1695,11 @@ int tls_parse_stoc_etm(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
     /* Ignore if inappropriate ciphersuite */
     if (!(s->options & SSL_OP_NO_ENCRYPT_THEN_MAC)
             && s->s3.tmp.new_cipher->algorithm_mac != SSL_AEAD
-            && s->s3.tmp.new_cipher->algorithm_enc != SSL_RC4)
+            && s->s3.tmp.new_cipher->algorithm_enc != SSL_RC4
+            && s->s3.tmp.new_cipher->algorithm_enc != SSL_eGOST2814789CNT
+            && s->s3.tmp.new_cipher->algorithm_enc != SSL_eGOST2814789CNT12
+            && s->s3.tmp.new_cipher->algorithm_enc != SSL_MAGMA
+            && s->s3.tmp.new_cipher->algorithm_enc != SSL_KUZNYECHIK)
         s->ext.use_etm = 1;
 
     return 1;


### PR DESCRIPTION
GOST ciphers don't use EtM. We don't send this extension in server and shouldn't set use_etm in client.
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
