### PR TITLE
evp_test: Add the missing check after calling OPENSSL_strdup and sk_OPENSSL_STRING_new_null

### DIFF
--- a/test/evp_test.c
+++ b/test/evp_test.c
@@ -1209,8 +1209,8 @@ static int mac_test_init(EVP_TEST *t, const char *alg)
     mdat->mac = mac;
     if (!TEST_ptr(mdat->controls = sk_OPENSSL_STRING_new_null())) {
         OPENSSL_free(mdat->mac_name);
-	OPENSSL_free(mdat);
-	return 0;
+        OPENSSL_free(mdat);
+        return 0;
     }
 
     mdat->output_size = mdat->block_size = -1;

--- a/test/evp_test.c
+++ b/test/evp_test.c
@@ -1201,9 +1201,18 @@ static int mac_test_init(EVP_TEST *t, const char *alg)
         return 0;
 
     mdat->type = type;
-    mdat->mac_name = OPENSSL_strdup(alg);
+    if (!TEST_ptr(mdat->mac_name = OPENSSL_strdup(alg))) {
+        OPENSSL_free(mdat);
+        return 0;
+    }
+
     mdat->mac = mac;
-    mdat->controls = sk_OPENSSL_STRING_new_null();
+    if (!TEST_ptr(mdat->controls = sk_OPENSSL_STRING_new_null())) {
+        OPENSSL_free(mdat->mac_name);
+	OPENSSL_free(mdat);
+	return 0;
+    }
+
     mdat->output_size = mdat->block_size = -1;
     t->data = mdat;
     return 1;


### PR DESCRIPTION
Since the memory allocation may fail, the 'mac_name' and 'controls'
could be NULL.
And the 'mac_name' will be printed in mac_test_run_mac() without check.
Also the result of 'params_n +
sk_OPENSSL_STRING_num(expected->controls)' in
mac_test_run_mac() will be 'params_n - 1' if allocation fails , which
does not make sense.
Therefore, it should be better to check them in order to guarantee the
complete success of initiation.
If fails, we also need to free the 'mdat' to avoid the memory leak.

Signed-off-by: Jiasheng Jiang <jiasheng@iscas.ac.cn>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
