### PR TITLE
Fix a use after free in error handling of hmac_dup

### DIFF
--- a/providers/implementations/macs/hmac_prov.c
+++ b/providers/implementations/macs/hmac_prov.c
@@ -115,6 +115,7 @@ static void *hmac_dup(void *vsrc)
     *dst = *src;
     dst->ctx = ctx;
     dst->key = NULL;
+    memset(&dst->digest, 0, sizeof(dst->digest));
 
     if (!HMAC_CTX_copy(dst->ctx, src->ctx)
         || !ossl_prov_digest_copy(&dst->digest, &src->digest)) {


### PR DESCRIPTION
dst->digest needs to be zeroized in case HMAC_CTX_copy
or ossl_prov_digest_copy return failure.

Fixes #18493

