### PR TITLE
Revert (most of) "Makefile: Generate crypto objects only as far as needed"

### DIFF
--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -1105,9 +1105,12 @@ uninstall_image_docs:
 # is sensitive to build.info changes.
 update: generate errors ordinals generate_buildinfo
 
+.PHONY: generate generate_apps generate_crypto_bn generate_crypto_objects \
+          generate_crypto_conf generate_crypto_asn1 generate_fuzz_oids
 generate: generate_apps generate_crypto_bn generate_crypto_objects \
           generate_crypto_conf generate_crypto_asn1 generate_fuzz_oids
 
+.PHONY: generate_buildinfo generate_doc_buildinfo
 generate_buildinfo: generate_doc_buildinfo
 
 .PHONY: doc-nits md-nits
@@ -1130,67 +1133,44 @@ md-nits:
 lint:
 	lint -DLINT $(INCLUDES) $(SRCS)
 
-$(SRCDIR)/apps/openssl-vms.cnf: $(SRCDIR)/apps/openssl.cnf
+generate_apps:
 	( cd $(SRCDIR); $(PERL) VMS/VMSify-conf.pl \
 				< apps/openssl.cnf > apps/openssl-vms.cnf )
-.PHONY: generate_apps
-generate_apps: $(SRCDIR)/apps/openssl-vms.cnf
 
-$(SRCDIR)/crypto/bn/bn_prime.h: $(SRCDIR)/crypto/bn/bn_prime.pl
+generate_crypto_bn:
 	( cd $(SRCDIR); $(PERL) crypto/bn/bn_prime.pl > crypto/bn/bn_prime.h )
-.PHONY: generate_crypto_bn
-generate_crypto_bn: $(SRCDIR)/crypto/bn/bn_prime.h
 
-$(SRCDIR)/crypto/objects/obj_mac.num: $(SRCDIR)/crypto/objects/objects.pl \
-                                      $(SRCDIR)/crypto/objects/objects.txt
+generate_crypto_objects:
 	( cd $(SRCDIR); $(PERL) crypto/objects/objects.pl -n \
 				crypto/objects/objects.txt \
 				crypto/objects/obj_mac.num \
 				> crypto/objects/obj_mac.new && \
 	    mv crypto/objects/obj_mac.new crypto/objects/obj_mac.num )
-$(SRCDIR)/include/openssl/obj_mac.h: $(SRCDIR)/crypto/objects/objects.pl \
-                                     $(SRCDIR)/crypto/objects/obj_dat.pl \
-                                     $(SRCDIR)/crypto/objects/obj_mac.num \
-                                     $(SRCDIR)/crypto/objects/obj_compat.h
 	( cd $(SRCDIR); $(PERL) crypto/objects/objects.pl \
 				crypto/objects/objects.txt \
 				crypto/objects/obj_mac.num \
-				> include/openssl/obj_mac.h && \
-			$(PERL) crypto/objects/obj_dat.pl \
+				> include/openssl/obj_mac.h )
+	( cd $(SRCDIR); $(PERL) crypto/objects/obj_dat.pl \
 				include/openssl/obj_mac.h \
-				> crypto/objects/obj_dat.h && \
-			sed -e '1,8d' crypto/objects/obj_compat.h \
-				>> include/openssl/obj_mac.h )
-$(SRCDIR)/crypto/objects/obj_dat.h: $(SRCDIR)/include/openssl/obj_mac.h
-$(SRCDIR)/crypto/objects/obj_xref.h: $(SRCDIR)/crypto/objects/objxref.pl \
-                                     $(SRCDIR)/crypto/objects/obj_mac.num \
-                                     $(SRCDIR)/crypto/objects/obj_xref.txt
+				> crypto/objects/obj_dat.h )
 	( cd $(SRCDIR); $(PERL) crypto/objects/objxref.pl \
 				crypto/objects/obj_mac.num \
 				crypto/objects/obj_xref.txt \
 				> crypto/objects/obj_xref.h )
-.PHONY: generate_crypto_objects
-generate_crypto_objects: $(SRCDIR)/crypto/objects/obj_dat.h \
-                         $(SRCDIR)/crypto/objects/obj_xref.h
+	( cd $(SRCDIR);	sed -e '1,8d' crypto/objects/obj_compat.h >> include/openssl/obj_mac.h )
 
-$(SRCDIR)/crypto/conf/conf_def.h: $(SRCDIR)/crypto/conf/keysets.pl
+generate_crypto_conf:
 	( cd $(SRCDIR); $(PERL) crypto/conf/keysets.pl \
 			        > crypto/conf/conf_def.h )
-.PHONY: generate_crypto_conf
-generate_crypto_conf: $(SRCDIR)/crypto/conf/conf_def.h
 
-$(SRCDIR)/crypto/asn1/charmap.h: $(SRCDIR)/crypto/asn1/charmap.pl
+generate_crypto_asn1:
 	( cd $(SRCDIR); $(PERL) crypto/asn1/charmap.pl \
 			        > crypto/asn1/charmap.h )
-.PHONY: generate_crypto_asn1
-generate_crypto_asn1: $(SRCDIR)/crypto/asn1/charmap.h
 
-$(SRCDIR)/fuzz/oids.txt: $(SRCDIR)/fuzz/mkfuzzoids.pl $(SRCDIR)/crypto/objects/obj_dat.h
+generate_fuzz_oids:
 	( cd $(SRCDIR); $(PERL) fuzz/mkfuzzoids.pl \
 				crypto/objects/obj_dat.h \
 				> fuzz/oids.txt )
-.PHONY: generate_fuzz_oids
-generate_fuzz_oids: $(SRCDIR)/fuzz/oids.txt
 
 generate_doc_buildinfo:
 	( $(PERL) -I$(BLDDIR) -Mconfigdata \

--- a/apps/openssl-vms.cnf
+++ b/apps/openssl-vms.cnf
@@ -13,7 +13,7 @@
 # defined.
 HOME			= .
 
- # Use this in order to automatically load providers.
+# Use this in order to automatically load providers.
 openssl_conf = openssl_init
 
 # Comment out the next line to ignore configuration errors
@@ -92,7 +92,7 @@ serial		= $dir]serial. 		# The current serial number
 crlnumber	= $dir]crlnumber.	# the current crl number
 					# must be commented out to leave a V1 CRL
 crl		= $dir]crl.pem 		# The current CRL
-private_key	= $dir.private]cakey.pem# The private key
+private_key	= $dir.private]cakey.pem # The private key
 
 x509_extensions	= usr_cert		# The extensions to add to the cert
 


### PR DESCRIPTION
This reverts the adaptations to ~`generate_crypto_objects`~ `Configurations/unix-Makefile.tmpl` (except for additions to `.PHONY`) that were done by commit 89c39bd8f6528ad268c1c0d0c9e196ba4396941b in #15224.

This ~is supposed to fix~ most likely fixes #19087.
