### PR TITLE
ssl/tls_srp.c: Add check for BN_dup

### DIFF
--- a/ssl/tls_srp.c
+++ b/ssl/tls_srp.c
@@ -233,14 +233,12 @@ int SSL_set_srp_server_param_pw(SSL *s, const char *user, const char *pass,
         return -1;
     s->srp_ctx.N = BN_dup(GN->N);
     s->srp_ctx.g = BN_dup(GN->g);
-    if (s->srp_ctx.N == NULL || s->srp_ctx.g == NULL)
-        return -1;
     BN_clear_free(s->srp_ctx.v);
     s->srp_ctx.v = NULL;
     BN_clear_free(s->srp_ctx.s);
     s->srp_ctx.s = NULL;
     if (!SRP_create_verifier_BN_ex(user, pass, &s->srp_ctx.s, &s->srp_ctx.v,
-                                   GN->N, GN->g, s->ctx->libctx,
+                                   s->srp_ctx.N, s->srp_ctx.g, s->ctx->libctx,
                                    s->ctx->propq))
         return -1;
 

--- a/ssl/tls_srp.c
+++ b/ssl/tls_srp.c
@@ -233,6 +233,8 @@ int SSL_set_srp_server_param_pw(SSL *s, const char *user, const char *pass,
         return -1;
     s->srp_ctx.N = BN_dup(GN->N);
     s->srp_ctx.g = BN_dup(GN->g);
+    if (s->srp_ctx.N == NULL || s->srp_ctx.g == NULL)
+        return -1;
     BN_clear_free(s->srp_ctx.v);
     s->srp_ctx.v = NULL;
     BN_clear_free(s->srp_ctx.s);


### PR DESCRIPTION
As the potential failure of the BN_dup,
it should be better to check the return value
in order to guarantee the success.

Signed-off-by: Jiasheng Jiang <jiasheng@iscas.ac.cn>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
