### PR TITLE
Fix undefined ipi_spec_dst for cygwin build.

### DIFF
--- a/crypto/bio/bss_dgram.c
+++ b/crypto/bio/bss_dgram.c
@@ -1125,7 +1125,9 @@ static int pack_local(BIO *b, MSGHDR_TYPE *mh, const BIO_ADDR *local) {
         cmsg->cmsg_type  = IP_PKTINFO;
 
         info = (struct in_pktinfo *)BIO_CMSG_DATA(cmsg);
+#   if !defined(OPENSSL_SYS_WINDOWS) && !defined(OPENSSL_SYS_CYGWIN)
         info->ipi_spec_dst      = local->s_in.sin_addr;
+#   endif
         info->ipi_addr.s_addr   = 0;
         info->ipi_ifindex       = 0;
 


### PR DESCRIPTION
The 'struct in_pktinfo' doesn't have a 'ipi_spec_dst' field on windows
OS which break cygwin builds of OpenSSL.

Signed-off-by: Tristan Lelong <tlelong@google.com>
