### PR TITLE
`OBJ_obj2txt()`: fix off-by-one documentation of the result - backport to 1.1.1

### DIFF
--- a/doc/man3/OBJ_nid2obj.pod
+++ b/doc/man3/OBJ_nid2obj.pod
@@ -68,13 +68,15 @@ If B<no_name> is 0 then long names and short names will be interpreted
 as well as numerical forms. If B<no_name> is 1 only the numerical form
 is acceptable.
 
-OBJ_obj2txt() converts the B<ASN1_OBJECT> B<a> into a textual representation.
-The representation is written as a null terminated string to B<buf>
-at most B<buf_len> bytes are written, truncating the result if necessary.
-The total amount of space required is returned. If B<no_name> is 0 then
-if the object has a long or short name then that will be used, otherwise
-the numerical form will be used. If B<no_name> is 1 then the numerical
-form will always be used.
+OBJ_obj2txt() converts the B<ASN1_OBJECT> I<a> into a textual representation.
+Unless I<buf> is NULL,
+the representation is written as a NUL-terminated string to I<buf>, where
+at most I<buf_len> bytes are written, truncating the result if necessary.
+In any case it returns the total string length, excluding the NUL character,
+required for non-truncated representation, or -1 on error.
+If I<no_name> is 0 then if the object has a long or short name
+then that will be used, otherwise the numerical form will be used.
+If I<no_name> is 1 then the numerical form will always be used.
 
 i2t_ASN1_OBJECT() is the same as OBJ_obj2txt() with the B<no_name> set to zero.
 
@@ -141,6 +143,13 @@ on error.
 OBJ_obj2nid(), OBJ_ln2nid(), OBJ_sn2nid() and OBJ_txt2nid() return
 a NID or B<NID_undef> on error.
 
+OBJ_add_sigid() returns 1 on success or 0 on error.
+
+i2t_ASN1_OBJECT() an OBJ_obj2txt() return -1 on error.
+On success, they return the length of the string written to I<buf> if I<buf> is
+not NULL and I<buf_len> is big enough, otherwise the total string length.
+Note that this does not count the trailing NUL character.
+
 =head1 EXAMPLES
 
 Create an object for B<commonName>:
@@ -160,15 +169,6 @@ Create a new NID and initialize an object from it:
 Create a new object directly:
 
  obj = OBJ_txt2obj("1.2.3.4", 1);
-
-=head1 BUGS
-
-OBJ_obj2txt() is awkward and messy to use: it doesn't follow the
-convention of other OpenSSL functions where the buffer can be set
-to B<NULL> to determine the amount of data that should be written.
-Instead B<buf> must point to a valid buffer and B<buf_len> should
-be set to a positive value. A buffer length of 80 should be more
-than enough to handle any OID encountered in practice.
 
 =head1 SEE ALSO
 

--- a/doc/man3/OBJ_nid2obj.pod
+++ b/doc/man3/OBJ_nid2obj.pod
@@ -46,26 +46,26 @@ Deprecated:
 The ASN1 object utility functions process ASN1_OBJECT structures which are
 a representation of the ASN1 OBJECT IDENTIFIER (OID) type.
 For convenience, OIDs are usually represented in source code as numeric
-identifiers, or B<NID>s.  OpenSSL has an internal table of OIDs that
+identifiers, or I<NID>s.  OpenSSL has an internal table of OIDs that
 are generated when the library is built, and their corresponding NIDs
 are available as defined constants.  For the functions below, application
 code should treat all returned values -- OIDs, NIDs, or names -- as
 constants.
 
-OBJ_nid2obj(), OBJ_nid2ln() and OBJ_nid2sn() convert the NID B<n> to
+OBJ_nid2obj(), OBJ_nid2ln() and OBJ_nid2sn() convert the NID I<n> to
 an ASN1_OBJECT structure, its long name and its short name respectively,
 or B<NULL> if an error occurred.
 
 OBJ_obj2nid(), OBJ_ln2nid(), OBJ_sn2nid() return the corresponding NID
-for the object B<o>, the long name <ln> or the short name <sn> respectively
+for the object I<o>, the long name <ln> or the short name <sn> respectively
 or NID_undef if an error occurred.
 
-OBJ_txt2nid() returns NID corresponding to text string <s>. B<s> can be
+OBJ_txt2nid() returns NID corresponding to text string I<s>. I<s> can be
 a long name, a short name or the numerical representation of an object.
 
-OBJ_txt2obj() converts the text string B<s> into an ASN1_OBJECT structure.
-If B<no_name> is 0 then long names and short names will be interpreted
-as well as numerical forms. If B<no_name> is 1 only the numerical form
+OBJ_txt2obj() converts the text string I<s> into an ASN1_OBJECT structure.
+If I<no_name> is 0 then long names and short names will be interpreted
+as well as numerical forms. If I<no_name> is 1 only the numerical form
 is acceptable.
 
 OBJ_obj2txt() converts the B<ASN1_OBJECT> I<a> into a textual representation.
@@ -78,20 +78,20 @@ If I<no_name> is 0 then if the object has a long or short name
 then that will be used, otherwise the numerical form will be used.
 If I<no_name> is 1 then the numerical form will always be used.
 
-i2t_ASN1_OBJECT() is the same as OBJ_obj2txt() with the B<no_name> set to zero.
+i2t_ASN1_OBJECT() is the same as OBJ_obj2txt() with the I<no_name> set to zero.
 
-OBJ_cmp() compares B<a> to B<b>. If the two are identical 0 is returned.
+OBJ_cmp() compares I<a> to I<b>. If the two are identical 0 is returned.
 
-OBJ_dup() returns a copy of B<o>.
+OBJ_dup() returns a copy of I<o>.
 
-OBJ_create() adds a new object to the internal table. B<oid> is the
-numerical form of the object, B<sn> the short name and B<ln> the
+OBJ_create() adds a new object to the internal table. I<oid> is the
+numerical form of the object, I<sn> the short name and I<ln> the
 long name. A new NID is returned for the created object in case of
 success and NID_undef in case of failure.
 
-OBJ_length() returns the size of the content octets of B<obj>.
+OBJ_length() returns the size of the content octets of I<obj>.
 
-OBJ_get0_data() returns a pointer to the content octets of B<obj>.
+OBJ_get0_data() returns a pointer to the content octets of I<obj>.
 The returned pointer is an internal pointer which B<must not> be freed.
 
 OBJ_cleanup() releases any resources allocated by creating new objects.


### PR DESCRIPTION
This backports #17189 to 1.1.1.
Doing so, I found that part of the reason why a cherry-pick did not apply cleanly was that the file still used `B<...>` for parameter names.
So for consistency I changed all remaining ones of those `B<...>` to  `I<...>`, in a separate commit.