### PR TITLE
Fix an enginetest failure when compiled with no-deprecated --api=1.1.1

### DIFF
--- a/test/enginetest.c
+++ b/test/enginetest.c
@@ -24,6 +24,7 @@
 # include <openssl/rsa.h>
 # include <openssl/err.h>
 # include <openssl/x509.h>
+# include <openssl/pem.h>
 
 static void display_engine_list(void)
 {


### PR DESCRIPTION
Fixes #17649
