### PR TITLE
changes: add note saying the locale based strcasecmp has been replaced

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,11 @@ OpenSSL 3.1
 
 ### Changes between 3.0 and 3.1 [xx XXX xxxx]
 
+ * Case insensitive string comparison no longer uses locales.  It has instead
+   been directly implemented.
+
+   *Paul Dale*
+
  * Add more SRTP protection profiles from RFC8723 and RFC8269.
 
    *Kijin Kim*

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,11 +24,6 @@ OpenSSL 3.1
 
 ### Changes between 3.0 and 3.1 [xx XXX xxxx]
 
- * Case insensitive string comparison no longer uses locales.  It has instead
-   been directly implemented.
-
-   *Paul Dale*
-
  * Add more SRTP protection profiles from RFC8723 and RFC8269.
 
    *Kijin Kim*
@@ -126,6 +121,13 @@ The migration guide contains more detailed information related to new features,
 breaking changes, and mappings for the large list of deprecated functions.
 
 [Migration guide]: https://github.com/openssl/openssl/tree/master/doc/man7/migration_guide.pod
+
+### Changes between 3.0.3 and 3.0.4
+
+ * Case insensitive string comparison no longer uses locales.  It has instead
+   been directly implemented.
+
+   *Paul Dale*
 
 ### Changes between 3.0.2 and 3.0.3
 


### PR DESCRIPTION
Missed reversion of changes for the locale free compare.  3.0 version in #18390.
