### PR TITLE
Fix time_t arithmetic after 2038

### DIFF
--- a/apps/s_time.c
+++ b/apps/s_time.c
@@ -270,10 +270,10 @@ int s_time_main(int argc, char **argv)
     /* Loop and time how long it takes to make connections */
 
     bytes_read = 0;
-    finishtime = (long)time(NULL) + maxtime;
+    finishtime = (long)((unsigned long)time(NULL) + maxtime);
     tm_Time_F(START);
     for (;;) {
-        if (finishtime < (long)time(NULL))
+        if ((long)((unsigned long)time(NULL) - finishtime) > 0)
             break;
 
         if ((scon = doConnection(NULL, host, ctx)) == NULL)
@@ -310,13 +310,12 @@ int s_time_main(int argc, char **argv)
     }
     totalTime += tm_Time_F(STOP); /* Add the time for this iteration */
 
-    i = (int)((long)time(NULL) - finishtime + maxtime);
     printf
         ("\n\n%d connections in %.2fs; %.2f connections/user sec, bytes read %ld\n",
          nConn, totalTime, ((double)nConn / totalTime), bytes_read);
     printf
         ("%d connections in %ld real seconds, %ld bytes read per connection\n",
-         nConn, (long)time(NULL) - finishtime + maxtime,
+         nConn, (long)((unsigned long)time(NULL) - finishtime + maxtime),
          nConn > 0 ? bytes_read / nConn : 0l);
 
     /*
@@ -348,14 +347,14 @@ int s_time_main(int argc, char **argv)
     nConn = 0;
     totalTime = 0.0;
 
-    finishtime = (long)time(NULL) + maxtime;
+    finishtime = (long)((unsigned long)time(NULL) + maxtime);
 
     printf("starting\n");
     bytes_read = 0;
     tm_Time_F(START);
 
     for (;;) {
-        if (finishtime < (long)time(NULL))
+        if ((long)((unsigned long)time(NULL) - finishtime) > 0)
             break;
 
         if ((doConnection(scon, host, ctx)) == NULL)
@@ -396,10 +395,11 @@ int s_time_main(int argc, char **argv)
     if (nConn > 0)
         printf
             ("%d connections in %ld real seconds, %ld bytes read per connection\n",
-             nConn, (long)time(NULL) - finishtime + maxtime, bytes_read / nConn);
+             nConn, (long)((unsigned long)time(NULL) - finishtime + maxtime),
+             bytes_read / nConn);
     else
         printf("0 connections in %ld real seconds\n",
-               (long)time(NULL) - finishtime + maxtime);
+               (long)((unsigned long)time(NULL) - finishtime + maxtime));
     ret = 0;
 
  end:

--- a/ssl/bio_ssl.c
+++ b/ssl/bio_ssl.c
@@ -120,7 +120,7 @@ static int ssl_read(BIO *b, char *buf, size_t size, size_t *readbytes)
             unsigned long tm;
 
             tm = (unsigned long)time(NULL);
-            if (tm > sb->last_time + sb->renegotiate_timeout) {
+            if (tm - sb->last_time > sb->renegotiate_timeout) {
                 sb->last_time = tm;
                 sb->num_renegotiates++;
                 SSL_renegotiate(ssl);
@@ -189,7 +189,7 @@ static int ssl_write(BIO *b, const char *buf, size_t size, size_t *written)
             unsigned long tm;
 
             tm = (unsigned long)time(NULL);
-            if (tm > bs->last_time + bs->renegotiate_timeout) {
+            if (tm - bs->last_time > bs->renegotiate_timeout) {
                 bs->last_time = tm;
                 bs->num_renegotiates++;
                 SSL_renegotiate(ssl);

--- a/ssl/statem/extensions_srvr.c
+++ b/ssl/statem/extensions_srvr.c
@@ -803,7 +803,7 @@ int tls_parse_ctos_cookie(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
 
     /* We tolerate a cookie age of up to 10 minutes (= 60 * 10 seconds) */
     now = (unsigned long)time(NULL);
-    if (tm > now || (now - tm) > 600) {
+    if ((uint32_t)(now - tm) > 600) {
         /* Cookie is stale. Ignore it */
         return 1;
     }


### PR DESCRIPTION
Some arithmetics using long when this type is 32
bit and time_t is 64 bit might break after 2038.
