### PR TITLE
Non-locale dependent OPENSSL_strcasecmp

### DIFF
--- a/crypto/ctype.c
+++ b/crypto/ctype.c
@@ -257,6 +257,36 @@ int ossl_ctype_check(int c, unsigned int mask)
     return a >= 0 && a < max && (ctype_char_map[a] & mask) != 0;
 }
 
+/*
+ * Implement some of the simplier functions directly to avoid the overhead of
+ * accessing memory via ctype_char_map[].
+ */
+
+#define ASCII_IS_DIGIT(c)   (c >= 0x30 && c <= 0x39)
+#define ASCII_IS_UPPER(c)   (c >= 0x41 && c <= 0x5A)
+#define ASCII_IS_LOWER(c)   (c >= 0x61 && c <= 0x7A)
+
+int ossl_isdigit(int c)
+{
+    int a = ossl_toascii(c);
+
+    return ASCII_IS_DIGIT(a);
+}
+
+int ossl_isupper(int c)
+{
+    int a = ossl_toascii(c);
+
+    return ASCII_IS_UPPER(a);
+}
+
+int ossl_islower(int c)
+{
+    int a = ossl_toascii(c);
+
+    return ASCII_IS_LOWER(a);
+}
+
 #if defined(CHARSET_EBCDIC) && !defined(CHARSET_EBCDIC_TEST)
 static const int case_change = 0x40;
 #else
@@ -265,16 +295,19 @@ static const int case_change = 0x20;
 
 int ossl_tolower(int c)
 {
-    return ossl_isupper(c) ? c ^ case_change : c;
+    int a = ossl_toascii(c);
+
+    return ASCII_IS_UPPER(a) ? c ^ case_change : c;
 }
 
 int ossl_toupper(int c)
 {
-    return ossl_islower(c) ? c ^ case_change : c;
+    int a = ossl_toascii(c);
+
+    return ASCII_IS_LOWER(a) ? c ^ case_change : c;
 }
 
-int ossl_ascii_isdigit(const char inchar) {
-    if (inchar > 0x2F && inchar < 0x3A)
-        return 1;
-    return 0;
+int ossl_ascii_isdigit(int c)
+{
+    return ASCII_IS_DIGIT(c);
 }

--- a/crypto/init.c
+++ b/crypto/init.c
@@ -442,9 +442,6 @@ void OPENSSL_cleanup(void)
     OSSL_TRACE(INIT, "OPENSSL_cleanup: ossl_trace_cleanup()\n");
     ossl_trace_cleanup();
 
-    OSSL_TRACE(INIT, "OPENSSL_cleanup: ossl_deinit_casecmp()\n");
-    ossl_deinit_casecmp();
-
     base_inited = 0;
 }
 
@@ -483,9 +480,6 @@ int OPENSSL_init_crypto(uint64_t opts, const OPENSSL_INIT_SETTINGS *settings)
             return 1;
         aloaddone = 1;
     }
-
-    if (!ossl_init_casecmp())
-        return 0;
 
     /*
      * At some point we should look at this function with a view to moving

--- a/crypto/o_str.c
+++ b/crypto/o_str.c
@@ -10,13 +10,8 @@
 #include "internal/e_os.h"
 #include <string.h>
 #include <limits.h>
-#ifndef OPENSSL_NO_LOCALE
-# include <locale.h>
-# ifdef OPENSSL_SYS_MACOSX
-#  include <xlocale.h>
-# endif
-#endif
 #include <openssl/crypto.h>
+#include "crypto/ctype.h"
 #include "internal/cryptlib.h"
 #include "internal/thread_once.h"
 
@@ -347,94 +342,25 @@ int openssl_strerror_r(int errnum, char *buf, size_t buflen)
 #endif
 }
 
-#ifndef OPENSSL_NO_LOCALE
-# ifndef FIPS_MODULE
-static CRYPTO_ONCE casecmp = CRYPTO_ONCE_STATIC_INIT;
-DEFINE_RUN_ONCE_STATIC(init_casecmp)
-{
-    int ret = ossl_init_casecmp_int();
-
-    return ret;
-}
-
-int ossl_init_casecmp(void)
-{
-    if (!RUN_ONCE(&casecmp, init_casecmp))
-        return 0;
-    return 1;
-}
-# endif
-
-static locale_t loc;
-
-static locale_t ossl_c_locale(void)
-{
-# ifndef FIPS_MODULE
-    if (!ossl_init_casecmp())
-        return (locale_t)0;
-# endif
-    return loc;
-}
-
-int ossl_init_casecmp_int(void)
-{
-# ifdef OPENSSL_SYS_WINDOWS
-    loc = _create_locale(LC_COLLATE, "C");
-# else
-    loc = newlocale(LC_COLLATE_MASK, "C", (locale_t) 0);
-# endif
-    return (loc == (locale_t)0) ? 0 : 1;
-}
-
-void ossl_deinit_casecmp(void)
-{
-    if (loc != (locale_t)0) {
-        freelocale(loc);
-        loc = (locale_t)0;
-    }
-}
-
 int OPENSSL_strcasecmp(const char *s1, const char *s2)
 {
-    locale_t l = ossl_c_locale();
+    int t;
 
-    /* Fallback in case of locale initialization failure */
-    if (l == (locale_t)0)
-        return strcasecmp(s1, s2);
-    return strcasecmp_l(s1, s2, l);
+    while ((t = ossl_tolower(*s1) - ossl_tolower(*s2++)) == 0)
+        if (*s1++ == '\0')
+            return 0;
+    return t;
 }
 
 int OPENSSL_strncasecmp(const char *s1, const char *s2, size_t n)
 {
-    locale_t l = ossl_c_locale();
+    int t;
+    size_t i;
 
-    /* Fallback in case of locale initialization failure */
-    if (l == (locale_t)0)
-        return strncasecmp(s1, s2, n);
-    return strncasecmp_l(s1, s2, n, l);
+    for (i = 0; i < n; i++)
+        if ((t = ossl_tolower(*s1) - ossl_tolower(*s2++)) != 0)
+            return t;
+        else if (*s1++ == '\0')
+            return 0;
+    return 0;
 }
-#else
-int ossl_init_casecmp(void)
-{
-    return 1;
-}
-
-int ossl_init_casecmp_int(void)
-{
-    return 1;
-}
-
-void ossl_deinit_casecmp(void)
-{
-}
-
-int OPENSSL_strcasecmp(const char *s1, const char *s2)
-{
-    return strcasecmp(s1, s2);
-}
-
-int OPENSSL_strncasecmp(const char *s1, const char *s2, size_t n)
-{
-    return strncasecmp(s1, s2, n);
-}
-#endif

--- a/include/crypto/ctype.h
+++ b/include/crypto/ctype.h
@@ -22,6 +22,8 @@
 # define OSSL_CRYPTO_CTYPE_H
 # pragma once
 
+# include <openssl/e_os2.h>
+
 # define CTYPE_MASK_lower       0x1
 # define CTYPE_MASK_upper       0x2
 # define CTYPE_MASK_digit       0x4
@@ -55,10 +57,15 @@ int ossl_fromascii(int c);
 #  define ossl_fromascii(c)     (c)
 # endif
 int ossl_ctype_check(int c, unsigned int mask);
+
 int ossl_tolower(int c);
 int ossl_toupper(int c);
 
-int ossl_ascii_isdigit(const char inchar);
+int ossl_isdigit(int c);
+int ossl_islower(int c);
+int ossl_isupper(int c);
+
+int ossl_ascii_isdigit(int c);
 
 # define ossl_isalnum(c)        (ossl_ctype_check((c), CTYPE_MASK_alnum))
 # define ossl_isalpha(c)        (ossl_ctype_check((c), CTYPE_MASK_alpha))
@@ -69,13 +76,10 @@ int ossl_ascii_isdigit(const char inchar);
 # endif
 # define ossl_isblank(c)        (ossl_ctype_check((c), CTYPE_MASK_blank))
 # define ossl_iscntrl(c)        (ossl_ctype_check((c), CTYPE_MASK_cntrl))
-# define ossl_isdigit(c)        (ossl_ctype_check((c), CTYPE_MASK_digit))
 # define ossl_isgraph(c)        (ossl_ctype_check((c), CTYPE_MASK_graph))
-# define ossl_islower(c)        (ossl_ctype_check((c), CTYPE_MASK_lower))
 # define ossl_isprint(c)        (ossl_ctype_check((c), CTYPE_MASK_print))
 # define ossl_ispunct(c)        (ossl_ctype_check((c), CTYPE_MASK_punct))
 # define ossl_isspace(c)        (ossl_ctype_check((c), CTYPE_MASK_space))
-# define ossl_isupper(c)        (ossl_ctype_check((c), CTYPE_MASK_upper))
 # define ossl_isxdigit(c)       (ossl_ctype_check((c), CTYPE_MASK_xdigit))
 # define ossl_isbase64(c)       (ossl_ctype_check((c), CTYPE_MASK_base64))
 # define ossl_isasn1print(c)    (ossl_ctype_check((c), CTYPE_MASK_asn1print))

--- a/include/internal/cryptlib.h
+++ b/include/internal/cryptlib.h
@@ -157,7 +157,4 @@ char *ossl_ipaddr_to_asc(unsigned char *p, int len);
 char *ossl_buf2hexstr_sep(const unsigned char *buf, long buflen, char sep);
 unsigned char *ossl_hexstr2buf_sep(const char *str, long *buflen,
                                    const char sep);
-int ossl_init_casecmp_int(void);
-int ossl_init_casecmp(void);
-void ossl_deinit_casecmp(void);
 #endif

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -483,7 +483,6 @@ static void fips_teardown(void *provctx)
 {
     OSSL_LIB_CTX_free(PROV_LIBCTX_OF(provctx));
     ossl_prov_ctx_free(provctx);
-    ossl_deinit_casecmp();
 }
 
 static void fips_intern_teardown(void *provctx)
@@ -541,8 +540,6 @@ int OSSL_provider_init_int(const OSSL_CORE_HANDLE *handle,
 
     memset(&selftest_params, 0, sizeof(selftest_params));
 
-    if (!ossl_init_casecmp_int())
-        return 0;
     if (!ossl_prov_seeding_from_dispatch(in))
         goto err;
     for (; in->function_id != 0; in++) {


### PR DESCRIPTION
This implements a version of OSSL_strcasecmp that doesn't rely on locale support.

This also includes performance improvements for some of the ctype functions.

Fixes #18322

- [ ] documentation is added or updated
- [ ] tests are added or updated
