### PR TITLE
bn2binpad: Use memset as the buffer will be used later

### DIFF
--- a/crypto/bn/bn_lib.c
+++ b/crypto/bn/bn_lib.c
@@ -505,7 +505,8 @@ int bn2binpad(const BIGNUM *a, unsigned char *to, int tolen, endianess_t endiane
     /* Swipe through whole available data and don't give away padded zero. */
     atop = a->dmax * BN_BYTES;
     if (atop == 0) {
-        OPENSSL_cleanse(to, tolen);
+        if (to != NULL)
+            memset(to, '\0', tolen);
         return tolen;
     }
 

--- a/crypto/bn/bn_lib.c
+++ b/crypto/bn/bn_lib.c
@@ -505,7 +505,7 @@ int bn2binpad(const BIGNUM *a, unsigned char *to, int tolen, endianess_t endiane
     /* Swipe through whole available data and don't give away padded zero. */
     atop = a->dmax * BN_BYTES;
     if (atop == 0) {
-        if (to != NULL)
+        if (tolen != 0)
             memset(to, '\0', tolen);
         return tolen;
     }


### PR DESCRIPTION
Apparently using OPENSSL_cleanse() confuses the fuzzer so it
makes the buffer to appear uninitialized. And memset can be
safely used here and it is also potentially faster.

Fixes partially #17237
