### PR TITLE
Crypto/evp: Fix null pointer dereference

### DIFF
--- a/crypto/evp/p5_crpt2.c
+++ b/crypto/evp/p5_crpt2.c
@@ -42,6 +42,8 @@ int ossl_pkcs5_pbkdf2_hmac_ex(const char *pass, int passlen,
         salt = (unsigned char *)empty;
 
     kdf = EVP_KDF_fetch(libctx, OSSL_KDF_NAME_PBKDF2, propq);
+    if (kdf == NULL)
+         return 0;
     kctx = EVP_KDF_CTX_new(kdf);
     EVP_KDF_free(kdf);
     if (kctx == NULL)


### PR DESCRIPTION
Check the return value of EVP_KDF_fetch to avoid a potential
null pointer dereference.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
