### PR TITLE
Fix build on OPENSSL_SYS_TANDEM and older POSIXes

### DIFF
--- a/crypto/ctype.c
+++ b/crypto/ctype.c
@@ -15,16 +15,13 @@
 #include <openssl/crypto.h>
 #include "internal/core.h"
 #include "internal/thread_once.h"
-
-#ifndef OPENSSL_SYS_WINDOWS
-#include <strings.h>
+#include "e_os.h"
+#ifndef OPENSSL_NO_LOCALE
+# include <locale.h>
+# ifdef OPENSSL_SYS_MACOSX
+#  include <xlocale.h>
+# endif
 #endif
-#include <locale.h>
-
-#ifdef OPENSSL_SYS_MACOSX
-#include <xlocale.h>
-#endif
-
 /*
  * Define the character classes for each character in the seven bit ASCII
  * character set.  This is independent of the host's character set, characters
@@ -292,18 +289,7 @@ int ossl_ascii_isdigit(const char inchar) {
     return 0;
 }
 
-/* str[n]casecmp_l is defined in POSIX 2008-01. Value is taken accordingly
- * https://www.gnu.org/software/libc/manual/html_node/Feature-Test-Macros.html */
-
-#if (defined OPENSSL_SYS_WINDOWS) || (defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 200809L)
-
-# if defined OPENSSL_SYS_WINDOWS
-# define locale_t _locale_t
-# define freelocale _free_locale
-# define strcasecmp_l _stricmp_l
-# define strncasecmp_l _strnicmp_l
-# endif
-
+#ifndef OPENSSL_NO_LOCALE
 # ifndef FIPS_MODULE
 static locale_t loc;
 

--- a/crypto/ctype.c
+++ b/crypto/ctype.c
@@ -7,15 +7,14 @@
  * https://www.openssl.org/source/license.html
  */
 
+#include "e_os.h"
 #include <string.h>
 #include <stdio.h>
 #include "crypto/ctype.h"
 #include <openssl/ebcdic.h>
-
 #include <openssl/crypto.h>
 #include "internal/core.h"
 #include "internal/thread_once.h"
-#include "e_os.h"
 #ifndef OPENSSL_NO_LOCALE
 # include <locale.h>
 # ifdef OPENSSL_SYS_MACOSX

--- a/e_os.h
+++ b/e_os.h
@@ -409,4 +409,23 @@ inline int nssgetpid();
 #   endif
 # endif
 
+/*
+ * str[n]casecmp_l is defined in POSIX 2008-01. Value is taken accordingly
+ * https://www.gnu.org/software/libc/manual/html_node/Feature-Test-Macros.html
+ * There are also equivalent functions on Windows.
+ * There is no locale_t on NONSTOP.
+ */
+# if defined(OPENSSL_SYS_WINDOWS)
+#  define locale_t _locale_t
+#  define freelocale _free_locale
+#  define strcasecmp_l _stricmp_l
+#  define strncasecmp_l _strnicmp_l
+#  define strcasecmp _stricmp
+# elif !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE < 200809L \
+     || defined(OPENSSL_SYS_TANDEM)
+#  ifndef OPENSSL_NO_LOCALE
+#   define OPENSSL_NO_LOCALE
+#  endif
+# endif
+
 #endif

--- a/test/localetest.c
+++ b/test/localetest.c
@@ -7,15 +7,14 @@
  * https://www.openssl.org/source/license.html
  */
 
+#include "../e_os.h"
 #include <stdio.h>
 #include <string.h>
+#include <stdlib.h>
 #include <openssl/x509.h>
 #include "testutil.h"
 #include "testutil/output.h"
 
-#include <stdio.h>
-#include <stdlib.h>
-#include "../e_os.h"
 #ifndef OPENSSL_NO_LOCALE
 # include <locale.h>
 # ifdef OPENSSL_SYS_MACOSX

--- a/test/localetest.c
+++ b/test/localetest.c
@@ -1,3 +1,11 @@
+/*
+ * Copyright 2022 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
 
 #include <stdio.h>
 #include <string.h>
@@ -7,12 +15,12 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <locale.h>
-#ifdef OPENSSL_SYS_WINDOWS
-# define strcasecmp _stricmp
-#else
-# include <strings.h>
-#endif
+#include "../e_os.h"
+#ifndef OPENSSL_NO_LOCALE
+# include <locale.h>
+# ifdef OPENSSL_SYS_MACOSX
+#  include <xlocale.h>
+# endif
 
 int setup_tests(void)
 {
@@ -118,7 +126,12 @@ int setup_tests(void)
     X509_free(cert);
     return 1;
 }
-
+#else
+int setup_tests(void)
+{
+    return TEST_skip("Locale support not available");
+}
+#endif /* OPENSSL_NO_LOCALE */
 void cleanup_tests(void)
 {
 }


### PR DESCRIPTION
This should hopefully fix not just the build on NONSTOP platform but also older POSIX systems.

It also allows for passing `-DOPENSSL_NO_LOCALE` as a workaround to `./Configure` command.

This is alternative to #18233

Fixes #18232 