### PR TITLE
Fix a typo in the X509_STORE_load_locations_ex documentation

### DIFF
--- a/doc/man3/X509_STORE_add_cert.pod
+++ b/doc/man3/X509_STORE_add_cert.pod
@@ -115,7 +115,7 @@ X509_STORE_load_store() is similar to X509_STORE_load_store_ex() but
 uses NULL for the library context I<libctx> and property query I<propq>.
 
 X509_STORE_load_locations_ex() combines
-X509_STORE_load_file_ex() and X509_STORE_load_dir() for a given file
+X509_STORE_load_file_ex() and X509_STORE_load_path() for a given file
 and/or directory path.
 It is permitted to specify just a file, just a directory, or both
 paths.


### PR DESCRIPTION
X509_STORE_load_locations_ex() calls X509_STORE_load_file_ex() and X509_STORE_load_path(), there's no such function name as X509_STORE_load_dir().

CLA: trivial