### PR TITLE
Fix X509_STORE_CTX_set_purpose()

### DIFF
--- a/crypto/x509/x509_vfy.c
+++ b/crypto/x509/x509_vfy.c
@@ -2230,6 +2230,12 @@ int X509_STORE_CTX_purpose_inherit(X509_STORE_CTX *ctx, int def_purpose,
     /* If purpose not set use default */
     if (purpose == 0)
         purpose = def_purpose;
+    /*
+     * If purpose is set but we don't have a default then set the default to
+     * the current purpose
+     */
+    else if (def_purpose == 0)
+        def_purpose = purpose;
     /* If we have a purpose then check it is valid */
     if (purpose != 0) {
         X509_PURPOSE *ptmp;
@@ -2242,11 +2248,6 @@ int X509_STORE_CTX_purpose_inherit(X509_STORE_CTX *ctx, int def_purpose,
         ptmp = X509_PURPOSE_get0(idx);
         if (ptmp->trust == X509_TRUST_DEFAULT) {
             idx = X509_PURPOSE_get_by_id(def_purpose);
-            /*
-             * XXX: In the two callers above def_purpose is always 0, which is
-             * not a known value, so idx will always be -1.  How is the
-             * X509_TRUST_DEFAULT case actually supposed to be handled?
-             */
             if (idx == -1) {
                 ERR_raise(ERR_LIB_X509, X509_R_UNKNOWN_PURPOSE_ID);
                 return 0;

--- a/test/recipes/70-test_verify_extra.t
+++ b/test/recipes/70-test_verify_extra.t
@@ -7,15 +7,11 @@
 # https://www.openssl.org/source/license.html
 
 
-use OpenSSL::Test qw/:DEFAULT srctop_file/;
+use OpenSSL::Test qw/:DEFAULT srctop_dir/;
 
 setup("test_verify_extra");
 
 plan tests => 1;
 
 ok(run(test(["verify_extra_test",
-             srctop_file("test", "certs", "rootCA.pem"),
-             srctop_file("test", "certs", "roots.pem"),
-             srctop_file("test", "certs", "untrusted.pem"),
-             srctop_file("test", "certs", "bad.pem"),
-             srctop_file("test", "certs", "sm2-csr.pem")])));
+             srctop_dir("test", "certs")])));

--- a/test/verify_extra_test.c
+++ b/test/verify_extra_test.c
@@ -16,11 +16,15 @@
 #include <openssl/err.h>
 #include "testutil.h"
 
-static const char *root_f;
-static const char *roots_f;
-static const char *untrusted_f;
-static const char *bad_f;
-static const char *req_f;
+static const char *certs_dir;
+static char *root_f = NULL;
+static char *roots_f = NULL;
+static char *untrusted_f = NULL;
+static char *bad_f = NULL;
+static char *req_f = NULL;
+static char *sroot_cert = NULL;
+static char *ca_cert = NULL;
+static char *ee_cert = NULL;
 
 #define load_cert_from_file(file) load_cert_pem(file, NULL)
 
@@ -98,8 +102,6 @@ static int test_alt_chains_cert_forgery(void)
     X509_STORE_free(store);
     return ret;
 }
-
-OPT_TEST_DECLARE_USAGE("roots.pem untrusted.pem bad.pem\n")
 
 static int test_distinguishing_id(void)
 {
@@ -219,6 +221,69 @@ static int test_store_ctx(void)
     return test_self_signed(bad_f, 0, 0);
 }
 
+static int test_purpose(int purpose, int expected)
+{
+    X509 *eecert = load_cert_from_file(ee_cert); /* may result in NULL */
+    X509 *untrcert = load_cert_from_file(ca_cert);
+    X509 *trcert = load_cert_from_file(sroot_cert);
+    STACK_OF(X509) *trusted = sk_X509_new_null();
+    STACK_OF(X509) *untrusted = sk_X509_new_null();
+    X509_STORE_CTX *ctx = X509_STORE_CTX_new();
+    int testresult = 0;
+
+    if (!TEST_ptr(eecert)
+            || !TEST_ptr(trusted)
+            || !TEST_ptr(untrusted)
+            || !TEST_ptr(ctx))
+        goto err;
+
+
+    if (!TEST_true(sk_X509_push(trusted, trcert))
+            || !TEST_true(sk_X509_push(untrusted, untrcert)))
+        goto err;
+
+    if (!TEST_true(X509_STORE_CTX_init(ctx, NULL, eecert, untrusted)))
+        goto err;
+    untrusted = NULL;
+
+    if (!TEST_true(X509_STORE_CTX_set_purpose(ctx, purpose)))
+        goto err;
+
+    X509_STORE_CTX_set0_trusted_stack(ctx, trusted);
+    trusted = NULL;
+
+    if (!TEST_int_eq(X509_verify_cert(ctx), expected))
+        goto err;
+
+    testresult = 1;
+ err:
+    sk_X509_pop_free(trusted, X509_free);
+    sk_X509_pop_free(untrusted, X509_free);
+    X509_STORE_CTX_free(ctx);
+    X509_free(eecert);
+    X509_free(untrcert);
+    X509_free(trcert);
+    return testresult;
+}
+
+static int test_purpose_ssl_client(void)
+{
+    return test_purpose(X509_PURPOSE_SSL_CLIENT, 0);
+}
+
+static int test_purpose_ssl_server(void)
+{
+    return test_purpose(X509_PURPOSE_SSL_SERVER, 1);
+}
+
+static int test_purpose_any(void)
+{
+    return test_purpose(X509_PURPOSE_ANY, 1);
+}
+
+
+OPT_TEST_DECLARE_USAGE("certs-dir\n")
+
 int setup_tests(void)
 {
     if (!test_skip_common_options()) {
@@ -226,12 +291,18 @@ int setup_tests(void)
         return 0;
     }
 
-    if (!TEST_ptr(root_f = test_get_argument(0))
-            || !TEST_ptr(roots_f = test_get_argument(1))
-            || !TEST_ptr(untrusted_f = test_get_argument(2))
-            || !TEST_ptr(bad_f = test_get_argument(3))
-            || !TEST_ptr(req_f = test_get_argument(4)))
+    if (!TEST_ptr(certs_dir = test_get_argument(0)))
         return 0;
+
+    if (!TEST_ptr(root_f = test_mk_file_path(certs_dir, "rootCA.pem"))
+            || !TEST_ptr(roots_f = test_mk_file_path(certs_dir, "roots.pem"))
+            || !TEST_ptr(untrusted_f = test_mk_file_path(certs_dir, "untrusted.pem"))
+            || !TEST_ptr(bad_f = test_mk_file_path(certs_dir, "bad.pem"))
+            || !TEST_ptr(req_f = test_mk_file_path(certs_dir, "sm2-csr.pem"))
+            || !TEST_ptr(sroot_cert = test_mk_file_path(certs_dir, "sroot-cert.pem"))
+            || !TEST_ptr(ca_cert = test_mk_file_path(certs_dir, "ca-cert.pem"))
+            || !TEST_ptr(ee_cert = test_mk_file_path(certs_dir, "ee-cert.pem")))
+        goto err;
 
     ADD_TEST(test_alt_chains_cert_forgery);
     ADD_TEST(test_store_ctx);
@@ -240,5 +311,23 @@ int setup_tests(void)
     ADD_TEST(test_self_signed_good);
     ADD_TEST(test_self_signed_bad);
     ADD_TEST(test_self_signed_error);
+    ADD_TEST(test_purpose_ssl_client);
+    ADD_TEST(test_purpose_ssl_server);
+    ADD_TEST(test_purpose_any);
     return 1;
+ err:
+    cleanup_tests();
+    return 0;
+}
+
+void cleanup_tests(void)
+{
+    OPENSSL_free(root_f);
+    OPENSSL_free(roots_f);
+    OPENSSL_free(untrusted_f);
+    OPENSSL_free(bad_f);
+    OPENSSL_free(req_f);
+    OPENSSL_free(sroot_cert);
+    OPENSSL_free(ca_cert);
+    OPENSSL_free(ee_cert);
 }


### PR DESCRIPTION
This function was previously failing if you attempted to set a purpose of X509_PURPOSE_ANY.

Fixes #17367