### PR TITLE
crypto/x509/by_store.c: Add check for OPENSSL_strdup

### DIFF
--- a/crypto/x509/by_store.c
+++ b/crypto/x509/by_store.c
@@ -119,14 +119,15 @@ static int by_store_ctrl_ex(X509_LOOKUP *ctx, int cmd, const char *argp,
 
         {
             STACK_OF(OPENSSL_STRING) *uris = X509_LOOKUP_get_method_data(ctx);
+            char *data = OPENSSL_strdup(argp);
 
+            if (data == NULL) {
+                return -1;
+            }
             if (uris == NULL) {
                 uris = sk_OPENSSL_STRING_new_null();
                 X509_LOOKUP_set_method_data(ctx, uris);
             }
-            char *data = OPENSSL_strdup(argp);
-            if (data == NULL)
-                return -1;
             return sk_OPENSSL_STRING_push(uris, data) > 0;
         }
     case X509_L_LOAD_STORE:

--- a/crypto/x509/by_store.c
+++ b/crypto/x509/by_store.c
@@ -122,7 +122,7 @@ static int by_store_ctrl_ex(X509_LOOKUP *ctx, int cmd, const char *argp,
             char *data = OPENSSL_strdup(argp);
 
             if (data == NULL) {
-                return -1;
+                return 0;
             }
             if (uris == NULL) {
                 uris = sk_OPENSSL_STRING_new_null();

--- a/crypto/x509/by_store.c
+++ b/crypto/x509/by_store.c
@@ -109,6 +109,8 @@ static int by_store_ctrl_ex(X509_LOOKUP *ctx, int cmd, const char *argp,
                             long argl, char **retp, OSSL_LIB_CTX *libctx,
                             const char *propq)
 {
+    char *data;
+
     switch (cmd) {
     case X509_L_ADD_STORE:
         /* If no URI is given, use the default cert dir as default URI */
@@ -124,7 +126,10 @@ static int by_store_ctrl_ex(X509_LOOKUP *ctx, int cmd, const char *argp,
                 uris = sk_OPENSSL_STRING_new_null();
                 X509_LOOKUP_set_method_data(ctx, uris);
             }
-            return sk_OPENSSL_STRING_push(uris, OPENSSL_strdup(argp)) > 0;
+            data = OPENSSL_strdup(argp);
+            if (data == NULL)
+                return -1;
+            return sk_OPENSSL_STRING_push(uris, data) > 0;
         }
     case X509_L_LOAD_STORE:
         /* This is a shortcut for quick loading of specific containers */

--- a/crypto/x509/by_store.c
+++ b/crypto/x509/by_store.c
@@ -109,8 +109,6 @@ static int by_store_ctrl_ex(X509_LOOKUP *ctx, int cmd, const char *argp,
                             long argl, char **retp, OSSL_LIB_CTX *libctx,
                             const char *propq)
 {
-    char *data;
-
     switch (cmd) {
     case X509_L_ADD_STORE:
         /* If no URI is given, use the default cert dir as default URI */
@@ -126,7 +124,7 @@ static int by_store_ctrl_ex(X509_LOOKUP *ctx, int cmd, const char *argp,
                 uris = sk_OPENSSL_STRING_new_null();
                 X509_LOOKUP_set_method_data(ctx, uris);
             }
-            data = OPENSSL_strdup(argp);
+            char *data = OPENSSL_strdup(argp);
             if (data == NULL)
                 return -1;
             return sk_OPENSSL_STRING_push(uris, data) > 0;


### PR DESCRIPTION
As the potential failure of the OPENSSL_strdup(),
it should be better to check the return value and
return error if fails.

Signed-off-by: Jiasheng Jiang <jiasheng@iscas.ac.cn>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
