### PR TITLE
follow up on #19180, OSSL_CRYPTO_ASIZE* macros

### DIFF
--- a/include/openssl/crypto.h.in
+++ b/include/openssl/crypto.h.in
@@ -318,15 +318,15 @@ void CRYPTO_get_mem_functions(CRYPTO_malloc_fn *malloc_fn,
                               CRYPTO_realloc_fn *realloc_fn,
                               CRYPTO_free_fn *free_fn);
 
-OSSL_CRYPTO_ALLOC void *CRYPTO_malloc(size_t num, const char *file, int line);
-OSSL_CRYPTO_ALLOC void *CRYPTO_zalloc(size_t num, const char *file, int line);
-OSSL_CRYPTO_ALLOC void *CRYPTO_memdup(const void *str, size_t siz, const char *file, int line);
+OSSL_CRYPTO_ALLOC OSSL_CRYPTO_ASIZE_1 void *CRYPTO_malloc(size_t num, const char *file, int line);
+OSSL_CRYPTO_ALLOC OSSL_CRYPTO_ASIZE_1 void *CRYPTO_zalloc(size_t num, const char *file, int line);
+OSSL_CRYPTO_ALLOC OSSL_CRYPTO_ASIZE_2 void *CRYPTO_memdup(const void *str, size_t siz, const char *file, int line);
 OSSL_CRYPTO_ALLOC char *CRYPTO_strdup(const char *str, const char *file, int line);
 OSSL_CRYPTO_ALLOC char *CRYPTO_strndup(const char *str, size_t s, const char *file, int line);
 void CRYPTO_free(void *ptr, const char *file, int line);
 void CRYPTO_clear_free(void *ptr, size_t num, const char *file, int line);
-void *CRYPTO_realloc(void *addr, size_t num, const char *file, int line);
-void *CRYPTO_clear_realloc(void *addr, size_t old_num, size_t num,
+OSSL_CRYPTO_ASIZE_2 void *CRYPTO_realloc(void *addr, size_t num, const char *file, int line);
+OSSL_CRYPTO_ASIZE_3 void *CRYPTO_clear_realloc(void *addr, size_t old_num, size_t num,
                            const char *file, int line);
 
 int CRYPTO_secure_malloc_init(size_t sz, size_t minsize);

--- a/include/openssl/macros.h
+++ b/include/openssl/macros.h
@@ -322,4 +322,16 @@
 #  endif
 # endif
 
+# ifndef OSSL_CRYPTO_ASIZE_1
+#  if defined(__GNUC__)
+#   define OSSL_CRYPTO_ASIZE_1 __attribute__((alloc_size(1)))
+#   define OSSL_CRYPTO_ASIZE_2 __attribute__((alloc_size(2)))
+#   define OSSL_CRYPTO_ASIZE_3 __attribute__((alloc_size(3)))
+#  else
+#   define OSSL_CRYPTO_ASIZE_1
+#   define OSSL_CRYPTO_ASIZE_2
+#   define OSSL_CRYPTO_ASIZE_3
+#  endif
+# endif
+
 #endif  /* OPENSSL_MACROS_H */


### PR DESCRIPTION
to give hints to the compiler about the origin of the size.