### PR TITLE
README: add missing link to OpenSSL 3.0 manual pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ The manual pages for the master branch and all current stable releases are
 available online.
 
 - [OpenSSL master](https://www.openssl.org/docs/manmaster)
+- [OpenSSL 3.0](https://www.openssl.org/docs/man3.0)
 - [OpenSSL 1.1.1](https://www.openssl.org/docs/man1.1.1)
 
 Wiki


### PR DESCRIPTION
_(Note: I didn't add a link for the [1.0.2 manual pages](https://www.openssl.org/docs/man1.0.2/), even though they have been restored recently, since 1.0.2 is EOL)_