### PR TITLE
Add Reproducible Error Injection

### DIFF
--- a/fuzz/asn1.c
+++ b/fuzz/asn1.c
@@ -286,6 +286,9 @@ int FuzzerInitialize(int *argc, char ***argv)
 {
     FuzzerSetRand();
     pctx = ASN1_PCTX_new();
+    if (pctx == NULL)
+        return 0;
+
     ASN1_PCTX_set_flags(pctx, ASN1_PCTX_FLAGS_SHOW_ABSENT |
         ASN1_PCTX_FLAGS_SHOW_SEQUENCE | ASN1_PCTX_FLAGS_SHOW_SSOF |
         ASN1_PCTX_FLAGS_SHOW_TYPE | ASN1_PCTX_FLAGS_SHOW_FIELD_STRUCT_NAME);

--- a/fuzz/bndiv.c
+++ b/fuzz/bndiv.c
@@ -21,22 +21,8 @@
 /* 256 kB */
 #define MAX_LEN (256 * 1000)
 
-static BN_CTX *ctx;
-static BIGNUM *b1;
-static BIGNUM *b2;
-static BIGNUM *b3;
-static BIGNUM *b4;
-static BIGNUM *b5;
-
 int FuzzerInitialize(int *argc, char ***argv)
 {
-    b1 = BN_new();
-    b2 = BN_new();
-    b3 = BN_new();
-    b4 = BN_new();
-    b5 = BN_new();
-    ctx = BN_CTX_new();
-
     OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CRYPTO_STRINGS, NULL);
     ERR_clear_error();
 
@@ -49,6 +35,22 @@ int FuzzerTestOneInput(const uint8_t *buf, size_t len)
     size_t l1 = 0, l2 = 0;
     /* s1 and s2 will be the signs for b1 and b2. */
     int s1 = 0, s2 = 0;
+    BN_CTX *ctx;
+    BIGNUM *b1;
+    BIGNUM *b2;
+    BIGNUM *b3;
+    BIGNUM *b4;
+    BIGNUM *b5;
+
+    b1 = BN_new();
+    b2 = BN_new();
+    b3 = BN_new();
+    b4 = BN_new();
+    b5 = BN_new();
+    ctx = BN_CTX_new();
+    if (b1 == NULL || b2 == NULL || b3 == NULL
+        || b4 == NULL || b5 == NULL || ctx == NULL)
+        goto err;
 
     /* limit the size of the input to avoid timeout */
     if (len > MAX_LEN)
@@ -69,9 +71,11 @@ int FuzzerTestOneInput(const uint8_t *buf, size_t len)
         ++buf;
         l2 = len - l1;
     }
-    OPENSSL_assert(BN_bin2bn(buf, l1, b1) == b1);
+    if (BN_bin2bn(buf, l1, b1) != b1)
+        goto err;
     BN_set_negative(b1, s1);
-    OPENSSL_assert(BN_bin2bn(buf + l1, l2, b2) == b2);
+    if (BN_bin2bn(buf + l1, l2, b2) != b2)
+        goto err;
     BN_set_negative(b2, s2);
 
     /* divide by 0 is an error */
@@ -80,7 +84,12 @@ int FuzzerTestOneInput(const uint8_t *buf, size_t len)
         goto done;
     }
 
-    OPENSSL_assert(BN_div(b3, b4, b1, b2, ctx));
+    if (!BN_div(b3, b4, b1, b2, ctx))
+        goto err;
+    if (!BN_mul(b5, b3, b2, ctx))
+        goto err;
+    if (!BN_add(b5, b5, b4))
+        goto err;
     if (BN_is_zero(b1))
         success = BN_is_zero(b3) && BN_is_zero(b4);
     else if (BN_is_negative(b1))
@@ -89,8 +98,6 @@ int FuzzerTestOneInput(const uint8_t *buf, size_t len)
     else
         success = (BN_is_negative(b3) == BN_is_negative(b2)  || BN_is_zero(b3))
             && (!BN_is_negative(b4) || BN_is_zero(b4));
-    OPENSSL_assert(BN_mul(b5, b3, b2, ctx));
-    OPENSSL_assert(BN_add(b5, b5, b4));
 
     success = success && BN_cmp(b5, b1) == 0;
     if (!success) {
@@ -115,6 +122,13 @@ int FuzzerTestOneInput(const uint8_t *buf, size_t len)
 
  done:
     OPENSSL_assert(success);
+ err:
+    BN_free(b1);
+    BN_free(b2);
+    BN_free(b3);
+    BN_free(b4);
+    BN_free(b5);
+    BN_CTX_free(ctx);
     ERR_clear_error();
 
     return 0;
@@ -122,10 +136,4 @@ int FuzzerTestOneInput(const uint8_t *buf, size_t len)
 
 void FuzzerCleanup(void)
 {
-    BN_free(b1);
-    BN_free(b2);
-    BN_free(b3);
-    BN_free(b4);
-    BN_free(b5);
-    BN_CTX_free(ctx);
 }

--- a/fuzz/client.c
+++ b/fuzz/client.c
@@ -72,7 +72,8 @@ int FuzzerTestOneInput(const uint8_t *buf, size_t len)
     if (client == NULL)
         goto end;
     OPENSSL_assert(SSL_set_min_proto_version(client, 0) == 1);
-    OPENSSL_assert(SSL_set_cipher_list(client, "ALL:eNULL:@SECLEVEL=0") == 1);
+    if (SSL_set_cipher_list(client, "ALL:eNULL:@SECLEVEL=0") != 1)
+        goto end;
     SSL_set_tlsext_host_name(client, "localhost");
     in = BIO_new(BIO_s_mem());
     if (in == NULL)
@@ -84,7 +85,8 @@ int FuzzerTestOneInput(const uint8_t *buf, size_t len)
     }
     SSL_set_bio(client, in, out);
     SSL_set_connect_state(client);
-    OPENSSL_assert((size_t)BIO_write(in, buf, len) == len);
+    if ((size_t)BIO_write(in, buf, len) != len)
+        goto end;
     if (SSL_do_handshake(client) == 1) {
         /* Keep reading application data until error or EOF. */
         uint8_t tmp[1024];

--- a/fuzz/cmp.c
+++ b/fuzz/cmp.c
@@ -164,7 +164,10 @@ int FuzzerTestOneInput(const uint8_t *buf, size_t len)
         return 0;
 
     in = BIO_new(BIO_s_mem());
-    OPENSSL_assert((size_t)BIO_write(in, buf, len) == len);
+    if ((size_t)BIO_write(in, buf, len) != len) {
+        BIO_free(in);
+        return 0;
+    }
     msg = d2i_OSSL_CMP_MSG_bio(in, NULL);
     if (msg != NULL) {
         BIO *out = BIO_new(BIO_s_null());

--- a/fuzz/cms.c
+++ b/fuzz/cms.c
@@ -34,7 +34,10 @@ int FuzzerTestOneInput(const uint8_t *buf, size_t len)
         return 0;
 
     in = BIO_new(BIO_s_mem());
-    OPENSSL_assert((size_t)BIO_write(in, buf, len) == len);
+    if ((size_t)BIO_write(in, buf, len) != len) {
+        BIO_free(in);
+        return 0;
+    }
     cms = d2i_CMS_bio(in, NULL);
     if (cms != NULL) {
         BIO *out = BIO_new(BIO_s_null());

--- a/fuzz/conf.c
+++ b/fuzz/conf.c
@@ -34,7 +34,11 @@ int FuzzerTestOneInput(const uint8_t *buf, size_t len)
 
     conf = NCONF_new(NULL);
     in = BIO_new(BIO_s_mem());
-    OPENSSL_assert((size_t)BIO_write(in, buf, len) == len);
+    if ((size_t)BIO_write(in, buf, len) != len) {
+        BIO_free(in);
+        NCONF_free(conf);
+        return 0;
+    }
     NCONF_load_bio(conf, in, &eline);
     NCONF_free(conf);
     BIO_free(in);

--- a/fuzz/fuzz_rand.c
+++ b/fuzz/fuzz_rand.c
@@ -159,7 +159,11 @@ void FuzzerSetRand(void)
     if (!OSSL_PROVIDER_add_builtin(NULL, "fuzz-rand", fuzz_rand_provider_init)
         || !RAND_set_DRBG_type(NULL, "fuzz", NULL, NULL, NULL)
         || (r_prov = OSSL_PROVIDER_try_load(NULL, "fuzz-rand", 1)) == NULL)
+#ifdef ERROR_INJECT
+        exit(0);
+#else
         exit(1);
+#endif
 }
 
 void FuzzerClearRand(void)

--- a/fuzz/server.c
+++ b/fuzz/server.c
@@ -540,18 +540,32 @@ int FuzzerTestOneInput(const uint8_t *buf, size_t len)
 
     /* This only fuzzes the initial flow from the client so far. */
     ctx = SSL_CTX_new(SSLv23_method());
+    if (ctx == NULL)
+        return 0;
 
     ret = SSL_CTX_set_min_proto_version(ctx, 0);
     OPENSSL_assert(ret == 1);
     ret = SSL_CTX_set_cipher_list(ctx, "ALL:eNULL:@SECLEVEL=0");
-    OPENSSL_assert(ret == 1);
+    if (ret != 1) {
+        SSL_CTX_free(ctx);
+        return 0;
+    }
 
 #ifndef OPENSSL_NO_DEPRECATED_3_0
     /* RSA */
     bufp = kRSAPrivateKeyDER;
     privkey = d2i_RSAPrivateKey(NULL, &bufp, sizeof(kRSAPrivateKeyDER));
+    if (privkey == NULL) {
+        SSL_CTX_free(ctx);
+        return 0;
+    }
     OPENSSL_assert(privkey != NULL);
     pkey = EVP_PKEY_new();
+    if (pkey == NULL) {
+        RSA_free(privkey);
+        SSL_CTX_free(ctx);
+        return 0;
+    }
     EVP_PKEY_assign_RSA(pkey, privkey);
     ret = SSL_CTX_use_PrivateKey(ctx, pkey);
     OPENSSL_assert(ret == 1);
@@ -560,61 +574,124 @@ int FuzzerTestOneInput(const uint8_t *buf, size_t len)
 
     bufp = kCertificateDER;
     cert = d2i_X509(NULL, &bufp, sizeof(kCertificateDER));
+    if (cert == NULL) {
+        SSL_CTX_free(ctx);
+        return 0;
+    }
     OPENSSL_assert(cert != NULL);
     ret = SSL_CTX_use_certificate(ctx, cert);
-    OPENSSL_assert(ret == 1);
     X509_free(cert);
+    if (ret != 1) {
+        SSL_CTX_free(ctx);
+        return 0;
+    }
 
 #ifndef OPENSSL_NO_EC
 # ifndef OPENSSL_NO_DEPRECATED_3_0
     /* ECDSA */
     bio_buf = BIO_new(BIO_s_mem());
-    OPENSSL_assert((size_t)BIO_write(bio_buf, ECDSAPrivateKeyPEM, sizeof(ECDSAPrivateKeyPEM)) == sizeof(ECDSAPrivateKeyPEM));
+    if ((size_t)BIO_write(bio_buf, ECDSAPrivateKeyPEM, sizeof(ECDSAPrivateKeyPEM)) != sizeof(ECDSAPrivateKeyPEM)) {
+        BIO_free(bio_buf);
+        SSL_CTX_free(ctx);
+        return 0;
+    }
     ecdsakey = PEM_read_bio_ECPrivateKey(bio_buf, NULL, NULL, NULL);
     ERR_print_errors_fp(stderr);
+    if (ecdsakey == NULL) {
+        BIO_free(bio_buf);
+        SSL_CTX_free(ctx);
+        return 0;
+    }
     OPENSSL_assert(ecdsakey != NULL);
     BIO_free(bio_buf);
     pkey = EVP_PKEY_new();
+    if (pkey == NULL) {
+        EC_KEY_free(ecdsakey);
+        SSL_CTX_free(ctx);
+        return 0;
+    }
     EVP_PKEY_assign_EC_KEY(pkey, ecdsakey);
     ret = SSL_CTX_use_PrivateKey(ctx, pkey);
     OPENSSL_assert(ret == 1);
     EVP_PKEY_free(pkey);
 # endif
     bio_buf = BIO_new(BIO_s_mem());
-    OPENSSL_assert((size_t)BIO_write(bio_buf, ECDSACertPEM, sizeof(ECDSACertPEM)) == sizeof(ECDSACertPEM));
+    if ((size_t)BIO_write(bio_buf, ECDSACertPEM, sizeof(ECDSACertPEM)) != sizeof(ECDSACertPEM)) {
+        BIO_free(bio_buf);
+        SSL_CTX_free(ctx);
+        return 0;
+    }
     cert = PEM_read_bio_X509(bio_buf, NULL, NULL, NULL);
+    if (cert == NULL) {
+        BIO_free(bio_buf);
+        SSL_CTX_free(ctx);
+        return 0;
+    }
     OPENSSL_assert(cert != NULL);
     BIO_free(bio_buf);
     ret = SSL_CTX_use_certificate(ctx, cert);
-    OPENSSL_assert(ret == 1);
     X509_free(cert);
+    if(ret != 1) {
+        SSL_CTX_free(ctx);
+        return 0;
+    }
 #endif
 
 #if !defined(OPENSSL_NO_DSA) && !defined(OPENSSL_NO_DEPRECATED_3_0)
     /* DSA */
     bio_buf = BIO_new(BIO_s_mem());
-    OPENSSL_assert((size_t)BIO_write(bio_buf, DSAPrivateKeyPEM, sizeof(DSAPrivateKeyPEM)) == sizeof(DSAPrivateKeyPEM));
+    if ((size_t)BIO_write(bio_buf, DSAPrivateKeyPEM, sizeof(DSAPrivateKeyPEM)) != sizeof(DSAPrivateKeyPEM)) {
+        BIO_free(bio_buf);
+        SSL_CTX_free(ctx);
+        return 0;
+    }
     dsakey = PEM_read_bio_DSAPrivateKey(bio_buf, NULL, NULL, NULL);
     ERR_print_errors_fp(stderr);
+    if (dsakey == NULL) {
+        BIO_free(bio_buf);
+        SSL_CTX_free(ctx);
+        return 0;
+    }
     OPENSSL_assert(dsakey != NULL);
     BIO_free(bio_buf);
     pkey = EVP_PKEY_new();
+    if (pkey == NULL) {
+        DSA_free(dsakey);
+        SSL_CTX_free(ctx);
+        return 0;
+    }
     EVP_PKEY_assign_DSA(pkey, dsakey);
     ret = SSL_CTX_use_PrivateKey(ctx, pkey);
     OPENSSL_assert(ret == 1);
     EVP_PKEY_free(pkey);
 
     bio_buf = BIO_new(BIO_s_mem());
-    OPENSSL_assert((size_t)BIO_write(bio_buf, DSACertPEM, sizeof(DSACertPEM)) == sizeof(DSACertPEM));
+    if ((size_t)BIO_write(bio_buf, DSACertPEM, sizeof(DSACertPEM)) != sizeof(DSACertPEM)) {
+        BIO_free(bio_buf);
+        SSL_CTX_free(ctx);
+        return 0;
+    }
     cert = PEM_read_bio_X509(bio_buf, NULL, NULL, NULL);
+    if (cert == NULL) {
+        BIO_free(bio_buf);
+        SSL_CTX_free(ctx);
+        return 0;
+    }
     OPENSSL_assert(cert != NULL);
     BIO_free(bio_buf);
     ret = SSL_CTX_use_certificate(ctx, cert);
-    OPENSSL_assert(ret == 1);
     X509_free(cert);
+    if(ret != 1) {
+        SSL_CTX_free(ctx);
+        return 0;
+    }
 #endif
 
     server = SSL_new(ctx);
+    if (server == NULL) {
+        SSL_CTX_free(ctx);
+        return 0;
+    }
     in = BIO_new(BIO_s_mem());
     out = BIO_new(BIO_s_mem());
     SSL_set_bio(server, in, out);
@@ -623,7 +700,11 @@ int FuzzerTestOneInput(const uint8_t *buf, size_t len)
     opt = (uint8_t)buf[len-1];
     len--;
 
-    OPENSSL_assert((size_t)BIO_write(in, buf, len) == len);
+    if ((size_t)BIO_write(in, buf, len) != len) {
+        SSL_free(server);
+        SSL_CTX_free(ctx);
+        return 0;
+    }
 
     if ((opt & 0x01) != 0)
     {

--- a/fuzz/test-corpus.c
+++ b/fuzz/test-corpus.c
@@ -22,6 +22,128 @@
 #include "fuzzer.h"
 #include "internal/o_dir.h"
 
+#ifdef ERROR_INJECT
+# ifdef __linux__
+#  include <sys/time.h>
+# endif
+# ifdef __SANITIZE_ADDRESS__
+#  include <sanitizer/asan_interface.h>
+# endif
+
+static uint64_t my_seed = 88172645463325252LL;
+
+static void my_srand(uint32_t seed)
+{
+    uint64_t y = seed;
+    y ^= (~y) << 32;
+    my_seed = y;
+}
+
+static uint32_t my_rand(void)
+{
+    /*
+     * Implement the 64 bit xorshift as suggested by George Marsaglia in:
+     *      https://doi.org/10.18637/jss.v008.i14
+     */
+    uint64_t y = my_seed;
+    y ^= y << 13;
+    y ^= y >> 7;
+    y ^= y << 17;
+    my_seed = y;
+    return y;
+}
+
+static void my_init(void)
+{
+    static int init = 0;
+    if(!init) {
+        uint32_t seed;
+        char *env = getenv("ERROR_INJECT");
+        if (env && *env) {
+            seed = atoi(env);
+        } else {
+# ifdef __linux__
+            struct timeval tv;
+            gettimeofday(&tv, NULL);
+            seed = (uint32_t)(tv.tv_sec ^ tv.tv_usec);
+# else
+            seed = (uint32_t)time(NULL);
+# endif
+        }
+        my_srand(seed);
+        init = 1;
+        if (env && !*env) {
+# ifdef __SANITIZE_ADDRESS__
+            char msg[40];
+            sprintf(msg, "ERROR_INJECT=%u", seed);
+            __sanitizer_report_error_summary(msg);
+# else
+            fprintf(stderr, "ERROR_INJECT=%u\n", seed);
+            fflush(stderr);
+# endif
+        }
+    }
+}
+
+# ifdef ERROR_CALLSTACK
+#  ifdef __SANITIZE_ADDRESS__
+#   define MY_NULL (__sanitizer_print_stack_trace(),NULL)
+#  else
+void break_here(void);
+void break_here(void)
+{
+}
+#   define MY_NULL (break_here(),NULL)
+#  endif
+# else
+#  define MY_NULL NULL
+# endif
+
+static void* my_malloc(size_t s
+#if OPENSSL_VERSION_NUMBER >= 0x1010000fL
+    , const char *file
+    , int line
+#endif
+    )
+{
+#if OPENSSL_VERSION_NUMBER >= 0x1010000fL
+    (void)file;
+    (void)line;
+#endif
+    my_init();
+    return my_rand() % 10000 ? malloc(s) : MY_NULL;
+}
+
+static void* my_realloc(void *p, size_t s
+#if OPENSSL_VERSION_NUMBER >= 0x1010000fL
+    , const char *file
+    , int line
+#endif
+    )
+{
+#if OPENSSL_VERSION_NUMBER >= 0x1010000fL
+    (void)file;
+    (void)line;
+#endif
+    my_init();
+    return my_rand() % 100 ? realloc(p, s) : MY_NULL;
+}
+
+static void my_free(void *p
+#if OPENSSL_VERSION_NUMBER >= 0x1010000fL
+    , const char *file
+    , int line
+#endif
+    )
+{
+#if OPENSSL_VERSION_NUMBER >= 0x1010000fL
+    (void)file;
+    (void)line;
+#endif
+    free(p);
+}
+#endif /* ERROR_INJECT */
+
 #if defined(_WIN32) && defined(_MAX_PATH) && !defined(PATH_MAX)
 # define PATH_MAX _MAX_PATH
 #endif
@@ -52,6 +174,11 @@ static void testfile(const char *pathname)
     if (buf != NULL) {
         s = fread(buf, 1, st.st_size, f);
         OPENSSL_assert(s == (size_t)st.st_size);
+#ifdef ERROR_INJECT
+        if (s > 0)
+            while (my_rand() % 3 <= 1)
+                buf[my_rand() % s] = (unsigned char)my_rand();
+#endif
         FuzzerTestOneInput(buf, s);
         free(buf);
     }
@@ -61,6 +188,9 @@ static void testfile(const char *pathname)
 int main(int argc, char **argv) {
     int n;
 
+#ifdef ERROR_INJECT
+    CRYPTO_set_mem_functions(my_malloc, my_realloc, my_free);
+#endif
     FuzzerInitialize(&argc, &argv);
 
     for (n = 1; n < argc; ++n) {

--- a/fuzz/testrun.sh
+++ b/fuzz/testrun.sh
@@ -1,0 +1,29 @@
+#! /bin/bash
+while true
+do
+  for X in `ls ./corpora`
+  do
+    echo `date`: running $X
+    for Y in `ls ./corpora/$X`
+    do
+      UBSAN_OPTIONS=${UBSAN_OPTIONS:-print_stacktrace=1} \
+      ERROR_INJECT=${ERROR_INJECT:-} \
+      ../util/shlib_wrap.sh ./$X-test ./corpora/$X/$Y &> $X-$Y-$$-test.out
+      if [ $? != 0 ]
+      then
+        echo `date`: error detected
+        echo `grep ERROR_INJECT= $X-$Y-$$-test.out` ../util/shlib_wrap.sh ./$X-test ./corpora/$X/$Y
+        echo log file: $X-$Y-$$-test.out
+        cat $X-$Y-$$-test.out
+        exit
+      fi
+      rm $X-$Y-$$-test.out
+      if [ -f stop.signal ]
+      then
+        rm stop.signal
+        echo `date`: stopped
+        exit
+      fi
+    done
+  done
+done


### PR DESCRIPTION
This adds reproducible memory error and test-data
error injection, to the fuzzy-test framework.

This feature can be enabled with ./config -DERROR_INJECT
and additionally to enable call stacks -DERROR_CALLSTACK

If enable-asan is used, the callstack is printed by the
sanitizer, otherwise please set a breakpoint
at the function "break_here", which is executed each
time a memory allocation error is injected.

If called with the environment variable ERROR_INJECT
defined to the empty string the initialization value
is printed, and can be used to reproduce the failure
later, by passing the value to the ERROR_INJECT variable.

There is a search script that can be used to look
for errors, and print the command to reproduce the bug:

./testrun.sh

This runs in endless mode until an error is found.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
