### PR TITLE
doc: fix example in ssh KDF man page.

### DIFF
--- a/doc/man7/EVP_KDF-SSHKDF.pod
+++ b/doc/man7/EVP_KDF-SSHKDF.pod
@@ -103,7 +103,7 @@ This example derives an 8 byte IV using SHA-256 with a 1K "key" and appropriate
 
  EVP_KDF *kdf;
  EVP_KDF_CTX *kctx;
- const char type = EVP_KDF_SSHKDF_TYPE_INITIAL_IV_CLI_TO_SRV;
+ char type = EVP_KDF_SSHKDF_TYPE_INITIAL_IV_CLI_TO_SRV;
  unsigned char key[1024] = "01234...";
  unsigned char xcghash[32] = "012345...";
  unsigned char session_id[32] = "012345...";
@@ -126,7 +126,7 @@ This example derives an 8 byte IV using SHA-256 with a 1K "key" and appropriate
  *p++ = OSSL_PARAM_construct_utf8_string(OSSL_KDF_PARAM_SSHKDF_TYPE,
                                          &type, sizeof(type));
  *p = OSSL_PARAM_construct_end();
- if (EVP_KDF_derive(kctx, out, &outlen, params) <= 0)
+ if (EVP_KDF_derive(kctx, out, outlen, params) <= 0)
      /* Error */
 
 


### PR DESCRIPTION
Fixing a const/non-const issue that was mentioned on openssl-users

- [x] documentation is added or updated
- [ ] tests are added or updated
