### PR TITLE
Fix MS-VC++2008 and Windows XP 32bit critical error problem

### DIFF
--- a/crypto/threads_win.c
+++ b/crypto/threads_win.c
@@ -208,40 +208,50 @@ int CRYPTO_atomic_or(uint64_t *val, uint64_t op, uint64_t *ret,
                      CRYPTO_RWLOCK *lock)
 {
 #if (defined(_MSC_VER) && defined(_M_IX86) && _MSC_VER <= 1500)
-    // VC++ 2008 or earlier x86 compilers do not have an inline implementation of InterlockedOr64 for 32bit and will fail to run on Windows XP 32bit.
-    // See: https://docs.microsoft.com/en-us/cpp/intrinsics/interlockedor-intrinsic-functions#requirements
-    // To work around this problem, we implement a manual locking mechanism for only VC++ 2008 or earlier x86 compilers.
-	if (lock == NULL || !CRYPTO_THREAD_write_lock(lock))
-		return 0;
-	*val |= op;
-	*ret = *val;
+    /*
+     * VC++ 2008 or earlier x86 compilers do not have an inline implementation
+     * of InterlockedOr64 for 32bit and will fail to run on Windows XP 32bit.
+     * https://docs.microsoft.com/en-us/cpp/intrinsics/interlockedor-intrinsic-functions#requirements
+     * To work around this problem, we implement a manual locking mechanism for
+     * only VC++ 2008 or earlier x86 compilers.
+     */
 
-	if (!CRYPTO_THREAD_unlock(lock))
-		return 0;
+    if (lock == NULL || !CRYPTO_THREAD_write_lock(lock))
+        return 0;
+    *val |= op;
+    *ret = *val;
 
-	return 1;
+    if (!CRYPTO_THREAD_unlock(lock))
+        return 0;
+
+    return 1;
 #else
-	*ret = (uint64_t)InterlockedOr64((LONG64 volatile *)val, (LONG64)op) | op;
-	return 1;
+    *ret = (uint64_t)InterlockedOr64((LONG64 volatile *)val, (LONG64)op) | op;
+    return 1;
 #endif
 }
 
 int CRYPTO_atomic_load(uint64_t *val, uint64_t *ret, CRYPTO_RWLOCK *lock)
 {
 #if (defined(_MSC_VER) && defined(_M_IX86) && _MSC_VER <= 1500)
-	// VC++ 2008 or earlier x86 compilers do not have an inline implementation of InterlockedOr64 for 32bit and will fail to run on Windows XP 32bit.
-	// See: https://docs.microsoft.com/en-us/cpp/intrinsics/interlockedor-intrinsic-functions#requirements
-	// To work around this problem, we implement a manual locking mechanism for only VC++ 2008 or earlier x86 compilers.
-	if (lock == NULL || !CRYPTO_THREAD_read_lock(lock))
-		return 0;
-	*ret = *val;
-	if (!CRYPTO_THREAD_unlock(lock))
-		return 0;
+    /*
+     * VC++ 2008 or earlier x86 compilers do not have an inline implementation
+     * of InterlockedOr64 for 32bit and will fail to run on Windows XP 32bit.
+     * https://docs.microsoft.com/en-us/cpp/intrinsics/interlockedor-intrinsic-functions#requirements
+     * To work around this problem, we implement a manual locking mechanism for
+     * only VC++ 2008 or earlier x86 compilers.
+     */
 
-	return 1;
+    if (lock == NULL || !CRYPTO_THREAD_read_lock(lock))
+        return 0;
+    *ret = *val;
+    if (!CRYPTO_THREAD_unlock(lock))
+        return 0;
+
+    return 1;
 #else
-	*ret = (uint64_t)InterlockedOr64((LONG64 volatile *)val, 0);
-	return 1;
+    *ret = (uint64_t)InterlockedOr64((LONG64 volatile *)val, 0);
+    return 1;
 #endif
 }
 


### PR DESCRIPTION
### Problem
OpenSSL 3.0.0 to 3.0.5 binaries built with MS-VC++ 2008 always fails to run on Windows XP 32-bit Editions.

### Solution
VC++ 2008 or earlier x86 compilers do not have an inline implementation of InterlockedOr64 for 32bit CPUs, then OpenSSL 3.0.0 to 3.0.5 binaries built with MS-VC++ 2008 will always fail to run on Windows XP 32bit.

See: https://docs.microsoft.com/en-us/cpp/intrinsics/interlockedor-intrinsic-functions#requirements

To work around this problem, we implement a manual locking mechanism for only VC++ 2008 or earlier x86 compilers.

### Related issue
This patch fixes https://github.com/openssl/openssl/issues/18855