### PR TITLE
check the return value of BIO_new()

### DIFF
--- a/crypto/cmp/cmp_vfy.c
+++ b/crypto/cmp/cmp_vfy.c
@@ -34,10 +34,8 @@ static int verify_signature(const OSSL_CMP_CTX *cmp_ctx,
         return 0;
 
     bio = BIO_new(BIO_s_mem()); /* may be NULL */
-    if (bio == NULL) {
-        ERR_raise(ERR_LIB_CMP, ERR_R_MALLOC_FAILURE);
+    if (bio == NULL)
         return 0;
-    }
     /* verify that keyUsage, if present, contains digitalSignature */
     if (!cmp_ctx->ignore_keyusage
             && (X509_get_key_usage(cert) & X509v3_KU_DIGITAL_SIGNATURE) == 0) {

--- a/crypto/cmp/cmp_vfy.c
+++ b/crypto/cmp/cmp_vfy.c
@@ -34,7 +34,10 @@ static int verify_signature(const OSSL_CMP_CTX *cmp_ctx,
         return 0;
 
     bio = BIO_new(BIO_s_mem()); /* may be NULL */
-
+    if (bio == NULL) {
+        ERR_raise(ERR_LIB_CMP, ERR_R_MALLOC_FAILURE);
+        return 0;
+    }
     /* verify that keyUsage, if present, contains digitalSignature */
     if (!cmp_ctx->ignore_keyusage
             && (X509_get_key_usage(cert) & X509v3_KU_DIGITAL_SIGNATURE) == 0) {

--- a/crypto/x509/t_x509.c
+++ b/crypto/x509/t_x509.c
@@ -470,6 +470,10 @@ int X509_STORE_CTX_print_verify_cb(int ok, X509_STORE_CTX *ctx)
         int cert_error = X509_STORE_CTX_get_error(ctx);
         BIO *bio = BIO_new(BIO_s_mem()); /* may be NULL */
 
+        if (bio == NULL) {
+            ERR_raise(ERR_LIB_X509, ERR_R_MALLOC_FAILURE);
+            return 0;
+        }
         BIO_printf(bio, "%s at depth = %d error = %d (%s)\n",
                    X509_STORE_CTX_get0_parent_ctx(ctx) != NULL
                    ? "CRL path validation"

--- a/crypto/x509/t_x509.c
+++ b/crypto/x509/t_x509.c
@@ -470,10 +470,8 @@ int X509_STORE_CTX_print_verify_cb(int ok, X509_STORE_CTX *ctx)
         int cert_error = X509_STORE_CTX_get_error(ctx);
         BIO *bio = BIO_new(BIO_s_mem()); /* may be NULL */
 
-        if (bio == NULL) {
-            ERR_raise(ERR_LIB_X509, ERR_R_MALLOC_FAILURE);
+        if (bio == NULL)
             return 0;
-        }
         BIO_printf(bio, "%s at depth = %d error = %d (%s)\n",
                    X509_STORE_CTX_get0_parent_ctx(ctx) != NULL
                    ? "CRL path validation"


### PR DESCRIPTION
Check the return value of BIO_new() in t_x509.c:471 & cmp_vfy.c:36 in time to prevent further memory errors.