### PR TITLE
Update session timeout code with OSSL_TIME

### DIFF
--- a/include/internal/time.h
+++ b/include/internal/time.h
@@ -77,6 +77,16 @@ void ossl_time_time_to_timeval(OSSL_TIME t, struct timeval *out)
     out->tv_usec = (t.t % OSSL_TIME_SECOND) / (OSSL_TIME_SECOND / 1000000);
 }
 
+/* Convert time_t to OSSL_TIME */
+static ossl_inline OSSL_TIME ossl_time_from_time_t(time_t t)
+{
+    OSSL_TIME ot;
+
+    ot.t = t;
+    ot.t *= OSSL_TIME_SECOND;
+    return ot;
+}
+
 /* Compare two time values, return -1 if less, 1 if greater and 0 if equal */
 static ossl_unused ossl_inline
 int ossl_time_compare(OSSL_TIME a, OSSL_TIME b)

--- a/ssl/ssl_local.h
+++ b/ssl/ssl_local.h
@@ -35,6 +35,7 @@
 # include "internal/tsan_assist.h"
 # include "internal/bio.h"
 # include "internal/ktls.h"
+# include "internal/time.h"
 
 # ifdef OPENSSL_BUILD_SHLIBSSL
 #  undef OPENSSL_EXTERN
@@ -600,8 +601,7 @@ struct ssl_session_st {
     CRYPTO_REF_COUNT references;
     time_t timeout;
     time_t time;
-    time_t calc_timeout;
-    int timeout_ovf;
+    OSSL_TIME calc_timeout;
     unsigned int compress_meth; /* Need to lookup the method */
     const SSL_CIPHER *cipher;
     unsigned long cipher_id;    /* when ASN.1 loaded, this needs to be used to

--- a/ssl/ssl_sess.c
+++ b/ssl/ssl_sess.c
@@ -26,35 +26,31 @@ static int remove_session_lock(SSL_CTX *ctx, SSL_SESSION *c, int lck);
 
 DEFINE_STACK_OF(SSL_SESSION)
 
-__owur static int sess_timedout(time_t t, SSL_SESSION *ss)
+__owur static ossl_inline OSSL_TIME time_t_to_ossl_time(time_t t)
 {
-    /* if timeout overflowed, it can never timeout! */
-    if (ss->timeout_ovf)
-        return 0;
-    return t > ss->calc_timeout;
+    OSSL_TIME ot;
+
+    ot.t = t;
+    ot.t *= OSSL_TIME_SECOND;
+    return ot;
+}
+
+__owur static ossl_inline int sess_timedout(time_t t, SSL_SESSION *ss)
+{
+    return ossl_time_compare(time_t_to_ossl_time(t), ss->calc_timeout) > 0;
 }
 
 /*
  * Returns -1/0/+1 as other XXXcmp-type functions
- * Takes overflow of calculated timeout into consideration
+ * Takes calculated timeout into consideration
  */
-__owur static int timeoutcmp(SSL_SESSION *a, SSL_SESSION *b)
+__owur static ossl_inline int timeoutcmp(SSL_SESSION *a, SSL_SESSION *b)
 {
-    /* if only one overflowed, then it is greater */
-    if (a->timeout_ovf && !b->timeout_ovf)
-        return 1;
-    if (!a->timeout_ovf && b->timeout_ovf)
-        return -1;
-    /* No overflow, or both overflowed, so straight compare is safe */
-    if (a->calc_timeout < b->calc_timeout)
-        return -1;
-    if (a->calc_timeout > b->calc_timeout)
-        return 1;
-    return 0;
+    return ossl_time_compare(a->calc_timeout, b->calc_timeout);
 }
 
 /*
- * Calculates effective timeout, saving overflow state
+ * Calculates effective timeout
  * Locking must be done by the caller of this function
  */
 void ssl_session_calculate_timeout(SSL_SESSION *ss)
@@ -62,18 +58,9 @@ void ssl_session_calculate_timeout(SSL_SESSION *ss)
     /* Force positive timeout */
     if (ss->timeout < 0)
         ss->timeout = 0;
-    ss->calc_timeout = ss->time + ss->timeout;
-    /*
-     * |timeout| is always zero or positive, so the check for
-     * overflow only needs to consider if |time| is positive
-     */
-    ss->timeout_ovf = ss->time > 0 && ss->calc_timeout < ss->time;
-    /*
-     * N.B. Realistic overflow can only occur in our lifetimes on a
-     *      32-bit machine in January 2038.
-     *      However, There are no controls to limit the |timeout|
-     *      value, except to keep it positive.
-     */
+
+    ss->calc_timeout = ossl_time_add(time_t_to_ossl_time(ss->time),
+                                     time_t_to_ossl_time(ss->timeout));
 }
 
 /*

--- a/ssl/ssl_sess.c
+++ b/ssl/ssl_sess.c
@@ -26,18 +26,9 @@ static int remove_session_lock(SSL_CTX *ctx, SSL_SESSION *c, int lck);
 
 DEFINE_STACK_OF(SSL_SESSION)
 
-__owur static ossl_inline OSSL_TIME time_t_to_ossl_time(time_t t)
-{
-    OSSL_TIME ot;
-
-    ot.t = t;
-    ot.t *= OSSL_TIME_SECOND;
-    return ot;
-}
-
 __owur static ossl_inline int sess_timedout(time_t t, SSL_SESSION *ss)
 {
-    return ossl_time_compare(time_t_to_ossl_time(t), ss->calc_timeout) > 0;
+    return ossl_time_compare(ossl_time_from_time_t(t), ss->calc_timeout) > 0;
 }
 
 /*
@@ -59,8 +50,8 @@ void ssl_session_calculate_timeout(SSL_SESSION *ss)
     if (ss->timeout < 0)
         ss->timeout = 0;
 
-    ss->calc_timeout = ossl_time_add(time_t_to_ossl_time(ss->time),
-                                     time_t_to_ossl_time(ss->timeout));
+    ss->calc_timeout = ossl_time_add(ossl_time_from_time_t(ss->time),
+                                     ossl_time_from_time_t(ss->timeout));
 }
 
 /*


### PR DESCRIPTION
This updates the session timeout code to use OSSL_TIME, however, I had to write a function to covert `time_t` to `OSSL_TIME`. Because of this, this will conflict with #18882.
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
