### PR TITLE
ci: Add GitHub token permissions for workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ on: [pull_request, push]
 # before_script:
 #     - make="make -s"
 
+permissions:
+  contents: read
+
 jobs:
   check_update:
     runs-on: ubuntu-latest

--- a/.github/workflows/compiler-zoo.yml
+++ b/.github/workflows/compiler-zoo.yml
@@ -9,6 +9,9 @@ name: Compiler Zoo CI
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   compiler:
     strategy:

--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -12,8 +12,14 @@ on:
   schedule:
     - cron:  '49 0 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   coverage:
+    permissions:
+      checks: write  # for coverallsapp/github-action to create new checks
+      contents: read  # for actions/checkout to fetch code
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/cross-compiles.yml
+++ b/.github/workflows/cross-compiles.yml
@@ -9,6 +9,9 @@ name: Cross Compile
 
 on: [pull_request, push]
 
+permissions:
+  contents: read
+
 jobs:
   cross-compilation:
     strategy:

--- a/.github/workflows/fips-checksums.yml
+++ b/.github/workflows/fips-checksums.yml
@@ -8,6 +8,9 @@
 name: FIPS Checksums
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   compute-checksums:
     runs-on: ubuntu-latest

--- a/.github/workflows/fips-label.yml
+++ b/.github/workflows/fips-label.yml
@@ -12,8 +12,14 @@ on:
     types:
       - completed
 
+permissions:
+  contents: read
+
 jobs:
   apply-label:
+    permissions:
+      actions: read  
+      pull-requests: write  
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.event == 'pull_request' }}
     steps:

--- a/.github/workflows/fips-provider.yml
+++ b/.github/workflows/fips-provider.yml
@@ -8,6 +8,9 @@
 name: Provider compat
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   fips-provider-30:
     runs-on: ubuntu-latest

--- a/.github/workflows/fuzz-checker.yml
+++ b/.github/workflows/fuzz-checker.yml
@@ -9,6 +9,9 @@ name: Fuzz-checker CI
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   fuzz-checker:
     strategy:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,9 @@
 
 name: CIFuzz
 on: [pull_request, push]
+permissions:
+  contents: read
+
 jobs:
   Fuzzing:
     runs-on: ubuntu-latest

--- a/.github/workflows/os-zoo.yml
+++ b/.github/workflows/os-zoo.yml
@@ -11,6 +11,9 @@ on:
   schedule:
     - cron: '0 5 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   unix:
     strategy:

--- a/.github/workflows/run-checker-ci.yml
+++ b/.github/workflows/run-checker-ci.yml
@@ -8,6 +8,9 @@
 # Jobs run per pull request submission
 name: Run-checker CI
 on: [pull_request, push]
+permissions:
+  contents: read
+
 jobs:
   run-checker:
     strategy:

--- a/.github/workflows/run-checker-daily.yml
+++ b/.github/workflows/run-checker-daily.yml
@@ -11,6 +11,9 @@ name: Run-checker daily
 on:
   schedule:
     - cron: '0 6 * * *'
+permissions:
+  contents: read
+
 jobs:
   run-checker:
     strategy:

--- a/.github/workflows/run-checker-merge.yml
+++ b/.github/workflows/run-checker-merge.yml
@@ -9,6 +9,9 @@ name: Run-checker merge
 # Jobs run per merge to master
 
 on: [push]
+permissions:
+  contents: read
+
 jobs:
   run-checker:
     strategy:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -12,6 +12,9 @@ on:
   schedule:
     - cron:  '20 0 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   coverity:
     runs-on: ubuntu-latest

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -9,6 +9,9 @@ name: Windows GitHub CI
 
 on: [pull_request, push]
 
+permissions:
+  contents: read
+
 jobs:
   shared:
     # Run a job for each of the specified target architectures:


### PR DESCRIPTION
This PR adds minimum token permissions for the GITHUB_TOKEN using https://github.com/step-security/secure-workflows.

GitHub recommends defining minimum GITHUB_TOKEN permissions for securing GitHub Actions workflows 
- https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/  
- https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
- The Open Source Security Foundation (OpenSSF) [Scorecards](https://github.com/ossf/scorecard) treats not setting token permissions as a high-risk issue 

This project is part of the top 100 critical projects as per OpenSSF (https://github.com/ossf/wg-securing-critical-projects), so fixing the token permissions to improve security.

Signed-off-by: Varun Sharma <varunsh@stepsecurity.io>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

