### PR TITLE
Fix sporadic test failure in 15-test_gendhparam.t

### DIFF
--- a/test/recipes/15-test_gendhparam.t
+++ b/test/recipes/15-test_gendhparam.t
@@ -165,7 +165,9 @@ sub compareline {
     }
     print "-----------------\n";
     foreach (@lines) {
-        print $_;
+        my $line = $_;
+        $line =~ s/^ok/??/;
+        print $line;
     }
     print "-----------------\n";
     foreach my $ex (@expected) {


### PR DESCRIPTION
Since random dhparams are printed in PEM format to stdout,
it is possible to output lines starting with "ok/" or "ok+".
Both disturb the test harnesh and cause random test failures.
Work around that by replacing any ok at the beginning of the
line with ??.

Fixes #17480
