### PR TITLE
Move types.h #undefs for wincrypt.h compatibility

### DIFF
--- a/include/openssl/types.h
+++ b/include/openssl/types.h
@@ -7,9 +7,21 @@
  * https://www.openssl.org/source/license.html
  */
 
+/*
+ * Unfortunate workaround to avoid symbol conflict with wincrypt.h
+ * See https://github.com/openssl/openssl/issues/9981
+ */
+#ifdef _WIN32
+# define WINCRYPT_USE_SYMBOL_PREFIX
+# undef X509_NAME
+# undef X509_EXTENSIONS
+# undef PKCS7_SIGNER_INFO
+# undef OCSP_REQUEST
+# undef OCSP_RESPONSE
+#endif
+
 #ifndef OPENSSL_TYPES_H
 # define OPENSSL_TYPES_H
-# pragma once
 
 # include <limits.h>
 
@@ -69,15 +81,6 @@ typedef struct asn1_string_table_st ASN1_STRING_TABLE;
 typedef struct ASN1_ITEM_st ASN1_ITEM;
 typedef struct asn1_pctx_st ASN1_PCTX;
 typedef struct asn1_sctx_st ASN1_SCTX;
-
-# ifdef _WIN32
-#  undef X509_NAME
-#  undef X509_EXTENSIONS
-#  undef PKCS7_ISSUER_AND_SERIAL
-#  undef PKCS7_SIGNER_INFO
-#  undef OCSP_REQUEST
-#  undef OCSP_RESPONSE
-# endif
 
 # ifdef BIGNUM
 #  undef BIGNUM

--- a/test/build.info
+++ b/test/build.info
@@ -58,7 +58,7 @@ IF[{- !$disabled{tests} -}]
           recordlentest drbgtest rand_status_test sslbuffertest \
           time_offset_test pemtest ssl_cert_table_internal_test ciphername_test \
           http_test servername_test ocspapitest fatalerrtest tls13ccstest \
-          sysdefaulttest errtest ssl_ctx_test \
+          sysdefaulttest errtest ssl_ctx_test build_wincrypt_test \
           context_internal_test aesgcmtest params_test evp_pkey_dparams_test \
           keymgmt_internal_test hexstr_test provider_status_test defltfips_test \
           bio_readbuffer_test user_property_test pkcs7_test upcallstest \
@@ -925,6 +925,10 @@ ENDIF
   SOURCE[ssl_ctx_test]=ssl_ctx_test.c
   INCLUDE[ssl_ctx_test]=../include ../apps/include
   DEPEND[ssl_ctx_test]=../libcrypto ../libssl libtestutil.a
+
+  SOURCE[build_wincrypt_test]=build_wincrypt_test.c
+  INCLUDE[build_wincrypt_test]=../include
+  DEPEND[build_wincrypt_test]=../libssl ../libcrypto
 
 {-
    use File::Spec::Functions;

--- a/test/build_wincrypt_test.c
+++ b/test/build_wincrypt_test.c
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+/*
+ * Simple buildtest to check for symbol collisions between wincrypt and
+ * OpenSSL headers
+ */
+
+#include <openssl/types.h>
+
+#ifdef _WIN32
+# ifndef WIN32_LEAN_AND_MEAN
+#  define WIN32_LEAN_AND_MEAN
+# endif
+# include <windows.h>
+# include <wincrypt.h>
+# ifndef X509_NAME
+#  ifndef PEDANTIC
+#   warning "wincrypt.h no longer defining X509_NAME before OpenSSL headers"
+#  endif
+# endif
+#endif
+
+#include <openssl/opensslconf.h>
+#ifndef OPENSSL_NO_STDIO
+# include <stdio.h>
+#endif
+
+#include <openssl/evp.h>
+#include <openssl/x509.h>
+#include <openssl/x509v3.h>
+
+int main(void)
+{
+    return 0;
+}


### PR DESCRIPTION
+ Always undef the symbols that may have been #define-d
  by wincrypt.h after the first inclusion of types.h to
  avoid errors from wincrypt.h symbols being used to
  compile OpenSSL code
+ Also need to remove #pragma once for this approach to work
+ Define WINCRYPT_USE_SYMBOL_PREFIX to enable wincrypt
  symbol prefix at some point in future

Fixes #9981

- [x] tests are added or updated
