### PR TITLE
Fix a crash in asn1_item_embed_new

### DIFF
--- a/crypto/x509/x_crl.c
+++ b/crypto/x509/x_crl.c
@@ -255,7 +255,7 @@ static int crl_cb(int operation, ASN1_VALUE **pval, const ASN1_ITEM *it,
         break;
 
     case ASN1_OP_FREE_POST:
-        if (crl->meth->crl_free) {
+        if (crl->meth != NULL && crl->meth->crl_free != NULL) {
             if (!crl->meth->crl_free(crl))
                 return 0;
         }


### PR DESCRIPTION
This happens usually if an template object is created
and there is an out of memory error before the ASN1_OP_NEW_POST
method is called, but asn1_item_embed_free calls now the
ASN1_OP_FREE_POST which may crash because the object is not
properly initialized.  Apparently that is only an issue with
the ASN1_OP_FREE_POST handling of crypot/x509/x_crl.c, which
ought to be tolerant to incomplete initialized objects.

The error can be reproduced with the reproducible error injection patch:
```
$ ERROR_INJECT=1652890550 ../util/shlib_wrap.sh ./asn1-test ./corpora/asn1/0ff17293911f54d1538b9896563a4048d67d9ee4
    #0 0x7faae9dbeeba in __sanitizer_print_stack_trace ../../../../gcc-trunk/libsanitizer/asan/asan_stack.cpp:87
    #1 0x408dc4 in my_malloc fuzz/test-corpus.c:114
    #2 0x7faae99f2430 in CRYPTO_zalloc crypto/mem.c:230
    #3 0x7faae97f09e5 in ASN1_STRING_type_new crypto/asn1/asn1_lib.c:341
    #4 0x7faae98118f7 in asn1_primitive_new crypto/asn1/tasn_new.c:318
    #5 0x7faae9812401 in asn1_item_embed_new crypto/asn1/tasn_new.c:78
    #6 0x7faae9812401 in asn1_template_new crypto/asn1/tasn_new.c:240
    #7 0x7faae9812315 in asn1_item_embed_new crypto/asn1/tasn_new.c:137
    #8 0x7faae9812315 in asn1_template_new crypto/asn1/tasn_new.c:240
    #9 0x7faae9812a54 in asn1_item_embed_new crypto/asn1/tasn_new.c:137
    #10 0x7faae9812a54 in ASN1_item_ex_new crypto/asn1/tasn_new.c:39
    #11 0x7faae980be51 in asn1_item_embed_d2i crypto/asn1/tasn_dec.c:325
    #12 0x7faae980c813 in asn1_template_noexp_d2i crypto/asn1/tasn_dec.c:611
    #13 0x7faae980d288 in asn1_template_ex_d2i crypto/asn1/tasn_dec.c:518
    #14 0x7faae980b9ce in asn1_item_embed_d2i crypto/asn1/tasn_dec.c:382
    #15 0x7faae980caf5 in asn1_template_noexp_d2i crypto/asn1/tasn_dec.c:643
    #16 0x7faae980d7d3 in asn1_template_ex_d2i crypto/asn1/tasn_dec.c:494
    #17 0x7faae980b9ce in asn1_item_embed_d2i crypto/asn1/tasn_dec.c:382
    #18 0x7faae980dd1f in ASN1_item_ex_d2i crypto/asn1/tasn_dec.c:124
    #19 0x7faae980de35 in ASN1_item_d2i crypto/asn1/tasn_dec.c:114
    #20 0x40712c in FuzzerTestOneInput fuzz/asn1.c:301
    #21 0x40893b in testfile fuzz/test-corpus.c:182
    #22 0x406b86 in main fuzz/test-corpus.c:226
    #23 0x7faae8eb1f44 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21f44)

AddressSanitizer:DEADLYSIGNAL
=================================================================
==1194==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000010 (pc 0x7faae9b0625f bp 0x7fffffe41a00 sp 0x7fffffe41920 T0)
==1194==The signal is caused by a READ memory access.
==1194==Hint: address points to the zero page.
    #0 0x7faae9b0625f in crl_cb crypto/x509/x_crl.c:258
    #1 0x7faae9811255 in asn1_item_embed_free crypto/asn1/tasn_fre.c:113
    #2 0x7faae9812a65 in asn1_item_embed_new crypto/asn1/tasn_new.c:150
    #3 0x7faae9812a65 in ASN1_item_ex_new crypto/asn1/tasn_new.c:39
    #4 0x7faae980be51 in asn1_item_embed_d2i crypto/asn1/tasn_dec.c:325
    #5 0x7faae980c813 in asn1_template_noexp_d2i crypto/asn1/tasn_dec.c:611
    #6 0x7faae980d288 in asn1_template_ex_d2i crypto/asn1/tasn_dec.c:518
    #7 0x7faae980b9ce in asn1_item_embed_d2i crypto/asn1/tasn_dec.c:382
    #8 0x7faae980caf5 in asn1_template_noexp_d2i crypto/asn1/tasn_dec.c:643
    #9 0x7faae980d7d3 in asn1_template_ex_d2i crypto/asn1/tasn_dec.c:494
    #10 0x7faae980b9ce in asn1_item_embed_d2i crypto/asn1/tasn_dec.c:382
    #11 0x7faae980dd1f in ASN1_item_ex_d2i crypto/asn1/tasn_dec.c:124
    #12 0x7faae980de35 in ASN1_item_d2i crypto/asn1/tasn_dec.c:114
    #13 0x40712c in FuzzerTestOneInput fuzz/asn1.c:301
    #14 0x40893b in testfile fuzz/test-corpus.c:182
    #15 0x406b86 in main fuzz/test-corpus.c:226
    #16 0x7faae8eb1f44 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21f44)

AddressSanitizer can not provide additional info.
SUMMARY: AddressSanitizer: SEGV crypto/x509/x_crl.c:258 in crl_cb
==1194==ABORTING
```
