### PR TITLE
Fix UWP builds by defining VirtualLock

### DIFF
--- a/crypto/mem_sec.c
+++ b/crypto/mem_sec.c
@@ -23,6 +23,20 @@
 #ifndef OPENSSL_NO_SECURE_MEMORY
 # if defined(_WIN32)
 #  include <windows.h>
+#  if defined(WINAPI_FAMILY_PARTITION) \
+     && !WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP | WINAPI_PARTITION_SYSTEM)
+/*
+ * While VirtualLock is available under the app partition (e.g. UWP),
+ * the headers do not define the API. Define it ourselves instead.
+ */
+WINBASEAPI
+BOOL
+WINAPI
+VirtualLock(
+    _In_ LPVOID lpAddress,
+    _In_ SIZE_T dwSize
+    );
+#  endif
 # endif
 # include <stdlib.h>
 # include <assert.h>


### PR DESCRIPTION
There may a better place to put that forward declaration in, feel free to point me where.

Random thought: should there be CI coverage for UWP builds, to avoid these kinds of issues in the future?