### PR TITLE
Check for presence of 3.x openssl runtime

### DIFF
--- a/crypto/engine/eng_dyn.c
+++ b/crypto/engine/eng_dyn.c
@@ -443,8 +443,17 @@ static int dynamic_load(ENGINE *e, dynamic_data_ctx *ctx)
          * We fail if the version checker veto'd the load *or* if it is
          * deferring to us (by returning its version) and we think it is too
          * old.
+         * Unfortunately the version checker does not distinguish between
+         * engines built for openssl 1.1.x and openssl 3.x, but loading
+         * an engine that is built for openssl 3.x will cause a fatal
+         * error.  Detect such engines, since EVP_PKEY_get_base_id is exported
+         * as a function in openssl 3.x, while it is named EVP_PKEY_base_id
+         * in openssl 1.1.x.  Therefore we take the presence of that symbol
+         * as an indication that the engine will be incompatible.
          */
-        if (vcheck_res < OSSL_DYNAMIC_OLDEST) {
+        if (vcheck_res < OSSL_DYNAMIC_OLDEST
+                || DSO_bind_func(ctx->dynamic_dso,
+                                 "EVP_PKEY_get_base_id") != NULL) {
             /* Fail */
             ctx->bind_engine = NULL;
             ctx->v_check = NULL;

--- a/include/openssl/engine.h
+++ b/include/openssl/engine.h
@@ -722,6 +722,7 @@ typedef int (*dynamic_bind_engine) (ENGINE *e, const char *id,
             CRYPTO_set_mem_functions(fns->mem_fns.malloc_fn, \
                                      fns->mem_fns.realloc_fn, \
                                      fns->mem_fns.free_fn); \
+            OPENSSL_init_crypto(OPENSSL_INIT_NO_ATEXIT, NULL); \
         skip_cbs: \
             if (!fn(e, id)) return 0; \
             return 1; }


### PR DESCRIPTION
if the newly loaded engine contains the symbol
EVP_PKEY_get_base_id, we know it is linked to 3.x openssl.
Abort loading this engine, as it will definitely crash.

This is meant in combination with the first commit in #17112 which cherry-picks cleanly to 1.1.1