### PR TITLE
properly free the resource from CRYPTO_malloc

### DIFF
--- a/crypto/x509/x509_req.c
+++ b/crypto/x509/x509_req.c
@@ -56,6 +56,7 @@ X509_REQ *X509_to_X509_REQ(X509 *x, EVP_PKEY *pkey, const EVP_MD *md)
     }
     return ret;
  err:
+    OPENSSL_free(ri->version->data);
     X509_REQ_free(ret);
     return NULL;
 }

--- a/crypto/x509/x509_req.c
+++ b/crypto/x509/x509_req.c
@@ -29,7 +29,7 @@ X509_REQ *X509_to_X509_REQ(X509 *x, EVP_PKEY *pkey, const EVP_MD *md)
     ret = X509_REQ_new_ex(x->libctx, x->propq);
     if (ret == NULL) {
         ERR_raise(ERR_LIB_X509, ERR_R_MALLOC_FAILURE);
-        goto err;
+        return NULL;
     }
 
     ri = &ret->req_info;

--- a/crypto/x509/x509_req.c
+++ b/crypto/x509/x509_req.c
@@ -29,7 +29,7 @@ X509_REQ *X509_to_X509_REQ(X509 *x, EVP_PKEY *pkey, const EVP_MD *md)
     ret = X509_REQ_new_ex(x->libctx, x->propq);
     if (ret == NULL) {
         ERR_raise(ERR_LIB_X509, ERR_R_MALLOC_FAILURE);
-        return NULL;
+        goto err;
     }
 
     ri = &ret->req_info;
@@ -56,7 +56,6 @@ X509_REQ *X509_to_X509_REQ(X509 *x, EVP_PKEY *pkey, const EVP_MD *md)
     }
     return ret;
  err:
-    OPENSSL_free(ri->version->data);
     X509_REQ_free(ret);
     return NULL;
 }

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -3187,7 +3187,7 @@ static int tls_construct_cke_gost18(SSL *s, WPACKET *pkt)
     if (peer_cert == NULL) {
         SSLfatal(s, SSL_AD_HANDSHAKE_FAILURE,
                  SSL_R_NO_GOST_CERTIFICATE_SENT_BY_PEER);
-        return 0;
+        goto err;
     }
 
     pkey_ctx = EVP_PKEY_CTX_new_from_pkey(s->ctx->libctx,
@@ -3195,7 +3195,7 @@ static int tls_construct_cke_gost18(SSL *s, WPACKET *pkt)
                                           s->ctx->propq);
     if (pkey_ctx == NULL) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_MALLOC_FAILURE);
-        return 0;
+        goto err;
     }
 
     if (EVP_PKEY_encrypt_init(pkey_ctx) <= 0) {


### PR DESCRIPTION
properly free the resource from CRYPTO_malloc. In statem_clnt.c:3174 `pms` is allocated by `OPENSSL_malloc()`.