### PR TITLE
README: add link to migration_guide manual page [3.0]

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,8 @@ document.
  * [Notes on Perl](NOTES-PERL.md)
  * [Notes on Valgrind](NOTES-VALGRIND.md)
 
-Specific notes on upgrading to OpenSSL 3.0 from previous versions, as well as
-known issues are available on the [OpenSSL 3.0 Wiki] page.
+Specific notes on upgrading to OpenSSL 3.0 from previous versions can be found
+in the [migration_guide(7ossl)] manual page.
 
 Documentation
 =============
@@ -165,7 +165,7 @@ attempting to develop or distribute cryptographic code.
 Copyright
 =========
 
-Copyright (c) 1998-2021 The OpenSSL Project
+Copyright (c) 1998-2022 The OpenSSL Project
 
 Copyright (c) 1995-1998 Eric A. Young, Tim J. Hudson
 
@@ -193,9 +193,9 @@ All rights reserved.
     <https://wiki.openssl.org>
     "OpenSSL Wiki"
 
-[OpenSSL 3.0 Wiki]:
-    <https://wiki.openssl.org/index.php/OpenSSL_3.0>
-    "OpenSSL 3.0 Wiki"
+[migration_guide(7ossl)]:
+    <https://www.openssl.org/docs/man3.0/man7/migration_guide.html>
+    "OpenSSL Migration Guide"
 
 [RFC 8446]:
      <https://tools.ietf.org/html/rfc8446>


### PR DESCRIPTION
Cherry-pick of #17840, except for the link to the migration_guide, which points into man3.0 instead of manmaster.
