### PR TITLE
Fix test failure when testing with Test::Harness

### DIFF
--- a/test/run_tests.pl
+++ b/test/run_tests.pl
@@ -314,7 +314,12 @@ my $harness = $package->new(\%tapargs);
 my $ret =
     $harness->runtests(map { [ abs2rel($_, rel2abs(curdir())), basename($_) ] }
                        @preps);
-die if $ret->has_errors;
+
+# If using the pre-TAP test harness the above call will simply die if any
+# test fails. For TAP::Parser::Aggregator we have to check ourselves,
+# but $ret->has_errors is only available for TAP::Parser::Aggregator.
+die if ref($ret) eq "TAP::Parser::Aggregator" && $ret->has_errors;
+
 $ret =
     $harness->runtests(map { [ abs2rel($_, rel2abs(curdir())), basename($_) ] }
                        sort { reorder($a) cmp reorder($b) } keys %tests);

--- a/test/run_tests.pl
+++ b/test/run_tests.pl
@@ -315,14 +315,11 @@ my $ret =
     $harness->runtests(map { [ abs2rel($_, rel2abs(curdir())), basename($_) ] }
                        @preps);
 
-# If using the pre-TAP test harness the above call will simply die if any
-# test fails. For TAP::Parser::Aggregator we have to check ourselves,
-# but $ret->has_errors is only available for TAP::Parser::Aggregator.
-die if ref($ret) eq "TAP::Parser::Aggregator" && $ret->has_errors;
-
-$ret =
-    $harness->runtests(map { [ abs2rel($_, rel2abs(curdir())), basename($_) ] }
-                       sort { reorder($a) cmp reorder($b) } keys %tests);
+if (ref($ret) ne "TAP::Parser::Aggregator" || !$ret->has_errors) {
+    $ret =
+        $harness->runtests(map { [ abs2rel($_, rel2abs(curdir())), basename($_) ] }
+                           sort { reorder($a) cmp reorder($b) } keys %tests);
+}
 
 # If this is a TAP::Parser::Aggregator, $ret->has_errors is the count of
 # tests that failed.  We don't bother with that exact number, just exit


### PR DESCRIPTION
Fixes an issue where, when the test suite was being run with the older Test::Harness package, the test suite would not complete correctly due to evaluation of `$harness->runtests()->has_errors`, which is only available for the newer TAP::Parser::Aggregator code path.

Fixes #17818.