### PR TITLE
Update EVP_KDF-X942-ASN1.pod

### DIFF
--- a/doc/man7/EVP_KDF-X942-ASN1.pod
+++ b/doc/man7/EVP_KDF-X942-ASN1.pod
@@ -30,7 +30,7 @@ The supported parameters are:
 
 These parameters work as described in L<EVP_KDF(3)/PARAMETERS>.
 
-=item "key" (B<OSSL_KDF_PARAM_KEY>) <octet string>
+=item "secret" (B<OSSL_KDF_PARAM_SECRET>) <octet string>
 
 The shared secret used for key derivation.  This parameter sets the secret.
 
@@ -60,7 +60,7 @@ An optional octet string containing public info contributed by the responder.
 An optional octet string containing some additional, mutually-known public
 information. Setting this value also sets "use-keybits" to 0.
 
-=item "use-keybits" (B<OSSL_KDF_PARAM_X942_SUPP_PRIVINFO>) <integer>
+=item "use-keybits" (B<OSSL_KDF_PARAM_X942_USE_KEYBITS>) <integer>
 
 The default value of 1 will use the KEK key length (in bits) as the
 "supp-pubinfo". A value of 0 disables setting the "supp-pubinfo".


### PR DESCRIPTION
Replaced OSSL_KDF_PARAM_KEY with OSSL_KDF_PARAM_SECRET as that seems to be the intended value from the code (OSSL_KDF_PARAM_KEY is also supported but looks like a fallback).
Fixed name for OSSL_KDF_PARAM_X942_USE_KEYBITS.

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
