### PR TITLE
siphash: Fail finalization on uninitialized siphash context

### DIFF
--- a/crypto/siphash/siphash.c
+++ b/crypto/siphash/siphash.c
@@ -204,7 +204,7 @@ int SipHash_Final(SIPHASH *ctx, unsigned char *out, size_t outlen)
     uint64_t v2 = ctx->v2;
     uint64_t v3 = ctx->v3;
 
-    if (outlen != (size_t)ctx->hash_size)
+    if (ctx->crounds == 0 || outlen == 0 || outlen != (size_t)ctx->hash_size)
         return 0;
 
     switch (ctx->len) {

--- a/providers/implementations/macs/siphash_prov.c
+++ b/providers/implementations/macs/siphash_prov.c
@@ -77,11 +77,11 @@ static void *siphash_dup(void *vsrc)
 
     if (!ossl_prov_is_running())
         return NULL;
-    sdst = siphash_new(ssrc->provctx);
+    sdst = OPENSSL_malloc(sizeof(*sdst));
     if (sdst == NULL)
         return NULL;
 
-    sdst->siphash = ssrc->siphash;
+    sdst = ssrc;
     return sdst;
 }
 
@@ -112,7 +112,8 @@ static int siphash_init(void *vmacctx, const unsigned char *key, size_t keylen,
 
     if (!ossl_prov_is_running() || !siphash_set_params(ctx, params))
         return 0;
-    /* Without a key, there is not much to do here,
+    /*
+     * Without a key, there is not much to do here,
      * The actual initialization happens through controls.
      */
     if (key == NULL) {
@@ -202,7 +203,8 @@ static int siphash_set_params(void *vmacctx, const OSSL_PARAM *params)
 
     if ((p = OSSL_PARAM_locate_const(params, OSSL_MAC_PARAM_SIZE)) != NULL) {
         if (!OSSL_PARAM_get_size_t(p, &size)
-            || !SipHash_set_hash_size(&ctx->siphash, size))
+            || !SipHash_set_hash_size(&ctx->siphash, size)
+            || !SipHash_set_hash_size(&ctx->sipcopy, size))
             return 0;
     }
     if ((p = OSSL_PARAM_locate_const(params, OSSL_MAC_PARAM_C_ROUNDS)) != NULL

--- a/providers/implementations/macs/siphash_prov.c
+++ b/providers/implementations/macs/siphash_prov.c
@@ -81,7 +81,7 @@ static void *siphash_dup(void *vsrc)
     if (sdst == NULL)
         return NULL;
 
-    sdst = ssrc;
+    *sdst = *ssrc;
     return sdst;
 }
 

--- a/test/siphash_internal_test.c
+++ b/test/siphash_internal_test.c
@@ -262,8 +262,10 @@ static int test_siphash_basic(void)
 
     /* Use invalid hash size */
     return TEST_int_eq(SipHash_set_hash_size(&siphash, 4), 0)
+           && TEST_false(SipHash_Final(&siphash, output, 0))
            /* Use hash size = 8 */
            && TEST_true(SipHash_set_hash_size(&siphash, 8))
+           && TEST_false(SipHash_Final(&siphash, output, 8))
            && TEST_true(SipHash_Init(&siphash, key, 0, 0))
            && TEST_true(SipHash_Final(&siphash, output, 8))
            && TEST_int_eq(SipHash_Final(&siphash, output, 16), 0)


### PR DESCRIPTION
Also properly update sipcopy when setting the size and fully duplicate the context on dup.

Fixes #18140 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
