### PR TITLE
Fix time_t arithmetic after 2038 [1.1.1]

### DIFF
--- a/apps/s_time.c
+++ b/apps/s_time.c
@@ -100,7 +100,8 @@ int s_time_main(int argc, char **argv)
     double totalTime = 0.0;
     int noCApath = 0, noCAfile = 0;
     int maxtime = SECONDS, nConn = 0, perform = 3, ret = 1, i, st_bugs = 0;
-    long bytes_read = 0, finishtime = 0;
+    long bytes_read = 0;
+    time_t starttime;
     OPTION_CHOICE o;
     int max_version = 0, ver, buf_len;
     size_t buf_size;
@@ -217,10 +218,10 @@ int s_time_main(int argc, char **argv)
     /* Loop and time how long it takes to make connections */
 
     bytes_read = 0;
-    finishtime = (long)time(NULL) + maxtime;
+    starttime = time(NULL);
     tm_Time_F(START);
     for (;;) {
-        if (finishtime < (long)time(NULL))
+        if (time(NULL) - starttime > maxtime)
             break;
 
         if ((scon = doConnection(NULL, host, ctx)) == NULL)
@@ -257,13 +258,12 @@ int s_time_main(int argc, char **argv)
     }
     totalTime += tm_Time_F(STOP); /* Add the time for this iteration */
 
-    i = (int)((long)time(NULL) - finishtime + maxtime);
     printf
         ("\n\n%d connections in %.2fs; %.2f connections/user sec, bytes read %ld\n",
          nConn, totalTime, ((double)nConn / totalTime), bytes_read);
     printf
         ("%d connections in %ld real seconds, %ld bytes read per connection\n",
-         nConn, (long)time(NULL) - finishtime + maxtime,
+         nConn, (long)(time(NULL) - starttime),
          nConn > 0 ? bytes_read / nConn : 0l);
 
     /*
@@ -294,14 +294,14 @@ int s_time_main(int argc, char **argv)
     nConn = 0;
     totalTime = 0.0;
 
-    finishtime = (long)time(NULL) + maxtime;
+    starttime = time(NULL);
 
     printf("starting\n");
     bytes_read = 0;
     tm_Time_F(START);
 
     for (;;) {
-        if (finishtime < (long)time(NULL))
+        if (time(NULL) - starttime > maxtime)
             break;
 
         if ((doConnection(scon, host, ctx)) == NULL)
@@ -340,7 +340,8 @@ int s_time_main(int argc, char **argv)
          nConn, totalTime, ((double)nConn / totalTime), bytes_read);
     printf
         ("%d connections in %ld real seconds, %ld bytes read per connection\n",
-         nConn, (long)time(NULL) - finishtime + maxtime, bytes_read / nConn);
+         nConn, (long)(time(NULL) - starttime),
+         nConn > 0 ? bytes_read / nConn : 0l);
 
     ret = 0;
 

--- a/ssl/bio_ssl.c
+++ b/ssl/bio_ssl.c
@@ -120,7 +120,7 @@ static int ssl_read(BIO *b, char *buf, size_t size, size_t *readbytes)
             unsigned long tm;
 
             tm = (unsigned long)time(NULL);
-            if (tm > sb->last_time + sb->renegotiate_timeout) {
+            if (tm - sb->last_time > sb->renegotiate_timeout) {
                 sb->last_time = tm;
                 sb->num_renegotiates++;
                 SSL_renegotiate(ssl);
@@ -189,7 +189,7 @@ static int ssl_write(BIO *b, const char *buf, size_t size, size_t *written)
             unsigned long tm;
 
             tm = (unsigned long)time(NULL);
-            if (tm > bs->last_time + bs->renegotiate_timeout) {
+            if (tm - bs->last_time > bs->renegotiate_timeout) {
                 bs->last_time = tm;
                 bs->num_renegotiates++;
                 SSL_renegotiate(ssl);

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -3560,8 +3560,10 @@ void ssl_update_cache(SSL *s, int mode)
             stat = &s->session_ctx->stats.sess_connect_good;
         else
             stat = &s->session_ctx->stats.sess_accept_good;
-        if ((tsan_load(stat) & 0xff) == 0xff)
-            SSL_CTX_flush_sessions(s->session_ctx, (unsigned long)time(NULL));
+        if ((tsan_load(stat) & 0xff) == 0xff) {
+            long tm = (long)time(NULL);
+            SSL_CTX_flush_sessions(s->session_ctx, tm == 0 ? 1 : tm);
+        }
     }
 }
 

--- a/ssl/ssl_sess.c
+++ b/ssl/ssl_sess.c
@@ -580,7 +580,8 @@ int ssl_get_prev_session(SSL *s, CLIENTHELLO_MSG *hello)
         goto err;
     }
 
-    if (ret->timeout < (long)(time(NULL) - ret->time)) { /* timeout */
+    if ((unsigned long)ret->timeout
+        < (unsigned long)time(NULL) - ret->time) { /* timeout */
         tsan_counter(&s->session_ctx->stats.sess_timeout);
         if (try_session_cache) {
             /* session was from the cache, so remove it */
@@ -1050,7 +1051,9 @@ typedef struct timeout_param_st {
 
 static void timeout_cb(SSL_SESSION *s, TIMEOUT_PARAM *p)
 {
-    if ((p->time == 0) || (p->time > (s->time + s->timeout))) { /* timeout */
+    if ((p->time == 0)
+            || (unsigned long)s->timeout
+               < (unsigned long)p->time - s->time) { /* timeout */
         /*
          * The reason we don't call SSL_CTX_remove_session() is to save on
          * locking overhead

--- a/ssl/statem/extensions_srvr.c
+++ b/ssl/statem/extensions_srvr.c
@@ -862,7 +862,7 @@ int tls_parse_ctos_cookie(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
 
     /* We tolerate a cookie age of up to 10 minutes (= 60 * 10 seconds) */
     now = (unsigned long)time(NULL);
-    if (tm > now || (now - tm) > 600) {
+    if ((uint32_t)(now - tm) > 600) {
         /* Cookie is stale. Ignore it */
         return 1;
     }


### PR DESCRIPTION
Some arithmetics using long when this type is 32
bit and time_t is 64 bit might break after 2038.

Back-port of #17701 for 1.1.1 branch