### PR TITLE
Validate the category in OSSL_trace_end()

### DIFF
--- a/crypto/trace.c
+++ b/crypto/trace.c
@@ -496,6 +496,8 @@ void OSSL_trace_end(int category, BIO * channel)
     char *suffix = NULL;
 
     category = ossl_trace_get_category(category);
+    if (category < 0)
+        return;
     suffix = trace_channels[category].suffix;
     if (channel != NULL
         && ossl_assert(channel == current_channel)) {


### PR DESCRIPTION
OSSL_trace_end() should validate that the category it has been passed
by the caler is valid, and return immediately if not.

Fixes #17353
