### PR TITLE
test/mdc2test.c: Add check for OSSL_PROVIDER_load

### DIFF
--- a/test/mdc2test.c
+++ b/test/mdc2test.c
@@ -48,7 +48,7 @@ static int test_mdc2(void)
     int testresult = 0;
     unsigned int pad_type = 2;
     unsigned char md[MDC2_DIGEST_LENGTH];
-    EVP_MD_CTX *c;
+    EVP_MD_CTX *c = NULL;
     static char text[] = "Now is the time for all ";
     size_t tlen = strlen(text), i = 0;
     OSSL_PROVIDER *prov = NULL;
@@ -59,6 +59,9 @@ static int test_mdc2(void)
     params[i++] = OSSL_PARAM_construct_end();
 
     prov = OSSL_PROVIDER_load(NULL, "legacy");
+    if (!TEST_ptr(prov))
+        goto end;
+
 # ifdef CHARSET_EBCDIC
     ebcdic2ascii(text, text, tlen);
 # endif


### PR DESCRIPTION
Since the potential failure of the OSSL_PROVIDER_load(),
for example there is no lock, the provider could fail to
be loaded into the library context.
Therefore, it should be better to check it and return error
if fails.
Also, in order to avoid free unknown pointer, 'c' should be
initialized as NULL.

Signed-off-by: Jiasheng Jiang <jiasheng@iscas.ac.cn>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
