### PR TITLE
`test/trace_api_test.c`: fix gcc error on `-Werror=strict-prototypes`

### DIFF
--- a/test/trace_api_test.c
+++ b/test/trace_api_test.c
@@ -67,7 +67,7 @@ static int test_trace_categories(void)
 }
 
 #ifndef OPENSSL_NO_TRACE
-static void put_trace_output()
+static void put_trace_output(void)
 {
     OSSL_TRACE_BEGIN(TLS) {
         BIO_printf(trc_out, "Hello World\n");
@@ -75,7 +75,7 @@ static void put_trace_output()
     } OSSL_TRACE_END(TLS);
 }
 
-static int test_trace_channel()
+static int test_trace_channel(void)
 {
     static const char expected[] = "xyz-\nHello World\nGood Bye Universe\n-abc\n";
     static const char expected_len = sizeof(expected) - 1;


### PR DESCRIPTION
Carved out of #19271.

This is a fixup of #19096.
I wonder why the
```
test/trace_api_test.c:70:13: error: function declaration isn't a prototype [-Werror=strict-prototypes]
   70 | static void put_trace_output()
      |             ^~~~~~~~~~~~~~~~
test/trace_api_test.c:78:12: error: function declaration isn't a prototype [-Werror=strict-prototypes]
   78 | static int test_trace_channel()
      |            ^~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
```
got unnoticed, which occurs when configuring with `--strict-warnings -std=gnu90`.
