### PR TITLE
aarch64: Fix async_fibre_swapcontext() on clang BTI builds

### DIFF
--- a/crypto/async/arch/async_posix.h
+++ b/crypto/async/arch/async_posix.h
@@ -36,6 +36,18 @@
  */
 #   define USE_SWAPCONTEXT
 #  endif
+#  if defined(__aarch64__) && defined(__clang__) \
+    && defined(__ARM_FEATURE_BTI_DEFAULT) && __ARM_FEATURE_BTI_DEFAULT == 1
+/*
+ * setjmp/longjmp don't currently work with BTI on all libc implementations
+ * when compiled by clang. This is because clang doesn't put a BTI after the
+ * call to setjmp where it returns the second time. This then fails on libc
+ * implementations - notably glibc - which use an indirect jump to there.
+ * So use the swapcontext implementation, which does work.
+ * See https://github.com/llvm/llvm-project/issues/48888.
+ */
+#   define USE_SWAPCONTEXT
+#  endif
 #  include <ucontext.h>
 #  ifndef USE_SWAPCONTEXT
 #   include <setjmp.h>


### PR DESCRIPTION
Reverting to using swapcontext() when compiling with clang on BTI-enabled builds fixes the BTI setjmp() failure seen when running asynctest.

The issue with setjmp/longjmp is a known clang bug: see https://github.com/llvm/llvm-project/issues/48888

When there is a released fix for clang, this workaround can have a version guard added
