### PR TITLE
Add BIO_s_dgram_mem()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,10 @@ OpenSSL 3.1
 
 ### Changes between 3.0 and 3.1 [xx XXX xxxx]
 
+ * Added the ability for BIO_s_mem() to read/write datagrams
+
+   *Matt Caswell*
+
  * Add a mac salt length option for the pkcs12 command.
 
    *Xinping Chen*

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,7 +24,7 @@ OpenSSL 3.1
 
 ### Changes between 3.0 and 3.1 [xx XXX xxxx]
 
- * Added the ability for BIO_s_mem() to read/write datagrams
+ * Added a new BIO_s_dgram_mem() to read/write datagrams to memory
 
    *Matt Caswell*
 

--- a/crypto/bio/bss_mem.c
+++ b/crypto/bio/bss_mem.c
@@ -18,6 +18,7 @@ static int mem_puts(BIO *h, const char *str);
 static int mem_gets(BIO *h, char *str, int size);
 static long mem_ctrl(BIO *h, int cmd, long arg1, void *arg2);
 static int mem_new(BIO *h);
+static int dgram_mem_new(BIO *h);
 static int secmem_new(BIO *h);
 static int mem_free(BIO *data);
 static int mem_buf_free(BIO *data);
@@ -38,6 +39,21 @@ static const BIO_METHOD mem_method = {
     NULL,                      /* mem_callback_ctrl */
 };
 
+static const BIO_METHOD dgram_mem_method = {
+    BIO_TYPE_MEM,
+    "datagram memory buffer",
+    bwrite_conv,
+    mem_write,
+    bread_conv,
+    mem_read,
+    mem_puts,
+    mem_gets,
+    mem_ctrl,
+    dgram_mem_new,
+    mem_free,
+    NULL,                      /* mem_callback_ctrl */
+};
+
 static const BIO_METHOD secmem_method = {
     BIO_TYPE_MEM,
     "secure memory buffer",
@@ -54,10 +70,9 @@ static const BIO_METHOD secmem_method = {
 };
 
 struct buf_mem_dgram_st {
-    /* Pointer into the buffer for where the dgram starts */
-    char *dgram;
-    /* Length of the dgram */
-    size_t dgramlen;
+    char *dgram;  /* Pointer into the buffer for where the dgram starts */
+    size_t dgramlen;  /* Length of the dgram */
+    struct buf_mem_dgram_st *next; /* Next dgram to read */
 };
 
 /*
@@ -69,10 +84,9 @@ struct buf_mem_dgram_st {
 typedef struct bio_buf_mem_st {
     struct buf_mem_st *buf;   /* allocated buffer */
     struct buf_mem_st *readp; /* read pointer */
-    struct buf_mem_dgram_st *dgrams; /* dgram data */
-    size_t nextdgram; /* Next dgram to be read */
-    size_t numdgrams; /* Number of dgrams currently stored */
-    size_t maxdgrams; /* Max number of dgrams that can be stored */
+    struct buf_mem_dgram_st *dgrams; /* linked list of dgram data */
+    struct buf_mem_dgram_st *last; /* last dgram in the linked list */
+    int use_dgrams;
 } BIO_BUF_MEM;
 
 /*
@@ -83,6 +97,11 @@ typedef struct bio_buf_mem_st {
 const BIO_METHOD *BIO_s_mem(void)
 {
     return &mem_method;
+}
+
+const BIO_METHOD *BIO_s_dgram_mem(void)
+{
+    return &dgram_mem_method;
 }
 
 const BIO_METHOD *BIO_s_secmem(void)
@@ -145,10 +164,39 @@ static int mem_new(BIO *bi)
     return mem_init(bi, 0L);
 }
 
+static int dgram_mem_new(BIO *bi)
+{
+    BIO_BUF_MEM *bbm;
+
+    if (!mem_init(bi, 0L))
+        return 0;
+
+    bbm = (BIO_BUF_MEM *)bi->ptr;
+
+    bbm->use_dgrams = 1;
+    bi->num = -1;
+
+    return 1;
+}
+
 static int secmem_new(BIO *bi)
 {
     return mem_init(bi, BUF_MEM_FLAG_SECURE);
 }
+
+static void clear_all_dgrams(BIO_BUF_MEM *bbm)
+{
+    struct buf_mem_dgram_st *dgrams = bbm->dgrams;
+
+    while (dgrams != NULL) {
+        struct buf_mem_dgram_st *tmp = dgrams;
+
+        dgrams = dgrams->next;
+        OPENSSL_free(tmp);
+    }
+    bbm->dgrams = NULL;
+}
+
 
 static int mem_free(BIO *a)
 {
@@ -161,7 +209,7 @@ static int mem_free(BIO *a)
     if (!mem_buf_free(a))
         return 0;
     OPENSSL_free(bb->readp);
-    OPENSSL_free(bb->dgrams);
+    clear_all_dgrams(bb);
     OPENSSL_free(bb);
     return 1;
 }
@@ -196,12 +244,6 @@ static int mem_buf_sync(BIO *b)
             bbm->buf->length = bbm->readp->length;
             bbm->readp->data = bbm->buf->data;
         }
-        if (bbm->nextdgram > 0) {
-            if (bbm->numdgrams > 0)
-                memmove(bbm->dgrams, &bbm->dgrams[bbm->nextdgram],
-                        sizeof(*bbm->dgrams) * bbm->numdgrams);
-            bbm->nextdgram = 0;
-        }
     }
     return 0;
 }
@@ -217,12 +259,11 @@ static int mem_read(BIO *b, char *out, int outl)
     if (b->flags & BIO_FLAGS_MEM_RDONLY)
         bm = bbm->buf;
     BIO_clear_retry_flags(b);
-    if (bbm->maxdgrams > 0) {
-        if (bbm->numdgrams > 0) {
-            maxreadlen = bbm->dgrams[bbm->nextdgram++].dgramlen;
+    if (bbm->use_dgrams) {
+        if (bbm->dgrams != NULL) {
+            maxreadlen = bbm->dgrams->dgramlen;
             if (!ossl_assert(maxreadlen <= bm->length))
                 return 0;
-            bbm->numdgrams--;
         } else {
             eof = 1;
         }
@@ -235,11 +276,19 @@ static int mem_read(BIO *b, char *out, int outl)
         size_t flushlen;
 
         memcpy(out, bm->data, ret);
-        flushlen = (bbm->maxdgrams > 0) ? maxreadlen : (size_t)ret;
+        flushlen = bbm->use_dgrams ? maxreadlen : (size_t)ret;
             
         bm->length -= flushlen;
         bm->max -= flushlen;
         bm->data += flushlen;
+        if (bbm->use_dgrams) {
+            struct buf_mem_dgram_st *tmp = bbm->dgrams;
+
+            bbm->dgrams = tmp->next;
+            OPENSSL_free(tmp);
+            if (bbm->dgrams == NULL)
+                bbm->last = NULL;
+        }
     } else if (eof) {
         ret = b->num;
         if (ret != 0)
@@ -275,29 +324,22 @@ static int mem_write(BIO *b, const char *in, int inl)
     memcpy(bbm->buf->data + blen, in, inl);
     *bbm->readp = *bbm->buf;
 
-    if (bbm->maxdgrams > 0) {
-        size_t off = bbm->numdgrams + bbm->nextdgram;
+    if (bbm->use_dgrams) {
+        struct buf_mem_dgram_st *dgram = OPENSSL_malloc(sizeof(*dgram));
 
-        if (off == bbm->maxdgrams) {
-            size_t newmax;
-            struct buf_mem_dgram_st *tmp = bbm->dgrams;
-
-            if (bbm->maxdgrams <= SIZE_MAX / (sizeof(*bbm->dgrams) * 2))
-                newmax = bbm->maxdgrams * 2;
-            else
-                goto end;
-
-            bbm->dgrams = OPENSSL_realloc(bbm->dgrams,
-                                          sizeof(*bbm->dgrams) * newmax);
-            if (bbm->dgrams == NULL) {
-                bbm->dgrams = tmp;
-                goto end;
-            }
-            bbm->maxdgrams = newmax;
+        if (dgram == NULL) {
+            ERR_raise(ERR_LIB_BIO, ERR_R_MALLOC_FAILURE);
+            goto end;
         }
-        bbm->dgrams[off].dgram = bbm->buf->data + blen;
-        bbm->dgrams[off].dgramlen = inl;
-        bbm->numdgrams++;
+
+        dgram->dgram = bbm->buf->data + blen;
+        dgram->dgramlen = inl;
+        dgram->next = NULL;
+        if (bbm->dgrams == NULL)
+            bbm->dgrams = dgram;
+        else
+            bbm->last->next = dgram;
+        bbm->last = dgram;
     }
 
     ret = inl;
@@ -338,7 +380,7 @@ static long mem_ctrl(BIO *b, int cmd, long num, void *ptr)
                 *bbm->buf = *bbm->readp;
             }
         }
-        bbm->nextdgram = bbm->numdgrams = 0;
+        clear_all_dgrams(bbm);
         break;
     case BIO_C_FILE_SEEK:
         if (num < 0 || num > off + remain)
@@ -353,10 +395,10 @@ static long mem_ctrl(BIO *b, int cmd, long num, void *ptr)
         ret = off;
         break;
     case BIO_CTRL_EOF:
-        ret = (long)(bm->length == 0 && bbm->numdgrams == 0);
+        ret = (long)(bm->length == 0 && bbm->use_dgrams == 0);
         break;
     case BIO_C_SET_BUF_MEM_EOF_RETURN:
-        if (bbm->maxdgrams == 0)
+        if (!bbm->use_dgrams)
             b->num = (int)num;
         else
             ret = -1;
@@ -381,34 +423,6 @@ static long mem_ctrl(BIO *b, int cmd, long num, void *ptr)
             bm = bbm->buf;
             pptr = (char **)ptr;
             *pptr = (char *)bm;
-        }
-        break;
-    case BIO_C_SET_INITIAL_DGRAM_SIZE:
-        /*
-         * We only allow setting the maxdgrams if no dgrams have been written.
-         * We don't support this for read only mem bios
-         */
-        if (bbm->numdgrams == 0
-                && (b->flags & BIO_FLAGS_MEM_RDONLY) == 0
-                && num > 0) {
-            struct buf_mem_dgram_st *tmp = bbm->dgrams;
-
-            if (bbm->maxdgrams == 0)
-                bbm->dgrams = OPENSSL_malloc(sizeof(*bbm->dgrams) * num);
-            else
-                bbm->dgrams = OPENSSL_realloc(bbm->dgrams,
-                                              sizeof(*bbm->dgrams) * num);
-
-            if (bbm->dgrams != NULL) {
-                bbm->maxdgrams = num;
-                b->num = -1;
-            } else {
-                /* Failed. Restore the previous pointer (which may also be NULL) */
-                bbm->dgrams = tmp;
-                ret = -1;
-            }
-        } else {
-            ret = -1;
         }
         break;
     case BIO_CTRL_GET_CLOSE:
@@ -447,7 +461,8 @@ static int mem_gets(BIO *bp, char *buf, int size)
     if (bp->flags & BIO_FLAGS_MEM_RDONLY)
         bm = bbm->buf;
     BIO_clear_retry_flags(bp);
-    j = bbm->numdgrams > 0 ? bbm->dgrams[bbm->nextdgram].dgramlen : bm->length;
+    j = (!bbm->use_dgrams || bbm->dgrams == NULL) ? bm->length
+                                                  : bbm->dgrams->dgramlen;
     if ((size - 1) < j)
         j = size - 1;
     if (j <= 0) {

--- a/crypto/bio/bss_mem.c
+++ b/crypto/bio/bss_mem.c
@@ -197,7 +197,6 @@ static void clear_all_dgrams(BIO_BUF_MEM *bbm)
     bbm->dgrams = NULL;
 }
 
-
 static int mem_free(BIO *a)
 {
     BIO_BUF_MEM *bb;

--- a/doc/man3/BIO_s_mem.pod
+++ b/doc/man3/BIO_s_mem.pod
@@ -2,15 +2,16 @@
 
 =head1 NAME
 
-BIO_s_secmem,
+BIO_s_secmem, BIO_s_dgram_mem,
 BIO_s_mem, BIO_set_mem_eof_return, BIO_get_mem_data, BIO_set_mem_buf,
-BIO_get_mem_ptr, BIO_new_mem_buf, BIO_set_initial_dgram_size - memory BIO
+BIO_get_mem_ptr, BIO_new_mem_buf - memory BIO
 
 =head1 SYNOPSIS
 
  #include <openssl/bio.h>
 
  const BIO_METHOD *BIO_s_mem(void);
+ const BIO_METHOD *BIO_s_dgram_mem(void);
  const BIO_METHOD *BIO_s_secmem(void);
 
  BIO_set_mem_eof_return(BIO *b, int v);
@@ -19,8 +20,6 @@ BIO_get_mem_ptr, BIO_new_mem_buf, BIO_set_initial_dgram_size - memory BIO
  BIO_get_mem_ptr(BIO *b, BUF_MEM **pp);
 
  BIO *BIO_new_mem_buf(const void *buf, int len);
-
- long BIO_set_initial_dgram_size(BIO *bp, long sz);
 
 =head1 DESCRIPTION
 
@@ -32,6 +31,22 @@ as appropriate to accommodate the stored data.
 
 BIO_s_secmem() is like BIO_s_mem() except that the secure heap is used
 for buffer storage.
+
+BIO_s_dgram_mem() is a memory BIO that respects datagram semantics. A single
+call to L<BIO_write(3)> will write a single datagram to the memory BIO. A
+subsequent call to L<BIO_read(3)> will read the data in that datagram. The
+L<BIO_read(3)> call will never return more data than was written in the original
+L<BIO_write(3)> call even if there were subsequent L<BIO_write(3)> calls that
+wrote more datagrams. Each successive call to L<BIO_read(3)> will read the next
+datagram. If a L<BIO_read(3)> call supplies a read buffer that is smaller than
+the size of the datagram, then the read buffer will be completely filled and the
+remaining data from the datagram will be discarded.
+
+It is not possible to write a zero length datagram. Calling L<BIO_write(3)> in
+this case will return 0 and no datagrams will be written. Calling L<BIO_read(3)>
+when there are no datagrams in the BIO to read will return a negative result and
+the "retry" flags will be set (i.e. calling L<BIO_should_retry(3)> will return
+true). A datagram mem BIO will never return true from L<BIO_eof(3)>.
 
 Any data written to a memory BIO can be recalled by reading from it.
 Unless the memory BIO is read only any data read from it is deleted from
@@ -58,8 +73,7 @@ it will return zero and BIO_should_retry(b) will be false. If B<v> is non
 zero then it will return B<v> when it is empty and it will set the read retry
 flag (that is BIO_read_retry(b) is true). To avoid ambiguity with a normal
 positive return value B<v> should be set to a negative value, typically -1.
-Calling this macro will fail if the BIO has been set to use datagram semantics
-(see below).
+Calling this macro will fail for datagram mem BIOs.
 
 BIO_get_mem_data() sets *B<pp> to a pointer to the start of the memory BIOs data
 and returns the total amount of data available. It is implemented as a macro.
@@ -79,33 +93,6 @@ made available from a static area of memory in the form of a BIO. The
 supplied data is read directly from the supplied buffer: it is B<not> copied
 first, so the supplied area of memory must be unchanged until the BIO is freed.
 
-A memory BIO can be converted to use datagram semantics. To do this call the
-macro BIO_set_initial_dgram_size() and specify the initial buffer size for
-storing datagram meta data in the I<sz> parameter. The buffer size must be
-greater than 0. For example setting an initial buffer size of 3 will setup the
-BIO to initially be able to handle 3 datagrams. If more datagrams than that are
-written to the BIO then the buffer will automatically grow to accomodate them.
-
-When operating like this a single call to L<BIO_write(3)> will write a single
-datagram to the memory BIO. A subsequent call to L<BIO_read(3)> will read the
-data in that datagram. The L<BIO_read(3)> call will never return more data than
-was written in the original L<BIO_write(3)> call even if there were subsequent
-L<BIO_write(3)> calls that write more datagrams. Each successive call to
-L<BIO_read(3)> will read the next datagram. If a L<BIO_read(3)> call supplies a
-read buffer that is smaller than the size of the datagram, then the read buffer
-will be completely filled and the remaining data from the datagram will be
-discarded.
-
-It is not possible to write a zero length datagram. Calling L<BIO_write(3)> in
-this case will return 0 and no datagrams will be written. If there are no
-datagrams available to read then L<BIO_eof(3)> will return true. Calling
-L<BIO_read(3)> in this state will return a negative result and the "retry" flags
-will be set (i.e. calling L<BIO_should_retry(3)> will return true).
-
-It is not possible to convert a read only BIO to datagram semantics (i.e. one
-that was created by calling BIO_new_mem_buf()). Attempting to call
-BIO_set_initial_dgram_size() on such a BIO will indicate a failure return code.
-
 =head1 NOTES
 
 Writes to memory BIOs will always succeed if memory is available: that is
@@ -117,8 +104,18 @@ copy operation, if a BIO contains a lot of data and it is read in small
 chunks intertwined with writes the operation can be very slow. Adding
 a buffering BIO to the chain can speed up the process.
 
-Calling BIO_set_mem_buf() on a BIO created with BIO_new_secmem() will
-give undefined results, including perhaps a program crash.
+Calling BIO_set_mem_buf() on a secmem or dgram BIO will give undefined results,
+including perhaps a program crash.
+
+Switching a memory BIO from read write to read only is not supported and
+can give undefined results including a program crash. There are two notable
+exceptions to the rule. The first one is to assign a static memory buffer
+immediately after BIO creation and set the BIO as read only.
+
+The other supported sequence is to start with a read write BIO then temporarily
+switch it to read only and call BIO_reset() on the read only BIO immediately
+before switching it back to read write. Before the BIO is freed it must be
+switched back to the read write mode.
 
 Calling BIO_get_mem_ptr() on read only BIO will return a BUF_MEM that
 contains only the remaining data to be read. If the close status of the
@@ -137,7 +134,8 @@ BIO_FLAGS_NONCLEAR_RST set has the same effect as a write operation.
 
 =head1 RETURN VALUES
 
-BIO_s_mem() and BIO_s_secmem() return a valid memory B<BIO_METHOD> structure.
+BIO_s_mem(), BIO_s_dgram_mem() and BIO_s_secmem() return a valid memory
+B<BIO_METHOD> structure.
 
 BIO_set_mem_eof_return(), BIO_set_mem_buf() and BIO_get_mem_ptr()
 return 1 on success or a value which is less than or equal to 0 if an error occurred.
@@ -146,9 +144,6 @@ BIO_get_mem_data() returns the total number of bytes available on success,
 0 if b is NULL, or a negative value in case of other errors.
 
 BIO_new_mem_buf() returns a valid B<BIO> structure on success or NULL on error.
-
-BIO_set_initial_dgram_size() will return 1 on success or 0 or a negative value
-on error.
 
 =head1 EXAMPLES
 

--- a/doc/man3/BIO_s_mem.pod
+++ b/doc/man3/BIO_s_mem.pod
@@ -4,7 +4,7 @@
 
 BIO_s_secmem,
 BIO_s_mem, BIO_set_mem_eof_return, BIO_get_mem_data, BIO_set_mem_buf,
-BIO_get_mem_ptr, BIO_new_mem_buf - memory BIO
+BIO_get_mem_ptr, BIO_new_mem_buf, BIO_set_initial_dgram_size - memory BIO
 
 =head1 SYNOPSIS
 
@@ -19,6 +19,8 @@ BIO_get_mem_ptr, BIO_new_mem_buf - memory BIO
  BIO_get_mem_ptr(BIO *b, BUF_MEM **pp);
 
  BIO *BIO_new_mem_buf(const void *buf, int len);
+
+ long BIO_set_initial_dgram_size(BIO *bp, long sz);
 
 =head1 DESCRIPTION
 
@@ -56,6 +58,8 @@ it will return zero and BIO_should_retry(b) will be false. If B<v> is non
 zero then it will return B<v> when it is empty and it will set the read retry
 flag (that is BIO_read_retry(b) is true). To avoid ambiguity with a normal
 positive return value B<v> should be set to a negative value, typically -1.
+Calling this macro will fail if the BIO has been set to use datagram semantics
+(see below).
 
 BIO_get_mem_data() sets *B<pp> to a pointer to the start of the memory BIOs data
 and returns the total amount of data available. It is implemented as a macro.
@@ -75,6 +79,33 @@ made available from a static area of memory in the form of a BIO. The
 supplied data is read directly from the supplied buffer: it is B<not> copied
 first, so the supplied area of memory must be unchanged until the BIO is freed.
 
+A memory BIO can be converted to use datagram semantics. To do this call the
+macro BIO_set_initial_dgram_size() and specify the initial buffer size for
+storing datagram meta data in the I<sz> parameter. The buffer size must be
+greater than 0. For example setting an initial buffer size of 3 will setup the
+BIO to initially be able to handle 3 datagrams. If more datagrams than that are
+written to the BIO then the buffer will automatically grow to accomodate them.
+
+When operating like this a single call to L<BIO_write(3)> will write a single
+datagram to the memory BIO. A subsequent call to L<BIO_read(3)> will read the
+data in that datagram. The L<BIO_read(3)> call will never return more data than
+was written in the original L<BIO_write(3)> call even if there were subsequent
+L<BIO_write(3)> calls that write more datagrams. Each successive call to
+L<BIO_read(3)> will read the next datagram. If a L<BIO_read(3)> call supplies a
+read buffer that is smaller than the size of the datagram, then the read buffer
+will be completely filled and the remaining data from the datagram will be
+discarded.
+
+It is not possible to write a zero length datagram. Calling L<BIO_write(3)> in
+this case will return 0 and no datagrams will be written. If there are no
+datagrams available to read then L<BIO_eof(3)> will return true. Calling
+L<BIO_read(3)> in this state will return a negative result and the "retry" flags
+will be set (i.e. calling L<BIO_should_retry(3)> will return true).
+
+It is not possible to convert a read only BIO to datagram semantics (i.e. one
+that was created by calling BIO_new_mem_buf()). Attempting to call
+BIO_set_initial_dgram_size() on such a BIO will indicate a failure return code.
+
 =head1 NOTES
 
 Writes to memory BIOs will always succeed if memory is available: that is
@@ -88,16 +119,6 @@ a buffering BIO to the chain can speed up the process.
 
 Calling BIO_set_mem_buf() on a BIO created with BIO_new_secmem() will
 give undefined results, including perhaps a program crash.
-
-Switching the memory BIO from read write to read only is not supported and
-can give undefined results including a program crash. There are two notable
-exceptions to the rule. The first one is to assign a static memory buffer
-immediately after BIO creation and set the BIO as read only.
-
-The other supported sequence is to start with read write BIO then temporarily
-switch it to read only and call BIO_reset() on the read only BIO immediately
-before switching it back to read write. Before the BIO is freed it must be
-switched back to the read write mode.
 
 Calling BIO_get_mem_ptr() on read only BIO will return a BUF_MEM that
 contains only the remaining data to be read. If the close status of the
@@ -114,10 +135,6 @@ preceding that write operation cannot be undone.
 Calling BIO_get_mem_ptr() prior to a BIO_reset() call with
 BIO_FLAGS_NONCLEAR_RST set has the same effect as a write operation.
 
-=head1 BUGS
-
-There should be an option to set the maximum size of a memory BIO.
-
 =head1 RETURN VALUES
 
 BIO_s_mem() and BIO_s_secmem() return a valid memory B<BIO_METHOD> structure.
@@ -129,6 +146,9 @@ BIO_get_mem_data() returns the total number of bytes available on success,
 0 if b is NULL, or a negative value in case of other errors.
 
 BIO_new_mem_buf() returns a valid B<BIO> structure on success or NULL on error.
+
+BIO_set_initial_dgram_size() will return 1 on success or 0 or a negative value
+on error.
 
 =head1 EXAMPLES
 

--- a/include/openssl/bio.h.in
+++ b/include/openssl/bio.h.in
@@ -407,8 +407,6 @@ struct bio_dgram_sctp_prinfo {
 
 # define BIO_C_SET_TFO                           156 /* like BIO_C_SET_NBIO */
 
-# define BIO_C_SET_INITIAL_DGRAM_SIZE            157
-
 # define BIO_set_app_data(s,arg)         BIO_set_ex_data(s,0,arg)
 # define BIO_get_app_data(s)             BIO_get_ex_data(s,0)
 
@@ -525,9 +523,6 @@ int BIO_read_filename(BIO *b, const char *name);
                                           (char *)(pp))
 # define BIO_set_mem_eof_return(b,v) \
                                 BIO_ctrl(b,BIO_C_SET_BUF_MEM_EOF_RETURN,v,NULL)
-
-# define BIO_set_initial_dgram_size(b,n) \
-                                BIO_ctrl(b, BIO_C_SET_INITIAL_DGRAM_SIZE, n, NULL)
 
 /* For the BIO_f_buffer() type */
 # define BIO_get_buffer_num_lines(b)     BIO_ctrl(b,BIO_C_GET_BUFF_NUM_LINES,0,NULL)
@@ -654,6 +649,7 @@ int BIO_nwrite0(BIO *bio, char **buf);
 int BIO_nwrite(BIO *bio, char **buf, int num);
 
 const BIO_METHOD *BIO_s_mem(void);
+const BIO_METHOD *BIO_s_dgram_mem(void);
 const BIO_METHOD *BIO_s_secmem(void);
 BIO *BIO_new_mem_buf(const void *buf, int len);
 # ifndef OPENSSL_NO_SOCK

--- a/include/openssl/bio.h.in
+++ b/include/openssl/bio.h.in
@@ -454,8 +454,6 @@ struct bio_dgram_sctp_prinfo {
 #  define BIO_get_accept_ip_family(b)   BIO_ctrl(b,BIO_C_GET_ACCEPT,4,NULL)
 #  define BIO_set_tfo_accept(b,n)       BIO_ctrl(b,BIO_C_SET_ACCEPT,5,(n)?(void *)"a":NULL)
 
-#  define BIO_set_initial_dgram_size(b,n)   BIO_ctrl(b, BIO_C_SET_INITIAL_DGRAM_SIZE, n, NULL)
-
 /* Aliases kept for backward compatibility */
 #  define BIO_BIND_NORMAL                 0
 #  define BIO_BIND_REUSEADDR              BIO_SOCK_REUSEADDR
@@ -527,6 +525,9 @@ int BIO_read_filename(BIO *b, const char *name);
                                           (char *)(pp))
 # define BIO_set_mem_eof_return(b,v) \
                                 BIO_ctrl(b,BIO_C_SET_BUF_MEM_EOF_RETURN,v,NULL)
+
+# define BIO_set_initial_dgram_size(b,n) \
+                                BIO_ctrl(b, BIO_C_SET_INITIAL_DGRAM_SIZE, n, NULL)
 
 /* For the BIO_f_buffer() type */
 # define BIO_get_buffer_num_lines(b)     BIO_ctrl(b,BIO_C_GET_BUFF_NUM_LINES,0,NULL)

--- a/include/openssl/bio.h.in
+++ b/include/openssl/bio.h.in
@@ -407,6 +407,8 @@ struct bio_dgram_sctp_prinfo {
 
 # define BIO_C_SET_TFO                           156 /* like BIO_C_SET_NBIO */
 
+# define BIO_C_SET_INITIAL_DGRAM_SIZE            157
+
 # define BIO_set_app_data(s,arg)         BIO_set_ex_data(s,0,arg)
 # define BIO_get_app_data(s)             BIO_get_ex_data(s,0)
 
@@ -451,6 +453,8 @@ struct bio_dgram_sctp_prinfo {
 #  define BIO_set_accept_ip_family(b,f) BIO_int_ctrl(b,BIO_C_SET_ACCEPT,4,f)
 #  define BIO_get_accept_ip_family(b)   BIO_ctrl(b,BIO_C_GET_ACCEPT,4,NULL)
 #  define BIO_set_tfo_accept(b,n)       BIO_ctrl(b,BIO_C_SET_ACCEPT,5,(n)?(void *)"a":NULL)
+
+#  define BIO_set_initial_dgram_size(b,n)   BIO_ctrl(b, BIO_C_SET_INITIAL_DGRAM_SIZE, n, NULL)
 
 /* Aliases kept for backward compatibility */
 #  define BIO_BIND_NORMAL                 0

--- a/test/build.info
+++ b/test/build.info
@@ -63,7 +63,7 @@ IF[{- !$disabled{tests} -}]
           keymgmt_internal_test hexstr_test provider_status_test defltfips_test \
           bio_readbuffer_test user_property_test pkcs7_test upcallstest \
           provfetchtest prov_config_test rand_test ca_internals_test \
-          bio_tfo_test
+          bio_tfo_test membio_test
 
   IF[{- !$disabled{'deprecated-3.0'} -}]
     PROGRAMS{noinst}=enginetest
@@ -390,6 +390,10 @@ IF[{- !$disabled{tests} -}]
   SOURCE[bio_tfo_test]=bio_tfo_test.c
   INCLUDE[bio_tfo_test]=../include ../apps/include ..
   DEPEND[bio_tfo_test]=../libcrypto libtestutil.a
+
+  SOURCE[membio_test]=membio_test.c
+  INCLUDE[membio_test]=../include ../apps/include ..
+  DEPEND[membio_test]=../libcrypto libtestutil.a
 
   SOURCE[params_api_test]=params_api_test.c
   INCLUDE[params_api_test]=../include ../apps/include

--- a/test/membio_test.c
+++ b/test/membio_test.c
@@ -14,7 +14,7 @@
 
 static int test_dgram(void)
 {
-    BIO *bio = BIO_new(BIO_s_mem()), *rbio;
+    BIO *bio = BIO_new(BIO_s_mem()), *rbio = NULL;
     int testresult = 0;
     const char msg1[] = "12345656";
     const char msg2[] = "abcdefghijklmno";

--- a/test/membio_test.c
+++ b/test/membio_test.c
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2022 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <openssl/bio.h>
+#include "testutil.h"
+
+
+
+static int test_dgram(void)
+{
+    BIO *bio = BIO_new(BIO_s_mem()), *rbio;
+    int testresult = 0;
+    const char msg1[] = "12345656";
+    const char msg2[] = "abcdefghijklmno";
+    const char msg3[] = "ABCDEF";
+    const char msg4[] = "FEDCBA";
+    char buf[80];
+
+    if (!TEST_ptr(bio))
+        goto err;
+
+    rbio = BIO_new_mem_buf(msg1, sizeof(msg1));
+    if (!TEST_ptr(rbio))
+        goto err;
+
+    /* Attempting to convert a read-only BIO to datagram semantics should fail */
+    if (!TEST_int_le(BIO_set_initial_dgram_size(rbio, 3), 0))
+        goto err;
+
+    /* Seeting the EOF return value on a non datagram mem BIO should be fine */
+    if (!TEST_int_gt(BIO_set_mem_eof_return(rbio, 0), 0))
+        goto err;
+
+    /* The initial dgram size must be greater than 0 */
+    if (!TEST_int_le(BIO_set_initial_dgram_size(bio, -1), 0)
+            || !TEST_int_le(BIO_set_initial_dgram_size(bio, 0), 0))
+        goto err;
+
+    /* Handle 3 dgrams initially */
+    if (!TEST_int_gt(BIO_set_initial_dgram_size(bio, 3), 0))
+        goto err;
+
+    /* Setting the EOF return value on a datagram mem BIO should fail */
+    if (!TEST_int_le(BIO_set_mem_eof_return(bio, 0), 0))
+        goto err;
+
+    /* Write 4 dgrams */
+    if (!TEST_int_eq(BIO_write(bio, msg1, sizeof(msg1)), sizeof(msg1)))
+        goto err;
+    if (!TEST_int_eq(BIO_write(bio, msg2, sizeof(msg2)), sizeof(msg2)))
+        goto err;
+    if (!TEST_int_eq(BIO_write(bio, msg3, sizeof(msg3)), sizeof(msg3)))
+        goto err;
+    /* Writing more dgrams that the initial buffer size should be fine */
+    if (!TEST_int_eq(BIO_write(bio, msg4, sizeof(msg4)), sizeof(msg4)))
+        goto err;
+
+    /* Reading all 4 dgrams out again should all be the correct size */
+    if (!TEST_int_eq(BIO_read(bio, buf, sizeof(buf)), sizeof(msg1))
+            || !TEST_mem_eq(buf, sizeof(msg1), msg1, sizeof(msg1))
+            || !TEST_int_eq(BIO_read(bio, buf, sizeof(buf)), sizeof(msg2))
+            || !TEST_mem_eq(buf, sizeof(msg2), msg2, sizeof(msg2))
+            || !TEST_int_eq(BIO_read(bio, buf, sizeof(buf)), sizeof(msg3))
+            || !TEST_mem_eq(buf, sizeof(msg3), msg3, sizeof(msg3))
+            || !TEST_int_eq(BIO_read(bio, buf, sizeof(buf)), sizeof(msg4))
+            || !TEST_mem_eq(buf, sizeof(msg4), msg4, sizeof(msg4))
+            || !TEST_int_lt(BIO_read(bio, buf, sizeof(buf)), 0))
+        goto err;
+
+    /* Interleaving writes and reads should be fine */
+    if (!TEST_int_eq(BIO_write(bio, msg1, sizeof(msg1)), sizeof(msg1)))
+        goto err;
+    if (!TEST_int_eq(BIO_write(bio, msg2, sizeof(msg2)), sizeof(msg2)))
+        goto err;
+    if (!TEST_int_eq(BIO_read(bio, buf, sizeof(buf)), sizeof(msg1))
+            || !TEST_mem_eq(buf, sizeof(msg1), msg1, sizeof(msg1)))
+        goto err;
+    if (!TEST_int_eq(BIO_write(bio, msg3, sizeof(msg3)), sizeof(msg3)))
+        goto err;
+    if (!TEST_int_eq(BIO_read(bio, buf, sizeof(buf)), sizeof(msg2))
+            || !TEST_mem_eq(buf, sizeof(msg2), msg2, sizeof(msg2))
+            || !TEST_int_eq(BIO_read(bio, buf, sizeof(buf)), sizeof(msg3))
+            || !TEST_mem_eq(buf, sizeof(msg3), msg3, sizeof(msg3)))
+        goto err;
+
+    /*
+     * Requesting less than the available data in a dgram should not impact the
+     * next packet.
+     */
+    if (!TEST_int_eq(BIO_write(bio, msg1, sizeof(msg1)), sizeof(msg1)))
+        goto err;
+    if (!TEST_int_eq(BIO_write(bio, msg2, sizeof(msg2)), sizeof(msg2)))
+        goto err;
+    if (!TEST_int_eq(BIO_read(bio, buf, /* Short buffer */ 2), 2)
+            || !TEST_mem_eq(buf, 2, msg1, 2))
+        goto err;
+    if (!TEST_int_eq(BIO_read(bio, buf, sizeof(buf)), sizeof(msg2))
+            || !TEST_mem_eq(buf, sizeof(msg2), msg2, sizeof(msg2)))
+        goto err;
+
+    /*
+     * Writing a zero length datagram will return zero, but no datagrams will
+     * be written. Attempting to read when there are no datagrams to read should
+     * return a negative result and indicate eof. Retry flags will be set.
+     */
+    if (!TEST_int_eq(BIO_write(bio, NULL, 0), 0)
+            || !TEST_int_lt(BIO_read(bio, buf, sizeof(buf)), 0)
+            || !TEST_true(BIO_eof(bio))
+            || !TEST_true(BIO_should_retry(bio)))
+        goto err;
+
+    testresult = 1;
+ err:
+    BIO_free(rbio);
+    BIO_free(bio);
+    return testresult;
+}
+
+
+int setup_tests(void)
+{
+    if (!test_skip_common_options()) {
+        TEST_error("Error parsing test options\n");
+        return 0;
+    }
+
+    ADD_TEST(test_dgram);
+
+    return 1;
+}

--- a/test/membio_test.c
+++ b/test/membio_test.c
@@ -10,8 +10,6 @@
 #include <openssl/bio.h>
 #include "testutil.h"
 
-
-
 static int test_dgram(void)
 {
     BIO *bio = BIO_new(BIO_s_dgram_mem()), *rbio = NULL;

--- a/test/recipes/04-test_membio.t
+++ b/test/recipes/04-test_membio.t
@@ -1,0 +1,16 @@
+#! /usr/bin/env perl
+# Copyright 2016-2022 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+use strict;
+use OpenSSL::Test;
+use OpenSSL::Test::Simple;
+use OpenSSL::Test::Utils;
+
+setup("test_membio");
+
+simple_test("test_membio", "membio_test");

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5447,3 +5447,4 @@ CMS_SignedData_new                      ?	3_1_0	EXIST::FUNCTION:CMS
 CMS_SignedData_verify                   ?	3_1_0	EXIST::FUNCTION:CMS
 OPENSSL_strcasecmp                      ?	3_0_3	EXIST::FUNCTION:
 OPENSSL_strncasecmp                     ?	3_0_3	EXIST::FUNCTION:
+BIO_s_dgram_mem                         ?	3_1_0	EXIST::FUNCTION:

--- a/util/other.syms
+++ b/util/other.syms
@@ -205,6 +205,7 @@ BIO_set_fd                              define
 BIO_set_fp                              define
 BIO_set_indent                          define
 BIO_set_info_callback                   define
+BIO_set_initial_dgram_size              define
 BIO_set_md                              define
 BIO_set_mem_buf                         define
 BIO_set_mem_eof_return                  define

--- a/util/other.syms
+++ b/util/other.syms
@@ -205,7 +205,6 @@ BIO_set_fd                              define
 BIO_set_fp                              define
 BIO_set_indent                          define
 BIO_set_info_callback                   define
-BIO_set_initial_dgram_size              define
 BIO_set_md                              define
 BIO_set_mem_buf                         define
 BIO_set_mem_eof_return                  define


### PR DESCRIPTION
We introduce a new BIO ctrl that switches a BIO_s_mem() into datagram
mode. Packet boundaries are respected.
