### PR TITLE
free the resource allocated by BN_new()

### DIFF
--- a/providers/implementations/keymgmt/rsa_kmgmt.c
+++ b/providers/implementations/keymgmt/rsa_kmgmt.c
@@ -463,6 +463,7 @@ static void *gen_init(void *provctx, int selection, int rsa_type,
         gctx->rsa_type = rsa_type;
     }
     if (!rsa_gen_set_params(gctx, params)) {
+        BN_free(gctx->pub_exp);
         OPENSSL_free(gctx);
         return NULL;
     }

--- a/providers/implementations/keymgmt/rsa_kmgmt.c
+++ b/providers/implementations/keymgmt/rsa_kmgmt.c
@@ -461,6 +461,8 @@ static void *gen_init(void *provctx, int selection, int rsa_type,
         gctx->nbits = 2048;
         gctx->primes = RSA_DEFAULT_PRIME_NUM;
         gctx->rsa_type = rsa_type;
+    } else {
+        return NULL;
     }
     if (!rsa_gen_set_params(gctx, params)) {
         BN_free(gctx->pub_exp);


### PR DESCRIPTION
properly free the resource allocated by BN_new() to prevent a potential memory leak. `gctx->pub_exp` is allocated by `BN_new()` at `rsa_kmgmt.c:455` but lack properly release on the failure path in the block at  `rsa_kmgmt.c:465`.