### PR TITLE
doc: Add hint to use EVP_PKEY_get_bn_param to retrieve big integers

### DIFF
--- a/doc/man3/EVP_PKEY_gettable_params.pod
+++ b/doc/man3/EVP_PKEY_gettable_params.pod
@@ -38,10 +38,12 @@ the names and types of key parameters that can be retrieved.
 See L<OSSL_PARAM(3)> for information about parameters.
 
 EVP_PKEY_get_int_param() retrieves a key I<pkey> integer value I<*out>
-associated with a name of I<key_name>.
+associated with a name of I<key_name> if it fits into C<int> type. For
+parameters that usually do not fit into C<int> use EVP_PKEY_get_bn_param().
 
 EVP_PKEY_get_size_t_param() retrieves a key I<pkey> size_t value I<*out>
-associated with a name of I<key_name>.
+associated with a name of I<key_name> if it fits into C<size_t> type. For
+parameters that usually do not fit into C<size_t> use EVP_PKEY_get_bn_param().
 
 EVP_PKEY_get_bn_param() retrieves a key I<pkey> BIGNUM value I<**bn>
 associated with a name of I<key_name>. If I<*bn> is NULL then the BIGNUM


### PR DESCRIPTION
This came out of a discussion on openssl-users list.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
