### PR TITLE
Configurations: mips64*-linux-*abin32 needs bn_ops SIXTY_FOUR_BIT

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -742,7 +742,7 @@ my %targets = (
         inherit_from     => [ "linux-generic32", asm("mips64_asm") ],
         cflags           => add("-mabi=n32"),
         cxxflags         => add("-mabi=n32"),
-        bn_ops           => "RC4_CHAR",
+        bn_ops           => "RC4_CHAR SIXTY_FOUR_BIT",
         perlasm_scheme   => "n32",
         multilib         => "32",
     },


### PR DESCRIPTION
As requested: https://github.com/openssl/openssl/pull/19320#issuecomment-1264291644

Fixes #19319

CLA: trivial

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated