### PR TITLE
Remove duplicated BIO_get_ktls_send calls in do_ssl3_write

### DIFF
--- a/ssl/record/ssl3_record.c
+++ b/ssl/record/ssl3_record.c
@@ -217,7 +217,7 @@ int ssl3_get_record(SSL *s)
                                num_recs == 0 ? 1 : 0, &n);
             if (rret <= 0) {
 #ifndef OPENSSL_NO_KTLS
-                if (!BIO_get_ktls_recv(s->rbio) || rret == 0)
+                if (!using_ktls || rret == 0)
                     return rret;     /* error or non-blocking */
                 switch (errno) {
                 case EBADMSG:


### PR DESCRIPTION
This rather long function used to call BIO_get_ktls_send
mutliple times, although that result cannot change during
the execution of that function.
There was a similar unnecessary call to BIO_get_ktls_recv
in ssl3_get_record.
And while I'm already there, rewrite ssl3_write_bytes
to use BIO_get_ktls_send as a boolean (so using "!" instead
of "== 0").

This is just a re-factoring change, and is expected to allow
some additional compiler optimizations.