### PR TITLE
Increase size limits of RFC values

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,10 @@ OpenSSL 3.1
 
 ### Changes between 3.0 and 3.1 [xx XXX xxxx]
 
+ * Increase size limits of data entries used for certificate generation
+
+   *Dimitris Soumis*
+
  * Added a new BIO_s_dgram_mem() to read/write datagrams to memory
 
    *Matt Caswell*

--- a/apps/openssl.cnf
+++ b/apps/openssl.cnf
@@ -171,11 +171,14 @@ countryName_max			= 2
 
 stateOrProvinceName		= State or Province Name (full name)
 stateOrProvinceName_default	= Some-State
+stateOrProvinceName_max         = 256
 
 localityName			= Locality Name (eg, city)
+localityName_max		= 256
 
 0.organizationName		= Organization Name (eg, company)
 0.organizationName_default	= Internet Widgits Pty Ltd
+0.organizationName_max	        = 256
 
 # we can do this but it is not needed normally :-)
 #1.organizationName		= Second Organization Name (eg, company)
@@ -183,12 +186,13 @@ localityName			= Locality Name (eg, city)
 
 organizationalUnitName		= Organizational Unit Name (eg, section)
 #organizationalUnitName_default	=
+organizationalUnitName_max	= 256
 
 commonName			= Common Name (e.g. server FQDN or YOUR name)
-commonName_max			= 64
+commonName_max			= 256
 
 emailAddress			= Email Address
-emailAddress_max		= 64
+emailAddress_max		= 320
 
 # SET-ex3			= SET extension number 3
 

--- a/crypto/asn1/tbl_standard.h
+++ b/crypto/asn1/tbl_standard.h
@@ -7,17 +7,17 @@
  * https://www.openssl.org/source/license.html
  */
 
-/* size limits: this stuff is taken straight from RFC3280 */
+/* size limits */
 
 #define ub_name                         32768
-#define ub_common_name                  64
-#define ub_locality_name                128
-#define ub_state_name                   128
-#define ub_organization_name            64
-#define ub_organization_unit_name       64
-#define ub_title                        64
-#define ub_email_address                128
-#define ub_serial_number                64
+#define ub_common_name                  256
+#define ub_locality_name                256
+#define ub_state_name                   256
+#define ub_organization_name            256
+#define ub_organization_unit_name       256
+#define ub_title                        256
+#define ub_email_address                320
+#define ub_serial_number                256
 
 /* From RFC4524 */
 

--- a/include/openssl/asn1.h.in
+++ b/include/openssl/asn1.h.in
@@ -212,16 +212,16 @@ struct asn1_string_table_st {
     generate_stack_macros("ASN1_STRING_TABLE");
 -}
 
-/* size limits: this stuff is taken straight from RFC2459 */
+/* size limits */
 
 # define ub_name                         32768
-# define ub_common_name                  64
-# define ub_locality_name                128
-# define ub_state_name                   128
-# define ub_organization_name            64
-# define ub_organization_unit_name       64
-# define ub_title                        64
-# define ub_email_address                128
+# define ub_common_name                  256
+# define ub_locality_name                256
+# define ub_state_name                   256
+# define ub_organization_name            256
+# define ub_organization_unit_name       256
+# define ub_title                        256
+# define ub_email_address                320
 
 /*
  * Declarations for template structures: for full definitions see asn1t.h


### PR DESCRIPTION
CLA: trivial

Leading edge technologies are using long names to define for example a fully qualified domain name. Thus, it is of utmost importance  to replace those old limits and adapt them to the current needs.

Also max values have been defined in openssl.cnf file to prevent the binary of openssl from exiting and to provide the user with proper feedback in order to fix their input without the need of restarting the execution of the binary.

##### Checklist
- [X] documentation is added or updated
