### PR TITLE
stack push retval in line with doc

### DIFF
--- a/crypto/stack/stack.c
+++ b/crypto/stack/stack.c
@@ -370,7 +370,7 @@ int OPENSSL_sk_find_all(OPENSSL_STACK *st, const void *data, int *pnum)
 int OPENSSL_sk_push(OPENSSL_STACK *st, const void *data)
 {
     if (st == NULL)
-        return -1;
+        return 0;
     return OPENSSL_sk_insert(st, data, st->num);
 }
 


### PR DESCRIPTION
Bringing stack push return value in line with other functions and documentation.

Fixes #17314 for master.