### PR TITLE
Fix coverity 1504433: unchecked return value

### DIFF
--- a/ssl/ssl_rsa.c
+++ b/ssl/ssl_rsa.c
@@ -252,6 +252,7 @@ static int ssl_set_cert(CERT *c, X509 *x)
         /*
          * The return code from EVP_PKEY_copy_parameters is deliberately
          * ignored. Some EVP_PKEY types cannot do this.
+         * coverity[check_return]
          */
         EVP_PKEY_copy_parameters(pkey, c->pkeys[i].privatekey);
         ERR_clear_error();


### PR DESCRIPTION
Just extending the comment so Coveriety knows as well.

