### PR TITLE
Include the modules directory in openssl.pc [3.0]

### DIFF
--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -1400,6 +1400,7 @@ libcrypto.pc:
 	    fi; \
 	    echo 'includedir=$${prefix}/include'; \
 	    echo 'enginesdir=$${libdir}/engines-{- $sover_dirname -}'; \
+	    echo 'modulesdir=$${libdir}/ossl-modules'; \
 	    echo ''; \
 	    echo 'Name: OpenSSL-libcrypto'; \
 	    echo 'Description: OpenSSL cryptography library'; \


### PR DESCRIPTION
Affected file: Configurations/unix-Makefile.tmpl

Fixes #18516

-----

This is the same fix as #17605, which was made in master in response to
issue #17602.
