### PR TITLE
free the resource from EVP_MD_CTX_new()

### DIFF
--- a/ssl/record/ssl3_record.c
+++ b/ssl/record/ssl3_record.c
@@ -1450,8 +1450,10 @@ int tls1_mac(SSL *ssl, SSL3_RECORD *rec, unsigned char *md, int sending)
         *p++ = OSSL_PARAM_construct_end();
 
         if (!EVP_PKEY_CTX_set_params(EVP_MD_CTX_get_pkey_ctx(mac_ctx),
-                                     tls_hmac_params))
+                                     tls_hmac_params)) {
+            EVP_MD_CTX_free(hmac);
             return 0;
+        }
     }
 
     if (EVP_DigestSignUpdate(mac_ctx, header, sizeof(header)) <= 0

--- a/ssl/record/ssl3_record.c
+++ b/ssl/record/ssl3_record.c
@@ -1480,8 +1480,7 @@ int tls1_mac(SSL *ssl, SSL3_RECORD *rec, unsigned char *md, int sending)
     } OSSL_TRACE_END(TLS);
     ret = 1;
  end:
-    if (!stream_mac)
-        EVP_MD_CTX_free(hmac);
+    EVP_MD_CTX_free(hmac);
     return ret;
 }
 

--- a/ssl/record/ssl3_record.c
+++ b/ssl/record/ssl3_record.c
@@ -1392,6 +1392,7 @@ int tls1_mac(SSL *ssl, SSL3_RECORD *rec, unsigned char *md, int sending)
     int tlstree_mac = sending ? (ssl->mac_flags & SSL_MAC_FLAG_WRITE_MAC_TLSTREE)
                               : (ssl->mac_flags & SSL_MAC_FLAG_READ_MAC_TLSTREE);
     int t;
+    int ret = 0;
 
     if (sending) {
         seq = RECORD_LAYER_get_write_sequence(&ssl->rlayer);
@@ -1412,15 +1413,13 @@ int tls1_mac(SSL *ssl, SSL3_RECORD *rec, unsigned char *md, int sending)
     } else {
         hmac = EVP_MD_CTX_new();
         if (hmac == NULL || !EVP_MD_CTX_copy(hmac, hash)) {
-            EVP_MD_CTX_free(hmac);
-            return 0;
+            goto end;
         }
         mac_ctx = hmac;
     }
 
     if (!SSL_IS_DTLS(ssl) && tlstree_mac && EVP_MD_CTX_ctrl(mac_ctx, EVP_MD_CTRL_TLSTREE, 0, seq) <= 0) {
-        EVP_MD_CTX_free(hmac);
-        return 0;
+        goto end;
     }
 
     if (SSL_IS_DTLS(ssl)) {
@@ -1451,19 +1450,15 @@ int tls1_mac(SSL *ssl, SSL3_RECORD *rec, unsigned char *md, int sending)
 
         if (!EVP_PKEY_CTX_set_params(EVP_MD_CTX_get_pkey_ctx(mac_ctx),
                                      tls_hmac_params)) {
-            EVP_MD_CTX_free(hmac);
-            return 0;
+            goto end;
         }
     }
 
     if (EVP_DigestSignUpdate(mac_ctx, header, sizeof(header)) <= 0
         || EVP_DigestSignUpdate(mac_ctx, rec->input, rec->length) <= 0
         || EVP_DigestSignFinal(mac_ctx, md, &md_size) <= 0) {
-        EVP_MD_CTX_free(hmac);
-        return 0;
+        goto end;
     }
-
-    EVP_MD_CTX_free(hmac);
 
     OSSL_TRACE_BEGIN(TLS) {
         BIO_printf(trc_out, "seq:\n");
@@ -1483,7 +1478,11 @@ int tls1_mac(SSL *ssl, SSL3_RECORD *rec, unsigned char *md, int sending)
         BIO_printf(trc_out, "md:\n");
         BIO_dump_indent(trc_out, md, md_size, 4);
     } OSSL_TRACE_END(TLS);
-    return 1;
+    ret = 1;
+ end:
+    if (!stream_mac)
+        EVP_MD_CTX_free(hmac);
+    return ret;
 }
 
 int dtls1_process_record(SSL *s, DTLS1_BITMAP *bitmap)


### PR DESCRIPTION
`hmac` is allocated by `EVP_MD_CTX_new()` at `ssl3_record.c:1413` under condition `!stream_mac`. But there is a potential memory leak of it inside the block `ssl3_record.c:1452`.