### PR TITLE
Add build note for win-arm64

### DIFF
--- a/NOTES-WINDOWS.md
+++ b/NOTES-WINDOWS.md
@@ -71,9 +71,10 @@ Quick start
     <https://docs.microsoft.com/cpp/build/building-on-the-command-line>
 
  5. From the root of the OpenSSL source directory enter
-    perl Configure VC-WIN32    if you want 32-bit OpenSSL or
-    perl Configure VC-WIN64A   if you want 64-bit OpenSSL or
-    perl Configure             to let Configure figure out the platform
+    perl Configure VC-WIN32     if you want 32-bit OpenSSL or
+    perl Configure VC-WIN64A    if you want 64-bit OpenSSL or
+    perl Configure              to let Configure figure out the x86/x64 platform or
+    perl Configure VC-WIN64-ARM if you want Windows on Arm (win-arm64) OpenSSL
 
  6. nmake
 


### PR DESCRIPTION
Windows on Arm is not officially supported by release, but with x86 emulated Perl it can be built locally.
This method is added to Windows notes.
Locally all tests are passed on win-arm64.
Fix for #11289

CLA: trivial
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
