### PR TITLE
Prefer GNU init/destructor mechanism to be used for FIPS self tests

### DIFF
--- a/providers/fips/self_test.c
+++ b/providers/fips/self_test.c
@@ -132,7 +132,6 @@ void _cleanup(void)
 # pragma init "init"
 # pragma fini "cleanup"
 
-
 #elif defined(__TANDEM)
 /* Method automatically called by the NonStop OS when the DLL loads */
 void __INIT__init(void) {

--- a/providers/fips/self_test.c
+++ b/providers/fips/self_test.c
@@ -110,7 +110,6 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
 # define DEP_INIT_ATTRIBUTE static __attribute__((constructor))
 # define DEP_FINI_ATTRIBUTE static __attribute__((destructor))
 
-
 #elif defined(__sun)
 # pragma init(init)
 # pragma fini(cleanup)

--- a/providers/fips/self_test.c
+++ b/providers/fips/self_test.c
@@ -103,6 +103,14 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
     }
     return TRUE;
 }
+
+#elif defined(__GNUC__)
+# undef DEP_INIT_ATTRIBUTE
+# undef DEP_FINI_ATTRIBUTE
+# define DEP_INIT_ATTRIBUTE static __attribute__((constructor))
+# define DEP_FINI_ATTRIBUTE static __attribute__((destructor))
+
+
 #elif defined(__sun)
 # pragma init(init)
 # pragma fini(cleanup)
@@ -125,11 +133,6 @@ void _cleanup(void)
 # pragma init "init"
 # pragma fini "cleanup"
 
-#elif defined(__GNUC__)
-# undef DEP_INIT_ATTRIBUTE
-# undef DEP_FINI_ATTRIBUTE
-# define DEP_INIT_ATTRIBUTE static __attribute__((constructor))
-# define DEP_FINI_ATTRIBUTE static __attribute__((destructor))
 
 #elif defined(__TANDEM)
 /* Method automatically called by the NonStop OS when the DLL loads */


### PR DESCRIPTION
I've run across a problem on HP-UX where builds using gcc fail to run the init/cleanup functions. It seems that the compiler does not recognise the platform-specific #pragma init/fini statements.

By moving around the order of checks to ensure the __GNUC__ check is done first the build now works. If using the HP compiler the build/test also works fine.

I have checked that this mechanism works for gcc builds on AIX and Solaris also.