### PR TITLE
CMP: add subject of any provided CSR as default message sender

### DIFF
--- a/crypto/cmp/cmp_hdr.c
+++ b/crypto/cmp/cmp_hdr.c
@@ -301,11 +301,12 @@ int ossl_cmp_hdr_init(OSSL_CMP_CTX *ctx, OSSL_CMP_PKIHEADER *hdr)
         return 0;
 
     /*
-     * If neither protection cert nor oldCert nor subject are given,
+     * If no protection cert nor oldCert nor CSR nor subject is given,
      * sender name is not known to the client and thus set to NULL-DN
      */
     sender = ctx->cert != NULL ? X509_get_subject_name(ctx->cert) :
         ctx->oldCert != NULL ? X509_get_subject_name(ctx->oldCert) :
+        ctx->p10CSR != NULL ? X509_REQ_get_subject_name(ctx->p10CSR) :
         ctx->subjectName;
     if (!ossl_cmp_hdr_set1_sender(hdr, sender))
         return 0;

--- a/doc/man1/openssl-cmp.pod.in
+++ b/doc/man1/openssl-cmp.pod.in
@@ -273,7 +273,7 @@ or of the reference certificate (see B<-oldcert>) if provided.
 This default is used for IR and CR only if no SANs are set.
 If the NULL-DN (C<"/">) is given then no subject is placed in the template.
 
-If provided and neither B<-cert> nor B<-oldcert> is given,
+If provided and neither of B<-cert>, B<-oldcert>, or B<-csr> is given,
 the subject DN is used as fallback sender of outgoing CMP messages.
 
 The argument must be formatted as I</type0=value0/type1=value1/type2=...>.
@@ -360,6 +360,8 @@ When used with B<-cmd> I<ir>, I<cr>, or I<kur>, it is transformed into the
 respective regular CMP request.
 It may also be used with B<-cmd> I<rr> to specify the certificate to be revoked
 via the included subject name and public key.
+Its subject is used as fallback sender in CMP message headers
+if B<-cert> and B<-oldcert> are not given.
 
 =item B<-out_trusted> I<filenames>|I<uris>
 

--- a/doc/man3/OSSL_CMP_CTX_new.pod
+++ b/doc/man3/OSSL_CMP_CTX_new.pod
@@ -457,7 +457,8 @@ When using signature-based protection of CMP request messages
 this CMP signer certificate will be included first in the extraCerts field.
 It serves as fallback reference certificate, see OSSL_CMP_CTX_set1_oldCert().
 The subject of this I<cert> will be used as the sender field of outgoing
-messages, while the subject of any cert set via OSSL_CMP_CTX_set1_oldCert()
+messages, while the subject of any cert set via OSSL_CMP_CTX_set1_oldCert(),
+the subject of any PKCS#10 CSR set via OSSL_CMP_CTX_set1_p10CSR(),
 and any value set via OSSL_CMP_CTX_set1_subjectName() are used as fallback.
 
 The I<cert> argument may be NULL to clear the entry.


### PR DESCRIPTION
This is a minor improvement.