### PR TITLE
iOS config targets: Add target iossimulator86-xcrun to build for 32 bit ios simulator

### DIFF
--- a/Configurations/15-ios.conf
+++ b/Configurations/15-ios.conf
@@ -30,9 +30,15 @@ my %targets = (
         asm_arch         => 'aarch64',
         perlasm_scheme   => "ios64",
     },
+    "iossimulator86-xcrun" => {
+        inherit_from     => [ "ios-common" ],
+        CC               => "xcrun -sdk iphonesimulator cc",
+        cflags           => add("-arch i386"),
+    },
     "iossimulator-xcrun" => {
         inherit_from     => [ "ios-common" ],
         CC               => "xcrun -sdk iphonesimulator cc",
+        cflags           => add("-arch x86_64"),
     },
 # It takes three prior-set environment variables to make it work:
 #


### PR DESCRIPTION
Currently the available iossimulator-xcrun target doesn't specify the architecture, so x86_64 is picked on 64 bit versions of xcode. This is an issue as ios 9 (and probably earlier as well) simulators run in 32 bit mode and thus require 32 bit libraries. This new target will explicitly pass the architecture as ``i386``, and the default target got updated to passing ``x86_64``.

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
