### PR TITLE
Add X509v3_addr_get_safi() function

### DIFF
--- a/crypto/x509/v3_addr.c
+++ b/crypto/x509/v3_addr.c
@@ -96,6 +96,19 @@ unsigned int X509v3_addr_get_afi(const IPAddressFamily *f)
 }
 
 /*
+ * Extract the SAFI from an IPAddressFamily.
+ */
+unsigned X509v3_addr_get_safi(const IPAddressFamily *f)
+{
+    if (f == NULL
+        || f->addressFamily == NULL
+        || f->addressFamily->data == NULL
+        || f->addressFamily->length < 3)
+        return 0;
+    return f->addressFamily->data[2];
+}
+
+/*
  * Expand the bitstring form of an address into a raw byte array.
  * At the moment this is coded for simplicity, not speed.
  */

--- a/include/openssl/x509v3.h.in
+++ b/include/openssl/x509v3.h.in
@@ -912,6 +912,7 @@ int X509v3_addr_add_range(IPAddrBlocks *addr,
                           const unsigned afi, const unsigned *safi,
                           unsigned char *min, unsigned char *max);
 unsigned X509v3_addr_get_afi(const IPAddressFamily *f);
+unsigned X509v3_addr_get_safi(const IPAddressFamily *f);
 int X509v3_addr_get_range(IPAddressOrRange *aor, const unsigned afi,
                           unsigned char *min, unsigned char *max,
                           const int length);


### PR DESCRIPTION
Implementation of the X509v3_addr_get_safi() function, which is a getter for the SAFI.

This presents the same issue as `X509v3_addr_get_afi()` with returning 0 as an error instead of the reserved SAFI. Maybe we should have something like
`int X509v3_addr_get_safi(unsigned *safi);`
return `1` on success and modify the `safi`'s value if we want to fully comply with the standard, or maybe that's too over-engineered.


Fixes #18529 in `master` branch.
