### PR TITLE
Dont' report success from ec_export if OSSL_PARAM_BLD_to_param failed

### DIFF
--- a/providers/implementations/keymgmt/ec_kmgmt.c
+++ b/providers/implementations/keymgmt/ec_kmgmt.c
@@ -498,6 +498,8 @@ int ec_export(void *keydata, int selection, OSSL_CALLBACK *param_cb,
 
     if (ok && (params = OSSL_PARAM_BLD_to_param(tmpl)) != NULL)
         ok = param_cb(params, cbarg);
+    else
+        ok = 0;
 end:
     OSSL_PARAM_free(params);
     OSSL_PARAM_BLD_free(tmpl);


### PR DESCRIPTION
If the call to OSSL_PARAM_BLD_to_param() failed then ec_export was
reporting success, even though it has never called the param_cb.

Found due to:
https://github.com/openssl/openssl/pull/18355#issuecomment-1145993650
