### PR TITLE
Add ROTATE inline RISC-V zbb/zbkb asm for DES

### DIFF
--- a/crypto/des/des_local.h
+++ b/crypto/des/des_local.h
@@ -109,6 +109,19 @@
                                         : "cc");        \
                            ret;                         \
                         })
+#  elif defined(__riscv_zbb) || defined(__riscv_zbkb)
+#   if __riscv_xlen == 64
+#    define ROTATE(x, n) ({ register unsigned int ret; \
+                       asm ("roriw %0, %1, %2"         \
+                       : "=r"(ret)                     \
+                       : "r"(x), "i"(n)); ret; })
+#   endif
+#   if __riscv_xlen == 32
+#    define ROTATE(x, n) ({ register unsigned int ret; \
+                       asm ("rori %0, %1, %2"          \
+                       : "=r"(ret)                     \
+                       : "r"(x), "i"(n)); ret; })
+#   endif
 #  endif
 # endif
 # ifndef ROTATE


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->
This PR provides RISC-V Zbb support for DES by adding inline asm

Mainly ref to https://github.com/openssl/openssl/pull/18287#issuecomment-1123460382

Benchmark (setup see https://github.com/openssl/openssl/pull/18287):
```
# pure C
DES-EDE3-CBC       163.54k      169.74k      170.84k      172.03k      173.61k      173.03k
# with Zbb asm
DES-EDE3-CBC       190.06k      197.61k      198.91k      200.35k      201.40k      201.40k
```
Can be enabled with `-march="rv64gc_zbb"` or `-march="rv64gc_zbkb"`

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
