### PR TITLE
Limit the size of various MAXCHUNK definitions

### DIFF
--- a/include/crypto/evp.h
+++ b/include/crypto/evp.h
@@ -365,7 +365,7 @@ static int cname##_ecb_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out, const uns
         return 1;\
 }
 
-#define EVP_MAXCHUNK ((size_t)1<<(sizeof(long)*8-2))
+#define EVP_MAXCHUNK ((size_t)1 << 30)
 
 #define BLOCK_CIPHER_func_ofb(cname, cprefix, cbits, kstruct, ksched) \
     static int cname##_ofb_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out, const unsigned char *in, size_t inl) \

--- a/providers/implementations/include/prov/ciphercommon.h
+++ b/providers/implementations/include/prov/ciphercommon.h
@@ -18,8 +18,8 @@
 # include "internal/cryptlib.h"
 # include "crypto/modes.h"
 
-# define MAXCHUNK    ((size_t)1 << (sizeof(long) * 8 - 2))
-# define MAXBITCHUNK ((size_t)1 << (sizeof(size_t) * 8 - 4))
+# define MAXCHUNK    ((size_t)1 << 30)
+# define MAXBITCHUNK ((size_t)1 << 28)
 
 # define GENERIC_BLOCK_SIZE 16
 # define IV_STATE_UNINITIALISED 0  /* initial state is not initialized */

--- a/providers/implementations/include/prov/ciphercommon.h
+++ b/providers/implementations/include/prov/ciphercommon.h
@@ -19,7 +19,7 @@
 # include "crypto/modes.h"
 
 # define MAXCHUNK    ((size_t)1 << 30)
-# define MAXBITCHUNK ((size_t)1 << 28)
+# define MAXBITCHUNK ((size_t)1 << (sizeof(size_t) * 8 - 4))
 
 # define GENERIC_BLOCK_SIZE 16
 # define IV_STATE_UNINITIALISED 0  /* initial state is not initialized */


### PR DESCRIPTION
The current code has issues when `sizeof(long) <> sizeof(size_t)`.  The two types are assumed to be interchangeable and them being different will cause crashes and endless loops.

This fix limits the maximum chunk size for many of the symmetric ciphers to 2³⁰ bytes.  This chunk size limits the amount of data that will be encrypted/decrypted in one lump.  The code internally handles blocks of data later than the chunk limit, so this will present no difference to the caller.  Any loss of efficiency due to limiting the chunking to 1 Gbyte rather than more should be insignificant.

Fixes Coverity issues: 1508498, 1508500 - 1508505, 1508507 - 1508527, 1508529 - 1508533, 1508535 - 1508537, 1508539, 1508541 - 1508549, 1508551 - 1508569, 1508571 - 1508582.

- [ ] documentation is added or updated
- [ ] tests are added or updated
