### PR TITLE
Fix Coverity 1201740 & 1201712: uninitialised values

### DIFF
--- a/crypto/evp/e_des.c
+++ b/crypto/evp/e_des.c
@@ -149,7 +149,7 @@ static int des_cfb1_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
                            const unsigned char *in, size_t inl)
 {
     size_t n, chunk = EVP_MAXCHUNK / 8;
-    unsigned char c[1], d[1];
+    unsigned char c[1], d[1] = { 0 };
 
     if (inl < chunk)
         chunk = inl;

--- a/crypto/evp/e_des.c
+++ b/crypto/evp/e_des.c
@@ -149,7 +149,8 @@ static int des_cfb1_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
                            const unsigned char *in, size_t inl)
 {
     size_t n, chunk = EVP_MAXCHUNK / 8;
-    unsigned char c[1], d[1] = { 0 };
+    unsigned char c[1];
+    unsigned char d[1] = { 0 };
 
     if (inl < chunk)
         chunk = inl;

--- a/crypto/evp/e_des3.c
+++ b/crypto/evp/e_des3.c
@@ -165,7 +165,8 @@ static int des_ede3_cfb1_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
                                 const unsigned char *in, size_t inl)
 {
     size_t n;
-    unsigned char c[1], d[1] = { 0 };
+    unsigned char c[1];
+    unsigned char d[1] = { 0 };
 
     if (!EVP_CIPHER_CTX_test_flags(ctx, EVP_CIPH_FLAG_LENGTH_BITS))
             inl *= 8;

--- a/crypto/evp/e_des3.c
+++ b/crypto/evp/e_des3.c
@@ -165,7 +165,7 @@ static int des_ede3_cfb1_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
                                 const unsigned char *in, size_t inl)
 {
     size_t n;
-    unsigned char c[1], d[1];
+    unsigned char c[1], d[1] = { 0 };
 
     if (!EVP_CIPHER_CTX_test_flags(ctx, EVP_CIPH_FLAG_LENGTH_BITS))
             inl *= 8;


### PR DESCRIPTION
These are both false positives since the `d` array is initialised by
the `DES_cfb_encrypt()` call via the `l2cn` macro.  Rather than ignoring them
and having them crop up later, it's easier to just add an initialiser.

- [ ] documentation is added or updated
- [ ] tests are added or updated
