### PR TITLE
namemap: handle a NULL return when looking for a non-legacy cipher/MD

### DIFF
--- a/crypto/core_namemap.c
+++ b/crypto/core_namemap.c
@@ -409,14 +409,16 @@ static void get_legacy_cipher_names(const OBJ_NAME *on, void *arg)
 {
     const EVP_CIPHER *cipher = (void *)OBJ_NAME_get(on->name, on->type);
 
-    get_legacy_evp_names(NID_undef, EVP_CIPHER_get_type(cipher), NULL, arg);
+    if (cipher != NULL)
+        get_legacy_evp_names(NID_undef, EVP_CIPHER_get_type(cipher), NULL, arg);
 }
 
 static void get_legacy_md_names(const OBJ_NAME *on, void *arg)
 {
     const EVP_MD *md = (void *)OBJ_NAME_get(on->name, on->type);
 
-    get_legacy_evp_names(0, EVP_MD_get_type(md), NULL, arg);
+    if (md != NULL)
+        get_legacy_evp_names(0, EVP_MD_get_type(md), NULL, arg);
 }
 
 static void get_legacy_pkey_meth_names(const EVP_PKEY_ASN1_METHOD *ameth,


### PR DESCRIPTION
Fixes #17313

It's not clear how to write a reproducer for this.


- [ ] documentation is added or updated
- [ ] tests are added or updated
