### PR TITLE
Fix error propagatation in BN_check_prime()

### DIFF
--- a/crypto/bn/bn_prime.c
+++ b/crypto/bn/bn_prime.c
@@ -308,9 +308,10 @@ static int bn_is_prime_int(const BIGNUM *w, int checks, BN_CTX *ctx,
         goto err;
 #endif
 
-    ret = ossl_bn_miller_rabin_is_prime(w, checks, ctx, cb, 0, &status);
-    if (!ret)
+    if (!ossl_bn_miller_rabin_is_prime(w, checks, ctx, cb, 0, &status)) {
+        ret = -1;
         goto err;
+    }
     ret = (status == BN_PRIMETEST_PROBABLY_PRIME);
 err:
 #ifndef FIPS_MODULE


### PR DESCRIPTION
BN_check_prime() is supposed to return 0 for a composite number and -1 on error. Properly translate the return value of the internal function ossl_bn_miller_rabin_is_prime(), where 0 means an error.

The confusion prevented BN_GENCB callbacks from aborting the primality test or key generation routines utilizing this.

This patch applies to 3.0 and master.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
