### PR TITLE
test/ssl_old_test.c: Add check for OPENSSL_malloc

### DIFF
--- a/test/ssl_old_test.c
+++ b/test/ssl_old_test.c
@@ -311,6 +311,7 @@ static int cb_server_alpn(SSL *s, const unsigned char **out,
      */
     alpn_selected = OPENSSL_malloc(*outlen);
     if (alpn_selected == NULL) {
+        fprintf(stderr, "failed to allocate memory");
         OPENSSL_free(protos);
         abort();
     }

--- a/test/ssl_old_test.c
+++ b/test/ssl_old_test.c
@@ -311,7 +311,7 @@ static int cb_server_alpn(SSL *s, const unsigned char **out,
      */
     alpn_selected = OPENSSL_malloc(*outlen);
     if (alpn_selected == NULL) {
-        fprintf(stderr, "failed to allocate memory");
+        fprintf(stderr, "failed to allocate memory\n");
         OPENSSL_free(protos);
         abort();
     }

--- a/test/ssl_old_test.c
+++ b/test/ssl_old_test.c
@@ -310,6 +310,10 @@ static int cb_server_alpn(SSL *s, const unsigned char **out,
      * verify_alpn.
      */
     alpn_selected = OPENSSL_malloc(*outlen);
+    if (alpn_selected == NULL) {
+        OPENSSL_free(protos);
+        abort();
+    }
     memcpy(alpn_selected, *out, *outlen);
     *out = alpn_selected;
 


### PR DESCRIPTION
As the potential failure of the OPENSSL_malloc(),
it should be better to add the check and return
error if fails.

Signed-off-by: Jiasheng Jiang <jiasheng@iscas.ac.cn>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
