### PR TITLE
Clarify the int param getter documentation

### DIFF
--- a/doc/man3/EVP_PKEY_gettable_params.pod
+++ b/doc/man3/EVP_PKEY_gettable_params.pod
@@ -42,7 +42,7 @@ B<OSSL_PARAM_UNSIGNED_INTEGER> is of arbitrary length. Such a parameter can be
 obtained using any of the functions EVP_PKEY_get_int_param(),
 EVP_PKEY_get_size_t_param() or EVP_PKEY_get_bn_param(). Attempting to
 obtain an integer value that does not fit into a native C B<int> type will cause
-EVP_PKEY_get_int_param() to fail. Similaraly attempting to obtain an integer
+EVP_PKEY_get_int_param() to fail. Similarly attempting to obtain an integer
 value that is negative or does not fit into a native C B<size_t> type using
 EVP_PKEY_get_size_t_param() will also fail.
 

--- a/doc/man3/EVP_PKEY_gettable_params.pod
+++ b/doc/man3/EVP_PKEY_gettable_params.pod
@@ -37,6 +37,15 @@ EVP_PKEY_gettable_params() returns a constant list of I<params> indicating
 the names and types of key parameters that can be retrieved.
 See L<OSSL_PARAM(3)> for information about parameters.
 
+An B<OSSL_PARAM> of type B<OSSL_PARAM_INTEGER> or
+B<OSSL_PARAM_UNSIGNED_INTEGER> is of arbitrary length. Such a parameter can be
+obtained using any of the functions EVP_PKEY_get_int_param(),
+EVP_PKEY_get_size_t_param() or EVP_PKEY_get_bn_param(). Attempting to
+obtain an integer value that does not fit into a native C B<int> type will cause
+EVP_PKEY_get_int_param() to fail. Similaraly attempting to obtain an integer
+value that is negative or does not fit into a native C B<size_t> type using
+EVP_PKEY_get_size_t_param() will also fail.
+
 EVP_PKEY_get_int_param() retrieves a key I<pkey> integer value I<*out>
 associated with a name of I<key_name>.
 


### PR DESCRIPTION
OSSL_PARAMs that are of type OSSL_PARAM_INTEGER or
OSSL_PARAM_UNSIGNED_INTEGER can be obtained using any of the functions
EVP_PKEY_get_int_param(), EVP_PKEY_get_size_t_param() or
EVP_PKEY_get_bn_param(). The former two will fail if the parameter is too
large to fit into the C variable. We clarify this in the documentation.

