### PR TITLE
1.1.1: Add missing header for memcmp

### DIFF
--- a/test/v3ext.c
+++ b/test/v3ext.c
@@ -8,6 +8,7 @@
  */
 
 #include <stdio.h>
+#include <string.h>
 #include <openssl/x509.h>
 #include <openssl/x509v3.h>
 #include <openssl/pem.h>


### PR DESCRIPTION
This fixes a regression in 1.1.1q:

```
test/v3ext.c:201:24: error: implicitly declaring library function 'memcmp' with type 'int (const void *, const void *, unsigned long)' [-Werror,-Wimplicit-function-declaration]
        if (!TEST_true(memcmp(ip1->data, ip2->data, ip1->length) <= 0))
```
