### PR TITLE
CRMF: add missing check and API function; clean up `X509{,_REQ}_check_private_key()`

### DIFF
--- a/crypto/crmf/crmf_lib.c
+++ b/crypto/crmf/crmf_lib.c
@@ -31,6 +31,7 @@
 #include "crmf_local.h"
 #include "internal/constant_time.h"
 #include "internal/sizes.h"
+#include "crypto/x509.h"
 
 /* explicit #includes not strictly needed since implied by the above: */
 #include <openssl/crmf.h>
@@ -370,11 +371,16 @@ static int create_popo_signature(OSSL_CRMF_POPOSIGNINGKEY *ps,
                                  OSSL_LIB_CTX *libctx, const char *propq)
 {
     char name[80] = "";
+    EVP_PKEY *pub;
 
     if (ps == NULL || cr == NULL || pkey == NULL) {
         ERR_raise(ERR_LIB_CRMF, CRMF_R_NULL_ARGUMENT);
         return 0;
     }
+    pub = X509_PUBKEY_get0(cr->certTemplate->publicKey);
+    if (!ossl_x509_check_private_key(pub, pkey))
+        return 0;
+
     if (ps->poposkInput != NULL) {
         /* We do not support cases 1+2 defined in RFC 4211, section 4.1 */
         ERR_raise(ERR_LIB_CRMF, CRMF_R_POPOSKINPUT_NOT_SUPPORTED);

--- a/crypto/crmf/crmf_lib.c
+++ b/crypto/crmf/crmf_lib.c
@@ -530,6 +530,12 @@ int OSSL_CRMF_MSGS_verify_popo(const OSSL_CRMF_MSGS *reqs,
     return 1;
 }
 
+const X509_PUBKEY
+    *OSSL_CRMF_CERTTEMPLATE_get0_publicKey(const OSSL_CRMF_CERTTEMPLATE *tmpl)
+{
+    return tmpl != NULL ? tmpl->publicKey : NULL;
+}
+
 /* retrieves the serialNumber of the given cert template or NULL on error */
 const ASN1_INTEGER
 *OSSL_CRMF_CERTTEMPLATE_get0_serialNumber(const OSSL_CRMF_CERTTEMPLATE *tmpl)

--- a/crypto/x509/x509_req.c
+++ b/crypto/x509/x509_req.c
@@ -67,7 +67,7 @@ EVP_PKEY *X509_REQ_get_pubkey(X509_REQ *req)
     return X509_PUBKEY_get(req->req_info.pubkey);
 }
 
-EVP_PKEY *X509_REQ_get0_pubkey(X509_REQ *req)
+EVP_PKEY *X509_REQ_get0_pubkey(const X509_REQ *req)
 {
     if (req == NULL)
         return NULL;
@@ -79,28 +79,9 @@ X509_PUBKEY *X509_REQ_get_X509_PUBKEY(X509_REQ *req)
     return req->req_info.pubkey;
 }
 
-int X509_REQ_check_private_key(X509_REQ *x, EVP_PKEY *k)
+int X509_REQ_check_private_key(const X509_REQ *req, EVP_PKEY *pkey)
 {
-    EVP_PKEY *xk = NULL;
-    int ok = 0;
-
-    xk = X509_REQ_get_pubkey(x);
-    switch (EVP_PKEY_eq(xk, k)) {
-    case 1:
-        ok = 1;
-        break;
-    case 0:
-        ERR_raise(ERR_LIB_X509, X509_R_KEY_VALUES_MISMATCH);
-        break;
-    case -1:
-        ERR_raise(ERR_LIB_X509, X509_R_KEY_TYPE_MISMATCH);
-        break;
-    case -2:
-        ERR_raise(ERR_LIB_X509, X509_R_UNKNOWN_KEY_TYPE);
-    }
-
-    EVP_PKEY_free(xk);
-    return ok;
+    return ossl_x509_check_private_key(X509_REQ_get0_pubkey(req), pkey);
 }
 
 /*

--- a/doc/man3/OSSL_CRMF_MSG_get0_tmpl.pod
+++ b/doc/man3/OSSL_CRMF_MSG_get0_tmpl.pod
@@ -3,9 +3,10 @@
 =head1 NAME
 
 OSSL_CRMF_MSG_get0_tmpl,
-OSSL_CRMF_CERTTEMPLATE_get0_serialNumber,
+OSSL_CRMF_CERTTEMPLATE_get0_publicKey,
 OSSL_CRMF_CERTTEMPLATE_get0_subject,
 OSSL_CRMF_CERTTEMPLATE_get0_issuer,
+OSSL_CRMF_CERTTEMPLATE_get0_serialNumber,
 OSSL_CRMF_CERTTEMPLATE_get0_extensions,
 OSSL_CRMF_CERTID_get0_serialNumber,
 OSSL_CRMF_CERTID_get0_issuer,
@@ -18,12 +19,14 @@ OSSL_CRMF_MSG_get_certReqId
  #include <openssl/crmf.h>
 
  OSSL_CRMF_CERTTEMPLATE *OSSL_CRMF_MSG_get0_tmpl(const OSSL_CRMF_MSG *crm);
- const ASN1_INTEGER
- *OSSL_CRMF_CERTTEMPLATE_get0_serialNumber(const OSSL_CRMF_CERTTEMPLATE *tmpl);
+ const X509_PUBKEY
+ *OSSL_CRMF_CERTTEMPLATE_get0_publicKey(const OSSL_CRMF_CERTTEMPLATE *tmpl);
  const X509_NAME
  *OSSL_CRMF_CERTTEMPLATE_get0_subject(const OSSL_CRMF_CERTTEMPLATE *tmpl);
  const X509_NAME
  *OSSL_CRMF_CERTTEMPLATE_get0_issuer(const OSSL_CRMF_CERTTEMPLATE *tmpl);
+ const ASN1_INTEGER
+ *OSSL_CRMF_CERTTEMPLATE_get0_serialNumber(const OSSL_CRMF_CERTTEMPLATE *tmpl);
  X509_EXTENSIONS
  *OSSL_CRMF_CERTTEMPLATE_get0_extensions(const OSSL_CRMF_CERTTEMPLATE *tmpl);
 
@@ -43,13 +46,16 @@ OSSL_CRMF_MSG_get_certReqId
 
 OSSL_CRMF_MSG_get0_tmpl() retrieves the certificate template of I<crm>.
 
-OSSL_CRMF_CERTTEMPLATE_get0_serialNumber() retrieves the serialNumber of the
+OSSL_CRMF_CERTTEMPLATE_get0_publicKey() retrieves the public key of the
 given certificate template I<tmpl>.
 
 OSSL_CRMF_CERTTEMPLATE_get0_subject() retrieves the subject name of the
 given certificate template I<tmpl>.
 
 OSSL_CRMF_CERTTEMPLATE_get0_issuer() retrieves the issuer name of the
+given certificate template I<tmpl>.
+
+OSSL_CRMF_CERTTEMPLATE_get0_serialNumber() retrieves the serialNumber of the
 given certificate template I<tmpl>.
 
 OSSL_CRMF_CERTTEMPLATE_get0_extensions() retrieves the X.509 extensions
@@ -69,7 +75,6 @@ The function returns the decrypted certificate as a copy, leaving its ownership
 with the caller, who is responsible for freeing it.
 
 OSSL_CRMF_MSG_get_certReqId() retrieves the certReqId of I<crm>.
-
 
 =head1 RETURN VALUES
 

--- a/doc/man3/X509_check_private_key.pod
+++ b/doc/man3/X509_check_private_key.pod
@@ -10,17 +10,17 @@ request
 
  #include <openssl/x509.h>
 
- int X509_check_private_key(X509 *x, EVP_PKEY *k);
+ int X509_check_private_key(const X509 *cert, EVP_PKEY *pkey);
 
- int X509_REQ_check_private_key(X509_REQ *x, EVP_PKEY *k);
+ int X509_REQ_check_private_key(X509_REQ *req, EVP_PKEY *pkey);
 
 =head1 DESCRIPTION
 
 X509_check_private_key() function checks the consistency of private
-key B<k> with the public key in B<x>.
+key I<pkey> with the public key in I<cert>.
 
 X509_REQ_check_private_key() is equivalent to X509_check_private_key()
-except that B<x> represents a certificate request of structure B<X509_REQ>.
+except that I<req> represents a certificate request of structure B<X509_REQ>.
 
 =head1 RETURN VALUES
 
@@ -32,11 +32,11 @@ obtained using L<ERR_get_error(3)>.
 
 =head1 BUGS
 
-The B<check_private_key> functions don't check if B<k> itself is indeed
-a private key or not. It merely compares the public materials (e.g. exponent
-and modulus of an RSA key) and/or key parameters (e.g. EC params of an EC key)
-of a key pair. So if you pass a public key to these functions in B<k>, it will
-return success.
+The X509_check_private_key() and X509_REQ_check_private_key() functions
+do not check if I<pkey> itself is indeed a private key or not.
+They merely compare the public materials (e.g., exponent and modulus of an RSA
+key) and/or key parameters (e.g. EC params of an EC key) of a key pair.
+So they also return success if if I<pkey> is a matching public key.
 
 =head1 SEE ALSO
 

--- a/doc/man3/X509_check_private_key.pod
+++ b/doc/man3/X509_check_private_key.pod
@@ -36,7 +36,7 @@ The X509_check_private_key() and X509_REQ_check_private_key() functions
 do not check if I<pkey> itself is indeed a private key or not.
 They merely compare the public materials (e.g., exponent and modulus of an RSA
 key) and/or key parameters (e.g. EC params of an EC key) of a key pair.
-So they also return success if if I<pkey> is a matching public key.
+So they also return success if I<pkey> is a matching public key.
 
 =head1 SEE ALSO
 

--- a/include/crypto/x509.h
+++ b/include/crypto/x509.h
@@ -361,6 +361,7 @@ int ossl_i2d_X448_PUBKEY(const ECX_KEY *a, unsigned char **pp);
 # endif /* OPENSSL_NO_EC */
 EVP_PKEY *ossl_d2i_PUBKEY_legacy(EVP_PKEY **a, const unsigned char **pp,
                                  long length);
+int ossl_x509_check_private_key(const EVP_PKEY *k, const EVP_PKEY *pkey);
 
 int x509v3_add_len_value_uchar(const char *name, const unsigned char *value,
                                size_t vallen, STACK_OF(CONF_VALUE) **extlist);

--- a/include/openssl/crmf.h.in
+++ b/include/openssl/crmf.h.in
@@ -151,12 +151,14 @@ int OSSL_CRMF_MSGS_verify_popo(const OSSL_CRMF_MSGS *reqs,
                                int rid, int acceptRAVerified,
                                OSSL_LIB_CTX *libctx, const char *propq);
 OSSL_CRMF_CERTTEMPLATE *OSSL_CRMF_MSG_get0_tmpl(const OSSL_CRMF_MSG *crm);
-const ASN1_INTEGER
-*OSSL_CRMF_CERTTEMPLATE_get0_serialNumber(const OSSL_CRMF_CERTTEMPLATE *tmpl);
+const X509_PUBKEY
+*OSSL_CRMF_CERTTEMPLATE_get0_publicKey(const OSSL_CRMF_CERTTEMPLATE *tmpl);
 const X509_NAME
 *OSSL_CRMF_CERTTEMPLATE_get0_subject(const OSSL_CRMF_CERTTEMPLATE *tmpl);
 const X509_NAME
 *OSSL_CRMF_CERTTEMPLATE_get0_issuer(const OSSL_CRMF_CERTTEMPLATE *tmpl);
+const ASN1_INTEGER
+*OSSL_CRMF_CERTTEMPLATE_get0_serialNumber(const OSSL_CRMF_CERTTEMPLATE *tmpl);
 X509_EXTENSIONS
 *OSSL_CRMF_CERTTEMPLATE_get0_extensions(const OSSL_CRMF_CERTTEMPLATE *tmpl);
 const X509_NAME

--- a/include/openssl/x509.h.in
+++ b/include/openssl/x509.h.in
@@ -693,7 +693,7 @@ int X509_REQ_get_signature_nid(const X509_REQ *req);
 int i2d_re_X509_REQ_tbs(X509_REQ *req, unsigned char **pp);
 int X509_REQ_set_pubkey(X509_REQ *x, EVP_PKEY *pkey);
 EVP_PKEY *X509_REQ_get_pubkey(X509_REQ *req);
-EVP_PKEY *X509_REQ_get0_pubkey(X509_REQ *req);
+EVP_PKEY *X509_REQ_get0_pubkey(const X509_REQ *req);
 X509_PUBKEY *X509_REQ_get_X509_PUBKEY(X509_REQ *req);
 int X509_REQ_extension_nid(int nid);
 int *X509_REQ_get_extension_nids(void);
@@ -759,9 +759,9 @@ X509_REVOKED_get0_extensions(const X509_REVOKED *r);
 X509_CRL *X509_CRL_diff(X509_CRL *base, X509_CRL *newer,
                         EVP_PKEY *skey, const EVP_MD *md, unsigned int flags);
 
-int X509_REQ_check_private_key(X509_REQ *x509, EVP_PKEY *pkey);
+int X509_REQ_check_private_key(const X509_REQ *req, EVP_PKEY *pkey);
 
-int X509_check_private_key(const X509 *x509, const EVP_PKEY *pkey);
+int X509_check_private_key(const X509 *cert, const EVP_PKEY *pkey);
 int X509_chain_check_suiteb(int *perror_depth,
                             X509 *x, STACK_OF(X509) *chain,
                             unsigned long flags);

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5439,6 +5439,7 @@ ASYNC_set_mem_functions                 ?	3_1_0	EXIST::FUNCTION:
 ASYNC_get_mem_functions                 ?	3_1_0	EXIST::FUNCTION:
 BIO_ADDR_dup                            ?	3_1_0	EXIST::FUNCTION:SOCK
 OSSL_CMP_CTX_get0_validatedSrvCert      ?	3_1_0	EXIST::FUNCTION:CMP
+OSSL_CRMF_CERTTEMPLATE_get0_publicKey   ?	3_1_0	EXIST::FUNCTION:CRMF
 CMS_final_digest                        ?	3_1_0	EXIST::FUNCTION:CMS
 CMS_EnvelopedData_it                    ?	3_1_0	EXIST::FUNCTION:CMS
 CMS_EnvelopedData_decrypt               ?	3_1_0	EXIST::FUNCTION:CMS


### PR DESCRIPTION
* add missing CRMF API function `OSSL_CRMF_CERTTEMPLATE_get0_publicKey()`
* CRMF: make `create_popo_signature()` check that pubkey and pkey match

The latter has a prerequisite:

* X509: clean up implementation of `X509{,_REQ}_check_private_key()` and its doc

On this occasion, constify `X509_REQ_get0_pubkey()` and `X509_REQ_check_private_key()`.
