### PR TITLE
UI: Check for NULL pointer after calling OPENSSL_memdup

### DIFF
--- a/crypto/ui/ui_util.c
+++ b/crypto/ui/ui_util.c
@@ -73,9 +73,12 @@ static void ui_new_method_data(void *parent, void *ptr, CRYPTO_EX_DATA *ad,
 static int ui_dup_method_data(CRYPTO_EX_DATA *to, const CRYPTO_EX_DATA *from,
                               void **pptr, int idx, long argl, void *argp)
 {
-    if (*pptr != NULL)
+    if (*pptr != NULL) {
         *pptr = OPENSSL_memdup(*pptr, sizeof(struct pem_password_cb_data));
-    return 1;
+        if (*pptr != NULL)
+            return 1;
+    }
+    return 0;
 }
 
 static void ui_free_method_data(void *parent, void *ptr, CRYPTO_EX_DATA *ad,


### PR DESCRIPTION
The OPENSSL_memdup() is not always success, as the potential failure of
the allocation.
Then the '*pptr'could be NULL pointer but the ui_dup_method_data() will
still return 1.
In CRYPTO_dup_ex_data(), the 'storage[i]->dup_func' will not fail and
'ptr' will be used in CRYPTO_set_ex_data().
Also, if '*pptr' is NULL, I think it should also return 0 to tell the
caller that the duplication fails in order to prevernt using the NULL
pointer.
Therefore, it should be better to add the check and return 1 only if the
duplication succeed.

Signed-off-by: Jiasheng Jiang <jiasheng@iscas.ac.cn>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
