### PR TITLE
`X509_STORE_CTX_set_default()`: improve error handling and reporting, also in its use

### DIFF
--- a/crypto/conf/conf_def.c
+++ b/crypto/conf/conf_def.c
@@ -296,7 +296,7 @@ static int def_load_bio(CONF *conf, BIO *in, long *line)
             }
 #endif
             /* no more files in directory, continue with processing parent */
-            if ((parent = sk_BIO_pop(biosk)) == NULL) {
+            if (sk_BIO_num(biosk) < 1 || (parent = sk_BIO_pop(biosk)) == NULL) {
                 /* everything processed get out of the loop */
                 break;
             } else {

--- a/crypto/pkcs7/pk7_smime.c
+++ b/crypto/pkcs7/pk7_smime.c
@@ -280,7 +280,8 @@ int PKCS7_verify(PKCS7 *p7, STACK_OF(X509) *certs, X509_STORE *store,
                     ERR_raise(ERR_LIB_PKCS7, ERR_R_X509_LIB);
                     goto err;
                 }
-                X509_STORE_CTX_set_default(cert_ctx, "smime_sign");
+                if (!X509_STORE_CTX_set_default(cert_ctx, "smime_sign"))
+                    goto err;
             } else if (!X509_STORE_CTX_init(cert_ctx, store, signer, NULL)) {
                 ERR_raise(ERR_LIB_PKCS7, ERR_R_X509_LIB);
                 goto err;

--- a/crypto/x509/x509_vfy.c
+++ b/crypto/x509/x509_vfy.c
@@ -2430,15 +2430,11 @@ int X509_STORE_CTX_init(X509_STORE_CTX *ctx, X509_STORE *store, X509 *x509,
         ret = X509_VERIFY_PARAM_inherit(ctx->param, store->param);
     else
         ctx->param->inh_flags |= X509_VP_FLAG_DEFAULT | X509_VP_FLAG_ONCE;
-
-    if (ret)
-        ret = X509_VERIFY_PARAM_inherit(ctx->param,
-                                        X509_VERIFY_PARAM_lookup("default"));
-
-    if (ret == 0) {
-        ERR_raise(ERR_LIB_X509, ERR_R_MALLOC_FAILURE);
+    if (ret == 0)
         goto err;
-    }
+
+    if (!X509_STORE_CTX_set_default(ctx, "default"))
+        goto err;
 
     /*
      * XXX: For now, continue to inherit trust from VPM, but infer from the
@@ -2640,8 +2636,10 @@ int X509_STORE_CTX_set_default(X509_STORE_CTX *ctx, const char *name)
     const X509_VERIFY_PARAM *param;
 
     param = X509_VERIFY_PARAM_lookup(name);
-    if (param == NULL)
+    if (param == NULL) {
+        ERR_raise_data(ERR_LIB_X509, X509_R_UNKNOWN_PURPOSE_ID, "name=%s", name);
         return 0;
+    }
     return X509_VERIFY_PARAM_inherit(ctx->param, param);
 }
 

--- a/crypto/x509/x509_vfy.c
+++ b/crypto/x509/x509_vfy.c
@@ -2327,8 +2327,6 @@ void X509_STORE_CTX_free(X509_STORE_CTX *ctx)
 int X509_STORE_CTX_init(X509_STORE_CTX *ctx, X509_STORE *store, X509 *x509,
                         STACK_OF(X509) *chain)
 {
-    int ret = 1;
-
     if (ctx == NULL) {
         ERR_raise(ERR_LIB_X509, ERR_R_PASSED_NULL_PARAMETER);
         return 0;
@@ -2426,11 +2424,9 @@ int X509_STORE_CTX_init(X509_STORE_CTX *ctx, X509_STORE *store, X509 *x509,
     }
 
     /* Inherit callbacks and flags from X509_STORE if not set use defaults. */
-    if (store != NULL)
-        ret = X509_VERIFY_PARAM_inherit(ctx->param, store->param);
-    else
+    if (store == NULL)
         ctx->param->inh_flags |= X509_VP_FLAG_DEFAULT | X509_VP_FLAG_ONCE;
-    if (ret == 0)
+    else if (X509_VERIFY_PARAM_inherit(ctx->param, store->param) == 0)
         goto err;
 
     if (!X509_STORE_CTX_set_default(ctx, "default"))

--- a/crypto/x509/x509_vpm.c
+++ b/crypto/x509/x509_vpm.c
@@ -44,7 +44,8 @@ static int int_x509_param_set_hosts(X509_VERIFY_PARAM *vpm, int mode,
      */
     if (namelen == 0 || name == NULL)
         namelen = name ? strlen(name) : 0;
-    else if (name && memchr(name, '\0', namelen > 1 ? namelen - 1 : namelen))
+    else if (name != NULL
+             && memchr(name, '\0', namelen > 1 ? namelen - 1 : namelen) != NULL)
         return 0;
     if (namelen > 0 && name[namelen - 1] == '\0')
         --namelen;
@@ -77,7 +78,6 @@ static int int_x509_param_set_hosts(X509_VERIFY_PARAM *vpm, int mode,
 
     return 1;
 }
-
 
 X509_VERIFY_PARAM *X509_VERIFY_PARAM_new(void)
 {
@@ -142,8 +142,7 @@ void X509_VERIFY_PARAM_free(X509_VERIFY_PARAM *param)
 /* Macro to test if a field should be copied from src to dest */
 
 #define test_x509_verify_param_copy(field, def) \
-    (to_overwrite \
-         || ((src->field != def) && (to_default || (dest->field == def))))
+    (to_overwrite || (src->field != def && (to_default || dest->field == def)))
 
 /* Macro to test and copy a field if necessary */
 
@@ -156,25 +155,19 @@ int X509_VERIFY_PARAM_inherit(X509_VERIFY_PARAM *dest,
 {
     unsigned long inh_flags;
     int to_default, to_overwrite;
-    if (!src)
+
+    if (src == NULL)
         return 1;
     inh_flags = dest->inh_flags | src->inh_flags;
 
-    if (inh_flags & X509_VP_FLAG_ONCE)
+    if ((inh_flags & X509_VP_FLAG_ONCE) != 0)
         dest->inh_flags = 0;
 
-    if (inh_flags & X509_VP_FLAG_LOCKED)
+    if ((inh_flags & X509_VP_FLAG_LOCKED) != 0)
         return 1;
 
-    if (inh_flags & X509_VP_FLAG_DEFAULT)
-        to_default = 1;
-    else
-        to_default = 0;
-
-    if (inh_flags & X509_VP_FLAG_OVERWRITE)
-        to_overwrite = 1;
-    else
-        to_overwrite = 0;
+    to_default = (inh_flags & X509_VP_FLAG_DEFAULT) != 0;
+    to_overwrite = (inh_flags & X509_VP_FLAG_OVERWRITE) != 0;
 
     x509_verify_param_copy(purpose, 0);
     x509_verify_param_copy(trust, X509_TRUST_DEFAULT);
@@ -183,13 +176,13 @@ int X509_VERIFY_PARAM_inherit(X509_VERIFY_PARAM *dest,
 
     /* If overwrite or check time not set, copy across */
 
-    if (to_overwrite || !(dest->flags & X509_V_FLAG_USE_CHECK_TIME)) {
+    if (to_overwrite || (dest->flags & X509_V_FLAG_USE_CHECK_TIME) == 0) {
         dest->check_time = src->check_time;
         dest->flags &= ~X509_V_FLAG_USE_CHECK_TIME;
         /* Don't need to copy flag: that is done below */
     }
 
-    if (inh_flags & X509_VP_FLAG_RESET_FLAGS)
+    if ((inh_flags & X509_VP_FLAG_RESET_FLAGS) != 0)
         dest->flags = 0;
 
     dest->flags |= src->flags;
@@ -204,7 +197,7 @@ int X509_VERIFY_PARAM_inherit(X509_VERIFY_PARAM *dest,
     if (test_x509_verify_param_copy(hosts, NULL)) {
         sk_OPENSSL_STRING_pop_free(dest->hosts, str_free);
         dest->hosts = NULL;
-        if (src->hosts) {
+        if (src->hosts != NULL) {
             dest->hosts =
                 sk_OPENSSL_STRING_deep_copy(src->hosts, str_copy, str_free);
             if (dest->hosts == NULL)
@@ -228,8 +221,14 @@ int X509_VERIFY_PARAM_inherit(X509_VERIFY_PARAM *dest,
 int X509_VERIFY_PARAM_set1(X509_VERIFY_PARAM *to,
                            const X509_VERIFY_PARAM *from)
 {
-    unsigned long save_flags = to->inh_flags;
+    unsigned long save_flags;
     int ret;
+
+    if (to == NULL) {
+        ERR_raise(ERR_LIB_X509, ERR_R_PASSED_NULL_PARAMETER);
+        return 0;
+    }
+    save_flags = to->inh_flags;
     to->inh_flags |= X509_VP_FLAG_DEFAULT;
     ret = X509_VERIFY_PARAM_inherit(to, from);
     to->inh_flags = save_flags;
@@ -240,7 +239,8 @@ static int int_x509_param_set1(char **pdest, size_t *pdestlen,
                                const char *src, size_t srclen)
 {
     char *tmp;
-    if (src) {
+
+    if (src != NULL) {
         if (srclen == 0)
             srclen = strlen(src);
 
@@ -264,15 +264,13 @@ int X509_VERIFY_PARAM_set1_name(X509_VERIFY_PARAM *param, const char *name)
 {
     OPENSSL_free(param->name);
     param->name = OPENSSL_strdup(name);
-    if (param->name)
-        return 1;
-    return 0;
+    return param->name != NULL;
 }
 
 int X509_VERIFY_PARAM_set_flags(X509_VERIFY_PARAM *param, unsigned long flags)
 {
     param->flags |= flags;
-    if (flags & X509_V_FLAG_POLICY_MASK)
+    if ((flags & X509_V_FLAG_POLICY_MASK) != 0)
         param->flags |= X509_V_FLAG_POLICY_CHECK;
     return 1;
 }
@@ -339,9 +337,7 @@ int X509_VERIFY_PARAM_add0_policy(X509_VERIFY_PARAM *param,
         if (param->policies == NULL)
             return 0;
     }
-    if (!sk_ASN1_OBJECT_push(param->policies, policy))
-        return 0;
-    return 1;
+    return sk_ASN1_OBJECT_push(param->policies, policy);
 }
 
 int X509_VERIFY_PARAM_set1_policies(X509_VERIFY_PARAM *param,
@@ -350,8 +346,10 @@ int X509_VERIFY_PARAM_set1_policies(X509_VERIFY_PARAM *param,
     int i;
     ASN1_OBJECT *oid, *doid;
 
-    if (param == NULL)
+    if (param == NULL) {
+        ERR_raise(ERR_LIB_X509, ERR_R_PASSED_NULL_PARAMETER);
         return 0;
+    }
     sk_ASN1_OBJECT_pop_free(param->policies, ASN1_OBJECT_free);
 
     if (policies == NULL) {
@@ -366,7 +364,7 @@ int X509_VERIFY_PARAM_set1_policies(X509_VERIFY_PARAM *param,
     for (i = 0; i < sk_ASN1_OBJECT_num(policies); i++) {
         oid = sk_ASN1_OBJECT_value(policies, i);
         doid = OBJ_dup(oid);
-        if (!doid)
+        if (doid == NULL)
             return 0;
         if (!sk_ASN1_OBJECT_push(param->policies, doid)) {
             ASN1_OBJECT_free(doid);
@@ -424,7 +422,7 @@ void X509_VERIFY_PARAM_move_peername(X509_VERIFY_PARAM *to,
         OPENSSL_free(to->peername);
         to->peername = peername;
     }
-    if (from)
+    if (from != NULL)
         from->peername = NULL;
 }
 
@@ -443,8 +441,10 @@ int X509_VERIFY_PARAM_set1_email(X509_VERIFY_PARAM *param,
 static unsigned char
 *int_X509_VERIFY_PARAM_get0_ip(X509_VERIFY_PARAM *param, size_t *plen)
 {
-    if (param == NULL || param->ip == NULL)
+    if (param == NULL || param->ip == NULL) {
+        ERR_raise(ERR_LIB_X509, ERR_R_PASSED_NULL_PARAMETER);
         return NULL;
+    }
     if (plen != NULL)
         *plen = param->iplen;
     return param->ip;
@@ -455,14 +455,16 @@ char *X509_VERIFY_PARAM_get1_ip_asc(X509_VERIFY_PARAM *param)
     size_t iplen;
     unsigned char *ip = int_X509_VERIFY_PARAM_get0_ip(param, &iplen);
 
-    return  ip == NULL ? NULL : ossl_ipaddr_to_asc(ip, iplen);
+    return ip == NULL ? NULL : ossl_ipaddr_to_asc(ip, iplen);
 }
 
 int X509_VERIFY_PARAM_set1_ip(X509_VERIFY_PARAM *param,
                               const unsigned char *ip, size_t iplen)
 {
-    if (iplen != 0 && iplen != 4 && iplen != 16)
+    if (iplen != 0 && iplen != 4 && iplen != 16) {
+        ERR_raise(ERR_LIB_X509, ERR_R_PASSED_INVALID_ARGUMENT);
         return 0;
+    }
     return int_x509_param_set1((char **)&param->ip, &param->iplen,
                                (char *)ip, iplen);
 }
@@ -470,9 +472,8 @@ int X509_VERIFY_PARAM_set1_ip(X509_VERIFY_PARAM *param,
 int X509_VERIFY_PARAM_set1_ip_asc(X509_VERIFY_PARAM *param, const char *ipasc)
 {
     unsigned char ipout[16];
-    size_t iplen;
+    size_t iplen = (size_t)ossl_a2i_ipadd(ipout, ipasc);
 
-    iplen = (size_t)ossl_a2i_ipadd(ipout, ipasc);
     if (iplen == 0)
         return 0;
     return X509_VERIFY_PARAM_set1_ip(param, ipout, iplen);
@@ -579,6 +580,7 @@ int X509_VERIFY_PARAM_add0_table(X509_VERIFY_PARAM *param)
 {
     int idx;
     X509_VERIFY_PARAM *ptmp;
+
     if (param_table == NULL) {
         param_table = sk_X509_VERIFY_PARAM_new(param_cmp);
         if (param_table == NULL)
@@ -590,15 +592,14 @@ int X509_VERIFY_PARAM_add0_table(X509_VERIFY_PARAM *param)
             X509_VERIFY_PARAM_free(ptmp);
         }
     }
-    if (!sk_X509_VERIFY_PARAM_push(param_table, param))
-        return 0;
-    return 1;
+    return sk_X509_VERIFY_PARAM_push(param_table, param);
 }
 
 int X509_VERIFY_PARAM_get_count(void)
 {
     int num = OSSL_NELEM(default_table);
-    if (param_table)
+
+    if (param_table != NULL)
         num += sk_X509_VERIFY_PARAM_num(param_table);
     return num;
 }
@@ -606,6 +607,7 @@ int X509_VERIFY_PARAM_get_count(void)
 const X509_VERIFY_PARAM *X509_VERIFY_PARAM_get0(int id)
 {
     int num = OSSL_NELEM(default_table);
+
     if (id < num)
         return default_table + id;
     return sk_X509_VERIFY_PARAM_value(param_table, id - num);

--- a/ssl/ssl_ciph.c
+++ b/ssl/ssl_ciph.c
@@ -532,7 +532,8 @@ int ssl_cipher_get_evp(SSL_CTX *ctx, const SSL_SESSION *s,
         ctmp.id = s->compress_meth;
         if (ssl_comp_methods != NULL) {
             i = sk_SSL_COMP_find(ssl_comp_methods, &ctmp);
-            *comp = sk_SSL_COMP_value(ssl_comp_methods, i);
+            if (i >= 0)
+                *comp = sk_SSL_COMP_value(ssl_comp_methods, i);
         }
         /* If were only interested in comp then return success */
         if ((enc == NULL) && (md == NULL))

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -5699,7 +5699,8 @@ static int ct_move_scts(STACK_OF(SCT) **dst, STACK_OF(SCT) *src,
         }
     }
 
-    while ((sct = sk_SCT_pop(src)) != NULL) {
+    while (sk_SCT_num(src) > 0) {
+        sct = sk_SCT_pop(src);
         if (SCT_set_source(sct, origin) != 1)
             goto err;
 

--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -3585,7 +3585,7 @@ MSG_PROCESS_RETURN tls_process_client_certificate(SSL_CONNECTION *s,
     }
 
     X509_free(s->session->peer);
-    s->session->peer = sk_X509_shift(sk);
+    s->session->peer = sk_X509_num(sk) == 0 ? NULL: sk_X509_shift(sk);
     s->session->verify_result = s->verify_result;
 
     OSSL_STACK_OF_X509_free(s->session->peer_chain);

--- a/test/recipes/80-test_ssl_new.t
+++ b/test/recipes/80-test_ssl_new.t
@@ -6,6 +6,10 @@
 # in the file LICENSE in the source distribution or at
 # https://www.openssl.org/source/license.html
 
+# For manually running these tests, set specific environment variables like this:
+# CTLOG_FILE=test/ct/log_list.cnf
+# TEST_CERTS_DIR=test/certs
+# For details on the environment variables needed, see test/README.ssltest.md
 
 use strict;
 use warnings;
@@ -173,13 +177,14 @@ sub test_conf {
       skip "No tests available; skipping tests", 1 if $skip;
       skip "Stale sources; skipping tests", 1 if !$run_test;
 
+      my $msg = "running CTLOG_FILE=test/ct/log_list.cnf". # $ENV{CTLOG_FILE}.
+          " TEST_CERTS_DIR=test/certs". # $ENV{TEST_CERTS_DIR}.
+          " test/ssl_test test/ssl-tests/$conf $provider";
       if ($provider eq "fips") {
           ok(run(test(["ssl_test", $output_file, $provider,
-                       srctop_file("test", "fips-and-base.cnf")])),
-             "running ssl_test $conf");
+                       srctop_file("test", "fips-and-base.cnf")])), $msg);
       } else {
-          ok(run(test(["ssl_test", $output_file, $provider])),
-             "running ssl_test $conf");
+          ok(run(test(["ssl_test", $output_file, $provider])), $msg);
       }
     }
 }


### PR DESCRIPTION
So far, error result of `X509_STORE_CTX_set_default()` was not checked in `pk7_smime.c` and the error code was misleading in in `x509_vfy.c`.
This PR also adds error information which purpose name could not be found.

As the bugs fixed are minor and `ERR_raise_data()` is not available in 1.1.1., I do not suggest backporting to 1.1.1.
