### PR TITLE
test/v3nametest.c: Add check for OPENSSL_malloc

### DIFF
--- a/test/v3nametest.c
+++ b/test/v3nametest.c
@@ -288,9 +288,8 @@ static int run_cert(X509 *crt, const char *nameincert,
         char *name = OPENSSL_malloc(namelen + 1);
         int match, ret;
 
-        if (!TEST_ptr(name)) {
+        if (!TEST_ptr(name))
             return 0;
-        }
         memcpy(name, *pname, namelen + 1);
 
         match = -1;

--- a/test/v3nametest.c
+++ b/test/v3nametest.c
@@ -288,6 +288,9 @@ static int run_cert(X509 *crt, const char *nameincert,
         char *name = OPENSSL_malloc(namelen + 1);
         int match, ret;
 
+        if (name == NULL) {
+            return 1;
+        }
         memcpy(name, *pname, namelen + 1);
 
         match = -1;

--- a/test/v3nametest.c
+++ b/test/v3nametest.c
@@ -288,8 +288,8 @@ static int run_cert(X509 *crt, const char *nameincert,
         char *name = OPENSSL_malloc(namelen + 1);
         int match, ret;
 
-        if (name == NULL) {
-            return 1;
+        if (!TEST_ptr(name)) {
+            return 0;
         }
         memcpy(name, *pname, namelen + 1);
 


### PR DESCRIPTION
As the potential failure of the OPENSSL_malloc(),
it should be better to add the check and return
error if fails.

Signed-off-by: Jiasheng Jiang <jiasheng@iscas.ac.cn>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
