### PR TITLE
x86asm: Generate endbr32 based on __CET__.

### DIFF
--- a/crypto/aes/build.info
+++ b/crypto/aes/build.info
@@ -2,9 +2,9 @@ LIBS=../../libcrypto
 
 $AESASM=aes_core.c aes_cbc.c
 IF[{- !$disabled{asm} -}]
-  $AESASM_x86=aes-586.s
+  $AESASM_x86=aes-586.S
   $AESDEF_x86=AES_ASM
-  $AESASM_x86_sse2=vpaes-x86.s aesni-x86.s
+  $AESASM_x86_sse2=vpaes-x86.S aesni-x86.S
   $AESDEF_x86_sse2=VPAES_ASM OPENSSL_IA32_SSE2
 
   $AESASM_x86_64=\
@@ -85,12 +85,12 @@ ENDIF
 GENERATE[aes-ia64.s]=asm/aes-ia64.S
 GENERATE[bsaes-armv8.S]=asm/bsaes-armv8.pl
 
-GENERATE[aes-586.s]=asm/aes-586.pl
-DEPEND[aes-586.s]=../perlasm/x86asm.pl
-GENERATE[vpaes-x86.s]=asm/vpaes-x86.pl
-DEPEND[vpaes-586.s]=../perlasm/x86asm.pl
-GENERATE[aesni-x86.s]=asm/aesni-x86.pl
-DEPEND[aesni-586.s]=../perlasm/x86asm.pl
+GENERATE[aes-586.S]=asm/aes-586.pl
+DEPEND[aes-586.S]=../perlasm/x86asm.pl
+GENERATE[vpaes-x86.S]=asm/vpaes-x86.pl
+DEPEND[vpaes-586.S]=../perlasm/x86asm.pl
+GENERATE[aesni-x86.S]=asm/aesni-x86.pl
+DEPEND[aesni-586.S]=../perlasm/x86asm.pl
 
 GENERATE[aes-x86_64.s]=asm/aes-x86_64.pl
 GENERATE[vpaes-x86_64.s]=asm/vpaes-x86_64.pl

--- a/crypto/bf/build.info
+++ b/crypto/bf/build.info
@@ -2,7 +2,7 @@ LIBS=../../libcrypto
 
 $BFASM=bf_enc.c
 IF[{- !$disabled{asm} -}]
-  $BFASM_x86=bf-586.s
+  $BFASM_x86=bf-586.S
 
   # Now that we have defined all the arch specific variables, use the
   # appropriate one
@@ -21,5 +21,5 @@ IF[{- $disabled{'deprecated-3.0'} -}]
   SOURCE[../../providers/liblegacy.a]=$ALL
 ENDIF
 
-GENERATE[bf-586.s]=asm/bf-586.pl
-DEPEND[bf-586.s]=../perlasm/x86asm.pl ../perlasm/cbc.pl
+GENERATE[bf-586.S]=asm/bf-586.pl
+DEPEND[bf-586.S]=../perlasm/x86asm.pl ../perlasm/cbc.pl

--- a/crypto/bn/build.info
+++ b/crypto/bn/build.info
@@ -16,7 +16,7 @@ IF[{- !$disabled{asm} -}]
   # All variables are named in such a way that they can be "indexed" with
   # $target{asm_arch}
 
-  $BNASM_x86=bn-586.s co-586.s x86-mont.s x86-gf2m.s
+  $BNASM_x86=bn-586.S co-586.S x86-mont.S x86-gf2m.S
   # bn-586 is the only one implementing bn_*_part_words
   # => OPENSSL_BN_ASM_PART_WORDS
   $BNDEF_x86=OPENSSL_BN_ASM_PART_WORDS OPENSSL_BN_ASM_MONT OPENSSL_BN_ASM_GF2m
@@ -127,14 +127,14 @@ DEFINE[../../providers/libcommon.a]=$BNDEF
 
 INCLUDE[bn_exp.o]=..
 
-GENERATE[bn-586.s]=asm/bn-586.pl
-DEPEND[bn-586.s]=../perlasm/x86asm.pl
-GENERATE[co-586.s]=asm/co-586.pl
-DEPEND[co-586.s]=../perlasm/x86asm.pl
-GENERATE[x86-mont.s]=asm/x86-mont.pl
-DEPEND[x86-mont.s]=../perlasm/x86asm.pl
-GENERATE[x86-gf2m.s]=asm/x86-gf2m.pl
-DEPEND[x86-gf2m.s]=../perlasm/x86asm.pl
+GENERATE[bn-586.S]=asm/bn-586.pl
+DEPEND[bn-586.S]=../perlasm/x86asm.pl
+GENERATE[co-586.S]=asm/co-586.pl
+DEPEND[co-586.S]=../perlasm/x86asm.pl
+GENERATE[x86-mont.S]=asm/x86-mont.pl
+DEPEND[x86-mont.S]=../perlasm/x86asm.pl
+GENERATE[x86-gf2m.S]=asm/x86-gf2m.pl
+DEPEND[x86-gf2m.S]=../perlasm/x86asm.pl
 
 GENERATE[sparcv9a-mont.S]=asm/sparcv9a-mont.pl
 INCLUDE[sparcv9a-mont.o]=..

--- a/crypto/build.info
+++ b/crypto/build.info
@@ -14,7 +14,7 @@ $UPLINKSRC=
 $UPLINKDEF=
 IF[{- !$disabled{uplink} -}]
   $UPLINKSRC_common=../ms/uplink.c
-  $UPLINKSRC_x86=$UPLINKSRC_common uplink-x86.s
+  $UPLINKSRC_x86=$UPLINKSRC_common uplink-x86.S
   $UPLINKSRC_x86_64=$UPLINKSRC_common uplink-x86_64.s
   $UPLINKSRC_ia64=$UPLINKSRC_common uplink-ia64.s
 
@@ -27,7 +27,7 @@ ENDIF
 $CPUIDASM=mem_clr.c
 $CPUIDDEF=
 IF[{- !$disabled{asm} && $config{processor} ne '386' -}]
-  $CPUIDASM_x86=x86cpuid.s
+  $CPUIDASM_x86=x86cpuid.S
 
   $CPUIDASM_x86_64=x86_64cpuid.s
 
@@ -113,11 +113,11 @@ DEPEND[info.o]=buildinf.h
 DEPEND[cversion.o]=buildinf.h
 GENERATE[buildinf.h]=../util/mkbuildinf.pl "$(CC) $(LIB_CFLAGS) $(CPPFLAGS_Q)" "$(PLATFORM)"
 
-GENERATE[uplink-x86.s]=../ms/uplink-x86.pl
+GENERATE[uplink-x86.S]=../ms/uplink-x86.pl
 GENERATE[uplink-x86_64.s]=../ms/uplink-x86_64.pl
 GENERATE[uplink-ia64.s]=../ms/uplink-ia64.pl
 
-GENERATE[x86cpuid.s]=x86cpuid.pl
+GENERATE[x86cpuid.S]=x86cpuid.pl
 DEPEND[x86cpuid.s]=perlasm/x86asm.pl
 
 GENERATE[x86_64cpuid.s]=x86_64cpuid.pl

--- a/crypto/camellia/build.info
+++ b/crypto/camellia/build.info
@@ -2,7 +2,7 @@ LIBS=../../libcrypto
 
 $CMLLASM=camellia.c cmll_misc.c cmll_cbc.c
 IF[{- !$disabled{asm} -}]
-  $CMLLASM_x86=cmll-x86.s
+  $CMLLASM_x86=cmll-x86.S
   $CMLLASM_x86_64=cmll-x86_64.s cmll_misc.c
   $CMLLASM_sparcv9=camellia.c cmll_misc.c cmll_cbc.c cmllt4-sparcv9.S
 
@@ -17,8 +17,8 @@ ENDIF
 SOURCE[../../libcrypto]=cmll_ecb.c cmll_ofb.c cmll_cfb.c cmll_ctr.c $CMLLASM
 DEFINE[../../libcrypto]=$CMLLDEF
 
-GENERATE[cmll-x86.s]=asm/cmll-x86.pl
-DEPEND[cmll-x86.s]=../perlasm/x86asm.pl
+GENERATE[cmll-x86.S]=asm/cmll-x86.pl
+DEPEND[cmll-x86.S]=../perlasm/x86asm.pl
 GENERATE[cmll-x86_64.s]=asm/cmll-x86_64.pl
 GENERATE[cmllt4-sparcv9.S]=asm/cmllt4-sparcv9.pl
 INCLUDE[cmllt4-sparcv9.o]=..

--- a/crypto/cast/build.info
+++ b/crypto/cast/build.info
@@ -3,7 +3,7 @@ LIBS=../../libcrypto
 $CASTASM=c_enc.c
 # CAST assembly source is not PIC
 IF[{- !$disabled{asm} && $disabled{pic} -}]
-  $CASTASM_x86=cast-586.s
+  $CASTASM_x86=cast-586.S
 
   # Now that we have defined all the arch specific variables, use the
   # appropriate one
@@ -22,5 +22,5 @@ IF[{- $disabled{'deprecated-3.0'} -}]
   SOURCE[../../providers/liblegacy.a]=$ALL
 ENDIF
 
-GENERATE[cast-586.s]=asm/cast-586.pl
-DEPEND[cast-586.s]=../perlasm/x86asm.pl ../perlasm/cbc.pl
+GENERATE[cast-586.S]=asm/cast-586.pl
+DEPEND[cast-586.S]=../perlasm/x86asm.pl ../perlasm/cbc.pl

--- a/crypto/chacha/build.info
+++ b/crypto/chacha/build.info
@@ -2,7 +2,7 @@ LIBS=../../libcrypto
 
 $CHACHAASM=chacha_enc.c
 IF[{- !$disabled{asm} -}]
-  $CHACHAASM_x86=chacha-x86.s
+  $CHACHAASM_x86=chacha-x86.S
   $CHACHAASM_x86_64=chacha-x86_64.s
 
   $CHACHAASM_ia64=chacha-ia64.s
@@ -26,7 +26,7 @@ ENDIF
 
 SOURCE[../../libcrypto]=$CHACHAASM
 
-GENERATE[chacha-x86.s]=asm/chacha-x86.pl
+GENERATE[chacha-x86.S]=asm/chacha-x86.pl
 GENERATE[chacha-x86_64.s]=asm/chacha-x86_64.pl
 GENERATE[chacha-ppc.s]=asm/chacha-ppc.pl
 GENERATE[chachap10-ppc.s]=asm/chachap10-ppc.pl

--- a/crypto/des/build.info
+++ b/crypto/des/build.info
@@ -1,6 +1,6 @@
 $DESASM=des_enc.c fcrypt_b.c
 IF[{- !$disabled{asm} -}]
-  $DESASM_x86=des-586.s crypt586.s
+  $DESASM_x86=des-586.S crypt586.S
   $DESASM_sparcv9=des_enc-sparc.S fcrypt_b.c dest4-sparcv9.S
   $DESASM_sparcv8=des_enc-sparc.S fcrypt_b.c
 
@@ -40,7 +40,7 @@ GENERATE[des_enc-sparc.S]=asm/des_enc.m4
 GENERATE[dest4-sparcv9.S]=asm/dest4-sparcv9.pl
 INCLUDE[dest4-sparcv9.o]=..
 
-GENERATE[des-586.s]=asm/des-586.pl
-DEPEND[des-586.s]=../perlasm/x86asm.pl ../perlasm/cbc.pl
-GENERATE[crypt586.s]=asm/crypt586.pl
-DEPEND[crypt586.s]=../perlasm/x86asm.pl ../perlasm/cbc.pl
+GENERATE[des-586.S]=asm/des-586.pl
+DEPEND[des-586.S]=../perlasm/x86asm.pl ../perlasm/cbc.pl
+GENERATE[crypt586.S]=asm/crypt586.pl
+DEPEND[crypt586.S]=../perlasm/x86asm.pl ../perlasm/cbc.pl

--- a/crypto/ec/build.info
+++ b/crypto/ec/build.info
@@ -1,6 +1,6 @@
 $ECASM=
 IF[{- !$disabled{asm} -}]
-  $ECASM_x86=ecp_nistz256.c ecp_nistz256-x86.s
+  $ECASM_x86=ecp_nistz256.c ecp_nistz256-x86.S
   $ECDEF_x86=ECP_NISTZ256_ASM
 
   $ECASM_x86_64=ecp_nistz256.c ecp_nistz256-x86_64.s x25519-x86_64.s
@@ -72,7 +72,7 @@ SOURCE[../../providers/libfips.a]=$COMMON
 DEFINE[../../libcrypto]=$ECDEF
 DEFINE[../../providers/libfips.a]=$ECDEF
 
-GENERATE[ecp_nistz256-x86.s]=asm/ecp_nistz256-x86.pl
+GENERATE[ecp_nistz256-x86.S]=asm/ecp_nistz256-x86.pl
 
 GENERATE[ecp_nistz256-x86_64.s]=asm/ecp_nistz256-x86_64.pl
 

--- a/crypto/md5/build.info
+++ b/crypto/md5/build.info
@@ -2,7 +2,7 @@ LIBS=../../libcrypto
 
 $MD5ASM=
 IF[{- !$disabled{asm} -}]
-  $MD5ASM_x86=md5-586.s
+  $MD5ASM_x86=md5-586.S
   $MD5ASM_x86_64=md5-x86_64.s
   $MD5ASM_aarch64=md5-aarch64.s
   $MD5ASM_sparcv9=md5-sparcv9.S
@@ -33,7 +33,7 @@ ENDIF
 DEFINE[../../libcrypto]=$MD5DEF
 DEFINE[../../providers/liblegacy.a]=$MD5DEF
 
-GENERATE[md5-586.s]=asm/md5-586.pl
+GENERATE[md5-586.S]=asm/md5-586.pl
 
 GENERATE[md5-x86_64.s]=asm/md5-x86_64.pl
 GENERATE[md5-aarch64.s]=asm/md5-aarch64.pl

--- a/crypto/modes/build.info
+++ b/crypto/modes/build.info
@@ -2,7 +2,7 @@ LIBS=../../libcrypto
 
 $MODESASM=
 IF[{- !$disabled{asm} -}]
-  $MODESASM_x86=ghash-x86.s
+  $MODESASM_x86=ghash-x86.S
   $MODESDEF_x86=GHASH_ASM
   $MODESASM_x86_64=ghash-x86_64.s aesni-gcm-x86_64.s aes-gcm-avx512.s
   $MODESDEF_x86_64=GHASH_ASM
@@ -66,7 +66,7 @@ DEFINE[../../providers/libfips.a]=$MODESDEF
 INCLUDE[gcm128.o]=..
 
 GENERATE[ghash-ia64.s]=asm/ghash-ia64.pl
-GENERATE[ghash-x86.s]=asm/ghash-x86.pl
+GENERATE[ghash-x86.S]=asm/ghash-x86.pl
 GENERATE[ghash-x86_64.s]=asm/ghash-x86_64.pl
 GENERATE[aesni-gcm-x86_64.s]=asm/aesni-gcm-x86_64.pl
 GENERATE[aes-gcm-avx512.s]=asm/aes-gcm-avx512.pl

--- a/crypto/perlasm/x86asm.pl
+++ b/crypto/perlasm/x86asm.pl
@@ -174,7 +174,9 @@ sub ::vprotd
 
 sub ::endbranch
 {
+    &::generic("#ifdef __CET__\n");
     &::data_byte(0xf3,0x0f,0x1e,0xfb);
+    &::generic("#endif\n");
 }
 
 # label management

--- a/crypto/poly1305/build.info
+++ b/crypto/poly1305/build.info
@@ -2,7 +2,7 @@ LIBS=../../libcrypto
 
 $POLY1305ASM=
 IF[{- !$disabled{asm} -}]
-  $POLY1305ASM_x86=poly1305-x86.s
+  $POLY1305ASM_x86=poly1305-x86.S
   $POLY1305ASM_x86_64=poly1305-x86_64.s
 
   $POLY1305ASM_ia64=asm/poly1305-ia64.s
@@ -37,7 +37,7 @@ DEFINE[../../libcrypto]=$POLY1305DEF
 
 GENERATE[poly1305-sparcv9.S]=asm/poly1305-sparcv9.pl
 INCLUDE[poly1305-sparcv9.o]=..
-GENERATE[poly1305-x86.s]=asm/poly1305-x86.pl
+GENERATE[poly1305-x86.S]=asm/poly1305-x86.pl
 GENERATE[poly1305-x86_64.s]=asm/poly1305-x86_64.pl
 GENERATE[poly1305-ppc.s]=asm/poly1305-ppc.pl
 GENERATE[poly1305-ppcfp.s]=asm/poly1305-ppcfp.pl

--- a/crypto/rc4/build.info
+++ b/crypto/rc4/build.info
@@ -2,7 +2,7 @@ LIBS=../../libcrypto
 
 $RC4ASM=rc4_enc.c rc4_skey.c
 IF[{- !$disabled{asm} -}]
-  $RC4ASM_x86=rc4-586.s
+  $RC4ASM_x86=rc4-586.S
   $RC4ASM_x86_64=rc4-x86_64.s rc4-md5-x86_64.s
   $RC4ASM_s390x=rc4-s390x.s
   $RC4ASM_parisc11=rc4-parisc.s
@@ -25,8 +25,8 @@ IF[{- $disabled{'deprecated-3.0'} -}]
   SOURCE[../../providers/liblegacy.a]=$RC4ASM
 ENDIF
 
-GENERATE[rc4-586.s]=asm/rc4-586.pl
-DEPEND[rc4-586.s]=../perlasm/x86asm.pl
+GENERATE[rc4-586.S]=asm/rc4-586.pl
+DEPEND[rc4-586.S]=../perlasm/x86asm.pl
 
 GENERATE[rc4-x86_64.s]=asm/rc4-x86_64.pl
 GENERATE[rc4-md5-x86_64.s]=asm/rc4-md5-x86_64.pl

--- a/crypto/rc5/build.info
+++ b/crypto/rc5/build.info
@@ -2,7 +2,7 @@ LIBS=../../libcrypto
 
 $RC5ASM=rc5_enc.c
 IF[{- !$disabled{asm} -}]
-  $RC5ASM_x86=rc5-586.s
+  $RC5ASM_x86=rc5-586.S
 
   # Now that we have defined all the arch specific variables, use the
   # appropriate one, and define the appropriate macros
@@ -22,5 +22,5 @@ IF[{- $disabled{'deprecated-3.0'} -}]
   SOURCE[../../providers/liblegacy.a]=$ALL
 ENDIF
 
-GENERATE[rc5-586.s]=asm/rc5-586.pl
-DEPEND[rc5-586.s]=../perlasm/x86asm.pl ../perlasm/cbc.pl
+GENERATE[rc5-586.S]=asm/rc5-586.pl
+DEPEND[rc5-586.S]=../perlasm/x86asm.pl ../perlasm/cbc.pl

--- a/crypto/ripemd/build.info
+++ b/crypto/ripemd/build.info
@@ -2,7 +2,7 @@ LIBS=../../libcrypto
 
 $RMD160ASM=
 IF[{- !$disabled{asm} -}]
-  $RMD160ASM_x86=rmd-586.s
+  $RMD160ASM_x86=rmd-586.S
 
   # Now that we have defined all the arch specific variables, use the
   # appropriate one, and define the appropriate macros
@@ -25,5 +25,5 @@ IF[{- $disabled{'deprecated-3.0'} -}]
   DEFINE[../../providers/liblegacy.a]=$RMD160DEF
 ENDIF
 
-GENERATE[rmd-586.s]=asm/rmd-586.pl
-DEPEND[rmd-586.s]=../perlasm/x86asm.pl
+GENERATE[rmd-586.S]=asm/rmd-586.pl
+DEPEND[rmd-586.S]=../perlasm/x86asm.pl

--- a/crypto/sha/build.info
+++ b/crypto/sha/build.info
@@ -2,7 +2,7 @@ LIBS=../../libcrypto
 
 $SHA1ASM=
 IF[{- !$disabled{asm} -}]
-  $SHA1ASM_x86=sha1-586.s sha256-586.s sha512-586.s
+  $SHA1ASM_x86=sha1-586.S sha256-586.S sha512-586.S
   $SHA1DEF_x86=SHA1_ASM SHA256_ASM SHA512_ASM
   $SHA1ASM_x86_64=\
         sha1-x86_64.s sha256-x86_64.s sha512-x86_64.s sha1-mb-x86_64.s \
@@ -83,12 +83,12 @@ SOURCE[../../providers/libfips.a]= $COMMON
 DEFINE[../../libcrypto]=$SHA1DEF $KECCAK1600DEF
 DEFINE[../../providers/libfips.a]=$SHA1DEF $KECCAK1600DEF
 
-GENERATE[sha1-586.s]=asm/sha1-586.pl
-DEPEND[sha1-586.s]=../perlasm/x86asm.pl
-GENERATE[sha256-586.s]=asm/sha256-586.pl
-DEPEND[sha256-586.s]=../perlasm/x86asm.pl
-GENERATE[sha512-586.s]=asm/sha512-586.pl
-DEPEND[sha512-586.s]=../perlasm/x86asm.pl
+GENERATE[sha1-586.S]=asm/sha1-586.pl
+DEPEND[sha1-586.S]=../perlasm/x86asm.pl
+GENERATE[sha256-586.S]=asm/sha256-586.pl
+DEPEND[sha256-586.S]=../perlasm/x86asm.pl
+GENERATE[sha512-586.S]=asm/sha512-586.pl
+DEPEND[sha512-586.S]=../perlasm/x86asm.pl
 
 GENERATE[sha1-ia64.s]=asm/sha1-ia64.pl
 GENERATE[sha256-ia64.s]=asm/sha512-ia64.pl

--- a/crypto/whrlpool/build.info
+++ b/crypto/whrlpool/build.info
@@ -3,7 +3,7 @@ LIBS=../../libcrypto
 $WPASM=wp_block.c
 IF[{- !$disabled{asm} -}]
   IF[{- $config{processor} ne "386" -}]
-    $WPASM_x86=wp_block.c wp-mmx.s
+    $WPASM_x86=wp_block.c wp-mmx.S
     $WPDEF_x86=WHIRLPOOL_ASM
   ENDIF
   $WPASM_x86_64=wp-x86_64.s
@@ -27,7 +27,7 @@ IF[{- $disabled{'deprecated-3.0'} -}]
   DEFINE[../../providers/liblegacy.a]=$WPDEF
 ENDIF
 
-GENERATE[wp-mmx.s]=asm/wp-mmx.pl
-DEPEND[wp-mmx.s]=../perlasm/x86asm.pl
+GENERATE[wp-mmx.S]=asm/wp-mmx.pl
+DEPEND[wp-mmx.S]=../perlasm/x86asm.pl
 
 GENERATE[wp-x86_64.s]=asm/wp-x86_64.pl

--- a/engines/build.info
+++ b/engines/build.info
@@ -1,7 +1,7 @@
 IF[{- !$disabled{"engine"} -}]
   $PADLOCKASM=
   IF[{- !$disabled{asm} -}]
-    $PADLOCKASM_x86=e_padlock-x86.s
+    $PADLOCKASM_x86=e_padlock-x86.S
     $PADLOCKASM_x86_64=e_padlock-x86_64.s
 
     # Now that we have defined all the arch specific variables, use the
@@ -98,6 +98,6 @@ IF[{- !$disabled{"engine"} -}]
       GENERATE[ossltest.ld]=../util/engines.num
     ENDIF
   ENDIF
-  GENERATE[e_padlock-x86.s]=asm/e_padlock-x86.pl
+  GENERATE[e_padlock-x86.S]=asm/e_padlock-x86.pl
   GENERATE[e_padlock-x86_64.s]=asm/e_padlock-x86_64.pl
 ENDIF


### PR DESCRIPTION
The VIA Nehemiah CPU is a x86-32 CPU without SSE2 support. It does not
support multi byte nops and considers the endb32 opcode as an invalid
instruction.

First patch renames .s -> .S so the pre-processor picks up the ifdef and second
patch adds the ifdef to the perl script.

Fixes: #18334