### PR TITLE
test/evp_test.c: Add check for OPENSSL_strdup

### DIFF
--- a/test/evp_test.c
+++ b/test/evp_test.c
@@ -1245,6 +1245,7 @@ static int mac_test_parse(EVP_TEST *t,
                           const char *keyword, const char *value)
 {
     MAC_DATA *mdata = t->data;
+    char *data;
 
     if (strcmp(keyword, "Key") == 0)
         return parse_bin(value, &mdata->key, &mdata->key_len);
@@ -1268,9 +1269,12 @@ static int mac_test_parse(EVP_TEST *t,
         return mdata->xof = 1;
     if (strcmp(keyword, "NoReinit") == 0)
         return mdata->no_reinit = 1;
-    if (strcmp(keyword, "Ctrl") == 0)
-        return sk_OPENSSL_STRING_push(mdata->controls,
-                                      OPENSSL_strdup(value)) != 0;
+    if (strcmp(keyword, "Ctrl") == 0) {
+        data = OPENSSL_strdup(value);
+        if (!data)
+            return -1;
+        return sk_OPENSSL_STRING_push(mdata->controls, data) != 0;
+    }
     if (strcmp(keyword, "OutputSize") == 0) {
         mdata->output_size = atoi(value);
         if (mdata->output_size < 0)


### PR DESCRIPTION
As the potential failure of the OPENSSL_strdup(),
it should be better to check the return value and
return error if fails.

Signed-off-by: Jiasheng Jiang <jiasheng@iscas.ac.cn>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
