### PR TITLE
Fix regression in default key length for Blowfish CFB and OFB ciphers

### DIFF
--- a/providers/implementations/ciphers/cipher_blowfish.c
+++ b/providers/implementations/ciphers/cipher_blowfish.c
@@ -55,6 +55,6 @@ IMPLEMENT_var_keylen_cipher(blowfish, BLOWFISH, ecb, ECB, BF_FLAGS, 128, 64, 0, 
 /* bf_cbc_functions */
 IMPLEMENT_var_keylen_cipher(blowfish, BLOWFISH, cbc, CBC, BF_FLAGS, 128, 64, 64, block)
 /* bf_ofb_functions */
-IMPLEMENT_var_keylen_cipher(blowfish, BLOWFISH, ofb64, OFB, BF_FLAGS, 64, 8, 64, stream)
+IMPLEMENT_var_keylen_cipher(blowfish, BLOWFISH, ofb64, OFB, BF_FLAGS, 128, 8, 64, stream)
 /* bf_cfb_functions */
-IMPLEMENT_var_keylen_cipher(blowfish, BLOWFISH, cfb64,  CFB, BF_FLAGS, 64, 8, 64, stream)
+IMPLEMENT_var_keylen_cipher(blowfish, BLOWFISH, cfb64,  CFB, BF_FLAGS, 128, 8, 64, stream)

--- a/providers/implementations/include/prov/implementations.h
+++ b/providers/implementations/include/prov/implementations.h
@@ -156,8 +156,8 @@ extern const OSSL_DISPATCH ossl_camellia128ctr_functions[];
 #ifndef OPENSSL_NO_BF
 extern const OSSL_DISPATCH ossl_blowfish128ecb_functions[];
 extern const OSSL_DISPATCH ossl_blowfish128cbc_functions[];
-extern const OSSL_DISPATCH ossl_blowfish64ofb64_functions[];
-extern const OSSL_DISPATCH ossl_blowfish64cfb64_functions[];
+extern const OSSL_DISPATCH ossl_blowfish128ofb64_functions[];
+extern const OSSL_DISPATCH ossl_blowfish128cfb64_functions[];
 #endif /* OPENSSL_NO_BF */
 #ifndef OPENSSL_NO_IDEA
 extern const OSSL_DISPATCH ossl_idea128ecb_functions[];

--- a/providers/legacyprov.c
+++ b/providers/legacyprov.c
@@ -112,8 +112,8 @@ static const OSSL_ALGORITHM legacy_ciphers[] = {
 #ifndef OPENSSL_NO_BF
     ALG(PROV_NAMES_BF_ECB, ossl_blowfish128ecb_functions),
     ALG(PROV_NAMES_BF_CBC, ossl_blowfish128cbc_functions),
-    ALG(PROV_NAMES_BF_OFB, ossl_blowfish64ofb64_functions),
-    ALG(PROV_NAMES_BF_CFB, ossl_blowfish64cfb64_functions),
+    ALG(PROV_NAMES_BF_OFB, ossl_blowfish128ofb64_functions),
+    ALG(PROV_NAMES_BF_CFB, ossl_blowfish128cfb64_functions),
 #endif /* OPENSSL_NO_BF */
 #ifndef OPENSSL_NO_IDEA
     ALG(PROV_NAMES_IDEA_ECB, ossl_idea128ecb_functions),

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -3267,6 +3267,31 @@ err:
 }
 #endif
 
+#ifndef OPENSSL_NO_BF
+static int test_evp_bf_default_keylen(int idx)
+{
+    int ret = 0;
+    static const char *algos[4] = {
+        "bf-ecb", "bf-cbc", "bf-cfb", "bf-ofb"
+    };
+    int ivlen[4] = { 0, 8, 8, 8 };
+    EVP_CIPHER *cipher = NULL;
+
+    if (lgcyprov == NULL)
+        return TEST_skip("Test requires legacy provider to be loaded");
+
+    if (!TEST_ptr(cipher = EVP_CIPHER_fetch(testctx, algos[idx], testpropq))
+            || !TEST_int_eq(EVP_CIPHER_get_key_length(cipher), 16)
+            || !TEST_int_eq(EVP_CIPHER_get_iv_length(cipher), ivlen[idx]))
+        goto err;
+
+    ret = 1;
+err:
+    EVP_CIPHER_free(cipher);
+    return ret;
+}
+#endif
+
 #ifndef OPENSSL_NO_EC
 static int ecpub_nids[] = {
     NID_brainpoolP256r1, NID_X9_62_prime256v1,
@@ -4557,6 +4582,9 @@ int setup_tests(void)
     ADD_ALL_TESTS(test_evp_iv_aes, 12);
 #ifndef OPENSSL_NO_DES
     ADD_ALL_TESTS(test_evp_iv_des, 6);
+#endif
+#ifndef OPENSSL_NO_BF
+    ADD_ALL_TESTS(test_evp_bf_default_keylen, 4);
 #endif
     ADD_TEST(test_EVP_rsa_pss_with_keygen_bits);
     ADD_TEST(test_EVP_rsa_pss_set_saltlen);


### PR DESCRIPTION
Fixes #18359

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
