### PR TITLE
Fix bug in EVP_CIPHER_CTX_get_iv_length()

### DIFF
--- a/crypto/evp/evp_lib.c
+++ b/crypto/evp/evp_lib.c
@@ -509,12 +509,17 @@ int EVP_CIPHER_CTX_get_iv_length(const EVP_CIPHER_CTX *ctx)
         size_t v = len;
         OSSL_PARAM params[2] = { OSSL_PARAM_END, OSSL_PARAM_END };
 
-        params[0] = OSSL_PARAM_construct_size_t(OSSL_CIPHER_PARAM_IVLEN, &v);
-        rv = evp_do_ciph_ctx_getparams(ctx->cipher, ctx->algctx, params);
-        if (rv != EVP_CTRL_RET_UNSUPPORTED) {
-            if (rv <= 0)
+        if (ctx->cipher->get_ctx_params != NULL) {
+            params[0] = OSSL_PARAM_construct_size_t(OSSL_CIPHER_PARAM_IVLEN,
+                                                    &v);
+            rv = evp_do_ciph_ctx_getparams(ctx->cipher, ctx->algctx, params);
+            if (rv > 0) {
+                if (OSSL_PARAM_modified(params)
+                        && !OSSL_PARAM_get_int(params, &len))
+                    return -1;
+            } else if (rv != EVP_CTRL_RET_UNSUPPORTED) {
                 return -1;
-            len = (int)v;
+            }
         }
         /* Code below to be removed when legacy support is dropped. */
         else if ((EVP_CIPHER_get_flags(ctx->cipher)

--- a/doc/man3/EVP_EncryptInit.pod
+++ b/doc/man3/EVP_EncryptInit.pod
@@ -1234,7 +1234,7 @@ length.
 EVP_CIPHER_CTX_set_padding() always returns 1.
 
 EVP_CIPHER_get_iv_length() and EVP_CIPHER_CTX_get_iv_length() return the IV
-length or zero if the cipher does not use an IV.
+length, zero if the cipher does not use an IV and a negative value on error.
 
 EVP_CIPHER_CTX_get_tag_length() return the tag length or zero if the cipher
 does not use a tag.


### PR DESCRIPTION
Out of range values could possibly be returned due to a lack of range checking.
Very unlikely to be exploitable for our provider because sensible values are returned for all ciphers.

Also fixed the defaulting code so that the cipher's IV length is returned if the cipher ctx doesn't support getting.
