### PR TITLE
(1.1.1) Fix issue where OBJ_nid2obj doesn't always raise an error

### DIFF
--- a/crypto/objects/obj_dat.c
+++ b/crypto/objects/obj_dat.c
@@ -228,9 +228,10 @@ ASN1_OBJECT *OBJ_nid2obj(int n)
             return NULL;
         }
         return (ASN1_OBJECT *)&(nid_objs[n]);
-    } else if (added == NULL)
+    } else if (added == NULL) {
+        OBJerr(OBJ_F_OBJ_NID2OBJ, OBJ_R_UNKNOWN_NID);
         return NULL;
-    else {
+    } else {
         ad.type = ADDED_NID;
         ad.obj = &ob;
         ob.nid = n;

--- a/test/asn1_internal_test.c
+++ b/test/asn1_internal_test.c
@@ -107,9 +107,36 @@ static int test_standard_methods(void)
     return 0;
 }
 
+/**********************************************************************
+ *
+ * Regression test for issue where OBJ_nid2obj does not raise
+ * an error when a NID is not registered.
+ *
+ ***/
+static int test_nid2obj_nonexist(void)
+{
+    ASN1_OBJECT *obj;
+    unsigned long err;
+
+    obj = OBJ_nid2obj(INT_MAX);
+    if (!TEST_true(obj == NULL))
+        return 0;
+
+    err = ERR_get_error();
+
+    if (!TEST_int_eq(ERR_GET_FUNC(err), OBJ_F_OBJ_NID2OBJ))
+        return 0;
+
+    if (!TEST_int_eq(ERR_GET_REASON(err), OBJ_R_UNKNOWN_NID))
+        return 0;
+
+    return 1;
+}
+
 int setup_tests(void)
 {
     ADD_TEST(test_tbl_standard);
     ADD_TEST(test_standard_methods);
+    ADD_TEST(test_nid2obj_nonexist);
     return 1;
 }


### PR DESCRIPTION
This was previously fixed in 3.0 but not 1.1.

Fixes #13008. Regression test added.