### PR TITLE
Windows: use the basename of the product (.dll) for definition files

### DIFF
--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -742,7 +742,7 @@ EOF
                               rel2abs($config{builddir}));
           my $ord_ver = $args{intent} eq 'lib' ? ' --version $(VERSION_NUMBER)' : '';
           my $ord_name =
-              $args{generator}->[1] || platform->dsoname($args{product});
+              $args{generator}->[1] || basename(platform->dsoname($args{product}));
           return <<"EOF";
 $target: $gen0 $deps $mkdef
 	"\$(PERL)" "$mkdef"$ord_ver --type $args{intent} --ordinals $gen0 --name $ord_name --OS windows > $target


### PR DESCRIPTION
This resolves the faulty LIBRARY value that contained the directory
of the product (.dll) in the build tree.  This applies to engines and
other modules alike.

Fixes #18726
