### PR TITLE
BIO_get_ktls_recv(): fix return check

### DIFF
--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -3210,7 +3210,7 @@ static void print_stuff(BIO *bio, SSL *s, int full)
 #ifndef OPENSSL_NO_KTLS
     if (BIO_get_ktls_send(SSL_get_wbio(s)))
         BIO_printf(bio_err, "Using Kernel TLS for sending\n");
-    if (BIO_get_ktls_recv(SSL_get_rbio(s)))
+    if (BIO_get_ktls_recv(SSL_get_rbio(s)) > 0)
         BIO_printf(bio_err, "Using Kernel TLS for receiving\n");
 #endif
 

--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -2976,7 +2976,7 @@ static void print_connection_info(SSL *con)
 #ifndef OPENSSL_NO_KTLS
     if (BIO_get_ktls_send(SSL_get_wbio(con)))
         BIO_printf(bio_err, "Using Kernel TLS for sending\n");
-    if (BIO_get_ktls_recv(SSL_get_rbio(con)))
+    if (BIO_get_ktls_recv(SSL_get_rbio(con)) > 0)
         BIO_printf(bio_err, "Using Kernel TLS for receiving\n");
 #endif
 

--- a/crypto/bio/bss_conn.c
+++ b/crypto/bio/bss_conn.c
@@ -323,7 +323,7 @@ static int conn_read(BIO *b, char *out, int outl)
     if (out != NULL) {
         clear_socket_error();
 # ifndef OPENSSL_NO_KTLS
-        if (BIO_get_ktls_recv(b))
+        if (BIO_get_ktls_recv(b) > 0)
             ret = ktls_read_record(b->num, out, outl);
         else
 # endif
@@ -626,7 +626,7 @@ int conn_gets(BIO *bio, char *buf, int size)
     clear_socket_error();
     while (size-- > 1) {
 # ifndef OPENSSL_NO_KTLS
-        if (BIO_get_ktls_recv(bio))
+        if (BIO_get_ktls_recv(bio) > 0)
             ret = ktls_read_record(bio->num, ptr, 1);
         else
 # endif

--- a/crypto/bio/bss_sock.c
+++ b/crypto/bio/bss_sock.c
@@ -107,7 +107,7 @@ static int sock_read(BIO *b, char *out, int outl)
     if (out != NULL) {
         clear_socket_error();
 # ifndef OPENSSL_NO_KTLS
-        if (BIO_get_ktls_recv(b))
+        if (BIO_get_ktls_recv(b) > 0)
             ret = ktls_read_record(b->num, out, outl);
         else
 # endif

--- a/ssl/record/ssl3_record.c
+++ b/ssl/record/ssl3_record.c
@@ -518,7 +518,7 @@ int ssl3_get_record(SSL *s)
      * KTLS reads full records. If there is any data left,
      * then it is from before enabling ktls
      */
-    if (BIO_get_ktls_recv(s->rbio) && !is_ktls_left)
+    if (BIO_get_ktls_recv(s->rbio) > 0 && !is_ktls_left)
         goto skip_decryption;
 
     if (s->read_hash != NULL) {

--- a/ssl/t1_enc.c
+++ b/ssl/t1_enc.c
@@ -463,7 +463,7 @@ int tls1_change_cipher_state(SSL *s, int which)
 
     /* ktls doesn't support renegotiation */
     if ((BIO_get_ktls_send(s->wbio) && (which & SSL3_CC_WRITE)) ||
-        (BIO_get_ktls_recv(s->rbio) && (which & SSL3_CC_READ))) {
+        (BIO_get_ktls_recv(s->rbio) > 0 && (which & SSL3_CC_READ))) {
         SSLfatal(s, SSL_AD_NO_RENEGOTIATION, ERR_R_INTERNAL_ERROR);
         goto err;
     }

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -1224,7 +1224,7 @@ static int execute_test_ktls(int cis_ktls, int sis_ktls,
     rx_supported = (tls_version != TLS1_3_VERSION);
 #endif
     if (!cis_ktls || !rx_supported) {
-        if (!TEST_false(BIO_get_ktls_recv(clientssl->rbio)))
+        if (!TEST_int_gt(BIO_get_ktls_recv(clientssl->rbio), 0))
             goto end;
     } else {
         if (BIO_get_ktls_send(clientssl->rbio))
@@ -1232,7 +1232,7 @@ static int execute_test_ktls(int cis_ktls, int sis_ktls,
     }
 
     if (!sis_ktls || !rx_supported) {
-        if (!TEST_false(BIO_get_ktls_recv(serverssl->rbio)))
+        if (!TEST_int_gt(BIO_get_ktls_recv(serverssl->rbio), 0))
             goto end;
     } else {
         if (BIO_get_ktls_send(serverssl->rbio))


### PR DESCRIPTION
Return checks like `if (BIO_get_ktls_recv()) `are changed to `if (BIO_get_ktls_recv() > 0)` to capture more accurate semantic. Most of return checks in `if (!BIO_get_ktls_recv()) `format are reserved except it leads to error processing stage, where negative return values should be classfied too. 

Thanks for taking time for reviewing. 