### PR TITLE
Fix openssl-dgst.html hep file

### DIFF
--- a/doc/man1/openssl-dgst.pod.in
+++ b/doc/man1/openssl-dgst.pod.in
@@ -9,11 +9,11 @@ openssl-dgst - perform digest operations
 
 B<openssl> B<dgst>|I<digest>
 [B<-I<digest>>]
+[B<-list>]
 [B<-help>]
 [B<-c>]
 [B<-d>]
 [B<-debug>]
-[B<-list>]
 [B<-hex>]
 [B<-binary>]
 [B<-xoflen> I<length>]
@@ -47,7 +47,7 @@ The generic name, B<openssl dgst>, may be used with an option specifying the
 algorithm to be used.
 The default digest is B<sha256>.
 A supported I<digest> name may also be used as the sub-command name.
-To see the list of supported algorithms, use C<openssl list -digest-commands>
+To see the list of supported algorithms, use C<openssl list -digest-algorithms>
 
 =head1 OPTIONS
 
@@ -59,8 +59,11 @@ Print out a usage message.
 
 =item B<-I<digest>>
 
-Specifies name of a supported digest to be used. To see the list of
-supported digests, use the command C<list --digest-commands>.
+Specifies name of a supported digest to be used. See option B<-list> below :
+
+=item B<-list>
+
+Prints out a list of supported message digests.
 
 =item B<-c>
 
@@ -70,10 +73,6 @@ the B<-hex> option is given as well.
 =item B<-d>, B<-debug>
 
 Print out BIO debugging information.
-
-=item B<-list>
-
-Prints out a list of supported message digests.
 
 =item B<-hex>
 
@@ -206,12 +205,19 @@ used.
 =head1 EXAMPLES
 
 To create a hex-encoded message digest of a file:
+
  openssl dgst -md5 -hex file.txt
+ or
+ openssl md5 file.txt
 
 To sign a file using SHA-256 with binary file output:
+
  openssl dgst -sha256 -sign privatekey.pem -out signature.sign file.txt
+ or
+ openssl sha256 -sign privatekey.pem -out signature.sign file.txt
 
 To verify a signature:
+
  openssl dgst -sha256 -verify publickey.pem \
  -signature signature.sign \
  file.txt
@@ -221,7 +227,7 @@ To verify a signature:
 
 The digest mechanisms that are available will depend on the options
 used when building OpenSSL.
-The C<openssl list -digest-commands> command can be used to list them.
+The C<openssl list -digest-algorithms> command can be used to list them.
 
 New or agile applications should use probably use SHA-256. Other digests,
 particularly SHA-1 and MD5, are still widely used for interoperating


### PR DESCRIPTION
Fix openssl-dgst.html (list -digest-algorithms, NOT -digest-commands), 
move option -list just after the related option -digest, 
fix HTML formatting of section 'Examples' by adding missing newlines 
and add 2 examples variant to clarify syntax of the command openssl dgst|digest [-digest] ...

[x] documentation is updated
