### PR TITLE
Fixes for TFO Tests in ASAN build

### DIFF
--- a/crypto/bio/bio_addr.c
+++ b/crypto/bio/bio_addr.c
@@ -74,7 +74,7 @@ BIO_ADDR *BIO_ADDR_dup(const BIO_ADDR *ap)
     if (ap != NULL) {
         ret = BIO_ADDR_new();
         if (ret != NULL)
-            memcpy(ret, ap, sizeof(BIO_ADDR));
+            BIO_ADDR_make(ret, &ap->sa);
     }
     return ret;
 }

--- a/test/bio_tfo_test.c
+++ b/test/bio_tfo_test.c
@@ -400,6 +400,8 @@ err:
         if (errstr != NULL)
             BIO_printf(bio_err, "last errno: %d=%s\n", sockerr, errstr);
     }
+    if (ai != NULL)
+        freeaddrinfo(ai);
     BIO_ADDR_free(baddr);
     BIO_closesocket(cfd);
     BIO_closesocket(sfd);


### PR DESCRIPTION
ASAN reports a heap overflow and a leak when running tfo tests.

The heap overflow might be spurious (not sure what the C standard says to that case), but we can simply fix that by using the correct member of a union instead of copying all bytes of said union including bytes that might not belong to the structure written into the union.

The leak is due to a missing freeaddrinfo call.
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->