### PR TITLE
Make OSSL_provider_init() OPENSSL_EXPORT, not just extern

### DIFF
--- a/include/openssl/core.h
+++ b/include/openssl/core.h
@@ -195,7 +195,7 @@ typedef int (OSSL_provider_init_fn)(const OSSL_CORE_HANDLE *handle,
 #  pragma names save
 #  pragma names uppercase,truncated
 # endif
-extern OSSL_provider_init_fn OSSL_provider_init;
+OPENSSL_EXPORT OSSL_provider_init_fn OSSL_provider_init;
 # ifdef __VMS
 #  pragma names restore
 # endif

--- a/util/perl/OpenSSL/ParseC.pm
+++ b/util/perl/OpenSSL/ParseC.pm
@@ -610,6 +610,12 @@ EOF
       },
     },
 
+    # OpenSSL's declaration of externs with possible export linkage
+    # (really only relevant on Windows)
+    { regexp   => qr/OPENSSL_(?:EXPORT|EXTERN)/,
+      massager => sub { return ("extern"); }
+    },
+
     # Spurious stuff found in the OpenSSL headers
     # Usually, these are just macros that expand to, well, something
     { regexp   => qr/__NDK_FPABI__/,


### PR DESCRIPTION
On non-Windows systems, there's no difference at all.  On Windows systems,
__declspec(dllexport) is added, which ensures it gets exported no matter
what.

Fixes #17203