### PR TITLE
add a check for the return of OBJ_new_nid()

### DIFF
--- a/crypto/objects/obj_dat.c
+++ b/crypto/objects/obj_dat.c
@@ -758,6 +758,9 @@ int OBJ_create(const char *oid, const char *sn, const char *ln)
     }
 
     tmpoid->nid = OBJ_new_nid(1);
+    if (tmpoid->nid == NID_undef)
+        goto err;
+
     tmpoid->sn = (char *)sn;
     tmpoid->ln = (char *)ln;
 


### PR DESCRIPTION
When `TSAN_REQUIRES_LOCKING` is enabled, OBJ_new_nid() can fail in getting the write lock and return NID_undef.
Therefore, it is better to check the return of it to propagate the error in time.