### PR TITLE
Documentation update for EVP_set_default_properties

### DIFF
--- a/doc/man3/EVP_set_default_properties.pod
+++ b/doc/man3/EVP_set_default_properties.pod
@@ -36,6 +36,12 @@ existing query strings that have been set via EVP_set_default_properties().
 EVP_default_properties_is_fips_enabled() indicates if 'fips=yes' is a default
 property for the given I<libctx>.
 
+=head1 NOTES
+
+EVP_set_default_properties() and  EVP_default_properties_enable_fips() are not
+thread safe. They are intended to be called only during the initialisation
+phase of a I<libctx>.
+
 =head1 RETURN VALUES
 
 EVP_set_default_properties() and  EVP_default_properties_enable_fips() return 1


### PR DESCRIPTION
State that it is not thread safe.
Fixes #18613

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
