### PR TITLE
Improve OSSL_PARAM locate performance

### DIFF
--- a/apps/build.info
+++ b/apps/build.info
@@ -18,7 +18,7 @@ $OPENSSLSRC=\
         pkcs8.c pkey.c pkeyparam.c pkeyutl.c prime.c rand.c req.c \
         s_client.c s_server.c s_time.c sess_id.c smime.c speed.c \
         spkac.c verify.c version.c x509.c rehash.c storeutl.c \
-        list.c info.c fipsinstall.c pkcs12.c
+        list.c info.c fipsinstall.c pkcs12.c ../crypto/param_trie.c
 IF[{- !$disabled{'ec'} -}]
   $OPENSSLSRC=$OPENSSLSRC ec.c ecparam.c
 ENDIF

--- a/crypto/build.info
+++ b/crypto/build.info
@@ -83,6 +83,8 @@ ENDIF
 DEFINE[../providers/libcommon.a]=$CPUIDDEF
 DEFINE[../providers/libdefault.a]=$CPUIDDEF
 
+SOURCE[../providers/libcommon.a]=param_trie.c
+
 # The Core
 $CORE_COMMON=provider_core.c provider_predefined.c \
         core_fetch.c core_algorithm.c core_namemap.c self_test_core.c
@@ -95,7 +97,8 @@ $UTIL_COMMON=\
         cryptlib.c params.c params_from_text.c bsearch.c ex_data.c o_str.c \
         threads_pthread.c threads_win.c threads_none.c initthread.c \
         context.c sparse_array.c asn1_dsa.c packet.c param_build.c \
-        param_build_set.c der_writer.c threads_lib.c params_dup.c
+        param_build_set.c der_writer.c threads_lib.c params_dup.c \
+        param_trie.c
 
 SOURCE[../libcrypto]=$UTIL_COMMON \
         mem.c mem_sec.c \

--- a/crypto/cpt_err.c
+++ b/crypto/cpt_err.c
@@ -17,8 +17,11 @@
 static const ERR_STRING_DATA CRYPTO_str_reasons[] = {
     {ERR_PACK(ERR_LIB_CRYPTO, 0, CRYPTO_R_BAD_ALGORITHM_NAME),
     "bad algorithm name"},
+    {ERR_PACK(ERR_LIB_CRYPTO, 0, CRYPTO_R_BAD_CHARACTER), "bad character"},
     {ERR_PACK(ERR_LIB_CRYPTO, 0, CRYPTO_R_CONFLICTING_NAMES),
     "conflicting names"},
+    {ERR_PACK(ERR_LIB_CRYPTO, 0, CRYPTO_R_DUPLICATE_PARAMETER),
+    "duplicate parameter"},
     {ERR_PACK(ERR_LIB_CRYPTO, 0, CRYPTO_R_HEX_STRING_TOO_SHORT),
     "hex string too short"},
     {ERR_PACK(ERR_LIB_CRYPTO, 0, CRYPTO_R_ILLEGAL_HEX_DIGIT),

--- a/crypto/err/openssl.txt
+++ b/crypto/err/openssl.txt
@@ -428,7 +428,9 @@ CRMF_R_UNSUPPORTED_METHOD_FOR_CREATING_POPO:115:\
 	unsupported method for creating popo
 CRMF_R_UNSUPPORTED_POPO_METHOD:116:unsupported popo method
 CRYPTO_R_BAD_ALGORITHM_NAME:117:bad algorithm name
+CRYPTO_R_BAD_CHARACTER:123:bad character
 CRYPTO_R_CONFLICTING_NAMES:118:conflicting names
+CRYPTO_R_DUPLICATE_PARAMETER:124:duplicate parameter
 CRYPTO_R_HEX_STRING_TOO_SHORT:121:hex string too short
 CRYPTO_R_ILLEGAL_HEX_DIGIT:102:illegal hex digit
 CRYPTO_R_INSUFFICIENT_DATA_SPACE:106:insufficient data space

--- a/crypto/param_trie.c
+++ b/crypto/param_trie.c
@@ -139,12 +139,13 @@ int ossl_ptrie_scan(const OSSL_PTRIE *pt, const OSSL_PARAM *params,
 
     if (params == NULL)
         return 0;
-    if (pt == NULL || n == 0 || indicies == NULL)
+    if (n == 0 || indicies == NULL)
         return 1;
     memset(indicies, NO_IDX, n * sizeof(unsigned char));
-    for (i = 0; params[i].key != NULL && (size_t)i < n; i++)
-        if ((idx = ptrie_search(pt, params[i].key)) != NO_IDX)
-            indicies[pt->trie[idx].paramidx] = i;
+    if (pt != NULL)
+        for (i = 0; params[i].key != NULL && (size_t)i < n; i++)
+            if ((idx = ptrie_search(pt, params[i].key)) != NO_IDX)
+                indicies[pt->trie[idx].paramidx] = i;
     return 1;
 #endif
 }
@@ -155,9 +156,8 @@ OSSL_PARAM *ossl_ptrie_locate(int idx, OSSL_PARAM *params,
 #ifndef OPENSSL_SMALL_FOOTPRINT
     if (params == NULL)
         return NULL;
-    
-    if (indicies != NULL && idx >= 0)
-        return indicies[idx] != NO_IDX ? params + indicies[idx] : NULL;
+    if (indicies != NULL && idx >= 0 && indicies[idx] != NO_IDX)
+        return params + indicies[idx];
 #endif /* OPENSSL_SMALL_FOOTPRINT */
     return OSSL_PARAM_locate(params, key);
 }

--- a/crypto/param_trie.c
+++ b/crypto/param_trie.c
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2021 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <string.h>
+#include <openssl/params.h>
+#include <openssl/crypto.h>
+#include <openssl/err.h>
+#include "crypto/param_trie.h"
+
+/* We need the run once to initialise the alphabet lookup table */
+#define ALLOW_RUN_ONCE_IN_FIPS
+#include "internal/thread_once.h"
+
+typedef unsigned char NODE_IDX;
+#define NO_IDX  255
+
+#ifndef OPENSSL_SMALL_FOOTPRINT
+static const char alphabet[] = "abcdefghijklmnopqrstuvwxyz0123456789-_";
+# define ALPHABET_SIZE (OSSL_NELEM(alphabet) - 1)
+# define TRIE_NODES  200
+
+struct ossl_ptrie_s {
+    NODE_IDX end;                   /* First unused node in the TRIE */
+    struct {
+        OSSL_PTRIE_PARAM_IDX paramidx;         /* Index into passed params */
+        NODE_IDX children[ALPHABET_SIZE];
+    } trie[TRIE_NODES];
+};
+
+static unsigned char alphabet_map[256];
+
+static void init_alphabet_table(void)
+{
+    unsigned int i;
+
+    memset(alphabet_map, 255, sizeof(alphabet_map));
+    for (i = 0; i < ALPHABET_SIZE; i++)
+        alphabet_map[(unsigned char)alphabet[i]] = i;
+}
+
+static CRYPTO_ONCE ptrie_init = CRYPTO_ONCE_STATIC_INIT;
+
+DEFINE_RUN_ONCE_STATIC(do_ptrie_init)
+{
+    init_alphabet_table();
+    return 1;
+}
+#endif /* OPENSSL_SMALL_FOOTPRINT */
+
+OSSL_PTRIE *ossl_ptrie_new(const OSSL_PARAM *params)
+{
+#ifndef OPENSSL_SMALL_FOOTPRINT
+    OSSL_PTRIE *pt = NULL;
+    OSSL_PTRIE_PARAM_IDX i;
+    unsigned char ch;
+    NODE_IDX idx;
+    const char *key;
+
+    if (params == NULL)
+        goto fail;
+    pt = OPENSSL_zalloc(sizeof(*pt));
+    pt->end = 1;
+    for (i = 0; i < TRIE_NODES; i++)
+        pt->trie[i].paramidx = NO_IDX;
+
+    if (!RUN_ONCE(&ptrie_init, do_ptrie_init))
+        goto fail;
+
+    for (i = 0; params[i].key != NULL; i++) {
+        idx = 0;
+        for (key = params[i].key; *key != '\0'; key++) {
+            ch = alphabet_map[(unsigned char)*key];
+            if (ch == 255) {
+                ERR_raise_data(ERR_LIB_CRYPTO, CRYPTO_R_BAD_CHARACTER,
+                               "`%c' is not valid in parameter keys", *key);
+                goto fail;
+            }
+            if (pt->trie[idx].children[ch] == 0) {
+                if (pt->end >= TRIE_NODES) {
+                    ERR_raise(ERR_LIB_CRYPTO, CRYPTO_R_TOO_MANY_RECORDS);
+                    goto fail;
+                }
+                pt->trie[idx].children[ch] = pt->end++;
+            }
+            idx = pt->trie[idx].children[ch];
+        }
+        if (pt->trie[idx].paramidx != NO_IDX) {
+            ERR_raise_data(ERR_LIB_CRYPTO, CRYPTO_R_DUPLICATE_PARAMETER,
+                           "duplicate param `%s'", params[i].key);
+            goto fail;
+        }
+        pt->trie[idx].paramidx = i;
+    }
+    return pt;
+
+ fail:
+    /* Failed to create the param TRIE, fall back to normal locate calls */
+    OPENSSL_free(pt);
+#endif /* OPENSSL_SMALL_FOOTPRINT */
+    return NULL;
+}
+
+void ossl_ptrie_free(OSSL_PTRIE *pt)
+{
+    OPENSSL_free(pt);
+}
+
+#ifndef OPENSSL_SMALL_FOOTPRINT
+static int ptrie_search(const OSSL_PTRIE *pt, const char *key)
+{
+    NODE_IDX idx;
+    unsigned char ch;
+
+    for (idx = 0; *key != '\0';) {
+        if ((ch = alphabet_map[(unsigned char)*key++]) == 0xff)
+            return NO_IDX;
+        idx = pt->trie[idx].children[ch];
+        if (idx == 0)
+            return NO_IDX;
+    }
+    return pt->trie[idx].paramidx == NO_IDX ? NO_IDX : idx;
+}
+#endif /* OPENSSL_SMALL_FOOTPRINT */
+
+int ossl_ptrie_scan(const OSSL_PTRIE *pt, const OSSL_PARAM *params,
+                    size_t n, OSSL_PTRIE_PARAM_IDX *indicies)
+{
+#ifdef OPENSSL_SMALL_FOOTPRINT
+    return params != NULL;
+#else
+    OSSL_PTRIE_PARAM_IDX i;
+    NODE_IDX idx;
+
+    if (params == NULL)
+        return 0;
+    if (pt == NULL || n == 0 || indicies == NULL)
+        return 1;
+    memset(indicies, NO_IDX, n * sizeof(unsigned char));
+    for (i = 0; params[i].key != NULL && (size_t)i < n; i++)
+        if ((idx = ptrie_search(pt, params[i].key)) != NO_IDX)
+            indicies[pt->trie[idx].paramidx] = i;
+    return 1;
+#endif
+}
+
+OSSL_PARAM *ossl_ptrie_locate(int idx, OSSL_PARAM *params,
+                              OSSL_PTRIE_PARAM_IDX *indicies, const char *key)
+{
+#ifndef OPENSSL_SMALL_FOOTPRINT
+    if (params == NULL)
+        return NULL;
+    
+    if (indicies != NULL && idx >= 0)
+        return indicies[idx] != NO_IDX ? params + indicies[idx] : NULL;
+#endif /* OPENSSL_SMALL_FOOTPRINT */
+    return OSSL_PARAM_locate(params, key);
+}
+
+const OSSL_PARAM *ossl_ptrie_locate_const(int idx, const OSSL_PARAM *params,
+                                          OSSL_PTRIE_PARAM_IDX *indicies,
+                                          const char *key)
+{
+    return ossl_ptrie_locate(idx, (OSSL_PARAM *)params, indicies, key);
+}

--- a/include/crypto/param_trie.h
+++ b/include/crypto/param_trie.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2021 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#ifndef OSSL_CRYPTO_PARAM_TRIE_H
+# define OSSL_CRYPTO_PARAM_TRIE_H
+# pragma once
+
+# include <openssl/params.h>
+# include "internal/nelem.h"
+
+typedef struct ossl_ptrie_s OSSL_PTRIE;
+typedef unsigned char OSSL_PTRIE_PARAM_IDX;
+
+OSSL_PTRIE *ossl_ptrie_new(const OSSL_PARAM *params);
+void ossl_ptrie_free(OSSL_PTRIE *pt);
+int ossl_ptrie_scan(const OSSL_PTRIE *pt, const OSSL_PARAM *params,
+                    size_t n, OSSL_PTRIE_PARAM_IDX *indicies);
+OSSL_PARAM *ossl_ptrie_locate(int idx, OSSL_PARAM *params,
+                              OSSL_PTRIE_PARAM_IDX *indicies, const char *key);
+const OSSL_PARAM *ossl_ptrie_locate_const(int idx, const OSSL_PARAM *params,
+                                          OSSL_PTRIE_PARAM_IDX *indicies,
+                                          const char *key);
+
+#endif  /* OSSL_CRYPTO_PARAM_TRIE_H */

--- a/include/openssl/cryptoerr.h
+++ b/include/openssl/cryptoerr.h
@@ -22,7 +22,9 @@
  * CRYPTO reason codes.
  */
 # define CRYPTO_R_BAD_ALGORITHM_NAME                      117
+# define CRYPTO_R_BAD_CHARACTER                           123
 # define CRYPTO_R_CONFLICTING_NAMES                       118
+# define CRYPTO_R_DUPLICATE_PARAMETER                     124
 # define CRYPTO_R_HEX_STRING_TOO_SHORT                    121
 # define CRYPTO_R_ILLEGAL_HEX_DIGIT                       102
 # define CRYPTO_R_INSUFFICIENT_DATA_SPACE                 106

--- a/providers/implementations/ciphers/ciphercommon.c
+++ b/providers/implementations/ciphers/ciphercommon.c
@@ -74,7 +74,7 @@ static const OSSL_PARAM cipher_aead_known_gettable_ctx_params[] = {
 static OSSL_PTRIE *generic_cipher_get_ptrie;
 static OSSL_PTRIE *generic_cipher_ctx_get_ptrie;
 
-#if !defined(OPENSSL_SMALL_FOOTPRINT) && !defined(FIPS_MODULE)
+#if !defined(FIPS_MODULE)
 static void cipher_free_trie_memory(void)
 {
     ossl_ptrie_free(generic_cipher_get_ptrie);
@@ -107,7 +107,6 @@ int ossl_cipher_generic_get_params(OSSL_PARAM params[], unsigned int md,
                                    size_t kbits, size_t blkbits, size_t ivbits)
 {
     OSSL_PARAM *p;
-    OSSL_PTRIE *pt;
     OSSL_PTRIE_PARAM_IDX indicies[OSSL_NELEM(cipher_known_gettable_params) - 1];
 
 #if !defined(FIPS_MODULE)
@@ -614,16 +613,15 @@ int ossl_cipher_generic_get_ctx_params(void *vctx, OSSL_PARAM params[])
 {
     PROV_CIPHER_CTX *ctx = (PROV_CIPHER_CTX *)vctx;
     OSSL_PARAM *p;
-    OSSL_PTRIE *pt;
     OSSL_PTRIE_PARAM_IDX indicies[OSSL_NELEM(cipher_aead_known_gettable_ctx_params) - 1];
 
-#if !defined(OPENSSL_SMALL_FOOTPRINT) && !defined(FIPS_MODULE)
+#if !defined(FIPS_MODULE)
     if (!RUN_ONCE(&cipher_common_init, do_cipher_common_init))
         return 0;
 #endif
-    pt = generic_cipher_ctx_get_ptrie;
 
-    if (!ossl_ptrie_scan(pt, params, OSSL_NELEM(indicies), indicies))
+    if (!ossl_ptrie_scan(generic_cipher_ctx_get_ptrie, params,
+                         OSSL_NELEM(indicies), indicies))
         return 0;
 
     p = ossl_ptrie_locate(CIPHER_CTX_GETTABLE_IVLEN, params, indicies,

--- a/providers/implementations/digests/digestcommon.c
+++ b/providers/implementations/digests/digestcommon.c
@@ -10,29 +10,83 @@
 #include <openssl/err.h>
 #include <openssl/proverr.h>
 #include "prov/digestcommon.h"
+#include "crypto/param_trie.h"
+#define ALLOW_RUN_ONCE_IN_FIPS
+#include "internal/thread_once.h"
+
+/* This enums *must* be in the same order at the param array */
+enum {
+    DIGEST_GETTABLE_BLOCK_SIZE,
+    DIGEST_GETTABLE_SIZE,
+    DIGEST_GETTABLE_XOF,
+    DIGEST_GETTABLE_ALGID_ABSENT
+};
+static const OSSL_PARAM digest_default_known_gettable_params[] = {
+    OSSL_PARAM_size_t(OSSL_DIGEST_PARAM_BLOCK_SIZE, NULL),
+    OSSL_PARAM_size_t(OSSL_DIGEST_PARAM_SIZE, NULL),
+    OSSL_PARAM_int(OSSL_DIGEST_PARAM_XOF, NULL),
+    OSSL_PARAM_int(OSSL_DIGEST_PARAM_ALGID_ABSENT, NULL),
+    OSSL_PARAM_END
+};
+
+static OSSL_PTRIE *generic_digest_get_ptrie;
+
+#if 0
+static void digest_free_trie_memory(void)
+{
+    ossl_ptrie_free(generic_digest_get_ptrie);
+}
+#endif
+
+static CRYPTO_ONCE digest_common_init = CRYPTO_ONCE_STATIC_INIT;
+DEFINE_RUN_ONCE_STATIC(do_digest_common_init)
+{
+    /*
+     * If this fails, it's not a problem because the code will
+     * fallback to a slower but equivalent path
+     */
+#if 0
+    if (OPENSSL_atexit(&digest_free_trie_memory))
+#endif
+        generic_digest_get_ptrie =
+                ossl_ptrie_new(digest_default_known_gettable_params);
+    return 1;
+}
 
 int ossl_digest_default_get_params(OSSL_PARAM params[], size_t blksz,
                                    size_t paramsz, unsigned long flags)
 {
     OSSL_PARAM *p = NULL;
+    OSSL_PTRIE_PARAM_IDX indicies[OSSL_NELEM(digest_default_known_gettable_params) - 1];
 
-    p = OSSL_PARAM_locate(params, OSSL_DIGEST_PARAM_BLOCK_SIZE);
+    if (!RUN_ONCE(&digest_common_init, do_digest_common_init))
+        return 0;
+
+    if (!ossl_ptrie_scan(generic_digest_get_ptrie, params,
+                         OSSL_NELEM(indicies), indicies))
+        return 0;
+
+    p = ossl_ptrie_locate(DIGEST_GETTABLE_BLOCK_SIZE, params, indicies,
+                          OSSL_DIGEST_PARAM_BLOCK_SIZE);
     if (p != NULL && !OSSL_PARAM_set_size_t(p, blksz)) {
         ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
         return 0;
     }
-    p = OSSL_PARAM_locate(params, OSSL_DIGEST_PARAM_SIZE);
+    p = ossl_ptrie_locate(DIGEST_GETTABLE_SIZE, params, indicies,
+                          OSSL_DIGEST_PARAM_SIZE);
     if (p != NULL && !OSSL_PARAM_set_size_t(p, paramsz)) {
         ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
         return 0;
     }
-    p = OSSL_PARAM_locate(params, OSSL_DIGEST_PARAM_XOF);
+    p = ossl_ptrie_locate(DIGEST_GETTABLE_XOF, params, indicies,
+                          OSSL_DIGEST_PARAM_XOF);
     if (p != NULL
         && !OSSL_PARAM_set_int(p, (flags & PROV_DIGEST_FLAG_XOF) != 0)) {
         ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
         return 0;
     }
-    p = OSSL_PARAM_locate(params, OSSL_DIGEST_PARAM_ALGID_ABSENT);
+    p = ossl_ptrie_locate(DIGEST_GETTABLE_ALGID_ABSENT, params, indicies,
+                          OSSL_DIGEST_PARAM_ALGID_ABSENT);
     if (p != NULL
         && !OSSL_PARAM_set_int(p, (flags & PROV_DIGEST_FLAG_ALGID_ABSENT) != 0)) {
         ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
@@ -41,13 +95,6 @@ int ossl_digest_default_get_params(OSSL_PARAM params[], size_t blksz,
     return 1;
 }
 
-static const OSSL_PARAM digest_default_known_gettable_params[] = {
-    OSSL_PARAM_size_t(OSSL_DIGEST_PARAM_BLOCK_SIZE, NULL),
-    OSSL_PARAM_size_t(OSSL_DIGEST_PARAM_SIZE, NULL),
-    OSSL_PARAM_int(OSSL_DIGEST_PARAM_XOF, NULL),
-    OSSL_PARAM_int(OSSL_DIGEST_PARAM_ALGID_ABSENT, NULL),
-    OSSL_PARAM_END
-};
 const OSSL_PARAM *ossl_digest_default_gettable_params(void *provctx)
 {
     return digest_default_known_gettable_params;

--- a/test/build.info
+++ b/test/build.info
@@ -62,7 +62,8 @@ IF[{- !$disabled{tests} -}]
           context_internal_test aesgcmtest params_test evp_pkey_dparams_test \
           keymgmt_internal_test hexstr_test provider_status_test defltfips_test \
           bio_readbuffer_test user_property_test pkcs7_test upcallstest \
-          provfetchtest prov_config_test rand_test
+          provfetchtest prov_config_test rand_test \
+          param_trie_test
 
   IF[{- !$disabled{'deprecated-3.0'} -}]
     PROGRAMS{noinst}=enginetest
@@ -857,6 +858,11 @@ IF[{- !$disabled{tests} -}]
   SOURCE[params_test]=params_test.c
   INCLUDE[params_test]=.. ../include ../apps/include
   DEPEND[params_test]=../libcrypto.a libtestutil.a
+
+  PROGRAMS{noinst}=param_trie_test
+  SOURCE[param_trie_test]=param_trie_test.c
+  INCLUDE[param_trie_test]=.. ../include ../apps/include
+  DEPEND[param_trie_test]=../libcrypto.a libtestutil.a
 
   PROGRAMS{noinst}=hexstr_test
   SOURCE[hexstr_test]=hexstr_test.c

--- a/test/param_trie_test.c
+++ b/test/param_trie_test.c
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2021 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://www.openssl.org/source/license.html
+ * or in the file LICENSE in the source distribution.
+ */
+
+/*
+ * This program tests the use of OSSL_PARAM TRIE.
+ */
+
+#include <openssl/core.h>
+#include <openssl/params.h>
+#include "internal/numbers.h"
+#include "crypto/param_trie.h"
+#include "internal/nelem.h"
+#include "testutil.h"
+
+static const OSSL_PARAM known[] = {
+    OSSL_PARAM_int("mmmmm", NULL),      /* 0 */
+    OSSL_PARAM_int("a", NULL),          /* 1 */
+    OSSL_PARAM_int("z", NULL),          /* 2 */
+    OSSL_PARAM_int("mmmmmm2", NULL),    /* 3 */
+    OSSL_PARAM_int("mmmmmm", NULL),     /* 4 */
+    OSSL_PARAM_int("aa", NULL),         /* 5 */
+    OSSL_PARAM_int("zz", NULL),         /* 6 */
+    OSSL_PARAM_int("dd", NULL),         /* 7 */
+    OSSL_PARAM_int("qq", NULL),         /* 8 */
+    OSSL_PARAM_END
+};
+static OSSL_PARAM passed[] = {
+    OSSL_PARAM_int("mmmmm", NULL),      /* 0 */
+    OSSL_PARAM_int("a", NULL),          /* 1 */
+    OSSL_PARAM_int("z", NULL),          /* 2 */
+    OSSL_PARAM_int("dd", NULL),         /* 3 */
+    OSSL_PARAM_int("qq", NULL),         /* 4 */
+    OSSL_PARAM_int("mmmmmm", NULL),     /* 5 */
+    OSSL_PARAM_int("mmmmmm2", NULL),    /* 6 */
+    OSSL_PARAM_int("zz", NULL),         /* 7 */
+    OSSL_PARAM_int("fnord", NULL),      /* 8 */
+    /* OSSL_PARAM_int("aa", NULL) is deliberately missing */
+    OSSL_PARAM_END
+};
+
+static int test_trie(void)
+{
+    OSSL_PTRIE *pt;
+    int res = 0;
+
+    OSSL_PTRIE_PARAM_IDX idxs[OSSL_NELEM(known) - 1];
+    pt = ossl_ptrie_new(known);
+#ifndef OPENSSL_SMALL_FOOTPRINT
+    if (!TEST_ptr(pt))
+        goto err;
+#endif
+    if (!TEST_true(ossl_ptrie_scan(pt, passed, OSSL_NELEM(idxs), idxs)))
+        goto err;
+
+    if (TEST_ptr_eq(ossl_ptrie_locate(0, passed, idxs, "mmmmm"), passed)
+            && TEST_ptr_eq(ossl_ptrie_locate(1, passed, idxs, "a"), passed + 1)
+            && TEST_ptr_eq(ossl_ptrie_locate(2, passed, idxs, "z"), passed + 2)
+            && TEST_ptr_eq(ossl_ptrie_locate(2, passed, NULL, "z"), passed + 2)
+            && TEST_ptr_eq(ossl_ptrie_locate(3, passed, idxs, "mmmmmm2"),
+                           passed + 6)
+            && TEST_ptr_eq(ossl_ptrie_locate(4, passed, idxs, "mmmmmm"),
+                           passed + 5)
+            && TEST_ptr_null(ossl_ptrie_locate_const(5, passed, idxs, "aa"))
+            && TEST_ptr_eq(ossl_ptrie_locate_const(6, passed, idxs, "zz"),
+                           passed + 7)
+            && TEST_ptr_eq(ossl_ptrie_locate_const(7, passed, idxs, "dd"),
+                           passed + 3)
+            && TEST_ptr_eq(ossl_ptrie_locate_const(8, passed, idxs, "qq"),
+                           passed + 4)
+            && TEST_ptr_eq(ossl_ptrie_locate_const(-1, passed, idxs, "fnord"),
+                                                   passed + 8)
+            && TEST_ptr_eq(ossl_ptrie_locate_const(-1, passed, NULL, "fnord"),
+                                                   passed + 8)
+            && TEST_ptr_eq(ossl_ptrie_locate(-1, passed, idxs, "mmmmm"), passed)
+            && TEST_ptr_eq(ossl_ptrie_locate(-1, passed, idxs, "a"), passed + 1)
+            && TEST_ptr_eq(ossl_ptrie_locate(-1, passed, idxs, "z"), passed + 2)
+            && TEST_ptr_eq(ossl_ptrie_locate(-1, passed, idxs, "mmmmmm2"),
+                                             passed + 6)
+            && TEST_ptr_eq(ossl_ptrie_locate(-1, passed, idxs, "mmmmmm"),
+                                             passed + 5)
+            && TEST_ptr_null(ossl_ptrie_locate_const(-1, passed, idxs, "aa"))
+            && TEST_ptr_eq(ossl_ptrie_locate_const(-1, passed, idxs, "zz"),
+                                                   passed + 7)
+            && TEST_ptr_eq(ossl_ptrie_locate_const(-1, passed, idxs, "dd"),
+                                                   passed + 3)
+            && TEST_ptr_eq(ossl_ptrie_locate_const(-1, passed, idxs, "qq"),
+                                                   passed + 4)
+            && TEST_ptr_eq(ossl_ptrie_locate_const(-1, passed, idxs, "fnord"),
+                                                   passed + 8)
+            && TEST_ptr_null(ossl_ptrie_locate_const(-1, passed, idxs, "aaa"))
+            && TEST_ptr_null(ossl_ptrie_locate_const(-1, passed, idxs, "ab"))
+            && TEST_ptr_null(ossl_ptrie_locate_const(-1, passed, idxs, "d"))
+            && TEST_ptr_null(ossl_ptrie_locate_const(-1, passed, idxs, "q"))
+            && TEST_ptr_null(ossl_ptrie_locate(-1, passed, idxs, "dfg"))
+            && TEST_ptr_null(ossl_ptrie_locate(-1, passed, idxs, "qrs"))
+            && TEST_ptr_null(ossl_ptrie_locate(-1, passed, idxs, "mmmm")))
+        res = 1;
+ err:
+    ossl_ptrie_free(pt);
+    return res;
+}
+
+int setup_tests(void)
+{
+    ADD_TEST(test_trie);
+    return 1;
+}

--- a/test/recipes/04-test_param_trie.t
+++ b/test/recipes/04-test_param_trie.t
@@ -1,0 +1,15 @@
+#! /usr/bin/env perl
+# Copyright 2021 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+use strict;
+use OpenSSL::Test;
+use OpenSSL::Test::Simple;
+
+setup("test_param_trie");
+
+simple_test("test_param_trie", "param_trie_test");


### PR DESCRIPTION
By building a TRIE of the parameters being passed to a get/set function, the myriad locate calls will be significantly faster.   The complexity to build the TRIE is linear in the length of the parameter keys.  Lookup is linear in the length of the lookup string, although it short circuits once the leading portion of a string can no longer be matched.

This compares favourable with the existing complexity of the product of these.

Note that the usual compression techniques that are applied to TRIEs are not implemented here.  Our corpus is small and the extra time is unlikely to be worthwhile.

Partial fix for #17064

- [x] documentation is added or updated
- [x] tests are added or updated
