### PR TITLE
test/mdc2test.c: Remove unused OSSL_PROVIDER

### DIFF
--- a/test/mdc2test.c
+++ b/test/mdc2test.c
@@ -51,14 +51,12 @@ static int test_mdc2(void)
     EVP_MD_CTX *c;
     static char text[] = "Now is the time for all ";
     size_t tlen = strlen(text), i = 0;
-    OSSL_PROVIDER *prov = NULL;
     OSSL_PARAM params[2];
 
     params[i++] = OSSL_PARAM_construct_uint(OSSL_DIGEST_PARAM_PAD_TYPE,
                                             &pad_type),
     params[i++] = OSSL_PARAM_construct_end();
 
-    prov = OSSL_PROVIDER_load(NULL, "legacy");
 # ifdef CHARSET_EBCDIC
     ebcdic2ascii(text, text, tlen);
 # endif
@@ -81,7 +79,6 @@ static int test_mdc2(void)
     testresult = 1;
  end:
     EVP_MD_CTX_free(c);
-    OSSL_PROVIDER_unload(prov);
     return testresult;
 }
 #endif


### PR DESCRIPTION
Since the 'prov' is not used after initialization,
it should be better to remove it.

Signed-off-by: Jiasheng Jiang <jiasheng@iscas.ac.cn>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
