### PR TITLE
SSL object refactoring using SSL_CONNECTION object

### DIFF
--- a/ssl/d1_srtp.c
+++ b/ssl/d1_srtp.c
@@ -144,14 +144,21 @@ int SSL_CTX_set_tlsext_use_srtp(SSL_CTX *ctx, const char *profiles)
 
 int SSL_set_tlsext_use_srtp(SSL *s, const char *profiles)
 {
-    return ssl_ctx_make_profiles(profiles, &s->srtp_profiles);
+    SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL_ONLY(s);
+
+    if (sc == NULL)
+        return 0;
+
+    return ssl_ctx_make_profiles(profiles, &sc->srtp_profiles);
 }
 
 STACK_OF(SRTP_PROTECTION_PROFILE) *SSL_get_srtp_profiles(SSL *s)
 {
-    if (s != NULL) {
-        if (s->srtp_profiles != NULL) {
-            return s->srtp_profiles;
+    SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL_ONLY(s);
+
+    if (sc != NULL) {
+        if (sc->srtp_profiles != NULL) {
+            return sc->srtp_profiles;
         } else if ((s->ctx != NULL) && (s->ctx->srtp_profiles != NULL)) {
             return s->ctx->srtp_profiles;
         }
@@ -162,6 +169,11 @@ STACK_OF(SRTP_PROTECTION_PROFILE) *SSL_get_srtp_profiles(SSL *s)
 
 SRTP_PROTECTION_PROFILE *SSL_get_selected_srtp_profile(SSL *s)
 {
-    return s->srtp_profile;
+    SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL_ONLY(s);
+
+    if (sc == NULL)
+        return 0;
+
+    return sc->srtp_profile;
 }
 #endif

--- a/ssl/ktls.c
+++ b/ssl/ktls.c
@@ -18,7 +18,7 @@
   * record layer. If read_ahead is enabled, then this might be false and this
   * function will fail.
   */
-static int count_unprocessed_records(SSL *s)
+static int count_unprocessed_records(SSL_CONNECTION *s)
 {
     SSL3_BUFFER *rbuf = RECORD_LAYER_get_rbuf(&s->rlayer);
     PACKET pkt, subpkt;
@@ -48,7 +48,7 @@ static int count_unprocessed_records(SSL *s)
  * partial record, fail and return 0.  Otherwise, update the sequence
  * number at *rec_seq for the count of unprocessed records and return 1.
  */
-static int check_rx_read_ahead(SSL *s, unsigned char *rec_seq)
+static int check_rx_read_ahead(SSL_CONNECTION *s, unsigned char *rec_seq)
 {
     int bit, count_unprocessed;
 
@@ -80,7 +80,7 @@ static int check_rx_read_ahead(SSL *s, unsigned char *rec_seq)
  * provider is found, but this checks if the socket option
  * supports the cipher suite used at all.
  */
-int ktls_check_supported_cipher(const SSL *s, const EVP_CIPHER *c,
+int ktls_check_supported_cipher(const SSL_CONNECTION *s, const EVP_CIPHER *c,
                                 const EVP_CIPHER_CTX *dd)
 {
 
@@ -120,7 +120,8 @@ int ktls_check_supported_cipher(const SSL *s, const EVP_CIPHER *c,
 }
 
 /* Function to configure kernel TLS structure */
-int ktls_configure_crypto(SSL *s, const EVP_CIPHER *c, EVP_CIPHER_CTX *dd,
+int ktls_configure_crypto(SSL_CONNECTION *s, const EVP_CIPHER *c,
+                          EVP_CIPHER_CTX *dd,
                           void *rl_sequence, ktls_crypto_info_t *crypto_info,
                           int is_tx, unsigned char *iv,
                           unsigned char *key, unsigned char *mac_key,
@@ -186,7 +187,7 @@ int ktls_configure_crypto(SSL *s, const EVP_CIPHER *c, EVP_CIPHER_CTX *dd,
 #if defined(OPENSSL_SYS_LINUX)
 
 /* Function to check supported ciphers in Linux */
-int ktls_check_supported_cipher(const SSL *s, const EVP_CIPHER *c,
+int ktls_check_supported_cipher(const SSL_CONNECTION *s, const EVP_CIPHER *c,
                                 const EVP_CIPHER_CTX *dd)
 {
     switch (s->version) {
@@ -225,7 +226,8 @@ int ktls_check_supported_cipher(const SSL *s, const EVP_CIPHER *c,
 }
 
 /* Function to configure kernel TLS structure */
-int ktls_configure_crypto(SSL *s, const EVP_CIPHER *c, EVP_CIPHER_CTX *dd,
+int ktls_configure_crypto(SSL_CONNECTION *s, const EVP_CIPHER *c,
+                          EVP_CIPHER_CTX *dd,
                           void *rl_sequence, ktls_crypto_info_t *crypto_info,
                           int is_tx, unsigned char *iv,
                           unsigned char *key, unsigned char *mac_key,

--- a/ssl/priority_queue.c
+++ b/ssl/priority_queue.c
@@ -356,7 +356,7 @@ void ossl_pqueue_free(OSSL_PQUEUE *pq)
         OPENSSL_free(pq->heap);
         OPENSSL_free(pq->elements);
         OPENSSL_free(pq);
-    }    
+    }
 }
 
 void ossl_pqueue_pop_free(OSSL_PQUEUE *pq, void (*freefunc)(void *))

--- a/ssl/record/dtls1_bitmap.c
+++ b/ssl/record/dtls1_bitmap.c
@@ -35,7 +35,7 @@ static int satsub64be(const unsigned char *v1, const unsigned char *v2)
         return (int)ret;
 }
 
-int dtls1_record_replay_check(SSL *s, DTLS1_BITMAP *bitmap)
+int dtls1_record_replay_check(SSL_CONNECTION *s, DTLS1_BITMAP *bitmap)
 {
     int cmp;
     unsigned int shift;
@@ -56,7 +56,7 @@ int dtls1_record_replay_check(SSL *s, DTLS1_BITMAP *bitmap)
     return 1;
 }
 
-void dtls1_record_bitmap_update(SSL *s, DTLS1_BITMAP *bitmap)
+void dtls1_record_bitmap_update(SSL_CONNECTION *s, DTLS1_BITMAP *bitmap)
 {
     int cmp;
     unsigned int shift;

--- a/ssl/record/record.h
+++ b/ssl/record/record.h
@@ -7,6 +7,8 @@
  * https://www.openssl.org/source/license.html
  */
 
+typedef struct ssl_connection_st SSL_CONNECTION;
+
 /*****************************************************************************
  *                                                                           *
  * These structures should be considered PRIVATE to the record layer. No     *
@@ -127,8 +129,8 @@ typedef struct dtls_record_layer_st {
  *****************************************************************************/
 
 typedef struct record_layer_st {
-    /* The parent SSL structure */
-    SSL *s;
+    /* The parent SSL_CONNECTION structure */
+    SSL_CONNECTION *s;
     /*
      * Read as many input bytes as possible (for
      * non-blocking reads)
@@ -199,7 +201,7 @@ typedef struct ssl_mac_buf_st SSL_MAC_BUF;
 #define RECORD_LAYER_get_rbuf(rl)               (&(rl)->rbuf)
 #define RECORD_LAYER_get_wbuf(rl)               ((rl)->wbuf)
 
-void RECORD_LAYER_init(RECORD_LAYER *rl, SSL *s);
+void RECORD_LAYER_init(RECORD_LAYER *rl, SSL_CONNECTION *s);
 void RECORD_LAYER_clear(RECORD_LAYER *rl);
 void RECORD_LAYER_release(RECORD_LAYER *rl);
 int RECORD_LAYER_read_pending(const RECORD_LAYER *rl);
@@ -212,23 +214,26 @@ size_t RECORD_LAYER_get_rrec_length(RECORD_LAYER *rl);
 __owur size_t ssl3_pending(const SSL *s);
 __owur int ssl3_write_bytes(SSL *s, int type, const void *buf, size_t len,
                             size_t *written);
-int do_ssl3_write(SSL *s, int type, const unsigned char *buf,
+int do_ssl3_write(SSL_CONNECTION *s, int type, const unsigned char *buf,
                   size_t *pipelens, size_t numpipes,
                   int create_empty_fragment, size_t *written);
 __owur int ssl3_read_bytes(SSL *s, int type, int *recvd_type,
                            unsigned char *buf, size_t len, int peek,
                            size_t *readbytes);
-__owur int ssl3_setup_buffers(SSL *s);
-__owur int ssl3_enc(SSL *s, SSL3_RECORD *inrecs, size_t n_recs, int send,
-                    SSL_MAC_BUF *mac, size_t macsize);
-__owur int n_ssl3_mac(SSL *ssl, SSL3_RECORD *rec, unsigned char *md, int send);
-__owur int ssl3_write_pending(SSL *s, int type, const unsigned char *buf, size_t len,
+__owur int ssl3_setup_buffers(SSL_CONNECTION *s);
+__owur int ssl3_enc(SSL_CONNECTION *s, SSL3_RECORD *inrecs, size_t n_recs,
+                    int send, SSL_MAC_BUF *mac, size_t macsize);
+__owur int n_ssl3_mac(SSL_CONNECTION *s, SSL3_RECORD *rec, unsigned char *md,
+                      int send);
+__owur int ssl3_write_pending(SSL_CONNECTION *s, int type,
+                              const unsigned char *buf, size_t len,
                               size_t *written);
-__owur int tls1_enc(SSL *s, SSL3_RECORD *recs, size_t n_recs, int sending,
-                    SSL_MAC_BUF *mac, size_t macsize);
-__owur int tls1_mac(SSL *ssl, SSL3_RECORD *rec, unsigned char *md, int send);
-__owur int tls13_enc(SSL *s, SSL3_RECORD *recs, size_t n_recs, int send,
-                     SSL_MAC_BUF *mac, size_t macsize);
+__owur int tls1_enc(SSL_CONNECTION *s, SSL3_RECORD *recs, size_t n_recs,
+                    int sending, SSL_MAC_BUF *mac, size_t macsize);
+__owur int tls1_mac(SSL_CONNECTION *s, SSL3_RECORD *rec, unsigned char *md,
+                    int send);
+__owur int tls13_enc(SSL_CONNECTION *s, SSL3_RECORD *recs, size_t n_recs,
+                     int send, SSL_MAC_BUF *mac, size_t macsize);
 int DTLS_RECORD_LAYER_new(RECORD_LAYER *rl);
 void DTLS_RECORD_LAYER_free(RECORD_LAYER *rl);
 void DTLS_RECORD_LAYER_clear(RECORD_LAYER *rl);
@@ -238,10 +243,10 @@ void DTLS_RECORD_LAYER_set_write_sequence(RECORD_LAYER *rl, unsigned char *seq);
 __owur int dtls1_read_bytes(SSL *s, int type, int *recvd_type,
                             unsigned char *buf, size_t len, int peek,
                             size_t *readbytes);
-__owur int dtls1_write_bytes(SSL *s, int type, const void *buf, size_t len,
-                             size_t *written);
-int do_dtls1_write(SSL *s, int type, const unsigned char *buf,
+__owur int dtls1_write_bytes(SSL_CONNECTION *s, int type, const void *buf,
+                             size_t len, size_t *written);
+int do_dtls1_write(SSL_CONNECTION *s, int type, const unsigned char *buf,
                    size_t len, int create_empty_fragment, size_t *written);
-void dtls1_reset_seq_numbers(SSL *s, int rw);
-int dtls_buffer_listen_record(SSL *s, size_t len, unsigned char *seq,
+void dtls1_reset_seq_numbers(SSL_CONNECTION *s, int rw);
+int dtls_buffer_listen_record(SSL_CONNECTION *s, size_t len, unsigned char *seq,
                               size_t off);

--- a/ssl/record/record_local.h
+++ b/ssl/record/record_local.h
@@ -36,20 +36,21 @@
 #define RECORD_LAYER_clear_first_record(rl)     ((rl)->is_first_record = 0)
 #define DTLS_RECORD_LAYER_get_r_epoch(rl)       ((rl)->d->r_epoch)
 
-__owur int ssl3_read_n(SSL *s, size_t n, size_t max, int extend, int clearold,
-                       size_t *readbytes);
+__owur int ssl3_read_n(SSL_CONNECTION *s, size_t n, size_t max, int extend,
+                       int clearold, size_t *readbytes);
 
-DTLS1_BITMAP *dtls1_get_bitmap(SSL *s, SSL3_RECORD *rr,
+DTLS1_BITMAP *dtls1_get_bitmap(SSL_CONNECTION *s, SSL3_RECORD *rr,
                                unsigned int *is_next_epoch);
-int dtls1_process_buffered_records(SSL *s);
-int dtls1_retrieve_buffered_record(SSL *s, record_pqueue *queue);
-int dtls1_buffer_record(SSL *s, record_pqueue *q, unsigned char *priority);
+int dtls1_process_buffered_records(SSL_CONNECTION *s);
+int dtls1_retrieve_buffered_record(SSL_CONNECTION *s, record_pqueue *queue);
+int dtls1_buffer_record(SSL_CONNECTION *s, record_pqueue *q,
+                        unsigned char *priority);
 void ssl3_record_sequence_update(unsigned char *seq);
 
 /* Functions provided by the DTLS1_BITMAP component */
 
-int dtls1_record_replay_check(SSL *s, DTLS1_BITMAP *bitmap);
-void dtls1_record_bitmap_update(SSL *s, DTLS1_BITMAP *bitmap);
+int dtls1_record_replay_check(SSL_CONNECTION *s, DTLS1_BITMAP *bitmap);
+void dtls1_record_bitmap_update(SSL_CONNECTION *s, DTLS1_BITMAP *bitmap);
 
 /* Macros/functions provided by the SSL3_BUFFER component */
 
@@ -71,10 +72,11 @@ void dtls1_record_bitmap_update(SSL *s, DTLS1_BITMAP *bitmap);
 void SSL3_BUFFER_clear(SSL3_BUFFER *b);
 void SSL3_BUFFER_set_data(SSL3_BUFFER *b, const unsigned char *d, size_t n);
 void SSL3_BUFFER_release(SSL3_BUFFER *b);
-__owur int ssl3_setup_read_buffer(SSL *s);
-__owur int ssl3_setup_write_buffer(SSL *s, size_t numwpipes, size_t len);
-int ssl3_release_read_buffer(SSL *s);
-int ssl3_release_write_buffer(SSL *s);
+__owur int ssl3_setup_read_buffer(SSL_CONNECTION *s);
+__owur int ssl3_setup_write_buffer(SSL_CONNECTION *s, size_t numwpipes,
+                                   size_t len);
+int ssl3_release_read_buffer(SSL_CONNECTION *s);
+int ssl3_release_write_buffer(SSL_CONNECTION *s);
 
 /* Macros/functions provided by the SSL3_RECORD component */
 
@@ -104,9 +106,9 @@ int ssl3_release_write_buffer(SSL *s);
 void SSL3_RECORD_clear(SSL3_RECORD *r, size_t);
 void SSL3_RECORD_release(SSL3_RECORD *r, size_t num_recs);
 void SSL3_RECORD_set_seq_num(SSL3_RECORD *r, const unsigned char *seq_num);
-int ssl3_get_record(SSL *s);
-__owur int ssl3_do_compress(SSL *ssl, SSL3_RECORD *wr);
-__owur int ssl3_do_uncompress(SSL *ssl, SSL3_RECORD *rr);
+int ssl3_get_record(SSL_CONNECTION *s);
+__owur int ssl3_do_compress(SSL_CONNECTION *ssl, SSL3_RECORD *wr);
+__owur int ssl3_do_uncompress(SSL_CONNECTION *ssl, SSL3_RECORD *rr);
 __owur int ssl3_cbc_remove_padding_and_mac(size_t *reclen,
                                            size_t origreclen,
                                            unsigned char *recdata,
@@ -122,6 +124,7 @@ __owur int tls1_cbc_remove_padding_and_mac(size_t *reclen,
                                            size_t block_size, size_t mac_size,
                                            int aead,
                                            OSSL_LIB_CTX *libctx);
-int dtls1_process_record(SSL *s, DTLS1_BITMAP *bitmap);
-__owur int dtls1_get_record(SSL *s);
-int early_data_count_ok(SSL *s, size_t length, size_t overhead, int send);
+int dtls1_process_record(SSL_CONNECTION *s, DTLS1_BITMAP *bitmap);
+__owur int dtls1_get_record(SSL_CONNECTION *s);
+int ossl_early_data_count_ok(SSL_CONNECTION *s, size_t length,
+                             size_t overhead, int send);

--- a/ssl/record/ssl3_buffer.c
+++ b/ssl/record/ssl3_buffer.c
@@ -34,7 +34,7 @@ void SSL3_BUFFER_release(SSL3_BUFFER *b)
     b->buf = NULL;
 }
 
-int ssl3_setup_read_buffer(SSL *s)
+int ssl3_setup_read_buffer(SSL_CONNECTION *s)
 {
     unsigned char *p;
     size_t len, align = 0, headerlen;
@@ -42,7 +42,7 @@ int ssl3_setup_read_buffer(SSL *s)
 
     b = RECORD_LAYER_get_rbuf(&s->rlayer);
 
-    if (SSL_IS_DTLS(s))
+    if (SSL_CONNECTION_IS_DTLS(s))
         headerlen = DTLS1_RT_HEADER_LENGTH;
     else
         headerlen = SSL3_RT_HEADER_LENGTH;
@@ -76,7 +76,8 @@ int ssl3_setup_read_buffer(SSL *s)
     return 1;
 }
 
-int ssl3_setup_write_buffer(SSL *s, size_t numwpipes, size_t len)
+int ssl3_setup_write_buffer(SSL_CONNECTION *s, size_t numwpipes,
+                            size_t len)
 {
     unsigned char *p;
     size_t align = 0, headerlen;
@@ -86,7 +87,7 @@ int ssl3_setup_write_buffer(SSL *s, size_t numwpipes, size_t len)
     s->rlayer.numwpipes = numwpipes;
 
     if (len == 0) {
-        if (SSL_IS_DTLS(s))
+        if (SSL_CONNECTION_IS_DTLS(s))
             headerlen = DTLS1_RT_HEADER_LENGTH + 1;
         else
             headerlen = SSL3_RT_HEADER_LENGTH;
@@ -139,7 +140,7 @@ int ssl3_setup_write_buffer(SSL *s, size_t numwpipes, size_t len)
     return 1;
 }
 
-int ssl3_setup_buffers(SSL *s)
+int ssl3_setup_buffers(SSL_CONNECTION *s)
 {
     if (!ssl3_setup_read_buffer(s)) {
         /* SSLfatal() already called */
@@ -152,7 +153,7 @@ int ssl3_setup_buffers(SSL *s)
     return 1;
 }
 
-int ssl3_release_write_buffer(SSL *s)
+int ssl3_release_write_buffer(SSL_CONNECTION *s)
 {
     SSL3_BUFFER *wb;
     size_t pipes;
@@ -172,7 +173,7 @@ int ssl3_release_write_buffer(SSL *s)
     return 1;
 }
 
-int ssl3_release_read_buffer(SSL *s)
+int ssl3_release_read_buffer(SSL_CONNECTION *s)
 {
     SSL3_BUFFER *b;
 

--- a/ssl/record/ssl3_record.c
+++ b/ssl/record/ssl3_record.c
@@ -67,7 +67,7 @@ void SSL3_RECORD_set_seq_num(SSL3_RECORD *r, const unsigned char *seq_num)
  * Peeks ahead into "read_ahead" data to see if we have a whole record waiting
  * for us in the buffer.
  */
-static int ssl3_record_app_data_waiting(SSL *s)
+static int ssl3_record_app_data_waiting(SSL_CONNECTION *s)
 {
     SSL3_BUFFER *rbuf;
     size_t left, len;
@@ -102,7 +102,8 @@ static int ssl3_record_app_data_waiting(SSL *s)
     return 1;
 }
 
-int early_data_count_ok(SSL *s, size_t length, size_t overhead, int send)
+int ossl_early_data_count_ok(SSL_CONNECTION *s, size_t length,
+                             size_t overhead, int send)
 {
     uint32_t max_early_data;
     SSL_SESSION *sess = s->session;
@@ -170,7 +171,7 @@ int early_data_count_ok(SSL *s, size_t length, size_t overhead, int send)
  * |max_pipelines|
  */
 /* used only by ssl3_read_bytes */
-int ssl3_get_record(SSL *s)
+int ssl3_get_record(SSL_CONNECTION *s)
 {
     int enc_err, rret;
     int i;
@@ -188,6 +189,7 @@ int ssl3_get_record(SSL *s)
     int using_ktls;
     SSL_MAC_BUF *macbufs = NULL;
     int ret = -1;
+    SSL *ssl = SSL_CONNECTION_GET_SSL(s);
 
     rr = RECORD_LAYER_get_rrec(&s->rlayer);
     rbuf = RECORD_LAYER_get_rbuf(&s->rlayer);
@@ -291,7 +293,7 @@ int ssl3_get_record(SSL *s)
                         || !PACKET_get_net_2(&pkt, &version)
                         || !PACKET_get_net_2_len(&pkt, &thisrr->length)) {
                     if (s->msg_callback)
-                        s->msg_callback(0, 0, SSL3_RT_HEADER, p, 5, s,
+                        s->msg_callback(0, 0, SSL3_RT_HEADER, p, 5, ssl,
                                         s->msg_callback_arg);
                     SSLfatal(s, SSL_AD_DECODE_ERROR, ERR_R_INTERNAL_ERROR);
                     return -1;
@@ -300,7 +302,7 @@ int ssl3_get_record(SSL *s)
                 thisrr->rec_version = version;
 
                 if (s->msg_callback)
-                    s->msg_callback(0, version, SSL3_RT_HEADER, p, 5, s,
+                    s->msg_callback(0, version, SSL3_RT_HEADER, p, 5, ssl,
                                     s->msg_callback_arg);
 
                 /*
@@ -310,7 +312,7 @@ int ssl3_get_record(SSL *s)
                  * yet, but we still treat it as TLSv1.3, so we must check for
                  * that explicitly
                  */
-                if (!s->first_packet && !SSL_IS_TLS13(s)
+                if (!s->first_packet && !SSL_CONNECTION_IS_TLS13(s)
                         && s->hello_retry_request != SSL_HRR_PENDING
                         && version != (unsigned int)s->version) {
                     if ((s->version & 0xFF00) == (version & 0xFF00)
@@ -366,7 +368,7 @@ int ssl3_get_record(SSL *s)
                     }
                 }
 
-                if (SSL_IS_TLS13(s)
+                if (SSL_CONNECTION_IS_TLS13(s)
                         && s->enc_read_ctx != NULL
                         && !using_ktls) {
                     if (thisrr->type != SSL3_RT_APPLICATION_DATA
@@ -397,7 +399,7 @@ int ssl3_get_record(SSL *s)
             /* now s->rlayer.rstate == SSL_ST_READ_BODY */
         }
 
-        if (SSL_IS_TLS13(s)) {
+        if (SSL_CONNECTION_IS_TLS13(s)) {
             size_t len = SSL3_RT_MAX_TLS13_ENCRYPTED_LENGTH;
 
             /* KTLS strips the inner record type. */
@@ -503,7 +505,8 @@ int ssl3_get_record(SSL *s)
 
     if (num_recs == 1
             && thisrr->type == SSL3_RT_CHANGE_CIPHER_SPEC
-            && (SSL_IS_TLS13(s) || s->hello_retry_request != SSL_HRR_NONE)
+            && (SSL_CONNECTION_IS_TLS13(s)
+                || s->hello_retry_request != SSL_HRR_NONE)
             && SSL_IS_FIRST_HANDSHAKE(s)) {
         /*
          * CCS messages must be exactly 1 byte long, containing the value 0x01
@@ -563,7 +566,7 @@ int ssl3_get_record(SSL *s)
             }
             thisrr->length -= mac_size;
             mac = thisrr->data + thisrr->length;
-            i = s->method->ssl3_enc->mac(s, thisrr, md, 0 /* not send */ );
+            i = ssl->method->ssl3_enc->mac(s, thisrr, md, 0 /* not send */ );
             if (i == 0 || CRYPTO_memcmp(md, mac, mac_size) != 0) {
                 SSLfatal(s, SSL_AD_BAD_RECORD_MAC,
                          SSL_R_DECRYPTION_FAILED_OR_BAD_RECORD_MAC);
@@ -585,7 +588,7 @@ int ssl3_get_record(SSL *s)
         }
     }
 
-    enc_err = s->method->ssl3_enc->enc(s, rr, num_recs, 0, macbufs, mac_size);
+    enc_err = ssl->method->ssl3_enc->enc(s, rr, num_recs, 0, macbufs, mac_size);
 
     /*-
      * enc_err is:
@@ -606,8 +609,8 @@ int ssl3_get_record(SSL *s)
 
             thisrr = &rr[0];
 
-            if (!early_data_count_ok(s, thisrr->length,
-                                     EARLY_DATA_CIPHERTEXT_OVERHEAD, 0)) {
+            if (!ossl_early_data_count_ok(s, thisrr->length,
+                                          EARLY_DATA_CIPHERTEXT_OVERHEAD, 0)) {
                 /* SSLfatal() already called */
                 goto end;
             }
@@ -638,7 +641,7 @@ int ssl3_get_record(SSL *s)
             SSL_MAC_BUF *thismb = &macbufs[j];
             thisrr = &rr[j];
 
-            i = s->method->ssl3_enc->mac(s, thisrr, md, 0 /* not send */ );
+            i = ssl->method->ssl3_enc->mac(s, thisrr, md, 0 /* not send */ );
             if (i == 0 || thismb == NULL || thismb->mac == NULL
                 || CRYPTO_memcmp(md, thismb->mac, (size_t)mac_size) != 0)
                 enc_err = 0;
@@ -683,7 +686,7 @@ int ssl3_get_record(SSL *s)
             }
         }
 
-        if (SSL_IS_TLS13(s)
+        if (SSL_CONNECTION_IS_TLS13(s)
                 && s->enc_read_ctx != NULL
                 && thisrr->type != SSL3_RT_ALERT) {
             /*
@@ -717,14 +720,14 @@ int ssl3_get_record(SSL *s)
             }
             if (s->msg_callback)
                 s->msg_callback(0, s->version, SSL3_RT_INNER_CONTENT_TYPE,
-                                &thisrr->type, 1, s, s->msg_callback_arg);
+                                &thisrr->type, 1, ssl, s->msg_callback_arg);
         }
 
         /*
          * TLSv1.3 alert and handshake records are required to be non-zero in
          * length.
          */
-        if (SSL_IS_TLS13(s)
+        if (SSL_CONNECTION_IS_TLS13(s)
                 && (thisrr->type == SSL3_RT_HANDSHAKE
                     || thisrr->type == SSL3_RT_ALERT)
                 && thisrr->length == 0) {
@@ -781,7 +784,7 @@ int ssl3_get_record(SSL *s)
     if (s->early_data_state == SSL_EARLY_DATA_READING) {
         thisrr = &rr[0];
         if (thisrr->type == SSL3_RT_APPLICATION_DATA
-                && !early_data_count_ok(s, thisrr->length, 0, 0)) {
+                && !ossl_early_data_count_ok(s, thisrr->length, 0, 0)) {
             /* SSLfatal already called */
             goto end;
         }
@@ -800,7 +803,7 @@ int ssl3_get_record(SSL *s)
     return ret;
 }
 
-int ssl3_do_uncompress(SSL *ssl, SSL3_RECORD *rr)
+int ssl3_do_uncompress(SSL_CONNECTION *sc, SSL3_RECORD *rr)
 {
 #ifndef OPENSSL_NO_COMP
     int i;
@@ -812,7 +815,7 @@ int ssl3_do_uncompress(SSL *ssl, SSL3_RECORD *rr)
     if (rr->comp == NULL)
         return 0;
 
-    i = COMP_expand_block(ssl->expand, rr->comp,
+    i = COMP_expand_block(sc->expand, rr->comp,
                           SSL3_RT_MAX_PLAIN_LENGTH, rr->data, (int)rr->length);
     if (i < 0)
         return 0;
@@ -823,12 +826,12 @@ int ssl3_do_uncompress(SSL *ssl, SSL3_RECORD *rr)
     return 1;
 }
 
-int ssl3_do_compress(SSL *ssl, SSL3_RECORD *wr)
+int ssl3_do_compress(SSL_CONNECTION *sc, SSL3_RECORD *wr)
 {
 #ifndef OPENSSL_NO_COMP
     int i;
 
-    i = COMP_compress_block(ssl->compress, wr->data,
+    i = COMP_compress_block(sc->compress, wr->data,
                             (int)(wr->length + SSL3_RT_MAX_COMPRESSED_OVERHEAD),
                             wr->input, (int)wr->length);
     if (i < 0)
@@ -850,7 +853,7 @@ int ssl3_do_compress(SSL *ssl, SSL3_RECORD *wr)
  *    0: if the record is publicly invalid, or an internal error
  *    1: Success or Mac-then-encrypt decryption failed (MAC will be randomised)
  */
-int ssl3_enc(SSL *s, SSL3_RECORD *inrecs, size_t n_recs, int sending,
+int ssl3_enc(SSL_CONNECTION *s, SSL3_RECORD *inrecs, size_t n_recs, int sending,
              SSL_MAC_BUF *mac, size_t macsize)
 {
     SSL3_RECORD *rec;
@@ -957,7 +960,7 @@ int ssl3_enc(SSL *s, SSL3_RECORD *inrecs, size_t n_recs, int sending,
                                            (mac != NULL) ? &mac->alloced : NULL,
                                            bs,
                                            macsize,
-                                           s->ctx->libctx);
+                                           SSL_CONNECTION_GET_CTX(s)->libctx);
         }
     }
     return 1;
@@ -974,7 +977,7 @@ int ssl3_enc(SSL *s, SSL3_RECORD *inrecs, size_t n_recs, int sending,
  *       decryption failed, or Encrypt-then-mac decryption failed.
  *    1: Success or Mac-then-encrypt decryption failed (MAC will be randomised)
  */
-int tls1_enc(SSL *s, SSL3_RECORD *recs, size_t n_recs, int sending,
+int tls1_enc(SSL_CONNECTION *s, SSL3_RECORD *recs, size_t n_recs, int sending,
              SSL_MAC_BUF *macs, size_t macsize)
 {
     EVP_CIPHER_CTX *ds;
@@ -1022,7 +1025,8 @@ int tls1_enc(SSL *s, SSL3_RECORD *recs, size_t n_recs, int sending,
                          */
                         SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
                         return 0;
-                    } else if (RAND_bytes_ex(s->ctx->libctx, recs[ctr].input,
+                    } else if (RAND_bytes_ex(SSL_CONNECTION_GET_CTX(s)->libctx,
+                                             recs[ctr].input,
                                              ivlen, 0) <= 0) {
                         SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
                         return 0;
@@ -1076,7 +1080,7 @@ int tls1_enc(SSL *s, SSL3_RECORD *recs, size_t n_recs, int sending,
                 seq = sending ? RECORD_LAYER_get_write_sequence(&s->rlayer)
                     : RECORD_LAYER_get_read_sequence(&s->rlayer);
 
-                if (SSL_IS_DTLS(s)) {
+                if (SSL_CONNECTION_IS_DTLS(s)) {
                     /* DTLS does not support pipelining */
                     unsigned char dtlsseq[8], *p = dtlsseq;
 
@@ -1163,7 +1167,7 @@ int tls1_enc(SSL *s, SSL3_RECORD *recs, size_t n_recs, int sending,
             }
         }
 
-        if (!SSL_IS_DTLS(s) && tlstree_enc) {
+        if (!SSL_CONNECTION_IS_DTLS(s) && tlstree_enc) {
             unsigned char *seq;
             int decrement_seq = 0;
 
@@ -1282,7 +1286,7 @@ int tls1_enc(SSL *s, SSL3_RECORD *recs, size_t n_recs, int sending,
                                          pad ? (size_t)pad : macsize,
                                          (EVP_CIPHER_get_flags(enc)
                                          & EVP_CIPH_FLAG_AEAD_CIPHER) != 0,
-                                         s->ctx->libctx))
+                                         SSL_CONNECTION_GET_CTX(s)->libctx))
                         return 0;
                 }
             }
@@ -1310,7 +1314,8 @@ char ssl3_cbc_record_digest_supported(const EVP_MD_CTX *ctx)
     }
 }
 
-int n_ssl3_mac(SSL *ssl, SSL3_RECORD *rec, unsigned char *md, int sending)
+int n_ssl3_mac(SSL_CONNECTION *sc, SSL3_RECORD *rec, unsigned char *md,
+               int sending)
 {
     unsigned char *mac_sec, *seq;
     const EVP_MD_CTX *hash;
@@ -1320,13 +1325,13 @@ int n_ssl3_mac(SSL *ssl, SSL3_RECORD *rec, unsigned char *md, int sending)
     int t;
 
     if (sending) {
-        mac_sec = &(ssl->s3.write_mac_secret[0]);
-        seq = RECORD_LAYER_get_write_sequence(&ssl->rlayer);
-        hash = ssl->write_hash;
+        mac_sec = &(sc->s3.write_mac_secret[0]);
+        seq = RECORD_LAYER_get_write_sequence(&sc->rlayer);
+        hash = sc->write_hash;
     } else {
-        mac_sec = &(ssl->s3.read_mac_secret[0]);
-        seq = RECORD_LAYER_get_read_sequence(&ssl->rlayer);
-        hash = ssl->read_hash;
+        mac_sec = &(sc->s3.read_mac_secret[0]);
+        seq = RECORD_LAYER_get_read_sequence(&sc->rlayer);
+        hash = sc->read_hash;
     }
 
     t = EVP_MD_CTX_get_size(hash);
@@ -1336,7 +1341,7 @@ int n_ssl3_mac(SSL *ssl, SSL3_RECORD *rec, unsigned char *md, int sending)
     npad = (48 / md_size) * md_size;
 
     if (!sending
-        && EVP_CIPHER_CTX_get_mode(ssl->enc_read_ctx) == EVP_CIPH_CBC_MODE
+        && EVP_CIPHER_CTX_get_mode(sc->enc_read_ctx) == EVP_CIPH_CBC_MODE
         && ssl3_cbc_record_digest_supported(hash)) {
 #ifdef OPENSSL_NO_DEPRECATED_3_0
         return 0;
@@ -1410,7 +1415,8 @@ int n_ssl3_mac(SSL *ssl, SSL3_RECORD *rec, unsigned char *md, int sending)
     return 1;
 }
 
-int tls1_mac(SSL *ssl, SSL3_RECORD *rec, unsigned char *md, int sending)
+int tls1_mac(SSL_CONNECTION *sc, SSL3_RECORD *rec, unsigned char *md,
+             int sending)
 {
     unsigned char *seq;
     EVP_MD_CTX *hash;
@@ -1418,19 +1424,19 @@ int tls1_mac(SSL *ssl, SSL3_RECORD *rec, unsigned char *md, int sending)
     int i;
     EVP_MD_CTX *hmac = NULL, *mac_ctx;
     unsigned char header[13];
-    int stream_mac = sending ? (ssl->mac_flags & SSL_MAC_FLAG_WRITE_MAC_STREAM)
-                             : (ssl->mac_flags & SSL_MAC_FLAG_READ_MAC_STREAM);
-    int tlstree_mac = sending ? (ssl->mac_flags & SSL_MAC_FLAG_WRITE_MAC_TLSTREE)
-                              : (ssl->mac_flags & SSL_MAC_FLAG_READ_MAC_TLSTREE);
+    int stream_mac = sending ? (sc->mac_flags & SSL_MAC_FLAG_WRITE_MAC_STREAM)
+                             : (sc->mac_flags & SSL_MAC_FLAG_READ_MAC_STREAM);
+    int tlstree_mac = sending ? (sc->mac_flags & SSL_MAC_FLAG_WRITE_MAC_TLSTREE)
+                              : (sc->mac_flags & SSL_MAC_FLAG_READ_MAC_TLSTREE);
     int t;
     int ret = 0;
 
     if (sending) {
-        seq = RECORD_LAYER_get_write_sequence(&ssl->rlayer);
-        hash = ssl->write_hash;
+        seq = RECORD_LAYER_get_write_sequence(&sc->rlayer);
+        hash = sc->write_hash;
     } else {
-        seq = RECORD_LAYER_get_read_sequence(&ssl->rlayer);
-        hash = ssl->read_hash;
+        seq = RECORD_LAYER_get_read_sequence(&sc->rlayer);
+        hash = sc->read_hash;
     }
 
     t = EVP_MD_CTX_get_size(hash);
@@ -1449,15 +1455,16 @@ int tls1_mac(SSL *ssl, SSL3_RECORD *rec, unsigned char *md, int sending)
         mac_ctx = hmac;
     }
 
-    if (!SSL_IS_DTLS(ssl) && tlstree_mac && EVP_MD_CTX_ctrl(mac_ctx, EVP_MD_CTRL_TLSTREE, 0, seq) <= 0) {
+    if (!SSL_CONNECTION_IS_DTLS(sc) && tlstree_mac
+        && EVP_MD_CTX_ctrl(mac_ctx, EVP_MD_CTRL_TLSTREE, 0, seq) <= 0) {
         goto end;
     }
 
-    if (SSL_IS_DTLS(ssl)) {
+    if (SSL_CONNECTION_IS_DTLS(sc)) {
         unsigned char dtlsseq[8], *p = dtlsseq;
 
-        s2n(sending ? DTLS_RECORD_LAYER_get_w_epoch(&ssl->rlayer) :
-            DTLS_RECORD_LAYER_get_r_epoch(&ssl->rlayer), p);
+        s2n(sending ? DTLS_RECORD_LAYER_get_w_epoch(&sc->rlayer) :
+            DTLS_RECORD_LAYER_get_r_epoch(&sc->rlayer), p);
         memcpy(p, &seq[2], 6);
 
         memcpy(header, dtlsseq, 8);
@@ -1465,13 +1472,13 @@ int tls1_mac(SSL *ssl, SSL3_RECORD *rec, unsigned char *md, int sending)
         memcpy(header, seq, 8);
 
     header[8] = rec->type;
-    header[9] = (unsigned char)(ssl->version >> 8);
-    header[10] = (unsigned char)(ssl->version);
+    header[9] = (unsigned char)(sc->version >> 8);
+    header[10] = (unsigned char)(sc->version);
     header[11] = (unsigned char)(rec->length >> 8);
     header[12] = (unsigned char)(rec->length & 0xff);
 
-    if (!sending && !SSL_READ_ETM(ssl)
-        && EVP_CIPHER_CTX_get_mode(ssl->enc_read_ctx) == EVP_CIPH_CBC_MODE
+    if (!sending && !SSL_READ_ETM(sc)
+        && EVP_CIPHER_CTX_get_mode(sc->enc_read_ctx) == EVP_CIPH_CBC_MODE
         && ssl3_cbc_record_digest_supported(mac_ctx)) {
         OSSL_PARAM tls_hmac_params[2], *p = tls_hmac_params;
 
@@ -1498,7 +1505,7 @@ int tls1_mac(SSL *ssl, SSL3_RECORD *rec, unsigned char *md, int sending)
         BIO_dump_indent(trc_out, rec->data, rec->length, 4);
     } OSSL_TRACE_END(TLS);
 
-    if (!SSL_IS_DTLS(ssl)) {
+    if (!SSL_CONNECTION_IS_DTLS(sc)) {
         for (i = 7; i >= 0; i--) {
             ++seq[i];
             if (seq[i] != 0)
@@ -1515,7 +1522,7 @@ int tls1_mac(SSL *ssl, SSL3_RECORD *rec, unsigned char *md, int sending)
     return ret;
 }
 
-int dtls1_process_record(SSL *s, DTLS1_BITMAP *bitmap)
+int dtls1_process_record(SSL_CONNECTION *s, DTLS1_BITMAP *bitmap)
 {
     int i;
     int enc_err;
@@ -1527,6 +1534,7 @@ int dtls1_process_record(SSL *s, DTLS1_BITMAP *bitmap)
     size_t max_plain_length = SSL3_RT_MAX_PLAIN_LENGTH;
     SSL_MAC_BUF macbuf = { NULL, 0 };
     int ret = 0;
+    SSL *ssl = SSL_CONNECTION_GET_SSL(s);
 
     rr = RECORD_LAYER_get_rrec(&s->rlayer);
     sess = s->session;
@@ -1581,7 +1589,7 @@ int dtls1_process_record(SSL *s, DTLS1_BITMAP *bitmap)
         }
         rr->length -= mac_size;
         mac = rr->data + rr->length;
-        i = s->method->ssl3_enc->mac(s, rr, md, 0 /* not send */ );
+        i = ssl->method->ssl3_enc->mac(s, rr, md, 0 /* not send */ );
         if (i == 0 || CRYPTO_memcmp(md, mac, (size_t)mac_size) != 0) {
             SSLfatal(s, SSL_AD_BAD_RECORD_MAC,
                      SSL_R_DECRYPTION_FAILED_OR_BAD_RECORD_MAC);
@@ -1600,7 +1608,7 @@ int dtls1_process_record(SSL *s, DTLS1_BITMAP *bitmap)
      * errors in the queue from processing bogus junk that we ignored.
      */
     ERR_set_mark();
-    enc_err = s->method->ssl3_enc->enc(s, rr, 1, 0, &macbuf, mac_size);
+    enc_err = ssl->method->ssl3_enc->enc(s, rr, 1, 0, &macbuf, mac_size);
 
     /*-
      * enc_err is:
@@ -1632,7 +1640,7 @@ int dtls1_process_record(SSL *s, DTLS1_BITMAP *bitmap)
             && (EVP_MD_CTX_get0_md(s->read_hash) != NULL)) {
         /* s->read_hash != NULL => mac_size != -1 */
 
-        i = s->method->ssl3_enc->mac(s, rr, md, 0 /* not send */ );
+        i = ssl->method->ssl3_enc->mac(s, rr, md, 0 /* not send */ );
         if (i == 0 || macbuf.mac == NULL
             || CRYPTO_memcmp(md, macbuf.mac, mac_size) != 0)
             enc_err = 0;
@@ -1710,7 +1718,7 @@ int dtls1_process_record(SSL *s, DTLS1_BITMAP *bitmap)
  * ssl->s3.rrec.length  - number of bytes
  */
 /* used only by dtls1_read_bytes */
-int dtls1_get_record(SSL *s)
+int dtls1_get_record(SSL_CONNECTION *s)
 {
     int ssl_major, ssl_minor;
     int rret;
@@ -1720,6 +1728,7 @@ int dtls1_get_record(SSL *s)
     unsigned short version;
     DTLS1_BITMAP *bitmap;
     unsigned int is_next_epoch;
+    SSL *ssl = SSL_CONNECTION_GET_SSL(s);
 
     rr = RECORD_LAYER_get_rrec(&s->rlayer);
 
@@ -1763,7 +1772,7 @@ int dtls1_get_record(SSL *s)
 
         if (s->msg_callback)
             s->msg_callback(0, 0, SSL3_RT_HEADER, p, DTLS1_RT_HEADER_LENGTH,
-                            s, s->msg_callback_arg);
+                            ssl, s->msg_callback_arg);
 
         /* Pull apart the header into the DTLS1_RECORD */
         rr->type = *(p++);
@@ -1859,7 +1868,7 @@ int dtls1_get_record(SSL *s)
     }
 #ifndef OPENSSL_NO_SCTP
     /* Only do replay check if no SCTP bio */
-    if (!BIO_dgram_is_sctp(SSL_get_rbio(s))) {
+    if (!BIO_dgram_is_sctp(SSL_get_rbio(ssl))) {
 #endif
         /* Check whether this is a repeat, or aged record. */
         if (!dtls1_record_replay_check(s, bitmap)) {
@@ -1884,7 +1893,7 @@ int dtls1_get_record(SSL *s)
      * processed at this time.
      */
     if (is_next_epoch) {
-        if ((SSL_in_init(s) || ossl_statem_get_in_handshake(s))) {
+        if ((SSL_in_init(ssl) || ossl_statem_get_in_handshake(s))) {
             if (dtls1_buffer_record (s,
                     &(DTLS_RECORD_LAYER_get_unprocessed_rcds(&s->rlayer)),
                     rr->seq_num) < 0) {
@@ -1913,7 +1922,8 @@ int dtls1_get_record(SSL *s)
 
 }
 
-int dtls_buffer_listen_record(SSL *s, size_t len, unsigned char *seq, size_t off)
+int dtls_buffer_listen_record(SSL_CONNECTION *s, size_t len, unsigned char *seq,
+                              size_t off)
 {
     SSL3_RECORD *rr;
 

--- a/ssl/record/ssl3_record_tls13.c
+++ b/ssl/record/ssl3_record_tls13.c
@@ -20,7 +20,7 @@
  *    0: On failure
  *    1: if the record encryption/decryption was successful.
  */
-int tls13_enc(SSL *s, SSL3_RECORD *recs, size_t n_recs, int sending,
+int tls13_enc(SSL_CONNECTION *s, SSL3_RECORD *recs, size_t n_recs, int sending,
               ossl_unused SSL_MAC_BUF *mac, ossl_unused size_t macsize)
 {
     EVP_CIPHER_CTX *ctx;
@@ -140,8 +140,8 @@ int tls13_enc(SSL *s, SSL3_RECORD *recs, size_t n_recs, int sending,
 
     if (EVP_CipherInit_ex(ctx, NULL, NULL, NULL, iv, sending) <= 0
             || (!sending && EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_AEAD_SET_TAG,
-                                             taglen,
-                                             rec->data + rec->length) <= 0)) {
+                                                taglen,
+                                                rec->data + rec->length) <= 0)) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
         return 0;
     }

--- a/ssl/s3_enc.c
+++ b/ssl/s3_enc.c
@@ -15,7 +15,7 @@
 #include <openssl/core_names.h>
 #include "internal/cryptlib.h"
 
-static int ssl3_generate_key_block(SSL *s, unsigned char *km, int num)
+static int ssl3_generate_key_block(SSL_CONNECTION *s, unsigned char *km, int num)
 {
     const EVP_MD *md5 = NULL, *sha1 = NULL;
     EVP_MD_CTX *m5;
@@ -24,13 +24,14 @@ static int ssl3_generate_key_block(SSL *s, unsigned char *km, int num)
     unsigned char c = 'A';
     unsigned int i, k;
     int ret = 0;
+    SSL_CTX *sctx = SSL_CONNECTION_GET_CTX(s);
 
 #ifdef CHARSET_EBCDIC
     c = os_toascii[c];          /* 'A' in ASCII */
 #endif
     k = 0;
-    md5 = ssl_evp_md_fetch(s->ctx->libctx, NID_md5, s->ctx->propq);
-    sha1 = ssl_evp_md_fetch(s->ctx->libctx, NID_sha1, s->ctx->propq);
+    md5 = ssl_evp_md_fetch(sctx->libctx, NID_md5, sctx->propq);
+    sha1 = ssl_evp_md_fetch(sctx->libctx, NID_sha1, sctx->propq);
     m5 = EVP_MD_CTX_new();
     s1 = EVP_MD_CTX_new();
     if (md5 == NULL || sha1 == NULL || m5 == NULL || s1 == NULL) {
@@ -86,7 +87,7 @@ static int ssl3_generate_key_block(SSL *s, unsigned char *km, int num)
     return ret;
 }
 
-int ssl3_change_cipher_state(SSL *s, int which)
+int ssl3_change_cipher_state(SSL_CONNECTION *s, int which)
 {
     unsigned char *p, *mac_secret;
     unsigned char *ms, *key, *iv;
@@ -237,7 +238,7 @@ int ssl3_change_cipher_state(SSL *s, int which)
     return 0;
 }
 
-int ssl3_setup_key_block(SSL *s)
+int ssl3_setup_key_block(SSL_CONNECTION *s)
 {
     unsigned char *p;
     const EVP_CIPHER *c;
@@ -249,8 +250,8 @@ int ssl3_setup_key_block(SSL *s)
     if (s->s3.tmp.key_block_length != 0)
         return 1;
 
-    if (!ssl_cipher_get_evp(s->ctx, s->session, &c, &hash, NULL, NULL, &comp,
-                            0)) {
+    if (!ssl_cipher_get_evp(SSL_CONNECTION_GET_CTX(s), s->session, &c, &hash,
+                            NULL, NULL, &comp, 0)) {
         /* Error is already recorded */
         SSLfatal_alert(s, SSL_AD_INTERNAL_ERROR);
         return 0;
@@ -305,14 +306,14 @@ int ssl3_setup_key_block(SSL *s)
     return ret;
 }
 
-void ssl3_cleanup_key_block(SSL *s)
+void ssl3_cleanup_key_block(SSL_CONNECTION *s)
 {
     OPENSSL_clear_free(s->s3.tmp.key_block, s->s3.tmp.key_block_length);
     s->s3.tmp.key_block = NULL;
     s->s3.tmp.key_block_length = 0;
 }
 
-int ssl3_init_finished_mac(SSL *s)
+int ssl3_init_finished_mac(SSL_CONNECTION *s)
 {
     BIO *buf = BIO_new(BIO_s_mem());
 
@@ -331,7 +332,7 @@ int ssl3_init_finished_mac(SSL *s)
  * together.
  */
 
-void ssl3_free_digest_list(SSL *s)
+void ssl3_free_digest_list(SSL_CONNECTION *s)
 {
     BIO_free(s->s3.handshake_buffer);
     s->s3.handshake_buffer = NULL;
@@ -339,7 +340,7 @@ void ssl3_free_digest_list(SSL *s)
     s->s3.handshake_dgst = NULL;
 }
 
-int ssl3_finish_mac(SSL *s, const unsigned char *buf, size_t len)
+int ssl3_finish_mac(SSL_CONNECTION *s, const unsigned char *buf, size_t len)
 {
     int ret;
 
@@ -364,7 +365,7 @@ int ssl3_finish_mac(SSL *s, const unsigned char *buf, size_t len)
     return 1;
 }
 
-int ssl3_digest_cached_records(SSL *s, int keep)
+int ssl3_digest_cached_records(SSL_CONNECTION *s, int keep)
 {
     const EVP_MD *md;
     long hdatalen;
@@ -413,7 +414,7 @@ void ssl3_digest_master_key_set_params(const SSL_SESSION *session,
     params[n++] = OSSL_PARAM_construct_end();
 }
 
-size_t ssl3_final_finish_mac(SSL *s, const char *sender, size_t len,
+size_t ssl3_final_finish_mac(SSL_CONNECTION *s, const char *sender, size_t len,
                              unsigned char *p)
 {
     int ret;
@@ -466,7 +467,8 @@ size_t ssl3_final_finish_mac(SSL *s, const char *sender, size_t len,
     return ret;
 }
 
-int ssl3_generate_master_secret(SSL *s, unsigned char *out, unsigned char *p,
+int ssl3_generate_master_secret(SSL_CONNECTION *s, unsigned char *out,
+                                unsigned char *p,
                                 size_t len, size_t *secret_size)
 {
     static const unsigned char *salt[3] = {
@@ -491,7 +493,7 @@ int ssl3_generate_master_secret(SSL *s, unsigned char *out, unsigned char *p,
         return 0;
     }
     for (i = 0; i < 3; i++) {
-        if (EVP_DigestInit_ex(ctx, s->ctx->sha1, NULL) <= 0
+        if (EVP_DigestInit_ex(ctx, SSL_CONNECTION_GET_CTX(s)->sha1, NULL) <= 0
             || EVP_DigestUpdate(ctx, salt[i],
                                 strlen((const char *)salt[i])) <= 0
             || EVP_DigestUpdate(ctx, p, len) <= 0
@@ -500,7 +502,7 @@ int ssl3_generate_master_secret(SSL *s, unsigned char *out, unsigned char *p,
             || EVP_DigestUpdate(ctx, &(s->s3.server_random[0]),
                                 SSL3_RANDOM_SIZE) <= 0
             || EVP_DigestFinal_ex(ctx, buf, &n) <= 0
-            || EVP_DigestInit_ex(ctx, s->ctx->md5, NULL) <= 0
+            || EVP_DigestInit_ex(ctx, SSL_CONNECTION_GET_CTX(s)->md5, NULL) <= 0
             || EVP_DigestUpdate(ctx, p, len) <= 0
             || EVP_DigestUpdate(ctx, buf, n) <= 0
             || EVP_DigestFinal_ex(ctx, out, &n) <= 0) {

--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -3255,9 +3255,9 @@ void ssl_sort_cipher_list(void)
     qsort(ssl3_scsvs, SSL3_NUM_SCSVS, sizeof(ssl3_scsvs[0]), cipher_compare);
 }
 
-static int ssl_undefined_function_1(SSL *ssl, unsigned char *r, size_t s,
-                                    const char * t, size_t u,
-                                    const unsigned char * v, size_t w, int x)
+static int sslcon_undefined_function_1(SSL_CONNECTION *sc, unsigned char *r,
+                                       size_t s, const char *t, size_t u,
+                                       const unsigned char *v, size_t w, int x)
 {
     (void)r;
     (void)s;
@@ -3266,7 +3266,7 @@ static int ssl_undefined_function_1(SSL *ssl, unsigned char *r, size_t s,
     (void)v;
     (void)w;
     (void)x;
-    return ssl_undefined_function(ssl);
+    return ssl_undefined_function(SSL_CONNECTION_GET_SSL(sc));
 }
 
 const SSL3_ENC_METHOD SSLv3_enc_data = {
@@ -3279,7 +3279,7 @@ const SSL3_ENC_METHOD SSLv3_enc_data = {
     SSL3_MD_CLIENT_FINISHED_CONST, 4,
     SSL3_MD_SERVER_FINISHED_CONST, 4,
     ssl3_alert_code,
-    ssl_undefined_function_1,
+    sslcon_undefined_function_1,
     0,
     ssl3_set_handshake_header,
     tls_close_construct_packet,
@@ -3308,7 +3308,7 @@ const SSL_CIPHER *ssl3_get_cipher(unsigned int u)
         return NULL;
 }
 
-int ssl3_set_handshake_header(SSL *s, WPACKET *pkt, int htype)
+int ssl3_set_handshake_header(SSL_CONNECTION *s, WPACKET *pkt, int htype)
 {
     /* No header in the event of a CCS */
     if (htype == SSL3_MT_CHANGE_CIPHER_SPEC)
@@ -3322,7 +3322,7 @@ int ssl3_set_handshake_header(SSL *s, WPACKET *pkt, int htype)
     return 1;
 }
 
-int ssl3_handshake_write(SSL *s)
+int ssl3_handshake_write(SSL_CONNECTION *s)
 {
     return ssl3_do_write(s, SSL3_RT_HANDSHAKE);
 }
@@ -3330,7 +3330,12 @@ int ssl3_handshake_write(SSL *s)
 int ssl3_new(SSL *s)
 {
 #ifndef OPENSSL_NO_SRP
-    if (!ssl_srp_ctx_init_intern(s))
+    SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL(s);
+
+    if (sc == NULL)
+        return 0;
+
+    if (!ssl_srp_ctx_init_intern(sc))
         return 0;
 #endif
 
@@ -3342,65 +3347,72 @@ int ssl3_new(SSL *s)
 
 void ssl3_free(SSL *s)
 {
-    if (s == NULL)
+    SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL(s);
+
+    if (sc == NULL)
         return;
 
-    ssl3_cleanup_key_block(s);
+    ssl3_cleanup_key_block(sc);
 
-    EVP_PKEY_free(s->s3.peer_tmp);
-    s->s3.peer_tmp = NULL;
-    EVP_PKEY_free(s->s3.tmp.pkey);
-    s->s3.tmp.pkey = NULL;
+    EVP_PKEY_free(sc->s3.peer_tmp);
+    sc->s3.peer_tmp = NULL;
+    EVP_PKEY_free(sc->s3.tmp.pkey);
+    sc->s3.tmp.pkey = NULL;
 
-    ssl_evp_cipher_free(s->s3.tmp.new_sym_enc);
-    ssl_evp_md_free(s->s3.tmp.new_hash);
+    ssl_evp_cipher_free(sc->s3.tmp.new_sym_enc);
+    ssl_evp_md_free(sc->s3.tmp.new_hash);
 
-    OPENSSL_free(s->s3.tmp.ctype);
-    sk_X509_NAME_pop_free(s->s3.tmp.peer_ca_names, X509_NAME_free);
-    OPENSSL_free(s->s3.tmp.ciphers_raw);
-    OPENSSL_clear_free(s->s3.tmp.pms, s->s3.tmp.pmslen);
-    OPENSSL_free(s->s3.tmp.peer_sigalgs);
-    OPENSSL_free(s->s3.tmp.peer_cert_sigalgs);
-    ssl3_free_digest_list(s);
-    OPENSSL_free(s->s3.alpn_selected);
-    OPENSSL_free(s->s3.alpn_proposed);
+    OPENSSL_free(sc->s3.tmp.ctype);
+    sk_X509_NAME_pop_free(sc->s3.tmp.peer_ca_names, X509_NAME_free);
+    OPENSSL_free(sc->s3.tmp.ciphers_raw);
+    OPENSSL_clear_free(sc->s3.tmp.pms, sc->s3.tmp.pmslen);
+    OPENSSL_free(sc->s3.tmp.peer_sigalgs);
+    OPENSSL_free(sc->s3.tmp.peer_cert_sigalgs);
+    ssl3_free_digest_list(sc);
+    OPENSSL_free(sc->s3.alpn_selected);
+    OPENSSL_free(sc->s3.alpn_proposed);
 
 #ifndef OPENSSL_NO_SRP
-    ssl_srp_ctx_free_intern(s);
+    ssl_srp_ctx_free_intern(sc);
 #endif
-    memset(&s->s3, 0, sizeof(s->s3));
+    memset(&sc->s3, 0, sizeof(sc->s3));
 }
 
 int ssl3_clear(SSL *s)
 {
-    ssl3_cleanup_key_block(s);
-    OPENSSL_free(s->s3.tmp.ctype);
-    sk_X509_NAME_pop_free(s->s3.tmp.peer_ca_names, X509_NAME_free);
-    OPENSSL_free(s->s3.tmp.ciphers_raw);
-    OPENSSL_clear_free(s->s3.tmp.pms, s->s3.tmp.pmslen);
-    OPENSSL_free(s->s3.tmp.peer_sigalgs);
-    OPENSSL_free(s->s3.tmp.peer_cert_sigalgs);
+    SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL(s);
 
-    EVP_PKEY_free(s->s3.tmp.pkey);
-    EVP_PKEY_free(s->s3.peer_tmp);
-
-    ssl3_free_digest_list(s);
-
-    OPENSSL_free(s->s3.alpn_selected);
-    OPENSSL_free(s->s3.alpn_proposed);
-
-    /* NULL/zero-out everything in the s3 struct */
-    memset(&s->s3, 0, sizeof(s->s3));
-
-    if (!ssl_free_wbio_buffer(s))
+    if (sc == NULL)
         return 0;
 
-    s->version = SSL3_VERSION;
+    ssl3_cleanup_key_block(sc);
+    OPENSSL_free(sc->s3.tmp.ctype);
+    sk_X509_NAME_pop_free(sc->s3.tmp.peer_ca_names, X509_NAME_free);
+    OPENSSL_free(sc->s3.tmp.ciphers_raw);
+    OPENSSL_clear_free(sc->s3.tmp.pms, sc->s3.tmp.pmslen);
+    OPENSSL_free(sc->s3.tmp.peer_sigalgs);
+    OPENSSL_free(sc->s3.tmp.peer_cert_sigalgs);
+
+    EVP_PKEY_free(sc->s3.tmp.pkey);
+    EVP_PKEY_free(sc->s3.peer_tmp);
+
+    ssl3_free_digest_list(sc);
+
+    OPENSSL_free(sc->s3.alpn_selected);
+    OPENSSL_free(sc->s3.alpn_proposed);
+
+    /* NULL/zero-out everything in the s3 struct */
+    memset(&sc->s3, 0, sizeof(sc->s3));
+
+    if (!ssl_free_wbio_buffer(sc))
+        return 0;
+
+    sc->version = SSL3_VERSION;
 
 #if !defined(OPENSSL_NO_NEXTPROTONEG)
-    OPENSSL_free(s->ext.npn);
-    s->ext.npn = NULL;
-    s->ext.npn_len = 0;
+    OPENSSL_free(sc->ext.npn);
+    sc->ext.npn = NULL;
+    sc->ext.npn_len = 0;
 #endif
 
     return 1;
@@ -3409,7 +3421,12 @@ int ssl3_clear(SSL *s)
 #ifndef OPENSSL_NO_SRP
 static char *srp_password_from_info_cb(SSL *s, void *arg)
 {
-    return OPENSSL_strdup(s->srp_ctx.info);
+    SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL(s);
+
+    if (sc == NULL)
+        return NULL;
+
+    return OPENSSL_strdup(sc->srp_ctx.info);
 }
 #endif
 
@@ -3418,22 +3435,26 @@ static int ssl3_set_req_cert_type(CERT *c, const unsigned char *p, size_t len);
 long ssl3_ctrl(SSL *s, int cmd, long larg, void *parg)
 {
     int ret = 0;
+    SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL(s);
+
+    if (sc == NULL)
+        return ret;
 
     switch (cmd) {
     case SSL_CTRL_GET_CLIENT_CERT_REQUEST:
         break;
     case SSL_CTRL_GET_NUM_RENEGOTIATIONS:
-        ret = s->s3.num_renegotiations;
+        ret = sc->s3.num_renegotiations;
         break;
     case SSL_CTRL_CLEAR_NUM_RENEGOTIATIONS:
-        ret = s->s3.num_renegotiations;
-        s->s3.num_renegotiations = 0;
+        ret = sc->s3.num_renegotiations;
+        sc->s3.num_renegotiations = 0;
         break;
     case SSL_CTRL_GET_TOTAL_RENEGOTIATIONS:
-        ret = s->s3.total_renegotiations;
+        ret = sc->s3.total_renegotiations;
         break;
     case SSL_CTRL_GET_FLAGS:
-        ret = (int)(s->s3.flags);
+        ret = (int)(sc->s3.flags);
         break;
 #if !defined(OPENSSL_NO_DEPRECATED_3_0)
     case SSL_CTRL_SET_TMP_DH:
@@ -3462,7 +3483,7 @@ long ssl3_ctrl(SSL *s, int cmd, long larg, void *parg)
         }
 #endif
     case SSL_CTRL_SET_DH_AUTO:
-        s->cert->dh_tmp_auto = larg;
+        sc->cert->dh_tmp_auto = larg;
         return 1;
 #if !defined(OPENSSL_NO_DEPRECATED_3_0)
     case SSL_CTRL_SET_TMP_ECDH:
@@ -3471,8 +3492,8 @@ long ssl3_ctrl(SSL *s, int cmd, long larg, void *parg)
                 ERR_raise(ERR_LIB_SSL, ERR_R_PASSED_NULL_PARAMETER);
                 return 0;
             }
-            return ssl_set_tmp_ecdh_groups(&s->ext.supportedgroups,
-                                           &s->ext.supportedgroups_len,
+            return ssl_set_tmp_ecdh_groups(&sc->ext.supportedgroups,
+                                           &sc->ext.supportedgroups_len,
                                            parg);
         }
 #endif                          /* !OPENSSL_NO_DEPRECATED_3_0 */
@@ -3488,8 +3509,8 @@ long ssl3_ctrl(SSL *s, int cmd, long larg, void *parg)
         if (larg == TLSEXT_NAMETYPE_host_name) {
             size_t len;
 
-            OPENSSL_free(s->ext.hostname);
-            s->ext.hostname = NULL;
+            OPENSSL_free(sc->ext.hostname);
+            sc->ext.hostname = NULL;
 
             ret = 1;
             if (parg == NULL)
@@ -3499,7 +3520,7 @@ long ssl3_ctrl(SSL *s, int cmd, long larg, void *parg)
                 ERR_raise(ERR_LIB_SSL, SSL_R_SSL3_EXT_INVALID_SERVERNAME);
                 return 0;
             }
-            if ((s->ext.hostname = OPENSSL_strdup((char *)parg)) == NULL) {
+            if ((sc->ext.hostname = OPENSSL_strdup((char *)parg)) == NULL) {
                 ERR_raise(ERR_LIB_SSL, ERR_R_INTERNAL_ERROR);
                 return 0;
             }
@@ -3509,79 +3530,79 @@ long ssl3_ctrl(SSL *s, int cmd, long larg, void *parg)
         }
         break;
     case SSL_CTRL_SET_TLSEXT_DEBUG_ARG:
-        s->ext.debug_arg = parg;
+        sc->ext.debug_arg = parg;
         ret = 1;
         break;
 
     case SSL_CTRL_GET_TLSEXT_STATUS_REQ_TYPE:
-        ret = s->ext.status_type;
+        ret = sc->ext.status_type;
         break;
 
     case SSL_CTRL_SET_TLSEXT_STATUS_REQ_TYPE:
-        s->ext.status_type = larg;
+        sc->ext.status_type = larg;
         ret = 1;
         break;
 
     case SSL_CTRL_GET_TLSEXT_STATUS_REQ_EXTS:
-        *(STACK_OF(X509_EXTENSION) **)parg = s->ext.ocsp.exts;
+        *(STACK_OF(X509_EXTENSION) **)parg = sc->ext.ocsp.exts;
         ret = 1;
         break;
 
     case SSL_CTRL_SET_TLSEXT_STATUS_REQ_EXTS:
-        s->ext.ocsp.exts = parg;
+        sc->ext.ocsp.exts = parg;
         ret = 1;
         break;
 
     case SSL_CTRL_GET_TLSEXT_STATUS_REQ_IDS:
-        *(STACK_OF(OCSP_RESPID) **)parg = s->ext.ocsp.ids;
+        *(STACK_OF(OCSP_RESPID) **)parg = sc->ext.ocsp.ids;
         ret = 1;
         break;
 
     case SSL_CTRL_SET_TLSEXT_STATUS_REQ_IDS:
-        s->ext.ocsp.ids = parg;
+        sc->ext.ocsp.ids = parg;
         ret = 1;
         break;
 
     case SSL_CTRL_GET_TLSEXT_STATUS_REQ_OCSP_RESP:
-        *(unsigned char **)parg = s->ext.ocsp.resp;
-        if (s->ext.ocsp.resp_len == 0
-                || s->ext.ocsp.resp_len > LONG_MAX)
+        *(unsigned char **)parg = sc->ext.ocsp.resp;
+        if (sc->ext.ocsp.resp_len == 0
+                || sc->ext.ocsp.resp_len > LONG_MAX)
             return -1;
-        return (long)s->ext.ocsp.resp_len;
+        return (long)sc->ext.ocsp.resp_len;
 
     case SSL_CTRL_SET_TLSEXT_STATUS_REQ_OCSP_RESP:
-        OPENSSL_free(s->ext.ocsp.resp);
-        s->ext.ocsp.resp = parg;
-        s->ext.ocsp.resp_len = larg;
+        OPENSSL_free(sc->ext.ocsp.resp);
+        sc->ext.ocsp.resp = parg;
+        sc->ext.ocsp.resp_len = larg;
         ret = 1;
         break;
 
     case SSL_CTRL_CHAIN:
         if (larg)
-            return ssl_cert_set1_chain(s, NULL, (STACK_OF(X509) *)parg);
+            return ssl_cert_set1_chain(sc, NULL, (STACK_OF(X509) *)parg);
         else
-            return ssl_cert_set0_chain(s, NULL, (STACK_OF(X509) *)parg);
+            return ssl_cert_set0_chain(sc, NULL, (STACK_OF(X509) *)parg);
 
     case SSL_CTRL_CHAIN_CERT:
         if (larg)
-            return ssl_cert_add1_chain_cert(s, NULL, (X509 *)parg);
+            return ssl_cert_add1_chain_cert(sc, NULL, (X509 *)parg);
         else
-            return ssl_cert_add0_chain_cert(s, NULL, (X509 *)parg);
+            return ssl_cert_add0_chain_cert(sc, NULL, (X509 *)parg);
 
     case SSL_CTRL_GET_CHAIN_CERTS:
-        *(STACK_OF(X509) **)parg = s->cert->key->chain;
+        *(STACK_OF(X509) **)parg = sc->cert->key->chain;
         ret = 1;
         break;
 
     case SSL_CTRL_SELECT_CURRENT_CERT:
-        return ssl_cert_select_current(s->cert, (X509 *)parg);
+        return ssl_cert_select_current(sc->cert, (X509 *)parg);
 
     case SSL_CTRL_SET_CURRENT_CERT:
         if (larg == SSL_CERT_SET_SERVER) {
             const SSL_CIPHER *cipher;
-            if (!s->server)
+            if (!sc->server)
                 return 0;
-            cipher = s->s3.tmp.new_cipher;
+            cipher = sc->s3.tmp.new_cipher;
             if (cipher == NULL)
                 return 0;
             /*
@@ -3590,28 +3611,28 @@ long ssl3_ctrl(SSL *s, int cmd, long larg, void *parg)
              */
             if (cipher->algorithm_auth & (SSL_aNULL | SSL_aSRP))
                 return 2;
-            if (s->s3.tmp.cert == NULL)
+            if (sc->s3.tmp.cert == NULL)
                 return 0;
-            s->cert->key = s->s3.tmp.cert;
+            sc->cert->key = sc->s3.tmp.cert;
             return 1;
         }
-        return ssl_cert_set_current(s->cert, larg);
+        return ssl_cert_set_current(sc->cert, larg);
 
     case SSL_CTRL_GET_GROUPS:
         {
             uint16_t *clist;
             size_t clistlen;
 
-            if (!s->session)
+            if (!sc->session)
                 return 0;
-            clist = s->ext.peer_supportedgroups;
-            clistlen = s->ext.peer_supportedgroups_len;
+            clist = sc->ext.peer_supportedgroups;
+            clistlen = sc->ext.peer_supportedgroups_len;
             if (parg) {
                 size_t i;
                 int *cptr = parg;
 
                 for (i = 0; i < clistlen; i++) {
-                    uint16_t cid = SSL_IS_TLS13(s)
+                    uint16_t cid = SSL_CONNECTION_IS_TLS13(sc)
                                    ? ssl_group_id_tls13_to_internal(clist[i])
                                    : clist[i];
                     const TLS_GROUP_INFO *cinf
@@ -3627,16 +3648,16 @@ long ssl3_ctrl(SSL *s, int cmd, long larg, void *parg)
         }
 
     case SSL_CTRL_SET_GROUPS:
-        return tls1_set_groups(&s->ext.supportedgroups,
-                               &s->ext.supportedgroups_len, parg, larg);
+        return tls1_set_groups(&sc->ext.supportedgroups,
+                               &sc->ext.supportedgroups_len, parg, larg);
 
     case SSL_CTRL_SET_GROUPS_LIST:
-        return tls1_set_groups_list(s->ctx, &s->ext.supportedgroups,
-                                    &s->ext.supportedgroups_len, parg);
+        return tls1_set_groups_list(s->ctx, &sc->ext.supportedgroups,
+                                    &sc->ext.supportedgroups_len, parg);
 
     case SSL_CTRL_GET_SHARED_GROUP:
         {
-            uint16_t id = tls1_shared_group(s, larg);
+            uint16_t id = tls1_shared_group(sc, larg);
 
             if (larg != -1)
                 return tls1_group_id2nid(id, 1);
@@ -3646,82 +3667,82 @@ long ssl3_ctrl(SSL *s, int cmd, long larg, void *parg)
         {
             unsigned int id;
 
-            if (SSL_IS_TLS13(s) && s->s3.did_kex)
-                id = s->s3.group_id;
+            if (SSL_CONNECTION_IS_TLS13(sc) && sc->s3.did_kex)
+                id = sc->s3.group_id;
             else
-                id = s->session->kex_group;
+                id = sc->session->kex_group;
             ret = tls1_group_id2nid(id, 1);
             break;
         }
     case SSL_CTRL_SET_SIGALGS:
-        return tls1_set_sigalgs(s->cert, parg, larg, 0);
+        return tls1_set_sigalgs(sc->cert, parg, larg, 0);
 
     case SSL_CTRL_SET_SIGALGS_LIST:
-        return tls1_set_sigalgs_list(s->cert, parg, 0);
+        return tls1_set_sigalgs_list(sc->cert, parg, 0);
 
     case SSL_CTRL_SET_CLIENT_SIGALGS:
-        return tls1_set_sigalgs(s->cert, parg, larg, 1);
+        return tls1_set_sigalgs(sc->cert, parg, larg, 1);
 
     case SSL_CTRL_SET_CLIENT_SIGALGS_LIST:
-        return tls1_set_sigalgs_list(s->cert, parg, 1);
+        return tls1_set_sigalgs_list(sc->cert, parg, 1);
 
     case SSL_CTRL_GET_CLIENT_CERT_TYPES:
         {
             const unsigned char **pctype = parg;
-            if (s->server || !s->s3.tmp.cert_req)
+            if (sc->server || !sc->s3.tmp.cert_req)
                 return 0;
             if (pctype)
-                *pctype = s->s3.tmp.ctype;
-            return s->s3.tmp.ctype_len;
+                *pctype = sc->s3.tmp.ctype;
+            return sc->s3.tmp.ctype_len;
         }
 
     case SSL_CTRL_SET_CLIENT_CERT_TYPES:
-        if (!s->server)
+        if (!sc->server)
             return 0;
-        return ssl3_set_req_cert_type(s->cert, parg, larg);
+        return ssl3_set_req_cert_type(sc->cert, parg, larg);
 
     case SSL_CTRL_BUILD_CERT_CHAIN:
-        return ssl_build_cert_chain(s, NULL, larg);
+        return ssl_build_cert_chain(sc, NULL, larg);
 
     case SSL_CTRL_SET_VERIFY_CERT_STORE:
-        return ssl_cert_set_cert_store(s->cert, parg, 0, larg);
+        return ssl_cert_set_cert_store(sc->cert, parg, 0, larg);
 
     case SSL_CTRL_SET_CHAIN_CERT_STORE:
-        return ssl_cert_set_cert_store(s->cert, parg, 1, larg);
+        return ssl_cert_set_cert_store(sc->cert, parg, 1, larg);
 
     case SSL_CTRL_GET_VERIFY_CERT_STORE:
-        return ssl_cert_get_cert_store(s->cert, parg, 0);
+        return ssl_cert_get_cert_store(sc->cert, parg, 0);
 
     case SSL_CTRL_GET_CHAIN_CERT_STORE:
-        return ssl_cert_get_cert_store(s->cert, parg, 1);
+        return ssl_cert_get_cert_store(sc->cert, parg, 1);
 
     case SSL_CTRL_GET_PEER_SIGNATURE_NID:
-        if (s->s3.tmp.peer_sigalg == NULL)
+        if (sc->s3.tmp.peer_sigalg == NULL)
             return 0;
-        *(int *)parg = s->s3.tmp.peer_sigalg->hash;
+        *(int *)parg = sc->s3.tmp.peer_sigalg->hash;
         return 1;
 
     case SSL_CTRL_GET_SIGNATURE_NID:
-        if (s->s3.tmp.sigalg == NULL)
+        if (sc->s3.tmp.sigalg == NULL)
             return 0;
-        *(int *)parg = s->s3.tmp.sigalg->hash;
+        *(int *)parg = sc->s3.tmp.sigalg->hash;
         return 1;
 
     case SSL_CTRL_GET_PEER_TMP_KEY:
-        if (s->session == NULL || s->s3.peer_tmp == NULL) {
+        if (sc->session == NULL || sc->s3.peer_tmp == NULL) {
             return 0;
         } else {
-            EVP_PKEY_up_ref(s->s3.peer_tmp);
-            *(EVP_PKEY **)parg = s->s3.peer_tmp;
+            EVP_PKEY_up_ref(sc->s3.peer_tmp);
+            *(EVP_PKEY **)parg = sc->s3.peer_tmp;
             return 1;
         }
 
     case SSL_CTRL_GET_TMP_KEY:
-        if (s->session == NULL || s->s3.tmp.pkey == NULL) {
+        if (sc->session == NULL || sc->s3.tmp.pkey == NULL) {
             return 0;
         } else {
-            EVP_PKEY_up_ref(s->s3.tmp.pkey);
-            *(EVP_PKEY **)parg = s->s3.tmp.pkey;
+            EVP_PKEY_up_ref(sc->s3.tmp.pkey);
+            *(EVP_PKEY **)parg = sc->s3.tmp.pkey;
             return 1;
         }
 
@@ -3729,18 +3750,18 @@ long ssl3_ctrl(SSL *s, int cmd, long larg, void *parg)
         {
             const unsigned char **pformat = parg;
 
-            if (s->ext.peer_ecpointformats == NULL)
+            if (sc->ext.peer_ecpointformats == NULL)
                 return 0;
-            *pformat = s->ext.peer_ecpointformats;
-            return (int)s->ext.peer_ecpointformats_len;
+            *pformat = sc->ext.peer_ecpointformats;
+            return (int)sc->ext.peer_ecpointformats_len;
         }
 
     case SSL_CTRL_GET_IANA_GROUPS:
         {
             if (parg != NULL) {
-                *(uint16_t **)parg = (uint16_t *)s->ext.peer_supportedgroups;
+                *(uint16_t **)parg = (uint16_t *)sc->ext.peer_supportedgroups;
             }
-            return (int)s->ext.peer_supportedgroups_len;
+            return (int)sc->ext.peer_supportedgroups_len;
         }
 
     default:
@@ -3752,22 +3773,26 @@ long ssl3_ctrl(SSL *s, int cmd, long larg, void *parg)
 long ssl3_callback_ctrl(SSL *s, int cmd, void (*fp) (void))
 {
     int ret = 0;
+    SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL(s);
+
+    if (sc == NULL)
+        return ret;
 
     switch (cmd) {
 #if !defined(OPENSSL_NO_DEPRECATED_3_0)
     case SSL_CTRL_SET_TMP_DH_CB:
-        s->cert->dh_tmp_cb = (DH *(*)(SSL *, int, int))fp;
+        sc->cert->dh_tmp_cb = (DH *(*)(SSL *, int, int))fp;
         ret = 1;
         break;
 #endif
     case SSL_CTRL_SET_TLSEXT_DEBUG_CB:
-        s->ext.debug_cb = (void (*)(SSL *, int, int,
-                                    const unsigned char *, int, void *))fp;
+        sc->ext.debug_cb = (void (*)(SSL *, int, int,
+                                     const unsigned char *, int, void *))fp;
         ret = 1;
         break;
 
     case SSL_CTRL_SET_NOT_RESUMABLE_SESS_CB:
-        s->not_resumable_session_cb = (int (*)(SSL *, int))fp;
+        sc->not_resumable_session_cb = (int (*)(SSL *, int))fp;
         ret = 1;
         break;
     default:
@@ -4029,9 +4054,9 @@ long ssl3_ctx_callback_ctrl(SSL_CTX *ctx, int cmd, void (*fp) (void))
 # ifndef OPENSSL_NO_DEPRECATED_3_0
     case SSL_CTRL_SET_TLSEXT_TICKET_KEY_CB:
         ctx->ext.ticket_key_cb = (int (*)(SSL *, unsigned char *,
-                                             unsigned char *,
-                                             EVP_CIPHER_CTX *,
-                                             HMAC_CTX *, int))fp;
+                                          unsigned char *,
+                                          EVP_CIPHER_CTX *,
+                                          HMAC_CTX *, int))fp;
         break;
 #endif
 
@@ -4138,7 +4163,7 @@ int ssl3_put_cipher_by_char(const SSL_CIPHER *c, WPACKET *pkt, size_t *len)
  *
  * Returns the selected cipher or NULL when no common ciphers.
  */
-const SSL_CIPHER *ssl3_choose_cipher(SSL *s, STACK_OF(SSL_CIPHER) *clnt,
+const SSL_CIPHER *ssl3_choose_cipher(SSL_CONNECTION *s, STACK_OF(SSL_CIPHER) *clnt,
                                      STACK_OF(SSL_CIPHER) *srvr)
 {
     const SSL_CIPHER *c, *ret = NULL;
@@ -4222,7 +4247,7 @@ const SSL_CIPHER *ssl3_choose_cipher(SSL *s, STACK_OF(SSL_CIPHER) *clnt,
         allow = srvr;
     }
 
-    if (SSL_IS_TLS13(s)) {
+    if (SSL_CONNECTION_IS_TLS13(s)) {
 #ifndef OPENSSL_NO_PSK
         int j;
 
@@ -4250,10 +4275,10 @@ const SSL_CIPHER *ssl3_choose_cipher(SSL *s, STACK_OF(SSL_CIPHER) *clnt,
         c = sk_SSL_CIPHER_value(prio, i);
 
         /* Skip ciphers not supported by the protocol version */
-        if (!SSL_IS_DTLS(s) &&
+        if (!SSL_CONNECTION_IS_DTLS(s) &&
             ((s->version < c->min_tls) || (s->version > c->max_tls)))
             continue;
-        if (SSL_IS_DTLS(s) &&
+        if (SSL_CONNECTION_IS_DTLS(s) &&
             (DTLS_VERSION_LT(s->version, c->min_dtls) ||
              DTLS_VERSION_GT(s->version, c->max_dtls)))
             continue;
@@ -4262,7 +4287,7 @@ const SSL_CIPHER *ssl3_choose_cipher(SSL *s, STACK_OF(SSL_CIPHER) *clnt,
          * Since TLS 1.3 ciphersuites can be used with any auth or
          * key exchange scheme skip tests.
          */
-        if (!SSL_IS_TLS13(s)) {
+        if (!SSL_CONNECTION_IS_TLS13(s)) {
             mask_k = s->s3.tmp.mask_k;
             mask_a = s->s3.tmp.mask_a;
 #ifndef OPENSSL_NO_SRP
@@ -4312,7 +4337,8 @@ const SSL_CIPHER *ssl3_choose_cipher(SSL *s, STACK_OF(SSL_CIPHER) *clnt,
 
             if (prefer_sha256) {
                 const SSL_CIPHER *tmp = sk_SSL_CIPHER_value(allow, ii);
-                const EVP_MD *md = ssl_md(s->ctx, tmp->algorithm2);
+                const EVP_MD *md = ssl_md(SSL_CONNECTION_GET_CTX(s),
+                                          tmp->algorithm2);
 
                 if (md != NULL
                         && EVP_MD_is_a(md, OSSL_DIGEST_NAME_SHA2_256)) {
@@ -4333,7 +4359,7 @@ const SSL_CIPHER *ssl3_choose_cipher(SSL *s, STACK_OF(SSL_CIPHER) *clnt,
     return ret;
 }
 
-int ssl3_get_req_cert_type(SSL *s, WPACKET *pkt)
+int ssl3_get_req_cert_type(SSL_CONNECTION *s, WPACKET *pkt)
 {
     uint32_t alg_k, alg_a = 0;
 
@@ -4403,26 +4429,30 @@ static int ssl3_set_req_cert_type(CERT *c, const unsigned char *p, size_t len)
 int ssl3_shutdown(SSL *s)
 {
     int ret;
+    SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL_ONLY(s);
+
+    if (sc == NULL)
+        return 0;
 
     /*
      * Don't do anything much if we have not done the handshake or we don't
      * want to send messages :-)
      */
-    if (s->quiet_shutdown || SSL_in_before(s)) {
-        s->shutdown = (SSL_SENT_SHUTDOWN | SSL_RECEIVED_SHUTDOWN);
+    if (sc->quiet_shutdown || SSL_in_before(s)) {
+        sc->shutdown = (SSL_SENT_SHUTDOWN | SSL_RECEIVED_SHUTDOWN);
         return 1;
     }
 
-    if (!(s->shutdown & SSL_SENT_SHUTDOWN)) {
-        s->shutdown |= SSL_SENT_SHUTDOWN;
-        ssl3_send_alert(s, SSL3_AL_WARNING, SSL_AD_CLOSE_NOTIFY);
+    if (!(sc->shutdown & SSL_SENT_SHUTDOWN)) {
+        sc->shutdown |= SSL_SENT_SHUTDOWN;
+        ssl3_send_alert(sc, SSL3_AL_WARNING, SSL_AD_CLOSE_NOTIFY);
         /*
          * our shutdown alert has been sent now, and if it still needs to be
          * written, s->s3.alert_dispatch will be true
          */
-        if (s->s3.alert_dispatch)
+        if (sc->s3.alert_dispatch)
             return -1;        /* return WANT_WRITE */
-    } else if (s->s3.alert_dispatch) {
+    } else if (sc->s3.alert_dispatch) {
         /* resend it if not sent */
         ret = s->method->ssl_dispatch_alert(s);
         if (ret == -1) {
@@ -4433,19 +4463,19 @@ int ssl3_shutdown(SSL *s)
              */
             return ret;
         }
-    } else if (!(s->shutdown & SSL_RECEIVED_SHUTDOWN)) {
+    } else if (!(sc->shutdown & SSL_RECEIVED_SHUTDOWN)) {
         size_t readbytes;
         /*
          * If we are waiting for a close from our peer, we are closed
          */
         s->method->ssl_read_bytes(s, 0, NULL, NULL, 0, 0, &readbytes);
-        if (!(s->shutdown & SSL_RECEIVED_SHUTDOWN)) {
+        if (!(sc->shutdown & SSL_RECEIVED_SHUTDOWN)) {
             return -1;        /* return WANT_READ */
         }
     }
 
-    if ((s->shutdown == (SSL_SENT_SHUTDOWN | SSL_RECEIVED_SHUTDOWN)) &&
-        !s->s3.alert_dispatch)
+    if ((sc->shutdown == (SSL_SENT_SHUTDOWN | SSL_RECEIVED_SHUTDOWN)) &&
+        !sc->s3.alert_dispatch)
         return 1;
     else
         return 0;
@@ -4453,8 +4483,13 @@ int ssl3_shutdown(SSL *s)
 
 int ssl3_write(SSL *s, const void *buf, size_t len, size_t *written)
 {
+    SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL_ONLY(s);
+
+    if (sc == NULL)
+        return 0;
+
     clear_sys_error();
-    if (s->s3.renegotiate)
+    if (sc->s3.renegotiate)
         ssl3_renegotiate_check(s, 0);
 
     return s->method->ssl_write_bytes(s, SSL3_RT_APPLICATION_DATA, buf, len,
@@ -4465,15 +4500,19 @@ static int ssl3_read_internal(SSL *s, void *buf, size_t len, int peek,
                               size_t *readbytes)
 {
     int ret;
+    SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL_ONLY(s);
+
+    if (sc == NULL)
+        return 0;
 
     clear_sys_error();
-    if (s->s3.renegotiate)
+    if (sc->s3.renegotiate)
         ssl3_renegotiate_check(s, 0);
-    s->s3.in_read_app_data = 1;
+    sc->s3.in_read_app_data = 1;
     ret =
         s->method->ssl_read_bytes(s, SSL3_RT_APPLICATION_DATA, NULL, buf, len,
                                   peek, readbytes);
-    if ((ret == -1) && (s->s3.in_read_app_data == 2)) {
+    if ((ret == -1) && (sc->s3.in_read_app_data == 2)) {
         /*
          * ssl3_read_bytes decided to call s->handshake_func, which called
          * ssl3_read_bytes to read handshake data. However, ssl3_read_bytes
@@ -4481,13 +4520,13 @@ static int ssl3_read_internal(SSL *s, void *buf, size_t len, int peek,
          * makes sense here; so disable handshake processing and try to read
          * application data again.
          */
-        ossl_statem_set_in_handshake(s, 1);
+        ossl_statem_set_in_handshake(sc, 1);
         ret =
             s->method->ssl_read_bytes(s, SSL3_RT_APPLICATION_DATA, NULL, buf,
                                       len, peek, readbytes);
-        ossl_statem_set_in_handshake(s, 0);
+        ossl_statem_set_in_handshake(sc, 0);
     } else
-        s->s3.in_read_app_data = 0;
+        sc->s3.in_read_app_data = 0;
 
     return ret;
 }
@@ -4504,10 +4543,15 @@ int ssl3_peek(SSL *s, void *buf, size_t len, size_t *readbytes)
 
 int ssl3_renegotiate(SSL *s)
 {
-    if (s->handshake_func == NULL)
+    SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL_ONLY(s);
+
+    if (sc == NULL)
+        return 0;
+
+    if (sc->handshake_func == NULL)
         return 1;
 
-    s->s3.renegotiate = 1;
+    sc->s3.renegotiate = 1;
     return 1;
 }
 
@@ -4522,20 +4566,24 @@ int ssl3_renegotiate(SSL *s)
 int ssl3_renegotiate_check(SSL *s, int initok)
 {
     int ret = 0;
+    SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL_ONLY(s);
 
-    if (s->s3.renegotiate) {
-        if (!RECORD_LAYER_read_pending(&s->rlayer)
-            && !RECORD_LAYER_write_pending(&s->rlayer)
+    if (sc == NULL)
+        return 0;
+
+    if (sc->s3.renegotiate) {
+        if (!RECORD_LAYER_read_pending(&sc->rlayer)
+            && !RECORD_LAYER_write_pending(&sc->rlayer)
             && (initok || !SSL_in_init(s))) {
             /*
              * if we are the server, and we have sent a 'RENEGOTIATE'
              * message, we need to set the state machine into the renegotiate
              * state.
              */
-            ossl_statem_set_renegotiate(s);
-            s->s3.renegotiate = 0;
-            s->s3.num_renegotiations++;
-            s->s3.total_renegotiations++;
+            ossl_statem_set_renegotiate(sc);
+            sc->s3.renegotiate = 0;
+            sc->s3.num_renegotiations++;
+            sc->s3.total_renegotiations++;
             ret = 1;
         }
     }
@@ -4548,13 +4596,15 @@ int ssl3_renegotiate_check(SSL *s, int initok)
  *
  * If PSK and using SHA384 for TLS < 1.2 switch to default.
  */
-long ssl_get_algorithm2(SSL *s)
+long ssl_get_algorithm2(SSL_CONNECTION *s)
 {
     long alg2;
+    SSL *ssl = SSL_CONNECTION_GET_SSL(s);
+
     if (s->s3.tmp.new_cipher == NULL)
         return -1;
     alg2 = s->s3.tmp.new_cipher->algorithm2;
-    if (s->method->ssl3_enc->enc_flags & SSL_ENC_FLAG_SHA256_PRF) {
+    if (ssl->method->ssl3_enc->enc_flags & SSL_ENC_FLAG_SHA256_PRF) {
         if (alg2 == (SSL_HANDSHAKE_MAC_DEFAULT | TLS1_PRF))
             return SSL_HANDSHAKE_MAC_SHA256 | TLS1_PRF_SHA256;
     } else if (s->s3.tmp.new_cipher->algorithm_mkey & SSL_PSK) {
@@ -4568,7 +4618,8 @@ long ssl_get_algorithm2(SSL *s)
  * Fill a ClientRandom or ServerRandom field of length len. Returns <= 0 on
  * failure, 1 on success.
  */
-int ssl_fill_hello_random(SSL *s, int server, unsigned char *result, size_t len,
+int ssl_fill_hello_random(SSL_CONNECTION *s, int server,
+                          unsigned char *result, size_t len,
                           DOWNGRADE dgrd)
 {
     int send_time = 0, ret;
@@ -4584,9 +4635,9 @@ int ssl_fill_hello_random(SSL *s, int server, unsigned char *result, size_t len,
         unsigned char *p = result;
 
         l2n(Time, p);
-        ret = RAND_bytes_ex(s->ctx->libctx, p, len - 4, 0);
+        ret = RAND_bytes_ex(SSL_CONNECTION_GET_CTX(s)->libctx, p, len - 4, 0);
     } else {
-        ret = RAND_bytes_ex(s->ctx->libctx, result, len, 0);
+        ret = RAND_bytes_ex(SSL_CONNECTION_GET_CTX(s)->libctx, result, len, 0);
     }
 
     if (ret > 0) {
@@ -4604,11 +4655,12 @@ int ssl_fill_hello_random(SSL *s, int server, unsigned char *result, size_t len,
     return ret;
 }
 
-int ssl_generate_master_secret(SSL *s, unsigned char *pms, size_t pmslen,
-                               int free_pms)
+int ssl_generate_master_secret(SSL_CONNECTION *s, unsigned char *pms,
+                               size_t pmslen, int free_pms)
 {
     unsigned long alg_k = s->s3.tmp.new_cipher->algorithm_mkey;
     int ret = 0;
+    SSL *ssl = SSL_CONNECTION_GET_SSL(s);
 
     if (alg_k & SSL_PSK) {
 #ifndef OPENSSL_NO_PSK
@@ -4639,7 +4691,7 @@ int ssl_generate_master_secret(SSL *s, unsigned char *pms, size_t pmslen,
         OPENSSL_clear_free(s->s3.tmp.psk, psklen);
         s->s3.tmp.psk = NULL;
         s->s3.tmp.psklen = 0;
-        if (!s->method->ssl3_enc->generate_master_secret(s,
+        if (!ssl->method->ssl3_enc->generate_master_secret(s,
                     s->session->master_key, pskpms, pskpmslen,
                     &s->session->master_key_length)) {
             OPENSSL_clear_free(pskpms, pskpmslen);
@@ -4652,7 +4704,7 @@ int ssl_generate_master_secret(SSL *s, unsigned char *pms, size_t pmslen,
         goto err;
 #endif
     } else {
-        if (!s->method->ssl3_enc->generate_master_secret(s,
+        if (!ssl->method->ssl3_enc->generate_master_secret(s,
                 s->session->master_key, pms, pmslen,
                 &s->session->master_key_length)) {
             /* SSLfatal() already called */
@@ -4676,14 +4728,15 @@ int ssl_generate_master_secret(SSL *s, unsigned char *pms, size_t pmslen,
 }
 
 /* Generate a private key from parameters */
-EVP_PKEY *ssl_generate_pkey(SSL *s, EVP_PKEY *pm)
+EVP_PKEY *ssl_generate_pkey(SSL_CONNECTION *s, EVP_PKEY *pm)
 {
     EVP_PKEY_CTX *pctx = NULL;
     EVP_PKEY *pkey = NULL;
+    SSL_CTX *sctx = SSL_CONNECTION_GET_CTX(s);
 
     if (pm == NULL)
         return NULL;
-    pctx = EVP_PKEY_CTX_new_from_pkey(s->ctx->libctx, pm, s->ctx->propq);
+    pctx = EVP_PKEY_CTX_new_from_pkey(sctx->libctx, pm, sctx->propq);
     if (pctx == NULL)
         goto err;
     if (EVP_PKEY_keygen_init(pctx) <= 0)
@@ -4699,9 +4752,10 @@ EVP_PKEY *ssl_generate_pkey(SSL *s, EVP_PKEY *pm)
 }
 
 /* Generate a private key from a group ID */
-EVP_PKEY *ssl_generate_pkey_group(SSL *s, uint16_t id)
+EVP_PKEY *ssl_generate_pkey_group(SSL_CONNECTION *s, uint16_t id)
 {
-    const TLS_GROUP_INFO *ginf = tls1_group_id_lookup(s->ctx, id);
+    SSL_CTX *sctx = SSL_CONNECTION_GET_CTX(s);
+    const TLS_GROUP_INFO *ginf = tls1_group_id_lookup(sctx, id);
     EVP_PKEY_CTX *pctx = NULL;
     EVP_PKEY *pkey = NULL;
 
@@ -4710,8 +4764,8 @@ EVP_PKEY *ssl_generate_pkey_group(SSL *s, uint16_t id)
         goto err;
     }
 
-    pctx = EVP_PKEY_CTX_new_from_name(s->ctx->libctx, ginf->algorithm,
-                                      s->ctx->propq);
+    pctx = EVP_PKEY_CTX_new_from_name(sctx->libctx, ginf->algorithm,
+                                      sctx->propq);
 
     if (pctx == NULL) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_MALLOC_FAILURE);
@@ -4739,17 +4793,18 @@ EVP_PKEY *ssl_generate_pkey_group(SSL *s, uint16_t id)
 /*
  * Generate parameters from a group ID
  */
-EVP_PKEY *ssl_generate_param_group(SSL *s, uint16_t id)
+EVP_PKEY *ssl_generate_param_group(SSL_CONNECTION *s, uint16_t id)
 {
+    SSL_CTX *sctx = SSL_CONNECTION_GET_CTX(s);
     EVP_PKEY_CTX *pctx = NULL;
     EVP_PKEY *pkey = NULL;
-    const TLS_GROUP_INFO *ginf = tls1_group_id_lookup(s->ctx, id);
+    const TLS_GROUP_INFO *ginf = tls1_group_id_lookup(sctx, id);
 
     if (ginf == NULL)
         goto err;
 
-    pctx = EVP_PKEY_CTX_new_from_name(s->ctx->libctx, ginf->algorithm,
-                                      s->ctx->propq);
+    pctx = EVP_PKEY_CTX_new_from_name(sctx->libctx, ginf->algorithm,
+                                      sctx->propq);
 
     if (pctx == NULL)
         goto err;
@@ -4770,12 +4825,12 @@ EVP_PKEY *ssl_generate_param_group(SSL *s, uint16_t id)
 }
 
 /* Generate secrets from pms */
-int ssl_gensecret(SSL *s, unsigned char *pms, size_t pmslen)
+int ssl_gensecret(SSL_CONNECTION *s, unsigned char *pms, size_t pmslen)
 {
     int rv = 0;
 
     /* SSLfatal() called as appropriate in the below functions */
-    if (SSL_IS_TLS13(s)) {
+    if (SSL_CONNECTION_IS_TLS13(s)) {
         /*
          * If we are resuming then we already generated the early secret
          * when we created the ClientHello, so don't recreate it.
@@ -4796,19 +4851,20 @@ int ssl_gensecret(SSL *s, unsigned char *pms, size_t pmslen)
 }
 
 /* Derive secrets for ECDH/DH */
-int ssl_derive(SSL *s, EVP_PKEY *privkey, EVP_PKEY *pubkey, int gensecret)
+int ssl_derive(SSL_CONNECTION *s, EVP_PKEY *privkey, EVP_PKEY *pubkey, int gensecret)
 {
     int rv = 0;
     unsigned char *pms = NULL;
     size_t pmslen = 0;
     EVP_PKEY_CTX *pctx;
+    SSL_CTX *sctx = SSL_CONNECTION_GET_CTX(s);
 
     if (privkey == NULL || pubkey == NULL) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
         return 0;
     }
 
-    pctx = EVP_PKEY_CTX_new_from_pkey(s->ctx->libctx, privkey, s->ctx->propq);
+    pctx = EVP_PKEY_CTX_new_from_pkey(sctx->libctx, privkey, sctx->propq);
 
     if (EVP_PKEY_derive_init(pctx) <= 0
         || EVP_PKEY_derive_set_peer(pctx, pubkey) <= 0
@@ -4817,7 +4873,7 @@ int ssl_derive(SSL *s, EVP_PKEY *privkey, EVP_PKEY *pubkey, int gensecret)
         goto err;
     }
 
-    if (SSL_IS_TLS13(s) &&  EVP_PKEY_is_a(privkey, "DH"))
+    if (SSL_CONNECTION_IS_TLS13(s) &&  EVP_PKEY_is_a(privkey, "DH"))
         EVP_PKEY_CTX_set_dh_pad(pctx, 1);
 
     pms = OPENSSL_malloc(pmslen);
@@ -4849,7 +4905,7 @@ int ssl_derive(SSL *s, EVP_PKEY *privkey, EVP_PKEY *pubkey, int gensecret)
 }
 
 /* Decapsulate secrets for KEM */
-int ssl_decapsulate(SSL *s, EVP_PKEY *privkey,
+int ssl_decapsulate(SSL_CONNECTION *s, EVP_PKEY *privkey,
                     const unsigned char *ct, size_t ctlen,
                     int gensecret)
 {
@@ -4857,13 +4913,14 @@ int ssl_decapsulate(SSL *s, EVP_PKEY *privkey,
     unsigned char *pms = NULL;
     size_t pmslen = 0;
     EVP_PKEY_CTX *pctx;
+    SSL_CTX *sctx = SSL_CONNECTION_GET_CTX(s);
 
     if (privkey == NULL) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
         return 0;
     }
 
-    pctx = EVP_PKEY_CTX_new_from_pkey(s->ctx->libctx, privkey, s->ctx->propq);
+    pctx = EVP_PKEY_CTX_new_from_pkey(sctx->libctx, privkey, sctx->propq);
 
     if (EVP_PKEY_decapsulate_init(pctx, NULL) <= 0
             || EVP_PKEY_decapsulate(pctx, NULL, &pmslen, ct, ctlen) <= 0) {
@@ -4899,7 +4956,7 @@ int ssl_decapsulate(SSL *s, EVP_PKEY *privkey,
     return rv;
 }
 
-int ssl_encapsulate(SSL *s, EVP_PKEY *pubkey,
+int ssl_encapsulate(SSL_CONNECTION *s, EVP_PKEY *pubkey,
                     unsigned char **ctp, size_t *ctlenp,
                     int gensecret)
 {
@@ -4907,13 +4964,14 @@ int ssl_encapsulate(SSL *s, EVP_PKEY *pubkey,
     unsigned char *pms = NULL, *ct = NULL;
     size_t pmslen = 0, ctlen = 0;
     EVP_PKEY_CTX *pctx;
+    SSL_CTX *sctx = SSL_CONNECTION_GET_CTX(s);
 
     if (pubkey == NULL) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
         return 0;
     }
 
-    pctx = EVP_PKEY_CTX_new_from_pkey(s->ctx->libctx, pubkey, s->ctx->propq);
+    pctx = EVP_PKEY_CTX_new_from_pkey(sctx->libctx, pubkey, sctx->propq);
 
     if (EVP_PKEY_encapsulate_init(pctx, NULL) <= 0
             || EVP_PKEY_encapsulate(pctx, NULL, &ctlen, NULL, &pmslen) <= 0

--- a/ssl/ssl_ciph.c
+++ b/ssl/ssl_ciph.c
@@ -625,14 +625,15 @@ const EVP_MD *ssl_md(SSL_CTX *ctx, int idx)
     return ctx->ssl_digest_methods[idx];
 }
 
-const EVP_MD *ssl_handshake_md(SSL *s)
+const EVP_MD *ssl_handshake_md(SSL_CONNECTION *s)
 {
-    return ssl_md(s->ctx, ssl_get_algorithm2(s));
+    return ssl_md(SSL_CONNECTION_GET_CTX(s), ssl_get_algorithm2(s));
 }
 
-const EVP_MD *ssl_prf_md(SSL *s)
+const EVP_MD *ssl_prf_md(SSL_CONNECTION *s)
 {
-    return ssl_md(s->ctx, ssl_get_algorithm2(s) >> TLS1_PRF_DGST_SHIFT);
+    return ssl_md(SSL_CONNECTION_GET_CTX(s),
+                  ssl_get_algorithm2(s) >> TLS1_PRF_DGST_SHIFT);
 }
 
 #define ITEM_SEP(a) \
@@ -1431,15 +1432,22 @@ int SSL_CTX_set_ciphersuites(SSL_CTX *ctx, const char *str)
 int SSL_set_ciphersuites(SSL *s, const char *str)
 {
     STACK_OF(SSL_CIPHER) *cipher_list;
-    int ret = set_ciphersuites(&(s->tls13_ciphersuites), str);
+    SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL(s);
+    int ret;
 
-    if (s->cipher_list == NULL) {
+    if (sc == NULL)
+        return 0;
+
+    ret = set_ciphersuites(&(sc->tls13_ciphersuites), str);
+
+    if (sc->cipher_list == NULL) {
         if ((cipher_list = SSL_get_ciphers(s)) != NULL)
-            s->cipher_list = sk_SSL_CIPHER_dup(cipher_list);
+            sc->cipher_list = sk_SSL_CIPHER_dup(cipher_list);
     }
-    if (ret && s->cipher_list != NULL)
-        return update_cipher_list(s->ctx, &s->cipher_list, &s->cipher_list_by_id,
-                                  s->tls13_ciphersuites);
+    if (ret && sc->cipher_list != NULL)
+        return update_cipher_list(s->ctx, &sc->cipher_list,
+                                  &sc->cipher_list_by_id,
+                                  sc->tls13_ciphersuites);
 
     return ret;
 }
@@ -2096,10 +2104,11 @@ int SSL_COMP_get_id(const SSL_COMP *comp)
 #endif
 }
 
-const SSL_CIPHER *ssl_get_cipher_by_char(SSL *ssl, const unsigned char *ptr,
+const SSL_CIPHER *ssl_get_cipher_by_char(SSL_CONNECTION *s,
+                                         const unsigned char *ptr,
                                          int all)
 {
-    const SSL_CIPHER *c = ssl->method->get_cipher_by_char(ptr);
+    const SSL_CIPHER *c = SSL_CONNECTION_GET_SSL(s)->method->get_cipher_by_char(ptr);
 
     if (c == NULL || (!all && c->valid == 0))
         return NULL;

--- a/ssl/ssl_stat.c
+++ b/ssl/ssl_stat.c
@@ -13,7 +13,9 @@
 
 const char *SSL_state_string_long(const SSL *s)
 {
-    if (ossl_statem_in_error(s))
+    const SSL_CONNECTION *sc = SSL_CONNECTION_FROM_CONST_SSL(s);
+
+    if (sc == NULL || ossl_statem_in_error(sc))
         return "error";
 
     switch (SSL_get_state(s)) {
@@ -120,7 +122,9 @@ const char *SSL_state_string_long(const SSL *s)
 
 const char *SSL_state_string(const SSL *s)
 {
-    if (ossl_statem_in_error(s))
+    const SSL_CONNECTION *sc = SSL_CONNECTION_FROM_CONST_SSL(s);
+
+    if (sc == NULL || ossl_statem_in_error(sc))
         return "SSLERR";
 
     switch (SSL_get_state(s)) {

--- a/ssl/statem/statem.c
+++ b/ssl/statem/statem.c
@@ -62,29 +62,49 @@ typedef enum {
     SUB_STATE_END_HANDSHAKE
 } SUB_STATE_RETURN;
 
-static int state_machine(SSL *s, int server);
-static void init_read_state_machine(SSL *s);
-static SUB_STATE_RETURN read_state_machine(SSL *s);
-static void init_write_state_machine(SSL *s);
-static SUB_STATE_RETURN write_state_machine(SSL *s);
+static int state_machine(SSL_CONNECTION *s, int server);
+static void init_read_state_machine(SSL_CONNECTION *s);
+static SUB_STATE_RETURN read_state_machine(SSL_CONNECTION *s);
+static void init_write_state_machine(SSL_CONNECTION *s);
+static SUB_STATE_RETURN write_state_machine(SSL_CONNECTION *s);
 
 OSSL_HANDSHAKE_STATE SSL_get_state(const SSL *ssl)
 {
-    return ssl->statem.hand_state;
+    const SSL_CONNECTION *sc = SSL_CONNECTION_FROM_CONST_SSL(ssl);
+
+    if (sc == NULL)
+        return TLS_ST_BEFORE;
+
+    return sc->statem.hand_state;
 }
 
 int SSL_in_init(const SSL *s)
 {
-    return s->statem.in_init;
+    const SSL_CONNECTION *sc = SSL_CONNECTION_FROM_CONST_SSL(s);
+
+    if (sc == NULL)
+        return 0;
+
+    return sc->statem.in_init;
 }
 
 int SSL_is_init_finished(const SSL *s)
 {
-    return !(s->statem.in_init) && (s->statem.hand_state == TLS_ST_OK);
+    const SSL_CONNECTION *sc = SSL_CONNECTION_FROM_CONST_SSL(s);
+
+    if (sc == NULL)
+        return 0;
+
+    return !(sc->statem.in_init) && (sc->statem.hand_state == TLS_ST_OK);
 }
 
 int SSL_in_before(const SSL *s)
 {
+    const SSL_CONNECTION *sc = SSL_CONNECTION_FROM_CONST_SSL(s);
+
+    if (sc == NULL)
+        return 0;
+
     /*
      * Historically being "in before" meant before anything had happened. In the
      * current code though we remain in the "before" state for a while after we
@@ -92,14 +112,14 @@ int SSL_in_before(const SSL *s)
      * first message to arrive). There "in before" is taken to mean "in before"
      * and not started any handshake process yet.
      */
-    return (s->statem.hand_state == TLS_ST_BEFORE)
-        && (s->statem.state == MSG_FLOW_UNINITED);
+    return (sc->statem.hand_state == TLS_ST_BEFORE)
+        && (sc->statem.state == MSG_FLOW_UNINITED);
 }
 
 /*
  * Clear the state machine state and reset back to MSG_FLOW_UNINITED
  */
-void ossl_statem_clear(SSL *s)
+void ossl_statem_clear(SSL_CONNECTION *s)
 {
     s->statem.state = MSG_FLOW_UNINITED;
     s->statem.hand_state = TLS_ST_BEFORE;
@@ -110,13 +130,13 @@ void ossl_statem_clear(SSL *s)
 /*
  * Set the state machine up ready for a renegotiation handshake
  */
-void ossl_statem_set_renegotiate(SSL *s)
+void ossl_statem_set_renegotiate(SSL_CONNECTION *s)
 {
     s->statem.in_init = 1;
     s->statem.request_state = TLS_ST_SW_HELLO_REQ;
 }
 
-void ossl_statem_send_fatal(SSL *s, int al)
+void ossl_statem_send_fatal(SSL_CONNECTION *s, int al)
 {
     /* We shouldn't call SSLfatal() twice. Once is enough */
     if (s->statem.in_init && s->statem.state == MSG_FLOW_ERROR)
@@ -134,7 +154,8 @@ void ossl_statem_send_fatal(SSL *s, int al)
  * into an error state and sends an alert if appropriate.
  * This is a permanent error for the current connection.
  */
-void ossl_statem_fatal(SSL *s, int al, int reason, const char *fmt, ...)
+void ossl_statem_fatal(SSL_CONNECTION *s, int al, int reason,
+                       const char *fmt, ...)
 {
     va_list args;
 
@@ -164,7 +185,7 @@ void ossl_statem_fatal(SSL *s, int al, int reason, const char *fmt, ...)
  *   1: Yes
  *   0: No
  */
-int ossl_statem_in_error(const SSL *s)
+int ossl_statem_in_error(const SSL_CONNECTION *s)
 {
     if (s->statem.state == MSG_FLOW_ERROR)
         return 1;
@@ -172,17 +193,17 @@ int ossl_statem_in_error(const SSL *s)
     return 0;
 }
 
-void ossl_statem_set_in_init(SSL *s, int init)
+void ossl_statem_set_in_init(SSL_CONNECTION *s, int init)
 {
     s->statem.in_init = init;
 }
 
-int ossl_statem_get_in_handshake(SSL *s)
+int ossl_statem_get_in_handshake(SSL_CONNECTION *s)
 {
     return s->statem.in_handshake;
 }
 
-void ossl_statem_set_in_handshake(SSL *s, int inhand)
+void ossl_statem_set_in_handshake(SSL_CONNECTION *s, int inhand)
 {
     if (inhand)
         s->statem.in_handshake++;
@@ -191,7 +212,7 @@ void ossl_statem_set_in_handshake(SSL *s, int inhand)
 }
 
 /* Are we in a sensible state to skip over unreadable early data? */
-int ossl_statem_skip_early_data(SSL *s)
+int ossl_statem_skip_early_data(SSL_CONNECTION *s)
 {
     if (s->ext.early_data != SSL_EARLY_DATA_REJECTED)
         return 0;
@@ -212,7 +233,7 @@ int ossl_statem_skip_early_data(SSL *s)
  * attempting to read data (SSL_read*()), or -1 if we are in SSL_do_handshake()
  * or similar.
  */
-void ossl_statem_check_finish_init(SSL *s, int sending)
+void ossl_statem_check_finish_init(SSL_CONNECTION *s, int sending)
 {
     if (sending == -1) {
         if (s->statem.hand_state == TLS_ST_PENDING_EARLY_DATA_END
@@ -246,7 +267,7 @@ void ossl_statem_check_finish_init(SSL *s, int sending)
     }
 }
 
-void ossl_statem_set_hello_verify_done(SSL *s)
+void ossl_statem_set_hello_verify_done(SSL_CONNECTION *s)
 {
     s->statem.state = MSG_FLOW_UNINITED;
     s->statem.in_init = 1;
@@ -262,22 +283,34 @@ void ossl_statem_set_hello_verify_done(SSL *s)
 
 int ossl_statem_connect(SSL *s)
 {
-    return state_machine(s, 0);
+    SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL(s);
+
+    if (sc == NULL)
+        return -1;
+
+    return state_machine(sc, 0);
 }
 
 int ossl_statem_accept(SSL *s)
 {
-    return state_machine(s, 1);
+    SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL(s);
+
+    if (sc == NULL)
+        return -1;
+
+    return state_machine(sc, 1);
 }
 
 typedef void (*info_cb) (const SSL *, int, int);
 
-static info_cb get_callback(SSL *s)
+static info_cb get_callback(SSL_CONNECTION *s)
 {
+    SSL_CTX *sctx = SSL_CONNECTION_GET_CTX(s);
+
     if (s->info_callback != NULL)
         return s->info_callback;
-    else if (s->ctx->info_callback != NULL)
-        return s->ctx->info_callback;
+    else if (sctx->info_callback != NULL)
+        return sctx->info_callback;
 
     return NULL;
 }
@@ -310,13 +343,14 @@ static info_cb get_callback(SSL *s)
  *   1: Success
  * <=0: NBIO or error
  */
-static int state_machine(SSL *s, int server)
+static int state_machine(SSL_CONNECTION *s, int server)
 {
     BUF_MEM *buf = NULL;
     void (*cb) (const SSL *ssl, int type, int val) = NULL;
     OSSL_STATEM *st = &s->statem;
     int ret = -1;
     int ssret;
+    SSL *ssl = SSL_CONNECTION_GET_SSL(s);
 
     if (st->state == MSG_FLOW_ERROR) {
         /* Shouldn't have been called if we're already in the error state */
@@ -329,21 +363,21 @@ static int state_machine(SSL *s, int server)
     cb = get_callback(s);
 
     st->in_handshake++;
-    if (!SSL_in_init(s) || SSL_in_before(s)) {
+    if (!SSL_in_init(ssl) || SSL_in_before(ssl)) {
         /*
          * If we are stateless then we already called SSL_clear() - don't do
          * it again and clear the STATELESS flag itself.
          */
-        if ((s->s3.flags & TLS1_FLAGS_STATELESS) == 0 && !SSL_clear(s))
+        if ((s->s3.flags & TLS1_FLAGS_STATELESS) == 0 && !SSL_clear(ssl))
             return -1;
     }
 #ifndef OPENSSL_NO_SCTP
-    if (SSL_IS_DTLS(s) && BIO_dgram_is_sctp(SSL_get_wbio(s))) {
+    if (SSL_CONNECTION_IS_DTLS(s) && BIO_dgram_is_sctp(SSL_get_wbio(ssl))) {
         /*
          * Notify SCTP BIO socket to enter handshake mode and prevent stream
          * identifier other than 0.
          */
-        BIO_ctrl(SSL_get_wbio(s), BIO_CTRL_DGRAM_SCTP_SET_IN_HANDSHAKE,
+        BIO_ctrl(SSL_get_wbio(ssl), BIO_CTRL_DGRAM_SCTP_SET_IN_HANDSHAKE,
                  st->in_handshake, NULL);
     }
 #endif
@@ -358,8 +392,8 @@ static int state_machine(SSL *s, int server)
 
         s->server = server;
         if (cb != NULL) {
-            if (SSL_IS_FIRST_HANDSHAKE(s) || !SSL_IS_TLS13(s))
-                cb(s, SSL_CB_HANDSHAKE_START, 1);
+            if (SSL_IS_FIRST_HANDSHAKE(s) || !SSL_CONNECTION_IS_TLS13(s))
+                cb(ssl, SSL_CB_HANDSHAKE_START, 1);
         }
 
         /*
@@ -368,7 +402,7 @@ static int state_machine(SSL *s, int server)
          * doomed to failure.
          */
 
-        if (SSL_IS_DTLS(s)) {
+        if (SSL_CONNECTION_IS_DTLS(s)) {
             if ((s->version & 0xff00) != (DTLS1_VERSION & 0xff00) &&
                 (server || (s->version & 0xff00) != (DTLS1_BAD_VER & 0xff00))) {
                 SSLfatal(s, SSL_AD_NO_ALERT, ERR_R_INTERNAL_ERROR);
@@ -415,14 +449,14 @@ static int state_machine(SSL *s, int server)
          * SCTP
          */
 #ifndef OPENSSL_NO_SCTP
-        if (!SSL_IS_DTLS(s) || !BIO_dgram_is_sctp(SSL_get_wbio(s)))
+        if (!SSL_CONNECTION_IS_DTLS(s) || !BIO_dgram_is_sctp(SSL_get_wbio(ssl)))
 #endif
             if (!ssl_init_wbio_buffer(s)) {
                 SSLfatal(s, SSL_AD_NO_ALERT, ERR_R_INTERNAL_ERROR);
                 goto end;
             }
 
-        if ((SSL_in_before(s))
+        if ((SSL_in_before(ssl))
                 || s->renegotiate) {
             if (!tls_setup_handshake(s)) {
                 /* SSLfatal() already called */
@@ -472,12 +506,12 @@ static int state_machine(SSL *s, int server)
     st->in_handshake--;
 
 #ifndef OPENSSL_NO_SCTP
-    if (SSL_IS_DTLS(s) && BIO_dgram_is_sctp(SSL_get_wbio(s))) {
+    if (SSL_CONNECTION_IS_DTLS(s) && BIO_dgram_is_sctp(SSL_get_wbio(ssl))) {
         /*
          * Notify SCTP BIO socket to leave handshake mode and allow stream
          * identifier other than 0.
          */
-        BIO_ctrl(SSL_get_wbio(s), BIO_CTRL_DGRAM_SCTP_SET_IN_HANDSHAKE,
+        BIO_ctrl(SSL_get_wbio(ssl), BIO_CTRL_DGRAM_SCTP_SET_IN_HANDSHAKE,
                  st->in_handshake, NULL);
     }
 #endif
@@ -485,9 +519,9 @@ static int state_machine(SSL *s, int server)
     BUF_MEM_free(buf);
     if (cb != NULL) {
         if (server)
-            cb(s, SSL_CB_ACCEPT_EXIT, ret);
+            cb(ssl, SSL_CB_ACCEPT_EXIT, ret);
         else
-            cb(s, SSL_CB_CONNECT_EXIT, ret);
+            cb(ssl, SSL_CB_CONNECT_EXIT, ret);
     }
     return ret;
 }
@@ -495,14 +529,14 @@ static int state_machine(SSL *s, int server)
 /*
  * Initialise the MSG_FLOW_READING sub-state machine
  */
-static void init_read_state_machine(SSL *s)
+static void init_read_state_machine(SSL_CONNECTION *s)
 {
     OSSL_STATEM *st = &s->statem;
 
     st->read_state = READ_STATE_HEADER;
 }
 
-static int grow_init_buf(SSL *s, size_t size) {
+static int grow_init_buf(SSL_CONNECTION *s, size_t size) {
 
     size_t msg_offset = (char *)s->init_msg - s->init_buf->data;
 
@@ -543,17 +577,18 @@ static int grow_init_buf(SSL *s, size_t size) {
  * control returns to the calling application. When this function is recalled we
  * will resume in the same state where we left off.
  */
-static SUB_STATE_RETURN read_state_machine(SSL *s)
+static SUB_STATE_RETURN read_state_machine(SSL_CONNECTION *s)
 {
     OSSL_STATEM *st = &s->statem;
     int ret, mt;
     size_t len = 0;
-    int (*transition) (SSL *s, int mt);
+    int (*transition) (SSL_CONNECTION *s, int mt);
     PACKET pkt;
-    MSG_PROCESS_RETURN(*process_message) (SSL *s, PACKET *pkt);
-    WORK_STATE(*post_process_message) (SSL *s, WORK_STATE wst);
-    size_t (*max_message_size) (SSL *s);
+    MSG_PROCESS_RETURN(*process_message) (SSL_CONNECTION *s, PACKET *pkt);
+    WORK_STATE(*post_process_message) (SSL_CONNECTION *s, WORK_STATE wst);
+    size_t (*max_message_size) (SSL_CONNECTION *s);
     void (*cb) (const SSL *ssl, int type, int val) = NULL;
+    SSL *ssl = SSL_CONNECTION_GET_SSL(s);
 
     cb = get_callback(s);
 
@@ -578,7 +613,7 @@ static SUB_STATE_RETURN read_state_machine(SSL *s)
         switch (st->read_state) {
         case READ_STATE_HEADER:
             /* Get the state the peer wants to move to */
-            if (SSL_IS_DTLS(s)) {
+            if (SSL_CONNECTION_IS_DTLS(s)) {
                 /*
                  * In DTLS we get the whole message in one go - header and body
                  */
@@ -595,9 +630,9 @@ static SUB_STATE_RETURN read_state_machine(SSL *s)
             if (cb != NULL) {
                 /* Notify callback of an impending state change */
                 if (s->server)
-                    cb(s, SSL_CB_ACCEPT_LOOP, 1);
+                    cb(ssl, SSL_CB_ACCEPT_LOOP, 1);
                 else
-                    cb(s, SSL_CB_CONNECT_LOOP, 1);
+                    cb(ssl, SSL_CB_CONNECT_LOOP, 1);
             }
             /*
              * Validate that we are allowed to move to the new state and move
@@ -613,7 +648,7 @@ static SUB_STATE_RETURN read_state_machine(SSL *s)
             }
 
             /* dtls_get_message already did this */
-            if (!SSL_IS_DTLS(s)
+            if (!SSL_CONNECTION_IS_DTLS(s)
                     && s->s3.tmp.message_size > 0
                     && !grow_init_buf(s, s->s3.tmp.message_size
                                          + SSL3_HM_HEADER_LENGTH)) {
@@ -625,7 +660,7 @@ static SUB_STATE_RETURN read_state_machine(SSL *s)
             /* Fall through */
 
         case READ_STATE_BODY:
-            if (SSL_IS_DTLS(s)) {
+            if (SSL_CONNECTION_IS_DTLS(s)) {
                 /*
                  * Actually we already have the body, but we give DTLS the
                  * opportunity to do any further processing.
@@ -655,7 +690,7 @@ static SUB_STATE_RETURN read_state_machine(SSL *s)
                 return SUB_STATE_ERROR;
 
             case MSG_PROCESS_FINISHED_READING:
-                if (SSL_IS_DTLS(s)) {
+                if (SSL_CONNECTION_IS_DTLS(s)) {
                     dtls1_stop_timer(s);
                 }
                 return SUB_STATE_FINISHED;
@@ -687,7 +722,7 @@ static SUB_STATE_RETURN read_state_machine(SSL *s)
                 break;
 
             case WORK_FINISHED_STOP:
-                if (SSL_IS_DTLS(s)) {
+                if (SSL_CONNECTION_IS_DTLS(s)) {
                     dtls1_stop_timer(s);
                 }
                 return SUB_STATE_FINISHED;
@@ -705,13 +740,13 @@ static SUB_STATE_RETURN read_state_machine(SSL *s)
 /*
  * Send a previously constructed message to the peer.
  */
-static int statem_do_write(SSL *s)
+static int statem_do_write(SSL_CONNECTION *s)
 {
     OSSL_STATEM *st = &s->statem;
 
     if (st->hand_state == TLS_ST_CW_CHANGE
         || st->hand_state == TLS_ST_SW_CHANGE) {
-        if (SSL_IS_DTLS(s))
+        if (SSL_CONNECTION_IS_DTLS(s))
             return dtls1_do_write(s, SSL3_RT_CHANGE_CIPHER_SPEC);
         else
             return ssl3_do_write(s, SSL3_RT_CHANGE_CIPHER_SPEC);
@@ -723,7 +758,7 @@ static int statem_do_write(SSL *s)
 /*
  * Initialise the MSG_FLOW_WRITING sub-state machine
  */
-static void init_write_state_machine(SSL *s)
+static void init_write_state_machine(SSL_CONNECTION *s)
 {
     OSSL_STATEM *st = &s->statem;
 
@@ -761,20 +796,22 @@ static void init_write_state_machine(SSL *s)
  * message has been completed. As for WRITE_STATE_PRE_WORK this could also
  * result in an NBIO event.
  */
-static SUB_STATE_RETURN write_state_machine(SSL *s)
+static SUB_STATE_RETURN write_state_machine(SSL_CONNECTION *s)
 {
     OSSL_STATEM *st = &s->statem;
     int ret;
-    WRITE_TRAN(*transition) (SSL *s);
-    WORK_STATE(*pre_work) (SSL *s, WORK_STATE wst);
-    WORK_STATE(*post_work) (SSL *s, WORK_STATE wst);
-    int (*get_construct_message_f) (SSL *s,
-                                    int (**confunc) (SSL *s, WPACKET *pkt),
+    WRITE_TRAN(*transition) (SSL_CONNECTION *s);
+    WORK_STATE(*pre_work) (SSL_CONNECTION *s, WORK_STATE wst);
+    WORK_STATE(*post_work) (SSL_CONNECTION *s, WORK_STATE wst);
+    int (*get_construct_message_f) (SSL_CONNECTION *s,
+                                    int (**confunc) (SSL_CONNECTION *s,
+                                                     WPACKET *pkt),
                                     int *mt);
     void (*cb) (const SSL *ssl, int type, int val) = NULL;
-    int (*confunc) (SSL *s, WPACKET *pkt);
+    int (*confunc) (SSL_CONNECTION *s, WPACKET *pkt);
     int mt;
     WPACKET pkt;
+    SSL *ssl = SSL_CONNECTION_GET_SSL(s);
 
     cb = get_callback(s);
 
@@ -796,9 +833,9 @@ static SUB_STATE_RETURN write_state_machine(SSL *s)
             if (cb != NULL) {
                 /* Notify callback of an impending state change */
                 if (s->server)
-                    cb(s, SSL_CB_ACCEPT_LOOP, 1);
+                    cb(ssl, SSL_CB_ACCEPT_LOOP, 1);
                 else
-                    cb(s, SSL_CB_CONNECT_LOOP, 1);
+                    cb(ssl, SSL_CB_CONNECT_LOOP, 1);
             }
             switch (transition(s)) {
             case WRITE_TRAN_CONTINUE:
@@ -864,7 +901,7 @@ static SUB_STATE_RETURN write_state_machine(SSL *s)
             /* Fall through */
 
         case WRITE_STATE_SEND:
-            if (SSL_IS_DTLS(s) && st->use_timer) {
+            if (SSL_CONNECTION_IS_DTLS(s) && st->use_timer) {
                 dtls1_start_timer(s);
             }
             ret = statem_do_write(s);
@@ -904,7 +941,7 @@ static SUB_STATE_RETURN write_state_machine(SSL *s)
 /*
  * Flush the write BIO
  */
-int statem_flush(SSL *s)
+int statem_flush(SSL_CONNECTION *s)
 {
     s->rwstate = SSL_WRITING;
     if (BIO_flush(s->wbio) <= 0) {
@@ -923,7 +960,7 @@ int statem_flush(SSL *s)
  *   1: Yes (application data allowed)
  *   0: No (application data not allowed)
  */
-int ossl_statem_app_data_allowed(SSL *s)
+int ossl_statem_app_data_allowed(SSL_CONNECTION *s)
 {
     OSSL_STATEM *st = &s->statem;
 
@@ -957,7 +994,7 @@ int ossl_statem_app_data_allowed(SSL *s)
  * This function returns 1 if TLS exporter is ready to export keying
  * material, or 0 if otherwise.
  */
-int ossl_statem_export_allowed(SSL *s)
+int ossl_statem_export_allowed(SSL_CONNECTION *s)
 {
     return s->s3.previous_server_finished_len != 0
            && s->statem.hand_state != TLS_ST_SW_FINISHED;
@@ -967,7 +1004,7 @@ int ossl_statem_export_allowed(SSL *s)
  * Return 1 if early TLS exporter is ready to export keying material,
  * or 0 if otherwise.
  */
-int ossl_statem_export_early_allowed(SSL *s)
+int ossl_statem_export_early_allowed(SSL_CONNECTION *s)
 {
     /*
      * The early exporter secret is only present on the server if we

--- a/ssl/statem/statem.h
+++ b/ssl/statem/statem.h
@@ -130,10 +130,11 @@ typedef struct ossl_statem_st OSSL_STATEM;
 
 __owur int ossl_statem_accept(SSL *s);
 __owur int ossl_statem_connect(SSL *s);
-void ossl_statem_clear(SSL *s);
-void ossl_statem_set_renegotiate(SSL *s);
-void ossl_statem_send_fatal(SSL *s, int al);
-void ossl_statem_fatal(SSL *s, int al, int reason, const char *fmt, ...);
+void ossl_statem_clear(SSL_CONNECTION *s);
+void ossl_statem_set_renegotiate(SSL_CONNECTION *s);
+void ossl_statem_send_fatal(SSL_CONNECTION *s, int al);
+void ossl_statem_fatal(SSL_CONNECTION *s, int al, int reason,
+                       const char *fmt, ...);
 # define SSL_AD_NO_ALERT    -1
 # define SSLfatal_alert(s, al) ossl_statem_send_fatal((s), (al))
 # define SSLfatal(s, al, r) SSLfatal_data((s), (al), (r), NULL)
@@ -142,16 +143,16 @@ void ossl_statem_fatal(SSL *s, int al, int reason, const char *fmt, ...);
      ERR_set_debug(OPENSSL_FILE, OPENSSL_LINE, OPENSSL_FUNC),   \
      ossl_statem_fatal)
 
-int ossl_statem_in_error(const SSL *s);
-void ossl_statem_set_in_init(SSL *s, int init);
-int ossl_statem_get_in_handshake(SSL *s);
-void ossl_statem_set_in_handshake(SSL *s, int inhand);
-__owur int ossl_statem_skip_early_data(SSL *s);
-void ossl_statem_check_finish_init(SSL *s, int send);
-void ossl_statem_set_hello_verify_done(SSL *s);
-__owur int ossl_statem_app_data_allowed(SSL *s);
-__owur int ossl_statem_export_allowed(SSL *s);
-__owur int ossl_statem_export_early_allowed(SSL *s);
+int ossl_statem_in_error(const SSL_CONNECTION *s);
+void ossl_statem_set_in_init(SSL_CONNECTION *s, int init);
+int ossl_statem_get_in_handshake(SSL_CONNECTION *s);
+void ossl_statem_set_in_handshake(SSL_CONNECTION *s, int inhand);
+__owur int ossl_statem_skip_early_data(SSL_CONNECTION *s);
+void ossl_statem_check_finish_init(SSL_CONNECTION *s, int send);
+void ossl_statem_set_hello_verify_done(SSL_CONNECTION *s);
+__owur int ossl_statem_app_data_allowed(SSL_CONNECTION *s);
+__owur int ossl_statem_export_allowed(SSL_CONNECTION *s);
+__owur int ossl_statem_export_early_allowed(SSL_CONNECTION *s);
 
 /* Flush the write BIO */
-int statem_flush(SSL *s);
+int statem_flush(SSL_CONNECTION *s);

--- a/ssl/statem/statem_local.h
+++ b/ssl/statem/statem_local.h
@@ -54,116 +54,142 @@ typedef enum {
     MSG_PROCESS_CONTINUE_READING
 } MSG_PROCESS_RETURN;
 
-typedef int (*confunc_f) (SSL *s, WPACKET *pkt);
+typedef int (*confunc_f) (SSL_CONNECTION *s, WPACKET *pkt);
 
-int ssl3_take_mac(SSL *s);
-int check_in_list(SSL *s, uint16_t group_id, const uint16_t *groups,
+int ssl3_take_mac(SSL_CONNECTION *s);
+int check_in_list(SSL_CONNECTION *s, uint16_t group_id, const uint16_t *groups,
                   size_t num_groups, int checkallow);
-int create_synthetic_message_hash(SSL *s, const unsigned char *hashval,
+int create_synthetic_message_hash(SSL_CONNECTION *s,
+                                  const unsigned char *hashval,
                                   size_t hashlen, const unsigned char *hrr,
                                   size_t hrrlen);
-int parse_ca_names(SSL *s, PACKET *pkt);
-const STACK_OF(X509_NAME) *get_ca_names(SSL *s);
-int construct_ca_names(SSL *s, const STACK_OF(X509_NAME) *ca_sk, WPACKET *pkt);
-size_t construct_key_exchange_tbs(SSL *s, unsigned char **ptbs,
+int parse_ca_names(SSL_CONNECTION *s, PACKET *pkt);
+const STACK_OF(X509_NAME) *get_ca_names(SSL_CONNECTION *s);
+int construct_ca_names(SSL_CONNECTION *s, const STACK_OF(X509_NAME) *ca_sk,
+                       WPACKET *pkt);
+size_t construct_key_exchange_tbs(SSL_CONNECTION *s, unsigned char **ptbs,
                                   const void *param, size_t paramlen);
 
 /*
  * TLS/DTLS client state machine functions
  */
-int ossl_statem_client_read_transition(SSL *s, int mt);
-WRITE_TRAN ossl_statem_client_write_transition(SSL *s);
-WORK_STATE ossl_statem_client_pre_work(SSL *s, WORK_STATE wst);
-WORK_STATE ossl_statem_client_post_work(SSL *s, WORK_STATE wst);
-int ossl_statem_client_construct_message(SSL *s,
+int ossl_statem_client_read_transition(SSL_CONNECTION *s, int mt);
+WRITE_TRAN ossl_statem_client_write_transition(SSL_CONNECTION *s);
+WORK_STATE ossl_statem_client_pre_work(SSL_CONNECTION *s, WORK_STATE wst);
+WORK_STATE ossl_statem_client_post_work(SSL_CONNECTION *s, WORK_STATE wst);
+int ossl_statem_client_construct_message(SSL_CONNECTION *s,
                                          confunc_f *confunc, int *mt);
-size_t ossl_statem_client_max_message_size(SSL *s);
-MSG_PROCESS_RETURN ossl_statem_client_process_message(SSL *s, PACKET *pkt);
-WORK_STATE ossl_statem_client_post_process_message(SSL *s, WORK_STATE wst);
+size_t ossl_statem_client_max_message_size(SSL_CONNECTION *s);
+MSG_PROCESS_RETURN ossl_statem_client_process_message(SSL_CONNECTION *s,
+                                                      PACKET *pkt);
+WORK_STATE ossl_statem_client_post_process_message(SSL_CONNECTION *s,
+                                                   WORK_STATE wst);
 
 /*
  * TLS/DTLS server state machine functions
  */
-int ossl_statem_server_read_transition(SSL *s, int mt);
-WRITE_TRAN ossl_statem_server_write_transition(SSL *s);
-WORK_STATE ossl_statem_server_pre_work(SSL *s, WORK_STATE wst);
-WORK_STATE ossl_statem_server_post_work(SSL *s, WORK_STATE wst);
-int ossl_statem_server_construct_message(SSL *s,
+int ossl_statem_server_read_transition(SSL_CONNECTION *s, int mt);
+WRITE_TRAN ossl_statem_server_write_transition(SSL_CONNECTION *s);
+WORK_STATE ossl_statem_server_pre_work(SSL_CONNECTION *s, WORK_STATE wst);
+WORK_STATE ossl_statem_server_post_work(SSL_CONNECTION *s, WORK_STATE wst);
+int ossl_statem_server_construct_message(SSL_CONNECTION *s,
                                          confunc_f *confunc,int *mt);
-size_t ossl_statem_server_max_message_size(SSL *s);
-MSG_PROCESS_RETURN ossl_statem_server_process_message(SSL *s, PACKET *pkt);
-WORK_STATE ossl_statem_server_post_process_message(SSL *s, WORK_STATE wst);
+size_t ossl_statem_server_max_message_size(SSL_CONNECTION *s);
+MSG_PROCESS_RETURN ossl_statem_server_process_message(SSL_CONNECTION *s,
+                                                      PACKET *pkt);
+WORK_STATE ossl_statem_server_post_process_message(SSL_CONNECTION *s,
+                                                   WORK_STATE wst);
 
 /* Functions for getting new message data */
-__owur int tls_get_message_header(SSL *s, int *mt);
-__owur int tls_get_message_body(SSL *s, size_t *len);
-__owur int dtls_get_message(SSL *s, int *mt);
-__owur int dtls_get_message_body(SSL *s, size_t *len);
+__owur int tls_get_message_header(SSL_CONNECTION *s, int *mt);
+__owur int tls_get_message_body(SSL_CONNECTION *s, size_t *len);
+__owur int dtls_get_message(SSL_CONNECTION *s, int *mt);
+__owur int dtls_get_message_body(SSL_CONNECTION *s, size_t *len);
 
 /* Message construction and processing functions */
-__owur int tls_process_initial_server_flight(SSL *s);
-__owur MSG_PROCESS_RETURN tls_process_change_cipher_spec(SSL *s, PACKET *pkt);
-__owur MSG_PROCESS_RETURN tls_process_finished(SSL *s, PACKET *pkt);
-__owur int tls_construct_change_cipher_spec(SSL *s, WPACKET *pkt);
-__owur int dtls_construct_change_cipher_spec(SSL *s, WPACKET *pkt);
+__owur int tls_process_initial_server_flight(SSL_CONNECTION *s);
+__owur MSG_PROCESS_RETURN tls_process_change_cipher_spec(SSL_CONNECTION *s,
+                                                         PACKET *pkt);
+__owur MSG_PROCESS_RETURN tls_process_finished(SSL_CONNECTION *s, PACKET *pkt);
+__owur int tls_construct_change_cipher_spec(SSL_CONNECTION *s, WPACKET *pkt);
+__owur int dtls_construct_change_cipher_spec(SSL_CONNECTION *s, WPACKET *pkt);
 
-__owur int tls_construct_finished(SSL *s, WPACKET *pkt);
-__owur int tls_construct_key_update(SSL *s, WPACKET *pkt);
-__owur MSG_PROCESS_RETURN tls_process_key_update(SSL *s, PACKET *pkt);
-__owur WORK_STATE tls_finish_handshake(SSL *s, WORK_STATE wst, int clearbufs,
-                                       int stop);
-__owur WORK_STATE dtls_wait_for_dry(SSL *s);
+__owur int tls_construct_finished(SSL_CONNECTION *s, WPACKET *pkt);
+__owur int tls_construct_key_update(SSL_CONNECTION *s, WPACKET *pkt);
+__owur MSG_PROCESS_RETURN tls_process_key_update(SSL_CONNECTION *s,
+                                                 PACKET *pkt);
+__owur WORK_STATE tls_finish_handshake(SSL_CONNECTION *s, WORK_STATE wst,
+                                       int clearbufs, int stop);
+__owur WORK_STATE dtls_wait_for_dry(SSL_CONNECTION *s);
 
 /* some client-only functions */
-__owur int tls_construct_client_hello(SSL *s, WPACKET *pkt);
-__owur MSG_PROCESS_RETURN tls_process_server_hello(SSL *s, PACKET *pkt);
-__owur MSG_PROCESS_RETURN tls_process_certificate_request(SSL *s, PACKET *pkt);
-__owur MSG_PROCESS_RETURN tls_process_new_session_ticket(SSL *s, PACKET *pkt);
-__owur int tls_process_cert_status_body(SSL *s, PACKET *pkt);
-__owur MSG_PROCESS_RETURN tls_process_cert_status(SSL *s, PACKET *pkt);
-__owur MSG_PROCESS_RETURN tls_process_server_done(SSL *s, PACKET *pkt);
-__owur int tls_construct_cert_verify(SSL *s, WPACKET *pkt);
-__owur WORK_STATE tls_prepare_client_certificate(SSL *s, WORK_STATE wst);
-__owur int tls_construct_client_certificate(SSL *s, WPACKET *pkt);
-__owur int ssl_do_client_cert_cb(SSL *s, X509 **px509, EVP_PKEY **ppkey);
-__owur int tls_construct_client_key_exchange(SSL *s, WPACKET *pkt);
-__owur int tls_client_key_exchange_post_work(SSL *s);
-__owur int tls_construct_cert_status_body(SSL *s, WPACKET *pkt);
-__owur int tls_construct_cert_status(SSL *s, WPACKET *pkt);
-__owur MSG_PROCESS_RETURN tls_process_key_exchange(SSL *s, PACKET *pkt);
-__owur MSG_PROCESS_RETURN tls_process_server_certificate(SSL *s, PACKET *pkt);
-__owur WORK_STATE tls_post_process_server_certificate(SSL *s, WORK_STATE wst);
-__owur int ssl3_check_cert_and_algorithm(SSL *s);
+__owur int tls_construct_client_hello(SSL_CONNECTION *s, WPACKET *pkt);
+__owur MSG_PROCESS_RETURN tls_process_server_hello(SSL_CONNECTION *s,
+                                                   PACKET *pkt);
+__owur MSG_PROCESS_RETURN tls_process_certificate_request(SSL_CONNECTION *s,
+                                                          PACKET *pkt);
+__owur MSG_PROCESS_RETURN tls_process_new_session_ticket(SSL_CONNECTION *s,
+                                                         PACKET *pkt);
+__owur int tls_process_cert_status_body(SSL_CONNECTION *s, PACKET *pkt);
+__owur MSG_PROCESS_RETURN tls_process_cert_status(SSL_CONNECTION *s,
+                                                  PACKET *pkt);
+__owur MSG_PROCESS_RETURN tls_process_server_done(SSL_CONNECTION *s,
+                                                  PACKET *pkt);
+__owur int tls_construct_cert_verify(SSL_CONNECTION *s, WPACKET *pkt);
+__owur WORK_STATE tls_prepare_client_certificate(SSL_CONNECTION *s,
+                                                 WORK_STATE wst);
+__owur int tls_construct_client_certificate(SSL_CONNECTION *s, WPACKET *pkt);
+__owur int ssl_do_client_cert_cb(SSL_CONNECTION *s, X509 **px509,
+                                 EVP_PKEY **ppkey);
+__owur int tls_construct_client_key_exchange(SSL_CONNECTION *s, WPACKET *pkt);
+__owur int tls_client_key_exchange_post_work(SSL_CONNECTION *s);
+__owur int tls_construct_cert_status_body(SSL_CONNECTION *s, WPACKET *pkt);
+__owur int tls_construct_cert_status(SSL_CONNECTION *s, WPACKET *pkt);
+__owur MSG_PROCESS_RETURN tls_process_key_exchange(SSL_CONNECTION *s,
+                                                   PACKET *pkt);
+__owur MSG_PROCESS_RETURN tls_process_server_certificate(SSL_CONNECTION *s,
+                                                         PACKET *pkt);
+__owur WORK_STATE tls_post_process_server_certificate(SSL_CONNECTION *s,
+                                                      WORK_STATE wst);
+__owur int ssl3_check_cert_and_algorithm(SSL_CONNECTION *s);
 #ifndef OPENSSL_NO_NEXTPROTONEG
-__owur int tls_construct_next_proto(SSL *s, WPACKET *pkt);
+__owur int tls_construct_next_proto(SSL_CONNECTION *s, WPACKET *pkt);
 #endif
-__owur MSG_PROCESS_RETURN tls_process_hello_req(SSL *s, PACKET *pkt);
-__owur MSG_PROCESS_RETURN dtls_process_hello_verify(SSL *s, PACKET *pkt);
-__owur int tls_construct_end_of_early_data(SSL *s, WPACKET *pkt);
+__owur MSG_PROCESS_RETURN tls_process_hello_req(SSL_CONNECTION *s, PACKET *pkt);
+__owur MSG_PROCESS_RETURN dtls_process_hello_verify(SSL_CONNECTION *s, PACKET *pkt);
+__owur int tls_construct_end_of_early_data(SSL_CONNECTION *s, WPACKET *pkt);
 
 /* some server-only functions */
-__owur MSG_PROCESS_RETURN tls_process_client_hello(SSL *s, PACKET *pkt);
-__owur WORK_STATE tls_post_process_client_hello(SSL *s, WORK_STATE wst);
-__owur int tls_construct_server_hello(SSL *s, WPACKET *pkt);
-__owur int dtls_construct_hello_verify_request(SSL *s, WPACKET *pkt);
-__owur int tls_construct_server_certificate(SSL *s, WPACKET *pkt);
-__owur int tls_construct_server_key_exchange(SSL *s, WPACKET *pkt);
-__owur int tls_construct_certificate_request(SSL *s, WPACKET *pkt);
-__owur int tls_construct_server_done(SSL *s, WPACKET *pkt);
-__owur MSG_PROCESS_RETURN tls_process_client_certificate(SSL *s, PACKET *pkt);
-__owur MSG_PROCESS_RETURN tls_process_client_key_exchange(SSL *s, PACKET *pkt);
-__owur WORK_STATE tls_post_process_client_key_exchange(SSL *s, WORK_STATE wst);
-__owur MSG_PROCESS_RETURN tls_process_cert_verify(SSL *s, PACKET *pkt);
+__owur MSG_PROCESS_RETURN tls_process_client_hello(SSL_CONNECTION *s,
+                                                   PACKET *pkt);
+__owur WORK_STATE tls_post_process_client_hello(SSL_CONNECTION *s,
+                                                WORK_STATE wst);
+__owur int tls_construct_server_hello(SSL_CONNECTION *s, WPACKET *pkt);
+__owur int dtls_construct_hello_verify_request(SSL_CONNECTION *s, WPACKET *pkt);
+__owur int tls_construct_server_certificate(SSL_CONNECTION *s, WPACKET *pkt);
+__owur int tls_construct_server_key_exchange(SSL_CONNECTION *s, WPACKET *pkt);
+__owur int tls_construct_certificate_request(SSL_CONNECTION *s, WPACKET *pkt);
+__owur int tls_construct_server_done(SSL_CONNECTION *s, WPACKET *pkt);
+__owur MSG_PROCESS_RETURN tls_process_client_certificate(SSL_CONNECTION *s,
+                                                         PACKET *pkt);
+__owur MSG_PROCESS_RETURN tls_process_client_key_exchange(SSL_CONNECTION *s,
+                                                          PACKET *pkt);
+__owur WORK_STATE tls_post_process_client_key_exchange(SSL_CONNECTION *s,
+                                                       WORK_STATE wst);
+__owur MSG_PROCESS_RETURN tls_process_cert_verify(SSL_CONNECTION *s,
+                                                  PACKET *pkt);
 #ifndef OPENSSL_NO_NEXTPROTONEG
-__owur MSG_PROCESS_RETURN tls_process_next_proto(SSL *s, PACKET *pkt);
+__owur MSG_PROCESS_RETURN tls_process_next_proto(SSL_CONNECTION *s,
+                                                 PACKET *pkt);
 #endif
-__owur int tls_construct_new_session_ticket(SSL *s, WPACKET *pkt);
-MSG_PROCESS_RETURN tls_process_end_of_early_data(SSL *s, PACKET *pkt);
+__owur int tls_construct_new_session_ticket(SSL_CONNECTION *s, WPACKET *pkt);
+MSG_PROCESS_RETURN tls_process_end_of_early_data(SSL_CONNECTION *s,
+                                                 PACKET *pkt);
 
 #ifndef OPENSSL_NO_GOST
 /* These functions are used in GOST18 CKE, both for client and server */
-int ossl_gost18_cke_cipher_nid(const SSL *s);
-int ossl_gost_ukm(const SSL *s, unsigned char *dgst_buf);
+int ossl_gost18_cke_cipher_nid(const SSL_CONNECTION *s);
+int ossl_gost_ukm(const SSL_CONNECTION *s, unsigned char *dgst_buf);
 #endif
 
 /* Extension processing */
@@ -174,252 +200,293 @@ typedef enum ext_return_en {
     EXT_RETURN_NOT_SENT
 } EXT_RETURN;
 
-__owur int tls_validate_all_contexts(SSL *s, unsigned int thisctx,
+__owur int tls_validate_all_contexts(SSL_CONNECTION *s, unsigned int thisctx,
                                      RAW_EXTENSION *exts);
-__owur int extension_is_relevant(SSL *s, unsigned int extctx,
+__owur int extension_is_relevant(SSL_CONNECTION *s, unsigned int extctx,
                                  unsigned int thisctx);
-__owur int tls_collect_extensions(SSL *s, PACKET *packet, unsigned int context,
+__owur int tls_collect_extensions(SSL_CONNECTION *s, PACKET *packet,
+                                  unsigned int context,
                                   RAW_EXTENSION **res, size_t *len, int init);
-__owur int tls_parse_extension(SSL *s, TLSEXT_INDEX idx, int context,
+__owur int tls_parse_extension(SSL_CONNECTION *s, TLSEXT_INDEX idx, int context,
                                RAW_EXTENSION *exts,  X509 *x, size_t chainidx);
-__owur int tls_parse_all_extensions(SSL *s, int context, RAW_EXTENSION *exts,
+__owur int tls_parse_all_extensions(SSL_CONNECTION *s, int context,
+                                    RAW_EXTENSION *exts,
                                     X509 *x, size_t chainidx, int fin);
-__owur int should_add_extension(SSL *s, unsigned int extctx,
+__owur int should_add_extension(SSL_CONNECTION *s, unsigned int extctx,
                                 unsigned int thisctx, int max_version);
-__owur int tls_construct_extensions(SSL *s, WPACKET *pkt, unsigned int context,
+__owur int tls_construct_extensions(SSL_CONNECTION *s, WPACKET *pkt,
+                                    unsigned int context,
                                     X509 *x, size_t chainidx);
 
-__owur int tls_psk_do_binder(SSL *s, const EVP_MD *md,
+__owur int tls_psk_do_binder(SSL_CONNECTION *s, const EVP_MD *md,
                              const unsigned char *msgstart,
                              size_t binderoffset, const unsigned char *binderin,
                              unsigned char *binderout,
                              SSL_SESSION *sess, int sign, int external);
 
 /* Server Extension processing */
-int tls_parse_ctos_renegotiate(SSL *s, PACKET *pkt, unsigned int context,
+int tls_parse_ctos_renegotiate(SSL_CONNECTION *s, PACKET *pkt,
+                               unsigned int context,
                                X509 *x, size_t chainidx);
-int tls_parse_ctos_server_name(SSL *s, PACKET *pkt, unsigned int context,
+int tls_parse_ctos_server_name(SSL_CONNECTION *s, PACKET *pkt,
+                               unsigned int context,
                                X509 *x, size_t chainidx);
-int tls_parse_ctos_maxfragmentlen(SSL *s, PACKET *pkt, unsigned int context,
+int tls_parse_ctos_maxfragmentlen(SSL_CONNECTION *s, PACKET *pkt,
+                                  unsigned int context,
                                   X509 *x, size_t chainidx);
 #ifndef OPENSSL_NO_SRP
-int tls_parse_ctos_srp(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
-                       size_t chainidx);
+int tls_parse_ctos_srp(SSL_CONNECTION *s, PACKET *pkt, unsigned int context,
+                       X509 *x, size_t chainidx);
 #endif
-int tls_parse_ctos_early_data(SSL *s, PACKET *pkt, unsigned int context,
+int tls_parse_ctos_early_data(SSL_CONNECTION *s, PACKET *pkt,
+                              unsigned int context,
                               X509 *x, size_t chainidx);
-int tls_parse_ctos_ec_pt_formats(SSL *s, PACKET *pkt, unsigned int context,
+int tls_parse_ctos_ec_pt_formats(SSL_CONNECTION *s, PACKET *pkt,
+                                 unsigned int context,
                                  X509 *x, size_t chainidx);
-int tls_parse_ctos_supported_groups(SSL *s, PACKET *pkt, unsigned int context,
+int tls_parse_ctos_supported_groups(SSL_CONNECTION *s, PACKET *pkt,
+                                    unsigned int context,
                                     X509 *x, size_t chainidxl);
-int tls_parse_ctos_session_ticket(SSL *s, PACKET *pkt, unsigned int context,
+int tls_parse_ctos_session_ticket(SSL_CONNECTION *s, PACKET *pkt,
+                                  unsigned int context,
                                   X509 *x, size_t chainidx);
-int tls_parse_ctos_sig_algs_cert(SSL *s, PACKET *pkt, unsigned int context,
+int tls_parse_ctos_sig_algs_cert(SSL_CONNECTION *s, PACKET *pkt,
+                                 unsigned int context,
                                  X509 *x, size_t chainidx);
-int tls_parse_ctos_sig_algs(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
-                            size_t chainidx);
+int tls_parse_ctos_sig_algs(SSL_CONNECTION *s, PACKET *pkt,
+                            unsigned int context, X509 *x, size_t chainidx);
 #ifndef OPENSSL_NO_OCSP
-int tls_parse_ctos_status_request(SSL *s, PACKET *pkt, unsigned int context,
+int tls_parse_ctos_status_request(SSL_CONNECTION *s, PACKET *pkt,
+                                  unsigned int context,
                                   X509 *x, size_t chainidx);
 #endif
 #ifndef OPENSSL_NO_NEXTPROTONEG
-int tls_parse_ctos_npn(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
-                       size_t chainidx);
+int tls_parse_ctos_npn(SSL_CONNECTION *s, PACKET *pkt, unsigned int context,
+                       X509 *x, size_t chainidx);
 #endif
-int tls_parse_ctos_alpn(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
-                        size_t chainidx);
+int tls_parse_ctos_alpn(SSL_CONNECTION *s, PACKET *pkt, unsigned int context,
+                        X509 *x, size_t chainidx);
 #ifndef OPENSSL_NO_SRTP
-int tls_parse_ctos_use_srtp(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
-                            size_t chainidx);
+int tls_parse_ctos_use_srtp(SSL_CONNECTION *s, PACKET *pkt,
+                            unsigned int context, X509 *x, size_t chainidx);
 #endif
-int tls_parse_ctos_etm(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
-                       size_t chainidx);
-int tls_parse_ctos_key_share(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
-                             size_t chainidx);
-int tls_parse_ctos_cookie(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
-                          size_t chainidx);
-int tls_parse_ctos_ems(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
-                       size_t chainidx);
-int tls_parse_ctos_psk_kex_modes(SSL *s, PACKET *pkt, unsigned int context,
+int tls_parse_ctos_etm(SSL_CONNECTION *s, PACKET *pkt, unsigned int context,
+                       X509 *x, size_t chainidx);
+int tls_parse_ctos_key_share(SSL_CONNECTION *s, PACKET *pkt,
+                             unsigned int context, X509 *x, size_t chainidx);
+int tls_parse_ctos_cookie(SSL_CONNECTION *s, PACKET *pkt, unsigned int context,
+                          X509 *x, size_t chainidx);
+int tls_parse_ctos_ems(SSL_CONNECTION *s, PACKET *pkt, unsigned int context,
+                       X509 *x, size_t chainidx);
+int tls_parse_ctos_psk_kex_modes(SSL_CONNECTION *s, PACKET *pkt,
+                                 unsigned int context,
                                  X509 *x, size_t chainidx);
-int tls_parse_ctos_psk(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
-                       size_t chainidx);
-int tls_parse_ctos_post_handshake_auth(SSL *, PACKET *pkt, unsigned int context,
+int tls_parse_ctos_psk(SSL_CONNECTION *s, PACKET *pkt, unsigned int context,
+                       X509 *x, size_t chainidx);
+int tls_parse_ctos_post_handshake_auth(SSL_CONNECTION *, PACKET *pkt,
+                                       unsigned int context,
                                        X509 *x, size_t chainidx);
 
-EXT_RETURN tls_construct_stoc_renegotiate(SSL *s, WPACKET *pkt,
+EXT_RETURN tls_construct_stoc_renegotiate(SSL_CONNECTION *s, WPACKET *pkt,
                                           unsigned int context, X509 *x,
                                           size_t chainidx);
-EXT_RETURN tls_construct_stoc_server_name(SSL *s, WPACKET *pkt,
+EXT_RETURN tls_construct_stoc_server_name(SSL_CONNECTION *s, WPACKET *pkt,
                                           unsigned int context, X509 *x,
                                           size_t chainidx);
-EXT_RETURN tls_construct_stoc_early_data(SSL *s, WPACKET *pkt,
+EXT_RETURN tls_construct_stoc_early_data(SSL_CONNECTION *s, WPACKET *pkt,
                                          unsigned int context, X509 *x,
                                          size_t chainidx);
-EXT_RETURN tls_construct_stoc_maxfragmentlen(SSL *s, WPACKET *pkt,
+EXT_RETURN tls_construct_stoc_maxfragmentlen(SSL_CONNECTION *s, WPACKET *pkt,
                                              unsigned int context, X509 *x,
                                              size_t chainidx);
-EXT_RETURN tls_construct_stoc_ec_pt_formats(SSL *s, WPACKET *pkt,
+EXT_RETURN tls_construct_stoc_ec_pt_formats(SSL_CONNECTION *s, WPACKET *pkt,
                                             unsigned int context, X509 *x,
                                             size_t chainidx);
-EXT_RETURN tls_construct_stoc_supported_groups(SSL *s, WPACKET *pkt,
+EXT_RETURN tls_construct_stoc_supported_groups(SSL_CONNECTION *s, WPACKET *pkt,
                                                unsigned int context, X509 *x,
                                                size_t chainidx);
-EXT_RETURN tls_construct_stoc_session_ticket(SSL *s, WPACKET *pkt,
+EXT_RETURN tls_construct_stoc_session_ticket(SSL_CONNECTION *s, WPACKET *pkt,
                                              unsigned int context, X509 *x,
                                              size_t chainidx);
 #ifndef OPENSSL_NO_OCSP
-EXT_RETURN tls_construct_stoc_status_request(SSL *s, WPACKET *pkt,
+EXT_RETURN tls_construct_stoc_status_request(SSL_CONNECTION *s, WPACKET *pkt,
                                              unsigned int context, X509 *x,
                                              size_t chainidx);
 #endif
 #ifndef OPENSSL_NO_NEXTPROTONEG
-EXT_RETURN tls_construct_stoc_next_proto_neg(SSL *s, WPACKET *pkt,
+EXT_RETURN tls_construct_stoc_next_proto_neg(SSL_CONNECTION *s, WPACKET *pkt,
                                              unsigned int context, X509 *x,
                                              size_t chainidx);
 #endif
-EXT_RETURN tls_construct_stoc_alpn(SSL *s, WPACKET *pkt, unsigned int context,
+EXT_RETURN tls_construct_stoc_alpn(SSL_CONNECTION *s, WPACKET *pkt,
+                                   unsigned int context,
                                    X509 *x, size_t chainidx);
 #ifndef OPENSSL_NO_SRTP
-EXT_RETURN tls_construct_stoc_use_srtp(SSL *s, WPACKET *pkt, unsigned int context,
-                                X509 *x, size_t chainidx);
+EXT_RETURN tls_construct_stoc_use_srtp(SSL_CONNECTION *s, WPACKET *pkt,
+                                       unsigned int context,
+                                       X509 *x, size_t chainidx);
 #endif
-EXT_RETURN tls_construct_stoc_etm(SSL *s, WPACKET *pkt, unsigned int context,
+EXT_RETURN tls_construct_stoc_etm(SSL_CONNECTION *s, WPACKET *pkt,
+                                  unsigned int context,
                                   X509 *x, size_t chainidx);
-EXT_RETURN tls_construct_stoc_ems(SSL *s, WPACKET *pkt, unsigned int context,
+EXT_RETURN tls_construct_stoc_ems(SSL_CONNECTION *s, WPACKET *pkt,
+                                  unsigned int context,
                                   X509 *x, size_t chainidx);
-EXT_RETURN tls_construct_stoc_supported_versions(SSL *s, WPACKET *pkt,
+EXT_RETURN tls_construct_stoc_supported_versions(SSL_CONNECTION *s, WPACKET *pkt,
                                                  unsigned int context, X509 *x,
                                                  size_t chainidx);
-EXT_RETURN tls_construct_stoc_key_share(SSL *s, WPACKET *pkt,
+EXT_RETURN tls_construct_stoc_key_share(SSL_CONNECTION *s, WPACKET *pkt,
                                         unsigned int context, X509 *x,
                                         size_t chainidx);
-EXT_RETURN tls_construct_stoc_cookie(SSL *s, WPACKET *pkt, unsigned int context,
+EXT_RETURN tls_construct_stoc_cookie(SSL_CONNECTION *s, WPACKET *pkt,
+                                     unsigned int context,
                                      X509 *x, size_t chainidx);
 /*
  * Not in public headers as this is not an official extension. Only used when
  * SSL_OP_CRYPTOPRO_TLSEXT_BUG is set.
  */
 #define TLSEXT_TYPE_cryptopro_bug      0xfde8
-EXT_RETURN tls_construct_stoc_cryptopro_bug(SSL *s, WPACKET *pkt,
+EXT_RETURN tls_construct_stoc_cryptopro_bug(SSL_CONNECTION *s, WPACKET *pkt,
                                             unsigned int context, X509 *x,
                                             size_t chainidx);
-EXT_RETURN tls_construct_stoc_psk(SSL *s, WPACKET *pkt, unsigned int context,
+EXT_RETURN tls_construct_stoc_psk(SSL_CONNECTION *s, WPACKET *pkt,
+                                  unsigned int context,
                                   X509 *x, size_t chainidx);
 
 /* Client Extension processing */
-EXT_RETURN tls_construct_ctos_renegotiate(SSL *s, WPACKET *pkt, unsigned int context,
-                                   X509 *x, size_t chainidx);
-EXT_RETURN tls_construct_ctos_server_name(SSL *s, WPACKET *pkt, unsigned int context,
-                                   X509 *x, size_t chainidx);
-EXT_RETURN tls_construct_ctos_maxfragmentlen(SSL *s, WPACKET *pkt, unsigned int context,
+EXT_RETURN tls_construct_ctos_renegotiate(SSL_CONNECTION *s, WPACKET *pkt,
+                                          unsigned int context,
+                                          X509 *x, size_t chainidx);
+EXT_RETURN tls_construct_ctos_server_name(SSL_CONNECTION *s, WPACKET *pkt,
+                                          unsigned int context,
+                                          X509 *x, size_t chainidx);
+EXT_RETURN tls_construct_ctos_maxfragmentlen(SSL_CONNECTION *s, WPACKET *pkt,
+                                             unsigned int context,
                                              X509 *x, size_t chainidx);
 #ifndef OPENSSL_NO_SRP
-EXT_RETURN tls_construct_ctos_srp(SSL *s, WPACKET *pkt, unsigned int context, X509 *x,
-                           size_t chainidx);
+EXT_RETURN tls_construct_ctos_srp(SSL_CONNECTION *s, WPACKET *pkt,
+                                  unsigned int context, X509 *x,
+                                  size_t chainidx);
 #endif
-EXT_RETURN tls_construct_ctos_ec_pt_formats(SSL *s, WPACKET *pkt,
+EXT_RETURN tls_construct_ctos_ec_pt_formats(SSL_CONNECTION *s, WPACKET *pkt,
                                             unsigned int context, X509 *x,
                                             size_t chainidx);
-EXT_RETURN tls_construct_ctos_supported_groups(SSL *s, WPACKET *pkt,
+EXT_RETURN tls_construct_ctos_supported_groups(SSL_CONNECTION *s, WPACKET *pkt,
                                                unsigned int context, X509 *x,
                                                size_t chainidx);
 
-EXT_RETURN tls_construct_ctos_early_data(SSL *s, WPACKET *pkt,
+EXT_RETURN tls_construct_ctos_early_data(SSL_CONNECTION *s, WPACKET *pkt,
                                          unsigned int context, X509 *x,
                                          size_t chainidx);
-EXT_RETURN tls_construct_ctos_session_ticket(SSL *s, WPACKET *pkt,
+EXT_RETURN tls_construct_ctos_session_ticket(SSL_CONNECTION *s, WPACKET *pkt,
                                              unsigned int context, X509 *x,
                                              size_t chainidx);
-EXT_RETURN tls_construct_ctos_sig_algs(SSL *s, WPACKET *pkt,
+EXT_RETURN tls_construct_ctos_sig_algs(SSL_CONNECTION *s, WPACKET *pkt,
                                        unsigned int context, X509 *x,
                                        size_t chainidx);
 #ifndef OPENSSL_NO_OCSP
-EXT_RETURN tls_construct_ctos_status_request(SSL *s, WPACKET *pkt,
+EXT_RETURN tls_construct_ctos_status_request(SSL_CONNECTION *s, WPACKET *pkt,
                                              unsigned int context, X509 *x,
                                              size_t chainidx);
 #endif
 #ifndef OPENSSL_NO_NEXTPROTONEG
-EXT_RETURN tls_construct_ctos_npn(SSL *s, WPACKET *pkt, unsigned int context,
+EXT_RETURN tls_construct_ctos_npn(SSL_CONNECTION *s, WPACKET *pkt,
+                                  unsigned int context,
                                   X509 *x, size_t chainidx);
 #endif
-EXT_RETURN tls_construct_ctos_alpn(SSL *s, WPACKET *pkt, unsigned int context,
+EXT_RETURN tls_construct_ctos_alpn(SSL_CONNECTION *s, WPACKET *pkt,
+                                   unsigned int context,
                                    X509 *x, size_t chainidx);
 #ifndef OPENSSL_NO_SRTP
-EXT_RETURN tls_construct_ctos_use_srtp(SSL *s, WPACKET *pkt, unsigned int context,
+EXT_RETURN tls_construct_ctos_use_srtp(SSL_CONNECTION *s, WPACKET *pkt,
+                                       unsigned int context,
                                        X509 *x, size_t chainidx);
 #endif
-EXT_RETURN tls_construct_ctos_etm(SSL *s, WPACKET *pkt, unsigned int context,
+EXT_RETURN tls_construct_ctos_etm(SSL_CONNECTION *s, WPACKET *pkt,
+                                  unsigned int context,
                                   X509 *x, size_t chainidx);
 #ifndef OPENSSL_NO_CT
-EXT_RETURN tls_construct_ctos_sct(SSL *s, WPACKET *pkt, unsigned int context,
+EXT_RETURN tls_construct_ctos_sct(SSL_CONNECTION *s, WPACKET *pkt,
+                                  unsigned int context,
                                   X509 *x, size_t chainidx);
 #endif
-EXT_RETURN tls_construct_ctos_ems(SSL *s, WPACKET *pkt, unsigned int context,
+EXT_RETURN tls_construct_ctos_ems(SSL_CONNECTION *s, WPACKET *pkt,
+                                  unsigned int context,
                                   X509 *x, size_t chainidx);
-EXT_RETURN tls_construct_ctos_supported_versions(SSL *s, WPACKET *pkt,
+EXT_RETURN tls_construct_ctos_supported_versions(SSL_CONNECTION *s, WPACKET *pkt,
                                                  unsigned int context, X509 *x,
                                                  size_t chainidx);
-EXT_RETURN tls_construct_ctos_key_share(SSL *s, WPACKET *pkt,
+EXT_RETURN tls_construct_ctos_key_share(SSL_CONNECTION *s, WPACKET *pkt,
                                         unsigned int context, X509 *x,
                                         size_t chainidx);
-EXT_RETURN tls_construct_ctos_psk_kex_modes(SSL *s, WPACKET *pkt,
+EXT_RETURN tls_construct_ctos_psk_kex_modes(SSL_CONNECTION *s, WPACKET *pkt,
                                             unsigned int context, X509 *x,
                                             size_t chainidx);
-EXT_RETURN tls_construct_ctos_cookie(SSL *s, WPACKET *pkt, unsigned int context,
+EXT_RETURN tls_construct_ctos_cookie(SSL_CONNECTION *s, WPACKET *pkt,
+                                     unsigned int context,
                                      X509 *x, size_t chainidx);
-EXT_RETURN tls_construct_ctos_padding(SSL *s, WPACKET *pkt,
+EXT_RETURN tls_construct_ctos_padding(SSL_CONNECTION *s, WPACKET *pkt,
                                       unsigned int context, X509 *x,
                                       size_t chainidx);
-EXT_RETURN tls_construct_ctos_psk(SSL *s, WPACKET *pkt, unsigned int context,
+EXT_RETURN tls_construct_ctos_psk(SSL_CONNECTION *s, WPACKET *pkt,
+                                  unsigned int context,
                                   X509 *x, size_t chainidx);
-EXT_RETURN tls_construct_ctos_post_handshake_auth(SSL *s, WPACKET *pkt, unsigned int context,
+EXT_RETURN tls_construct_ctos_post_handshake_auth(SSL_CONNECTION *s, WPACKET *pkt,
+                                                  unsigned int context,
                                                   X509 *x, size_t chainidx);
 
-int tls_parse_stoc_renegotiate(SSL *s, PACKET *pkt, unsigned int context,
+int tls_parse_stoc_renegotiate(SSL_CONNECTION *s, PACKET *pkt,
+                               unsigned int context,
                                X509 *x, size_t chainidx);
-int tls_parse_stoc_server_name(SSL *s, PACKET *pkt, unsigned int context,
+int tls_parse_stoc_server_name(SSL_CONNECTION *s, PACKET *pkt,
+                               unsigned int context,
                                X509 *x, size_t chainidx);
-int tls_parse_stoc_early_data(SSL *s, PACKET *pkt, unsigned int context,
+int tls_parse_stoc_early_data(SSL_CONNECTION *s, PACKET *pkt,
+                              unsigned int context,
                               X509 *x, size_t chainidx);
-int tls_parse_stoc_maxfragmentlen(SSL *s, PACKET *pkt, unsigned int context,
+int tls_parse_stoc_maxfragmentlen(SSL_CONNECTION *s, PACKET *pkt,
+                                  unsigned int context,
                                   X509 *x, size_t chainidx);
-int tls_parse_stoc_ec_pt_formats(SSL *s, PACKET *pkt, unsigned int context,
+int tls_parse_stoc_ec_pt_formats(SSL_CONNECTION *s, PACKET *pkt,
+                                 unsigned int context,
                                  X509 *x, size_t chainidx);
-int tls_parse_stoc_session_ticket(SSL *s, PACKET *pkt, unsigned int context,
+int tls_parse_stoc_session_ticket(SSL_CONNECTION *s, PACKET *pkt,
+                                  unsigned int context,
                                   X509 *x, size_t chainidx);
 #ifndef OPENSSL_NO_OCSP
-int tls_parse_stoc_status_request(SSL *s, PACKET *pkt, unsigned int context,
+int tls_parse_stoc_status_request(SSL_CONNECTION *s, PACKET *pkt,
+                                  unsigned int context,
                                   X509 *x, size_t chainidx);
 #endif
 #ifndef OPENSSL_NO_CT
-int tls_parse_stoc_sct(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
-                       size_t chainidx);
+int tls_parse_stoc_sct(SSL_CONNECTION *s, PACKET *pkt, unsigned int context,
+                       X509 *x, size_t chainidx);
 #endif
 #ifndef OPENSSL_NO_NEXTPROTONEG
-int tls_parse_stoc_npn(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
-                       size_t chainidx);
+int tls_parse_stoc_npn(SSL_CONNECTION *s, PACKET *pkt, unsigned int context,
+                       X509 *x, size_t chainidx);
 #endif
-int tls_parse_stoc_alpn(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
-                        size_t chainidx);
+int tls_parse_stoc_alpn(SSL_CONNECTION *s, PACKET *pkt, unsigned int context,
+                        X509 *x, size_t chainidx);
 #ifndef OPENSSL_NO_SRTP
-int tls_parse_stoc_use_srtp(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
-                            size_t chainidx);
+int tls_parse_stoc_use_srtp(SSL_CONNECTION *s, PACKET *pkt,
+                            unsigned int context, X509 *x, size_t chainidx);
 #endif
-int tls_parse_stoc_etm(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
-                       size_t chainidx);
-int tls_parse_stoc_ems(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
-                       size_t chainidx);
-int tls_parse_stoc_supported_versions(SSL *s, PACKET *pkt, unsigned int context,
+int tls_parse_stoc_etm(SSL_CONNECTION *s, PACKET *pkt, unsigned int context,
+                       X509 *x, size_t chainidx);
+int tls_parse_stoc_ems(SSL_CONNECTION *s, PACKET *pkt, unsigned int context,
+                       X509 *x, size_t chainidx);
+int tls_parse_stoc_supported_versions(SSL_CONNECTION *s, PACKET *pkt,
+                                      unsigned int context,
                                       X509 *x, size_t chainidx);
-int tls_parse_stoc_key_share(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
-                             size_t chainidx);
-int tls_parse_stoc_cookie(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
-                       size_t chainidx);
-int tls_parse_stoc_psk(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
-                       size_t chainidx);
+int tls_parse_stoc_key_share(SSL_CONNECTION *s, PACKET *pkt,
+                             unsigned int context, X509 *x, size_t chainidx);
+int tls_parse_stoc_cookie(SSL_CONNECTION *s, PACKET *pkt, unsigned int context,
+                          X509 *x, size_t chainidx);
+int tls_parse_stoc_psk(SSL_CONNECTION *s, PACKET *pkt, unsigned int context,
+                       X509 *x, size_t chainidx);
 
-int tls_handle_alpn(SSL *s);
+int tls_handle_alpn(SSL_CONNECTION *s);
 
-int tls13_save_handshake_digest_for_pha(SSL *s);
-int tls13_restore_handshake_digest_for_pha(SSL *s);
+int tls13_save_handshake_digest_for_pha(SSL_CONNECTION *s);
+int tls13_restore_handshake_digest_for_pha(SSL_CONNECTION *s);

--- a/ssl/tls13_enc.c
+++ b/ssl/tls13_enc.c
@@ -31,13 +31,15 @@ static const unsigned char label_prefix[] = "tls13 ";
  * The |data| value may be zero length. Any errors will be treated as fatal if
  * |fatal| is set. Returns 1 on success  0 on failure.
  */
-int tls13_hkdf_expand(SSL *s, const EVP_MD *md, const unsigned char *secret,
+int tls13_hkdf_expand(SSL_CONNECTION *s, const EVP_MD *md,
+                      const unsigned char *secret,
                       const unsigned char *label, size_t labellen,
                       const unsigned char *data, size_t datalen,
                       unsigned char *out, size_t outlen, int fatal)
 {
-    EVP_KDF *kdf = EVP_KDF_fetch(s->ctx->libctx, OSSL_KDF_NAME_TLS1_3_KDF,
-                                 s->ctx->propq);
+    SSL_CTX *sctx = SSL_CONNECTION_GET_CTX(s);
+    EVP_KDF *kdf = EVP_KDF_fetch(sctx->libctx, OSSL_KDF_NAME_TLS1_3_KDF,
+                                 sctx->propq);
     EVP_KDF_CTX *kctx;
     OSSL_PARAM params[7], *p = params;
     int mode = EVP_PKEY_HKDEF_MODE_EXPAND_ONLY;
@@ -107,7 +109,8 @@ int tls13_hkdf_expand(SSL *s, const EVP_MD *md, const unsigned char *secret,
  * Given a |secret| generate a |key| of length |keylen| bytes. Returns 1 on
  * success  0 on failure.
  */
-int tls13_derive_key(SSL *s, const EVP_MD *md, const unsigned char *secret,
+int tls13_derive_key(SSL_CONNECTION *s, const EVP_MD *md,
+                     const unsigned char *secret,
                      unsigned char *key, size_t keylen)
 {
 #ifdef CHARSET_EBCDIC
@@ -124,7 +127,8 @@ int tls13_derive_key(SSL *s, const EVP_MD *md, const unsigned char *secret,
  * Given a |secret| generate an |iv| of length |ivlen| bytes. Returns 1 on
  * success  0 on failure.
  */
-int tls13_derive_iv(SSL *s, const EVP_MD *md, const unsigned char *secret,
+int tls13_derive_iv(SSL_CONNECTION *s, const EVP_MD *md,
+                    const unsigned char *secret,
                     unsigned char *iv, size_t ivlen)
 {
 #ifdef CHARSET_EBCDIC
@@ -137,7 +141,7 @@ int tls13_derive_iv(SSL *s, const EVP_MD *md, const unsigned char *secret,
                              NULL, 0, iv, ivlen, 1);
 }
 
-int tls13_derive_finishedkey(SSL *s, const EVP_MD *md,
+int tls13_derive_finishedkey(SSL_CONNECTION *s, const EVP_MD *md,
                              const unsigned char *secret,
                              unsigned char *fin, size_t finlen)
 {
@@ -156,7 +160,7 @@ int tls13_derive_finishedkey(SSL *s, const EVP_MD *md,
  * length |insecretlen|, generate a new secret and store it in the location
  * pointed to by |outsecret|. Returns 1 on success  0 on failure.
  */
-int tls13_generate_secret(SSL *s, const EVP_MD *md,
+int tls13_generate_secret(SSL_CONNECTION *s, const EVP_MD *md,
                           const unsigned char *prevsecret,
                           const unsigned char *insecret,
                           size_t insecretlen,
@@ -175,8 +179,9 @@ int tls13_generate_secret(SSL *s, const EVP_MD *md,
 #else
     static const char derived_secret_label[] = "derived";
 #endif
+    SSL_CTX *sctx = SSL_CONNECTION_GET_CTX(s);
 
-    kdf = EVP_KDF_fetch(s->ctx->libctx, OSSL_KDF_NAME_TLS1_3_KDF, s->ctx->propq);
+    kdf = EVP_KDF_fetch(sctx->libctx, OSSL_KDF_NAME_TLS1_3_KDF, sctx->propq);
     kctx = EVP_KDF_CTX_new(kdf);
     EVP_KDF_free(kdf);
     if (kctx == NULL) {
@@ -225,8 +230,9 @@ int tls13_generate_secret(SSL *s, const EVP_MD *md,
  * handshake secret. This requires the early secret to already have been
  * generated. Returns 1 on success  0 on failure.
  */
-int tls13_generate_handshake_secret(SSL *s, const unsigned char *insecret,
-                                size_t insecretlen)
+int tls13_generate_handshake_secret(SSL_CONNECTION *s,
+                                    const unsigned char *insecret,
+                                    size_t insecretlen)
 {
     /* Calls SSLfatal() if required */
     return tls13_generate_secret(s, ssl_handshake_md(s), s->early_secret,
@@ -239,7 +245,7 @@ int tls13_generate_handshake_secret(SSL *s, const unsigned char *insecret,
  * secret and store its length in |*secret_size|. Returns 1 on success  0 on
  * failure.
  */
-int tls13_generate_master_secret(SSL *s, unsigned char *out,
+int tls13_generate_master_secret(SSL_CONNECTION *s, unsigned char *out,
                                  unsigned char *prev, size_t prevlen,
                                  size_t *secret_size)
 {
@@ -254,7 +260,7 @@ int tls13_generate_master_secret(SSL *s, unsigned char *out,
  * Generates the mac for the Finished message. Returns the length of the MAC or
  * 0 on error.
  */
-size_t tls13_final_finish_mac(SSL *s, const char *str, size_t slen,
+size_t tls13_final_finish_mac(SSL_CONNECTION *s, const char *str, size_t slen,
                              unsigned char *out)
 {
     const EVP_MD *md = ssl_handshake_md(s);
@@ -264,14 +270,15 @@ size_t tls13_final_finish_mac(SSL *s, const char *str, size_t slen,
     unsigned char *key = NULL;
     size_t len = 0, hashlen;
     OSSL_PARAM params[2], *p = params;
+    SSL_CTX *sctx = SSL_CONNECTION_GET_CTX(s);
 
     if (md == NULL)
         return 0;
 
     /* Safe to cast away const here since we're not "getting" any data */
-    if (s->ctx->propq != NULL)
+    if (sctx->propq != NULL)
         *p++ = OSSL_PARAM_construct_utf8_string(OSSL_ALG_PARAM_PROPERTIES,
-                                                (char *)s->ctx->propq,
+                                                (char *)sctx->propq,
                                                 0);
     *p = OSSL_PARAM_construct_end();
 
@@ -280,7 +287,7 @@ size_t tls13_final_finish_mac(SSL *s, const char *str, size_t slen,
         goto err;
     }
 
-    if (str == s->method->ssl3_enc->server_finished_label) {
+    if (str == SSL_CONNECTION_GET_SSL(s)->method->ssl3_enc->server_finished_label) {
         key = s->server_finished_secret;
     } else if (SSL_IS_FIRST_HANDSHAKE(s)) {
         key = s->client_finished_secret;
@@ -292,7 +299,7 @@ size_t tls13_final_finish_mac(SSL *s, const char *str, size_t slen,
         key = finsecret;
     }
 
-    if (!EVP_Q_mac(s->ctx->libctx, "HMAC", s->ctx->propq, mdname,
+    if (!EVP_Q_mac(sctx->libctx, "HMAC", sctx->propq, mdname,
                    params, key, hashlen, hash, hashlen,
                    /* outsize as per sizeof(peer_finish_md) */
                    out, EVP_MAX_MD_SIZE * 2, &len)) {
@@ -309,14 +316,14 @@ size_t tls13_final_finish_mac(SSL *s, const char *str, size_t slen,
  * There isn't really a key block in TLSv1.3, but we still need this function
  * for initialising the cipher and hash. Returns 1 on success or 0 on failure.
  */
-int tls13_setup_key_block(SSL *s)
+int tls13_setup_key_block(SSL_CONNECTION *s)
 {
     const EVP_CIPHER *c;
     const EVP_MD *hash;
 
     s->session->cipher = s->s3.tmp.new_cipher;
-    if (!ssl_cipher_get_evp(s->ctx, s->session, &c, &hash, NULL, NULL, NULL,
-                            0)) {
+    if (!ssl_cipher_get_evp(SSL_CONNECTION_GET_CTX(s), s->session, &c, &hash,
+                            NULL, NULL, NULL, 0)) {
         /* Error is already recorded */
         SSLfatal_alert(s, SSL_AD_INTERNAL_ERROR);
         return 0;
@@ -330,7 +337,8 @@ int tls13_setup_key_block(SSL *s)
     return 1;
 }
 
-static int derive_secret_key_and_iv(SSL *s, int sending, const EVP_MD *md,
+static int derive_secret_key_and_iv(SSL_CONNECTION *s, int sending,
+                                    const EVP_MD *md,
                                     const EVP_CIPHER *ciph,
                                     const unsigned char *insecret,
                                     const unsigned char *hash,
@@ -400,7 +408,7 @@ static int derive_secret_key_and_iv(SSL *s, int sending, const EVP_MD *md,
     return 1;
 }
 
-int tls13_change_cipher_state(SSL *s, int which)
+int tls13_change_cipher_state(SSL_CONNECTION *s, int which)
 {
 #ifdef CHARSET_EBCDIC
   static const unsigned char client_early_traffic[]       = {0x63, 0x20, 0x65, 0x20,       /*traffic*/0x74, 0x72, 0x61, 0x66, 0x66, 0x69, 0x63, 0x00};
@@ -436,6 +444,7 @@ int tls13_change_cipher_state(SSL *s, int which)
     int ret = 0;
     const EVP_MD *md = NULL;
     const EVP_CIPHER *cipher = NULL;
+    SSL_CTX *sctx = SSL_CONNECTION_GET_CTX(s);
 #if !defined(OPENSSL_NO_KTLS) && defined(OPENSSL_KTLS_TLS13)
     ktls_crypto_info_t crypto_info;
     void *rl_sequence;
@@ -529,14 +538,14 @@ int tls13_change_cipher_state(SSL *s, int which)
              * This ups the ref count on cipher so we better make sure we free
              * it again
              */
-            if (!ssl_cipher_get_evp_cipher(s->ctx, sslcipher, &cipher)) {
+            if (!ssl_cipher_get_evp_cipher(sctx, sslcipher, &cipher)) {
                 /* Error is already recorded */
                 SSLfatal_alert(s, SSL_AD_INTERNAL_ERROR);
                 EVP_MD_CTX_free(mdctx);
                 goto err;
             }
 
-            md = ssl_md(s->ctx, sslcipher->algorithm2);
+            md = ssl_md(sctx, sslcipher->algorithm2);
             if (md == NULL || !EVP_DigestInit_ex(mdctx, md, NULL)
                     || !EVP_DigestUpdate(mdctx, hdata, handlen)
                     || !EVP_DigestFinal_ex(mdctx, hashval, &hashlenui)) {
@@ -754,7 +763,7 @@ skip_ktls:
     return ret;
 }
 
-int tls13_update_key(SSL *s, int sending)
+int tls13_update_key(SSL_CONNECTION *s, int sending)
 {
 #ifdef CHARSET_EBCDIC
   static const unsigned char application_traffic[] = { 0x74, 0x72 ,0x61 ,0x66 ,0x66 ,0x69 ,0x63 ,0x20 ,0x75 ,0x70 ,0x64, 0x00};
@@ -813,7 +822,8 @@ int tls13_alert_code(int code)
     return tls1_alert_code(code);
 }
 
-int tls13_export_keying_material(SSL *s, unsigned char *out, size_t olen,
+int tls13_export_keying_material(SSL_CONNECTION *s,
+                                 unsigned char *out, size_t olen,
                                  const char *label, size_t llen,
                                  const unsigned char *context,
                                  size_t contextlen, int use_context)
@@ -855,7 +865,8 @@ int tls13_export_keying_material(SSL *s, unsigned char *out, size_t olen,
     return ret;
 }
 
-int tls13_export_keying_material_early(SSL *s, unsigned char *out, size_t olen,
+int tls13_export_keying_material_early(SSL_CONNECTION *s,
+                                       unsigned char *out, size_t olen,
                                        const char *label, size_t llen,
                                        const unsigned char *context,
                                        size_t contextlen)
@@ -882,7 +893,7 @@ int tls13_export_keying_material_early(SSL *s, unsigned char *out, size_t olen,
     else
         sslcipher = SSL_SESSION_get0_cipher(s->session);
 
-    md = ssl_md(s->ctx, sslcipher->algorithm2);
+    md = ssl_md(SSL_CONNECTION_GET_CTX(s), sslcipher->algorithm2);
 
     /*
      * Calculate the hash value and store it in |data|. The reason why

--- a/ssl/tls_depr.c
+++ b/ssl/tls_depr.c
@@ -64,10 +64,14 @@ const EVP_MD *tls_get_digest_from_engine(int nid)
 }
 
 #ifndef OPENSSL_NO_ENGINE
-int tls_engine_load_ssl_client_cert(SSL *s, X509 **px509, EVP_PKEY **ppkey)
+int tls_engine_load_ssl_client_cert(SSL_CONNECTION *s, X509 **px509,
+                                    EVP_PKEY **ppkey)
 {
-    return ENGINE_load_ssl_client_cert(s->ctx->client_cert_engine, s,
-                                       SSL_get_client_CA_list(s),
+    SSL *ssl = SSL_CONNECTION_GET_SSL(s);
+
+    return ENGINE_load_ssl_client_cert(SSL_CONNECTION_GET_CTX(s)->client_cert_engine,
+                                       ssl,
+                                       SSL_get_client_CA_list(ssl),
                                        px509, ppkey, NULL, NULL, NULL);
 }
 #endif

--- a/ssl/tls_srp.c
+++ b/ssl/tls_srp.c
@@ -57,7 +57,7 @@ int SSL_CTX_SRP_CTX_free(SSL_CTX *ctx)
  * The public API SSL_SRP_CTX_free() is deprecated so we use
  * ssl_srp_ctx_free_intern() internally.
  */
-int ssl_srp_ctx_free_intern(SSL *s)
+int ssl_srp_ctx_free_intern(SSL_CONNECTION *s)
 {
     if (s == NULL)
         return 0;
@@ -78,18 +78,21 @@ int ssl_srp_ctx_free_intern(SSL *s)
 
 int SSL_SRP_CTX_free(SSL *s)
 {
-    return ssl_srp_ctx_free_intern(s);
+    SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL(s);
+
+    /* the call works with NULL sc */
+    return ssl_srp_ctx_free_intern(sc);
 }
 
 /*
  * The public API SSL_SRP_CTX_init() is deprecated so we use
  * ssl_srp_ctx_init_intern() internally.
  */
-int ssl_srp_ctx_init_intern(SSL *s)
+int ssl_srp_ctx_init_intern(SSL_CONNECTION *s)
 {
-    SSL_CTX *ctx;
+    SSL_CTX *ctx = SSL_CONNECTION_GET_CTX(s);
 
-    if ((s == NULL) || ((ctx = s->ctx) == NULL))
+    if (s == NULL || ctx == NULL)
         return 0;
 
     memset(&s->srp_ctx, 0, sizeof(s->srp_ctx));
@@ -156,7 +159,10 @@ int ssl_srp_ctx_init_intern(SSL *s)
 
 int SSL_SRP_CTX_init(SSL *s)
 {
-    return ssl_srp_ctx_init_intern(s);
+    SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL(s);
+
+    /* the call works with NULL sc */
+    return ssl_srp_ctx_init_intern(sc);
 }
 
 /*
@@ -184,15 +190,17 @@ int SSL_CTX_SRP_CTX_init(SSL_CTX *ctx)
  * The public API SSL_srp_server_param_with_username() is deprecated so we use
  * ssl_srp_server_param_with_username_intern() internally.
  */
-int ssl_srp_server_param_with_username_intern(SSL *s, int *ad)
+int ssl_srp_server_param_with_username_intern(SSL_CONNECTION *s, int *ad)
 {
     unsigned char b[SSL_MAX_MASTER_KEY_LENGTH];
     int al;
+    SSL_CTX *sctx = SSL_CONNECTION_GET_CTX(s);
 
     *ad = SSL_AD_UNKNOWN_PSK_IDENTITY;
     if ((s->srp_ctx.TLS_ext_srp_username_callback != NULL) &&
         ((al =
-          s->srp_ctx.TLS_ext_srp_username_callback(s, ad,
+          s->srp_ctx.TLS_ext_srp_username_callback(SSL_CONNECTION_GET_SSL(s),
+                                                   ad,
                                                    s->srp_ctx.SRP_cb_arg)) !=
          SSL_ERROR_NONE))
         return al;
@@ -203,7 +211,8 @@ int ssl_srp_server_param_with_username_intern(SSL *s, int *ad)
         (s->srp_ctx.s == NULL) || (s->srp_ctx.v == NULL))
         return SSL3_AL_FATAL;
 
-    if (RAND_priv_bytes_ex(s->ctx->libctx, b, sizeof(b), 0) <= 0)
+    if (RAND_priv_bytes_ex(SSL_CONNECTION_GET_CTX(s)->libctx, b, sizeof(b),
+                           0) <= 0)
         return SSL3_AL_FATAL;
     s->srp_ctx.b = BN_bin2bn(b, sizeof(b), NULL);
     OPENSSL_cleanse(b, sizeof(b));
@@ -212,13 +221,18 @@ int ssl_srp_server_param_with_username_intern(SSL *s, int *ad)
 
     return ((s->srp_ctx.B =
              SRP_Calc_B_ex(s->srp_ctx.b, s->srp_ctx.N, s->srp_ctx.g,
-                           s->srp_ctx.v, s->ctx->libctx, s->ctx->propq)) !=
+                           s->srp_ctx.v, sctx->libctx, sctx->propq)) !=
             NULL) ? SSL_ERROR_NONE : SSL3_AL_FATAL;
 }
 
 int SSL_srp_server_param_with_username(SSL *s, int *ad)
 {
-    return ssl_srp_server_param_with_username_intern(s, ad);
+    SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL(s);
+
+    if (sc == NULL)
+        return SSL3_AL_FATAL;
+
+    return ssl_srp_server_param_with_username_intern(sc, ad);
 }
 
 /*
@@ -228,17 +242,23 @@ int SSL_srp_server_param_with_username(SSL *s, int *ad)
 int SSL_set_srp_server_param_pw(SSL *s, const char *user, const char *pass,
                                 const char *grp)
 {
-    SRP_gN *GN = SRP_get_default_gN(grp);
+    SRP_gN *GN;
+    SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL(s);
+
+    if (sc == NULL)
+        return -1;
+
+    GN = SRP_get_default_gN(grp);
     if (GN == NULL)
         return -1;
-    s->srp_ctx.N = BN_dup(GN->N);
-    s->srp_ctx.g = BN_dup(GN->g);
-    BN_clear_free(s->srp_ctx.v);
-    s->srp_ctx.v = NULL;
-    BN_clear_free(s->srp_ctx.s);
-    s->srp_ctx.s = NULL;
-    if (!SRP_create_verifier_BN_ex(user, pass, &s->srp_ctx.s, &s->srp_ctx.v,
-                                   s->srp_ctx.N, s->srp_ctx.g, s->ctx->libctx,
+    sc->srp_ctx.N = BN_dup(GN->N);
+    sc->srp_ctx.g = BN_dup(GN->g);
+    BN_clear_free(sc->srp_ctx.v);
+    sc->srp_ctx.v = NULL;
+    BN_clear_free(sc->srp_ctx.s);
+    sc->srp_ctx.s = NULL;
+    if (!SRP_create_verifier_BN_ex(user, pass, &sc->srp_ctx.s, &sc->srp_ctx.v,
+                                   sc->srp_ctx.N, sc->srp_ctx.g, s->ctx->libctx,
                                    s->ctx->propq))
         return -1;
 
@@ -248,66 +268,72 @@ int SSL_set_srp_server_param_pw(SSL *s, const char *user, const char *pass,
 int SSL_set_srp_server_param(SSL *s, const BIGNUM *N, const BIGNUM *g,
                              BIGNUM *sa, BIGNUM *v, char *info)
 {
+    SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL(s);
+
+    if (sc == NULL)
+        return -1;
+
     if (N != NULL) {
-        if (s->srp_ctx.N != NULL) {
-            if (!BN_copy(s->srp_ctx.N, N)) {
-                BN_free(s->srp_ctx.N);
-                s->srp_ctx.N = NULL;
+        if (sc->srp_ctx.N != NULL) {
+            if (!BN_copy(sc->srp_ctx.N, N)) {
+                BN_free(sc->srp_ctx.N);
+                sc->srp_ctx.N = NULL;
             }
         } else
-            s->srp_ctx.N = BN_dup(N);
+            sc->srp_ctx.N = BN_dup(N);
     }
     if (g != NULL) {
-        if (s->srp_ctx.g != NULL) {
-            if (!BN_copy(s->srp_ctx.g, g)) {
-                BN_free(s->srp_ctx.g);
-                s->srp_ctx.g = NULL;
+        if (sc->srp_ctx.g != NULL) {
+            if (!BN_copy(sc->srp_ctx.g, g)) {
+                BN_free(sc->srp_ctx.g);
+                sc->srp_ctx.g = NULL;
             }
         } else
-            s->srp_ctx.g = BN_dup(g);
+            sc->srp_ctx.g = BN_dup(g);
     }
     if (sa != NULL) {
-        if (s->srp_ctx.s != NULL) {
-            if (!BN_copy(s->srp_ctx.s, sa)) {
-                BN_free(s->srp_ctx.s);
-                s->srp_ctx.s = NULL;
+        if (sc->srp_ctx.s != NULL) {
+            if (!BN_copy(sc->srp_ctx.s, sa)) {
+                BN_free(sc->srp_ctx.s);
+                sc->srp_ctx.s = NULL;
             }
         } else
-            s->srp_ctx.s = BN_dup(sa);
+            sc->srp_ctx.s = BN_dup(sa);
     }
     if (v != NULL) {
-        if (s->srp_ctx.v != NULL) {
-            if (!BN_copy(s->srp_ctx.v, v)) {
-                BN_free(s->srp_ctx.v);
-                s->srp_ctx.v = NULL;
+        if (sc->srp_ctx.v != NULL) {
+            if (!BN_copy(sc->srp_ctx.v, v)) {
+                BN_free(sc->srp_ctx.v);
+                sc->srp_ctx.v = NULL;
             }
         } else
-            s->srp_ctx.v = BN_dup(v);
+            sc->srp_ctx.v = BN_dup(v);
     }
     if (info != NULL) {
-        if (s->srp_ctx.info)
-            OPENSSL_free(s->srp_ctx.info);
-        if ((s->srp_ctx.info = OPENSSL_strdup(info)) == NULL)
+        if (sc->srp_ctx.info)
+            OPENSSL_free(sc->srp_ctx.info);
+        if ((sc->srp_ctx.info = OPENSSL_strdup(info)) == NULL)
             return -1;
     }
 
-    if (!(s->srp_ctx.N) ||
-        !(s->srp_ctx.g) || !(s->srp_ctx.s) || !(s->srp_ctx.v))
+    if (!(sc->srp_ctx.N) ||
+        !(sc->srp_ctx.g) || !(sc->srp_ctx.s) || !(sc->srp_ctx.v))
         return -1;
 
     return 1;
 }
 
-int srp_generate_server_master_secret(SSL *s)
+int srp_generate_server_master_secret(SSL_CONNECTION *s)
 {
     BIGNUM *K = NULL, *u = NULL;
     int ret = 0, tmp_len = 0;
     unsigned char *tmp = NULL;
+    SSL_CTX *sctx = SSL_CONNECTION_GET_CTX(s);
 
     if (!SRP_Verify_A_mod_N(s->srp_ctx.A, s->srp_ctx.N))
         goto err;
     if ((u = SRP_Calc_u_ex(s->srp_ctx.A, s->srp_ctx.B, s->srp_ctx.N,
-                           s->ctx->libctx, s->ctx->propq)) == NULL)
+                           sctx->libctx, sctx->propq)) == NULL)
         goto err;
     if ((K = SRP_Calc_server_key(s->srp_ctx.A, s->srp_ctx.v, u, s->srp_ctx.b,
                                  s->srp_ctx.N)) == NULL)
@@ -328,37 +354,38 @@ int srp_generate_server_master_secret(SSL *s)
 }
 
 /* client side */
-int srp_generate_client_master_secret(SSL *s)
+int srp_generate_client_master_secret(SSL_CONNECTION *s)
 {
     BIGNUM *x = NULL, *u = NULL, *K = NULL;
     int ret = 0, tmp_len = 0;
     char *passwd = NULL;
     unsigned char *tmp = NULL;
+    SSL_CTX *sctx = SSL_CONNECTION_GET_CTX(s);
 
     /*
      * Checks if b % n == 0
      */
     if (SRP_Verify_B_mod_N(s->srp_ctx.B, s->srp_ctx.N) == 0
             || (u = SRP_Calc_u_ex(s->srp_ctx.A, s->srp_ctx.B, s->srp_ctx.N,
-                                  s->ctx->libctx, s->ctx->propq))
+                                  sctx->libctx, sctx->propq))
                == NULL
             || s->srp_ctx.SRP_give_srp_client_pwd_callback == NULL) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
         goto err;
     }
-    if ((passwd = s->srp_ctx.SRP_give_srp_client_pwd_callback(s,
-                                                      s->srp_ctx.SRP_cb_arg))
+    if ((passwd = s->srp_ctx.SRP_give_srp_client_pwd_callback(SSL_CONNECTION_GET_SSL(s),
+                                                              s->srp_ctx.SRP_cb_arg))
             == NULL) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_R_CALLBACK_FAILED);
         goto err;
     }
     if ((x = SRP_Calc_x_ex(s->srp_ctx.s, s->srp_ctx.login, passwd,
-                           s->ctx->libctx, s->ctx->propq)) == NULL
+                           sctx->libctx, sctx->propq)) == NULL
             || (K = SRP_Calc_client_key_ex(s->srp_ctx.N, s->srp_ctx.B,
                                            s->srp_ctx.g, x,
                                            s->srp_ctx.a, u,
-                                           s->ctx->libctx,
-                                           s->ctx->propq)) == NULL) {
+                                           sctx->libctx,
+                                           sctx->propq)) == NULL) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
         goto err;
     }
@@ -380,7 +407,7 @@ int srp_generate_client_master_secret(SSL *s)
     return ret;
 }
 
-int srp_verify_server_param(SSL *s)
+int srp_verify_server_param(SSL_CONNECTION *s)
 {
     SRP_CTX *srp = &s->srp_ctx;
     /*
@@ -399,7 +426,8 @@ int srp_verify_server_param(SSL *s)
     }
 
     if (srp->SRP_verify_param_callback) {
-        if (srp->SRP_verify_param_callback(s, srp->SRP_cb_arg) <= 0) {
+        if (srp->SRP_verify_param_callback(SSL_CONNECTION_GET_SSL(s),
+                                           srp->SRP_cb_arg) <= 0) {
             SSLfatal(s, SSL_AD_INSUFFICIENT_SECURITY, SSL_R_CALLBACK_FAILED);
             return 0;
         }
@@ -416,11 +444,12 @@ int srp_verify_server_param(SSL *s)
  * The public API SRP_Calc_A_param() is deprecated so we use
  * ssl_srp_calc_a_param_intern() internally.
  */
-int ssl_srp_calc_a_param_intern(SSL *s)
+int ssl_srp_calc_a_param_intern(SSL_CONNECTION *s)
 {
     unsigned char rnd[SSL_MAX_MASTER_KEY_LENGTH];
 
-    if (RAND_priv_bytes_ex(s->ctx->libctx, rnd, sizeof(rnd), 0) <= 0)
+    if (RAND_priv_bytes_ex(SSL_CONNECTION_GET_CTX(s)->libctx,
+                           rnd, sizeof(rnd), 0) <= 0)
         return 0;
     s->srp_ctx.a = BN_bin2bn(rnd, sizeof(rnd), s->srp_ctx.a);
     OPENSSL_cleanse(rnd, sizeof(rnd));
@@ -433,34 +462,59 @@ int ssl_srp_calc_a_param_intern(SSL *s)
 
 int SRP_Calc_A_param(SSL *s)
 {
-    return ssl_srp_calc_a_param_intern(s);
+    SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL(s);
+
+    if (sc == NULL)
+        return 0;
+
+    return ssl_srp_calc_a_param_intern(sc);
 }
 
 BIGNUM *SSL_get_srp_g(SSL *s)
 {
-    if (s->srp_ctx.g != NULL)
-        return s->srp_ctx.g;
+    SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL(s);
+
+    if (sc == NULL)
+        return NULL;
+
+    if (sc->srp_ctx.g != NULL)
+        return sc->srp_ctx.g;
     return s->ctx->srp_ctx.g;
 }
 
 BIGNUM *SSL_get_srp_N(SSL *s)
 {
-    if (s->srp_ctx.N != NULL)
-        return s->srp_ctx.N;
+    SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL(s);
+
+    if (sc == NULL)
+        return NULL;
+
+    if (sc->srp_ctx.N != NULL)
+        return sc->srp_ctx.N;
     return s->ctx->srp_ctx.N;
 }
 
 char *SSL_get_srp_username(SSL *s)
 {
-    if (s->srp_ctx.login != NULL)
-        return s->srp_ctx.login;
+    SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL(s);
+
+    if (sc == NULL)
+        return NULL;
+
+    if (sc->srp_ctx.login != NULL)
+        return sc->srp_ctx.login;
     return s->ctx->srp_ctx.login;
 }
 
 char *SSL_get_srp_userinfo(SSL *s)
 {
-    if (s->srp_ctx.info != NULL)
-        return s->srp_ctx.info;
+    SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL(s);
+
+    if (sc == NULL)
+        return NULL;
+
+    if (sc->srp_ctx.info != NULL)
+        return sc->srp_ctx.info;
     return s->ctx->srp_ctx.info;
 }
 

--- a/test/dtls_mtu_test.c
+++ b/test/dtls_mtu_test.c
@@ -55,6 +55,7 @@ static int mtu_test(SSL_CTX *ctx, const char *cs, int no_etm)
     size_t mtus[30];
     unsigned char buf[600];
     int rv = 0;
+    SSL_CONNECTION *clnt_sc;
 
     memset(buf, 0x5a, sizeof(buf));
 
@@ -132,8 +133,10 @@ static int mtu_test(SSL_CTX *ctx, const char *cs, int no_etm)
             }
         }
     }
+    if (!TEST_ptr(clnt_sc = SSL_CONNECTION_FROM_SSL_ONLY(clnt_ssl)))
+        goto end;
     rv = 1;
-    if (SSL_READ_ETM(clnt_ssl))
+    if (SSL_READ_ETM(clnt_sc))
         rv = 2;
  end:
     SSL_free(clnt_ssl);

--- a/test/helpers/handshake.c
+++ b/test/helpers/handshake.c
@@ -978,9 +978,15 @@ static void do_reneg_setup_step(const SSL_TEST_CTX *test_ctx, PEER *peer)
         return;
     } else if (test_ctx->handshake_mode == SSL_TEST_HANDSHAKE_POST_HANDSHAKE_AUTH) {
         if (SSL_is_server(peer->ssl)) {
+            SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL_ONLY(peer->ssl);
+
+            if (sc == NULL) {
+                peer->status = PEER_ERROR;
+                return;
+            }
             /* Make the server believe it's received the extension */
             if (test_ctx->extra.server.force_pha)
-                peer->ssl->post_handshake_auth = SSL_PHA_EXT_RECEIVED;
+                sc->post_handshake_auth = SSL_PHA_EXT_RECEIVED;
             ret = SSL_verify_client_post_handshake(peer->ssl);
             if (!ret) {
                 peer->status = PEER_ERROR;

--- a/test/tls13encryptiontest.c
+++ b/test/tls13encryptiontest.c
@@ -304,12 +304,13 @@ static int test_record(SSL3_RECORD *rec, RECORD_DATA *recd, int enc)
 static int test_tls13_encryption(void)
 {
     SSL_CTX *ctx = NULL;
-    SSL *s = NULL;
+    SSL *ssl = NULL;
     SSL3_RECORD rec;
     unsigned char *key = NULL, *iv = NULL, *seq = NULL;
     const EVP_CIPHER *ciph = EVP_aes_128_gcm();
     int ret = 0;
     size_t ivlen, ctr;
+    SSL_CONNECTION *s;
 
     /*
      * Encrypted TLSv1.3 records always have an outer content type of
@@ -325,8 +326,8 @@ static int test_tls13_encryption(void)
         goto err;
     }
 
-    s = SSL_new(ctx);
-    if (!TEST_ptr(s)) {
+    ssl = SSL_new(ctx);
+    if (!TEST_ptr(ssl) || !TEST_ptr(s = SSL_CONNECTION_FROM_SSL_ONLY(ssl))) {
         TEST_info("Failed creating SSL");
         goto err;
     }
@@ -339,7 +340,7 @@ static int test_tls13_encryption(void)
     if (!TEST_ptr(s->enc_write_ctx))
         goto err;
 
-    s->s3.tmp.new_cipher = SSL_CIPHER_find(s, TLS13_AES_128_GCM_SHA256_BYTES);
+    s->s3.tmp.new_cipher = SSL_CIPHER_find(ssl, TLS13_AES_128_GCM_SHA256_BYTES);
     if (!TEST_ptr(s->s3.tmp.new_cipher)) {
         TEST_info("Failed to find cipher");
         goto err;
@@ -405,7 +406,7 @@ static int test_tls13_encryption(void)
     OPENSSL_free(key);
     OPENSSL_free(iv);
     OPENSSL_free(seq);
-    SSL_free(s);
+    SSL_free(ssl);
     SSL_CTX_free(ctx);
     return ret;
 }


### PR DESCRIPTION
We make the SSL object polymorphic based on whether this is
a traditional SSL connection, QUIC connection, or later
to be implemented a QUIC stream.
