### PR TITLE
Fix compilation for RISC-V SHA256/SHA512  inline asm

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -816,6 +816,7 @@ my %targets = (
     "linux64-riscv64" => {
         inherit_from     => [ "linux-generic64"],
         perlasm_scheme   => "linux64",
+        asm_arch         => 'riscv64',
     },
 
     # loongarch64 below refers to contemporary LOONGARCH Architecture

--- a/crypto/sha/sha256.c
+++ b/crypto/sha/sha256.c
@@ -132,7 +132,7 @@ static const SHA_LONG K256[64] = {
 # ifndef PEDANTIC
 #  if defined(__GNUC__) && __GNUC__>=2 && \
       !defined(OPENSSL_NO_ASM) && !defined(OPENSSL_NO_INLINE_ASM)
-#   if __riscv_zknh
+#   if defined(__riscv_zknh)
 #    define Sigma0(x) ({ MD32_REG_T ret;            \
                         asm ("sha256sum0 %0, %1"    \
                         : "=r"(ret)                 \
@@ -150,7 +150,7 @@ static const SHA_LONG K256[64] = {
                         : "=r"(ret)                 \
                         : "r"(x)); ret;             })
 #   endif
-#   if __riscv_zbt || __riscv_zpn
+#   if defined(__riscv_zbt) || defined(__riscv_zpn)
 #    define Ch(x,y,z) ({  MD32_REG_T ret;                           \
                         asm (".insn r4 0x33, 1, 0x3, %0, %2, %1, %3"\
                         : "=r"(ret)                                 \

--- a/crypto/sha/sha512.c
+++ b/crypto/sha/sha512.c
@@ -432,7 +432,7 @@ static const SHA_LONG64 K512[80] = {
                                 : "=r"(ret)                     \
                                 : "r"(*((const SHA_LONG64 *)(&(x))))); ret; })
 #    endif
-#   elif (__riscv_zbkb || __riscv_zbb) && __riscv_xlen == 32
+#   elif (defined(__riscv_zbkb) || defined(__riscv_zbb)) && __riscv_xlen == 32
 #    define PULL64(x) ({ SHA_LONG64 ret;                                        \
                         unsigned int *r = (unsigned int *)(&(ret));             \
                         const unsigned int *p = (const unsigned int *)(&(x));   \
@@ -442,13 +442,13 @@ static const SHA_LONG64 K512[80] = {
                         asm ("rev8 %0, %1"                                      \
                         : "=r"(r[1])                                            \
                         : "r" (p[0])); ret;                                     })
-#   elif (__riscv_zbkb || __riscv_zbb) && __riscv_xlen == 64
+#   elif (defined(__riscv_zbkb) || defined(__riscv_zbb)) && __riscv_xlen == 64
 #    define PULL64(x) ({ SHA_LONG64 ret;    \
                         asm ("rev8 %0, %1"  \
                         : "=r"(ret)         \
                         : "r"(x)); ret;     })
 #   endif
-#   if __riscv_zknh && __riscv_xlen == 32
+#   if defined(__riscv_zknh) && __riscv_xlen == 32
 #    define Sigma0(x) ({ SHA_LONG64 ret; unsigned int *r = (unsigned int *)(&(ret));    \
                         const unsigned int *p = (const unsigned int *)(&(x));           \
                         asm ("sha512sum0r %0, %1, %2"                                   \
@@ -481,7 +481,7 @@ static const SHA_LONG64 K512[80] = {
                         asm ("sha512sig1h %0, %2, %1"                                   \
                         : "=r"(r[1])                                                    \
                         : "r" (p[0]), "r" (p[1])); ret;                                 })
-#   elif __riscv_zknh && __riscv_xlen == 64
+#   elif defined(__riscv_zknh) && __riscv_xlen == 64
 #    define Sigma0(x) ({ SHA_LONG64 ret;            \
                         asm ("sha512sum0 %0, %1"    \
                         : "=r"(ret)                 \
@@ -499,7 +499,7 @@ static const SHA_LONG64 K512[80] = {
                         : "=r"(ret)                 \
                         : "r"(x)); ret;             })
 #   endif
-#   if (__riscv_zbt || __riscv_zpn) && __riscv_xlen == 32
+#   if (defined(__riscv_zbt) || defined(__riscv_zpn)) && __riscv_xlen == 32
 #    define Ch(x,y,z) ({  SHA_LONG64 ret; unsigned int *r = (unsigned int *)(&(ret));   \
                         const unsigned int *xp = (const unsigned int *)(&(x));          \
                         const unsigned int *yp = (const unsigned int *)(&(y));          \
@@ -520,7 +520,7 @@ static const SHA_LONG64 K512[80] = {
                         asm (".insn r4 0x33, 1, 0x3, %0, %2, %1, %3\n\t"                \
                         : "=r"(r[1])                                                    \
                         : "r"(xp[1]^zp[1]), "r"(yp[1]), "r"(zp[1])); ret;               })
-#   elif (__riscv_zbt || __riscv_zpn) && __riscv_xlen == 64
+#   elif (defined(__riscv_zbt) || defined(__riscv_zpn)) && __riscv_xlen == 64
 #    define Ch(x,y,z) ({  SHA_LONG64 ret;                           \
                         asm (".insn r4 0x33, 1, 0x3, %0, %2, %1, %3"\
                         : "=r"(ret)                                 \


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->
This fixes the issue mentioned in https://github.com/openssl/openssl/pull/16638#issuecomment-1121281173

I have cherry-picked a commit from #17640 so Cc @hbrausen. If #17640 gets merged before this, then that commit will be dropped.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->