### PR TITLE
Doc: NASM is optional and required only for x86 platforms

### DIFF
--- a/NOTES-WINDOWS.md
+++ b/NOTES-WINDOWS.md
@@ -58,7 +58,7 @@ Quick start
 
  1. Install Perl
 
- 2. Install NASM
+ 2. Install NASM (optional - required for x86 based platforms)
 
  3. Make sure both Perl and NASM are on your %PATH%
 


### PR DESCRIPTION
A minor change to Windows notes to clarify that `NASM` is required only for x86-based platforms.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [X] documentation is added or updated