### PR TITLE
CI: Replace windows-2016 with windows-2022

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -9,8 +9,8 @@ jobs:
     strategy:
       matrix:
         os:
-        - windows-latest
-        - windows-2016
+        - windows-2019
+        - windows-2022
         platform:
         - arch: win64
           config: VC-WIN64A
@@ -25,6 +25,7 @@ jobs:
     - uses: ilammy/setup-nasm@v1
       with:
         platform: ${{ matrix.platform.arch }}
+    - uses: shogo82148/actions-setup-perl@v1
     - name: prepare the build directory
       run: mkdir _build
     - name: config
@@ -49,12 +50,13 @@ jobs:
     strategy:
       matrix:
         os:
-        - windows-latest
-        - windows-2016
+        - windows-2019
+        - windows-2022
     runs-on: ${{matrix.os}}
     steps:
     - uses: actions/checkout@v2
     - uses: ilammy/msvc-dev-cmd@v1
+    - uses: shogo82148/actions-setup-perl@v1
     - name: prepare the build directory
       run: mkdir _build
     - name: config
@@ -72,12 +74,13 @@ jobs:
     strategy:
       matrix:
         os:
-        - windows-latest
-        - windows-2016
+        - windows-2019
+        - windows-2022
     runs-on: ${{matrix.os}}
     steps:
     - uses: actions/checkout@v2
     - uses: ilammy/msvc-dev-cmd@v1
+    - uses: shogo82148/actions-setup-perl@v1
     - name: prepare the build directory
       run: mkdir _build
     - name: config


### PR DESCRIPTION
Windows 2016 environment is going to be discontinued.

Fixes #17177
