### PR TITLE
Check that sk_SSL_CIPHER_value returns non-NULL value.

### DIFF
--- a/apps/ciphers.c
+++ b/apps/ciphers.c
@@ -226,6 +226,10 @@ int ciphers_main(int argc, char **argv)
     if (!verbose) {
         for (i = 0; i < sk_SSL_CIPHER_num(sk); i++) {
             const SSL_CIPHER *c = sk_SSL_CIPHER_value(sk, i);
+
+            if (!ossl_assert(c != NULL))
+                continue;
+
             p = SSL_CIPHER_get_name(c);
             if (p == NULL)
                 break;

--- a/apps/ciphers.c
+++ b/apps/ciphers.c
@@ -241,6 +241,9 @@ int ciphers_main(int argc, char **argv)
 
             c = sk_SSL_CIPHER_value(sk, i);
 
+            if (!ossl_assert(c != NULL))
+                continue;
+
             if (Verbose) {
                 unsigned long id = SSL_CIPHER_get_id(c);
                 int id0 = (int)(id >> 24);


### PR DESCRIPTION
Fixes openssl#19162.

I revisited the code and it looks that `sk_SSL_CIPHER_value` should not return `NULL`. But these checks with assert make it more obvious. 

There are other places that iterate over all ciphers' indexes, but they are more internal, so probably no need to add these checks.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
