### PR TITLE
Fix crypto/dso/dso_vms.c

### DIFF
--- a/crypto/dso/dso_vms.c
+++ b/crypto/dso/dso_vms.c
@@ -106,9 +106,12 @@ static int vms_load(DSO *dso)
 #   pragma pointer_size save
 #   pragma pointer_size 32
 #  endif                        /* __INITIAL_POINTER_SIZE == 64 */
+# endif                         /* __INITIAL_POINTER_SIZE && defined
+                                 * _ANSI_C_SOURCE */
 
     DSO_VMS_INTERNAL *p = NULL;
 
+# if __INITIAL_POINTER_SIZE && defined _ANSI_C_SOURCE
 #  if __INITIAL_POINTER_SIZE == 64
 #   pragma pointer_size restore
 #  endif                        /* __INITIAL_POINTER_SIZE == 64 */


### PR DESCRIPTION
In the "Stop raising ERR_R_MALLOC_FAILURE in most places" commit, some
fixes of this file weren't done quite right, leading to a symbol being
undeclared depending on building circumstances.
