### PR TITLE
Changed some typedefs to use the fixed-width integer types from opens…

### DIFF
--- a/crypto/aes/aes_local.h
+++ b/crypto/aes/aes_local.h
@@ -25,13 +25,9 @@
 # endif
 
 typedef uint64_t u64;
-# ifdef AES_LONG
-typedef unsigned long u32;
-# else
-typedef unsigned int u32;
-# endif
-typedef unsigned short u16;
-typedef unsigned char u8;
+typedef uint32_t u32;
+typedef uint16_t u16;
+typedef uint8_t u8;
 
 # define MAXKC   (256/32)
 # define MAXKB   (256/8)

--- a/crypto/aes/aes_x86core.c
+++ b/crypto/aes/aes_x86core.c
@@ -81,13 +81,10 @@ static void prefetch256(const void *table)
 #define GETU32(p) (*((u32*)(p)))
 
 #if (defined(_WIN32) || defined(_WIN64)) && !defined(__MINGW32__)
-typedef unsigned __int64 u64;
 #define U64(C)  C##UI64
 #elif defined(__arch64__)
-typedef unsigned long u64;
 #define U64(C)  C##UL
 #else
-typedef unsigned long long u64;
 #define U64(C)  C##ULL
 #endif
 

--- a/crypto/camellia/cmll_local.h
+++ b/crypto/camellia/cmll_local.h
@@ -25,8 +25,10 @@
 #ifndef OSSL_CRYPTO_CAMELLIA_CMLL_LOCAL_H
 # define OSSL_CRYPTO_CAMELLIA_CMLL_LOCAL_H
 
-typedef unsigned int u32;
-typedef unsigned char u8;
+#include <openssl/e_os2.h>
+
+typedef uint32_t u32;
+typedef uint8_t u8;
 
 int Camellia_Ekeygen(int keyBitLength, const u8 *rawKey,
                      KEY_TABLE_TYPE keyTable);

--- a/crypto/chacha/chacha_enc.c
+++ b/crypto/chacha/chacha_enc.c
@@ -11,12 +11,13 @@
 
 #include <string.h>
 
+#include <openssl/e_os2.h>
 #include "internal/endian.h"
 #include "crypto/chacha.h"
 #include "crypto/ctype.h"
 
-typedef unsigned int u32;
-typedef unsigned char u8;
+typedef uint32_t u32;
+typedef uint8_t u8;
 typedef union {
     u32 u[16];
     u8 c[64];

--- a/crypto/poly1305/poly1305.c
+++ b/crypto/poly1305/poly1305.c
@@ -246,13 +246,7 @@ static void poly1305_emit(void *ctx, unsigned char mac[16],
 
 # else
 
-#  if defined(_WIN32) && !defined(__MINGW32__)
-typedef unsigned __int64 u64;
-#  elif defined(__arch64__)
-typedef unsigned long u64;
-#  else
-typedef unsigned long long u64;
-#  endif
+typedef uint64_t u64;
 
 typedef struct {
     u32 h[5];

--- a/crypto/poly1305/poly1305_ieee754.c
+++ b/crypto/poly1305/poly1305_ieee754.c
@@ -51,10 +51,11 @@
 #endif
 
 #include <stdlib.h>
+#include <openssl/e_os2.h>
 
-typedef unsigned char u8;
-typedef unsigned int u32;
-typedef unsigned long long u64;
+typedef uint8_t u8;
+typedef uint32_t u32;
+typedef uint64_t u64;
 typedef union { double d; u64 u; } elem64;
 
 #define TWO(p)          ((double)(1ULL<<(p)))

--- a/crypto/seed/seed_local.h
+++ b/crypto/seed/seed_local.h
@@ -38,11 +38,7 @@
 # include <openssl/e_os2.h>
 # include <openssl/seed.h>
 
-# ifdef SEED_LONG               /* need 32-bit type */
-typedef unsigned long seed_word;
-# else
-typedef unsigned int seed_word;
-# endif
+typedef uint32_t seed_word;
 
 
 # define char2word(c, i)  \

--- a/crypto/whrlpool/wp_block.c
+++ b/crypto/whrlpool/wp_block.c
@@ -42,18 +42,13 @@
  */
 #include "internal/deprecated.h"
 
+#include <openssl/e_os2.h>
 #include "internal/cryptlib.h"
 #include "wp_local.h"
 #include <string.h>
 
-typedef unsigned char u8;
-#if (defined(_WIN32) || defined(_WIN64)) && !defined(__MINGW32)
-typedef unsigned __int64 u64;
-#elif defined(__arch64__)
-typedef unsigned long u64;
-#else
-typedef unsigned long long u64;
-#endif
+typedef uint8_t u8;
+typedef uint64_t u64;
 
 #define ROUNDS  10
 

--- a/include/crypto/modes.h
+++ b/include/crypto/modes.h
@@ -9,23 +9,20 @@
 
 /* This header can move into provider when legacy support is removed */
 #include <openssl/modes.h>
+#include <openssl/e_os2.h>
 
 #if (defined(_WIN32) || defined(_WIN64)) && !defined(__MINGW32__)
-typedef __int64 i64;
-typedef unsigned __int64 u64;
 # define U64(C) C##UI64
 #elif defined(__arch64__)
-typedef long i64;
-typedef unsigned long u64;
 # define U64(C) C##UL
 #else
-typedef long long i64;
-typedef unsigned long long u64;
 # define U64(C) C##ULL
 #endif
 
-typedef unsigned int u32;
-typedef unsigned char u8;
+typedef int64_t i64;
+typedef uint64_t u64;
+typedef uint32_t u32;
+typedef uint8_t u8;
 
 #define STRICT_ALIGNMENT 1
 #ifndef PEDANTIC

--- a/include/openssl/aes.h
+++ b/include/openssl/aes.h
@@ -11,6 +11,7 @@
 # define OPENSSL_AES_H
 # pragma once
 
+# include <openssl/e_os2.h>
 # include <openssl/macros.h>
 # ifndef OPENSSL_NO_DEPRECATED_3_0
 #  define HEADER_AES_H
@@ -35,11 +36,7 @@ extern "C" {
 
 /* This should be a hidden type, but EVP requires that the size be known */
 struct aes_key_st {
-#  ifdef AES_LONG
-    unsigned long rd_key[4 * (AES_MAXNR + 1)];
-#  else
-    unsigned int rd_key[4 * (AES_MAXNR + 1)];
-#  endif
+    uint32_t rd_key[4 * (AES_MAXNR + 1)];
     int rounds;
 };
 typedef struct aes_key_st AES_KEY;

--- a/include/openssl/bn.h
+++ b/include/openssl/bn.h
@@ -31,23 +31,16 @@ extern "C" {
 #endif
 
 /*
- * 64-bit processor with LP64 ABI
+ * 64-bit processors regardless of ABI will use the 64-bit integer type as defined in openssl/e_os2.h. 
+ * Therefore the configuration switch SIXTY_FOUR_BIT_LONG is superfluous but kept here for compatability. 
  */
-# ifdef SIXTY_FOUR_BIT_LONG
-#  define BN_ULONG        unsigned long
-#  define BN_BYTES        8
-# endif
-
-/*
- * 64-bit processor other than LP64 ABI
- */
-# ifdef SIXTY_FOUR_BIT
-#  define BN_ULONG        unsigned long long
+# if defined(SIXTY_FOUR_BIT) || defined(SIXTY_FOUR_BIT_LONG) 
+#  define BN_ULONG        uint64_t
 #  define BN_BYTES        8
 # endif
 
 # ifdef THIRTY_TWO_BIT
-#  define BN_ULONG        unsigned int
+#  define BN_ULONG        uint32_t
 #  define BN_BYTES        4
 # endif
 

--- a/include/openssl/bn.h
+++ b/include/openssl/bn.h
@@ -30,26 +30,8 @@
 extern "C" {
 #endif
 
-/*
- * 64-bit processor with LP64 ABI
- */
-# ifdef SIXTY_FOUR_BIT_LONG
-#  define BN_ULONG        unsigned long
-#  define BN_BYTES        8
-# endif
-
-/*
- * 64-bit processor other than LP64 ABI
- */
-# ifdef SIXTY_FOUR_BIT
-#  define BN_ULONG        unsigned long long
-#  define BN_BYTES        8
-# endif
-
-# ifdef THIRTY_TWO_BIT
-#  define BN_ULONG        unsigned int
-#  define BN_BYTES        4
-# endif
+#define BN_ULONG        uint64_t
+#define BN_BYTES        8
 
 # define BN_BITS2       (BN_BYTES * 8)
 # define BN_BITS        (BN_BITS2 * 2)

--- a/include/openssl/bn.h
+++ b/include/openssl/bn.h
@@ -30,8 +30,26 @@
 extern "C" {
 #endif
 
-#define BN_ULONG        uint64_t
-#define BN_BYTES        8
+/*
+ * 64-bit processor with LP64 ABI
+ */
+# ifdef SIXTY_FOUR_BIT_LONG
+#  define BN_ULONG        unsigned long
+#  define BN_BYTES        8
+# endif
+
+/*
+ * 64-bit processor other than LP64 ABI
+ */
+# ifdef SIXTY_FOUR_BIT
+#  define BN_ULONG        unsigned long long
+#  define BN_BYTES        8
+# endif
+
+# ifdef THIRTY_TWO_BIT
+#  define BN_ULONG        unsigned int
+#  define BN_BYTES        4
+# endif
 
 # define BN_BITS2       (BN_BYTES * 8)
 # define BN_BITS        (BN_BITS2 * 2)

--- a/include/openssl/seed.h
+++ b/include/openssl/seed.h
@@ -56,20 +56,9 @@ extern "C" {
 #  define SEED_KEY_LENGTH 16
 
 #  ifndef OPENSSL_NO_DEPRECATED_3_0
-/* look whether we need 'long' to get 32 bits */
-#   ifdef AES_LONG
-#    ifndef SEED_LONG
-#     define SEED_LONG 1
-#    endif
-#   endif
-
 
 typedef struct seed_key_st {
-#   ifdef SEED_LONG
-    unsigned long data[32];
-#   else
-    unsigned int data[32];
-#   endif
+    uint32_t data[32];
 } SEED_KEY_SCHEDULE;
 #  endif /* OPENSSL_NO_DEPRECATED_3_0 */
 #  ifndef OPENSSL_NO_DEPRECATED_3_0

--- a/include/openssl/sha.h
+++ b/include/openssl/sha.h
@@ -98,13 +98,7 @@ unsigned char *SHA256(const unsigned char *d, size_t n, unsigned char *md);
  * wide big-endian values.
  */
 #  define SHA512_CBLOCK   (SHA_LBLOCK*8)
-#  if (defined(_WIN32) || defined(_WIN64)) && !defined(__MINGW32__)
-#   define SHA_LONG64 unsigned __int64
-#  elif defined(__arch64__)
-#   define SHA_LONG64 unsigned long
-#  else
-#   define SHA_LONG64 unsigned long long
-#  endif
+#  define SHA_LONG64 uint64_t
 
 typedef struct SHA512state_st {
     SHA_LONG64 h[8];


### PR DESCRIPTION
…sl/e_os2.h, which uses stdint.h when possible.

Considering the project already uses fixed-width integer types extensively, this PR switches several files to using fixed-width integer types, as defined in e_os2.h.