### PR TITLE
Apply the AES-GCM unroll8 optimization patch to Neoverse N2

### DIFF
--- a/crypto/arm_arch.h
+++ b/crypto/arm_arch.h
@@ -101,6 +101,7 @@ extern unsigned int OPENSSL_armv8_rsa_neonized;
 # define ARM_CPU_PART_CORTEX_A72   0xD08
 # define ARM_CPU_PART_N1           0xD0C
 # define ARM_CPU_PART_V1           0xD40
+# define ARM_CPU_PART_N2           0xD49
 
 # define MIDR_PARTNUM_SHIFT       4
 # define MIDR_PARTNUM_MASK        (0xfff << MIDR_PARTNUM_SHIFT)

--- a/crypto/armcap.c
+++ b/crypto/armcap.c
@@ -375,7 +375,8 @@ void OPENSSL_cpuid_setup(void)
         (OPENSSL_armcap_P & ARMV7_NEON)) {
             OPENSSL_armv8_rsa_neonized = 1;
     }
-    if ((MIDR_IS_CPU_MODEL(OPENSSL_arm_midr, ARM_CPU_IMP_ARM, ARM_CPU_PART_V1)) &&
+    if ((MIDR_IS_CPU_MODEL(OPENSSL_arm_midr, ARM_CPU_IMP_ARM, ARM_CPU_PART_V1) ||
+         MIDR_IS_CPU_MODEL(OPENSSL_arm_midr, ARM_CPU_IMP_ARM, ARM_CPU_PART_N2)) &&
         (OPENSSL_armcap_P & ARMV8_SHA3))
         OPENSSL_armcap_P |= ARMV8_UNROLL8_EOR3;
 # endif


### PR DESCRIPTION
The loop unrolling and use of EOR3 can improve N2 performance
by up to 32%

We have one patch which optimize aes-gcm, which has been merged, it can gain 25-40% performance uplift on out-of-order microarchitectures. Currently we find Neoverse N2 can also benifit from this patch(about 32% uplift). So we provide one patch to add the support.
