### PR TITLE
ocspapitest.c: check the return of three memory-allocation related functions

### DIFF
--- a/test/ocspapitest.c
+++ b/test/ocspapitest.c
@@ -81,10 +81,11 @@ static OCSP_BASICRESP *make_dummy_resp(void)
     if (!TEST_ptr(name)
         || !TEST_ptr(key)
         || !TEST_ptr(serial)
-        || !X509_NAME_add_entry_by_NID(name, NID_commonName, MBSTRING_ASC,
-                                   namestr, -1, -1, 1)
-        || !ASN1_BIT_STRING_set(key, keybytes, sizeof(keybytes))
-        || !ASN1_INTEGER_set_uint64(serial, (uint64_t)1))
+        || !TEST_true(X509_NAME_add_entry_by_NID(name, NID_commonName,
+                                                 MBSTRING_ASC,
+                                                 namestr, -1, -1, 1))
+        || !TEST_true(ASN1_BIT_STRING_set(key, keybytes, sizeof(keybytes)))
+        || !TEST_true(ASN1_INTEGER_set_uint64(serial, (uint64_t)1)))
         goto err;
     cid = OCSP_cert_id_new(EVP_sha256(), name, key, serial);
     if (!TEST_ptr(bs)

--- a/test/ocspapitest.c
+++ b/test/ocspapitest.c
@@ -78,7 +78,10 @@ static OCSP_BASICRESP *make_dummy_resp(void)
     ASN1_BIT_STRING *key = ASN1_BIT_STRING_new();
     ASN1_INTEGER *serial = ASN1_INTEGER_new();
 
-    if (!X509_NAME_add_entry_by_NID(name, NID_commonName, MBSTRING_ASC,
+    if (!TEST_ptr(name)
+        || !TEST_ptr(key)
+        || !TEST_ptr(serial)
+        || !X509_NAME_add_entry_by_NID(name, NID_commonName, MBSTRING_ASC,
                                    namestr, -1, -1, 1)
         || !ASN1_BIT_STRING_set(key, keybytes, sizeof(keybytes))
         || !ASN1_INTEGER_set_uint64(serial, (uint64_t)1))


### PR DESCRIPTION
Check for the return X509_NAME_new(), ASN1_BIT_STRING_new() and ASN1_INTEGER_new(), respectively, because they return NULL when fail.
Especially for ASN1_BIT_STRING_new() and ASN1_INTEGER_new(), the memory may be wrongly access by ASN1_BIT_STRING_set() and ASN1_INTEGER_set_uint64() since they do not check the validity of the first argument.