### PR TITLE
eng_dyn: Avoid spurious errors when checking for 3.x engine [1.1.1]

### DIFF
--- a/crypto/engine/eng_dyn.c
+++ b/crypto/engine/eng_dyn.c
@@ -393,6 +393,26 @@ static int int_load(dynamic_data_ctx *ctx)
     return 0;
 }
 
+/*
+ * Unfortunately the version checker does not distinguish between
+ * engines built for openssl 1.1.x and openssl 3.x, but loading
+ * an engine that is built for openssl 3.x will cause a fatal
+ * error.  Detect such engines, since EVP_PKEY_get_base_id is exported
+ * as a function in openssl 3.x, while it is named EVP_PKEY_base_id
+ * in openssl 1.1.x.  Therefore we take the presence of that symbol
+ * as an indication that the engine will be incompatible.
+ */
+static int using_libcrypto_3(dynamic_data_ctx *ctx)
+{
+    int ret;
+
+    ERR_set_mark();
+    ret = DSO_bind_func(ctx->dynamic_dso, "EVP_PKEY_get_base_id") != NULL;
+    ERR_pop_to_mark();
+
+    return ret;
+}
+
 static int dynamic_load(ENGINE *e, dynamic_data_ctx *ctx)
 {
     ENGINE cpy;
@@ -442,18 +462,9 @@ static int dynamic_load(ENGINE *e, dynamic_data_ctx *ctx)
         /*
          * We fail if the version checker veto'd the load *or* if it is
          * deferring to us (by returning its version) and we think it is too
-         * old.
-         * Unfortunately the version checker does not distinguish between
-         * engines built for openssl 1.1.x and openssl 3.x, but loading
-         * an engine that is built for openssl 3.x will cause a fatal
-         * error.  Detect such engines, since EVP_PKEY_get_base_id is exported
-         * as a function in openssl 3.x, while it is named EVP_PKEY_base_id
-         * in openssl 1.1.x.  Therefore we take the presence of that symbol
-         * as an indication that the engine will be incompatible.
+         * old. Also fail if this is engine for openssl 3.x.
          */
-        if (vcheck_res < OSSL_DYNAMIC_OLDEST
-                || DSO_bind_func(ctx->dynamic_dso,
-                                 "EVP_PKEY_get_base_id") != NULL) {
+        if (vcheck_res < OSSL_DYNAMIC_OLDEST || using_libcrypto_3(ctx)) {
             /* Fail */
             ctx->bind_engine = NULL;
             ctx->v_check = NULL;


### PR DESCRIPTION
As seen in https://github.com/openssl/openssl/issues/17900 we produce spurious errors on the error stack when checking for 3.x engines.

This is 1.1.1 equivalent of #17901 