### PR TITLE
Add quotes around perl scripts

### DIFF
--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -744,7 +744,7 @@ EOF
               $args{generator}->[1] || platform->dsoname($args{product});
           return <<"EOF";
 $target: $gen0 $deps $mkdef
-	"\$(PERL)" $mkdef$ord_ver --ordinals $gen0 --name $ord_name --OS windows > $target
+	"\$(PERL)" "$mkdef"$ord_ver --ordinals $gen0 --name $ord_name --OS windows > $target
 EOF
       } elsif (platform->isasm($args{src})) {
           #
@@ -760,7 +760,7 @@ EOF
 
           my $generator;
           if ($gen0 =~ /\.pl$/) {
-              $generator = '"$(PERL)"'.$gen_incs.' '.$gen0.$gen_args
+              $generator = '"$(PERL)"'.$gen_incs.' "'.$gen0.'"'.$gen_args
                   .' "$(PERLASM_SCHEME)"'.$incs.' '.$cppflags.$defs.' $(PROCESSSOR)';
           } elsif ($gen0 =~ /\.S$/) {
               $generator = undef;
@@ -817,7 +817,7 @@ EOF
           $gen0 = platform->bin($gen0);
           return <<"EOF";
 $args{src}: $gen0 $deps "\$(BLDDIR)\\util\\wrap.pl"
-	"\$(PERL)" "\$(BLDDIR)\\util\\wrap.pl" $gen0$gen_args > \$@
+	"\$(PERL)" "\$(BLDDIR)\\util\\wrap.pl" "$gen0"$gen_args > \$@
 EOF
       } else {
           #
@@ -825,7 +825,7 @@ EOF
           #
           return <<"EOF";
 $args{src}: "$gen0" $deps
-	"\$(PERL)"$gen_incs $gen0$gen_args > \$@
+	"\$(PERL)"$gen_incs "$gen0"$gen_args > \$@
 EOF
       }
   }


### PR DESCRIPTION
Otherwise, it seems nmake doesn't invoke perl properly.

See also the discussion here: https://github.com/eclipse-openj9/openj9/pull/14900#issuecomment-1095904613.