### PR TITLE
Fix: ticket_lifetime_hint may exceed 1 week in TLSv1.3

### DIFF
--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -6754,7 +6754,7 @@ static int test_ticket_lifetime(int idx)
         version = TLS1_2_VERSION;
     }
 
-    if (!TEST_true(create_ssl_ctx_pair(libctx, TLS_server_method(),
+    if (!TEST_true(create_ssl_ctx_pair(TLS_server_method(),
                                        TLS_client_method(), version, version,
                                        &sctx, &cctx, cert, privkey)))
         goto end;


### PR DESCRIPTION
libctx was left in cherry-pick from master/3.0 cherry-pick

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
