### PR TITLE
providers: Set the size of EC signature on s390.

### DIFF
--- a/providers/implementations/signature/eddsa_sig.c
+++ b/providers/implementations/signature/eddsa_sig.c
@@ -164,8 +164,14 @@ int ed25519_digest_sign(void *vpeddsactx, unsigned char *sigret,
         return 0;
     }
 #ifdef S390X_EC_ASM
-    if (S390X_CAN_SIGN(ED25519))
-        return s390x_ed25519_digestsign(edkey, sigret, tbs, tbslen);
+    if (S390X_CAN_SIGN(ED25519)) {
+	    if (s390x_ed25519_digestsign(edkey, sigret, tbs, tbslen) == 0) {
+		    ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SIGN);
+		    return 0;
+	    }
+	    *siglen = ED25519_SIGSIZE;
+	    return 1;
+    }
 #endif /* S390X_EC_ASM */
     if (ossl_ed25519_sign(sigret, tbs, tbslen, edkey->pubkey, edkey->privkey,
                           peddsactx->libctx, NULL) == 0) {
@@ -195,8 +201,14 @@ int ed448_digest_sign(void *vpeddsactx, unsigned char *sigret,
         return 0;
     }
 #ifdef S390X_EC_ASM
-    if (S390X_CAN_SIGN(ED448))
-        return s390x_ed448_digestsign(edkey, sigret, tbs, tbslen);
+    if (S390X_CAN_SIGN(ED448)) {
+        if (s390x_ed448_digestsign(edkey, sigret, tbs, tbslen) == 0) {
+		ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SIGN);
+		return 0;
+	}
+	*siglen = ED448_SIGSIZE;
+	return 1;
+    }
 #endif /* S390X_EC_ASM */
     if (ossl_ed448_sign(peddsactx->libctx, sigret, tbs, tbslen, edkey->pubkey,
                         edkey->privkey, NULL, 0, edkey->propq) == 0) {


### PR DESCRIPTION
The s390x provides its custom implementation for the creation of the
ed448 and ed25519 signatures. Unfortunately it does not set the size.
Users that rely of this return parameter end up with wrong values and
will compare wrong sizes of signature.

Set the proper size of the returned signature on success. Set an error
if the signing operation fails.

Fixes: #18912
Signed-off-by: Sebastian Andrzej Siewior <sebastian@breakpoint.cc>