### PR TITLE
test/crltest.c: Add check for glue2bio

### DIFF
--- a/test/crltest.c
+++ b/test/crltest.c
@@ -200,14 +200,16 @@ static BIO *glue2bio(const char **pem, char **out)
  */
 static X509_CRL *CRL_from_strings(const char **pem)
 {
+    X509_CRL *crl;
     char *p;
     BIO *b = glue2bio(pem, &p);
+
     if (b == NULL) {
         OPENSSL_free(p);
         return NULL;
     }
 
-    X509_CRL *crl = PEM_read_bio_X509_CRL(b, NULL, NULL, NULL);
+    crl = PEM_read_bio_X509_CRL(b, NULL, NULL, NULL);
 
     OPENSSL_free(p);
     BIO_free(b);
@@ -219,14 +221,16 @@ static X509_CRL *CRL_from_strings(const char **pem)
  */
 static X509 *X509_from_strings(const char **pem)
 {
+    X509 *x;
     char *p;
     BIO *b = glue2bio(pem, &p);
+
     if (b == NULL) {
         OPENSSL_free(p);
         return NULL;
     }
 
-    X509 *x = PEM_read_bio_X509(b, NULL, NULL, NULL);
+    x = PEM_read_bio_X509(b, NULL, NULL, NULL);
 
     OPENSSL_free(p);
     BIO_free(b);
@@ -372,6 +376,7 @@ static int test_reuse_crl(void)
     X509_CRL *reused_crl = CRL_from_strings(kBasicCRL);
     char *p;
     BIO *b = glue2bio(kRevokedCRL, &p);
+
     if (b == NULL) {
         OPENSSL_free(p);
         X509_CRL_free(reused_crl);

--- a/test/crltest.c
+++ b/test/crltest.c
@@ -202,6 +202,11 @@ static X509_CRL *CRL_from_strings(const char **pem)
 {
     char *p;
     BIO *b = glue2bio(pem, &p);
+    if (b == NULL) {
+        OPENSSL_free(p);
+        return NULL;
+    }
+
     X509_CRL *crl = PEM_read_bio_X509_CRL(b, NULL, NULL, NULL);
 
     OPENSSL_free(p);
@@ -216,6 +221,11 @@ static X509 *X509_from_strings(const char **pem)
 {
     char *p;
     BIO *b = glue2bio(pem, &p);
+    if (b == NULL) {
+        OPENSSL_free(p);
+        return NULL;
+    }
+
     X509 *x = PEM_read_bio_X509(b, NULL, NULL, NULL);
 
     OPENSSL_free(p);
@@ -362,6 +372,11 @@ static int test_reuse_crl(void)
     X509_CRL *reused_crl = CRL_from_strings(kBasicCRL);
     char *p;
     BIO *b = glue2bio(kRevokedCRL, &p);
+    if (b == NULL) {
+        OPENSSL_free(p);
+        X509_CRL_free(reused_crl);
+        return 0;
+    }
 
     reused_crl = PEM_read_bio_X509_CRL(b, &reused_crl, NULL, NULL);
 


### PR DESCRIPTION
As the glue2bio() could return NULL pointer if fails,
it should be better to check the return value in order
to avoid the use of NULL pointer.

Signed-off-by: Jiasheng Jiang <jiasheng@iscas.ac.cn>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
