### PR TITLE
Fix Coverity 1498612: integer overflow

### DIFF
--- a/crypto/ec/curve448/curve448.c
+++ b/crypto/ec/curve448/curve448.c
@@ -586,6 +586,7 @@ static int recode_wnaf(struct smvt_control *control,
             int32_t delta = odd & mask;
 
             assert(position >= 0);
+            assert(pos < 32);       /* can't fail since current & 0xFFFF != 0 */
             if (odd & (1 << (table_bits + 1)))
                 delta -= (1 << (table_bits + 1));
             current -= delta * (1 << pos);


### PR DESCRIPTION
For the case where `current` is zero, the shift becomes 32 which overflows an integer.


- [ ] documentation is added or updated
- [ ] tests are added or updated
