### PR TITLE
Align util/libcrypto.num with the openssl-3.0 branch

### DIFF
--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5425,6 +5425,8 @@ ASN1_item_d2i_ex                        5552	3_0_0	EXIST::FUNCTION:
 ASN1_TIME_print_ex                      5553	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_get0_provider                  5554	3_0_0	EXIST::FUNCTION:
 EVP_PKEY_CTX_get0_provider              5555	3_0_0	EXIST::FUNCTION:
+OPENSSL_strcasecmp                      5556	3_0_3	EXIST::FUNCTION:
+OPENSSL_strncasecmp                     5557	3_0_3	EXIST::FUNCTION:
 X509_PUBKEY_set0_public_key             ?	3_2_0	EXIST::FUNCTION:
 OSSL_STACK_OF_X509_free                 ?	3_2_0	EXIST::FUNCTION:
 EVP_MD_CTX_dup                          ?	3_2_0	EXIST::FUNCTION:
@@ -5446,8 +5448,6 @@ CMS_EnvelopedData_decrypt               ?	3_2_0	EXIST::FUNCTION:CMS
 CMS_SignedData_free                     ?	3_2_0	EXIST::FUNCTION:CMS
 CMS_SignedData_new                      ?	3_2_0	EXIST::FUNCTION:CMS
 CMS_SignedData_verify                   ?	3_2_0	EXIST::FUNCTION:CMS
-OPENSSL_strcasecmp                      ?	3_0_3	EXIST::FUNCTION:
-OPENSSL_strncasecmp                     ?	3_0_3	EXIST::FUNCTION:
 BIO_s_dgram_mem                         ?	3_2_0	EXIST::FUNCTION:
 BIO_recvmmsg                            ?	3_2_0	EXIST::FUNCTION:
 BIO_sendmmsg                            ?	3_2_0	EXIST::FUNCTION:


### PR DESCRIPTION
OPENSSL_strcasecmp() and OPENSSL_strncasecmp() appeared in OpenSSL 3.0.3,
and were assigned numbers in util/libcrypto.num.  These numbers must be
transported up to the master branch as long as development of OpenSSL 3.x
is going on there (as indicated by the version info found in VERSION.dat).
