### PR TITLE
Check password length only when `verify` is enabled.

### DIFF
--- a/apps/apps.c
+++ b/apps/apps.c
@@ -307,6 +307,8 @@ int password_callback(char *buf, int bufsiz, int verify, PW_CB_DATA *cb_tmp)
         if (cb_data != NULL && cb_data->password != NULL
                 && *(const char*)cb_data->password != '\0')
             pw_min_len = 1;
+        else if (!verify)
+            pw_min_len = 0;
         prompt = UI_construct_prompt(ui, "pass phrase", prompt_info);
         if (!prompt) {
             BIO_printf(bio_err, "Out of memory\n");


### PR DESCRIPTION
Fixes #16231.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
