### PR TITLE
OPENSSL_strcasecmp build, cleanup, and initialization fixes [3.0]

### DIFF
--- a/crypto/ctype.c
+++ b/crypto/ctype.c
@@ -7,20 +7,11 @@
  * https://www.openssl.org/source/license.html
  */
 
-#include "e_os.h"
 #include <string.h>
 #include <stdio.h>
 #include "crypto/ctype.h"
 #include <openssl/ebcdic.h>
-#include <openssl/crypto.h>
-#include "internal/core.h"
-#include "internal/thread_once.h"
-#ifndef OPENSSL_NO_LOCALE
-# include <locale.h>
-# ifdef OPENSSL_SYS_MACOSX
-#  include <xlocale.h>
-# endif
-#endif
+
 /*
  * Define the character classes for each character in the seven bit ASCII
  * character set.  This is independent of the host's character set, characters
@@ -287,79 +278,3 @@ int ossl_ascii_isdigit(const char inchar) {
         return 1;
     return 0;
 }
-
-#ifndef OPENSSL_NO_LOCALE
-# ifndef FIPS_MODULE
-static locale_t loc;
-
-static int locale_base_inited = 0;
-static CRYPTO_ONCE locale_base = CRYPTO_ONCE_STATIC_INIT;
-static CRYPTO_ONCE locale_base_deinit = CRYPTO_ONCE_STATIC_INIT;
-
-void *ossl_c_locale() {
-    return (void *)loc;
-}
-
-DEFINE_RUN_ONCE_STATIC(ossl_init_locale_base)
-{
-# ifdef OPENSSL_SYS_WINDOWS
-    loc = _create_locale(LC_COLLATE, "C");
-# else
-    loc = newlocale(LC_COLLATE_MASK, "C", (locale_t) 0);
-# endif
-    locale_base_inited = 1;
-    return (loc == (locale_t) 0) ? 0 : 1;
-}
-
-DEFINE_RUN_ONCE_STATIC(ossl_deinit_locale_base)
-{
-    if (locale_base_inited && loc) {
-        freelocale(loc);
-        loc = NULL;
-    }
-    return 1;
-}
-
-int ossl_init_casecmp()
-{
-   return RUN_ONCE(&locale_base, ossl_init_locale_base);
-}
-
-void ossl_deinit_casecmp() {
-    (void)RUN_ONCE(&locale_base_deinit, ossl_deinit_locale_base);
-}
-# endif
-
-int OPENSSL_strcasecmp(const char *s1, const char *s2)
-{
-    return strcasecmp_l(s1, s2, (locale_t)ossl_c_locale());
-}
-
-int OPENSSL_strncasecmp(const char *s1, const char *s2, size_t n)
-{
-    return strncasecmp_l(s1, s2, n, (locale_t)ossl_c_locale());
-}
-#else
-# ifndef FIPS_MODULE
-void *ossl_c_locale() {
-    return NULL;
-}
-# endif
-
-int ossl_init_casecmp() {
-    return 1;
-}
-
-void ossl_deinit_casecmp() {
-}
-
-int OPENSSL_strcasecmp(const char *s1, const char *s2)
-{
-    return strcasecmp(s1, s2);
-}
-
-int OPENSSL_strncasecmp(const char *s1, const char *s2, size_t n)
-{
-    return strncasecmp(s1, s2, n);
-}
-#endif

--- a/crypto/ctype.c
+++ b/crypto/ctype.c
@@ -15,16 +15,13 @@
 #include <openssl/crypto.h>
 #include "internal/core.h"
 #include "internal/thread_once.h"
-
-#ifndef OPENSSL_SYS_WINDOWS
-#include <strings.h>
+#include "e_os.h"
+#ifndef OPENSSL_NO_LOCALE
+# include <locale.h>
+# ifdef OPENSSL_SYS_MACOSX
+#  include <xlocale.h>
+# endif
 #endif
-#include <locale.h>
-
-#ifdef OPENSSL_SYS_MACOSX
-#include <xlocale.h>
-#endif
-
 /*
  * Define the character classes for each character in the seven bit ASCII
  * character set.  This is independent of the host's character set, characters
@@ -292,18 +289,7 @@ int ossl_ascii_isdigit(const char inchar) {
     return 0;
 }
 
-/* str[n]casecmp_l is defined in POSIX 2008-01. Value is taken accordingly
- * https://www.gnu.org/software/libc/manual/html_node/Feature-Test-Macros.html */
-
-#if (defined OPENSSL_SYS_WINDOWS) || (defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 200809L)
-
-# if defined OPENSSL_SYS_WINDOWS
-# define locale_t _locale_t
-# define freelocale _free_locale
-# define strcasecmp_l _stricmp_l
-# define strncasecmp_l _strnicmp_l
-# endif
-
+#ifndef OPENSSL_NO_LOCALE
 # ifndef FIPS_MODULE
 static locale_t loc;
 

--- a/crypto/ctype.c
+++ b/crypto/ctype.c
@@ -7,15 +7,14 @@
  * https://www.openssl.org/source/license.html
  */
 
+#include "e_os.h"
 #include <string.h>
 #include <stdio.h>
 #include "crypto/ctype.h"
 #include <openssl/ebcdic.h>
-
 #include <openssl/crypto.h>
 #include "internal/core.h"
 #include "internal/thread_once.h"
-#include "e_os.h"
 #ifndef OPENSSL_NO_LOCALE
 # include <locale.h>
 # ifdef OPENSSL_SYS_MACOSX

--- a/crypto/evp/evp_lib.c
+++ b/crypto/evp/evp_lib.c
@@ -1172,8 +1172,6 @@ EVP_PKEY *EVP_PKEY_Q_keygen(OSSL_LIB_CTX *libctx, const char *propq,
 
     va_start(args, type);
 
-    OPENSSL_init_crypto(OPENSSL_INIT_BASE_ONLY, NULL);
-
     if (OPENSSL_strcasecmp(type, "RSA") == 0) {
         bits = va_arg(args, size_t);
         params[0] = OSSL_PARAM_construct_size_t(OSSL_PKEY_PARAM_RSA_BITS, &bits);

--- a/crypto/evp/pmeth_lib.c
+++ b/crypto/evp/pmeth_lib.c
@@ -27,7 +27,6 @@
 #ifndef FIPS_MODULE
 # include "crypto/asn1.h"
 #endif
-#include "crypto/ctype.h"
 #include "crypto/evp.h"
 #include "crypto/dh.h"
 #include "crypto/ec.h"
@@ -200,7 +199,6 @@ static EVP_PKEY_CTX *int_ctx_new(OSSL_LIB_CTX *libctx,
             }
 #ifndef FIPS_MODULE
             if (keytype != NULL) {
-                ossl_init_casecmp();
                 id = evp_pkey_name2type(keytype);
                 if (id == NID_undef)
                     id = -1;

--- a/crypto/init.c
+++ b/crypto/init.c
@@ -458,9 +458,6 @@ int OPENSSL_init_crypto(uint64_t opts, const OPENSSL_INIT_SETTINGS *settings)
     uint64_t tmp;
     int aloaddone = 0;
 
-    if (!ossl_init_casecmp())
-        return 0;
-
    /* Applications depend on 0 being returned when cleanup was already done */
     if (stopped) {
         if (!(opts & OPENSSL_INIT_BASE_ONLY))
@@ -486,6 +483,9 @@ int OPENSSL_init_crypto(uint64_t opts, const OPENSSL_INIT_SETTINGS *settings)
             return 1;
         aloaddone = 1;
     }
+
+    if (!ossl_init_casecmp())
+        return 0;
 
     /*
      * At some point we should look at this function with a view to moving

--- a/crypto/o_str.c
+++ b/crypto/o_str.c
@@ -349,8 +349,8 @@ int openssl_strerror_r(int errnum, char *buf, size_t buflen)
 #ifndef OPENSSL_NO_LOCALE
 static locale_t loc;
 
-static void *ossl_c_locale(void) {
-    return (void *)loc;
+static locale_t ossl_c_locale(void) {
+    return loc;
 }
 
 int ossl_init_casecmp_int(void) {
@@ -359,21 +359,32 @@ int ossl_init_casecmp_int(void) {
 # else
     loc = newlocale(LC_COLLATE_MASK, "C", (locale_t) 0);
 # endif
-    return (loc == (locale_t) 0) ? 0 : 1;
+    return (loc == (locale_t)0) ? 0 : 1;
 }
 
 void ossl_deinit_casecmp(void) {
     freelocale(loc);
+    loc = (locale_t)0;
 }
 
 int OPENSSL_strcasecmp(const char *s1, const char *s2)
 {
-    return strcasecmp_l(s1, s2, (locale_t)ossl_c_locale());
+    locale_t l = ossl_c_locale();
+
+    /* Fallback in case of locale initialization failure */
+    if (l == (locale_t)0)
+        return strcasecmp(s1, s2);
+    return strcasecmp_l(s1, s2, l);
 }
 
 int OPENSSL_strncasecmp(const char *s1, const char *s2, size_t n)
 {
-    return strncasecmp_l(s1, s2, n, (locale_t)ossl_c_locale());
+    locale_t l = ossl_c_locale();
+
+    /* Fallback in case of locale initialization failure */
+    if (l == (locale_t)0)
+        return strncasecmp(s1, s2, n);
+    return strncasecmp_l(s1, s2, n, l);
 }
 #else
 int ossl_init_casecmp_int(void) {

--- a/crypto/o_str.c
+++ b/crypto/o_str.c
@@ -18,7 +18,6 @@
 #endif
 #include <openssl/crypto.h>
 #include "internal/cryptlib.h"
-#include "internal/core.h"
 
 #define DEFAULT_SEPARATOR ':'
 #define CH_ZERO '\0'
@@ -348,15 +347,13 @@ int openssl_strerror_r(int errnum, char *buf, size_t buflen)
 }
 
 #ifndef OPENSSL_NO_LOCALE
-# ifndef FIPS_MODULE
 static locale_t loc;
 
-
-void *ossl_c_locale() {
+static void *ossl_c_locale(void) {
     return (void *)loc;
 }
 
-int ossl_init_casecmp_int() {
+int ossl_init_casecmp_int(void) {
 # ifdef OPENSSL_SYS_WINDOWS
     loc = _create_locale(LC_COLLATE, "C");
 # else
@@ -365,10 +362,9 @@ int ossl_init_casecmp_int() {
     return (loc == (locale_t) 0) ? 0 : 1;
 }
 
-void ossl_deinit_casecmp() {
+void ossl_deinit_casecmp(void) {
     freelocale(loc);
 }
-# endif
 
 int OPENSSL_strcasecmp(const char *s1, const char *s2)
 {
@@ -380,17 +376,11 @@ int OPENSSL_strncasecmp(const char *s1, const char *s2, size_t n)
     return strncasecmp_l(s1, s2, n, (locale_t)ossl_c_locale());
 }
 #else
-# ifndef FIPS_MODULE
-void *ossl_c_locale() {
-    return NULL;
-}
-# endif
-
-int ossl_init_casecmp_int() {
+int ossl_init_casecmp_int(void) {
     return 1;
 }
 
-void ossl_deinit_casecmp() {
+void ossl_deinit_casecmp(void) {
 }
 
 int OPENSSL_strcasecmp(const char *s1, const char *s2)

--- a/crypto/o_str.c
+++ b/crypto/o_str.c
@@ -18,6 +18,7 @@
 #endif
 #include <openssl/crypto.h>
 #include "internal/cryptlib.h"
+#include "internal/thread_once.h"
 
 #define DEFAULT_SEPARATOR ':'
 #define CH_ZERO '\0'
@@ -347,13 +348,36 @@ int openssl_strerror_r(int errnum, char *buf, size_t buflen)
 }
 
 #ifndef OPENSSL_NO_LOCALE
+# ifndef FIPS_MODULE
+static CRYPTO_ONCE casecmp = CRYPTO_ONCE_STATIC_INIT;
+DEFINE_RUN_ONCE_STATIC(init_casecmp)
+{
+    int ret = ossl_init_casecmp_int();
+
+    return ret;
+}
+
+int ossl_init_casecmp(void)
+{
+    if (!RUN_ONCE(&casecmp, init_casecmp))
+        return 0;
+    return 1;
+}
+# endif
+
 static locale_t loc;
 
-static locale_t ossl_c_locale(void) {
+static locale_t ossl_c_locale(void)
+{
+# ifndef FIPS_MODULE
+    if (!ossl_init_casecmp())
+        return (locale_t)0;
+# endif
     return loc;
 }
 
-int ossl_init_casecmp_int(void) {
+int ossl_init_casecmp_int(void)
+{
 # ifdef OPENSSL_SYS_WINDOWS
     loc = _create_locale(LC_COLLATE, "C");
 # else
@@ -362,9 +386,12 @@ int ossl_init_casecmp_int(void) {
     return (loc == (locale_t)0) ? 0 : 1;
 }
 
-void ossl_deinit_casecmp(void) {
-    freelocale(loc);
-    loc = (locale_t)0;
+void ossl_deinit_casecmp(void)
+{
+    if (loc != (locale_t)0) {
+        freelocale(loc);
+        loc = (locale_t)0;
+    }
 }
 
 int OPENSSL_strcasecmp(const char *s1, const char *s2)
@@ -387,11 +414,18 @@ int OPENSSL_strncasecmp(const char *s1, const char *s2, size_t n)
     return strncasecmp_l(s1, s2, n, l);
 }
 #else
-int ossl_init_casecmp_int(void) {
+int ossl_init_casecmp(void)
+{
     return 1;
 }
 
-void ossl_deinit_casecmp(void) {
+int ossl_init_casecmp_int(void)
+{
+    return 1;
+}
+
+void ossl_deinit_casecmp(void)
+{
 }
 
 int OPENSSL_strcasecmp(const char *s1, const char *s2)

--- a/e_os.h
+++ b/e_os.h
@@ -421,6 +421,7 @@ inline int nssgetpid();
 #  define strcasecmp_l _stricmp_l
 #  define strncasecmp_l _strnicmp_l
 #  define strcasecmp _stricmp
+#  define strncasecmp _strnicmp
 # elif !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE < 200809L \
      || defined(OPENSSL_SYS_TANDEM)
 #  ifndef OPENSSL_NO_LOCALE

--- a/e_os.h
+++ b/e_os.h
@@ -409,4 +409,23 @@ inline int nssgetpid();
 #   endif
 # endif
 
+/*
+ * str[n]casecmp_l is defined in POSIX 2008-01. Value is taken accordingly
+ * https://www.gnu.org/software/libc/manual/html_node/Feature-Test-Macros.html
+ * There are also equivalent functions on Windows.
+ * There is no locale_t on NONSTOP.
+ */
+# if defined(OPENSSL_SYS_WINDOWS)
+#  define locale_t _locale_t
+#  define freelocale _free_locale
+#  define strcasecmp_l _stricmp_l
+#  define strncasecmp_l _strnicmp_l
+#  define strcasecmp _stricmp
+# elif !defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE < 200809L \
+     || defined(OPENSSL_SYS_TANDEM)
+#  ifndef OPENSSL_NO_LOCALE
+#   define OPENSSL_NO_LOCALE
+#  endif
+# endif
+
 #endif

--- a/include/crypto/ctype.h
+++ b/include/crypto/ctype.h
@@ -79,7 +79,4 @@ int ossl_ascii_isdigit(const char inchar);
 # define ossl_isxdigit(c)       (ossl_ctype_check((c), CTYPE_MASK_xdigit))
 # define ossl_isbase64(c)       (ossl_ctype_check((c), CTYPE_MASK_base64))
 # define ossl_isasn1print(c)    (ossl_ctype_check((c), CTYPE_MASK_asn1print))
-
-int ossl_init_casecmp(void);
-void ossl_deinit_casecmp(void);
 #endif

--- a/include/internal/core.h
+++ b/include/internal/core.h
@@ -62,7 +62,4 @@ __owur int ossl_lib_ctx_write_lock(OSSL_LIB_CTX *ctx);
 __owur int ossl_lib_ctx_read_lock(OSSL_LIB_CTX *ctx);
 int ossl_lib_ctx_unlock(OSSL_LIB_CTX *ctx);
 int ossl_lib_ctx_is_child(OSSL_LIB_CTX *ctx);
-
-void *ossl_c_locale(void);
-
 #endif

--- a/include/internal/cryptlib.h
+++ b/include/internal/cryptlib.h
@@ -258,4 +258,6 @@ static ossl_inline int ossl_is_absolute_path(const char *path)
     return path[0] == '/';
 }
 
+int ossl_init_casecmp_int(void);
+void ossl_deinit_casecmp(void);
 #endif

--- a/include/internal/cryptlib.h
+++ b/include/internal/cryptlib.h
@@ -259,5 +259,6 @@ static ossl_inline int ossl_is_absolute_path(const char *path)
 }
 
 int ossl_init_casecmp_int(void);
+int ossl_init_casecmp(void);
 void ossl_deinit_casecmp(void);
 #endif

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -23,7 +23,6 @@
 #include "prov/seeding.h"
 #include "self_test.h"
 #include "internal/core.h"
-#include "e_os.h"
 
 static const char FIPS_DEFAULT_PROPERTIES[] = "provider=fips,fips=yes";
 static const char FIPS_UNAPPROVED_PROPERTIES[] = "provider=fips,fips=no";

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -37,18 +37,6 @@ static OSSL_FUNC_provider_gettable_params_fn fips_gettable_params;
 static OSSL_FUNC_provider_get_params_fn fips_get_params;
 static OSSL_FUNC_provider_query_operation_fn fips_query;
 
-/* Locale object accessor functions */
-#ifndef OPENSSL_NO_LOCALE
-# include <locale.h>
-# ifdef OPENSSL_SYS_MACOSX
-#  include <xlocale.h>
-# endif
-static locale_t loc;
-#endif
-
-static int fips_init_casecmp(void);
-static void fips_deinit_casecmp(void);
-
 #define ALGC(NAMES, FUNC, CHECK) { { NAMES, FIPS_DEFAULT_PROPERTIES, FUNC }, CHECK }
 #define ALG(NAMES, FUNC) ALGC(NAMES, FUNC, NULL)
 
@@ -500,40 +488,11 @@ static const OSSL_ALGORITHM *fips_query(void *provctx, int operation_id,
     return NULL;
 }
 
-# ifndef OPENSSL_NO_LOCALE
-void *ossl_c_locale() {
-    return (void *)loc;
-}
-
-static int fips_init_casecmp(void) {
-#  ifdef OPENSSL_SYS_WINDOWS
-    loc = _create_locale(LC_COLLATE, "C");
-#  else
-    loc = newlocale(LC_COLLATE_MASK, "C", (locale_t) 0);
-#  endif
-    return (loc == (locale_t) 0) ? 0 : 1;
-}
-
-static void fips_deinit_casecmp(void) {
-    freelocale(loc);
-}
-# else
-void *ossl_c_locale() {
-    return NULL;
-}
-
-static int fips_init_casecmp(void) {
-    return 1;
-}
-
-static void fips_deinit_casecmp(void) {
-}
-# endif
-
 static void fips_teardown(void *provctx)
 {
     OSSL_LIB_CTX_free(PROV_LIBCTX_OF(provctx));
     ossl_prov_ctx_free(provctx);
+    ossl_deinit_casecmp();
 }
 
 static void fips_intern_teardown(void *provctx)
@@ -542,7 +501,6 @@ static void fips_intern_teardown(void *provctx)
      * We know that the library context is the same as for the outer provider,
      * so no need to destroy it here.
      */
-    fips_deinit_casecmp();
     ossl_prov_ctx_free(provctx);
 }
 
@@ -592,10 +550,10 @@ int OSSL_provider_init_int(const OSSL_CORE_HANDLE *handle,
 
     memset(&selftest_params, 0, sizeof(selftest_params));
 
-    if (!fips_init_casecmp())
+    if (!ossl_init_casecmp_int())
         return 0;
     if (!ossl_prov_seeding_from_dispatch(in))
-        return 0;
+        goto err;
     for (; in->function_id != 0; in++) {
         /*
          * We do not support the scenario of an application linked against

--- a/test/localetest.c
+++ b/test/localetest.c
@@ -7,15 +7,14 @@
  * https://www.openssl.org/source/license.html
  */
 
+#include "../e_os.h"
 #include <stdio.h>
 #include <string.h>
+#include <stdlib.h>
 #include <openssl/x509.h>
 #include "testutil.h"
 #include "testutil/output.h"
 
-#include <stdio.h>
-#include <stdlib.h>
-#include "../e_os.h"
 #ifndef OPENSSL_NO_LOCALE
 # include <locale.h>
 # ifdef OPENSSL_SYS_MACOSX

--- a/test/localetest.c
+++ b/test/localetest.c
@@ -1,3 +1,11 @@
+/*
+ * Copyright 2022 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
 
 #include <stdio.h>
 #include <string.h>
@@ -7,12 +15,12 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <locale.h>
-#ifdef OPENSSL_SYS_WINDOWS
-# define strcasecmp _stricmp
-#else
-# include <strings.h>
-#endif
+#include "../e_os.h"
+#ifndef OPENSSL_NO_LOCALE
+# include <locale.h>
+# ifdef OPENSSL_SYS_MACOSX
+#  include <xlocale.h>
+# endif
 
 int setup_tests(void)
 {
@@ -118,7 +126,12 @@ int setup_tests(void)
     X509_free(cert);
     return 1;
 }
-
+#else
+int setup_tests(void)
+{
+    return TEST_skip("Locale support not available");
+}
+#endif /* OPENSSL_NO_LOCALE */
 void cleanup_tests(void)
 {
 }


### PR DESCRIPTION
This is just a backport of #18282 for the 3.0 branch.

This PR encompasses cleanups, build, and initialization fixes for the OPENSSL_strcasecmp related fix.

I recommend reviewing by individual commits.

It incorporates the PR from #18241.
