### PR TITLE
fuzz/asn1.c: Add missing check for BIO_new

### DIFF
--- a/fuzz/asn1.c
+++ b/fuzz/asn1.c
@@ -220,11 +220,12 @@ static ASN1_PCTX *pctx;
         if (bio != NULL) { \
             PRINT(bio, type); \
             BIO_free(bio); \
-            len2 = I2D(type, &der); \
-            if (len2 != 0) {} \
-            OPENSSL_free(der); \
-            TYPE ## _free(type); \
         } \
+        \
+        len2 = I2D(type, &der); \
+        if (len2 != 0) {} \
+        OPENSSL_free(der); \
+        TYPE ## _free(type); \
     } \
 }
 
@@ -238,10 +239,11 @@ static ASN1_PCTX *pctx;
         if (bio != NULL) { \
             PRINT(bio, type, 0); \
             BIO_free(bio); \
-            I2D(type, &der); \
-            OPENSSL_free(der); \
-            TYPE ## _free(type); \
         } \
+        \
+        I2D(type, &der); \
+        OPENSSL_free(der); \
+        TYPE ## _free(type); \
     } \
 }
 
@@ -255,10 +257,11 @@ static ASN1_PCTX *pctx;
         if (bio != NULL) { \
             PRINT(bio, type, 0, pctx); \
             BIO_free(bio); \
-            I2D(type, &der); \
-            OPENSSL_free(der); \
-            TYPE ## _free(type); \
         } \
+        \
+        I2D(type, &der); \
+        OPENSSL_free(der); \
+        TYPE ## _free(type); \
     } \
 }
 
@@ -270,12 +273,10 @@ static ASN1_PCTX *pctx;
     \
     if (type != NULL) { \
         BIO *bio = BIO_new(BIO_s_null()); \
-        if (bio != NULL) { \
-            BIO_free(bio); \
-            I2D(type, &der); \
-            OPENSSL_free(der); \
-            TYPE ## _free(type); \
-        } \
+        BIO_free(bio); \
+        I2D(type, &der); \
+        OPENSSL_free(der); \
+        TYPE ## _free(type); \
     } \
 }
 
@@ -314,10 +315,10 @@ int FuzzerTestOneInput(const uint8_t *buf, size_t len)
             if (bio != NULL) {
                 ASN1_item_print(bio, o, 4, i, pctx);
                 BIO_free(bio);
-                ASN1_item_i2d(o, &der, i);
-                OPENSSL_free(der);
-                ASN1_item_free(o, i);
             }
+            ASN1_item_i2d(o, &der, i);
+            OPENSSL_free(der);
+            ASN1_item_free(o, i);
         }
     }
 

--- a/fuzz/asn1.c
+++ b/fuzz/asn1.c
@@ -217,11 +217,11 @@ static ASN1_PCTX *pctx;
     if (type != NULL) { \
         int len2; \
         BIO *bio = BIO_new(BIO_s_null()); \
+        \
         if (bio != NULL) { \
             PRINT(bio, type); \
             BIO_free(bio); \
         } \
-        \
         len2 = I2D(type, &der); \
         if (len2 != 0) {} \
         OPENSSL_free(der); \
@@ -236,11 +236,11 @@ static ASN1_PCTX *pctx;
     \
     if (type != NULL) { \
         BIO *bio = BIO_new(BIO_s_null()); \
+        \
         if (bio != NULL) { \
             PRINT(bio, type, 0); \
             BIO_free(bio); \
         } \
-        \
         I2D(type, &der); \
         OPENSSL_free(der); \
         TYPE ## _free(type); \
@@ -254,11 +254,11 @@ static ASN1_PCTX *pctx;
     \
     if (type != NULL) { \
         BIO *bio = BIO_new(BIO_s_null()); \
+        \
         if (bio != NULL) { \
             PRINT(bio, type, 0, pctx); \
             BIO_free(bio); \
         } \
-        \
         I2D(type, &der); \
         OPENSSL_free(der); \
         TYPE ## _free(type); \
@@ -273,6 +273,7 @@ static ASN1_PCTX *pctx;
     \
     if (type != NULL) { \
         BIO *bio = BIO_new(BIO_s_null()); \
+        \
         BIO_free(bio); \
         I2D(type, &der); \
         OPENSSL_free(der); \

--- a/fuzz/asn1.c
+++ b/fuzz/asn1.c
@@ -217,13 +217,14 @@ static ASN1_PCTX *pctx;
     if (type != NULL) { \
         int len2; \
         BIO *bio = BIO_new(BIO_s_null()); \
-        \
-        PRINT(bio, type); \
-        BIO_free(bio); \
-        len2 = I2D(type, &der); \
-        if (len2 != 0) {} \
-        OPENSSL_free(der); \
-        TYPE ## _free(type); \
+        if (bio != NULL) { \
+            PRINT(bio, type); \
+            BIO_free(bio); \
+            len2 = I2D(type, &der); \
+            if (len2 != 0) {} \
+            OPENSSL_free(der); \
+            TYPE ## _free(type); \
+        } \
     } \
 }
 
@@ -234,12 +235,13 @@ static ASN1_PCTX *pctx;
     \
     if (type != NULL) { \
         BIO *bio = BIO_new(BIO_s_null()); \
-        \
-        PRINT(bio, type, 0); \
-        BIO_free(bio); \
-        I2D(type, &der); \
-        OPENSSL_free(der); \
-        TYPE ## _free(type); \
+        if (bio != NULL) { \
+            PRINT(bio, type, 0); \
+            BIO_free(bio); \
+            I2D(type, &der); \
+            OPENSSL_free(der); \
+            TYPE ## _free(type); \
+        } \
     } \
 }
 
@@ -250,12 +252,13 @@ static ASN1_PCTX *pctx;
     \
     if (type != NULL) { \
         BIO *bio = BIO_new(BIO_s_null()); \
-        \
-        PRINT(bio, type, 0, pctx); \
-        BIO_free(bio); \
-        I2D(type, &der); \
-        OPENSSL_free(der); \
-        TYPE ## _free(type); \
+        if (bio != NULL) { \
+            PRINT(bio, type, 0, pctx); \
+            BIO_free(bio); \
+            I2D(type, &der); \
+            OPENSSL_free(der); \
+            TYPE ## _free(type); \
+        } \
     } \
 }
 
@@ -267,11 +270,12 @@ static ASN1_PCTX *pctx;
     \
     if (type != NULL) { \
         BIO *bio = BIO_new(BIO_s_null()); \
-        \
-        BIO_free(bio); \
-        I2D(type, &der); \
-        OPENSSL_free(der); \
-        TYPE ## _free(type); \
+        if (bio != NULL) { \
+            BIO_free(bio); \
+            I2D(type, &der); \
+            OPENSSL_free(der); \
+            TYPE ## _free(type); \
+        } \
     } \
 }
 
@@ -307,12 +311,13 @@ int FuzzerTestOneInput(const uint8_t *buf, size_t len)
 
         if (o != NULL) {
             BIO *bio = BIO_new(BIO_s_null());
-
-            ASN1_item_print(bio, o, 4, i, pctx);
-            BIO_free(bio);
-            ASN1_item_i2d(o, &der, i);
-            OPENSSL_free(der);
-            ASN1_item_free(o, i);
+            if (bio != NULL) {
+                ASN1_item_print(bio, o, 4, i, pctx);
+                BIO_free(bio);
+                ASN1_item_i2d(o, &der, i);
+                OPENSSL_free(der);
+                ASN1_item_free(o, i);
+            }
         }
     }
 


### PR DESCRIPTION
Since the BIO_new may fail, the 'bio' could be NULL pointer and be used.
Therefore, it should be better to check it and skip the print if fails.

Signed-off-by: Jiasheng Jiang <jiasheng@iscas.ac.cn>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
