### PR TITLE
KTLS: enable the CCM mode of ktls

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -223,6 +223,14 @@ OpenSSL 3.2
 
    *Hugo Landau*
 
+ * Enable KTLS with the TLS 1.3 CCM mode ciphersuites. Note that some linux
+   kernel versions that support KTLS have a known bug in CCM processing. That
+   has been fixed in stable releases starting from 5.4.164, 5.10.84, 5.15.7,
+   and all releases since 5.16. KTLS with CCM ciphersuites should be only used
+   on these releases.
+
+   *Tianjia Zhang*
+
 OpenSSL 3.0
 -----------
 

--- a/ssl/record/methods/ktls_meth.c
+++ b/ssl/record/methods/ktls_meth.c
@@ -147,8 +147,7 @@ static int ktls_int_check_supported_cipher(OSSL_RECORD_LAYER *rl,
      */
 # ifdef OPENSSL_KTLS_AES_CCM_128
     if (EVP_CIPHER_is_a(c, "AES-128-CCM")) {
-        if (rl->version == TLS_1_3_VERSION /* broken on 5.x kernels */
-            || taglen != EVP_CCM_TLS_TAG_LEN)
+        if (taglen != EVP_CCM_TLS_TAG_LEN)
             return 0;
         return 1;
     } else


### PR DESCRIPTION
The latest kernel (including stable kernel) has fixed the issue
of decryption failure in CCM mode in TLS 1.3. It is necessary to
reenable CCM mode for KTLS.

Signed-off-by: Tianjia Zhang <tianjia.zhang@linux.alibaba.com>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
