### PR TITLE
s_client: Support interactive reconnect command

### DIFF
--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -3081,6 +3081,16 @@ int s_client_main(int argc, char **argv)
                 goto shut;
             }
 
+            if ((!c_ign_eof) && ((i <= 0) || (cbuf[0] == 'C' && cmdletters))) {
+                cbuf_len = 0;
+                BIO_printf(bio_c_out,
+                           "RECONNECTING\n");
+                do_ssl_shutdown(con);
+                SSL_set_connect_state(con);
+                BIO_closesocket(SSL_get_fd(con));
+                goto re_start;
+            }
+
             if ((!c_ign_eof) && (cbuf[0] == 'R' && cmdletters)) {
                 BIO_printf(bio_err, "RENEGOTIATING\n");
                 SSL_renegotiate(con);


### PR DESCRIPTION
This change adds the 'C' command character to allow a user to drop the
current session and reconnect to the server. It has the same behavior as
the `-reconnect` option except this allows reconnect to be triggered at
an arbitrary point in the session.

The primary use case for this change is to provide a way for the user to
probe a server for TLS1.3 session resumption support. This is not
currently reliably supported by the `-reconnect` option.

related to #10714 