### PR TITLE
bio_dgram_test.c: Fix warning from older clang compilers

### DIFF
--- a/test/bio_dgram_test.c
+++ b/test/bio_dgram_test.c
@@ -102,9 +102,9 @@ static int test_bio_dgram_impl(int af, int use_local)
     int fd1 = -1, fd2 = -1;
     BIO_ADDR *addr1 = NULL, *addr2 = NULL, *addr3 = NULL, *addr4 = NULL,
              *addr5 = NULL, *addr6 = NULL;
-    struct in_addr ina = {0};
+    struct in_addr ina;
 #if defined(OPENSSL_USE_IPV6)
-    struct in6_addr ina6 = {0};
+    struct in6_addr ina6;
 #endif
     void *pina;
     size_t inal, i;
@@ -133,6 +133,7 @@ static int test_bio_dgram_impl(int af, int use_local)
         goto err;
     }
 
+    memset(pina, 0, inal);
     addr1 = BIO_ADDR_new();
     if (!TEST_ptr(addr1))
         goto err;

--- a/test/bio_dgram_test.c
+++ b/test/bio_dgram_test.c
@@ -114,9 +114,6 @@ static int test_bio_dgram_impl(int af, int use_local)
     char tx_buf[128];
     size_t num_processed = 0;
 
-    ina.s_addr = htonl(0x7f000001UL);
-    ina6.s6_addr[15] = 1;
-
     if (af == AF_INET) {
         TEST_info("# Testing with AF_INET, local=%d\n", use_local);
         pina = &ina;
@@ -134,6 +131,9 @@ static int test_bio_dgram_impl(int af, int use_local)
     }
 
     memset(pina, 0, inal);
+    ina.s_addr = htonl(0x7f000001UL);
+    ina6.s6_addr[15] = 1;
+
     addr1 = BIO_ADDR_new();
     if (!TEST_ptr(addr1))
         goto err;


### PR DESCRIPTION
Older clang compilers warn about the initializer:
```
test/bio_dgram_test.c:107:29: error: suggest braces around initialization
 of subobject [-Werror,-Wmissing-braces]
    struct in6_addr ina6 = {0};
                            ^
                            {}
```
