### PR TITLE
Fixes #17613

### DIFF
--- a/apps/x509.c
+++ b/apps/x509.c
@@ -711,9 +711,12 @@ int x509_main(int argc, char **argv)
                        : "Certificate request self-signature did not match the contents\n");
             goto err;
         }
+      
         BIO_printf(out, "Certificate request self-signature ok\n");
-
-        print_name(out, "subject=", X509_REQ_get_subject_name(req));
+      
+        if (out != NULL){
+           print_name(out, "subject=", X509_REQ_get_subject_name(req));
+        }
     } else if (!x509toreq && ext_copy != EXT_COPY_UNSET) {
         BIO_printf(bio_err, "Warning: ignoring -copy_extensions since neither -x509toreq nor -req is given\n");
     }


### PR DESCRIPTION
Check if out ptr is NULL before printing to it. Fixes the issue of trying to print to a NULL ptr.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->