### PR TITLE
ossl_provider_add_to_store: Avoid use-after-free

### DIFF
--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -602,6 +602,9 @@ int ossl_provider_add_to_store(OSSL_PROVIDER *prov, OSSL_PROVIDER **actualprov,
     OSSL_PROVIDER tmpl = { 0, };
     OSSL_PROVIDER *actualtmp = NULL;
 
+    if (actualprov != NULL)
+        *actualprov = NULL;
+
     if ((store = get_provider_store(prov->libctx)) == NULL)
         return 0;
 
@@ -658,7 +661,7 @@ int ossl_provider_add_to_store(OSSL_PROVIDER *prov, OSSL_PROVIDER **actualprov,
  err:
     CRYPTO_THREAD_unlock(store->lock);
     if (actualprov != NULL)
-        ossl_provider_free(actualtmp);
+        ossl_provider_free(*actualprov);
     return 0;
 }
 


### PR DESCRIPTION
Avoid freeing a provider that was not up-ref-ed before.

Fixes #17292
