### PR TITLE
Adding signature algorithms via provider interface

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,15 @@ OpenSSL 3.2
 
    *Oliver Mihatsch*
 
+ * Added support for pluggable (provider-based) TLS signature algorithms.
+   This enables TLS 1.3 authentication operations with algorithms embedded
+   in providers not included by default in OpenSSL. In combination with
+   the already available pluggable KEM and X.509 support, this enables
+   for example suitable providers to deliver post-quantum or quantum-safe
+   cryptography to OpenSSL users.
+
+   *Michael Baentsch*
+
  * Added support for Hybrid Public Key Encryption (HPKE) as defined
    in RFC9180. HPKE is required for TLS Encrypted ClientHello (ECH),
    Message Layer Security (MLS) and other IETF specifications.

--- a/NEWS.md
+++ b/NEWS.md
@@ -28,6 +28,9 @@ OpenSSL 3.2
     by default.
   * TCP Fast Open (RFC7413) support is available on Linux, macOS, and FreeBSD
     where enabled and supported.
+  * Full support for provider-based/pluggable signature algorithms in TLS 1.3
+    operations as well as X.509 data structure support. With a suitable provider
+    this fully enables use of post-quantum/quantum-safe cryptography.
 
 OpenSSL 3.1
 -----------

--- a/apps/lib/s_cb.c
+++ b/apps/lib/s_cb.c
@@ -258,7 +258,8 @@ static const char *get_sigtype(int nid)
         return "gost2012_512";
 
     default:
-        return NULL;
+        /* Try to output provider-registered sig alg name */
+        return OBJ_nid2sn(nid);
     }
 }
 

--- a/crypto/x509/x509_set.c
+++ b/crypto/x509/x509_set.c
@@ -238,6 +238,7 @@ static int x509_sig_info_init(X509_SIG_INFO *siginf, const X509_ALGOR *alg,
         }
         if (pubkey != NULL) {
             int secbits = EVP_PKEY_get_security_bits(pubkey);
+
             if (secbits != 0) {
                 siginf->secbits = secbits;
                 break;

--- a/crypto/x509/x509_set.c
+++ b/crypto/x509/x509_set.c
@@ -234,15 +234,15 @@ static int x509_sig_info_init(X509_SIG_INFO *siginf, const X509_ALGOR *alg,
         ameth = EVP_PKEY_asn1_find(NULL, pknid);
         if (ameth != NULL && ameth->siginf_set != NULL
                 && ameth->siginf_set(siginf, alg, sig)) {
-	    break;
-	}
-	if (pubkey != NULL) {
-	    int secbits = EVP_PKEY_get_security_bits(pubkey);
-	    if (secbits != 0) {
+           break;
+        }
+        if (pubkey != NULL) {
+            int secbits = EVP_PKEY_get_security_bits(pubkey);
+            if (secbits != 0) {
                 siginf->secbits = secbits;
-		break;
-	    }
-	}
+                break;
+            }
+        }
         ERR_raise(ERR_LIB_X509, X509_R_ERROR_USING_SIGINF_SET);
         return 0;
         /*
@@ -296,5 +296,5 @@ static int x509_sig_info_init(X509_SIG_INFO *siginf, const X509_ALGOR *alg,
 int ossl_x509_init_sig_info(X509 *x)
 {
     return x509_sig_info_init(&x->siginf, &x->sig_alg, &x->signature,
-		              X509_PUBKEY_get0(x->cert_info.key));
+                              X509_PUBKEY_get0(x->cert_info.key));
 }

--- a/crypto/x509/x509_set.c
+++ b/crypto/x509/x509_set.c
@@ -210,7 +210,7 @@ int X509_get_signature_info(X509 *x, int *mdnid, int *pknid, int *secbits,
 
 /* Modify *siginf according to alg and sig. Return 1 on success, else 0. */
 static int x509_sig_info_init(X509_SIG_INFO *siginf, const X509_ALGOR *alg,
-                              const ASN1_STRING *sig)
+                              const ASN1_STRING *sig, const EVP_PKEY *pubkey)
 {
     int pknid, mdnid;
     const EVP_MD *md;
@@ -232,12 +232,19 @@ static int x509_sig_info_init(X509_SIG_INFO *siginf, const X509_ALGOR *alg,
     case NID_undef:
         /* If we have one, use a custom handler for this algorithm */
         ameth = EVP_PKEY_asn1_find(NULL, pknid);
-        if (ameth == NULL || ameth->siginf_set == NULL
-                || !ameth->siginf_set(siginf, alg, sig)) {
-            ERR_raise(ERR_LIB_X509, X509_R_ERROR_USING_SIGINF_SET);
-            return 0;
-        }
-        break;
+        if (ameth != NULL && ameth->siginf_set != NULL
+                && ameth->siginf_set(siginf, alg, sig)) {
+	    break;
+	}
+	if (pubkey != NULL) {
+	    int secbits = EVP_PKEY_get_security_bits(pubkey);
+	    if (secbits != 0) {
+                siginf->secbits = secbits;
+		break;
+	    }
+	}
+        ERR_raise(ERR_LIB_X509, X509_R_ERROR_USING_SIGINF_SET);
+        return 0;
         /*
          * SHA1 and MD5 are known to be broken. Reduce security bits so that
          * they're no longer accepted at security level 1.
@@ -288,5 +295,6 @@ static int x509_sig_info_init(X509_SIG_INFO *siginf, const X509_ALGOR *alg,
 /* Returns 1 on success, 0 on failure */
 int ossl_x509_init_sig_info(X509 *x)
 {
-    return x509_sig_info_init(&x->siginf, &x->sig_alg, &x->signature);
+    return x509_sig_info_init(&x->siginf, &x->sig_alg, &x->signature,
+		              X509_PUBKEY_get0(x->cert_info.key));
 }

--- a/crypto/x509/x509_set.c
+++ b/crypto/x509/x509_set.c
@@ -233,12 +233,12 @@ static int x509_sig_info_init(X509_SIG_INFO *siginf, const X509_ALGOR *alg,
         /* If we have one, use a custom handler for this algorithm */
         ameth = EVP_PKEY_asn1_find(NULL, pknid);
         if (ameth != NULL && ameth->siginf_set != NULL
-                && ameth->siginf_set(siginf, alg, sig)) {
+                && ameth->siginf_set(siginf, alg, sig))
            break;
-        }
         if (pubkey != NULL) {
-            int secbits = EVP_PKEY_get_security_bits(pubkey);
+            int secbits;
 
+            secbits = EVP_PKEY_get_security_bits(pubkey);
             if (secbits != 0) {
                 siginf->secbits = secbits;
                 break;

--- a/doc/man7/provider-base.pod
+++ b/doc/man7/provider-base.pod
@@ -605,11 +605,13 @@ of the various TLS versions. For example TLSv1.3 is 0x0304 (772 decimal), and
 TLSv1.2 is 0x0303 (771 decimal). A 0 indicates that there is no defined minimum
 or maximum. A -1 indicates that the group should not be used in that protocol.
 
+=back
+
 =head3 "TLS-SIGALG" Capability
 
 The "TLS-SIGALG" capability can be queried by libssl to discover the list of
 TLS signature algorithms that a provider can support. Each signature supported
-can be used for client- or server-authentication in addition to the build-in
+can be used for client- or server-authentication in addition to the built-in
 signature algorithms.
 TLS1.3 clients can advertise the list of TLS signature algorithms they support
 in the signature_algorithms extension, and TLS servers can select an algorithm
@@ -619,61 +621,111 @@ additional ones.
 
 Each TLS signature algorithm that a provider supports should be described via
 the callback passed in through the provider_get_capabilities function. Each
-algorithm should have the following details supplied (all are mandatory):
+algorithm can have the following details supplied:
 
 =over 4
 
-=item "tls-sigalg-name" (B<OSSL_CAPABILITY_TLS_SIGALG_NAME>) <UTF8 string>
+=item "iana-name" (B<OSSL_CAPABILITY_TLS_SIGALG_IANA_NAME>) <UTF8 string>
 
-The name of the signature algorithm as given in the IANA TLS Signature Scheme registry
+The name of the signature algorithm as given in the IANA TLS Signature Scheme
+registry as "Description":
 L<https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-signaturescheme>.
+This value is mandatory to be supplied.
 
-=item "tls-sigalg-name-internal" (B<OSSL_CAPABILITY_TLS_SIGALG_NAME_INTERNAL>) <UTF8 string>
+=item "iana-code-point" (B<OSSL_CAPABILITY_TLS_SIGALG_CODE_POINT>) <unsigned integer>
 
-The name of the signature algorithm as known by the provider. This could be
-the same as the "tls-sigalg-name", but does not have to be.
+The TLS algorithm ID value as given in the IANA TLS SignatureScheme registry.
+This value is mandatory to be supplied.
 
-=item "tls-sigalg-code-point" (B<OSSL_CAPABILITY_TLS_SIGALG_CODE_POINT>) <unsigned integer>
+=item "sigalg-name" (B<OSSL_CAPABILITY_TLS_SIGALG_NAME>) <UTF8 string>
 
-The TLS algorithm id value as given in the IANA TLS SignatureScheme registry.
+A name for the full (possibly composite hash-and-signature) signature
+algorithm.
+The provider may, but is not obligated to provide a signature implementation
+with this name; if it doesn't, this is assumed to be a composite of a pure
+signature algorithm and a hash algorithm, which must be given with the
+parameters "sig-name" and "hash-name".
+This value is mandatory to be supplied.
 
-=item "tls-sigalg-alg" (B<OSSL_CAPABILITY_TLS_SIGALG_ALG>) <UTF8 string>
+=item "sigalg-oid" (B<OSSL_CAPABILITY_TLS_SIGALG_OID>) <UTF8 string>
 
-The name of a Key Management algorithm that the provider offers and that should
-be used with this algorithm.
-The algorithm must support key and parameter generation as well as sign and
-verify operations.
+The OID of the "sig-name" algorithm in canonical numeric text form. If
+this parameter is given, OBJ_create() will be used to create an OBJ and
+a NID for this OID, using the "sigalg-name" parameter for its (short) name.
+Otherwise, it's assumed to already exist in the object database, possibly
+done by the provider with the core_obj_create() upcall.
+This value is optional to be supplied.
 
-=item "tls-sigalg-oid" (B<OSSL_CAPABILITY_TLS_SIGALG_OID>) <UTF8 string>
+=item "sig-name" (B<OSSL_CAPABILITY_TLS_SIGALG_SIG_NAME>) <UTF8 string>
 
-The OID of the signature algorithm.
+The name of the pure signature algorithm that is part of a composite
+"sigalg-name". If "sigalg-name" is implemented by the provider, this
+parameter is redundant and must not be given.
+This value is optional to be supplied.
 
-=item "tls-sigalg-hashalg" (B<OSSL_CAPABILITY_TLS_SIGALG_HASHALG>) <UTF8 string>
+=item "sig-oid" (B<OSSL_CAPABILITY_TLS_SIGALG_SIG_OID>) <UTF8 string>
 
-The name of the hash algorithm to be used with this signature algorithm.
-Value may be NULL or "" (empty string) if the signature algorithm can
-process arbitrary length data in sign/verify operations.
+The OID of the "sig-name" algorithm in canonical numeric text form. If
+this parameter is given, OBJ_create() will be used to create an OBJ and
+a NID for this OID, using the "sig-name" parameter for its (short) name.
+Otherwise, it's assumed to already exist in the object database, possibly
+done by the provider with the core_obj_create() upcall.
+This value is optional to be supplied.
 
-=item "tls-sigalg-sec-bits" (B<OSSL_CAPABILITY_TLS_SIGALG_SECURITY_BITS>) <unsigned integer>
+=item "hash-name" (B<OSSL_CAPABILITY_TLS_SIGALG_HASH_NAME>) <UTF8 string>
+
+The name of the hash algorithm that is part of a composite "sigalg-name".
+If "sigalg-name" is implemented by the provider, this parameter is redundant
+and must not be given.
+This value is optional to be supplied.
+
+=item "hash-oid" (B<OSSL_CAPABILITY_TLS_SIGALG_HASH_OID>) <UTF8 string>
+
+The OID of the "hash-name" algorithm in canonical numeric text form. If
+this parameter is given, OBJ_create() will be used to create an OBJ and
+a NID for this OID, using the "hash-name" parameter for its (short) name.
+Otherwise, it's assumed to already exist in the object database, possibly
+done by the provider with the core_obj_create() upcall.
+This value is optional to be supplied.
+
+=item "key-type" (B<OSSL_CAPABILITY_TLS_SIGALG_KEYTYPE>) <UTF8 string>
+
+The key type of the public key of applicable certificates. If this parameter
+isn't present, it's assumed to be the same as "sig-name" if that's present,
+otherwise "sigalg-name".
+This value is optional to be supplied.
+
+=item "key-type-oid" (B<OSSL_CAPABILITY_TLS_SIGALG_KEYTYPE_OID>) <UTF8 string>
+
+The OID of the "key-type" in canonical numeric text form. If
+this parameter is given, OBJ_create() will be used to create an OBJ and
+a NID for this OID, using the "key-type" parameter for its (short) name.
+Otherwise, it's assumed to already exist in the object database, possibly
+done by the provider with the core_obj_create() upcall.
+This value is optional to be supplied.
+
+=item "sec-bits" (B<OSSL_CAPABILITY_TLS_SIGALG_SECURITY_BITS>) <unsigned integer>
 
 The number of bits of security offered by keys of this algorithm. The number
 of bits should be comparable with the ones given in table 2 and 3 of the NIST
-SP800-57 document.
+SP800-57 document. This number is used to determine the security strength of
+the algorithm if no digest algorithm has been registered that otherwise
+defines the security strength. If the signature algorithm implements its own
+digest internally, this value needs to be set to properly reflect the overall
+security strength.
+This value is mandatory to be supplied.
 
-=item "tls-min-tls" (B<OSSL_CAPABILITY_TLS_GROUP_MIN_TLS>) <integer>
+=item "tls-min-tls" (B<OSSL_CAPABILITY_TLS_SIGALG_MIN_TLS>) <integer>
 
-=item "tls-max-tls" (B<OSSL_CAPABILITY_TLS_GROUP_MAX_TLS>) <integer>
+=item "tls-max-tls" (B<OSSL_CAPABILITY_TLS_SIGALG_MAX_TLS>) <integer>
 
-=item "tls-min-dtls" (B<OSSL_CAPABILITY_TLS_GROUP_MIN_DTLS>) <integer>
-
-=item "tls-max-dtls" (B<OSSL_CAPABILITY_TLS_GROUP_MAX_DTLS>) <integer>
-
-These parameters can be used to describe the minimum and maximum TLS and DTLS
-versions supported by the group. The values equate to the on-the-wire encoding
-of the various TLS versions. For example TLSv1.3 is 0x0304 (772 decimal), and
-TLSv1.2 is 0x0303 (771 decimal). A 0 indicates that there is no defined minimum
-or maximum. A -1 indicates that the group should not be used in that protocol.
-Presently values representing anything other than TLS1.3 are rejected.
+These parameters can be used to describe the minimum and maximum TLS
+versions supported by the signature algorithm. The values equate to the
+on-the-wire encoding of the various TLS versions. For example TLSv1.3 is
+0x0304 (772 decimal), and TLSv1.2 is 0x0303 (771 decimal). A 0 indicates that
+there is no defined minimum or maximum. A -1 indicates that the signature
+algorithm should not be used in that protocol.
+Presently values representing anything other than TLS1.3 are ignored.
 
 =back
 

--- a/doc/man7/provider-base.pod
+++ b/doc/man7/provider-base.pod
@@ -630,54 +630,54 @@ algorithm can have the following details supplied:
 The name of the signature algorithm as given in the IANA TLS Signature Scheme
 registry as "Description":
 L<https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-signaturescheme>.
-This value is mandatory to be supplied.
+This value must be supplied.
 
 =item "iana-code-point" (B<OSSL_CAPABILITY_TLS_SIGALG_CODE_POINT>) <unsigned integer>
 
 The TLS algorithm ID value as given in the IANA TLS SignatureScheme registry.
-This value is mandatory to be supplied.
+This value must be supplied.
 
 =item "sigalg-name" (B<OSSL_CAPABILITY_TLS_SIGALG_NAME>) <UTF8 string>
 
 A name for the full (possibly composite hash-and-signature) signature
 algorithm.
-The provider may, but is not obligated to provide a signature implementation
+The provider may, but is not obligated to, provide a signature implementation
 with this name; if it doesn't, this is assumed to be a composite of a pure
 signature algorithm and a hash algorithm, which must be given with the
 parameters "sig-name" and "hash-name".
-This value is mandatory to be supplied.
+This value must be supplied.
 
 =item "sigalg-oid" (B<OSSL_CAPABILITY_TLS_SIGALG_OID>) <UTF8 string>
 
-The OID of the "sig-name" algorithm in canonical numeric text form. If
+The OID of the "sigalg-name" algorithm in canonical numeric text form. If
 this parameter is given, OBJ_create() will be used to create an OBJ and
 a NID for this OID, using the "sigalg-name" parameter for its (short) name.
 Otherwise, it's assumed to already exist in the object database, possibly
 done by the provider with the core_obj_create() upcall.
-This value is optional to be supplied.
+This value is optional.
 
 =item "sig-name" (B<OSSL_CAPABILITY_TLS_SIGALG_SIG_NAME>) <UTF8 string>
 
 The name of the pure signature algorithm that is part of a composite
 "sigalg-name". If "sigalg-name" is implemented by the provider, this
 parameter is redundant and must not be given.
-This value is optional to be supplied.
+This value is optional.
 
 =item "sig-oid" (B<OSSL_CAPABILITY_TLS_SIGALG_SIG_OID>) <UTF8 string>
 
 The OID of the "sig-name" algorithm in canonical numeric text form. If
 this parameter is given, OBJ_create() will be used to create an OBJ and
 a NID for this OID, using the "sig-name" parameter for its (short) name.
-Otherwise, it's assumed to already exist in the object database, possibly
-done by the provider with the core_obj_create() upcall.
-This value is optional to be supplied.
+Otherwise, it is assumed to already exist in the object database. This
+can be done by the provider using the core_obj_create() upcall.
+This value is optional.
 
 =item "hash-name" (B<OSSL_CAPABILITY_TLS_SIGALG_HASH_NAME>) <UTF8 string>
 
 The name of the hash algorithm that is part of a composite "sigalg-name".
 If "sigalg-name" is implemented by the provider, this parameter is redundant
 and must not be given.
-This value is optional to be supplied.
+This value is optional.
 
 =item "hash-oid" (B<OSSL_CAPABILITY_TLS_SIGALG_HASH_OID>) <UTF8 string>
 
@@ -686,14 +686,14 @@ this parameter is given, OBJ_create() will be used to create an OBJ and
 a NID for this OID, using the "hash-name" parameter for its (short) name.
 Otherwise, it's assumed to already exist in the object database, possibly
 done by the provider with the core_obj_create() upcall.
-This value is optional to be supplied.
+This value is optional.
 
 =item "key-type" (B<OSSL_CAPABILITY_TLS_SIGALG_KEYTYPE>) <UTF8 string>
 
 The key type of the public key of applicable certificates. If this parameter
 isn't present, it's assumed to be the same as "sig-name" if that's present,
 otherwise "sigalg-name".
-This value is optional to be supplied.
+This value is optional.
 
 =item "key-type-oid" (B<OSSL_CAPABILITY_TLS_SIGALG_KEYTYPE_OID>) <UTF8 string>
 
@@ -702,7 +702,7 @@ this parameter is given, OBJ_create() will be used to create an OBJ and
 a NID for this OID, using the "key-type" parameter for its (short) name.
 Otherwise, it's assumed to already exist in the object database, possibly
 done by the provider with the core_obj_create() upcall.
-This value is optional to be supplied.
+This value is optional.
 
 =item "sec-bits" (B<OSSL_CAPABILITY_TLS_SIGALG_SECURITY_BITS>) <unsigned integer>
 
@@ -713,7 +713,7 @@ the algorithm if no digest algorithm has been registered that otherwise
 defines the security strength. If the signature algorithm implements its own
 digest internally, this value needs to be set to properly reflect the overall
 security strength.
-This value is mandatory to be supplied.
+This value must be supplied.
 
 =item "tls-min-tls" (B<OSSL_CAPABILITY_TLS_SIGALG_MIN_TLS>) <integer>
 
@@ -725,7 +725,8 @@ on-the-wire encoding of the various TLS versions. For example TLSv1.3 is
 0x0304 (772 decimal), and TLSv1.2 is 0x0303 (771 decimal). A 0 indicates that
 there is no defined minimum or maximum. A -1 indicates that the signature
 algorithm should not be used in that protocol.
-Presently values representing anything other than TLS1.3 are ignored.
+Presently values representing anything other than TLS1.3 mean that the
+complete algorithm is ignored.
 
 =back
 

--- a/doc/man7/provider-base.pod
+++ b/doc/man7/provider-base.pod
@@ -605,6 +605,76 @@ of the various TLS versions. For example TLSv1.3 is 0x0304 (772 decimal), and
 TLSv1.2 is 0x0303 (771 decimal). A 0 indicates that there is no defined minimum
 or maximum. A -1 indicates that the group should not be used in that protocol.
 
+=head3 "TLS-SIGALG" Capability
+
+The "TLS-SIGALG" capability can be queried by libssl to discover the list of
+TLS signature algorithms that a provider can support. Each signature supported
+can be used for client- or server-authentication in addition to the build-in
+signature algorithms.
+TLS1.3 clients can advertise the list of TLS signature algorithms they support
+in the signature_algorithms extension, and TLS servers can select an algorithm
+from the offered list that they also support. In this way a provider can add
+to the list of signature algorithms that libssl already supports with
+additional ones.
+
+Each TLS signature algorithm that a provider supports should be described via
+the callback passed in through the provider_get_capabilities function. Each
+algorithm should have the following details supplied (all are mandatory):
+
+=over 4
+
+=item "tls-sigalg-name" (B<OSSL_CAPABILITY_TLS_SIGALG_NAME>) <UTF8 string>
+
+The name of the signature algorithm as given in the IANA TLS Signature Scheme registry
+L<https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-signaturescheme>.
+
+=item "tls-sigalg-name-internal" (B<OSSL_CAPABILITY_TLS_SIGALG_NAME_INTERNAL>) <UTF8 string>
+
+The name of the signature algorithm as known by the provider. This could be
+the same as the "tls-sigalg-name", but does not have to be.
+
+=item "tls-sigalg-code-point" (B<OSSL_CAPABILITY_TLS_SIGALG_CODE_POINT>) <unsigned integer>
+
+The TLS algorithm id value as given in the IANA TLS SignatureScheme registry.
+
+=item "tls-sigalg-alg" (B<OSSL_CAPABILITY_TLS_SIGALG_ALG>) <UTF8 string>
+
+The name of a Key Management algorithm that the provider offers and that should
+be used with this algorithm.
+The algorithm must support key and parameter generation as well as sign and
+verify operations.
+
+=item "tls-sigalg-oid" (B<OSSL_CAPABILITY_TLS_SIGALG_OID>) <UTF8 string>
+
+The OID of the signature algorithm.
+
+=item "tls-sigalg-hashalg" (B<OSSL_CAPABILITY_TLS_SIGALG_HASHALG>) <UTF8 string>
+
+The name of the hash algorithm to be used with this signature algorithm.
+Value may be NULL or "" (empty string) if the signature algorithm can
+process arbitrary length data in sign/verify operations.
+
+=item "tls-sigalg-sec-bits" (B<OSSL_CAPABILITY_TLS_SIGALG_SECURITY_BITS>) <unsigned integer>
+
+The number of bits of security offered by keys of this algorithm. The number
+of bits should be comparable with the ones given in table 2 and 3 of the NIST
+SP800-57 document.
+
+=item "tls-min-tls" (B<OSSL_CAPABILITY_TLS_GROUP_MIN_TLS>) <integer>
+
+=item "tls-max-tls" (B<OSSL_CAPABILITY_TLS_GROUP_MAX_TLS>) <integer>
+
+=item "tls-min-dtls" (B<OSSL_CAPABILITY_TLS_GROUP_MIN_DTLS>) <integer>
+
+=item "tls-max-dtls" (B<OSSL_CAPABILITY_TLS_GROUP_MAX_DTLS>) <integer>
+
+These parameters can be used to describe the minimum and maximum TLS and DTLS
+versions supported by the group. The values equate to the on-the-wire encoding
+of the various TLS versions. For example TLSv1.3 is 0x0304 (772 decimal), and
+TLSv1.2 is 0x0303 (771 decimal). A 0 indicates that there is no defined minimum
+or maximum. A -1 indicates that the group should not be used in that protocol.
+Presently values representing anything other than TLS1.3 are rejected.
+
 =back
 
 =head1 NOTES

--- a/include/openssl/core_names.h
+++ b/include/openssl/core_names.h
@@ -541,17 +541,19 @@ extern "C" {
 #define OSSL_CAPABILITY_TLS_GROUP_MAX_DTLS          "tls-max-dtls"
 
 /* TLS-SIGALG Capability */
-#define OSSL_CAPABILITY_TLS_SIGALG_NAME              "tls-sigalg-name"
-#define OSSL_CAPABILITY_TLS_SIGALG_NAME_INTERNAL     "tls-sigalg-name-internal"
-#define OSSL_CAPABILITY_TLS_SIGALG_ALG               "tls-sigalg-alg"
-#define OSSL_CAPABILITY_TLS_SIGALG_HASHALG           "tls-sigalg-hashalg"
-#define OSSL_CAPABILITY_TLS_SIGALG_OID               "tls-sigalg-oid"
+#define OSSL_CAPABILITY_TLS_SIGALG_IANA_NAME         "tls-sigalg-iana-name"
 #define OSSL_CAPABILITY_TLS_SIGALG_CODE_POINT        "tls-sigalg-code-point"
+#define OSSL_CAPABILITY_TLS_SIGALG_NAME              "tls-sigalg-name"
+#define OSSL_CAPABILITY_TLS_SIGALG_OID               "tls-sigalg-oid"
+#define OSSL_CAPABILITY_TLS_SIGALG_SIG_NAME          "tls-sigalg-sig-name"
+#define OSSL_CAPABILITY_TLS_SIGALG_SIG_OID           "tls-sigalg-sig-oid"
+#define OSSL_CAPABILITY_TLS_SIGALG_HASH_NAME         "tls-sigalg-hash-name"
+#define OSSL_CAPABILITY_TLS_SIGALG_HASH_OID          "tls-sigalg-hash-oid"
+#define OSSL_CAPABILITY_TLS_SIGALG_KEYTYPE           "tls-sigalg-keytype"
+#define OSSL_CAPABILITY_TLS_SIGALG_KEYTYPE_OID       "tls-sigalg-keytype-oid"
 #define OSSL_CAPABILITY_TLS_SIGALG_SECURITY_BITS     "tls-sigalg-sec-bits"
 #define OSSL_CAPABILITY_TLS_SIGALG_MIN_TLS           "tls-min-tls"
 #define OSSL_CAPABILITY_TLS_SIGALG_MAX_TLS           "tls-max-tls"
-#define OSSL_CAPABILITY_TLS_SIGALG_MIN_DTLS          "tls-min-dtls"
-#define OSSL_CAPABILITY_TLS_SIGALG_MAX_DTLS          "tls-max-dtls"
 
 /*-
  * storemgmt parameters

--- a/include/openssl/core_names.h
+++ b/include/openssl/core_names.h
@@ -540,6 +540,19 @@ extern "C" {
 #define OSSL_CAPABILITY_TLS_GROUP_MIN_DTLS          "tls-min-dtls"
 #define OSSL_CAPABILITY_TLS_GROUP_MAX_DTLS          "tls-max-dtls"
 
+/* TLS-SIGALG Capability */
+#define OSSL_CAPABILITY_TLS_SIGALG_NAME              "tls-sigalg-name"
+#define OSSL_CAPABILITY_TLS_SIGALG_NAME_INTERNAL     "tls-sigalg-name-internal"
+#define OSSL_CAPABILITY_TLS_SIGALG_ALG               "tls-sigalg-alg"
+#define OSSL_CAPABILITY_TLS_SIGALG_HASHALG           "tls-sigalg-hashalg"
+#define OSSL_CAPABILITY_TLS_SIGALG_OID               "tls-sigalg-oid"
+#define OSSL_CAPABILITY_TLS_SIGALG_CODE_POINT        "tls-sigalg-code-point"
+#define OSSL_CAPABILITY_TLS_SIGALG_SECURITY_BITS     "tls-sigalg-sec-bits"
+#define OSSL_CAPABILITY_TLS_SIGALG_MIN_TLS           "tls-min-tls"
+#define OSSL_CAPABILITY_TLS_SIGALG_MAX_TLS           "tls-max-tls"
+#define OSSL_CAPABILITY_TLS_SIGALG_MIN_DTLS          "tls-min-dtls"
+#define OSSL_CAPABILITY_TLS_SIGALG_MAX_DTLS          "tls-max-dtls"
+
 /*-
  * storemgmt parameters
  */

--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -3366,6 +3366,7 @@ void ssl3_free(SSL *s)
     OPENSSL_clear_free(sc->s3.tmp.pms, sc->s3.tmp.pmslen);
     OPENSSL_free(sc->s3.tmp.peer_sigalgs);
     OPENSSL_free(sc->s3.tmp.peer_cert_sigalgs);
+    OPENSSL_free(sc->s3.tmp.valid_flags);
     ssl3_free_digest_list(sc);
     OPENSSL_free(sc->s3.alpn_selected);
     OPENSSL_free(sc->s3.alpn_proposed);
@@ -3390,6 +3391,7 @@ int ssl3_clear(SSL *s)
     OPENSSL_clear_free(sc->s3.tmp.pms, sc->s3.tmp.pmslen);
     OPENSSL_free(sc->s3.tmp.peer_sigalgs);
     OPENSSL_free(sc->s3.tmp.peer_cert_sigalgs);
+    OPENSSL_free(sc->s3.tmp.valid_flags);
 
     EVP_PKEY_free(sc->s3.tmp.pkey);
     EVP_PKEY_free(sc->s3.peer_tmp);
@@ -4244,7 +4246,7 @@ const SSL_CIPHER *ssl3_choose_cipher(SSL_CONNECTION *s, STACK_OF(SSL_CIPHER) *cl
 
     if (SSL_CONNECTION_IS_TLS13(s)) {
 #ifndef OPENSSL_NO_PSK
-        int j;
+        size_t j;
 
         /*
          * If we allow "old" style PSK callbacks, and we have no certificate (so
@@ -4254,8 +4256,8 @@ const SSL_CIPHER *ssl3_choose_cipher(SSL_CONNECTION *s, STACK_OF(SSL_CIPHER) *cl
          * that.
          */
         if (s->psk_server_callback != NULL) {
-            for (j = 0; j < SSL_PKEY_NUM && !ssl_has_cert(s, j); j++);
-            if (j == SSL_PKEY_NUM) {
+            for (j = 0; j < s->ssl_pkey_num && !ssl_has_cert(s, j); j++);
+            if (j == s->ssl_pkey_num) {
                 /* There are no certificates */
                 prefer_sha256 = 1;
             }

--- a/ssl/ssl_cert_table.h
+++ b/ssl/ssl_cert_table.h
@@ -10,7 +10,7 @@
 /*
  * Certificate table information. NB: table entries must match SSL_PKEY indices
  */
-static const SSL_CERT_LOOKUP ssl_cert_info [] = {
+static SSL_CERT_LOOKUP ssl_cert_info [] = {
     {EVP_PKEY_RSA, SSL_aRSA}, /* SSL_PKEY_RSA */
     {EVP_PKEY_RSA_PSS, SSL_aRSA}, /* SSL_PKEY_RSA_PSS_SIGN */
     {EVP_PKEY_DSA, SSL_aDSS}, /* SSL_PKEY_DSA_SIGN */

--- a/ssl/ssl_ciph.c
+++ b/ssl/ssl_ciph.c
@@ -2156,7 +2156,7 @@ int SSL_CIPHER_get_auth_nid(const SSL_CIPHER *c)
 int ssl_get_md_idx(int md_nid) {
     int i;
 
-    for(i=0; i<SSL_MD_NUM_IDX; i++) {
+    for(i = 0; i < SSL_MD_NUM_IDX; i++) {
         if (md_nid == ssl_cipher_table_mac[i].nid)
             return i;
     }
@@ -2231,17 +2231,16 @@ int ssl_cipher_get_overhead(const SSL_CIPHER *c, size_t *mac_overhead,
 
 int ssl_cert_is_disabled(SSL_CTX *ctx, size_t idx)
 {
-    /* A new provider-loaded key type is always enabled */
-    if (idx >= SSL_PKEY_NUM) {
-        return 0;
-    }
-    else {
-        const SSL_CERT_LOOKUP *cl = ssl_cert_lookup_by_idx(idx, ctx);
+    SSL_CERT_LOOKUP *cl;
 
-        if (cl == NULL || (cl->amask & ctx->disabled_auth_mask) != 0)
-            return 1;
+    /* A provider-loaded key type is always enabled */
+    if (idx >= SSL_PKEY_NUM)
         return 0;
-    }
+
+    cl = ssl_cert_lookup_by_idx(idx, ctx);
+    if (cl == NULL || (cl->amask & ctx->disabled_auth_mask) != 0)
+        return 1;
+    return 0;
 }
 
 /*

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -3813,7 +3813,7 @@ SSL_CTX *SSL_CTX_new_ex(OSSL_LIB_CTX *libctx, const char *propq,
     }
 
     /* initialise sig algs */
-    if (!ssl_setup_sig_algs(ret)) {
+    if (!ssl_setup_sigalgs(ret)) {
         ERR_raise(ERR_LIB_SSL, ERR_R_SSL_LIB);
         goto err;
     }

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -3796,26 +3796,34 @@ SSL_CTX *SSL_CTX_new_ex(OSSL_LIB_CTX *libctx, const char *propq,
 #endif
 
     /* initialize cipher/digest methods table */
-    if (!ssl_load_ciphers(ret))
+    if (!ssl_load_ciphers(ret)) {
+        ERR_raise(ERR_LIB_SSL, ERR_R_SSL_LIB);
         goto err;
+    }
 
-    if (!ssl_load_groups(ret))
+    if (!ssl_load_groups(ret)) {
+        ERR_raise(ERR_LIB_SSL, ERR_R_SSL_LIB);
         goto err;
+    }
 
     /* load provider sigalgs */
-    if (!ssl_load_sigalgs(ret))
+    if (!ssl_load_sigalgs(ret)) {
+        ERR_raise(ERR_LIB_SSL, ERR_R_SSL_LIB);
         goto err;
+    }
 
     /* initialise sig algs */
-    if (!ssl_setup_sig_algs(ret))
+    if (!ssl_setup_sig_algs(ret)) {
+        ERR_raise(ERR_LIB_SSL, ERR_R_SSL_LIB);
         goto err;
+    }
 
     if (!SSL_CTX_set_ciphersuites(ret, OSSL_default_ciphersuites())) {
         ERR_raise(ERR_LIB_SSL, ERR_R_SSL_LIB);
         goto err;
     }
 
-    if ((ret->cert = ssl_cert_new(SSL_PKEY_NUM+ret->sigalg_list_len)) == NULL) {
+    if ((ret->cert = ssl_cert_new(SSL_PKEY_NUM + ret->sigalg_list_len)) == NULL) {
         ERR_raise(ERR_LIB_SSL, ERR_R_SSL_LIB);
         goto err;
     }
@@ -4062,11 +4070,15 @@ void SSL_CTX_free(SSL_CTX *a)
     }
     OPENSSL_free(a->group_list);
     for (j = 0; j < a->sigalg_list_len; j++) {
-        OPENSSL_free(a->sigalg_list[j].tlsname);
-        OPENSSL_free(a->sigalg_list[j].realname);
-        OPENSSL_free(a->sigalg_list[j].algorithm);
-        OPENSSL_free(a->sigalg_list[j].oid);
-        OPENSSL_free(a->sigalg_list[j].hash_algorithm);
+        OPENSSL_free(a->sigalg_list[j].name);
+        OPENSSL_free(a->sigalg_list[j].sigalg_name);
+        OPENSSL_free(a->sigalg_list[j].sigalg_oid);
+        OPENSSL_free(a->sigalg_list[j].sig_name);
+        OPENSSL_free(a->sigalg_list[j].sig_oid);
+        OPENSSL_free(a->sigalg_list[j].hash_name);
+        OPENSSL_free(a->sigalg_list[j].hash_oid);
+        OPENSSL_free(a->sigalg_list[j].keytype);
+        OPENSSL_free(a->sigalg_list[j].keytype_oid);
     }
     OPENSSL_free(a->sigalg_list);
     OPENSSL_free(a->ssl_cert_info);

--- a/ssl/ssl_local.h
+++ b/ssl/ssl_local.h
@@ -769,8 +769,6 @@ typedef struct tls_sigalg_info_st {
     unsigned int secbits;    /* Bits of security (from SP800-57) */
     int mintls;              /* Minimum TLS version, -1 unsupported */
     int maxtls;              /* Maximum TLS version (or 0 for undefined) */
-    int mindtls;             /* Minimum DTLS version, -1 unsupported */
-    int maxdtls;             /* Maximum DTLS version (or 0 for undefined) */
 } TLS_SIGALG_INFO;
 
 /*
@@ -2491,7 +2489,7 @@ __owur STACK_OF(SSL_CIPHER) *ssl_get_ciphers_by_id(SSL_CONNECTION *sc);
 __owur int ssl_x509err2alert(int type);
 void ssl_sort_cipher_list(void);
 int ssl_load_ciphers(SSL_CTX *ctx);
-__owur int ssl_setup_sig_algs(SSL_CTX *ctx);
+__owur int ssl_setup_sigalgs(SSL_CTX *ctx);
 int ssl_load_groups(SSL_CTX *ctx);
 int ssl_load_sigalgs(SSL_CTX *ctx);
 __owur int ssl_fill_hello_random(SSL_CONNECTION *s, int server,

--- a/ssl/ssl_local.h
+++ b/ssl/ssl_local.h
@@ -755,6 +755,29 @@ typedef struct tls_group_info_st {
     char is_kem;             /* Mode for this Group: 0 is KEX, 1 is KEM */
 } TLS_GROUP_INFO;
 
+typedef struct tls_sigalg_info_st {
+    char *tlsname;           /* Algorithm Name as in TLS specs */
+    char *realname;          /* Algorithm Name according to provider */
+    char *algorithm;         /* Algorithm name to fetch */
+    char *oid;               /* OID of algorithm */
+    char *hash_algorithm;    /* Name of hash algorithm if any */
+    uint16_t code_point;     /* Code point of algorithm */
+    unsigned int secbits;    /* Bits of security (from SP800-57) */
+    int mintls;              /* Minimum TLS version, -1 unsupported */
+    int maxtls;              /* Maximum TLS version (or 0 for undefined) */
+    int mindtls;             /* Minimum DTLS version, -1 unsupported */
+    int maxdtls;             /* Maximum DTLS version (or 0 for undefined) */
+} TLS_SIGALG_INFO;
+
+/*
+ * Structure containing table entry of certificate info corresponding to
+ * CERT_PKEY entries
+ */
+typedef struct {
+    int nid; /* NID of public key algorithm */
+    uint32_t amask; /* authmask corresponding to key type */
+} SSL_CERT_LOOKUP;
+
 /* flags values */
 # define TLS_GROUP_TYPE             0x0000000FU /* Mask for group type */
 # define TLS_GROUP_CURVE_PRIME      0x00000001U
@@ -1120,12 +1143,20 @@ struct ssl_ctx_st {
     const EVP_MD *ssl_digest_methods[SSL_MD_NUM_IDX];
     size_t ssl_mac_secret_size[SSL_MD_NUM_IDX];
 
+    size_t tls12_sigalgs_len;
     /* Cache of all sigalgs we know and whether they are available or not */
     struct sigalg_lookup_st *sigalg_lookup_cache;
+    /* List of all sigalgs (code points) available, incl. from providers */
+    uint16_t *tls12_sigalgs;
 
     TLS_GROUP_INFO *group_list;
     size_t group_list_len;
     size_t group_list_max_len;
+
+    TLS_SIGALG_INFO *sigalg_list;
+    SSL_CERT_LOOKUP *ssl_cert_info;
+    size_t sigalg_list_len;
+    size_t sigalg_list_max_len;
 
     /* masks of disabled algorithms */
     uint32_t disabled_enc_mask;
@@ -1210,6 +1241,8 @@ struct ssl_connection_st {
     size_t init_num;               /* amount read/written */
     size_t init_off;               /* amount read/written */
 
+    size_t ssl_pkey_num;
+
     struct {
         long flags;
         unsigned char server_random[SSL3_RANDOM_SIZE];
@@ -1244,6 +1277,7 @@ struct ssl_connection_st {
         int total_renegotiations;
         int num_renegotiations;
         int in_read_app_data;
+
         struct {
             /* actually only need to be 16+20 for SSLv3 and 12 for TLS */
             unsigned char finish_md[EVP_MAX_MD_SIZE * 2];
@@ -1307,7 +1341,7 @@ struct ssl_connection_st {
              * SSL session: e.g. appropriate curve, signature algorithms etc.
              * If zero it can't be used at all.
              */
-            uint32_t valid_flags[SSL_PKEY_NUM];
+            uint32_t *valid_flags;
             /*
              * For servers the following masks are for the key and auth algorithms
              * that are supported by the certs below. For clients they are masks of
@@ -1794,15 +1828,6 @@ typedef struct sigalg_lookup_st {
     int enabled;
 } SIGALG_LOOKUP;
 
-/*
- * Structure containing table entry of certificate info corresponding to
- * CERT_PKEY entries
- */
-typedef struct {
-    int nid; /* NID of public key algorithm */
-    uint32_t amask; /* authmask corresponding to key type */
-} SSL_CERT_LOOKUP;
-
 /* DTLS structures */
 
 # ifndef OPENSSL_NO_SCTP
@@ -2000,7 +2025,8 @@ typedef struct cert_st {
     int dh_tmp_auto;
     /* Flags related to certificates */
     uint32_t cert_flags;
-    CERT_PKEY pkeys[SSL_PKEY_NUM];
+    CERT_PKEY *pkeys;
+    size_t ssl_pkey_num;
     /* Custom certificate types sent in certificate request message. */
     uint8_t *ctype;
     size_t ctype_len;
@@ -2355,7 +2381,7 @@ const char *ssl_protocol_to_string(int version);
 /* Returns true if certificate and private key for 'idx' are present */
 static ossl_inline int ssl_has_cert(const SSL_CONNECTION *s, int idx)
 {
-    if (idx < 0 || idx >= SSL_PKEY_NUM)
+    if (idx < 0 || idx >= (int)s->ssl_pkey_num)
         return 0;
     return s->cert->pkeys[idx].x509 != NULL
         && s->cert->pkeys[idx].privatekey != NULL;
@@ -2381,7 +2407,7 @@ __owur int ossl_ssl_connection_reset(SSL *ssl);
 __owur int ssl_read_internal(SSL *s, void *buf, size_t num, size_t *readbytes);
 __owur int ssl_write_internal(SSL *s, const void *buf, size_t num, size_t *written);
 int ssl_clear_bad_session(SSL_CONNECTION *s);
-__owur CERT *ssl_cert_new(void);
+__owur CERT *ssl_cert_new(size_t ssl_pkey_num);
 __owur CERT *ssl_cert_dup(CERT *cert);
 void ssl_cert_clear_certs(CERT *c);
 void ssl_cert_free(CERT *c);
@@ -2444,10 +2470,11 @@ __owur int ssl_ctx_security(const SSL_CTX *ctx, int op, int bits, int nid,
                             void *other);
 int ssl_get_security_level_bits(const SSL *s, const SSL_CTX *ctx, int *levelp);
 
-__owur int ssl_cert_lookup_by_nid(int nid, size_t *pidx);
-__owur const SSL_CERT_LOOKUP *ssl_cert_lookup_by_pkey(const EVP_PKEY *pk,
-                                                      size_t *pidx);
-__owur const SSL_CERT_LOOKUP *ssl_cert_lookup_by_idx(size_t idx);
+__owur int ssl_cert_lookup_by_nid(int nid, size_t *pidx, SSL_CTX *ctx);
+__owur SSL_CERT_LOOKUP *ssl_cert_lookup_by_pkey(const EVP_PKEY *pk,
+                                                size_t *pidx,
+						SSL_CTX *ctx);
+__owur SSL_CERT_LOOKUP *ssl_cert_lookup_by_idx(size_t idx, SSL_CTX *ctx);
 
 int ssl_undefined_function(SSL *s);
 __owur int ssl_undefined_void_function(void);
@@ -2462,6 +2489,7 @@ void ssl_sort_cipher_list(void);
 int ssl_load_ciphers(SSL_CTX *ctx);
 __owur int ssl_setup_sig_algs(SSL_CTX *ctx);
 int ssl_load_groups(SSL_CTX *ctx);
+int ssl_load_sigalgs(SSL_CTX *ctx);
 __owur int ssl_fill_hello_random(SSL_CONNECTION *s, int server,
                                  unsigned char *field, size_t len,
                                  DOWNGRADE dgrd);
@@ -2750,6 +2778,7 @@ __owur int ssl_handshake_hash(SSL_CONNECTION *s,
                               unsigned char *out, size_t outlen,
                               size_t *hashlen);
 __owur const EVP_MD *ssl_md(SSL_CTX *ctx, int idx);
+int ssl_get_md_idx(int md_nid);
 __owur const EVP_MD *ssl_handshake_md(SSL_CONNECTION *s);
 __owur const EVP_MD *ssl_prf_md(SSL_CONNECTION *s);
 

--- a/ssl/ssl_local.h
+++ b/ssl/ssl_local.h
@@ -756,12 +756,16 @@ typedef struct tls_group_info_st {
 } TLS_GROUP_INFO;
 
 typedef struct tls_sigalg_info_st {
-    char *tlsname;           /* Algorithm Name as in TLS specs */
-    char *realname;          /* Algorithm Name according to provider */
-    char *algorithm;         /* Algorithm name to fetch */
-    char *oid;               /* OID of algorithm */
-    char *hash_algorithm;    /* Name of hash algorithm if any */
-    uint16_t code_point;     /* Code point of algorithm */
+    char *name;              /* name as in IANA TLS specs */
+    uint16_t code_point;     /* IANA-specified code point of sigalg-name */
+    char *sigalg_name;       /* (combined) sigalg name */
+    char *sigalg_oid;        /* (combined) sigalg OID */
+    char *sig_name;          /* pure signature algorithm name */
+    char *sig_oid;           /* pure signature algorithm OID */
+    char *hash_name;         /* hash algorithm name */
+    char *hash_oid;          /* hash algorithm OID */
+    char *keytype;           /* keytype name */
+    char *keytype_oid;       /* keytype OID */
     unsigned int secbits;    /* Bits of security (from SP800-57) */
     int mintls;              /* Minimum TLS version, -1 unsupported */
     int maxtls;              /* Maximum TLS version (or 0 for undefined) */
@@ -924,6 +928,7 @@ struct ssl_ctx_st {
     size_t max_cert_list;
 
     struct cert_st /* CERT */ *cert;
+    SSL_CERT_LOOKUP *ssl_cert_info;
     int read_ahead;
 
     /* callback that allows applications to peek at protocol messages */
@@ -1154,7 +1159,6 @@ struct ssl_ctx_st {
     size_t group_list_max_len;
 
     TLS_SIGALG_INFO *sigalg_list;
-    SSL_CERT_LOOKUP *ssl_cert_info;
     size_t sigalg_list_len;
     size_t sigalg_list_max_len;
 
@@ -2473,7 +2477,7 @@ int ssl_get_security_level_bits(const SSL *s, const SSL_CTX *ctx, int *levelp);
 __owur int ssl_cert_lookup_by_nid(int nid, size_t *pidx, SSL_CTX *ctx);
 __owur SSL_CERT_LOOKUP *ssl_cert_lookup_by_pkey(const EVP_PKEY *pk,
                                                 size_t *pidx,
-						SSL_CTX *ctx);
+                                                SSL_CTX *ctx);
 __owur SSL_CERT_LOOKUP *ssl_cert_lookup_by_idx(size_t idx, SSL_CTX *ctx);
 
 int ssl_undefined_function(SSL *s);

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -2435,13 +2435,15 @@ MSG_PROCESS_RETURN tls_process_key_exchange(SSL_CONNECTION *s, PACKET *pkt)
 MSG_PROCESS_RETURN tls_process_certificate_request(SSL_CONNECTION *s,
                                                    PACKET *pkt)
 {
-    /* Allocate and clear certificate validity flags */
-    OPENSSL_free(s->s3.tmp.valid_flags);
-    s->s3.tmp.valid_flags = OPENSSL_zalloc(s->ssl_pkey_num * sizeof(uint32_t));
-    if (s->s3.tmp.valid_flags == NULL) {
-        SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_MALLOC_FAILURE);
+    /* Clear certificate validity flags */
+    if (s->s3.tmp.valid_flags != NULL)
+        memset(s->s3.tmp.valid_flags, 0, s->ssl_pkey_num * sizeof(uint32_t));
+    else
+        s->s3.tmp.valid_flags = OPENSSL_zalloc(s->ssl_pkey_num * sizeof(uint32_t));
+
+    /* Give up for good if allocation didn't work */
+    if (s->s3.tmp.valid_flags == NULL)
         return 0;
-    }
 
     if (SSL_CONNECTION_IS_TLS13(s)) {
         PACKET reqctx, extensions;

--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -424,7 +424,7 @@ MSG_PROCESS_RETURN tls_process_cert_verify(SSL_CONNECTION *s, PACKET *pkt)
         goto err;
     }
 
-    if (ssl_cert_lookup_by_pkey(pkey, NULL) == NULL) {
+    if (ssl_cert_lookup_by_pkey(pkey, NULL, sctx) == NULL) {
         SSLfatal(s, SSL_AD_ILLEGAL_PARAMETER,
                  SSL_R_SIGNATURE_FOR_NON_SIGNING_CERTIFICATE);
         goto err;
@@ -1558,7 +1558,7 @@ static int ssl_method_error(const SSL_CONNECTION *s, const SSL_METHOD *method)
  */
 static int is_tls13_capable(const SSL_CONNECTION *s)
 {
-    int i;
+    size_t i;
     int curve;
     SSL_CTX *sctx = SSL_CONNECTION_GET_CTX(s);
 
@@ -1581,7 +1581,7 @@ static int is_tls13_capable(const SSL_CONNECTION *s)
     if (s->psk_find_session_cb != NULL || s->cert->cert_cb != NULL)
         return 1;
 
-    for (i = 0; i < SSL_PKEY_NUM; i++) {
+    for (i = 0; i < s->ssl_pkey_num; i++) {
         /* Skip over certs disallowed for TLSv1.3 */
         switch (i) {
         case SSL_PKEY_DSA_SIGN:

--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -1581,6 +1581,7 @@ static int is_tls13_capable(const SSL_CONNECTION *s)
     if (s->psk_find_session_cb != NULL || s->cert->cert_cb != NULL)
         return 1;
 
+    /* All provider-based sig algs are required to support at least TLS1.3 */
     for (i = 0; i < s->ssl_pkey_num; i++) {
         /* Skip over certs disallowed for TLSv1.3 */
         switch (i) {

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -1457,7 +1457,7 @@ static const uint16_t tls_default_sigalg[] = {
     0, /* SSL_PKEY_ED448 */
 };
 
-int ssl_setup_sig_algs(SSL_CTX *ctx)
+int ssl_setup_sigalgs(SSL_CTX *ctx)
 {
     size_t i, cache_idx, sigalgs_len;
     const SIGALG_LOOKUP *lu;

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -458,6 +458,7 @@ static int add_provider_sigalgs(const OSSL_PARAM params[], void *data)
         ERR_raise(ERR_LIB_SSL, ERR_R_PASSED_INVALID_ARGUMENT);
         goto err;
     }
+    OPENSSL_free(sinf->sigalg_name);
     sinf->sigalg_name = OPENSSL_strdup(p->data);
     if (sinf->sigalg_name == NULL)
         goto err;
@@ -467,6 +468,7 @@ static int add_provider_sigalgs(const OSSL_PARAM params[], void *data)
         ERR_raise(ERR_LIB_SSL, ERR_R_PASSED_INVALID_ARGUMENT);
         goto err;
     }
+    OPENSSL_free(sinf->name);
     sinf->name = OPENSSL_strdup(p->data);
     if (sinf->name == NULL)
         goto err;
@@ -495,6 +497,7 @@ static int add_provider_sigalgs(const OSSL_PARAM params[], void *data)
     } else if (p->data_type != OSSL_PARAM_UTF8_STRING) {
         goto err;
     } else {
+        OPENSSL_free(sinf->sigalg_oid);
         sinf->sigalg_oid = OPENSSL_strdup(p->data);
         if (sinf->sigalg_oid == NULL)
             goto err;
@@ -506,6 +509,7 @@ static int add_provider_sigalgs(const OSSL_PARAM params[], void *data)
     } else if (p->data_type != OSSL_PARAM_UTF8_STRING) {
         goto err;
     } else {
+        OPENSSL_free(sinf->sig_name);
         sinf->sig_name = OPENSSL_strdup(p->data);
         if (sinf->sig_name == NULL)
             goto err;
@@ -517,6 +521,7 @@ static int add_provider_sigalgs(const OSSL_PARAM params[], void *data)
     } else if (p->data_type != OSSL_PARAM_UTF8_STRING) {
         goto err;
     } else {
+        OPENSSL_free(sinf->sig_oid);
         sinf->sig_oid = OPENSSL_strdup(p->data);
         if (sinf->sig_oid == NULL)
             goto err;
@@ -528,6 +533,7 @@ static int add_provider_sigalgs(const OSSL_PARAM params[], void *data)
     } else if (p->data_type != OSSL_PARAM_UTF8_STRING) {
         goto err;
     } else {
+        OPENSSL_free(sinf->hash_name);
         sinf->hash_name = OPENSSL_strdup(p->data);
         if (sinf->hash_name == NULL)
             goto err;
@@ -539,6 +545,7 @@ static int add_provider_sigalgs(const OSSL_PARAM params[], void *data)
     } else if (p->data_type != OSSL_PARAM_UTF8_STRING) {
         goto err;
     } else {
+        OPENSSL_free(sinf->hash_oid);
         sinf->hash_oid = OPENSSL_strdup(p->data);
         if (sinf->hash_oid == NULL)
             goto err;
@@ -550,6 +557,7 @@ static int add_provider_sigalgs(const OSSL_PARAM params[], void *data)
     } else if (p->data_type != OSSL_PARAM_UTF8_STRING) {
         goto err;
     } else {
+        OPENSSL_free(sinf->keytype);
         sinf->keytype = OPENSSL_strdup(p->data);
         if (sinf->keytype == NULL)
             goto err;
@@ -561,6 +569,7 @@ static int add_provider_sigalgs(const OSSL_PARAM params[], void *data)
     } else if (p->data_type != OSSL_PARAM_UTF8_STRING) {
         goto err;
     } else {
+        OPENSSL_free(sinf->keytype_oid);
         sinf->keytype_oid = OPENSSL_strdup(p->data);
         if (sinf->keytype_oid == NULL)
             goto err;

--- a/test/tls-provider.c
+++ b/test/tls-provider.c
@@ -12,9 +12,38 @@
 #include <openssl/core_dispatch.h>
 #include <openssl/rand.h>
 #include <openssl/params.h>
+#include <openssl/err.h>
+#include <openssl/proverr.h>
+#include <openssl/pkcs12.h>
+#include <openssl/provider.h>
+#include <assert.h>
+#include <openssl/asn1.h>
+#include <openssl/asn1t.h>
+#include <openssl/core_object.h>
+#include "internal/asn1.h"
 /* For TLS1_3_VERSION */
 #include <openssl/ssl.h>
 #include "internal/nelem.h"
+#include "internal/refcount.h"
+
+/* error codes */
+
+/* xorprovider error codes */
+#define XORPROV_R_INVALID_DIGEST                            1
+#define XORPROV_R_INVALID_SIZE                              2
+#define XORPROV_R_INVALID_KEY                               3
+#define XORPROV_R_UNSUPPORTED                               4
+#define XORPROV_R_MISSING_OID                               5
+#define XORPROV_R_OBJ_CREATE_ERR                            6
+#define XORPROV_R_INVALID_ENCODING                          7
+#define XORPROV_R_SIGN_ERROR                                8
+#define XORPROV_R_LIB_CREATE_ERR                            9
+#define XORPROV_R_NO_PRIVATE_KEY                            10
+#define XORPROV_R_BUFFER_LENGTH_WRONG                       11
+#define XORPROV_R_SIGNING_FAILED                            12
+#define XORPROV_R_WRONG_PARAMETERS                          13
+#define XORPROV_R_VERIFY_ERROR                              14
+#define XORPROV_R_EVPINFO_MISSING                           15
 
 static OSSL_FUNC_keymgmt_import_fn xor_import;
 static OSSL_FUNC_keymgmt_import_types_fn xor_import_types;
@@ -45,13 +74,15 @@ typedef struct xorkey_st {
     unsigned char pubkey[XOR_KEY_SIZE];
     int hasprivkey;
     int haspubkey;
+    char *tls_name;
+    CRYPTO_REF_COUNT references;
+    CRYPTO_RWLOCK *lock;
 } XORKEY;
 
+/* Key Management for the dummy XOR KEX, KEM and signature algorithms */
 
-/* Key Management for the dummy XOR KEX and KEM algorithms */
-
-static OSSL_FUNC_keymgmt_new_fn xor_newdata;
-static OSSL_FUNC_keymgmt_free_fn xor_freedata;
+static OSSL_FUNC_keymgmt_new_fn xor_newkey;
+static OSSL_FUNC_keymgmt_free_fn xor_freekey;
 static OSSL_FUNC_keymgmt_has_fn xor_has;
 static OSSL_FUNC_keymgmt_dup_fn xor_dup;
 static OSSL_FUNC_keymgmt_gen_init_fn xor_gen_init;
@@ -59,6 +90,7 @@ static OSSL_FUNC_keymgmt_gen_set_params_fn xor_gen_set_params;
 static OSSL_FUNC_keymgmt_gen_settable_params_fn xor_gen_settable_params;
 static OSSL_FUNC_keymgmt_gen_fn xor_gen;
 static OSSL_FUNC_keymgmt_gen_cleanup_fn xor_gen_cleanup;
+static OSSL_FUNC_keymgmt_load_fn xor_load;
 static OSSL_FUNC_keymgmt_get_params_fn xor_get_params;
 static OSSL_FUNC_keymgmt_gettable_params_fn xor_gettable_params;
 static OSSL_FUNC_keymgmt_set_params_fn xor_set_params;
@@ -69,7 +101,7 @@ static OSSL_FUNC_keymgmt_settable_params_fn xor_settable_params;
  * together. Don't use this!
  */
 
-static OSSL_FUNC_keyexch_newctx_fn xor_newctx;
+static OSSL_FUNC_keyexch_newctx_fn xor_newkemkexctx;
 static OSSL_FUNC_keyexch_init_fn xor_init;
 static OSSL_FUNC_keyexch_set_peer_fn xor_set_peer;
 static OSSL_FUNC_keyexch_derive_fn xor_derive;
@@ -81,7 +113,7 @@ static OSSL_FUNC_keyexch_dupctx_fn xor_dupctx;
  * Don't use this!
  */
 
-static OSSL_FUNC_kem_newctx_fn xor_newctx;
+static OSSL_FUNC_kem_newctx_fn xor_newkemkexctx;
 static OSSL_FUNC_kem_freectx_fn xor_freectx;
 static OSSL_FUNC_kem_dupctx_fn xor_dupctx;
 static OSSL_FUNC_kem_encapsulate_init_fn xor_init;
@@ -89,6 +121,79 @@ static OSSL_FUNC_kem_encapsulate_fn xor_encapsulate;
 static OSSL_FUNC_kem_decapsulate_init_fn xor_init;
 static OSSL_FUNC_kem_decapsulate_fn xor_decapsulate;
 
+/*
+ * Common key management table access functions
+ */
+static OSSL_FUNC_keymgmt_new_fn *
+xor_prov_get_keymgmt_new(const OSSL_DISPATCH *fns)
+{
+    /* Pilfer the keymgmt dispatch table */
+    for (; fns->function_id != 0; fns++)
+        if (fns->function_id == OSSL_FUNC_KEYMGMT_NEW)
+            return OSSL_FUNC_keymgmt_new(fns);
+
+    return NULL;
+}
+
+static OSSL_FUNC_keymgmt_free_fn *
+xor_prov_get_keymgmt_free(const OSSL_DISPATCH *fns)
+{
+    /* Pilfer the keymgmt dispatch table */
+    for (; fns->function_id != 0; fns++)
+        if (fns->function_id == OSSL_FUNC_KEYMGMT_FREE)
+            return OSSL_FUNC_keymgmt_free(fns);
+
+    return NULL;
+}
+
+static OSSL_FUNC_keymgmt_import_fn *
+xor_prov_get_keymgmt_import(const OSSL_DISPATCH *fns)
+{
+    /* Pilfer the keymgmt dispatch table */
+    for (; fns->function_id != 0; fns++)
+        if (fns->function_id == OSSL_FUNC_KEYMGMT_IMPORT)
+            return OSSL_FUNC_keymgmt_import(fns);
+
+    return NULL;
+}
+
+static OSSL_FUNC_keymgmt_export_fn *
+xor_prov_get_keymgmt_export(const OSSL_DISPATCH *fns)
+{
+    /* Pilfer the keymgmt dispatch table */
+    for (; fns->function_id != 0; fns++)
+        if (fns->function_id == OSSL_FUNC_KEYMGMT_EXPORT)
+            return OSSL_FUNC_keymgmt_export(fns);
+
+    return NULL;
+}
+
+static void *xor_prov_import_key(const OSSL_DISPATCH *fns, void *provctx,
+                           int selection, const OSSL_PARAM params[])
+{
+    OSSL_FUNC_keymgmt_new_fn *kmgmt_new = xor_prov_get_keymgmt_new(fns);
+    OSSL_FUNC_keymgmt_free_fn *kmgmt_free = xor_prov_get_keymgmt_free(fns);
+    OSSL_FUNC_keymgmt_import_fn *kmgmt_import =
+        xor_prov_get_keymgmt_import(fns);
+    void *key = NULL;
+
+    if (kmgmt_new != NULL && kmgmt_import != NULL && kmgmt_free != NULL) {
+        if ((key = kmgmt_new(provctx)) == NULL
+            || !kmgmt_import(key, selection, params)) {
+            kmgmt_free(key);
+            key = NULL;
+        }
+    }
+    return key;
+}
+
+static void xor_prov_free_key(const OSSL_DISPATCH *fns, void *key)
+{
+    OSSL_FUNC_keymgmt_free_fn *kmgmt_free = xor_prov_get_keymgmt_free(fns);
+
+    if (kmgmt_free != NULL)
+        kmgmt_free(key);
+}
 
 /*
  * We define 2 dummy TLS groups called "xorgroup" and "xorkemgroup" for test
@@ -107,7 +212,7 @@ struct tls_group_st {
 #define XORGROUP_NAME "xorgroup"
 #define XORGROUP_NAME_INTERNAL "xorgroup-int"
 static struct tls_group_st xor_group = {
-    0,                  /* group_id, set by randomize_tls_group_id() */
+    0,                  /* group_id, set by randomize_tls_alg_id() */
     128,                /* secbits */
     TLS1_3_VERSION,     /* mintls */
     0,                  /* maxtls */
@@ -119,7 +224,7 @@ static struct tls_group_st xor_group = {
 #define XORKEMGROUP_NAME "xorkemgroup"
 #define XORKEMGROUP_NAME_INTERNAL "xorkemgroup-int"
 static struct tls_group_st xor_kemgroup = {
-    0,                  /* group_id, set by randomize_tls_group_id() */
+    0,                  /* group_id, set by randomize_tls_alg_id() */
     128,                /* secbits */
     TLS1_3_VERSION,     /* mintls */
     0,                  /* maxtls */
@@ -171,65 +276,188 @@ static const OSSL_PARAM xor_kemgroup_params[] = {
 #define NUM_DUMMY_GROUPS 50
 static char *dummy_group_names[NUM_DUMMY_GROUPS];
 
+/*
+ * We define a dummy TLS sigalg called for test purposes
+ */
+struct tls_sigalg_st {
+    unsigned int code_point; /* for "tls-sigalg-alg", see provider-base(7) */
+    unsigned int secbits;
+    unsigned int mintls;
+    unsigned int maxtls;
+};
+
+#define XORSIGALG_NAME "xorhmacsig"
+#define XORSIGALG_OID "1.3.6.1.4.1.16604.998888.1"
+#define XORSIGALG_HASH_NAME "xorhmacsha2sig"
+#define XORSIGALG_HASH "SHA256"
+#define XORSIGALG_HASH_OID "1.3.6.1.4.1.16604.998888.2"
+#define XORSIGALG12_NAME "xorhmacsig12"
+#define XORSIGALG12_OID "1.3.6.1.4.1.16604.998888.3"
+
+static struct tls_sigalg_st xor_sigalg = {
+    0,                  /* alg id, set by randomize_tls_alg_id() */
+    128,                /* secbits */
+    TLS1_3_VERSION,     /* mintls */
+    0,                  /* maxtls */
+};
+
+static struct tls_sigalg_st xor_sigalg_hash = {
+    0,                  /* alg id, set by randomize_tls_alg_id() */
+    128,                /* secbits */
+    TLS1_3_VERSION,     /* mintls */
+    0,                  /* maxtls */
+};
+
+static struct tls_sigalg_st xor_sigalg12 = {
+    0,                  /* alg id, set by randomize_tls_alg_id() */
+    128,                /* secbits */
+    TLS1_2_VERSION,     /* mintls */
+    TLS1_2_VERSION,     /* maxtls */
+};
+
+static const OSSL_PARAM xor_sig_nohash_params[] = {
+    OSSL_PARAM_utf8_string(OSSL_CAPABILITY_TLS_SIGALG_IANA_NAME,
+                           XORSIGALG_NAME, sizeof(XORSIGALG_NAME)),
+    OSSL_PARAM_utf8_string(OSSL_CAPABILITY_TLS_SIGALG_NAME,
+                           XORSIGALG_NAME,
+                           sizeof(XORSIGALG_NAME)),
+    OSSL_PARAM_utf8_string(OSSL_CAPABILITY_TLS_SIGALG_OID,
+                           XORSIGALG_OID, sizeof(XORSIGALG_OID)),
+    OSSL_PARAM_uint(OSSL_CAPABILITY_TLS_SIGALG_CODE_POINT,
+                    &xor_sigalg.code_point),
+    OSSL_PARAM_uint(OSSL_CAPABILITY_TLS_SIGALG_SECURITY_BITS,
+                    &xor_sigalg.secbits),
+    OSSL_PARAM_int(OSSL_CAPABILITY_TLS_SIGALG_MIN_TLS,
+                   &xor_sigalg.mintls),
+    OSSL_PARAM_int(OSSL_CAPABILITY_TLS_SIGALG_MAX_TLS,
+                   &xor_sigalg.maxtls),
+    OSSL_PARAM_END
+};
+
+static const OSSL_PARAM xor_sig_hash_params[] = {
+    OSSL_PARAM_utf8_string(OSSL_CAPABILITY_TLS_SIGALG_IANA_NAME,
+                           XORSIGALG_HASH_NAME, sizeof(XORSIGALG_HASH_NAME)),
+    OSSL_PARAM_utf8_string(OSSL_CAPABILITY_TLS_SIGALG_NAME,
+                           XORSIGALG_HASH_NAME,
+                           sizeof(XORSIGALG_HASH_NAME)),
+    OSSL_PARAM_utf8_string(OSSL_CAPABILITY_TLS_SIGALG_HASH_NAME,
+                           XORSIGALG_HASH, sizeof(XORSIGALG_HASH)),
+    OSSL_PARAM_utf8_string(OSSL_CAPABILITY_TLS_SIGALG_OID,
+                           XORSIGALG_HASH_OID, sizeof(XORSIGALG_HASH_OID)),
+    OSSL_PARAM_uint(OSSL_CAPABILITY_TLS_SIGALG_CODE_POINT,
+                    &xor_sigalg_hash.code_point),
+    OSSL_PARAM_uint(OSSL_CAPABILITY_TLS_SIGALG_SECURITY_BITS,
+                    &xor_sigalg_hash.secbits),
+    OSSL_PARAM_int(OSSL_CAPABILITY_TLS_SIGALG_MIN_TLS,
+                   &xor_sigalg_hash.mintls),
+    OSSL_PARAM_int(OSSL_CAPABILITY_TLS_SIGALG_MAX_TLS,
+                   &xor_sigalg_hash.maxtls),
+    OSSL_PARAM_END
+};
+
+static const OSSL_PARAM xor_sig_12_params[] = {
+    OSSL_PARAM_utf8_string(OSSL_CAPABILITY_TLS_SIGALG_IANA_NAME,
+                           XORSIGALG12_NAME, sizeof(XORSIGALG12_NAME)),
+    OSSL_PARAM_utf8_string(OSSL_CAPABILITY_TLS_SIGALG_NAME,
+                           XORSIGALG12_NAME,
+                           sizeof(XORSIGALG12_NAME)),
+    OSSL_PARAM_utf8_string(OSSL_CAPABILITY_TLS_SIGALG_OID,
+                           XORSIGALG12_OID, sizeof(XORSIGALG12_OID)),
+    OSSL_PARAM_uint(OSSL_CAPABILITY_TLS_SIGALG_CODE_POINT,
+                    &xor_sigalg12.code_point),
+    OSSL_PARAM_uint(OSSL_CAPABILITY_TLS_SIGALG_SECURITY_BITS,
+                    &xor_sigalg12.secbits),
+    OSSL_PARAM_int(OSSL_CAPABILITY_TLS_SIGALG_MIN_TLS,
+                   &xor_sigalg12.mintls),
+    OSSL_PARAM_int(OSSL_CAPABILITY_TLS_SIGALG_MAX_TLS,
+                   &xor_sigalg12.maxtls),
+    OSSL_PARAM_END
+};
+
 static int tls_prov_get_capabilities(void *provctx, const char *capability,
                                      OSSL_CALLBACK *cb, void *arg)
 {
-    int ret;
+    int ret = 0;
     int i;
     const char *dummy_base = "dummy";
     const size_t dummy_name_max_size = strlen(dummy_base) + 3;
 
-    if (strcmp(capability, "TLS-GROUP") != 0) {
-        /* We don't support this capability */
-        return 0;
-    }
+    if (strcmp(capability, "TLS-GROUP") == 0) {
+        /* Register our 2 groups */
+        ret = cb(xor_group_params, arg);
+        ret &= cb(xor_kemgroup_params, arg);
 
-    /* Register our 2 groups */
-    ret = cb(xor_group_params, arg);
-    ret &= cb(xor_kemgroup_params, arg);
+        /*
+         * Now register some dummy groups > GROUPLIST_INCREMENT (== 40) as defined
+         * in ssl/t1_lib.c, to make sure we exercise the code paths for registering
+         * large numbers of groups.
+         */
 
-    /*
-     * Now register some dummy groups > GROUPLIST_INCREMENT (== 40) as defined
-     * in ssl/t1_lib.c, to make sure we exercise the code paths for registering
-     * large numbers of groups.
-     */
+        for (i = 0; i < NUM_DUMMY_GROUPS; i++) {
+            OSSL_PARAM dummygroup[OSSL_NELEM(xor_group_params)];
 
-    for (i = 0; i < NUM_DUMMY_GROUPS; i++) {
-        OSSL_PARAM dummygroup[OSSL_NELEM(xor_group_params)];
+            memcpy(dummygroup, xor_group_params, sizeof(xor_group_params));
 
-        memcpy(dummygroup, xor_group_params, sizeof(xor_group_params));
-
-        /* Give the dummy group a unique name */
-        if (dummy_group_names[i] == NULL) {
-            dummy_group_names[i] = OPENSSL_zalloc(dummy_name_max_size);
-            if (dummy_group_names[i] == NULL)
-                return 0;
-            BIO_snprintf(dummy_group_names[i],
+            /* Give the dummy group a unique name */
+            if (dummy_group_names[i] == NULL) {
+                dummy_group_names[i] = OPENSSL_zalloc(dummy_name_max_size);
+                if (dummy_group_names[i] == NULL)
+                    return 0;
+                BIO_snprintf(dummy_group_names[i],
                          dummy_name_max_size,
                          "%s%d", dummy_base, i);
+            }
+            dummygroup[0].data = dummy_group_names[i];
+            dummygroup[0].data_size = strlen(dummy_group_names[i]) + 1;
+            ret &= cb(dummygroup, arg);
         }
-        dummygroup[0].data = dummy_group_names[i];
-        dummygroup[0].data_size = strlen(dummy_group_names[i]) + 1;
-        ret &= cb(dummygroup, arg);
     }
 
+    if (strcmp(capability, "TLS-SIGALG") == 0) {
+        ret = cb(xor_sig_nohash_params, arg);
+        ret &= cb(xor_sig_hash_params, arg);
+        ret &= cb(xor_sig_12_params, arg);
+    }
     return ret;
 }
 
+typedef struct {
+    OSSL_LIB_CTX *libctx;
+} PROV_XOR_CTX;
+
+static PROV_XOR_CTX *xor_newprovctx(OSSL_LIB_CTX *libctx)
+{
+    PROV_XOR_CTX* prov_ctx = OPENSSL_malloc(sizeof(PROV_XOR_CTX));
+
+    if (prov_ctx == NULL)
+        return NULL;
+
+    if (libctx == NULL) {
+        OPENSSL_free(prov_ctx);
+        return NULL;
+    }
+    prov_ctx->libctx = libctx;
+    return prov_ctx;
+}
+
+
+
+#define PROV_XOR_LIBCTX_OF(provctx) (((PROV_XOR_CTX *)provctx)->libctx)
+
 /*
- * Dummy "XOR" Key Exchange algorithm. We just xor the private and public keys
- * together. Don't use this!
+ * Dummy "XOR" Key Exchange and signature algorithm. We just xor the
+ * private and public keys together. Don't use this!
  */
 
 typedef struct {
     XORKEY *key;
     XORKEY *peerkey;
     void *provctx;
-} PROV_XOR_CTX;
+} PROV_XORKEMKEX_CTX;
 
-static void *xor_newctx(void *provctx)
+static void *xor_newkemkexctx(void *provctx)
 {
-    PROV_XOR_CTX *pxorctx = OPENSSL_zalloc(sizeof(PROV_XOR_CTX));
+    PROV_XORKEMKEX_CTX *pxorctx = OPENSSL_zalloc(sizeof(PROV_XORKEMKEX_CTX));
 
     if (pxorctx == NULL)
         return NULL;
@@ -242,7 +470,7 @@ static void *xor_newctx(void *provctx)
 static int xor_init(void *vpxorctx, void *vkey,
                     ossl_unused const OSSL_PARAM params[])
 {
-    PROV_XOR_CTX *pxorctx = (PROV_XOR_CTX *)vpxorctx;
+    PROV_XORKEMKEX_CTX *pxorctx = (PROV_XORKEMKEX_CTX *)vpxorctx;
 
     if (pxorctx == NULL || vkey == NULL)
         return 0;
@@ -252,7 +480,7 @@ static int xor_init(void *vpxorctx, void *vkey,
 
 static int xor_set_peer(void *vpxorctx, void *vpeerkey)
 {
-    PROV_XOR_CTX *pxorctx = (PROV_XOR_CTX *)vpxorctx;
+    PROV_XORKEMKEX_CTX *pxorctx = (PROV_XORKEMKEX_CTX *)vpxorctx;
 
     if (pxorctx == NULL || vpeerkey == NULL)
         return 0;
@@ -263,7 +491,7 @@ static int xor_set_peer(void *vpxorctx, void *vpeerkey)
 static int xor_derive(void *vpxorctx, unsigned char *secret, size_t *secretlen,
                       size_t outlen)
 {
-    PROV_XOR_CTX *pxorctx = (PROV_XOR_CTX *)vpxorctx;
+    PROV_XORKEMKEX_CTX *pxorctx = (PROV_XORKEMKEX_CTX *)vpxorctx;
     int i;
 
     if (pxorctx->key == NULL || pxorctx->peerkey == NULL)
@@ -289,8 +517,8 @@ static void xor_freectx(void *pxorctx)
 
 static void *xor_dupctx(void *vpxorctx)
 {
-    PROV_XOR_CTX *srcctx = (PROV_XOR_CTX *)vpxorctx;
-    PROV_XOR_CTX *dstctx;
+    PROV_XORKEMKEX_CTX *srcctx = (PROV_XORKEMKEX_CTX *)vpxorctx;
+    PROV_XORKEMKEX_CTX *dstctx;
 
     dstctx = OPENSSL_zalloc(sizeof(*srcctx));
     if (dstctx == NULL)
@@ -302,7 +530,7 @@ static void *xor_dupctx(void *vpxorctx)
 }
 
 static const OSSL_DISPATCH xor_keyexch_functions[] = {
-    { OSSL_FUNC_KEYEXCH_NEWCTX, (void (*)(void))xor_newctx },
+    { OSSL_FUNC_KEYEXCH_NEWCTX, (void (*)(void))xor_newkemkexctx },
     { OSSL_FUNC_KEYEXCH_INIT, (void (*)(void))xor_init },
     { OSSL_FUNC_KEYEXCH_DERIVE, (void (*)(void))xor_derive },
     { OSSL_FUNC_KEYEXCH_SET_PEER, (void (*)(void))xor_set_peer },
@@ -340,7 +568,7 @@ static int xor_encapsulate(void *vpxorctx,
     int rv = 0;
     void *genctx = NULL, *derivectx = NULL;
     XORKEY *ourkey = NULL;
-    PROV_XOR_CTX *pxorctx = vpxorctx;
+    PROV_XORKEMKEX_CTX *pxorctx = vpxorctx;
 
     if (ct == NULL || ss == NULL) {
         /* Just return sizes */
@@ -367,7 +595,7 @@ static int xor_encapsulate(void *vpxorctx,
     *ctlen = XOR_KEY_SIZE;
 
     /* 3. Derive ss via KEX */
-    derivectx = xor_newctx(pxorctx->provctx);
+    derivectx = xor_newkemkexctx(pxorctx->provctx);
     if (derivectx == NULL
             || !xor_init(derivectx, ourkey, NULL)
             || !xor_set_peer(derivectx, pxorctx->key)
@@ -378,7 +606,7 @@ static int xor_encapsulate(void *vpxorctx,
 
  end:
     xor_gen_cleanup(genctx);
-    xor_freedata(ourkey);
+    xor_freekey(ourkey);
     xor_freectx(derivectx);
     return rv;
 }
@@ -396,7 +624,7 @@ static int xor_decapsulate(void *vpxorctx,
     int rv = 0;
     void *derivectx = NULL;
     XORKEY *peerkey = NULL;
-    PROV_XOR_CTX *pxorctx = vpxorctx;
+    PROV_XORKEMKEX_CTX *pxorctx = vpxorctx;
 
     if (ss == NULL) {
         /* Just return size */
@@ -408,13 +636,13 @@ static int xor_decapsulate(void *vpxorctx,
 
     if (ctlen != XOR_KEY_SIZE)
         return 0;
-    peerkey = xor_newdata(pxorctx->provctx);
+    peerkey = xor_newkey(pxorctx->provctx);
     if (peerkey == NULL)
         goto end;
     memcpy(peerkey->pubkey, ct, XOR_KEY_SIZE);
 
     /* Derive ss via KEX */
-    derivectx = xor_newctx(pxorctx->provctx);
+    derivectx = xor_newkemkexctx(pxorctx->provctx);
     if (derivectx == NULL
             || !xor_init(derivectx, pxorctx->key, NULL)
             || !xor_set_peer(derivectx, peerkey)
@@ -424,13 +652,13 @@ static int xor_decapsulate(void *vpxorctx,
     rv = 1;
 
  end:
-    xor_freedata(peerkey);
+    xor_freekey(peerkey);
     xor_freectx(derivectx);
     return rv;
 }
 
 static const OSSL_DISPATCH xor_kem_functions[] = {
-    { OSSL_FUNC_KEM_NEWCTX, (void (*)(void))xor_newctx },
+    { OSSL_FUNC_KEM_NEWCTX, (void (*)(void))xor_newkemkexctx },
     { OSSL_FUNC_KEM_FREECTX, (void (*)(void))xor_freectx },
     { OSSL_FUNC_KEM_DUPCTX, (void (*)(void))xor_dupctx },
     { OSSL_FUNC_KEM_ENCAPSULATE_INIT, (void (*)(void))xor_init },
@@ -451,14 +679,56 @@ static const OSSL_ALGORITHM tls_prov_kem[] = {
 
 /* Key Management for the dummy XOR key exchange algorithm */
 
-static void *xor_newdata(void *provctx)
+static void *xor_newkey(void *provctx)
 {
-    return OPENSSL_zalloc(sizeof(XORKEY));
+    XORKEY *ret = OPENSSL_zalloc(sizeof(XORKEY));
+
+    if (ret == NULL)
+        return NULL;
+
+    ret->references = 1;
+    ret->lock = CRYPTO_THREAD_lock_new();
+    if (ret->lock == NULL) {
+        ERR_raise(ERR_LIB_USER, ERR_R_MALLOC_FAILURE);
+        OPENSSL_free(ret);
+        return NULL;
+    }
+
+    return ret;
 }
 
-static void xor_freedata(void *keydata)
+static void xor_freekey(void *keydata)
 {
-    OPENSSL_free(keydata);
+    XORKEY* key = (XORKEY *)keydata;
+    int refcnt;
+
+    if (key == NULL)
+        return;
+
+    if (CRYPTO_DOWN_REF(&key->references, &refcnt, key->lock) <= 0)
+        return;
+
+    if (refcnt > 0)
+        return;
+    assert(refcnt == 0);
+
+    if (key != NULL) {
+        OPENSSL_free(key->tls_name);
+        key->tls_name = NULL;
+    }
+    CRYPTO_THREAD_lock_free(key->lock);
+    OPENSSL_free(key);
+}
+
+static int xor_key_up_ref(XORKEY *key)
+{
+    int refcnt;
+
+    if (CRYPTO_UP_REF(&key->references, &refcnt, key->lock) <= 0)
+        return 0;
+
+    assert(refcnt > 1);
+    return (refcnt > 1);
 }
 
 static int xor_has(const void *vkey, int selection)
@@ -479,7 +749,7 @@ static int xor_has(const void *vkey, int selection)
 
 static void *xor_dup(const void *vfromkey, int selection)
 {
-    XORKEY *tokey = xor_newdata(NULL);
+    XORKEY *tokey = xor_newkey(NULL);
     const XORKEY *fromkey = vfromkey;
     int ok = 0;
 
@@ -502,9 +772,11 @@ static void *xor_dup(const void *vfromkey, int selection)
                 tokey->hasprivkey = 0;
             }
         }
+        if (fromkey->tls_name != NULL)
+            tokey->tls_name = OPENSSL_strdup(fromkey->tls_name);
     }
     if (!ok) {
-        xor_freedata(tokey);
+        xor_freekey(tokey);
         tokey = NULL;
     }
     return tokey;
@@ -569,6 +841,72 @@ static const OSSL_PARAM xor_known_settable_params[] = {
     OSSL_PARAM_END
 };
 
+static void *xor_load(const void *reference, size_t reference_sz)
+{
+    XORKEY *key = NULL;
+
+    if (reference_sz == sizeof(key)) {
+        /* The contents of the reference is the address to our object */
+        key = *(XORKEY **)reference;
+        /* We grabbed, so we detach it */
+        *(XORKEY **)reference = NULL;
+        return key;
+    }
+    return NULL;
+}
+
+/* check one key is the "XOR complement" of the other */
+static int xor_recreate(const unsigned char *kd1, const unsigned char *kd2) {
+    int i;
+
+    for(i = 0; i < XOR_KEY_SIZE; i++) {
+        if ((kd1[i] & 0xff) != ((kd2[i] ^ private_constant[i]) & 0xff))
+            return 0;
+    }
+    return 1;
+}
+
+static int xor_match(const void *keydata1, const void *keydata2, int selection)
+{
+    const XORKEY *key1 = keydata1;
+    const XORKEY *key2 = keydata2;
+    int ok = 1;
+
+    if (key1->tls_name && key2->tls_name)
+        ok = ok & (strcmp(key1->tls_name, key2->tls_name) == 0);
+
+    if ((selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) != 0)  {
+        if (key1->hasprivkey) {
+            if (key2->hasprivkey)
+                ok = ok & (CRYPTO_memcmp(key1->privkey, key2->privkey,
+                                         XOR_KEY_SIZE) == 0);
+            else
+                ok = ok & xor_recreate(key1->privkey, key2->pubkey);
+        } else {
+            if (key2->hasprivkey)
+                ok = ok & xor_recreate(key2->privkey, key1->pubkey);
+            else
+                ok = 0;
+        }
+    }
+
+    if ((selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY) != 0)  {
+        if (key1->haspubkey) {
+            if (key2->haspubkey)
+                ok = ok & (CRYPTO_memcmp(key1->pubkey, key2->pubkey, XOR_KEY_SIZE) == 0);
+            else
+                ok = ok & xor_recreate(key1->pubkey, key2->privkey);
+        } else {
+            if (key2->haspubkey)
+                ok = ok & xor_recreate(key2->pubkey, key1->privkey);
+            else
+                ok = 0;
+        }
+    }
+
+    return ok;
+}
+
 static const OSSL_PARAM *xor_settable_params(void *provctx)
 {
     return xor_known_settable_params;
@@ -591,8 +929,7 @@ static void *xor_gen_init(void *provctx, int selection,
     if ((gctx = OPENSSL_zalloc(sizeof(*gctx))) != NULL)
         gctx->selection = selection;
 
-    /* Our provctx is really just an OSSL_LIB_CTX */
-    gctx->libctx = (OSSL_LIB_CTX *)provctx;
+    gctx->libctx = PROV_XOR_LIBCTX_OF(provctx);
 
     if (!xor_gen_set_params(gctx, params)) {
         OPENSSL_free(gctx);
@@ -633,7 +970,7 @@ static const OSSL_PARAM *xor_gen_settable_params(ossl_unused void *genctx,
 static void *xor_gen(void *genctx, OSSL_CALLBACK *osslcb, void *cbarg)
 {
     struct xor_gen_ctx *gctx = genctx;
-    XORKEY *key = OPENSSL_zalloc(sizeof(*key));
+    XORKEY *key = xor_newkey(NULL);
     size_t i;
 
     if (key == NULL)
@@ -735,7 +1072,7 @@ static void xor_gen_cleanup(void *genctx)
 }
 
 static const OSSL_DISPATCH xor_keymgmt_functions[] = {
-    { OSSL_FUNC_KEYMGMT_NEW, (void (*)(void))xor_newdata },
+    { OSSL_FUNC_KEYMGMT_NEW, (void (*)(void))xor_newkey },
     { OSSL_FUNC_KEYMGMT_GEN_INIT, (void (*)(void))xor_gen_init },
     { OSSL_FUNC_KEYMGMT_GEN_SET_PARAMS, (void (*)(void))xor_gen_set_params },
     { OSSL_FUNC_KEYMGMT_GEN_SETTABLE_PARAMS,
@@ -748,7 +1085,7 @@ static const OSSL_DISPATCH xor_keymgmt_functions[] = {
     { OSSL_FUNC_KEYMGMT_SETTABLE_PARAMS, (void (*) (void))xor_settable_params },
     { OSSL_FUNC_KEYMGMT_HAS, (void (*)(void))xor_has },
     { OSSL_FUNC_KEYMGMT_DUP, (void (*)(void))xor_dup },
-    { OSSL_FUNC_KEYMGMT_FREE, (void (*)(void))xor_freedata },
+    { OSSL_FUNC_KEYMGMT_FREE, (void (*)(void))xor_freekey },
     { OSSL_FUNC_KEYMGMT_IMPORT, (void (*)(void))xor_import },
     { OSSL_FUNC_KEYMGMT_IMPORT_TYPES, (void (*)(void))xor_import_types },
     { OSSL_FUNC_KEYMGMT_EXPORT, (void (*)(void))xor_export },
@@ -756,14 +1093,2024 @@ static const OSSL_DISPATCH xor_keymgmt_functions[] = {
     { 0, NULL }
 };
 
+/* We're re-using most XOR keymgmt functions also for signature operations: */
+static void *xor_xorhmacsig_gen(void *genctx, OSSL_CALLBACK *osslcb, void *cbarg)
+{
+    XORKEY *k = xor_gen(genctx, osslcb, cbarg);
+
+    if (k == NULL)
+        return NULL;
+    k->tls_name = OPENSSL_strdup(XORSIGALG_NAME);
+    if (k->tls_name == NULL) {
+        xor_freekey(k);
+        return NULL;
+    }
+    return k;
+}
+
+static void *xor_xorhmacsha2sig_gen(void *genctx, OSSL_CALLBACK *osslcb, void *cbarg)
+{
+    XORKEY* k = xor_gen(genctx, osslcb, cbarg);
+
+    if (k == NULL)
+        return NULL;
+    k->tls_name = OPENSSL_strdup(XORSIGALG_HASH_NAME);
+    if (k->tls_name == NULL) {
+        xor_freekey(k);
+        return NULL;
+    }
+    return k;
+}
+
+
+static const OSSL_DISPATCH xor_xorhmacsig_keymgmt_functions[] = {
+    { OSSL_FUNC_KEYMGMT_NEW, (void (*)(void))xor_newkey },
+    { OSSL_FUNC_KEYMGMT_GEN_INIT, (void (*)(void))xor_gen_init },
+    { OSSL_FUNC_KEYMGMT_GEN_SET_PARAMS, (void (*)(void))xor_gen_set_params },
+    { OSSL_FUNC_KEYMGMT_GEN_SETTABLE_PARAMS,
+      (void (*)(void))xor_gen_settable_params },
+    { OSSL_FUNC_KEYMGMT_GEN, (void (*)(void))xor_xorhmacsig_gen },
+    { OSSL_FUNC_KEYMGMT_GEN_CLEANUP, (void (*)(void))xor_gen_cleanup },
+    { OSSL_FUNC_KEYMGMT_GET_PARAMS, (void (*) (void))xor_get_params },
+    { OSSL_FUNC_KEYMGMT_GETTABLE_PARAMS, (void (*) (void))xor_gettable_params },
+    { OSSL_FUNC_KEYMGMT_SET_PARAMS, (void (*) (void))xor_set_params },
+    { OSSL_FUNC_KEYMGMT_SETTABLE_PARAMS, (void (*) (void))xor_settable_params },
+    { OSSL_FUNC_KEYMGMT_HAS, (void (*)(void))xor_has },
+    { OSSL_FUNC_KEYMGMT_DUP, (void (*)(void))xor_dup },
+    { OSSL_FUNC_KEYMGMT_FREE, (void (*)(void))xor_freekey },
+    { OSSL_FUNC_KEYMGMT_IMPORT, (void (*)(void))xor_import },
+    { OSSL_FUNC_KEYMGMT_IMPORT_TYPES, (void (*)(void))xor_import_types },
+    { OSSL_FUNC_KEYMGMT_EXPORT, (void (*)(void))xor_export },
+    { OSSL_FUNC_KEYMGMT_EXPORT_TYPES, (void (*)(void))xor_export_types },
+    { OSSL_FUNC_KEYMGMT_LOAD, (void (*)(void))xor_load },
+    { OSSL_FUNC_KEYMGMT_MATCH, (void (*)(void))xor_match },
+    { 0, NULL }
+};
+
+static const OSSL_DISPATCH xor_xorhmacsha2sig_keymgmt_functions[] = {
+    { OSSL_FUNC_KEYMGMT_NEW, (void (*)(void))xor_newkey },
+    { OSSL_FUNC_KEYMGMT_GEN_INIT, (void (*)(void))xor_gen_init },
+    { OSSL_FUNC_KEYMGMT_GEN_SET_PARAMS, (void (*)(void))xor_gen_set_params },
+    { OSSL_FUNC_KEYMGMT_GEN_SETTABLE_PARAMS,
+      (void (*)(void))xor_gen_settable_params },
+    { OSSL_FUNC_KEYMGMT_GEN, (void (*)(void))xor_xorhmacsha2sig_gen },
+    { OSSL_FUNC_KEYMGMT_GEN_CLEANUP, (void (*)(void))xor_gen_cleanup },
+    { OSSL_FUNC_KEYMGMT_GET_PARAMS, (void (*) (void))xor_get_params },
+    { OSSL_FUNC_KEYMGMT_GETTABLE_PARAMS, (void (*) (void))xor_gettable_params },
+    { OSSL_FUNC_KEYMGMT_SET_PARAMS, (void (*) (void))xor_set_params },
+    { OSSL_FUNC_KEYMGMT_SETTABLE_PARAMS, (void (*) (void))xor_settable_params },
+    { OSSL_FUNC_KEYMGMT_HAS, (void (*)(void))xor_has },
+    { OSSL_FUNC_KEYMGMT_DUP, (void (*)(void))xor_dup },
+    { OSSL_FUNC_KEYMGMT_FREE, (void (*)(void))xor_freekey },
+    { OSSL_FUNC_KEYMGMT_IMPORT, (void (*)(void))xor_import },
+    { OSSL_FUNC_KEYMGMT_IMPORT_TYPES, (void (*)(void))xor_import_types },
+    { OSSL_FUNC_KEYMGMT_EXPORT, (void (*)(void))xor_export },
+    { OSSL_FUNC_KEYMGMT_EXPORT_TYPES, (void (*)(void))xor_export_types },
+    { OSSL_FUNC_KEYMGMT_LOAD, (void (*)(void))xor_load },
+    { OSSL_FUNC_KEYMGMT_MATCH, (void (*)(void))xor_match },
+    { 0, NULL }
+};
+
+typedef enum {
+    KEY_OP_PUBLIC,
+    KEY_OP_PRIVATE,
+    KEY_OP_KEYGEN
+} xor_key_op_t;
+
+/* Re-create XORKEY from encoding(s): Same end-state as after key-gen */
+static XORKEY *xor_key_op(const X509_ALGOR *palg,
+                          const unsigned char *p, int plen,
+                          xor_key_op_t op,
+                          OSSL_LIB_CTX *libctx, const char *propq)
+{
+    XORKEY *key = NULL;
+    int nid = NID_undef;
+
+    if (palg != NULL) {
+        int ptype;
+
+        /* Algorithm parameters must be absent */
+        X509_ALGOR_get0(NULL, &ptype, NULL, palg);
+        if (ptype != V_ASN1_UNDEF || palg->algorithm == NULL) {
+            ERR_raise(ERR_LIB_USER, XORPROV_R_INVALID_ENCODING);
+            return 0;
+        }
+        nid = OBJ_obj2nid(palg->algorithm);
+    }
+
+    if (p == NULL || nid == EVP_PKEY_NONE || nid == NID_undef) {
+        ERR_raise(ERR_LIB_USER, XORPROV_R_INVALID_ENCODING);
+        return 0;
+    }
+
+    key = xor_newkey(NULL);
+    if (key == NULL) {
+        ERR_raise(ERR_LIB_USER, ERR_R_MALLOC_FAILURE);
+        return 0;
+    }
+
+    if (XOR_KEY_SIZE != plen) {
+        ERR_raise(ERR_LIB_USER, XORPROV_R_INVALID_ENCODING);
+        goto err;
+    }
+
+    if (op == KEY_OP_PUBLIC) {
+        memcpy(key->pubkey, p, plen);
+        key->haspubkey = 1;
+    } else {
+        memcpy(key->privkey, p, plen);
+        key->hasprivkey = 1;
+    }
+
+    key->tls_name = OPENSSL_strdup(OBJ_nid2sn(nid));
+    if (key->tls_name == NULL)
+        goto err;
+    return key;
+
+ err:
+    xor_freekey(key);
+    return NULL;
+}
+
+static XORKEY *xor_key_from_x509pubkey(const X509_PUBKEY *xpk,
+                                 OSSL_LIB_CTX *libctx, const char *propq)
+{
+    const unsigned char *p;
+    int plen;
+    X509_ALGOR *palg;
+
+    if (!xpk || (!X509_PUBKEY_get0_param(NULL, &p, &plen, &palg, xpk))) {
+        return NULL;
+    }
+    return xor_key_op(palg, p, plen, KEY_OP_PUBLIC, libctx, propq);
+}
+
+static XORKEY *xor_key_from_pkcs8(const PKCS8_PRIV_KEY_INFO *p8inf,
+                           OSSL_LIB_CTX *libctx, const char *propq)
+{
+    XORKEY *xork = NULL;
+    const unsigned char *p;
+    int plen;
+    ASN1_OCTET_STRING *oct = NULL;
+    const X509_ALGOR *palg;
+
+    if (!PKCS8_pkey_get0(NULL, &p, &plen, &palg, p8inf))
+        return 0;
+
+    oct = d2i_ASN1_OCTET_STRING(NULL, &p, plen);
+    if (oct == NULL) {
+        p = NULL;
+        plen = 0;
+    } else {
+        p = ASN1_STRING_get0_data(oct);
+        plen = ASN1_STRING_length(oct);
+    }
+
+    xork = xor_key_op(palg, p, plen, KEY_OP_PRIVATE,
+                      libctx, propq);
+    ASN1_OCTET_STRING_free(oct);
+    return xork;
+}
+
 static const OSSL_ALGORITHM tls_prov_keymgmt[] = {
     /*
      * Obviously this is not FIPS approved, but in order to test in conjunction
      * with the FIPS provider we pretend that it is.
      */
-    { "XOR", "provider=tls-provider,fips=yes", xor_keymgmt_functions },
+    { "XOR", "provider=tls-provider,fips=yes",
+             xor_keymgmt_functions },
+    { XORSIGALG_NAME, "provider=tls-provider,fips=yes",
+             xor_xorhmacsig_keymgmt_functions },
+    { XORSIGALG_HASH_NAME,
+    "provider=tls-provider,fips=yes",
+             xor_xorhmacsha2sig_keymgmt_functions },
     { NULL, NULL, NULL }
 };
+
+struct key2any_ctx_st {
+    PROV_XOR_CTX *provctx;
+
+    /* Set to 0 if parameters should not be saved (dsa only) */
+    int save_parameters;
+
+    /* Set to 1 if intending to encrypt/decrypt, otherwise 0 */
+    int cipher_intent;
+
+    EVP_CIPHER *cipher;
+
+    OSSL_PASSPHRASE_CALLBACK *pwcb;
+    void *pwcbarg;
+};
+
+typedef int check_key_type_fn(const void *key, int nid);
+typedef int key_to_paramstring_fn(const void *key, int nid, int save,
+                                  void **str, int *strtype);
+typedef int key_to_der_fn(BIO *out, const void *key,
+                          int key_nid, const char *pemname,
+                          key_to_paramstring_fn *p2s, i2d_of_void *k2d,
+                          struct key2any_ctx_st *ctx);
+typedef int write_bio_of_void_fn(BIO *bp, const void *x);
+
+
+/* Free the blob allocated during key_to_paramstring_fn */
+static void free_asn1_data(int type, void *data)
+{
+    switch(type) {
+    case V_ASN1_OBJECT:
+        ASN1_OBJECT_free(data);
+        break;
+    case V_ASN1_SEQUENCE:
+        ASN1_STRING_free(data);
+        break;
+    }
+}
+
+static PKCS8_PRIV_KEY_INFO *key_to_p8info(const void *key, int key_nid,
+                                          void *params, int params_type,
+                                          i2d_of_void *k2d)
+{
+    /* der, derlen store the key DER output and its length */
+    unsigned char *der = NULL;
+    int derlen;
+    /* The final PKCS#8 info */
+    PKCS8_PRIV_KEY_INFO *p8info = NULL;
+
+    if ((p8info = PKCS8_PRIV_KEY_INFO_new()) == NULL
+        || (derlen = k2d(key, &der)) <= 0
+        || !PKCS8_pkey_set0(p8info, OBJ_nid2obj(key_nid), 0,
+                            V_ASN1_UNDEF, NULL,
+                            der, derlen)) {
+        ERR_raise(ERR_LIB_USER, ERR_R_MALLOC_FAILURE);
+        PKCS8_PRIV_KEY_INFO_free(p8info);
+        OPENSSL_free(der);
+        p8info = NULL;
+    }
+
+    return p8info;
+}
+
+static X509_SIG *p8info_to_encp8(PKCS8_PRIV_KEY_INFO *p8info,
+                                 struct key2any_ctx_st *ctx)
+{
+    X509_SIG *p8 = NULL;
+    char kstr[PEM_BUFSIZE];
+    size_t klen = 0;
+    OSSL_LIB_CTX *libctx = PROV_XOR_LIBCTX_OF(ctx->provctx);
+
+    if (ctx->cipher == NULL || ctx->pwcb == NULL)
+        return NULL;
+
+    if (!ctx->pwcb(kstr, PEM_BUFSIZE, &klen, NULL, ctx->pwcbarg)) {
+        ERR_raise(ERR_LIB_USER, PROV_R_UNABLE_TO_GET_PASSPHRASE);
+        return NULL;
+    }
+    /* First argument == -1 means "standard" */
+    p8 = PKCS8_encrypt_ex(-1, ctx->cipher, kstr, klen, NULL, 0, 0, p8info, libctx, NULL);
+    OPENSSL_cleanse(kstr, klen);
+    return p8;
+}
+
+static X509_SIG *key_to_encp8(const void *key, int key_nid,
+                              void *params, int params_type,
+                              i2d_of_void *k2d, struct key2any_ctx_st *ctx)
+{
+    PKCS8_PRIV_KEY_INFO *p8info =
+        key_to_p8info(key, key_nid, params, params_type, k2d);
+    X509_SIG *p8 = NULL;
+
+    if (p8info == NULL) {
+        free_asn1_data(params_type, params);
+    } else {
+        p8 = p8info_to_encp8(p8info, ctx);
+        PKCS8_PRIV_KEY_INFO_free(p8info);
+    }
+    return p8;
+}
+
+static X509_PUBKEY *xorx_key_to_pubkey(const void *key, int key_nid,
+                                  void *params, int params_type,
+                                  i2d_of_void k2d)
+{
+    /* der, derlen store the key DER output and its length */
+    unsigned char *der = NULL;
+    int derlen;
+    /* The final X509_PUBKEY */
+    X509_PUBKEY *xpk = NULL;
+
+    if ((xpk = X509_PUBKEY_new()) == NULL
+        || (derlen = k2d(key, &der)) <= 0
+        || !X509_PUBKEY_set0_param(xpk, OBJ_nid2obj(key_nid),
+                        V_ASN1_UNDEF, NULL,
+                        der, derlen)) {
+        ERR_raise(ERR_LIB_USER, ERR_R_MALLOC_FAILURE);
+        X509_PUBKEY_free(xpk);
+        OPENSSL_free(der);
+        xpk = NULL;
+    }
+
+    return xpk;
+}
+
+/*
+ * key_to_epki_* produce encoded output with the private key data in a
+ * EncryptedPrivateKeyInfo structure (defined by PKCS#8).  They require
+ * that there's an intent to encrypt, anything else is an error.
+ *
+ * key_to_pki_* primarly produce encoded output with the private key data
+ * in a PrivateKeyInfo structure (also defined by PKCS#8).  However, if
+ * there is an intent to encrypt the data, the corresponding key_to_epki_*
+ * function is used instead.
+ *
+ * key_to_spki_* produce encoded output with the public key data in an
+ * X.509 SubjectPublicKeyInfo.
+ *
+ * Key parameters don't have any defined envelopment of this kind, but are
+ * included in some manner in the output from the functions described above,
+ * either in the AlgorithmIdentifier's parameter field, or as part of the
+ * key data itself.
+ */
+
+static int key_to_epki_der_priv_bio(BIO *out, const void *key,
+                                    int key_nid,
+                                    ossl_unused const char *pemname,
+                                    key_to_paramstring_fn *p2s,
+                                    i2d_of_void *k2d,
+                                    struct key2any_ctx_st *ctx)
+{
+    int ret = 0;
+    void *str = NULL;
+    int strtype = V_ASN1_UNDEF;
+    X509_SIG *p8;
+
+    if (!ctx->cipher_intent)
+        return 0;
+
+    if (p2s != NULL && !p2s(key, key_nid, ctx->save_parameters,
+                            &str, &strtype))
+        return 0;
+
+    p8 = key_to_encp8(key, key_nid, str, strtype, k2d, ctx);
+    if (p8 != NULL)
+        ret = i2d_PKCS8_bio(out, p8);
+
+    X509_SIG_free(p8);
+
+    return ret;
+}
+
+static int key_to_epki_pem_priv_bio(BIO *out, const void *key,
+                                    int key_nid,
+                                    ossl_unused const char *pemname,
+                                    key_to_paramstring_fn *p2s,
+                                    i2d_of_void *k2d,
+                                    struct key2any_ctx_st *ctx)
+{
+    int ret = 0;
+    void *str = NULL;
+    int strtype = V_ASN1_UNDEF;
+    X509_SIG *p8;
+
+    if (!ctx->cipher_intent)
+        return 0;
+
+    if (p2s != NULL && !p2s(key, key_nid, ctx->save_parameters,
+                            &str, &strtype))
+        return 0;
+
+    p8 = key_to_encp8(key, key_nid, str, strtype, k2d, ctx);
+    if (p8 != NULL)
+        ret = PEM_write_bio_PKCS8(out, p8);
+
+    X509_SIG_free(p8);
+
+    return ret;
+}
+
+static int key_to_pki_der_priv_bio(BIO *out, const void *key,
+                                   int key_nid,
+                                   ossl_unused const char *pemname,
+                                   key_to_paramstring_fn *p2s,
+                                   i2d_of_void *k2d,
+                                   struct key2any_ctx_st *ctx)
+{
+    int ret = 0;
+    void *str = NULL;
+    int strtype = V_ASN1_UNDEF;
+    PKCS8_PRIV_KEY_INFO *p8info;
+
+    if (ctx->cipher_intent)
+        return key_to_epki_der_priv_bio(out, key, key_nid, pemname,
+                                        p2s, k2d, ctx);
+
+    if (p2s != NULL && !p2s(key, key_nid, ctx->save_parameters,
+                            &str, &strtype))
+        return 0;
+
+    p8info = key_to_p8info(key, key_nid, str, strtype, k2d);
+
+    if (p8info != NULL)
+        ret = i2d_PKCS8_PRIV_KEY_INFO_bio(out, p8info);
+    else
+        free_asn1_data(strtype, str);
+
+    PKCS8_PRIV_KEY_INFO_free(p8info);
+
+    return ret;
+}
+
+static int key_to_pki_pem_priv_bio(BIO *out, const void *key,
+                                   int key_nid,
+                                   ossl_unused const char *pemname,
+                                   key_to_paramstring_fn *p2s,
+                                   i2d_of_void *k2d,
+                                   struct key2any_ctx_st *ctx)
+{
+    int ret = 0;
+    void *str = NULL;
+    int strtype = V_ASN1_UNDEF;
+    PKCS8_PRIV_KEY_INFO *p8info;
+
+    if (ctx->cipher_intent)
+        return key_to_epki_pem_priv_bio(out, key, key_nid, pemname,
+                                        p2s, k2d, ctx);
+
+    if (p2s != NULL && !p2s(key, key_nid, ctx->save_parameters,
+                            &str, &strtype))
+        return 0;
+
+    p8info = key_to_p8info(key, key_nid, str, strtype, k2d);
+
+    if (p8info != NULL)
+        ret = PEM_write_bio_PKCS8_PRIV_KEY_INFO(out, p8info);
+    else
+        free_asn1_data(strtype, str);
+
+    PKCS8_PRIV_KEY_INFO_free(p8info);
+
+    return ret;
+}
+
+static int key_to_spki_der_pub_bio(BIO *out, const void *key,
+                                   int key_nid,
+                                   ossl_unused const char *pemname,
+                                   key_to_paramstring_fn *p2s,
+                                   i2d_of_void *k2d,
+                                   struct key2any_ctx_st *ctx)
+{
+    int ret = 0;
+    X509_PUBKEY *xpk = NULL;
+    void *str = NULL;
+    int strtype = V_ASN1_UNDEF;
+
+    if (p2s != NULL && !p2s(key, key_nid, ctx->save_parameters,
+                            &str, &strtype))
+        return 0;
+
+    xpk = xorx_key_to_pubkey(key, key_nid, str, strtype, k2d);
+
+    if (xpk != NULL)
+        ret = i2d_X509_PUBKEY_bio(out, xpk);
+
+    X509_PUBKEY_free(xpk);
+    return ret;
+}
+
+static int key_to_spki_pem_pub_bio(BIO *out, const void *key,
+                                   int key_nid,
+                                   ossl_unused const char *pemname,
+                                   key_to_paramstring_fn *p2s,
+                                   i2d_of_void *k2d,
+                                   struct key2any_ctx_st *ctx)
+{
+    int ret = 0;
+    X509_PUBKEY *xpk = NULL;
+    void *str = NULL;
+    int strtype = V_ASN1_UNDEF;
+
+    if (p2s != NULL && !p2s(key, key_nid, ctx->save_parameters,
+                            &str, &strtype))
+        return 0;
+
+    xpk = xorx_key_to_pubkey(key, key_nid, str, strtype, k2d);
+
+    if (xpk != NULL)
+        ret = PEM_write_bio_X509_PUBKEY(out, xpk);
+    else
+        free_asn1_data(strtype, str);
+
+    /* Also frees |str| */
+    X509_PUBKEY_free(xpk);
+    return ret;
+}
+
+/* ---------------------------------------------------------------------- */
+
+static int prepare_xorx_params(const void *xorxkey, int nid, int save,
+                             void **pstr, int *pstrtype)
+{
+    ASN1_OBJECT *params = NULL;
+    XORKEY *k = (XORKEY*)xorxkey;
+
+    if (k->tls_name && OBJ_sn2nid(k->tls_name) != nid) {
+        ERR_raise(ERR_LIB_USER, XORPROV_R_INVALID_KEY);
+        return 0;
+    }
+
+    if (nid == NID_undef) {
+        ERR_raise(ERR_LIB_USER, XORPROV_R_MISSING_OID);
+        return 0;
+    }
+
+    params = OBJ_nid2obj(nid);
+
+    if (params == NULL || OBJ_length(params) == 0) {
+        /* unexpected error */
+        ERR_raise(ERR_LIB_USER, XORPROV_R_MISSING_OID);
+        ASN1_OBJECT_free(params);
+        return 0;
+    }
+    *pstr = params;
+    *pstrtype = V_ASN1_OBJECT;
+    return 1;
+}
+
+static int xorx_spki_pub_to_der(const void *vecxkey, unsigned char **pder)
+{
+    const XORKEY *xorxkey = vecxkey;
+    unsigned char *keyblob;
+    int retlen;
+
+    if (xorxkey == NULL) {
+        ERR_raise(ERR_LIB_USER, ERR_R_PASSED_NULL_PARAMETER);
+        return 0;
+    }
+
+    keyblob = OPENSSL_memdup(xorxkey->pubkey, retlen = XOR_KEY_SIZE);
+    if (keyblob == NULL) {
+        ERR_raise(ERR_LIB_USER, ERR_R_MALLOC_FAILURE);
+        return 0;
+    }
+
+    *pder = keyblob;
+    return retlen;
+}
+
+static int xorx_pki_priv_to_der(const void *vecxkey, unsigned char **pder)
+{
+    XORKEY *xorxkey = (XORKEY *)vecxkey;
+    unsigned char* buf = NULL;
+    ASN1_OCTET_STRING oct;
+    int keybloblen;
+
+    if (xorxkey == NULL) {
+        ERR_raise(ERR_LIB_USER, ERR_R_PASSED_NULL_PARAMETER);
+        return 0;
+    }
+
+    buf = OPENSSL_secure_malloc(XOR_KEY_SIZE);
+    memcpy(buf, xorxkey->privkey, XOR_KEY_SIZE);
+
+    oct.data = buf;
+    oct.length = XOR_KEY_SIZE;
+    oct.flags = 0;
+
+    keybloblen = i2d_ASN1_OCTET_STRING(&oct, pder);
+    if (keybloblen < 0) {
+        ERR_raise(ERR_LIB_USER, ERR_R_MALLOC_FAILURE);
+        keybloblen = 0;
+    }
+
+    OPENSSL_secure_clear_free(buf, XOR_KEY_SIZE);
+    return keybloblen;
+}
+
+# define xorx_epki_priv_to_der xorx_pki_priv_to_der
+
+/*
+ * XORX only has PKCS#8 / SubjectPublicKeyInfo
+ * representation, so we don't define xorx_type_specific_[priv,pub,params]_to_der.
+ */
+
+# define xorx_check_key_type            NULL
+
+# define xorhmacsig_evp_type            0
+# define xorhmacsig_input_type          XORSIGALG_NAME
+# define xorhmacsig_pem_type            XORSIGALG_NAME
+# define xorhmacsha2sig_evp_type        0
+# define xorhmacsha2sig_input_type      XORSIGALG_HASH_NAME
+# define xorhmacsha2sig_pem_type        XORSIGALG_HASH_NAME
+
+/* ---------------------------------------------------------------------- */
+
+static OSSL_FUNC_decoder_newctx_fn key2any_newctx;
+static OSSL_FUNC_decoder_freectx_fn key2any_freectx;
+
+static void *key2any_newctx(void *provctx)
+{
+    struct key2any_ctx_st *ctx = OPENSSL_zalloc(sizeof(*ctx));
+
+    if (ctx != NULL) {
+        ctx->provctx = provctx;
+        ctx->save_parameters = 1;
+    }
+
+    return ctx;
+}
+
+static void key2any_freectx(void *vctx)
+{
+    struct key2any_ctx_st *ctx = vctx;
+
+    EVP_CIPHER_free(ctx->cipher);
+    OPENSSL_free(ctx);
+}
+
+static const OSSL_PARAM *key2any_settable_ctx_params(ossl_unused void *provctx)
+{
+    static const OSSL_PARAM settables[] = {
+        OSSL_PARAM_utf8_string(OSSL_ENCODER_PARAM_CIPHER, NULL, 0),
+        OSSL_PARAM_utf8_string(OSSL_ENCODER_PARAM_PROPERTIES, NULL, 0),
+        OSSL_PARAM_END,
+    };
+
+    return settables;
+}
+
+static int key2any_set_ctx_params(void *vctx, const OSSL_PARAM params[])
+{
+    struct key2any_ctx_st *ctx = vctx;
+    OSSL_LIB_CTX *libctx = PROV_XOR_LIBCTX_OF(ctx->provctx);
+    const OSSL_PARAM *cipherp =
+        OSSL_PARAM_locate_const(params, OSSL_ENCODER_PARAM_CIPHER);
+    const OSSL_PARAM *propsp =
+        OSSL_PARAM_locate_const(params, OSSL_ENCODER_PARAM_PROPERTIES);
+    const OSSL_PARAM *save_paramsp =
+        OSSL_PARAM_locate_const(params, OSSL_ENCODER_PARAM_SAVE_PARAMETERS);
+
+    if (cipherp != NULL) {
+        const char *ciphername = NULL;
+        const char *props = NULL;
+
+        if (!OSSL_PARAM_get_utf8_string_ptr(cipherp, &ciphername))
+            return 0;
+        if (propsp != NULL && !OSSL_PARAM_get_utf8_string_ptr(propsp, &props))
+            return 0;
+
+        EVP_CIPHER_free(ctx->cipher);
+        ctx->cipher = NULL;
+        ctx->cipher_intent = ciphername != NULL;
+        if (ciphername != NULL
+            && ((ctx->cipher =
+                 EVP_CIPHER_fetch(libctx, ciphername, props)) == NULL)) {
+            return 0;
+        }
+    }
+
+    if (save_paramsp != NULL) {
+        if (!OSSL_PARAM_get_int(save_paramsp, &ctx->save_parameters)) {
+            return 0;
+        }
+    }
+    return 1;
+}
+
+static int key2any_check_selection(int selection, int selection_mask)
+{
+    /*
+     * The selections are kinda sorta "levels", i.e. each selection given
+     * here is assumed to include those following.
+     */
+    int checks[] = {
+        OSSL_KEYMGMT_SELECT_PRIVATE_KEY,
+        OSSL_KEYMGMT_SELECT_PUBLIC_KEY,
+        OSSL_KEYMGMT_SELECT_ALL_PARAMETERS
+    };
+    size_t i;
+
+    /* The decoder implementations made here support guessing */
+    if (selection == 0)
+        return 1;
+
+    for (i = 0; i < OSSL_NELEM(checks); i++) {
+        int check1 = (selection & checks[i]) != 0;
+        int check2 = (selection_mask & checks[i]) != 0;
+
+        /*
+         * If the caller asked for the currently checked bit(s), return
+         * whether the decoder description says it's supported.
+         */
+        if (check1) 
+            return check2;
+    }
+
+    /* This should be dead code, but just to be safe... */
+    return 0;
+}
+
+static int key2any_encode(struct key2any_ctx_st *ctx, OSSL_CORE_BIO *cout,
+                          const void *key, const char* typestr, const char *pemname,
+                          key_to_der_fn *writer,
+                          OSSL_PASSPHRASE_CALLBACK *pwcb, void *pwcbarg,
+                          key_to_paramstring_fn *key2paramstring,
+                          i2d_of_void *key2der)
+{
+    int ret = 0;
+    int type = OBJ_sn2nid(typestr);
+
+    if (key == NULL || type <= 0) {
+        ERR_raise(ERR_LIB_USER, ERR_R_PASSED_NULL_PARAMETER);
+    } else if (writer != NULL) {
+        BIO *out = BIO_new_from_core_bio(ctx->provctx->libctx, cout);
+
+        if (out != NULL) {
+            ctx->pwcb = pwcb;
+            ctx->pwcbarg = pwcbarg;
+
+            ret = writer(out, key, type, pemname, key2paramstring, key2der, ctx);
+        }
+
+        BIO_free(out);
+    } else {
+        ERR_raise(ERR_LIB_USER, ERR_R_PASSED_INVALID_ARGUMENT);
+    }
+    return ret;
+}
+
+#define DO_ENC_PRIVATE_KEY_selection_mask OSSL_KEYMGMT_SELECT_PRIVATE_KEY
+#define DO_ENC_PRIVATE_KEY(impl, type, kind, output)                            \
+    if ((selection & DO_ENC_PRIVATE_KEY_selection_mask) != 0)                   \
+        return key2any_encode(ctx, cout, key, impl##_pem_type,              \
+                              impl##_pem_type " PRIVATE KEY",               \
+                              key_to_##kind##_##output##_priv_bio,          \
+                              cb, cbarg, prepare_##type##_params,           \
+                              type##_##kind##_priv_to_der);
+
+#define DO_ENC_PUBLIC_KEY_selection_mask OSSL_KEYMGMT_SELECT_PUBLIC_KEY
+#define DO_ENC_PUBLIC_KEY(impl, type, kind, output)                             \
+    if ((selection & DO_ENC_PUBLIC_KEY_selection_mask) != 0)                    \
+        return key2any_encode(ctx, cout, key, impl##_pem_type,              \
+                              impl##_pem_type " PUBLIC KEY",                \
+                              key_to_##kind##_##output##_pub_bio,           \
+                              cb, cbarg, prepare_##type##_params,           \
+                              type##_##kind##_pub_to_der);
+
+#define DO_ENC_PARAMETERS_selection_mask OSSL_KEYMGMT_SELECT_ALL_PARAMETERS
+#define DO_ENC_PARAMETERS(impl, type, kind, output)                             \
+    if ((selection & DO_ENC_PARAMETERS_selection_mask) != 0)                    \
+        return key2any_encode(ctx, cout, key, impl##_pem_type,              \
+                              impl##_pem_type " PARAMETERS",                \
+                              key_to_##kind##_##output##_param_bio,         \
+                              NULL, NULL, NULL,                             \
+                              type##_##kind##_params_to_der);
+
+/*-
+ * Implement the kinds of output structure that can be produced.  They are
+ * referred to by name, and for each name, the following macros are defined
+ * (braces not included):
+ *
+ * DO_{kind}_selection_mask
+ *
+ *      A mask of selection bits that must not be zero.  This is used as a
+ *      selection criterion for each implementation.
+ *      This mask must never be zero.
+ *
+ * DO_{kind}
+ *
+ *      The performing macro.  It must use the DO_ macros defined above,
+ *      always in this order:
+ *
+ *      - DO_PRIVATE_KEY
+ *      - DO_PUBLIC_KEY
+ *      - DO_PARAMETERS
+ *
+ *      Any of those may be omitted, but the relative order must still be
+ *      the same.
+ */
+
+/*
+ * PKCS#8 defines two structures for private keys only:
+ * - PrivateKeyInfo             (raw unencrypted form)
+ * - EncryptedPrivateKeyInfo    (encrypted wrapping)
+ *
+ * To allow a certain amount of flexibility, we allow the routines
+ * for PrivateKeyInfo to also produce EncryptedPrivateKeyInfo if a
+ * passphrase callback has been passed to them.
+ */
+#define DO_ENC_PrivateKeyInfo_selection_mask DO_ENC_PRIVATE_KEY_selection_mask
+#define DO_ENC_PrivateKeyInfo(impl, type, output)                               \
+    DO_ENC_PRIVATE_KEY(impl, type, pki, output)
+
+#define DO_ENC_EncryptedPrivateKeyInfo_selection_mask DO_ENC_PRIVATE_KEY_selection_mask
+#define DO_ENC_EncryptedPrivateKeyInfo(impl, type, output)                      \
+    DO_ENC_PRIVATE_KEY(impl, type, epki, output)
+
+/* SubjectPublicKeyInfo is a structure for public keys only */
+#define DO_ENC_SubjectPublicKeyInfo_selection_mask DO_ENC_PUBLIC_KEY_selection_mask
+#define DO_ENC_SubjectPublicKeyInfo(impl, type, output)                         \
+    DO_ENC_PUBLIC_KEY(impl, type, spki, output)
+
+/*
+ * MAKE_ENCODER is the single driver for creating OSSL_DISPATCH tables.
+ * It takes the following arguments:
+ *
+ * impl         This is the key type name that's being implemented.
+ * type         This is the type name for the set of functions that implement
+ *              the key type.  For example, ed25519, ed448, x25519 and x448
+ *              are all implemented with the exact same set of functions.
+ * kind         What kind of support to implement.  These translate into
+ *              the DO_##kind macros above.
+ * output       The output type to implement.  may be der or pem.
+ *
+ * The resulting OSSL_DISPATCH array gets the following name (expressed in
+ * C preprocessor terms) from those arguments:
+ *
+ * xor_##impl##_to_##kind##_##output##_encoder_functions
+ */
+#define MAKE_ENCODER(impl, type, kind, output)                              \
+    static OSSL_FUNC_encoder_import_object_fn                               \
+    impl##_to_##kind##_##output##_import_object;                            \
+    static OSSL_FUNC_encoder_free_object_fn                                 \
+    impl##_to_##kind##_##output##_free_object;                              \
+    static OSSL_FUNC_encoder_encode_fn                                      \
+    impl##_to_##kind##_##output##_encode;                                   \
+                                                                            \
+    static void *                                                           \
+    impl##_to_##kind##_##output##_import_object(void *vctx, int selection,  \
+                                                const OSSL_PARAM params[])  \
+    {                                                                       \
+        struct key2any_ctx_st *ctx = vctx;                                  \
+                                                                            \
+        return xor_prov_import_key(xor_##impl##_keymgmt_functions,          \
+                                    ctx->provctx, selection, params);       \
+    }                                                                       \
+    static void impl##_to_##kind##_##output##_free_object(void *key)        \
+    {                                                                       \
+        xor_prov_free_key(xor_##impl##_keymgmt_functions, key);             \
+    }                                                                       \
+    static int impl##_to_##kind##_##output##_does_selection(void *ctx,      \
+                                                            int selection)  \
+    {                                                                       \
+        return key2any_check_selection(selection,                           \
+                                       DO_ENC_##kind##_selection_mask);     \
+    }                                                                       \
+    static int                                                              \
+    impl##_to_##kind##_##output##_encode(void *ctx, OSSL_CORE_BIO *cout,    \
+                                         const void *key,                   \
+                                         const OSSL_PARAM key_abstract[],   \
+                                         int selection,                     \
+                                         OSSL_PASSPHRASE_CALLBACK *cb,      \
+                                         void *cbarg)                       \
+    {                                                                       \
+        /* We don't deal with abstract objects */                           \
+        if (key_abstract != NULL) {                                         \
+            ERR_raise(ERR_LIB_USER, ERR_R_PASSED_INVALID_ARGUMENT);         \
+            return 0;                                                       \
+        }                                                                   \
+        DO_ENC_##kind(impl, type, output)                                   \
+                                                                            \
+        ERR_raise(ERR_LIB_USER, ERR_R_PASSED_INVALID_ARGUMENT);             \
+        return 0;                                                           \
+    }                                                                       \
+    static const OSSL_DISPATCH                                              \
+    xor_##impl##_to_##kind##_##output##_encoder_functions[] = {             \
+        { OSSL_FUNC_ENCODER_NEWCTX,                                         \
+          (void (*)(void))key2any_newctx },                                 \
+        { OSSL_FUNC_ENCODER_FREECTX,                                        \
+          (void (*)(void))key2any_freectx },                                \
+        { OSSL_FUNC_ENCODER_SETTABLE_CTX_PARAMS,                            \
+          (void (*)(void))key2any_settable_ctx_params },                    \
+        { OSSL_FUNC_ENCODER_SET_CTX_PARAMS,                                 \
+          (void (*)(void))key2any_set_ctx_params },                         \
+        { OSSL_FUNC_ENCODER_DOES_SELECTION,                                 \
+          (void (*)(void))impl##_to_##kind##_##output##_does_selection },   \
+        { OSSL_FUNC_ENCODER_IMPORT_OBJECT,                                  \
+          (void (*)(void))impl##_to_##kind##_##output##_import_object },    \
+        { OSSL_FUNC_ENCODER_FREE_OBJECT,                                    \
+          (void (*)(void))impl##_to_##kind##_##output##_free_object },      \
+        { OSSL_FUNC_ENCODER_ENCODE,                                         \
+          (void (*)(void))impl##_to_##kind##_##output##_encode },           \
+        { 0, NULL }                                                         \
+    }
+
+/*
+ * Replacements for i2d_{TYPE}PrivateKey, i2d_{TYPE}PublicKey,
+ * i2d_{TYPE}params, as they exist.
+ */
+
+/*
+ * PKCS#8 and SubjectPublicKeyInfo support.  This may duplicate some of the
+ * implementations specified above, but are more specific.
+ * The SubjectPublicKeyInfo implementations also replace the
+ * PEM_write_bio_{TYPE}_PUBKEY functions.
+ * For PEM, these are expected to be used by PEM_write_bio_PrivateKey(),
+ * PEM_write_bio_PUBKEY() and PEM_write_bio_Parameters().
+ */
+
+MAKE_ENCODER(xorhmacsig, xorx, EncryptedPrivateKeyInfo, der);
+MAKE_ENCODER(xorhmacsig, xorx, EncryptedPrivateKeyInfo, pem);
+MAKE_ENCODER(xorhmacsig, xorx, PrivateKeyInfo, der);
+MAKE_ENCODER(xorhmacsig, xorx, PrivateKeyInfo, pem);
+MAKE_ENCODER(xorhmacsig, xorx, SubjectPublicKeyInfo, der);
+MAKE_ENCODER(xorhmacsig, xorx, SubjectPublicKeyInfo, pem);
+MAKE_ENCODER(xorhmacsha2sig, xorx, EncryptedPrivateKeyInfo, der);
+MAKE_ENCODER(xorhmacsha2sig, xorx, EncryptedPrivateKeyInfo, pem);
+MAKE_ENCODER(xorhmacsha2sig, xorx, PrivateKeyInfo, der);
+MAKE_ENCODER(xorhmacsha2sig, xorx, PrivateKeyInfo, pem);
+MAKE_ENCODER(xorhmacsha2sig, xorx, SubjectPublicKeyInfo, der);
+MAKE_ENCODER(xorhmacsha2sig, xorx, SubjectPublicKeyInfo, pem);
+
+static const OSSL_ALGORITHM tls_prov_encoder[] = {
+#define ENCODER_PROVIDER "tls-provider"
+#ifndef ENCODER_PROVIDER
+# error Macro ENCODER_PROVIDER undefined
+#endif
+
+#define ENCODER_STRUCTURE_PKCS8                         "pkcs8"
+#define ENCODER_STRUCTURE_SubjectPublicKeyInfo          "SubjectPublicKeyInfo"
+#define ENCODER_STRUCTURE_PrivateKeyInfo                "PrivateKeyInfo"
+#define ENCODER_STRUCTURE_EncryptedPrivateKeyInfo       "EncryptedPrivateKeyInfo"
+#define ENCODER_STRUCTURE_PKCS1                         "pkcs1"
+#define ENCODER_STRUCTURE_PKCS3                         "pkcs3"
+
+/* Arguments are prefixed with '_' to avoid build breaks on certain platforms */
+/*
+ * Obviously this is not FIPS approved, but in order to test in conjunction
+ * with the FIPS provider we pretend that it is.
+ */
+#define ENCODER_TEXT(_name, _sym)                                \
+    { _name,                                                            \
+      "provider=" ENCODER_PROVIDER ",fips=yes,output=text",      \
+      (xor_##_sym##_to_text_encoder_functions) }
+#define ENCODER(_name, _sym, _fips, _output)                            \
+    { _name,                                                            \
+      "provider=" ENCODER_PROVIDER ",fips=yes,output=" #_output, \
+      (xor_##_sym##_to_##_output##_encoder_functions) }
+
+#define ENCODER_w_structure(_name, _sym, _output, _structure)    \
+    { _name,                                                            \
+      "provider=" ENCODER_PROVIDER ",fips=yes,output=" #_output  \
+      ",structure=" ENCODER_STRUCTURE_##_structure,                     \
+      (xor_##_sym##_to_##_structure##_##_output##_encoder_functions) }
+
+/*
+ * Entries for human text "encoders"
+ */
+
+/*
+ * Entries for PKCS#8 and SubjectPublicKeyInfo.
+ * The "der" ones are added convenience for any user that wants to use
+ * OSSL_ENCODER directly.
+ * The "pem" ones also support PEM_write_bio_PrivateKey() and
+ * PEM_write_bio_PUBKEY().
+ */
+
+ENCODER_w_structure(XORSIGALG_NAME, xorhmacsig, der, PrivateKeyInfo),
+ENCODER_w_structure(XORSIGALG_NAME, xorhmacsig, pem, PrivateKeyInfo),
+ENCODER_w_structure(XORSIGALG_NAME, xorhmacsig, der, EncryptedPrivateKeyInfo),
+ENCODER_w_structure(XORSIGALG_NAME, xorhmacsig, pem, EncryptedPrivateKeyInfo),
+ENCODER_w_structure(XORSIGALG_NAME, xorhmacsig, der, SubjectPublicKeyInfo),
+ENCODER_w_structure(XORSIGALG_NAME, xorhmacsig, pem, SubjectPublicKeyInfo),
+ENCODER_w_structure(XORSIGALG_HASH_NAME, xorhmacsha2sig,
+                    der, PrivateKeyInfo),
+ENCODER_w_structure(XORSIGALG_HASH_NAME, xorhmacsha2sig,
+                    pem, PrivateKeyInfo),
+ENCODER_w_structure(XORSIGALG_HASH_NAME, xorhmacsha2sig,
+                    der, EncryptedPrivateKeyInfo),
+ENCODER_w_structure(XORSIGALG_HASH_NAME, xorhmacsha2sig,
+                    pem, EncryptedPrivateKeyInfo),
+ENCODER_w_structure(XORSIGALG_HASH_NAME, xorhmacsha2sig,
+                    der, SubjectPublicKeyInfo),
+ENCODER_w_structure(XORSIGALG_HASH_NAME, xorhmacsha2sig,
+                    pem, SubjectPublicKeyInfo),
+#undef ENCODER_PROVIDER
+    { NULL, NULL, NULL }
+};
+
+struct der2key_ctx_st;           /* Forward declaration */
+typedef int check_key_fn(void *, struct der2key_ctx_st *ctx);
+typedef void adjust_key_fn(void *, struct der2key_ctx_st *ctx);
+typedef void free_key_fn(void *);
+typedef void *d2i_PKCS8_fn(void **, const unsigned char **, long,
+                           struct der2key_ctx_st *);
+struct keytype_desc_st {
+    const char *keytype_name;
+    const OSSL_DISPATCH *fns; /* Keymgmt (to pilfer functions from) */
+
+    /* The input structure name */
+    const char *structure_name;
+
+    /*
+     * The EVP_PKEY_xxx type macro.  Should be zero for type specific
+     * structures, non-zero when the outermost structure is PKCS#8 or
+     * SubjectPublicKeyInfo.  This determines which of the function
+     * pointers below will be used.
+     */
+    int evp_type;
+
+    /* The selection mask for OSSL_FUNC_decoder_does_selection() */
+    int selection_mask;
+
+    /* For type specific decoders, we use the corresponding d2i */
+    d2i_of_void *d2i_private_key; /* From type-specific DER */
+    d2i_of_void *d2i_public_key;  /* From type-specific DER */
+    d2i_of_void *d2i_key_params;  /* From type-specific DER */
+    d2i_PKCS8_fn *d2i_PKCS8;      /* Wrapped in a PrivateKeyInfo */
+    d2i_of_void *d2i_PUBKEY;      /* Wrapped in a SubjectPublicKeyInfo */
+
+    /*
+     * For any key, we may need to check that the key meets expectations.
+     * This is useful when the same functions can decode several variants
+     * of a key.
+     */
+    check_key_fn *check_key;
+
+    /*
+     * For any key, we may need to make provider specific adjustments, such
+     * as ensure the key carries the correct library context.
+     */
+    adjust_key_fn *adjust_key;
+    /* {type}_free() */
+    free_key_fn *free_key;
+};
+
+/*
+ * Start blatant code steal. Alternative: Open up d2i_X509_PUBKEY_INTERNAL
+ * as per https://github.com/openssl/openssl/issues/16697 (TBD)
+ * Code from from openssl/crypto/x509/x_pubkey.c as
+ * ossl_d2i_X509_PUBKEY_INTERNAL is presently not public
+ */
+struct X509_pubkey_st {
+    X509_ALGOR *algor;
+    ASN1_BIT_STRING *public_key;
+
+    EVP_PKEY *pkey;
+
+    /* extra data for the callback, used by d2i_PUBKEY_ex */
+    OSSL_LIB_CTX *libctx;
+    char *propq;
+
+    /* Flag to force legacy keys */
+   unsigned int flag_force_legacy : 1;
+};
+
+ASN1_SEQUENCE(X509_PUBKEY_INTERNAL) = {
+        ASN1_SIMPLE(X509_PUBKEY, algor, X509_ALGOR),
+        ASN1_SIMPLE(X509_PUBKEY, public_key, ASN1_BIT_STRING)
+} static_ASN1_SEQUENCE_END_name(X509_PUBKEY, X509_PUBKEY_INTERNAL)
+
+static X509_PUBKEY *xorx_d2i_X509_PUBKEY_INTERNAL(const unsigned char **pp,
+                                           long len, OSSL_LIB_CTX *libctx)
+{
+    X509_PUBKEY *xpub = OPENSSL_zalloc(sizeof(*xpub));
+
+    if (xpub == NULL)
+        return NULL;
+    return (X509_PUBKEY *)ASN1_item_d2i_ex((ASN1_VALUE **)&xpub, pp, len,
+                                           ASN1_ITEM_rptr(X509_PUBKEY_INTERNAL),
+                                           libctx, NULL);
+}
+/* end steal https://github.com/openssl/openssl/issues/16697 */
+
+/*
+ * Context used for DER to key decoding.
+ */
+struct der2key_ctx_st {
+    PROV_XOR_CTX *provctx;
+    struct keytype_desc_st *desc;
+    /* The selection that is passed to xor_der2key_decode() */
+    int selection;
+    /* Flag used to signal that a failure is fatal */
+    unsigned int flag_fatal : 1;
+};
+
+static int xor_read_der(PROV_XOR_CTX *provctx, OSSL_CORE_BIO *cin,
+                        unsigned char **data, long *len)
+{
+    BUF_MEM *mem = NULL;
+    BIO *in = BIO_new_from_core_bio(provctx->libctx, cin);
+    int ok = (asn1_d2i_read_bio(in, &mem) >= 0);
+
+    if (ok) {
+        *data = (unsigned char *)mem->data;
+        *len = (long)mem->length;
+        OPENSSL_free(mem);
+    }
+    BIO_free(in);
+    return ok;
+}
+
+typedef void *key_from_pkcs8_t(const PKCS8_PRIV_KEY_INFO *p8inf,
+                               OSSL_LIB_CTX *libctx, const char *propq);
+static void *xor_der2key_decode_p8(const unsigned char **input_der,
+                               long input_der_len, struct der2key_ctx_st *ctx,
+                               key_from_pkcs8_t *key_from_pkcs8)
+{
+    PKCS8_PRIV_KEY_INFO *p8inf = NULL;
+    const X509_ALGOR *alg = NULL;
+    void *key = NULL;
+
+    if ((p8inf = d2i_PKCS8_PRIV_KEY_INFO(NULL, input_der, input_der_len)) != NULL
+        && PKCS8_pkey_get0(NULL, NULL, NULL, &alg, p8inf)
+        && OBJ_obj2nid(alg->algorithm) == ctx->desc->evp_type)
+        key = key_from_pkcs8(p8inf, PROV_XOR_LIBCTX_OF(ctx->provctx), NULL);
+    PKCS8_PRIV_KEY_INFO_free(p8inf);
+
+    return key;
+}
+
+static XORKEY *xor_d2i_PUBKEY(XORKEY **a,
+                               const unsigned char **pp, long length)
+{
+    XORKEY *key = NULL;
+    X509_PUBKEY *xpk;
+
+    xpk = xorx_d2i_X509_PUBKEY_INTERNAL(pp, length, NULL);
+
+    key = xor_key_from_x509pubkey(xpk, NULL, NULL);
+
+    if (key == NULL)
+        goto err_exit;
+
+    if (a != NULL) {
+        xor_freekey(*a);
+        *a = key;
+    }
+
+    err_exit:
+    X509_PUBKEY_free(xpk);
+    return key;
+}
+
+
+/* ---------------------------------------------------------------------- */
+
+static OSSL_FUNC_decoder_freectx_fn der2key_freectx;
+static OSSL_FUNC_decoder_decode_fn xor_der2key_decode;
+static OSSL_FUNC_decoder_export_object_fn der2key_export_object;
+
+static struct der2key_ctx_st *
+der2key_newctx(void *provctx, struct keytype_desc_st *desc, const char* tls_name)
+{
+    struct der2key_ctx_st *ctx = OPENSSL_zalloc(sizeof(*ctx));
+
+    if (ctx != NULL) {
+        ctx->provctx = provctx;
+        ctx->desc = desc;
+        if (desc->evp_type == 0) {
+           ctx->desc->evp_type = OBJ_sn2nid(tls_name);
+        }
+    }
+    return ctx;
+}
+
+static void der2key_freectx(void *vctx)
+{
+    struct der2key_ctx_st *ctx = vctx;
+
+    OPENSSL_free(ctx);
+}
+
+static int der2key_check_selection(int selection,
+                                   const struct keytype_desc_st *desc)
+{
+    /*
+     * The selections are kinda sorta "levels", i.e. each selection given
+     * here is assumed to include those following.
+     */
+    int checks[] = {
+        OSSL_KEYMGMT_SELECT_PRIVATE_KEY,
+        OSSL_KEYMGMT_SELECT_PUBLIC_KEY,
+        OSSL_KEYMGMT_SELECT_ALL_PARAMETERS
+    };
+    size_t i;
+
+    /* The decoder implementations made here support guessing */
+    if (selection == 0)
+        return 1;
+
+    for (i = 0; i < OSSL_NELEM(checks); i++) {
+        int check1 = (selection & checks[i]) != 0;
+        int check2 = (desc->selection_mask & checks[i]) != 0;
+
+        /*
+         * If the caller asked for the currently checked bit(s), return
+         * whether the decoder description says it's supported.
+         */
+        if (check1)
+            return check2;
+    }
+
+    /* This should be dead code, but just to be safe... */
+    return 0;
+}
+
+static int xor_der2key_decode(void *vctx, OSSL_CORE_BIO *cin, int selection,
+                          OSSL_CALLBACK *data_cb, void *data_cbarg,
+                          OSSL_PASSPHRASE_CALLBACK *pw_cb, void *pw_cbarg)
+{
+    struct der2key_ctx_st *ctx = vctx;
+    unsigned char *der = NULL;
+    const unsigned char *derp;
+    long der_len = 0;
+    void *key = NULL;
+    int ok = 0;
+
+    ctx->selection = selection;
+    /*
+     * The caller is allowed to specify 0 as a selection mark, to have the
+     * structure and key type guessed.  For type-specific structures, this
+     * is not recommended, as some structures are very similar.
+     * Note that 0 isn't the same as OSSL_KEYMGMT_SELECT_ALL, as the latter
+     * signifies a private key structure, where everything else is assumed
+     * to be present as well.
+     */
+    if (selection == 0)
+        selection = ctx->desc->selection_mask;
+    if ((selection & ctx->desc->selection_mask) == 0) {
+        ERR_raise(ERR_LIB_PROV, ERR_R_PASSED_INVALID_ARGUMENT);
+        return 0;
+    }
+
+    ok = xor_read_der(ctx->provctx, cin, &der, &der_len);
+    if (!ok)
+        goto next;
+
+    ok = 0;                      /* Assume that we fail */
+
+    if ((selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) != 0) {
+        derp = der;
+        if (ctx->desc->d2i_PKCS8 != NULL) {
+            key = ctx->desc->d2i_PKCS8(NULL, &derp, der_len, ctx);
+            if (ctx->flag_fatal)
+                goto end;
+        } else if (ctx->desc->d2i_private_key != NULL) {
+            key = ctx->desc->d2i_private_key(NULL, &derp, der_len);
+        }
+        if (key == NULL && ctx->selection != 0)
+            goto next;
+    }
+    if (key == NULL && (selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY) != 0) {
+        derp = der;
+        if (ctx->desc->d2i_PUBKEY != NULL)
+            key = ctx->desc->d2i_PUBKEY(NULL, &derp, der_len);
+        else
+            key = ctx->desc->d2i_public_key(NULL, &derp, der_len);
+        if (key == NULL && ctx->selection != 0)
+            goto next;
+    }
+    if (key == NULL && (selection & OSSL_KEYMGMT_SELECT_ALL_PARAMETERS) != 0) {
+        derp = der;
+        if (ctx->desc->d2i_key_params != NULL)
+            key = ctx->desc->d2i_key_params(NULL, &derp, der_len);
+        if (key == NULL && ctx->selection != 0)
+            goto next;
+    }
+
+    /*
+     * Last minute check to see if this was the correct type of key.  This
+     * should never lead to a fatal error, i.e. the decoding itself was
+     * correct, it was just an unexpected key type.  This is generally for
+     * classes of key types that have subtle variants, like RSA-PSS keys as
+     * opposed to plain RSA keys.
+     */
+    if (key != NULL
+        && ctx->desc->check_key != NULL
+        && !ctx->desc->check_key(key, ctx)) {
+        ctx->desc->free_key(key);
+        key = NULL;
+    }
+
+    if (key != NULL && ctx->desc->adjust_key != NULL)
+        ctx->desc->adjust_key(key, ctx);
+
+ next:
+    /*
+     * Indicated that we successfully decoded something, or not at all.
+     * Ending up "empty handed" is not an error.
+     */
+    ok = 1;
+
+    /*
+     * We free memory here so it's not held up during the callback, because
+     * we know the process is recursive and the allocated chunks of memory
+     * add up.
+     */
+    OPENSSL_free(der);
+    der = NULL;
+
+    if (key != NULL) {
+        OSSL_PARAM params[4];
+        int object_type = OSSL_OBJECT_PKEY;
+
+        params[0] =
+            OSSL_PARAM_construct_int(OSSL_OBJECT_PARAM_TYPE, &object_type);
+        params[1] =
+            OSSL_PARAM_construct_utf8_string(OSSL_OBJECT_PARAM_DATA_TYPE,
+                                             (char *)ctx->desc->keytype_name,
+                                             0);
+        /* The address of the key becomes the octet string */
+        params[2] =
+            OSSL_PARAM_construct_octet_string(OSSL_OBJECT_PARAM_REFERENCE,
+                                              &key, sizeof(key));
+        params[3] = OSSL_PARAM_construct_end();
+
+        ok = data_cb(params, data_cbarg);
+    }
+
+ end:
+    ctx->desc->free_key(key);
+    OPENSSL_free(der);
+
+    return ok;
+}
+
+static int der2key_export_object(void *vctx,
+                                 const void *reference, size_t reference_sz,
+                                 OSSL_CALLBACK *export_cb, void *export_cbarg)
+{
+    struct der2key_ctx_st *ctx = vctx;
+    OSSL_FUNC_keymgmt_export_fn *export =
+        xor_prov_get_keymgmt_export(ctx->desc->fns);
+    void *keydata;
+
+    if (reference_sz == sizeof(keydata) && export != NULL) {
+        /* The contents of the reference is the address to our object */
+        keydata = *(void **)reference;
+
+        return export(keydata, ctx->selection, export_cb, export_cbarg);
+    }
+    return 0;
+}
+
+/* ---------------------------------------------------------------------- */
+
+static void *xorx_d2i_PKCS8(void **key, const unsigned char **der, long der_len,
+                           struct der2key_ctx_st *ctx)
+{
+    return xor_der2key_decode_p8(der, der_len, ctx,
+                             (key_from_pkcs8_t *)xor_key_from_pkcs8);
+}
+
+static void xorx_key_adjust(void *key, struct der2key_ctx_st *ctx)
+{
+}
+
+/* ---------------------------------------------------------------------- */
+
+#define DO_PrivateKeyInfo(keytype)                      \
+    "PrivateKeyInfo", 0,                                \
+        ( OSSL_KEYMGMT_SELECT_PRIVATE_KEY ),            \
+        NULL,                                           \
+        NULL,                                           \
+        NULL,                                           \
+        xorx_d2i_PKCS8,                                 \
+        NULL,                                           \
+        NULL,                                           \
+        xorx_key_adjust,                                \
+        (free_key_fn *)xor_freekey
+
+#define DO_SubjectPublicKeyInfo(keytype)                \
+    "SubjectPublicKeyInfo", 0,                          \
+        ( OSSL_KEYMGMT_SELECT_PUBLIC_KEY ),             \
+        NULL,                                           \
+        NULL,                                           \
+        NULL,                                           \
+        NULL,                                           \
+        (d2i_of_void *)xor_d2i_PUBKEY,                 \
+        NULL,                                           \
+        xorx_key_adjust,                                \
+        (free_key_fn *)xor_freekey
+
+/*
+ * MAKE_DECODER is the single driver for creating OSSL_DISPATCH tables.
+ * It takes the following arguments:
+ *
+ * keytype_name The implementation key type as a string.
+ * keytype      The implementation key type.  This must correspond exactly
+ *              to our existing keymgmt keytype names...  in other words,
+ *              there must exist an ossl_##keytype##_keymgmt_functions.
+ * type         The type name for the set of functions that implement the
+ *              decoder for the key type.  This isn't necessarily the same
+ *              as keytype.  For example, the key types ed25519, ed448,
+ *              x25519 and x448 are all handled by the same functions with
+ *              the common type name ecx.
+ * kind         The kind of support to implement.  This translates into
+ *              the DO_##kind macros above, to populate the keytype_desc_st
+ *              structure.
+ */
+#define MAKE_DECODER(keytype_name, keytype, type, kind)                 \
+    static struct keytype_desc_st kind##_##keytype##_desc =             \
+        { keytype_name, xor_##keytype##_keymgmt_functions,              \
+          DO_##kind(keytype) };                                         \
+                                                                        \
+    static OSSL_FUNC_decoder_newctx_fn kind##_der2##keytype##_newctx;   \
+                                                                        \
+    static void *kind##_der2##keytype##_newctx(void *provctx)           \
+    {                                                                   \
+        return der2key_newctx(provctx, &kind##_##keytype##_desc, keytype_name );\
+    }                                                                   \
+    static int kind##_der2##keytype##_does_selection(void *provctx,     \
+                                                     int selection)     \
+    {                                                                   \
+        return der2key_check_selection(selection,                       \
+                                       &kind##_##keytype##_desc);       \
+    }                                                                   \
+    static const OSSL_DISPATCH                                          \
+    xor_##kind##_der_to_##keytype##_decoder_functions[] = {             \
+        { OSSL_FUNC_DECODER_NEWCTX,                                     \
+          (void (*)(void))kind##_der2##keytype##_newctx },              \
+        { OSSL_FUNC_DECODER_FREECTX,                                    \
+          (void (*)(void))der2key_freectx },                            \
+        { OSSL_FUNC_DECODER_DOES_SELECTION,                             \
+          (void (*)(void))kind##_der2##keytype##_does_selection },      \
+        { OSSL_FUNC_DECODER_DECODE,                                     \
+          (void (*)(void))xor_der2key_decode },                         \
+        { OSSL_FUNC_DECODER_EXPORT_OBJECT,                              \
+          (void (*)(void))der2key_export_object },                      \
+        { 0, NULL }                                                     \
+    }
+
+MAKE_DECODER(XORSIGALG_NAME, xorhmacsig, xor, PrivateKeyInfo);
+MAKE_DECODER(XORSIGALG_NAME, xorhmacsig, xor, SubjectPublicKeyInfo);
+MAKE_DECODER(XORSIGALG_HASH_NAME, xorhmacsha2sig, xor, PrivateKeyInfo);
+MAKE_DECODER(XORSIGALG_HASH_NAME, xorhmacsha2sig, xor, SubjectPublicKeyInfo);
+
+static const OSSL_ALGORITHM tls_prov_decoder[] = {
+#define DECODER_PROVIDER "tls-provider"
+#define DECODER_STRUCTURE_SubjectPublicKeyInfo          "SubjectPublicKeyInfo"
+#define DECODER_STRUCTURE_PrivateKeyInfo                "PrivateKeyInfo"
+
+/* Arguments are prefixed with '_' to avoid build breaks on certain platforms */
+/*
+ * Obviously this is not FIPS approved, but in order to test in conjunction
+ * with the FIPS provider we pretend that it is.
+ */
+
+#define DECODER(_name, _input, _output)                          \
+    { _name,                                                            \
+      "provider=" DECODER_PROVIDER ",fips=yes,input=" #_input,   \
+      (xor_##_input##_to_##_output##_decoder_functions) }
+#define DECODER_w_structure(_name, _input, _structure, _output)  \
+    { _name,                                                            \
+      "provider=" DECODER_PROVIDER ",fips=yes,input=" #_input    \
+      ",structure=" DECODER_STRUCTURE_##_structure,                     \
+      (xor_##_structure##_##_input##_to_##_output##_decoder_functions) }
+
+DECODER_w_structure(XORSIGALG_NAME, der, PrivateKeyInfo, xorhmacsig),
+DECODER_w_structure(XORSIGALG_NAME, der, SubjectPublicKeyInfo, xorhmacsig),
+DECODER_w_structure(XORSIGALG_HASH_NAME, der, PrivateKeyInfo, xorhmacsha2sig),
+DECODER_w_structure(XORSIGALG_HASH_NAME, der, SubjectPublicKeyInfo, xorhmacsha2sig),
+#undef DECODER_PROVIDER
+    { NULL, NULL, NULL }
+};
+
+#define OSSL_MAX_NAME_SIZE 50
+#define OSSL_MAX_PROPQUERY_SIZE     256 /* Property query strings */
+
+static OSSL_FUNC_signature_newctx_fn xor_sig_newctx;
+static OSSL_FUNC_signature_sign_init_fn xor_sig_sign_init;
+static OSSL_FUNC_signature_verify_init_fn xor_sig_verify_init;
+static OSSL_FUNC_signature_sign_fn xor_sig_sign;
+static OSSL_FUNC_signature_verify_fn xor_sig_verify;
+static OSSL_FUNC_signature_digest_sign_init_fn xor_sig_digest_sign_init;
+static OSSL_FUNC_signature_digest_sign_update_fn xor_sig_digest_signverify_update;
+static OSSL_FUNC_signature_digest_sign_final_fn xor_sig_digest_sign_final;
+static OSSL_FUNC_signature_digest_verify_init_fn xor_sig_digest_verify_init;
+static OSSL_FUNC_signature_digest_verify_update_fn xor_sig_digest_signverify_update;
+static OSSL_FUNC_signature_digest_verify_final_fn xor_sig_digest_verify_final;
+static OSSL_FUNC_signature_freectx_fn xor_sig_freectx;
+static OSSL_FUNC_signature_dupctx_fn xor_sig_dupctx;
+static OSSL_FUNC_signature_get_ctx_params_fn xor_sig_get_ctx_params;
+static OSSL_FUNC_signature_gettable_ctx_params_fn xor_sig_gettable_ctx_params;
+static OSSL_FUNC_signature_set_ctx_params_fn xor_sig_set_ctx_params;
+static OSSL_FUNC_signature_settable_ctx_params_fn xor_sig_settable_ctx_params;
+static OSSL_FUNC_signature_get_ctx_md_params_fn xor_sig_get_ctx_md_params;
+static OSSL_FUNC_signature_gettable_ctx_md_params_fn xor_sig_gettable_ctx_md_params;
+static OSSL_FUNC_signature_set_ctx_md_params_fn xor_sig_set_ctx_md_params;
+static OSSL_FUNC_signature_settable_ctx_md_params_fn xor_sig_settable_ctx_md_params;
+
+static int xor_get_aid(unsigned char** oidbuf, const char *tls_name) {
+   X509_ALGOR *algor = X509_ALGOR_new();
+   int aidlen = 0;
+
+   X509_ALGOR_set0(algor, OBJ_txt2obj(tls_name, 0), V_ASN1_UNDEF, NULL);
+
+   aidlen = i2d_X509_ALGOR(algor, oidbuf); 
+   X509_ALGOR_free(algor);
+   return(aidlen);
+}
+
+/*
+ * What's passed as an actual key is defined by the KEYMGMT interface.
+ */
+typedef struct {
+    OSSL_LIB_CTX *libctx;
+    char *propq;
+    XORKEY *sig;
+
+    /*
+     * Flag to determine if the hash function can be changed (1) or not (0)
+     * Because it's dangerous to change during a DigestSign or DigestVerify
+     * operation, this flag is cleared by their Init function, and set again
+     * by their Final function.
+     */
+    unsigned int flag_allow_md : 1;
+
+    char mdname[OSSL_MAX_NAME_SIZE];
+
+    /* The Algorithm Identifier of the combined signature algorithm */
+    unsigned char *aid;
+    size_t  aid_len;
+
+    /* main digest */
+    EVP_MD *md;
+    EVP_MD_CTX *mdctx;
+    int operation;
+} PROV_XORSIG_CTX;
+
+static void *xor_sig_newctx(void *provctx, const char *propq)
+{
+    PROV_XORSIG_CTX *pxor_sigctx;
+
+    pxor_sigctx = OPENSSL_zalloc(sizeof(PROV_XORSIG_CTX));
+    if (pxor_sigctx == NULL)
+        return NULL;
+
+    pxor_sigctx->libctx = ((PROV_XOR_CTX*)provctx)->libctx;
+    pxor_sigctx->flag_allow_md = 0;
+    if (propq != NULL && (pxor_sigctx->propq = OPENSSL_strdup(propq)) == NULL) {
+        OPENSSL_free(pxor_sigctx);
+        pxor_sigctx = NULL;
+        ERR_raise(ERR_LIB_USER, ERR_R_MALLOC_FAILURE);
+    }
+    return pxor_sigctx;
+}
+
+static int xor_sig_setup_md(PROV_XORSIG_CTX *ctx,
+                        const char *mdname, const char *mdprops)
+{
+    EVP_MD *md;
+
+    if (mdprops == NULL)
+        mdprops = ctx->propq;
+
+    md = EVP_MD_fetch(ctx->libctx, mdname, mdprops);
+
+    if ((md == NULL) || (EVP_MD_nid(md)==NID_undef)) {
+        if (md == NULL)
+            ERR_raise_data(ERR_LIB_USER, XORPROV_R_INVALID_DIGEST,
+                           "%s could not be fetched", mdname);
+        EVP_MD_free(md);
+        return 0;
+    }
+
+    EVP_MD_CTX_free(ctx->mdctx);
+    ctx->mdctx = NULL;
+    EVP_MD_free(ctx->md);
+    ctx->md = NULL;
+
+    OPENSSL_free(ctx->aid);
+    ctx->aid = NULL;
+    ctx->aid_len = xor_get_aid(&(ctx->aid), ctx->sig->tls_name);
+
+    ctx->mdctx = NULL;
+    ctx->md = md;
+    OPENSSL_strlcpy(ctx->mdname, mdname, sizeof(ctx->mdname));
+    return 1;
+}
+
+static int xor_sig_signverify_init(void *vpxor_sigctx, void *vxorsig,
+                                   int operation)
+{
+    PROV_XORSIG_CTX *pxor_sigctx = (PROV_XORSIG_CTX *)vpxor_sigctx;
+
+    if (pxor_sigctx == NULL || vxorsig == NULL)
+        return 0;
+    xor_freekey(pxor_sigctx->sig);
+    if (!xor_key_up_ref(vxorsig))
+        return 0;
+    pxor_sigctx->sig = vxorsig;
+    pxor_sigctx->operation = operation;
+    if ((operation==EVP_PKEY_OP_SIGN && pxor_sigctx->sig == NULL)
+        || (operation==EVP_PKEY_OP_VERIFY && pxor_sigctx->sig == NULL)) {
+        ERR_raise(ERR_LIB_USER, XORPROV_R_INVALID_KEY);
+        return 0;
+    }
+    return 1;
+}
+
+static int xor_sig_sign_init(void *vpxor_sigctx, void *vxorsig,
+                             const OSSL_PARAM params[])
+{
+    return xor_sig_signverify_init(vpxor_sigctx, vxorsig, EVP_PKEY_OP_SIGN);
+}
+
+static int xor_sig_verify_init(void *vpxor_sigctx, void *vxorsig,
+                               const OSSL_PARAM params[])
+{
+    return xor_sig_signverify_init(vpxor_sigctx, vxorsig, EVP_PKEY_OP_VERIFY);
+}
+
+static int xor_sig_sign(void *vpxor_sigctx, unsigned char *sig, size_t *siglen,
+                    size_t sigsize, const unsigned char *tbs, size_t tbslen)
+{
+    PROV_XORSIG_CTX *pxor_sigctx = (PROV_XORSIG_CTX *)vpxor_sigctx;
+    XORKEY *xorkey = pxor_sigctx->sig;
+
+    size_t max_sig_len = EVP_MAX_MD_SIZE;
+    size_t xor_sig_len = 0;
+    int rv = 0;
+
+    if (xorkey == NULL || !xorkey->hasprivkey) {
+        ERR_raise(ERR_LIB_USER, XORPROV_R_NO_PRIVATE_KEY);
+        return rv;
+    }
+
+    if (sig == NULL) {
+        *siglen = max_sig_len;
+        return 1;
+    }
+    if (*siglen < max_sig_len) {
+        ERR_raise(ERR_LIB_USER, XORPROV_R_BUFFER_LENGTH_WRONG);
+        return rv;
+    }
+
+    /*
+     * create HMAC using XORKEY as key and hash as data:
+     * No real crypto, just for test, don't do this at home!
+     */
+    if (!EVP_Q_mac(pxor_sigctx->libctx, "HMAC", NULL, "sha1", NULL,
+                   xorkey->privkey, XOR_KEY_SIZE, tbs, tbslen,
+                   &sig[0], EVP_MAX_MD_SIZE, &xor_sig_len)) {
+        ERR_raise(ERR_LIB_USER, XORPROV_R_SIGNING_FAILED);
+        goto endsign;
+    }
+
+    *siglen = xor_sig_len;
+    rv = 1; /* success */
+
+ endsign:
+    return rv;
+}
+
+static int xor_sig_verify(void *vpxor_sigctx,
+    const unsigned char *sig, size_t siglen,
+                          const unsigned char *tbs, size_t tbslen)
+{
+    PROV_XORSIG_CTX *pxor_sigctx = (PROV_XORSIG_CTX *)vpxor_sigctx;
+    XORKEY *xorkey = pxor_sigctx->sig;
+    unsigned char resignature[EVP_MAX_MD_SIZE];
+    size_t resiglen;
+    int i;
+
+    if (xorkey == NULL || sig == NULL || tbs == NULL) {
+        ERR_raise(ERR_LIB_USER, XORPROV_R_WRONG_PARAMETERS);
+        return 0;
+    }
+
+    /*
+     * This is no real verify: just re-sign and compare:
+     * Don't do this at home! Not fit for real use!
+     */
+    /* First re-create private key from public key: */
+    for (i = 0; i < XOR_KEY_SIZE; i++)
+        xorkey->privkey[i] = xorkey->pubkey[i] ^ private_constant[i];
+
+    /* Now re-create signature */
+    if (!EVP_Q_mac(pxor_sigctx->libctx, "HMAC", NULL, "sha1", NULL,
+                   xorkey->privkey, XOR_KEY_SIZE, tbs, tbslen,
+                   &resignature[0], EVP_MAX_MD_SIZE, &resiglen)) {
+        ERR_raise(ERR_LIB_USER, XORPROV_R_VERIFY_ERROR);
+        return 0;
+    }
+
+    /* Now compare with signature passed */
+    if (siglen != resiglen || memcmp(resignature, sig, siglen) != 0) {
+        ERR_raise(ERR_LIB_USER, XORPROV_R_VERIFY_ERROR);
+        return 0;
+    }
+    return 1;
+}
+
+static int xor_sig_digest_signverify_init(void *vpxor_sigctx, const char *mdname,
+                                      void *vxorsig, int operation)
+{
+    PROV_XORSIG_CTX *pxor_sigctx = (PROV_XORSIG_CTX *)vpxor_sigctx;
+    char *rmdname = (char *)mdname;
+
+    if (rmdname == NULL)
+        rmdname = "sha256";
+
+    pxor_sigctx->flag_allow_md = 0;
+    if (!xor_sig_signverify_init(vpxor_sigctx, vxorsig, operation))
+        return 0;
+
+    if (!xor_sig_setup_md(pxor_sigctx, rmdname, NULL))
+        return 0;
+
+    pxor_sigctx->mdctx = EVP_MD_CTX_new();
+    if (pxor_sigctx->mdctx == NULL)
+        goto error;
+
+    if (!EVP_DigestInit_ex(pxor_sigctx->mdctx, pxor_sigctx->md, NULL))
+        goto error;
+
+    return 1;
+
+ error:
+    EVP_MD_CTX_free(pxor_sigctx->mdctx);
+    EVP_MD_free(pxor_sigctx->md);
+    pxor_sigctx->mdctx = NULL;
+    pxor_sigctx->md = NULL;
+    return 0;
+}
+
+static int xor_sig_digest_sign_init(void *vpxor_sigctx, const char *mdname,
+                                      void *vxorsig, const OSSL_PARAM params[])
+{
+    return xor_sig_digest_signverify_init(vpxor_sigctx, mdname, vxorsig,
+                                          EVP_PKEY_OP_SIGN);
+}
+
+static int xor_sig_digest_verify_init(void *vpxor_sigctx, const char *mdname, void *vxorsig, const OSSL_PARAM params[])
+{
+    return xor_sig_digest_signverify_init(vpxor_sigctx, mdname,
+                                          vxorsig, EVP_PKEY_OP_VERIFY);
+}
+
+int xor_sig_digest_signverify_update(void *vpxor_sigctx,
+                                     const unsigned char *data,
+                                     size_t datalen)
+{
+    PROV_XORSIG_CTX *pxor_sigctx = (PROV_XORSIG_CTX *)vpxor_sigctx;
+
+    if (pxor_sigctx == NULL || pxor_sigctx->mdctx == NULL)
+        return 0;
+
+    return EVP_DigestUpdate(pxor_sigctx->mdctx, data, datalen);
+}
+
+int xor_sig_digest_sign_final(void *vpxor_sigctx,
+                              unsigned char *sig, size_t *siglen,
+                              size_t sigsize)
+{
+    PROV_XORSIG_CTX *pxor_sigctx = (PROV_XORSIG_CTX *)vpxor_sigctx;
+    unsigned char digest[EVP_MAX_MD_SIZE];
+    unsigned int dlen = 0;
+
+    if (sig != NULL) {
+        if (pxor_sigctx == NULL || pxor_sigctx->mdctx == NULL)
+            return 0;
+
+        if (!EVP_DigestFinal_ex(pxor_sigctx->mdctx, digest, &dlen))
+            return 0;
+
+        pxor_sigctx->flag_allow_md = 1;
+    }
+
+    return xor_sig_sign(vpxor_sigctx, sig, siglen, sigsize, digest, (size_t)dlen);
+        
+}
+
+int xor_sig_digest_verify_final(void *vpxor_sigctx, const unsigned char *sig,
+                            size_t siglen)
+{
+    PROV_XORSIG_CTX *pxor_sigctx = (PROV_XORSIG_CTX *)vpxor_sigctx;
+    unsigned char digest[EVP_MAX_MD_SIZE];
+    unsigned int dlen = 0;
+
+    if (pxor_sigctx == NULL || pxor_sigctx->mdctx == NULL)
+        return 0;
+
+    if (!EVP_DigestFinal_ex(pxor_sigctx->mdctx, digest, &dlen))
+        return 0;
+
+    pxor_sigctx->flag_allow_md = 1;
+
+    return xor_sig_verify(vpxor_sigctx, sig, siglen, digest, (size_t)dlen);
+}
+
+static void xor_sig_freectx(void *vpxor_sigctx)
+{
+    PROV_XORSIG_CTX *ctx = (PROV_XORSIG_CTX *)vpxor_sigctx;
+
+    OPENSSL_free(ctx->propq);
+    EVP_MD_CTX_free(ctx->mdctx);
+    EVP_MD_free(ctx->md);
+    ctx->propq = NULL;
+    ctx->mdctx = NULL;
+    ctx->md = NULL;
+    xor_freekey(ctx->sig);
+    ctx->sig = NULL;
+    OPENSSL_free(ctx->aid);
+    OPENSSL_free(ctx);
+}
+
+static void *xor_sig_dupctx(void *vpxor_sigctx)
+{
+    PROV_XORSIG_CTX *srcctx = (PROV_XORSIG_CTX *)vpxor_sigctx;
+    PROV_XORSIG_CTX *dstctx;
+
+    dstctx = OPENSSL_zalloc(sizeof(*srcctx));
+    if (dstctx == NULL)
+        return NULL;
+
+    *dstctx = *srcctx;
+    dstctx->sig = NULL;
+    dstctx->md = NULL;
+    dstctx->mdctx = NULL;
+    dstctx->aid = NULL;
+
+    if ((srcctx->sig != NULL) && !xor_key_up_ref(srcctx->sig))
+        goto err;
+    dstctx->sig = srcctx->sig;
+
+    if (srcctx->md != NULL && !EVP_MD_up_ref(srcctx->md))
+        goto err;
+    dstctx->md = srcctx->md;
+
+    if (srcctx->mdctx != NULL) {
+        dstctx->mdctx = EVP_MD_CTX_new();
+        if (dstctx->mdctx == NULL
+                || !EVP_MD_CTX_copy_ex(dstctx->mdctx, srcctx->mdctx))
+            goto err;
+    }
+
+    return dstctx;
+ err:
+    xor_sig_freectx(dstctx);
+    return NULL;
+}
+
+static int xor_sig_get_ctx_params(void *vpxor_sigctx, OSSL_PARAM *params)
+{
+    PROV_XORSIG_CTX *pxor_sigctx = (PROV_XORSIG_CTX *)vpxor_sigctx;
+    OSSL_PARAM *p;
+
+    if (pxor_sigctx == NULL || params == NULL)
+        return 0;
+
+    p = OSSL_PARAM_locate(params, OSSL_SIGNATURE_PARAM_ALGORITHM_ID);
+
+    if (pxor_sigctx->aid == NULL)
+        pxor_sigctx->aid_len = xor_get_aid(&(pxor_sigctx->aid), pxor_sigctx->sig->tls_name);
+
+    if (p != NULL
+        && !OSSL_PARAM_set_octet_string(p, pxor_sigctx->aid, pxor_sigctx->aid_len))
+        return 0;
+
+    p = OSSL_PARAM_locate(params, OSSL_SIGNATURE_PARAM_DIGEST);
+    if (p != NULL && !OSSL_PARAM_set_utf8_string(p, pxor_sigctx->mdname))
+        return 0;
+
+    return 1;
+}
+
+static const OSSL_PARAM known_gettable_ctx_params[] = {
+    OSSL_PARAM_octet_string(OSSL_SIGNATURE_PARAM_ALGORITHM_ID, NULL, 0),
+    OSSL_PARAM_utf8_string(OSSL_SIGNATURE_PARAM_DIGEST, NULL, 0),
+    OSSL_PARAM_END
+};
+
+static const OSSL_PARAM *xor_sig_gettable_ctx_params(ossl_unused void *vpxor_sigctx, ossl_unused void *vctx)
+{
+    return known_gettable_ctx_params;
+}
+
+static int xor_sig_set_ctx_params(void *vpxor_sigctx, const OSSL_PARAM params[])
+{
+    PROV_XORSIG_CTX *pxor_sigctx = (PROV_XORSIG_CTX *)vpxor_sigctx;
+    const OSSL_PARAM *p;
+
+    if (pxor_sigctx == NULL || params == NULL)
+        return 0;
+
+    p = OSSL_PARAM_locate_const(params, OSSL_SIGNATURE_PARAM_DIGEST);
+    /* Not allowed during certain operations */
+    if (p != NULL && !pxor_sigctx->flag_allow_md)
+        return 0;
+    if (p != NULL) {
+        char mdname[OSSL_MAX_NAME_SIZE] = "", *pmdname = mdname;
+        char mdprops[OSSL_MAX_PROPQUERY_SIZE] = "", *pmdprops = mdprops;
+        const OSSL_PARAM *propsp =
+            OSSL_PARAM_locate_const(params,
+                                    OSSL_SIGNATURE_PARAM_PROPERTIES);
+
+        if (!OSSL_PARAM_get_utf8_string(p, &pmdname, sizeof(mdname)))
+            return 0;
+        if (propsp != NULL
+            && !OSSL_PARAM_get_utf8_string(propsp, &pmdprops, sizeof(mdprops)))
+            return 0;
+        if (!xor_sig_setup_md(pxor_sigctx, mdname, mdprops))
+            return 0;
+    }
+
+    return 1;
+}
+
+static const OSSL_PARAM known_settable_ctx_params[] = {
+    OSSL_PARAM_utf8_string(OSSL_SIGNATURE_PARAM_DIGEST, NULL, 0),
+    OSSL_PARAM_utf8_string(OSSL_SIGNATURE_PARAM_PROPERTIES, NULL, 0),
+    OSSL_PARAM_END
+};
+
+static const OSSL_PARAM *xor_sig_settable_ctx_params(ossl_unused void *vpsm2ctx,
+                                                     ossl_unused void *provctx)
+{
+    return known_settable_ctx_params;
+}
+
+static int xor_sig_get_ctx_md_params(void *vpxor_sigctx, OSSL_PARAM *params)
+{
+    PROV_XORSIG_CTX *pxor_sigctx = (PROV_XORSIG_CTX *)vpxor_sigctx;
+
+    if (pxor_sigctx->mdctx == NULL)
+        return 0;
+
+    return EVP_MD_CTX_get_params(pxor_sigctx->mdctx, params);
+}
+
+static const OSSL_PARAM *xor_sig_gettable_ctx_md_params(void *vpxor_sigctx)
+{
+    PROV_XORSIG_CTX *pxor_sigctx = (PROV_XORSIG_CTX *)vpxor_sigctx;
+
+    if (pxor_sigctx->md == NULL)
+        return 0;
+
+    return EVP_MD_gettable_ctx_params(pxor_sigctx->md);
+}
+
+static int xor_sig_set_ctx_md_params(void *vpxor_sigctx, const OSSL_PARAM params[])
+{
+    PROV_XORSIG_CTX *pxor_sigctx = (PROV_XORSIG_CTX *)vpxor_sigctx;
+
+    if (pxor_sigctx->mdctx == NULL)
+        return 0;
+
+    return EVP_MD_CTX_set_params(pxor_sigctx->mdctx, params);
+}
+
+static const OSSL_PARAM *xor_sig_settable_ctx_md_params(void *vpxor_sigctx)
+{
+    PROV_XORSIG_CTX *pxor_sigctx = (PROV_XORSIG_CTX *)vpxor_sigctx;
+
+    if (pxor_sigctx->md == NULL)
+        return 0;
+
+    return EVP_MD_settable_ctx_params(pxor_sigctx->md);
+}
+
+static const OSSL_DISPATCH xor_signature_functions[] = {
+    { OSSL_FUNC_SIGNATURE_NEWCTX, (void (*)(void))xor_sig_newctx },
+    { OSSL_FUNC_SIGNATURE_SIGN_INIT, (void (*)(void))xor_sig_sign_init },
+    { OSSL_FUNC_SIGNATURE_SIGN, (void (*)(void))xor_sig_sign },
+    { OSSL_FUNC_SIGNATURE_VERIFY_INIT, (void (*)(void))xor_sig_verify_init },
+    { OSSL_FUNC_SIGNATURE_VERIFY, (void (*)(void))xor_sig_verify },
+    { OSSL_FUNC_SIGNATURE_DIGEST_SIGN_INIT,
+      (void (*)(void))xor_sig_digest_sign_init },
+    { OSSL_FUNC_SIGNATURE_DIGEST_SIGN_UPDATE,
+      (void (*)(void))xor_sig_digest_signverify_update },
+    { OSSL_FUNC_SIGNATURE_DIGEST_SIGN_FINAL,
+      (void (*)(void))xor_sig_digest_sign_final },
+    { OSSL_FUNC_SIGNATURE_DIGEST_VERIFY_INIT,
+      (void (*)(void))xor_sig_digest_verify_init },
+    { OSSL_FUNC_SIGNATURE_DIGEST_VERIFY_UPDATE,
+      (void (*)(void))xor_sig_digest_signverify_update },
+    { OSSL_FUNC_SIGNATURE_DIGEST_VERIFY_FINAL,
+      (void (*)(void))xor_sig_digest_verify_final },
+    { OSSL_FUNC_SIGNATURE_FREECTX, (void (*)(void))xor_sig_freectx },
+    { OSSL_FUNC_SIGNATURE_DUPCTX, (void (*)(void))xor_sig_dupctx },
+    { OSSL_FUNC_SIGNATURE_GET_CTX_PARAMS, (void (*)(void))xor_sig_get_ctx_params },
+    { OSSL_FUNC_SIGNATURE_GETTABLE_CTX_PARAMS,
+      (void (*)(void))xor_sig_gettable_ctx_params },
+    { OSSL_FUNC_SIGNATURE_SET_CTX_PARAMS, (void (*)(void))xor_sig_set_ctx_params },
+    { OSSL_FUNC_SIGNATURE_SETTABLE_CTX_PARAMS,
+      (void (*)(void))xor_sig_settable_ctx_params },
+    { OSSL_FUNC_SIGNATURE_GET_CTX_MD_PARAMS,
+      (void (*)(void))xor_sig_get_ctx_md_params },
+    { OSSL_FUNC_SIGNATURE_GETTABLE_CTX_MD_PARAMS,
+      (void (*)(void))xor_sig_gettable_ctx_md_params },
+    { OSSL_FUNC_SIGNATURE_SET_CTX_MD_PARAMS,
+      (void (*)(void))xor_sig_set_ctx_md_params },
+    { OSSL_FUNC_SIGNATURE_SETTABLE_CTX_MD_PARAMS,
+      (void (*)(void))xor_sig_settable_ctx_md_params },
+    { 0, NULL }
+};
+
+static const OSSL_ALGORITHM tls_prov_signature[] = {
+    /*
+     * Obviously this is not FIPS approved, but in order to test in conjunction
+     * with the FIPS provider we pretend that it is.
+     */
+    { XORSIGALG_NAME, "provider=tls-provider,fips=yes",
+                           xor_signature_functions },
+    { XORSIGALG_HASH_NAME, "provider=tls-provider,fips=yes",
+                           xor_signature_functions },
+    { XORSIGALG12_NAME, "provider=tls-provider,fips=yes",
+                           xor_signature_functions },
+    { NULL, NULL, NULL }
+};
+
 
 static const OSSL_ALGORITHM *tls_prov_query(void *provctx, int operation_id,
                                             int *no_cache)
@@ -776,6 +3123,12 @@ static const OSSL_ALGORITHM *tls_prov_query(void *provctx, int operation_id,
         return tls_prov_keyexch;
     case OSSL_OP_KEM:
         return tls_prov_kem;
+    case OSSL_OP_ENCODER:
+        return tls_prov_encoder;
+    case OSSL_OP_DECODER:
+        return tls_prov_decoder;
+    case OSSL_OP_SIGNATURE:
+        return tls_prov_signature;
     }
     return NULL;
 }
@@ -783,13 +3136,15 @@ static const OSSL_ALGORITHM *tls_prov_query(void *provctx, int operation_id,
 static void tls_prov_teardown(void *provctx)
 {
     int i;
+    PROV_XOR_CTX *pctx = (PROV_XOR_CTX*)provctx;
 
-    OSSL_LIB_CTX_free(provctx);
+    OSSL_LIB_CTX_free(pctx->libctx);
 
     for (i = 0; i < NUM_DUMMY_GROUPS; i++) {
         OPENSSL_free(dummy_group_names[i]);
         dummy_group_names[i] = NULL;
     }
+    OPENSSL_free(pctx);
 }
 
 /* Functions we provide to the core */
@@ -801,36 +3156,36 @@ static const OSSL_DISPATCH tls_prov_dispatch_table[] = {
 };
 
 static
-unsigned int randomize_tls_group_id(OSSL_LIB_CTX *libctx)
+unsigned int randomize_tls_alg_id(OSSL_LIB_CTX *libctx)
 {
     /*
-     * Randomise the group_id we're going to use to ensure we don't interoperate
+     * Randomise the id we're going to use to ensure we don't interoperate
      * with anything but ourselves.
      */
-    unsigned int group_id;
+    unsigned int id;
     static unsigned int mem[10] = { 0 };
     static int in_mem = 0;
     int i;
 
  retry:
-    if (RAND_bytes_ex(libctx, (unsigned char *)&group_id, sizeof(group_id), 0) <= 0)
+    if (RAND_bytes_ex(libctx, (unsigned char *)&id, sizeof(id), 0) <= 0)
         return 0;
     /*
-     * Ensure group_id is within the IANA Reserved for private use range
+     * Ensure id is within the IANA Reserved for private use range
      * (65024-65279)
      */
-    group_id %= 65279 - 65024;
-    group_id += 65024;
+    id %= 65279 - 65024;
+    id += 65024;
 
-    /* Ensure we did not already issue this group_id */
+    /* Ensure we did not already issue this id */
     for (i = 0; i < in_mem; i++)
-        if (mem[i] == group_id)
+        if (mem[i] == id)
             goto retry;
 
-    /* Add this group_id to the list of ids issued by this function */
-    mem[in_mem++] = group_id;
+    /* Add this id to the list of ids issued by this function */
+    mem[in_mem++] = id;
 
-    return group_id;
+    return id;
 }
 
 int tls_provider_init(const OSSL_CORE_HANDLE *handle,
@@ -838,19 +3193,63 @@ int tls_provider_init(const OSSL_CORE_HANDLE *handle,
                       const OSSL_DISPATCH **out,
                       void **provctx)
 {
-    OSSL_LIB_CTX *libctx = OSSL_LIB_CTX_new();
+    OSSL_LIB_CTX *libctx = OSSL_LIB_CTX_new_from_dispatch(handle, in);
+    OSSL_FUNC_core_obj_create_fn *c_obj_create= NULL;
+    OSSL_FUNC_core_obj_add_sigid_fn *c_obj_add_sigid= NULL;
+    PROV_XOR_CTX *prov_ctx = xor_newprovctx(libctx);
 
-    if (libctx == NULL)
+    if (libctx == NULL || prov_ctx == NULL)
         return 0;
 
-    *provctx = libctx;
+    *provctx = prov_ctx;
 
     /*
-     * Randomise the group_id we're going to use to ensure we don't interoperate
-     * with anything but ourselves.
+     * Randomise the group_id and code_points we're going to use to ensure we
+     * don't interoperate with anything but ourselves.
      */
-    xor_group.group_id = randomize_tls_group_id(libctx);
-    xor_kemgroup.group_id = randomize_tls_group_id(libctx);
+    xor_group.group_id = randomize_tls_alg_id(libctx);
+    xor_kemgroup.group_id = randomize_tls_alg_id(libctx);
+    xor_sigalg.code_point = randomize_tls_alg_id(libctx);
+    xor_sigalg_hash.code_point = randomize_tls_alg_id(libctx);
+
+    /* Retrieve registration functions */
+    for (; in->function_id != 0; in++) {
+        switch (in->function_id) {
+        case OSSL_FUNC_CORE_OBJ_CREATE:
+            c_obj_create = OSSL_FUNC_core_obj_create(in);
+            break;
+        case OSSL_FUNC_CORE_OBJ_ADD_SIGID:
+            c_obj_add_sigid = OSSL_FUNC_core_obj_add_sigid(in);
+            break;
+        /* Just ignore anything we don't understand */
+        default:
+            break;
+        }
+    }
+
+    /*
+     * Register algorithms manually as add_provider_sigalgs is
+     * only called during session establishment -- too late for
+     * key & cert generation...
+     */
+    if (!c_obj_create(handle, XORSIGALG_OID, XORSIGALG_NAME, XORSIGALG_NAME)) {
+        ERR_raise(ERR_LIB_USER, XORPROV_R_OBJ_CREATE_ERR);
+        return 0;
+    }
+
+    if (!c_obj_add_sigid(handle, XORSIGALG_OID, "", XORSIGALG_OID)) {
+        ERR_raise(ERR_LIB_USER, XORPROV_R_OBJ_CREATE_ERR);
+        return 0;
+    }
+    if (!c_obj_create(handle, XORSIGALG_HASH_OID, XORSIGALG_HASH_NAME, NULL)) {
+        ERR_raise(ERR_LIB_USER, XORPROV_R_OBJ_CREATE_ERR);
+        return 0;
+    }
+
+    if (!c_obj_add_sigid(handle, XORSIGALG_HASH_OID, XORSIGALG_HASH, XORSIGALG_HASH_OID)) {
+        ERR_raise(ERR_LIB_USER, XORPROV_R_OBJ_CREATE_ERR);
+        return 0;
+    }
 
     *out = tls_prov_dispatch_table;
     return 1;

--- a/test/tls-provider.c
+++ b/test/tls-provider.c
@@ -859,7 +859,7 @@ static void *xor_load(const void *reference, size_t reference_sz)
 static int xor_recreate(const unsigned char *kd1, const unsigned char *kd2) {
     int i;
 
-    for(i = 0; i < XOR_KEY_SIZE; i++) {
+    for (i = 0; i < XOR_KEY_SIZE; i++) {
         if ((kd1[i] & 0xff) != ((kd2[i] ^ private_constant[i]) & 0xff))
             return 0;
     }
@@ -872,7 +872,7 @@ static int xor_match(const void *keydata1, const void *keydata2, int selection)
     const XORKEY *key2 = keydata2;
     int ok = 1;
 
-    if (key1->tls_name && key2->tls_name)
+    if (key1->tls_name != NULL && key2->tls_name != NULL)
         ok = ok & (strcmp(key1->tls_name, key2->tls_name) == 0);
 
     if ((selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) != 0)  {
@@ -2476,7 +2476,7 @@ static void xorx_key_adjust(void *key, struct der2key_ctx_st *ctx)
         NULL,                                           \
         NULL,                                           \
         NULL,                                           \
-        (d2i_of_void *)xor_d2i_PUBKEY,                 \
+        (d2i_of_void *)xor_d2i_PUBKEY,                  \
         NULL,                                           \
         xorx_key_adjust,                                \
         (free_key_fn *)xor_freekey

--- a/test/tls-provider.c
+++ b/test/tls-provider.c
@@ -2148,9 +2148,6 @@ struct X509_pubkey_st {
     /* extra data for the callback, used by d2i_PUBKEY_ex */
     OSSL_LIB_CTX *libctx;
     char *propq;
-
-    /* Flag to force legacy keys */
-   unsigned int flag_force_legacy : 1;
 };
 
 ASN1_SEQUENCE(X509_PUBKEY_INTERNAL) = {


### PR DESCRIPTION
~First cut tackling~ Fixing #10512 ~as per discussion there~. Fixing #19369.

~Still considered WIP: Missing e.g. is a test within the OpenSSL test harness. Testing right now done via [oqs-provider](https://github.com/open-quantum-safe/oqs-provider/pull/69). Testing available in https://github.com/baentsch/openssl/compare/sigload...baentsch:openssl:sigload-test?expand=1~