### PR TITLE
Don't free the EVP_PKEY on error in set0_tmp_dh_pkey() functions

### DIFF
--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -3448,7 +3448,11 @@ long ssl3_ctrl(SSL *s, int cmd, long larg, void *parg)
                 ERR_raise(ERR_LIB_SSL, ERR_R_MALLOC_FAILURE);
                 return 0;
             }
-            return SSL_set0_tmp_dh_pkey(s, pkdh);
+            if (!SSL_set0_tmp_dh_pkey(s, pkdh)) {
+                EVP_PKEY_free(pkdh);
+                return 0;
+            }
+            return 1;
         }
         break;
     case SSL_CTRL_SET_TMP_DH_CB:
@@ -3774,7 +3778,11 @@ long ssl3_ctx_ctrl(SSL_CTX *ctx, int cmd, long larg, void *parg)
                 ERR_raise(ERR_LIB_SSL, ERR_R_MALLOC_FAILURE);
                 return 0;
             }
-            return SSL_CTX_set0_tmp_dh_pkey(ctx, pkdh);
+            if (!SSL_CTX_set0_tmp_dh_pkey(ctx, pkdh)) {
+                EVP_PKEY_free(pkdh);
+                return 0;
+            }
+            return 1;
         }
     case SSL_CTRL_SET_TMP_DH_CB:
         {

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -5975,7 +5975,6 @@ int SSL_set0_tmp_dh_pkey(SSL *s, EVP_PKEY *dhpkey)
     if (!ssl_security(s, SSL_SECOP_TMP_DH,
                       EVP_PKEY_get_security_bits(dhpkey), 0, dhpkey)) {
         ERR_raise(ERR_LIB_SSL, SSL_R_DH_KEY_TOO_SMALL);
-        EVP_PKEY_free(dhpkey);
         return 0;
     }
     EVP_PKEY_free(s->cert->dh_tmp);
@@ -5988,7 +5987,6 @@ int SSL_CTX_set0_tmp_dh_pkey(SSL_CTX *ctx, EVP_PKEY *dhpkey)
     if (!ssl_ctx_security(ctx, SSL_SECOP_TMP_DH,
                           EVP_PKEY_get_security_bits(dhpkey), 0, dhpkey)) {
         ERR_raise(ERR_LIB_SSL, SSL_R_DH_KEY_TOO_SMALL);
-        EVP_PKEY_free(dhpkey);
         return 0;
     }
     EVP_PKEY_free(ctx->cert->dh_tmp);


### PR DESCRIPTION
We should not be freeing the caller's key in the event of error.

Fixes #17196

