### PR TITLE
Add riscv64 asm_arch to BSD-riscv64 target

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1108,6 +1108,7 @@ my %targets = (
     "BSD-riscv64" => {
         inherit_from     => [ "BSD-generic64"],
         perlasm_scheme   => "linux64",
+        asm_arch         => 'riscv64',
     },
 
     "bsdi-elf-gcc" => {


### PR DESCRIPTION
Following cb2764f2a8 Add riscv64 asm_arch to linux64-riscv64 target (see #18275)

Current ASM does not have Linux specific thing thus theoretically enabling asm for BSD does not break things

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
