### PR TITLE
Have set_dateopt() return 1 on success to make -dateopt work

### DIFF
--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -1186,7 +1186,9 @@ int set_dateopt(unsigned long *dateopt, const char *arg)
         *dateopt = ASN1_DTFLGS_RFC822;
     else if (OPENSSL_strcasecmp(arg, "iso_8601") == 0)
         *dateopt = ASN1_DTFLGS_ISO8601;
-    return 0;
+    else
+        return 0;
+    return 1;
 }
 
 int set_ext_copy(int *copy_type, const char *arg)

--- a/test/recipes/25-test_x509.t
+++ b/test/recipes/25-test_x509.t
@@ -16,7 +16,7 @@ use OpenSSL::Test qw/:DEFAULT srctop_file/;
 
 setup("test_x509");
 
-plan tests => 18;
+plan tests => 21;
 
 # Prevent MSys2 filename munging for arguments that look like file paths but
 # aren't
@@ -135,3 +135,14 @@ SKIP: {
     ok(test_errors("Unable to load Public Key", "sm2.pem", '-text'),
        "error loading unsupported sm2 cert");
 }
+
+# 3 tests for -dateopts formats
+ok(run(app(["openssl", "x509", "-noout", "-dates", "-dateopt", "rfc_822",
+	     "-in", srctop_file("test/certs", "ca-cert.pem")])),
+   "Run with rfc_8222 -dateopt format");
+ok(run(app(["openssl", "x509", "-noout", "-dates", "-dateopt", "iso_8601",
+	     "-in", srctop_file("test/certs", "ca-cert.pem")])),
+   "Run with iso_8601 -dateopt format");
+ok(!run(app(["openssl", "x509", "-noout", "-dates", "-dateopt", "invalid_format",
+	     "-in", srctop_file("test/certs", "ca-cert.pem")])),
+   "Run with invalid -dateopt format");


### PR DESCRIPTION
Fixes #18553

- [ ] documentation is added or updated
- [x] tests are added or updated
