### PR TITLE
test/recipes/*.t: setup() doesn't play well with spaces in the argument

### DIFF
--- a/test/recipes/02-test_localetest.t
+++ b/test/recipes/02-test_localetest.t
@@ -10,7 +10,7 @@
 use OpenSSL::Test;
 use OpenSSL::Test::Utils;
 
-setup("locale tests");
+setup("test_locale");
 
 plan skip_all => "Locale tests not available on Windows or VMS"
     if $^O =~ /^(VMS|MSWin32)$/;


### PR DESCRIPTION
The argument translates into a directory name, and there are platforms
that don't allow spaces (at least not easily), which makes the test fail.
This modifies it to conform a bit better to the usual form for that arg.
