### PR TITLE
mdl: Don't enforce one space after list markers

### DIFF
--- a/util/markdownlint.rb
+++ b/util/markdownlint.rb
@@ -21,3 +21,4 @@ exclude_rule 'MD024' # Multiple headers with the same content
 exclude_rule 'MD025' # Multiple top level headers in the same document
 exclude_rule 'MD026' # Trailing punctuation in header
 exclude_rule 'MD029' # Ordered list item prefix
+exclude_rule 'MD030' # Spaces after list markers (default: 1!)


### PR DESCRIPTION
Common markdown styles usually show 4-column indents to separate the
list marker and the list item text.  That's a common template for
writing new markdown files.

On the other hand, we do have some files (such as CHANGES.md) where we
use a different style.

From a markdown perspective, both are perfectly OK, and there's no
reason to enforce either.

Therefore, the best thing is to exclude this particular rule.
