### PR TITLE
put_str: Use memcpy instead of strncpy

### DIFF
--- a/crypto/property/property_parse.c
+++ b/crypto/property/property_parse.c
@@ -600,7 +600,7 @@ static void put_str(const char *str, char **buf, size_t *remain, size_t *needed)
         len = *remain - 1;
 
     if (len > 0) {
-        strncpy(*buf, str, len);
+        memcpy(*buf, str, len);
         *buf += len;
         *remain -= len;
     }


### PR DESCRIPTION
This fixes a warning from latest gcc.

There is no point in using strncpy here as we
intentionally copy only the string contents without
the terminating NUL. The len is set from strlen().
