### PR TITLE
Add AES implementation in RISC-V 32 Zkn asm

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -811,12 +811,18 @@ my %targets = (
         multilib         => "64",
     },
 
-    # riscv64 below refers to contemporary RISCV Architecture
+    # riscv below refers to contemporary RISCV Architecture
     # specifications,
     "linux64-riscv64" => {
         inherit_from     => [ "linux-generic64"],
         perlasm_scheme   => "linux64",
         asm_arch         => 'riscv64',
+    },
+
+    "linux32-riscv32" => {
+        inherit_from     => [ "linux-generic32"],
+        perlasm_scheme   => "linux32",
+        asm_arch         => 'riscv32',
     },
 
     # loongarch64 below refers to contemporary LOONGARCH Architecture
@@ -1103,12 +1109,18 @@ my %targets = (
         perlasm_scheme   => "linux64le",
     },
 
-    # riscv64 below refers to contemporary RISCV Architecture
+    # riscv below refers to contemporary RISCV Architecture
     # specifications,
     "BSD-riscv64" => {
         inherit_from     => [ "BSD-generic64"],
         perlasm_scheme   => "linux64",
         asm_arch         => 'riscv64',
+    },
+
+    "BSD-riscv32" => {
+        inherit_from     => [ "BSD-generic32"],
+        perlasm_scheme   => "linux32",
+        asm_arch         => 'riscv32',
     },
 
     "BSD-armv4" => {

--- a/crypto/aes/asm/aes-riscv32-zkn.pl
+++ b/crypto/aes/asm/aes-riscv32-zkn.pl
@@ -1,0 +1,1061 @@
+#! /usr/bin/env perl
+# Copyright 2022 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+# $output is the last argument if it looks like a file (it has an extension)
+# $flavour is the first argument if it doesn't look like a file
+$output = $#ARGV >= 0 && $ARGV[$#ARGV] =~ m|\.\w+$| ? pop : undef;
+$flavour = $#ARGV >= 0 && $ARGV[0] !~ m|\.| ? shift : undef;
+
+$output and open STDOUT,">$output";
+
+################################################################################
+# Utility functions to help with keeping track of which registers to stack/
+# unstack when entering / exiting routines.
+################################################################################
+{
+    # Callee-saved registers
+    my @callee_saved = map("x$_",(2,8,9,18..27));
+    # Caller-saved registers
+    my @caller_saved = map("x$_",(1,5..7,10..17,28..31));
+    my @must_save;
+    sub use_reg {
+        my $reg = shift;
+        if (grep(/^$reg$/, @callee_saved)) {
+            push(@must_save, $reg);
+        } elsif (!grep(/^$reg$/, @caller_saved)) {
+            # Register is not usable!
+            die("Unusable register ".$reg);
+        }
+        return $reg;
+    }
+    sub use_regs {
+        return map(use_reg("x$_"), @_);
+    }
+    sub save_regs {
+        my $ret = '';
+        my $stack_reservation = ($#must_save + 1) * 8;
+        my $stack_offset = $stack_reservation;
+        if ($stack_reservation % 16) {
+            $stack_reservation += 8;
+        }
+        $ret.="    addi    sp,sp,-$stack_reservation\n";
+        foreach (@must_save) {
+            $stack_offset -= 8;
+            $ret.="    sw      $_,$stack_offset(sp)\n";
+        }
+        return $ret;
+    }
+    sub load_regs {
+        my $ret = '';
+        my $stack_reservation = ($#must_save + 1) * 8;
+        my $stack_offset = $stack_reservation;
+        if ($stack_reservation % 16) {
+            $stack_reservation += 8;
+        }
+        foreach (@must_save) {
+            $stack_offset -= 8;
+            $ret.="    lw      $_,$stack_offset(sp)\n";
+        }
+        $ret.="    addi    sp,sp,$stack_reservation\n";
+        return $ret;
+    }
+    sub clear_regs {
+        @must_save = ();
+    }
+}
+
+################################################################################
+# util for encoding scalar crypto extension instructions
+################################################################################
+
+my @regs = map("x$_",(0..31));
+my %reglookup;
+@reglookup{@regs} = @regs;
+
+# Takes a register name, possibly an alias, and converts it to a register index
+# from 0 to 31
+sub read_reg {
+    my $reg = lc shift;
+    if (!exists($reglookup{$reg})) {
+        die("Unknown register ".$reg);
+    }
+    my $regstr = $reglookup{$reg};
+    if (!($regstr =~ /^x([0-9]+)$/)) {
+        die("Could not process register ".$reg);
+    }
+    return $1;
+}
+
+sub aes32dsi {
+    # Encoding for aes32dsi rd, rs1, rs2, bs instruction on RV32
+    #                bs_XXXXX_ rs2 _ rs1 _XXX_ rd  _XXXXXXX
+    my $template = 0b00_10101_00000_00000_000_00000_0110011;
+    my $rd = read_reg shift;
+    my $rs1 = read_reg shift;
+    my $rs2 = read_reg shift;
+    my $bs = shift;
+
+    return ".word ".($template | ($bs << 30) | ($rs2 << 20) | ($rs1 << 15) | ($rd << 7));
+}
+
+sub aes32dsmi {
+    # Encoding for aes32dsmi rd, rs1, rs2, bs instruction on RV32
+    #                bs_XXXXX_ rs2 _ rs1 _XXX_ rd  _XXXXXXX
+    my $template = 0b00_10111_00000_00000_000_00000_0110011;
+    my $rd = read_reg shift;
+    my $rs1 = read_reg shift;
+    my $rs2 = read_reg shift;
+    my $bs = shift;
+
+    return ".word ".($template | ($bs << 30) | ($rs2 << 20) | ($rs1 << 15) | ($rd << 7));
+}
+
+sub aes32esi {
+    # Encoding for aes32esi rd, rs1, rs2, bs instruction on RV32
+    #                bs_XXXXX_ rs2 _ rs1 _XXX_ rd  _XXXXXXX
+    my $template = 0b00_10001_00000_00000_000_00000_0110011;
+    my $rd = read_reg shift;
+    my $rs1 = read_reg shift;
+    my $rs2 = read_reg shift;
+    my $bs = shift;
+
+    return ".word ".($template | ($bs << 30) | ($rs2 << 20) | ($rs1 << 15) | ($rd << 7));
+}
+
+sub aes32esmi {
+    # Encoding for aes32esmi rd, rs1, rs2, bs instruction on RV32
+    #                bs_XXXXX_ rs2 _ rs1 _XXX_ rd  _XXXXXXX
+    my $template = 0b00_10011_00000_00000_000_00000_0110011;
+    my $rd = read_reg shift;
+    my $rs1 = read_reg shift;
+    my $rs2 = read_reg shift;
+    my $bs = shift;
+
+    return ".word ".($template | ($bs << 30) | ($rs2 << 20) | ($rs1 << 15) | ($rd << 7));
+}
+
+sub rori {
+    # Encoding for ror rd, rs1, imm instruction on RV64
+    #                XXXXXXX_shamt_ rs1 _XXX_ rd  _XXXXXXX
+    my $template = 0b0110000_00000_00000_101_00000_0010011;
+    my $rd = read_reg shift;
+    my $rs1 = read_reg shift;
+    my $shamt = shift;
+
+    return ".word ".($template | ($shamt << 20) | ($rs1 << 15) | ($rd << 7));
+}
+
+################################################################################
+# Register assignment for rv32i_zkne_encrypt and rv32i_zknd_decrypt
+################################################################################
+
+# Registers initially to hold AES state (called s0-s3 or y0-y3 elsewhere)
+my ($Q0,$Q1,$Q2,$Q3) = use_regs(6..9);
+
+# Function arguments (x10-x12 are a0-a2 in the ABI)
+# Input block pointer, output block pointer, key pointer
+my ($INP,$OUTP,$KEYP) = use_regs(10..12);
+
+# Registers initially to hold Key
+my ($T0,$T1,$T2,$T3) = use_regs(13..16);
+
+# Loop counter
+my ($loopcntr) = use_regs(30);
+
+################################################################################
+# Utility for rv32i_zkne_encrypt and rv32i_zknd_decrypt
+################################################################################
+
+# outer product of whole state into one column of key
+sub outer {
+    my $inst = shift;
+    my $key = shift;
+    # state 0 to 3
+    my $s0 = shift;
+    my $s1 = shift;
+    my $s2 = shift;
+    my $s3 = shift;
+    my $ret = '';
+$ret .= <<___;
+    @{[$inst->($key,$key,$s0,0)]}
+    @{[$inst->($key,$key,$s1,1)]}
+    @{[$inst->($key,$key,$s2,2)]}
+    @{[$inst->($key,$key,$s3,3)]}
+___
+    return $ret;
+}
+
+sub aes32esmi4 {
+    return outer(\&aes32esmi, @_)
+}
+
+sub aes32esi4 {
+    return outer(\&aes32esi, @_)
+}
+
+sub aes32dsmi4 {
+    return outer(\&aes32dsmi, @_)
+}
+
+sub aes32dsi4 {
+    return outer(\&aes32dsi, @_)
+}
+
+################################################################################
+# void rv32i_zkne_encrypt(const unsigned char *in, unsigned char *out,
+#   const AES_KEY *key);
+################################################################################
+my $code .= <<___;
+.text
+.balign 16
+.globl rv32i_zkne_encrypt
+.type   rv32i_zkne_encrypt,\@function
+rv32i_zkne_encrypt:
+___
+
+$code .= save_regs();
+
+$code .= <<___;
+    # Load input to block cipher
+    lw      $Q0,0($INP)
+    lw      $Q1,4($INP)
+    lw      $Q2,8($INP)
+    lw      $Q3,12($INP)
+
+    # Load key
+    lw      $T0,0($KEYP)
+    lw      $T1,4($KEYP)
+    lw      $T2,8($KEYP)
+    lw      $T3,12($KEYP)
+
+    # Load number of rounds
+    lw      $loopcntr,240($KEYP)
+
+    # initial transformation
+    xor     $Q0,$Q0,$T0
+    xor     $Q1,$Q1,$T1
+    xor     $Q2,$Q2,$T2
+    xor     $Q3,$Q3,$T3
+
+    # The main loop only executes the first N-2 rounds, each loop consumes two rounds
+    add     $loopcntr,$loopcntr,-2
+    srli    $loopcntr,$loopcntr,1
+1:
+    # Grab next key in schedule
+    add     $KEYP,$KEYP,16
+    lw      $T0,0($KEYP)
+    lw      $T1,4($KEYP)
+    lw      $T2,8($KEYP)
+    lw      $T3,12($KEYP)
+
+    @{[aes32esmi4 $T0,$Q0,$Q1,$Q2,$Q3]}
+    @{[aes32esmi4 $T1,$Q1,$Q2,$Q3,$Q0]}
+    @{[aes32esmi4 $T2,$Q2,$Q3,$Q0,$Q1]}
+    @{[aes32esmi4 $T3,$Q3,$Q0,$Q1,$Q2]}
+    # now T0~T3 hold the new state
+
+    # Grab next key in schedule
+    add     $KEYP,$KEYP,16
+    lw      $Q0,0($KEYP)
+    lw      $Q1,4($KEYP)
+    lw      $Q2,8($KEYP)
+    lw      $Q3,12($KEYP)
+
+    @{[aes32esmi4 $Q0,$T0,$T1,$T2,$T3]}
+    @{[aes32esmi4 $Q1,$T1,$T2,$T3,$T0]}
+    @{[aes32esmi4 $Q2,$T2,$T3,$T0,$T1]}
+    @{[aes32esmi4 $Q3,$T3,$T0,$T1,$T2]}
+    # now Q0~Q3 hold the new state
+
+    add     $loopcntr,$loopcntr,-1
+    bgtz    $loopcntr,1b
+
+# final two rounds
+    # Grab next key in schedule
+    add     $KEYP,$KEYP,16
+    lw      $T0,0($KEYP)
+    lw      $T1,4($KEYP)
+    lw      $T2,8($KEYP)
+    lw      $T3,12($KEYP)
+
+    @{[aes32esmi4 $T0,$Q0,$Q1,$Q2,$Q3]}
+    @{[aes32esmi4 $T1,$Q1,$Q2,$Q3,$Q0]}
+    @{[aes32esmi4 $T2,$Q2,$Q3,$Q0,$Q1]}
+    @{[aes32esmi4 $T3,$Q3,$Q0,$Q1,$Q2]}
+    # now T0~T3 hold the new state
+
+    # Grab next key in schedule
+    add     $KEYP,$KEYP,16
+    lw      $Q0,0($KEYP)
+    lw      $Q1,4($KEYP)
+    lw      $Q2,8($KEYP)
+    lw      $Q3,12($KEYP)
+
+    # no mix column now
+    @{[aes32esi4 $Q0,$T0,$T1,$T2,$T3]}
+    @{[aes32esi4 $Q1,$T1,$T2,$T3,$T0]}
+    @{[aes32esi4 $Q2,$T2,$T3,$T0,$T1]}
+    @{[aes32esi4 $Q3,$T3,$T0,$T1,$T2]}
+    # now Q0~Q3 hold the new state
+
+    sw      $Q0,0($OUTP)
+    sw      $Q1,4($OUTP)
+    sw      $Q2,8($OUTP)
+    sw      $Q3,12($OUTP)
+
+    # Pop registers and return
+___
+
+$code .= load_regs();
+
+$code .= <<___;
+    ret
+___
+
+################################################################################
+# void rv32i_zknd_decrypt(const unsigned char *in, unsigned char *out,
+#   const AES_KEY *key);
+################################################################################
+$code .= <<___;
+.text
+.balign 16
+.globl rv32i_zknd_decrypt
+.type   rv32i_zknd_decrypt,\@function
+rv32i_zknd_decrypt:
+___
+
+$code .= save_regs();
+
+$code .= <<___;
+    # Load input to block cipher
+    lw      $Q0,0($INP)
+    lw      $Q1,4($INP)
+    lw      $Q2,8($INP)
+    lw      $Q3,12($INP)
+
+    # Load number of rounds
+    lw      $loopcntr,240($KEYP)
+
+    # Load the last key
+    # use T0 as temporary now
+    slli    $T0,$loopcntr,4
+    add     $KEYP,$KEYP,$T0
+    # Load key
+    lw      $T0,0($KEYP)
+    lw      $T1,4($KEYP)
+    lw      $T2,8($KEYP)
+    lw      $T3,12($KEYP)
+
+    # initial transformation
+    xor     $Q0,$Q0,$T0
+    xor     $Q1,$Q1,$T1
+    xor     $Q2,$Q2,$T2
+    xor     $Q3,$Q3,$T3
+
+    # The main loop only executes the first N-2 rounds, each loop consumes two rounds
+    add     $loopcntr,$loopcntr,-2
+    srli    $loopcntr,$loopcntr,1
+1:
+    # Grab next key in schedule
+    add     $KEYP,$KEYP,-16
+    lw      $T0,0($KEYP)
+    lw      $T1,4($KEYP)
+    lw      $T2,8($KEYP)
+    lw      $T3,12($KEYP)
+
+    @{[aes32dsmi4 $T0,$Q0,$Q3,$Q2,$Q1]}
+    @{[aes32dsmi4 $T1,$Q1,$Q0,$Q3,$Q2]}
+    @{[aes32dsmi4 $T2,$Q2,$Q1,$Q0,$Q3]}
+    @{[aes32dsmi4 $T3,$Q3,$Q2,$Q1,$Q0]}
+    # now T0~T3 hold the new state
+
+    # Grab next key in schedule
+    add     $KEYP,$KEYP,-16
+    lw      $Q0,0($KEYP)
+    lw      $Q1,4($KEYP)
+    lw      $Q2,8($KEYP)
+    lw      $Q3,12($KEYP)
+
+    @{[aes32dsmi4 $Q0,$T0,$T3,$T2,$T1]}
+    @{[aes32dsmi4 $Q1,$T1,$T0,$T3,$T2]}
+    @{[aes32dsmi4 $Q2,$T2,$T1,$T0,$T3]}
+    @{[aes32dsmi4 $Q3,$T3,$T2,$T1,$T0]}
+    # now Q0~Q3 hold the new state
+
+    add     $loopcntr,$loopcntr,-1
+    bgtz    $loopcntr,1b
+
+# final two rounds
+    # Grab next key in schedule
+    add     $KEYP,$KEYP,-16
+    lw      $T0,0($KEYP)
+    lw      $T1,4($KEYP)
+    lw      $T2,8($KEYP)
+    lw      $T3,12($KEYP)
+
+    @{[aes32dsmi4 $T0,$Q0,$Q3,$Q2,$Q1]}
+    @{[aes32dsmi4 $T1,$Q1,$Q0,$Q3,$Q2]}
+    @{[aes32dsmi4 $T2,$Q2,$Q1,$Q0,$Q3]}
+    @{[aes32dsmi4 $T3,$Q3,$Q2,$Q1,$Q0]}
+    # now T0~T3 hold the new state
+
+    # Grab next key in schedule
+    add     $KEYP,$KEYP,-16
+    lw      $Q0,0($KEYP)
+    lw      $Q1,4($KEYP)
+    lw      $Q2,8($KEYP)
+    lw      $Q3,12($KEYP)
+
+    # no mix column now
+    @{[aes32dsi4 $Q0,$T0,$T3,$T2,$T1]}
+    @{[aes32dsi4 $Q1,$T1,$T0,$T3,$T2]}
+    @{[aes32dsi4 $Q2,$T2,$T1,$T0,$T3]}
+    @{[aes32dsi4 $Q3,$T3,$T2,$T1,$T0]}
+    # now Q0~Q3 hold the new state
+
+    sw      $Q0,0($OUTP)
+    sw      $Q1,4($OUTP)
+    sw      $Q2,8($OUTP)
+    sw      $Q3,12($OUTP)
+
+    # Pop registers and return
+___
+
+$code .= load_regs();
+
+$code .= <<___;
+    ret
+___
+
+clear_regs();
+
+################################################################################
+# Register assignment for rv32i_zkn[e/d]_set_[en/de]crypt
+################################################################################
+
+# Function arguments (x10-x12 are a0-a2 in the ABI)
+# Pointer to user key, number of bits in key, key pointer
+my ($UKEY,$BITS,$KEYP) = use_regs(10..12);
+
+# Temporaries
+my ($T0,$T1,$T2,$T3,$T4,$T5,$T6,$T7,$T8) = use_regs(13..17,28..31);
+
+################################################################################
+# utility functions for rv32i_zkne_set_encrypt_key
+################################################################################
+
+my @rcon = (0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80, 0x1b, 0x36);
+
+# do 4 sbox on 4 bytes of rs, (possibly mix), then xor with rd
+sub sbox4 {
+    my $inst = shift;
+    my $rd = shift;
+    my $rs = shift;
+    my $ret = <<___;
+    @{[$inst->($rd,$rd,$rs,0)]}
+    @{[$inst->($rd,$rd,$rs,1)]}
+    @{[$inst->($rd,$rd,$rs,2)]}
+    @{[$inst->($rd,$rd,$rs,3)]}
+___
+    return $ret;
+}
+
+sub fwdsbox4 {
+    return sbox4(\&aes32esi, @_);
+}
+
+sub ke128enc {
+    my $zbkb = shift;
+    my $rnum = 0;
+    my $ret = '';
+$ret .= <<___;
+    lw      $T0,0($UKEY)
+    lw      $T1,4($UKEY)
+    lw      $T2,8($UKEY)
+    lw      $T3,12($UKEY)
+
+    sw      $T0,0($KEYP)
+    sw      $T1,4($KEYP)
+    sw      $T2,8($KEYP)
+    sw      $T3,12($KEYP)
+___
+    while($rnum < 10) {
+$ret .= <<___;
+    # use T4 to store rcon
+    li      $T4,$rcon[$rnum]
+    # as xor is associative and commutative
+    # we fist xor T0 with RCON, then use T0 to
+    # xor the result of each SBOX result of T3
+    xor     $T0,$T0,$T4
+    # use T4 to store rotated T3
+___
+        # right rotate by 8
+        if ($zbkb) {
+$ret .= <<___;
+    @{[rori    $T4,$T3,8]}
+___
+        } else {
+$ret .= <<___;
+    srli    $T4,$T3,8
+    slli    $T5,$T3,24
+    or      $T4,$T4,$T5
+___
+        }
+$ret .= <<___;
+    # update T0
+    @{[fwdsbox4 $T0,$T4]}
+
+    # update new T1~T3
+    xor     $T1,$T1,$T0
+    xor     $T2,$T2,$T1
+    xor     $T3,$T3,$T2
+
+    add     $KEYP,$KEYP,16
+    sw      $T0,0($KEYP)
+    sw      $T1,4($KEYP)
+    sw      $T2,8($KEYP)
+    sw      $T3,12($KEYP)
+___
+        $rnum++;
+    }
+    return $ret;
+}
+
+sub ke192enc {
+    my $zbkb = shift;
+    my $rnum = 0;
+    my $ret = '';
+$ret .= <<___;
+    lw      $T0,0($UKEY)
+    lw      $T1,4($UKEY)
+    lw      $T2,8($UKEY)
+    lw      $T3,12($UKEY)
+    lw      $T4,16($UKEY)
+    lw      $T5,20($UKEY)
+
+    sw      $T0,0($KEYP)
+    sw      $T1,4($KEYP)
+    sw      $T2,8($KEYP)
+    sw      $T3,12($KEYP)
+    sw      $T4,16($KEYP)
+    sw      $T5,20($KEYP)
+___
+    while($rnum < 8) {
+$ret .= <<___;
+    # see the comment in ke128enc
+    li      $T6,$rcon[$rnum]
+    xor     $T0,$T0,$T6
+___
+        # right rotate by 8
+        if ($zbkb) {
+$ret .= <<___;
+    @{[rori    $T6,$T5,8]}
+___
+        } else {
+$ret .= <<___;
+    srli    $T6,$T5,8
+    slli    $T7,$T5,24
+    or      $T6,$T6,$T7
+___
+        }
+$ret .= <<___;
+    @{[fwdsbox4 $T0,$T6]}
+    xor     $T1,$T1,$T0
+    xor     $T2,$T2,$T1
+    xor     $T3,$T3,$T2
+___
+        if ($rnum != 7) {
+        # note that (8+1)*24 = 216, (12+1)*16 = 208
+        # thus the last 8 bytes can be dropped
+$ret .= <<___;
+    xor     $T4,$T4,$T3
+    xor     $T5,$T5,$T4
+___
+        }
+$ret .= <<___;
+    add     $KEYP,$KEYP,24
+    sw      $T0,0($KEYP)
+    sw      $T1,4($KEYP)
+    sw      $T2,8($KEYP)
+    sw      $T3,12($KEYP)
+___
+        if ($rnum != 7) {
+$ret .= <<___;
+    sw      $T4,16($KEYP)
+    sw      $T5,20($KEYP)
+___
+        }
+        $rnum++;
+    }
+    return $ret;
+}
+
+sub ke256enc {
+    my $zbkb = shift;
+    my $rnum = 0;
+    my $ret = '';
+$ret .= <<___;
+    lw      $T0,0($UKEY)
+    lw      $T1,4($UKEY)
+    lw      $T2,8($UKEY)
+    lw      $T3,12($UKEY)
+    lw      $T4,16($UKEY)
+    lw      $T5,20($UKEY)
+    lw      $T6,24($UKEY)
+    lw      $T7,28($UKEY)
+
+    sw      $T0,0($KEYP)
+    sw      $T1,4($KEYP)
+    sw      $T2,8($KEYP)
+    sw      $T3,12($KEYP)
+    sw      $T4,16($KEYP)
+    sw      $T5,20($KEYP)
+    sw      $T6,24($KEYP)
+    sw      $T7,28($KEYP)
+___
+    while($rnum < 7) {
+$ret .= <<___;
+    # see the comment in ke128enc
+    li      $T8,$rcon[$rnum]
+    xor     $T0,$T0,$T8
+___
+        # right rotate by 8
+        if ($zbkb) {
+$ret .= <<___;
+    @{[rori    $T8,$T7,8]}
+___
+        } else {
+$ret .= <<___;
+    srli    $T8,$T7,8
+    slli    $BITS,$T7,24
+    or      $T8,$T8,$BITS
+___
+        }
+$ret .= <<___;
+    @{[fwdsbox4 $T0,$T8]}
+    xor     $T1,$T1,$T0
+    xor     $T2,$T2,$T1
+    xor     $T3,$T3,$T2
+
+    add     $KEYP,$KEYP,32
+    sw      $T0,0($KEYP)
+    sw      $T1,4($KEYP)
+    sw      $T2,8($KEYP)
+    sw      $T3,12($KEYP)
+___
+        if ($rnum != 6) {
+        # note that (7+1)*32 = 256, (14+1)*16 = 240
+        # thus the last 16 bytes can be dropped
+$ret .= <<___;
+    # for aes256, T3->T4 needs 4sbox but no rotate/rcon
+    @{[fwdsbox4 $T4,$T3]}
+    xor     $T5,$T5,$T4
+    xor     $T6,$T6,$T5
+    xor     $T7,$T7,$T6
+    sw      $T4,16($KEYP)
+    sw      $T5,20($KEYP)
+    sw      $T6,24($KEYP)
+    sw      $T7,28($KEYP)
+___
+        }
+        $rnum++;
+    }
+    return $ret;
+}
+
+################################################################################
+# void rv32i_zkne_set_encrypt_key(const unsigned char *userKey, const int bits,
+#   AES_KEY *key)
+################################################################################
+sub AES_set_common {
+    my ($ke128, $ke192, $ke256) = @_;
+    my $ret = '';
+$ret .= <<___;
+    bnez    $UKEY,1f        # if (!userKey || !key) return -1;
+    bnez    $KEYP,1f
+    li      a0,-1
+    ret
+1:
+    # Determine number of rounds from key size in bits
+    li      $T0,128
+    bne     $BITS,$T0,1f
+    li      $T1,10          # key->rounds = 10 if bits == 128
+    sw      $T1,240($KEYP)  # store key->rounds
+$ke128
+    j       4f
+1:
+    li      $T0,192
+    bne     $BITS,$T0,2f
+    li      $T1,12          # key->rounds = 12 if bits == 192
+    sw      $T1,240($KEYP)  # store key->rounds
+$ke192
+    j       4f
+2:
+    li      $T1,14          # key->rounds = 14 if bits == 256
+    li      $T0,256
+    beq     $BITS,$T0,3f
+    li      a0,-2           # If bits != 128, 192, or 256, return -2
+    j       5f
+3:
+    sw      $T1,240($KEYP)  # store key->rounds
+$ke256
+4:  # return 0
+    li      a0,0
+5:  # return a0
+___
+    return $ret;
+}
+$code .= <<___;
+.text
+.balign 16
+.globl rv32i_zkne_set_encrypt_key
+.type rv32i_zkne_set_encrypt_key,\@function
+rv32i_zkne_set_encrypt_key:
+___
+
+$code .= save_regs();
+$code .= AES_set_common(ke128enc(0), ke192enc(0),ke256enc(0));
+$code .= load_regs();
+$code .= <<___;
+    ret
+___
+
+################################################################################
+# void rv32i_zbkb_zkne_set_encrypt_key(const unsigned char *userKey,
+#   const int bits, AES_KEY *key)
+################################################################################
+$code .= <<___;
+.text
+.balign 16
+.globl rv32i_zbkb_zkne_set_encrypt_key
+.type rv32i_zbkb_zkne_set_encrypt_key,\@function
+rv32i_zbkb_zkne_set_encrypt_key:
+___
+
+$code .= save_regs();
+$code .= AES_set_common(ke128enc(1), ke192enc(1),ke256enc(1));
+$code .= load_regs();
+$code .= <<___;
+    ret
+___
+
+################################################################################
+# utility functions for rv32i_zknd_zkne_set_decrypt_key
+################################################################################
+
+sub invm4 {
+    # fwd sbox then inv sbox then mix column
+    # the result is only mix column
+    # this simulates aes64im T0
+    my $rd = shift;
+    my $tmp = shift;
+    my $rs = shift;
+    my $ret = <<___;
+    li      $tmp,0
+    li      $rd,0
+    @{[fwdsbox4 $tmp,$rs]}
+    @{[sbox4(\&aes32dsmi, $rd,$tmp)]}
+___
+    return $ret;
+}
+
+sub ke128dec {
+    my $zbkb = shift;
+    my $rnum = 0;
+    my $ret = '';
+$ret .= <<___;
+    lw      $T0,0($UKEY)
+    lw      $T1,4($UKEY)
+    lw      $T2,8($UKEY)
+    lw      $T3,12($UKEY)
+
+    sw      $T0,0($KEYP)
+    sw      $T1,4($KEYP)
+    sw      $T2,8($KEYP)
+    sw      $T3,12($KEYP)
+___
+    while($rnum < 10) {
+$ret .= <<___;
+    # see comments in ke128enc
+    li      $T4,$rcon[$rnum]
+    xor     $T0,$T0,$T4
+___
+        # right rotate by 8
+        if ($zbkb) {
+$ret .= <<___;
+    @{[rori    $T4,$T3,8]}
+___
+        } else {
+$ret .= <<___;
+    srli    $T4,$T3,8
+    slli    $T5,$T3,24
+    or      $T4,$T4,$T5
+___
+        }
+$ret .= <<___;
+    @{[fwdsbox4 $T0,$T4]}
+    xor     $T1,$T1,$T0
+    xor     $T2,$T2,$T1
+    xor     $T3,$T3,$T2
+    add     $KEYP,$KEYP,16
+___
+    # need to mixcolumn only for [1:N-1] round keys
+    # this is from the fact that aes32dsmi subwords first then mix column
+    # intuitively decryption needs to first mix column then subwords
+    # however, for merging datapaths (encryption first subwords then mix column)
+    # aes32dsmi chooses to inverse the order of them, thus
+    # transform should then be done on the round key
+        if ($rnum < 9) {
+$ret .= <<___;
+    # T4 and T5 are temp variables
+    @{[invm4 $T5,$T4,$T0]}
+    sw      $T5,0($KEYP)
+    @{[invm4 $T5,$T4,$T1]}
+    sw      $T5,4($KEYP)
+    @{[invm4 $T5,$T4,$T2]}
+    sw      $T5,8($KEYP)
+    @{[invm4 $T5,$T4,$T3]}
+    sw      $T5,12($KEYP)
+___
+        } else {
+$ret .= <<___;
+    sw      $T0,0($KEYP)
+    sw      $T1,4($KEYP)
+    sw      $T2,8($KEYP)
+    sw      $T3,12($KEYP)
+___
+        }
+        $rnum++;
+    }
+    return $ret;
+}
+
+sub ke192dec {
+    my $zbkb = shift;
+    my $rnum = 0;
+    my $ret = '';
+$ret .= <<___;
+    lw      $T0,0($UKEY)
+    lw      $T1,4($UKEY)
+    lw      $T2,8($UKEY)
+    lw      $T3,12($UKEY)
+    lw      $T4,16($UKEY)
+    lw      $T5,20($UKEY)
+
+    sw      $T0,0($KEYP)
+    sw      $T1,4($KEYP)
+    sw      $T2,8($KEYP)
+    sw      $T3,12($KEYP)
+    # see the comment in ke128dec
+    # T7 and T6 are temp variables
+    @{[invm4 $T7,$T6,$T4]}
+    sw      $T7,16($KEYP)
+    @{[invm4 $T7,$T6,$T5]}
+    sw      $T7,20($KEYP)
+___
+    while($rnum < 8) {
+$ret .= <<___;
+    # see the comment in ke128enc
+    li      $T6,$rcon[$rnum]
+    xor     $T0,$T0,$T6
+___
+        # right rotate by 8
+        if ($zbkb) {
+$ret .= <<___;
+    @{[rori    $T6,$T5,8]}
+___
+        } else {
+$ret .= <<___;
+    srli    $T6,$T5,8
+    slli    $T7,$T5,24
+    or      $T6,$T6,$T7
+___
+        }
+$ret .= <<___;
+    @{[fwdsbox4 $T0,$T6]}
+    xor     $T1,$T1,$T0
+    xor     $T2,$T2,$T1
+    xor     $T3,$T3,$T2
+
+    add     $KEYP,$KEYP,24
+___
+        if ($rnum < 7) {
+$ret .= <<___;
+    xor     $T4,$T4,$T3
+    xor     $T5,$T5,$T4
+
+    # see the comment in ke128dec
+    # T7 and T6 are temp variables
+    @{[invm4 $T7,$T6,$T0]}
+    sw      $T7,0($KEYP)
+    @{[invm4 $T7,$T6,$T1]}
+    sw      $T7,4($KEYP)
+    @{[invm4 $T7,$T6,$T2]}
+    sw      $T7,8($KEYP)
+    @{[invm4 $T7,$T6,$T3]}
+    sw      $T7,12($KEYP)
+    @{[invm4 $T7,$T6,$T4]}
+    sw      $T7,16($KEYP)
+    @{[invm4 $T7,$T6,$T5]}
+    sw      $T7,20($KEYP)
+___
+        } else { # rnum == 7
+$ret .= <<___;
+    # the reason for dropping T4/T5 is in ke192enc
+    # the reason for not invm4 is in ke128dec
+    sw      $T0,0($KEYP)
+    sw      $T1,4($KEYP)
+    sw      $T2,8($KEYP)
+    sw      $T3,12($KEYP)
+___
+        }
+        $rnum++;
+    }
+    return $ret;
+}
+
+sub ke256dec {
+    my $zbkb = shift;
+    my $rnum = 0;
+    my $ret = '';
+$ret .= <<___;
+    lw      $T0,0($UKEY)
+    lw      $T1,4($UKEY)
+    lw      $T2,8($UKEY)
+    lw      $T3,12($UKEY)
+    lw      $T4,16($UKEY)
+    lw      $T5,20($UKEY)
+    lw      $T6,24($UKEY)
+    lw      $T7,28($UKEY)
+
+    sw      $T0,0($KEYP)
+    sw      $T1,4($KEYP)
+    sw      $T2,8($KEYP)
+    sw      $T3,12($KEYP)
+    # see the comment in ke128dec
+    # BITS and T8 are temp variables
+    # BITS are not used anymore
+    @{[invm4 $T8,$BITS,$T4]}
+    sw      $T8,16($KEYP)
+    @{[invm4 $T8,$BITS,$T5]}
+    sw      $T8,20($KEYP)
+    @{[invm4 $T8,$BITS,$T6]}
+    sw      $T8,24($KEYP)
+    @{[invm4 $T8,$BITS,$T7]}
+    sw      $T8,28($KEYP)
+___
+    while($rnum < 7) {
+$ret .= <<___;
+    # see the comment in ke128enc
+    li      $T8,$rcon[$rnum]
+    xor     $T0,$T0,$T8
+___
+        # right rotate by 8
+        if ($zbkb) {
+$ret .= <<___;
+    @{[rori    $T8,$T7,8]}
+___
+        } else {
+$ret .= <<___;
+    srli    $T8,$T7,8
+    slli    $BITS,$T7,24
+    or      $T8,$T8,$BITS
+___
+        }
+$ret .= <<___;
+    @{[fwdsbox4 $T0,$T8]}
+    xor     $T1,$T1,$T0
+    xor     $T2,$T2,$T1
+    xor     $T3,$T3,$T2
+
+    add     $KEYP,$KEYP,32
+___
+        if ($rnum < 6) {
+$ret .= <<___;
+    # for aes256, T3->T4 needs 4sbox but no rotate/rcon
+    @{[fwdsbox4 $T4,$T3]}
+    xor     $T5,$T5,$T4
+    xor     $T6,$T6,$T5
+    xor     $T7,$T7,$T6
+
+    # see the comment in ke128dec
+    # T8 and BITS are temp variables
+    @{[invm4 $T8,$BITS,$T0]}
+    sw      $T8,0($KEYP)
+    @{[invm4 $T8,$BITS,$T1]}
+    sw      $T8,4($KEYP)
+    @{[invm4 $T8,$BITS,$T2]}
+    sw      $T8,8($KEYP)
+    @{[invm4 $T8,$BITS,$T3]}
+    sw      $T8,12($KEYP)
+    @{[invm4 $T8,$BITS,$T4]}
+    sw      $T8,16($KEYP)
+    @{[invm4 $T8,$BITS,$T5]}
+    sw      $T8,20($KEYP)
+    @{[invm4 $T8,$BITS,$T6]}
+    sw      $T8,24($KEYP)
+    @{[invm4 $T8,$BITS,$T7]}
+    sw      $T8,28($KEYP)
+___
+        } else {
+$ret .= <<___;
+    sw      $T0,0($KEYP)
+    sw      $T1,4($KEYP)
+    sw      $T2,8($KEYP)
+    sw      $T3,12($KEYP)
+    # last 16 bytes are dropped
+    # see the comment in ke256enc
+___
+        }
+        $rnum++;
+    }
+    return $ret;
+}
+
+################################################################################
+# void rv32i_zknd_zkne_set_decrypt_key(const unsigned char *userKey, const int bits,
+#   AES_KEY *key)
+################################################################################
+# a note on naming: set_decrypt_key needs aes32esi thus add zkne on name
+$code .= <<___;
+.text
+.balign 16
+.globl rv32i_zknd_zkne_set_decrypt_key
+.type   rv32i_zknd_zkne_set_decrypt_key,\@function
+rv32i_zknd_zkne_set_decrypt_key:
+___
+$code .= save_regs();
+$code .= AES_set_common(ke128dec(0), ke192dec(0),ke256dec(0));
+$code .= load_regs();
+$code .= <<___;
+    ret
+___
+
+################################################################################
+# void rv32i_zbkb_zknd_zkne_set_decrypt_key(const unsigned char *userKey,
+#   const int bits, AES_KEY *key)
+################################################################################
+$code .= <<___;
+.text
+.balign 16
+.globl rv32i_zbkb_zknd_zkne_set_decrypt_key
+.type rv32i_zbkb_zknd_zkne_set_decrypt_key,\@function
+rv32i_zbkb_zknd_zkne_set_decrypt_key:
+___
+
+$code .= save_regs();
+$code .= AES_set_common(ke128dec(1), ke192dec(1),ke256dec(1));
+$code .= load_regs();
+$code .= <<___;
+    ret
+___
+
+
+
+print $code;
+close STDOUT or die "error closing STDOUT: $!";

--- a/crypto/aes/build.info
+++ b/crypto/aes/build.info
@@ -49,6 +49,7 @@ IF[{- !$disabled{asm} -}]
 
   $AESASM_riscv64=aes_cbc.c aes-riscv64.s aes-riscv64-zkn.s
   $AESDEF_riscv64=AES_ASM
+  $AESASM_riscv32=aes_core.c aes_cbc.c aes-riscv32-zkn.s
 
   # Now that we have defined all the arch specific variables, use the
   # appropriate one, and define the appropriate macros
@@ -119,6 +120,7 @@ INCLUDE[aes-mips.o]=..
 
 GENERATE[aes-riscv64.s]=asm/aes-riscv64.pl
 GENERATE[aes-riscv64-zkn.s]=asm/aes-riscv64-zkn.pl
+GENERATE[aes-riscv32-zkn.s]=asm/aes-riscv32-zkn.pl
 
 GENERATE[aesv8-armx.S]=asm/aesv8-armx.pl
 INCLUDE[aesv8-armx.o]=..

--- a/crypto/build.info
+++ b/crypto/build.info
@@ -52,6 +52,7 @@ IF[{- !$disabled{asm} && $config{processor} ne '386' -}]
   $CPUIDASM_c64xplus=c64xpluscpuid.s
 
   $CPUIDASM_riscv64=riscvcap.c riscv64cpuid.s
+  $CPUIDASM_riscv32=riscvcap.c riscv32cpuid.s
 
   # Now that we have defined all the arch specific variables, use the
   # appropriate one, and define the appropriate macros
@@ -136,6 +137,7 @@ INCLUDE[armv4cpuid.o]=.
 GENERATE[s390xcpuid.S]=s390xcpuid.pl
 INCLUDE[s390xcpuid.o]=.
 GENERATE[riscv64cpuid.s]=riscv64cpuid.pl
+GENERATE[riscv32cpuid.s]=riscv32cpuid.pl
 
 IF[{- $config{target} =~ /^(?:Cygwin|mingw|VC-|BC-)/ -}]
   SHARED_SOURCE[../libcrypto]=dllmain.c

--- a/crypto/riscv32cpuid.pl
+++ b/crypto/riscv32cpuid.pl
@@ -1,0 +1,88 @@
+#! /usr/bin/env perl
+# Copyright 2022 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+
+# $output is the last argument if it looks like a file (it has an extension)
+# $flavour is the first argument if it doesn't look like a file
+$output = $#ARGV >= 0 && $ARGV[$#ARGV] =~ m|\.\w+$| ? pop : undef;
+$flavour = $#ARGV >= 0 && $ARGV[0] !~ m|\.| ? shift : undef;
+
+$output and open STDOUT,">$output";
+
+{
+my ($in_a,$in_b,$len,$x,$temp1,$temp2) = ('a0','a1','a2','t0','t1','t2');
+$code.=<<___;
+################################################################################
+# int CRYPTO_memcmp(const void * in_a, const void * in_b, size_t len)
+################################################################################
+.text
+.balign 16
+.globl CRYPTO_memcmp
+.type   CRYPTO_memcmp,\@function
+CRYPTO_memcmp:
+    li      $x,0
+    beqz    $len,2f   # len == 0
+1:
+    lbu     $temp1,0($in_a)
+    lbu     $temp2,0($in_b)
+    addi    $in_a,$in_a,1
+    addi    $in_b,$in_b,1
+    addi    $len,$len,-1
+    xor     $temp1,$temp1,$temp2
+    or      $x,$x,$temp1
+    bgtz    $len,1b
+2:
+    mv      a0,$x
+    ret
+___
+}
+{
+my ($ptr,$len,$temp1,$temp2) = ('a0','a1','t0','t1');
+$code.=<<___;
+################################################################################
+# void OPENSSL_cleanse(void *ptr, size_t len)
+################################################################################
+.text
+.balign 16
+.globl OPENSSL_cleanse
+.type   OPENSSL_cleanse,\@function
+OPENSSL_cleanse:
+    beqz    $len,2f         # len == 0, return
+    srli    $temp1,$len,4
+    bnez    $temp1,3f       # len > 15
+
+1:  # Store <= 15 individual bytes
+    sb      x0,0($ptr)
+    addi    $ptr,$ptr,1
+    addi    $len,$len,-1
+    bnez    $len,1b
+2:
+    ret
+
+3:  # Store individual bytes until we are aligned
+    andi    $temp1,$ptr,0x3
+    beqz    $temp1,4f
+    sb      x0,0($ptr)
+    addi    $ptr,$ptr,1
+    addi    $len,$len,-1
+    j       3b
+
+4:  # Store aligned words
+    li      $temp2,4
+4:
+    sw      x0,0($ptr)
+    addi    $ptr,$ptr,4
+    addi    $len,$len,-4
+    bge     $len,$temp2,4b  # if len>=4 loop
+    bnez    $len,1b         # if len<4 and len != 0, store remaining bytes
+    ret
+___
+}
+
+print $code;
+close STDOUT or die "error closing STDOUT: $!";

--- a/include/crypto/aes_platform.h
+++ b/include/crypto/aes_platform.h
@@ -441,6 +441,25 @@ void rv64i_zkne_encrypt(const unsigned char *in, unsigned char *out,
                    const AES_KEY *key);
 void rv64i_zknd_decrypt(const unsigned char *in, unsigned char *out,
                    const AES_KEY *key);
+# elif defined(OPENSSL_CPUID_OBJ) && defined(__riscv) && __riscv_xlen == 32
+/* RISC-V 32 support */
+#  include "riscv_arch.h"
+#  define RV32I_ZKND_ZKNE_CAPABLE   (RISCV_HAS_ZKND() && RISCV_HAS_ZKNE())
+#  define RV32I_ZBKB_ZKND_ZKNE_CAPABLE   (RV32I_ZKND_ZKNE_CAPABLE && RISCV_HAS_ZBKB())
+
+int rv32i_zkne_set_encrypt_key(const unsigned char *userKey, const int bits,
+                               AES_KEY *key);
+/* set_decrypt_key needs both zknd and zkne */
+int rv32i_zknd_zkne_set_decrypt_key(const unsigned char *userKey, const int bits,
+                                    AES_KEY *key);
+int rv32i_zbkb_zkne_set_encrypt_key(const unsigned char *userKey, const int bits,
+                                    AES_KEY *key);
+int rv32i_zbkb_zknd_zkne_set_decrypt_key(const unsigned char *userKey, const int bits,
+                                         AES_KEY *key);
+void rv32i_zkne_encrypt(const unsigned char *in, unsigned char *out,
+                        const AES_KEY *key);
+void rv32i_zknd_decrypt(const unsigned char *in, unsigned char *out,
+                        const AES_KEY *key);
 # endif
 
 # if defined(HWAES_CAPABLE)

--- a/providers/implementations/ciphers/cipher_aes_ccm_hw.c
+++ b/providers/implementations/ciphers/cipher_aes_ccm_hw.c
@@ -63,6 +63,8 @@ static const PROV_CCM_HW aes_ccm = {
 # include "cipher_aes_ccm_hw_t4.inc"
 #elif defined(RV64I_ZKND_ZKNE_CAPABLE)
 # include "cipher_aes_ccm_hw_rv64i_zknd_zkne.inc"
+#elif defined(RV32I_ZBKB_ZKND_ZKNE_CAPABLE) && defined(RV32I_ZKND_ZKNE_CAPABLE)
+# include "cipher_aes_ccm_hw_rv32i_zknd_zkne.inc"
 #else
 const PROV_CCM_HW *ossl_prov_aes_hw_ccm(size_t keybits)
 {

--- a/providers/implementations/ciphers/cipher_aes_ccm_hw_rv32i_zknd_zkne.inc
+++ b/providers/implementations/ciphers/cipher_aes_ccm_hw_rv32i_zknd_zkne.inc
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2022 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+/*-
+ * RISC-V 32 ZKND ZKNE support for AES CCM.
+ * This file is included by cipher_aes_ccm_hw.c
+ */
+
+static int ccm_rv32i_zknd_zkne_initkey(PROV_CCM_CTX *ctx, const unsigned char *key,
+                                       size_t keylen)
+{
+    PROV_AES_CCM_CTX *actx = (PROV_AES_CCM_CTX *)ctx;
+
+    AES_HW_CCM_SET_KEY_FN(rv32i_zkne_set_encrypt_key, rv32i_zkne_encrypt,
+                          NULL, NULL);
+    return 1;
+}
+
+static int ccm_rv32i_zbkb_zknd_zkne_initkey(PROV_CCM_CTX *ctx, const unsigned char *key,
+                                            size_t keylen)
+{
+    PROV_AES_CCM_CTX *actx = (PROV_AES_CCM_CTX *)ctx;
+
+    AES_HW_CCM_SET_KEY_FN(rv32i_zbkb_zkne_set_encrypt_key, rv32i_zkne_encrypt,
+                          NULL, NULL);
+    return 1;
+}
+
+static const PROV_CCM_HW rv32i_zknd_zkne_ccm = {
+    ccm_rv32i_zknd_zkne_initkey,
+    ossl_ccm_generic_setiv,
+    ossl_ccm_generic_setaad,
+    ossl_ccm_generic_auth_encrypt,
+    ossl_ccm_generic_auth_decrypt,
+    ossl_ccm_generic_gettag
+};
+
+static const PROV_CCM_HW rv32i_zbkb_zknd_zkne_ccm = {
+    ccm_rv32i_zbkb_zknd_zkne_initkey,
+    ossl_ccm_generic_setiv,
+    ossl_ccm_generic_setaad,
+    ossl_ccm_generic_auth_encrypt,
+    ossl_ccm_generic_auth_decrypt,
+    ossl_ccm_generic_gettag
+};
+
+const PROV_CCM_HW *ossl_prov_aes_hw_ccm(size_t keybits)
+{
+    if (RV32I_ZBKB_ZKND_ZKNE_CAPABLE)
+        return &rv32i_zbkb_zknd_zkne_ccm;
+    if (RV32I_ZKND_ZKNE_CAPABLE)
+        return &rv32i_zknd_zkne_ccm;
+    return &aes_ccm;
+}

--- a/providers/implementations/ciphers/cipher_aes_gcm_hw.c
+++ b/providers/implementations/ciphers/cipher_aes_gcm_hw.c
@@ -145,6 +145,8 @@ static const PROV_GCM_HW aes_gcm = {
 # include "cipher_aes_gcm_hw_ppc.inc"
 #elif defined(RV64I_ZKND_ZKNE_CAPABLE)
 # include "cipher_aes_gcm_hw_rv64i_zknd_zkne.inc"
+#elif defined(RV32I_ZBKB_ZKND_ZKNE_CAPABLE) && defined(RV32I_ZKND_ZKNE_CAPABLE)
+# include "cipher_aes_gcm_hw_rv32i_zknd_zkne.inc"
 #else
 const PROV_GCM_HW *ossl_prov_aes_hw_gcm(size_t keybits)
 {

--- a/providers/implementations/ciphers/cipher_aes_gcm_hw_rv32i_zknd_zkne.inc
+++ b/providers/implementations/ciphers/cipher_aes_gcm_hw_rv32i_zknd_zkne.inc
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2022 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+/*-
+ * RISC-V 32 ZKND ZKNE support for AES GCM.
+ * This file is included by cipher_aes_gcm_hw.c
+ */
+
+static int rv32i_zknd_zkne_gcm_initkey(PROV_GCM_CTX *ctx, const unsigned char *key,
+                                       size_t keylen)
+{
+    PROV_AES_GCM_CTX *actx = (PROV_AES_GCM_CTX *)ctx;
+    AES_KEY *ks = &actx->ks.ks;
+
+    GCM_HW_SET_KEY_CTR_FN(ks, rv32i_zkne_set_encrypt_key, rv32i_zkne_encrypt,
+                          NULL);
+    return 1;
+}
+
+static int rv32i_zbkb_zknd_zkne_gcm_initkey(PROV_GCM_CTX *ctx,
+                                            const unsigned char *key,
+                                            size_t keylen)
+{
+    PROV_AES_GCM_CTX *actx = (PROV_AES_GCM_CTX *)ctx;
+    AES_KEY *ks = &actx->ks.ks;
+
+    GCM_HW_SET_KEY_CTR_FN(ks, rv32i_zbkb_zkne_set_encrypt_key, rv32i_zkne_encrypt,
+                          NULL);
+    return 1;
+}
+
+static const PROV_GCM_HW rv32i_zknd_zkne_gcm = {
+    rv32i_zknd_zkne_gcm_initkey,
+    ossl_gcm_setiv,
+    ossl_gcm_aad_update,
+    generic_aes_gcm_cipher_update,
+    ossl_gcm_cipher_final,
+    ossl_gcm_one_shot
+};
+
+static const PROV_GCM_HW rv32i_zbkb_zknd_zkne_gcm = {
+    rv32i_zbkb_zknd_zkne_gcm_initkey,
+    ossl_gcm_setiv,
+    ossl_gcm_aad_update,
+    generic_aes_gcm_cipher_update,
+    ossl_gcm_cipher_final,
+    ossl_gcm_one_shot
+};
+
+const PROV_GCM_HW *ossl_prov_aes_hw_gcm(size_t keybits)
+{
+    if (RV32I_ZBKB_ZKND_ZKNE_CAPABLE)
+        return &rv32i_zbkb_zknd_zkne_gcm;
+    if (RV32I_ZKND_ZKNE_CAPABLE)
+        return &rv32i_zknd_zkne_gcm;
+    return &aes_gcm;
+}

--- a/providers/implementations/ciphers/cipher_aes_hw.c
+++ b/providers/implementations/ciphers/cipher_aes_hw.c
@@ -144,6 +144,8 @@ const PROV_CIPHER_HW *ossl_prov_cipher_hw_aes_##mode(size_t keybits)           \
 # include "cipher_aes_hw_s390x.inc"
 #elif defined(RV64I_ZKND_ZKNE_CAPABLE)
 # include "cipher_aes_hw_rv64i_zknd_zkne.inc"
+#elif defined(RV32I_ZBKB_ZKND_ZKNE_CAPABLE) && defined(RV32I_ZKND_ZKNE_CAPABLE)
+# include "cipher_aes_hw_rv32i_zknd_zkne.inc"
 #else
 /* The generic case */
 # define PROV_CIPHER_HW_declare(mode)

--- a/providers/implementations/ciphers/cipher_aes_hw_rv32i_zknd_zkne.inc
+++ b/providers/implementations/ciphers/cipher_aes_hw_rv32i_zknd_zkne.inc
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2022 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+/*-
+ * RISC-V 32 ZKND ZKNE support for AES modes ecb, cbc, ofb, cfb, ctr.
+ * This file is included by cipher_aes_hw.c
+ */
+
+#define cipher_hw_rv32i_zknd_zkne_cbc    ossl_cipher_hw_generic_cbc
+#define cipher_hw_rv32i_zknd_zkne_ecb    ossl_cipher_hw_generic_ecb
+#define cipher_hw_rv32i_zknd_zkne_ofb128 ossl_cipher_hw_generic_ofb128
+#define cipher_hw_rv32i_zknd_zkne_cfb128 ossl_cipher_hw_generic_cfb128
+#define cipher_hw_rv32i_zknd_zkne_cfb8   ossl_cipher_hw_generic_cfb8
+#define cipher_hw_rv32i_zknd_zkne_cfb1   ossl_cipher_hw_generic_cfb1
+#define cipher_hw_rv32i_zknd_zkne_ctr    ossl_cipher_hw_generic_ctr
+
+#define cipher_hw_rv32i_zbkb_zknd_zkne_cbc    ossl_cipher_hw_generic_cbc
+#define cipher_hw_rv32i_zbkb_zknd_zkne_ecb    ossl_cipher_hw_generic_ecb
+#define cipher_hw_rv32i_zbkb_zknd_zkne_ofb128 ossl_cipher_hw_generic_ofb128
+#define cipher_hw_rv32i_zbkb_zknd_zkne_cfb128 ossl_cipher_hw_generic_cfb128
+#define cipher_hw_rv32i_zbkb_zknd_zkne_cfb8   ossl_cipher_hw_generic_cfb8
+#define cipher_hw_rv32i_zbkb_zknd_zkne_cfb1   ossl_cipher_hw_generic_cfb1
+#define cipher_hw_rv32i_zbkb_zknd_zkne_ctr    ossl_cipher_hw_generic_ctr
+
+static int cipher_hw_rv32i_zknd_zkne_initkey(PROV_CIPHER_CTX *dat,
+                                             const unsigned char *key, size_t keylen)
+{
+    int ret;
+    PROV_AES_CTX *adat = (PROV_AES_CTX *)dat;
+    AES_KEY *ks = &adat->ks.ks;
+
+    dat->ks = ks;
+
+    if ((dat->mode == EVP_CIPH_ECB_MODE || dat->mode == EVP_CIPH_CBC_MODE)
+        && !dat->enc) {
+        ret = rv32i_zknd_zkne_set_decrypt_key(key, keylen * 8, ks);
+        dat->block = (block128_f) rv32i_zknd_decrypt;
+        dat->stream.cbc = NULL;
+    } else {
+        ret = rv32i_zkne_set_encrypt_key(key, keylen * 8, ks);
+        dat->block = (block128_f) rv32i_zkne_encrypt;
+        dat->stream.cbc = NULL;
+    }
+
+    if (ret < 0) {
+        ERR_raise(ERR_LIB_PROV, PROV_R_KEY_SETUP_FAILED);
+        return 0;
+    }
+
+    return 1;
+}
+
+static int cipher_hw_rv32i_zbkb_zknd_zkne_initkey(PROV_CIPHER_CTX *dat,
+                                                  const unsigned char *key, size_t keylen)
+{
+    int ret;
+    PROV_AES_CTX *adat = (PROV_AES_CTX *)dat;
+    AES_KEY *ks = &adat->ks.ks;
+
+    dat->ks = ks;
+
+    if ((dat->mode == EVP_CIPH_ECB_MODE || dat->mode == EVP_CIPH_CBC_MODE)
+        && !dat->enc) {
+        ret = rv32i_zbkb_zknd_zkne_set_decrypt_key(key, keylen * 8, ks);
+        dat->block = (block128_f) rv32i_zknd_decrypt;
+        dat->stream.cbc = NULL;
+    } else {
+        ret = rv32i_zbkb_zkne_set_encrypt_key(key, keylen * 8, ks);
+        dat->block = (block128_f) rv32i_zkne_encrypt;
+        dat->stream.cbc = NULL;
+    }
+
+    if (ret < 0) {
+        ERR_raise(ERR_LIB_PROV, PROV_R_KEY_SETUP_FAILED);
+        return 0;
+    }
+
+    return 1;
+}
+
+#define PROV_CIPHER_HW_declare(mode)                                           \
+static const PROV_CIPHER_HW rv32i_zknd_zkne_##mode = {                         \
+    cipher_hw_rv32i_zknd_zkne_initkey,                                         \
+    cipher_hw_rv32i_zknd_zkne_##mode,                                          \
+    cipher_hw_aes_copyctx                                                      \
+};                                                                             \
+static const PROV_CIPHER_HW rv32i_zbkb_zknd_zkne_##mode = {                    \
+    cipher_hw_rv32i_zbkb_zknd_zkne_initkey,                                    \
+    cipher_hw_rv32i_zbkb_zknd_zkne_##mode,                                     \
+    cipher_hw_aes_copyctx                                                      \
+};
+#define PROV_CIPHER_HW_select(mode)                                            \
+if (RV32I_ZBKB_ZKND_ZKNE_CAPABLE)                                              \
+    return &rv32i_zbkb_zknd_zkne_##mode;                                       \
+if (RV32I_ZKND_ZKNE_CAPABLE)                                                   \
+    return &rv32i_zknd_zkne_##mode;

--- a/providers/implementations/ciphers/cipher_aes_ocb_hw.c
+++ b/providers/implementations/ciphers/cipher_aes_ocb_hw.c
@@ -124,6 +124,44 @@ static const PROV_CIPHER_HW aes_rv64i_zknd_zkne_ocb = {                        \
 # define PROV_CIPHER_HW_select()                                               \
     if (RV64I_ZKND_ZKNE_CAPABLE)                                               \
         return &aes_rv64i_zknd_zkne_ocb;
+#elif defined(RV32I_ZBKB_ZKND_ZKNE_CAPABLE) && defined(RV32I_ZKND_ZKNE_CAPABLE)
+
+static int cipher_hw_aes_ocb_rv32i_zknd_zkne_initkey(PROV_CIPHER_CTX *vctx,
+                                                     const unsigned char *key,
+                                                     size_t keylen)
+{
+    PROV_AES_OCB_CTX *ctx = (PROV_AES_OCB_CTX *)vctx;
+
+    OCB_SET_KEY_FN(rv32i_zkne_set_encrypt_key, rv32i_zknd_zkne_set_decrypt_key,
+                   rv32i_zkne_encrypt, rv32i_zknd_decrypt, NULL, NULL);
+    return 1;
+}
+
+static int cipher_hw_aes_ocb_rv32i_zbkb_zknd_zkne_initkey(PROV_CIPHER_CTX *vctx,
+                                                          const unsigned char *key,
+                                                          size_t keylen)
+{
+    PROV_AES_OCB_CTX *ctx = (PROV_AES_OCB_CTX *)vctx;
+
+    OCB_SET_KEY_FN(rv32i_zbkb_zkne_set_encrypt_key, rv32i_zbkb_zknd_zkne_set_decrypt_key,
+                   rv32i_zkne_encrypt, rv32i_zknd_decrypt, NULL, NULL);
+    return 1;
+}
+
+# define PROV_CIPHER_HW_declare()                                              \
+static const PROV_CIPHER_HW aes_rv32i_zknd_zkne_ocb = {                        \
+    cipher_hw_aes_ocb_rv32i_zknd_zkne_initkey,                                 \
+    NULL                                                                       \
+};                                                                             \
+static const PROV_CIPHER_HW aes_rv32i_zbkb_zknd_zkne_ocb = {                   \
+    cipher_hw_aes_ocb_rv32i_zbkb_zknd_zkne_initkey,                            \
+    NULL                                                                       \
+};
+# define PROV_CIPHER_HW_select()                                               \
+    if (RV32I_ZBKB_ZKND_ZKNE_CAPABLE)                                          \
+        return &aes_rv32i_zbkb_zknd_zkne_ocb;                                  \
+    if (RV32I_ZKND_ZKNE_CAPABLE)                                               \
+        return &aes_rv32i_zknd_zkne_ocb;
 #else
 # define PROV_CIPHER_HW_declare()
 # define PROV_CIPHER_HW_select()

--- a/providers/implementations/ciphers/cipher_aes_xts_hw.c
+++ b/providers/implementations/ciphers/cipher_aes_xts_hw.c
@@ -183,6 +183,48 @@ static const PROV_CIPHER_HW aes_xts_rv64i_zknd_zkne = {                        \
 # define PROV_CIPHER_HW_select_xts()                                           \
 if (RV64I_ZKND_ZKNE_CAPABLE)                                                   \
     return &aes_xts_rv64i_zknd_zkne;
+#elif defined(RV32I_ZBKB_ZKND_ZKNE_CAPABLE) && defined(RV32I_ZKND_ZKNE_CAPABLE)
+
+static int cipher_hw_aes_xts_rv32i_zknd_zkne_initkey(PROV_CIPHER_CTX *ctx,
+                                                     const unsigned char *key,
+                                                     size_t keylen)
+{
+    PROV_AES_XTS_CTX *xctx = (PROV_AES_XTS_CTX *)ctx;
+
+    XTS_SET_KEY_FN(rv32i_zkne_set_encrypt_key, rv32i_zknd_zkne_set_decrypt_key,
+                   rv32i_zkne_encrypt, rv32i_zknd_decrypt,
+                   NULL, NULL);
+    return 1;
+}
+
+static int cipher_hw_aes_xts_rv32i_zbkb_zknd_zkne_initkey(PROV_CIPHER_CTX *ctx,
+                                                         const unsigned char *key,
+                                                         size_t keylen)
+{
+    PROV_AES_XTS_CTX *xctx = (PROV_AES_XTS_CTX *)ctx;
+
+    XTS_SET_KEY_FN(rv32i_zbkb_zkne_set_encrypt_key, rv32i_zbkb_zknd_zkne_set_decrypt_key,
+                   rv32i_zkne_encrypt, rv32i_zknd_decrypt,
+                   NULL, NULL);
+    return 1;
+}
+
+# define PROV_CIPHER_HW_declare_xts()                                          \
+static const PROV_CIPHER_HW aes_xts_rv32i_zknd_zkne = {                        \
+    cipher_hw_aes_xts_rv32i_zknd_zkne_initkey,                                 \
+    NULL,                                                                      \
+    cipher_hw_aes_xts_copyctx                                                  \
+};                                                                             \
+static const PROV_CIPHER_HW aes_xts_rv32i_zbkb_zknd_zkne = {                   \
+    cipher_hw_aes_xts_rv32i_zbkb_zknd_zkne_initkey,                            \
+    NULL,                                                                      \
+    cipher_hw_aes_xts_copyctx                                                  \
+};
+# define PROV_CIPHER_HW_select_xts()                                           \
+if (RV32I_ZBKB_ZKND_ZKNE_CAPABLE)                                              \
+    return &aes_xts_rv32i_zbkb_zknd_zkne;                                      \
+if (RV32I_ZKND_ZKNE_CAPABLE)                                                   \
+    return &aes_xts_rv32i_zknd_zkne;
 # else
 /* The generic case */
 # define PROV_CIPHER_HW_declare_xts()


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->
This PR adds the support of AES implementation for RISC-V 32 platform with Zkn capability. This PR also adds infra for RISC-V 32 platform with CPUID and Configurations (inspired by #17640).

It depends on infra from #17640. It depends on RISCV CAP from #18197. This PR is marked as draft as the infra it depends have not been merged.

The RISC-V 32 infra by this PR is a dependency of the RV32 part of SM4 implementation in #18285.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
- [x] dependencies (#17640, #18197) are merged
