### PR TITLE
Fix no-dtls1_2

### DIFF
--- a/test/dtlstest.c
+++ b/test/dtlstest.c
@@ -405,6 +405,12 @@ static int test_just_finished(void)
                                        &sctx, NULL, cert, privkey)))
         return 0;
 
+#ifdef OPENSSL_NO_DTLS1_2
+    /* DTLSv1 is not allowed at the default security level */
+    if (!TEST_true(SSL_CTX_set_cipher_list(sctx, "DEFAULT:@SECLEVEL=0")))
+        goto end;
+#endif
+
     serverssl = SSL_new(sctx);
     rbio = BIO_new(BIO_s_mem());
     wbio = BIO_new(BIO_s_mem());


### PR DESCRIPTION
dtlstest.c needs some adjusting to handle no-dtls1_2 since commit
7bf2e4d7f0c banned DTLSv1 at the default security level - causing the
test to fail.
