### PR TITLE
Add -verbose/-quiet flags to dhparam

### DIFF
--- a/apps/ca.c
+++ b/apps/ca.c
@@ -154,7 +154,7 @@ typedef enum OPTION_choice {
     OPT_CRLDAYS, OPT_CRLHOURS, OPT_CRLSEC,
     OPT_INFILES, OPT_SS_CERT, OPT_SPKAC, OPT_REVOKE, OPT_VALID,
     OPT_EXTENSIONS, OPT_EXTFILE, OPT_STATUS, OPT_UPDATEDB, OPT_CRLEXTS,
-    OPT_RAND_SERIAL,
+    OPT_RAND_SERIAL, OPT_QUIET,
     OPT_R_ENUM, OPT_PROV_ENUM,
     /* Do not change the order here; see related case statements below */
     OPT_CRL_REASON, OPT_CRL_HOLD, OPT_CRL_COMPROMISE, OPT_CRL_CA_COMPROMISE
@@ -166,6 +166,7 @@ const OPTIONS ca_options[] = {
     OPT_SECTION("General"),
     {"help", OPT_HELP, '-', "Display this summary"},
     {"verbose", OPT_VERBOSE, '-', "Verbose output during processing"},
+    {"quiet", OPT_QUIET, '-', "Terse output during processing"},
     {"outdir", OPT_OUTDIR, '/', "Where to put output cert"},
     {"in", OPT_IN, '<', "The input cert request(s)"},
     {"inform", OPT_INFORM, 'F', "CSR input format (DER or PEM); default PEM"},
@@ -331,6 +332,9 @@ opthelp:
             break;
         case OPT_VERBOSE:
             verbose = 1;
+            break;
+        case OPT_QUIET:
+            verbose = 0;
             break;
         case OPT_CONFIG:
             configfile = opt_arg();

--- a/apps/dhparam.c
+++ b/apps/dhparam.c
@@ -32,11 +32,13 @@
 
 static EVP_PKEY *dsa_to_dh(EVP_PKEY *dh);
 
+static int verbose = 1;
+
 typedef enum OPTION_choice {
     OPT_COMMON,
     OPT_INFORM, OPT_OUTFORM, OPT_IN, OPT_OUT,
     OPT_ENGINE, OPT_CHECK, OPT_TEXT, OPT_NOOUT,
-    OPT_DSAPARAM, OPT_2, OPT_3, OPT_5,
+    OPT_DSAPARAM, OPT_2, OPT_3, OPT_5, OPT_VERBOSE, OPT_QUIET,
     OPT_R_ENUM, OPT_PROV_ENUM
 } OPTION_CHOICE;
 
@@ -66,6 +68,8 @@ const OPTIONS dhparam_options[] = {
     {"2", OPT_2, '-', "Generate parameters using 2 as the generator value"},
     {"3", OPT_3, '-', "Generate parameters using 3 as the generator value"},
     {"5", OPT_5, '-', "Generate parameters using 5 as the generator value"},
+    {"verbose", OPT_VERBOSE, '-', "Verbose output"},
+    {"quiet", OPT_QUIET, '-', "Terse output"},
 
     OPT_R_OPTIONS,
     OPT_PROV_OPTIONS,
@@ -137,6 +141,12 @@ int dhparam_main(int argc, char **argv)
         case OPT_NOOUT:
             noout = 1;
             break;
+        case OPT_VERBOSE:
+            verbose = 1;
+            break;
+        case OPT_QUIET:
+            verbose = 0;
+            break;
         case OPT_R_CASES:
             if (!opt_rand(o))
                 goto end;
@@ -187,11 +197,13 @@ int dhparam_main(int argc, char **argv)
                         alg);
             goto end;
         }
-        EVP_PKEY_CTX_set_cb(ctx, progress_cb);
         EVP_PKEY_CTX_set_app_data(ctx, bio_err);
-        BIO_printf(bio_err,
-                    "Generating %s parameters, %d bit long %sprime\n",
-                    alg, num, dsaparam ? "" : "safe ");
+        if (verbose) {
+            EVP_PKEY_CTX_set_cb(ctx, progress_cb);
+            BIO_printf(bio_err,
+                        "Generating %s parameters, %d bit long %sprime\n",
+                        alg, num, dsaparam ? "" : "safe ");
+        }
 
         if (EVP_PKEY_paramgen_init(ctx) <= 0) {
             BIO_printf(bio_err,

--- a/apps/dsaparam.c
+++ b/apps/dsaparam.c
@@ -27,7 +27,7 @@ static int verbose = 0;
 typedef enum OPTION_choice {
     OPT_COMMON,
     OPT_INFORM, OPT_OUTFORM, OPT_IN, OPT_OUT, OPT_TEXT,
-    OPT_NOOUT, OPT_GENKEY, OPT_ENGINE, OPT_VERBOSE,
+    OPT_NOOUT, OPT_GENKEY, OPT_ENGINE, OPT_VERBOSE, OPT_QUIET,
     OPT_R_ENUM, OPT_PROV_ENUM
 } OPTION_CHOICE;
 
@@ -50,6 +50,7 @@ const OPTIONS dsaparam_options[] = {
     {"text", OPT_TEXT, '-', "Print as text"},
     {"noout", OPT_NOOUT, '-', "No output"},
     {"verbose", OPT_VERBOSE, '-', "Verbose output"},
+    {"quiet", OPT_QUIET, '-', "Terse output"},
     {"genkey", OPT_GENKEY, '-', "Generate a DSA key"},
 
     OPT_R_OPTIONS,
@@ -120,6 +121,9 @@ int dsaparam_main(int argc, char **argv)
             break;
         case OPT_VERBOSE:
             verbose = 1;
+            break;
+        case OPT_QUIET:
+            verbose = 0;
             break;
         }
     }

--- a/apps/gendsa.c
+++ b/apps/gendsa.c
@@ -24,7 +24,7 @@
 
 typedef enum OPTION_choice {
     OPT_COMMON,
-    OPT_OUT, OPT_PASSOUT, OPT_ENGINE, OPT_CIPHER, OPT_VERBOSE,
+    OPT_OUT, OPT_PASSOUT, OPT_ENGINE, OPT_CIPHER, OPT_VERBOSE, OPT_QUIET,
     OPT_R_ENUM, OPT_PROV_ENUM
 } OPTION_CHOICE;
 
@@ -44,6 +44,7 @@ const OPTIONS gendsa_options[] = {
     OPT_PROV_OPTIONS,
     {"", OPT_CIPHER, '-', "Encrypt the output with any supported cipher"},
     {"verbose", OPT_VERBOSE, '-', "Verbose output"},
+    {"quiet", OPT_QUIET, '-', "Terse output"},
 
     OPT_PARAMETERS(),
     {"dsaparam-file", 0, 0, "File containing DSA parameters"},
@@ -97,6 +98,9 @@ int gendsa_main(int argc, char **argv)
             break;
         case OPT_VERBOSE:
             verbose = 1;
+            break;
+        case OPT_QUIET:
+            verbose = 0;
             break;
         }
     }

--- a/apps/genpkey.c
+++ b/apps/genpkey.c
@@ -15,7 +15,7 @@
 #include <openssl/err.h>
 #include <openssl/evp.h>
 
-static int quiet;
+static int verbose = 1;
 
 static int init_keygen_file(EVP_PKEY_CTX **pctx, const char *file, ENGINE *e,
                             OSSL_LIB_CTX *libctx, const char *propq);
@@ -23,7 +23,7 @@ typedef enum OPTION_choice {
     OPT_COMMON,
     OPT_ENGINE, OPT_OUTFORM, OPT_OUT, OPT_PASS, OPT_PARAMFILE,
     OPT_ALGORITHM, OPT_PKEYOPT, OPT_GENPARAM, OPT_TEXT, OPT_CIPHER,
-    OPT_QUIET, OPT_CONFIG,
+    OPT_VERBOSE, OPT_QUIET, OPT_CONFIG,
     OPT_PROV_ENUM
 } OPTION_CHOICE;
 
@@ -35,6 +35,7 @@ const OPTIONS genpkey_options[] = {
 #endif
     {"paramfile", OPT_PARAMFILE, '<', "Parameters file"},
     {"algorithm", OPT_ALGORITHM, 's', "The public key algorithm"},
+    {"verbose", OPT_VERBOSE, '-', "Output status while generating keys"},
     {"quiet", OPT_QUIET, '-', "Do not output status while generating keys"},
     {"pkeyopt", OPT_PKEYOPT, 's',
      "Set the public key algorithm option as opt:value"},
@@ -114,7 +115,10 @@ int genpkey_main(int argc, char **argv)
                 goto end;
             break;
         case OPT_QUIET:
-            quiet = 1;
+            verbose = 0;
+            break;
+        case OPT_VERBOSE:
+            verbose = 1;
             break;
         case OPT_GENPARAM:
             do_param = 1;
@@ -179,7 +183,7 @@ int genpkey_main(int argc, char **argv)
     if (out == NULL)
         goto end;
 
-    if (!quiet)
+    if (verbose)
         EVP_PKEY_CTX_set_cb(ctx, progress_cb);
     EVP_PKEY_CTX_set_app_data(ctx, bio_err);
 

--- a/apps/genrsa.c
+++ b/apps/genrsa.c
@@ -35,7 +35,7 @@ typedef enum OPTION_choice {
     OPT_3,
 #endif
     OPT_F4, OPT_ENGINE,
-    OPT_OUT, OPT_PASSOUT, OPT_CIPHER, OPT_PRIMES, OPT_VERBOSE,
+    OPT_OUT, OPT_PASSOUT, OPT_CIPHER, OPT_PRIMES, OPT_VERBOSE, OPT_QUIET,
     OPT_R_ENUM, OPT_PROV_ENUM, OPT_TRADITIONAL
 } OPTION_CHOICE;
 
@@ -60,6 +60,7 @@ const OPTIONS genrsa_options[] = {
     {"passout", OPT_PASSOUT, 's', "Output file pass phrase source"},
     {"primes", OPT_PRIMES, 'p', "Specify number of primes"},
     {"verbose", OPT_VERBOSE, '-', "Verbose output"},
+    {"quiet", OPT_QUIET, '-', "Terse output"},
     {"traditional", OPT_TRADITIONAL, '-',
      "Use traditional format for private keys"},
     {"", OPT_CIPHER, '-', "Encrypt the output with any supported cipher"},
@@ -138,6 +139,9 @@ opthelp:
         case OPT_VERBOSE:
             verbose = 1;
             break;
+        case OPT_QUIET:
+            verbose = 0;
+            break;
         case OPT_TRADITIONAL:
             traditional = 1;
             break;
@@ -178,7 +182,8 @@ opthelp:
     if (!init_gen_str(&ctx, "RSA", eng, 0, NULL, NULL))
         goto end;
 
-    EVP_PKEY_CTX_set_cb(ctx, progress_cb);
+    if (verbose)
+        EVP_PKEY_CTX_set_cb(ctx, progress_cb);
     EVP_PKEY_CTX_set_app_data(ctx, bio_err);
 
     if (EVP_PKEY_CTX_set_rsa_keygen_bits(ctx, num) <= 0) {

--- a/apps/genrsa.c
+++ b/apps/genrsa.c
@@ -29,8 +29,6 @@
 
 static int verbose = 0;
 
-static int genrsa_cb(EVP_PKEY_CTX *ctx);
-
 typedef enum OPTION_choice {
     OPT_COMMON,
 #ifndef OPENSSL_NO_DEPRECATED_3_0
@@ -180,7 +178,7 @@ opthelp:
     if (!init_gen_str(&ctx, "RSA", eng, 0, NULL, NULL))
         goto end;
 
-    EVP_PKEY_CTX_set_cb(ctx, genrsa_cb);
+    EVP_PKEY_CTX_set_cb(ctx, progress_cb);
     EVP_PKEY_CTX_set_app_data(ctx, bio_err);
 
     if (EVP_PKEY_CTX_set_rsa_keygen_bits(ctx, num) <= 0) {
@@ -243,24 +241,3 @@ opthelp:
     return ret;
 }
 
-static int genrsa_cb(EVP_PKEY_CTX *ctx)
-{
-    char c = '*';
-    BIO *b = EVP_PKEY_CTX_get_app_data(ctx);
-    int p = EVP_PKEY_CTX_get_keygen_info(ctx, 0);
-
-    if (!verbose)
-        return 1;
-
-    if (p == 0)
-        c = '.';
-    if (p == 1)
-        c = '+';
-    if (p == 2)
-        c = '*';
-    if (p == 3)
-        c = '\n';
-    BIO_write(b, &c, 1);
-    (void)BIO_flush(b);
-    return 1;
-}

--- a/doc/man1/openssl-ca.pod.in
+++ b/doc/man1/openssl-ca.pod.in
@@ -10,6 +10,7 @@ openssl-ca - sample minimal CA application
 B<openssl> B<ca>
 [B<-help>]
 [B<-verbose>]
+[B<-quiet>]
 [B<-config> I<filename>]
 [B<-name> I<section>]
 [B<-section> I<section>]
@@ -94,6 +95,11 @@ Print out a usage message.
 =item B<-verbose>
 
 This prints extra details about the operations being performed.
+
+=item B<-quiet>
+
+This prints fewer details about the operations being performed, which may
+be handy during batch scripts or pipelines.
 
 =item B<-config> I<filename>
 

--- a/doc/man1/openssl-dhparam.pod.in
+++ b/doc/man1/openssl-dhparam.pod.in
@@ -17,6 +17,8 @@ B<openssl dhparam>
 [B<-check>]
 [B<-noout>]
 [B<-text>]
+[B<-verbose>]
+[B<-quiet>]
 [B<-2>]
 [B<-3>]
 [B<-5>]
@@ -103,6 +105,16 @@ This option prints out the DH parameters in human readable form.
 {- $OpenSSL::safe::opt_r_item -}
 
 {- $OpenSSL::safe::opt_provider_item -}
+
+=item B<-verbose>
+
+This option enables the output of progress messages, which is handy when
+running commands interactively that may take a long time to execute.
+
+=item B<-quiet>
+
+This option suppresses the output of progress messages, which may be
+undesirable in batch scripts or pipelines.
 
 =back
 

--- a/doc/man1/openssl-dsaparam.pod.in
+++ b/doc/man1/openssl-dsaparam.pod.in
@@ -17,6 +17,7 @@ B<openssl dsaparam>
 [B<-text>]
 [B<-genkey>]
 [B<-verbose>]
+[B<-quiet>]
 {- $OpenSSL::safe::opt_r_synopsis -}
 {- $OpenSSL::safe::opt_engine_synopsis -}{- $OpenSSL::safe::opt_provider_synopsis -}
 [I<numbits>]
@@ -78,6 +79,11 @@ parameters.
 =item B<-verbose>
 
 Print extra details about the operations being performed.
+
+=item B<-quiet>
+
+Print fewer details about the operations being performed, which may
+be handy during batch scripts and pipelines.
 
 {- $OpenSSL::safe::opt_r_item -}
 

--- a/doc/man1/openssl-gendsa.pod.in
+++ b/doc/man1/openssl-gendsa.pod.in
@@ -24,6 +24,7 @@ B<openssl> B<gendsa>
 [B<-des3>]
 [B<-idea>]
 [B<-verbose>]
+[B<-quiet>]
 {- $OpenSSL::safe::opt_r_synopsis -}
 {- $OpenSSL::safe::opt_engine_synopsis -}{- $OpenSSL::safe::opt_provider_synopsis -}
 [I<paramfile>]
@@ -60,6 +61,11 @@ If none of these options is specified no encryption is used.
 =item B<-verbose>
 
 Print extra details about the operations being performed.
+
+=item B<-quiet>
+
+Print fewer details about the operations being performed, which may
+be handy during batch scripts and pipelines.
 
 {- $OpenSSL::safe::opt_r_item -}
 

--- a/doc/man1/openssl-genpkey.pod.in
+++ b/doc/man1/openssl-genpkey.pod.in
@@ -15,6 +15,7 @@ B<openssl> B<genpkey>
 [B<-help>]
 [B<-out> I<filename>]
 [B<-outform> B<DER>|B<PEM>]
+[B<-verbose>]
 [B<-quiet>]
 [B<-pass> I<arg>]
 [B<-I<cipher>>]
@@ -49,6 +50,10 @@ The output format, except when B<-genparam> is given; the default is B<PEM>.
 See L<openssl-format-options(1)> for details.
 
 When B<-genparam> is given, B<-outform> is ignored.
+
+=item B<-verbose>
+
+Output "status dots" while generating keys.
 
 =item B<-quiet>
 

--- a/doc/man1/openssl-genrsa.pod.in
+++ b/doc/man1/openssl-genrsa.pod.in
@@ -28,6 +28,7 @@ B<openssl> B<genrsa>
 [B<-3>]
 [B<-primes> I<num>]
 [B<-verbose>]
+[B<-quiet>]
 [B<-traditional>]
 {- $OpenSSL::safe::opt_r_synopsis -}
 {- $OpenSSL::safe::opt_engine_synopsis -}{- $OpenSSL::safe::opt_provider_synopsis -}
@@ -80,6 +81,11 @@ RSA key, which is defined in RFC 8017.
 =item B<-verbose>
 
 Print extra details about the operations being performed.
+
+=item B<-quiet>
+
+Print fewer details about the operations being performed, which may
+be handy during batch scripts and pipelines.
 
 =item B<-traditional>
 


### PR DESCRIPTION
Allow dhparam to run quietly in scripts, etc.

For other commands that took a -verbose flag already, also support -quiet.

For genpkey which only supported -quiet, add the -verbose flag.