### PR TITLE
`check-format.pl`: improve handling of preprocessor directives like `#define`, etc.

### DIFF
--- a/util/check-format-test-negatives.c
+++ b/util/check-format-test-negatives.c
@@ -32,6 +32,9 @@
  */
 /** allow extra '*' in comment opening */
 /*! allow extra '!' in comment opening */
+/*
+ ** allow "**" as first non-space chars of a line within multi-line comment
+ */
 
 int f(void) /*
              * trailing multi-line comment
@@ -260,10 +263,11 @@ X509 *x509 = NULL;
 int y = a + 1 < b;
 int ret, was_NULL = *certs == NULL;
 
-/* should not trigger: no space before binary ... operator */
+/* should not trigger: missing space before ... */
 float z = 1e-6 * (-1) * b[+6] * 1e+1 * (a)->f * (long)+1
     - (tmstart.tv_sec + tmstart.tv_nsec * 1e-9);
 struct st = {-1, 0};
+int x = (y <<= 1) + (z <= 5.0);
 
 const OPTIONS passwd_options[] = {
     {"aixmd5", OPT_AIXMD5, '-', "AIX MD5-based password algorithm"},

--- a/util/check-format-test-negatives.c
+++ b/util/check-format-test-negatives.c
@@ -117,17 +117,24 @@ int g(void)
         /* leading comment has same indentation as normal code */ stmt;
         /* entire-line comment may have same indent as normal code */
     }
-
-    for (;;)
-        ;
-    for (i = 0;;)
-        ;
-    for (i = 0; i < 1;)
-        ;
-    for (;;)
+    for (i = 0; i < n; i++)
         for (; i < n; i++)
-            for (;; p++)
-                ;
+            for (i = 0; ; i++)
+                for (i = 0;; i++)
+                    for (i = 0; i < n; )
+                        for (i = 0; i < n;)
+                            ;
+    for (i = 0; ; )
+        for (i = 0; ;)
+            for (i = 0;; )
+                for (i = 0;;)
+                    for (; i < n; )
+                        for (; j < n;)
+                            for (; ; i++)
+                                for (;; i++)
+                                    ;
+    for (;;) /* the only variant allowed in case of "empty" for (...) */
+        ;
     for (;;) ; /* should not trigger: space before ';' */
  lab: ;  /* should not trigger: space before ';' */
 

--- a/util/check-format-test-negatives.c
+++ b/util/check-format-test-negatives.c
@@ -30,6 +30,9 @@
 /*-
  * allow extra  SPC in format-tagged multi-line comment
  */
+/** allow extra '*' in comment opening */
+/*! allow extra '!' in comment opening */
+
 int f(void) /*
              * trailing multi-line comment
              */

--- a/util/check-format-test-negatives.c
+++ b/util/check-format-test-negatives.c
@@ -13,6 +13,7 @@
  * There are some known false positives, though, which are marked below.
  */
 
+#include <errno.h> /* should not report whitespace nits within <...> */
 #define F                                       \
     void f()                                    \
     {                                           \
@@ -22,8 +23,12 @@
         return;                                 \
     }
 
+/* allow extra  SPC in single-line comment */
 /*-
- * allow extra SPC in format-tagged multi-line comment
+ * allow extra  SPC in regular multi-line comment
+ */
+/*-
+ * allow extra  SPC in format-tagged multi-line comment
  */
 int f(void) /*
              * trailing multi-line comment
@@ -236,6 +241,9 @@ int g(void)
             && expr_line3)
         hanging_stmt;
 }
+#define m \
+    do { /* should not be confused with function header followed by '{' */ \
+    } while (0)
 
 /* should not trigger: constant on LHS of comparison or assignment operator */
 X509 *x509 = NULL;
@@ -268,6 +276,47 @@ x;
 typedef OSSL_CMP_MSG *(*cmp_srv_process_cb_t)
     (OSSL_CMP_SRV_CTX *ctx, OSSL_CMP_MSG *msg)
     xx;
+
+#define IF(cond) if (cond)
+
+_Pragma("GCC diagnostic push")
+_Pragma("GCC diagnostic pop")
+
+#define CB_ERR_IF(cond, ctx, cert, depth, err) \
+    if ((cond) && ((depth) < 0 || verify_cb_cert(ctx, cert, depth, err) == 0)) \
+        return err
+static int verify_cb_crl(X509_STORE_CTX *ctx, int err)
+{
+    ctx->error = err;
+    return ctx->verify_cb(0, ctx);
+}
+
+#ifdef CMP_FALLBACK_EST
+# define CMP_FALLBACK_CERT_FILE "cert.pem"
+#endif
+
+#define X509_OBJECT_get0_X509(obj)                                      \
+    ((obj) == NULL || (obj)->type != X509_LU_X509 ? NULL : (obj)->data.x509)
+#define X509_STORE_CTX_set_current_cert(ctx, x) { (ctx)->current_cert = (x); }
+#define X509_STORE_set_ex_data(ctx, idx, data) \
+    CRYPTO_set_ex_data(&(ctx)->ex_data, (idx), (data))
+
+typedef int (*X509_STORE_CTX_check_revocation_fn)(X509_STORE_CTX *ctx);
+#define X509_STORE_CTX_set_error_depth(ctx, depth) \
+    { (ctx)->error_depth = (depth); }
+#define EVP_PKEY_up_ref(x) ((x)->references++)
+/* should not report missing blank line: */
+DECLARE_STACK_OF(OPENSSL_CSTRING)
+bool UTIL_iterate_dir(int (*fn)(const char *file, void *arg), void *arg,
+                      const char *path, bool recursive);
+size_t UTIL_url_encode(
+                       size_t *size_needed
+                       );
+size_t UTIL_url_encode(const char  *source,
+                       char        *destination,
+                       size_t      destination_len,
+                       size_t      *size_needed);
+#error well. oops.
 
 int f()
 {

--- a/util/check-format-test-negatives.c
+++ b/util/check-format-test-negatives.c
@@ -24,7 +24,7 @@
     }
 
 /* allow extra  SPC in single-line comment */
-/*-
+/*
  * allow extra  SPC in regular multi-line comment
  */
 /*-

--- a/util/check-format-test-positives.c
+++ b/util/check-format-test-positives.c
@@ -47,10 +47,12 @@
 */ /*@ unexpected comment ending delimiter outside comment */
 /*@ comment line is 4 columns tooooooooooooooooo wide, reported unless sloppy-len */
 /*@ comment line is 5 columns toooooooooooooooooooooooooooooooooooooooooooooo wide */
-#define X   1       /*@0 extra space false negative due to coincidence */
- #define Y  2       /*@ indent of preprocessor directive off by 1 (must be 0) */
+#define X (1 +  1)  /*@0 extra space in body, reported unless sloppy-spc */
+#define X   1       /*@ extra space before body, reported unless sloppy-spc */
+ #define Y 2        /*@2 indent of preproc. directive off by 1 (must be 0) */ \
+#define Z           /*@ preprocessor directive within multi-line directive */
 typedef struct  {   /*@0 extra space in code, reported unless sloppy-spc */
-    enum {          /*@1 extra space  in comment, reported unless sloppy-spc */
+    enum {          /*@1 extra space  in comment, no more reported */
            w = 0 /*@ hanging expr indent off by 1, or 3 for lines after '{' */
              && 1,  /*@ hanging expr indent off by 3, or -1 for leading '&&' */
          x = 1,     /*@ hanging expr indent off by -1 */

--- a/util/check-format-test-positives.c
+++ b/util/check-format-test-positives.c
@@ -108,8 +108,10 @@ int f (int a,       /*@ space after fn before '(', reported unless sloppy-spc */
           /*@0 intra-line comment indent off by -1 (not: by 3 due to '&&') */
            && ! 0   /*@2 space after '!', reported unless sloppy-spc */
          || b ==    /*@ hanging expr indent off by 2, or -2 for leading '||' */
+       (x<<= 1) +   /*@ missing space before '<<=' reported unless sloppy-spc */
        (xx+= 2) +   /*@ missing space before '+=', reported unless sloppy-spc */
        (a^ 1) +     /*@ missing space before '^', reported unless sloppy-spc */
+       (y *=z) +    /*@ missing space after '*=' reported unless sloppy-spc */
        a %2 /       /*@ missing space after '%', reported unless sloppy-spc */
        1 +/* */     /*@ no space before comment, reported unless sloppy-spc */
        /* */+       /*@ no space after comment, reported unless sloppy-spc */

--- a/util/check-format-test-positives.c
+++ b/util/check-format-test-positives.c
@@ -40,19 +40,21 @@
  *@ comment starting delimiter: /* inside multi-line comment
 *@ multi-line comment indent off by -1
  *X*@ no spc after leading '*' in multi-line comment, reported unless sloppy-spc
- *@0 more than two spaces after .   in comment, reported unless sloppy-spc
- *@0 more than two spaces after ?   in comment, reported unless sloppy-spc
- *@0 more than two spaces after !   in comment, reported unless sloppy-spc
+ *@0 more than two spaces after .   in comment, no more reported
+ *@0 more than two spaces after ?   in comment, no more reported
+ *@0 more than two spaces after !   in comment, no more reported
 */ /*@ multi-line comment end indent off by -1 (relative to comment start) */
 */ /*@ unexpected comment ending delimiter outside comment */
+/*- '-' for formatted comment not allowed in intra-line comment */
 /*@ comment line is 4 columns tooooooooooooooooo wide, reported unless sloppy-len */
 /*@ comment line is 5 columns toooooooooooooooooooooooooooooooooooooooooooooo wide */
+#if ~0              /*@ '#if' with constant condition */
+ #endif             /*@ indent of preproc. directive off by 1 (must be 0) */
 #define X (1 +  1)  /*@0 extra space in body, reported unless sloppy-spc */
-#define X   1       /*@ extra space before body, reported unless sloppy-spc */
- #define Y 2        /*@2 indent of preproc. directive off by 1 (must be 0) */ \
-#define Z           /*@ preprocessor directive within multi-line directive */
+#define Y   1       /*@ extra space before body, reported unless sloppy-spc */ \
+#define Z           /*@2 preprocessor directive within multi-line directive */
 typedef struct  {   /*@0 extra space in code, reported unless sloppy-spc */
-    enum {          /*@1 extra space  in comment, no more reported */
+    enum {          /*@1 extra space  in intra-line comment, no more reported */
            w = 0 /*@ hanging expr indent off by 1, or 3 for lines after '{' */
              && 1,  /*@ hanging expr indent off by 3, or -1 for leading '&&' */
          x = 1,     /*@ hanging expr indent off by -1 */
@@ -344,7 +346,7 @@ void f_looong_body()
 
     ;               /*@ 2 essentially blank lines before, if !sloppy-spc */
 }                   /*@ function body length > 200 lines */
-#if 0               /*@0 unclosed #if */
+#if X               /*@0 unclosed #if */
 struct t {          /*@0 unclosed brace at decl/block level */
     enum {          /*@0 unclosed brace at enum/expression level */
           v = (1    /*@0 unclosed parenthesis */

--- a/util/check-format-test-positives.c
+++ b/util/check-format-test-positives.c
@@ -29,8 +29,8 @@
 /*@ whitespace at EOL: */ 
 // /*@ end-of-line comment style not allowed (for C90 compatibility) */
  /*@0 intra-line comment indent off by 1, reported unless sloppy-cmt */
-/*X */ /*@2 no space nor '*' after comment start, reported unless sloppy-spc */
-/* X*/ /*@ no space before comment end , reported unless sloppy-spc */
+/*X */ /*@2 missing spc or '*' after comment start reported unless sloppy-spc */
+/* X*/ /*@ missing space before comment end , reported unless sloppy-spc */
 /*@ comment starting delimiter: /* inside intra-line comment */
  /*@0
   *@ above multi-line comment start indent off by 1, reported unless sloppy-cmt; this comment line is too long
@@ -67,7 +67,9 @@ typedef struct  {   /*@0 extra space in code, reported unless sloppy-spc */
     } s_type;       /*@ statement/type declaration indent off by 4 */
 int* somefunc();    /*@ no space before '*' in type decl, r unless sloppy-spc */
 void main(int n) {  /*@ opening brace at end of function definition header */
-    for (;;n++) {   /*@ no space after ';', reported unless sloppy-spc */
+    for (; ; ) ;    /*@ space before ')', reported unless sloppy-spc */
+    for ( ; x; y) ; /*@2 space after '(' and before ';', unless sloppy-spc */
+    for (;;n++) {   /*@ missing space after ';', reported unless sloppy-spc */
         return;     /*@0 (1-line) single statement in braces */
     }}              /*@2 code after '}' outside expr */
 }                   /*@ unexpected closing brace (too many '}') outside expr */
@@ -102,13 +104,13 @@ int f (int a,       /*@ space after fn before '(', reported unless sloppy-spc */
 # define MAC(A) (A) /*@ nesting indent of preprocessor directive off by 1 */
              ? 1    /*@ hanging expr indent off by 1 */
               : 2); /*@ hanging expr indent off by 2, or 1 for leading ':' */
-    if(a            /*@ no space after 'if', reported unless sloppy-spc */
+    if(a            /*@ missing space after 'if', reported unless sloppy-spc */
           /*@0 intra-line comment indent off by -1 (not: by 3 due to '&&') */
            && ! 0   /*@2 space after '!', reported unless sloppy-spc */
          || b ==    /*@ hanging expr indent off by 2, or -2 for leading '||' */
-       (xx+= 2) +   /*@ no space before '+=', reported unless sloppy-spc */
-       (a^ 1) +     /*@ no space before '^', reported unless sloppy-spc */
-       a %2 /       /*@ no space after '%', reported unless sloppy-spc */
+       (xx+= 2) +   /*@ missing space before '+=', reported unless sloppy-spc */
+       (a^ 1) +     /*@ missing space before '^', reported unless sloppy-spc */
+       a %2 /       /*@ missing space after '%', reported unless sloppy-spc */
        1 +/* */     /*@ no space before comment, reported unless sloppy-spc */
        /* */+       /*@ no space after comment, reported unless sloppy-spc */
        s. e_member) /*@ space after '.', reported unless sloppy-spc */
@@ -117,7 +119,7 @@ int f (int a,       /*@ space after fn before '(', reported unless sloppy-spc */
     if (a ++)       /*@ space before postfix '++', reported unless sloppy-spc */
     {               /*@ {' not on same line as preceding 'if' */
         c;          /*@0 single stmt in braces, reported on 1-stmt */
-    } else          /*@ no '{' on same line after '} else' */
+    } else          /*@ missing '{' on same line after '} else' */
       {             /*@ statement indent off by 2 */
         d;          /*@0 single stmt in braces, reported on 1-stmt */
           }         /*@ statement indent off by 6 */
@@ -127,18 +129,18 @@ int f (int a,       /*@ space after fn before '(', reported unless sloppy-spc */
         while ( 2); /*@ space after '(', reported unless sloppy-spc */
     b; c;           /*@ more than one statement per line */
   outer:            /*@ outer label special indent off by 1 */
-    do{             /*@ no space before '{', reported unless sloppy-spc */
+    do{             /*@ missing space before '{', reported unless sloppy-spc */
      inner:         /*@ inner label normal indent off by 1 */
         f (3,       /*@ space after fn before '(', reported unless sloppy-spc */
            4);      /*@0 false negative: should report single stmt in braces */
     }               /*@0 'while' not on same line as preceding '}' */
-    while (a+ 0);   /*@2 no space before '+', reported unless sloppy-spc */
+    while (a+ 0);   /*@2 missing space before '+', reported unless sloppy-spc */
     switch (b ) {   /*@ space before ')', reported unless sloppy-spc */
    case 1:          /*@ 'case' special statement indent off by -1 */
-    case(2):        /*@ no space after 'case', reported unless sloppy-spc */
+    case(2):       /*@ missing space after 'case', reported unless sloppy-spc */
     default: ;      /*@ code after 'default:' */
 }                   /*@ statement indent off by -4 */
-    return(         /*@ no space after 'return', reported unless sloppy-spc */
+    return(      /*@ missing space after 'return', reported unless sloppy-spc */
            x); }    /*@ code before block-level '}' */
 /* Here the tool should stop complaining apart from the below issues at EOF */
 

--- a/util/check-format.pl
+++ b/util/check-format.pl
@@ -771,8 +771,15 @@ while (<>) { # loop over all lines of all input files
         }
         # ignore paths in #include
         $intra_line =~ s/^(include\s*)(".*?"|<.*?>)/$1/e if $head =~ m/#/;
+        report("missing space before '$2'")
+            if $intra_line =~ m/(\S)((<<|>>)=)/ # '<<=' or >>=' without preceding space
+            || ($intra_line =~ m/(\S)([\+\-\*\/\/%\&\|\^\!<>=]=)/
+                && "$1$2" ne "<<=" && "$1$2" ne ">>=") # other <op>= or (in)equality without preceding space
+            || ($intra_line =~ m/(\S)=/
+                && !($1 =~ m/[\+\-\*\/\/%\&\|\^\!<>=]/)
+                && $intra_line =~ m/(\S)(=)/); # otherwise, '=' without preceding space
         # treat op= and comparison operators as simple '=', simplifying matching below
-        $intra_line =~ s/([\+\-\*\/\/%\&\|\^\!<>=]|<<|>>)=/=/g;
+        $intra_line =~ s/(<<|>>|[\+\-\*\/\/%\&\|\^\!<>=])=/=/g;
         # treat (type) variables within macro, indicated by trailing '\', as 'int' simplifying matching below
         $intra_line =~ s/[A-Z_]+/int/g if $trailing_backslash;
         # treat double &&, ||, <<, and >> as single ones, simplifying matching below
@@ -803,7 +810,6 @@ while (<>) { # loop over all lines of all input files
         report("space before '$1'")     if $intra_line =~ m/\s([,)\]])/;       # space before ,)]
         report("space after '$1'")      if $intra_line =~ m/([(\[~!])\s/;      # space after ([~!
         report("space after '$1'")      if $intra_line =~ m/(defined)\s/;      # space after 'defined'
-        report("missing space before '=' or '<op>='") if $intra_line =~ m/\S(=)/;   # '=' etc. without preceding space
         report("missing space before '$1'")  if $intra_line =~ m/\S([|\/%<>^\?])/;  # |/%<>^? without preceding space
         # TODO ternary ':' without preceding SPC, while allowing no SPC before ':' after 'case'
         report("missing space before binary '$2'")  if $intra_line =~ m/([^\s{()\[e])([+\-])/; # '+'/'-' without preceding space or {()[e


### PR DESCRIPTION
* report `#if` and `#elif` with constant condition
* improve checks on comment opening: `/*`
* extend checking into macro bodies and other preprocessor directives
* make sure handling of indentation etc. in preprocessor directives is independent of normal code
* improve detection/handling of trailing backslash and essentially empty lines
* improve detection of function definition headers
* improve whitespace reporting on `<op>=`, including (in-)equality
* further fixes for whitespace reporting within `for (...)`
* add some tests
* better reflect in tests that whitespace nits in comments are no longer reported
* improve wording of some reports
* refactor order of state variables
* small further improvements

- [x] tests are added or updated
