### PR TITLE
APPS `load_cert_certs()`: fix crash on `pcerts == NULL`

### DIFF
--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -691,8 +691,9 @@ int load_cert_certs(const char *uri,
     if (ret) {
         if (pcert != NULL)
             warn_cert(uri, *pcert, 0, vpm);
-        warn_certs(uri, *pcerts, 1, vpm);
-    } else {
+        if (pcerts != NULL)
+            warn_certs(uri, *pcerts, 1, vpm);
+    } else if (pcerts != NULL) {
         OSSL_STACK_OF_X509_free(*pcerts);
         *pcerts = NULL;
     }


### PR DESCRIPTION
One of the two defects was found by Coverity:
```
>>>     CID 1497107:  Null pointer dereferences  (FORWARD_NULL)
>>>     Dereferencing null pointer "pcerts".
696             OSSL_STACK_OF_X509_free(*pcerts);
```