### PR TITLE
Add return value check of X509V3_add_value() in X509V3_parse_list()

### DIFF
--- a/crypto/x509/v3_utl.c
+++ b/crypto/x509/v3_utl.c
@@ -349,7 +349,9 @@ STACK_OF(CONF_VALUE) *X509V3_parse_list(const char *line)
                     ERR_raise(ERR_LIB_X509V3, X509V3_R_INVALID_EMPTY_NAME);
                     goto err;
                 }
-                X509V3_add_value(ntmp, NULL, &values);
+                if (!X509V3_add_value(ntmp, NULL, &values)) {
+                    goto err;
+                }
             }
             break;
 
@@ -362,7 +364,9 @@ STACK_OF(CONF_VALUE) *X509V3_parse_list(const char *line)
                     ERR_raise(ERR_LIB_X509V3, X509V3_R_INVALID_NULL_VALUE);
                     goto err;
                 }
-                X509V3_add_value(ntmp, vtmp, &values);
+                if (!X509V3_add_value(ntmp, vtmp, &values)) {
+                    goto err;
+                }
                 ntmp = NULL;
                 q = p + 1;
             }
@@ -376,14 +380,18 @@ STACK_OF(CONF_VALUE) *X509V3_parse_list(const char *line)
             ERR_raise(ERR_LIB_X509V3, X509V3_R_INVALID_NULL_VALUE);
             goto err;
         }
-        X509V3_add_value(ntmp, vtmp, &values);
+        if (!X509V3_add_value(ntmp, vtmp, &values)) {
+            goto err;
+        }
     } else {
         ntmp = strip_spaces(q);
         if (!ntmp) {
             ERR_raise(ERR_LIB_X509V3, X509V3_R_INVALID_EMPTY_NAME);
             goto err;
         }
-        X509V3_add_value(ntmp, NULL, &values);
+        if (!X509V3_add_value(ntmp, NULL, &values)) {
+            goto err;
+        }
     }
     OPENSSL_free(linebuf);
     return values;


### PR DESCRIPTION
X509V3_add_value() will return 0 on malloc failure, which could lead to
err logic without check in X509V3_parse_list().

Fix this by adding return value check of X509V3_add_value().
