### PR TITLE
Ensure we initialized the locale before evp_pkey_name2type

### DIFF
--- a/crypto/evp/pmeth_lib.c
+++ b/crypto/evp/pmeth_lib.c
@@ -199,6 +199,7 @@ static EVP_PKEY_CTX *int_ctx_new(OSSL_LIB_CTX *libctx,
             }
 #ifndef FIPS_MODULE
             if (keytype != NULL) {
+                OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CONFIG, NULL);
                 id = evp_pkey_name2type(keytype);
                 if (id == NID_undef)
                     id = -1;

--- a/test/build.info
+++ b/test/build.info
@@ -37,7 +37,7 @@ IF[{- !$disabled{tests} -}]
           sanitytest rsa_complex exdatatest bntest \
           ecstresstest gmdifftest pbelutest \
           destest mdc2test sha_test \
-          exptest pbetest localetest \
+          exptest pbetest localetest evp_pkey_ctx_new_from_name\
           evp_pkey_provided_test evp_test evp_extra_test evp_extra_test2 \
           evp_fetch_prov_test evp_libctx_test ossl_store_test \
           v3nametest v3ext \
@@ -138,6 +138,10 @@ IF[{- !$disabled{tests} -}]
   SOURCE[localetest]=localetest.c
   INCLUDE[localetest]=../include ../apps/include
   DEPEND[localetest]=../libcrypto libtestutil.a
+
+  SOURCE[evp_pkey_ctx_new_from_name]=evp_pkey_ctx_new_from_name.c
+  INCLUDE[evp_pkey_ctx_new_from_name]=../include ../apps/include
+  DEPEND[evp_pkey_ctx_new_from_name]=../libcrypto
 
   SOURCE[pbetest]=pbetest.c
   INCLUDE[pbetest]=../include ../apps/include

--- a/test/evp_pkey_ctx_new_from_name.c
+++ b/test/evp_pkey_ctx_new_from_name.c
@@ -1,0 +1,14 @@
+#include <stdio.h>
+#include <openssl/ec.h>
+#include <openssl/evp.h>
+#include <openssl/err.h>
+
+int main(int argc, char *argv[])
+{
+    EVP_PKEY_CTX *pctx = NULL;
+
+    pctx = EVP_PKEY_CTX_new_from_name(NULL, "NO_SUCH_ALGORITHM", NULL);
+    EVP_PKEY_CTX_free(pctx);
+
+    return 0;
+}

--- a/test/recipes/02-test_localetest.t
+++ b/test/recipes/02-test_localetest.t
@@ -15,7 +15,9 @@ setup("locale tests");
 plan skip_all => "Locale tests not available on Windows or VMS"
     if $^O =~ /^(VMS|MSWin32)$/;
 
-plan tests => 2;
+plan tests => 3;
+
+ok(run(test(["evp_pkey_ctx_new_from_name"])), "running evp_pkey_ctx_new_from_name without explicit context init");
 
 $ENV{LANG} = "C";
 ok(run(test(["localetest"])), "running localetest");


### PR DESCRIPTION
Before we call `evp_pkey_name2type`, we must have a locale object, so call `OPENSSL_init_crypto` explicitly.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
