### PR TITLE
APPS/cmp: fix `-rspin` option such that it works again without `-reqin`

### DIFF
--- a/apps/cmp.c
+++ b/apps/cmp.c
@@ -753,6 +753,7 @@ static OSSL_CMP_MSG *read_write_req_resp(OSSL_CMP_CTX *ctx,
     OSSL_CMP_MSG *req_new = NULL;
     OSSL_CMP_MSG *res = NULL;
     OSSL_CMP_PKIHEADER *hdr;
+    const char *prev_opt_rspin = opt_rspin;
 
     if (req != NULL && opt_reqout != NULL
             && !write_PKIMESSAGE(req, &opt_reqout))
@@ -782,7 +783,7 @@ static OSSL_CMP_MSG *read_write_req_resp(OSSL_CMP_CTX *ctx,
     if (res == NULL)
         goto err;
 
-    if (opt_reqin != NULL || opt_rspin != NULL) {
+    if (opt_reqin != NULL || prev_opt_rspin != NULL) {
         /* need to satisfy nonce and transactionID checks */
         ASN1_OCTET_STRING *nonce;
         ASN1_OCTET_STRING *tid;

--- a/test/recipes/80-test_cmp_http_data/test_commands.csv
+++ b/test/recipes/80-test_cmp_http_data/test_commands.csv
@@ -53,3 +53,7 @@ expected,description, -section,val, -cmd,val,val2, -cacertsout,val,val2, -infoty
 0,geninfo bad syntax: missing ':', -section,, -cmd,cr,, -cert,signer.crt, -key,signer.p12, -keypass,pass:12345,BLANK,, -geninfo,1.2.3:int987,,,,
 0,geninfo bad syntax: double ':', -section,, -cmd,cr,, -cert,signer.crt, -key,signer.p12, -keypass,pass:12345,BLANK,, -geninfo,1.2.3:int::987,,,,
 0,geninfo bad syntax: missing ':int', -section,, -cmd,cr,, -cert,signer.crt, -key,signer.p12, -keypass,pass:12345,BLANK,, -geninfo,1.2.3,,,,
+,,,,,,,,,,,,,,,,,,,
+1,reqout+rspout, -section,, -cmd,ir,,-reqout,_RESULT_DIR/req1.der _RESULT_DIR/req2.der,,-rspout,_RESULT_DIR/rsp1.der _RESULT_DIR/rsp2.der,,BLANK,,BLANK,
+1,reqin, -section,, -cmd,ir,,-reqin,_RESULT_DIR/req1.der _RESULT_DIR/req2.der,,BLANK,,,BLANK,,BLANK,
+1,rspin, -section,, -cmd,ir,,BLANK,,,-rspin,_RESULT_DIR/rsp1.der _RESULT_DIR/rsp2.der,,BLANK,,BLANK,


### PR DESCRIPTION
The code contained a tricky bug.
Added a few test cases for `-rspin` and the three related options, 
which would have caught this issue.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
