### PR TITLE
Allow safer hooking of OPENSSL_cleanup in providers

### DIFF
--- a/crypto/init.c
+++ b/crypto/init.c
@@ -123,11 +123,7 @@ static int ossl_init_register_cleanup(const OSSL_CORE_HANDLE *handle)
     if (i < handles_num)
         goto end;
 
-    /*
-     * Allocate the handles array in chunks of 10 elements.
-     * Trust that the memory allocator doesn't actually reallocate
-     * when the size is unchanged.
-     */
+    /* Allocate the handles array in chunks of 10 elements */
     handles
         = OPENSSL_realloc(handles,
                           (handles_num / 10 + 1) * 10 * sizeof(handles[0]));

--- a/crypto/init.c
+++ b/crypto/init.c
@@ -130,7 +130,7 @@ static int ossl_init_register_cleanup(const OSSL_CORE_HANDLE *handle)
         goto end;
 
     ret = -1;
-    if (handles_num < OSSL_NELEM(handles)) {
+    if (ossl_assert(handles_num < OSSL_NELEM(handles))) {
         ret = (int)handles_num;
         handles[handles_num++] = handle;
     }

--- a/crypto/init.c
+++ b/crypto/init.c
@@ -699,7 +699,7 @@ int OPENSSL_init_crypto(uint64_t opts, const OPENSSL_INIT_SETTINGS *settings)
      * torn down.
      * Care is taken to handle the case where libcrypto is shared by multiple
      * providers, by registering the provider handle.  When the cleanup
-     * function is called, that same handle is unregistered, when when the
+     * function is called, that same handle is unregistered, when the
      * register is empty, OPENSSL_cleanup() is called.
      * Care is also taken to handle the case where the libcrypto that the
      * provider is linked with is shared with the calling application, by

--- a/crypto/init.c
+++ b/crypto/init.c
@@ -128,7 +128,9 @@ static int ossl_init_register_cleanup(const OSSL_CORE_HANDLE *handle)
      * Trust that the memory allocator doesn't actually reallocate
      * when the size is unchanged.
      */
-    handles = OPENSSL_realloc(handles, (handles_num / 10 + 1) * 10);
+    handles
+        = OPENSSL_realloc(handles,
+                          (handles_num / 10 + 1) * 10 * sizeof(handles[0]));
     ret = 0;
     if (handles != NULL) {
         handles[handles_num++] = handle;

--- a/crypto/init.c
+++ b/crypto/init.c
@@ -165,7 +165,7 @@ static int ossl_init_unregister_cleanup(const OSSL_CORE_HANDLE *handle)
     }
     ret = (int)handles_num;
 
-    if (handles_num == NULL) {
+    if (handles_num == 0) {
         OPENSSL_free(handles);
         handles = NULL;
     }
@@ -497,7 +497,6 @@ DEFINE_RUN_ONCE_STATIC(ossl_init_engine_afalg)
 
 void OPENSSL_cleanup(void)
 {
-    int n;
     OPENSSL_INIT_STOP *currhandler, *lasthandler;
 
     /*
@@ -614,8 +613,8 @@ void OPENSSL_cleanup(void)
      * the application is not, so it gets removed now to avoid causing a
      * small memory leak.
      */
-    n = ossl_init_unregister_cleanup(NULL);
-    /* What to do if n != 0 ? */
+    ossl_init_unregister_cleanup(NULL);
+    /* What to do if ossl_init_unregister_cleanup(NULL) != 0 ? */
 
     CRYPTO_THREAD_lock_free(init_lock);
     init_lock = NULL;

--- a/doc/man3/OPENSSL_init_crypto.pod
+++ b/doc/man3/OPENSSL_init_crypto.pod
@@ -28,7 +28,7 @@ and deinitialisation functions
                                      const char* name);
  int OPENSSL_INIT_set_upcalls(OPENSSL_INIT_SETTINGS *settings,
                               const OSSL_CORE_HANDLE *handle,
-                              const OSSL_DISPATCH *upcalls)
+                              const OSSL_DISPATCH *upcalls);
  void OPENSSL_INIT_free(OPENSSL_INIT_SETTINGS *init);
 
 =head1 DESCRIPTION

--- a/doc/man3/OPENSSL_init_crypto.pod
+++ b/doc/man3/OPENSSL_init_crypto.pod
@@ -4,7 +4,8 @@
 
 OPENSSL_INIT_new, OPENSSL_INIT_set_config_filename,
 OPENSSL_INIT_set_config_appname, OPENSSL_INIT_set_config_file_flags,
-OPENSSL_INIT_free, OPENSSL_init_crypto, OPENSSL_cleanup, OPENSSL_atexit,
+OPENSSL_INIT_set_upcalls, OPENSSL_INIT_free,
+OPENSSL_init_crypto, OPENSSL_cleanup, OPENSSL_atexit,
 OPENSSL_thread_stop_ex, OPENSSL_thread_stop - OpenSSL initialisation
 and deinitialisation functions
 
@@ -25,6 +26,9 @@ and deinitialisation functions
                                         unsigned long flags);
  int OPENSSL_INIT_set_config_appname(OPENSSL_INIT_SETTINGS *init,
                                      const char* name);
+ int OPENSSL_INIT_set_upcalls(OPENSSL_INIT_SETTINGS *settings,
+                              const OSSL_CORE_HANDLE *handle,
+                              const OSSL_DISPATCH *upcalls)
  void OPENSSL_INIT_free(OPENSSL_INIT_SETTINGS *init);
 
 =head1 DESCRIPTION
@@ -180,6 +184,25 @@ By default OpenSSL will attempt to clean itself up when the process exits via an
 the application will have to clean up OpenSSL explicitly using
 OPENSSL_cleanup().
 
+=item OPENSSL_INIT_PROVIDER
+
+For providers that are linked with libcrypto, using this option ensures that
+proper libcrypto cleanup is done when the provider is torn down.
+
+This option requires an B<OPENSSL_INIT_SETTINGS> object that has been populated
+using OPENSSL_INIT_set_upcalls(), given the provider's B<OSSL_CORE_HANDLE> and
+input B<OSSL_DISPATCH>.  A typical call would look like this:
+
+ OPENSSL_INIT_SETTINGS *settings = NULL;
+
+ if ((settings = OPENSSL_INIT_new()) == NULL
+     || !OPENSSL_INIT_set_upcalls(settings, handle, in)
+     || !OPENSSL_init_crypto(OPENSSL_INIT_PROVIDER, settings)) {
+     OPENSSL_INIT_free(settings);
+     return 0;
+ }
+ OPENSSL_INIT_free(settings);
+
 =back
 
 Multiple options may be combined together in a single call to
@@ -244,7 +267,7 @@ The B<OPENSSL_INIT_set_config_filename()> function can be used to specify a
 nondefault filename, which is copied and need not refer to persistent storage.
 Similarly, OPENSSL_INIT_set_config_appname() can be used to specify a
 nondefault application name.
-Finally, OPENSSL_INIT_set_file_flags can be used to specify nondefault flags.
+Finally, OPENSSL_INIT_set_file_flags() can be used to specify nondefault flags.
 If the B<CONF_MFLAGS_IGNORE_RETURN_CODES> flag is not included, any errors in
 the configuration file will cause an error return from B<OPENSSL_init_crypto>
 or indirectly L<OPENSSL_init_ssl(3)>.

--- a/doc/man7/provider-base.pod
+++ b/doc/man7/provider-base.pod
@@ -31,6 +31,9 @@ provider-base
  void core_vset_error(const OSSL_CORE_HANDLE *handle,
                       uint32_t reason, const char *fmt, va_list args);
 
+ int core_hook_cleanup(const OSSL_CORE_HANDLE *prov,
+                       void (*function)(const OSSL_CORE_HANDLE *handle));
+
  int core_obj_add_sigid(const OSSL_CORE_HANDLE *prov, const char  *sign_name,
                         const char *digest_name, const char *pkey_name);
  int core_obj_create(const OSSL_CORE_HANDLE *handle, const char *oid,
@@ -144,6 +147,7 @@ provider):
  core_new_error                 OSSL_FUNC_CORE_NEW_ERROR
  core_set_error_debug           OSSL_FUNC_CORE_SET_ERROR_DEBUG
  core_vset_error                OSSL_FUNC_CORE_VSET_ERROR
+ core_hook_cleanup              OSSL_FUNC_CORE_HOOK_CLEANUP
  core_obj_add_sigid             OSSL_FUNC_CORE_OBJ_ADD_SIGID
  core_obj_create                OSSL_FUNC_CORE_OBJ_CREATE
  CRYPTO_malloc                  OSSL_FUNC_CRYPTO_MALLOC
@@ -257,6 +261,11 @@ error occurred or was reported.
 This corresponds to the OpenSSL function L<ERR_vset_error(3)>.
 
 =back
+
+core_hook_cleanup() is used to hook libcrypto cleanup functionality to the
+provider tear down.
+The is used by the call C<OPENSSL_init_crypto(OPENSSL_INIT_PROVIDER, ...)>,
+see the documentation of B<OPENSSL_INIT_PROVIDER> in L<OPENSSL_init_crypto(3)>.
 
 The core_obj_create() function registers a new OID and associated short name
 I<sn> and long name I<ln> for the given I<handle>. It is similar to the OpenSSL

--- a/doc/man7/provider.pod
+++ b/doc/man7/provider.pod
@@ -72,6 +72,39 @@ the provider.
 Note that the provider will not be made available for applications to use until
 the initialization function has completed and returned successfully.
 
+I<< If the provider is a shared module and uses F<libcrypto> functions,
+it is B<strongly> recommended that the initialization function initialises
+F<libcrypto> appropriately, by including the following lines as early as
+possible: >>
+
+ if ((settings = OPENSSL_INIT_new()) == NULL
+     || !OPENSSL_INIT_set_upcalls(settings, handle, in)
+     || !OPENSSL_init_crypto(OPENSSL_INIT_PROVIDER, settings)) {
+     OPENSSL_INIT_free(settings);
+     return 0;
+ }
+ OPENSSL_INIT_free(settings);
+
+Those lines can be in providers that are statically linked into the application
+as well.  They are not necessary in that case, but are harmless, so they can be
+used unconditionally in source code that is used equally for providers that are
+made into dynamically loadable modules and for providers that are built into the
+application.
+
+=begin comment
+
+Those lines are harmless in providers that are built into libcrypto as well,
+such as the base and default providers.  However, since those are never built
+as dynamically loadable modules, we simply don't include those lines on those
+providers.
+
+Those lines aren't used in the FIPS provider module either.  That provider is
+rather special, as it uses select libcrypto source files rather than linking
+with, and doesn't include the OPENSSL_init_crypto source at all, so it's assumed
+that it has every in control in a different manner.
+
+=end comment
+
 One of the functions the provider offers to the OpenSSL libraries is
 the central mechanism for the OpenSSL libraries to get access to
 operation implementations for diverse algorithms.

--- a/doc/man7/provider.pod
+++ b/doc/man7/provider.pod
@@ -91,20 +91,6 @@ used unconditionally in source code that is used equally for providers that are
 made into dynamically loadable modules and for providers that are built into the
 application.
 
-=begin comment
-
-Those lines are harmless in providers that are built into libcrypto as well,
-such as the base and default providers.  However, since those are never built
-as dynamically loadable modules, we simply don't include those lines on those
-providers.
-
-Those lines aren't used in the FIPS provider module either.  That provider is
-rather special, as it uses select libcrypto source files rather than linking
-with, and doesn't include the OPENSSL_init_crypto source at all, so it's assumed
-that it has every in control in a different manner.
-
-=end comment
-
 One of the functions the provider offers to the OpenSSL libraries is
 the central mechanism for the OpenSSL libraries to get access to
 operation implementations for diverse algorithms.

--- a/include/internal/conf.h
+++ b/include/internal/conf.h
@@ -19,9 +19,20 @@
      CONF_MFLAGS_IGNORE_RETURN_CODES)
 
 struct ossl_init_settings_st {
+    /*
+     * config(5) elements, only used when  OPENSSL_init_crypto() is called
+     * with the option OPENSSL_INIT_LOAD_CONFIG
+     */
     char *filename;
     char *appname;
     unsigned long flags;
+
+    /*
+     * Provider elements, only used when OPENSSL_init_crypto() is called
+     * with the option OPENSSL_INIT_PROVIDER.
+     */
+    const OSSL_DISPATCH *upcalls;
+    const OSSL_CORE_HANDLE *handle;
 };
 
 int ossl_config_int(const OPENSSL_INIT_SETTINGS *);

--- a/include/internal/provider.h
+++ b/include/internal/provider.h
@@ -47,6 +47,9 @@ const OSSL_CORE_HANDLE *ossl_provider_get_parent(OSSL_PROVIDER *prov);
 int ossl_provider_up_ref_parent(OSSL_PROVIDER *prov, int activate);
 int ossl_provider_free_parent(OSSL_PROVIDER *prov, int deactivate);
 int ossl_provider_default_props_update(OSSL_LIB_CTX *libctx, const char *props);
+int ossl_provider_set_cleanup_hook(OSSL_PROVIDER *prov,
+                                   void (*function)(const OSSL_CORE_HANDLE
+                                                    *handle));
 
 /* Disable fallback loading */
 int ossl_provider_disable_fallback_loading(OSSL_LIB_CTX *libctx);

--- a/include/openssl/core_dispatch.h
+++ b/include/openssl/core_dispatch.h
@@ -104,6 +104,11 @@ OSSL_CORE_MAKE_FUNC(int, core_obj_create,
                     (const OSSL_CORE_HANDLE *prov, const char *oid,
                      const char *sn, const char *ln))
 
+#define OSSL_FUNC_CORE_HOOK_CLEANUP           13
+OSSL_CORE_MAKE_FUNC(int, core_hook_cleanup,
+                    (const OSSL_CORE_HANDLE *prov,
+                     void (*function)(const OSSL_CORE_HANDLE *handle)))
+
 /* Memory allocation, freeing, clearing. */
 #define OSSL_FUNC_CRYPTO_MALLOC               20
 OSSL_CORE_MAKE_FUNC(void *,

--- a/include/openssl/crypto.h.in
+++ b/include/openssl/crypto.h.in
@@ -438,7 +438,7 @@ int CRYPTO_memcmp(const void * in_a, const void * in_b, size_t len);
 # define OPENSSL_INIT_ENGINE_CAPI            0x00002000L
 # define OPENSSL_INIT_ENGINE_PADLOCK         0x00004000L
 # define OPENSSL_INIT_ENGINE_AFALG           0x00008000L
-/* FREE:                                     0x00010000L */
+# define OPENSSL_INIT_PROVIDER               0x00010000L
 # define OPENSSL_INIT_ATFORK                 0x00020000L
 /* OPENSSL_INIT_BASE_ONLY                    0x00040000L */
 # define OPENSSL_INIT_NO_ATEXIT              0x00080000L
@@ -474,6 +474,9 @@ void OPENSSL_INIT_set_config_file_flags(OPENSSL_INIT_SETTINGS *settings,
 int OPENSSL_INIT_set_config_appname(OPENSSL_INIT_SETTINGS *settings,
                                     const char *config_appname);
 # endif
+int OPENSSL_INIT_set_upcalls(OPENSSL_INIT_SETTINGS *settings,
+                             const OSSL_CORE_HANDLE *handle,
+                             const OSSL_DISPATCH *upcalls);
 void OPENSSL_INIT_free(OPENSSL_INIT_SETTINGS *settings);
 
 # if defined(OPENSSL_THREADS) && !defined(CRYPTO_TDEBUG)

--- a/providers/baseprov.c
+++ b/providers/baseprov.c
@@ -130,6 +130,15 @@ int ossl_base_provider_init(const OSSL_CORE_HANDLE *handle,
     OSSL_FUNC_core_get_libctx_fn *c_get_libctx = NULL;
     BIO_METHOD *corebiometh;
 
+    /*
+     * The OPENSSL_init_crypto(OPENSSL_INIT_PROVIDER, ...) call that's
+     * indicated in provider(7) isn't necessary here, since this provider
+     * is built into libcrypto and never built into a loadable module.
+     *
+     * It would be perfectly harmless to have that call here, possibly for
+     * demonstration purposes, but that seems like unnecessary churn.
+     */
+
     if (!ossl_prov_bio_from_dispatch(in))
         return 0;
     for (; in->function_id != 0; in++) {

--- a/providers/defltprov.c
+++ b/providers/defltprov.c
@@ -565,6 +565,15 @@ int ossl_default_provider_init(const OSSL_CORE_HANDLE *handle,
     OSSL_FUNC_core_get_libctx_fn *c_get_libctx = NULL;
     BIO_METHOD *corebiometh;
 
+    /*
+     * The OPENSSL_init_crypto(OPENSSL_INIT_PROVIDER, ...) call that's
+     * indicated in provider(7) isn't necessary here, since this provider
+     * is built into libcrypto and never built into a loadable module.
+     *
+     * It would be perfectly harmless to have that call here, possibly for
+     * demonstration purposes, but that seems like unnecessary churn.
+     */
+
     if (!ossl_prov_bio_from_dispatch(in)
             || !ossl_prov_seeding_from_dispatch(in))
         return 0;

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -550,7 +550,7 @@ int OSSL_provider_init_int(const OSSL_CORE_HANDLE *handle,
 
     /*
      * The OPENSSL_init_crypto(OPENSSL_INIT_PROVIDER, ...) call that's
-     * indicated in provider(7) isn't necessary here, since The FIPS module
+     * indicated in provider(7) isn't necessary here, since the FIPS module
      * uses select libcrypto sources and doesn't include crypto/init.c among
      * those (i.e. doesn't even have access to OPENSSL_init_crypto() or
      * OPENSSL_cleanup()).

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -548,6 +548,14 @@ int OSSL_provider_init_int(const OSSL_CORE_HANDLE *handle,
     OSSL_LIB_CTX *libctx = NULL;
     SELF_TEST_POST_PARAMS selftest_params;
 
+    /*
+     * The OPENSSL_init_crypto(OPENSSL_INIT_PROVIDER, ...) call that's
+     * indicated in provider(7) isn't necessary here, since The FIPS module
+     * uses select libcrypto sources and doesn't include crypto/init.c among
+     * those (i.e. doesn't even have access to OPENSSL_init_crypto() or
+     * OPENSSL_cleanup()).
+     */
+
     memset(&selftest_params, 0, sizeof(selftest_params));
 
     if (!ossl_prov_seeding_from_dispatch(in))

--- a/providers/legacyprov.c
+++ b/providers/legacyprov.c
@@ -205,6 +205,16 @@ int OSSL_provider_init(const OSSL_CORE_HANDLE *handle,
 #ifndef STATIC_LEGACY
     const OSSL_DISPATCH *tmp;
 #endif
+    OPENSSL_INIT_SETTINGS *settings = NULL;
+
+    if ((settings = OPENSSL_INIT_new()) == NULL
+        || !OPENSSL_INIT_set_upcalls(settings, handle, in)
+        || !OPENSSL_init_crypto(OPENSSL_INIT_PROVIDER, settings)) {
+        OPENSSL_INIT_free(settings);
+        return 0;
+    }
+    OPENSSL_INIT_free(settings);
+
 
 #ifndef STATIC_LEGACY
     for (tmp = in; tmp->function_id != 0; tmp++) {

--- a/test/build.info
+++ b/test/build.info
@@ -1003,14 +1003,6 @@ IF[{- !$disabled{tests} -}]
   SOURCE[endecode_test]=endecode_test.c helpers/predefined_dhparams.c
   INCLUDE[endecode_test]=.. ../include ../apps/include
   DEPEND[endecode_test]=../libcrypto.a libtestutil.a
-  IF[{- !$disabled{module} && !$disabled{legacy} -}]
-    DEFINE[endecode_test]=STATIC_LEGACY
-    SOURCE[endecode_test]=../providers/legacyprov.c
-    INCLUDE[endecode_test]=../providers/common/include \
-                           ../providers/implementations/include
-    DEPEND[endecode_test]=../providers/liblegacy.a \
-                          ../providers/libcommon.a
-  ENDIF
 
   IF[{- !$disabled{'deprecated-3.0'} -}]
     PROGRAMS{noinst}=endecoder_legacy_test

--- a/test/endecode_test.c
+++ b/test/endecode_test.c
@@ -26,10 +26,6 @@
 #include "helpers/predefined_dhparams.h"
 #include "testutil.h"
 
-#ifdef STATIC_LEGACY
-OSSL_provider_init_fn ossl_legacy_provider_init;
-#endif
-
 /* Extended test macros to allow passing file & line number */
 #define TEST_FL_ptr(a)               test_ptr(file, line, #a, a)
 #define TEST_FL_mem_eq(a, m, b, n)   test_mem_eq(file, line, #a, #b, a, m, b, n)
@@ -1328,16 +1324,6 @@ int setup_tests(void)
     is_fips_3_0_0 = fips_provider_version_eq(testctx, 3, 0, 0);
     if (is_fips_3_0_0 < 0)
         return 0;
-
-#ifdef STATIC_LEGACY
-    /*
-     * This test is always statically linked against libcrypto. We must not
-     * attempt to load legacy.so that might be dynamically linked against
-     * libcrypto. Instead we use a built-in version of the legacy provider.
-     */
-    if (!OSSL_PROVIDER_add_builtin(testctx, "legacy", ossl_legacy_provider_init))
-        return 0;
-#endif
 
     /* Separate provider/ctx for generating the test data */
     if (!TEST_ptr(keyctx = OSSL_LIB_CTX_new()))

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5506,3 +5506,4 @@ OSSL_HPKE_CTX_get_seq                   ?	3_2_0	EXIST::FUNCTION:
 OSSL_HPKE_CTX_set_seq                   ?	3_2_0	EXIST::FUNCTION:
 OSSL_HPKE_get_recommended_ikmelen       ?	3_2_0	EXIST::FUNCTION:
 OSSL_PROVIDER_get0_default_search_path  ?	3_2_0	EXIST::FUNCTION:
+OPENSSL_INIT_set_upcalls                ?	3_1_0	EXIST::FUNCTION:


### PR DESCRIPTION
Calling OPENSSL_cleanup() through atexit() from a libcrypto that's loaded via a provider module is a bad idea, since the handler will most likely be called after the provider has been unloaded.

This adds a mechanism that allows a provider to hook the ~addition of atexit functions~ libcrypto cleanup via an upcall that's offered by the calling libcrypto, and have an internal mechanism that ensures that the cleanup isn't called too early.  The legacy provider module is enhanced with this.

Because the FIPS provider only contains a subset of libcrypto, and nothing that gives cause to call atexit(), we don't change it.

