### PR TITLE
Don't run TLSFuzzer tests when it is not properly set

### DIFF
--- a/test/recipes/95-test_external_tlsfuzzer.t
+++ b/test/recipes/95-test_external_tlsfuzzer.t
@@ -18,8 +18,8 @@ plan skip_all => "No external tests in this configuration"
     if disabled("external-tests");
 plan skip_all => "TLSFuzzer tests not available on Windows or VMS"
     if $^O =~ /^(VMS|MSWin32)$/;
-plan skip_all => "TLSFuzzer tests not supported in out of tree builds"
-    if bldtop_dir() ne srctop_dir();
+plan skip_all => "TLSFuzzer is not properly checked out"
+    unless (-d srctop_dir()."/tlsfuzzer" && -d srctop_dir()."/tlsfuzzer/tests");
 
 $ENV{TESTDATADIR} = abs_path(data_dir());
 plan tests => 1;

--- a/test/recipes/95-test_external_tlsfuzzer.t
+++ b/test/recipes/95-test_external_tlsfuzzer.t
@@ -19,7 +19,7 @@ plan skip_all => "No external tests in this configuration"
 plan skip_all => "TLSFuzzer tests not available on Windows or VMS"
     if $^O =~ /^(VMS|MSWin32)$/;
 plan skip_all => "TLSFuzzer is not properly checked out"
-    unless (-d srctop_dir()."/tlsfuzzer" && -d srctop_dir()."/tlsfuzzer/tests");
+    unless (-d srctop_dir("tlsfuzzer") && -d srctop_dir("tlsfuzzer", "tests"));
 
 $ENV{TESTDATADIR} = abs_path(data_dir());
 plan tests => 1;


### PR DESCRIPTION
Follow-up PR for #17340

If TLSFuzzer submodule is not checked up, skip the test.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
