### PR TITLE
Move types.h #undefs for wincrypt.h compatibility

### DIFF
--- a/include/openssl/types.h
+++ b/include/openssl/types.h
@@ -6,10 +6,23 @@
  * in the file LICENSE in the source distribution or at
  * https://www.openssl.org/source/license.html
  */
+ 
+/*
+ * Unfortunate workaround to avoid symbol conflict with wincrypt.h
+ * See https://github.com/openssl/openssl/issues/9981
+ */
+# ifdef _WIN32
+#  define WINCRYPT_OPENSSL_SYMBOL_COMPAT
+#  undef X509_NAME
+#  undef X509_EXTENSIONS
+#  undef PKCS7_ISSUER_AND_SERIAL
+#  undef PKCS7_SIGNER_INFO
+#  undef OCSP_REQUEST
+#  undef OCSP_RESPONSE
+# endif
 
 #ifndef OPENSSL_TYPES_H
 # define OPENSSL_TYPES_H
-# pragma once
 
 # include <limits.h>
 
@@ -69,15 +82,6 @@ typedef struct asn1_string_table_st ASN1_STRING_TABLE;
 typedef struct ASN1_ITEM_st ASN1_ITEM;
 typedef struct asn1_pctx_st ASN1_PCTX;
 typedef struct asn1_sctx_st ASN1_SCTX;
-
-# ifdef _WIN32
-#  undef X509_NAME
-#  undef X509_EXTENSIONS
-#  undef PKCS7_ISSUER_AND_SERIAL
-#  undef PKCS7_SIGNER_INFO
-#  undef OCSP_REQUEST
-#  undef OCSP_RESPONSE
-# endif
 
 # ifdef BIGNUM
 #  undef BIGNUM


### PR DESCRIPTION
+ Always undef the symbols that may have been #define-d
  by wincrypt.h after the first inclusion of types.h to
  avoid errors from wincrypt.h symbols being used to
  compile OpenSSL code
+ Also need to remove #pragma once for this approach to work
+ Define WINCRYPT_OPENSSL_SYMBOL_COMPAT to enable wincrypt
  symbol prefix at some point in future

Fixes #9981

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
