### PR TITLE
release s->s3.handshake_dgst on error path to prevent memory leak.

### DIFF
--- a/ssl/s3_enc.c
+++ b/ssl/s3_enc.c
@@ -385,12 +385,16 @@ int ssl3_digest_cached_records(SSL *s, int keep)
 
         md = ssl_handshake_md(s);
         if (md == NULL) {
+            EVP_MD_CTX_free(s->s3.handshake_dgst);
+            s->s3.handshake_dgst = NULL;
             SSLfatal(s, SSL_AD_INTERNAL_ERROR,
                      SSL_R_NO_SUITABLE_DIGEST_ALGORITHM);
             return 0;
         }
         if (!EVP_DigestInit_ex(s->s3.handshake_dgst, md, NULL)
             || !EVP_DigestUpdate(s->s3.handshake_dgst, hdata, hdatalen)) {
+            EVP_MD_CTX_free(s->s3.handshake_dgst);
+            s->s3.handshake_dgst = NULL;
             SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
             return 0;
         }


### PR DESCRIPTION
release s->s3.handshake_dgst on error path to prevent memory leak.