### PR TITLE
openssl list: Fix help text about -cipher-algorithms option

### DIFF
--- a/apps/list.c
+++ b/apps/list.c
@@ -1476,7 +1476,7 @@ const OPTIONS list_options[] = {
     "List of cipher commands (deprecated)"},
 #endif
     {"cipher-algorithms", OPT_CIPHER_ALGORITHMS, '-',
-     "List of cipher algorithms"},
+     "List of symetric cipher algorithms"},
     {"encoders", OPT_ENCODERS, '-', "List of encoding methods" },
     {"decoders", OPT_DECODERS, '-', "List of decoding methods" },
     {"key-managers", OPT_KEYMANAGERS, '-', "List of key managers" },

--- a/apps/list.c
+++ b/apps/list.c
@@ -1476,7 +1476,7 @@ const OPTIONS list_options[] = {
     "List of cipher commands (deprecated)"},
 #endif
     {"cipher-algorithms", OPT_CIPHER_ALGORITHMS, '-',
-     "List of symetric cipher algorithms"},
+     "List of symmetric cipher algorithms"},
     {"encoders", OPT_ENCODERS, '-', "List of encoding methods" },
     {"decoders", OPT_DECODERS, '-', "List of decoding methods" },
     {"key-managers", OPT_KEYMANAGERS, '-', "List of key managers" },

--- a/doc/man1/openssl-list.pod.in
+++ b/doc/man1/openssl-list.pod.in
@@ -132,7 +132,7 @@ to the L<openssl-enc(1)> or L<openssl-speed(1)> commands.
 =item B<-cipher-algorithms>, B<-digest-algorithms>, B<-kdf-algorithms>,
 B<-mac-algorithms>,
 
-Display a list of symetric cipher, digest, kdf and mac algorithms.
+Display a list of symmetric cipher, digest, kdf and mac algorithms.
 See L</Display of algorithm names> for a description of how names are
 displayed.
 

--- a/doc/man1/openssl-list.pod.in
+++ b/doc/man1/openssl-list.pod.in
@@ -129,10 +129,10 @@ This option is deprecated. Use B<cipher-algorithms> instead.
 Display a list of cipher commands, which are typically used as input
 to the L<openssl-enc(1)> or L<openssl-speed(1)> commands.
 
-=item B<-digest-algorithms>, B<-kdf-algorithms>, B<-mac-algorithms>,
-B<-cipher-algorithms>
+=item B<-cipher-algorithms>, B<-digest-algorithms>, B<-kdf-algorithms>,
+B<-mac-algorithms>,
 
-Display a list of cipher, digest, kdf and mac algorithms.
+Display a list of symetric cipher, digest, kdf and mac algorithms.
 See L</Display of algorithm names> for a description of how names are
 displayed.
 


### PR DESCRIPTION
Fixes openssl#19133

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
