### PR TITLE
EVP_PKEY_Q_keygen: Call OPENSSL_init_crypto to init strcasecmp

### DIFF
--- a/crypto/evp/evp_lib.c
+++ b/crypto/evp/evp_lib.c
@@ -24,6 +24,7 @@
 #include <openssl/dh.h>
 #include <openssl/ec.h>
 #include "crypto/evp.h"
+#include "crypto/cryptlib.h"
 #include "internal/provider.h"
 #include "evp_local.h"
 
@@ -1118,6 +1119,8 @@ int EVP_CIPHER_CTX_test_flags(const EVP_CIPHER_CTX *ctx, int flags)
     return (ctx->flags & flags);
 }
 
+#if !defined(FIPS_MODULE)
+
 int EVP_PKEY_CTX_set_group_name(EVP_PKEY_CTX *ctx, const char *name)
 {
     OSSL_PARAM params[] = { OSSL_PARAM_END, OSSL_PARAM_END };
@@ -1193,6 +1196,8 @@ EVP_PKEY *EVP_PKEY_Q_keygen(OSSL_LIB_CTX *libctx, const char *propq,
 
     va_start(args, type);
 
+    OPENSSL_init_crypto(OPENSSL_INIT_BASE_ONLY, NULL);
+
     if (OPENSSL_strcasecmp(type, "RSA") == 0) {
         bits = va_arg(args, size_t);
         params[0] = OSSL_PARAM_construct_size_t(OSSL_PKEY_PARAM_RSA_BITS, &bits);
@@ -1213,3 +1218,5 @@ EVP_PKEY *EVP_PKEY_Q_keygen(OSSL_LIB_CTX *libctx, const char *propq,
     va_end(args);
     return ret;
 }
+
+#endif /* !defined(FIPS_MODULE) */


### PR DESCRIPTION
OPENSSL_strcasecmp() is directly used in EVP_PKEY_Q_keygen but that needs an initialization.

This was reported on openssl-users ML.
