### PR TITLE
Fix DJGPP in 1.1.1

### DIFF
--- a/crypto/bio/b_addr.c
+++ b/crypto/bio/b_addr.c
@@ -744,7 +744,7 @@ int BIO_lookup_ex(const char *host, const char *service, int lookup_type,
 # pragma pointer_size 32
 #endif
         /* Windows doesn't seem to have in_addr_t */
-#ifdef OPENSSL_SYS_WINDOWS
+#if defined(OPENSSL_SYS_WINDOWS) || defined(OPENSSL_SYS_MSDOS)
         static uint32_t he_fallback_address;
         static const char *he_fallback_addresses[] =
             { (char *)&he_fallback_address, NULL };

--- a/include/internal/sockets.h
+++ b/include/internal/sockets.h
@@ -30,6 +30,8 @@
 #   include <sys/un.h>
 #   include <tcp.h>
 #   include <netdb.h>
+#   include <arpa/inet.h>
+#   include <netinet/tcp.h>
 #  elif defined(_WIN32_WCE) && _WIN32_WCE<410
 #   define getservbyname _masked_declaration_getservbyname
 #  endif


### PR DESCRIPTION
DJGPP specific maodifications.

CLA: trivial

Hello,
I hope that the DJGPP port is still supported and thus contributions are
still welcome.  To get the OpenSSL_1_1_1-stable branch compiled some minor
adjustments are required.  They will have no impact on any other ports.
The DJGPP port uses the Watt-32 library to provide the required network
functionality and some of its headers need to be included.

1)
Neither DJGPP nor the Watt-32 library provide in_addr_t thus it must be
provided as it is done for OPENSSL_SYS_WINDOWS in crypto/bio/b_addr.c.

2)
In the DJGPP section of include/internal/sockets.h the following Watt-32
headers must be added:
 - arpa/inet.h: to provide declaration of inet_ntoa required in crypto/bio/b_addr.c
 - netinet/tcp.h: to provide defintion of TCP_NODELAY required in crypto/bio/b_sock2.c


Regards,
Juan M. Guerrero
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
