### PR TITLE
Change `strlen' argument name to `strlength' to avoid c++ reserved words.

### DIFF
--- a/crypto/o_str.c
+++ b/crypto/o_str.c
@@ -215,7 +215,7 @@ unsigned char *OPENSSL_hexstr2buf(const char *str, long *buflen)
     return ossl_hexstr2buf_sep(str, buflen, DEFAULT_SEPARATOR);
 }
 
-static int buf2hexstr_sep(char *str, size_t str_n, size_t *strlen,
+static int buf2hexstr_sep(char *str, size_t str_n, size_t *strlength,
                           const unsigned char *buf, size_t buflen,
                           const char sep)
 {
@@ -226,8 +226,8 @@ static int buf2hexstr_sep(char *str, size_t str_n, size_t *strlen,
     int has_sep = (sep != CH_ZERO);
     size_t len = has_sep ? buflen * 3 : 1 + buflen * 2;
 
-    if (strlen != NULL)
-        *strlen = len;
+    if (strlength != NULL)
+        *strlength = len;
     if (str == NULL)
         return 1;
 
@@ -253,11 +253,11 @@ static int buf2hexstr_sep(char *str, size_t str_n, size_t *strlen,
     return 1;
 }
 
-int OPENSSL_buf2hexstr_ex(char *str, size_t str_n, size_t *strlen,
+int OPENSSL_buf2hexstr_ex(char *str, size_t str_n, size_t *strlength,
                           const unsigned char *buf, size_t buflen,
                           const char sep)
 {
-    return buf2hexstr_sep(str, str_n, strlen, buf, buflen, sep);
+    return buf2hexstr_sep(str, str_n, strlength, buf, buflen, sep);
 }
 
 char *ossl_buf2hexstr_sep(const unsigned char *buf, long buflen, char sep)

--- a/doc/man3/OPENSSL_hexchar2int.pod
+++ b/doc/man3/OPENSSL_hexchar2int.pod
@@ -15,8 +15,9 @@ OPENSSL_buf2hexstr_ex, OPENSSL_buf2hexstr
  int OPENSSL_hexstr2buf_ex(unsigned char *buf, size_t buf_n, long *buflen,
                            const char *str, const char sep);
  unsigned char *OPENSSL_hexstr2buf(const char *str, long *len);
- int OPENSSL_buf2hexstr_ex(char *str, size_t str_n, size_t *strlen,
-                           const unsigned char *buf, long buflen, const char sep);
+ int OPENSSL_buf2hexstr_ex(char *str, size_t str_n, size_t *strlength,
+                           const unsigned char *buf, long buflen,
+                           const char sep);
  char *OPENSSL_buf2hexstr(const unsigned char *buf, long buflen);
 
 =head1 DESCRIPTION
@@ -47,7 +48,7 @@ in the given I<str>.
 The character I<sep> is the separator between the bytes, setting this to '\0'
 means that there is no separator.
 I<str_n> gives the size of the of the string buffer.
-If I<strlen> is not NULL, it is filled in with the result length.
+If I<strlength> is not NULL, it is filled in with the result length.
 To find out how large the result will be, call this function with NULL
 for I<str>.
 

--- a/include/openssl/crypto.h.in
+++ b/include/openssl/crypto.h.in
@@ -125,7 +125,7 @@ int CRYPTO_atomic_load(uint64_t *val, uint64_t *ret, CRYPTO_RWLOCK *lock);
 size_t OPENSSL_strlcpy(char *dst, const char *src, size_t siz);
 size_t OPENSSL_strlcat(char *dst, const char *src, size_t siz);
 size_t OPENSSL_strnlen(const char *str, size_t maxlen);
-int OPENSSL_buf2hexstr_ex(char *str, size_t str_n, size_t *strlen,
+int OPENSSL_buf2hexstr_ex(char *str, size_t str_n, size_t *strlength,
                           const unsigned char *buf, size_t buflen,
                           const char sep);
 char *OPENSSL_buf2hexstr(const unsigned char *buf, long buflen);


### PR DESCRIPTION

Fixes #17753


- [x] documentation is added or updated
- [ ] tests are added or updated
