### PR TITLE
util/wrap.pl.in: Use parentheses so `kill` gets all its arguments

### DIFF
--- a/util/wrap.pl.in
+++ b/util/wrap.pl.in
@@ -69,7 +69,7 @@ die "wrap.pl: Failed to execute '", join(' ', @cmd), "': $!\n"
     if $waitcode == -1;
 
 # When the subprocess aborted on a signal, we simply raise the same signal.
-kill ($? & 255) => $$ if ($? & 255) != 0;
+kill(($? & 255) => $$) if ($? & 255) != 0;
 
 # If that didn't stop this script, mimic what Unix shells do, by
 # converting the signal code to an exit code by setting the high bit.


### PR DESCRIPTION
In perl, this may be ambiguous:

    fn (expr1), expr2

Is the comma (which may be `=>` just as well in this case) a separator
between arguments to `fn`, or is it the comma operator, separating the
expressions `fn(expr1)` and `expr2`?  It appears that in this particular
case, perl takes the existing parentheses to mean the latter.  When the
former was intended, extra parentheses are required.

Fixes #19209
