### PR TITLE
Use USE_SWAPCONTEXT by default on IA64.

### DIFF
--- a/crypto/async/arch/async_posix.h
+++ b/crypto/async/arch/async_posix.h
@@ -25,12 +25,14 @@
 #  define ASYNC_POSIX
 #  define ASYNC_ARCH
 
-#  ifdef __CET__
+#  if defined(__CET__) || defined(__ia64__)
 /*
  * When Intel CET is enabled, makecontext will create a different
  * shadow stack for each context.  async_fibre_swapcontext cannot
  * use _longjmp.  It must call swapcontext to swap shadow stack as
  * well as normal stack.
+ * On IA64 the register stack engine is not saved across setjmp/longjmp. Here
+ * swapcontext() performs correctly.
  */
 #   define USE_SWAPCONTEXT
 #  endif


### PR DESCRIPTION
On ia64 the use of setjmp()/ longjmp() has some portability issues and
requires often extra care. The use of it in the async interface led
to a failure in the test_async.t test since its introduction in 1.1.0
series.

Using swapcontext() unconditionally cures it.
swapcontext() has been removed from the specification since POSIX.1-2008
but this also the case for the still used setcontext() function.

Use the __CET__ code path unconditially, this is also less code/
possibilities to maintain and test.

Signed-off-by: Sebastian Andrzej Siewior <sebastian@breakpoint.cc>