### PR TITLE
Fixes OSCP->OCSP typo in ocsp command line

### DIFF
--- a/apps/ocsp.c
+++ b/apps/ocsp.c
@@ -135,7 +135,7 @@ const OPTIONS ocsp_options[] = {
     {"no_certs", OPT_NO_CERTS, '-',
      "Don't include any certificates in signed request"},
     {"badsig", OPT_BADSIG, '-',
-        "Corrupt last byte of loaded OSCP response signature (for test)"},
+        "Corrupt last byte of loaded OCSP response signature (for test)"},
     {"CA", OPT_CA, '<', "CA certificate"},
     {"nmin", OPT_NMIN, 'p', "Number of minutes before next update"},
     {"nrequest", OPT_REQUEST, 'p',


### PR DESCRIPTION
The existing help text says:

>  -badsig                 Corrupt last byte of loaded OSCP response signature (for test)

but this should be OCSP. This is the only occurrence within the project
of this typo.

---

My understanding (and hope) is that this should qualify as very trivial and shouldn't require a CLA.


##### Checklist


