### PR TITLE
test/helpers/handshake.c: Add check for OPENSSL_strdup

### DIFF
--- a/test/helpers/handshake.c
+++ b/test/helpers/handshake.c
@@ -633,6 +633,8 @@ static int configure_handshake_ctx(SSL_CTX *server_ctx, SSL_CTX *server2_ctx,
     if (extra->server.session_ticket_app_data != NULL) {
         server_ctx_data->session_ticket_app_data =
             OPENSSL_strdup(extra->server.session_ticket_app_data);
+        if (!TEST_ptr(server_ctx_data->session_ticket_app_data))
+            goto err;
         SSL_CTX_set_session_ticket_cb(server_ctx, generate_session_ticket_cb,
                                       decrypt_session_ticket_cb, server_ctx_data);
     }
@@ -641,6 +643,8 @@ static int configure_handshake_ctx(SSL_CTX *server_ctx, SSL_CTX *server2_ctx,
             goto err;
         server2_ctx_data->session_ticket_app_data =
             OPENSSL_strdup(extra->server2.session_ticket_app_data);
+        if (!TEST_ptr(server2_ctx_data->session_ticket_app_data))
+            goto err;
         SSL_CTX_set_session_ticket_cb(server2_ctx, NULL,
                                       decrypt_session_ticket_cb, server2_ctx_data);
     }


### PR DESCRIPTION
As the potential failure of the memory allocation, the OPENSSL_strdup()
could return NULL pointer and then be assigned to 'server_ctx'.
In order to tell the callers the failure of the configuration, it should
be better to return error.

Signed-off-by: Jiasheng Jiang <jiasheng@iscas.ac.cn>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
