### PR TITLE
speed: Always reset the outlen when calling EVP_PKEY_derive

### DIFF
--- a/apps/speed.c
+++ b/apps/speed.c
@@ -879,11 +879,14 @@ static int FFDH_derive_key_loop(void *args)
     loopargs_t *tempargs = *(loopargs_t **) args;
     EVP_PKEY_CTX *ffdh_ctx = tempargs->ffdh_ctx[testnum];
     unsigned char *derived_secret = tempargs->secret_ff_a;
-    size_t outlen = MAX_FFDH_SIZE;
     int count;
 
-    for (count = 0; COND(ffdh_c[testnum][0]); count++)
+    for (count = 0; COND(ffdh_c[testnum][0]); count++) {
+        /* outlen can be overwritten with too small value (no padding used) */
+        size_t outlen = MAX_FFDH_SIZE;
+
         EVP_PKEY_derive(ffdh_ctx, derived_secret, &outlen);
+    }
     return count;
 }
 #endif /* OPENSSL_NO_DH */

--- a/apps/speed.c
+++ b/apps/speed.c
@@ -882,7 +882,7 @@ static int FFDH_derive_key_loop(void *args)
     int count;
 
     for (count = 0; COND(ffdh_c[testnum][0]); count++) {
-        /* outlen can be overwritten with too small value (no padding used) */
+        /* outlen can be overwritten with a too small value (no padding used) */
         size_t outlen = MAX_FFDH_SIZE;
 
         EVP_PKEY_derive(ffdh_ctx, derived_secret, &outlen);


### PR DESCRIPTION
Fixes #18768
