### PR TITLE
Statically link the legacy provider to endecode_test

### DIFF
--- a/crypto/build.info
+++ b/crypto/build.info
@@ -74,8 +74,8 @@ DEFINE[../providers/libfips.a]=$CPUIDDEF
 # already gets everything that the static libcrypto.a has, and doesn't need it
 # added again.
 IF[{- !$disabled{module} && !$disabled{shared} -}]
-  SOURCE[../providers/liblegacy.a]=$CPUID_COMMON
-  DEFINE[../providers/liblegacy.a]=$CPUIDDEF
+  SOURCE[../providers/legacy]=$CPUID_COMMON
+  DEFINE[../providers/legacy]=$CPUIDDEF
 ENDIF
 
 # Implementations are now spread across several libraries, so the CPUID define

--- a/test/build.info
+++ b/test/build.info
@@ -864,14 +864,17 @@ IF[{- !$disabled{tests} -}]
   DEPEND[hexstr_test]=../libcrypto.a libtestutil.a
 
   PROGRAMS{noinst}=endecode_test
-  DEFINE[endecode_test]=STATIC_LEGACY
-  SOURCE[endecode_test]=endecode_test.c helpers/predefined_dhparams.c \
-                        ../providers/legacyprov.c
-  INCLUDE[endecode_test]=.. ../include ../apps/include \
-                         ../providers/common/include \
-                         ../providers/implementations/include
-  DEPEND[endecode_test]=../libcrypto.a libtestutil.a ../providers/liblegacy.a \
-                        ../providers/libcommon.a
+  SOURCE[endecode_test]=endecode_test.c helpers/predefined_dhparams.c
+  INCLUDE[endecode_test]=.. ../include ../apps/include
+  DEPEND[endecode_test]=../libcrypto.a libtestutil.a
+  IF[{- !$disabled{module} && !$disabled{legacy} -}]
+    DEFINE[endecode_test]=STATIC_LEGACY
+    SOURCE[endecode_test]=../providers/legacyprov.c
+    INCLUDE[endecode_test]=../providers/common/include \
+                           ../providers/implementations/include
+    DEPEND[endecode_test]=../providers/liblegacy.a \
+                          ../providers/libcommon.a
+  ENDIF
 
   IF[{- !$disabled{'deprecated-3.0'} -}]
     PROGRAMS{noinst}=endecoder_legacy_test

--- a/test/build.info
+++ b/test/build.info
@@ -864,9 +864,14 @@ IF[{- !$disabled{tests} -}]
   DEPEND[hexstr_test]=../libcrypto.a libtestutil.a
 
   PROGRAMS{noinst}=endecode_test
-  SOURCE[endecode_test]=endecode_test.c helpers/predefined_dhparams.c
-  INCLUDE[endecode_test]=.. ../include ../apps/include
-  DEPEND[endecode_test]=../libcrypto.a libtestutil.a
+  DEFINE[endecode_test]=STATIC_LEGACY
+  SOURCE[endecode_test]=endecode_test.c helpers/predefined_dhparams.c \
+                        ../providers/legacyprov.c
+  INCLUDE[endecode_test]=.. ../include ../apps/include \
+                         ../providers/common/include \
+                         ../providers/implementations/include
+  DEPEND[endecode_test]=../libcrypto.a libtestutil.a ../providers/liblegacy.a \
+                        ../providers/libcommon.a
 
   IF[{- !$disabled{'deprecated-3.0'} -}]
     PROGRAMS{noinst}=endecoder_legacy_test

--- a/test/endecode_test.c
+++ b/test/endecode_test.c
@@ -26,7 +26,9 @@
 #include "helpers/predefined_dhparams.h"
 #include "testutil.h"
 
+#ifdef STATIC_LEGACY
 OSSL_provider_init_fn ossl_legacy_provider_init;
+#endif
 
 /* Extended test macros to allow passing file & line number */
 #define TEST_FL_ptr(a)               test_ptr(file, line, #a, a)
@@ -1307,6 +1309,7 @@ int setup_tests(void)
             return 0;
     }
 
+#ifdef STATIC_LEGACY
     /*
      * This test is always statically linked against libcrypto. We must not
      * attempt to load legacy.so that might be dynamically linked against
@@ -1314,6 +1317,7 @@ int setup_tests(void)
      */
     if (!OSSL_PROVIDER_add_builtin(testctx, "legacy", ossl_legacy_provider_init))
         return 0;
+#endif
 
     /* Separate provider/ctx for generating the test data */
     if (!TEST_ptr(keyctx = OSSL_LIB_CTX_new()))

--- a/test/endecode_test.c
+++ b/test/endecode_test.c
@@ -26,6 +26,8 @@
 #include "helpers/predefined_dhparams.h"
 #include "testutil.h"
 
+OSSL_provider_init_fn ossl_legacy_provider_init;
+
 /* Extended test macros to allow passing file & line number */
 #define TEST_FL_ptr(a)               test_ptr(file, line, #a, a)
 #define TEST_FL_mem_eq(a, m, b, n)   test_mem_eq(file, line, #a, #b, a, m, b, n)
@@ -1304,6 +1306,14 @@ int setup_tests(void)
         if (!test_get_libctx(&testctx, &nullprov, config_file, &deflprov, prov_name))
             return 0;
     }
+
+    /*
+     * This test is always statically linked against libcrypto. We must not
+     * attempt to load legacy.so that might be dynamically linked against
+     * libcrypto. Instead we use a built-in version of the legacy provider.
+     */
+    if (!OSSL_PROVIDER_add_builtin(testctx, "legacy", ossl_legacy_provider_init))
+        return 0;
 
     /* Separate provider/ctx for generating the test data */
     if (!TEST_ptr(keyctx = OSSL_LIB_CTX_new()))


### PR DESCRIPTION
We already statically link libcrypto to endecode_test even in a "shared"
build. This can cause problems on some platforms with tests that load the
legacy provider which is dynamically linked to libcrypto. Two versions of
libcrypto are then linked to the same executable which can lead to crashes.

Fixes #17059
