### PR TITLE
OpenSSL::config: diverse guessing fixes

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -22,9 +22,9 @@ jobs:
           - windows-2022
         platform:
           - arch: win64
-            config: VC-WIN64A enable-fips
+            config: enable-fips
           - arch: win32
-            config: VC-WIN32 --strict-warnings no-fips
+            config: --strict-warnings no-fips
     runs-on: ${{matrix.os}}
     steps:
     - uses: actions/checkout@v2
@@ -95,7 +95,7 @@ jobs:
     - name: config
       working-directory: _build
       run: |
-        perl ..\Configure --banner=Configured no-makedepend no-bulk no-deprecated no-fips no-asm -DOPENSSL_SMALL_FOOTPRINT VC-WIN64A
+        perl ..\Configure --banner=Configured no-makedepend no-bulk no-deprecated no-fips no-asm -DOPENSSL_SMALL_FOOTPRINT
         perl configdata.pm --dump
     - name: build
       working-directory: _build

--- a/util/perl/OpenSSL/config.pm
+++ b/util/perl/OpenSSL/config.pm
@@ -15,6 +15,7 @@ use strict;
 use warnings;
 use Getopt::Std;
 use File::Basename;
+use File::Spec;
 use IPC::Cmd;
 use POSIX;
 use Config;
@@ -51,12 +52,15 @@ my @c_compilers = qw(clang gcc cc);
 my @cc_version =
     (
      clang => sub {
+         return undef unless IPC::Cmd::can_run("$CROSS_COMPILE$CC");
          my $v = `$CROSS_COMPILE$CC -v 2>&1`;
          $v =~ m/(?:(?:clang|LLVM) version|.*based on LLVM)\s+([0-9]+\.[0-9]+)/;
          return $1;
      },
      gnu => sub {
-         my $v = `$CROSS_COMPILE$CC -dumpversion 2>/dev/null`;
+         return undef unless IPC::Cmd::can_run("$CROSS_COMPILE$CC");
+         my $nul = File::Spec->devnull();
+         my $v = `$CROSS_COMPILE$CC -dumpversion 2> $nul`;
          # Strip off whatever prefix egcs prepends the number with.
          # Hopefully, this will work for any future prefixes as well.
          $v =~ s/^[a-zA-Z]*\-//;
@@ -903,7 +907,7 @@ EOF
             } else {
                 $config{disable} = [ 'asm' ];
             }
-            return %config;
+            return { %config };
         }
       ],
 

--- a/util/perl/OpenSSL/config.pm
+++ b/util/perl/OpenSSL/config.pm
@@ -17,6 +17,7 @@ use Getopt::Std;
 use File::Basename;
 use IPC::Cmd;
 use POSIX;
+use Config;
 use Carp;
 
 # These control our behavior.
@@ -159,6 +160,12 @@ my $guess_patterns = [
     [ 'MINGW.*',                    '${MACHINE}-whatever-mingw' ],
     [ 'CYGWIN.*',                   '${MACHINE}-pc-cygwin' ],
     [ 'vxworks.*',                  '${MACHINE}-whatever-vxworks' ],
+
+    # The MACHINE part of the array POSIX::uname() returns on VMS isn't
+    # worth the bits wasted on it.  It's better, then, to rely on perl's
+    # %Config, which has a trustworthy item 'archname', especially since
+    # VMS installation aren't multiarch (yet)
+    [ 'OpenVMS:.*',                 "$Config{archname}-whatever-OpenVMS" ],
 
     # Note: there's also NEO and NSR, but they are old and unsupported
     [ 'NONSTOP_KERNEL:.*:NSE-.*?',  'nse-tandem-nsk${RELEASE}' ],
@@ -930,12 +937,9 @@ _____
       ],
 
       # VMS values found by observation on existing machinery.
-      # Unfortunately, the machine part is a bit...  overdone.  It seems,
-      # though, that 'Alpha' exists in that part for Alphas, making it
-      # distinguishable from Itanium.  It will be interesting to see what
-      # we'll get in the upcoming x86_64 port...
-      [ '.*Alpha.*?-.*?-OpenVMS', { target => 'vms-alpha' } ],
-      [ '.*?-.*?-OpenVMS',        { target => 'vms-ia64'  } ],
+      [ 'VMS_AXP-.*?-OpenVMS',    { target => 'vms-alpha'  } ],
+      [ 'VMS_IA64-.*?-OpenVMS',   { target => 'vms-ia64'   } ],
+      [ 'VMS_x86_64-.*?-OpenVMS', { target => 'vms-x86_64' } ],
 
       # TODO: There are a few more choices among OpenSSL config targets, but
       # reaching them involves a bit more than just a host tripet.  Select

--- a/util/perl/OpenSSL/config.pm
+++ b/util/perl/OpenSSL/config.pm
@@ -920,10 +920,10 @@ EOF
             my $config;
 
             if ($arch) {
-                $config = { 'amd64' => { target => 'VC-WIN64I'    },
+                $config = { 'amd64' => { target => 'VC-WIN64A'    },
                             'ia64'  => { target => 'VC-WIN64I'    },
                             'x86'   => { target => 'VC-WIN32'     },
-                            'x64'   => { target => 'VC-WIN64I'    },
+                            'x64'   => { target => 'VC-WIN64A'    },
                             'ARM'   => { target => 'VC-WIN64-ARM' },
                           } -> {$arch};
                 die <<_____ unless defined $config;


### PR DESCRIPTION
- OpenSSL::config: determine the MSVC target architecture by asking cl
- OpenSSL::config: Fix VMS guesses
- OpenSSL::config: Fix trivial bugs

Please read the commit messages for details.

Fixes #19281, and more.
