### PR TITLE
Fix a possible NULL pointer dereference in create_cert_store()

### DIFF
--- a/apps/ts.c
+++ b/apps/ts.c
@@ -980,6 +980,10 @@ static X509_STORE *create_cert_store(const char *CApath, const char *CAfile,
     const char *propq = app_get0_propq();
 
     cert_ctx = X509_STORE_new();
+    if (cert_ctx == NULL) {
+        BIO_printf(bio_err, "memory allocation failure\n");
+        return NULL;
+    }
     X509_STORE_set_verify_cb(cert_ctx, verify_cb);
     if (CApath != NULL) {
         lookup = X509_STORE_add_lookup(cert_ctx, X509_LOOKUP_hash_dir());


### PR DESCRIPTION
In create_cert_store(), X509_STORE_new() is called and there is a
dereference of it in following function X509_STORE_add_lookup()
without check, which could lead to NULL pointer dereference.

Fix this by adding a NULL check of X509_STORE_new()

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
