### PR TITLE
Fix another decoder mem leak on an error path

### DIFF
--- a/crypto/encode_decode/decoder_lib.c
+++ b/crypto/encode_decode/decoder_lib.c
@@ -362,8 +362,9 @@ static void collect_all_decoders(OSSL_DECODER *decoder, void *arg)
 {
     STACK_OF(OSSL_DECODER) *skdecoders = arg;
 
-    if (OSSL_DECODER_up_ref(decoder))
-        sk_OSSL_DECODER_push(skdecoders, decoder);
+    if (OSSL_DECODER_up_ref(decoder)
+            && !sk_OSSL_DECODER_push(skdecoders, decoder))
+        OSSL_DECODER_free(decoder);
 }
 
 static void collect_extra_decoder(OSSL_DECODER *decoder, void *arg)


### PR DESCRIPTION
If pushing the decoder onto a stack fails then we should free the ref
we just created.

Found due to the error report here:
https://github.com/openssl/openssl/pull/18355#issuecomment-1138205688

