### PR TITLE
Send progress to stdout

### DIFF
--- a/apps/dhparam.c
+++ b/apps/dhparam.c
@@ -31,7 +31,6 @@
 #define DEFBITS 2048
 
 static EVP_PKEY *dsa_to_dh(EVP_PKEY *dh);
-static int gendh_cb(EVP_PKEY_CTX *ctx);
 
 typedef enum OPTION_choice {
     OPT_COMMON,
@@ -188,7 +187,7 @@ int dhparam_main(int argc, char **argv)
                         alg);
             goto end;
         }
-        EVP_PKEY_CTX_set_cb(ctx, gendh_cb);
+        EVP_PKEY_CTX_set_cb(ctx, progress_cb);
         EVP_PKEY_CTX_set_app_data(ctx, bio_err);
         BIO_printf(bio_err,
                     "Generating %s parameters, %d bit long %sprime\n",
@@ -399,14 +398,3 @@ static EVP_PKEY *dsa_to_dh(EVP_PKEY *dh)
     return pkey;
 }
 
-static int gendh_cb(EVP_PKEY_CTX *ctx)
-{
-    int p = EVP_PKEY_CTX_get_keygen_info(ctx, 0);
-    BIO *b = EVP_PKEY_CTX_get_app_data(ctx);
-    static const char symbols[] = ".+*\n";
-    char c = (p >= 0 && (size_t)p < sizeof(symbols) - 1) ? symbols[p] : '?';
-
-    BIO_write(b, &c, 1);
-    (void)BIO_flush(b);
-    return 1;
-}

--- a/apps/dhparam.c
+++ b/apps/dhparam.c
@@ -188,7 +188,7 @@ int dhparam_main(int argc, char **argv)
             goto end;
         }
         EVP_PKEY_CTX_set_cb(ctx, progress_cb);
-        EVP_PKEY_CTX_set_app_data(ctx, bio_err);
+        EVP_PKEY_CTX_set_app_data(ctx, bio_out);
         BIO_printf(bio_err,
                     "Generating %s parameters, %d bit long %sprime\n",
                     alg, num, dsaparam ? "" : "safe ");

--- a/apps/dsaparam.c
+++ b/apps/dsaparam.c
@@ -11,7 +11,6 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include "apps.h"
 #include <time.h>
 #include <string.h>
 #include "apps.h"
@@ -24,8 +23,6 @@
 #include <openssl/pem.h>
 
 static int verbose = 0;
-
-static int gendsa_cb(EVP_PKEY_CTX *ctx);
 
 typedef enum OPTION_choice {
     OPT_COMMON,
@@ -160,9 +157,9 @@ int dsaparam_main(int argc, char **argv)
                        "         Your key size is %d! Larger key size may behave not as expected.\n",
                        OPENSSL_DSA_MAX_MODULUS_BITS, numbits);
 
-        EVP_PKEY_CTX_set_cb(ctx, gendsa_cb);
         EVP_PKEY_CTX_set_app_data(ctx, bio_err);
         if (verbose) {
+            EVP_PKEY_CTX_set_cb(ctx, progress_cb);
             BIO_printf(bio_err, "Generating DSA parameters, %d bit long prime\n",
                        num);
             BIO_printf(bio_err, "This could take some time\n");
@@ -235,21 +232,3 @@ int dsaparam_main(int argc, char **argv)
     return ret;
 }
 
-static int gendsa_cb(EVP_PKEY_CTX *ctx)
-{
-    static const char symbols[] = ".+*\n";
-    int p;
-    char c;
-    BIO *b;
-
-    if (!verbose)
-        return 1;
-
-    b = EVP_PKEY_CTX_get_app_data(ctx);
-    p = EVP_PKEY_CTX_get_keygen_info(ctx, 0);
-    c = (p >= 0 && (size_t)p < sizeof(symbols) - 1) ? symbols[p] : '?';
-
-    BIO_write(b, &c, 1);
-    (void)BIO_flush(b);
-    return 1;
-}

--- a/apps/dsaparam.c
+++ b/apps/dsaparam.c
@@ -157,7 +157,7 @@ int dsaparam_main(int argc, char **argv)
                        "         Your key size is %d! Larger key size may behave not as expected.\n",
                        OPENSSL_DSA_MAX_MODULUS_BITS, numbits);
 
-        EVP_PKEY_CTX_set_app_data(ctx, bio_err);
+        EVP_PKEY_CTX_set_app_data(ctx, bio_out);
         if (verbose) {
             EVP_PKEY_CTX_set_cb(ctx, progress_cb);
             BIO_printf(bio_err, "Generating DSA parameters, %d bit long prime\n",

--- a/apps/genpkey.c
+++ b/apps/genpkey.c
@@ -180,7 +180,7 @@ int genpkey_main(int argc, char **argv)
 
     if (!quiet)
         EVP_PKEY_CTX_set_cb(ctx, progress_cb);
-    EVP_PKEY_CTX_set_app_data(ctx, bio_err);
+    EVP_PKEY_CTX_set_app_data(ctx, bio_out);
 
     pkey = do_param ? app_paramgen(ctx, algname)
                     : app_keygen(ctx, algname, 0, 0 /* not verbose */);

--- a/apps/genpkey.c
+++ b/apps/genpkey.c
@@ -19,8 +19,6 @@ static int quiet;
 
 static int init_keygen_file(EVP_PKEY_CTX **pctx, const char *file, ENGINE *e,
                             OSSL_LIB_CTX *libctx, const char *propq);
-static int genpkey_cb(EVP_PKEY_CTX *ctx);
-
 typedef enum OPTION_choice {
     OPT_COMMON,
     OPT_ENGINE, OPT_OUTFORM, OPT_OUT, OPT_PASS, OPT_PARAMFILE,
@@ -180,7 +178,8 @@ int genpkey_main(int argc, char **argv)
     if (out == NULL)
         goto end;
 
-    EVP_PKEY_CTX_set_cb(ctx, genpkey_cb);
+    if (!quiet)
+        EVP_PKEY_CTX_set_cb(ctx, progress_cb);
     EVP_PKEY_CTX_set_app_data(ctx, bio_err);
 
     pkey = do_param ? app_paramgen(ctx, algname)
@@ -318,27 +317,3 @@ int init_gen_str(EVP_PKEY_CTX **pctx,
 
 }
 
-static int genpkey_cb(EVP_PKEY_CTX *ctx)
-{
-    char c = '*';
-    BIO *b = EVP_PKEY_CTX_get_app_data(ctx);
-
-    if (quiet)
-        return 1;
-
-    switch (EVP_PKEY_CTX_get_keygen_info(ctx, 0)) {
-    case 0:
-        c = '.';
-        break;
-    case 1:
-        c = '+';
-        break;
-    case 3:
-        c = '\n';
-        break;
-    }
-
-    BIO_write(b, &c, 1);
-    (void)BIO_flush(b);
-    return 1;
-}

--- a/apps/genrsa.c
+++ b/apps/genrsa.c
@@ -180,7 +180,7 @@ opthelp:
         goto end;
 
     EVP_PKEY_CTX_set_cb(ctx, genrsa_cb);
-    EVP_PKEY_CTX_set_app_data(ctx, bio_err);
+    EVP_PKEY_CTX_set_app_data(ctx, bio_out);
 
     if (EVP_PKEY_CTX_set_rsa_keygen_bits(ctx, num) <= 0) {
         BIO_printf(bio_err, "Error setting RSA length\n");

--- a/apps/include/apps.h
+++ b/apps/include/apps.h
@@ -94,6 +94,9 @@ typedef struct args_st {
 /* We need both wrap and the "real" function because libcrypto uses both. */
 int wrap_password_callback(char *buf, int bufsiz, int verify, void *cb_data);
 
+/* progress callback for dsaparam, dhparam, req, genpkey, etc. */
+int progress_cb(EVP_PKEY_CTX *ctx);
+
 int chopup_args(ARGS *arg, char *buf);
 void dump_cert_text(BIO *out, X509 *x);
 void print_name(BIO *out, const char *title, const X509_NAME *nm);

--- a/apps/lib/s_cb.c
+++ b/apps/lib/s_cb.c
@@ -1574,3 +1574,16 @@ void ssl_print_secure_renegotiation_notes(BIO *bio, SSL *s)
         BIO_printf(bio, "This TLS version forbids renegotiation.\n");
     }
 }
+
+int progress_cb(EVP_PKEY_CTX *ctx)
+{
+    BIO *b = EVP_PKEY_CTX_get_app_data(ctx);
+    int p = EVP_PKEY_CTX_get_keygen_info(ctx, 0);
+    static const char symbols[] = ".+*\n";
+    char c = (p >= 0 && (size_t)p <= sizeof(symbols) - 1) ? symbols[p] : '?';
+
+    BIO_write(b, &c, 1);
+    (void)BIO_flush(b);
+    return 1;
+}
+

--- a/apps/req.c
+++ b/apps/req.c
@@ -662,7 +662,7 @@ int req_main(int argc, char **argv)
         }
 
         EVP_PKEY_CTX_set_cb(genctx, progress_cb);
-        EVP_PKEY_CTX_set_app_data(genctx, bio_err);
+        EVP_PKEY_CTX_set_app_data(genctx, bio_out);
 
         pkey = app_keygen(genctx, keyalgstr, newkey_len, verbose);
 

--- a/apps/req.c
+++ b/apps/req.c
@@ -62,7 +62,6 @@ static int add_attribute_object(X509_REQ *req, char *text, const char *def,
 static int add_DN_object(X509_NAME *n, char *text, const char *def,
                          char *value, int nid, int n_min, int n_max,
                          unsigned long chtype, int mval);
-static int genpkey_cb(EVP_PKEY_CTX *ctx);
 static int build_data(char *text, const char *def, char *value,
                       int n_min, int n_max, char *buf, const int buf_size,
                       const char *desc1, const char *desc2);
@@ -662,7 +661,7 @@ int req_main(int argc, char **argv)
             }
         }
 
-        EVP_PKEY_CTX_set_cb(genctx, genpkey_cb);
+        EVP_PKEY_CTX_set_cb(genctx, progress_cb);
         EVP_PKEY_CTX_set_app_data(genctx, bio_err);
 
         pkey = app_keygen(genctx, keyalgstr, newkey_len, verbose);
@@ -1648,21 +1647,3 @@ static EVP_PKEY_CTX *set_keygen_ctx(const char *gstr,
     return gctx;
 }
 
-static int genpkey_cb(EVP_PKEY_CTX *ctx)
-{
-    char c = '*';
-    BIO *b = EVP_PKEY_CTX_get_app_data(ctx);
-    int p;
-    p = EVP_PKEY_CTX_get_keygen_info(ctx, 0);
-    if (p == 0)
-        c = '.';
-    if (p == 1)
-        c = '+';
-    if (p == 2)
-        c = '*';
-    if (p == 3)
-        c = '\n';
-    BIO_write(b, &c, 1);
-    (void)BIO_flush(b);
-    return 1;
-}


### PR DESCRIPTION
Progress (in this case, from computationally intensive tasks) should be sent to `stdout` instead of `stderr`.
