### PR TITLE
Add ASYNC_set_mem_functions ASYNC_get_mem_functions

### DIFF
--- a/crypto/async/arch/async_null.c
+++ b/crypto/async/arch/async_null.c
@@ -16,6 +16,21 @@ int ASYNC_is_capable(void)
     return 0;
 }
 
+int ASYNC_set_mem_functions(ASYNC_stack_alloc_fn alloc_fn,
+                            ASYNC_stack_free_fn free_fn)
+{
+    return 0;
+}
+
+void ASYNC_get_mem_functions(ASYNC_stack_alloc_fn *alloc_fn,
+                             ASYNC_stack_free_fn *free_fn)
+{
+    if (alloc_fn != NULL)
+        *alloc_fn = NULL;
+    if (free_fn != NULL)
+        *free_fn = NULL;
+}
+
 void async_local_cleanup(void)
 {
 }

--- a/crypto/async/arch/async_null.h
+++ b/crypto/async/arch/async_null.h
@@ -26,5 +26,7 @@ typedef struct async_fibre_st {
 # define async_fibre_makecontext(c)             0
 # define async_fibre_free(f)
 # define async_fibre_init_dispatcher(f)
+# define async_local_init()                     1
+# define async_local_deinit()
 
 #endif

--- a/crypto/async/arch/async_posix.c
+++ b/crypto/async/arch/async_posix.c
@@ -14,6 +14,7 @@
 
 # include <stddef.h>
 # include <unistd.h>
+# include <openssl/err.h>
 
 #define STACKSIZE       32768
 
@@ -45,6 +46,7 @@ int async_fibre_makecontext(async_fibre *fibre)
             makecontext(&fibre->fibre, async_start_func, 0);
             return 1;
         }
+        ERR_raise(ERR_LIB_ASYNC, ERR_R_MALLOC_FAILURE);
     } else {
         fibre->fibre.uc_stack.ss_sp = NULL;
     }

--- a/crypto/async/arch/async_posix.h
+++ b/crypto/async/arch/async_posix.h
@@ -61,6 +61,9 @@ typedef struct async_fibre_st {
 #  endif
 } async_fibre;
 
+int async_local_init(void);
+void async_local_deinit(void);
+
 static ossl_inline int async_fibre_swapcontext(async_fibre *o, async_fibre *n, int r)
 {
 #  ifdef USE_SWAPCONTEXT

--- a/crypto/async/arch/async_win.c
+++ b/crypto/async/arch/async_win.c
@@ -20,6 +20,21 @@ int ASYNC_is_capable(void)
     return 1;
 }
 
+int ASYNC_set_mem_functions(ASYNC_stack_alloc_fn alloc_fn,
+                            ASYNC_stack_free_fn free_fn)
+{
+    return 0;
+}
+
+void ASYNC_get_mem_functions(ASYNC_stack_alloc_fn *alloc_fn,
+                             ASYNC_stack_free_fn *free_fn)
+{
+    if (alloc_fn != NULL)
+        *alloc_fn = NULL;
+    if (free_fn != NULL)
+        *free_fn = NULL;
+}
+
 void async_local_cleanup(void)
 {
     async_ctx *ctx = async_get_ctx();

--- a/crypto/async/arch/async_win.h
+++ b/crypto/async/arch/async_win.h
@@ -37,6 +37,8 @@ typedef struct async_fibre_st {
 # endif
 
 # define async_fibre_free(f)             (DeleteFiber((f)->fibre))
+# define async_local_init()              1
+# define async_local_deinit()
 
 int async_fibre_init_dispatcher(async_fibre *fibre);
 VOID CALLBACK async_start_func_win(PVOID unused);

--- a/crypto/async/async.c
+++ b/crypto/async/async.c
@@ -340,13 +340,14 @@ int async_init(void)
         return 0;
     }
 
-    return 1;
+    return async_local_init();
 }
 
 void async_deinit(void)
 {
     CRYPTO_THREAD_cleanup_local(&ctxkey);
     CRYPTO_THREAD_cleanup_local(&poolkey);
+    async_local_deinit();
 }
 
 int ASYNC_init_thread(size_t max_size, size_t init_size)

--- a/doc/man3/ASYNC_start_job.pod
+++ b/doc/man3/ASYNC_start_job.pod
@@ -4,7 +4,8 @@
 
 ASYNC_get_wait_ctx,
 ASYNC_init_thread, ASYNC_cleanup_thread, ASYNC_start_job, ASYNC_pause_job,
-ASYNC_get_current_job, ASYNC_block_pause, ASYNC_unblock_pause, ASYNC_is_capable
+ASYNC_get_current_job, ASYNC_block_pause, ASYNC_unblock_pause, ASYNC_is_capable,
+ASYNC_stack_alloc_fn, ASYNC_stack_free_fn, ASYNC_set_mem_functions, ASYNC_get_mem_functions
 - asynchronous job management functions
 
 =head1 SYNOPSIS
@@ -24,6 +25,13 @@ ASYNC_get_current_job, ASYNC_block_pause, ASYNC_unblock_pause, ASYNC_is_capable
  void ASYNC_unblock_pause(void);
 
  int ASYNC_is_capable(void);
+
+ typedef void *(*ASYNC_stack_alloc_fn)(size_t *num);
+ typedef void (*ASYNC_stack_free_fn)(void *addr);
+ int ASYNC_set_mem_functions(ASYNC_stack_alloc_fn alloc_fn,
+                             ASYNC_stack_free_fn free_fn);
+ void ASYNC_get_mem_functions(ASYNC_stack_alloc_fn *alloc_fn,
+                              ASYNC_stack_free_fn *free_fn);
 
 =head1 DESCRIPTION
 
@@ -146,6 +154,15 @@ occur.
 Some platforms cannot support async operations. The ASYNC_is_capable() function
 can be used to detect whether the current platform is async capable or not.
 
+Custom memory allocation functions are supported for the POSIX platform.
+Custom memory allocation functions allow alternative methods of allocating
+stack memory such as mmap, or using stack memory from the current thread.
+Using an ASYNC_stack_alloc_fn callback also allows manipulation of the stack
+size, which defaults to 32k.
+The stack size can be altered by allocating a stack of a size different to
+the requested size, and passing back the new stack size in the callback's I<*num>
+parameter.
+
 =head1 RETURN VALUES
 
 ASYNC_init_thread returns 1 on success or 0 otherwise.
@@ -164,6 +181,9 @@ ASYNC_get_wait_ctx() returns a pointer to the B<ASYNC_WAIT_CTX> for the job.
 
 ASYNC_is_capable() returns 1 if the current platform is async capable or 0
 otherwise.
+
+ASYNC_set_mem_functions returns 1 if custom stack allocators are supported by
+the current platform and no allocations have already occurred or 0 otherwise.
 
 =head1 NOTES
 

--- a/include/openssl/async.h
+++ b/include/openssl/async.h
@@ -80,6 +80,14 @@ int ASYNC_WAIT_CTX_clear_fd(ASYNC_WAIT_CTX *ctx, const void *key);
 
 int ASYNC_is_capable(void);
 
+typedef void *(*ASYNC_stack_alloc_fn)(size_t *num);
+typedef void (*ASYNC_stack_free_fn)(void *addr);
+
+int ASYNC_set_mem_functions(ASYNC_stack_alloc_fn alloc_fn,
+                            ASYNC_stack_free_fn free_fn);
+void ASYNC_get_mem_functions(ASYNC_stack_alloc_fn *alloc_fn,
+                             ASYNC_stack_free_fn *free_fn);
+
 int ASYNC_start_job(ASYNC_JOB **job, ASYNC_WAIT_CTX *ctx, int *ret,
                     int (*func)(void *), void *args, size_t size);
 int ASYNC_pause_job(void);

--- a/test/asynctest.c
+++ b/test/asynctest.c
@@ -18,6 +18,8 @@
 
 static int ctr = 0;
 static ASYNC_JOB *currjob = NULL;
+static int custom_alloc_used = 0;
+static int custom_free_used = 0;
 
 static int only_pause(void *args)
 {
@@ -413,6 +415,51 @@ static int test_ASYNC_start_job_ex(void)
     return ret;
 }
 
+static void *test_alloc_stack(size_t *num)
+{
+    custom_alloc_used = 1;
+    return OPENSSL_malloc(*num);
+}
+
+static void test_free_stack(void *addr)
+{
+    custom_free_used = 1;
+    OPENSSL_free(addr);
+}
+
+static int test_ASYNC_set_mem_functions(void)
+{
+    ASYNC_stack_alloc_fn alloc_fn;
+    ASYNC_stack_free_fn free_fn;
+
+    /* Not all platforms support this */
+    if (ASYNC_set_mem_functions(test_alloc_stack, test_free_stack) == 0) return 1;
+
+    ASYNC_get_mem_functions(&alloc_fn, &free_fn);
+
+    if ((alloc_fn != test_alloc_stack) || (free_fn != test_free_stack)) {
+        fprintf(stderr,
+                "test_ASYNC_set_mem_functions() - setting and retrieving custom allocators failed\n");
+        return 0;
+    }
+
+    if (!ASYNC_init_thread(1, 1)) {
+        fprintf(stderr,
+                "test_ASYNC_set_mem_functions() - failed initialising ctx pool\n");
+        return 0;
+    }
+    ASYNC_cleanup_thread();
+
+    if (!custom_alloc_used || !custom_free_used) {
+         fprintf(stderr,
+                "test_ASYNC_set_mem_functions() - custom allocation functions not used\n");
+
+        return 0;
+    }
+
+    return 1;
+}
+
 int main(int argc, char **argv)
 {
     if (!ASYNC_is_capable()) {
@@ -425,7 +472,8 @@ int main(int argc, char **argv)
                 || !test_ASYNC_get_current_job()
                 || !test_ASYNC_WAIT_CTX_get_all_fds()
                 || !test_ASYNC_block_pause()
-                || !test_ASYNC_start_job_ex()) {
+                || !test_ASYNC_start_job_ex()
+                || !test_ASYNC_set_mem_functions()) {
             return 1;
         }
     }

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5434,3 +5434,5 @@ BN_signed_lebin2bn                      ?	3_1_0	EXIST::FUNCTION:
 BN_signed_bn2lebin                      ?	3_1_0	EXIST::FUNCTION:
 BN_signed_native2bn                     ?	3_1_0	EXIST::FUNCTION:
 BN_signed_bn2native                     ?	3_1_0	EXIST::FUNCTION:
+ASYNC_set_mem_functions                 ?	3_1_0	EXIST::FUNCTION:
+ASYNC_get_mem_functions                 ?	3_1_0	EXIST::FUNCTION:

--- a/util/other.syms
+++ b/util/other.syms
@@ -137,6 +137,8 @@ custom_ext_free_cb                      datatype
 custom_ext_parse_cb                     datatype
 pem_password_cb                         datatype
 ssl_ct_validation_cb                    datatype
+ASYNC_stack_alloc_fn                    datatype
+ASYNC_stack_free_fn                     datatype
 #
 ASN1_BIT_STRING_digest                  define
 BIO_append_filename                     define


### PR DESCRIPTION
In our application we use the OpenSSL ASYNC_* API to jump out of verification and session load/store callbacks.

On the POSIX side, when creating a new context OpenSSL calls the standard OPENSSL_malloc and
OPENSSL_free functions are used to allocate memory for the stack passed into makecontext.

https://github.com/openssl/openssl/blob/1c0eede9827b0962f1d752fa4ab5d436fa039da4/crypto/async/arch/async_posix.c

There are several issues with this approach:

1.  On some systems stack memory must be page aligned.  The user provided allocation functions
    don't know the context in which the memory is being requested so can't ensure this.
2.  glibc recommends the stack be allocated with mmap and set to executable to allow trampoline
    functions to work correctly (unsure if this is relevant).
    https://www.gnu.org/software/libc/manual/html_node/System-V-contexts.html
3. Using heap memory for the stack means there's no guard page.  Overflowing the stack appears
    to cause silent memory corruption on both macOS and Linux.

The stack size is also currently fixed and requires OpenSSL recompilation to change.

This PR adds the following functions:

```c
int ASYNC_set_mem_functions(ASYNC_stack_alloc_fn alloc_fn,
                            ASYNC_stack_free_fn free_fn);
void ASYNC_get_mem_functions(ASYNC_stack_alloc_fn *alloc_fn,
                             ASYNC_stack_free_fn *free_fn);
```

The new functions mirror `CRYPTO_set_mem_functions` and `CRYPTO_get_mem_functions` and allow setting custom stack allocation functions at a global/application wide level.

In addition to allowing alternative allocation functions for stack memory to be used, the `ASYNC_stack_alloc_fn` callback allows changing the stack size allocated, by passing back a new value in its `*num` parameter.
