### PR TITLE
`CMS_decrypt*()`: fix misconceptions and memory leak

### DIFF
--- a/crypto/cms/cms_env.c
+++ b/crypto/cms/cms_env.c
@@ -266,7 +266,7 @@ BIO *CMS_EnvelopedData_decrypt(CMS_EnvelopedData *env, BIO *detached_data,
                                      ASN1_STRING_get0_data(secret),
                                      ASN1_STRING_length(secret)) != 1)
         goto end;
-    res = CMS_decrypt(ci, secret == NULL ? pkey: NULL,
+    res = CMS_decrypt(ci, secret == NULL ? pkey : NULL,
                       secret == NULL ? cert : NULL, detached_data, bio, flags);
 
  end:

--- a/crypto/cms/cms_env.c
+++ b/crypto/cms/cms_env.c
@@ -138,7 +138,7 @@ int ossl_cms_env_asn1_ctrl(CMS_RecipientInfo *ri, int cmd)
     return 1;
 }
 
-CMS_EncryptedContentInfo* ossl_cms_get0_env_enc_content(const CMS_ContentInfo *cms)
+CMS_EncryptedContentInfo *ossl_cms_get0_env_enc_content(const CMS_ContentInfo *cms)
 {
     switch (cms_get_enveloped_type(cms)) {
     case CMS_ENVELOPED_STANDARD:
@@ -266,7 +266,8 @@ BIO *CMS_EnvelopedData_decrypt(CMS_EnvelopedData *env, BIO *detached_data,
                                      ASN1_STRING_get0_data(secret),
                                      ASN1_STRING_length(secret)) != 1)
         goto end;
-    res = CMS_decrypt(ci, pkey, cert, detached_data, bio, flags);
+    res = CMS_decrypt(ci, secret == NULL ? pkey: NULL,
+                      secret == NULL ? cert : NULL, detached_data, bio, flags);
 
  end:
     if (ci != NULL)

--- a/crypto/cms/cms_smime.c
+++ b/crypto/cms/cms_smime.c
@@ -702,7 +702,7 @@ int CMS_decrypt_set1_pkey(CMS_ContentInfo *cms, EVP_PKEY *pk, X509 *cert)
 int CMS_decrypt_set1_pkey_and_peer(CMS_ContentInfo *cms, EVP_PKEY *pk,
                                    X509 *cert, X509 *peer)
 {
-    STACK_OF(CMS_RecipientInfo) *ris;
+    STACK_OF(CMS_RecipientInfo) *ris = CMS_get0_RecipientInfos(cms);
     CMS_RecipientInfo *ri;
     int i, r, cms_pkey_ri_type;
     int debug = 0, match_ri = 0;
@@ -713,7 +713,6 @@ int CMS_decrypt_set1_pkey_and_peer(CMS_ContentInfo *cms, EVP_PKEY *pk,
     ec->key = NULL;
     ec->keylen = 0;
 
-    ris = CMS_get0_RecipientInfos(cms);
     if (ris != NULL)
         debug = ec->debug;
 
@@ -824,11 +823,16 @@ int CMS_decrypt_set1_key(CMS_ContentInfo *cms,
 int CMS_decrypt_set1_password(CMS_ContentInfo *cms,
                               unsigned char *pass, ossl_ssize_t passlen)
 {
-    STACK_OF(CMS_RecipientInfo) *ris;
+    STACK_OF(CMS_RecipientInfo) *ris = CMS_get0_RecipientInfos(cms);
     CMS_RecipientInfo *ri;
     int i, r;
+    CMS_EncryptedContentInfo *ec = ossl_cms_get0_env_enc_content(cms);
 
-    ris = CMS_get0_RecipientInfos(cms);
+    /* Prevent mem leak on earlier CMS_decrypt_set1_{pkey_and_peer,password} */
+    OPENSSL_clear_free(ec->key, ec->keylen);
+    ec->key = NULL;
+    ec->keylen = 0;
+
     for (i = 0; i < sk_CMS_RecipientInfo_num(ris); i++) {
         ri = sk_CMS_RecipientInfo_value(ris, i);
         if (CMS_RecipientInfo_type(ri) != CMS_RECIPINFO_PASS)

--- a/crypto/cms/cms_smime.c
+++ b/crypto/cms/cms_smime.c
@@ -737,11 +737,8 @@ int CMS_decrypt_set1_pkey_and_peer(CMS_ContentInfo *cms, EVP_PKEY *pk,
             if (r < 0)
                 return 0;
         }
-        /*
-         * If we have a cert try matching RecipientInfo otherwise try them
-         * all.
-         */
-        else if (cert == NULL|| !CMS_RecipientInfo_ktri_cert_cmp(ri, cert)) {
+        /* If we have a cert, try matching RecipientInfo, else try them all */
+        else if (cert == NULL || !CMS_RecipientInfo_ktri_cert_cmp(ri, cert)) {
             EVP_PKEY_up_ref(pk);
             CMS_RecipientInfo_set0_pkey(ri, pk);
             r = CMS_RecipientInfo_decrypt(cms, ri);
@@ -778,7 +775,8 @@ int CMS_decrypt_set1_pkey_and_peer(CMS_ContentInfo *cms, EVP_PKEY *pk,
         return 1;
     }
 
-    ERR_raise(ERR_LIB_CMS, CMS_R_NO_MATCHING_RECIPIENT);
+    if (!match_ri)
+        ERR_raise(ERR_LIB_CMS, CMS_R_NO_MATCHING_RECIPIENT);
     return 0;
 
 }
@@ -789,7 +787,7 @@ int CMS_decrypt_set1_key(CMS_ContentInfo *cms,
 {
     STACK_OF(CMS_RecipientInfo) *ris;
     CMS_RecipientInfo *ri;
-    int i, r;
+    int i, r, match_ri = 0;
 
     ris = CMS_get0_RecipientInfos(cms);
     for (i = 0; i < sk_CMS_RecipientInfo_num(ris); i++) {
@@ -797,11 +795,10 @@ int CMS_decrypt_set1_key(CMS_ContentInfo *cms,
         if (CMS_RecipientInfo_type(ri) != CMS_RECIPINFO_KEK)
             continue;
 
-        /*
-         * If we have an id try matching RecipientInfo otherwise try them
-         * all.
-         */
-        if (id == NULL || (CMS_RecipientInfo_kekri_id_cmp(ri, id, idlen) == 0)) {
+        /* If we have an id, try matching RecipientInfo, else try them all */
+        if (id == NULL
+                || (CMS_RecipientInfo_kekri_id_cmp(ri, id, idlen) == 0)) {
+            match_ri = 1;
             CMS_RecipientInfo_set0_key(ri, key, keylen);
             r = CMS_RecipientInfo_decrypt(cms, ri);
             CMS_RecipientInfo_set0_key(ri, NULL, 0);
@@ -815,7 +812,8 @@ int CMS_decrypt_set1_key(CMS_ContentInfo *cms,
         }
     }
 
-    ERR_raise(ERR_LIB_CMS, CMS_R_NO_MATCHING_RECIPIENT);
+    if (!match_ri)
+        ERR_raise(ERR_LIB_CMS, CMS_R_NO_MATCHING_RECIPIENT);
     return 0;
 
 }
@@ -825,7 +823,7 @@ int CMS_decrypt_set1_password(CMS_ContentInfo *cms,
 {
     STACK_OF(CMS_RecipientInfo) *ris = CMS_get0_RecipientInfos(cms);
     CMS_RecipientInfo *ri;
-    int i, r;
+    int i, r, match_ri = 0;
     CMS_EncryptedContentInfo *ec = ossl_cms_get0_env_enc_content(cms);
 
     /* Prevent mem leak on earlier CMS_decrypt_set1_{pkey_and_peer,password} */
@@ -837,6 +835,9 @@ int CMS_decrypt_set1_password(CMS_ContentInfo *cms,
         ri = sk_CMS_RecipientInfo_value(ris, i);
         if (CMS_RecipientInfo_type(ri) != CMS_RECIPINFO_PASS)
             continue;
+
+        /* Must try each PasswordRecipientInfo */
+        match_ri = 1;
         CMS_RecipientInfo_set0_password(ri, pass, passlen);
         r = CMS_RecipientInfo_decrypt(cms, ri);
         CMS_RecipientInfo_set0_password(ri, NULL, 0);
@@ -844,7 +845,8 @@ int CMS_decrypt_set1_password(CMS_ContentInfo *cms,
             return 1;
     }
 
-    ERR_raise(ERR_LIB_CMS, CMS_R_NO_MATCHING_RECIPIENT);
+    if (!match_ri)
+        ERR_raise(ERR_LIB_CMS, CMS_R_NO_MATCHING_RECIPIENT);
     return 0;
 
 }

--- a/doc/man3/CMS_EncryptedData_decrypt.pod
+++ b/doc/man3/CMS_EncryptedData_decrypt.pod
@@ -26,15 +26,16 @@ to and I<flags> is an optional set of flags.
 I<dcont> is used in the rare case where the encrypted content is detached. It
 will normally be set to NULL.
 
-The following flags can be passed in the B<flags> parameter.
+The following flags can be passed in the I<flags> parameter.
 
-If the B<CMS_TEXT> flag is set MIME headers for type B<text/plain> are deleted
-from the content. If the content is not of type B<text/plain> then an error is
+If the B<CMS_TEXT> flag is set MIME headers for type C<text/plain> are deleted
+from the content. If the content is not of type C<text/plain> then an error is
 returned.
 
 CMS_EnvelopedData_decrypt() decrypts, similarly to CMS_decrypt(3),
-a CMS EnvelopedData object I<env> using the symmetric key I<secret> or
-the private key of the recipient B<pkey> and its associated certificate B<cert>.
+a CMS EnvelopedData object I<env> using the symmetric key I<secret> if it
+is not NULL, otherwise the private key of the recipient I<pkey> and
+the associated certificate I<cert>, which is then recommended to provide.
 The optional parameters I<flags> and I<dcont> are used as described above.
 The optional parameters library context I<libctx> and property query I<propq>
 are used when retrieving algorithms from providers.

--- a/doc/man3/CMS_EncryptedData_decrypt.pod
+++ b/doc/man3/CMS_EncryptedData_decrypt.pod
@@ -34,8 +34,9 @@ returned.
 
 CMS_EnvelopedData_decrypt() decrypts, similarly to CMS_decrypt(3),
 a CMS EnvelopedData object I<env> using the symmetric key I<secret> if it
-is not NULL, otherwise the private key of the recipient I<pkey> and
-the associated certificate I<cert>, which is then recommended to provide.
+is not NULL, otherwise the private key of the recipient I<pkey>.
+If I<pkey> is given, it is recommended to provide also the associated
+certificate in I<cert> - see L<CMS_decrypt(3)> and the NOTES on I<cert> there.
 The optional parameters I<flags> and I<dcont> are used as described above.
 The optional parameters library context I<libctx> and property query I<propq>
 are used when retrieving algorithms from providers.

--- a/doc/man3/CMS_decrypt.pod
+++ b/doc/man3/CMS_decrypt.pod
@@ -96,7 +96,7 @@ The error can be obtained from ERR_get_error(3).
 =head1 BUGS
 
 The B<set1_> part of these function names is misleading
-and should bettter read: B<with_>.
+and should better read: B<with_>.
 
 The lack of single pass processing and the need to hold all data in memory as
 mentioned in CMS_verify() also applies to CMS_decrypt().

--- a/doc/man3/CMS_decrypt.pod
+++ b/doc/man3/CMS_decrypt.pod
@@ -20,23 +20,31 @@ CMS_decrypt_set1_pkey, CMS_decrypt_set1_password
 
 =head1 DESCRIPTION
 
-CMS_decrypt() extracts and decrypts the content from a CMS EnvelopedData
-or AuthEnvelopedData structure. I<pkey> is the private key of the recipient,
-I<cert> is the recipient's certificate, I<out> is a BIO to write the content to
-and I<flags> is an optional set of flags.
-
+CMS_decrypt() extracts the decrypted content from a CMS EnvelopedData
+or AuthEnvelopedData structure.
+It uses CMS_decrypt_set1_pkey() to decrypt the content
+with the recipient private key I<pkey> if I<pkey> is not NULL.
+In this case, the associated certificate is recommended to provide in I<cert> -
+see the NOTES below.
+I<out> is a BIO to write the content to and
+I<flags> is an optional set of flags.
+If I<pkey> is NULL the function assumes that decryption was already done
+(e.g., using CMS_decrypt_set1_pkey() or CMS_decrypt_set1_password()) and just
+provides the content unless I<cert>, I<dcont>, and I<out> are NULL as well.
 The I<dcont> parameter is used in the rare case where the encrypted content
 is detached. It will normally be set to NULL.
 
-CMS_decrypt_set1_pkey_and_peer() associates the private key I<pkey>, the
-corresponding certificate I<cert> and the originator certificate I<peer> with
-the CMS_ContentInfo structure I<cms>.
+CMS_decrypt_set1_pkey_and_peer() decrypts the CMS_ContentInfo structure I<cms>
+using the private key I<pkey>, the corresponding certificate I<cert>, which is
+recommended but may be NULL, and the (optional) originator certificate I<peer>.
+It can be followed by I<CMS_decrypt(cms, NULL, NULL, dcont, out, flags)>.
 
-CMS_decrypt_set1_pkey() associates the private key I<pkey> and the corresponding
-certificate I<cert> with the CMS_ContentInfo structure I<cms>.
+CMS_decrypt_set1_pkey() is the same as
+CMS_decrypt_set1_pkey_and_peer() with I<peer> being NULL.
 
-CMS_decrypt_set1_password() associates the secret I<pass> of length I<passlen>
-with the CMS_ContentInfo structure I<cms>.
+CMS_decrypt_set1_password() decrypts the CMS_ContentInfo structure I<cms>
+using the secret I<pass> of length I<passlen>.
+It can be followed by I<CMS_decrypt(cms, NULL, NULL, dcont, out, flags)>.
 
 =head1 NOTES
 
@@ -60,8 +68,9 @@ open to attack.
 
 It is possible to determine the correct recipient key by other means (for
 example looking them up in a database) and setting them in the CMS structure
-in advance using the CMS utility functions such as CMS_set1_pkey(). In this
-case both I<cert> and I<pkey> should be set to NULL.
+in advance using the CMS utility functions such as CMS_set1_pkey(),
+or use CMS_decrypt_set1_password() if the recipient has a symmetric key.
+In these cases both I<cert> and I<pkey> should be set to NULL.
 
 To process KEKRecipientInfo types CMS_set1_key() or CMS_RecipientInfo_set0_key()
 and CMS_RecipientInfo_decrypt() should be called before CMS_decrypt() and
@@ -81,6 +90,9 @@ return either 1 for success or 0 for failure.
 The error can be obtained from ERR_get_error(3).
 
 =head1 BUGS
+
+The B<set1_> part of these function names is misleading
+and should bettter read: B<with_>.
 
 The lack of single pass processing and the need to hold all data in memory as
 mentioned in CMS_verify() also applies to CMS_decrypt().

--- a/doc/man3/CMS_decrypt.pod
+++ b/doc/man3/CMS_decrypt.pod
@@ -37,9 +37,9 @@ is detached. It will normally be set to NULL.
 CMS_decrypt_set1_pkey_and_peer() decrypts the CMS_ContentInfo structure I<cms>
 using the private key I<pkey>, the corresponding certificate I<cert>, which is
 recommended but may be NULL, and the (optional) originator certificate I<peer>.
-On success, it also records the key I<cms>, and then
+On success, it also records in I<cms> the decryption key I<pkey>, and then
 should be followed by C<CMS_decrypt(cms, NULL, NULL, dcont, out, flags)>.
-Among others, this call deallocates any decryption key stored in I<cms>.
+This call deallocates any decryption key stored in I<cms>.
 
 CMS_decrypt_set1_pkey() is the same as
 CMS_decrypt_set1_pkey_and_peer() with I<peer> being NULL.
@@ -48,7 +48,7 @@ CMS_decrypt_set1_password() decrypts the CMS_ContentInfo structure I<cms>
 using the secret I<pass> of length I<passlen>.
 On success, it also records in I<cms> the decryption key used, and then
 should be followed by C<CMS_decrypt(cms, NULL, NULL, dcont, out, flags)>.
-Among others, this call deallocates any decryption key stored in I<cms>.
+This call deallocates any decryption key stored in I<cms>.
 
 =head1 NOTES
 

--- a/doc/man3/CMS_decrypt.pod
+++ b/doc/man3/CMS_decrypt.pod
@@ -37,14 +37,14 @@ is detached. It will normally be set to NULL.
 CMS_decrypt_set1_pkey_and_peer() decrypts the CMS_ContentInfo structure I<cms>
 using the private key I<pkey>, the corresponding certificate I<cert>, which is
 recommended but may be NULL, and the (optional) originator certificate I<peer>.
-It can be followed by I<CMS_decrypt(cms, NULL, NULL, dcont, out, flags)>.
+It can be followed by C<CMS_decrypt(cms, NULL, NULL, dcont, out, flags)>.
 
 CMS_decrypt_set1_pkey() is the same as
 CMS_decrypt_set1_pkey_and_peer() with I<peer> being NULL.
 
 CMS_decrypt_set1_password() decrypts the CMS_ContentInfo structure I<cms>
 using the secret I<pass> of length I<passlen>.
-It can be followed by I<CMS_decrypt(cms, NULL, NULL, dcont, out, flags)>.
+It can be followed by C<CMS_decrypt(cms, NULL, NULL, dcont, out, flags)>.
 
 =head1 NOTES
 

--- a/doc/man3/CMS_decrypt.pod
+++ b/doc/man3/CMS_decrypt.pod
@@ -37,14 +37,18 @@ is detached. It will normally be set to NULL.
 CMS_decrypt_set1_pkey_and_peer() decrypts the CMS_ContentInfo structure I<cms>
 using the private key I<pkey>, the corresponding certificate I<cert>, which is
 recommended but may be NULL, and the (optional) originator certificate I<peer>.
-It can be followed by C<CMS_decrypt(cms, NULL, NULL, dcont, out, flags)>.
+On success, it also records the key I<cms>, and then
+should be followed by C<CMS_decrypt(cms, NULL, NULL, dcont, out, flags)>.
+Among others, this call deallocates any decryption key stored in I<cms>.
 
 CMS_decrypt_set1_pkey() is the same as
 CMS_decrypt_set1_pkey_and_peer() with I<peer> being NULL.
 
 CMS_decrypt_set1_password() decrypts the CMS_ContentInfo structure I<cms>
 using the secret I<pass> of length I<passlen>.
-It can be followed by C<CMS_decrypt(cms, NULL, NULL, dcont, out, flags)>.
+On success, it also records in I<cms> the decryption key used, and then
+should be followed by C<CMS_decrypt(cms, NULL, NULL, dcont, out, flags)>.
+Among others, this call deallocates any decryption key stored in I<cms>.
 
 =head1 NOTES
 


### PR DESCRIPTION
It turns out that my recent implementation of `CMS_EnvelopedData_decrypt()` in #18301 was somewhat mislead
* by the `set1_` part of the function name `CMS_decrypt_set1_password()` and 
* mostly by the fact that all the `CMS_decrypt*()` functions were insufficiently documented.

The reviewers did not notice presumably for the same reason(s).
Both the function and the docs are fixed by this PR, pointing out the potential pitfall.

The catch is that all `CMS_decrypt*()` functions do not only set/use decryption credentials 
but actually attempt decryption (unless `CMS_decrypt()` is called with a NULL `pkey` argument)
and this will fail if not just the right type of decryption key (symmetric or asymmetric) is provided.

BTW, this CMS API is (needlessly) limited in case the recipient does not know which decryption credential to use, which may be asymmetric and/or symmetric. So it could be helpful to provide both, in case it is unclear which type of encryption the peer used.

In the original implementation of `CMS_EnvelopedData_decrypt()` I had assumed that both types of decryption keys can be provided at the same time, but this not only lead to the error(s) quoted here:
```
...:CMS routines():crypto/cms/cms_smime.c:776: ERROR: no matching recipient
...:OSSL_CRMF_ENCRYPTEDKEY_get1_pkey():crypto/crmf/crmf_lib.c:717: ERROR: error decrypting encryptedkey
...:ossl_cmp_certresponse_get1_cert_key():crypto/cmp/cmp_msg.c:1102: ERROR: failed extracting central gen key
...:get1_cert_key_status():crypto/cmp/cmp_client.c:457: ERROR: certificate not found:; cannot extract certificate from response
...
```
but also to a tricky memory leak:
```
=================================================================
==1366017==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 48 byte(s) in 1 object(s) allocated from:
    #0 0x7f03d5997e8f in __interceptor_malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:145
    #1 0x7f03d54312a4 in CRYPTO_malloc crypto/mem.c:196
    #2 0x7f03d5330f59 in ossl_cms_RecipientInfo_pwri_crypt crypto/cms/cms_pwri.c:378
    #3 0x7f03d532b40d in CMS_RecipientInfo_decrypt crypto/cms/cms_env.c:1016
    #4 0x7f03d5336c1a in CMS_decrypt_set1_password crypto/cms/cms_smime.c:831
    #5 0x7f03d5801295 in CMS_EnvelopedData_decrypt crypto/crmf/crmf_lib.c:983
    #6 0x7f03d57ff750 in OSSL_CRMF_ENCRYPTEDKEY_get1_pkey crypto/crmf/crmf_lib.c:714
    #7 0x7f03d5819d2a in ossl_cmp_certresponse_get1_cert_key crypto/cmp/cmp_msg.c:1096
    #8 0x7f03d5821709 in get1_cert_key_status crypto/cmp/cmp_client.c:455
    #9 0x7f03d5822325 in cert_response crypto/cmp/cmp_client.c:578
    #10 0x7f03d5823241 in OSSL_CMP_exec_certreq crypto/cmp/cmp_client.c:726
    ...

SUMMARY: AddressSanitizer: 48 byte(s) leaked in 1 allocation(s).
```
which is fixed - hopefully in a sufficient way - by this PR, too.