### PR TITLE
APPS HTTP server: trace message headers and diagnostics, clean up logging

### DIFF
--- a/apps/cmp.c
+++ b/apps/cmp.c
@@ -2729,7 +2729,7 @@ static int cmp_server(OSSL_CMP_CTX *srv_cmp_ctx)
         msgs++;
         if (req != NULL) {
             if (strcmp(path, "") != 0 && strcmp(path, "pkix/") != 0) {
-                (void)http_server_send_status(cbio, 404, "Not Found");
+                (void)http_server_send_status(prog, cbio, 404, "Not Found");
                 CMP_err1("expecting empty path or 'pkix/' but got '%s'",
                          path);
                 OPENSSL_free(path);
@@ -2740,11 +2740,11 @@ static int cmp_server(OSSL_CMP_CTX *srv_cmp_ctx)
             resp = OSSL_CMP_CTX_server_perform(cmp_ctx, req);
             OSSL_CMP_MSG_free(req);
             if (resp == NULL) {
-                (void)http_server_send_status(cbio,
+                (void)http_server_send_status(prog, cbio,
                                               500, "Internal Server Error");
                 break; /* treated as fatal error */
             }
-            ret = http_server_send_asn1_resp(cbio, keep_alive,
+            ret = http_server_send_asn1_resp(prog, cbio, keep_alive,
                                              "application/pkixcmp",
                                              ASN1_ITEM_rptr(OSSL_CMP_MSG),
                                              (const ASN1_VALUE *)resp);

--- a/apps/include/http_server.h
+++ b/apps/include/http_server.h
@@ -11,6 +11,7 @@
 # define OSSL_HTTP_SERVER_H
 
 # include "apps.h"
+# include "log.h"
 
 # ifndef HAVE_FORK
 #  if defined(OPENSSL_SYS_VMS) || defined(OPENSSL_SYS_WINDOWS)
@@ -31,36 +32,9 @@
 #  define HTTP_DAEMON
 #  include <sys/types.h>
 #  include <sys/wait.h>
-#  include <syslog.h>
 #  include <signal.h>
 #  define MAXERRLEN 1000 /* limit error text sent to syslog to 1000 bytes */
 # endif
-
-# undef LOG_TRACE
-# undef LOG_DEBUG
-# undef LOG_INFO
-# undef LOG_WARNING
-# undef LOG_ERR
-# define LOG_TRACE     8
-# define LOG_DEBUG     7
-# define LOG_INFO      6
-# define LOG_WARNING   4
-# define LOG_ERR       3
-
-/*-
- * Output a message using the trace API with the given category
- * if the category is >= 0 and tracing is enabled.
- * Log the message to syslog if multi-threaded HTTP_DAEMON, else to bio_err
- * if the verbosity is sufficient for the given level of severity.
- * category: trace category as defined in trace.h, or -1
- * prog: the name of the current app, or NULL
- * level: the severity of the message, e.g., LOG_ERR
- * fmt: message format, which should not include a trailing newline
- * ...: potential extra parameters like with printf()
- * returns nothing
- */
-void trace_log_message(int category,
-                       const char *prog, int level, const char *fmt, ...);
 
 # ifndef OPENSSL_NO_SOCK
 /*-

--- a/apps/include/http_server.h
+++ b/apps/include/http_server.h
@@ -48,13 +48,19 @@
 # define LOG_ERR       3
 
 /*-
- * Log a message to syslog if multi-threaded HTTP_DAEMON, else to bio_err
- * prog: the name of the current app
+ * Output a message using the trace API with the given category
+ * if the category is >= 0 and tracing is enabled.
+ * Log the message to syslog if multi-threaded HTTP_DAEMON, else to bio_err
+ * if the verbosity is sufficient for the given level of severity.
+ * category: trace category as defined in trace.h, or -1
+ * prog: the name of the current app, or NULL
  * level: the severity of the message, e.g., LOG_ERR
- * fmt: message with potential extra parameters like with printf()
+ * fmt: message format, which should not include a trailing newline
+ * ...: potential extra parameters like with printf()
  * returns nothing
  */
-void log_message(const char *prog, int level, const char *fmt, ...);
+void trace_log_message(int category,
+                       const char *prog, int level, const char *fmt, ...);
 
 # ifndef OPENSSL_NO_SOCK
 /*-
@@ -92,6 +98,7 @@ int http_server_get_asn1_req(const ASN1_ITEM *it, ASN1_VALUE **preq,
 
 /*-
  * Send an ASN.1-formatted HTTP response
+ * prog: the name of the current app, for diagnostics only
  * cbio: destination BIO (typically as returned by http_server_get_asn1_req())
  *       note: cbio should not do an encoding that changes the output length
  * keep_alive: grant persistent connection
@@ -100,18 +107,20 @@ int http_server_get_asn1_req(const ASN1_ITEM *it, ASN1_VALUE **preq,
  * resp: the response to send
  * returns 1 on success, 0 on failure
  */
-int http_server_send_asn1_resp(BIO *cbio, int keep_alive,
+int http_server_send_asn1_resp(const char *prog, BIO *cbio, int keep_alive,
                                const char *content_type,
                                const ASN1_ITEM *it, const ASN1_VALUE *resp);
 
 /*-
  * Send a trivial HTTP response, typically to report an error or OK
+ * prog: the name of the current app, for diagnostics only
  * cbio: destination BIO (typically as returned by http_server_get_asn1_req())
  * status: the status code to send
  * reason: the corresponding human-readable string
  * returns 1 on success, 0 on failure
  */
-int http_server_send_status(BIO *cbio, int status, const char *reason);
+int http_server_send_status(const char *prog, BIO *cbio,
+                            int status, const char *reason);
 
 # endif
 

--- a/apps/include/http_server.h
+++ b/apps/include/http_server.h
@@ -125,7 +125,7 @@ int http_server_send_status(const char *prog, BIO *cbio,
 # endif
 
 # ifdef HTTP_DAEMON
-extern int multi;
+extern int n_responders;
 extern int acfd;
 
 void socket_timeout(int signum);

--- a/apps/include/log.h
+++ b/apps/include/log.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright 1995-2022 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#ifndef OSSL_APPS_LOG_H
+# define OSSL_APPS_LOG_H
+
+# include <openssl/bio.h>
+# if !defined(OPENSSL_SYS_VMS) && !defined(OPENSSL_SYS_WINDOWS) \
+    && !defined(OPENSSL_NO_SOCK) && !defined(OPENSSL_NO_POSIX_IO)
+#  include <syslog.h>
+# else
+#  define LOG_EMERG   0
+#  define LOG_ALERT   1
+#  define LOG_CRIT    2
+#  define LOG_ERR     3
+#  define LOG_WARNING 4
+#  define LOG_NOTICE  5
+#  define LOG_INFO    6
+#  define LOG_DEBUG   7
+# endif
+
+# undef LOG_TRACE
+# define LOG_TRACE (LOG_DEBUG + 1)
+
+int log_set_verbosity(const char *prog, int level);
+int log_get_verbosity(void);
+
+/*-
+ * Output a message using the trace API with the given category
+ * if the category is >= 0 and tracing is enabled.
+ * Log the message to syslog if multi-threaded HTTP_DAEMON, else to bio_err
+ * if the verbosity is sufficient for the given level of severity.
+ * Yet cannot do both types of output in strict ANSI mode.
+ * category: trace category as defined in trace.h, or -1
+ * prog: the name of the current app, or NULL
+ * level: the severity of the message, e.g., LOG_ERR
+ * fmt: message format, which should not include a trailing newline
+ * ...: potential extra parameters like with printf()
+ * returns nothing
+ */
+void trace_log_message(int category,
+                       const char *prog, int level, const char *fmt, ...);
+
+#endif /* OSSL_APPS_LOG_H */

--- a/apps/lib/build.info
+++ b/apps/lib/build.info
@@ -8,7 +8,7 @@ IF[{- $config{target} =~ /^vms-/ -}]
 ENDIF
 
 # Source for libapps
-$LIBAPPSSRC=apps.c apps_ui.c opt.c fmt.c s_cb.c s_socket.c app_rand.c \
+$LIBAPPSSRC=apps.c apps_ui.c log.c opt.c fmt.c s_cb.c s_socket.c app_rand.c \
         columns.c app_params.c names.c app_provider.c app_x509.c http_server.c \
         engine.c engine_loader.c app_libctx.c apps_opt_printf.c
 

--- a/apps/lib/log.c
+++ b/apps/lib/log.c
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2020-2022 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <openssl/trace.h>
+#include "apps.h"
+#include "log.h"
+
+static int verbosity = LOG_INFO;
+
+int log_set_verbosity(const char *prog, int level)
+{
+    if (level < LOG_EMERG || level > LOG_TRACE) {
+        trace_log_message(-1, prog, LOG_ERR,
+                          "Invalid verbosity level %d", level);
+        return 0;
+    }
+    verbosity = level;
+    return 1;
+}
+
+int log_get_verbosity(void)
+{
+    return verbosity;
+}
+
+#ifdef HTTP_DAEMON
+static int print_syslog(const char *str, size_t len, void *levPtr)
+{
+    int level = *(int *)levPtr;
+    int ilen = len > MAXERRLEN ? MAXERRLEN : len;
+
+    syslog(level, "%.*s", ilen, str);
+
+    return ilen;
+}
+#endif
+
+static void log_with_prefix(const char *prog, const char *fmt, va_list ap)
+{
+    char prefix[80];
+    BIO *bio, *pre = BIO_new(BIO_f_prefix());
+
+    (void)snprintf(prefix, sizeof(prefix), "%s: ", prog);
+    (void)BIO_set_prefix(pre, prefix);
+    bio = BIO_push(pre, bio_err);
+    (void)BIO_vprintf(bio, fmt, ap);
+    (void)BIO_printf(bio, "\n");
+    (void)BIO_flush(bio);
+    (void)BIO_pop(pre);
+    BIO_free(pre);
+}
+
+void trace_log_message(int category,
+                       const char *prog, int level, const char *fmt, ...)
+{
+    va_list ap;
+    va_start(ap, fmt);
+#ifdef __STRICT_ANSI__ /* unfortuantely, ANSI does not define va_copy */
+    if (verbosity >= level)
+        category = -1; /* disabling trace output in addition to logging */
+#endif
+    if (category >= 0 && OSSL_trace_enabled(category)) {
+        BIO *out = OSSL_trace_begin(category);
+#ifndef __STRICT_ANSI__
+        va_list ap_copy;
+
+        va_copy(ap_copy, ap);
+        (void)BIO_vprintf(out, fmt, ap_copy);
+        va_end(ap_copy);
+#else
+        (void)BIO_vprintf(out, fmt, ap);
+#endif
+        (void)BIO_printf(out, "\n");
+        OSSL_trace_end(category, out);
+    }
+    if (verbosity < level) {
+        va_end(ap);
+        return;
+    }
+#ifdef HTTP_DAEMON
+    if (n_responders != 0) {
+        vsyslog(level, fmt, ap);
+        if (level <= LOG_ERR)
+            ERR_print_errors_cb(print_syslog, &level);
+    } else
+#endif
+    log_with_prefix(prog, fmt, ap);
+    va_end(ap);
+}

--- a/apps/ocsp.c
+++ b/apps/ocsp.c
@@ -529,7 +529,7 @@ int ocsp_main(int argc, char **argv)
             break;
         case OPT_MULTI:
 #ifdef HTTP_DAEMON
-            multi = atoi(opt_arg());
+            n_responders = atoi(opt_arg());
 #endif
             break;
         case OPT_PROV_CASES:
@@ -633,7 +633,7 @@ int ocsp_main(int argc, char **argv)
     }
 
 #ifdef HTTP_DAEMON
-    if (multi != 0 && acbio != NULL)
+    if (n_responders != 0 && acbio != NULL)
         spawn_loop(prog);
     if (acbio != NULL && req_timeout > 0)
         signal(SIGALRM, socket_timeout);

--- a/apps/ocsp.c
+++ b/apps/ocsp.c
@@ -633,14 +633,15 @@ int ocsp_main(int argc, char **argv)
     }
 
 #ifdef HTTP_DAEMON
-    if (multi && acbio != NULL)
+    if (multi != 0 && acbio != NULL)
         spawn_loop(prog);
     if (acbio != NULL && req_timeout > 0)
         signal(SIGALRM, socket_timeout);
 #endif
 
     if (acbio != NULL)
-        log_message(prog, LOG_INFO, "waiting for OCSP client connections...");
+        trace_log_message(-1, prog,
+                          LOG_INFO, "waiting for OCSP client connections...");
 
 redo_accept:
 
@@ -654,8 +655,9 @@ redo_accept:
                 rdb = newrdb;
             } else {
                 free_index(newrdb);
-                log_message(prog, LOG_ERR, "error reloading updated index: %s",
-                            ridx_filename);
+                trace_log_message(-1, prog,
+                                  LOG_ERR, "error reloading updated index: %s",
+                                  ridx_filename);
             }
         }
 #endif
@@ -1217,7 +1219,7 @@ static int do_responder(OCSP_REQUEST **preq, BIO **pcbio, BIO *acbio,
 static int send_ocsp_response(BIO *cbio, const OCSP_RESPONSE *resp)
 {
 #ifndef OPENSSL_NO_SOCK
-    return http_server_send_asn1_resp(cbio,
+    return http_server_send_asn1_resp(prog, cbio,
                                       0 /* no keep-alive */,
                                       "application/ocsp-response",
                                       ASN1_ITEM_rptr(OCSP_RESPONSE),

--- a/doc/man1/openssl.pod
+++ b/doc/man1/openssl.pod
@@ -792,7 +792,7 @@ Traces decrementing certain ASN.1 structure references.
 
 =item B<HTTP>
 
-Traces the HTTP client, such as message headers being sent and received.
+Traces the HTTP client and server, such as messages being sent and received.
 
 =back
 

--- a/doc/man3/OSSL_trace_enabled.pod
+++ b/doc/man3/OSSL_trace_enabled.pod
@@ -33,6 +33,7 @@ OSSL_TRACE_ENABLED
  } OSSL_TRACE_END(category);
 
  /* one-shot trace macros */
+ OSSL_TRACE(category, text)
  OSSL_TRACE1(category, format, arg1)
  OSSL_TRACE2(category, format, arg1, arg2)
  ...


### PR DESCRIPTION
This is a follow-up of #18386, adding message header tracing also to the HTTP server side.
On this occasion, extract the more generally usable logging functionality to `apps/lib/log.c`
and fix some related nits in documentation, coding style, and error handling.

* `apps/lib/http_server.c`: trace message headers and diagnostics when enabled
* `OSSL_trace_enabled.pod`: add missing synopsis for `OSSL_TRACE()`
* `apps/lib/http_server.{c,h}`: clean up logging and move it to `log.{c,h}`
* `apps/ocsp.c` etc.: rename 'multi' to 'n_responders' for clarity
* ~`BIO_f_prefix`: improve diagnostics where prefix operations not implemented; fix nit in doc~