### PR TITLE
Revert EVP_CIPHER_CTX_get_iv_length() fix

### DIFF
--- a/crypto/evp/evp_lib.c
+++ b/crypto/evp/evp_lib.c
@@ -504,36 +504,21 @@ int EVP_CIPHER_get_iv_length(const EVP_CIPHER *cipher)
 
 int EVP_CIPHER_CTX_get_iv_length(const EVP_CIPHER_CTX *ctx)
 {
-    if (ctx->iv_len < 0) {
-        int rv, len = EVP_CIPHER_get_iv_length(ctx->cipher);
-        size_t v = len;
-        OSSL_PARAM params[2] = { OSSL_PARAM_END, OSSL_PARAM_END };
+    int rv, len = EVP_CIPHER_get_iv_length(ctx->cipher);
+    size_t v = len;
+    OSSL_PARAM params[2] = { OSSL_PARAM_END, OSSL_PARAM_END };
 
-        if (ctx->cipher->get_ctx_params != NULL) {
-            params[0] = OSSL_PARAM_construct_size_t(OSSL_CIPHER_PARAM_IVLEN,
-                                                    &v);
-            rv = evp_do_ciph_ctx_getparams(ctx->cipher, ctx->algctx, params);
-            if (rv > 0) {
-                if (OSSL_PARAM_modified(params)
-                        && !OSSL_PARAM_get_int(params, &len))
-                    return -1;
-            } else if (rv != EVP_CTRL_RET_UNSUPPORTED) {
-                return -1;
-            }
-        }
-        /* Code below to be removed when legacy support is dropped. */
-        else if ((EVP_CIPHER_get_flags(ctx->cipher)
-                  & EVP_CIPH_CUSTOM_IV_LENGTH) != 0) {
-            rv = EVP_CIPHER_CTX_ctrl((EVP_CIPHER_CTX *)ctx, EVP_CTRL_GET_IVLEN,
-                                     0, &len);
-            if (rv <= 0)
-                return -1;
-        }
-        /*-
-         * Casting away the const is annoying but required here.  We need to
-         * cache the result for performance reasons.
-         */
-        ((EVP_CIPHER_CTX *)ctx)->iv_len = len;
+    params[0] = OSSL_PARAM_construct_size_t(OSSL_CIPHER_PARAM_IVLEN, &v);
+    rv = evp_do_ciph_ctx_getparams(ctx->cipher, ctx->algctx, params);
+    if (rv == EVP_CTRL_RET_UNSUPPORTED)
+        goto legacy;
+    return rv != 0 ? (int)v : -1;
+    /* Code below to be removed when legacy support is dropped. */
+legacy:
+    if ((EVP_CIPHER_get_flags(ctx->cipher) & EVP_CIPH_CUSTOM_IV_LENGTH) != 0) {
+        rv = EVP_CIPHER_CTX_ctrl((EVP_CIPHER_CTX *)ctx, EVP_CTRL_GET_IVLEN,
+                                 0, &len);
+        return (rv == 1) ? len : -1;
     }
     return len;
 }

--- a/doc/man3/EVP_EncryptInit.pod
+++ b/doc/man3/EVP_EncryptInit.pod
@@ -1216,7 +1216,7 @@ length.
 EVP_CIPHER_CTX_set_padding() always returns 1.
 
 EVP_CIPHER_get_iv_length() and EVP_CIPHER_CTX_get_iv_length() return the IV
-length, zero if the cipher does not use an IV and a negative value on error.
+length or zero if the cipher does not use an IV.
 
 EVP_CIPHER_CTX_get_tag_length() return the tag length or zero if the cipher
 does not use a tag.


### PR DESCRIPTION
PR #18875 fixed a bug in `EVP_CIPHER_CTX_get_iv_length()` in the master branch, and backported the same fix to the 3.0 branch. However the backport to 3.0 seems to have inadvertently also backported some code from the master branch that was not in the original PR and did not exist in 3.0. This is now causing the openssl-3.0 branch to fail to build.

It is not immediately obvious what the correct fix is so it seems the best answer is to revert the backport and redo it in a separate PR.

Marking as urgent because this is causing builds to fail.