### PR TITLE
Fix the export routines to not return success if param alloc failed

### DIFF
--- a/providers/implementations/keymgmt/dh_kmgmt.c
+++ b/providers/implementations/keymgmt/dh_kmgmt.c
@@ -236,11 +236,11 @@ static int dh_export(void *keydata, int selection, OSSL_CALLBACK *param_cb,
         ok = ok && ossl_dh_key_todata(dh, tmpl, NULL, include_private);
     }
 
-    if (!ok
-        || (params = OSSL_PARAM_BLD_to_param(tmpl)) == NULL) {
+    if (!ok || (params = OSSL_PARAM_BLD_to_param(tmpl)) == NULL) {
         ok = 0;
         goto err;
     }
+
     ok = param_cb(params, cbarg);
     OSSL_PARAM_free(params);
 err:

--- a/providers/implementations/keymgmt/dsa_kmgmt.c
+++ b/providers/implementations/keymgmt/dsa_kmgmt.c
@@ -235,9 +235,10 @@ static int dsa_export(void *keydata, int selection, OSSL_CALLBACK *param_cb,
         ok = ok && dsa_key_todata(dsa, tmpl, NULL, include_private);
     }
 
-    if (!ok
-        || (params = OSSL_PARAM_BLD_to_param(tmpl)) == NULL)
+    if (!ok || (params = OSSL_PARAM_BLD_to_param(tmpl)) == NULL) {
+        ok = 0;
         goto err;
+    }
 
     ok = param_cb(params, cbarg);
     OSSL_PARAM_free(params);

--- a/providers/implementations/keymgmt/ec_kmgmt.c
+++ b/providers/implementations/keymgmt/ec_kmgmt.c
@@ -501,7 +501,7 @@ int ec_export(void *keydata, int selection, OSSL_CALLBACK *param_cb,
         goto end;
     }
 
-    param_cb(params, cbarg);
+    ok = param_cb(params, cbarg);
     OSSL_PARAM_free(params);
 end:
     OSSL_PARAM_BLD_free(tmpl);

--- a/providers/implementations/keymgmt/ec_kmgmt.c
+++ b/providers/implementations/keymgmt/ec_kmgmt.c
@@ -496,12 +496,14 @@ int ec_export(void *keydata, int selection, OSSL_CALLBACK *param_cb,
     if ((selection & OSSL_KEYMGMT_SELECT_OTHER_PARAMETERS) != 0)
         ok = ok && otherparams_to_params(ec, tmpl, NULL);
 
-    if (ok && (params = OSSL_PARAM_BLD_to_param(tmpl)) != NULL)
-        ok = param_cb(params, cbarg);
-    else
+    if (!ok || (params = OSSL_PARAM_BLD_to_param(tmpl)) == NULL) {
         ok = 0;
-end:
+        goto end;
+    }
+
+    param_cb(params, cbarg);
     OSSL_PARAM_free(params);
+end:
     OSSL_PARAM_BLD_free(tmpl);
     OPENSSL_free(pub_key);
     OPENSSL_free(genbuf);

--- a/providers/implementations/keymgmt/rsa_kmgmt.c
+++ b/providers/implementations/keymgmt/rsa_kmgmt.c
@@ -229,9 +229,10 @@ static int rsa_export(void *keydata, int selection,
         ok = ok && ossl_rsa_todata(rsa, tmpl, NULL, include_private);
     }
 
-    if (!ok
-        || (params = OSSL_PARAM_BLD_to_param(tmpl)) == NULL)
+    if (!ok || (params = OSSL_PARAM_BLD_to_param(tmpl)) == NULL) {
+        ok = 0;
         goto err;
+    }
 
     ok = param_callback(params, cbarg);
     OSSL_PARAM_free(params);


### PR DESCRIPTION
We fix the dsa, dh, ec and rsa export routines so that they are
consistent with each other and do not report success if the allocation
of parameters failed.

This is essentially the same fix as applied in #18483 but applied to all
relevant key types.
