### PR TITLE
Clarify flags argument of X509_check_ip

### DIFF
--- a/doc/man3/X509_check_host.pod
+++ b/doc/man3/X509_check_host.pod
@@ -62,7 +62,8 @@ X509_check_ip() checks if the certificate matches a specified IPv4 or
 IPv6 address.  The B<address> array is in binary format, in network
 byte order.  The length is either 4 (IPv4) or 16 (IPv6).  Only
 explicitly marked addresses in the certificates are considered; IP
-addresses stored in DNS names and Common Names are ignored.
+addresses stored in DNS names and Common Names are ignored. There are
+currently no B<flags> that would affect the behavior of this call.
 
 X509_check_ip_asc() is similar, except that the NUL-terminated
 string B<address> is first converted to the internal representation.


### PR DESCRIPTION
Because no supported flag affects the behavior of `X509_check_ip`, the `flags` argument currently has no effect. Clarify this in the documentation to avoid confusion.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
