### PR TITLE
Correction: uncompressed is the default value

### DIFF
--- a/doc/man1/openssl-ec.pod.in
+++ b/doc/man1/openssl-ec.pod.in
@@ -118,8 +118,8 @@ a public key.
 =item B<-conv_form> I<arg>
 
 This specifies how the points on the elliptic curve are converted
-into octet strings. Possible values are: B<compressed> (the default
-value), B<uncompressed> and B<hybrid>. For more information regarding
+into octet strings. Possible values are: B<compressed>, B<uncompressed> (the
+default value) and B<hybrid>. For more information regarding
 the point conversion forms please read the X9.62 standard.
 B<Note> Due to patent issues the B<compressed> option is disabled
 by default for binary curves and can be enabled by defining


### PR DESCRIPTION
CLA: trivial

The description was incorrect. The uncompressed is the default value.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
