### PR TITLE
Ensure s_client sends SNI data when used with -proxy (master & 3.0)

### DIFF
--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -847,6 +847,7 @@ int s_client_main(int argc, char **argv)
     struct timeval tv;
 #endif
     const char *servername = NULL;
+    char *sname_alloc = NULL;
     int noservername = 0;
     const char *alpn_in = NULL;
     tlsextctx tlsextcbp = { NULL, 0 };
@@ -1539,6 +1540,14 @@ int s_client_main(int argc, char **argv)
         if (host == NULL || port == NULL) {
             BIO_printf(bio_err, "%s: -proxy requires use of -connect or target parameter\n", prog);
             goto opthelp;
+        }
+
+        if (servername == NULL && !noservername) {
+            servername = sname_alloc = OPENSSL_strdup(host);
+            if (sname_alloc == NULL) {
+                BIO_printf(bio_err, "%s: out of memory\n", prog);
+                goto end;
+            }
         }
 
         /* Retain the original target host:port for use in the HTTP proxy connect string */
@@ -3053,6 +3062,7 @@ int s_client_main(int argc, char **argv)
 #ifndef OPENSSL_NO_SRP
     OPENSSL_free(srp_arg.srppassin);
 #endif
+    OPENSSL_free(sname_alloc);
     OPENSSL_free(connectstr);
     OPENSSL_free(bindstr);
     OPENSSL_free(bindhost);


### PR DESCRIPTION
The use of -proxy prevented s_client from correctly sending the target
hostname as SNI data.

Fixes #17232

