### PR TITLE
Document the fact that setting a BIO create function means the BIO will no longer be marked as initialised

### DIFF
--- a/doc/man3/BIO_meth_new.pod
+++ b/doc/man3/BIO_meth_new.pod
@@ -118,7 +118,10 @@ for creating a new instance of the BIO respectively. This function will be
 called in response to the application calling BIO_new() and passing
 in a pointer to the current BIO_METHOD. The BIO_new() function will allocate the
 memory for the new BIO, and a pointer to this newly allocated structure will
-be passed as a parameter to the function.
+be passed as a parameter to the function. If a create function is set,
+BIO_new() will not mark the BIO as initialised on allocation.
+L<BIO_set_init(3)> must then be called either by the create function, or later,
+by a BIO ctrl function, once BIO initialisation is complete.
 
 BIO_meth_get_destroy() and BIO_meth_set_destroy() get and set the function used
 for destroying an instance of a BIO respectively. This function will be


### PR DESCRIPTION
We use custom logging BIOs for `SSL_trace()`.  Adding reference counting (using create and free callbacks) for those BIOs to figure out when it's safe to free the BIO methods broke things in an unexpected way.

Apparently all the internal BIO create callbacks call `BIO_set_init(<bio>, 1)` but this isn't documented as required anywhere.  It's also not documented that setting a create callback for a BIO method will mean that `BIO_new()` will no longer mark the BIO as initialised on allocation.

Honestly I'm not convinced of the utility of the `init` field.  It seems to always be toggled to `1` by the create callback and toggled back to `0` by the free callbacks. I'd just as rather submit a PR to remove it and turn `BIO_set_init` and `BIO_get_init` into no ops... or at least call `BIO_set_init` automatically in `BIO_new` if there's a positive return code from the create callback, and again in `BIO_free`.

But If there's no appetite for those solutions, this PR at least documents the requirement to explicitly mark BIOs as initialised to save other custom BIO authors some head scratching.

##### Checklist
- [x] documentation is added or updated

