### PR TITLE
Add missing CRYPTO_THREAD_cleanup_local of default_context_thread_local

### DIFF
--- a/crypto/context.c
+++ b/crypto/context.c
@@ -156,6 +156,7 @@ DEFINE_RUN_ONCE_STATIC(default_context_do_init)
 void ossl_lib_ctx_default_deinit(void)
 {
     context_deinit(&default_context_int);
+    CRYPTO_THREAD_cleanup_local(&default_context_thread_local);
 }
 
 static OSSL_LIB_CTX *get_thread_default_context(void)


### PR DESCRIPTION
Trivial change to ossl_lib_ctx_default_deinit() to clean up the default_context_thread_local.
While on most platforms leaking resources has no consequence, for some others it may matter.