### PR TITLE
providers/implementations/keymgmt/rsa_kmgmt.c: refactor gen_init

### DIFF
--- a/providers/implementations/keymgmt/rsa_kmgmt.c
+++ b/providers/implementations/keymgmt/rsa_kmgmt.c
@@ -459,18 +459,17 @@ static void *gen_init(void *provctx, int selection, int rsa_type,
         gctx->nbits = 2048;
         gctx->primes = RSA_DEFAULT_PRIME_NUM;
         gctx->rsa_type = rsa_type;
-    } else
-        goto err;
-
-    if (!rsa_gen_set_params(gctx, params)) {
+    } else {
         goto err;
     }
+
+    if (!rsa_gen_set_params(gctx, params))
+        goto err;
     return gctx;
 
 err:
-    if (gctx != NULL) {
+    if (gctx != NULL)
         BN_free(gctx->pub_exp);
-    }
     OPENSSL_free(gctx);
     return NULL;
 }

--- a/providers/implementations/keymgmt/rsa_kmgmt.c
+++ b/providers/implementations/keymgmt/rsa_kmgmt.c
@@ -454,19 +454,25 @@ static void *gen_init(void *provctx, int selection, int rsa_type,
         gctx->libctx = libctx;
         if ((gctx->pub_exp = BN_new()) == NULL
             || !BN_set_word(gctx->pub_exp, RSA_F4)) {
-            BN_free(gctx->pub_exp);
-            OPENSSL_free(gctx);
-            return NULL;
+            goto err;
         }
         gctx->nbits = 2048;
         gctx->primes = RSA_DEFAULT_PRIME_NUM;
         gctx->rsa_type = rsa_type;
-    }
+    } else
+        goto err;
+
     if (!rsa_gen_set_params(gctx, params)) {
-        OPENSSL_free(gctx);
-        return NULL;
+        goto err;
     }
     return gctx;
+
+err:
+    if (gctx != NULL) {
+        BN_free(gctx->pub_exp);
+    }
+    OPENSSL_free(gctx);
+    return NULL;
 }
 
 static void *rsa_gen_init(void *provctx, int selection,


### PR DESCRIPTION
There is the risk to pass the gctx assigned with NULL value to rsa_gen_set_params
which dereference gctx directly.  

BN_free(gctx->pub_exp); is **first found** by https://github.com/openssl/openssl/pull/17418, I checked that pr first. 

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
