### PR TITLE
fuzz/x509.c: Add check for BIO_new

### DIFF
--- a/fuzz/x509.c
+++ b/fuzz/x509.c
@@ -32,7 +32,8 @@ int FuzzerTestOneInput(const uint8_t *buf, size_t len)
     if (x509 != NULL) {
         BIO *bio = BIO_new(BIO_s_null());
         /* This will load and print the public key as well as extensions */
-        X509_print(bio, x509);
+        if (bio != NULL)
+            X509_print(bio, x509);
         BIO_free(bio);
 
         X509_issuer_and_serial_hash(x509);


### PR DESCRIPTION
As the potential failure of the BIO_new,
it should be better to check the return value.

Signed-off-by: Jiasheng Jiang <jiasheng@iscas.ac.cn>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
