### PR TITLE
[WIP][RFC] Implement Montgomery Modular Multiplication in RISC-V Vector Extension ASM

### DIFF
--- a/crypto/bn/asm/riscv64-vector-mont-256.pl
+++ b/crypto/bn/asm/riscv64-vector-mont-256.pl
@@ -1,0 +1,229 @@
+#! /usr/bin/env perl
+use POSIX;
+use warnings;
+
+# $output is the last argument if it looks like a file (it has an extension)
+# $flavour is the first argument if it doesn't look like a file
+$output = $#ARGV >= 0 && $ARGV[$#ARGV] =~ m|\.\w+$| ? pop : undef;
+#$flavour = $#ARGV >= 0 && $ARGV[0] !~ m|\.| ? shift : undef;
+
+$output and open STDOUT,">$output";
+
+my $code = "";
+
+################################################################################
+# Constants
+################################################################################
+
+my $xl = 64; # XLEN
+my $vl = 128; # VLEN should be at least $vl
+my $el = 32; # ELEN should be at least $el
+# we only support LMUL = 1
+my $lmul = 1;
+
+my $bn = 256; # bits of Big Number
+my $word = 16; # number of bits in one SEW
+my $R = $bn + $word; # log(montgomery radix R). 
+# e.g. when bn = 256, word = 16, then R = log(2 ** (256 + 16)) = 272
+# the result of this mmm is A*B*2^{-R} mod P
+
+my $sew = $word * 2; # SEW
+if ($sew > $el) {
+    die "SEW must not be greater than ELEN! params: vl $vl, el $el, word $word, sew $sew";
+}
+
+my $way = $vl / $sew; # simd way
+my $niter = $bn / $word; # number of iterations
+my $nreg = $niter / $way + 1; # number of vreg for one bn
+# max nreg = 8 as restraint by seg8
+# thus max possible value for bn is 8 * (VLEN / 2) - word >= 496, suitable for most ECC (not P521, though)
+# of couse with greater VLEN=2048 we can compute RSA 4096 here
+if ($nreg > 8) {
+    die "nreg must not be greater than 8! params: vl $vl, sew $sew, bn $bn, word $word, nreg $nreg";
+}
+my $nelement = $nreg * $way; # number of elements should be in A, B, P and AB
+# actual bits used for one bn: $nreg * $vl
+# we use vlseg to load data
+# e.g, when BN = 256, VLEN = 128 and SEW = 32
+# nreg is 5 instead of 4, thus nelement is 20 instead of 16
+
+################################################################################
+# Register assignment
+################################################################################
+
+my ($AB, $A, $B, $P, $MU) = ("a0", "a1", "a2", "a3", "a4");
+
+my ($T0, $LOOP, $LOOP2) = ("t0", "t1", "t2"); # happy that it is caller-saved
+
+my ($PVN, $AVN, $ABVN) = (0, 10, 20);
+my ($PV, $AV, $ABV) = ("v$PVN", "v$AVN", "v$ABVN");
+
+# temporary reg
+my $TV = "v30";
+my $TV2 = "v31";
+
+################################################################################
+# utility
+################################################################################
+
+sub propagate {
+    my $j = shift;
+    my $f = shift;
+    my $j1 = ($j + 1) % $nreg;
+    my $ABVJ = "v@{[$ABVN + $j]}";
+    my $ABVJ1 = "v@{[$ABVN + $j1]}";
+    $code .= <<___;
+    # save carry in TV
+    vsrl.vi $TV, $ABVJ, $word
+    # mod 2 ** $word
+    # TV2 the mask until after j == nreg - 1
+    vand.vv $ABVJ, $ABVJ, $TV2
+___
+    if ($j == $nreg - 1) {
+    # carry of AB_s-1 does not add to AB_0
+        $code .= <<___;
+    # changed TV2 here! re-init TV2 when the loop start again
+    vslide1up.vx $TV2, $TV, zero
+    vadd.vv $ABVJ1, $ABVJ1, $TV2
+___
+    } else {
+        $code .= <<___;
+    vadd.vv $ABVJ1, $ABVJ1, $TV
+___
+    }
+}
+
+sub move {
+    $code .= <<___;
+    vslide1down.vx $TV2, $ABV, zero
+___
+# move AB_1 to AB_0, AB_0 (now AB_s in TV2) to AB_s-1
+    for (my $k = 0; $k != $nreg - 1; $k++) {
+        my $ABVK = "v@{[$ABVN + $k]}";
+        my $ABVK1 = "v@{[$ABVN + $k + 1]}";
+        $code .= <<___;
+    vmv.v.v        $ABVK, $ABVK1
+___
+    }
+    my $ABVF = "v@{[$ABVN + $nreg - 1]}";
+    $code .= <<___;
+    vmv.v.v        $ABVF, $TV2
+___
+}
+
+sub propagate_niter {
+# propagate carry for nreg*way (bigger than niter) round
+# original algorithm propagates for niter round
+$code .= <<___;
+    # start loop of niter + 1 times
+    li  $LOOP2,0
+10:
+    # mask
+    # T0 reused at the end
+    # set TV2 for every loop
+    li  $T0,@{[2 ** $word - 1]}
+    vmv.v.x $TV2,$T0
+___
+# propagate carry for nreg round
+for (my $j = 0; $j != $nreg; $j++) {
+    propagate($j);
+}
+$code .= <<___;
+    addi  $LOOP2,$LOOP2,1
+    li    $T0,$way
+    bne   $LOOP2,$T0,10b
+___
+}
+
+################################################################################
+# function
+################################################################################
+$code .= <<___;
+.text
+.balign 16
+.globl bn_mul_mont_rv${xl}imv_zvl${vl}b_sew${el}_bn${bn}_nelement${nelement}
+.type bn_mul_mont_rv${xl}imv_zvl${vl}b_sew${el}_bn${bn}_nelement${nelement},\@function
+# assume VLEN >= $vl, BN = $bn, SEW = $word * 2 = $sew
+# we only support LMUL = 1 for now
+# P, A, B, AB should have $nelement elements
+bn_mul_mont_rv${xl}imv_zvl${vl}b_sew${el}_bn${bn}_nelement${nelement}:
+    # quite SIMD
+    li  $T0, $way # in case way > 31
+    vsetvli zero, $T0, e$sew, m$lmul, ta, ma
+
+    # load values from arg
+    vlseg${nreg}e$sew.v $PV, ($P)
+    vlseg${nreg}e$sew.v $AV, ($A)
+___
+
+    # set ABV to 0
+for (my $j = 0; $j != $nreg; $j++) {
+    my $ABVJ = "v@{[$ABVN + $j]}";
+    $code .= <<___;
+    vmv.v.i            $ABVJ, 0
+___
+}
+
+$code .= <<___;
+    # start loop of niter + 1 times
+    li  $LOOP,0
+1:
+    # AB = B_i*A + AB
+    # !!!!!! important: lw here assumes SEW = 32
+    lw $T0, 0($B)
+    addi $B, $B, 4 # advance B by a SEW
+___
+
+for (my $j = 0; $j != $nreg; $j++) {
+    my $ABVJ = "v@{[$ABVN + $j]}";
+    my $AVJ = "v@{[$AVN + $j]}";
+    $code .= <<___;
+    vmacc.vx $ABVJ, $T0, $AVJ
+___
+}
+
+## NOT TRUE: propagate carry for nreg round
+# nreg round is not enough, should do it for n
+#for (my $j = 0; $j != $nreg; $j++) {
+#    propagate($j, 0);
+#}
+# fully propagte
+propagate_niter();
+
+# AB = q*P + AB
+$code .= <<___;
+    vmv.x.s $T0, $ABV
+    mul     $T0, $T0, $MU
+    # mod 2 ** $word
+    # !!!! important: here we assume SEW = 32 and XLEN = 64
+    sllw    $T0, $T0, $word
+    srlw    $T0, $T0, $word
+___
+for (my $j = 0; $j != $nreg; $j++) {
+    my $ABVJ = "v@{[$ABVN + $j]}";
+    my $PVJ = "v@{[$PVN + $j]}";
+    $code .= <<___;
+    vmacc.vx $ABVJ, $T0, $PVJ
+___
+    }
+
+## NOT TRUE: propagate carry for nreg round
+#for (my $j = 0; $j != $nreg - 1; $j++) {
+#    propagate($j, 0);
+#}
+## propagate final round and move
+#propagate($nreg - 1, 1);
+propagate_niter();
+move();
+
+$code .= <<___;
+    addi  $LOOP,$LOOP,1
+    li    $T0,@{[$niter + 1]}
+    bne   $LOOP,$T0,1b
+
+    vsseg${nreg}e$sew.v $ABV, ($AB)
+    ret
+___
+
+print $code;
+close STDOUT or die "error closing STDOUT: $!";

--- a/crypto/bn/asm/riscv64-vector-mont-4096.pl
+++ b/crypto/bn/asm/riscv64-vector-mont-4096.pl
@@ -1,0 +1,400 @@
+#! /usr/bin/env perl
+use POSIX;
+use warnings;
+
+# $output is the last argument if it looks like a file (it has an extension)
+# $flavour is the first argument if it doesn't look like a file
+$output = $#ARGV >= 0 && $ARGV[$#ARGV] =~ m|\.\w+$| ? pop : undef;
+#$flavour = $#ARGV >= 0 && $ARGV[0] !~ m|\.| ? shift : undef;
+
+$output and open STDOUT,">$output";
+
+my $code = "";
+
+################################################################################
+# Constants
+################################################################################
+
+my $xl = 64; # XLEN
+my $vl = 128; # VLEN should be at least $vl
+my $el = 32; # ELEN should be at least $el
+# we only support LMUL = 1
+my $lmul = 1;
+
+my $bn = 4096; # bits of Big Number
+my $word = 16; # number of bits in one SEW
+my $R = $bn + $word; # log(montgomery radix R). 
+# e.g. when bn = 256, word = 16, then R = log(2 ** (256 + 16)) = 272
+# the result of this mmm is A*B*2^{-R} mod P
+
+my $sew = $word * 2; # SEW
+if ($sew > $el) {
+    die "SEW must not be greater than ELEN! params: vl $vl, el $el, word $word, sew $sew";
+}
+
+my $way = $vl / $sew; # simd way
+my $niter = $bn / $word; # number of iterations
+my $ntotalreg = $niter / $way + 1; # number of vreg for one bn
+my $nreg = $ntotalreg;
+my $nelement = $ntotalreg * $way; # number of elements should be in A, B, P and AB
+# e.g, when BN = 4096, VLEN = 128 and SEW = 32
+# ntotalreg is 65 instead of 64, then nelement is 260 instead of 256
+
+# we use vlseg to load data
+# max nreg = 8 as restraint by seg8
+# for nreg > 8, we can split them into groups
+my $ngroup = 1;
+my $lastgroup = 0;
+if ($nreg > 8) {
+    $lastgroup = $nreg % 8;
+    $ngroup = ($nreg - $lastgroup) / 8;
+    if ($lastgroup != 0) {
+        $ngroup = $ngroup + 1;
+    } else {
+        # if last group is 0, then last group is 8
+        $lastgroup = 8;
+    }
+    $nreg = 8;
+} else {
+    $lastgroup = $nreg;
+}
+# e.g, when BN = 4096, VLEN = 128 and SEW = 32
+# ngroup is 9 and last group is 1
+
+################################################################################
+# Register assignment
+################################################################################
+
+my ($AB, $A, $B, $P, $MU) = ("a0", "a1", "a2", "a3", "a4");
+
+# happy that they are caller-saved
+my ($T0, $STRIDE, $T2, $T3, $LOOP, $LOOP2) = ("t0", "t1", "t2", "t3", "t4", "t5");
+
+my ($PVN, $AVN, $ABVN) = (0, 10, 20);
+my ($PV, $AV, $ABV) = ("v$PVN", "v$AVN", "v$ABVN");
+
+# temporary reg
+my $TV = "v30";
+my $TV2 = "v31";
+
+################################################################################
+# utility
+################################################################################
+
+sub propagate {
+    my $j = shift;
+    my $ngroupreg = shift;
+    my $j1 = $j + 1; # no warry on overflow: see j != nreg - 1 below
+    my $ABVJ = "v@{[$ABVN + $j]}";
+    my $ABVJ1 = "v@{[$ABVN + $j1]}";
+    # use carry TV from the $nreg - 1 of the previous group
+    if ($j == 0) {
+        $code .= <<___;
+    vadd.vv $ABVJ, $ABVJ, $TV
+___
+    }
+    $code .= <<___;
+    # save carry in TV
+    vsrl.vi $TV, $ABVJ, $word
+    # mod 2 ** $word
+    vand.vv $ABVJ, $ABVJ, $TV2
+___
+    if ($j != $ngroupreg - 1) {
+        $code .= <<___;
+    vadd.vv $ABVJ1, $ABVJ1, $TV
+___
+    }
+}
+
+sub propagate_niter {
+# propagate carry for the whole bn
+# in total ntotalreg*way times
+$code .= <<___;
+    # start loop of niter + 1 times
+    # use T2 as outer loop index
+    li  $T2,0
+9:
+    # mask
+    # set TV2 for every propagate()
+    # set TV2 every time (see slide1up below)
+    li  $T0,@{[2 ** $word - 1]}
+    vmv.v.x $TV2,$T0
+
+    # carry for ABV_0
+    vmv.v.i $TV,0
+
+    # loop variable
+    li  $LOOP2,0
+___
+# start loop of ngroup - 1 times
+if ($ngroup != 1) {
+    $code .= <<___;
+10:
+    # load one group of values from arg
+    # offset of one group
+    # !!! important: assume nreg = 8 and sew = 32
+    # log(8) + log(32/8) = 5
+    slli $T3,$LOOP2,5
+    add  $T3,$T3,$AB
+    vlsseg${nreg}e$sew.v $ABV, ($T3), $STRIDE
+___
+
+    # propagate carry for nreg round
+    # the carry for $nreg - 1 is propagated to TV
+    # then added in the next group
+    for (my $j = 0; $j != $nreg; $j++) {
+        propagate($j, $nreg);
+    }
+
+$code .= <<___;
+    # store one group of AB
+    vssseg${nreg}e$sew.v $ABV, ($T3), $STRIDE
+
+    addi $LOOP2,$LOOP2,1
+    li  $T0,@{[$ngroup - 1]}
+    bne $LOOP2,$T0,10b
+___
+}
+# special treatment on last group
+$code .= <<___;
+    # load last group of values from arg
+    # offset of last group
+    # !!! important: assume nreg = 8 and sew = 32
+    # log(8) + log(32/8) = 5
+    # LOOP2 is now ngroup - 1
+    slli $T3,$LOOP2,5
+    add  $T3,$T3,$AB
+    vlsseg${lastgroup}e$sew.v $ABV, ($T3), $STRIDE
+___
+# propagate carry for lastgroup round
+# the carry for $lastgroup - 1 is propagated to TV
+# then added in the next group (now AB_0)
+for (my $j = 0; $j != $lastgroup; $j++) {
+    propagate($j, $lastgroup);
+}
+$code .= <<___;
+    # store last group of AB
+    vssseg${lastgroup}e$sew.v $ABV, ($T3), $STRIDE
+
+    # update carry of AB_{ntotalreg - 1} to AB_0
+    vlsseg1e$sew.v $ABV, ($AB), $STRIDE
+    vslide1up.vx $TV2, $TV, zero
+    vadd.vv $ABV, $ABV, $TV2
+    vssseg1e$sew.v $ABV, ($AB), $STRIDE
+___
+
+# outer loop
+$code .= <<___;
+    addi  $T2,$T2,1
+    li    $T0,$way
+    bne   $T2,$T0,9b
+___
+}
+
+sub move {
+# move AB_1 to AB_0, AB_2 to AB_1, ... , AB_0 (in TV now) to AB_{ntotalreg-1}
+$code .= <<___;
+    # loop variable
+    li  $LOOP2,0
+___
+if ($ngroup != 1) {
+    $code .= <<___;
+2:
+    # load one offseted group of values from arg
+    # offset of one group
+    # !!! important: assume nreg = 8 and sew = 32
+    # log(8) + log(32/8) = 5
+    slli $T2,$LOOP2,5
+
+    # then offset by 1 element
+    addi $T2,$T2,@{[$sew / 8]}
+    add  $T3,$T2,$AB
+    vlsseg${nreg}e$sew.v $ABV, ($T3), $STRIDE
+
+    # back to original offset
+    addi $T3,$T3,@{[-$sew / 8]}
+    vssseg${nreg}e$sew.v $ABV, ($T3), $STRIDE
+
+    addi $LOOP2,$LOOP2,1
+    li  $T2,@{[$ngroup - 1]}
+    bne $LOOP2,$T2,2b
+___
+}
+# special treatment on last group
+$code .= <<___;
+    # load last group of values from arg
+    # offset of last group
+    # !!! important: assume nreg = 8 and sew = 32
+    # log(8) + log(32/8) = 5
+    # LOOP2 is now ngroup - 1
+    slli $T2,$LOOP2,5
+    # then offset by 1 element
+    addi $T2,$T2,@{[$sew / 8]}
+    add  $T3,$T2,$AB
+___
+if ($lastgroup != 1) {
+    $code .= <<___;
+    vlsseg@{[$lastgroup - 1]}e$sew.v $ABV, ($T3), $STRIDE
+___
+}
+
+$code .= <<___;
+    # move AB_0 to AB_{ntotalreg-1}
+    vmv.v.v v@{[$ABVN + $lastgroup - 1]}, $TV
+
+    # back to original offset
+    addi $T3,$T3,@{[-$sew / 8]}
+    vssseg${lastgroup}e$sew.v $ABV, ($T3), $STRIDE
+___
+}
+
+# consumes LOOP2, T0, AB, STRIDE from env, use T2, T3 as tmp var
+sub macc {
+    my $V = shift;
+    my $VV = shift;
+    my $VVN = shift;
+    my $ngroupreg = shift;
+    $code .= <<___;
+    # load one group of values from arg
+    # offset of one group
+    # !!! important: assume nreg = 8 and sew = 32
+    # log(8) + log(32/8) = 5
+    slli $T2,$LOOP2,5
+    add  $T3,$T2,$V
+    vlsseg${ngroupreg}e$sew.v $VV, ($T3), $STRIDE
+    add  $T3,$T2,$AB
+    vlsseg${ngroupreg}e$sew.v $ABV, ($T3), $STRIDE
+___
+
+    for (my $j = 0; $j != $ngroupreg; $j++) {
+        my $ABVJ = "v@{[$ABVN + $j]}";
+        my $VVJ = "v@{[$VVN + $j]}";
+        $code .= <<___;
+        vmacc.vx $ABVJ, $T0, $VVJ
+___
+    }
+
+    $code .= <<___;
+    # store one group of AB
+    vssseg${ngroupreg}e$sew.v $ABV, ($T3), $STRIDE
+___
+}
+
+################################################################################
+# function
+################################################################################
+$code .= <<___;
+.text
+.balign 16
+.globl bn_mul_mont_rv${xl}imv_zvl${vl}b_sew${el}_bn${bn}_nelement${nelement}
+.type bn_mul_mont_rv${xl}imv_zvl${vl}b_sew${el}_bn${bn}_nelement${nelement},\@function
+# assume VLEN >= $vl, BN = $bn, SEW = $word * 2 = $sew
+# we only support LMUL = 1 for now
+# P, A, B, AB should have $nelement elements
+bn_mul_mont_rv${xl}imv_zvl${vl}b_sew${el}_bn${bn}_nelement${nelement}:
+    # quite SIMD
+    li  $T0, $way # in case way > 31
+    vsetvli zero, $T0, e$sew, m$lmul, ta, ma
+    # stride
+    li  $STRIDE, @{[$ntotalreg * $sew / 8]}
+___
+
+$code .= <<___;
+    # start loop of niter + 1 times
+    li  $LOOP,0
+1:
+    # AB = B_i*A + AB
+    # !!!!!! important: lw here assumes SEW = 32
+    # T0 is used in vmacc, do not use for temp now!
+    lw  $T0, 0($B)
+    addi $B, $B, 4 # advance B by a SEW
+
+    # carry for ABV_0
+    vmv.v.i $TV,0 
+    # loop variable
+    li  $LOOP2,0
+___
+# start loop of ngroup - 1 times
+if ($ngroup != 1) {
+    $code .= <<___;
+2:
+___
+    macc($A, $AV, $AVN, $nreg);
+
+    $code .= <<___;
+    addi $LOOP2,$LOOP2,1
+    # reuse T0 for special treatment
+    li  $T2,@{[$ngroup - 1]}
+    bne $LOOP2,$T2,2b
+___
+}
+# special treatment on last group
+macc($A, $AV, $AVN, $lastgroup);
+
+## NOT TRUE: propagate carry for nreg round
+# fully propagte
+propagate_niter();
+
+# AB = q*P + AB
+$code .= <<___;
+    # !!!!!! important: lw here assumes SEW = 32
+    # T0 is used in vmacc, do not use for temp now!
+    lw      $T0, 0($AB)
+    mul     $T0, $T0, $MU
+    # mod 2 ** $word
+    # !!!! important: here we assume SEW = 32 and XLEN = 64
+    sllw    $T0, $T0, $word
+    srlw    $T0, $T0, $word
+
+    # loop variable
+    li  $LOOP2,0
+___
+
+# start loop of ngroup - 1 times
+if ($ngroup != 1) {
+    $code .= <<___;
+2:
+___
+    macc($P, $PV, $PVN, $nreg);
+
+$code .= <<___;
+    addi $LOOP2,$LOOP2,1
+    # reuse T0 for special treatment
+    li  $T2,@{[$ngroup - 1]}
+    bne $LOOP2,$T2,2b
+___
+}
+# special treatment on last group
+macc($P, $PV, $PVN, $lastgroup);
+
+## NOT TRUE: propagate carry for nreg round
+# fully propagte
+propagate_niter();
+
+$code .= <<___;
+    # update carry of AB_{ntotalreg - 1} to AB_0
+    # since we need to substract AB_0
+    vlsseg1e$sew.v $ABV, ($AB), $STRIDE
+    # AB / word
+    vslide1down.vx $TV, $ABV, zero
+    # do not need vssseg1e now
+    # just store it in TV for move
+___
+
+move();
+
+# outer loop
+$code .= <<___;
+    addi  $LOOP,$LOOP,1
+    li    $T0,@{[$niter + 1]}
+    bne   $LOOP,$T0,1b
+
+    ret
+___
+
+# vlsseg1e32 is a pseudo-op of vlse32
+# vssseg1e32 is a pseudo-op of vsse32
+$code =~ s/seg1//g;
+
+print $code;
+close STDOUT or die "error closing STDOUT: $!";

--- a/crypto/bn/bn_mont.c
+++ b/crypto/bn/bn_mont.c
@@ -42,7 +42,15 @@ int bn_mul_mont_fixed_top(BIGNUM *r, const BIGNUM *a, const BIGNUM *b,
     int num = mont->N.top;
 
 #if defined(OPENSSL_BN_ASM_MONT) && defined(MONT_WORD)
+# if defined(__riscv) && __riscv_xlen == 64 && defined(__riscv_v)
+    // We force all mul_mont into bn_mul_mont
+    // this heavily relies on the fact that
+    // even after shrink a->top, a->d[top] is still accessible
+    // To achieve so we avoided BN_value_one() in mod_exp
+    if (1) {
+# else
     if (num > 1 && a->top == num && b->top == num) {
+# endif
         if (bn_wexpand(r, num) == NULL)
             return 0;
         if (bn_mul_mont(r->d, a->d, b->d, mont->N.d, mont->n0, num)) {
@@ -163,11 +171,24 @@ int BN_from_montgomery(BIGNUM *ret, const BIGNUM *a, BN_MONT_CTX *mont,
                        BN_CTX *ctx)
 {
     int retn;
+# if defined(__riscv) && __riscv_xlen == 64 && defined(__riscv_v)
+    BIGNUM *T = BN_new();
+    // T = 1 (not in minimal representation)
+    BN_copy(T, a);
+    for(int i = 0; i != T->top; ++i) {
+        T->d[i] = 0;
+    }
+    T->d[0] = 1;
 
+    retn = bn_mul_mont_fixed_top(ret, a, T, mont, ctx);
+
+    BN_free(T);
+#else
     retn = bn_from_mont_fixed_top(ret, a, mont, ctx);
     bn_correct_top(ret);
     bn_check_top(ret);
 
+#endif
     return retn;
 }
 
@@ -291,7 +312,14 @@ int BN_MONT_CTX_set(BN_MONT_CTX *mont, const BIGNUM *mod, BN_CTX *ctx)
         if (BN_get_flags(mod, BN_FLG_CONSTTIME) != 0)
             BN_set_flags(&tmod, BN_FLG_CONSTTIME);
 
+# if defined(__riscv) && __riscv_xlen == 64 && defined(__riscv_v)
+        if (BN_num_bits(mod) <= 256)
+            mont->ri = 272; // 256 + 16
+        else
+            mont->ri = 4112; // 4096 + 16
+# else
         mont->ri = (BN_num_bits(mod) + (BN_BITS2 - 1)) / BN_BITS2 * BN_BITS2;
+# endif
 
 # if defined(OPENSSL_BN_ASM_MONT) && (BN_BITS2<=32)
         /*

--- a/crypto/bn/bn_riscv64_vector.c
+++ b/crypto/bn/bn_riscv64_vector.c
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2022 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <stdint.h>
+#include <openssl/crypto.h>
+#include <openssl/bn.h>
+#include "bn_local.h"
+
+void bn_mul_mont_rv64imv_zvl128b_sew32_bn256_nelement20(
+        uint32_t* r, const uint32_t* a, const uint32_t* b, const uint32_t* p, const uint32_t mu);
+
+void bn_mul_mont_rv64imv_zvl128b_sew32_bn4096_nelement260(
+        uint32_t* r, const uint32_t* a, const uint32_t* b, const uint32_t* p, const uint32_t mu);
+
+int bn_mul_mont(BN_ULONG *rp, const BN_ULONG *ap, const BN_ULONG *bp,
+                const BN_ULONG *np, const BN_ULONG *n0, int num)
+{
+    //printf("!: ");
+    //for(int i = 0 ; i != num; i ++)
+    //    printf("%lx ", ap[i]);
+    //printf("\n");
+    //for(int i = 0 ; i != num; i ++)
+    //    printf("%lx ", bp[i]);
+    //printf("\n");
+    //for(int i = 0 ; i != num; i ++)
+    //    printf("%lx ", np[i]);
+    //printf("\n");
+
+    // prepare input for rvv
+    // 20 comes from 256/16 + 4, where 16 = sew (32) / 2, 4 = vlen(128) / sew(32)
+    // 260 comes from 4096/16 + 4
+    // NOT SECURE!!!! only for demo
+    uint32_t AB[260] = {0};
+    uint32_t A[260] = {0};
+    uint32_t B[260] = {0};
+    uint32_t N[260] = {0};
+
+    BN_ULONG ta, tb, tn;
+    for(int i = 0; i != num; ++i) {
+        ta = ap[i];
+        tb = bp[i];
+        tn = np[i];
+        // 64 bit (BN_ULONG) into 4 uint32_t
+        for(int j = 0; j != BN_BYTES/2; ++j) {
+            A[i* (BN_BYTES/2) + j] = ta & 0xffff;
+            B[i* (BN_BYTES/2) + j] = tb & 0xffff;
+            N[i* (BN_BYTES/2) + j] = tn & 0xffff;
+            ta >>= 16;
+            tb >>= 16;
+            tn >>= 16;
+        }
+    }
+    
+    // number of 16-bit words in A, B and N
+    if (num*(BN_BYTES/2) <= 16)
+        bn_mul_mont_rv64imv_zvl128b_sew32_bn256_nelement20(AB, A, B, N, n0[0] & 0xffff);
+    else
+        bn_mul_mont_rv64imv_zvl128b_sew32_bn4096_nelement260(AB, A, B, N, n0[0] & 0xffff);
+    // 256 and 4096 are just two demo here
+    // we can generate any bn{x} in mmm_mem.pl
+
+    // convert rvv output to BN format
+    for(int i = 0; i != num; ++i) {
+        tn = 0;
+        for(int j = 0; j != BN_BYTES/2; ++j) {
+            tn <<= 16;
+            tn |= AB[i* (BN_BYTES/2) + BN_BYTES/2 - 1 - j];
+        }
+        rp[i] = tn;
+    }
+
+    // conditional subtraction as rp is now in Z/2NZ
+    // NOTE: this is not constant time!
+    int bigger = 0;
+    for(int i = num - 1; i >= 0; --i) {
+        if (rp[i] > np[i]) {
+            bigger = 1;
+            break;
+        } else if (rp[i] < np[i])
+            break;
+        // equal then next iteration
+    }
+    // carry that should be in rp[num] (out of bound, of course)
+    if (AB[num * (BN_BYTES/2)] != 0 || bigger) {
+        bn_sub_words(rp, rp, np, num);
+    }
+
+    //for(int i = 0 ; i != num; i ++)
+    //    printf("%lx ", rp[i]);
+    //printf("\n\n");
+
+    // need to memzero A, B, AB and N!
+    return 1;
+}

--- a/crypto/bn/build.info
+++ b/crypto/bn/build.info
@@ -86,6 +86,9 @@ IF[{- !$disabled{asm} -}]
   $BNASM_c64xplus_ec2m=c64xplus-gf2m.s
   $BNDEF_c64xplus_ec2m=OPENSSL_BN_ASM_GF2m
 
+  $BNASM_riscv64=bn_asm.c bn_riscv64_vector.c riscv64-vector-mont-256.S riscv64-vector-mont-4096.S
+  $BNDEF_riscv64=OPENSSL_BN_ASM_MONT
+
   # Now that we have defined all the arch specific variables, use the
   # appropriate ones, and define the appropriate macros
   IF[$BNASM_{- $target{asm_arch} -}]
@@ -183,3 +186,6 @@ GENERATE[armv4-gf2m.S]=asm/armv4-gf2m.pl
 INCLUDE[armv4-gf2m.o]=..
 GENERATE[armv8-mont.S]=asm/armv8-mont.pl
 INCLUDE[armv8-mont.o]=..
+
+GENERATE[riscv64-vector-mont-256.S]=asm/riscv64-vector-mont-256.pl
+GENERATE[riscv64-vector-mont-4096.S]=asm/riscv64-vector-mont-4096.pl


### PR DESCRIPTION
This PR tries to demo that OpenSSL could use RISC-V Vector Extension to do modular multiplication, potentially accelerating (most notably) RSA4096 and other crypto operations. The author expect that with higher VLEN (e.g. 2048) the speedup would be more significant.

This is a draft and a baseline, and the author hereby request for comments on this implementation to seek for an eventually SOTA implementation.

More info on this implementation could be found at <https://github.com/ZenithalHourlyRate/rvv-mmm>

## Technical details

This is a modified version of [Montgomery Multiplication on the Cell](https://link.springer.com/chapter/10.1007/978-3-642-14390-8_50). Most notably, instead of representing one big number (BN) consecutively in one reg, this paper uses a column representation. This reduces the cost of carry propagation and division in each round.

However, by using this representation, this algorithm needs to use a different montgomery radix `R` than the `R` OpenSSL used. For example, when `M = 2 ** 255 - 19`, the `R` for OpenSSL would be 256, but the `R` for this algorithm would be 272.

Since the algorithm uses a different `R`, all computation should then be carried out by `bn_mont_mul` and we should avoid `word` variant like `bn_from_montgomery_word`. By forcing all computation being carried out by `bn_mont_mul`, we need to break an invariant called minimal representation (details at <https://github.com/openssl/openssl/issues/6640>), thus we can not use `BN_value_one` as we need to expand the width. This also leads to some quirks on some lib functions, like `BN_MONT_CTX_set` and `BN_mod_exp_mont`.

Also, the algorithm needs to allocate space as it uses redundent representation and we need to convert BN to/from it; in the meantime the `uint32_t AB[260] = {0};` allows `vlsseg8`.

For demostration purpose, there are only two implementations generated (256 bits and 4096 bits mmm), and the `R` for them are constants. You can alter `vl`/`bn` in these two perlasm (corresponding to `mmm_loop.pl` and `mmm_mem.pl` in my repo) for different `BN` with different minimum `VLEN`

## Compilation

You need to enable `v` extention when compiling, I used the lastest toolchain from [riscv-collab](https://github.com/riscv-collab/riscv-gnu-toolchain)

```
CC="riscv64-unknown-linux-gnu-gcc -march=rv64gcv" ./config linux64-riscv64
make -j`nproc`
make DESTDIR=/path/to/sysroot install
```

## Correctness

You can try the following commands between your native openssl and the RVV-backed openssl

```
# regular openssl
openssl genrsa -out private.pem 4096
# RVV-backed openssl
# may take a long time
export LD_LIBRARY_PATH=/path/to/sysroot/usr/local/lib
qemu-riscv64 -cpu rv64,v=on -L /path/to/sysroot apps/openssl pkeyutl -sign -in in.txt -inkey private.pem -out in.txt.rsa
# verify by regular openssl
openssl pkeyutl -verify -in in.txt -sigfile in.txt.rsa -inkey private.pem
```

Note that thanks to the feature of MMM, you can use RSA2048 even with 4096bit MMM.

## Benchmark

AFAIK, there is no existing Vector 1.0 real machine available generally, let me know if there is one that I can play with.

## Discussion

### R choice

Currently all `bn_mul_mont` asm use the `R` provided by OpenSSL. But this algorithm uses a different `R`. Also, there is some hard-encoded behavior that relies on the choice of `R`, e.g. Shay Gueron's suggestion in `bn_exp.c`

Should we support different `R`, or just implement RVV MMM just like RSAZ and stick to the OpenSSL `R`.

### subtraction less

From the paper above we know that for subtraction-less MMM we can represent the number in `Z/2MZ` instead of `Z/MZ`. This is especially beneficial for modular exponentiation. However, some comments showed that in some asm implementation it is assumed the input is less than `M`.

### VLEN

As the function name `bn_mul_mont_rv64imv_zvl128b_sew32_bn4096_nelement260` suggests, we would have a Cartesian product of all possible configurations when compiling. This increases the code size if we generate all of them, but if only some of them are provided, the speedup is a concern.

I know this is the packed SIMD way, but it seems not easy to implement in the vector way. Namely register assignment should be determined at codegen (by perlasm) time instead of runtime. I'll try to explore the vector way.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->