### PR TITLE
Resolve the BIO_ctrl() / OSSL_FUNC_BIO_ctrl_fn declaration clash [TAKE 2]

### DIFF
--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -1841,6 +1841,7 @@ OSSL_FUNC_BIO_up_ref_fn ossl_core_bio_up_ref;
 OSSL_FUNC_BIO_free_fn ossl_core_bio_free;
 OSSL_FUNC_BIO_vprintf_fn ossl_core_bio_vprintf;
 OSSL_FUNC_BIO_vsnprintf_fn BIO_vsnprintf;
+static OSSL_FUNC_BIO_ctrl_fn core_bio_ctrl;
 static OSSL_FUNC_self_test_cb_fn core_self_test_get_callback;
 OSSL_FUNC_get_entropy_fn ossl_rand_get_entropy;
 OSSL_FUNC_cleanup_entropy_fn ossl_rand_cleanup_entropy;
@@ -2000,6 +2001,19 @@ static int core_pop_error_to_mark(const OSSL_CORE_HANDLE *handle)
     return ERR_pop_to_mark();
 }
 
+/*
+ * This function maps ossl_core_bio_ctrl() to a function signature that
+ * matches OSSL_FUNC_BIO_ctrl_fn (it's unfortunately defined to return int
+ * when it should have returned long).
+ *
+ * Hopefully, no actual BIO control return a value that make us lose
+ * significant bits.
+ */
+static int core_bio_ctrl(OSSL_CORE_BIO *bio, int cmd, long num, void *ptr)
+{
+    return (int)ossl_core_bio_ctrl(bio, cmd, num, ptr);
+}
+
 static void core_self_test_get_callback(OPENSSL_CORE_CTX *libctx,
                                         OSSL_CALLBACK **cb, void **cbarg)
 {
@@ -2093,7 +2107,7 @@ static const OSSL_DISPATCH core_dispatch_[] = {
     { OSSL_FUNC_BIO_WRITE_EX, (void (*)(void))ossl_core_bio_write_ex },
     { OSSL_FUNC_BIO_GETS, (void (*)(void))ossl_core_bio_gets },
     { OSSL_FUNC_BIO_PUTS, (void (*)(void))ossl_core_bio_puts },
-    { OSSL_FUNC_BIO_CTRL, (void (*)(void))ossl_core_bio_ctrl },
+    { OSSL_FUNC_BIO_CTRL, (void (*)(void))core_bio_ctrl },
     { OSSL_FUNC_BIO_UP_REF, (void (*)(void))ossl_core_bio_up_ref },
     { OSSL_FUNC_BIO_FREE, (void (*)(void))ossl_core_bio_free },
     { OSSL_FUNC_BIO_VPRINTF, (void (*)(void))ossl_core_bio_vprintf },

--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -9,6 +9,7 @@
 
 #include <assert.h>
 #include <stdio.h>
+#include <limits.h>
 #include <openssl/core.h>
 #include <openssl/core_dispatch.h>
 #include <openssl/core_names.h>
@@ -2288,6 +2289,7 @@ OSSL_FUNC_BIO_vprintf_fn ossl_core_bio_vprintf;
 static OSSL_FUNC_BIO_vsnprintf_fn core_bio_vsnprintf;
 #endif
 static OSSL_FUNC_indicator_cb_fn core_indicator_get_callback;
+static OSSL_FUNC_BIO_ctrl_fn core_bio_ctrl;
 static OSSL_FUNC_self_test_cb_fn core_self_test_get_callback;
 static OSSL_FUNC_get_entropy_fn rand_get_entropy;
 static OSSL_FUNC_get_user_entropy_fn rand_get_user_entropy;
@@ -2451,6 +2453,25 @@ static void core_indicator_get_callback(OPENSSL_CORE_CTX *libctx,
     OSSL_INDICATOR_CALLBACK **cb)
 {
     OSSL_INDICATOR_get_callback((OSSL_LIB_CTX *)libctx, cb);
+}
+
+/*
+ * This function maps ossl_core_bio_ctrl() to a function signature that
+ * matches OSSL_FUNC_BIO_ctrl_fn (it's unfortunately defined to return int
+ * when it should have returned long).
+ *
+ * No actual BIO control is expected to return a value that makes us lose
+ * significant bits.  The ossl_assert() ensures that we notice in debug
+ * builds, and in other builds, we return an error instead of returning a
+ * truncated value.
+ */
+static int core_bio_ctrl(OSSL_CORE_BIO *bio, int cmd, long num, void *ptr)
+{
+    long ret = ossl_core_bio_ctrl(bio, cmd, num, ptr);
+
+    if (!ossl_assert(ret >= INT_MIN && ret <= INT_MAX))
+        return -1;
+    return (int)ret;
 }
 
 static void core_self_test_get_callback(OPENSSL_CORE_CTX *libctx,
@@ -2621,7 +2642,7 @@ static const OSSL_DISPATCH core_dispatch_[] = {
     { OSSL_FUNC_BIO_WRITE_EX, (void (*)(void))ossl_core_bio_write_ex },
     { OSSL_FUNC_BIO_GETS, (void (*)(void))ossl_core_bio_gets },
     { OSSL_FUNC_BIO_PUTS, (void (*)(void))ossl_core_bio_puts },
-    { OSSL_FUNC_BIO_CTRL, (void (*)(void))ossl_core_bio_ctrl },
+    { OSSL_FUNC_BIO_CTRL, (void (*)(void))core_bio_ctrl },
     { OSSL_FUNC_BIO_UP_REF, (void (*)(void))ossl_core_bio_up_ref },
     { OSSL_FUNC_BIO_FREE, (void (*)(void))ossl_core_bio_free },
     { OSSL_FUNC_BIO_VPRINTF, (void (*)(void))ossl_core_bio_vprintf },

--- a/doc/man7/provider-base.pod
+++ b/doc/man7/provider-base.pod
@@ -339,6 +339,15 @@ array are typically direct pointers to those public functions. Note that the BIO
 functions take an B<OSSL_CORE_BIO> type rather than the standard B<BIO>
 type. This is to ensure that a provider does not mix BIOs from the core
 with BIOs used on the provider side (the two are not compatible).
+
+There is one exception to the exact correspondence: while the public
+L<BIO_ctrl(3)> returns B<long>, the core function (OSSL_FUNC_BIO_ctrl_fn)
+is defined to return B<int> for historical reasons.  The core checks that
+the underlying return value fits in an B<int> and returns an error if it
+does not.  In practice, all BIO control commands return values that fit in
+an B<int>, so providers should treat B<int> as the effective return range
+of BIO_ctrl().
+
 OSSL_SELF_TEST_set_callback() is used to set an optional callback that can be
 passed into a provider. This may be ignored by a provider.
 


### PR DESCRIPTION
This is resolved by pretending that it isn't a clash, by making an internal
function in core that simply casts the result of `ossl_core_bio_ctrl()` to
`int` and hope for the best.  Since `OSSL_FUNC_BIO_ctrl_fn` declared an
`int` return value, that cast was done implicitly anyway.  Now it's done in
a more controlled manner.
