### PR TITLE
Avoid divide by 0 exception

### DIFF
--- a/include/internal/safe_math.h
+++ b/include/internal/safe_math.h
@@ -183,7 +183,7 @@
                                                                type b,       \
                                                                int *err)     \
     {                                                                        \
-        if (a > max / b)                                                     \
+        if (b != 0 && a > max / b)                                           \
             *err |= 1;                                                       \
         return a * b;                                                        \
     }


### PR DESCRIPTION
Problem is observed when running `quic_record_test` on Windows.
The test would lead to calling `safe_mul_time()` with `b = 0` and MSVC runtime would raise the divide by 0 exception.

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
