### PR TITLE
http_client.c: trace HTTP requests and responses when enabled

### DIFF
--- a/crypto/http/http_client.c
+++ b/crypto/http/http_client.c
@@ -981,20 +981,11 @@ OSSL_HTTP_REQ_CTX *OSSL_HTTP_open(const char *server, const char *port,
                             buf_size, overall_timeout);
 
  end:
-    if (rctx != NULL) {
+    if (rctx != NULL)
         /* remove any spurious error queue entries by ssl_add_cert_chain() */
         (void)ERR_pop_to_mark();
-#if !defined(OPENSSL_NO_TRACE) && !defined(OPENSSL_NO_STDIO)
-        {
-            BIO *trc_out = BIO_new_fp(stdout, BIO_NOCLOSE);
-
-            if (!OSSL_trace_set_channel(OSSL_TRACE_CATEGORY_HTTP, trc_out))
-                BIO_free(trc_out);
-        }
-#endif
-    } else {
+    else
         (void)ERR_clear_last_mark();
-    }
 
     return rctx;
 }
@@ -1235,7 +1226,6 @@ int OSSL_HTTP_close(OSSL_HTTP_REQ_CTX *rctx, int ok)
             rctx->wbio = wbio;
     }
     OSSL_HTTP_REQ_CTX_free(rctx);
-    (void)OSSL_trace_set_channel(OSSL_TRACE_CATEGORY_HTTP, NULL);
     return ret;
 }
 

--- a/crypto/trace.c
+++ b/crypto/trace.c
@@ -138,8 +138,9 @@ static const struct trace_category_st trace_categories[] = {
     TRACE_CATEGORY_(STORE),
     TRACE_CATEGORY_(DECODER),
     TRACE_CATEGORY_(ENCODER),
-    TRACE_CATEGORY_(REF_COUNT)
-};
+    TRACE_CATEGORY_(REF_COUNT),
+    TRACE_CATEGORY_(HTTP),
+}; /* KEEP THIS LIST IN SYNC with #define OSSL_TRACE_CATEGORY_... in trace.h */
 
 const char *OSSL_trace_get_category_name(int num)
 {

--- a/doc/man1/openssl-cmp.pod.in
+++ b/doc/man1/openssl-cmp.pod.in
@@ -1060,6 +1060,10 @@ although they usually contain hints that would be helpful for diagnostics.
 For assisting in such cases the CMP client offers a workaround via the
 B<-unprotected_errors> option, which allows accepting such negative messages.
 
+If OpenSSL was built with trace support enabled
+and the environment variable B<OPENSSL_TRACE> includes B<HTTP>,
+the request and response headers of HTTP transfers are printed.
+
 =head1 EXAMPLES
 
 =head2 Simple examples using the default OpenSSL configuration file

--- a/doc/man1/openssl.pod
+++ b/doc/man1/openssl.pod
@@ -710,8 +710,8 @@ see L<openssl-env(7)>.
 
 Enable tracing output of OpenSSL library, by name.
 This output will only make sense if you know OpenSSL internals well.
-Also, it might not give you any output at all, depending on how
-OpenSSL was built.
+Also, it might not give you any output at all
+if OpenSSL was built without tracing support.
 
 The value is a comma separated list of names, with the following
 available:
@@ -765,6 +765,10 @@ policy evaluation.
 =item B<BN_CTX>
 
 BIGNUM context.
+
+=item B<HTTP>
+
+HTTP client diagnostics
 
 =back
 

--- a/doc/man3/OSSL_HTTP_REQ_CTX.pod
+++ b/doc/man3/OSSL_HTTP_REQ_CTX.pod
@@ -213,6 +213,13 @@ This may be omitted if the GET method is used and "keep-alive" is not requested.
 When the request context is fully prepared, the HTTP exchange may be performed
 with OSSL_HTTP_REQ_CTX_nbio() or OSSL_HTTP_REQ_CTX_exchange().
 
+=head1 NOTES
+
+When built with tracing enabled, OSSL_HTTP_REQ_CTX_nbio() and all functions
+using it, such as OSSL_HTTP_REQ_CTX_exchange() and L<OSSL_HTTP_transfer(3)>,
+may be traced using B<OSSL_TRACE_CATEGORY_HTTP>.
+See also L<OSSL_trace_enabled(3)> and L<openssl(1)/ENVIRONMENT>.
+
 =head1 RETURN VALUES
 
 OSSL_HTTP_REQ_CTX_new() returns a pointer to a B<OSSL_HTTP_REQ_CTX>, or NULL
@@ -248,7 +255,8 @@ L<ASN1_item_i2d_mem_bio(3)>,
 L<OSSL_HTTP_open(3)>,
 L<OSSL_HTTP_get(3)>,
 L<OSSL_HTTP_transfer(3)>,
-L<OSSL_HTTP_close(3)>
+L<OSSL_HTTP_close(3)>,
+L<OSSL_trace_enabled(3)>
 
 =head1 HISTORY
 

--- a/doc/man3/OSSL_HTTP_transfer.pod
+++ b/doc/man3/OSSL_HTTP_transfer.pod
@@ -245,6 +245,10 @@ C<http_proxy>, C<HTTP_PROXY>, C<https_proxy>, C<HTTPS_PROXY>, C<no_proxy>, and
 C<NO_PROXY>, have been chosen for maximal compatibility with
 other HTTP client implementations such as wget, curl, and git.
 
+When built with tracing enabled, OSSL_HTTP_transfer() and all functions using it
+may be traced using B<OSSL_TRACE_CATEGORY_HTTP>.
+See also L<OSSL_trace_enabled(3)> and L<openssl(1)/ENVIRONMENT>.
+
 =head1 RETURN VALUES
 
 OSSL_HTTP_open() returns on success a B<OSSL_HTTP_REQ_CTX>, else NULL.
@@ -266,7 +270,8 @@ OSSL_HTTP_close() returns 0 if anything went wrong while disconnecting, else 1.
 
 L<OSSL_HTTP_parse_url(3)>, L<BIO_new_connect(3)>,
 L<ASN1_item_i2d_mem_bio(3)>, L<ASN1_item_d2i_bio(3)>,
-L<OSSL_HTTP_is_alive(3)>
+L<OSSL_HTTP_is_alive(3)>,
+L<OSSL_trace_enabled(3)>
 
 =head1 HISTORY
 

--- a/doc/man3/OSSL_trace_enabled.pod
+++ b/doc/man3/OSSL_trace_enabled.pod
@@ -49,8 +49,8 @@ The functions described here are mainly interesting for those who provide
 OpenSSL functionality, either in OpenSSL itself or in engine modules
 or similar.
 
-If tracing is enabled (see L</NOTES> below), these functions are used to
-generate free text tracing output.
+If the tracing facility is enabled (see L</Configure Tracing> below),
+these functions are used to generate free text tracing output.
 
 The tracing output is divided into types which are enabled
 individually by the application.
@@ -59,13 +59,13 @@ L<OSSL_trace_set_callback(3)/Trace types>.
 The fallback type B<OSSL_TRACE_CATEGORY_ALL> should I<not> be used
 with the functions described here.
 
-Tracing for a specific category is enabled if a so called
+Tracing for a specific category is enabled at run-time if a so-called
 I<trace channel> is attached to it. A trace channel is simply a
 BIO object to which the application can write its trace output.
 
 The application has two different ways of registering a trace channel,
-either by directly providing a BIO object using OSSL_trace_set_channel(),
-or by providing a callback routine using OSSL_trace_set_callback().
+either by directly providing a BIO object using L<OSSL_trace_set_channel(3)>,
+or by providing a callback routine using L<OSSL_trace_set_callback(3)>.
 The latter is wrapped internally by a dedicated BIO object, so for the
 tracing code both channel types are effectively indistinguishable.
 We call them a I<simple trace channel> and a I<callback trace channel>,
@@ -86,7 +86,9 @@ but rather uses a set of convenience macros, see the L</Macros> section below.
 =head2 Functions
 
 OSSL_trace_enabled() can be used to check if tracing for the given
-I<category> is enabled.
+I<category> is enabled, i.e., if the tracing facility has been statically
+enabled (see L</Configure Tracing> below) and a trace channel has been
+registered using L<OSSL_trace_set_channel(3)> or L<OSSL_trace_set_callback(3)>.
 
 OSSL_trace_begin() is used to starts a tracing section, and get the
 channel for the given I<category> in form of a BIO.
@@ -109,7 +111,7 @@ used as follows to wrap a trace section:
 
  OSSL_TRACE_BEGIN(TLS) {
 
-     BIO_fprintf(trc_out, ... );
+     BIO_printf(trc_out, ... );
 
  } OSSL_TRACE_END(TLS);
 
@@ -119,7 +121,7 @@ This will normally expand to:
      BIO *trc_out = OSSL_trace_begin(OSSL_TRACE_CATEGORY_TLS);
      if (trc_out != NULL) {
          ...
-         BIO_fprintf(trc_out, ...);
+         BIO_printf(trc_out, ...);
      }
      OSSL_trace_end(OSSL_TRACE_CATEGORY_TLS, trc_out);
  } while (0);
@@ -133,7 +135,7 @@ trace section:
          OSSL_TRACE_CANCEL(TLS);
          goto err;
      }
-     BIO_fprintf(trc_out, ... );
+     BIO_printf(trc_out, ... );
 
  } OSSL_TRACE_END(TLS);
 
@@ -146,7 +148,7 @@ This will normally expand to:
              OSSL_trace_end(OSSL_TRACE_CATEGORY_TLS, trc_out);
              goto err;
          }
-         BIO_fprintf(trc_out, ... );
+         BIO_printf(trc_out, ... );
      }
      OSSL_trace_end(OSSL_TRACE_CATEGORY_TLS, trc_out);
  } while (0);
@@ -249,7 +251,7 @@ For example, take this example from L</Macros> section above:
          OSSL_TRACE_CANCEL(TLS);
          goto err;
      }
-     BIO_fprintf(trc_out, ... );
+     BIO_printf(trc_out, ... );
 
  } OSSL_TRACE_END(TLS);
 
@@ -262,7 +264,7 @@ When the tracing API isn't operational, that will expand to:
              ((void)0);
              goto err;
          }
-         BIO_fprintf(trc_out, ... );
+         BIO_printf(trc_out, ... );
      }
  } while (0);
 
@@ -275,6 +277,10 @@ operational and enabled, otherwise 0.
 
 OSSL_trace_begin() returns a B<BIO> pointer if the given I<type> is enabled,
 otherwise NULL.
+
+=head1 SEE ALSO
+
+L<OSSL_trace_set_channel(3)>, L<OSSL_trace_set_callback(3)>
 
 =head1 HISTORY
 

--- a/doc/man3/OSSL_trace_set_channel.pod
+++ b/doc/man3/OSSL_trace_set_channel.pod
@@ -21,13 +21,13 @@ OSSL_trace_set_callback, OSSL_trace_cb - Enabling trace output
 
 =head1 DESCRIPTION
 
-If available (see L</NOTES> below), the application can request
+If available (see L</Configure Tracing> below), the application can request
 internal trace output.
 This output comes in form of free text for humans to read.
 
 The trace output is divided into categories which can be
 enabled individually.
-Every category can be enabled individually by attaching a so called
+Every category can be enabled individually by attaching a so-called
 I<trace channel> to it, which in the simplest case is just a BIO object
 to which the application can write the tracing output for this category.
 Alternatively, the application can provide a tracer callback in order to
@@ -37,6 +37,11 @@ internally by a dedicated BIO object.
 For the tracing code, both trace channel types are indistinguishable.
 These are called a I<simple trace channel> and a I<callback trace channel>,
 respectively.
+
+L<OSSL_TRACE_ENABLED(3)> can be used to check whether tracing is currently
+enabled for the given category.
+Functions like L<OSSL_TRACE1(3)> and macros like L<OSSL_TRACE_BEGIN(3)>
+can be used for producing free-text trace output.
 
 =head2 Functions
 
@@ -56,7 +61,7 @@ OSSL_trace_set_callback() is used to enable the given trace
 I<category> by giving it the tracer callback I<cb> with the associated
 data I<data>, which will simply be passed through to I<cb> whenever
 it's called. The callback function is internally wrapped by a
-dedicated BIO object, the so called I<callback trace channel>.
+dedicated BIO object, the so-called I<callback trace channel>.
 This should be used when it's desirable to do form the trace output to
 something suitable for application needs where a prefix and suffix
 line aren't enough.
@@ -291,6 +296,11 @@ necessary to configure and build OpenSSL with the 'enable-trace' option.
 When the library is built with tracing disabled, the macro
 B<OPENSSL_NO_TRACE> is defined in F<< <openssl/opensslconf.h> >> and all
 functions described here are inoperational, i.e. will do nothing.
+
+=head1 SEE ALSO
+
+L<OSSL_TRACE_ENABLED(3)>, L<OSSL_TRACE_BEGIN(3)>, L<OSSL_TRACE1(3)>,
+L<atexit(3)>
 
 =head1 HISTORY
 

--- a/include/openssl/trace.h
+++ b/include/openssl/trace.h
@@ -57,8 +57,9 @@ extern "C" {
 # define OSSL_TRACE_CATEGORY_DECODER            15
 # define OSSL_TRACE_CATEGORY_ENCODER            16
 # define OSSL_TRACE_CATEGORY_REF_COUNT          17
+# define OSSL_TRACE_CATEGORY_HTTP               18
 /* Count of available categories. */
-# define OSSL_TRACE_CATEGORY_NUM                18
+# define OSSL_TRACE_CATEGORY_NUM                19
 
 /* Returns the trace category number for the given |name| */
 int OSSL_trace_get_category_num(const char *name);

--- a/include/openssl/trace.h
+++ b/include/openssl/trace.h
@@ -60,6 +60,7 @@ extern "C" {
 # define OSSL_TRACE_CATEGORY_HTTP               18
 /* Count of available categories. */
 # define OSSL_TRACE_CATEGORY_NUM                19
+/* KEEP THIS LIST IN SYNC with trace_categories[] in crypto/trace.c */
 
 /* Returns the trace category number for the given |name| */
 int OSSL_trace_get_category_num(const char *name);


### PR DESCRIPTION
For HTTP responses received from the server, it is often very helpful for debugging to see the header, 
and in case of an error response with the body having text contents, also the body to determine what went wrong.

This PR dumps the mentioned information ~on error if `NDEBUG` is not defined.~ when tracing is enabled.