### PR TITLE
Fix an out-of-bounds read for TLS <- 1.2 cipher strings that end in a "-"

### DIFF
--- a/ssl/ssl_ciph.c
+++ b/ssl/ssl_ciph.c
@@ -1062,9 +1062,7 @@ static int ssl_cipher_process_rulestr(const char *rule_str,
                  * alphanumeric, so we call this an error.
                  */
                 ERR_raise(ERR_LIB_SSL, SSL_R_INVALID_COMMAND);
-                retval = found = 0;
-                l++;
-                break;
+                return 0;
             }
 
             if (rule == CIPHER_SPECIAL) {


### PR DESCRIPTION
In ssl_cipher_process_rulestr(), if rule_str ended in a "-", "l" was incremented one byte past the end of the buffer.  This resulted in an out-of-bounds read when "l" is dereferenced at the end of the loop.  The trivial fix is to only increment "l" if the last byte read is not a NUL.

CLA: trivial
