### PR TITLE
pkeyutl: Fix regression with -kdflen option

### DIFF
--- a/apps/pkeyutl.c
+++ b/apps/pkeyutl.c
@@ -463,23 +463,23 @@ int pkeyutl_main(int argc, char **argv)
         }
         goto end;
     }
-    if (kdflen != 0) {
-        buf_outlen = kdflen;
-        rv = 1;
+    if (rawin) {
+        /* rawin allocates the buffer in do_raw_keyop() */
+        rv = do_raw_keyop(pkey_op, mctx, pkey, in, filesize, NULL, 0,
+                          &buf_out, (size_t *)&buf_outlen);
     } else {
-        if (rawin) {
-            /* rawin allocates the buffer in do_raw_keyop() */
-            rv = do_raw_keyop(pkey_op, mctx, pkey, in, filesize, NULL, 0,
-                              &buf_out, (size_t *)&buf_outlen);
+        if (kdflen != 0) {
+            buf_outlen = kdflen;
+            rv = 1;
         } else {
             rv = do_keyop(ctx, pkey_op, NULL, (size_t *)&buf_outlen,
                           buf_in, (size_t)buf_inlen);
-            if (rv > 0 && buf_outlen != 0) {
-                buf_out = app_malloc(buf_outlen, "buffer output");
-                rv = do_keyop(ctx, pkey_op,
-                              buf_out, (size_t *)&buf_outlen,
-                              buf_in, (size_t)buf_inlen);
-            }
+        }
+        if (rv > 0 && buf_outlen != 0) {
+            buf_out = app_malloc(buf_outlen, "buffer output");
+            rv = do_keyop(ctx, pkey_op,
+                          buf_out, (size_t *)&buf_outlen,
+                          buf_in, (size_t)buf_inlen);
         }
     }
     if (rv <= 0) {


### PR DESCRIPTION
There is a regression of the -kdflen option handling reported in #17458 caused by commit a7cef52f9b961dcb.
