### PR TITLE
EVP_MD performance fix (refcount cache contention)

### DIFF
--- a/crypto/evp/m_sigver.c
+++ b/crypto/evp/m_sigver.c
@@ -231,7 +231,7 @@ static int do_sigver_init(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx,
              * We're about to get a new digest so clear anything associated with
              * an old digest.
              */
-            evp_md_ctx_clear_digest(ctx, 1);
+            evp_md_ctx_clear_digest(ctx, 1, 0);
 
             /* legacy code support for engines */
             ERR_set_mark();

--- a/include/crypto/evp.h
+++ b/include/crypto/evp.h
@@ -900,7 +900,7 @@ int evp_set_default_properties_int(OSSL_LIB_CTX *libctx, const char *propq,
                                    int loadconfig, int mirrored);
 char *evp_get_global_properties_str(OSSL_LIB_CTX *libctx, int loadconfig);
 
-void evp_md_ctx_clear_digest(EVP_MD_CTX *ctx, int force);
+void evp_md_ctx_clear_digest(EVP_MD_CTX *ctx, int force, int keep_digest);
 
 /* Three possible states: */
 # define EVP_PKEY_STATE_UNKNOWN         0


### PR DESCRIPTION
Partial fix for #17064. Avoid excessive writes to the cache line containing the refcount for an EVP_MD object to avoid extreme cache contention when using a single EVP_MD at high frequency on multiple threads. This changes performance in 3.0 from being double that of 1.1 to only slightly higher than that of 1.1.