### PR TITLE
Fix documentation for tlsext_ticket_key docs

### DIFF
--- a/doc/man3/SSL_CTX_set_tlsext_ticket_key_cb.pod
+++ b/doc/man3/SSL_CTX_set_tlsext_ticket_key_cb.pod
@@ -145,7 +145,7 @@ enable an attacker to obtain the session keys.
 
 =head1 RETURN VALUES
 
-returns 0 to indicate the callback function was set.
+Returns 1 to indicate the callback function was set and 0 otherwise.
 
 =head1 EXAMPLES
 


### PR DESCRIPTION
The tlsext_ticket_key functions are documented as returning 0 on success.
In fact they return 1 on success.

