### PR TITLE
remove legacy VxWorks workaround

### DIFF
--- a/crypto/rand/rand_egd.c
+++ b/crypto/rand/rand_egd.c
@@ -40,11 +40,7 @@ int RAND_egd_bytes(const char *path, int bytes)
 # include <sys/types.h>
 # include <sys/socket.h>
 # ifndef NO_SYS_UN_H
-#  ifdef OPENSSL_SYS_VXWORKS
-#   include <streams/un.h>
-#  else
-#   include <sys/un.h>
-#  endif
+#  include <sys/un.h>
 # else
 struct sockaddr_un {
     short sun_family;           /* AF_UNIX */


### PR DESCRIPTION
The same workaround was already removed in sockets.h
in 5c8b7b4caa0faedb69277063a7c6b3a8e56c6308

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
