### PR TITLE
public API: Remove needless `const` from scalar types

### DIFF
--- a/crypto/aes/aes_cfb.c
+++ b/crypto/aes/aes_cfb.c
@@ -24,7 +24,7 @@
 
 void AES_cfb128_encrypt(const unsigned char *in, unsigned char *out,
                         size_t length, const AES_KEY *key,
-                        unsigned char *ivec, int *num, const int enc)
+                        unsigned char *ivec, int *num, int enc)
 {
 
     CRYPTO_cfb128_encrypt(in, out, length, key, ivec, num, enc,
@@ -34,7 +34,7 @@ void AES_cfb128_encrypt(const unsigned char *in, unsigned char *out,
 /* N.B. This expects the input to be packed, MS bit first */
 void AES_cfb1_encrypt(const unsigned char *in, unsigned char *out,
                       size_t length, const AES_KEY *key,
-                      unsigned char *ivec, int *num, const int enc)
+                      unsigned char *ivec, int *num, int enc)
 {
     CRYPTO_cfb128_1_encrypt(in, out, length, key, ivec, num, enc,
                             (block128_f) AES_encrypt);
@@ -42,7 +42,7 @@ void AES_cfb1_encrypt(const unsigned char *in, unsigned char *out,
 
 void AES_cfb8_encrypt(const unsigned char *in, unsigned char *out,
                       size_t length, const AES_KEY *key,
-                      unsigned char *ivec, int *num, const int enc)
+                      unsigned char *ivec, int *num, int enc)
 {
     CRYPTO_cfb128_8_encrypt(in, out, length, key, ivec, num, enc,
                             (block128_f) AES_encrypt);

--- a/crypto/aes/aes_core.c
+++ b/crypto/aes/aes_core.c
@@ -628,8 +628,7 @@ static void KeyExpansion(const unsigned char *key, u64 *w,
 /**
  * Expand the cipher key into the encryption key schedule.
  */
-int AES_set_encrypt_key(const unsigned char *userKey, const int bits,
-                        AES_KEY *key)
+int AES_set_encrypt_key(const unsigned char *userKey, int bits, AES_KEY *key)
 {
     u64 *rk;
 
@@ -654,8 +653,7 @@ int AES_set_encrypt_key(const unsigned char *userKey, const int bits,
 /**
  * Expand the cipher key into the decryption key schedule.
  */
-int AES_set_decrypt_key(const unsigned char *userKey, const int bits,
-                        AES_KEY *key)
+int AES_set_decrypt_key(const unsigned char *userKey, int bits, AES_KEY *key)
 {
     return AES_set_encrypt_key(userKey, bits, key);
 }
@@ -1275,8 +1273,7 @@ static const u32 rcon[] = {
 /**
  * Expand the cipher key into the encryption key schedule.
  */
-int AES_set_encrypt_key(const unsigned char *userKey, const int bits,
-                        AES_KEY *key)
+int AES_set_encrypt_key(const unsigned char *userKey, int bits, AES_KEY *key)
 {
 
     u32 *rk;
@@ -1377,8 +1374,7 @@ int AES_set_encrypt_key(const unsigned char *userKey, const int bits,
 /**
  * Expand the cipher key into the decryption key schedule.
  */
-int AES_set_decrypt_key(const unsigned char *userKey, const int bits,
-                        AES_KEY *key)
+int AES_set_decrypt_key(const unsigned char *userKey, int bits, AES_KEY *key)
 {
 
     u32 *rk;
@@ -1854,8 +1850,7 @@ static const u32 rcon[] = {
 /**
  * Expand the cipher key into the encryption key schedule.
  */
-int AES_set_encrypt_key(const unsigned char *userKey, const int bits,
-                        AES_KEY *key)
+int AES_set_encrypt_key(const unsigned char *userKey, int bits, AES_KEY *key)
 {
     u32 *rk;
     int i = 0;
@@ -1955,8 +1950,7 @@ int AES_set_encrypt_key(const unsigned char *userKey, const int bits,
 /**
  * Expand the cipher key into the decryption key schedule.
  */
-int AES_set_decrypt_key(const unsigned char *userKey, const int bits,
-                        AES_KEY *key)
+int AES_set_decrypt_key(const unsigned char *userKey, int bits, AES_KEY *key)
 {
 
     u32 *rk;

--- a/crypto/aes/aes_ige.c
+++ b/crypto/aes/aes_ige.c
@@ -47,7 +47,7 @@ typedef struct {
 /*  Use of this function is deprecated. */
 void AES_ige_encrypt(const unsigned char *in, unsigned char *out,
                      size_t length, const AES_KEY *key,
-                     unsigned char *ivec, const int enc)
+                     unsigned char *ivec, int enc)
 {
     size_t n;
     size_t len = length / AES_BLOCK_SIZE;
@@ -185,8 +185,7 @@ void AES_ige_encrypt(const unsigned char *in, unsigned char *out,
 
 void AES_bi_ige_encrypt(const unsigned char *in, unsigned char *out,
                         size_t length, const AES_KEY *key,
-                        const AES_KEY *key2, const unsigned char *ivec,
-                        const int enc)
+                        const AES_KEY *key2, const unsigned char *ivec, int enc)
 {
     size_t n;
     size_t len = length;

--- a/crypto/aes/aes_x86core.c
+++ b/crypto/aes/aes_x86core.c
@@ -472,8 +472,7 @@ static const u32 rcon[] = {
 /**
  * Expand the cipher key into the encryption key schedule.
  */
-int AES_set_encrypt_key(const unsigned char *userKey, const int bits,
-                        AES_KEY *key)
+int AES_set_encrypt_key(const unsigned char *userKey, int bits, AES_KEY *key)
 {
 
     u32 *rk;
@@ -574,8 +573,7 @@ int AES_set_encrypt_key(const unsigned char *userKey, const int bits,
 /**
  * Expand the cipher key into the decryption key schedule.
  */
-int AES_set_decrypt_key(const unsigned char *userKey, const int bits,
-                        AES_KEY *key)
+int AES_set_decrypt_key(const unsigned char *userKey, int bits, AES_KEY *key)
 {
 
     u32 *rk;

--- a/crypto/aes/asm/aes-586.pl
+++ b/crypto/aes/asm/aes-586.pl
@@ -2022,7 +2022,7 @@ sub declast()
 
 # void AES_cbc_encrypt (const void char *inp, unsigned char *out,
 #			size_t length, const AES_KEY *key,
-#			unsigned char *ivp,const int enc);
+#			unsigned char *ivp, int enc);
 {
 # stack frame layout
 #             -4(%esp)		# return address	 0(%esp)
@@ -2870,8 +2870,7 @@ sub enckey()
     &set_label("exit");
 &function_end("_x86_AES_set_encrypt_key");
 
-# int AES_set_encrypt_key(const unsigned char *userKey, const int bits,
-#                        AES_KEY *key)
+# int AES_set_encrypt_key(const unsigned char *userKey, int bits, AES_KEY *key)
 &function_begin_B("AES_set_encrypt_key");
 	&call	("_x86_AES_set_encrypt_key");
 	&ret	();
@@ -2932,8 +2931,7 @@ sub deckey()
 	&mov	(&DWP(4*$i,$key),$tp1);
 }
 
-# int AES_set_decrypt_key(const unsigned char *userKey, const int bits,
-#                        AES_KEY *key)
+# int AES_set_decrypt_key(const unsigned char *userKey, int bits, AES_KEY *key)
 &function_begin_B("AES_set_decrypt_key");
 	&call	("_x86_AES_set_encrypt_key");
 	&cmp	("eax",0);

--- a/crypto/aes/asm/aes-x86_64.pl
+++ b/crypto/aes/asm/aes-x86_64.pl
@@ -1337,8 +1337,7 @@ $code.=<<___;
 ___
 }
 
-# int AES_set_encrypt_key(const unsigned char *userKey, const int bits,
-#                        AES_KEY *key)
+# int AES_set_encrypt_key(const unsigned char *userKey, int bits, AES_KEY *key)
 $code.=<<___;
 .globl	AES_set_encrypt_key
 .type	AES_set_encrypt_key,\@function,3
@@ -1618,8 +1617,7 @@ $code.=<<___;
 ___
 }
 
-# int AES_set_decrypt_key(const unsigned char *userKey, const int bits,
-#                        AES_KEY *key)
+# int AES_set_decrypt_key(const unsigned char *userKey, int bits, AES_KEY *key)
 $code.=<<___;
 .globl	AES_set_decrypt_key
 .type	AES_set_decrypt_key,\@function,3
@@ -1715,7 +1713,7 @@ ___
 
 # void AES_cbc_encrypt (const void char *inp, unsigned char *out,
 #			size_t length, const AES_KEY *key,
-#			unsigned char *ivp,const int enc);
+#			unsigned char *ivp, int enc);
 {
 # stack frame layout
 # -8(%rsp)		return address

--- a/crypto/camellia/asm/cmll-x86.pl
+++ b/crypto/camellia/asm/cmll-x86.pl
@@ -550,7 +550,7 @@ my $bias=int(@T[0])?shift(@T):0;
 }
 
 # void Camellia_Ekeygen(
-#		const int keyBitLength,
+#		int keyBitLength,
 #		const Byte *rawKey,
 #		KEY_TABLE_TYPE keyTable)
 &function_begin("Camellia_Ekeygen");
@@ -808,7 +808,7 @@ for ($i=0;$i<256;$i++) { &data_word(&S0222($i),&S3033($i)); }
 
 # void Camellia_cbc_encrypt (const void char *inp, unsigned char *out,
 #			size_t length, const CAMELLIA_KEY *key,
-#			unsigned char *ivp,const int enc);
+#			unsigned char *ivp, int enc);
 {
 # stack frame layout
 #             -4(%esp)		# return address	 0(%esp)

--- a/crypto/camellia/cmll_cbc.c
+++ b/crypto/camellia/cmll_cbc.c
@@ -18,7 +18,7 @@
 
 void Camellia_cbc_encrypt(const unsigned char *in, unsigned char *out,
                           size_t len, const CAMELLIA_KEY *key,
-                          unsigned char *ivec, const int enc)
+                          unsigned char *ivec, int enc)
 {
 
     if (enc)

--- a/crypto/camellia/cmll_cfb.c
+++ b/crypto/camellia/cmll_cfb.c
@@ -24,7 +24,7 @@
 
 void Camellia_cfb128_encrypt(const unsigned char *in, unsigned char *out,
                              size_t length, const CAMELLIA_KEY *key,
-                             unsigned char *ivec, int *num, const int enc)
+                             unsigned char *ivec, int *num, int enc)
 {
 
     CRYPTO_cfb128_encrypt(in, out, length, key, ivec, num, enc,
@@ -34,7 +34,7 @@ void Camellia_cfb128_encrypt(const unsigned char *in, unsigned char *out,
 /* N.B. This expects the input to be packed, MS bit first */
 void Camellia_cfb1_encrypt(const unsigned char *in, unsigned char *out,
                            size_t length, const CAMELLIA_KEY *key,
-                           unsigned char *ivec, int *num, const int enc)
+                           unsigned char *ivec, int *num, int enc)
 {
     CRYPTO_cfb128_1_encrypt(in, out, length, key, ivec, num, enc,
                             (block128_f) Camellia_encrypt);
@@ -42,7 +42,7 @@ void Camellia_cfb1_encrypt(const unsigned char *in, unsigned char *out,
 
 void Camellia_cfb8_encrypt(const unsigned char *in, unsigned char *out,
                            size_t length, const CAMELLIA_KEY *key,
-                           unsigned char *ivec, int *num, const int enc)
+                           unsigned char *ivec, int *num, int enc)
 {
     CRYPTO_cfb128_8_encrypt(in, out, length, key, ivec, num, enc,
                             (block128_f) Camellia_encrypt);

--- a/crypto/camellia/cmll_ecb.c
+++ b/crypto/camellia/cmll_ecb.c
@@ -17,7 +17,7 @@
 #include "cmll_local.h"
 
 void Camellia_ecb_encrypt(const unsigned char *in, unsigned char *out,
-                          const CAMELLIA_KEY *key, const int enc)
+                          const CAMELLIA_KEY *key, int enc)
 {
     if (CAMELLIA_ENCRYPT == enc)
         Camellia_encrypt(in, out, key);

--- a/crypto/camellia/cmll_misc.c
+++ b/crypto/camellia/cmll_misc.c
@@ -17,8 +17,7 @@
 #include <openssl/camellia.h>
 #include "cmll_local.h"
 
-int Camellia_set_key(const unsigned char *userKey, const int bits,
-                     CAMELLIA_KEY *key)
+int Camellia_set_key(const unsigned char *userKey, int bits, CAMELLIA_KEY *key)
 {
     if (!userKey || !key)
         return -1;

--- a/crypto/x509/v3_addr.c
+++ b/crypto/x509/v3_addr.c
@@ -528,7 +528,7 @@ static IPAddressFamily *make_IPAddressFamily(IPAddrBlocks *addr,
  * Add an inheritance element.
  */
 int X509v3_addr_add_inherit(IPAddrBlocks *addr,
-                            const unsigned afi, const unsigned *safi)
+                            unsigned afi, const unsigned *safi)
 {
     IPAddressFamily *f = make_IPAddressFamily(addr, afi, safi);
     if (f == NULL ||
@@ -584,9 +584,8 @@ static IPAddressOrRanges *make_prefix_or_range(IPAddrBlocks *addr,
  * Add a prefix.
  */
 int X509v3_addr_add_prefix(IPAddrBlocks *addr,
-                           const unsigned afi,
-                           const unsigned *safi,
-                           unsigned char *a, const int prefixlen)
+                           unsigned afi, const unsigned *safi,
+                           unsigned char *a, int prefixlen)
 {
     IPAddressOrRanges *aors = make_prefix_or_range(addr, afi, safi);
     IPAddressOrRange *aor;
@@ -602,8 +601,7 @@ int X509v3_addr_add_prefix(IPAddrBlocks *addr,
  * Add a range.
  */
 int X509v3_addr_add_range(IPAddrBlocks *addr,
-                          const unsigned afi,
-                          const unsigned *safi,
+                          unsigned afi, const unsigned *safi,
                           unsigned char *min, unsigned char *max)
 {
     IPAddressOrRanges *aors = make_prefix_or_range(addr, afi, safi);
@@ -641,10 +639,8 @@ static int extract_min_max(IPAddressOrRange *aor,
 /*
  * Public wrapper for extract_min_max().
  */
-int X509v3_addr_get_range(IPAddressOrRange *aor,
-                          const unsigned afi,
-                          unsigned char *min,
-                          unsigned char *max, const int length)
+int X509v3_addr_get_range(IPAddressOrRange *aor, unsigned afi,
+                          unsigned char *min, unsigned char *max, int length)
 {
     int afi_length = length_from_afi(afi);
     if (aor == NULL || min == NULL || max == NULL ||

--- a/doc/man3/OSSL_CMP_CTX_new.pod
+++ b/doc/man3/OSSL_CMP_CTX_new.pod
@@ -115,7 +115,7 @@ OSSL_CMP_CTX_set1_senderNonce
  int OSSL_CMP_CTX_set1_referenceValue(OSSL_CMP_CTX *ctx,
                                       const unsigned char *ref, int len);
  int OSSL_CMP_CTX_set1_secretValue(OSSL_CMP_CTX *ctx, const unsigned char *sec,
-                                   const int len);
+                                   int len);
 
  /* CMP message header and extra certificates: */
  int OSSL_CMP_CTX_set1_recipient(OSSL_CMP_CTX *ctx, const X509_NAME *name);

--- a/doc/man3/SSL_CTX_set_tlsext_servername_callback.pod
+++ b/doc/man3/SSL_CTX_set_tlsext_servername_callback.pod
@@ -14,7 +14,7 @@ SSL_set_tlsext_host_name - handle server name indication (SNI)
                                    int (*cb)(SSL *s, int *al, void *arg));
  long SSL_CTX_set_tlsext_servername_arg(SSL_CTX *ctx, void *arg);
 
- const char *SSL_get_servername(const SSL *s, const int type);
+ const char *SSL_get_servername(const SSL *s, int type);
  int SSL_get_servername_type(const SSL *s);
 
  int SSL_set_tlsext_host_name(const SSL *s, const char *name);

--- a/include/openssl/aes.h
+++ b/include/openssl/aes.h
@@ -48,11 +48,9 @@ typedef struct aes_key_st AES_KEY;
 # ifndef OPENSSL_NO_DEPRECATED_3_0
 OSSL_DEPRECATEDIN_3_0 const char *AES_options(void);
 OSSL_DEPRECATEDIN_3_0
-int AES_set_encrypt_key(const unsigned char *userKey, const int bits,
-                        AES_KEY *key);
+int AES_set_encrypt_key(const unsigned char *userKey, int bits, AES_KEY *key);
 OSSL_DEPRECATEDIN_3_0
-int AES_set_decrypt_key(const unsigned char *userKey, const int bits,
-                        AES_KEY *key);
+int AES_set_decrypt_key(const unsigned char *userKey, int bits, AES_KEY *key);
 OSSL_DEPRECATEDIN_3_0
 void AES_encrypt(const unsigned char *in, unsigned char *out,
                  const AES_KEY *key);
@@ -61,23 +59,23 @@ void AES_decrypt(const unsigned char *in, unsigned char *out,
                  const AES_KEY *key);
 OSSL_DEPRECATEDIN_3_0
 void AES_ecb_encrypt(const unsigned char *in, unsigned char *out,
-                     const AES_KEY *key, const int enc);
+                     const AES_KEY *key, int enc);
 OSSL_DEPRECATEDIN_3_0
 void AES_cbc_encrypt(const unsigned char *in, unsigned char *out,
                      size_t length, const AES_KEY *key,
-                     unsigned char *ivec, const int enc);
+                     unsigned char *ivec, int enc);
 OSSL_DEPRECATEDIN_3_0
 void AES_cfb128_encrypt(const unsigned char *in, unsigned char *out,
                         size_t length, const AES_KEY *key,
-                        unsigned char *ivec, int *num, const int enc);
+                        unsigned char *ivec, int *num, int enc);
 OSSL_DEPRECATEDIN_3_0
 void AES_cfb1_encrypt(const unsigned char *in, unsigned char *out,
                       size_t length, const AES_KEY *key,
-                      unsigned char *ivec, int *num, const int enc);
+                      unsigned char *ivec, int *num, int enc);
 OSSL_DEPRECATEDIN_3_0
 void AES_cfb8_encrypt(const unsigned char *in, unsigned char *out,
                       size_t length, const AES_KEY *key,
-                      unsigned char *ivec, int *num, const int enc);
+                      unsigned char *ivec, int *num, int enc);
 OSSL_DEPRECATEDIN_3_0
 void AES_ofb128_encrypt(const unsigned char *in, unsigned char *out,
                         size_t length, const AES_KEY *key,
@@ -87,12 +85,12 @@ void AES_ofb128_encrypt(const unsigned char *in, unsigned char *out,
 OSSL_DEPRECATEDIN_3_0
 void AES_ige_encrypt(const unsigned char *in, unsigned char *out,
                      size_t length, const AES_KEY *key,
-                     unsigned char *ivec, const int enc);
+                     unsigned char *ivec, int enc);
 /* NB: the IV is _four_ blocks long */
 OSSL_DEPRECATEDIN_3_0
 void AES_bi_ige_encrypt(const unsigned char *in, unsigned char *out,
                         size_t length, const AES_KEY *key, const AES_KEY *key2,
-                        const unsigned char *ivec, const int enc);
+                        const unsigned char *ivec, int enc);
 OSSL_DEPRECATEDIN_3_0
 int AES_wrap_key(AES_KEY *key, const unsigned char *iv,
                  unsigned char *out, const unsigned char *in,

--- a/include/openssl/camellia.h
+++ b/include/openssl/camellia.h
@@ -56,8 +56,7 @@ typedef struct camellia_key_st CAMELLIA_KEY;
 # endif /* OPENSSL_NO_DEPRECATED_3_0 */
 # ifndef OPENSSL_NO_DEPRECATED_3_0
 OSSL_DEPRECATEDIN_3_0 int Camellia_set_key(const unsigned char *userKey,
-                                           const int bits,
-                                           CAMELLIA_KEY *key);
+                                           int bits, CAMELLIA_KEY *key);
 OSSL_DEPRECATEDIN_3_0 void Camellia_encrypt(const unsigned char *in,
                                             unsigned char *out,
                                             const CAMELLIA_KEY *key);
@@ -67,34 +66,30 @@ OSSL_DEPRECATEDIN_3_0 void Camellia_decrypt(const unsigned char *in,
 OSSL_DEPRECATEDIN_3_0 void Camellia_ecb_encrypt(const unsigned char *in,
                                                 unsigned char *out,
                                                 const CAMELLIA_KEY *key,
-                                                const int enc);
+                                                int enc);
 OSSL_DEPRECATEDIN_3_0 void Camellia_cbc_encrypt(const unsigned char *in,
                                                 unsigned char *out,
                                                 size_t length,
                                                 const CAMELLIA_KEY *key,
-                                                unsigned char *ivec,
-                                                const int enc);
+                                                unsigned char *ivec, int enc);
 OSSL_DEPRECATEDIN_3_0 void Camellia_cfb128_encrypt(const unsigned char *in,
                                                    unsigned char *out,
                                                    size_t length,
                                                    const CAMELLIA_KEY *key,
                                                    unsigned char *ivec,
-                                                   int *num,
-                                                   const int enc);
+                                                   int *num, int enc);
 OSSL_DEPRECATEDIN_3_0 void Camellia_cfb1_encrypt(const unsigned char *in,
                                                  unsigned char *out,
                                                  size_t length,
                                                  const CAMELLIA_KEY *key,
                                                  unsigned char *ivec,
-                                                 int *num,
-                                                 const int enc);
+                                                 int *num, int enc);
 OSSL_DEPRECATEDIN_3_0 void Camellia_cfb8_encrypt(const unsigned char *in,
                                                  unsigned char *out,
                                                  size_t length,
                                                  const CAMELLIA_KEY *key,
                                                  unsigned char *ivec,
-                                                 int *num,
-                                                 const int enc);
+                                                 int *num, int enc);
 OSSL_DEPRECATEDIN_3_0 void Camellia_ofb128_encrypt(const unsigned char *in,
                                                    unsigned char *out,
                                                    size_t length,

--- a/include/openssl/cmp.h.in
+++ b/include/openssl/cmp.h.in
@@ -323,7 +323,7 @@ int OSSL_CMP_CTX_set1_pkey(OSSL_CMP_CTX *ctx, EVP_PKEY *pkey);
 int OSSL_CMP_CTX_set1_referenceValue(OSSL_CMP_CTX *ctx,
                                      const unsigned char *ref, int len);
 int OSSL_CMP_CTX_set1_secretValue(OSSL_CMP_CTX *ctx, const unsigned char *sec,
-                                  const int len);
+                                  int len);
 /* CMP message header and extra certificates: */
 int OSSL_CMP_CTX_set1_recipient(OSSL_CMP_CTX *ctx, const X509_NAME *name);
 int OSSL_CMP_CTX_push0_geninfo_ITAV(OSSL_CMP_CTX *ctx, OSSL_CMP_ITAV *itav);

--- a/include/openssl/tls1.h
+++ b/include/openssl/tls1.h
@@ -216,7 +216,7 @@ int SSL_set_tlsext_max_fragment_length(SSL *ssl, uint8_t mode);
 
 # define TLSEXT_MAXLEN_host_name 255
 
-__owur const char *SSL_get_servername(const SSL *s, const int type);
+__owur const char *SSL_get_servername(const SSL *s, int type);
 __owur int SSL_get_servername_type(const SSL *s);
 /*
  * SSL_export_keying_material exports a value derived from the master secret,

--- a/include/openssl/x509v3.h.in
+++ b/include/openssl/x509v3.h.in
@@ -901,17 +901,16 @@ int X509v3_asid_add_inherit(ASIdentifiers *asid, int which);
 int X509v3_asid_add_id_or_range(ASIdentifiers *asid, int which,
                                 ASN1_INTEGER *min, ASN1_INTEGER *max);
 int X509v3_addr_add_inherit(IPAddrBlocks *addr,
-                            const unsigned afi, const unsigned *safi);
+                            unsigned afi, const unsigned *safi);
 int X509v3_addr_add_prefix(IPAddrBlocks *addr,
-                           const unsigned afi, const unsigned *safi,
-                           unsigned char *a, const int prefixlen);
+                           unsigned afi, const unsigned *safi,
+                           unsigned char *a, int prefixlen);
 int X509v3_addr_add_range(IPAddrBlocks *addr,
-                          const unsigned afi, const unsigned *safi,
+                          unsigned afi, const unsigned *safi,
                           unsigned char *min, unsigned char *max);
 unsigned X509v3_addr_get_afi(const IPAddressFamily *f);
-int X509v3_addr_get_range(IPAddressOrRange *aor, const unsigned afi,
-                          unsigned char *min, unsigned char *max,
-                          const int length);
+int X509v3_addr_get_range(IPAddressOrRange *aor, unsigned afi,
+                          unsigned char *min, unsigned char *max, int length);
 
 /*
  * Canonical forms.

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -2821,7 +2821,7 @@ char *SSL_get_shared_ciphers(const SSL *s, char *buf, int size)
  * 
  * Note that only the host_name type is defined (RFC 3546).
  */
-const char *SSL_get_servername(const SSL *s, const int type)
+const char *SSL_get_servername(const SSL *s, int type)
 {
     /*
      * If we don't know if we are the client or the server yet then we assume


### PR DESCRIPTION
Some function declarations in public headers needlessly use  `const` with scalar types.
This PR cleans them up, updating also their documentation (as far as it exists) and their decls in implementation files.

Targeted for 4.0 because syntactically (though not semantically) this is an API break.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated

