### PR TITLE
Add support for BSD-riscv64 target to 1.1.1

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -988,6 +988,13 @@ my %targets = (
         perlasm_scheme   => "elf",
     },
 
+    # riscv64 below refers to contemporary RISCV Architecture
+    # specifications,
+    "BSD-riscv64" => {
+        inherit_from     => [ "BSD-generic64"],
+        perlasm_scheme   => "linux64",
+    },
+
     "bsdi-elf-gcc" => {
         inherit_from     => [ "BASE_unix", asm("x86_elf_asm") ],
         CC               => "gcc",

--- a/config
+++ b/config
@@ -704,6 +704,7 @@ case "$GUESSOS" in
 			__CNF_CPPFLAGS="$__CNF_CPPFLAGS -DL_ENDIAN" ;;
   powerpc64-*-*bsd*)	OUT="BSD-generic64";
 			__CNF_CPPFLAGS="$__CNF_CPPFLAGS -DB_ENDIAN" ;;
+  riscv64-*-*bsd*)	OUT="BSD-riscv64" ;;
   sparc64-*-*bsd*)	OUT="BSD-sparc64" ;;
   ia64-*-*bsd*)		OUT="BSD-ia64" ;;
   x86_64-*-dragonfly*)  OUT="BSD-x86_64" ;;


### PR DESCRIPTION
Reviewed-by: Tomas Mraz <tomas@openssl.org>
Reviewed-by: Ben Kaduk <kaduk@mit.edu>
Reviewed-by: Paul Dale <pauli@openssl.org>
(Merged from https://github.com/openssl/openssl/pull/17306)

(cherry picked from commit c2d1ad0e048dd3bfa60e6aa0b5ee343cc6d97a15)
(cherry picked from commit c9ede1ee2058f067274929e813e257394d0ef6bb)

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
