### PR TITLE
Fix quotes install_fips in Configurations/windows-makefile.tmpl

### DIFF
--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -500,8 +500,8 @@ uninstall_docs: uninstall_html_docs
 {- output_off() if $disabled{fips}; "" -}
 install_fips: build_sw $(INSTALL_FIPSMODULECONF)
 #	@[ -n "$(INSTALLTOP)" ] || (echo INSTALLTOP should not be empty; exit 1)
-	@$(PERL) $(SRCDIR)\util\mkdir-p.pl $(MODULESDIR)
-	@$(PERL) $(SRCDIR)\util\mkdir-p.pl $(OPENSSLDIR)
+	@"$(PERL)" "$(SRCDIR)\util\mkdir-p.pl" "$(MODULESDIR)"
+	@"$(PERL)" "$(SRCDIR)\util\mkdir-p.pl" "$(OPENSSLDIR)"
 	@$(ECHO) "*** Installing FIPS module"
 	@$(ECHO) "install $(INSTALL_FIPSMODULE) -> $(MODULESDIR)\$(FIPSMODULENAME)"
 	@"$(PERL)" "$(SRCDIR)\util\copy.pl" "$(INSTALL_FIPSMODULE)" "$(MODULESDIR)"


### PR DESCRIPTION
Directories and file names with spaces require quoting...  again

Fixes #18880
