### PR TITLE
Rework dependencies between config files and build files

### DIFF
--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -553,7 +553,6 @@ distclean : clean
         - DELETE descrip.mms;*
 
 depend : descrip.mms
-descrip.mms : FORCE
 	@ ! {- output_off() if $disabled{makedepend}; "" -}
 	@ $(PERL) {- sourcefile("util", "add-depends.pl") -} "{- $config{makedep_scheme} -}"
 	@ ! {- output_on() if $disabled{makedepend}; "" -}
@@ -755,7 +754,16 @@ debug_logicals :
 
 # Building targets ###################################################
 
-configdata.pm : $(SRCDIR)Configure $(SRCDIR)config.com {- join(" ", @{$config{build_file_templates}}, @{$config{build_infos}}, @{$config{conf_files}}) -}
+descrip.mms : configdata.pm {- join(" ", @{$config{build_file_templates}}) -}
+	perl configdata.pm
+        @ WRITE SYS$OUTPUT "*************************************************"
+        @ WRITE SYS$OUTPUT "***                                           ***"
+        @ WRITE SYS$OUTPUT "***   Please run the same mms command again   ***"
+        @ WRITE SYS$OUTPUT "***                                           ***"
+        @ WRITE SYS$OUTPUT "*************************************************"
+        @ PIPE ( EXIT %X10000000 )
+
+configdata.pm : $(SRCDIR)Configure $(SRCDIR)config.com {- join(" ", @{$config{build_infos}}, @{$config{conf_files}}) -}
         perl configdata.pm -r
         @ WRITE SYS$OUTPUT "*************************************************"
         @ WRITE SYS$OUTPUT "***                                           ***"

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -599,7 +599,7 @@ distclean: clean
 
 # We check if any depfile is newer than Makefile and decide to
 # concatenate only if that is true.
-depend:
+depend: Makefile
 	@: {- output_off() if $disabled{makedepend}; "" -}
 	@$(PERL) $(SRCDIR)/util/add-depends.pl "{- $makedep_scheme -}"
 	@: {- output_on() if $disabled{makedepend}; "" -}
@@ -1371,13 +1371,13 @@ tar:
 
 link-utils: $(BLDDIR)/util/opensslwrap.sh $(BLDDIR)/apps/openssl.cnf
 
-$(BLDDIR)/util/opensslwrap.sh: configdata.pm
+$(BLDDIR)/util/opensslwrap.sh: Makefile
 	@if [ "$(SRCDIR)" != "$(BLDDIR)" ]; then \
 	    mkdir -p "$(BLDDIR)/util"; \
 	    ln -sf "../$(SRCDIR)/util/`basename "$@"`" "$(BLDDIR)/util"; \
 	fi
 
-$(BLDDIR)/apps/openssl.cnf: configdata.pm
+$(BLDDIR)/apps/openssl.cnf: Makefile
 	@if [ "$(SRCDIR)" != "$(BLDDIR)" ]; then \
 	    mkdir -p "$(BLDDIR)/apps"; \
 	    ln -sf "../$(SRCDIR)/apps/`basename "$@"`" "$(BLDDIR)/apps"; \
@@ -1387,7 +1387,8 @@ FORCE:
 
 # Building targets ###################################################
 
-libcrypto.pc libssl.pc openssl.pc: configdata.pm $(LIBS) {- join(" ",map { platform->sharedlib_simple($_) // platform->sharedlib_import($_) // platform->sharedlib($_) // () } @{$unified_info{libraries}}) -}
+libcrypto.pc libssl.pc openssl.pc: Makefile $(LIBS) {- join(" ",map { platform->sharedlib_simple($_) // platform->sharedlib_import($_) // platform->sharedlib($_) // () } @{$unified_info{libraries}}) -}
+
 libcrypto.pc:
 	@ ( echo 'prefix=$(INSTALLTOP)'; \
 	    echo 'exec_prefix=$${prefix}'; \
@@ -1439,10 +1440,22 @@ openssl.pc:
 	    echo 'Version: '$(VERSION); \
 	    echo 'Requires: libssl libcrypto' ) > openssl.pc
 
+Makefile: configdata.pm \
+          {- join(" \\\n" . ' ' x 10,
+                  fill_lines(" ", $COLUMNS - 10,
+                             @{$config{build_file_templates}})) -}
+	@echo "Detected changed: $?"
+	$(PERL) configdata.pm
+	@echo "**************************************************"
+	@echo "***                                            ***"
+	@echo "***   Please run the same make command again   ***"
+	@echo "***                                            ***"
+	@echo "**************************************************"
+	@false
+
 configdata.pm: $(SRCDIR)/Configure $(SRCDIR)/config \
                {- join(" \\\n" . ' ' x 15,
                        fill_lines(" ", $COLUMNS - 15,
-                                  @{$config{build_file_templates}},
                                   @{$config{build_infos}},
                                   @{$config{conf_files}})) -}
 	@echo "Detected changed: $?"

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -481,7 +481,7 @@ distclean: clean
 	-del /Q /F configdata.pm
 	-del /Q /F makefile
 
-depend:
+depend: makefile
 	@ {- output_off() if $disabled{makedepend}; "\@rem" -}
 	@ "$(PERL)" "$(SRCDIR)\util\add-depends.pl" "{- $target{makedep_scheme} -}"
 	@ {- output_on() if $disabled{makedepend}; "\@rem" -}
@@ -643,13 +643,23 @@ uninstall_image_docs:
 
 copy-utils: $(BLDDIR)\apps\openssl.cnf
 
-$(BLDDIR)\apps\openssl.cnf: configdata.pm
+$(BLDDIR)\apps\openssl.cnf: makefile
 	@if NOT EXIST "$(BLDDIR)\apps" mkdir "$(BLDDIR)\apps"
 	@if NOT "$(SRCDIR)"=="$(BLDDIR)" copy "$(SRCDIR)\apps\$(@F)" "$(BLDDIR)\apps"
 
 # Building targets ###################################################
 
-configdata.pm: "$(SRCDIR)\Configure" {- join(" ", map { '"'.$_.'"' } @{$config{build_file_templates}}, @{$config{build_infos}}, @{$config{conf_files}}) -}
+makefile: configdata.pm {- join(" ", map { '"'.$_.'"' } @{$config{build_file_templates}}) -}
+	@$(ECHO) "Detected changed: $?"
+	"$(PERL)" configdata.pm
+	@$(ECHO) "**************************************************"
+	@$(ECHO) "***                                            ***"
+	@$(ECHO) "***   Please run the same make command again   ***"
+	@$(ECHO) "***                                            ***"
+	@$(ECHO) "**************************************************"
+	@exit 1
+
+configdata.pm: "$(SRCDIR)\Configure" {- join(" ", map { '"'.$_.'"' } @{$config{build_infos}}, @{$config{conf_files}}) -}
 	@$(ECHO) "Detected changed: $?"
 	"$(PERL)" configdata.pm -r
 	@$(ECHO) "**************************************************"


### PR DESCRIPTION
Before PR #15310, which reworked how build files (Makefile, ...) were
generated, everything was done when configuring, so configdata.pm
could depend on build file templates and we'd get away with it.

However, since building configdata.pm is now independent of the build
file templates, that dependency is unnecessary, and would lead to
surprises of the build file template is updated, with an unexpected
full reconfiguration as a result, when all that's needed is to run
configdata.pm with no flags to get the build file re-generated.

This change is therefore a completion of what was forgotten in #15310.
