### PR TITLE
The flag "decoded-from-explicit" must be imp/exportable

### DIFF
--- a/crypto/ec/ec_backend.c
+++ b/crypto/ec/ec_backend.c
@@ -318,6 +318,11 @@ int ossl_ec_group_todata(const EC_GROUP *group, OSSL_PARAM_BLD *tmpl,
         return 0;
     }
 
+    if (!ossl_param_build_set_int(tmpl, params,
+                                  OSSL_PKEY_PARAM_EC_DECODED_FROM_EXPLICIT_PARAMS,
+                                  group->decoded_from_explicit_params))
+        return 0;
+
     curve_nid = EC_GROUP_get_curve_name(group);
 
     /*

--- a/providers/implementations/keymgmt/ec_kmgmt.c
+++ b/providers/implementations/keymgmt/ec_kmgmt.c
@@ -525,7 +525,8 @@ end:
     OSSL_PARAM_octet_string(OSSL_PKEY_PARAM_EC_GENERATOR, NULL, 0),            \
     OSSL_PARAM_BN(OSSL_PKEY_PARAM_EC_ORDER, NULL, 0),                          \
     OSSL_PARAM_BN(OSSL_PKEY_PARAM_EC_COFACTOR, NULL, 0),                       \
-    OSSL_PARAM_octet_string(OSSL_PKEY_PARAM_EC_SEED, NULL, 0)
+    OSSL_PARAM_octet_string(OSSL_PKEY_PARAM_EC_SEED, NULL, 0),                 \
+    OSSL_PARAM_int(OSSL_PKEY_PARAM_EC_DECODED_FROM_EXPLICIT_PARAMS, NULL)
 
 # define EC_IMEXPORTABLE_PUBLIC_KEY                                            \
     OSSL_PARAM_octet_string(OSSL_PKEY_PARAM_PUB_KEY, NULL, 0)

--- a/test/recipes/25-test_verify.t
+++ b/test/recipes/25-test_verify.t
@@ -12,7 +12,7 @@ use warnings;
 
 use File::Spec::Functions qw/canonpath/;
 use File::Copy;
-use OpenSSL::Test qw/:DEFAULT srctop_file ok_nofips with/;
+use OpenSSL::Test qw/:DEFAULT srctop_file bldtop_dir ok_nofips with/;
 use OpenSSL::Test::Utils;
 
 setup("test_verify");
@@ -29,7 +29,7 @@ sub verify {
     run(app([@args]));
 }
 
-plan tests => 169;
+plan tests => 172;
 
 # Canonical success
 ok(verify("ee-cert", "sslserver", ["root-cert"], ["ca-cert"]),
@@ -328,6 +328,29 @@ SKIP: {
     ok(verify("ee-cert-ec-named-named", "", ["root-cert"],
               ["ca-cert-ec-named"]),
         "accept named curve leaf with named curve intermediate");
+}
+# Same as above but with base provider used for decoding
+SKIP: {
+    my $no_fips = disabled('fips') || ($ENV{NO_FIPS} // 0);
+    skip "EC is not supported or FIPS is disabled", 3
+        if disabled("ec") || $no_fips;
+
+    my $provconf = srctop_file("test", "fips-and-base.cnf");
+    my $provpath = bldtop_dir("providers");
+    my @prov = ("-provider-path", $provpath);
+    $ENV{OPENSSL_CONF} = $provconf;
+
+    ok(!verify("ee-cert-ec-explicit", "", ["root-cert"],
+               ["ca-cert-ec-named"], @prov),
+        "reject explicit curve leaf with named curve intermediate w/fips");
+    ok(!verify("ee-cert-ec-named-explicit", "", ["root-cert"],
+               ["ca-cert-ec-explicit"], @prov),
+        "reject named curve leaf with explicit curve intermediate w/fips");
+    ok(verify("ee-cert-ec-named-named", "", ["root-cert"],
+              ["ca-cert-ec-named"], @prov),
+        "accept named curve leaf with named curve intermediate w/fips");
+
+    delete $ENV{OPENSSL_CONF};
 }
 
 # Depth tests, note the depth limit bounds the number of CA certificates


### PR DESCRIPTION
Otherwise the information that the EC group was imported from
explicit parameters is lost when the key is moved across providers.

Fixes #18600

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
