### PR TITLE
Fix a leak in EVP_DigestInit_ex()

### DIFF
--- a/crypto/evp/digest.c
+++ b/crypto/evp/digest.c
@@ -208,7 +208,8 @@ static int evp_md_init_internal(EVP_MD_CTX *ctx, const EVP_MD *type,
             || tmpimpl != NULL
 # endif
 #endif
-            || (ctx->flags & EVP_MD_CTX_FLAG_NO_INIT) != 0) {
+            || (ctx->flags & EVP_MD_CTX_FLAG_NO_INIT) != 0
+            || type->origin == EVP_ORIG_METH) {
         if (ctx->digest == ctx->fetched_digest)
             ctx->digest = NULL;
         EVP_MD_free(ctx->fetched_digest);

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -4180,7 +4180,7 @@ static int test_evp_md_cipher_meth(void)
 }
 
 typedef struct {
-        void *pdata;
+        int data;
 } custom_dgst_ctx;
 
 static int custom_md_init_called = 0;
@@ -4192,9 +4192,7 @@ static int custom_md_init(EVP_MD_CTX *ctx)
 
     if (p == NULL)
         return 0;
-    p->pdata = OPENSSL_malloc(32);
-    if (p->pdata == NULL)
-        return 0;
+
     custom_md_init_called++;
     return 1;
 }
@@ -4207,8 +4205,6 @@ static int custom_md_cleanup(EVP_MD_CTX *ctx)
         /* Nothing to do */
         return 1;
 
-    OPENSSL_free(p->pdata);
-    p->pdata = NULL;
     custom_md_cleanup_called++;
     return 1;
 }
@@ -4217,8 +4213,7 @@ static int test_custom_md_meth(void)
 {
     EVP_MD_CTX *mdctx = NULL;
     EVP_MD *tmp = NULL;
-    char mess1[] = "Test Message\n";
-    char mess2[] = "Hello World\n";
+    char mess[] = "Test Message\n";
     unsigned char md_value[EVP_MAX_MD_SIZE];
     unsigned int md_len;
     int testresult = 0;
@@ -4255,8 +4250,7 @@ static int test_custom_md_meth(void)
                 */
             || !TEST_true(EVP_DigestInit_ex(mdctx, tmp, NULL))
             || !TEST_true(EVP_DigestInit_ex(mdctx, EVP_sha256(), NULL))
-            || !TEST_true(EVP_DigestUpdate(mdctx, mess1, strlen(mess1)))
-            || !TEST_true(EVP_DigestUpdate(mdctx, mess2, strlen(mess2)))
+            || !TEST_true(EVP_DigestUpdate(mdctx, mess, strlen(mess)))
             || !TEST_true(EVP_DigestFinal_ex(mdctx, md_value, &md_len))
             || !TEST_int_eq(custom_md_init_called, 1)
             || !TEST_int_eq(custom_md_cleanup_called, 1))

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -4179,6 +4179,96 @@ static int test_evp_md_cipher_meth(void)
     return testresult;
 }
 
+typedef struct {
+        void *pdata;
+} custom_dgst_ctx;
+
+static int custom_md_init_called = 0;
+static int custom_md_cleanup_called = 0;
+
+static int custom_md_init(EVP_MD_CTX *ctx)
+{
+    custom_dgst_ctx *p = EVP_MD_CTX_md_data(ctx);
+
+    if (p == NULL)
+        return 0;
+    p->pdata = OPENSSL_malloc(32);
+    if (p->pdata == NULL)
+        return 0;
+    custom_md_init_called++;
+    return 1;
+}
+
+static int custom_md_cleanup(EVP_MD_CTX *ctx)
+{
+    custom_dgst_ctx *p = EVP_MD_CTX_md_data(ctx);
+
+    if (p == NULL)
+        /* Nothing to do */
+        return 1;
+
+    OPENSSL_free(p->pdata);
+    p->pdata = NULL;
+    custom_md_cleanup_called++;
+    return 1;
+}
+
+static int test_custom_md_meth(void)
+{
+    EVP_MD_CTX *mdctx = NULL;
+    EVP_MD *tmp = NULL;
+    char mess1[] = "Test Message\n";
+    char mess2[] = "Hello World\n";
+    unsigned char md_value[EVP_MAX_MD_SIZE];
+    unsigned int md_len;
+    int testresult = 0;
+    int nid;
+
+    /*
+     * We are testing deprecated functions. We don't support a non-default
+     * library context in this test.
+     */
+    if (testctx != NULL)
+        return 1;
+
+    custom_md_init_called = custom_md_cleanup_called = 0;
+
+    nid = OBJ_create("1.3.6.1.4.1.16604.998866.1", "custom-md", "custom-md");
+    if (!TEST_int_ne(nid, NID_undef))
+        goto err;
+    tmp = EVP_MD_meth_new(nid, NID_undef);
+    if (!TEST_ptr(tmp))
+        goto err;
+
+    if (!TEST_true(EVP_MD_meth_set_init(tmp, custom_md_init))
+            || !TEST_true(EVP_MD_meth_set_cleanup(tmp, custom_md_cleanup))
+            || !TEST_true(EVP_MD_meth_set_app_datasize(tmp,
+                                                       sizeof(custom_dgst_ctx))))
+        goto err;
+
+    mdctx = EVP_MD_CTX_new();
+    if (!TEST_ptr(mdctx)
+               /*
+                * Initing our custom md and then initing another md should
+                * result in the init and cleanup functions of the custom md
+                * from being called.
+                */
+            || !TEST_true(EVP_DigestInit_ex(mdctx, tmp, NULL))
+            || !TEST_true(EVP_DigestInit_ex(mdctx, EVP_sha256(), NULL))
+            || !TEST_true(EVP_DigestUpdate(mdctx, mess1, strlen(mess1)))
+            || !TEST_true(EVP_DigestUpdate(mdctx, mess2, strlen(mess2)))
+            || !TEST_true(EVP_DigestFinal_ex(mdctx, md_value, &md_len))
+            || !TEST_int_eq(custom_md_init_called, 1)
+            || !TEST_int_eq(custom_md_cleanup_called, 1))
+        goto err;
+
+    testresult = 1;
+ err:
+    EVP_MD_CTX_free(mdctx);
+    EVP_MD_meth_free(tmp);
+    return testresult;
+}
+
 # ifndef OPENSSL_NO_DYNAMIC_ENGINE
 /* Test we can create a signature keys with an associated ENGINE */
 static int test_signatures_with_engine(int tst)
@@ -4473,6 +4563,7 @@ int setup_tests(void)
 #ifndef OPENSSL_NO_DEPRECATED_3_0
     ADD_ALL_TESTS(test_custom_pmeth, 12);
     ADD_TEST(test_evp_md_cipher_meth);
+    ADD_TEST(test_custom_md_meth);
 
 # ifndef OPENSSL_NO_DYNAMIC_ENGINE
     /* Tests only support the default libctx */


### PR DESCRIPTION
If an EVP_MD_CTX is reused then memory allocated and stored in md_data
can be leaked unless the EVP_MD's cleanup function is called.

Fixes #17149

Also we ensure that MDs created via EVP_MD_meth_new() go down the legacy route