### PR TITLE
Fix the static check miss in BN_hex2bn

### DIFF
--- a/crypto/bn/bn_conv.c
+++ b/crypto/bn/bn_conv.c
@@ -154,6 +154,10 @@ int BN_hex2bn(BIGNUM **bn, const char *a)
             return 0;
     } else {
         ret = *bn;
+        if (BN_get_flags(ret, BN_FLG_STATIC_DATA)) {
+            ERR_raise(ERR_LIB_BN, ERR_R_PASSED_INVALID_ARGUMENT);
+            return 0;
+        }
         BN_zero(ret);
     }
 


### PR DESCRIPTION
Fix #17298