### PR TITLE
Fix small typo in X509v3_get_ext_by_NID man page

### DIFF
--- a/doc/man3/X509v3_get_ext_by_NID.pod
+++ b/doc/man3/X509v3_get_ext_by_NID.pod
@@ -124,7 +124,7 @@ X509v3_get_ext(), X509v3_delete_ext() and X509_delete_ext() return an
 B<X509_EXTENSION> pointer or B<NULL> if an error occurs.
 
 X509v3_get_ext_by_NID() X509v3_get_ext_by_OBJ() and
-X509v3_get_ext_by_critical() return the an extension index or B<-1> if an
+X509v3_get_ext_by_critical() return the extension index or B<-1> if an
 error occurs.
 
 X509v3_add_ext() returns a stack of extensions or B<NULL> on error.


### PR DESCRIPTION
Just remove an extra/redondant word. 
