### PR TITLE
Fix LLVM vs Apple LLVM version numbering confusion, for $avx512ifma

### DIFF
--- a/crypto/bn/asm/rsaz-2k-avx512.pl
+++ b/crypto/bn/asm/rsaz-2k-avx512.pl
@@ -49,8 +49,17 @@ if (!$avx512 && $win64 && ($flavour =~ /nasm/ || $ENV{ASM} =~ /nasm/) &&
     $avx512ifma = ($1==2.11 && $2>=8) + ($1>=2.12);
 }
 
-if (!$avx512 && `$ENV{CC} -v 2>&1` =~ /((?:clang|LLVM) version|.*based on LLVM) ([0-9]+\.[0-9]+)/) {
-    $avx512ifma = ($2>=7.0);
+if (!$avx512 && `$ENV{CC} -v 2>&1`
+    =~ /(Apple)?\s*((?:clang|LLVM) version|.*based on LLVM) ([0-9]+)\.([0-9]+)\.([0-9]+)?/) {
+    my $ver = $3 + $4/100.0 + $5/10000.0; # 3.1.0->3.01, 3.10.1->3.1001
+    if ($1) {
+        # Apple conditions, they use a different version series, see
+        # https://en.wikipedia.org/wiki/Xcode#Xcode_7.0_-_10.x_(since_Free_On-Device_Development)_2
+        # clang 7.0.0 is Apple clang 10.0.1
+        $avx512ifma = ($ver>=10.0001)
+    } else {
+        $avx512ifma = ($ver>=7.0);
+    }
 }
 
 open OUT,"| \"$^X\" \"$xlate\" $flavour \"$output\""

--- a/crypto/bn/asm/rsaz-3k-avx512.pl
+++ b/crypto/bn/asm/rsaz-3k-avx512.pl
@@ -48,8 +48,17 @@ if (!$avx512 && $win64 && ($flavour =~ /nasm/ || $ENV{ASM} =~ /nasm/) &&
     $avx512ifma = ($1==2.11 && $2>=8) + ($1>=2.12);
 }
 
-if (!$avx512 && `$ENV{CC} -v 2>&1` =~ /((?:clang|LLVM) version|.*based on LLVM) ([0-9]+\.[0-9]+)/) {
-    $avx512ifma = ($2>=7.0);
+if (!$avx512 && `$ENV{CC} -v 2>&1`
+    =~ /(Apple)?\s*((?:clang|LLVM) version|.*based on LLVM) ([0-9]+)\.([0-9]+)\.([0-9]+)?/) {
+    my $ver = $3 + $4/100.0 + $5/10000.0; # 3.1.0->3.01, 3.10.1->3.1001
+    if ($1) {
+        # Apple conditions, they use a different version series, see
+        # https://en.wikipedia.org/wiki/Xcode#Xcode_7.0_-_10.x_(since_Free_On-Device_Development)_2
+        # clang 7.0.0 is Apple clang 10.0.1
+        $avx512ifma = ($ver>=10.0001)
+    } else {
+        $avx512ifma = ($ver>=7.0);
+    }
 }
 
 open OUT,"| \"$^X\" \"$xlate\" $flavour \"$output\""

--- a/crypto/bn/asm/rsaz-4k-avx512.pl
+++ b/crypto/bn/asm/rsaz-4k-avx512.pl
@@ -48,8 +48,17 @@ if (!$avx512 && $win64 && ($flavour =~ /nasm/ || $ENV{ASM} =~ /nasm/) &&
     $avx512ifma = ($1==2.11 && $2>=8) + ($1>=2.12);
 }
 
-if (!$avx512 && `$ENV{CC} -v 2>&1` =~ /((?:clang|LLVM) version|.*based on LLVM) ([0-9]+\.[0-9]+)/) {
-    $avx512ifma = ($2>=7.0);
+if (!$avx512 && `$ENV{CC} -v 2>&1`
+    =~ /(Apple)?\s*((?:clang|LLVM) version|.*based on LLVM) ([0-9]+)\.([0-9]+)\.([0-9]+)?/) {
+    my $ver = $3 + $4/100.0 + $5/10000.0; # 3.1.0->3.01, 3.10.1->3.1001
+    if ($1) {
+        # Apple conditions, they use a different version series, see
+        # https://en.wikipedia.org/wiki/Xcode#Xcode_7.0_-_10.x_(since_Free_On-Device_Development)_2
+        # clang 7.0.0 is Apple clang 10.0.1
+        $avx512ifma = ($ver>=10.0001)
+    } else {
+        $avx512ifma = ($ver>=7.0);
+    }
 }
 
 open OUT,"| \"$^X\" \"$xlate\" $flavour \"$output\""


### PR DESCRIPTION
Apple LLVM has a different version numbering scheme than upstream LLVM.
That makes for quite a bit of confusion.

https://en.wikipedia.org/wiki/Xcode#Toolchain_versions to the rescue,
they have collected quite a lot of useful data.

This change is concentrated around the `$avx512ifma` flag

Fixes #16670 for the master branch
