### PR TITLE
Fix Decoder, Encoder and Store loader fetching

### DIFF
--- a/crypto/encode_decode/decoder_meth.c
+++ b/crypto/encode_decode/decoder_meth.c
@@ -375,13 +375,14 @@ inner_ossl_decoder_fetch(struct decoder_data_st *methdata, int id,
             construct_decoder,
             destruct_decoder
         };
+        OSSL_PROVIDER *prov = NULL;
 
         methdata->id = id;
         methdata->names = name;
         methdata->propquery = properties;
         methdata->flag_construct_error_occurred = 0;
         if ((method = ossl_method_construct(methdata->libctx, OSSL_OP_DECODER,
-                                            NULL, 0 /* !force_cache */,
+                                            &prov, 0 /* !force_cache */,
                                             &mcm, methdata)) != NULL) {
             /*
              * If construction did create a method for us, we know that
@@ -392,7 +393,7 @@ inner_ossl_decoder_fetch(struct decoder_data_st *methdata, int id,
             if (id == 0 && name != NULL)
                 id = ossl_namemap_name2num(namemap, name);
             if (id != 0)
-                ossl_method_store_cache_set(store, NULL, id, properties, method,
+                ossl_method_store_cache_set(store, prov, id, properties, method,
                                             up_ref_decoder, free_decoder);
         }
 

--- a/crypto/encode_decode/encoder_meth.c
+++ b/crypto/encode_decode/encoder_meth.c
@@ -385,13 +385,14 @@ inner_ossl_encoder_fetch(struct encoder_data_st *methdata, int id,
             construct_encoder,
             destruct_encoder
         };
+        OSSL_PROVIDER *prov = NULL;
 
         methdata->id = id;
         methdata->names = name;
         methdata->propquery = properties;
         methdata->flag_construct_error_occurred = 0;
         if ((method = ossl_method_construct(methdata->libctx, OSSL_OP_ENCODER,
-                                            NULL, 0 /* !force_cache */,
+                                            &prov, 0 /* !force_cache */,
                                             &mcm, methdata)) != NULL) {
             /*
              * If construction did create a method for us, we know that
@@ -401,7 +402,7 @@ inner_ossl_encoder_fetch(struct encoder_data_st *methdata, int id,
              */
             if (id == 0)
                 id = ossl_namemap_name2num(namemap, name);
-            ossl_method_store_cache_set(store, NULL, id, properties, method,
+            ossl_method_store_cache_set(store, prov, id, properties, method,
                                         up_ref_encoder, free_encoder);
         }
 

--- a/crypto/store/store_meth.c
+++ b/crypto/store/store_meth.c
@@ -317,13 +317,14 @@ inner_loader_fetch(struct loader_data_st *methdata, int id,
             construct_loader,
             destruct_loader
         };
+        OSSL_PROVIDER *prov = NULL;
 
         methdata->scheme_id = id;
         methdata->scheme = scheme;
         methdata->propquery = properties;
         methdata->flag_construct_error_occurred = 0;
         if ((method = ossl_method_construct(methdata->libctx, OSSL_OP_STORE,
-                                            NULL, 0 /* !force_cache */,
+                                            &prov, 0 /* !force_cache */,
                                             &mcm, methdata)) != NULL) {
             /*
              * If construction did create a method for us, we know that there
@@ -332,7 +333,7 @@ inner_loader_fetch(struct loader_data_st *methdata, int id,
              */
             if (id == 0)
                 id = ossl_namemap_name2num(namemap, scheme);
-            ossl_method_store_cache_set(store, NULL, id, properties, method,
+            ossl_method_store_cache_set(store, prov, id, properties, method,
                                         up_ref_loader, free_loader);
         }
 

--- a/test/provfetchtest.c
+++ b/test/provfetchtest.c
@@ -225,6 +225,7 @@ static int dummy_provider_init(const OSSL_CORE_HANDLE *handle,
  * Test 1: Encoder
  * Test 2: Store loader
  * Test 3: EVP_RAND
+ * Test 4-7: As above, but additionally with a query string
  */
 static int fetch_test(int tst)
 {
@@ -236,6 +237,7 @@ static int fetch_test(int tst)
     OSSL_STORE_LOADER *loader = NULL;
     int testresult = 0;
     unsigned char buf[32];
+    int query = tst > 3;
 
     if (!TEST_ptr(libctx))
         goto err;
@@ -246,24 +248,29 @@ static int fetch_test(int tst)
             || !TEST_ptr(dummyprov = OSSL_PROVIDER_load(libctx, "dummy-prov")))
         goto err;
 
-    switch (tst) {
+    switch (tst % 4) {
     case 0:
-        decoder = OSSL_DECODER_fetch(libctx, "DUMMY", NULL);
+        decoder = OSSL_DECODER_fetch(libctx, "DUMMY",
+                                     query ? "provider=dummy" : NULL);
         if (!TEST_ptr(decoder))
             goto err;
         break;
     case 1:
-        encoder = OSSL_ENCODER_fetch(libctx, "DUMMY", NULL);
+        encoder = OSSL_ENCODER_fetch(libctx, "DUMMY",
+                                     query ? "provider=dummy" : NULL);
         if (!TEST_ptr(encoder))
             goto err;
         break;
     case 2:
-        loader = OSSL_STORE_LOADER_fetch(libctx, "DUMMY", NULL);
+        loader = OSSL_STORE_LOADER_fetch(libctx, "DUMMY",
+                                         query ? "provider=dummy" : NULL);
         if (!TEST_ptr(loader))
             goto err;
         break;
     case 3:
-        if (!TEST_true(RAND_set_DRBG_type(libctx, "DUMMY", NULL, NULL, NULL))
+        if (!TEST_true(RAND_set_DRBG_type(libctx, "DUMMY",
+                                          query ? "provider=dummy" : NULL,
+                                          NULL, NULL))
                 || !TEST_int_ge(RAND_bytes_ex(libctx, buf, sizeof(buf), 0), 1))
             goto err;
         break;
@@ -284,7 +291,7 @@ static int fetch_test(int tst)
 
 int setup_tests(void)
 {
-    ADD_ALL_TESTS(fetch_test, 4);
+    ADD_ALL_TESTS(fetch_test, 8);
 
     return 1;
 }


### PR DESCRIPTION
Attempting to fetch one of the above and providing a query string was
failing with an internal assertion error. We must ensure that we give the
provider when calling ossl_method_store_cache_set()

Fixes #17456