### PR TITLE
Fix Coverity 1503096: out-of-bounds access

### DIFF
--- a/crypto/evp/evp_enc.c
+++ b/crypto/evp/evp_enc.c
@@ -354,7 +354,7 @@ static int evp_cipher_init_internal(EVP_CIPHER_CTX *ctx,
 
         case EVP_CIPH_CBC_MODE:
             n = EVP_CIPHER_CTX_get_iv_length(ctx);
-            if (n <= 0 || n > (int)sizeof(ctx->iv)) {
+            if (n < 0 || n > (int)sizeof(ctx->iv)) {
                 ERR_raise(ERR_LIB_EVP, EVP_R_INVALID_IV_LENGTH);
                 return 0;
             }

--- a/crypto/evp/evp_enc.c
+++ b/crypto/evp/evp_enc.c
@@ -354,8 +354,8 @@ static int evp_cipher_init_internal(EVP_CIPHER_CTX *ctx,
 
         case EVP_CIPH_CBC_MODE:
             n = EVP_CIPHER_CTX_get_iv_length(ctx);
-            if (!ossl_assert(n >= 0 && n <= (int)sizeof(ctx->iv)))
-                    return 0;
+            if (n <= 0 || n > (int)sizeof(ctx->iv))
+                return 0;
             if (iv != NULL)
                 memcpy(ctx->oiv, iv, n);
             memcpy(ctx->iv, ctx->oiv, n);
@@ -366,8 +366,8 @@ static int evp_cipher_init_internal(EVP_CIPHER_CTX *ctx,
             /* Don't reuse IV for CTR mode */
             if (iv != NULL) {
                 n = EVP_CIPHER_CTX_get_iv_length(ctx);
-                if (!ossl_assert(n > 0 && n <= (int)sizeof(ctx->iv)))
-                        return 0;
+                if (n <= 0 || n > (int)sizeof(ctx->iv))
+                    return 0;
                 memcpy(ctx->iv, iv, n);
             }
             break;

--- a/crypto/evp/evp_enc.c
+++ b/crypto/evp/evp_enc.c
@@ -355,7 +355,7 @@ static int evp_cipher_init_internal(EVP_CIPHER_CTX *ctx,
         case EVP_CIPH_CBC_MODE:
             n = EVP_CIPHER_CTX_get_iv_length(ctx);
             if (n <= 0 || n > (int)sizeof(ctx->iv)) {
-                ERR_raise(ERR_LIB_EVP, EVP_R_INVALID_KEY_LENGTH);
+                ERR_raise(ERR_LIB_EVP, EVP_R_INVALID_IV_LENGTH);
                 return 0;
             }
             if (iv != NULL)
@@ -369,7 +369,7 @@ static int evp_cipher_init_internal(EVP_CIPHER_CTX *ctx,
             if (iv != NULL) {
                 n = EVP_CIPHER_CTX_get_iv_length(ctx);
                 if (n <= 0 || n > (int)sizeof(ctx->iv)) {
-                    ERR_raise(ERR_LIB_EVP, EVP_R_INVALID_KEY_LENGTH);
+                    ERR_raise(ERR_LIB_EVP, EVP_R_INVALID_IV_LENGTH);
                     return 0;
                 }
                 memcpy(ctx->iv, iv, n);

--- a/crypto/evp/evp_enc.c
+++ b/crypto/evp/evp_enc.c
@@ -354,8 +354,10 @@ static int evp_cipher_init_internal(EVP_CIPHER_CTX *ctx,
 
         case EVP_CIPH_CBC_MODE:
             n = EVP_CIPHER_CTX_get_iv_length(ctx);
-            if (n <= 0 || n > (int)sizeof(ctx->iv))
+            if (n <= 0 || n > (int)sizeof(ctx->iv)) {
+                ERR_raise(ERR_LIB_EVP, EVP_R_INVALID_KEY_LENGTH);
                 return 0;
+            }
             if (iv != NULL)
                 memcpy(ctx->oiv, iv, n);
             memcpy(ctx->iv, ctx->oiv, n);
@@ -366,8 +368,10 @@ static int evp_cipher_init_internal(EVP_CIPHER_CTX *ctx,
             /* Don't reuse IV for CTR mode */
             if (iv != NULL) {
                 n = EVP_CIPHER_CTX_get_iv_length(ctx);
-                if (n <= 0 || n > (int)sizeof(ctx->iv))
+                if (n <= 0 || n > (int)sizeof(ctx->iv)) {
+                    ERR_raise(ERR_LIB_EVP, EVP_R_INVALID_KEY_LENGTH);
                     return 0;
+                }
                 memcpy(ctx->iv, iv, n);
             }
             break;

--- a/crypto/evp/evp_enc.c
+++ b/crypto/evp/evp_enc.c
@@ -365,8 +365,9 @@ static int evp_cipher_init_internal(EVP_CIPHER_CTX *ctx,
             ctx->num = 0;
             /* Don't reuse IV for CTR mode */
             if (iv != NULL) {
-                if ((n = EVP_CIPHER_CTX_get_iv_length(ctx)) <= 0)
-                    return 0;
+                n = EVP_CIPHER_CTX_get_iv_length(ctx);
+                if (!ossl_assert(n > 0 && n <= (int)sizeof(ctx->iv)))
+                        return 0;
                 memcpy(ctx->iv, iv, n);
             }
             break;


### PR DESCRIPTION
Coverity is claiming that `n` can be 48 which is larger than the IV size.  It's not clear how/why this is possible but other paths do check for a maximum IV length, so adding it here seems reasonable.

- [ ] documentation is added or updated
- [ ] tests are added or updated
