### PR TITLE
added support for OCSP multistapling

### DIFF
--- a/apps/lib/s_cb.c
+++ b/apps/lib/s_cb.c
@@ -106,6 +106,10 @@ int verify_callback(int ok, X509_STORE_CTX *ctx)
         if (!verify_args.quiet)
             policies_print(ctx);
         break;
+    case X509_V_ERR_OCSP_NO_RESPONSE:
+        if (!verify_args.quiet)
+            BIO_printf(bio_err, "no OCSP response for certificate found.\n");
+        break;
     }
     if (err == X509_V_OK && ok == 2 && !verify_args.quiet)
         policies_print(ctx);

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -436,7 +436,8 @@ typedef enum OPTION_choice {
     OPT_CERTFORM, OPT_CRLFORM, OPT_VERIFY_RET_ERROR, OPT_VERIFY_QUIET,
     OPT_BRIEF, OPT_PREXIT, OPT_NO_INTERACTIVE, OPT_CRLF, OPT_QUIET, OPT_NBIO,
     OPT_SSL_CLIENT_ENGINE, OPT_IGN_EOF, OPT_NO_IGN_EOF,
-    OPT_DEBUG, OPT_TLSEXTDEBUG, OPT_STATUS, OPT_WDEBUG,
+    OPT_DEBUG, OPT_TLSEXTDEBUG, OPT_STATUS, OPT_STATUS_OCSP_CHECK,
+    OPT_STATUS_OCSP_CHECK_ALL, OPT_WDEBUG,
     OPT_MSG, OPT_MSGFILE, OPT_ENGINE, OPT_TRACE, OPT_SECURITY_DEBUG,
     OPT_SECURITY_DEBUG_VERBOSE, OPT_SHOWCERTS, OPT_NBIO_TEST, OPT_STATE,
     OPT_PSK_IDENTITY, OPT_PSK, OPT_PSK_SESS,
@@ -611,6 +612,10 @@ const OPTIONS s_client_options[] = {
      "Do not treat lack of close_notify from a peer as an error"},
 #ifndef OPENSSL_NO_OCSP
     {"status", OPT_STATUS, '-', "Request certificate status from server"},
+    {"ocsp_check", OPT_STATUS_OCSP_CHECK, '-',
+     "check leaf certificate revocation with OCSP response"},
+    {"ocsp_check_all", OPT_STATUS_OCSP_CHECK_ALL, '-',
+     "check full chain revocation with OCSP response"},
 #endif
     {"serverinfo", OPT_SERVERINFO, 's',
      "types  Send empty ClientHello extensions (comma-separated numbers)"},
@@ -1138,6 +1143,20 @@ int s_client_main(int argc, char **argv)
         case OPT_STATUS:
 #ifndef OPENSSL_NO_OCSP
             c_status_req = 1;
+#endif
+            break;
+        case OPT_STATUS_OCSP_CHECK:
+#ifndef OPENSSL_NO_OCSP
+            X509_VERIFY_PARAM_set_flags(vpm, X509_V_FLAG_OCSP_CHECK);
+            vpmtouched++;
+#endif
+            break;
+        case OPT_STATUS_OCSP_CHECK_ALL:
+#ifndef OPENSSL_NO_OCSP
+            X509_VERIFY_PARAM_set_flags(vpm,
+                                        X509_V_FLAG_OCSP_CHECK |
+                                        X509_V_FLAG_OCSP_CHECK_ALL);
+            vpmtouched++;
 #endif
             break;
         case OPT_WDEBUG:
@@ -3420,25 +3439,27 @@ static void print_stuff(BIO *bio, SSL *s, int full)
 # ifndef OPENSSL_NO_OCSP
 static int ocsp_resp_cb(SSL *s, void *arg)
 {
-    const unsigned char *p;
-    int len;
+    int len, i;
+    STACK_OF(OCSP_RESPONSE) *sk_resp = NULL;
     OCSP_RESPONSE *rsp;
-    len = SSL_get_tlsext_status_ocsp_resp(s, &p);
+    SSL_get_tlsext_status_ocsp_resp(s, &sk_resp);
     BIO_puts(arg, "OCSP response: ");
-    if (p == NULL) {
+    if (sk_resp == NULL) {
         BIO_puts(arg, "no response sent\n");
         return 1;
     }
-    rsp = d2i_OCSP_RESPONSE(NULL, &p, len);
-    if (rsp == NULL) {
-        BIO_puts(arg, "response parse error\n");
-        BIO_dump_indent(arg, (char *)p, len, 4);
-        return 0;
+    len = sk_OCSP_RESPONSE_num(sk_resp);
+    BIO_printf(arg, "number of responses: %d", len);
+    for (i=0; i<len; i++) {
+        rsp = sk_OCSP_RESPONSE_value(sk_resp, i);
+        if (rsp == NULL) {
+            BIO_puts(arg, "response parse error\n");
+            return 0;
+        }
+        BIO_puts(arg, "\n======================================\n");
+        OCSP_RESPONSE_print(arg, rsp, 0);
+        BIO_puts(arg, "======================================\n");
     }
-    BIO_puts(arg, "\n======================================\n");
-    OCSP_RESPONSE_print(arg, rsp, 0);
-    BIO_puts(arg, "======================================\n");
-    OCSP_RESPONSE_free(rsp);
     return 1;
 }
 # endif

--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -464,14 +464,13 @@ static tlsextstatusctx tlscstatp = { -1 };
  * the OCSP certificate IDs and minimise the number of OCSP responses by caching
  * them until they were considered "expired".
  */
-static int get_ocsp_resp_from_responder(SSL *s, tlsextstatusctx *srctx,
-                                        OCSP_RESPONSE **resp)
+static int get_ocsp_resp_from_responder_single(SSL *s, X509* x, tlsextstatusctx *srctx,
+                                               OCSP_RESPONSE **resp)
 {
     char *host = NULL, *port = NULL, *path = NULL;
     char *proxy = NULL, *no_proxy = NULL;
     int use_ssl;
     STACK_OF(OPENSSL_STRING) *aia = NULL;
-    X509 *x = NULL;
     X509_STORE_CTX *inctx = NULL;
     X509_OBJECT *obj;
     OCSP_REQUEST *req = NULL;
@@ -479,9 +478,9 @@ static int get_ocsp_resp_from_responder(SSL *s, tlsextstatusctx *srctx,
     STACK_OF(X509_EXTENSION) *exts;
     int ret = SSL_TLSEXT_ERR_NOACK;
     int i;
+    *resp = NULL;
 
     /* Build up OCSP query from server certificate */
-    x = SSL_get_certificate(s);
     aia = X509_get1_ocsp(x);
     if (aia != NULL) {
         if (!OSSL_HTTP_parse_url(sk_OPENSSL_STRING_value(aia, 0), &use_ssl,
@@ -565,6 +564,47 @@ static int get_ocsp_resp_from_responder(SSL *s, tlsextstatusctx *srctx,
     return ret;
 }
 
+static int get_ocsp_resp_from_responder(SSL *s, tlsextstatusctx *srctx,
+                                        STACK_OF(OCSP_RESPONSE) **sk_resp)
+{
+    X509 *x = NULL;
+    int ret = SSL_TLSEXT_ERR_NOACK;
+    int i;
+    int len = 1;
+    STACK_OF(X509) *server_certs = NULL;
+    OCSP_RESPONSE *resp = NULL;
+
+    if (*sk_resp != NULL) {
+        sk_OCSP_RESPONSE_pop_free(*sk_resp, OCSP_RESPONSE_free);
+    }
+    *sk_resp = sk_OCSP_RESPONSE_new_null();
+
+    SSL_get0_chain_certs(s, &server_certs);
+    if (server_certs != NULL) 
+        /* certificate chain is available */
+        len = sk_X509_num(server_certs);
+    else
+        /* certificate chain is not available, set len to 1 for server certificate */
+        len = 1; 
+    for (i = -1; i < len-1; i++) {
+        if (i == -1) {
+            /* get OCSP response for server certificate first */
+            x = SSL_get_certificate(s);
+        } else {
+            /* for each certificate in chain (except root) get the OCSP response */
+            x = sk_X509_value(server_certs, i);
+        }
+
+        resp = NULL;
+        ret = get_ocsp_resp_from_responder_single(s, x, srctx, &resp);
+        if (resp != NULL && ret == SSL_TLSEXT_ERR_OK) {
+            sk_OCSP_RESPONSE_insert(*sk_resp, resp, -1);
+ 	    }
+    }
+
+    return SSL_TLSEXT_ERR_OK;
+}
+
 /*
  * Certificate Status callback. This is called when a client includes a
  * certificate status request extension. The response is either obtained from a
@@ -574,9 +614,9 @@ static int cert_status_cb(SSL *s, void *arg)
 {
     tlsextstatusctx *srctx = arg;
     OCSP_RESPONSE *resp = NULL;
-    unsigned char *rspder = NULL;
-    int rspderlen;
+    STACK_OF(OCSP_RESPONSE) *sk_resp = NULL;
     int ret = SSL_TLSEXT_ERR_ALERT_FATAL;
+    int i;
 
     if (srctx->verbose)
         BIO_puts(bio_err, "cert_status: callback called\n");
@@ -593,20 +633,22 @@ static int cert_status_cb(SSL *s, void *arg)
             BIO_puts(bio_err, "cert_status: Error reading OCSP response\n");
             goto err;
         }
+        sk_OCSP_RESPONSE_insert(sk_resp, resp, -1);
     } else {
-        ret = get_ocsp_resp_from_responder(s, srctx, &resp);
+        ret = get_ocsp_resp_from_responder(s, srctx, &sk_resp);
         if (ret != SSL_TLSEXT_ERR_OK)
             goto err;
     }
 
-    rspderlen = i2d_OCSP_RESPONSE(resp, &rspder);
-    if (rspderlen <= 0)
-        goto err;
-
-    SSL_set_tlsext_status_ocsp_resp(s, rspder, rspderlen);
+    SSL_set_tlsext_status_ocsp_resp(s, sk_resp, 0);
     if (srctx->verbose) {
         BIO_puts(bio_err, "cert_status: ocsp response sent:\n");
-        OCSP_RESPONSE_print(bio_err, resp, 2);
+        for (i=0; i<sk_OCSP_RESPONSE_num(sk_resp); i++) {
+            resp = sk_OCSP_RESPONSE_value(sk_resp, i);
+            if (resp != NULL) {
+                OCSP_RESPONSE_print(bio_err, resp, 2);
+            }
+        }
     }
 
     ret = SSL_TLSEXT_ERR_OK;
@@ -614,8 +656,6 @@ static int cert_status_cb(SSL *s, void *arg)
  err:
     if (ret != SSL_TLSEXT_ERR_OK)
         ERR_print_errors(bio_err);
-
-    OCSP_RESPONSE_free(resp);
 
     return ret;
 }

--- a/crypto/x509/x509_txt.c
+++ b/crypto/x509/x509_txt.c
@@ -174,6 +174,16 @@ const char *X509_verify_cert_error_string(long n)
         return "OCSP verification failed";
     case X509_V_ERR_OCSP_CERT_UNKNOWN:
         return "OCSP unknown cert";
+    case X509_V_ERR_OCSP_INVALID:
+        return "OCSP response invalid";
+    case X509_V_ERR_OCSP_SIGNATURE_FAILURE:
+        return "OCSP signature failure";
+    case X509_V_ERR_OCSP_NOT_YET_VALID:
+        return "OCSP response not yet valid";
+    case X509_V_ERR_OCSP_HAS_EXPIRED:
+        return "OCSP response has expired";
+    case X509_V_ERR_OCSP_NO_RESPONSE:
+        return "no OCSP response found";
     case X509_V_ERR_UNSUPPORTED_SIGNATURE_ALGORITHM:
         return "Cannot find certificate signature algorithm";
     case X509_V_ERR_SIGNATURE_ALGORITHM_MISMATCH:

--- a/crypto/x509/x509_vfy.c
+++ b/crypto/x509/x509_vfy.c
@@ -22,6 +22,8 @@
 #include <openssl/asn1.h>
 #include <openssl/x509.h>
 #include <openssl/x509v3.h>
+#include <openssl/ocsp.h>
+#include <openssl/tls1.h>
 #include <openssl/objects.h>
 #include <openssl/core_names.h>
 #include "internal/dane.h"
@@ -52,7 +54,8 @@ static int check_name_constraints(X509_STORE_CTX *ctx);
 static int check_id(X509_STORE_CTX *ctx);
 static int check_trust(X509_STORE_CTX *ctx, int num_untrusted);
 static int check_revocation(X509_STORE_CTX *ctx);
-static int check_cert(X509_STORE_CTX *ctx);
+static int check_cert_ocsp(X509_STORE_CTX *ctx);
+static int check_cert_crl(X509_STORE_CTX *ctx);
 static int check_policy(X509_STORE_CTX *ctx);
 static int get_issuer_sk(X509 **issuer, X509_STORE_CTX *ctx, X509 *x);
 static int check_dane_issuer(X509_STORE_CTX *ctx, int depth);
@@ -176,6 +179,19 @@ static int verify_cb_cert(X509_STORE_CTX *ctx, X509 *x, int depth, int err)
  * Returns 0 to abort verification with an error, non-zero to continue.
  */
 static int verify_cb_crl(X509_STORE_CTX *ctx, int err)
+{
+    ctx->error = err;
+    return ctx->verify_cb(0, ctx);
+}
+
+/*-
+  * Inform the verify callback of an error, OCSP-specific variant.  Here, the
+  * error depth and certificate are already set, we just specify the error
+  * number.
+  *
+  * Returns 0 to abort verification with an error, non-zero to continue.
+  */
+static int verify_cb_ocsp(X509_STORE_CTX *ctx, int err)
 {
     ctx->error = err;
     return ctx->verify_cb(0, ctx);
@@ -920,9 +936,11 @@ static int check_revocation(X509_STORE_CTX *ctx)
 {
     int i = 0, last = 0, ok = 0;
 
-    if ((ctx->param->flags & X509_V_FLAG_CRL_CHECK) == 0)
+    if (!(ctx->param->flags & X509_V_FLAG_CRL_CHECK)
+            && !(ctx->param->flags & X509_V_FLAG_OCSP_CHECK))
         return 1;
-    if ((ctx->param->flags & X509_V_FLAG_CRL_CHECK_ALL) != 0) {
+    if (ctx->param->flags & X509_V_FLAG_CRL_CHECK_ALL
+            || ctx->param->flags & X509_V_FLAG_OCSP_CHECK_ALL) {
         last = sk_X509_num(ctx->chain) - 1;
     } else {
         /* If checking CRL paths this isn't the EE certificate */
@@ -932,15 +950,140 @@ static int check_revocation(X509_STORE_CTX *ctx)
     }
     for (i = 0; i <= last; i++) {
         ctx->error_depth = i;
-        ok = check_cert(ctx);
-        if (!ok)
-            return ok;
+        if (ctx->param->flags & X509_V_FLAG_OCSP_CHECK) {
+            ok = check_cert_ocsp(ctx);
+
+            /*
+             * If the client receives a "ocsp_response_list" that does not contain
+             * a response for one or more of the certificates in the completed
+             * certificate chain, the client SHOULD attempt to validate the
+             * certificate using an alternative retrieval method, such as
+             * downloading the relevant CRL;
+             * If the OCSP response received from the server does not result in a
+             * definite "good" or "revoked" status, it is inconclusive.  A TLS
+             * client in such a case MAY check the validity of the server
+             * certificate through other means, e.g., by directly querying the
+             * certificate issuer.
+             */
+            if (ok == V_OCSP_CERTSTATUS_REVOKED) {
+                verify_cb_ocsp(ctx, X509_V_ERR_CERT_REVOKED);
+                return 0; /* X509_V_ERR_CERT_REVOKED */
+            }
+
+            if (ok == V_OCSP_CERTSTATUS_GOOD)
+                continue;
+
+            if (!(ctx->param->flags & X509_V_FLAG_CRL_CHECK)) {
+                verify_cb_ocsp(ctx, ok);
+                return ok;
+            }
+        }
+
+        if (ctx->param->flags & X509_V_FLAG_CRL_CHECK) {
+            ok = check_cert_crl(ctx);
+            if (!ok)
+                return ok;
+        }
     }
     return 1;
 }
 
+static int check_cert_ocsp(X509_STORE_CTX *ctx)
+{
+    int cert_status, crl_reason;
+    int cnum = ctx->error_depth;
+    int i, found, ret;
+    OCSP_BASICRESP *bs = NULL;
+    OCSP_RESPONSE *resp = NULL;
+    OCSP_CERTID *cert_id = NULL;
+    ASN1_GENERALIZEDTIME *rev, *thisupd, *nextupd;
+    X509 *x = sk_X509_value(ctx->chain, cnum);
+
+    ret = V_OCSP_CERTSTATUS_UNKNOWN;
+    ctx->current_cert = x;
+    ctx->current_issuer = X509_find_by_subject(ctx->chain,
+                                                X509_get_issuer_name(x));
+
+
+    if(ctx->ocsp_resp == NULL || sk_OCSP_RESPONSE_num(ctx->ocsp_resp) == 0) {
+        return X509_V_ERR_OCSP_NO_RESPONSE;
+    }
+
+    cert_id = OCSP_cert_to_id(NULL, ctx->current_cert, ctx->current_issuer);
+
+    for (i=0; i<sk_OCSP_RESPONSE_num(ctx->ocsp_resp); i++) {
+        if ((resp = sk_OCSP_RESPONSE_value(ctx->ocsp_resp, i)) == NULL)
+            continue;
+
+        if ((bs = OCSP_response_get1_basic(resp)) == NULL)
+            continue;
+
+        found = OCSP_resp_find(bs, cert_id, -1);
+
+        if (found >= 0)
+            break;
+    }
+    if(found < 0) resp = NULL;
+
+    if (resp == NULL) {
+        ret = X509_V_ERR_OCSP_NO_RESPONSE;
+        goto end;
+    }
+
+    if(OCSP_response_status(resp) != OCSP_RESPONSE_STATUS_SUCCESSFUL) {
+        ret = X509_V_ERR_OCSP_INVALID;
+        goto end;
+    }
+
+    if((bs = OCSP_response_get1_basic(resp)) == NULL) {
+        ret = X509_V_ERR_OCSP_NO_RESPONSE;
+        goto end;
+    }
+
+    if (OCSP_basic_verify(bs, ctx->chain, ctx->store, 0) <= 0) {
+        ret = X509_V_ERR_OCSP_SIGNATURE_FAILURE;
+        goto end;
+    }
+
+    if(OCSP_resp_find_status(bs, cert_id, &cert_status, &crl_reason, &rev,
+                                &thisupd, &nextupd) <=0 ) {
+        ret = X509_V_ERR_OCSP_INVALID;
+        goto end;
+    }
+
+    switch(cert_status) {
+    case V_OCSP_CERTSTATUS_GOOD:
+        /* Note: A OCSP stapling result will be accepted up to 5 minutes after it expired! */
+        if(!OCSP_check_validity(thisupd, nextupd, 300L, -1L)) {
+            ret = X509_V_ERR_OCSP_HAS_EXPIRED;
+        } else {
+            ret = V_OCSP_CERTSTATUS_GOOD;
+        }
+        goto end;
+
+    case V_OCSP_CERTSTATUS_REVOKED:
+        ret = V_OCSP_CERTSTATUS_REVOKED;
+        goto end;
+
+    case V_OCSP_CERTSTATUS_UNKNOWN:
+        ret = V_OCSP_CERTSTATUS_UNKNOWN;
+        goto end;
+
+    default:
+        ret = V_OCSP_CERTSTATUS_UNKNOWN;
+        goto end;
+    }
+
+end:
+
+    if (cert_id != NULL) OCSP_CERTID_free(cert_id);
+    if (bs != NULL) OCSP_BASICRESP_free(bs);
+
+    return ret;
+}
+
 /* Sadly, returns 0 also on internal error. */
-static int check_cert(X509_STORE_CTX *ctx)
+static int check_cert_crl(X509_STORE_CTX *ctx)
 {
     X509_CRL *crl = NULL, *dcrl = NULL;
     int ok = 0;
@@ -2203,6 +2346,11 @@ void X509_STORE_CTX_set_cert(X509_STORE_CTX *ctx, X509 *x)
 void X509_STORE_CTX_set0_crls(X509_STORE_CTX *ctx, STACK_OF(X509_CRL) *sk)
 {
     ctx->crls = sk;
+}
+
+void X509_STORE_CTX_set_ocsp_resp(X509_STORE_CTX *ctx, STACK_OF(OCSP_RESPONSE) *sk)
+{
+    ctx->ocsp_resp = (STACK_OF(OCSP_RESPONSE) *)sk;
 }
 
 int X509_STORE_CTX_set_purpose(X509_STORE_CTX *ctx, int purpose)

--- a/doc/man1/openssl-s_client.pod.in
+++ b/doc/man1/openssl-s_client.pod.in
@@ -105,6 +105,8 @@ B<openssl> B<s_client>
 [B<-sess_in> I<filename>]
 [B<-serverinfo> I<types>]
 [B<-status>]
+[B<-ocsp_check>]
+[B<-ocsp_check_all>]
 [B<-alpn> I<protocols>]
 [B<-nextprotoneg> I<protocols>]
 [B<-ct>]

--- a/doc/man1/openssl-verify.pod.in
+++ b/doc/man1/openssl-verify.pod.in
@@ -13,6 +13,8 @@ B<openssl> B<verify>
 [B<-crl_download>]
 [B<-show_chain>]
 [B<-verbose>]
+[B<-ocsp_check>]
+[B<-ocsp_check_all>]
 [B<-trusted> I<filename>|I<uri>]
 [B<-untrusted> I<filename>|I<uri>]
 [B<-vfyopt> I<nm>:I<v>]
@@ -45,6 +47,17 @@ sources.
 =item B<-crl_download>
 
 Attempt to download CRL information for certificates via their CDP entries.
+
+=item B<-ocsp_check>
+
+Checks end entity certificate validity with a OCSP response provided in the
+TLS handshake (OCSP stapling). If no valid OCSP response can be found no error
+occurs and the client should attempt to check to validity with a CRL.
+
+=item B<-ocsp_check_all>
+
+Checks the validity of B<all> certificates in the chain by attempting
+to look up valid OCSP responses.
 
 =item B<-show_chain>
 

--- a/include/crypto/x509.h
+++ b/include/crypto/x509.h
@@ -221,6 +221,8 @@ struct x509_store_ctx_st {      /* X509_STORE_CTX */
     STACK_OF(X509) *untrusted;
     /* set of CRLs passed in */
     STACK_OF(X509_CRL) *crls;
+    int ocsp_status_flags;
+    STACK_OF(OCSP_RESPONSE) *ocsp_resp;
     X509_VERIFY_PARAM *param;
     /* Other info for use with get_issuer() */
     void *other_ctx;

--- a/include/openssl/ocsp.h.in
+++ b/include/openssl/ocsp.h.in
@@ -60,6 +60,14 @@ use OpenSSL::stackhash qw(generate_stack_macros);
 
 # ifndef OPENSSL_NO_OCSP
 
+# ifndef STACK_OF_OCSP_RESPONSE
+/* Protect against recursion */
+#  define STACK_OF_OCSP_RESPONSE
+# include <openssl/asn1.h>
+DEFINE_STACK_OF(OCSP_RESPONSE)
+DECLARE_ASN1_FUNCTIONS(OCSP_RESPONSE)
+# endif
+
 #  include <openssl/x509.h>
 #  include <openssl/x509v3.h>
 #  include <openssl/safestack.h>

--- a/include/openssl/x509_vfy.h.in
+++ b/include/openssl/x509_vfy.h.in
@@ -29,6 +29,7 @@ use OpenSSL::stackhash qw(generate_stack_macros);
 #  include <openssl/x509.h>
 # endif
 
+# include <openssl/ocsp.h>
 # include <openssl/opensslconf.h>
 # include <openssl/lhash.h>
 # include <openssl/bio.h>
@@ -315,6 +316,13 @@ X509_LOOKUP_ctrl_ex((x), X509_L_ADD_STORE, (name), 0, NULL,           \
 # define X509_V_ERR_EXTENSIONS_REQUIRE_VERSION_3         93
 # define X509_V_ERR_EC_KEY_EXPLICIT_PARAMS               94
 
+/* additional OCSP status errors */
+# define X509_V_ERR_OCSP_INVALID                         95
+# define X509_V_ERR_OCSP_SIGNATURE_FAILURE               96
+# define X509_V_ERR_OCSP_NOT_YET_VALID                   97
+# define X509_V_ERR_OCSP_HAS_EXPIRED                     98
+# define X509_V_ERR_OCSP_NO_RESPONSE                     99
+
 /* Certificate verify flags */
 # ifndef OPENSSL_NO_DEPRECATED_1_1_0
 #  define X509_V_FLAG_CB_ISSUER_CHECK             0x0   /* Deprecated */
@@ -365,6 +373,11 @@ X509_LOOKUP_ctrl_ex((x), X509_L_ADD_STORE, (name), 0, NULL,           \
 # define X509_V_FLAG_NO_ALT_CHAINS               0x100000
 /* Do not check certificate/CRL validity against current time */
 # define X509_V_FLAG_NO_CHECK_TIME               0x200000
+
+/* Verify OCSP stapling response for server certificate */
+# define X509_V_FLAG_OCSP_CHECK                   0x400000
+/* Verify OCSP stapling responses for whole chain */
+# define X509_V_FLAG_OCSP_CHECK_ALL               0x800000
 
 # define X509_VP_FLAG_DEFAULT                    0x1
 # define X509_VP_FLAG_OVERWRITE                  0x2
@@ -667,6 +680,7 @@ STACK_OF(X509) *X509_STORE_CTX_get1_chain(const X509_STORE_CTX *ctx);
 void X509_STORE_CTX_set_cert(X509_STORE_CTX *ctx, X509 *target);
 void X509_STORE_CTX_set0_verified_chain(X509_STORE_CTX *c, STACK_OF(X509) *sk);
 void X509_STORE_CTX_set0_crls(X509_STORE_CTX *ctx, STACK_OF(X509_CRL) *sk);
+void X509_STORE_CTX_set_ocsp_resp(X509_STORE_CTX *c, STACK_OF(OCSP_RESPONSE) *sk);
 int X509_STORE_CTX_set_purpose(X509_STORE_CTX *ctx, int purpose);
 int X509_STORE_CTX_set_trust(X509_STORE_CTX *ctx, int trust);
 int X509_STORE_CTX_purpose_inherit(X509_STORE_CTX *ctx, int def_purpose,

--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -20,6 +20,7 @@
 #include <openssl/x509v3.h>
 #include <openssl/core_names.h>
 #include "internal/cryptlib.h"
+#include <openssl/ocsp.h>
 
 #define TLS13_NUM_CIPHERS       OSSL_NELEM(tls13_ciphers)
 #define SSL3_NUM_CIPHERS        OSSL_NELEM(ssl3_ciphers)
@@ -3564,16 +3565,11 @@ long ssl3_ctrl(SSL *s, int cmd, long larg, void *parg)
         break;
 
     case SSL_CTRL_GET_TLSEXT_STATUS_REQ_OCSP_RESP:
-        *(unsigned char **)parg = sc->ext.ocsp.resp;
-        if (sc->ext.ocsp.resp_len == 0
-                || sc->ext.ocsp.resp_len > LONG_MAX)
-            return -1;
-        return (long)sc->ext.ocsp.resp_len;
+        *(STACK_OF(OCSP_RESPONSE) **)parg = sc->ext.ocsp.resp;
+        return 1;
 
     case SSL_CTRL_SET_TLSEXT_STATUS_REQ_OCSP_RESP:
-        OPENSSL_free(sc->ext.ocsp.resp);
-        sc->ext.ocsp.resp = parg;
-        sc->ext.ocsp.resp_len = larg;
+        sc->ext.ocsp.resp = (STACK_OF(OCSP_RESPONSE) *)parg;
         ret = 1;
         break;
 

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -818,7 +818,6 @@ SSL *ossl_ssl_connection_new(SSL_CTX *ctx)
     s->ext.ocsp.ids = NULL;
     s->ext.ocsp.exts = NULL;
     s->ext.ocsp.resp = NULL;
-    s->ext.ocsp.resp_len = 0;
     SSL_CTX_up_ref(ctx);
     s->session_ctx = ctx;
     if (ctx->ext.ecpointformats) {
@@ -5789,41 +5788,40 @@ static int ct_extract_ocsp_response_scts(SSL_CONNECTION *s)
 {
 # ifndef OPENSSL_NO_OCSP
     int scts_extracted = 0;
-    const unsigned char *p;
     OCSP_BASICRESP *br = NULL;
     OCSP_RESPONSE *rsp = NULL;
     STACK_OF(SCT) *scts = NULL;
-    int i;
+    int i, j;
 
-    if (s->ext.ocsp.resp == NULL || s->ext.ocsp.resp_len == 0)
+    if (s->ext.ocsp.resp == NULL)
         goto err;
 
-    p = s->ext.ocsp.resp;
-    rsp = d2i_OCSP_RESPONSE(NULL, &p, (int)s->ext.ocsp.resp_len);
-    if (rsp == NULL)
-        goto err;
-
-    br = OCSP_response_get1_basic(rsp);
-    if (br == NULL)
-        goto err;
-
-    for (i = 0; i < OCSP_resp_count(br); ++i) {
-        OCSP_SINGLERESP *single = OCSP_resp_get0(br, i);
-
-        if (single == NULL)
-            continue;
-
-        scts =
-            OCSP_SINGLERESP_get1_ext_d2i(single, NID_ct_cert_scts, NULL, NULL);
-        scts_extracted =
-            ct_move_scts(&s->scts, scts, SCT_SOURCE_OCSP_STAPLED_RESPONSE);
-        if (scts_extracted < 0)
+    for (j=0; j<sk_OCSP_RESPONSE_num(s->ext.ocsp.resp); j++) {
+        rsp = sk_OCSP_RESPONSE_value(s->ext.ocsp.resp, j);
+        if (rsp == NULL)
             goto err;
+
+        br = OCSP_response_get1_basic(rsp);
+        if (br == NULL)
+            goto err;
+
+        for (i = 0; i < OCSP_resp_count(br); ++i) {
+            OCSP_SINGLERESP *single = OCSP_resp_get0(br, i);
+
+            if (single == NULL)
+                continue;
+
+            scts =
+                OCSP_SINGLERESP_get1_ext_d2i(single, NID_ct_cert_scts, NULL, NULL);
+            scts_extracted =
+                ct_move_scts(&s->scts, scts, SCT_SOURCE_OCSP_STAPLED_RESPONSE);
+            if (scts_extracted < 0)
+                goto err;
+        }
     }
  err:
     SCT_LIST_free(scts);
     OCSP_BASICRESP_free(br);
-    OCSP_RESPONSE_free(rsp);
     return scts_extracted;
 # else
     /* Behave as if no OCSP response exists */

--- a/ssl/ssl_local.h
+++ b/ssl/ssl_local.h
@@ -27,6 +27,7 @@
 # include <openssl/async.h>
 # include <openssl/symhacks.h>
 # include <openssl/ct.h>
+# include <openssl/ocsp.h>
 # include "record/record.h"
 # include "record/recordmethod.h"
 # include "statem/statem.h"
@@ -1620,8 +1621,7 @@ struct ssl_connection_st {
             STACK_OF(OCSP_RESPID) *ids;
             X509_EXTENSIONS *exts;
             /* OCSP response received or to be sent */
-            unsigned char *resp;
-            size_t resp_len;
+            STACK_OF(OCSP_RESPONSE) *resp;
         } ocsp;
 
         /* RFC4507 session ticket expected to be received or sent */
@@ -2506,6 +2506,7 @@ __owur int ssl_cert_set_current(CERT *c, long arg);
 void ssl_cert_set_cert_cb(CERT *c, int (*cb) (SSL *ssl, void *arg), void *arg);
 
 __owur int ssl_verify_cert_chain(SSL_CONNECTION *s, STACK_OF(X509) *sk);
+__owur int ssl_verify_ocsp(SSL *s, STACK_OF(X509) *sk);
 __owur int ssl_build_cert_chain(SSL_CONNECTION *s, SSL_CTX *ctx, int flags);
 __owur int ssl_cert_set_cert_store(CERT *c, X509_STORE *store, int chain,
                                    int ref);

--- a/ssl/statem/extensions.c
+++ b/ssl/statem/extensions.c
@@ -1089,7 +1089,6 @@ static int init_status_request(SSL_CONNECTION *s, unsigned int context)
          */
         OPENSSL_free(s->ext.ocsp.resp);
         s->ext.ocsp.resp = NULL;
-        s->ext.ocsp.resp_len = 0;
     }
 
     return 1;

--- a/ssl/statem/extensions_clnt.c
+++ b/ssl/statem/extensions_clnt.c
@@ -1443,14 +1443,8 @@ int tls_parse_stoc_status_request(SSL_CONNECTION *s, PACKET *pkt,
     }
 
     if (SSL_CONNECTION_IS_TLS13(s)) {
-        /* We only know how to handle this if it's for the first Certificate in
-         * the chain. We ignore any other responses.
-         */
-        if (chainidx != 0)
-            return 1;
-
         /* SSLfatal() already called */
-        return tls_process_cert_status_body(s, pkt);
+        return tls_process_cert_status_body(s, chainidx, pkt);
     }
 
     /* Set flag to expect CertificateStatus message */

--- a/ssl/statem/extensions_srvr.c
+++ b/ssl/statem/extensions_srvr.c
@@ -1429,9 +1429,7 @@ EXT_RETURN tls_construct_stoc_status_request(SSL_CONNECTION *s, WPACKET *pkt,
     if (!s->ext.status_expected)
         return EXT_RETURN_NOT_SENT;
 
-    if (SSL_CONNECTION_IS_TLS13(s) && chainidx != 0)
-        return EXT_RETURN_NOT_SENT;
-
+   
     if (!WPACKET_put_bytes_u16(pkt, TLSEXT_TYPE_status_request)
             || !WPACKET_start_sub_packet_u16(pkt)) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
@@ -1443,7 +1441,7 @@ EXT_RETURN tls_construct_stoc_status_request(SSL_CONNECTION *s, WPACKET *pkt,
      * send back an empty extension, with the certificate status appearing as a
      * separate message
      */
-    if (SSL_CONNECTION_IS_TLS13(s) && !tls_construct_cert_status_body(s, pkt)) {
+    if (SSL_CONNECTION_IS_TLS13(s) && !tls_construct_cert_status_body(s, chainidx, pkt)) {
        /* SSLfatal() already called */
        return EXT_RETURN_FAIL;
     }

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -27,6 +27,7 @@
 #include <openssl/core_names.h>
 #include <openssl/param_build.h>
 #include "internal/cryptlib.h"
+#include <openssl/ocsp.h>
 
 static MSG_PROCESS_RETURN tls_process_as_hello_retry_request(SSL_CONNECTION *s,
                                                              PACKET *pkt);
@@ -2657,31 +2658,51 @@ MSG_PROCESS_RETURN tls_process_new_session_ticket(SSL_CONNECTION *s,
  * In TLSv1.3 this is called from the extensions code, otherwise it is used to
  * parse a separate message. Returns 1 on success or 0 on failure
  */
-int tls_process_cert_status_body(SSL_CONNECTION *s, PACKET *pkt)
+int tls_process_cert_status_body(SSL_CONNECTION *s, size_t chainidx, PACKET *pkt)
 {
-    size_t resplen;
-    unsigned int type;
+    unsigned int type, resplen;
+    unsigned char* respder;
+    OCSP_RESPONSE *resp = NULL;
+    const unsigned char *p;
 
     if (!PACKET_get_1(pkt, &type)
         || type != TLSEXT_STATUSTYPE_ocsp) {
         SSLfatal(s, SSL_AD_DECODE_ERROR, SSL_R_UNSUPPORTED_STATUS_TYPE);
         return 0;
     }
-    if (!PACKET_get_net_3_len(pkt, &resplen)
-        || PACKET_remaining(pkt) != resplen) {
-        SSLfatal(s, SSL_AD_DECODE_ERROR, SSL_R_LENGTH_MISMATCH);
-        return 0;
+    if(s->ext.ocsp.resp == NULL) {
+        s->ext.ocsp.resp = sk_OCSP_RESPONSE_new_null();
     }
-    s->ext.ocsp.resp = OPENSSL_malloc(resplen);
-    if (s->ext.ocsp.resp == NULL) {
-        s->ext.ocsp.resp_len = 0;
-        SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_MALLOC_FAILURE);
-        return 0;
+    if (!SSL_CONNECTION_IS_TLS13(s) && type == TLSEXT_STATUSTYPE_ocsp) {
+        sk_OCSP_RESPONSE_pop_free(s->ext.ocsp.resp, OCSP_RESPONSE_free);
+        s->ext.ocsp.resp = sk_OCSP_RESPONSE_new_null();
     }
-    s->ext.ocsp.resp_len = resplen;
-    if (!PACKET_copy_bytes(pkt, s->ext.ocsp.resp, resplen)) {
-        SSLfatal(s, SSL_AD_DECODE_ERROR, SSL_R_LENGTH_MISMATCH);
-        return 0;
+    if (SSL_CONNECTION_IS_TLS13(s) || type == TLSEXT_STATUSTYPE_ocsp) {
+        if(PACKET_remaining(pkt) > 0) {
+            if (!PACKET_get_net_3_len(pkt, (size_t *)&resplen)
+                    || PACKET_remaining(pkt) != resplen) {
+                SSLfatal(s, SSL_AD_DECODE_ERROR, SSL_R_LENGTH_MISMATCH);
+                return 0;
+            }
+
+            if (resplen > 0) {
+                respder = OPENSSL_malloc(resplen);
+                if (!PACKET_copy_bytes(pkt, respder, resplen)) {
+                SSLfatal(s, SSL_AD_DECODE_ERROR, SSL_R_LENGTH_MISMATCH);
+                    return 0;
+                }
+                p = respder;
+                resp = d2i_OCSP_RESPONSE(NULL, &p, resplen);
+                if (resp == NULL) {
+                    
+                    SSLfatal(s, TLS1_AD_BAD_CERTIFICATE_STATUS_RESPONSE, 
+                    SSL_R_TLSV1_BAD_CERTIFICATE_STATUS_RESPONSE);
+                    return 0;
+                }
+                sk_OCSP_RESPONSE_insert(s->ext.ocsp.resp, resp, chainidx);
+                OPENSSL_free(respder);
+            }
+        }
     }
 
     return 1;
@@ -2690,7 +2711,7 @@ int tls_process_cert_status_body(SSL_CONNECTION *s, PACKET *pkt)
 
 MSG_PROCESS_RETURN tls_process_cert_status(SSL_CONNECTION *s, PACKET *pkt)
 {
-    if (!tls_process_cert_status_body(s, pkt)) {
+    if (!tls_process_cert_status_body(s, 0, pkt)) {
         /* SSLfatal() already called */
         return MSG_PROCESS_ERROR;
     }

--- a/ssl/statem/statem_local.h
+++ b/ssl/statem/statem_local.h
@@ -130,7 +130,7 @@ __owur MSG_PROCESS_RETURN tls_process_certificate_request(SSL_CONNECTION *s,
                                                           PACKET *pkt);
 __owur MSG_PROCESS_RETURN tls_process_new_session_ticket(SSL_CONNECTION *s,
                                                          PACKET *pkt);
-__owur int tls_process_cert_status_body(SSL_CONNECTION *s, PACKET *pkt);
+__owur int tls_process_cert_status_body(SSL_CONNECTION *s, size_t chainidx, PACKET *pkt);
 __owur MSG_PROCESS_RETURN tls_process_cert_status(SSL_CONNECTION *s,
                                                   PACKET *pkt);
 __owur MSG_PROCESS_RETURN tls_process_server_done(SSL_CONNECTION *s,
@@ -143,7 +143,7 @@ __owur int ssl_do_client_cert_cb(SSL_CONNECTION *s, X509 **px509,
                                  EVP_PKEY **ppkey);
 __owur int tls_construct_client_key_exchange(SSL_CONNECTION *s, WPACKET *pkt);
 __owur int tls_client_key_exchange_post_work(SSL_CONNECTION *s);
-__owur int tls_construct_cert_status_body(SSL_CONNECTION *s, WPACKET *pkt);
+__owur int tls_construct_cert_status_body(SSL_CONNECTION *s, size_t chainidx, WPACKET *pkt);
 __owur int tls_construct_cert_status(SSL_CONNECTION *s, WPACKET *pkt);
 __owur MSG_PROCESS_RETURN tls_process_key_exchange(SSL_CONNECTION *s,
                                                    PACKET *pkt);

--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -26,6 +26,7 @@
 #include <openssl/trace.h>
 #include <openssl/core_names.h>
 #include <openssl/asn1t.h>
+#include <openssl/ocsp.h>
 
 #define TICKET_NONCE_SIZE       8
 
@@ -4048,21 +4049,99 @@ int tls_construct_new_session_ticket(SSL_CONNECTION *s, WPACKET *pkt)
  * In TLSv1.3 this is called from the extensions code, otherwise it is used to
  * create a separate message. Returns 1 on success or 0 on failure.
  */
-int tls_construct_cert_status_body(SSL_CONNECTION *s, WPACKET *pkt)
+int tls_construct_cert_status_body(SSL_CONNECTION *s, size_t chainidx, WPACKET *pkt)
 {
-    if (!WPACKET_put_bytes_u8(pkt, s->ext.status_type)
-            || !WPACKET_sub_memcpy_u24(pkt, s->ext.ocsp.resp,
-                                       s->ext.ocsp.resp_len)) {
+    unsigned char *respder = NULL;
+    int resplen = 0;
+    int i = 0;
+    OCSP_RESPONSE *resp = NULL;
+    OCSP_BASICRESP *bs = NULL;
+    X509 *x = NULL;
+    X509 *issuer = NULL;
+    STACK_OF(X509) *server_certs = NULL;
+    OCSP_CERTID *cert_id = NULL;
+    SSL *ssl = SSL_CONNECTION_GET_SSL(s);
+    int found = 0;
+
+    if (!WPACKET_put_bytes_u8(pkt, s->ext.status_type)) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
         return 0;
     }
+
+    /* In TLSv1.3 the caller gives the index of the certificate for which the
+     * status message should be created.
+     * Prior to TLSv1.3 the chain index is 0 and the body should only the status
+     * of the server certificate itself.
+     */
+    x = SSL_get_certificate(ssl);
+
+    SSL_get0_chain_certs(ssl, &server_certs);
+    issuer = X509_find_by_subject(server_certs, X509_get_issuer_name(x));
+
+    if (server_certs != NULL) {
+        /*
+         * if the certificate chain was built, get the status message for the
+         * requested certificate specified by chainidx
+         * SSL_get0_chain_certs contains certificate chain except the server cert
+         * if chainidx = 0 the server certificate is request
+         * if chainidx > 0 an intermediate certificate is request
+         */
+        if((int)chainidx < sk_X509_num(server_certs)+1 && chainidx > 0) {
+            x = sk_X509_value(server_certs, chainidx-1);
+            issuer = X509_find_by_subject(server_certs, X509_get_issuer_name(x));
+        }
+
+        /* search the stack for the requested OCSP response */
+        cert_id = OCSP_cert_to_id(NULL, x, issuer);
+
+        /* find the correct OCSP response for the requested certificate */
+        found = 0;
+        for (i=0; i<sk_OCSP_RESPONSE_num(s->ext.ocsp.resp); i++) {
+            if ((resp = sk_OCSP_RESPONSE_value(s->ext.ocsp.resp, i)) == NULL)
+                continue;
+
+            if ((bs = OCSP_response_get1_basic(resp)) == NULL)
+                continue;
+
+            found = OCSP_resp_find(bs, cert_id, -1);
+
+            if (bs != NULL) OCSP_BASICRESP_free(bs);
+
+            if (found > -1)
+                break;
+        }
+        if(found < 0) resp = NULL;
+
+    } else if (chainidx == 0) {
+        /*
+         * if certificate chain was not built and only the response for the server
+         * certificate (chainidx=0) was requested, check if the stack contains an
+         * OCSP response and get the first one
+         * TODO: check if the first response on the stack is indeed the one for the
+         *       server certificate
+         */
+        if (sk_OCSP_RESPONSE_num(s->ext.ocsp.resp) > 0) {
+            resp = sk_OCSP_RESPONSE_value(s->ext.ocsp.resp, 0);
+        }
+    }
+
+    respder = NULL;
+    if (resp != NULL) {
+        resplen = i2d_OCSP_RESPONSE(resp, &respder);
+    }
+
+    if (!WPACKET_sub_memcpy_u24(pkt, respder, resplen)) {
+        SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
+        return 0;
+    }
+    if (respder != NULL) OPENSSL_free(respder);
 
     return 1;
 }
 
 int tls_construct_cert_status(SSL_CONNECTION *s, WPACKET *pkt)
 {
-    if (!tls_construct_cert_status_body(s, pkt)) {
+    if (!tls_construct_cert_status_body(s, 0, pkt)) {
         /* SSLfatal() already called */
         return 0;
     }

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5456,3 +5456,4 @@ BIO_meth_get_sendmmsg                   ?	3_1_0	EXIST::FUNCTION:
 BIO_meth_set_recvmmsg                   ?	3_1_0	EXIST::FUNCTION:
 BIO_meth_get_recvmmsg                   ?	3_1_0	EXIST::FUNCTION:
 BIO_err_is_non_fatal                    ?	3_1_0	EXIST::FUNCTION:SOCK
+X509_STORE_CTX_set_ocsp_resp            ?   3_1_0   EXIST::FUNCTION:


### PR DESCRIPTION
OCSP multistapling for TLSv1.3:

changed resp variable in the the ssl_struct from one DER encoded OCSP response to a stack of responses
server side: added function in s_server code for retrieving the OCSP responses from all certificates in the server cert chain
server side: added function in statem_srvr code to retrieve and return the response for the requested certificate
client side: added verify function for multiple OCSP responses

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
