### PR TITLE
http_client.c: check expected content type only if HTTP status code is 200 (OK)

### DIFF
--- a/crypto/http/http_client.c
+++ b/crypto/http/http_client.c
@@ -669,7 +669,7 @@ int OSSL_HTTP_REQ_CTX_nbio(OSSL_HTTP_REQ_CTX *rctx)
                 rctx->redirection_url = value;
                 return 0;
             }
-            if (rctx->expected_ct != NULL
+            if (rctx->state == OHS_HEADERS && rctx->expected_ct != NULL
                     && OPENSSL_strcasecmp(key, "Content-Type") == 0) {
                 if (OPENSSL_strcasecmp(rctx->expected_ct, value) != 0) {
                     ERR_raise_data(ERR_LIB_HTTP, HTTP_R_UNEXPECTED_CONTENT_TYPE,


### PR DESCRIPTION
This prevents on error responses irrelevant client-side errors regarding the content type expected for responses.
When the response contains a redirection, it prevents wrong failure.
