### PR TITLE
Fix mistake in ERR_peek_error_all documentation.

### DIFF
--- a/doc/man3/ERR_get_error.pod
+++ b/doc/man3/ERR_get_error.pod
@@ -31,7 +31,7 @@ ERR_get_error_line_data, ERR_peek_error_line_data, ERR_peek_last_error_line_data
                                  const char **func,
                                  const char **data, int *flags);
  unsigned long ERR_peek_error_all(const char **file, int *line,
-                                  const char *func,
+                                  const char **func,
                                   const char **data, int *flags);
  unsigned long ERR_peek_last_error_all(const char **file, int *line,
                                        const char *func,


### PR DESCRIPTION
The `func` parameter was incorrect in the documentation for `ERR_peek_error_all`. It was documented as `const char *func` instead of `const char **func`.

CLA: trivial

Fixes https://github.com/openssl/openssl/issues/17521

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [X] documentation is added or updated
