### PR TITLE
QUIC: convert implementations to use the list data type

### DIFF
--- a/doc/internal/man3/DEFINE_LIST_OF.pod
+++ b/doc/internal/man3/DEFINE_LIST_OF.pod
@@ -51,55 +51,55 @@ The OSSL_LIST() macro returns the name for a list of the specified
 B<I<TYPE>>.  This is a structure which should be treated as opaque.
 
 DEFINE_LIST_OF() creates a set of functions for a list of B<I<TYPE>>
-elements with the name B<I<NAME>>.  The type is represented
-by B<OSSL_LIST>(B<I<NAME>>) and each function name begins with
-B<ossl_list_I<NAME>_>.  The list's linkages are stored in the
-B<OSSL_LIST_MEMBER>(B<I<NAME>>, B<I<TYPE>>) field.
+elements with the name B<I<TYPE>>.  The type is represented
+by B<OSSL_LIST>(B<I<TYPE>>) and each function name begins with
+B<ossl_list_I<TYPE>_>.  The list's linkages are stored in the
+B<OSSL_LIST_MEMBER>(B<I<TYPE>>, B<I<TYPE>>) field.
 
-B<ossl_list_I<NAME>_init>() initialises the memory pointed to by I<list>
+B<ossl_list_I<TYPE>_init>() initialises the memory pointed to by I<list>
 to zero which creates an empty list.
 
-B<ossl_list_I<NAME>_init_elem>() initialises the list related memory pointed
+B<ossl_list_I<TYPE>_init_elem>() initialises the list related memory pointed
 to by I<elem> to zero which allows it to be used in lists.
 
-B<ossl_list_I<NAME>_is_empty>() returns nonzero if I<list> has no elements and
+B<ossl_list_I<TYPE>_is_empty>() returns nonzero if I<list> has no elements and
 zero otherwise.
 
-B<ossl_list_I<NAME>_num>() returns the number of elements in I<list>.
+B<ossl_list_I<TYPE>_num>() returns the number of elements in I<list>.
 
-B<ossl_list_I<NAME>_head>() returns the first element in the I<list>
+B<ossl_list_I<TYPE>_head>() returns the first element in the I<list>
 or NULL if there are no elements.
 
-B<ossl_list_I<NAME>_tail>() returns the last element in the I<list>
+B<ossl_list_I<TYPE>_tail>() returns the last element in the I<list>
 or NULL if there are no elements.
 
-B<ossl_list_I<NAME>_remove>() removes the specified element I<elem> from
+B<ossl_list_I<TYPE>_remove>() removes the specified element I<elem> from
 the I<list>.  It is illegal to remove an element that isn't in the list.
 
-B<ossl_list_I<NAME>_insert_head>() inserts the element I<elem>, which
+B<ossl_list_I<TYPE>_insert_head>() inserts the element I<elem>, which
 must not be in the list, into the first position in the I<list>.
 
-B<ossl_list_I<NAME>_insert_tail>() inserts the element I<elem>, which
+B<ossl_list_I<TYPE>_insert_tail>() inserts the element I<elem>, which
 must not be in the list, into the last position in the I<list>.
 
-B<ossl_list_I<NAME>_insert_before>() inserts the element I<elem>,
+B<ossl_list_I<TYPE>_insert_before>() inserts the element I<elem>,
 which must not be in the list, into the I<list> immediately before the
 I<existing> element.
 
-B<ossl_list_I<NAME>_insert_after>() inserts the element I<elem>,
+B<ossl_list_I<TYPE>_insert_after>() inserts the element I<elem>,
 which must not be in the list, into the I<list> immediately after the
 I<existing> element.
 
 =head1 RETURN VALUES
 
-B<ossl_list_I<NAME>_is_empty>() returns nonzero if the list is empty and zero
+B<ossl_list_I<TYPE>_is_empty>() returns nonzero if the list is empty and zero
 otherwise.
 
-B<ossl_list_I<NAME>_num>() returns the number of elements in the
+B<ossl_list_I<TYPE>_num>() returns the number of elements in the
 list.
 
-B<ossl_list_I<NAME>_head>(), B<ossl_list_I<NAME>_tail>(),
-B<ossl_list_I<NAME>_next>() and B<ossl_list_I<NAME>_prev>() return
+B<ossl_list_I<TYPE>_head>(), B<ossl_list_I<TYPE>_tail>(),
+B<ossl_list_I<TYPE>_next>() and B<ossl_list_I<TYPE>_prev>() return
 the specified element in the list.
 
 =head1 EXAMPLES

--- a/doc/internal/man3/DEFINE_LIST_OF.pod
+++ b/doc/internal/man3/DEFINE_LIST_OF.pod
@@ -3,7 +3,8 @@
 =head1 NAME
 
 DEFINE_LIST_OF, OSSL_LIST_MEMBER, OSSL_LIST,
-ossl_list_TYPE_init, ossl_list_TYPE_num,
+ossl_list_TYPE_init, ossl_list_TYPE_init_elem,
+ossl_list_TYPE_is_empty, ossl_list_TYPE_num,
 ossl_list_TYPE_head, ossl_list_TYPE_tail,
 ossl_list_TYPE_next, ossl_list_TYPE_prev,
 ossl_list_TYPE_remove, ossl_list_TYPE_insert_head, ossl_list_TYPE_insert_tail,
@@ -21,7 +22,9 @@ ossl_list_TYPE_insert_before, ossl_list_TYPE_after
  DEFINE_LIST_OF(NAME, TYPE);
 
  void ossl_list_TYPE_init(OSSL_LIST(name) *list);
+ void ossl_list_TYPE_init_elem(type *elem);
 
+ int ossl_list_TYPE_is_empty(const OSSL_LIST(name) *list);
  size_t ossl_list_TYPE_num(const OSSL_LIST(name) *list);
  type *ossl_list_TYPE_head(const OSSL_LIST(name) *list);
  type *ossl_list_TYPE_tail(const OSSL_LIST(name) *list);
@@ -56,6 +59,12 @@ B<OSSL_LIST_MEMBER>(B<I<NAME>>, B<I<TYPE>>) field.
 B<ossl_list_I<NAME>_init>() initialises the memory pointed to by I<list>
 to zero which creates an empty list.
 
+B<ossl_list_I<NAME>_init_elem>() initialises the list related memory pointed
+to by I<elem> to zero which allows it to be used in lists.
+
+B<ossl_list_I<NAME>_is_empty>() returns nonzero if I<list> has no elements and
+zero otherwise.
+
 B<ossl_list_I<NAME>_num>() returns the number of elements in I<list>.
 
 B<ossl_list_I<NAME>_head>() returns the first element in the I<list>
@@ -82,6 +91,9 @@ which must not be in the list, into the I<list> immediately after the
 I<existing> element.
 
 =head1 RETURN VALUES
+
+B<ossl_list_I<NAME>_is_empty>() returns nonzero if the list is empty and zero
+otherwise.
 
 B<ossl_list_I<NAME>_num>() returns the number of elements in the
 list.

--- a/include/internal/list.h
+++ b/include/internal/list.h
@@ -25,7 +25,7 @@
 # define DEFINE_LIST_OF(name, type)                                         \
     typedef struct ossl_list_st_ ## name OSSL_LIST(name);                   \
     struct ossl_list_st_ ## name {                                          \
-        type *head, *tail;                                                  \
+        type *alpha, *omega;                                                \
         size_t num_elems;                                                   \
     };                                                                      \
     static ossl_unused ossl_inline void                                     \
@@ -41,12 +41,12 @@
     static ossl_unused ossl_inline type *                                   \
     ossl_list_##name##_head(const OSSL_LIST(name) *list)                    \
     {                                                                       \
-        return list->head;                                                  \
+        return list->alpha;                                                 \
     }                                                                       \
     static ossl_unused ossl_inline type *                                   \
     ossl_list_##name##_tail(const OSSL_LIST(name) *list)                    \
     {                                                                       \
-        return list->tail;                                                  \
+        return list->omega;                                                 \
     }                                                                       \
     static ossl_unused ossl_inline type *                                   \
     ossl_list_##name##_next(const type *elem)                               \
@@ -61,10 +61,10 @@
     static ossl_unused ossl_inline void                                     \
     ossl_list_##name##_remove(OSSL_LIST(name) *list, type *elem)            \
     {                                                                       \
-        if (list->head == elem)                                             \
-            list->head = elem->ossl_list_ ## name.next;                     \
-        if (list->tail == elem)                                             \
-            list->tail = elem->ossl_list_ ## name.prev;                     \
+        if (list->alpha == elem)                                            \
+            list->alpha = elem->ossl_list_ ## name.next;                    \
+        if (list->omega == elem)                                            \
+            list->omega = elem->ossl_list_ ## name.prev;                    \
         if (elem->ossl_list_ ## name.prev != NULL)                          \
             elem->ossl_list_ ## name.prev->ossl_list_ ## name.next =        \
                     elem->ossl_list_ ## name.next;                          \
@@ -78,25 +78,25 @@
     static ossl_unused ossl_inline void                                     \
     ossl_list_##name##_insert_head(OSSL_LIST(name) *list, type *elem)       \
     {                                                                       \
-        if (list->head != NULL)                                             \
-            list->head->ossl_list_ ## name.prev = elem;                     \
-        elem->ossl_list_ ## name.next = list->head;                         \
+        if (list->alpha != NULL)                                            \
+            list->alpha->ossl_list_ ## name.prev = elem;                    \
+        elem->ossl_list_ ## name.next = list->alpha;                        \
         elem->ossl_list_ ## name.prev = NULL;                               \
-        list->head = elem;                                                  \
-        if (list->tail == NULL)                                             \
-            list->tail = elem;                                              \
+        list->alpha = elem;                                                 \
+        if (list->omega == NULL)                                            \
+            list->omega = elem;                                             \
         list->num_elems++;                                                  \
     }                                                                       \
     static ossl_unused ossl_inline void                                     \
     ossl_list_##name##_insert_tail(OSSL_LIST(name) *list, type *elem)       \
     {                                                                       \
-        if (list->tail != NULL)                                             \
-            list->tail->ossl_list_ ## name.next = elem;                     \
-        elem->ossl_list_ ## name.prev = list->tail;                         \
+        if (list->omega != NULL)                                            \
+            list->omega->ossl_list_ ## name.next = elem;                    \
+        elem->ossl_list_ ## name.prev = list->omega;                        \
         elem->ossl_list_ ## name.next = NULL;                               \
-        list->tail = elem;                                                  \
-        if (list->head == NULL)                                             \
-            list->head = elem;                                              \
+        list->omega = elem;                                                 \
+        if (list->alpha == NULL)                                            \
+            list->alpha = elem;                                             \
         list->num_elems++;                                                  \
     }                                                                       \
     static ossl_unused ossl_inline void                                     \
@@ -108,21 +108,21 @@
         if (e->ossl_list_ ## name.prev != NULL)                             \
             e->ossl_list_ ## name.prev->ossl_list_ ## name.next = elem;     \
         e->ossl_list_ ## name.prev = elem;                                  \
-        if (list->head == e)                                                \
-            list->head = elem;                                              \
+        if (list->alpha == e)                                               \
+            list->alpha = elem;                                             \
         list->num_elems++;                                                  \
     }                                                                       \
     static ossl_unused ossl_inline void                                     \
     ossl_list_##name##_insert_after(OSSL_LIST(name) *list, type *e,         \
-                                     type *elem)                            \
+                                    type *elem)                             \
     {                                                                       \
         elem->ossl_list_ ## name.prev = e;                                  \
         elem->ossl_list_ ## name.next = e->ossl_list_ ## name.next;         \
         if (e->ossl_list_ ## name.next != NULL)                             \
             e->ossl_list_ ## name.next->ossl_list_ ## name.prev = elem;     \
         e->ossl_list_ ## name.next = elem;                                  \
-        if (list->tail == e)                                                \
-            list->tail = elem;                                              \
+        if (list->omega == e)                                               \
+            list->omega = elem;                                             \
         list->num_elems++;                                                  \
     }                                                                       \
     struct ossl_list_st_ ## name

--- a/include/internal/list.h
+++ b/include/internal/list.h
@@ -33,6 +33,17 @@
     {                                                                       \
         memset(list, 0, sizeof(*list));                                     \
     }                                                                       \
+    static ossl_unused ossl_inline void                                     \
+    ossl_list_##name##_init_elem(type *elem)                                \
+    {                                                                       \
+        memset(&elem->ossl_list_ ## name, 0,                                \
+               sizeof(elem->ossl_list_ ## name));                           \
+    }                                                                       \
+    static ossl_unused ossl_inline int                                      \
+    ossl_list_##name##_is_empty(const OSSL_LIST(name) *list)                \
+    {                                                                       \
+        return list->num_elems == 0;                                        \
+    }                                                                       \
     static ossl_unused ossl_inline size_t                                   \
     ossl_list_##name##_num(const OSSL_LIST(name) *list)                     \
     {                                                                       \

--- a/include/internal/list.h
+++ b/include/internal/list.h
@@ -12,6 +12,13 @@
 # pragma once
 
 # include <string.h>
+# include <assert.h>
+
+# ifdef NDEBUG
+#  define OSSL_LIST_DBG(x)
+# else
+#  define OSSL_LIST_DBG(x) x;
+# endif
 
 /* Define a list structure */
 # define OSSL_LIST(name) OSSL_LIST_ ## name
@@ -20,6 +27,7 @@
 # define OSSL_LIST_MEMBER(name, type)                                       \
     struct {                                                                \
         type *next, *prev;                                                  \
+        OSSL_LIST_DBG(struct ossl_list_st_ ## name *list)                   \
     } ossl_list_ ## name
 
 # define DEFINE_LIST_OF(name, type)                                         \
@@ -52,26 +60,38 @@
     static ossl_unused ossl_inline type *                                   \
     ossl_list_##name##_head(const OSSL_LIST(name) *list)                    \
     {                                                                       \
+        assert(list->alpha == NULL                                          \
+               || list->alpha->ossl_list_ ## name.list == list);            \
         return list->alpha;                                                 \
     }                                                                       \
     static ossl_unused ossl_inline type *                                   \
     ossl_list_##name##_tail(const OSSL_LIST(name) *list)                    \
     {                                                                       \
+        assert(list->omega == NULL                                          \
+               || list->omega->ossl_list_ ## name.list == list);            \
         return list->omega;                                                 \
     }                                                                       \
     static ossl_unused ossl_inline type *                                   \
     ossl_list_##name##_next(const type *elem)                               \
     {                                                                       \
+        assert(elem->ossl_list_ ## name.next == NULL                        \
+               || elem->ossl_list_ ## name.next                             \
+                      ->ossl_list_ ## name.prev == elem);                   \
         return elem->ossl_list_ ## name.next;                               \
     }                                                                       \
     static ossl_unused ossl_inline type *                                   \
     ossl_list_##name##_prev(const type *elem)                               \
     {                                                                       \
+        assert(elem->ossl_list_ ## name.prev == NULL                        \
+               || elem->ossl_list_ ## name.prev                             \
+                      ->ossl_list_ ## name.next == elem);                   \
         return elem->ossl_list_ ## name.prev;                               \
     }                                                                       \
     static ossl_unused ossl_inline void                                     \
     ossl_list_##name##_remove(OSSL_LIST(name) *list, type *elem)            \
     {                                                                       \
+        assert(elem->ossl_list_ ## name.list == list);                      \
+        OSSL_LIST_DBG(elem->ossl_list_ ## name.list = NULL)                 \
         if (list->alpha == elem)                                            \
             list->alpha = elem->ossl_list_ ## name.next;                    \
         if (list->omega == elem)                                            \
@@ -89,6 +109,8 @@
     static ossl_unused ossl_inline void                                     \
     ossl_list_##name##_insert_head(OSSL_LIST(name) *list, type *elem)       \
     {                                                                       \
+        assert(elem->ossl_list_ ## name.list == NULL);                      \
+        OSSL_LIST_DBG(elem->ossl_list_ ## name.list = list)                 \
         if (list->alpha != NULL)                                            \
             list->alpha->ossl_list_ ## name.prev = elem;                    \
         elem->ossl_list_ ## name.next = list->alpha;                        \
@@ -101,6 +123,8 @@
     static ossl_unused ossl_inline void                                     \
     ossl_list_##name##_insert_tail(OSSL_LIST(name) *list, type *elem)       \
     {                                                                       \
+        assert(elem->ossl_list_ ## name.list == NULL);                      \
+        OSSL_LIST_DBG(elem->ossl_list_ ## name.list = list)                 \
         if (list->omega != NULL)                                            \
             list->omega->ossl_list_ ## name.next = elem;                    \
         elem->ossl_list_ ## name.prev = list->omega;                        \
@@ -114,6 +138,8 @@
     ossl_list_##name##_insert_before(OSSL_LIST(name) *list, type *e,        \
                                      type *elem)                            \
     {                                                                       \
+        assert(elem->ossl_list_ ## name.list == NULL);                      \
+        OSSL_LIST_DBG(elem->ossl_list_ ## name.list = list)                 \
         elem->ossl_list_ ## name.next = e;                                  \
         elem->ossl_list_ ## name.prev = e->ossl_list_ ## name.prev;         \
         if (e->ossl_list_ ## name.prev != NULL)                             \
@@ -127,6 +153,8 @@
     ossl_list_##name##_insert_after(OSSL_LIST(name) *list, type *e,         \
                                     type *elem)                             \
     {                                                                       \
+        assert(elem->ossl_list_ ## name.list == NULL);                      \
+        OSSL_LIST_DBG(elem->ossl_list_ ## name.list = list)                 \
         elem->ossl_list_ ## name.prev = e;                                  \
         elem->ossl_list_ ## name.next = e->ossl_list_ ## name.next;         \
         if (e->ossl_list_ ## name.next != NULL)                             \

--- a/include/internal/quic_ackm.h
+++ b/include/internal/quic_ackm.h
@@ -14,6 +14,7 @@
 # include "internal/quic_types.h"
 # include "internal/quic_wire.h"
 # include "internal/time.h"
+# include "internal/list.h"
 
 typedef struct ossl_ackm_st OSSL_ACKM;
 
@@ -35,7 +36,8 @@ void ossl_ackm_set_ack_deadline_callback(OSSL_ACKM *ackm,
                                                     void *arg),
                                          void *arg);
 
-typedef struct ossl_ackm_tx_pkt_st {
+typedef struct ossl_ackm_tx_pkt_st OSSL_ACKM_TX_PKT;
+struct ossl_ackm_tx_pkt_st {
     /* The packet number of the transmitted packet. */
     QUIC_PN pkt_num;
 
@@ -89,15 +91,15 @@ typedef struct ossl_ackm_tx_pkt_st {
     /* 
      * (Internal use fields; must be zero-initialized.)
      *
-     * prev and next link us into the TX history list, anext is used to manifest
+     * Keep a TX history list, anext is used to manifest
      * a singly-linked list of newly-acknowledged packets, and lnext is used to
      * manifest a singly-linked list of newly lost packets.
      */
-    struct ossl_ackm_tx_pkt_st *prev;
-    struct ossl_ackm_tx_pkt_st *next;
+    OSSL_LIST_MEMBER(tx_history, OSSL_ACKM_TX_PKT);
+
     struct ossl_ackm_tx_pkt_st *anext;
     struct ossl_ackm_tx_pkt_st *lnext;
-} OSSL_ACKM_TX_PKT;
+};
 
 int ossl_ackm_on_tx_packet(OSSL_ACKM *ackm, OSSL_ACKM_TX_PKT *pkt);
 int ossl_ackm_on_rx_datagram(OSSL_ACKM *ackm, size_t num_bytes);

--- a/include/internal/quic_demux.h
+++ b/include/internal/quic_demux.h
@@ -14,6 +14,7 @@
 # include "internal/quic_types.h"
 # include "internal/bio_addr.h"
 # include "internal/time.h"
+# include "internal/list.h"
 
 /*
  * QUIC Demuxer
@@ -86,7 +87,7 @@ typedef struct quic_urxe_st QUIC_URXE;
 #define QUIC_MAX_PKT_PER_URXE       (sizeof(uint64_t) * 8)
 
 struct quic_urxe_st {
-    QUIC_URXE *prev, *next;
+    OSSL_LIST_MEMBER(urxe, QUIC_URXE);
 
     /*
      * The URXE data starts after this structure so we don't need a pointer.
@@ -139,9 +140,8 @@ ossl_quic_urxe_data_end(const QUIC_URXE *e)
 }
 
 /* List structure tracking a queue of URXEs. */
-typedef struct quic_urxe_list_st {
-    QUIC_URXE *head, *tail;
-} QUIC_URXE_LIST;
+DEFINE_LIST_OF(urxe, QUIC_URXE);
+typedef OSSL_LIST(urxe) QUIC_URXE_LIST;
 
 /*
  * List management helpers. These are used by the demuxer but can also be used

--- a/include/internal/uint_set.h
+++ b/include/internal/uint_set.h
@@ -10,6 +10,7 @@
 # define OSSL_UINT_SET_H
 
 #include "openssl/params.h"
+#include "internal/list.h"
 
 /*
  * uint64_t Integer Sets
@@ -27,17 +28,15 @@ typedef struct uint_range_st {
     uint64_t    start, end;
 } UINT_RANGE;
 
-typedef struct uint_set_item_st {
-    struct uint_set_item_st    *prev, *next;
+typedef struct uint_set_item_st UINT_SET_ITEM;
+struct uint_set_item_st {
+    OSSL_LIST_MEMBER(uint_set, UINT_SET_ITEM);
     UINT_RANGE                  range;
-} UINT_SET_ITEM;
+};
 
-typedef struct uint_set_st {
-    UINT_SET_ITEM  *head, *tail;
+DEFINE_LIST_OF(uint_set, UINT_SET_ITEM);
 
-    /* Number of ranges (not integers) in the set. */
-    size_t          num_ranges;
-} UINT_SET;
+typedef OSSL_LIST(uint_set) UINT_SET;
 
 void ossl_uint_set_init(UINT_SET *s);
 void ossl_uint_set_destroy(UINT_SET *s);

--- a/ssl/quic/quic_fifd.c
+++ b/ssl/quic/quic_fifd.c
@@ -10,6 +10,8 @@
 #include "internal/quic_fifd.h"
 #include "internal/quic_wire.h"
 
+DEFINE_LIST_OF(tx_history, OSSL_ACKM_TX_PKT);
+
 int ossl_quic_fifd_init(QUIC_FIFD *fifd,
                         QUIC_CFQ *cfq,
                         OSSL_ACKM *ackm,
@@ -185,8 +187,8 @@ int ossl_quic_fifd_pkt_commit(QUIC_FIFD *fifd, QUIC_TXPIM_PKT *pkt)
     pkt->ackm_pkt.on_discarded  = on_discarded;
     pkt->ackm_pkt.cb_arg        = pkt;
 
-    pkt->ackm_pkt.prev = pkt->ackm_pkt.next
-        = pkt->ackm_pkt.anext = pkt->ackm_pkt.lnext = NULL;
+    ossl_list_tx_history_init_elem(&pkt->ackm_pkt);
+    pkt->ackm_pkt.anext = pkt->ackm_pkt.lnext = NULL;
 
     /*
      * Mark the CFQ items which have been added to this packet as having been

--- a/ssl/quic/quic_record_tx.c
+++ b/ssl/quic/quic_record_tx.c
@@ -11,6 +11,7 @@
 #include "internal/bio_addr.h"
 #include "internal/common.h"
 #include "quic_record_shared.h"
+#include "internal/list.h"
 #include "../ssl_local.h"
 
 /*
@@ -22,7 +23,7 @@
 typedef struct txe_st TXE;
 
 struct txe_st {
-    TXE                *prev, *next;
+    OSSL_LIST_MEMBER(txe, TXE);
     size_t              data_len, alloc_len;
 
     /*
@@ -37,42 +38,12 @@ struct txe_st {
      */
 };
 
+DEFINE_LIST_OF(txe, TXE);
+typedef OSSL_LIST(txe) TXE_LIST;
+
 static ossl_inline unsigned char *txe_data(const TXE *e)
 {
     return (unsigned char *)(e + 1);
-}
-
-typedef struct txe_list_st {
-    TXE *head, *tail;
-} TXE_LIST;
-
-static void txe_remove(TXE_LIST *l, TXE *e)
-{
-    if (e->prev != NULL)
-        e->prev->next = e->next;
-    if (e->next != NULL)
-        e->next->prev = e->prev;
-
-    if (e == l->head)
-        l->head = e->next;
-    if (e == l->tail)
-        l->tail = e->prev;
-
-    e->next = e->prev = NULL;
-}
-
-static void txe_insert_tail(TXE_LIST *l, TXE *e)
-{
-    if (l->tail == NULL) {
-        l->head = l->tail = e;
-        e->next = e->prev = NULL;
-        return;
-    }
-
-    l->tail->next = e;
-    e->prev = l->tail;
-    e->next = NULL;
-    l->tail = e;
 }
 
 /*
@@ -145,11 +116,11 @@ OSSL_QTX *ossl_qtx_new(const OSSL_QTX_ARGS *args)
 static void qtx_cleanup_txl(TXE_LIST *l)
 {
     TXE *e, *enext;
-    for (e = l->head; e != NULL; e = enext) {
-        enext = e->next;
+
+    for (e = ossl_list_txe_head(l); e != NULL; e = enext) {
+        enext = ossl_list_txe_next(e);
         OPENSSL_free(e);
     }
-    l->head = l->tail = NULL;
 }
 
 /* Frees the QTX. */
@@ -212,9 +183,9 @@ static TXE *qtx_alloc_txe(size_t alloc_len)
     if (txe == NULL)
         return NULL;
 
-    txe->prev = txe->next = NULL;
+    ossl_list_txe_init_elem(txe);
     txe->alloc_len = alloc_len;
-    txe->data_len  = 0;
+    txe->data_len = 0;
     return txe;
 }
 
@@ -229,14 +200,15 @@ static TXE *qtx_ensure_free_txe(OSSL_QTX *qtx, size_t alloc_len)
 {
     TXE *txe;
 
-    if (qtx->free.head != NULL)
-        return qtx->free.head;
+    txe = ossl_list_txe_head(&qtx->free);
+    if (txe != NULL)
+        return txe;
 
     txe = qtx_alloc_txe(alloc_len);
     if (txe == NULL)
         return NULL;
 
-    txe_insert_tail(&qtx->free, txe);
+    ossl_list_txe_insert_tail(&qtx->free, txe);
     return txe;
 }
 
@@ -247,7 +219,7 @@ static TXE *qtx_ensure_free_txe(OSSL_QTX *qtx, size_t alloc_len)
  */
 static TXE *qtx_resize_txe(OSSL_QTX *qtx, TXE_LIST *txl, TXE *txe, size_t n)
 {
-    TXE *txe2;
+    TXE *txe2, *p;
 
     /* Should never happen. */
     if (txe == NULL)
@@ -256,25 +228,27 @@ static TXE *qtx_resize_txe(OSSL_QTX *qtx, TXE_LIST *txl, TXE *txe, size_t n)
     if (n >= SIZE_MAX - sizeof(TXE))
         return NULL;
 
+    /* Remove the item from the list to avoid accessing freed memory */
+    p = ossl_list_txe_prev(txe);
+    ossl_list_txe_remove(txl, txe);
+
     /*
      * NOTE: We do not clear old memory, although it does contain decrypted
      * data.
      */
     txe2 = OPENSSL_realloc(txe, sizeof(TXE) + n);
-    if (txe2 == NULL)
-        /* original TXE is still in tact unchanged */
-        return NULL;
-
-    if (txl != NULL && txe != txe2) {
-        if (txl->head == txe)
-            txl->head = txe2;
-        if (txl->tail == txe)
-            txl->tail = txe2;
-        if (txe->prev != NULL)
-            txe->prev->next = txe2;
-        if (txe->next != NULL)
-            txe->next->prev = txe2;
+    if (txe2 == NULL || txe == txe2) {
+        if (p == NULL)
+            ossl_list_txe_insert_head(txl, txe);
+        else
+            ossl_list_txe_insert_after(txl, p, txe);
+        return txe2;
     }
+
+    if (p == NULL)
+        ossl_list_txe_insert_head(txl, txe2);
+    else
+        ossl_list_txe_insert_after(txl, p, txe2);
 
     if (qtx->cons == txe)
         qtx->cons = txe2;
@@ -299,19 +273,19 @@ static TXE *qtx_reserve_txe(OSSL_QTX *qtx, TXE_LIST *txl,
 /* Move a TXE from pending to free. */
 static void qtx_pending_to_free(OSSL_QTX *qtx)
 {
-    TXE *txe = qtx->pending.head;
+    TXE *txe = ossl_list_txe_head(&qtx->pending);
 
     assert(txe != NULL);
-    txe_remove(&qtx->pending, txe);
+    ossl_list_txe_remove(&qtx->pending, txe);
     --qtx->pending_count;
     qtx->pending_bytes -= txe->data_len;
-    txe_insert_tail(&qtx->free, txe);
+    ossl_list_txe_insert_tail(&qtx->free, txe);
 }
 
 /* Add a TXE not currently in any list to the pending list. */
 static void qtx_add_to_pending(OSSL_QTX *qtx, TXE *txe)
 {
-    txe_insert_tail(&qtx->pending, txe);
+    ossl_list_txe_insert_tail(&qtx->pending, txe);
     ++qtx->pending_count;
     qtx->pending_bytes += txe->data_len;
 }
@@ -649,7 +623,7 @@ static TXE *qtx_ensure_cons(OSSL_QTX *qtx)
     if (txe == NULL)
         return NULL;
 
-    txe_remove(&qtx->free, txe);
+    ossl_list_txe_remove(&qtx->free, txe);
     qtx->cons = txe;
     qtx->cons_count = 0;
     txe->data_len = 0;
@@ -780,7 +754,7 @@ void ossl_qtx_finish_dgram(OSSL_QTX *qtx)
          * If we did not put anything in the datagram, just move it back to the
          * free list.
          */
-        txe_insert_tail(&qtx->free, txe);
+        ossl_list_txe_insert_tail(&qtx->free, txe);
     else
         qtx_add_to_pending(qtx, txe);
 
@@ -811,9 +785,9 @@ void ossl_qtx_flush_net(OSSL_QTX *qtx)
         return;
 
     for (;;) {
-        for (txe = qtx->pending.head, i = 0;
+        for (txe = ossl_list_txe_head(&qtx->pending), i = 0;
              txe != NULL && i < OSSL_NELEM(msg);
-             txe = txe->next, ++i)
+             txe = ossl_list_txe_next(txe), ++i)
             txe_to_msg(txe, &msg[i]);
 
         if (!i)
@@ -837,7 +811,7 @@ void ossl_qtx_flush_net(OSSL_QTX *qtx)
 
 int ossl_qtx_pop_net(OSSL_QTX *qtx, BIO_MSG *msg)
 {
-    TXE *txe = qtx->pending.head;
+    TXE *txe = ossl_list_txe_head(&qtx->pending);
 
     if (txe == NULL)
         return 0;

--- a/ssl/quic/quic_sstream.c
+++ b/ssl/quic/quic_sstream.c
@@ -271,13 +271,13 @@ int ossl_quic_sstream_get_stream_frame(QUIC_SSTREAM *qss,
     size_t num_iov_ = 0, src_len = 0, total_len = 0, i;
     uint64_t max_len;
     const unsigned char *src = NULL;
-    UINT_SET_ITEM *range = qss->new_set.head;
+    UINT_SET_ITEM *range = ossl_list_uint_set_head(&qss->new_set);
 
     if (*num_iov < 2)
         return 0;
 
     for (i = 0; i < skip && range != NULL; ++i)
-        range = range->next;
+        range = ossl_list_uint_set_next(range);
 
     if (range == NULL) {
         /* No new bytes to send, but we might have a FIN */
@@ -476,6 +476,8 @@ int ossl_quic_sstream_append(QUIC_SSTREAM *qss,
 
 static void qss_cull(QUIC_SSTREAM *qss)
 {
+    UINT_SET_ITEM *h = ossl_list_uint_set_head(&qss->acked_set);
+
     /*
      * Potentially cull data from our ring buffer. This can happen once data has
      * been ACKed and we know we are never going to have to transmit it again.
@@ -492,10 +494,8 @@ static void qss_cull(QUIC_SSTREAM *qss)
      * We only need to check the first range entry in the integer set because we
      * can only cull contiguous areas at the start of the ring buffer anyway.
      */
-    if (qss->acked_set.head != NULL)
-        ring_buf_cpop_range(&qss->ring_buf,
-                            qss->acked_set.head->range.start,
-                            qss->acked_set.head->range.end);
+    if (h != NULL)
+        ring_buf_cpop_range(&qss->ring_buf, h->range.start, h->range.end);
 }
 
 int ossl_quic_sstream_set_buffer_size(QUIC_SSTREAM *qss, size_t num_bytes)

--- a/test/list_test.c
+++ b/test/list_test.c
@@ -43,6 +43,8 @@ static int test_fizzbuzz(void)
         return 0;
 
     for (i = 1; i < nelem; i++) {
+        ossl_list_fizz_init_elem(elem + i);
+        ossl_list_buzz_init_elem(elem + i);
         elem[i].n = i;
         if (i % 3 == 0) {
             ossl_list_fizz_insert_tail(&a, elem + i);
@@ -99,8 +101,10 @@ static int test_insert(void)
     int n = 1;
 
     ossl_list_int_init(&l);
-    for (i = 0; i < OSSL_NELEM(elem); i++)
-            elem[i].n = i;
+    for (i = 0; i < OSSL_NELEM(elem); i++) {
+        ossl_list_int_init_elem(elem + i);
+        elem[i].n = i;
+    }
 
     /* Check various insert options - head, tail, middle */
     ossl_list_int_insert_head(&l, elem + 3);                /* 3 */

--- a/test/list_test.c
+++ b/test/list_test.c
@@ -39,6 +39,9 @@ static int test_fizzbuzz(void)
     ossl_list_fizz_init(&a);
     ossl_list_buzz_init(&b);
 
+    if (!TEST_true(ossl_list_fizz_is_empty(&a)))
+        return 0;
+
     for (i = 1; i < nelem; i++) {
         elem[i].n = i;
         if (i % 3 == 0) {
@@ -51,7 +54,8 @@ static int test_fizzbuzz(void)
         }
     }
 
-    if (!TEST_size_t_eq(ossl_list_fizz_num(&a), na)
+    if (!TEST_false(ossl_list_fizz_is_empty(&a))
+            || !TEST_size_t_eq(ossl_list_fizz_num(&a), na)
             || !TEST_size_t_eq(ossl_list_buzz_num(&b), nb)
             || !TEST_ptr(ossl_list_fizz_head(&a))
             || !TEST_ptr(ossl_list_fizz_tail(&a))


### PR DESCRIPTION
This is instead of re-implementing a linked list in four or five different places.

- [ ] documentation is added or updated
- [ ] tests are added or updated
