### PR TITLE
Fix memory leak in cmp_calc_protection()

### DIFF
--- a/crypto/cmp/cmp_protect.c
+++ b/crypto/cmp/cmp_protect.c
@@ -91,7 +91,7 @@ ASN1_BIT_STRING *ossl_cmp_calc_protection(const OSSL_CMP_CTX *ctx,
             goto end;
 
         if ((prot = ASN1_BIT_STRING_new()) == NULL)
-            return NULL;
+            goto end;
         /* OpenSSL defaults all bit strings to be encoded as ASN.1 NamedBitList */
         prot->flags &= ~(ASN1_STRING_FLAG_BITS_LEFT | 0x07);
         prot->flags |= ASN1_STRING_FLAG_BITS_LEFT;


### PR DESCRIPTION
Triggered by a  memory allocation failure.
Detected by PR #18355

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
