### PR TITLE
Correct padding mode flag name for EVP_PKEY_decrypt/encrypt() examples

### DIFF
--- a/doc/man3/EVP_PKEY_decrypt.pod
+++ b/doc/man3/EVP_PKEY_decrypt.pod
@@ -71,7 +71,7 @@ Decrypt data using OAEP (for RSA keys):
      /* Error occurred */
  if (EVP_PKEY_decrypt_init(ctx) <= 0)
      /* Error */
- if (EVP_PKEY_CTX_set_rsa_padding(ctx, RSA_OAEP_PADDING) <= 0)
+ if (EVP_PKEY_CTX_set_rsa_padding(ctx, RSA_PKCS1_OAEP_PADDING) <= 0)
      /* Error */
 
  /* Determine buffer length */

--- a/doc/man3/EVP_PKEY_encrypt.pod
+++ b/doc/man3/EVP_PKEY_encrypt.pod
@@ -74,7 +74,7 @@ set 'eng = NULL;' to start with the default OpenSSL RSA implementation:
      /* Error occurred */
  if (EVP_PKEY_encrypt_init(ctx) <= 0)
      /* Error */
- if (EVP_PKEY_CTX_set_rsa_padding(ctx, RSA_OAEP_PADDING) <= 0)
+ if (EVP_PKEY_CTX_set_rsa_padding(ctx, RSA_PKCS1_OAEP_PADDING) <= 0)
      /* Error */
 
  /* Determine buffer length */


### PR DESCRIPTION
The example code in EVP_PKEY_decrypt(3) and EVP_PKEY_encrypt(3) and uses
a nonexistent padding mode `RSA_OAEP_PADDING`, which should be
`RSA_PKCS1_OAEP_PADDING` instead.

CLA: trivial

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
