### PR TITLE
Do not send an empty supported groups extension

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,20 +9,24 @@
 
  Changes between 1.1.1o and 1.1.1p [xx XXX xxxx]
 
-  *)
+  *) When OpenSSL TLS client is connecting without any supported elliptic
+     curves and TLS-1.3 protocol is disabled the connection will no longer fail
+     if a ciphersuite that does not use a key exchange based on elliptic
+     curves can be negotiated.
+     [Tomáš Mráz]
 
  Changes between 1.1.1n and 1.1.1o [3 May 2022]
 
   *) Fixed a bug in the c_rehash script which was not properly sanitising shell
-    metacharacters to prevent command injection.  This script is distributed by
-    some operating systems in a manner where it is automatically executed.  On
-    such operating systems, an attacker could execute arbitrary commands with the
-    privileges of the script.
+     metacharacters to prevent command injection.  This script is distributed
+     by some operating systems in a manner where it is automatically executed.
+     On such operating systems, an attacker could execute arbitrary commands
+     with the privileges of the script.
 
-    Use of the c_rehash script is considered obsolete and should be replaced
-    by the OpenSSL rehash command line tool.
-    (CVE-2022-1292)
-    [Tomáš Mráz]
+     Use of the c_rehash script is considered obsolete and should be replaced
+     by the OpenSSL rehash command line tool.
+     (CVE-2022-1292)
+     [Tomáš Mráz]
 
  Changes between 1.1.1m and 1.1.1n [15 Mar 2022]
 

--- a/ssl/statem/extensions_clnt.c
+++ b/ssl/statem/extensions_clnt.c
@@ -118,6 +118,8 @@ static int use_ecc(SSL *s)
     int i, end, ret = 0;
     unsigned long alg_k, alg_a;
     STACK_OF(SSL_CIPHER) *cipher_stack = NULL;
+    const uint16_t *pgroups = NULL;
+    size_t num_groups, j;
 
     /* See if we support any ECC ciphersuites */
     if (s->version == SSL3_VERSION)
@@ -139,7 +141,19 @@ static int use_ecc(SSL *s)
     }
 
     sk_SSL_CIPHER_free(cipher_stack);
-    return ret;
+    if (!ret)
+        return 0;
+
+    /* Check we have at least one EC supported group */
+    tls1_get_supported_groups(s, &pgroups, &num_groups);
+    for (j = 0; j < num_groups; j++) {
+        uint16_t ctmp = pgroups[j];
+
+        if (tls_curve_allowed(s, ctmp, SSL_SECOP_CURVE_SUPPORTED))
+            return 1;
+    }
+
+    return 0;
 }
 
 EXT_RETURN tls_construct_ctos_ec_pt_formats(SSL *s, WPACKET *pkt,

--- a/test/recipes/80-test_ssl_new.t
+++ b/test/recipes/80-test_ssl_new.t
@@ -28,7 +28,7 @@ map { s/\^// } @conf_files if $^O eq "VMS";
 
 # We hard-code the number of tests to double-check that the globbing above
 # finds all files as expected.
-plan tests => 29;  # = scalar @conf_srcs
+plan tests => 30;  # = scalar @conf_srcs
 
 # Some test results depend on the configuration of enabled protocols. We only
 # verify generated sources in the default configuration.
@@ -70,6 +70,8 @@ my %conf_dependent_tests = (
   "25-cipher.conf" => disabled("poly1305") || disabled("chacha"),
   "27-ticket-appdata.conf" => !$is_default_tls,
   "28-seclevel.conf" => disabled("tls1_2") || $no_ec,
+  "30-supported-groups.conf" => disabled("tls1_2") || disabled("tls1_3")
+                                || $no_ec || $no_ec2m
 );
 
 # Add your test here if it should be skipped for some compile-time

--- a/test/ssl-tests/30-supported-groups.conf
+++ b/test/ssl-tests/30-supported-groups.conf
@@ -1,0 +1,54 @@
+# Generated with generate_ssl_tests.pl
+
+num_tests = 2
+
+test-0 = 0-Just a sanity test case
+test-1 = 1-Pass with empty groups with TLS1.2
+# ===========================================================
+
+[0-Just a sanity test case]
+ssl_conf = 0-Just a sanity test case-ssl
+
+[0-Just a sanity test case-ssl]
+server = 0-Just a sanity test case-server
+client = 0-Just a sanity test case-client
+
+[0-Just a sanity test case-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[0-Just a sanity test case-client]
+CipherString = DEFAULT
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-0]
+ExpectedResult = Success
+
+
+# ===========================================================
+
+[1-Pass with empty groups with TLS1.2]
+ssl_conf = 1-Pass with empty groups with TLS1.2-ssl
+
+[1-Pass with empty groups with TLS1.2-ssl]
+server = 1-Pass with empty groups with TLS1.2-server
+client = 1-Pass with empty groups with TLS1.2-client
+
+[1-Pass with empty groups with TLS1.2-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[1-Pass with empty groups with TLS1.2-client]
+CipherString = DEFAULT
+Groups = sect163k1
+MaxProtocol = TLSv1.2
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-1]
+ExpectedResult = Success
+
+

--- a/test/ssl-tests/30-supported-groups.conf.in
+++ b/test/ssl-tests/30-supported-groups.conf.in
@@ -1,0 +1,45 @@
+# -*- mode: perl; -*-
+# Copyright 2016-2020 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the OpenSSL license (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+
+## SSL test configurations
+
+package ssltests;
+use OpenSSL::Test::Utils;
+
+our @tests = (
+    {
+        name => "Just a sanity test case",
+        server => { },
+        client => { },
+        test   => { "ExpectedResult" => "Success" },
+    },
+);
+
+our @tests_tls1_3 = (
+    {
+        name => "Fail empty groups with TLS1.3",
+        server => { },
+        client => { "Groups" => "sect163k1" },
+        test   => { "ExpectedResult" => "ClientFail" },
+    },
+);
+
+our @tests_tls1_2 = (
+    {
+        name => "Pass with empty groups with TLS1.2",
+        server => { },
+        client => { "Groups" => "sect163k1",
+                    "MaxProtocol" => "TLSv1.2" },
+        test   => { "ExpectedResult" => "Success" },
+    },
+);
+
+push @tests, @tests_tls1_3 unless disabled("tls1_3")
+                                  || !disabled("ec2m") || disabled("ec");
+push @tests, @tests_tls1_2 unless disabled("tls1_2") || disabled("ec");


### PR DESCRIPTION
This allows handshake to proceed if the maximum TLS version enabled is <1.3

Fixes #13583

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
