### PR TITLE
Fix copyright year issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     - name: config
       run: ./config --strict-warnings && perl configdata.pm --dump
     - name: make build_generated

--- a/crypto/asn1/charmap.pl
+++ b/crypto/asn1/charmap.pl
@@ -1,5 +1,5 @@
 #! /usr/bin/env perl
-# Copyright 2000-2019 The OpenSSL Project Authors. All Rights Reserved.
+# Copyright 2000-2022 The OpenSSL Project Authors. All Rights Reserved.
 #
 # Licensed under the OpenSSL license (the "License").  You may not use
 # this file except in compliance with the License.  You can obtain a copy
@@ -7,6 +7,9 @@
 # https://www.openssl.org/source/license.html
 
 use strict;
+use FindBin;
+use lib "$FindBin::Bin/../../util/perl";
+use OpenSSL::copyright;
 
 my ($i, @arr);
 
@@ -82,8 +85,8 @@ $arr[ord("?")] |= $PSTRING_CHAR;
 
 # Now generate the C code
 
-# Output year depends on the year of the script.
-my $YEAR = [localtime([stat($0)]->[9])]->[5] + 1900;
+# Year the file was generated.
+my $YEAR = OpenSSL::copyright::year_of($0);
 print <<EOF;
 /*
  * WARNING: do not edit!

--- a/crypto/bn/bn_prime.pl
+++ b/crypto/bn/bn_prime.pl
@@ -1,13 +1,16 @@
 #! /usr/bin/env perl
-# Copyright 1998-2019 The OpenSSL Project Authors. All Rights Reserved.
+# Copyright 1998-2022 The OpenSSL Project Authors. All Rights Reserved.
 #
 # Licensed under the OpenSSL license (the "License").  You may not use
 # this file except in compliance with the License.  You can obtain a copy
 # in the file LICENSE in the source distribution or at
 # https://www.openssl.org/source/license.html
+use FindBin;
+use lib "$FindBin::Bin/../../util/perl";
+use OpenSSL::copyright;
 
-# Output year depends on the year of the script.
-my $YEAR = [localtime([stat($0)]->[9])]->[5] + 1900;
+# The year the output file is generated.
+my $YEAR = OpenSSL::copyright::year_of($0);
 print <<"EOF";
 /*
  * WARNING: do not edit!

--- a/crypto/conf/keysets.pl
+++ b/crypto/conf/keysets.pl
@@ -1,5 +1,5 @@
 #! /usr/bin/env perl
-# Copyright 1995-2019 The OpenSSL Project Authors. All Rights Reserved.
+# Copyright 1995-2022 The OpenSSL Project Authors. All Rights Reserved.
 #
 # Licensed under the OpenSSL license (the "License").  You may not use
 # this file except in compliance with the License.  You can obtain a copy
@@ -8,6 +8,9 @@
 
 use strict;
 use warnings;
+use FindBin;
+use lib "$FindBin::Bin/../../util/perl";
+use OpenSSL::copyright;
 
 my $NUMBER      = 0x0001;
 my $UPPER       = 0x0002;
@@ -54,9 +57,8 @@ foreach (0 .. 127) {
     push(@V_w32, $v);
 }
 
-# Output year depends on the year of the script.
-my $YEAR = [localtime([stat($0)]->[9])]->[5] + 1900;
-
+# The year the output file is generated.
+my $YEAR = OpenSSL::copyright::year_of($0);
 print <<"EOF";
 /*
  * WARNING: do not edit!

--- a/crypto/objects/obj_dat.pl
+++ b/crypto/objects/obj_dat.pl
@@ -9,6 +9,9 @@
 use integer;
 use strict;
 use warnings;
+use FindBin;
+use lib "$FindBin::Bin/../../util/perl";
+use OpenSSL::copyright;
 
 # Generate the DER encoding for the given OID.
 sub der_it
@@ -36,10 +39,8 @@ sub der_it
     return $ret;
 }
 
-# Output year depends on the year of the script and the input file.
-my $YEAR = [localtime([stat($0)]->[9])]->[5] + 1900;
-my $iYEAR = [localtime([stat($ARGV[0])]->[9])]->[5] + 1900;
-$YEAR = $iYEAR if $iYEAR > $YEAR;
+# The year the output file is generated.
+my $YEAR = OpenSSL::copyright::latest(($0, $ARGV[0]));
 
 # Read input, parse all #define's into OID name and value.
 # Populate %ln and %sn with long and short names (%dupln and %dupsn)

--- a/crypto/objects/objects.pl
+++ b/crypto/objects/objects.pl
@@ -7,16 +7,15 @@
 # https://www.openssl.org/source/license.html
 
 use Getopt::Std;
+use FindBin;
+use lib "$FindBin::Bin/../../util/perl";
+use OpenSSL::copyright;
 
 our($opt_n);
 getopts('n');
 
-# Output year depends on the year of the script and the input file.
-my $YEAR = [localtime([stat($0)]->[9])]->[5] + 1900;
-my $iYEAR = [localtime([stat($ARGV[0])]->[9])]->[5] + 1900;
-$YEAR = $iYEAR if $iYEAR > $YEAR;
-$iYEAR = [localtime([stat($ARGV[1])]->[9])]->[5] + 1900;
-$YEAR = $iYEAR if $iYEAR > $YEAR;
+# The year the output file is generated.
+my $YEAR = OpenSSL::copyright::latest(($0, $ARGV[1], $ARGV[0]));
 
 open (NUMIN,"$ARGV[1]") || die "Can't open number file $ARGV[1]";
 $max_nid=0;

--- a/crypto/objects/objxref.pl
+++ b/crypto/objects/objxref.pl
@@ -8,18 +8,17 @@
 
 
 use strict;
+use FindBin;
+use lib "$FindBin::Bin/../../util/perl";
+use OpenSSL::copyright;
 
 my %xref_tbl;
 my %oid_tbl;
 
 my ($mac_file, $xref_file) = @ARGV;
 
-# Output year depends on the year of the script and the input file.
-my $YEAR = [localtime([stat($0)]->[9])]->[5] + 1900;
-my $iYEAR = [localtime([stat($mac_file)]->[9])]->[5] + 1900;
-$YEAR = $iYEAR if $iYEAR > $YEAR;
-$iYEAR = [localtime([stat($xref_file)]->[9])]->[5] + 1900;
-$YEAR = $iYEAR if $iYEAR > $YEAR;
+# The year the output file is generated.
+my $YEAR = OpenSSL::copyright::latest(($0, $mac_file, $xref_file));
 
 open(IN, $mac_file) || die "Can't open $mac_file, $!\n";
 

--- a/util/perl/OpenSSL/copyright.pm
+++ b/util/perl/OpenSSL/copyright.pm
@@ -1,0 +1,41 @@
+#! /usr/bin/env perl
+# Copyright 2022 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+use strict;
+use warnings;
+
+package OpenSSL::copyright;
+
+sub year_of {
+    my $file = shift;
+
+    return $ENV{'OSSL_COPYRIGHT_YEAR'} if defined $ENV{'OSSL_COPYRIGHT_YEAR'};
+
+    # Use the file date for backward compatibility.
+    my $YEAR = [localtime([stat($file)]->[9])]->[5] + 1900;
+
+    # See if git's available
+    open my $FH,
+       "git log -1 --date=short --format=format:%cd $file 2>/dev/null|"
+           or return $YEAR;
+    my $LINE = <$FH>;
+    close $FH;
+    $LINE =~ s/^([0-9]*)-.*/$1/ if $LINE;
+    $YEAR = $LINE if $LINE;
+    return $YEAR;
+}
+
+sub latest {
+    my $l = 0;
+    foreach my $f (@_ ) {
+        my $y = year_of($f);
+        $l = $y if $y > $l;
+    }
+    return $l
+}
+1;


### PR DESCRIPTION
Fixes: #13765

Back-port of #17427 to 1.1.1
But stays compatible to previous version,
i.e. using file-time if git does not know the date.