### PR TITLE
Use OSSL_TIME more widely

### DIFF
--- a/crypto/bio/bss_dgram.c
+++ b/crypto/bio/bss_dgram.c
@@ -14,6 +14,7 @@
 #include <stdio.h>
 #include <errno.h>
 
+#include "internal/time.h"
 #include "bio_local.h"
 #ifndef OPENSSL_NO_DGRAM
 
@@ -149,8 +150,6 @@ static void dgram_sctp_handle_auth_free_key_event(BIO *b, union sctp_notificatio
 
 static int BIO_dgram_should_retry(int s);
 
-static void get_current_time(struct timeval *t);
-
 static const BIO_METHOD methods_dgramp = {
     BIO_TYPE_DGRAM,
     "datagram socket",
@@ -193,8 +192,8 @@ typedef struct bio_dgram_data_st {
     unsigned int connected;
     unsigned int _errno;
     unsigned int mtu;
-    struct timeval next_timeout;
-    struct timeval socket_timeout;
+    OSSL_TIME next_timeout;
+    OSSL_TIME socket_timeout;
     unsigned int peekmode;
     char local_addr_enabled;
 } bio_dgram_data;
@@ -283,70 +282,55 @@ static void dgram_adjust_rcv_timeout(BIO *b)
 {
 # if defined(SO_RCVTIMEO)
     bio_dgram_data *data = (bio_dgram_data *)b->ptr;
+    OSSL_TIME timeleft;
 
     /* Is a timer active? */
-    if (data->next_timeout.tv_sec > 0 || data->next_timeout.tv_usec > 0) {
-        struct timeval timenow, timeleft;
-
+    if (!ossl_time_is_zero(data->next_timeout)) {
         /* Read current socket timeout */
 #  ifdef OPENSSL_SYS_WINDOWS
         int timeout;
-
         int sz = sizeof(timeout);
+
         if (getsockopt(b->num, SOL_SOCKET, SO_RCVTIMEO,
                        (void *)&timeout, &sz) < 0) {
             ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
                            "calling getsockopt()");
         } else {
-            data->socket_timeout.tv_sec = timeout / 1000;
-            data->socket_timeout.tv_usec = (timeout % 1000) * 1000;
+            data->socket_timeout = ossl_ms2time(timeout);
         }
 #  else
-        socklen_t sz = sizeof(data->socket_timeout);
-        if (getsockopt(b->num, SOL_SOCKET, SO_RCVTIMEO,
-                       &(data->socket_timeout), &sz) < 0)
+        struct timeval tv;
+        socklen_t sz = sizeof(tv);
+
+        if (getsockopt(b->num, SOL_SOCKET, SO_RCVTIMEO, &tv, &sz) < 0) {
             ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
                            "calling getsockopt()");
-        else
-            OPENSSL_assert(sz <= sizeof(data->socket_timeout));
+        } else {
+            data->socket_timeout = ossl_time_from_timeval(tv);
+        }
 #  endif
 
-        /* Get current time */
-        get_current_time(&timenow);
-
         /* Calculate time left until timer expires */
-        memcpy(&timeleft, &(data->next_timeout), sizeof(struct timeval));
-        if (timeleft.tv_usec < timenow.tv_usec) {
-            timeleft.tv_usec = 1000000 - timenow.tv_usec + timeleft.tv_usec;
-            timeleft.tv_sec--;
-        } else {
-            timeleft.tv_usec -= timenow.tv_usec;
-        }
-        if (timeleft.tv_sec < timenow.tv_sec) {
-            timeleft.tv_sec = 0;
-            timeleft.tv_usec = 1;
-        } else {
-            timeleft.tv_sec -= timenow.tv_sec;
-        }
+        timeleft = ossl_time_subtract(data->next_timeout, ossl_time_now());
+        if (ossl_time_compare(timeleft, ossl_ticks2time(OSSL_TIME_US)) < 0)
+            timeleft = ossl_ticks2time(OSSL_TIME_US);
 
         /*
          * Adjust socket timeout if next handshake message timer will expire
          * earlier.
          */
-        if ((data->socket_timeout.tv_sec == 0
-             && data->socket_timeout.tv_usec == 0)
-            || (data->socket_timeout.tv_sec > timeleft.tv_sec)
-            || (data->socket_timeout.tv_sec == timeleft.tv_sec
-                && data->socket_timeout.tv_usec >= timeleft.tv_usec)) {
+        if (ossl_time_is_zero(data->socket_timeout)
+            || ossl_time_compare(data->socket_timeout, timeleft) >= 0) {
 #  ifdef OPENSSL_SYS_WINDOWS
-            timeout = timeleft.tv_sec * 1000 + timeleft.tv_usec / 1000;
+            timeout = (int)ossl_time2ms(timeleft);
             if (setsockopt(b->num, SOL_SOCKET, SO_RCVTIMEO,
                            (void *)&timeout, sizeof(timeout)) < 0)
                 ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
                                "calling setsockopt()");
 #  else
-            if (setsockopt(b->num, SOL_SOCKET, SO_RCVTIMEO, &timeleft,
-                           sizeof(struct timeval)) < 0)
+            tv = ossl_time_to_timeval(timeleft);
+            if (setsockopt(b->num, SOL_SOCKET, SO_RCVTIMEO, &tv,
+                           sizeof(tv)) < 0)
                 ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
                                "calling setsockopt()");
 #  endif
@@ -382,17 +366,18 @@ static void dgram_reset_rcv_timeout(BIO *b)
     bio_dgram_data *data = (bio_dgram_data *)b->ptr;
 
     /* Is a timer active? */
-    if (data->next_timeout.tv_sec > 0 || data->next_timeout.tv_usec > 0) {
+    if (!ossl_time_is_zero(data->next_timeout)) {
 #  ifdef OPENSSL_SYS_WINDOWS
-        int timeout = data->socket_timeout.tv_sec * 1000 +
-            data->socket_timeout.tv_usec / 1000;
+        int timeout = (int)ossl_time2ms(data->socket_timeout);
+
         if (setsockopt(b->num, SOL_SOCKET, SO_RCVTIMEO,
                        (void *)&timeout, sizeof(timeout)) < 0)
             ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
                            "calling setsockopt()");
 #  else
-        if (setsockopt(b->num, SOL_SOCKET, SO_RCVTIMEO,
-                       &(data->socket_timeout), sizeof(struct timeval)) < 0)
+        struct timeval tv = ossl_time_to_timeval(data->socket_timeout);
+
+        if (setsockopt(b->num, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv)) < 0)
             ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
                            "calling setsockopt()");
 #  endif
@@ -737,7 +722,7 @@ static long dgram_ctrl(BIO *b, int cmd, long num, void *ptr)
         BIO_ADDR_make(&data->peer, BIO_ADDR_sockaddr((BIO_ADDR *)ptr));
         break;
     case BIO_CTRL_DGRAM_SET_NEXT_TIMEOUT:
-        memcpy(&(data->next_timeout), ptr, sizeof(struct timeval));
+        data->next_timeout = ossl_time_from_timeval(*(struct timeval *)ptr);
         break;
 # if defined(SO_RCVTIMEO)
     case BIO_CTRL_DGRAM_SET_RECV_TIMEOUT:
@@ -745,6 +730,7 @@ static long dgram_ctrl(BIO *b, int cmd, long num, void *ptr)
         {
             struct timeval *tv = (struct timeval *)ptr;
             int timeout = tv->tv_sec * 1000 + tv->tv_usec / 1000;
+
             if ((ret = setsockopt(b->num, SOL_SOCKET, SO_RCVTIMEO,
                                   (void *)&timeout, sizeof(timeout))) < 0)
                 ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
@@ -2792,31 +2778,6 @@ int BIO_dgram_non_fatal_error(int err)
         break;
     }
     return 0;
-}
-
-static void get_current_time(struct timeval *t)
-{
-# if defined(_WIN32)
-    SYSTEMTIME st;
-    unsigned __int64 now_ul;
-    FILETIME now_ft;
-
-    GetSystemTime(&st);
-    SystemTimeToFileTime(&st, &now_ft);
-    now_ul = ((unsigned __int64)now_ft.dwHighDateTime << 32) | now_ft.dwLowDateTime;
-#  ifdef  __MINGW32__
-    now_ul -= 116444736000000000ULL;
-#  else
-    now_ul -= 116444736000000000UI64; /* re-bias to 1/1/1970 */
-#  endif
-    t->tv_sec = (long)(now_ul / 10000000);
-    t->tv_usec = ((int)(now_ul % 10000000)) / 10;
-# else
-    if (gettimeofday(t, NULL) < 0)
-        ERR_raise_data(ERR_LIB_SYS, errno,
-                       "calling gettimeofday");
-
-# endif
 }
 
 #endif

--- a/crypto/bio/bss_dgram.c
+++ b/crypto/bio/bss_dgram.c
@@ -292,22 +292,20 @@ static void dgram_adjust_rcv_timeout(BIO *b)
         int sz = sizeof(timeout);
 
         if (getsockopt(b->num, SOL_SOCKET, SO_RCVTIMEO,
-                       (void *)&timeout, &sz) < 0) {
+                       (void *)&timeout, &sz) < 0)
             ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
                            "calling getsockopt()");
-        } else {
+        else
             data->socket_timeout = ossl_ms2time(timeout);
-        }
 #  else
         struct timeval tv;
         socklen_t sz = sizeof(tv);
 
-        if (getsockopt(b->num, SOL_SOCKET, SO_RCVTIMEO, &tv, &sz) < 0) {
+        if (getsockopt(b->num, SOL_SOCKET, SO_RCVTIMEO, &tv, &sz) < 0)
             ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
                            "calling getsockopt()");
-        } else {
+        else
             data->socket_timeout = ossl_time_from_timeval(tv);
-        }
 #  endif
 
         /* Calculate time left until timer expires */

--- a/crypto/build.info
+++ b/crypto/build.info
@@ -99,7 +99,7 @@ $UTIL_COMMON=\
         threads_pthread.c threads_win.c threads_none.c initthread.c \
         context.c sparse_array.c asn1_dsa.c packet.c param_build.c \
         param_build_set.c der_writer.c threads_lib.c params_dup.c \
-        quic_vlint.c
+        quic_vlint.c time.c
 
 SOURCE[../libssl]=sparse_array.c
 

--- a/crypto/ct/ct_policy.c
+++ b/crypto/ct/ct_policy.c
@@ -13,7 +13,7 @@
 
 #include <openssl/ct.h>
 #include <openssl/err.h>
-#include <time.h>
+#include "internal/time.h"
 
 #include "ct_local.h"
 
@@ -29,6 +29,7 @@ CT_POLICY_EVAL_CTX *CT_POLICY_EVAL_CTX_new_ex(OSSL_LIB_CTX *libctx,
                                               const char *propq)
 {
     CT_POLICY_EVAL_CTX *ctx = OPENSSL_zalloc(sizeof(CT_POLICY_EVAL_CTX));
+    OSSL_TIME now;
 
     if (ctx == NULL) {
         ERR_raise(ERR_LIB_CT, ERR_R_MALLOC_FAILURE);
@@ -45,9 +46,9 @@ CT_POLICY_EVAL_CTX *CT_POLICY_EVAL_CTX_new_ex(OSSL_LIB_CTX *libctx,
         }
     }
 
-    /* time(NULL) shouldn't ever fail, so don't bother checking for -1. */
-    ctx->epoch_time_in_ms = (uint64_t)(time(NULL) + SCT_CLOCK_DRIFT_TOLERANCE) *
-            1000;
+    now = ossl_time_add(ossl_time_now(),
+                        ossl_seconds2time(SCT_CLOCK_DRIFT_TOLERANCE));
+    ctx->epoch_time_in_ms = ossl_time2ms(now);
 
     return ctx;
 }

--- a/crypto/time.c
+++ b/crypto/time.c
@@ -31,7 +31,7 @@ OSSL_TIME ossl_time_now(void)
     now.ul -= 116444736000000000UI64;
 # endif
     r.t = ((uint64_t)now.ul) * (OSSL_TIME_SECOND / 10000000);
-#else
+#else   /* defined(_WIN32) */
     struct timeval t;
 
     if (gettimeofday(&t, NULL) < 0) {
@@ -43,6 +43,6 @@ OSSL_TIME ossl_time_now(void)
         r.t = t.tv_usec <= 0 ? 0 : t.tv_usec * OSSL_TIME_US;
     else
         r.t = ((uint64_t)t.tv_sec * 1000000 + t.tv_usec) * OSSL_TIME_US;
-#endif
+#endif  /* defined(_WIN32) */
     return r;
 }

--- a/doc/internal/man3/OSSL_TIME.pod
+++ b/doc/internal/man3/OSSL_TIME.pod
@@ -2,11 +2,16 @@
 
 =head1 NAME
 
-OSSL_TIME, OSSL_TIME_SECOND, ossl_time_infinite, ossl_time_zero,
-ossl_ticks2time, ossl_time2ticks,
-ossl_time_now, ossl_time_time_to_timeval, ossl_time_compare,
-ossl_time_add, ossl_time_subtract, ossl_time_multiply,
-ossl_time_divide, ossl_time_abs_difference, ossl_time_max,
+OSSL_TIME, OSSL_TIME_SECOND, OSSL_TIME_MS, OSSL_TIME_US,
+ossl_time_infinite, ossl_time_zero, ossl_time_now,
+ossl_ticks2time, ossl_time2ticks, ossl_seconds2time, ossl_time2seconds,
+ossl_ms2time, ossl_us2time, ossl_time2ms, ossl_time2us,
+ossl_time_to_timeval, ossl_time_from_timeval,
+ossl_time_to_time_t, ossl_time_from_time_t,
+ossl_time_compare, ossl_time_is_zero, ossl_time_is_infinite,
+ossl_time_add, ossl_time_subtract,
+ossl_time_multiply, ossl_time_divide, ossl_time_muldiv,
+ossl_time_abs_difference, ossl_time_max,
 ossl_time_min - times and durations
 
 =head1 SYNOPSIS
@@ -16,21 +21,36 @@ ossl_time_min - times and durations
  typedef struct OSSL_TIME;
 
  #define OSSL_TIME_SECOND   /* Ticks per second */
+ #define OSSL_TIME_MS       /* Ticks per millisecond */
+ #define OSSL_TIME_US       /* Ticks per microsecond */
 
  OSSL_TIME ossl_ticks2time(uint64_t);
  uint64_t ossl_time2ticks(OSSL_TIME t);
+ OSSL_TIME ossl_seconds2time(uint64_t);
+ uint64_t ossl_time2seconds(OSSL_TIME t);
+ OSSL_TIME ossl_ms2time(uint64_t);
+ uint64_t ossl_time2ms(OSSL_TIME t);
+ OSSL_TIME ossl_us2time(uint64_t);
+ uint64_t ossl_time2us(OSSL_TIME t);
 
  OSSL_TIME ossl_time_zero(void);
  OSSL_TIME ossl_time_infinite(void);
  OSSL_TIME ossl_time_now(void);
 
- void ossl_time_time_to_timeval(OSSL_TIME t, struct timeval *out);
+ struct timeval ossl_time_to_timeval(OSSL_TIME t);
+ OSSL_TIME ossl_time_from_timeval(struct timeval tv);
+ time_t ossl_time_to_time_t(OSSL_TIME t);
+ OSSL_TIME ossl_time_from_time_t(time_t t);
 
  int ossl_time_compare(OSSL_TIME a, OSSL_TIME b);
+ int ossl_time_is_zero(OSSL_TIME t);
+ int ossl_time_is_infinite(OSSL_TIME t);
+
  OSSL_TIME ossl_time_add(OSSL_TIME a, OSSL_TIME b);
  OSSL_TIME ossl_time_subtract(OSSL_TIME a, OSSL_TIME b);
  OSSL_TIME ossl_time_multiply(OSSL_TIME a, uint64_t b);
  OSSL_TIME ossl_time_divide(OSSL_TIME a, uint64_t b);
+ OSSL_TIME ossl_time_muldiv(OSSL_TIME a, uint64_t b, uint64_t c);
  OSSL_TIME ossl_time_abs_difference(OSSL_TIME a, OSSL_TIME b);
  OSSL_TIME ossl_time_max(OSSL_TIME a, OSSL_TIME b);
  OSSL_TIME ossl_time_min(OSSL_TIME a, OSSL_TIME b);
@@ -56,6 +76,15 @@ B<ossl_ticks2time> converts an integral number of counts to a time.
 
 B<ossl_time2ticks> converts a time to an integral number of counts.
 
+B<ossl_seconds2time>, B<ossl_ms2time> and B<ossl_us2time> convert an
+integral number of seconds, milliseconds and microseconds respectively
+to a time.  These functions are implemented as macros.
+
+B<ossl_time2seconds>, B<ossl_time2ms> and B<ossl_time2us> convert a
+time to an integral number of second, milliseconds and microseconds
+respectively.  These functions truncates any fractional seconds and are
+implemented as macros.
+
 B<ossl_time_zero> returns the smallest representable B<OSSL_TIME>.
 This value represents the time Epoch and it is returned when an underflow
 would otherwise occur.
@@ -70,11 +99,21 @@ wall-clock time.  The time returned by this function is useful for
 scheduling timeouts, deadlines and recurring events, but due to its
 undefined Epoch and monotonic nature, is not suitable for other uses.
 
-B<ossl_time_time_to_timeval> converts a time to a I<struct timeval>.
+B<ossl_time_to_timeval> converts a time to a I<struct timeval>.
+
+B<ossl_time_from_timeval> converts a I<struct timeval> to a time.
+
+B<ossl_time_to_time_t> converts a time to a I<time_t>.
+
+B<ossl_time_from_time_t> converts a I<time_t> to a time.
 
 B<ossl_time_compare> compares I<a> with I<b> and returns -1 if I<a>
 is smaller than I<b>, 0 if they are equal and +1 if I<a> is
 larger than I<b>.
+
+B<ossl_time_is_zero> returns 1 if the time I<t> is zero and 0 otherwise.
+
+B<ossl_time_is_infinite> returns 1 if the time I<t> is infinite and 0 otherwise.
 
 B<ossl_time_add> performs a saturating addition of the two times,
 returning I<a> + I<b>.
@@ -85,10 +124,13 @@ returning I<a> - I<b>.
 If the difference would be negative,  B<0> is returned.
 
 B<ossl_time_multiply> performs a saturating multiplication of a time value by a
-given integer multiplier.
+given integer multiplier returning I<a> &#xD7; I<b>.
 
-B<ossl_time_divide> performs floor division of a time value by a given integer
-divisor.
+B<ossl_time_divide> performs division of a time value by a given integer
+divisor returning &#x230A;I<a> &#xF7; I<b>&#x230B;.
+
+B<ossl_time_muldiv> performs a fused multiplication and division operation.
+The result is equal to &#x230A;I<a> &#xD7; I<b> &#xF7; I<c>&#x230B;.
 
 B<ossl_time_abs_difference> returns the magnitude of the difference between two
 time values.
@@ -109,11 +151,21 @@ B<ossl_time_zero> returns the time of the Epoch.
 
 B<ossl_time_infinite> returns the last representable time.
 
-B<ossl_ticks2time> return the duration specified.
+B<ossl_ticks2time>, B<ossl_seconds2time>, B<ossl_ms2time> and B<ossl_us2time>
+return the duration specified in ticks, seconds, milliseconds and microseconds
+respectively.
 
-B<ossl_time2ticks> returns the ticks since Epoch.
+B<ossl_time2ticks>, B<ossl_time2seconds>, B<ossl_time2ms> and B<ossl_time2us>
+return the number of ticks, seconds, microseconds and microseconds respectively
+that the time object represents.
+
+B<ossl_time_to_timeval>, B<ossl_time_from_timeval>, B<ossl_time_to_time_t> and
+B<ossl_time_from_time_t> all return the converted time.
 
 B<ossl_time_compare> returns -1, 0 or 1 depending on the comparison.
+
+B<ossl_time_is_zero> and B<ossl_time_is_infinite> return 1 if the condition
+is true and 0 otherwise.
 
 B<ossl_time_add> returns the summation of the two times or
 the last representable time on overflow.
@@ -126,6 +178,9 @@ given integral multiplier, or B<OSSL_TIME_INFINITY> on overflow.
 
 B<ossl_time_divide> returns the result of dividing the given time by the given
 integral divisor.
+
+B<ossl_time_muldiv> returns the fused multiplication and division of the given
+time and the two integral values.
 
 B<ossl_time_abs_difference> returns the magnitude of the difference between the
 input time values.

--- a/include/internal/e_os.h
+++ b/include/internal/e_os.h
@@ -322,15 +322,10 @@ static ossl_inline void ossl_sleep(unsigned long millis)
 /* Fallback to a busy wait */
 static ossl_inline void ossl_sleep(unsigned long millis)
 {
-    struct timeval start, now;
-    unsigned long elapsedms;
+    const OSSL_TIME finish = ossl_time_add(ossl_time_now(), ossl_ms2time(millis));
 
-    gettimeofday(&start, NULL);
-    do {
-        gettimeofday(&now, NULL);
-        elapsedms = (((now.tv_sec - start.tv_sec) * 1000000)
-                     + now.tv_usec - start.tv_usec) / 1000;
-    } while (elapsedms < millis);
+    while (ossl_time_compare(ossl_time_now(), finish) < 0)
+        /* busy wait */ ;
 }
 #endif /* defined OPENSSL_SYS_UNIX */
 

--- a/include/internal/safe_math.h
+++ b/include/internal/safe_math.h
@@ -321,7 +321,7 @@
                                                                   int *err)  \
     {                                                                        \
         int e2 = 0;                                                          \
-        type q, r, x, y;                                                           \
+        type q, r, x, y;                                                     \
                                                                              \
         if (c == 0) {                                                        \
             *err |= 1;                                                       \

--- a/ssl/build.info
+++ b/ssl/build.info
@@ -7,7 +7,7 @@ IF[{- !$disabled{quic} -}]
 ENDIF
 
 SOURCE[../libssl]=\
-        pqueue.c time.c \
+        pqueue.c \
         statem/statem_srvr.c statem/statem_clnt.c  s3_lib.c  s3_enc.c \
         statem/statem_lib.c statem/extensions.c statem/extensions_srvr.c \
         statem/extensions_clnt.c statem/extensions_cust.c s3_msg.c \
@@ -23,7 +23,8 @@ SOURCE[../libssl]=\
 
 # For shared builds we need to include the libcrypto packet.c and quic_vlint.c
 # in libssl as well.
-SHARED_SOURCE[../libssl]=../crypto/packet.c ../crypto/quic_vlint.c
+SHARED_SOURCE[../libssl]=\
+        ../crypto/packet.c ../crypto/quic_vlint.c ../crypto/time.c
 
 IF[{- !$disabled{'deprecated-3.0'} -}]
   SOURCE[../libssl]=ssl_rsa_legacy.c

--- a/ssl/quic/quic_ackm.c
+++ b/ssl/quic/quic_ackm.c
@@ -1713,7 +1713,7 @@ int ossl_ackm_get_largest_unacked(OSSL_ACKM *ackm, int pkt_space, QUIC_PN *pn)
 /* Number of ACK-eliciting packets RX'd before we always emit an ACK. */
 #define PKTS_BEFORE_ACK     2
 /* Maximum amount of time to leave an ACK-eliciting packet un-ACK'd. */
-#define MAX_ACK_DELAY       (OSSL_TIME_MS * 25)
+#define MAX_ACK_DELAY       ossl_ms2time(25)
 
 /*
  * Return 1 if emission of an ACK frame is currently desired.
@@ -1865,13 +1865,12 @@ static void ackm_on_rx_ack_eliciting(OSSL_ACKM *ackm,
      */
     if (ossl_time_is_infinite(ackm->rx_ack_flush_deadline[pkt_space]))
         ackm_set_flush_deadline(ackm, pkt_space,
-                                ossl_time_add(rx_time,
-                                              ossl_ticks2time(MAX_ACK_DELAY)));
+                                ossl_time_add(rx_time, MAX_ACK_DELAY));
     else
         ackm_set_flush_deadline(ackm, pkt_space,
                                 ossl_time_min(ackm->rx_ack_flush_deadline[pkt_space],
                                               ossl_time_add(rx_time,
-                                                            ossl_ticks2time(MAX_ACK_DELAY))));
+                                                            MAX_ACK_DELAY)));
 }
 
 int ossl_ackm_on_rx_packet(OSSL_ACKM *ackm, const OSSL_ACKM_RX_PKT *pkt)

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -197,9 +197,9 @@ size_t ossl_quic_pending(const SSL *s)
     return 0;
 }
 
-long ossl_quic_default_timeout(void)
+OSSL_TIME ossl_quic_default_timeout(void)
 {
-    return 0;
+    return ossl_time_zero();
 }
 
 int ossl_quic_num_ciphers(void)

--- a/ssl/quic/quic_local.h
+++ b/ssl/quic/quic_local.h
@@ -103,7 +103,7 @@ __owur long ossl_quic_ctx_ctrl(SSL_CTX *ctx, int cmd, long larg, void *parg);
 __owur long ossl_quic_callback_ctrl(SSL *s, int cmd, void (*fp) (void));
 __owur long ossl_quic_ctx_callback_ctrl(SSL_CTX *ctx, int cmd, void (*fp) (void));
 __owur size_t ossl_quic_pending(const SSL *s);
-__owur long ossl_quic_default_timeout(void);
+__owur OSSL_TIME ossl_quic_default_timeout(void);
 __owur int ossl_quic_num_ciphers(void);
 __owur const SSL_CIPHER *ossl_quic_get_cipher(unsigned int u);
 int ossl_quic_renegotiate_check(SSL *ssl, int initok);

--- a/ssl/quic/quic_statm.c
+++ b/ssl/quic/quic_statm.c
@@ -50,7 +50,7 @@ void ossl_statm_update_rtt(OSSL_STATM *statm,
 }
 
 /* RFC 9002 kInitialRtt value. RFC recommended value. */
-#define K_INITIAL_RTT               (ossl_ticks2time(333 * OSSL_TIME_MS))
+#define K_INITIAL_RTT               ossl_ms2time(333)
 
 int ossl_statm_init(OSSL_STATM *statm)
 {

--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -3286,13 +3286,13 @@ const SSL3_ENC_METHOD SSLv3_enc_data = {
     ssl3_handshake_write
 };
 
-long ssl3_default_timeout(void)
+OSSL_TIME ssl3_default_timeout(void)
 {
     /*
      * 2 hours, the 24 hours mentioned in the SSLv3 spec is way too long for
      * http, the cache would over fill
      */
-    return (60 * 60 * 2);
+    return ossl_seconds2time(60 * 60 * 2);
 }
 
 int ssl3_num_ciphers(void)

--- a/ssl/ssl_asn1.c
+++ b/ssl/ssl_asn1.c
@@ -163,8 +163,8 @@ int i2d_SSL_SESSION(const SSL_SESSION *in, unsigned char **pp)
     ssl_session_oinit(&as.session_id_context, &sid_ctx,
                       in->sid_ctx, in->sid_ctx_length);
 
-    as.time = (int64_t)in->time;
-    as.timeout = (int64_t)in->timeout;
+    as.time = (int64_t)ossl_time_to_time_t(in->time);
+    as.timeout = (int64_t)ossl_time2seconds(in->timeout);
     as.verify_result = in->verify_result;
 
     as.peer = in->peer;
@@ -302,14 +302,14 @@ SSL_SESSION *d2i_SSL_SESSION(SSL_SESSION **a, const unsigned char **pp,
     ret->master_key_length = tmpl;
 
     if (as->time != 0)
-        ret->time = (time_t)as->time;
+        ret->time = ossl_time_from_time_t(as->time);
     else
-        ret->time = time(NULL);
+        ret->time = ossl_time_now();
 
     if (as->timeout != 0)
-        ret->timeout = (time_t)as->timeout;
+        ret->timeout = ossl_seconds2time(as->timeout);
     else
-        ret->timeout = 3;
+        ret->timeout = ossl_seconds2time(3);
     ssl_session_calculate_timeout(ret);
 
     X509_free(ret->peer);

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -2047,7 +2047,7 @@ int SSL_connect(SSL *s)
 
 long SSL_get_default_timeout(const SSL *s)
 {
-    return s->method->get_timeout();
+    return (long int)ossl_time2seconds(s->method->get_timeout());
 }
 
 static int ssl_async_wait_ctx_cb(void *arg)

--- a/ssl/ssl_txt.c
+++ b/ssl/ssl_txt.c
@@ -128,12 +128,14 @@ int SSL_SESSION_print(BIO *bp, const SSL_SESSION *x)
         }
     }
 #endif
-    if (x->time != 0L) {
-        if (BIO_printf(bp, "\n    Start Time: %lld", (long long)x->time) <= 0)
+    if (!ossl_time_is_zero(x->time)) {
+        if (BIO_printf(bp, "\n    Start Time: %lld",
+                       (long long)ossl_time_to_time_t(x->time)) <= 0)
             goto err;
     }
-    if (x->timeout != 0L) {
-        if (BIO_printf(bp, "\n    Timeout   : %lld (sec)", (long long)x->timeout) <= 0)
+    if (!ossl_time_is_zero(x->timeout)) {
+        if (BIO_printf(bp, "\n    Timeout   : %lld (sec)",
+                       (long long)ossl_time2seconds(x->timeout)) <= 0)
             goto err;
     }
     if (BIO_puts(bp, "\n") <= 0)

--- a/ssl/statem/extensions_clnt.c
+++ b/ssl/statem/extensions_clnt.c
@@ -1011,6 +1011,7 @@ EXT_RETURN tls_construct_ctos_psk(SSL_CONNECTION *s, WPACKET *pkt,
     const EVP_MD *handmd = NULL, *mdres = NULL, *mdpsk = NULL;
     int dores = 0;
     SSL_CTX *sctx = SSL_CONNECTION_GET_CTX(s);
+    OSSL_TIME t;
 
     s->ext.tick_identity = 0;
 
@@ -1062,7 +1063,8 @@ EXT_RETURN tls_construct_ctos_psk(SSL_CONNECTION *s, WPACKET *pkt,
          * this in multiple places in the code, so portability shouldn't be an
          * issue.
          */
-        agesec = (uint32_t)(time(NULL) - s->session->time);
+        t = ossl_time_subtract(ossl_time_now(), s->session->time);
+        agesec = (uint32_t)ossl_time2seconds(t);
         /*
          * We calculate the age in seconds but the server may work in ms. Due to
          * rounding errors we could overestimate the age by up to 1s. It is

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -2542,7 +2542,7 @@ MSG_PROCESS_RETURN tls_process_new_session_ticket(SSL_CONNECTION *s,
         s->session = new_sess;
     }
 
-    s->session->time = time(NULL);
+    s->session->time = ossl_time_now();
     ssl_session_calculate_timeout(s->session);
 
     OPENSSL_free(s->session->ext.tick);

--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -3656,7 +3656,7 @@ int tls_construct_server_certificate(SSL_CONNECTION *s, WPACKET *pkt)
 static int create_ticket_prequel(SSL_CONNECTION *s, WPACKET *pkt,
                                  uint32_t age_add, unsigned char *tick_nonce)
 {
-    uint32_t timeout = (uint32_t)s->session->timeout;
+    uint32_t timeout = (uint32_t)ossl_time2seconds(s->session->timeout);
 
     /*
      * Ticket lifetime hint:
@@ -3668,7 +3668,8 @@ static int create_ticket_prequel(SSL_CONNECTION *s, WPACKET *pkt,
 #define ONE_WEEK_SEC (7 * 24 * 60 * 60)
 
     if (SSL_CONNECTION_IS_TLS13(s)) {
-        if (s->session->timeout > ONE_WEEK_SEC)
+        if (ossl_time_compare(s->session->timeout,
+                              ossl_seconds2time(ONE_WEEK_SEC)) > 0)
             timeout = ONE_WEEK_SEC;
     } else if (s->hit)
         timeout = 0;
@@ -3978,7 +3979,7 @@ int tls_construct_new_session_ticket(SSL_CONNECTION *s, WPACKET *pkt)
         }
         s->session->master_key_length = hashlen;
 
-        s->session->time = time(NULL);
+        s->session->time = ossl_time_now();
         ssl_session_calculate_timeout(s->session);
         if (s->s3.alpn_selected != NULL) {
             OPENSSL_free(s->session->ext.alpn_selected);

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -98,13 +98,13 @@ SSL3_ENC_METHOD const TLSv1_3_enc_data = {
     ssl3_handshake_write
 };
 
-long tls1_default_timeout(void)
+OSSL_TIME tls1_default_timeout(void)
 {
     /*
      * 2 hours, the 24 hours mentioned in the TLSv1 spec is way too long for
      * http, the cache would over fill
      */
-    return (60 * 60 * 2);
+    return ossl_seconds2time(60 * 60 * 2);
 }
 
 int tls1_new(SSL *s)

--- a/ssl/time.c
+++ b/ssl/time.c
@@ -40,10 +40,9 @@ OSSL_TIME ossl_time_now(void)
         return ossl_time_zero();
     }
     if (t.tv_sec <= 0)
-        r.t = t.tv_usec <= 0 ? 0 : t.tv_usec * (OSSL_TIME_SECOND / 1000000);
+        r.t = t.tv_usec <= 0 ? 0 : t.tv_usec * OSSL_TIME_US;
     else
-        r.t = ((uint64_t)t.tv_sec * 1000000 + t.tv_usec)
-              * (OSSL_TIME_SECOND / 1000000);
+        r.t = ((uint64_t)t.tv_sec * 1000000 + t.tv_usec) * OSSL_TIME_US;
 #endif
     return r;
 }


### PR DESCRIPTION
This unifies out time handle and will help avoid 2038 problems.
Because we have some public APIs that accept time_t and struct timeval, it's impossible to completely convert.


##### Checklist

- [x] documentation is added or updated
- [ ] tests are added or updated
