### PR TITLE
Fix recent regressions in CI builds

### DIFF
--- a/crypto/bio/bss_dgram_pair.c
+++ b/crypto/bio/bss_dgram_pair.c
@@ -745,7 +745,8 @@ static size_t dgram_pair_read_inner(struct bio_dgram_pair_st *b, uint8_t *buf, s
 
         ring_buf_pop(&b->rbuf, src_len);
 
-        buf         += src_len;
+        if (buf != NULL)
+            buf += src_len;
         total_read  += src_len;
         sz          -= src_len;
     }

--- a/crypto/bio/bss_dgram_pair.c
+++ b/crypto/bio/bss_dgram_pair.c
@@ -1012,7 +1012,7 @@ static ossl_ssize_t dgram_pair_write_actual(BIO *bio, const char *buf, size_t sz
                                             const BIO_ADDR *local, const BIO_ADDR *peer,
                                             int is_multi)
 {
-    static const BIO_ADDR zero_addr = {0};
+    static const BIO_ADDR zero_addr;
     size_t saved_idx, saved_count;
     struct bio_dgram_pair_st *b = bio->ptr, *peerb;
     struct dgram_hdr hdr = {0};

--- a/ssl/record/methods/tls_common.c
+++ b/ssl/record/methods/tls_common.c
@@ -1495,7 +1495,7 @@ int tls_write_records_default(OSSL_RECORD_LAYER *rl,
     size_t align = 0;
     SSL3_BUFFER *wb;
     SSL_SESSION *sess;
-    size_t totlen = 0, len, wpinited = 0;
+    size_t len, wpinited = 0;
     size_t j, prefix = 0;
     int using_ktls;
     /* TODO(RECLAYER): REMOVE ME */
@@ -1625,7 +1625,6 @@ int tls_write_records_default(OSSL_RECORD_LAYER *rl,
         }
     }
 
-    totlen = 0;
     /* Clear our SSL3_RECORD structures */
     memset(wr, 0, sizeof(wr));
     for (j = 0; j < numtempl + prefix; j++) {
@@ -1679,7 +1678,6 @@ int tls_write_records_default(OSSL_RECORD_LAYER *rl,
         SSL3_RECORD_set_length(thiswr, thistempl->buflen);
 
         SSL3_RECORD_set_input(thiswr, (unsigned char *)thistempl->buf);
-        totlen += thistempl->buflen;
 
         /*
          * we now 'read' from thiswr->input, thiswr->length bytes into


### PR DESCRIPTION
Fixes Compiler ZOO CI test failures and the stochastic test_bio_dgram failure.

Urgent as these are CI failures.
