### PR TITLE
Change name of parameter in documentation from sigret to sig

### DIFF
--- a/doc/man3/EVP_DigestSignInit.pod
+++ b/doc/man3/EVP_DigestSignInit.pod
@@ -18,7 +18,7 @@ EVP_DigestSignFinal, EVP_DigestSign - EVP signing functions
  int EVP_DigestSignUpdate(EVP_MD_CTX *ctx, const void *d, size_t cnt);
  int EVP_DigestSignFinal(EVP_MD_CTX *ctx, unsigned char *sig, size_t *siglen);
 
- int EVP_DigestSign(EVP_MD_CTX *ctx, unsigned char *sigret,
+ int EVP_DigestSign(EVP_MD_CTX *ctx, unsigned char *sig,
                     size_t *siglen, const unsigned char *tbs,
                     size_t tbslen);
 

--- a/doc/man3/EVP_DigestVerifyInit.pod
+++ b/doc/man3/EVP_DigestVerifyInit.pod
@@ -18,7 +18,7 @@ EVP_DigestVerifyFinal, EVP_DigestVerify - EVP signature verification functions
  int EVP_DigestVerifyUpdate(EVP_MD_CTX *ctx, const void *d, size_t cnt);
  int EVP_DigestVerifyFinal(EVP_MD_CTX *ctx, const unsigned char *sig,
                            size_t siglen);
- int EVP_DigestVerify(EVP_MD_CTX *ctx, const unsigned char *sigret,
+ int EVP_DigestVerify(EVP_MD_CTX *ctx, const unsigned char *sig,
                       size_t siglen, const unsigned char *tbs, size_t tbslen);
 
 =head1 DESCRIPTION

--- a/doc/man7/provider-signature.pod
+++ b/doc/man7/provider-signature.pod
@@ -50,7 +50,7 @@ provider-signature - The signature library E<lt>-E<gt> provider functions
  int OSSL_FUNC_signature_digest_sign_final(void *ctx, unsigned char *sig,
                                            size_t *siglen, size_t sigsize);
  int OSSL_FUNC_signature_digest_sign(void *ctx,
-                              unsigned char *sigret, size_t *siglen,
+                              unsigned char *sig, size_t *siglen,
                               size_t sigsize, const unsigned char *tbs,
                               size_t tbslen);
 


### PR DESCRIPTION
The rest of the documentation talks about sig, not sigret
