### PR TITLE
ocsp: Fix calling of X509_check_trust in OCSP_basic_verify

### DIFF
--- a/crypto/ocsp/ocsp_vfy.c
+++ b/crypto/ocsp/ocsp_vfy.c
@@ -144,7 +144,7 @@ int OCSP_basic_verify(OCSP_BASICRESP *bs, STACK_OF(X509) *certs,
             goto end;
 
         x = sk_X509_value(chain, sk_X509_num(chain) - 1);
-        if (X509_check_trust(x, NID_OCSP_sign, 0) != X509_TRUST_TRUSTED) {
+        if (X509_check_trust(x, X509_TRUST_OCSP_SIGN, 0) != X509_TRUST_TRUSTED) {
             ERR_raise(ERR_LIB_OCSP, OCSP_R_ROOT_CA_NOT_TRUSTED);
             ret = 0;
             goto end;


### PR DESCRIPTION
It takes and works with a X509_TRUST_* id, not a NID.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->