### PR TITLE
Pin actions to a full length commit SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get -yq --no-install-suggests --no-install-recommends --force-yes install unifdef
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
       with:
         fetch-depth: 0
     - name: config
@@ -41,7 +41,7 @@ jobs:
   check_docs:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
     - name: config
       run: ./config --banner=Configured --strict-warnings enable-fips && perl configdata.pm --dump
     - name: make build_generated
@@ -59,7 +59,7 @@ jobs:
   check-ansi:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
     - name: config
       run: CPPFLAGS=-ansi ./config --banner=Configured no-asm no-makedepend enable-buildtest-c++ enable-fips --strict-warnings -D_DEFAULT_SOURCE && perl configdata.pm --dump
     - name: make
@@ -68,7 +68,7 @@ jobs:
   basic_gcc:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
     - name: config
       run: CC=gcc ./config --banner=Configured enable-fips --strict-warnings && perl configdata.pm --dump
     - name: make
@@ -79,7 +79,7 @@ jobs:
   basic_clang:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
     - name: config
       run: CC=clang ./config --banner=Configured no-fips --strict-warnings && perl configdata.pm --dump
     - name: make
@@ -90,7 +90,7 @@ jobs:
   minimal:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
     - name: config
       run: ./config --banner=Configured --strict-warnings no-bulk no-pic no-asm -DOPENSSL_NO_SECURE_MEMORY -DOPENSSL_SMALL_FOOTPRINT && perl configdata.pm --dump
     - name: make
@@ -101,7 +101,7 @@ jobs:
   no-deprecated:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
     - name: config
       run: ./config --banner=Configured --strict-warnings no-deprecated enable-fips && perl configdata.pm --dump
     - name: make
@@ -115,7 +115,7 @@ jobs:
         os: [ ubuntu-latest, macos-latest ]
     runs-on: ${{matrix.os}}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
     - name: config
       run: ./config --banner=Configured --strict-warnings no-shared no-fips && perl configdata.pm --dump
     - name: make
@@ -126,7 +126,7 @@ jobs:
   non-caching:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
     - name: config
       run: ./config --banner=Configured --debug enable-asan enable-ubsan no-cached-fetch no-fips no-dtls no-tls1 no-tls1-method no-tls1_1 no-tls1_1-method no-async && perl configdata.pm --dump
     - name: make
@@ -137,7 +137,7 @@ jobs:
   address_ub_sanitizer:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
     - name: config
       run: ./config --banner=Configured --debug enable-asan enable-ubsan enable-rc5 enable-md2 enable-ec_nistp_64_gcc_128 enable-fips -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION && perl configdata.pm --dump
     - name: make
@@ -148,7 +148,7 @@ jobs:
   memory_sanitizer:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
     - name: config
       # --debug -O1 is to produce a debug build that runs in a reasonable amount of time
       run: CC=clang ./config --banner=Configured --debug -O1 -fsanitize=memory -DOSSL_SANITIZE_MEMORY -fno-optimize-sibling-calls enable-rc5 enable-md2 enable-ec_nistp_64_gcc_128 enable-fips && perl configdata.pm --dump
@@ -160,7 +160,7 @@ jobs:
   threads_sanitizer:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
     - name: config
       run: CC=clang ./config --banner=Configured no-fips --strict-warnings -fsanitize=thread && perl configdata.pm --dump
     - name: make
@@ -171,7 +171,7 @@ jobs:
   enable_non-default_options:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
     - name: modprobe tls
       run: sudo modprobe tls
     - name: config
@@ -184,7 +184,7 @@ jobs:
   fips_and_ktls:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
     - name: modprobe tls
       run: sudo modprobe tls
     - name: config
@@ -197,7 +197,7 @@ jobs:
   no-legacy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
     - name: config
       run: ./config --banner=Configured --strict-warnings no-legacy enable-fips && perl configdata.pm --dump
     - name: make
@@ -208,7 +208,7 @@ jobs:
   legacy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
     - name: config
       run: ./config --banner=Configured -Werror --debug no-afalgeng no-shared enable-crypto-mdebug enable-rc5 enable-md2 enable-ssl3 enable-ssl3-method enable-weak-ssl-ciphers enable-zlib enable-ec_nistp_64_gcc_128 no-fips && perl configdata.pm --dump
     - name: make
@@ -222,7 +222,7 @@ jobs:
         os: [ ubuntu-latest, macos-latest ]
     runs-on: ${{matrix.os}}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
     - name: config
       run: CC=gcc ./config --banner=Configured enable-tfo --strict-warnings && perl configdata.pm --dump
     - name: make
@@ -233,7 +233,7 @@ jobs:
   buildtest:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
     - name: config
       run: ./config --banner=Configured no-asm no-makedepend enable-buildtest-c++ enable-fips --strict-warnings -D_DEFAULT_SOURCE && perl configdata.pm --dump
     - name: make
@@ -247,7 +247,7 @@ jobs:
         os: [ubuntu-latest, macos-latest ]
     runs-on: ${{matrix.os}}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
     - name: extra preparations
       run: |
         mkdir ./build
@@ -268,7 +268,7 @@ jobs:
   external-tests:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
       with:
         submodules: recursive
     - name: package installs
@@ -276,7 +276,7 @@ jobs:
         sudo apt-get update
         sudo apt-get -yq install bison gettext keyutils ldap-utils libldap2-dev libkeyutils-dev python3 python3-paste python3-pyrad slapd tcsh python3-virtualenv virtualenv python3-kdcproxy
     - name: install cpanm and Test2::V0 for gost_engine testing
-      uses: perl-actions/install-with-cpanm@v1
+      uses: perl-actions/install-with-cpanm@d167bf8c6435f73464d60d565e67eda9e0831012 # v1
       with:
         install: Test2::V0
     - name: setup hostname workaround
@@ -303,7 +303,7 @@ jobs:
         PYTHON:
           - 3.9
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
       with:
         submodules: recursive
     - name: Configure OpenSSL
@@ -311,10 +311,10 @@ jobs:
     - name: make
       run: make -s -j4
     - name: Setup Python
-      uses: actions/setup-python@v2.2.2
+      uses: actions/setup-python@dc73133d4da04e56a135ae2246682783cc7c7cb6 # v2.2.2
       with:
         python-version: ${{ matrix.PYTHON }}
-    - uses: actions-rs/toolchain@v1
+    - uses: actions-rs/toolchain@63eb9591781c46a70274cb3ebdf190fce92702e8 # v1
       with:
         profile: minimal
         toolchain: ${{ matrix.RUST }}

--- a/.github/workflows/compiler-zoo.yml
+++ b/.github/workflows/compiler-zoo.yml
@@ -9,6 +9,9 @@ name: Compiler Zoo CI
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   compiler:
     strategy:
@@ -45,7 +48,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get -yq --force-yes install ${{ matrix.zoo.cc }}
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
 
     - name: config
       run: |

--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -12,11 +12,17 @@ on:
   schedule:
     - cron:  '49 0 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   coverage:
+    permissions:
+      checks: write  # for coverallsapp/github-action to create new checks
+      contents: read  # for actions/checkout to fetch code
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
     - name: package installs
       run: |
         sudo apt-get -yq install lcov
@@ -31,7 +37,7 @@ jobs:
     - name: generate coverage info
       run: lcov -d . -c -o ./lcov.info
     - name: Coveralls upload
-      uses: coverallsapp/github-action@v1.1.2
+      uses: coverallsapp/github-action@8cbef1dea373ebce56de0a14c68d6267baa10b44 # v1.1.2
       with:
         github-token: ${{ secrets.github_token }}
         path-to-lcov: ./lcov.info

--- a/.github/workflows/cross-compiles.yml
+++ b/.github/workflows/cross-compiles.yml
@@ -9,6 +9,9 @@ name: Cross Compile
 
 on: [pull_request, push]
 
+permissions:
+  contents: read
+
 jobs:
   cross-compilation:
     strategy:
@@ -134,7 +137,7 @@ jobs:
         sudo apt-get -yq --force-yes install \
             gcc-${{ matrix.platform.arch }} \
             ${{ matrix.platform.libs }}
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
 
     - name: config with FIPS
       if: matrix.platform.fips != 'no'

--- a/.github/workflows/fips-checksums.yml
+++ b/.github/workflows/fips-checksums.yml
@@ -8,6 +8,9 @@
 name: FIPS Checksums
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   compute-checksums:
     runs-on: ubuntu-latest
@@ -23,7 +26,7 @@ jobs:
           mkdir ./build
           mkdir ./source
           mkdir ./artifact
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
         with:
           repository: ${{ github.event.pull_request.base.repo.full_name }}
           ref: ${{ github.event.pull_request.base.ref }}
@@ -40,7 +43,7 @@ jobs:
       - name: make fips-checksums pristine
         run: make fips-checksums
         working-directory: ./build-pristine
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
         with:
           path: source
       - name: config
@@ -66,7 +69,7 @@ jobs:
       - name: save PR number
         run: echo ${{ github.event.number }} > ./artifact/pr_num
       - name: save artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2
         with:
           name: fips_checksum
           path: artifact/

--- a/.github/workflows/fips-label.yml
+++ b/.github/workflows/fips-label.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: 'Download artifact'
         if: ${{ github.event.workflow_run.conclusion == 'success' }}
-        uses: actions/github-script@v4
+        uses: actions/github-script@ee99cebd8f95dcfa18a106963011c76500a16521 # v4
         with:
           script: |
             var artifacts = await github.actions.listWorkflowRunArtifacts({
@@ -42,7 +42,7 @@ jobs:
         if: ${{ github.event.workflow_run.conclusion == 'success' }}
       - name: 'Check artifact and apply'
         if: ${{ github.event.workflow_run.conclusion == 'success' }}
-        uses: actions/github-script@v4
+        uses: actions/github-script@ee99cebd8f95dcfa18a106963011c76500a16521 # v4
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |

--- a/.github/workflows/fips-provider.yml
+++ b/.github/workflows/fips-provider.yml
@@ -8,6 +8,9 @@
 name: Provider compat
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   fips-provider-30:
     runs-on: ubuntu-latest
@@ -18,7 +21,7 @@ jobs:
           mkdir ./build-3.0
           mkdir ./source
           mkdir ./source-3.0
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
         with:
           path: source
       - name: config current
@@ -30,7 +33,7 @@ jobs:
       - name: make
         run: make -s -j4
         working-directory: ./build
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
         with:
           repository: openssl/openssl
           ref: openssl-3.0
@@ -60,7 +63,7 @@ jobs:
           mkdir ./build-3.0
           mkdir ./source
           mkdir ./source-3.0
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
         with:
           repository: openssl/openssl
           ref: openssl-3.0
@@ -74,7 +77,7 @@ jobs:
       - name: make 3.0
         run: make -s -j4
         working-directory: ./build-3.0
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
         with:
           path: source
       - name: config current

--- a/.github/workflows/fuzz-checker.yml
+++ b/.github/workflows/fuzz-checker.yml
@@ -9,6 +9,9 @@ name: Fuzz-checker CI
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   fuzz-checker:
     strategy:
@@ -45,7 +48,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get -yq --force-yes install ${{ matrix.fuzzy.install }}
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
 
     - name: config
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
         fuzz-seconds: 600
         dry-run: false
     - name: Upload Crash
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@34622df80861c3ed63eb2bff892de2f1fbf4c9da # v1
       if: failure()
       with:
         name: artifacts

--- a/.github/workflows/os-zoo.yml
+++ b/.github/workflows/os-zoo.yml
@@ -24,7 +24,7 @@ jobs:
         ]
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
     - name: config
       run: |
         CC=${{ matrix.zoo.cc }} ./config --banner=Configured \
@@ -45,10 +45,10 @@ jobs:
         ]
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
-    - uses: ilammy/msvc-dev-cmd@v1
-    - uses: ilammy/setup-nasm@v1
-    - uses: shogo82148/actions-setup-perl@v1
+    - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
+    - uses: ilammy/msvc-dev-cmd@d8610e2b41c6d0f0c3b4c46dad8df0fd826c68e1 # v1
+    - uses: ilammy/setup-nasm@e2335e5fc95548c09cd2deea2768793e0e8f0941 # v1
+    - uses: shogo82148/actions-setup-perl@6416baf582122cf9273f04c4facf3ba130883754 # v1
     - name: prepare the build directory
       run: mkdir _build
     - name: config

--- a/.github/workflows/run-checker-ci.yml
+++ b/.github/workflows/run-checker-ci.yml
@@ -8,6 +8,9 @@
 # Jobs run per pull request submission
 name: Run-checker CI
 on: [pull_request, push]
+permissions:
+  contents: read
+
 jobs:
   run-checker:
     strategy:
@@ -35,7 +38,7 @@ jobs:
         ]
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
     - name: config
       run: CC=clang ./config --banner=Configured --strict-warnings ${{ matrix.opt }}
     - name: config dump

--- a/.github/workflows/run-checker-daily.yml
+++ b/.github/workflows/run-checker-daily.yml
@@ -11,6 +11,9 @@ name: Run-checker daily
 on:
   schedule:
     - cron: '0 6 * * *'
+permissions:
+  contents: read
+
 jobs:
   run-checker:
     strategy:
@@ -133,7 +136,7 @@ jobs:
         ]
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
     - name: config
       run: CC=clang ./config --banner=Configured --strict-warnings ${{ matrix.opt }}
     - name: config dump

--- a/.github/workflows/run-checker-merge.yml
+++ b/.github/workflows/run-checker-merge.yml
@@ -9,6 +9,9 @@ name: Run-checker merge
 # Jobs run per merge to master
 
 on: [push]
+permissions:
+  contents: read
+
 jobs:
   run-checker:
     strategy:
@@ -29,7 +32,7 @@ jobs:
         ]
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
     - name: config
       run: CC=clang ./config --banner=Configured --strict-warnings ${{ matrix.opt }}
     - name: config dump

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -12,11 +12,14 @@ on:
   schedule:
     - cron:  '20 0 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   coverity:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
     - name: tool download
       run: |
         wget https://scan.coverity.com/download/linux64 \

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -24,14 +24,14 @@ jobs:
             config: VC-WIN32 --strict-warnings no-fips
     runs-on: ${{matrix.os}}
     steps:
-    - uses: actions/checkout@v2
-    - uses: ilammy/msvc-dev-cmd@v1
+    - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
+    - uses: ilammy/msvc-dev-cmd@d8610e2b41c6d0f0c3b4c46dad8df0fd826c68e1 # v1
       with:
         arch: ${{ matrix.platform.arch }}
-    - uses: ilammy/setup-nasm@v1
+    - uses: ilammy/setup-nasm@e2335e5fc95548c09cd2deea2768793e0e8f0941 # v1
       with:
         platform: ${{ matrix.platform.arch }}
-    - uses: shogo82148/actions-setup-perl@v1
+    - uses: shogo82148/actions-setup-perl@6416baf582122cf9273f04c4facf3ba130883754 # v1
     - name: prepare the build directory
       run: mkdir _build
     - name: config
@@ -60,9 +60,9 @@ jobs:
           - windows-2022
     runs-on: ${{matrix.os}}
     steps:
-    - uses: actions/checkout@v2
-    - uses: ilammy/msvc-dev-cmd@v1
-    - uses: shogo82148/actions-setup-perl@v1
+    - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
+    - uses: ilammy/msvc-dev-cmd@d8610e2b41c6d0f0c3b4c46dad8df0fd826c68e1 # v1
+    - uses: shogo82148/actions-setup-perl@6416baf582122cf9273f04c4facf3ba130883754 # v1
     - name: prepare the build directory
       run: mkdir _build
     - name: config
@@ -84,9 +84,9 @@ jobs:
           - windows-2022
     runs-on: ${{matrix.os}}
     steps:
-    - uses: actions/checkout@v2
-    - uses: ilammy/msvc-dev-cmd@v1
-    - uses: shogo82148/actions-setup-perl@v1
+    - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
+    - uses: ilammy/msvc-dev-cmd@d8610e2b41c6d0f0c3b4c46dad8df0fd826c68e1 # v1
+    - uses: shogo82148/actions-setup-perl@6416baf582122cf9273f04c4facf3ba130883754 # v1
     - name: prepare the build directory
       run: mkdir _build
     - name: config


### PR DESCRIPTION
- Pinned actions by SHA https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies
- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

>Pin actions to a full length commit SHA

>Pinning an action to a full length commit SHA is currently the only way to use an action as an immutable release. Pinning to a particular SHA helps mitigate the risk of a bad actor adding a backdoor to the action's repository, as they would need to generate a SHA-1 collision for a valid Git object payload.

https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions

Also, dependabot supports upgrading based on SHA.

Signed-off-by: naveensinivasan <172697+naveensrinivasan@users.noreply.github.com>

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
