### PR TITLE
Fix password_callback to handle short passwords

### DIFF
--- a/apps/apps.c
+++ b/apps/apps.c
@@ -300,9 +300,13 @@ int password_callback(char *buf, int bufsiz, int verify, PW_CB_DATA *cb_tmp)
         int ui_flags = 0;
         const char *prompt_info = NULL;
         char *prompt;
+        int pw_min_len = PW_MIN_LENGTH;
 
         if (cb_data != NULL && cb_data->prompt_info != NULL)
             prompt_info = cb_data->prompt_info;
+        if (cb_data != NULL && cb_data->password != NULL
+                && *(const char*)cb_data->password != '\0')
+            pw_min_len = 1;
         prompt = UI_construct_prompt(ui, "pass phrase", prompt_info);
         if (!prompt) {
             BIO_printf(bio_err, "Out of memory\n");
@@ -317,12 +321,12 @@ int password_callback(char *buf, int bufsiz, int verify, PW_CB_DATA *cb_tmp)
         (void)UI_add_user_data(ui, cb_data);
 
         ok = UI_add_input_string(ui, prompt, ui_flags, buf,
-                                 PW_MIN_LENGTH, bufsiz - 1);
+                                 pw_min_len, bufsiz - 1);
 
         if (ok >= 0 && verify) {
             buff = app_malloc(bufsiz, "password buffer");
             ok = UI_add_verify_string(ui, prompt, ui_flags, buff,
-                                      PW_MIN_LENGTH, bufsiz - 1, buf);
+                                      pw_min_len, bufsiz - 1, buf);
         }
         if (ok >= 0)
             do {

--- a/test/recipes/15-test_genrsa.t
+++ b/test/recipes/15-test_genrsa.t
@@ -16,7 +16,7 @@ use OpenSSL::Test::Utils;
 
 setup("test_genrsa");
 
-plan tests => 5;
+plan tests => 7;
 
 # We want to know that an absurdly small number of bits isn't support
 is(run(app([ 'openssl', 'genrsa', '-3', '-out', 'genrsatest.pem', '8'])), 0, "genrsa -3 8");
@@ -52,3 +52,8 @@ ok(run(app([ 'openssl', 'genrsa', '-f4', '-out', 'genrsatest.pem', $good ])),
    "genrsa -f4 $good");
 ok(run(app([ 'openssl', 'rsa', '-check', '-in', 'genrsatest.pem', '-noout' ])),
    "rsa -check");
+ok(run(app([ 'openssl', 'rsa', '-in', 'genrsatest.pem', '-out', 'genrsatest-enc.pem',
+   '-aes256', '-passout', 'pass:x' ])),
+   "rsa encrypt");
+ok(run(app([ 'openssl', 'rsa', '-in', 'genrsatest-enc.pem', '-passin', 'pass:x' ])),
+   "rsa decrypt");


### PR DESCRIPTION
Fixes #17426

steps to reproduce:
```
$ apps/openssl genrsa -out xx.key 2048
$ apps/openssl rsa -in xx.key -out xx-enc.key -aes256 -passout pass:xx
writing RSA key
$ apps/openssl req -new -key xx-enc.key -out xx.csr -subj "/CN=XX" -passin pass:xx -config apps/openssl.cnf
unable to load Private Key
140467060270912:error:28078065:UI routines:UI_set_result_ex:result too small:crypto/ui/ui_lib.c:905:You must type in 4 to 1023 characters
140467060270912:error:06065064:digital envelope routines:EVP_DecryptFinal_ex:bad decrypt:crypto/evp/evp_enc.c:610:
140467060270912:error:0906A065:PEM routines:PEM_do_header:bad decrypt:crypto/pem/pem_lib.c:461:
```

this one is 1.1.1 only, as master does not seem to be affected.