### PR TITLE
apps/ciphers.h: Ensure ossl_assert() is properly declared [3.0 only]

### DIFF
--- a/apps/include/apps.h
+++ b/apps/include/apps.h
@@ -13,6 +13,7 @@
 # include "e_os.h" /* struct timeval for DTLS */
 # include "internal/nelem.h"
 # include "internal/sockets.h" /* for openssl_fdset() */
+# include "internal/cryptlib.h"  /* ossl_assert() */
 # include <assert.h>
 
 # include <stdarg.h>


### PR DESCRIPTION
This is necessary for this branch to build
