### PR TITLE
Remove void* type cast

### DIFF
--- a/test/drbgtest.c
+++ b/test/drbgtest.c
@@ -104,7 +104,7 @@ DRBG_UINT(reseed_counter)
 
 static PROV_DRBG *prov_rand(EVP_RAND_CTX *drbg)
 {
-    return (PROV_DRBG *)drbg->algctx;
+    return drbg->algctx;
 }
 
 static void set_reseed_counter(EVP_RAND_CTX *drbg, unsigned int n)

--- a/test/p_test.c
+++ b/test/p_test.c
@@ -309,7 +309,7 @@ int OSSL_provider_init(const OSSL_CORE_HANDLE *handle,
 
 static void p_teardown(void *provctx)
 {
-    P_TEST_CTX *ctx = (P_TEST_CTX *)provctx;
+    P_TEST_CTX *ctx = provctx;
 
 #ifdef PROVIDER_INIT_FUNCTION_NAME
     OSSL_LIB_CTX_free(ctx->libctx);

--- a/test/tls-provider.c
+++ b/test/tls-provider.c
@@ -592,7 +592,7 @@ static void *xor_gen_init(void *provctx, int selection,
         gctx->selection = selection;
 
     /* Our provctx is really just an OSSL_LIB_CTX */
-    gctx->libctx = (OSSL_LIB_CTX *)provctx;
+    gctx->libctx = provctx;
 
     if (!xor_gen_set_params(gctx, params)) {
         OPENSSL_free(gctx);


### PR DESCRIPTION
I think void* type pointers don't need to be cast.

CLA: trivial