### PR TITLE
Fix AES-GCM-SIV for s390x optimized assembly

### DIFF
--- a/providers/implementations/ciphers/cipher_aes_gcm_siv_hw.c
+++ b/providers/implementations/ciphers/cipher_aes_gcm_siv_hw.c
@@ -173,21 +173,21 @@ static int aes_gcm_siv_encrypt(PROV_AES_GCM_SIV_CTX *ctx, const unsigned char *i
         len_blk[1] = GSWAP8((uint64_t)len * 8);
     }
     memset(S_s, 0, TAG_SIZE);
-    ossl_polyval_ghash_init(ctx->Htable, (const uint64_t*)ctx->msg_auth_key);
+    ossl_polyval_ghash_init(&ctx->args, (const uint64_t*)ctx->msg_auth_key);
 
     if (ctx->aad != NULL) {
         /* AAD is allocated with padding, but need to adjust length */
-        ossl_polyval_ghash_hash(ctx->Htable, S_s, ctx->aad, UP16(ctx->aad_len));
+        ossl_polyval_ghash_hash(&ctx->args, S_s, ctx->aad, UP16(ctx->aad_len));
     }
     if (DOWN16(len) > 0)
-        ossl_polyval_ghash_hash(ctx->Htable, S_s, (uint8_t *) in, DOWN16(len));
+        ossl_polyval_ghash_hash(&ctx->args, S_s, (uint8_t *) in, DOWN16(len));
     if (!IS16(len)) {
         /* deal with padding - probably easier to memset the padding first rather than calculate */
         memset(padding, 0, sizeof(padding));
         memcpy(padding, &in[DOWN16(len)], REMAINDER16(len));
-        ossl_polyval_ghash_hash(ctx->Htable, S_s, padding, sizeof(padding));
+        ossl_polyval_ghash_hash(&ctx->args, S_s, padding, sizeof(padding));
     }
-    ossl_polyval_ghash_hash(ctx->Htable, S_s, (uint8_t *) len_blk, sizeof(len_blk));
+    ossl_polyval_ghash_hash(&ctx->args, S_s, (uint8_t *) len_blk, sizeof(len_blk));
 
     for (i = 0; i < NONCE_SIZE; i++)
         S_s[i] ^= ctx->nonce[i];
@@ -239,20 +239,20 @@ static int aes_gcm_siv_decrypt(PROV_AES_GCM_SIV_CTX *ctx, const unsigned char *i
         len_blk[1] = GSWAP8((uint64_t)len * 8);
     }
     memset(S_s, 0, TAG_SIZE);
-    ossl_polyval_ghash_init(ctx->Htable, (const uint64_t*)ctx->msg_auth_key);
+    ossl_polyval_ghash_init(&ctx->args, (const uint64_t*)ctx->msg_auth_key);
     if (ctx->aad != NULL) {
         /* AAD allocated with padding, but need to adjust length */
-        ossl_polyval_ghash_hash(ctx->Htable, S_s, ctx->aad, UP16(ctx->aad_len));
+        ossl_polyval_ghash_hash(&ctx->args, S_s, ctx->aad, UP16(ctx->aad_len));
     }
     if (DOWN16(len) > 0)
-        ossl_polyval_ghash_hash(ctx->Htable, S_s, out, DOWN16(len));
+        ossl_polyval_ghash_hash(&ctx->args, S_s, out, DOWN16(len));
     if (!IS16(len)) {
         /* deal with padding - probably easier to "memset" the padding first rather than calculate */
         padding[0] = padding[1] = 0;
         memcpy(padding, &out[DOWN16(len)], REMAINDER16(len));
-        ossl_polyval_ghash_hash(ctx->Htable, S_s, (uint8_t *)padding, sizeof(padding));
+        ossl_polyval_ghash_hash(&ctx->args, S_s, (uint8_t *)padding, sizeof(padding));
     }
-    ossl_polyval_ghash_hash(ctx->Htable, S_s, (uint8_t *)len_blk, TAG_SIZE);
+    ossl_polyval_ghash_hash(&ctx->args, S_s, (uint8_t *)len_blk, TAG_SIZE);
 
     for (i = 0; i < NONCE_SIZE; i++)
         S_s[i] ^= ctx->nonce[i];


### PR DESCRIPTION
Fixes #18693 for s390x

The s390x assembly assumes that the data for GHASH is stored in a
GCM128_CONTEXT structure, where a 128-bit argument immediately preceeds
the Htable.

Given the size (and extra fields) of the GCM128_CONTEXT structure, that
structure isn't used directly, but instead a similar structure is used
to emulate it so that the 128-bit argument preceeds the Htable. This
is then passed to the GHASH functions.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
