### PR TITLE
Add config option to limit MDs used in signatures

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -452,6 +452,18 @@ OpenSSL 3.2
 
    *Čestmír Kalina*
 
+ * The functions `EVP_signature_md_algorithms_set()` and
+   `EVP_signature_md_algorithm_set()` and their equivalent settings
+   `signature_md_algorithms_signing` and `signature_md_algorithms_verification`
+   in the alg section allow restricting which digest algorithms are considered
+   acceptable for signature creation and signature verification. Applications
+   can use `EVP_signature_md_algorithm_allowed()` to check whether a specific
+   operation will succeed or fail. The default is to continue allowing all
+   message digests. For further details, see
+   EVP_signature_md_algorithm_allowed(3).
+
+   *Clemens Lang*
+
 OpenSSL 3.1
 -----------
 

--- a/crypto/context.c
+++ b/crypto/context.c
@@ -47,6 +47,7 @@ struct ossl_lib_ctx_st {
     void *thread_event_handler;
     void *fips_prov;
 #endif
+    void *signature_md_algorithms;
 
     unsigned int ischild:1;
 };
@@ -187,6 +188,10 @@ static int context_init(OSSL_LIB_CTX *ctx)
     if (ctx->threads == NULL)
         goto err;
 #endif
+
+    ctx->signature_md_algorithms = ossl_ctx_signature_md_algorithms_new(ctx);
+    if (ctx->signature_md_algorithms == NULL)
+        goto err;
 
     /* Low priority. */
 #ifndef FIPS_MODULE
@@ -330,6 +335,11 @@ static void context_deinit_objs(OSSL_LIB_CTX *ctx)
         ctx->threads = NULL;
     }
 #endif
+
+    if (ctx->signature_md_algorithms != NULL) {
+        ossl_ctx_signature_md_algorithms_free(ctx->signature_md_algorithms);
+        ctx->signature_md_algorithms = NULL;
+    }
 
     /* Low priority. */
 #ifndef FIPS_MODULE
@@ -626,6 +636,9 @@ void *ossl_lib_ctx_get_data(OSSL_LIB_CTX *ctx, int index)
     case OSSL_LIB_CTX_FIPS_PROV_INDEX:
         return ctx->fips_prov;
 #endif
+
+    case OSSL_LIB_CTX_SIGNATURE_MD_ALGORITHMS_INDEX:
+        return ctx->signature_md_algorithms;
 
     default:
         return NULL;

--- a/crypto/evp/evp_cnf.c
+++ b/crypto/evp/evp_cnf.c
@@ -57,6 +57,20 @@ static int alg_module_init(CONF_IMODULE *md, const CONF *cnf)
                 ERR_raise(ERR_LIB_EVP, EVP_R_SET_DEFAULT_PROPERTY_FAILURE);
                 return 0;
             }
+        } else if (strcmp(oval->name, "signature_md_algorithms_signing") == 0) {
+            if (!EVP_signature_md_algorithms_set(
+                    NCONF_get0_libctx((CONF *)cnf),
+                    EVP_SIGNATURE_MD_ALGORITHMS_SIGNING, oval->value)) {
+                ERR_raise(ERR_LIB_EVP, EVP_R_SET_DEFAULT_PROPERTY_FAILURE);
+                return 0;
+            }
+        } else if (strcmp(oval->name, "signature_md_algorithms_verification") == 0) {
+            if (!EVP_signature_md_algorithms_set(
+                    NCONF_get0_libctx((CONF *)cnf),
+                    EVP_SIGNATURE_MD_ALGORITHMS_VERIFICATION, oval->value)) {
+                ERR_raise(ERR_LIB_EVP, EVP_R_SET_DEFAULT_PROPERTY_FAILURE);
+                return 0;
+            }
         } else {
             ERR_raise_data(ERR_LIB_EVP, EVP_R_UNKNOWN_OPTION,
                            "name=%s, value=%s", oval->name, oval->value);

--- a/doc/build.info
+++ b/doc/build.info
@@ -1451,6 +1451,10 @@ DEPEND[html/man3/EVP_sha3_224.html]=man3/EVP_sha3_224.pod
 GENERATE[html/man3/EVP_sha3_224.html]=man3/EVP_sha3_224.pod
 DEPEND[man/man3/EVP_sha3_224.3]=man3/EVP_sha3_224.pod
 GENERATE[man/man3/EVP_sha3_224.3]=man3/EVP_sha3_224.pod
+DEPEND[html/man3/EVP_signature_md_algorithm_allowed.html]=man3/EVP_signature_md_algorithm_allowed.pod
+GENERATE[html/man3/EVP_signature_md_algorithm_allowed.html]=man3/EVP_signature_md_algorithm_allowed.pod
+DEPEND[man/man3/EVP_signature_md_algorithm_allowed.3]=man3/EVP_signature_md_algorithm_allowed.pod
+GENERATE[man/man3/EVP_signature_md_algorithm_allowed.3]=man3/EVP_signature_md_algorithm_allowed.pod
 DEPEND[html/man3/EVP_sm3.html]=man3/EVP_sm3.pod
 GENERATE[html/man3/EVP_sm3.html]=man3/EVP_sm3.pod
 DEPEND[man/man3/EVP_sm3.3]=man3/EVP_sm3.pod
@@ -3270,6 +3274,7 @@ html/man3/EVP_set_default_properties.html \
 html/man3/EVP_sha1.html \
 html/man3/EVP_sha224.html \
 html/man3/EVP_sha3_224.html \
+html/man3/EVP_signature_md_algorithm_allowed.html \
 html/man3/EVP_sm3.html \
 html/man3/EVP_sm4_cbc.html \
 html/man3/EVP_whirlpool.html \
@@ -3909,6 +3914,7 @@ man/man3/EVP_set_default_properties.3 \
 man/man3/EVP_sha1.3 \
 man/man3/EVP_sha224.3 \
 man/man3/EVP_sha3_224.3 \
+man/man3/EVP_signature_md_algorithm_allowed.3 \
 man/man3/EVP_sm3.3 \
 man/man3/EVP_sm4_cbc.3 \
 man/man3/EVP_whirlpool.3 \

--- a/doc/man3/EVP_signature_md_algorithm_allowed.pod
+++ b/doc/man3/EVP_signature_md_algorithm_allowed.pod
@@ -1,0 +1,141 @@
+=pod
+
+=head1 NAME
+
+EVP_signature_md_algorithm_allowed, EVP_signature_md_algorithms_get,
+EVP_signature_md_algorithm_set, EVP_signature_md_algorithms_set,
+EVP_SIGNATURE_MD_ALGORITHMS_SIGNING, EVP_SIGNATURE_MD_ALGORITHMS_VERIFICATION
+- EVP signature digest algorithm filter routines
+
+=head1 SYNOPSIS
+
+ #include <openssl/evp.h>
+
+ #define EVP_SIGNATURE_MD_ALGORITHMS_SIGNING (0)
+ #define EVP_SIGNATURE_MD_ALGORITHMS_VERIFICATION (1)
+
+ int EVP_signature_md_algorithm_allowed(OSSL_LIB_CTX *libctx, int usecase,
+                                        const EVP_MD *md, EVP_PKEY_CTX *ctx);
+ int EVP_signature_md_algorithm_set(OSSL_LIB_CTX *libctx, int usecase,
+                                    EVP_MD *md, int allow);
+ int EVP_signature_md_algorithms_set(OSSL_LIB_CTX *libctx, int usecase,
+                                     const char *value);
+ char *EVP_signature_md_algorithms_get(OSSL_LIB_CTX *libctx, int usecase);
+
+=head1 DESCRIPTION
+
+The EVP signature digest algorithm filter routines provide a way for system
+administrators and applications to configure which digest algorithms they
+consider secure enough for use in signatures.
+
+=over 4
+
+=item EVP_signature_md_algorithm_allowed()
+
+Check whether the given B<EVP_MD> is allowed.
+
+When B<ctx> is not B<NULL> and the provider associated with the B<EVP_PKEY_CTX>
+supports limiting the allowed digest algorithms, check whether this
+B<EVP_PKEY_CTX> allows the given B<md> for signature creation or signature
+verification, depending on the given B<usecase>.
+
+When B<ctx> is B<NULL> or the provider associated with a non-B<NULL>
+B<EVP_PKEY_CTX> does not support limiting the allowed digest algorithms, check
+whether the given digest algorithm is supported in the given B<OSSL_LIB_CTX>.
+
+Possible values for B<usecase> are B<EVP_SIGNATURE_MD_ALGORITHMS_SIGNING> to
+check for signing, andB<EVP_SIGNATURE_MD_ALGORITHMS_VERIFICATION> for
+verification.
+
+As a rule of thumb, pass a specific B<EVP_PKEY_CTX> if you want to check
+whether a specific operation will succeed.  Pass B<NULL> if you want to check
+what will happen in TLS and to check the system administrator's intentions.
+
+Returns a negative value on error, 0 if the given digest algorithm is not
+accepted for the given use case, and a positive value otherwise.
+
+=item EVP_signature_md_algorithm_set()
+
+Allow or disallow the given B<EVP_MD> in the given B<OSSL_LIB_CTX> for
+signature creation or verification depending on the value of B<usecase>.  Pass
+0 for B<allow> to deny use of the given digest algorithm, pass any other value
+to allow it.
+
+Libraries and applications authors should take care to not call this on the
+root B<OSSL_LIB_CTX> because doing so will modify the behavior or all other
+code running in the same address space that uses OpenSSL.  Instead, authors
+should create their own B<OSSL_LIB_CTX>.
+
+=item EVP_signature_md_algorithms_set()
+
+Replace the list of allowed digest algorithms for signature creation
+(B<EVP_SIGNATURE_MD_ALGORITHMS_SIGNING>) or signature verification
+(B<EVP_SIGNATURE_MD_ALGORITHMS_VERIFICATION>) in the given B<OSSL_LIB_CTX> with
+the given colon-separated string B<value>. See the the
+B<signature_md_algorithms_signing> option in L<config(5)> for a detailed
+description of the expected format.
+
+Libraries and applications authors should take care to not call this on the
+root B<OSSL_LIB_CTX> because doing so will modify the behavior or all other
+code running in the same address space that uses OpenSSL.  Instead, authors
+should create their own B<OSSL_LIB_CTX>.
+
+=item EVP_signature_md_algorithms_get()
+
+Get a copy of the current algorithm allow- or denylist for the use case
+specified in B<usecase>.  Returns a copy that must be freed with
+L<OPENSSL_free(3)> on success, and B<NULL> when no restrictions are set.
+
+=back
+
+=head1 RETURN VALUES
+
+=over 4
+
+=item EVP_signature_md_algorithm_allowed()
+
+Returns a negative value on error, 0 if the given digest algorithm is not
+accepted for the given use case, and a positive value otherwise.
+
+=item EVP_signature_md_algorithm_set(), EVP_signature_md_algorithms_set()
+
+Returns 1 for success or 0 for failure.
+
+=item EVP_signature_md_algorithms_get()
+
+Returns an allocated string on success, which must be freed using
+L<OPENSSL_free(3)>.  When no restrictions are set, returns B<NULL>.
+
+=back
+
+=head1 NOTES
+
+These functions are intended to provide a way for system administrators to
+indicate that they no longer consider a certain digest algorithm secure enough
+for use in signatures (for example, due to the discovery of chosen-prefix
+collision attacks).
+
+Applications and libraries should consider carefully whether overriding the
+system administrator's configuration is in the user's best interest before
+doing so.
+
+=head1 SEE ALSO
+
+L<config(5)>
+
+=head1 HISTORY
+
+The EVP_signature_md_algorithm_allowed(), EVP_signature_md_algorithm_set(),
+EVP_signature_md_algorithms_set(), and EVP_signature_md_algorithms_get()
+functions were added in OpenSSL 3.2.
+
+=head1 COPYRIGHT
+
+Copyright 2023 The OpenSSL Project Authors. All Rights Reserved.
+
+Licensed under the Apache License 2.0 (the "License").  You may not use
+this file except in compliance with the License.  You can obtain a copy
+in the file LICENSE in the source distribution or at
+L<https://www.openssl.org/source/license.html>.
+
+=cut

--- a/doc/man5/config.pod
+++ b/doc/man5/config.pod
@@ -306,6 +306,58 @@ B<yes>, this is exactly equivalent to:
 If the value is B<no>, nothing happens. Using this name is deprecated, and
 if used, it must be the only name in the section.
 
+=item B<signature_md_algorithms_signing> / B<signature_md_algorithms_verification>
+
+The value is a colon-separated list of digest algorithm names that are
+acceptable when creating or verifying signatures, respectively.
+
+If the first entry is B<ALL>, all digest algorithms are allowed by default.
+The other entries must start with B<!> and specify which diegst algorithms
+should not be allowed, i.e., the list is a deny list.
+
+If the first entry is not B<ALL>, entries are names of digest algorithms that
+should be allowed.  Algorithms that are not listed will be rejected, i.e., the
+list is an allow list.
+
+Operations that attempt to use digests that are not permitted will receive an
+"invalid digest" or "digest not allowed" error.
+
+Mixing the allow and deny styles is not supported.  The default is to allow all
+digests for both signing and verification.
+
+For example, to disable signature creation with the MD4, MD5, SHA1, MD5-SHA1,
+and SM3 algorithms but allow all other supported algorithms, set
+
+ signature_md_algorithms_signing = ALL:!MD4:!MD5:!SHA1:!MD5-SHA1:!SM3
+
+Note that this setting also affects TLS connections, in addition to the
+B<SECLEVEL> option.  Because of its use of signatures when using client
+certificates, digest algorithms must be in both the signing and verification
+allowed list to be advertised in the TLS handshake by OpenSSL.  Furthermore,
+disallowing MD5-SHA1 breaks TLS versions earlier than 1.2 and should thus be
+set together with a minimum TLS version of 1.2 or higher.
+
+Applications can check whether a digest is allowed in a L<OSSL_LIB_CTX(3)> or
+L<EVP_PKEY_CTX(3)> using L<EVP_signature_md_algorithm_allowed(3)>.
+Applications that want to modify the list of acceptable algorithms can do so
+either in a B<OSSL_LIB_CTX> or in a specific B<EVP_PKEY_CTX>.
+
+To modify the default that will be used for new signature or verification
+operations, use L<EVP_signature_md_algorithms_set(3)> to adjust the full list,
+or L<EVP_signature_md_algorithm_set(3)> to change whether a single algorithm is
+supported.  These functions modify a B<OSSL_LIB_CTX>.  Libraries should take
+care to avoid modifying the default B<OSSL_LIB_CTX>, since the effects would be
+process-wide, and instead create a new B<OSSL_LIB_CTX>.  Use this method to
+change the settings used for TLS connections.
+
+Alternatively, the list of acceptable digest algorithms for signing and
+verification can be changed by setting the
+B<OSSL_SIGNATURE_PARAM_DIGEST_ALGORITHMS_SIGNING> and
+B<OSSL_SIGNATURE_PARAM_DIGEST_ALGORITHMS_VERIFICATION> parameters in an
+B<EVP_PKEY_CTX>, either explicitly using L<EVP_PKEY_CTX_set_params(3)> or using
+a parameter that will be passed to an B<EVP_PKEY_CTX> such as the B<params>
+argument of L<EVP_DigestSignInit_ex(3)>.
+
 =back
 
 =head2 SSL Configuration

--- a/doc/man5/config.pod
+++ b/doc/man5/config.pod
@@ -338,9 +338,9 @@ disallowing MD5-SHA1 breaks TLS versions earlier than 1.2 and should thus be
 set together with a minimum TLS version of 1.2 or higher.
 
 Applications can check whether a digest is allowed in a L<OSSL_LIB_CTX(3)> or
-L<EVP_PKEY_CTX(3)> using L<EVP_signature_md_algorithm_allowed(3)>.
-Applications that want to modify the list of acceptable algorithms can do so
-either in a B<OSSL_LIB_CTX> or in a specific B<EVP_PKEY_CTX>.
+B<EVP_PKEY_CTX> using L<EVP_signature_md_algorithm_allowed(3)>.  Applications
+that want to modify the list of acceptable algorithms can do so either in
+a B<OSSL_LIB_CTX> or in a specific B<EVP_PKEY_CTX>.
 
 To modify the default that will be used for new signature or verification
 operations, use L<EVP_signature_md_algorithms_set(3)> to adjust the full list,

--- a/doc/man7/EVP_SIGNATURE-DSA.pod
+++ b/doc/man7/EVP_SIGNATURE-DSA.pod
@@ -24,6 +24,10 @@ and before calling EVP_PKEY_sign() or EVP_PKEY_verify().
 
 =item "nonce-type" (B<OSSL_SIGNATURE_PARAM_NONCE_TYPE>) <unsigned integer>
 
+=item "digest-algorithms-signing" (B<OSSL_SIGNATURE_PARAM_DIGEST_ALGORITHMS_SIGNING>) <UTF8 string>
+
+=item "digest-algorithms-verification" (B<OSSL_SIGNATURE_PARAM_DIGEST_ALGORITHMS_VERIFICATION>) <UTF8 string>
+
 The settable parameters are described in L<provider-signature(7)>.
 
 =back
@@ -38,6 +42,10 @@ EVP_PKEY_CTX_get_params().
 =item "digest" (B<OSSL_SIGNATURE_PARAM_DIGEST>) <UTF8 string>
 
 =item "nonce-type" (B<OSSL_SIGNATURE_PARAM_NONCE_TYPE>) <unsigned integer>
+
+=item "digest-algorithms-signing" (B<OSSL_SIGNATURE_PARAM_DIGEST_ALGORITHMS_SIGNING>) <UTF8 string>
+
+=item "digest-algorithms-verification" (B<OSSL_SIGNATURE_PARAM_DIGEST_ALGORITHMS_VERIFICATION>) <UTF8 string>
 
 The gettable parameters are described in L<provider-signature(7)>.
 

--- a/doc/man7/EVP_SIGNATURE-ECDSA.pod
+++ b/doc/man7/EVP_SIGNATURE-ECDSA.pod
@@ -23,6 +23,10 @@ and before calling EVP_PKEY_sign() or EVP_PKEY_verify().
 
 =item "nonce-type" (B<OSSL_SIGNATURE_PARAM_NONCE_TYPE>) <unsigned integer>
 
+=item "digest-algorithms-signing" (B<OSSL_SIGNATURE_PARAM_DIGEST_ALGORITHMS_SIGNING>) <UTF8 string>
+
+=item "digest-algorithms-verification" (B<OSSL_SIGNATURE_PARAM_DIGEST_ALGORITHMS_VERIFICATION>) <UTF8 string>
+
 These parameters are described in L<provider-signature(7)>.
 
 =back
@@ -37,6 +41,10 @@ EVP_PKEY_CTX_get_params().
 =item "digest" (B<OSSL_SIGNATURE_PARAM_DIGEST>) <UTF8 string>
 
 =item "nonce-type" (B<OSSL_SIGNATURE_PARAM_NONCE_TYPE>) <unsigned integer>
+
+=item "digest-algorithms-signing" (B<OSSL_SIGNATURE_PARAM_DIGEST_ALGORITHMS_SIGNING>) <UTF8 string>
+
+=item "digest-algorithms-verification" (B<OSSL_SIGNATURE_PARAM_DIGEST_ALGORITHMS_VERIFICATION>) <UTF8 string>
 
 The parameters are described in L<provider-signature(7)>.
 

--- a/doc/man7/EVP_SIGNATURE-RSA.pod
+++ b/doc/man7/EVP_SIGNATURE-RSA.pod
@@ -75,6 +75,12 @@ digest size when signing to comply with FIPS 186-4 section 5.5.
 
 =back
 
+=item "digest-algorithms-signing" (B<OSSL_SIGNATURE_PARAM_DIGEST_ALGORITHMS_SIGNING>) <UTF8 string>
+
+=item "digest-algorithms-verification" (B<OSSL_SIGNATURE_PARAM_DIGEST_ALGORITHMS_VERIFICATION>) <UTF8 string>
+
+This common parameter is described in L<provider-signature(7)>.
+
 =back
 
 The following signature parameters can be retrieved using
@@ -95,6 +101,12 @@ This common parameter is described in L<provider-signature(7)>.
 =item "saltlen" (B<OSSL_SIGNATURE_PARAM_PSS_SALTLEN>) <integer> or <UTF8 string>
 
 These parameters are as described above.
+
+=item "digest-algorithms-signing" (B<OSSL_SIGNATURE_PARAM_DIGEST_ALGORITHMS_SIGNING>) <UTF8 string>
+
+=item "digest-algorithms-verification" (B<OSSL_SIGNATURE_PARAM_DIGEST_ALGORITHMS_VERIFICATION>) <UTF8 string>
+
+This common parameter is described in L<provider-signature(7)>.
 
 =back
 

--- a/doc/man7/provider-signature.pod
+++ b/doc/man7/provider-signature.pod
@@ -385,6 +385,21 @@ was successful.
 Known answer tests can be performed if the random generator is overridden to
 supply known values that either pass or fail.
 
+=item "digest-algorithms-signing" (B<OSSL_SIGNATURE_PARAM_DIGEST_ALGORITHMS_SIGNING>) <UTF8 string>
+
+=item "digest-algorithms-verification" (B<OSSL_SIGNATURE_PARAM_DIGEST_ALGORITHMS_VERIFICATION>) <UTF8 string>
+
+Gets or sets a allow- or denylist of digest algorithms that are permitted in
+the signature operation.  See the documentation for the
+B<signature_md_algorithms_signing> and B<signature_md_algorithms_verification>
+options in L<config(5)> for a description of the expected format.
+
+Providers do not have to implement this parameter.  Support for this parameter
+will be indicated using the B<gettable_params> and B<settable_params>
+interfaces.
+
+See also L<EVP_signature_md_algorithm_allowed(3)>.
+
 =back
 
 OSSL_FUNC_signature_gettable_ctx_params() and OSSL_FUNC_signature_settable_ctx_params() get a

--- a/include/crypto/context.h
+++ b/include/crypto/context.h
@@ -26,6 +26,7 @@ void *ossl_fips_prov_ossl_ctx_new(OSSL_LIB_CTX *);
 #if defined(OPENSSL_THREADS)
 void *ossl_threads_ctx_new(OSSL_LIB_CTX *);
 #endif
+void *ossl_ctx_signature_md_algorithms_new(OSSL_LIB_CTX *ctx);
 
 void ossl_provider_store_free(void *);
 void ossl_property_string_data_free(void *);
@@ -45,3 +46,4 @@ void ossl_release_default_drbg_ctx(void);
 #if defined(OPENSSL_THREADS)
 void ossl_threads_ctx_free(void *);
 #endif
+void ossl_ctx_signature_md_algorithms_free(void *);

--- a/include/internal/cryptlib.h
+++ b/include/internal/cryptlib.h
@@ -118,7 +118,8 @@ typedef struct ossl_ex_data_global_st {
 # define OSSL_LIB_CTX_CHILD_PROVIDER_INDEX          18
 # define OSSL_LIB_CTX_THREAD_INDEX                  19
 # define OSSL_LIB_CTX_DECODER_CACHE_INDEX           20
-# define OSSL_LIB_CTX_MAX_INDEXES                   20
+# define OSSL_LIB_CTX_SIGNATURE_MD_ALGORITHMS_INDEX 21
+# define OSSL_LIB_CTX_MAX_INDEXES                   21
 
 OSSL_LIB_CTX *ossl_lib_ctx_get_concrete(OSSL_LIB_CTX *ctx);
 int ossl_lib_ctx_is_default(OSSL_LIB_CTX *ctx);
@@ -160,5 +161,7 @@ char *ossl_ipaddr_to_asc(unsigned char *p, int len);
 char *ossl_buf2hexstr_sep(const unsigned char *buf, long buflen, char sep);
 unsigned char *ossl_hexstr2buf_sep(const char *str, long *buflen,
                                    const char sep);
+
+int ossl_digest_in_allowlist(const EVP_MD *md, const char *digest_algorithms);
 
 #endif

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -2172,6 +2172,19 @@ OSSL_LIB_CTX *EVP_PKEY_CTX_get0_libctx(EVP_PKEY_CTX *ctx);
 const char *EVP_PKEY_CTX_get0_propq(const EVP_PKEY_CTX *ctx);
 const OSSL_PROVIDER *EVP_PKEY_CTX_get0_provider(const EVP_PKEY_CTX *ctx);
 
+
+#define EVP_SIGNATURE_MD_ALGORITHMS_SIGNING (0)
+#define EVP_SIGNATURE_MD_ALGORITHMS_VERIFICATION (1)
+
+char *EVP_signature_md_algorithms_get(OSSL_LIB_CTX *libctx, int usecase);
+int EVP_signature_md_algorithms_set(OSSL_LIB_CTX *libctx, int usecase,
+                                    const char *value);
+int EVP_signature_md_algorithm_set(OSSL_LIB_CTX *libctx, int usecase,
+                                   const EVP_MD *md, int allow);
+int EVP_signature_md_algorithm_allowed(OSSL_LIB_CTX *libctx, int usecase,
+                                       const EVP_MD *md, EVP_PKEY_CTX *ctx);
+
+
 # ifdef  __cplusplus
 }
 # endif

--- a/providers/common/include/prov/securitycheck.h
+++ b/providers/common/include/prov/securitycheck.h
@@ -17,15 +17,20 @@ int ossl_dh_check_key(OSSL_LIB_CTX *ctx, const DH *dh);
 
 int ossl_digest_is_allowed(OSSL_LIB_CTX *ctx, const EVP_MD *md);
 /* With security check enabled it can return -1 to indicate disallowed md */
-int ossl_digest_get_approved_nid_with_sha1(OSSL_LIB_CTX *ctx, const EVP_MD *md,
-                                           int sha1_allowed);
+int ossl_digest_get_approved_nid_with_securitycheck(
+        OSSL_LIB_CTX *ctx, const EVP_MD *md, const char *digest_algorithms,
+        int operation);
 
 /* Functions that are common */
 int ossl_digest_md_to_nid(const EVP_MD *md, const OSSL_ITEM *it, size_t it_len);
 int ossl_digest_get_approved_nid(const EVP_MD *md);
+int ossl_digest_securitycheck(
+        OSSL_LIB_CTX *ctx, const EVP_MD *md, const char *digest_algorithms,
+        int operation);
 
 /* Functions that have different implementations for the FIPS_MODULE */
-int ossl_digest_rsa_sign_get_md_nid(OSSL_LIB_CTX *ctx, const EVP_MD *md,
-                                    int sha1_allowed);
+int ossl_digest_rsa_sign_get_md_nid(
+        OSSL_LIB_CTX *ctx, const EVP_MD *md, const char *digest_algorithms,
+        int operation);
 int ossl_securitycheck_enabled(OSSL_LIB_CTX *libctx);
 int ossl_tls1_prf_ems_check_enabled(OSSL_LIB_CTX *libctx);

--- a/providers/common/securitycheck_default.c
+++ b/providers/common/securitycheck_default.c
@@ -13,6 +13,7 @@
 #include <openssl/core.h>
 #include <openssl/core_names.h>
 #include <openssl/obj_mac.h>
+#include <openssl/evp.h>
 #include "prov/securitycheck.h"
 #include "internal/nelem.h"
 
@@ -29,7 +30,8 @@ int ossl_tls1_prf_ems_check_enabled(OSSL_LIB_CTX *libctx)
 }
 
 int ossl_digest_rsa_sign_get_md_nid(OSSL_LIB_CTX *ctx, const EVP_MD *md,
-                                    ossl_unused int sha1_allowed)
+                                    const char *digest_algorithms,
+                                    int operation)
 {
     int mdnid;
 
@@ -42,8 +44,12 @@ int ossl_digest_rsa_sign_get_md_nid(OSSL_LIB_CTX *ctx, const EVP_MD *md,
         { NID_ripemd160, OSSL_DIGEST_NAME_RIPEMD160 },
     };
 
-    mdnid = ossl_digest_get_approved_nid_with_sha1(ctx, md, 1);
+    mdnid = ossl_digest_get_approved_nid(md);
     if (mdnid == NID_undef)
         mdnid = ossl_digest_md_to_nid(md, name_to_nid, OSSL_NELEM(name_to_nid));
+
+    if (!ossl_digest_securitycheck(ctx, md, digest_algorithms, operation))
+        return -1; /* digest not allowed */
+
     return mdnid;
 }

--- a/providers/common/securitycheck_fips.c
+++ b/providers/common/securitycheck_fips.c
@@ -35,11 +35,10 @@ int ossl_tls1_prf_ems_check_enabled(OSSL_LIB_CTX *libctx)
 }
 
 int ossl_digest_rsa_sign_get_md_nid(OSSL_LIB_CTX *ctx, const EVP_MD *md,
-                                    int sha1_allowed)
+                                    const char *digest_algorithms, int operation)
 {
-#if !defined(OPENSSL_NO_FIPS_SECURITYCHECKS)
-    if (ossl_securitycheck_enabled(ctx))
-        return ossl_digest_get_approved_nid_with_sha1(ctx, md, sha1_allowed);
-#endif /* OPENSSL_NO_FIPS_SECURITYCHECKS */
+    if (!ossl_digest_securitycheck(ctx, md, digest_algorithms, operation))
+        return -1; /* digest not allowed */
+
     return ossl_digest_get_approved_nid(md);
 }

--- a/providers/implementations/signature/ecdsa_sig.c
+++ b/providers/implementations/signature/ecdsa_sig.c
@@ -105,6 +105,9 @@ typedef struct {
 #endif
     /* If this is set then the generated k is not random */
     unsigned int nonce_type;
+
+    char *digest_algorithms_signing;
+    char *digest_algorithms_verification;
 } PROV_ECDSA_CTX;
 
 static void *ecdsa_newctx(void *provctx, const char *propq)
@@ -227,8 +230,9 @@ static int ecdsa_setup_md(PROV_ECDSA_CTX *ctx, const char *mdname,
 {
     EVP_MD *md = NULL;
     size_t mdname_len;
-    int md_nid, sha1_allowed;
+    int md_nid;
     WPACKET pkt;
+    const char *digest_algorithms = NULL;
 
     if (mdname == NULL)
         return 1;
@@ -247,9 +251,11 @@ static int ecdsa_setup_md(PROV_ECDSA_CTX *ctx, const char *mdname,
                        "%s could not be fetched", mdname);
         return 0;
     }
-    sha1_allowed = (ctx->operation != EVP_PKEY_OP_SIGN);
-    md_nid = ossl_digest_get_approved_nid_with_sha1(ctx->libctx, md,
-                                                    sha1_allowed);
+    digest_algorithms = (ctx->operation != EVP_PKEY_OP_SIGN)
+        ? ctx->digest_algorithms_verification
+        : ctx->digest_algorithms_signing;
+    md_nid = ossl_digest_get_approved_nid_with_securitycheck(
+            ctx->libctx, md, digest_algorithms, ctx->operation);
     if (md_nid < 0) {
         ERR_raise_data(ERR_LIB_PROV, PROV_R_DIGEST_NOT_ALLOWED,
                        "digest=%s", mdname);
@@ -394,6 +400,8 @@ static void ecdsa_freectx(void *vctx)
     EC_KEY_free(ctx->ec);
     BN_clear_free(ctx->kinv);
     BN_clear_free(ctx->r);
+    OPENSSL_free(ctx->digest_algorithms_signing);
+    OPENSSL_free(ctx->digest_algorithms_verification);
     OPENSSL_free(ctx);
 }
 
@@ -439,6 +447,18 @@ static void *ecdsa_dupctx(void *vctx)
             goto err;
     }
 
+    if (srcctx->digest_algorithms_signing != NULL) {
+        dstctx->digest_algorithms_signing = OPENSSL_strdup(srcctx->digest_algorithms_signing);
+        if (dstctx->digest_algorithms_signing == NULL)
+            goto err;
+    }
+
+    if (srcctx->digest_algorithms_verification != NULL) {
+        dstctx->digest_algorithms_verification = OPENSSL_strdup(srcctx->digest_algorithms_verification);
+        if (dstctx->digest_algorithms_verification == NULL)
+            goto err;
+    }
+
     return dstctx;
  err:
     ecdsa_freectx(dstctx);
@@ -471,6 +491,20 @@ static int ecdsa_get_ctx_params(void *vctx, OSSL_PARAM *params)
     if (p != NULL && !OSSL_PARAM_set_uint(p, ctx->nonce_type))
         return 0;
 
+    p = OSSL_PARAM_locate(params, OSSL_SIGNATURE_PARAM_DIGEST_ALGORITHMS_SIGNING);
+    if (p != NULL) {
+        if (ctx->digest_algorithms_signing != NULL
+                && !OSSL_PARAM_set_utf8_string(p, ctx->digest_algorithms_signing))
+            return 0;
+    }
+
+    p = OSSL_PARAM_locate(params, OSSL_SIGNATURE_PARAM_DIGEST_ALGORITHMS_VERIFICATION);
+    if (p != NULL) {
+        if (ctx->digest_algorithms_verification != NULL
+                && !OSSL_PARAM_set_utf8_string(p, ctx->digest_algorithms_verification))
+            return 0;
+    }
+
     return 1;
 }
 
@@ -479,6 +513,8 @@ static const OSSL_PARAM known_gettable_ctx_params[] = {
     OSSL_PARAM_size_t(OSSL_SIGNATURE_PARAM_DIGEST_SIZE, NULL),
     OSSL_PARAM_utf8_string(OSSL_SIGNATURE_PARAM_DIGEST, NULL, 0),
     OSSL_PARAM_uint(OSSL_SIGNATURE_PARAM_NONCE_TYPE, NULL),
+    OSSL_PARAM_utf8_string(OSSL_SIGNATURE_PARAM_DIGEST_ALGORITHMS_SIGNING, NULL, 0),
+    OSSL_PARAM_utf8_string(OSSL_SIGNATURE_PARAM_DIGEST_ALGORITHMS_VERIFICATION, NULL, 0),
     OSSL_PARAM_END
 };
 
@@ -534,6 +570,24 @@ static int ecdsa_set_ctx_params(void *vctx, const OSSL_PARAM params[])
         && !OSSL_PARAM_get_uint(p, &ctx->nonce_type))
         return 0;
 
+    p = OSSL_PARAM_locate_const(params, OSSL_SIGNATURE_PARAM_DIGEST_ALGORITHMS_SIGNING);
+    if (p != NULL) {
+        OPENSSL_free(ctx->digest_algorithms_signing);
+        ctx->digest_algorithms_signing = NULL;
+
+        if (!OSSL_PARAM_get_utf8_string(p, &ctx->digest_algorithms_signing, 0))
+            return 0;
+    }
+
+    p = OSSL_PARAM_locate_const(params, OSSL_SIGNATURE_PARAM_DIGEST_ALGORITHMS_VERIFICATION);
+    if (p != NULL) {
+        OPENSSL_free(ctx->digest_algorithms_verification);
+        ctx->digest_algorithms_verification = NULL;
+
+        if (!OSSL_PARAM_get_utf8_string(p, &ctx->digest_algorithms_verification, 0))
+            return 0;
+    }
+
     return 1;
 }
 
@@ -543,11 +597,15 @@ static const OSSL_PARAM settable_ctx_params[] = {
     OSSL_PARAM_utf8_string(OSSL_SIGNATURE_PARAM_PROPERTIES, NULL, 0),
     OSSL_PARAM_uint(OSSL_SIGNATURE_PARAM_KAT, NULL),
     OSSL_PARAM_uint(OSSL_SIGNATURE_PARAM_NONCE_TYPE, NULL),
+    OSSL_PARAM_utf8_string(OSSL_SIGNATURE_PARAM_DIGEST_ALGORITHMS_SIGNING, NULL, 0),
+    OSSL_PARAM_utf8_string(OSSL_SIGNATURE_PARAM_DIGEST_ALGORITHMS_VERIFICATION, NULL, 0),
     OSSL_PARAM_END
 };
 
 static const OSSL_PARAM settable_ctx_params_no_digest[] = {
     OSSL_PARAM_uint(OSSL_SIGNATURE_PARAM_KAT, NULL),
+    OSSL_PARAM_utf8_string(OSSL_SIGNATURE_PARAM_DIGEST_ALGORITHMS_SIGNING, NULL, 0),
+    OSSL_PARAM_utf8_string(OSSL_SIGNATURE_PARAM_DIGEST_ALGORITHMS_VERIFICATION, NULL, 0),
     OSSL_PARAM_END
 };
 

--- a/ssl/ssl_ciph.c
+++ b/ssl/ssl_ciph.c
@@ -618,7 +618,7 @@ int ssl_cipher_get_evp(SSL_CTX *ctx, const SSL_SESSION *s,
     return 0;
 }
 
-const EVP_MD *ssl_md(SSL_CTX *ctx, int idx)
+const EVP_MD *ssl_md(const SSL_CTX *ctx, int idx)
 {
     idx &= SSL_HANDSHAKE_MAC_MASK;
     if (idx < 0 || idx >= SSL_MD_NUM_IDX)

--- a/ssl/ssl_local.h
+++ b/ssl/ssl_local.h
@@ -2825,7 +2825,7 @@ __owur int tls1_save_u16(PACKET *pkt, uint16_t **pdest, size_t *pdestlen);
 __owur int tls1_save_sigalgs(SSL_CONNECTION *s, PACKET *pkt, int cert);
 __owur int tls1_process_sigalgs(SSL_CONNECTION *s);
 __owur int tls1_set_peer_legacy_sigalg(SSL_CONNECTION *s, const EVP_PKEY *pkey);
-__owur int tls1_lookup_md(SSL_CTX *ctx, const SIGALG_LOOKUP *lu,
+__owur int tls1_lookup_md(const SSL_CTX *ctx, const SIGALG_LOOKUP *lu,
                           const EVP_MD **pmd);
 __owur size_t tls12_get_psigalgs(SSL_CONNECTION *s, int sent,
                                  const uint16_t **psigs);
@@ -2838,7 +2838,7 @@ __owur int ssl_cipher_disabled(const SSL_CONNECTION *s, const SSL_CIPHER *c,
 __owur int ssl_handshake_hash(SSL_CONNECTION *s,
                               unsigned char *out, size_t outlen,
                               size_t *hashlen);
-__owur const EVP_MD *ssl_md(SSL_CTX *ctx, int idx);
+__owur const EVP_MD *ssl_md(const SSL_CTX *ctx, int idx);
 int ssl_get_md_idx(int md_nid);
 __owur const EVP_MD *ssl_handshake_md(SSL_CONNECTION *s);
 __owur const EVP_MD *ssl_prf_md(SSL_CONNECTION *s);

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -1605,7 +1605,7 @@ static const SIGALG_LOOKUP *tls1_lookup_sigalg(const SSL_CONNECTION *s,
     return NULL;
 }
 /* Lookup hash: return 0 if invalid or not enabled */
-int tls1_lookup_md(SSL_CTX *ctx, const SIGALG_LOOKUP *lu, const EVP_MD **pmd)
+int tls1_lookup_md(const SSL_CTX *ctx, const SIGALG_LOOKUP *lu, const EVP_MD **pmd)
 {
     const EVP_MD *md;
 

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -1970,6 +1970,18 @@ int tls12_check_peer_sigalg(SSL_CONNECTION *s, uint16_t sig, EVP_PKEY *pkey)
         return 0;
     }
     /*
+     * Check whether the signature algorithm's digest is OK for us. This code
+     * path is only used when verifying, so checking for the verification use
+     * case is sufficient here.
+     */
+    if (md != NULL &&
+            EVP_signature_md_algorithm_allowed(
+                SSL_CONNECTION_GET_CTX(s)->libctx,
+                EVP_SIGNATURE_MD_ALGORITHMS_VERIFICATION, md, NULL) <= 0) {
+        SSLfatal(s, SSL_AD_HANDSHAKE_FAILURE, SSL_R_WRONG_SIGNATURE_TYPE);
+        return 0;
+    }
+    /*
      * Make sure security callback allows algorithm. For historical
      * reasons we have to pass the sigalg as a two byte char array.
      */
@@ -2495,6 +2507,8 @@ static int tls12_sigalg_allowed(const SSL_CONNECTION *s, int op,
 {
     unsigned char sigalgstr[2];
     int secbits;
+    const EVP_MD *md = NULL;
+    int usecase = EVP_SIGNATURE_MD_ALGORITHMS_VERIFICATION;
 
     if (lu == NULL || !lu->enabled)
         return 0;
@@ -2510,6 +2524,27 @@ static int tls12_sigalg_allowed(const SSL_CONNECTION *s, int op,
         && (lu->sig == EVP_PKEY_DSA || lu->hash_idx == SSL_MD_SHA1_IDX
             || lu->hash_idx == SSL_MD_MD5_IDX
             || lu->hash_idx == SSL_MD_SHA224_IDX))
+        return 0;
+
+    /*
+     * Check whether the signature algorithm's digest is acceptable.
+     *
+     * When invoked with SSL_SECOP_SIGALG_MASK, SSL_SECOP_SIGALG_SUPPORTED, or
+     * SSL_SECOP_SIGALG_CHECK, the returned list is used to indicate to the
+     * peer which signature algorithms the implementation would be willing to
+     * verify, so check for that by default.
+     *
+     * When invoked with SSL_SECOP_SIGALG_SHARED, we are trying to find
+     * a signature algorithm to use to sign a message, so set the usecase to
+     * EVP_SIGNATURE_MD_ALGORITHMS_SIGNING.
+     */
+    if (op == SSL_SECOP_SIGALG_SHARED)
+        usecase = EVP_SIGNATURE_MD_ALGORITHMS_SIGNING;
+    if (!tls1_lookup_md(SSL_CONNECTION_GET_CTX(s), lu, &md))
+        return 0;
+    if (md != NULL &&
+            EVP_signature_md_algorithm_allowed(
+                SSL_CONNECTION_GET_CTX(s)->libctx, usecase, md, NULL) <= 0)
         return 0;
 
     /* See if public key algorithm allowed */

--- a/test/build.info
+++ b/test/build.info
@@ -62,7 +62,7 @@ IF[{- !$disabled{tests} -}]
           bio_readbuffer_test user_property_test pkcs7_test upcallstest \
           provfetchtest prov_config_test rand_test ca_internals_test \
           bio_tfo_test membio_test bio_dgram_test list_test fips_version_test \
-          x509_test hpke_test pairwise_fail_test nodefltctxtest
+          x509_test hpke_test pairwise_fail_test nodefltctxtest sig_md_alg_test
 
   IF[{- !$disabled{'rpk'} -}]
     PROGRAMS{noinst}=rpktest
@@ -1127,6 +1127,10 @@ ENDIF
   SOURCE[cert_comp_test]=cert_comp_test.c helpers/ssltestlib.c
   INCLUDE[cert_comp_test]=../include ../apps/include ..
   DEPEND[cert_comp_test]=../libcrypto ../libssl libtestutil.a
+
+  SOURCE[sig_md_alg_test]=sig_md_alg_test.c
+  INCLUDE[sig_md_alg_test]=../include ../apps/include ..
+  DEPEND[sig_md_alg_test]=../libcrypto libtestutil.a
 
 {-
    use File::Spec::Functions;

--- a/test/helpers/ssl_test_ctx.c
+++ b/test/helpers/ssl_test_ctx.c
@@ -366,6 +366,12 @@ IMPLEMENT_SSL_TEST_STRING_OPTION(SSL_TEST_SERVER_CONF, server, srp_password)
 IMPLEMENT_SSL_TEST_STRING_OPTION(SSL_TEST_CTX, test, expected_session_ticket_app_data)
 IMPLEMENT_SSL_TEST_STRING_OPTION(SSL_TEST_SERVER_CONF, server, session_ticket_app_data)
 
+/* Signature MD algorithms for signing and verification */
+IMPLEMENT_SSL_TEST_STRING_OPTION(SSL_TEST_CTX, test, server_signature_md_algorithms_signing)
+IMPLEMENT_SSL_TEST_STRING_OPTION(SSL_TEST_CTX, test, server_signature_md_algorithms_verification)
+IMPLEMENT_SSL_TEST_STRING_OPTION(SSL_TEST_CTX, test, client_signature_md_algorithms_signing)
+IMPLEMENT_SSL_TEST_STRING_OPTION(SSL_TEST_CTX, test, client_signature_md_algorithms_verification)
+
 /* Handshake mode */
 
 static const test_enum ssl_handshake_modes[] = {
@@ -696,6 +702,10 @@ static const ssl_test_ctx_option ssl_test_ctx_options[] = {
     { "ExpectedCipher", &parse_test_expected_cipher },
     { "ExpectedSessionTicketAppData", &parse_test_expected_session_ticket_app_data },
     { "FIPSversion", &parse_test_fips_version },
+    { "ServerSignatureMDAlgorithmsSigning", &parse_test_server_signature_md_algorithms_signing },
+    { "ServerSignatureMDAlgorithmsVerification", &parse_test_server_signature_md_algorithms_verification },
+    { "ClientSignatureMDAlgorithmsSigning", &parse_test_client_signature_md_algorithms_signing },
+    { "ClientSignatureMDAlgorithmsVerification", &parse_test_client_signature_md_algorithms_verification },
 };
 
 /* Nested client options. */
@@ -786,6 +796,10 @@ void SSL_TEST_CTX_free(SSL_TEST_CTX *ctx)
     sk_X509_NAME_pop_free(ctx->expected_client_ca_names, X509_NAME_free);
     OPENSSL_free(ctx->expected_cipher);
     OPENSSL_free(ctx->fips_version);
+    OPENSSL_free(ctx->server_signature_md_algorithms_signing);
+    OPENSSL_free(ctx->server_signature_md_algorithms_verification);
+    OPENSSL_free(ctx->client_signature_md_algorithms_signing);
+    OPENSSL_free(ctx->client_signature_md_algorithms_verification);
     OPENSSL_free(ctx);
 }
 

--- a/test/helpers/ssl_test_ctx.h
+++ b/test/helpers/ssl_test_ctx.h
@@ -229,6 +229,11 @@ typedef struct {
     char *expected_cipher;
     /* Expected Session Ticket Application Data */
     char *expected_session_ticket_app_data;
+    /* allowed signature digest algorithms */
+    char *server_signature_md_algorithms_signing;
+    char *server_signature_md_algorithms_verification;
+    char *client_signature_md_algorithms_signing;
+    char *client_signature_md_algorithms_verification;
 
     OSSL_LIB_CTX *libctx;
 

--- a/test/recipes/30-test_sig_md_alg.t
+++ b/test/recipes/30-test_sig_md_alg.t
@@ -1,0 +1,14 @@
+#! /usr/bin/env perl
+# Copyright 2022 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+use strict;
+use warnings;
+
+use OpenSSL::Test::Simple;
+
+simple_test("test_sig_md_alg", "sig_md_alg_test", "sig_md_alg")

--- a/test/recipes/80-test_ssl_new.t
+++ b/test/recipes/80-test_ssl_new.t
@@ -42,7 +42,7 @@ if (defined $ENV{SSL_TESTS}) {
     @conf_srcs = glob(srctop_file("test", "ssl-tests", "*.cnf.in"));
     # We hard-code the number of tests to double-check that the globbing above
     # finds all files as expected.
-    plan tests => 31;
+    plan tests => 32;
 }
 map { s/;.*// } @conf_srcs if $^O eq "VMS";
 my @conf_files = map { basename($_, ".in") } @conf_srcs;
@@ -94,6 +94,7 @@ my %conf_dependent_tests = (
   "28-seclevel.cnf" => disabled("tls1_2") || $no_ecx,
   "30-extended-master-secret.cnf" => disabled("tls1_2"),
   "32-compressed-certificate.cnf" => disabled("comp") || disabled("tls1_3"),
+  "33-signature-md-algorithms.cnf" => disabled("tls1_1") || disabled("ecdh"),
 );
 
 # Add your test here if it should be skipped for some compile-time
@@ -129,6 +130,7 @@ my %skip = (
   "26-tls13_client_auth.cnf" => disabled("tls1_3") || ($no_ec && $no_dh),
   "29-dtls-sctp-label-bug.cnf" => disabled("sctp") || disabled("sock"),
   "32-compressed-certificate.cnf" => disabled("comp") || disabled("tls1_3"),
+  "33-signature-md-algorithms.cnf" => $no_tls || ($no_dh && disabled("ecdh")),
 );
 
 foreach my $conf (@conf_files) {

--- a/test/sig_md_alg_test.c
+++ b/test/sig_md_alg_test.c
@@ -1,0 +1,619 @@
+/*
+ * Copyright 2022 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <string.h>
+#include <openssl/core_names.h>
+#include <openssl/evp.h>
+#include <openssl/param_build.h>
+#include <openssl/params.h>
+#include "testutil.h"
+
+typedef struct {
+    int success;
+    EVP_PKEY *pkey;
+    OSSL_LIB_CTX *libctx_no_signing;
+    OSSL_LIB_CTX *libctx_no_verification;
+} signature_md_algs_test_t;
+
+typedef struct {
+    EVP_MD *md;
+    EVP_PKEY *pkey;
+    OSSL_LIB_CTX *libctx_no_signing;
+    OSSL_LIB_CTX *libctx_no_verification;
+    char *conf_str;
+    int success;
+} signature_md_alg_test_t;
+
+static void test_signature_md_alg_name(const char *name,
+                                       signature_md_alg_test_t *test)
+{
+    EVP_MD *md = NULL;
+    EVP_PKEY_CTX *pkey_ctx = NULL;
+    EVP_PKEY *pkey = NULL;
+    EVP_MD_CTX *md_ctx = NULL;
+    BN_CTX *bn_ctx = NULL;
+    OSSL_PARAM params[3];
+    OSSL_PARAM params_no_signing[4];
+    OSSL_PARAM params_no_verification[4];
+    const char *canonical_name = NULL;
+    char *namebuf = NULL;
+    unsigned char *sig = NULL;
+    size_t siglen;
+    const char *tbs = "Hello, World!";
+    size_t tbslen = strlen(tbs);
+
+    md = EVP_MD_fetch(OSSL_LIB_CTX_get0_global_default(), name, NULL);
+    if (md == NULL)
+        goto err;
+    canonical_name = EVP_MD_get0_name(md);
+
+    TEST_info("Testing digest '%s' with its alias '%s'", canonical_name, name);
+
+    /* When explicitly disabled, EVP_signature_md_algorithm_allowed should say
+     * so */
+    if (!TEST_int_ne(1,
+                     EVP_signature_md_algorithm_allowed(
+                         test->libctx_no_signing,
+                         EVP_SIGNATURE_MD_ALGORITHMS_SIGNING,
+                         md, NULL)))
+        goto err;
+    if (!TEST_int_ne(1,
+                     EVP_signature_md_algorithm_allowed(
+                         test->libctx_no_verification,
+                         EVP_SIGNATURE_MD_ALGORITHMS_VERIFICATION,
+                         md, NULL)))
+        goto err;
+
+    /* When not explicitly disabled, EVP_signature_md_algorithm_allowed should
+     * return 1 */
+    if (!TEST_int_gt(EVP_signature_md_algorithm_allowed(
+                        test->libctx_no_signing,
+                        EVP_SIGNATURE_MD_ALGORITHMS_VERIFICATION,
+                        md, NULL),
+                     0))
+        goto err;
+    if (!TEST_int_gt(EVP_signature_md_algorithm_allowed(
+                        test->libctx_no_verification,
+                        EVP_SIGNATURE_MD_ALGORITHMS_SIGNING,
+                        md, NULL),
+                     0))
+        goto err;
+
+    /* In the default libctx, EVP_signature_md_algorithm_allowed should always
+     * return 1 */
+    if (!TEST_int_gt(EVP_signature_md_algorithm_allowed(
+                        OSSL_LIB_CTX_get0_global_default(),
+                        EVP_SIGNATURE_MD_ALGORITHMS_SIGNING,
+                        md, NULL),
+                     0))
+        goto err;
+    if (!TEST_int_gt(EVP_signature_md_algorithm_allowed(
+                        OSSL_LIB_CTX_get0_global_default(),
+                        EVP_SIGNATURE_MD_ALGORITHMS_VERIFICATION,
+                        md, NULL),
+                     0))
+        goto err;
+
+    /* RSA PSS only supports SHA1, SHA224, SHA256, SHA384, SHA512, MD5,
+     * MD5_SHA1, MD2, MD4, MDC2, SHA3-224, SHA3-256, SHA3-384, SHA3-512.
+     *
+     * Specifically SHA2-256/192 is also not supported. */
+    if (strstr(canonical_name, "SHAKE") != NULL
+            || strstr(canonical_name, "SM3") != NULL
+            || strstr(canonical_name, "NULL") != NULL
+            || strstr(canonical_name, "KECCAK") != NULL
+            || strstr(canonical_name, "BLAKE") != NULL
+            || strcmp(canonical_name, OSSL_DIGEST_NAME_SHA2_256_192) == 0)
+        goto out;
+
+    if (!TEST_ptr(namebuf = OPENSSL_strdup(name)))
+        goto err;
+    params[0] = OSSL_PARAM_construct_utf8_string(
+            OSSL_SIGNATURE_PARAM_PAD_MODE, "pss", 0);
+    params[1] = OSSL_PARAM_construct_utf8_string(
+            OSSL_SIGNATURE_PARAM_DIGEST, namebuf, 0);
+    params[2] = OSSL_PARAM_construct_end();
+
+    /* Copy these params, but add a local deny for signing */
+    params_no_signing[0] = params[0];
+    params_no_signing[1] = params[1];
+    params_no_signing[2] = OSSL_PARAM_construct_utf8_string(
+            OSSL_SIGNATURE_PARAM_DIGEST_ALGORITHMS_SIGNING,
+            test->conf_str, 0);
+    params_no_signing[3] = params[2];
+
+    /* Copy these params, but add a local deny for verification */
+    params_no_verification[0] = params[0];
+    params_no_verification[1] = params[1];
+    params_no_verification[2] = OSSL_PARAM_construct_utf8_string(
+            OSSL_SIGNATURE_PARAM_DIGEST_ALGORITHMS_VERIFICATION,
+            test->conf_str, 0);
+    params_no_verification[3] = params[2];
+
+    if (!TEST_ptr(bn_ctx = BN_CTX_new()))
+        goto err;
+
+    /* Generate a valid signature in the default library context */
+    TEST_info(" - %s (%s) signature in default library context",
+              canonical_name, name);
+    if (!TEST_ptr(md_ctx = EVP_MD_CTX_new()))
+        goto err;
+    if (!TEST_true(EVP_DigestSignInit_ex(md_ctx, &pkey_ctx, name,
+                                         OSSL_LIB_CTX_get0_global_default(),
+                                         NULL, test->pkey, params)))
+        goto err;
+    if (!TEST_true(EVP_DigestSign(md_ctx, NULL, &siglen,
+                                  (const unsigned char *)tbs, tbslen)))
+        goto err;
+    if (!TEST_ptr(sig = OPENSSL_malloc(siglen)))
+        goto err;
+    if (!TEST_true(EVP_DigestSign(md_ctx, sig, &siglen,
+                                  (const unsigned char *)tbs, tbslen)))
+        goto err;
+    EVP_MD_CTX_reset(md_ctx);
+    pkey_ctx = NULL;
+
+    /* Validate the signature in the default library context */
+    TEST_info(" - %s (%s) validation in default library context",
+              canonical_name, name);
+    if (!TEST_true(EVP_DigestVerifyInit_ex(md_ctx, &pkey_ctx, name,
+                                           OSSL_LIB_CTX_get0_global_default(),
+                                           NULL, test->pkey, params)))
+        goto err;
+    if (!TEST_true(EVP_DigestVerify(md_ctx, sig, siglen,
+                                    (const unsigned char *)tbs, tbslen)))
+        goto err;
+    EVP_MD_CTX_reset(md_ctx);
+    pkey_ctx = NULL;
+
+    /* Attempt to validate the signature in a library context where this digest
+     * cannot be verified, this should fail.
+     *
+     * Also check that EVP_signature_md_algorithm_allowed() returns the correct
+     * values when invoked with the EVP_PKEY_CTX. */
+    TEST_info(" - %s (%s) validation failure when disallowed",
+              canonical_name, name);
+    if (!TEST_false(EVP_DigestVerifyInit_ex(md_ctx, &pkey_ctx, name,
+                                            test->libctx_no_verification, NULL,
+                                            test->pkey, params)))
+        goto err;
+    if (!TEST_int_gt(EVP_signature_md_algorithm_allowed(
+                         OSSL_LIB_CTX_get0_global_default(),
+                         EVP_SIGNATURE_MD_ALGORITHMS_SIGNING,
+                         md, pkey_ctx),
+                     0))
+        goto err;
+    if (!TEST_int_ne(1,
+                     EVP_signature_md_algorithm_allowed(
+                         OSSL_LIB_CTX_get0_global_default(),
+                         EVP_SIGNATURE_MD_ALGORITHMS_VERIFICATION,
+                         md, pkey_ctx)))
+        goto err;
+    EVP_MD_CTX_reset(md_ctx);
+    pkey_ctx = NULL;
+
+    /* Attempt to validate the signature with a EVP_MD_CTX where this digest
+     * cannot be verified; this should fail.
+     *
+     * Also check that EVP_signature_md_algorithm_allowed() returns the correct
+     * values when invoked with the EVP_PKEY_CTX. */
+    TEST_info(" - %s (%s) validation failure when disallowed in EVP_MD_CTX",
+              canonical_name, name);
+    if (!TEST_false(EVP_DigestVerifyInit_ex(md_ctx, &pkey_ctx, name,
+                                            OSSL_LIB_CTX_get0_global_default(),
+                                            NULL, test->pkey, params_no_verification)))
+        goto err;
+    if (!TEST_int_gt(EVP_signature_md_algorithm_allowed(
+                         OSSL_LIB_CTX_get0_global_default(),
+                         EVP_SIGNATURE_MD_ALGORITHMS_SIGNING,
+                         md, pkey_ctx),
+                     0))
+        goto err;
+    if (!TEST_int_ne(1,
+                     EVP_signature_md_algorithm_allowed(
+                         OSSL_LIB_CTX_get0_global_default(),
+                         EVP_SIGNATURE_MD_ALGORITHMS_VERIFICATION,
+                         md, pkey_ctx)))
+        goto err;
+    EVP_MD_CTX_reset(md_ctx);
+    pkey_ctx = NULL;
+
+    /* Attempt to re-create the signature in a library context where this
+     * digest cannot be signed, this should fail.
+     *
+     * Also check that EVP_signature_md_algorithm_allowed() returns the correct
+     * values when invoked with the EVP_PKEY_CTX. */
+    TEST_info(" - %s (%s) signature failure when disallowed",
+              canonical_name, name);
+    if (!TEST_false(EVP_DigestSignInit_ex(md_ctx, &pkey_ctx, name,
+                                          test->libctx_no_signing, NULL,
+                                          test->pkey, params)))
+        goto err;
+    if (!TEST_int_ne(1,
+                     EVP_signature_md_algorithm_allowed(
+                         OSSL_LIB_CTX_get0_global_default(),
+                         EVP_SIGNATURE_MD_ALGORITHMS_SIGNING,
+                         md, pkey_ctx)))
+        goto err;
+    if (!TEST_int_gt(EVP_signature_md_algorithm_allowed(
+                         OSSL_LIB_CTX_get0_global_default(),
+                         EVP_SIGNATURE_MD_ALGORITHMS_VERIFICATION,
+                         md, pkey_ctx),
+                     0))
+        goto err;
+    ERR_clear_error();
+    EVP_MD_CTX_reset(md_ctx);
+    pkey_ctx = NULL;
+
+    /* Attempt to re-create the signature with a EVP_MD_CTX where this digest
+     * cannot be signed, this should fail.
+     *
+     * Also check that EVP_signature_md_algorithm_allowed() returns the correct
+     * values when invoked with the EVP_PKEY_CTX. */
+    TEST_info(" - %s (%s) signature failure when disallowed in EVP_MD_CTX",
+              canonical_name, name);
+    if (!TEST_false(EVP_DigestSignInit_ex(md_ctx, &pkey_ctx, name,
+                                          OSSL_LIB_CTX_get0_global_default(),
+                                          NULL, test->pkey, params_no_signing)))
+        goto err;
+    if (!TEST_int_ne(1,
+                     EVP_signature_md_algorithm_allowed(
+                         OSSL_LIB_CTX_get0_global_default(),
+                         EVP_SIGNATURE_MD_ALGORITHMS_SIGNING,
+                         md, pkey_ctx)))
+        goto err;
+    if (!TEST_int_gt(EVP_signature_md_algorithm_allowed(
+                         OSSL_LIB_CTX_get0_global_default(),
+                         EVP_SIGNATURE_MD_ALGORITHMS_VERIFICATION,
+                         md, pkey_ctx),
+                     0))
+        goto err;
+    ERR_clear_error();
+    EVP_MD_CTX_reset(md_ctx);
+    pkey_ctx = NULL;
+
+    /* Validate the signature in a library context where this digest cannot be
+     * signed, this should still succeed. */
+    TEST_info(" - %s (%s) validation success when signature is disallowed",
+              canonical_name, name);
+    if (!TEST_true(EVP_DigestVerifyInit_ex(md_ctx, &pkey_ctx, name,
+                                           test->libctx_no_signing, NULL,
+                                           test->pkey, params)))
+        goto err;
+    if (!TEST_true(EVP_DigestVerify(md_ctx, sig, siglen,
+                                    (const unsigned char *)tbs, tbslen)))
+        goto err;
+    EVP_MD_CTX_reset(md_ctx);
+    pkey_ctx = NULL;
+
+    /* Change the configuration to allow verification and re-attempt. This
+     * should succeed. */
+    TEST_info(" - %s (%s) validation success with explicit override",
+              canonical_name, name);
+    if (!TEST_true(EVP_signature_md_algorithm_set(
+                        test->libctx_no_verification,
+                        EVP_SIGNATURE_MD_ALGORITHMS_VERIFICATION,
+                        md, 1)))
+        goto err;
+    if (!TEST_true(EVP_DigestVerifyInit_ex(md_ctx, &pkey_ctx, name,
+                                           test->libctx_no_verification, NULL,
+                                           test->pkey, params)))
+        goto err;
+    if (!TEST_true(EVP_DigestVerify(md_ctx, sig, siglen,
+                                    (const unsigned char *)tbs, tbslen)))
+        goto err;
+    if (!TEST_true(EVP_signature_md_algorithm_set(
+                        test->libctx_no_verification,
+                        EVP_SIGNATURE_MD_ALGORITHMS_VERIFICATION,
+                        md, 0)))
+        goto err;
+    EVP_MD_CTX_reset(md_ctx);
+    pkey_ctx = NULL;
+
+    /* Re-create the signature in a library context where this digest cannot be
+     * verified. This is uncommon, but technically still supported and should
+     * succeed. */
+    TEST_info(" - %s (%s) signature success when validation is disallowed",
+              canonical_name, name);
+    OPENSSL_free(sig);
+    sig = NULL;
+    if (!TEST_true(EVP_DigestSignInit_ex(md_ctx, &pkey_ctx, name,
+                                         test->libctx_no_verification, NULL,
+                                         test->pkey, params)))
+        goto err;
+    if (!TEST_true(EVP_DigestSign(md_ctx, NULL, &siglen,
+                                  (const unsigned char *)tbs, tbslen)))
+        goto err;
+    if (!TEST_ptr(sig = OPENSSL_malloc(siglen)))
+        goto err;
+    if (!TEST_true(EVP_DigestSign(md_ctx, sig, &siglen,
+                                  (const unsigned char *)tbs, tbslen)))
+        goto err;
+
+    goto out;
+err:
+    TEST_openssl_errors();
+    test->success = 0;
+out:
+    OPENSSL_free(sig);
+    OPENSSL_free(namebuf);
+    EVP_MD_CTX_free(md_ctx);
+    EVP_PKEY_free(pkey);
+    BN_CTX_free(bn_ctx);
+    EVP_MD_free(md);
+}
+
+static void test_signature_md_alg(EVP_MD *md, signature_md_algs_test_t *result)
+{
+    int called = 0;
+    char conf_str[256];
+    signature_md_alg_test_t test = {0};
+
+    test.md = md;
+    test.pkey = result->pkey;
+    test.libctx_no_signing = result->libctx_no_signing;
+    test.libctx_no_verification = result->libctx_no_verification;
+    test.conf_str = conf_str;
+    test.success = 1;
+
+    if (snprintf(conf_str, sizeof(conf_str), "ALL:!%s",
+                 EVP_MD_get0_name(md)) >= (int) sizeof(conf_str))
+        goto err;
+
+    if (!EVP_signature_md_algorithms_set(result->libctx_no_signing,
+                                         EVP_SIGNATURE_MD_ALGORITHMS_SIGNING,
+                                         conf_str))
+        goto err;
+    if (!EVP_signature_md_algorithms_set(result->libctx_no_verification,
+                                         EVP_SIGNATURE_MD_ALGORITHMS_VERIFICATION,
+                                         conf_str))
+        goto err;
+
+    called = EVP_MD_names_do_all(
+        md, (void (*)(const char *, void *)) test_signature_md_alg_name,
+        &test);
+
+    if (!called || !test.success) {
+        goto err;
+    }
+
+    goto out;
+err:
+    result->success = 0;
+out:
+    return;
+}
+
+static int test_signature_md_algs(void)
+{
+    signature_md_algs_test_t result = { 1 };
+
+    EVP_PKEY *rsa = NULL;
+#ifndef OPENSSL_NO_EC
+    EVP_PKEY *ecdsa = NULL;
+#endif /* !defined(OPENSSL_NO_EC) */
+#ifndef OPENSSL_NO_DSA
+    EVP_PKEY_CTX *dsaparams_ctx = NULL;
+    EVP_PKEY_CTX *dsa_ctx = NULL;
+    unsigned int pbits = 2048;
+    unsigned int qbits = 256;
+    OSSL_PARAM dsa_gen_params[3];
+    EVP_PKEY *dsaparams = NULL;
+    EVP_PKEY *dsa = NULL;
+
+    dsa_gen_params[0] = OSSL_PARAM_construct_uint(OSSL_PKEY_PARAM_FFC_PBITS, &pbits);
+    dsa_gen_params[1] = OSSL_PARAM_construct_uint(OSSL_PKEY_PARAM_FFC_QBITS, &qbits);
+    dsa_gen_params[2] = OSSL_PARAM_construct_end();
+#endif /* !defined(OPENSSL_NO_DSA) */
+
+    if (!TEST_ptr(result.libctx_no_signing = OSSL_LIB_CTX_new()))
+        goto err;
+    if (!TEST_ptr(result.libctx_no_verification = OSSL_LIB_CTX_new()))
+        goto err;
+
+    if (!TEST_ptr(rsa = EVP_PKEY_Q_keygen(NULL, NULL, "RSA", 1024)))
+        goto err;
+#ifndef OPENSSL_NO_EC
+    if (!TEST_ptr(ecdsa = EVP_PKEY_Q_keygen(NULL, NULL, "EC", "secp256k1")))
+        goto err;
+#endif /* !defined(OPENSSL_NO_EC) */
+#ifndef OPENSSL_NO_DSA
+    if (!TEST_ptr(dsaparams_ctx = EVP_PKEY_CTX_new_from_name(NULL, "DSA", NULL)))
+        goto err;
+    if (!TEST_true(EVP_PKEY_paramgen_init(dsaparams_ctx) > 0))
+        goto err;
+    if (!TEST_true(EVP_PKEY_CTX_set_params(dsaparams_ctx, dsa_gen_params)))
+        goto err;
+    if (!TEST_true(EVP_PKEY_generate(dsaparams_ctx, &dsaparams) > 0))
+        goto err;
+    if (!TEST_ptr(dsa_ctx = EVP_PKEY_CTX_new_from_pkey(NULL, dsaparams, NULL)))
+        goto err;
+    if (!TEST_true(EVP_PKEY_keygen_init(dsa_ctx) > 0))
+        goto err;
+    if (!TEST_true(EVP_PKEY_generate(dsa_ctx, &dsa) > 0))
+        goto err;
+#endif /* !defined(OPENSSL_NO_DSA) */
+
+    TEST_info("Testing with a 1024-bit RSA key...");
+    result.pkey = rsa;
+    EVP_MD_do_all_provided(OSSL_LIB_CTX_get0_global_default(),
+                           (void (*)(EVP_MD *, void *)) test_signature_md_alg,
+                           &result);
+
+#ifndef OPENSSL_NO_EC
+    TEST_info("Testing with a secp256k1 ECDSA key...");
+    result.pkey = ecdsa;
+    EVP_MD_do_all_provided(OSSL_LIB_CTX_get0_global_default(),
+                           (void (*)(EVP_MD *, void *)) test_signature_md_alg,
+                           &result);
+#endif /* !defined(OPENSSL_NO_EC) */
+
+#ifndef OPENSSL_NO_DSA
+    TEST_info("Testing with a DSA key...");
+    result.pkey = dsa;
+    EVP_MD_do_all_provided(OSSL_LIB_CTX_get0_global_default(),
+                           (void (*)(EVP_MD *, void *)) test_signature_md_alg,
+                           &result);
+#endif /* !defined(OPENSSL_NO_DSA) */
+
+    goto out;
+
+err:
+    result.success = 0;
+out:
+    EVP_PKEY_free(rsa);
+#ifndef OPENSSL_NO_EC
+    EVP_PKEY_free(ecdsa);
+#endif /* !defined(OPENSSL_NO_EC) */
+#ifndef OPENSSL_NO_DSA
+    EVP_PKEY_free(dsa);
+    EVP_PKEY_free(dsaparams);
+    EVP_PKEY_CTX_free(dsaparams_ctx);
+    EVP_PKEY_CTX_free(dsa_ctx);
+#endif /* !defined(OPENSSL_NO_DSA) */
+    OSSL_LIB_CTX_free(result.libctx_no_signing);
+    OSSL_LIB_CTX_free(result.libctx_no_verification);
+    return result.success;
+}
+
+typedef struct {
+    const char *what;
+    const char *policy;
+    const char *md;
+    int allowed_before;
+    int allow;
+    int allowed_after;
+    const char *expected;
+} signature_md_alg_set_test_t;
+
+static signature_md_alg_set_test_t signature_md_alg_set_tests[] = {
+    {
+        "duplicate deny entries are removed",
+        "ALL:!SHA-1:!SHA1:!MD-5",
+        "SHA1",
+        0,
+        0,
+        0,
+        "ALL:!SHA-1:!MD-5"
+    },
+    {
+        "duplicate allow entries are removed (if we modify them)",
+        "SHA1:SHA256:SHA1:SHA256:SHA3-512",
+        "SHA1",
+        1,
+        1,
+        1,
+        "SHA1:SHA256:SHA256:SHA3-512"
+    },
+    {
+        "allowing another algorithm works and uses the canonical name",
+        "SHA256:SHA512",
+        "2.16.840.1.101.3.4.2.8",
+        0,
+        1,
+        1,
+        "SHA256:SHA512:SHA3-256"
+    },
+    {
+        "denying an algorithm works and uses the canonical name",
+        "ALL",
+        "SHA-1",
+        1,
+        0,
+        0,
+        "ALL:!SHA1"
+    },
+    {
+        "a non-canonical entry in the list is recognized",
+        "ALL:!1.3.14.3.2.26",
+        "SHA-1",
+        0,
+        1,
+        1,
+        "ALL"
+    },
+    {
+        "deny entries in an allow-only list are removed",
+        "!SHA1:SHA256:SHA512:!SHA3-512",
+        "SHA3-512",
+        0,
+        1,
+        1,
+        "SHA256:SHA512:SHA3-512"
+    },
+    {
+        "allow entries in an allow-by-default list are removed",
+        "ALL:SHA256:SHA512:SHA3-256",
+        "MD5",
+        1,
+        0,
+        0,
+        "ALL:!MD5"
+    }
+};
+
+static int test_signature_md_algorithm_set(void)
+{
+    int success = 1;
+    int usecase = 0;
+    size_t idx = 0;
+    OSSL_LIB_CTX *libctx = NULL;
+    EVP_MD *md = NULL;
+    char *algorithm_list = NULL;
+
+    if (!TEST_ptr(libctx = OSSL_LIB_CTX_new()))
+        goto err;
+
+    for (idx = 0; idx < OSSL_NELEM(signature_md_alg_set_tests); ++idx) {
+        signature_md_alg_set_test_t *test = &signature_md_alg_set_tests[idx];
+
+        TEST_info("Testing that %s with policy %s", test->what, test->policy);
+
+        EVP_MD_free(md);
+        if (!TEST_ptr(md = EVP_MD_fetch(NULL, test->md, NULL)))
+            goto err;
+        for (usecase = EVP_SIGNATURE_MD_ALGORITHMS_SIGNING; usecase <= EVP_SIGNATURE_MD_ALGORITHMS_VERIFICATION; ++usecase) {
+            if (!TEST_true(EVP_signature_md_algorithms_set(libctx, usecase, test->policy)))
+                goto err;
+            if (!TEST_int_eq(test->allowed_before, EVP_signature_md_algorithm_allowed(libctx, usecase, md, NULL)))
+                goto err;
+            if (!TEST_true(EVP_signature_md_algorithm_set(libctx, usecase, md, test->allow)))
+                goto err;
+            if (!TEST_int_eq(test->allowed_after, EVP_signature_md_algorithm_allowed(libctx, usecase, md, NULL)))
+                goto err;
+
+            OPENSSL_free(algorithm_list);
+            if (!TEST_ptr(algorithm_list = EVP_signature_md_algorithms_get(libctx, usecase)))
+                goto err;
+
+            if (!TEST_str_eq(test->expected, algorithm_list))
+                goto err;
+            TEST_info("  -> policy after %s %s is %s", test->allow ? "allowing" : "denying", test->md, algorithm_list);
+        }
+    }
+
+    goto out;
+
+err:
+    success = 0;
+
+out:
+    OPENSSL_free(algorithm_list);
+    EVP_MD_free(md);
+    OSSL_LIB_CTX_free(libctx);
+
+    return success;
+}
+
+int setup_tests(void)
+{
+    ADD_TEST(test_signature_md_algs);
+    ADD_TEST(test_signature_md_algorithm_set);
+    return 1;
+}

--- a/test/ssl-tests/33-signature-md-algorithms.cnf
+++ b/test/ssl-tests/33-signature-md-algorithms.cnf
@@ -1,0 +1,232 @@
+# Generated with generate_ssl_tests.pl
+
+num_tests = 8
+
+test-0 = 0-Server Signature MD algorithm SHA384 only
+test-1 = 1-Client Signature MD algorithm SHA256 and higher only
+test-2 = 2-Signature MD algorithms affects chosen server and client sign hash
+test-3 = 3-Clients that do not sign MD5-SHA1 can connect to TLS 1.2 or newer servers with client certificates
+test-4 = 4-Clients that verify but not sign MD5-SHA1 can connect to TLS 1.1 servers
+test-5 = 5-Clients that do not sign MD5-SHA1 can not connect to TLS 1.1 servers with client certificates
+test-6 = 6-TLS 1.1 or lower fails if the client does not verify MD5-SHA1
+test-7 = 7-TLS 1.1 or lower fails if the server does not sign MD5-SHA1
+# ===========================================================
+
+[0-Server Signature MD algorithm SHA384 only]
+ssl_conf = 0-Server Signature MD algorithm SHA384 only-ssl
+
+[0-Server Signature MD algorithm SHA384 only-ssl]
+server = 0-Server Signature MD algorithm SHA384 only-server
+client = 0-Server Signature MD algorithm SHA384 only-client
+
+[0-Server Signature MD algorithm SHA384 only-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT:@SECLEVEL=0:!kRSA
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[0-Server Signature MD algorithm SHA384 only-client]
+CipherString = DEFAULT
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-0]
+ExpectedResult = Success
+ExpectedServerSignHash = SHA384
+ServerSignatureMDAlgorithmsSigning = SHA384
+
+
+# ===========================================================
+
+[1-Client Signature MD algorithm SHA256 and higher only]
+ssl_conf = 1-Client Signature MD algorithm SHA256 and higher only-ssl
+
+[1-Client Signature MD algorithm SHA256 and higher only-ssl]
+server = 1-Client Signature MD algorithm SHA256 and higher only-server
+client = 1-Client Signature MD algorithm SHA256 and higher only-client
+
+[1-Client Signature MD algorithm SHA256 and higher only-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT:@SECLEVEL=0:!kRSA
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[1-Client Signature MD algorithm SHA256 and higher only-client]
+CipherString = DEFAULT
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-1]
+ClientSignatureMDAlgorithmsVerification = SHA256:SHA384:SHA512
+ExpectedResult = Success
+ExpectedServerSignHash = SHA256
+
+
+# ===========================================================
+
+[2-Signature MD algorithms affects chosen server and client sign hash]
+ssl_conf = 2-Signature MD algorithms affects chosen server and client sign hash-ssl
+
+[2-Signature MD algorithms affects chosen server and client sign hash-ssl]
+server = 2-Signature MD algorithms affects chosen server and client sign hash-server
+client = 2-Signature MD algorithms affects chosen server and client sign hash-client
+
+[2-Signature MD algorithms affects chosen server and client sign hash-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT:@SECLEVEL=0:!kRSA
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
+VerifyMode = Require
+
+[2-Signature MD algorithms affects chosen server and client sign hash-client]
+Certificate = ${ENV::TEST_CERTS_DIR}/ee-client-chain.pem
+CipherString = DEFAULT:@SECLEVEL=0
+PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-key.pem
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-2]
+ClientSignatureMDAlgorithmsSigning = ALL:!SHA256:!SHA384
+ClientSignatureMDAlgorithmsVerification = ALL:!SHA512
+ExpectedClientCertType = RSA
+ExpectedClientSignHash = SHA512
+ExpectedResult = Success
+ExpectedServerCertType = RSA
+ExpectedServerSignHash = SHA384
+ServerSignatureMDAlgorithmsSigning = SHA384
+ServerSignatureMDAlgorithmsVerification = SHA256:SHA512
+
+
+# ===========================================================
+
+[3-Clients that do not sign MD5-SHA1 can connect to TLS 1.2 or newer servers with client certificates]
+ssl_conf = 3-Clients that do not sign MD5-SHA1 can connect to TLS 1.2 or newer servers with client certificates-ssl
+
+[3-Clients that do not sign MD5-SHA1 can connect to TLS 1.2 or newer servers with client certificates-ssl]
+server = 3-Clients that do not sign MD5-SHA1 can connect to TLS 1.2 or newer servers with client certificates-server
+client = 3-Clients that do not sign MD5-SHA1 can connect to TLS 1.2 or newer servers with client certificates-client
+
+[3-Clients that do not sign MD5-SHA1 can connect to TLS 1.2 or newer servers with client certificates-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT:@SECLEVEL=0:!kRSA
+MinProtocol = TLSv1.2
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
+VerifyMode = Require
+
+[3-Clients that do not sign MD5-SHA1 can connect to TLS 1.2 or newer servers with client certificates-client]
+Certificate = ${ENV::TEST_CERTS_DIR}/ee-client-chain.pem
+CipherString = DEFAULT:@SECLEVEL=0
+PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-key.pem
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-3]
+ClientSignatureMDAlgorithmsSigning = ALL:!MD5-SHA1
+ExpectedClientCertType = RSA
+ExpectedClientSignHash = SHA256
+ExpectedResult = Success
+
+
+# ===========================================================
+
+[4-Clients that verify but not sign MD5-SHA1 can connect to TLS 1.1 servers]
+ssl_conf = 4-Clients that verify but not sign MD5-SHA1 can connect to TLS 1.1 servers-ssl
+
+[4-Clients that verify but not sign MD5-SHA1 can connect to TLS 1.1 servers-ssl]
+server = 4-Clients that verify but not sign MD5-SHA1 can connect to TLS 1.1 servers-server
+client = 4-Clients that verify but not sign MD5-SHA1 can connect to TLS 1.1 servers-client
+
+[4-Clients that verify but not sign MD5-SHA1 can connect to TLS 1.1 servers-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT:@SECLEVEL=0:!kRSA
+MaxProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[4-Clients that verify but not sign MD5-SHA1 can connect to TLS 1.1 servers-client]
+CipherString = DEFAULT:@SECLEVEL=0
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-4]
+ClientSignatureMDAlgorithmsSigning = ALL:!MD5-SHA1
+ExpectedResult = Success
+
+
+# ===========================================================
+
+[5-Clients that do not sign MD5-SHA1 can not connect to TLS 1.1 servers with client certificates]
+ssl_conf = 5-Clients that do not sign MD5-SHA1 can not connect to TLS 1.1 servers with client certificates-ssl
+
+[5-Clients that do not sign MD5-SHA1 can not connect to TLS 1.1 servers with client certificates-ssl]
+server = 5-Clients that do not sign MD5-SHA1 can not connect to TLS 1.1 servers with client certificates-server
+client = 5-Clients that do not sign MD5-SHA1 can not connect to TLS 1.1 servers with client certificates-client
+
+[5-Clients that do not sign MD5-SHA1 can not connect to TLS 1.1 servers with client certificates-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT:@SECLEVEL=0:!kRSA
+MaxProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/root-cert.pem
+VerifyMode = Require
+
+[5-Clients that do not sign MD5-SHA1 can not connect to TLS 1.1 servers with client certificates-client]
+Certificate = ${ENV::TEST_CERTS_DIR}/ee-client-chain.pem
+CipherString = DEFAULT:@SECLEVEL=0
+PrivateKey = ${ENV::TEST_CERTS_DIR}/ee-key.pem
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-5]
+ClientSignatureMDAlgorithmsSigning = ALL:!MD5-SHA1
+ExpectedResult = ClientFail
+
+
+# ===========================================================
+
+[6-TLS 1.1 or lower fails if the client does not verify MD5-SHA1]
+ssl_conf = 6-TLS 1.1 or lower fails if the client does not verify MD5-SHA1-ssl
+
+[6-TLS 1.1 or lower fails if the client does not verify MD5-SHA1-ssl]
+server = 6-TLS 1.1 or lower fails if the client does not verify MD5-SHA1-server
+client = 6-TLS 1.1 or lower fails if the client does not verify MD5-SHA1-client
+
+[6-TLS 1.1 or lower fails if the client does not verify MD5-SHA1-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT:@SECLEVEL=0:!kRSA
+MaxProtocol = TLSv1.1
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[6-TLS 1.1 or lower fails if the client does not verify MD5-SHA1-client]
+CipherString = DEFAULT:@SECLEVEL=0
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-6]
+ClientSignatureMDAlgorithmsVerification = ALL:!MD5-SHA1
+ExpectedResult = ClientFail
+
+
+# ===========================================================
+
+[7-TLS 1.1 or lower fails if the server does not sign MD5-SHA1]
+ssl_conf = 7-TLS 1.1 or lower fails if the server does not sign MD5-SHA1-ssl
+
+[7-TLS 1.1 or lower fails if the server does not sign MD5-SHA1-ssl]
+server = 7-TLS 1.1 or lower fails if the server does not sign MD5-SHA1-server
+client = 7-TLS 1.1 or lower fails if the server does not sign MD5-SHA1-client
+
+[7-TLS 1.1 or lower fails if the server does not sign MD5-SHA1-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT:@SECLEVEL=0
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[7-TLS 1.1 or lower fails if the server does not sign MD5-SHA1-client]
+CipherString = DEFAULT:@SECLEVEL=0:!kRSA
+MaxProtocol = TLSv1.1
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-7]
+ExpectedResult = ServerFail
+ServerSignatureMDAlgorithmsSigning = ALL:!MD5-SHA1
+
+

--- a/test/ssl-tests/33-signature-md-algorithms.cnf.in
+++ b/test/ssl-tests/33-signature-md-algorithms.cnf.in
@@ -1,0 +1,161 @@
+# -*- mode: perl; -*-
+# Copyright 2016-2022 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+
+## SSL test configurations
+
+package ssltests;
+use OpenSSL::Test::Utils;
+
+our $fips_mode;
+
+# !kRSA requires either DH or ECDH. Without !kRSA, these tests would not test
+# what we want them to test.
+our @tests = (
+    {
+        name => "Server Signature MD algorithm SHA384 only",
+        server => {
+            "CipherString" => "DEFAULT:\@SECLEVEL=0:!kRSA",
+        },
+        client => {},
+        test => {
+            "ExpectedResult" => "Success",
+            "ExpectedServerSignHash" => "SHA384",
+            "ServerSignatureMDAlgorithmsSigning" => "SHA384"
+        },
+    },
+    {
+        name => "Client Signature MD algorithm SHA256 and higher only",
+        server => {
+            "CipherString" => "DEFAULT:\@SECLEVEL=0:!kRSA",
+        },
+        client => {},
+        test => {
+            "ExpectedResult" => "Success",
+            "ExpectedServerSignHash" => "SHA256",
+            "ClientSignatureMDAlgorithmsVerification" => "SHA256:SHA384:SHA512"
+            # SHA256 is required because the server certificate uses that
+        },
+    },
+    {
+        name => "Signature MD algorithms affects chosen server and client sign hash",
+        server => {
+            "CipherString" => "DEFAULT:\@SECLEVEL=0:!kRSA",
+            "VerifyCAFile" => test_pem("root-cert.pem"),
+            "VerifyMode" => "Require",
+        },
+        client => {
+            "CipherString" => "DEFAULT:\@SECLEVEL=0",
+            "Certificate" => test_pem("ee-client-chain.pem"),
+            "PrivateKey" => test_pem("ee-key.pem"),
+        },
+        test => {
+            "ExpectedResult" => "Success",
+            # The client will verify everything but SHA512, the server signs
+            # only SHA384, so we should expect SHA384 here
+            "ExpectedServerCertType" => "RSA",
+            "ExpectedServerSignHash" => "SHA384",
+            # The server verifies SHA256 and SHA512, but the client will not
+            # sign SHA256, so the client must choose SHA512 for its signature
+            "ExpectedClientCertType" => "RSA",
+            "ExpectedClientSignHash" => "SHA512",
+            "ServerSignatureMDAlgorithmsSigning" => "SHA384",
+            "ServerSignatureMDAlgorithmsVerification" => "SHA256:SHA512",
+            "ClientSignatureMDAlgorithmsSigning" => "ALL:!SHA256:!SHA384",
+            "ClientSignatureMDAlgorithmsVerification" => "ALL:!SHA512",
+        },
+    },
+    {
+        name => "Clients that do not sign MD5-SHA1 can connect to TLS 1.2 or newer servers with client certificates",
+        server => {
+            "CipherString" => "DEFAULT:\@SECLEVEL=0:!kRSA",
+            "VerifyCAFile" => test_pem("root-cert.pem"),
+            "MinProtocol" => "TLSv1.2",
+            "VerifyMode" => "Require",
+        },
+        client => {
+            "CipherString" => "DEFAULT:\@SECLEVEL=0",
+            "Certificate" => test_pem("ee-client-chain.pem"),
+            "PrivateKey" => test_pem("ee-key.pem"),
+        },
+        test => {
+            "ExpectedResult" => "Success",
+            "ClientSignatureMDAlgorithmsSigning" => "ALL:!MD5-SHA1",
+            "ExpectedClientCertType" => "RSA",
+            "ExpectedClientSignHash" => "SHA256",
+        },
+    },
+);
+
+# These tests require ECDH for key exchange (TLS 1.1 can otherwise use the
+# Kx=RSA cipher suites, which do not require an MD5-SHA1 signature).
+my @tests_tls1_1_ec = (
+    {
+        name => "Clients that verify but not sign MD5-SHA1 can connect to TLS 1.1 servers",
+        server => {
+            "CipherString" => "DEFAULT:\@SECLEVEL=0:!kRSA",
+            "MaxProtocol" => "TLSv1.1",
+        },
+        client => {
+            "CipherString" => "DEFAULT:\@SECLEVEL=0",
+        },
+        test => {
+            "ExpectedResult" => "Success",
+            "ClientSignatureMDAlgorithmsSigning" => "ALL:!MD5-SHA1",
+        },
+    },
+    {
+        name => "Clients that do not sign MD5-SHA1 can not connect to TLS 1.1 servers with client certificates",
+        server => {
+            "CipherString" => "DEFAULT:\@SECLEVEL=0:!kRSA",
+            "MaxProtocol" => "TLSv1.1",
+            "VerifyCAFile" => test_pem("root-cert.pem"),
+            "VerifyMode" => "Require",
+        },
+        client => {
+            "CipherString" => "DEFAULT:\@SECLEVEL=0",
+            "Certificate" => test_pem("ee-client-chain.pem"),
+            "PrivateKey" => test_pem("ee-key.pem"),
+        },
+        test => {
+            "ExpectedResult" => "ClientFail",
+            "ClientSignatureMDAlgorithmsSigning" => "ALL:!MD5-SHA1",
+        },
+    },
+    {
+        name => "TLS 1.1 or lower fails if the client does not verify MD5-SHA1",
+        server => {
+            "CipherString" => "DEFAULT:\@SECLEVEL=0:!kRSA",
+            "MaxProtocol" => "TLSv1.1",
+        },
+        client => {
+            "CipherString" => "DEFAULT:\@SECLEVEL=0",
+        },
+        test => {
+            "ExpectedResult" => "ClientFail",
+            "ClientSignatureMDAlgorithmsVerification" => "ALL:!MD5-SHA1",
+        },
+    },
+    {
+        name => "TLS 1.1 or lower fails if the server does not sign MD5-SHA1",
+        server => {
+            "CipherString" => "DEFAULT:\@SECLEVEL=0"
+        },
+        client => {
+            "CipherString" => "DEFAULT:\@SECLEVEL=0:!kRSA",
+            "MaxProtocol" => "TLSv1.1",
+        },
+        test => {
+            "ExpectedResult" => "ServerFail",
+            "ServerSignatureMDAlgorithmsSigning" => "ALL:!MD5-SHA1",
+        },
+    },
+);
+
+push @tests, @tests_tls1_1_ec
+    unless disabled("tls1_1") || disabled("ecdh") || $fips_mode;

--- a/test/tls13secretstest.c
+++ b/test/tls13secretstest.c
@@ -185,7 +185,7 @@ int ssl_log_secret(SSL_CONNECTION *sc,
     return 1;
 }
 
-const EVP_MD *ssl_md(SSL_CTX *ctx, int idx)
+const EVP_MD *ssl_md(const SSL_CTX *ctx, int idx)
 {
     return EVP_sha256();
 }

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5534,3 +5534,7 @@ OSSL_PROVIDER_try_load_ex               ?	3_2_0	EXIST::FUNCTION:
 OSSL_ERR_STATE_save_to_mark             ?	3_2_0	EXIST::FUNCTION:
 X509_STORE_CTX_set_get_crl              ?	3_2_0	EXIST::FUNCTION:
 X509_STORE_CTX_set_current_reasons      ?	3_2_0	EXIST::FUNCTION:
+EVP_signature_md_algorithms_set         ?	3_2_0	EXIST::FUNCTION:
+EVP_signature_md_algorithms_get         ?	3_2_0	EXIST::FUNCTION:
+EVP_signature_md_algorithm_allowed      ?	3_2_0	EXIST::FUNCTION:
+EVP_signature_md_algorithm_set          ?	3_2_0	EXIST::FUNCTION:

--- a/util/other.syms
+++ b/util/other.syms
@@ -739,3 +739,5 @@ EVP_PKEY_size                           define
 EVP_PKEY_id                             define
 EVP_PKEY_base_id                        define
 SSL_set_retry_verify                    define
+EVP_SIGNATURE_MD_ALGORITHMS_SIGNING     define
+EVP_SIGNATURE_MD_ALGORITHMS_VERIFICATION define

--- a/util/perl/OpenSSL/paramnames.pm
+++ b/util/perl/OpenSSL/paramnames.pm
@@ -385,6 +385,8 @@ my %params = (
     'SIGNATURE_PARAM_NONCE_TYPE' =>         "nonce-type",
     'SIGNATURE_PARAM_INSTANCE' =>           "instance",
     'SIGNATURE_PARAM_CONTEXT_STRING' =>     "context-string",
+    'SIGNATURE_PARAM_DIGEST_ALGORITHMS_SIGNING' => "digest-algorithms-signing",
+    'SIGNATURE_PARAM_DIGEST_ALGORITHMS_VERIFICATION' => "digest-algorithms-verification",
 
 # Asym cipher parameters
     'ASYM_CIPHER_PARAM_DIGEST' =>                   '*PKEY_PARAM_DIGEST',


### PR DESCRIPTION
https://sha-mbles.github.io/ claims a chosen-prefix collision attack on SHA-1 is now achievable for a price of around 45k USD. As a consequence, SHA-1 should no longer be used in applications where collision resistance is required, most notably in signatures.

This has been achieved in OpenSSL for TLS by increasing the default SECLEVEL, but uses of SHA-1 in signatures outside of TLS were so far not covered.

Introduce the configuration options `signature_md_algorithms_signing` and `signature_md_algorithms_verification` that can contain a set of acceptable digest algorithms for use in signature creation and signature verification, respectively. Additionally, introduce functions allowing library authors to test whether a given digest is acceptable, and allowing to override the default configuration.

This mechanism is not specific to SHA-1 and can also be used to block older digests, such as MD4 and MD5, or newer algorithms should further research uncover new vulnerabilities.

In its default, no change to current behavior is made, i.e., all algorithms are allowed.

Fixes: #17662
Signed-off-by: Clemens Lang <cllang@redhat.com>

Draft PR for the upcoming OTC discussion. Still to be fixed:
 - add tests
 - see if I can't change this so that TLS without client certs works with digests where only verification is allowed

##### Checklist
- [x] documentation is added or updated
- [ ] tests are added or updated
