### PR TITLE
Add `X509_PUBKEY_set0_public_key()`

### DIFF
--- a/crypto/asn1/a_bitstr.c
+++ b/crypto/asn1/a_bitstr.c
@@ -110,8 +110,7 @@ ASN1_BIT_STRING *ossl_c2i_ASN1_BIT_STRING(ASN1_BIT_STRING **a,
      * We do this to preserve the settings.  If we modify the settings, via
      * the _set_bit function, we will recalculate on output
      */
-    ret->flags &= ~(ASN1_STRING_FLAG_BITS_LEFT | 0x07); /* clear */
-    ret->flags |= (ASN1_STRING_FLAG_BITS_LEFT | i); /* set */
+    ossl_asn1_string_set_bits_left(ret, i);
 
     if (len-- > 1) {            /* using one because of the bits left byte */
         s = OPENSSL_malloc((int)len);

--- a/crypto/asn1/a_bitstr.c
+++ b/crypto/asn1/a_bitstr.c
@@ -125,9 +125,7 @@ ASN1_BIT_STRING *ossl_c2i_ASN1_BIT_STRING(ASN1_BIT_STRING **a,
     } else
         s = NULL;
 
-    ret->length = (int)len;
-    OPENSSL_free(ret->data);
-    ret->data = s;
+    ASN1_STRING_set0(ret, s, (int)len);
     ret->type = V_ASN1_BIT_STRING;
     if (a != NULL)
         (*a) = ret;

--- a/crypto/asn1/a_int.c
+++ b/crypto/asn1/a_int.c
@@ -444,9 +444,7 @@ ASN1_INTEGER *d2i_ASN1_UINTEGER(ASN1_INTEGER **a, const unsigned char **pp,
         p += len;
     }
 
-    OPENSSL_free(ret->data);
-    ret->data = s;
-    ret->length = (int)len;
+    ASN1_STRING_set0(ret, s, (int)len);
     if (a != NULL)
         (*a) = ret;
     *pp = p;

--- a/crypto/asn1/a_mbstr.c
+++ b/crypto/asn1/a_mbstr.c
@@ -139,9 +139,7 @@ int ASN1_mbstring_ncopy(ASN1_STRING **out, const unsigned char *in, int len,
     if (*out) {
         free_out = 0;
         dest = *out;
-        OPENSSL_free(dest->data);
-        dest->data = NULL;
-        dest->length = 0;
+        ASN1_STRING_set0(dest,  NULL, 0);
         dest->type = str_type;
     } else {
         free_out = 1;

--- a/crypto/asn1/a_sign.c
+++ b/crypto/asn1/a_sign.c
@@ -96,10 +96,8 @@ int ASN1_sign(i2d_of_void *i2d, X509_ALGOR *algor1, X509_ALGOR *algor2,
         ERR_raise(ERR_LIB_ASN1, ERR_R_EVP_LIB);
         goto err;
     }
-    OPENSSL_free(signature->data);
-    signature->data = buf_out;
+    ASN1_STRING_set0(signature, buf_out, outl);
     buf_out = NULL;
-    signature->length = outl;
     /*
      * In the interests of compatibility, I'll make sure that the bit string
      * has a 'not-used bits' value of 0
@@ -282,10 +280,8 @@ int ASN1_item_sign_ctx(const ASN1_ITEM *it, X509_ALGOR *algor1,
         ERR_raise(ERR_LIB_ASN1, ERR_R_EVP_LIB);
         goto err;
     }
-    OPENSSL_free(signature->data);
-    signature->data = buf_out;
+    ASN1_STRING_set0(signature, buf_out, outl);
     buf_out = NULL;
-    signature->length = outl;
     /*
      * In the interests of compatibility, I'll make sure that the bit string
      * has a 'not-used bits' value of 0

--- a/crypto/asn1/a_sign.c
+++ b/crypto/asn1/a_sign.c
@@ -102,8 +102,7 @@ int ASN1_sign(i2d_of_void *i2d, X509_ALGOR *algor1, X509_ALGOR *algor2,
      * In the interests of compatibility, I'll make sure that the bit string
      * has a 'not-used bits' value of 0
      */
-    signature->flags &= ~(ASN1_STRING_FLAG_BITS_LEFT | 0x07);
-    signature->flags |= ASN1_STRING_FLAG_BITS_LEFT;
+    ossl_asn1_string_set_bits_left(signature, 0);
  err:
     EVP_MD_CTX_free(ctx);
     OPENSSL_clear_free((char *)buf_in, inll);
@@ -286,8 +285,7 @@ int ASN1_item_sign_ctx(const ASN1_ITEM *it, X509_ALGOR *algor1,
      * In the interests of compatibility, I'll make sure that the bit string
      * has a 'not-used bits' value of 0
      */
-    signature->flags &= ~(ASN1_STRING_FLAG_BITS_LEFT | 0x07);
-    signature->flags |= ASN1_STRING_FLAG_BITS_LEFT;
+    ossl_asn1_string_set_bits_left(signature, 0);
  err:
     OPENSSL_clear_free((char *)buf_in, inl);
     OPENSSL_clear_free((char *)buf_out, outll);

--- a/crypto/asn1/a_time.c
+++ b/crypto/asn1/a_time.c
@@ -601,7 +601,7 @@ int ASN1_TIME_compare(const ASN1_TIME *a, const ASN1_TIME *b)
 # define USE_TIMEGM
 #endif
 
-time_t asn1_string_to_time_t(const char *asn1_string)
+time_t ossl_asn1_string_to_time_t(const char *asn1_string)
 {
     ASN1_TIME *timestamp_asn1 = NULL;
     struct tm *timestamp_tm = NULL;

--- a/crypto/asn1/asn1_gen.c
+++ b/crypto/asn1/asn1_gen.c
@@ -714,11 +714,8 @@ static ASN1_TYPE *asn1_str2type(const char *str, int format, int utype)
             goto bad_form;
         }
 
-        if ((utype == V_ASN1_BIT_STRING) && no_unused) {
-            atmp->value.asn1_string->flags
-                &= ~(ASN1_STRING_FLAG_BITS_LEFT | 0x07);
-            atmp->value.asn1_string->flags |= ASN1_STRING_FLAG_BITS_LEFT;
-        }
+        if ((utype == V_ASN1_BIT_STRING) && no_unused)
+            ossl_asn1_string_set_bits_left(atmp->value.asn1_string, 0);
 
         break;
 

--- a/crypto/asn1/asn1_lib.c
+++ b/crypto/asn1/asn1_lib.c
@@ -248,6 +248,12 @@ int ASN1_object_size(int constructed, int length, int tag)
     return ret + length;
 }
 
+void ossl_asn1_string_set_bits_left(ASN1_STRING *str, unsigned int num)
+{
+    str->flags &= ~0x07;
+    str->flags |= ASN1_STRING_FLAG_BITS_LEFT | (num & 0x07);
+}
+
 int ASN1_STRING_copy(ASN1_STRING *dst, const ASN1_STRING *str)
 {
     if (str == NULL)

--- a/crypto/asn1/asn1_local.h
+++ b/crypto/asn1/asn1_local.h
@@ -9,6 +9,8 @@
 
 /* Internal ASN1 structures and functions: not for application use */
 
+#include "crypto/asn1.h"
+
 typedef const ASN1_VALUE const_ASN1_VALUE;
 SKM_DEFINE_STACK_OF(const_ASN1_VALUE, const ASN1_VALUE, ASN1_VALUE)
 

--- a/crypto/asn1/asn_pack.c
+++ b/crypto/asn1/asn_pack.c
@@ -17,7 +17,7 @@ ASN1_STRING *ASN1_item_pack(void *obj, const ASN1_ITEM *it, ASN1_STRING **oct)
 {
     ASN1_STRING *octmp;
 
-     if (oct == NULL || *oct == NULL) {
+    if (oct == NULL || *oct == NULL) {
         if ((octmp = ASN1_STRING_new()) == NULL) {
             ERR_raise(ERR_LIB_ASN1, ERR_R_MALLOC_FAILURE);
             return NULL;
@@ -26,8 +26,7 @@ ASN1_STRING *ASN1_item_pack(void *obj, const ASN1_ITEM *it, ASN1_STRING **oct)
         octmp = *oct;
     }
 
-    OPENSSL_free(octmp->data);
-    octmp->data = NULL;
+    ASN1_STRING_set0(octmp, NULL, 0);
 
     if ((octmp->length = ASN1_item_i2d(obj, &octmp->data, it)) == 0) {
         ERR_raise(ERR_LIB_ASN1, ASN1_R_ENCODE_ERROR);

--- a/crypto/asn1/tasn_dec.c
+++ b/crypto/asn1/tasn_dec.c
@@ -935,9 +935,7 @@ static int asn1_ex_c2i(ASN1_VALUE **pval, const unsigned char *cont, int len,
         }
         /* If we've already allocated a buffer use it */
         if (*free_cont) {
-            OPENSSL_free(stmp->data);
-            stmp->data = (unsigned char *)cont; /* UGLY CAST! RL */
-            stmp->length = len;
+            ASN1_STRING_set0(stmp, (unsigned char *)cont /* UGLY CAST! */, len);
             *free_cont = 0;
         } else {
             if (!ASN1_STRING_set(stmp, cont, len)) {

--- a/crypto/cmp/cmp_protect.c
+++ b/crypto/cmp/cmp_protect.c
@@ -93,8 +93,7 @@ ASN1_BIT_STRING *ossl_cmp_calc_protection(const OSSL_CMP_CTX *ctx,
         if ((prot = ASN1_BIT_STRING_new()) == NULL)
             return NULL;
         /* OpenSSL defaults all bit strings to be encoded as ASN.1 NamedBitList */
-        prot->flags &= ~(ASN1_STRING_FLAG_BITS_LEFT | 0x07);
-        prot->flags |= ASN1_STRING_FLAG_BITS_LEFT;
+        ossl_asn1_string_set_bits_left(prot, 0);
         if (!ASN1_BIT_STRING_set(prot, protection, sig_len)) {
             ASN1_BIT_STRING_free(prot);
             prot = NULL;

--- a/crypto/cms/cms_dh.c
+++ b/crypto/cms/cms_dh.c
@@ -13,6 +13,7 @@
 #include <openssl/err.h>
 #include <openssl/core_names.h>
 #include "internal/sizes.h"
+#include "crypto/asn1.h"
 #include "crypto/evp.h"
 #include "cms_local.h"
 
@@ -234,8 +235,7 @@ static int dh_cms_encrypt(CMS_RecipientInfo *ri)
         if (penclen <= 0)
             goto err;
         ASN1_STRING_set0(pubkey, penc, penclen);
-        pubkey->flags &= ~(ASN1_STRING_FLAG_BITS_LEFT | 0x07);
-        pubkey->flags |= ASN1_STRING_FLAG_BITS_LEFT;
+        ossl_asn1_string_set_bits_left(pubkey, 0);
 
         penc = NULL;
         (void)X509_ALGOR_set0(talg, OBJ_nid2obj(NID_dhpublicnumber),

--- a/crypto/cms/cms_ec.c
+++ b/crypto/cms/cms_ec.c
@@ -12,6 +12,7 @@
 #include <openssl/err.h>
 #include <openssl/decoder.h>
 #include "internal/sizes.h"
+#include "crypto/asn1.h"
 #include "crypto/evp.h"
 #include "cms_local.h"
 
@@ -277,8 +278,7 @@ static int ecdh_cms_encrypt(CMS_RecipientInfo *ri)
 
         penclen = EVP_PKEY_get1_encoded_public_key(pkey, &penc);
         ASN1_STRING_set0(pubkey, penc, penclen);
-        pubkey->flags &= ~(ASN1_STRING_FLAG_BITS_LEFT | 0x07);
-        pubkey->flags |= ASN1_STRING_FLAG_BITS_LEFT;
+        ossl_asn1_string_set_bits_left(pubkey, 0);
 
         penc = NULL;
         (void)X509_ALGOR_set0(talg, OBJ_nid2obj(NID_X9_62_id_ecPublicKey),

--- a/crypto/ec/ec_asn1.c
+++ b/crypto/ec/ec_asn1.c
@@ -19,6 +19,7 @@
 #include <openssl/asn1t.h>
 #include <openssl/objects.h>
 #include "internal/nelem.h"
+#include "crypto/asn1.h"
 #include "crypto/asn1_dsa.h"
 
 #ifndef FIPS_MODULE
@@ -358,8 +359,7 @@ static int ec_asn1_group2curve(const EC_GROUP *group, X9_62_CURVE *curve)
                 ERR_raise(ERR_LIB_EC, ERR_R_MALLOC_FAILURE);
                 goto err;
             }
-        curve->seed->flags &= ~(ASN1_STRING_FLAG_BITS_LEFT | 0x07);
-        curve->seed->flags |= ASN1_STRING_FLAG_BITS_LEFT;
+        ossl_asn1_string_set_bits_left(curve->seed, 0);
         if (!ASN1_BIT_STRING_set(curve->seed, group->seed,
                                  (int)group->seed_len)) {
             ERR_raise(ERR_LIB_EC, ERR_R_ASN1_LIB);
@@ -1072,8 +1072,7 @@ int i2d_ECPrivateKey(const EC_KEY *a, unsigned char **out)
             goto err;
         }
 
-        priv_key->publicKey->flags &= ~(ASN1_STRING_FLAG_BITS_LEFT | 0x07);
-        priv_key->publicKey->flags |= ASN1_STRING_FLAG_BITS_LEFT;
+        ossl_asn1_string_set_bits_left(priv_key->publicKey, 0);
         ASN1_STRING_set0(priv_key->publicKey, pub, publen);
         pub = NULL;
     }

--- a/crypto/x509/v3_addr.c
+++ b/crypto/x509/v3_addr.c
@@ -31,28 +31,28 @@
  */
 
 ASN1_SEQUENCE(IPAddressRange) = {
-  ASN1_SIMPLE(IPAddressRange, min, ASN1_BIT_STRING),
-  ASN1_SIMPLE(IPAddressRange, max, ASN1_BIT_STRING)
+    ASN1_SIMPLE(IPAddressRange, min, ASN1_BIT_STRING),
+    ASN1_SIMPLE(IPAddressRange, max, ASN1_BIT_STRING)
 } ASN1_SEQUENCE_END(IPAddressRange)
 
 ASN1_CHOICE(IPAddressOrRange) = {
-  ASN1_SIMPLE(IPAddressOrRange, u.addressPrefix, ASN1_BIT_STRING),
-  ASN1_SIMPLE(IPAddressOrRange, u.addressRange,  IPAddressRange)
+    ASN1_SIMPLE(IPAddressOrRange, u.addressPrefix, ASN1_BIT_STRING),
+    ASN1_SIMPLE(IPAddressOrRange, u.addressRange,  IPAddressRange)
 } ASN1_CHOICE_END(IPAddressOrRange)
 
 ASN1_CHOICE(IPAddressChoice) = {
-  ASN1_SIMPLE(IPAddressChoice,      u.inherit,           ASN1_NULL),
-  ASN1_SEQUENCE_OF(IPAddressChoice, u.addressesOrRanges, IPAddressOrRange)
+    ASN1_SIMPLE(IPAddressChoice,      u.inherit,           ASN1_NULL),
+    ASN1_SEQUENCE_OF(IPAddressChoice, u.addressesOrRanges, IPAddressOrRange)
 } ASN1_CHOICE_END(IPAddressChoice)
 
 ASN1_SEQUENCE(IPAddressFamily) = {
-  ASN1_SIMPLE(IPAddressFamily, addressFamily,   ASN1_OCTET_STRING),
-  ASN1_SIMPLE(IPAddressFamily, ipAddressChoice, IPAddressChoice)
+    ASN1_SIMPLE(IPAddressFamily, addressFamily,   ASN1_OCTET_STRING),
+    ASN1_SIMPLE(IPAddressFamily, ipAddressChoice, IPAddressChoice)
 } ASN1_SEQUENCE_END(IPAddressFamily)
 
 ASN1_ITEM_TEMPLATE(IPAddrBlocks) =
-  ASN1_EX_TEMPLATE_TYPE(ASN1_TFLG_SEQUENCE_OF, 0,
-                        IPAddrBlocks, IPAddressFamily)
+    ASN1_EX_TEMPLATE_TYPE(ASN1_TFLG_SEQUENCE_OF, 0,
+                          IPAddrBlocks, IPAddressFamily)
 static_ASN1_ITEM_TEMPLATE_END(IPAddrBlocks)
 
 IMPLEMENT_ASN1_FUNCTIONS(IPAddressRange)
@@ -63,7 +63,7 @@ IMPLEMENT_ASN1_FUNCTIONS(IPAddressFamily)
 /*
  * How much buffer space do we need for a raw address?
  */
-#define ADDR_RAW_BUF_LEN        16
+# define ADDR_RAW_BUF_LEN 16
 
 /*
  * What's the address length associated with this AFI?
@@ -107,6 +107,7 @@ static int addr_expand(unsigned char *addr,
         memcpy(addr, bs->data, bs->length);
         if ((bs->flags & 7) != 0) {
             unsigned char mask = 0xFF >> (8 - (bs->flags & 7));
+
             if (fill == 0)
                 addr[bs->length - 1] &= ~mask;
             else
@@ -120,7 +121,7 @@ static int addr_expand(unsigned char *addr,
 /*
  * Extract the prefix length from a bitstring.
  */
-#define addr_prefixlen(bs) ((int) ((bs)->length * 8 - ((bs)->flags & 7)))
+# define addr_prefixlen(bs) ((int)((bs)->length * 8 - ((bs)->flags & 7)))
 
 /*
  * i2r handler for one address bitstring.
@@ -171,8 +172,10 @@ static int i2r_IPAddressOrRanges(BIO *out,
                                  const unsigned afi)
 {
     int i;
+
     for (i = 0; i < sk_IPAddressOrRange_num(aors); i++) {
         const IPAddressOrRange *aor = sk_IPAddressOrRange_value(aors, i);
+
         BIO_printf(out, "%*s", indent, "");
         switch (aor->type) {
         case IPAddressOrRange_addressPrefix:
@@ -201,9 +204,11 @@ static int i2r_IPAddrBlocks(const X509V3_EXT_METHOD *method,
 {
     const IPAddrBlocks *addr = ext;
     int i;
+
     for (i = 0; i < sk_IPAddressFamily_num(addr); i++) {
         IPAddressFamily *f = sk_IPAddressFamily_value(addr, i);
         const unsigned int afi = X509v3_addr_get_afi(f);
+
         switch (afi) {
         case IANA_AFI_IPV4:
             BIO_printf(out, "%*sIPv4", indent, "");
@@ -400,9 +405,8 @@ static int make_addressPrefix(IPAddressOrRange **result,
         goto err;
     if (!ASN1_BIT_STRING_set(aor->u.addressPrefix, addr, bytelen))
         goto err;
-    if (bitlen > 0) {
+    if (bitlen > 0)
         aor->u.addressPrefix->data[bytelen - 1] &= ~(0xFF >> bitlen);
-    }
     ossl_asn1_string_set_bits_left(aor->u.addressPrefix, 8 - bitlen);
 
     *result = aor;
@@ -447,6 +451,7 @@ static int make_addressRange(IPAddressOrRange **result,
     if (i > 0) {
         unsigned char b = min[i - 1];
         int j = 1;
+
         while ((b & (0xFFU >> j)) != 0)
             ++j;
         aor->u.addressRange->min->flags |= 8 - j;
@@ -459,6 +464,7 @@ static int make_addressRange(IPAddressOrRange **result,
     if (i > 0) {
         unsigned char b = max[i - 1];
         int j = 1;
+
         while ((b & (0xFFU >> j)) != (0xFFU >> j))
             ++j;
         aor->u.addressRange->max->flags |= 8 - j;
@@ -527,6 +533,7 @@ int X509v3_addr_add_inherit(IPAddrBlocks *addr,
                             const unsigned afi, const unsigned *safi)
 {
     IPAddressFamily *f = make_IPAddressFamily(addr, afi, safi);
+
     if (f == NULL ||
         f->ipAddressChoice == NULL ||
         (f->ipAddressChoice->type == IPAddressChoice_addressesOrRanges &&
@@ -586,6 +593,7 @@ int X509v3_addr_add_prefix(IPAddrBlocks *addr,
 {
     IPAddressOrRanges *aors = make_prefix_or_range(addr, afi, safi);
     IPAddressOrRange *aor;
+
     if (aors == NULL || !make_addressPrefix(&aor, a, prefixlen))
         return 0;
     if (sk_IPAddressOrRange_push(aors, aor))
@@ -605,6 +613,7 @@ int X509v3_addr_add_range(IPAddrBlocks *addr,
     IPAddressOrRanges *aors = make_prefix_or_range(addr, afi, safi);
     IPAddressOrRange *aor;
     int length = length_from_afi(afi);
+
     if (aors == NULL)
         return 0;
     if (!make_addressRange(&aor, min, max, length))
@@ -643,6 +652,7 @@ int X509v3_addr_get_range(IPAddressOrRange *aor,
                           unsigned char *max, const int length)
 {
     int afi_length = length_from_afi(afi);
+
     if (aor == NULL || min == NULL || max == NULL ||
         afi_length == 0 || length < afi_length ||
         (aor->type != IPAddressOrRange_addressPrefix &&
@@ -670,6 +680,7 @@ static int IPAddressFamily_cmp(const IPAddressFamily *const *a_,
     const ASN1_OCTET_STRING *b = (*b_)->addressFamily;
     int len = ((a->length <= b->length) ? a->length : b->length);
     int cmp = memcmp(a->data, b->data, len);
+
     return cmp ? cmp : a->length - b->length;
 }
 
@@ -695,6 +706,7 @@ int X509v3_addr_is_canonical(IPAddrBlocks *addr)
     for (i = 0; i < sk_IPAddressFamily_num(addr) - 1; i++) {
         const IPAddressFamily *a = sk_IPAddressFamily_value(addr, i);
         const IPAddressFamily *b = sk_IPAddressFamily_value(addr, i + 1);
+
         if (IPAddressFamily_cmp(&a, &b) >= 0)
             return 0;
     }
@@ -766,6 +778,7 @@ int X509v3_addr_is_canonical(IPAddrBlocks *addr)
         j = sk_IPAddressOrRange_num(aors) - 1;
         {
             IPAddressOrRange *a = sk_IPAddressOrRange_value(aors, j);
+
             if (a != NULL && a->type == IPAddressOrRange_addressRange) {
                 if (!extract_min_max(a, a_min, a_max, length))
                     return 0;
@@ -828,6 +841,7 @@ static int IPAddressOrRanges_canonize(IPAddressOrRanges *aors,
         for (j = length - 1; j >= 0 && b_min[j]-- == 0x00; j--) ;
         if (memcmp(a_max, b_min, length) == 0) {
             IPAddressOrRange *merged;
+
             if (!make_addressRange(&merged, a_min, b_max, length))
                 return 0;
             (void)sk_IPAddressOrRange_set(aors, i, merged);
@@ -845,8 +859,10 @@ static int IPAddressOrRanges_canonize(IPAddressOrRanges *aors,
     j = sk_IPAddressOrRange_num(aors) - 1;
     {
         IPAddressOrRange *a = sk_IPAddressOrRange_value(aors, j);
+
         if (a != NULL && a->type == IPAddressOrRange_addressRange) {
             unsigned char a_min[ADDR_RAW_BUF_LEN], a_max[ADDR_RAW_BUF_LEN];
+
             if (!extract_min_max(a, a_min, a_max, length))
                 return 0;
             if (memcmp(a_min, a_max, length) > 0)
@@ -863,8 +879,10 @@ static int IPAddressOrRanges_canonize(IPAddressOrRanges *aors,
 int X509v3_addr_canonize(IPAddrBlocks *addr)
 {
     int i;
+
     for (i = 0; i < sk_IPAddressFamily_num(addr); i++) {
         IPAddressFamily *f = sk_IPAddressFamily_value(addr, i);
+
         if (f->ipAddressChoice->type == IPAddressChoice_addressesOrRanges &&
             !IPAddressOrRanges_canonize(f->ipAddressChoice->
                                         u.addressesOrRanges,
@@ -1066,10 +1084,12 @@ const X509V3_EXT_METHOD ossl_v3_addr = {
 int X509v3_addr_inherits(IPAddrBlocks *addr)
 {
     int i;
+
     if (addr == NULL)
         return 0;
     for (i = 0; i < sk_IPAddressFamily_num(addr); i++) {
         IPAddressFamily *f = sk_IPAddressFamily_value(addr, i);
+
         if (f->ipAddressChoice->type == IPAddressChoice_inherit)
             return 1;
     }
@@ -1119,6 +1139,7 @@ static int addr_contains(IPAddressOrRanges *parent,
 int X509v3_addr_subset(IPAddrBlocks *a, IPAddrBlocks *b)
 {
     int i;
+
     if (a == NULL || a == b)
         return 1;
     if (b == NULL || X509v3_addr_inherits(a) || X509v3_addr_inherits(b))
@@ -1127,8 +1148,8 @@ int X509v3_addr_subset(IPAddrBlocks *a, IPAddrBlocks *b)
     for (i = 0; i < sk_IPAddressFamily_num(a); i++) {
         IPAddressFamily *fa = sk_IPAddressFamily_value(a, i);
         int j = sk_IPAddressFamily_find(b, fa);
-        IPAddressFamily *fb;
-        fb = sk_IPAddressFamily_value(b, j);
+        IPAddressFamily *fb = sk_IPAddressFamily_value(b, j);
+
         if (fb == NULL)
             return 0;
         if (!addr_contains(fb->ipAddressChoice->u.addressesOrRanges,
@@ -1142,19 +1163,19 @@ int X509v3_addr_subset(IPAddrBlocks *a, IPAddrBlocks *b)
 /*
  * Validation error handling via callback.
  */
-#define validation_err(_err_)           \
-  do {                                  \
-    if (ctx != NULL) {                  \
-      ctx->error = _err_;               \
-      ctx->error_depth = i;             \
-      ctx->current_cert = x;            \
-      ret = ctx->verify_cb(0, ctx);     \
-    } else {                            \
-      ret = 0;                          \
-    }                                   \
-    if (!ret)                           \
-      goto done;                        \
-  } while (0)
+# define validation_err(_err_)            \
+    do {                                  \
+        if (ctx != NULL) {                \
+            ctx->error = _err_;           \
+            ctx->error_depth = i;         \
+            ctx->current_cert = x;        \
+            ret = ctx->verify_cb(0, ctx); \
+        } else {                          \
+            ret = 0;                      \
+        }                                 \
+        if (!ret)                         \
+            goto done;                    \
+    } while (0)
 
 /*
  * Core code for RFC 3779 2.3 path validation.
@@ -1216,6 +1237,7 @@ static int addr_validate_path_internal(X509_STORE_CTX *ctx,
         if (x->rfc3779_addr == NULL) {
             for (j = 0; j < sk_IPAddressFamily_num(child); j++) {
                 IPAddressFamily *fc = sk_IPAddressFamily_value(child, j);
+
                 if (fc->ipAddressChoice->type != IPAddressChoice_inherit) {
                     validation_err(X509_V_ERR_UNNESTED_RESOURCE);
                     break;
@@ -1230,6 +1252,7 @@ static int addr_validate_path_internal(X509_STORE_CTX *ctx,
             int k = sk_IPAddressFamily_find(x->rfc3779_addr, fc);
             IPAddressFamily *fp =
                 sk_IPAddressFamily_value(x->rfc3779_addr, k);
+
             if (fp == NULL) {
                 if (fc->ipAddressChoice->type ==
                     IPAddressChoice_addressesOrRanges) {
@@ -1256,8 +1279,8 @@ static int addr_validate_path_internal(X509_STORE_CTX *ctx,
      */
     if (x->rfc3779_addr != NULL) {
         for (j = 0; j < sk_IPAddressFamily_num(x->rfc3779_addr); j++) {
-            IPAddressFamily *fp =
-                sk_IPAddressFamily_value(x->rfc3779_addr, j);
+            IPAddressFamily *fp = sk_IPAddressFamily_value(x->rfc3779_addr, j);
+
             if (fp->ipAddressChoice->type == IPAddressChoice_inherit
                 && sk_IPAddressFamily_find(child, fp) >= 0)
                 validation_err(X509_V_ERR_UNNESTED_RESOURCE);
@@ -1269,7 +1292,7 @@ static int addr_validate_path_internal(X509_STORE_CTX *ctx,
     return ret;
 }
 
-#undef validation_err
+# undef validation_err
 
 /*
  * RFC 3779 2.3 path validation -- called from X509_verify_cert().
@@ -1290,7 +1313,7 @@ int X509v3_addr_validate_path(X509_STORE_CTX *ctx)
  * Test whether chain covers extension.
  */
 int X509v3_addr_validate_resource_set(STACK_OF(X509) *chain,
-                                  IPAddrBlocks *ext, int allow_inheritance)
+                                      IPAddrBlocks *ext, int allow_inheritance)
 {
     if (ext == NULL)
         return 1;
@@ -1301,4 +1324,4 @@ int X509v3_addr_validate_resource_set(STACK_OF(X509) *chain,
     return addr_validate_path_internal(NULL, chain, ext);
 }
 
-#endif                          /* OPENSSL_NO_RFC3779 */
+#endif /* OPENSSL_NO_RFC3779 */

--- a/crypto/x509/v3_addr.c
+++ b/crypto/x509/v3_addr.c
@@ -400,12 +400,10 @@ static int make_addressPrefix(IPAddressOrRange **result,
         goto err;
     if (!ASN1_BIT_STRING_set(aor->u.addressPrefix, addr, bytelen))
         goto err;
-    aor->u.addressPrefix->flags &= ~7;
-    aor->u.addressPrefix->flags |= ASN1_STRING_FLAG_BITS_LEFT;
     if (bitlen > 0) {
         aor->u.addressPrefix->data[bytelen - 1] &= ~(0xFF >> bitlen);
-        aor->u.addressPrefix->flags |= 8 - bitlen;
     }
+    ossl_asn1_string_set_bits_left(aor->u.addressPrefix, 8 - bitlen);
 
     *result = aor;
     return 1;
@@ -445,8 +443,7 @@ static int make_addressRange(IPAddressOrRange **result,
     for (i = length; i > 0 && min[i - 1] == 0x00; --i) ;
     if (!ASN1_BIT_STRING_set(aor->u.addressRange->min, min, i))
         goto err;
-    aor->u.addressRange->min->flags &= ~7;
-    aor->u.addressRange->min->flags |= ASN1_STRING_FLAG_BITS_LEFT;
+    ossl_asn1_string_set_bits_left(aor->u.addressRange->min, 0);
     if (i > 0) {
         unsigned char b = min[i - 1];
         int j = 1;
@@ -458,8 +455,7 @@ static int make_addressRange(IPAddressOrRange **result,
     for (i = length; i > 0 && max[i - 1] == 0xFF; --i) ;
     if (!ASN1_BIT_STRING_set(aor->u.addressRange->max, max, i))
         goto err;
-    aor->u.addressRange->max->flags &= ~7;
-    aor->u.addressRange->max->flags |= ASN1_STRING_FLAG_BITS_LEFT;
+    ossl_asn1_string_set_bits_left(aor->u.addressRange->max, 0);
     if (i > 0) {
         unsigned char b = max[i - 1];
         int j = 1;

--- a/crypto/x509/x_pubkey.c
+++ b/crypto/x509/x_pubkey.c
@@ -980,9 +980,7 @@ int ossl_i2d_X448_PUBKEY(const ECX_KEY *a, unsigned char **pp)
 void X509_PUBKEY_set0_public_key(X509_PUBKEY *pub,
                                  unsigned char *penc, int penclen)
 {
-    OPENSSL_free(pub->public_key->data);
-    pub->public_key->data = penc;
-    pub->public_key->length = penclen;
+    ASN1_STRING_set0(pub->public_key, penc, penclen);
     /* Set number of unused bits to zero */
     pub->public_key->flags &= ~(ASN1_STRING_FLAG_BITS_LEFT | 0x07);
     pub->public_key->flags |= ASN1_STRING_FLAG_BITS_LEFT;

--- a/crypto/x509/x_pubkey.c
+++ b/crypto/x509/x_pubkey.c
@@ -981,9 +981,7 @@ void X509_PUBKEY_set0_public_key(X509_PUBKEY *pub,
                                  unsigned char *penc, int penclen)
 {
     ASN1_STRING_set0(pub->public_key, penc, penclen);
-    /* Set number of unused bits to zero */
-    pub->public_key->flags &= ~(ASN1_STRING_FLAG_BITS_LEFT | 0x07);
-    pub->public_key->flags |= ASN1_STRING_FLAG_BITS_LEFT;
+    ossl_asn1_string_set_bits_left(pub->public_key, 0);
 }
 
 int X509_PUBKEY_set0_param(X509_PUBKEY *pub, ASN1_OBJECT *aobj,

--- a/crypto/x509/x_pubkey.c
+++ b/crypto/x509/x_pubkey.c
@@ -977,20 +977,25 @@ int ossl_i2d_X448_PUBKEY(const ECX_KEY *a, unsigned char **pp)
 
 #endif
 
+void X509_PUBKEY_set0_public_key(X509_PUBKEY *pub,
+                                 unsigned char *penc, int penclen)
+{
+    OPENSSL_free(pub->public_key->data);
+    pub->public_key->data = penc;
+    pub->public_key->length = penclen;
+    /* Set number of unused bits to zero */
+    pub->public_key->flags &= ~(ASN1_STRING_FLAG_BITS_LEFT | 0x07);
+    pub->public_key->flags |= ASN1_STRING_FLAG_BITS_LEFT;
+}
+
 int X509_PUBKEY_set0_param(X509_PUBKEY *pub, ASN1_OBJECT *aobj,
                            int ptype, void *pval,
                            unsigned char *penc, int penclen)
 {
     if (!X509_ALGOR_set0(pub->algor, aobj, ptype, pval))
         return 0;
-    if (penc) {
-        OPENSSL_free(pub->public_key->data);
-        pub->public_key->data = penc;
-        pub->public_key->length = penclen;
-        /* Set number of unused bits to zero */
-        pub->public_key->flags &= ~(ASN1_STRING_FLAG_BITS_LEFT | 0x07);
-        pub->public_key->flags |= ASN1_STRING_FLAG_BITS_LEFT;
-    }
+    if (penc != NULL)
+        X509_PUBKEY_set0_public_key(pub, penc, penclen);
     return 1;
 }
 

--- a/doc/man3/X509_PUBKEY_new.pod
+++ b/doc/man3/X509_PUBKEY_new.pod
@@ -5,7 +5,8 @@
 X509_PUBKEY_new_ex, X509_PUBKEY_new, X509_PUBKEY_free, X509_PUBKEY_dup,
 X509_PUBKEY_set, X509_PUBKEY_get0, X509_PUBKEY_get,
 d2i_PUBKEY_ex, d2i_PUBKEY, i2d_PUBKEY, d2i_PUBKEY_bio, d2i_PUBKEY_fp,
-i2d_PUBKEY_fp, i2d_PUBKEY_bio, X509_PUBKEY_set0_param, X509_PUBKEY_get0_param,
+i2d_PUBKEY_fp, i2d_PUBKEY_bio, X509_PUBKEY_set0_public_key,
+X509_PUBKEY_set0_param, X509_PUBKEY_get0_param,
 X509_PUBKEY_eq - SubjectPublicKeyInfo public key functions
 
 =head1 SYNOPSIS
@@ -32,6 +33,8 @@ X509_PUBKEY_eq - SubjectPublicKeyInfo public key functions
  int i2d_PUBKEY_fp(const FILE *fp, EVP_PKEY *pkey);
  int i2d_PUBKEY_bio(BIO *bp, const EVP_PKEY *pkey);
 
+ void X509_PUBKEY_set0_public_key(X509_PUBKEY *pub,
+                                  unsigned char *penc, int penclen);
  int X509_PUBKEY_set0_param(X509_PUBKEY *pub, ASN1_OBJECT *aobj,
                             int ptype, void *pval,
                             unsigned char *penc, int penclen);
@@ -85,13 +88,17 @@ d2i_PUBKEY_bio(), d2i_PUBKEY_fp(), i2d_PUBKEY_bio() and i2d_PUBKEY_fp() are
 similar to d2i_PUBKEY() and i2d_PUBKEY() except they decode or encode using a
 B<BIO> or B<FILE> pointer.
 
+X509_PUBKEY_set0_public_key() sets the public key encoding of I<pub>
+to the I<penclen> bytes contained in buffer I<penc>.
+I<penc> may be NULL to indicate that there is no actual public key data.
+
 X509_PUBKEY_set0_param() sets the public key parameters of I<pub>. The
 OID associated with the algorithm is set to I<aobj>. The type of the
 algorithm parameters is set to I<type> using the structure I<pval>.
 The encoding of the public key itself is set to the I<penclen>
-bytes contained in buffer I<penc>. On success ownership of all the supplied
-parameters is passed to I<pub> so they must not be freed after the
-call.
+bytes contained in buffer I<penc>, which may not be NULL.
+On success ownership of all the supplied parameters is passed to I<pub>
+so they must not be freed after the call.
 
 X509_PUBKEY_get0_param() retrieves the public key parameters from I<pub>,
 I<*ppkalg> is set to the associated OID and the encoding consists of
@@ -122,6 +129,8 @@ X509_PUBKEY_free() does not return a value.
 X509_PUBKEY_get0() and X509_PUBKEY_get() return a pointer to an B<EVP_PKEY>
 structure or NULL if an error occurs.
 
+X509_PUBKEY_set0_public_key() does not return a value.
+
 X509_PUBKEY_set(), X509_PUBKEY_set0_param() and X509_PUBKEY_get0_param()
 return 1 for success and 0 if an error occurred.
 
@@ -137,6 +146,8 @@ L<X509_get_pubkey(3)>,
 
 The X509_PUBKEY_new_ex() and X509_PUBKEY_eq() functions were added in OpenSSL
 3.0.
+
+X509_PUBKEY_set0_public_key() was added in OpenSSL 3.1.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/X509_PUBKEY_new.pod
+++ b/doc/man3/X509_PUBKEY_new.pod
@@ -88,16 +88,19 @@ d2i_PUBKEY_bio(), d2i_PUBKEY_fp(), i2d_PUBKEY_bio() and i2d_PUBKEY_fp() are
 similar to d2i_PUBKEY() and i2d_PUBKEY() except they decode or encode using a
 B<BIO> or B<FILE> pointer.
 
-X509_PUBKEY_set0_public_key() sets the public key encoding of I<pub>
+X509_PUBKEY_set0_public_key() sets the public-key encoding of I<pub>
 to the I<penclen> bytes contained in buffer I<penc>.
+Any earlier public-key encoding in I<pub> is freed.
 I<penc> may be NULL to indicate that there is no actual public key data.
+Ownership of the I<penc> argument is passed to I<pub>.
 
-X509_PUBKEY_set0_param() sets the public key parameters of I<pub>. The
-OID associated with the algorithm is set to I<aobj>. The type of the
+X509_PUBKEY_set0_param() sets the public-key parameters of I<pub>.
+The OID associated with the algorithm is set to I<aobj>. The type of the
 algorithm parameters is set to I<type> using the structure I<pval>.
-The encoding of the public key itself is set to the I<penclen>
-bytes contained in buffer I<penc>, which may not be NULL.
-On success ownership of all the supplied parameters is passed to I<pub>
+If I<penc> is not NULL the encoding of the public key itself is set
+to the I<penclen> bytes contained in buffer I<penc> and
+any earlier public-key encoding in I<pub> is freed.
+On success ownership of all the supplied arguments is passed to I<pub>
 so they must not be freed after the call.
 
 X509_PUBKEY_get0_param() retrieves the public key parameters from I<pub>,

--- a/include/crypto/asn1.h
+++ b/include/crypto/asn1.h
@@ -147,7 +147,7 @@ EVP_PKEY * ossl_d2i_PrivateKey_legacy(int keytype, EVP_PKEY **a,
                                       OSSL_LIB_CTX *libctx, const char *propq);
 X509_ALGOR *ossl_X509_ALGOR_from_nid(int nid, int ptype, void *pval);
 
-time_t asn1_string_to_time_t(const char *asn1_string);
+time_t ossl_asn1_string_to_time_t(const char *asn1_string);
 void ossl_asn1_string_set_bits_left(ASN1_STRING *str, unsigned int num);
 
 #endif /* ndef OSSL_CRYPTO_ASN1_H */

--- a/include/crypto/asn1.h
+++ b/include/crypto/asn1.h
@@ -148,5 +148,6 @@ EVP_PKEY * ossl_d2i_PrivateKey_legacy(int keytype, EVP_PKEY **a,
 X509_ALGOR *ossl_X509_ALGOR_from_nid(int nid, int ptype, void *pval);
 
 time_t asn1_string_to_time_t(const char *asn1_string);
+void ossl_asn1_string_set_bits_left(ASN1_STRING *str, unsigned int num);
 
 #endif /* ndef OSSL_CRYPTO_ASN1_H */

--- a/include/internal/cryptlib.h
+++ b/include/internal/cryptlib.h
@@ -19,6 +19,7 @@
 # endif
 
 # include "internal/common.h"
+# include "crypto/asn1.h"
 
 # include <openssl/crypto.h>
 # include <openssl/buffer.h>

--- a/include/openssl/asn1.h.in
+++ b/include/openssl/asn1.h.in
@@ -135,7 +135,7 @@ extern "C" {
 -}
 
 
-# define ASN1_STRING_FLAG_BITS_LEFT 0x08/* Set if 0x07 has bits left value */
+# define ASN1_STRING_FLAG_BITS_LEFT 0x08 /* Set if 0x07 has bits left value */
 /*
  * This indicates that the ASN1_STRING is not a real value but just a place
  * holder for the location where indefinite length constructed data should be

--- a/include/openssl/x509.h.in
+++ b/include/openssl/x509.h.in
@@ -1072,6 +1072,8 @@ int PKCS8_pkey_add1_attr_by_OBJ(PKCS8_PRIV_KEY_INFO *p8, const ASN1_OBJECT *obj,
                                 int type, const unsigned char *bytes, int len);
 
 
+void X509_PUBKEY_set0_public_key(X509_PUBKEY *pub,
+                                 unsigned char *penc, int penclen);
 int X509_PUBKEY_set0_param(X509_PUBKEY *pub, ASN1_OBJECT *aobj,
                            int ptype, void *pval,
                            unsigned char *penc, int penclen);

--- a/test/asn1_time_test.c
+++ b/test/asn1_time_test.c
@@ -431,10 +431,10 @@ static int convert_asn1_to_time_t(int idx)
 {
     time_t testdateutc;
 
-    testdateutc = asn1_string_to_time_t(asn1_to_utc[idx].input);
+    testdateutc = ossl_asn1_string_to_time_t(asn1_to_utc[idx].input);
 
     if (!TEST_time_t_eq(testdateutc, asn1_to_utc[idx].expected)) {
-        TEST_info("asn1_string_to_time_t (%s) failed: expected %li, got %li\n",
+        TEST_info("ossl_asn1_string_to_time_t (%s) failed: expected %li, got %li\n",
                 asn1_to_utc[idx].input, asn1_to_utc[idx].expected, (signed long) testdateutc);
         return 0;
     }

--- a/test/ca_internals_test.c
+++ b/test/ca_internals_test.c
@@ -47,7 +47,7 @@ static int test_do_updatedb(void)
     }
 
     testdate = test_get_argument(2);
-    testdateutc = asn1_string_to_time_t(testdate);
+    testdateutc = ossl_asn1_string_to_time_t(testdate);
     if (TEST_time_t_lt(testdateutc, 0)) {
         return 0;
     }

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5425,6 +5425,7 @@ ASN1_item_d2i_ex                        5552	3_0_0	EXIST::FUNCTION:
 ASN1_TIME_print_ex                      5553	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_get0_provider                  5554	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_CTX_get0_provider              5555	3_0_0	EXIST::FUNCTION:
+X509_PUBKEY_set0_public_key             ?	3_1_0	EXIST::FUNCTION:
 OSSL_STACK_OF_X509_free                 ?	3_1_0	EXIST::FUNCTION:
 EVP_MD_CTX_dup                          ?	3_1_0	EXIST::FUNCTION:
 EVP_CIPHER_CTX_dup                      ?	3_1_0	EXIST::FUNCTION:


### PR DESCRIPTION
This is needed to support central (server-side) key generation in CMP.

There the clients expresses its desire to obtain a public key of a given type by providing a "public key" structure that just has the wanted parameters but no actual (encoded) public key data,
as specified in https://datatracker.ietf.org/doc/html/rfc4210#appendix-D.4:
```
   crm[1].certReq       present
      certTemplate
      -- MUST NOT include actual public key bits, otherwise
      -- unconstrained (e.g., the names need not be the same as in
      -- crm[0]).  Note that subjectPublicKeyInfo MAY be present
      -- and contain an AlgorithmIdentifier followed by a
      -- zero-length BIT STRING for the subjectPublicKey if it is
      -- desired to inform the CA/RA of algorithm and parameter
      -- preferences regarding the to-be-generated key pair.
```

This is implemented by extraction of code from `X509_PUBKEY_set0_param()`.
On this occasion, partly refactor `ASN1_STRING` handling in libcrypto
and fix coding style nits reported by `check-format.pl` in `v3_addr.c`.