### PR TITLE
Fixes for building openssl_3.0.2 on WinCE

### DIFF
--- a/crypto/bio/bio_addr.c
+++ b/crypto/bio/bio_addr.c
@@ -238,7 +238,7 @@ static int addr_strings(const BIO_ADDR *ap, int numeric,
             } else
 # endif
             {
-                ERR_raise_data(ERR_LIB_BIO, ERR_R_SYS_LIB, gai_strerror(ret));
+                ERR_raise_data(ERR_LIB_BIO, ERR_R_SYS_LIB, gai_strerrorW(ret));
             }
             return 0;
         }
@@ -748,7 +748,7 @@ int BIO_lookup_ex(const char *host, const char *service, int lookup_type,
             }
 # endif
             ERR_raise_data(ERR_LIB_BIO, ERR_R_SYS_LIB,
-                           gai_strerror(old_ret ? old_ret : gai_ret));
+                           gai_strerrorW(old_ret ? old_ret : gai_ret));
             break;
         }
     } else {

--- a/crypto/bio/bio_addr.c
+++ b/crypto/bio/bio_addr.c
@@ -238,7 +238,18 @@ static int addr_strings(const BIO_ADDR *ap, int numeric,
             } else
 # endif
             {
-                ERR_raise_data(ERR_LIB_BIO, ERR_R_SYS_LIB, gai_strerrorW(ret));
+#if !defined(_WIN32_WCE)
+                ERR_raise_data(ERR_LIB_BIO, ERR_R_SYS_LIB, gai_strerror(ret));
+#else
+                wchar_t *wstr_error = gai_strerrorW(ret);
+                size_t length = wcslen(wstr_error) + 1;
+                char *str_error = OPENSSL_malloc(length);
+                if (str_error != NULL) {
+                    wcstombs(str_error, wstr_error, length);
+                    ERR_raise_data(ERR_LIB_BIO, ERR_R_SYS_LIB, str_error);
+                    OPENSSL_free(str_error);
+                }
+#endif
             }
             return 0;
         }
@@ -747,8 +758,21 @@ int BIO_lookup_ex(const char *host, const char *service, int lookup_type,
                 goto retry;
             }
 # endif
+#if !defined(_WIN32_WCE)
             ERR_raise_data(ERR_LIB_BIO, ERR_R_SYS_LIB,
-                           gai_strerrorW(old_ret ? old_ret : gai_ret));
+                           gai_strerror(old_ret ? old_ret : gai_ret));
+#else
+            {
+                wchar_t *wstr_error = gai_strerrorW(old_ret ? old_ret : gai_ret);
+                size_t length = wcslen(wstr_error) + 1;
+                char *str_error = OPENSSL_malloc(length);
+                if (str_error != NULL) {
+                    wcstombs(str_error, wstr_error, length);
+                    ERR_raise_data(ERR_LIB_BIO, ERR_R_SYS_LIB, str_error);
+                    OPENSSL_free(str_error);
+                }
+            }
+#endif
             break;
         }
     } else {

--- a/crypto/bio/bio_addr.c
+++ b/crypto/bio/bio_addr.c
@@ -238,18 +238,19 @@ static int addr_strings(const BIO_ADDR *ap, int numeric,
             } else
 # endif
             {
-#if !defined(_WIN32_WCE)
+# if !defined(_WIN32_WCE)
                 ERR_raise_data(ERR_LIB_BIO, ERR_R_SYS_LIB, gai_strerror(ret));
-#else
+# else
                 wchar_t *wstr_error = gai_strerrorW(ret);
                 size_t length = wcslen(wstr_error) + 1;
                 char *str_error = OPENSSL_malloc(length);
+
                 if (str_error != NULL) {
                     wcstombs(str_error, wstr_error, length);
                     ERR_raise_data(ERR_LIB_BIO, ERR_R_SYS_LIB, str_error);
                     OPENSSL_free(str_error);
                 }
-#endif
+# endif
             }
             return 0;
         }
@@ -758,21 +759,22 @@ int BIO_lookup_ex(const char *host, const char *service, int lookup_type,
                 goto retry;
             }
 # endif
-#if !defined(_WIN32_WCE)
+# if !defined(_WIN32_WCE)
             ERR_raise_data(ERR_LIB_BIO, ERR_R_SYS_LIB,
                            gai_strerror(old_ret ? old_ret : gai_ret));
-#else
+# else
             {
                 wchar_t *wstr_error = gai_strerrorW(old_ret ? old_ret : gai_ret);
                 size_t length = wcslen(wstr_error) + 1;
                 char *str_error = OPENSSL_malloc(length);
+
                 if (str_error != NULL) {
                     wcstombs(str_error, wstr_error, length);
                     ERR_raise_data(ERR_LIB_BIO, ERR_R_SYS_LIB, str_error);
                     OPENSSL_free(str_error);
                 }
             }
-#endif
+# endif
             break;
         }
     } else {

--- a/crypto/threads_win.c
+++ b/crypto/threads_win.c
@@ -207,10 +207,10 @@ int CRYPTO_atomic_add(int *val, int amount, int *ret, CRYPTO_RWLOCK *lock)
 int CRYPTO_atomic_or(uint64_t *val, uint64_t op, uint64_t *ret,
                      CRYPTO_RWLOCK *lock)
 {
-#if !defined(_WIN32_WCE)
+# if !defined(_WIN32_WCE)
     *ret = (uint64_t)InterlockedOr64((LONG64 volatile *)val, (LONG64)op) | op;
     return 1;
-#else
+# else
     if (lock == NULL || !CRYPTO_THREAD_write_lock(lock))
         return 0;
     *val |= op;
@@ -220,15 +220,15 @@ int CRYPTO_atomic_or(uint64_t *val, uint64_t op, uint64_t *ret,
         return 0;
 
     return 1;
-#endif
+# endif
 }
 
 int CRYPTO_atomic_load(uint64_t *val, uint64_t *ret, CRYPTO_RWLOCK *lock)
 {
-#if !defined(_WIN32_WCE)
+# if !defined(_WIN32_WCE)
     *ret = (uint64_t)InterlockedOr64((LONG64 volatile *)val, 0);
     return 1;
-#else
+# else
     if (lock == NULL || !CRYPTO_THREAD_read_lock(lock))
         return 0;
     *ret  = *val;
@@ -236,7 +236,7 @@ int CRYPTO_atomic_load(uint64_t *val, uint64_t *ret, CRYPTO_RWLOCK *lock)
         return 0;
 
     return 1;
-#endif
+# endif
 }
 
 int openssl_init_fork_handlers(void)

--- a/include/internal/e_os.h
+++ b/include/internal/e_os.h
@@ -113,7 +113,7 @@
         * definitions at link-time.  This header defines WspiapiLoad() as an
         * __inline function.  https://quality.embarcadero.com/browse/RSP-33806
         */
-#    if !defined(__BORLANDC__) || !defined(__clang__)
+#    if (!defined(__BORLANDC__) || !defined(__clang__)) && !defined(_WIN32_WCE)
 #     include <wspiapi.h>
 #    endif
        /* yes, they have to be #included prior to <windows.h> */

--- a/include/internal/e_os.h
+++ b/include/internal/e_os.h
@@ -404,7 +404,7 @@ inline int nssgetpid();
         && ( (defined(_POSIX_VERSION) && _POSIX_VERSION >= 200112L)      \
              || defined(__sun) || defined(__hpux) || defined(__sgi)      \
              || defined(__osf__) )) \
-      || defined(_WIN32)
+      || (defined(_WIN32) && !defined(_WIN32_WCE))
       /* secure memory is implemented */
 #   else
 #     define OPENSSL_NO_SECURE_MEMORY


### PR DESCRIPTION
1. Excluded the header file "wspiapi.h" for WinCE build.
2. Included OPENSSL_NO_SECURE_MEMORY compilation flag for WinCE build"'
3. Replaced 'gai_strerror' with 'gai_strerrorW'. This change was needed because gai_strerror internally uses FormatMessage which is not defined in WinCE.
4. The function 'InterlockedOr64' is not defined in WinCE.
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->