### PR TITLE
Allow application builds to be disabled during configuration

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,11 @@ OpenSSL 3.1
 
 ### Changes between 3.0 and 3.1 [xx XXX xxxx]
 
+ * Allow disabling OpenSSL application builds with no-apps at configuration
+   time.
+
+   *Derzsi Dániel*
+
  * Add more SRTP protection profiles from RFC8723 and RFC8269.
 
    *Kijin Kim*

--- a/Configure
+++ b/Configure
@@ -404,6 +404,7 @@ my @dtls = qw(dtls1 dtls1_2);
 my @disablables = (
     "acvp-tests",
     "afalgeng",
+    "apps",
     "aria",
     "asan",
     "asm",

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -526,6 +526,12 @@ access to algorithm internals that are not normally accessible.
 Additional information related to ACVP can be found at
 <https://github.com/usnistgov/ACVP>.
 
+### no-apps
+
+Do not build the OpenSSL application.
+
+This may be desirable when building with the [no-shared](#no-shared) option.
+
 ### no-asm
 
 Do not use assembler code.


### PR DESCRIPTION
Sometimes, the OpenSSL application does not need to be built. For example, when building with a "no-shared" configuration, a potential user might want to only link with the libraries, not use (or redistribute) the OpenSSL application.

This pull request adds the "apps" option to the list of disablable options, adding `no-apps` as a potential configuration-time option.

When building with `no-apps`, the `openssl.exe`/`openssl` binary will not be created.

CLA has been signed.

##### Checklist
- [x] documentation is added or updated
