### PR TITLE
Add missing header for memcmp

### DIFF
--- a/test/v3ext.c
+++ b/test/v3ext.c
@@ -8,6 +8,7 @@
  */
 
 #include <stdio.h>
+#include <string.h>
 #include <openssl/x509.h>
 #include <openssl/x509v3.h>
 #include <openssl/pem.h>


### PR DESCRIPTION
PR #18718 for master (to be cherry-picked to `openssl-3.0` and `OpenSSL_1_1_1-stable`.