### PR TITLE
VMS: move copy_argc to its own module and make it an aux source [backport #8381 to 1.1.1]

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1772,7 +1772,7 @@ my %targets = (
 
         disable          => add('pinshared'),
 
-        apps_aux_src     => "vms_term_sock.c",
+        apps_aux_src     => "vms_term_sock.c vms_decc_argv.c",
         apps_init_src    => "vms_decc_init.c",
     },
 

--- a/apps/openssl.c
+++ b/apps/openssl.c
@@ -120,7 +120,6 @@ int main(int argc, char *argv[])
 {
     FUNCTION f, *fp;
     LHASH_OF(FUNCTION) *prog = NULL;
-    char **copied_argv = NULL;
     char *p, *pname;
     char buf[1024];
     const char *prompt;
@@ -137,7 +136,7 @@ int main(int argc, char *argv[])
     bio_err = dup_bio_err(FORMAT_TEXT);
 
 #if defined(OPENSSL_SYS_VMS) && defined(__DECC)
-    copied_argv = argv = copy_argv(&argc, argv);
+    argv = copy_argv(&argc, argv);
 #elif defined(_WIN32)
     /*
      * Replace argv[] with UTF-8 encoded strings.
@@ -258,7 +257,6 @@ int main(int argc, char *argv[])
     }
     ret = 1;
  end:
-    OPENSSL_free(copied_argv);
     OPENSSL_free(default_config_file);
     lh_FUNCTION_free(prog);
     OPENSSL_free(arg.argv);

--- a/apps/vms_decc_argv.c
+++ b/apps/vms_decc_argv.c
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2015-2019 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <stdlib.h>
+#include <openssl/crypto.h>
+#include "apps.h"                /* for app_malloc() and copy_argv() */
+
+char **newargv = NULL;
+
+static void cleanup_argv(void)
+{
+    OPENSSL_free(newargv);
+    newargv = NULL;
+}
+
+char **copy_argv(int *argc, char *argv[])
+{
+    /*-
+     * The note below is for historical purpose.  On VMS now we always
+     * copy argv "safely."
+     *
+     * 2011-03-22 SMS.
+     * If we have 32-bit pointers everywhere, then we're safe, and
+     * we bypass this mess, as on non-VMS systems.
+     * Problem 1: Compaq/HP C before V7.3 always used 32-bit
+     * pointers for argv[].
+     * Fix 1: For a 32-bit argv[], when we're using 64-bit pointers
+     * everywhere else, we always allocate and use a 64-bit
+     * duplicate of argv[].
+     * Problem 2: Compaq/HP C V7.3 (Alpha, IA64) before ECO1 failed
+     * to NULL-terminate a 64-bit argv[].  (As this was written, the
+     * compiler ECO was available only on IA64.)
+     * Fix 2: Unless advised not to (VMS_TRUST_ARGV), we test a
+     * 64-bit argv[argc] for NULL, and, if necessary, use a
+     * (properly) NULL-terminated (64-bit) duplicate of argv[].
+     * The same code is used in either case to duplicate argv[].
+     * Some of these decisions could be handled in preprocessing,
+     * but the code tends to get even uglier, and the penalty for
+     * deciding at compile- or run-time is tiny.
+     */
+
+    int i, count = *argc;
+    char **p = newargv;
+
+    cleanup_argv();
+
+    newargv = app_malloc(sizeof(*newargv) * (count + 1), "argv copy");
+    if (newargv == NULL)
+        return NULL;
+
+    /* Register automatic cleanup on first use */
+    if (p == NULL)
+        OPENSSL_atexit(cleanup_argv);
+
+    for (i = 0; i < count; i++)
+        newargv[i] = argv[i];
+    newargv[i] = NULL;
+    *argc = i;
+    return newargv;
+}

--- a/apps/vms_decc_init.c
+++ b/apps/vms_decc_init.c
@@ -25,8 +25,6 @@
 # include <stdlib.h>
 # include <unixlib.h>
 
-# include "apps.h"
-
 /* Global storage. */
 
 /* Flag to sense if decc_init() was called. */
@@ -62,42 +60,6 @@ decc_feat_t decc_feat_array[] = {
     {(char *)NULL, 0}
 };
 
-
-char **copy_argv(int *argc, char *argv[])
-{
-    /*-
-     * The note below is for historical purpose.  On VMS now we always
-     * copy argv "safely."
-     *
-     * 2011-03-22 SMS.
-     * If we have 32-bit pointers everywhere, then we're safe, and
-     * we bypass this mess, as on non-VMS systems.
-     * Problem 1: Compaq/HP C before V7.3 always used 32-bit
-     * pointers for argv[].
-     * Fix 1: For a 32-bit argv[], when we're using 64-bit pointers
-     * everywhere else, we always allocate and use a 64-bit
-     * duplicate of argv[].
-     * Problem 2: Compaq/HP C V7.3 (Alpha, IA64) before ECO1 failed
-     * to NULL-terminate a 64-bit argv[].  (As this was written, the
-     * compiler ECO was available only on IA64.)
-     * Fix 2: Unless advised not to (VMS_TRUST_ARGV), we test a
-     * 64-bit argv[argc] for NULL, and, if necessary, use a
-     * (properly) NULL-terminated (64-bit) duplicate of argv[].
-     * The same code is used in either case to duplicate argv[].
-     * Some of these decisions could be handled in preprocessing,
-     * but the code tends to get even uglier, and the penalty for
-     * deciding at compile- or run-time is tiny.
-     */
-
-    int i, count = *argc;
-    char **newargv = app_malloc(sizeof(*newargv) * (count + 1), "argv copy");
-
-    for (i = 0; i < count; i++)
-        newargv[i] = argv[i];
-    newargv[i] = NULL;
-    *argc = i;
-    return newargv;
-}
 
 /* LIB$INITIALIZE initialization function. */
 


### PR DESCRIPTION
copy_argv was never initialization code.

Make it self-cleaning too.

-----

This is a backport of #8381 to 1.1.1.  Without this, VMS builds break.
