### PR TITLE
APPS: dsaparam, gendsa: Support setting properties

### DIFF
--- a/apps/dsaparam.c
+++ b/apps/dsaparam.c
@@ -148,7 +148,7 @@ int dsaparam_main(int argc, char **argv)
     if (out == NULL)
         goto end;
 
-    ctx = EVP_PKEY_CTX_new_from_name(NULL, "DSA", NULL);
+    ctx = EVP_PKEY_CTX_new_from_name(app_get0_libctx(), "DSA", app_get0_propq());
     if (ctx == NULL) {
         BIO_printf(bio_err,
                    "Error, DSA parameter generation context allocation failed\n");
@@ -206,7 +206,8 @@ int dsaparam_main(int argc, char **argv)
     }
     if (genkey) {
         EVP_PKEY_CTX_free(ctx);
-        ctx = EVP_PKEY_CTX_new(params, NULL);
+        ctx = EVP_PKEY_CTX_new_from_pkey(app_get0_libctx(), params,
+                app_get0_propq());
         if (ctx == NULL) {
             BIO_printf(bio_err,
                        "Error, DSA key generation context allocation failed\n");

--- a/apps/gendsa.c
+++ b/apps/gendsa.c
@@ -136,7 +136,7 @@ int gendsa_main(int argc, char **argv)
                    "         Your key size is %d! Larger key size may behave not as expected.\n",
                    OPENSSL_DSA_MAX_MODULUS_BITS, EVP_PKEY_get_bits(pkey));
 
-    ctx = EVP_PKEY_CTX_new(pkey, NULL);
+    ctx = EVP_PKEY_CTX_new_from_pkey(app_get0_libctx(), pkey, app_get0_propq());
     if (ctx == NULL) {
         BIO_printf(bio_err, "unable to create PKEY context\n");
         goto end;

--- a/test/recipes/20-test_cli_fips.t
+++ b/test/recipes/20-test_cli_fips.t
@@ -273,8 +273,9 @@ SKIP : {
         my $testtext = '';
         my $fips_param = $testtext_prefix.'.fips.param.pem';
         my $nonfips_param = $testtext_prefix.'.nonfips.param.pem';
+        my $shortnonfips_param = $testtext_prefix.'.shortnonfips.param.pem';
 
-        plan tests => 8 + $tsignverify_count;
+        plan tests => 13 + $tsignverify_count;
 
         $ENV{OPENSSL_CONF} = $defaultconf;
 
@@ -305,6 +306,23 @@ SKIP : {
                     '-pkeyopt', 'dsa_paramgen_bits:512',
                      '-out', $testtext_prefix.'.fail.param.pem'])),
            $testtext);
+
+        $testtext = $testtext_prefix.': '.
+            'Generate non-FIPS params using non-FIPS property query'.
+            ' (dsaparam)';
+        ok(run(app(['openssl', 'dsaparam', '-provider', 'default',
+                    '-propquery', '?fips!=yes',
+                    '-out', $shortnonfips_param, '1024'])),
+            $testtext);
+
+        $testtext = $testtext_prefix.': '.
+            'Generate non-FIPS params using non-FIPS property query'.
+            ' (genpkey)';
+        ok(run(app(['openssl', 'genpkey', '-provider', 'default',
+                    '-propquery', '?fips!=yes',
+                    '-genparam', '-algorithm', 'DSA',
+                    '-pkeyopt', 'dsa_paramgen_bits:512'])),
+            $testtext);
 
         $ENV{OPENSSL_CONF} = $defaultconf;
 
@@ -338,6 +356,32 @@ SKIP : {
                      '-pkeyopt', 'type:fips186_2',
                      '-out', $testtext_prefix.'.fail.priv.pem'])),
            $testtext);
+
+        $testtext = $testtext_prefix.': '.
+            'Generate a key with non-FIPS parameters using non-FIPS property'.
+            ' query (dsaparam)';
+        ok(run(app(['openssl', 'dsaparam', '-provider', 'default',
+                    '-propquery', '?fips!=yes',
+                    '-noout', '-genkey', '1024'])),
+            $testtext);
+
+        $testtext = $testtext_prefix.': '.
+            'Generate a key with non-FIPS parameters using non-FIPS property'.
+            ' query (gendsa)';
+        ok(run(app(['openssl', 'gendsa', '-provider', 'default',
+                    '-propquery', '?fips!=yes',
+                    $shortnonfips_param])),
+            $testtext);
+
+        $testtext = $testtext_prefix.': '.
+            'Generate a key with non-FIPS parameters using non-FIPS property'.
+            ' query (genpkey)';
+        ok(run(app(['openssl', 'genpkey', '-provider', 'default',
+                    '-propquery', '?fips!=yes',
+                    '-paramfile', $nonfips_param,
+                    '-pkeyopt', 'type:fips186_2',
+                    '-out', $testtext_prefix.'.fail.priv.pem'])),
+            $testtext);
 
         tsignverify($testtext_prefix, $fips_key, $fips_pub_key, $nonfips_key,
                     $nonfips_pub_key);


### PR DESCRIPTION
The -provider and -propquery options did not work on dsaparam and gendsa. Fix this and add tests that check that operations that are not supported by the FIPS provider work when run with

```
-provider default -propquery '?fips!=yes'
```

See also https://bugzilla.redhat.com/show_bug.cgi?id=2094956, where this was initially reported.

Signed-off-by: Clemens Lang <cllang@redhat.com>

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
