### PR TITLE
Undeprecate OPENSSL_VERSION_NUMBER and OpenSSL_version_num()

### DIFF
--- a/doc/man3/OpenSSL_version.pod
+++ b/doc/man3/OpenSSL_version.pod
@@ -38,8 +38,6 @@ OpenSSL_version_num, OPENSSL_info
 
  const char *OPENSSL_info(int t);
 
-Deprecated:
-
  /* from openssl/opensslv.h */
  #define OPENSSL_VERSION_NUMBER 0xnnnnnnnnL
 
@@ -80,6 +78,25 @@ version for the headers in use is at least at the given pre-requisite major
 (B<maj>) and minor (B<min>) number or not. It will evaluate to true if the
 header version number (B<OPENSSL_VERSION_MAJOR>.B<OPENSSL_VERSION_MINOR>) is
 greater than or equal to B<maj>.B<min>.
+
+B<OPENSSL_VERSION_NUMBER> is a combination of the major, minor and
+patch version into a single integer 0xMNN00PP0L, where:
+
+=over 4
+
+=item M
+
+is the number from B<OPENSSL_VERSION_MAJOR>, in hexadecimal notation
+
+=item NN
+
+is the number from B<OPENSSL_VERSION_MINOR>, in hexadecimal notation
+
+=item PP
+
+is the number from B<OPENSSL_VERSION_PATCH>, in hexadecimal notation
+
+=back
 
 =head2 Functions
 
@@ -198,35 +215,6 @@ For x86 the string looks like C<OPENSSL_ia32cap=0x123:0x456>.
 
 For an unknown I<t>, NULL is returned.
 
-=head1 BACKWARD COMPATIBILITY
-
-For compatibility, some older macros and functions are retained or
-synthesised.
-They are all considered deprecated.
-
-=head2 Macros
-
-B<OPENSSL_VERSION_NUMBER> is a combination of the major, minor and
-patch version into a single integer 0xMNN00PP0L, where:
-
-=over 4
-
-=item M
-
-is the number from B<OPENSSL_VERSION_MAJOR>, in hexadecimal notation
-
-=item NN
-
-is the number from B<OPENSSL_VERSION_MINOR>, in hexadecimal notation
-
-=item PP
-
-is the number from B<OPENSSL_VERSION_PATCH>, in hexadecimal notation
-
-=back
-
-=head2 Functions
-
 OpenSSL_version_num() returns the value of B<OPENSSL_VERSION_NUMBER>.
 
 =head1 RETURN VALUES
@@ -248,7 +236,7 @@ L<crypto(7)>
 =head1 HISTORY
 
 The macros and functions described here were added in OpenSSL 3.0,
-with the exception of the L</BACKWARD COMPATIBILITY> ones.
+except for OPENSSL_VERSION_NUMBER and OpenSSL_version_num().
 
 =head1 COPYRIGHT
 

--- a/util/other.syms
+++ b/util/other.syms
@@ -362,7 +362,7 @@ OPENSSL_MSTR                            define
 OPENSSL_MSTR_HELPER                     define
 OPENSSL_VERSION_MAJOR                   define
 OPENSSL_VERSION_MINOR                   define
-OPENSSL_VERSION_NUMBER                  define deprecated 3.0.0
+OPENSSL_VERSION_NUMBER                  define
 OPENSSL_VERSION_PATCH                   define
 OPENSSL_VERSION_PRE_RELEASE             define
 OPENSSL_VERSION_PREREQ                  define


### PR DESCRIPTION
This macro and function were deprecated in the documentation but not in
the source.

Following an OTC vote the deprecation has been removed from the
documentation.

See https://github.com/openssl/technical-policies/issues/26

Fixes #17517
