### PR TITLE
Fix the NEWS.md and CHANGES.md in 3.0 to avoid trailing spaces

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,7 +30,7 @@ breaking changes, and mappings for the large list of deprecated functions.
 
 ### Changes between 3.0.1 and 3.0.2 [xx XXX xxxx]
 
- * 
+ * none yet
 
 ### Changes between 3.0.0 and 3.0.1 [14 Dec 2021]
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -20,7 +20,7 @@ OpenSSL 3.0
 
 ### Major changes between OpenSSL 3.0.1 and OpenSSL 3.0.2 [under development]
 
- * 
+  * none
 
 ### Major changes between OpenSSL 3.0.0 and OpenSSL 3.0.1 [14 Dec 2021]
 

--- a/dev/release-aux/fixup-CHANGES.md-postrelease.pl
+++ b/dev/release-aux/fixup-CHANGES.md-postrelease.pl
@@ -20,7 +20,7 @@ if (/^### Changes between (\S+) and (\S+) \[xx XXX xxxx\]/
         $_ = <<_____
 ### Changes between $v2 and $RELEASE_TEXT [xx XXX xxxx]
 
- * 
+ * none yet
 
 ### Changes between $v1 and $v2 [$PREV_RELEASE_DATE]
 _____

--- a/dev/release-aux/fixup-NEWS.md-postrelease.pl
+++ b/dev/release-aux/fixup-NEWS.md-postrelease.pl
@@ -20,7 +20,7 @@ if (/^### Major changes between OpenSSL (\S+) and OpenSSL (\S+) \[under developm
         $_ = <<_____
 ### Major changes between OpenSSL $v2 and OpenSSL $RELEASE_TEXT [under development]
 
- * 
+  * none
 
 ### Major changes between OpenSSL $v1 and OpenSSL $v2 [$PREV_RELEASE_DATE]
 _____


### PR DESCRIPTION
The postrelease fixup scripts are also fixed to not create such errors in NEWS.md and CHANGES.md. (This commit is also applicable to master.)
