### PR TITLE
Enable provider-implemented sig algs for s_server startup

### DIFF
--- a/crypto/x509/x509_set.c
+++ b/crypto/x509/x509_set.c
@@ -192,8 +192,6 @@ int X509_get_signature_info(X509 *x, int *mdnid, int *pknid, int *secbits,
     return X509_SIG_INFO_get(&x->siginf, mdnid, pknid, secbits, flags);
 }
 
-#define MIN(A, B) if (A>B || A<0) A=B
-
 /* Modify *siginf according to alg and sig. Return 1 on success, else 0. */
 static int x509_sig_info_init(X509_SIG_INFO *siginf, const X509_ALGOR *alg,
                               const ASN1_STRING *sig, const EVP_PKEY *pubkey)
@@ -242,21 +240,21 @@ static int x509_sig_info_init(X509_SIG_INFO *siginf, const X509_ALGOR *alg,
          * https://eprint.iacr.org/2020/014 puts a chosen-prefix attack
          * for SHA1 at2^63.4
          */
-        MIN(siginf->secbits, 63);
+        siginf->secbits = 63;
         break;
     case NID_md5:
         /*
          * https://documents.epfl.ch/users/l/le/lenstra/public/papers/lat.pdf
          * puts a chosen-prefix attack for MD5 at 2^39.
          */
-        MIN(siginf->secbits, 39);
+        siginf->secbits = 39;
         break;
     case NID_id_GostR3411_94:
         /*
          * There is a collision attack on GOST R 34.11-94 at 2^105, see
          * https://link.springer.com/chapter/10.1007%2F978-3-540-85174-5_10
          */
-        MIN(siginf->secbits, 105);
+        siginf->secbits = 105;
         break;
     default:
         /* Security bits: half number of bits in digest */
@@ -264,7 +262,7 @@ static int x509_sig_info_init(X509_SIG_INFO *siginf, const X509_ALGOR *alg,
             ERR_raise(ERR_LIB_X509, X509_R_ERROR_GETTING_MD_BY_NID);
             return 0;
         }
-        MIN(siginf->secbits, EVP_MD_get_size(md) * 4);
+        siginf->secbits = EVP_MD_get_size(md) * 4;
         break;
     }
     switch (mdnid) {

--- a/crypto/x509/x509_set.c
+++ b/crypto/x509/x509_set.c
@@ -192,7 +192,7 @@ int X509_get_signature_info(X509 *x, int *mdnid, int *pknid, int *secbits,
     return X509_SIG_INFO_get(&x->siginf, mdnid, pknid, secbits, flags);
 }
 
-#define MAX(a, b) if (b<a) a=b
+#define MIN(A, B) if (A>B || A<0) A=B
 
 /* Modify *siginf according to alg and sig. Return 1 on success, else 0. */
 static int x509_sig_info_init(X509_SIG_INFO *siginf, const X509_ALGOR *alg,
@@ -241,21 +241,21 @@ static int x509_sig_info_init(X509_SIG_INFO *siginf, const X509_ALGOR *alg,
          * https://eprint.iacr.org/2020/014 puts a chosen-prefix attack
          * for SHA1 at2^63.4
          */
-        MAX(siginf->secbits, 63);
+        MIN(siginf->secbits, 63);
         break;
     case NID_md5:
         /*
          * https://documents.epfl.ch/users/l/le/lenstra/public/papers/lat.pdf
          * puts a chosen-prefix attack for MD5 at 2^39.
          */
-        MAX(siginf->secbits, 39);
+        MIN(siginf->secbits, 39);
         break;
     case NID_id_GostR3411_94:
         /*
          * There is a collision attack on GOST R 34.11-94 at 2^105, see
          * https://link.springer.com/chapter/10.1007%2F978-3-540-85174-5_10
          */
-        MAX(siginf->secbits, 105);
+        MIN(siginf->secbits, 105);
         break;
     default:
         /* Security bits: half number of bits in digest */
@@ -263,7 +263,7 @@ static int x509_sig_info_init(X509_SIG_INFO *siginf, const X509_ALGOR *alg,
             ERR_raise(ERR_LIB_X509, X509_R_ERROR_GETTING_MD_BY_NID);
             return 0;
         }
-        MAX(siginf->secbits, EVP_MD_get_size(md) * 4);
+        MIN(siginf->secbits, EVP_MD_get_size(md) * 4);
         break;
     }
     switch (mdnid) {

--- a/ssl/ssl_rsa.c
+++ b/ssl/ssl_rsa.c
@@ -891,9 +891,9 @@ static int ssl_set_cert_and_key(SSL *ssl, SSL_CTX *ctx, X509 *x509, EVP_PKEY *pr
                                 STACK_OF(X509) *chain, int override)
 {
     int ret = 0;
+    size_t i;
     int j;
     int rv;
-    size_t i=SSL_aANY; /* indicating non-legacy key */;
     CERT *c = ssl != NULL ? ssl->cert : ctx->cert;
     STACK_OF(X509) *dup_chain = NULL;
     EVP_PKEY *pubkey = NULL;
@@ -946,6 +946,7 @@ static int ssl_set_cert_and_key(SSL *ssl, SSL_CTX *ctx, X509 *x509, EVP_PKEY *pr
         }
     }
     /* cert lookup test only for legacy keys */
+    i=SSL_aANY; /* pre-set non-legacy key */;
     if ((EVP_PKEY_get_base_id(pubkey) != NID_undef) &&
         (ssl_cert_lookup_by_pkey(pubkey, &i) == NULL)) {
         ERR_raise(ERR_LIB_SSL, SSL_R_UNKNOWN_CERTIFICATE_TYPE);

--- a/ssl/ssl_rsa.c
+++ b/ssl/ssl_rsa.c
@@ -891,9 +891,9 @@ static int ssl_set_cert_and_key(SSL *ssl, SSL_CTX *ctx, X509 *x509, EVP_PKEY *pr
                                 STACK_OF(X509) *chain, int override)
 {
     int ret = 0;
-    size_t i=SSL_aANY; /* indicating non-legacy key */;
     int j;
     int rv;
+    size_t i=SSL_aANY; /* indicating non-legacy key */;
     CERT *c = ssl != NULL ? ssl->cert : ctx->cert;
     STACK_OF(X509) *dup_chain = NULL;
     EVP_PKEY *pubkey = NULL;


### PR DESCRIPTION
- Probes & sets external provider-delivered security bit information for certs with MD=NID_undef (e.g., quantum-safe certificates)
- Limits known signature algorithm assertions to known (i.e., non-external provider implemented) signature algorithms
  
Fixes #18375 