### PR TITLE
Remove include/openssl/configuration.h from mandatory dependencies

### DIFF
--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -549,6 +549,7 @@ clean : libclean
         - DELETE []vmsconfig.pm;*
 
 distclean : clean
+        - DELETE [.include.openssl]configuration.h;*
         - DELETE configdata.pm;*
         - DELETE descrip.mms;*
 

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -594,6 +594,7 @@ clean: libclean
 	-find . -type l \! -name '.*' -exec $(RM) {} \;
 
 distclean: clean
+	$(RM) include/openssl/configuration.h
 	$(RM) configdata.pm
 	$(RM) Makefile
 

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -478,6 +478,7 @@ clean: libclean
 	-rd /Q /S test\test-runs
 
 distclean: clean
+	-del /Q /F include\openssl\configuration.h
 	-del /Q /F configdata.pm
 	-del /Q /F makefile
 

--- a/build.info
+++ b/build.info
@@ -22,7 +22,6 @@ DEPEND[]=include/openssl/asn1.h \
          include/openssl/cmp.h \
          include/openssl/cms.h \
          include/openssl/conf.h \
-         include/openssl/configuration.h \
          include/openssl/crmf.h \
          include/openssl/crypto.h \
          include/openssl/ct.h \


### PR DESCRIPTION
Since this file is generated by configdata.pm, there's no need to include it
among the mandatory dependencies (which end up in the `GENERATE_MANDATORY`
Makefile variable).  In fact, it shouldn't be there any more, as that would
also cause it to be removed by `make clean`.

To compensate, we add an explicit removal of that file in the `distclean`
target on all platform families.

Fixes #18396
