### PR TITLE
Fix documented max. length for info buffer in HKDF

### DIFF
--- a/doc/man3/EVP_PKEY_CTX_set_hkdf_md.pod
+++ b/doc/man3/EVP_PKEY_CTX_set_hkdf_md.pod
@@ -99,7 +99,7 @@ A context for HKDF can be obtained by calling:
 
  EVP_PKEY_CTX *pctx = EVP_PKEY_CTX_new_id(EVP_PKEY_HKDF, NULL);
 
-The total length of the info buffer cannot exceed 1024 bytes in length: this
+The total length of the info buffer cannot exceed 2048 bytes in length: this
 should be more than enough for any normal use of HKDF.
 
 The output length of an HKDF expand operation is specified via the length


### PR DESCRIPTION
This limit was increased with 20c2876f24d0 ("Increase HKDF_MAXBUF from 1024 to 2048").

##### Checklist
- [x] documentation is added or updated

