### PR TITLE
changes opensssl typos to openssl (extra "s") in documentation

### DIFF
--- a/NOTES-VALGRIND.md
+++ b/NOTES-VALGRIND.md
@@ -16,7 +16,7 @@ Requirements
    See <http://valgrind.org/info/platforms.html>
 2. Valgrind installed on the platform
    See <http://valgrind.org/downloads/current.html>
-3. OpensSSL compiled
+3. OpenSSL compiled
    See [INSTALL.md](INSTALL.md)
 
 Running Tests

--- a/doc/man1/openssl-mac.pod.in
+++ b/doc/man1/openssl-mac.pod.in
@@ -116,7 +116,7 @@ This option is identical to the B<-cipher> option.
 =item I<mac_name>
 
 Specifies the name of a supported MAC algorithm which will be used.
-To see the list of supported MAC's use the command C<opensssl list
+To see the list of supported MAC's use the command C<openssl list
 -mac-algorithms>.
 
 =back

--- a/include/openssl/macros.h
+++ b/include/openssl/macros.h
@@ -20,7 +20,7 @@
 # define OPENSSL_MSTR(x) OPENSSL_MSTR_HELPER(x)
 
 /*
- * Sometimes OPENSSSL_NO_xxx ends up with an empty file and some compilers
+ * Sometimes OPENSSL_NO_xxx ends up with an empty file and some compilers
  * don't like that.  This will hopefully silence them.
  */
 # define NON_EMPTY_TRANSLATION_UNIT static void *dummy = &dummy;


### PR DESCRIPTION
##### Checklist
- [x] documentation is added or updated
