### PR TITLE
Remove the _fetch_by_number functions

### DIFF
--- a/crypto/encode_decode/decoder_meth.c
+++ b/crypto/encode_decode/decoder_meth.c
@@ -315,38 +315,27 @@ static void free_decoder(void *method)
 
 /* Fetching support.  Can fetch by numeric identity or by name */
 static OSSL_DECODER *
-inner_ossl_decoder_fetch(struct decoder_data_st *methdata, int id,
+inner_ossl_decoder_fetch(struct decoder_data_st *methdata,
                          const char *name, const char *properties)
 {
     OSSL_METHOD_STORE *store = get_decoder_store(methdata->libctx);
     OSSL_NAMEMAP *namemap = ossl_namemap_stored(methdata->libctx);
     const char *const propq = properties != NULL ? properties : "";
     void *method = NULL;
-    int unsupported = 0;
+    int unsupported, id;
 
     if (store == NULL || namemap == NULL) {
         ERR_raise(ERR_LIB_OSSL_DECODER, ERR_R_PASSED_INVALID_ARGUMENT);
         return NULL;
     }
 
-    /*
-     * If we have been passed both an id and a name, we have an
-     * internal programming error.
-     */
-    if (!ossl_assert(id == 0 || name == NULL)) {
-        ERR_raise(ERR_LIB_OSSL_DECODER, ERR_R_INTERNAL_ERROR);
-        return NULL;
-    }
-
-    if (id == 0 && name != NULL)
-        id = ossl_namemap_name2num(namemap, name);
+    id = name != NULL ? ossl_namemap_name2num(namemap, name) : 0;
 
     /*
      * If we haven't found the name yet, chances are that the algorithm to
      * be fetched is unsupported.
      */
-    if (id == 0)
-        unsupported = 1;
+    unsupported = id == 0;
 
     if (id == 0
         || !ossl_method_store_cache_get(store, NULL, id, propq, &method)) {
@@ -409,20 +398,7 @@ OSSL_DECODER *OSSL_DECODER_fetch(OSSL_LIB_CTX *libctx, const char *name,
 
     methdata.libctx = libctx;
     methdata.tmp_store = NULL;
-    method = inner_ossl_decoder_fetch(&methdata, 0, name, properties);
-    dealloc_tmp_decoder_store(methdata.tmp_store);
-    return method;
-}
-
-OSSL_DECODER *ossl_decoder_fetch_by_number(OSSL_LIB_CTX *libctx, int id,
-                                           const char *properties)
-{
-    struct decoder_data_st methdata;
-    void *method;
-
-    methdata.libctx = libctx;
-    methdata.tmp_store = NULL;
-    method = inner_ossl_decoder_fetch(&methdata, id, NULL, properties);
+    method = inner_ossl_decoder_fetch(&methdata, name, properties);
     dealloc_tmp_decoder_store(methdata.tmp_store);
     return method;
 }
@@ -533,7 +509,7 @@ void OSSL_DECODER_do_all_provided(OSSL_LIB_CTX *libctx,
 
     methdata.libctx = libctx;
     methdata.tmp_store = NULL;
-    (void)inner_ossl_decoder_fetch(&methdata, 0, NULL, NULL /* properties */);
+    (void)inner_ossl_decoder_fetch(&methdata, NULL, NULL /* properties */);
 
     data.user_fn = user_fn;
     data.user_arg = user_arg;

--- a/crypto/encode_decode/encoder_meth.c
+++ b/crypto/encode_decode/encoder_meth.c
@@ -325,38 +325,27 @@ static void free_encoder(void *method)
 
 /* Fetching support.  Can fetch by numeric identity or by name */
 static OSSL_ENCODER *
-inner_ossl_encoder_fetch(struct encoder_data_st *methdata, int id,
+inner_ossl_encoder_fetch(struct encoder_data_st *methdata,
                          const char *name, const char *properties)
 {
     OSSL_METHOD_STORE *store = get_encoder_store(methdata->libctx);
     OSSL_NAMEMAP *namemap = ossl_namemap_stored(methdata->libctx);
     const char *const propq = properties != NULL ? properties : "";
     void *method = NULL;
-    int unsupported = 0;
+    int unsupported, id;
 
     if (store == NULL || namemap == NULL) {
         ERR_raise(ERR_LIB_OSSL_ENCODER, ERR_R_PASSED_INVALID_ARGUMENT);
         return NULL;
     }
 
-    /*
-     * If we have been passed both an id and a name, we have an
-     * internal programming error.
-     */
-    if (!ossl_assert(id == 0 || name == NULL)) {
-        ERR_raise(ERR_LIB_OSSL_ENCODER, ERR_R_INTERNAL_ERROR);
-        return NULL;
-    }
-
-    if (id == 0)
-        id = ossl_namemap_name2num(namemap, name);
+    id = name != NULL ? ossl_namemap_name2num(namemap, name) : 0;
 
     /*
      * If we haven't found the name yet, chances are that the algorithm to
      * be fetched is unsupported.
      */
-    if (id == 0)
-        unsupported = 1;
+    unsupported = id == 0;
 
     if (id == 0
         || !ossl_method_store_cache_get(store, NULL, id, propq, &method)) {
@@ -418,20 +407,7 @@ OSSL_ENCODER *OSSL_ENCODER_fetch(OSSL_LIB_CTX *libctx, const char *name,
 
     methdata.libctx = libctx;
     methdata.tmp_store = NULL;
-    method = inner_ossl_encoder_fetch(&methdata, 0, name, properties);
-    dealloc_tmp_encoder_store(methdata.tmp_store);
-    return method;
-}
-
-OSSL_ENCODER *ossl_encoder_fetch_by_number(OSSL_LIB_CTX *libctx, int id,
-                                           const char *properties)
-{
-    struct encoder_data_st methdata;
-    void *method;
-
-    methdata.libctx = libctx;
-    methdata.tmp_store = NULL;
-    method = inner_ossl_encoder_fetch(&methdata, id, NULL, properties);
+    method = inner_ossl_encoder_fetch(&methdata, name, properties);
     dealloc_tmp_encoder_store(methdata.tmp_store);
     return method;
 }
@@ -524,7 +500,7 @@ void OSSL_ENCODER_do_all_provided(OSSL_LIB_CTX *libctx,
 
     methdata.libctx = libctx;
     methdata.tmp_store = NULL;
-    (void)inner_ossl_encoder_fetch(&methdata, 0, NULL, NULL /* properties */);
+    (void)inner_ossl_encoder_fetch(&methdata, NULL, NULL /* properties */);
 
     data.user_fn = user_fn;
     data.user_arg = user_arg;

--- a/crypto/evp/evp_fetch.c
+++ b/crypto/evp/evp_fetch.c
@@ -101,7 +101,7 @@ static void *get_evp_method_from_store(void *store, const OSSL_PROVIDER **prov,
 {
     struct evp_method_data_st *methdata = data;
     void *method = NULL;
-    int name_id = 0;
+    int name_id;
     uint32_t meth_id;
 
     /*
@@ -218,8 +218,7 @@ static void destruct_evp_method(void *method, void *data)
 static void *
 inner_evp_generic_fetch(struct evp_method_data_st *methdata,
                         OSSL_PROVIDER *prov, int operation_id,
-                        int name_id, const char *name,
-                        const char *properties,
+                        const char *name, const char *properties,
                         void *(*new_method)(int name_id,
                                             const OSSL_ALGORITHM *algodef,
                                             OSSL_PROVIDER *prov),
@@ -231,7 +230,7 @@ inner_evp_generic_fetch(struct evp_method_data_st *methdata,
     const char *const propq = properties != NULL ? properties : "";
     uint32_t meth_id = 0;
     void *method = NULL;
-    int unsupported = 0;
+    int unsupported, name_id;
 
     if (store == NULL || namemap == NULL) {
         ERR_raise(ERR_LIB_EVP, ERR_R_PASSED_INVALID_ARGUMENT);
@@ -247,18 +246,8 @@ inner_evp_generic_fetch(struct evp_method_data_st *methdata,
         return NULL;
     }
 
-    /*
-     * If we have been passed both a name_id and a name, we have an
-     * internal programming error.
-     */
-    if (!ossl_assert(name_id == 0 || name == NULL)) {
-        ERR_raise(ERR_LIB_EVP, ERR_R_INTERNAL_ERROR);
-        return NULL;
-    }
-
     /* If we haven't received a name id yet, try to get one for the name */
-    if (name_id == 0 && name != NULL)
-        name_id = ossl_namemap_name2num(namemap, name);
+    name_id = name != NULL ? ossl_namemap_name2num(namemap, name) : 0;
 
     /*
      * If we have a name id, calculate a method id with evp_method_id().
@@ -277,8 +266,7 @@ inner_evp_generic_fetch(struct evp_method_data_st *methdata,
      * If we haven't found the name yet, chances are that the algorithm to
      * be fetched is unsupported.
      */
-    if (name_id == 0)
-        unsupported = 1;
+    unsupported = name_id == 0;
 
     if (meth_id == 0
         || !ossl_method_store_cache_get(store, prov, meth_id, propq, &method)) {
@@ -351,34 +339,7 @@ void *evp_generic_fetch(OSSL_LIB_CTX *libctx, int operation_id,
     methdata.libctx = libctx;
     methdata.tmp_store = NULL;
     method = inner_evp_generic_fetch(&methdata, NULL, operation_id,
-                                     0, name, properties,
-                                     new_method, up_ref_method, free_method);
-    dealloc_tmp_evp_method_store(methdata.tmp_store);
-    return method;
-}
-
-/*
- * evp_generic_fetch_by_number() is special, and only returns methods for
- * already known names, i.e. it refuses to work if no name_id can be found
- * (it's considered an internal programming error).
- * This is meant to be used when one method needs to fetch an associated
- * method.
- */
-void *evp_generic_fetch_by_number(OSSL_LIB_CTX *libctx, int operation_id,
-                                  int name_id, const char *properties,
-                                  void *(*new_method)(int name_id,
-                                                      const OSSL_ALGORITHM *algodef,
-                                                      OSSL_PROVIDER *prov),
-                                  int (*up_ref_method)(void *),
-                                  void (*free_method)(void *))
-{
-    struct evp_method_data_st methdata;
-    void *method;
-
-    methdata.libctx = libctx;
-    methdata.tmp_store = NULL;
-    method = inner_evp_generic_fetch(&methdata, NULL, operation_id,
-                                     name_id, NULL, properties,
+                                     name, properties,
                                      new_method, up_ref_method, free_method);
     dealloc_tmp_evp_method_store(methdata.tmp_store);
     return method;
@@ -404,7 +365,7 @@ void *evp_generic_fetch_from_prov(OSSL_PROVIDER *prov, int operation_id,
     methdata.libctx = ossl_provider_libctx(prov);
     methdata.tmp_store = NULL;
     method = inner_evp_generic_fetch(&methdata, prov, operation_id,
-                                     0, name, properties,
+                                     name, properties,
                                      new_method, up_ref_method, free_method);
     dealloc_tmp_evp_method_store(methdata.tmp_store);
     return method;
@@ -598,7 +559,7 @@ void evp_generic_do_all(OSSL_LIB_CTX *libctx, int operation_id,
 
     methdata.libctx = libctx;
     methdata.tmp_store = NULL;
-    (void)inner_evp_generic_fetch(&methdata, NULL, operation_id, 0, NULL, NULL,
+    (void)inner_evp_generic_fetch(&methdata, NULL, operation_id, NULL, NULL,
                                   new_method, up_ref_method, free_method);
 
     data.operation_id = operation_id;

--- a/crypto/evp/evp_local.h
+++ b/crypto/evp/evp_local.h
@@ -270,13 +270,6 @@ void *evp_generic_fetch(OSSL_LIB_CTX *ctx, int operation_id,
                                             OSSL_PROVIDER *prov),
                         int (*up_ref_method)(void *),
                         void (*free_method)(void *));
-void *evp_generic_fetch_by_number(OSSL_LIB_CTX *ctx, int operation_id,
-                                  int name_id, const char *properties,
-                                  void *(*new_method)(int name_id,
-                                                      const OSSL_ALGORITHM *algodef,
-                                                      OSSL_PROVIDER *prov),
-                                  int (*up_ref_method)(void *),
-                                  void (*free_method)(void *));
 void *evp_generic_fetch_from_prov(OSSL_PROVIDER *prov, int operation_id,
                                   const char *name, const char *properties,
                                   void *(*new_method)(int name_id,

--- a/crypto/evp/keymgmt_meth.c
+++ b/crypto/evp/keymgmt_meth.c
@@ -203,16 +203,6 @@ static void *keymgmt_from_algorithm(int name_id,
     return keymgmt;
 }
 
-EVP_KEYMGMT *evp_keymgmt_fetch_by_number(OSSL_LIB_CTX *ctx, int name_id,
-                                         const char *properties)
-{
-    return evp_generic_fetch_by_number(ctx,
-                                       OSSL_OP_KEYMGMT, name_id, properties,
-                                       keymgmt_from_algorithm,
-                                       (int (*)(void *))EVP_KEYMGMT_up_ref,
-                                       (void (*)(void *))EVP_KEYMGMT_free);
-}
-
 EVP_KEYMGMT *evp_keymgmt_fetch_from_prov(OSSL_PROVIDER *prov,
                                          const char *name,
                                          const char *properties)

--- a/crypto/store/store_local.h
+++ b/crypto/store/store_local.h
@@ -168,9 +168,6 @@ int ossl_store_file_detach_pem_bio_int(OSSL_STORE_LOADER_CTX *ctx);
 OSSL_STORE_LOADER *ossl_store_loader_fetch(OSSL_LIB_CTX *libctx,
                                            const char *scheme,
                                            const char *properties);
-OSSL_STORE_LOADER *ossl_store_loader_fetch_by_number(OSSL_LIB_CTX *libctx,
-                                                     int scheme_id,
-                                                     const char *properties);
 
 /* Standard function to handle the result from OSSL_FUNC_store_load() */
 struct ossl_load_result_data_st {

--- a/crypto/store/store_meth.c
+++ b/crypto/store/store_meth.c
@@ -256,39 +256,28 @@ static void destruct_loader(void *method, void *data)
 
 /* Fetching support.  Can fetch by numeric identity or by scheme */
 static OSSL_STORE_LOADER *
-inner_loader_fetch(struct loader_data_st *methdata, int id,
+inner_loader_fetch(struct loader_data_st *methdata,
                    const char *scheme, const char *properties)
 {
     OSSL_METHOD_STORE *store = get_loader_store(methdata->libctx);
     OSSL_NAMEMAP *namemap = ossl_namemap_stored(methdata->libctx);
     const char *const propq = properties != NULL ? properties : "";
     void *method = NULL;
-    int unsupported = 0;
+    int unsupported, id;
 
     if (store == NULL || namemap == NULL) {
         ERR_raise(ERR_LIB_OSSL_STORE, ERR_R_PASSED_INVALID_ARGUMENT);
         return NULL;
     }
 
-    /*
-     * If we have been passed both an id and a scheme, we have an
-     * internal programming error.
-     */
-    if (!ossl_assert(id == 0 || scheme == NULL)) {
-        ERR_raise(ERR_LIB_OSSL_STORE, ERR_R_INTERNAL_ERROR);
-        return NULL;
-    }
-
     /* If we haven't received a name id yet, try to get one for the name */
-    if (id == 0 && scheme != NULL)
-        id = ossl_namemap_name2num(namemap, scheme);
+    id = scheme != NULL ? ossl_namemap_name2num(namemap, scheme) : 0;
 
     /*
      * If we haven't found the name yet, chances are that the algorithm to
      * be fetched is unsupported.
      */
-    if (id == 0)
-        unsupported = 1;
+    unsupported = id == 0;
 
     if (id == 0
         || !ossl_method_store_cache_get(store, NULL, id, propq, &method)) {
@@ -357,21 +346,7 @@ OSSL_STORE_LOADER *OSSL_STORE_LOADER_fetch(OSSL_LIB_CTX *libctx,
 
     methdata.libctx = libctx;
     methdata.tmp_store = NULL;
-    method = inner_loader_fetch(&methdata, 0, scheme, properties);
-    dealloc_tmp_loader_store(methdata.tmp_store);
-    return method;
-}
-
-OSSL_STORE_LOADER *ossl_store_loader_fetch_by_number(OSSL_LIB_CTX *libctx,
-                                                     int scheme_id,
-                                                     const char *properties)
-{
-    struct loader_data_st methdata;
-    void *method;
-
-    methdata.libctx = libctx;
-    methdata.tmp_store = NULL;
-    method = inner_loader_fetch(&methdata, scheme_id, NULL, properties);
+    method = inner_loader_fetch(&methdata, scheme, properties);
     dealloc_tmp_loader_store(methdata.tmp_store);
     return method;
 }
@@ -448,7 +423,7 @@ void OSSL_STORE_LOADER_do_all_provided(OSSL_LIB_CTX *libctx,
 
     methdata.libctx = libctx;
     methdata.tmp_store = NULL;
-    (void)inner_loader_fetch(&methdata, 0, NULL, NULL /* properties */);
+    (void)inner_loader_fetch(&methdata, NULL, NULL /* properties */);
 
     data.user_fn = user_fn;
     data.user_arg = user_arg;

--- a/doc/internal/man3/evp_generic_fetch.pod
+++ b/doc/internal/man3/evp_generic_fetch.pod
@@ -2,7 +2,7 @@
 
 =head1 NAME
 
-evp_generic_fetch, evp_generic_fetch_by_number, evp_generic_fetch_from_prov
+evp_generic_fetch, evp_generic_fetch_from_prov
 - generic algorithm fetchers and method creators for EVP
 
 =head1 SYNOPSIS
@@ -20,15 +20,6 @@ evp_generic_fetch, evp_generic_fetch_by_number, evp_generic_fetch_from_prov
                          int (*up_ref_method)(void *),
                          void (*free_method)(void *));
 
- void *evp_generic_fetch_by_number(OSSL_LIB_CTX *ctx, int operation_id,
-                                   int name_id, const char *properties,
-                                   void *(*new_method)(int name_id,
-                                                       const OSSL_DISPATCH *fns,
-                                                       OSSL_PROVIDER *prov,
-                                                       void *method_data),
-                                   void *method_data,
-                                   int (*up_ref_method)(void *),
-                                   void (*free_method)(void *));
  void *evp_generic_fetch_from_prov(OSSL_PROVIDER *prov, int operation_id,
                                    int name_id, const char *properties,
                                    void *(*new_method)(int name_id,
@@ -45,14 +36,6 @@ evp_generic_fetch() calls ossl_method_construct() with the given
 I<libctx>, I<operation_id>, I<name>, and I<properties> and uses
 it to create an EVP method with the help of the functions
 I<new_method>, I<up_ref_method>, and I<free_method>.
-
-evp_generic_fetch_by_number() does the same thing as evp_generic_fetch(),
-but takes a numeric I<name_id> instead of a name.
-I<name_id> must always be nonzero; as a matter of fact, it being zero
-is considered a programming error.
-This is meant to be used when one method needs to fetch an associated
-method, and is typically called from inside the given function
-I<new_method>.
 
 evp_generic_fetch_from_prov() does the same thing as evp_generic_fetch(),
 but limits the search of methods to the provider given with I<prov>.

--- a/include/crypto/decoder.h
+++ b/include/crypto/decoder.h
@@ -13,10 +13,6 @@
 
 # include <openssl/decoder.h>
 
-OSSL_DECODER *ossl_decoder_fetch_by_number(OSSL_LIB_CTX *libctx,
-                                                     int id,
-                                                     const char *properties);
-
 /*
  * These are specially made for the 'file:' provider-native loader, which
  * uses this to install a DER to anything decoder, which doesn't do much

--- a/include/crypto/encoder.h
+++ b/include/crypto/encoder.h
@@ -9,6 +9,4 @@
 
 #include <openssl/types.h>
 
-OSSL_ENCODER *ossl_encoder_fetch_by_number(OSSL_LIB_CTX *libctx, int id,
-                                           const char *properties);
 int ossl_encoder_get_number(const OSSL_ENCODER *encoder);


### PR DESCRIPTION
These functions are unused and untested.  They are also implemented rather
inefficiently.  If we ever needed them in the future, they'd almost surely
need to be rewritten more efficiently.

Fixes #18227


- [x] documentation is added or updated
- [ ] tests are added or updated
