### PR TITLE
Don't include e_os.h from header files in the include/ tree

### DIFF
--- a/include/internal/common.h
+++ b/include/internal/common.h
@@ -13,7 +13,6 @@
 
 # include <stdlib.h>
 # include <string.h>
-# include "../../e_os.h" /* To get strncasecmp() on Windows */
 
 # include "internal/nelem.h"
 


### PR DESCRIPTION
On some platforms, including e_os.h with a relative path from another
include file is risky, as it can cause build failures because of how
the compiler interacts with the platform.

Let's just not, and instead include it from the .c files that need it.
