### PR TITLE
Exclude IPv6 code using OPENSSL_USE_IPV6 instead of AF_INET6

### DIFF
--- a/crypto/bio/bio_addr.c
+++ b/crypto/bio/bio_addr.c
@@ -95,7 +95,7 @@ int BIO_ADDR_make(BIO_ADDR *ap, const struct sockaddr *sa)
         memcpy(&(ap->s_in), sa, sizeof(struct sockaddr_in));
         return 1;
     }
-#ifdef AF_INET6
+#if OPENSSL_USE_IPV6
     if (sa->sa_family == AF_INET6) {
         memcpy(&(ap->s_in6), sa, sizeof(struct sockaddr_in6));
         return 1;
@@ -134,7 +134,7 @@ int BIO_ADDR_rawmake(BIO_ADDR *ap, int family,
         ap->s_in.sin_addr = *(struct in_addr *)where;
         return 1;
     }
-#ifdef AF_INET6
+#if OPENSSL_USE_IPV6
     if (family == AF_INET6) {
         if (wherelen != sizeof(struct in6_addr))
             return 0;
@@ -163,7 +163,7 @@ int BIO_ADDR_rawaddress(const BIO_ADDR *ap, void *p, size_t *l)
         len = sizeof(ap->s_in.sin_addr);
         addrptr = &ap->s_in.sin_addr;
     }
-#ifdef AF_INET6
+#if OPENSSL_USE_IPV6
     else if (ap->sa.sa_family == AF_INET6) {
         len = sizeof(ap->s_in6.sin6_addr);
         addrptr = &ap->s_in6.sin6_addr;
@@ -192,7 +192,7 @@ unsigned short BIO_ADDR_rawport(const BIO_ADDR *ap)
 {
     if (ap->sa.sa_family == AF_INET)
         return ap->s_in.sin_port;
-#ifdef AF_INET6
+#if OPENSSL_USE_IPV6
     if (ap->sa.sa_family == AF_INET6)
         return ap->s_in6.sin6_port;
 #endif
@@ -346,7 +346,7 @@ socklen_t BIO_ADDR_sockaddr_size(const BIO_ADDR *ap)
 {
     if (ap->sa.sa_family == AF_INET)
         return sizeof(ap->s_in);
-#ifdef AF_INET6
+#if OPENSSL_USE_IPV6
     if (ap->sa.sa_family == AF_INET6)
         return sizeof(ap->s_in6);
 #endif
@@ -668,7 +668,7 @@ int BIO_lookup_ex(const char *host, const char *service, int lookup_type,
 
     switch (family) {
     case AF_INET:
-#ifdef AF_INET6
+#if OPENSSL_USE_IPV6
     case AF_INET6:
 #endif
 #ifdef AF_UNIX

--- a/crypto/bio/bio_local.h
+++ b/crypto/bio/bio_local.h
@@ -73,7 +73,7 @@ struct bio_addrinfo_st {
 
 union bio_addr_st {
     struct sockaddr sa;
-# ifdef AF_INET6
+# if OPENSSL_USE_IPV6
     struct sockaddr_in6 s_in6;
 # endif
     struct sockaddr_in s_in;

--- a/crypto/bio/bss_acpt.c
+++ b/crypto/bio/bss_acpt.c
@@ -188,7 +188,7 @@ static int acpt_state(BIO *b, BIO_ACCEPT *c)
                               * at least the "else" part will always be
                               * compiled.
                               */
-#ifdef AF_INET6
+#if OPENSSL_USE_IPV6
                         family = AF_INET6;
                     } else {
 #endif
@@ -501,7 +501,7 @@ static long acpt_ctrl(BIO *b, int cmd, long num, void *ptr)
                 *pp = data->cache_peer_serv;
             } else if (num == 4) {
                 switch (BIO_ADDRINFO_family(data->addr_iter)) {
-#ifdef AF_INET6
+#if OPENSSL_USE_IPV6
                 case AF_INET6:
                     ret = BIO_FAMILY_IPV6;
                     break;

--- a/crypto/bio/bss_conn.c
+++ b/crypto/bio/bss_conn.c
@@ -108,7 +108,7 @@ static int conn_state(BIO *b, BIO_CONNECT *c)
                               * at least the "else" part will always be
                               * compiled.
                               */
-#ifdef AF_INET6
+#if OPENSSL_USE_IPV6
                         family = AF_INET6;
                     } else {
 #endif
@@ -421,7 +421,7 @@ static long conn_ctrl(BIO *b, int cmd, long num, void *ptr)
                 *pptr = (const char *)BIO_ADDRINFO_address(data->addr_iter);
             } else if (num == 3) {
                 switch (BIO_ADDRINFO_family(data->addr_iter)) {
-# ifdef AF_INET6
+# if OPENSSL_USE_IPV6
                 case AF_INET6:
                     ret = BIO_FAMILY_IPV6;
                     break;


### PR DESCRIPTION
This replaces the usage of `#ifdef AF_INET6` in `bio/*` with `#if OPENSSL_USE_IPV6`. By default this still uses `AF_INET6`, but it allows the exclusion of all IPv6 related code by setting `OPENSSL_USE_IPV6=0`.
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->