### PR TITLE
Set OPENSSL_NO_SECURE_MEMORY on "UWP".

### DIFF
--- a/include/internal/e_os.h
+++ b/include/internal/e_os.h
@@ -402,7 +402,8 @@ inline int nssgetpid();
         && ( (defined(_POSIX_VERSION) && _POSIX_VERSION >= 200112L)      \
              || defined(__sun) || defined(__hpux) || defined(__sgi)      \
              || defined(__osf__) )) \
-      || defined(_WIN32)
+      || (defined(_WIN32) \
+        && (!defined(WINAPI_FAMILY_PARTITION) || !WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_APP)))
       /* secure memory is implemented */
 #   else
 #     define OPENSSL_NO_SECURE_MEMORY


### PR DESCRIPTION
UWP does not allow use of the VirtualProtect API underlying this feature.
