### PR TITLE
Convert the TLSv1.3 crypto code and KTLS to use the new write record layer

### DIFF
--- a/ssl/record/methods/dtls_meth.c
+++ b/ssl/record/methods/dtls_meth.c
@@ -253,7 +253,7 @@ static int dtls_process_record(OSSL_RECORD_LAYER *rl, DTLS_BITMAP *bitmap)
      * Check if the received packet overflows the current Max Fragment
      * Length setting.
      */
-    if (rl->max_frag_len > 0 && rr->length > rl->max_frag_len) {
+    if (rr->length > rl->max_frag_len) {
         RLAYERfatal(rl, SSL_AD_RECORD_OVERFLOW, SSL_R_DATA_LENGTH_TOO_LONG);
         goto end;
     }
@@ -482,8 +482,7 @@ int dtls_get_more_records(OSSL_RECORD_LAYER *rl)
          * If received packet overflows maximum possible fragment length then
          * silently discard it
          */
-        if (rl->max_frag_len > 0
-                && rr->length > rl->max_frag_len + SSL3_RT_MAX_ENCRYPTED_OVERHEAD) {
+        if (rr->length > rl->max_frag_len + SSL3_RT_MAX_ENCRYPTED_OVERHEAD) {
             /* record too long, silently discard it */
             rr->length = 0;
             rl->packet_length = 0;
@@ -713,5 +712,6 @@ const OSSL_RECORD_METHOD ossl_dtls_record_method = {
     dtls_set_in_init,
     tls_get_state,
     tls_set_options,
-    tls_get_compression
+    tls_get_compression,
+    tls_set_max_frag_len
 };

--- a/ssl/record/methods/ktls_meth.c
+++ b/ssl/record/methods/ktls_meth.c
@@ -492,6 +492,15 @@ static int ktls_prepare_record_header(OSSL_RECORD_LAYER *rl,
     return 1;
 }
 
+static int ktls_prepare_for_encryption(OSSL_RECORD_LAYER *rl,
+                                       size_t mac_size,
+                                       WPACKET *thispkt,
+                                       SSL3_RECORD *thiswr)
+{
+    /* No encryption, so nothing to do */
+    return 1;
+}
+
 static struct record_functions_st ossl_ktls_funcs = {
     ktls_set_crypto_state,
     ktls_cipher,
@@ -507,7 +516,8 @@ static struct record_functions_st ossl_ktls_funcs = {
     ktls_initialise_write_packets,
     NULL,
     ktls_prepare_record_header,
-    NULL
+    NULL,
+    ktls_prepare_for_encryption
 };
 
 const OSSL_RECORD_METHOD ossl_ktls_record_method = {

--- a/ssl/record/methods/ktls_meth.c
+++ b/ssl/record/methods/ktls_meth.c
@@ -506,7 +506,8 @@ static struct record_functions_st ossl_ktls_funcs = {
     ktls_allocate_write_buffers,
     ktls_initialise_write_packets,
     NULL,
-    ktls_prepare_record_header
+    ktls_prepare_record_header,
+    NULL
 };
 
 const OSSL_RECORD_METHOD ossl_ktls_record_method = {

--- a/ssl/record/methods/ktls_meth.c
+++ b/ssl/record/methods/ktls_meth.c
@@ -307,16 +307,8 @@ static int ktls_set_crypto_state(OSSL_RECORD_LAYER *rl, int level,
         return OSSL_RECORD_RETURN_NON_FATAL_ERR;
 
     /* ktls supports only the maximum fragment size */
-    if (rl->max_frag_len > 0 && rl->max_frag_len != SSL3_RT_MAX_PLAIN_LENGTH)
+    if (rl->max_frag_len != SSL3_RT_MAX_PLAIN_LENGTH)
         return OSSL_RECORD_RETURN_NON_FATAL_ERR;
-#if 0
-    /*
-     * TODO(RECLAYER): We will need to reintroduce the check of the send
-     * fragment for KTLS once we do the record write side implementation
-     */
-    if (ssl_get_max_send_fragment(s) != SSL3_RT_MAX_PLAIN_LENGTH)
-        return OSSL_RECORD_RETURN_NON_FATAL_ERR;
-#endif
 
     /* check that cipher is supported */
     if (!ktls_int_check_supported_cipher(rl, ciph, md, taglen))
@@ -476,5 +468,6 @@ const OSSL_RECORD_METHOD ossl_ktls_record_method = {
     NULL,
     tls_get_state,
     tls_set_options,
-    tls_get_compression
+    tls_get_compression,
+    tls_set_max_frag_len
 };

--- a/ssl/record/methods/ktls_meth.c
+++ b/ssl/record/methods/ktls_meth.c
@@ -492,7 +492,8 @@ static struct record_functions_st ossl_ktls_funcs = {
     tls_get_max_records_default,
     tls_write_records_default,
     ktls_allocate_write_buffers,
-    ktls_initialise_write_packets
+    ktls_initialise_write_packets,
+    NULL
 };
 
 const OSSL_RECORD_METHOD ossl_ktls_record_method = {

--- a/ssl/record/methods/ktls_meth.c
+++ b/ssl/record/methods/ktls_meth.c
@@ -501,6 +501,16 @@ static int ktls_prepare_for_encryption(OSSL_RECORD_LAYER *rl,
     return 1;
 }
 
+static int ktls_post_encryption_processing(OSSL_RECORD_LAYER *rl,
+                                           size_t mac_size,
+                                           OSSL_RECORD_TEMPLATE *templ,
+                                           WPACKET *thispkt,
+                                           SSL3_RECORD *thiswr)
+{
+    /* The kernel does anything that is needed, so nothing to do here */
+    return 1;
+}
+
 static struct record_functions_st ossl_ktls_funcs = {
     ktls_set_crypto_state,
     ktls_cipher,
@@ -517,7 +527,8 @@ static struct record_functions_st ossl_ktls_funcs = {
     NULL,
     ktls_prepare_record_header,
     NULL,
-    ktls_prepare_for_encryption
+    ktls_prepare_for_encryption,
+    ktls_post_encryption_processing
 };
 
 const OSSL_RECORD_METHOD ossl_ktls_record_method = {

--- a/ssl/record/methods/recmethod_local.h
+++ b/ssl/record/methods/recmethod_local.h
@@ -173,7 +173,10 @@ struct ossl_record_layer_st
     /* Set to 1 if this is the first handshake. 0 otherwise */
     int is_first_handshake;
 
-    /* The negotiated maximum fragment length */
+    /*
+     * The smaller of the configured and negotiated maximum fragment length
+     * or SSL3_RT_MAX_PLAIN_LENGTH if none
+     */
     unsigned int max_frag_len;
 
     /* The maxium amount of early data we can receive/send */
@@ -329,6 +332,7 @@ void tls_get_state(OSSL_RECORD_LAYER *rl, const char **shortstr,
                    const char **longstr);
 int tls_set_options(OSSL_RECORD_LAYER *rl, const OSSL_PARAM *options);
 const COMP_METHOD *tls_get_compression(OSSL_RECORD_LAYER *rl);
+void tls_set_max_frag_len(OSSL_RECORD_LAYER *rl, size_t max_frag_len);
 int tls_setup_read_buffer(OSSL_RECORD_LAYER *rl);
 int tls_setup_write_buffer(OSSL_RECORD_LAYER *rl, size_t numwpipes,
                            size_t firstlen, size_t nextlen);

--- a/ssl/record/methods/recmethod_local.h
+++ b/ssl/record/methods/recmethod_local.h
@@ -74,6 +74,27 @@ struct record_functions_st
     /* Return 1 for success or 0 for error */
     int (*write_records)(OSSL_RECORD_LAYER *rl, OSSL_RECORD_TEMPLATE *templates,
                          size_t numtempl);
+
+    /* Allocate the rl->wbuf buffers. Return 1 for success or 0 for error */
+    int (*allocate_write_buffers)(OSSL_RECORD_LAYER *rl,
+                                  OSSL_RECORD_TEMPLATE *templates,
+                                  size_t numtempl, size_t *prefix);
+
+    /*
+     * Initialise the packets in the |pkt| array using the buffers in |rl->wbuf|.
+     * Some protocol versions may use the space in |prefixtempl| to add
+     * an artificial template in front of the |templates| array and hence may
+     * initialise 1 more WPACKET than there are templates. |*wpinited|
+     * returns the number of WPACKETs in |pkt| that were successfully
+     * initialised. This must be 0 on entry and will be filled in even on error.
+     */
+    int (*initialise_write_packets)(OSSL_RECORD_LAYER *rl,
+                                    OSSL_RECORD_TEMPLATE *templates,
+                                    size_t numtempl,
+                                    OSSL_RECORD_TEMPLATE *prefixtempl,
+                                    WPACKET *pkt,
+                                    SSL3_BUFFER *bufs,
+                                    size_t *wpinited);
 };
 
 struct ossl_record_layer_st
@@ -343,6 +364,26 @@ int tls_write_records_multiblock(OSSL_RECORD_LAYER *rl,
 
 size_t tls_get_max_records_default(OSSL_RECORD_LAYER *rl, int type, size_t len,
                                    size_t maxfrag, size_t *preffrag);
+int tls_allocate_write_buffers_default(OSSL_RECORD_LAYER *rl,
+                                       OSSL_RECORD_TEMPLATE *templates,
+                                       size_t numtempl, size_t *prefix);
+int tls_initialise_write_packets_default(OSSL_RECORD_LAYER *rl,
+                                         OSSL_RECORD_TEMPLATE *templates,
+                                         size_t numtempl,
+                                         OSSL_RECORD_TEMPLATE *prefixtempl,
+                                         WPACKET *pkt,
+                                         SSL3_BUFFER *bufs,
+                                         size_t *wpinited);
+int tls1_allocate_write_buffers(OSSL_RECORD_LAYER *rl,
+                                OSSL_RECORD_TEMPLATE *templates,
+                                size_t numtempl, size_t *prefix);
+int tls1_initialise_write_packets(OSSL_RECORD_LAYER *rl,
+                                  OSSL_RECORD_TEMPLATE *templates,
+                                  size_t numtempl,
+                                  OSSL_RECORD_TEMPLATE *prefixtempl,
+                                  WPACKET *pkt,
+                                  SSL3_BUFFER *bufs,
+                                  size_t *wpinited);
 size_t tls_get_max_records_multiblock(OSSL_RECORD_LAYER *rl, int type,
                                       size_t len, size_t maxfrag,
                                       size_t *preffrag);

--- a/ssl/record/methods/recmethod_local.h
+++ b/ssl/record/methods/recmethod_local.h
@@ -120,6 +120,16 @@ struct record_functions_st
                                   size_t mac_size,
                                   WPACKET *thispkt,
                                   SSL3_RECORD *thiswr);
+
+    /*
+     * Any updates required to the record after encryption has been applied. For
+     * example, adding a MAC if using encrypt-then-mac
+     */
+    int (*post_encryption_processing)(OSSL_RECORD_LAYER *rl,
+                                      size_t mac_size,
+                                      OSSL_RECORD_TEMPLATE *thistempl,
+                                      WPACKET *thispkt,
+                                      SSL3_RECORD *thiswr);
 };
 
 struct ossl_record_layer_st
@@ -421,6 +431,11 @@ int tls_prepare_for_encryption_default(OSSL_RECORD_LAYER *rl,
                                        size_t mac_size,
                                        WPACKET *thispkt,
                                        SSL3_RECORD *thiswr);
+int tls_post_encryption_processing_default(OSSL_RECORD_LAYER *rl,
+                                           size_t mac_size,
+                                           OSSL_RECORD_TEMPLATE *thistempl,
+                                           WPACKET *thispkt,
+                                           SSL3_RECORD *thiswr);
 int tls_write_records_default(OSSL_RECORD_LAYER *rl,
                               OSSL_RECORD_TEMPLATE *templates,
                               size_t numtempl);

--- a/ssl/record/methods/recmethod_local.h
+++ b/ssl/record/methods/recmethod_local.h
@@ -110,6 +110,16 @@ struct record_functions_st
                               OSSL_RECORD_TEMPLATE *thistempl,
                               WPACKET *thispkt,
                               SSL3_RECORD *thiswr);
+
+    /*
+     * This applies any mac that might be necessary, ensures that we have enough
+     * space in the WPACKET to perform the encryption and sets up the
+     * SSL3_RECORD ready for that encryption.
+     */
+    int (*prepare_for_encryption)(OSSL_RECORD_LAYER *rl,
+                                  size_t mac_size,
+                                  WPACKET *thispkt,
+                                  SSL3_RECORD *thiswr);
 };
 
 struct ossl_record_layer_st
@@ -407,6 +417,10 @@ int tls_prepare_record_header_default(OSSL_RECORD_LAYER *rl,
                                       OSSL_RECORD_TEMPLATE *templ,
                                       unsigned int rectype,
                                       unsigned char **recdata);
+int tls_prepare_for_encryption_default(OSSL_RECORD_LAYER *rl,
+                                       size_t mac_size,
+                                       WPACKET *thispkt,
+                                       SSL3_RECORD *thiswr);
 int tls_write_records_default(OSSL_RECORD_LAYER *rl,
                               OSSL_RECORD_TEMPLATE *templates,
                               size_t numtempl);

--- a/ssl/record/methods/recmethod_local.h
+++ b/ssl/record/methods/recmethod_local.h
@@ -140,6 +140,7 @@ struct ossl_record_layer_st
     /* Sequence number for the next record */
     unsigned char sequence[SEQ_NUM_SIZE];
 
+    /* Alert code to be used if an error occurs */
     int alert;
 
     /*

--- a/ssl/record/methods/recmethod_local.h
+++ b/ssl/record/methods/recmethod_local.h
@@ -99,6 +99,12 @@ struct record_functions_st
     /* Get the actual record type to be used for a given template */
     unsigned int (*get_record_type)(OSSL_RECORD_LAYER *rl,
                                     OSSL_RECORD_TEMPLATE *template);
+
+    /* Write the record header data to the WPACKET */
+    int (*prepare_record_header)(OSSL_RECORD_LAYER *rl, WPACKET *thispkt,
+                                 OSSL_RECORD_TEMPLATE *templ,
+                                 unsigned int rectype,
+                                 unsigned char **recdata);
 };
 
 struct ossl_record_layer_st
@@ -368,6 +374,9 @@ int tls_write_records_multiblock(OSSL_RECORD_LAYER *rl,
 
 size_t tls_get_max_records_default(OSSL_RECORD_LAYER *rl, int type, size_t len,
                                    size_t maxfrag, size_t *preffrag);
+size_t tls_get_max_records_multiblock(OSSL_RECORD_LAYER *rl, int type,
+                                      size_t len, size_t maxfrag,
+                                      size_t *preffrag);
 int tls_allocate_write_buffers_default(OSSL_RECORD_LAYER *rl,
                                        OSSL_RECORD_TEMPLATE *templates,
                                        size_t numtempl, size_t *prefix);
@@ -388,9 +397,11 @@ int tls1_initialise_write_packets(OSSL_RECORD_LAYER *rl,
                                   WPACKET *pkt,
                                   SSL3_BUFFER *bufs,
                                   size_t *wpinited);
-size_t tls_get_max_records_multiblock(OSSL_RECORD_LAYER *rl, int type,
-                                      size_t len, size_t maxfrag,
-                                      size_t *preffrag);
+int tls_prepare_record_header_default(OSSL_RECORD_LAYER *rl,
+                                      WPACKET *thispkt,
+                                      OSSL_RECORD_TEMPLATE *templ,
+                                      unsigned int rectype,
+                                      unsigned char **recdata);
 int tls_write_records_default(OSSL_RECORD_LAYER *rl,
                               OSSL_RECORD_TEMPLATE *templates,
                               size_t numtempl);

--- a/ssl/record/methods/recmethod_local.h
+++ b/ssl/record/methods/recmethod_local.h
@@ -130,6 +130,13 @@ struct record_functions_st
                                       OSSL_RECORD_TEMPLATE *thistempl,
                                       WPACKET *thispkt,
                                       SSL3_RECORD *thiswr);
+
+    /*
+     * Some record layer implementations need to do some custom preparation of
+     * the BIO before we write to it. KTLS does this to prevent coalescing of
+     * control and data messages.
+     */
+    int (*prepare_write_bio)(OSSL_RECORD_LAYER *rl, int type);
 };
 
 struct ossl_record_layer_st

--- a/ssl/record/methods/recmethod_local.h
+++ b/ssl/record/methods/recmethod_local.h
@@ -105,6 +105,11 @@ struct record_functions_st
                                  OSSL_RECORD_TEMPLATE *templ,
                                  unsigned int rectype,
                                  unsigned char **recdata);
+
+    int (*add_record_padding)(OSSL_RECORD_LAYER *rl,
+                              OSSL_RECORD_TEMPLATE *thistempl,
+                              WPACKET *thispkt,
+                              SSL3_RECORD *thiswr);
 };
 
 struct ossl_record_layer_st

--- a/ssl/record/methods/recmethod_local.h
+++ b/ssl/record/methods/recmethod_local.h
@@ -95,6 +95,10 @@ struct record_functions_st
                                     WPACKET *pkt,
                                     SSL3_BUFFER *bufs,
                                     size_t *wpinited);
+
+    /* Get the actual record type to be used for a given template */
+    unsigned int (*get_record_type)(OSSL_RECORD_LAYER *rl,
+                                    OSSL_RECORD_TEMPLATE *template);
 };
 
 struct ossl_record_layer_st

--- a/ssl/record/methods/ssl3_meth.c
+++ b/ssl/record/methods/ssl3_meth.c
@@ -316,5 +316,6 @@ struct record_functions_st ssl_3_0_funcs = {
     tls1_initialise_write_packets,
     NULL,
     tls_prepare_record_header_default,
-    NULL
+    NULL,
+    tls_prepare_for_encryption_default
 };

--- a/ssl/record/methods/ssl3_meth.c
+++ b/ssl/record/methods/ssl3_meth.c
@@ -318,5 +318,6 @@ struct record_functions_st ssl_3_0_funcs = {
     tls_prepare_record_header_default,
     NULL,
     tls_prepare_for_encryption_default,
-    tls_post_encryption_processing_default
+    tls_post_encryption_processing_default,
+    NULL
 };

--- a/ssl/record/methods/ssl3_meth.c
+++ b/ssl/record/methods/ssl3_meth.c
@@ -313,5 +313,6 @@ struct record_functions_st ssl_3_0_funcs = {
     tls_write_records_default,
     /* These 2 functions are defined in tls1_meth.c */
     tls1_allocate_write_buffers,
-    tls1_initialise_write_packets
+    tls1_initialise_write_packets,
+    NULL
 };

--- a/ssl/record/methods/ssl3_meth.c
+++ b/ssl/record/methods/ssl3_meth.c
@@ -315,5 +315,6 @@ struct record_functions_st ssl_3_0_funcs = {
     tls1_allocate_write_buffers,
     tls1_initialise_write_packets,
     NULL,
-    tls_prepare_record_header_default
+    tls_prepare_record_header_default,
+    NULL
 };

--- a/ssl/record/methods/ssl3_meth.c
+++ b/ssl/record/methods/ssl3_meth.c
@@ -317,5 +317,6 @@ struct record_functions_st ssl_3_0_funcs = {
     NULL,
     tls_prepare_record_header_default,
     NULL,
-    tls_prepare_for_encryption_default
+    tls_prepare_for_encryption_default,
+    tls_post_encryption_processing_default
 };

--- a/ssl/record/methods/ssl3_meth.c
+++ b/ssl/record/methods/ssl3_meth.c
@@ -310,5 +310,8 @@ struct record_functions_st ssl_3_0_funcs = {
     tls_default_validate_record_header,
     tls_default_post_process_record,
     tls_get_max_records_default,
-    tls_write_records_default
+    tls_write_records_default,
+    /* These 2 functions are defined in tls1_meth.c */
+    tls1_allocate_write_buffers,
+    tls1_initialise_write_packets
 };

--- a/ssl/record/methods/ssl3_meth.c
+++ b/ssl/record/methods/ssl3_meth.c
@@ -314,5 +314,6 @@ struct record_functions_st ssl_3_0_funcs = {
     /* These 2 functions are defined in tls1_meth.c */
     tls1_allocate_write_buffers,
     tls1_initialise_write_packets,
-    NULL
+    NULL,
+    tls_prepare_record_header_default
 };

--- a/ssl/record/methods/tls13_meth.c
+++ b/ssl/record/methods/tls13_meth.c
@@ -325,5 +325,6 @@ struct record_functions_st tls_1_3_funcs = {
     tls13_get_record_type,
     tls_prepare_record_header_default,
     tls13_add_record_padding,
-    tls_prepare_for_encryption_default
+    tls_prepare_for_encryption_default,
+    tls_post_encryption_processing_default
 };

--- a/ssl/record/methods/tls13_meth.c
+++ b/ssl/record/methods/tls13_meth.c
@@ -249,5 +249,7 @@ struct record_functions_st tls_1_3_funcs = {
     tls13_validate_record_header,
     tls13_post_process_record,
     tls_get_max_records_default,
-    tls_write_records_default
+    tls_write_records_default,
+    tls_allocate_write_buffers_default,
+    tls_initialise_write_packets_default
 };

--- a/ssl/record/methods/tls13_meth.c
+++ b/ssl/record/methods/tls13_meth.c
@@ -326,5 +326,6 @@ struct record_functions_st tls_1_3_funcs = {
     tls_prepare_record_header_default,
     tls13_add_record_padding,
     tls_prepare_for_encryption_default,
-    tls_post_encryption_processing_default
+    tls_post_encryption_processing_default,
+    NULL
 };

--- a/ssl/record/methods/tls13_meth.c
+++ b/ssl/record/methods/tls13_meth.c
@@ -239,6 +239,20 @@ static int tls13_post_process_record(OSSL_RECORD_LAYER *rl, SSL3_RECORD *rec)
     return 1;
 }
 
+static unsigned int tls13_get_record_type(OSSL_RECORD_LAYER *rl,
+                                          OSSL_RECORD_TEMPLATE *template)
+{
+    if (rl->allow_plain_alerts && template->type == SSL3_RT_ALERT)
+        return  SSL3_RT_ALERT;
+
+    /*
+     * Aside from the above case we always use the application data record type
+     * when encrypting in TLSv1.3. The "inner" record type encodes the "real"
+     * record type from the template.
+     */
+    return SSL3_RT_APPLICATION_DATA;
+}
+
 struct record_functions_st tls_1_3_funcs = {
     tls13_set_crypto_state,
     tls13_cipher,
@@ -251,5 +265,6 @@ struct record_functions_st tls_1_3_funcs = {
     tls_get_max_records_default,
     tls_write_records_default,
     tls_allocate_write_buffers_default,
-    tls_initialise_write_packets_default
+    tls_initialise_write_packets_default,
+    tls13_get_record_type
 };

--- a/ssl/record/methods/tls13_meth.c
+++ b/ssl/record/methods/tls13_meth.c
@@ -266,5 +266,6 @@ struct record_functions_st tls_1_3_funcs = {
     tls_write_records_default,
     tls_allocate_write_buffers_default,
     tls_initialise_write_packets_default,
-    tls13_get_record_type
+    tls13_get_record_type,
+    tls_prepare_record_header_default
 };

--- a/ssl/record/methods/tls13_meth.c
+++ b/ssl/record/methods/tls13_meth.c
@@ -324,5 +324,6 @@ struct record_functions_st tls_1_3_funcs = {
     tls_initialise_write_packets_default,
     tls13_get_record_type,
     tls_prepare_record_header_default,
-    tls13_add_record_padding
+    tls13_add_record_padding,
+    tls_prepare_for_encryption_default
 };

--- a/ssl/record/methods/tls1_meth.c
+++ b/ssl/record/methods/tls1_meth.c
@@ -655,7 +655,8 @@ struct record_functions_st tls_1_funcs = {
     tls_write_records_multiblock, /* Defined in tls_multib.c */
     tls1_allocate_write_buffers,
     tls1_initialise_write_packets,
-    NULL
+    NULL,
+    tls_prepare_record_header_default
 };
 
 struct record_functions_st dtls_1_funcs = {

--- a/ssl/record/methods/tls1_meth.c
+++ b/ssl/record/methods/tls1_meth.c
@@ -658,7 +658,8 @@ struct record_functions_st tls_1_funcs = {
     NULL,
     tls_prepare_record_header_default,
     NULL,
-    tls_prepare_for_encryption_default
+    tls_prepare_for_encryption_default,
+    tls_post_encryption_processing_default
 };
 
 struct record_functions_st dtls_1_funcs = {
@@ -668,6 +669,7 @@ struct record_functions_st dtls_1_funcs = {
     tls_default_set_protocol_version,
     tls_default_read_n,
     dtls_get_more_records,
+    NULL,
     NULL,
     NULL,
     NULL,

--- a/ssl/record/methods/tls1_meth.c
+++ b/ssl/record/methods/tls1_meth.c
@@ -657,7 +657,8 @@ struct record_functions_st tls_1_funcs = {
     tls1_initialise_write_packets,
     NULL,
     tls_prepare_record_header_default,
-    NULL
+    NULL,
+    tls_prepare_for_encryption_default
 };
 
 struct record_functions_st dtls_1_funcs = {
@@ -667,6 +668,7 @@ struct record_functions_st dtls_1_funcs = {
     tls_default_set_protocol_version,
     tls_default_read_n,
     dtls_get_more_records,
+    NULL,
     NULL,
     NULL,
     NULL,

--- a/ssl/record/methods/tls1_meth.c
+++ b/ssl/record/methods/tls1_meth.c
@@ -659,7 +659,8 @@ struct record_functions_st tls_1_funcs = {
     tls_prepare_record_header_default,
     NULL,
     tls_prepare_for_encryption_default,
-    tls_post_encryption_processing_default
+    tls_post_encryption_processing_default,
+    NULL
 };
 
 struct record_functions_st dtls_1_funcs = {
@@ -669,6 +670,7 @@ struct record_functions_st dtls_1_funcs = {
     tls_default_set_protocol_version,
     tls_default_read_n,
     dtls_get_more_records,
+    NULL,
     NULL,
     NULL,
     NULL,

--- a/ssl/record/methods/tls1_meth.c
+++ b/ssl/record/methods/tls1_meth.c
@@ -654,7 +654,8 @@ struct record_functions_st tls_1_funcs = {
     tls_get_max_records_multiblock,
     tls_write_records_multiblock, /* Defined in tls_multib.c */
     tls1_allocate_write_buffers,
-    tls1_initialise_write_packets
+    tls1_initialise_write_packets,
+    NULL
 };
 
 struct record_functions_st dtls_1_funcs = {
@@ -664,6 +665,7 @@ struct record_functions_st dtls_1_funcs = {
     tls_default_set_protocol_version,
     tls_default_read_n,
     dtls_get_more_records,
+    NULL,
     NULL,
     NULL,
     NULL,

--- a/ssl/record/methods/tls1_meth.c
+++ b/ssl/record/methods/tls1_meth.c
@@ -656,7 +656,8 @@ struct record_functions_st tls_1_funcs = {
     tls1_allocate_write_buffers,
     tls1_initialise_write_packets,
     NULL,
-    tls_prepare_record_header_default
+    tls_prepare_record_header_default,
+    NULL
 };
 
 struct record_functions_st dtls_1_funcs = {
@@ -666,6 +667,7 @@ struct record_functions_st dtls_1_funcs = {
     tls_default_set_protocol_version,
     tls_default_read_n,
     dtls_get_more_records,
+    NULL,
     NULL,
     NULL,
     NULL,

--- a/ssl/record/methods/tls_common.c
+++ b/ssl/record/methods/tls_common.c
@@ -322,8 +322,13 @@ int tls_default_read_n(OSSL_RECORD_LAYER *rl, size_t n, size_t max, int extend,
      * the buffer).
      */
     if (rl->isdtls) {
-        if (left == 0 && extend)
-            return 0;
+        if (left == 0 && extend) {
+            /*
+             * We received a record with a header but no body data. This will
+             * get dumped.
+             */
+            return OSSL_RECORD_RETURN_NON_FATAL_ERR;
+        }
         if (left > 0 && n > left)
             n = left;
     }

--- a/ssl/record/methods/tls_common.c
+++ b/ssl/record/methods/tls_common.c
@@ -158,27 +158,24 @@ int tls_setup_write_buffer(OSSL_RECORD_LAYER *rl, size_t numwpipes,
             thiswb->buf = NULL;         /* force reallocation */
         }
 
-        if (thiswb->buf == NULL) {
-            if (rl->bio == NULL || !BIO_get_ktls_send(rl->bio)) {
-                p = OPENSSL_malloc(len);
-                if (p == NULL) {
-                    if (rl->numwpipes < currpipe)
-                        rl->numwpipes = currpipe;
-                    /*
-                     * We've got a malloc failure, and we're still initialising
-                     * buffers. We assume we're so doomed that we won't even be able
-                     * to send an alert.
-                     */
-                    RLAYERfatal(rl, SSL_AD_NO_ALERT, ERR_R_CRYPTO_LIB);
-                    return 0;
-                }
-            } else {
-                p = NULL;
+        p = thiswb->buf;
+        if (p == NULL) {
+            p = OPENSSL_malloc(len);
+            if (p == NULL) {
+                if (rl->numwpipes < currpipe)
+                    rl->numwpipes = currpipe;
+                /*
+                 * We've got a malloc failure, and we're still initialising
+                 * buffers. We assume we're so doomed that we won't even be able
+                 * to send an alert.
+                 */
+                RLAYERfatal(rl, SSL_AD_NO_ALERT, ERR_R_CRYPTO_LIB);
+                return 0;
             }
-            memset(thiswb, 0, sizeof(SSL3_BUFFER));
-            thiswb->buf = p;
-            thiswb->len = len;
         }
+        memset(thiswb, 0, sizeof(SSL3_BUFFER));
+        thiswb->buf = p;
+        thiswb->len = len;
     }
 
     /* Free any previously allocated buffers that we are no longer using */

--- a/ssl/record/methods/tls_common.c
+++ b/ssl/record/methods/tls_common.c
@@ -1587,14 +1587,11 @@ int tls_write_records_default(OSSL_RECORD_LAYER *rl,
         thistempl = (j < prefix) ? &prefixtempl : &templates[j - prefix];
 
         /*
-         * In TLSv1.3, once encrypting, we always use application data for the
-         * record type
+         * Default to the record type as specified in the template unless the
+         * protocol implementation says differently.
          */
-        if (rl->version == TLS1_3_VERSION
-                && rl->enc_ctx != NULL
-                && (!rl->allow_plain_alerts
-                    || thistempl->type != SSL3_RT_ALERT))
-            rectype = SSL3_RT_APPLICATION_DATA;
+        if (rl->funcs->get_record_type != NULL)
+            rectype = rl->funcs->get_record_type(rl, thistempl);
         else
             rectype = thistempl->type;
 

--- a/ssl/record/methods/tls_common.c
+++ b/ssl/record/methods/tls_common.c
@@ -1750,23 +1750,20 @@ int tls_write_records_default(OSSL_RECORD_LAYER *rl,
         }
     }
 
-    if (!using_ktls) {
-        if (prefix) {
-            if (rl->funcs->cipher(rl, wr, 1, 1, NULL, mac_size) < 1) {
-                if (rl->alert == SSL_AD_NO_ALERT) {
-                    RLAYERfatal(rl, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
-                }
-                goto err;
-            }
-        }
-
-        if (rl->funcs->cipher(rl, wr + prefix, numtempl, 1, NULL,
-                                mac_size) < 1) {
+    if (prefix) {
+        if (rl->funcs->cipher(rl, wr, 1, 1, NULL, mac_size) < 1) {
             if (rl->alert == SSL_AD_NO_ALERT) {
                 RLAYERfatal(rl, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
             }
             goto err;
         }
+    }
+
+    if (rl->funcs->cipher(rl, wr + prefix, numtempl, 1, NULL, mac_size) < 1) {
+        if (rl->alert == SSL_AD_NO_ALERT) {
+            RLAYERfatal(rl, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
+        }
+        goto err;
     }
 
     for (j = 0; j < numtempl + prefix; j++) {

--- a/ssl/record/methods/tls_common.c
+++ b/ssl/record/methods/tls_common.c
@@ -1623,7 +1623,7 @@ int tls_write_records_default(OSSL_RECORD_LAYER *rl,
          */
         if (rl->version == TLS1_3_VERSION
                 && rl->enc_ctx != NULL
-                && (s->statem.enc_write_state != ENC_WRITE_STATE_WRITE_PLAIN_ALERTS
+                && (!rl->allow_plain_alerts
                     || thistempl->type != SSL3_RT_ALERT))
             rectype = SSL3_RT_APPLICATION_DATA;
         else
@@ -1686,7 +1686,7 @@ int tls_write_records_default(OSSL_RECORD_LAYER *rl,
         if (rl->version == TLS1_3_VERSION
                 && !using_ktls
                 && rl->enc_ctx != NULL
-                && (s->statem.enc_write_state != ENC_WRITE_STATE_WRITE_PLAIN_ALERTS
+                && (!rl->allow_plain_alerts
                     || thistempl->type != SSL3_RT_ALERT)) {
             size_t rlen, max_send_fragment;
 
@@ -1779,7 +1779,7 @@ int tls_write_records_default(OSSL_RECORD_LAYER *rl,
     if (!using_ktls) {
         if (prefix) {
             if (rl->funcs->cipher(rl, wr, 1, 1, NULL, mac_size) < 1) {
-                if (!ossl_statem_in_error(s)) {
+                if (rl->alert == SSL_AD_NO_ALERT) {
                     RLAYERfatal(rl, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
                 }
                 goto err;
@@ -1788,7 +1788,7 @@ int tls_write_records_default(OSSL_RECORD_LAYER *rl,
 
         if (rl->funcs->cipher(rl, wr + prefix, numtempl, 1, NULL,
                                 mac_size) < 1) {
-            if (!ossl_statem_in_error(s)) {
+            if (rl->alert == SSL_AD_NO_ALERT) {
                 RLAYERfatal(rl, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
             }
             goto err;

--- a/ssl/record/methods/tls_common.c
+++ b/ssl/record/methods/tls_common.c
@@ -1612,6 +1612,68 @@ int tls_prepare_for_encryption_default(OSSL_RECORD_LAYER *rl,
     return 1;
 }
 
+int tls_post_encryption_processing_default(OSSL_RECORD_LAYER *rl,
+                                           size_t mac_size,
+                                           OSSL_RECORD_TEMPLATE *thistempl,
+                                           WPACKET *thispkt,
+                                           SSL3_RECORD *thiswr)
+{
+    size_t origlen, len;
+
+    /* Allocate bytes for the encryption overhead */
+    if (!WPACKET_get_length(thispkt, &origlen)
+                /* Encryption should never shrink the data! */
+            || origlen > thiswr->length
+            || (thiswr->length > origlen
+                && !WPACKET_allocate_bytes(thispkt,
+                                            thiswr->length - origlen,
+                                            NULL))) {
+        RLAYERfatal(rl, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
+        return 0;
+    }
+    if (rl->use_etm && mac_size != 0) {
+        unsigned char *mac;
+
+        if (!WPACKET_allocate_bytes(thispkt, mac_size, &mac)
+                || !rl->funcs->mac(rl, thiswr, mac, 1)) {
+            RLAYERfatal(rl, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
+            return 0;
+        }
+
+        SSL3_RECORD_add_length(thiswr, mac_size);
+    }
+
+    if (!WPACKET_get_length(thispkt, &len)
+            || !WPACKET_close(thispkt)) {
+        RLAYERfatal(rl, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
+        return 0;
+    }
+
+    if (rl->msg_callback != NULL) {
+        unsigned char *recordstart;
+
+        recordstart = WPACKET_get_curr(thispkt) - len - SSL3_RT_HEADER_LENGTH;
+        rl->msg_callback(1, thiswr->rec_version, SSL3_RT_HEADER, recordstart,
+                         SSL3_RT_HEADER_LENGTH, rl->cbarg);
+
+        if (rl->version == TLS1_3_VERSION && rl->enc_ctx != NULL) {
+            unsigned char ctype = thistempl->type;
+
+            rl->msg_callback(1, thiswr->rec_version, SSL3_RT_INNER_CONTENT_TYPE,
+                             &ctype, 1, rl->cbarg);
+        }
+    }
+
+    if (!WPACKET_finish(thispkt)) {
+        RLAYERfatal(rl, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
+        return 0;
+    }
+
+    SSL3_RECORD_add_length(thiswr, SSL3_RT_HEADER_LENGTH);
+
+    return 1;
+}
+
 int tls_write_records_default(OSSL_RECORD_LAYER *rl,
                               OSSL_RECORD_TEMPLATE *templates,
                               size_t numtempl)
@@ -1620,11 +1682,9 @@ int tls_write_records_default(OSSL_RECORD_LAYER *rl,
     SSL3_RECORD wr[SSL_MAX_PIPELINES + 1];
     WPACKET *thispkt;
     SSL3_RECORD *thiswr;
-    unsigned char *recordstart;
     int mac_size = 0, ret = 0;
-    size_t len, wpinited = 0;
+    size_t wpinited = 0;
     size_t j, prefix = 0;
-    int using_ktls;
     OSSL_RECORD_TEMPLATE prefixtempl;
     OSSL_RECORD_TEMPLATE *thistempl;
 
@@ -1645,12 +1705,6 @@ int tls_write_records_default(OSSL_RECORD_LAYER *rl,
                                              &prefixtempl, pkt, rl->wbuf,
                                              &wpinited)) {
         /* RLAYERfatal() already called */
-        goto err;
-    }
-
-    using_ktls = BIO_get_ktls_send(rl->bio);
-    if (!ossl_assert(!using_ktls || !prefix)) {
-        RLAYERfatal(rl, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
         goto err;
     }
 
@@ -1738,67 +1792,16 @@ int tls_write_records_default(OSSL_RECORD_LAYER *rl,
     }
 
     for (j = 0; j < numtempl + prefix; j++) {
-        size_t origlen;
-
         thispkt = &pkt[j];
         thiswr = &wr[j];
         thistempl = (j < prefix) ? &prefixtempl : &templates[j - prefix];
 
-        if (using_ktls)
-            goto mac_done;
-
-        /* Allocate bytes for the encryption overhead */
-        if (!WPACKET_get_length(thispkt, &origlen)
-                   /* Encryption should never shrink the data! */
-                || origlen > thiswr->length
-                || (thiswr->length > origlen
-                    && !WPACKET_allocate_bytes(thispkt,
-                                               thiswr->length - origlen,
-                                               NULL))) {
-            RLAYERfatal(rl, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
-            goto err;
-        }
-        if (rl->use_etm && mac_size != 0) {
-            unsigned char *mac;
-
-            if (!WPACKET_allocate_bytes(thispkt, mac_size, &mac)
-                    || !rl->funcs->mac(rl, thiswr, mac, 1)) {
-                RLAYERfatal(rl, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
-                goto err;
-            }
-
-            SSL3_RECORD_add_length(thiswr, mac_size);
-        }
-
-        if (!WPACKET_get_length(thispkt, &len)
-                || !WPACKET_close(thispkt)) {
-            RLAYERfatal(rl, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
+        if (!rl->funcs->post_encryption_processing(rl, mac_size, thistempl,
+                                                   thispkt, thiswr)) {
+            /* RLAYERfatal() already called */
             goto err;
         }
 
-        if (rl->msg_callback) {
-            recordstart = WPACKET_get_curr(thispkt) - len
-                          - SSL3_RT_HEADER_LENGTH;
-            rl->msg_callback(1, thiswr->rec_version, SSL3_RT_HEADER, recordstart,
-                             SSL3_RT_HEADER_LENGTH, rl->cbarg);
-
-            if (rl->version == TLS1_3_VERSION && rl->enc_ctx != NULL) {
-                unsigned char ctype = thistempl->type;
-
-                rl->msg_callback(1, thiswr->rec_version, SSL3_RT_INNER_CONTENT_TYPE,
-                                 &ctype, 1, rl->cbarg);
-            }
-        }
-
-        if (!WPACKET_finish(thispkt)) {
-            RLAYERfatal(rl, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
-            goto err;
-        }
-
-        /* header is added by the kernel when using offload */
-        SSL3_RECORD_add_length(thiswr, SSL3_RT_HEADER_LENGTH);
-
- mac_done:
         /*
          * we should now have thiswr->data pointing to the encrypted data, which
          * is thiswr->length long.

--- a/ssl/record/methods/tls_common.c
+++ b/ssl/record/methods/tls_common.c
@@ -1624,12 +1624,12 @@ int tls_post_encryption_processing_default(OSSL_RECORD_LAYER *rl,
 
     /* Allocate bytes for the encryption overhead */
     if (!WPACKET_get_length(thispkt, &origlen)
-                /* Encryption should never shrink the data! */
+            /* Encryption should never shrink the data! */
             || origlen > thiswr->length
             || (thiswr->length > origlen
                 && !WPACKET_allocate_bytes(thispkt,
-                                            thiswr->length - origlen,
-                                            NULL))) {
+                                           thiswr->length - origlen,
+                                           NULL))) {
         RLAYERfatal(rl, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
         return 0;
     }

--- a/ssl/record/methods/tlsany_meth.c
+++ b/ssl/record/methods/tlsany_meth.c
@@ -159,7 +159,8 @@ struct record_functions_st tls_any_funcs = {
     NULL,
     tls_prepare_record_header_default,
     NULL,
-    tls_any_prepare_for_encryption
+    tls_any_prepare_for_encryption,
+    tls_post_encryption_processing_default
 };
 
 static int dtls_any_set_protocol_version(OSSL_RECORD_LAYER *rl, int vers)
@@ -178,6 +179,7 @@ struct record_functions_st dtls_any_funcs = {
     dtls_any_set_protocol_version,
     tls_default_read_n,
     dtls_get_more_records,
+    NULL,
     NULL,
     NULL,
     NULL,

--- a/ssl/record/methods/tlsany_meth.c
+++ b/ssl/record/methods/tlsany_meth.c
@@ -144,7 +144,9 @@ struct record_functions_st tls_any_funcs = {
     tls_validate_record_header,
     tls_default_post_process_record,
     tls_get_max_records_default,
-    tls_write_records_default
+    tls_write_records_default,
+    tls_allocate_write_buffers_default,
+    tls_initialise_write_packets_default
 };
 
 static int dtls_any_set_protocol_version(OSSL_RECORD_LAYER *rl, int vers)
@@ -163,6 +165,8 @@ struct record_functions_st dtls_any_funcs = {
     dtls_any_set_protocol_version,
     tls_default_read_n,
     dtls_get_more_records,
+    NULL,
+    NULL,
     NULL,
     NULL,
     NULL,

--- a/ssl/record/methods/tlsany_meth.c
+++ b/ssl/record/methods/tlsany_meth.c
@@ -148,7 +148,8 @@ struct record_functions_st tls_any_funcs = {
     tls_allocate_write_buffers_default,
     tls_initialise_write_packets_default,
     NULL,
-    tls_prepare_record_header_default
+    tls_prepare_record_header_default,
+    NULL
 };
 
 static int dtls_any_set_protocol_version(OSSL_RECORD_LAYER *rl, int vers)
@@ -167,6 +168,7 @@ struct record_functions_st dtls_any_funcs = {
     dtls_any_set_protocol_version,
     tls_default_read_n,
     dtls_get_more_records,
+    NULL,
     NULL,
     NULL,
     NULL,

--- a/ssl/record/methods/tlsany_meth.c
+++ b/ssl/record/methods/tlsany_meth.c
@@ -160,7 +160,8 @@ struct record_functions_st tls_any_funcs = {
     tls_prepare_record_header_default,
     NULL,
     tls_any_prepare_for_encryption,
-    tls_post_encryption_processing_default
+    tls_post_encryption_processing_default,
+    NULL
 };
 
 static int dtls_any_set_protocol_version(OSSL_RECORD_LAYER *rl, int vers)
@@ -179,6 +180,7 @@ struct record_functions_st dtls_any_funcs = {
     dtls_any_set_protocol_version,
     tls_default_read_n,
     dtls_get_more_records,
+    NULL,
     NULL,
     NULL,
     NULL,

--- a/ssl/record/methods/tlsany_meth.c
+++ b/ssl/record/methods/tlsany_meth.c
@@ -146,7 +146,8 @@ struct record_functions_st tls_any_funcs = {
     tls_get_max_records_default,
     tls_write_records_default,
     tls_allocate_write_buffers_default,
-    tls_initialise_write_packets_default
+    tls_initialise_write_packets_default,
+    NULL
 };
 
 static int dtls_any_set_protocol_version(OSSL_RECORD_LAYER *rl, int vers)
@@ -165,6 +166,7 @@ struct record_functions_st dtls_any_funcs = {
     dtls_any_set_protocol_version,
     tls_default_read_n,
     dtls_get_more_records,
+    NULL,
     NULL,
     NULL,
     NULL,

--- a/ssl/record/methods/tlsany_meth.c
+++ b/ssl/record/methods/tlsany_meth.c
@@ -147,7 +147,8 @@ struct record_functions_st tls_any_funcs = {
     tls_write_records_default,
     tls_allocate_write_buffers_default,
     tls_initialise_write_packets_default,
-    NULL
+    NULL,
+    tls_prepare_record_header_default
 };
 
 static int dtls_any_set_protocol_version(OSSL_RECORD_LAYER *rl, int vers)
@@ -166,6 +167,7 @@ struct record_functions_st dtls_any_funcs = {
     dtls_any_set_protocol_version,
     tls_default_read_n,
     dtls_get_more_records,
+    NULL,
     NULL,
     NULL,
     NULL,

--- a/ssl/record/methods/tlsany_meth.c
+++ b/ssl/record/methods/tlsany_meth.c
@@ -134,6 +134,15 @@ static int tls_any_set_protocol_version(OSSL_RECORD_LAYER *rl, int vers)
     return 1;
 }
 
+static int tls_any_prepare_for_encryption(OSSL_RECORD_LAYER *rl,
+                                          size_t mac_size,
+                                          WPACKET *thispkt,
+                                          SSL3_RECORD *thiswr)
+{
+    /* No encryption, so nothing to do */
+    return 1;
+}
+
 struct record_functions_st tls_any_funcs = {
     tls_any_set_crypto_state,
     tls_any_cipher,
@@ -149,7 +158,8 @@ struct record_functions_st tls_any_funcs = {
     tls_initialise_write_packets_default,
     NULL,
     tls_prepare_record_header_default,
-    NULL
+    NULL,
+    tls_any_prepare_for_encryption
 };
 
 static int dtls_any_set_protocol_version(OSSL_RECORD_LAYER *rl, int vers)
@@ -168,6 +178,7 @@ struct record_functions_st dtls_any_funcs = {
     dtls_any_set_protocol_version,
     tls_default_read_n,
     dtls_get_more_records,
+    NULL,
     NULL,
     NULL,
     NULL,

--- a/ssl/record/rec_layer_s3.c
+++ b/ssl/record/rec_layer_s3.c
@@ -1226,7 +1226,6 @@ int ssl_set_new_record_layer(SSL_CONNECTION *s, int version,
      * using the early keys. A server also needs to worry about rejected early
      * data that might arrive when the handshake keys are in force.
      */
-    /* TODO(RECLAYER): Check this when doing the "write" record layer */
     if (s->server && direction == OSSL_RECORD_DIRECTION_READ) {
         use_early_data = (level == OSSL_RECORD_PROTECTION_LEVEL_EARLY
                           || level == OSSL_RECORD_PROTECTION_LEVEL_HANDSHAKE);

--- a/ssl/record/rec_layer_s3.c
+++ b/ssl/record/rec_layer_s3.c
@@ -1062,6 +1062,7 @@ static const OSSL_DISPATCH rlayer_dispatch[] = {
 };
 
 static const OSSL_RECORD_METHOD *ssl_select_next_record_layer(SSL_CONNECTION *s,
+                                                              int direction,
                                                               int level)
 {
 
@@ -1081,7 +1082,8 @@ static const OSSL_RECORD_METHOD *ssl_select_next_record_layer(SSL_CONNECTION *s,
 #endif
 
     /* Default to the current OSSL_RECORD_METHOD */
-    return s->rlayer.rrlmethod;
+    return direction == OSSL_RECORD_DIRECTION_READ ? s->rlayer.rrlmethod
+                                                   : s->rlayer.wrlmethod;
 }
 
 static int ssl_post_record_layer_select(SSL_CONNECTION *s, int direction)
@@ -1138,7 +1140,7 @@ int ssl_set_new_record_layer(SSL_CONNECTION *s, int version,
     uint32_t max_early_data;
     COMP_METHOD *compm = (comp == NULL) ? NULL : comp->method;
 
-    meth = ssl_select_next_record_layer(s, level);
+    meth = ssl_select_next_record_layer(s, direction, level);
 
     if (direction == OSSL_RECORD_DIRECTION_READ) {
         thismethod = &s->rlayer.rrlmethod;

--- a/ssl/record/rec_layer_s3.c
+++ b/ssl/record/rec_layer_s3.c
@@ -1135,7 +1135,9 @@ int ssl_set_new_record_layer(SSL_CONNECTION *s, int version,
     SSL_CTX *sctx = SSL_CONNECTION_GET_CTX(s);
     const OSSL_RECORD_METHOD *meth;
     int use_etm, stream_mac = 0, tlstree = 0;
-    unsigned int maxfrag = SSL3_RT_MAX_PLAIN_LENGTH;
+    unsigned int maxfrag = (direction == OSSL_RECORD_DIRECTION_WRITE)
+                           ? ssl_get_max_send_fragment(s)
+                           : SSL3_RT_MAX_PLAIN_LENGTH;
     int use_early_data = 0;
     uint32_t max_early_data;
     COMP_METHOD *compm = (comp == NULL) ? NULL : comp->method;
@@ -1205,8 +1207,15 @@ int ssl_set_new_record_layer(SSL_CONNECTION *s, int version,
         *set++ = OSSL_PARAM_construct_int(OSSL_LIBSSL_RECORD_LAYER_PARAM_TLSTREE,
                                           &tlstree);
 
-    if (s->session != NULL && USE_MAX_FRAGMENT_LENGTH_EXT(s->session))
+    /*
+     * We only need to do this for the read side. The write side should already
+     * have the correct value due to the ssl_get_max_send_fragment() call above
+     */
+    if (direction == OSSL_RECORD_DIRECTION_READ
+            && s->session != NULL
+            && USE_MAX_FRAGMENT_LENGTH_EXT(s->session))
         maxfrag = GET_MAX_FRAGMENT_LENGTH(s->session);
+
 
     if (maxfrag != SSL3_RT_MAX_PLAIN_LENGTH)
         *set++ = OSSL_PARAM_construct_uint(OSSL_LIBSSL_RECORD_LAYER_PARAM_MAX_FRAG_LEN,

--- a/ssl/record/recordmethod.h
+++ b/ssl/record/recordmethod.h
@@ -302,6 +302,13 @@ struct ossl_record_method_st {
     int (*set_options)(OSSL_RECORD_LAYER *rl, const OSSL_PARAM *options);
 
     const COMP_METHOD *(*get_compression)(OSSL_RECORD_LAYER *rl);
+
+    /*
+     * Set the maximum fragment length to be used for the record layer. This
+     * will override any previous value supplied for the "max_frag_len"
+     * setting during construction of the record layer.
+     */
+    void (*set_max_frag_len)(OSSL_RECORD_LAYER *rl, size_t max_frag_len);
 };
 
 

--- a/ssl/s3_enc.c
+++ b/ssl/s3_enc.c
@@ -143,9 +143,6 @@ int ssl3_change_cipher_state(SSL_CONNECTION *s, int which)
         goto err;
     }
 
-    if ((which & SSL3_CC_WRITE) != 0)
-        s->statem.enc_write_state = ENC_WRITE_STATE_INVALID;
-
     if (!ssl_set_new_record_layer(s, SSL3_VERSION,
                                   direction,
                                   OSSL_RECORD_PROTECTION_LEVEL_APPLICATION,
@@ -155,7 +152,6 @@ int ssl3_change_cipher_state(SSL_CONNECTION *s, int which)
         goto err;
     }
 
-    s->statem.enc_write_state = ENC_WRITE_STATE_VALID;
     return 1;
  err:
     return 0;

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -2789,6 +2789,7 @@ long SSL_ctrl(SSL *s, int cmd, long larg, void *parg)
         sc->max_send_fragment = larg;
         if (sc->max_send_fragment < sc->split_send_fragment)
             sc->split_send_fragment = sc->max_send_fragment;
+        sc->rlayer.wrlmethod->set_max_frag_len(sc->rlayer.wrl, larg);
         return 1;
     case SSL_CTRL_SET_SPLIT_SEND_FRAGMENT:
         if ((size_t)larg > sc->max_send_fragment || larg == 0)

--- a/ssl/ssl_local.h
+++ b/ssl/ssl_local.h
@@ -2854,18 +2854,6 @@ __owur int ssl_log_secret(SSL_CONNECTION *s, const char *label,
 #define EARLY_EXPORTER_SECRET_LABEL "EARLY_EXPORTER_SECRET"
 #define EXPORTER_SECRET_LABEL "EXPORTER_SECRET"
 
-#  ifndef OPENSSL_NO_KTLS
-/* ktls.c */
-int ktls_check_supported_cipher(const SSL_CONNECTION *s, const EVP_CIPHER *c,
-                                const EVP_MD *md, size_t taglen);
-int ktls_configure_crypto(OSSL_LIB_CTX *libctx, int version,
-                          const EVP_CIPHER *c, const EVP_MD *md,
-                          void *rl_sequence, ktls_crypto_info_t *crypto_info,
-                          int is_tx, unsigned char *iv, size_t ivlen,
-                          unsigned char *key, size_t keylen,
-                          unsigned char *mac_key, size_t mac_secret_size);
-#  endif
-
 __owur int srp_generate_server_master_secret(SSL_CONNECTION *s);
 __owur int srp_generate_client_master_secret(SSL_CONNECTION *s);
 __owur int srp_verify_server_param(SSL_CONNECTION *s);

--- a/ssl/statem/statem.c
+++ b/ssl/statem/statem.c
@@ -143,8 +143,7 @@ void ossl_statem_send_fatal(SSL_CONNECTION *s, int al)
       return;
     ossl_statem_set_in_init(s, 1);
     s->statem.state = MSG_FLOW_ERROR;
-    if (al != SSL_AD_NO_ALERT
-            && s->statem.enc_write_state != ENC_WRITE_STATE_INVALID)
+    if (al != SSL_AD_NO_ALERT)
         ssl3_send_alert(s, SSL3_AL_FATAL, al);
 }
 

--- a/ssl/statem/statem.h
+++ b/ssl/statem/statem.h
@@ -72,15 +72,6 @@ typedef enum {
 } WRITE_STATE;
 
 typedef enum {
-    /* The enc_write_ctx can be used normally */
-    ENC_WRITE_STATE_VALID,
-    /* The enc_write_ctx cannot be used */
-    ENC_WRITE_STATE_INVALID,
-    /* Write alerts in plaintext, but otherwise use the enc_write_ctx */
-    ENC_WRITE_STATE_WRITE_PLAIN_ALERTS
-} ENC_WRITE_STATES;
-
-typedef enum {
     CON_FUNC_ERROR = 0,
     CON_FUNC_SUCCESS,
     CON_FUNC_DONT_SEND
@@ -115,7 +106,6 @@ struct ossl_statem_st {
     /* Should we skip the CertificateVerify message? */
     unsigned int no_cert_verify;
     int use_timer;
-    ENC_WRITE_STATES enc_write_state;
 };
 typedef struct ossl_statem_st OSSL_STATEM;
 

--- a/ssl/t1_enc.c
+++ b/ssl/t1_enc.c
@@ -250,7 +250,6 @@ int tls1_change_cipher_state(SSL_CONNECTION *s, int which)
         /* TODO(RECLAYER): Temporary - remove me when DTLS write rlayer done*/
         goto done;
     } else {
-        s->statem.enc_write_state = ENC_WRITE_STATE_INVALID;
         if (s->ext.use_etm)
             s->s3.flags |= TLS1_FLAGS_ENCRYPT_THEN_MAC_WRITE;
         else
@@ -390,8 +389,6 @@ int tls1_change_cipher_state(SSL_CONNECTION *s, int which)
     }
 
  done:
-    s->statem.enc_write_state = ENC_WRITE_STATE_VALID;
-
     OSSL_TRACE_BEGIN(TLS) {
         BIO_printf(trc_out, "which = %04X, key:\n", which);
         BIO_dump_indent(trc_out, key, EVP_CIPHER_get_key_length(c), 4);

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -1073,14 +1073,8 @@ static int ping_pong_query(SSL *clientssl, SSL *serverssl)
         goto end;
 
     cbuf[0] = count++;
-    /* TODO(RECLAYER): Remove me once TLSv1.3 write side converted */
-    if (SSL_CONNECTION_IS_TLS13(serversc)) {
-        memcpy(crec_wseq_before, &clientsc->rlayer.write_sequence, SEQ_NUM_SIZE);
-        memcpy(srec_wseq_before, &serversc->rlayer.write_sequence, SEQ_NUM_SIZE);
-    } else {
-        memcpy(crec_wseq_before, &clientsc->rlayer.wrl->sequence, SEQ_NUM_SIZE);
-        memcpy(srec_wseq_before, &serversc->rlayer.wrl->sequence, SEQ_NUM_SIZE);
-    }
+    memcpy(crec_wseq_before, &clientsc->rlayer.wrl->sequence, SEQ_NUM_SIZE);
+    memcpy(srec_wseq_before, &serversc->rlayer.wrl->sequence, SEQ_NUM_SIZE);
     memcpy(crec_rseq_before, &clientsc->rlayer.rrl->sequence, SEQ_NUM_SIZE);
     memcpy(srec_rseq_before, &serversc->rlayer.rrl->sequence, SEQ_NUM_SIZE);
 
@@ -1102,14 +1096,8 @@ static int ping_pong_query(SSL *clientssl, SSL *serverssl)
         }
     }
 
-    /* TODO(RECLAYER): Remove me once TLSv1.3 write side converted */
-    if (SSL_CONNECTION_IS_TLS13(serversc)) {
-        memcpy(crec_wseq_after, &clientsc->rlayer.write_sequence, SEQ_NUM_SIZE);
-        memcpy(srec_wseq_after, &serversc->rlayer.write_sequence, SEQ_NUM_SIZE);
-    } else {
-        memcpy(crec_wseq_after, &clientsc->rlayer.wrl->sequence, SEQ_NUM_SIZE);
-        memcpy(srec_wseq_after, &serversc->rlayer.wrl->sequence, SEQ_NUM_SIZE);
-    }
+    memcpy(crec_wseq_after, &clientsc->rlayer.wrl->sequence, SEQ_NUM_SIZE);
+    memcpy(srec_wseq_after, &serversc->rlayer.wrl->sequence, SEQ_NUM_SIZE);
     memcpy(crec_rseq_after, &clientsc->rlayer.rrl->sequence, SEQ_NUM_SIZE);
     memcpy(srec_rseq_after, &serversc->rlayer.rrl->sequence, SEQ_NUM_SIZE);
 


### PR DESCRIPTION
This is built on top of #19217 and includes those commits. This converts the TLSv1.3 code and all remaining KTLS code to use the new write record layer.