### PR TITLE
`openssl-verification-options.pod`: updates and improvements

### DIFF
--- a/crypto/x509/v3_purp.c
+++ b/crypto/x509/v3_purp.c
@@ -800,7 +800,7 @@ static int check_purpose_ns_ssl_server(const X509_PURPOSE *xp, const X509 *x,
     return ku_reject(x, KU_KEY_ENCIPHERMENT) ? 0 : ret;
 }
 
-/* common S/MIME checks */
+/* common S/MIME client checks */
 static int purpose_smime(const X509 *x, int non_leaf)
 {
     if (xku_reject(x, XKU_SMIME))
@@ -869,7 +869,7 @@ static int check_purpose_ocsp_helper(const X509_PURPOSE *xp, const X509 *x,
      */
     if (non_leaf)
         return check_ca(x);
-    /* Leaf certificate is checked in OCSP_verify() */
+    /* Leaf certificate is checked in OCSP_basic_verify() */
     return 1;
 }
 

--- a/crypto/x509/x509_trust.c
+++ b/crypto/x509/x509_trust.c
@@ -247,6 +247,13 @@ static int trust_compat(X509_TRUST *trust, X509 *x, int flags)
         return X509_TRUST_UNTRUSTED;
 }
 
+/*
+ * |id| is the NID of the extended key usage (EKU) to check for certificate |x|.
+ * Return X509_TRUST_REJECTED if negative trust attributes of |x| prevents it.
+ * Return X509_TRUST_TRUSTED if positive trust attributes of |x| accepts it.
+ * If |flags| includes X509_TRUST_OK_ANY_EKU then anyEKU serves as wildcard.
+ * Return X509_TRUST_UNTRUSTED if no clear decision has been reached here.
+ */
 static int obj_trust(int id, X509 *x, int flags)
 {
     X509_CERT_AUX *ax = x->aux;

--- a/crypto/x509/x509_vfy.c
+++ b/crypto/x509/x509_vfy.c
@@ -2606,12 +2606,15 @@ int X509_STORE_CTX_set_trust(X509_STORE_CTX *ctx, int trust)
 }
 
 /*
- * This function is used to set the X509_STORE_CTX purpose and trust values.
+ * Use this function to set the X509_STORE_CTX purpose and/or trust id values.
+ * The |def_purpose| argument is used if the given purpose value is 0.
+ * The |purpose| is unchanged if also the def_purpose argument is 0.
+ * The |trust| is unchanged if the given trust value is X509_TRUST_DEFAULT.
  * This is intended to be used when another structure has its own trust and
- * purpose values which (if set) will be inherited by the ctx. If they aren't
- * set then we will usually have a default purpose in mind which should then
- * be used to set the trust value. An example of this is SSL use: an SSL
- * structure will have its own purpose and trust settings which the
+ * purpose values, which (if set) will be inherited by the |ctx|. If they aren't
+ * set then we will usually have a default purpose in mind, which should then
+ * be used to set the trust id. An example of this is SSL use: an SSL
+ * structure will have its own purpose and trust settings, which the
  * application can set: if they aren't set then we use the default of SSL
  * client/server.
  */

--- a/crypto/x509/x509_vfy.c
+++ b/crypto/x509/x509_vfy.c
@@ -2648,10 +2648,10 @@ int X509_STORE_CTX_purpose_inherit(X509_STORE_CTX *ctx, int def_purpose,
             ptmp = X509_PURPOSE_get0(idx);
         }
         /* If trust not set then get from purpose default */
-        if (trust == 0)
+        if (trust == X509_TRUST_DEFAULT)
             trust = ptmp->trust;
     }
-    if (trust != 0) {
+    if (trust != X509_TRUST_DEFAULT) {
         idx = X509_TRUST_get_by_id(trust);
         if (idx == -1) {
             ERR_raise(ERR_LIB_X509, X509_R_UNKNOWN_TRUST_ID);
@@ -2661,7 +2661,7 @@ int X509_STORE_CTX_purpose_inherit(X509_STORE_CTX *ctx, int def_purpose,
 
     if (ctx->param->purpose == 0 && purpose != 0)
         ctx->param->purpose = purpose;
-    if (ctx->param->trust == 0 && trust != 0)
+    if (ctx->param->trust == X509_TRUST_DEFAULT && trust != X509_TRUST_DEFAULT)
         ctx->param->trust = trust;
     return 1;
 }

--- a/doc/man1/openssl-verification-options.pod
+++ b/doc/man1/openssl-verification-options.pod
@@ -37,18 +37,18 @@ L<X509_VERIFY_PARAM_set_flags(3)>, and L<X509_check_host(3)>.
 
 =head2 Trust Anchors
 
-In general, according to RFC 4158 and RFC 5280, a I<trust anchor> is
-any public key and related subject distinguished name (DN) that
-for some reason is considered trusted
+In general, according to RFC 4158 and RFC 5280, a I<trust anchor> is just
+a public key (with algorithm and any parameters) and an associated subject name
+that for some reason is considered trusted
 and thus is acceptable as the root of a chain of certificates.
 
-In practice, trust anchors are given in the form of certificates,
-where their essential fields are the public key and the subject DN.
-In addition to the requirements in RFC 5280,
-OpenSSL checks the validity period of such certificates
-and makes use of some further fields.
-In particular, the subject key identifier extension, if present,
-is used for matching trust anchors during chain building.
+In practice, trust anchors are given in the form of (typically self-signed)
+certificates, where their essential fields are the subjectPublicKeyInfo and the
+subject distinguished name (DN), while the subject key identifier is optional.
+In addition to the requirements given in RFC 5280,
+OpenSSL checks the validity period of such certificates and takes the extended
+key usage (EKU) extension, if present, as a source of usage constraints.
+Any restrictions given by the (regular) key usage extension are ignored.
 
 In the most simple and common case, trust anchors are by default
 all self-signed "root" CA certificates that are placed in the I<trust store>,
@@ -103,13 +103,18 @@ It is self-signed or the B<-partial_chain> option is given
 First, a certificate chain is built up starting from the target certificate
 and ending in a trust anchor.
 
-The chain is built up iteratively, looking up in turn
-a certificate with suitable key usage that
+The chain is built up iteratively, looking up in turn a certificate that
 matches as an issuer of the current "subject" certificate as described below.
-If there is such a certificate, the first one found that is currently valid
-is taken, otherwise the one that expired most recently of all such certificates.
+If there is such a certificate, the first one found that has a suitable validity
+period or otherwise has the latest expiration date of all matching certificates.
 For efficiency, no backtracking is performed, thus
 any further candidate issuer certificates that would match equally are ignored.
+
+Certificate extensions are available since X.509 v3 and are mostly optional.
+For certificate chain building
+the subjectKeyIdentifier and authorityKeyIdentifier extensions are very useful,
+while subject alternative names (SAN) and issuer alternative names given
+in subjectAltName or issuerAltName extensions do not play a role.
 
 When a self-signed certificate has been added, chain construction stops.
 In this case it must fully match a trust anchor, otherwise chain building fails.
@@ -121,7 +126,8 @@ if all of the following conditions hold:
 
 =item *
 
-Its subject name matches the issuer name of the subject certificate.
+Its subject Distinguished Name (DN)
+matches the issuer DN of the subject certificate.
 
 =item *
 
@@ -135,6 +141,11 @@ as far as the respective fields are present in both certificates.
 The certificate signature algorithm used to sign the subject certificate
 is supported and
 equals the public key algorithm of the candidate issuer certificate.
+
+item *
+
+If the issuer certificate includes a key usage restriction,
+it must allow for certificate signing (keyCertSign).
 
 =back
 
@@ -381,7 +392,7 @@ keys shorter than 1024 bits.
 
 Allow verification to succeed if an incomplete chain can be built.
 That is, a chain ending in a certificate that normally would not be trusted
-(because it has no matching positive trust attributes and is not self-signed)
+(because it is not self-signed and has no matching positive trust attributes)
 but is an element of the trust store.
 This certificate may be self-issued or belong to an intermediate CA.
 

--- a/doc/man1/openssl-verification-options.pod
+++ b/doc/man1/openssl-verification-options.pod
@@ -73,8 +73,7 @@ B<clientAuth> (SSL client use), B<serverAuth> (SSL server use),
 B<emailProtection> (S/MIME email use), B<codeSigning> (object signer use),
 B<OCSPSigning> (OCSP responder use), B<OCSP> (OCSP request use),
 B<timeStamping> (TSA server use), and B<anyExtendedKeyUsage>.
-As of OpenSSL 1.1.0, the last of these blocks all uses when rejected or
-enables all uses when trusted.
+The last of these blocks all uses when rejected or enables all uses when trusted.
 
 A certificate, which may be CA certificate or an end-entity certificate,
 is considered a trust anchor for the given use
@@ -400,7 +399,7 @@ Allow the verification of proxy certificates.
 
 =item B<-trusted_first>
 
-As of OpenSSL 1.1.0 this option is on by default and cannot be disabled.
+This option is on by default and cannot be disabled.
 
 When constructing the certificate chain, the trusted certificates specified
 via B<-CAfile>, B<-CApath>, B<-CAstore> or B<-trusted> are always used
@@ -408,8 +407,7 @@ before any certificates specified via B<-untrusted>.
 
 =item B<-no_alt_chains>
 
-As of OpenSSL 1.1.0, since B<-trusted_first> always on, this option has no
-effect.
+Since B<-trusted_first> always on, this option has no effect.
 
 =item B<-trusted> I<file>
 
@@ -729,6 +727,8 @@ L<openssl-cmp(1)>,
 L<openssl-cms(1)>
 
 =head1 HISTORY
+
+Since OpenSSL 1.1.0, the B<-trusted_first> option is always enabled.
 
 The checks enabled by B<-x509_strict> have been extended in OpenSSL 3.0.
 

--- a/doc/man1/openssl-verification-options.pod
+++ b/doc/man1/openssl-verification-options.pod
@@ -13,20 +13,34 @@ I<command>
 
 =head1 DESCRIPTION
 
-There are many situations where X.509 certificates are verified
+There are many situations where X.509 public-key certificates are verified
 within the OpenSSL libraries and in various OpenSSL commands.
+For checking certificates, the term I<validation> would actually be more
+appropriate,
+but for historical reasons the term I<verification> is often used instead.
 
+In the sequel, the certificate to be validated is called I<target certificate>.
+Since it usually is an end-entity (EE) certificate, it is also known as
+"leaf" certificate (of a chain or tree), but it may also be a CA certificate.
 Certificate verification is implemented by L<X509_verify_cert(3)>.
-It is a complicated process consisting of a number of steps
-and depending on numerous options.
+The validation process involves several steps and depends on multiple options.
 The most important of them are detailed in the following sections.
 
-In a nutshell, a valid chain of certificates needs to be built up and verified
-starting from the I<target certificate> that is to be verified
-and ending in a certificate that due to some policy is trusted.
+In a nutshell, a valid chain of certificates needs to be constructed and checked
+starting from the I<target certificate> that is to be validated and ending in a
+trust anchor, which usually is a certificate that due to some policy is trusted.
 Certificate validation can be performed in the context of a I<purpose>, which
 is a high-level specification of the intended use of the target certificate,
-such as C<sslserver> for TLS servers, or (by default) for any purpose.
+such as C<sslserver> for (D)TLS servers, or (by default) for any purpose.
+
+All certificates in the chain except the target ceritificate must be CA
+certificates.
+An X.509v3 certificate is considered a CA certificate
+if it has a basicConstraints extension with the `CA` flag set.
+If a pathLenConstraint is included then the chain is checked to satisfy it.
+If a CA certificate has a keyUsage extension
+then the latter must include the keyCertSign bit, and for proxy certificates
+used for issuing a certificate it must include also the digitalSignature bit.
 
 The details of how each OpenSSL command handles errors
 are documented on the specific command page.
@@ -39,60 +53,67 @@ L<X509_VERIFY_PARAM_set_flags(3)>, and L<X509_check_host(3)>.
 
 In general, according to RFC 4158 and RFC 5280, a I<trust anchor> is just
 a public key (with algorithm and any parameters) and an associated subject name
-that for some reason is considered trusted
+that in a suitable context is considered trusted for some purpose(s)
 and thus is acceptable as the root of a chain of certificates.
 
-In practice, trust anchors are given in the form of (typically self-signed)
-certificates, where their essential fields are the subjectPublicKeyInfo and the
-subject distinguished name (DN), while the subject key identifier is optional.
-In addition to the requirements given in RFC 5280,
-OpenSSL checks the validity period of such certificates and takes the extended
-key usage (EKU) extension, if present, as a source of usage constraints.
-Any restrictions given by the (regular) key usage extension are ignored.
+In practice, trust anchors are given in the form of certificates.
+Commonly they are self-signed root CA certificates.
+Their most essential fields are the subjectPublicKeyInfo and
+the subject distinguished name (DN), while the subject key identifier extension
+is generally optional but highly recommended to be included in CA certificates
+because they help chain building.
+In addition to the requirements given in RFC 5280 for trust anchor handling,
+OpenSSL performs on trust anchor certificates the same checks as on regular
+CA certificates, in particular those regarding the validity period
+and X.509v3 extensions like basic constraints and key usage.
+Depending on the given validation purpose, in part even the extended key usage
+is checked - for details see the L</Extended Key Usage> section below.
 
-In the most simple and common case, trust anchors are by default
-all self-signed "root" CA certificates that are placed in the I<trust store>,
-which is a collection of certificates that are trusted for certain uses.
+The most crucial input to certificate validation is a I<trust store>,
+which includes a collection of certificates and validation options.
 This is akin to what is used in the trust stores of Mozilla Firefox,
 or Apple's and Microsoft's certificate stores, ...
+By default all self-signed certificates in the trust store
+are considered to be trust anchors, for all or for specified purposes.
 
-From the OpenSSL perspective, a trust anchor is a certificate
-that should be augmented with an explicit designation for which
+Independent of any extended key usage (EKU) X.509v3 extension included,
+from the OpenSSL perspective a trust anchor certificate should be augmented
+with local trust attributes, giving an explicit designation for which
 uses of a target certificate the certificate may serve as a trust anchor.
-In PEM encoding, this is indicated by the C<TRUSTED CERTIFICATE> string.
+If this information is missing, it is by default trusted for all uses.
+In PEM encoding, the presence of trust attributes
+is indicated by the C<TRUSTED CERTIFICATE> string.
 Such a designation provides a set of positive trust attributes
-explicitly stating trust for the listed purposes
-and/or a set of negative trust attributes
-explicitly rejecting the use for the listed purposes.
-The purposes are encoded using the values defined for the extended key usages
-(EKUs) that may be given in X.509 extensions of end-entity certificates.
-See also the L</Extended Key Usage> section below.
-
-The currently recognized uses are
-B<clientAuth> (SSL client use), B<serverAuth> (SSL server use),
-B<emailProtection> (S/MIME email use), B<codeSigning> (object signer use),
-B<OCSPSigning> (OCSP responder use), B<OCSP> (OCSP request use),
-B<timeStamping> (TSA server use), and B<anyExtendedKeyUsage>.
-The last of these blocks all uses when rejected or enables all uses when trusted.
+explicitly stating acceptance for the listed uses
+and/or a set of negative trust attributes explicitly rejecting the listed uses.
+These uses are encoded using the OID values defined for the extended key usages
+that may be included in X.509v3 certificate extensions.
+For the list of EKUs with currently predefined meaning
+see the L</Extended Key Usage> section below.
+The special EKU B<anyExtendedKeyUsage>
+enables all uses when trusted or blocks all uses when rejected.
 
 A certificate, which may be CA certificate or an end-entity certificate,
-is considered a trust anchor for the given use
+is considered a trust anchor for the intended use
 if and only if all the following conditions hold:
 
 =over 4
 
 =item *
 
-It is an an element of the trust store.
+It is an element of the trust store.
 
 =item *
 
-It does not have a negative trust attribute rejecting the given use.
+It does not have a negative trust attribute rejecting
+the EKU associated with the intended purpose.
 
 =item *
 
-It has a positive trust attribute accepting the given use
-or (by default) one of the following compatibility conditions apply:
+It has a positive trust attribute accepting
+the EKU associated with the intended purpose
+or it does not have any positive trust attribute
+and one of the following compatibility conditions apply:
 It is self-signed or the B<-partial_chain> option is given
 (which corresponds to the B<X509_V_FLAG_PARTIAL_CHAIN> flag being set).
 
@@ -102,21 +123,28 @@ It is self-signed or the B<-partial_chain> option is given
 
 First, a certificate chain is built up starting from the target certificate
 and ending in a trust anchor.
+The goal is that for each certificate in the chain, except for the final one,
+the subject of the successor is the issuer of the former certificate.
+Since it often happens that the subject and issuer Distinguished Names
+are not unique, the subject and issuer key identifier extensions,
+if present in the certificates, are used to disambiguate conflicts.
 
-The chain is built up iteratively, looking up in turn a certificate that
+The chain is built up iteratively, looking up each certificate in turn that
 matches as an issuer of the current "subject" certificate as described below.
-If there is such a certificate, the first one found that has a suitable validity
-period or otherwise has the latest expiration date of all matching certificates.
-For efficiency, no backtracking is performed, thus
+If there is more than one matching certificate, the algorithm uses
+the first certificate found that has a suitable validity period,
+otherwise the one with the latest expiration date of all matching certificates.
+For efficiency, the algorithm does not allow for backtracking, thus
 any further candidate issuer certificates that would match equally are ignored.
 
-Certificate extensions are available since X.509 v3 and are mostly optional.
+Certificate extensions are available since X.509v3,
+and though many are optional, some are generally recommended or required.
 For certificate chain building
-the subjectKeyIdentifier and authorityKeyIdentifier extensions are very useful,
-while subject alternative names (SAN) and issuer alternative names given
-in subjectAltName or issuerAltName extensions do not play a role.
+the subjectKeyIdentifier and authorityKeyIdentifier extensions are very useful.
+The subject alternative names (SAN) and issuer alternative names given in
+subjectAltName or issuerAltName extensions are not relevant for chain building.
 
-When a self-signed certificate has been added, chain construction stops.
+Once a self-signed certificate has been added, chain construction stops.
 In this case it must fully match a trust anchor, otherwise chain building fails.
 
 A candidate issuer certificate matches a subject certificate
@@ -163,7 +191,7 @@ Part of these checks are enabled only if the B<-x509_strict> option is given.
 
 The second step is to check the X.509v3 extensions of every certificate
 for consistency with the intended specific purpose, if any.
-If the B<-purpose> option is not given then no such checks are done except for
+If no purpose is given explicitly then no such checks are done except for
 CMS signature checking, where by default C<smimesign> is checked, and SSL/(D)TLS
 connection setup, where by default C<sslserver> or C<sslclient> are checked.
 The X.509v3 extensions of the target or "leaf" certificate
@@ -173,10 +201,10 @@ and possibly also further non-standard checks are performed.
 The precise extensions required are described in detail
 in the L</Certificate Extensions> section below.
 
-The third step is to check the trust settings on the last certificate
-(which typically is a self-signed root CA certificate).
-It must be trusted for the given use.
-For compatibility with previous versions of OpenSSL, a self-signed certificate
+The third step is to check the trust settings on the last certificate or
+trust anchor, which typically is given as a self-signed root CA certificate.
+If specified, it must be trusted for the given use.
+For compatibility, a self-signed certificate
 with no trust attributes is considered to be valid for all uses.
 
 The fourth, and final, step is to check the validity of the certificate chain.
@@ -296,11 +324,11 @@ CA certificates must explicitly include the keyUsage extension.
 
 =item *
 
-If a pathlenConstraint is given the key usage keyCertSign must be allowed.
+If a pathLenConstraint is given the key usage keyCertSign must be allowed.
 
 =item *
 
-The pathlenConstraint must not be given for non-CA certificates.
+The pathLenConstraint must not be given for non-CA certificates.
 
 =item *
 
@@ -347,12 +375,12 @@ Ignored.
 
 =item B<-crl_check>
 
-Checks end entity certificate validity by attempting to look up a valid CRL.
+Checks end-entity certificate validity by attempting to look up a valid CRL.
 If a valid CRL cannot be found an error occurs.
 
 =item B<-crl_check_all>
 
-Checks the validity of B<all> certificates in the chain by attempting
+Checks the validity of I<all> certificates in the chain by attempting
 to look up valid CRLs.
 
 =item B<-use_deltas>
@@ -418,7 +446,7 @@ before any certificates specified via B<-untrusted>.
 
 =item B<-no_alt_chains>
 
-Since B<-trusted_first> always on, this option has no effect.
+Since B<-trusted_first> is always on, this option has no effect.
 
 =item B<-trusted> I<file>
 
@@ -480,6 +508,8 @@ checks for consistency with S/MIME signing use (C<smimesign>).
 While IETF RFC 5280 says that B<id-kp-serverAuth> and B<id-kp-clientAuth>
 are only for WWW use, in practice they are used for all kinds of TLS clients
 and servers, and this is what OpenSSL assumes as well.
+
+For details on the checks performed see the L</Certificate Extensions> section.
 
 =item B<-verify_depth> I<num>
 
@@ -566,11 +596,15 @@ This option has no effect and is retained for backward compatibility only.
 Options like B<-purpose> and B<-verify_name> trigger the processing of specific
 certificate extensions, which determine what certificates can be used for.
 
+The following two subsections on the B<basicConstraints> and B<keyUsage>
+extensions and on X.509v1 certificates apply to I<all> CA certificates
+regardless of any required purpose.
+
 =head3 Basic Constraints
 
 The basicConstraints extension CA flag is used to determine whether the
 certificate can be used as a CA. If the CA flag is true then it is a CA,
-if the CA flag is false then it is not a CA. B<All> CAs should have the
+if the CA flag is false then it is not a CA. I<All> CAs should have the
 CA flag set to true.
 
 If the basicConstraints extension is absent,
@@ -583,8 +617,10 @@ is presently supported, but this could change in the future.
 =head3 Key Usage
 
 If the keyUsage extension is present then additional restraints are
-made on the uses of the certificate. A CA certificate B<must> have the
+made on the uses of the certificate. A CA certificate I<must> have the
 keyCertSign bit set if the keyUsage extension is present.
+Further restrictions are checked depending on the required purpose, if any;
+for details see the list given in the next subsection.
 
 =head3 Extended Key Usage
 
@@ -717,7 +753,7 @@ For all other certificates the normal CA checks apply.
 =head1 BUGS
 
 The issuer checks still suffer from limitations in the underlying X509_LOOKUP
-API.  One consequence of this is that trusted certificates with matching
+API.  Trusted certificates with matching
 subject name must appear in a file (as specified by the B<-CAfile> option),
 a directory (as specified by B<-CApath>),
 or a store (as specified by B<-CAstore>).

--- a/doc/man3/X509_STORE_CTX_new.pod
+++ b/doc/man3/X509_STORE_CTX_new.pod
@@ -203,7 +203,7 @@ return 1 on success or 0 on failure.
 
 X509 certificates may contain information about what purposes keys contained
 within them can be used for. For example "TLS WWW Server Authentication" or
-"Email Protection". This "key usage" information is held internally to the
+"Email Protection". This extended key usage information is held internally to the
 certificate itself. In addition the trust store containing trusted certificates
 can declare what purposes we trust different certificates for. This "trust"
 information is not held within the certificate itself but is "meta" information
@@ -238,18 +238,18 @@ the certificate and its chain are verified to be consistent with that purpose.
 For SSL client, SSL server, and S/MIME purposes, the EKU is checked also for the
 CA certificates along the chain, including any given trust anchor certificate.
 Potentially also further checks are done (depending on the purpose given).
-Every purpose also has an associated default trust value, which will also be set
+Every purpose also has an associated default trust id, which will also be set
 at the same time. During verification, this trust setting will be verified
 to check whether it is consistent with the trust set by the system administrator
 for certificates in the chain.
 
-X509_STORE_CTX_set_trust() sets the trust value for the target certificate
-being verified in the I<ctx>. Built-in available values for the I<trust>
+X509_STORE_CTX_set_trust() sets the trust id value for the target certificate
+being verified in the I<ctx>. Built-in available values for the I<trust> id
 argument are B<X509_TRUST_COMPAT>, B<X509_TRUST_SSL_CLIENT>,
 B<X509_TRUST_SSL_SERVER>, B<X509_TRUST_EMAIL>, B<X509_TRUST_OBJECT_SIGN>,
 B<X509_TRUST_OCSP_SIGN>, B<X509_TRUST_OCSP_REQUEST> and B<X509_TRUST_TSA>. It is
-also possible to create a custom trust value. Since X509_STORE_CTX_set_purpose()
-also sets the trust value it is normally sufficient to only call that function.
+also possible to create a custom trust id. Since X509_STORE_CTX_set_purpose()
+also sets the trust id it is normally sufficient to only call that function.
 If both are called then X509_STORE_CTX_set_trust() should be called after
 X509_STORE_CTX_set_purpose() since the trust setting of the last call will be
 used.
@@ -257,21 +257,21 @@ used.
 It should not normally be necessary for end user applications to call
 X509_STORE_CTX_purpose_inherit() directly. Typically applications should call
 X509_STORE_CTX_set_purpose() or X509_STORE_CTX_set_trust() instead. Using this
-function it is possible to set the purpose and trust values for the I<ctx> at
+function it is possible to set the purpose and trust id values for the I<ctx> at
 the same time.
 Both I<ctx> and its internal verification parameter pointer must not be NULL.
 The I<def_purpose> and I<purpose> arguments can have the same
 purpose values as described for X509_STORE_CTX_set_purpose() above. The I<trust>
-argument can have the same trust values as described in
+argument can have the same trust ids as described in
 X509_STORE_CTX_set_trust() above. Any of the I<def_purpose>, I<purpose> or
 I<trust> values may also have the value 0 to indicate that the supplied
 parameter should be ignored. After calling this function the purpose to be used
 for verification is set from the I<purpose> argument unless the purpose was
 already set in I<ctx> before, and the trust is set from the I<trust> argument
 unless the trust was already set in I<ctx> before.
-If I<trust> is 0 then the trust value will be set from
-the default trust value for I<purpose>. If the default trust value for the
-purpose is I<X509_TRUST_DEFAULT> and I<trust> is 0 then the default trust value
+If I<trust> is 0 then the trust id will be set from
+the default trust id for I<purpose>. If the default trust id for the
+purpose is I<X509_TRUST_DEFAULT> and I<trust> is 0 then the default trust id
 associated with the I<def_purpose> value is used for the trust setting instead.
 
 =head1 NOTES

--- a/test/certs/setup.sh
+++ b/test/certs/setup.sh
@@ -223,6 +223,8 @@ OPENSSL_KEYBITS=4096 \
 OPENSSL_KEYBITS=8192 \
 ./mkcert.sh genee server.example ee-key-8192 ee-cert-8192 ca-key ca-cert
 
+# root CA cert with explicit keyUsage not including KeyCertSign
+openssl req -new -x509 -key root-key.pem -subj /CN="Root CA" -out root-no-KeyCertSign.pem -addext keyUsage=digitalSignature -days 36525
 # self-signed end-entity cert with explicit keyUsage not including KeyCertSign
 openssl req -new -x509 -key ee-key.pem -subj /CN=ee-self-signed -out ee-self-signed.pem -addext keyUsage=digitalSignature -days 36525
 

--- a/test/recipes/25-test_verify.t
+++ b/test/recipes/25-test_verify.t
@@ -30,7 +30,7 @@ sub verify {
     run(app([@args]));
 }
 
-plan tests => 205;
+plan tests => 206;
 
 # Canonical success
 ok(verify("ee-cert", "sslserver", ["root-cert"], ["ca-cert"]),
@@ -39,6 +39,8 @@ ok(verify("ee-cert", "sslserver", ["root-cert"], ["ca-cert"]),
 # Root CA variants
 ok(!verify("ee-cert", "sslserver", [qw(root-nonca)], [qw(ca-cert)]),
    "fail trusted non-ca root");
+ok(!verify("ee-cert", "sslserver", [qw(root-no-KeyCertSign)], [qw(ca-cert)]),
+   "fail trusted root excluding key usage KeyCertSign");
 ok(!verify("ee-cert", "sslserver", [qw(nroot+serverAuth)], [qw(ca-cert)]),
    "fail server trust non-ca root");
 ok(!verify("ee-cert", "sslserver", [qw(nroot+anyEKU)], [qw(ca-cert)]),


### PR DESCRIPTION
* Move reference to changes brought by OpenSSL 1.1.0 to HISTORY section
* better explain trust anchors and their use
* significantly improve and complete the description of purpose checking
