### PR TITLE
Fix build issue with aes-gcm-armv8-unroll8_64.S on older aarch64 assemblers

### DIFF
--- a/crypto/modes/asm/aes-gcm-armv8-unroll8_64.pl
+++ b/crypto/modes/asm/aes-gcm-armv8-unroll8_64.pl
@@ -174,7 +174,7 @@ $code=<<___;
 
 #if __ARM_MAX_ARCH__>=8
 ___
-$code.=".arch   armv8.2-a+crypto\n.arch_extension sha3\n.text\n";
+$code.=".arch   armv8.2-a+crypto\n.text\n";
 
 $input_ptr="x0";  #argument block
 $bit_length="x1";


### PR DESCRIPTION

The EOR3 instruction is implemented with .inst, and the code here is enabled
using run-time detection of the CPU capabilities, so no need to explicitly
ask for the sha3 extension.

Fixes #17773

