### PR TITLE
Fix Coverity 1498605 & 1498606: uninitialised value

### DIFF
--- a/providers/implementations/ciphers/cipher_des_hw.c
+++ b/providers/implementations/ciphers/cipher_des_hw.c
@@ -136,7 +136,7 @@ static int cipher_hw_des_cfb1_cipher(PROV_CIPHER_CTX *ctx, unsigned char *out,
 {
     size_t n, chunk = MAXCHUNK / 8;
     DES_key_schedule *key = &(((PROV_DES_CTX *)ctx)->dks.ks);
-    unsigned char c[1], d[1];
+    unsigned char c[1], d[1] = { 0 };
 
     if (inl < chunk)
         chunk = inl;

--- a/providers/implementations/ciphers/cipher_des_hw.c
+++ b/providers/implementations/ciphers/cipher_des_hw.c
@@ -136,7 +136,8 @@ static int cipher_hw_des_cfb1_cipher(PROV_CIPHER_CTX *ctx, unsigned char *out,
 {
     size_t n, chunk = MAXCHUNK / 8;
     DES_key_schedule *key = &(((PROV_DES_CTX *)ctx)->dks.ks);
-    unsigned char c[1], d[1] = { 0 };
+    unsigned char c[1];
+    unsigned char d[1] = { 0 };
 
     if (inl < chunk)
         chunk = inl;

--- a/providers/implementations/ciphers/cipher_tdes_default_hw.c
+++ b/providers/implementations/ciphers/cipher_tdes_default_hw.c
@@ -99,7 +99,8 @@ static int ossl_cipher_hw_tdes_cfb1(PROV_CIPHER_CTX *ctx, unsigned char *out,
 {
     PROV_TDES_CTX *tctx = (PROV_TDES_CTX *)ctx;
     size_t n;
-    unsigned char c[1], d[1] = { 0 };
+    unsigned char c[1];
+    unsigned char d[1] = { 0 };
 
     if (ctx->use_bits == 0)
         inl *= 8;

--- a/providers/implementations/ciphers/cipher_tdes_default_hw.c
+++ b/providers/implementations/ciphers/cipher_tdes_default_hw.c
@@ -99,7 +99,7 @@ static int ossl_cipher_hw_tdes_cfb1(PROV_CIPHER_CTX *ctx, unsigned char *out,
 {
     PROV_TDES_CTX *tctx = (PROV_TDES_CTX *)ctx;
     size_t n;
-    unsigned char c[1], d[1];
+    unsigned char c[1], d[1] = { 0 };
 
     if (ctx->use_bits == 0)
         inl *= 8;


### PR DESCRIPTION
Both of these are false positives but better to be rid of the issue permanently than for it to repeatedly return to haunt us.


- [ ] documentation is added or updated
- [ ] tests are added or updated
