### PR TITLE
Make `openssl check -rsa ...` to work for both RSA and RSA-PSS.

### DIFF
--- a/apps/rsa.c
+++ b/apps/rsa.c
@@ -257,7 +257,7 @@ int rsa_main(int argc, char **argv)
         ERR_print_errors(bio_err);
         goto end;
     }
-    if (!EVP_PKEY_is_a(pkey, "RSA")) {
+    if (!EVP_PKEY_is_a(pkey, "RSA") && !EVP_PKEY_is_a(pkey, "RSA-PSS")) {
         BIO_printf(bio_err, "Not an RSA key\n");
         goto end;
     }

--- a/test/recipes/15-test_rsapss.t
+++ b/test/recipes/15-test_rsapss.t
@@ -16,7 +16,7 @@ use OpenSSL::Test::Utils;
 
 setup("test_rsapss");
 
-plan tests => 7;
+plan tests => 9;
 
 #using test/testrsa.pem which happens to be a 512 bit RSA
 ok(run(app(['openssl', 'dgst', '-sign', srctop_file('test', 'testrsa.pem'), '-sha1',
@@ -64,3 +64,11 @@ ok(run(app(['openssl', 'dgst', '-prverify', srctop_file('test', 'testrsa.pem'),
             '-signature', 'testrsapss-unrestricted.sig',
             srctop_file('test', 'testrsa.pem')])),
    "openssl dgst -prverify [plain RSA key, PSS padding mode, no PSS restrictions]");
+
+
+# Test for issue #17167
+{
+   my $rsapss = "rsapss.key";
+   ok(run(app(['openssl', 'genpkey', '-algorithm', 'RSA-PSS', '-pkeyopt', 'rsa_keygen_bits:1024', '--out', $rsapss])));
+   ok(run(app(['openssl', 'rsa', '-check', '-in', $rsapss, '-check'])));
+}

--- a/test/recipes/15-test_rsapss.t
+++ b/test/recipes/15-test_rsapss.t
@@ -65,10 +65,12 @@ ok(run(app(['openssl', 'dgst', '-prverify', srctop_file('test', 'testrsa.pem'),
             srctop_file('test', 'testrsa.pem')])),
    "openssl dgst -prverify [plain RSA key, PSS padding mode, no PSS restrictions]");
 
-
-# Test for issue #17167
+# Test that RSA-PSS keys are supported by genpkey and rsa commands.
 {
    my $rsapss = "rsapss.key";
-   ok(run(app(['openssl', 'genpkey', '-algorithm', 'RSA-PSS', '-pkeyopt', 'rsa_keygen_bits:1024', '--out', $rsapss])));
-   ok(run(app(['openssl', 'rsa', '-check', '-in', $rsapss, '-check'])));
+   ok(run(app(['openssl', 'genpkey', '-algorithm', 'RSA-PSS',
+               '-pkeyopt', 'rsa_keygen_bits:1024',
+               '--out', $rsapss])));
+   ok(run(app(['openssl', 'rsa', '-check',
+               '-in', $rsapss])));
 }


### PR DESCRIPTION
	Fixes openssl#17167

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
