### PR TITLE
ec_kmgmt.c: Do not crash when getting OSSL_PKEY_PARAM_ENCODED_PUBLIC_KEY

### DIFF
--- a/doc/man3/EVP_PKEY_fromdata.pod
+++ b/doc/man3/EVP_PKEY_fromdata.pod
@@ -53,6 +53,9 @@ the settable parameters that can be used with EVP_PKEY_fromdata().
 I<selection> is described in L</Selections>.
 See L<OSSL_PARAM(3)> for the use of B<OSSL_PARAM> as parameter descriptor.
 
+Parameters in the I<params> array that are not among the settable parameters
+for the given I<selection> are ignored.
+
 =head2 Selections
 
 The following constants can be used for I<selection>:

--- a/doc/man7/EVP_PKEY-EC.pod
+++ b/doc/man7/EVP_PKEY-EC.pod
@@ -110,7 +110,9 @@ per-operation basis.
 
 =item "pub" (B<OSSL_PKEY_PARAM_PUB_KEY>) <octet string>
 
-The public key value in EC point format.
+The public key value in encoded EC point format. This parameter is used
+when importing or exporting the public key value with the EVP_PKEY_fromdata()
+and EVP_PKEY_todata() functions.
 
 =item "priv" (B<OSSL_PKEY_PARAM_PRIV_KEY>) <unsigned integer>
 

--- a/providers/implementations/keymgmt/ec_kmgmt.c
+++ b/providers/implementations/keymgmt/ec_kmgmt.c
@@ -637,8 +637,10 @@ int common_get_params(void *key, OSSL_PARAM params[], int sm2)
     BN_CTX *bnctx = NULL;
 
     ecg = EC_KEY_get0_group(eck);
-    if (ecg == NULL)
+    if (ecg == NULL) {
+        ERR_raise(ERR_LIB_PROV, PROV_R_NO_PARAMETERS_SET);
         return 0;
+    }
 
     libctx = ossl_ec_key_get_libctx(eck);
     propq = ossl_ec_key_get0_propq(eck);
@@ -727,8 +729,13 @@ int common_get_params(void *key, OSSL_PARAM params[], int sm2)
     }
     if ((p = OSSL_PARAM_locate(params,
                                OSSL_PKEY_PARAM_ENCODED_PUBLIC_KEY)) != NULL) {
-        p->return_size = EC_POINT_point2oct(EC_KEY_get0_group(key),
-                                            EC_KEY_get0_public_key(key),
+        const EC_POINT *ecp = EC_KEY_get0_public_key(key);
+
+        if (ecp == NULL) {
+            ERR_raise(ERR_LIB_PROV, PROV_R_NOT_A_PUBLIC_KEY);
+            goto err;
+        }
+        p->return_size = EC_POINT_point2oct(ecg, ecp,
                                             POINT_CONVERSION_UNCOMPRESSED,
                                             p->data, p->return_size, bnctx);
         if (p->return_size == 0)

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -897,6 +897,7 @@ static int test_EC_priv_pub(void)
     EVP_PKEY *params_and_keypair = NULL;
     BIGNUM *priv = NULL;
     int ret = 0;
+    unsigned char *encoded = NULL;
 
     /*
      * Setup the parameters for our pkey object. For our purposes they don't
@@ -1004,6 +1005,17 @@ static int test_EC_priv_pub(void)
         || !TEST_int_gt(EVP_PKEY_eq(params_and_keypair, params_and_pub), 0)
         || !TEST_int_gt(EVP_PKEY_eq(params_and_keypair, params_and_priv), 0))
         goto err;
+
+    /* Positive and negative testcase for EVP_PKEY_get1_encoded_public_key */
+    if (!TEST_int_gt(EVP_PKEY_get1_encoded_public_key(params_and_pub, &encoded), 0))
+        goto err;
+    OPENSSL_free(encoded);
+    encoded = NULL;
+    if (!TEST_int_eq(EVP_PKEY_get1_encoded_public_key(just_params, &encoded), 0)) {
+        OPENSSL_free(encoded);
+        encoded = NULL;
+        goto err;
+    }
 
     ret = 1;
  err:


### PR DESCRIPTION
If the public key is not set on the key, return error instead of crash.

Also clarify documentation in regards to EC key parameters and clarify that EVP_PKEY_fromdata ignores parameters that are unknown or incorrect for given selection.

Also added fallback to OSSL_PKEY_PARAM_ENCODED_PUBLIC_KEY on key import.
    
Fixes #18495

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
