### PR TITLE
Fix Markdown links in SUPPORT.md

### DIFF
--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -37,7 +37,7 @@ consider searching the mail archives and posting a question to the
 
 ### Open an Issue
 
-If you wish to report a bug, please open an [issue][github-issues] on GitHub
+If you wish to report a bug, please open an [issue](../../issues/new/choose) on GitHub
 and include the following information:
 
 - OpenSSL version: output of `openssl version -a`
@@ -55,7 +55,7 @@ particular the manual pages, can be reported as issues.
 
 The fastest way to get a bug fixed is to fix it yourself ;-). If you are
 experienced in programming and know how to fix the bug, you can open a
-pull request. The details are covered in the [Contributing](#contributing) section.
+pull request. The details are covered in the [Contributing](./CONTRIBUTING.md) section.
 
 Don't hesitate to open a pull request, even if it's only a small change
 like a grammatical or typographical error in the documentation.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -37,7 +37,7 @@ consider searching the mail archives and posting a question to the
 
 ### Open an Issue
 
-If you wish to report a bug, please open an [issue](../../issues/new/choose) on GitHub
+If you wish to report a bug, please open an [issue][github-issues] on GitHub
 and include the following information:
 
 - OpenSSL version: output of `openssl version -a`
@@ -55,7 +55,7 @@ particular the manual pages, can be reported as issues.
 
 The fastest way to get a bug fixed is to fix it yourself ;-). If you are
 experienced in programming and know how to fix the bug, you can open a
-pull request. The details are covered in the [Contributing](./CONTRIBUTING.md) section.
+pull request. The details are covered in the [Contributing][contributing] section.
 
 Don't hesitate to open a pull request, even if it's only a small change
 like a grammatical or typographical error in the documentation.
@@ -89,3 +89,5 @@ anymore, the searchable archive may still contain useful information.
 [openssl-announce]:  https://mta.openssl.org/mailman/listinfo/openssl-announce
 [openssl-project]:   https://mta.openssl.org/mailman/listinfo/openssl-project
 [openssl-dev]:       https://mta.openssl.org/mailman/listinfo/openssl-dev
+[github-issues]:     https://github.com/openssl/openssl/issues/new/choose
+[contributing]:      https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md


### PR DESCRIPTION
Add link to CONTRIBUTING.md and fix (presumably broken?) link to Github issues in SUPPORT.md

CLA: trivial

##### Checklist

- [x] documentation is added or updated
