### PR TITLE
chore: Add extern C for sm2 and sm4 headers

### DIFF
--- a/include/crypto/sm2.h
+++ b/include/crypto/sm2.h
@@ -20,6 +20,10 @@
 #  include <openssl/ec.h>
 #  include "crypto/types.h"
 
+# ifdef  __cplusplus
+extern "C" {
+# endif
+
 int ossl_sm2_key_private_check(const EC_KEY *eckey);
 
 /* The default user id as specified in GM/T 0009-2012 */
@@ -82,5 +86,10 @@ int ossl_sm2_decrypt(const EC_KEY *key,
 
 const unsigned char *ossl_sm2_algorithmidentifier_encoding(int md_nid,
                                                            size_t *len);
+
+# ifdef  __cplusplus
+}
+# endif
+
 # endif /* OPENSSL_NO_SM2 */
 #endif

--- a/include/crypto/sm4.h
+++ b/include/crypto/sm4.h
@@ -19,6 +19,10 @@
 #  error SM4 is disabled.
 # endif
 
+# ifdef  __cplusplus
+extern "C" {
+# endif
+
 # define SM4_ENCRYPT     1
 # define SM4_DECRYPT     0
 
@@ -35,4 +39,7 @@ void ossl_sm4_encrypt(const uint8_t *in, uint8_t *out, const SM4_KEY *ks);
 
 void ossl_sm4_decrypt(const uint8_t *in, uint8_t *out, const SM4_KEY *ks);
 
+# ifdef  __cplusplus
+}
+# endif
 #endif


### PR DESCRIPTION
C++ program can not correctly link functions from sm2.h and sm4.h,
every c++ program should add the 'extern C' when they include sm2.h and sm4.h,
it not kindly to developers especially the new hand.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
