### PR TITLE
Follow-up on X.509 purpose code-sign

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -147,6 +147,11 @@ OpenSSL 3.1
 
    *Tomáš Mráz*
 
+ * Add X.509 certificate codeSigning purpose and related checks on key usage and
+   extended key usage of the leaf certificate according to the CA/Browser Forum.
+
+   * Lutz Jänicke*
+
  * Fix and extend certificate handling and the apps `x509`, `verify` etc.
    such as adding a trace facility for debugging certificate chain building.
 

--- a/crypto/x509/v3_purp.c
+++ b/crypto/x509/v3_purp.c
@@ -843,10 +843,21 @@ static int check_purpose_timestamp_sign(const X509_PURPOSE *xp, const X509 *x,
 {
     int i_ext;
 
-    /* If ca is true we must return if this is a valid CA certificate. */
+    /*
+     * If require_ca is true we must check if this is a valid CA certificate.
+     * The extra requirements by the CA/Browser Forum are not checked.
+     */
     if (require_ca)
         return check_ca(x);
 
+    /*
+     * Key Usage is checked according to RFC 5280 and
+     * Extended Key Usage attributes is checked according to RFC 3161.
+     * The extra (and somewhat conflicting) CA/Browser Forum
+     * Baseline Requirements for the Issuance and Management of
+     * Publicly‐Trusted Code Signing Certificates, Version 3.0.0,
+     * Section 7.1.2.3: Code signing and Timestamp Certificate are not checked.
+     */
     /*
      * Check the optional key usage field:
      * if Key Usage is present, it must be one of digitalSignature
@@ -875,21 +886,24 @@ static int check_purpose_code_sign(const X509_PURPOSE *xp, const X509 *x,
 {
     int i_ext;
 
-    /* If ca is true we must return if this is a valid CA certificate. */
+    /*
+     * If require_ca is true we must check if this is a valid CA certificate.
+     * The extra requirements by the CA/Browser Forum are not checked.
+     */
     if (require_ca)
         return check_ca(x);
 
     /*
      * Check the key usage and extended key usage fields:
      *
-     * Reference: CA Browser Forum,
-     * Baseline Requirements for the Issuance and Management of 
+     * Reference: CA/Browser Forum,
+     * Baseline Requirements for the Issuance and Management of
      * Publicly‐Trusted Code Signing Certificates, Version 3.0.0,
      * Section 7.1.2.3: Code signing and Timestamp Certificate
      *
      * Checking covers Key Usage and Extended Key Usage attributes.
-     * Other properties like CRL Distribution Points and Authoriy
-     * Information Access (AIA) are not checked.
+     * The certificatePolicies, cRLDistributionPoints (CDP), and
+     * authorityInformationAccess (AIA) extensions are so far not checked.
      */
     /* Key Usage */
     if ((x->ex_flags & EXFLAG_KUSAGE) == 0)

--- a/crypto/x509/v3_purp.c
+++ b/crypto/x509/v3_purp.c
@@ -18,26 +18,26 @@
 
 static int check_ssl_ca(const X509 *x);
 static int check_purpose_ssl_client(const X509_PURPOSE *xp, const X509 *x,
-                                    int require_ca);
+                                    int non_leaf);
 static int check_purpose_ssl_server(const X509_PURPOSE *xp, const X509 *x,
-                                    int require_ca);
+                                    int non_leaf);
 static int check_purpose_ns_ssl_server(const X509_PURPOSE *xp, const X509 *x,
-                                       int require_ca);
-static int purpose_smime(const X509 *x, int require_ca);
+                                       int non_leaf);
+static int purpose_smime(const X509 *x, int non_leaf);
 static int check_purpose_smime_sign(const X509_PURPOSE *xp, const X509 *x,
-                                    int require_ca);
+                                    int non_leaf);
 static int check_purpose_smime_encrypt(const X509_PURPOSE *xp, const X509 *x,
-                                       int require_ca);
+                                       int non_leaf);
 static int check_purpose_crl_sign(const X509_PURPOSE *xp, const X509 *x,
-                                  int require_ca);
+                                  int non_leaf);
 static int check_purpose_timestamp_sign(const X509_PURPOSE *xp, const X509 *x,
-                                        int require_ca);
+                                        int non_leaf);
 static int check_purpose_code_sign(const X509_PURPOSE *xp, const X509 *x,
-                                        int require_ca);
+                                        int non_leaf);
 static int no_check_purpose(const X509_PURPOSE *xp, const X509 *x,
-                            int require_ca);
+                            int non_leaf);
 static int check_purpose_ocsp_helper(const X509_PURPOSE *xp, const X509 *x,
-                                     int require_ca);
+                                     int non_leaf);
 
 static int xp_cmp(const X509_PURPOSE *const *a, const X509_PURPOSE *const *b);
 static void xptable_free(X509_PURPOSE *p);
@@ -83,7 +83,7 @@ static int xp_cmp(const X509_PURPOSE *const *a, const X509_PURPOSE *const *b)
  * If id == -1 it just calls x509v3_cache_extensions() for its side-effect.
  * Returns 1 on success, 0 if x does not allow purpose, -1 on (internal) error.
  */
-int X509_check_purpose(X509 *x, int id, int require_ca)
+int X509_check_purpose(X509 *x, int id, int non_leaf)
 {
     int idx;
     const X509_PURPOSE *pt;
@@ -97,7 +97,7 @@ int X509_check_purpose(X509 *x, int id, int require_ca)
     if (idx == -1)
         return -1;
     pt = X509_PURPOSE_get0(idx);
-    return pt->check_purpose(pt, x, require_ca);
+    return pt->check_purpose(pt, x, non_leaf);
 }
 
 int X509_PURPOSE_set(int *p, int purpose)
@@ -714,11 +714,11 @@ static int check_ssl_ca(const X509 *x)
 }
 
 static int check_purpose_ssl_client(const X509_PURPOSE *xp, const X509 *x,
-                                    int require_ca)
+                                    int non_leaf)
 {
     if (xku_reject(x, XKU_SSL_CLIENT))
         return 0;
-    if (require_ca)
+    if (non_leaf)
         return check_ssl_ca(x);
     /* We need to do digital signatures or key agreement */
     if (ku_reject(x, KU_DIGITAL_SIGNATURE | KU_KEY_AGREEMENT))
@@ -738,11 +738,11 @@ static int check_purpose_ssl_client(const X509_PURPOSE *xp, const X509 *x,
     KU_DIGITAL_SIGNATURE | KU_KEY_ENCIPHERMENT | KU_KEY_AGREEMENT
 
 static int check_purpose_ssl_server(const X509_PURPOSE *xp, const X509 *x,
-                                    int require_ca)
+                                    int non_leaf)
 {
     if (xku_reject(x, XKU_SSL_SERVER | XKU_SGC))
         return 0;
-    if (require_ca)
+    if (non_leaf)
         return check_ssl_ca(x);
 
     if (ns_reject(x, NS_SSL_SERVER))
@@ -755,22 +755,22 @@ static int check_purpose_ssl_server(const X509_PURPOSE *xp, const X509 *x,
 }
 
 static int check_purpose_ns_ssl_server(const X509_PURPOSE *xp, const X509 *x,
-                                       int require_ca)
+                                       int non_leaf)
 {
-    int ret = check_purpose_ssl_server(xp, x, require_ca);
+    int ret = check_purpose_ssl_server(xp, x, non_leaf);
 
-    if (!ret || require_ca)
+    if (!ret || non_leaf)
         return ret;
     /* We need to encipher or Netscape complains */
     return ku_reject(x, KU_KEY_ENCIPHERMENT) ? 0 : ret;
 }
 
 /* common S/MIME checks */
-static int purpose_smime(const X509 *x, int require_ca)
+static int purpose_smime(const X509 *x, int non_leaf)
 {
     if (xku_reject(x, XKU_SMIME))
         return 0;
-    if (require_ca) {
+    if (non_leaf) {
         int ca_ret = check_ca(x);
 
         if (ca_ret == 0)
@@ -791,29 +791,29 @@ static int purpose_smime(const X509 *x, int require_ca)
 }
 
 static int check_purpose_smime_sign(const X509_PURPOSE *xp, const X509 *x,
-                                    int require_ca)
+                                    int non_leaf)
 {
-    int ret = purpose_smime(x, require_ca);
+    int ret = purpose_smime(x, non_leaf);
 
-    if (!ret || require_ca)
+    if (!ret || non_leaf)
         return ret;
     return ku_reject(x, KU_DIGITAL_SIGNATURE | KU_NON_REPUDIATION) ? 0 : ret;
 }
 
 static int check_purpose_smime_encrypt(const X509_PURPOSE *xp, const X509 *x,
-                                       int require_ca)
+                                       int non_leaf)
 {
-    int ret = purpose_smime(x, require_ca);
+    int ret = purpose_smime(x, non_leaf);
 
-    if (!ret || require_ca)
+    if (!ret || non_leaf)
         return ret;
     return ku_reject(x, KU_KEY_ENCIPHERMENT) ? 0 : ret;
 }
 
 static int check_purpose_crl_sign(const X509_PURPOSE *xp, const X509 *x,
-                                  int require_ca)
+                                  int non_leaf)
 {
-    if (require_ca) {
+    if (non_leaf) {
         int ca_ret = check_ca(x);
 
         return ca_ret == 2 ? 0 : ca_ret;
@@ -826,28 +826,28 @@ static int check_purpose_crl_sign(const X509_PURPOSE *xp, const X509 *x,
  * is valid. Additional checks must be made on the chain.
  */
 static int check_purpose_ocsp_helper(const X509_PURPOSE *xp, const X509 *x,
-                                     int require_ca)
+                                     int non_leaf)
 {
     /*
      * Must be a valid CA.  Should we really support the "I don't know" value
      * (2)?
      */
-    if (require_ca)
+    if (non_leaf)
         return check_ca(x);
     /* Leaf certificate is checked in OCSP_verify() */
     return 1;
 }
 
 static int check_purpose_timestamp_sign(const X509_PURPOSE *xp, const X509 *x,
-                                        int require_ca)
+                                        int non_leaf)
 {
     int i_ext;
 
     /*
-     * If require_ca is true we must check if this is a valid CA certificate.
+     * If non_leaf is true we must check if this is a valid CA certificate.
      * The extra requirements by the CA/Browser Forum are not checked.
      */
-    if (require_ca)
+    if (non_leaf)
         return check_ca(x);
 
     /*
@@ -882,15 +882,15 @@ static int check_purpose_timestamp_sign(const X509_PURPOSE *xp, const X509 *x,
 }
 
 static int check_purpose_code_sign(const X509_PURPOSE *xp, const X509 *x,
-                                   int require_ca)
+                                   int non_leaf)
 {
     int i_ext;
 
     /*
-     * If require_ca is true we must check if this is a valid CA certificate.
+     * If non_leaf is true we must check if this is a valid CA certificate.
      * The extra requirements by the CA/Browser Forum are not checked.
      */
-    if (require_ca)
+    if (non_leaf)
         return check_ca(x);
 
     /*
@@ -936,7 +936,7 @@ static int check_purpose_code_sign(const X509_PURPOSE *xp, const X509 *x,
 }
 
 static int no_check_purpose(const X509_PURPOSE *xp, const X509 *x,
-                            int require_ca)
+                            int non_leaf)
 {
     return 1;
 }

--- a/doc/man3/X509_STORE_CTX_new.pod
+++ b/doc/man3/X509_STORE_CTX_new.pod
@@ -189,13 +189,16 @@ B<X509_PURPOSE_NS_SSL_SERVER>, B<X509_PURPOSE_SMIME_SIGN>,
 B<X509_PURPOSE_SMIME_ENCRYPT>, B<X509_PURPOSE_CRL_SIGN>, B<X509_PURPOSE_ANY>,
 B<X509_PURPOSE_OCSP_HELPER>, B<X509_PURPOSE_TIMESTAMP_SIGN> and
 B<X509_PURPOSE_CODE_SIGN>.  It is also
-possible to create a custom purpose value. Setting a purpose will ensure that
-the key usage declared within certificates in the chain being verified is
-consistent with that purpose as well as, potentially, other checks. Every
-purpose also has an associated default trust value which will also be set at the
-same time. During verification this trust setting will be verified to check it
-is consistent with the trust set by the system administrator for certificates in
-the chain.
+possible to create a custom purpose value. Setting a purpose requests that
+the key usage and extended key usage (EKU) extensions optionally declared within
+the certificate and its chain are verified to be consistent with that purpose.
+For SSL client, SSL server, and S/MIME purposes, the EKU is checked also for the
+CA certificates along the chain, including any given trust anchor certificate.
+Potentially also further checks are done (depending on the purpose given).
+Every purpose also has an associated default trust value, which will also be set
+at the same time. During verification, this trust setting will be verified
+to check whether it is consistent with the trust set by the system administrator
+for certificates in the chain.
 
 X509_STORE_CTX_set_trust() sets the trust value for the target certificate
 being verified in the I<ctx>. Built-in available values for the I<trust>

--- a/test/smime-certs/ca.cnf
+++ b/test/smime-certs/ca.cnf
@@ -18,8 +18,8 @@ default_keyfile 	= privkey.pem
 # Don't prompt for fields: use those in section directly
 prompt			= no
 distinguished_name	= req_distinguished_name
-x509_extensions	= v3_ca	# The extensions to add to the self signed cert
-string_mask = utf8only
+x509_extensions         = v3_ca # The extensions to add to the self signed cert
+string_mask             = utf8only
 
 # req_extensions = v3_req # The extensions to add to a certificate request
 
@@ -32,46 +32,39 @@ commonName			= $ENV::CN
 
 [ usr_cert ]
 
-# These extensions are added when 'ca' signs a request for an end entity
-# certificate
+# These extensions are added when 'ca' signs a request for a normal end-entity
+# certificate with key usage restrictions compatible with RSA keys
 
-basicConstraints=critical, CA:FALSE
-keyUsage=critical, nonRepudiation, digitalSignature, keyEncipherment
+basicConstraints = CA:FALSE
+keyUsage = critical, nonRepudiation, digitalSignature, keyEncipherment
 
-# PKIX recommendations harmless if included in all certificates.
-subjectKeyIdentifier=hash
-authorityKeyIdentifier=keyid
+# Following SKID and AKID settings are meanwhile by default in all certificates.
+# See doc/man5/x509v3_config.pod for details.
+
+# subjectKeyIdentifier   = hash
+# authorityKeyIdentifier = keyid, issuer
 
 [ dh_cert ]
 
-# These extensions are added when 'ca' signs a request for an end entity
-# DH certificate
+# These extensions are added when 'ca' signs a request for an end-entity
+# DH certificate, for which only key agreement makes sense
 
-basicConstraints=critical, CA:FALSE
-keyUsage=critical, keyAgreement
-
-# PKIX recommendations harmless if included in all certificates.
-subjectKeyIdentifier=hash
-authorityKeyIdentifier=keyid
+basicConstraints = CA:FALSE
+keyUsage = critical, keyAgreement
 
 [ codesign_cert ]
 
 # These extensions are added when 'ca' signs a request for a code-signing
-# end-entity certificate
+# end-entity certificate compatible with RSA and ECC keys
 
-basicConstraints=CA:FALSE
-keyUsage=critical, digitalSignature
-extendedKeyUsage=codeSigning
+basicConstraints = CA:FALSE
+keyUsage = critical, digitalSignature
+extendedKeyUsage = codeSigning
 
 [ v3_ca ]
 
+# Extensions for a typical CA as required by RFC 5280 etc.
+# SKID and AKID are by default set according to PKIX recommendation.
 
-# Extensions for a typical CA
-
-# PKIX recommendation.
-
-subjectKeyIdentifier=hash
-authorityKeyIdentifier=keyid:always
-basicConstraints = critical,CA:true
+basicConstraints = critical, CA:true
 keyUsage = critical, cRLSign, keyCertSign
-


### PR DESCRIPTION
This is a minor follow-up on #18567.

* `x509/v3_purp.c` etc.: improve doc/comments on codesign and timestamp purpose checks
* `x509/v3_purp.c`: rename `require_ca` parameters to the more adequate `non_leaf`
* `test/smime-certs/ca.cnf`: clean up comments, simplify settings using SKID and AKID defaults

