### PR TITLE
Fix Coverity 1503218: negative loop bound

### DIFF
--- a/crypto/encode_decode/decoder_pkey.c
+++ b/crypto/encode_decode/decoder_pkey.c
@@ -260,7 +260,7 @@ static void collect_decoder(OSSL_DECODER *decoder, void *arg)
 {
     struct collect_data_st *data = arg;
     STACK_OF(EVP_KEYMGMT) *keymgmts = data->keymgmts;
-    size_t i, end_i;
+    int i, end_i;
     EVP_KEYMGMT *keymgmt;
     const OSSL_PROVIDER *prov;
     void *provctx;


### PR DESCRIPTION
OPENSSL_sk_num returns an integer which can theoretically be negative. Assigning this to a size_t and using it as a loop bound isn't ideal.

Rather than adding checked for NULL or negative returns, changing the loop index and end to int is simpler and also addresses the integer parameter to `OPENSSL_sk_value()` where a size_t could overflow.

- [ ] documentation is added or updated
- [ ] tests are added or updated
