### PR TITLE
test/pkcs12_api_test.c: fix failure on MinGW

### DIFF
--- a/test/pkcs12_api_test.c
+++ b/test/pkcs12_api_test.c
@@ -35,7 +35,7 @@ static PKCS12 *PKCS12_load(const char *fpath)
     BIO *bio = NULL;
     PKCS12 *p12 = NULL;
 
-    bio = BIO_new_file(fpath, "r");
+    bio = BIO_new_file(fpath, "rb");
     if (!TEST_ptr(bio))
         goto err;
 


### PR DESCRIPTION
Use binary mode when opening a file.

Partially fixes #18017.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
