### PR TITLE
openssl: dhparam: Print warning if -in argument is ignored

### DIFF
--- a/apps/dhparam.c
+++ b/apps/dhparam.c
@@ -190,6 +190,10 @@ int dhparam_main(int argc, char **argv)
     if (num) {
         const char *alg = dsaparam ? "DSA" : "DH";
 
+        if (infile != NULL) {
+            BIO_printf(bio_err, "Warning, input file %s ignored\n", infile);
+        }
+
         ctx = EVP_PKEY_CTX_new_from_name(NULL, alg, NULL);
         if (ctx == NULL) {
             BIO_printf(bio_err,


### PR DESCRIPTION
Fixes: openssl#18146

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
