### PR TITLE
adding external oqsprovider testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,6 +277,8 @@ jobs:
       run: make test TESTS="test_external_krb5"
     - name: test external_tlsfuzzer
       run: make test TESTS="test_external_tlsfuzzer"
+    - name: test external oqs-provider
+      run: make test TESTS="test_external_oqsprovider"
 
   external-test-pyca:
     runs-on: ubuntu-latest

--- a/.gitmodules
+++ b/.gitmodules
@@ -22,3 +22,6 @@
 [submodule "tlslite-ng"]
 	path = tlslite-ng
 	url = https://github.com/tlsfuzzer/tlslite-ng
+[submodule "oqs-provider"]
+	path = oqs-provider
+	url = https://github.com/open-quantum-safe/oqs-provider.git

--- a/test/README-external.md
+++ b/test/README-external.md
@@ -117,9 +117,8 @@ example to exclude the "mceliece" and "kyber" algorithms execute
 
     OQS_SKIP_TESTS=mceliece,kyber make test TESTS=test_external_oqsprovider
 
-The names of all supported quantum-safe algorithms are available at 
-https://github.com/open-quantum-safe/openssl#supported-algorithms
-
+The names of all supported quantum-safe algorithms are available at
+<https://github.com/open-quantum-safe/openssl#supported-algorithms>
 
 Updating test suites
 ====================

--- a/test/README-external.md
+++ b/test/README-external.md
@@ -87,6 +87,40 @@ explicitly run (with more debugging):
 
     $ make test VERBOSE=1 TESTS=test_external_gost_engine
 
+OQSprovider test suite
+======================
+
+Much like the PYCA/Cryptography test suite, this builds and runs the OQS
+(OpenQuantumSafe -- www.openquantumsafe.org) provider tests against the
+local OpenSSL build.
+
+You will need a git checkout of oqsprovider at the top level:
+
+    $ git submodule update --init
+
+Then configure/build OpenSSL enabling external tests:
+
+    $ ./config shared enable-external-tests
+    $ make
+
+oqsprovider requires CMake for the build process.
+
+OQSprovider tests will then be run as part of the rest of the suite, or can be
+explicitly run (with more debugging):
+
+    $ make test VERBOSE=1 TESTS=test_external_oqsprovider
+
+The environment variable `OQS_SKIP_TESTS` can be set to select tests and
+algorithms to be skipped. If not set, the "rainbow" algorithm set as well as
+the (OQS-)OpenSSL1.1.1 compatibility tests will not be executed. So, for
+example to exclude the "mceliece" and "kyber" algorithms execute
+
+    OQS_SKIP_TESTS=mceliece,kyber make test TESTS=test_external_oqsprovider
+
+The names of all supported quantum-safe algorithms are available at 
+https://github.com/open-quantum-safe/openssl#supported-algorithms
+
+
 Updating test suites
 ====================
 

--- a/test/recipes/95-test_external_oqsprovider.t
+++ b/test/recipes/95-test_external_oqsprovider.t
@@ -1,0 +1,28 @@
+#! /usr/bin/env perl
+# Copyright 2022 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+
+use OpenSSL::Test;
+use OpenSSL::Test::Utils;
+use OpenSSL::Test qw/:DEFAULT data_file bldtop_dir srctop_dir cmdstr/;
+
+setup("test_external_oqsprovider");
+
+plan skip_all => "No external tests in this configuration"
+    if disabled("external-tests");
+plan skip_all => "oqsprovider tests not available on Windows or VMS"
+    if $^O =~ /^(VMS|MSWin32)$/;
+plan skip_all => "oqsprovider tests only available in a shared build"
+    if disabled("shared");
+plan skip_all => "oqsprovider tests not supported in out of tree builds"
+    if bldtop_dir() ne srctop_dir();
+
+plan tests => 1;
+
+ok(run(cmd(["sh", data_file("oqsprovider.sh")])),
+   "running oqsprovider tests");

--- a/test/recipes/95-test_external_oqsprovider_data/oqsprovider.sh
+++ b/test/recipes/95-test_external_oqsprovider_data/oqsprovider.sh
@@ -1,0 +1,68 @@
+#!/bin/sh
+#
+# Copyright 2022 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+#
+# OpenSSL external testing using the OQS provider
+#
+set -e
+
+PWD="$(pwd)"
+
+SRCTOP="$(cd $SRCTOP; pwd)"
+BLDTOP="$(cd $BLDTOP; pwd)"
+
+if [ "$SRCTOP" != "$BLDTOP" ] ; then
+    echo "Out of tree builds not supported with oqsprovider test!"
+    exit 1
+fi
+
+O_EXE="$BLDTOP/apps"
+O_BINC="$BLDTOP/include"
+O_SINC="$SRCTOP/include"
+O_LIB="$BLDTOP"
+
+unset OPENSSL_CONF
+
+export PATH="$O_EXE:$PATH"
+export LD_LIBRARY_PATH="$O_LIB:$LD_LIBRARY_PATH"
+export OPENSSL_ROOT_DIR="$O_LIB"
+
+# Check/Set openssl version
+OPENSSL_VERSION=`openssl version | cut -f 2 -d ' '`
+
+echo "------------------------------------------------------------------"
+echo "Testing OpenSSL using oqsprovider:"
+echo "   CWD:                $PWD"
+echo "   SRCTOP:             $SRCTOP"
+echo "   BLDTOP:             $BLDTOP"
+echo "   OPENSSL_ROOT_DIR:   $OPENSSL_ROOT_DIR"
+echo "   OpenSSL version:    $OPENSSL_VERSION"
+echo "------------------------------------------------------------------"
+
+if [ ! -d $SRCTOP/oqs-provider/oqs ]; then
+# disable rainbow family by default; all further config options listed at
+# https://github.com/open-quantum-safe/liboqs/wiki/Customizing-liboqs
+   cd $SRCTOP/oqs-provider && git clone --depth 1 --branch main https://github.com/open-quantum-safe/liboqs.git && cd liboqs && mkdir build && cd build && cmake -DOQS_ENABLE_SIG_RAINBOW=OFF -DCMAKE_INSTALL_PREFIX=$SRCTOP/oqs-provider/oqs .. && make && make install
+fi
+
+if [ ! -f $SRCTOP/oqs-provider/test/ssltestlib.c ]; then
+   cd $SRCTOP/oqs-provider && OPENSSL_BLDTOP=$BLDTOP ./scripts/preptests.sh
+fi
+
+echo "   CWD:                $PWD"
+cmake $SRCTOP/oqs-provider -DCMAKE_INCLUDE_PATH=$SRCTOP/oqs-provider/oqs -DCMAKE_PREFIX_PATH=$SRCTOP/oqs-provider/oqs -DOPENSSL_ROOT_DIR="$OPENSSL_ROOT_DIR" -DOPENSSL_BLDTOP=$BLDTOP -B _build && cmake --build _build
+export CTEST_OUTPUT_ON_FAILURE=1
+export HARNESS_OSSL_PREFIX=''
+export OPENSSL_APP="$O_EXE/openssl"
+if [ -z "$OQS_SKIP_TESTS" ]; then
+    export OQS_SKIP_TESTS="rainbow,111"
+fi
+export OPENSSL_MODULES=$PWD/_build/oqsprov
+export OQS_PROVIDER_TESTSCRIPTS=$SRCTOP/oqs-provider
+$SRCTOP/oqs-provider/scripts/runtests.sh

--- a/test/recipes/95-test_external_oqsprovider_data/oqsprovider.sh
+++ b/test/recipes/95-test_external_oqsprovider_data/oqsprovider.sh
@@ -48,11 +48,20 @@ echo "------------------------------------------------------------------"
 if [ ! -d $SRCTOP/oqs-provider/oqs ]; then
 # disable rainbow family by default; all further config options listed at
 # https://github.com/open-quantum-safe/liboqs/wiki/Customizing-liboqs
-   cd $SRCTOP/oqs-provider && git clone --depth 1 --branch main https://github.com/open-quantum-safe/liboqs.git && cd liboqs && mkdir build && cd build && cmake -DOQS_ENABLE_SIG_RAINBOW=OFF -DCMAKE_INSTALL_PREFIX=$SRCTOP/oqs-provider/oqs .. && make && make install
+(
+       cd $SRCTOP/oqs-provider \
+           && git clone --depth 1 --branch main https://github.com/open-quantum-safe/liboqs.git \
+           && cd liboqs \
+           && mkdir build \
+           && cd build \
+           && cmake -DOQS_ENABLE_SIG_RAINBOW=OFF -DCMAKE_INSTALL_PREFIX=$SRCTOP/oqs-provider/oqs .. \
+           && make \
+           && make install
+   )
 fi
 
 if [ ! -f $SRCTOP/oqs-provider/test/ssltestlib.c ]; then
-   cd $SRCTOP/oqs-provider && OPENSSL_BLDTOP=$BLDTOP ./scripts/preptests.sh
+   ( cd $SRCTOP/oqs-provider && OPENSSL_BLDTOP=$BLDTOP ./scripts/preptests.sh )
 fi
 
 echo "   CWD:                $PWD"


### PR DESCRIPTION
As per https://github.com/openssl/openssl/pull/17733#issuecomment-1055389417 adding [oqsprovider](https://github.com/open-quantum-safe/oqs-provider) as a submodule for (external) testing.