### PR TITLE
Fix inadvertent NULL assignments in ternary ops

### DIFF
--- a/crypto/encode_decode/decoder_meth.c
+++ b/crypto/encode_decode/decoder_meth.c
@@ -383,7 +383,7 @@ inner_ossl_decoder_fetch(struct decoder_data_st *methdata,
         ERR_raise_data(ERR_LIB_OSSL_DECODER, code,
                        "%s, Name (%s : %d), Properties (%s)",
                        ossl_lib_ctx_get_descriptor(methdata->libctx),
-                       name = NULL ? "<null>" : name, id,
+                       name == NULL ? "<null>" : name, id,
                        properties == NULL ? "<null>" : properties);
     }
 

--- a/crypto/encode_decode/encoder_meth.c
+++ b/crypto/encode_decode/encoder_meth.c
@@ -392,7 +392,7 @@ inner_ossl_encoder_fetch(struct encoder_data_st *methdata,
         ERR_raise_data(ERR_LIB_OSSL_ENCODER, code,
                        "%s, Name (%s : %d), Properties (%s)",
                        ossl_lib_ctx_get_descriptor(methdata->libctx),
-                       name = NULL ? "<null>" : name, id,
+                       name == NULL ? "<null>" : name, id,
                        properties == NULL ? "<null>" : properties);
     }
 

--- a/crypto/store/store_meth.c
+++ b/crypto/store/store_meth.c
@@ -330,7 +330,7 @@ inner_loader_fetch(struct loader_data_st *methdata,
                        "%s%s, Scheme (%s : %d), Properties (%s)",
                        helpful_msg,
                        ossl_lib_ctx_get_descriptor(methdata->libctx),
-                       scheme = NULL ? "<null>" : scheme, id,
+                       scheme == NULL ? "<null>" : scheme, id,
                        properties == NULL ? "<null>" : properties);
     }
 


### PR DESCRIPTION
As identified by both clang with a warning and `$> git grep -P '(?<![!=])= NULL \?'`

Signed-off-by: Clemens Lang <cllang@redhat.com>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
not applicable