### PR TITLE
`crmf_lib.c`: Make sure Edwards signature for POPO is called without digest

### DIFF
--- a/crypto/crmf/crmf_lib.c
+++ b/crypto/crmf/crmf_lib.c
@@ -369,6 +369,8 @@ static int create_popo_signature(OSSL_CRMF_POPOSIGNINGKEY *ps,
                                  EVP_PKEY *pkey, const EVP_MD *digest,
                                  OSSL_LIB_CTX *libctx, const char *propq)
 {
+    char name[80] = "";
+
     if (ps == NULL || cr == NULL || pkey == NULL) {
         ERR_raise(ERR_LIB_CRMF, CRMF_R_NULL_ARGUMENT);
         return 0;
@@ -378,6 +380,10 @@ static int create_popo_signature(OSSL_CRMF_POPOSIGNINGKEY *ps,
         ERR_raise(ERR_LIB_CRMF, CRMF_R_POPOSKINPUT_NOT_SUPPORTED);
         return 0;
     }
+
+    if (EVP_PKEY_get_default_digest_name(pkey, name, sizeof(name)) > 0
+            && strcmp(name, "UNDEF") == 0) /* at least for Ed25519, Ed448 */
+        digest = NULL;
 
     return ASN1_item_sign_ex(ASN1_ITEM_rptr(OSSL_CRMF_CERTREQUEST),
                              ps->algorithmIdentifier, NULL, ps->signature, cr,

--- a/doc/man3/OSSL_CRMF_MSG_set0_validity.pod
+++ b/doc/man3/OSSL_CRMF_MSG_set0_validity.pod
@@ -66,7 +66,9 @@ according to the method I<meth> in I<crm>.<
 The library context I<libctx> and property query string I<propq>,
 may be NULL to select the defaults.
 In case the method is OSSL_CRMF_POPO_SIGNATURE the POPO is calculated
-using the private key I<pkey> and the digest method I<digest>.
+using the private key I<pkey> and the digest method I<digest>,
+where the I<digest> argument is ignored if I<pke> is of a type (such as
+Ed25519 and Ed448) that is implicitly associated with a digest alorithm.
 
 I<meth> can be one of the following:
 

--- a/doc/man3/OSSL_CRMF_MSG_set0_validity.pod
+++ b/doc/man3/OSSL_CRMF_MSG_set0_validity.pod
@@ -62,7 +62,7 @@ OSSL_CRMF_MSG_push0_extension() pushes the X509 extension I<ext> to the
 extensions in the certTemplate of I<crm>.  Consumes I<ext>.
 
 OSSL_CRMF_MSG_create_popo() creates and sets the Proof-of-Possession (POPO)
-according to the method I<meth> in I<crm>.<
+according to the method I<meth> in I<crm>.
 The library context I<libctx> and property query string I<propq>,
 may be NULL to select the defaults.
 In case the method is OSSL_CRMF_POPO_SIGNATURE the POPO is calculated

--- a/doc/man3/OSSL_CRMF_MSG_set0_validity.pod
+++ b/doc/man3/OSSL_CRMF_MSG_set0_validity.pod
@@ -67,7 +67,7 @@ The library context I<libctx> and property query string I<propq>,
 may be NULL to select the defaults.
 In case the method is OSSL_CRMF_POPO_SIGNATURE the POPO is calculated
 using the private key I<pkey> and the digest method I<digest>,
-where the I<digest> argument is ignored if I<pke> is of a type (such as
+where the I<digest> argument is ignored if I<pkey> is of a type (such as
 Ed25519 and Ed448) that is implicitly associated with a digest alorithm.
 
 I<meth> can be one of the following:


### PR DESCRIPTION
This replaces #18195.

Fixes #18184
