### PR TITLE
CI: Replace windows-2016 with windows-2022

### DIFF
--- a/.github/workflows/os-zoo.yml
+++ b/.github/workflows/os-zoo.yml
@@ -40,9 +40,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [
-          windows-2016,
           windows-2019,
-          #windows-2022,    # Perl issues, doesn't finish configure step
+          windows-2022
         ]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/os-zoo.yml
+++ b/.github/workflows/os-zoo.yml
@@ -48,6 +48,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: ilammy/msvc-dev-cmd@v1
     - uses: ilammy/setup-nasm@v1
+    - uses: shogo82148/actions-setup-perl@v1
     - name: prepare the build directory
       run: mkdir _build
     - name: config

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         os:
           - windows-latest
-          - windows-2016
+          - windows-2022
         platform:
           - arch: win64
             config: VC-WIN64A enable-fips
@@ -56,7 +56,7 @@ jobs:
       matrix:
         os:
           - windows-latest
-          - windows-2016
+          - windows-2022
     runs-on: ${{matrix.os}}
     steps:
     - uses: actions/checkout@v2
@@ -79,7 +79,7 @@ jobs:
       matrix:
         os:
           - windows-latest
-          - windows-2016
+          - windows-2022
     runs-on: ${{matrix.os}}
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -31,6 +31,7 @@ jobs:
     - uses: ilammy/setup-nasm@v1
       with:
         platform: ${{ matrix.platform.arch }}
+    - uses: shogo82148/actions-setup-perl@v1
     - name: prepare the build directory
       run: mkdir _build
     - name: config
@@ -61,6 +62,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: ilammy/msvc-dev-cmd@v1
+    - uses: shogo82148/actions-setup-perl@v1
     - name: prepare the build directory
       run: mkdir _build
     - name: config
@@ -84,6 +86,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: ilammy/msvc-dev-cmd@v1
+    - uses: shogo82148/actions-setup-perl@v1
     - name: prepare the build directory
       run: mkdir _build
     - name: config


### PR DESCRIPTION
Windows 2016 environment is going to be discontinued.

Fixes #17177
