### PR TITLE
Fix a failure in sslapitest

### DIFF
--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -8091,7 +8091,7 @@ static int test_cert_cb_int(int prot, int tst)
         cert_cb_cnt = 0;
 
     if (tst == 2) {
-        snictx = SSL_CTX_new(TLS_server_method());
+        snictx = SSL_CTX_new_ex(libctx, NULL, TLS_server_method());
         if (!TEST_ptr(snictx))
             goto end;
     }


### PR DESCRIPTION
The SNI test in test_cert_cb_int() was always failing because it used
SSL_CTX_new() instead of SSL_CTX_new_ex() and was therefore not using the
correct libctx. PR #17739 amended the test to check the return value from
SSL_CTX_new() which made the failure obvious.

Fixes #17757

Marking this as urgent because the build is currently broken.