### PR TITLE
s_server: Add check for OPENSSL_strdup

### DIFF
--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -1007,7 +1007,7 @@ int s_server_main(int argc, char *argv[])
     int socket_family = AF_UNSPEC, socket_type = SOCK_STREAM, protocol = 0;
     int state = 0, crl_format = FORMAT_UNDEF, crl_download = 0;
     char *host = NULL;
-    char *port = OPENSSL_strdup(PORT);
+    char *port = NULL;
     unsigned char *context = NULL;
     OPTION_CHOICE o;
     EVP_PKEY *s_key2 = NULL;
@@ -1073,9 +1073,10 @@ int s_server_main(int argc, char *argv[])
     async = 0;
     use_sendfile = 0;
 
+    port = OPENSSL_strdup(PORT);
     cctx = SSL_CONF_CTX_new();
     vpm = X509_VERIFY_PARAM_new();
-    if (cctx == NULL || vpm == NULL)
+    if (port == NULL || cctx == NULL || vpm == NULL)
         goto end;
     SSL_CONF_CTX_set_flags(cctx,
                            SSL_CONF_FLAG_SERVER | SSL_CONF_FLAG_CMDLINE);


### PR DESCRIPTION
Since the OPENSSL_strdup() may return NULL if allocation
fails, the 'port' could be NULL.
And then it will be used in do_server(), which can accept
NULL as an valid parameter.
That means that the system could run with a wrong parameter.
Therefore it should be better to check it, like the other
memory allocation.

Signed-off-by: Jiasheng Jiang <jiasheng@iscas.ac.cn>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
