### PR TITLE
Fixes direct structure assignment in STACK_OF()

### DIFF
--- a/crypto/stack/stack.c
+++ b/crypto/stack/stack.c
@@ -51,8 +51,11 @@ OPENSSL_STACK *OPENSSL_sk_dup(const OPENSSL_STACK *sk)
         return NULL;
     }
 
-    /* direct structure assignment */
-    *ret = *sk;
+    /*
+     * Fix direct structure assignment not work, see:
+     * https://github.com/openssl/openssl/issues/19074
+     */
+    memcpy(ret, sk, sizeof(OPENSSL_STACK));
 
     if (sk->num == 0) {
         /* postpone |ret->data| allocation */
@@ -82,8 +85,11 @@ OPENSSL_STACK *OPENSSL_sk_deep_copy(const OPENSSL_STACK *sk,
         return NULL;
     }
 
-    /* direct structure assignment */
-    *ret = *sk;
+    /*
+     * Fix direct structure assignment not work, see:
+     * https://github.com/openssl/openssl/issues/19074
+     */
+    memcpy(ret, sk, sizeof(OPENSSL_STACK));
 
     if (sk->num == 0) {
         /* postpone |ret| data allocation */


### PR DESCRIPTION
direct structure assignment maybe not work in AIX
Fixes #19074

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
