### PR TITLE
apps/x509 with `-CA`: fix some cases regarding the `-CAserial` and `-CAcreateserial` options

### DIFF
--- a/apps/ca.c
+++ b/apps/ca.c
@@ -925,7 +925,8 @@ end_of_options:
                 goto end;
             }
         } else {
-            if ((serial = load_serial(serialfile, create_ser, NULL)) == NULL) {
+            serial = load_serial(serialfile, NULL, create_ser, NULL);
+            if (serial == NULL) {
                 BIO_printf(bio_err, "error while loading serial number\n");
                 goto end;
             }
@@ -1165,7 +1166,8 @@ end_of_options:
 
         if ((crlnumberfile = NCONF_get_string(conf, section, ENV_CRLNUMBER))
             != NULL)
-            if ((crlnumber = load_serial(crlnumberfile, 0, NULL)) == NULL) {
+            if ((crlnumber = load_serial(crlnumberfile, NULL, 0, NULL))
+                == NULL) {
                 BIO_printf(bio_err, "error while loading CRL number\n");
                 goto end;
             }

--- a/apps/include/apps.h
+++ b/apps/include/apps.h
@@ -225,12 +225,16 @@ extern int do_updatedb(CA_DB *db, time_t *now);
 
 void app_bail_out(char *fmt, ...);
 void *app_malloc(size_t sz, const char *what);
-BIGNUM *load_serial(const char *serialfile, int create, ASN1_INTEGER **retai);
-int save_serial(const char *serialfile, const char *suffix, const BIGNUM *serial,
-                ASN1_INTEGER **retai);
+
+/* load_serial, save_serial, and rotate_serial are also used for CRL numbers */
+BIGNUM *load_serial(const char *serialfile, int *exists, int create,
+                    ASN1_INTEGER **retai);
+int save_serial(const char *serialfile, const char *suffix,
+                const BIGNUM *serial, ASN1_INTEGER **retai);
 int rotate_serial(const char *serialfile, const char *new_suffix,
                   const char *old_suffix);
 int rand_serial(BIGNUM *b, ASN1_INTEGER *ai);
+
 CA_DB *load_index(const char *dbfile, DB_ATTR *dbattr);
 int index_index(CA_DB *db);
 int save_index(const char *dbfile, const char *suffix, CA_DB *db);

--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -1417,7 +1417,8 @@ static IMPLEMENT_LHASH_HASH_FN(index_name, OPENSSL_CSTRING)
 static IMPLEMENT_LHASH_COMP_FN(index_name, OPENSSL_CSTRING)
 #undef BSIZE
 #define BSIZE 256
-BIGNUM *load_serial(const char *serialfile, int create, ASN1_INTEGER **retai)
+BIGNUM *load_serial(const char *serialfile, int *exists, int create,
+                    ASN1_INTEGER **retai)
 {
     BIO *in = NULL;
     BIGNUM *ret = NULL;
@@ -1429,6 +1430,8 @@ BIGNUM *load_serial(const char *serialfile, int create, ASN1_INTEGER **retai)
         goto err;
 
     in = BIO_new_file(serialfile, "r");
+    if (exists != NULL)
+        *exists = in != NULL;
     if (in == NULL) {
         if (!create) {
             perror(serialfile);
@@ -1436,8 +1439,14 @@ BIGNUM *load_serial(const char *serialfile, int create, ASN1_INTEGER **retai)
         }
         ERR_clear_error();
         ret = BN_new();
-        if (ret == NULL || !rand_serial(ret, ai))
+        if (ret == NULL) {
             BIO_printf(bio_err, "Out of memory\n");
+        } else if (!rand_serial(ret, ai)) {
+            BIO_printf(bio_err, "Error creating random number to store in %s\n",
+                       serialfile);
+            BN_free(ret);
+            ret = NULL;
+        }
     } else {
         if (!a2i_ASN1_INTEGER(in, ai, buf, 1024)) {
             BIO_printf(bio_err, "Unable to load number from %s\n",
@@ -1451,12 +1460,13 @@ BIGNUM *load_serial(const char *serialfile, int create, ASN1_INTEGER **retai)
         }
     }
 
-    if (ret && retai) {
+    if (ret != NULL && retai != NULL) {
         *retai = ai;
         ai = NULL;
     }
  err:
-    ERR_print_errors(bio_err);
+    if (ret == NULL)
+        ERR_print_errors(bio_err);
     BIO_free(in);
     ASN1_INTEGER_free(ai);
     return ret;

--- a/apps/x509.c
+++ b/apps/x509.c
@@ -730,7 +730,7 @@ int x509_main(int argc, char **argv)
         }
         if ((x = X509_new_ex(app_get0_libctx(), app_get0_propq())) == NULL)
             goto end;
-        if (sno == NULL) {
+        if (CAfile == NULL && sno == NULL) {
             sno = ASN1_INTEGER_new();
             if (sno == NULL || !rand_serial(NULL, sno))
                 goto end;

--- a/apps/x509.c
+++ b/apps/x509.c
@@ -662,9 +662,19 @@ int x509_main(int argc, char **argv)
             BIO_printf(bio_err, "Cannot use both -key/-signkey and -CA option\n");
             goto err;
         }
-    } else if (CAkeyfile != NULL) {
-        BIO_printf(bio_err,
-                   "Warning: ignoring -CAkey option since no -CA option is given\n");
+    } else {
+#define WARN_NO_CA(opt) BIO_printf(bio_err, \
+        "Warning: ignoring " opt " option since -CA option is not given\n");
+        if (CAkeyfile != NULL)
+            WARN_NO_CA("-CAkey");
+        if (CAkeyformat != FORMAT_UNDEF)
+            WARN_NO_CA("-CAkeyform");
+        if (CAformat != FORMAT_UNDEF)
+            WARN_NO_CA("-CAform");
+        if (CAserial != NULL)
+            WARN_NO_CA("-CAserial");
+        if (CA_createserial)
+            WARN_NO_CA("-CAcreateserial");
     }
 
     if (extfile == NULL) {

--- a/doc/man1/openssl-x509.pod.in
+++ b/doc/man1/openssl-x509.pod.in
@@ -499,7 +499,7 @@ Sets the CA serial number file to use.
 When creating a certificate with this option, the certificate serial number
 is stored in the given file. This file consists of one line containing
 an even number of hex digits with the serial number used.
-Before the next use the number is incremented and written out to the file again.
+Before the use the number is incremented and written out to the file again.
 
 The default filename consists of the CA certificate file base name with
 F<.srl> appended. For example if the CA certificate file is called

--- a/doc/man1/openssl-x509.pod.in
+++ b/doc/man1/openssl-x509.pod.in
@@ -498,16 +498,16 @@ Sets the CA serial number file to use.
 
 When creating a certificate with this option, the certificate serial number
 is stored in the given file. This file consists of one line containing
-an even number of hex digits with the serial number used.
-Before the use the number is incremented and written out to the file again.
+an even number of hex digits with the serial number used last time.
+After reading this number, it is incremented and used, and the file is updated.
 
 The default filename consists of the CA certificate file base name with
 F<.srl> appended. For example if the CA certificate file is called
 F<mycacert.pem> it expects to find a serial number file called
 F<mycacert.srl>.
 
-If the B<-CA> option is specified and both the <-CAserial> and <-CAcreateserial>
-options are not given and the default serial number file does not exist,
+If the B<-CA> option is specified and neither <-CAserial> or <-CAcreateserial>
+is given and the default serial number file does not exist,
 a random number is generated; this is the recommended practice.
 
 =item B<-CAcreateserial>

--- a/doc/man1/openssl-x509.pod.in
+++ b/doc/man1/openssl-x509.pod.in
@@ -496,10 +496,10 @@ See L<openssl-format-options(1)> for details.
 
 Sets the CA serial number file to use.
 
-When the B<-CA> option is used to sign a certificate it uses a serial
-number specified in a file. This file consists of one line containing
-an even number of hex digits with the serial number to use. After each
-use the serial number is incremented and written out to the file again.
+When creating a certificate with this option, the certificate serial number
+is stored in the given file. This file consists of one line containing
+an even number of hex digits with the serial number used.
+Before the next use the number is incremented and written out to the file again.
 
 The default filename consists of the CA certificate file base name with
 F<.srl> appended. For example if the CA certificate file is called

--- a/doc/man1/openssl-x509.pod.in
+++ b/doc/man1/openssl-x509.pod.in
@@ -506,13 +506,15 @@ F<.srl> appended. For example if the CA certificate file is called
 F<mycacert.pem> it expects to find a serial number file called
 F<mycacert.srl>.
 
+If the B<-CA> option is specified and both the <-CAserial> and <-CAcreateserial>
+options are not given and the default serial number file does not exist,
+a random number is generated; this is the recommended practice.
+
 =item B<-CAcreateserial>
 
-With this option the CA serial number file is created if it does not exist:
-it will contain the serial number "02" and the certificate being signed will
-have the 1 as its serial number. If the B<-CA> option is specified
-and the serial number file does not exist a random number is generated;
-this is the recommended practice.
+With this option the CA serial number file is created if it does not exist.
+A random number is generated, used for the certificate, and saved into the
+serial number file in that case.
 
 =back
 


### PR DESCRIPTION
It turns out that since commit df368ecce4e2d2ab8aedb4fa5eadb08992b52b4f back in 2004, the `x509` app has a subtle bug: when the `-CAserial` option is given with `-CA` and (as usual) also the `-in` option is given, the serial number file is ignored and instead a random serial number is used in the newly created cert.

The recent comment https://github.com/openssl/openssl/pull/13711#issuecomment-1131985954 made me investigate on this topic, and I found that due to a consequential mistake of mine in commit 05458fdb73dcca30edace5ad727a15d6d919e215 this bug extended since OpenSSL 3.0 to the case that the `-new` option (rather than `-in`) is given along with `-CA`.

This PR fixes both cases.

This PR meanwhile also does the following:
* With `-CA` given but both `-CAserial` and `-CAcreateserial` not given, use a random serial number.
* improve `openssl-x509.pod.in` regarding the cert serial number storage and related options
* fix error handling of `load_serial()` in `apps.c` when calling `rand_serial()`.
* ~change serial number file semantics to post- incrementation as documented~
* apps/x509: add warnings for options ignored when `-CA` is not specified

