### PR TITLE
crypto/bio: fix build on UEFI

### DIFF
--- a/crypto/bio/bio_print.c
+++ b/crypto/bio/bio_print.c
@@ -13,6 +13,7 @@
 #include "crypto/ctype.h"
 #include "internal/numbers.h"
 #include <openssl/bio.h>
+#include <openssl/configuration.h>
 
 /*
  * Copyright Patrick Powell 1995
@@ -512,7 +513,11 @@ fmtint(char **sbuffer,
     return 1;
 }
 
+#ifdef OPENSSL_SYS_UEFI
+static LDOUBLE EFIAPI abs_val(LDOUBLE value)
+#else
 static LDOUBLE abs_val(LDOUBLE value)
+#endif
 {
     LDOUBLE result = value;
     if (value < 0)
@@ -520,7 +525,11 @@ static LDOUBLE abs_val(LDOUBLE value)
     return result;
 }
 
+#ifdef OPENSSL_SYS_UEFI
+static LDOUBLE EFIAPI pow_10(int in_exp)
+#else
 static LDOUBLE pow_10(int in_exp)
+#endif
 {
     LDOUBLE result = 1;
     while (in_exp) {


### PR DESCRIPTION
When compiling openssl for tianocore compiling abs_val() and pow_10()
fails with the following error because SSE support is disabled:

   crypto/bio/bio_print.c:587:46: error: SSE register return with SSE disabled

Fix that by using EFIAPI calling convention when compiling for UEFI.

Signed-off-by: Gerd Hoffmann <kraxel@redhat.com>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
