### PR TITLE
scrypt: increase memory usage beyond limit

### DIFF
--- a/test/recipes/30-test_evp_data/evpkdf.txt
+++ b/test/recipes/30-test_evp_data/evpkdf.txt
@@ -294,12 +294,12 @@ Ctrl.r = r:8
 Ctrl.p = p:1
 Output = 7023bdcb3afd7348461c06cd81fd38ebfda8fbba904f8e3ea9b543f6545da1f2d5432955613f0fcf62d49705242a9af9e61e85dc0d651e40dfcf017b45575887
 
-# Out of memory
+# Out of memory - request > 2 GB of memory
 KDF = scrypt
 Ctrl.pass = pass:pleaseletmein
 Ctrl.salt = salt:SodiumChloride
-Ctrl.N = N:1048576
+Ctrl.N = N:2097152
 Ctrl.r = r:8
 Ctrl.p = p:1
-Result = KDF_MISMATCH
+Result = KDF_DERIVE_ERROR
 

--- a/test/recipes/30-test_evp_data/evppbe.txt
+++ b/test/recipes/30-test_evp_data/evppbe.txt
@@ -38,14 +38,14 @@ r = 8
 p = 1
 Key = 7023bdcb3afd7348461c06cd81fd38ebfda8fbba904f8e3ea9b543f6545da1f2d5432955613f0fcf62d49705242a9af9e61e85dc0d651e40dfcf017b45575887
 
-# NB: this test requires more than 1GB of memory to run so it will hit the
+# NB: this test requires more than 2GB of memory to run so it will hit the
 # scrypt memory limit and return an error. To run this test without error
 # uncomment out the "maxmem" line and comment out the "Result"
 # line
 PBE = scrypt
 Password = "pleaseletmein"
 Salt = "SodiumChloride"
-N = 1048576
+N = 2097152
 r = 8
 p = 1
 Key = 2101cb9b6a511aaeaddbbe09cf70f881ec568d574a2ffd4dabe5ee9820adaa478e56fd8f4ba5d09ffa1c6d927c40f4c337304049e8a952fbcbf45c6fa77a41a4

--- a/test/recipes/30-test_evp_data/evppbe.txt
+++ b/test/recipes/30-test_evp_data/evppbe.txt
@@ -38,14 +38,14 @@ r = 8
 p = 1
 Key = 7023bdcb3afd7348461c06cd81fd38ebfda8fbba904f8e3ea9b543f6545da1f2d5432955613f0fcf62d49705242a9af9e61e85dc0d651e40dfcf017b45575887
 
-# NB: this test requires more than 2GB of memory to run so it will hit the
+# NB: this test requires more than 1GB of memory to run so it will hit the
 # scrypt memory limit and return an error. To run this test without error
 # uncomment out the "maxmem" line and comment out the "Result"
 # line
 PBE = scrypt
 Password = "pleaseletmein"
 Salt = "SodiumChloride"
-N = 2097152
+N = 1048576
 r = 8
 p = 1
 Key = 2101cb9b6a511aaeaddbbe09cf70f881ec568d574a2ffd4dabe5ee9820adaa478e56fd8f4ba5d09ffa1c6d927c40f4c337304049e8a952fbcbf45c6fa77a41a4


### PR DESCRIPTION
This brings these tests in line with 3.0 and master and makes them fail correctly.

Fixes #17612

- [ ] documentation is added or updated
- [x] tests are added or updated
