### PR TITLE
Perturb the malloc output during tests

### DIFF
--- a/test/run_tests.pl
+++ b/test/run_tests.pl
@@ -39,6 +39,11 @@ $ENV{OPENSSL_MODULES} = rel2abs(catdir($bldtop, "providers"));
 $ENV{OPENSSL_ENGINES} = rel2abs(catdir($bldtop, "engines"));
 $ENV{CTLOG_FILE} = rel2abs(catfile($srctop, "test", "ct", "log_list.cnf"));
 
+#On platforms that support this, this will ensure malloc returns data that is
+#set to a non-zero value. Can be helpful for detecting uninitialized reads in
+#some situations.
+$ENV{'MALLOC_PERTURB_'} = '128';
+
 my %tapargs =
     ( verbosity         => $ENV{HARNESS_VERBOSE} ? 1 : 0,
       lib               => [ $libdir ],

--- a/test/run_tests.pl
+++ b/test/run_tests.pl
@@ -39,10 +39,10 @@ $ENV{OPENSSL_MODULES} = rel2abs(catdir($bldtop, "providers"));
 $ENV{OPENSSL_ENGINES} = rel2abs(catdir($bldtop, "engines"));
 $ENV{CTLOG_FILE} = rel2abs(catfile($srctop, "test", "ct", "log_list.cnf"));
 
-#On platforms that support this, this will ensure malloc returns data that is
-#set to a non-zero value. Can be helpful for detecting uninitialized reads in
-#some situations.
-$ENV{'MALLOC_PERTURB_'} = '128';
+# On platforms that support this, this will ensure malloc returns data that is
+# set to a non-zero value. Can be helpful for detecting uninitialized reads in
+# some situations.
+$ENV{'MALLOC_PERTURB_'} = '128' if !defined $ENV{'MALLOC_PERTURB_'};
 
 my %tapargs =
     ( verbosity         => $ENV{HARNESS_VERBOSE} ? 1 : 0,


### PR DESCRIPTION
Set the environment variable MALLOC_PERTURB_ during tests to perturb the
output from OPENSSL_malloc() calls (see the mallopt man page for details
about this environment variable). This could be a low cost way of spotting
uninit reads in "make test" runs in some situations.

In tests I have found it to be a little unreliable (sometimes it seemed to
not perturb the output for inexplicable reasons) - but since this is easy
to implement I think it is worthwhile.
