### PR TITLE
trace API: fix missing/inconsistent doc of category items

### DIFF
--- a/doc/man1/openssl.pod
+++ b/doc/man1/openssl.pod
@@ -792,7 +792,7 @@ Traces decrementing certain ASN.1 structure references.
 
 =item B<HTTP>
 
-HTTP client diagnostics.
+Traces the HTTP client, such as message headers being sent and received.
 
 =back
 

--- a/doc/man1/openssl.pod
+++ b/doc/man1/openssl.pod
@@ -720,15 +720,19 @@ available:
 
 =item B<TRACE>
 
-The tracing functionality.
+Traces the OpenSSL trace API itself.
+
+=item B<INIT>
+
+Traces OpenSSL library initialization and cleanup.
 
 =item B<TLS>
 
-General SSL/TLS.
+Traces the TLS/SSL protocol.
 
 =item B<TLS_CIPHER>
 
-SSL/TLS cipher.
+Traces the ciphers used by the TLS/SSL protocol.
 
 =item B<CONF>
 
@@ -747,28 +751,48 @@ of generated for each change.
 
 =item B<PKCS5V2>
 
-PKCS#5 v2 keygen.
+Traces PKCS#5 v2 key generation.
 
 =item B<PKCS12_KEYGEN>
 
-PKCS#12 key generation.
+Traces PKCS#12 key generation.
 
 =item B<PKCS12_DECRYPT>
 
-PKCS#12 decryption.
+Traces PKCS#12 decryption.
 
 =item B<X509V3_POLICY>
 
-Generates the complete policy tree at various point during X.509 v3
+Generates the complete policy tree at various points during X.509 v3
 policy evaluation.
 
 =item B<BN_CTX>
 
-BIGNUM context.
+Traces BIGNUM context operations.
+
+=item B<CMP>
+
+Traces CMP client and server activity.
+
+=item B<STORE>
+
+Traces STORE operations.
+
+=item B<DECODER>
+
+Traces decoder operations.
+
+=item B<ENCODER>
+
+Traces encoder operations.
+
+=item B<REF_COUNT>
+
+Traces decrementing certain ASN.1 structure references.
 
 =item B<HTTP>
 
-HTTP client diagnostics
+HTTP client diagnostics.
 
 =back
 

--- a/doc/man3/OSSL_trace_set_channel.pod
+++ b/doc/man3/OSSL_trace_set_channel.pod
@@ -206,7 +206,7 @@ Traces decrementing certain ASN.1 structure references.
 
 =item B<OSSL_TRACE_CATEGORY_HTTP>
 
-HTTP client diagnostics.
+Traces the HTTP client, such as message headers being sent and received.
 
 =back
 

--- a/doc/man3/OSSL_trace_set_channel.pod
+++ b/doc/man3/OSSL_trace_set_channel.pod
@@ -141,6 +141,10 @@ Traces the TLS/SSL protocol.
 
 Traces the ciphers used by the TLS/SSL protocol.
 
+=item B<OSSL_TRACE_CATEGORY_CONF>
+
+Traces details about the provider and engine configuration.
+
 =item B<OSSL_TRACE_CATEGORY_ENGINE_TABLE>
 
 Traces the ENGINE algorithm table selection.
@@ -180,9 +184,29 @@ point during evaluation.
 
 Traces BIGNUM context operations.
 
-=item B<OSSL_TRACE_CATEGORY_CONF>
+=item B<OSSL_TRACE_CATEGORY_CMP>
 
-Traces details about the provider and engine configuration.
+Traces CMP client and server activity.
+
+=item B<OSSL_TRACE_CATEGORY_STORE>
+
+Traces STORE operations.
+
+=item B<OSSL_TRACE_CATEGORY_DECODER>
+
+Traces decoder operations.
+
+=item B<OSSL_TRACE_CATEGORY_ENCODER>
+
+Traces encoder operations.
+
+=item B<OSSL_TRACE_CATEGORY_ENGINE_REF_COUNT>
+
+Traces decrementing certain ASN.1 structure references.
+
+=item B<OSSL_TRACE_CATEGORY_HTTP>
+
+HTTP client diagnostics.
 
 =back
 

--- a/doc/man3/OSSL_trace_set_channel.pod
+++ b/doc/man3/OSSL_trace_set_channel.pod
@@ -200,7 +200,7 @@ Traces decoder operations.
 
 Traces encoder operations.
 
-=item B<OSSL_TRACE_CATEGORY_ENGINE_REF_COUNT>
+=item B<OSSL_TRACE_CATEGORY_REF_COUNT>
 
 Traces decrementing certain ASN.1 structure references.
 


### PR DESCRIPTION
Make `OSSL_trace_set_channel.pod` and `openssl.pod` consistent again with `trace.h`. 
