### PR TITLE
Add support for BSD-riscv64 target to 3.0

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1062,6 +1062,13 @@ my %targets = (
         perlasm_scheme   => "elf",
     },
 
+    # riscv64 below refers to contemporary RISCV Architecture
+    # specifications,
+    "BSD-riscv64" => {
+        inherit_from     => [ "BSD-generic64"],
+        perlasm_scheme   => "linux64",
+    },
+
     "bsdi-elf-gcc" => {
         inherit_from     => [ "BASE_unix" ],
         CC               => "gcc",

--- a/util/perl/OpenSSL/config.pm
+++ b/util/perl/OpenSSL/config.pm
@@ -741,6 +741,7 @@ EOF
                                     defines => [ 'L_ENDIAN' ] } ],
       [ 'powerpc64-.*-.*bsd.*',   { target => "BSD-generic64",
                                     defines => [ 'B_ENDIAN' ] } ],
+      [ 'riscv64-.*-.*bsd.*',     { target => "BSD-riscv64" } ],
       [ 'sparc64-.*-.*bsd.*',     { target => "BSD-sparc64" } ],
       [ 'ia64-.*-.*bsd.*',        { target => "BSD-ia64" } ],
       [ 'x86_64-.*-dragonfly.*',  { target => "BSD-x86_64" } ],


### PR DESCRIPTION
Add support for BSD-riscv64 target to 3.0 branch.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
