### PR TITLE
put_str: Use memcpy instead of strncpy [3.0]

### DIFF
--- a/crypto/property/property_parse.c
+++ b/crypto/property/property_parse.c
@@ -577,7 +577,7 @@ static void put_char(char ch, char **buf, size_t *remain, size_t *needed)
         ++*needed;
         return;
     }
-    if(*remain == 1)
+    if (*remain == 1)
         **buf = '\0';
     else
         **buf = ch;
@@ -596,16 +596,16 @@ static void put_str(const char *str, char **buf, size_t *remain, size_t *needed)
     if (*remain == 0)
         return;
 
-    if(*remain < len + 1)
+    if (*remain < len + 1)
         len = *remain - 1;
 
-    if(len > 0) {
-        strncpy(*buf, str, len);
+    if (len > 0) {
+        memcpy(*buf, str, len);
         *buf += len;
         *remain -= len;
     }
 
-    if(len < olen && *remain == 1) {
+    if (len < olen && *remain == 1) {
         **buf = '\0';
         ++*buf;
         --*remain;


### PR DESCRIPTION
This fixes a warning from latest gcc.

There is no point in using strncpy here as we
intentionally copy only the string contents without
the terminating NUL. The len is set from strlen().
