### PR TITLE
[apps/speed] Added checking for buflen overflow due to MAX_MISALIGNMENT.

### DIFF
--- a/apps/speed.c
+++ b/apps/speed.c
@@ -1778,7 +1778,12 @@ int speed_main(int argc, char **argv)
         buflen = lengths[size_num - 1];
         if (buflen < 36)    /* size of random vector in RSA benchmark */
             buflen = 36;
-        buflen += MAX_MISALIGNMENT + 1;
+        if (0x7fffffff - (MAX_MISALIGNMENT + 1) < buflen)
+        {
+            BIO_printf(bio_err, "Warning: ignoring -misalign option.\n");
+        } else {
+            buflen += MAX_MISALIGNMENT + 1;
+        }
         loopargs[i].buf_malloc = app_malloc(buflen, "input buffer");
         loopargs[i].buf2_malloc = app_malloc(buflen, "input buffer");
         memset(loopargs[i].buf_malloc, 0, buflen);


### PR DESCRIPTION
If a large enough value is given to the "-bytes" option, a signed integer overflow occurs as MAX_ALIGNMENT + 1 is added to buflen. This negative value is interpreted as unsigned by malloc, which then attempts to allocate an extremely large buffer. 

For now, I'm just ignoring the addition and printing a warning. I'm not sure about the semantics of the "-misalign" option, so if there is a better solution I will implement that instead. 

This also might be a consideration for backporting to the 1.1.1 branch. 