### PR TITLE
If a ticket key callback returns 0 in TLSv1.3 don't send a ticket 

### DIFF
--- a/ssl/statem/statem.c
+++ b/ssl/statem/statem.c
@@ -888,10 +888,24 @@ static SUB_STATE_RETURN write_state_machine(SSL_CONNECTION *s)
                 SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
                 return SUB_STATE_ERROR;
             }
-            if (confunc != NULL && !confunc(s, &pkt)) {
-                WPACKET_cleanup(&pkt);
-                check_fatal(s);
-                return SUB_STATE_ERROR;
+            if (confunc != NULL) {
+                int tmpret;
+
+                tmpret = confunc(s, &pkt);
+                if (tmpret <= 0) {
+                    WPACKET_cleanup(&pkt);
+                    check_fatal(s);
+                    return SUB_STATE_ERROR;
+                } else if (tmpret == 2) {
+                    /*
+                     * The construction function decided not to construct the
+                     * message after all and continue. Skip sending.
+                     */
+                    WPACKET_cleanup(&pkt);
+                    st->write_state = WRITE_STATE_POST_WORK;
+                    st->write_state_work = WORK_MORE_A;
+                    break;
+                } /* else success */
             }
             if (!ssl_close_construct_packet(s, &pkt, mt)
                     || !WPACKET_finish(&pkt)) {

--- a/ssl/statem/statem.h
+++ b/ssl/statem/statem.h
@@ -80,6 +80,12 @@ typedef enum {
     ENC_WRITE_STATE_WRITE_PLAIN_ALERTS
 } ENC_WRITE_STATES;
 
+typedef enum {
+    CON_FUNC_ERROR = 0,
+    CON_FUNC_SUCCESS,
+    CON_FUNC_DONT_SEND
+} CON_FUNC_RETURN;
+
 /*****************************************************************************
  *                                                                           *
  * This structure should be considered "opaque" to anything outside of the   *

--- a/ssl/statem/statem_dtls.c
+++ b/ssl/statem/statem_dtls.c
@@ -927,18 +927,19 @@ static int dtls_get_reassembled_message(SSL_CONNECTION *s, int *errtype,
  * ssl->session->read_compression       assign
  * ssl->session->read_hash              assign
  */
-int dtls_construct_change_cipher_spec(SSL_CONNECTION *s, WPACKET *pkt)
+CON_FUNC_RETURN dtls_construct_change_cipher_spec(SSL_CONNECTION *s,
+                                                  WPACKET *pkt)
 {
     if (s->version == DTLS1_BAD_VER) {
         s->d1->next_handshake_write_seq++;
 
         if (!WPACKET_put_bytes_u16(pkt, s->d1->handshake_write_seq)) {
             SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
-            return 0;
+            return CON_FUNC_ERROR;
         }
     }
 
-    return 1;
+    return CON_FUNC_SUCCESS;
 }
 
 #ifndef OPENSSL_NO_SCTP

--- a/ssl/statem/statem_local.h
+++ b/ssl/statem/statem_local.h
@@ -54,7 +54,7 @@ typedef enum {
     MSG_PROCESS_CONTINUE_READING
 } MSG_PROCESS_RETURN;
 
-typedef int (*confunc_f) (SSL_CONNECTION *s, WPACKET *pkt);
+typedef CON_FUNC_RETURN (*confunc_f) (SSL_CONNECTION *s, WPACKET *pkt);
 
 int ssl3_take_mac(SSL_CONNECTION *s);
 int check_in_list(SSL_CONNECTION *s, uint16_t group_id, const uint16_t *groups,
@@ -111,11 +111,13 @@ __owur int tls_process_initial_server_flight(SSL_CONNECTION *s);
 __owur MSG_PROCESS_RETURN tls_process_change_cipher_spec(SSL_CONNECTION *s,
                                                          PACKET *pkt);
 __owur MSG_PROCESS_RETURN tls_process_finished(SSL_CONNECTION *s, PACKET *pkt);
-__owur int tls_construct_change_cipher_spec(SSL_CONNECTION *s, WPACKET *pkt);
-__owur int dtls_construct_change_cipher_spec(SSL_CONNECTION *s, WPACKET *pkt);
+__owur CON_FUNC_RETURN  tls_construct_change_cipher_spec(SSL_CONNECTION *s,
+                                                         WPACKET *pkt);
+__owur CON_FUNC_RETURN dtls_construct_change_cipher_spec(SSL_CONNECTION *s,
+                                                         WPACKET *pkt);
 
-__owur int tls_construct_finished(SSL_CONNECTION *s, WPACKET *pkt);
-__owur int tls_construct_key_update(SSL_CONNECTION *s, WPACKET *pkt);
+__owur CON_FUNC_RETURN tls_construct_finished(SSL_CONNECTION *s, WPACKET *pkt);
+__owur CON_FUNC_RETURN tls_construct_key_update(SSL_CONNECTION *s, WPACKET *pkt);
 __owur MSG_PROCESS_RETURN tls_process_key_update(SSL_CONNECTION *s,
                                                  PACKET *pkt);
 __owur WORK_STATE tls_finish_handshake(SSL_CONNECTION *s, WORK_STATE wst,
@@ -123,7 +125,8 @@ __owur WORK_STATE tls_finish_handshake(SSL_CONNECTION *s, WORK_STATE wst,
 __owur WORK_STATE dtls_wait_for_dry(SSL_CONNECTION *s);
 
 /* some client-only functions */
-__owur int tls_construct_client_hello(SSL_CONNECTION *s, WPACKET *pkt);
+__owur CON_FUNC_RETURN tls_construct_client_hello(SSL_CONNECTION *s,
+                                                  WPACKET *pkt);
 __owur MSG_PROCESS_RETURN tls_process_server_hello(SSL_CONNECTION *s,
                                                    PACKET *pkt);
 __owur MSG_PROCESS_RETURN tls_process_certificate_request(SSL_CONNECTION *s,
@@ -135,16 +138,20 @@ __owur MSG_PROCESS_RETURN tls_process_cert_status(SSL_CONNECTION *s,
                                                   PACKET *pkt);
 __owur MSG_PROCESS_RETURN tls_process_server_done(SSL_CONNECTION *s,
                                                   PACKET *pkt);
-__owur int tls_construct_cert_verify(SSL_CONNECTION *s, WPACKET *pkt);
+__owur CON_FUNC_RETURN tls_construct_cert_verify(SSL_CONNECTION *s,
+                                                 WPACKET *pkt);
 __owur WORK_STATE tls_prepare_client_certificate(SSL_CONNECTION *s,
                                                  WORK_STATE wst);
-__owur int tls_construct_client_certificate(SSL_CONNECTION *s, WPACKET *pkt);
+__owur CON_FUNC_RETURN tls_construct_client_certificate(SSL_CONNECTION *s,
+                                                        WPACKET *pkt);
 __owur int ssl_do_client_cert_cb(SSL_CONNECTION *s, X509 **px509,
                                  EVP_PKEY **ppkey);
-__owur int tls_construct_client_key_exchange(SSL_CONNECTION *s, WPACKET *pkt);
+__owur CON_FUNC_RETURN tls_construct_client_key_exchange(SSL_CONNECTION *s,
+                                                         WPACKET *pkt);
 __owur int tls_client_key_exchange_post_work(SSL_CONNECTION *s);
 __owur int tls_construct_cert_status_body(SSL_CONNECTION *s, WPACKET *pkt);
-__owur int tls_construct_cert_status(SSL_CONNECTION *s, WPACKET *pkt);
+__owur CON_FUNC_RETURN tls_construct_cert_status(SSL_CONNECTION *s,
+                                                 WPACKET *pkt);
 __owur MSG_PROCESS_RETURN tls_process_key_exchange(SSL_CONNECTION *s,
                                                    PACKET *pkt);
 __owur MSG_PROCESS_RETURN tls_process_server_certificate(SSL_CONNECTION *s,
@@ -153,23 +160,30 @@ __owur WORK_STATE tls_post_process_server_certificate(SSL_CONNECTION *s,
                                                       WORK_STATE wst);
 __owur int ssl3_check_cert_and_algorithm(SSL_CONNECTION *s);
 #ifndef OPENSSL_NO_NEXTPROTONEG
-__owur int tls_construct_next_proto(SSL_CONNECTION *s, WPACKET *pkt);
+__owur CON_FUNC_RETURN tls_construct_next_proto(SSL_CONNECTION *s, WPACKET *pkt);
 #endif
 __owur MSG_PROCESS_RETURN tls_process_hello_req(SSL_CONNECTION *s, PACKET *pkt);
 __owur MSG_PROCESS_RETURN dtls_process_hello_verify(SSL_CONNECTION *s, PACKET *pkt);
-__owur int tls_construct_end_of_early_data(SSL_CONNECTION *s, WPACKET *pkt);
+__owur CON_FUNC_RETURN tls_construct_end_of_early_data(SSL_CONNECTION *s,
+                                                       WPACKET *pkt);
 
 /* some server-only functions */
 __owur MSG_PROCESS_RETURN tls_process_client_hello(SSL_CONNECTION *s,
                                                    PACKET *pkt);
 __owur WORK_STATE tls_post_process_client_hello(SSL_CONNECTION *s,
                                                 WORK_STATE wst);
-__owur int tls_construct_server_hello(SSL_CONNECTION *s, WPACKET *pkt);
-__owur int dtls_construct_hello_verify_request(SSL_CONNECTION *s, WPACKET *pkt);
-__owur int tls_construct_server_certificate(SSL_CONNECTION *s, WPACKET *pkt);
-__owur int tls_construct_server_key_exchange(SSL_CONNECTION *s, WPACKET *pkt);
-__owur int tls_construct_certificate_request(SSL_CONNECTION *s, WPACKET *pkt);
-__owur int tls_construct_server_done(SSL_CONNECTION *s, WPACKET *pkt);
+__owur CON_FUNC_RETURN tls_construct_server_hello(SSL_CONNECTION *s,
+                                                  WPACKET *pkt);
+__owur CON_FUNC_RETURN dtls_construct_hello_verify_request(SSL_CONNECTION *s,
+                                                           WPACKET *pkt);
+__owur CON_FUNC_RETURN tls_construct_server_certificate(SSL_CONNECTION *s,
+                                                        WPACKET *pkt);
+__owur CON_FUNC_RETURN tls_construct_server_key_exchange(SSL_CONNECTION *s,
+                                                         WPACKET *pkt);
+__owur CON_FUNC_RETURN tls_construct_certificate_request(SSL_CONNECTION *s,
+                                                         WPACKET *pkt);
+__owur CON_FUNC_RETURN tls_construct_server_done(SSL_CONNECTION *s,
+                                                 WPACKET *pkt);
 __owur MSG_PROCESS_RETURN tls_process_client_certificate(SSL_CONNECTION *s,
                                                          PACKET *pkt);
 __owur MSG_PROCESS_RETURN tls_process_client_key_exchange(SSL_CONNECTION *s,
@@ -182,7 +196,8 @@ __owur MSG_PROCESS_RETURN tls_process_cert_verify(SSL_CONNECTION *s,
 __owur MSG_PROCESS_RETURN tls_process_next_proto(SSL_CONNECTION *s,
                                                  PACKET *pkt);
 #endif
-__owur int tls_construct_new_session_ticket(SSL_CONNECTION *s, WPACKET *pkt);
+__owur CON_FUNC_RETURN tls_construct_new_session_ticket(SSL_CONNECTION *s,
+                                                        WPACKET *pkt);
 MSG_PROCESS_RETURN tls_process_end_of_early_data(SSL_CONNECTION *s,
                                                  PACKET *pkt);
 

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -7650,6 +7650,10 @@ static int tick_key_cb(SSL *s, unsigned char key_name[16],
     int ret;
 
     tick_key_cb_called = 1;
+
+    if (tick_key_renew == -1)
+        return 0;
+
     memset(iv, 0, AES_BLOCK_SIZE);
     memset(key_name, 0, 16);
     if (aes128cbc == NULL
@@ -7679,6 +7683,10 @@ static int tick_key_evp_cb(SSL *s, unsigned char key_name[16],
     int ret;
 
     tick_key_cb_called = 1;
+
+    if (tick_key_renew == -1)
+        return 0;
+
     memset(iv, 0, AES_BLOCK_SIZE);
     memset(key_name, 0, 16);
     params[0] = OSSL_PARAM_construct_utf8_string(OSSL_MAC_PARAM_DIGEST,
@@ -7711,10 +7719,14 @@ static int tick_key_evp_cb(SSL *s, unsigned char key_name[16],
  * Test 9: TLSv1.3, old ticket key callback, ticket, no renewal
  * Test 10: TLSv1.2, old ticket key callback, ticket, renewal
  * Test 11: TLSv1.3, old ticket key callback, ticket, renewal
- * Test 12: TLSv1.2, ticket key callback, ticket, no renewal
- * Test 13: TLSv1.3, ticket key callback, ticket, no renewal
- * Test 14: TLSv1.2, ticket key callback, ticket, renewal
- * Test 15: TLSv1.3, ticket key callback, ticket, renewal
+ * Test 12: TLSv1.2, old ticket key callback, no ticket
+ * Test 13: TLSv1.3, old ticket key callback, no ticket
+ * Test 14: TLSv1.2, ticket key callback, ticket, no renewal
+ * Test 15: TLSv1.3, ticket key callback, ticket, no renewal
+ * Test 16: TLSv1.2, ticket key callback, ticket, renewal
+ * Test 17: TLSv1.3, ticket key callback, ticket, renewal
+ * Test 18: TLSv1.2, ticket key callback, no ticket
+ * Test 19: TLSv1.3, ticket key callback, no ticket
  */
 static int test_ticket_callbacks(int tst)
 {
@@ -7739,8 +7751,11 @@ static int test_ticket_callbacks(int tst)
     gen_tick_called = dec_tick_called = tick_key_cb_called = 0;
 
     /* Which tests the ticket key callback should request renewal for */
-    if (tst == 10 || tst == 11 || tst == 14 || tst == 15)
+    
+    if (tst == 10 || tst == 11 || tst == 16 || tst == 17)
         tick_key_renew = 1;
+    else if (tst == 12 || tst == 13 || tst == 18 || tst == 19)
+        tick_key_renew = -1; /* abort sending the ticket/0-length ticket */
     else
         tick_key_renew = 0;
 
@@ -7789,7 +7804,7 @@ static int test_ticket_callbacks(int tst)
                                                  NULL)))
         goto end;
 
-    if (tst >= 12) {
+    if (tst >= 14) {
         if (!TEST_true(SSL_CTX_set_tlsext_ticket_key_evp_cb(sctx, tick_key_evp_cb)))
             goto end;
 #ifndef OPENSSL_NO_DEPRECATED_3_0
@@ -7834,7 +7849,8 @@ static int test_ticket_callbacks(int tst)
         goto end;
 
     if (tick_dec_ret == SSL_TICKET_RETURN_IGNORE
-            || tick_dec_ret == SSL_TICKET_RETURN_IGNORE_RENEW) {
+            || tick_dec_ret == SSL_TICKET_RETURN_IGNORE_RENEW
+            || tick_key_renew == -1) {
         if (!TEST_false(SSL_session_reused(clientssl)))
             goto end;
     } else {
@@ -7847,7 +7863,8 @@ static int test_ticket_callbacks(int tst)
                       || tick_dec_ret == SSL_TICKET_RETURN_IGNORE_RENEW
                       || tick_dec_ret == SSL_TICKET_RETURN_USE_RENEW)
                      ? 1 : 0)
-            || !TEST_int_eq(dec_tick_called, 1))
+               /* There is no ticket to decrypt in tests 13 and 19 */
+            || !TEST_int_eq(dec_tick_called, (tst == 13 || tst == 19) ? 0 : 1))
         goto end;
 
     testresult = 1;
@@ -10312,7 +10329,7 @@ int setup_tests(void)
     ADD_ALL_TESTS(test_info_callback, 6);
     ADD_ALL_TESTS(test_ssl_pending, 2);
     ADD_ALL_TESTS(test_ssl_get_shared_ciphers, OSSL_NELEM(shared_ciphers_data));
-    ADD_ALL_TESTS(test_ticket_callbacks, 16);
+    ADD_ALL_TESTS(test_ticket_callbacks, 20);
     ADD_ALL_TESTS(test_shutdown, 7);
     ADD_ALL_TESTS(test_incorrect_shutdown, 2);
     ADD_ALL_TESTS(test_cert_cb, 6);

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -7645,14 +7645,23 @@ static int tick_key_cb(SSL *s, unsigned char key_name[16],
 {
     const unsigned char tick_aes_key[16] = "0123456789abcdef";
     const unsigned char tick_hmac_key[16] = "0123456789abcdef";
-    EVP_CIPHER *aes128cbc = EVP_CIPHER_fetch(libctx, "AES-128-CBC", NULL);
-    EVP_MD *sha256 = EVP_MD_fetch(libctx, "SHA-256", NULL);
+    EVP_CIPHER *aes128cbc;
+    EVP_MD *sha256;
     int ret;
 
     tick_key_cb_called = 1;
 
     if (tick_key_renew == -1)
         return 0;
+
+    aes128cbc = EVP_CIPHER_fetch(libctx, "AES-128-CBC", NULL);
+    if (!TEST_ptr(aes128cbc))
+        return 0;
+    sha256 = EVP_MD_fetch(libctx, "SHA-256", NULL);
+    if (!TEST_ptr(sha256)) {
+        EVP_CIPHER_free(aes128cbc);
+        return 0;
+    }
 
     memset(iv, 0, AES_BLOCK_SIZE);
     memset(key_name, 0, 16);
@@ -7679,12 +7688,16 @@ static int tick_key_evp_cb(SSL *s, unsigned char key_name[16],
     const unsigned char tick_aes_key[16] = "0123456789abcdef";
     unsigned char tick_hmac_key[16] = "0123456789abcdef";
     OSSL_PARAM params[2];
-    EVP_CIPHER *aes128cbc = EVP_CIPHER_fetch(libctx, "AES-128-CBC", NULL);
+    EVP_CIPHER *aes128cbc;
     int ret;
 
     tick_key_cb_called = 1;
 
     if (tick_key_renew == -1)
+        return 0;
+
+    aes128cbc = EVP_CIPHER_fetch(libctx, "AES-128-CBC", NULL);
+    if (!TEST_ptr(aes128cbc))
         return 0;
 
     memset(iv, 0, AES_BLOCK_SIZE);

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -7744,7 +7744,7 @@ static int test_ticket_callbacks(int tst)
         return 1;
 #endif
 #ifdef OPENSSL_NO_DEPRECATED_3_0
-    if (tst >= 8 && tst <= 11)
+    if (tst >= 8 && tst <= 13)
         return 1;
 #endif
 


### PR DESCRIPTION
If we can't construct the ticket don't send one. This requires a change
to the TLS state machine to be able to a handle a construction function
deciding not to send a message after all.

Fixes #18977

This fix is for master only. It's probably too invasive to be suitable for backport to 3.0/1.1.1. I think I can create a version for those branches without the last commit that introduces the new return type - which should hopefully much restrict the amount of code touched.