### PR TITLE
Coverity 1508532: out of bounds access

### DIFF
--- a/crypto/dh/dh_pmeth.c
+++ b/crypto/dh/dh_pmeth.c
@@ -432,7 +432,8 @@ static int pkey_dh_derive(EVP_PKEY_CTX *ctx, unsigned char *key,
     else if (dctx->kdf_type == EVP_PKEY_DH_KDF_X9_42) {
 
         unsigned char *Z = NULL;
-        size_t Zlen = 0;
+        int Zlen = 0;
+
         if (!dctx->kdf_outlen || !dctx->kdf_oid)
             return 0;
         if (key == NULL) {


### PR DESCRIPTION
The problem is an `int` to `size_t` conversion where the `int` could be negative.
Changing the variable to `int` addresses things.  The less equal to zero check was already there.