### PR TITLE
Rename ossl_sleep() to OSSL_sleep() and make it public

### DIFF
--- a/apps/cmp.c
+++ b/apps/cmp.c
@@ -2688,7 +2688,7 @@ static int cmp_server(OSSL_CMP_CTX *srv_cmp_ctx)
                                        prog, 0, 0);
         if (ret == 0) { /* no request yet */
             if (retry) {
-                ossl_sleep(1000);
+                OSSL_sleep(1000);
                 retry = 0;
                 continue;
             }

--- a/apps/lib/http_server.c
+++ b/apps/lib/http_server.c
@@ -65,7 +65,7 @@ static void killall(int ret, pid_t *kidpids)
         if (kidpids[i] != 0)
             (void)kill(kidpids[i], SIGTERM);
     OPENSSL_free(kidpids);
-    ossl_sleep(1000);
+    OSSL_sleep(1000);
     exit(ret);
 }
 
@@ -141,7 +141,7 @@ void spawn_loop(const char *prog)
                                   "child process: %ld, term signal %d%s",
                                   (long)fpid, WTERMSIG(status), dumped);
                     }
-                    ossl_sleep(1000);
+                    OSSL_sleep(1000);
                 }
                 break;
             } else if (errno != EINTR) {
@@ -156,7 +156,7 @@ void spawn_loop(const char *prog)
         switch (fpid = fork()) {
         case -1: /* error */
             /* System critically low on memory, pause and try again later */
-            ossl_sleep(30000);
+            OSSL_sleep(30000);
             break;
         case 0: /* child */
             OPENSSL_free(kidpids);

--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -3184,7 +3184,7 @@ static int www_body(int s, int stype, int prot, unsigned char *context)
                     continue;
                 }
 #endif
-                ossl_sleep(1000);
+                OSSL_sleep(1000);
                 continue;
             }
         } else if (i == 0) {    /* end of input */
@@ -3625,7 +3625,7 @@ static int rev_body(int s, int stype, int prot, unsigned char *context)
                     continue;
                 }
 #endif
-                ossl_sleep(1000);
+                OSSL_sleep(1000);
                 continue;
             }
         } else if (i == 0) {    /* end of input */

--- a/crypto/bio/bio_lib.c
+++ b/crypto/bio/bio_lib.c
@@ -980,7 +980,7 @@ static int bio_wait(BIO *bio, time_t max_time, unsigned int nap_milliseconds)
         if ((unsigned long)sec_diff * 1000 < nap_milliseconds)
             nap_milliseconds = (unsigned int)sec_diff * 1000;
     }
-    ossl_sleep(nap_milliseconds);
+    OSSL_sleep(nap_milliseconds);
     return 1;
 }
 

--- a/crypto/build.info
+++ b/crypto/build.info
@@ -107,7 +107,7 @@ SOURCE[../libcrypto]=$UTIL_COMMON \
         mem.c mem_sec.c \
         cversion.c info.c cpt_err.c ebcdic.c uid.c o_time.c o_dir.c \
         o_fopen.c getenv.c o_init.c init.c trace.c provider.c provider_child.c \
-        punycode.c passphrase.c
+        punycode.c passphrase.c sleep.c
 SOURCE[../providers/libfips.a]=$UTIL_COMMON
 
 SOURCE[../libcrypto]=$UPLINKSRC

--- a/crypto/cmp/cmp_client.c
+++ b/crypto/cmp/cmp_client.c
@@ -11,7 +11,6 @@
 
 #include "cmp_local.h"
 #include "internal/cryptlib.h"
-#include "internal/e_os.h" /* ossl_sleep() */
 
 /* explicit #includes not strictly needed since implied by the above: */
 #include <openssl/bio.h>
@@ -332,7 +331,7 @@ static int poll_for_response(OSSL_CMP_CTX *ctx, int sleep, int rid,
             OSSL_CMP_MSG_free(prep);
             prep = NULL;
             if (sleep) {
-                ossl_sleep((unsigned long)(1000 * check_after));
+                OSSL_sleep((unsigned long)(1000 * check_after));
             } else {
                 if (checkAfter != NULL)
                     *checkAfter = (int)check_after;

--- a/crypto/sleep.c
+++ b/crypto/sleep.c
@@ -7,7 +7,6 @@
  * https://www.openssl.org/source/license.html
  */
 
-#include <unistd.h>
 #include <openssl/crypto.h>
 #include "internal/e_os.h"
 

--- a/crypto/sleep.c
+++ b/crypto/sleep.c
@@ -51,7 +51,7 @@ void OSSL_sleep(uint64_t millis)
     DWORD dword_times;
     DWORD i;
 
-    dword_times = (DWORD)(millis >> sizeof(DWORD));
+    dword_times = (DWORD)(millis >> (8 * sizeof(DWORD)));
     millis &= (DWORD)-1;
     if (dword_times > 0) {
         for (i = dword_times; i-- > 0;)
@@ -81,7 +81,7 @@ static void ossl_sleep_secs(uint64_t secs)
     unsigned int uint_times;
     unsigned int i;
 
-    uint_times = (unsigned int)(secs >> sizeof(unsigned int));
+    uint_times = (unsigned int)(secs >> (8 * sizeof(unsigned int)));
     if (uint_times > 0) {
         for (i = uint_times; i-- > 0;)
             sleep((unsigned int)-1);

--- a/crypto/sleep.c
+++ b/crypto/sleep.c
@@ -14,7 +14,7 @@
 #if defined(OPENSSL_SYS_UNIX) || defined(__DJGPP__)
 # include <unistd.h>
 
-void OSSL_sleep(unsigned long millis)
+void OSSL_sleep(uint64_t millis)
 {
 # ifdef OPENSSL_SYS_VXWORKS
     struct timespec ts;
@@ -43,7 +43,7 @@ void OSSL_sleep(unsigned long millis)
 #elif defined(_WIN32)
 # include <windows.h>
 
-void OSSL_sleep(unsigned long millis)
+void OSSL_sleep(uint64_t millis)
 {
     Sleep(millis);
 }
@@ -51,7 +51,7 @@ void OSSL_sleep(unsigned long millis)
 /* Fallback to a busy wait */
 # include "internal/time.h"
 
-void OSSL_sleep(unsigned long millis)
+void OSSL_sleep(uint64_t millis)
 {
     const OSSL_TIME finish
         = ossl_time_add(ossl_time_now(), ossl_ms2time(millis));

--- a/crypto/sleep.c
+++ b/crypto/sleep.c
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2022 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <openssl/crypto.h>
+#include "internal/e_os.h"
+
+/* system-specific variants defining OSSL_sleep() */
+#if defined(OPENSSL_SYS_UNIX) || defined(__DJGPP__)
+# include <unistd.h>
+void OSSL_sleep(unsigned long millis)
+{
+# ifdef OPENSSL_SYS_VXWORKS
+    struct timespec ts;
+    ts.tv_sec = (long int) (millis / 1000);
+    ts.tv_nsec = (long int) (millis % 1000) * 1000000ul;
+    nanosleep(&ts, NULL);
+# elif defined(__TANDEM)
+#  if !defined(_REENTRANT)
+#   include <cextdecs.h(PROCESS_DELAY_)>
+    /* HPNS does not support usleep for non threaded apps */
+    PROCESS_DELAY_(millis * 1000);
+#  elif defined(_SPT_MODEL_)
+#   include <spthread.h>
+#   include <spt_extensions.h>
+    usleep(millis * 1000);
+#  else
+    usleep(millis * 1000);
+#  endif
+# else
+    usleep(millis * 1000);
+# endif
+}
+#elif defined(_WIN32)
+# include <windows.h>
+void OSSL_sleep(unsigned long millis)
+{
+    Sleep(millis);
+}
+#else
+/* Fallback to a busy wait */
+# include "internal/time.h"
+void OSSL_sleep(unsigned long millis)
+{
+    const OSSL_TIME finish = ossl_time_add(ossl_time_now(), ossl_ms2time(millis));
+
+    while (ossl_time_compare(ossl_time_now(), finish) < 0)
+        /* busy wait */ ;
+}
+#endif /* defined(OPENSSL_SYS_UNIX) || defined(__DJGPP__) */

--- a/crypto/sleep.c
+++ b/crypto/sleep.c
@@ -65,8 +65,7 @@ void OSSL_sleep(uint64_t millis)
     }
 
     /* Now, sleep the remaining milliseconds */
-    if (millis > 0)
-        Sleep((DWORD)(millis));
+    Sleep((DWORD)(millis));
 }
 #else
 /* Fallback to a busy wait */

--- a/crypto/sleep.c
+++ b/crypto/sleep.c
@@ -13,21 +13,25 @@
 /* system-specific variants defining OSSL_sleep() */
 #if defined(OPENSSL_SYS_UNIX) || defined(__DJGPP__)
 # include <unistd.h>
+
 void OSSL_sleep(unsigned long millis)
 {
 # ifdef OPENSSL_SYS_VXWORKS
     struct timespec ts;
+
     ts.tv_sec = (long int) (millis / 1000);
     ts.tv_nsec = (long int) (millis % 1000) * 1000000ul;
     nanosleep(&ts, NULL);
 # elif defined(__TANDEM)
 #  if !defined(_REENTRANT)
 #   include <cextdecs.h(PROCESS_DELAY_)>
+
     /* HPNS does not support usleep for non threaded apps */
     PROCESS_DELAY_(millis * 1000);
 #  elif defined(_SPT_MODEL_)
 #   include <spthread.h>
 #   include <spt_extensions.h>
+
     usleep(millis * 1000);
 #  else
     usleep(millis * 1000);
@@ -38,6 +42,7 @@ void OSSL_sleep(unsigned long millis)
 }
 #elif defined(_WIN32)
 # include <windows.h>
+
 void OSSL_sleep(unsigned long millis)
 {
     Sleep(millis);
@@ -45,9 +50,11 @@ void OSSL_sleep(unsigned long millis)
 #else
 /* Fallback to a busy wait */
 # include "internal/time.h"
+
 void OSSL_sleep(unsigned long millis)
 {
-    const OSSL_TIME finish = ossl_time_add(ossl_time_now(), ossl_ms2time(millis));
+    const OSSL_TIME finish
+        = ossl_time_add(ossl_time_now(), ossl_ms2time(millis));
 
     while (ossl_time_compare(ossl_time_now(), finish) < 0)
         /* busy wait */ ;

--- a/doc/build.info
+++ b/doc/build.info
@@ -1723,6 +1723,10 @@ DEPEND[html/man3/OSSL_STORE_open.html]=man3/OSSL_STORE_open.pod
 GENERATE[html/man3/OSSL_STORE_open.html]=man3/OSSL_STORE_open.pod
 DEPEND[man/man3/OSSL_STORE_open.3]=man3/OSSL_STORE_open.pod
 GENERATE[man/man3/OSSL_STORE_open.3]=man3/OSSL_STORE_open.pod
+DEPEND[html/man3/OSSL_sleep.html]=man3/OSSL_sleep.pod
+GENERATE[html/man3/OSSL_sleep.html]=man3/OSSL_sleep.pod
+DEPEND[man/man3/OSSL_sleep.3]=man3/OSSL_sleep.pod
+GENERATE[man/man3/OSSL_sleep.3]=man3/OSSL_sleep.pod
 DEPEND[html/man3/OSSL_trace_enabled.html]=man3/OSSL_trace_enabled.pod
 GENERATE[html/man3/OSSL_trace_enabled.html]=man3/OSSL_trace_enabled.pod
 DEPEND[man/man3/OSSL_trace_enabled.3]=man3/OSSL_trace_enabled.pod
@@ -3194,6 +3198,7 @@ html/man3/OSSL_STORE_SEARCH.html \
 html/man3/OSSL_STORE_attach.html \
 html/man3/OSSL_STORE_expect.html \
 html/man3/OSSL_STORE_open.html \
+html/man3/OSSL_sleep.html \
 html/man3/OSSL_trace_enabled.html \
 html/man3/OSSL_trace_get_category_num.html \
 html/man3/OSSL_trace_set_channel.html \
@@ -3797,6 +3802,7 @@ man/man3/OSSL_STORE_SEARCH.3 \
 man/man3/OSSL_STORE_attach.3 \
 man/man3/OSSL_STORE_expect.3 \
 man/man3/OSSL_STORE_open.3 \
+man/man3/OSSL_sleep.3 \
 man/man3/OSSL_trace_enabled.3 \
 man/man3/OSSL_trace_get_category_num.3 \
 man/man3/OSSL_trace_set_channel.3 \

--- a/doc/man3/OSSL_sleep.pod
+++ b/doc/man3/OSSL_sleep.pod
@@ -2,7 +2,7 @@
 
 =head1 NAME
 
-OSSL_sleep - delay execution for a specified amount of milliseconds
+OSSL_sleep - delay execution for a specified number of milliseconds
 
 =head1 SYNOPSIS
 

--- a/doc/man3/OSSL_sleep.pod
+++ b/doc/man3/OSSL_sleep.pod
@@ -23,7 +23,7 @@ OSSL_sleep() does not return any value.
 
 =head1 HISTORY
 
-OSSL_sleep() was added in OpenSSL 3.1.
+OSSL_sleep() was added in OpenSSL 3.2.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/OSSL_sleep.pod
+++ b/doc/man3/OSSL_sleep.pod
@@ -8,7 +8,7 @@ OSSL_sleep - delay execution for a specified number of milliseconds
 
  #include <openssl/crypto.h>
 
- void OSSL_sleep(unsigned long millis);
+ void OSSL_sleep(uint64_t millis);
 
 =head1 DESCRIPTION
 

--- a/doc/man3/OSSL_sleep.pod
+++ b/doc/man3/OSSL_sleep.pod
@@ -1,0 +1,37 @@
+=pod
+
+=head1 NAME
+
+OSSL_sleep - delay execution for a specified amount of milliseconds
+
+=head1 SYNOPSIS
+
+ #include <openssl/crypto.h>
+
+ void OSSL_sleep(unsigned long millis);
+
+=head1 DESCRIPTION
+
+OSSL_sleep() is a convenience function to delay execution of the calling
+thread for (at least) I<millis> milliseconds.  The delay may be lengthened
+slightly by system activity, by the time spent processing the call or by
+system timers granularity.
+
+=head1 RETURN VALUES
+
+OSSL_sleep() does not return any value.
+
+=head1 HISTORY
+
+OSSL_sleep() was added in OpenSSL 3.1.
+
+=head1 COPYRIGHT
+
+Copyright 2022 The OpenSSL Project Authors. All Rights Reserved.
+
+Licensed under the Apache License 2.0 (the "License").  You may not use
+this file except in compliance with the License.  You can obtain a copy
+in the file LICENSE in the source distribution or at
+L<https://www.openssl.org/source/license.html>.
+
+=cut

--- a/doc/man3/OSSL_sleep.pod
+++ b/doc/man3/OSSL_sleep.pod
@@ -13,9 +13,9 @@ OSSL_sleep - delay execution for a specified number of milliseconds
 =head1 DESCRIPTION
 
 OSSL_sleep() is a convenience function to delay execution of the calling
-thread for (at least) I<millis> milliseconds.  The delay may be lengthened
-slightly by system activity, by the time spent processing the call or by
-system timers granularity.
+thread for (at least) I<millis> milliseconds.  The delay is not guaranteed;
+it may be affected by system activity, by the time spent processing the call
+or by system timer granularity.
 
 =head1 RETURN VALUES
 

--- a/include/internal/e_os.h
+++ b/include/internal/e_os.h
@@ -286,50 +286,6 @@ struct servent *getservbyname(const char *name, const char *proto);
 # endif
 /* end vxworks */
 
-/* system-specific variants defining ossl_sleep() */
-#if defined(OPENSSL_SYS_UNIX) || defined(__DJGPP__)
-# include <unistd.h>
-static ossl_inline void ossl_sleep(unsigned long millis)
-{
-# ifdef OPENSSL_SYS_VXWORKS
-    struct timespec ts;
-    ts.tv_sec = (long int) (millis / 1000);
-    ts.tv_nsec = (long int) (millis % 1000) * 1000000ul;
-    nanosleep(&ts, NULL);
-# elif defined(__TANDEM)
-#  if !defined(_REENTRANT)
-#   include <cextdecs.h(PROCESS_DELAY_)>
-    /* HPNS does not support usleep for non threaded apps */
-    PROCESS_DELAY_(millis * 1000);
-#  elif defined(_SPT_MODEL_)
-#   include <spthread.h>
-#   include <spt_extensions.h>
-    usleep(millis * 1000);
-#  else
-    usleep(millis * 1000);
-#  endif
-# else
-    usleep(millis * 1000);
-# endif
-}
-#elif defined(_WIN32)
-# include <windows.h>
-static ossl_inline void ossl_sleep(unsigned long millis)
-{
-    Sleep(millis);
-}
-#else
-/* Fallback to a busy wait */
-# include "internal/time.h"
-static ossl_inline void ossl_sleep(unsigned long millis)
-{
-    const OSSL_TIME finish = ossl_time_add(ossl_time_now(), ossl_ms2time(millis));
-
-    while (ossl_time_compare(ossl_time_now(), finish) < 0)
-        /* busy wait */ ;
-}
-#endif /* defined OPENSSL_SYS_UNIX */
-
 /* ----------------------------- HP NonStop -------------------------------- */
 /* Required to support platform variant without getpid() and pid_t. */
 # if defined(__TANDEM) && defined(_GUARDIAN_TARGET)

--- a/include/openssl/crypto.h.in
+++ b/include/openssl/crypto.h.in
@@ -529,7 +529,7 @@ void OSSL_LIB_CTX_free(OSSL_LIB_CTX *);
 OSSL_LIB_CTX *OSSL_LIB_CTX_get0_global_default(void);
 OSSL_LIB_CTX *OSSL_LIB_CTX_set0_default(OSSL_LIB_CTX *libctx);
 
-void OSSL_sleep(unsigned long millis);
+void OSSL_sleep(uint64_t millis);
 
 # ifdef  __cplusplus
 }

--- a/include/openssl/crypto.h.in
+++ b/include/openssl/crypto.h.in
@@ -529,6 +529,8 @@ void OSSL_LIB_CTX_free(OSSL_LIB_CTX *);
 OSSL_LIB_CTX *OSSL_LIB_CTX_get0_global_default(void);
 OSSL_LIB_CTX *OSSL_LIB_CTX_set0_default(OSSL_LIB_CTX *libctx);
 
+void OSSL_sleep(unsigned long millis);
+
 # ifdef  __cplusplus
 }
 # endif

--- a/test/helpers/ssltestlib.c
+++ b/test/helpers/ssltestlib.c
@@ -12,7 +12,6 @@
 #include "internal/nelem.h"
 #include "ssltestlib.h"
 #include "../testutil.h"
-#include "internal/e_os.h" /* for ossl_sleep() etc. */
 
 #ifdef OPENSSL_SYS_UNIX
 # include <unistd.h>
@@ -1164,7 +1163,7 @@ int create_bare_ssl_connection(SSL *serverssl, SSL *clientssl, int want,
              * give the DTLS timer a chance to do something. We only do this for
              * the first few times to prevent hangs.
              */
-            ossl_sleep(50);
+            OSSL_sleep(50);
         }
     } while (retc <=0 || rets <= 0);
 

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5465,3 +5465,4 @@ EVP_PKEY_auth_encapsulate_init          ?	3_1_0	EXIST::FUNCTION:
 EVP_PKEY_auth_decapsulate_init          ?	3_1_0	EXIST::FUNCTION:
 PKCS12_SAFEBAG_set0_attrs               ?	3_1_0	EXIST::FUNCTION:
 PKCS12_create_ex2                       ?	3_1_0	EXIST::FUNCTION:
+OSSL_sleep                              ?	3_1_0	EXIST::FUNCTION:


### PR DESCRIPTION
ossl_sleep() was implemented as a static inline function in internal/e_os.h,
using usleep() on Unix and Sleep() on Windows.  So far well and good.
However, it also has a fallback implementation for systems that do not have
usleep() or Sleep(), and that implementation happens to use ossl_time_now(),
which is a normal function, private to libcrypto, and is judged to be too
complex to sanely make into a static inline function.

This fallback creates a problem, because we do use ossl_sleep() in apps/ and
a few test programs in test/, and when they are linked with libcrypto in
shared library form, ossl_time_now() can't be found, since it's not publicly
exposed.

Something needs to give, and the easiest, and hopefully sanest answer is to
make ossl_sleep() a publicly exposed function, which requires a slight name
change.

Documentation and 'make update' result included.
