### PR TITLE
`apps/cmp.c`: fix cleanup of `CMP_CTX` vs. info in its `http_cb_arg` field

### DIFF
--- a/apps/cmp.c
+++ b/apps/cmp.c
@@ -1942,7 +1942,6 @@ static int setup_client_ctx(OSSL_CMP_CTX *ctx, ENGINE *engine)
         if ((info = OPENSSL_zalloc(sizeof(*info))) == NULL)
             goto err;
         (void)OSSL_CMP_CTX_set_http_cb_arg(ctx, info);
-        /* info will be freed along with CMP ctx */
         info->server = opt_server;
         info->port = server_port;
         /* workaround for callback design flaw, see #17088: */
@@ -3035,12 +3034,19 @@ int cmp_main(int argc, char **argv)
     if (ret != 1)
         OSSL_CMP_CTX_print_errors(cmp_ctx);
 
-    ossl_cmp_mock_srv_free(OSSL_CMP_CTX_get_transfer_cb_arg(cmp_ctx));
+    if (cmp_ctx != NULL) {
 #ifndef OPENSSL_NO_SOCK
-    APP_HTTP_TLS_INFO_free(OSSL_CMP_CTX_get_http_cb_arg(cmp_ctx));
+        APP_HTTP_TLS_INFO *info = OSSL_CMP_CTX_get_http_cb_arg(cmp_ctx);
+
 #endif
-    X509_STORE_free(OSSL_CMP_CTX_get_certConf_cb_arg(cmp_ctx));
-    OSSL_CMP_CTX_free(cmp_ctx);
+        ossl_cmp_mock_srv_free(OSSL_CMP_CTX_get_transfer_cb_arg(cmp_ctx));
+        X509_STORE_free(OSSL_CMP_CTX_get_certConf_cb_arg(cmp_ctx));
+        /* cannot free info already here, as it may be used indirectly by: */
+        OSSL_CMP_CTX_free(cmp_ctx);
+#ifndef OPENSSL_NO_SOCK
+        APP_HTTP_TLS_INFO_free(info);
+#endif
+    }
     X509_VERIFY_PARAM_free(vpm);
     release_engine(engine);
 

--- a/crypto/cmp/cmp_http.c
+++ b/crypto/cmp/cmp_http.c
@@ -29,7 +29,10 @@
 static int keep_alive(int keep_alive, int body_type)
 {
     if (keep_alive != 0
-        /* Ask for persistent connection only if may need more round trips */
+        /*
+         * Ask for persistent connection only if may need more round trips.
+         * Do so even with disableConfirm because polling might be needed.
+         */
             && body_type != OSSL_CMP_PKIBODY_IR
             && body_type != OSSL_CMP_PKIBODY_CR
             && body_type != OSSL_CMP_PKIBODY_P10CR


### PR DESCRIPTION
Prevent crashes on error by making sure the info of type ` APP_HTTP_TLS_INFO` is freed not before calling `OSSL_CMP_CTX_free`(),
which may call `OSSL_HTTP_close()` and thus indirectly reference the info.
Moreover, should not attempt to reference the `cmp_ctx` variable on cleanup when NULL.

On this occasion, in `cmp_http.c` slightly extend a comment in `keep_alive()`.


