### PR TITLE
util/wrap.pl.in: If the subprocess died with a signal, let's re-signal it

### DIFF
--- a/util/wrap.pl.in
+++ b/util/wrap.pl.in
@@ -68,7 +68,10 @@ my $waitcode = system @cmd;
 die "wrap.pl: Failed to execute '", join(' ', @cmd), "': $!\n"
     if $waitcode == -1;
 
-# When the subprocess aborted on a signal, mimic what Unix shells do, by
+# When the subprocess aborted on a signal, we simply raise the same signal.
+kill ($? & 255) => $$ if ($? & 255) != 0;
+
+# If that didn't stop this script, mimic what Unix shells do, by
 # converting the signal code to an exit code by setting the high bit.
 # This only happens on Unix flavored operating systems, the others don't
 # have this sort of signaling to date, and simply leave the low byte zero.


### PR DESCRIPTION
A simple 'kill' of the same signal on our own process should do it.
This will allow the shell that this is running under to catch it
properly, and output something if it usually does that.

Fixes #19041
