### PR TITLE
crypto/asn1/a_time.c: Add check for OPENSSL_malloc

### DIFF
--- a/crypto/asn1/a_time.c
+++ b/crypto/asn1/a_time.c
@@ -618,7 +618,10 @@ time_t asn1_string_to_time_t(const char *asn1_string)
     }
 
     timestamp_tm = OPENSSL_malloc(sizeof(*timestamp_tm));
-
+    if (timestamp_tm == NULL) {
+        ASN1_TIME_free(timestamp_asn1);
+        return -1;
+    }
     if (!(ASN1_TIME_to_tm(timestamp_asn1, timestamp_tm))) {
         OPENSSL_free(timestamp_tm);
         ASN1_TIME_free(timestamp_asn1);


### PR DESCRIPTION
As the potential failure of the OPENSSL_malloc(),
timestamp_tm could be NULL and be used in ASN1_TIME_to_tm()
without check.
Therefore, it should be better to check the return value of
OPENSSL_malloc() and return error if fails.

Signed-off-by: Jiasheng Jiang <jiasheng@iscas.ac.cn>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
