### PR TITLE
HTTP(S) client bugfixes

### DIFF
--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -2450,7 +2450,9 @@ BIO *app_http_tls_cb(BIO *bio, void *arg, int connect, int detail)
     APP_HTTP_TLS_INFO *info = (APP_HTTP_TLS_INFO *)arg;
     SSL_CTX *ssl_ctx = info->ssl_ctx;
 
-    if (connect && detail) { /* connecting with TLS */
+    if (ssl_ctx == NULL) /* not using TLS */
+        return bio;
+    if (connect) {
         SSL *ssl;
         BIO *sbio = NULL;
 
@@ -2528,6 +2530,11 @@ ASN1_VALUE *app_http_get_asn1(const char *url, const char *proxy,
     if (use_ssl && ssl_ctx == NULL) {
         ERR_raise_data(ERR_LIB_HTTP, ERR_R_PASSED_NULL_PARAMETER,
                        "missing SSL_CTX");
+        goto end;
+    }
+    if (!use_ssl && ssl_ctx != NULL) {
+        ERR_raise_data(ERR_LIB_HTTP, ERR_R_PASSED_INVALID_ARGUMENT,
+                       "SSL_CTX given but use_ssl == 0");
         goto end;
     }
 

--- a/crypto/http/http_client.c
+++ b/crypto/http/http_client.c
@@ -975,7 +975,7 @@ OSSL_HTTP_REQ_CTX *OSSL_HTTP_open(const char *server, const char *port,
     if (bio_update_fn != NULL) {
         BIO *orig_bio = cbio;
 
-        cbio = (*bio_update_fn)(cbio, arg, 1 /* connect */, use_ssl);
+        cbio = (*bio_update_fn)(cbio, arg, 1 /* connect */, use_ssl != 0);
         if (cbio == NULL) {
             if (bio == NULL) /* cbio was not provided by caller */
                 BIO_free_all(orig_bio);

--- a/crypto/http/http_client.c
+++ b/crypto/http/http_client.c
@@ -574,7 +574,7 @@ int OSSL_HTTP_REQ_CTX_nbio(OSSL_HTTP_REQ_CTX *rctx)
         if (rctx->req != NULL && !BIO_eof(rctx->req)) {
             n = BIO_read(rctx->req, rctx->buf, rctx->buf_size);
             if (n <= 0) {
-                if (BIO_should_retry(rctx->rbio))
+                if (BIO_should_retry(rctx->req))
                     return -1;
                 ERR_raise(ERR_LIB_HTTP, HTTP_R_FAILED_READING_DATA);
                 return 0;

--- a/crypto/http/http_client.c
+++ b/crypto/http/http_client.c
@@ -53,7 +53,7 @@ struct ossl_http_req_ctx_st {
     char *proxy;                /* Optional proxy name or URI */
     char *server;               /* Optional server host name */
     char *port;                 /* Optional server port */
-    BIO *mem;                   /* Memory BIO holding request/response header */
+    BIO *mem;                   /* Mem BIO holding request header or response */
     BIO *req;                   /* BIO holding the request provided by caller */
     int method_POST;            /* HTTP method is POST (else GET) */
     char *expected_ct;          /* Optional expected Content-Type */

--- a/doc/man3/OSSL_HTTP_REQ_CTX.pod
+++ b/doc/man3/OSSL_HTTP_REQ_CTX.pod
@@ -66,8 +66,8 @@ I<wbio>), and the maximum expected response header line length I<buf_size>.
 A value <= 0 indicates that
 the B<OSSL_HTTP_DEFAULT_MAX_LINE_LEN> of 4KiB should be used.
 I<buf_size> is also used as the number of content bytes that are read at a time.
-The allocated context structure is also populated with an internal allocated
-memory B<BIO>, which collects the HTTP request and additional headers as text.
+The allocated context structure includes an internal memory B<BIO>,
+which collects the HTTP request header lines.
 
 OSSL_HTTP_REQ_CTX_free() frees up the HTTP request context I<rctx>.
 The I<rbio> is not free'd, I<wbio> will be free'd if I<free_wbio> is set.
@@ -80,7 +80,7 @@ that the request should go through, otherwise they should be left NULL.
 I<path> is the HTTP request path; if left NULL, C</> is used.
 
 OSSL_HTTP_REQ_CTX_add1_header() adds header I<name> with value I<value> to the
-context I<rctx>. It can be called more than once to add multiple headers.
+context I<rctx>. It can be called more than once to add multiple header lines.
 For example, to add a C<Host> header for C<example.com> you would call:
 
  OSSL_HTTP_REQ_CTX_add1_header(ctx, "Host", "example.com");
@@ -96,7 +96,7 @@ If the I<asn1> parameter is nonzero a structure in ASN.1 encoding will be
 expected as the response content and input streaming is disabled.  This means
 that an ASN.1 sequence header is required, its length field is checked, and
 OSSL_HTTP_REQ_CTX_get0_mem_bio() should be used to get the buffered response.
-Otherwise any input format is allowed without length checks, which is the default.
+Otherwise (by default) any input format is allowed without length checks.
 In this case the BIO given as I<rbio> argument to OSSL_HTTP_REQ_CTX_new() should
 be used directly to read the response contents, which may support streaming.
 If the I<timeout> parameter is > 0 this indicates the maximum number of seconds
@@ -124,7 +124,7 @@ The HTTP header C<Content-Length> is filled out with the length of the request.
 I<content_type> must be NULL if I<req> is NULL.
 If I<content_type> isn't NULL,
 the HTTP header C<Content-Type> is also added with the given string value.
-All of this ends up in the internal memory B<BIO>.
+The header lines are added to the internal memory B<BIO> for the request header.
 
 OSSL_HTTP_REQ_CTX_nbio() attempts to send the request prepared in I<rctx>
 and to gather the response via HTTP, using the I<wbio> and I<rbio>
@@ -143,17 +143,17 @@ On success it returns a pointer to the BIO that can be used to read the result.
 If an ASN.1-encoded response was expected, this is the BIO
 returned by OSSL_HTTP_REQ_CTX_get0_mem_bio() when called after the exchange.
 This memory BIO does not support streaming.
-Otherwise it may be the I<rbio> given when calling OSSL_HTTP_REQ_CTX_new(),
-and this BIO has been read past the end of the response headers,
-such that the actual response body can be read via this BIO,
+Otherwise the returned BIO is the I<rbio> given to OSSL_HTTP_REQ_CTX_new(),
 which may support streaming.
-The returned BIO pointer must not be freed by the caller.
+When this BIO is returned, it has been read past the end of the response header,
+such that the actual response body can be read from it.
+The returned BIO pointer MUST NOT be freed by the caller.
 
 OSSL_HTTP_REQ_CTX_get0_mem_bio() returns the internal memory B<BIO>.
-Before sending the request, this could used to modify the HTTP request text.
+Before the HTTP request is sent, this could be used to adapt its header lines.
 I<Use with caution!>
 After receiving a response via HTTP, the BIO represents the current state of
-reading the response headers. If the response was expected to be ASN.1 encoded,
+reading the response header. If the response was expected to be ASN.1 encoded,
 its contents can be read via this BIO, which does not support streaming.
 The returned BIO pointer must not be freed by the caller.
 
@@ -200,7 +200,7 @@ Calling OSSL_HTTP_REQ_CTX_set_request_line().
 
 =item 2.
 
-Adding extra headers with OSSL_HTTP_REQ_CTX_add1_header().
+Adding extra header lines with OSSL_HTTP_REQ_CTX_add1_header().
 This is optional and may be done multiple times with different names.
 
 =item 3.
@@ -236,7 +236,7 @@ OSSL_HTTP_REQ_CTX_nbio() and OSSL_HTTP_REQ_CTX_nbio_d2i()
 return 1 for success, 0 on error or redirection, -1 if retry is needed.
 
 OSSL_HTTP_REQ_CTX_exchange() and OSSL_HTTP_REQ_CTX_get0_mem_bio()
-return a pointer to a B<BIO> on success and NULL on failure.
+return a pointer to a B<BIO> on success as described above or NULL on failure.
 The returned BIO must not be freed by the caller.
 
 OSSL_HTTP_REQ_CTX_get_resp_len() returns the size of the response contents

--- a/doc/man3/OSSL_HTTP_transfer.pod
+++ b/doc/man3/OSSL_HTTP_transfer.pod
@@ -102,8 +102,8 @@ The callback function may modify the BIO provided in the I<bio> argument,
 whereby it may make use of a custom defined argument I<arg>,
 which may for instance point to an B<SSL_CTX> structure.
 During connection establishment, just after calling BIO_do_connect_retry(), the
-callback function is invoked with the I<connect> argument being 1 and the I<detail>
-argument being 1 if HTTPS is requested, i.e., SSL/TLS should be enabled, else 0.
+callback function is invoked with the I<connect> argument being 1 and
+I<detail> being 1 if I<use_ssl> is nonzero (i.e., HTTPS is requested), else 0.
 On disconnect I<connect> is 0 and I<detail> is 1 if no error occurred, else 0.
 For instance, on connect the callback may push an SSL BIO to implement HTTPS;
 after disconnect it may do some diagnostic output and pop and free the SSL BIO.

--- a/doc/man3/OSSL_HTTP_transfer.pod
+++ b/doc/man3/OSSL_HTTP_transfer.pod
@@ -202,7 +202,7 @@ an ASN.1-encoded response is expected, which should include a total length,
 the length indications received are checked for consistency
 and for not exceeding any given maximum response length.
 If an ASN.1-encoded response is expected, the function returns on success
-the contents as a memory BIO, which does not support streaming.
+the contents buffered in a memory BIO, which does not support streaming.
 Otherwise it returns directly the read BIO that holds the response contents,
 which allows a response of indefinite length and may support streaming.
 The caller is responsible for freeing the BIO pointer obtained.
@@ -257,8 +257,8 @@ OSSL_HTTP_proxy_connect() and OSSL_HTTP_set1_request()
 return 1 on success, 0 on error.
 
 On success, OSSL_HTTP_exchange(), OSSL_HTTP_get(), and OSSL_HTTP_transfer()
-return a memory BIO containing the data received if an ASN.1-encoded response
-is expected, else a BIO that may support streaming.
+return a memory BIO that buffers all the data received if an ASN.1-encoded
+response is expected, otherwise a BIO that may support streaming.
 The BIO must be freed by the caller.
 On failure, they return NULL.
 Failure conditions include connection/transfer timeout, parse errors, etc.


### PR DESCRIPTION
These issues recently came up when preparing my answer at https://www.mail-archive.com/openssl-users@openssl.org/msg90965.html, where I provided a simple example HTTPS client for retrieving HTML pages.

* `app_http_tls_cb():` fix crash on inconsistency w.r.t. use of TLS.
   This happens if `use_ssl` is not set but an `SSL_CTX` is provided.
* `OSSL_HTTP_open():` improve use of `use_ssl` and its documentation
* `OSSL_HTTP_REQ_CTX_nbio()`: fix copy&paste glitch calling `BIO_should_retry(rctx->rbio)`
* `http_client.c:` fix comment and documentation of the memory BIOs used


