### PR TITLE
Restructure internal/time.h for better combination with internal/e_os.h

### DIFF
--- a/include/internal/time.h
+++ b/include/internal/time.h
@@ -12,7 +12,6 @@
 # pragma once
 
 # include <openssl/e_os2.h>     /* uint64_t */
-# include "internal/e_os.h"     /* for struct timeval */
 # include "internal/safe_math.h"
 
 /*
@@ -73,52 +72,6 @@ static ossl_unused ossl_inline
 OSSL_TIME ossl_time_infinite(void)
 {
     return ossl_ticks2time(~(uint64_t)0);
-}
-
-
-/* Convert time to timeval */
-static ossl_unused ossl_inline
-struct timeval ossl_time_to_timeval(OSSL_TIME t)
-{
-    struct timeval tv;
-
-#ifdef _WIN32
-    tv.tv_sec = (long int)(t.t / OSSL_TIME_SECOND);
-#else
-    tv.tv_sec = (time_t)(t.t / OSSL_TIME_SECOND);
-#endif
-    tv.tv_usec = (t.t % OSSL_TIME_SECOND) / OSSL_TIME_US;
-    return tv;
-}
-
-/* Convert timeval to time */
-static ossl_unused ossl_inline
-OSSL_TIME ossl_time_from_timeval(struct timeval tv)
-{
-    OSSL_TIME t;
-
-    if (tv.tv_sec < 0)
-        return ossl_time_zero();
-    t.t = tv.tv_sec * OSSL_TIME_SECOND + tv.tv_usec * OSSL_TIME_US;
-    return t;
-}
-
-/* Convert OSSL_TIME to time_t */
-static ossl_unused ossl_inline
-time_t ossl_time_to_time_t(OSSL_TIME t)
-{
-    return (time_t)(t.t / OSSL_TIME_SECOND);
-}
-
-/* Convert time_t to OSSL_TIME */
-static ossl_unused ossl_inline
-OSSL_TIME ossl_time_from_time_t(time_t t)
-{
-    OSSL_TIME ot;
-
-    ot.t = t;
-    ot.t *= OSSL_TIME_SECOND;
-    return ot;
 }
 
 /* Compare two time values, return -1 if less, 1 if greater and 0 if equal */
@@ -223,6 +176,58 @@ static ossl_unused ossl_inline
 OSSL_TIME ossl_time_min(OSSL_TIME a, OSSL_TIME b)
 {
     return a.t < b.t ? a : b;
+}
+
+/*
+ * Include e_os.h late, so it can benefit from the declarations
+ * above.  This is currently used for its fallback implementation
+ * of ossl_sleep().
+ */
+# include "internal/e_os.h"     /* for struct timeval */
+
+/* Convert time to timeval */
+static ossl_unused ossl_inline
+struct timeval ossl_time_to_timeval(OSSL_TIME t)
+{
+    struct timeval tv;
+
+#ifdef _WIN32
+    tv.tv_sec = (long int)(t.t / OSSL_TIME_SECOND);
+#else
+    tv.tv_sec = (time_t)(t.t / OSSL_TIME_SECOND);
+#endif
+    tv.tv_usec = (t.t % OSSL_TIME_SECOND) / OSSL_TIME_US;
+    return tv;
+}
+
+/* Convert timeval to time */
+static ossl_unused ossl_inline
+OSSL_TIME ossl_time_from_timeval(struct timeval tv)
+{
+    OSSL_TIME t;
+
+    if (tv.tv_sec < 0)
+        return ossl_time_zero();
+    t.t = tv.tv_sec * OSSL_TIME_SECOND + tv.tv_usec * OSSL_TIME_US;
+    return t;
+}
+
+/* Convert OSSL_TIME to time_t */
+static ossl_unused ossl_inline
+time_t ossl_time_to_time_t(OSSL_TIME t)
+{
+    return (time_t)(t.t / OSSL_TIME_SECOND);
+}
+
+/* Convert time_t to OSSL_TIME */
+static ossl_unused ossl_inline
+OSSL_TIME ossl_time_from_time_t(time_t t)
+{
+    OSSL_TIME ot;
+
+    ot.t = t;
+    ot.t *= OSSL_TIME_SECOND;
+    return ot;
 }
 
 #endif


### PR DESCRIPTION
For its fallback implementation of ossl_sleep(), internal/e_os.h includes
internal/time.h.  This is all good, as long as internal/e_os.h is included
first.  However, internal/time.h also includes internal/e_os.h for its time
structure conversion functions, and we find ourselves with an inclusion loop
that happens before OSSL_TIME is defined, and we get a warning or an error
for the fallback implementation of ossl_sleep().

To remedy this, internal/time.h is restructured to include internal/e_os.h
late, and move all the functions for converting between OSSL_TIME and other
time structures after that inclusion, as internal/e_os.h helps making those
other structures available.

-----

VMS builds currently fail, this fixes the current problem
