### PR TITLE
Apply the correct Apache v2 license

### DIFF
--- a/crypto/ec/asm/ecp_nistp521-ppc64.pl
+++ b/crypto/ec/asm/ecp_nistp521-ppc64.pl
@@ -1,7 +1,7 @@
 #! /usr/bin/env perl
-# Copyright 2021 The OpenSSL Project Authors. All Rights Reserved.
+# Copyright 2021-2022 The OpenSSL Project Authors. All Rights Reserved.
 #
-# Licensed under the OpenSSL license (the "License").  You may not use
+# Licensed under the Apache License 2.0 (the "License").  You may not use
 # this file except in compliance with the License.  You can obtain a copy
 # in the file LICENSE in the source distribution or at
 # https://www.openssl.org/source/license.html

--- a/doc/man1/openssl-cmp.pod.in
+++ b/doc/man1/openssl-cmp.pod.in
@@ -1239,9 +1239,9 @@ The B<-engine option> was deprecated in OpenSSL 3.0.
 
 =head1 COPYRIGHT
 
-Copyright 2007-2021 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2007-2022 The OpenSSL Project Authors. All Rights Reserved.
 
-Licensed under the OpenSSL license (the "License").  You may not use
+Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy
 in the file LICENSE in the source distribution or at
 L<https://www.openssl.org/source/license.html>.

--- a/test/dane-cross.in
+++ b/test/dane-cross.in
@@ -1,6 +1,6 @@
-# Copyright 2016-2021 The OpenSSL Project Authors. All Rights Reserved.
+# Copyright 2016-2022 The OpenSSL Project Authors. All Rights Reserved.
 #
-# Licensed under the OpenSSL license (the "License").  You may not use
+# Licensed under the Apache License 2.0 (the "License").  You may not use
 # this file except in compliance with the License.  You can obtain a copy
 # in the file LICENSE in the source distribution or at
 # https://www.openssl.org/source/license.html

--- a/test/recipes/03-test_internal_sm3.t
+++ b/test/recipes/03-test_internal_sm3.t
@@ -1,8 +1,8 @@
 #! /usr/bin/env perl
-# Copyright 2021 The OpenSSL Project Authors. All Rights Reserved.
+# Copyright 2021-2022 The OpenSSL Project Authors. All Rights Reserved.
 # Copyright 2021 [UnionTech](https://www.uniontech.com). All Rights Reserved.
 #
-# Licensed under the OpenSSL license (the "License").  You may not use
+# Licensed under the Apache License 2.0 (the "License").  You may not use
 # this file except in compliance with the License.  You can obtain a copy
 # in the file LICENSE in the source distribution or at
 # https://www.openssl.org/source/license.html

--- a/test/sm3_internal_test.c
+++ b/test/sm3_internal_test.c
@@ -2,7 +2,7 @@
  * Copyright 2021-2022 The OpenSSL Project Authors. All Rights Reserved.
  * Copyright 2021 UnionTech. All Rights Reserved.
  *
- * Licensed under the Apche License 2.0 (the "License").  You may not use
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
  * in the file LICENSE in the source distribution or at
  * https://www.openssl.org/source/license.html


### PR DESCRIPTION
There were still a few files mentioning the old OpenSSL license.

Fixes #17684
