### PR TITLE
Remove `no-{ssl|tls|tls1_3|dtls}-method` in INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -974,7 +974,7 @@ the individual protocol versions.
 
 ### no-{protocol}-method
 
-    no-{ssl|ssl3|tls|tls1|tls1_1|tls1_2|tls1_3|dtls|dtls1|dtls1_2}-method
+    no-{ssl3|tls1|tls1_1|tls1_2|dtls1|dtls1_2}-method
 
 Analogous to `no-{protocol}` but in addition do not build the methods for
 applications to explicitly select individual protocol versions.  Note that there


### PR DESCRIPTION
CLA: trivial

Actually there are no options called `no-{ssl|tls|tls1_3|dtls}-method`.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->