### PR TITLE
APPS: improve input file and option handling of `smime` and `ocsp`

### DIFF
--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -1379,8 +1379,12 @@ X509_STORE *setup_verify(const char *CAfile, int noCAfile,
         if (CAfile != NULL) {
             if (X509_LOOKUP_load_file_ex(lookup, CAfile, X509_FILETYPE_PEM,
                                          libctx, propq) <= 0) {
-                BIO_printf(bio_err, "Error loading file %s\n", CAfile);
-                goto end;
+                ERR_clear_error();
+                if (X509_LOOKUP_load_file_ex(lookup, CAfile, X509_FILETYPE_ASN1,
+                                             libctx, propq) <= 0) {
+                    BIO_printf(bio_err, "Error loading file %s\n", CAfile);
+                    goto end;
+                }
             }
         } else {
             X509_LOOKUP_load_file_ex(lookup, NULL, X509_FILETYPE_DEFAULT,

--- a/apps/ocsp.c
+++ b/apps/ocsp.c
@@ -136,7 +136,7 @@ const OPTIONS ocsp_options[] = {
      "Don't include any certificates in signed request"},
     {"badsig", OPT_BADSIG, '-',
         "Corrupt last byte of loaded OCSP response signature (for test)"},
-    {"CA", OPT_CA, '<', "CA certificate"},
+    {"CA", OPT_CA, '<', "CA certificates"},
     {"nmin", OPT_NMIN, 'p', "Number of minutes before next update"},
     {"nrequest", OPT_REQUEST, 'p',
      "Number of requests to accept (default unlimited)"},
@@ -230,7 +230,7 @@ int ocsp_main(int argc, char **argv)
     STACK_OF(X509) *sign_other = NULL, *verify_other = NULL, *rother = NULL;
     STACK_OF(X509) *issuers = NULL;
     X509 *issuer = NULL, *cert = NULL;
-    STACK_OF(X509) *rca_cert = NULL;
+    STACK_OF(X509) *rca_certs = NULL;
     EVP_MD *resp_certid_md = NULL;
     X509 *signer = NULL, *rsigner = NULL;
     X509_STORE *store = NULL;
@@ -597,7 +597,7 @@ int ocsp_main(int argc, char **argv)
             BIO_printf(bio_err, "Error loading responder certificate\n");
             goto end;
         }
-        if (!load_certs(rca_filename, 0, &rca_cert, NULL, "CA certificates"))
+        if (!load_certs(rca_filename, 0, &rca_certs, NULL, "CA certificates"))
             goto end;
         if (rcertfile != NULL) {
             if (!load_certs(rcertfile, 0, &rother, NULL,
@@ -615,7 +615,7 @@ int ocsp_main(int argc, char **argv)
     }
 
     if (ridx_filename != NULL
-        && (rkey == NULL || rsigner == NULL || rca_cert == NULL)) {
+        && (rkey == NULL || rsigner == NULL || rca_certs == NULL)) {
         BIO_printf(bio_err,
                    "Responder mode requires certificate, key, and CA.\n");
         goto end;
@@ -727,7 +727,7 @@ redo_accept:
     }
 
     if (rdb != NULL) {
-        make_ocsp_response(bio_err, &resp, req, rdb, rca_cert, rsigner, rkey,
+        make_ocsp_response(bio_err, &resp, req, rdb, rca_certs, rsigner, rkey,
                            rsign_md, rsign_sigopts, rother, rflags, nmin, ndays,
                            badsig, resp_certid_md);
         if (resp == NULL)
@@ -866,7 +866,7 @@ redo_accept:
     X509_free(cert);
     OSSL_STACK_OF_X509_free(issuers);
     X509_free(rsigner);
-    OSSL_STACK_OF_X509_free(rca_cert);
+    OSSL_STACK_OF_X509_free(rca_certs);
     free_index(rdb);
     BIO_free_all(cbio);
     BIO_free_all(acbio);

--- a/doc/man1/openssl-ocsp.pod.in
+++ b/doc/man1/openssl-ocsp.pod.in
@@ -103,12 +103,16 @@ specify output filename, default is standard output.
 =item B<-issuer> I<filename>
 
 This specifies the current issuer certificate.
+The input can be in PEM, DER, or PKCS#12 format.
+
 This option can be used multiple times.
 This option B<MUST> come before any B<-cert> options.
 
 =item B<-cert> I<filename>
 
 Add the certificate I<filename> to the request.
+The input can be in PEM, DER, or PKCS#12 format.
+
 This option can be used multiple times.
 The issuer certificate is taken from the previous B<-issuer> option,
 or an error occurs if no issuer certificate is specified.
@@ -127,8 +131,10 @@ be specified by preceding the value by a C<-> sign.
 =item B<-signer> I<filename>, B<-signkey> I<filename>
 
 Sign the OCSP request using the certificate specified in the B<-signer>
-option and the private key specified by the B<-signkey> option. If
-the B<-signkey> option is not present then the private key is read
+option and the private key specified by the B<-signkey> option.
+The input can be in PEM, DER, or PKCS#12 format.
+
+If the B<-signkey> option is not present then the private key is read
 from the same file as the certificate. If neither option is specified then
 the OCSP request is not signed.
 
@@ -322,13 +328,14 @@ must also be present.
 
 =item B<-CA> I<file>
 
-CA certificate corresponding to the revocation information in the index
+CA certificates corresponding to the revocation information in the index
 file given with B<-index>.
 The input can be in PEM, DER, or PKCS#12 format.
 
 =item B<-rsigner> I<file>
 
 The certificate to sign OCSP responses with.
+The input can be in PEM, DER, or PKCS#12 format.
 
 =item B<-rkey> I<file>
 

--- a/doc/man1/openssl-smime.pod.in
+++ b/doc/man1/openssl-smime.pod.in
@@ -59,7 +59,9 @@ and verify S/MIME messages.
 
 =head1 OPTIONS
 
-There are six operation options that set the type of operation to be performed.
+There are six operation options that set the type of operation to be performed:
+B<-encrypt>, B<-decrypt>, B<-sign>, B<-resign>, B<-verify>, and B<-pk7out>.
+These are mutually exclusive.
 The meaning of the other options varies according to the operation type.
 
 =over 4
@@ -88,6 +90,10 @@ Sign mail using the supplied certificate and private key. Input file is
 the message to be signed. The signed message in MIME format is written
 to the output file.
 
+=item B<-resign>
+
+Resign a message: take an existing message and one or more new signers.
+
 =item B<-verify>
 
 Verify signed mail. Expects a signed mail message on input and outputs
@@ -96,10 +102,6 @@ the signed data. Both clear text and opaque signing is supported.
 =item B<-pk7out>
 
 Takes an input message and writes out a PEM encoded PKCS#7 structure.
-
-=item B<-resign>
-
-Resign a message: take an existing message and one or more new signers.
 
 =item B<-in> I<filename>
 

--- a/doc/man1/openssl-verification-options.pod
+++ b/doc/man1/openssl-verification-options.pod
@@ -202,8 +202,8 @@ can be specified using following options.
 
 =item B<-CAfile> I<file>
 
-Load the specified file which contains a certificate
-or several of them in case the input is in PEM or PKCS#12 format.
+Load the specified file which contains a trusted certificate in DER format
+or potentially several of them in case the input is in PEM format.
 PEM-encoded certificates may also have trust attributes set.
 
 =item B<-no-CAfile>


### PR DESCRIPTION
* APPS: make sure the `-CAfile` argument can be in DER format.
   Note that PKCS#12 input is still not supported here, though this was claimed in `openssl-verification-options.pod`.
* `openssl-ocsp.pod.in:` state for options that they are flexible w.r.t. cert input format
* `apps/ocsp:` Tweak some places to make clear they refer to *lists* of certs
* `apps/smime:` Point out that the six operations are mutually exclusive and add check
