### PR TITLE
Fix BSAES operation when configured -DOPENSSL_AES_CONST_TIME

### DIFF
--- a/crypto/aes/asm/bsaes-armv8.pl
+++ b/crypto/aes/asm/bsaes-armv8.pl
@@ -61,8 +61,8 @@ __END__
 .text
 
 .extern AES_cbc_encrypt
-.extern AES_encrypt
-.extern AES_decrypt
+.extern ossl_bsaes_encrypt
+.extern ossl_bsaes_decrypt
 
 .type   _bsaes_decrypt8,%function
 .align  4
@@ -1239,7 +1239,7 @@ ossl_bsaes_cbc_encrypt:
         mov     v8.16b, v15.16b
         mov     v15.16b, v0.16b
         mov     x2, x3
-        bl      AES_decrypt
+        bl      ossl_bsaes_decrypt
         ldr     x14, [sp, #16]
         ldp     x1, x4, [sp], #32
         ldr     q0, [x1]                    // load result
@@ -1439,7 +1439,7 @@ ossl_bsaes_ctr32_encrypt_blocks:
         add     x1, sp, #64                 // output on the stack
         mov     x2, x22                     // key
 
-        bl      AES_encrypt
+        bl      ossl_bsaes_encrypt
 
         ldr     q0, [x19], #16              // load input
         ldr     q1, [sp, #64]               // load encrypted counter
@@ -1508,7 +1508,7 @@ ossl_bsaes_xts_encrypt:
         mov     x0, x5                      // iv[]
         mov     x1, sp
         mov     x2, x4                      // key2
-        bl      AES_encrypt
+        bl      ossl_bsaes_encrypt
         ldr     q11, [sp], #16
 
         ldr     w1, [x23, #240]             // get # of rounds
@@ -1837,11 +1837,11 @@ ossl_bsaes_xts_encrypt:
         sub     x0, sp, #16
         sub     x1, sp, #16
         mov     x2, x23
-        mov     v13.d[0], v11.d[1]          // just in case AES_encrypt corrupts top half of callee-saved SIMD registers
+        mov     v13.d[0], v11.d[1]          // just in case ossl_bsaes_encrypt corrupts top half of callee-saved SIMD registers
         mov     v14.d[0], v12.d[1]
         str     q0, [sp, #-16]!
 
-        bl      AES_encrypt
+        bl      ossl_bsaes_encrypt
 
         ldr     q0, [sp], #16
         trn1    v13.2d, v11.2d, v13.2d
@@ -1876,9 +1876,9 @@ ossl_bsaes_xts_encrypt:
         mov     x1, sp
         mov     x2, x23
         mov     x21, x6
-        mov     v13.d[0], v11.d[1]          // just in case AES_encrypt corrupts top half of callee-saved SIMD registers
+        mov     v13.d[0], v11.d[1]          // just in case ossl_bsaes_encrypt corrupts top half of callee-saved SIMD registers
 
-        bl      AES_encrypt
+        bl      ossl_bsaes_encrypt
 
         trn1    v11.2d, v11.2d, v13.2d
         ldr     q0, [sp], #16
@@ -1953,7 +1953,7 @@ ossl_bsaes_xts_decrypt:
         mov     x0, x5                      // iv[]
         mov     x1, sp
         mov     x2, x4                      // key2
-        bl      AES_encrypt
+        bl      ossl_bsaes_encrypt
         ldr     q11, [sp], #16
 
         ldr     w1, [x23, #240]             // get # of rounds
@@ -2288,11 +2288,11 @@ ossl_bsaes_xts_decrypt:
         sub     x0, sp, #16
         sub     x1, sp, #16
         mov     x2, x23
-        mov     v13.d[0], v11.d[1]          // just in case AES_decrypt corrupts top half of callee-saved SIMD registers
+        mov     v13.d[0], v11.d[1]          // just in case ossl_bsaes_decrypt corrupts top half of callee-saved SIMD registers
         mov     v14.d[0], v12.d[1]
         str     q0, [sp, #-16]!
 
-        bl      AES_decrypt
+        bl      ossl_bsaes_decrypt
 
         ldr     q0, [sp], #16
         trn1    v13.2d, v11.2d, v13.2d
@@ -2319,10 +2319,10 @@ ossl_bsaes_xts_decrypt:
         mov     x0, sp
         mov     x1, sp
         mov     x2, x23
-        mov     v13.d[0], v11.d[1]          // just in case AES_decrypt corrupts top half of callee-saved SIMD registers
+        mov     v13.d[0], v11.d[1]          // just in case ossl_bsaes_decrypt corrupts top half of callee-saved SIMD registers
         mov     v14.d[0], v12.d[1]
 
-        bl      AES_decrypt
+        bl      ossl_bsaes_decrypt
 
         trn1    v12.2d, v12.2d, v14.2d
         trn1    v11.2d, v11.2d, v13.2d
@@ -2354,7 +2354,7 @@ ossl_bsaes_xts_decrypt:
         mov     x2, x23
         mov     x21, x6
 
-        bl      AES_decrypt
+        bl      ossl_bsaes_decrypt
 
         trn1    v11.2d, v11.2d, v13.2d
         ldr     q0, [sp], #16

--- a/crypto/evp/e_aes.c
+++ b/crypto/evp/e_aes.c
@@ -2438,8 +2438,8 @@ static int aes_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
 #endif
 #ifdef BSAES_CAPABLE
         if (BSAES_CAPABLE && mode == EVP_CIPH_CBC_MODE) {
-            ret = AES_set_decrypt_key(key, keylen, &dat->ks.ks);
-            dat->block = (block128_f) AES_decrypt;
+            ret = ossl_bsaes_set_decrypt_key(key, keylen, &dat->ks.ks);
+            dat->block = (block128_f) ossl_bsaes_decrypt;
             dat->stream.cbc = (cbc128_f) ossl_bsaes_cbc_encrypt;
         } else
 #endif
@@ -2478,8 +2478,8 @@ static int aes_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
 #endif
 #ifdef BSAES_CAPABLE
     if (BSAES_CAPABLE && mode == EVP_CIPH_CTR_MODE) {
-        ret = AES_set_encrypt_key(key, keylen, &dat->ks.ks);
-        dat->block = (block128_f) AES_encrypt;
+        ret = ossl_bsaes_set_encrypt_key(key, keylen, &dat->ks.ks);
+        dat->block = (block128_f) ossl_bsaes_encrypt;
         dat->stream.ctr = (ctr128_f) ossl_bsaes_ctr32_encrypt_blocks;
     } else
 #endif
@@ -2830,9 +2830,9 @@ static int aes_gcm_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
 #endif
 #ifdef BSAES_CAPABLE
             if (BSAES_CAPABLE) {
-                AES_set_encrypt_key(key, keylen, &gctx->ks.ks);
+                ossl_bsaes_set_encrypt_key(key, keylen, &gctx->ks.ks);
                 CRYPTO_gcm128_init(&gctx->gcm, &gctx->ks,
-                                   (block128_f) AES_encrypt);
+                                   (block128_f) ossl_bsaes_encrypt);
                 gctx->ctr = (ctr128_f) ossl_bsaes_ctr32_encrypt_blocks;
                 break;
             } else
@@ -3294,9 +3294,23 @@ static int aes_xts_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
             } else
 #endif
 #ifdef BSAES_CAPABLE
-            if (BSAES_CAPABLE)
-                xctx->stream = enc ? ossl_bsaes_xts_encrypt : ossl_bsaes_xts_decrypt;
-            else
+            if (BSAES_CAPABLE) {
+                if (enc) {
+                    xctx->stream = ossl_bsaes_xts_encrypt;
+                    ossl_bsaes_set_encrypt_key(key, bits, &xctx->ks1.ks);
+                    xctx->xts.block1 = (block128_f) ossl_bsaes_encrypt;
+                } else {
+                    xctx->stream = ossl_bsaes_xts_decrypt;
+                    ossl_bsaes_set_decrypt_key(key, bits, &xctx->ks1.ks);
+                    xctx->xts.block1 = (block128_f) ossl_bsaes_decrypt;
+                }
+
+                ossl_bsaes_set_encrypt_key(key + bytes, bits, &xctx->ks2.ks);
+                xctx->xts.block2 = (block128_f) ossl_bsaes_encrypt;
+
+                xctx->xts.key1 = &xctx->ks1;
+                break;
+            } else
 #endif
 #ifdef VPAES_CAPABLE
             if (VPAES_CAPABLE) {

--- a/include/crypto/aes_platform.h
+++ b/include/crypto/aes_platform.h
@@ -29,6 +29,23 @@ void vpaes_cbc_encrypt(const unsigned char *in,
 # endif /* VPAES_ASM */
 
 # ifdef BSAES_ASM
+
+#  if defined(OPENSSL_AES_CONST_TIME) && !defined(AES_ASM)
+int ossl_bsaes_set_encrypt_key(const unsigned char *userKey, const int bits,
+                               AES_KEY *key);
+int ossl_bsaes_set_decrypt_key(const unsigned char *userKey, const int bits,
+                               AES_KEY *key);
+void ossl_bsaes_encrypt(const unsigned char *in, unsigned char *out,
+                        const AES_KEY *key);
+void ossl_bsaes_decrypt(const unsigned char *in, unsigned char *out,
+                        const AES_KEY *key);
+#  else
+#   define ossl_bsaes_set_encrypt_key AES_set_encrypt_key
+#   define ossl_bsaes_set_decrypt_key AES_set_decrypt_key
+#   define ossl_bsaes_encrypt         AES_encrypt
+#   define ossl_bsaes_decrypt         AES_decrypt
+#  endif
+
 void ossl_bsaes_cbc_encrypt(const unsigned char *in, unsigned char *out,
                             size_t length, const AES_KEY *key,
                             unsigned char ivec[16], int enc);

--- a/providers/implementations/ciphers/cipher_aes_gcm_hw.c
+++ b/providers/implementations/ciphers/cipher_aes_gcm_hw.c
@@ -36,7 +36,7 @@ static int aes_gcm_initkey(PROV_GCM_CTX *ctx, const unsigned char *key,
 
 # ifdef BSAES_CAPABLE
     if (BSAES_CAPABLE) {
-        GCM_HW_SET_KEY_CTR_FN(ks, AES_set_encrypt_key, AES_encrypt,
+        GCM_HW_SET_KEY_CTR_FN(ks, ossl_bsaes_set_encrypt_key, ossl_bsaes_encrypt,
                               ossl_bsaes_ctr32_encrypt_blocks);
     } else
 # endif /* BSAES_CAPABLE */

--- a/providers/implementations/ciphers/cipher_aes_hw.c
+++ b/providers/implementations/ciphers/cipher_aes_hw.c
@@ -44,8 +44,8 @@ static int cipher_hw_aes_initkey(PROV_CIPHER_CTX *dat,
 #endif
 #ifdef BSAES_CAPABLE
         if (BSAES_CAPABLE && dat->mode == EVP_CIPH_CBC_MODE) {
-            ret = AES_set_decrypt_key(key, keylen * 8, ks);
-            dat->block = (block128_f)AES_decrypt;
+            ret = ossl_bsaes_set_decrypt_key(key, keylen * 8, ks);
+            dat->block = (block128_f)ossl_bsaes_decrypt;
             dat->stream.cbc = (cbc128_f)ossl_bsaes_cbc_encrypt;
         } else
 #endif
@@ -89,8 +89,8 @@ static int cipher_hw_aes_initkey(PROV_CIPHER_CTX *dat,
 #endif
 #ifdef BSAES_CAPABLE
     if (BSAES_CAPABLE && dat->mode == EVP_CIPH_CTR_MODE) {
-        ret = AES_set_encrypt_key(key, keylen * 8, ks);
-        dat->block = (block128_f)AES_encrypt;
+        ret = ossl_bsaes_set_encrypt_key(key, keylen * 8, ks);
+        dat->block = (block128_f)ossl_bsaes_encrypt;
         dat->stream.ctr = (ctr128_f)ossl_bsaes_ctr32_encrypt_blocks;
     } else
 #endif

--- a/providers/implementations/ciphers/cipher_aes_xts_hw.c
+++ b/providers/implementations/ciphers/cipher_aes_xts_hw.c
@@ -65,8 +65,9 @@ static int cipher_hw_aes_xts_generic_initkey(PROV_CIPHER_CTX *ctx,
 
 #ifdef BSAES_CAPABLE
     if (BSAES_CAPABLE) {
-        stream_enc = ossl_bsaes_xts_encrypt;
-        stream_dec = ossl_bsaes_xts_decrypt;
+        XTS_SET_KEY_FN(ossl_bsaes_set_encrypt_key, ossl_bsaes_set_decrypt_key,
+                       ossl_bsaes_encrypt, ossl_bsaes_decrypt, ossl_bsaes_xts_encrypt, ossl_bsaes_xts_decrypt);
+        return 1;
     } else
 #endif /* BSAES_CAPABLE */
 #ifdef VPAES_CAPABLE


### PR DESCRIPTION
Commit 0051746 redefined `AES_set_encrypt_key`, `AES_set_decrypt_key`,
`AES_encrypt` and `AES_decrypt`, initially unless you configured
`-DOPENSSL_NO_AES_CONST_TIME`, and more recently only if you did configure
`-DOPENSSL_AES_CONST_TIME`.

The problem with this is that these functions also form part of the BSAES
algorithms, and the key format is incompatible so you can't mix and match.

To fix this, if you configure `-DOPENSSL_AES_CONST_TIME`, you now get both
sets of functions: the old ones now have an `ossl_bsaes_` prefix to match the
style of the assembly functions, and the new ones retain the `AES_` prefix.
In the default configuration, the old functions are used whether BSAES is
selected or not, and have the `AES_` prefix.

Tested on Cortex-A72 without hardware AES (Raspberry Pi 4) in AArch64 mode,
in conjunction with #17988. Between them, the two MRs fix  #17958.

Also tested on AArch32. However this target doesn't build `crypto/aes/aes_core.c`
and defines `AES_ASM`, so is unaffected by the constant-time AES patch. The
only other architecture that can define `BSAES_CAPABLE` is x86_64, and while I
haven't tested it, it's configured similarly to AArch32 so I believe it should be unaffected.
