### PR TITLE
APPS: generalize `load_csr()` and remove obsolete `OBJ_create()`

### DIFF
--- a/apps/ca.c
+++ b/apps/ca.c
@@ -168,7 +168,8 @@ const OPTIONS ca_options[] = {
     {"quiet", OPT_QUIET, '-', "Terse output during processing"},
     {"outdir", OPT_OUTDIR, '/', "Where to put output cert"},
     {"in", OPT_IN, '<', "The input cert request(s)"},
-    {"inform", OPT_INFORM, 'F', "CSR input format (DER or PEM); default PEM"},
+    {"inform", OPT_INFORM, 'F',
+     "CSR input format to try first (DER or PEM); default PEM"},
     {"infiles", OPT_INFILES, '-', "The last argument, requests to process"},
     {"out", OPT_OUT, '>', "Where to put the output file(s)"},
     {"dateopt", OPT_DATEOPT, 's', "Datetime format used for printing. (rfc_822/iso_8601). Default is rfc_822."},
@@ -1374,7 +1375,7 @@ static int certify(X509 **xret, const char *infile, int informat,
     EVP_PKEY *pktmp = NULL;
     int ok = -1, i;
 
-    req = load_csr(infile, informat, "certificate request");
+    req = load_csr_autofmt(infile, informat, "certificate request");
     if (req == NULL)
         goto end;
     if ((pktmp = X509_REQ_get0_pubkey(req)) == NULL) {

--- a/apps/ca.c
+++ b/apps/ca.c
@@ -169,7 +169,7 @@ const OPTIONS ca_options[] = {
     {"outdir", OPT_OUTDIR, '/', "Where to put output cert"},
     {"in", OPT_IN, '<', "The input cert request(s)"},
     {"inform", OPT_INFORM, 'F',
-     "CSR input format to try first (DER or PEM); default PEM"},
+     "CSR input format to use (PEM or DER; by default try PEM first)"},
     {"infiles", OPT_INFILES, '-', "The last argument, requests to process"},
     {"out", OPT_OUT, '>', "Where to put the output file(s)"},
     {"dateopt", OPT_DATEOPT, 's', "Datetime format used for printing. (rfc_822/iso_8601). Default is rfc_822."},

--- a/apps/include/apps.h
+++ b/apps/include/apps.h
@@ -114,6 +114,7 @@ char *get_passwd(const char *pass, const char *desc);
 int app_passwd(const char *arg1, const char *arg2, char **pass1, char **pass2);
 int add_oid_section(CONF *conf);
 X509_REQ *load_csr(const char *file, int format, const char *desc);
+X509_REQ *load_csr_autofmt(const char *infile, int format, const char *desc);
 X509 *load_cert_pass(const char *uri, int format, int maybe_stdin,
                      const char *pass, const char *desc);
 #define load_cert(uri, format, desc) load_cert_pass(uri, format, 1, NULL, desc)

--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -496,6 +496,7 @@ X509_CRL *load_crl(const char *uri, int format, int maybe_stdin,
     return crl;
 }
 
+/* Could be simplified if OSSL_STORE supported CSRs, see FR #15725 */
 X509_REQ *load_csr(const char *file, int format, const char *desc)
 {
     X509_REQ *req = NULL;
@@ -503,8 +504,6 @@ X509_REQ *load_csr(const char *file, int format, const char *desc)
 
     if (format == FORMAT_UNDEF)
         format = FORMAT_PEM;
-    if (desc == NULL)
-        desc = "CSR";
     in = bio_open_default(file, 'r', format);
     if (in == NULL)
         goto end;
@@ -519,10 +518,44 @@ X509_REQ *load_csr(const char *file, int format, const char *desc)
  end:
     if (req == NULL) {
         ERR_print_errors(bio_err);
-        BIO_printf(bio_err, "Unable to load %s\n", desc);
+        if (desc != NULL)
+            BIO_printf(bio_err, "Unable to load %s\n", desc);
     }
     BIO_free(in);
     return req;
+}
+
+/* Better extend OSSL_STORE to support CSRs, see FR #15725 */
+X509_REQ *load_csr_autofmt(const char *infile, int format, const char *desc)
+{
+    X509_REQ *csr;
+    BIO *bio_bak = bio_err;
+
+    if (format == FORMAT_UNDEF)
+        format = FORMAT_PEM;
+    bio_err = NULL; /* do not show errors on more than one try */
+    csr = load_csr(infile, format, NULL /* desc */);
+    bio_err = bio_bak;
+    if (csr == NULL) {
+        ERR_clear_error();
+        format = format == FORMAT_PEM ? FORMAT_ASN1 : FORMAT_PEM;
+        csr = load_csr(infile, format, NULL /* desc */);
+    }
+    if (csr == NULL) {
+        BIO_printf(bio_err, "error: unable to load %s from file '%s'\n", desc,
+                   infile);
+    } else {
+        EVP_PKEY *pkey = X509_REQ_get0_pubkey(csr);
+        int ret = do_X509_REQ_verify(csr, pkey, NULL /* vfyopts */);
+
+        if (pkey == NULL || ret < 0)
+            BIO_puts(bio_err, "Warning: error while verifying CSR self-signature");
+        else if (ret == 0)
+            BIO_puts(bio_err, "Warning: CSR self-signature does not match the contents");
+        return csr;
+    }
+    ERR_print_errors(bio_err);
+    return NULL;
 }
 
 void cleanse(char *str)

--- a/apps/req.c
+++ b/apps/req.c
@@ -103,7 +103,8 @@ const OPTIONS req_options[] = {
      "Specify engine to be used for key generation operations"},
 #endif
     {"in", OPT_IN, '<', "X.509 request input file (default stdin)"},
-    {"inform", OPT_INFORM, 'F', "CSR input format to try first - DER or PEM"},
+    {"inform", OPT_INFORM, 'F',
+     "CSR input format to use (PEM or DER; by default try PEM first)"},
     {"verify", OPT_VERIFY, '-', "Verify self-signature on the request"},
 
     OPT_SECTION("Certificate"),

--- a/apps/req.c
+++ b/apps/req.c
@@ -103,7 +103,7 @@ const OPTIONS req_options[] = {
      "Specify engine to be used for key generation operations"},
 #endif
     {"in", OPT_IN, '<', "X.509 request input file (default stdin)"},
-    {"inform", OPT_INFORM, 'F', "Input format - DER or PEM"},
+    {"inform", OPT_INFORM, 'F', "CSR input format to try first - DER or PEM"},
     {"verify", OPT_VERIFY, '-', "Verify self-signature on the request"},
 
     OPT_SECTION("Certificate"),
@@ -729,8 +729,8 @@ int req_main(int argc, char **argv)
         if (keyfile != NULL)
             BIO_printf(bio_err,
                        "Warning: Not placing -key in cert or request since request is used\n");
-        req = load_csr(infile /* if NULL, reads from stdin */,
-                       informat, "X509 request");
+        req = load_csr_autofmt(infile /* if NULL, reads from stdin */,
+                               informat, "X509 request");
         if (req == NULL)
             goto end;
     } else if (infile != NULL) {

--- a/apps/x509.c
+++ b/apps/x509.c
@@ -70,7 +70,7 @@ const OPTIONS x509_options[] = {
     {"copy_extensions", OPT_COPY_EXTENSIONS, 's',
      "copy extensions when converting from CSR to x509 or vice versa"},
     {"inform", OPT_INFORM, 'f',
-     "CSR input file format to try first (DER or PEM) - default PEM"},
+     "CSR input format to use (PEM or DER; by default try PEM first)"},
     {"vfyopt", OPT_VFYOPT, 's', "CSR verification parameter in n:v form"},
     {"key", OPT_KEY, 's',
      "Key for signing, and to include unless using -force_pubkey"},

--- a/apps/x509.c
+++ b/apps/x509.c
@@ -70,7 +70,7 @@ const OPTIONS x509_options[] = {
     {"copy_extensions", OPT_COPY_EXTENSIONS, 's',
      "copy extensions when converting from CSR to x509 or vice versa"},
     {"inform", OPT_INFORM, 'f',
-     "CSR input file format (DER or PEM) - default PEM"},
+     "CSR input file format to try first (DER or PEM) - default PEM"},
     {"vfyopt", OPT_VFYOPT, 's', "CSR verification parameter in n:v form"},
     {"key", OPT_KEY, 's',
      "Key for signing, and to include unless using -force_pubkey"},
@@ -706,7 +706,7 @@ int x509_main(int argc, char **argv)
         if (infile == NULL)
             BIO_printf(bio_err,
                        "Warning: Reading cert request from stdin since no -in option is given\n");
-        req = load_csr(infile, informat, "certificate request input");
+        req = load_csr_autofmt(infile, informat, "certificate request input");
         if (req == NULL)
             goto end;
 

--- a/apps/x509.c
+++ b/apps/x509.c
@@ -782,9 +782,6 @@ int x509_main(int argc, char **argv)
     if (out == NULL)
         goto end;
 
-    if (!noout || text || next_serial)
-        OBJ_create("2.99999.3", "SET.ex3", "SET x509v3 extension 3");
-
     if (alias)
         X509_alias_set1(x, (unsigned char *)alias, -1);
 

--- a/doc/man1/openssl-ca.pod.in
+++ b/doc/man1/openssl-ca.pod.in
@@ -119,8 +119,8 @@ signed by the CA.
 
 =item B<-inform> B<DER>|B<PEM>
 
-The format of the data in certificate request input files;
-unspecified by default.
+The format to try first when loading certificate request (CSR) input files;
+PEM by default.
 See L<openssl-format-options(1)> for details.
 
 =item B<-ss_cert> I<filename>

--- a/doc/man1/openssl-ca.pod.in
+++ b/doc/man1/openssl-ca.pod.in
@@ -119,8 +119,8 @@ signed by the CA.
 
 =item B<-inform> B<DER>|B<PEM>
 
-The format to try first when loading certificate request (CSR) input files;
-PEM by default.
+The format to use when loading certificate request (CSR) input files;
+by default PEM is tried first.
 See L<openssl-format-options(1)> for details.
 
 =item B<-ss_cert> I<filename>

--- a/doc/man1/openssl-req.pod.in
+++ b/doc/man1/openssl-req.pod.in
@@ -72,7 +72,7 @@ Print out a usage message.
 
 =item B<-inform> B<DER>|B<PEM>
 
-The CSR input file format to try first; PEM by default.
+The CSR input file format to use; by default PEM is tried first.
 See L<openssl-format-options(1)> for details.
 
 =item B<-outform> B<DER>|B<PEM>

--- a/doc/man1/openssl-req.pod.in
+++ b/doc/man1/openssl-req.pod.in
@@ -70,9 +70,14 @@ for use as root CAs for example.
 
 Print out a usage message.
 
-=item B<-inform> B<DER>|B<PEM>, B<-outform> B<DER>|B<PEM>
+=item B<-inform> B<DER>|B<PEM>
 
-The input and output formats; unspecified by default.
+The CSR input file format to try first; PEM by default.
+See L<openssl-format-options(1)> for details.
+
+=item B<-outform> B<DER>|B<PEM>
+
+The output format; unspecified by default.
 See L<openssl-format-options(1)> for details.
 
 The data is a PKCS#10 object.

--- a/doc/man1/openssl-x509.pod.in
+++ b/doc/man1/openssl-x509.pod.in
@@ -155,7 +155,7 @@ The B<-ext> option can be used to further restrict which extensions to copy.
 
 =item B<-inform> B<DER>|B<PEM>
 
-The input file format to try first; PEM by default.
+The input file format to use; by default PEM is tried first.
 See L<openssl-format-options(1)> for details.
 
 =item B<-vfyopt> I<nm>:I<v>

--- a/doc/man1/openssl-x509.pod.in
+++ b/doc/man1/openssl-x509.pod.in
@@ -155,7 +155,7 @@ The B<-ext> option can be used to further restrict which extensions to copy.
 
 =item B<-inform> B<DER>|B<PEM>
 
-The input file format; unspecified by default.
+The input file format to try first; PEM by default.
 See L<openssl-format-options(1)> for details.
 
 =item B<-vfyopt> I<nm>:I<v>


### PR DESCRIPTION
This has been carved out of #16006 and slightly extended.
* Move `load_csr_autofmt()` from `apps/cmp.c` to `apps.c` and use it also for other apps
* `apps/x509.c:` Remove legacy call to `OBJ_create()`

