### PR TITLE
s_server: Do not use SSL_sendfile when KTLS is not being used

### DIFF
--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -3340,7 +3340,7 @@ static int www_body(int s, int stype, int prot, unsigned char *context)
             }
             /* send the file */
 #ifndef OPENSSL_NO_KTLS
-            if (use_sendfile) {
+            if (use_sendfile && BIO_get_ktls_send(SSL_get_wbio(con))) {
                 FILE *fp = NULL;
                 int fd;
                 struct stat st;

--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -3010,6 +3010,7 @@ static int www_body(int s, int stype, int prot, unsigned char *context)
     int total_bytes = 0;
 #endif
     int width;
+    int use_sendfile_for_req = use_sendfile;
     fd_set readfds;
     const char *opmode;
 #ifdef CHARSET_EBCDIC
@@ -3340,7 +3341,11 @@ static int www_body(int s, int stype, int prot, unsigned char *context)
             }
             /* send the file */
 #ifndef OPENSSL_NO_KTLS
-            if (use_sendfile && BIO_get_ktls_send(SSL_get_wbio(con))) {
+            if (use_sendfile_for_req && !BIO_get_ktls_send(SSL_get_wbio(con))) {
+                BIO_printf(bio_err, "Warning: sendfile requested but KTLS is not available\n");
+                use_sendfile_for_req = 0;
+            }
+            if (use_sendfile) {
                 FILE *fp = NULL;
                 int fd;
                 struct stat st;

--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -3010,7 +3010,9 @@ static int www_body(int s, int stype, int prot, unsigned char *context)
     int total_bytes = 0;
 #endif
     int width;
+#ifndef OPENSSL_NO_KTLS
     int use_sendfile_for_req = use_sendfile;
+#endif
     fd_set readfds;
     const char *opmode;
 #ifdef CHARSET_EBCDIC
@@ -3345,7 +3347,7 @@ static int www_body(int s, int stype, int prot, unsigned char *context)
                 BIO_printf(bio_err, "Warning: sendfile requested but KTLS is not available\n");
                 use_sendfile_for_req = 0;
             }
-            if (use_sendfile) {
+            if (use_sendfile_for_req) {
                 FILE *fp = NULL;
                 int fd;
                 struct stat st;


### PR DESCRIPTION
Fix a bug in `openssl s_server -WWW` where it would attempt to invoke `SSL_sendfile` if `-ktls -sendfile` was passed on the command line, even if KTLS has not actually been enabled, for example because it is not supported by the host. Since `SSL_sendfile` is only supported when KTLS is actually being used, this resulted in a failure to serve requests.

Fixes #17503.

Taking advice on how to test this, as most usage of `s_server` in the test suite seems to be incidental via TLSProxy rather than testing of `s_server` itself.