### PR TITLE
Prerequisite for tracing chain building: refactor `find_issuer()` etc. in `x509_lu.c` and `x509_vfy.c`

### DIFF
--- a/crypto/x509/x509_vfy.c
+++ b/crypto/x509/x509_vfy.c
@@ -423,16 +423,16 @@ static X509 *get0_best_issuer_sk(X509_STORE_CTX *ctx, int trusted,
  */
 int X509_STORE_CTX_get1_issuer(X509 **issuer, X509_STORE_CTX *ctx, X509 *x)
 {
-    const X509_NAME *xn = X509_get_issuer_name(x);
-    STACK_OF(X509) *certs = ossl_x509_store_ctx_get_certs(ctx, xn, 0);
+    STACK_OF(X509) *certs = X509_STORE_CTX_get1_certs(ctx, X509_get_issuer_name(x));
+    int ret = 0;
 
     if (certs == NULL)
         return -1;
     *issuer = get0_best_issuer_sk(ctx, 1 /* trusted */, 0, certs, x);
-    sk_X509_free(certs);
-    if (*issuer == NULL)
-        return 0;
-    return X509_up_ref(*issuer) ? 1 : -1;
+    if (*issuer != NULL)
+        ret = X509_up_ref(*issuer) ? 1 : -1;
+    OSSL_STACK_OF_X509_free(certs);
+    return ret;
 }
 
 /* Check that the given certificate |x| is issued by the certificate |issuer| */

--- a/include/crypto/x509.h
+++ b/include/crypto/x509.h
@@ -312,6 +312,8 @@ int ossl_a2i_ipadd(unsigned char *ipout, const char *ipasc);
 int ossl_x509_set1_time(int *modified, ASN1_TIME **ptm, const ASN1_TIME *tm);
 int ossl_x509_print_ex_brief(BIO *bio, X509 *cert, unsigned long neg_cflags);
 int ossl_x509v3_cache_extensions(X509 *x);
+STACK_OF(X509) *ossl_x509_store_ctx_get_certs(X509_STORE_CTX *ctx,
+                                              const X509_NAME *nm, int up_refs);
 int ossl_x509_init_sig_info(X509 *x);
 
 int ossl_x509_set0_libctx(X509 *x, OSSL_LIB_CTX *libctx, const char *propq);

--- a/include/crypto/x509.h
+++ b/include/crypto/x509.h
@@ -312,8 +312,6 @@ int ossl_a2i_ipadd(unsigned char *ipout, const char *ipasc);
 int ossl_x509_set1_time(int *modified, ASN1_TIME **ptm, const ASN1_TIME *tm);
 int ossl_x509_print_ex_brief(BIO *bio, X509 *cert, unsigned long neg_cflags);
 int ossl_x509v3_cache_extensions(X509 *x);
-STACK_OF(X509) *ossl_x509_store_ctx_get_certs(X509_STORE_CTX *ctx,
-                                              const X509_NAME *nm, int up_refs);
 int ossl_x509_init_sig_info(X509 *x);
 
 int ossl_x509_set0_libctx(X509 *x, OSSL_LIB_CTX *libctx, const char *propq);


### PR DESCRIPTION
This is a prerequisite for #18761. When preparing the new trace feature for cert chain building, I found again that there is an ugly overlap between
* `STACK_OF(X509) *X509_STORE_CTX_get1_certs(X509_STORE_CTX *ctx, const X509_NAME *nm)`
* `X509_STORE_CTX_get1_issuer()` in `x509_lu.c` used to search for suitable trusted certs
* the local function `find_issuer()` in `x509_vfy.c` used to search for both untrusted and trusted certs.

Among others, this means that any changes (such as the addition of trace output) would need to be done consistently in their function bodies.

Moreover, most of `X509_STORE_CTX_get1_issuer()` does not really belong to `x509_lu.c` but to `x509_vfy.c`,
but not all of its implementation can be moved because it includes collecting certs via the internal X509/CRL object lookup mechanism.
When adding the tracing for chain building, I also noticed that the function checks the first cert found twice, which of course is needless and should be avoided.

This PR fixes all this, while not changing the documented/commented semantics of these functions,
by letting `X509_STORE_CTX_get1_issuer()` make use of `X509_STORE_CTX_get1_certs()`
~by factoring out from `X509_STORE_CTX_get1_certs()` and `X509_STORE_CTX_get1_issuer()` a new function~
<!-- 
```
STACK_OF(X509) *ossl_x509_store_ctx_get_certs(X509_STORE_CTX *ctx, 
                                              const X509_NAME *nm, int up_refs)
```
-->
and moving the rest to `x509_vfy.c`.

These functions are now implemented using a more general internal function
```
static X509 *get0_best_issuer_sk(X509_STORE_CTX *ctx, int trusted,
                                 int no_dup, STACK_OF(X509) *sk, X509 *x)
```
which will be extended by #18761 to provide tracing.

This PR also renames the local function `get_issuer_sk()` to `get1_best_issuer_other_sk()` in `x509_vfy.c`.