### PR TITLE
Use as small dh key size as possible to support the security

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -139,6 +139,13 @@ breaking changes, and mappings for the large list of deprecated functions.
 
 [Migration guide]: https://github.com/openssl/openssl/tree/master/doc/man7/migration_guide.pod
 
+### Changes between 3.0.4 and 3.0.5
+
+ * When generating safe-prime DH parameters set the recommended private key
+   length equivalent to minimum key lengths as in RFC 7919.
+
+   *Tomáš Mráz*
+
 ### Changes between 3.0.3 and 3.0.4 [21 June 2022]
 
  * In addition to the c_rehash shell command injection identified in

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -129,6 +129,11 @@ OpenSSL 3.1
 
    *Hugo Landau*
 
+ * When generating safe-prime DH parameters set the recommended private key
+   length equivalent to minimum key lengths as in RFC 7919.
+
+   *Tomáš Mráz*
+
 OpenSSL 3.0
 -----------
 
@@ -138,13 +143,6 @@ The migration guide contains more detailed information related to new features,
 breaking changes, and mappings for the large list of deprecated functions.
 
 [Migration guide]: https://github.com/openssl/openssl/tree/master/doc/man7/migration_guide.pod
-
-### Changes between 3.0.4 and 3.0.5
-
- * When generating safe-prime DH parameters set the recommended private key
-   length equivalent to minimum key lengths as in RFC 7919.
-
-   *Tomáš Mráz*
 
 ### Changes between 3.0.3 and 3.0.4 [21 June 2022]
 

--- a/crypto/dh/dh_gen.c
+++ b/crypto/dh/dh_gen.c
@@ -28,6 +28,7 @@
 #include <openssl/bn.h>
 #include <openssl/sha.h>
 #include "crypto/dh.h"
+#include "crypto/security_bits.h"
 #include "dh_local.h"
 
 #ifndef FIPS_MODULE
@@ -219,6 +220,9 @@ static int dh_builtin_genparams(DH *ret, int prime_len, int generator,
         goto err;
     if (!BN_set_word(ret->params.g, g))
         goto err;
+    /* We are using safe prime p, set key length equivalent to RFC 7919 */
+    ret->length = (2 * ossl_ifc_ffc_compute_security_bits(prime_len)
+                   + 24) / 25 * 25;
     ret->dirty_cnt++;
     ok = 1;
  err:

--- a/crypto/dh/dh_group_params.c
+++ b/crypto/dh/dh_group_params.c
@@ -31,7 +31,7 @@ static DH *dh_param_init(OSSL_LIB_CTX *libctx, const DH_NAMED_GROUP *group)
     if (dh == NULL)
         return NULL;
 
-    ossl_ffc_named_group_set_pqg(&dh->params, group);
+    ossl_ffc_named_group_set(&dh->params, group);
     dh->params.nid = ossl_ffc_named_group_get_uid(group);
     dh->dirty_cnt++;
     return dh;
@@ -72,8 +72,9 @@ void ossl_dh_cache_named_group(DH *dh)
                                                     dh->params.g)) != NULL) {
         if (dh->params.q == NULL)
             dh->params.q = (BIGNUM *)ossl_ffc_named_group_get_q(group);
-        /* cache the nid */
+        /* cache the nid and default key length */
         dh->params.nid = ossl_ffc_named_group_get_uid(group);
+        dh->params.keylength = group->keylength;
         dh->dirty_cnt++;
     }
 }

--- a/crypto/dh/dh_group_params.c
+++ b/crypto/dh/dh_group_params.c
@@ -74,7 +74,7 @@ void ossl_dh_cache_named_group(DH *dh)
             dh->params.q = (BIGNUM *)ossl_ffc_named_group_get_q(group);
         /* cache the nid and default key length */
         dh->params.nid = ossl_ffc_named_group_get_uid(group);
-        dh->params.keylength = group->keylength;
+        dh->params.keylength = ossl_ffc_named_group_get_keylength(group);
         dh->dirty_cnt++;
     }
 }

--- a/crypto/ffc/ffc_backend.c
+++ b/crypto/ffc/ffc_backend.c
@@ -39,7 +39,7 @@ int ossl_ffc_params_fromdata(FFC_PARAMS *ffc, const OSSL_PARAM params[])
         if (prm->data_type != OSSL_PARAM_UTF8_STRING
             || prm->data == NULL
             || (group = ossl_ffc_name_to_dh_named_group(prm->data)) == NULL
-            || !ossl_ffc_named_group_set_pqg(ffc, group))
+            || !ossl_ffc_named_group_set(ffc, group))
 #endif
             goto err;
     }

--- a/crypto/ffc/ffc_dh.c
+++ b/crypto/ffc/ffc_dh.c
@@ -150,7 +150,7 @@ const BIGNUM *ossl_ffc_named_group_get_q(const DH_NAMED_GROUP *group)
     return group->q;
 }
 
-int ossl_ffc_named_group_set_pqg(FFC_PARAMS *ffc, const DH_NAMED_GROUP *group)
+int ossl_ffc_named_group_set(FFC_PARAMS *ffc, const DH_NAMED_GROUP *group)
 {
     if (ffc == NULL || group == NULL)
         return 0;

--- a/crypto/ffc/ffc_dh.c
+++ b/crypto/ffc/ffc_dh.c
@@ -142,6 +142,13 @@ const char *ossl_ffc_named_group_get_name(const DH_NAMED_GROUP *group)
     return group->name;
 }
 
+int ossl_ffc_named_group_get_keylength(const DH_NAMED_GROUP *group)
+{
+    if (group == NULL)
+        return 0;
+    return group->keylength;
+}
+
 #ifndef OPENSSL_NO_DH
 const BIGNUM *ossl_ffc_named_group_get_q(const DH_NAMED_GROUP *group)
 {

--- a/crypto/ffc/ffc_dh.c
+++ b/crypto/ffc/ffc_dh.c
@@ -142,6 +142,7 @@ const char *ossl_ffc_named_group_get_name(const DH_NAMED_GROUP *group)
     return group->name;
 }
 
+#ifndef OPENSSL_NO_DH
 int ossl_ffc_named_group_get_keylength(const DH_NAMED_GROUP *group)
 {
     if (group == NULL)
@@ -149,7 +150,6 @@ int ossl_ffc_named_group_get_keylength(const DH_NAMED_GROUP *group)
     return group->keylength;
 }
 
-#ifndef OPENSSL_NO_DH
 const BIGNUM *ossl_ffc_named_group_get_q(const DH_NAMED_GROUP *group)
 {
     if (group == NULL)

--- a/crypto/ffc/ffc_dh.c
+++ b/crypto/ffc/ffc_dh.c
@@ -13,16 +13,18 @@
 
 #ifndef OPENSSL_NO_DH
 
-# define FFDHE(sz) {                                                        \
+# define FFDHE(sz, keylength) {                                             \
         SN_ffdhe##sz, NID_ffdhe##sz,                                        \
         sz,                                                                 \
+        keylength,                                                          \
         &ossl_bignum_ffdhe##sz##_p, &ossl_bignum_ffdhe##sz##_q,             \
         &ossl_bignum_const_2,                                               \
     }
 
-# define MODP(sz)  {                                                        \
+# define MODP(sz, keylength)  {                                             \
         SN_modp_##sz, NID_modp_##sz,                                        \
         sz,                                                                 \
+        keylength,                                                          \
         &ossl_bignum_modp_##sz##_p, &ossl_bignum_modp_##sz##_q,             \
         &ossl_bignum_const_2                                                \
     }
@@ -30,14 +32,15 @@
 # define RFC5114(name, uid, sz, tag) {                                      \
         name, uid,                                                          \
         sz,                                                                 \
+        0,                                                                  \
         &ossl_bignum_dh##tag##_p, &ossl_bignum_dh##tag##_q,                 \
         &ossl_bignum_dh##tag##_g                                            \
     }
 
 #else
 
-# define FFDHE(sz)                      { SN_ffdhe##sz, NID_ffdhe##sz }
-# define MODP(sz)                       { SN_modp_##sz, NID_modp_##sz }
+# define FFDHE(sz, keylength)           { SN_ffdhe##sz, NID_ffdhe##sz }
+# define MODP(sz, keylength)            { SN_modp_##sz, NID_modp_##sz }
 # define RFC5114(name, uid, sz, tag)    { name, uid }
 
 #endif
@@ -47,26 +50,32 @@ struct dh_named_group_st {
     int uid;
 #ifndef OPENSSL_NO_DH
     int32_t nbits;
+    int keylength;
     const BIGNUM *p;
     const BIGNUM *q;
     const BIGNUM *g;
 #endif
 };
 
+/*
+ * The private key length values are taken from RFC7919 with the values for
+ * MODP primes given the same lengths as the equivalent FFDHE.
+ * The MODP 1536 value is approximated.
+ */
 static const DH_NAMED_GROUP dh_named_groups[] = {
-    FFDHE(2048),
-    FFDHE(3072),
-    FFDHE(4096),
-    FFDHE(6144),
-    FFDHE(8192),
+    FFDHE(2048, 225),
+    FFDHE(3072, 275),
+    FFDHE(4096, 325),
+    FFDHE(6144, 375),
+    FFDHE(8192, 400),
 #ifndef FIPS_MODULE
-    MODP(1536),
+    MODP(1536, 200),
 #endif
-    MODP(2048),
-    MODP(3072),
-    MODP(4096),
-    MODP(6144),
-    MODP(8192),
+    MODP(2048, 225),
+    MODP(3072, 275),
+    MODP(4096, 325),
+    MODP(6144, 375),
+    MODP(8192, 400),
     /*
      * Additional dh named groups from RFC 5114 that have a different g.
      * The uid can be any unique identifier.
@@ -148,6 +157,7 @@ int ossl_ffc_named_group_set_pqg(FFC_PARAMS *ffc, const DH_NAMED_GROUP *group)
 
     ossl_ffc_params_set0_pqg(ffc, (BIGNUM *)group->p, (BIGNUM *)group->q,
                              (BIGNUM *)group->g);
+    ffc->keylength = group->keylength;
 
     /* flush the cached nid, The DH layer is responsible for caching */
     ffc->nid = NID_undef;

--- a/crypto/ffc/ffc_key_generate.c
+++ b/crypto/ffc/ffc_key_generate.c
@@ -25,11 +25,11 @@ int ossl_ffc_generate_private_key(BN_CTX *ctx, const FFC_PARAMS *params,
     int ret = 0, qbits = BN_num_bits(params->q);
     BIGNUM *m, *two_powN = NULL;
 
-    /* Deal with the edge case where the value of N is not set */
-    if (N == 0)
-        N = qbits;
+    /* Deal with the edge cases where the value of N and/or s is not set */
     if (s == 0)
-        s = N / 2;
+        goto err;
+    if (N == 0)
+        N = params->keylength ? params->keylength : 2 * s;
 
     /* Step (2) : check range of N */
     if (N < 2 * s || N > qbits)

--- a/crypto/ffc/ffc_params.c
+++ b/crypto/ffc/ffc_params.c
@@ -196,6 +196,7 @@ int ossl_ffc_params_copy(FFC_PARAMS *dst, const FFC_PARAMS *src)
     dst->h = src->h;
     dst->gindex = src->gindex;
     dst->flags = src->flags;
+    dst->keylength = src->keylength;
     return 1;
 }
 

--- a/doc/man1/openssl-dhparam.pod.in
+++ b/doc/man1/openssl-dhparam.pod.in
@@ -62,14 +62,13 @@ as the input filename.
 =item B<-dsaparam>
 
 If this option is used, DSA rather than DH parameters are read or created;
-they are converted to DH format.  Otherwise, "strong" primes (such
+they are converted to DH format.  Otherwise, safe primes (such
 that (p-1)/2 is also prime) will be used for DH parameter generation.
 
-DH parameter generation with the B<-dsaparam> option is much faster,
-and the recommended exponent length is shorter, which makes DH key
-exchange more efficient.  Beware that with such DSA-style DH
-parameters, a fresh DH key should be created for each use to
-avoid small-subgroup attacks that may be possible otherwise.
+DH parameter generation with the B<-dsaparam> option is much faster.
+Beware that with such DSA-style DH parameters, a fresh DH key should be
+created for each use to avoid small-subgroup attacks that may be possible
+otherwise.
 
 =item B<-check>
 

--- a/include/internal/ffc.h
+++ b/include/internal/ffc.h
@@ -112,6 +112,8 @@ typedef struct ffc_params_st {
      */
     const char *mdname;
     const char *mdprops;
+    /* Default key length for known named groups according to RFC7919 */
+    int keylength;
 } FFC_PARAMS;
 
 void ossl_ffc_params_init(FFC_PARAMS *params);

--- a/include/internal/ffc.h
+++ b/include/internal/ffc.h
@@ -206,8 +206,8 @@ const DH_NAMED_GROUP *ossl_ffc_numbers_to_dh_named_group(const BIGNUM *p,
 #endif
 int ossl_ffc_named_group_get_uid(const DH_NAMED_GROUP *group);
 const char *ossl_ffc_named_group_get_name(const DH_NAMED_GROUP *);
-int ossl_ffc_named_group_get_keylength(const DH_NAMED_GROUP *group);
 #ifndef OPENSSL_NO_DH
+int ossl_ffc_named_group_get_keylength(const DH_NAMED_GROUP *group);
 const BIGNUM *ossl_ffc_named_group_get_q(const DH_NAMED_GROUP *group);
 int ossl_ffc_named_group_set(FFC_PARAMS *ffc, const DH_NAMED_GROUP *group);
 #endif

--- a/include/internal/ffc.h
+++ b/include/internal/ffc.h
@@ -206,6 +206,7 @@ const DH_NAMED_GROUP *ossl_ffc_numbers_to_dh_named_group(const BIGNUM *p,
 #endif
 int ossl_ffc_named_group_get_uid(const DH_NAMED_GROUP *group);
 const char *ossl_ffc_named_group_get_name(const DH_NAMED_GROUP *);
+int ossl_ffc_named_group_get_keylength(const DH_NAMED_GROUP *group);
 #ifndef OPENSSL_NO_DH
 const BIGNUM *ossl_ffc_named_group_get_q(const DH_NAMED_GROUP *group);
 int ossl_ffc_named_group_set(FFC_PARAMS *ffc, const DH_NAMED_GROUP *group);

--- a/include/internal/ffc.h
+++ b/include/internal/ffc.h
@@ -208,7 +208,7 @@ int ossl_ffc_named_group_get_uid(const DH_NAMED_GROUP *group);
 const char *ossl_ffc_named_group_get_name(const DH_NAMED_GROUP *);
 #ifndef OPENSSL_NO_DH
 const BIGNUM *ossl_ffc_named_group_get_q(const DH_NAMED_GROUP *group);
-int ossl_ffc_named_group_set_pqg(FFC_PARAMS *ffc, const DH_NAMED_GROUP *group);
+int ossl_ffc_named_group_set(FFC_PARAMS *ffc, const DH_NAMED_GROUP *group);
 #endif
 
 #endif /* OSSL_INTERNAL_FFC_H */

--- a/providers/implementations/encode_decode/encode_key2text.c
+++ b/providers/implementations/encode_decode/encode_key2text.c
@@ -220,6 +220,7 @@ static int dh_to_text(BIO *out, const void *key, int selection)
     const BIGNUM *priv_key = NULL, *pub_key = NULL;
     const FFC_PARAMS *params = NULL;
     const BIGNUM *p = NULL;
+    long length;
 
     if (out == NULL || dh == NULL) {
         ERR_raise(ERR_LIB_PROV, ERR_R_PASSED_NULL_PARAMETER);
@@ -271,6 +272,11 @@ static int dh_to_text(BIO *out, const void *key, int selection)
         return 0;
     if (params != NULL
         && !ffc_params_to_text(out, params))
+        return 0;
+    length = DH_get_length(dh);
+    if (length > 0
+        && BIO_printf(out, "recommended-private-length: %ld bits\n",
+                      length) <= 0)
         return 0;
 
     return 1;

--- a/test/evp_extra_test2.c
+++ b/test/evp_extra_test2.c
@@ -333,6 +333,10 @@ static int test_dh_tofrom_data_select(void)
     OSSL_PARAM params[2];
     EVP_PKEY *key = NULL;
     EVP_PKEY_CTX *gctx = NULL;
+# ifndef OPENSSL_NO_DEPRECATED_3_0
+    const DH *dhkey;
+    const BIGNUM *privkey;
+# endif
 
     params[0] = OSSL_PARAM_construct_utf8_string("group", "ffdhe2048", 0);
     params[1] = OSSL_PARAM_construct_end();
@@ -341,6 +345,12 @@ static int test_dh_tofrom_data_select(void)
           && TEST_true(EVP_PKEY_CTX_set_params(gctx, params))
           && TEST_int_gt(EVP_PKEY_generate(gctx, &key), 0)
           && TEST_true(do_pkey_tofrom_data_select(key, "DHX"));
+# ifndef OPENSSL_NO_DEPRECATED_3_0
+    dhkey = EVP_PKEY_get0_DH(key);
+    ret = ret && TEST_ptr(dhkey);
+    ret = ret && TEST_ptr(privkey = DH_get0_priv_key(dhkey))
+              && TEST_int_le(BN_num_bits(privkey), 225);
+# endif
     EVP_PKEY_free(key);
     EVP_PKEY_CTX_free(gctx);
     return ret;

--- a/test/ffc_internal_test.c
+++ b/test/ffc_internal_test.c
@@ -618,6 +618,8 @@ static int ffc_private_gen_test(int index)
                                                  ossl_ifc_ffc_compute_security_bits(BN_num_bits(params->p)),
                                                  priv)))
         goto err;
+    if (!TEST_int_le(BN_num_bits(priv), 225))
+        goto err;
     if (!TEST_true(ossl_ffc_validate_private_key(params->q, priv, &res)))
         goto err;
 
@@ -626,6 +628,37 @@ err:
     DH_free(dh);
     BN_free(priv);
     BN_CTX_free(ctx);
+    return ret;
+}
+
+static int ffc_params_copy_test(void)
+{
+    int ret = 0;
+    DH *dh = NULL;
+    FFC_PARAMS *params, copy;
+
+    ossl_ffc_params_init(&copy);
+
+    if (!TEST_ptr(dh = DH_new_by_nid(NID_ffdhe3072)))
+        goto err;
+    params = ossl_dh_get0_params(dh);
+
+    if (!TEST_int_eq(params->keylength, 275))
+        goto err;
+
+    if (!TEST_true(ossl_ffc_params_copy(&copy, params)))
+        goto err;
+
+    if (!TEST_int_eq(copy.keylength, 275))
+        goto err;
+
+    if (!TEST_true(ossl_ffc_params_cmp(&copy, params, 0)))
+        goto err;
+
+    ret = 1;
+err:
+    ossl_ffc_params_cleanup(&copy);
+    DH_free(dh);
     return ret;
 }
 #endif /* OPENSSL_NO_DH */
@@ -643,6 +676,7 @@ int setup_tests(void)
     ADD_TEST(ffc_public_validate_test);
     ADD_TEST(ffc_private_validate_test);
     ADD_ALL_TESTS(ffc_private_gen_test, 10);
+    ADD_TEST(ffc_params_copy_test);
 #endif /* OPENSSL_NO_DH */
     return 1;
 }

--- a/test/recipes/20-test_dhparam.t
+++ b/test/recipes/20-test_dhparam.t
@@ -27,6 +27,7 @@ sub checkdhparams {
     my $gen = shift; #2, 5 or something else (0 is "something else")?
     my $format = shift; #DER or PEM?
     my $bits = shift; #Number of bits in p
+    my $keybits = shift; #Recommended private key bits
     my $pemtype;
     my $readtype;
     my $readbits = 0;
@@ -82,6 +83,13 @@ sub checkdhparams {
 
     ok((grep { (index($_, $genline) + length ($genline)) == length ($_)} @textdata),
        "Checking generator is correct");
+
+    if ($keybits) {
+        my $keybits_line = "recommended-private-length: $keybits bits";
+        ok((grep { (index($_, $keybits_line) + length($keybits_line))
+                   == length($_) } @textdata),
+           "Checking recommended private key bits is correct");
+    }
 }
 
 #Test some "known good" parameter files to check that we can read them
@@ -120,28 +128,28 @@ subtest "Read: 1024 bit X9.42 params, DER file" => sub {
 #Test that generating parameters of different types creates what we expect. We
 #use 512 for the size for speed reasons. Don't use this in real applications!
 subtest "Generate: 512 bit PKCS3 params, generator 2, PEM file" => sub {
-    plan tests => 5;
+    plan tests => 6;
     ok(run(app([ 'openssl', 'dhparam', '-out', 'gen-pkcs3-2-512.pem',
                  '512' ])));
-    checkdhparams("gen-pkcs3-2-512.pem", "PKCS3", 2, "PEM", 512);
+    checkdhparams("gen-pkcs3-2-512.pem", "PKCS3", 2, "PEM", 512, 125);
 };
 subtest "Generate: 512 bit PKCS3 params, explicit generator 2, PEM file" => sub {
-    plan tests => 5;
+    plan tests => 6;
     ok(run(app([ 'openssl', 'dhparam', '-out', 'gen-pkcs3-exp2-512.pem', '-2',
                  '512' ])));
-    checkdhparams("gen-pkcs3-exp2-512.pem", "PKCS3", 2, "PEM", 512);
+    checkdhparams("gen-pkcs3-exp2-512.pem", "PKCS3", 2, "PEM", 512, 125);
 };
 subtest "Generate: 512 bit PKCS3 params, generator 5, PEM file" => sub {
-    plan tests => 5;
+    plan tests => 6;
     ok(run(app([ 'openssl', 'dhparam', '-out', 'gen-pkcs3-5-512.pem', '-5',
                  '512' ])));
-    checkdhparams("gen-pkcs3-5-512.pem", "PKCS3", 5, "PEM", 512);
+    checkdhparams("gen-pkcs3-5-512.pem", "PKCS3", 5, "PEM", 512, 125);
 };
 subtest "Generate: 512 bit PKCS3 params, generator 2, explicit PEM file" => sub {
-    plan tests => 5;
+    plan tests => 6;
     ok(run(app([ 'openssl', 'dhparam', '-out', 'gen-pkcs3-2-512.exp.pem',
                  '-outform', 'PEM', '512' ])));
-    checkdhparams("gen-pkcs3-2-512.exp.pem", "PKCS3", 2, "PEM", 512);
+    checkdhparams("gen-pkcs3-2-512.exp.pem", "PKCS3", 2, "PEM", 512, 125);
 };
 SKIP: {
     skip "Skipping tests that require DSA", 4 if disabled("dsa");

--- a/test/recipes/30-test_evp_pkey_provided/DH.priv.txt
+++ b/test/recipes/30-test_evp_pkey_provided/DH.priv.txt
@@ -22,3 +22,4 @@ public-key:
     a8:ee:72:13:45:65:15:42:17:aa:d8:ab:cf:33:42:
     83:42
 GROUP: ffdhe2048
+recommended-private-length: 224 bits

--- a/test/recipes/30-test_evp_pkey_provided/DH.pub.txt
+++ b/test/recipes/30-test_evp_pkey_provided/DH.pub.txt
@@ -19,3 +19,4 @@ public-key:
     a8:ee:72:13:45:65:15:42:17:aa:d8:ab:cf:33:42:
     83:42
 GROUP: ffdhe2048
+recommended-private-length: 224 bits


### PR DESCRIPTION
Longer private key sizes unnecessarily raise the cycles needed to
compute the shared secret without any increase of the real security.

This also fixes a regression where we weren't printing the recommended-private-length
in the DH parameters/key text output.