### PR TITLE
fips self test: avoid using a macro expansion in a macro when statically initialising

### DIFF
--- a/providers/fips/self_test_data.inc
+++ b/providers/fips/self_test_data.inc
@@ -18,7 +18,7 @@
     { name, OSSL_PARAM_OCTET_STRING, ITM(data) }
 #define ST_KAT_PARAM_UTF8STRING(name, data)                                    \
     { name, OSSL_PARAM_UTF8_STRING, ITM_STR(data) }
-#define ST_KAT_PARAM_UTF8CHAR(name, data)                                    \
+#define ST_KAT_PARAM_UTF8CHAR(name, data)                                      \
     { name, OSSL_PARAM_UTF8_STRING, ITM(data) }
 #define ST_KAT_PARAM_INT(name, i)                                              \
     { name, OSSL_PARAM_INTEGER, ITM(i) }
@@ -1291,9 +1291,15 @@ static const ST_KAT_PARAM rsa_priv_key[] = {
     ST_KAT_PARAM_END()
 };
 
+/*-
+ * Using OSSL_PKEY_RSA_PAD_MODE_NONE directly in the expansion of the
+ * ST_KAT_PARAM_UTF8STRING macro below causes a failure on ancient
+ * HP/UX PA-RISC compilers.
+ */
+static const char pad_mode_none[] = OSSL_PKEY_RSA_PAD_MODE_NONE;
+
 static const ST_KAT_PARAM rsa_enc_params[] = {
-    ST_KAT_PARAM_UTF8STRING(OSSL_ASYM_CIPHER_PARAM_PAD_MODE,
-                            OSSL_PKEY_RSA_PAD_MODE_NONE),
+    ST_KAT_PARAM_UTF8STRING(OSSL_ASYM_CIPHER_PARAM_PAD_MODE, pad_mode_none),
     ST_KAT_PARAM_END()
 };
 


### PR DESCRIPTION
Circumvents a problem with ancient PA-RISC compilers on HP/UX.

Fixes #17477


- [ ] documentation is added or updated
- [ ] tests are added or updated
