### PR TITLE
SHAKE documentation updates for default output length.

### DIFF
--- a/apps/dgst.c
+++ b/apps/dgst.c
@@ -66,7 +66,7 @@ const OPTIONS dgst_options[] = {
     {"keyform", OPT_KEYFORM, 'f', "Key file format (ENGINE, other values ignored)"},
     {"hex", OPT_HEX, '-', "Print as hex dump"},
     {"binary", OPT_BINARY, '-', "Print in binary form"},
-    {"xoflen", OPT_XOFLEN, 'p', "Output length for XOF algorithms. Use 32 or higher to ensure a security strength of 128 bits"},
+    {"xoflen", OPT_XOFLEN, 'p', "Output length for XOF algorithms. To obtain the maximum security strength set this to 32 (or greater) for SHAKE128, and 64 (or greater) for SHAKE256"},
     {"d", OPT_DEBUG, '-', "Print debug info"},
     {"debug", OPT_DEBUG, '-', "Print debug info"},
 
@@ -403,7 +403,7 @@ int dgst_main(int argc, char **argv)
         md_name = EVP_MD_get0_name(md);
 
     if (xoflen > 0) {
-        if ((EVP_MD_get_flags(md) & EVP_MD_FLAG_XOF) == 0) {
+        if (!(EVP_MD_get_flags(md) & EVP_MD_FLAG_XOF)) {
             BIO_printf(bio_err, "Length can only be specified for XOF\n");
             goto end;
         }
@@ -416,19 +416,6 @@ int dgst_main(int argc, char **argv)
             BIO_printf(bio_err, "Signing key cannot be specified for XOF\n");
             goto end;
         }
-    } else {
-        /*
-         * Print a warning if the default security strength is less than 128 bits,
-         * but don't fail if the -xoflen was not specified.
-         */
-        if ((EVP_MD_get_flags(md) & EVP_MD_FLAG_XOF) != 0)
-            BIO_printf(bio_err,
-                       "Warning: The -xoflen option was not set.\n"
-                       "By default the xoflen is set to half of the maximum security strength\n"
-                       "SHAKE256 should set this value to 64 to obtain the"
-                       "maximum security strength of 256 bits.\n"
-                       "SHAKE128 should set this value to 32 to obtain the"
-                       "maximum security strength of 128 bits.\n");
     }
 
     if (argc == 0) {

--- a/apps/dgst.c
+++ b/apps/dgst.c
@@ -421,7 +421,7 @@ int dgst_main(int argc, char **argv)
          * Print a warning if the default security strength is less than 128 bits,
          * but don't fail if the -xoflen was not specified.
          */
-        if ((EVP_MD_get_flags(md) & EVP_MD_FLAG_XOF)
+        if ((EVP_MD_get_flags(md) & EVP_MD_FLAG_XOF) != 0
                 && EVP_MD_get_size(md) < 32)
             BIO_printf(bio_err,
                        "Warning: The -xoflen option was not set.\n"

--- a/apps/dgst.c
+++ b/apps/dgst.c
@@ -403,7 +403,7 @@ int dgst_main(int argc, char **argv)
         md_name = EVP_MD_get0_name(md);
 
     if (xoflen > 0) {
-        if (!(EVP_MD_get_flags(md) & EVP_MD_FLAG_XOF)) {
+        if ((EVP_MD_get_flags(md) & EVP_MD_FLAG_XOF) == 0) {
             BIO_printf(bio_err, "Length can only be specified for XOF\n");
             goto end;
         }
@@ -421,13 +421,14 @@ int dgst_main(int argc, char **argv)
          * Print a warning if the default security strength is less than 128 bits,
          * but don't fail if the -xoflen was not specified.
          */
-        if ((EVP_MD_get_flags(md) & EVP_MD_FLAG_XOF) != 0
-                && EVP_MD_get_size(md) < 32)
+        if ((EVP_MD_get_flags(md) & EVP_MD_FLAG_XOF) != 0)
             BIO_printf(bio_err,
                        "Warning: The -xoflen option was not set.\n"
-                       "By default this XOF algorithm has a bit length which results in a\n"
-                       "security strength less than 128 bits.\n"
-                       "The xoflen should be set to at least 32.\n");
+                       "By default the xoflen is set to half of the maximum security strength\n"
+                       "SHAKE256 should set this value to 64 to obtain the"
+                       "maximum security strength of 256 bits.\n"
+                       "SHAKE128 should set this value to 32 to obtain the"
+                       "maximum security strength of 128 bits.\n");
     }
 
     if (argc == 0) {

--- a/doc/man1/openssl-dgst.pod.in
+++ b/doc/man1/openssl-dgst.pod.in
@@ -86,7 +86,15 @@ Output the digest or signature in binary form.
 
 =item B<-xoflen> I<length>
 
-Set the output length for XOF algorithms, such as B<shake128>.
+Set the output length for XOF algorithms, such as B<shake128> and B<shake256>.
+This option is not supported for signing operations.
+It is recommended to set this value to at least 32 to ensure a security strength
+of 128 bits.
+
+B<shake128> defaults to 16 (which is only a security strength of 64 bits).
+
+B<shake256> defaults to 32. Use a value of at least 64 to ensure it uses the
+maximum security strength of 256 bits.
 
 =item B<-r>
 

--- a/doc/man1/openssl-dgst.pod.in
+++ b/doc/man1/openssl-dgst.pod.in
@@ -88,13 +88,18 @@ Output the digest or signature in binary form.
 
 Set the output length for XOF algorithms, such as B<shake128> and B<shake256>.
 This option is not supported for signing operations.
-It is recommended to set this value to at least 32 to ensure a security strength
-of 128 bits.
 
-B<shake128> defaults to 16 (which is only a security strength of 64 bits).
+For OpenSSL providers it is recommended to set this value for shake algorithms,
+since the default values are set to only supply half of the maximum security
+strength.
 
-B<shake256> defaults to 32. Use a value of at least 64 to ensure it uses the
-maximum security strength of 256 bits.
+For backwards compatibility reasons the default xoflen length for B<shake128> is
+16 (bytes) which results in a security strength of only 64 bits. To ensure the
+maximum security strength of 128 bits, the xoflen should be set to at least 32.
+
+For backwards compatibility reasons the default xoflen length for B<shake256> is
+32 (bytes) which results in a security strength of only 128 bits. To ensure the
+maximum security strength of 256 bits, the xoflen should be set to at least 64.
 
 =item B<-r>
 

--- a/doc/man7/EVP_MD-SHAKE.pod
+++ b/doc/man7/EVP_MD-SHAKE.pod
@@ -57,11 +57,11 @@ settable for an B<EVP_MD_CTX> with L<EVP_MD_CTX_set_params(3)>:
 Sets the digest length for extendable output functions.
 The length of the "xoflen" parameter should not exceed that of a B<size_t>.
 
-For backwards compatability reasons the default xoflen length for SHAKE-128 is
+For backwards compatibility reasons the default xoflen length for SHAKE-128 is
 16 (bytes) which results in a security strength of only 64 bits. To ensure the
 maximum security strength of 128 bits, the xoflen should be set to at least 32.
 
-For backwards compatability reasons the default xoflen length for SHAKE-256 is
+For backwards compatibility reasons the default xoflen length for SHAKE-256 is
 32 (bytes) which results in a security strength of only 128 bits. To ensure the
 maximum security strength of 256 bits, the xoflen should be set to at least 64.
 

--- a/doc/man7/EVP_MD-SHAKE.pod
+++ b/doc/man7/EVP_MD-SHAKE.pod
@@ -15,18 +15,20 @@ implementation (see L<EVP_MAC-KMAC(7)>).
 
 =head2 Identities
 
-This implementation is only available with the default provider, and
-includes the following varieties:
+This implementation is available in the FIPS provider as well as the default
+provider, and includes the following varieties:
 
 =over 4
 
 =item KECCAK-KMAC-128
 
 Known names are "KECCAK-KMAC-128" and "KECCAK-KMAC128"
+This is used by L<EVP_MAC-KMAC128(7)>
 
 =item KECCAK-KMAC-256
 
 Known names are "KECCAK-KMAC-256" and "KECCAK-KMAC256"
+This is used by L<EVP_MAC-KMAC256(7)>
 
 =item SHAKE-128
 
@@ -55,6 +57,14 @@ settable for an B<EVP_MD_CTX> with L<EVP_MD_CTX_set_params(3)>:
 Sets the digest length for extendable output functions.
 The length of the "xoflen" parameter should not exceed that of a B<size_t>.
 
+For backwards compatability reasons the default xoflen length for SHAKE-128 is
+16 (bytes) which results in a security strength of only 64 bits. To ensure the
+maximum security strength of 128 bits, the xoflen should be set to at least 32.
+
+For backwards compatability reasons the default xoflen length for SHAKE-256 is
+32 (bytes) which results in a security strength of only 128 bits. To ensure the
+maximum security strength of 256 bits, the xoflen should be set to at least 64.
+
 =back
 
 =head1 SEE ALSO
@@ -63,7 +73,7 @@ L<EVP_MD_CTX_set_params(3)>, L<provider-digest(7)>, L<OSSL_PROVIDER-default(7)>
 
 =head1 COPYRIGHT
 
-Copyright 2020 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2020-2022 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/test/recipes/20-test_dgst.t
+++ b/test/recipes/20-test_dgst.t
@@ -196,7 +196,7 @@ subtest "SHAKE digest generation with no xoflen set `dgst` CLI" => sub {
 };
 
 SKIP: {
-    skip "EdDSA is not supported by this OpenSSL build", 1
+    skip "ECDSA is not supported by this OpenSSL build", 1
         if disabled("ec");
 
     subtest "signing with xoflen is not supported `dgst` CLI" => sub {

--- a/test/recipes/20-test_dgst.t
+++ b/test/recipes/20-test_dgst.t
@@ -17,7 +17,7 @@ use OpenSSL::Test::Utils;
 
 setup("test_dgst");
 
-plan tests => 10;
+plan tests => 12;
 
 sub tsignverify {
     my $testtext = shift;
@@ -178,3 +178,35 @@ subtest "Custom length XOF digest generation with `dgst` CLI" => sub {
     ok($xofdata[1] =~ $expected,
        "XOF: Check second digest value is consistent with the first ($xofdata[1]) vs ($expected)");
 };
+
+subtest "SHAKE digest generation with no xoflen set `dgst` CLI" => sub {
+    plan tests => 2;
+
+    my $testdata = srctop_file('test', 'data.bin');
+
+    # For SHAKE128 check that it prints a warning if the -xoflen option is not set
+    my @xofdata = run(app(['openssl', 'dgst', '-shake128', $testdata], stderr => "outerr.txt"), capture => 1);
+    chomp(@xofdata);
+    my $expected = qr/SHAKE-128\(\Q$testdata\E\)= bb565dac72640109e1c926ef441d3fa6/;
+    ok($xofdata[0] =~ $expected, "Check short digest is output");
+    open DATA, "outerr.txt";
+    my @match = grep /Warning: The -xoflen option was not set/, <DATA>;
+    close DATA;
+    ok(scalar @match > 0 ? 1 : 0);
+};
+
+SKIP: {
+    skip "EdDSA is not supported by this OpenSSL build", 1
+        if disabled("ec");
+
+    subtest "signing with xoflen is not supported `dgst` CLI" => sub {
+        plan tests => 1;
+        my $data_to_sign = srctop_file('test', 'data.bin');
+
+        ok(!run(app(['openssl', 'dgst', '-shake256', '-xoflen', '64',
+                     '-sign', srctop_file("test","testec-p256.pem"),
+                     '-out', 'test.sig',
+                     srctop_file('test', 'data.bin')])),
+                     "Generating signature with xoflen should fail");
+    }
+}

--- a/test/recipes/20-test_dgst.t
+++ b/test/recipes/20-test_dgst.t
@@ -180,19 +180,13 @@ subtest "Custom length XOF digest generation with `dgst` CLI" => sub {
 };
 
 subtest "SHAKE digest generation with no xoflen set `dgst` CLI" => sub {
-    plan tests => 2;
+    plan tests => 1;
 
     my $testdata = srctop_file('test', 'data.bin');
-
-    # For SHAKE128 check that it prints a warning if the -xoflen option is not set
     my @xofdata = run(app(['openssl', 'dgst', '-shake128', $testdata], stderr => "outerr.txt"), capture => 1);
     chomp(@xofdata);
     my $expected = qr/SHAKE-128\(\Q$testdata\E\)= bb565dac72640109e1c926ef441d3fa6/;
     ok($xofdata[0] =~ $expected, "Check short digest is output");
-    open DATA, "outerr.txt";
-    my @match = grep /Warning: The -xoflen option was not set/, <DATA>;
-    close DATA;
-    ok(scalar @match > 0 ? 1 : 0);
 };
 
 SKIP: {


### PR DESCRIPTION
Fixes #18586

In order to not break existing applications the OpenSSL documentation
related to SHAKE has been updated.
~~The openssl dgst commandline app will log a warning to stderr if
SHAKE128 is used without the -xoflen option.~~

Background:

All digests algorithms (including XOF's) use the bitlen as the default output length.
This results in a security strength of bitlen / 2.

This means that SHAKE128 will by default have an output length of 16
bytes and a security strength of 64 bits.

For SHAKE256 the default output length is 32 bytes and has a security
strength of 128 bits.

This behaviour was present in 1.1.1 and has been duplicated in the
provider SHAKE algorithms for 3.0.

The SHAKE XOF algorithms have a security strength of
min(bitlen, output xof length in bits / 2).

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
