### PR TITLE
apps/s_server.c: Add check for OPENSSL_strdup

### DIFF
--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -1168,6 +1168,8 @@ int s_server_main(int argc, char *argv[])
         case OPT_UNIX:
             socket_family = AF_UNIX;
             OPENSSL_free(host); host = OPENSSL_strdup(opt_arg());
+            if (host == NULL)
+                goto end;
             OPENSSL_free(port); port = NULL;
             break;
         case OPT_UNLINK:


### PR DESCRIPTION
As the potential failure of the OPENSSL_strdup(),
it should be better to check the return value and
return error if fails.

Signed-off-by: Jiasheng Jiang <jiasheng@iscas.ac.cn>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
