### PR TITLE
Add return check of EVP_PKEY_copy_parameters() in ssl_set_cert_and_key()

### DIFF
--- a/ssl/ssl_rsa.c
+++ b/ssl/ssl_rsa.c
@@ -921,11 +921,17 @@ static int ssl_set_cert_and_key(SSL *ssl, SSL_CTX *ctx, X509 *x509, EVP_PKEY *pr
                 goto out;
             } else {
                 /* copy to privatekey from pubkey */
-                EVP_PKEY_copy_parameters(privatekey, pubkey);
+                if (!EVP_PKEY_copy_parameters(privatekey, pubkey)) {
+                    ERR_raise(ERR_LIB_SSL, SSL_R_COPY_PARAMETERS_FAILED);
+                    goto out;
+                }
             }
         } else if (EVP_PKEY_missing_parameters(pubkey)) {
             /* copy to pubkey from privatekey */
-            EVP_PKEY_copy_parameters(pubkey, privatekey);
+            if (!EVP_PKEY_copy_parameters(pubkey, privatekey)) {
+                ERR_raise(ERR_LIB_SSL, SSL_R_COPY_PARAMETERS_FAILED);
+                goto out;
+            }
         } /* else both have parameters */
 
         /* check that key <-> cert match */


### PR DESCRIPTION
It seems the return value of EVP_PKEY_copy_parameters() in
ssl_set_cert_and_key() are not checked, and could lead to null pointer dereference in
EVP_PKEY_eq() function.

However those functions are complicated and this fix is suggested by
a static analyzer, so please advise.
