### PR TITLE
docs: correct manual page links for version 3.0

### DIFF
--- a/README-FIPS.md
+++ b/README-FIPS.md
@@ -64,4 +64,4 @@ Using the FIPS Module in applications
 Documentation about using the FIPS module is available on the [fips_module(7)]
 manual page.
 
- [fips_module(7)]: https://www.openssl.org/docs/manmaster/man7/fips_module.html
+ [fips_module(7)]: https://www.openssl.org/docs/man3.0/man7/fips_module.html

--- a/README-PROVIDERS.md
+++ b/README-PROVIDERS.md
@@ -20,7 +20,7 @@ distribute their own providers which can be added to OpenSSL dynamically.
 Documentation about writing providers is available on the [provider(7)]
 manual page.
 
- [provider(7)]: https://www.openssl.org/docs/manmaster/man7/provider.html
+ [provider(7)]: https://www.openssl.org/docs/man3.0/man7/provider.html
 
 The Default Provider
 --------------------
@@ -88,7 +88,7 @@ Providers to be loaded can be specified in the OpenSSL config file.
 See the [config(5)] manual page for information about how to configure
 providers via the config file, and how to automatically activate them.
 
- [config(5)]: https://www.openssl.org/docs/manmaster/man5/config.html
+ [config(5)]: https://www.openssl.org/docs/man3.0/man5/config.html
 
 The following is a minimal config file example to load and activate both
 the legacy and the default provider in the default library context.

--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ The manual pages for the master branch and all current stable releases are
 available online.
 
 - [OpenSSL master](https://www.openssl.org/docs/manmaster)
+- [OpenSSL 3.0](https://www.openssl.org/docs/man3.0)
 - [OpenSSL 1.1.1](https://www.openssl.org/docs/man1.1.1)
 
 Wiki

--- a/dev/release-aux/openssl-announce-pre-release.tmpl
+++ b/dev/release-aux/openssl-announce-pre-release.tmpl
@@ -15,7 +15,7 @@
    Specific notes on upgrading to OpenSSL $series from previous versions are
    available in the OpenSSL Migration Guide, here:
 
-        https://www.openssl.org/docs/manmaster/man7/migration_guide.html
+        https://www.openssl.org/docs/man3.0/man7/migration_guide.html
 
    The $label release is available for download via HTTPS and FTP from the
    following master locations (you can find the various FTP mirrors under


### PR DESCRIPTION
_(For consistency reasons; inspired by #17849)_