### PR TITLE
OSSL_CRYPTO_ALLOC attribute introduction proposal.

### DIFF
--- a/include/openssl/crypto.h.in
+++ b/include/openssl/crypto.h.in
@@ -318,11 +318,11 @@ void CRYPTO_get_mem_functions(CRYPTO_malloc_fn *malloc_fn,
                               CRYPTO_realloc_fn *realloc_fn,
                               CRYPTO_free_fn *free_fn);
 
-void *CRYPTO_malloc(size_t num, const char *file, int line);
-void *CRYPTO_zalloc(size_t num, const char *file, int line);
-void *CRYPTO_memdup(const void *str, size_t siz, const char *file, int line);
-char *CRYPTO_strdup(const char *str, const char *file, int line);
-char *CRYPTO_strndup(const char *str, size_t s, const char *file, int line);
+OSSL_CRYPTO_ALLOC void *CRYPTO_malloc(size_t num, const char *file, int line);
+OSSL_CRYPTO_ALLOC void *CRYPTO_zalloc(size_t num, const char *file, int line);
+OSSL_CRYPTO_ALLOC void *CRYPTO_memdup(const void *str, size_t siz, const char *file, int line);
+OSSL_CRYPTO_ALLOC char *CRYPTO_strdup(const char *str, const char *file, int line);
+OSSL_CRYPTO_ALLOC char *CRYPTO_strndup(const char *str, size_t s, const char *file, int line);
 void CRYPTO_free(void *ptr, const char *file, int line);
 void CRYPTO_clear_free(void *ptr, size_t num, const char *file, int line);
 void *CRYPTO_realloc(void *addr, size_t num, const char *file, int line);
@@ -331,8 +331,8 @@ void *CRYPTO_clear_realloc(void *addr, size_t old_num, size_t num,
 
 int CRYPTO_secure_malloc_init(size_t sz, size_t minsize);
 int CRYPTO_secure_malloc_done(void);
-void *CRYPTO_secure_malloc(size_t num, const char *file, int line);
-void *CRYPTO_secure_zalloc(size_t num, const char *file, int line);
+OSSL_CRYPTO_ALLOC void *CRYPTO_secure_malloc(size_t num, const char *file, int line);
+OSSL_CRYPTO_ALLOC void *CRYPTO_secure_zalloc(size_t num, const char *file, int line);
 void CRYPTO_secure_free(void *ptr, const char *file, int line);
 void CRYPTO_secure_clear_free(void *ptr, size_t num,
                               const char *file, int line);

--- a/include/openssl/macros.h
+++ b/include/openssl/macros.h
@@ -312,4 +312,14 @@
 #  endif
 # endif
 
+# ifndef OSSL_CRYPTO_ALLOC
+#  if defined(__GNUC__)
+#   define OSSL_CRYPTO_ALLOC __attribute__((malloc))
+#  elif defined(_MSC_VER)
+#   define OSSL_CRYPTO_ALLOC __declspec(restrict)
+#  else
+#   define OSSL_CRYPTO_ALLOC
+#  endif
+# endif
+
 #endif  /* OPENSSL_MACROS_H */


### PR DESCRIPTION
Giving hint to the compiler the returned pointer is not aliased
 (so realloc-like api is de facto excluded).
