### PR TITLE
`X509_REQ_get_extensions()`: no extensions found is not an error

### DIFF
--- a/crypto/x509/x509_req.c
+++ b/crypto/x509/x509_req.c
@@ -167,7 +167,9 @@ STACK_OF(X509_EXTENSION) *X509_REQ_get_extensions(X509_REQ *req)
         ext = X509_ATTRIBUTE_get0_type(attr, 0);
         break;
     }
-    if (!ext || (ext->type != V_ASN1_SEQUENCE))
+    if (ext == NULL) /* no extensions is not an error */
+        return sk_X509_EXTENSION_new_null();
+    if (ext->type != V_ASN1_SEQUENCE)
         return NULL;
     p = ext->value.sequence->data;
     return (STACK_OF(X509_EXTENSION) *)


### PR DESCRIPTION
This backports one of the commits of #13841.
I forgot to backport this bug fix to 1.1.1.
So I got a test failure on my external CMP tests with OpenSSL 1.1.1.
