### PR TITLE
EVP_CIPHER_CTX_get_key_length and EVP_CIPHER_CTX_get_iv_length speedup

### DIFF
--- a/crypto/params.c
+++ b/crypto/params.c
@@ -1293,3 +1293,12 @@ int OSSL_PARAM_get_octet_string_ptr(const OSSL_PARAM *p, const void **val,
     return OSSL_PARAM_get_octet_ptr(p, val, used_len)
         || get_string_ptr_internal(p, val, used_len, OSSL_PARAM_OCTET_STRING);
 }
+
+int OSSL_PARAM_count(const OSSL_PARAM *p)
+{
+    int count = 0;
+
+    if (p != NULL)
+        for (; p[count].key != NULL; ++count);
+    return count;
+}

--- a/include/openssl/params.h
+++ b/include/openssl/params.h
@@ -150,6 +150,8 @@ int OSSL_PARAM_get_octet_string_ptr(const OSSL_PARAM *p, const void **val,
 int OSSL_PARAM_modified(const OSSL_PARAM *p);
 void OSSL_PARAM_set_all_unmodified(OSSL_PARAM *p);
 
+int OSSL_PARAM_count(const OSSL_PARAM *p);
+
 OSSL_PARAM *OSSL_PARAM_dup(const OSSL_PARAM *p);
 OSSL_PARAM *OSSL_PARAM_merge(const OSSL_PARAM *p1, const OSSL_PARAM *p2);
 void OSSL_PARAM_free(OSSL_PARAM *p);

--- a/providers/implementations/ciphers/ciphercommon.c
+++ b/providers/implementations/ciphers/ciphercommon.c
@@ -544,46 +544,72 @@ int ossl_cipher_generic_get_ctx_params(void *vctx, OSSL_PARAM params[])
 {
     PROV_CIPHER_CTX *ctx = (PROV_CIPHER_CTX *)vctx;
     OSSL_PARAM *p;
+    int count = OSSL_PARAM_count(params);
 
     p = OSSL_PARAM_locate(params, OSSL_CIPHER_PARAM_IVLEN);
-    if (p != NULL && !OSSL_PARAM_set_size_t(p, ctx->ivlen)) {
-        ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
-        return 0;
-    }
-    p = OSSL_PARAM_locate(params, OSSL_CIPHER_PARAM_PADDING);
-    if (p != NULL && !OSSL_PARAM_set_uint(p, ctx->pad)) {
-        ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
-        return 0;
+    if (p != NULL) {
+        if (!OSSL_PARAM_set_size_t(p, ctx->ivlen)) {
+            ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
+            return 0;
+        }
+        if (--count == 0)
+            return 1;    /* short-cut for speedup */
     }
     p = OSSL_PARAM_locate(params, OSSL_CIPHER_PARAM_IV);
-    if (p != NULL
-        && !OSSL_PARAM_set_octet_ptr(p, &ctx->oiv, ctx->ivlen)
-        && !OSSL_PARAM_set_octet_string(p, &ctx->oiv, ctx->ivlen)) {
-        ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
-        return 0;
+    if (p != NULL) {
+        if (!OSSL_PARAM_set_octet_ptr(p, &ctx->oiv, ctx->ivlen)
+            && !OSSL_PARAM_set_octet_string(p, &ctx->oiv, ctx->ivlen)) {
+            ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
+            return 0;
+        }
+        if (--count == 0)
+            return 1;    /* short-cut for speedup */
     }
     p = OSSL_PARAM_locate(params, OSSL_CIPHER_PARAM_UPDATED_IV);
-    if (p != NULL
-        && !OSSL_PARAM_set_octet_ptr(p, &ctx->iv, ctx->ivlen)
-        && !OSSL_PARAM_set_octet_string(p, &ctx->iv, ctx->ivlen)) {
-        ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
-        return 0;
-    }
-    p = OSSL_PARAM_locate(params, OSSL_CIPHER_PARAM_NUM);
-    if (p != NULL && !OSSL_PARAM_set_uint(p, ctx->num)) {
-        ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
-        return 0;
+    if (p != NULL) {
+        if (!OSSL_PARAM_set_octet_ptr(p, &ctx->iv, ctx->ivlen)
+            && !OSSL_PARAM_set_octet_string(p, &ctx->iv, ctx->ivlen)) {
+            ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
+            return 0;
+        }
+        if (--count == 0)
+            return 1;    /* short-cut for speedup */
     }
     p = OSSL_PARAM_locate(params, OSSL_CIPHER_PARAM_KEYLEN);
-    if (p != NULL && !OSSL_PARAM_set_size_t(p, ctx->keylen)) {
-        ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
-        return 0;
+    if (p != NULL) {
+        if (!OSSL_PARAM_set_size_t(p, ctx->keylen)) {
+            ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
+            return 0;
+        }
+        if (--count == 0)
+            return 1;    /* short-cut for speedup */
     }
     p = OSSL_PARAM_locate(params, OSSL_CIPHER_PARAM_TLS_MAC);
-    if (p != NULL
-        && !OSSL_PARAM_set_octet_ptr(p, ctx->tlsmac, ctx->tlsmacsize)) {
-        ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
-        return 0;
+    if (p != NULL) {
+        if (!OSSL_PARAM_set_octet_ptr(p, ctx->tlsmac, ctx->tlsmacsize)) {
+            ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
+            return 0;
+        }
+        if (--count == 0)
+            return 1;    /* short-cut for speedup */
+    }
+    p = OSSL_PARAM_locate(params, OSSL_CIPHER_PARAM_PADDING);
+    if (p != NULL) {
+        if (!OSSL_PARAM_set_uint(p, ctx->pad)) {
+            ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
+            return 0;
+        }
+        if (--count == 0)
+            return 1;    /* short-cut for speedup */
+    }
+    p = OSSL_PARAM_locate(params, OSSL_CIPHER_PARAM_NUM);
+    if (p != NULL) {
+        if (!OSSL_PARAM_set_uint(p, ctx->num)) {
+            ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
+            return 0;
+        }
+        if (--count == 0)
+            return 1;    /* short-cut for speedup */
     }
     return 1;
 }

--- a/providers/implementations/ciphers/ciphercommon_gcm.c
+++ b/providers/implementations/ciphers/ciphercommon_gcm.c
@@ -137,16 +137,25 @@ int ossl_gcm_get_ctx_params(void *vctx, OSSL_PARAM params[])
     PROV_GCM_CTX *ctx = (PROV_GCM_CTX *)vctx;
     OSSL_PARAM *p;
     size_t sz;
+    int count = OSSL_PARAM_count(params);
 
     p = OSSL_PARAM_locate(params, OSSL_CIPHER_PARAM_IVLEN);
-    if (p != NULL && !OSSL_PARAM_set_size_t(p, ctx->ivlen)) {
-        ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
-        return 0;
+    if (p != NULL) {
+        if (!OSSL_PARAM_set_size_t(p, ctx->ivlen)) {
+            ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
+            return 0;
+        }
+        if (--count == 0)
+            return 1; /* short-cut for speedup */
     }
     p = OSSL_PARAM_locate(params, OSSL_CIPHER_PARAM_KEYLEN);
-    if (p != NULL && !OSSL_PARAM_set_size_t(p, ctx->keylen)) {
-        ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
-        return 0;
+    if (p != NULL) {
+        if (!OSSL_PARAM_set_size_t(p, ctx->keylen)) {
+            ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
+            return 0;
+        }
+        if (--count == 0)
+            return 1; /* short-cut for speedup */
     }
     p = OSSL_PARAM_locate(params, OSSL_CIPHER_PARAM_AEAD_TAGLEN);
     if (p != NULL) {
@@ -157,6 +166,8 @@ int ossl_gcm_get_ctx_params(void *vctx, OSSL_PARAM params[])
             ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
             return 0;
         }
+        if (--count == 0)
+            return 1; /* short-cut for speedup */
     }
 
     p = OSSL_PARAM_locate(params, OSSL_CIPHER_PARAM_IV);
@@ -172,6 +183,8 @@ int ossl_gcm_get_ctx_params(void *vctx, OSSL_PARAM params[])
             ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
             return 0;
         }
+        if (--count == 0)
+            return 1; /* short-cut for speedup */
     }
 
     p = OSSL_PARAM_locate(params, OSSL_CIPHER_PARAM_UPDATED_IV);
@@ -187,12 +200,18 @@ int ossl_gcm_get_ctx_params(void *vctx, OSSL_PARAM params[])
             ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
             return 0;
         }
+        if (--count == 0)
+            return 1; /* short-cut for speedup */
     }
 
     p = OSSL_PARAM_locate(params, OSSL_CIPHER_PARAM_AEAD_TLS1_AAD_PAD);
-    if (p != NULL && !OSSL_PARAM_set_size_t(p, ctx->tls_aad_pad_sz)) {
-        ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
-        return 0;
+    if (p != NULL) {
+        if (!OSSL_PARAM_set_size_t(p, ctx->tls_aad_pad_sz)) {
+            ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
+            return 0;
+        }
+        if (--count == 0)
+            return 1; /* short-cut for speedup */
     }
     p = OSSL_PARAM_locate(params, OSSL_CIPHER_PARAM_AEAD_TAG);
     if (p != NULL) {
@@ -208,6 +227,8 @@ int ossl_gcm_get_ctx_params(void *vctx, OSSL_PARAM params[])
             ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
             return 0;
         }
+        if (--count == 0)
+            return 1; /* short-cut for speedup */
     }
     p = OSSL_PARAM_locate(params, OSSL_CIPHER_PARAM_AEAD_TLS1_GET_IV_GEN);
     if (p != NULL) {
@@ -215,6 +236,8 @@ int ossl_gcm_get_ctx_params(void *vctx, OSSL_PARAM params[])
             || p->data_type != OSSL_PARAM_OCTET_STRING
             || !getivgen(ctx, p->data, p->data_size))
             return 0;
+        if (--count == 0)
+            return 1; /* short-cut for speedup */
     }
     return 1;
 }

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5425,3 +5425,4 @@ ASN1_item_d2i_ex                        5552	3_0_0	EXIST::FUNCTION:
 ASN1_TIME_print_ex                      5553	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_get0_provider                  5554	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_CTX_get0_provider              5555	3_0_0	EXIST::FUNCTION:
+OSSL_PARAM_count                        ?	3_1_0	EXIST::FUNCTION:


### PR DESCRIPTION
This is just a draft PR for the approach I've suggested. IMO this does not really complicate the get_ctx_param code however of course it is not really generic approach and speeds up in practice only the case where we get a single param and one that is near the beginning of the params we check in the get_ctx_param code.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
