### PR TITLE
add `OSSL_STACK_OF_X509_free()` for commonly used pattern

### DIFF
--- a/apps/ca.c
+++ b/apps/ca.c
@@ -1325,7 +1325,7 @@ end_of_options:
     BIO_free_all(Sout);
     BIO_free_all(out);
     BIO_free_all(in);
-    sk_X509_pop_free(cert_sk, X509_free);
+    OSSL_STACK_OF_X509_free(cert_sk);
 
     cleanse(passin);
     if (free_passin)

--- a/apps/cmp.c
+++ b/apps/cmp.c
@@ -933,7 +933,7 @@ static int setup_certs(char *files, const char *desc, void *ctx,
     if ((certs = load_certs_multifile(files, opt_otherpass, desc, vpm)) == NULL)
         return 0;
     ok = (*set1_fn)(ctx, certs);
-    sk_X509_pop_free(certs, X509_free);
+    OSSL_STACK_OF_X509_free(certs);
     return ok;
 }
 
@@ -1262,7 +1262,7 @@ static SSL_CTX *setup_ssl_ctx(OSSL_CMP_CTX *ctx, const char *host,
         if (!ok || !SSL_CTX_set0_chain(ssl_ctx, certs)) {
             CMP_err1("unable to use client TLS certificate file '%s'",
                      opt_tls_cert);
-            sk_X509_pop_free(certs, X509_free);
+            OSSL_STACK_OF_X509_free(certs);
             goto err;
         }
         for (i = 0; i < sk_X509_num(untrusted); i++) {
@@ -1441,7 +1441,7 @@ static int setup_protection_ctx(OSSL_CMP_CTX *ctx, ENGINE *engine)
             ok = ok && OSSL_CMP_CTX_build_cert_chain(ctx, own_trusted, certs);
         }
         X509_STORE_free(own_trusted);
-        sk_X509_pop_free(certs, X509_free);
+        OSSL_STACK_OF_X509_free(certs);
         if (!ok)
             return 0;
     } else if (opt_own_trusted != NULL) {
@@ -2020,7 +2020,7 @@ static int save_free_certs(OSSL_CMP_CTX *ctx,
 
  end:
     BIO_free(bio);
-    sk_X509_pop_free(certs, X509_free);
+    OSSL_STACK_OF_X509_free(certs);
     return n;
 }
 

--- a/apps/cms.c
+++ b/apps/cms.c
@@ -909,7 +909,7 @@ int cms_main(int argc, char **argv)
                 ret = 5;
                 goto end;
             }
-            sk_X509_pop_free(allcerts, X509_free);
+            OSSL_STACK_OF_X509_free(allcerts);
         }
     }
 
@@ -1237,8 +1237,8 @@ int cms_main(int argc, char **argv)
  end:
     if (ret)
         ERR_print_errors(bio_err);
-    sk_X509_pop_free(encerts, X509_free);
-    sk_X509_pop_free(other, X509_free);
+    OSSL_STACK_OF_X509_free(encerts);
+    OSSL_STACK_OF_X509_free(other);
     X509_VERIFY_PARAM_free(vpm);
     sk_OPENSSL_STRING_free(sksigners);
     sk_OPENSSL_STRING_free(skkeys);

--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -696,7 +696,7 @@ int load_cert_certs(const char *uri,
             warn_cert(uri, *pcert, 0, vpm);
         warn_certs(uri, *pcerts, 1, vpm);
     } else {
-        sk_X509_pop_free(*pcerts, X509_free);
+        OSSL_STACK_OF_X509_free(*pcerts);
         *pcerts = NULL;
     }
     return ret;
@@ -721,7 +721,7 @@ STACK_OF(X509) *load_certs_multifile(char *files, const char *pass,
         if (!X509_add_certs(result, certs,
                             X509_ADD_FLAG_UP_REF | X509_ADD_FLAG_NO_DUP))
             goto oom;
-        sk_X509_pop_free(certs, X509_free);
+        OSSL_STACK_OF_X509_free(certs);
         certs = NULL;
         files = next;
     }
@@ -730,8 +730,8 @@ STACK_OF(X509) *load_certs_multifile(char *files, const char *pass,
  oom:
     BIO_printf(bio_err, "out of memory\n");
  err:
-    sk_X509_pop_free(certs, X509_free);
-    sk_X509_pop_free(result, X509_free);
+    OSSL_STACK_OF_X509_free(certs);
+    OSSL_STACK_OF_X509_free(result);
     return NULL;
 }
 
@@ -772,7 +772,7 @@ X509_STORE *load_certstore(char *input, const char *pass, const char *desc,
             return NULL;
         }
         ok = (store = sk_X509_to_store(store, certs)) != NULL;
-        sk_X509_pop_free(certs, X509_free);
+        OSSL_STACK_OF_X509_free(certs);
         certs = NULL;
         if (!ok)
             return NULL;
@@ -794,7 +794,7 @@ int load_certs(const char *uri, int maybe_stdin, STACK_OF(X509) **certs,
                                   NULL, NULL, certs, NULL, NULL);
 
     if (!ret && was_NULL) {
-        sk_X509_pop_free(*certs, X509_free);
+        OSSL_STACK_OF_X509_free(*certs);
         *certs = NULL;
     }
     return ret;

--- a/apps/lib/cmp_mock_srv.c
+++ b/apps/lib/cmp_mock_srv.c
@@ -38,8 +38,8 @@ static void mock_srv_ctx_free(mock_srv_ctx *ctx)
 
     OSSL_CMP_PKISI_free(ctx->statusOut);
     X509_free(ctx->certOut);
-    sk_X509_pop_free(ctx->chainOut, X509_free);
-    sk_X509_pop_free(ctx->caPubsOut, X509_free);
+    OSSL_STACK_OF_X509_free(ctx->chainOut);
+    OSSL_STACK_OF_X509_free(ctx->caPubsOut);
     OSSL_CMP_MSG_free(ctx->certReq);
     OPENSSL_free(ctx);
 }
@@ -91,7 +91,7 @@ int ossl_cmp_mock_srv_set1_chainOut(OSSL_CMP_SRV_CTX *srv_ctx,
     }
     if (chain != NULL && (chain_copy = X509_chain_up_ref(chain)) == NULL)
         return 0;
-    sk_X509_pop_free(ctx->chainOut, X509_free);
+    OSSL_STACK_OF_X509_free(ctx->chainOut);
     ctx->chainOut = chain_copy;
     return 1;
 }
@@ -108,7 +108,7 @@ int ossl_cmp_mock_srv_set1_caPubsOut(OSSL_CMP_SRV_CTX *srv_ctx,
     }
     if (caPubs != NULL && (caPubs_copy = X509_chain_up_ref(caPubs)) == NULL)
         return 0;
-    sk_X509_pop_free(ctx->caPubsOut, X509_free);
+    OSSL_STACK_OF_X509_free(ctx->caPubsOut);
     ctx->caPubsOut = caPubs_copy;
     return 1;
 }
@@ -252,9 +252,9 @@ static OSSL_CMP_PKISI *process_cert_request(OSSL_CMP_SRV_CTX *srv_ctx,
  err:
     X509_free(*certOut);
     *certOut = NULL;
-    sk_X509_pop_free(*chainOut, X509_free);
+    OSSL_STACK_OF_X509_free(*chainOut);
     *chainOut = NULL;
-    sk_X509_pop_free(*caPubs, X509_free);
+    OSSL_STACK_OF_X509_free(*caPubs);
     *caPubs = NULL;
     return NULL;
 }

--- a/apps/lib/s_cb.c
+++ b/apps/lib/s_cb.c
@@ -992,7 +992,7 @@ void ssl_excert_free(SSL_EXCERT *exc)
     while (exc) {
         X509_free(exc->cert);
         EVP_PKEY_free(exc->key);
-        sk_X509_pop_free(exc->chain, X509_free);
+        OSSL_STACK_OF_X509_free(exc->chain);
         curr = exc;
         exc = exc->next;
         OPENSSL_free(curr);

--- a/apps/ocsp.c
+++ b/apps/ocsp.c
@@ -855,9 +855,9 @@ redo_accept:
     EVP_MD_free(rsign_md);
     EVP_MD_free(resp_certid_md);
     X509_free(cert);
-    sk_X509_pop_free(issuers, X509_free);
+    OSSL_STACK_OF_X509_free(issuers);
     X509_free(rsigner);
-    sk_X509_pop_free(rca_cert, X509_free);
+    OSSL_STACK_OF_X509_free(rca_cert);
     free_index(rdb);
     BIO_free_all(cbio);
     BIO_free_all(acbio);
@@ -867,8 +867,8 @@ redo_accept:
     OCSP_BASICRESP_free(bs);
     sk_OPENSSL_STRING_free(reqnames);
     sk_OCSP_CERTID_free(ids);
-    sk_X509_pop_free(sign_other, X509_free);
-    sk_X509_pop_free(verify_other, X509_free);
+    OSSL_STACK_OF_X509_free(sign_other);
+    OSSL_STACK_OF_X509_free(verify_other);
     sk_CONF_VALUE_pop_free(headers, X509V3_conf_free);
     OPENSSL_free(thost);
     OPENSSL_free(tport);

--- a/apps/pkcs12.c
+++ b/apps/pkcs12.c
@@ -610,7 +610,7 @@ int pkcs12_main(int argc, char **argv)
                 /* Add the remaining certs (except for duplicates) */
                 add_certs = X509_add_certs(certs, chain2, X509_ADD_FLAG_UP_REF
                                            | X509_ADD_FLAG_NO_DUP);
-                sk_X509_pop_free(chain2, X509_free);
+                OSSL_STACK_OF_X509_free(chain2);
                 if (!add_certs)
                     goto export_end;
             } else {
@@ -697,8 +697,8 @@ int pkcs12_main(int argc, char **argv)
 
         EVP_PKEY_free(key);
         EVP_MD_free(macmd);
-        sk_X509_pop_free(certs, X509_free);
-        sk_X509_pop_free(untrusted_certs, X509_free);
+        OSSL_STACK_OF_X509_free(certs);
+        OSSL_STACK_OF_X509_free(untrusted_certs);
         X509_free(ee_cert);
 
         ERR_print_errors(bio_err);

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -3048,7 +3048,7 @@ int s_client_main(int argc, char **argv)
     X509_free(cert);
     sk_X509_CRL_pop_free(crls, X509_CRL_free);
     EVP_PKEY_free(key);
-    sk_X509_pop_free(chain, X509_free);
+    OSSL_STACK_OF_X509_free(chain);
     OPENSSL_free(pass);
 #ifndef OPENSSL_NO_SRP
     OPENSSL_free(srp_arg.srppassin);

--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -2240,8 +2240,8 @@ int s_server_main(int argc, char *argv[])
     X509_free(s_dcert);
     EVP_PKEY_free(s_key);
     EVP_PKEY_free(s_dkey);
-    sk_X509_pop_free(s_chain, X509_free);
-    sk_X509_pop_free(s_dchain, X509_free);
+    OSSL_STACK_OF_X509_free(s_chain);
+    OSSL_STACK_OF_X509_free(s_dchain);
     OPENSSL_free(pass);
     OPENSSL_free(dpass);
     OPENSSL_free(host);

--- a/apps/smime.c
+++ b/apps/smime.c
@@ -651,8 +651,8 @@ int smime_main(int argc, char **argv)
  end:
     if (ret)
         ERR_print_errors(bio_err);
-    sk_X509_pop_free(encerts, X509_free);
-    sk_X509_pop_free(other, X509_free);
+    OSSL_STACK_OF_X509_free(encerts);
+    OSSL_STACK_OF_X509_free(other);
     X509_VERIFY_PARAM_free(vpm);
     sk_OPENSSL_STRING_free(sksigners);
     sk_OPENSSL_STRING_free(skkeys);

--- a/apps/verify.c
+++ b/apps/verify.c
@@ -234,8 +234,8 @@ int verify_main(int argc, char **argv)
  end:
     X509_VERIFY_PARAM_free(vpm);
     X509_STORE_free(store);
-    sk_X509_pop_free(untrusted, X509_free);
-    sk_X509_pop_free(trusted, X509_free);
+    OSSL_STACK_OF_X509_free(untrusted);
+    OSSL_STACK_OF_X509_free(trusted);
     sk_X509_CRL_pop_free(crls, X509_CRL_free);
     sk_OPENSSL_STRING_free(vfyopts);
     release_engine(e);
@@ -307,7 +307,7 @@ static int check(X509_STORE *ctx, const char *file,
                     BIO_printf(bio_out, " (untrusted)");
                 BIO_printf(bio_out, "\n");
             }
-            sk_X509_pop_free(chain, X509_free);
+            OSSL_STACK_OF_X509_free(chain);
         }
     } else {
         BIO_printf(bio_err,

--- a/crypto/cmp/cmp_client.c
+++ b/crypto/cmp/cmp_client.c
@@ -514,7 +514,7 @@ int OSSL_CMP_certConf_cb(OSSL_CMP_CTX *ctx, X509 *cert, int fail_info,
                        "success building approximate chain for newly enrolled cert");
     }
     (void)ossl_cmp_ctx_set1_newChain(ctx, chain);
-    sk_X509_pop_free(chain, X509_free);
+    OSSL_STACK_OF_X509_free(chain);
 
     return fail_info;
 }

--- a/crypto/cmp/cmp_ctx.c
+++ b/crypto/cmp/cmp_ctx.c
@@ -61,9 +61,6 @@ DEFINE_OSSL_set0_NAME(OSSL_CMP_CTX, trustedStore, trusted, X509_STORE)
 /* Get current list of non-trusted intermediate certs */
 DEFINE_OSSL_CMP_CTX_get0(untrusted, STACK_OF(X509))
 
-#define X509_STACK_free(certs) \
-    sk_X509_pop_free(certs, X509_free)
-
 /*
  * Set untrusted certificates for path construction in authentication of
  * the CMP server and potentially others (TLS server, newly enrolled cert).
@@ -79,11 +76,11 @@ int OSSL_CMP_CTX_set1_untrusted(OSSL_CMP_CTX *ctx, STACK_OF(X509) *certs)
     if (!ossl_x509_add_certs_new(&untrusted, certs,
                                  X509_ADD_FLAG_UP_REF | X509_ADD_FLAG_NO_DUP))
         goto err;
-    X509_STACK_free(ctx->untrusted);
+    OSSL_STACK_OF_X509_free(ctx->untrusted);
     ctx->untrusted = untrusted;
     return 1;
  err:
-    X509_STACK_free(untrusted);
+    OSSL_STACK_OF_X509_free(untrusted);
     return 0;
 }
 
@@ -202,10 +199,10 @@ void OSSL_CMP_CTX_free(OSSL_CMP_CTX *ctx)
     X509_free(ctx->validatedSrvCert);
     X509_NAME_free(ctx->expected_sender);
     X509_STORE_free(ctx->trusted);
-    X509_STACK_free(ctx->untrusted);
+    OSSL_STACK_OF_X509_free(ctx->untrusted);
 
     X509_free(ctx->cert);
-    X509_STACK_free(ctx->chain);
+    OSSL_STACK_OF_X509_free(ctx->chain);
     EVP_PKEY_free(ctx->pkey);
     ASN1_OCTET_STRING_free(ctx->referenceValue);
     if (ctx->secretValue != NULL)
@@ -219,7 +216,7 @@ void OSSL_CMP_CTX_free(OSSL_CMP_CTX *ctx)
     ASN1_OCTET_STRING_free(ctx->senderNonce);
     ASN1_OCTET_STRING_free(ctx->recipNonce);
     OSSL_CMP_ITAVs_free(ctx->geninfo_ITAVs);
-    X509_STACK_free(ctx->extraCertsOut);
+    OSSL_STACK_OF_X509_free(ctx->extraCertsOut);
 
     EVP_PKEY_free(ctx->newPkey);
     X509_NAME_free(ctx->issuer);
@@ -234,9 +231,9 @@ void OSSL_CMP_CTX_free(OSSL_CMP_CTX *ctx)
 
     OSSL_CMP_PKIFREETEXT_free(ctx->statusString);
     X509_free(ctx->newCert);
-    X509_STACK_free(ctx->newChain);
-    X509_STACK_free(ctx->caPubs);
-    X509_STACK_free(ctx->extraCertsIn);
+    OSSL_STACK_OF_X509_free(ctx->newChain);
+    OSSL_STACK_OF_X509_free(ctx->caPubs);
+    OSSL_STACK_OF_X509_free(ctx->extraCertsIn);
 
     OPENSSL_free(ctx);
 }
@@ -469,7 +466,7 @@ int PREFIX##_set1_##FIELD(OSSL_CMP_CTX *ctx, STACK_OF(X509) *certs) \
         ERR_raise(ERR_LIB_CMP, CMP_R_NULL_ARGUMENT); \
         return 0; \
     } \
-    X509_STACK_free(ctx->FIELD); \
+    OSSL_STACK_OF_X509_free(ctx->FIELD); \
     ctx->FIELD = NULL; \
     return certs == NULL || (ctx->FIELD = X509_chain_up_ref(certs)) != NULL; \
 }

--- a/crypto/cmp/cmp_server.c
+++ b/crypto/cmp/cmp_server.c
@@ -234,8 +234,8 @@ static OSSL_CMP_MSG *process_cert_request(OSSL_CMP_SRV_CTX *srv_ctx,
  err:
     OSSL_CMP_PKISI_free(si);
     X509_free(certOut);
-    sk_X509_pop_free(chainOut, X509_free);
-    sk_X509_pop_free(caPubs, X509_free);
+    OSSL_STACK_OF_X509_free(chainOut);
+    OSSL_STACK_OF_X509_free(caPubs);
     return msg;
 }
 

--- a/crypto/cmp/cmp_vfy.c
+++ b/crypto/cmp/cmp_vfy.c
@@ -432,7 +432,7 @@ static int check_msg_all_certs(OSSL_CMP_CTX *ctx, const OSSL_CMP_MSG *msg,
                                              : "certs in trusted store",
                                    msg->extraCerts, ctx->untrusted,
                                    msg, mode_3gpp);
-        sk_X509_pop_free(trusted, X509_free);
+        OSSL_STACK_OF_X509_free(trusted);
     }
     return ret;
 }

--- a/crypto/cms/cms_lib.c
+++ b/crypto/cms/cms_lib.c
@@ -634,7 +634,7 @@ STACK_OF(X509) *CMS_get1_certs(CMS_ContentInfo *cms)
         if (cch->type == 0) {
             if (!ossl_x509_add_cert_new(&certs, cch->d.certificate,
                                         X509_ADD_FLAG_UP_REF)) {
-                sk_X509_pop_free(certs, X509_free);
+                OSSL_STACK_OF_X509_free(certs);
                 return NULL;
             }
         }

--- a/crypto/cms/cms_smime.c
+++ b/crypto/cms/cms_smime.c
@@ -478,10 +478,10 @@ int CMS_verify(CMS_ContentInfo *cms, STACK_OF(X509) *certs,
  err2:
     if (si_chains != NULL) {
         for (i = 0; i < scount; ++i)
-            sk_X509_pop_free(si_chains[i], X509_free);
+            OSSL_STACK_OF_X509_free(si_chains[i]);
         OPENSSL_free(si_chains);
     }
-    sk_X509_pop_free(cms_certs, X509_free);
+    OSSL_STACK_OF_X509_free(cms_certs);
     sk_X509_CRL_pop_free(crls, X509_CRL_free);
 
     return ret;

--- a/crypto/ocsp/ocsp_vfy.c
+++ b/crypto/ocsp/ocsp_vfy.c
@@ -153,7 +153,7 @@ int OCSP_basic_verify(OCSP_BASICRESP *bs, STACK_OF(X509) *certs,
     }
 
  end:
-    sk_X509_pop_free(chain, X509_free);
+    OSSL_STACK_OF_X509_free(chain);
     sk_X509_free(untrusted);
     return ret;
 }

--- a/crypto/pkcs12/p12_kiss.c
+++ b/crypto/pkcs12/p12_kiss.c
@@ -125,7 +125,7 @@ int PKCS12_parse(PKCS12 *p12, const char *pass, EVP_PKEY **pkey, X509 **cert,
         *cert = NULL;
     }
     X509_free(x);
-    sk_X509_pop_free(ocerts, X509_free);
+    OSSL_STACK_OF_X509_free(ocerts);
     return 0;
 
 }

--- a/crypto/store/store_result.c
+++ b/crypto/store/store_result.c
@@ -603,7 +603,7 @@ static int try_pkcs12(struct extracted_param_data_st *data, OSSL_STORE_INFO **v,
                 }
                 EVP_PKEY_free(pkey);
                 X509_free(cert);
-                sk_X509_pop_free(chain, X509_free);
+                OSSL_STACK_OF_X509_free(chain);
                 OSSL_STORE_INFO_free(osi_pkey);
                 OSSL_STORE_INFO_free(osi_cert);
                 OSSL_STORE_INFO_free(osi_ca);

--- a/crypto/ts/ts_conf.c
+++ b/crypto/ts/ts_conf.c
@@ -78,7 +78,7 @@ STACK_OF(X509) *TS_CONF_load_certs(const char *file)
 
         if (xi->x509 != NULL) {
             if (!X509_add_cert(othercerts, xi->x509, X509_ADD_FLAG_DEFAULT)) {
-                sk_X509_pop_free(othercerts, X509_free);
+                OSSL_STACK_OF_X509_free(othercerts);
                 othercerts = NULL;
                 goto end;
             }
@@ -233,7 +233,7 @@ int TS_CONF_set_certs(CONF *conf, const char *section, const char *certs,
  end:
     ret = 1;
  err:
-    sk_X509_pop_free(certs_obj, X509_free);
+    OSSL_STACK_OF_X509_free(certs_obj);
     return ret;
 }
 

--- a/crypto/ts/ts_rsp_sign.c
+++ b/crypto/ts/ts_rsp_sign.c
@@ -147,7 +147,7 @@ void TS_RESP_CTX_free(TS_RESP_CTX *ctx)
     OPENSSL_free(ctx->propq);
     X509_free(ctx->signer_cert);
     EVP_PKEY_free(ctx->signer_key);
-    sk_X509_pop_free(ctx->certs, X509_free);
+    OSSL_STACK_OF_X509_free(ctx->certs);
     sk_ASN1_OBJECT_pop_free(ctx->policies, ASN1_OBJECT_free);
     ASN1_OBJECT_free(ctx->default_policy);
     sk_EVP_MD_free(ctx->mds);   /* No EVP_MD_free method exists. */
@@ -197,7 +197,7 @@ int TS_RESP_CTX_set_def_policy(TS_RESP_CTX *ctx, const ASN1_OBJECT *def_policy)
 
 int TS_RESP_CTX_set_certs(TS_RESP_CTX *ctx, STACK_OF(X509) *certs)
 {
-    sk_X509_pop_free(ctx->certs, X509_free);
+    OSSL_STACK_OF_X509_free(ctx->certs);
     ctx->certs = NULL;
 
     return certs == NULL || (ctx->certs = X509_chain_up_ref(certs)) != NULL;

--- a/crypto/ts/ts_rsp_verify.c
+++ b/crypto/ts/ts_rsp_verify.c
@@ -158,7 +158,7 @@ int TS_RESP_verify_signature(PKCS7 *token, STACK_OF(X509) *certs,
  err:
     BIO_free_all(p7bio);
     sk_X509_free(untrusted);
-    sk_X509_pop_free(chain, X509_free);
+    OSSL_STACK_OF_X509_free(chain);
     sk_X509_free(signers);
 
     return ret;

--- a/crypto/ts/ts_verify_ctx.c
+++ b/crypto/ts/ts_verify_ctx.c
@@ -82,7 +82,7 @@ void TS_VERIFY_CTX_cleanup(TS_VERIFY_CTX *ctx)
         return;
 
     X509_STORE_free(ctx->store);
-    sk_X509_pop_free(ctx->certs, X509_free);
+    OSSL_STACK_OF_X509_free(ctx->certs);
 
     ASN1_OBJECT_free(ctx->policy);
 

--- a/crypto/x509/t_x509.c
+++ b/crypto/x509/t_x509.c
@@ -17,6 +17,11 @@
 #include "crypto/asn1.h"
 #include "crypto/x509.h"
 
+void OSSL_STACK_OF_X509_free(STACK_OF(X509) *certs)
+{
+    sk_X509_pop_free(certs, X509_free);
+}
+
 #ifndef OPENSSL_NO_STDIO
 int X509_print_fp(FILE *fp, X509 *x)
 {
@@ -456,7 +461,7 @@ static int print_store_certs(BIO *bio, X509_STORE *store)
         STACK_OF(X509) *certs = X509_STORE_get1_all_certs(store);
         int ret = print_certs(bio, certs);
 
-        sk_X509_pop_free(certs, X509_free);
+        OSSL_STACK_OF_X509_free(certs);
         return ret;
     } else {
         return BIO_printf(bio, "    (no trusted store)\n") >= 0;

--- a/crypto/x509/x509_lu.c
+++ b/crypto/x509/x509_lu.c
@@ -567,7 +567,7 @@ STACK_OF(X509) *X509_STORE_get1_all_certs(X509_STORE *store)
 
  err:
     X509_STORE_unlock(store);
-    sk_X509_pop_free(sk, X509_free);
+    OSSL_STACK_OF_X509_free(sk);
     return NULL;
 }
 
@@ -615,7 +615,7 @@ STACK_OF(X509) *X509_STORE_CTX_get1_certs(X509_STORE_CTX *ctx,
         x = obj->data.x509;
         if (!X509_add_cert(sk, x, X509_ADD_FLAG_UP_REF)) {
             X509_STORE_unlock(store);
-            sk_X509_pop_free(sk, X509_free);
+            OSSL_STACK_OF_X509_free(sk);
             return NULL;
         }
     }

--- a/crypto/x509/x509_vfy.c
+++ b/crypto/x509/x509_vfy.c
@@ -138,7 +138,7 @@ static int lookup_cert_match(X509 **result, X509_STORE_CTX *ctx, X509 *x)
         else
             *result = xtmp;
     }
-    sk_X509_pop_free(certs, X509_free);
+    OSSL_STACK_OF_X509_free(certs);
     return ret;
 }
 
@@ -385,7 +385,7 @@ static STACK_OF(X509) *lookup_certs_sk(X509_STORE_CTX *ctx,
         x = sk_X509_value(ctx->other_ctx, i);
         if (X509_NAME_cmp(nm, X509_get_subject_name(x)) == 0) {
             if (!X509_add_cert(sk, x, X509_ADD_FLAG_UP_REF)) {
-                sk_X509_pop_free(sk, X509_free);
+                OSSL_STACK_OF_X509_free(sk);
                 ctx->error = X509_V_ERR_OUT_OF_MEM;
                 return NULL;
             }
@@ -2484,7 +2484,7 @@ void X509_STORE_CTX_cleanup(X509_STORE_CTX *ctx)
     }
     X509_policy_tree_free(ctx->tree);
     ctx->tree = NULL;
-    sk_X509_pop_free(ctx->chain, X509_free);
+    OSSL_STACK_OF_X509_free(ctx->chain);
     ctx->chain = NULL;
     CRYPTO_free_ex_data(CRYPTO_EX_INDEX_X509_STORE_CTX, ctx, &(ctx->ex_data));
     memset(&ctx->ex_data, 0, sizeof(ctx->ex_data));
@@ -2523,7 +2523,7 @@ void X509_STORE_CTX_set0_untrusted(X509_STORE_CTX *ctx, STACK_OF(X509) *sk)
 
 void X509_STORE_CTX_set0_verified_chain(X509_STORE_CTX *ctx, STACK_OF(X509) *sk)
 {
-    sk_X509_pop_free(ctx->chain, X509_free);
+    OSSL_STACK_OF_X509_free(ctx->chain);
     ctx->chain = sk;
 }
 

--- a/demos/cms/cms_denc.c
+++ b/demos/cms/cms_denc.c
@@ -46,8 +46,8 @@ int main(int argc, char **argv)
         goto err;
 
     /*
-     * sk_X509_pop_free will free up recipient STACK and its contents so set
-     * rcert to NULL so it isn't freed up twice.
+     * OSSL_STACK_OF_X509_free() free up recipient STACK and its contents
+     * so set rcert to NULL so it isn't freed up twice.
      */
     rcert = NULL;
 
@@ -88,7 +88,7 @@ int main(int argc, char **argv)
 
     CMS_ContentInfo_free(cms);
     X509_free(rcert);
-    sk_X509_pop_free(recips, X509_free);
+    OSSL_STACK_OF_X509_free(recips);
     BIO_free(in);
     BIO_free(out);
     BIO_free(dout);

--- a/demos/cms/cms_enc.c
+++ b/demos/cms/cms_enc.c
@@ -47,8 +47,8 @@ int main(int argc, char **argv)
         goto err;
 
     /*
-     * sk_X509_pop_free will free up recipient STACK and its contents so set
-     * rcert to NULL so it isn't freed up twice.
+     * OSSL_STACK_OF_X509_free() will free up recipient STACK and its contents
+     * so set rcert to NULL so it isn't freed up twice.
      */
     rcert = NULL;
 
@@ -84,7 +84,7 @@ int main(int argc, char **argv)
 
     CMS_ContentInfo_free(cms);
     X509_free(rcert);
-    sk_X509_pop_free(recips, X509_free);
+    OSSL_STACK_OF_X509_free(recips);
     BIO_free(in);
     BIO_free(out);
     BIO_free(tbio);

--- a/demos/pkcs12/pkread.c
+++ b/demos/pkcs12/pkread.c
@@ -105,7 +105,7 @@ int main(int argc, char **argv)
     OPENSSL_free(name);
     X509_free(cert);
     EVP_PKEY_free(pkey);
-    sk_X509_pop_free(ca, X509_free);
+    OSSL_STACK_OF_X509_free(ca);
 
     return ret;
 }

--- a/demos/smime/smenc.c
+++ b/demos/smime/smenc.c
@@ -47,8 +47,8 @@ int main(int argc, char **argv)
         goto err;
 
     /*
-     * sk_X509_pop_free will free up recipient STACK and its contents so set
-     * rcert to NULL so it isn't freed up twice.
+     * OSSL_STACK_OF_X509_free() will free up recipient STACK and its contents
+     * so set rcert to NULL so it isn't freed up twice.
      */
     rcert = NULL;
 
@@ -82,7 +82,7 @@ int main(int argc, char **argv)
     }
     PKCS7_free(p7);
     X509_free(rcert);
-    sk_X509_pop_free(recips, X509_free);
+    OSSL_STACK_OF_X509_free(recips);
     BIO_free(in);
     BIO_free(out);
     BIO_free(tbio);

--- a/doc/man3/X509_STORE_CTX_get_error.pod
+++ b/doc/man3/X509_STORE_CTX_get_error.pod
@@ -72,7 +72,7 @@ verification is successful. Otherwise the returned chain may be incomplete or
 invalid.  The returned chain persists after the I<ctx> structure is freed.
 When it is no longer needed it should be free up using:
 
- sk_X509_pop_free(chain, X509_free);
+ OSSL_STACK_OF_X509_free(chain);
 
 X509_verify_cert_error_string() returns a human readable error string for
 verification error I<n>.

--- a/doc/man3/X509_new.pod
+++ b/doc/man3/X509_new.pod
@@ -4,7 +4,9 @@
 
 X509_new, X509_new_ex,
 X509_free, X509_up_ref,
-X509_chain_up_ref - X509 certificate ASN1 allocation functions
+X509_chain_up_ref,
+OSSL_STACK_OF_X509_free
+- X509 certificate ASN1 allocation and deallocation functions
 
 =head1 SYNOPSIS
 
@@ -15,6 +17,7 @@ X509_chain_up_ref - X509 certificate ASN1 allocation functions
  void X509_free(X509 *a);
  int X509_up_ref(X509 *a);
  STACK_OF(X509) *X509_chain_up_ref(STACK_OF(X509) *x);
+ void OSSL_STACK_OF_X509_free(STACK_OF(X509) *certs);
 
 =head1 DESCRIPTION
 
@@ -40,6 +43,9 @@ X509_up_ref() increments the reference count of B<a>.
 X509_chain_up_ref() increases the reference count of all certificates in
 chain B<x> and returns a copy of the stack, or an empty stack if B<a> is NULL.
 
+OSSL_STACK_OF_X509_free() deallocates the given list of pointers to
+certificates after calling X509_free() on all its elements.
+
 =head1 NOTES
 
 The function X509_up_ref() if useful if a certificate structure is being
@@ -60,6 +66,8 @@ Otherwise it returns a pointer to the newly allocated structure.
 X509_up_ref() returns 1 for success and 0 for failure.
 
 X509_chain_up_ref() returns a copy of the stack or NULL if an error occurred.
+
+OSSL_STACK_OF_X509_free() has no return value.
 
 =head1 SEE ALSO
 
@@ -82,7 +90,9 @@ L<X509_verify_cert(3)>
 
 =head1 HISTORY
 
-The function X509_new_ex() was added in OpenSSL 3.0.
+X509_new_ex() was added in OpenSSL 3.0.
+
+OSSL_STACK_OF_X509_free() was added in OpenSSL 3.1.
 
 =head1 COPYRIGHT
 

--- a/engines/e_loader_attic.c
+++ b/engines/e_loader_attic.c
@@ -375,7 +375,7 @@ static OSSL_STORE_INFO *try_decode_PKCS12(const char *pem_name,
                 }
                 EVP_PKEY_free(pkey);
                 X509_free(cert);
-                sk_X509_pop_free(chain, X509_free);
+                OSSL_STACK_OF_X509_free(chain);
                 store_info_free(osi_pkey);
                 store_info_free(osi_cert);
                 store_info_free(osi_ca);

--- a/include/openssl/x509.h.in
+++ b/include/openssl/x509.h.in
@@ -763,6 +763,7 @@ int X509_chain_check_suiteb(int *perror_depth,
                             X509 *x, STACK_OF(X509) *chain,
                             unsigned long flags);
 int X509_CRL_check_suiteb(X509_CRL *crl, EVP_PKEY *pk, unsigned long flags);
+void OSSL_STACK_OF_X509_free(STACK_OF(X509) *certs);
 STACK_OF(X509) *X509_chain_up_ref(STACK_OF(X509) *chain);
 
 int X509_issuer_and_serial_cmp(const X509 *a, const X509 *b);

--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -3956,7 +3956,7 @@ long ssl3_ctx_ctrl(SSL_CTX *ctx, int cmd, long larg, void *parg)
         break;
 
     case SSL_CTRL_CLEAR_EXTRA_CHAIN_CERTS:
-        sk_X509_pop_free(ctx->extra_certs, X509_free);
+        OSSL_STACK_OF_X509_free(ctx->extra_certs);
         ctx->extra_certs = NULL;
         break;
 

--- a/ssl/ssl_cert.c
+++ b/ssl/ssl_cert.c
@@ -212,7 +212,7 @@ void ssl_cert_clear_certs(CERT *c)
         cpk->x509 = NULL;
         EVP_PKEY_free(cpk->privatekey);
         cpk->privatekey = NULL;
-        sk_X509_pop_free(cpk->chain, X509_free);
+        OSSL_STACK_OF_X509_free(cpk->chain);
         cpk->chain = NULL;
         OPENSSL_free(cpk->serverinfo);
         cpk->serverinfo = NULL;
@@ -264,7 +264,7 @@ int ssl_cert_set0_chain(SSL *s, SSL_CTX *ctx, STACK_OF(X509) *chain)
             return 0;
         }
     }
-    sk_X509_pop_free(cpk->chain, X509_free);
+    OSSL_STACK_OF_X509_free(cpk->chain);
     cpk->chain = chain;
     return 1;
 }
@@ -278,7 +278,7 @@ int ssl_cert_set1_chain(SSL *s, SSL_CTX *ctx, STACK_OF(X509) *chain)
     if (!dchain)
         return 0;
     if (!ssl_cert_set0_chain(s, ctx, dchain)) {
-        sk_X509_pop_free(dchain, X509_free);
+        OSSL_STACK_OF_X509_free(dchain);
         return 0;
     }
     return 1;
@@ -440,7 +440,7 @@ int ssl_verify_cert_chain(SSL *s, STACK_OF(X509) *sk)
     }
 
     s->verify_result = X509_STORE_CTX_get_error(ctx);
-    sk_X509_pop_free(s->verified_chain, X509_free);
+    OSSL_STACK_OF_X509_free(s->verified_chain);
     s->verified_chain = NULL;
     if (X509_STORE_CTX_get0_chain(ctx) != NULL) {
         s->verified_chain = X509_STORE_CTX_get1_chain(ctx);
@@ -940,12 +940,12 @@ int ssl_build_cert_chain(SSL *s, SSL_CTX *ctx, int flags)
         rv = ssl_security_cert(s, ctx, x, 0, 0);
         if (rv != 1) {
             ERR_raise(ERR_LIB_SSL, rv);
-            sk_X509_pop_free(chain, X509_free);
+            OSSL_STACK_OF_X509_free(chain);
             rv = 0;
             goto err;
         }
     }
-    sk_X509_pop_free(cpk->chain, X509_free);
+    OSSL_STACK_OF_X509_free(cpk->chain);
     cpk->chain = chain;
     if (rv == 0)
         rv = 1;

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -172,7 +172,7 @@ static void dane_final(SSL_DANE *dane)
     sk_danetls_record_pop_free(dane->trecs, tlsa_free);
     dane->trecs = NULL;
 
-    sk_X509_pop_free(dane->certs, X509_free);
+    OSSL_STACK_OF_X509_free(dane->certs);
     dane->certs = NULL;
 
     X509_free(dane->mcert);
@@ -1243,7 +1243,7 @@ void SSL_free(SSL *s)
     sk_X509_NAME_pop_free(s->ca_names, X509_NAME_free);
     sk_X509_NAME_pop_free(s->client_ca_names, X509_NAME_free);
 
-    sk_X509_pop_free(s->verified_chain, X509_free);
+    OSSL_STACK_OF_X509_free(s->verified_chain);
 
     if (s->method != NULL)
         s->method->ssl_free(s);
@@ -3430,7 +3430,7 @@ void SSL_CTX_free(SSL_CTX *a)
     ssl_cert_free(a->cert);
     sk_X509_NAME_pop_free(a->ca_names, X509_NAME_free);
     sk_X509_NAME_pop_free(a->client_ca_names, X509_NAME_free);
-    sk_X509_pop_free(a->extra_certs, X509_free);
+    OSSL_STACK_OF_X509_free(a->extra_certs);
     a->comp_methods = NULL;
 #ifndef OPENSSL_NO_SRTP
     sk_SRTP_PROTECTION_PROFILE_free(a->srtp_profiles);

--- a/ssl/ssl_rsa.c
+++ b/ssl/ssl_rsa.c
@@ -955,7 +955,7 @@ static int ssl_set_cert_and_key(SSL *ssl, SSL_CTX *ctx, X509 *x509, EVP_PKEY *pr
         }
     }
 
-    sk_X509_pop_free(c->pkeys[i].chain, X509_free);
+    OSSL_STACK_OF_X509_free(c->pkeys[i].chain);
     c->pkeys[i].chain = dup_chain;
 
     X509_free(c->pkeys[i].x509);

--- a/ssl/ssl_sess.c
+++ b/ssl/ssl_sess.c
@@ -828,7 +828,7 @@ void SSL_SESSION_free(SSL_SESSION *ss)
     OPENSSL_cleanse(ss->master_key, sizeof(ss->master_key));
     OPENSSL_cleanse(ss->session_id, sizeof(ss->session_id));
     X509_free(ss->peer);
-    sk_X509_pop_free(ss->peer_chain, X509_free);
+    OSSL_STACK_OF_X509_free(ss->peer_chain);
     OPENSSL_free(ss->ext.hostname);
     OPENSSL_free(ss->ext.tick);
 #ifndef OPENSSL_NO_PSK

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -1841,7 +1841,7 @@ MSG_PROCESS_RETURN tls_process_server_certificate(SSL *s, PACKET *pkt)
 
  err:
     X509_free(x);
-    sk_X509_pop_free(s->session->peer_chain, X509_free);
+    OSSL_STACK_OF_X509_free(s->session->peer_chain);
     s->session->peer_chain = NULL;
     return MSG_PROCESS_ERROR;
 }

--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -3554,7 +3554,7 @@ MSG_PROCESS_RETURN tls_process_client_certificate(SSL *s, PACKET *pkt)
     s->session->peer = sk_X509_shift(sk);
     s->session->verify_result = s->verify_result;
 
-    sk_X509_pop_free(s->session->peer_chain, X509_free);
+    OSSL_STACK_OF_X509_free(s->session->peer_chain);
     s->session->peer_chain = sk;
     sk = NULL;
 
@@ -3589,7 +3589,7 @@ MSG_PROCESS_RETURN tls_process_client_certificate(SSL *s, PACKET *pkt)
 
  err:
     X509_free(x);
-    sk_X509_pop_free(sk, X509_free);
+    OSSL_STACK_OF_X509_free(sk);
     return ret;
 }
 

--- a/test/cmp_client_test.c
+++ b/test/cmp_client_test.c
@@ -116,7 +116,7 @@ static int execute_exec_certrequest_ses_test(CMP_SES_TEST_FIXTURE *fixture)
         STACK_OF(X509) *caPubs = OSSL_CMP_CTX_get1_caPubs(fixture->cmp_ctx);
         int ret = TEST_int_eq(STACK_OF_X509_cmp(fixture->caPubs, caPubs), 0);
 
-        sk_X509_pop_free(caPubs, X509_free);
+        OSSL_STACK_OF_X509_free(caPubs);
         return ret;
     }
     return 1;

--- a/test/cmp_ctx_test.c
+++ b/test/cmp_ctx_test.c
@@ -59,7 +59,7 @@ static STACK_OF(X509) *sk_X509_new_1(void)
 
 static void sk_X509_pop_X509_free(STACK_OF(X509) *sk)
 {
-    sk_X509_pop_free(sk, X509_free);
+    OSSL_STACK_OF_X509_free(sk);
 }
 
 static int execute_CTX_reinit_test(OSSL_CMP_CTX_TEST_FIXTURE *fixture)

--- a/test/cmp_protect_test.c
+++ b/test/cmp_protect_test.c
@@ -340,7 +340,7 @@ static int execute_cmp_build_cert_chain_test(CMP_PROTECT_TEST_FIXTURE *fixture)
     if (TEST_ptr(chain)) {
         /* Check whether chain built is equal to the expected one */
         ret = TEST_int_eq(0, STACK_OF_X509_cmp(chain, fixture->chain));
-        sk_X509_pop_free(chain, X509_free);
+        OSSL_STACK_OF_X509_free(chain);
     }
     if (!ret)
         return 0;
@@ -355,7 +355,7 @@ static int execute_cmp_build_cert_chain_test(CMP_PROTECT_TEST_FIXTURE *fixture)
         if (ret && chain != NULL) {
             /* Check whether chain built is equal to the expected one */
             ret = TEST_int_eq(0, STACK_OF_X509_cmp(chain, fixture->chain));
-            sk_X509_pop_free(chain, X509_free);
+            OSSL_STACK_OF_X509_free(chain);
         }
     }
     X509_STORE_free(store);
@@ -475,7 +475,7 @@ static int execute_X509_STORE_test(CMP_PROTECT_TEST_FIXTURE *fixture)
     res = 1;
  err:
     X509_STORE_free(store);
-    sk_X509_pop_free(sk, X509_free);
+    OSSL_STACK_OF_X509_free(sk);
     return res;
 
 }

--- a/test/crltest.c
+++ b/test/crltest.c
@@ -264,7 +264,7 @@ static int verify(X509 *leaf, X509 *root, STACK_OF(X509_CRL) *crls,
     status = X509_verify_cert(ctx) == 1 ? X509_V_OK
                                         : X509_STORE_CTX_get_error(ctx);
 err:
-    sk_X509_pop_free(roots, X509_free);
+    OSSL_STACK_OF_X509_free(roots);
     sk_X509_CRL_pop_free(crls, X509_CRL_free);
     X509_VERIFY_PARAM_free(param);
     X509_STORE_CTX_free(ctx);

--- a/test/danetest.c
+++ b/test/danetest.c
@@ -143,7 +143,7 @@ err:
     OPENSSL_free(name);
     OPENSSL_free(header);
     OPENSSL_free(data);
-    sk_X509_pop_free(chain, X509_free);
+    OSSL_STACK_OF_X509_free(chain);
     return NULL;
 }
 
@@ -344,7 +344,7 @@ static int test_tlsafile(SSL_CTX *ctx, const char *base_name,
         }
 
         ok = verify_chain(ssl, chain);
-        sk_X509_pop_free(chain, X509_free);
+        OSSL_STACK_OF_X509_free(chain);
         err = SSL_get_verify_result(ssl);
         /*
          * Peek under the hood, normally TLSA match data is hidden when

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -8038,7 +8038,7 @@ static int cert_cb(SSL *s, void *arg)
     EVP_PKEY_free(pkey);
     X509_free(x509);
     X509_free(rootx);
-    sk_X509_pop_free(chain, X509_free);
+    OSSL_STACK_OF_X509_free(chain);
     return ret;
 }
 

--- a/test/testutil/load.c
+++ b/test/testutil/load.c
@@ -49,7 +49,7 @@ STACK_OF(X509) *load_certs_pem(const char *file)
     do {
         x = PEM_read_bio_X509(bio, NULL, 0, NULL);
         if (x != NULL && !sk_X509_push(certs, x)) {
-            sk_X509_pop_free(certs, X509_free);
+            OSSL_STACK_OF_X509_free(certs);
             BIO_free(bio);
             return NULL;
         } else if (x == NULL) {

--- a/test/verify_extra_test.c
+++ b/test/verify_extra_test.c
@@ -94,7 +94,7 @@ static int test_alt_chains_cert_forgery(void)
  err:
     X509_STORE_CTX_free(sctx);
     X509_free(x);
-    sk_X509_pop_free(untrusted, X509_free);
+    OSSL_STACK_OF_X509_free(untrusted);
     X509_STORE_free(store);
     return ret;
 }

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5425,3 +5425,4 @@ ASN1_item_d2i_ex                        5552	3_0_0	EXIST::FUNCTION:
 ASN1_TIME_print_ex                      5553	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_get0_provider                  5554	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_CTX_get0_provider              5555	3_0_0	EXIST::FUNCTION:
+OSSL_STACK_OF_X509_free                 ?	3_1_0	EXIST::FUNCTION:


### PR DESCRIPTION
As discussed in https://github.com/openssl/openssl/pull/17284#discussion_r770127185.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
