### PR TITLE
Fix the symbol_presence test with a shlib_variant

### DIFF
--- a/test/recipes/01-test_symbol_presence.t
+++ b/test/recipes/01-test_symbol_presence.t
@@ -76,7 +76,7 @@ foreach my $libname (@libnames) {
                 # Drop the first space and everything following it
                 s| .*||;
                 # Drop OpenSSL dynamic version information if there is any
-                s|\@\@OPENSSL_[0-9._]+[a-z]?$||;
+                s|\@\@.+$||;
                 # Return the result
                 $_
             }


### PR DESCRIPTION
If a shlib_variant is used then the dynamic version information for
symbols will be different from what the symbol presence test was
expecting. We just make it more liberal about what it accepts as dynamic
version information.

Fixes #17366
