### PR TITLE
s_client -proxy / -starttls are mutually exclusive

### DIFF
--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -713,7 +713,6 @@ typedef enum PROTOCOL_choice {
     PROTO_TELNET,
     PROTO_XMPP,
     PROTO_XMPP_SERVER,
-    PROTO_CONNECT,
     PROTO_IRC,
     PROTO_MYSQL,
     PROTO_POSTGRES,
@@ -1002,7 +1001,6 @@ int s_client_main(int argc, char **argv)
             break;
         case OPT_PROXY:
             proxystr = opt_arg();
-            starttls_proto = PROTO_CONNECT;
             break;
         case OPT_PROXY_USER:
             proxyuser = opt_arg();
@@ -2201,6 +2199,13 @@ int s_client_main(int argc, char **argv)
     sbuf_len = 0;
     sbuf_off = 0;
 
+    if (proxystr != NULL) {
+        /* Here we must use the connect string target host & port */
+        if (!OSSL_HTTP_proxy_connect(sbio, thost, tport, proxyuser, proxypass,
+                                     0 /* no timeout */, bio_err, prog))
+            goto shut;
+    }
+
     switch ((PROTOCOL_CHOICE) starttls_proto) {
     case PROTO_OFF:
         break;
@@ -2387,12 +2392,6 @@ int s_client_main(int argc, char **argv)
             if (bytes != 6 || memcmp(mbuf, tls_follows, 6) != 0)
                 goto shut;
         }
-        break;
-    case PROTO_CONNECT:
-        /* Here we must use the connect string target host & port */
-        if (!OSSL_HTTP_proxy_connect(sbio, thost, tport, proxyuser, proxypass,
-                                     0 /* no timeout */, bio_err, prog))
-            goto shut;
         break;
     case PROTO_IRC:
         {


### PR DESCRIPTION
The option **-proxy** of openssl s_client works fine. The option **-starttls** also works fine. However, try putting both of them on command line. It breaks, these options don't work together. The problem is that -proxy option is implemented using starttls_proto (the option parsing code sets it to PROTO_CONNECT) and -starttls option overwrites the same variable again based on argument value. The suggested fix is to independently handle -proxy option before -starttls so the s_client can connect through HTTP proxy server and then use STARTTLS command.