### PR TITLE
Prepare NonStop for fixed-size integer types.

### DIFF
--- a/Configurations/50-nonstop.conf
+++ b/Configurations/50-nonstop.conf
@@ -58,7 +58,7 @@
     # Itanium + guardian:
     'nonstop-archenv-itanium-guardian' => {
         template         => 1,
-        defines          => ['NO_GETPID', '_TANDEM_ARCH=2'],
+        defines          => ['NO_GETPID'],
         cflags           => '-Wtarget=tns/e -Wsystype=guardian',
         lflags           => '-Weld="-set systype guardian"',
         shared_ldflag    => '-Wshared -Weld="-soname $(@:lib%.so=%)"',
@@ -69,7 +69,7 @@
     # x86 + guardian:
     'nonstop-archenv-x86_64-guardian' => {
         template         => 1,
-        defines          => ['NO_GETPID', '_TANDEM_ARCH=3'],
+        defines          => ['NO_GETPID'],
         cflags           => '-Wtarget=tns/x -Wsystype=guardian',
         lflags           => '-Wxld="-set systype guardian"',
         shared_ldflag    => '-Wshared -Wxld="-soname $(@:lib%.so=%)"',
@@ -89,7 +89,6 @@
     # Itanium + oss:
     'nonstop-archenv-itanium-oss' => {
         template         => 1,
-        defines          => ['_TANDEM_ARCH=2'],
         cflags           => '-Wtarget=tns/e -Wsystype=oss',
         lflags           => '-Weld="-set systype oss"',
         shared_ldflag    => '-Wshared',
@@ -99,7 +98,6 @@
     # x86_64 + oss:
     'nonstop-archenv-x86_64-oss' => {
         template         => 1,
-        defines          => ['_TANDEM_ARCH=3'],
         cflags           => '-Wtarget=tns/x -Wsystype=oss',
         lflags           => '-Wxld="-set systype oss"',
         shared_ldflag    => '-Wshared',

--- a/include/openssl/e_os2.h
+++ b/include/openssl/e_os2.h
@@ -248,6 +248,9 @@ typedef int int32_t;
 typedef unsigned int uint32_t;
 typedef __int64 int64_t;
 typedef unsigned __int64 uint64_t;
+# elif defined(OPENSSL_SYS_TANDEM)
+#  include <stdint.h>
+#  include <sys/types.h>
 # else
 #  include <stdint.h>
 #  undef OPENSSL_NO_STDINT_H


### PR DESCRIPTION
This commit removes platform defines the interfere with loading and resolution
of platform and memory model variants of integer types and includes the
appropriate files, stdint.h and sys/types.h where the types are defined.

Fixes #17669

Signed-off-by: Randall S. Becker <randall.becker@nexbridge.ca