### PR TITLE
Fix the same BIO_FLAGS_* macro definition

### DIFF
--- a/include/internal/bio.h
+++ b/include/internal/bio.h
@@ -48,9 +48,9 @@ int bread_conv(BIO *bio, char *data, size_t datal, size_t *read);
  * BIO_FLAGS_KTLS_TX_CTRL_MSG means we are about to send a ctrl message next.
  * BIO_FLAGS_KTLS_RX means we are using ktls with this BIO for receiving.
  */
-# define BIO_FLAGS_KTLS_TX          0x800
 # define BIO_FLAGS_KTLS_TX_CTRL_MSG 0x1000
 # define BIO_FLAGS_KTLS_RX          0x2000
+# define BIO_FLAGS_KTLS_TX          0x4000
 
 /* KTLS related controls and flags */
 # define BIO_set_ktls_flag(b, is_tx) \

--- a/include/openssl/bio.h.in
+++ b/include/openssl/bio.h.in
@@ -209,6 +209,8 @@ extern "C" {
 # define BIO_FLAGS_NONCLEAR_RST  0x400
 # define BIO_FLAGS_IN_EOF        0x800
 
+/* the BIO FLAGS values 0x1000 to 0x4000 are reserved for internal KTLS flags */
+
 typedef union bio_addr_st BIO_ADDR;
 typedef struct bio_addrinfo_st BIO_ADDRINFO;
 


### PR DESCRIPTION
Fix the same BIO_FLAGS macro definition and add comment to the
public header

Fixes: #17545 

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

