### PR TITLE
tls: ban SSL3, TLS1, TLS1.1 and DTLS1.0 at security level one and above

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -25,6 +25,7 @@ OpenSSL 3.1
     by default.
   * TCP Fast Open (RFC7413) support is available on Linux, macOS, and FreeBSD
     where enabled and supported.
+  * SSL 3, TLS 1.0, TLS 1.1, and DTLS 1.0 only work at security level 0.
 
 OpenSSL 3.0
 -----------

--- a/doc/man3/SSL_CTX_set_security_level.pod
+++ b/doc/man3/SSL_CTX_set_security_level.pod
@@ -78,32 +78,28 @@ DSA and DH keys shorter than 1024 bits and ECC keys shorter than 160 bits
 are prohibited. Any cipher suite using MD5 for the MAC is also prohibited. Any
 cipher suites using CCM with a 64 bit authentication tag are prohibited. Note
 that signatures using SHA1 and MD5 are also forbidden at this level as they
-have less than 80 security bits.
-
-Additionally, SSLv3, TLS 1.0, TLS 1.1 and DTLS 1.0 are all disabled at this
-level.
+have less than 80 security bits. Additionally, SSLv3, TLS 1.0, TLS 1.1 and
+DTLS 1.0 are all disabled at this level.
 
 =item B<Level 2>
 
 Security level set to 112 bits of security. As a result RSA, DSA and DH keys
 shorter than 2048 bits and ECC keys shorter than 224 bits are prohibited.
 In addition to the level 1 exclusions any cipher suite using RC4 is also
-prohibited. SSL version 3 is also not allowed. Compression is disabled.
+prohibited. Compression is disabled.
 
 =item B<Level 3>
 
 Security level set to 128 bits of security. As a result RSA, DSA and DH keys
 shorter than 3072 bits and ECC keys shorter than 256 bits are prohibited.
 In addition to the level 2 exclusions cipher suites not offering forward
-secrecy are prohibited. TLS versions below 1.1 are not permitted. Session
-tickets are disabled.
+secrecy are prohibited. Session tickets are disabled.
 
 =item B<Level 4>
 
 Security level set to 192 bits of security. As a result RSA, DSA and
 DH keys shorter than 7680 bits and ECC keys shorter than 384 bits are
-prohibited.  Cipher suites using SHA1 for the MAC are prohibited. TLS
-versions below 1.2 are not permitted.
+prohibited.  Cipher suites using SHA1 for the MAC are prohibited.
 
 =item B<Level 5>
 

--- a/doc/man3/SSL_CTX_set_security_level.pod
+++ b/doc/man3/SSL_CTX_set_security_level.pod
@@ -80,6 +80,9 @@ cipher suites using CCM with a 64 bit authentication tag are prohibited. Note
 that signatures using SHA1 and MD5 are also forbidden at this level as they
 have less than 80 security bits.
 
+Additionally, SSLv3, TLS 1.0, TLS 1.1 and DTLS 1.0 are all disabled at this
+level.
+
 =item B<Level 2>
 
 Security level set to 112 bits of security. As a result RSA, DSA and DH keys

--- a/ssl/ssl_cert.c
+++ b/ssl/ssl_cert.c
@@ -1052,10 +1052,7 @@ static int ssl_security_default_callback(const SSL *s, const SSL_CTX *ctx,
                 return 0;
         } else {
             /* DTLS v1.0 only allowed at level 0 */
-            if (DTLS_VERSION_LE(nid, DTLS1_VERSION) && level > 0)
-                return 0;
-            /* DTLS v1.2 only for level 4 and above */
-            if (DTLS_VERSION_LT(nid, DTLS1_2_VERSION) && level >= 4)
+            if (DTLS_VERSION_LT(nid, DTLS1_2_VERSION) && level > 0)
                 return 0;
         }
         break;

--- a/ssl/ssl_cert.c
+++ b/ssl/ssl_cert.c
@@ -1047,16 +1047,13 @@ static int ssl_security_default_callback(const SSL *s, const SSL_CTX *ctx,
         }
     case SSL_SECOP_VERSION:
         if (!SSL_IS_DTLS(s)) {
-            /* SSLv3 not allowed at level 2 */
-            if (nid <= SSL3_VERSION && level >= 2)
-                return 0;
-            /* TLS v1.1 and above only for level 3 */
-            if (nid <= TLS1_VERSION && level >= 3)
-                return 0;
-            /* TLS v1.2 only for level 4 and above */
-            if (nid <= TLS1_1_VERSION && level >= 4)
+            /* SSLv3, TLS v1.0 and TLS v1.1 only allowed at level 0 */
+            if (nid <= TLS1_1_VERSION && level > 0)
                 return 0;
         } else {
+            /* DTLS v1.0 only allowed at level 0 */
+            if (DTLS_VERSION_LE(nid, DTLS1_VERSION) && level > 0)
+                return 0;
             /* DTLS v1.2 only for level 4 and above */
             if (DTLS_VERSION_LT(nid, DTLS1_2_VERSION) && level >= 4)
                 return 0;

--- a/test/bad_dtls_test.c
+++ b/test/bad_dtls_test.c
@@ -499,6 +499,7 @@ static int test_bad_dtls(void)
             || !TEST_true(SSL_CTX_set_cipher_list(ctx, "AES128-SHA")))
         goto end;
 
+    SSL_CTX_set_security_level(ctx, 0);
     con = SSL_new(ctx);
     if (!TEST_ptr(con)
             || !TEST_true(SSL_set_session(con, sess)))

--- a/test/recipes/80-test_ssl_old.t
+++ b/test/recipes/80-test_ssl_old.t
@@ -568,7 +568,7 @@ sub testssl {
     subtest 'RSA/(EC)DHE/PSK tests' => sub {
         ######################################################################
 
-        plan tests => 6;
+        plan tests => 10;
 
       SKIP: {
             skip "TLSv1.0 is not supported by this OpenSSL build", 6
@@ -615,6 +615,44 @@ sub testssl {
                'test auto DH meets security strength');
           }
 	}
+
+      SKIP: {
+            skip "TLSv1.2 is not supported by this OpenSSL build", 4
+                if $no_tls1_2;
+
+        SKIP: {
+            skip "skipping auto DHE PSK test at SECLEVEL 3", 1
+                if ($no_dh || $no_psk);
+
+            ok(run(test(['ssl_old_test', '-tls1_2', '-dhe4096', '-psk', '0102030405', '-cipher', '@SECLEVEL=3:DHE-PSK-AES256-CBC-SHA384'])),
+               'test auto DHE PSK meets security strength');
+          }
+
+        SKIP: {
+            skip "skipping auto ECDHE PSK test at SECLEVEL 3", 1
+                if ($no_ec || $no_psk);
+
+            ok(run(test(['ssl_old_test', '-tls1_2', '-no_dhe', '-psk', '0102030405', '-cipher', '@SECLEVEL=3:ECDHE-PSK-AES256-CBC-SHA384'])),
+               'test auto ECDHE PSK meets security strength');
+          }
+
+        SKIP: {
+            skip "skipping no RSA PSK at SECLEVEL 3 test", 1
+                if ($no_rsa || $no_psk);
+
+            ok(!run(test(['ssl_old_test', '-tls1_2', '-no_dhe', '-psk', '0102030405', '-cipher', '@SECLEVEL=3:RSA-PSK-AES256-CBC-SHA384'])),
+               'test auto RSA PSK does not meet security level 3 requirements (PFS)');
+          }
+
+        SKIP: {
+            skip "skipping no PSK at SECLEVEL 3 test", 1
+                if ($no_psk);
+
+            ok(!run(test(['ssl_old_test', '-tls1_2', '-no_dhe', '-psk', '0102030405', '-cipher', '@SECLEVEL=3:PSK-AES256-CBC-SHA384'])),
+               'test auto PSK does not meet security level 3 requirements (PFS)');
+          }
+	}
+
     };
 
     subtest 'Custom Extension tests' => sub {

--- a/test/recipes/80-test_ssl_old.t
+++ b/test/recipes/80-test_ssl_old.t
@@ -78,7 +78,7 @@ my $client_sess="client.ss";
 # If you're adding tests here, you probably want to convert them to the
 # new format in ssl_test.c and add recipes to 80-test_ssl_new.t instead.
 plan tests =>
-   ($no_fips ? 0 : 5)     # testssl with fips provider
+   ($no_fips ? 0 : 6)     # testssl with fips provider
     + 1                   # For testss
     + 5                   # For the testssl with default provider
     + 1                   # For security level 0 failure tests

--- a/test/ssl-tests/20-cert-select.cnf
+++ b/test/ssl-tests/20-cert-select.cnf
@@ -1119,11 +1119,11 @@ client = 34-Only RSA-PSS Certificate, TLS v1.1-client
 
 [34-Only RSA-PSS Certificate, TLS v1.1-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/server-pss-cert.pem
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 PrivateKey = ${ENV::TEST_CERTS_DIR}/server-pss-key.pem
 
 [34-Only RSA-PSS Certificate, TLS v1.1-client]
-CipherString = DEFAULT
+CipherString = DEFAULT:@SECLEVEL=0
 MaxProtocol = TLSv1.1
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer

--- a/test/ssl-tests/20-cert-select.cnf.in
+++ b/test/ssl-tests/20-cert-select.cnf.in
@@ -585,9 +585,14 @@ my @tests_pss = (
 my @tests_tls_1_1 = (
     {
         name => "Only RSA-PSS Certificate, TLS v1.1",
-        server => $server_pss_only,
+        server => {
+            "CipherString" => "DEFAULT:\@SECLEVEL=0",
+            "Certificate" => test_pem("server-pss-cert.pem"),
+            "PrivateKey" => test_pem("server-pss-key.pem"),
+        },
         client => {
             "MaxProtocol" => "TLSv1.1",
+            "CipherString" => "DEFAULT:\@SECLEVEL=0",
         },
         test   => {
             "ExpectedResult" => "ServerFail"


### PR DESCRIPTION
This is in line with the NEWS entry (erroneously) announcing such for 3.0.

Fixes #18194

- [ ] documentation is added or updated
- [x] tests are added or updated
