### PR TITLE
Allow users to set the send flags used by send/sendto via BIO_ctrl

### DIFF
--- a/crypto/bio/bio_local.h
+++ b/crypto/bio/bio_local.h
@@ -126,6 +126,7 @@ struct bio_st {
     int flags;                  /* extra storage */
     int retry_reason;
     int num;
+    int send_flags;             /* flags for send()/sendto() */
     void *ptr;
     struct bio_st *next_bio;    /* used by filter BIOs */
     struct bio_st *prev_bio;    /* used by filter BIOs */
@@ -190,4 +191,3 @@ void bio_sock_cleanup_int(void);
 # endif
 
 #endif
-

--- a/crypto/bio/bss_conn.c
+++ b/crypto/bio/bss_conn.c
@@ -361,7 +361,7 @@ static int conn_write(BIO *b, const char *in, int inl)
         }
     } else
 # endif
-        ret = writesocket(b->num, in, inl);
+        ret = writesocket(b->num, in, inl, b->send_flags);
     BIO_clear_retry_flags(b);
     if (ret <= 0) {
         if (BIO_sock_should_retry(ret))
@@ -558,6 +558,9 @@ static long conn_ctrl(BIO *b, int cmd, long num, void *ptr)
     case BIO_CTRL_CLEAR_KTLS_TX_CTRL_MSG:
         BIO_clear_ktls_ctrl_msg_flag(b);
         ret = 0;
+        break;
+    case BIO_CTRL_DGRAM_SET_SEND_FLAGS:
+        b->send_flags = num;
         break;
 # endif
     default:

--- a/crypto/bio/bss_dgram.c
+++ b/crypto/bio/bss_dgram.c
@@ -337,11 +337,11 @@ static int dgram_write(BIO *b, const char *in, int inl)
     clear_socket_error();
 
     if (data->connected)
-        ret = writesocket(b->num, in, inl);
+        ret = writesocket(b->num, in, inl, b->send_flags);
     else {
         int peerlen = BIO_ADDR_sockaddr_size(&data->peer);
 
-        ret = sendto(b->num, in, inl, 0,
+        ret = sendto(b->num, in, inl, b->send_flags,
                      BIO_ADDR_sockaddr(&data->peer), peerlen);
     }
 
@@ -791,6 +791,9 @@ static long dgram_ctrl(BIO *b, int cmd, long num, void *ptr)
     case BIO_CTRL_DGRAM_SCTP_SET_IN_HANDSHAKE:
     case BIO_CTRL_DGRAM_SET_PEEK_MODE:
         data->peekmode = (unsigned int)num;
+        break;
+    case BIO_CTRL_DGRAM_SET_SEND_FLAGS:
+        b->send_flags = num;
         break;
     default:
         ret = 0;

--- a/crypto/bio/bss_sock.c
+++ b/crypto/bio/bss_sock.c
@@ -138,7 +138,7 @@ static int sock_write(BIO *b, const char *in, int inl)
         }
     } else
 # endif
-        ret = writesocket(b->num, in, inl);
+        ret = writesocket(b->num, in, inl, b->send_flags);
     BIO_clear_retry_flags(b);
     if (ret <= 0) {
         if (BIO_sock_should_retry(ret))
@@ -204,6 +204,9 @@ static long sock_ctrl(BIO *b, int cmd, long num, void *ptr)
 # endif
     case BIO_CTRL_EOF:
         ret = (b->flags & BIO_FLAGS_IN_EOF) != 0;
+        break;
+    case BIO_CTRL_DGRAM_SET_SEND_FLAGS:
+        b->send_flags = num;
         break;
     default:
         ret = 0;

--- a/include/internal/sockets.h
+++ b/include/internal/sockets.h
@@ -132,31 +132,31 @@ struct servent *PASCAL getservbyname(const char *, const char *);
 #  define get_last_socket_error() WSAGetLastError()
 #  define clear_socket_error()    WSASetLastError(0)
 #  define readsocket(s,b,n)       recv((s),(b),(n),0)
-#  define writesocket(s,b,n)      send((s),(b),(n),0)
+#  define writesocket(s,b,n,f)    send((s),(b),(n),(f))
 # elif defined(__DJGPP__)
 #  define WATT32
 #  define WATT32_NO_OLDIES
 #  define closesocket(s)          close_s(s)
 #  define readsocket(s,b,n)       read_s(s,b,n)
-#  define writesocket(s,b,n)      send(s,b,n,0)
+#  define writesocket(s,b,n,f)    send(s,b,n,f)
 # elif defined(OPENSSL_SYS_VMS)
 #  define ioctlsocket(a,b,c)      ioctl(a,b,c)
 #  define closesocket(s)          close(s)
 #  define readsocket(s,b,n)       recv((s),(b),(n),0)
-#  define writesocket(s,b,n)      send((s),(b),(n),0)
+#  define writesocket(s,b,n,f)    send((s),(b),(n),(f))
 # elif defined(OPENSSL_SYS_VXWORKS)
 #  define ioctlsocket(a,b,c)          ioctl((a),(b),(int)(c))
 #  define closesocket(s)              close(s)
 #  define readsocket(s,b,n)           read((s),(b),(n))
-#  define writesocket(s,b,n)          write((s),(char *)(b),(n))
+#  define writesocket(s,b,n,f)        write((s),(char *)(b),(n))
 # elif defined(OPENSSL_SYS_TANDEM)
 #  if defined(OPENSSL_TANDEM_FLOSS)
 #   include <floss.h(floss_read, floss_write)>
 #   define readsocket(s,b,n)       floss_read((s),(b),(n))
-#   define writesocket(s,b,n)      floss_write((s),(b),(n))
+#   define writesocket(s,b,n,f)    floss_write((s),(b),(n))
 #  else
 #   define readsocket(s,b,n)       read((s),(b),(n))
-#   define writesocket(s,b,n)      write((s),(b),(n))
+#   define writesocket(s,b,n,f)    write((s),(b),(n))
 #  endif
 #  define ioctlsocket(a,b,c)      ioctl(a,b,c)
 #  define closesocket(s)          close(s)
@@ -164,7 +164,7 @@ struct servent *PASCAL getservbyname(const char *, const char *);
 #  define ioctlsocket(a,b,c)      ioctl(a,b,c)
 #  define closesocket(s)          close(s)
 #  define readsocket(s,b,n)       read((s),(b),(n))
-#  define writesocket(s,b,n)      write((s),(b),(n))
+#  define writesocket(s,b,n,f)    send((s),(b),(n),(f))
 # endif
 
 /* also in apps/include/apps.h */

--- a/include/openssl/bio.h.in
+++ b/include/openssl/bio.h.in
@@ -172,6 +172,8 @@ extern "C" {
 # define BIO_CTRL_SET_INDENT                    80
 # define BIO_CTRL_GET_INDENT                    81
 
+# define BIO_CTRL_DGRAM_SET_SEND_FLAGS          82 /* flags for send/sendto */
+
 # ifndef OPENSSL_NO_KTLS
 #  define BIO_get_ktls_send(b)         \
      BIO_ctrl(b, BIO_CTRL_GET_KTLS_SEND, 0, NULL)


### PR DESCRIPTION
These sets of patches adds a new ctrl to BIO_ctrl, BIO_CTRL_DGRAM_SET_SEND_FLAGS, which allows users to set the socket flags used by the send/sendto calls.

The main use case here is for the user to be able to set the MSG_NOSIGNAL flag, but instead of only adding support for that I thought that it was cleanest to just add support for the flags in general so we don't have to add new ctrls in the future if another flag might be interesting to use.

Many applications that use OpenSSL like e.g cURL have to make extra syscalls to disable and enable the SIGPIPE signal between each call to SSL_read and SSL_write since there are no way to set the MSG_NOSIGNAL flag in the current version of OpenSSL so this addition have quite useful benefits.

I have signed and sent in a CLA to legal so that part should be cleared.