### PR TITLE
strcasecmp is not locale-safe, use strcasecmp_l

### DIFF
--- a/apps/ca.c
+++ b/apps/ca.c
@@ -11,6 +11,7 @@
 #include <string.h>
 #include <ctype.h>
 #include <sys/types.h>
+#include <locale.h>
 #include <openssl/conf.h>
 #include <openssl/bio.h>
 #include <openssl/err.h>
@@ -2371,6 +2372,10 @@ static char *make_revocation_str(REVINFO_TYPE rev_type, const char *rev_arg)
     ASN1_OBJECT *otmp;
     ASN1_UTCTIME *revtm = NULL;
     int i;
+    static locale_t c_locale = LC_GLOBAL_LOCALE;
+
+    if (c_locale == LC_GLOBAL_LOCALE)
+        c_locale = newlocale(LC_CTYPE_MASK, "C", 0);
 
     switch (rev_type) {
     case REV_NONE:
@@ -2379,7 +2384,7 @@ static char *make_revocation_str(REVINFO_TYPE rev_type, const char *rev_arg)
 
     case REV_CRL_REASON:
         for (i = 0; i < 8; i++) {
-            if (strcasecmp(rev_arg, crl_reasons[i]) == 0) {
+            if (strcasecmp_l(rev_arg, crl_reasons[i], c_locale) == 0) {
                 reason = crl_reasons[i];
                 break;
             }
@@ -2595,8 +2600,13 @@ int unpack_revinfo(ASN1_TIME **prevtm, int *preason, ASN1_OBJECT **phold,
         }
     }
     if (reason_str) {
+        static locale_t c_locale = LC_GLOBAL_LOCALE;
+
+        if (c_locale == LC_GLOBAL_LOCALE)
+            c_locale = newlocale(LC_CTYPE_MASK, "C", 0);
+
         for (i = 0; i < NUM_REASONS; i++) {
-            if (strcasecmp(reason_str, crl_reasons[i]) == 0) {
+            if (strcasecmp_l(reason_str, crl_reasons[i], c_locale) == 0) {
                 reason_code = i;
                 break;
             }

--- a/apps/cmp.c
+++ b/apps/cmp.c
@@ -13,6 +13,7 @@
 
 #include <string.h>
 #include <ctype.h>
+#include <locale.h>
 
 #include "apps.h"
 #include "http_server.h"
@@ -1758,6 +1759,10 @@ static int handle_opt_geninfo(OSSL_CMP_CTX *ctx)
     OSSL_CMP_ITAV *itav;
     char *endstr;
     char *valptr = strchr(opt_geninfo, ':');
+    static locale_t c_locale = LC_GLOBAL_LOCALE;
+
+    if (c_locale == LC_GLOBAL_LOCALE)
+        c_locale = newlocale(LC_CTYPE_MASK, "C", 0);
 
     if (valptr == NULL) {
         CMP_err("missing ':' in -geninfo option");

--- a/apps/ecparam.c
+++ b/apps/ecparam.c
@@ -9,6 +9,7 @@
  */
 
 #include <string.h>
+#include <locale.h>
 #include <openssl/opensslconf.h>
 #include <openssl/evp.h>
 #include <openssl/encoder.h>
@@ -207,6 +208,7 @@ int ecparam_main(int argc, char **argv)
     if (curve_name != NULL) {
         OSSL_PARAM params[4];
         OSSL_PARAM *p = params;
+        locale_t c_locale;
 
         if (strcmp(curve_name, "secp192r1") == 0) {
             BIO_printf(bio_err,
@@ -228,7 +230,8 @@ int ecparam_main(int argc, char **argv)
                        point_format, 0);
         *p = OSSL_PARAM_construct_end();
 
-        if (strcasecmp(curve_name, "SM2") == 0)
+        c_locale = newlocale(LC_CTYPE_MASK, "C", 0);
+        if (strcasecmp_l(curve_name, "SM2", c_locale) == 0)
             gctx_params = EVP_PKEY_CTX_new_from_name(NULL, "sm2", NULL);
         else
             gctx_params = EVP_PKEY_CTX_new_from_name(NULL, "ec", NULL);

--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -1242,9 +1242,6 @@ static int set_table_opts(unsigned long *flags, const char *arg,
     if (c_locale == LC_GLOBAL_LOCALE)
         c_locale = newlocale(LC_CTYPE_MASK, "C", 0);
 
-     if (c == '-') {
-         c = 0;
-         arg++;
     c = arg[0];
     if (c == '-') {
         c = 0;

--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -684,7 +684,6 @@ int load_cert_certs(const char *uri,
 {
     int ret = 0;
     char *pass_string;
-    static locale_t c_locale = LC_GLOBAL_LOCALE;
 
     if (c_locale == LC_GLOBAL_LOCALE)
         c_locale = newlocale(LC_CTYPE_MASK, "C", 0);

--- a/apps/lib/engine_loader.c
+++ b/apps/lib/engine_loader.c
@@ -20,6 +20,7 @@
 
 # include <stdarg.h>
 # include <string.h>
+# include <locale.h>
 # include <openssl/engine.h>
 # include <openssl/store.h>
 
@@ -70,6 +71,10 @@ static OSSL_STORE_LOADER_CTX *engine_open(const OSSL_STORE_LOADER *loader,
     ENGINE *e = NULL;
     char *keyid = NULL;
     OSSL_STORE_LOADER_CTX *ctx = NULL;
+    static locale_t c_locale = LC_GLOBAL_LOCALE;
+
+    if (c_locale == LC_GLOBAL_LOCALE)
+        c_locale = newlocale(LC_CTYPE_MASK, "C", 0);
 
     if (!CHECK_AND_SKIP_CASE_PREFIX(p, ENGINE_SCHEME_COLON))
         return NULL;

--- a/apps/lib/http_server.c
+++ b/apps/lib/http_server.c
@@ -18,6 +18,7 @@
 #endif
 
 #include <ctype.h>
+#include <locale.h>
 #include "http_server.h"
 #include "internal/sockets.h"
 #include <openssl/err.h>
@@ -301,6 +302,10 @@ int http_server_get_asn1_req(const ASN1_ITEM *it, ASN1_VALUE **preq,
     char *meth, *url, *end;
     ASN1_VALUE *req;
     int ret = 0;
+    static locale_t c_locale = LC_GLOBAL_LOCALE;
+
+    if (c_locale == LC_GLOBAL_LOCALE)
+        c_locale = newlocale(LC_CTYPE_MASK, "C", 0);
 
     *preq = NULL;
     if (ppath != NULL)
@@ -468,10 +473,11 @@ int http_server_get_asn1_req(const ASN1_ITEM *it, ASN1_VALUE **preq,
         }
         *line_end = '\0';
         /* https://tools.ietf.org/html/rfc7230#section-6.3 Persistence */
-        if (found_keep_alive != NULL && strcasecmp(key, "Connection") == 0) {
-            if (strcasecmp(value, "keep-alive") == 0)
+        if (found_keep_alive != NULL
+            && strcasecmp_l(key, "Connection", c_locale) == 0) {
+            if (strcasecmp_l(value, "keep-alive", c_locale) == 0)
                 *found_keep_alive = 1;
-            else if (strcasecmp(value, "close") == 0)
+            else if (strcasecmp_l(value, "close", c_locale) == 0)
                 *found_keep_alive = 0;
         }
     }

--- a/apps/lib/names.c
+++ b/apps/lib/names.c
@@ -8,17 +8,22 @@
  */
 
 #include <string.h>
+#include <locale.h>
 #include <openssl/bio.h>
 #include <openssl/safestack.h>
 #include "names.h"
 
 #ifdef _WIN32
-# define strcasecmp _stricmp
+# define strcasecmp_l(a,b,c) _stricmp(a,b)
 #endif
 
 int name_cmp(const char * const *a, const char * const *b)
 {
-    return strcasecmp(*a, *b);
+    static locale_t c_locale = LC_GLOBAL_LOCALE;
+    if (c_locale == LC_GLOBAL_LOCALE)
+        c_locale = newlocale(LC_CTYPE_MASK, "C", 0);
+
+    return strcasecmp_l(*a, *b, c_locale);
 }
 
 void collect_names(const char *name, void *vdata)

--- a/apps/lib/vms_term_sock.c
+++ b/apps/lib/vms_term_sock.c
@@ -36,6 +36,7 @@
 # include <errno.h>
 # include <starlet.h>
 # include <iodef.h>
+# include <locale.h>
 # ifdef __alpha
 #  include <iosbdef.h>
 # else
@@ -131,8 +132,13 @@ int main (int argc, char *argv[], char *envp[])
         status,
         len;
 
+    static locale_t c_locale = LC_GLOBAL_LOCALE;
+
+    if (c_locale == LC_GLOBAL_LOCALE)
+        c_locale = newlocale(LC_CTYPE_MASK, "C", 0);
+
     LogMessage ("Enter 'q' or 'Q' to quit ...");
-    while (strcasecmp (TermBuff, "Q")) {
+    while (strcasecmp_l (TermBuff, "Q", c_locale)) {
         /*
         ** Create the terminal socket
         */

--- a/apps/rehash.c
+++ b/apps/rehash.c
@@ -20,6 +20,7 @@
 # include <string.h>
 # include <ctype.h>
 # include <sys/stat.h>
+# include <locale.h>
 
 /*
  * Make sure that the processing of symbol names is treated the same as when
@@ -243,12 +244,17 @@ static int do_file(const char *filename, const char *fullpath, enum Hash h)
     unsigned char digest[EVP_MAX_MD_SIZE];
     int type, errs = 0;
     size_t i;
+    static locale_t c_locale = LC_GLOBAL_LOCALE;
 
     /* Does it end with a recognized extension? */
     if ((ext = strrchr(filename, '.')) == NULL)
         goto end;
+
+    if (c_locale == LC_GLOBAL_LOCALE)
+        c_locale = newlocale(LC_CTYPE_MASK, "C", 0);
+
     for (i = 0; i < OSSL_NELEM(extensions); i++) {
-        if (strcasecmp(extensions[i], ext + 1) == 0)
+        if (strcasecmp_l(extensions[i], ext + 1, c_locale) == 0)
             break;
     }
     if (i >= OSSL_NELEM(extensions))

--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -13,6 +13,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <locale.h>
 #if defined(_WIN32)
 /* Included before async.h to avoid some warnings */
 # include <windows.h>
@@ -432,7 +433,12 @@ static int ssl_servername_cb(SSL *s, int *ad, void *arg)
         return SSL_TLSEXT_ERR_NOACK;
 
     if (servername != NULL) {
-        if (strcasecmp(servername, p->servername))
+        static locale_t c_locale = LC_GLOBAL_LOCALE;
+
+        if (c_locale == LC_GLOBAL_LOCALE)
+            c_locale = newlocale(LC_CTYPE_MASK, "C", 0);
+
+        if (strcasecmp_l(servername, p->servername, c_locale))
             return p->extension_error;
         if (ctx2 != NULL) {
             BIO_printf(p->biodebug, "Switching server context.\n");

--- a/crypto/LPdir_unix.c
+++ b/crypto/LPdir_unix.c
@@ -43,6 +43,7 @@
 #include <sys/types.h>
 #include <dirent.h>
 #include <errno.h>
+#include <locale.h>
 #ifndef LPDIR_H
 # include "LPdir.h"
 #endif
@@ -137,11 +138,17 @@ const char *LP_find_file(LP_DIR_CTX **ctx, const char *directory)
     if ((*ctx)->expect_file_generations) {
         char *p = (*ctx)->entry_name + strlen((*ctx)->entry_name);
 
+        static locale_t c_locale = LC_GLOBAL_LOCALE;
+
+        if (c_locale == LC_GLOBAL_LOCALE)
+            c_locale = newlocale(LC_CTYPE_MASK, "C", 0);
+
         while (p > (*ctx)->entry_name && isdigit(p[-1]))
             p--;
         if (p > (*ctx)->entry_name && p[-1] == ';')
             p[-1] = '\0';
-        if (strcasecmp((*ctx)->entry_name, (*ctx)->previous_entry_name) == 0)
+        if (strcasecmp_l((*ctx)->entry_name, (*ctx)->previous_entry_name,
+                         c_locale) == 0)
             goto again;
     }
 #endif

--- a/crypto/core_namemap.c
+++ b/crypto/core_namemap.c
@@ -7,7 +7,9 @@
  * https://www.openssl.org/source/license.html
  */
 
-#include "internal/e_os.h"                /* strcasecmp */
+#include <locale.h>
+
+#include "internal/e_os.h"                /* strcasecmp_l */
 #include "internal/namemap.h"
 #include <openssl/lhash.h>
 #include "crypto/lhash.h"      /* ossl_lh_strcasehash */
@@ -50,7 +52,12 @@ static unsigned long namenum_hash(const NAMENUM_ENTRY *n)
 
 static int namenum_cmp(const NAMENUM_ENTRY *a, const NAMENUM_ENTRY *b)
 {
-    return strcasecmp(a->name, b->name);
+    static locale_t c_locale = LC_GLOBAL_LOCALE;
+
+    if (c_locale == LC_GLOBAL_LOCALE)
+        c_locale = newlocale(LC_CTYPE_MASK, "C", 0);
+
+    return strcasecmp_l(a->name, b->name, c_locale);
 }
 
 static void namenum_free(NAMENUM_ENTRY *n)

--- a/crypto/dh/dh_group_params.c
+++ b/crypto/dh/dh_group_params.c
@@ -23,7 +23,7 @@
 #include <openssl/objects.h>
 #include "internal/nelem.h"
 #include "crypto/dh.h"
-#include "internal/e_os.h" /* strcasecmp */
+#include "internal/e_os.h" /* strcasecmp_l */
 
 static DH *dh_param_init(OSSL_LIB_CTX *libctx, const DH_NAMED_GROUP *group)
 {

--- a/crypto/ec/ec_backend.c
+++ b/crypto/ec/ec_backend.c
@@ -13,6 +13,7 @@
  */
 #include "internal/deprecated.h"
 
+#include <locale.h>
 #include <openssl/core_names.h>
 #include <openssl/objects.h>
 #include <openssl/params.h>
@@ -49,12 +50,17 @@ int ossl_ec_encoding_name2id(const char *name)
 {
     size_t i, sz;
 
+    static locale_t c_locale = LC_GLOBAL_LOCALE;
+
     /* Return the default value if there is no name */
     if (name == NULL)
         return OPENSSL_EC_NAMED_CURVE;
 
+    if (c_locale == LC_GLOBAL_LOCALE)
+        c_locale = newlocale(LC_CTYPE_MASK, "C", 0);
+
     for (i = 0, sz = OSSL_NELEM(encoding_nameid_map); i < sz; i++) {
-        if (strcasecmp(name, encoding_nameid_map[i].ptr) == 0)
+        if (strcasecmp_l(name, encoding_nameid_map[i].ptr, c_locale) == 0)
             return encoding_nameid_map[i].id;
     }
     return -1;
@@ -85,13 +91,18 @@ char *ossl_ec_check_group_type_id2name(int id)
 static int ec_check_group_type_name2id(const char *name)
 {
     size_t i, sz;
+    static locale_t c_locale = LC_GLOBAL_LOCALE;
 
     /* Return the default value if there is no name */
     if (name == NULL)
         return 0;
 
+    if (c_locale == LC_GLOBAL_LOCALE)
+        c_locale = newlocale(LC_CTYPE_MASK, "C", 0);
+
     for (i = 0, sz = OSSL_NELEM(check_group_type_nameid_map); i < sz; i++) {
-        if (strcasecmp(name, check_group_type_nameid_map[i].ptr) == 0)
+        if (strcasecmp_l(name, check_group_type_nameid_map[i].ptr,
+                         c_locale) == 0)
             return check_group_type_nameid_map[i].id;
     }
     return -1;
@@ -130,13 +141,17 @@ static int ec_set_check_group_type_from_param(EC_KEY *ec, const OSSL_PARAM *p)
 int ossl_ec_pt_format_name2id(const char *name)
 {
     size_t i, sz;
+    static locale_t c_locale = LC_GLOBAL_LOCALE;
 
     /* Return the default value if there is no name */
     if (name == NULL)
         return (int)POINT_CONVERSION_UNCOMPRESSED;
 
+    if (c_locale == LC_GLOBAL_LOCALE)
+        c_locale = newlocale(LC_CTYPE_MASK, "C", 0);
+
     for (i = 0, sz = OSSL_NELEM(format_nameid_map); i < sz; i++) {
-        if (strcasecmp(name, format_nameid_map[i].ptr) == 0)
+        if (strcasecmp_l(name, format_nameid_map[i].ptr, c_locale) == 0)
             return format_nameid_map[i].id;
     }
     return -1;

--- a/crypto/encode_decode/decoder_pkey.c
+++ b/crypto/encode_decode/decoder_pkey.c
@@ -19,7 +19,7 @@
 #include "crypto/decoder.h"
 #include "crypto/evp/evp_local.h"
 #include "encoder_local.h"
-#include "internal/e_os.h"                /* strcasecmp on Windows */
+#include "internal/e_os.h"                /* strcasecmp_l on Windows */
 #include "internal/namemap.h"
 
 int OSSL_DECODER_CTX_set_passphrase(OSSL_DECODER_CTX *ctx,

--- a/crypto/encode_decode/encoder_lib.c
+++ b/crypto/encode_decode/encoder_lib.c
@@ -7,7 +7,8 @@
  * https://www.openssl.org/source/license.html
  */
 
-#include "internal/e_os.h"                /* strcasecmp on Windows */
+#include "internal/e_os.h"                /* strcasecmp_l on Windows */
+#include <locale.h>
 #include <openssl/core_names.h>
 #include <openssl/bio.h>
 #include <openssl/encoder.h>
@@ -415,6 +416,10 @@ static int encoder_process(struct encoder_process_data_st *data)
         const char *current_output_type;
         const char *current_output_structure;
         struct encoder_process_data_st new_data;
+        static locale_t c_locale = LC_GLOBAL_LOCALE;
+
+        if (c_locale == LC_GLOBAL_LOCALE)
+            c_locale = newlocale(LC_CTYPE_MASK, "C", 0);
 
         if (!top)
             next_encoder =
@@ -453,8 +458,8 @@ static int encoder_process(struct encoder_process_data_st *data)
          */
         if (top) {
             if (data->ctx->output_type != NULL
-                && strcasecmp(current_output_type,
-                              data->ctx->output_type) != 0) {
+                && strcasecmp_l(current_output_type,
+                              data->ctx->output_type, c_locale) != 0) {
                 OSSL_TRACE_BEGIN(ENCODER) {
                     BIO_printf(trc_out,
                                "[%d]    Skipping because current encoder output type (%s) != desired output type (%s)\n",
@@ -482,8 +487,8 @@ static int encoder_process(struct encoder_process_data_st *data)
          */
         if (data->ctx->output_structure != NULL
             && current_output_structure != NULL) {
-            if (strcasecmp(data->ctx->output_structure,
-                           current_output_structure) != 0) {
+            if (strcasecmp_l(data->ctx->output_structure,
+                           current_output_structure, c_locale) != 0) {
                 OSSL_TRACE_BEGIN(ENCODER) {
                     BIO_printf(trc_out,
                                "[%d]    Skipping because current encoder output structure (%s) != ctx output structure (%s)\n",

--- a/crypto/encode_decode/encoder_pkey.c
+++ b/crypto/encode_decode/encoder_pkey.c
@@ -7,7 +7,7 @@
  * https://www.openssl.org/source/license.html
  */
 
-#include "internal/e_os.h"                /* strcasecmp on Windows */
+#include "internal/e_os.h"                /* strcasecmp_l on Windows */
 #include <openssl/err.h>
 #include <openssl/ui.h>
 #include <openssl/params.h>

--- a/crypto/evp/ec_support.c
+++ b/crypto/evp/ec_support.c
@@ -8,9 +8,10 @@
  */
 
 #include <string.h>
+#include <locale.h>
 #include <openssl/ec.h>
 #include "crypto/ec.h"
-#include "internal/e_os.h" /* strcasecmp required by windows */
+#include "internal/e_os.h" /* strcasecmp_l required by windows */
 
 typedef struct ec_name2nid_st {
     const char *name;
@@ -133,13 +134,17 @@ int ossl_ec_curve_name2nid(const char *name)
 {
     size_t i;
     int nid;
+    static locale_t c_locale = LC_GLOBAL_LOCALE;
+
+    if (c_locale == LC_GLOBAL_LOCALE)
+        c_locale = newlocale(LC_CTYPE_MASK, "C", 0);
 
     if (name != NULL) {
         if ((nid = ossl_ec_curve_nist2nid_int(name)) != NID_undef)
             return nid;
 
         for (i = 0; i < OSSL_NELEM(curve_list); i++) {
-            if (strcasecmp(curve_list[i].name, name) == 0)
+            if (strcasecmp_l(curve_list[i].name, name, c_locale) == 0)
                 return curve_list[i].nid;
         }
     }

--- a/crypto/evp/evp_lib.c
+++ b/crypto/evp/evp_lib.c
@@ -15,7 +15,8 @@
 
 #include <stdio.h>
 #include <string.h>
-#include "internal/e_os.h" /* strcasecmp */
+#include <locale.h>
+#include "internal/e_os.h" /* strcasecmp_l */
 #include "internal/cryptlib.h"
 #include <openssl/evp.h>
 #include <openssl/objects.h>
@@ -1191,20 +1192,24 @@ EVP_PKEY *EVP_PKEY_Q_keygen(OSSL_LIB_CTX *libctx, const char *propq,
     char *name;
     OSSL_PARAM params[] = { OSSL_PARAM_END, OSSL_PARAM_END };
     EVP_PKEY *ret = NULL;
+    static locale_t c_locale = LC_GLOBAL_LOCALE;
 
     va_start(args, type);
 
-    if (strcasecmp(type, "RSA") == 0) {
+    if (c_locale == LC_GLOBAL_LOCALE)
+        c_locale = newlocale(LC_CTYPE_MASK, "C", 0);
+
+    if (strcasecmp_l(type, "RSA", c_locale) == 0) {
         bits = va_arg(args, size_t);
         params[0] = OSSL_PARAM_construct_size_t(OSSL_PKEY_PARAM_RSA_BITS, &bits);
-    } else if (strcasecmp(type, "EC") == 0) {
+    } else if (strcasecmp_l(type, "EC", c_locale) == 0) {
         name = va_arg(args, char *);
         params[0] = OSSL_PARAM_construct_utf8_string(OSSL_PKEY_PARAM_GROUP_NAME,
                                                      name, 0);
-    } else if (strcasecmp(type, "ED25519") != 0
-               && strcasecmp(type, "X25519") != 0
-               && strcasecmp(type, "ED448") != 0
-               && strcasecmp(type, "X448") != 0) {
+    } else if (strcasecmp_l(type, "ED25519", c_locale) != 0
+               && strcasecmp_l(type, "X25519", c_locale) != 0
+               && strcasecmp_l(type, "ED448", c_locale) != 0
+               && strcasecmp_l(type, "X448", c_locale) != 0) {
         ERR_raise(ERR_LIB_EVP, ERR_R_PASSED_INVALID_ARGUMENT);
         goto end;
     }

--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -15,6 +15,7 @@
 
 #include <assert.h>
 #include <stdio.h>
+#include <locale.h>
 #include "internal/cryptlib.h"
 #include "internal/refcount.h"
 #include "internal/namemap.h"
@@ -50,7 +51,7 @@
 #include "internal/provider.h"
 #include "evp_local.h"
 
-#include "internal/e_os.h"                /* strcasecmp on Windows */
+#include "internal/e_os.h"                /* strcasecmp_l on Windows */
 
 static int pkey_set_type(EVP_PKEY *pkey, ENGINE *e, int type, const char *str,
                          int len, EVP_KEYMGMT *keymgmt);
@@ -1016,9 +1017,13 @@ int evp_pkey_name2type(const char *name)
 {
     int type;
     size_t i;
+    static locale_t c_locale = LC_GLOBAL_LOCALE;
+
+    if (c_locale == LC_GLOBAL_LOCALE)
+        c_locale = newlocale(LC_CTYPE_MASK, "C", 0);
 
     for (i = 0; i < OSSL_NELEM(standard_name2type); i++) {
-        if (strcasecmp(name, standard_name2type[i].ptr) == 0)
+        if (strcasecmp_l(name, standard_name2type[i].ptr, c_locale) == 0)
             return (int)standard_name2type[i].id;
     }
 

--- a/crypto/ffc/ffc_dh.c
+++ b/crypto/ffc/ffc_dh.c
@@ -7,10 +7,11 @@
  * https://www.openssl.org/source/license.html
  */
 
+#include <locale.h>
 #include "internal/ffc.h"
 #include "internal/nelem.h"
 #include "crypto/bn_dh.h"
-#include "internal/e_os.h" /* strcasecmp */
+#include "internal/e_os.h" /* strcasecmp_l */
 
 #ifndef OPENSSL_NO_DH
 
@@ -82,9 +83,13 @@ static const DH_NAMED_GROUP dh_named_groups[] = {
 const DH_NAMED_GROUP *ossl_ffc_name_to_dh_named_group(const char *name)
 {
     size_t i;
+    static locale_t c_locale = LC_GLOBAL_LOCALE;
+
+    if (c_locale == LC_GLOBAL_LOCALE)
+        c_locale = newlocale(LC_CTYPE_MASK, "C", 0);
 
     for (i = 0; i < OSSL_NELEM(dh_named_groups); ++i) {
-        if (strcasecmp(dh_named_groups[i].name, name) == 0)
+        if (strcasecmp_l(dh_named_groups[i].name, name, c_locale) == 0)
             return &dh_named_groups[i];
     }
     return NULL;

--- a/crypto/ffc/ffc_params.c
+++ b/crypto/ffc/ffc_params.c
@@ -12,7 +12,7 @@
 #include "internal/ffc.h"
 #include "internal/param_build_set.h"
 #include "internal/nelem.h"
-#include "internal/e_os.h" /* strcasecmp */
+#include "internal/e_os.h" /* strcasecmp_l */
 
 #ifndef FIPS_MODULE
 # include <openssl/asn1.h> /* ossl_ffc_params_print */

--- a/crypto/rand/rand_lib.c
+++ b/crypto/rand/rand_lib.c
@@ -10,6 +10,7 @@
 /* We need to use some engine deprecated APIs */
 #define OPENSSL_SUPPRESS_DEPRECATED
 
+#include <locale.h>
 #include <openssl/err.h>
 #include <openssl/opensslconf.h>
 #include <openssl/core_names.h>
@@ -765,23 +766,28 @@ static int random_conf_init(CONF_IMODULE *md, const CONF *cnf)
         return 0;
 
     for (i = 0; i < sk_CONF_VALUE_num(elist); i++) {
+        static locale_t c_locale = LC_GLOBAL_LOCALE;
+
+        if (c_locale == LC_GLOBAL_LOCALE)
+            c_locale = newlocale(LC_CTYPE_MASK, "C", 0);
+
         cval = sk_CONF_VALUE_value(elist, i);
-        if (strcasecmp(cval->name, "random") == 0) {
+        if (strcasecmp_l(cval->name, "random", c_locale) == 0) {
             if (!random_set_string(&dgbl->rng_name, cval->value))
                 return 0;
-        } else if (strcasecmp(cval->name, "cipher") == 0) {
+        } else if (strcasecmp_l(cval->name, "cipher", c_locale) == 0) {
             if (!random_set_string(&dgbl->rng_cipher, cval->value))
                 return 0;
-        } else if (strcasecmp(cval->name, "digest") == 0) {
+        } else if (strcasecmp_l(cval->name, "digest", c_locale) == 0) {
             if (!random_set_string(&dgbl->rng_digest, cval->value))
                 return 0;
-        } else if (strcasecmp(cval->name, "properties") == 0) {
+        } else if (strcasecmp_l(cval->name, "properties", c_locale) == 0) {
             if (!random_set_string(&dgbl->rng_propq, cval->value))
                 return 0;
-        } else if (strcasecmp(cval->name, "seed") == 0) {
+        } else if (strcasecmp_l(cval->name, "seed", c_locale) == 0) {
             if (!random_set_string(&dgbl->seed_name, cval->value))
                 return 0;
-        } else if (strcasecmp(cval->name, "seed_properties") == 0) {
+        } else if (strcasecmp_l(cval->name, "seed_properties", c_locale) == 0) {
             if (!random_set_string(&dgbl->seed_propq, cval->value))
                 return 0;
         } else {

--- a/crypto/store/store_lib.c
+++ b/crypto/store/store_lib.c
@@ -10,6 +10,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <assert.h>
+#include <locale.h>
 
 /* We need to use some STORE deprecated APIs */
 #define OPENSSL_SUPPRESS_DEPRECATED
@@ -75,6 +76,10 @@ OSSL_STORE_open_ex(const char *uri, OSSL_LIB_CTX *libctx, const char *propq,
     char scheme_copy[256], *p, *schemes[2], *scheme = NULL;
     size_t schemes_n = 0;
     size_t i;
+    static locale_t c_locale = LC_GLOBAL_LOCALE;
+
+    if (c_locale == LC_GLOBAL_LOCALE)
+        c_locale = newlocale(LC_CTYPE_MASK, "C", 0);
 
     /*
      * Put the file scheme first.  If the uri does represent an existing file,
@@ -93,7 +98,7 @@ OSSL_STORE_open_ex(const char *uri, OSSL_LIB_CTX *libctx, const char *propq,
     OPENSSL_strlcpy(scheme_copy, uri, sizeof(scheme_copy));
     if ((p = strchr(scheme_copy, ':')) != NULL) {
         *p++ = '\0';
-        if (strcasecmp(scheme_copy, "file") != 0) {
+        if (strcasecmp_l(scheme_copy, "file", c_locale) != 0) {
             if (HAS_PREFIX(p, "//"))
                 schemes_n--;         /* Invalidate the file scheme */
             schemes[schemes_n++] = scheme_copy;

--- a/crypto/trace.c
+++ b/crypto/trace.c
@@ -9,6 +9,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <locale.h>
 
 #include "internal/thread_once.h"
 #include <openssl/bio.h>
@@ -19,7 +20,7 @@
 #include "internal/refcount.h"
 #include "crypto/cryptlib.h"
 
-#include "internal/e_os.h"                /* strcasecmp for Windows */
+#include "internal/e_os.h"                /* strcasecmp_l for Windows */
 
 #ifndef OPENSSL_NO_TRACE
 
@@ -156,9 +157,13 @@ const char *OSSL_trace_get_category_name(int num)
 int OSSL_trace_get_category_num(const char *name)
 {
     size_t i;
+    static locale_t c_locale = LC_GLOBAL_LOCALE;
+
+    if (c_locale == LC_GLOBAL_LOCALE)
+        c_locale = newlocale(LC_CTYPE_MASK, "C", 0);
 
     for (i = 0; i < OSSL_NELEM(trace_categories); i++)
-        if (strcasecmp(name, trace_categories[i].name) == 0)
+        if (strcasecmp_l(name, trace_categories[i].name, c_locale) == 0)
             return trace_categories[i].num;
     return -1; /* not found */
 }

--- a/crypto/x509/v3_tlsf.c
+++ b/crypto/x509/v3_tlsf.c
@@ -10,6 +10,7 @@
 #include "internal/e_os.h"
 #include "internal/cryptlib.h"
 #include <stdio.h>
+#include <locale.h>
 #include <openssl/asn1t.h>
 #include <openssl/conf.h>
 #include <openssl/x509v3.h>
@@ -101,6 +102,11 @@ static TLS_FEATURE *v2i_TLS_FEATURE(const X509V3_EXT_METHOD *method,
     }
 
     for (i = 0; i < sk_CONF_VALUE_num(nval); i++) {
+        static locale_t c_locale = LC_GLOBAL_LOCALE;
+
+        if (c_locale == LC_GLOBAL_LOCALE)
+            c_locale = newlocale(LC_CTYPE_MASK, "C", 0);
+
         val = sk_CONF_VALUE_value(nval, i);
         if (val->value)
             extval = val->value;
@@ -108,7 +114,7 @@ static TLS_FEATURE *v2i_TLS_FEATURE(const X509V3_EXT_METHOD *method,
             extval = val->name;
 
         for (j = 0; j < OSSL_NELEM(tls_feature_tbl); j++)
-            if (strcasecmp(extval, tls_feature_tbl[j].name) == 0)
+            if (strcasecmp_l(extval, tls_feature_tbl[j].name, c_locale) == 0)
                 break;
         if (j < OSSL_NELEM(tls_feature_tbl))
             tlsextid = tls_feature_tbl[j].num;

--- a/crypto/x509/v3_utl.c
+++ b/crypto/x509/v3_utl.c
@@ -13,6 +13,7 @@
 #include "internal/cryptlib.h"
 #include <stdio.h>
 #include <string.h>
+#include <locale.h>
 #include "crypto/ctype.h"
 #include <openssl/conf.h>
 #include <openssl/crypto.h>
@@ -21,6 +22,8 @@
 #include <openssl/bn.h>
 #include "ext_dat.h"
 #include "x509_local.h"
+
+static locale_t c_locale = LC_GLOBAL_LOCALE;
 
 static char *strip_spaces(char *name);
 static int sk_strcmp(const char *const *a, const char *const *b);
@@ -694,6 +697,9 @@ static int wildcard_match(const unsigned char *prefix, size_t prefix_len,
     int allow_multi = 0;
     int allow_idna = 0;
 
+    if (c_locale == LC_GLOBAL_LOCALE)
+        c_locale = newlocale(LC_CTYPE_MASK, "C", 0);
+
     if (subject_len < prefix_len + suffix_len)
         return 0;
     if (!equal_nocase(prefix, prefix_len, subject, prefix_len, flags))
@@ -746,6 +752,9 @@ static const unsigned char *valid_star(const unsigned char *p, size_t len,
     size_t i;
     int state = LABEL_START;
     int dots = 0;
+
+    if (c_locale == LC_GLOBAL_LOCALE)
+        c_locale = newlocale(LC_CTYPE_MASK, "C", 0);
 
     for (i = 0; i < len; ++i) {
         /*

--- a/engines/e_devcrypto.c
+++ b/engines/e_devcrypto.c
@@ -18,6 +18,7 @@
 #include <sys/ioctl.h>
 #include <unistd.h>
 #include <assert.h>
+#include <locale.h>
 
 #include <openssl/conf.h>
 #include <openssl/evp.h>
@@ -1134,6 +1135,11 @@ static const ENGINE_CMD_DEFN devcrypto_cmds[] = {
 static int devcrypto_ctrl(ENGINE *e, int cmd, long i, void *p, void (*f) (void))
 {
     int *new_list;
+    static locale_t c_locale = LC_GLOBAL_LOCALE;
+
+    if (c_locale == LC_GLOBAL_LOCALE)
+        c_locale = newlocale(LC_CTYPE_MASK, "C", 0);
+
     switch (cmd) {
 #if defined(CIOCGSESSINFO) || defined(CIOCGSESSION2)
     case DEVCRYPTO_CMD_USE_SOFTDRIVERS:
@@ -1159,9 +1165,9 @@ static int devcrypto_ctrl(ENGINE *e, int cmd, long i, void *p, void (*f) (void))
     case DEVCRYPTO_CMD_CIPHERS:
         if (p == NULL)
             return 1;
-        if (strcasecmp((const char *)p, "ALL") == 0) {
+        if (strcasecmp_l((const char *)p, "ALL", c_locale) == 0) {
             devcrypto_select_all_ciphers(selected_ciphers);
-        } else if (strcasecmp((const char*)p, "NONE") == 0) {
+        } else if (strcasecmp_l((const char*)p, "NONE", c_locale) == 0) {
             memset(selected_ciphers, 0, sizeof(selected_ciphers));
         } else {
             new_list=OPENSSL_zalloc(sizeof(selected_ciphers));
@@ -1179,9 +1185,9 @@ static int devcrypto_ctrl(ENGINE *e, int cmd, long i, void *p, void (*f) (void))
     case DEVCRYPTO_CMD_DIGESTS:
         if (p == NULL)
             return 1;
-        if (strcasecmp((const char *)p, "ALL") == 0) {
+        if (strcasecmp_l((const char *)p, "ALL", c_locale) == 0) {
             devcrypto_select_all_digests(selected_digests);
-        } else if (strcasecmp((const char*)p, "NONE") == 0) {
+        } else if (strcasecmp_l((const char*)p, "NONE", c_locale) == 0) {
             memset(selected_digests, 0, sizeof(selected_digests));
         } else {
             new_list=OPENSSL_zalloc(sizeof(selected_digests));

--- a/engines/e_loader_attic.c
+++ b/engines/e_loader_attic.c
@@ -19,6 +19,7 @@
 #include <sys/stat.h>
 #include <ctype.h>
 #include <assert.h>
+#include <locale.h>
 
 #include <openssl/bio.h>
 #include <openssl/dsa.h>         /* For d2i_DSAPrivateKey */
@@ -953,6 +954,10 @@ static OSSL_STORE_LOADER_CTX *file_open_ex
     } path_data[2];
     size_t path_data_n = 0, i;
     const char *path, *p = uri, *q;
+    static locale_t c_locale = LC_GLOBAL_LOCALE;
+
+    if (c_locale == LC_GLOBAL_LOCALE)
+        c_locale = newlocale(LC_CTYPE_MASK, "C", 0);
 
     /*
      * First step, just take the URI as is.

--- a/engines/e_ossltest.c
+++ b/engines/e_ossltest.c
@@ -27,6 +27,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <locale.h>
 #include "internal/common.h" /* for CHECK_AND_SKIP_CASE_PREFIX */
 
 #include <openssl/engine.h>
@@ -379,6 +380,10 @@ static EVP_PKEY *load_key(ENGINE *eng, const char *key_id, int pub,
 {
     BIO *in;
     EVP_PKEY *key;
+    static locale_t c_locale = LC_GLOBAL_LOCALE;
+
+    if (c_locale == LC_GLOBAL_LOCALE)
+        c_locale = newlocale(LC_CTYPE_MASK, "C", 0);
 
     if (!CHECK_AND_SKIP_CASE_PREFIX(key_id, "ot:"))
         return NULL;

--- a/include/internal/common.h
+++ b/include/internal/common.h
@@ -40,13 +40,15 @@ __owur static ossl_inline int ossl_assert_int(int expr, const char *exprstr,
 #define CHECK_AND_SKIP_PREFIX(str, pre) \
     (HAS_PREFIX(str, pre) ? ((str) += sizeof(pre) - 1, 1) : 0)
 /* Check if the string literal |p| is a case-insensitive prefix of |s| */
-#define HAS_CASE_PREFIX(s, p) (strncasecmp(s, p "", sizeof(p) - 1) == 0)
+#define HAS_CASE_PREFIX(s, p) \
+(strncasecmp(s, p "", sizeof(p) - 1, c_locale) == 0)
 /* As before, and if check succeeds, advance |str| past the prefix |pre| */
 #define CHECK_AND_SKIP_CASE_PREFIX(str, pre) \
     (HAS_CASE_PREFIX(str, pre) ? ((str) += sizeof(pre) - 1, 1) : 0)
 /* Check if the string literal |suffix| is a case-insensitive suffix of |str| */
 #define HAS_CASE_SUFFIX(str, suffix) (strlen(str) < sizeof(suffix) - 1 ? 0 : \
-    strcasecmp(str + strlen(str) - sizeof(suffix) + 1, suffix "") == 0)
+    strcasecmp_l(str + strlen(str) - sizeof(suffix) + 1, suffix "", \
+                 c_locale) == 0)
 
 /*
  * Use this inside a union with the field that needs to be aligned to a

--- a/include/internal/common.h
+++ b/include/internal/common.h
@@ -41,7 +41,7 @@ __owur static ossl_inline int ossl_assert_int(int expr, const char *exprstr,
     (HAS_PREFIX(str, pre) ? ((str) += sizeof(pre) - 1, 1) : 0)
 /* Check if the string literal |p| is a case-insensitive prefix of |s| */
 #define HAS_CASE_PREFIX(s, p) \
-(strncasecmp(s, p "", sizeof(p) - 1, c_locale) == 0)
+(strncasecmp_l(s, p "", sizeof(p) - 1, c_locale) == 0)
 /* As before, and if check succeeds, advance |str| past the prefix |pre| */
 #define CHECK_AND_SKIP_CASE_PREFIX(str, pre) \
     (HAS_CASE_PREFIX(str, pre) ? ((str) += sizeof(pre) - 1, 1) : 0)

--- a/include/internal/e_os.h
+++ b/include/internal/e_os.h
@@ -249,8 +249,8 @@ FILE *__iob_func();
 /***********************************************/
 
 # if defined(OPENSSL_SYS_WINDOWS)
-#  define strcasecmp _stricmp
-#  define strncasecmp _strnicmp
+#  define strcasecmp_l(a,b,c) _stricmp(a,b)
+#  define strncasecmp_l(a,b,c,d) _strnicmp(a,b,c)
 #  if (_MSC_VER >= 1310) && !defined(_WIN32_WCE)
 #   define open _open
 #   define fdopen _fdopen

--- a/providers/common/capabilities.c
+++ b/providers/common/capabilities.c
@@ -9,6 +9,7 @@
 
 #include <assert.h>
 #include <string.h>
+#include <locale.h>
 #include <openssl/core_dispatch.h>
 #include <openssl/core_names.h>
 /* For TLS1_VERSION etc */
@@ -217,7 +218,12 @@ static int tls_group_capability(OSSL_CALLBACK *cb, void *arg)
 int ossl_prov_get_capabilities(void *provctx, const char *capability,
                                OSSL_CALLBACK *cb, void *arg)
 {
-    if (strcasecmp(capability, "TLS-GROUP") == 0)
+    static locale_t c_locale = LC_GLOBAL_LOCALE;
+
+    if (c_locale == LC_GLOBAL_LOCALE)
+        c_locale = newlocale(LC_CTYPE_MASK, "C", 0);
+
+    if (strcasecmp_l(capability, "TLS-GROUP", c_locale) == 0)
         return tls_group_capability(cb, arg);
 
     /* We don't support this capability */

--- a/providers/implementations/ciphers/cipher_cts.c
+++ b/providers/implementations/ciphers/cipher_cts.c
@@ -46,7 +46,8 @@
  *      Otherwise it is the same as CS2.
  */
 
-#include "internal/e_os.h" /* strcasecmp */
+#include "internal/e_os.h" /* strcasecmp_l */
+#include <locale.h>
 #include <openssl/core_names.h>
 #include "prov/ciphercommon.h"
 #include "internal/nelem.h"
@@ -90,9 +91,13 @@ const char *ossl_cipher_cbc_cts_mode_id2name(unsigned int id)
 int ossl_cipher_cbc_cts_mode_name2id(const char *name)
 {
     size_t i;
+    static locale_t c_locale = LC_GLOBAL_LOCALE;
+
+    if (c_locale == LC_GLOBAL_LOCALE)
+        c_locale = newlocale(LC_CTYPE_MASK, "C", 0);
 
     for (i = 0; i < OSSL_NELEM(cts_modes); ++i) {
-        if (strcasecmp(name, cts_modes[i].name) == 0)
+        if (strcasecmp_l(name, cts_modes[i].name, c_locale) == 0)
             return (int)cts_modes[i].id;
     }
     return -1;

--- a/providers/implementations/kdfs/tls1_prf.c
+++ b/providers/implementations/kdfs/tls1_prf.c
@@ -48,6 +48,7 @@
 #include <stdio.h>
 #include <stdarg.h>
 #include <string.h>
+#include <locale.h>
 #include <openssl/evp.h>
 #include <openssl/kdf.h>
 #include <openssl/core_names.h>
@@ -193,12 +194,16 @@ static int kdf_tls1_prf_set_ctx_params(void *vctx, const OSSL_PARAM params[])
     const OSSL_PARAM *p;
     TLS1_PRF *ctx = vctx;
     OSSL_LIB_CTX *libctx = PROV_LIBCTX_OF(ctx->provctx);
+    static locale_t c_locale = LC_GLOBAL_LOCALE;
+
+    if (c_locale == LC_GLOBAL_LOCALE)
+        c_locale = newlocale(LC_CTYPE_MASK, "C", 0);
 
     if (params == NULL)
         return 1;
 
     if ((p = OSSL_PARAM_locate_const(params, OSSL_KDF_PARAM_DIGEST)) != NULL) {
-        if (strcasecmp(p->data, SN_md5_sha1) == 0) {
+        if (strcasecmp_l(p->data, SN_md5_sha1, c_locale) == 0) {
             if (!ossl_prov_macctx_load_from_params(&ctx->P_hash, params,
                                                    OSSL_MAC_NAME_HMAC,
                                                    NULL, SN_md5, libctx)

--- a/providers/implementations/kem/rsa_kem.c
+++ b/providers/implementations/kem/rsa_kem.c
@@ -1,4 +1,3 @@
---- providers/implementations/kem/rsa_kem.c
 /*
  * Copyright 2020-2021 The OpenSSL Project Authors. All Rights Reserved.
  *

--- a/providers/implementations/kem/rsa_kem.c
+++ b/providers/implementations/kem/rsa_kem.c
@@ -1,3 +1,4 @@
+--- providers/implementations/kem/rsa_kem.c
 /*
  * Copyright 2020-2021 The OpenSSL Project Authors. All Rights Reserved.
  *
@@ -7,13 +8,15 @@
  * https://www.openssl.org/source/license.html
  */
 
+#include <locale.h>
+
 /*
  * RSA low level APIs are deprecated for public use, but still ok for
  * internal use.
  */
 #include "internal/deprecated.h"
 
-#include "internal/e_os.h"  /* strcasecmp */
+#include "internal/e_os.h"  /* strcasecmp_l */
 #include <openssl/crypto.h>
 #include <openssl/evp.h>
 #include <openssl/core_dispatch.h>
@@ -64,12 +67,16 @@ static const OSSL_ITEM rsakem_opname_id_map[] = {
 static int name2id(const char *name, const OSSL_ITEM *map, size_t sz)
 {
     size_t i;
+    static locale_t c_locale = LC_GLOBAL_LOCALE;
+
+    if (c_locale == LC_GLOBAL_LOCALE)
+        c_locale = newlocale(LC_CTYPE_MASK, "C", 0);
 
     if (name == NULL)
         return -1;
 
     for (i = 0; i < sz; ++i) {
-        if (strcasecmp(map[i].ptr, name) == 0)
+        if (strcasecmp_l(map[i].ptr, name, c_locale) == 0)
             return map[i].id;
     }
     return -1;

--- a/providers/implementations/keymgmt/dsa_kmgmt.c
+++ b/providers/implementations/keymgmt/dsa_kmgmt.c
@@ -7,13 +7,15 @@
  * https://www.openssl.org/source/license.html
  */
 
+#include <locale.h>
+
 /*
  * DSA low level APIs are deprecated for public use, but still ok for
  * internal use.
  */
 #include "internal/deprecated.h"
 
-#include "internal/e_os.h" /* strcasecmp */
+#include "internal/e_os.h" /* strcasecmp_l */
 #include <openssl/core_dispatch.h>
 #include <openssl/core_names.h>
 #include <openssl/bn.h>
@@ -88,9 +90,13 @@ static const DSA_GENTYPE_NAME2ID dsatype2id[]=
 static int dsa_gen_type_name2id(const char *name)
 {
     size_t i;
+    static locale_t c_locale = LC_GLOBAL_LOCALE;
+
+    if (c_locale == LC_GLOBAL_LOCALE)
+        c_locale = newlocale(LC_CTYPE_MASK, "C", 0);
 
     for (i = 0; i < OSSL_NELEM(dsatype2id); ++i) {
-        if (strcasecmp(dsatype2id[i].name, name) == 0)
+        if (strcasecmp_l(dsatype2id[i].name, name, c_locale) == 0)
             return dsatype2id[i].id;
     }
     return -1;

--- a/providers/implementations/keymgmt/ec_kmgmt.c
+++ b/providers/implementations/keymgmt/ec_kmgmt.c
@@ -13,7 +13,7 @@
  */
 #include "internal/deprecated.h"
 
-#include "internal/e_os.h" /* strcasecmp */
+#include "internal/e_os.h" /* strcasecmp_l */
 #include <string.h>
 #include <openssl/core_dispatch.h>
 #include <openssl/core_names.h>

--- a/providers/implementations/keymgmt/ecx_kmgmt.c
+++ b/providers/implementations/keymgmt/ecx_kmgmt.c
@@ -9,7 +9,8 @@
 
 #include <assert.h>
 #include <string.h>
-/* For strcasecmp on Windows */
+#include <locale.h>
+/* For strcasecmp_l on Windows */
 #include "internal/e_os.h"
 #include <openssl/core_dispatch.h>
 #include <openssl/core_names.h>
@@ -520,9 +521,13 @@ static int ecx_gen_set_params(void *genctx, const OSSL_PARAM params[])
 {
     struct ecx_gen_ctx *gctx = genctx;
     const OSSL_PARAM *p;
+    static locale_t c_locale = LC_GLOBAL_LOCALE;
 
     if (gctx == NULL)
         return 0;
+
+    if (c_locale == LC_GLOBAL_LOCALE)
+        c_locale = newlocale(LC_CTYPE_MASK, "C", 0);
 
     p = OSSL_PARAM_locate_const(params, OSSL_PKEY_PARAM_GROUP_NAME);
     if (p != NULL) {
@@ -546,7 +551,7 @@ static int ecx_gen_set_params(void *genctx, const OSSL_PARAM params[])
         }
         if (p->data_type != OSSL_PARAM_UTF8_STRING
                 || groupname == NULL
-                || strcasecmp(p->data, groupname) != 0) {
+                || strcasecmp_l(p->data, groupname, c_locale) != 0) {
             ERR_raise(ERR_LIB_PROV, ERR_R_PASSED_INVALID_ARGUMENT);
             return 0;
         }

--- a/providers/implementations/keymgmt/mac_legacy_kmgmt.c
+++ b/providers/implementations/keymgmt/mac_legacy_kmgmt.c
@@ -26,7 +26,7 @@
 #include "prov/providercommon.h"
 #include "prov/provider_ctx.h"
 #include "prov/macsignature.h"
-#include "internal/e_os.h" /* strcasecmp */
+#include "internal/e_os.h" /* strcasecmp_l */
 
 static OSSL_FUNC_keymgmt_new_fn mac_new;
 static OSSL_FUNC_keymgmt_free_fn mac_free;

--- a/providers/implementations/storemgmt/file_store.c
+++ b/providers/implementations/storemgmt/file_store.c
@@ -15,6 +15,7 @@
 #include <sys/stat.h>
 #include <ctype.h>  /* isdigit */
 #include <assert.h>
+#include <locale.h>
 
 #include <openssl/core_dispatch.h>
 #include <openssl/core_names.h>
@@ -205,8 +206,12 @@ static void *file_open(void *provctx, const char *uri)
     size_t path_data_n = 0, i;
     const char *path, *p = uri, *q;
     BIO *bio;
+    static locale_t c_locale = LC_GLOBAL_LOCALE;
 
     ERR_set_mark();
+
+    if (c_locale == LC_GLOBAL_LOCALE)
+        c_locale = newlocale(LC_CTYPE_MASK, "C", 0);
 
     /*
      * First step, just take the URI as is.

--- a/test/bntest.c
+++ b/test/bntest.c
@@ -11,9 +11,10 @@
 #include <stdio.h>
 #include <string.h>
 #ifdef __TANDEM
-# include <strings.h> /* strcasecmp */
+# include <strings.h> /* strcasecmp_l */
 #endif
 #include <ctype.h>
+#include <locale.h>
 
 #include <openssl/bn.h>
 #include <openssl/crypto.h>
@@ -24,7 +25,7 @@
 #include "testutil.h"
 
 #ifdef OPENSSL_SYS_WINDOWS
-# define strcasecmp _stricmp
+# define strcasecmp_l(a,b,c) _stricmp(a,b)
 #endif
 
 /*
@@ -60,11 +61,16 @@ static int p1[] = { 193, 15, 0, -1 };
  */
 static const char *findattr(STANZA *s, const char *key)
 {
+    static locale_t c_locale = LC_GLOBAL_LOCALE;
+
     int i = s->numpairs;
     PAIR *pp = s->pairs;
 
+    if (c_locale == LC_GLOBAL_LOCALE)
+        c_locale = newlocale(LC_CTYPE_MASK, "C", 0);
+
     for ( ; --i >= 0; pp++)
-        if (strcasecmp(pp->key, key) == 0)
+        if (strcasecmp_l(pp->key, key, c_locale) == 0)
             return pp->value;
     return NULL;
 }

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -13,6 +13,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <locale.h>
 #include <openssl/bio.h>
 #include <openssl/conf.h>
 #include <openssl/crypto.h>
@@ -35,7 +36,7 @@
 #include "internal/nelem.h"
 #include "internal/sizes.h"
 #include "crypto/evp.h"
-#include "internal/e_os.h" /* strcasecmp */
+#include "internal/e_os.h" /* strcasecmp_l */
 
 static OSSL_LIB_CTX *testctx = NULL;
 static char *testpropq = NULL;
@@ -1730,6 +1731,7 @@ static int ec_export_get_encoding_cb(const OSSL_PARAM params[], void *arg)
     const char *enc_name = NULL;
     int *enc = arg;
     size_t i;
+    locale_t c_locale = newlocale(LC_CTYPE_MASK, "C", 0);
 
     *enc = -1;
 
@@ -1739,7 +1741,8 @@ static int ec_export_get_encoding_cb(const OSSL_PARAM params[], void *arg)
         return 0;
 
     for (i = 0; i < OSSL_NELEM(ec_encodings); i++) {
-        if (strcasecmp(enc_name, ec_encodings[i].encoding_name) == 0) {
+        if (strcasecmp_l(enc_name, ec_encodings[i].encoding_name,
+                         c_locale) == 0) {
             *enc = ec_encodings[i].encoding;
             break;
         }

--- a/test/evp_libctx_test.c
+++ b/test/evp_libctx_test.c
@@ -21,6 +21,7 @@
  */
 #include "internal/deprecated.h"
 #include <assert.h>
+#include <locale.h>
 #include <openssl/evp.h>
 #include <openssl/provider.h>
 #include <openssl/dsa.h>
@@ -33,7 +34,7 @@
 #include "testutil.h"
 #include "internal/nelem.h"
 #include "crypto/bn_dh.h"   /* _bignum_ffdhe2048_p */
-#include "internal/e_os.h"        /* strcasecmp */
+#include "internal/e_os.h"        /* strcasecmp_l */
 
 static OSSL_LIB_CTX *libctx = NULL;
 static OSSL_PROVIDER *nullprov = NULL;
@@ -478,7 +479,8 @@ err:
 
 static int name_cmp(const char * const *a, const char * const *b)
 {
-    return strcasecmp(*a, *b);
+    locale_t c_locale = newlocale(LC_CTYPE_MASK, "C", 0);
+    return strcasecmp_l(*a, *b, c_locale);
 }
 
 static void collect_cipher_names(EVP_CIPHER *cipher, void *cipher_names_list)

--- a/test/evp_test.c
+++ b/test/evp_test.c
@@ -12,7 +12,8 @@
 #include <string.h>
 #include <stdlib.h>
 #include <ctype.h>
-#include "internal/e_os.h" /* strcasecmp and strncasecmp */
+#include <locale.h>
+#include "internal/e_os.h" /* strcasecmp_l and strncasecmp_l */
 #include <openssl/evp.h>
 #include <openssl/pem.h>
 #include <openssl/err.h>
@@ -81,6 +82,8 @@ static OSSL_LIB_CTX *libctx = NULL;
 /* List of public and private keys */
 static KEY_LIST *private_keys;
 static KEY_LIST *public_keys;
+
+static locale_t c_locale = LC_GLOBAL_LOCALE;
 
 static int find_key(EVP_PKEY **ppk, const char *name, KEY_LIST *lst);
 static int parse_bin(const char *value, unsigned char **buf, size_t *buflen);
@@ -3923,36 +3926,39 @@ void cleanup_tests(void)
 
 static int is_digest_disabled(const char *name)
 {
+    if (c_locale == LC_GLOBAL_LOCALE)
+        c_locale = newlocale(LC_CTYPE_MASK, "C", 0);
+
 #ifdef OPENSSL_NO_BLAKE2
     if (HAS_CASE_PREFIX(name, "BLAKE"))
         return 1;
 #endif
 #ifdef OPENSSL_NO_MD2
-    if (strcasecmp(name, "MD2") == 0)
+    if (strcasecmp_l(name, "MD2", c_locale) == 0)
         return 1;
 #endif
 #ifdef OPENSSL_NO_MDC2
-    if (strcasecmp(name, "MDC2") == 0)
+    if (strcasecmp_l(name, "MDC2", c_locale) == 0)
         return 1;
 #endif
 #ifdef OPENSSL_NO_MD4
-    if (strcasecmp(name, "MD4") == 0)
+    if (strcasecmp_l(name, "MD4", c_locale) == 0)
         return 1;
 #endif
 #ifdef OPENSSL_NO_MD5
-    if (strcasecmp(name, "MD5") == 0)
+    if (strcasecmp_l(name, "MD5", c_locale) == 0)
         return 1;
 #endif
 #ifdef OPENSSL_NO_RMD160
-    if (strcasecmp(name, "RIPEMD160") == 0)
+    if (strcasecmp_l(name, "RIPEMD160", c_locale) == 0)
         return 1;
 #endif
 #ifdef OPENSSL_NO_SM3
-    if (strcasecmp(name, "SM3") == 0)
+    if (strcasecmp_l(name, "SM3", c_locale) == 0)
         return 1;
 #endif
 #ifdef OPENSSL_NO_WHIRLPOOL
-    if (strcasecmp(name, "WHIRLPOOL") == 0)
+    if (strcasecmp_l(name, "WHIRLPOOL", c_locale) == 0)
         return 1;
 #endif
     return 0;
@@ -3960,6 +3966,9 @@ static int is_digest_disabled(const char *name)
 
 static int is_pkey_disabled(const char *name)
 {
+    if (c_locale == LC_GLOBAL_LOCALE)
+        c_locale = newlocale(LC_CTYPE_MASK, "C", 0);
+
 #ifdef OPENSSL_NO_EC
     if (HAS_CASE_PREFIX(name, "EC"))
         return 1;
@@ -3977,6 +3986,9 @@ static int is_pkey_disabled(const char *name)
 
 static int is_mac_disabled(const char *name)
 {
+    if (c_locale == LC_GLOBAL_LOCALE)
+        c_locale = newlocale(LC_CTYPE_MASK, "C", 0);
+
 #ifdef OPENSSL_NO_BLAKE2
     if (HAS_CASE_PREFIX(name, "BLAKE2BMAC")
         || HAS_CASE_PREFIX(name, "BLAKE2SMAC"))
@@ -3998,6 +4010,9 @@ static int is_mac_disabled(const char *name)
 }
 static int is_kdf_disabled(const char *name)
 {
+    if (c_locale == LC_GLOBAL_LOCALE)
+        c_locale = newlocale(LC_CTYPE_MASK, "C", 0);
+
 #ifdef OPENSSL_NO_SCRYPT
     if (HAS_CASE_SUFFIX(name, "SCRYPT"))
         return 1;
@@ -4007,6 +4022,9 @@ static int is_kdf_disabled(const char *name)
 
 static int is_cipher_disabled(const char *name)
 {
+    if (c_locale == LC_GLOBAL_LOCALE)
+        c_locale = newlocale(LC_CTYPE_MASK, "C", 0);
+
 #ifdef OPENSSL_NO_ARIA
     if (HAS_CASE_PREFIX(name, "ARIA"))
         return 1;

--- a/test/helpers/ssl_test_ctx.c
+++ b/test/helpers/ssl_test_ctx.c
@@ -8,6 +8,7 @@
  */
 
 #include <string.h>
+#include <locale.h>
 
 #include <openssl/e_os2.h>
 #include <openssl/crypto.h>
@@ -17,7 +18,7 @@
 #include "../testutil.h"
 
 #ifdef OPENSSL_SYS_WINDOWS
-# define strcasecmp _stricmp
+# define strcasecmp_l(a,b,c) _stricmp(a,b)
 #endif
 
 static const int default_app_data_size = 256;
@@ -26,11 +27,16 @@ static const int default_max_fragment_size = 512;
 
 static int parse_boolean(const char *value, int *result)
 {
-    if (strcasecmp(value, "Yes") == 0) {
+    static locale_t c_locale = LC_GLOBAL_LOCALE;
+
+    if (c_locale == LC_GLOBAL_LOCALE)
+        c_locale = newlocale(LC_CTYPE_MASK, "C", 0);
+
+    if (strcasecmp_l(value, "Yes", c_locale) == 0) {
         *result = 1;
         return 1;
     }
-    else if (strcasecmp(value, "No") == 0) {
+    else if (strcasecmp_l(value, "No", c_locale) == 0) {
         *result = 0;
         return 1;
     }

--- a/test/params_conversion_test.c
+++ b/test/params_conversion_test.c
@@ -9,6 +9,7 @@
  */
 
 #include <string.h>
+#include <locale.h>
 #include <openssl/params.h>
 #include "testutil.h"
 
@@ -16,7 +17,7 @@
 #if !defined(OPENSSL_NO_INTTYPES_H)
 
 # ifdef OPENSSL_SYS_WINDOWS
-#  define strcasecmp _stricmp
+#  define strcasecmp_l(a,b,c) _stricmp(a,b)
 # endif
 
 # ifdef OPENSSL_SYS_VMS
@@ -57,12 +58,16 @@ static int param_conversion_load_stanza(PARAM_CONVERSION *pc, const STANZA *s)
     const char *type = NULL;
     char *p;
     int i;
+    static locale_t c_locale = LC_GLOBAL_LOCALE;
+
+    if (c_locale == LC_GLOBAL_LOCALE)
+        c_locale = newlocale(LC_CTYPE_MASK, "C", 0);
 
     memset(pc, 0, sizeof(*pc));
 
     for (i = 0; i < s->numpairs; i++, pp++) {
         p = "";
-        if (strcasecmp(pp->key, "type") == 0) {
+        if (strcasecmp_l(pp->key, "type", c_locale) == 0) {
             if (type != NULL) {
                 TEST_info("Line %d: multiple type lines", s->curr);
                 return 0;
@@ -72,48 +77,48 @@ static int param_conversion_load_stanza(PARAM_CONVERSION *pc, const STANZA *s)
                 TEST_info("Line %d: unknown type line", s->curr);
                 return 0;
             }
-        } else if (strcasecmp(pp->key, "int32") == 0) {
+        } else if (strcasecmp_l(pp->key, "int32", c_locale) == 0) {
             if (def_i32++) {
                 TEST_info("Line %d: multiple int32 lines", s->curr);
                 return 0;
             }
-            if (strcasecmp(pp->value, "invalid") != 0) {
+            if (strcasecmp_l(pp->value, "invalid", c_locale) != 0) {
                 pc->valid_i32 = 1;
                 pc->i32 = (int32_t)strtoimax(pp->value, &p, 10);
             }
-        } else if (strcasecmp(pp->key, "int64") == 0) {
+        } else if (strcasecmp_l(pp->key, "int64", c_locale) == 0) {
             if (def_i64++) {
                 TEST_info("Line %d: multiple int64 lines", s->curr);
                 return 0;
             }
-            if (strcasecmp(pp->value, "invalid") != 0) {
+            if (strcasecmp_l(pp->value, "invalid", c_locale) != 0) {
                 pc->valid_i64 = 1;
                 pc->i64 = (int64_t)strtoimax(pp->value, &p, 10);
             }
-        } else if (strcasecmp(pp->key, "uint32") == 0) {
+        } else if (strcasecmp_l(pp->key, "uint32", c_locale) == 0) {
             if (def_u32++) {
                 TEST_info("Line %d: multiple uint32 lines", s->curr);
                 return 0;
             }
-            if (strcasecmp(pp->value, "invalid") != 0) {
+            if (strcasecmp_l(pp->value, "invalid", c_locale) != 0) {
                 pc->valid_u32 = 1;
                 pc->u32 = (uint32_t)strtoumax(pp->value, &p, 10);
             }
-        } else if (strcasecmp(pp->key, "uint64") == 0) {
+        } else if (strcasecmp_l(pp->key, "uint64", c_locale) == 0) {
             if (def_u64++) {
                 TEST_info("Line %d: multiple uint64 lines", s->curr);
                 return 0;
             }
-            if (strcasecmp(pp->value, "invalid") != 0) {
+            if (strcasecmp_l(pp->value, "invalid", c_locale) != 0) {
                 pc->valid_u64 = 1;
                 pc->u64 = (uint64_t)strtoumax(pp->value, &p, 10);
             }
-        } else if (strcasecmp(pp->key, "double") == 0) {
+        } else if (strcasecmp_l(pp->key, "double", c_locale) == 0) {
             if (def_d++) {
                 TEST_info("Line %d: multiple double lines", s->curr);
                 return 0;
             }
-            if (strcasecmp(pp->value, "invalid") != 0) {
+            if (strcasecmp_l(pp->value, "invalid", c_locale) != 0) {
                 pc->valid_d = 1;
                 pc->d = strtod(pp->value, &p);
             }
@@ -133,7 +138,7 @@ static int param_conversion_load_stanza(PARAM_CONVERSION *pc, const STANZA *s)
         return 0;
     }
 
-    if (strcasecmp(type, "int32") == 0) {
+    if (strcasecmp_l(type, "int32", c_locale) == 0) {
         if (!TEST_true(def_i32) || !TEST_true(pc->valid_i32)) {
             TEST_note("errant int32 on line %d", s->curr);
             return 0;
@@ -142,7 +147,7 @@ static int param_conversion_load_stanza(PARAM_CONVERSION *pc, const STANZA *s)
         pc->datum = &datum_i32;
         pc->ref = &ref_i32;
         pc->size = sizeof(ref_i32);
-    } else if (strcasecmp(type, "int64") == 0) {
+    } else if (strcasecmp_l(type, "int64", c_locale) == 0) {
         if (!TEST_true(def_i64) || !TEST_true(pc->valid_i64)) {
             TEST_note("errant int64 on line %d", s->curr);
             return 0;
@@ -151,7 +156,7 @@ static int param_conversion_load_stanza(PARAM_CONVERSION *pc, const STANZA *s)
         pc->datum = &datum_i64;
         pc->ref = &ref_i64;
         pc->size = sizeof(ref_i64);
-    } else if (strcasecmp(type, "uint32") == 0) {
+    } else if (strcasecmp_l(type, "uint32", c_locale) == 0) {
         if (!TEST_true(def_u32) || !TEST_true(pc->valid_u32)) {
             TEST_note("errant uint32 on line %d", s->curr);
             return 0;
@@ -160,7 +165,7 @@ static int param_conversion_load_stanza(PARAM_CONVERSION *pc, const STANZA *s)
         pc->datum = &datum_u32;
         pc->ref = &ref_u32;
         pc->size = sizeof(ref_u32);
-    } else if (strcasecmp(type, "uint64") == 0) {
+    } else if (strcasecmp_l(type, "uint64", c_locale) == 0) {
         if (!TEST_true(def_u64) || !TEST_true(pc->valid_u64)) {
             TEST_note("errant uint64 on line %d", s->curr);
             return 0;
@@ -169,7 +174,7 @@ static int param_conversion_load_stanza(PARAM_CONVERSION *pc, const STANZA *s)
         pc->datum = &datum_u64;
         pc->ref = &ref_u64;
         pc->size = sizeof(ref_u64);
-    } else if (strcasecmp(type, "double") == 0) {
+    } else if (strcasecmp_l(type, "double", c_locale) == 0) {
         if (!TEST_true(def_d) || !TEST_true(pc->valid_d)) {
             TEST_note("errant double on line %d", s->curr);
             return 0;

--- a/test/ssl_old_test.c
+++ b/test/ssl_old_test.c
@@ -26,6 +26,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#include <locale.h>
 
 #include "internal/nelem.h"
 
@@ -209,6 +210,11 @@ static SSL_SESSION *client_sess;
 static int servername_cb(SSL *s, int *ad, void *arg)
 {
     const char *servername = SSL_get_servername(s, TLSEXT_NAMETYPE_host_name);
+    static locale_t c_locale = LC_GLOBAL_LOCALE;
+
+    if (c_locale == LC_GLOBAL_LOCALE)
+        c_locale = newlocale(LC_CTYPE_MASK, "C", 0);
+
     if (sn_server2 == NULL) {
         BIO_printf(bio_stdout, "Servername 2 is NULL\n");
         return SSL_TLSEXT_ERR_NOACK;
@@ -216,7 +222,7 @@ static int servername_cb(SSL *s, int *ad, void *arg)
 
     if (servername) {
         if (s_ctx2 != NULL && sn_server2 != NULL &&
-            !strcasecmp(servername, sn_server2)) {
+            !strcasecmp_l(servername, sn_server2, c_locale)) {
             BIO_printf(bio_stdout, "Switching server context.\n");
             SSL_set_SSL_CTX(s, s_ctx2);
         }

--- a/test/v3nametest.c
+++ b/test/v3nametest.c
@@ -8,6 +8,7 @@
  */
 
 #include <string.h>
+#include <locale.h>
 
 #include <openssl/e_os2.h>
 #include <openssl/x509.h>
@@ -16,7 +17,7 @@
 #include "testutil.h"
 
 #ifdef OPENSSL_SYS_WINDOWS
-# define strcasecmp _stricmp
+# define strcasecmp_l(a,b,c) _stricmp(a,b)
 #endif
 
 static const char *const names[] = {
@@ -286,8 +287,13 @@ static int run_cert(X509 *crt, const char *nameincert,
     const char *const *pname = names;
     int failed = 0;
 
+    static locale_t c_locale = LC_GLOBAL_LOCALE;
+
+    if (c_locale == LC_GLOBAL_LOCALE)
+        c_locale = newlocale(LC_CTYPE_MASK, "C", 0);
+
     for (; *pname != NULL; ++pname) {
-        int samename = strcasecmp(nameincert, *pname) == 0;
+        int samename = strcasecmp_l(nameincert, *pname, c_locale) == 0;
         size_t namelen = strlen(*pname);
         char *name = OPENSSL_malloc(namelen + 1);
         int match, ret;


### PR DESCRIPTION
The behavior of strcasecmp() and strncasecmp() varies by locale.  To avoid
misbehavior in certain locales, always use strcasecmp_l() and
strncasecmp_l() instead.

Fixes #18039

This is an alternative implementation to https://github.com/openssl/openssl/pull/18069; the latter is incomplete and is attempting to use global state, which is fraught.  I've opted here to use local static variables instead, as the cost of calling newlocale() multiple times in a process and keeping separate local state should not be onerous.

The tests from https://github.com/openssl/openssl/pull/18069 are likely suitable to be included.

- [ ] tests are added or updated
