### PR TITLE
Add the check after calling OPENSSL_strdup

### DIFF
--- a/test/helpers/handshake_srp.c
+++ b/test/helpers/handshake_srp.c
@@ -49,6 +49,8 @@ int configure_handshake_ctx_for_srp(SSL_CTX *server_ctx, SSL_CTX *server2_ctx,
         SSL_CTX_set_srp_username_callback(server_ctx, server_srp_cb);
         server_ctx_data->srp_user = OPENSSL_strdup(extra->server.srp_user);
         server_ctx_data->srp_password = OPENSSL_strdup(extra->server.srp_password);
+        if (server_ctx_data->srp_user == NULL || server_ctx_data->srp_password == NULL)
+            return 0;
         SSL_CTX_set_srp_cb_arg(server_ctx, server_ctx_data);
     }
     if (extra->server2.srp_user != NULL) {
@@ -57,6 +59,8 @@ int configure_handshake_ctx_for_srp(SSL_CTX *server_ctx, SSL_CTX *server2_ctx,
         SSL_CTX_set_srp_username_callback(server2_ctx, server_srp_cb);
         server2_ctx_data->srp_user = OPENSSL_strdup(extra->server2.srp_user);
         server2_ctx_data->srp_password = OPENSSL_strdup(extra->server2.srp_password);
+        if (server2_ctx_data->srp_user == NULL || server2_ctx_data->srp_password == NULL)
+            return 0;
         SSL_CTX_set_srp_cb_arg(server2_ctx, server2_ctx_data);
     }
     if (extra->client.srp_user != NULL) {
@@ -65,6 +69,8 @@ int configure_handshake_ctx_for_srp(SSL_CTX *server_ctx, SSL_CTX *server2_ctx,
             return 0;
         SSL_CTX_set_srp_client_pwd_callback(client_ctx, client_srp_cb);
         client_ctx_data->srp_password = OPENSSL_strdup(extra->client.srp_password);
+        if (client_ctx_data->srp_password == NULL)
+            return 0;
         SSL_CTX_set_srp_cb_arg(client_ctx, client_ctx_data);
     }
     return 1;

--- a/test/helpers/handshake_srp.c
+++ b/test/helpers/handshake_srp.c
@@ -52,6 +52,8 @@ int configure_handshake_ctx_for_srp(SSL_CTX *server_ctx, SSL_CTX *server2_ctx,
         if (server_ctx_data->srp_user == NULL || server_ctx_data->srp_password == NULL) {
             OPENSSL_free(server_ctx_data->srp_user);
             OPENSSL_free(server_ctx_data->srp_password);
+            server_ctx_data->srp_user = NULL;
+            server_ctx_data->srp_password = NULL;
             return 0;
         }
         SSL_CTX_set_srp_cb_arg(server_ctx, server_ctx_data);
@@ -65,6 +67,8 @@ int configure_handshake_ctx_for_srp(SSL_CTX *server_ctx, SSL_CTX *server2_ctx,
         if (server2_ctx_data->srp_user == NULL || server2_ctx_data->srp_password == NULL) {
             OPENSSL_free(server2_ctx_data->srp_user);
             OPENSSL_free(server2_ctx_data->srp_password);
+            server2_ctx_data->srp_user = NULL;
+            server2_ctx_data->srp_password = NULL;
             return 0;
         }
         SSL_CTX_set_srp_cb_arg(server2_ctx, server2_ctx_data);

--- a/test/helpers/handshake_srp.c
+++ b/test/helpers/handshake_srp.c
@@ -49,8 +49,11 @@ int configure_handshake_ctx_for_srp(SSL_CTX *server_ctx, SSL_CTX *server2_ctx,
         SSL_CTX_set_srp_username_callback(server_ctx, server_srp_cb);
         server_ctx_data->srp_user = OPENSSL_strdup(extra->server.srp_user);
         server_ctx_data->srp_password = OPENSSL_strdup(extra->server.srp_password);
-        if (server_ctx_data->srp_user == NULL || server_ctx_data->srp_password == NULL)
+        if (server_ctx_data->srp_user == NULL || server_ctx_data->srp_password == NULL) {
+            OPENSSL_free(server_ctx_data->srp_user);
+            OPENSSL_free(server_ctx_data->srp_password);
             return 0;
+        }
         SSL_CTX_set_srp_cb_arg(server_ctx, server_ctx_data);
     }
     if (extra->server2.srp_user != NULL) {
@@ -59,8 +62,11 @@ int configure_handshake_ctx_for_srp(SSL_CTX *server_ctx, SSL_CTX *server2_ctx,
         SSL_CTX_set_srp_username_callback(server2_ctx, server_srp_cb);
         server2_ctx_data->srp_user = OPENSSL_strdup(extra->server2.srp_user);
         server2_ctx_data->srp_password = OPENSSL_strdup(extra->server2.srp_password);
-        if (server2_ctx_data->srp_user == NULL || server2_ctx_data->srp_password == NULL)
+        if (server2_ctx_data->srp_user == NULL || server2_ctx_data->srp_password == NULL) {
+            OPENSSL_free(server2_ctx_data->srp_user);
+            OPENSSL_free(server2_ctx_data->srp_password);
             return 0;
+        }
         SSL_CTX_set_srp_cb_arg(server2_ctx, server2_ctx_data);
     }
     if (extra->client.srp_user != NULL) {


### PR DESCRIPTION
Since the potential failure of the memory allocation, the
OPENSSL_strdup() could return NULL pointer.
Therefore, it should be better to check it in order to guarantee the
success of the configuration, same as the check for
SSL_CTX_set_srp_username().

Signed-off-by: Jiasheng Jiang <jiasheng@iscas.ac.cn>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
