### PR TITLE
BIO_get_ktls_send(): fix return check

### DIFF
--- a/doc/man3/BIO_ctrl.pod
+++ b/doc/man3/BIO_ctrl.pod
@@ -103,9 +103,9 @@ BIO_pending(), BIO_ctrl_pending(), BIO_wpending() and BIO_ctrl_wpending()
 return the amount of pending data.
 
 BIO_get_ktls_send() returns 1 if the BIO is using the Kernel TLS data-path for
-sending. Otherwise, it returns zero.
+sending. Otherwise, it returns zero. It also returns negative values for failure.
 BIO_get_ktls_recv() returns 1 if the BIO is using the Kernel TLS data-path for
-receiving. Otherwise, it returns zero.
+receiving. Otherwise, it returns zero. It also returns negative values for failure.
 
 =head1 NOTES
 

--- a/ssl/record/rec_layer_s3.c
+++ b/ssl/record/rec_layer_s3.c
@@ -764,7 +764,7 @@ int do_ssl3_write(SSL *s, int type, const unsigned char *buf,
         s->s3.empty_fragment_done = 1;
     }
 
-    if (BIO_get_ktls_send(s->wbio)) {
+    if (BIO_get_ktls_send(s->wbio) > 0) {
         /*
          * ktls doesn't modify the buffer, but to avoid a warning we need to
          * discard the const qualifier.
@@ -921,7 +921,7 @@ int do_ssl3_write(SSL *s, int type, const unsigned char *buf,
                 goto err;
             }
         } else {
-            if (BIO_get_ktls_send(s->wbio)) {
+            if (BIO_get_ktls_send(s->wbio) > 0) {
                 SSL3_RECORD_reset_data(&wr[j]);
             } else {
                 if (!WPACKET_memcpy(thispkt, thiswr->input, thiswr->length)) {
@@ -1053,7 +1053,7 @@ int do_ssl3_write(SSL *s, int type, const unsigned char *buf,
         thispkt = &pkt[j];
         thiswr = &wr[j];
 
-        if (BIO_get_ktls_send(s->wbio))
+        if (BIO_get_ktls_send(s->wbio) > 0)
             goto mac_done;
 
         /* Allocate bytes for the encryption overhead */
@@ -1186,7 +1186,7 @@ int ssl3_write_pending(SSL *s, int type, const unsigned char *buf, size_t len,
              * To prevent coalescing of control and data messages,
              * such as in buffer_write, we flush the BIO
              */
-            if (BIO_get_ktls_send(s->wbio) && type != SSL3_RT_APPLICATION_DATA) {
+            if (BIO_get_ktls_send(s->wbio) > 0 && type != SSL3_RT_APPLICATION_DATA) {
                 i = BIO_flush(s->wbio);
                 if (i <= 0)
                     return i;

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -2063,7 +2063,7 @@ ossl_ssize_t SSL_sendfile(SSL *s, int fd, off_t offset, size_t size, int flags)
         return -1;
     }
 
-    if (!BIO_get_ktls_send(s->wbio)) {
+    if (BIO_get_ktls_send(s->wbio) <= 0) {
         ERR_raise(ERR_LIB_SSL, SSL_R_UNINITIALIZED);
         return -1;
     }
@@ -2372,7 +2372,7 @@ long SSL_ctrl(SSL *s, int cmd, long larg, void *parg)
         if (larg < 512 || larg > SSL3_RT_MAX_PLAIN_LENGTH)
             return 0;
 #ifndef OPENSSL_NO_KTLS
-        if (s->wbio != NULL && BIO_get_ktls_send(s->wbio))
+        if (s->wbio != NULL && BIO_get_ktls_send(s->wbio) > 0)
             return 0;
 #endif /* OPENSSL_NO_KTLS */
         s->max_send_fragment = larg;

--- a/ssl/t1_enc.c
+++ b/ssl/t1_enc.c
@@ -462,7 +462,7 @@ int tls1_change_cipher_state(SSL *s, int which)
     }
 
     /* ktls doesn't support renegotiation */
-    if ((BIO_get_ktls_send(s->wbio) && (which & SSL3_CC_WRITE)) ||
+    if ((BIO_get_ktls_send(s->wbio) > 0 && (which & SSL3_CC_WRITE)) ||
         (BIO_get_ktls_recv(s->rbio) && (which & SSL3_CC_READ))) {
         SSLfatal(s, SSL_AD_NO_RENEGOTIATION, ERR_R_INTERNAL_ERROR);
         goto err;

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -1203,18 +1203,18 @@ static int execute_test_ktls(int cis_ktls, int sis_ktls,
      * isn't enabled.
      */
     if (!cis_ktls) {
-        if (!TEST_false(BIO_get_ktls_send(clientssl->wbio)))
+        if (!TEST_int_gt(BIO_get_ktls_send(clientssl->wbio), 0))
             goto end;
     } else {
-        if (BIO_get_ktls_send(clientssl->wbio))
+        if (BIO_get_ktls_send(clientssl->wbio) > 0)
             ktls_used = 1;
     }
 
     if (!sis_ktls) {
-        if (!TEST_false(BIO_get_ktls_send(serverssl->wbio)))
+        if (!TEST_int_gt(BIO_get_ktls_send(serverssl->wbio), 0))
             goto end;
     } else {
-        if (BIO_get_ktls_send(serverssl->wbio))
+        if (BIO_get_ktls_send(serverssl->wbio) > 0)
             ktls_used = 1;
     }
 
@@ -1227,7 +1227,7 @@ static int execute_test_ktls(int cis_ktls, int sis_ktls,
         if (!TEST_false(BIO_get_ktls_recv(clientssl->rbio)))
             goto end;
     } else {
-        if (BIO_get_ktls_send(clientssl->rbio))
+        if (BIO_get_ktls_send(clientssl->rbio) > 0)
             ktls_used = 1;
     }
 
@@ -1235,7 +1235,7 @@ static int execute_test_ktls(int cis_ktls, int sis_ktls,
         if (!TEST_false(BIO_get_ktls_recv(serverssl->rbio)))
             goto end;
     } else {
-        if (BIO_get_ktls_send(serverssl->rbio))
+        if (BIO_get_ktls_send(serverssl->rbio) > 0)
             ktls_used = 1;
     }
 


### PR DESCRIPTION
BIO_get_ktls_send() can also return negative values. 

Return checks like `if (BIO_get_ktls_send())` are changed to `if (BIO_get_ktls_send() > 0)` to capture more accurate semantic. Most of return checks in `if (!BIO_get_ktls_send())` format are reserved except it leads to error processing stage, where negative return values should be classfied too. 