### PR TITLE
Remove unsafe call to OPENSSL_cpuid_setup

### DIFF
--- a/crypto/engine/eng_all.c
+++ b/crypto/engine/eng_all.c
@@ -12,9 +12,6 @@
 
 void ENGINE_load_builtin_engines(void)
 {
-    /* Some ENGINEs need this */
-    OPENSSL_cpuid_setup();
-
     OPENSSL_init_crypto(OPENSSL_INIT_ENGINE_ALL_BUILTIN, NULL);
 }
 


### PR DESCRIPTION
This function is inherently thread-unsafe,
and moreover it is unnecessary here, because
OPENSSL_init_crypto always calls it in a thread-safe way.

This is 1.1.1 only, as 3.0 dropped this call a long time ago.