### PR TITLE
armcap: skip probing _armv7_tick()

### DIFF
--- a/crypto/armcap.c
+++ b/crypto/armcap.c
@@ -357,11 +357,11 @@ void OPENSSL_cpuid_setup(void)
 #  endif
 # endif
 
-    /* Things that getauxval didn't tell us */
-    if (sigsetjmp(ill_jmp, 1) == 0) {
-        _armv7_tick();
-        OPENSSL_armcap_P |= ARMV7_TICK;
-    }
+    /*
+     * Probing for ARMV7_TICK is known to produce unreliable results,
+     * so we will only use the feature when the user explicitly enables
+     * it with OPENSSL_armcap.
+     */
 
     sigaction(SIGILL, &ill_oact, NULL);
     sigprocmask(SIG_SETMASK, &oset, NULL);


### PR DESCRIPTION
Using `_armv7_tick()` leads to crashes on a variety of AArch32 Android devices while providing [little benefit](https://github.com/openssl/openssl/issues/14838#issuecomment-820518715). Nobody has succeeded in getting a reliable repro to debug it for years, so just disable it by default on these known problematic configurations unless the user opts in by setting `OPENSSL_armcap`.

If this approach is acceptable, this should also be backported to `OpenSSL_1_1_1-stable` to resolve the linked issues.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

Fixes #14838
Fixes #17009
Fixes #17465