### PR TITLE
Use ERR upcalls in legacy provider

### DIFF
--- a/crypto/err/build.info
+++ b/crypto/err/build.info
@@ -1,3 +1,3 @@
 LIBS=../../libcrypto
 SOURCE[../../libcrypto]=\
-        err_blocks.c err.c err_all.c err_all_legacy.c err_prn.c
+        err_blocks.c err_mark.c err.c err_all.c err_all_legacy.c err_prn.c

--- a/crypto/err/err.c
+++ b/crypto/err/err.c
@@ -847,61 +847,6 @@ void ERR_add_error_vdata(int num, va_list args)
         OPENSSL_free(str);
 }
 
-int ERR_set_mark(void)
-{
-    ERR_STATE *es;
-
-    es = ossl_err_get_state_int();
-    if (es == NULL)
-        return 0;
-
-    if (es->bottom == es->top)
-        return 0;
-    es->err_marks[es->top]++;
-    return 1;
-}
-
-int ERR_pop_to_mark(void)
-{
-    ERR_STATE *es;
-
-    es = ossl_err_get_state_int();
-    if (es == NULL)
-        return 0;
-
-    while (es->bottom != es->top
-           && es->err_marks[es->top] == 0) {
-        err_clear(es, es->top, 0);
-        es->top = es->top > 0 ? es->top - 1 : ERR_NUM_ERRORS - 1;
-    }
-
-    if (es->bottom == es->top)
-        return 0;
-    es->err_marks[es->top]--;
-    return 1;
-}
-
-int ERR_clear_last_mark(void)
-{
-    ERR_STATE *es;
-    int top;
-
-    es = ossl_err_get_state_int();
-    if (es == NULL)
-        return 0;
-
-    top = es->top;
-    while (es->bottom != top
-           && es->err_marks[top] == 0) {
-        top = top > 0 ? top - 1 : ERR_NUM_ERRORS - 1;
-    }
-
-    if (es->bottom == top)
-        return 0;
-    es->err_marks[top]--;
-    return 1;
-}
-
 void err_clear_last_constant_time(int clear)
 {
     ERR_STATE *es;

--- a/crypto/err/err_mark.c
+++ b/crypto/err/err_mark.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 2003-2022 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy

--- a/crypto/err/err_mark.c
+++ b/crypto/err/err_mark.c
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2022 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#define OSSL_FORCE_ERR_STATE
+
+#include <openssl/err.h>
+#include "err_local.h"
+
+int ERR_set_mark(void)
+{
+    ERR_STATE *es;
+
+    es = ossl_err_get_state_int();
+    if (es == NULL)
+        return 0;
+
+    if (es->bottom == es->top)
+        return 0;
+    es->err_marks[es->top]++;
+    return 1;
+}
+
+int ERR_pop_to_mark(void)
+{
+    ERR_STATE *es;
+
+    es = ossl_err_get_state_int();
+    if (es == NULL)
+        return 0;
+
+    while (es->bottom != es->top
+           && es->err_marks[es->top] == 0) {
+        err_clear(es, es->top, 0);
+        es->top = es->top > 0 ? es->top - 1 : ERR_NUM_ERRORS - 1;
+    }
+
+    if (es->bottom == es->top)
+        return 0;
+    es->err_marks[es->top]--;
+    return 1;
+}
+
+int ERR_clear_last_mark(void)
+{
+    ERR_STATE *es;
+    int top;
+
+    es = ossl_err_get_state_int();
+    if (es == NULL)
+        return 0;
+
+    top = es->top;
+    while (es->bottom != top
+           && es->err_marks[top] == 0) {
+        top = top > 0 ? top - 1 : ERR_NUM_ERRORS - 1;
+    }
+
+    if (es->bottom == top)
+        return 0;
+    es->err_marks[top]--;
+    return 1;
+}
+

--- a/providers/legacyprov.c
+++ b/providers/legacyprov.c
@@ -12,6 +12,7 @@
 #include <openssl/core.h>
 #include <openssl/core_dispatch.h>
 #include <openssl/core_names.h>
+#include <openssl/err.h>
 #include <openssl/params.h>
 #include "prov/provider_ctx.h"
 #include "prov/implementations.h"
@@ -31,6 +32,22 @@ static OSSL_FUNC_provider_query_operation_fn legacy_query;
 #ifdef STATIC_LEGACY
 OSSL_provider_init_fn ossl_legacy_provider_init;
 # define OSSL_provider_init ossl_legacy_provider_init
+#endif
+
+#ifndef STATIC_LEGACY
+/*
+ * Should these function pointers be stored in the provider side provctx?
+ * Could they ever be different from one init to the next? We assume not for
+ * now.
+ */
+
+/* Functions provided by the core */
+static OSSL_FUNC_core_new_error_fn *c_new_error;
+static OSSL_FUNC_core_set_error_debug_fn *c_set_error_debug;
+static OSSL_FUNC_core_vset_error_fn *c_vset_error;
+static OSSL_FUNC_core_set_error_mark_fn *c_set_error_mark;
+static OSSL_FUNC_core_clear_last_error_mark_fn *c_clear_last_error_mark;
+static OSSL_FUNC_core_pop_error_to_mark_fn *c_pop_error_to_mark;
 #endif
 
 /* Parameters we provide to the core */
@@ -185,6 +202,48 @@ int OSSL_provider_init(const OSSL_CORE_HANDLE *handle,
                        void **provctx)
 {
     OSSL_LIB_CTX *libctx = NULL;
+#ifndef STATIC_LEGACY
+    const OSSL_DISPATCH *tmp;
+#endif
+
+#ifndef STATIC_LEGACY
+    for (tmp = in; tmp->function_id != 0; tmp++) {
+        /*
+         * We do not support the scenario of an application linked against
+         * multiple versions of libcrypto (e.g. one static and one dynamic),
+         * but sharing a single legacy.so. We do a simple sanity check here.
+         */
+#define set_func(c, f)                          \
+        if (c == NULL)                          \
+            c = f;                              \
+        else                                    \
+            if (c != f) {                       \
+                fprintf(stderr, "FOO" #f);      \
+                return 0;                       \
+            }
+        switch (tmp->function_id) {
+        case OSSL_FUNC_CORE_NEW_ERROR:
+            set_func(c_new_error, OSSL_FUNC_core_new_error(tmp));
+            break;
+        case OSSL_FUNC_CORE_SET_ERROR_DEBUG:
+            set_func(c_set_error_debug, OSSL_FUNC_core_set_error_debug(tmp));
+            break;
+        case OSSL_FUNC_CORE_VSET_ERROR:
+            set_func(c_vset_error, OSSL_FUNC_core_vset_error(tmp));
+            break;
+        case OSSL_FUNC_CORE_SET_ERROR_MARK:
+            set_func(c_set_error_mark, OSSL_FUNC_core_set_error_mark(tmp));
+            break;
+        case OSSL_FUNC_CORE_CLEAR_LAST_ERROR_MARK:
+            set_func(c_clear_last_error_mark,
+                     OSSL_FUNC_core_clear_last_error_mark(tmp));
+            break;
+        case OSSL_FUNC_CORE_POP_ERROR_TO_MARK:
+            set_func(c_pop_error_to_mark, OSSL_FUNC_core_pop_error_to_mark(tmp));
+            break;
+        }
+    }
+#endif
 
     if ((*provctx = ossl_prov_ctx_new()) == NULL
         || (libctx = OSSL_LIB_CTX_new_child(handle, in)) == NULL) {
@@ -200,3 +259,53 @@ int OSSL_provider_init(const OSSL_CORE_HANDLE *handle,
 
     return 1;
 }
+
+#ifndef STATIC_LEGACY
+/*
+ * Provider specific implementation of libcrypto functions in terms of
+ * upcalls.
+ */
+
+/*
+ * For ERR functions, we pass a NULL context.  This is valid to do as long
+ * as only error codes that the calling libcrypto supports are used.
+ */
+void ERR_new(void)
+{
+    c_new_error(NULL);
+}
+
+void ERR_set_debug(const char *file, int line, const char *func)
+{
+    c_set_error_debug(NULL, file, line, func);
+}
+
+void ERR_set_error(int lib, int reason, const char *fmt, ...)
+{
+    va_list args;
+
+    va_start(args, fmt);
+    c_vset_error(NULL, ERR_PACK(lib, 0, reason), fmt, args);
+    va_end(args);
+}
+
+void ERR_vset_error(int lib, int reason, const char *fmt, va_list args)
+{
+    c_vset_error(NULL, ERR_PACK(lib, 0, reason), fmt, args);
+}
+
+int ERR_set_mark(void)
+{
+    return c_set_error_mark(NULL);
+}
+
+int ERR_clear_last_mark(void)
+{
+    return c_clear_last_error_mark(NULL);
+}
+
+int ERR_pop_to_mark(void)
+{
+    return c_pop_error_to_mark(NULL);
+}
+#endif

--- a/providers/legacyprov.c
+++ b/providers/legacyprov.c
@@ -213,14 +213,7 @@ int OSSL_provider_init(const OSSL_CORE_HANDLE *handle,
          * multiple versions of libcrypto (e.g. one static and one dynamic),
          * but sharing a single legacy.so. We do a simple sanity check here.
          */
-#define set_func(c, f)                          \
-        if (c == NULL)                          \
-            c = f;                              \
-        else                                    \
-            if (c != f) {                       \
-                fprintf(stderr, "FOO" #f);      \
-                return 0;                       \
-            }
+#define set_func(c, f) if (c == NULL) c = f; else if (c != f) return 0;
         switch (tmp->function_id) {
         case OSSL_FUNC_CORE_NEW_ERROR:
             set_func(c_new_error, OSSL_FUNC_core_new_error(tmp));


### PR DESCRIPTION
~This reverts 7ee992a5d931ab5ad9df00d2d8e47e1b7a72d7ac, which linked
`test/endecode_test` statically with the legacy provider to avoid
having `ossl_init_register_atexit()` called from inside the provider.~

~We avoid calling `ossl_init_register_atexit()` from inside the provider
by reimplementing libcrypto functions that end up doing so, in terms of
upcalls.  For the legacy provider, that's the set of ERR upcalls.~

Any provider module should use the ERR upcalls for error reporting, or they may be lost (if the provider module is linked with a different libcrypto than it's loaded by).