### PR TITLE
CMS, PKCS7, and CRMF: simplify use of `EVP_PKEY_decrypt()` by helper function

### DIFF
--- a/crypto/cmp/cmp_http.c
+++ b/crypto/cmp/cmp_http.c
@@ -44,7 +44,6 @@ static int keep_alive(int keep_alive, int body_type)
 
 /*
  * Send the PKIMessage req and on success return the response, else NULL.
- * Any previous error queue entries will likely be removed by ERR_clear_error().
  */
 OSSL_CMP_MSG *OSSL_CMP_MSG_http_perform(OSSL_CMP_CTX *ctx,
                                         const OSSL_CMP_MSG *req)

--- a/crypto/cms/cms_env.c
+++ b/crypto/cms/cms_env.c
@@ -615,23 +615,10 @@ static int cms_RecipientInfo_ktri_decrypt(CMS_ContentInfo *cms,
          * disable implicit rejection for RSA keys */
         EVP_PKEY_CTX_ctrl_str(ktri->pctx, "rsa_pkcs1_implicit_rejection", "0");
 
-    if (EVP_PKEY_decrypt(ktri->pctx, NULL, &eklen,
-                         ktri->encryptedKey->data,
-                         ktri->encryptedKey->length) <= 0)
+    if (evp_pkey_decrypt_alloc(ktri->pctx, &ek, &eklen, fixlen,
+                               ktri->encryptedKey->data,
+                               ktri->encryptedKey->length) <= 0)
         goto err;
-
-    ek = OPENSSL_malloc(eklen);
-    if (ek == NULL)
-        goto err;
-
-    if (EVP_PKEY_decrypt(ktri->pctx, ek, &eklen,
-                         ktri->encryptedKey->data,
-                         ktri->encryptedKey->length) <= 0
-            || eklen == 0
-            || (fixlen != 0 && eklen != fixlen)) {
-        ERR_raise(ERR_LIB_CMS, CMS_R_CMS_LIB);
-        goto err;
-    }
 
     ret = 1;
 

--- a/include/crypto/evp.h
+++ b/include/crypto/evp.h
@@ -952,4 +952,8 @@ int evp_md_get_number(const EVP_MD *md);
 int evp_rand_get_number(const EVP_RAND *rand);
 int evp_signature_get_number(const EVP_SIGNATURE *signature);
 
+int evp_pkey_decrypt_alloc(EVP_PKEY_CTX *ctx, unsigned char **outp,
+                           size_t *outlenp, size_t expected_outlen,
+                           const unsigned char *in, size_t inlen);
+
 #endif /* OSSL_CRYPTO_EVP_H */

--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -3050,8 +3050,7 @@ static int tls_process_cke_rsa(SSL_CONNECTION *s, PACKET *pkt)
     }
 
     /* Also cleanses rsa_decrypt (on success or failure) */
-    if (!ssl_generate_master_secret(s, rsa_decrypt,
-                                    SSL_MAX_MASTER_KEY_LENGTH, 0)) {
+    if (!ssl_generate_master_secret(s, rsa_decrypt, outlen, 0)) {
         /* SSLfatal() already called */
         goto err;
     }
@@ -3216,7 +3215,7 @@ static int tls_process_cke_gost(SSL_CONNECTION *s, PACKET *pkt)
     EVP_PKEY *client_pub_pkey = NULL, *pk = NULL;
     unsigned char premaster_secret[32];
     const unsigned char *start;
-    size_t outlen = 32, inlen;
+    size_t outlen = sizeof(premaster_secret), inlen;
     unsigned long alg_a;
     GOST_KX_MESSAGE *pKX = NULL;
     const unsigned char *ptr;
@@ -3291,8 +3290,7 @@ static int tls_process_cke_gost(SSL_CONNECTION *s, PACKET *pkt)
         goto err;
     }
     /* Generate master secret */
-    if (!ssl_generate_master_secret(s, premaster_secret,
-                                    sizeof(premaster_secret), 0)) {
+    if (!ssl_generate_master_secret(s, premaster_secret, outlen, 0)) {
         /* SSLfatal() already called */
         goto err;
     }
@@ -3321,7 +3319,7 @@ static int tls_process_cke_gost18(SSL_CONNECTION *s, PACKET *pkt)
     EVP_PKEY *pk = NULL;
     unsigned char premaster_secret[32];
     const unsigned char *start = NULL;
-    size_t outlen = 32, inlen = 0;
+    size_t outlen = sizeof(premaster_secret), inlen = 0;
     int ret = 0;
     int cipher_nid = ossl_gost18_cke_cipher_nid(s);
     SSL_CTX *sctx = SSL_CONNECTION_GET_CTX(s);
@@ -3375,8 +3373,7 @@ static int tls_process_cke_gost18(SSL_CONNECTION *s, PACKET *pkt)
         goto err;
     }
     /* Generate master secret */
-    if (!ssl_generate_master_secret(s, premaster_secret,
-         sizeof(premaster_secret), 0)) {
+    if (!ssl_generate_master_secret(s, premaster_secret, outlen, 0)) {
          /* SSLfatal() already called */
          goto err;
     }


### PR DESCRIPTION
Part of this has originally been carved out from #15283.
* Factor out common decryption pattern involving two calls of `EVP_PKEY_decrypt()` within libcrypto, where further improvements such as those as discussed in #17319 can done there, at just one place for all these uses.
*  `ssl/statem/statem_srvr.c`: clean up handling of `EVP_PKEY_decrypt()` outlen
* `OSSL_CRMF_ENCRYPTEDVALUE_get1_encCert()`: remove needless `constant_time_*`  and `ERR_clear_error()` calls, as discussed in https://github.com/openssl/openssl/pull/15283#pullrequestreview-836288625
* `cmp_http.c`: Remove obsolete comment w.r.t. `ERR_clear_error()`
