### PR TITLE
openssl rehash: add check for OPENSSL_strdup

### DIFF
--- a/apps/rehash.c
+++ b/apps/rehash.c
@@ -171,6 +171,7 @@ static int add_entry(enum Type type, unsigned int hash, const char *filename,
         if (ep->filename == NULL) {
             OPENSSL_free(ep);
             ep = NULL;
+            BIO_printf(bio_err, "out of memory\n");
             return 1;
         }
         if (bp->last_entry)

--- a/apps/rehash.c
+++ b/apps/rehash.c
@@ -168,6 +168,11 @@ static int add_entry(enum Type type, unsigned int hash, const char *filename,
         *ep = nilhentry;
         ep->old_id = ~0;
         ep->filename = OPENSSL_strdup(filename);
+        if (ep->filename == NULL) {
+            OPENSSL_free(ep);
+            ep = NULL;
+            return 1;
+        }
         if (bp->last_entry)
             bp->last_entry->next = ep;
         if (bp->first_entry == NULL)


### PR DESCRIPTION
As the potential failure of the memory allocation,
it should be better to check the return value of
OPENSSL_strdup() and return error if fails.
Also, we need to restore the 'ep' to be NULL if fails.
And since the OPENSSL_strdup() will print report if
fails, the BIO_print() is not needed.

Signed-off-by: Jiasheng Jiang <jiasheng@iscas.ac.cn>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
