### PR TITLE
crypto/sm2/sm2_sign.c: Add BN_CTX_end

### DIFF
--- a/crypto/sm2/sm2_sign.c
+++ b/crypto/sm2/sm2_sign.c
@@ -382,6 +382,7 @@ static int sm2_sig_verify(const EC_KEY *key, const ECDSA_SIG *sig,
         ret = 1;
 
  done:
+    BN_CTX_end(ctx);
     EC_POINT_free(pt);
     BN_CTX_free(ctx);
     return ret;


### PR DESCRIPTION
To match the BN_CTX_start, it should be better to add BN_CTX_end in the end of the function.

Signed-off-by: Jiasheng Jiang <jiasheng@iscas.ac.cn>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
