### PR TITLE
Fix re-signing certificates with different key sizes

### DIFF
--- a/apps/x509.c
+++ b/apps/x509.c
@@ -590,7 +590,7 @@ int x509_main(int argc, char **argv)
         xca = load_cert(CAfile, CAformat, "CA Certificate");
         if (xca == NULL)
             goto end;
-        if (!X509_set_issuer_name(x, X509_get_subject_name(xca)))
+        if (reqfile && !X509_set_issuer_name(x, X509_get_subject_name(xca)))
             goto end;
     }
 
@@ -993,6 +993,8 @@ static int x509_certify(X509_STORE *ctx, const char *CAfile, const EVP_MD *diges
         goto end;
     }
 
+    if (!X509_set_issuer_name(x, X509_get_subject_name(xca)))
+        goto end;
     if (!X509_set_serialNumber(x, bs))
         goto end;
 

--- a/test/recipes/25-test_x509.t
+++ b/test/recipes/25-test_x509.t
@@ -15,7 +15,11 @@ use OpenSSL::Test qw/:DEFAULT srctop_file/;
 
 setup("test_x509");
 
-plan tests => 9;
+plan tests => 16;
+
+# Prevent MSys2 filename munging for arguments that look like file paths but
+# aren't
+$ENV{MSYS2_ARG_CONV_EXCL} = "/CN=";
 
 require_ok(srctop_file('test','recipes','tconversion.pl'));
 
@@ -46,4 +50,59 @@ subtest 'x509 -- second x.509 v3 certificate' => sub {
 
 subtest 'x509 -- pathlen' => sub {
     ok(run(test(["v3ext", srctop_file("test/certs", "pathlen.pem")])));
+};
+
+# extracts issuer from a -text formatted-output
+sub get_issuer {
+    my $f = shift(@_);
+    my $issuer = "";
+    open my $fh, $f or die;
+    while (my $line = <$fh>) {
+        if ($line =~ /Issuer:/) {
+            $issuer = $line;
+        }
+    }
+    close $fh;
+    return $issuer;
 }
+
+# Tests for signing certs (broken in 1.1.1o)
+my $a_key = "a-key.pem";
+my $a_cert = "a-cert.pem";
+my $a2_cert = "a2-cert.pem";
+my $ca_key = "ca-key.pem";
+my $ca_cert = "ca-cert.pem";
+my $cnf = srctop_file('apps', 'openssl.cnf');
+
+# Create cert A
+ok(run(app(["openssl", "req", "-x509", "-newkey", "rsa:2048",
+            "-config", $cnf,
+            "-keyout", $a_key, "-out", $a_cert, "-days", "365",
+            "-nodes", "-subj", "/CN=test.example.com"])));
+# Create cert CA - note key size
+ok(run(app(["openssl", "req", "-x509", "-newkey", "rsa:4096",
+            "-config", $cnf,
+            "-keyout", $ca_key, "-out", $ca_cert, "-days", "3650",
+            "-nodes", "-subj", "/CN=ca.example.com"])));
+# Sign cert A with CA (errors on 1.1.1o)
+ok(run(app(["openssl", "x509", "-in", $a_cert, "-CA", $ca_cert,
+            "-CAkey", $ca_key, "-set_serial", "1234567890",
+            "-preserve_dates", "-sha256", "-text", "-out", $a2_cert])));
+# verify issuer is CA
+ok (get_issuer($a2_cert) =~ /CN = ca.example.com/);
+
+# Tests for issue #16080 (fixed in 1.1.1o)
+my $b_key = "b-key.pem";
+my $b_csr = "b-cert.csr";
+my $b_cert = "b-cert.pem";
+# Create the CSR
+ok(run(app(["openssl", "req", "-new", "-newkey", "rsa:4096",
+            "-keyout", $b_key, "-out", $b_csr, "-nodes",
+            "-config", $cnf,
+            "-subj", "/CN=b.example.com"])));
+# Sign it - position of "-text" matters!
+ok(run(app(["openssl", "x509", "-req", "-text", "-CAcreateserial",
+            "-CA", $ca_cert, "-CAkey", $ca_key,
+            "-in", $b_csr, "-out", $b_cert])));
+# Verify issuer is CA
+ok(get_issuer($b_cert) =~ /CN = ca.example.com/);


### PR DESCRIPTION
PR #18129 broke the scenario of signing a certificate (not CSR) with
different-sized key. This works in 3.0, so port the fix from 3.0
(which is to only update the issuer for a request).

Partially undo #18129, but keep setting the issuer only for a CSR

Create two certs (a and ca) then sign a with c (into b):
```
openssl req -x509 -newkey rsa:2048 -keyout a-key.pem -out a-cert.pem -days 365 -nodes -subj /CN=a.example.com
openssl req -x509 -newkey rsa:4096 -keyout ca-key.pem -out ca-cert.pem -days 3650 -nodes -subj /CN=ca.example.com
openssl x509 -in a-cert.pem -CA ca-cert.pem -CAkey ca-key.pem -set_serial '1234567890' -preserve_dates -sha256 -out b-cert.pem
```
The above succeeds in 1.1.1n and 3.0, fails in 1.1.1o (which includes #18129)
The issue in #16080 is also fixed.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
