### PR TITLE
Fix BIO_dgram_pair buffer arithmetic bug

### DIFF
--- a/crypto/bio/bss_dgram_pair.c
+++ b/crypto/bio/bss_dgram_pair.c
@@ -745,7 +745,9 @@ static size_t dgram_pair_read_inner(struct bio_dgram_pair_st *b, uint8_t *buf, s
 
         ring_buf_pop(&b->rbuf, src_len);
 
-        buf         += src_len;
+        if (buf != NULL)
+            buf += src_len;
+
         total_read  += src_len;
         sz          -= src_len;
     }


### PR DESCRIPTION
Managed to reproduce the test segfault. This appears to be the cause of the CI failures.