### PR TITLE
Fix HPKE and DHKEM for X25519 and X448 on s390x

### DIFF
--- a/providers/implementations/keymgmt/ecx_kmgmt.c
+++ b/providers/implementations/keymgmt/ecx_kmgmt.c
@@ -881,8 +881,19 @@ static void *s390x_ecx_keygen25519(struct ecx_gen_ctx *gctx)
         goto err;
     }
 
-    if (RAND_priv_bytes_ex(gctx->libctx, privkey, X25519_KEYLEN, 0) <= 0)
-        goto err;
+#ifndef FIPS_MODULE
+    if (gctx->dhkem_ikm != NULL && gctx->dhkem_ikmlen != 0) {
+        if (gctx->type != ECX_KEY_TYPE_X25519)
+            goto err;
+        if (!ossl_ecx_dhkem_derive_private(key, privkey,
+                                           gctx->dhkem_ikm, gctx->dhkem_ikmlen))
+            goto err;
+    } else
+#endif
+    {
+        if (RAND_priv_bytes_ex(gctx->libctx, privkey, X25519_KEYLEN, 0) <= 0)
+            goto err;
+    }
 
     privkey[0] &= 248;
     privkey[31] &= 127;
@@ -927,8 +938,19 @@ static void *s390x_ecx_keygen448(struct ecx_gen_ctx *gctx)
         goto err;
     }
 
-    if (RAND_priv_bytes_ex(gctx->libctx, privkey, X448_KEYLEN, 0) <= 0)
-        goto err;
+#ifndef FIPS_MODULE
+    if (gctx->dhkem_ikm != NULL && gctx->dhkem_ikmlen != 0) {
+        if (gctx->type != ECX_KEY_TYPE_X448)
+            goto err;
+        if (!ossl_ecx_dhkem_derive_private(key, privkey,
+                                           gctx->dhkem_ikm, gctx->dhkem_ikmlen))
+            goto err;
+    } else
+#endif
+    {
+        if (RAND_priv_bytes_ex(gctx->libctx, privkey, X448_KEYLEN, 0) <= 0)
+            goto err;
+    }
 
     privkey[0] &= 252;
     privkey[55] |= 128;


### PR DESCRIPTION
The IKM was not respected by the s390x specific implementations of X25519 and X448 keygen.  This caused test failures and wrong results if the PCC instruction was actually available and supported X25519 and/or X448.

Fixes: 78c44b05945b ("Add HPKE DHKEM provider support for EC, X25519 and X448.")
Signed-off-by: Juergen Christ <jchrist@linux.ibm.com>
