### PR TITLE
Fix usage of custom EVP_CIPHER objects

### DIFF
--- a/crypto/evp/digest.c
+++ b/crypto/evp/digest.c
@@ -230,11 +230,12 @@ static int evp_md_init_internal(EVP_MD_CTX *ctx, const EVP_MD *type,
 # endif
 #endif
             || (ctx->flags & EVP_MD_CTX_FLAG_NO_INIT) != 0
-            || type->origin == EVP_ORIG_METH) {
+            || (type != NULL && type->origin == EVP_ORIG_METH)
+            || (type == NULL && ctx->digest != NULL
+                             && ctx->digest->origin == EVP_ORIG_METH)) {
         /* If we were using provided hash before, cleanup algctx */
         if (!evp_md_ctx_free_algctx(ctx))
             return 0;
-
         if (ctx->digest == ctx->fetched_digest)
             ctx->digest = NULL;
         EVP_MD_free(ctx->fetched_digest);

--- a/crypto/evp/evp_enc.c
+++ b/crypto/evp/evp_enc.c
@@ -159,6 +159,8 @@ static int evp_cipher_init_internal(EVP_CIPHER_CTX *ctx,
      * (legacy code)
      */
     if (cipher != NULL && ctx->cipher != NULL) {
+        if (ctx->cipher->cleanup && !ctx->cipher->cleanup(ctx))
+            return 0;
         OPENSSL_clear_free(ctx->cipher_data, ctx->cipher->ctx_size);
         ctx->cipher_data = NULL;
     }

--- a/crypto/evp/evp_enc.c
+++ b/crypto/evp/evp_enc.c
@@ -159,7 +159,7 @@ static int evp_cipher_init_internal(EVP_CIPHER_CTX *ctx,
      * (legacy code)
      */
     if (cipher != NULL && ctx->cipher != NULL) {
-        if (ctx->cipher->cleanup && !ctx->cipher->cleanup(ctx))
+        if (ctx->cipher->cleanup != NULL && !ctx->cipher->cleanup(ctx))
             return 0;
         OPENSSL_clear_free(ctx->cipher_data, ctx->cipher->ctx_size);
         ctx->cipher_data = NULL;

--- a/crypto/evp/evp_enc.c
+++ b/crypto/evp/evp_enc.c
@@ -144,7 +144,10 @@ static int evp_cipher_init_internal(EVP_CIPHER_CTX *ctx,
 #if !defined(OPENSSL_NO_ENGINE) && !defined(FIPS_MODULE)
             || tmpimpl != NULL
 #endif
-            || impl != NULL) {
+            || impl != NULL
+            || (cipher != NULL && cipher->origin == EVP_ORIG_METH)
+            || (cipher == NULL && ctx->cipher != NULL
+                               && ctx->cipher->origin == EVP_ORIG_METH)) {
         if (ctx->cipher == ctx->fetched_cipher)
             ctx->cipher = NULL;
         EVP_CIPHER_free(ctx->fetched_cipher);
@@ -159,7 +162,6 @@ static int evp_cipher_init_internal(EVP_CIPHER_CTX *ctx,
         OPENSSL_clear_free(ctx->cipher_data, ctx->cipher->ctx_size);
         ctx->cipher_data = NULL;
     }
-
 
     /* Start of non-legacy code below */
 

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -4290,7 +4290,7 @@ static int test_custom_md_meth(void)
      * library context in this test.
      */
     if (testctx != NULL)
-        return 1;
+        return TEST_skip("Non-default libctx");
 
     custom_md_init_called = custom_md_cleanup_called = 0;
 
@@ -4372,7 +4372,7 @@ static int test_custom_ciph_meth(void)
      * library context in this test.
      */
     if (testctx != NULL)
-        return 1;
+        return TEST_skip("Non-default libctx");
 
     custom_ciph_init_called = custom_ciph_cleanup_called = 0;
 


### PR DESCRIPTION
If a custom EVP_CIPHER object has been passed to EVP_CipherInit() then it
should be used in preference to a fetched cipher.

We also fix a possible NULL pointer deref in the same code for digests.

If the custom cipher passed to EVP_CipherInit() happens to use NID_undef
(which should be a discouraged practice), then in the previous
implementation this could result in the NULL cipher being fetched and
hence NULL encryption being unexpectedly used.

CVE-2022-3358

Fixes #18970

Note that this has been assessed as a low severity security issue. As per our policy, since it is low, it is being fixed in public and will be included in the next release.

We also fix a bug where the cleanup function for an EVP_CIPHER was not always being called when it should, which was highlighted by writing the test for the original issue.