### PR TITLE
`OSSL_CMP_CTX_reinit()`: fix missing reset of `ctx->genm_ITAVs` and of `ctx->geninfo_ITAVs`

### DIFF
--- a/apps/lib/cmp_mock_srv.c
+++ b/apps/lib/cmp_mock_srv.c
@@ -324,7 +324,7 @@ static int process_genm(OSSL_CMP_SRV_CTX *srv_ctx,
         ERR_raise(ERR_LIB_CMP, CMP_R_NULL_ARGUMENT);
         return 0;
     }
-    if (ctx->sendError) {
+    if (sk_OSSL_CMP_ITAV_num(in) > 1 || ctx->sendError) {
         ERR_raise(ERR_LIB_CMP, CMP_R_ERROR_PROCESSING_MESSAGE);
         return 0;
     }

--- a/crypto/cmp/cmp_ctx.c
+++ b/crypto/cmp/cmp_ctx.c
@@ -517,6 +517,17 @@ int OSSL_CMP_CTX_push0_geninfo_ITAV(OSSL_CMP_CTX *ctx, OSSL_CMP_ITAV *itav)
     return OSSL_CMP_ITAV_push0_stack_item(&ctx->geninfo_ITAVs, itav);
 }
 
+int OSSL_CMP_CTX_reset_geninfo_ITAVs(OSSL_CMP_CTX *ctx)
+{
+    if (ctx == NULL) {
+        ERR_raise(ERR_LIB_CMP, CMP_R_NULL_ARGUMENT);
+        return 0;
+    }
+    OSSL_CMP_ITAVs_free(ctx->geninfo_ITAVs);
+    ctx->geninfo_ITAVs = NULL;
+    return 1;
+}
+
 /* Add an itav for the body of outgoing general messages */
 int OSSL_CMP_CTX_push0_genm_ITAV(OSSL_CMP_CTX *ctx, OSSL_CMP_ITAV *itav)
 {

--- a/crypto/cmp/cmp_ctx.c
+++ b/crypto/cmp/cmp_ctx.c
@@ -148,6 +148,13 @@ OSSL_CMP_CTX *OSSL_CMP_CTX_new(OSSL_LIB_CTX *libctx, const char *propq)
     return NULL;
 }
 
+#define OSSL_CMP_ITAVs_free(itavs) \
+    sk_OSSL_CMP_ITAV_pop_free(itavs, OSSL_CMP_ITAV_free);
+#define X509_EXTENSIONS_free(exts) \
+    sk_X509_EXTENSION_pop_free(exts, X509_EXTENSION_free)
+#define OSSL_CMP_PKIFREETEXT_free(text) \
+    sk_ASN1_UTF8STRING_pop_free(text, ASN1_UTF8STRING_free)
+
 /* Prepare the OSSL_CMP_CTX for next use, partly re-initializing OSSL_CMP_CTX */
 int OSSL_CMP_CTX_reinit(OSSL_CMP_CTX *ctx)
 {
@@ -164,6 +171,9 @@ int OSSL_CMP_CTX_reinit(OSSL_CMP_CTX *ctx)
     ctx->status = -1;
     ctx->failInfoCode = -1;
 
+    OSSL_CMP_ITAVs_free(ctx->genm_ITAVs);
+    ctx->genm_ITAVs = NULL;
+
     return ossl_cmp_ctx_set0_statusString(ctx, NULL)
         && ossl_cmp_ctx_set0_newCert(ctx, NULL)
         && ossl_cmp_ctx_set1_newChain(ctx, NULL)
@@ -174,13 +184,6 @@ int OSSL_CMP_CTX_reinit(OSSL_CMP_CTX *ctx)
         && OSSL_CMP_CTX_set1_senderNonce(ctx, NULL)
         && ossl_cmp_ctx_set1_recipNonce(ctx, NULL);
 }
-
-#define OSSL_CMP_ITAVs_free(itavs) \
-    sk_OSSL_CMP_ITAV_pop_free(itavs, OSSL_CMP_ITAV_free);
-#define X509_EXTENSIONS_free(exts) \
-    sk_X509_EXTENSION_pop_free(exts, X509_EXTENSION_free)
-#define OSSL_CMP_PKIFREETEXT_free(text) \
-    sk_ASN1_UTF8STRING_pop_free(text, ASN1_UTF8STRING_free)
 
 /* Frees OSSL_CMP_CTX variables allocated in OSSL_CMP_CTX_new() */
 void OSSL_CMP_CTX_free(OSSL_CMP_CTX *ctx)

--- a/crypto/cmp/cmp_msg.c
+++ b/crypto/cmp/cmp_msg.c
@@ -700,8 +700,7 @@ static OSSL_CMP_MSG *gen_new(OSSL_CMP_CTX *ctx,
     if ((msg = ossl_cmp_msg_create(ctx, body_type)) == NULL)
         return NULL;
 
-    if (ctx->genm_ITAVs != NULL
-            && !ossl_cmp_msg_gen_push1_ITAVs(msg, itavs))
+    if (itavs != NULL && !ossl_cmp_msg_gen_push1_ITAVs(msg, itavs))
         goto err;
 
     if (!ossl_cmp_msg_protect(ctx, msg))

--- a/doc/man3/OSSL_CMP_CTX_new.pod
+++ b/doc/man3/OSSL_CMP_CTX_new.pod
@@ -188,6 +188,7 @@ OSSL_CMP_CTX_reinit() prepares the given I<ctx> for a further transaction by
 clearing the internal CMP transaction (aka session) status, PKIStatusInfo,
 and any previous results (newCert, newChain, caPubs, and extraCertsIn)
 from the last executed transaction.
+It also clears any ITAVs that were added by OSSL_CMP_CTX_push0_genm_ITAV().
 All other field values (i.e., CMP options) are retained for potential re-use.
 
 OSSL_CMP_CTX_get0_libctx() returns the I<libctx> argument that was used
@@ -710,7 +711,8 @@ OSSL_CMP_certConf_cb() returns I<fail_info> if it is not equal to 0,
 else 0 on successful validation,
 or else a bit field with the B<OSSL_CMP_PKIFAILUREINFO_incorrectData> bit set.
 
-All other functions return 1 on success, 0 on error.
+All other functions, including OSSL_CMP_CTX_reinit(),
+return 1 on success, 0 on error.
 
 =head1 EXAMPLES
 
@@ -766,7 +768,7 @@ the id-it-signKeyPairTypes OID and prints info on the General Response contents:
     OSSL_CMP_CTX_reinit(cmp_ctx);
 
     ASN1_OBJECT *type = OBJ_txt2obj("1.3.6.1.5.5.7.4.2", 1);
-    OSSL_CMP_ITAV *itav = OSSL_CMP_ITAV_new(type, NULL);
+    OSSL_CMP_ITAV *itav = OSSL_CMP_ITAV_create(type, NULL);
     OSSL_CMP_CTX_push0_genm_ITAV(cmp_ctx, itav);
 
     STACK_OF(OSSL_CMP_ITAV) *itavs;

--- a/doc/man3/OSSL_CMP_CTX_new.pod
+++ b/doc/man3/OSSL_CMP_CTX_new.pod
@@ -38,6 +38,7 @@ OSSL_CMP_CTX_set1_referenceValue,
 OSSL_CMP_CTX_set1_secretValue,
 OSSL_CMP_CTX_set1_recipient,
 OSSL_CMP_CTX_push0_geninfo_ITAV,
+OSSL_CMP_CTX_reset_geninfo_ITAVs,
 OSSL_CMP_CTX_set1_extraCertsOut,
 OSSL_CMP_CTX_set0_newPkey,
 OSSL_CMP_CTX_get0_newPkey,
@@ -124,6 +125,7 @@ OSSL_CMP_CTX_set1_senderNonce
  /* CMP message header and extra certificates: */
  int OSSL_CMP_CTX_set1_recipient(OSSL_CMP_CTX *ctx, const X509_NAME *name);
  int OSSL_CMP_CTX_push0_geninfo_ITAV(OSSL_CMP_CTX *ctx, OSSL_CMP_ITAV *itav);
+ int OSSL_CMP_CTX_reset_geninfo_ITAVs(OSSL_CMP_CTX *ctx);
  int OSSL_CMP_CTX_set1_extraCertsOut(OSSL_CMP_CTX *ctx,
                                      STACK_OF(X509) *extraCertsOut);
 
@@ -530,6 +532,9 @@ OSSL_CMP_CTX_push0_geninfo_ITAV() adds I<itav> to the stack in the I<ctx> to be
 added to the GeneralInfo field of the CMP PKIMessage header of a request
 message sent with this context.
 
+OSSL_CMP_CTX_reset_geninfo_ITAVs()
+clears any ITAVs that were added by OSSL_CMP_CTX_push0_geninfo_ITAV().
+
 OSSL_CMP_CTX_set1_extraCertsOut() sets the stack of extraCerts that will be
 sent to remote.
 
@@ -711,7 +716,8 @@ OSSL_CMP_certConf_cb() returns I<fail_info> if it is not equal to 0,
 else 0 on successful validation,
 or else a bit field with the B<OSSL_CMP_PKIFAILUREINFO_incorrectData> bit set.
 
-All other functions, including OSSL_CMP_CTX_reinit(),
+All other functions, including OSSL_CMP_CTX_reinit()
+and OSSL_CMP_CTX_reset_geninfo_ITAVs(),
 return 1 on success, 0 on error.
 
 =head1 EXAMPLES
@@ -791,6 +797,8 @@ OSSL_CMP_CTX_get0_trustedStore() was renamed to OSSL_CMP_CTX_get0_trusted() and
 OSSL_CMP_CTX_set0_trustedStore() was renamed to OSSL_CMP_CTX_set0_trusted(),
 using macros, while keeping the old names for backward compatibility,
 in OpenSSL 3.2.
+
+OSSL_CMP_CTX_reset_geninfo_ITAVs() was added in OpenSSL 3.0.8.
 
 OSSL_CMP_CTX_get0_libctx(), OSSL_CMP_CTX_get0_propq(), and
 OSSL_CMP_CTX_get0_validatedSrvCert() were added in OpenSSL 3.2.

--- a/include/openssl/cmp.h.in
+++ b/include/openssl/cmp.h.in
@@ -331,6 +331,7 @@ int OSSL_CMP_CTX_set1_secretValue(OSSL_CMP_CTX *ctx, const unsigned char *sec,
 /* CMP message header and extra certificates: */
 int OSSL_CMP_CTX_set1_recipient(OSSL_CMP_CTX *ctx, const X509_NAME *name);
 int OSSL_CMP_CTX_push0_geninfo_ITAV(OSSL_CMP_CTX *ctx, OSSL_CMP_ITAV *itav);
+int OSSL_CMP_CTX_reset_geninfo_ITAVs(OSSL_CMP_CTX *ctx);
 int OSSL_CMP_CTX_set1_extraCertsOut(OSSL_CMP_CTX *ctx,
                                     STACK_OF(X509) *extraCertsOut);
 /* certificate template: */

--- a/test/cmp_client_test.c
+++ b/test/cmp_client_test.c
@@ -94,13 +94,25 @@ static int execute_exec_RR_ses_test(CMP_SES_TEST_FIXTURE *fixture)
                        OSSL_CMP_exec_RR_ses(fixture->cmp_ctx) == 1);
 }
 
-static int execute_exec_GENM_ses_test(CMP_SES_TEST_FIXTURE *fixture)
+static int execute_exec_GENM_ses_test_single(CMP_SES_TEST_FIXTURE *fixture)
 {
-    STACK_OF(OSSL_CMP_ITAV) *itavs = NULL;
+    ASN1_OBJECT *type = OBJ_txt2obj("1.3.6.1.5.5.7.4.2", 1);
+    OSSL_CMP_ITAV *itav = OSSL_CMP_ITAV_create(type, NULL);
+    STACK_OF(OSSL_CMP_ITAV) *itavs;
+
+    OSSL_CMP_CTX_push0_genm_ITAV(fixture->cmp_ctx, itav);
+
     if (!TEST_ptr(itavs = OSSL_CMP_exec_GENM_ses(fixture->cmp_ctx)))
         return 0;
     sk_OSSL_CMP_ITAV_pop_free(itavs, OSSL_CMP_ITAV_free);
     return 1;
+}
+
+static int execute_exec_GENM_ses_test(CMP_SES_TEST_FIXTURE *fixture)
+{
+    return execute_exec_GENM_ses_test_single(fixture)
+        && OSSL_CMP_CTX_reinit(fixture->cmp_ctx)
+        && execute_exec_GENM_ses_test_single(fixture);
 }
 
 static int execute_exec_certrequest_ses_test(CMP_SES_TEST_FIXTURE *fixture)

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5446,6 +5446,7 @@ ASYNC_get_mem_functions                 ?	3_2_0	EXIST::FUNCTION:
 BIO_ADDR_dup                            ?	3_2_0	EXIST::FUNCTION:SOCK
 OSSL_CMP_CTX_get0_libctx                ?	3_2_0	EXIST::FUNCTION:CMP
 OSSL_CMP_CTX_get0_propq                 ?	3_2_0	EXIST::FUNCTION:CMP
+OSSL_CMP_CTX_reset_geninfo_ITAVs        ?	3_0_8	EXIST::FUNCTION:CMP
 OSSL_CMP_CTX_get0_validatedSrvCert      ?	3_2_0	EXIST::FUNCTION:CMP
 OSSL_CRMF_CERTTEMPLATE_get0_publicKey   ?	3_2_0	EXIST::FUNCTION:CRMF
 CMS_final_digest                        ?	3_2_0	EXIST::FUNCTION:CMS


### PR DESCRIPTION
Otherwise, further `OSSL_CMP_exec_GENM_ses()` calls go wrong.

