### PR TITLE
Fix typo in SSLeay License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -99,7 +99,7 @@
  *    must display the following acknowledgement:
  *    "This product includes cryptographic software written by
  *     Eric Young (eay@cryptsoft.com)"
- *    The word 'cryptographic' can be left out if the rouines from the library
+ *    The word 'cryptographic' can be left out if the routines from the library
  *    being used are not cryptographic related :-).
  * 4. If you include any Windows specific code (or a derivative thereof) from
  *    the apps directory (application code) you must include an acknowledgement:


### PR DESCRIPTION
Fixed a small typo in the original SSLeay License