### PR TITLE
Don't include sys/select.h on HP-UX as it doesn't exist

### DIFF
--- a/crypto/bio/bio_sock.c
+++ b/crypto/bio/bio_sock.c
@@ -35,6 +35,8 @@ static int wsa_init_done = 0;
 #  include <unistd.h>
 #  if defined __VMS
 #   include <sys/socket.h>
+#  elif defined _HPUX_SOURCE
+#   include <sys/time.h>
 #  else
 #   include <sys/select.h>
 #  endif


### PR DESCRIPTION
There is no `sys/select.h` on HP-UX and the man page lists `sys/time.h` as the correct header for `select`.