### PR TITLE
apps: Add option -no_ems to s_client/s_server command line.

### DIFF
--- a/apps/include/opt.h
+++ b/apps/include/opt.h
@@ -163,7 +163,8 @@
         OPT_S_CURVES, OPT_S_NAMEDCURVE, OPT_S_CIPHER, OPT_S_CIPHERSUITES, \
         OPT_S_RECORD_PADDING, OPT_S_DEBUGBROKE, OPT_S_COMP, \
         OPT_S_MINPROTO, OPT_S_MAXPROTO, \
-        OPT_S_NO_RENEGOTIATION, OPT_S_NO_MIDDLEBOX, OPT_S_NO_ETM, OPT_S__LAST
+        OPT_S_NO_RENEGOTIATION, OPT_S_NO_MIDDLEBOX, OPT_S_NO_ETM, \
+        OPT_S_NO_EMS, OPT_S__LAST
 
 # define OPT_S_OPTIONS \
         OPT_SECTION("TLS/SSL"), \
@@ -218,7 +219,9 @@
         {"no_middlebox", OPT_S_NO_MIDDLEBOX, '-', \
             "Disable TLSv1.3 middlebox compat mode" }, \
         {"no_etm", OPT_S_NO_ETM, '-', \
-            "Disable Encrypt-then-Mac extension"}
+            "Disable Encrypt-then-Mac extension"}, \
+        {"no_ems", OPT_S_NO_EMS, '-', \
+            "Disable Extended master secret extension"}
 
 # define OPT_S_CASES \
         OPT_S__FIRST: case OPT_S__LAST: break; \
@@ -253,7 +256,8 @@
         case OPT_S_MAXPROTO: \
         case OPT_S_DEBUGBROKE: \
         case OPT_S_NO_MIDDLEBOX: \
-        case OPT_S_NO_ETM
+        case OPT_S_NO_ETM: \
+        case OPT_S_NO_EMS
 
 #define IS_NO_PROT_FLAG(o) \
  (o == OPT_S_NOSSL3 || o == OPT_S_NOTLS1 || o == OPT_S_NOTLS1_1 \

--- a/doc/man1/openssl-s_client.pod.in
+++ b/doc/man1/openssl-s_client.pod.in
@@ -57,6 +57,7 @@ B<openssl> B<s_client>
 [B<-timeout>]
 [B<-mtu> I<size>]
 [B<-no_etm>]
+[B<-no_ems>]
 [B<-keymatexport> I<label>]
 [B<-keymatexportlen> I<len>]
 [B<-msgfile> I<filename>]
@@ -453,6 +454,10 @@ Set MTU of the link layer to the specified size.
 =item B<-no_etm>
 
 Disable Encrypt-then-MAC negotiation.
+
+=item B<-no_ems>
+
+Disable Extended master secret negotiation.
 
 =item B<-keymatexport> I<label>
 

--- a/doc/man1/openssl-s_server.pod.in
+++ b/doc/man1/openssl-s_server.pod.in
@@ -71,6 +71,7 @@ B<openssl> B<s_server>
 [B<-ign_eof>]
 [B<-no_ign_eof>]
 [B<-no_etm>]
+[B<-no_ems>]
 [B<-status>]
 [B<-status_verbose>]
 [B<-status_timeout> I<int>]
@@ -492,6 +493,10 @@ Do not ignore input EOF.
 =item B<-no_etm>
 
 Disable Encrypt-then-MAC negotiation.
+
+=item B<-no_ems>
+
+Disable Extended master secret negotiation.
 
 =item B<-status>
 

--- a/ssl/ssl_conf.c
+++ b/ssl/ssl_conf.c
@@ -703,6 +703,7 @@ static const ssl_conf_cmd_tbl ssl_conf_cmds[] = {
     SSL_CONF_CMD_SWITCH("anti_replay", SSL_CONF_FLAG_SERVER),
     SSL_CONF_CMD_SWITCH("no_anti_replay", SSL_CONF_FLAG_SERVER),
     SSL_CONF_CMD_SWITCH("no_etm", 0),
+    SSL_CONF_CMD_SWITCH("no_ems", 0),
     SSL_CONF_CMD_STRING(SignatureAlgorithms, "sigalgs", 0),
     SSL_CONF_CMD_STRING(ClientSignatureAlgorithms, "client_sigalgs", 0),
     SSL_CONF_CMD_STRING(Curves, "curves", 0),
@@ -794,6 +795,8 @@ static const ssl_switch_tbl ssl_cmd_switches[] = {
     {SSL_OP_NO_ANTI_REPLAY, 0},
     /* no Encrypt-then-Mac */
     {SSL_OP_NO_ENCRYPT_THEN_MAC, 0},
+    /* no Extended master secret */
+    {SSL_OP_NO_EXTENDED_MASTER_SECRET, 0},
 };
 
 static int ssl_conf_cmd_skip_prefix(SSL_CONF_CTX *cctx, const char **pcmd)


### PR DESCRIPTION
The option SSL_OP_NO_EXTENDED_MASTER_SECRET add in #3910.
And it is valid for versions below (D)TLS 1.2.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
