### PR TITLE
Add ROTATE inline RISC-V zbb/zbkb asm for chacha

### DIFF
--- a/crypto/chacha/chacha_enc.c
+++ b/crypto/chacha/chacha_enc.c
@@ -24,6 +24,28 @@ typedef union {
 
 # define ROTATE(v, n) (((v) << (n)) | ((v) >> (32 - (n))))
 
+# ifndef PEDANTIC
+#  if defined(__GNUC__) && __GNUC__>=2 && \
+      !defined(OPENSSL_NO_ASM) && !defined(OPENSSL_NO_INLINE_ASM)
+#   if defined(__riscv_zbb) || defined(__riscv_zbkb)
+#    if __riscv_xlen == 64
+#    undef ROTATE
+#    define ROTATE(x, n) ({ u32 ret;                   \
+                        asm ("roriw %0, %1, %2"        \
+                        : "=r"(ret)                    \
+                        : "r"(x), "i"(32 - (n))); ret;})
+#    endif
+#    if __riscv_xlen == 32
+#    undef ROTATE
+#    define ROTATE(x, n) ({ u32 ret;                   \
+                        asm ("rori %0, %1, %2"         \
+                        : "=r"(ret)                    \
+                        : "r"(x), "i"(32 - (n))); ret;})
+#    endif
+#   endif
+#  endif
+# endif
+
 # define U32TO8_LITTLE(p, v) do { \
                                 (p)[0] = (u8)(v >>  0); \
                                 (p)[1] = (u8)(v >>  8); \


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

This PR provides RISC-V Zbb support for chacha by adding inline asm

Mainly ref to https://github.com/openssl/openssl/pull/18287#issuecomment-1123460382

Benchmark (setup see #18287):
```
# pure C
ChaCha20          1657.84k     2520.79k     2776.66k     2843.23k     2801.66k     2768.90k
# with rorwi asm
ChaCha20          2215.63k     4080.44k     4730.61k     4912.81k     4857.86k     4734.98k
```

Enabled with `-march="rv64gc_zbb" or -march="rv64gc_zbkb"`

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
