### PR TITLE
doc: Fix KDF example for scrypt

### DIFF
--- a/doc/man1/openssl-kdf.pod.in
+++ b/doc/man1/openssl-kdf.pod.in
@@ -166,7 +166,7 @@ Use PBKDF2 to create a hex-encoded derived key from a password and salt:
 Use scrypt to create a hex-encoded derived key from a password and salt:
 
     openssl kdf -keylen 64 -kdfopt pass:password -kdfopt salt:NaCl \
-                -kdfopt N:1024 -kdfopt r:8 -kdfopt p:16 \
+                -kdfopt n:1024 -kdfopt r:8 -kdfopt p:16 \
                 -kdfopt maxmem_bytes:10485760 SCRYPT
 
 =head1 NOTES


### PR DESCRIPTION
CLA: trivial

The current example is not working and return the error `Parameter unknown: 'N:1024'`, changing the KDF option to be a lower case "n" instead of upper case "N" do fix the problem and return expected output.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
