### PR TITLE
dh_exch.c: Add check for OPENSSL_strdup

### DIFF
--- a/providers/implementations/exchange/dh_exch.c
+++ b/providers/implementations/exchange/dh_exch.c
@@ -293,6 +293,8 @@ static void *dh_dupctx(void *vpdhctx)
             goto err;
     }
     dstctx->kdf_cekalg = OPENSSL_strdup(srcctx->kdf_cekalg);
+    if (dstctx->kdf_cekalg == NULL)
+        goto err;
 
     return dstctx;
 err:
@@ -393,6 +395,8 @@ static int dh_set_ctx_params(void *vpdhctx, const OSSL_PARAM params[])
         if (!OSSL_PARAM_get_utf8_string(p, &str, sizeof(name)))
             return 0;
         pdhctx->kdf_cekalg = OPENSSL_strdup(name);
+        if (pdhctx->kdf_cekalg == NULL)
+            return 0;
     }
     return 1;
 }

--- a/providers/implementations/exchange/dh_exch.c
+++ b/providers/implementations/exchange/dh_exch.c
@@ -395,11 +395,16 @@ static int dh_set_ctx_params(void *vpdhctx, const OSSL_PARAM params[])
     p = OSSL_PARAM_locate_const(params, OSSL_KDF_PARAM_CEK_ALG);
     if (p != NULL) {
         str = name;
-        if (!OSSL_PARAM_get_utf8_string(p, &str, sizeof(name)))
-            return 0;
-        pdhctx->kdf_cekalg = OPENSSL_strdup(name);
-        if (pdhctx->kdf_cekalg == NULL)
-            return 0;
+
+        OPENSSL_free(pdhctx->kdf_cekalg);
+        pdhctx->kdf_cekalg = NULL;
+        if (p->data != NULL && p->data_size != 0) {
+            if (!OSSL_PARAM_get_utf8_string(p, &str, sizeof(name)))
+                return 0;
+            pdhctx->kdf_cekalg = OPENSSL_strdup(name);
+            if (pdhctx->kdf_cekalg == NULL)
+                return 0;
+        }
     }
     return 1;
 }

--- a/providers/implementations/exchange/dh_exch.c
+++ b/providers/implementations/exchange/dh_exch.c
@@ -292,9 +292,12 @@ static void *dh_dupctx(void *vpdhctx)
         if (dstctx->kdf_ukm == NULL)
             goto err;
     }
-    dstctx->kdf_cekalg = OPENSSL_strdup(srcctx->kdf_cekalg);
-    if (dstctx->kdf_cekalg == NULL)
-        goto err;
+
+    if (srcctx->kdf_cekalg != NULL) {
+        dstctx->kdf_cekalg = OPENSSL_strdup(srcctx->kdf_cekalg);
+        if (dstctx->kdf_cekalg == NULL)
+            goto err;
+    }
 
     return dstctx;
 err:


### PR DESCRIPTION
Since the OPENSSL_strdup() may return NULL if allocation
fails, it should be better to check the return value.

Signed-off-by: Jiasheng Jiang <jiasheng@iscas.ac.cn>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
