### PR TITLE
Document SSL_set_session(pSSL, NULL) behaviour

### DIFF
--- a/doc/man3/SSL_set_session.pod
+++ b/doc/man3/SSL_set_session.pod
@@ -22,7 +22,7 @@ with the L<SSL_session_reused(3)> call.
 If there is already a session set inside B<ssl> (because it was set with
 SSL_set_session() before or because the same B<ssl> was already used for
 a connection), SSL_SESSION_free() will be called for that session. 
-This is also the case when B<session> is a null pointer. If that old
+This is also the case when B<session> is a NULL pointer. If that old
 session is still B<open>, it is considered bad and will be removed from the
 session cache (if used). A session is considered open, if L<SSL_shutdown(3)> was
 not called for the connection (or at least L<SSL_set_shutdown(3)> was used to

--- a/doc/man3/SSL_set_session.pod
+++ b/doc/man3/SSL_set_session.pod
@@ -21,7 +21,8 @@ with the L<SSL_session_reused(3)> call.
 
 If there is already a session set inside B<ssl> (because it was set with
 SSL_set_session() before or because the same B<ssl> was already used for
-a connection), SSL_SESSION_free() will be called for that session. If that old
+a connection), SSL_SESSION_free() will be called for that session. 
+This is also the case when B<session> is a null pointer. If that old
 session is still B<open>, it is considered bad and will be removed from the
 session cache (if used). A session is considered open, if L<SSL_shutdown(3)> was
 not called for the connection (or at least L<SSL_set_shutdown(3)> was used to


### PR DESCRIPTION
Found a mistake in my code because I was expecting that SSL_set_session() on an uninitialized SSL_SESSION* would return 0.
What is your opinion ?
Should the ssl internal session be released in that case ?
Not sure about what I read from the man page.
