### PR TITLE
`apps.c`: fix various coding style nits found by `check-format.pl`

### DIFF
--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -51,7 +51,7 @@
 
 #ifdef _WIN32
 static int WIN32_rename(const char *from, const char *to);
-# define rename(from,to) WIN32_rename((from),(to))
+# define rename(from, to) WIN32_rename((from), (to))
 #endif
 
 #if defined(OPENSSL_SYS_WINDOWS) || defined(OPENSSL_SYS_MSDOS)
@@ -102,6 +102,7 @@ int chopup_args(ARGS *arg, char *buf)
         /* The start of something good :-) */
         if (arg->argc >= arg->size) {
             char **tmp;
+
             arg->size += 20;
             tmp = OPENSSL_realloc(arg->argv, sizeof(*arg->argv) * arg->size);
             if (tmp == NULL)
@@ -188,7 +189,8 @@ int set_nameopt(const char *arg)
 
 unsigned long get_nameopt(void)
 {
-    return (nmflag_set) ? nmflag : XN_FLAG_SEP_CPLUS_SPC | ASN1_STRFLGS_UTF8_CONVERT;
+    return
+        nmflag_set ? nmflag : XN_FLAG_SEP_CPLUS_SPC | ASN1_STRFLGS_UTF8_CONVERT;
 }
 
 void dump_cert_text(BIO *out, X509 *x)
@@ -201,7 +203,6 @@ int wrap_password_callback(char *buf, int bufsiz, int verify, void *userdata)
 {
     return password_callback(buf, bufsiz, verify, (PW_CB_DATA *)userdata);
 }
-
 
 static char *app_get_pass(const char *arg, int keepbio);
 
@@ -218,7 +219,8 @@ char *get_passwd(const char *pass, const char *desc)
                    "Trying plain input string (better precede with 'pass:')\n");
         result = OPENSSL_strdup(pass);
         if (result == NULL)
-            BIO_printf(bio_err, "Out of memory getting password for %s\n", desc);
+            BIO_printf(bio_err,
+                       "Out of memory getting password for %s\n", desc);
     }
     return result;
 }
@@ -279,6 +281,7 @@ static char *app_get_pass(const char *arg, int keepbio)
              */
         } else if (CHECK_AND_SKIP_PREFIX(arg, "fd:")) {
             BIO *btmp;
+
             i = atoi(arg);
             if (i >= 0)
                 pwdbio = BIO_new_fd(i, BIO_NOCLOSE);
@@ -568,8 +571,8 @@ EVP_PKEY *load_pubkey(const char *uri, int format, int maybe_stdin,
 }
 
 EVP_PKEY *load_keyparams_suppress(const char *uri, int format, int maybe_stdin,
-                                 const char *keytype, const char *desc,
-                                 int suppress_decode_errors)
+                                  const char *keytype, const char *desc,
+                                  int suppress_decode_errors)
 {
     EVP_PKEY *params = NULL;
     BIO *bio_bak = bio_err;
@@ -829,7 +832,8 @@ static const char *format2string(int format)
 }
 
 /* Set type expectation, but clear it if objects of different types expected. */
-#define SET_EXPECT(expect, val) ((expect) = (expect) < 0 ? (val) : ((expect) == (val) ? (val) : 0))
+#define SET_EXPECT(expect, val) \
+    ((expect) = (expect) < 0 ? (val) : ((expect) == (val) ? (val) : 0))
 /*
  * Load those types of credentials for which the result pointer is not NULL.
  * Reads from stdio if uri is NULL and maybe_stdin is nonzero.
@@ -919,10 +923,10 @@ int load_key_certs_crls(const char *uri, int format, int maybe_stdin,
     uidata.prompt_info = uri;
 
     if ((input_type = format2string(format)) != NULL) {
-       itp[0] = OSSL_PARAM_construct_utf8_string(OSSL_STORE_PARAM_INPUT_TYPE,
-                                                 (char *)input_type, 0);
-       itp[1] = OSSL_PARAM_construct_end();
-       params = itp;
+        itp[0] = OSSL_PARAM_construct_utf8_string(OSSL_STORE_PARAM_INPUT_TYPE,
+                                                  (char *)input_type, 0);
+        itp[1] = OSSL_PARAM_construct_end();
+        params = itp;
     }
 
     if (uri == NULL) {
@@ -1001,20 +1005,20 @@ int load_key_certs_crls(const char *uri, int format, int maybe_stdin,
             if (pcert != NULL && *pcert == NULL) {
                 ok = (*pcert = OSSL_STORE_INFO_get1_CERT(info)) != NULL;
                 cnt_expectations -= ok;
-            }
-            else if (pcerts != NULL)
+            } else if (pcerts != NULL) {
                 ok = X509_add_cert(*pcerts,
                                    OSSL_STORE_INFO_get1_CERT(info),
                                    X509_ADD_FLAG_DEFAULT);
+            }
             ncerts += ok;
             break;
         case OSSL_STORE_INFO_CRL:
             if (pcrl != NULL && *pcrl == NULL) {
                 ok = (*pcrl = OSSL_STORE_INFO_get1_CRL(info)) != NULL;
                 cnt_expectations -= ok;
-            }
-            else if (pcrls != NULL)
+            } else if (pcrls != NULL) {
                 ok = sk_X509_CRL_push(*pcrls, OSSL_STORE_INFO_get1_CRL(info));
+            }
             ncrls += ok;
             break;
         default:
@@ -1082,18 +1086,14 @@ int load_key_certs_crls(const char *uri, int format, int maybe_stdin,
     return failed == NULL;
 }
 
-#define X509V3_EXT_UNKNOWN_MASK         (0xfL << 16)
-/* Return error for unknown extensions */
-#define X509V3_EXT_DEFAULT              0
-/* Print error for unknown extensions */
-#define X509V3_EXT_ERROR_UNKNOWN        (1L << 16)
-/* ASN1 parse unknown extensions */
-#define X509V3_EXT_PARSE_UNKNOWN        (2L << 16)
-/* BIO_dump unknown extensions */
-#define X509V3_EXT_DUMP_UNKNOWN         (3L << 16)
+#define X509V3_EXT_UNKNOWN_MASK  (0xfL << 16)
+#define X509V3_EXT_DEFAULT       0          /* Return error for unknown exts */
+#define X509V3_EXT_ERROR_UNKNOWN (1L << 16) /* Print error for unknown exts */
+#define X509V3_EXT_PARSE_UNKNOWN (2L << 16) /* ASN1 parse unknown extensions */
+#define X509V3_EXT_DUMP_UNKNOWN  (3L << 16) /* BIO_dump unknown extensions */
 
 #define X509_FLAG_CA (X509_FLAG_NO_ISSUER | X509_FLAG_NO_PUBKEY | \
-                         X509_FLAG_NO_HEADER | X509_FLAG_NO_VERSION)
+                      X509_FLAG_NO_HEADER | X509_FLAG_NO_VERSION)
 
 int set_cert_ex(unsigned long *flags, const char *arg)
 {
@@ -1227,6 +1227,7 @@ static int set_multi_opts(unsigned long *flags, const char *arg,
     STACK_OF(CONF_VALUE) *vals;
     CONF_VALUE *val;
     int i, ret = 1;
+
     if (!arg)
         return 0;
     vals = X509V3_parse_list(arg);
@@ -1244,8 +1245,8 @@ static int set_table_opts(unsigned long *flags, const char *arg,
 {
     char c;
     const NAME_EX_TBL *ptbl;
-    c = arg[0];
 
+    c = arg[0];
     if (c == '-') {
         c = 0;
         arg++;
@@ -1318,7 +1319,7 @@ void print_bignum_var(BIO *out, const BIGNUM *in, const char *var,
     BIO_printf(out, "\n    };\n");
 }
 
-void print_array(BIO *out, const char* title, int len, const unsigned char* d)
+void print_array(BIO *out, const char *title, int len, const unsigned char *d)
 {
     int i;
 
@@ -1481,8 +1482,8 @@ BIGNUM *load_serial(const char *serialfile, int create, ASN1_INTEGER **retai)
     return ret;
 }
 
-int save_serial(const char *serialfile, const char *suffix, const BIGNUM *serial,
-                ASN1_INTEGER **retai)
+int save_serial(const char *serialfile, const char *suffix,
+                const BIGNUM *serial, ASN1_INTEGER **retai)
 {
     char buf[1][BSIZE];
     BIO *out = NULL;
@@ -1499,9 +1500,9 @@ int save_serial(const char *serialfile, const char *suffix, const BIGNUM *serial
         goto err;
     }
 
-    if (suffix == NULL)
+    if (suffix == NULL) {
         OPENSSL_strlcpy(buf[0], serialfile, BSIZE);
-    else {
+    } else {
 #ifndef OPENSSL_SYS_VMS
         j = BIO_snprintf(buf[0], sizeof(buf[0]), "%s.%s", serialfile, suffix);
 #else
@@ -1640,12 +1641,12 @@ CA_DB *load_index(const char *dbfile, DB_ATTR *db_attr)
     tmpdb = NULL;
     if (db_attr)
         retdb->attributes = *db_attr;
-    else {
+    else
         retdb->attributes.unique_subject = 1;
-    }
 
     if (dbattr_conf) {
         char *p = NCONF_get_string(dbattr_conf, NULL, "unique_subject");
+
         if (p) {
             retdb->attributes.unique_subject = parse_yesno(p, 1);
         }
@@ -1875,6 +1876,7 @@ X509_NAME *parse_name(const char *cp, int chtype, int canmulti,
         unsigned char *valstr;
         int nid;
         int ismulti = nextismulti;
+
         nextismulti = 0;
 
         /* Collect the type */
@@ -2030,6 +2032,7 @@ void policies_print(X509_STORE_CTX *ctx)
 {
     X509_POLICY_TREE *tree;
     int explicit_policy;
+
     tree = X509_STORE_CTX_get0_policy_tree(ctx);
     explicit_policy = X509_STORE_CTX_get_explicit_policy(ctx);
 
@@ -2081,7 +2084,7 @@ unsigned char *next_protos_parse(size_t *outlen, const char *in)
                 OPENSSL_free(out);
                 return NULL;
             }
-            out[start-skipped] = (unsigned char)(i - start);
+            out[start - skipped] = (unsigned char)(i - start);
             start = i + 1;
         } else {
             out[i + 1 - skipped] = in[i];
@@ -2097,9 +2100,9 @@ unsigned char *next_protos_parse(size_t *outlen, const char *in)
     return out;
 }
 
-int check_cert_attributes(BIO *bio, X509 *x,
-                       const char *checkhost,
-                       const char *checkemail, const char *checkip, int print)
+int check_cert_attributes(BIO *bio, X509 *x, const char *checkhost,
+                          const char *checkemail, const char *checkip,
+                          int print)
 {
     int valid_host = 0;
     int valid_mail = 0;
@@ -2126,10 +2129,10 @@ int check_cert_attributes(BIO *bio, X509 *x,
     }
 
     if (checkip != NULL) {
-        valid_ip   =  X509_check_ip_asc(x, checkip, 0);
+        valid_ip = X509_check_ip_asc(x, checkip, 0);
         if (print)
             BIO_printf(bio, "IP %s does%s match certificate\n",
-                       checkip,  valid_ip ? "" : " NOT");
+                       checkip, valid_ip ? "" : " NOT");
         ret = ret && valid_ip;
     }
 
@@ -2145,6 +2148,7 @@ static int do_pkey_ctx_init(EVP_PKEY_CTX *pkctx, STACK_OF(OPENSSL_STRING) *opts)
 
     for (i = 0; i < sk_OPENSSL_STRING_num(opts); i++) {
         char *opt = sk_OPENSSL_STRING_value(opts, i);
+
         if (pkey_ctrl_string(pkctx, opt) <= 0) {
             BIO_printf(bio_err, "parameter error \"%s\"\n", opt);
             ERR_print_errors(bio_err);
@@ -2164,6 +2168,7 @@ static int do_x509_init(X509 *x, STACK_OF(OPENSSL_STRING) *opts)
 
     for (i = 0; i < sk_OPENSSL_STRING_num(opts); i++) {
         char *opt = sk_OPENSSL_STRING_value(opts, i);
+
         if (x509_ctrl_string(x, opt) <= 0) {
             BIO_printf(bio_err, "parameter error \"%s\"\n", opt);
             ERR_print_errors(bio_err);
@@ -2183,6 +2188,7 @@ static int do_x509_req_init(X509_REQ *x, STACK_OF(OPENSSL_STRING) *opts)
 
     for (i = 0; i < sk_OPENSSL_STRING_num(opts); i++) {
         char *opt = sk_OPENSSL_STRING_value(opts, i);
+
         if (x509_req_ctrl_string(x, opt) <= 0) {
             BIO_printf(bio_err, "parameter error \"%s\"\n", opt);
             ERR_print_errors(bio_err);
@@ -2237,7 +2243,7 @@ static int adapt_keyid_ext(X509 *cert, X509V3_CTX *ext_ctx,
             X509_EXTENSION_free(found_ext);
         } /* else keep existing key identifier, which might be outdated */
         rv = 1;
-    } else  {
+    } else {
         rv = !add_default || X509_add_ext(cert, new_ext, -1);
     }
     X509_EXTENSION_free(new_ext);
@@ -2340,8 +2346,7 @@ int do_X509_REQ_verify(X509_REQ *x, EVP_PKEY *pkey,
     int rv = 0;
 
     if (do_x509_req_init(x, vfyopts) > 0)
-        rv = X509_REQ_verify_ex(x, pkey,
-                                 app_get0_libctx(), app_get0_propq());
+        rv = X509_REQ_verify_ex(x, pkey, app_get0_libctx(), app_get0_propq());
     else
         rv = -1;
     return rv;
@@ -2355,6 +2360,7 @@ static const char *get_dp_url(DIST_POINT *dp)
     GENERAL_NAME *gen;
     int i, gtype;
     ASN1_STRING *uri;
+
     if (!dp->distpoint || dp->distpoint->type != 0)
         return NULL;
     gens = dp->distpoint->name.fullname;
@@ -2380,8 +2386,10 @@ static X509_CRL *load_crl_crldp(STACK_OF(DIST_POINT) *crldp)
 {
     int i;
     const char *urlptr = NULL;
+
     for (i = 0; i < sk_DIST_POINT_num(crldp); i++) {
         DIST_POINT *dp = sk_DIST_POINT_value(crldp, i);
+
         urlptr = get_dp_url(dp);
         if (urlptr != NULL)
             return load_crl(urlptr, FORMAT_UNDEF, 0, "CRL via CDP");
@@ -2621,18 +2629,18 @@ static int WIN32_rename(const char *from, const char *to)
         tfrom = (TCHAR *)from;
         tto = (TCHAR *)to;
     } else {                    /* UNICODE path */
-
         size_t i, flen = strlen(from) + 1, tlen = strlen(to) + 1;
+
         tfrom = malloc(sizeof(*tfrom) * (flen + tlen));
         if (tfrom == NULL)
             goto err;
         tto = tfrom + flen;
-# if !defined(_WIN32_WCE) || _WIN32_WCE>=101
+# if !defined(_WIN32_WCE) || _WIN32_WCE >= 101
         if (!MultiByteToWideChar(CP_ACP, 0, from, flen, (WCHAR *)tfrom, flen))
 # endif
             for (i = 0; i < flen; i++)
                 tfrom[i] = (TCHAR)from[i];
-# if !defined(_WIN32_WCE) || _WIN32_WCE>=101
+# if !defined(_WIN32_WCE) || _WIN32_WCE >= 101
         if (!MultiByteToWideChar(CP_ACP, 0, to, tlen, (WCHAR *)tto, tlen))
 # endif
             for (i = 0; i < tlen; i++)
@@ -2683,6 +2691,7 @@ double app_tminterval(int stop, int usertime)
 
     if (usertime && proc != (HANDLE) - 1) {
         FILETIME junk;
+
         GetProcessTimes(proc, &junk, &junk, &junk, &now);
     } else
 # endif
@@ -2766,6 +2775,7 @@ double app_tminterval(int stop, int usertime)
         tmstart = now;
     } else {
         long int tck = sysconf(_SC_CLK_TCK);
+
         ret = (now - tmstart) / (double)tck;
     }
 
@@ -2798,7 +2808,7 @@ double app_tminterval(int stop, int usertime)
 }
 #endif
 
-int app_access(const char* name, int flag)
+int app_access(const char *name, int flag)
 {
 #ifdef _WIN32
     return _access(name, flag);
@@ -2819,7 +2829,7 @@ static int stdin_sock = -1;
 
 static void close_stdin_sock(void)
 {
-    TerminalSocket (TERM_SOCK_DELETE, &stdin_sock);
+    TerminalSocket(TERM_SOCK_DELETE, &stdin_sock);
 }
 
 int fileno_stdin(void)
@@ -2847,6 +2857,7 @@ int fileno_stdout(void)
 int raw_read_stdin(void *buf, int siz)
 {
     DWORD n;
+
     if (ReadFile(GetStdHandle(STD_INPUT_HANDLE), buf, siz, &n, NULL))
         return n;
     else
@@ -2875,6 +2886,7 @@ int raw_read_stdin(void *buf, int siz)
 int raw_write_stdout(const void *buf, int siz)
 {
     DWORD n;
+
     if (WriteFile(GetStdHandle(STD_OUTPUT_HANDLE), buf, siz, &n, NULL))
         return n;
     else
@@ -2888,7 +2900,7 @@ int raw_write_stdout(const void *buf, int siz)
 # endif
 int raw_write_stdout(const void *buf, int siz)
 {
-	return write(fileno(stdout), (void*)buf, siz);
+    return write(fileno(stdout), (void *)buf, siz);
 }
 #else
 # if defined(__TANDEM)
@@ -2939,6 +2951,7 @@ BIO *dup_bio_err(int format)
 {
     BIO *b = BIO_new_fp(stderr,
                         BIO_NOCLOSE | (FMT_istext(format) ? BIO_FP_TEXT : 0));
+
 #ifdef OPENSSL_SYS_VMS
     if (FMT_istext(format))
         b = BIO_push(BIO_new(BIO_f_linebuffer()), b);
@@ -3027,7 +3040,8 @@ BIO *bio_open_owner(const char *filename, int format, int private)
     }
 
 # ifdef OPENSSL_SYS_VMS
-    /* VMS doesn't have O_BINARY, it just doesn't make sense.  But,
+    /*
+     * VMS doesn't have O_BINARY, it just doesn't make sense.  But,
      * it still needs to know that we're going binary, or fdopen()
      * will fail with "invalid argument"...  so we tell VMS what the
      * context is.
@@ -3171,8 +3185,9 @@ int has_stdin_waiting(void)
 /* Corrupt a signature by modifying final byte */
 void corrupt_signature(const ASN1_STRING *signature)
 {
-        unsigned char *s = signature->data;
-        s[signature->length - 1] ^= 0x1;
+    unsigned char *s = signature->data;
+
+    s[signature->length - 1] ^= 0x1;
 }
 
 int set_cert_times(X509 *x, const char *startdate, const char *enddate,


### PR DESCRIPTION
Part of the nits were found by the enhancements to the tool in #17434.