### PR TITLE
Coverity: explicit null dereference

### DIFF
--- a/test/list_test.c
+++ b/test/list_test.c
@@ -53,6 +53,10 @@ static int test_fizzbuzz(void)
 
     if (!TEST_size_t_eq(ossl_list_fizz_num(&a), na)
             || !TEST_size_t_eq(ossl_list_buzz_num(&b), nb)
+            || !TEST_ptr(ossl_list_fizz_head(&a))
+            || !TEST_ptr(ossl_list_fizz_tail(&a))
+            || !TEST_ptr(ossl_list_buzz_head(&b))
+            || !TEST_ptr(ossl_list_buzz_tail(&b))
             || !TEST_int_eq(ossl_list_fizz_head(&a)->n, 3)
             || !TEST_int_eq(ossl_list_fizz_tail(&a)->n, na * 3)
             || !TEST_int_eq(ossl_list_buzz_head(&b)->n, nb * 5)
@@ -62,8 +66,12 @@ static int test_fizzbuzz(void)
     ossl_list_buzz_remove(&b, ossl_list_buzz_tail(&b));
     if (!TEST_size_t_eq(ossl_list_fizz_num(&a), --na)
             || !TEST_size_t_eq(ossl_list_buzz_num(&b), --nb)
+            || !TEST_ptr(ossl_list_fizz_head(&a))
+            || !TEST_ptr(ossl_list_buzz_tail(&b))
             || !TEST_int_eq(ossl_list_fizz_head(&a)->n, 6)
             || !TEST_int_eq(ossl_list_buzz_tail(&b)->n, 10)
+            || !TEST_ptr(ossl_list_fizz_next(ossl_list_fizz_head(&a)))
+            || !TEST_ptr(ossl_list_fizz_prev(ossl_list_fizz_tail(&a)))
             || !TEST_int_eq(ossl_list_fizz_next(ossl_list_fizz_head(&a))->n, 9)
             || !TEST_int_eq(ossl_list_fizz_prev(ossl_list_fizz_tail(&a))->n, 15))
         return 0;
@@ -133,14 +141,18 @@ static int test_insert(void)
     ossl_list_int_remove(&l, elem + 2);                     /* 3 4 5 */
     ossl_list_int_remove(&l, elem + 4);                     /* 3 5 */
     ossl_list_int_remove(&l, elem + 3);                     /* 5 */
-    if (!TEST_int_eq(ossl_list_int_head(&l)->n, 5)
+    if (!TEST_ptr(ossl_list_int_head(&l))
+            || !TEST_ptr(ossl_list_int_tail(&l))
+            || !TEST_int_eq(ossl_list_int_head(&l)->n, 5)
             || !TEST_int_eq(ossl_list_int_tail(&l)->n, 5))
         return 0;
 
     /* Check removing the tail of a two element list works */
     ossl_list_int_insert_head(&l, elem);                    /* 0 5 */
     ossl_list_int_remove(&l, elem + 5);                     /* 0 */
-    if (!TEST_int_eq(ossl_list_int_head(&l)->n, 0)
+    if (!TEST_ptr(ossl_list_int_head(&l))
+            || !TEST_ptr(ossl_list_int_tail(&l))
+            || !TEST_int_eq(ossl_list_int_head(&l)->n, 0)
             || !TEST_int_eq(ossl_list_int_tail(&l)->n, 0))
         return 0;
 


### PR DESCRIPTION
Coverity is being pretty silly here but adding the explicit pointer checks will stop a crash if something goes badly awry and is probably good practice.

Fixes Coverity 1513706 - 1513709

- [ ] documentation is added or updated
- [x] tests are added or updated
