### PR TITLE
Fix build errors on djgpp

### DIFF
--- a/Configurations/50-djgpp.conf
+++ b/Configurations/50-djgpp.conf
@@ -4,6 +4,7 @@
 
 my %targets = (
     "DJGPP" => {
+        inherit_from     => [ "BASE_unix" ],
         CC               => "gcc",
         CFLAGS           => "-fomit-frame-pointer -O2 -Wall",
         cflags           => "-I/dev/env/WATT_ROOT/inc -DTERMIOS -DL_ENDIAN",

--- a/include/internal/e_os.h
+++ b/include/internal/e_os.h
@@ -287,7 +287,7 @@ struct servent *getservbyname(const char *name, const char *proto);
 /* end vxworks */
 
 /* system-specific variants defining ossl_sleep() */
-#ifdef OPENSSL_SYS_UNIX
+#if defined(OPENSSL_SYS_UNIX) || defined(__DJGPP__)
 # include <unistd.h>
 static ossl_inline void ossl_sleep(unsigned long millis)
 {

--- a/include/internal/sockets.h
+++ b/include/internal/sockets.h
@@ -28,6 +28,8 @@
 
 # elif defined(OPENSSL_SYS_WINDOWS) || defined(OPENSSL_SYS_MSDOS)
 #  if defined(__DJGPP__)
+#   define WATT32
+#   define WATT32_NO_OLDIES
 #   include <sys/socket.h>
 #   include <sys/un.h>
 #   include <tcp.h>
@@ -150,8 +152,6 @@ struct servent *PASCAL getservbyname(const char *, const char *);
 #  define readsocket(s,b,n)       recv((s),(b),(n),0)
 #  define writesocket(s,b,n)      send((s),(b),(n),0)
 # elif defined(__DJGPP__)
-#  define WATT32
-#  define WATT32_NO_OLDIES
 #  define closesocket(s)          close_s(s)
 #  define readsocket(s,b,n)       read_s(s,b,n)
 #  define writesocket(s,b,n)      send(s,b,n,0)


### PR DESCRIPTION
I tried cross-compiling the current `master` branch for djgpp and ran into some
errors.  This patch set aims to solve those.

On each commit I specified `CLA: trivial`, since they are small tweaks and do
not introduce any new features.  Only build errors are fixed.

Remaining issues:
* `test/rsa_complex.c` does not compile due to missing header `<complex.h>`.
* Linking is only possible when compiled with `-march=i486` or better, due to
  missing atomic instructions on i386 (these are compiled to libatomic calls,
  which are also missing).  Is it safe to define `-DOPENSSL_DEV_NO_ATOMICS`
  here, given that we have no (native) pre-emptive threads?

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->
