### PR TITLE
OSSL_PARAM_get_*_ptr: Drop errors from ptr/string mismatch

### DIFF
--- a/crypto/params.c
+++ b/crypto/params.c
@@ -1506,14 +1506,25 @@ static int get_string_ptr_internal(const OSSL_PARAM *p, const void **val,
 
 int OSSL_PARAM_get_utf8_string_ptr(const OSSL_PARAM *p, const char **val)
 {
-    return OSSL_PARAM_get_utf8_ptr(p, val)
-        || get_string_ptr_internal(p, (const void **)val, NULL,
-                                   OSSL_PARAM_UTF8_STRING);
+    int rv;
+
+    ERR_set_mark();
+    rv = OSSL_PARAM_get_utf8_ptr(p, val);
+    ERR_pop_to_mark();
+
+    return rv || get_string_ptr_internal(p, (const void **)val, NULL,
+                                         OSSL_PARAM_UTF8_STRING);
 }
 
 int OSSL_PARAM_get_octet_string_ptr(const OSSL_PARAM *p, const void **val,
                                     size_t *used_len)
 {
-    return OSSL_PARAM_get_octet_ptr(p, val, used_len)
-        || get_string_ptr_internal(p, val, used_len, OSSL_PARAM_OCTET_STRING);
+    int rv;
+
+    ERR_set_mark();
+    rv = OSSL_PARAM_get_octet_ptr(p, val, used_len);
+    ERR_pop_to_mark();
+
+    return rv || get_string_ptr_internal(p, val, used_len,
+                                         OSSL_PARAM_OCTET_STRING);
 }


### PR DESCRIPTION
Those errors started to appear when decoding as we use get_ptr functions there on string parameters.