### PR TITLE
HTTP client: Work around HTTPS proxy use bug due to callback design flaw

### DIFF
--- a/apps/cmp.c
+++ b/apps/cmp.c
@@ -1926,15 +1926,18 @@ static int setup_client_ctx(OSSL_CMP_CTX *ctx, ENGINE *engine)
                 goto err;
             }
         }
+
         if ((info = OPENSSL_zalloc(sizeof(*info))) == NULL)
             goto err;
         (void)OSSL_CMP_CTX_set_http_cb_arg(ctx, info);
         /* info will be freed along with CMP ctx */
         info->server = opt_server;
         info->port = server_port;
-        info->use_proxy = opt_proxy != NULL;
+        /* workaround for callback design flaw, see #17088: */
+        info->use_proxy = proxy_host != NULL;
         info->timeout = OSSL_CMP_CTX_get_option(ctx, OSSL_CMP_OPT_MSG_TIMEOUT);
         info->ssl_ctx = setup_ssl_ctx(ctx, host, engine);
+
         if (info->ssl_ctx == NULL)
             goto err;
         (void)OSSL_CMP_CTX_set_http_cb(ctx, app_http_tls_cb);

--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -2470,7 +2470,7 @@ BIO *app_http_tls_cb(BIO *bio, void *arg, int connect, int detail)
         SSL *ssl;
         BIO *sbio = NULL;
 
-        /* TODO adapt after fixing callback design flaw, see #17088 */
+        /* adapt after fixing callback design flaw, see #17088 */
         if ((info->use_proxy
              && !OSSL_HTTP_proxy_connect(bio, info->server, info->port,
                                          NULL, NULL, /* no proxy credentials */
@@ -2483,7 +2483,7 @@ BIO *app_http_tls_cb(BIO *bio, void *arg, int connect, int detail)
             return NULL;
         }
 
-        /* TODO adapt after fixing callback design flaw, see #17088 */
+        /* adapt after fixing callback design flaw, see #17088 */
         SSL_set_tlsext_host_name(ssl, info->server); /* not critical to do */
 
         SSL_set_connect_state(ssl);

--- a/crypto/http/http_client.c
+++ b/crypto/http/http_client.c
@@ -946,7 +946,7 @@ OSSL_HTTP_REQ_CTX *OSSL_HTTP_open(const char *server, const char *port,
     }
     /* now overall_timeout is guaranteed to be >= 0 */
 
-    /* TODO adapt in order to fix callback design flaw, see #176088 */
+    /* adapt in order to fix callback design flaw, see #17088 */
     /* callback can be used to wrap or prepend TLS session */
     if (bio_update_fn != NULL) {
         BIO *orig_bio = cbio;

--- a/crypto/http/http_client.c
+++ b/crypto/http/http_client.c
@@ -946,6 +946,7 @@ OSSL_HTTP_REQ_CTX *OSSL_HTTP_open(const char *server, const char *port,
     }
     /* now overall_timeout is guaranteed to be >= 0 */
 
+    /* TODO adapt in order to fix callback design flaw, see #176088 */
     /* callback can be used to wrap or prepend TLS session */
     if (bio_update_fn != NULL) {
         BIO *orig_bio = cbio;


### PR DESCRIPTION
See discussion in #17088, where the real solution was postponed to 4.0.

This PR preliminarily fixes the issue that the HTTP(S) proxy environment variables were neglected when determining whether a proxy should be used for HTTPS.
