### PR TITLE
Restore record length checks for KTLS

### DIFF
--- a/test/recipes/80-test_ssl_old.t
+++ b/test/recipes/80-test_ssl_old.t
@@ -346,11 +346,9 @@ sub testssl {
     }
 
 
-    # plan tests => 11;
-
     subtest 'standard SSL tests' => sub {
         ######################################################################
-        plan tests => 13;
+        plan tests => 19;
 
       SKIP: {
           skip "SSLv3 is not supported by this OpenSSL build", 4
@@ -378,7 +376,7 @@ sub testssl {
         }
 
       SKIP: {
-          skip "Neither SSLv3 nor any TLS version are supported by this OpenSSL build", 8
+          skip "Neither SSLv3 nor any TLS version are supported by this OpenSSL build", 14
               if $no_anytls;
 
         SKIP: {
@@ -406,17 +404,29 @@ sub testssl {
              'test sslv2/sslv3 with both client and server authentication via BIO pair and app verify');
 
         SKIP: {
-            skip "No IPv4 available on this machine", 1
+            skip "No IPv4 available on this machine", 4
                 unless !disabled("sock") && have_IPv4();
             ok(run(test([@ssltest, "-ipv4"])),
                'test TLS via IPv4');
+            ok(run(test([@ssltest, "-ipv4", "-client_ktls"])),
+               'test TLS via IPv4 + ktls(client)');
+            ok(run(test([@ssltest, "-ipv4", "-server_ktls"])),
+               'test TLS via IPv4 + ktls(server)');
+            ok(run(test([@ssltest, "-ipv4", "-client_ktls", "-server_ktls"])),
+               'test TLS via IPv4 + ktls');
           }
 
         SKIP: {
-            skip "No IPv6 available on this machine", 1
+            skip "No IPv6 available on this machine", 4
                 unless !disabled("sock") && have_IPv6();
             ok(run(test([@ssltest, "-ipv6"])),
                'test TLS via IPv6');
+            ok(run(test([@ssltest, "-ipv6", "-client_ktls"])),
+               'test TLS via IPv6 + ktls(client)');
+            ok(run(test([@ssltest, "-ipv6", "-server_ktls"])),
+               'test TLS via IPv6 + ktls(client)');
+            ok(run(test([@ssltest, "-ipv6", "-client_ktls", "-server_ktls"])),
+               'test TLS via IPv6 + ktls');
           }
         }
     };

--- a/test/ssl_old_test.c
+++ b/test/ssl_old_test.c
@@ -711,6 +711,8 @@ static void sv_usage(void)
     fprintf(stderr, " -client_sess_in <file>     - Read the client session from a file\n");
     fprintf(stderr, " -should_reuse <number>     - The expected state of reusing the session\n");
     fprintf(stderr, " -no_ticket    - do not issue TLS session ticket\n");
+    fprintf(stderr, " -client_ktls  - try to enable client KTLS\n");
+    fprintf(stderr, " -server_ktls  - try to enable server KTLS\n");
     fprintf(stderr, " -provider <name>    - Load the given provider into the library context\n");
     fprintf(stderr, " -config <cnf>    - Load the given config file into the library context\n");
 }
@@ -883,6 +885,7 @@ int main(int argc, char *argv[])
     int number = 1, reuse = 0;
     int should_reuse = -1;
     int no_ticket = 0;
+    int client_ktls = 0, server_ktls = 0;
     long bytes = 256L;
 #ifndef OPENSSL_NO_DH
     EVP_PKEY *dhpkey;
@@ -1167,6 +1170,10 @@ int main(int argc, char *argv[])
             should_reuse = !!atoi(*(++argv));
         } else if (strcmp(*argv, "-no_ticket") == 0) {
             no_ticket = 1;
+        } else if (strcmp(*argv, "-client_ktls") == 0) {
+            client_ktls = 1;
+        } else if (strcmp(*argv, "-server_ktls") == 0) {
+            server_ktls = 1;
         } else if (strcmp(*argv, "-provider") == 0) {
             if (--argc < 1)
                 goto bad;
@@ -1724,6 +1731,10 @@ int main(int argc, char *argv[])
 
     if (sn_client)
         SSL_set_tlsext_host_name(c_ssl, sn_client);
+    if (client_ktls)
+        SSL_set_options(c_ssl, SSL_OP_ENABLE_KTLS);
+    if (server_ktls)
+        SSL_set_options(s_ssl, SSL_OP_ENABLE_KTLS);
 
     if (!set_protocol_version(server_min_proto, s_ssl, SSL_CTRL_SET_MIN_PROTO_VERSION))
         goto end;


### PR DESCRIPTION
There seems to be no good reason to ignore packets
which exceed the allowed record length.
Add at least some tests for KTLS, since we have
currently zero test coverage for KTLS.

##### Checklist
- [x] tests are added or updated
