### PR TITLE
Prevent crash with engine using different openssl runtime

### DIFF
--- a/crypto/engine/eng_dyn.c
+++ b/crypto/engine/eng_dyn.c
@@ -452,7 +452,9 @@ static int dynamic_load(ENGINE *e, dynamic_data_ctx *ctx)
          * deferring to us (by returning its version) and we think it is too
          * old.
          */
-        if (vcheck_res < OSSL_DYNAMIC_OLDEST) {
+        if (vcheck_res < OSSL_DYNAMIC_OLDEST
+                || DSO_bind_func(ctx->dynamic_dso,
+                                 "EVP_PKEY_base_id") != NULL) {
             /* Fail */
             ctx->bind_engine = NULL;
             ctx->v_check = NULL;

--- a/include/openssl/engine.h
+++ b/include/openssl/engine.h
@@ -798,9 +798,17 @@ typedef int (*dynamic_bind_engine) (ENGINE *e, const char *id,
         OPENSSL_EXPORT \
         int bind_engine(ENGINE *e, const char *id, const dynamic_fns *fns) { \
             if (ENGINE_get_static_state() == fns->static_state) goto skip_cbs; \
+            if (getenv("OPENSSL_engine_libcrypto_override") == NULL) { \
+                fprintf(stderr, "ERROR: engine load aborted because a " \
+                        "different libcrypto was detected!\n" \
+                        "To override this check, please set " \
+                        "OPENSSL_engine_libcrypto_override=yes."); \
+                return 0; \
+            } \
             CRYPTO_set_mem_functions(fns->mem_fns.malloc_fn, \
                                      fns->mem_fns.realloc_fn, \
                                      fns->mem_fns.free_fn); \
+            OPENSSL_init_crypto(OPENSSL_INIT_NO_ATEXIT, NULL); \
         skip_cbs: \
             if (!fn(e, id)) return 0; \
             return 1; }

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -4562,6 +4562,11 @@ int setup_tests(void)
 # ifndef OPENSSL_NO_DYNAMIC_ENGINE
     /* Tests only support the default libctx */
     if (testctx == NULL) {
+#  ifdef _WIN32
+        _putenv("OPENSSL_engine_libcrypto_override=yes");
+#  else
+        setenv("OPENSSL_engine_libcrypto_override", "yes", 1);
+#  endif
 #  ifndef OPENSSL_NO_EC
         ADD_ALL_TESTS(test_signatures_with_engine, 3);
 #  else

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -4564,6 +4564,8 @@ int setup_tests(void)
     if (testctx == NULL) {
 #  ifdef _WIN32
         _putenv("OPENSSL_engine_libcrypto_override=yes");
+#  elif defined(__TANDEM)
+        putenv("OPENSSL_engine_libcrypto_override=yes");
 #  else
         setenv("OPENSSL_engine_libcrypto_override", "yes", 1);
 #  endif


### PR DESCRIPTION
This problem happens usually because an application
links libcrypto and/or libssl statically which
installs an atexit handler, but later an engine using
a shared instance of libcrypto is installed.
The problem is in simple words that both instances
of libcrypto have an atexit handler installed,
but both are unable to coordinate with each other,
which causes a crash, typically a use-after-free
in the engine's destroy function.

To make this even worse, engines built against
openssl 1.1.1 and 3.x have the same OPENSSL_DYNAMIC_VERSION
which is an unfortunate oversight, but cannot be fixed
without breaking something.

Since it is unlikely that an engine will run
successfully in this situation, this adds an
error message, and aborts the engine load.

But since it is not impossible that it may still work,
especially when both static libcrypto runtimes are from
the same major and minor and patch version, this adds an
environment to override this check and enable the workaround
below, which should work for duplicated static runtime.

Work around that by preventing the engine's
libcrypto to install the atexit handler.
This may result in a small memory leak, but that
memory is still reachable.

Additional to this, any errors pushed by the engine
on the error stack, will not be visible to the application.

Fixes #15898

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
