### PR TITLE
Fix EC_KEY_set_private_key() NULL private key behavior in 1.1.1

### DIFF
--- a/crypto/ec/ec_key.c
+++ b/crypto/ec/ec_key.c
@@ -444,6 +444,16 @@ int EC_KEY_set_private_key(EC_KEY *key, const BIGNUM *priv_key)
         return 0;
 
     /*
+     * Return `0` to comply with legacy behavior for this function, see
+     * https://github.com/openssl/openssl/issues/18744#issuecomment-1195175696
+     */
+    if (priv_key == NULL) {
+        BN_clear_free(key->priv_key);
+        key->priv_key = NULL;
+        return 0; /* intentional for legacy compatibility */
+    }
+
+    /*
      * We should never leak the bit length of the secret scalar in the key,
      * so we always set the `BN_FLG_CONSTTIME` flag on the internal `BIGNUM`
      * holding the secret scalar.

--- a/doc/man3/EC_KEY_new.pod
+++ b/doc/man3/EC_KEY_new.pod
@@ -33,7 +33,7 @@ EC_KEY objects
  const EC_GROUP *EC_KEY_get0_group(const EC_KEY *key);
  int EC_KEY_set_group(EC_KEY *key, const EC_GROUP *group);
  const BIGNUM *EC_KEY_get0_private_key(const EC_KEY *key);
- int EC_KEY_set_private_key(EC_KEY *key, const BIGNUM *prv);
+ int EC_KEY_set_private_key(EC_KEY *key, const BIGNUM *priv_key);
  const EC_POINT *EC_KEY_get0_public_key(const EC_KEY *key);
  int EC_KEY_set_public_key(EC_KEY *key, const EC_POINT *pub);
  point_conversion_form_t EC_KEY_get_conv_form(const EC_KEY *key);
@@ -102,7 +102,9 @@ that it is valid.
 The functions EC_KEY_get0_group(), EC_KEY_set_group(),
 EC_KEY_get0_private_key(), EC_KEY_set_private_key(), EC_KEY_get0_public_key(),
 and EC_KEY_set_public_key() get and set the EC_GROUP object, the private key,
-and the EC_POINT public key for the B<key> respectively.
+and the EC_POINT public key for the B<key> respectively. The function
+EC_KEY_set_private_key() accepts NULL as the priv_key argument to securely clear
+the private key component from the EC_KEY.
 
 The functions EC_KEY_get_conv_form() and EC_KEY_set_conv_form() get and set the
 point_conversion_form for the B<key>. For a description of
@@ -160,10 +162,14 @@ EC_KEY_copy() returns a pointer to the destination key, or NULL on error.
 
 EC_KEY_get0_engine() returns a pointer to an ENGINE, or NULL if it wasn't set.
 
-EC_KEY_up_ref(), EC_KEY_set_group(), EC_KEY_set_private_key(),
-EC_KEY_set_public_key(), EC_KEY_precompute_mult(), EC_KEY_generate_key(),
-EC_KEY_check_key(), EC_KEY_set_public_key_affine_coordinates(),
-EC_KEY_oct2key() and EC_KEY_oct2priv() return 1 on success or 0 on error.
+EC_KEY_up_ref(), EC_KEY_set_group(), EC_KEY_set_public_key(),
+EC_KEY_precompute_mult(), EC_KEY_generate_key(), EC_KEY_check_key(),
+EC_KEY_set_public_key_affine_coordinates(), EC_KEY_oct2key() and
+EC_KEY_oct2priv() return 1 on success or 0 on error.
+
+EC_KEY_set_private_key() returns 1 on success or 0 on error except when the
+priv_key argument is NULL, in that case it returns 0, for legacy compatibility,
+and should not be treated as an error.
 
 EC_KEY_get0_group() returns the EC_GROUP associated with the EC_KEY.
 

--- a/test/ec_internal_test.c
+++ b/test/ec_internal_test.c
@@ -184,6 +184,39 @@ static int field_tests_default(int n)
 }
 
 /*
+ * Tests behavior of the EC_KEY_set_private_key
+ */
+static int set_private_key(void)
+{
+    EC_KEY *key = NULL, *aux_key = NULL;
+    int testresult = 0;
+
+    key = EC_KEY_new_by_curve_name(NID_secp224r1);
+    aux_key = EC_KEY_new_by_curve_name(NID_secp224r1);
+    if (!TEST_ptr(key)
+        || !TEST_ptr(aux_key)
+        || !TEST_int_eq(EC_KEY_generate_key(key), 1)
+        || !TEST_int_eq(EC_KEY_generate_key(aux_key), 1))
+        goto err;
+
+    /* Test setting a valid private key */
+    if (!TEST_int_eq(EC_KEY_set_private_key(key, aux_key->priv_key), 1))
+        goto err;
+
+    /* Test compliance with legacy behavior for NULL private keys */
+    if (!TEST_int_eq(EC_KEY_set_private_key(key, NULL), 0)
+        || !TEST_ptr_null(key->priv_key))
+        goto err;
+
+    testresult = 1;
+
+ err:
+    EC_KEY_free(key);
+    EC_KEY_free(aux_key);
+    return testresult;
+}
+
+/*
  * Tests behavior of the decoded_from_explicit_params flag and API
  */
 static int decoded_flag_test(void)
@@ -337,6 +370,7 @@ int setup_tests(void)
     ADD_TEST(field_tests_ec2_simple);
 #endif
     ADD_ALL_TESTS(field_tests_default, crv_len);
+    ADD_TEST(set_private_key);
     ADD_TEST(decoded_flag_test);
     ADD_ALL_TESTS(ecpkparams_i2d2i_test, crv_len);
 


### PR DESCRIPTION
This allows to set EC_KEY's private key to NULL.

Fixes #18744 in 1.1.1 branch.