### PR TITLE
Fix incorrect clearing OPENSSL_ia32cap[2,3]

### DIFF
--- a/crypto/cpuid.c
+++ b/crypto/cpuid.c
@@ -139,9 +139,6 @@ void OPENSSL_cpuid_setup(void)
                 OPENSSL_ia32cap_P[2] = (unsigned int)vecx;
                 OPENSSL_ia32cap_P[3] = (unsigned int)(vecx >> 32);
             }
-        } else {
-            OPENSSL_ia32cap_P[2] = 0;
-            OPENSSL_ia32cap_P[3] = 0;
         }
     } else {
         vec = OPENSSL_ia32_cpuid(OPENSSL_ia32cap_P);


### PR DESCRIPTION
When exporting env OPENSSL_ia32cap to ~0x1000000000000000 for disabling AVX, OPENSSL_ia32cap[2] and OPENSSL_ia32cap[3] would be assigned to 0 incorrectly.

See also: https://www.openssl.org/docs/man1.1.1/man3/OPENSSL_ia32cap.html

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->