### PR TITLE
tls_process_server_hello: Disallow repeated HRR

### DIFF
--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -1395,6 +1395,10 @@ MSG_PROCESS_RETURN tls_process_server_hello(SSL *s, PACKET *pkt)
             && sversion == TLS1_2_VERSION
             && PACKET_remaining(pkt) >= SSL3_RANDOM_SIZE
             && memcmp(hrrrandom, PACKET_data(pkt), SSL3_RANDOM_SIZE) == 0) {
+        if (s->hello_retry_request != SSL_HRR_NONE) {
+            SSLfatal(s, SSL_AD_UNEXPECTED_MESSAGE, SSL_R_UNEXPECTED_MESSAGE);
+            goto err;
+        }
         s->hello_retry_request = SSL_HRR_PENDING;
         hrr = 1;
         if (!PACKET_forward(pkt, SSL3_RANDOM_SIZE)) {

--- a/test/recipes/70-test_tls13hrr.t
+++ b/test/recipes/70-test_tls13hrr.t
@@ -102,7 +102,7 @@ sub hrr_filter
     if ($testtype == DUPLICATE_HRR) {
         # We're only interested in the HRR
         # and the unexpected_message alert from client
-        if ($proxy->flight == 2) {
+        if ($proxy->flight == 2 || $proxy->flight == 4) {
             $fatal_alert = 1
                 if @{$proxy->record_list}[-1]->is_fatal_alert(0) == 10;
             return;

--- a/test/recipes/70-test_tls13hrr.t
+++ b/test/recipes/70-test_tls13hrr.t
@@ -35,8 +35,11 @@ my $proxy = TLSProxy::Proxy->new(
 
 use constant {
     CHANGE_HRR_CIPHERSUITE => 0,
-    CHANGE_CH1_CIPHERSUITE => 1
+    CHANGE_CH1_CIPHERSUITE => 1,
+    DUPLICATE_HRR => 2
 };
+
+plan tests => 3;
 
 #Test 1: A client should fail if the server changes the ciphersuite between the
 #        HRR and the SH
@@ -48,7 +51,6 @@ if (disabled("ec")) {
 }
 my $testtype = CHANGE_HRR_CIPHERSUITE;
 $proxy->start() or plan skip_all => "Unable to start up Proxy for tests";
-plan tests => 2;
 ok(TLSProxy::Message->fail(), "Server ciphersuite changes");
 
 #Test 2: It is an error if the client changes the offered ciphersuites so that
@@ -63,6 +65,19 @@ $proxy->ciphersuitess("TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384");
 $testtype = CHANGE_CH1_CIPHERSUITE;
 $proxy->start();
 ok(TLSProxy::Message->fail(), "Client ciphersuite changes");
+
+#Test 3: A client should fail with unexpected_message alert if the server
+#        sends more than 1 HRR
+my $fatal_alert = 0;
+$proxy->clear();
+if (disabled("ec")) {
+    $proxy->serverflags("-curves ffdhe3072");
+} else {
+    $proxy->serverflags("-curves P-256");
+}
+$testtype = DUPLICATE_HRR;
+$proxy->start();
+ok($fatal_alert, "Server duplicated HRR");
 
 sub hrr_filter
 {
@@ -81,6 +96,39 @@ sub hrr_filter
         # the ciphersuite will change will we get the ServerHello
         $hrr->ciphersuite(TLSProxy::Message::CIPHER_TLS13_AES_256_GCM_SHA384);
         $hrr->repack();
+        return;
+    }
+
+    if ($testtype == DUPLICATE_HRR) {
+        # We're only interested in the HRR
+        # and the unexpected_message alert from client
+        if ($proxy->flight == 2) {
+            $fatal_alert = 1
+                if @{$proxy->record_list}[-1]->is_fatal_alert(0) == 10;
+            return;
+        }
+        if ($proxy->flight != 1) {
+            return;
+        }
+
+        # Find ServerHello record (HRR actually) and insert after that
+        my $i;
+        for ($i = 0; ${$proxy->record_list}[$i]->flight() < 1; $i++) {
+            next;
+        }
+        my $hrr_record = ${$proxy->record_list}[$i];
+        my $dup_hrr = TLSProxy::Record->new(1,
+            $hrr_record->content_type(),
+            $hrr_record->version(),
+            $hrr_record->len(),
+            $hrr_record->sslv2(),
+            $hrr_record->len_real(),
+            $hrr_record->decrypt_len(),
+            $hrr_record->data(),
+            $hrr_record->decrypt_data());
+
+        $i++;
+        splice @{$proxy->record_list}, $i, 0, $dup_hrr;
         return;
     }
 

--- a/test/recipes/70-test_tls13hrr.t
+++ b/test/recipes/70-test_tls13hrr.t
@@ -39,8 +39,6 @@ use constant {
     DUPLICATE_HRR => 2
 };
 
-plan tests => 3;
-
 #Test 1: A client should fail if the server changes the ciphersuite between the
 #        HRR and the SH
 $proxy->filter(\&hrr_filter);
@@ -51,6 +49,7 @@ if (disabled("ec")) {
 }
 my $testtype = CHANGE_HRR_CIPHERSUITE;
 $proxy->start() or plan skip_all => "Unable to start up Proxy for tests";
+plan tests => 3;
 ok(TLSProxy::Message->fail(), "Server ciphersuite changes");
 
 #Test 2: It is an error if the client changes the offered ciphersuites so that

--- a/test/recipes/70-test_tls13hrr.t
+++ b/test/recipes/70-test_tls13hrr.t
@@ -102,12 +102,12 @@ sub hrr_filter
     if ($testtype == DUPLICATE_HRR) {
         # We're only interested in the HRR
         # and the unexpected_message alert from client
-        if ($proxy->flight == 2 || $proxy->flight == 4) {
+        if ($proxy->flight == 4) {
             $fatal_alert = 1
                 if @{$proxy->record_list}[-1]->is_fatal_alert(0) == 10;
             return;
         }
-        if ($proxy->flight != 1) {
+        if ($proxy->flight != 3) {
             return;
         }
 
@@ -117,7 +117,7 @@ sub hrr_filter
             next;
         }
         my $hrr_record = ${$proxy->record_list}[$i];
-        my $dup_hrr = TLSProxy::Record->new(1,
+        my $dup_hrr = TLSProxy::Record->new(3,
             $hrr_record->content_type(),
             $hrr_record->version(),
             $hrr_record->len(),


### PR DESCRIPTION
Repeated HRR must be rejected.

Fixes #17934

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
