### PR TITLE
Fix a crash in ssl_security_cert_chain

### DIFF
--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -3065,6 +3065,8 @@ int ssl_security_cert_chain(SSL *s, STACK_OF(X509) *sk, X509 *x, int vfy)
     int rv, start_idx, i;
     if (x == NULL) {
         x = sk_X509_value(sk, 0);
+        if (x == NULL)
+            return ERR_R_INTERNAL_ERROR;
         start_idx = 1;
     } else
         start_idx = 0;


### PR DESCRIPTION
Prior to the crash there is an out of memory error
in X509_verify_cert which makes the chain NULL or
empty.  The error is ignored by ssl_add_cert_chain,
and ssl_security_cert_chain crashes due to the
unchecked null pointer.

This is reproducible with my error injection patch.

The test vector has been validated on the 1.1.1 branch
but the issue is of course identical in all branches.
```
$ ERROR_INJECT=1652848273 ../util/shlib_wrap.sh ./server-test ./corpora/server/47c8e933c4ec66fa3c309422283dfe0f31aafae8# ./corpora/server/47c8e933c4ec66fa3c309422283dfe0f31aafae8
    #0 0x7f3a8f766eba in __sanitizer_print_stack_trace ../../../../gcc-trunk/libsanitizer/asan/asan_stack.cpp:87
    #1 0x403ba4 in my_malloc fuzz/test-corpus.c:114
    #2 0x7f3a8f39a430 in CRYPTO_zalloc crypto/mem.c:230
    #3 0x7f3a8f46bd3b in sk_reserve crypto/stack/stack.c:180
    #4 0x7f3a8f46bd3b in OPENSSL_sk_insert crypto/stack/stack.c:242
    #5 0x7f3a8f4a4fd8 in sk_X509_push include/openssl/x509.h:99
    #6 0x7f3a8f4a4fd8 in X509_verify_cert crypto/x509/x509_vfy.c:286
    #7 0x7f3a8fed726e in ssl_add_cert_chain ssl/statem/statem_lib.c:959
    #8 0x7f3a8fed726e in ssl3_output_cert_chain ssl/statem/statem_lib.c:1015
    #9 0x7f3a8fee1c50 in tls_construct_server_certificate ssl/statem/statem_srvr.c:3812
    #10 0x7f3a8feb8b0a in write_state_machine ssl/statem/statem.c:843
    #11 0x7f3a8feb8b0a in state_machine ssl/statem/statem.c:443
    #12 0x7f3a8fe84b3f in SSL_do_handshake ssl/ssl_lib.c:3718
    #13 0x403202 in FuzzerTestOneInput fuzz/server.c:740
    #14 0x40371b in testfile fuzz/test-corpus.c:182
    #15 0x402856 in main fuzz/test-corpus.c:226
    #16 0x7f3a8e859f44 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21f44)
    #17 0x402936  (/home/ed/OPC/openssl/fuzz/server-test+0x402936)

AddressSanitizer:DEADLYSIGNAL
=================================================================
==8400==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000158 (pc 0x7f3a8f4d822f bp 0x7ffc39b76190 sp 0x7ffc39b760a0 T0)
==8400==The signal is caused by a READ memory access.
==8400==Hint: address points to the zero page.
    #0 0x7f3a8f4d822f in x509v3_cache_extensions crypto/x509v3/v3_purp.c:386
    #1 0x7f3a8f4d9d3a in X509_check_purpose crypto/x509v3/v3_purp.c:84
    #2 0x7f3a8f4da02a in X509_get_extension_flags crypto/x509v3/v3_purp.c:921
    #3 0x7f3a8feff7d2 in ssl_security_cert_sig ssl/t1_lib.c:2518
    #4 0x7f3a8feff7d2 in ssl_security_cert ssl/t1_lib.c:2542
    #5 0x7f3a8feffa03 in ssl_security_cert_chain ssl/t1_lib.c:2562
    #6 0x7f3a8fed728d in ssl_add_cert_chain ssl/statem/statem_lib.c:963
    #7 0x7f3a8fed728d in ssl3_output_cert_chain ssl/statem/statem_lib.c:1015
    #8 0x7f3a8fee1c50 in tls_construct_server_certificate ssl/statem/statem_srvr.c:3812
    #9 0x7f3a8feb8b0a in write_state_machine ssl/statem/statem.c:843
    #10 0x7f3a8feb8b0a in state_machine ssl/statem/statem.c:443
    #11 0x7f3a8fe84b3f in SSL_do_handshake ssl/ssl_lib.c:3718
    #12 0x403202 in FuzzerTestOneInput fuzz/server.c:740
    #13 0x40371b in testfile fuzz/test-corpus.c:182
    #14 0x402856 in main fuzz/test-corpus.c:226
    #15 0x7f3a8e859f44 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21f44)
    #16 0x402936  (/home/ed/OPC/openssl/fuzz/server-test+0x402936)

AddressSanitizer can not provide additional info.
SUMMARY: AddressSanitizer: SEGV crypto/x509v3/v3_purp.c:386 in x509v3_cache_extensions
==8400==ABORTING
```
