### PR TITLE
Enable openssl req -x509 to create certificates from CSRs (3.0)

### DIFF
--- a/apps/req.c
+++ b/apps/req.c
@@ -775,8 +775,9 @@ int req_main(int argc, char **argv)
         }
     }
     if (newreq || gen_x509) {
-        if (pkey == NULL /* can happen only if !newreq */) {
-            BIO_printf(bio_err, "Must provide a signature key using -key\n");
+        if (CAcert == NULL && pkey == NULL) {
+            BIO_printf(bio_err, "Must provide a signature key using -key or"
+                " provide -CA / -CAkey\n");
             goto end;
         }
 

--- a/test/recipes/25-test_req.t
+++ b/test/recipes/25-test_req.t
@@ -15,7 +15,7 @@ use OpenSSL::Test qw/:DEFAULT srctop_file/;
 
 setup("test_req");
 
-plan tests => 43;
+plan tests => 44;
 
 require_ok(srctop_file('test', 'recipes', 'tconversion.pl'));
 
@@ -48,6 +48,11 @@ ok(!run(app([@addext_args, "-addext", $val, "-addext", $val])));
 ok(!run(app([@addext_args, "-addext", $val, "-addext", $val2])));
 ok(!run(app([@addext_args, "-addext", $val, "-addext", $val3])));
 ok(!run(app([@addext_args, "-addext", $val2, "-addext", $val3])));
+
+# If a CSR is provided with neither of -key or -CA/-CAkey, this should fail.
+ok(!run(app(["openssl", "req", "-x509",
+                "-in", srctop_file(@certs, "x509-check.csr"),
+                "-out", "testreq.pem"])));
 
 subtest "generating alt certificate requests with RSA" => sub {
     plan tests => 3;
@@ -383,7 +388,8 @@ sub generate_cert {
     my $ca_key = srctop_file(@certs, "ca-key.pem");
     my $key = $is_ca ? $ca_key : srctop_file(@certs, "ee-key.pem");
     my @cmd = ("openssl", "req", "-config", "", "-x509",
-               "-key", $key, "-subj", "/CN=$cn", @_, "-out", $cert);
+               "-subj", "/CN=$cn", @_, "-out", $cert);
+    push(@cmd, ("-key", $key)) if $ss;
     push(@cmd, ("-CA", $ca_cert, "-CAkey", $ca_key)) unless $ss;
     ok(run(app([@cmd])), "generate $cert");
 }
@@ -442,12 +448,14 @@ generate_cert($cert, "-addext", "keyUsage = keyCertSign");
 #TODO strict_verify($cert, 1); # should be accepted because RFC 5280 does not apply
 
 $cert = "v3_EE_default_KIDs.pem";
-generate_cert($cert, "-addext", "keyUsage = dataEncipherment");
+generate_cert($cert, "-addext", "keyUsage = dataEncipherment",
+              "-key", srctop_file(@certs, "ee-key.pem"));
 cert_ext_has_n_different_lines($cert, 4, $SKID_AKID); # SKID != AKID
 strict_verify($cert, 1, $ca_cert);
 
 $cert = "v3_EE_no_AKID.pem";
-generate_cert($cert, "-addext", "authorityKeyIdentifier = none");
+generate_cert($cert, "-addext", "authorityKeyIdentifier = none",
+              "-key", srctop_file(@certs, "ee-key.pem"));
 has_SKID($cert, 1);
 has_AKID($cert, 0);
 strict_verify($cert, 0, $ca_cert);


### PR DESCRIPTION
`openssl req -x509` has code allowing it to generate certificates from CSRs as a replacement for `openssl x509`, but a bug prevents it from working properly. -CA and -CAkey can now be passed to generate a CA-signed certificate as documented in openssl-req(1).

Regression testing has been added for `openssl req`.

Backport of #17782 to 3.0.

Fixes #17736.