### PR TITLE
Convert the SSLv3/TLSv1.0/1.1/1.2 crypto code to use the new write record layer

### DIFF
--- a/ssl/record/methods/dtls_meth.c
+++ b/ssl/record/methods/dtls_meth.c
@@ -237,7 +237,7 @@ static int dtls_process_record(OSSL_RECORD_LAYER *rl, DTLS_BITMAP *bitmap)
     }
 
     /* r->length is now just compressed */
-    if (rl->expand != NULL) {
+    if (rl->compctx != NULL) {
         if (rr->length > SSL3_RT_MAX_COMPRESSED_LENGTH) {
             RLAYERfatal(rl, SSL_AD_RECORD_OVERFLOW,
                         SSL_R_COMPRESSED_LENGTH_TOO_LONG);

--- a/ssl/record/methods/dtls_meth.c
+++ b/ssl/record/methods/dtls_meth.c
@@ -628,7 +628,7 @@ dtls_new_record_layer(OSSL_LIB_CTX *libctx, const char *propq, int vers,
                       size_t ivlen, unsigned char *mackey, size_t mackeylen,
                       const EVP_CIPHER *ciph, size_t taglen,
                       int mactype,
-                      const EVP_MD *md, const SSL_COMP *comp, BIO *prev,
+                      const EVP_MD *md, COMP_METHOD *comp, BIO *prev,
                       BIO *transport, BIO *next, BIO_ADDR *local, BIO_ADDR *peer,
                       const OSSL_PARAM *settings, const OSSL_PARAM *options,
                       const OSSL_DISPATCH *fns, void *cbarg,
@@ -712,5 +712,6 @@ const OSSL_RECORD_METHOD ossl_dtls_record_method = {
     tls_set_max_pipelines,
     dtls_set_in_init,
     tls_get_state,
-    tls_set_options
+    tls_set_options,
+    tls_get_compression
 };

--- a/ssl/record/methods/ktls_meth.c
+++ b/ssl/record/methods/ktls_meth.c
@@ -375,7 +375,7 @@ static int ktls_set_crypto_state(OSSL_RECORD_LAYER *rl, int level,
                                  size_t taglen,
                                  int mactype,
                                  const EVP_MD *md,
-                                 const SSL_COMP *comp)
+                                 COMP_METHOD *comp)
 {
     ktls_crypto_info_t crypto_info;
 
@@ -499,7 +499,7 @@ ktls_new_record_layer(OSSL_LIB_CTX *libctx, const char *propq, int vers,
                       size_t ivlen, unsigned char *mackey, size_t mackeylen,
                       const EVP_CIPHER *ciph, size_t taglen,
                       int mactype,
-                      const EVP_MD *md, const SSL_COMP *comp, BIO *prev,
+                      const EVP_MD *md, COMP_METHOD *comp, BIO *prev,
                       BIO *transport, BIO *next, BIO_ADDR *local, BIO_ADDR *peer,
                       const OSSL_PARAM *settings, const OSSL_PARAM *options,
                       const OSSL_DISPATCH *fns, void *cbarg,
@@ -520,10 +520,11 @@ ktls_new_record_layer(OSSL_LIB_CTX *libctx, const char *propq, int vers,
 
     /*
      * TODO(RECLAYER): We're not ready to set the crypto state for the write
-     * record layer. Fix this once we are
+     * record layer in TLSv1.3. Fix this once we are
      */
-    if (direction == OSSL_RECORD_DIRECTION_WRITE)
+    if (direction == OSSL_RECORD_DIRECTION_WRITE && vers == TLS1_3_VERSION)
         return 1;
+
     ret = (*retrl)->funcs->set_crypto_state(*retrl, level, key, keylen, iv,
                                             ivlen, mackey, mackeylen, ciph,
                                             taglen, mactype, md, comp);
@@ -563,5 +564,6 @@ const OSSL_RECORD_METHOD ossl_ktls_record_method = {
     tls_set_max_pipelines,
     NULL,
     tls_get_state,
-    tls_set_options
+    tls_set_options,
+    tls_get_compression
 };

--- a/ssl/record/methods/recmethod_local.h
+++ b/ssl/record/methods/recmethod_local.h
@@ -160,11 +160,14 @@ struct ossl_record_layer_st
     /* cryptographic state */
     EVP_CIPHER_CTX *enc_ctx;
 
+    /* Explicit IV length */
+    size_t eivlen;
+
     /* used for mac generation */
     EVP_MD_CTX *md_ctx;
 
-    /* uncompress */
-    COMP_CTX *expand;
+    /* compress/uncompress */
+    COMP_CTX *compctx;
 
     /* Set to 1 if this is the first handshake. 0 otherwise */
     int is_first_handshake;

--- a/ssl/record/methods/recmethod_local.h
+++ b/ssl/record/methods/recmethod_local.h
@@ -36,7 +36,7 @@ struct record_functions_st
                             size_t taglen,
                             int mactype,
                             const EVP_MD *md,
-                            const SSL_COMP *comp);
+                            COMP_METHOD *comp);
 
     /*
      * Returns:
@@ -295,7 +295,7 @@ tls_int_new_record_layer(OSSL_LIB_CTX *libctx, const char *propq, int vers,
                          unsigned char *mackey, size_t mackeylen,
                          const EVP_CIPHER *ciph, size_t taglen,
                          int mactype,
-                         const EVP_MD *md, const SSL_COMP *comp, BIO *prev,
+                         const EVP_MD *md, COMP_METHOD *comp, BIO *prev,
                          BIO *transport, BIO *next,
                          BIO_ADDR *local, BIO_ADDR *peer,
                          const OSSL_PARAM *settings, const OSSL_PARAM *options,
@@ -327,6 +327,7 @@ void tls_set_max_pipelines(OSSL_RECORD_LAYER *rl, size_t max_pipelines);
 void tls_get_state(OSSL_RECORD_LAYER *rl, const char **shortstr,
                    const char **longstr);
 int tls_set_options(OSSL_RECORD_LAYER *rl, const OSSL_PARAM *options);
+const COMP_METHOD *tls_get_compression(OSSL_RECORD_LAYER *rl);
 int tls_setup_read_buffer(OSSL_RECORD_LAYER *rl);
 int tls_setup_write_buffer(OSSL_RECORD_LAYER *rl, size_t numwpipes,
                            size_t firstlen, size_t nextlen);

--- a/ssl/record/methods/ssl3_meth.c
+++ b/ssl/record/methods/ssl3_meth.c
@@ -21,7 +21,7 @@ static int ssl3_set_crypto_state(OSSL_RECORD_LAYER *rl, int level,
                                  size_t taglen,
                                  int mactype,
                                  const EVP_MD *md,
-                                 const SSL_COMP *comp)
+                                 COMP_METHOD *comp)
 {
     EVP_CIPHER_CTX *ciph_ctx;
 
@@ -43,7 +43,7 @@ static int ssl3_set_crypto_state(OSSL_RECORD_LAYER *rl, int level,
     }
 #ifndef OPENSSL_NO_COMP
     if (comp != NULL) {
-        rl->compctx = COMP_CTX_new(comp->method);
+        rl->compctx = COMP_CTX_new(comp);
         if (rl->compctx == NULL) {
             ERR_raise(ERR_LIB_SSL, SSL_R_COMPRESSION_LIBRARY_ERROR);
             return OSSL_RECORD_RETURN_FATAL;

--- a/ssl/record/methods/ssl3_meth.c
+++ b/ssl/record/methods/ssl3_meth.c
@@ -43,8 +43,8 @@ static int ssl3_set_crypto_state(OSSL_RECORD_LAYER *rl, int level,
     }
 #ifndef OPENSSL_NO_COMP
     if (comp != NULL) {
-        rl->expand = COMP_CTX_new(comp->method);
-        if (rl->expand == NULL) {
+        rl->compctx = COMP_CTX_new(comp->method);
+        if (rl->compctx == NULL) {
             ERR_raise(ERR_LIB_SSL, SSL_R_COMPRESSION_LIBRARY_ERROR);
             return OSSL_RECORD_RETURN_FATAL;
         }

--- a/ssl/record/methods/tls13_meth.c
+++ b/ssl/record/methods/tls13_meth.c
@@ -21,7 +21,7 @@ static int tls13_set_crypto_state(OSSL_RECORD_LAYER *rl, int level,
                                   size_t taglen,
                                   int mactype,
                                   const EVP_MD *md,
-                                  const SSL_COMP *comp)
+                                  COMP_METHOD *comp)
 {
     EVP_CIPHER_CTX *ciph_ctx;
     int mode;

--- a/ssl/record/methods/tls1_meth.c
+++ b/ssl/record/methods/tls1_meth.c
@@ -22,7 +22,7 @@ static int tls1_set_crypto_state(OSSL_RECORD_LAYER *rl, int level,
                                  size_t taglen,
                                  int mactype,
                                  const EVP_MD *md,
-                                 const SSL_COMP *comp)
+                                 COMP_METHOD *comp)
 {
     EVP_CIPHER_CTX *ciph_ctx;
     EVP_PKEY *mac_key;
@@ -45,7 +45,7 @@ static int tls1_set_crypto_state(OSSL_RECORD_LAYER *rl, int level,
     }
 #ifndef OPENSSL_NO_COMP
     if (comp != NULL) {
-        rl->compctx = COMP_CTX_new(comp->method);
+        rl->compctx = COMP_CTX_new(comp);
         if (rl->compctx == NULL) {
             ERR_raise(ERR_LIB_SSL, SSL_R_COMPRESSION_LIBRARY_ERROR);
             return OSSL_RECORD_RETURN_FATAL;

--- a/ssl/record/methods/tls1_meth.c
+++ b/ssl/record/methods/tls1_meth.c
@@ -26,6 +26,7 @@ static int tls1_set_crypto_state(OSSL_RECORD_LAYER *rl, int level,
 {
     EVP_CIPHER_CTX *ciph_ctx;
     EVP_PKEY *mac_key;
+    int enc = (rl->direction == OSSL_RECORD_DIRECTION_WRITE) ? 1 : 0;
 
     if (level != OSSL_RECORD_PROTECTION_LEVEL_APPLICATION)
         return OSSL_RECORD_RETURN_FATAL;
@@ -44,8 +45,8 @@ static int tls1_set_crypto_state(OSSL_RECORD_LAYER *rl, int level,
     }
 #ifndef OPENSSL_NO_COMP
     if (comp != NULL) {
-        rl->expand = COMP_CTX_new(comp->method);
-        if (rl->expand == NULL) {
+        rl->compctx = COMP_CTX_new(comp->method);
+        if (rl->compctx == NULL) {
             ERR_raise(ERR_LIB_SSL, SSL_R_COMPRESSION_LIBRARY_ERROR);
             return OSSL_RECORD_RETURN_FATAL;
         }
@@ -82,26 +83,26 @@ static int tls1_set_crypto_state(OSSL_RECORD_LAYER *rl, int level,
     }
 
     if (EVP_CIPHER_get_mode(ciph) == EVP_CIPH_GCM_MODE) {
-        if (!EVP_DecryptInit_ex(ciph_ctx, ciph, NULL, key, NULL)
+        if (!EVP_CipherInit_ex(ciph_ctx, ciph, NULL, key, NULL, enc)
                 || EVP_CIPHER_CTX_ctrl(ciph_ctx, EVP_CTRL_GCM_SET_IV_FIXED,
                                        (int)ivlen, iv) <= 0) {
             ERR_raise(ERR_LIB_SSL, ERR_R_INTERNAL_ERROR);
             return OSSL_RECORD_RETURN_FATAL;
         }
     } else if (EVP_CIPHER_get_mode(ciph) == EVP_CIPH_CCM_MODE) {
-        if (!EVP_DecryptInit_ex(ciph_ctx, ciph, NULL, NULL, NULL)
+        if (!EVP_CipherInit_ex(ciph_ctx, ciph, NULL, NULL, NULL, enc)
                 || EVP_CIPHER_CTX_ctrl(ciph_ctx, EVP_CTRL_AEAD_SET_IVLEN, 12,
                                        NULL) <= 0
                 || EVP_CIPHER_CTX_ctrl(ciph_ctx, EVP_CTRL_AEAD_SET_TAG,
                                        (int)taglen, NULL) <= 0
                 || EVP_CIPHER_CTX_ctrl(ciph_ctx, EVP_CTRL_CCM_SET_IV_FIXED,
                                        (int)ivlen, iv) <= 0
-                || !EVP_DecryptInit_ex(ciph_ctx, NULL, NULL, key, NULL)) {
+                || !EVP_CipherInit_ex(ciph_ctx, NULL, NULL, key, NULL, enc)) {
             ERR_raise(ERR_LIB_SSL, ERR_R_INTERNAL_ERROR);
             return OSSL_RECORD_RETURN_FATAL;
         }
     } else {
-        if (!EVP_DecryptInit_ex(ciph_ctx, ciph, NULL, key, iv)) {
+        if (!EVP_CipherInit_ex(ciph_ctx, ciph, NULL, key, iv, enc)) {
             ERR_raise(ERR_LIB_SSL, ERR_R_INTERNAL_ERROR);
             return OSSL_RECORD_RETURN_FATAL;
         }
@@ -117,6 +118,29 @@ static int tls1_set_crypto_state(OSSL_RECORD_LAYER *rl, int level,
     if (EVP_CIPHER_get0_provider(ciph) != NULL
             && !ossl_set_tls_provider_parameters(rl, ciph_ctx, ciph, md))
         return OSSL_RECORD_RETURN_FATAL;
+
+    /* Calculate the explict IV length */
+    if (RLAYER_USE_EXPLICIT_IV(rl)) {
+        int mode = EVP_CIPHER_CTX_get_mode(ciph_ctx);
+        int eivlen = 0;
+
+        if (mode == EVP_CIPH_CBC_MODE) {
+            eivlen = EVP_CIPHER_CTX_get_iv_length(ciph_ctx);
+            if (eivlen < 0) {
+                RLAYERfatal(rl, SSL_AD_INTERNAL_ERROR, SSL_R_LIBRARY_BUG);
+               return OSSL_RECORD_RETURN_FATAL;
+
+            }
+            if (eivlen <= 1)
+                eivlen = 0;
+        } else if (mode == EVP_CIPH_GCM_MODE) {
+            /* Need explicit part of IV for GCM mode */
+            eivlen = EVP_GCM_TLS_EXPLICIT_IV_LEN;
+        } else if (mode == EVP_CIPH_CCM_MODE) {
+            eivlen = EVP_CCM_TLS_EXPLICIT_IV_LEN;
+        }
+        rl->eivlen = (size_t)eivlen;
+    }
 
     return OSSL_RECORD_RETURN_SUCCESS;
 }

--- a/ssl/record/methods/tls1_meth.c
+++ b/ssl/record/methods/tls1_meth.c
@@ -128,8 +128,7 @@ static int tls1_set_crypto_state(OSSL_RECORD_LAYER *rl, int level,
             eivlen = EVP_CIPHER_CTX_get_iv_length(ciph_ctx);
             if (eivlen < 0) {
                 RLAYERfatal(rl, SSL_AD_INTERNAL_ERROR, SSL_R_LIBRARY_BUG);
-               return OSSL_RECORD_RETURN_FATAL;
-
+                return OSSL_RECORD_RETURN_FATAL;
             }
             if (eivlen <= 1)
                 eivlen = 0;

--- a/ssl/record/methods/tls_common.c
+++ b/ssl/record/methods/tls_common.c
@@ -159,7 +159,7 @@ int tls_setup_write_buffer(OSSL_RECORD_LAYER *rl, size_t numwpipes,
         defltlen = ssl_get_max_send_fragment(s)
             + SSL3_RT_SEND_MAX_ENCRYPTED_OVERHEAD + headerlen + align;
 #ifndef OPENSSL_NO_COMP
-        if (ssl_allow_compression(s))
+        if (tls_allow_compression(rl))
             defltlen += SSL3_RT_MAX_COMPRESSED_OVERHEAD;
 #endif
         if (!(rl->options & SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS))
@@ -968,7 +968,7 @@ int tls_default_validate_record_header(OSSL_RECORD_LAYER *rl, SSL3_RECORD *rec)
      * If OPENSSL_NO_COMP is defined then SSL3_RT_MAX_ENCRYPTED_LENGTH
      * does not include the compression overhead anyway.
      */
-    if (rl->expand == NULL)
+    if (rl->compctx == NULL)
         len -= SSL3_RT_MAX_COMPRESSED_OVERHEAD;
 #endif
 
@@ -978,6 +978,24 @@ int tls_default_validate_record_header(OSSL_RECORD_LAYER *rl, SSL3_RECORD *rec)
         return 0;
     }
 
+    return 1;
+}
+
+static int tls_do_compress(OSSL_RECORD_LAYER *rl, SSL3_RECORD *wr)
+{
+#ifndef OPENSSL_NO_COMP
+    int i;
+
+    i = COMP_compress_block(rl->compctx, wr->data,
+                            (int)(wr->length + SSL3_RT_MAX_COMPRESSED_OVERHEAD),
+                            wr->input, (int)wr->length);
+    if (i < 0)
+        return 0;
+    else
+        wr->length = i;
+
+    wr->input = wr->data;
+#endif
     return 1;
 }
 
@@ -993,7 +1011,7 @@ int tls_do_uncompress(OSSL_RECORD_LAYER *rl, SSL3_RECORD *rec)
     if (rec->comp == NULL)
         return 0;
 
-    i = COMP_expand_block(rl->expand, rec->comp, SSL3_RT_MAX_PLAIN_LENGTH,
+    i = COMP_expand_block(rl->compctx, rec->comp, SSL3_RT_MAX_PLAIN_LENGTH,
                           rec->data, (int)rec->length);
     if (i < 0)
         return 0;
@@ -1009,7 +1027,7 @@ int tls_do_uncompress(OSSL_RECORD_LAYER *rl, SSL3_RECORD *rec)
 /* Shared by tlsany_meth, ssl3_meth and tls1_meth */
 int tls_default_post_process_record(OSSL_RECORD_LAYER *rl, SSL3_RECORD *rec)
 {
-    if (rl->expand != NULL) {
+    if (rl->compctx != NULL) {
         if (rec->length > SSL3_RT_MAX_COMPRESSED_LENGTH) {
             RLAYERfatal(rl, SSL_AD_RECORD_OVERFLOW,
                         SSL_R_COMPRESSED_LENGTH_TOO_LONG);
@@ -1373,7 +1391,7 @@ static void tls_int_free(OSSL_RECORD_LAYER *rl)
     EVP_CIPHER_CTX_free(rl->enc_ctx);
     EVP_MD_CTX_free(rl->md_ctx);
 #ifndef OPENSSL_NO_COMP
-    COMP_CTX_free(rl->expand);
+    COMP_CTX_free(rl->compctx);
 #endif
 
     if (rl->version == SSL3_VERSION)
@@ -1490,11 +1508,9 @@ int tls_write_records_default(OSSL_RECORD_LAYER *rl,
     WPACKET *thispkt;
     SSL3_RECORD *thiswr;
     unsigned char *recordstart;
-    int mac_size, clear = 0, ret = 0;
-    int eivlen = 0;
+    int mac_size = 0, ret = 0;
     size_t align = 0;
     SSL3_BUFFER *wb;
-    SSL_SESSION *sess;
     size_t len, wpinited = 0;
     size_t j, prefix = 0;
     int using_ktls;
@@ -1504,28 +1520,37 @@ int tls_write_records_default(OSSL_RECORD_LAYER *rl,
     OSSL_RECORD_TEMPLATE prefixtempl;
     OSSL_RECORD_TEMPLATE *thistempl;
 
-    sess = s->session;
+    /*
+     * TODO(RECLAYER): Remove this once SSLv3/TLSv1.3/DTLS crypto has
+     *                 been moved to the new write record layer.
+     */
+    if (rl->version == SSL3_VERSION
+            || rl->version == TLS1_3_VERSION
+            || rl->isdtls) {
+        SSL_SESSION *sess = s->session;
 
-    if ((sess == NULL)
-            || (s->enc_write_ctx == NULL)
-            || (EVP_MD_CTX_get0_md(s->write_hash) == NULL)) {
-        clear = s->enc_write_ctx ? 0 : 1; /* must be AEAD cipher */
-        mac_size = 0;
+        if ((sess == NULL)
+                || (s->enc_write_ctx == NULL)
+                || (EVP_MD_CTX_get0_md(s->write_hash) == NULL)) {
+            mac_size = 0;
+        } else {
+            mac_size = EVP_MD_CTX_get_size(s->write_hash);
+            if (mac_size < 0) {
+                RLAYERfatal(rl, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
+                goto err;
+            }
+        }
     } else {
-        mac_size = EVP_MD_CTX_get_size(s->write_hash);
-        if (mac_size < 0) {
-            RLAYERfatal(rl, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
-            goto err;
+        if (rl->md_ctx != NULL && EVP_MD_CTX_get0_md(rl->md_ctx) != NULL) {
+            mac_size = EVP_MD_CTX_get_size(rl->md_ctx);
+            if (mac_size < 0) {
+                RLAYERfatal(rl, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
+                goto err;
+            }
         }
     }
-
-    /*
-     * 'create_empty_fragment' is true only when we have recursively called
-     * ourselves.
-     * Do we need to do that recursion in order to add an empty record prefix?
-     */
+    /* Do we need to add an empty record prefix? */
     prefix = rl->need_empty_fragments
-             && !clear
              && templates[0].type == SSL3_RT_APPLICATION_DATA;
 
     /*
@@ -1603,28 +1628,6 @@ int tls_write_records_default(OSSL_RECORD_LAYER *rl,
         }
     }
 
-    if (!using_ktls) {
-        /* Explicit IV length, block ciphers appropriate version flag */
-        if (s->enc_write_ctx != NULL && RLAYER_USE_EXPLICIT_IV(rl)
-            && rl->version != TLS1_3_VERSION) {
-            int mode = EVP_CIPHER_CTX_get_mode(s->enc_write_ctx);
-            if (mode == EVP_CIPH_CBC_MODE) {
-                eivlen = EVP_CIPHER_CTX_get_iv_length(s->enc_write_ctx);
-                if (eivlen < 0) {
-                    RLAYERfatal(rl, SSL_AD_INTERNAL_ERROR, SSL_R_LIBRARY_BUG);
-                    goto err;
-                }
-                if (eivlen <= 1)
-                    eivlen = 0;
-            } else if (mode == EVP_CIPH_GCM_MODE) {
-                /* Need explicit part of IV for GCM mode */
-                eivlen = EVP_GCM_TLS_EXPLICIT_IV_LEN;
-            } else if (mode == EVP_CIPH_CCM_MODE) {
-                eivlen = EVP_CCM_TLS_EXPLICIT_IV_LEN;
-            }
-        }
-    }
-
     /* Clear our SSL3_RECORD structures */
     memset(wr, 0, sizeof(wr));
     for (j = 0; j < numtempl + prefix; j++) {
@@ -1653,7 +1656,7 @@ int tls_write_records_default(OSSL_RECORD_LAYER *rl,
         SSL3_RECORD_set_rec_version(thiswr, thistempl->version);
 
         maxcomplen = thistempl->buflen;
-        if (s->compress != NULL)
+        if (rl->compctx != NULL)
             maxcomplen += SSL3_RT_MAX_COMPRESSED_OVERHEAD;
 
         /*
@@ -1664,8 +1667,8 @@ int tls_write_records_default(OSSL_RECORD_LAYER *rl,
                 && (!WPACKET_put_bytes_u8(thispkt, rectype)
                 || !WPACKET_put_bytes_u16(thispkt, thistempl->version)
                 || !WPACKET_start_sub_packet_u16(thispkt)
-                || (eivlen > 0
-                    && !WPACKET_allocate_bytes(thispkt, eivlen, NULL))
+                || (rl->eivlen > 0
+                    && !WPACKET_allocate_bytes(thispkt, rl->eivlen, NULL))
                 || (maxcomplen > 0
                     && !WPACKET_reserve_bytes(thispkt, maxcomplen,
                                               &compressdata)))) {
@@ -1685,8 +1688,8 @@ int tls_write_records_default(OSSL_RECORD_LAYER *rl,
          */
 
         /* first we compress */
-        if (s->compress != NULL) {
-            if (!ssl3_do_compress(s, thiswr)
+        if (rl->compctx != NULL) {
+            if (!tls_do_compress(rl, thiswr)
                     || !WPACKET_allocate_bytes(thispkt, thiswr->length, NULL)) {
                 RLAYERfatal(rl, SSL_AD_INTERNAL_ERROR, SSL_R_COMPRESSION_FAILURE);
                 goto err;
@@ -1763,10 +1766,24 @@ int tls_write_records_default(OSSL_RECORD_LAYER *rl,
         if (!using_ktls && !rl->use_etm && mac_size != 0) {
             unsigned char *mac;
 
-            if (!WPACKET_allocate_bytes(thispkt, mac_size, &mac)
-                    || !ssl->method->ssl3_enc->mac(s, thiswr, mac, 1)) {
-                RLAYERfatal(rl, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
-                goto err;
+            /*
+             * TODO(RECLAYER): Remove this once SSLv3/TLSv1.3/DTLS crypto has
+             *                 been moved to the new write record layer.
+             */
+            if (rl->version == SSL3_VERSION
+                    || rl->version == TLS1_3_VERSION
+                    || rl->isdtls) {
+                if (!WPACKET_allocate_bytes(thispkt, mac_size, &mac)
+                        || !ssl->method->ssl3_enc->mac(s, thiswr, mac, 1)) {
+                    RLAYERfatal(rl, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
+                    goto err;
+                }
+            } else {
+                if (!WPACKET_allocate_bytes(thispkt, mac_size, &mac)
+                        || !rl->funcs->mac(rl, thiswr, mac, 1)) {
+                    RLAYERfatal(rl, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
+                    goto err;
+                }
             }
         }
 
@@ -1809,17 +1826,44 @@ int tls_write_records_default(OSSL_RECORD_LAYER *rl,
     } else {
         if (!using_ktls) {
             if (prefix) {
-                if (ssl->method->ssl3_enc->enc(s, wr, 1, 1, NULL, mac_size) < 1) {
+                /*
+                * TODO(RECLAYER): Remove this once SSLv3 crypto has been moved
+                *                 to the new write record layer.
+                */
+                if (rl->version == SSL3_VERSION) {
+                    if (ssl->method->ssl3_enc->enc(s, wr, 1, 1, NULL, mac_size) < 1) {
+                        if (!ossl_statem_in_error(s))
+                            RLAYERfatal(rl, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
+                        goto err;
+                    }
+                } else {
+                    if (rl->funcs->cipher(rl, wr, 1, 1, NULL, mac_size) < 1) {
+                        if (!ossl_statem_in_error(s))
+                            RLAYERfatal(rl, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
+                        goto err;
+                    }
+                }
+            }
+            /*
+             * TODO(RECLAYER): Remove this once SSLv3/TLSv1.3/DTLS crypto has
+             *                 been moved to the new write record layer.
+             */
+            if (rl->version == SSL3_VERSION
+                    || rl->version == TLS1_3_VERSION
+                    || rl->isdtls) {
+                if (ssl->method->ssl3_enc->enc(s, wr + prefix, numtempl, 1, NULL,
+                                               mac_size) < 1) {
                     if (!ossl_statem_in_error(s))
                         RLAYERfatal(rl, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
                     goto err;
                 }
-            }
-            if (ssl->method->ssl3_enc->enc(s, wr + prefix, numtempl, 1, NULL,
-                                           mac_size) < 1) {
-                if (!ossl_statem_in_error(s))
-                    RLAYERfatal(rl, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
-                goto err;
+            } else {
+                if (rl->funcs->cipher(rl, wr + prefix, numtempl, 1, NULL,
+                                      mac_size) < 1) {
+                    if (!ossl_statem_in_error(s))
+                        RLAYERfatal(rl, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
+                    goto err;
+                }
             }
         }
     }
@@ -1849,11 +1893,26 @@ int tls_write_records_default(OSSL_RECORD_LAYER *rl,
         if (rl->use_etm && mac_size != 0) {
             unsigned char *mac;
 
-            if (!WPACKET_allocate_bytes(thispkt, mac_size, &mac)
-                    || !ssl->method->ssl3_enc->mac(s, thiswr, mac, 1)) {
-                RLAYERfatal(rl, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
-                goto err;
+            /*
+             * TODO(RECLAYER): Remove this once SSLv3/TLSv1.3/DTLS crypto has
+             *                 been moved to the new write record layer.
+             */
+            if (rl->version == SSL3_VERSION
+                    || rl->version == TLS1_3_VERSION
+                    || rl->isdtls) {
+                if (!WPACKET_allocate_bytes(thispkt, mac_size, &mac)
+                        || !ssl->method->ssl3_enc->mac(s, thiswr, mac, 1)) {
+                    RLAYERfatal(rl, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
+                    goto err;
+                }
+            } else {
+                if (!WPACKET_allocate_bytes(thispkt, mac_size, &mac)
+                        || !rl->funcs->mac(rl, thiswr, mac, 1)) {
+                    RLAYERfatal(rl, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
+                    goto err;
+                }
             }
+
             SSL3_RECORD_add_length(thiswr, mac_size);
         }
 

--- a/ssl/record/methods/tls_common.c
+++ b/ssl/record/methods/tls_common.c
@@ -12,6 +12,7 @@
 #include <openssl/ssl.h>
 #include <openssl/err.h>
 #include <openssl/core_names.h>
+#include <openssl/comp.h>
 #include "internal/e_os.h"
 #include "internal/packet.h"
 #include "../../ssl_local.h"
@@ -1196,7 +1197,7 @@ tls_int_new_record_layer(OSSL_LIB_CTX *libctx, const char *propq, int vers,
                          unsigned char *mackey, size_t mackeylen,
                          const EVP_CIPHER *ciph, size_t taglen,
                          int mactype,
-                         const EVP_MD *md, const SSL_COMP *comp, BIO *prev,
+                         const EVP_MD *md, COMP_METHOD *comp, BIO *prev,
                          BIO *transport, BIO *next, BIO_ADDR *local,
                          BIO_ADDR *peer, const OSSL_PARAM *settings,
                          const OSSL_PARAM *options,
@@ -1328,7 +1329,7 @@ tls_new_record_layer(OSSL_LIB_CTX *libctx, const char *propq, int vers,
                      size_t ivlen, unsigned char *mackey, size_t mackeylen,
                      const EVP_CIPHER *ciph, size_t taglen,
                      int mactype,
-                     const EVP_MD *md, const SSL_COMP *comp, BIO *prev,
+                     const EVP_MD *md, COMP_METHOD *comp, BIO *prev,
                      BIO *transport, BIO *next, BIO_ADDR *local, BIO_ADDR *peer,
                      const OSSL_PARAM *settings, const OSSL_PARAM *options,
                      const OSSL_DISPATCH *fns, void *cbarg,
@@ -2141,6 +2142,15 @@ void tls_get_state(OSSL_RECORD_LAYER *rl, const char **shortstr,
         *longstr = lng;
 }
 
+const COMP_METHOD *tls_get_compression(OSSL_RECORD_LAYER *rl)
+{
+#ifndef OPENSSL_NO_COMP
+    return (rl->compctx == NULL) ? NULL : COMP_CTX_get_method(rl->compctx);
+#else
+    return NULL;
+#endif
+}
+
 const OSSL_RECORD_METHOD ossl_tls_record_method = {
     tls_new_record_layer,
     tls_free,
@@ -2163,5 +2173,6 @@ const OSSL_RECORD_METHOD ossl_tls_record_method = {
     tls_set_max_pipelines,
     NULL,
     tls_get_state,
-    tls_set_options
+    tls_set_options,
+    tls_get_compression
 };

--- a/ssl/record/methods/tls_common.c
+++ b/ssl/record/methods/tls_common.c
@@ -992,9 +992,8 @@ static int tls_do_compress(OSSL_RECORD_LAYER *rl, SSL3_RECORD *wr)
                             wr->input, (int)wr->length);
     if (i < 0)
         return 0;
-    else
-        wr->length = i;
 
+    wr->length = i;
     wr->input = wr->data;
 #endif
     return 1;

--- a/ssl/record/methods/tls_common.c
+++ b/ssl/record/methods/tls_common.c
@@ -995,8 +995,10 @@ static int tls_do_compress(OSSL_RECORD_LAYER *rl, SSL3_RECORD *wr)
 
     wr->length = i;
     wr->input = wr->data;
-#endif
     return 1;
+#else
+    return 0;
+#endif
 }
 
 int tls_do_uncompress(OSSL_RECORD_LAYER *rl, SSL3_RECORD *rec)

--- a/ssl/record/methods/tls_common.c
+++ b/ssl/record/methods/tls_common.c
@@ -1522,11 +1522,10 @@ int tls_write_records_default(OSSL_RECORD_LAYER *rl,
     OSSL_RECORD_TEMPLATE *thistempl;
 
     /*
-     * TODO(RECLAYER): Remove this once SSLv3/TLSv1.3/DTLS crypto has
+     * TODO(RECLAYER): Remove this once TLSv1.3/DTLS crypto has
      *                 been moved to the new write record layer.
      */
-    if (rl->version == SSL3_VERSION
-            || rl->version == TLS1_3_VERSION
+    if (rl->version == TLS1_3_VERSION
             || rl->isdtls) {
         SSL_SESSION *sess = s->session;
 
@@ -1768,11 +1767,10 @@ int tls_write_records_default(OSSL_RECORD_LAYER *rl,
             unsigned char *mac;
 
             /*
-             * TODO(RECLAYER): Remove this once SSLv3/TLSv1.3/DTLS crypto has
+             * TODO(RECLAYER): Remove this once TLSv1.3/DTLS crypto has
              *                 been moved to the new write record layer.
              */
-            if (rl->version == SSL3_VERSION
-                    || rl->version == TLS1_3_VERSION
+            if (rl->version == TLS1_3_VERSION
                     || rl->isdtls) {
                 if (!WPACKET_allocate_bytes(thispkt, mac_size, &mac)
                         || !ssl->method->ssl3_enc->mac(s, thiswr, mac, 1)) {
@@ -1827,30 +1825,17 @@ int tls_write_records_default(OSSL_RECORD_LAYER *rl,
     } else {
         if (!using_ktls) {
             if (prefix) {
-                /*
-                * TODO(RECLAYER): Remove this once SSLv3 crypto has been moved
-                *                 to the new write record layer.
-                */
-                if (rl->version == SSL3_VERSION) {
-                    if (ssl->method->ssl3_enc->enc(s, wr, 1, 1, NULL, mac_size) < 1) {
-                        if (!ossl_statem_in_error(s))
-                            RLAYERfatal(rl, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
-                        goto err;
-                    }
-                } else {
-                    if (rl->funcs->cipher(rl, wr, 1, 1, NULL, mac_size) < 1) {
-                        if (!ossl_statem_in_error(s))
-                            RLAYERfatal(rl, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
-                        goto err;
-                    }
+                if (rl->funcs->cipher(rl, wr, 1, 1, NULL, mac_size) < 1) {
+                    if (!ossl_statem_in_error(s))
+                        RLAYERfatal(rl, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
+                    goto err;
                 }
             }
             /*
-             * TODO(RECLAYER): Remove this once SSLv3/TLSv1.3/DTLS crypto has
+             * TODO(RECLAYER): Remove this once TLSv1.3/DTLS crypto has
              *                 been moved to the new write record layer.
              */
-            if (rl->version == SSL3_VERSION
-                    || rl->version == TLS1_3_VERSION
+            if (rl->version == TLS1_3_VERSION
                     || rl->isdtls) {
                 if (ssl->method->ssl3_enc->enc(s, wr + prefix, numtempl, 1, NULL,
                                                mac_size) < 1) {
@@ -1895,11 +1880,10 @@ int tls_write_records_default(OSSL_RECORD_LAYER *rl,
             unsigned char *mac;
 
             /*
-             * TODO(RECLAYER): Remove this once SSLv3/TLSv1.3/DTLS crypto has
+             * TODO(RECLAYER): Remove this once TLSv1.3/DTLS crypto has
              *                 been moved to the new write record layer.
              */
-            if (rl->version == SSL3_VERSION
-                    || rl->version == TLS1_3_VERSION
+            if (rl->version == TLS1_3_VERSION
                     || rl->isdtls) {
                 if (!WPACKET_allocate_bytes(thispkt, mac_size, &mac)
                         || !ssl->method->ssl3_enc->mac(s, thiswr, mac, 1)) {

--- a/ssl/record/methods/tls_multib.c
+++ b/ssl/record/methods/tls_multib.c
@@ -24,17 +24,14 @@ static int tls_is_multiblock_capable(OSSL_RECORD_LAYER *rl, int type,
                                      size_t len, size_t fraglen)
 {
 #if !defined(OPENSSL_NO_MULTIBLOCK) && EVP_CIPH_FLAG_TLS1_1_MULTIBLOCK
-    /* TODO(RECLAYER): REMOVE ME */
-    SSL_CONNECTION *s = rl->cbarg;
-
     if (type == SSL3_RT_APPLICATION_DATA
             && len >= 4 * fraglen
-            && s->compress == NULL
+            && rl->compctx == NULL
             && rl->msg_callback == NULL
             && !rl->use_etm
             && RLAYER_USE_EXPLICIT_IV(rl)
-            && !BIO_get_ktls_send(s->wbio)
-            && (EVP_CIPHER_get_flags(EVP_CIPHER_CTX_get0_cipher(s->enc_write_ctx))
+            && !BIO_get_ktls_send(rl->bio)
+            && (EVP_CIPHER_get_flags(EVP_CIPHER_CTX_get0_cipher(rl->enc_ctx))
                 & EVP_CIPH_FLAG_TLS1_1_MULTIBLOCK) != 0)
         return 1;
 #endif
@@ -73,8 +70,6 @@ static int tls_write_records_multiblock_int(OSSL_RECORD_LAYER *rl,
     size_t i;
     size_t totlen;
     SSL3_BUFFER *wb;
-    /* TODO(RECLAYER): Remove me */
-    SSL_CONNECTION *s = rl->cbarg;
     unsigned char aad[13];
     EVP_CTRL_TLS1_1_MULTIBLOCK_PARAM mb_param;
     size_t packlen;
@@ -113,7 +108,7 @@ static int tls_write_records_multiblock_int(OSSL_RECORD_LAYER *rl,
      * multiblock write in the call to tls_setup_write_buffer() - the different
      * buffer sizes will be spotted and the buffer reallocated.
      */
-    packlen = EVP_CIPHER_CTX_ctrl(s->enc_write_ctx,
+    packlen = EVP_CIPHER_CTX_ctrl(rl->enc_ctx,
                                     EVP_CTRL_TLS1_1_MULTIBLOCK_MAX_BUFSIZE,
                                     (int)templates[0].buflen, NULL);
     packlen *= numtempl;
@@ -124,7 +119,7 @@ static int tls_write_records_multiblock_int(OSSL_RECORD_LAYER *rl,
     wb = &rl->wbuf[0];
 
     mb_param.interleave = numtempl;
-    memcpy(aad, s->rlayer.write_sequence, 8);
+    memcpy(aad, rl->sequence, 8);
     aad[8] = templates[0].type;
     aad[9] = (unsigned char)(templates[0].version >> 8);
     aad[10] = (unsigned char)(templates[0].version);
@@ -134,7 +129,7 @@ static int tls_write_records_multiblock_int(OSSL_RECORD_LAYER *rl,
     mb_param.inp = aad;
     mb_param.len = totlen;
 
-    packleni = EVP_CIPHER_CTX_ctrl(s->enc_write_ctx,
+    packleni = EVP_CIPHER_CTX_ctrl(rl->enc_ctx,
                                     EVP_CTRL_TLS1_1_MULTIBLOCK_AAD,
                                     sizeof(mb_param), &mb_param);
     packlen = (size_t)packleni;
@@ -147,17 +142,17 @@ static int tls_write_records_multiblock_int(OSSL_RECORD_LAYER *rl,
     mb_param.inp = templates[0].buf;
     mb_param.len = totlen;
 
-    if (EVP_CIPHER_CTX_ctrl(s->enc_write_ctx,
+    if (EVP_CIPHER_CTX_ctrl(rl->enc_ctx,
                             EVP_CTRL_TLS1_1_MULTIBLOCK_ENCRYPT,
                             sizeof(mb_param), &mb_param) <= 0) {
         RLAYERfatal(rl, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
         return -1;
     }
 
-    s->rlayer.write_sequence[7] += mb_param.interleave;
-    if (s->rlayer.write_sequence[7] < mb_param.interleave) {
+    rl->sequence[7] += mb_param.interleave;
+    if (rl->sequence[7] < mb_param.interleave) {
         int j = 6;
-        while (j >= 0 && (++s->rlayer.write_sequence[j--]) == 0) ;
+        while (j >= 0 && (++rl->sequence[j--]) == 0) ;
     }
 
     wb->offset = 0;

--- a/ssl/record/methods/tls_multib.c
+++ b/ssl/record/methods/tls_multib.c
@@ -109,8 +109,8 @@ static int tls_write_records_multiblock_int(OSSL_RECORD_LAYER *rl,
      * buffer sizes will be spotted and the buffer reallocated.
      */
     packlen = EVP_CIPHER_CTX_ctrl(rl->enc_ctx,
-                                    EVP_CTRL_TLS1_1_MULTIBLOCK_MAX_BUFSIZE,
-                                    (int)templates[0].buflen, NULL);
+                                  EVP_CTRL_TLS1_1_MULTIBLOCK_MAX_BUFSIZE,
+                                  (int)templates[0].buflen, NULL);
     packlen *= numtempl;
     if (!tls_setup_write_buffer(rl, 1, packlen, packlen)) {
         /* RLAYERfatal() already called */
@@ -130,8 +130,8 @@ static int tls_write_records_multiblock_int(OSSL_RECORD_LAYER *rl,
     mb_param.len = totlen;
 
     packleni = EVP_CIPHER_CTX_ctrl(rl->enc_ctx,
-                                    EVP_CTRL_TLS1_1_MULTIBLOCK_AAD,
-                                    sizeof(mb_param), &mb_param);
+                                   EVP_CTRL_TLS1_1_MULTIBLOCK_AAD,
+                                   sizeof(mb_param), &mb_param);
     packlen = (size_t)packleni;
     if (packleni <= 0 || packlen > wb->len) { /* never happens */
         RLAYERfatal(rl, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);

--- a/ssl/record/methods/tlsany_meth.c
+++ b/ssl/record/methods/tlsany_meth.c
@@ -20,7 +20,7 @@ static int tls_any_set_crypto_state(OSSL_RECORD_LAYER *rl, int level,
                                     size_t taglen,
                                     int mactype,
                                     const EVP_MD *md,
-                                    const SSL_COMP *comp)
+                                    COMP_METHOD *comp)
 {
     if (level != OSSL_RECORD_PROTECTION_LEVEL_NONE) {
         ERR_raise(ERR_LIB_SSL, ERR_R_INTERNAL_ERROR);

--- a/ssl/record/rec_layer_s3.c
+++ b/ssl/record/rec_layer_s3.c
@@ -1136,6 +1136,7 @@ int ssl_set_new_record_layer(SSL_CONNECTION *s, int version,
     unsigned int maxfrag = SSL3_RT_MAX_PLAIN_LENGTH;
     int use_early_data = 0;
     uint32_t max_early_data;
+    COMP_METHOD *compm = (comp == NULL) ? NULL : comp->method;
 
     meth = ssl_select_next_record_layer(s, level);
 
@@ -1282,7 +1283,7 @@ int ssl_set_new_record_layer(SSL_CONNECTION *s, int version,
                                        s->server, direction, level, epoch,
                                        key, keylen, iv, ivlen, mackey,
                                        mackeylen, ciph, taglen, mactype, md,
-                                       comp, prev, thisbio, next, NULL, NULL,
+                                       compm, prev, thisbio, next, NULL, NULL,
                                        settings, options, rlayer_dispatch_tmp,
                                        s, &newrl);
         BIO_free(prev);

--- a/ssl/record/record.h
+++ b/ssl/record/record.h
@@ -226,10 +226,6 @@ __owur int ssl3_read_bytes(SSL *s, int type, int *recvd_type,
                            unsigned char *buf, size_t len, int peek,
                            size_t *readbytes);
 __owur int ssl3_setup_buffers(SSL_CONNECTION *s);
-__owur int ssl3_enc(SSL_CONNECTION *s, SSL3_RECORD *inrecs, size_t n_recs,
-                    int send, SSL_MAC_BUF *mac, size_t macsize);
-__owur int n_ssl3_mac(SSL_CONNECTION *s, SSL3_RECORD *rec, unsigned char *md,
-                      int send);
 __owur int tls1_enc(SSL_CONNECTION *s, SSL3_RECORD *recs, size_t n_recs,
                     int sending, SSL_MAC_BUF *mac, size_t macsize);
 __owur int tls1_mac_old(SSL_CONNECTION *s, SSL3_RECORD *rec, unsigned char *md,

--- a/ssl/record/recordmethod.h
+++ b/ssl/record/recordmethod.h
@@ -134,7 +134,7 @@ struct ossl_record_method_st {
                             size_t taglen,
                             int mactype,
                             const EVP_MD *md,
-                            const SSL_COMP *comp,
+                            COMP_METHOD *comp,
                             BIO *prev,
                             BIO *transport,
                             BIO *next,
@@ -300,6 +300,8 @@ struct ossl_record_method_st {
      * new_record_layer call.
      */
     int (*set_options)(OSSL_RECORD_LAYER *rl, const OSSL_PARAM *options);
+
+    const COMP_METHOD *(*get_compression)(OSSL_RECORD_LAYER *rl);
 };
 
 

--- a/ssl/s3_enc.c
+++ b/ssl/s3_enc.c
@@ -92,13 +92,11 @@ int ssl3_change_cipher_state(SSL_CONNECTION *s, int which)
     unsigned char *p, *mac_secret;
     size_t md_len;
     unsigned char *key, *iv;
-    EVP_CIPHER_CTX *dd;
     const EVP_CIPHER *ciph;
     const SSL_COMP *comp = NULL;
     const EVP_MD *md;
     int mdi;
     size_t n, iv_len, key_len;
-    int reuse_dd = 0;
     int direction = (which & SSL3_CC_READ) != 0 ? OSSL_RECORD_DIRECTION_READ
                                                 : OSSL_RECORD_DIRECTION_WRITE;
 
@@ -145,61 +143,14 @@ int ssl3_change_cipher_state(SSL_CONNECTION *s, int which)
         goto err;
     }
 
+    if ((which & SSL3_CC_WRITE) != 0)
+        s->statem.enc_write_state = ENC_WRITE_STATE_INVALID;
+
     if (!ssl_set_new_record_layer(s, SSL3_VERSION,
                                   direction,
                                   OSSL_RECORD_PROTECTION_LEVEL_APPLICATION,
                                   key, key_len, iv, iv_len, mac_secret,
                                   md_len, ciph, 0, NID_undef, md, comp)) {
-        /* SSLfatal already called */
-        goto err;
-    }
-
-    if (which & SSL3_CC_READ) {
-        s->statem.enc_write_state = ENC_WRITE_STATE_VALID;
-        return 1;
-    }
-
-    s->statem.enc_write_state = ENC_WRITE_STATE_INVALID;
-    if (s->enc_write_ctx != NULL) {
-        reuse_dd = 1;
-    } else if ((s->enc_write_ctx = EVP_CIPHER_CTX_new()) == NULL) {
-        SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_MALLOC_FAILURE);
-        goto err;
-    } else {
-        /*  make sure it's initialised in case we exit later with an error */
-        EVP_CIPHER_CTX_reset(s->enc_write_ctx);
-    }
-    dd = s->enc_write_ctx;
-    if (ssl_replace_hash(&s->write_hash, md) == NULL) {
-        SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_MALLOC_FAILURE);
-        goto err;
-    }
-#ifndef OPENSSL_NO_COMP
-    /* COMPRESS */
-    COMP_CTX_free(s->compress);
-    s->compress = NULL;
-    if (comp != NULL) {
-        s->compress = COMP_CTX_new(comp->method);
-        if (s->compress == NULL) {
-            SSLfatal(s, SSL_AD_INTERNAL_ERROR,
-                        SSL_R_COMPRESSION_LIBRARY_ERROR);
-            goto err;
-        }
-    }
-#endif
-    RECORD_LAYER_reset_write_sequence(&s->rlayer);
-    memcpy(&(s->s3.write_mac_secret[0]), mac_secret, md_len);
-
-    if (reuse_dd)
-        EVP_CIPHER_CTX_reset(dd);
-
-    if (!EVP_CipherInit_ex(dd, ciph, NULL, key, iv, (which & SSL3_CC_WRITE))) {
-        SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
-        goto err;
-    }
-
-    if (EVP_CIPHER_get0_provider(ciph) != NULL
-            && !tls_provider_set_tls_params(s, dd, ciph, md)) {
         /* SSLfatal already called */
         goto err;
     }

--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -3270,8 +3270,8 @@ static int sslcon_undefined_function_1(SSL_CONNECTION *sc, unsigned char *r,
 }
 
 const SSL3_ENC_METHOD SSLv3_enc_data = {
-    ssl3_enc,
-    n_ssl3_mac,
+    NULL,
+    NULL,
     ssl3_setup_key_block,
     ssl3_generate_master_secret,
     ssl3_change_cipher_state,

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -4773,7 +4773,11 @@ const COMP_METHOD *SSL_get_current_compression(const SSL *s)
     if (sc == NULL)
         return NULL;
 
-    return sc->compress ? COMP_CTX_get_method(sc->compress) : NULL;
+    /* TODO(RECLAYER): Remove me once SSLv3/DTLS moved to write record layer */
+    if (SSL_CONNECTION_IS_DTLS(sc) || sc->version == SSL3_VERSION)
+        return sc->compress ? COMP_CTX_get_method(sc->compress) : NULL;
+
+    return sc->rlayer.wrlmethod->get_compression(sc->rlayer.wrl);
 #else
     return NULL;
 #endif
@@ -4787,7 +4791,7 @@ const COMP_METHOD *SSL_get_current_expansion(const SSL *s)
     if (sc == NULL)
         return NULL;
 
-    return sc->expand ? COMP_CTX_get_method(sc->expand) : NULL;
+    return sc->rlayer.rrlmethod->get_compression(sc->rlayer.rrl);
 #else
     return NULL;
 #endif

--- a/ssl/t1_enc.c
+++ b/ssl/t1_enc.c
@@ -252,7 +252,7 @@ int tls1_change_cipher_state(SSL_CONNECTION *s, int which)
             goto err;
         }
 
-        /* TODO(RECLAYER): Temporary - remove me when write rlayer done*/
+        /* TODO(RECLAYER): Temporary - remove me when DTLS write rlayer done*/
         goto skip_ktls;
     } else {
         s->statem.enc_write_state = ENC_WRITE_STATE_INVALID;
@@ -280,6 +280,10 @@ int tls1_change_cipher_state(SSL_CONNECTION *s, int which)
             /* SSLfatal already called */
             goto err;
         }
+
+        /* TODO(RECLAYER): Temporary - remove me when DTLS write rlayer done*/
+        if (!SSL_CONNECTION_IS_DTLS(s))
+            goto skip_ktls;
 
         if (s->enc_write_ctx != NULL && !SSL_CONNECTION_IS_DTLS(s)) {
             reuse_dd = 1;

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -1073,9 +1073,15 @@ static int ping_pong_query(SSL *clientssl, SSL *serverssl)
         goto end;
 
     cbuf[0] = count++;
-    memcpy(crec_wseq_before, &clientsc->rlayer.write_sequence, SEQ_NUM_SIZE);
+    /* TODO(RECLAYER): Remove me once TLSv1.3 write side converted */
+    if (SSL_CONNECTION_IS_TLS13(serversc)) {
+        memcpy(crec_wseq_before, &clientsc->rlayer.write_sequence, SEQ_NUM_SIZE);
+        memcpy(srec_wseq_before, &serversc->rlayer.write_sequence, SEQ_NUM_SIZE);
+    } else {
+        memcpy(crec_wseq_before, &clientsc->rlayer.wrl->sequence, SEQ_NUM_SIZE);
+        memcpy(srec_wseq_before, &serversc->rlayer.wrl->sequence, SEQ_NUM_SIZE);
+    }
     memcpy(crec_rseq_before, &clientsc->rlayer.rrl->sequence, SEQ_NUM_SIZE);
-    memcpy(srec_wseq_before, &serversc->rlayer.write_sequence, SEQ_NUM_SIZE);
     memcpy(srec_rseq_before, &serversc->rlayer.rrl->sequence, SEQ_NUM_SIZE);
 
     if (!TEST_true(SSL_write(clientssl, cbuf, sizeof(cbuf)) == sizeof(cbuf)))
@@ -1096,9 +1102,15 @@ static int ping_pong_query(SSL *clientssl, SSL *serverssl)
         }
     }
 
-    memcpy(crec_wseq_after, &clientsc->rlayer.write_sequence, SEQ_NUM_SIZE);
+    /* TODO(RECLAYER): Remove me once TLSv1.3 write side converted */
+    if (SSL_CONNECTION_IS_TLS13(serversc)) {
+        memcpy(crec_wseq_after, &clientsc->rlayer.write_sequence, SEQ_NUM_SIZE);
+        memcpy(srec_wseq_after, &serversc->rlayer.write_sequence, SEQ_NUM_SIZE);
+    } else {
+        memcpy(crec_wseq_after, &clientsc->rlayer.wrl->sequence, SEQ_NUM_SIZE);
+        memcpy(srec_wseq_after, &serversc->rlayer.wrl->sequence, SEQ_NUM_SIZE);
+    }
     memcpy(crec_rseq_after, &clientsc->rlayer.rrl->sequence, SEQ_NUM_SIZE);
-    memcpy(srec_wseq_after, &serversc->rlayer.write_sequence, SEQ_NUM_SIZE);
     memcpy(srec_rseq_after, &serversc->rlayer.rrl->sequence, SEQ_NUM_SIZE);
 
     /* verify the payload */


### PR DESCRIPTION
This is built on top of #19198 and extends it to move the TLSv1.0/1.1/1.2 crypto code into the new write record layer.

Only the last commit is relevant. All the rest are inherited from #19198. For that reason this will remain in draft until that one has been merged.