### PR TITLE
Add context dup functions for KDFs

### DIFF
--- a/providers/common/include/prov/provider_util.h
+++ b/providers/common/include/prov/provider_util.h
@@ -136,3 +136,7 @@ typedef struct ag_capable_st {
  */
 void ossl_prov_cache_exported_algorithms(const OSSL_ALGORITHM_CAPABLE *in,
                                          OSSL_ALGORITHM *out);
+
+/* Duplicate a lump of memory safely */
+int ossl_prov_memdup(const void *src, size_t src_len,
+                     unsigned char **dest, size_t *dest_len);

--- a/providers/common/provider_util.c
+++ b/providers/common/provider_util.c
@@ -351,3 +351,20 @@ void ossl_prov_cache_exported_algorithms(const OSSL_ALGORITHM_CAPABLE *in,
         out[j++] = in[i].alg;
     }
 }
+
+/* Duplicate a lump of memory safely */
+int ossl_prov_memdup(const void *src, size_t src_len,
+                     unsigned char **dest, size_t *dest_len)
+{
+    if (src != NULL) {
+        if ((*dest = OPENSSL_memdup(src, src_len)) == NULL) {
+            ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
+            return 0;
+        }
+        *dest_len = src_len;
+    } else {
+        *dest = NULL;
+        *dest_len = 0;
+    }
+    return 1;
+}

--- a/providers/common/provider_util.c
+++ b/providers/common/provider_util.c
@@ -165,7 +165,7 @@ int ossl_prov_digest_copy(PROV_DIGEST *dst, const PROV_DIGEST *src)
 }
 
 const EVP_MD *ossl_prov_digest_fetch(PROV_DIGEST *pd, OSSL_LIB_CTX *libctx,
-                           const char *mdname, const char *propquery)
+                                     const char *mdname, const char *propquery)
 {
     EVP_MD_free(pd->alloc_md);
     pd->md = pd->alloc_md = EVP_MD_fetch(libctx, mdname, propquery);

--- a/providers/implementations/kdfs/hkdf.c
+++ b/providers/implementations/kdfs/hkdf.c
@@ -34,6 +34,7 @@
 #define HKDF_MAXBUF 2048
 
 static OSSL_FUNC_kdf_newctx_fn kdf_hkdf_new;
+static OSSL_FUNC_kdf_dupctx_fn kdf_hkdf_dup;
 static OSSL_FUNC_kdf_freectx_fn kdf_hkdf_free;
 static OSSL_FUNC_kdf_reset_fn kdf_hkdf_reset;
 static OSSL_FUNC_kdf_derive_fn kdf_hkdf_derive;
@@ -124,6 +125,36 @@ static void kdf_hkdf_reset(void *vctx)
     OPENSSL_cleanse(ctx->info, ctx->info_len);
     memset(ctx, 0, sizeof(*ctx));
     ctx->provctx = provctx;
+}
+
+static void *kdf_hkdf_dup(void *vctx)
+{
+    const KDF_HKDF *src = (const KDF_HKDF *)vctx;
+    KDF_HKDF *dest;
+
+    dest = kdf_hkdf_new(src->provctx);
+    if (dest != NULL) {
+        if (!ossl_prov_memdup(src->salt, src->salt_len, &dest->salt,
+                              &dest->salt_len)
+                || !ossl_prov_memdup(src->key, src->key_len,
+                                     &dest->key , &dest->key_len)
+                || !ossl_prov_memdup(src->prefix, src->prefix_len,
+                                     &dest->prefix, &dest->prefix_len)
+                || !ossl_prov_memdup(src->label, src->label_len,
+                                     &dest->label, &dest->label_len)
+                || !ossl_prov_memdup(src->data, src->data_len,
+                                     &dest->data, &dest->data_len)
+                || !ossl_prov_digest_copy(&dest->digest, &src->digest))
+            goto err;
+        memcpy(dest->info, src->info, sizeof(dest->info));
+        dest->info_len = src->info_len;
+        dest->mode = src->mode;
+    }
+    return dest;
+
+ err:
+    kdf_hkdf_free(dest);
+    return NULL;
 }
 
 static size_t kdf_hkdf_size(KDF_HKDF *ctx)
@@ -313,6 +344,7 @@ static const OSSL_PARAM *kdf_hkdf_gettable_ctx_params(ossl_unused void *ctx,
 
 const OSSL_DISPATCH ossl_kdf_hkdf_functions[] = {
     { OSSL_FUNC_KDF_NEWCTX, (void(*)(void))kdf_hkdf_new },
+    { OSSL_FUNC_KDF_DUPCTX, (void(*)(void))kdf_hkdf_dup },
     { OSSL_FUNC_KDF_FREECTX, (void(*)(void))kdf_hkdf_free },
     { OSSL_FUNC_KDF_RESET, (void(*)(void))kdf_hkdf_reset },
     { OSSL_FUNC_KDF_DERIVE, (void(*)(void))kdf_hkdf_derive },
@@ -728,6 +760,7 @@ static const OSSL_PARAM *kdf_tls1_3_settable_ctx_params(ossl_unused void *ctx,
 
 const OSSL_DISPATCH ossl_kdf_tls1_3_kdf_functions[] = {
     { OSSL_FUNC_KDF_NEWCTX, (void(*)(void))kdf_hkdf_new },
+    { OSSL_FUNC_KDF_DUPCTX, (void(*)(void))kdf_hkdf_dup },
     { OSSL_FUNC_KDF_FREECTX, (void(*)(void))kdf_hkdf_free },
     { OSSL_FUNC_KDF_RESET, (void(*)(void))kdf_hkdf_reset },
     { OSSL_FUNC_KDF_DERIVE, (void(*)(void))kdf_tls1_3_derive },

--- a/providers/implementations/kdfs/kbkdf.c
+++ b/providers/implementations/kdfs/kbkdf.c
@@ -75,6 +75,7 @@ typedef struct {
 
 /* Definitions needed for typechecking. */
 static OSSL_FUNC_kdf_newctx_fn kbkdf_new;
+static OSSL_FUNC_kdf_newctx_fn kbkdf_dup;
 static OSSL_FUNC_kdf_freectx_fn kbkdf_free;
 static OSSL_FUNC_kdf_reset_fn kbkdf_reset;
 static OSSL_FUNC_kdf_derive_fn kbkdf_derive;
@@ -147,6 +148,36 @@ static void kbkdf_reset(void *vctx)
     memset(ctx, 0, sizeof(*ctx));
     ctx->provctx = provctx;
     init(ctx);
+}
+
+static void *kbkdf_dup(void *vctx)
+{
+    const KBKDF *src = (const KBKDF *)vctx;
+    KBKDF *dest;
+
+    dest = kbkdf_new(src->provctx);
+    if (dest != NULL) {
+        dest->ctx_init = EVP_MAC_CTX_dup(src->ctx_init);
+        if (dest->ctx_init == NULL
+                || !ossl_prov_memdup(src->ki, src->ki_len,
+                                     &dest->ki, &dest->ki_len)
+                || !ossl_prov_memdup(src->label, src->label_len,
+                                     &dest->label, &dest->label_len)
+                || !ossl_prov_memdup(src->context, src->context_len,
+                                     &dest->context, &dest->context_len)
+                || !ossl_prov_memdup(src->iv, src->iv_len,
+                                     &dest->iv, &dest->iv_len))
+            goto err;
+        dest->mode = src->mode;
+        dest->r = src->r;
+        dest->use_l = src->use_l;
+        dest->use_separator = src->use_separator;
+    }
+    return dest;
+
+ err:
+    kbkdf_free(dest);
+    return NULL;
 }
 
 /* SP800-108 section 5.1 or section 5.2 depending on mode. */
@@ -405,6 +436,7 @@ static const OSSL_PARAM *kbkdf_gettable_ctx_params(ossl_unused void *ctx,
 
 const OSSL_DISPATCH ossl_kdf_kbkdf_functions[] = {
     { OSSL_FUNC_KDF_NEWCTX, (void(*)(void))kbkdf_new },
+    { OSSL_FUNC_KDF_DUPCTX, (void(*)(void))kbkdf_dup },
     { OSSL_FUNC_KDF_FREECTX, (void(*)(void))kbkdf_free },
     { OSSL_FUNC_KDF_RESET, (void(*)(void))kbkdf_reset },
     { OSSL_FUNC_KDF_DERIVE, (void(*)(void))kbkdf_derive },

--- a/providers/implementations/kdfs/pbkdf2.c
+++ b/providers/implementations/kdfs/pbkdf2.c
@@ -37,6 +37,7 @@
 #define KDF_PBKDF2_MIN_SALT_LEN   (128 / 8)
 
 static OSSL_FUNC_kdf_newctx_fn kdf_pbkdf2_new;
+static OSSL_FUNC_kdf_dupctx_fn kdf_pbkdf2_dup;
 static OSSL_FUNC_kdf_freectx_fn kdf_pbkdf2_free;
 static OSSL_FUNC_kdf_reset_fn kdf_pbkdf2_reset;
 static OSSL_FUNC_kdf_derive_fn kdf_pbkdf2_derive;
@@ -63,7 +64,7 @@ typedef struct {
 
 static void kdf_pbkdf2_init(KDF_PBKDF2 *ctx);
 
-static void *kdf_pbkdf2_new(void *provctx)
+static void *kdf_pbkdf2_new_no_init(void *provctx)
 {
     KDF_PBKDF2 *ctx;
 
@@ -76,7 +77,15 @@ static void *kdf_pbkdf2_new(void *provctx)
         return NULL;
     }
     ctx->provctx = provctx;
-    kdf_pbkdf2_init(ctx);
+    return ctx;
+}
+
+static void *kdf_pbkdf2_new(void *provctx)
+{
+    KDF_PBKDF2 *ctx = kdf_pbkdf2_new_no_init(provctx);
+
+    if (ctx != NULL)
+        kdf_pbkdf2_init(ctx);
     return ctx;
 }
 
@@ -106,6 +115,30 @@ static void kdf_pbkdf2_reset(void *vctx)
     kdf_pbkdf2_cleanup(ctx);
     ctx->provctx = provctx;
     kdf_pbkdf2_init(ctx);
+}
+
+static void *kdf_pbkdf2_dup(void *vctx)
+{
+    const KDF_PBKDF2 *src = (const KDF_PBKDF2 *)vctx;
+    KDF_PBKDF2 *dest;
+
+    /* We need a new PBKDF2 object but uninitialised since we're filling it */
+    dest = kdf_pbkdf2_new_no_init(src->provctx);
+    if (dest != NULL) {
+        if (!ossl_prov_memdup(src->salt, src->salt_len,
+                              &dest->salt, &dest->salt_len)
+                || !ossl_prov_memdup(src->pass, src->pass_len,
+                                     &dest->pass , &dest->pass_len)
+                || !ossl_prov_digest_copy(&dest->digest, &src->digest))
+            goto err;
+        dest->iter = src->iter;
+        dest->lower_bound_checks = src->lower_bound_checks;
+    }
+    return dest;
+
+ err:
+    kdf_pbkdf2_free(dest);
+    return NULL;
 }
 
 static void kdf_pbkdf2_init(KDF_PBKDF2 *ctx)
@@ -249,6 +282,7 @@ static const OSSL_PARAM *kdf_pbkdf2_gettable_ctx_params(ossl_unused void *ctx,
 
 const OSSL_DISPATCH ossl_kdf_pbkdf2_functions[] = {
     { OSSL_FUNC_KDF_NEWCTX, (void(*)(void))kdf_pbkdf2_new },
+    { OSSL_FUNC_KDF_DUPCTX, (void(*)(void))kdf_pbkdf2_dup },
     { OSSL_FUNC_KDF_FREECTX, (void(*)(void))kdf_pbkdf2_free },
     { OSSL_FUNC_KDF_RESET, (void(*)(void))kdf_pbkdf2_reset },
     { OSSL_FUNC_KDF_DERIVE, (void(*)(void))kdf_pbkdf2_derive },

--- a/providers/implementations/kdfs/pbkdf2.c
+++ b/providers/implementations/kdfs/pbkdf2.c
@@ -128,7 +128,7 @@ static void *kdf_pbkdf2_dup(void *vctx)
         if (!ossl_prov_memdup(src->salt, src->salt_len,
                               &dest->salt, &dest->salt_len)
                 || !ossl_prov_memdup(src->pass, src->pass_len,
-                                     &dest->pass , &dest->pass_len)
+                                     &dest->pass, &dest->pass_len)
                 || !ossl_prov_digest_copy(&dest->digest, &src->digest))
             goto err;
         dest->iter = src->iter;

--- a/providers/implementations/kdfs/pvkkdf.c
+++ b/providers/implementations/kdfs/pvkkdf.c
@@ -82,7 +82,7 @@ static void *kdf_pvk_dup(void *vctx)
         if (!ossl_prov_memdup(src->salt, src->salt_len,
                               &dest->salt, &dest->salt_len)
                 || !ossl_prov_memdup(src->pass, src->pass_len,
-                              &dest->pass , &dest->pass_len)
+                                     &dest->pass , &dest->pass_len)
                 || !ossl_prov_digest_copy(&dest->digest, &src->digest))
             goto err;
     return dest;

--- a/providers/implementations/kdfs/pvkkdf.c
+++ b/providers/implementations/kdfs/pvkkdf.c
@@ -17,6 +17,7 @@
 #include "prov/provider_util.h"
 
 static OSSL_FUNC_kdf_newctx_fn kdf_pvk_new;
+static OSSL_FUNC_kdf_dupctx_fn kdf_pvk_dup;
 static OSSL_FUNC_kdf_freectx_fn kdf_pvk_free;
 static OSSL_FUNC_kdf_reset_fn kdf_pvk_reset;
 static OSSL_FUNC_kdf_derive_fn kdf_pvk_derive;
@@ -69,6 +70,26 @@ static void kdf_pvk_free(void *vctx)
         kdf_pvk_cleanup(ctx);
         OPENSSL_free(ctx);
     }
+}
+
+static void *kdf_pvk_dup(void *vctx)
+{
+    const KDF_PVK *src = (const KDF_PVK *)vctx;
+    KDF_PVK *dest;
+
+    dest = kdf_pvk_new(src->provctx);
+    if (dest != NULL)
+        if (!ossl_prov_memdup(src->salt, src->salt_len,
+                              &dest->salt, &dest->salt_len)
+                || !ossl_prov_memdup(src->pass, src->pass_len,
+                              &dest->pass , &dest->pass_len)
+                || !ossl_prov_digest_copy(&dest->digest, &src->digest))
+            goto err;
+    return dest;
+
+ err:
+    kdf_pvk_free(dest);
+    return NULL;
 }
 
 static void kdf_pvk_reset(void *vctx)
@@ -216,6 +237,7 @@ static const OSSL_PARAM *kdf_pvk_gettable_ctx_params(ossl_unused void *ctx,
 
 const OSSL_DISPATCH ossl_kdf_pvk_functions[] = {
     { OSSL_FUNC_KDF_NEWCTX, (void(*)(void))kdf_pvk_new },
+    { OSSL_FUNC_KDF_DUPCTX, (void(*)(void))kdf_pvk_dup },
     { OSSL_FUNC_KDF_FREECTX, (void(*)(void))kdf_pvk_free },
     { OSSL_FUNC_KDF_RESET, (void(*)(void))kdf_pvk_reset },
     { OSSL_FUNC_KDF_DERIVE, (void(*)(void))kdf_pvk_derive },

--- a/providers/implementations/kdfs/scrypt.c
+++ b/providers/implementations/kdfs/scrypt.c
@@ -21,10 +21,12 @@
 #include "prov/provider_ctx.h"
 #include "prov/providercommon.h"
 #include "prov/implementations.h"
+#include "prov/provider_util.h"
 
 #ifndef OPENSSL_NO_SCRYPT
 
 static OSSL_FUNC_kdf_newctx_fn kdf_scrypt_new;
+static OSSL_FUNC_kdf_dupctx_fn kdf_scrypt_dup;
 static OSSL_FUNC_kdf_freectx_fn kdf_scrypt_free;
 static OSSL_FUNC_kdf_reset_fn kdf_scrypt_reset;
 static OSSL_FUNC_kdf_derive_fn kdf_scrypt_derive;
@@ -90,6 +92,38 @@ static void kdf_scrypt_reset(void *vctx)
     OPENSSL_free(ctx->salt);
     OPENSSL_clear_free(ctx->pass, ctx->pass_len);
     kdf_scrypt_init(ctx);
+}
+
+static void *kdf_scrypt_dup(void *vctx)
+{
+    const KDF_SCRYPT *src = (const KDF_SCRYPT *)vctx;
+    KDF_SCRYPT *dest;
+
+    dest = kdf_scrypt_new(src->libctx);
+    if (dest != NULL) {
+        if (src->sha256 != NULL && !EVP_MD_up_ref(src->sha256))
+            goto err;
+        if (src->propq != NULL) {
+            dest->propq = OPENSSL_strdup(src->propq);
+            if (dest->propq == NULL)
+                goto err;
+        }
+        if (!ossl_prov_memdup(src->salt, src->salt_len,
+                              &dest->salt, &dest->salt_len)
+                || !ossl_prov_memdup(src->pass, src->pass_len,
+                                     &dest->pass , &dest->pass_len))
+            goto err;
+        dest->N = src->N;
+        dest->r = src->r;
+        dest->p = src->p;
+        dest->maxmem_bytes = src->maxmem_bytes;
+        dest->sha256 = src->sha256;
+    }
+    return dest;
+
+ err:
+    kdf_scrypt_free(dest);
+    return NULL;
 }
 
 static void kdf_scrypt_init(KDF_SCRYPT *ctx)
@@ -275,6 +309,7 @@ static const OSSL_PARAM *kdf_scrypt_gettable_ctx_params(ossl_unused void *ctx,
 
 const OSSL_DISPATCH ossl_kdf_scrypt_functions[] = {
     { OSSL_FUNC_KDF_NEWCTX, (void(*)(void))kdf_scrypt_new },
+    { OSSL_FUNC_KDF_DUPCTX, (void(*)(void))kdf_scrypt_dup },
     { OSSL_FUNC_KDF_FREECTX, (void(*)(void))kdf_scrypt_free },
     { OSSL_FUNC_KDF_RESET, (void(*)(void))kdf_scrypt_reset },
     { OSSL_FUNC_KDF_DERIVE, (void(*)(void))kdf_scrypt_derive },

--- a/providers/implementations/kdfs/sshkdf.c
+++ b/providers/implementations/kdfs/sshkdf.c
@@ -24,6 +24,7 @@
 
 /* See RFC 4253, Section 7.2 */
 static OSSL_FUNC_kdf_newctx_fn kdf_sshkdf_new;
+static OSSL_FUNC_kdf_dupctx_fn kdf_sshkdf_dup;
 static OSSL_FUNC_kdf_freectx_fn kdf_sshkdf_free;
 static OSSL_FUNC_kdf_reset_fn kdf_sshkdf_reset;
 static OSSL_FUNC_kdf_derive_fn kdf_sshkdf_derive;
@@ -84,6 +85,30 @@ static void kdf_sshkdf_reset(void *vctx)
     OPENSSL_clear_free(ctx->session_id, ctx->session_id_len);
     memset(ctx, 0, sizeof(*ctx));
     ctx->provctx = provctx;
+}
+
+static void *kdf_sshkdf_dup(void *vctx)
+{
+    const KDF_SSHKDF *src = (const KDF_SSHKDF *)vctx;
+    KDF_SSHKDF *dest;
+
+    dest = kdf_sshkdf_new(src->provctx);
+    if (dest != NULL) {
+        if (!ossl_prov_memdup(src->key, src->key_len,
+                              &dest->key, &dest->key_len)
+                || !ossl_prov_memdup(src->xcghash, src->xcghash_len,
+                                     &dest->xcghash , &dest->xcghash_len)
+                || !ossl_prov_memdup(src->session_id, src->session_id_len,
+                                     &dest->session_id , &dest->session_id_len)
+                || !ossl_prov_digest_copy(&dest->digest, &src->digest))
+            goto err;
+        dest->type = src->type;
+    }
+    return dest;
+
+ err:
+    kdf_sshkdf_free(dest);
+    return NULL;
 }
 
 static int sshkdf_set_membuf(unsigned char **dst, size_t *dst_len,
@@ -211,6 +236,7 @@ static const OSSL_PARAM *kdf_sshkdf_gettable_ctx_params(ossl_unused void *ctx,
 
 const OSSL_DISPATCH ossl_kdf_sshkdf_functions[] = {
     { OSSL_FUNC_KDF_NEWCTX, (void(*)(void))kdf_sshkdf_new },
+    { OSSL_FUNC_KDF_DUPCTX, (void(*)(void))kdf_sshkdf_dup },
     { OSSL_FUNC_KDF_FREECTX, (void(*)(void))kdf_sshkdf_free },
     { OSSL_FUNC_KDF_RESET, (void(*)(void))kdf_sshkdf_reset },
     { OSSL_FUNC_KDF_DERIVE, (void(*)(void))kdf_sshkdf_derive },

--- a/providers/implementations/kdfs/sskdf.c
+++ b/providers/implementations/kdfs/sskdf.c
@@ -72,6 +72,7 @@ typedef struct {
 static const unsigned char kmac_custom_str[] = { 0x4B, 0x44, 0x46 };
 
 static OSSL_FUNC_kdf_newctx_fn sskdf_new;
+static OSSL_FUNC_kdf_dupctx_fn sskdf_dup;
 static OSSL_FUNC_kdf_freectx_fn sskdf_free;
 static OSSL_FUNC_kdf_reset_fn sskdf_reset;
 static OSSL_FUNC_kdf_derive_fn sskdf_derive;
@@ -319,6 +320,35 @@ static void sskdf_free(void *vctx)
     }
 }
 
+static void *sskdf_dup(void *vctx)
+{
+    const KDF_SSKDF *src = (const KDF_SSKDF *)vctx;
+    KDF_SSKDF *dest;
+
+    dest = sskdf_new(src->provctx);
+    if (dest != NULL) {
+        if (src->macctx != NULL) {
+            dest->macctx = EVP_MAC_CTX_dup(src->macctx);
+            if (dest->macctx == NULL)
+                goto err;
+        }
+        if (!ossl_prov_memdup(src->info, src->info_len,
+                              &dest->info, &dest->info_len)
+                || !ossl_prov_memdup(src->salt, src->salt_len,
+                                     &dest->salt , &dest->salt_len)
+                || !ossl_prov_memdup(src->secret, src->secret_len,
+                                     &dest->secret, &dest->secret_len)
+                || !ossl_prov_digest_copy(&dest->digest, &src->digest))
+            goto err;
+        dest->out_len = src->out_len;
+    }
+    return dest;
+
+ err:
+    sskdf_free(dest);
+    return NULL;
+}
+
 static int sskdf_set_buffer(unsigned char **out, size_t *out_len,
                             const OSSL_PARAM *p)
 {
@@ -520,6 +550,7 @@ static const OSSL_PARAM *sskdf_gettable_ctx_params(ossl_unused void *ctx,
 
 const OSSL_DISPATCH ossl_kdf_sskdf_functions[] = {
     { OSSL_FUNC_KDF_NEWCTX, (void(*)(void))sskdf_new },
+    { OSSL_FUNC_KDF_DUPCTX, (void(*)(void))sskdf_dup },
     { OSSL_FUNC_KDF_FREECTX, (void(*)(void))sskdf_free },
     { OSSL_FUNC_KDF_RESET, (void(*)(void))sskdf_reset },
     { OSSL_FUNC_KDF_DERIVE, (void(*)(void))sskdf_derive },
@@ -534,6 +565,7 @@ const OSSL_DISPATCH ossl_kdf_sskdf_functions[] = {
 
 const OSSL_DISPATCH ossl_kdf_x963_kdf_functions[] = {
     { OSSL_FUNC_KDF_NEWCTX, (void(*)(void))sskdf_new },
+    { OSSL_FUNC_KDF_DUPCTX, (void(*)(void))sskdf_dup },
     { OSSL_FUNC_KDF_FREECTX, (void(*)(void))sskdf_free },
     { OSSL_FUNC_KDF_RESET, (void(*)(void))sskdf_reset },
     { OSSL_FUNC_KDF_DERIVE, (void(*)(void))x963kdf_derive },

--- a/test/evp_pkey_provided_test.c
+++ b/test/evp_pkey_provided_test.c
@@ -1693,7 +1693,6 @@ static OSSL_PARAM *do_construct_hkdf_params(char *digest, char *key,
     return params;
 }
 
-/* Test that EVP_PKEY_CTX_dup() fails gracefully for a KDF */
 static int test_evp_pkey_ctx_dup_kdf(void)
 {
     int ret = 0;

--- a/test/evp_test.c
+++ b/test/evp_test.c
@@ -2690,6 +2690,7 @@ static int kdf_test_run(EVP_TEST *t)
     KDF_DATA *expected = t->data;
     unsigned char *got = NULL;
     size_t got_len = expected->output_len;
+    EVP_KDF_CTX *ctx;
 
     if (!EVP_KDF_CTX_set_params(expected->ctx, expected->params)) {
         t->err = "KDF_CTRL_ERROR";
@@ -2698,6 +2699,10 @@ static int kdf_test_run(EVP_TEST *t)
     if (!TEST_ptr(got = OPENSSL_malloc(got_len == 0 ? 1 : got_len))) {
         t->err = "INTERNAL_ERROR";
         goto err;
+    }
+    if ((ctx = EVP_KDF_CTX_dup(expected->ctx)) != NULL) {
+        EVP_KDF_CTX_free(expected->ctx);
+        expected->ctx = ctx;
     }
     if (EVP_KDF_derive(expected->ctx, got, got_len, NULL) <= 0) {
         t->err = "KDF_DERIVE_ERROR";


### PR DESCRIPTION
None of the existing KDF implementations included a context dup function.  This adds them.


- [ ] documentation is added or updated
- [x] tests are added or updated
