### PR TITLE
Change loops conditions to make zero loop risk more obvious.

### DIFF
--- a/crypto/aria/aria.c
+++ b/crypto/aria/aria.c
@@ -498,7 +498,7 @@ void ossl_aria_encrypt(const unsigned char *in, unsigned char *out,
     ARIA_ADD_ROUND_KEY(rk, reg0, reg1, reg2, reg3);
     rk++;
 
-    while ((Nr -= 2)>0) {
+    while ((Nr -= 2) > 0) {
         ARIA_SUBST_DIFF_EVEN(reg0, reg1, reg2, reg3);
         ARIA_ADD_ROUND_KEY(rk, reg0, reg1, reg2, reg3);
         rk++;

--- a/crypto/aria/aria.c
+++ b/crypto/aria/aria.c
@@ -498,7 +498,7 @@ void ossl_aria_encrypt(const unsigned char *in, unsigned char *out,
     ARIA_ADD_ROUND_KEY(rk, reg0, reg1, reg2, reg3);
     rk++;
 
-    while (Nr -= 2) {
+    while ((Nr -= 2)>0) {
         ARIA_SUBST_DIFF_EVEN(reg0, reg1, reg2, reg3);
         ARIA_ADD_ROUND_KEY(rk, reg0, reg1, reg2, reg3);
         rk++;

--- a/crypto/modes/gcm128.c
+++ b/crypto/modes/gcm128.c
@@ -537,7 +537,11 @@ static void gcm_ghash_4bit(u64 Xi[2], const u128 Htable[16],
             Xi[0] = Z.hi;
             Xi[1] = Z.lo;
         }
-    } while (inp += 16, (len >= 16) && (len -= 16));
+
+        inp += 16;
+        /* Block size is 128 bits so len is a multiple of 16 */
+        len -= 16;
+    } while (len > 0);
 }
 #  endif
 # else

--- a/crypto/modes/gcm128.c
+++ b/crypto/modes/gcm128.c
@@ -537,7 +537,7 @@ static void gcm_ghash_4bit(u64 Xi[2], const u128 Htable[16],
             Xi[0] = Z.hi;
             Xi[1] = Z.lo;
         }
-    } while (inp += 16, len -= 16);
+    } while (inp += 16, (len -= 16)>0);
 }
 #  endif
 # else

--- a/crypto/modes/gcm128.c
+++ b/crypto/modes/gcm128.c
@@ -537,7 +537,7 @@ static void gcm_ghash_4bit(u64 Xi[2], const u128 Htable[16],
             Xi[0] = Z.hi;
             Xi[1] = Z.lo;
         }
-    } while (inp += 16, (len -= 16)>0);
+    } while (inp += 16, (len >= 16) && (len -= 16));
 }
 #  endif
 # else


### PR DESCRIPTION
Fixes openssl#18073.

I compiled `libcrypto.so` with flags: `linux-x86_64`, `no-asm` and generated ASM for the modified functions looks to be the same with and without these changes. And the changes increases readability a bit.


<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
