### PR TITLE
engines: Add XTS, GCM, CCM, OFB and CFB AES algorithms for openssl speed

### DIFF
--- a/engines/e_devcrypto.c
+++ b/engines/e_devcrypto.c
@@ -141,19 +141,34 @@ static const struct cipher_data_st {
     { NID_aes_192_ctr, 16, 192 / 8, 16, EVP_CIPH_CTR_MODE, CRYPTO_AES_CTR },
     { NID_aes_256_ctr, 16, 256 / 8, 16, EVP_CIPH_CTR_MODE, CRYPTO_AES_CTR },
 #endif
-#if 0                            /* Not yet supported */
-    { NID_aes_128_xts, 16, 128 / 8 * 2, 16, EVP_CIPH_XTS_MODE, CRYPTO_AES_XTS },
-    { NID_aes_256_xts, 16, 256 / 8 * 2, 16, EVP_CIPH_XTS_MODE, CRYPTO_AES_XTS },
+#if !defined(CHECK_BSD_STYLE_MACROS) || defined(CRYPTO_AES_CFB)
+    { NID_aes_128_cfb128, 16, 128 / 8, 16, EVP_CIPH_CFB_MODE, CRYPTO_AES_CFB },
+    { NID_aes_192_cfb128, 16, 192 / 8, 16, EVP_CIPH_CFB_MODE, CRYPTO_AES_CFB },
+    { NID_aes_256_cfb128, 16, 256 / 8, 16, EVP_CIPH_CFB_MODE, CRYPTO_AES_CFB },
+#endif
+#if !defined(CHECK_BSD_STYLE_MACROS) || defined(CRYPTO_AES_OFB)
+    { NID_aes_128_ofb128, 16, 128 / 8, 16, EVP_CIPH_OFB_MODE, CRYPTO_AES_OFB },
+    { NID_aes_192_ofb128, 16, 192 / 8, 16, EVP_CIPH_OFB_MODE, CRYPTO_AES_OFB },
+    { NID_aes_256_ofb128, 16, 256 / 8, 16, EVP_CIPH_OFB_MODE, CRYPTO_AES_OFB },
+#endif
+#if !defined(CHECK_BSD_STYLE_MACROS) || defined(CRYPTO_AES_XTS)
+    { NID_aes_128_xts, 16, 128 / 8 * 2, 16, EVP_CIPH_XTS_MODE | EVP_CIPH_CUSTOM_IV, CRYPTO_AES_XTS },
+    { NID_aes_256_xts, 16, 256 / 8 * 2, 16, EVP_CIPH_XTS_MODE | EVP_CIPH_CUSTOM_IV, CRYPTO_AES_XTS },
 #endif
 #if !defined(CHECK_BSD_STYLE_MACROS) || defined(CRYPTO_AES_ECB)
     { NID_aes_128_ecb, 16, 128 / 8, 0, EVP_CIPH_ECB_MODE, CRYPTO_AES_ECB },
     { NID_aes_192_ecb, 16, 192 / 8, 0, EVP_CIPH_ECB_MODE, CRYPTO_AES_ECB },
     { NID_aes_256_ecb, 16, 256 / 8, 0, EVP_CIPH_ECB_MODE, CRYPTO_AES_ECB },
 #endif
-#if 0                            /* Not yet supported */
-    { NID_aes_128_gcm, 16, 128 / 8, 16, EVP_CIPH_GCM_MODE, CRYPTO_AES_GCM },
-    { NID_aes_192_gcm, 16, 192 / 8, 16, EVP_CIPH_GCM_MODE, CRYPTO_AES_GCM },
-    { NID_aes_256_gcm, 16, 256 / 8, 16, EVP_CIPH_GCM_MODE, CRYPTO_AES_GCM },
+#if !defined(CHECK_BSD_STYLE_MACROS) || defined(CRYPTO_AES_GCM)
+    { NID_aes_128_gcm, 16, 128 / 8, 16, EVP_CIPH_GCM_MODE | EVP_CIPH_CUSTOM_IV, CRYPTO_AES_GCM },
+    { NID_aes_192_gcm, 16, 192 / 8, 16, EVP_CIPH_GCM_MODE | EVP_CIPH_CUSTOM_IV, CRYPTO_AES_GCM },
+    { NID_aes_256_gcm, 16, 256 / 8, 16, EVP_CIPH_GCM_MODE | EVP_CIPH_CUSTOM_IV, CRYPTO_AES_GCM },
+#endif
+#if !defined(CHECK_BSD_STYLE_MACROS) || defined(CRYPTO_AES_CCM)
+    { NID_aes_128_ccm, 16, 128 / 8, 16, EVP_CIPH_CCM_MODE | EVP_CIPH_CUSTOM_IV, CRYPTO_AES_CCM },
+    { NID_aes_192_ccm, 16, 192 / 8, 16, EVP_CIPH_CCM_MODE | EVP_CIPH_CUSTOM_IV, CRYPTO_AES_CCM },
+    { NID_aes_256_ccm, 16, 256 / 8, 16, EVP_CIPH_CCM_MODE | EVP_CIPH_CUSTOM_IV, CRYPTO_AES_CCM },
 #endif
 #ifndef OPENSSL_NO_CAMELLIA
     { NID_camellia_128_cbc, 16, 128 / 8, 16, EVP_CIPH_CBC_MODE,
@@ -237,7 +252,7 @@ static int cipher_init(EVP_CIPHER_CTX *ctx, const unsigned char *key,
     return 1;
 }
 
-static int cipher_do_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
+static int cipher_do_cipher_noauth(EVP_CIPHER_CTX *ctx, unsigned char *out,
                             const unsigned char *in, size_t inl)
 {
     struct cipher_ctx *cipher_ctx =
@@ -316,6 +331,49 @@ static int cipher_do_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
 #endif
 
     return 1;
+}
+
+static int cipher_do_cipher_auth(EVP_CIPHER_CTX *ctx, unsigned char *out,
+                            const unsigned char *in, size_t inl)
+{
+    struct cipher_ctx *cipher_ctx =
+        (struct cipher_ctx *)EVP_CIPHER_CTX_get_cipher_data(ctx);
+    struct crypt_auth_op cryp;
+    unsigned char *iv = EVP_CIPHER_CTX_iv_noconst(ctx);
+
+    memset(&cryp, 0, sizeof(cryp));
+    cryp.ses = cipher_ctx->sess.ses;
+    cryp.len = inl;
+    cryp.src = (void *)in;
+    cryp.dst = (void *)out;
+    cryp.iv = (void *)iv;
+    cryp.auth_len = 0;
+    cryp.tag_len = 0;
+    cryp.op = cipher_ctx->op;
+    cryp.flags = COP_FLAG_WRITE_IV;
+
+    if (ioctl(cfd, CIOCAUTHCRYPT, &cryp) < 0) {
+        ERR_raise_data(ERR_LIB_SYS, errno, "calling ioctl()");
+        return 0;
+    }
+
+    return 1;
+}
+
+static int cipher_do_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
+                            const unsigned char *in, size_t inl)
+{
+    struct cipher_ctx *cipher_ctx =
+        (struct cipher_ctx *)EVP_CIPHER_CTX_get_cipher_data(ctx);
+    switch (cipher_ctx->mode) {
+    case EVP_CIPH_GCM_MODE:
+    case EVP_CIPH_CCM_MODE:
+        return cipher_do_cipher_auth(ctx, out, in, inl);
+        break;
+
+    default:
+        return cipher_do_cipher_noauth(ctx, out, in, inl);
+    }
 }
 
 static int ctr_do_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,


### PR DESCRIPTION
Based on a PR for cryptodev-linux this change allows to use openssl speed
with HW accelerated XTS, GCM, CCM, OFB and CFB AES algorithms that are
exposed through cryptodev-linux.
In addition without this patch there is an error: EVP_CipherInit_ex
failure when trying to run openssl speed -evp AES-128-XTS when the
algorithm is present with openssl engine -c -t.
In order to use the AEAD algorithms GCM and CCM this patch also adds the
use of CIOCAUTHCRYPT ioctl to the devcrypto engine.

Signed-off-by: Daniel Kestrel <kestrel1974@t-online.de>