### PR TITLE
apps/s_server: Correct s_server to return the correct file path

### DIFF
--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -3220,7 +3220,7 @@ static int www_body(int s, int stype, int prot, unsigned char *context)
             }
             BIO_puts(io, "</pre></BODY></HTML>\r\n\r\n");
             break;
-        } else if ((www == 2 || www == 3) && HAS_PREFIX(p, "GET /")) {
+        } else if ((www == 2 || www == 3) && CHECK_AND_SKIP_PREFIX(p, "GET /")) {
             BIO *file;
             char *e;
             static const char *text =


### PR DESCRIPTION
When s_server responds to a file data with the -WWW parameter, it
always gets a path named "GET". In this case, we need to skip the
"GET /" character to get the correct file path.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
