### PR TITLE
Header file cleanup for C++20 header-units

### DIFF
--- a/include/openssl/asn1.h.in
+++ b/include/openssl/asn1.h.in
@@ -22,6 +22,9 @@ use OpenSSL::stackhash qw(generate_stack_macros);
 #  define HEADER_ASN1_H
 # endif
 
+# ifndef OPENSSL_NO_STDIO
+#  include <stdio.h>
+# endif
 # include <time.h>
 # include <openssl/e_os2.h>
 # include <openssl/opensslconf.h>

--- a/include/openssl/conf.h.in
+++ b/include/openssl/conf.h.in
@@ -28,6 +28,9 @@ use OpenSSL::stackhash qw(generate_stack_macros generate_lhash_macros);
 # include <openssl/e_os2.h>
 # include <openssl/types.h>
 # include <openssl/conferr.h>
+# ifndef OPENSSL_NO_STDIO
+#  include <stdio.h>
+# endif
 
 #ifdef  __cplusplus
 extern "C" {

--- a/include/openssl/dh.h
+++ b/include/openssl/dh.h
@@ -79,6 +79,9 @@ int EVP_PKEY_CTX_get0_dh_kdf_ukm(EVP_PKEY_CTX *ctx, unsigned char **ukm);
 # define EVP_PKEY_DH_KDF_NONE                            1
 # define EVP_PKEY_DH_KDF_X9_42                           2
 
+# ifndef OPENSSL_NO_STDIO
+#  include <stdio.h>
+# endif
 # ifndef OPENSSL_NO_DH
 #  include <openssl/e_os2.h>
 #  include <openssl/bio.h>

--- a/include/openssl/dsa.h
+++ b/include/openssl/dsa.h
@@ -19,11 +19,26 @@
 # include <openssl/opensslconf.h>
 # include <openssl/types.h>
 
+# include <stdlib.h>
+
+# ifndef OPENSSL_NO_DSA
+#  include <openssl/e_os2.h>
+#  include <openssl/asn1.h>
+#  include <openssl/bio.h>
+#  include <openssl/crypto.h>
+#  include <openssl/bn.h>
+#  ifndef OPENSSL_NO_DEPRECATED_1_1_0
+#   include <openssl/dh.h>
+#  endif
+#  include <openssl/dsaerr.h>
+#  ifndef OPENSSL_NO_STDIO
+#   include <stdio.h>
+#  endif
+# endif
+
 # ifdef  __cplusplus
 extern "C" {
 # endif
-
-# include <stdlib.h>
 
 int EVP_PKEY_CTX_set_dsa_paramgen_bits(EVP_PKEY_CTX *ctx, int nbits);
 int EVP_PKEY_CTX_set_dsa_paramgen_q_bits(EVP_PKEY_CTX *ctx, int qbits);
@@ -42,16 +57,6 @@ int EVP_PKEY_CTX_set_dsa_paramgen_md(EVP_PKEY_CTX *ctx, const EVP_MD *md);
 # define EVP_PKEY_CTRL_DSA_PARAMGEN_MD           (EVP_PKEY_ALG_CTRL + 3)
 
 # ifndef OPENSSL_NO_DSA
-#  include <openssl/e_os2.h>
-#  include <openssl/asn1.h>
-#  include <openssl/bio.h>
-#  include <openssl/crypto.h>
-#  include <openssl/bn.h>
-#  ifndef OPENSSL_NO_DEPRECATED_1_1_0
-#   include <openssl/dh.h>
-#  endif
-#  include <openssl/dsaerr.h>
-
 #  ifndef OPENSSL_DSA_MAX_MODULUS_BITS
 #   define OPENSSL_DSA_MAX_MODULUS_BITS   10000
 #  endif

--- a/include/openssl/ec.h
+++ b/include/openssl/ec.h
@@ -88,6 +88,9 @@ typedef enum {
 
 const char *OSSL_EC_curve_nid2name(int nid);
 
+# ifndef OPENSSL_NO_STDIO
+#  include <stdio.h>
+# endif
 # ifndef OPENSSL_NO_EC
 #  include <openssl/asn1.h>
 #  include <openssl/symhacks.h>

--- a/include/openssl/lhash.h.in
+++ b/include/openssl/lhash.h.in
@@ -26,6 +26,9 @@ use OpenSSL::stackhash qw(generate_lhash_macros);
 
 # include <openssl/e_os2.h>
 # include <openssl/bio.h>
+# ifndef OPENSSL_NO_STDIO
+#  include <stdio.h>
+# endif
 
 #ifdef  __cplusplus
 extern "C" {

--- a/include/openssl/pem.h
+++ b/include/openssl/pem.h
@@ -22,6 +22,9 @@
 # include <openssl/evp.h>
 # include <openssl/x509.h>
 # include <openssl/pemerr.h>
+# ifndef OPENSSL_NO_STDIO
+#  include <stdio.h>
+# endif
 
 #ifdef  __cplusplus
 extern "C" {

--- a/include/openssl/pkcs12.h.in
+++ b/include/openssl/pkcs12.h.in
@@ -26,6 +26,9 @@ use OpenSSL::stackhash qw(generate_stack_macros);
 # include <openssl/core.h>
 # include <openssl/x509.h>
 # include <openssl/pkcs12err.h>
+# ifndef OPENSSL_NO_STDIO
+#  include <stdio.h>
+# endif
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/openssl/pkcs7.h.in
+++ b/include/openssl/pkcs7.h.in
@@ -29,6 +29,9 @@ use OpenSSL::stackhash qw(generate_stack_macros);
 # include <openssl/symhacks.h>
 # include <openssl/types.h>
 # include <openssl/pkcs7err.h>
+# ifndef OPENSSL_NO_STDIO
+#  include <stdio.h>
+# endif
 
 #ifdef  __cplusplus
 extern "C" {

--- a/include/openssl/rsa.h
+++ b/include/openssl/rsa.h
@@ -27,6 +27,9 @@
 # endif
 # include <openssl/rsaerr.h>
 # include <openssl/safestack.h>
+# ifndef OPENSSL_NO_STDIO
+#  include <stdio.h>
+# endif
 
 # ifdef  __cplusplus
 extern "C" {

--- a/include/openssl/ssl.h.in
+++ b/include/openssl/ssl.h.in
@@ -43,6 +43,9 @@ use OpenSSL::stackhash qw(generate_stack_macros generate_const_stack_macros);
 # include <openssl/ct.h>
 # include <openssl/sslerr.h>
 # include <openssl/prov_ssl.h>
+# ifndef OPENSSL_NO_STDIO
+#  include <stdio.h>
+# endif
 
 #ifdef  __cplusplus
 extern "C" {

--- a/include/openssl/ts.h
+++ b/include/openssl/ts.h
@@ -30,12 +30,14 @@
 # include <openssl/dh.h>
 # include <openssl/tserr.h>
 # include <openssl/ess.h>
+# include <openssl/x509.h>
+# include <openssl/x509v3.h>
+# ifndef OPENSSL_NO_STDIO
+#  include <stdio.h>
+# endif
 # ifdef  __cplusplus
 extern "C" {
 # endif
-
-# include <openssl/x509.h>
-# include <openssl/x509v3.h>
 
 typedef struct TS_msg_imprint_st TS_MSG_IMPRINT;
 typedef struct TS_req_st TS_REQ;

--- a/include/openssl/x509.h.in
+++ b/include/openssl/x509.h.in
@@ -41,6 +41,9 @@ use OpenSSL::stackhash qw(generate_stack_macros);
 
 # include <openssl/sha.h>
 # include <openssl/x509err.h>
+# ifndef OPENSSL_NO_STDIO
+#  include <stdio.h>
+# endif
 
 #ifdef  __cplusplus
 extern "C" {

--- a/include/openssl/x509v3.h.in
+++ b/include/openssl/x509v3.h.in
@@ -26,6 +26,9 @@ use OpenSSL::stackhash qw(generate_stack_macros);
 # include <openssl/x509.h>
 # include <openssl/conf.h>
 # include <openssl/x509v3err.h>
+# ifndef OPENSSL_NO_STDIO
+#  include <stdio.h>
+# endif
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
C++20 adds 'header units' as a stepping-stone to modules.  Header units are regular header-files that have a 'self-contained' property -- essentially they do not require previously-included headers to provide typedefs and what not.

This addresses 2 problems discovered when using clang modules (as a proxy for C++20 header-units).

a) Some headers that pay attention to OPENSSL_NO_STDIO to determine whether to declare certain FILE*-taking functions do not #include <stdio.h> themselves, relying on their includer already having done that.  That breaks the above mentioned encapuslation requirement. Fixed by conditionally including stdio.h in those headers.  I chose to always include stdio.h in such headers, even when they included another such header that transitively included stdio.  That way they do not rely on an artifact of that intermediate header's behaviour.

b) Some headers have #includes inside 'extern "C" { ... }' regions. That has a bad code-smell, but GCC and clang have extensions to permit it with implementation-defined effects.  Clang needs annotation on the included files to know that they themselves are entirely inside a similar region.  GCC behaves as-if there's an extern "C++" region wrapping the included header (which must therefore wrap its contents in extern "C", if that is what it wants.  In effect the includer's extern "C" region is just misleading. I didn't audit all the headers for this, only those I noticed when addressing #a.

\#a is necessary to build the headers as a set of clang-modules.  #b is not necessary, but as I mentioned, avoids potential
implementation-defined behaviour.

[Contribution assignment is now on file]