### PR TITLE
test_external_oqsprovider: Use working checkout of liboqs

### DIFF
--- a/test/recipes/95-test_external_oqsprovider_data/oqsprovider.sh
+++ b/test/recipes/95-test_external_oqsprovider_data/oqsprovider.sh
@@ -50,8 +50,9 @@ if [ ! -d $SRCTOP/oqs-provider/oqs ]; then
 # https://github.com/open-quantum-safe/liboqs/wiki/Customizing-liboqs
 (
        cd $SRCTOP/oqs-provider \
-           && git clone --depth 1 --branch main https://github.com/open-quantum-safe/liboqs.git \
+           && git clone --shallow-since=2022-07-01 --branch main https://github.com/open-quantum-safe/liboqs.git \
            && cd liboqs \
+           && git checkout 2c687b122084902ab287bb4a5497872e06cf2bf4 \
            && mkdir build \
            && cd build \
            && cmake -DOQS_ENABLE_SIG_RAINBOW=OFF -DCMAKE_INSTALL_PREFIX=$SRCTOP/oqs-provider/oqs .. \


### PR DESCRIPTION
Fixes #18898

Urgent because the CI is broken.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
