### PR TITLE
aes: make the no-asm constant time code path not the default

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -90,7 +90,7 @@ breaking changes, and mappings for the large list of deprecated functions.
 
 [Migration guide]: https://github.com/openssl/openssl/tree/master/doc/man7/migration_guide.pod
 
-### Changes between 3.0.1 and 3.0.2 [?? ??? 2022]
+### Changes between 3.0.1 and 3.0.2 [xx XXX xxxx]
 
  * Made the AES constant time code for no-asm configurations
    optional due to the resulting 95% performance degradation.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -90,6 +90,15 @@ breaking changes, and mappings for the large list of deprecated functions.
 
 [Migration guide]: https://github.com/openssl/openssl/tree/master/doc/man7/migration_guide.pod
 
+### Changes between 3.0.1 and 3.0.2 [?? ??? 2022]
+
+ * Made the AES constant time code for no-asm configurations
+   optional due to the resulting 95% performance degradation.
+   The AES constant time code can be enabled, for no assembly
+   builds, with: ./config no-asm -DOPENSSL_AES_CONST_TIME
+
+   *Paul Dale*
+
 ### Changes between 3.0.0 and 3.0.1 [14 dec 2021]
 
  * Fixed invalid handling of X509_verify_cert() internal errors in libssl

--- a/crypto/aes/aes_core.c
+++ b/crypto/aes/aes_core.c
@@ -50,7 +50,7 @@
 #include <openssl/aes.h>
 #include "aes_local.h"
 
-#if !defined(OPENSSL_NO_AES_CONST_TIME) && !defined(AES_ASM)
+#if defined(OPENSSL_AES_CONST_TIME) && !defined(AES_ASM)
 
 # if (defined(_WIN32) || defined(_WIN64)) && !defined(__MINGW32__)
 #  define U64(C) C##UI64


### PR DESCRIPTION
After OMC and OTC discussions, the 95% performance loss resulting from the constant time code was deemed excessive for something outside of our security policy.

The option to use the constant time code exists as it was in OpenSSL 1.1.1.
