### PR TITLE
Fix possible null pointer dereference caused by evp_pkey_get_legacy()

### DIFF
--- a/crypto/dh/dh_ameth.c
+++ b/crypto/dh/dh_ameth.c
@@ -393,14 +393,21 @@ int DHparams_print(BIO *bp, const DH *x)
 
 static int dh_pkey_ctrl(EVP_PKEY *pkey, int op, long arg1, void *arg2)
 {
+    DH *dh;
     switch (op) {
     case ASN1_PKEY_CTRL_SET1_TLS_ENCPT:
         /* We should only be here if we have a legacy key */
         if (!ossl_assert(evp_pkey_is_legacy(pkey)))
             return 0;
-        return ossl_dh_buf2key(evp_pkey_get0_DH_int(pkey), arg2, arg1);
+        dh = (DH *) evp_pkey_get0_DH_int(pkey);
+        if (dh == NULL)
+            return 0;
+        return ossl_dh_buf2key(dh, arg2, arg1);
     case ASN1_PKEY_CTRL_GET1_TLS_ENCPT:
-        return ossl_dh_key2buf(EVP_PKEY_get0_DH(pkey), arg2, 0, 1);
+        dh = (DH *) EVP_PKEY_get0_DH(pkey);
+        if (dh == NULL)
+            return 0;
+        return ossl_dh_key2buf(dh, arg2, 0, 1);
     default:
         return -2;
     }

--- a/crypto/ec/ecx_meth.c
+++ b/crypto/ec/ecx_meth.c
@@ -809,6 +809,11 @@ static int pkey_ecd_digestsign25519(EVP_MD_CTX *ctx, unsigned char *sig,
 {
     const ECX_KEY *edkey = evp_pkey_get_legacy(EVP_MD_CTX_get_pkey_ctx(ctx)->pkey);
 
+    if (edkey == NULL) {
+        ERR_raise(ERR_LIB_EC, EC_R_INVALID_KEY);
+        return 0;
+    }
+
     if (sig == NULL) {
         *siglen = ED25519_SIGSIZE;
         return 1;
@@ -830,6 +835,11 @@ static int pkey_ecd_digestsign448(EVP_MD_CTX *ctx, unsigned char *sig,
                                   size_t tbslen)
 {
     const ECX_KEY *edkey = evp_pkey_get_legacy(EVP_MD_CTX_get_pkey_ctx(ctx)->pkey);
+
+    if (edkey == NULL) {
+        ERR_raise(ERR_LIB_EC, EC_R_INVALID_KEY);
+        return 0;
+    }
 
     if (sig == NULL) {
         *siglen = ED448_SIGSIZE;
@@ -853,6 +863,11 @@ static int pkey_ecd_digestverify25519(EVP_MD_CTX *ctx, const unsigned char *sig,
 {
     const ECX_KEY *edkey = evp_pkey_get_legacy(EVP_MD_CTX_get_pkey_ctx(ctx)->pkey);
 
+    if (edkey == NULL) {
+        ERR_raise(ERR_LIB_EC, EC_R_INVALID_KEY);
+        return 0;
+    }
+
     if (siglen != ED25519_SIGSIZE)
         return 0;
 
@@ -865,6 +880,11 @@ static int pkey_ecd_digestverify448(EVP_MD_CTX *ctx, const unsigned char *sig,
                                     size_t tbslen)
 {
     const ECX_KEY *edkey = evp_pkey_get_legacy(EVP_MD_CTX_get_pkey_ctx(ctx)->pkey);
+
+    if (edkey == NULL) {
+        ERR_raise(ERR_LIB_EC, EC_R_INVALID_KEY);
+        return 0;
+    }
 
     if (siglen != ED448_SIGSIZE)
         return 0;
@@ -1181,6 +1201,11 @@ static int s390x_pkey_ecd_digestsign25519(EVP_MD_CTX *ctx,
     const ECX_KEY *edkey = evp_pkey_get_legacy(EVP_MD_CTX_get_pkey_ctx(ctx)->pkey);
     int rc;
 
+    if (edkey == NULL) {
+        ERR_raise(ERR_LIB_EC, EC_R_INVALID_KEY);
+        return 0;
+    }
+
     if (sig == NULL) {
         *siglen = ED25519_SIGSIZE;
         return 1;
@@ -1220,6 +1245,11 @@ static int s390x_pkey_ecd_digestsign448(EVP_MD_CTX *ctx,
     } param;
     const ECX_KEY *edkey = evp_pkey_get_legacy(EVP_MD_CTX_get_pkey_ctx(ctx)->pkey);
     int rc;
+
+    if (edkey == NULL) {
+        ERR_raise(ERR_LIB_EC, EC_R_INVALID_KEY);
+        return 0;
+    }
 
     if (sig == NULL) {
         *siglen = ED448_SIGSIZE;
@@ -1263,6 +1293,11 @@ static int s390x_pkey_ecd_digestverify25519(EVP_MD_CTX *ctx,
     } param;
     const ECX_KEY *edkey = evp_pkey_get_legacy(EVP_MD_CTX_get_pkey_ctx(ctx)->pkey);
 
+    if (edkey == NULL) {
+        ERR_raise(ERR_LIB_EC, EC_R_INVALID_KEY);
+        return 0;
+    }
+
     if (siglen != ED25519_SIGSIZE)
         return 0;
 
@@ -1289,6 +1324,11 @@ static int s390x_pkey_ecd_digestverify448(EVP_MD_CTX *ctx,
         unsigned long long buff[512];
     } param;
     const ECX_KEY *edkey = evp_pkey_get_legacy(EVP_MD_CTX_get_pkey_ctx(ctx)->pkey);
+
+    if (edkey == NULL) {
+        ERR_raise(ERR_LIB_EC, EC_R_INVALID_KEY);
+        return 0;
+    }
 
     if (siglen != ED448_SIGSIZE)
         return 0;

--- a/crypto/evp/p_dec.c
+++ b/crypto/evp/p_dec.c
@@ -22,15 +22,19 @@ int EVP_PKEY_decrypt_old(unsigned char *key, const unsigned char *ek, int ekl,
                          EVP_PKEY *priv)
 {
     int ret = -1;
+    RSA *rsa = NULL;
 
     if (EVP_PKEY_get_id(priv) != EVP_PKEY_RSA) {
         ERR_raise(ERR_LIB_EVP, EVP_R_PUBLIC_KEY_NOT_RSA);
         goto err;
     }
 
+    rsa = evp_pkey_get0_RSA_int(priv);
+    if (rsa == NULL)
+        goto err;
+    
     ret =
-        RSA_private_decrypt(ekl, ek, key, evp_pkey_get0_RSA_int(priv),
-                            RSA_PKCS1_PADDING);
+        RSA_private_decrypt(ekl, ek, key, rsa, RSA_PKCS1_PADDING);
  err:
     return ret;
 }

--- a/crypto/evp/p_enc.c
+++ b/crypto/evp/p_enc.c
@@ -22,15 +22,19 @@ int EVP_PKEY_encrypt_old(unsigned char *ek, const unsigned char *key,
                          int key_len, EVP_PKEY *pubk)
 {
     int ret = 0;
+    RSA *rsa = NULL;
 
     if (EVP_PKEY_get_id(pubk) != EVP_PKEY_RSA) {
         ERR_raise(ERR_LIB_EVP, EVP_R_PUBLIC_KEY_NOT_RSA);
         goto err;
     }
 
+    rsa = evp_pkey_get0_RSA_int(pubk);
+    if (rsa == NULL)
+        goto err;
+   
     ret =
-        RSA_public_encrypt(key_len, key, ek, evp_pkey_get0_RSA_int(pubk),
-                           RSA_PKCS1_PADDING);
+        RSA_public_encrypt(key_len, key, ek, rsa, RSA_PKCS1_PADDING);
  err:
     return ret;
 }


### PR DESCRIPTION
evp_pkey_get_legacy() will return NULL on failure, however several
uses of it or its wrappers does not check the return value of
evp_pkey_get_legacy(), which could lead to NULL pointer dereference.

Fix those possible bugs by adding NULL checking.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->
