### PR TITLE
OSSL_HTTP_proxy_connect(): Fix glitch in response HTTP header parsing

### DIFF
--- a/crypto/http/http_client.c
+++ b/crypto/http/http_client.c
@@ -1317,7 +1317,7 @@ int OSSL_HTTP_proxy_connect(BIO *bio, const char *server, const char *port,
 
         /* Check for HTTP/1.x */
         mbufp = mbuf;
-        if (!HAS_PREFIX(mbufp, HTTP_PREFIX)) {
+        if (!CHECK_AND_SKIP_PREFIX(mbufp, HTTP_PREFIX)) {
             ERR_raise(ERR_LIB_HTTP, HTTP_R_HEADER_PARSE_ERROR);
             BIO_printf(bio_err, "%s: HTTP CONNECT failed, non-HTTP response\n",
                        prog);
@@ -1335,6 +1335,8 @@ int OSSL_HTTP_proxy_connect(BIO *bio, const char *server, const char *port,
 
         /* RFC 7231 4.3.6: any 2xx status code is valid */
         if (!HAS_PREFIX(mbufp, " 2")) {
+            if (ossl_isspace(*mbufp))
+                mbufp++;
             /* chop any trailing whitespace */
             while (read_len > 0 && ossl_isspace(mbuf[read_len - 1]))
                 read_len--;


### PR DESCRIPTION
Fixes #17247
