### PR TITLE
Disable printf format checking on MinGW

### DIFF
--- a/include/openssl/bio.h.in
+++ b/include/openssl/bio.h.in
@@ -870,6 +870,7 @@ void BIO_copy_next_retry(BIO *b);
 
 # define ossl_bio__attr__(x)
 # if defined(__GNUC__) && defined(__STDC_VERSION__) \
+    && !defined(__MINGW32__) && !defined(__MINGW64__) \
     && !defined(__APPLE__)
     /*
      * Because we support the 'z' modifier, which made its appearance in C99,

--- a/test/testutil.h
+++ b/test/testutil.h
@@ -286,7 +286,9 @@ const OPTIONS *test_get_options(void);
  */
 
 # define PRINTF_FORMAT(a, b)
-# if defined(__GNUC__) && defined(__STDC_VERSION__)
+# if defined(__GNUC__) && defined(__STDC_VERSION__) \
+    && !defined(__MINGW32__) && !defined(__MINGW64__) \
+    && !defined(__APPLE__)
   /*
    * Because we support the 'z' modifier, which made its appearance in C99,
    * we can't use __attribute__ with pre C99 dialects.

--- a/test/testutil/output.h
+++ b/test/testutil/output.h
@@ -14,6 +14,7 @@
 
 # define ossl_test__attr__(x)
 # if defined(__GNUC__) && defined(__STDC_VERSION__) \
+    && !defined(__MINGW32__) && !defined(__MINGW64__) \
     && !defined(__APPLE__)
     /*
      * Because we support the 'z' modifier, which made its appearance in C99,


### PR DESCRIPTION
Fixes openssl#19185

The same code related to format checking is on several places, maybe it would be better to have just one place, `bio.h.in` and not undef macro `ossl_bio__attr__` there.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
