### PR TITLE
Crash fix

### DIFF
--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -4464,7 +4464,7 @@ static int ssl3_read_internal(SSL *s, void *buf, size_t len, int peek,
     ret =
         s->method->ssl_read_bytes(s, SSL3_RT_APPLICATION_DATA, NULL, buf, len,
                                   peek, readbytes);
-    if ((ret == -1) && (s->s3->in_read_app_data == 2)) {
+    if ((ret == -1) && (s->s3 == 0 || s->s3->in_read_app_data == 2)) {
         /*
          * ssl3_read_bytes decided to call s->handshake_func, which called
          * ssl3_read_bytes to read handshake data. However, ssl3_read_bytes


### PR DESCRIPTION
Hi,

this patch fixes the problem with threads at the client's side. Imagine the following situation:
- a worker thread opens the persistent SSL connection with a server and hangs on SSL_read;
- the main thread, which acts as a UI runner, receives a command to break connection, and to force the worker thread to leave it issues shutdown() call over the result of SSL_get_fd(). 
- in this case the main thread modifies the internal structures of openssl, and a worker immediately crashes inside SSL_read(), because s->s3 pointer becomes NULL.

This patch adds a check that s->s3 is not NULL after reading, if SSL_read returned -1.
Hope this helps. Thank you.

