### PR TITLE
Cleanup EBCDIC string defintions

### DIFF
--- a/include/openssl/tls1.h
+++ b/include/openssl/tls1.h
@@ -1138,78 +1138,35 @@ int SSL_CTX_set_tlsext_ticket_key_evp_cb
 
 # define TLS1_FINISH_MAC_LENGTH          12
 
-# define TLS_MD_MAX_CONST_SIZE                   22
-# define TLS_MD_CLIENT_FINISH_CONST              "client finished"
-# define TLS_MD_CLIENT_FINISH_CONST_SIZE         15
-# define TLS_MD_SERVER_FINISH_CONST              "server finished"
-# define TLS_MD_SERVER_FINISH_CONST_SIZE         15
-# define TLS_MD_KEY_EXPANSION_CONST              "key expansion"
-# define TLS_MD_KEY_EXPANSION_CONST_SIZE         13
-# define TLS_MD_CLIENT_WRITE_KEY_CONST           "client write key"
-# define TLS_MD_CLIENT_WRITE_KEY_CONST_SIZE      16
-# define TLS_MD_SERVER_WRITE_KEY_CONST           "server write key"
-# define TLS_MD_SERVER_WRITE_KEY_CONST_SIZE      16
-# define TLS_MD_IV_BLOCK_CONST                   "IV block"
-# define TLS_MD_IV_BLOCK_CONST_SIZE              8
-# define TLS_MD_MASTER_SECRET_CONST              "master secret"
-# define TLS_MD_MASTER_SECRET_CONST_SIZE         13
-# define TLS_MD_EXTENDED_MASTER_SECRET_CONST     "extended master secret"
-# define TLS_MD_EXTENDED_MASTER_SECRET_CONST_SIZE        22
+# define TLS_MD_MAX_CONST_SIZE                     22
 
-# ifdef CHARSET_EBCDIC
-#  undef TLS_MD_CLIENT_FINISH_CONST
-/*
- * client finished
- */
-#  define TLS_MD_CLIENT_FINISH_CONST    "\x63\x6c\x69\x65\x6e\x74\x20\x66\x69\x6e\x69\x73\x68\x65\x64"
-
-#  undef TLS_MD_SERVER_FINISH_CONST
-/*
- * server finished
- */
-#  define TLS_MD_SERVER_FINISH_CONST    "\x73\x65\x72\x76\x65\x72\x20\x66\x69\x6e\x69\x73\x68\x65\x64"
-
-#  undef TLS_MD_SERVER_WRITE_KEY_CONST
-/*
- * server write key
- */
-#  define TLS_MD_SERVER_WRITE_KEY_CONST "\x73\x65\x72\x76\x65\x72\x20\x77\x72\x69\x74\x65\x20\x6b\x65\x79"
-
-#  undef TLS_MD_KEY_EXPANSION_CONST
-/*
- * key expansion
- */
-#  define TLS_MD_KEY_EXPANSION_CONST    "\x6b\x65\x79\x20\x65\x78\x70\x61\x6e\x73\x69\x6f\x6e"
-
-#  undef TLS_MD_CLIENT_WRITE_KEY_CONST
-/*
- * client write key
- */
-#  define TLS_MD_CLIENT_WRITE_KEY_CONST "\x63\x6c\x69\x65\x6e\x74\x20\x77\x72\x69\x74\x65\x20\x6b\x65\x79"
-
-#  undef TLS_MD_SERVER_WRITE_KEY_CONST
-/*
- * server write key
- */
-#  define TLS_MD_SERVER_WRITE_KEY_CONST "\x73\x65\x72\x76\x65\x72\x20\x77\x72\x69\x74\x65\x20\x6b\x65\x79"
-
-#  undef TLS_MD_IV_BLOCK_CONST
-/*
- * IV block
- */
-#  define TLS_MD_IV_BLOCK_CONST         "\x49\x56\x20\x62\x6c\x6f\x63\x6b"
-
-#  undef TLS_MD_MASTER_SECRET_CONST
-/*
- * master secret
- */
-#  define TLS_MD_MASTER_SECRET_CONST    "\x6d\x61\x73\x74\x65\x72\x20\x73\x65\x63\x72\x65\x74"
-#  undef TLS_MD_EXTENDED_MASTER_SECRET_CONST
-/*
- * extended master secret
- */
-#  define TLS_MD_EXTENDED_MASTER_SECRET_CONST    "\x65\x78\x74\x65\x6e\x64\x65\x64\x20\x6d\x61\x73\x74\x65\x72\x20\x73\x65\x63\x72\x65\x74"
-# endif
+/* ASCII: "client finished", in hex for EBCDIC compatibility */
+# define TLS_MD_CLIENT_FINISH_CONST                "\x63\x6c\x69\x65\x6e\x74\x20\x66\x69\x6e\x69\x73\x68\x65\x64"
+# define TLS_MD_CLIENT_FINISH_CONST_SIZE           15
+/* ASCII: "server finished", in hex for EBCDIC compatibility */
+# define TLS_MD_SERVER_FINISH_CONST                "\x73\x65\x72\x76\x65\x72\x20\x66\x69\x6e\x69\x73\x68\x65\x64"
+# define TLS_MD_SERVER_FINISH_CONST_SIZE           15
+/* ASCII: "server write key", in hex for EBCDIC compatibility */
+# define TLS_MD_SERVER_WRITE_KEY_CONST             "\x73\x65\x72\x76\x65\x72\x20\x77\x72\x69\x74\x65\x20\x6b\x65\x79"
+# define TLS_MD_SERVER_WRITE_KEY_CONST_SIZE        16
+/* ASCII: "key expansion", in hex for EBCDIC compatibility */
+# define TLS_MD_KEY_EXPANSION_CONST                "\x6b\x65\x79\x20\x65\x78\x70\x61\x6e\x73\x69\x6f\x6e"
+# define TLS_MD_KEY_EXPANSION_CONST_SIZE           13
+/* ASCII: "client write key", in hex for EBCDIC compatibility */
+# define TLS_MD_CLIENT_WRITE_KEY_CONST             "\x63\x6c\x69\x65\x6e\x74\x20\x77\x72\x69\x74\x65\x20\x6b\x65\x79"
+# define TLS_MD_CLIENT_WRITE_KEY_CONST_SIZE        16
+/* ASCII: "server write key", in hex for EBCDIC compatibility */
+# define TLS_MD_SERVER_WRITE_KEY_CONST             "\x73\x65\x72\x76\x65\x72\x20\x77\x72\x69\x74\x65\x20\x6b\x65\x79"
+# define TLS_MD_SERVER_WRITE_KEY_CONST_SIZE        16
+/* ASCII: "IV block", in hex for EBCDIC compatibility */
+# define TLS_MD_IV_BLOCK_CONST                     "\x49\x56\x20\x62\x6c\x6f\x63\x6b"
+# define TLS_MD_IV_BLOCK_CONST_SIZE                8
+/* ASCII: "master secret", in hex for EBCDIC compatibility */
+# define TLS_MD_MASTER_SECRET_CONST                "\x6d\x61\x73\x74\x65\x72\x20\x73\x65\x63\x72\x65\x74"
+# define TLS_MD_MASTER_SECRET_CONST_SIZE           13
+/* ASCII: "extended master secret", in hex for EBCDIC compatibility */
+# define TLS_MD_EXTENDED_MASTER_SECRET_CONST       "\x65\x78\x74\x65\x6e\x64\x65\x64\x20\x6d\x61\x73\x74\x65\x72\x20\x73\x65\x63\x72\x65\x74"
+# define TLS_MD_EXTENDED_MASTER_SECRET_CONST_SIZE  22
 
 /* TLS Session Ticket extension struct */
 struct tls_session_ticket_ext_st {

--- a/providers/implementations/rands/drbg_local.h
+++ b/providers/implementations/rands/drbg_local.h
@@ -50,13 +50,8 @@
 # define DRBG_MAX_LENGTH                         INT32_MAX
 
 /* The default nonce */
-#ifdef CHARSET_EBCDIC
-# define DRBG_DEFAULT_PERS_STRING      { 0x4f, 0x70, 0x65, 0x6e, 0x53, 0x53, \
-     0x4c, 0x20, 0x4e, 0x49, 0x53, 0x54, 0x20, 0x53, 0x50, 0x20, 0x38, 0x30, \
-     0x30, 0x2d, 0x39, 0x30, 0x41, 0x20, 0x44, 0x52, 0x42, 0x47, 0x00};
-#else
-# define DRBG_DEFAULT_PERS_STRING                "OpenSSL NIST SP 800-90A DRBG"
-#endif
+/* ASCII: "OpenSSL NIST SP 800-90A DRBG", in hex for EBCDIC compatibility */
+#define DRBG_DEFAULT_PERS_STRING "\x4f\x70\x65\x6e\x53\x53\x4c\x20\x4e\x49\x53\x54\x20\x53\x50\x20\x38\x30\x30\x2d\x39\x30\x41\x20\x44\x52\x42\x47"
 
 typedef struct prov_drbg_st PROV_DRBG;
 

--- a/ssl/statem/extensions.c
+++ b/ssl/statem/extensions.c
@@ -1469,13 +1469,10 @@ int tls_psk_do_binder(SSL_CONNECTION *s, const EVP_MD *md,
     unsigned char hash[EVP_MAX_MD_SIZE], binderkey[EVP_MAX_MD_SIZE];
     unsigned char finishedkey[EVP_MAX_MD_SIZE], tmpbinder[EVP_MAX_MD_SIZE];
     unsigned char *early_secret;
-#ifdef CHARSET_EBCDIC
-    static const unsigned char resumption_label[] = { 0x72, 0x65, 0x73, 0x20, 0x62, 0x69, 0x6E, 0x64, 0x65, 0x72, 0x00 };
-    static const unsigned char external_label[]   = { 0x65, 0x78, 0x74, 0x20, 0x62, 0x69, 0x6E, 0x64, 0x65, 0x72, 0x00 };
-#else
-    static const unsigned char resumption_label[] = "res binder";
-    static const unsigned char external_label[] = "ext binder";
-#endif
+    /* ASCII: "res binder", in hex for EBCDIC compatibility */
+    static const unsigned char resumption_label[] = "\x72\x65\x73\x20\x62\x69\x6E\x64\x65\x72";
+    /* ASCII: "ext binder", in hex for EBCDIC compatibility */
+    static const unsigned char external_label[] = "\x65\x78\x74\x20\x62\x69\x6E\x64\x65\x72";
     const unsigned char *label;
     size_t bindersize, labelsize, hashsize;
     int hashsizei = EVP_MD_get_size(md);

--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -216,19 +216,12 @@ int tls_setup_handshake(SSL_CONNECTION *s)
 static int get_cert_verify_tbs_data(SSL_CONNECTION *s, unsigned char *tls13tbs,
                                     void **hdata, size_t *hdatalen)
 {
-#ifdef CHARSET_EBCDIC
-    static const char servercontext[] = { 0x54, 0x4c, 0x53, 0x20, 0x31, 0x2e,
-     0x33, 0x2c, 0x20, 0x73, 0x65, 0x72, 0x76, 0x65, 0x72, 0x20, 0x43, 0x65,
-     0x72, 0x74, 0x69, 0x66, 0x69, 0x63, 0x61, 0x74, 0x65, 0x56, 0x65, 0x72,
-     0x69, 0x66, 0x79, 0x00 };
-    static const char clientcontext[] = { 0x54, 0x4c, 0x53, 0x20, 0x31, 0x2e,
-     0x33, 0x2c, 0x20, 0x63, 0x6c, 0x69, 0x65, 0x6e, 0x74, 0x20, 0x43, 0x65,
-     0x72, 0x74, 0x69, 0x66, 0x69, 0x63, 0x61, 0x74, 0x65, 0x56, 0x65, 0x72,
-     0x69, 0x66, 0x79, 0x00 };
-#else
-    static const char servercontext[] = "TLS 1.3, server CertificateVerify";
-    static const char clientcontext[] = "TLS 1.3, client CertificateVerify";
-#endif
+    /* ASCII: "TLS 1.3, server CertificateVerify", in hex for EBCDIC compatibility */
+    static const char servercontext[] = "\x54\x4c\x53\x20\x31\x2e\x33\x2c\x20\x73\x65\x72"
+        "\x76\x65\x72\x20\x43\x65\x72\x74\x69\x66\x69\x63\x61\x74\x65\x56\x65\x72\x69\x66\x79";
+    /* ASCII: "TLS 1.3, client CertificateVerify", in hex for EBCDIC compatibility */
+    static const char clientcontext[] = "\x54\x4c\x53\x20\x31\x2e\x33\x2c\x20\x63\x6c\x69"
+        "\x65\x6e\x74\x20\x43\x65\x72\x74\x69\x66\x69\x63\x61\x74\x65\x56\x65\x72\x69\x66\x79";
 
     if (SSL_CONNECTION_IS_TLS13(s)) {
         size_t hashlen;

--- a/ssl/tls13_enc.c
+++ b/ssl/tls13_enc.c
@@ -18,11 +18,8 @@
 
 #define TLS13_MAX_LABEL_LEN     249
 
-#ifdef CHARSET_EBCDIC
-static const unsigned char label_prefix[] = { 0x74, 0x6C, 0x73, 0x31, 0x33, 0x20, 0x00 };
-#else
-static const unsigned char label_prefix[] = "tls13 ";
-#endif
+/* ASCII: "tls13 ", in hex for EBCDIC compatibility */
+static const unsigned char label_prefix[] = "\x74\x6C\x73\x31\x33\x20";
 
 /*
  * Given a |secret|; a |label| of length |labellen|; and |data| of length
@@ -125,11 +122,8 @@ int tls13_derive_key(SSL_CONNECTION *s, const EVP_MD *md,
                      const unsigned char *secret,
                      unsigned char *key, size_t keylen)
 {
-#ifdef CHARSET_EBCDIC
-  static const unsigned char keylabel[] ={ 0x6B, 0x65, 0x79, 0x00 };
-#else
-  static const unsigned char keylabel[] = "key";
-#endif
+    /* ASCII: "key", in hex for EBCDIC compatibility */
+    static const unsigned char keylabel[] = "\x6B\x65\x79";
 
     return tls13_hkdf_expand(s, md, secret, keylabel, sizeof(keylabel) - 1,
                              NULL, 0, key, keylen, 1);
@@ -143,11 +137,8 @@ int tls13_derive_iv(SSL_CONNECTION *s, const EVP_MD *md,
                     const unsigned char *secret,
                     unsigned char *iv, size_t ivlen)
 {
-#ifdef CHARSET_EBCDIC
-  static const unsigned char ivlabel[] = { 0x69, 0x76, 0x00 };
-#else
-  static const unsigned char ivlabel[] = "iv";
-#endif
+    /* ASCII: "iv", in hex for EBCDIC compatibility */
+    static const unsigned char ivlabel[] = "\x69\x76";
 
     return tls13_hkdf_expand(s, md, secret, ivlabel, sizeof(ivlabel) - 1,
                              NULL, 0, iv, ivlen, 1);
@@ -157,11 +148,8 @@ int tls13_derive_finishedkey(SSL_CONNECTION *s, const EVP_MD *md,
                              const unsigned char *secret,
                              unsigned char *fin, size_t finlen)
 {
-#ifdef CHARSET_EBCDIC
-  static const unsigned char finishedlabel[] = { 0x66, 0x69, 0x6E, 0x69, 0x73, 0x68, 0x65, 0x64, 0x00 };
-#else
-  static const unsigned char finishedlabel[] = "finished";
-#endif
+    /* ASCII: "finished", in hex for EBCDIC compatibility */
+    static const unsigned char finishedlabel[] = "\0x66\x69\x6E\x69\x73\x68\x65\x64";
 
     return tls13_hkdf_expand(s, md, secret, finishedlabel,
                              sizeof(finishedlabel) - 1, NULL, 0, fin, finlen, 1);
@@ -186,11 +174,8 @@ int tls13_generate_secret(SSL_CONNECTION *s, const EVP_MD *md,
     OSSL_PARAM params[7], *p = params;
     int mode = EVP_PKEY_HKDEF_MODE_EXTRACT_ONLY;
     const char *mdname = EVP_MD_get0_name(md);
-#ifdef CHARSET_EBCDIC
-    static const char derived_secret_label[] = { 0x64, 0x65, 0x72, 0x69, 0x76, 0x65, 0x64, 0x00 };
-#else
-    static const char derived_secret_label[] = "derived";
-#endif
+    /* ASCII: "derived", in hex for EBCDIC compatibility */
+    static const char derived_secret_label[] = "\x64\x65\x72\x69\x76\x65\x64";
     SSL_CTX *sctx = SSL_CONNECTION_GET_CTX(s);
 
     kdf = EVP_KDF_fetch(sctx->libctx, OSSL_KDF_NAME_TLS1_3_KDF, sctx->propq);
@@ -440,25 +425,22 @@ static int derive_secret_key_and_iv(SSL_CONNECTION *s, int sending,
 
 int tls13_change_cipher_state(SSL_CONNECTION *s, int which)
 {
-#ifdef CHARSET_EBCDIC
-    static const unsigned char client_early_traffic[]       = {0x63, 0x20, 0x65, 0x20,       /*traffic*/0x74, 0x72, 0x61, 0x66, 0x66, 0x69, 0x63, 0x00};
-    static const unsigned char client_handshake_traffic[]   = {0x63, 0x20, 0x68, 0x73, 0x20, /*traffic*/0x74, 0x72, 0x61, 0x66, 0x66, 0x69, 0x63, 0x00};
-    static const unsigned char client_application_traffic[] = {0x63, 0x20, 0x61, 0x70, 0x20, /*traffic*/0x74, 0x72, 0x61, 0x66, 0x66, 0x69, 0x63, 0x00};
-    static const unsigned char server_handshake_traffic[]   = {0x73, 0x20, 0x68, 0x73, 0x20, /*traffic*/0x74, 0x72, 0x61, 0x66, 0x66, 0x69, 0x63, 0x00};
-    static const unsigned char server_application_traffic[] = {0x73, 0x20, 0x61, 0x70, 0x20, /*traffic*/0x74, 0x72, 0x61, 0x66, 0x66, 0x69, 0x63, 0x00};
-    static const unsigned char exporter_master_secret[] = {0x65, 0x78, 0x70, 0x20,                    /* master*/  0x6D, 0x61, 0x73, 0x74, 0x65, 0x72, 0x00};
-    static const unsigned char resumption_master_secret[] = {0x72, 0x65, 0x73, 0x20,                  /* master*/  0x6D, 0x61, 0x73, 0x74, 0x65, 0x72, 0x00};
-    static const unsigned char early_exporter_master_secret[] = {0x65, 0x20, 0x65, 0x78, 0x70, 0x20,  /* master*/  0x6D, 0x61, 0x73, 0x74, 0x65, 0x72, 0x00};
-#else
-    static const unsigned char client_early_traffic[] = "c e traffic";
-    static const unsigned char client_handshake_traffic[] = "c hs traffic";
-    static const unsigned char client_application_traffic[] = "c ap traffic";
-    static const unsigned char server_handshake_traffic[] = "s hs traffic";
-    static const unsigned char server_application_traffic[] = "s ap traffic";
-    static const unsigned char exporter_master_secret[] = "exp master";
-    static const unsigned char resumption_master_secret[] = "res master";
-    static const unsigned char early_exporter_master_secret[] = "e exp master";
-#endif
+    /* ASCII: "c e traffic", in hex for EBCDIC compatibility */
+    static const unsigned char client_early_traffic[] = "\x63\x20\x65\x20\x74\x72\x61\x66\x66\x69\x63";
+    /* ASCII: "c hs traffic", in hex for EBCDIC compatibility */
+    static const unsigned char client_handshake_traffic[] = "\x63\x20\x68\x73\x20\x74x72\x61\x66\x66\x69\x63";
+    /* ASCII: "c ap traffic", in hex for EBCDIC compatibility */
+    static const unsigned char client_application_traffic[] = "\x63\x20\x61\x70\x20\x74\x72\x61\x66\x66\x69\x63";
+    /* ASCII: "s hs traffic", in hex for EBCDIC compatibility */
+    static const unsigned char server_handshake_traffic[] = "\x73\x20\x68\x73\x20\x74\x72\x61\x66\x66\x69\x63";
+    /* ASCII: "s ap traffic", in hex for EBCDIC compatibility */
+    static const unsigned char server_application_traffic[] = "\x73\x20\x61\x70\x20\x74\x72\x61\x66\x66\x69\x63";
+    /* ASCII: "exp master", in hex for EBCDIC compatibility */
+    static const unsigned char exporter_master_secret[] = "\x65\x78\x70\x20\x6D\x61\x73\x74\x65\x72";
+    /* ASCII: "res master", in hex for EBCDIC compatibility */
+    static const unsigned char resumption_master_secret[] = "\x72\x65\x73\x20\x6D\x61\x73\x74\x65\x72";
+    /* ASCII: "e exp master", in hex for EBCDIC compatibility */
+    static const unsigned char early_exporter_master_secret[] = "\x65\x20\x65\x78\x70\x20\x6D\x61\x73\x74\x65\x72";
     unsigned char *iv;
     unsigned char key[EVP_MAX_KEY_LENGTH];
     unsigned char secret[EVP_MAX_MD_SIZE];
@@ -805,11 +787,8 @@ skip_ktls:
 
 int tls13_update_key(SSL_CONNECTION *s, int sending)
 {
-#ifdef CHARSET_EBCDIC
-  static const unsigned char application_traffic[] = { 0x74, 0x72 ,0x61 ,0x66 ,0x66 ,0x69 ,0x63 ,0x20 ,0x75 ,0x70 ,0x64, 0x00};
-#else
-  static const unsigned char application_traffic[] = "traffic upd";
-#endif
+    /* ASCII: "traffic upd", in hex for EBCDIC compatibility */
+    static const unsigned char application_traffic[] = "\x74\x72\x61\x66\x66\x69\x63\x20\x75\x70\x64";
     const EVP_MD *md = ssl_handshake_md(s);
     size_t hashlen;
     unsigned char key[EVP_MAX_KEY_LENGTH];
@@ -887,11 +866,8 @@ int tls13_export_keying_material(SSL_CONNECTION *s,
                                  size_t contextlen, int use_context)
 {
     unsigned char exportsecret[EVP_MAX_MD_SIZE];
-#ifdef CHARSET_EBCDIC
-    static const unsigned char exporterlabel[] = {0x65, 0x78, 0x70, 0x6F, 0x72, 0x74, 0x65, 0x72, 0x00};
-#else
-    static const unsigned char exporterlabel[] = "exporter";
-#endif
+    /* ASCII: "exporter", in hex for EBCDIC compatibility */
+    static const unsigned char exporterlabel[] = "\x65\x78\x70\x6F\x72\x74\x65\x72";
     unsigned char hash[EVP_MAX_MD_SIZE], data[EVP_MAX_MD_SIZE];
     const EVP_MD *md = ssl_handshake_md(s);
     EVP_MD_CTX *ctx = EVP_MD_CTX_new();
@@ -929,11 +905,8 @@ int tls13_export_keying_material_early(SSL_CONNECTION *s,
                                        const unsigned char *context,
                                        size_t contextlen)
 {
-#ifdef CHARSET_EBCDIC
-  static const unsigned char exporterlabel[] = {0x65, 0x78, 0x70, 0x6F, 0x72, 0x74, 0x65, 0x72, 0x00};
-#else
-  static const unsigned char exporterlabel[] = "exporter";
-#endif
+    /* ASCII: "exporter", in hex for EBCDIC compatibility */
+    static const unsigned char exporterlabel[] = "\x65\x78\x70\x6F\x72\x74\x65\x72";
     unsigned char exportsecret[EVP_MAX_MD_SIZE];
     unsigned char hash[EVP_MAX_MD_SIZE], data[EVP_MAX_MD_SIZE];
     const EVP_MD *md;

--- a/ssl/tls13_enc.c
+++ b/ssl/tls13_enc.c
@@ -149,7 +149,7 @@ int tls13_derive_finishedkey(SSL_CONNECTION *s, const EVP_MD *md,
                              unsigned char *fin, size_t finlen)
 {
     /* ASCII: "finished", in hex for EBCDIC compatibility */
-    static const unsigned char finishedlabel[] = "\0x66\x69\x6E\x69\x73\x68\x65\x64";
+    static const unsigned char finishedlabel[] = "\x66\x69\x6E\x69\x73\x68\x65\x64";
 
     return tls13_hkdf_expand(s, md, secret, finishedlabel,
                              sizeof(finishedlabel) - 1, NULL, 0, fin, finlen, 1);
@@ -428,7 +428,7 @@ int tls13_change_cipher_state(SSL_CONNECTION *s, int which)
     /* ASCII: "c e traffic", in hex for EBCDIC compatibility */
     static const unsigned char client_early_traffic[] = "\x63\x20\x65\x20\x74\x72\x61\x66\x66\x69\x63";
     /* ASCII: "c hs traffic", in hex for EBCDIC compatibility */
-    static const unsigned char client_handshake_traffic[] = "\x63\x20\x68\x73\x20\x74x72\x61\x66\x66\x69\x63";
+    static const unsigned char client_handshake_traffic[] = "\x63\x20\x68\x73\x20\x74\x72\x61\x66\x66\x69\x63";
     /* ASCII: "c ap traffic", in hex for EBCDIC compatibility */
     static const unsigned char client_application_traffic[] = "\x63\x20\x61\x70\x20\x74\x72\x61\x66\x66\x69\x63";
     /* ASCII: "s hs traffic", in hex for EBCDIC compatibility */


### PR DESCRIPTION
Use a single definiton for protocol string defintions.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
