### PR TITLE
OPENSSL_strcasecmp build, cleanup, and initialization fixes

### DIFF
--- a/crypto/ctype.c
+++ b/crypto/ctype.c
@@ -7,18 +7,11 @@
  * https://www.openssl.org/source/license.html
  */
 
-#include "internal/e_os.h"
 #include <string.h>
 #include <stdio.h>
 #include "crypto/ctype.h"
 #include <openssl/ebcdic.h>
-#include "internal/core.h"
-#ifndef OPENSSL_NO_LOCALE
-# include <locale.h>
-# ifdef OPENSSL_SYS_MACOSX
-#  include <xlocale.h>
-# endif
-#endif
+
 /*
  * Define the character classes for each character in the seven bit ASCII
  * character set.  This is independent of the host's character set, characters
@@ -285,60 +278,3 @@ int ossl_ascii_isdigit(const char inchar) {
         return 1;
     return 0;
 }
-
-#ifndef OPENSSL_NO_LOCALE
-# ifndef FIPS_MODULE
-static locale_t loc;
-
-
-void *ossl_c_locale() {
-    return (void *)loc;
-}
-
-int ossl_init_casecmp_int() {
-# ifdef OPENSSL_SYS_WINDOWS
-    loc = _create_locale(LC_COLLATE, "C");
-# else
-    loc = newlocale(LC_COLLATE_MASK, "C", (locale_t) 0);
-# endif
-    return (loc == (locale_t) 0) ? 0 : 1;
-}
-
-void ossl_deinit_casecmp() {
-    freelocale(loc);
-}
-# endif
-
-int OPENSSL_strcasecmp(const char *s1, const char *s2)
-{
-    return strcasecmp_l(s1, s2, (locale_t)ossl_c_locale());
-}
-
-int OPENSSL_strncasecmp(const char *s1, const char *s2, size_t n)
-{
-    return strncasecmp_l(s1, s2, n, (locale_t)ossl_c_locale());
-}
-#else
-# ifndef FIPS_MODULE
-void *ossl_c_locale() {
-    return NULL;
-}
-# endif
-
-int ossl_init_casecmp_int() {
-    return 1;
-}
-
-void ossl_deinit_casecmp() {
-}
-
-int OPENSSL_strcasecmp(const char *s1, const char *s2)
-{
-    return strcasecmp(s1, s2);
-}
-
-int OPENSSL_strncasecmp(const char *s1, const char *s2, size_t n)
-{
-    return strncasecmp(s1, s2, n);
-}
-#endif

--- a/crypto/ctype.c
+++ b/crypto/ctype.c
@@ -14,16 +14,12 @@
 
 #include "internal/e_os.h"
 #include "internal/core.h"
-
-#ifndef OPENSSL_SYS_WINDOWS
-#include <strings.h>
+#ifndef OPENSSL_NO_LOCALE
+# include <locale.h>
+# ifdef OPENSSL_SYS_MACOSX
+#  include <xlocale.h>
+# endif
 #endif
-#include <locale.h>
-
-#ifdef OPENSSL_SYS_MACOSX
-#include <xlocale.h>
-#endif
-
 /*
  * Define the character classes for each character in the seven bit ASCII
  * character set.  This is independent of the host's character set, characters
@@ -291,24 +287,14 @@ int ossl_ascii_isdigit(const char inchar) {
     return 0;
 }
 
-/* str[n]casecmp_l is defined in POSIX 2008-01. Value is taken accordingly
- * https://www.gnu.org/software/libc/manual/html_node/Feature-Test-Macros.html */
-
-#if (defined OPENSSL_SYS_WINDOWS) || (defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 200809L)
-
-# if defined OPENSSL_SYS_WINDOWS
-# define locale_t _locale_t
-# define freelocale _free_locale
-# define strcasecmp_l _stricmp_l
-# define strncasecmp_l _strnicmp_l
-# endif
+#ifndef OPENSSL_NO_LOCALE
+# ifndef FIPS_MODULE
 static locale_t loc;
 
-# ifndef FIPS_MODULE
+
 void *ossl_c_locale() {
     return (void *)loc;
 }
-# endif
 
 int ossl_init_casecmp_int() {
 # ifdef OPENSSL_SYS_WINDOWS
@@ -322,6 +308,7 @@ int ossl_init_casecmp_int() {
 void ossl_deinit_casecmp() {
     freelocale(loc);
 }
+# endif
 
 int OPENSSL_strcasecmp(const char *s1, const char *s2)
 {

--- a/crypto/ctype.c
+++ b/crypto/ctype.c
@@ -7,12 +7,11 @@
  * https://www.openssl.org/source/license.html
  */
 
+#include "internal/e_os.h"
 #include <string.h>
 #include <stdio.h>
 #include "crypto/ctype.h"
 #include <openssl/ebcdic.h>
-
-#include "internal/e_os.h"
 #include "internal/core.h"
 #ifndef OPENSSL_NO_LOCALE
 # include <locale.h>

--- a/crypto/evp/evp_lib.c
+++ b/crypto/evp/evp_lib.c
@@ -1196,8 +1196,6 @@ EVP_PKEY *EVP_PKEY_Q_keygen(OSSL_LIB_CTX *libctx, const char *propq,
 
     va_start(args, type);
 
-    OPENSSL_init_crypto(OPENSSL_INIT_BASE_ONLY, NULL);
-
     if (OPENSSL_strcasecmp(type, "RSA") == 0) {
         bits = va_arg(args, size_t);
         params[0] = OSSL_PARAM_construct_size_t(OSSL_PKEY_PARAM_RSA_BITS, &bits);

--- a/crypto/evp/pmeth_lib.c
+++ b/crypto/evp/pmeth_lib.c
@@ -23,7 +23,7 @@
 #include <openssl/dh.h>
 #include <openssl/rsa.h>
 #include <openssl/kdf.h>
-#include "crypto/cryptlib.h"
+#include "internal/cryptlib.h"
 #ifndef FIPS_MODULE
 # include "crypto/asn1.h"
 #endif
@@ -199,7 +199,6 @@ static EVP_PKEY_CTX *int_ctx_new(OSSL_LIB_CTX *libctx,
             }
 #ifndef FIPS_MODULE
             if (keytype != NULL) {
-                OPENSSL_init_crypto(OPENSSL_INIT_BASE_ONLY, NULL);
                 id = evp_pkey_name2type(keytype);
                 if (id == NID_undef)
                     id = -1;

--- a/crypto/o_str.c
+++ b/crypto/o_str.c
@@ -349,8 +349,8 @@ int openssl_strerror_r(int errnum, char *buf, size_t buflen)
 #ifndef OPENSSL_NO_LOCALE
 static locale_t loc;
 
-static void *ossl_c_locale(void) {
-    return (void *)loc;
+static locale_t ossl_c_locale(void) {
+    return loc;
 }
 
 int ossl_init_casecmp_int(void) {
@@ -359,21 +359,32 @@ int ossl_init_casecmp_int(void) {
 # else
     loc = newlocale(LC_COLLATE_MASK, "C", (locale_t) 0);
 # endif
-    return (loc == (locale_t) 0) ? 0 : 1;
+    return (loc == (locale_t)0) ? 0 : 1;
 }
 
 void ossl_deinit_casecmp(void) {
     freelocale(loc);
+    loc = (locale_t)0;
 }
 
 int OPENSSL_strcasecmp(const char *s1, const char *s2)
 {
-    return strcasecmp_l(s1, s2, (locale_t)ossl_c_locale());
+    locale_t l = ossl_c_locale();
+
+    /* Fallback in case of locale initialization failure */
+    if (l == (locale_t)0)
+        return strcasecmp(s1, s2);
+    return strcasecmp_l(s1, s2, l);
 }
 
 int OPENSSL_strncasecmp(const char *s1, const char *s2, size_t n)
 {
-    return strncasecmp_l(s1, s2, n, (locale_t)ossl_c_locale());
+    locale_t l = ossl_c_locale();
+
+    /* Fallback in case of locale initialization failure */
+    if (l == (locale_t)0)
+        return strncasecmp(s1, s2, n);
+    return strncasecmp_l(s1, s2, n, l);
 }
 #else
 int ossl_init_casecmp_int(void) {

--- a/crypto/o_str.c
+++ b/crypto/o_str.c
@@ -18,7 +18,6 @@
 #endif
 #include <openssl/crypto.h>
 #include "internal/cryptlib.h"
-#include "internal/core.h"
 
 #define DEFAULT_SEPARATOR ':'
 #define CH_ZERO '\0'
@@ -348,15 +347,13 @@ int openssl_strerror_r(int errnum, char *buf, size_t buflen)
 }
 
 #ifndef OPENSSL_NO_LOCALE
-# ifndef FIPS_MODULE
 static locale_t loc;
 
-
-void *ossl_c_locale() {
+static void *ossl_c_locale(void) {
     return (void *)loc;
 }
 
-int ossl_init_casecmp_int() {
+int ossl_init_casecmp_int(void) {
 # ifdef OPENSSL_SYS_WINDOWS
     loc = _create_locale(LC_COLLATE, "C");
 # else
@@ -365,10 +362,9 @@ int ossl_init_casecmp_int() {
     return (loc == (locale_t) 0) ? 0 : 1;
 }
 
-void ossl_deinit_casecmp() {
+void ossl_deinit_casecmp(void) {
     freelocale(loc);
 }
-# endif
 
 int OPENSSL_strcasecmp(const char *s1, const char *s2)
 {
@@ -380,17 +376,11 @@ int OPENSSL_strncasecmp(const char *s1, const char *s2, size_t n)
     return strncasecmp_l(s1, s2, n, (locale_t)ossl_c_locale());
 }
 #else
-# ifndef FIPS_MODULE
-void *ossl_c_locale() {
-    return NULL;
-}
-# endif
-
-int ossl_init_casecmp_int() {
+int ossl_init_casecmp_int(void) {
     return 1;
 }
 
-void ossl_deinit_casecmp() {
+void ossl_deinit_casecmp(void) {
 }
 
 int OPENSSL_strcasecmp(const char *s1, const char *s2)

--- a/crypto/o_str.c
+++ b/crypto/o_str.c
@@ -18,6 +18,7 @@
 #endif
 #include <openssl/crypto.h>
 #include "internal/cryptlib.h"
+#include "internal/thread_once.h"
 
 #define DEFAULT_SEPARATOR ':'
 #define CH_ZERO '\0'
@@ -347,13 +348,36 @@ int openssl_strerror_r(int errnum, char *buf, size_t buflen)
 }
 
 #ifndef OPENSSL_NO_LOCALE
+# ifndef FIPS_MODULE
+static CRYPTO_ONCE casecmp = CRYPTO_ONCE_STATIC_INIT;
+DEFINE_RUN_ONCE_STATIC(init_casecmp)
+{
+    int ret = ossl_init_casecmp_int();
+
+    return ret;
+}
+
+int ossl_init_casecmp(void)
+{
+    if (!RUN_ONCE(&casecmp, init_casecmp))
+        return 0;
+    return 1;
+}
+# endif
+
 static locale_t loc;
 
-static locale_t ossl_c_locale(void) {
+static locale_t ossl_c_locale(void)
+{
+# ifndef FIPS_MODULE
+    if (!ossl_init_casecmp())
+        return (locale_t)0;
+# endif
     return loc;
 }
 
-int ossl_init_casecmp_int(void) {
+int ossl_init_casecmp_int(void)
+{
 # ifdef OPENSSL_SYS_WINDOWS
     loc = _create_locale(LC_COLLATE, "C");
 # else
@@ -362,9 +386,12 @@ int ossl_init_casecmp_int(void) {
     return (loc == (locale_t)0) ? 0 : 1;
 }
 
-void ossl_deinit_casecmp(void) {
-    freelocale(loc);
-    loc = (locale_t)0;
+void ossl_deinit_casecmp(void)
+{
+    if (loc != (locale_t)0) {
+        freelocale(loc);
+        loc = (locale_t)0;
+    }
 }
 
 int OPENSSL_strcasecmp(const char *s1, const char *s2)
@@ -387,11 +414,18 @@ int OPENSSL_strncasecmp(const char *s1, const char *s2, size_t n)
     return strncasecmp_l(s1, s2, n, l);
 }
 #else
-int ossl_init_casecmp_int(void) {
+int ossl_init_casecmp(void)
+{
     return 1;
 }
 
-void ossl_deinit_casecmp(void) {
+int ossl_init_casecmp_int(void)
+{
+    return 1;
+}
+
+void ossl_deinit_casecmp(void)
+{
 }
 
 int OPENSSL_strcasecmp(const char *s1, const char *s2)

--- a/crypto/o_str.c
+++ b/crypto/o_str.c
@@ -8,9 +8,17 @@
  */
 
 #include "internal/e_os.h"
+#include <string.h>
 #include <limits.h>
+#ifndef OPENSSL_NO_LOCALE
+# include <locale.h>
+# ifdef OPENSSL_SYS_MACOSX
+#  include <xlocale.h>
+# endif
+#endif
 #include <openssl/crypto.h>
 #include "internal/cryptlib.h"
+#include "internal/core.h"
 
 #define DEFAULT_SEPARATOR ':'
 #define CH_ZERO '\0'
@@ -338,3 +346,60 @@ int openssl_strerror_r(int errnum, char *buf, size_t buflen)
     return 1;
 #endif
 }
+
+#ifndef OPENSSL_NO_LOCALE
+# ifndef FIPS_MODULE
+static locale_t loc;
+
+
+void *ossl_c_locale() {
+    return (void *)loc;
+}
+
+int ossl_init_casecmp_int() {
+# ifdef OPENSSL_SYS_WINDOWS
+    loc = _create_locale(LC_COLLATE, "C");
+# else
+    loc = newlocale(LC_COLLATE_MASK, "C", (locale_t) 0);
+# endif
+    return (loc == (locale_t) 0) ? 0 : 1;
+}
+
+void ossl_deinit_casecmp() {
+    freelocale(loc);
+}
+# endif
+
+int OPENSSL_strcasecmp(const char *s1, const char *s2)
+{
+    return strcasecmp_l(s1, s2, (locale_t)ossl_c_locale());
+}
+
+int OPENSSL_strncasecmp(const char *s1, const char *s2, size_t n)
+{
+    return strncasecmp_l(s1, s2, n, (locale_t)ossl_c_locale());
+}
+#else
+# ifndef FIPS_MODULE
+void *ossl_c_locale() {
+    return NULL;
+}
+# endif
+
+int ossl_init_casecmp_int() {
+    return 1;
+}
+
+void ossl_deinit_casecmp() {
+}
+
+int OPENSSL_strcasecmp(const char *s1, const char *s2)
+{
+    return strcasecmp(s1, s2);
+}
+
+int OPENSSL_strncasecmp(const char *s1, const char *s2, size_t n)
+{
+    return strncasecmp(s1, s2, n);
+}
+#endif

--- a/include/crypto/ctype.h
+++ b/include/crypto/ctype.h
@@ -79,7 +79,4 @@ int ossl_ascii_isdigit(const char inchar);
 # define ossl_isxdigit(c)       (ossl_ctype_check((c), CTYPE_MASK_xdigit))
 # define ossl_isbase64(c)       (ossl_ctype_check((c), CTYPE_MASK_base64))
 # define ossl_isasn1print(c)    (ossl_ctype_check((c), CTYPE_MASK_asn1print))
-
-int ossl_init_casecmp_int(void);
-void ossl_deinit_casecmp(void);
 #endif

--- a/include/internal/core.h
+++ b/include/internal/core.h
@@ -62,7 +62,4 @@ __owur int ossl_lib_ctx_write_lock(OSSL_LIB_CTX *ctx);
 __owur int ossl_lib_ctx_read_lock(OSSL_LIB_CTX *ctx);
 int ossl_lib_ctx_unlock(OSSL_LIB_CTX *ctx);
 int ossl_lib_ctx_is_child(OSSL_LIB_CTX *ctx);
-
-void *ossl_c_locale(void);
-
 #endif

--- a/include/internal/cryptlib.h
+++ b/include/internal/cryptlib.h
@@ -158,5 +158,6 @@ char *ossl_buf2hexstr_sep(const unsigned char *buf, long buflen, char sep);
 unsigned char *ossl_hexstr2buf_sep(const char *str, long *buflen,
                                    const char sep);
 int ossl_init_casecmp_int(void);
+int ossl_init_casecmp(void);
 void ossl_deinit_casecmp(void);
 #endif

--- a/include/internal/cryptlib.h
+++ b/include/internal/cryptlib.h
@@ -157,5 +157,6 @@ char *ossl_ipaddr_to_asc(unsigned char *p, int len);
 char *ossl_buf2hexstr_sep(const unsigned char *buf, long buflen, char sep);
 unsigned char *ossl_hexstr2buf_sep(const char *str, long *buflen,
                                    const char sep);
-
+int ossl_init_casecmp_int(void);
+void ossl_deinit_casecmp(void);
 #endif

--- a/include/internal/e_os.h
+++ b/include/internal/e_os.h
@@ -421,6 +421,7 @@ inline int nssgetpid();
 #  define strcasecmp_l _stricmp_l
 #  define strncasecmp_l _strnicmp_l
 #  define strcasecmp _stricmp
+#  define strncasecmp _strnicmp
 # elif !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE < 200809L \
      || defined(OPENSSL_SYS_TANDEM)
 #  ifndef OPENSSL_NO_LOCALE

--- a/include/internal/e_os.h
+++ b/include/internal/e_os.h
@@ -409,4 +409,23 @@ inline int nssgetpid();
 #   endif
 # endif
 
+/*
+ * str[n]casecmp_l is defined in POSIX 2008-01. Value is taken accordingly
+ * https://www.gnu.org/software/libc/manual/html_node/Feature-Test-Macros.html
+ * There are also equivalent functions on Windows.
+ * There is no locale_t on NONSTOP.
+ */
+# if defined(OPENSSL_SYS_WINDOWS)
+#  define locale_t _locale_t
+#  define freelocale _free_locale
+#  define strcasecmp_l _stricmp_l
+#  define strncasecmp_l _strnicmp_l
+#  define strcasecmp _stricmp
+# elif !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE < 200809L \
+     || defined(OPENSSL_SYS_TANDEM)
+#  ifndef OPENSSL_NO_LOCALE
+#   define OPENSSL_NO_LOCALE
+#  endif
+# endif
+
 #endif

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -38,18 +38,6 @@ static OSSL_FUNC_provider_gettable_params_fn fips_gettable_params;
 static OSSL_FUNC_provider_get_params_fn fips_get_params;
 static OSSL_FUNC_provider_query_operation_fn fips_query;
 
-/* Locale object accessor functions */
-#ifndef OPENSSL_NO_LOCALE
-# include <locale.h>
-# ifdef OPENSSL_SYS_MACOSX
-#  include <xlocale.h>
-# endif
-static locale_t loc;
-#endif
-
-static int fips_init_casecmp(void);
-static void fips_deinit_casecmp(void);
-
 #define ALGC(NAMES, FUNC, CHECK) { { NAMES, FIPS_DEFAULT_PROPERTIES, FUNC }, CHECK }
 #define ALG(NAMES, FUNC) ALGC(NAMES, FUNC, NULL)
 
@@ -492,40 +480,11 @@ static const OSSL_ALGORITHM *fips_query(void *provctx, int operation_id,
     return NULL;
 }
 
-# ifndef OPENSSL_NO_LOCALE
-void *ossl_c_locale() {
-    return (void *)loc;
-}
-
-static int fips_init_casecmp(void) {
-#  ifdef OPENSSL_SYS_WINDOWS
-    loc = _create_locale(LC_COLLATE, "C");
-#  else
-    loc = newlocale(LC_COLLATE_MASK, "C", (locale_t) 0);
-#  endif
-    return (loc == (locale_t) 0) ? 0 : 1;
-}
-
-static void fips_deinit_casecmp(void) {
-    freelocale(loc);
-}
-# else
-void *ossl_c_locale() {
-    return NULL;
-}
-
-static int fips_init_casecmp(void) {
-    return 1;
-}
-
-static void fips_deinit_casecmp(void) {
-}
-# endif
-
 static void fips_teardown(void *provctx)
 {
     OSSL_LIB_CTX_free(PROV_LIBCTX_OF(provctx));
     ossl_prov_ctx_free(provctx);
+    ossl_deinit_casecmp();
 }
 
 static void fips_intern_teardown(void *provctx)
@@ -534,7 +493,6 @@ static void fips_intern_teardown(void *provctx)
      * We know that the library context is the same as for the outer provider,
      * so no need to destroy it here.
      */
-    fips_deinit_casecmp();
     ossl_prov_ctx_free(provctx);
 }
 
@@ -584,10 +542,10 @@ int OSSL_provider_init_int(const OSSL_CORE_HANDLE *handle,
 
     memset(&selftest_params, 0, sizeof(selftest_params));
 
-    if (!fips_init_casecmp())
+    if (!ossl_init_casecmp_int())
         return 0;
     if (!ossl_prov_seeding_from_dispatch(in))
-        return 0;
+        goto err;
     for (; in->function_id != 0; in++) {
         /*
          * We do not support the scenario of an application linked against

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -24,6 +24,7 @@
 #include "self_test.h"
 #include "crypto/context.h"
 #include "internal/core.h"
+#include "internal/e_os.h"
 
 static const char FIPS_DEFAULT_PROPERTIES[] = "provider=fips,fips=yes";
 static const char FIPS_UNAPPROVED_PROPERTIES[] = "provider=fips,fips=no";
@@ -38,17 +39,13 @@ static OSSL_FUNC_provider_get_params_fn fips_get_params;
 static OSSL_FUNC_provider_query_operation_fn fips_query;
 
 /* Locale object accessor functions */
-#ifdef OPENSSL_SYS_MACOSX
-# include <xlocale.h>
-#else
+#ifndef OPENSSL_NO_LOCALE
 # include <locale.h>
-#endif
-
-#if defined OPENSSL_SYS_WINDOWS
-# define locale_t _locale_t
-# define freelocale _free_locale
-#endif
+# ifdef OPENSSL_SYS_MACOSX
+#  include <xlocale.h>
+# endif
 static locale_t loc;
+#endif
 
 static int fips_init_casecmp(void);
 static void fips_deinit_casecmp(void);
@@ -495,22 +492,35 @@ static const OSSL_ALGORITHM *fips_query(void *provctx, int operation_id,
     return NULL;
 }
 
+# ifndef OPENSSL_NO_LOCALE
 void *ossl_c_locale() {
     return (void *)loc;
 }
 
 static int fips_init_casecmp(void) {
-# ifdef OPENSSL_SYS_WINDOWS
+#  ifdef OPENSSL_SYS_WINDOWS
     loc = _create_locale(LC_COLLATE, "C");
-# else
+#  else
     loc = newlocale(LC_COLLATE_MASK, "C", (locale_t) 0);
-# endif
+#  endif
     return (loc == (locale_t) 0) ? 0 : 1;
 }
 
 static void fips_deinit_casecmp(void) {
     freelocale(loc);
 }
+# else
+void *ossl_c_locale() {
+    return NULL;
+}
+
+static int fips_init_casecmp(void) {
+    return 1;
+}
+
+static void fips_deinit_casecmp(void) {
+}
+# endif
 
 static void fips_teardown(void *provctx)
 {

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -24,7 +24,6 @@
 #include "self_test.h"
 #include "crypto/context.h"
 #include "internal/core.h"
-#include "internal/e_os.h"
 
 static const char FIPS_DEFAULT_PROPERTIES[] = "provider=fips,fips=yes";
 static const char FIPS_UNAPPROVED_PROPERTIES[] = "provider=fips,fips=no";

--- a/test/localetest.c
+++ b/test/localetest.c
@@ -1,3 +1,11 @@
+/*
+ * Copyright 2022 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
 
 #include <stdio.h>
 #include <string.h>
@@ -6,12 +14,12 @@
 #include "testutil/output.h"
 
 #include <stdlib.h>
-#include <locale.h>
-#ifdef OPENSSL_SYS_WINDOWS
-# define strcasecmp _stricmp
-#else
-# include <strings.h>
-#endif
+#include "internal/e_os.h"
+#ifndef OPENSSL_NO_LOCALE
+# include <locale.h>
+# ifdef OPENSSL_SYS_MACOSX
+#  include <xlocale.h>
+# endif
 
 int setup_tests(void)
 {
@@ -117,7 +125,12 @@ int setup_tests(void)
     X509_free(cert);
     return 1;
 }
-
+#else
+int setup_tests(void)
+{
+    return TEST_skip("Locale support not available");
+}
+#endif /* OPENSSL_NO_LOCALE */
 void cleanup_tests(void)
 {
 }

--- a/test/localetest.c
+++ b/test/localetest.c
@@ -7,14 +7,14 @@
  * https://www.openssl.org/source/license.html
  */
 
+#include "internal/e_os.h"
 #include <stdio.h>
 #include <string.h>
+#include <stdlib.h>
 #include <openssl/x509.h>
 #include "testutil.h"
 #include "testutil/output.h"
 
-#include <stdlib.h>
-#include "internal/e_os.h"
 #ifndef OPENSSL_NO_LOCALE
 # include <locale.h>
 # ifdef OPENSSL_SYS_MACOSX


### PR DESCRIPTION
This PR encompasses cleanups, build, and initialization fixes for the OPENSSL_strcasecmp related fix.

I recommend reviewing by individual commits.

We will need similar PR for 3.0 but that will require some backporting effort because the patches won't apply cleanly. In the end however the final state on 3.0 should be exactly the same.
