### PR TITLE
fuzz/asn1.c: Add check for ASN1_item_i2d

### DIFF
--- a/fuzz/asn1.c
+++ b/fuzz/asn1.c
@@ -317,9 +317,10 @@ int FuzzerTestOneInput(const uint8_t *buf, size_t len)
                 ASN1_item_print(bio, o, 4, i, pctx);
                 BIO_free(bio);
             }
-            ASN1_item_i2d(o, &der, i);
-            OPENSSL_free(der);
-            ASN1_item_free(o, i);
+            if (ASN1_item_i2d(o, &der, i) > 0) {
+                OPENSSL_free(der);
+                ASN1_item_free(o, i);
+            }
         }
     }
 


### PR DESCRIPTION
As the potential failure of the ASN1_item_i2d,
it should be better to check the return value.

Signed-off-by: Jiasheng Jiang <jiasheng@iscas.ac.cn>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
