### PR TITLE
Fix erroneous checks of EVP_CIPHER_CTX_rand_key and EVP_CIPHER_CTX_set_key_length

### DIFF
--- a/apps/speed.c
+++ b/apps/speed.c
@@ -695,7 +695,7 @@ static EVP_CIPHER_CTX *init_evp_cipher_ctx(const char *ciphername,
         goto end;
     }
 
-    if (!EVP_CIPHER_CTX_set_key_length(ctx, keylen)) {
+    if (EVP_CIPHER_CTX_set_key_length(ctx, keylen) <= 0) {
         EVP_CIPHER_CTX_free(ctx);
         ctx = NULL;
         goto end;

--- a/apps/speed.c
+++ b/apps/speed.c
@@ -3602,7 +3602,7 @@ static void multiblock_speed(const EVP_CIPHER *evp_cipher, int lengths_single,
         goto err;
     }
     key = app_malloc(keylen, "evp_cipher key");
-    if (!EVP_CIPHER_CTX_rand_key(ctx, key))
+    if (EVP_CIPHER_CTX_rand_key(ctx, key) <= 0)
         app_bail_out("failed to generate random cipher key\n");
     if (!EVP_EncryptInit_ex(ctx, NULL, NULL, key, NULL))
         app_bail_out("failed to set cipher key\n");

--- a/crypto/cmac/cmac.c
+++ b/crypto/cmac/cmac.c
@@ -137,9 +137,9 @@ int CMAC_Init(CMAC_CTX *ctx, const void *key, size_t keylen,
 
         /* If anything fails then ensure we can't use this ctx */
         ctx->nlast_block = -1;
-        if (!EVP_CIPHER_CTX_get0_cipher(ctx->cctx))
+        if (EVP_CIPHER_CTX_get0_cipher(ctx->cctx) == NULL)
             return 0;
-        if (!EVP_CIPHER_CTX_set_key_length(ctx->cctx, keylen))
+        if (EVP_CIPHER_CTX_set_key_length(ctx->cctx, keylen) <= 0)
             return 0;
         if (!EVP_EncryptInit_ex(ctx->cctx, NULL, NULL, key, zero_iv))
             return 0;

--- a/crypto/evp/p_open.c
+++ b/crypto/evp/p_open.c
@@ -50,7 +50,7 @@ int EVP_OpenInit(EVP_CIPHER_CTX *ctx, const EVP_CIPHER *type,
     if (EVP_PKEY_decrypt(pctx, key, &keylen, ek, ekl) <= 0)
         goto err;
 
-    if (!EVP_CIPHER_CTX_set_key_length(ctx, keylen)
+    if (EVP_CIPHER_CTX_set_key_length(ctx, keylen) <= 0
         || !EVP_DecryptInit_ex(ctx, NULL, NULL, key, iv))
         goto err;
 

--- a/crypto/pkcs7/pk7_doit.c
+++ b/crypto/pkcs7/pk7_doit.c
@@ -612,7 +612,7 @@ BIO *PKCS7_dataDecode(PKCS7 *p7, EVP_PKEY *pkey, BIO *in_bio, X509 *pcert)
              * length. The key length is determined by the size of the
              * decrypted RSA key.
              */
-            if (!EVP_CIPHER_CTX_set_key_length(evp_ctx, eklen)) {
+            if (EVP_CIPHER_CTX_set_key_length(evp_ctx, eklen) <= 0) {
                 /* Use random key as MMA defence */
                 OPENSSL_clear_free(ek, eklen);
                 ek = tkey;

--- a/crypto/ui/ui_util.c
+++ b/crypto/ui/ui_util.c
@@ -153,7 +153,7 @@ UI_METHOD *UI_UTIL_wrap_read_pem_callback(pem_password_cb *cb, int rwflag)
         || UI_method_set_writer(ui_method, ui_write) < 0
         || UI_method_set_closer(ui_method, ui_close) < 0
         || !RUN_ONCE(&get_index_once, ui_method_data_index_init)
-        || UI_method_set_ex_data(ui_method, ui_method_data_index, data) < 0) {
+        || !UI_method_set_ex_data(ui_method, ui_method_data_index, data)) {
         UI_destroy_method(ui_method);
         OPENSSL_free(data);
         return NULL;

--- a/providers/implementations/kdfs/krb5kdf.c
+++ b/providers/implementations/kdfs/krb5kdf.c
@@ -359,8 +359,10 @@ static int cipher_init(EVP_CIPHER_CTX *ctx,
     klen = EVP_CIPHER_CTX_get_key_length(ctx);
     if (key_len != (size_t)klen) {
         ret = EVP_CIPHER_CTX_set_key_length(ctx, key_len);
-        if (ret <= 0)
+        if (ret <= 0) {
+            ret = 0;
             goto out;
+        }
     }
     /* we never want padding, either the length requested is a multiple of
      * the cipher block size or we are passed a cipher that can cope with

--- a/providers/implementations/kdfs/krb5kdf.c
+++ b/providers/implementations/kdfs/krb5kdf.c
@@ -359,7 +359,7 @@ static int cipher_init(EVP_CIPHER_CTX *ctx,
     klen = EVP_CIPHER_CTX_get_key_length(ctx);
     if (key_len != (size_t)klen) {
         ret = EVP_CIPHER_CTX_set_key_length(ctx, key_len);
-        if (!ret)
+        if (ret <= 0)
             goto out;
     }
     /* we never want padding, either the length requested is a multiple of

--- a/test/aesgcmtest.c
+++ b/test/aesgcmtest.c
@@ -111,7 +111,7 @@ static int badkeylen_test(void)
     ret = TEST_ptr(cipher = EVP_aes_192_gcm())
           && TEST_ptr(ctx = EVP_CIPHER_CTX_new())
           && TEST_true(EVP_EncryptInit_ex(ctx, cipher, NULL, NULL, NULL))
-          && TEST_false(EVP_CIPHER_CTX_set_key_length(ctx, 2));
+          && TEST_int_gt(EVP_CIPHER_CTX_set_key_length(ctx, 2), 0);
     EVP_CIPHER_CTX_free(ctx);
     return ret;
 }

--- a/test/aesgcmtest.c
+++ b/test/aesgcmtest.c
@@ -111,7 +111,7 @@ static int badkeylen_test(void)
     ret = TEST_ptr(cipher = EVP_aes_192_gcm())
           && TEST_ptr(ctx = EVP_CIPHER_CTX_new())
           && TEST_true(EVP_EncryptInit_ex(ctx, cipher, NULL, NULL, NULL))
-          && TEST_int_gt(EVP_CIPHER_CTX_set_key_length(ctx, 2), 0);
+          && TEST_int_le(EVP_CIPHER_CTX_set_key_length(ctx, 2), 0);
     EVP_CIPHER_CTX_free(ctx);
     return ret;
 }

--- a/test/evp_libctx_test.c
+++ b/test/evp_libctx_test.c
@@ -576,7 +576,7 @@ static int test_cipher_tdes_randkey(void)
           && TEST_int_ne(EVP_CIPHER_get_flags(tdes_cipher) & EVP_CIPH_RAND_KEY, 0)
           && TEST_ptr(ctx = EVP_CIPHER_CTX_new())
           && TEST_true(EVP_CipherInit_ex(ctx, tdes_cipher, NULL, NULL, NULL, 1))
-          && TEST_true(EVP_CIPHER_CTX_rand_key(ctx, key));
+          && TEST_int_gt(EVP_CIPHER_CTX_rand_key(ctx, key), 0);
 
     EVP_CIPHER_CTX_free(ctx);
     EVP_CIPHER_free(tdes_cipher);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
