### PR TITLE
Update the comment on ssl3_write_pending()

### DIFF
--- a/ssl/record/rec_layer_s3.c
+++ b/ssl/record/rec_layer_s3.c
@@ -1151,7 +1151,7 @@ int do_ssl3_write(SSL *s, int type, const unsigned char *buf,
     return -1;
 }
 
-/* if s->s3.wbuf.left != 0, we need to call this
+/* if SSL3_BUFFER_get_left() != 0, we need to call this
  *
  * Return values are as per SSL_write()
  */


### PR DESCRIPTION
The struct s->s3 has been modified.
Check if there is a SSL3_BUFFER left, ssl3_write_pending() should be called.
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
