### PR TITLE
Fix openssl mac and documentation

### DIFF
--- a/apps/mac.c
+++ b/apps/mac.c
@@ -169,9 +169,6 @@ opthelp:
             goto err;
     }
 
-    /* Use text mode for stdin */
-    if (infile == NULL || strcmp(infile, "-") == 0)
-        inform = FORMAT_TEXT;
     in = bio_open_default(infile, 'r', inform);
     if (in == NULL)
         goto err;

--- a/doc/man1/openssl-mac.pod.in
+++ b/doc/man1/openssl-mac.pod.in
@@ -35,8 +35,7 @@ Print a usage message.
 
 Input filename to calculate a MAC for, or standard input by default.
 Standard input is used if the filename is '-'.
-Files are expected to be in binary format, standard input uses hexadecimal text
-format.
+Files and standard input are expected to be in binary format.
 
 =item B<-out> I<filename>
 


### PR DESCRIPTION
Fixes #19227

The documentation incorrectly said stdin should be hexadecimal. Code incorrectly switched to FORMAT_TEXT when using stdin.
Documentation and code updated to reflect reality.

##### Checklist
- [x] documentation is added or updated

