### PR TITLE
kdf: avoid NULL dereference on malloc failure in sshkdf

### DIFF
--- a/providers/implementations/kdfs/sshkdf.c
+++ b/providers/implementations/kdfs/sshkdf.c
@@ -60,7 +60,8 @@ static void *kdf_sshkdf_new(void *provctx)
 
     if ((ctx = OPENSSL_zalloc(sizeof(*ctx))) == NULL)
         ERR_raise(ERR_LIB_PROV, ERR_R_MALLOC_FAILURE);
-    ctx->provctx = provctx;
+    else
+        ctx->provctx = provctx;
     return ctx;
 }
 


### PR DESCRIPTION
Fixes #18009

- [ ] documentation is added or updated
- [ ] tests are added or updated
