### PR TITLE
Fix sporadic KTLS RX failures

### DIFF
--- a/ssl/t1_enc.c
+++ b/ssl/t1_enc.c
@@ -414,6 +414,14 @@ int tls1_change_cipher_state(SSL *s, int which)
         goto err;
     }
 
+    /*
+     * Disable the KTLS RX path for now, since that may
+     * cause bad record mac errors for unknown reasons.
+     * See: https://github.com/openssl/openssl/issues/18276
+     */
+    if (which & SSL3_CC_READ)
+       goto skip_ktls;
+
     /* All future data will get encrypted by ktls. Flush the BIO or skip ktls */
     if (which & SSL3_CC_WRITE) {
        if (BIO_flush(bio) <= 0)

--- a/ssl/tls13_enc.c
+++ b/ssl/tls13_enc.c
@@ -715,6 +715,14 @@ int tls13_change_cipher_state(SSL *s, int which)
         goto err;
     }
 
+    /*
+     * Disable the KTLS RX path for now, since that may
+     * cause bad record mac errors for unknown reasons.
+     * See: https://github.com/openssl/openssl/issues/18276
+     */
+    if (which & SSL3_CC_READ)
+        goto skip_ktls;
+
     /* All future data will get encrypted by ktls. Flush the BIO or skip ktls */
     if (which & SSL3_CC_WRITE) {
         if (BIO_flush(bio) <= 0)


### PR DESCRIPTION
Disable the KTLS RX path, since that may
cause bad record mac errors for unknown reasons.

Fixes #18276

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
