### PR TITLE
cleanup of 15-test_gendhparam.t and fix for #17480

### DIFF
--- a/test/recipes/15-test_gendhparam.t
+++ b/test/recipes/15-test_gendhparam.t
@@ -165,7 +165,7 @@ sub compareline {
     }
     print "-----------------\n";
     foreach (@lines) {
-        print $_;
+        print ": ".$_;
     }
     print "-----------------\n";
     foreach my $ex (@expected) {

--- a/test/recipes/15-test_gendhparam.t
+++ b/test/recipes/15-test_gendhparam.t
@@ -118,12 +118,12 @@ my @testdata = (
 #        expect => [ 'BEGIN DH PARAMETERS', 'G:    5' ],
 #        message   => 'DH safe prime generator using an alias',
 #    },
-     {
+    {
         algorithm => 'DHX',
         pkeyopts => [ 'type:generator', 'safeprime-generator:5'],
         expect => [ 'ERROR' ],
         message   => 'safe prime generator should fail for DHX',
-    },
+    }
 );
 
 plan skip_all => "DH isn't supported in this build" if disabled("dh");


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

In the definition of the testdata-array in ```15-test_gendhparam.t```, there is a trailing comma. Even though this should be allowed in perl, I think this might cause the sporadic error described in #17480.