### PR TITLE
Fix KTLS with BIO_new_connect

### DIFF
--- a/crypto/bio/bio_sock.c
+++ b/crypto/bio/bio_sock.c
@@ -400,7 +400,7 @@ int BIO_socket_wait(int fd, int for_read, time_t max_time)
         return 1;
 
     now = time(NULL);
-    if (max_time <= now)
+    if (max_time < now)
         return 0;
 
     FD_ZERO(&confds);

--- a/crypto/bio/bio_sock2.c
+++ b/crypto/bio/bio_sock2.c
@@ -53,17 +53,6 @@ int BIO_socket(int domain, int socktype, int protocol, int options)
         ERR_raise(ERR_LIB_BIO, BIO_R_UNABLE_TO_CREATE_SOCKET);
         return INVALID_SOCKET;
     }
-# ifndef OPENSSL_NO_KTLS
-    {
-        /*
-         * The new socket is created successfully regardless of ktls_enable.
-         * ktls_enable doesn't change any functionality of the socket, except
-         * changing the setsockopt to enable the processing of ktls_start.
-         * Thus, it is not a problem to call it for non-TLS sockets.
-         */
-        ktls_enable(sock);
-    }
-# endif
 
     return sock;
 }
@@ -192,6 +181,15 @@ int BIO_connect(int sock, const BIO_ADDR *addr, int options)
         }
         return 0;
     }
+# ifndef OPENSSL_NO_KTLS
+    /*
+     * The new socket is created successfully regardless of ktls_enable.
+     * ktls_enable doesn't change any functionality of the socket, except
+     * changing the setsockopt to enable the processing of ktls_start.
+     * Thus, it is not a problem to call it for non-TLS sockets.
+     */
+    ktls_enable(sock);
+# endif
     return 1;
 }
 

--- a/crypto/bio/bss_conn.c
+++ b/crypto/bio/bss_conn.c
@@ -191,6 +191,9 @@ static int conn_state(BIO *b, BIO_CONNECT *c)
             break;
 
         case BIO_CONN_S_BLOCKED_CONNECT:
+            /* wait for socket being writable, before querying BIO_sock_error */
+            if (BIO_socket_wait(b->num, 0, time(NULL)) == 0)
+                break;
             i = BIO_sock_error(b->num);
             if (i != 0) {
                 BIO_clear_retry_flags(b);
@@ -208,8 +211,18 @@ static int conn_state(BIO *b, BIO_CONNECT *c)
                 ERR_raise(ERR_LIB_BIO, BIO_R_NBIO_CONNECT_ERROR);
                 ret = 0;
                 goto exit_loop;
-            } else
+            } else {
                 c->state = BIO_CONN_S_OK;
+# ifndef OPENSSL_NO_KTLS
+                /*
+                 * The new socket is created successfully regardless of ktls_enable.
+                 * ktls_enable doesn't change any functionality of the socket, except
+                 * changing the setsockopt to enable the processing of ktls_start.
+                 * Thus, it is not a problem to call it for non-TLS sockets.
+                 */
+                ktls_enable(b->num);
+# endif
+            }
             break;
 
         case BIO_CONN_S_CONNECT_ERROR:


### PR DESCRIPTION
When a socket connection is done using BIO_new_connect,
the ktls_enable is done too early, and fails with ENOTCONN.
Therefore the KLTS ioctl will fail later with ENOPROTOOPT.
Fix that by doing the ktls_enable after the connection
succeeded, not when the socket is created as that will
always fail.

One example where this happens is doit_localhost in
test/ssl_old_test.c, and therefore, contrary to the expectation
the -client_ktls option did never enable the client KTLS
connection, but this was not noticed, because there was no
diagnostic output, and it was only visible with strace output.

Also enhanced the ssl_old_test -client_ktls/-server_ktls
options together with -v option to print a summary line
if and how KTLS was negotiated in server and client.

While I am already there adjusted the usage info of
the -s_cert, -s_key commands, and allow -time to print the
timings of ktls connections.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
