### PR TITLE
Fix style nits in crl_set_issuers

### DIFF
--- a/crypto/x509/x_crl.c
+++ b/crypto/x509/x_crl.c
@@ -94,15 +94,15 @@ static int crl_set_issuers(X509_CRL *crl)
         STACK_OF(X509_EXTENSION) *exts;
         ASN1_ENUMERATED *reason;
         X509_EXTENSION *ext;
+
         gtmp = X509_REVOKED_get_ext_d2i(rev,
                                         NID_certificate_issuer, &j, NULL);
-        if (!gtmp && (j != -1)) {
+        if (gtmp == NULL && j != -1) {
             crl->flags |= EXFLAG_INVALID;
             return 1;
         }
 
-        if (gtmp) {
-            gens = gtmp;
+        if (gtmp != NULL) {
             if (crl->issuers == NULL) {
                 crl->issuers = sk_GENERAL_NAMES_new_null();
                 if (crl->issuers == NULL) {
@@ -114,16 +114,17 @@ static int crl_set_issuers(X509_CRL *crl)
                 GENERAL_NAMES_free(gtmp);
                 return 0;
             }
+            gens = gtmp;
         }
         rev->issuer = gens;
 
         reason = X509_REVOKED_get_ext_d2i(rev, NID_crl_reason, &j, NULL);
-        if (!reason && (j != -1)) {
+        if (reason == NULL && j != -1) {
             crl->flags |= EXFLAG_INVALID;
             return 1;
         }
 
-        if (reason) {
+        if (reason != NULL) {
             rev->reason = ASN1_ENUMERATED_get(reason);
             ASN1_ENUMERATED_free(reason);
         } else
@@ -136,7 +137,8 @@ static int crl_set_issuers(X509_CRL *crl)
         for (j = 0; j < sk_X509_EXTENSION_num(exts); j++) {
             ext = sk_X509_EXTENSION_value(exts, j);
             if (X509_EXTENSION_get_critical(ext)) {
-                if (OBJ_obj2nid(X509_EXTENSION_get_object(ext)) == NID_certificate_issuer)
+                if (OBJ_obj2nid(X509_EXTENSION_get_object(ext))
+                    == NID_certificate_issuer)
                     continue;
                 crl->flags |= EXFLAG_CRITICAL;
                 break;

--- a/crypto/x509/x_crl.c
+++ b/crypto/x509/x_crl.c
@@ -105,11 +105,15 @@ static int crl_set_issuers(X509_CRL *crl)
             gens = gtmp;
             if (!crl->issuers) {
                 crl->issuers = sk_GENERAL_NAMES_new_null();
-                if (!crl->issuers)
+                if (!crl->issuers) {
+                    GENERAL_NAMES_free(gtmp);
                     return 0;
+                }
             }
-            if (!sk_GENERAL_NAMES_push(crl->issuers, gtmp))
+            if (!sk_GENERAL_NAMES_push(crl->issuers, gtmp)) {
+                GENERAL_NAMES_free(gtmp);
                 return 0;
+            }
         }
         rev->issuer = gens;
 

--- a/crypto/x509/x_crl.c
+++ b/crypto/x509/x_crl.c
@@ -103,9 +103,9 @@ static int crl_set_issuers(X509_CRL *crl)
 
         if (gtmp) {
             gens = gtmp;
-            if (!crl->issuers) {
+            if (crl->issuers == NULL) {
                 crl->issuers = sk_GENERAL_NAMES_new_null();
-                if (!crl->issuers) {
+                if (crl->issuers == NULL) {
                     GENERAL_NAMES_free(gtmp);
                     return 0;
                 }


### PR DESCRIPTION
This fixes some style nits in crl_set_issuers.
The first commit is from #18327
I'd like to do the style nits either only on master or on master / 3.0