### PR TITLE
Avoid using tsan_add

### DIFF
--- a/crypto/property/property.c
+++ b/crypto/property/property.c
@@ -673,7 +673,7 @@ static void ossl_method_cache_flush_some(OSSL_METHOD_STORE *store)
     store->cache_nelem = state.nelem;
     /* Without a timer, update the global seed */
     if (state.using_global_seed)
-        tsan_add(&global_seed, state.seed);
+        tsan_store(&global_seed, state.seed);
 }
 
 int ossl_method_store_cache_get(OSSL_METHOD_STORE *store, OSSL_PROVIDER *prov,


### PR DESCRIPTION

tasn_add was added after 3.0 was released and isn't available.
This prevents builds from working, so urgent.

The change to tsan_store still achieves the goal of this original fix.
