### PR TITLE
EVP: Make sure Ed signature is called without digest

### DIFF
--- a/crypto/asn1/a_sign.c
+++ b/crypto/asn1/a_sign.c
@@ -131,12 +131,17 @@ int ASN1_item_sign_ex(const ASN1_ITEM *it, X509_ALGOR *algor1,
 {
     int rv = 0;
     EVP_MD_CTX *ctx = evp_md_ctx_new_ex(pkey, id, libctx, propq);
+    char mdname[80] = "";
+
+    if (EVP_PKEY_get_default_digest_name(pkey, mdname, sizeof(mdname)) > 0
+            && strcmp(mdname, "UNDEF") == 0) /* at least for Ed25519, Ed448 */
+        md = NULL;
 
     if (ctx == NULL) {
         ERR_raise(ERR_LIB_ASN1, ERR_R_MALLOC_FAILURE);
         return 0;
     }
-    /* We can use the non _ex variant here since the pkey is already setup */
+    /* We can use the non _ex variant here since the pkey is already set up */
     if (!EVP_DigestSignInit(ctx, NULL, md, NULL, pkey))
         goto err;
 

--- a/doc/man3/ASN1_item_sign.pod
+++ b/doc/man3/ASN1_item_sign.pod
@@ -40,7 +40,10 @@ ASN1 sign and verify
 =head1 DESCRIPTION
 
 ASN1_item_sign_ex() is used to sign arbitrary ASN1 data using a data object
-I<data>, the ASN.1 structure I<it>, private key I<pkey> and message digest I<md>.
+I<data>, the ASN.1 structure I<it>, a private key I<pkey>,
+and a message digest algorithm I<md>.
+In case the private key is of a type (such as Ed25519 and Ed448) that is
+implicitly associated with a digest alorithm, the I<md> argument is ignored.
 The data that is signed is formed by taking the data object in I<data> and
 converting it to der format using the ASN.1 structure I<it>.
 The I<data> that will be signed, and a structure containing the signature may


### PR DESCRIPTION
`eddsa_digest_signverify_init()` has an `mdname` parameter although the function fails if it is not NULL/empty (because for Ed25519 and Ed448 the digest algorithm is implicit).
This turns out to be a problem if a general signing operation has an explicit default digest algorithm,
as for self-signature proof-of-possession operations in CMP/CRMF.

This PR resets and provided `md` argument of `ASN1_item_sign_ex()` if no digest should be used.
See also `EVP_PKEY_get_default_digest_name()`.

Fixes #18184
