### PR TITLE
Fixed decoration prefix for some assembler labels (win64 related) in aes-gcm-avx512.pl for mingw64 build.

### DIFF
--- a/crypto/modes/asm/aes-gcm-avx512.pl
+++ b/crypto/modes/asm/aes-gcm-avx512.pl
@@ -4767,7 +4767,7 @@ ___
 .align  8
 .L${func_name}_seh_info:
     .byte   1   # version 1, no flags
-    .byte   \$L\$${func_name}_seh_prolog_end-\$L\$${func_name}_seh_begin
+    .byte   .L${func_name}_seh_prolog_end-.L${func_name}_seh_begin
     .byte   31 # num_slots = 1*8 + 2 + 1 + 2*10
     # FR = rbp; Offset from RSP = $XMM_STORAGE scaled on 16
     .byte   @{[$UWOP_REG_NUMBER{rbp} | (($XMM_STORAGE / 16 ) << 4)]}
@@ -4780,7 +4780,7 @@ ___
       # Scaled-by-16 stack offset
       my $xmm_reg_offset = ($reg_idx - 6);
       $code .= <<___;
-    .byte   \$L\$${func_name}_seh_save_xmm${reg_idx}-\$L\$${func_name}_seh_begin
+    .byte   .L${func_name}_seh_save_xmm${reg_idx}-.L${func_name}_seh_begin
     .byte   @{[$UWOP_SAVE_XMM128 | (${reg_idx} << 4)]}
     .value  $xmm_reg_offset
 ___
@@ -4788,11 +4788,11 @@ ___
 
     $code .= <<___;
     # Frame pointer (occupy 1 slot)
-    .byte   \$L\$${func_name}_seh_setfp-\$L\$${func_name}_seh_begin
+    .byte   .L${func_name}_seh_setfp-.L${func_name}_seh_begin
     .byte   $UWOP_SET_FPREG
 
     # Occupy 2 slots, as stack allocation < 512K, but > 128 bytes
-    .byte   \$L\$${func_name}_seh_allocstack_xmm-\$L\$${func_name}_seh_begin
+    .byte   .L${func_name}_seh_allocstack_xmm-.L${func_name}_seh_begin
     .byte   $UWOP_ALLOC_LARGE
     .value  `($XMM_STORAGE + 8) / 8`
 ___
@@ -4801,7 +4801,7 @@ ___
     # Occupy 1 slot each
     foreach my $reg ("rsi", "rdi", "r15", "r14", "r13", "r12", "rbp", "rbx") {
       $code .= <<___;
-    .byte   \$L\$${func_name}_seh_push_${reg}-\$L\$${func_name}_seh_begin
+    .byte   .L${func_name}_seh_push_${reg}-.L${func_name}_seh_begin
     .byte   @{[$UWOP_PUSH_NONVOL | ($UWOP_REG_NUMBER{$reg} << 4)]}
 ___
     }

--- a/crypto/perlasm/x86_64-xlate.pl
+++ b/crypto/perlasm/x86_64-xlate.pl
@@ -811,7 +811,7 @@ my %globals;
 				    }
 				    last;
 				  };
-		/\.rva|\.long|\.quad/
+		/\.rva|\.long|\.quad|\.byte/
 			    && do { $$line =~ s/([_a-z][_a-z0-9]*)/$globals{$1} or $1/gei;
 				    $$line =~ s/\.L/$decor/g;
 				    last;


### PR DESCRIPTION
Fixed decoration prefix for some assembler labels (win64 related) in aes-gcm-avx512.pl for mingw64 build.

The root cause is that some assembler labels in aes-gcm-avx512.pl were stuck to specific convention on win64, while they should be different for different flavors (mingw64 uses gas flavor) and it should be handled by x86_64-xlate.pl generator. The generator itself is also updated to support labels renaming in .byte directives used in win64 SEH structures.

Fixes #17864.