### PR TITLE
Fixed duplicate session_id conflict check

### DIFF
--- a/ssl/ssl_sess.c
+++ b/ssl/ssl_sess.c
@@ -412,10 +412,12 @@ int ssl_generate_session_id(SSL *s, SSL_SESSION *ss)
     }
     ss->session_id_length = tmp;
     /* Finally, check for a conflict */
-    if (SSL_has_matching_session_id(s, ss->session_id,
-                                    (unsigned int)ss->session_id_length)) {
-        SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_R_SSL_SESSION_ID_CONFLICT);
-        return 0;
+    if (cb != def_generate_session_id) {
+        if (SSL_has_matching_session_id(s, ss->session_id,
+                                        (unsigned int)ss->session_id_length)) {
+            SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_R_SSL_SESSION_ID_CONFLICT);
+            return 0;
+        }
     }
 
     return 1;


### PR DESCRIPTION
def_generate_session_id has checked the conflict of session_id, it is called in ssl_generate_session_id( ), ssl_generate_session_id( ) does not need to check the conflict repeatedly.
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->



