### PR TITLE
Add Windows VERSIONINFO resource to fips provider dll.

### DIFF
--- a/providers/build.info
+++ b/providers/build.info
@@ -118,6 +118,12 @@ IF[{- !$disabled{fips} -}]
   GENERATE[fipsmodule.cnf]=../util/mk-fipsmodule-cnf.pl \
           -module $(FIPSMODULE) -section_name fips_sect -key $(FIPSKEY)
   DEPEND[fipsmodule.cnf]=$FIPSGOAL
+
+  # Add VERSIONINFO resource for windows
+  IF[{- $config{target} =~ /^(?:Cygwin|mingw|VC-|BC-)/ -}]
+    GENERATE[fips.rc]=../util/mkrc.pl fips
+    SOURCE[$FIPSGOAL]=fips.rc
+  ENDIF
 ENDIF
 
 #

--- a/providers/build.info
+++ b/providers/build.info
@@ -152,6 +152,13 @@ IF[{- !$disabled{legacy} -}]
       SOURCE[legacy]=legacy.ld
       GENERATE[legacy.ld]=../util/providers.num
     ENDIF
+
+    # Add VERSIONINFO resource for windows
+    IF[{- $config{target} =~ /^(?:Cygwin|mingw|VC-|BC-)/ -}]
+      GENERATE[legacy.rc]=../util/mkrc.pl legacy
+      SOURCE[$LEGACYGOAL]=legacy.rc
+    ENDIF
+
     SOURCE[$LIBLEGACY]=prov_running.c
   ENDIF
 


### PR DESCRIPTION
Fixes #18388

This just looks like an omission, as this is added to libcrypto and libssl

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
