### PR TITLE
Updating ifdefs to account for xlclang compiler frontend on AIX. The …

### DIFF
--- a/providers/fips/self_test.c
+++ b/providers/fips/self_test.c
@@ -104,7 +104,7 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
     return TRUE;
 }
 
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) && !defined(_AIX)
 # undef DEP_INIT_ATTRIBUTE
 # undef DEP_FINI_ATTRIBUTE
 # define DEP_INIT_ATTRIBUTE static __attribute__((constructor))
@@ -114,7 +114,7 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
 # pragma init(init)
 # pragma fini(cleanup)
 
-#elif defined(_AIX)
+#elif defined(_AIX) && !defined(__GNUC__)
 void _init(void);
 void _cleanup(void);
 # pragma init(_init)


### PR DESCRIPTION
…fallback DEP works fine there. XLC should be unaffected.

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
