### PR TITLE
fix_dh_paramgen_type: Avoid crash with invalid paramgen type

### DIFF
--- a/crypto/evp/ctrl_params_translate.c
+++ b/crypto/evp/ctrl_params_translate.c
@@ -1072,7 +1072,11 @@ static int fix_dh_paramgen_type(enum state state,
         return 0;
 
     if (state == PRE_CTRL_STR_TO_PARAMS) {
-        ctx->p2 = (char *)ossl_dh_gen_type_id2name(atoi(ctx->p2));
+        if ((ctx->p2 = (char *)ossl_dh_gen_type_id2name(atoi(ctx->p2)))
+             == NULL) {
+            ERR_raise(ERR_LIB_EVP, EVP_R_INVALID_VALUE);
+            return 0;
+        }
         ctx->p1 = strlen(ctx->p2);
     }
 


### PR DESCRIPTION
This fixes a segfault on `openssl genpkey -genparam -algorithm DH -pkeyopt dh_paramgen_type:4`
