### PR TITLE
set MGF1 digest correctly

### DIFF
--- a/providers/implementations/asymciphers/rsa_enc.c
+++ b/providers/implementations/asymciphers/rsa_enc.c
@@ -425,7 +425,7 @@ static int rsa_set_ctx_params(void *vprsactx, const OSSL_PARAM params[])
     const OSSL_PARAM *p;
     char mdname[OSSL_MAX_NAME_SIZE];
     char mdprops[OSSL_MAX_PROPQUERY_SIZE] = { '\0' };
-    char *str = mdname;
+    char *str = NULL;
 
     if (prsactx == NULL)
         return 0;
@@ -434,13 +434,14 @@ static int rsa_set_ctx_params(void *vprsactx, const OSSL_PARAM params[])
 
     p = OSSL_PARAM_locate_const(params, OSSL_ASYM_CIPHER_PARAM_OAEP_DIGEST);
     if (p != NULL) {
+        str = mdname;
         if (!OSSL_PARAM_get_utf8_string(p, &str, sizeof(mdname)))
             return 0;
 
-        str = mdprops;
         p = OSSL_PARAM_locate_const(params,
                                     OSSL_ASYM_CIPHER_PARAM_OAEP_DIGEST_PROPS);
         if (p != NULL) {
+            str = mdprops;
             if (!OSSL_PARAM_get_utf8_string(p, &str, sizeof(mdprops)))
                 return 0;
         }
@@ -496,13 +497,14 @@ static int rsa_set_ctx_params(void *vprsactx, const OSSL_PARAM params[])
 
     p = OSSL_PARAM_locate_const(params, OSSL_ASYM_CIPHER_PARAM_MGF1_DIGEST);
     if (p != NULL) {
+        str = mdname;
         if (!OSSL_PARAM_get_utf8_string(p, &str, sizeof(mdname)))
             return 0;
 
-        str = mdprops;
         p = OSSL_PARAM_locate_const(params,
                                     OSSL_ASYM_CIPHER_PARAM_MGF1_DIGEST_PROPS);
         if (p != NULL) {
+            str = mdprops;
             if (!OSSL_PARAM_get_utf8_string(p, &str, sizeof(mdprops)))
                 return 0;
         } else {


### PR DESCRIPTION
update rsa_set_ctx_params() so that the digest function used in the MGF1 construction is set correctly.

Fixes #19290

Testing:
scaro-axway gave code to reproduce the defect in the github issue. The code is supposed to set the rsa-oaep hash function to SHA2-256 and mgf1 hash function to SHA1.  Here is the code:

```c
  #include <openssl/evp.h>
  #include <openssl/core_names.h>
  #include <openssl/rsa.h>
  #include <stdio.h>

  void main(int argc, char **argv)
  {
    EVP_PKEY *key = EVP_RSA_gen(1024);
    EVP_PKEY_CTX *keyCtx = EVP_PKEY_CTX_new_from_pkey(0, key, 0);

    { // Set params
        int padding = RSA_PKCS1_OAEP_PADDING;
        OSSL_PARAM params[4];
        params[0] = OSSL_PARAM_construct_int(OSSL_SIGNATURE_PARAM_PAD_MODE, & padding);
        params[1] = OSSL_PARAM_construct_utf8_string(OSSL_ASYM_CIPHER_PARAM_OAEP_DIGEST,
                                                     SN_sha256, 0);
        params[2] = OSSL_PARAM_construct_utf8_string(OSSL_ASYM_CIPHER_PARAM_MGF1_DIGEST,
                                                     SN_sha1, 0);
        params[3] = OSSL_PARAM_construct_end();

        EVP_PKEY_encrypt_init_ex(keyCtx, params);
    }
    { // Read params
        OSSL_PARAM params[3];
        char       oaepmd[30] = { '\0' };
        char       mgf1md[30] = { '\0' };

        params[0] = OSSL_PARAM_construct_utf8_string(OSSL_ASYM_CIPHER_PARAM_OAEP_DIGEST,
                                                     oaepmd, sizeof(oaepmd));
        params[1] = OSSL_PARAM_construct_utf8_string(OSSL_ASYM_CIPHER_PARAM_MGF1_DIGEST,
                                                     mgf1md, sizeof(mgf1md));
        params[2] = OSSL_PARAM_construct_end();

        EVP_PKEY_CTX_get_params(keyCtx, params);
        printf("oaep = %s / mgf1 = %s\n", oaepmd, mgf1md);
    }
  }
```

before this commit:

```
  openssl/tmp$ make -B && ./issue-19290
  gcc -Wall -g -O0 -I../include -c issue-19290.c -o issue-19290.o
  gcc -Wall -g -O0 -I../include issue-19290.o ../libcrypto.a -o issue-19290
  oaep = SHA2-256 / mgf1 = SHA2-256
```

after this commit:

```
  openssl/tmp$ make -B && ./issue-19290
  gcc -Wall -g -O0 -I../include -c issue-19290.c -o issue-19290.o
  gcc -Wall -g -O0 -I../include issue-19290.o ../libcrypto.a -o issue-19290
  oaep = SHA2-256 / mgf1 = SHA1
```
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
