### PR TITLE
Document bug in openssl cms -binary (1.1.1)

### DIFF
--- a/doc/man1/cms.pod
+++ b/doc/man1/cms.pod
@@ -719,6 +719,9 @@ the list of permitted ciphers in a database and only use those.
 
 No revocation checking is done on the signer's certificate.
 
+The B<-binary> option does not work correctly when processing text input which
+(contrary to the S/MIME specification) uses LF rather than CRLF line endings.
+
 =head1 HISTORY
 
 The use of multiple B<-signer> options and the B<-resign> command were first


### PR DESCRIPTION
Documents a bug in `openssl cms -binary` for 1.1 whereby it cannot process input using LF line endings correctly. Binary input processing was reworked substantially for 3.0 and backporting these changes doesn't appear reasonable.

Fixes #17797.