### PR TITLE
APPS/cmp: Fix logic and doc of mutually exclusive  `-server`/`-port`/`-rspin`/`-use_mock_srv` options

### DIFF
--- a/apps/cmp.c
+++ b/apps/cmp.c
@@ -161,7 +161,7 @@ static char *opt_rspin = NULL;
 static char *opt_rspout = NULL;
 static int opt_use_mock_srv = 0;
 
-/* server-side debugging */
+/* mock server */
 #ifndef OPENSSL_NO_SOCK
 static char *opt_port = NULL;
 static int opt_max_msgs = 0;
@@ -287,7 +287,7 @@ const OPTIONS cmp_options[] = {
     {"subject", OPT_SUBJECT, 's',
      "Distinguished Name (DN) of subject to use in the requested cert template"},
     {OPT_MORE_STR, 0, 0,
-     "For kur, default is subject of -csr arg or else of reference cert (see -oldcert)"},
+     "For kur, default is subject of -csr arg or reference cert (see -oldcert)"},
     {OPT_MORE_STR, 0, 0,
      "this default is used for ir and cr only if no Subject Alt Names are set"},
     {"issuer", OPT_ISSUER, 's',
@@ -336,7 +336,7 @@ const OPTIONS cmp_options[] = {
     {OPT_MORE_STR, 0, 0,
      "also used as reference (defaulting to -cert) for subject DN and SANs."},
     {OPT_MORE_STR, 0, 0,
-     "Its issuer is used as recipient unless -recipient, -srvcert, or -issuer given"},
+     "Issuer is used as recipient unless -recipient, -srvcert, or -issuer given"},
     {"revreason", OPT_REVREASON, 'n',
      "Reason code to include in revocation request (rr); possible values:"},
     {OPT_MORE_STR, 0, 0,
@@ -470,14 +470,16 @@ const OPTIONS cmp_options[] = {
      "Process sequence of CMP responses provided in file(s), skipping server"},
     {"rspout", OPT_RSPOUT, 's', "Save sequence of CMP responses to file(s)"},
 
-    {"use_mock_srv", OPT_USE_MOCK_SRV, '-', "Use mock server at API level, bypassing HTTP"},
+    {"use_mock_srv", OPT_USE_MOCK_SRV, '-',
+     "Use internal mock server at API level, bypassing socket-based HTTP"},
 
     OPT_SECTION("Mock server"),
 #ifdef OPENSSL_NO_SOCK
     {OPT_MORE_STR, 0, 0,
      "NOTE: -port and -max_msgs not supported due to no-sock build"},
 #else
-    {"port", OPT_PORT, 's', "Act as HTTP mock server listening on given port"},
+    {"port", OPT_PORT, 's',
+     "Act as HTTP-based mock server listening on given port"},
     {"max_msgs", OPT_MAX_MSGS, 'N',
      "max number of messages handled by HTTP mock server. Default: 0 = unlimited"},
 #endif
@@ -1001,7 +1003,7 @@ static OSSL_CMP_SRV_CTX *setup_srv_ctx(ENGINE *engine)
     if (opt_srv_ref == NULL) {
         if (opt_srv_cert == NULL) {
             /* opt_srv_cert should determine the sender */
-            CMP_err("must give -srv_ref for server if no -srv_cert given");
+            CMP_err("must give -srv_ref for mock server if no -srv_cert given");
             goto err;
         }
     } else {
@@ -1012,7 +1014,7 @@ static OSSL_CMP_SRV_CTX *setup_srv_ctx(ENGINE *engine)
 
     if (opt_srv_secret != NULL) {
         int res;
-        char *pass_str = get_passwd(opt_srv_secret, "PBMAC secret of server");
+        char *pass_str = get_passwd(opt_srv_secret, "PBMAC secret of mock server");
 
         if (pass_str != NULL) {
             cleanse(opt_srv_secret);
@@ -1023,10 +1025,10 @@ static OSSL_CMP_SRV_CTX *setup_srv_ctx(ENGINE *engine)
                 goto err;
         }
     } else if (opt_srv_cert == NULL) {
-        CMP_err("server credentials must be given if -use_mock_srv or -port is used");
+        CMP_err("mock server credentials must be given if -use_mock_srv or -port is used");
         goto err;
     } else {
-        CMP_warn("server will not be able to handle PBM-protected requests since -srv_secret is not given");
+        CMP_warn("mock server will not be able to handle PBM-protected requests since -srv_secret is not given");
     }
 
     if (opt_srv_secret == NULL
@@ -1036,7 +1038,7 @@ static OSSL_CMP_SRV_CTX *setup_srv_ctx(ENGINE *engine)
     }
     if (opt_srv_cert != NULL) {
         X509 *srv_cert = load_cert_pwd(opt_srv_cert, opt_srv_keypass,
-                                       "certificate of the server");
+                                       "certificate of the mock server");
 
         if (srv_cert == NULL || !OSSL_CMP_CTX_set1_cert(ctx, srv_cert)) {
             X509_free(srv_cert);
@@ -1047,7 +1049,7 @@ static OSSL_CMP_SRV_CTX *setup_srv_ctx(ENGINE *engine)
     if (opt_srv_key != NULL) {
         EVP_PKEY *pkey = load_key_pwd(opt_srv_key, opt_keyform,
                                       opt_srv_keypass,
-                                      engine, "private key for server cert");
+                                      engine, "private key for mock server cert");
 
         if (pkey == NULL || !OSSL_CMP_CTX_set1_pkey(ctx, pkey)) {
             EVP_PKEY_free(pkey);
@@ -1059,14 +1061,14 @@ static OSSL_CMP_SRV_CTX *setup_srv_ctx(ENGINE *engine)
 
     if (opt_srv_trusted != NULL) {
         X509_STORE *ts =
-            load_trusted(opt_srv_trusted, 0, "certs trusted by server");
+            load_trusted(opt_srv_trusted, 0, "certs trusted by mock server");
 
         if (ts == NULL || !OSSL_CMP_CTX_set0_trustedStore(ctx, ts)) {
             X509_STORE_free(ts);
             goto err;
         }
     } else {
-        CMP_warn("server will not be able to handle signature-protected requests since -srv_trusted is not given");
+        CMP_warn("mock server will not be able to handle signature-protected requests since -srv_trusted is not given");
     }
     if (!setup_certs(opt_srv_untrusted,
                      "untrusted certificates for mock server", ctx,
@@ -1074,8 +1076,7 @@ static OSSL_CMP_SRV_CTX *setup_srv_ctx(ENGINE *engine)
         goto err;
 
     if (opt_rsp_cert == NULL) {
-        CMP_err("must give -rsp_cert for mock server");
-        goto err;
+        CMP_warn("no -rsp_cert given for mock server");
     } else {
         X509 *cert = load_cert_pwd(opt_rsp_cert, opt_keypass,
                                    "cert to be returned by the mock server");
@@ -1805,13 +1806,31 @@ static int setup_client_ctx(OSSL_CMP_CTX *ctx, ENGINE *engine)
     static char server_port[32] = { '\0' };
     const char *proxy_host = NULL;
 #endif
-    char server_buf[200] = { '\0' };
-    char proxy_buf[200] = { '\0' };
+    char server_buf[200] = "mock server";
+    char proxy_buf[200] = "";
 
+    if (!opt_use_mock_srv && opt_rspin == NULL) { /* note: -port is not given */
+#ifndef OPENSSL_NO_SOCK
+        if (opt_server == NULL) {
+            CMP_err("missing -server or -use_mock_srv or -rspin option");
+            goto err;
+        }
+#else
+        CMP_err("missing -use_mock_srv or -rspin option; -server option is not supported due to no-sock build");
+        goto err;
+#endif
+    }
 #ifndef OPENSSL_NO_SOCK
     if (opt_server == NULL) {
-        CMP_err("missing -server option");
-        goto err;
+        if (opt_proxy != NULL)
+            CMP_warn("ignoring -proxy option since -server is not given");
+        if (opt_no_proxy != NULL)
+            CMP_warn("ignoring -no_proxy option since -server is not given");
+        if (opt_tls_used) {
+            CMP_warn("ignoring -tls_used option since -server is not given");
+            opt_tls_used = 0;
+        }
+        goto set_path;
     }
     if (!OSSL_HTTP_parse_url(opt_server, &ssl, NULL /* user */, &host, &port,
                              &portnum, &path, NULL /* q */, NULL /* frag */)) {
@@ -1841,6 +1860,7 @@ static int setup_client_ctx(OSSL_CMP_CTX *ctx, ENGINE *engine)
     if (proxy_host != NULL)
         (void)BIO_snprintf(proxy_buf, sizeof(proxy_buf), " via %s", proxy_host);
 
+ set_path:
 #endif
 
     if (!OSSL_CMP_CTX_set1_serverPath(ctx, used_path))
@@ -1886,11 +1906,6 @@ static int setup_client_ctx(OSSL_CMP_CTX *ctx, ENGINE *engine)
         (void)OSSL_CMP_CTX_set_transfer_cb(ctx, read_write_req_resp);
 
 #ifndef OPENSSL_NO_SOCK
-    if ((opt_tls_cert != NULL || opt_tls_key != NULL
-         || opt_tls_keypass != NULL || opt_tls_extra != NULL
-         || opt_tls_trusted != NULL || opt_tls_host != NULL)
-            && !opt_tls_used)
-        CMP_warn("TLS options(s) given but not -tls_used");
     if (opt_tls_used) {
         APP_HTTP_TLS_INFO *info;
 
@@ -1903,10 +1918,6 @@ static int setup_client_ctx(OSSL_CMP_CTX *ctx, ENGINE *engine)
                 CMP_err("missing -tls_cert option");
                 goto err;
             }
-        }
-        if (opt_use_mock_srv) {
-            CMP_err("cannot use TLS options together with -use_mock_srv");
-            goto err;
         }
         if ((info = OPENSSL_zalloc(sizeof(*info))) == NULL)
             goto err;
@@ -1938,7 +1949,10 @@ static int setup_client_ctx(OSSL_CMP_CTX *ctx, ENGINE *engine)
         goto err;
 
     /* not printing earlier, to minimize confusion in case setup fails before */
-    CMP_info2("will contact %s%s", server_buf, proxy_buf);
+    if (opt_rspin != NULL)
+        CMP_info("will not contact any server since -rspin is given");
+    else
+        CMP_info2("will contact %s%s", server_buf, proxy_buf);
 
     ret = 1;
 
@@ -2690,9 +2704,6 @@ int cmp_main(int argc, char **argv)
     int i;
     X509 *newcert = NULL;
     ENGINE *engine = NULL;
-#ifndef OPENSSL_NO_SOCK
-    char mock_server[] = "mock server:1";
-#endif
     OSSL_CMP_CTX *srv_cmp_ctx = NULL;
     int ret = 0; /* default: failure */
 
@@ -2783,19 +2794,6 @@ int cmp_main(int argc, char **argv)
         }
     }
 
-#ifndef OPENSSL_NO_SOCK
-    if (opt_port != NULL) {
-        if (opt_use_mock_srv) {
-            CMP_err("cannot use both -port and -use_mock_srv options");
-            goto err;
-        }
-        if (opt_server != NULL) {
-            CMP_err("cannot use both -port and -server options");
-            goto err;
-        }
-    }
-#endif
-
     cmp_ctx = OSSL_CMP_CTX_new(app_get0_libctx(), app_get0_propq());
     if (cmp_ctx == NULL)
         goto err;
@@ -2804,6 +2802,33 @@ int cmp_main(int argc, char **argv)
         CMP_err1("cannot set up error reporting and logging for %s", prog);
         goto err;
     }
+
+#ifndef OPENSSL_NO_SOCK
+    if ((opt_tls_cert != NULL || opt_tls_key != NULL
+         || opt_tls_keypass != NULL || opt_tls_extra != NULL
+         || opt_tls_trusted != NULL || opt_tls_host != NULL)
+            && !opt_tls_used)
+        CMP_warn("Ingnoring TLS options(s) since -tls_used is not given");
+    if (opt_port != NULL) {
+        if (opt_tls_used) {
+            CMP_err("-tls_used option not supported with -port option");
+            goto err;
+        }
+        if (opt_use_mock_srv || opt_server != NULL || opt_rspin != NULL) {
+            CMP_err("cannot use -port with -use_mock_srv, -server, or -rspin options");
+            goto err;
+        }
+    }
+    if (opt_server != NULL && opt_use_mock_srv) {
+        CMP_err("cannot use both -server and -use_mock_srv options");
+        goto err;
+    }
+#endif
+    if (opt_rspin != NULL && opt_use_mock_srv) {
+        CMP_err("cannot use both -rspin and -use_mock_srv options");
+        goto err;
+    }
+
     if (opt_use_mock_srv
 #ifndef OPENSSL_NO_SOCK
         || opt_port != NULL
@@ -2822,29 +2847,26 @@ int cmp_main(int argc, char **argv)
         OSSL_CMP_CTX_set_log_verbosity(srv_cmp_ctx, opt_verbosity);
     }
 
-
 #ifndef OPENSSL_NO_SOCK
+    if (opt_tls_used && (opt_use_mock_srv || opt_rspin != NULL)) {
+        CMP_warn("ignoring -tls_used option since -use_mock_srv or -rspin is given");
+        opt_tls_used = 0;
+    }
+
     if (opt_port != NULL) { /* act as very basic CMP HTTP server */
         ret = cmp_server(srv_cmp_ctx);
         goto err;
     }
-#endif
-    /* else act as CMP client */
 
-    if (opt_use_mock_srv) {
-#ifndef OPENSSL_NO_SOCK
-        if (opt_server != NULL) {
-            CMP_err("cannot use both -use_mock_srv and -server options");
-            goto err;
+    /* act as CMP client, possibly using internal mock server */
+
+    if (opt_server != NULL) {
+        if (opt_rspin != NULL) {
+            CMP_warn("ignoring -server option since -rspin is given");
+            opt_server = NULL;
         }
-        if (opt_proxy != NULL) {
-            CMP_err("cannot use both -use_mock_srv and -proxy options");
-            goto err;
-        }
-        opt_server = mock_server;
-        opt_proxy = "API";
-#endif
     }
+#endif
 
     if (!setup_client_ctx(cmp_ctx, engine)) {
         CMP_err("cannot set up CMP context");

--- a/doc/man1/openssl-cmp.pod.in
+++ b/doc/man1/openssl-cmp.pod.in
@@ -441,8 +441,10 @@ Reason numbers defined in RFC 5280 are:
 
 =item B<-server> I<[http[s]://][userinfo@]host[:port][/path][?query][#fragment]>
 
-The IP address or DNS hostname and optionally port
-of the CMP server to connect to using HTTP(S) transport.
+The DNS hostname or IP address and optionally port
+of the CMP server to connect to using HTTP(S).
+This excludes I<-port> and I<-use_mock_srv> and is ignored with I<-rspin>.
+
 The scheme C<https> may be given only if the B<-tls_used> option is used.
 In this case the default port is 443, else 80.
 The optional userinfo and fragment components are ignored.
@@ -459,6 +461,7 @@ selected by B<-tls_used>), as well as any path, userinfo, and query, and fragmen
 components.
 Defaults to the environment variable C<http_proxy> if set, else C<HTTP_PROXY>
 in case no TLS is used, otherwise C<https_proxy> if set, else C<HTTPS_PROXY>.
+This option is ignored if I<-server> is not given.
 
 =item B<-no_proxy> I<addresses>
 
@@ -466,6 +469,7 @@ List of IP addresses and/or DNS names of servers
 not to use an HTTP(S) proxy for, separated by commas and/or whitespace
 (where in the latter case the whole argument must be enclosed in "...").
 Default is from the environment variable C<no_proxy> if set, else C<NO_PROXY>.
+This option is ignored if I<-server> is not given.
 
 =item B<-recipient> I<name>
 
@@ -796,7 +800,10 @@ B<-tls_key>.
 =item B<-tls_used>
 
 Enable using TLS (even when other TLS_related options are not set)
-when connecting to CMP server.
+when connecting to CMP server via HTTP.
+This option is not supported with the I<-port> option
+and is ignored with the I<-use_mock_srv> and I<-rspin> options
+or if the I<-server> option is not given.
 
 =item B<-tls_cert> I<filename>|I<uri>
 
@@ -881,6 +888,7 @@ As many files are written as needed to store the complete transaction.
 =item B<-rspin> I<filenames>
 
 Process sequence of CMP responses provided in file(s), skipping server.
+This excludes I<-server>, I<-port>, and I<-use_mock_srv>.
 
 Multiple filenames may be given, separated by commas and/or whitespace.
 As many files are read as needed for the complete transaction.
@@ -894,8 +902,9 @@ As many files are written as needed to store the complete transaction.
 
 =item B<-use_mock_srv>
 
-Use the internal mock server for testing the client.
-This works at API level, bypassing HTTP transport.
+Test the client using the internal CMP server mock-up at API level,
+bypassing socket-based transfer via HTTP.
+This excludes I<-server>, I<-port>, and I<-rspin>.
 
 =back
 
@@ -905,7 +914,8 @@ This works at API level, bypassing HTTP transport.
 
 =item B<-port> I<number>
 
-Act as CMP HTTP server mock-up listening on the given port.
+Act as HTTP-based CMP server mock-up listening on the given port.
+This excludes I<-server>, I<-rspin>, and I<-use_mock_srv>.
 
 =item B<-max_msgs> I<number>
 


### PR DESCRIPTION
Some major option combinations do not make sense or are not supported. Add missing checks and document that `-server`/`-port`/`-rspin`/`-use_mock_srv` options exclude each other:

Ignore `-server` with `-rspin` and exclude all of `-use_mock_srv`/`-port`/`-rspin.`
On the other hand, `-server` is required if no `-use_mock_srv`/`-port`/`-rspin` is given.
Ignore `-tls_used` with `-use_mock_srv` and `-rspin;` it is not supported with `-port.`
If `-server` is not given, ignore `-proxy,` `-no_proxy,` and `-tls_used.`

Rearrange the partly existing checks such that the major options are checked for consistency first,
preventing otherwise misleading errors/warnings.
Also slightly improve the documentation of the two mock server variants.

- [x] documentation is added or updated
