### PR TITLE
Fix SHA, SHAKE, and KECCAK ASM flag passing

### DIFF
--- a/crypto/sha/build.info
+++ b/crypto/sha/build.info
@@ -82,6 +82,14 @@ SOURCE[../../providers/libfips.a]= $COMMON
 # need to be applied to all affected libraries and modules.
 DEFINE[../../libcrypto]=$SHA1DEF $KECCAK1600DEF
 DEFINE[../../providers/libfips.a]=$SHA1DEF $KECCAK1600DEF
+DEFINE[../../providers/libdefault.a]=$SHA1DEF $KECCAK1600DEF
+# We only need to include the SHA1DEF and KECCAK1600DEF stuff in the
+# legacy provider when it's a separate module and it's dynamically
+# linked with libcrypto.  Otherwise, it already gets everything that
+# the static libcrypto.a has, and doesn't need it added again.
+IF[{- !$disabled{module} && !$disabled{shared} -}]
+  DEFINE[../providers/liblegacy.a]=$SHA1DEF $KECCAK1600DEF
+ENDIF
 
 GENERATE[sha1-586.S]=asm/sha1-586.pl
 DEPEND[sha1-586.S]=../perlasm/x86asm.pl


### PR DESCRIPTION
Flags for ASM implementations of SHA, SHAKE, and KECCAK were only passed to
the FIPS provider and not to the default or legacy provider.  This left some
potential for optimization.  Pass the correct flags also to these providers.

Signed-off-by: Juergen Christ <jchrist@linux.ibm.com>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

