### PR TITLE
Correct NEWS entry about required security level for old versions of TLS, DTLS and SSL

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -115,7 +115,8 @@ OpenSSL 3.0
     RC4, RC5 and SEED cipher functions have been deprecated.
   * All of the low-level DH, DSA, ECDH, ECDSA and RSA public key functions
     have been deprecated.
-  * SSL 3, TLS 1.0, TLS 1.1, and DTLS 1.0 only work at security level 0.
+  * SSL 3, TLS 1.0, TLS 1.1, and DTLS 1.0 only work at security level 0,
+    except when RSA key exchange without SHA1 is used.
   * Added providers, a new pluggability concept that will replace the
     ENGINE API and ENGINE implementations.
 


### PR DESCRIPTION
The entry was incorrect because suites using RSA key exchange without SHA1 were permitted at security level 1.

Partial fix for #18194
