### PR TITLE
s390x: Fix GCM setup

### DIFF
--- a/crypto/modes/gcm128.c
+++ b/crypto/modes/gcm128.c
@@ -499,6 +499,11 @@ static void gcm_get_funcs(struct gcm_funcs_st *ctx)
     }
     return;
 #endif
+#if defined(__s390__) || defined(__s390x__)
+    ctx->gmult = gcm_gmult_4bit;
+    ctx->ghash = gcm_ghash_4bit;
+    return;
+#endif
 }
 
 void CRYPTO_gcm128_init(GCM128_CONTEXT *ctx, void *key, block128_f block)


### PR DESCRIPTION
Rework of GCM code did not include s390x causing NULL pointer dereferences on
GCM operations other than AES-GCM on platforms that support kma.  Fix this by
a proper setup of the function pointers.

Fixes: 92c9086e5c2b ("Use separate function to get GCM functions")

Signed-off-by: Juergen Christ <jchrist@linux.ibm.com>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

