### PR TITLE
apps/ocsp: Add check for OPENSSL_strdup

### DIFF
--- a/apps/ocsp.c
+++ b/apps/ocsp.c
@@ -1180,8 +1180,10 @@ static char **lookup_serial(CA_DB *db, ASN1_INTEGER *ser)
     bn = ASN1_INTEGER_to_BN(ser, NULL);
     OPENSSL_assert(bn);         /* FIXME: should report an error at this
                                  * point and abort */
-    if (BN_is_zero(bn))
+    if (BN_is_zero(bn)) {
         itmp = OPENSSL_strdup("00");
+        OPENSSL_assert(itmp);
+    }
     else
         itmp = BN_bn2hex(bn);
     row[DB_serial] = itmp;

--- a/apps/ocsp.c
+++ b/apps/ocsp.c
@@ -1183,9 +1183,9 @@ static char **lookup_serial(CA_DB *db, ASN1_INTEGER *ser)
     if (BN_is_zero(bn)) {
         itmp = OPENSSL_strdup("00");
         OPENSSL_assert(itmp);
-    }
-    else
+    } else {
         itmp = BN_bn2hex(bn);
+    }
     row[DB_serial] = itmp;
     BN_free(bn);
     rrow = TXT_DB_get_by_index(db->db, DB_serial, row);


### PR DESCRIPTION
Just assert 'bn' to be non-NULL is not enough.
The check for 'itmp' is still needed.
If 'bn' is 0, the 'itmp' is assigned by OPENSSL_strdup().
Since OPENSSL_strdup() may fail because of the lack of memory,
the 'itmp' will be NULL and be an valid parameter hashed in
TXT_DB_get_by_index(), returning a wrong result.

Signed-off-by: Jiasheng Jiang <jiasheng@iscas.ac.cn>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
