### PR TITLE
Fix wild pointer dereference in make_ocsp_response()

### DIFF
--- a/apps/ocsp.c
+++ b/apps/ocsp.c
@@ -1119,6 +1119,11 @@ static void make_ocsp_response(BIO *err, OCSP_RESPONSE **resp, OCSP_REQUEST *req
             single = OCSP_basic_add1_status(bs, cid,
                                             V_OCSP_CERTSTATUS_REVOKED,
                                             reason, revtm, thisupd, nextupd);
+            if (single == NULL) {
+                *resp = OCSP_response_create(OCSP_RESPONSE_STATUS_INTERNALERROR,
+                                             NULL);
+                goto end;
+            }
             if (invtm != NULL)
                 OCSP_SINGLERESP_add1_ext_i2d(single, NID_invalidity_date,
                                              invtm, 0, 0);


### PR DESCRIPTION
The function OCSP_basic_add1_status() will return NULL on malloc failure.
However the return value is not checked in make_ocsp_response() 
before passed to OCSP_SINGLERESP_add1_ext_i2d(), and there is 
a wild field pointer in that function, which could lead to a wild pointer dereference.

Fix this by adding return value check.


