### PR TITLE
Flag modified when X509_req_info_st attribute updated

### DIFF
--- a/crypto/x509/x509_req.c
+++ b/crypto/x509/x509_req.c
@@ -227,44 +227,52 @@ X509_ATTRIBUTE *X509_REQ_get_attr(const X509_REQ *req, int loc)
 
 X509_ATTRIBUTE *X509_REQ_delete_attr(X509_REQ *req, int loc)
 {
-    return X509at_delete_attr(req->req_info.attributes, loc);
+    X509_ATTRIBUTE *attr = X509at_delete_attr(req->req_info.attributes, loc);
+
+    if (attr != NULL)
+        req->req_info.enc.modified = 1;
+    return attr;
 }
 
 int X509_REQ_add1_attr(X509_REQ *req, X509_ATTRIBUTE *attr)
 {
-    if (X509at_add1_attr(&req->req_info.attributes, attr))
-        return 1;
-    return 0;
+    if (!X509at_add1_attr(&req->req_info.attributes, attr))
+        return 0;
+    req->req_info.enc.modified = 1;
+    return 1;
 }
 
 int X509_REQ_add1_attr_by_OBJ(X509_REQ *req,
                               const ASN1_OBJECT *obj, int type,
                               const unsigned char *bytes, int len)
 {
-    if (X509at_add1_attr_by_OBJ(&req->req_info.attributes, obj,
-                                type, bytes, len))
-        return 1;
-    return 0;
+    if (!X509at_add1_attr_by_OBJ(&req->req_info.attributes, obj,
+                                 type, bytes, len))
+        return 0;
+    req->req_info.enc.modified = 1;
+    return 1;
 }
 
 int X509_REQ_add1_attr_by_NID(X509_REQ *req,
                               int nid, int type,
                               const unsigned char *bytes, int len)
 {
-    if (X509at_add1_attr_by_NID(&req->req_info.attributes, nid,
-                                type, bytes, len))
-        return 1;
-    return 0;
+    if (!X509at_add1_attr_by_NID(&req->req_info.attributes, nid,
+                                 type, bytes, len))
+        return 0;
+    req->req_info.enc.modified = 1;
+    return 1;
 }
 
 int X509_REQ_add1_attr_by_txt(X509_REQ *req,
                               const char *attrname, int type,
                               const unsigned char *bytes, int len)
 {
-    if (X509at_add1_attr_by_txt(&req->req_info.attributes, attrname,
-                                type, bytes, len))
-        return 1;
-    return 0;
+    if (!X509at_add1_attr_by_txt(&req->req_info.attributes, attrname,
+                                 type, bytes, len))
+        return 0;
+    req->req_info.enc.modified = 1;
+    return 1;
 }
 
 long X509_REQ_get_version(const X509_REQ *req)

--- a/crypto/x509/x_all.c
+++ b/crypto/x509/x_all.c
@@ -41,18 +41,26 @@ int NETSCAPE_SPKI_verify(NETSCAPE_SPKI *a, EVP_PKEY *r)
 
 int X509_sign(X509 *x, EVP_PKEY *pkey, const EVP_MD *md)
 {
-    x->cert_info.enc.modified = 1;
-    return (ASN1_item_sign(ASN1_ITEM_rptr(X509_CINF), &x->cert_info.signature,
-                           &x->sig_alg, &x->signature, &x->cert_info, pkey,
-                           md));
+    int ret = 0;
+
+    ret = ASN1_item_sign(ASN1_ITEM_rptr(X509_CINF), &x->cert_info.signature,
+                         &x->sig_alg, &x->signature, &x->cert_info, pkey,
+                         md);
+    if (ret > 0)
+        x->cert_info.enc.modified = 1;
+    return ret;
 }
 
 int X509_sign_ctx(X509 *x, EVP_MD_CTX *ctx)
 {
-    x->cert_info.enc.modified = 1;
-    return ASN1_item_sign_ctx(ASN1_ITEM_rptr(X509_CINF),
-                              &x->cert_info.signature,
-                              &x->sig_alg, &x->signature, &x->cert_info, ctx);
+    int ret = 0;
+
+    ret = ASN1_item_sign_ctx(ASN1_ITEM_rptr(X509_CINF),
+                             &x->cert_info.signature,
+                             &x->sig_alg, &x->signature, &x->cert_info, ctx);
+    if (ret > 0)
+        x->cert_info.enc.modified = 1;
+    return ret;
 }
 
 #ifndef OPENSSL_NO_OCSP
@@ -65,32 +73,48 @@ int X509_http_nbio(OCSP_REQ_CTX *rctx, X509 **pcert)
 
 int X509_REQ_sign(X509_REQ *x, EVP_PKEY *pkey, const EVP_MD *md)
 {
-    x->req_info.enc.modified = 1;
-    return (ASN1_item_sign(ASN1_ITEM_rptr(X509_REQ_INFO), &x->sig_alg, NULL,
-                           x->signature, &x->req_info, pkey, md));
+    int ret = 0;
+
+    ret = ASN1_item_sign(ASN1_ITEM_rptr(X509_REQ_INFO), &x->sig_alg, NULL,
+                         x->signature, &x->req_info, pkey, md);
+    if (ret > 0)
+        x->req_info.enc.modified = 1;
+    return ret;
 }
 
 int X509_REQ_sign_ctx(X509_REQ *x, EVP_MD_CTX *ctx)
 {
-    x->req_info.enc.modified = 1;
-    return ASN1_item_sign_ctx(ASN1_ITEM_rptr(X509_REQ_INFO),
-                              &x->sig_alg, NULL, x->signature, &x->req_info,
-                              ctx);
+    int ret = 0;
+
+    ret = ASN1_item_sign_ctx(ASN1_ITEM_rptr(X509_REQ_INFO),
+                             &x->sig_alg, NULL, x->signature, &x->req_info,
+                             ctx);
+    if (ret > 0)
+        x->req_info.enc.modified = 1;
+    return ret;
 }
 
 int X509_CRL_sign(X509_CRL *x, EVP_PKEY *pkey, const EVP_MD *md)
 {
-    x->crl.enc.modified = 1;
-    return (ASN1_item_sign(ASN1_ITEM_rptr(X509_CRL_INFO), &x->crl.sig_alg,
-                           &x->sig_alg, &x->signature, &x->crl, pkey, md));
+    int ret = 0;
+
+    ret = ASN1_item_sign(ASN1_ITEM_rptr(X509_CRL_INFO), &x->crl.sig_alg,
+                         &x->sig_alg, &x->signature, &x->crl, pkey, md);
+    if (ret > 0)
+        x->crl.enc.modified = 1;
+    return ret;
 }
 
 int X509_CRL_sign_ctx(X509_CRL *x, EVP_MD_CTX *ctx)
 {
-    x->crl.enc.modified = 1;
-    return ASN1_item_sign_ctx(ASN1_ITEM_rptr(X509_CRL_INFO),
-                              &x->crl.sig_alg, &x->sig_alg, &x->signature,
-                              &x->crl, ctx);
+    int ret = 0;
+
+    ret = ASN1_item_sign_ctx(ASN1_ITEM_rptr(X509_CRL_INFO),
+                             &x->crl.sig_alg, &x->sig_alg, &x->signature,
+                             &x->crl, ctx);
+    if (ret > 0)
+        x->crl.enc.modified = 1;
+    return ret;
 }
 
 #ifndef OPENSSL_NO_OCSP

--- a/crypto/x509/x_all.c
+++ b/crypto/x509/x_all.c
@@ -65,12 +65,14 @@ int X509_http_nbio(OCSP_REQ_CTX *rctx, X509 **pcert)
 
 int X509_REQ_sign(X509_REQ *x, EVP_PKEY *pkey, const EVP_MD *md)
 {
+    x->req_info.enc.modified = 1;
     return (ASN1_item_sign(ASN1_ITEM_rptr(X509_REQ_INFO), &x->sig_alg, NULL,
                            x->signature, &x->req_info, pkey, md));
 }
 
 int X509_REQ_sign_ctx(X509_REQ *x, EVP_MD_CTX *ctx)
 {
+    x->req_info.enc.modified = 1;
     return ASN1_item_sign_ctx(ASN1_ITEM_rptr(X509_REQ_INFO),
                               &x->sig_alg, NULL, x->signature, &x->req_info,
                               ctx);


### PR DESCRIPTION
If `X509_REQ` is created by `PEM_read_X509_REQ` and only the attribute is changed, it is not exported as intended by `PEM_write_X509_REQ` Because the non-updated `enc` is used.
This patch turns on the modified flag when an attribute change occurs.

To reproduce:
1. Create a CSR file with extensions.
```
Certificate Request:
    Data:
        Version: 1 (0x0)
        Subject: C = KR, ST = dkfs, L = kdslf, O = klsdfjkldfjsd, OU = kdlfsjfdskl, CN = kfldsjdfs
        Subject Public Key Info:
            Public Key Algorithm: rsaEncryption
                RSA Public-Key: (2048 bit)
                Modulus:
                    00:c8:25:ae:fe:f2:a7:9a:54:c8:ce:6f:1f:d6:10:
                    0d:b7:7c:e2:0b:fe:c3:bc:68:f0:86:52:45:50:2b:
                    d5:f4:82:b8:3d:ab:85:14:0b:4e:6c:b7:00:12:e6:
                    9e:a8:98:29:32:b6:c2:a1:85:10:4c:93:68:d2:4e:
                    4e:04:df:e3:4f:53:da:ea:da:67:30:ee:d2:6b:15:
                    74:55:f2:7a:43:1c:1a:02:18:62:98:14:6f:b7:1d:
                    49:d4:e5:60:db:ca:80:43:34:28:c9:aa:79:fe:38:
                    5f:34:66:2f:53:d5:b5:6e:05:14:6e:97:c2:cb:d3:
                    1f:76:80:a0:bf:f9:86:96:02:00:4a:ac:6c:4d:ab:
                    1b:59:46:46:bd:46:53:9f:02:ca:45:86:6d:95:75:
                    ec:51:41:25:48:11:3d:72:b1:05:22:0c:61:b4:74:
                    2e:b0:09:1e:99:cb:2a:fd:e0:9e:3f:c4:96:85:c0:
                    24:0d:db:50:ca:74:74:5c:e2:b7:23:9f:12:e1:01:
                    24:39:6e:86:63:6b:1c:51:18:2d:ec:32:03:03:28:
                    85:b4:3e:56:42:fd:d0:2c:36:ab:f6:14:89:2b:8e:
                    55:a9:0a:63:29:3e:33:ce:a8:25:ca:55:8c:a6:6d:
                    56:47:f3:9d:88:31:82:60:fd:1e:5f:12:71:65:47:
                    1d:e1
                Exponent: 65537 (0x10001)
        Attributes:
        Requested Extensions:
            X509v3 Basic Constraints: critical
                CA:FALSE
            X509v3 Extended Key Usage: 
                TLS Web Server Authentication, TLS Web Client Authentication, Code Signing, E-mail Protection
            X509v3 Key Usage: 
                Digital Signature, Non Repudiation, Key Encipherment
    Signature Algorithm: sha256WithRSAEncryption
         06:85:a4:ff:19:a0:63:5e:ed:69:99:37:20:3d:ab:1f:c7:86:
         e2:d9:98:70:ca:0e:b3:21:52:66:99:f6:b1:06:22:a7:9d:40:
         7a:56:e4:1e:73:e8:e5:de:96:7f:e6:31:09:e3:5d:17:a5:4f:
         3d:ac:93:de:d7:4c:bc:1b:1c:db:d4:c9:2e:a9:f3:d1:81:8c:
         e1:60:97:af:51:59:d4:12:81:41:ba:b6:7b:c0:a1:f7:4d:87:
         b0:a5:12:aa:11:94:0b:5d:23:4a:b8:19:e8:ba:80:3e:c5:5c:
         59:b5:e7:41:21:b8:8a:2c:c4:39:5b:0c:29:92:62:cc:d6:8a:
         b8:11:27:9c:f8:09:4d:21:88:54:ea:ff:97:70:a3:43:57:06:
         a5:01:ed:64:d9:b5:7f:2d:ff:a2:05:e8:81:46:6d:7c:01:52:
         02:df:bb:04:91:e5:3f:2f:84:2f:71:b5:54:6d:0e:b2:f7:98:
         bf:c6:1e:b8:1f:03:71:7e:9f:1c:2d:b6:2e:5e:d1:e3:a8:27:
         71:de:ed:74:12:ce:44:b5:90:79:15:04:ff:a3:09:b7:8e:2d:
         6c:4f:e0:f8:62:56:a9:3b:f2:a6:12:60:84:95:58:2b:d6:c4:
         c5:48:63:f6:5c:4f:3c:e4:c0:b9:25:81:94:eb:1c:11:a8:22:
         84:37:d4:03
-----BEGIN CERTIFICATE REQUEST-----
MIIDEjCCAfoCAQAwbjELMAkGA1UEBhMCS1IxDTALBgNVBAgMBGRrZnMxDjAMBgNV
BAcMBWtkc2xmMRYwFAYDVQQKDA1rbHNkZmprbGRmanNkMRQwEgYDVQQLDAtrZGxm
c2pmZHNrbDESMBAGA1UEAwwJa2ZsZHNqZGZzMIIBIjANBgkqhkiG9w0BAQEFAAOC
AQ8AMIIBCgKCAQEAyCWu/vKnmlTIzm8f1hANt3ziC/7DvGjwhlJFUCvV9IK4PauF
FAtObLcAEuaeqJgpMrbCoYUQTJNo0k5OBN/jT1Pa6tpnMO7SaxV0VfJ6QxwaAhhi
mBRvtx1J1OVg28qAQzQoyap5/jhfNGYvU9W1bgUUbpfCy9MfdoCgv/mGlgIASqxs
TasbWUZGvUZTnwLKRYZtlXXsUUElSBE9crEFIgxhtHQusAkemcsq/eCeP8SWhcAk
DdtQynR0XOK3I58S4QEkOW6GY2scURgt7DIDAyiFtD5WQv3QLDar9hSJK45VqQpj
KT4zzqglylWMpm1WR/OdiDGCYP0eXxJxZUcd4QIDAQABoF8wXQYJKoZIhvcNAQkO
MVAwTjAMBgNVHRMBAf8EAjAAMDEGA1UdJQQqMCgGCCsGAQUFBwMBBggrBgEFBQcD
AgYIKwYBBQUHAwMGCCsGAQUFBwMEMAsGA1UdDwQEAwIF4DANBgkqhkiG9w0BAQsF
AAOCAQEABoWk/xmgY17taZk3ID2rH8eG4tmYcMoOsyFSZpn2sQYip51AelbkHnPo
5d6Wf+YxCeNdF6VPPayT3tdMvBsc29TJLqnz0YGM4WCXr1FZ1BKBQbq2e8Ch902H
sKUSqhGUC10jSrgZ6LqAPsVcWbXnQSG4iizEOVsMKZJizNaKuBEnnPgJTSGIVOr/
l3CjQ1cGpQHtZNm1fy3/ogXogUZtfAFSAt+7BJHlPy+EL3G1VG0OsveYv8YeuB8D
cX6fHC22Ll7R46gncd7tdBLORLWQeRUE/6MJt44tbE/g+GJWqTvyphJghJVYK9bE
xUhj9lxPPOTAuSWBlOscEagihDfUAw==
-----END CERTIFICATE REQUEST-----
```
2. Compile and run this C code. This code removes the requested extensions and save as `edited.csr`
```C
#include <stdio.h>
#include <openssl/crypto.h>
#include <openssl/x509v3.h>
#include <openssl/pem.h>
#include <openssl/err.h>

int main()
{
        /*
        FILE *f = fopen("privekey.key","rb");
        EVP_PKEY *privkey = NULL;
        if(PEM_read_PrivateKey(f,&privkey,NULL,NULL) == NULL)
                printf("error\n");
        fclose(f);
        */

        FILE *f = fopen("test.csr","rb");
        X509_REQ *req = NULL;
        if(PEM_read_X509_REQ(f,&req,NULL,NULL) == NULL)
                printf("x509 req error\n");
        fclose(f);

        int attr_len = X509_REQ_get_attr_count(req);
        printf("count : %d\n",attr_len);

        X509_REQ_delete_attr(req,0);

        attr_len = X509_REQ_get_attr_count(req);
        printf("count : %d\n",attr_len);

        /*
        if(X509_REQ_sign(req,privkey,NULL) == 0)
                printf("sign error\n");
        */

        f = fopen("edited.csr","wb");
        PEM_write_X509_REQ(f,req);
        fclose(f);
        return 0;
}
```
3. edited.csr still has `Requested Extensions`
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->