### PR TITLE
fix building failure when using -Wconditional-uninitialized

### DIFF
--- a/crypto/armcap.c
+++ b/crypto/armcap.c
@@ -65,7 +65,7 @@ size_t OPENSSL_rndrrs_bytes(unsigned char *buf, size_t len);
 
 static size_t OPENSSL_rndr_wrapper(size_t (*func)(unsigned char *, size_t), unsigned char *buf, size_t len)
 {
-    size_t buffer_size;
+    size_t buffer_size = 0;
     int i;
 
     for (i = 0; i < 8; i++) {


### PR DESCRIPTION
Use clang -Wconditional-uninitialized to build, the error "initialize
the variable 'buffer_size' to silence this warning" will be reported.
This fix initializes buffer_size to silence this warning.
