### PR TITLE
Use OPENSSL_zalloc to avoid uninitialized read

### DIFF
--- a/ssl/pqueue.c
+++ b/ssl/pqueue.c
@@ -17,7 +17,7 @@ struct pqueue_st {
 
 pitem *pitem_new(unsigned char *prio64be, void *data)
 {
-    pitem *item = OPENSSL_malloc(sizeof(*item));
+    pitem *item = OPENSSL_zalloc(sizeof(*item));
 
     if (item == NULL) {
         ERR_raise(ERR_LIB_SSL, ERR_R_MALLOC_FAILURE);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
