### PR TITLE
lhash: Avoid 32 bit right shift of a 32 bit value

### DIFF
--- a/crypto/lhash/lhash.c
+++ b/crypto/lhash/lhash.c
@@ -383,7 +383,8 @@ unsigned long OPENSSL_LH_strhash(const char *c)
         v = n | (*c);
         n += 0x100;
         r = (int)((v >> 2) ^ v) & 0x0f;
-        ret = (ret << r) | (ret >> (32 - r));
+        /* cast to uint64_t to avoid 32 bit shift of 32 bit value */
+        ret = (ret << r) | (unsigned long)((uint64_t)ret >> (32 - r));
         ret &= 0xFFFFFFFFL;
         ret ^= v * v;
         c++;
@@ -404,7 +405,8 @@ unsigned long ossl_lh_strcasehash(const char *c)
     for (n = 0x100; *c != '\0'; n += 0x100) {
         v = n | ossl_tolower(*c);
         r = (int)((v >> 2) ^ v) & 0x0f;
-        ret = (ret << r) | (ret >> (32 - r));
+        /* cast to uint64_t to avoid 32 bit shift of 32 bit value */
+        ret = (ret << r) | (unsigned long)((uint64_t)ret >> (32 - r));
         ret &= 0xFFFFFFFFL;
         ret ^= v * v;
         c++;


### PR DESCRIPTION
Fixes #17583
