### PR TITLE
Fix SIZE_MAX not defined on z/OS etc

### DIFF
--- a/apps/speed.c
+++ b/apps/speed.c
@@ -29,7 +29,7 @@
 #include <math.h>
 #include "apps.h"
 #include "progs.h"
-#include <internal/numbers.h>
+#include "internal/numbers.h"
 #include <openssl/crypto.h>
 #include <openssl/rand.h>
 #include <openssl/err.h>

--- a/apps/speed.c
+++ b/apps/speed.c
@@ -29,6 +29,7 @@
 #include <math.h>
 #include "apps.h"
 #include "progs.h"
+#include <internal/numbers.h>
 #include <openssl/crypto.h>
 #include <openssl/rand.h>
 #include <openssl/err.h>
@@ -82,10 +83,6 @@
 
 #ifndef RSA_DEFAULT_PRIME_NUM
 # define RSA_DEFAULT_PRIME_NUM 2
-#endif
-
-#ifndef SIZE_MAX
-#include <internal/numbers.h>
 #endif
 
 typedef struct openssl_speed_sec_st {

--- a/apps/speed.c
+++ b/apps/speed.c
@@ -84,6 +84,10 @@
 # define RSA_DEFAULT_PRIME_NUM 2
 #endif
 
+#ifndef SIZE_MAX
+#include <internal/numbers.h>
+#endif
+
 typedef struct openssl_speed_sec_st {
     int sym;
     int rsa;


### PR DESCRIPTION
Includes internal/numbers.h if SIZE_MAX is not defined by the OS. Fixes #17629 

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->