### PR TITLE
Remove perror() usage in library

### DIFF
--- a/crypto/bio/bss_dgram.c
+++ b/crypto/bio/bss_dgram.c
@@ -295,7 +295,8 @@ static void dgram_adjust_rcv_timeout(BIO *b)
         int sz = sizeof(timeout);
         if (getsockopt(b->num, SOL_SOCKET, SO_RCVTIMEO,
                        (void *)&timeout, &sz) < 0) {
-            perror("getsockopt");
+            ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
+                           "calling getsockopt()");
         } else {
             data->socket_timeout.tv_sec = timeout / 1000;
             data->socket_timeout.tv_usec = (timeout % 1000) * 1000;
@@ -303,9 +304,10 @@ static void dgram_adjust_rcv_timeout(BIO *b)
 #  else
         socklen_t sz = sizeof(data->socket_timeout);
         if (getsockopt(b->num, SOL_SOCKET, SO_RCVTIMEO,
-                       &(data->socket_timeout), &sz) < 0) {
-            perror("getsockopt");
-        } else
+                       &(data->socket_timeout), &sz) < 0)
+            ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
+                           "calling getsockopt()");
+        else
             OPENSSL_assert(sz <= sizeof(data->socket_timeout));
 #  endif
 
@@ -339,14 +341,14 @@ static void dgram_adjust_rcv_timeout(BIO *b)
 #  ifdef OPENSSL_SYS_WINDOWS
             timeout = timeleft.tv_sec * 1000 + timeleft.tv_usec / 1000;
             if (setsockopt(b->num, SOL_SOCKET, SO_RCVTIMEO,
-                           (void *)&timeout, sizeof(timeout)) < 0) {
-                perror("setsockopt");
-            }
+                           (void *)&timeout, sizeof(timeout)) < 0)
+                ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
+                               "calling setsockopt()");
 #  else
             if (setsockopt(b->num, SOL_SOCKET, SO_RCVTIMEO, &timeleft,
-                           sizeof(struct timeval)) < 0) {
-                perror("setsockopt");
-            }
+                           sizeof(struct timeval)) < 0)
+                ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
+                               "calling setsockopt()");
 #  endif
         }
     }
@@ -385,15 +387,14 @@ static void dgram_reset_rcv_timeout(BIO *b)
         int timeout = data->socket_timeout.tv_sec * 1000 +
             data->socket_timeout.tv_usec / 1000;
         if (setsockopt(b->num, SOL_SOCKET, SO_RCVTIMEO,
-                       (void *)&timeout, sizeof(timeout)) < 0) {
-            perror("setsockopt");
-        }
+                       (void *)&timeout, sizeof(timeout)) < 0)
+            ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
+                           "calling setsockopt()");
 #  else
-        if (setsockopt
-            (b->num, SOL_SOCKET, SO_RCVTIMEO, &(data->socket_timeout),
-             sizeof(struct timeval)) < 0) {
-            perror("setsockopt");
-        }
+        if (setsockopt(b->num, SOL_SOCKET, SO_RCVTIMEO,
+                       &(data->socket_timeout), sizeof(struct timeval)) < 0)
+            ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
+                           "calling setsockopt()");
 #  endif
     }
 # endif
@@ -615,14 +616,16 @@ static long dgram_ctrl(BIO *b, int cmd, long num, void *ptr)
             sockopt_val = IP_PMTUDISC_DO;
             if ((ret = setsockopt(b->num, IPPROTO_IP, IP_MTU_DISCOVER,
                                   &sockopt_val, sizeof(sockopt_val))) < 0)
-                perror("setsockopt");
+                ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
+                               "calling setsockopt()");
             break;
 #  if OPENSSL_USE_IPV6 && defined(IPV6_MTU_DISCOVER) && defined(IPV6_PMTUDISC_DO)
         case AF_INET6:
             sockopt_val = IPV6_PMTUDISC_DO;
             if ((ret = setsockopt(b->num, IPPROTO_IPV6, IPV6_MTU_DISCOVER,
                                   &sockopt_val, sizeof(sockopt_val))) < 0)
-                perror("setsockopt");
+                ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
+                               "calling setsockopt()");
             break;
 #  endif
         default:
@@ -742,18 +745,16 @@ static long dgram_ctrl(BIO *b, int cmd, long num, void *ptr)
         {
             struct timeval *tv = (struct timeval *)ptr;
             int timeout = tv->tv_sec * 1000 + tv->tv_usec / 1000;
-            if (setsockopt(b->num, SOL_SOCKET, SO_RCVTIMEO,
-                           (void *)&timeout, sizeof(timeout)) < 0) {
-                perror("setsockopt");
-                ret = -1;
-            }
+            if ((ret = setsockopt(b->num, SOL_SOCKET, SO_RCVTIMEO,
+                                  (void *)&timeout, sizeof(timeout))) < 0)
+                ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
+                               "calling setsockopt()");
         }
 #  else
-        if (setsockopt(b->num, SOL_SOCKET, SO_RCVTIMEO, ptr,
-                       sizeof(struct timeval)) < 0) {
-            perror("setsockopt");
-            ret = -1;
-        }
+        if ((ret = setsockopt(b->num, SOL_SOCKET, SO_RCVTIMEO, ptr,
+                              sizeof(struct timeval))) < 0)
+            ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
+                           "calling setsockopt()");
 #  endif
         break;
     case BIO_CTRL_DGRAM_GET_RECV_TIMEOUT:
@@ -764,10 +765,10 @@ static long dgram_ctrl(BIO *b, int cmd, long num, void *ptr)
             struct timeval *tv = (struct timeval *)ptr;
 
             sz = sizeof(timeout);
-            if (getsockopt(b->num, SOL_SOCKET, SO_RCVTIMEO,
-                           (void *)&timeout, &sz) < 0) {
-                perror("getsockopt");
-                ret = -1;
+            if ((ret = getsockopt(b->num, SOL_SOCKET, SO_RCVTIMEO,
+                                  (void *)&timeout, &sz)) < 0) {
+                ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
+                               "calling getsockopt()");
             } else {
                 tv->tv_sec = timeout / 1000;
                 tv->tv_usec = (timeout % 1000) * 1000;
@@ -775,10 +776,10 @@ static long dgram_ctrl(BIO *b, int cmd, long num, void *ptr)
             }
 #  else
             socklen_t sz = sizeof(struct timeval);
-            if (getsockopt(b->num, SOL_SOCKET, SO_RCVTIMEO,
-                           ptr, &sz) < 0) {
-                perror("getsockopt");
-                ret = -1;
+            if ((ret = getsockopt(b->num, SOL_SOCKET, SO_RCVTIMEO,
+                                  ptr, &sz)) < 0) {
+                ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
+                               "calling getsockopt()");
             } else {
                 OPENSSL_assert(sz <= sizeof(struct timeval));
                 ret = (int)sz;
@@ -793,18 +794,17 @@ static long dgram_ctrl(BIO *b, int cmd, long num, void *ptr)
         {
             struct timeval *tv = (struct timeval *)ptr;
             int timeout = tv->tv_sec * 1000 + tv->tv_usec / 1000;
-            if (setsockopt(b->num, SOL_SOCKET, SO_SNDTIMEO,
-                           (void *)&timeout, sizeof(timeout)) < 0) {
-                perror("setsockopt");
-                ret = -1;
-            }
+
+            if ((ret = setsockopt(b->num, SOL_SOCKET, SO_SNDTIMEO,
+                                  (void *)&timeout, sizeof(timeout))) < 0)
+                ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
+                               "calling setsockopt()");
         }
 #  else
-        if (setsockopt(b->num, SOL_SOCKET, SO_SNDTIMEO, ptr,
-                       sizeof(struct timeval)) < 0) {
-            perror("setsockopt");
-            ret = -1;
-        }
+        if ((ret = setsockopt(b->num, SOL_SOCKET, SO_SNDTIMEO, ptr,
+                              sizeof(struct timeval))) < 0)
+            ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
+                           "calling setsockopt()");
 #  endif
         break;
     case BIO_CTRL_DGRAM_GET_SEND_TIMEOUT:
@@ -815,10 +815,10 @@ static long dgram_ctrl(BIO *b, int cmd, long num, void *ptr)
             struct timeval *tv = (struct timeval *)ptr;
 
             sz = sizeof(timeout);
-            if (getsockopt(b->num, SOL_SOCKET, SO_SNDTIMEO,
-                           (void *)&timeout, &sz) < 0) {
-                perror("getsockopt");
-                ret = -1;
+            if ((ret = getsockopt(b->num, SOL_SOCKET, SO_SNDTIMEO,
+                                  (void *)&timeout, &sz)) < 0) {
+                ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
+                               "calling getsockopt()");
             } else {
                 tv->tv_sec = timeout / 1000;
                 tv->tv_usec = (timeout % 1000) * 1000;
@@ -826,10 +826,11 @@ static long dgram_ctrl(BIO *b, int cmd, long num, void *ptr)
             }
 #  else
             socklen_t sz = sizeof(struct timeval);
-            if (getsockopt(b->num, SOL_SOCKET, SO_SNDTIMEO,
-                           ptr, &sz) < 0) {
-                perror("getsockopt");
-                ret = -1;
+
+            if ((ret = getsockopt(b->num, SOL_SOCKET, SO_SNDTIMEO,
+                                  ptr, &sz)) < 0) {
+                ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
+                               "calling getsockopt()");
             } else {
                 OPENSSL_assert(sz <= sizeof(struct timeval));
                 ret = (int)sz;
@@ -868,24 +869,21 @@ static long dgram_ctrl(BIO *b, int cmd, long num, void *ptr)
         case AF_INET:
 # if defined(IP_DONTFRAG)
             if ((ret = setsockopt(b->num, IPPROTO_IP, IP_DONTFRAG,
-                                  &sockopt_val, sizeof(sockopt_val))) < 0) {
-                perror("setsockopt");
-                ret = -1;
-            }
+                                  &sockopt_val, sizeof(sockopt_val))) < 0)
+                ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
+                               "calling setsockopt()");
 # elif defined(OPENSSL_SYS_LINUX) && defined(IP_MTU_DISCOVER) && defined (IP_PMTUDISC_PROBE)
             if ((sockopt_val = num ? IP_PMTUDISC_PROBE : IP_PMTUDISC_DONT),
                 (ret = setsockopt(b->num, IPPROTO_IP, IP_MTU_DISCOVER,
-                                  &sockopt_val, sizeof(sockopt_val))) < 0) {
-                perror("setsockopt");
-                ret = -1;
-            }
+                                  &sockopt_val, sizeof(sockopt_val))) < 0)
+                ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
+                               "calling setsockopt()");
 # elif defined(OPENSSL_SYS_WINDOWS) && defined(IP_DONTFRAGMENT)
             if ((ret = setsockopt(b->num, IPPROTO_IP, IP_DONTFRAGMENT,
                                   (const char *)&sockopt_val,
-                                  sizeof(sockopt_val))) < 0) {
-                perror("setsockopt");
-                ret = -1;
-            }
+                                  sizeof(sockopt_val))) < 0)
+                ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
+                               "calling setsockopt()");
 # else
             ret = -1;
 # endif
@@ -895,17 +893,16 @@ static long dgram_ctrl(BIO *b, int cmd, long num, void *ptr)
 #  if defined(IPV6_DONTFRAG)
             if ((ret = setsockopt(b->num, IPPROTO_IPV6, IPV6_DONTFRAG,
                                   (const void *)&sockopt_val,
-                                  sizeof(sockopt_val))) < 0) {
-                perror("setsockopt");
-                ret = -1;
-            }
+                                  sizeof(sockopt_val))) < 0)
+                ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
+                               "calling setsockopt()");
+
 #  elif defined(OPENSSL_SYS_LINUX) && defined(IPV6_MTUDISCOVER)
             if ((sockopt_val = num ? IP_PMTUDISC_PROBE : IP_PMTUDISC_DONT),
                 (ret = setsockopt(b->num, IPPROTO_IPV6, IPV6_MTU_DISCOVER,
-                                  &sockopt_val, sizeof(sockopt_val))) < 0) {
-                perror("setsockopt");
-                ret = -1;
-            }
+                                  &sockopt_val, sizeof(sockopt_val))) < 0)
+                ERR_raise_data(ERR_LIB_SYS, get_last_socket_error(),
+                               "calling setsockopt()");
 #  else
             ret = -1;
 #  endif
@@ -964,6 +961,9 @@ static long dgram_ctrl(BIO *b, int cmd, long num, void *ptr)
         ret = 0;
         break;
     }
+    /* Normalize if error */
+    if (ret < 0)
+        ret = -1;
     return ret;
 }
 
@@ -1493,7 +1493,7 @@ static int dgram_recvmmsg(BIO *b, BIO_MSG *msg,
         num_msg = BIO_MAX_MSGS_PER_CALL;
 
     for (i = 0; i < num_msg; ++i) {
-        translate_msg(b, &mh[i].msg_hdr, &iov[i], 
+        translate_msg(b, &mh[i].msg_hdr, &iov[i],
                       control[i], &BIO_MSG_N(msg, stride, i));
 
         /* If local address was requested, it must have been enabled */
@@ -2809,7 +2809,9 @@ static void get_current_time(struct timeval *t)
     t->tv_usec = ((int)(now_ul % 10000000)) / 10;
 # else
     if (gettimeofday(t, NULL) < 0)
-        perror("gettimeofday");
+        ERR_raise_data(ERR_LIB_SYS, errno,
+                       "calling gettimeofday");
+
 # endif
 }
 


### PR DESCRIPTION
The dgram code used perror extensively.

Keep the `perror()` in the allocation code; it's used for debugging only.
Keep the `perror()`s in the demos, tests and apps.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
