### PR TITLE
Fix the missing check of BN_bn2hex in print_labeled_bignum()

### DIFF
--- a/providers/implementations/encode_decode/encode_key2text.c
+++ b/providers/implementations/encode_decode/encode_key2text.c
@@ -80,6 +80,9 @@ static int print_labeled_bignum(BIO *out, const char *label, const BIGNUM *bn)
     }
 
     hex_str = BN_bn2hex(bn);
+    if (hex_str == NULL)
+        return 0;
+
     p = hex_str;
     if (*p == '-') {
         ++p;


### PR DESCRIPTION
In encode_key2text.c file, BN_bn2hex() could return NULL on failure of allocation, which could lead to NULL pointer dereference in the following *p expression.

CLA: trivial

Signed-off-by: Zhou Qingyang <zhou1615@umn.edu>
