### PR TITLE
Fix documentation of BIO_FLAGS_BASE64_NO_NL

### DIFF
--- a/doc/man3/BIO_f_base64.pod
+++ b/doc/man3/BIO_f_base64.pod
@@ -38,9 +38,8 @@ to flush the final block through the BIO.
 The flag BIO_FLAGS_BASE64_NO_NL can be set with BIO_set_flags().
 For writing, it causes all data to be written on one line without
 newline at the end.
-For reading, it forces the decoder to process the data regardless
-of newlines. All newlines are ignored and the input does not need
-to contain any newline at all.
+For reading, it expects the data to be all on one line (with or
+without a trailing newline).
 
 =head1 NOTES
 


### PR DESCRIPTION
Commit 8bfb7506d210841f2ee4eda8afe96441a0e33fa5 updated
`BIO_f_base64(3)` to improve the documentation of the
`BIO_FLAGS_BASE64_NO_NL` flag.  In particular, the updated text
states that when this flag is used, all newlines in the input are
ignored.  This is incorrect, as the following program proves:

```c

unsigned char *in_buf =
    "IlRoZSBxdWljayBicm93biBmb3gganVt\ncHMgb3ZlciBhIGxhenkgZG9nLiI=\n";

int main(int argc, char **argv) {
    BIO *b64 = BIO_new(BIO_f_base64());
    if (b64 == NULL) return 1;
    BIO_set_flags(b64, BIO_get_flags(b64) | BIO_FLAGS_BASE64_NO_NL);
    int in_len = strlen(in_buf);
    BIO *in = BIO_new_mem_buf(in_buf, in_len);
    if (in == NULL) return 2;
    in = BIO_push(b64, in);
    unsigned char *out_buf = calloc(in_len, sizeof(unsigned char));
    if (out_buf == NULL) return 3;
    size_t out_len;
    int r = BIO_read_ex(in, out_buf, in_len, &out_len);
    printf("rv = %d\n", r);
    printf("decoded = %s\n", out_buf);
    return 0;
}
```

Update the text of `BIO_f_base64(3)` to clarify that when the flag
is set, the data must be all on one line (with or without a trailing
newline character).



<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated