### PR TITLE
quic: Define SHUT_RD|SHUT_WR for Windows

### DIFF
--- a/ssl/quic/quic_rx_depack.c
+++ b/ssl/quic/quic_rx_depack.c
@@ -18,6 +18,18 @@
 #include "quic_local.h"
 #include "../ssl_local.h"
 
+#ifdef _WIN32
+#ifndef SHUT_RD
+#define SHUT_RD SD_RECEIVE
+#endif
+#ifndef SHUT_WR
+#define SHUT_WR SD_SEND
+#endif
+#ifndef SHUT_RDWR
+#define SHUT_RDWR SD_BOTH
+#endif
+#endif
+
 /*
  * TODO(QUIC): ASSUMPTION: the QUIC_CONNECTION structure refers to other related
  * components, such as OSSL_ACKM and OSSL_QRX, in some manner.  These macros


### PR DESCRIPTION
WIN32 defines `how` options for `shutdown()` in their own way.
This fix defines `SHUT_RD` and `SHUT_RD` based on WIN32 equivalents.

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
