### PR TITLE
Change condition to avoid spurious compiler complaints.

### DIFF
--- a/crypto/x509/x509_trust.c
+++ b/crypto/x509/x509_trust.c
@@ -134,7 +134,7 @@ int X509_TRUST_add(int id, int flags, int (*ck) (X509_TRUST *, X509 *, int),
     /* Get existing entry if any */
     idx = X509_TRUST_get_by_id(id);
     /* Need a new entry */
-    if (idx == -1) {
+    if (idx < 0) {
         if ((trtmp = OPENSSL_malloc(sizeof(*trtmp))) == NULL) {
             ERR_raise(ERR_LIB_X509, ERR_R_MALLOC_FAILURE);
             return 0;


### PR DESCRIPTION
X509_TRUST_get0() is checking < 0, the code here was checking == -1.  Both are
equivalent in this situation but gcc-12 has conniptions about a subsequent
possible NULL dereference (which isn't possible).

Fixes #17665
