### PR TITLE
Revert the var thiswr in do_ssl3_write()

### DIFF
--- a/ssl/record/rec_layer_s3.c
+++ b/ssl/record/rec_layer_s3.c
@@ -1105,7 +1105,7 @@ int do_ssl3_write(SSL *s, int type, const unsigned char *buf,
         }
 
         /* header is added by the kernel when using offload */
-        SSL3_RECORD_add_length(&wr[j], SSL3_RT_HEADER_LENGTH);
+        SSL3_RECORD_add_length(thiswr, SSL3_RT_HEADER_LENGTH);
 
         if (create_empty_fragment) {
             /*


### PR DESCRIPTION
The var 'thiswr' is an unwanted modification,
it was submitted in #5253.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->


