### PR TITLE
HTTP client: Fix parameter checks and their documentation

### DIFF
--- a/crypto/http/http_client.c
+++ b/crypto/http/http_client.c
@@ -961,7 +961,7 @@ int OSSL_HTTP_set1_request(OSSL_HTTP_REQ_CTX *rctx, const char *path,
         return 0;
     }
     use_http_proxy = rctx->proxy != NULL && !rctx->use_ssl;
-    if (use_http_proxy && (rctx->server == NULL || rctx->port == NULL)) {
+    if (use_http_proxy && rctx->server == NULL) {
         ERR_raise(ERR_LIB_HTTP, ERR_R_PASSED_INVALID_ARGUMENT);
         return 0;
     }

--- a/doc/man3/OSSL_HTTP_transfer.pod
+++ b/doc/man3/OSSL_HTTP_transfer.pod
@@ -56,9 +56,10 @@ OSSL_HTTP_open() initiates an HTTP session using the I<bio> argument if not
 NULL, else by connecting to a given I<server> optionally via a I<proxy>.
 
 Typically the OpenSSL build supports sockets and the I<bio> parameter is NULL.
-In this case I<rbio> must be NULL as well, and the
-library creates a network BIO internally for connecting to the given I<server>
-and the optionally given I<port>, defaulting to 80 for HTTP or 443 for HTTPS.
+In this case I<rbio> must be NULL as well and the I<server> must be non-NULL.
+The function creates a network BIO internally using L<BIO_new_connect(3)>
+for connecting to the given server and the optionally given I<port>,
+defaulting to 80 for HTTP or 443 for HTTPS.
 Then this internal BIO is used for setting up a connection
 and for exchanging one or more request and response.
 If I<bio> is given and I<rbio> is NULL then this I<bio> is used instead.
@@ -255,7 +256,7 @@ OSSL_HTTP_close() returns 0 if anything went wrong while disconnecting, else 1.
 
 =head1 SEE ALSO
 
-L<OSSL_HTTP_parse_url(3)>, L<BIO_set_conn_port(3)>
+L<OSSL_HTTP_parse_url(3)>, L<BIO_new_connect(3)>,
 L<ASN1_item_i2d_mem_bio(3)>, L<ASN1_item_d2i_bio(3)>,
 L<OSSL_HTTP_is_alive(3)>
 

--- a/doc/man3/OSSL_HTTP_transfer.pod
+++ b/doc/man3/OSSL_HTTP_transfer.pod
@@ -68,6 +68,8 @@ I<bio> is used for writing requests and I<rbio> for reading responses.
 As soon as the client has flushed I<bio> the server must be ready to provide
 a response or indicate a waiting condition via I<rbio>.
 
+If I<bio> is given, it is an error to provide I<proxy> or I<no_proxy> arguments,
+while I<server> and I<port> arguments may be given to support diagnostic output.
 If I<bio> is NULL the optional I<proxy> parameter can be used to set an
 HTTP(S) proxy to use (unless overridden by "no_proxy" settings).
 If TLS is not used this defaults to the environment variable C<http_proxy>

--- a/doc/man3/OSSL_HTTP_transfer.pod
+++ b/doc/man3/OSSL_HTTP_transfer.pod
@@ -58,7 +58,7 @@ NULL, else by connecting to a given I<server> optionally via a I<proxy>.
 Typically the OpenSSL build supports sockets and the I<bio> parameter is NULL.
 In this case I<rbio> must be NULL as well, and the
 library creates a network BIO internally for connecting to the given I<server>
-at the specified I<port> if any, defaulting to 80 for HTTP or 443 for HTTPS.
+and the optionally given I<port>, defaulting to 80 for HTTP or 443 for HTTPS.
 Then this internal BIO is used for setting up a connection
 and for exchanging one or more request and response.
 If I<bio> is given and I<rbio> is NULL then this I<bio> is used instead.
@@ -150,6 +150,8 @@ NULL) to print additional diagnostic information in a user-oriented way.
 
 OSSL_HTTP_set1_request() sets up in I<rctx> the request header and content data
 and expectations on the response using the following parameters.
+If <rctx> indicates using a proxy for HTTP (but not HTTPS), the server hostname
+(and optionally port) needs to be placed in the header and thus must be present.
 If I<path> is NULL it defaults to "/".
 If I<req> is NULL the HTTP GET method will be used to send the request
 else HTTP POST with the contents of I<req> and optional I<content_type>, where


### PR DESCRIPTION
A couple of small fixes:
* `OSSL_HTTP_set1_request():` Fix check for presence of `port` option and its documentation.
    For HTTP (not HTTPS) with proxy, `server` must be given, `port` is optional
* `OSSL_HTTP_open():` clarify doc of `server` arg and its use of `BIO_new_connect()`
* `OSSL_HTTP_open():` Complete documentation of checks for `server` and `proxy` args
