### PR TITLE
OSSL_CMP_CTX: rename get/set functions for `trustedStore`

### DIFF
--- a/apps/cmp.c
+++ b/apps/cmp.c
@@ -1062,7 +1062,7 @@ static OSSL_CMP_SRV_CTX *setup_srv_ctx(ENGINE *engine)
         X509_STORE *ts =
             load_trusted(opt_srv_trusted, 0, "certs trusted by mock server");
 
-        if (ts == NULL || !OSSL_CMP_CTX_set0_trustedStore(ctx, ts)) {
+        if (ts == NULL || !OSSL_CMP_CTX_set0_trusted(ctx, ts)) {
             X509_STORE_free(ts);
             goto err;
         }
@@ -1179,7 +1179,7 @@ static int setup_verification_ctx(OSSL_CMP_CTX *ctx)
              */
             ts = load_trusted(opt_trusted, 0, "certs trusted by client");
 
-            if (ts == NULL || !OSSL_CMP_CTX_set0_trustedStore(ctx, ts)) {
+            if (ts == NULL || !OSSL_CMP_CTX_set0_trusted(ctx, ts)) {
                 X509_STORE_free(ts);
                 return 0;
             }

--- a/crypto/cmp/cmp_ctx.c
+++ b/crypto/cmp/cmp_ctx.c
@@ -35,7 +35,7 @@ TYPE *OSSL_CMP_CTX_get0_##NAME(const OSSL_CMP_CTX *ctx) \
 /*
  * Get current certificate store containing trusted root CA certs
  */
-DEFINE_OSSL_CMP_CTX_get0_NAME(trustedStore, trusted, X509_STORE)
+DEFINE_OSSL_CMP_CTX_get0_NAME(trusted, trusted, X509_STORE)
 
 #define DEFINE_OSSL_set0(PREFIX, FIELD, TYPE) \
     DEFINE_OSSL_set0_NAME(PREFIX, FIELD, FIELD, TYPE)
@@ -56,7 +56,7 @@ int PREFIX##_set0##_##NAME(OSSL_CMP_CTX *ctx, TYPE *val) \
  * and a cert verification callback function used for CMP server authentication.
  * Any already existing store entry is freed. Given NULL, the entry is reset.
  */
-DEFINE_OSSL_set0_NAME(OSSL_CMP_CTX, trustedStore, trusted, X509_STORE)
+DEFINE_OSSL_set0_NAME(OSSL_CMP_CTX, trusted, trusted, X509_STORE)
 
 /* Get current list of non-trusted intermediate certs */
 DEFINE_OSSL_CMP_CTX_get0(untrusted, STACK_OF(X509))

--- a/doc/internal/man3/ossl_cmp_msg_check_update.pod
+++ b/doc/internal/man3/ossl_cmp_msg_check_update.pod
@@ -66,7 +66,7 @@ and learns the transaction ID if none is currently present in B<ctx>.
 
 Moreover, according to RFC 4210 section 5.3.2, if the message protection is
 PBM-based then any certificates in the caPubs field are added to the list of
-trusted certificates (if set via L<OSSL_CMP_CTX_set0_trustedStore(3)>).
+trusted certificates (if set via L<OSSL_CMP_CTX_set0_trusted(3)>).
 This way these certs are available for validating subsequent messages in the
 same context and could apply to any Polling Response (pollRep), error, or PKI
 Confirmation (PKIConf) messages following in the same or future transactions.

--- a/doc/man3/OSSL_CMP_CTX_new.pod
+++ b/doc/man3/OSSL_CMP_CTX_new.pod
@@ -756,7 +756,8 @@ The OpenSSL CMP support was added in OpenSSL 3.0.
 
 OSSL_CMP_CTX_get0_trustedStore() was renamed to OSSL_CMP_CTX_get0_trusted() and
 OSSL_CMP_CTX_set0_trustedStore() was renamed to OSSL_CMP_CTX_set0_trusted(),
-adding name macros for backward compatibility, in OpenSSL 4.0.
+using macros, while keeping the old names for backward compatibility,
+in OpenSSL 3.1.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/OSSL_CMP_CTX_new.pod
+++ b/doc/man3/OSSL_CMP_CTX_new.pod
@@ -24,8 +24,8 @@ OSSL_CMP_CTX_set_transfer_cb_arg,
 OSSL_CMP_CTX_get_transfer_cb_arg,
 OSSL_CMP_CTX_set1_srvCert,
 OSSL_CMP_CTX_set1_expected_sender,
-OSSL_CMP_CTX_set0_trustedStore,
-OSSL_CMP_CTX_get0_trustedStore,
+OSSL_CMP_CTX_set0_trusted,
+OSSL_CMP_CTX_get0_trusted,
 OSSL_CMP_CTX_set1_untrusted,
 OSSL_CMP_CTX_get0_untrusted,
 OSSL_CMP_CTX_set1_cert,
@@ -98,8 +98,8 @@ OSSL_CMP_CTX_set1_senderNonce
  int OSSL_CMP_CTX_set1_srvCert(OSSL_CMP_CTX *ctx, X509 *cert);
  int OSSL_CMP_CTX_set1_expected_sender(OSSL_CMP_CTX *ctx,
                                       const X509_NAME *name);
- int OSSL_CMP_CTX_set0_trustedStore(OSSL_CMP_CTX *ctx, X509_STORE *store);
- X509_STORE *OSSL_CMP_CTX_get0_trustedStore(const OSSL_CMP_CTX *ctx);
+ int OSSL_CMP_CTX_set0_trusted(OSSL_CMP_CTX *ctx, X509_STORE *store);
+ X509_STORE *OSSL_CMP_CTX_get0_trusted(const OSSL_CMP_CTX *ctx);
  int OSSL_CMP_CTX_set1_untrusted(OSSL_CMP_CTX *ctx, STACK_OF(X509) *certs);
  STACK_OF(X509) *OSSL_CMP_CTX_get0_untrusted(const OSSL_CMP_CTX *ctx);
 
@@ -111,7 +111,7 @@ OSSL_CMP_CTX_set1_senderNonce
  int OSSL_CMP_CTX_set1_referenceValue(OSSL_CMP_CTX *ctx,
                                       const unsigned char *ref, int len);
  int OSSL_CMP_CTX_set1_secretValue(OSSL_CMP_CTX *ctx, const unsigned char *sec,
-                                   const int len);
+                                   int len);
 
  /* CMP message header and extra certificates: */
  int OSSL_CMP_CTX_set1_recipient(OSSL_CMP_CTX *ctx, const X509_NAME *name);
@@ -404,7 +404,7 @@ OSSL_CMP_CTX_set_transfer_cb_arg() or NULL if unset.
 
 OSSL_CMP_CTX_set1_srvCert() sets the expected server cert in I<ctx> and trusts
 it directly (even if it is expired) when verifying signed response messages.
-May be used alternatively to OSSL_CMP_CTX_set0_trustedStore()
+May be used alternatively to OSSL_CMP_CTX_set0_trusted()
 to pin the accepted server.
 Any previously set value is freed.
 The I<cert> argument may be NULL to clear the entry.
@@ -422,14 +422,14 @@ Note that this gives slightly more freedom than OSSL_CMP_CTX_set1_srvCert(),
 which pins the server to the holder of a particular certificate, while the
 expected sender name will continue to match after updates of the server cert.
 
-OSSL_CMP_CTX_set0_trustedStore() sets the certificate store of type X509_STORE
+OSSL_CMP_CTX_set0_trusted() sets the certificate store of type X509_STORE
 containing trusted (root) CA certificates.
 The store may also hold CRLs and
 a certificate verification callback function used for CMP server authentication.
 Any store entry already set before is freed.
 When given a NULL parameter the entry is cleared.
 
-OSSL_CMP_CTX_get0_trustedStore() returns a pointer to the currently set
+OSSL_CMP_CTX_get0_trusted() returns a pointer to the currently set
 certificate store containing trusted cert etc., or an empty store if unset.
 
 OSSL_CMP_CTX_set1_untrusted() sets up a list of non-trusted certificates
@@ -658,7 +658,7 @@ OSSL_CMP_CTX_free() and OSSL_CMP_CTX_print_errors() do not return anything.
 OSSL_CMP_CTX_new(),
 OSSL_CMP_CTX_get_http_cb_arg(),
 OSSL_CMP_CTX_get_transfer_cb_arg(),
-OSSL_CMP_CTX_get0_trustedStore(),
+OSSL_CMP_CTX_get0_trusted(),
 OSSL_CMP_CTX_get0_untrusted(),
 OSSL_CMP_CTX_get0_newPkey(),
 OSSL_CMP_CTX_get_certConf_cb_arg(),
@@ -691,7 +691,7 @@ Set up a CMP client context for sending requests and verifying responses:
     OSSL_CMP_CTX_set1_server(cmp_ctx, name_or_address);
     OSSL_CMP_CTX_set1_serverPort(cmp_ctx, port_string);
     OSSL_CMP_CTX_set1_serverPath(cmp_ctx, path_or_alias);
-    OSSL_CMP_CTX_set0_trustedStore(cmp_ctx, ts);
+    OSSL_CMP_CTX_set0_trusted(cmp_ctx, ts);
 
 Set up client credentials for password-based protection (PBM):
 
@@ -753,6 +753,10 @@ L<ERR_print_errors_cb(3)>
 =head1 HISTORY
 
 The OpenSSL CMP support was added in OpenSSL 3.0.
+
+OSSL_CMP_CTX_get0_trustedStore() was renamed to OSSL_CMP_CTX_get0_trusted() and
+OSSL_CMP_CTX_set0_trustedStore() was renamed to OSSL_CMP_CTX_set0_trusted(),
+adding name macros for backward compatibility, in OpenSSL 4.0.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/OSSL_CMP_CTX_new.pod
+++ b/doc/man3/OSSL_CMP_CTX_new.pod
@@ -115,7 +115,7 @@ OSSL_CMP_CTX_set1_senderNonce
  int OSSL_CMP_CTX_set1_referenceValue(OSSL_CMP_CTX *ctx,
                                       const unsigned char *ref, int len);
  int OSSL_CMP_CTX_set1_secretValue(OSSL_CMP_CTX *ctx, const unsigned char *sec,
-                                   int len);
+                                   const int len);
 
  /* CMP message header and extra certificates: */
  int OSSL_CMP_CTX_set1_recipient(OSSL_CMP_CTX *ctx, const X509_NAME *name);
@@ -426,14 +426,18 @@ Note that this gives slightly more freedom than OSSL_CMP_CTX_set1_srvCert(),
 which pins the server to the holder of a particular certificate, while the
 expected sender name will continue to match after updates of the server cert.
 
-OSSL_CMP_CTX_set0_trusted() sets the certificate store of type X509_STORE
+OSSL_CMP_CTX_set0_trusted() is an alias of the original
+OSSL_CMP_CTX_set0_trustedStore().
+It sets in the CMP context I<ctx> the certificate store of type X509_STORE
 containing trusted (root) CA certificates.
 The store may also hold CRLs and
 a certificate verification callback function used for CMP server authentication.
 Any store entry already set before is freed.
 When given a NULL parameter the entry is cleared.
 
-OSSL_CMP_CTX_get0_trusted() returns a pointer to the currently set
+OSSL_CMP_CTX_get0_trusted() is an alias of the original
+OSSL_CMP_CTX_get0_trustedStore().
+It extracts from the CMP context I<ctx> the pointer to the currently set
 certificate store containing trusted cert etc., or an empty store if unset.
 
 OSSL_CMP_CTX_set1_untrusted() sets up a list of non-trusted certificates

--- a/doc/man3/OSSL_CMP_CTX_new.pod
+++ b/doc/man3/OSSL_CMP_CTX_new.pod
@@ -25,7 +25,9 @@ OSSL_CMP_CTX_get_transfer_cb_arg,
 OSSL_CMP_CTX_set1_srvCert,
 OSSL_CMP_CTX_set1_expected_sender,
 OSSL_CMP_CTX_set0_trusted,
+OSSL_CMP_CTX_set0_trustedStore,
 OSSL_CMP_CTX_get0_trusted,
+OSSL_CMP_CTX_get0_trustedStore,
 OSSL_CMP_CTX_set1_untrusted,
 OSSL_CMP_CTX_get0_untrusted,
 OSSL_CMP_CTX_set1_cert,
@@ -98,8 +100,10 @@ OSSL_CMP_CTX_set1_senderNonce
  int OSSL_CMP_CTX_set1_srvCert(OSSL_CMP_CTX *ctx, X509 *cert);
  int OSSL_CMP_CTX_set1_expected_sender(OSSL_CMP_CTX *ctx,
                                       const X509_NAME *name);
- int OSSL_CMP_CTX_set0_trusted(OSSL_CMP_CTX *ctx, X509_STORE *store);
- X509_STORE *OSSL_CMP_CTX_get0_trusted(const OSSL_CMP_CTX *ctx);
+ #define OSSL_CMP_CTX_set0_trusted OSSL_CMP_CTX_set0_trustedStore
+ int OSSL_CMP_CTX_set0_trustedStore(OSSL_CMP_CTX *ctx, X509_STORE *store);
+ #define OSSL_CMP_CTX_get0_trusted OSSL_CMP_CTX_get0_trustedStore
+ X509_STORE *OSSL_CMP_CTX_get0_trustedStore(const OSSL_CMP_CTX *ctx);
  int OSSL_CMP_CTX_set1_untrusted(OSSL_CMP_CTX *ctx, STACK_OF(X509) *certs);
  STACK_OF(X509) *OSSL_CMP_CTX_get0_untrusted(const OSSL_CMP_CTX *ctx);
 

--- a/doc/man3/OSSL_CMP_validate_msg.pod
+++ b/doc/man3/OSSL_CMP_validate_msg.pod
@@ -27,13 +27,13 @@ is preferably the one provided by a call to L<OSSL_CMP_CTX_set1_srvCert(3)>.
 If no such sender cert has been pinned then candidate sender certificates are
 taken from the list of certificates received in the I<msg> extraCerts, then any
 certificates provided before via L<OSSL_CMP_CTX_set1_untrusted(3)>, and
-then all trusted certificates provided via L<OSSL_CMP_CTX_set0_trustedStore(3)>,
+then all trusted certificates provided via L<OSSL_CMP_CTX_set0_trusted(3)>,
 where a candidate is acceptable only if has not expired, its subject DN matches
 the I<msg> sender DN (as far as present), and its subject key identifier
 is present and matches the senderKID (as far as the latter present).
 Each acceptable cert is tried in the given order to see if the message
 signature check succeeds and the cert and its path can be verified
-using any trust store set via L<OSSL_CMP_CTX_set0_trustedStore(3)>.
+using any trust store set via L<OSSL_CMP_CTX_set0_trusted(3)>.
 
 If the option OSSL_CMP_OPT_PERMIT_TA_IN_EXTRACERTS_FOR_IR was set by calling
 L<OSSL_CMP_CTX_set_option(3)>, for an Initialization Response (IP) message

--- a/include/openssl/cmp.h.in
+++ b/include/openssl/cmp.h.in
@@ -309,8 +309,10 @@ void *OSSL_CMP_CTX_get_transfer_cb_arg(const OSSL_CMP_CTX *ctx);
 /* server authentication: */
 int OSSL_CMP_CTX_set1_srvCert(OSSL_CMP_CTX *ctx, X509 *cert);
 int OSSL_CMP_CTX_set1_expected_sender(OSSL_CMP_CTX *ctx, const X509_NAME *name);
-int OSSL_CMP_CTX_set0_trustedStore(OSSL_CMP_CTX *ctx, X509_STORE *store);
-X509_STORE *OSSL_CMP_CTX_get0_trustedStore(const OSSL_CMP_CTX *ctx);
+int OSSL_CMP_CTX_set0_trusted(OSSL_CMP_CTX *ctx, X509_STORE *store);
+#define OSSL_CMP_CTX_set0_trustedStore OSSL_CMP_CTX_set0_trusted
+X509_STORE *OSSL_CMP_CTX_get0_trusted(const OSSL_CMP_CTX *ctx);
+#define OSSL_CMP_CTX_get0_trustedStore OSSL_CMP_CTX_get0_trusted
 int OSSL_CMP_CTX_set1_untrusted(OSSL_CMP_CTX *ctx, STACK_OF(X509) *certs);
 STACK_OF(X509) *OSSL_CMP_CTX_get0_untrusted(const OSSL_CMP_CTX *ctx);
 /* client authentication: */
@@ -321,7 +323,7 @@ int OSSL_CMP_CTX_set1_pkey(OSSL_CMP_CTX *ctx, EVP_PKEY *pkey);
 int OSSL_CMP_CTX_set1_referenceValue(OSSL_CMP_CTX *ctx,
                                      const unsigned char *ref, int len);
 int OSSL_CMP_CTX_set1_secretValue(OSSL_CMP_CTX *ctx, const unsigned char *sec,
-                                  const int len);
+                                  int len);
 /* CMP message header and extra certificates: */
 int OSSL_CMP_CTX_set1_recipient(OSSL_CMP_CTX *ctx, const X509_NAME *name);
 int OSSL_CMP_CTX_push0_geninfo_ITAV(OSSL_CMP_CTX *ctx, OSSL_CMP_ITAV *itav);

--- a/include/openssl/cmp.h.in
+++ b/include/openssl/cmp.h.in
@@ -309,10 +309,10 @@ void *OSSL_CMP_CTX_get_transfer_cb_arg(const OSSL_CMP_CTX *ctx);
 /* server authentication: */
 int OSSL_CMP_CTX_set1_srvCert(OSSL_CMP_CTX *ctx, X509 *cert);
 int OSSL_CMP_CTX_set1_expected_sender(OSSL_CMP_CTX *ctx, const X509_NAME *name);
-int OSSL_CMP_CTX_set0_trusted(OSSL_CMP_CTX *ctx, X509_STORE *store);
-#define OSSL_CMP_CTX_set0_trustedStore OSSL_CMP_CTX_set0_trusted
-X509_STORE *OSSL_CMP_CTX_get0_trusted(const OSSL_CMP_CTX *ctx);
-#define OSSL_CMP_CTX_get0_trustedStore OSSL_CMP_CTX_get0_trusted
+int OSSL_CMP_CTX_set0_trustedStore(OSSL_CMP_CTX *ctx, X509_STORE *store);
+#define OSSL_CMP_CTX_set0_trusted OSSL_CMP_CTX_set0_trustedStore
+X509_STORE *OSSL_CMP_CTX_get0_trustedStore(const OSSL_CMP_CTX *ctx);
+#define OSSL_CMP_CTX_get0_trusted OSSL_CMP_CTX_get0_trustedStore
 int OSSL_CMP_CTX_set1_untrusted(OSSL_CMP_CTX *ctx, STACK_OF(X509) *certs);
 STACK_OF(X509) *OSSL_CMP_CTX_get0_untrusted(const OSSL_CMP_CTX *ctx);
 /* client authentication: */

--- a/include/openssl/cmp.h.in
+++ b/include/openssl/cmp.h.in
@@ -323,7 +323,7 @@ int OSSL_CMP_CTX_set1_pkey(OSSL_CMP_CTX *ctx, EVP_PKEY *pkey);
 int OSSL_CMP_CTX_set1_referenceValue(OSSL_CMP_CTX *ctx,
                                      const unsigned char *ref, int len);
 int OSSL_CMP_CTX_set1_secretValue(OSSL_CMP_CTX *ctx, const unsigned char *sec,
-                                  int len);
+                                  const int len);
 /* CMP message header and extra certificates: */
 int OSSL_CMP_CTX_set1_recipient(OSSL_CMP_CTX *ctx, const X509_NAME *name);
 int OSSL_CMP_CTX_push0_geninfo_ITAV(OSSL_CMP_CTX *ctx, OSSL_CMP_ITAV *itav);

--- a/test/cmp_ctx_test.c
+++ b/test/cmp_ctx_test.c
@@ -507,6 +507,7 @@ static X509_STORE *X509_STORE_new_1(void)
         return ret; \
     }
 
+/* cannot use PREFIX instead of OSSL_CMP and CTX due to #define OSSL_CMP_CTX */
 #define DEFINE_SET_GET_TEST(OSSL_CMP, CTX, N, M, DUP, FIELD, TYPE) \
     DEFINE_SET_GET_BASE_TEST(OSSL_CMP##_##CTX, set##N, get##M, DUP, FIELD, \
                              TYPE *, NULL, IS_0, TYPE##_new(), TYPE##_free)
@@ -741,7 +742,7 @@ DEFINE_SET_GET_P_VOID_TEST(transfer_cb_arg)
 DEFINE_SET_TEST(OSSL_CMP, CTX, 1, 0, srvCert, X509)
 DEFINE_SET_TEST(ossl_cmp, ctx, 0, 0, validatedSrvCert, X509)
 DEFINE_SET_TEST(OSSL_CMP, CTX, 1, 1, expected_sender, X509_NAME)
-DEFINE_SET_GET_BASE_TEST(OSSL_CMP_CTX, set0, get0, 0, trustedStore,
+DEFINE_SET_GET_BASE_TEST(OSSL_CMP_CTX, set0, get0, 0, trusted,
                          X509_STORE *, NULL,
                          DEFAULT_STORE, X509_STORE_new_1(), X509_STORE_free)
 DEFINE_SET_GET_SK_X509_TEST(OSSL_CMP, CTX, 1, 0, untrusted)
@@ -838,7 +839,7 @@ int setup_tests(void)
     ADD_TEST(test_CTX_set1_get0_srvCert);
     ADD_TEST(test_CTX_set0_get0_validatedSrvCert);
     ADD_TEST(test_CTX_set1_get0_expected_sender);
-    ADD_TEST(test_CTX_set0_get0_trustedStore);
+    ADD_TEST(test_CTX_set0_get0_trusted);
     ADD_TEST(test_CTX_set1_get0_untrusted);
     /* client authentication: */
     ADD_TEST(test_CTX_set1_get0_cert);

--- a/test/cmp_vfy_test.c
+++ b/test/cmp_vfy_test.c
@@ -61,7 +61,7 @@ static CMP_VFY_TEST_FIXTURE *set_up(const char *const test_case_name)
     fixture->test_case_name = test_case_name;
     if (ts == NULL
             || !TEST_ptr(fixture->cmp_ctx = OSSL_CMP_CTX_new(libctx, NULL))
-            || !OSSL_CMP_CTX_set0_trustedStore(fixture->cmp_ctx, ts)
+            || !OSSL_CMP_CTX_set0_trusted(fixture->cmp_ctx, ts)
             || !OSSL_CMP_CTX_set_log_cb(fixture->cmp_ctx, print_to_bio_out)) {
         tear_down(fixture);
         X509_STORE_free(ts);
@@ -133,7 +133,7 @@ static int execute_validate_msg_test(CMP_VFY_TEST_FIXTURE *fixture)
 
 static int execute_validate_cert_path_test(CMP_VFY_TEST_FIXTURE *fixture)
 {
-    X509_STORE *ts = OSSL_CMP_CTX_get0_trustedStore(fixture->cmp_ctx);
+    X509_STORE *ts = OSSL_CMP_CTX_get0_trusted(fixture->cmp_ctx);
     int res = TEST_int_eq(fixture->expected,
                           OSSL_CMP_validate_cert_path(fixture->cmp_ctx,
                                                       ts, fixture->cert));
@@ -187,7 +187,7 @@ static int test_validate_msg_mac_alg_protection_bad(void)
 
 static int add_trusted(OSSL_CMP_CTX *ctx, X509 *cert)
 {
-    return X509_STORE_add_cert(OSSL_CMP_CTX_get0_trustedStore(ctx), cert);
+    return X509_STORE_add_cert(OSSL_CMP_CTX_get0_trusted(ctx), cert);
 }
 
 static int add_untrusted(OSSL_CMP_CTX *ctx, X509 *cert)
@@ -202,7 +202,7 @@ static int test_validate_msg_signature_partial_chain(int expired)
 
     SETUP_TEST_FIXTURE(CMP_VFY_TEST_FIXTURE, set_up);
 
-    ts = OSSL_CMP_CTX_get0_trustedStore(fixture->cmp_ctx);
+    ts = OSSL_CMP_CTX_get0_trusted(fixture->cmp_ctx);
     fixture->expected = !expired;
     if (ts == NULL
             || !TEST_ptr(fixture->msg = load_pkimsg(ir_protected_f, libctx))
@@ -369,7 +369,7 @@ static void setup_path(CMP_VFY_TEST_FIXTURE **fixture, X509 *wrong, int expired)
     (*fixture)->cert = endentity2;
     (*fixture)->expected = wrong == NULL && !expired;
     if (expired) {
-        X509_STORE *ts = OSSL_CMP_CTX_get0_trustedStore((*fixture)->cmp_ctx);
+        X509_STORE *ts = OSSL_CMP_CTX_get0_trusted((*fixture)->cmp_ctx);
         X509_VERIFY_PARAM *vpm = X509_STORE_get0_param(ts);
         X509_VERIFY_PARAM_set_time(vpm, test_time_after_expiration);
     }

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4733,8 +4733,8 @@ OSSL_CMP_CTX_set_transfer_cb_arg        4860	3_0_0	EXIST::FUNCTION:CMP
 OSSL_CMP_CTX_get_transfer_cb_arg        4861	3_0_0	EXIST::FUNCTION:CMP
 OSSL_CMP_CTX_set1_srvCert               4862	3_0_0	EXIST::FUNCTION:CMP
 OSSL_CMP_CTX_set1_expected_sender       4863	3_0_0	EXIST::FUNCTION:CMP
-OSSL_CMP_CTX_set0_trustedStore          4864	3_0_0	EXIST::FUNCTION:CMP
-OSSL_CMP_CTX_get0_trustedStore          4865	3_0_0	EXIST::FUNCTION:CMP
+OSSL_CMP_CTX_set0_trusted               4864	3_0_0	EXIST::FUNCTION:CMP
+OSSL_CMP_CTX_get0_trusted               4865	3_0_0	EXIST::FUNCTION:CMP
 OSSL_CMP_CTX_set1_untrusted             4866	3_0_0	EXIST::FUNCTION:CMP
 OSSL_CMP_CTX_get0_untrusted             4867	3_0_0	EXIST::FUNCTION:CMP
 OSSL_CMP_CTX_set1_cert                  4868	3_0_0	EXIST::FUNCTION:CMP

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -4733,8 +4733,8 @@ OSSL_CMP_CTX_set_transfer_cb_arg        4860	3_0_0	EXIST::FUNCTION:CMP
 OSSL_CMP_CTX_get_transfer_cb_arg        4861	3_0_0	EXIST::FUNCTION:CMP
 OSSL_CMP_CTX_set1_srvCert               4862	3_0_0	EXIST::FUNCTION:CMP
 OSSL_CMP_CTX_set1_expected_sender       4863	3_0_0	EXIST::FUNCTION:CMP
-OSSL_CMP_CTX_set0_trusted               4864	3_0_0	EXIST::FUNCTION:CMP
-OSSL_CMP_CTX_get0_trusted               4865	3_0_0	EXIST::FUNCTION:CMP
+OSSL_CMP_CTX_set0_trustedStore          4864	3_0_0	EXIST::FUNCTION:CMP
+OSSL_CMP_CTX_get0_trustedStore          4865	3_0_0	EXIST::FUNCTION:CMP
 OSSL_CMP_CTX_set1_untrusted             4866	3_0_0	EXIST::FUNCTION:CMP
 OSSL_CMP_CTX_get0_untrusted             4867	3_0_0	EXIST::FUNCTION:CMP
 OSSL_CMP_CTX_set1_cert                  4868	3_0_0	EXIST::FUNCTION:CMP

--- a/util/other.syms
+++ b/util/other.syms
@@ -397,9 +397,7 @@ OSSL_CMP_exec_CR_ses                    define
 OSSL_CMP_exec_P10CR_ses                 define
 OSSL_CMP_exec_KUR_ses                   define
 OSSL_CMP_CTX_get0_trusted               define
-OSSL_CMP_CTX_set0_trustedStore          define
 OSSL_CMP_CTX_set0_trusted               define
-OSSL_CMP_CTX_get0_trustedStore          define
 OSSL_CMP_CTX_set_log_verbosity          define
 OSSL_CMP_CR                             define
 OSSL_CMP_IR                             define

--- a/util/other.syms
+++ b/util/other.syms
@@ -396,6 +396,8 @@ OSSL_CMP_exec_IR_ses                    define
 OSSL_CMP_exec_CR_ses                    define
 OSSL_CMP_exec_P10CR_ses                 define
 OSSL_CMP_exec_KUR_ses                   define
+OSSL_CMP_CTX_get0_trustedStore          define
+OSSL_CMP_CTX_set0_trustedStore          define
 OSSL_CMP_CTX_set_log_verbosity          define
 OSSL_CMP_CR                             define
 OSSL_CMP_IR                             define

--- a/util/other.syms
+++ b/util/other.syms
@@ -396,8 +396,10 @@ OSSL_CMP_exec_IR_ses                    define
 OSSL_CMP_exec_CR_ses                    define
 OSSL_CMP_exec_P10CR_ses                 define
 OSSL_CMP_exec_KUR_ses                   define
-OSSL_CMP_CTX_get0_trustedStore          define
+OSSL_CMP_CTX_get0_trusted               define
 OSSL_CMP_CTX_set0_trustedStore          define
+OSSL_CMP_CTX_set0_trusted               define
+OSSL_CMP_CTX_get0_trustedStore          define
 OSSL_CMP_CTX_set_log_verbosity          define
 OSSL_CMP_CR                             define
 OSSL_CMP_IR                             define


### PR DESCRIPTION
Rename `OSSL_CMP_CTX_get0_trustedStore()` to `OSSL_CMP_CTX_get0_trusted()` and
`OSSL_CMP_CTX_set0_trustedStore()` to `OSSL_CMP_CTX_set0_trusted()`,
adding name macros for backward compatibility.

This makes the get/set function naming more consistent
(in particular with `OSSL_CMP_CTX_{get0,set1}_untrusted()`) ~and
removes much redundancy form the definition of many getters and setters~.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
