### PR TITLE
Add SM3 implementation in RISC-V Zksh inline asm

### DIFF
--- a/crypto/sm3/sm3_local.h
+++ b/crypto/sm3/sm3_local.h
@@ -53,8 +53,28 @@ void ossl_sm3_transform(SM3_CTX *c, const unsigned char *data);
 
 #include "crypto/md32_common.h"
 
-#define P0(X) (X ^ ROTATE(X, 9) ^ ROTATE(X, 17))
-#define P1(X) (X ^ ROTATE(X, 15) ^ ROTATE(X, 23))
+#ifndef PEDANTIC
+# if defined(__GNUC__) && __GNUC__>=2 && \
+     !defined(OPENSSL_NO_ASM) && !defined(OPENSSL_NO_INLINE_ASM)
+#  if defined(__riscv_zksh)
+#   define P0(x) ({ MD32_REG_T ret;                \
+                       asm ("sm3p0 %0, %1"         \
+                       : "=r"(ret)                 \
+                       : "r"(x)); ret;             })
+#   define P1(x) ({ MD32_REG_T ret;                \
+                       asm ("sm3p1 %0, %1"         \
+                       : "=r"(ret)                 \
+                       : "r"(x)); ret;             })
+#  endif
+# endif
+#endif
+
+#ifndef P0
+# define P0(X) (X ^ ROTATE(X, 9) ^ ROTATE(X, 17))
+#endif
+#ifndef P1
+# define P1(X) (X ^ ROTATE(X, 15) ^ ROTATE(X, 23))
+#endif
 
 #define FF0(X,Y,Z) (X ^ Y ^ Z)
 #define GG0(X,Y,Z) (X ^ Y ^ Z)

--- a/crypto/sm3/sm3_local.h
+++ b/crypto/sm3/sm3_local.h
@@ -57,14 +57,30 @@ void ossl_sm3_transform(SM3_CTX *c, const unsigned char *data);
 # if defined(__GNUC__) && __GNUC__>=2 && \
      !defined(OPENSSL_NO_ASM) && !defined(OPENSSL_NO_INLINE_ASM)
 #  if defined(__riscv_zksh)
-#   define P0(x) ({ MD32_REG_T ret;                \
-                       asm ("sm3p0 %0, %1"         \
-                       : "=r"(ret)                 \
-                       : "r"(x)); ret;             })
-#   define P1(x) ({ MD32_REG_T ret;                \
-                       asm ("sm3p1 %0, %1"         \
-                       : "=r"(ret)                 \
-                       : "r"(x)); ret;             })
+#   define P0(x) ({ MD32_REG_T ret;        \
+                       asm ("sm3p0 %0, %1" \
+                       : "=r"(ret)         \
+                       : "r"(x)); ret;     })
+#   define P1(x) ({ MD32_REG_T ret;        \
+                       asm ("sm3p1 %0, %1" \
+                       : "=r"(ret)         \
+                       : "r"(x)); ret;     })
+#  endif
+#  if defined(__riscv_zbb) || defined(__riscv_zbkb)
+#   if __riscv_xlen == 64
+#   undef ROTATE
+#   define ROTATE(x, n) ({ MD32_REG_T ret;            \
+                       asm ("roriw %0, %1, %2"        \
+                       : "=r"(ret)                    \
+                       : "r"(x), "i"(32 - (n))); ret;})
+#   endif
+#   if __riscv_xlen == 32
+#   undef ROTATE
+#   define ROTATE(x, n) ({ MD32_REG_T ret;            \
+                       asm ("rori %0, %1, %2"         \
+                       : "=r"(ret)                    \
+                       : "r"(x), "i"(32 - (n))); ret;})
+#   endif
 #  endif
 # endif
 #endif

--- a/crypto/sm3/sm3_local.h
+++ b/crypto/sm3/sm3_local.h
@@ -66,22 +66,6 @@ void ossl_sm3_transform(SM3_CTX *c, const unsigned char *data);
                        : "=r"(ret)         \
                        : "r"(x)); ret;     })
 #  endif
-#  if defined(__riscv_zbb) || defined(__riscv_zbkb)
-#   if __riscv_xlen == 64
-#   undef ROTATE
-#   define ROTATE(x, n) ({ MD32_REG_T ret;            \
-                       asm ("roriw %0, %1, %2"        \
-                       : "=r"(ret)                    \
-                       : "r"(x), "i"(32 - (n))); ret;})
-#   endif
-#   if __riscv_xlen == 32
-#   undef ROTATE
-#   define ROTATE(x, n) ({ MD32_REG_T ret;            \
-                       asm ("rori %0, %1, %2"         \
-                       : "=r"(ret)                    \
-                       : "r"(x), "i"(32 - (n))); ret;})
-#   endif
-#  endif
 # endif
 #endif
 

--- a/include/crypto/md32_common.h
+++ b/include/crypto/md32_common.h
@@ -99,6 +99,28 @@
 
 # define ROTATE(a,n)     (((a)<<(n))|(((a)&0xffffffff)>>(32-(n))))
 
+#ifndef PEDANTIC
+# if defined(__GNUC__) && __GNUC__>=2 && \
+     !defined(OPENSSL_NO_ASM) && !defined(OPENSSL_NO_INLINE_ASM)
+#  if defined(__riscv_zbb) || defined(__riscv_zbkb)
+#   if __riscv_xlen == 64
+#   undef ROTATE
+#   define ROTATE(x, n) ({ MD32_REG_T ret;            \
+                       asm ("roriw %0, %1, %2"        \
+                       : "=r"(ret)                    \
+                       : "r"(x), "i"(32 - (n))); ret;})
+#   endif
+#   if __riscv_xlen == 32
+#   undef ROTATE
+#   define ROTATE(x, n) ({ MD32_REG_T ret;            \
+                       asm ("rori %0, %1, %2"         \
+                       : "=r"(ret)                    \
+                       : "r"(x), "i"(32 - (n))); ret;})
+#   endif
+#  endif
+# endif
+#endif
+
 # if defined(DATA_ORDER_IS_BIG_ENDIAN)
 
 #  define HOST_c2l(c,l)  (l =(((unsigned long)(*((c)++)))<<24),          \


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

This PR adds the support of SM3 for RISC-V platform with Zksh capability. Note that this works for both RV32 and RV64

The RV64 infra has been merged (#18275). RV32 infra will be contributed in further PRs (see #18285). So this PR is ready to merge.

This feature is enabled when using GNU compiler with `-march=rv64gc_zksh`.

This PR borrowed the idea from #16710 and #16638

Correctness has been verified as both C and inline asm version outputed the same digest.

##### Benchmark of `openssl speed -evp sm3`

With the setup in https://gist.github.com/ZenithalHourlyRate/7b5175734f87acb73d0bbc53391d7140

```
# pure C
sm3                 97.79k      258.58k      578.42k      969.12k     1223.19k     1199.24k
# with zksh asm
sm3                142.48k      404.12k      937.73k     1443.19k     1707.36k     1742.17k
```

##### Discussion on runtime selection

This inline asm feature is only enabled at compile time (the same way as #16710 and #16638), and can not be enabled at runtime with `OPENSSL_riscvcap` as #17640, #18197 and #18285.

If we implement runtime selection in current `sm3_local.h`, then we need to judge `RISCV_HAS_ZKSH` before each `P0/P1`, which is not acceptable for performance.

Another way is to implement `rvi_zksh_{init,update,finish}` along side current `ossl_sm3_{init,update,finish}` in `providers/implementations/digests/sm3_prov.c`. However, re-implementing all the functions just for one instruction is not maintainable. Also, there are two ways to implement it: C with inline asm, then we must use `-march="zksh"` when compiling even for pure C version and it is not portable; or perlasm, and we need to rewrite the whole thing in asm and need `.word` magic for compiler compatibility.

It seems there is no good way to implement it with small effort.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
