### PR TITLE
default provider: include RIPEMD160

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,10 @@ OpenSSL 3.2
 
 ### Changes between 3.0 and 3.2 [xx XXX xxxx]
 
+ * Added RIPEMD160 to the default provider.
+
+   *Paul Dale*
+
  * Add the ability to add custom attributes to PKCS12 files. Add a new API
    PKCS12_create_ex2, identical to the existing PKCS12_create_ex but allows
    for a user specified callback and optional argument.

--- a/crypto/ripemd/build.info
+++ b/crypto/ripemd/build.info
@@ -19,10 +19,10 @@ SOURCE[../../libcrypto]=rmd_dgst.c rmd_one.c $RMD160ASM
 DEFINE[../../libcrypto]=$RMD160DEF
 
 # When all deprecated symbols are removed, libcrypto doesn't export the
-# RIPEMD160 functions, so we must include them directly in liblegacy.a
+# RIPEMD160 functions, so we must include them directly in libcommon.a
 IF[{- $disabled{'deprecated-3.0'} -}]
-  SOURCE[../../providers/liblegacy.a]=rmd_dgst.c rmd_one.c $RMD160ASM
-  DEFINE[../../providers/liblegacy.a]=$RMD160DEF
+  SOURCE[../../providers/libcommon.a]=rmd_dgst.c rmd_one.c $RMD160ASM
+  DEFINE[../../providers/libcommon.a]=$RMD160DEF
 ENDIF
 
 GENERATE[rmd-586.S]=asm/rmd-586.pl

--- a/crypto/ripemd/build.info
+++ b/crypto/ripemd/build.info
@@ -19,10 +19,10 @@ SOURCE[../../libcrypto]=rmd_dgst.c rmd_one.c $RMD160ASM
 DEFINE[../../libcrypto]=$RMD160DEF
 
 # When all deprecated symbols are removed, libcrypto doesn't export the
-# RIPEMD160 functions, so we must include them directly in libcommon.a
-IF[{- $disabled{'deprecated-3.0'} -}]
-  SOURCE[../../providers/libcommon.a]=rmd_dgst.c rmd_one.c $RMD160ASM
-  DEFINE[../../providers/libcommon.a]=$RMD160DEF
+# RIPEMD160 functions, so we must include them directly in liblegacy.a
+IF[{- $disabled{'deprecated-3.0'} && !$disabled{'module'} -}]
+  SOURCE[../../providers/liblegacy.a]=rmd_dgst.c rmd_one.c $RMD160ASM
+  DEFINE[../../providers/liblegacy.a]=$RMD160DEF
 ENDIF
 
 GENERATE[rmd-586.S]=asm/rmd-586.pl

--- a/doc/man7/EVP_MD-RIPEMD160.pod
+++ b/doc/man7/EVP_MD-RIPEMD160.pod
@@ -10,7 +10,7 @@ Support for computing RIPEMD160 digests through the B<EVP_MD> API.
 
 =head2 Identities
 
-This implementation is only available with the legacy provider, and is
+This implementation is available in both the default and legacy providers, and is
 identified with any of the names "RIPEMD-160", "RIPEMD160", "RIPEMD" and
 "RMD160".
 
@@ -22,6 +22,10 @@ in L<EVP_MD-common(7)>.
 =head1 SEE ALSO
 
 L<provider-digest(7)>, L<OSSL_PROVIDER-default(7)>
+
+=head1 HISTORY
+
+This digest was added to the default provider in OpenSSL 3.0.7.
 
 =head1 COPYRIGHT
 

--- a/doc/man7/OSSL_PROVIDER-default.pod
+++ b/doc/man7/OSSL_PROVIDER-default.pod
@@ -71,6 +71,8 @@ The OpenSSL default provider supports these operations and algorithms:
 
 =item MD5-SHA1, see L<EVP_MD-MD5-SHA1(7)>
 
+=item RIPEMD160, see L<EVP_MD-RIPEMD160(7)>
+
 =back
 
 =head2 Symmetric Ciphers
@@ -246,6 +248,10 @@ to allow them to be used together with the FIPS provider.
 
 L<openssl-core.h(7)>, L<openssl-core_dispatch.h(7)>, L<provider(7)>,
 L<OSSL_PROVIDER-base(7)>
+
+=head1 HISTORY
+
+The RIPEMD160 digest was added to the default provider in OpenSSL 3.0.7.
 
 =head1 COPYRIGHT
 

--- a/providers/defltprov.c
+++ b/providers/defltprov.c
@@ -153,6 +153,10 @@ static const OSSL_ALGORITHM deflt_digests[] = {
     { PROV_NAMES_MD5_SHA1, "provider=default", ossl_md5_sha1_functions },
 #endif /* OPENSSL_NO_MD5 */
 
+#ifndef OPENSSL_NO_RMD160
+    { PROV_NAMES_RIPEMD_160, "provider=default", ossl_ripemd160_functions },
+#endif /* OPENSSL_NO_RMD160 */
+
     { PROV_NAMES_NULL, "provider=default", ossl_nullmd_functions },
     { NULL, NULL, NULL }
 };

--- a/providers/implementations/digests/build.info
+++ b/providers/implementations/digests/build.info
@@ -15,7 +15,11 @@ $MD2_GOAL=../../liblegacy.a
 $MD4_GOAL=../../liblegacy.a
 $MDC2_GOAL=../../liblegacy.a
 $WHIRLPOOL_GOAL=../../liblegacy.a
-$RIPEMD_GOAL=$COMMON_GOAL
+IF[{- !$disabled{module} -}]
+  $RIPEMD_GOAL=../../libdefault.a ../../liblegacy.a
+ELSE
+  $RIPEMD_GOAL=../../libdefault.a
+ENDIF
 
 # This source is common for all digests in all our providers.
 SOURCE[$COMMON_GOAL]=digestcommon.c

--- a/providers/implementations/digests/build.info
+++ b/providers/implementations/digests/build.info
@@ -15,7 +15,7 @@ $MD2_GOAL=../../liblegacy.a
 $MD4_GOAL=../../liblegacy.a
 $MDC2_GOAL=../../liblegacy.a
 $WHIRLPOOL_GOAL=../../liblegacy.a
-$RIPEMD_GOAL=../../liblegacy.a
+$RIPEMD_GOAL=$COMMON_GOAL
 
 # This source is common for all digests in all our providers.
 SOURCE[$COMMON_GOAL]=digestcommon.c

--- a/test/recipes/30-test_evp_data/evpmd_ripemd.txt
+++ b/test/recipes/30-test_evp_data/evpmd_ripemd.txt
@@ -13,42 +13,42 @@
 
 Title = RIPEMD160 tests
 
-Availablein = legacy
+Availablein = legacy default
 Digest = RIPEMD160
 Input = ""
 Output = 9c1185a5c5e9fc54612808977ee8f548b2258d31
 
-Availablein = legacy
+Availablein = legacy default
 Digest = RIPEMD160
 Input = "a"
 Output = 0bdc9d2d256b3ee9daae347be6f4dc835a467ffe
 
-Availablein = legacy
+Availablein = legacy default
 Digest = RIPEMD160
 Input = "abc"
 Output = 8eb208f7e05d987a9b044a8e98c6b087f15a0bfc
 
-Availablein = legacy
+Availablein = legacy default
 Digest = RIPEMD160
 Input = "message digest"
 Output = 5d0689ef49d2fae572b881b123a85ffa21595f36
 
-Availablein = legacy
+Availablein = legacy default
 Digest = RIPEMD160
 Input = "abcdefghijklmnopqrstuvwxyz"
 Output = f71c27109c692c1b56bbdceb5b9d2865b3708dbc
 
-Availablein = legacy
+Availablein = legacy default
 Digest = RIPEMD160
 Input = "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq"
 Output = 12a053384a9c0c88e405a06c27dcf49ada62eb2b
 
-Availablein = legacy
+Availablein = legacy default
 Digest = RIPEMD160
 Input = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
 Output = b0e20b6e3116640286ed3a87a5713079b21f5189
 
-Availablein = legacy
+Availablein = legacy default
 Digest = RIPEMD160
 Input = "12345678901234567890123456789012345678901234567890123456789012345678901234567890"
 Output = 9b752e45573d4b39f4dbd3323cab82bf63326bfb


### PR DESCRIPTION
Including RIPEMD160 in both the default and legacy providers shouldn't break anyone and makes the algorithm available more readily.

Fixes #17722
