### PR TITLE
Fix a memory leak in ossl_method_store_add()

### DIFF
--- a/crypto/property/defn_cache.c
+++ b/crypto/property/defn_cache.c
@@ -79,6 +79,11 @@ OSSL_PROPERTY_LIST *ossl_prop_defn_get(OSSL_LIB_CTX *ctx, const char *prop)
     return r != NULL ? r->defn : NULL;
 }
 
+/*
+ * Cache the property list for a given property string. Callers of this function
+ * should call ossl_prop_defn_get first to ensure that there is no existing
+ * cache entry for this property string.
+ */
 int ossl_prop_defn_set(OSSL_LIB_CTX *ctx, const char *prop,
                        OSSL_PROPERTY_LIST *pl)
 {
@@ -109,8 +114,14 @@ int ossl_prop_defn_set(OSSL_LIB_CTX *ctx, const char *prop,
         p->defn = pl;
         memcpy(p->body, prop, len + 1);
         old = lh_PROPERTY_DEFN_ELEM_insert(property_defns, p);
-        if (old != NULL) {
-            property_defn_free(old);
+        if (!ossl_assert(old == NULL)) {
+            /*
+             * This should not happen. Any caller of ossl_prop_defn_set should
+             * have called ossl_prop_defn_get first - so we should know that
+             * there is no existing entry. If we get here we have a bug. We
+             * deliberately leak the |old| reference in order to avoid a crash
+             * if there are any existing users of it.
+             */
             goto end;
         }
         if (!lh_PROPERTY_DEFN_ELEM_error(property_defns))

--- a/crypto/property/property.c
+++ b/crypto/property/property.c
@@ -304,7 +304,11 @@ int ossl_method_store_add(OSSL_METHOD_STORE *store, const OSSL_PROVIDER *prov,
         impl->properties = ossl_parse_property(store->ctx, properties);
         if (impl->properties == NULL)
             goto err;
-        ossl_prop_defn_set(store->ctx, properties, impl->properties);
+        if (!ossl_prop_defn_set(store->ctx, properties, impl->properties)) {
+            ossl_property_free(impl->properties);
+            impl->properties = NULL;
+            goto err;
+        }
     }
 
     alg = ossl_method_store_retrieve(store, nid);


### PR DESCRIPTION
If the call to ossl_prop_defn_set() fails then the OSSL_PROPERTY_LIST
we just created will leak.

Found as a result of:
https://github.com/openssl/openssl/pull/18355#issuecomment-1139499881
