### PR TITLE
Resolve the BIO_ctrl() / OSSL_FUNC_BIO_ctrl_fn declaration clash [TAKE 1]

### DIFF
--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -1841,6 +1841,7 @@ OSSL_FUNC_BIO_up_ref_fn ossl_core_bio_up_ref;
 OSSL_FUNC_BIO_free_fn ossl_core_bio_free;
 OSSL_FUNC_BIO_vprintf_fn ossl_core_bio_vprintf;
 OSSL_FUNC_BIO_vsnprintf_fn BIO_vsnprintf;
+static OSSL_FUNC_BIO_ctrl_fn ossl_core_bio_ctrl;
 static OSSL_FUNC_self_test_cb_fn core_self_test_get_callback;
 OSSL_FUNC_get_entropy_fn ossl_rand_get_entropy;
 OSSL_FUNC_cleanup_entropy_fn ossl_rand_cleanup_entropy;
@@ -2000,6 +2001,18 @@ static int core_pop_error_to_mark(const OSSL_CORE_HANDLE *handle)
     return ERR_pop_to_mark();
 }
 
+/*
+ * This function makes sure that a call of a previously incorrect definition
+ * of OSSL_FUNC_BIO_ctrl_fn (it was defined to return int when it should
+ * have returned long), to maintain ABI compatibility for providers that
+ * were compiled with the incorrect definition.
+ */
+static int core_bio_ctrl_bogus(OSSL_CORE_BIO *bio,
+                               int cmd, long num, void *ptr)
+{
+    return (int)ossl_core_bio_ctrl(bio, cmd, num, ptr);
+}
+
 static void core_self_test_get_callback(OPENSSL_CORE_CTX *libctx,
                                         OSSL_CALLBACK **cb, void **cbarg)
 {
@@ -2093,6 +2106,7 @@ static const OSSL_DISPATCH core_dispatch_[] = {
     { OSSL_FUNC_BIO_WRITE_EX, (void (*)(void))ossl_core_bio_write_ex },
     { OSSL_FUNC_BIO_GETS, (void (*)(void))ossl_core_bio_gets },
     { OSSL_FUNC_BIO_PUTS, (void (*)(void))ossl_core_bio_puts },
+    { OSSL_FUNC_BIO_CTRL_BOGUS, (void (*)(void))core_bio_ctrl_bogus },
     { OSSL_FUNC_BIO_CTRL, (void (*)(void))ossl_core_bio_ctrl },
     { OSSL_FUNC_BIO_UP_REF, (void (*)(void))ossl_core_bio_up_ref },
     { OSSL_FUNC_BIO_FREE, (void (*)(void))ossl_core_bio_free },

--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -1841,7 +1841,7 @@ OSSL_FUNC_BIO_up_ref_fn ossl_core_bio_up_ref;
 OSSL_FUNC_BIO_free_fn ossl_core_bio_free;
 OSSL_FUNC_BIO_vprintf_fn ossl_core_bio_vprintf;
 OSSL_FUNC_BIO_vsnprintf_fn BIO_vsnprintf;
-static OSSL_FUNC_BIO_ctrl_fn ossl_core_bio_ctrl;
+OSSL_FUNC_BIO_ctrl_fn ossl_core_bio_ctrl;
 static OSSL_FUNC_self_test_cb_fn core_self_test_get_callback;
 OSSL_FUNC_get_entropy_fn ossl_rand_get_entropy;
 OSSL_FUNC_cleanup_entropy_fn ossl_rand_cleanup_entropy;

--- a/include/openssl/core_dispatch.h
+++ b/include/openssl/core_dispatch.h
@@ -155,7 +155,8 @@ OSSL_CORE_MAKE_FUNC(void,
 #define OSSL_FUNC_BIO_VSNPRINTF               47
 #define OSSL_FUNC_BIO_PUTS                    48
 #define OSSL_FUNC_BIO_GETS                    49
-#define OSSL_FUNC_BIO_CTRL                    50
+#define OSSL_FUNC_BIO_CTRL_BOGUS              50
+#define OSSL_FUNC_BIO_CTRL                    51
 
 
 OSSL_CORE_MAKE_FUNC(OSSL_CORE_BIO *, BIO_new_file, (const char *filename,
@@ -173,8 +174,9 @@ OSSL_CORE_MAKE_FUNC(int, BIO_vprintf, (OSSL_CORE_BIO *bio, const char *format,
                                        va_list args))
 OSSL_CORE_MAKE_FUNC(int, BIO_vsnprintf,
                    (char *buf, size_t n, const char *fmt, va_list args))
-OSSL_CORE_MAKE_FUNC(int, BIO_ctrl, (OSSL_CORE_BIO *bio,
-                                    int cmd, long num, void *ptr))
+/* OSSL_FUNC_BIO_CTRL_BOGUS doesn't have a corresponding declaration */
+OSSL_CORE_MAKE_FUNC(long, BIO_ctrl, (OSSL_CORE_BIO *bio,
+                                     int cmd, long num, void *ptr))
 
 #define OSSL_FUNC_SELF_TEST_CB               100
 OSSL_CORE_MAKE_FUNC(void, self_test_cb, (OPENSSL_CORE_CTX *ctx, OSSL_CALLBACK **cb,


### PR DESCRIPTION
A new dispatch index is defined and given the name `OSSL_FUNC_BIO_CTRL`,
which is the index macro of the old.  The old dispatch index is now named
`OSSL_FUNC_BIO_CTRL_BOGUS`.

In `crypto/provider_core.c`, `OSSL_FUNC_BIO_CTRL` (the new index) remains
mapped to `ossl_core_bio_trl()`, as that one was already correctly defined
(i.e. returns `long`), while `OSSL_FUNC_BIO_CTRL_BOGUS` (the old index) is
mapped to a function that casts the result of `ossl_core_bio_trl()` to
`int`.

This allows providers compiled before this change to continue to work, as
the ABI is preserved, while new compiles should automatically get
corrected.
