### PR TITLE
`CMP check_msg_find_cert()`: improve diagnostics on transactionID mismatch

### DIFF
--- a/crypto/cmp/cmp_hdr.c
+++ b/crypto/cmp/cmp_hdr.c
@@ -276,8 +276,7 @@ int ossl_cmp_hdr_set_transactionID(OSSL_CMP_CTX *ctx, OSSL_CMP_PKIHEADER *hdr)
         if (!set_random(&ctx->transactionID, ctx,
                         OSSL_CMP_TRANSACTIONID_LENGTH))
             return 0;
-        tid = OPENSSL_buf2hexstr(ctx->transactionID->data,
-                                 ctx->transactionID->length);
+        tid = i2s_ASN1_OCTET_STRING(NULL, ctx->transactionID);
         if (tid != NULL)
             ossl_cmp_log1(DEBUG, ctx,
                           "Starting new transaction with ID=%s", tid);

--- a/crypto/cmp/cmp_server.c
+++ b/crypto/cmp/cmp_server.c
@@ -481,10 +481,8 @@ OSSL_CMP_MSG *OSSL_CMP_SRV_process_request(OSSL_CMP_SRV_CTX *srv_ctx,
     case OSSL_CMP_PKIBODY_GENM:
     case OSSL_CMP_PKIBODY_ERROR:
         if (ctx->transactionID != NULL) {
-            char *tid;
+            char *tid = i2s_ASN1_OCTET_STRING(NULL, ctx->transactionID);
 
-            tid = OPENSSL_buf2hexstr(ctx->transactionID->data,
-                                     ctx->transactionID->length);
             if (tid != NULL)
                 ossl_cmp_log1(WARN, ctx,
                               "Assuming that last transaction with ID=%s got aborted",

--- a/crypto/x509/v3_akid.c
+++ b/crypto/x509/v3_akid.c
@@ -44,7 +44,7 @@ static STACK_OF(CONF_VALUE) *i2v_AUTHORITY_KEYID(X509V3_EXT_METHOD *method,
     STACK_OF(CONF_VALUE) *origextlist = extlist, *tmpextlist;
 
     if (akeyid->keyid) {
-        tmp = OPENSSL_buf2hexstr(akeyid->keyid->data, akeyid->keyid->length);
+        tmp = i2s_ASN1_OCTET_STRING(NULL, akeyid->keyid);
         if (tmp == NULL) {
             ERR_raise(ERR_LIB_X509V3, ERR_R_MALLOC_FAILURE);
             return NULL;
@@ -66,7 +66,7 @@ static STACK_OF(CONF_VALUE) *i2v_AUTHORITY_KEYID(X509V3_EXT_METHOD *method,
         extlist = tmpextlist;
     }
     if (akeyid->serial) {
-        tmp = OPENSSL_buf2hexstr(akeyid->serial->data, akeyid->serial->length);
+        tmp = i2s_ASN1_OCTET_STRING(NULL, akeyid->serial);
         if (tmp == NULL) {
             ERR_raise(ERR_LIB_X509V3, ERR_R_MALLOC_FAILURE);
             goto err;

--- a/test/recipes/80-test_cmp_http_data/test_commands.csv
+++ b/test/recipes/80-test_cmp_http_data/test_commands.csv
@@ -33,7 +33,7 @@ expected,description, -section,val, -cmd,val,val2, -cacertsout,val,val2, -infoty
 1, --- get certificate for revocation ----, -section,, -cmd,cr,,BLANK,,,BLANK,,,BLANK,,BLANK,
 1,revreason AACompromise, -section,, -cmd,rr,,BLANK,,,BLANK,,, -oldcert,_RESULT_DIR/test.cert.pem, -revreason,10
 1, --- get certificate for revocation ----, -section,, -cmd,cr,,BLANK,,,BLANK,,,BLANK,,BLANK,
-1, --- use csr for revocation ----, -section,, -cmd,rr,,BLANK,,,BLANK,,,BLANK,,BLANK, -revreason,0, -csr,csr.pem
+1, --- use csr for revocation ----, -section,, -cmd,rr,,BLANK,,,BLANK,,,BLANK,, -revreason,0, -csr,csr.pem
 1, --- get certificate for revocation ----, -section,, -cmd,cr,,BLANK,,,BLANK,,,BLANK,,BLANK,
 0,without oldcert, -section,, -cmd,rr,,BLANK,,,BLANK,,,BLANK,,BLANK,
 0,oldcert file nonexistent, -section,, -cmd,rr,,BLANK,,,BLANK,,, -oldcert,idontexist,BLANK,


### PR DESCRIPTION
Make `CMP check_msg_find_cert()` print the expected and actual transaction ID on mismatch.

On this occasion, 
* make use of `i2s_ASN1_OCTET_STRING()` wherever possible 
* `80-test_cmp_http_data/test_commands.csv`: fix minor glitch in column alignment

