### PR TITLE
Add djgpp as CI cross-compile target

### DIFF
--- a/.github/workflows/cross-compiles.yml
+++ b/.github/workflows/cross-compiles.yml
@@ -39,8 +39,15 @@ jobs:
         #   opensslcaps: optional; if opensslcapsname (see above) is set, then
         #                this string will be used as content for the OpenSSL
         #                capabilities variable.
+        #   ppa:   Launchpad PPA repository to download packages from.
         platform: [
           {
+            arch: i386-pc-msdosdjgpp,
+            libs: libc-djgpp-dev libwatt-djgpp-dev djgpp-utils,
+            target: no-threads 386 DJGPP,
+            tests: none,
+            ppa: jwt27/djgpp-toolchain
+          }, {
             arch: aarch64-linux-gnu,
             libs: libc6-dev-arm64-cross,
             target: linux-aarch64
@@ -143,6 +150,10 @@ jobs:
         ]
     runs-on: ubuntu-latest
     steps:
+    - name: install package repository
+      if: matrix.platform.ppa != ''
+      run: |
+        sudo add-apt-repository ppa:${{ matrix.platform.ppa }}
     - name: install packages
       run: |
         sudo apt-get update


### PR DESCRIPTION
As the title says, this patch introduces CI builds for djgpp.  This will help
catch incompatibilities from future commits early, making this port easier to
maintain.

The djgpp toolchain is not available from any official Debian/Ubuntu
repositories, so instead it is downloaded and installed from a Launchpad PPA
that I personally maintain.  This is located here:

https://launchpad.net/~jwt27/+archive/ubuntu/djgpp-toolchain

Of course, this could introduce possible security risks.  If write permissions
are ever given in `cross-compiles.yml`, or any secrets are ever exported to the
build environment, software from this repository could gain access to that, so
care must be taken to avoid this.

I am leaving this PR as a draft for now, since the library currently does not
compile with `--strict-warnings`.  In order for this patch to be useful, that
would have to be resolved first.  The output from `make -k 2> error.log` may be
found here:

https://gist.github.com/jwt27/c7ac4f9b3f8c277c170e8acf374e8a5e

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->