### PR TITLE
Drop the optimisation level for ppc64le cross-compile

### DIFF
--- a/.github/workflows/cross-compiles.yml
+++ b/.github/workflows/cross-compiles.yml
@@ -80,7 +80,10 @@ jobs:
           }, {
             arch: powerpc64le-linux-gnu,
             libs: libc6-dev-ppc64el-cross,
-            target: linux-ppc64le
+            # The default compiler for this platform on Ubuntu 20.04 seems
+            # buggy and causes test failures. Dropping the optimisation level
+            # resolves it.
+            target: -O2 linux-ppc64le
           }, {
             arch: riscv64-linux-gnu,
             libs: libc6-dev-riscv64-cross,


### PR DESCRIPTION
The default cross compiler (gcc 9.4.0) for ppc64le on Ubunut 20.04 seems
buggy and causes a seg fault in sslapitest. This doesn't impact any other
CI cross compile platforms and does not seem to impact the gcc 10.3.0 cross
compiler.

We just drop the optimisation level on that platform.
