### PR TITLE
`x590_lu.c` and `x509_vfy.c`: improve coding style, comments, and related doc

### DIFF
--- a/doc/man3/X509_STORE_CTX_new.pod
+++ b/doc/man3/X509_STORE_CTX_new.pod
@@ -74,6 +74,7 @@ X509_STORE_CTX_free() completely frees up I<ctx>. After this call I<ctx>
 is no longer valid.
 If I<ctx> is NULL nothing is done.
 
+X509_STORE_CTX_init() sets up I<ctx> for a subsequent verification operation.
 It must be called before each call to L<X509_verify_cert(3)> or
 L<X509_STORE_CTX_verify(3)>, i.e., a context is only good for one verification.
 If you want to verify a further certificate or chain with the same I<ctx>

--- a/doc/man3/X509_STORE_add_cert.pod
+++ b/doc/man3/X509_STORE_add_cert.pod
@@ -18,30 +18,30 @@ X509_STORE_load_locations_ex, X509_STORE_load_locations
 
  typedef x509_store_st X509_STORE;
 
- int X509_STORE_add_cert(X509_STORE *ctx, X509 *x);
- int X509_STORE_add_crl(X509_STORE *ctx, X509_CRL *x);
+ int X509_STORE_add_cert(X509_STORE *xs, X509 *x);
+ int X509_STORE_add_crl(X509_STORE *xs, X509_CRL *x);
  int X509_STORE_set_depth(X509_STORE *store, int depth);
- int X509_STORE_set_flags(X509_STORE *ctx, unsigned long flags);
- int X509_STORE_set_purpose(X509_STORE *ctx, int purpose);
- int X509_STORE_set_trust(X509_STORE *ctx, int trust);
+ int X509_STORE_set_flags(X509_STORE *xs, unsigned long flags);
+ int X509_STORE_set_purpose(X509_STORE *xs, int purpose);
+ int X509_STORE_set_trust(X509_STORE *xs, int trust);
 
  X509_LOOKUP *X509_STORE_add_lookup(X509_STORE *store,
                                     X509_LOOKUP_METHOD *meth);
 
- int X509_STORE_set_default_paths_ex(X509_STORE *ctx, OSSL_LIB_CTX *libctx,
+ int X509_STORE_set_default_paths_ex(X509_STORE *xs, OSSL_LIB_CTX *libctx,
                                      const char *propq);
- int X509_STORE_set_default_paths(X509_STORE *ctx);
- int X509_STORE_load_file_ex(X509_STORE *ctx, const char *file,
+ int X509_STORE_set_default_paths(X509_STORE *xs);
+ int X509_STORE_load_file_ex(X509_STORE *xs, const char *file,
                              OSSL_LIB_CTX *libctx, const char *propq);
- int X509_STORE_load_file(X509_STORE *ctx, const char *file);
- int X509_STORE_load_path(X509_STORE *ctx, const char *dir);
- int X509_STORE_load_store_ex(X509_STORE *ctx, const char *uri,
+ int X509_STORE_load_file(X509_STORE *xs, const char *file);
+ int X509_STORE_load_path(X509_STORE *xs, const char *dir);
+ int X509_STORE_load_store_ex(X509_STORE *xs, const char *uri,
                               OSSL_LIB_CTX *libctx, const char *propq);
- int X509_STORE_load_store(X509_STORE *ctx, const char *uri);
- int X509_STORE_load_locations_ex(X509_STORE *ctx, const char *file,
+ int X509_STORE_load_store(X509_STORE *xs, const char *uri);
+ int X509_STORE_load_locations_ex(X509_STORE *xs, const char *file,
                                   const char *dir, OSSL_LIB_CTX *libctx,
                                   const char *propq);
- int X509_STORE_load_locations(X509_STORE *ctx,
+ int X509_STORE_load_locations(X509_STORE *xs,
                                const char *file, const char *dir);
 
 =head1 DESCRIPTION

--- a/doc/man3/X509_STORE_get0_param.pod
+++ b/doc/man3/X509_STORE_get0_param.pod
@@ -10,18 +10,17 @@ X509_STORE_get0_objects, X509_STORE_get1_all_certs
 
  #include <openssl/x509_vfy.h>
 
- X509_VERIFY_PARAM *X509_STORE_get0_param(const X509_STORE *ctx);
- int X509_STORE_set1_param(X509_STORE *ctx, const X509_VERIFY_PARAM *pm);
- STACK_OF(X509_OBJECT) *X509_STORE_get0_objects(const X509_STORE *ctx);
- STACK_OF(X509) *X509_STORE_get1_all_certs(X509_STORE *st);
+ X509_VERIFY_PARAM *X509_STORE_get0_param(const X509_STORE *xs);
+ int X509_STORE_set1_param(X509_STORE *xs, const X509_VERIFY_PARAM *pm);
+ STACK_OF(X509_OBJECT) *X509_STORE_get0_objects(const X509_STORE *xs);
+ STACK_OF(X509) *X509_STORE_get1_all_certs(X509_STORE *xs);
 
 =head1 DESCRIPTION
 
-X509_STORE_set1_param() sets the verification parameters
-to B<pm> for B<ctx>.
+X509_STORE_set1_param() sets the verification parameters to I<pm> for I<xs>.
 
 X509_STORE_get0_param() retrieves an internal pointer to the verification
-parameters for B<ctx>. The returned pointer must not be freed by the
+parameters for I<xs>. The returned pointer must not be freed by the
 calling application
 
 X509_STORE_get0_objects() retrieves an internal pointer to the store's

--- a/doc/man3/X509_STORE_new.pod
+++ b/doc/man3/X509_STORE_new.pod
@@ -11,10 +11,10 @@ X509_STORE_lock,X509_STORE_unlock
  #include <openssl/x509_vfy.h>
 
  X509_STORE *X509_STORE_new(void);
- void X509_STORE_free(X509_STORE *v);
- int X509_STORE_lock(X509_STORE *v);
- int X509_STORE_unlock(X509_STORE *v);
- int X509_STORE_up_ref(X509_STORE *v);
+ void X509_STORE_free(X509_STORE *xs);
+ int X509_STORE_lock(X509_STORE *xs);
+ int X509_STORE_unlock(X509_STORE *xs);
+ int X509_STORE_up_ref(X509_STORE *xs);
 
 =head1 DESCRIPTION
 

--- a/doc/man3/X509_STORE_set_verify_cb_func.pod
+++ b/doc/man3/X509_STORE_set_verify_cb_func.pod
@@ -58,78 +58,78 @@ X509_STORE_CTX_lookup_certs_fn, X509_STORE_CTX_lookup_crls_fn
                                                               const X509_NAME *nm);
  typedef int (*X509_STORE_CTX_cleanup_fn)(X509_STORE_CTX *ctx);
 
- void X509_STORE_set_verify_cb(X509_STORE *ctx,
+ void X509_STORE_set_verify_cb(X509_STORE *xs,
                                X509_STORE_CTX_verify_cb verify_cb);
  X509_STORE_CTX_verify_cb X509_STORE_get_verify_cb(const X509_STORE_CTX *ctx);
 
- void X509_STORE_set_verify(X509_STORE *ctx, X509_STORE_CTX_verify_fn verify);
+ void X509_STORE_set_verify(X509_STORE *xs, X509_STORE_CTX_verify_fn verify);
  X509_STORE_CTX_verify_fn X509_STORE_CTX_get_verify(const X509_STORE_CTX *ctx);
 
  int X509_STORE_CTX_get1_issuer(X509 **issuer, X509_STORE_CTX *ctx, X509 *x);
  X509_STORE_CTX_get_issuer_fn X509_STORE_get_get_issuer(const X509_STORE_CTX *ctx);
- void X509_STORE_set_get_issuer(X509_STORE *ctx,
+ void X509_STORE_set_get_issuer(X509_STORE *xs,
                                 X509_STORE_CTX_get_issuer_fn get_issuer);
 
- void X509_STORE_set_check_issued(X509_STORE *ctx,
+ void X509_STORE_set_check_issued(X509_STORE *xs,
                                   X509_STORE_CTX_check_issued_fn check_issued);
  X509_STORE_CTX_check_issued_fn
      X509_STORE_get_check_issued(const X509_STORE_CTX *ctx);
 
- void X509_STORE_set_check_revocation(X509_STORE *ctx,
+ void X509_STORE_set_check_revocation(X509_STORE *xs,
                                       X509_STORE_CTX_check_revocation_fn check_revocation);
  X509_STORE_CTX_check_revocation_fn
      X509_STORE_get_check_revocation(const X509_STORE_CTX *ctx);
 
- void X509_STORE_set_get_crl(X509_STORE *ctx,
+ void X509_STORE_set_get_crl(X509_STORE *xs,
                              X509_STORE_CTX_get_crl_fn get_crl);
  X509_STORE_CTX_get_crl_fn X509_STORE_get_get_crl(const X509_STORE_CTX *ctx);
 
- void X509_STORE_set_check_crl(X509_STORE *ctx,
+ void X509_STORE_set_check_crl(X509_STORE *xs,
                                X509_STORE_CTX_check_crl_fn check_crl);
  X509_STORE_CTX_check_crl_fn
      X509_STORE_get_check_crl(const X509_STORE_CTX *ctx);
 
- void X509_STORE_set_cert_crl(X509_STORE *ctx,
+ void X509_STORE_set_cert_crl(X509_STORE *xs,
                               X509_STORE_CTX_cert_crl_fn cert_crl);
  X509_STORE_CTX_cert_crl_fn X509_STORE_get_cert_crl(const X509_STORE_CTX *ctx);
 
- void X509_STORE_set_check_policy(X509_STORE *ctx,
+ void X509_STORE_set_check_policy(X509_STORE *xs,
                                   X509_STORE_CTX_check_policy_fn check_policy);
  X509_STORE_CTX_check_policy_fn
      X509_STORE_get_check_policy(const X509_STORE_CTX *ctx);
 
- void X509_STORE_set_lookup_certs(X509_STORE *ctx,
+ void X509_STORE_set_lookup_certs(X509_STORE *xs,
                                   X509_STORE_CTX_lookup_certs_fn lookup_certs);
  X509_STORE_CTX_lookup_certs_fn
      X509_STORE_get_lookup_certs(const X509_STORE_CTX *ctx);
 
- void X509_STORE_set_lookup_crls(X509_STORE *ctx,
+ void X509_STORE_set_lookup_crls(X509_STORE *xs,
                                  X509_STORE_CTX_lookup_crls_fn lookup_crls);
  X509_STORE_CTX_lookup_crls_fn
      X509_STORE_get_lookup_crls(const X509_STORE_CTX *ctx);
 
- void X509_STORE_set_cleanup(X509_STORE *ctx,
+ void X509_STORE_set_cleanup(X509_STORE *xs,
                              X509_STORE_CTX_cleanup_fn cleanup);
  X509_STORE_CTX_cleanup_fn X509_STORE_get_cleanup(const X509_STORE_CTX *ctx);
 
  /* Aliases */
  void X509_STORE_set_verify_cb_func(X509_STORE *st,
                                     X509_STORE_CTX_verify_cb verify_cb);
- void X509_STORE_set_verify_func(X509_STORE *ctx,
+ void X509_STORE_set_verify_func(X509_STORE *xs,
                                  X509_STORE_CTX_verify_fn verify);
- void X509_STORE_set_lookup_crls_cb(X509_STORE *ctx,
+ void X509_STORE_set_lookup_crls_cb(X509_STORE *xs,
                                     X509_STORE_CTX_lookup_crls_fn lookup_crls);
 
 =head1 DESCRIPTION
 
-X509_STORE_set_verify_cb() sets the verification callback of I<ctx> to
+X509_STORE_set_verify_cb() sets the verification callback of I<xs> to
 I<verify_cb> overwriting the previous callback.
 The callback assigned with this function becomes a default for the one
 that can be assigned directly to the corresponding B<X509_STORE_CTX>,
 please see L<X509_STORE_CTX_set_verify_cb(3)> for further information.
 
 X509_STORE_set_verify() sets the final chain verification function for
-I<ctx> to I<verify>.
+I<xs> to I<verify>.
 Its purpose is to go through the chain of certificates and check that
 all signatures are valid and that the current time is within the
 limits of each certificate's first and last validity time.
@@ -139,12 +139,14 @@ I<If no chain verification function is provided, the internal default
 function will be used instead.>
 
 X509_STORE_CTX_get1_issuer() tries to find a certificate from the I<store>
-component of I<ctx> with a subject name matching the issuer name of I<x>.
-On success it assigns to I<*issuer> the first match that is currently valid,
-or at least the most recently expired match if there is no currently valid one.
+component of I<ctx> that has a subject name matching the issuer name of I<x>
+and is accepted by the I<check_issued> function in I<ctx>.
+On success it assigns to I<*issuer> the first match that has a suitable validity
+period or otherwise has the latest expiration date of all matching certificates.
 If the function returns 1 the caller is responsible for freeing I<*issuer>.
+Note that this search does not support backtracking.
 
-X509_STORE_set_get_issuer() sets the function I<get_issuer>
+X509_STORE_set_get_issuer() sets the function I<get_issuer> that is used
 to get the "best" candidate issuer certificate of the given certificate I<x>.
 When such a certificate is found, I<get_issuer> must up-ref and assign it
 to I<*issuer> and then return 1.

--- a/include/openssl/x509_vfy.h.in
+++ b/include/openssl/x509_vfy.h.in
@@ -394,71 +394,71 @@ int X509_OBJECT_set1_X509(X509_OBJECT *a, X509 *obj);
 X509_CRL *X509_OBJECT_get0_X509_CRL(const X509_OBJECT *a);
 int X509_OBJECT_set1_X509_CRL(X509_OBJECT *a, X509_CRL *obj);
 X509_STORE *X509_STORE_new(void);
-void X509_STORE_free(X509_STORE *v);
-int X509_STORE_lock(X509_STORE *ctx);
-int X509_STORE_unlock(X509_STORE *ctx);
-int X509_STORE_up_ref(X509_STORE *v);
-STACK_OF(X509_OBJECT) *X509_STORE_get0_objects(const X509_STORE *v);
-STACK_OF(X509) *X509_STORE_get1_all_certs(X509_STORE *st);
-STACK_OF(X509) *X509_STORE_CTX_get1_certs(X509_STORE_CTX *st,
+void X509_STORE_free(X509_STORE *xs);
+int X509_STORE_lock(X509_STORE *xs);
+int X509_STORE_unlock(X509_STORE *xs);
+int X509_STORE_up_ref(X509_STORE *xs);
+STACK_OF(X509_OBJECT) *X509_STORE_get0_objects(const X509_STORE *xs);
+STACK_OF(X509) *X509_STORE_get1_all_certs(X509_STORE *xs);
+STACK_OF(X509) *X509_STORE_CTX_get1_certs(X509_STORE_CTX *xs,
                                           const X509_NAME *nm);
 STACK_OF(X509_CRL) *X509_STORE_CTX_get1_crls(const X509_STORE_CTX *st,
                                              const X509_NAME *nm);
-int X509_STORE_set_flags(X509_STORE *ctx, unsigned long flags);
-int X509_STORE_set_purpose(X509_STORE *ctx, int purpose);
-int X509_STORE_set_trust(X509_STORE *ctx, int trust);
-int X509_STORE_set1_param(X509_STORE *ctx, const X509_VERIFY_PARAM *pm);
-X509_VERIFY_PARAM *X509_STORE_get0_param(const X509_STORE *ctx);
+int X509_STORE_set_flags(X509_STORE *xs, unsigned long flags);
+int X509_STORE_set_purpose(X509_STORE *xs, int purpose);
+int X509_STORE_set_trust(X509_STORE *xs, int trust);
+int X509_STORE_set1_param(X509_STORE *xs, const X509_VERIFY_PARAM *pm);
+X509_VERIFY_PARAM *X509_STORE_get0_param(const X509_STORE *xs);
 
-void X509_STORE_set_verify(X509_STORE *ctx, X509_STORE_CTX_verify_fn verify);
+void X509_STORE_set_verify(X509_STORE *xs, X509_STORE_CTX_verify_fn verify);
 #define X509_STORE_set_verify_func(ctx, func) \
             X509_STORE_set_verify((ctx),(func))
 void X509_STORE_CTX_set_verify(X509_STORE_CTX *ctx,
                                X509_STORE_CTX_verify_fn verify);
-X509_STORE_CTX_verify_fn X509_STORE_get_verify(const X509_STORE *ctx);
-void X509_STORE_set_verify_cb(X509_STORE *ctx,
+X509_STORE_CTX_verify_fn X509_STORE_get_verify(const X509_STORE *xs);
+void X509_STORE_set_verify_cb(X509_STORE *xs,
                               X509_STORE_CTX_verify_cb verify_cb);
 # define X509_STORE_set_verify_cb_func(ctx,func) \
             X509_STORE_set_verify_cb((ctx),(func))
-X509_STORE_CTX_verify_cb X509_STORE_get_verify_cb(const X509_STORE *ctx);
-void X509_STORE_set_get_issuer(X509_STORE *ctx,
+X509_STORE_CTX_verify_cb X509_STORE_get_verify_cb(const X509_STORE *xs);
+void X509_STORE_set_get_issuer(X509_STORE *xs,
                                X509_STORE_CTX_get_issuer_fn get_issuer);
-X509_STORE_CTX_get_issuer_fn X509_STORE_get_get_issuer(const X509_STORE *ctx);
-void X509_STORE_set_check_issued(X509_STORE *ctx,
+X509_STORE_CTX_get_issuer_fn X509_STORE_get_get_issuer(const X509_STORE *xs);
+void X509_STORE_set_check_issued(X509_STORE *xs,
                                  X509_STORE_CTX_check_issued_fn check_issued);
-X509_STORE_CTX_check_issued_fn X509_STORE_get_check_issued(const X509_STORE *ctx);
-void X509_STORE_set_check_revocation(X509_STORE *ctx,
+X509_STORE_CTX_check_issued_fn X509_STORE_get_check_issued(const X509_STORE *s);
+void X509_STORE_set_check_revocation(X509_STORE *xs,
                                      X509_STORE_CTX_check_revocation_fn check_revocation);
 X509_STORE_CTX_check_revocation_fn
-    X509_STORE_get_check_revocation(const X509_STORE *ctx);
-void X509_STORE_set_get_crl(X509_STORE *ctx,
+    X509_STORE_get_check_revocation(const X509_STORE *xs);
+void X509_STORE_set_get_crl(X509_STORE *xs,
                             X509_STORE_CTX_get_crl_fn get_crl);
-X509_STORE_CTX_get_crl_fn X509_STORE_get_get_crl(const X509_STORE *ctx);
-void X509_STORE_set_check_crl(X509_STORE *ctx,
+X509_STORE_CTX_get_crl_fn X509_STORE_get_get_crl(const X509_STORE *xs);
+void X509_STORE_set_check_crl(X509_STORE *xs,
                               X509_STORE_CTX_check_crl_fn check_crl);
-X509_STORE_CTX_check_crl_fn X509_STORE_get_check_crl(const X509_STORE *ctx);
-void X509_STORE_set_cert_crl(X509_STORE *ctx,
+X509_STORE_CTX_check_crl_fn X509_STORE_get_check_crl(const X509_STORE *xs);
+void X509_STORE_set_cert_crl(X509_STORE *xs,
                              X509_STORE_CTX_cert_crl_fn cert_crl);
-X509_STORE_CTX_cert_crl_fn X509_STORE_get_cert_crl(const X509_STORE *ctx);
-void X509_STORE_set_check_policy(X509_STORE *ctx,
+X509_STORE_CTX_cert_crl_fn X509_STORE_get_cert_crl(const X509_STORE *xs);
+void X509_STORE_set_check_policy(X509_STORE *xs,
                                  X509_STORE_CTX_check_policy_fn check_policy);
-X509_STORE_CTX_check_policy_fn X509_STORE_get_check_policy(const X509_STORE *ctx);
-void X509_STORE_set_lookup_certs(X509_STORE *ctx,
+X509_STORE_CTX_check_policy_fn X509_STORE_get_check_policy(const X509_STORE *s);
+void X509_STORE_set_lookup_certs(X509_STORE *xs,
                                  X509_STORE_CTX_lookup_certs_fn lookup_certs);
-X509_STORE_CTX_lookup_certs_fn X509_STORE_get_lookup_certs(const X509_STORE *ctx);
-void X509_STORE_set_lookup_crls(X509_STORE *ctx,
+X509_STORE_CTX_lookup_certs_fn X509_STORE_get_lookup_certs(const X509_STORE *s);
+void X509_STORE_set_lookup_crls(X509_STORE *xs,
                                 X509_STORE_CTX_lookup_crls_fn lookup_crls);
 #define X509_STORE_set_lookup_crls_cb(ctx, func) \
     X509_STORE_set_lookup_crls((ctx), (func))
-X509_STORE_CTX_lookup_crls_fn X509_STORE_get_lookup_crls(const X509_STORE *ctx);
-void X509_STORE_set_cleanup(X509_STORE *ctx,
+X509_STORE_CTX_lookup_crls_fn X509_STORE_get_lookup_crls(const X509_STORE *xs);
+void X509_STORE_set_cleanup(X509_STORE *xs,
                             X509_STORE_CTX_cleanup_fn cleanup);
-X509_STORE_CTX_cleanup_fn X509_STORE_get_cleanup(const X509_STORE *ctx);
+X509_STORE_CTX_cleanup_fn X509_STORE_get_cleanup(const X509_STORE *xs);
 
 #define X509_STORE_get_ex_new_index(l, p, newf, dupf, freef) \
     CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_X509_STORE, l, p, newf, dupf, freef)
-int X509_STORE_set_ex_data(X509_STORE *ctx, int idx, void *data);
-void *X509_STORE_get_ex_data(const X509_STORE *ctx, int idx);
+int X509_STORE_set_ex_data(X509_STORE *xs, int idx, void *data);
+void *X509_STORE_get_ex_data(const X509_STORE *xs, int idx);
 
 X509_STORE_CTX *X509_STORE_CTX_new_ex(OSSL_LIB_CTX *libctx, const char *propq);
 X509_STORE_CTX *X509_STORE_CTX_new(void);
@@ -503,7 +503,7 @@ X509_STORE_CTX_cleanup_fn X509_STORE_CTX_get_cleanup(const X509_STORE_CTX *ctx);
 # define X509_STORE_get1_crl X509_STORE_CTX_get1_crls
 #endif
 
-X509_LOOKUP *X509_STORE_add_lookup(X509_STORE *v, X509_LOOKUP_METHOD *m);
+X509_LOOKUP *X509_STORE_add_lookup(X509_STORE *xs, X509_LOOKUP_METHOD *m);
 X509_LOOKUP_METHOD *X509_LOOKUP_hash_dir(void);
 X509_LOOKUP_METHOD *X509_LOOKUP_file(void);
 X509_LOOKUP_METHOD *X509_LOOKUP_store(void);
@@ -588,8 +588,8 @@ X509_LOOKUP_get_by_alias_fn X509_LOOKUP_meth_get_get_by_alias(
     const X509_LOOKUP_METHOD *method);
 
 
-int X509_STORE_add_cert(X509_STORE *ctx, X509 *x);
-int X509_STORE_add_crl(X509_STORE *ctx, X509_CRL *x);
+int X509_STORE_add_cert(X509_STORE *xs, X509 *x);
+int X509_STORE_add_crl(X509_STORE *xs, X509_CRL *x);
 
 int X509_STORE_CTX_get_by_subject(const X509_STORE_CTX *vs,
                                   X509_LOOKUP_TYPE type,
@@ -633,23 +633,21 @@ void *X509_LOOKUP_get_method_data(const X509_LOOKUP *ctx);
 X509_STORE *X509_LOOKUP_get_store(const X509_LOOKUP *ctx);
 int X509_LOOKUP_shutdown(X509_LOOKUP *ctx);
 
-int X509_STORE_load_file(X509_STORE *ctx, const char *file);
-int X509_STORE_load_path(X509_STORE *ctx, const char *path);
-int X509_STORE_load_store(X509_STORE *ctx, const char *store);
-int X509_STORE_load_locations(X509_STORE *ctx,
-                                               const char *file,
-                                               const char *dir);
-int X509_STORE_set_default_paths(X509_STORE *ctx);
+int X509_STORE_load_file(X509_STORE *xs, const char *file);
+int X509_STORE_load_path(X509_STORE *xs, const char *path);
+int X509_STORE_load_store(X509_STORE *xs, const char *store);
+int X509_STORE_load_locations(X509_STORE *s, const char *file, const char *dir);
+int X509_STORE_set_default_paths(X509_STORE *xs);
 
-int X509_STORE_load_file_ex(X509_STORE *ctx, const char *file,
+int X509_STORE_load_file_ex(X509_STORE *xs, const char *file,
                             OSSL_LIB_CTX *libctx, const char *propq);
-int X509_STORE_load_store_ex(X509_STORE *ctx, const char *store,
+int X509_STORE_load_store_ex(X509_STORE *xs, const char *store,
                              OSSL_LIB_CTX *libctx, const char *propq);
-int X509_STORE_load_locations_ex(X509_STORE *ctx, const char *file,
-                                 const char *dir, OSSL_LIB_CTX *libctx,
-                                 const char *propq);
-int X509_STORE_set_default_paths_ex(X509_STORE *ctx, OSSL_LIB_CTX *libctx,
-                                    const char *propq);
+int X509_STORE_load_locations_ex(X509_STORE *xs,
+                                 const char *file, const char *dir,
+                                 OSSL_LIB_CTX *libctx, const char *propq);
+int X509_STORE_set_default_paths_ex(X509_STORE *xs,
+                                    OSSL_LIB_CTX *libctx, const char *propq);
 
 #define X509_STORE_CTX_get_ex_new_index(l, p, newf, dupf, freef) \
     CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_X509_STORE_CTX, l, p, newf, dupf, freef)


### PR DESCRIPTION
This is a spin-off from #18762 in order to simplify reviewing,
as suggested and agreed in https://github.com/openssl/openssl/pull/18762#issuecomment-1191371415.

* improve adherence to the coding style guidelines also by fixing misleading parameter names,
* improve related documenting comments and user documentation

- [x] documentation is added or updated

