### PR TITLE
Some platforms don't have pthread_atfork

### DIFF
--- a/crypto/threads_pthread.c
+++ b/crypto/threads_pthread.c
@@ -261,26 +261,9 @@ int CRYPTO_atomic_load(uint64_t *val, uint64_t *ret, CRYPTO_RWLOCK *lock)
     return 1;
 }
 # ifndef FIPS_MODULE
-#  ifdef OPENSSL_SYS_UNIX
-
-static pthread_once_t fork_once_control = PTHREAD_ONCE_INIT;
-
-static void fork_once_func(void)
-{
-#   ifndef OPENSSL_NO_DEPRECATED_3_0
-    pthread_atfork(OPENSSL_fork_prepare,
-                   OPENSSL_fork_parent, OPENSSL_fork_child);
-#   endif
-}
-#  endif
-
 int openssl_init_fork_handlers(void)
 {
-#  ifdef OPENSSL_SYS_UNIX
-    if (pthread_once(&fork_once_control, fork_once_func) == 0)
-        return 1;
-#  endif
-    return 0;
+    return 1;
 }
 # endif /* FIPS_MODULE */
 


### PR DESCRIPTION
We've had a report of a linker failure on some platforms (this one was
linux ARM) that apparently did not have pthread_atfork. It's strange that
this has not been reported before but the simplest solution is just to
remove this from the library since it isn't really used anyway.

Currently it is called to set up the fork handlers OPENSSL_fork_prepare,
OPENSSL_fork_parent and OPENSSL_fork_child. However all of those functions
are no-ops. This is a remnant from earlier code that got removed. We can
safely remove it now.