### PR TITLE
several return value checks for BIO_new and its related function

### DIFF
--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -285,7 +285,7 @@ static char *app_get_pass(const char *arg, int keepbio)
             i = atoi(arg);
             if (i >= 0)
                 pwdbio = BIO_new_fd(i, BIO_NOCLOSE);
-            if ((i < 0) || !pwdbio) {
+            if ((i < 0) || pwdbio == NULL) {
                 BIO_printf(bio_err, "Can't access file descriptor %s\n", arg);
                 return NULL;
             }
@@ -294,7 +294,8 @@ static char *app_get_pass(const char *arg, int keepbio)
              */
             btmp = BIO_new(BIO_f_buffer());
             if (btmp == NULL) {
-                BIO_free(pwdbio);
+                BIO_free_all(pwdbio);
+                pwdbio = NULL;
                 BIO_printf(bio_err, "Out of memory\n");
                 return NULL;
             }

--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -293,6 +293,11 @@ static char *app_get_pass(const char *arg, int keepbio)
              * Can't do BIO_gets on an fd BIO so add a buffering BIO
              */
             btmp = BIO_new(BIO_f_buffer());
+            if (btmp == NULL) {
+                BIO_free(pwdbio);
+                BIO_printf(bio_err, "Out of memory\n");
+                return NULL;
+            }
             pwdbio = BIO_push(btmp, pwdbio);
 #endif
         } else if (strcmp(arg, "stdin") == 0) {

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -2059,6 +2059,7 @@ int s_client_main(int argc, char **argv)
 
         if (sbio == NULL || (peer_info.addr = BIO_ADDR_new()) == NULL) {
             BIO_printf(bio_err, "memory allocation failure\n");
+            BIO_ADDR_free(peer_info.addr);
             BIO_closesocket(sock);
             goto end;
         }

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -2060,6 +2060,7 @@ int s_client_main(int argc, char **argv)
 
         if (sbio == NULL || (peer_info.addr = BIO_ADDR_new()) == NULL) {
             BIO_printf(bio_err, "memory allocation failure\n");
+            BIO_free(sbio);
             BIO_closesocket(sock);
             goto end;
         }
@@ -2372,7 +2373,7 @@ int s_client_main(int argc, char **argv)
 
             if (fbio == NULL) {
                 BIO_printf(bio_err, "Unable to create BIO\n");
-                goto shut;
+                goto end;
             }
             BIO_push(fbio, sbio);
             BIO_printf(fbio, "STARTTLS\r\n");
@@ -2536,7 +2537,7 @@ int s_client_main(int argc, char **argv)
 
             if (fbio == NULL) {
                 BIO_printf(bio_err, "Unable to create BIO\n");
-                goto shut;
+                goto end;
             }
             BIO_push(fbio, sbio);
             BIO_gets(fbio, mbuf, BUFSIZZ);
@@ -2580,7 +2581,7 @@ int s_client_main(int argc, char **argv)
 
             if (fbio == NULL) {
                 BIO_printf(bio_err, "Unable to create BIO\n");
-                goto shut;
+                goto end;
             }
             BIO_push(fbio, sbio);
             /* wait for multi-line response to end from Sieve */

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -1680,12 +1680,13 @@ int s_client_main(int argc, char **argv)
             if (c_msg && bio_c_msg == NULL) {
                 bio_c_msg = dup_bio_out(FORMAT_TEXT);
                 if (bio_c_msg == NULL) {
-                    BIO_printf(bio_err, "Can't open BIO for stdout\n");
+                    BIO_printf(bio_err, "Out of memory\n");
                     goto end;
                 }
             }
-        } else
+        } else {
             bio_c_out = dup_bio_out(FORMAT_TEXT);
+        }
 
         if (bio_c_out == NULL) {
             BIO_printf(bio_err, "Unable to create BIO\n");
@@ -2059,7 +2060,6 @@ int s_client_main(int argc, char **argv)
 
         if (sbio == NULL || (peer_info.addr = BIO_ADDR_new()) == NULL) {
             BIO_printf(bio_err, "memory allocation failure\n");
-            BIO_ADDR_free(peer_info.addr);
             BIO_closesocket(sock);
             goto end;
         }
@@ -2188,7 +2188,7 @@ int s_client_main(int argc, char **argv)
 
             if (fbio == NULL) {
                 BIO_printf(bio_err, "Unable to create BIO\n");
-                goto end;
+                goto shut;
             }
             BIO_push(fbio, sbio);
             /* Wait for multi-line response to end from LMTP or SMTP */
@@ -2240,7 +2240,7 @@ int s_client_main(int argc, char **argv)
 
             if (fbio == NULL) {
                 BIO_printf(bio_err, "Unable to create BIO\n");
-                goto end;
+                goto shut;
             }
             BIO_push(fbio, sbio);
             BIO_gets(fbio, mbuf, BUFSIZZ);
@@ -2271,7 +2271,7 @@ int s_client_main(int argc, char **argv)
 
             if (fbio == NULL) {
                 BIO_printf(bio_err, "Unable to create BIO\n");
-                goto end;
+                goto shut;
             }
             BIO_push(fbio, sbio);
             /* wait for multi-line response to end from FTP */
@@ -2369,7 +2369,7 @@ int s_client_main(int argc, char **argv)
 
             if (fbio == NULL) {
                 BIO_printf(bio_err, "Unable to create BIO\n");
-                goto end;
+                goto shut;
             }
             BIO_push(fbio, sbio);
             BIO_printf(fbio, "STARTTLS\r\n");
@@ -2533,7 +2533,7 @@ int s_client_main(int argc, char **argv)
 
             if (fbio == NULL) {
                 BIO_printf(bio_err, "Unable to create BIO\n");
-                goto end;
+                goto shut;
             }
             BIO_push(fbio, sbio);
             BIO_gets(fbio, mbuf, BUFSIZZ);
@@ -2577,7 +2577,7 @@ int s_client_main(int argc, char **argv)
 
             if (fbio == NULL) {
                 BIO_printf(bio_err, "Unable to create BIO\n");
-                goto end;
+                goto shut;
             }
             BIO_push(fbio, sbio);
             /* wait for multi-line response to end from Sieve */
@@ -2640,6 +2640,7 @@ int s_client_main(int argc, char **argv)
 
             if (ldapbio == NULL || cnf == NULL) {
                 BIO_free(ldapbio);
+                NCONF_free(cnf);
                 goto end;
             }
             BIO_puts(ldapbio, ldap_tls_genconf);

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -2066,6 +2066,7 @@ int s_client_main(int argc, char **argv)
         if (!BIO_sock_info(sock, BIO_SOCK_INFO_ADDRESS, &peer_info)) {
             BIO_printf(bio_err, "getsockname:errno=%d\n",
                        get_last_socket_error());
+            BIO_free(sbio);
             BIO_ADDR_free(peer_info.addr);
             BIO_closesocket(sock);
             goto end;
@@ -2109,7 +2110,8 @@ int s_client_main(int argc, char **argv)
     if (sbio == NULL) {
         BIO_printf(bio_err, "Unable to create BIO\n");
         ERR_print_errors(bio_err);
-        goto shut;
+        BIO_closesocket(sock);
+        goto end;
     }
 
     if (nbio_test) {
@@ -2118,6 +2120,7 @@ int s_client_main(int argc, char **argv)
         test = BIO_new(BIO_f_nbio_test());
         if (test == NULL) {
             BIO_printf(bio_err, "Unable to create BIO\n");
+            BIO_free(sbio);
             goto end;
         }
         sbio = BIO_push(test, sbio);

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -2121,7 +2121,7 @@ int s_client_main(int argc, char **argv)
         if (test == NULL) {
             BIO_printf(bio_err, "Unable to create BIO\n");
             BIO_free(sbio);
-            goto end;
+            goto shut;
         }
         sbio = BIO_push(test, sbio);
     }

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -2109,7 +2109,7 @@ int s_client_main(int argc, char **argv)
     if (sbio == NULL) {
         BIO_printf(bio_err, "Unable to create BIO\n");
         ERR_print_errors(bio_err);
-        goto end;
+        goto shut;
     }
 
     if (nbio_test) {

--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -1814,10 +1814,20 @@ int s_server_main(int argc, char *argv[])
     if (bio_s_out == NULL) {
         if (s_quiet && !s_debug) {
             bio_s_out = BIO_new(BIO_s_null());
-            if (s_msg && bio_s_msg == NULL)
+            if (s_msg && bio_s_msg == NULL) {
                 bio_s_msg = dup_bio_out(FORMAT_TEXT);
+                if (bio_s_msg == NULL) {
+                    BIO_printf(bio_err, "Can't open BIO for stdout\n");
+                    goto end;
+                }
+            }
         } else {
             bio_s_out = dup_bio_out(FORMAT_TEXT);
+        }
+
+        if (bio_s_out == NULL) {
+            BIO_printf(bio_err, "Unable to create BIO\n");
+            goto end;
         }
     }
 
@@ -2425,7 +2435,6 @@ static int sv_body(int s, int stype, int prot, unsigned char *context)
             BIO_free(sbio);
             goto err;
         }
-
         sbio = BIO_push(test, sbio);
     }
 

--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -1824,11 +1824,6 @@ int s_server_main(int argc, char *argv[])
         } else {
             bio_s_out = dup_bio_out(FORMAT_TEXT);
         }
-
-        if (bio_s_out == NULL) {
-            BIO_printf(bio_err, "Unable to create BIO\n");
-            goto end;
-        }
     }
 
     if (bio_s_out == NULL)

--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -1817,7 +1817,7 @@ int s_server_main(int argc, char *argv[])
             if (s_msg && bio_s_msg == NULL) {
                 bio_s_msg = dup_bio_out(FORMAT_TEXT);
                 if (bio_s_msg == NULL) {
-                    BIO_printf(bio_err, "Can't open BIO for stdout\n");
+                    BIO_printf(bio_err, "Out of memory\n");
                     goto end;
                 }
             }


### PR DESCRIPTION
several return value checks for BIO_new() and its related function such as dup_bio_out().
BIO_new() is a memory allocation related function, when it returns `NULL` usually means some internal memory errors happened, so it is better to check the return value of it immediately to catch the error in time.
Note: I am not very sure which label should `goto` or what the err_text is most proper. Thank you for taking the time to review this PR. If there are some checks unnecessary, I will restore them.