### PR TITLE
Check that IV length is not less than zero

### DIFF
--- a/crypto/cms/cms_enc.c
+++ b/crypto/cms/cms_enc.c
@@ -83,6 +83,11 @@ BIO *ossl_cms_EncryptedContent_init_bio(CMS_EncryptedContentInfo *ec,
         calg->algorithm = OBJ_nid2obj(EVP_CIPHER_CTX_get_type(ctx));
         /* Generate a random IV if we need one */
         ivlen = EVP_CIPHER_CTX_get_iv_length(ctx);
+        if (ivlen < 0) {
+            ERR_raise(ERR_LIB_CMS, ERR_R_EVP_LIB);
+            goto err;
+        }
+
         if (ivlen > 0) {
             if (RAND_bytes_ex(libctx, iv, ivlen, 0) <= 0)
                 goto err;

--- a/crypto/cms/cms_pwri.c
+++ b/crypto/cms/cms_pwri.c
@@ -96,6 +96,10 @@ CMS_RecipientInfo *CMS_add0_recipient_password(CMS_ContentInfo *cms,
     }
 
     ivlen = EVP_CIPHER_CTX_get_iv_length(ctx);
+    if (ivlen < 0) {
+        ERR_raise(ERR_LIB_CMS, ERR_R_EVP_LIB);
+        goto err;
+    }
 
     if (ivlen > 0) {
         if (RAND_bytes_ex(ossl_cms_ctx_get0_libctx(cms_ctx), iv, ivlen, 0) <= 0)

--- a/ssl/ktls.c
+++ b/ssl/ktls.c
@@ -132,8 +132,11 @@ int ktls_configure_crypto(SSL_CONNECTION *s, const EVP_CIPHER *c,
     case SSL_AES128GCM:
     case SSL_AES256GCM:
         crypto_info->cipher_algorithm = CRYPTO_AES_NIST_GCM_16;
-        if (s->version == TLS1_3_VERSION)
+        if (s->version == TLS1_3_VERSION) {
             crypto_info->iv_len = EVP_CIPHER_CTX_get_iv_length(dd);
+            if (crypto_info->iv_len < 0)
+                return 0;
+        }
         else
             crypto_info->iv_len = EVP_GCM_TLS_FIXED_IV_LEN;
         break;
@@ -141,6 +144,8 @@ int ktls_configure_crypto(SSL_CONNECTION *s, const EVP_CIPHER *c,
     case SSL_CHACHA20POLY1305:
         crypto_info->cipher_algorithm = CRYPTO_CHACHA20_POLY1305;
         crypto_info->iv_len = EVP_CIPHER_CTX_get_iv_length(dd);
+        if (crypto_info->iv_len < 0)
+            return 0;
         break;
 # endif
     case SSL_AES128:

--- a/ssl/record/rec_layer_d1.c
+++ b/ssl/record/rec_layer_d1.c
@@ -883,6 +883,10 @@ int do_dtls1_write(SSL_CONNECTION *sc, int type, const unsigned char *buf,
         int mode = EVP_CIPHER_CTX_get_mode(sc->enc_write_ctx);
         if (mode == EVP_CIPH_CBC_MODE) {
             eivlen = EVP_CIPHER_CTX_get_iv_length(sc->enc_write_ctx);
+            if (eivlen < 0) {
+                SSLfatal(sc, SSL_AD_INTERNAL_ERROR, SSL_R_LIBRARY_BUG);
+                return -1;
+            }
             if (eivlen <= 1)
                 eivlen = 0;
         }

--- a/ssl/record/rec_layer_s3.c
+++ b/ssl/record/rec_layer_s3.c
@@ -862,6 +862,10 @@ int do_ssl3_write(SSL_CONNECTION *s, int type, const unsigned char *buf,
         int mode = EVP_CIPHER_CTX_get_mode(s->enc_write_ctx);
         if (mode == EVP_CIPH_CBC_MODE) {
             eivlen = EVP_CIPHER_CTX_get_iv_length(s->enc_write_ctx);
+            if (eivlen < 0) {
+                SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_R_LIBRARY_BUG);
+                return -1;
+	    }
             if (eivlen <= 1)
                 eivlen = 0;
         } else if (mode == EVP_CIPH_GCM_MODE) {

--- a/ssl/record/ssl3_record_tls13.c
+++ b/ssl/record/ssl3_record_tls13.c
@@ -25,7 +25,8 @@ int tls13_enc(SSL_CONNECTION *s, SSL3_RECORD *recs, size_t n_recs, int sending,
 {
     EVP_CIPHER_CTX *ctx;
     unsigned char iv[EVP_MAX_IV_LENGTH], recheader[SSL3_RT_HEADER_LENGTH];
-    size_t ivlen, taglen, offset, loop, hdrlen;
+    size_t taglen, offset, loop, hdrlen;
+    int ivlen;
     unsigned char *staticiv;
     unsigned char *seq;
     int lenu, lenf;
@@ -62,6 +63,10 @@ int tls13_enc(SSL_CONNECTION *s, SSL3_RECORD *recs, size_t n_recs, int sending,
     }
 
     ivlen = EVP_CIPHER_CTX_get_iv_length(ctx);
+    if (ivlen < 0) {
+        SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
+        return 0;
+    }
 
     if (s->early_data_state == SSL_EARLY_DATA_WRITING
             || s->early_data_state == SSL_EARLY_DATA_WRITE_RETRY) {

--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -3809,6 +3809,10 @@ static int construct_stateless_ticket(SSL_CONNECTION *s, WPACKET *pkt,
             goto err;
         }
         iv_len = EVP_CIPHER_CTX_get_iv_length(ctx);
+        if (iv_len < 0) {
+            SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
+            goto err;
+        }
     } else {
         EVP_CIPHER *cipher = EVP_CIPHER_fetch(sctx->libctx, "AES-256-CBC",
                                               sctx->propq);


### PR DESCRIPTION
As EVP_CIPHER_CTX_get_iv_length indicates failure with -1, this error
should be processed. Also the result of this function shouldn't be
assigned to an unsigned variable.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
