### PR TITLE
Fix memory leak with TLS1.2 compression

### DIFF
--- a/ssl/record/methods/tls_common.c
+++ b/ssl/record/methods/tls_common.c
@@ -1238,6 +1238,8 @@ static void tls_int_free(OSSL_RECORD_LAYER *rl)
     if (rl->version == SSL3_VERSION)
         OPENSSL_cleanse(rl->mac_secret, sizeof(rl->mac_secret));
 
+    SSL3_RECORD_release(rl->rrec, SSL_MAX_PIPELINES);
+
     OPENSSL_free(rl);
 }
 


### PR DESCRIPTION
Leak sanitizer reports following leak for ssl-test-new subtest
4-tlsv1_2-both-compress:

==335733==ERROR: LeakSanitizer: detected memory leaks
Direct leak of 17728 byte(s) in 1 object(s) allocated from:
    #0 0x3ff9fbba251 in malloc (/usr/lib64/libasan.so.8+0xba251)
    #1 0x3ff9f71744f in tls_do_uncompress ssl/record/methods/tls_common.c:868
    #2 0x3ff9f7175bd in tls_default_post_process_record ssl/record/methods/tls_common.c:896
    #3 0x3ff9f715ee7 in tls_get_more_records ssl/record/methods/tls_common.c:773
    #4 0x3ff9f712209 in tls_read_record ssl/record/methods/tls_common.c:958
    #5 0x3ff9f6ef73f in ssl3_read_bytes ssl/record/rec_layer_s3.c:1235
    #6 0x3ff9f776165 in tls_get_message_header ssl/statem/statem_lib.c:1198
    #7 0x3ff9f74709b in read_state_machine ssl/statem/statem.c:624
    #8 0x3ff9f74709b in state_machine ssl/statem/statem.c:478
    #9 0x3ff9f662e61 in SSL_do_handshake ssl/ssl_lib.c:4430
    #10 0x100c55d in do_handshake_step test/helpers/handshake.c:775
    #11 0x100c55d in do_connect_step test/helpers/handshake.c:1134
    #12 0x100e85b in do_handshake_internal test/helpers/handshake.c:1544
    #13 0x1011715 in do_handshake test/helpers/handshake.c:1738
    #14 0x101d1a7 in test_handshake test/ssl_test.c:543
    #15 0x1027875 in run_tests test/testutil/driver.c:370
    #16 0x1008393 in main test/testutil/main.c:30
    #17 0x3ff9cc2b871 in __libc_start_call_main (/usr/lib64/libc.so.6+0x2b871)
    #18 0x3ff9cc2b94f in __libc_start_main_alias_2 (/usr/lib64/libc.so.6+0x2b94f)
    #19 0x100864f  (/code/openssl/test/ssl_test+0x100864f)
Direct leak of 17728 byte(s) in 1 object(s) allocated from:
    #0 0x3ff9fbba251 in malloc (/usr/lib64/libasan.so.8+0xba251)
    #1 0x3ff9f71744f in tls_do_uncompress ssl/record/methods/tls_common.c:868
    #2 0x3ff9f7175bd in tls_default_post_process_record ssl/record/methods/tls_common.c:896
    #3 0x3ff9f715ee7 in tls_get_more_records ssl/record/methods/tls_common.c:773
    #4 0x3ff9f712209 in tls_read_record ssl/record/methods/tls_common.c:958
    #5 0x3ff9f6ef73f in ssl3_read_bytes ssl/record/rec_layer_s3.c:1235
    #6 0x3ff9f776165 in tls_get_message_header ssl/statem/statem_lib.c:1198
    #7 0x3ff9f74709b in read_state_machine ssl/statem/statem.c:624
    #8 0x3ff9f74709b in state_machine ssl/statem/statem.c:478
    #9 0x3ff9f662e61 in SSL_do_handshake ssl/ssl_lib.c:4430
    #10 0x100c55d in do_handshake_step test/helpers/handshake.c:775
    #11 0x100c55d in do_connect_step test/helpers/handshake.c:1134
    #12 0x1010b09 in do_handshake_internal test/helpers/handshake.c:1550
    #13 0x1011715 in do_handshake test/helpers/handshake.c:1738
    #14 0x101d1a7 in test_handshake test/ssl_test.c:543
    #15 0x1027875 in run_tests test/testutil/driver.c:370
    #16 0x1008393 in main test/testutil/main.c:30
    #17 0x3ff9cc2b871 in __libc_start_call_main (/usr/lib64/libc.so.6+0x2b871)
    #18 0x3ff9cc2b94f in __libc_start_main_alias_2 (/usr/lib64/libc.so.6+0x2b94f)
    #19 0x100864f  (/code/openssl/test/ssl_test+0x100864f)
SUMMARY: AddressSanitizer: 35456 byte(s) leaked in 2 allocation(s).

Fix this by freeing the SSL3_RECORD structure inside the OSSL_RECORD_LAYER.

Signed-off-by: Juergen Christ <jchrist@linux.ibm.com>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

