### PR TITLE
Cleansing all the temporary data for s390x

### DIFF
--- a/crypto/ec/ecp_s390x_nistp.c
+++ b/crypto/ec/ecp_s390x_nistp.c
@@ -116,7 +116,7 @@ ret:
     /* Otherwise use default. */
     if (rc == -1)
         rc = ossl_ec_wNAF_mul(group, r, scalar, num, points, scalars, ctx);
-    OPENSSL_cleanse(param + S390X_OFF_SCALAR(len), len);
+    OPENSSL_cleanse(param, sizeof(param));
     BN_CTX_end(ctx);
     BN_CTX_free(new_ctx);
     return rc;
@@ -212,7 +212,7 @@ static ECDSA_SIG *ecdsa_s390x_nistp_sign_sig(const unsigned char *dgst,
 
     ok = 1;
 ret:
-    OPENSSL_cleanse(param + S390X_OFF_K(len), 2 * len);
+    OPENSSL_cleanse(param, sizeof(param));
     if (ok != 1) {
         ECDSA_SIG_free(sig);
         sig = NULL;


### PR DESCRIPTION
s390x shared key computation didn't properly clean the shared key value.
This patch fixes the issue.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
