### PR TITLE
util/markdownlint.rb: Allow fenced code blocks

### DIFF
--- a/util/markdownlint.rb
+++ b/util/markdownlint.rb
@@ -5,8 +5,9 @@ all
 
 # Use --- and === for H1 and H2.
 rule 'MD003', :style => :setext_with_atx
-# Code blocks are indented
-rule 'MD046', :style => :indented
+# Code blocks may be fenced or indented, both are OK...
+# but they must be consistent throughout each file.
+rule 'MD046', :style => :consistent
 
 # Bug in mdl, https://github.com/markdownlint/markdownlint/issues/313
 exclude_rule 'MD007'


### PR DESCRIPTION
We use both indented and fenced styles in diverse markdown files.
We try to do this consistently in each file, though.
