### PR TITLE
Add d2i_PUBKEY_ex_fp and d2i_PUBKEY_ex_bio

### DIFF
--- a/doc/man3/OSSL_CMP_MSG_get0_header.pod
+++ b/doc/man3/OSSL_CMP_MSG_get0_header.pod
@@ -118,10 +118,11 @@ d2i_OSSL_CMP_MSG_bio() returns the parsed message or NULL on error.
 OSSL_CMP_MSG_read() and d2i_OSSL_CMP_MSG_bio()
 return the parsed CMP message or NULL on error.
 
-OSSL_CMP_MSG_write() and i2d_OSSL_CMP_MSG_bio() return
-the number of bytes successfully encoded or a negative value if an error occurs.
+OSSL_CMP_MSG_write() returns the number of bytes successfully encoded or a
+negative value if an error occurs.
 
-OSSL_CMP_MSG_update_transactionID() returns 1 on success, 0 on error.
+i2d_OSSL_CMP_MSG_bio() and OSSL_CMP_MSG_update_transactionID() return 1 on
+success, 0 on error.
 
 =head1 SEE ALSO
 

--- a/doc/man3/X509_PUBKEY_new.pod
+++ b/doc/man3/X509_PUBKEY_new.pod
@@ -4,9 +4,9 @@
 
 X509_PUBKEY_new_ex, X509_PUBKEY_new, X509_PUBKEY_free, X509_PUBKEY_dup,
 X509_PUBKEY_set, X509_PUBKEY_get0, X509_PUBKEY_get,
-d2i_PUBKEY_ex, d2i_PUBKEY, i2d_PUBKEY, d2i_PUBKEY_bio, d2i_PUBKEY_fp,
-i2d_PUBKEY_fp, i2d_PUBKEY_bio, X509_PUBKEY_set0_public_key,
-X509_PUBKEY_set0_param, X509_PUBKEY_get0_param,
+d2i_PUBKEY_ex, d2i_PUBKEY, i2d_PUBKEY, d2i_PUBKEY_ex_bio, d2i_PUBKEY_bio,
+d2i_PUBKEY_ex_fp, d2i_PUBKEY_fp, i2d_PUBKEY_fp, i2d_PUBKEY_bio,
+X509_PUBKEY_set0_public_key, X509_PUBKEY_set0_param, X509_PUBKEY_get0_param,
 X509_PUBKEY_eq - SubjectPublicKeyInfo public key functions
 
 =head1 SYNOPSIS
@@ -27,7 +27,12 @@ X509_PUBKEY_eq - SubjectPublicKeyInfo public key functions
  EVP_PKEY *d2i_PUBKEY(EVP_PKEY **a, const unsigned char **pp, long length);
  int i2d_PUBKEY(const EVP_PKEY *a, unsigned char **pp);
 
+ EVP_PKEY *d2i_PUBKEY_ex_bio(BIO *bp, EVP_PKEY **a, OSSL_LIB_CTX *libctx,
+                             const char *propq);
  EVP_PKEY *d2i_PUBKEY_bio(BIO *bp, EVP_PKEY **a);
+
+ EVP_PKEY *d2i_PUBKEY_ex_fp(FILE *fp, EVP_PKEY **a, OSSL_LIB_CTX *libctx,
+                            const char *propq);
  EVP_PKEY *d2i_PUBKEY_fp(FILE *fp, EVP_PKEY **a);
 
  int i2d_PUBKEY_fp(const FILE *fp, EVP_PKEY *pkey);
@@ -88,6 +93,9 @@ d2i_PUBKEY_bio(), d2i_PUBKEY_fp(), i2d_PUBKEY_bio() and i2d_PUBKEY_fp() are
 similar to d2i_PUBKEY() and i2d_PUBKEY() except they decode or encode using a
 B<BIO> or B<FILE> pointer.
 
+d2i_PUBKEY_ex_bio() and d2i_PUBKEY_ex_fp() are similar to d2i_PUBKEY_ex() except
+they decode using a B<BIO> or B<FILE> pointer.
+
 X509_PUBKEY_set0_public_key() sets the public-key encoding of I<pub>
 to the I<penclen> bytes contained in buffer I<penc>.
 Any earlier public-key encoding in I<pub> is freed.
@@ -129,8 +137,15 @@ Otherwise they return a pointer to the newly allocated structure.
 
 X509_PUBKEY_free() does not return a value.
 
-X509_PUBKEY_get0() and X509_PUBKEY_get() return a pointer to an B<EVP_PKEY>
-structure or NULL if an error occurs.
+X509_PUBKEY_get0(), X509_PUBKEY_get(), d2i_PUBKEY_ex(), d2i_PUBKEY(),
+d2i_PUBKEY_ex_bio(), d2i_PUBKEY_bio(), d2i_PUBKEY_ex_fp() and d2i_PUBKEY_fp()
+return a pointer to an B<EVP_PKEY> structure or NULL if an error occurs.
+
+i2d_PUBKEY() returns the number of bytes successfully encoded or a
+negative value if an error occurs.
+
+i2d_PUBKEY_fp() and i2d_PUBKEY_bio() return 1 if successfully
+encoded or 0 if an error occurs.
 
 X509_PUBKEY_set0_public_key() does not return a value.
 
@@ -150,11 +165,12 @@ L<X509_get_pubkey(3)>,
 The X509_PUBKEY_new_ex() and X509_PUBKEY_eq() functions were added in OpenSSL
 3.0.
 
-X509_PUBKEY_set0_public_key() was added in OpenSSL 3.2.
+The X509_PUBKEY_set0_public_key(), d2i_PUBKEY_ex_bio() and d2i_PUBKEY_ex_fp()
+functions were added in OpenSSL 3.2.
 
 =head1 COPYRIGHT
 
-Copyright 2016-2021 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2016-2022 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/doc/man3/d2i_PrivateKey.pod
+++ b/doc/man3/d2i_PrivateKey.pod
@@ -107,10 +107,12 @@ and d2i_KeyParams_bio() functions return a valid B<EVP_PKEY> structure or NULL
 if an error occurs. The error code can be obtained by calling
 L<ERR_get_error(3)>.
 
-i2d_PrivateKey(), i2d_PrivateKey_bio(), i2d_PrivateKey_fp(), i2d_PublicKey(),
-i2d_KeyParams() i2d_KeyParams_bio() return the number of bytes successfully
-encoded or a negative value if an error occurs. The error code can be obtained
-by calling L<ERR_get_error(3)>.
+i2d_PrivateKey(),  i2d_PublicKey() and i2d_KeyParams()return the number of
+bytes successfully encoded or a negative value if an error occurs. The error
+code can be obtained by calling L<ERR_get_error(3)>.
+
+i2d_PrivateKey_bio(), i2d_PrivateKey_fp() and i2d_KeyParams_bio() return 1 if
+successfully encoded or zero if an error occurs.
 
 =head1 SEE ALSO
 

--- a/doc/man3/d2i_PrivateKey.pod
+++ b/doc/man3/d2i_PrivateKey.pod
@@ -103,11 +103,10 @@ EC_GROUP.
 The d2i_PrivateKey_ex(), d2i_PrivateKey(), d2i_AutoPrivateKey_ex(),
 d2i_AutoPrivateKey(), d2i_PrivateKey_ex_bio(), d2i_PrivateKey_bio(),
 d2i_PrivateKey_ex_fp(), d2i_PrivateKey_fp(), d2i_PublicKey(), d2i_KeyParams()
-and d2i_KeyParams_bio() functions return a valid B<EVP_PKEY> structure or NULL
-if an error occurs. The error code can be obtained by calling
-L<ERR_get_error(3)>.
+and d2i_KeyParams_bio() functions return a valid B<EVP_PKEY> structure or NULL if
+an error occurs. The error code can be obtained by calling L<ERR_get_error(3)>.
 
-i2d_PrivateKey(),  i2d_PublicKey() and i2d_KeyParams()return the number of
+i2d_PrivateKey(), i2d_PublicKey() and i2d_KeyParams() return the number of
 bytes successfully encoded or a negative value if an error occurs. The error
 code can be obtained by calling L<ERR_get_error(3)>.
 

--- a/include/openssl/x509.h.in
+++ b/include/openssl/x509.h.in
@@ -412,6 +412,8 @@ EVP_PKEY *d2i_PrivateKey_ex_fp(FILE *fp, EVP_PKEY **a, OSSL_LIB_CTX *libctx,
                                const char *propq);
 EVP_PKEY *d2i_PrivateKey_fp(FILE *fp, EVP_PKEY **a);
 int i2d_PUBKEY_fp(FILE *fp, const EVP_PKEY *pkey);
+EVP_PKEY *d2i_PUBKEY_ex_fp(FILE *fp, EVP_PKEY **a, OSSL_LIB_CTX *libctx,
+                           const char *propq);
 EVP_PKEY *d2i_PUBKEY_fp(FILE *fp, EVP_PKEY **a);
 # endif
 
@@ -460,6 +462,8 @@ EVP_PKEY *d2i_PrivateKey_ex_bio(BIO *bp, EVP_PKEY **a, OSSL_LIB_CTX *libctx,
                                 const char *propq);
 EVP_PKEY *d2i_PrivateKey_bio(BIO *bp, EVP_PKEY **a);
 int i2d_PUBKEY_bio(BIO *bp, const EVP_PKEY *pkey);
+EVP_PKEY *d2i_PUBKEY_ex_bio(BIO *bp, EVP_PKEY **a, OSSL_LIB_CTX *libctx,
+                            const char *propq);
 EVP_PKEY *d2i_PUBKEY_bio(BIO *bp, EVP_PKEY **a);
 
 DECLARE_ASN1_DUP_FUNCTION(X509)

--- a/test/build.info
+++ b/test/build.info
@@ -183,7 +183,7 @@ IF[{- !$disabled{tests} -}]
   INCLUDE[evp_extra_test]=../include ../apps/include
   DEPEND[evp_extra_test]=../libcrypto.a libtestutil.a
 
-  SOURCE[evp_extra_test2]=evp_extra_test2.c
+  SOURCE[evp_extra_test2]=evp_extra_test2.c $INITSRC
   INCLUDE[evp_extra_test2]=../include ../apps/include
   DEPEND[evp_extra_test2]=../libcrypto libtestutil.a
 

--- a/test/evp_extra_test2.c
+++ b/test/evp_extra_test2.c
@@ -359,6 +359,35 @@ static int test_dh_tofrom_data_select(void)
 #endif
 
 #ifndef OPENSSL_NO_EC
+
+static int test_ec_d2i_i2d_pubkey(void)
+{
+    int ret = 0;
+    FILE *fp = NULL;
+    EVP_PKEY *key = NULL, *outkey = NULL;
+    static const char *filename = "pubkey.der";
+
+    if (!TEST_ptr(fp = fopen(filename, "wb"))
+        || !TEST_ptr(key = EVP_PKEY_Q_keygen(mainctx, NULL, "EC", "P-256"))
+        || !TEST_true(i2d_PUBKEY_fp(fp, key))
+        || !TEST_int_eq(fclose(fp), 0))
+        goto err;
+    fp = NULL;
+
+    if (!TEST_ptr(fp = fopen(filename, "rb"))
+        || !TEST_ptr(outkey = d2i_PUBKEY_ex_fp(fp, NULL, mainctx, NULL))
+        || !TEST_int_eq(EVP_PKEY_eq(key, outkey), 1))
+        goto err;
+
+    ret = 1;
+
+err:
+    EVP_PKEY_free(outkey);
+    EVP_PKEY_free(key);
+    fclose(fp);
+    return ret;
+}
+
 static int test_ec_tofrom_data_select(void)
 {
     int ret;
@@ -1117,6 +1146,7 @@ int setup_tests(void)
     ADD_ALL_TESTS(test_d2i_PrivateKey_ex, 2);
     ADD_TEST(test_ec_tofrom_data_select);
     ADD_TEST(test_ecx_tofrom_data_select);
+    ADD_TEST(test_ec_d2i_i2d_pubkey);
 #else
     ADD_ALL_TESTS(test_d2i_PrivateKey_ex, 1);
 #endif

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5475,3 +5475,5 @@ BIO_f_brotli                            ?	3_2_0	EXIST::FUNCTION:COMP
 COMP_zstd                               ?	3_2_0	EXIST::FUNCTION:COMP
 COMP_zstd_oneshot                       ?	3_2_0	EXIST::FUNCTION:COMP
 BIO_f_zstd                              ?	3_2_0	EXIST::FUNCTION:COMP
+d2i_PUBKEY_ex_fp                        ?	3_2_0	EXIST::FUNCTION:STDIO
+d2i_PUBKEY_ex_bio                       ?	3_2_0	EXIST::FUNCTION:


### PR DESCRIPTION
Add variants of d2i_PUBKEY_fp and d2i_PUBKEY_bio that pass a library context.

This also fixes some incorrect i2d documentation.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
