### PR TITLE
Allow to *just* print key and IV of unstreamable ciphers

### DIFF
--- a/apps/enc.c
+++ b/apps/enc.c
@@ -334,7 +334,7 @@ int enc_main(int argc, char **argv)
     buff = app_malloc(EVP_ENCODE_LENGTH(bsize), "evp buffer");
 
     if (infile == NULL) {
-        if (!streamable) {
+        if (!streamable && printkey != 2) {  /* if just print key and exit, it's ok */
             BIO_printf(bio_err, "Unstreamable cipher mode\n");
             goto end;
         }


### PR DESCRIPTION
Allow to *just* print key and IV of unstreamable ciphers when no input file is given.

The behaviour of the command is not changed in a way that need documentation update.
It just fix inconsistency introduced with recent support of wrap (/unstreamable) modes (#17691)
