### PR TITLE
Base64 doc fixes and extensions

### DIFF
--- a/doc/man1/openssl-enc.pod.in
+++ b/doc/man1/openssl-enc.pod.in
@@ -444,8 +444,9 @@ or
 =head1 BUGS
 
 The B<-A> option when used with large files doesn't work properly.
-On the other hand, when the B<-A> option is not given,
-decoding goes wrong if there is no newline among the first 1024 bytes of input.
+On the other hand, when base64 decoding without the B<-A> option,
+if the first 1024 bytes of input do not include a newline character
+the first two lines of input are ignored.
 
 The B<openssl enc> command only supports a fixed number of algorithms with
 certain parameters. So if, for example, you want to use RC2 with a

--- a/doc/man1/openssl-enc.pod.in
+++ b/doc/man1/openssl-enc.pod.in
@@ -97,13 +97,19 @@ Base64 process the data. This means that if encryption is taking place
 the data is base64 encoded after encryption. If decryption is set then
 the input data is base64 decoded before being decrypted.
 
+When the B<-A> option not given,
+on encoding a newline is inserted after each 64 characters, and
+on decoding a newline is expected among the first 1024 bytes of input.
+
 =item B<-base64>
 
 Same as B<-a>
 
 =item B<-A>
 
-If the B<-a> option is set then base64 process the data on one line.
+If the B<-a> option is set then base64 encoding produces output without any
+newline character, and base64 decoding does not require any newlines.
+Therefore it can be helpful to use the B<-A> option when decoding unknown input.
 
 =item B<-k> I<password>
 
@@ -438,6 +444,8 @@ or
 =head1 BUGS
 
 The B<-A> option when used with large files doesn't work properly.
+On the other hand, when the B<-A> option is not given,
+decoding goes wrong if there is no newline among the first 1024 bytes of input.
 
 The B<openssl enc> command only supports a fixed number of algorithms with
 certain parameters. So if, for example, you want to use RC2 with a

--- a/doc/man3/BIO_f_base64.pod
+++ b/doc/man3/BIO_f_base64.pod
@@ -21,15 +21,15 @@ any data read through it.
 
 Base64 BIOs do not support BIO_gets() or BIO_puts().
 
-For writing, output is by default divided to lines of length 64
-characters and there is always a newline at the end of output.
-
-For reading, first line should be at most 1024
-characters long. If it is longer then it is ignored completely.
-Other input lines can be of any length. There must be a newline
-at the end of input.
-
+For writing, by default output is divided to lines of length 64
+characters and there is a newline at the end of output.
 This behavior can be changed with BIO_FLAGS_BASE64_NO_NL flag.
+
+For reading, first line should be at most 1024 bytes long
+unless the flag BIO_FLAGS_BASE64_NO_NL is set.
+If it is longer then it is ignored completely, along with the next line.
+Further input lines can be of any length (i.e., newlines may appear anywhere
+in the input) and a newline at the end of input is not needed.
 
 BIO_flush() on a base64 BIO that is being written through is
 used to signal that no more data is to be encoded: this is used
@@ -38,8 +38,7 @@ to flush the final block through the BIO.
 The flag BIO_FLAGS_BASE64_NO_NL can be set with BIO_set_flags().
 For writing, it causes all data to be written on one line without
 newline at the end.
-For reading, it expects the data to be all on one line (with or
-without a trailing newline).
+For reading, it removes all expectations on newlines in the input data.
 
 =head1 NOTES
 

--- a/doc/man3/BIO_f_base64.pod
+++ b/doc/man3/BIO_f_base64.pod
@@ -23,11 +23,10 @@ Base64 BIOs do not support BIO_gets() or BIO_puts().
 
 For writing, by default output is divided to lines of length 64
 characters and there is a newline at the end of output.
-This behavior can be changed with BIO_FLAGS_BASE64_NO_NL flag.
+This behavior can be changed with B<BIO_FLAGS_BASE64_NO_NL> flag.
 
-For reading, first line should be at most 1024 bytes long
-unless the flag BIO_FLAGS_BASE64_NO_NL is set.
-If it is longer then it is ignored completely, along with the next line.
+For reading, first line should be at most 1024 bytes long including newline
+unless the flag B<BIO_FLAGS_BASE64_NO_NL> is set.
 Further input lines can be of any length (i.e., newlines may appear anywhere
 in the input) and a newline at the end of input is not needed.
 
@@ -35,7 +34,7 @@ BIO_flush() on a base64 BIO that is being written through is
 used to signal that no more data is to be encoded: this is used
 to flush the final block through the BIO.
 
-The flag BIO_FLAGS_BASE64_NO_NL can be set with BIO_set_flags().
+The flag B<BIO_FLAGS_BASE64_NO_NL> can be set with BIO_set_flags().
 For writing, it causes all data to be written on one line without
 newline at the end.
 For reading, it removes all expectations on newlines in the input data.
@@ -83,6 +82,10 @@ data to standard output:
  BIO_free_all(b64);
 
 =head1 BUGS
+
+On decoding, if the flag B<BIO_FLAGS_BASE64_NO_NL> is not set and
+the first 1024 bytes of input do not include a newline character
+the first two lines of input are ignored.
 
 The ambiguity of EOF in base64 encoded data can cause additional
 data following the base64 encoded block to be misinterpreted.


### PR DESCRIPTION
*  `BIO_f_base64.pod` and `openssl-enc.pod.in`: improve description on newline handling
* ~`crypto/evp/bio_b64.c`: improve coding style~

This PR is related to #18780 but does not fix the issues reported there.