### PR TITLE
test_fipsinstall: Fallback to config(FIPSKEY) for the FIPSKEY

### DIFF
--- a/test/recipes/03-test_fipsinstall.t
+++ b/test/recipes/03-test_fipsinstall.t
@@ -27,7 +27,7 @@ plan skip_all => "Test only supported in a fips build" if disabled("fips");
 plan tests => 29;
 
 my $infile = bldtop_file('providers', platform->dso('fips'));
-my $fipskey = $ENV{FIPSKEY} // '00';
+my $fipskey = $ENV{FIPSKEY} // config('FIPSKEY') // '00';
 
 # Read in a text $infile and replace the regular expression in $srch with the
 # value in $repl and output to a new file $outfile.


### PR DESCRIPTION
This can be useful if running the test directly and not through the Makefile.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
