### PR TITLE
Use $SOURCE_DATE_EPOCH for copyright year if defined

### DIFF
--- a/apps/progs.pl
+++ b/apps/progs.pl
@@ -21,7 +21,7 @@ die "Unrecognised option, must be -C or -H\n"
 my %commands     = ();
 my $cmdre        = qr/^\s*int\s+([a-z_][a-z0-9_]*)_main\(\s*int\s+argc\s*,/;
 my $apps_openssl = shift @ARGV;
-my $YEAR         = [localtime()]->[5] + 1900;
+my $YEAR         = [gmtime($ENV{SOURCE_DATE_EPOCH} || time())]->[5] + 1900;
 
 # because the program apps/openssl has object files as sources, and
 # they then have the corresponding C files as source, we need to chain


### PR DESCRIPTION
From the commit message:
```
This allows reproducible sources for apps/progs.c and apps/progs.h.

This change is similar to 11d7d90344, but for apps/progs.pl.
```
As mentioned in the commit message, this change is similar to what was done in 11d7d90344 (https://github.com/openssl/openssl/pull/11296).

This reprodicibility issue was originally discovered and reported by the freedesktop-sdk project.<sup>0</sup> Our diffoscope report highlights the source reproducibility issue.<sup>1</sup>

<sup>0</sup> https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/issues/1372
<sup>1</sup> https://freedesktop-sdk.gitlab.io/-/freedesktop-sdk/-/jobs/1955804555/artifacts/result_folder/components/openssl.bst/index.html