### PR TITLE
Fix undefined behaviour in EC_GROUP_new_from_ecparameters

### DIFF
--- a/crypto/ec/ec_asn1.c
+++ b/crypto/ec/ec_asn1.c
@@ -687,6 +687,16 @@ EC_GROUP *EC_GROUP_new_from_ecparameters(const ECPARAMETERS *params)
 
     /* extract seed (optional) */
     if (params->curve->seed != NULL) {
+        /*
+         * This happens for instance with
+         * fuzz/corpora/asn1/65cf44e85614c62f10cf3b7a7184c26293a19e4a
+         * and causes the OPENSSL_malloc below to choke on the
+         * zero length allocation request.
+         */
+        if (params->curve->seed->length == 0) {
+            ERR_raise(ERR_LIB_EC, EC_R_ASN1_ERROR);
+            goto err;
+        }
         OPENSSL_free(ret->seed);
         if ((ret->seed = OPENSSL_malloc(params->curve->seed->length)) == NULL) {
             ERR_raise(ERR_LIB_EC, ERR_R_MALLOC_FAILURE);


### PR DESCRIPTION
This happens for instance with
fuzz/corpora/asn1/65cf44e85614c62f10cf3b7a7184c26293a19e4a
and causes the OPENSSL_malloc below to choke on the
zero length allocation request.

This is the equivalent of #18363 for the master / 3.0 branch