### PR TITLE
Add define guards to avoid multi-inclusion

### DIFF
--- a/include/crypto/md32_common.h
+++ b/include/crypto/md32_common.h
@@ -63,63 +63,67 @@
  *      #define HASH_BLOCK_DATA_ORDER   md5_block_data_order
  */
 
-#include <openssl/crypto.h>
+#ifndef OSSL_CRYPTO_MD32_COMMON_H
+# define OSSL_CRYPTO_MD32_COMMON_H
+# pragma once
 
-#if !defined(DATA_ORDER_IS_BIG_ENDIAN) && !defined(DATA_ORDER_IS_LITTLE_ENDIAN)
-# error "DATA_ORDER must be defined!"
-#endif
+# include <openssl/crypto.h>
 
-#ifndef HASH_CBLOCK
-# error "HASH_CBLOCK must be defined!"
-#endif
-#ifndef HASH_LONG
-# error "HASH_LONG must be defined!"
-#endif
-#ifndef HASH_CTX
-# error "HASH_CTX must be defined!"
-#endif
+# if !defined(DATA_ORDER_IS_BIG_ENDIAN) && !defined(DATA_ORDER_IS_LITTLE_ENDIAN)
+#  error "DATA_ORDER must be defined!"
+# endif
 
-#ifndef HASH_UPDATE
-# error "HASH_UPDATE must be defined!"
-#endif
-#ifndef HASH_TRANSFORM
-# error "HASH_TRANSFORM must be defined!"
-#endif
-#ifndef HASH_FINAL
-# error "HASH_FINAL must be defined!"
-#endif
+# ifndef HASH_CBLOCK
+#  error "HASH_CBLOCK must be defined!"
+# endif
+# ifndef HASH_LONG
+#  error "HASH_LONG must be defined!"
+# endif
+# ifndef HASH_CTX
+#  error "HASH_CTX must be defined!"
+# endif
 
-#ifndef HASH_BLOCK_DATA_ORDER
-# error "HASH_BLOCK_DATA_ORDER must be defined!"
-#endif
+# ifndef HASH_UPDATE
+#  error "HASH_UPDATE must be defined!"
+# endif
+# ifndef HASH_TRANSFORM
+#  error "HASH_TRANSFORM must be defined!"
+# endif
+# ifndef HASH_FINAL
+#  error "HASH_FINAL must be defined!"
+# endif
 
-#define ROTATE(a,n)     (((a)<<(n))|(((a)&0xffffffff)>>(32-(n))))
+# ifndef HASH_BLOCK_DATA_ORDER
+#  error "HASH_BLOCK_DATA_ORDER must be defined!"
+# endif
 
-#if defined(DATA_ORDER_IS_BIG_ENDIAN)
+# define ROTATE(a,n)     (((a)<<(n))|(((a)&0xffffffff)>>(32-(n))))
 
-# define HOST_c2l(c,l)  (l =(((unsigned long)(*((c)++)))<<24),          \
+# if defined(DATA_ORDER_IS_BIG_ENDIAN)
+
+#  define HOST_c2l(c,l)  (l =(((unsigned long)(*((c)++)))<<24),          \
                          l|=(((unsigned long)(*((c)++)))<<16),          \
                          l|=(((unsigned long)(*((c)++)))<< 8),          \
                          l|=(((unsigned long)(*((c)++)))    )           )
-# define HOST_l2c(l,c)  (*((c)++)=(unsigned char)(((l)>>24)&0xff),      \
+#  define HOST_l2c(l,c)  (*((c)++)=(unsigned char)(((l)>>24)&0xff),      \
                          *((c)++)=(unsigned char)(((l)>>16)&0xff),      \
                          *((c)++)=(unsigned char)(((l)>> 8)&0xff),      \
                          *((c)++)=(unsigned char)(((l)    )&0xff),      \
                          l)
 
-#elif defined(DATA_ORDER_IS_LITTLE_ENDIAN)
+# elif defined(DATA_ORDER_IS_LITTLE_ENDIAN)
 
-# define HOST_c2l(c,l)  (l =(((unsigned long)(*((c)++)))    ),          \
+#  define HOST_c2l(c,l)  (l =(((unsigned long)(*((c)++)))    ),          \
                          l|=(((unsigned long)(*((c)++)))<< 8),          \
                          l|=(((unsigned long)(*((c)++)))<<16),          \
                          l|=(((unsigned long)(*((c)++)))<<24)           )
-# define HOST_l2c(l,c)  (*((c)++)=(unsigned char)(((l)    )&0xff),      \
+#  define HOST_l2c(l,c)  (*((c)++)=(unsigned char)(((l)    )&0xff),      \
                          *((c)++)=(unsigned char)(((l)>> 8)&0xff),      \
                          *((c)++)=(unsigned char)(((l)>>16)&0xff),      \
                          *((c)++)=(unsigned char)(((l)>>24)&0xff),      \
                          l)
 
-#endif
+# endif
 
 /*
  * Time for some action :-)
@@ -204,30 +208,30 @@ int HASH_FINAL(unsigned char *md, HASH_CTX *c)
     memset(p + n, 0, HASH_CBLOCK - 8 - n);
 
     p += HASH_CBLOCK - 8;
-#if   defined(DATA_ORDER_IS_BIG_ENDIAN)
+# if   defined(DATA_ORDER_IS_BIG_ENDIAN)
     (void)HOST_l2c(c->Nh, p);
     (void)HOST_l2c(c->Nl, p);
-#elif defined(DATA_ORDER_IS_LITTLE_ENDIAN)
+# elif defined(DATA_ORDER_IS_LITTLE_ENDIAN)
     (void)HOST_l2c(c->Nl, p);
     (void)HOST_l2c(c->Nh, p);
-#endif
+# endif
     p -= HASH_CBLOCK;
     HASH_BLOCK_DATA_ORDER(c, p, 1);
     c->num = 0;
     OPENSSL_cleanse(p, HASH_CBLOCK);
 
-#ifndef HASH_MAKE_STRING
-# error "HASH_MAKE_STRING must be defined!"
-#else
+# ifndef HASH_MAKE_STRING
+#  error "HASH_MAKE_STRING must be defined!"
+# else
     HASH_MAKE_STRING(c, md);
-#endif
+# endif
 
     return 1;
 }
 
-#ifndef MD32_REG_T
-# if defined(__alpha) || defined(__sparcv9) || defined(__mips)
-#  define MD32_REG_T long
+# ifndef MD32_REG_T
+#  if defined(__alpha) || defined(__sparcv9) || defined(__mips)
+#   define MD32_REG_T long
 /*
  * This comment was originally written for MD5, which is why it
  * discusses A-D. But it basically applies to all 32-bit digests,
@@ -244,13 +248,15 @@ int HASH_FINAL(unsigned char *md, HASH_CTX *c)
  * Well, to be honest it should say that this *prevents*
  * performance degradation.
  */
-# else
+#  else
 /*
  * Above is not absolute and there are LP64 compilers that
  * generate better code if MD32_REG_T is defined int. The above
  * pre-processor condition reflects the circumstances under which
  * the conclusion was made and is subject to further extension.
  */
-#  define MD32_REG_T int
+#   define MD32_REG_T int
+#  endif
 # endif
+
 #endif

--- a/include/internal/der.h
+++ b/include/internal/der.h
@@ -7,8 +7,12 @@
  * https://www.openssl.org/source/license.html
  */
 
-#include <openssl/bn.h>
-#include "internal/packet.h"
+#ifndef OSSL_INTERNAL_DER_H
+# define OSSL_INTERNAL_DER_H
+# pragma once
+
+# include <openssl/bn.h>
+# include "internal/packet.h"
 
 /*
  * NOTE: X.690 numbers the identifier octet bits 1 to 8.
@@ -22,42 +26,42 @@
  * These are only valid for the UNIVERSAL class.  With the other classes,
  * these bits have a different meaning.
  */
-#define DER_P_EOC                       0 /* BER End Of Contents tag */
-#define DER_P_BOOLEAN                   1
-#define DER_P_INTEGER                   2
-#define DER_P_BIT_STRING                3
-#define DER_P_OCTET_STRING              4
-#define DER_P_NULL                      5
-#define DER_P_OBJECT                    6
-#define DER_P_OBJECT_DESCRIPTOR         7
-#define DER_P_EXTERNAL                  8
-#define DER_P_REAL                      9
-#define DER_P_ENUMERATED               10
-#define DER_P_UTF8STRING               12
-#define DER_P_SEQUENCE                 16
-#define DER_P_SET                      17
-#define DER_P_NUMERICSTRING            18
-#define DER_P_PRINTABLESTRING          19
-#define DER_P_T61STRING                20
-#define DER_P_VIDEOTEXSTRING           21
-#define DER_P_IA5STRING                22
-#define DER_P_UTCTIME                  23
-#define DER_P_GENERALIZEDTIME          24
-#define DER_P_GRAPHICSTRING            25
-#define DER_P_ISO64STRING              26
-#define DER_P_GENERALSTRING            27
-#define DER_P_UNIVERSALSTRING          28
-#define DER_P_BMPSTRING                30
+# define DER_P_EOC                       0 /* BER End Of Contents tag */
+# define DER_P_BOOLEAN                   1
+# define DER_P_INTEGER                   2
+# define DER_P_BIT_STRING                3
+# define DER_P_OCTET_STRING              4
+# define DER_P_NULL                      5
+# define DER_P_OBJECT                    6
+# define DER_P_OBJECT_DESCRIPTOR         7
+# define DER_P_EXTERNAL                  8
+# define DER_P_REAL                      9
+# define DER_P_ENUMERATED               10
+# define DER_P_UTF8STRING               12
+# define DER_P_SEQUENCE                 16
+# define DER_P_SET                      17
+# define DER_P_NUMERICSTRING            18
+# define DER_P_PRINTABLESTRING          19
+# define DER_P_T61STRING                20
+# define DER_P_VIDEOTEXSTRING           21
+# define DER_P_IA5STRING                22
+# define DER_P_UTCTIME                  23
+# define DER_P_GENERALIZEDTIME          24
+# define DER_P_GRAPHICSTRING            25
+# define DER_P_ISO64STRING              26
+# define DER_P_GENERALSTRING            27
+# define DER_P_UNIVERSALSTRING          28
+# define DER_P_BMPSTRING                30
 
 /* DER Flags, occupying bit 6 in the DER identifier byte */
-#define DER_F_PRIMITIVE              0x00
-#define DER_F_CONSTRUCTED            0x20
+# define DER_F_PRIMITIVE              0x00
+# define DER_F_CONSTRUCTED            0x20
 
 /* DER classes tags, occupying bits 7-8 in the DER identifier byte */
-#define DER_C_UNIVERSAL              0x00
-#define DER_C_APPLICATION            0x40
-#define DER_C_CONTEXT                0x80
-#define DER_C_PRIVATE                0xC0
+# define DER_C_UNIVERSAL              0x00
+# define DER_C_APPLICATION            0x40
+# define DER_C_CONTEXT                0x80
+# define DER_C_PRIVATE                0xC0
 
 /*
  * Run-time constructors.
@@ -67,7 +71,7 @@
  */
 
 /* This can be used for all items that don't have a context */
-#define DER_NO_CONTEXT  -1
+# define DER_NO_CONTEXT  -1
 
 int ossl_DER_w_precompiled(WPACKET *pkt, int tag,
                            const unsigned char *precompiled,
@@ -86,3 +90,5 @@ int ossl_DER_w_octet_string_uint32(WPACKET *pkt, int tag, uint32_t value);
  */
 int ossl_DER_w_begin_sequence(WPACKET *pkt, int tag);
 int ossl_DER_w_end_sequence(WPACKET *pkt, int tag);
+
+#endif

--- a/include/internal/tsan_assist.h
+++ b/include/internal/tsan_assist.h
@@ -47,33 +47,37 @@
  * can use TSAN_QUALIFIER in cast specifically when it has to count.
  */
 
-#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L \
+#ifndef OSSL_INTERNAL_TSAN_ASSIST_H
+# define OSSL_INTERNAL_TSAN_ASSIST_H
+# pragma once
+
+# if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L \
     && !defined(__STDC_NO_ATOMICS__)
-# include <stdatomic.h>
+#  include <stdatomic.h>
 
-# if defined(ATOMIC_POINTER_LOCK_FREE) \
+#  if defined(ATOMIC_POINTER_LOCK_FREE) \
           && ATOMIC_POINTER_LOCK_FREE >= 2
-#  define TSAN_QUALIFIER _Atomic
-#  define tsan_load(ptr) atomic_load_explicit((ptr), memory_order_relaxed)
-#  define tsan_store(ptr, val) atomic_store_explicit((ptr), (val), memory_order_relaxed)
-#  define tsan_add(ptr, n) atomic_fetch_add_explicit((ptr), (n), memory_order_relaxed)
-#  define tsan_ld_acq(ptr) atomic_load_explicit((ptr), memory_order_acquire)
-#  define tsan_st_rel(ptr, val) atomic_store_explicit((ptr), (val), memory_order_release)
-# endif
+#   define TSAN_QUALIFIER _Atomic
+#   define tsan_load(ptr) atomic_load_explicit((ptr), memory_order_relaxed)
+#   define tsan_store(ptr, val) atomic_store_explicit((ptr), (val), memory_order_relaxed)
+#   define tsan_add(ptr, n) atomic_fetch_add_explicit((ptr), (n), memory_order_relaxed)
+#   define tsan_ld_acq(ptr) atomic_load_explicit((ptr), memory_order_acquire)
+#   define tsan_st_rel(ptr, val) atomic_store_explicit((ptr), (val), memory_order_release)
+#  endif
 
-#elif defined(__GNUC__) && defined(__ATOMIC_RELAXED)
+# elif defined(__GNUC__) && defined(__ATOMIC_RELAXED)
 
-# if defined(__GCC_ATOMIC_POINTER_LOCK_FREE) \
+#  if defined(__GCC_ATOMIC_POINTER_LOCK_FREE) \
           && __GCC_ATOMIC_POINTER_LOCK_FREE >= 2
-#  define TSAN_QUALIFIER volatile
-#  define tsan_load(ptr) __atomic_load_n((ptr), __ATOMIC_RELAXED)
-#  define tsan_store(ptr, val) __atomic_store_n((ptr), (val), __ATOMIC_RELAXED)
-#  define tsan_add(ptr, n) __atomic_fetch_add((ptr), (n), __ATOMIC_RELAXED)
-#  define tsan_ld_acq(ptr) __atomic_load_n((ptr), __ATOMIC_ACQUIRE)
-#  define tsan_st_rel(ptr, val) __atomic_store_n((ptr), (val), __ATOMIC_RELEASE)
-# endif
+#   define TSAN_QUALIFIER volatile
+#   define tsan_load(ptr) __atomic_load_n((ptr), __ATOMIC_RELAXED)
+#   define tsan_store(ptr, val) __atomic_store_n((ptr), (val), __ATOMIC_RELAXED)
+#   define tsan_add(ptr, n) __atomic_fetch_add((ptr), (n), __ATOMIC_RELAXED)
+#   define tsan_ld_acq(ptr) __atomic_load_n((ptr), __ATOMIC_ACQUIRE)
+#   define tsan_st_rel(ptr, val) __atomic_store_n((ptr), (val), __ATOMIC_RELEASE)
+#  endif
 
-#elif defined(_MSC_VER) && _MSC_VER>=1200 \
+# elif defined(_MSC_VER) && _MSC_VER>=1200 \
       && (defined(_M_IX86) || defined(_M_AMD64) || defined(_M_X64) || \
           defined(_M_ARM64) || (defined(_M_ARM) && _M_ARM >= 7 && !defined(_WIN32_WCE)))
 /*
@@ -87,62 +91,63 @@
  * with additional instructions and penalties, it kind of makes sense to
  * default to "iso"...
  */
-# define TSAN_QUALIFIER volatile
-# if defined(_M_ARM) || defined(_M_ARM64)
-#  define _InterlockedExchangeAdd _InterlockedExchangeAdd_nf
-#  pragma intrinsic(_InterlockedExchangeAdd_nf)
-#  pragma intrinsic(__iso_volatile_load32, __iso_volatile_store32)
-#  ifdef _WIN64
-#   define _InterlockedExchangeAdd64 _InterlockedExchangeAdd64_nf
-#   pragma intrinsic(_InterlockedExchangeAdd64_nf)
-#   pragma intrinsic(__iso_volatile_load64, __iso_volatile_store64)
-#   define tsan_load(ptr) (sizeof(*(ptr)) == 8 ? __iso_volatile_load64(ptr) \
+#  define TSAN_QUALIFIER volatile
+#  if defined(_M_ARM) || defined(_M_ARM64)
+#   define _InterlockedExchangeAdd _InterlockedExchangeAdd_nf
+#   pragma intrinsic(_InterlockedExchangeAdd_nf)
+#   pragma intrinsic(__iso_volatile_load32, __iso_volatile_store32)
+#   ifdef _WIN64
+#    define _InterlockedExchangeAdd64 _InterlockedExchangeAdd64_nf
+#    pragma intrinsic(_InterlockedExchangeAdd64_nf)
+#    pragma intrinsic(__iso_volatile_load64, __iso_volatile_store64)
+#    define tsan_load(ptr) (sizeof(*(ptr)) == 8 ? __iso_volatile_load64(ptr) \
                                                : __iso_volatile_load32(ptr))
-#   define tsan_store(ptr, val) (sizeof(*(ptr)) == 8 ? __iso_volatile_store64((ptr), (val)) \
+#    define tsan_store(ptr, val) (sizeof(*(ptr)) == 8 ? __iso_volatile_store64((ptr), (val)) \
                                                      : __iso_volatile_store32((ptr), (val)))
+#   else
+#    define tsan_load(ptr) __iso_volatile_load32(ptr)
+#    define tsan_store(ptr, val) __iso_volatile_store32((ptr), (val))
+#   endif
 #  else
-#   define tsan_load(ptr) __iso_volatile_load32(ptr)
-#   define tsan_store(ptr, val) __iso_volatile_store32((ptr), (val))
+#   define tsan_load(ptr) (*(ptr))
+#   define tsan_store(ptr, val) (*(ptr) = (val))
 #  endif
-# else
+#  pragma intrinsic(_InterlockedExchangeAdd)
+#  ifdef _WIN64
+#   pragma intrinsic(_InterlockedExchangeAdd64)
+#   define tsan_add(ptr, n) (sizeof(*(ptr)) == 8 ? _InterlockedExchangeAdd64((ptr), (n)) \
+                                                : _InterlockedExchangeAdd((ptr), (n)))
+#  else
+#   define tsan_add(ptr, n) _InterlockedExchangeAdd((ptr), (n))
+#  endif
+#  if !defined(_ISO_VOLATILE)
+#   define tsan_ld_acq(ptr) (*(ptr))
+#   define tsan_st_rel(ptr, val) (*(ptr) = (val))
+#  endif
+
+# endif
+
+# ifndef TSAN_QUALIFIER
+
+#  ifdef OPENSSL_THREADS
+#   define TSAN_QUALIFIER volatile
+#   define TSAN_REQUIRES_LOCKING
+#  else  /* OPENSSL_THREADS */
+#   define TSAN_QUALIFIER
+#  endif /* OPENSSL_THREADS */
+
 #  define tsan_load(ptr) (*(ptr))
 #  define tsan_store(ptr, val) (*(ptr) = (val))
-# endif
-# pragma intrinsic(_InterlockedExchangeAdd)
-# ifdef _WIN64
-#  pragma intrinsic(_InterlockedExchangeAdd64)
-#  define tsan_add(ptr, n) (sizeof(*(ptr)) == 8 ? _InterlockedExchangeAdd64((ptr), (n)) \
-                                                : _InterlockedExchangeAdd((ptr), (n)))
-# else
-#  define tsan_add(ptr, n) _InterlockedExchangeAdd((ptr), (n))
-# endif
-# if !defined(_ISO_VOLATILE)
-#  define tsan_ld_acq(ptr) (*(ptr))
-#  define tsan_st_rel(ptr, val) (*(ptr) = (val))
-# endif
-
-#endif
-
-#ifndef TSAN_QUALIFIER
-
-# ifdef OPENSSL_THREADS
-#  define TSAN_QUALIFIER volatile
-#  define TSAN_REQUIRES_LOCKING
-# else  /* OPENSSL_THREADS */
-#  define TSAN_QUALIFIER
-# endif /* OPENSSL_THREADS */
-
-# define tsan_load(ptr) (*(ptr))
-# define tsan_store(ptr, val) (*(ptr) = (val))
-# define tsan_add(ptr, n) (*(ptr) += (n))
+#  define tsan_add(ptr, n) (*(ptr) += (n))
 /*
  * Lack of tsan_ld_acq and tsan_ld_rel means that compiler support is not
  * sophisticated enough to support them. Code that relies on them should be
  * protected with #ifdef tsan_ld_acq with locked fallback.
  */
 
+# endif
+
+# define tsan_counter(ptr) tsan_add((ptr), 1)
+# define tsan_decr(ptr) tsan_add((ptr), -1)
+
 #endif
-
-#define tsan_counter(ptr) tsan_add((ptr), 1)
-#define tsan_decr(ptr) tsan_add((ptr), -1)
-

--- a/providers/implementations/include/prov/ciphercommon.h
+++ b/providers/implementations/include/prov/ciphercommon.h
@@ -7,23 +7,27 @@
  * https://www.openssl.org/source/license.html
  */
 
-#include <openssl/params.h>
-#include <openssl/core_dispatch.h>
-#include <openssl/core_names.h>
-#include <openssl/evp.h>
-#include "internal/cryptlib.h"
-#include "crypto/modes.h"
+#ifndef OSSL_PROV_CIPHERCOMMON_H
+# define OSSL_PROV_CIPHERCOMMON_H
+# pragma once
 
-#define MAXCHUNK    ((size_t)1 << (sizeof(long) * 8 - 2))
-#define MAXBITCHUNK ((size_t)1 << (sizeof(size_t) * 8 - 4))
+# include <openssl/params.h>
+# include <openssl/core_dispatch.h>
+# include <openssl/core_names.h>
+# include <openssl/evp.h>
+# include "internal/cryptlib.h"
+# include "crypto/modes.h"
 
-#define GENERIC_BLOCK_SIZE 16
-#define IV_STATE_UNINITIALISED 0  /* initial state is not initialized */
-#define IV_STATE_BUFFERED      1  /* iv has been copied to the iv buffer */
-#define IV_STATE_COPIED        2  /* iv has been copied from the iv buffer */
-#define IV_STATE_FINISHED      3  /* the iv has been used - so don't reuse it */
+# define MAXCHUNK    ((size_t)1 << (sizeof(long) * 8 - 2))
+# define MAXBITCHUNK ((size_t)1 << (sizeof(size_t) * 8 - 4))
 
-#define PROV_CIPHER_FUNC(type, name, args) typedef type (* OSSL_##name##_fn)args
+# define GENERIC_BLOCK_SIZE 16
+# define IV_STATE_UNINITIALISED 0  /* initial state is not initialized */
+# define IV_STATE_BUFFERED      1  /* iv has been copied to the iv buffer */
+# define IV_STATE_COPIED        2  /* iv has been copied from the iv buffer */
+# define IV_STATE_FINISHED      3  /* the iv has been used - so don't reuse it */
+
+# define PROV_CIPHER_FUNC(type, name, args) typedef type (* OSSL_##name##_fn)args
 
 typedef struct prov_cipher_hw_st PROV_CIPHER_HW;
 typedef struct prov_cipher_ctx_st PROV_CIPHER_CTX;
@@ -32,14 +36,14 @@ typedef int (PROV_CIPHER_HW_FN)(PROV_CIPHER_CTX *dat, unsigned char *out,
                                 const unsigned char *in, size_t len);
 
 /* Internal flags that can be queried */
-#define PROV_CIPHER_FLAG_AEAD             0x0001
-#define PROV_CIPHER_FLAG_CUSTOM_IV        0x0002
-#define PROV_CIPHER_FLAG_CTS              0x0004
-#define PROV_CIPHER_FLAG_TLS1_MULTIBLOCK  0x0008
-#define PROV_CIPHER_FLAG_RAND_KEY         0x0010
+# define PROV_CIPHER_FLAG_AEAD             0x0001
+# define PROV_CIPHER_FLAG_CUSTOM_IV        0x0002
+# define PROV_CIPHER_FLAG_CTS              0x0004
+# define PROV_CIPHER_FLAG_TLS1_MULTIBLOCK  0x0008
+# define PROV_CIPHER_FLAG_RAND_KEY         0x0010
 /* Internal flags that are only used within the provider */
-#define PROV_CIPHER_FLAG_VARIABLE_LENGTH  0x0100
-#define PROV_CIPHER_FLAG_INVERSE_CIPHER   0x0200
+# define PROV_CIPHER_FLAG_VARIABLE_LENGTH  0x0100
+# define PROV_CIPHER_FLAG_INVERSE_CIPHER   0x0200
 
 struct prov_cipher_ctx_st {
     block128_f block;
@@ -125,7 +129,7 @@ void ossl_cipher_generic_initkey(void *vctx, size_t kbits, size_t blkbits,
                                  uint64_t flags,
                                  const PROV_CIPHER_HW *hw, void *provctx);
 
-#define IMPLEMENT_generic_cipher_func(alg, UCALG, lcmode, UCMODE, flags, kbits,\
+# define IMPLEMENT_generic_cipher_func(alg, UCALG, lcmode, UCMODE, flags, kbits,\
                                       blkbits, ivbits, typ)                    \
 const OSSL_DISPATCH ossl_##alg##kbits##lcmode##_functions[] = {                \
     { OSSL_FUNC_CIPHER_NEWCTX,                                                 \
@@ -152,7 +156,7 @@ const OSSL_DISPATCH ossl_##alg##kbits##lcmode##_functions[] = {                \
     { 0, NULL }                                                                \
 };
 
-#define IMPLEMENT_var_keylen_cipher_func(alg, UCALG, lcmode, UCMODE, flags,    \
+# define IMPLEMENT_var_keylen_cipher_func(alg, UCALG, lcmode, UCMODE, flags,    \
                                          kbits, blkbits, ivbits, typ)          \
 const OSSL_DISPATCH ossl_##alg##kbits##lcmode##_functions[] = {                \
     { OSSL_FUNC_CIPHER_NEWCTX,                                                 \
@@ -180,7 +184,7 @@ const OSSL_DISPATCH ossl_##alg##kbits##lcmode##_functions[] = {                \
 };
 
 
-#define IMPLEMENT_generic_cipher_genfn(alg, UCALG, lcmode, UCMODE, flags,      \
+# define IMPLEMENT_generic_cipher_genfn(alg, UCALG, lcmode, UCMODE, flags,      \
                                        kbits, blkbits, ivbits, typ)            \
 static OSSL_FUNC_cipher_get_params_fn alg##_##kbits##_##lcmode##_get_params;   \
 static int alg##_##kbits##_##lcmode##_get_params(OSSL_PARAM params[])          \
@@ -202,14 +206,14 @@ static void * alg##_##kbits##_##lcmode##_newctx(void *provctx)                 \
      return ctx;                                                               \
 }                                                                              \
 
-#define IMPLEMENT_generic_cipher(alg, UCALG, lcmode, UCMODE, flags, kbits,     \
+# define IMPLEMENT_generic_cipher(alg, UCALG, lcmode, UCMODE, flags, kbits,     \
                                  blkbits, ivbits, typ)                         \
 IMPLEMENT_generic_cipher_genfn(alg, UCALG, lcmode, UCMODE, flags, kbits,       \
                                blkbits, ivbits, typ)                           \
 IMPLEMENT_generic_cipher_func(alg, UCALG, lcmode, UCMODE, flags, kbits,        \
                               blkbits, ivbits, typ)
 
-#define IMPLEMENT_var_keylen_cipher(alg, UCALG, lcmode, UCMODE, flags, kbits,  \
+# define IMPLEMENT_var_keylen_cipher(alg, UCALG, lcmode, UCMODE, flags, kbits,  \
                                     blkbits, ivbits, typ)                      \
 IMPLEMENT_generic_cipher_genfn(alg, UCALG, lcmode, UCMODE, flags, kbits,       \
                                blkbits, ivbits, typ)                           \
@@ -227,11 +231,11 @@ PROV_CIPHER_HW_FN ossl_cipher_hw_chunked_cbc;
 PROV_CIPHER_HW_FN ossl_cipher_hw_chunked_cfb8;
 PROV_CIPHER_HW_FN ossl_cipher_hw_chunked_cfb128;
 PROV_CIPHER_HW_FN ossl_cipher_hw_chunked_ofb128;
-#define ossl_cipher_hw_chunked_ecb  ossl_cipher_hw_generic_ecb
-#define ossl_cipher_hw_chunked_ctr  ossl_cipher_hw_generic_ctr
-#define ossl_cipher_hw_chunked_cfb1 ossl_cipher_hw_generic_cfb1
+# define ossl_cipher_hw_chunked_ecb  ossl_cipher_hw_generic_ecb
+# define ossl_cipher_hw_chunked_ctr  ossl_cipher_hw_generic_ctr
+# define ossl_cipher_hw_chunked_cfb1 ossl_cipher_hw_generic_cfb1
 
-#define IMPLEMENT_CIPHER_HW_OFB(MODE, NAME, CTX_NAME, KEY_NAME, FUNC_PREFIX)   \
+# define IMPLEMENT_CIPHER_HW_OFB(MODE, NAME, CTX_NAME, KEY_NAME, FUNC_PREFIX)   \
 static int cipher_hw_##NAME##_##MODE##_cipher(PROV_CIPHER_CTX *ctx,            \
                                          unsigned char *out,                   \
                                          const unsigned char *in, size_t len)  \
@@ -252,7 +256,7 @@ static int cipher_hw_##NAME##_##MODE##_cipher(PROV_CIPHER_CTX *ctx,            \
     return 1;                                                                  \
 }
 
-#define IMPLEMENT_CIPHER_HW_ECB(MODE, NAME, CTX_NAME, KEY_NAME, FUNC_PREFIX)   \
+# define IMPLEMENT_CIPHER_HW_ECB(MODE, NAME, CTX_NAME, KEY_NAME, FUNC_PREFIX)   \
 static int cipher_hw_##NAME##_##MODE##_cipher(PROV_CIPHER_CTX *ctx,            \
                                          unsigned char *out,                   \
                                          const unsigned char *in, size_t len)  \
@@ -267,7 +271,7 @@ static int cipher_hw_##NAME##_##MODE##_cipher(PROV_CIPHER_CTX *ctx,            \
     return 1;                                                                  \
 }
 
-#define IMPLEMENT_CIPHER_HW_CBC(MODE, NAME, CTX_NAME, KEY_NAME, FUNC_PREFIX)   \
+# define IMPLEMENT_CIPHER_HW_CBC(MODE, NAME, CTX_NAME, KEY_NAME, FUNC_PREFIX)   \
 static int cipher_hw_##NAME##_##MODE##_cipher(PROV_CIPHER_CTX *ctx,            \
                                          unsigned char *out,                   \
                                          const unsigned char *in, size_t len)  \
@@ -285,7 +289,7 @@ static int cipher_hw_##NAME##_##MODE##_cipher(PROV_CIPHER_CTX *ctx,            \
     return 1;                                                                  \
 }
 
-#define IMPLEMENT_CIPHER_HW_CFB(MODE, NAME, CTX_NAME, KEY_NAME, FUNC_PREFIX)   \
+# define IMPLEMENT_CIPHER_HW_CFB(MODE, NAME, CTX_NAME, KEY_NAME, FUNC_PREFIX)   \
 static int cipher_hw_##NAME##_##MODE##_cipher(PROV_CIPHER_CTX *ctx,            \
                                          unsigned char *out,                   \
                                          const unsigned char *in, size_t len)  \
@@ -309,7 +313,7 @@ static int cipher_hw_##NAME##_##MODE##_cipher(PROV_CIPHER_CTX *ctx,            \
     return 1;                                                                  \
 }
 
-#define IMPLEMENT_CIPHER_HW_COPYCTX(name, CTX_TYPE)                            \
+# define IMPLEMENT_CIPHER_HW_COPYCTX(name, CTX_TYPE)                            \
 static void name(PROV_CIPHER_CTX *dst, const PROV_CIPHER_CTX *src)             \
 {                                                                              \
     CTX_TYPE *sctx = (CTX_TYPE *)src;                                          \
@@ -319,7 +323,7 @@ static void name(PROV_CIPHER_CTX *dst, const PROV_CIPHER_CTX *src)             \
     dst->ks = &dctx->ks.ks;                                                    \
 }
 
-#define CIPHER_DEFAULT_GETTABLE_CTX_PARAMS_START(name)                         \
+# define CIPHER_DEFAULT_GETTABLE_CTX_PARAMS_START(name)                         \
 static const OSSL_PARAM name##_known_gettable_ctx_params[] = {                 \
     OSSL_PARAM_size_t(OSSL_CIPHER_PARAM_KEYLEN, NULL),                         \
     OSSL_PARAM_size_t(OSSL_CIPHER_PARAM_IVLEN, NULL),                          \
@@ -328,7 +332,7 @@ static const OSSL_PARAM name##_known_gettable_ctx_params[] = {                 \
     OSSL_PARAM_octet_string(OSSL_CIPHER_PARAM_IV, NULL, 0),                    \
     OSSL_PARAM_octet_string(OSSL_CIPHER_PARAM_UPDATED_IV, NULL, 0),
 
-#define CIPHER_DEFAULT_GETTABLE_CTX_PARAMS_END(name)                           \
+# define CIPHER_DEFAULT_GETTABLE_CTX_PARAMS_END(name)                           \
     OSSL_PARAM_END                                                             \
 };                                                                             \
 const OSSL_PARAM * name##_gettable_ctx_params(ossl_unused void *cctx,          \
@@ -337,11 +341,11 @@ const OSSL_PARAM * name##_gettable_ctx_params(ossl_unused void *cctx,          \
     return name##_known_gettable_ctx_params;                                   \
 }
 
-#define CIPHER_DEFAULT_SETTABLE_CTX_PARAMS_START(name)                         \
+# define CIPHER_DEFAULT_SETTABLE_CTX_PARAMS_START(name)                         \
 static const OSSL_PARAM name##_known_settable_ctx_params[] = {                 \
     OSSL_PARAM_uint(OSSL_CIPHER_PARAM_PADDING, NULL),                          \
     OSSL_PARAM_uint(OSSL_CIPHER_PARAM_NUM, NULL),
-#define CIPHER_DEFAULT_SETTABLE_CTX_PARAMS_END(name)                           \
+# define CIPHER_DEFAULT_SETTABLE_CTX_PARAMS_END(name)                           \
     OSSL_PARAM_END                                                             \
 };                                                                             \
 const OSSL_PARAM * name##_settable_ctx_params(ossl_unused void *cctx,          \
@@ -359,3 +363,5 @@ size_t ossl_cipher_fillblock(unsigned char *buf, size_t *buflen,
 int ossl_cipher_trailingdata(unsigned char *buf, size_t *buflen,
                              size_t blocksize,
                              const unsigned char **in, size_t *inlen);
+
+#endif

--- a/providers/implementations/include/prov/ciphercommon_aead.h
+++ b/providers/implementations/include/prov/ciphercommon_aead.h
@@ -7,11 +7,15 @@
  * https://www.openssl.org/source/license.html
  */
 
-#define UNINITIALISED_SIZET ((size_t)-1)
+#ifndef OSSL_PROV_CIPHERCOMMON_AEAD_H
+# define OSSL_PROV_CIPHERCOMMON_AEAD_H
+# pragma once
 
-#define AEAD_FLAGS (PROV_CIPHER_FLAG_AEAD | PROV_CIPHER_FLAG_CUSTOM_IV)
+# define UNINITIALISED_SIZET ((size_t)-1)
 
-#define IMPLEMENT_aead_cipher(alg, lc, UCMODE, flags, kbits, blkbits, ivbits)  \
+# define AEAD_FLAGS (PROV_CIPHER_FLAG_AEAD | PROV_CIPHER_FLAG_CUSTOM_IV)
+
+# define IMPLEMENT_aead_cipher(alg, lc, UCMODE, flags, kbits, blkbits, ivbits)  \
 static OSSL_FUNC_cipher_get_params_fn alg##_##kbits##_##lc##_get_params;       \
 static int alg##_##kbits##_##lc##_get_params(OSSL_PARAM params[])              \
 {                                                                              \
@@ -45,3 +49,5 @@ const OSSL_DISPATCH ossl_##alg##kbits##lc##_functions[] = {                    \
       (void (*)(void))ossl_cipher_aead_settable_ctx_params },                  \
     { 0, NULL }                                                                \
 }
+
+#endif

--- a/providers/implementations/include/prov/ciphercommon_ccm.h
+++ b/providers/implementations/include/prov/ciphercommon_ccm.h
@@ -7,11 +7,15 @@
  * https://www.openssl.org/source/license.html
  */
 
-#include "ciphercommon_aead.h"
+#ifndef OSSL_PROV_CIPHERCOMMON_CCM_H
+# define OSSL_PROV_CIPHERCOMMON_CCM_H
+# pragma once
+
+# include "ciphercommon_aead.h"
 
 typedef struct prov_ccm_hw_st PROV_CCM_HW;
 
-#if defined(OPENSSL_CPUID_OBJ) && defined(__s390__)
+# if defined(OPENSSL_CPUID_OBJ) && defined(__s390__)
 /*-
  * KMAC-AES parameter block - begin
  * (see z/Architecture Principles of Operation >= SA22-7832-08)
@@ -24,7 +28,7 @@ typedef struct S390X_kmac_params_st {
     unsigned char k[32];
 } S390X_KMAC_PARAMS;
 /* KMAC-AES parameter block - end */
-#endif
+# endif
 
 /* Base structure that is shared by AES & ARIA for CCM MODE */
 typedef struct prov_ccm_st {
@@ -98,3 +102,5 @@ int ossl_ccm_generic_auth_encrypt(PROV_CCM_CTX *ctx, const unsigned char *in,
 int ossl_ccm_generic_auth_decrypt(PROV_CCM_CTX *ctx, const unsigned char *in,
                                   unsigned char *out, size_t len,
                                   unsigned char *expected_tag, size_t taglen);
+
+#endif

--- a/providers/implementations/include/prov/ciphercommon_gcm.h
+++ b/providers/implementations/include/prov/ciphercommon_gcm.h
@@ -8,16 +8,20 @@
  * https://www.openssl.org/source/license.html
  */
 
-#include <openssl/aes.h>
-#include "ciphercommon_aead.h"
+#ifndef OSSL_PROV_CIPHERCOMMON_GCM_H
+# define OSSL_PROV_CIPHERCOMMON_GCM_H
+# pragma once
+
+# include <openssl/aes.h>
+# include "ciphercommon_aead.h"
 
 typedef struct prov_gcm_hw_st PROV_GCM_HW;
 
-#define GCM_IV_DEFAULT_SIZE 12 /* IV's for AES_GCM should normally be 12 bytes */
-#define GCM_IV_MAX_SIZE     (1024 / 8)
-#define GCM_TAG_MAX_SIZE    16
+# define GCM_IV_DEFAULT_SIZE 12 /* IV's for AES_GCM should normally be 12 bytes */
+# define GCM_IV_MAX_SIZE     (1024 / 8)
+# define GCM_TAG_MAX_SIZE    16
 
-#if defined(OPENSSL_CPUID_OBJ) && defined(__s390__)
+# if defined(OPENSSL_CPUID_OBJ) && defined(__s390__)
 /*-
  * KMA-GCM-AES parameter block - begin
  * (see z/Architecture Principles of Operation >= SA22-7832-11)
@@ -42,7 +46,7 @@ typedef struct S390X_kma_params_st {
     unsigned char k[32];    /* key */
 } S390X_KMA_PARAMS;
 
-#endif
+# endif
 
 typedef struct prov_gcm_ctx_st {
     unsigned int mode;          /* The mode that we are using */
@@ -121,9 +125,11 @@ int ossl_gcm_one_shot(PROV_GCM_CTX *ctx, unsigned char *aad, size_t aad_len,
 int ossl_gcm_cipher_update(PROV_GCM_CTX *ctx, const unsigned char *in,
                            size_t len, unsigned char *out);
 
-#define GCM_HW_SET_KEY_CTR_FN(ks, fn_set_enc_key, fn_block, fn_ctr)            \
+# define GCM_HW_SET_KEY_CTR_FN(ks, fn_set_enc_key, fn_block, fn_ctr)            \
     ctx->ks = ks;                                                              \
     fn_set_enc_key(key, keylen * 8, ks);                                       \
     CRYPTO_gcm128_init(&ctx->gcm, ks, (block128_f)fn_block);                   \
     ctx->ctr = (ctr128_f)fn_ctr;                                               \
     ctx->key_set = 1;
+
+#endif


### PR DESCRIPTION
This header files are included by multiple other headers.
It's better to add define guards to prevent multi-inclusion.

CLA: trivial

Signed-off-by: Weiguo Li <liwg06@foxmail.com>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
