### PR TITLE
Tolerate a bad record version in TLSv1.3 plaintext records

### DIFF
--- a/ssl/record/methods/tlsany_meth.c
+++ b/ssl/record/methods/tlsany_meth.c
@@ -87,15 +87,9 @@ static int tls_validate_record_header(OSSL_RECORD_LAYER *rl, SSL3_RECORD *rec)
         } else if (rl->version == TLS1_3_VERSION) {
             /*
              * In this case we know we are going to negotiate TLSv1.3, but we've
-             * had an HRR, so we haven't actually done so yet. Nonetheless we
-             * still expect the record version to be TLSv1.2 as per a normal
-             * TLSv1.3 record
+             * had an HRR, so we haven't actually done so yet. In TLSv1.3 we
+             * must ignore the legacy record version in plaintext records.
              */
-            if (rec->rec_version != TLS1_2_VERSION) {
-                RLAYERfatal(rl, SSL_AD_PROTOCOL_VERSION,
-                            SSL_R_WRONG_VERSION_NUMBER);
-                return 0;
-            }
         } else if (rec->rec_version != rl->version) {
             if ((rl->version & 0xFF00) == (rec->rec_version & 0xFF00)) {
                 if (rec->type == SSL3_RT_ALERT) {

--- a/test/recipes/70-test_sslrecords.t
+++ b/test/recipes/70-test_sslrecords.t
@@ -248,17 +248,21 @@ SKIP: {
     $proxy->start();
     ok(TLSProxy::Message->success(), "No data between KeyUpdate");
 
-    #Test 21: Force an HRR and change the "real" ServerHello to have a protocol
-    #         record version of 0x0301 (TLSv1.0). At this point we have already
-    #         decided that we are doing TLSv1.3 but are still using plaintext
-    #         records. The server should be sending a record version of 0x303
-    #         (TLSv1.2), but the RFC requires us to ignore this field so we
-    #         should tolerate the incorrect version.
-    $proxy->clear();
-    $proxy->filter(\&change_server_hello_version);
-    $proxy->serverflags("-groups P-256"); # Force an HRR
-    $proxy->start();
-    ok(TLSProxy::Message->success(), "Bad ServerHello record version after HRR");
+    SKIP: {
+        skip "EC disabled", 1 if disabled("ec");
+
+        #Test 21: Force an HRR and change the "real" ServerHello to have a protocol
+        #         record version of 0x0301 (TLSv1.0). At this point we have already
+        #         decided that we are doing TLSv1.3 but are still using plaintext
+        #         records. The server should be sending a record version of 0x303
+        #         (TLSv1.2), but the RFC requires us to ignore this field so we
+        #         should tolerate the incorrect version.
+        $proxy->clear();
+        $proxy->filter(\&change_server_hello_version);
+        $proxy->serverflags("-groups P-256"); # Force an HRR
+        $proxy->start();
+        ok(TLSProxy::Message->success(), "Bad ServerHello record version after HRR");
+    }
  }
 
 

--- a/test/recipes/70-test_sslrecords.t
+++ b/test/recipes/70-test_sslrecords.t
@@ -44,7 +44,7 @@ my $inject_recs_num = 1;
 $proxy->serverflags("-tls1_2");
 $proxy->clientflags("-no_tls1_3");
 $proxy->start() or plan skip_all => "Unable to start up Proxy for tests";
-plan tests => 20;
+plan tests => 21;
 ok($fatal_alert, "Out of context empty records test");
 
 #Test 2: Injecting in context empty records should succeed
@@ -175,7 +175,7 @@ ok($fatal_alert, "Changed record version in TLS1.2");
 
 #TLS1.3 specific tests
 SKIP: {
-    skip "TLSv1.3 disabled", 8
+    skip "TLSv1.3 disabled", 9
         if disabled("tls1_3") || (disabled("ec") && disabled("dh"));
 
     #Test 13: Sending a different record version in TLS1.3 should fail
@@ -247,6 +247,18 @@ SKIP: {
     $boundary_test_type = NO_DATA_BETWEEN_KEY_UPDATE;
     $proxy->start();
     ok(TLSProxy::Message->success(), "No data between KeyUpdate");
+
+    #Test 21: Force an HRR and change the "real" ServerHello to have a protocol
+    #         record version of 0x0301 (TLSv1.0). At this point we have already
+    #         decided that we are doing TLSv1.3 but are still using plaintext
+    #         records. The server should be sending a record version of 0x303
+    #         (TLSv1.2), but the RFC requires us to ignore this field so we
+    #         should tolerate the incorrect version.
+    $proxy->clear();
+    $proxy->filter(\&change_server_hello_version);
+    $proxy->serverflags("-groups P-256"); # Force an HRR
+    $proxy->start();
+    ok(TLSProxy::Message->success(), "Bad ServerHello record version after HRR");
  }
 
 
@@ -533,6 +545,26 @@ sub change_version
         # ... typically in ServerHelloDone
         @{$records}[-1]->version(TLSProxy::Record::VERS_TLS_1_1);
     }
+}
+
+sub change_server_hello_version
+{
+    my $proxy = shift;
+    my $records = $proxy->record_list;
+
+    # We're only interested in changing the ServerHello after an HRR
+    if ($proxy->flight != 3) {
+        return;
+    }
+
+    # The ServerHello has index 5
+    # 0 - ClientHello
+    # 1 - HRR
+    # 2 - CCS
+    # 3 - ClientHello(2)
+    # 4 - CCS
+    # 5 - ServerHello
+    @{$records}[5]->version(TLSProxy::Record::VERS_TLS_1_0);
 }
 
 sub change_outer_record_type


### PR DESCRIPTION
When a server responds to a second TLSv1.3 ClientHello it is required to
set the legacy_record_version to 0x0303 (TLSv1.2). The client is required
to ignore that field even if it is wrong. The recent changes to the read
record layer in PR #18132 made the record layer stricter and it was
checking that the legacy_record_version was the correct value. This
caused connection failures when talking to buggy servers that set the
wrong legacy_record_version value.

We make us more tolerant again.

Fixes #19051
