### PR TITLE
apps: Enable TCP Keepalive for Clients

### DIFF
--- a/apps/lib/s_socket.c
+++ b/apps/lib/s_socket.c
@@ -162,7 +162,8 @@ int init_client(int *sock, const char *host, const char *port,
 #endif
 
         if (!BIO_connect(*sock, BIO_ADDRINFO_address(ai),
-                         protocol == IPPROTO_TCP ? BIO_SOCK_NODELAY : 0)) {
+                         protocol == IPPROTO_TCP ?
+                         (BIO_SOCK_KEEPALIVE | BIO_SOCK_NODELAY) : 0)) {
             BIO_closesocket(*sock);
             *sock = INVALID_SOCKET;
             continue;


### PR DESCRIPTION
Not sure why TCP Keepalive was not enabled. Theoretically (and in my test scenario where I found this, practically) even the TLS Handshake alone can take long, longer than a NAT port binding of the local router/firewall. In other words, I need this in my scenario, I am using a short system-wide TCP Keepalive because my TLS Handshake fails otherwise. Therefore, reporting this through a Pull Request to the general public. If it is invalid and it was discussed before, do not hesitate to close this Pull Request … but then, please, explain why, for example, by linking to such a discussion.