### PR TITLE
Fix opt_cipher_silent and opt_cipher_silent not clear errors

### DIFF
--- a/apps/lib/opt.c
+++ b/apps/lib/opt.c
@@ -397,7 +397,7 @@ int opt_cipher_silent(const char *name, EVP_CIPHER **cipherp)
         }
         return 1;
     }
-    ERR_clear_last_mark();
+    ERR_pop_to_mark();
     return 0;
 }
 
@@ -456,7 +456,7 @@ int opt_md_silent(const char *name, EVP_MD **mdp)
         }
         return 1;
     }
-    ERR_clear_last_mark();
+    ERR_pop_to_mark();
     return 0;
 }
 


### PR DESCRIPTION
EVP_CIPHER_fetch() and EVP_MD_fetch() may push errors to error stack, use
ERR_pop_to_mark to clear errors instead of ERR_clear_last_mark.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
