### PR TITLE
x509: handle returns from X509_TRUST_get_by_id() more consistently

### DIFF
--- a/crypto/x509/x509_trust.c
+++ b/crypto/x509/x509_trust.c
@@ -72,7 +72,7 @@ int X509_check_trust(X509 *x, int id, int flags)
         return obj_trust(NID_anyExtendedKeyUsage, x,
                          flags | X509_TRUST_DO_SS_COMPAT);
     idx = X509_TRUST_get_by_id(id);
-    if (idx == -1)
+    if (idx < 0)
         return default_trust(id, x, flags);
     pt = X509_TRUST_get0(idx);
     return pt->check_trust(pt, x, flags);
@@ -112,7 +112,7 @@ int X509_TRUST_get_by_id(int id)
 
 int X509_TRUST_set(int *t, int trust)
 {
-    if (X509_TRUST_get_by_id(trust) == -1) {
+    if (X509_TRUST_get_by_id(trust) < 0) {
         ERR_raise(ERR_LIB_X509, X509_R_INVALID_TRUST);
         return 0;
     }
@@ -162,7 +162,7 @@ int X509_TRUST_add(int id, int flags, int (*ck) (X509_TRUST *, X509 *, int),
     trtmp->arg2 = arg2;
 
     /* If its a new entry manage the dynamic table */
-    if (idx == -1) {
+    if (idx < 0) {
         if (trtable == NULL
             && (trtable = sk_X509_TRUST_new(tr_cmp)) == NULL) {
             ERR_raise(ERR_LIB_X509, ERR_R_MALLOC_FAILURE);
@@ -175,7 +175,7 @@ int X509_TRUST_add(int id, int flags, int (*ck) (X509_TRUST *, X509 *, int),
     }
     return 1;
  err:
-    if (idx == -1) {
+    if (idx < 0) {
         OPENSSL_free(trtmp->name);
         OPENSSL_free(trtmp);
     }


### PR DESCRIPTION
The inconsistency was noted by @bernd-edlinger [here](https://github.com/openssl/openssl/pull/17668#issuecomment-1035872142)

- [ ] documentation is added or updated
- [ ] tests are added or updated
