### PR TITLE
Fix possible memory leaks lead by DSO_free

### DIFF
--- a/crypto/engine/eng_dyn.c
+++ b/crypto/engine/eng_dyn.c
@@ -440,8 +440,8 @@ static int dynamic_load(ENGINE *e, dynamic_data_ctx *ctx)
     }
     if (!int_load(ctx)) {
         ERR_raise(ERR_LIB_ENGINE, ENGINE_R_DSO_NOT_FOUND);
-        DSO_free(ctx->dynamic_dso);
-        ctx->dynamic_dso = NULL;
+        if (!DSO_free(ctx->dynamic_dso))
+            ctx->dynamic_dso = NULL;
         return 0;
     }
     /* We have to find a bind function otherwise it'll always end badly */
@@ -450,8 +450,8 @@ static int dynamic_load(ENGINE *e, dynamic_data_ctx *ctx)
          (dynamic_bind_engine) DSO_bind_func(ctx->dynamic_dso,
                                              ctx->DYNAMIC_F2))) {
         ctx->bind_engine = NULL;
-        DSO_free(ctx->dynamic_dso);
-        ctx->dynamic_dso = NULL;
+        if (!DSO_free(ctx->dynamic_dso))
+            ctx->dynamic_dso = NULL;
         ERR_raise(ERR_LIB_ENGINE, ENGINE_R_DSO_FAILURE);
         return 0;
     }
@@ -476,8 +476,8 @@ static int dynamic_load(ENGINE *e, dynamic_data_ctx *ctx)
             /* Fail */
             ctx->bind_engine = NULL;
             ctx->v_check = NULL;
-            DSO_free(ctx->dynamic_dso);
-            ctx->dynamic_dso = NULL;
+            if (!DSO_free(ctx->dynamic_dso))
+                ctx->dynamic_dso = NULL;
             ERR_raise(ERR_LIB_ENGINE, ENGINE_R_VERSION_INCOMPATIBILITY);
             return 0;
         }
@@ -509,8 +509,8 @@ static int dynamic_load(ENGINE *e, dynamic_data_ctx *ctx)
         engine_remove_dynamic_id(e, 1);
         ctx->bind_engine = NULL;
         ctx->v_check = NULL;
-        DSO_free(ctx->dynamic_dso);
-        ctx->dynamic_dso = NULL;
+        if (!DSO_free(ctx->dynamic_dso))
+            ctx->dynamic_dso = NULL;
         ERR_raise(ERR_LIB_ENGINE, ENGINE_R_INIT_FAILED);
         /* Copy the original ENGINE structure back */
         memcpy(e, &cpy, sizeof(ENGINE));

--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -887,8 +887,8 @@ static int provider_init(OSSL_PROVIDER *prov)
 
             if (merged_path == NULL
                 || (DSO_load(prov->module, merged_path, NULL, 0)) == NULL) {
-                DSO_free(prov->module);
-                prov->module = NULL;
+                if (!DSO_free(prov->module))
+                    prov->module = NULL;
             }
 
             OPENSSL_free(merged_path);


### PR DESCRIPTION
DSO_free() will not perform OPENSSL_free on the dso variable and
return 1 when dso->meth->finish() fails.
So directly setting related variables to NULL without checking
the return value of DSO_free() may lead to possible memleaks.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
