### PR TITLE
BIOs: Clean up and fix cmd handling

### DIFF
--- a/crypto/bio/bf_buff.c
+++ b/crypto/bio/bf_buff.c
@@ -304,7 +304,6 @@ static long buffer_ctrl(BIO *b, int cmd, long num, void *ptr)
         ctx->ibuf_off = 0;
         ctx->ibuf_len = (int)num;
         memcpy(ctx->ibuf, ptr, (int)num);
-        ret = 1;
         break;
     case BIO_C_SET_BUFF_SIZE:
         if (ptr != NULL) {

--- a/crypto/bio/bf_readbuff.c
+++ b/crypto/bio/bf_readbuff.c
@@ -199,7 +199,6 @@ static long readbuffer_ctrl(BIO *b, int cmd, long num, void *ptr)
         break;
     case BIO_CTRL_DUP:
     case BIO_CTRL_FLUSH:
-        ret = 1;
         break;
     default:
         ret = 0;

--- a/crypto/bio/bf_readbuff.c
+++ b/crypto/bio/bf_readbuff.c
@@ -202,7 +202,9 @@ static long readbuffer_ctrl(BIO *b, int cmd, long num, void *ptr)
     case BIO_CTRL_DUP:
     case BIO_CTRL_FLUSH:
         break;
+
     default:
+        ERR_raise_data(ERR_LIB_BIO, ERR_R_UNSUPPORTED, "cmd=%d", cmd);
         ret = 0;
         break;
     }

--- a/crypto/bio/bf_readbuff.c
+++ b/crypto/bio/bf_readbuff.c
@@ -197,6 +197,8 @@ static long readbuffer_ctrl(BIO *b, int cmd, long num, void *ptr)
             ret = BIO_ctrl(b->next_bio, cmd, num, ptr);
         }
         break;
+    case BIO_CTRL_PUSH:
+    case BIO_CTRL_POP:
     case BIO_CTRL_DUP:
     case BIO_CTRL_FLUSH:
         break;

--- a/crypto/bio/bio_lib.c
+++ b/crypto/bio/bio_lib.c
@@ -752,7 +752,7 @@ BIO *BIO_push(BIO *b, BIO *bio)
     if (bio != NULL)
         bio->prev_bio = lb;
     /* called to do internal processing */
-    BIO_ctrl(b, BIO_CTRL_PUSH, 0, lb);
+    (void)BIO_ctrl(b, BIO_CTRL_PUSH, 0, lb); /* discarding any err result */
     return b;
 }
 
@@ -765,7 +765,7 @@ BIO *BIO_pop(BIO *b)
         return NULL;
     ret = b->next_bio;
 
-    BIO_ctrl(b, BIO_CTRL_POP, 0, b);
+    (void)BIO_ctrl(b, BIO_CTRL_POP, 0, b); /* discarding any error result */
 
     if (b->prev_bio != NULL)
         b->prev_bio->next_bio = b->next_bio;

--- a/crypto/bio/bss_acpt.c
+++ b/crypto/bio/bss_acpt.c
@@ -523,6 +523,7 @@ static long acpt_ctrl(BIO *b, int cmd, long num, void *ptr)
         } else
             ret = -1;
         break;
+
     case BIO_CTRL_GET_CLOSE:
         ret = b->shutdown;
         break;

--- a/crypto/bio/bss_acpt.c
+++ b/crypto/bio/bss_acpt.c
@@ -556,6 +556,7 @@ static long acpt_ctrl(BIO *b, int cmd, long num, void *ptr)
         break;
 
     default:
+        ERR_raise_data(ERR_LIB_BIO, ERR_R_UNSUPPORTED, "cmd=%d", cmd);
         ret = 0;
         break;
     }

--- a/crypto/bio/bss_acpt.c
+++ b/crypto/bio/bss_acpt.c
@@ -550,6 +550,11 @@ static long acpt_ctrl(BIO *b, int cmd, long num, void *ptr)
         else
             ret = BIO_ctrl(b->next_bio, cmd, num, ptr);
         break;
+    case BIO_CTRL_PUSH:
+    case BIO_CTRL_POP:
+        ret = 0;
+        break;
+
     default:
         ret = 0;
         break;

--- a/crypto/bio/bss_bio.c
+++ b/crypto/bio/bss_bio.c
@@ -564,8 +564,6 @@ static long bio_ctrl(BIO *bio, int cmd, long num, void *ptr)
         break;
 
     case BIO_CTRL_FLUSH:
-    case BIO_CTRL_PUSH:
-    case BIO_CTRL_POP:
         break;
 
     case BIO_CTRL_EOF:
@@ -575,8 +573,13 @@ static long bio_ctrl(BIO *bio, int cmd, long num, void *ptr)
             ret = (long)(peer_b->len == 0 && peer_b->closed);
         }
         break;
+    case BIO_CTRL_PUSH:
+    case BIO_CTRL_POP:
+        ret = 0;
+        break;
 
     default:
+        ERR_raise_data(ERR_LIB_BIO, ERR_R_UNSUPPORTED, "cmd=%d", cmd);
         ret = 0;
     }
     return ret;

--- a/crypto/bio/bss_bio.c
+++ b/crypto/bio/bss_bio.c
@@ -564,6 +564,8 @@ static long bio_ctrl(BIO *bio, int cmd, long num, void *ptr)
         break;
 
     case BIO_CTRL_FLUSH:
+    case BIO_CTRL_PUSH:
+    case BIO_CTRL_POP:
         break;
 
     case BIO_CTRL_EOF:

--- a/crypto/bio/bss_bio.c
+++ b/crypto/bio/bss_bio.c
@@ -575,6 +575,8 @@ static long bio_ctrl(BIO *bio, int cmd, long num, void *ptr)
         break;
     case BIO_CTRL_PUSH:
     case BIO_CTRL_POP:
+    case BIO_CTRL_GET_KTLS_SEND:
+    case BIO_CTRL_GET_KTLS_RECV:
         ret = 0;
         break;
 

--- a/crypto/bio/bss_bio.c
+++ b/crypto/bio/bss_bio.c
@@ -413,7 +413,7 @@ static ossl_ssize_t bio_nwrite(BIO *bio, char **buf, size_t num_)
 
 static long bio_ctrl(BIO *bio, int cmd, long num, void *ptr)
 {
-    long ret;
+    long ret = 1;
     struct bio_bio_st *b = bio->ptr;
 
     assert(b != NULL);
@@ -436,7 +436,6 @@ static long bio_ctrl(BIO *bio, int cmd, long num, void *ptr)
                 b->buf = NULL;
                 b->size = new_size;
             }
-            ret = 1;
         }
         break;
 
@@ -447,10 +446,7 @@ static long bio_ctrl(BIO *bio, int cmd, long num, void *ptr)
     case BIO_C_MAKE_BIO_PAIR: {
         BIO *other_bio = ptr;
 
-        if (bio_make_pair(bio, other_bio))
-            ret = 1;
-        else
-            ret = 0;
+        ret = bio_make_pair(bio, other_bio) != 0;
     } break;
 
     case BIO_C_DESTROY_BIO_PAIR:
@@ -459,7 +455,6 @@ static long bio_ctrl(BIO *bio, int cmd, long num, void *ptr)
          * BIO_free(bio1); BIO_free(bio2); do the job.
          */
         bio_destroy_pair(bio);
-        ret = 1;
         break;
 
     case BIO_C_GET_WRITE_GUARANTEE:
@@ -489,13 +484,11 @@ static long bio_ctrl(BIO *bio, int cmd, long num, void *ptr)
          * to see if any data is available.)
          */
         b->request = 0;
-        ret = 1;
         break;
 
     case BIO_C_SHUTDOWN_WR:
         /* similar to shutdown(..., SHUT_WR) */
         b->closed = 1;
-        ret = 1;
         break;
 
     case BIO_C_NREAD0:
@@ -534,7 +527,6 @@ static long bio_ctrl(BIO *bio, int cmd, long num, void *ptr)
 
     case BIO_CTRL_SET_CLOSE:
         bio->shutdown = (int)num;
-        ret = 1;
         break;
 
     case BIO_CTRL_PENDING:
@@ -542,8 +534,9 @@ static long bio_ctrl(BIO *bio, int cmd, long num, void *ptr)
             struct bio_bio_st *peer_b = b->peer->ptr;
 
             ret = (long)peer_b->len;
-        } else
+        } else {
             ret = 0;
+        }
         break;
 
     case BIO_CTRL_WPENDING:
@@ -568,23 +561,16 @@ static long bio_ctrl(BIO *bio, int cmd, long num, void *ptr)
             other_b->size = b->size;
         }
 
-        ret = 1;
         break;
 
     case BIO_CTRL_FLUSH:
-        ret = 1;
         break;
 
     case BIO_CTRL_EOF:
         if (b->peer != NULL) {
             struct bio_bio_st *peer_b = b->peer->ptr;
 
-            if (peer_b->len == 0 && peer_b->closed)
-                ret = 1;
-            else
-                ret = 0;
-        } else {
-            ret = 1;
+            ret = (long)(peer_b->len == 0 && peer_b->closed);
         }
         break;
 

--- a/crypto/bio/bss_conn.c
+++ b/crypto/bio/bss_conn.c
@@ -710,6 +710,7 @@ static long conn_ctrl(BIO *b, int cmd, long num, void *ptr)
         break;
 #endif
     default:
+        ERR_raise_data(ERR_LIB_BIO, ERR_R_UNSUPPORTED, "cmd=%d", cmd);
         ret = 0;
         break;
     }

--- a/crypto/bio/bss_conn.c
+++ b/crypto/bio/bss_conn.c
@@ -468,8 +468,6 @@ static long conn_ctrl(BIO *b, int cmd, long num, void *ptr)
         /* use this one to start the connection */
         if (data->state != BIO_CONN_S_OK)
             ret = (long)conn_state(b, data);
-        else
-            ret = 1;
         break;
     case BIO_C_GET_CONNECT:
         if (ptr != NULL) {

--- a/crypto/bio/bss_conn.c
+++ b/crypto/bio/bss_conn.c
@@ -653,6 +653,8 @@ static long conn_ctrl(BIO *b, int cmd, long num, void *ptr)
     case BIO_CTRL_WPENDING:
         ret = 0;
         break;
+    case BIO_CTRL_PUSH:
+    case BIO_CTRL_POP:
     case BIO_CTRL_FLUSH:
         break;
     case BIO_CTRL_DUP: {

--- a/crypto/bio/bss_dgram.c
+++ b/crypto/bio/bss_dgram.c
@@ -627,7 +627,6 @@ static long dgram_ctrl(BIO *b, int cmd, long num, void *ptr)
         break;
     case BIO_CTRL_DUP:
     case BIO_CTRL_FLUSH:
-        ret = 1;
         break;
     case BIO_CTRL_DGRAM_CONNECT:
         BIO_ADDR_make(&data->peer, BIO_ADDR_sockaddr((BIO_ADDR *)ptr));
@@ -907,7 +906,6 @@ static long dgram_ctrl(BIO *b, int cmd, long num, void *ptr)
         d_errno = (data->_errno == EAGAIN);
 #endif
         if (d_errno) {
-            ret = 1;
             data->_errno = 0;
         } else
             ret = 0;
@@ -915,7 +913,6 @@ static long dgram_ctrl(BIO *b, int cmd, long num, void *ptr)
 #ifdef EMSGSIZE
     case BIO_CTRL_DGRAM_MTU_EXCEEDED:
         if (data->_errno == EMSGSIZE) {
-            ret = 1;
             data->_errno = 0;
         } else
             ret = 0;

--- a/crypto/bio/bss_dgram.c
+++ b/crypto/bio/bss_dgram.c
@@ -1037,6 +1037,7 @@ static long dgram_ctrl(BIO *b, int cmd, long num, void *ptr)
     } break;
 
     default:
+        ERR_raise_data(ERR_LIB_BIO, ERR_R_UNSUPPORTED, "cmd=%d", cmd);
         ret = 0;
         break;
     }

--- a/crypto/bio/bss_dgram.c
+++ b/crypto/bio/bss_dgram.c
@@ -625,6 +625,8 @@ static long dgram_ctrl(BIO *b, int cmd, long num, void *ptr)
     case BIO_CTRL_WPENDING:
         ret = 0;
         break;
+    case BIO_CTRL_PUSH:
+    case BIO_CTRL_POP:
     case BIO_CTRL_DUP:
     case BIO_CTRL_FLUSH:
         break;

--- a/crypto/bio/bss_fd.c
+++ b/crypto/bio/bss_fd.c
@@ -191,7 +191,9 @@ static long fd_ctrl(BIO *b, int cmd, long num, void *ptr)
     case BIO_CTRL_EOF:
         ret = (b->flags & BIO_FLAGS_IN_EOF) != 0;
         break;
+
     default:
+        ERR_raise_data(ERR_LIB_BIO, ERR_R_UNSUPPORTED, "cmd=%d", cmd);
         ret = 0;
         break;
     }

--- a/crypto/bio/bss_fd.c
+++ b/crypto/bio/bss_fd.c
@@ -183,6 +183,8 @@ static long fd_ctrl(BIO *b, int cmd, long num, void *ptr)
     case BIO_CTRL_WPENDING:
         ret = 0;
         break;
+    case BIO_CTRL_PUSH:
+    case BIO_CTRL_POP:
     case BIO_CTRL_DUP:
     case BIO_CTRL_FLUSH:
         break;

--- a/crypto/bio/bss_fd.c
+++ b/crypto/bio/bss_fd.c
@@ -185,7 +185,6 @@ static long fd_ctrl(BIO *b, int cmd, long num, void *ptr)
         break;
     case BIO_CTRL_DUP:
     case BIO_CTRL_FLUSH:
-        ret = 1;
         break;
     case BIO_CTRL_EOF:
         ret = (b->flags & BIO_FLAGS_IN_EOF) != 0;

--- a/crypto/bio/bss_file.c
+++ b/crypto/bio/bss_file.c
@@ -321,14 +321,17 @@ static long file_ctrl(BIO *b, int cmd, long num, void *ptr)
             ret = 0;
         }
         break;
+    case BIO_CTRL_WPENDING:
+    case BIO_CTRL_PENDING:
+        ret = 0;
+        break;
     case BIO_CTRL_PUSH:
     case BIO_CTRL_POP:
     case BIO_CTRL_DUP:
         break;
 
-    case BIO_CTRL_WPENDING:
-    case BIO_CTRL_PENDING:
     default:
+        ERR_raise_data(ERR_LIB_BIO, ERR_R_UNSUPPORTED, "cmd=%d", cmd);
         ret = 0;
         break;
     }

--- a/crypto/bio/bss_file.c
+++ b/crypto/bio/bss_file.c
@@ -321,13 +321,13 @@ static long file_ctrl(BIO *b, int cmd, long num, void *ptr)
             ret = 0;
         }
         break;
+    case BIO_CTRL_PUSH:
+    case BIO_CTRL_POP:
     case BIO_CTRL_DUP:
         break;
 
     case BIO_CTRL_WPENDING:
     case BIO_CTRL_PENDING:
-    case BIO_CTRL_PUSH:
-    case BIO_CTRL_POP:
     default:
         ret = 0;
         break;

--- a/crypto/bio/bss_file.c
+++ b/crypto/bio/bss_file.c
@@ -322,7 +322,6 @@ static long file_ctrl(BIO *b, int cmd, long num, void *ptr)
         }
         break;
     case BIO_CTRL_DUP:
-        ret = 1;
         break;
 
     case BIO_CTRL_WPENDING:

--- a/crypto/bio/bss_mem.c
+++ b/crypto/bio/bss_mem.c
@@ -326,19 +326,22 @@ static long mem_ctrl(BIO *b, int cmd, long num, void *ptr)
     case BIO_CTRL_SET_CLOSE:
         b->shutdown = (int)num;
         break;
+    case BIO_CTRL_PUSH:
+    case BIO_CTRL_POP:
     case BIO_CTRL_WPENDING:
+    case BIO_CTRL_GET_INDENT:
+    case BIO_CTRL_SET_INDENT:
         ret = 0L;
         break;
     case BIO_CTRL_PENDING:
         ret = (long)bm->length;
         break;
-    case BIO_CTRL_PUSH:
-    case BIO_CTRL_POP:
     case BIO_CTRL_DUP:
     case BIO_CTRL_FLUSH:
         break;
 
     default:
+        ERR_raise_data(ERR_LIB_BIO, ERR_R_UNSUPPORTED, "cmd=%d", cmd);
         ret = 0;
         break;
     }

--- a/crypto/bio/bss_mem.c
+++ b/crypto/bio/bss_mem.c
@@ -334,7 +334,6 @@ static long mem_ctrl(BIO *b, int cmd, long num, void *ptr)
         break;
     case BIO_CTRL_DUP:
     case BIO_CTRL_FLUSH:
-        ret = 1;
         break;
     case BIO_CTRL_PUSH:
     case BIO_CTRL_POP:

--- a/crypto/bio/bss_mem.c
+++ b/crypto/bio/bss_mem.c
@@ -333,6 +333,8 @@ static long mem_ctrl(BIO *b, int cmd, long num, void *ptr)
     case BIO_CTRL_DGRAM_GET_MTU_OVERHEAD:
     case BIO_CTRL_DGRAM_SET_NEXT_TIMEOUT:
     case BIO_CTRL_WPENDING:
+    case BIO_CTRL_GET_KTLS_SEND:
+    case BIO_CTRL_GET_KTLS_RECV:
     case BIO_CTRL_GET_INDENT:
     case BIO_CTRL_SET_INDENT:
         ret = 0L;
@@ -342,6 +344,7 @@ static long mem_ctrl(BIO *b, int cmd, long num, void *ptr)
         break;
     case BIO_CTRL_DUP:
     case BIO_CTRL_FLUSH:
+    case BIO_C_SET_NBIO:
         break;
 
     default:

--- a/crypto/bio/bss_mem.c
+++ b/crypto/bio/bss_mem.c
@@ -328,6 +328,10 @@ static long mem_ctrl(BIO *b, int cmd, long num, void *ptr)
         break;
     case BIO_CTRL_PUSH:
     case BIO_CTRL_POP:
+    case BIO_CTRL_DGRAM_QUERY_MTU:
+    case BIO_CTRL_DGRAM_SET_MTU:
+    case BIO_CTRL_DGRAM_GET_MTU_OVERHEAD:
+    case BIO_CTRL_DGRAM_SET_NEXT_TIMEOUT:
     case BIO_CTRL_WPENDING:
     case BIO_CTRL_GET_INDENT:
     case BIO_CTRL_SET_INDENT:

--- a/crypto/bio/bss_mem.c
+++ b/crypto/bio/bss_mem.c
@@ -332,11 +332,12 @@ static long mem_ctrl(BIO *b, int cmd, long num, void *ptr)
     case BIO_CTRL_PENDING:
         ret = (long)bm->length;
         break;
+    case BIO_CTRL_PUSH:
+    case BIO_CTRL_POP:
     case BIO_CTRL_DUP:
     case BIO_CTRL_FLUSH:
         break;
-    case BIO_CTRL_PUSH:
-    case BIO_CTRL_POP:
+
     default:
         ret = 0;
         break;

--- a/crypto/bio/bss_mem.c
+++ b/crypto/bio/bss_mem.c
@@ -331,6 +331,11 @@ static long mem_ctrl(BIO *b, int cmd, long num, void *ptr)
     case BIO_CTRL_DGRAM_QUERY_MTU:
     case BIO_CTRL_DGRAM_SET_MTU:
     case BIO_CTRL_DGRAM_GET_MTU_OVERHEAD:
+#ifndef OPENSSL_NO_SCTP
+    case BIO_CTRL_DGRAM_SCTP_ADD_AUTH_KEY:
+    case BIO_CTRL_DGRAM_SCTP_NEXT_AUTH_KEY:
+    case BIO_CTRL_DGRAM_SCTP_AUTH_CCS_RCVD:
+#endif
     case BIO_CTRL_DGRAM_SET_NEXT_TIMEOUT:
     case BIO_CTRL_WPENDING:
     case BIO_CTRL_GET_KTLS_SEND:

--- a/crypto/bio/bss_null.c
+++ b/crypto/bio/bss_null.c
@@ -59,6 +59,8 @@ static long null_ctrl(BIO *b, int cmd, long num, void *ptr)
     case BIO_CTRL_FLUSH:
     case BIO_CTRL_DUP:
         break;
+    case BIO_CTRL_PUSH:
+    case BIO_CTRL_POP:
     case BIO_CTRL_GET_CLOSE:
     case BIO_CTRL_INFO:
     case BIO_CTRL_GET:

--- a/crypto/bio/bss_null.c
+++ b/crypto/bio/bss_null.c
@@ -66,7 +66,11 @@ static long null_ctrl(BIO *b, int cmd, long num, void *ptr)
     case BIO_CTRL_GET:
     case BIO_CTRL_PENDING:
     case BIO_CTRL_WPENDING:
+        ret = 0;
+        break;
+
     default:
+        ERR_raise_data(ERR_LIB_BIO, ERR_R_UNSUPPORTED, "cmd=%d", cmd);
         ret = 0;
         break;
     }

--- a/crypto/bio/bss_null.c
+++ b/crypto/bio/bss_null.c
@@ -58,7 +58,6 @@ static long null_ctrl(BIO *b, int cmd, long num, void *ptr)
     case BIO_CTRL_SET_CLOSE:
     case BIO_CTRL_FLUSH:
     case BIO_CTRL_DUP:
-        ret = 1;
         break;
     case BIO_CTRL_GET_CLOSE:
     case BIO_CTRL_INFO:

--- a/crypto/bio/bss_sock.c
+++ b/crypto/bio/bss_sock.c
@@ -203,7 +203,6 @@ static long sock_ctrl(BIO *b, int cmd, long num, void *ptr)
         break;
     case BIO_CTRL_DUP:
     case BIO_CTRL_FLUSH:
-        ret = 1;
         break;
     case BIO_CTRL_GET_RPOLL_DESCRIPTOR:
     case BIO_CTRL_GET_WPOLL_DESCRIPTOR: {

--- a/crypto/bio/bss_sock.c
+++ b/crypto/bio/bss_sock.c
@@ -267,6 +267,7 @@ static long sock_ctrl(BIO *b, int cmd, long num, void *ptr)
         }
         break;
     default:
+        ERR_raise_data(ERR_LIB_BIO, ERR_R_UNSUPPORTED, "cmd=%d", cmd);
         ret = 0;
         break;
     }

--- a/crypto/bio/bss_sock.c
+++ b/crypto/bio/bss_sock.c
@@ -201,6 +201,8 @@ static long sock_ctrl(BIO *b, int cmd, long num, void *ptr)
     case BIO_CTRL_SET_CLOSE:
         b->shutdown = (int)num;
         break;
+    case BIO_CTRL_PUSH:
+    case BIO_CTRL_POP:
     case BIO_CTRL_DUP:
     case BIO_CTRL_FLUSH:
         break;

--- a/doc/man3/BIO_f_prefix.pod
+++ b/doc/man3/BIO_f_prefix.pod
@@ -46,10 +46,10 @@ implemented as macros.
 
 BIO_f_prefix() returns the prefix BIO method.
 
-BIO_set_prefix() returns 1 if the prefix was correctly set, or <=0 on
+BIO_set_prefix() returns 1 if the prefix was correctly set, or <= 0 on
 failure.
 
-BIO_set_indent() returns 1 if the prefix was correctly set, or <=0 on
+BIO_set_indent() returns 1 if the prefix was correctly set, or <= 0 on
 failure.
 
 BIO_get_indent() returns the current indentation, or a negative value for failure.

--- a/ssl/d1_lib.c
+++ b/ssl/d1_lib.c
@@ -896,7 +896,7 @@ int dtls1_query_mtu(SSL_CONNECTION *s)
             if (s->d1->mtu < dtls1_min_mtu(s)) {
                 /* Set to min mtu */
                 s->d1->mtu = dtls1_min_mtu(s);
-                BIO_ctrl(SSL_get_wbio(ssl), BIO_CTRL_DGRAM_SET_MTU,
+                (void)BIO_ctrl(SSL_get_wbio(ssl), BIO_CTRL_DGRAM_SET_MTU,
                     (long)s->d1->mtu, NULL);
             }
         } else


### PR DESCRIPTION
This has been carved out of #18434.

It turns out that most of the `switch` statements for BIO cmd handling have been implemented pretty sloppily and partly even wrong.
* The `default` case tends to mix (correct) integer `0` results and Boolean `false` results, which causes trouble when adding a proper error queue entry for unsupported (or even undefined) cmds.
* There are many cases where `BIO_CTRL_PUSH` and `BIO_CTRL_POP` wrongly return `0` (failure), and this so far did not emerge because the error code is ignored (and no error stack entry was produced).

Fixes proposed here:
* `bf_readbuff.c` and `bss_*.c:` bug fix: calling `BIO_CTRL_PUSH` and `BIO_CTRL_POP` is not an error
*  `bf_readbuff.c` and `bss_*.c`: add error queue entry for cmds not supported
* `bss_mem.c`: fix `BIO_CTRL_SET_NBIO` and `BIO_CTRL_GET_KTLS_{SEND,RECV}`
* `bss_{bio,file,mem}.c`: fix `BIO_CTRL_DGRAM_{SET_NEXT_TIMEOUT,SET_MTU,QUERY_MTU,GET_MTU_OVERHEAD}`
* `BIO_f_prefix.pod:` fix nit
* `bss_*.c` and `bf_*.c`: harmonize the assignments to the 'res' variable of the ctrl function