### PR TITLE
s390x: Hide internal cpuid symbol and function

### DIFF
--- a/crypto/s390x_arch.h
+++ b/crypto/s390x_arch.h
@@ -72,6 +72,9 @@ struct OPENSSL_s390xcap_st {
     unsigned long long kdsa[2];
 };
 
+#if defined(__GNUC__) && defined(__linux)
+__attribute__ ((visibility("hidden")))
+#endif
 extern struct OPENSSL_s390xcap_st OPENSSL_s390xcap_P;
 
 /* Max number of 64-bit words currently returned by STFLE */

--- a/crypto/s390xcap.c
+++ b/crypto/s390xcap.c
@@ -74,6 +74,9 @@ void OPENSSL_s390x_functions(void);
 
 struct OPENSSL_s390xcap_st OPENSSL_s390xcap_P;
 
+#if defined(__GNUC__) && defined(__linux)
+__attribute__ ((visibility("hidden")))
+#endif
 void OPENSSL_cpuid_setup(void)
 {
     struct OPENSSL_s390xcap_st cap;


### PR DESCRIPTION
The symbol OPENSSL_s390xcap_P and the OPENSSL_cpuid_setup function are not
exported by the version script of OpenSSL.  However, if someone uses the
static library without the version script, these symbols all of a sudden
become global symbols and their usage in assembler code does not correctly
reflect that for PIC.  Since these symbols should never be used outside of
OpenSSL, hide them inside the binary.

Signed-off-by: Juergen Christ <jchrist@linux.ibm.com>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

This could fix #14529 although I could not reproduce the problem reported there.  Nevertheless, shared libraries linked against the static libopenssl.a without this fix contains text-relative relocations for exactly these two symbols.  With this fix, these text-relative relocations are gone.