### PR TITLE
fix for sslecho in demos echoing garbage #18165

### DIFF
--- a/demos/sslecho/main.c
+++ b/demos/sslecho/main.c
@@ -285,7 +285,8 @@ int main(int argc, char **argv)
             /* Loop to send input from keyboard */
             while (true) {
                 /* Get a line of input */
-                txlen = getline(&txbuf, &txcap, stdin);
+                char * txbufp = txbuf;
+                txlen = getline(&txbufp, &txcap, stdin);
                 /* Exit loop if just a carriage return */
                 if (txbuf[0] == '\n') {
                     break;
@@ -330,9 +331,6 @@ int main(int argc, char **argv)
         close(client_skt);
     if (server_skt != -1)
         close(server_skt);
-
-    OPENSSL_free(txbuf);
-    OPENSSL_free(rxbuf);
 
     printf("sslecho exiting\n");
 

--- a/demos/sslecho/main.c
+++ b/demos/sslecho/main.c
@@ -137,8 +137,8 @@ int main(int argc, char **argv)
     int server_skt = -1;
     int client_skt = -1;
 
-    /** used by getline relying on realloc, can't be statically allocated */
-    char * txbuf = NULL;
+    /* used by getline relying on realloc, can't be statically allocated */
+    char *txbuf = NULL;
     size_t txcap = 0;
     int txlen;
 
@@ -288,7 +288,7 @@ int main(int argc, char **argv)
                 /* Get a line of input */
                 txlen = getline(&txbuf, &txcap, stdin);
                 /* Exit loop on error */
-                if ((txlen < 0  )||(txbuf == NULL)) {
+                if (txlen < 0 || txbuf == NULL) {
                     break;
                 }
                 /* Exit loop if just a carriage return */
@@ -335,10 +335,8 @@ int main(int argc, char **argv)
     if (server_skt != -1)
         close(server_skt);
 
-    if ( txbuf && (txcap>0) )
-      {
-	free(txbuf);
-      }
+    if (txbuf != NULL && txcap > 0)
+        free(txbuf);
 
     printf("sslecho exiting\n");
 


### PR DESCRIPTION
- getline does set &txbufp content at return, make sure it can be done.
  - fixes warning 'passing argument 1 of ‘getline’ from incompatible pointer type'
- remove OPENSSL_free on non allocated fixed size array
  - fixes 'free(): invalid pointer'

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
