### PR TITLE
Updates apps/speed.c to use opt_int_arg() to prevent malformed proces…

### DIFF
--- a/apps/speed.c
+++ b/apps/speed.c
@@ -214,7 +214,11 @@ typedef enum OPTION_choice {
 } OPTION_CHOICE;
 
 const OPTIONS speed_options[] = {
-    {OPT_HELP_STR, 1, '-', "Usage: %s [options] [algorithm...]\n"},
+    {OPT_HELP_STR, 1, '-',
+     "Usage: %s [options] [algorithm...]\n"
+     "All +int options consider prefix '0' as base-8 input, "
+     "prefix '0x'/'0X' as base-16 input.\n"
+    },
 
     OPT_SECTION("General"),
     {"help", OPT_HELP, '-', "Display this summary"},
@@ -1543,7 +1547,7 @@ int speed_main(int argc, char **argv)
             break;
         case OPT_MULTI:
 #ifndef NO_FORK
-            multi = atoi(opt_arg());
+            multi = opt_int_arg();
             if ((size_t)multi >= SIZE_MAX / sizeof(int)) {
                 BIO_printf(bio_err, "%s: multi argument too large\n", prog);
                 return 0;
@@ -1552,7 +1556,7 @@ int speed_main(int argc, char **argv)
             break;
         case OPT_ASYNCJOBS:
 #ifndef OPENSSL_NO_ASYNC
-            async_jobs = atoi(opt_arg());
+            async_jobs = opt_int_arg();
             if (!ASYNC_is_capable()) {
                 BIO_printf(bio_err,
                            "%s: async_jobs specified but async not supported\n",
@@ -1599,10 +1603,10 @@ int speed_main(int argc, char **argv)
         case OPT_SECONDS:
             seconds.sym = seconds.rsa = seconds.dsa = seconds.ecdsa
                         = seconds.ecdh = seconds.eddsa
-                        = seconds.sm2 = seconds.ffdh = atoi(opt_arg());
+                        = seconds.sm2 = seconds.ffdh = opt_int_arg();
             break;
         case OPT_BYTES:
-            lengths_single = atoi(opt_arg());
+            lengths_single = opt_int_arg();
             lengths = &lengths_single;
             size_num = 1;
             break;


### PR DESCRIPTION
…sing of hexadecimal input to some command line options. Updated help to notify the change.

CLA: trivial

In the "openssl speed" CLI, one is able to specify arguments to some options [like -seconds -bytes] in terms of hexadecimal values prefixed by 0x or 0X. These are accepted by the command-line parser as valid arguments as long as the value fits in the prescribed range. However, the actual conversion to an integer takes place via atoi(opt_arg()) which does not handle hexadecimal strings and returns 0 instead. This leads to issues since these options expect positive integers.

This PR replaces all such calls with opt_int_arg() which was already in use in this file. The help text has also been modified to ensure people are aware of the prefix rules surrounding the usage of opt_int_arg() [which calls strtol() internally]

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated

