### PR TITLE
Emit rev8 on __riscv_zbkb as on __riscv_zbb

### DIFF
--- a/include/crypto/modes.h
+++ b/include/crypto/modes.h
@@ -74,13 +74,13 @@ typedef unsigned char u8;
                         asm ("rev %0,%1"                \
                         : "=r"(ret_) : "r"((u32)(x)));  \
                         ret_;                           })
-#  elif defined(__riscv_zbb) && __riscv_xlen == 64
+#  elif (defined(__riscv_zbb) || defined(__riscv_zbkb)) && __riscv_xlen == 64
 #   define BSWAP8(x) ({ u64 ret_=(x);                   \
                         asm ("rev8 %0,%0"               \
                         : "+r"(ret_));   ret_;          })
 #   define BSWAP4(x) ({ u32 ret_=(x);                   \
                         asm ("rev8 %0,%0; srli %0,%0,32"\
-                        : "+r"(ret_));   ret_;          })
+                        : "+&r"(ret_));  ret_;          })
 #  endif
 # elif defined(_MSC_VER)
 #  if _MSC_VER>=1300


### PR DESCRIPTION
Also add early clobber for two-insn bswap.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->
