### PR TITLE
Fix BIO_get_ktls_send/recv to return 0 or 1 only

### DIFF
--- a/doc/man3/BIO_ctrl.pod
+++ b/doc/man3/BIO_ctrl.pod
@@ -82,9 +82,9 @@ return a size_t type and are functions, BIO_pending() and BIO_wpending() are
 macros which call BIO_ctrl().
 
 BIO_get_ktls_send() returns 1 if the BIO is using the Kernel TLS data-path for
-sending. Otherwise, it returns zero. It also returns negative values for failure.
+sending. Otherwise, it returns zero.
 BIO_get_ktls_recv() returns 1 if the BIO is using the Kernel TLS data-path for
-receiving. Otherwise, it returns zero. It also returns negative values for failure.
+receiving. Otherwise, it returns zero.
 
 BIO_get_conn_mode() returns the BIO connection mode. BIO_set_conn_mode() sets
 the BIO connection mode.
@@ -166,7 +166,7 @@ the case of BIO_seek() on a file BIO for a successful operation.
 
 =head1 HISTORY
 
-The BIO_get_ktls_send() and BIO_get_ktls_recv() functions were added in
+The BIO_get_ktls_send() and BIO_get_ktls_recv() macros were added in
 OpenSSL 3.0.
 
 The BIO_get_conn_mode(), BIO_set_conn_mode() and BIO_set_tfo() functions

--- a/doc/man3/BIO_ctrl.pod
+++ b/doc/man3/BIO_ctrl.pod
@@ -167,7 +167,7 @@ the case of BIO_seek() on a file BIO for a successful operation.
 =head1 HISTORY
 
 The BIO_get_ktls_send() and BIO_get_ktls_recv() macros were added in
-OpenSSL 3.0.
+OpenSSL 3.0. They were modified to never return -1 in OpenSSL 3.0.3.
 
 The BIO_get_conn_mode(), BIO_set_conn_mode() and BIO_set_tfo() functions
 were added in OpenSSL 3.1.

--- a/doc/man3/BIO_ctrl.pod
+++ b/doc/man3/BIO_ctrl.pod
@@ -167,7 +167,7 @@ the case of BIO_seek() on a file BIO for a successful operation.
 =head1 HISTORY
 
 The BIO_get_ktls_send() and BIO_get_ktls_recv() macros were added in
-OpenSSL 3.0. They were modified to never return -1 in OpenSSL 3.0.3.
+OpenSSL 3.0. They were modified to never return -1 in OpenSSL 3.0.4.
 
 The BIO_get_conn_mode(), BIO_set_conn_mode() and BIO_set_tfo() functions
 were added in OpenSSL 3.1.

--- a/include/openssl/bio.h.in
+++ b/include/openssl/bio.h.in
@@ -174,9 +174,9 @@ extern "C" {
 
 # ifndef OPENSSL_NO_KTLS
 #  define BIO_get_ktls_send(b)         \
-     BIO_ctrl(b, BIO_CTRL_GET_KTLS_SEND, 0, NULL)
+     (BIO_ctrl(b, BIO_CTRL_GET_KTLS_SEND, 0, NULL) > 0)
 #  define BIO_get_ktls_recv(b)         \
-     BIO_ctrl(b, BIO_CTRL_GET_KTLS_RECV, 0, NULL)
+     (BIO_ctrl(b, BIO_CTRL_GET_KTLS_RECV, 0, NULL) > 0)
 # else
 #  define BIO_get_ktls_send(b)  (0)
 #  define BIO_get_ktls_recv(b)  (0)


### PR DESCRIPTION
We use it as a boolean everywhere in the code and there is no reason to distinguish between the 0 and -1 return.

Fixes #18176 

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
