### PR TITLE
Fix memory leak caused by BN_rand_range()

### DIFF
--- a/crypto/bn/bn_rand.c
+++ b/crypto/bn/bn_rand.c
@@ -136,6 +136,11 @@ static int bnrand_range(BNRAND_FLAG flag, BIGNUM *r, const BIGNUM *range,
     int n;
     int count = 100;
 
+    if (r == NULL) {
+        ERR_raise(ERR_LIB_BN, BN_R_NOT_INITIALIZED);
+        return 0;
+    }
+
     if (range->neg || BN_is_zero(range)) {
         ERR_raise(ERR_LIB_BN, BN_R_INVALID_RANGE);
         return 0;

--- a/crypto/bn/bn_rand.c
+++ b/crypto/bn/bn_rand.c
@@ -137,7 +137,7 @@ static int bnrand_range(BNRAND_FLAG flag, BIGNUM *r, const BIGNUM *range,
     int count = 100;
 
     if (r == NULL) {
-        ERR_raise(ERR_LIB_BN, BN_R_NOT_INITIALIZED);
+        ERR_raise(ERR_LIB_BN, ERR_R_PASSED_NULL_PARAMETER);
         return 0;
     }
 


### PR DESCRIPTION
Fixes: #18951

The patch enables `BN_rand_range()` to exit immediately if `BIGNUM *rnd` is NULL.

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->