### PR TITLE
s390x: fix ecx derive

### DIFF
--- a/crypto/ec/ecx_meth.c
+++ b/crypto/ec/ecx_meth.c
@@ -1161,12 +1161,10 @@ static int s390x_pkey_ecx_derive25519(EVP_PKEY_CTX *ctx, unsigned char *key,
 {
     const unsigned char *privkey, *pubkey;
 
-    if (!validate_ecx_derive(ctx, key, keylen, &privkey, &pubkey))
+    if (!validate_ecx_derive(ctx, key, keylen, &privkey, &pubkey)
+        || (key != NULL
+            && s390x_x25519_mul(key, privkey, pubkey) == 0))
         return 0;
-
-    if (key != NULL)
-        return s390x_x25519_mul(key, pubkey, privkey);
-
     *keylen = X25519_KEYLEN;
     return 1;
 }
@@ -1176,12 +1174,10 @@ static int s390x_pkey_ecx_derive448(EVP_PKEY_CTX *ctx, unsigned char *key,
 {
     const unsigned char *privkey, *pubkey;
 
-    if (!validate_ecx_derive(ctx, key, keylen, &privkey, &pubkey))
+    if (!validate_ecx_derive(ctx, key, keylen, &privkey, &pubkey)
+        || (key != NULL
+            && s390x_x448_mul(key, pubkey, privkey) == 0))
         return 0;
-
-    if (key != NULL)
-        return s390x_x448_mul(key, pubkey, privkey);
-
     *keylen = X448_KEYLEN;
     return 1;
 }


### PR DESCRIPTION
Derivation via ecx-methods did not properly set the length.  Make the code more similar to common code and set the length property.

Signed-off-by: Juergen Christ <jchrist@linux.ibm.com>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
