### PR TITLE
apps/ciphers.c: Add check for app_get0_libctx

### DIFF
--- a/apps/ciphers.c
+++ b/apps/ciphers.c
@@ -104,6 +104,7 @@ int ciphers_main(int argc, char **argv)
     char buf[512];
     OPTION_CHOICE o;
     int min_version = 0, max_version = 0;
+    OSSL_LIB_CTX *libctx;
 
     prog = opt_init(argc, argv, ciphers_options);
     while ((o = opt_next()) != OPT_EOF) {
@@ -186,7 +187,7 @@ int ciphers_main(int argc, char **argv)
         goto end;
     }
 
-    OSSL_LIB_CTX *libctx = app_get0_libctx();
+    libctx = app_get0_libctx();
     if (libctx == NULL)
         goto err;
     ctx = SSL_CTX_new_ex(libctx, app_get0_propq(), meth);

--- a/apps/ciphers.c
+++ b/apps/ciphers.c
@@ -186,7 +186,10 @@ int ciphers_main(int argc, char **argv)
         goto end;
     }
 
-    ctx = SSL_CTX_new_ex(app_get0_libctx(), app_get0_propq(), meth);
+    OSSL_LIB_CTX *libctx = app_get0_libctx();
+    if (libctx == NULL)
+        goto err;
+    ctx = SSL_CTX_new_ex(libctx, app_get0_propq(), meth);
     if (ctx == NULL)
         goto err;
     if (SSL_CTX_set_min_proto_version(ctx, min_version) == 0)


### PR DESCRIPTION
As app_get0_libctx may return NULL, it should be better
to check the return value.

Signed-off-by: Jiasheng Jiang <jiasheng@iscas.ac.cn>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
