### PR TITLE
Fix EC ASM flag passing

### DIFF
--- a/crypto/ec/build.info
+++ b/crypto/ec/build.info
@@ -71,6 +71,14 @@ SOURCE[../../providers/libfips.a]=$COMMON
 # need to be applied to all affected libraries and modules.
 DEFINE[../../libcrypto]=$ECDEF
 DEFINE[../../providers/libfips.a]=$ECDEF
+DEFINE[../../providers/libdefault.a]=$ECDEF
+# We only need to include the ECDEF stuff in the legacy provider when
+# it's a separate module and it's dynamically linked with libcrypto.
+# Otherwise, it already gets everything that the static libcrypto.a
+# has, and doesn't need it added again.
+IF[{- !$disabled{module} && !$disabled{shared} -}]
+  DEFINE[../providers/liblegacy.a]=$ECDEF
+ENDIF
 
 GENERATE[ecp_nistz256-x86.S]=asm/ecp_nistz256-x86.pl
 


### PR DESCRIPTION
Flags for ASM implementations of EC curves were only passed to the FIPS
provider and not to the default or legacy provider.  This left some potential
for optimization.  Pass the correct flags also to these providers.

Signed-off-by: Juergen Christ <jchrist@linux.ibm.com>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->