### PR TITLE
SSL_get_current_cipher() and SSL_get_pending_cipher() return values

### DIFF
--- a/doc/man3/SSL_get_current_cipher.pod
+++ b/doc/man3/SSL_get_current_cipher.pod
@@ -10,8 +10,8 @@ SSL_get_pending_cipher - get SSL_CIPHER of a connection
 
  #include <openssl/ssl.h>
 
- SSL_CIPHER *SSL_get_current_cipher(const SSL *ssl);
- SSL_CIPHER *SSL_get_pending_cipher(const SSL *ssl);
+ const SSL_CIPHER *SSL_get_current_cipher(const SSL *ssl);
+ const SSL_CIPHER *SSL_get_pending_cipher(const SSL *ssl);
 
  const char *SSL_get_cipher_name(const SSL *s);
  const char *SSL_get_cipher(const SSL *s);


### PR DESCRIPTION
`SSL_get_current_cipher()` returns `const SSL_CIPHER *` value type since version 1.0.0 according to this definition:
```c
const SSL_CIPHER *SSL_get_current_cipher(const SSL *s)
{
    if ((s->session != NULL) && (s->session->cipher != NULL))
        return s->session->cipher;
    return NULL;
}
```

`SSL_get_pending_cipher()` returns `const SSL_CIPHER *` value type  according to this definition:
```c
const SSL_CIPHER *SSL_get_pending_cipher(const SSL *s)
{
    return s->s3->tmp.new_cipher;
}
```

CLA: trivial