### PR TITLE
apps/s_server: Add missing check for BIO_new

### DIFF
--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -3492,12 +3492,11 @@ static int rev_body(int s, int stype, int prot, unsigned char *context)
     BIO_push(io, ssl_bio);
     ssl_bio = NULL;
 #ifdef CHARSET_EBCDIC
-    BIO *filter;
     filter = BIO_new(BIO_f_ebcdic_filter());
     if (filter == NULL)
         goto err;
 
-    io = BIO_push((filter), io);
+    io = BIO_push(filter, io);
 #endif
 
     if (s_debug) {

--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -3011,6 +3011,9 @@ static int www_body(int s, int stype, int prot, unsigned char *context)
     int width;
     fd_set readfds;
     const char *opmode;
+#ifdef CHARSET_EBCDIC
+    BIO *filter;
+#endif
 
     /* Set width for a select call if needed */
     width = s + 1;
@@ -3075,7 +3078,6 @@ static int www_body(int s, int stype, int prot, unsigned char *context)
     BIO_push(io, ssl_bio);
     ssl_bio = NULL;
 #ifdef CHARSET_EBCDIC
-    BIO *filter;
     filter = BIO_new(BIO_f_ebcdic_filter());
     if (filter == NULL)
         goto err;
@@ -3444,6 +3446,9 @@ static int rev_body(int s, int stype, int prot, unsigned char *context)
     int ret = 1;
     SSL *con;
     BIO *io, *ssl_bio, *sbio;
+#ifdef CHARSET_EBCDIC
+    BIO *filter;
+#endif
 
     /* as we use BIO_gets(), and it always null terminates data, we need
      * to allocate 1 byte longer buffer to fit the full 2^14 byte record */
@@ -3488,11 +3493,11 @@ static int rev_body(int s, int stype, int prot, unsigned char *context)
     ssl_bio = NULL;
 #ifdef CHARSET_EBCDIC
     BIO *filter;
-    filter = BIO_new(BIO_f_ebcdic_filter();
+    filter = BIO_new(BIO_f_ebcdic_filter());
     if (filter == NULL)
         goto err;
 
-    io = BIO_push(filter), io);
+    io = BIO_push((filter), io);
 #endif
 
     if (s_debug) {


### PR DESCRIPTION
As the potential failure of the BIO_new(), it should be better to check the return value and return error if fails in order to avoid the dereference of NULL pointer.
And because 'bio_s_msg' is checked before being used everytime, which has no need to add the check.
But 'bio_s_out' is not.
And since the check 'if (bio_s_out == NULL)' is redundant, it can be removed to make the code succincter.
Also the 'sbio' and so forth should be checked like the other places in the same file.

Signed-off-by: Jiasheng Jiang <jiasheng@iscas.ac.cn>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
