### PR TITLE
crypto/pem/pem_lib.c: Add check for BIO_read

### DIFF
--- a/crypto/pem/pem_lib.c
+++ b/crypto/pem/pem_lib.c
@@ -971,19 +971,22 @@ int PEM_read_bio_ex(BIO *bp, char **name_out, char **header,
     headerlen = BIO_get_mem_data(headerB, NULL);
     *header = pem_malloc(headerlen + 1, flags);
     *data = pem_malloc(len, flags);
-    if (*header == NULL || *data == NULL) {
-        pem_free(*header, flags, 0);
-        pem_free(*data, flags, 0);
-        goto end;
-    }
-    BIO_read(headerB, *header, headerlen);
+    if (*header == NULL || *data == NULL)
+        goto out_free;
+    if (headerlen == 0 || BIO_read(headerB, *header, headerlen) != headerlen)
+        goto out_free;
     (*header)[headerlen] = '\0';
-    BIO_read(dataB, *data, len);
+    if (BIO_read(dataB, *data, len) != len)
+        goto out_free;
     *len_out = len;
     *name_out = name;
     name = NULL;
     ret = 1;
+    goto end;
 
+out_free:
+    pem_free(*header, flags, 0);
+    pem_free(*data, flags, 0);
 end:
     EVP_ENCODE_CTX_free(ctx);
     pem_free(name, flags, 0);

--- a/crypto/pem/pem_lib.c
+++ b/crypto/pem/pem_lib.c
@@ -973,7 +973,7 @@ int PEM_read_bio_ex(BIO *bp, char **name_out, char **header,
     *data = pem_malloc(len, flags);
     if (*header == NULL || *data == NULL)
         goto out_free;
-    if (headerlen == 0 || BIO_read(headerB, *header, headerlen) != headerlen)
+    if (headerlen != 0 && BIO_read(headerB, *header, headerlen) != headerlen)
         goto out_free;
     (*header)[headerlen] = '\0';
     if (BIO_read(dataB, *data, len) != len)


### PR DESCRIPTION
As the potential failure of the BIO_read(),
it should be better to add the check and return
error if fails.
Also, in order to decrease the same code, using
'out_free' will be better.

Signed-off-by: Jiasheng Jiang <jiasheng@iscas.ac.cn>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
