### PR TITLE
test/sslapitest.c: Add check for SSL_CTX_new

### DIFF
--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -8090,8 +8090,12 @@ static int test_cert_cb_int(int prot, int tst)
     else
         cert_cb_cnt = 0;
 
-    if (tst == 2)
+    if (tst == 2) {
         snictx = SSL_CTX_new(TLS_server_method());
+        if (!TEST_ptr(snictx))
+            goto end;
+    }
+
     SSL_CTX_set_cert_cb(sctx, cert_cb, snictx);
 
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,


### PR DESCRIPTION
As the potential failure of the memory allocation, it should
be better to check the return value of SSL_CTX_new() and return
error if fails, like SSL_CTX_new_ex().

Signed-off-by: Jiasheng Jiang <jiasheng@iscas.ac.cn>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
