### PR TITLE
Improve post-2038 compatibility of time_t usage

### DIFF
--- a/apps/s_time.c
+++ b/apps/s_time.c
@@ -124,8 +124,9 @@ int s_time_main(int argc, char **argv)
     char *host = SSL_CONNECT_NAME, *certfile = NULL, *keyfile = NULL, *prog;
     double totalTime = 0.0;
     int noCApath = 0, noCAfile = 0, noCAstore = 0;
-    int maxtime = SECONDS, nConn = 0, perform = 3, ret = 1, i, st_bugs = 0;
-    long bytes_read = 0, finishtime = 0;
+    time_t maxtime = SECONDS, finishtime = 0;
+    int  nConn = 0, perform = 3, ret = 1, i, st_bugs = 0;
+    long bytes_read = 0;
     OPTION_CHOICE o;
     int min_version = 0, max_version = 0, ver, buf_len, fd;
     size_t buf_size;
@@ -265,15 +266,16 @@ int s_time_main(int argc, char **argv)
     }
     if (!(perform & 1))
         goto next;
-    printf("Collecting connection statistics for %d seconds\n", maxtime);
+    printf("Collecting connection statistics for %lld seconds\n",
+           (long long)maxtime);
 
     /* Loop and time how long it takes to make connections */
 
     bytes_read = 0;
-    finishtime = (long)time(NULL) + maxtime;
+    finishtime = time(NULL) + maxtime;
     tm_Time_F(START);
     for (;;) {
-        if (finishtime < (long)time(NULL))
+        if (finishtime < time(NULL))
             break;
 
         if ((scon = doConnection(NULL, host, ctx)) == NULL)
@@ -310,13 +312,12 @@ int s_time_main(int argc, char **argv)
     }
     totalTime += tm_Time_F(STOP); /* Add the time for this iteration */
 
-    i = (int)((long)time(NULL) - finishtime + maxtime);
     printf
         ("\n\n%d connections in %.2fs; %.2f connections/user sec, bytes read %ld\n",
          nConn, totalTime, ((double)nConn / totalTime), bytes_read);
     printf
-        ("%d connections in %ld real seconds, %ld bytes read per connection\n",
-         nConn, (long)time(NULL) - finishtime + maxtime,
+        ("%d connections in %lld real seconds, %ld bytes read per connection\n",
+         nConn, (long long)(time(NULL) - finishtime + maxtime),
          nConn > 0 ? bytes_read / nConn : 0l);
 
     /*
@@ -348,14 +349,14 @@ int s_time_main(int argc, char **argv)
     nConn = 0;
     totalTime = 0.0;
 
-    finishtime = (long)time(NULL) + maxtime;
+    finishtime = time(NULL) + maxtime;
 
     printf("starting\n");
     bytes_read = 0;
     tm_Time_F(START);
 
     for (;;) {
-        if (finishtime < (long)time(NULL))
+        if (finishtime < time(NULL))
             break;
 
         if ((doConnection(scon, host, ctx)) == NULL)
@@ -395,11 +396,11 @@ int s_time_main(int argc, char **argv)
          nConn, totalTime, ((double)nConn / totalTime), bytes_read);
     if (nConn > 0)
         printf
-            ("%d connections in %ld real seconds, %ld bytes read per connection\n",
-             nConn, (long)time(NULL) - finishtime + maxtime, bytes_read / nConn);
+            ("%d connections in %lld real seconds, %ld bytes read per connection\n",
+             nConn, (long long)(time(NULL) - finishtime + maxtime), bytes_read / nConn);
     else
-        printf("0 connections in %ld real seconds\n",
-               (long)time(NULL) - finishtime + maxtime);
+        printf("0 connections in %lld real seconds\n",
+               (long long)(time(NULL) - finishtime + maxtime));
     ret = 0;
 
  end:

--- a/ssl/bio_ssl.c
+++ b/ssl/bio_ssl.c
@@ -30,7 +30,7 @@ typedef struct bio_ssl_st {
     unsigned long renegotiate_count;
     size_t byte_count;
     unsigned long renegotiate_timeout;
-    unsigned long last_time;
+    time_t last_time;
 } BIO_SSL;
 
 static const BIO_METHOD methods_sslp = {
@@ -117,10 +117,10 @@ static int ssl_read(BIO *b, char *buf, size_t size, size_t *readbytes)
             }
         }
         if ((sb->renegotiate_timeout > 0) && (!r)) {
-            unsigned long tm;
+            time_t tm;
 
-            tm = (unsigned long)time(NULL);
-            if (tm > sb->last_time + sb->renegotiate_timeout) {
+            tm = time(NULL);
+            if (tm - sb->last_time > (time_t)sb->renegotiate_timeout) {
                 sb->last_time = tm;
                 sb->num_renegotiates++;
                 SSL_renegotiate(ssl);
@@ -186,10 +186,10 @@ static int ssl_write(BIO *b, const char *buf, size_t size, size_t *written)
             }
         }
         if ((bs->renegotiate_timeout > 0) && (!r)) {
-            unsigned long tm;
+            time_t tm;
 
-            tm = (unsigned long)time(NULL);
-            if (tm > bs->last_time + bs->renegotiate_timeout) {
+            tm = time(NULL);
+            if (tm - bs->last_time > (time_t)bs->renegotiate_timeout) {
                 bs->last_time = tm;
                 bs->num_renegotiates++;
                 SSL_renegotiate(ssl);
@@ -268,7 +268,7 @@ static long ssl_ctrl(BIO *b, int cmd, long num, void *ptr)
         if (num < 60)
             num = 5;
         bs->renegotiate_timeout = (unsigned long)num;
-        bs->last_time = (unsigned long)time(NULL);
+        bs->last_time = time(NULL);
         break;
     case BIO_C_SET_SSL_RENEGOTIATE_BYTES:
         ret = bs->renegotiate_count;


### PR DESCRIPTION
The Unix epoch will overflow a signed 32-bit integer in the year 2038,
and many systems are updating time_t to be 64-bits or to treat the time
as an unsigned integer as a result.  To protect openssl against such
issues:

- update s_time's internal logic to consistently use time_t for tracking
  timeouts

- update BIO_SSL to use a time_t to track the last renegotiation time,
  rather than the ad hoc 'unsigned long'.  The structure is private to
  bio_ssl.c and so there is no external ABI breakage

