### PR TITLE
Clarify the deprecation warnings in the docs

### DIFF
--- a/doc/man3/BF_encrypt.pod
+++ b/doc/man3/BF_encrypt.pod
@@ -9,9 +9,9 @@ BF_cfb64_encrypt, BF_ofb64_encrypt, BF_options - Blowfish encryption
 
  #include <openssl/blowfish.h>
 
-Deprecated since OpenSSL 3.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following functions have been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  void BF_set_key(BF_KEY *key, int len, const unsigned char *data);
 

--- a/doc/man3/BIO_get_ex_new_index.pod
+++ b/doc/man3/BIO_get_ex_new_index.pod
@@ -43,9 +43,9 @@ X509_get_ex_new_index, X509_set_ex_data, X509_get_ex_data
  #define TYPE_set_app_data(TYPE *d, void *arg)
  #define TYPE_get_app_data(TYPE *d)
 
-Deprecated since OpenSSL 3.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following functions have been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  int DH_get_ex_new_index(long argl, void *argp, CRYPTO_EX_new *new_func,
                          CRYPTO_EX_dup *dup_func, CRYPTO_EX_free *free_func);

--- a/doc/man3/BIO_set_callback.pod
+++ b/doc/man3/BIO_set_callback.pod
@@ -24,9 +24,9 @@ BIO_debug_callback_ex, BIO_callback_fn_ex, BIO_callback_fn
  long BIO_debug_callback_ex(BIO *bio, int oper, const char *argp, size_t len,
                             int argi, long argl, int ret, size_t *processed);
 
- Deprecated since OpenSSL 3.0, can be hidden entirely by defining
- OPENSSL_API_COMPAT with a suitable version value, see
- openssl_user_macros(7):
+The following functions have been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  typedef long (*BIO_callback_fn)(BIO *b, int oper, const char *argp, int argi,
                                  long argl, long ret);

--- a/doc/man3/BN_generate_prime.pod
+++ b/doc/man3/BN_generate_prime.pod
@@ -34,9 +34,9 @@ BN_is_prime, BN_is_prime_fasttest - generate primes and test for primality
 
  void *BN_GENCB_get_arg(BN_GENCB *cb);
 
-Deprecated since OpenSSL 0.9.8, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following functions have been deprecated since OpenSSL 0.9.8, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  BIGNUM *BN_generate_prime(BIGNUM *ret, int num, int safe, BIGNUM *add,
                            BIGNUM *rem, void (*callback)(int, int, void *),
@@ -49,7 +49,9 @@ L<openssl_user_macros(7)>:
                           void (*callback)(int, int, void *), BN_CTX *ctx,
                           void *cb_arg, int do_trial_division);
 
-Deprecated since OpenSSL 3.0:
+The following functions have been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  int BN_is_prime_ex(const BIGNUM *p, int nchecks, BN_CTX *ctx, BN_GENCB *cb);
 

--- a/doc/man3/BN_rand.pod
+++ b/doc/man3/BN_rand.pod
@@ -27,9 +27,9 @@ BN_pseudo_rand_range
                            BN_CTX *ctx);
  int BN_priv_rand_range(BIGNUM *rnd, const BIGNUM *range);
 
-Deprecated since OpenSSL 3.0, can be hidden entirely by defining
-OPENSSL_API_COMPAT with a suitable version value, see
-openssl_user_macros(7):
+The following functions have been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  int BN_pseudo_rand(BIGNUM *rnd, int bits, int top, int bottom);
  int BN_pseudo_rand_range(BIGNUM *rnd, const BIGNUM *range);

--- a/doc/man3/CONF_modules_free.pod
+++ b/doc/man3/CONF_modules_free.pod
@@ -12,9 +12,9 @@ OpenSSL configuration cleanup functions
  void CONF_modules_finish(void);
  void CONF_modules_unload(int all);
 
-Deprecated since OpenSSL 1.1.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following functions have been deprecated since OpenSSL 1.1.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  void CONF_modules_free(void);
 

--- a/doc/man3/DES_random_key.pod
+++ b/doc/man3/DES_random_key.pod
@@ -16,9 +16,9 @@ DES_fcrypt, DES_crypt - DES encryption
 
  #include <openssl/des.h>
 
-Deprecated since OpenSSL 3.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following functions have been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  void DES_random_key(DES_cblock *ret);
 

--- a/doc/man3/DH_generate_key.pod
+++ b/doc/man3/DH_generate_key.pod
@@ -9,9 +9,9 @@ Diffie-Hellman key exchange
 
  #include <openssl/dh.h>
 
-Deprecated since OpenSSL 3.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following functions have been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  int DH_generate_key(DH *dh);
 

--- a/doc/man3/DH_generate_parameters.pod
+++ b/doc/man3/DH_generate_parameters.pod
@@ -12,9 +12,9 @@ parameters
 
  #include <openssl/dh.h>
 
-Deprecated since OpenSSL 3.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following functions have been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  int DH_generate_parameters_ex(DH *dh, int prime_len, int generator, BN_GENCB *cb);
 
@@ -25,9 +25,9 @@ L<openssl_user_macros(7)>:
  int DH_check_params_ex(const DH *dh);
  int DH_check_pub_key_ex(const DH *dh, const BIGNUM *pub_key);
 
-Deprecated since OpenSSL 0.9.8, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following functions have been deprecated since OpenSSL 0.9.8, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  DH *DH_generate_parameters(int prime_len, int generator,
                             void (*callback)(int, int, void *), void *cb_arg);

--- a/doc/man3/DH_get0_pqg.pod
+++ b/doc/man3/DH_get0_pqg.pod
@@ -12,9 +12,9 @@ DH_get_length, DH_set_length - Routines for getting and setting data in a DH obj
 
  #include <openssl/dh.h>
 
-Deprecated since OpenSSL 3.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following functions have been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  void DH_get0_pqg(const DH *dh,
                   const BIGNUM **p, const BIGNUM **q, const BIGNUM **g);

--- a/doc/man3/DH_get_1024_160.pod
+++ b/doc/man3/DH_get_1024_160.pod
@@ -39,9 +39,9 @@ BN_get_rfc3526_prime_8192
  BIGNUM *BN_get_rfc3526_prime_6144(BIGNUM *bn);
  BIGNUM *BN_get_rfc3526_prime_8192(BIGNUM *bn);
 
-Deprecated since OpenSSL 3.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following functions have been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  #include <openssl/dh.h>
 

--- a/doc/man3/DH_meth_new.pod
+++ b/doc/man3/DH_meth_new.pod
@@ -14,9 +14,9 @@ DH_meth_set_generate_params - Routines to build up DH methods
 
  #include <openssl/dh.h>
 
-Deprecated since OpenSSL 3.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following functions have been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  DH_METHOD *DH_meth_new(const char *name, int flags);
 

--- a/doc/man3/DH_new_by_nid.pod
+++ b/doc/man3/DH_new_by_nid.pod
@@ -9,9 +9,9 @@ DH_new_by_nid, DH_get_nid - create or get DH named parameters
  #include <openssl/dh.h>
  DH *DH_new_by_nid(int nid);
 
-Deprecated since OpenSSL 3.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following functions have been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  int DH_get_nid(const DH *dh);
 

--- a/doc/man3/DH_set_method.pod
+++ b/doc/man3/DH_set_method.pod
@@ -9,9 +9,9 @@ DH_set_method, DH_new_method, DH_OpenSSL - select DH method
 
  #include <openssl/dh.h>
 
-Deprecated since OpenSSL 3.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following functions have been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  void DH_set_default_method(const DH_METHOD *meth);
 

--- a/doc/man3/DH_size.pod
+++ b/doc/man3/DH_size.pod
@@ -9,9 +9,9 @@ security bits
 
  #include <openssl/dh.h>
 
-Deprecated since OpenSSL 3.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following functions have been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  int DH_bits(const DH *dh);
 

--- a/doc/man3/DSA_do_sign.pod
+++ b/doc/man3/DSA_do_sign.pod
@@ -8,9 +8,9 @@ DSA_do_sign, DSA_do_verify - raw DSA signature operations
 
  #include <openssl/dsa.h>
 
-Deprecated since OpenSSL 3.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following functions have been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  DSA_SIG *DSA_do_sign(const unsigned char *dgst, int dlen, DSA *dsa);
 

--- a/doc/man3/DSA_dup_DH.pod
+++ b/doc/man3/DSA_dup_DH.pod
@@ -8,9 +8,9 @@ DSA_dup_DH - create a DH structure out of DSA structure
 
  #include <openssl/dsa.h>
 
-Deprecated since OpenSSL 3.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following functions have been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  DH *DSA_dup_DH(const DSA *r);
 

--- a/doc/man3/DSA_generate_key.pod
+++ b/doc/man3/DSA_generate_key.pod
@@ -8,9 +8,9 @@ DSA_generate_key - generate DSA key pair
 
  #include <openssl/dsa.h>
 
-Deprecated since OpenSSL 3.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following functions have been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  int DSA_generate_key(DSA *a);
 

--- a/doc/man3/DSA_generate_parameters.pod
+++ b/doc/man3/DSA_generate_parameters.pod
@@ -8,18 +8,18 @@ DSA_generate_parameters_ex, DSA_generate_parameters - generate DSA parameters
 
  #include <openssl/dsa.h>
 
-Deprecated since OpenSSL 3.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following functions have been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  int DSA_generate_parameters_ex(DSA *dsa, int bits,
                                 const unsigned char *seed, int seed_len,
                                 int *counter_ret, unsigned long *h_ret,
                                 BN_GENCB *cb);
 
-Deprecated since OpenSSL 0.9.8, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following functions have been deprecated since OpenSSL 0.9.8, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  DSA *DSA_generate_parameters(int bits, unsigned char *seed, int seed_len,
                               int *counter_ret, unsigned long *h_ret,

--- a/doc/man3/DSA_get0_pqg.pod
+++ b/doc/man3/DSA_get0_pqg.pod
@@ -13,9 +13,9 @@ setting data in a DSA object
 
  #include <openssl/dsa.h>
 
-Deprecated since OpenSSL 3.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following functions have been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  void DSA_get0_pqg(const DSA *d,
                    const BIGNUM **p, const BIGNUM **q, const BIGNUM **g);

--- a/doc/man3/DSA_meth_new.pod
+++ b/doc/man3/DSA_meth_new.pod
@@ -16,9 +16,9 @@ DSA_meth_set_keygen - Routines to build up DSA methods
 
  #include <openssl/dsa.h>
 
-Deprecated since OpenSSL 3.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following functions have been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  DSA_METHOD *DSA_meth_new(const char *name, int flags);
 

--- a/doc/man3/DSA_new.pod
+++ b/doc/man3/DSA_new.pod
@@ -8,9 +8,9 @@ DSA_new, DSA_free - allocate and free DSA objects
 
  #include <openssl/dsa.h>
 
-Deprecated since OpenSSL 3.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following functions have been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  DSA* DSA_new(void);
 

--- a/doc/man3/DSA_set_method.pod
+++ b/doc/man3/DSA_set_method.pod
@@ -9,9 +9,9 @@ DSA_set_method, DSA_new_method, DSA_OpenSSL - select DSA method
 
  #include <openssl/dsa.h>
 
-Deprecated since OpenSSL 3.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following functions have been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  void DSA_set_default_method(const DSA_METHOD *meth);
 

--- a/doc/man3/DSA_sign.pod
+++ b/doc/man3/DSA_sign.pod
@@ -8,9 +8,9 @@ DSA_sign, DSA_sign_setup, DSA_verify - DSA signatures
 
  #include <openssl/dsa.h>
 
-Deprecated since OpenSSL 3.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following functions have been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  int DSA_sign(int type, const unsigned char *dgst, int len,
               unsigned char *sigret, unsigned int *siglen, DSA *dsa);

--- a/doc/man3/DSA_size.pod
+++ b/doc/man3/DSA_size.pod
@@ -8,9 +8,9 @@ DSA_size, DSA_bits, DSA_security_bits - get DSA signature size, key bits or secu
 
  #include <openssl/dsa.h>
 
-Deprecated since OpenSSL 3.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following functions have been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  int DSA_bits(const DSA *dsa);
 

--- a/doc/man3/ECDSA_SIG_new.pod
+++ b/doc/man3/ECDSA_SIG_new.pod
@@ -19,9 +19,9 @@ functions
  const BIGNUM *ECDSA_SIG_get0_s(const ECDSA_SIG *sig);
  int ECDSA_SIG_set0(ECDSA_SIG *sig, BIGNUM *r, BIGNUM *s);
 
-Deprecated since OpenSSL 3.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following functions have been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  int ECDSA_size(const EC_KEY *eckey);
 

--- a/doc/man3/ECPKParameters_print.pod
+++ b/doc/man3/ECPKParameters_print.pod
@@ -9,9 +9,9 @@ encoding ASN1 representations of elliptic curve entities
 
  #include <openssl/ec.h>
 
-Deprecated since OpenSSL 3.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following functions have been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  int ECPKParameters_print(BIO *bp, const EC_GROUP *x, int off);
  int ECPKParameters_print_fp(FILE *fp, const EC_GROUP *x, int off);

--- a/doc/man3/EC_GFp_simple_method.pod
+++ b/doc/man3/EC_GFp_simple_method.pod
@@ -8,7 +8,9 @@ EC_GFp_simple_method, EC_GFp_mont_method, EC_GFp_nist_method, EC_GFp_nistp224_me
 
  #include <openssl/ec.h>
 
-Deprecated since OpenSSL 3.0:
+The following functions have been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  const EC_METHOD *EC_GFp_simple_method(void);
  const EC_METHOD *EC_GFp_mont_method(void);

--- a/doc/man3/EC_GROUP_copy.pod
+++ b/doc/man3/EC_GROUP_copy.pod
@@ -64,7 +64,9 @@ EC_GROUP_get_field_type
 
  int EC_GROUP_get_field_type(const EC_GROUP *group);
 
-Deprecated since OpenSSL 3.0:
+The following function has been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  const EC_METHOD *EC_GROUP_method_of(const EC_GROUP *group);
 

--- a/doc/man3/EC_GROUP_new.pod
+++ b/doc/man3/EC_GROUP_new.pod
@@ -55,9 +55,9 @@ Functions for creating and destroying EC_GROUP objects
  size_t EC_get_builtin_curves(EC_builtin_curve *r, size_t nitems);
  const char *OSSL_EC_curve_nid2name(int nid);
 
-Deprecated since OpenSSL 3.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following functions have been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  EC_GROUP *EC_GROUP_new(const EC_METHOD *meth);
  void EC_GROUP_clear_free(EC_GROUP *group);

--- a/doc/man3/EC_KEY_new.pod
+++ b/doc/man3/EC_KEY_new.pod
@@ -23,9 +23,9 @@ EC_KEY objects
 
  EVP_PKEY *EVP_EC_gen(const char *curve);
 
-Deprecated since OpenSSL 3.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following functions have been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  EC_KEY *EC_KEY_new_ex(OSSL_LIB_CTX *ctx, const char *propq);
  EC_KEY *EC_KEY_new(void);

--- a/doc/man3/EC_POINT_add.pod
+++ b/doc/man3/EC_POINT_add.pod
@@ -18,7 +18,9 @@ EC_POINT_add, EC_POINT_dbl, EC_POINT_invert, EC_POINT_is_at_infinity, EC_POINT_i
  int EC_POINT_mul(const EC_GROUP *group, EC_POINT *r, const BIGNUM *n,
                   const EC_POINT *q, const BIGNUM *m, BN_CTX *ctx);
 
-Deprecated since OpenSSL 3.0:
+The following functions have been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  int EC_POINT_make_affine(const EC_GROUP *group, EC_POINT *point, BN_CTX *ctx);
  int EC_POINTs_make_affine(const EC_GROUP *group, size_t num,

--- a/doc/man3/EC_POINT_new.pod
+++ b/doc/man3/EC_POINT_new.pod
@@ -60,7 +60,9 @@ EC_POINT_hex2point
  EC_POINT *EC_POINT_hex2point(const EC_GROUP *group, const char *hex,
                               EC_POINT *p, BN_CTX *ctx);
 
-Deprecated since OpenSSL 3.0:
+The following functions have been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  const EC_METHOD *EC_POINT_method_of(const EC_POINT *point);
  int EC_POINT_set_Jprojective_coordinates_GFp(const EC_GROUP *group,

--- a/doc/man3/ENGINE_add.pod
+++ b/doc/man3/ENGINE_add.pod
@@ -46,9 +46,9 @@ ENGINE_unregister_digests
 
  #include <openssl/engine.h>
 
-Deprecated since OpenSSL 3.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following functions have been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  ENGINE *ENGINE_get_first(void);
  ENGINE *ENGINE_get_last(void);
@@ -158,9 +158,9 @@ L<openssl_user_macros(7)>:
  EVP_PKEY *ENGINE_load_public_key(ENGINE *e, const char *key_id,
                                   UI_METHOD *ui_method, void *callback_data);
 
-Deprecated since OpenSSL 1.1.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following function has been deprecated since OpenSSL 1.1.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  void ENGINE_cleanup(void);
 

--- a/doc/man3/ERR_get_error.pod
+++ b/doc/man3/ERR_get_error.pod
@@ -37,7 +37,9 @@ ERR_get_error_line_data, ERR_peek_error_line_data, ERR_peek_last_error_line_data
                                        const char *func,
                                        const char **data, int *flags);
 
-Deprecated since OpenSSL 3.0:
+The following functions have been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  unsigned long ERR_get_error_line(const char **file, int *line);
  unsigned long ERR_get_error_line_data(const char **file, int *line,

--- a/doc/man3/ERR_load_crypto_strings.pod
+++ b/doc/man3/ERR_load_crypto_strings.pod
@@ -7,9 +7,9 @@ load and free error strings
 
 =head1 SYNOPSIS
 
-Deprecated since OpenSSL 1.1.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following functions have been deprecated since OpenSSL 1.1.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  #include <openssl/err.h>
 

--- a/doc/man3/ERR_put_error.pod
+++ b/doc/man3/ERR_put_error.pod
@@ -21,7 +21,9 @@ ERR_add_error_txt, ERR_add_error_mem_bio
  void ERR_add_error_txt(const char *sep, const char *txt);
  void ERR_add_error_mem_bio(const char *sep, BIO *bio);
 
-Deprecated since OpenSSL 3.0:
+The following function has been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  void ERR_put_error(int lib, int func, int reason, const char *file, int line);
 

--- a/doc/man3/ERR_remove_state.pod
+++ b/doc/man3/ERR_remove_state.pod
@@ -6,15 +6,15 @@ ERR_remove_thread_state, ERR_remove_state - DEPRECATED
 
 =head1 SYNOPSIS
 
-Deprecated since OpenSSL 1.0.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following function has been deprecated since OpenSSL 1.0.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  void ERR_remove_state(unsigned long tid);
 
-Deprecated since OpenSSL 1.1.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following function has been deprecated since OpenSSL 1.1.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  void ERR_remove_thread_state(void *tid);
 

--- a/doc/man3/EVP_CIPHER_CTX_get_original_iv.pod
+++ b/doc/man3/EVP_CIPHER_CTX_get_original_iv.pod
@@ -13,9 +13,9 @@ EVP_CIPHER_CTX_iv_noconst - Routines to inspect EVP_CIPHER_CTX IV data
  int EVP_CIPHER_CTX_get_original_iv(EVP_CIPHER_CTX *ctx, void *buf, size_t len);
  int EVP_CIPHER_CTX_get_updated_iv(EVP_CIPHER_CTX *ctx, void *buf, size_t len);
 
-Deprecated since OpenSSL 3.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following functions have been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  const unsigned char *EVP_CIPHER_CTX_iv(const EVP_CIPHER_CTX *ctx);
  const unsigned char *EVP_CIPHER_CTX_original_iv(const EVP_CIPHER_CTX *ctx);

--- a/doc/man3/EVP_CIPHER_meth_new.pod
+++ b/doc/man3/EVP_CIPHER_meth_new.pod
@@ -17,9 +17,9 @@ EVP_CIPHER_meth_get_ctrl
 
  #include <openssl/evp.h>
 
-Deprecated since OpenSSL 3.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following functions have been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  EVP_CIPHER *EVP_CIPHER_meth_new(int cipher_type, int block_size, int key_len);
  EVP_CIPHER *EVP_CIPHER_meth_dup(const EVP_CIPHER *cipher);

--- a/doc/man3/EVP_DigestInit.pod
+++ b/doc/man3/EVP_DigestInit.pod
@@ -117,9 +117,9 @@ EVP_MD_CTX_type, EVP_MD_CTX_pkey_ctx, EVP_MD_CTX_md_data
  #define EVP_MD_CTX_pkey_ctx EVP_MD_CTX_get_pkey_ctx
  #define EVP_MD_CTX_md_data EVP_MD_CTX_get0_md_data
 
-Deprecated since OpenSSL 3.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following functions have been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  const EVP_MD *EVP_MD_CTX_md(const EVP_MD_CTX *ctx);
 

--- a/doc/man3/EVP_EncryptInit.pod
+++ b/doc/man3/EVP_EncryptInit.pod
@@ -229,15 +229,15 @@ EVP_CIPHER_CTX_mode
  #define EVP_CIPHER_CTX_type EVP_CIPHER_CTX_get_type
  #define EVP_CIPHER_CTX_mode EVP_CIPHER_CTX_get_mode
 
-Deprecated since OpenSSL 3.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following function has been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  const EVP_CIPHER *EVP_CIPHER_CTX_cipher(const EVP_CIPHER_CTX *ctx);
 
-Deprecated since OpenSSL 1.1.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following function has been deprecated since OpenSSL 1.1.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  int EVP_CIPHER_CTX_flags(const EVP_CIPHER_CTX *ctx);
 

--- a/doc/man3/EVP_MD_meth_new.pod
+++ b/doc/man3/EVP_MD_meth_new.pod
@@ -18,9 +18,9 @@ EVP_MD_meth_get_ctrl
 
  #include <openssl/evp.h>
 
-Deprecated since OpenSSL 3.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following functions have been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  EVP_MD *EVP_MD_meth_new(int md_type, int pkey_type);
  void EVP_MD_meth_free(EVP_MD *md);

--- a/doc/man3/EVP_PKEY_CTX_ctrl.pod
+++ b/doc/man3/EVP_PKEY_CTX_ctrl.pod
@@ -176,9 +176,9 @@ EVP_PKEY_CTX_set_kem_op
  int EVP_PKEY_CTX_get1_id(EVP_PKEY_CTX *ctx, void *id);
  int EVP_PKEY_CTX_get1_id_len(EVP_PKEY_CTX *ctx, size_t *id_len);
 
-Deprecated since OpenSSL 3.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following functions have been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  #include <openssl/rsa.h>
 

--- a/doc/man3/EVP_PKEY_copy_parameters.pod
+++ b/doc/man3/EVP_PKEY_copy_parameters.pod
@@ -16,9 +16,9 @@ EVP_PKEY_cmp - public key parameter and comparison functions
  int EVP_PKEY_parameters_eq(const EVP_PKEY *a, const EVP_PKEY *b);
  int EVP_PKEY_eq(const EVP_PKEY *a, const EVP_PKEY *b);
 
-Deprecated since OpenSSL 3.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following functions have been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  int EVP_PKEY_cmp_parameters(const EVP_PKEY *a, const EVP_PKEY *b);
  int EVP_PKEY_cmp(const EVP_PKEY *a, const EVP_PKEY *b);

--- a/doc/man3/EVP_PKEY_meth_get_count.pod
+++ b/doc/man3/EVP_PKEY_meth_get_count.pod
@@ -8,9 +8,9 @@ EVP_PKEY_meth_get_count, EVP_PKEY_meth_get0, EVP_PKEY_meth_get0_info - enumerate
 
  #include <openssl/evp.h>
 
-Deprecated since OpenSSL 3.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following functions have been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  size_t EVP_PKEY_meth_get_count(void);
  const EVP_PKEY_METHOD *EVP_PKEY_meth_get0(size_t idx);

--- a/doc/man3/EVP_PKEY_meth_new.pod
+++ b/doc/man3/EVP_PKEY_meth_new.pod
@@ -29,9 +29,9 @@ EVP_PKEY_meth_remove
 
  #include <openssl/evp.h>
 
-Deprecated since OpenSSL 3.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following functions have been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  typedef struct evp_pkey_method_st EVP_PKEY_METHOD;
 

--- a/doc/man3/EVP_PKEY_new.pod
+++ b/doc/man3/EVP_PKEY_new.pod
@@ -50,9 +50,9 @@ EVP_PKEY_get_raw_public_key
  int EVP_PKEY_get_raw_public_key(const EVP_PKEY *pkey, unsigned char *pub,
                                  size_t *len);
 
-Deprecated since OpenSSL 3.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following function has been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  EVP_PKEY *EVP_PKEY_new_CMAC_key(ENGINE *e, const unsigned char *priv,
                                  size_t len, const EVP_CIPHER *cipher);

--- a/doc/man3/EVP_PKEY_set1_RSA.pod
+++ b/doc/man3/EVP_PKEY_set1_RSA.pod
@@ -24,9 +24,9 @@ EVP_PKEY assignment functions
  #define EVP_PKEY_id EVP_PKEY_get_id
  #define EVP_PKEY_base_id EVP_PKEY_get_base_id
 
-Deprecated since OpenSSL 3.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following functions have been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  int EVP_PKEY_set1_RSA(EVP_PKEY *pkey, RSA *key);
  int EVP_PKEY_set1_DSA(EVP_PKEY *pkey, DSA *key);

--- a/doc/man3/EVP_PKEY_set1_encoded_public_key.pod
+++ b/doc/man3/EVP_PKEY_set1_encoded_public_key.pod
@@ -15,9 +15,9 @@ EVP_PKEY_set1_tls_encodedpoint, EVP_PKEY_get1_tls_encodedpoint
 
  size_t EVP_PKEY_get1_encoded_public_key(EVP_PKEY *pkey, unsigned char **ppub);
 
-Deprecated since OpenSSL 3.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following functions have been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  int EVP_PKEY_set1_tls_encodedpoint(EVP_PKEY *pkey,
                                     const unsigned char *pt, size_t ptlen);

--- a/doc/man3/HMAC.pod
+++ b/doc/man3/HMAC.pod
@@ -24,9 +24,9 @@ HMAC_size
                      const unsigned char *data, size_t data_len,
                      unsigned char *md, unsigned int *md_len);
 
-Deprecated since OpenSSL 3.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following functions have been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  HMAC_CTX *HMAC_CTX_new(void);
  int HMAC_CTX_reset(HMAC_CTX *ctx);
@@ -44,9 +44,9 @@ L<openssl_user_macros(7)>:
 
  size_t HMAC_size(const HMAC_CTX *e);
 
-Deprecated since OpenSSL 1.1.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following function has been deprecated since OpenSSL 1.1.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  int HMAC_Init(HMAC_CTX *ctx, const void *key, int key_len,
                const EVP_MD *md);

--- a/doc/man3/MD5.pod
+++ b/doc/man3/MD5.pod
@@ -9,9 +9,9 @@ MD4_Final, MD5_Init, MD5_Update, MD5_Final - MD2, MD4, and MD5 hash functions
 
  #include <openssl/md2.h>
 
-Deprecated since OpenSSL 3.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following functions have been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  unsigned char *MD2(const unsigned char *d, unsigned long n, unsigned char *md);
 
@@ -22,9 +22,9 @@ L<openssl_user_macros(7)>:
 
  #include <openssl/md4.h>
 
-Deprecated since OpenSSL 3.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following functions have been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  unsigned char *MD4(const unsigned char *d, unsigned long n, unsigned char *md);
 
@@ -35,9 +35,9 @@ L<openssl_user_macros(7)>:
 
  #include <openssl/md5.h>
 
-Deprecated since OpenSSL 3.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following functions have been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  unsigned char *MD5(const unsigned char *d, unsigned long n, unsigned char *md);
 

--- a/doc/man3/MDC2_Init.pod
+++ b/doc/man3/MDC2_Init.pod
@@ -8,9 +8,9 @@ MDC2, MDC2_Init, MDC2_Update, MDC2_Final - MDC2 hash function
 
  #include <openssl/mdc2.h>
 
-Deprecated since OpenSSL 3.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following functions have been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  unsigned char *MDC2(const unsigned char *d, unsigned long n,
                      unsigned char *md);

--- a/doc/man3/OBJ_nid2obj.pod
+++ b/doc/man3/OBJ_nid2obj.pod
@@ -37,9 +37,9 @@ OBJ_dup, OBJ_txt2obj, OBJ_obj2txt, OBJ_create, OBJ_cleanup, OBJ_add_sigid
 
  int OBJ_add_sigid(int signid, int dig_id, int pkey_id);
 
-Deprecated since OpenSSL 1.1.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following function has been deprecated since OpenSSL 1.1.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  void OBJ_cleanup(void);
 

--- a/doc/man3/OCSP_sendreq_new.pod
+++ b/doc/man3/OCSP_sendreq_new.pod
@@ -21,9 +21,9 @@ OCSP_REQ_CTX_set1_req
                                      const OCSP_REQUEST *req, int buf_size);
  OCSP_RESPONSE *OCSP_sendreq_bio(BIO *io, const char *path, OCSP_REQUEST *req);
 
-Deprecated since OpenSSL 3.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following functions have been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  typedef OSSL_HTTP_REQ_CTX OCSP_REQ_CTX;
  int OCSP_sendreq_nbio(OCSP_RESPONSE **presp, OSSL_HTTP_REQ_CTX *rctx);

--- a/doc/man3/OPENSSL_config.pod
+++ b/doc/man3/OPENSSL_config.pod
@@ -8,9 +8,9 @@ OPENSSL_config, OPENSSL_no_config - simple OpenSSL configuration functions
 
  #include <openssl/conf.h>
 
-Deprecated since OpenSSL 1.1.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following functions have been deprecated since OpenSSL 1.1.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  void OPENSSL_config(const char *appname);
  void OPENSSL_no_config(void);

--- a/doc/man3/OPENSSL_fork_prepare.pod
+++ b/doc/man3/OPENSSL_fork_prepare.pod
@@ -11,9 +11,9 @@ OPENSSL_fork_child
 
  #include <openssl/crypto.h>
 
-Deprecated since OpenSSL 3.0.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following functions have been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  void OPENSSL_fork_prepare(void);
  void OPENSSL_fork_parent(void);

--- a/doc/man3/OPENSSL_malloc.pod
+++ b/doc/man3/OPENSSL_malloc.pod
@@ -66,9 +66,9 @@ OPENSSL_MALLOC_FD
  env OPENSSL_MALLOC_FAILURES=... <application>
  env OPENSSL_MALLOC_FD=... <application>
 
-Deprecated since OpenSSL 3.0.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following functions have been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  int CRYPTO_mem_leaks(BIO *b);
  int CRYPTO_mem_leaks_fp(FILE *fp);

--- a/doc/man3/OSSL_HTTP_parse_url.pod
+++ b/doc/man3/OSSL_HTTP_parse_url.pod
@@ -23,9 +23,9 @@ OCSP_parse_url
                          char **pport, int *pport_num,
                          char **ppath, char **pquery, char **pfrag);
 
-Deprecated since OpenSSL 3.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following functions have been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  int OCSP_parse_url(const char *url, char **phost, char **pport, char **ppath,
                     int *pssl);

--- a/doc/man3/OSSL_STORE_LOADER.pod
+++ b/doc/man3/OSSL_STORE_LOADER.pod
@@ -52,9 +52,9 @@ unregister STORE loaders for different URI schemes
                                     void (*fn)(const char *name, void *data),
                                     void *data);
 
-Deprecated since OpenSSL 3.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following functions have been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  OSSL_STORE_LOADER *OSSL_STORE_LOADER_new(ENGINE *e, const char *scheme);
  const ENGINE *OSSL_STORE_LOADER_get0_engine(const OSSL_STORE_LOADER

--- a/doc/man3/OSSL_STORE_open.pod
+++ b/doc/man3/OSSL_STORE_open.pod
@@ -33,9 +33,9 @@ OSSL_STORE_error, OSSL_STORE_close
  int OSSL_STORE_error(OSSL_STORE_CTX *ctx);
  int OSSL_STORE_close(OSSL_STORE_CTX *ctx);
 
-Deprecated since OpenSSL 3.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following function has been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  int OSSL_STORE_ctrl(OSSL_STORE_CTX *ctx, int cmd, ... /* args */);
 

--- a/doc/man3/OpenSSL_add_all_algorithms.pod
+++ b/doc/man3/OpenSSL_add_all_algorithms.pod
@@ -9,9 +9,9 @@ add algorithms to internal table
 
  #include <openssl/evp.h>
 
-Deprecated since OpenSSL 1.1.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following functions have been deprecated since OpenSSL 1.1.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  void OpenSSL_add_all_algorithms(void);
  void OpenSSL_add_all_ciphers(void);

--- a/doc/man3/PEM_read_CMS.pod
+++ b/doc/man3/PEM_read_CMS.pod
@@ -55,9 +55,9 @@ PEM_write_bio_X509_PUBKEY
  int PEM_write_TYPE(FILE *fp, const TYPE *a);
  int PEM_write_bio_TYPE(BIO *bp, const TYPE *a);
 
-Deprecated since OpenSSL 3.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following functions have been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  #include <openssl/pem.h>
 

--- a/doc/man3/PEM_read_bio_PrivateKey.pod
+++ b/doc/man3/PEM_read_bio_PrivateKey.pod
@@ -134,9 +134,9 @@ PEM_write_bio_PKCS7, PEM_write_PKCS7 - PEM routines
  int PEM_write_bio_PKCS7(BIO *bp, PKCS7 *x);
  int PEM_write_PKCS7(FILE *fp, PKCS7 *x);
 
-Deprecated since OpenSSL 3.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following functions have been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  RSA *PEM_read_bio_RSAPrivateKey(BIO *bp, RSA **x,
                                  pem_password_cb *cb, void *u);

--- a/doc/man3/RAND_add.pod
+++ b/doc/man3/RAND_add.pod
@@ -18,9 +18,9 @@ RAND_keep_random_devices_open
 
  void RAND_keep_random_devices_open(int keep);
 
-Deprecated since OpenSSL 1.1.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following functions have been deprecated since OpenSSL 1.1.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  int RAND_event(UINT iMsg, WPARAM wParam, LPARAM lParam);
  void RAND_screen(void);

--- a/doc/man3/RAND_bytes.pod
+++ b/doc/man3/RAND_bytes.pod
@@ -17,9 +17,9 @@ RAND_pseudo_bytes - generate random data
  int RAND_priv_bytes_ex(OSSL_LIB_CTX *ctx, unsigned char *buf, size_t num,
                         unsigned int strength);
 
-Deprecated since OpenSSL 1.1.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following function has been deprecated since OpenSSL 1.1.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  int RAND_pseudo_bytes(unsigned char *buf, int num);
 

--- a/doc/man3/RAND_cleanup.pod
+++ b/doc/man3/RAND_cleanup.pod
@@ -8,9 +8,9 @@ RAND_cleanup - erase the PRNG state
 
  #include <openssl/rand.h>
 
-Deprecated since OpenSSL 1.1.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following function has been deprecated since OpenSSL 1.1.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  void RAND_cleanup(void);
 

--- a/doc/man3/RAND_set_rand_method.pod
+++ b/doc/man3/RAND_set_rand_method.pod
@@ -8,9 +8,9 @@ RAND_set_rand_method, RAND_get_rand_method, RAND_OpenSSL - select RAND method
 
  #include <openssl/rand.h>
 
-Deprecated since OpenSSL 3.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following functions have been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  RAND_METHOD *RAND_OpenSSL(void);
 

--- a/doc/man3/RC4_set_key.pod
+++ b/doc/man3/RC4_set_key.pod
@@ -8,9 +8,9 @@ RC4_set_key, RC4 - RC4 encryption
 
  #include <openssl/rc4.h>
 
-Deprecated since OpenSSL 3.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following functions have been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  void RC4_set_key(RC4_KEY *key, int len, const unsigned char *data);
 

--- a/doc/man3/RIPEMD160_Init.pod
+++ b/doc/man3/RIPEMD160_Init.pod
@@ -9,9 +9,9 @@ RIPEMD-160 hash function
 
  #include <openssl/ripemd.h>
 
-Deprecated since OpenSSL 3.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following functions have been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  unsigned char *RIPEMD160(const unsigned char *d, unsigned long n,
                           unsigned char *md);

--- a/doc/man3/RSA_blinding_on.pod
+++ b/doc/man3/RSA_blinding_on.pod
@@ -8,9 +8,9 @@ RSA_blinding_on, RSA_blinding_off - protect the RSA operation from timing attack
 
  #include <openssl/rsa.h>
 
-Deprecated since OpenSSL 3.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following functions have been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  int RSA_blinding_on(RSA *rsa, BN_CTX *ctx);
 

--- a/doc/man3/RSA_check_key.pod
+++ b/doc/man3/RSA_check_key.pod
@@ -8,9 +8,9 @@ RSA_check_key_ex, RSA_check_key - validate private RSA keys
 
  #include <openssl/rsa.h>
 
-Deprecated since OpenSSL 3.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following functions have been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  int RSA_check_key_ex(const RSA *rsa, BN_GENCB *cb);
 

--- a/doc/man3/RSA_generate_key.pod
+++ b/doc/man3/RSA_generate_key.pod
@@ -12,14 +12,16 @@ RSA_generate_multi_prime_key - generate RSA key pair
 
  EVP_PKEY *EVP_RSA_gen(unsigned int bits);
 
-Deprecated since OpenSSL 3.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following functions have been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  int RSA_generate_key_ex(RSA *rsa, int bits, BIGNUM *e, BN_GENCB *cb);
  int RSA_generate_multi_prime_key(RSA *rsa, int bits, int primes, BIGNUM *e, BN_GENCB *cb);
 
-Deprecated since OpenSSL 0.9.8:
+The following function has been deprecated since OpenSSL 0.9.8, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  RSA *RSA_generate_key(int bits, unsigned long e,
                        void (*callback)(int, int, void *), void *cb_arg);

--- a/doc/man3/RSA_get0_key.pod
+++ b/doc/man3/RSA_get0_key.pod
@@ -16,9 +16,9 @@ RSA_set0_multi_prime_params, RSA_get_version
 
  #include <openssl/rsa.h>
 
-Deprecated since OpenSSL 3.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following functions have been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  int RSA_set0_key(RSA *r, BIGNUM *n, BIGNUM *e, BIGNUM *d);
  int RSA_set0_factors(RSA *r, BIGNUM *p, BIGNUM *q);

--- a/doc/man3/RSA_meth_new.pod
+++ b/doc/man3/RSA_meth_new.pod
@@ -20,9 +20,9 @@ RSA_meth_get_multi_prime_keygen, RSA_meth_set_multi_prime_keygen
 
  #include <openssl/rsa.h>
 
-Deprecated since OpenSSL 3.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following functions have been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  RSA_METHOD *RSA_meth_new(const char *name, int flags);
  void RSA_meth_free(RSA_METHOD *meth);

--- a/doc/man3/RSA_new.pod
+++ b/doc/man3/RSA_new.pod
@@ -8,7 +8,9 @@ RSA_new, RSA_free - allocate and free RSA objects
 
  #include <openssl/rsa.h>
 
-Deprecated since OpenSSL 3.0:
+The following functions have been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  RSA *RSA_new(void);
 

--- a/doc/man3/RSA_padding_add_PKCS1_type_1.pod
+++ b/doc/man3/RSA_padding_add_PKCS1_type_1.pod
@@ -13,9 +13,9 @@ padding
 
  #include <openssl/rsa.h>
 
-Deprecated since OpenSSL 3.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following functions have been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  int RSA_padding_add_PKCS1_type_1(unsigned char *to, int tlen,
                                   const unsigned char *f, int fl);

--- a/doc/man3/RSA_print.pod
+++ b/doc/man3/RSA_print.pod
@@ -10,18 +10,18 @@ DHparams_print, DHparams_print_fp - print cryptographic parameters
 
  #include <openssl/rsa.h>
 
-Deprecated since OpenSSL 3.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following functions have been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  int RSA_print(BIO *bp, const RSA *x, int offset);
  int RSA_print_fp(FILE *fp, const RSA *x, int offset);
 
  #include <openssl/dsa.h>
 
-Deprecated since OpenSSL 3.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following functions have been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  int DSAparams_print(BIO *bp, const DSA *x);
  int DSAparams_print_fp(FILE *fp, const DSA *x);
@@ -30,9 +30,9 @@ L<openssl_user_macros(7)>:
 
  #include <openssl/dh.h>
 
-Deprecated since OpenSSL 3.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following functions have been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  int DHparams_print(BIO *bp, DH *x);
  int DHparams_print_fp(FILE *fp, const DH *x);

--- a/doc/man3/RSA_private_encrypt.pod
+++ b/doc/man3/RSA_private_encrypt.pod
@@ -8,9 +8,9 @@ RSA_private_encrypt, RSA_public_decrypt - low-level signature operations
 
  #include <openssl/rsa.h>
 
-Deprecated since OpenSSL 3.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following functions have been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  int RSA_private_encrypt(int flen, unsigned char *from,
                          unsigned char *to, RSA *rsa, int padding);

--- a/doc/man3/RSA_public_encrypt.pod
+++ b/doc/man3/RSA_public_encrypt.pod
@@ -8,9 +8,9 @@ RSA_public_encrypt, RSA_private_decrypt - RSA public key cryptography
 
  #include <openssl/rsa.h>
 
-Deprecated since OpenSSL 3.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following functions have been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  int RSA_public_encrypt(int flen, const unsigned char *from,
                         unsigned char *to, RSA *rsa, int padding);

--- a/doc/man3/RSA_set_method.pod
+++ b/doc/man3/RSA_set_method.pod
@@ -10,9 +10,9 @@ RSA_new_method - select RSA method
 
  #include <openssl/rsa.h>
 
-Deprecated since OpenSSL 3.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following functions have been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  void RSA_set_default_method(const RSA_METHOD *meth);
 

--- a/doc/man3/RSA_sign.pod
+++ b/doc/man3/RSA_sign.pod
@@ -8,9 +8,9 @@ RSA_sign, RSA_verify - RSA signatures
 
  #include <openssl/rsa.h>
 
-Deprecated since OpenSSL 3.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following functions have been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  int RSA_sign(int type, const unsigned char *m, unsigned int m_len,
               unsigned char *sigret, unsigned int *siglen, RSA *rsa);

--- a/doc/man3/RSA_sign_ASN1_OCTET_STRING.pod
+++ b/doc/man3/RSA_sign_ASN1_OCTET_STRING.pod
@@ -8,9 +8,9 @@ RSA_sign_ASN1_OCTET_STRING, RSA_verify_ASN1_OCTET_STRING - RSA signatures
 
  #include <openssl/rsa.h>
 
-Deprecated since OpenSSL 3.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following functions have been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  int RSA_sign_ASN1_OCTET_STRING(int dummy, unsigned char *m,
                                 unsigned int m_len, unsigned char *sigret,

--- a/doc/man3/RSA_size.pod
+++ b/doc/man3/RSA_size.pod
@@ -10,9 +10,9 @@ RSA_size, RSA_bits, RSA_security_bits - get RSA modulus size or security bits
 
  int RSA_bits(const RSA *rsa);
 
-Deprecated since OpenSSL 3.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following functions have been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  int RSA_size(const RSA *rsa);
 

--- a/doc/man3/SHA256_Init.pod
+++ b/doc/man3/SHA256_Init.pod
@@ -17,9 +17,9 @@ SHA512_Final - Secure Hash Algorithm
  unsigned char *SHA384(const unsigned char *data, size_t count, unsigned char *md_buf);
  unsigned char *SHA512(const unsigned char *data, size_t count, unsigned char *md_buf);
 
-Deprecated since OpenSSL 3.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following functions have been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  int SHA1_Init(SHA_CTX *c);
  int SHA1_Update(SHA_CTX *c, const void *data, size_t len);

--- a/doc/man3/SRP_Calc_B.pod
+++ b/doc/man3/SRP_Calc_B.pod
@@ -18,9 +18,9 @@ SRP_Calc_client_key
 
  #include <openssl/srp.h>
 
-Deprecated since OpenSSL 3.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following functions have been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  /* server side .... */
  BIGNUM *SRP_Calc_server_key(const BIGNUM *A, const BIGNUM *v, const BIGNUM *u,

--- a/doc/man3/SRP_VBASE_new.pod
+++ b/doc/man3/SRP_VBASE_new.pod
@@ -14,9 +14,9 @@ SRP_VBASE_get_by_user
 
  #include <openssl/srp.h>
 
-Deprecated since OpenSSL 3.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following functions have been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  SRP_VBASE *SRP_VBASE_new(char *seed_key);
  void SRP_VBASE_free(SRP_VBASE *vb);

--- a/doc/man3/SRP_create_verifier.pod
+++ b/doc/man3/SRP_create_verifier.pod
@@ -14,9 +14,9 @@ SRP_get_default_gN
 
  #include <openssl/srp.h>
 
-Deprecated since OpenSSL 3.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following functions have been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  int SRP_create_verifier_BN_ex(const char *user, const char *pass, BIGNUM **salt,
                                BIGNUM **verifier, const BIGNUM *N,

--- a/doc/man3/SRP_user_pwd_new.pod
+++ b/doc/man3/SRP_user_pwd_new.pod
@@ -13,9 +13,9 @@ SRP_user_pwd_set0_sv
 
  #include <openssl/srp.h>
 
-Deprecated since OpenSSL 3.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following functions have been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  SRP_user_pwd *SRP_user_pwd_new(void);
  void SRP_user_pwd_free(SRP_user_pwd *user_pwd);

--- a/doc/man3/SSL_COMP_add_compression_method.pod
+++ b/doc/man3/SSL_COMP_add_compression_method.pod
@@ -15,9 +15,9 @@ SSL_COMP_get0_name, SSL_COMP_get_id, SSL_COMP_free_compression_methods
  const char *SSL_COMP_get0_name(const SSL_COMP *comp);
  int SSL_COMP_get_id(const SSL_COMP *comp);
 
-Deprecated since OpenSSL 1.1.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following function has been deprecated since OpenSSL 1.1.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  void SSL_COMP_free_compression_methods(void);
 

--- a/doc/man3/SSL_CTX_set_srp_password.pod
+++ b/doc/man3/SSL_CTX_set_srp_password.pod
@@ -21,9 +21,9 @@ SSL_get_srp_userinfo
 
  #include <openssl/ssl.h>
 
-Deprecated since OpenSSL 3.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following functions have been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  int SSL_CTX_set_srp_username(SSL_CTX *ctx, char *name);
  int SSL_CTX_set_srp_password(SSL_CTX *ctx, char *password);

--- a/doc/man3/SSL_CTX_set_tlsext_ticket_key_cb.pod
+++ b/doc/man3/SSL_CTX_set_tlsext_ticket_key_cb.pod
@@ -15,9 +15,9 @@ SSL_CTX_set_tlsext_ticket_key_cb
                unsigned char iv[EVP_MAX_IV_LENGTH],
                EVP_CIPHER_CTX *ctx, EVP_MAC_CTX *hctx, int enc));
 
-Deprecated since OpenSSL 3.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following function has been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  int SSL_CTX_set_tlsext_ticket_key_cb(SSL_CTX sslctx,
      int (*cb)(SSL *s, unsigned char key_name[16],

--- a/doc/man3/SSL_CTX_set_tmp_dh_callback.pod
+++ b/doc/man3/SSL_CTX_set_tmp_dh_callback.pod
@@ -16,9 +16,9 @@ SSL_set_tmp_dh_callback, SSL_set_tmp_dh
  int SSL_CTX_set0_tmp_dh_pkey(SSL_CTX *ctx, EVP_PKEY *dhpkey);
  int SSL_set0_tmp_dh_pkey(SSL *s, EVP_PKEY *dhpkey);
 
-Deprecated since OpenSSL 3.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following functions have been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  void SSL_CTX_set_tmp_dh_callback(SSL_CTX *ctx,
                                   DH *(*tmp_dh_callback)(SSL *ssl, int is_export,

--- a/doc/man3/X509_dup.pod
+++ b/doc/man3/X509_dup.pod
@@ -320,9 +320,9 @@ X509_dup,
  void TYPE_free(TYPE *a);
  int TYPE_print_ctx(BIO *out, TYPE *a, int indent, const ASN1_PCTX *pctx);
 
-Deprecated since OpenSSL 3.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following functions have been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  DSA *DSAparams_dup(const DSA *dsa);
  RSA *RSAPrivateKey_dup(const RSA *rsa);

--- a/doc/man3/X509_get_subject_name.pod
+++ b/doc/man3/X509_get_subject_name.pod
@@ -15,8 +15,6 @@ get X509_NAME hashes or get and set issuer or subject names
 
  unsigned long X509_NAME_hash_ex(const X509_NAME *x, OSSL_LIB_CTX *libctx,
                                  const char *propq, int *ok);
-Deprecated since OpenSSL 3.0:
- #define X509_NAME_hash(x) X509_NAME_hash_ex(x, NULL, NULL, NULL)
 
  X509_NAME *X509_get_subject_name(const X509 *x);
  int X509_set_subject_name(X509 *x, const X509_NAME *name);
@@ -31,6 +29,12 @@ Deprecated since OpenSSL 3.0:
 
  X509_NAME *X509_CRL_get_issuer(const X509_CRL *crl);
  int X509_CRL_set_issuer_name(X509_CRL *x, const X509_NAME *name);
+
+The following macro has been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
+
+ #define X509_NAME_hash(x) X509_NAME_hash_ex(x, NULL, NULL, NULL)
 
 =head1 DESCRIPTION
 

--- a/doc/man3/X509_load_http.pod
+++ b/doc/man3/X509_load_http.pod
@@ -15,9 +15,9 @@ X509_CRL_http_nbio
  X509 *X509_load_http(const char *url, BIO *bio, BIO *rbio, int timeout);
  X509_CRL *X509_CRL_load_http(const char *url, BIO *bio, BIO *rbio, int timeout);
 
-Deprecated since OpenSSL 3.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following macros have been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  #define X509_http_nbio(rctx, pcert)
  #define X509_CRL_http_nbio(rctx, pcrl)

--- a/doc/man3/d2i_RSAPrivateKey.pod
+++ b/doc/man3/d2i_RSAPrivateKey.pod
@@ -70,9 +70,9 @@ i2d_EC_PUBKEY_fp
 
 =for openssl generic
 
-Deprecated since OpenSSL 3.0, can be hidden entirely by defining
-B<OPENSSL_API_COMPAT> with a suitable version value, see
-L<openssl_user_macros(7)>:
+The following functions have been deprecated since OpenSSL 3.0, and can be
+hidden entirely by defining B<OPENSSL_API_COMPAT> with a suitable version value,
+see L<openssl_user_macros(7)>:
 
  TYPE *d2i_TYPEPrivateKey(TYPE **a, const unsigned char **ppin, long length);
  TYPE *d2i_TYPEPrivateKey_bio(BIO *bp, TYPE **a);


### PR DESCRIPTION
There was recently an instance where a user was confused by the
deprecation warnings in the docs. They believed the warning applied to
the immediately preceding function declarations, when it fact it applied
to the following function declarations.

https://mta.openssl.org/pipermail/openssl-users/2021-December/014665.html

We clarify the wording to make it clear that the warning applies to the
following functions.
