### PR TITLE
Test the FIPS provider from openssl-3.0 branch with the master and vice versa

### DIFF
--- a/.github/workflows/fips-provider.yml
+++ b/.github/workflows/fips-provider.yml
@@ -1,0 +1,52 @@
+# Copyright 2022 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+name: Provider compat
+on: [push, pull_request]
+
+jobs:
+  fips-provider-30:
+    runs-on: ubuntu-latest
+    steps:
+      - name: create build dirs
+        run: |
+          mkdir ./build
+          mkdir ./build-3.0
+          mkdir ./source
+          mkdir ./source-3.0
+      - uses: actions/checkout@v2
+        with:
+          path: source
+      - name: config current
+        run: ../source/config enable-shared enable-fips
+        working-directory: ./build
+      - name: config dump
+        run: ./configdata.pm --dump
+        working-directory: ./build
+      - name: make
+        run: make -s -j4
+        working-directory: ./build
+      - uses: actions/checkout@v2
+        with:
+          repository: openssl/openssl
+          ref: openssl-3.0
+          path: source-3.0
+      - name: config 3.0
+        run: ../source-3.0/config enable-shared enable-fips
+        working-directory: ./build-3.0
+      - name: config 3.0 dump
+        run: ./configdata.pm --dump
+        working-directory: ./build-3.0
+      - name: make fips provider
+        run: make -s -j4 build_modules
+        working-directory: ./build-3.0
+      - name: copy the provider
+        run: |
+          cp -a build-3.0/providers/fips.so build/providers/fips.so
+      - name: make test
+        run: make test HARNESS_JOBS=${HARNESS_JOBS:-4}
+        working-directory: ./build

--- a/.github/workflows/fips-provider.yml
+++ b/.github/workflows/fips-provider.yml
@@ -50,3 +50,45 @@ jobs:
       - name: make test
         run: make test HARNESS_JOBS=${HARNESS_JOBS:-4}
         working-directory: ./build
+
+  fips-provider-master:
+    runs-on: ubuntu-latest
+    steps:
+      - name: create build dirs
+        run: |
+          mkdir ./build
+          mkdir ./build-3.0
+          mkdir ./source
+          mkdir ./source-3.0
+      - uses: actions/checkout@v2
+        with:
+          repository: openssl/openssl
+          ref: openssl-3.0
+          path: source-3.0
+      - name: config 3.0
+        run: ../source-3.0/config enable-shared enable-fips
+        working-directory: ./build-3.0
+      - name: config 3.0 dump
+        run: ./configdata.pm --dump
+        working-directory: ./build-3.0
+      - name: make fips provider
+        run: make -s -j4
+        working-directory: ./build-3.0
+      - uses: actions/checkout@v2
+        with:
+          path: source
+      - name: config current
+        run: ../source/config enable-shared enable-fips
+        working-directory: ./build
+      - name: config dump
+        run: ./configdata.pm --dump
+        working-directory: ./build
+      - name: make
+        run: make -s -j4 build_modules
+        working-directory: ./build
+      - name: copy the provider
+        run: |
+          cp -a build/providers/fips.so build-3.0/providers/fips.so
+      - name: make test 3.0
+        run: make test HARNESS_JOBS=${HARNESS_JOBS:-4}
+        working-directory: ./build-3.0

--- a/.github/workflows/fips-provider.yml
+++ b/.github/workflows/fips-provider.yml
@@ -6,7 +6,7 @@
 # https://www.openssl.org/source/license.html
 
 name: Provider compat
-on: [push, pull_request]
+on: [push]
 
 jobs:
   fips-provider-30:
@@ -71,7 +71,7 @@ jobs:
       - name: config 3.0 dump
         run: ./configdata.pm --dump
         working-directory: ./build-3.0
-      - name: make fips provider
+      - name: make 3.0
         run: make -s -j4
         working-directory: ./build-3.0
       - uses: actions/checkout@v2
@@ -83,7 +83,7 @@ jobs:
       - name: config dump
         run: ./configdata.pm --dump
         working-directory: ./build
-      - name: make
+      - name: make fips provider
         run: make -s -j4 build_modules
         working-directory: ./build
       - name: copy the provider

--- a/test/evp_test.c
+++ b/test/evp_test.c
@@ -2651,6 +2651,13 @@ static int kdf_test_ctrl(EVP_TEST *t, EVP_KDF_CTX *kctx,
     if (p != NULL)
         *p++ = '\0';
 
+    if (strcmp(name, "r") == 0
+        && OSSL_PARAM_locate_const(defs, name) == NULL) {
+        TEST_info("skipping, setting 'r' is unsupported");
+        t->skip = 1;
+        goto end;
+    }
+
     rv = OSSL_PARAM_allocate_from_text(kdata->p, defs, name, p,
                                        p != NULL ? strlen(p) : 0, NULL);
     *++kdata->p = OSSL_PARAM_construct_end();
@@ -2664,6 +2671,7 @@ static int kdf_test_ctrl(EVP_TEST *t, EVP_KDF_CTX *kctx,
             TEST_info("skipping, '%s' is disabled", p);
             t->skip = 1;
         }
+        goto end;
     }
     if (p != NULL
         && (strcmp(name, "cipher") == 0
@@ -2671,6 +2679,7 @@ static int kdf_test_ctrl(EVP_TEST *t, EVP_KDF_CTX *kctx,
         && is_cipher_disabled(p)) {
         TEST_info("skipping, '%s' is disabled", p);
         t->skip = 1;
+        goto end;
     }
     if (p != NULL
         && (strcmp(name, "mac") == 0)
@@ -2678,6 +2687,7 @@ static int kdf_test_ctrl(EVP_TEST *t, EVP_KDF_CTX *kctx,
         TEST_info("skipping, '%s' is disabled", p);
         t->skip = 1;
     }
+ end:
     OPENSSL_free(name);
     return 1;
 }


### PR DESCRIPTION
There was one change necessary in the EVP test to skip testcases of a feature unimplemented in 3.0.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
