### PR TITLE
Windows CI: explicitly use windows-2019 instead of using windows-latest

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - windows-latest
+          - windows-2019
           - windows-2022
         platform:
           - arch: win64
@@ -56,7 +56,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - windows-latest
+          - windows-2019
           - windows-2022
     runs-on: ${{matrix.os}}
     steps:
@@ -80,7 +80,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - windows-latest
+          - windows-2019
           - windows-2022
     runs-on: ${{matrix.os}}
     steps:


### PR DESCRIPTION
The windows-latest is the same as windows-2019 currently but we do not want to run two identical builds once windows-latest is switched to mean windows-2022.
