### PR TITLE
rename MIN() macro

### DIFF
--- a/providers/implementations/kdfs/kbkdf.c
+++ b/providers/implementations/kdfs/kbkdf.c
@@ -46,7 +46,7 @@
 
 #include "e_os.h"
 
-#define MIN(a, b) ((a) < (b)) ? (a) : (b)
+#define ossl_min(a, b) ((a) < (b)) ? (a) : (b)
 
 typedef enum {
     COUNTER = 0,
@@ -197,7 +197,7 @@ static int derive(EVP_MAC_CTX *ctx_init, kbkdf_mode mode, unsigned char *iv,
             goto done;
 
         to_write = ko_len - written;
-        memcpy(ko + written, k_i, MIN(to_write, h));
+        memcpy(ko + written, k_i, ossl_min(to_write, h));
         written += h;
 
         k_i_len = h;


### PR DESCRIPTION
MIN is a rather generic name and results in a name clash when trying to
port tianocore over to openssl 3.0.  Use the usual ossl prefix and
rename the macro to ossl_min() to solve this.

Signed-off-by: Gerd Hoffmann <kraxel@redhat.com>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
