### PR TITLE
Don't use a non-resumable session if it is returned from the cache

### DIFF
--- a/ssl/ssl_sess.c
+++ b/ssl/ssl_sess.c
@@ -520,6 +520,13 @@ SSL_SESSION *lookup_sess_in_cache(SSL_CONNECTION *s,
                                              sess_id, sess_id_len, &copy);
 
         if (ret != NULL) {
+            if (ret->not_resumable) {
+                /* If its not resumable then ignore this session */
+                if (!copy) {
+                    SSL_SESSION_free(ret);
+                }
+                return NULL;
+            }
             ssl_tsan_counter(s->session_ctx,
                              &s->session_ctx->stats.sess_cb_hit);
 

--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -2358,9 +2358,8 @@ int tls_construct_server_hello(SSL_CONNECTION *s, WPACKET *pkt)
      * so the following won't overwrite an ID that we're supposed
      * to send back.
      */
-    if (s->session->not_resumable ||
-        (!(SSL_CONNECTION_GET_CTX(s)->session_cache_mode & SSL_SESS_CACHE_SERVER)
-         && !s->hit))
+    if (!(SSL_CONNECTION_GET_CTX(s)->session_cache_mode & SSL_SESS_CACHE_SERVER)
+         && !s->hit)
         s->session->session_id_length = 0;
 
     if (usetls13) {

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -8665,12 +8665,12 @@ static int test_session_cache_overflow(int idx)
 #ifdef OPENSSL_NO_TLS1_3
     /* If no TLSv1.3 available then do nothing in this case */
     if (idx % 2 == 0)
-        return 1;
+        return TEST_skip("No TLSv1.3 available");
 #endif
 #ifdef OPENSSL_NO_TLS1_2
     /* If no TLSv1.2 available then do nothing in this case */
     if (idx % 2 == 1)
-        return 1;
+        return TEST_skip("No TLSv1.2 available");
 #endif
 
     if (!TEST_true(create_ssl_ctx_pair(libctx, TLS_server_method(),

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -8654,6 +8654,7 @@ static int test_session_timeout(int test)
  * Test 2: TLSv1.3, timeout on new session earlier than old session
  * Test 3: TLSv1.2, timeout on new session earlier than old session
  */
+#if !defined(OSSL_NO_USABLE_TLS1_3) || !defined(OPENSSL_NO_TLS1_2)
 static int test_session_cache_overflow(int idx)
 {
     SSL_CTX *sctx = NULL, *cctx = NULL;
@@ -8761,6 +8762,7 @@ static int test_session_cache_overflow(int idx)
 
     return testresult;
 }
+#endif /* !defined(OSSL_NO_USABLE_TLS1_3) || !defined(OPENSSL_NO_TLS1_2) */
 
 /*
  * Test 0: Client sets servername and server acknowledges it (TLSv1.2)
@@ -10209,7 +10211,9 @@ int setup_tests(void)
     ADD_TEST(test_set_verify_cert_store_ssl_ctx);
     ADD_TEST(test_set_verify_cert_store_ssl);
     ADD_ALL_TESTS(test_session_timeout, 1);
+#if !defined(OSSL_NO_USABLE_TLS1_3) || !defined(OPENSSL_NO_TLS1_2)
     ADD_ALL_TESTS(test_session_cache_overflow, 4);
+#endif
     ADD_TEST(test_load_dhfile);
     return 1;
 


### PR DESCRIPTION
We were incorrectly handling the case where the server side cache
returns a non-resumable session. We ended up attempting to use the session
for resumption but setting the session id to 0 length. This will cause the
client to fail (typically with an unexpected message alert).

Fixes #18690
