### PR TITLE
modify armv7_tick prototype to return uint64_t instead of uint32_t

### DIFF
--- a/crypto/armcap.c
+++ b/crypto/armcap.c
@@ -89,12 +89,12 @@ size_t OPENSSL_rndrrs_bytes(unsigned char *buf, size_t len)
     return OPENSSL_rndr_wrapper(OPENSSL_rndrrs_asm, buf, len);
 }
 # endif
-uint32_t _armv7_tick(void);
+uint64_t _armv7_tick(void);
 
 uint32_t OPENSSL_rdtsc(void)
 {
     if (OPENSSL_armcap_P & ARMV7_TICK)
-        return _armv7_tick();
+        return (uint32_t)(_armv7_tick() & 0xffffffff);
     else
         return 0;
 }


### PR DESCRIPTION
Addresses an ABI issue on 32-bit arm.  The implementation of `armv7_tick` calls the `mrrc` instruction to retrieve a counter from the p15 coprocessor. This is a 64-bit counter and it is stored into the 2 32-bit registers r0 and r1.  The problem is that the C prototype only declares the function as returning a 32-bit value, so the compiler is not aware that the r1 register is being clobbered.  This results in undefined behavior and I confirmed that I would get unpredictable results with a small test app that duplicates this problem.  Modifying the return type to uint64_t fixed the unpredictable results that I observed. I confirmed in the 32-bit arm ABI documentation that a 64-bit result from a function is stored in r0 and r1, which would inform the compiler that r1 is being overwritten by the armv7_tick function properly.

This could be related to:

https://github.com/openssl/openssl/issues/14838
https://github.com/openssl/openssl/issues/17009
https://github.com/openssl/openssl/issues/17465
