### PR TITLE
Fix a memory leak in crl_set_issuers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,6 +100,7 @@ providers/common/include/prov/der_sm2.h
 /test/confdump
 /test/bio_prefix_text
 /test/evp_extra_test2
+/test/evp_pkey_ctx_new_from_name
 /test/threadstest_fips
 
 # Certain files that get created by tests on the fly

--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -2327,6 +2327,30 @@ static void print_stats(BIO *bio, SSL_CTX *ssl_ctx)
                SSL_CTX_sess_get_cache_size(ssl_ctx));
 }
 
+static long int count_reads_callback(BIO *bio, int cmd, const char *argp, size_t len,
+                                 int argi, long argl, int ret, size_t *processed)
+{
+    unsigned int *p_counter = (unsigned int *)BIO_get_callback_arg(bio);
+
+    switch (cmd) {
+    case BIO_CB_READ:  /* No break here */
+    case BIO_CB_GETS:
+        if (p_counter != NULL)
+            ++*p_counter;
+        break;
+    default:
+        break;
+    }
+
+    if (s_debug) {
+        BIO_set_callback_arg(bio, (char *)bio_s_out);
+        ret = (int)bio_dump_callback(bio, cmd, argp, len, argi, argl, ret, processed);
+        BIO_set_callback_arg(bio, (char *)p_counter);
+    }
+
+    return ret;
+}
+
 static int sv_body(int s, int stype, int prot, unsigned char *context)
 {
     char *buf = NULL;
@@ -2455,10 +2479,7 @@ static int sv_body(int s, int stype, int prot, unsigned char *context)
     SSL_set_accept_state(con);
     /* SSL_set_fd(con,s); */
 
-    if (s_debug) {
-        BIO_set_callback_ex(SSL_get_rbio(con), bio_dump_callback);
-        BIO_set_callback_arg(SSL_get_rbio(con), (char *)bio_s_out);
-    }
+    BIO_set_callback_ex(SSL_get_rbio(con), count_reads_callback);
     if (s_msg) {
 #ifndef OPENSSL_NO_SSL_TRACE
         if (s_msg == 2)
@@ -2736,8 +2757,25 @@ static int sv_body(int s, int stype, int prot, unsigned char *context)
              */
             if ((!async || !SSL_waiting_for_async(con))
                     && !SSL_is_init_finished(con)) {
-                i = init_ssl_connection(con);
+                /*
+                 * Count number of reads during init_ssl_connection.
+                 * It helps us to distinguish configuration errors from errors
+                 * caused by a client.
+                 */
+                unsigned int read_counter = 0;
 
+                BIO_set_callback_arg(SSL_get_rbio(con), (char *)&read_counter);
+                i = init_ssl_connection(con);
+                BIO_set_callback_arg(SSL_get_rbio(con), NULL);
+
+                /*
+                 * If initialization fails without reads, then
+                 * there was a fatal error in configuration.
+                 */
+                if (i <= 0 && read_counter == 0) {
+                    ret = -1;
+                    goto err;
+                }
                 if (i < 0) {
                     ret = 0;
                     goto err;

--- a/crypto/evp/evp_enc.c
+++ b/crypto/evp/evp_enc.c
@@ -202,6 +202,8 @@ static int evp_cipher_init_internal(EVP_CIPHER_CTX *ctx,
             return 0;
         }
         EVP_CIPHER_free(ctx->fetched_cipher);
+        /* Coverity false positive, the reference counting is confusing it */
+        /* coverity[use_after_free] */
         ctx->fetched_cipher = (EVP_CIPHER *)cipher;
     }
     ctx->cipher = cipher;

--- a/crypto/evp/exchange.c
+++ b/crypto/evp/exchange.c
@@ -332,7 +332,11 @@ int EVP_PKEY_derive_init_ex(EVP_PKEY_CTX *ctx, const OSSL_PARAM params[])
 
     /* No more legacy from here down to legacy: */
 
+    /* A Coverity false positive with up_ref/down_ref and free */
+    /* coverity[use_after_free] */
     ctx->op.kex.exchange = exchange;
+    /* A Coverity false positive with up_ref/down_ref and free */
+    /* coverity[deref_arg] */
     ctx->op.kex.algctx = exchange->newctx(ossl_provider_ctx(exchange->prov));
     if (ctx->op.kex.algctx == NULL) {
         /* The provider key can stay in the cache */
@@ -420,6 +424,8 @@ int EVP_PKEY_derive_set_peer_ex(EVP_PKEY_CTX *ctx, EVP_PKEY *peer,
                                     EVP_KEYMGMT_get0_name(ctx->keymgmt),
                                     ctx->propquery);
     if (tmp_keymgmt != NULL)
+        /* A Coverity issue with up_ref/down_ref and free */
+        /* coverity[pass_freed_arg] */
         provkey = evp_pkey_export_to_provider(peer, ctx->libctx,
                                               &tmp_keymgmt, ctx->propquery);
     EVP_KEYMGMT_free(tmp_keymgmt_tofree);

--- a/crypto/store/store_lib.c
+++ b/crypto/store/store_lib.c
@@ -215,6 +215,8 @@ OSSL_STORE_open_ex(const char *uri, OSSL_LIB_CTX *libctx, const char *propq,
          */
         (void)ossl_store_close_it(&tmpctx);
     }
+    /* Coverity false positive, the reference counting is confusing it */
+    /* coverity[pass_freed_arg] */
     OSSL_STORE_LOADER_free(fetched_loader);
     OPENSSL_free(propq_copy);
     OPENSSL_free(ctx);

--- a/crypto/x509/x_crl.c
+++ b/crypto/x509/x_crl.c
@@ -105,11 +105,15 @@ static int crl_set_issuers(X509_CRL *crl)
             gens = gtmp;
             if (!crl->issuers) {
                 crl->issuers = sk_GENERAL_NAMES_new_null();
-                if (!crl->issuers)
+                if (!crl->issuers) {
+                    GENERAL_NAMES_free(gtmp);
                     return 0;
+                }
             }
-            if (!sk_GENERAL_NAMES_push(crl->issuers, gtmp))
+            if (!sk_GENERAL_NAMES_push(crl->issuers, gtmp)) {
+                GENERAL_NAMES_free(gtmp);
                 return 0;
+            }
         }
         rev->issuer = gens;
 

--- a/crypto/x509/x_crl.c
+++ b/crypto/x509/x_crl.c
@@ -103,9 +103,9 @@ static int crl_set_issuers(X509_CRL *crl)
 
         if (gtmp) {
             gens = gtmp;
-            if (!crl->issuers) {
+            if (crl->issuers == NULL) {
                 crl->issuers = sk_GENERAL_NAMES_new_null();
-                if (!crl->issuers) {
+                if (crl->issuers == NULL) {
                     GENERAL_NAMES_free(gtmp);
                     return 0;
                 }

--- a/test/acvp_test.c
+++ b/test/acvp_test.c
@@ -1381,6 +1381,8 @@ static int drbg_test(int id)
     res = 1;
 err:
     EVP_RAND_CTX_free(ctx);
+    /* Coverity is confused by the upref/free in EVP_RAND_CTX_new() subdue it */
+    /* coverity[pass_freed_arg] */
     EVP_RAND_CTX_free(parent);
     EVP_RAND_free(rand);
     return res;


### PR DESCRIPTION
This can be reproduced with my error injection patch.

The test vector has been validated on the 1.1.1 branch
but the issue is of course identical in all branches.

```
$ ERROR_INJECT=1653520461 ../util/shlib_wrap.sh ./cms-test ./corpora/cms/3eff1d2f1232bd66d5635db2c3f9e7f23830dfd1
log file: cms-3eff1d2f1232bd66d5635db2c3f9e7f23830dfd1-32454-test.out
ERROR_INJECT=1653520461
    #0 0x7fd5d8b8eeba in __sanitizer_print_stack_trace ../../../../gcc-trunk/libsanitizer/asan/asan_stack.cpp:87
    #1 0x402fc4 in my_realloc fuzz/test-corpus.c:129
    #2 0x7fd5d8893c49 in sk_reserve crypto/stack/stack.c:198
    #3 0x7fd5d8893c49 in OPENSSL_sk_insert crypto/stack/stack.c:242
    #4 0x7fd5d88d6d7f in sk_GENERAL_NAMES_push include/openssl/x509v3.h:168
    #5 0x7fd5d88d6d7f in crl_set_issuers crypto/x509/x_crl.c:111
    #6 0x7fd5d88d6d7f in crl_cb crypto/x509/x_crl.c:246
    #7 0x7fd5d85dc032 in asn1_item_embed_d2i crypto/asn1/tasn_dec.c:432
    #8 0x7fd5d85dcaf5 in asn1_template_noexp_d2i crypto/asn1/tasn_dec.c:643
    #9 0x7fd5d85dd288 in asn1_template_ex_d2i crypto/asn1/tasn_dec.c:518
    #10 0x7fd5d85db2b5 in asn1_item_embed_d2i crypto/asn1/tasn_dec.c:259
    #11 0x7fd5d85dc813 in asn1_template_noexp_d2i crypto/asn1/tasn_dec.c:611
    #12 0x7fd5d85dd288 in asn1_template_ex_d2i crypto/asn1/tasn_dec.c:518
    #13 0x7fd5d85db9ce in asn1_item_embed_d2i crypto/asn1/tasn_dec.c:382
    #14 0x7fd5d85dca28 in asn1_template_noexp_d2i crypto/asn1/tasn_dec.c:633
    #15 0x7fd5d85dd288 in asn1_template_ex_d2i crypto/asn1/tasn_dec.c:518
    #16 0x7fd5d85db9ce in asn1_item_embed_d2i crypto/asn1/tasn_dec.c:382
    #17 0x7fd5d85dcaf5 in asn1_template_noexp_d2i crypto/asn1/tasn_dec.c:643
    #18 0x7fd5d85dd7d3 in asn1_template_ex_d2i crypto/asn1/tasn_dec.c:494
    #19 0x7fd5d85db9ce in asn1_item_embed_d2i crypto/asn1/tasn_dec.c:382
    #20 0x7fd5d85ddd1f in ASN1_item_ex_d2i crypto/asn1/tasn_dec.c:124
    #21 0x7fd5d85dde35 in ASN1_item_d2i crypto/asn1/tasn_dec.c:114
    #22 0x7fd5d85a77e0 in ASN1_item_d2i_bio crypto/asn1/a_d2i_fp.c:69
    #23 0x402845 in FuzzerTestOneInput fuzz/cms.c:43
    #24 0x402bbb in testfile fuzz/test-corpus.c:182
    #25 0x402626 in main fuzz/test-corpus.c:226
    #26 0x7fd5d7c81f44 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21f44)
    #27 0x402706  (/home/ed/OPC/openssl/fuzz/cms-test+0x402706)

=================================================================
==29625==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 32 byte(s) in 1 object(s) allocated from:
    #0 0x7fd5d8b8309f in __interceptor_malloc ../../../../gcc-trunk/libsanitizer/asan/asan_malloc_linux.cpp:69
    #1 0x7fd5d87c2430 in CRYPTO_zalloc crypto/mem.c:230
    #2 0x7fd5d889501f in OPENSSL_sk_new_reserve crypto/stack/stack.c:209
    #3 0x7fd5d85dcbc3 in sk_ASN1_VALUE_new_null include/openssl/asn1t.h:928
    #4 0x7fd5d85dcbc3 in asn1_template_noexp_d2i crypto/asn1/tasn_dec.c:577
    #5 0x7fd5d85dd288 in asn1_template_ex_d2i crypto/asn1/tasn_dec.c:518
    #6 0x7fd5d85db104 in asn1_item_embed_d2i crypto/asn1/tasn_dec.c:178
    #7 0x7fd5d85ddd1f in ASN1_item_ex_d2i crypto/asn1/tasn_dec.c:124
    #8 0x7fd5d85dde35 in ASN1_item_d2i crypto/asn1/tasn_dec.c:114
    #9 0x7fd5d88f86d9 in X509V3_EXT_d2i crypto/x509v3/v3_lib.c:142
    #10 0x7fd5d88d6d3c in crl_set_issuers crypto/x509/x_crl.c:97
    #11 0x7fd5d88d6d3c in crl_cb crypto/x509/x_crl.c:246
    #12 0x7fd5d85dc032 in asn1_item_embed_d2i crypto/asn1/tasn_dec.c:432
    #13 0x7fd5d85dcaf5 in asn1_template_noexp_d2i crypto/asn1/tasn_dec.c:643
    #14 0x7fd5d85dd288 in asn1_template_ex_d2i crypto/asn1/tasn_dec.c:518
    #15 0x7fd5d85db2b5 in asn1_item_embed_d2i crypto/asn1/tasn_dec.c:259
    #16 0x7fd5d85dc813 in asn1_template_noexp_d2i crypto/asn1/tasn_dec.c:611
    #17 0x7fd5d85dd288 in asn1_template_ex_d2i crypto/asn1/tasn_dec.c:518
    #18 0x7fd5d85db9ce in asn1_item_embed_d2i crypto/asn1/tasn_dec.c:382
    #19 0x7fd5d85dca28 in asn1_template_noexp_d2i crypto/asn1/tasn_dec.c:633
    #20 0x7fd5d85dd288 in asn1_template_ex_d2i crypto/asn1/tasn_dec.c:518
    #21 0x7fd5d85db9ce in asn1_item_embed_d2i crypto/asn1/tasn_dec.c:382
    #22 0x7fd5d85dcaf5 in asn1_template_noexp_d2i crypto/asn1/tasn_dec.c:643
    #23 0x7fd5d85dd7d3 in asn1_template_ex_d2i crypto/asn1/tasn_dec.c:494
    #24 0x7fd5d85db9ce in asn1_item_embed_d2i crypto/asn1/tasn_dec.c:382
    #25 0x7fd5d85ddd1f in ASN1_item_ex_d2i crypto/asn1/tasn_dec.c:124
    #26 0x7fd5d85dde35 in ASN1_item_d2i crypto/asn1/tasn_dec.c:114
    #27 0x7fd5d85a77e0 in ASN1_item_d2i_bio crypto/asn1/a_d2i_fp.c:69
    #28 0x402845 in FuzzerTestOneInput fuzz/cms.c:43
    #29 0x402bbb in testfile fuzz/test-corpus.c:182
    #30 0x402626 in main fuzz/test-corpus.c:226
    #31 0x7fd5d7c81f44 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21f44)

SUMMARY: AddressSanitizer: 32 byte(s) leaked in 1 allocation(s).
```