### PR TITLE
fuzz/fuzz_rand.c: Add check for OSSL_LIB_CTX_new

### DIFF
--- a/fuzz/fuzz_rand.c
+++ b/fuzz/fuzz_rand.c
@@ -146,6 +146,8 @@ static int fuzz_rand_provider_init(const OSSL_CORE_HANDLE *handle,
                                    const OSSL_DISPATCH **out, void **provctx)
 {
     *provctx = OSSL_LIB_CTX_new();
+    if (*provctx == NULL)
+        return 0;
     *out = fuzz_rand_method;
     return 1;
 }


### PR DESCRIPTION
As the potential failure of the OPENSSL_zalloc(), the OSSL_LIB_CTX_new()
could return NULL.
Therefore, it should be better to check it and return error if fails in
order to guarantee the success of the initialization.

Signed-off-by: Jiasheng Jiang <jiasheng@iscas.ac.cn>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
