### PR TITLE
`cmp_client.c`: fix handling of total_timeout for RR and GENM transactions

### DIFF
--- a/crypto/cmp/cmp_client.c
+++ b/crypto/cmp/cmp_client.c
@@ -122,13 +122,13 @@ static int save_statusInfo(OSSL_CMP_CTX *ctx, OSSL_CMP_PKISI *si)
 static int send_receive_check(OSSL_CMP_CTX *ctx, const OSSL_CMP_MSG *req,
                               OSSL_CMP_MSG **rep, int expected_type)
 {
-    int is_enrollment = IS_CREP(expected_type)
-        || expected_type == OSSL_CMP_PKIBODY_POLLREP
-        || expected_type == OSSL_CMP_PKIBODY_PKICONF;
+    int begin_transaction =
+        expected_type != OSSL_CMP_PKIBODY_POLLREP
+        && expected_type != OSSL_CMP_PKIBODY_PKICONF;
     const char *req_type_str =
         ossl_cmp_bodytype_to_string(OSSL_CMP_MSG_get_bodytype(req));
     const char *expected_type_str = ossl_cmp_bodytype_to_string(expected_type);
-    int msg_timeout;
+    int bak_msg_timeout = ctx->msg_timeout;
     int bt;
     time_t now = time(NULL);
     int time_left;
@@ -136,15 +136,16 @@ static int send_receive_check(OSSL_CMP_CTX *ctx, const OSSL_CMP_MSG *req,
 
     if (transfer_cb == NULL)
         transfer_cb = OSSL_CMP_MSG_http_perform;
-
     *rep = NULL;
-    msg_timeout = ctx->msg_timeout; /* backup original value */
-    if (is_enrollment && ctx->total_timeout != 0 /* timeout not infinite */) {
+
+    if (ctx->total_timeout != 0 /* not waiting indefinitely */) {
+        if (begin_transaction)
+            ctx->end_time = now + ctx->total_timeout;
         if (now >= ctx->end_time) {
             ERR_raise(ERR_LIB_CMP, CMP_R_TOTAL_TIMEOUT);
             return 0;
         }
-        if (!ossl_assert(ctx->end_time - time(NULL) < INT_MAX)) {
+        if (!ossl_assert(ctx->end_time - now < INT_MAX)) {
             /* actually cannot happen due to assignment in initial_certreq() */
             ERR_raise(ERR_LIB_CMP, CMP_R_INVALID_ARGS);
             return 0;
@@ -160,7 +161,7 @@ static int send_receive_check(OSSL_CMP_CTX *ctx, const OSSL_CMP_MSG *req,
     ossl_cmp_log1(INFO, ctx, "sending %s", req_type_str);
 
     *rep = (*transfer_cb)(ctx, req);
-    ctx->msg_timeout = msg_timeout; /* restore original value */
+    ctx->msg_timeout = bak_msg_timeout;
 
     if (*rep == NULL) {
         ERR_raise_data(ERR_LIB_CMP,
@@ -645,9 +646,6 @@ static int initial_certreq(OSSL_CMP_CTX *ctx,
     ctx->status = OSSL_CMP_PKISTATUS_request;
     if (!ossl_cmp_ctx_set0_newCert(ctx, NULL))
         return 0;
-
-    if (ctx->total_timeout != 0) /* else ctx->end_time is not used */
-        ctx->end_time = time(NULL) + ctx->total_timeout;
 
     /* also checks if all necessary options are set */
     if ((req = ossl_cmp_certreq_new(ctx, req_type, crm)) == NULL)

--- a/crypto/cmp/cmp_client.c
+++ b/crypto/cmp/cmp_client.c
@@ -139,7 +139,7 @@ static int send_receive_check(OSSL_CMP_CTX *ctx, const OSSL_CMP_MSG *req,
 
     *rep = NULL;
     msg_timeout = ctx->msg_timeout; /* backup original value */
-    if (is_enrollment && ctx->total_timeout > 0 /* timeout is not infinite */) {
+    if (is_enrollment && ctx->total_timeout != 0 /* timeout not infinite */) {
         if (now >= ctx->end_time) {
             ERR_raise(ERR_LIB_CMP, CMP_R_TOTAL_TIMEOUT);
             return 0;
@@ -164,7 +164,7 @@ static int send_receive_check(OSSL_CMP_CTX *ctx, const OSSL_CMP_MSG *req,
 
     if (*rep == NULL) {
         ERR_raise_data(ERR_LIB_CMP,
-                       ctx->total_timeout > 0 && time(NULL) >= ctx->end_time ?
+                       ctx->total_timeout != 0 && time(NULL) >= ctx->end_time ?
                        CMP_R_TOTAL_TIMEOUT : CMP_R_TRANSFER_ERROR,
                        "request sent: %s, expected response: %s",
                        req_type_str, expected_type_str);
@@ -236,7 +236,7 @@ static int send_receive_check(OSSL_CMP_CTX *ctx, const OSSL_CMP_MSG *req,
  * On receiving a pollRep, which includes a checkAfter value, it return this
  * value if sleep == 0, else it sleeps as long as indicated and retries.
  *
- * A transaction timeout is enabled if ctx->total_timeout is > 0.
+ * A transaction timeout is enabled if ctx->total_timeout is != 0.
  * In this case polling will continue until the timeout is reached and then
  * polling is done a last time even if this is before the "checkAfter" time.
  *
@@ -308,7 +308,7 @@ static int poll_for_response(OSSL_CMP_CTX *ctx, int sleep, int rid,
                           "received polling response%s; checkAfter = %ld seconds",
                           str, check_after);
 
-            if (ctx->total_timeout > 0) { /* timeout is not infinite */
+            if (ctx->total_timeout != 0) { /* timeout is not infinite */
                 const int exp = 5; /* expected max time per msg round trip */
                 int64_t time_left = (int64_t)(ctx->end_time - exp - time(NULL));
 
@@ -646,7 +646,7 @@ static int initial_certreq(OSSL_CMP_CTX *ctx,
     if (!ossl_cmp_ctx_set0_newCert(ctx, NULL))
         return 0;
 
-    if (ctx->total_timeout > 0) /* else ctx->end_time is not used */
+    if (ctx->total_timeout != 0) /* else ctx->end_time is not used */
         ctx->end_time = time(NULL) + ctx->total_timeout;
 
     /* also checks if all necessary options are set */

--- a/crypto/cmp/cmp_ctx.c
+++ b/crypto/cmp/cmp_ctx.c
@@ -919,9 +919,13 @@ int OSSL_CMP_CTX_set_option(OSSL_CMP_CTX *ctx, int opt, int val)
         ctx->keep_alive = val;
         break;
     case OSSL_CMP_OPT_MSG_TIMEOUT:
+        if (val < 0)
+            val = 0;
         ctx->msg_timeout = val;
         break;
     case OSSL_CMP_OPT_TOTAL_TIMEOUT:
+        if (val < 0)
+            val = 0;
         ctx->total_timeout = val;
         break;
     case OSSL_CMP_OPT_PERMIT_TA_IN_EXTRACERTS_FOR_IR:

--- a/doc/man1/openssl-cmp.pod.in
+++ b/doc/man1/openssl-cmp.pod.in
@@ -508,15 +508,17 @@ The default value is 1, which means preferring to keep the connection open.
 
 =item B<-msg_timeout> I<seconds>
 
-Number of seconds (or 0 for infinite) a CMP request-response message round trip
+Number of seconds a CMP request-response message round trip
 is allowed to take before a timeout error is returned.
+A value <= 0 means no limitation (waiting indefinitely).
 Default is to use the B<-total_timeout> setting.
 
 =item B<-total_timeout> I<seconds>
 
-Maximum number seconds an overall enrollment transaction may take,
-including attempts polling for certificates on C<waiting> PKIStatus.
-Default is 0 (infinite).
+Maximum total number of seconds a transaction may take,
+including polling etc.
+A value <= 0 means no limitation (waiting indefinitely).
+Default is 0.
 
 =back
 

--- a/doc/man3/OSSL_CMP_CTX_new.pod
+++ b/doc/man3/OSSL_CMP_CTX_new.pod
@@ -223,14 +223,17 @@ The following options can be set:
 
 =item B<OSSL_CMP_OPT_MSG_TIMEOUT>
 
-        Number of seconds (or 0 for infinite) a CMP message round trip is
-        allowed to take before a timeout error is returned.
-        Default is to use the B<OSSL_CMP_OPT_MSG_TIMEOUT> setting.
+        Number of seconds a CMP request-response message round trip
+        is allowed to take before a timeout error is returned.
+        A value <= 0 means no limitation (waiting indefinitely).
+        Default is to use the B<OSSL_CMP_OPT_TOTAL_TIMEOUT> setting.
 
 =item B<OSSL_CMP_OPT_TOTAL_TIMEOUT>
 
-        Maximum total number of seconds an enrollment (including polling)
-        may take. Default is 0 (infinite).
+        Maximum total number of seconds a transaction may take,
+        including polling etc.
+        A value <= 0 means no limitation (waiting indefinitely).
+        Default is 0.
 
 =item B<OSSL_CMP_OPT_VALIDITY_DAYS>
 


### PR DESCRIPTION
It turns out that initialization of `ctx->end_time` was missing for revocation and general message transactions, which mislead the timeout checks and error reporting.

Also fix related documentation.


