### PR TITLE
Fix wrong default algorithm in openssl pkcs12 help

### DIFF
--- a/apps/pkcs12.c
+++ b/apps/pkcs12.c
@@ -144,7 +144,7 @@ const OPTIONS pkcs12_options[] = {
      "Encrypt output with 3DES (default PBES2 with PBKDF2 and AES-256 CBC)"},
 #endif
     {"macalg", OPT_MACALG, 's',
-     "Digest algorithm to use in MAC (default SHA1)"},
+     "Digest algorithm to use in MAC (default SHA256)"},
     {"iter", OPT_ITER, 'p', "Specify the iteration count for encryption and MAC"},
     {"noiter", OPT_NOITER, '-', "Don't use encryption iteration"},
     {"nomaciter", OPT_NOMACITER, '-', "Don't use MAC iteration)"},


### PR DESCRIPTION
The default that pkcs12 -export uses is SHA256 and not SHA1.

##### Checklist
- [x] documentation is added or updated
