### PR TITLE
print SSL session, fix build warnings on OpenBSD.

### DIFF
--- a/ssl/ssl_txt.c
+++ b/ssl/ssl_txt.c
@@ -129,11 +129,11 @@ int SSL_SESSION_print(BIO *bp, const SSL_SESSION *x)
     }
 #endif
     if (x->time != 0L) {
-        if (BIO_printf(bp, "\n    Start Time: %ld", x->time) <= 0)
+        if (BIO_printf(bp, "\n    Start Time: %lld", (long long)x->time) <= 0)
             goto err;
     }
     if (x->timeout != 0L) {
-        if (BIO_printf(bp, "\n    Timeout   : %ld (sec)", x->timeout) <= 0)
+        if (BIO_printf(bp, "\n    Timeout   : %lld (sec)", (long long)x->timeout) <= 0)
             goto err;
     }
     if (BIO_puts(bp, "\n") <= 0)


### PR DESCRIPTION
time_t is a 64 bits type on this platform.
