### PR TITLE
bn_ppc.c: Fix build failure on AIX with XLC/XLCLANG

### DIFF
--- a/crypto/bn/bn_ppc.c
+++ b/crypto/bn/bn_ppc.c
@@ -40,7 +40,7 @@ int bn_mul_mont(BN_ULONG *rp, const BN_ULONG *ap, const BN_ULONG *bp,
      * no opportunity to figure it out...
      */
 
-#if defined(_ARCH_PPC64)
+#if defined(_ARCH_PPC64) && !defined(__ILP32__)
     if (num == 6) {
         if (OPENSSL_ppccap_P & PPC_MADD300)
             return bn_mul_mont_300_fixed_n6(rp, ap, bp, np, n0, num);


### PR DESCRIPTION
These compilers define _ARCH_PPC64 for 32 bit builds
so we cannot depend solely on this define to identify
32 bit build.

Fixes #17087
