### PR TITLE
Skip test/rsa_complex.c on djgpp

### DIFF
--- a/test/rsa_complex.c
+++ b/test/rsa_complex.c
@@ -11,13 +11,18 @@
  * Check to see if there is a conflict between complex.h and openssl/rsa.h.
  * The former defines "I" as a macro and earlier versions of the latter use
  * for function arguments.
+ *
+ * Will always succeed on djgpp, since its libc does not have complex.h.
  */
-#if defined(__STDC_VERSION__)
-# if __STDC_VERSION__ >= 199901L
-#  include <complex.h>
+
+#if !defined(__DJGPP__)
+# if defined(__STDC_VERSION__)
+#  if __STDC_VERSION__ >= 199901L
+#   include <complex.h>
+#  endif
 # endif
+# include <openssl/rsa.h>
 #endif
-#include <openssl/rsa.h>
 #include <stdlib.h>
 
 int main(int argc, char *argv[])


### PR DESCRIPTION
My other PR (#19274) is already undergoing review so I will refrain from
pushing more commits there.

I noted there that `test/rsa_complex.h` failed to compile but never actually
opened the file.  I see now that it only checks for macro collisions between
`<complex.h>` and `<openssl/rsa.h>`.  We don't have the former so this entire
test can simply be skipped.

This patch also applies to the 3.0 branch.

Alternatively `__has_include(<complex.h>)` could be checked, but I don't
believe that is a standardized macro in C (only in C++).

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
