### PR TITLE
`80-test_cmp_http.t`: fix adaption of plan on 'certstatus' aspect of Mock server

### DIFF
--- a/test/recipes/80-test_cmp_http.t
+++ b/test/recipes/80-test_cmp_http.t
@@ -171,7 +171,7 @@ sub test_cmp_http_aspect {
 
 indir data_dir() => sub {
     plan tests => 1 + @server_configurations * @all_aspects
-        + (grep(/^Mock$/, @server_configurations)
+        - (grep(/^Mock$/, @server_configurations)
            && grep(/^certstatus$/, @all_aspects));
 
     foreach my $server_name (@server_configurations) {


### PR DESCRIPTION
This fixes a small issue hinted on by @bernd-edlinger  in https://github.com/openssl/openssl/pull/18401#discussion_r880791191.

- [x] tests are added or updated
