### PR TITLE
Disable the test_afalg on cross compile targets

### DIFF
--- a/.github/workflows/cross-compiles.yml
+++ b/.github/workflows/cross-compiles.yml
@@ -162,6 +162,7 @@ jobs:
       if: github.event_name == 'push' && matrix.platform.tests == ''
       run: |
         make test HARNESS_JOBS=${HARNESS_JOBS:-4} \
+                  TESTS="-test_afalg" \
                   QEMU_LD_PREFIX=/usr/${{ matrix.platform.arch }}
     - name: make some tests
       if: github.event_name == 'push' && matrix.platform.tests != 'none' && matrix.platform.tests != ''

--- a/.github/workflows/cross-compiles.yml
+++ b/.github/workflows/cross-compiles.yml
@@ -167,5 +167,5 @@ jobs:
       if: github.event_name == 'push' && matrix.platform.tests != 'none' && matrix.platform.tests != ''
       run: |
         make test HARNESS_JOBS=${HARNESS_JOBS:-4} \
-                  TESTS="${{ matrix.platform.tests }}" \
+                  TESTS="${{ matrix.platform.tests }} -test_afalg" \
                   QEMU_LD_PREFIX=/usr/${{ matrix.platform.arch }}


### PR DESCRIPTION
The afalg engine does not work when run through qemu.

This fixes the CI cross-compile failures on merges so I am marking this urgent.
