### PR TITLE
Make IV/buf in prov_cipher_ctx_st aligned

### DIFF
--- a/providers/implementations/include/prov/ciphercommon.h
+++ b/providers/implementations/include/prov/ciphercommon.h
@@ -46,6 +46,13 @@ typedef int (PROV_CIPHER_HW_FN)(PROV_CIPHER_CTX *dat, unsigned char *out,
 # define PROV_CIPHER_FLAG_INVERSE_CIPHER   0x0200
 
 struct prov_cipher_ctx_st {
+    /* place buffer at the beginning for memory alignment */
+    /* The original value of the iv */
+    unsigned char oiv[GENERIC_BLOCK_SIZE];
+    /* Buffer of partial blocks processed via update calls */
+    unsigned char buf[GENERIC_BLOCK_SIZE];
+    unsigned char iv[GENERIC_BLOCK_SIZE];
+
     block128_f block;
     union {
         cbc128_f cbc;
@@ -86,12 +93,6 @@ struct prov_cipher_ctx_st {
      * manage partial blocks themselves.
      */
     unsigned int num;
-
-    /* The original value of the iv */
-    unsigned char oiv[GENERIC_BLOCK_SIZE];
-    /* Buffer of partial blocks processed via update calls */
-    unsigned char buf[GENERIC_BLOCK_SIZE];
-    unsigned char iv[GENERIC_BLOCK_SIZE];
     const PROV_CIPHER_HW *hw; /* hardware specific functions */
     const void *ks; /* Pointer to algorithm specific key data */
     OSSL_LIB_CTX *libctx;


### PR DESCRIPTION
The benchmark and reason behind this alignment issue can be found in
https://gist.github.com/ZenithalHourlyRate/7b5175734f87acb73d0bbc53391d7140#file-2-openssl-long-md
In short, misaligned `oiv/buf/iv` in `prov_cipher_ctx_st` will lead to drastically performance drop when doing aes-ctr/cfb/ofb

This improves the performance of master when compiled to RISC-V, #18197 and #17640. Benchmark on other architecture is wanted but I do not have enough resources.

Generally, making a buffer aligned is wanted for most architecture. Though this leads to a larger memory footprint.

The issue is suggested by @cyyself and this solution is inspired by @dramforever