### PR TITLE
apps/progs.pl: use SOURCE_DATE_EPOCH if defined for copyright year

### DIFF
--- a/apps/progs.pl
+++ b/apps/progs.pl
@@ -21,7 +21,7 @@ die "Unrecognised option, must be -C or -H\n"
 my %commands     = ();
 my $cmdre        = qr/^\s*int\s+([a-z_][a-z0-9_]*)_main\(\s*int\s+argc\s*,/;
 my $apps_openssl = shift @ARGV;
-my $YEAR         = [localtime()]->[5] + 1900;
+my $YEAR         = [gmtime($ENV{SOURCE_DATE_EPOCH} || time())]->[5] + 1900;
 
 # because the program apps/openssl has object files as sources, and
 # they then have the corresponding C files as source, we need to chain


### PR DESCRIPTION
As with 11d7d903, use SOURCE_DATE_EPOCH for the copyright year if it is
defined, to avoid reproducibility problems.

CLA: trivial

Signed-off-by: Ross Burton <ross.burton@arm.com>
Change-Id: I1bea19070411a69155c43de7082350fb2c499da3

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
