### PR TITLE
Fix AIX build when no-shared is passed to Configure.

### DIFF
--- a/Configurations/platform/AIX.pm
+++ b/Configurations/platform/AIX.pm
@@ -25,5 +25,5 @@ sub staticname {
     return $in_libname
         if $unified_info{attributes}->{libraries}->{$_[1]}->{noinst};
 
-    return platform::BASE->staticname($_[1]) . '_a';
+    return platform::BASE->staticname($_[1]) . ($disabled{shared} ? '' : '_a');
 }


### PR DESCRIPTION
AIX shared libs are also .a files so the AIX platform staticname() appends a '_a' to the name to avoid a collision.  However, this must not be done when no-shared is passed to Configure or the binaries that link with -lcrypto and -lssl be unable to link as those libraries won't exist without the '_a' suffix.

CLA: trivial