### PR TITLE
Fix EC_POINT_new doc

### DIFF
--- a/doc/man3/EC_POINT_new.pod
+++ b/doc/man3/EC_POINT_new.pod
@@ -127,7 +127,7 @@ be at infinity by calling EC_POINT_set_to_infinity().
 The affine co-ordinates for a point describe a point in terms of its x and y
 position. The function EC_POINT_set_affine_coordinates() sets the B<x> and B<y>
 co-ordinates for the point B<p> defined over the curve given in B<group>. The
-function EC_POINT_get_affine_coordinates() sets B<x> and B<y>, either of which
+function EC_POINT_set_affine_coordinates() sets B<x> and B<y>, either of which
 may be NULL, to the corresponding coordinates of B<p>.
 
 The functions EC_POINT_set_affine_coordinates_GFp() and


### PR DESCRIPTION
Should be EC_POINT_set_affine_coordinates() sets x and y

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
