### PR TITLE
crypto/conf: gcc build warning fix

### DIFF
--- a/crypto/conf/conf_sap.c
+++ b/crypto/conf/conf_sap.c
@@ -44,16 +44,20 @@ void OPENSSL_config(const char *appname)
 int ossl_config_int(const OPENSSL_INIT_SETTINGS *settings)
 {
     int ret = 0;
+#if defined(OPENSSL_INIT_DEBUG) || !defined(OPENSSL_SYS_UEFI)
     const char *filename;
     const char *appname;
     unsigned long flags;
+#endif
 
     if (openssl_configured)
         return 1;
 
+#if defined(OPENSSL_INIT_DEBUG) || !defined(OPENSSL_SYS_UEFI)
     filename = settings ? settings->filename : NULL;
     appname = settings ? settings->appname : NULL;
     flags = settings ? settings->flags : DEFAULT_CONF_MFLAGS;
+#endif
 
 #ifdef OPENSSL_INIT_DEBUG
     fprintf(stderr, "OPENSSL_INIT: ossl_config_int(%s, %s, %lu)\n",


### PR DESCRIPTION
Fix the gcc build warning from conf_sap.c:
variable flags set but not used [-Wunused-but-set-variable] 
variable appname set but not used [-Wunused-but-set-variable] 
variable filename set but not used [-Wunused-but-set-variable]

Signed-off-by: Gang Chen <gang.c.chen@intel.com>

