### PR TITLE
[crypto/bn] BN_consttime_swap: remove superfluous early exit

### DIFF
--- a/crypto/bn/bn_lib.c
+++ b/crypto/bn/bn_lib.c
@@ -910,9 +910,6 @@ void BN_consttime_swap(BN_ULONG condition, BIGNUM *a, BIGNUM *b, int nwords)
     BN_ULONG t;
     int i;
 
-    if (a == b)
-        return;
-
     bn_wcheck_size(a, nwords);
     bn_wcheck_size(b, nwords);
 

--- a/test/bntest.c
+++ b/test/bntest.c
@@ -171,6 +171,11 @@ static int test_swap(void)
             || !equalBN("swap", b, c))
         goto err;
 
+    /* regular swap: same pointer */
+    BN_swap(a, a);
+    if (!equalBN("swap with same pointer", a, d))
+        goto err;
+
     /* conditional swap: true */
     cond = 1;
     BN_consttime_swap(cond, a, b, top);
@@ -178,11 +183,21 @@ static int test_swap(void)
             || !equalBN("cswap true", b, d))
         goto err;
 
+    /* conditional swap: true, same pointer */
+    BN_consttime_swap(cond, a, a, top);
+    if (!equalBN("cswap true", a, c))
+        goto err;
+
     /* conditional swap: false */
     cond = 0;
     BN_consttime_swap(cond, a, b, top);
     if (!equalBN("cswap false", a, c)
             || !equalBN("cswap false", b, d))
+        goto err;
+
+    /* conditional swap: false, same pointer */
+    BN_consttime_swap(cond, a, a, top);
+    if (!equalBN("cswap false", a, c))
         goto err;
 
     /* same tests but checking flag swap */


### PR DESCRIPTION
This code functions just fine when you pass two `BIGNUM` pointers that are equal.

I think this is just a relic from like 1.0.2 days or even earlier. This function has undergone many changes since then. Although not enough---the API is still terrible.

I didn't bother passing this to `openssl-security`. A colleague of mine emailed me some time ago about this early exit, we exchanged a few emails, and agreed `a == b` vs `a != b` is never a secret bc the former case never really happens. The point of this kind of swapping in crypto code is limited to precisely the latter case.

Nevertheless, I am still relevant and can submit PRs. Yay me.