### PR TITLE
HTTP(S) client: add support for partial Content-Type string matching, cleanup apps.c

### DIFF
--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -2426,7 +2426,7 @@ static const char *tls_error_hint(void)
     if (ERR_GET_LIB(err) != ERR_LIB_SSL)
         err = ERR_peek_last_error();
     if (ERR_GET_LIB(err) != ERR_LIB_SSL)
-        return NULL;
+        return NULL; /* likely no TLS error */
 
     switch (ERR_GET_REASON(err)) {
     case SSL_R_WRONG_VERSION_NUMBER:
@@ -2439,9 +2439,27 @@ static const char *tls_error_hint(void)
         return "Server did not accept our TLS certificate, likely due to mismatch with server's trust anchor or missing revocation status";
     case SSL_AD_REASON_OFFSET + SSL3_AD_HANDSHAKE_FAILURE:
         return "TLS handshake failure. Possibly the server requires our TLS certificate but did not receive it";
-    default: /* no error or no hint available for error */
-        return NULL;
+    default:
+        return NULL; /* no hint available for TLS error */
     }
+}
+
+static BIO *http_tls_shutdown(BIO *bio)
+{
+    if (bio != NULL) {
+        BIO *cbio;
+        const char *hint = tls_error_hint();
+
+        if (hint != NULL)
+            BIO_printf(bio_err, "%s\n", hint);
+        (void)ERR_set_mark();
+        BIO_ssl_shutdown(bio);
+        cbio = BIO_pop(bio); /* connect+HTTP BIO */
+        BIO_free(bio); /* SSL BIO */
+        (void)ERR_pop_to_mark(); /* hide SSL_R_READ_BIO_NOT_SET etc. */
+        bio = cbio;
+    }
+    return bio;
 }
 
 /* HTTP callback function that supports TLS connection also via HTTPS proxy */
@@ -2464,7 +2482,7 @@ BIO *app_http_tls_cb(BIO *bio, void *arg, int connect, int detail)
                 || (sbio = BIO_new(BIO_f_ssl())) == NULL) {
             return NULL;
         }
-        if (ssl_ctx == NULL || (ssl = SSL_new(ssl_ctx)) == NULL) {
+        if ((ssl = SSL_new(ssl_ctx)) == NULL) {
             BIO_free(sbio);
             return NULL;
         }
@@ -2476,24 +2494,8 @@ BIO *app_http_tls_cb(BIO *bio, void *arg, int connect, int detail)
         BIO_set_ssl(sbio, ssl, BIO_CLOSE);
 
         bio = BIO_push(sbio, bio);
-    }
-    if (!connect) {
-        const char *hint;
-        BIO *cbio;
-
-        if (!detail) { /* disconnecting after error */
-            hint = tls_error_hint();
-            if (hint != NULL)
-                ERR_add_error_data(2, " : ", hint);
-        }
-        if (ssl_ctx != NULL) {
-            (void)ERR_set_mark();
-            BIO_ssl_shutdown(bio);
-            cbio = BIO_pop(bio); /* connect+HTTP BIO */
-            BIO_free(bio); /* SSL BIO */
-            (void)ERR_pop_to_mark(); /* hide SSL_R_READ_BIO_NOT_SET etc. */
-            bio = cbio;
-        }
+    } else { /* disconnect from TLS */
+        bio = http_tls_shutdown(bio);
     }
     return bio;
 }

--- a/crypto/http/http_client.c
+++ b/crypto/http/http_client.c
@@ -693,8 +693,7 @@ int OSSL_HTTP_REQ_CTX_nbio(OSSL_HTTP_REQ_CTX *rctx)
                         /* ignore past ';' unless expected_ct contains ';' */
                         && (strchr(rctx->expected_ct, ';') != NULL
                             || (semicolon = strchr(value, ';')) == NULL
-                            || (size_t)(semicolon - value) !=
-                            strlen(rctx->expected_ct)
+                            || (size_t)(semicolon - value) != strlen(rctx->expected_ct)
                             || OPENSSL_strncasecmp(rctx->expected_ct, value,
                                                    semicolon - value) != 0)) {
                         ERR_raise_data(ERR_LIB_HTTP,

--- a/crypto/http/http_client.c
+++ b/crypto/http/http_client.c
@@ -687,7 +687,16 @@ int OSSL_HTTP_REQ_CTX_nbio(OSSL_HTTP_REQ_CTX *rctx)
             if (OPENSSL_strcasecmp(key, "Content-Type") == 0) {
                 if (rctx->state == OHS_HEADERS
                     && rctx->expected_ct != NULL) {
-                    if (OPENSSL_strcasecmp(rctx->expected_ct, value) != 0) {
+                    const char *semicolon;
+
+                    if (OPENSSL_strcasecmp(rctx->expected_ct, value) != 0
+                        /* ignore past ';' unless expected_ct contains ';' */
+                        && (strchr(rctx->expected_ct, ';') != NULL
+                            || (semicolon = strchr(value, ';')) == NULL
+                            || (size_t)(semicolon - value) !=
+                            strlen(rctx->expected_ct)
+                            || OPENSSL_strncasecmp(rctx->expected_ct, value,
+                                                   semicolon - value) != 0)) {
                         ERR_raise_data(ERR_LIB_HTTP,
                                        HTTP_R_UNEXPECTED_CONTENT_TYPE,
                                        "expected=%s, actual=%s",

--- a/doc/man3/OSSL_HTTP_REQ_CTX.pod
+++ b/doc/man3/OSSL_HTTP_REQ_CTX.pod
@@ -89,9 +89,17 @@ OSSL_HTTP_REQ_CTX_set_expected() optionally sets in I<rctx> some expectations
 of the HTTP client on the response.
 Due to the structure of an HTTP request, if the I<keep_alive> argument is
 nonzero the function must be used before calling OSSL_HTTP_REQ_CTX_set1_req().
-If the I<content_type> parameter
-is not NULL then the client will check that the given content type string
+
+If the I<content_type> argument is not NULL,
+the client will check that the specified content-type string
 is included in the HTTP header of the response and return an error if not.
+In the content-type header line the specified string shouldb be present either
+as a whole, or in case the specified string does not include a C<;> character,
+it is sufficient that the specified string appears as a prefix
+in the header line, followed by a C<;> character and any further text.
+For instance, if the I<content_type> argument specifies C<text/html>,
+this is matched by C<text/html>, C<text/html; charset=UTF-8>, etc.
+
 If the I<asn1> parameter is nonzero a structure in ASN.1 encoding will be
 expected as the response content and input streaming is disabled.  This means
 that an ASN.1 sequence header is required, its length field is checked, and

--- a/doc/man3/OSSL_HTTP_REQ_CTX.pod
+++ b/doc/man3/OSSL_HTTP_REQ_CTX.pod
@@ -93,7 +93,7 @@ nonzero the function must be used before calling OSSL_HTTP_REQ_CTX_set1_req().
 If the I<content_type> argument is not NULL,
 the client will check that the specified content-type string
 is included in the HTTP header of the response and return an error if not.
-In the content-type header line the specified string shouldb be present either
+In the content-type header line the specified string should be present either
 as a whole, or in case the specified string does not include a C<;> character,
 it is sufficient that the specified string appears as a prefix
 in the header line, followed by a C<;> character and any further text.

--- a/doc/man3/OSSL_HTTP_transfer.pod
+++ b/doc/man3/OSSL_HTTP_transfer.pod
@@ -169,9 +169,17 @@ else HTTP POST with the contents of I<req> and optional I<content_type>, where
 the length of the data in I<req> does not need to be determined in advance: the
 BIO will be read on-the-fly while sending the request, which supports streaming.
 The optional list I<headers> may contain additional custom HTTP header lines.
-If the parameter I<expected_content_type>
-is not NULL then the client will check that the given content type string
+
+If the I<expected_content_type> argument is not NULL,
+the client will check that the specified content-type string
 is included in the HTTP header of the response and return an error if not.
+In the content-type header line the specified string shouldb be present either
+as a whole, or in case the specified string does not include a C<;> character,
+it is sufficient that the specified string appears as a prefix
+in the header line, followed by a C<;> character and any further text.
+For instance, if I<expected_content_type> specifies C<text/html>,
+this is matched by C<text/html>, C<text/html; charset=UTF-8>, etc.
+
 If the I<expect_asn1> parameter is nonzero,
 a structure in ASN.1 encoding will be expected as response content.
 The I<max_resp_len> parameter specifies the maximum allowed

--- a/doc/man3/OSSL_HTTP_transfer.pod
+++ b/doc/man3/OSSL_HTTP_transfer.pod
@@ -173,7 +173,7 @@ The optional list I<headers> may contain additional custom HTTP header lines.
 If the I<expected_content_type> argument is not NULL,
 the client will check that the specified content-type string
 is included in the HTTP header of the response and return an error if not.
-In the content-type header line the specified string shouldb be present either
+In the content-type header line the specified string should be present either
 as a whole, or in case the specified string does not include a C<;> character,
 it is sufficient that the specified string appears as a prefix
 in the header line, followed by a C<;> character and any further text.


### PR DESCRIPTION
Like with #18674, these improvements recently came up when preparing my answer at https://www.mail-archive.com/openssl-users@openssl.org/msg90965.html, where I provided a simple example HTTPS client for retrieving HTML pages.

* `OSSL_HTTP_REQ_CTX_nbio:` add support for partial `Content-Type` string matching
* code cleanup in `apps.c:` `app_http_tls_cb()` and `tls_error_hint()`
