### PR TITLE
apps/s_server: Avoid EOF error messages

### DIFF
--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -2626,6 +2626,10 @@ static int sv_body(int s, int stype, int prot, unsigned char *context)
                 if (buf[0] == 'S') {
                     print_stats(bio_s_out, SSL_get_SSL_CTX(con));
                 }
+            } else if (i <= 0) {
+                (void)BIO_flush(bio_s_out);
+                ret = 1;
+                goto err;
             }
 #ifdef CHARSET_EBCDIC
             ebcdic2ascii(buf, buf, i);


### PR DESCRIPTION
When EOF is encountered in quiet mode, should end the link early,
instead of printing an error after calling SSL_write() and finally
ending the link.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
