### PR TITLE
REGRESSION: CMS_final: do not ignore CMS_dataFinal result

### DIFF
--- a/crypto/asn1/asn_mime.c
+++ b/crypto/asn1/asn_mime.c
@@ -69,6 +69,8 @@ static void mime_hdr_free(MIME_HEADER *hdr);
 int i2d_ASN1_bio_stream(BIO *out, ASN1_VALUE *val, BIO *in, int flags,
                         const ASN1_ITEM *it)
 {
+    int rv = 1;
+
     /* If streaming create stream BIO and copy all content through it */
     if (flags & SMIME_STREAM) {
         BIO *bio, *tbio;
@@ -77,7 +79,10 @@ int i2d_ASN1_bio_stream(BIO *out, ASN1_VALUE *val, BIO *in, int flags,
             ERR_raise(ERR_LIB_ASN1, ERR_R_MALLOC_FAILURE);
             return 0;
         }
-        SMIME_crlf_copy(in, bio, flags);
+        if (!SMIME_crlf_copy(in, bio, flags)) {
+            rv = 0;
+        }
+
         (void)BIO_flush(bio);
         /* Free up successive BIOs until we hit the old output BIO */
         do {
@@ -92,7 +97,7 @@ int i2d_ASN1_bio_stream(BIO *out, ASN1_VALUE *val, BIO *in, int flags,
      */
     else
         ASN1_item_i2d_bio(it, out, val);
-    return 1;
+    return rv;
 }
 
 /* Base 64 read and write of ASN1 structure */
@@ -346,8 +351,7 @@ static int asn1_output_data(BIO *out, BIO *data, ASN1_VALUE *val, int flags,
      * set up to finalise when it is written through.
      */
     if (!(flags & SMIME_DETACHED) || (flags & PKCS7_REUSE_DIGEST)) {
-        SMIME_crlf_copy(data, out, flags);
-        return 1;
+        return SMIME_crlf_copy(data, out, flags);
     }
 
     if (!aux || !aux->asn1_cb) {
@@ -365,7 +369,8 @@ static int asn1_output_data(BIO *out, BIO *data, ASN1_VALUE *val, int flags,
         return 0;
 
     /* Copy data across, passing through filter BIOs for processing */
-    SMIME_crlf_copy(data, sarg.ndef_bio, flags);
+    if (!SMIME_crlf_copy(data, sarg.ndef_bio, flags))
+        rv = 0;
 
     /* Finalize structure */
     if (aux->asn1_cb(ASN1_OP_DETACHED_POST, &val, it, &sarg) <= 0)
@@ -515,8 +520,10 @@ int SMIME_crlf_copy(BIO *in, BIO *out, int flags)
      * when streaming as we don't end up with one OCTET STRING per line.
      */
     bf = BIO_new(BIO_f_buffer());
-    if (bf == NULL)
+    if (bf == NULL) {
+        ERR_raise(ERR_LIB_ASN1, ERR_R_MALLOC_FAILURE);
         return 0;
+    }
     out = BIO_push(bf, out);
     if (flags & SMIME_BINARY) {
         while ((len = BIO_read(in, linebuf, MAX_SMLEN)) > 0)

--- a/crypto/cms/cms_smime.c
+++ b/crypto/cms/cms_smime.c
@@ -882,7 +882,7 @@ int CMS_final(CMS_ContentInfo *cms, BIO *data, BIO *dcont, unsigned int flags)
         return 0;
     }
 
-    ret = SMIME_crlf_copy(data, cmsbio, flags);
+    SMIME_crlf_copy(data, cmsbio, flags);
 
     (void)BIO_flush(cmsbio);
 
@@ -890,6 +890,9 @@ int CMS_final(CMS_ContentInfo *cms, BIO *data, BIO *dcont, unsigned int flags)
         ERR_raise(ERR_LIB_CMS, CMS_R_CMS_DATAFINAL_ERROR);
         goto err;
     }
+
+    ret = 1;
+
 err:
     do_free_upto(cmsbio, dcont);
 

--- a/crypto/cms/cms_smime.c
+++ b/crypto/cms/cms_smime.c
@@ -432,7 +432,8 @@ int CMS_verify(CMS_ContentInfo *cms, STACK_OF(X509) *certs,
          * Don't use SMIME_TEXT for verify: it adds headers and we want to
          * remove them.
          */
-        SMIME_crlf_copy(dcont, cmsbio, flags & ~SMIME_TEXT);
+        if (!SMIME_crlf_copy(dcont, cmsbio, flags & ~SMIME_TEXT))
+            goto err;
 
         if (flags & CMS_TEXT) {
             if (!SMIME_text(tmpout, out)) {
@@ -882,7 +883,9 @@ int CMS_final(CMS_ContentInfo *cms, BIO *data, BIO *dcont, unsigned int flags)
         return 0;
     }
 
-    SMIME_crlf_copy(data, cmsbio, flags);
+    if (!SMIME_crlf_copy(data, cmsbio, flags)) {
+        goto err;
+    }
 
     (void)BIO_flush(cmsbio);
 

--- a/crypto/pkcs7/pk7_smime.c
+++ b/crypto/pkcs7/pk7_smime.c
@@ -81,7 +81,8 @@ int PKCS7_final(PKCS7 *p7, BIO *data, int flags)
         return 0;
     }
 
-    SMIME_crlf_copy(data, p7bio, flags);
+    if (!SMIME_crlf_copy(data, p7bio, flags))
+        goto err;
 
     (void)BIO_flush(p7bio);
 


### PR DESCRIPTION
The CMS_dataFinal result is important as signature may fail, however, it
is ignored while returning success from CMS_final.

The SMIME_crlf_copy result is returned while it is ignored in the rest
of the openssl code.

Prefer the CMS_dataFinal result.

This is regression from openssl-1.

Blame finds c1669f41ei as root cause of regression.

Signed-off-by: Alon Bar-Lev <alon.barlev@gmail.com>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
