### PR TITLE
evp_test: Add the missing check after calling OPENSSL_malloc

### DIFF
--- a/test/ct_test.c
+++ b/test/ct_test.c
@@ -449,6 +449,9 @@ static int test_encode_tls_sct(void)
     SETUP_CT_TEST_FIXTURE();
 
     fixture->sct_list = sk_SCT_new_null();
+    if (fixture->sct_list == NULL)
+	    return 0;
+
     if (!TEST_ptr(sct = SCT_new_from_base64(SCT_VERSION_V1, log_id,
                                             CT_LOG_ENTRY_TYPE_X509, timestamp,
                                             extensions, signature)))

--- a/test/evp_test.c
+++ b/test/evp_test.c
@@ -574,7 +574,9 @@ static int cipher_test_init(EVP_TEST *t, const char *alg)
     }
     ERR_clear_last_mark();
 
-    cdat = OPENSSL_zalloc(sizeof(*cdat));
+    if (!TEST_ptr(cdat = OPENSSL_zalloc(sizeof(*cdat))))
+        return 0;
+
     cdat->cipher = cipher;
     cdat->fetched_cipher = fetched_cipher;
     cdat->enc = -1;
@@ -1175,7 +1177,9 @@ static int mac_test_init(EVP_TEST *t, const char *alg)
             return 0;
     }
 
-    mdat = OPENSSL_zalloc(sizeof(*mdat));
+    if (!TEST_ptr(mdat = OPENSSL_zalloc(sizeof(*mdat))))
+        return 0;
+
     mdat->type = type;
     mdat->mac_name = OPENSSL_strdup(alg);
     mdat->mac = mac;


### PR DESCRIPTION
The OPENSSL_zalloc() could return NULL pointer if fails.
Add the check for it does make sense, like how digest_test_init() deals
with.

CLA: trivial

Signed-off-by: Jiasheng Jiang <jiasheng@iscas.ac.cn>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
