### PR TITLE
Fix no longer implicitly refresh the cached TBSCertificate for 3.0+

### DIFF
--- a/crypto/x509/x_all.c
+++ b/crypto/x509/x_all.c
@@ -59,34 +59,34 @@ int NETSCAPE_SPKI_verify(NETSCAPE_SPKI *a, EVP_PKEY *r)
 
 int X509_sign(X509 *x, EVP_PKEY *pkey, const EVP_MD *md)
 {
-    int ret;
-
     if (x == NULL) {
         ERR_raise(ERR_LIB_X509, ERR_R_PASSED_NULL_PARAMETER);
         return 0;
     }
-    ret = ASN1_item_sign_ex(ASN1_ITEM_rptr(X509_CINF), &x->cert_info.signature,
-                            &x->sig_alg, &x->signature, &x->cert_info, NULL,
-                            pkey, md, x->libctx, x->propq);
-    if (ret > 0)
-        x->cert_info.enc.modified = 1;
-    return ret;
+
+    /*
+     * Setting the modified flag before signing it. This makes the cached
+     * encoding to be ignored, so even if the certificate fields have changed,
+     * they are signed correctly.
+     * The X509_sign_ctx, X509_REQ_sign{,_ctx}, X509_CRL_sign{,_ctx} functions
+     * which exist below are the same.
+     */
+    x->cert_info.enc.modified = 1;
+    return ASN1_item_sign_ex(ASN1_ITEM_rptr(X509_CINF), &x->cert_info.signature,
+                             &x->sig_alg, &x->signature, &x->cert_info, NULL,
+                             pkey, md, x->libctx, x->propq);
 }
 
 int X509_sign_ctx(X509 *x, EVP_MD_CTX *ctx)
 {
-    int ret;
-
     if (x == NULL) {
         ERR_raise(ERR_LIB_X509, ERR_R_PASSED_NULL_PARAMETER);
         return 0;
     }
-    ret = ASN1_item_sign_ctx(ASN1_ITEM_rptr(X509_CINF),
-                             &x->cert_info.signature,
-                             &x->sig_alg, &x->signature, &x->cert_info, ctx);
-    if (ret > 0)
-        x->cert_info.enc.modified = 1;
-    return ret;
+    x->cert_info.enc.modified = 1;
+    return ASN1_item_sign_ctx(ASN1_ITEM_rptr(X509_CINF),
+                              &x->cert_info.signature,
+                              &x->sig_alg, &x->signature, &x->cert_info, ctx);
 }
 
 static ASN1_VALUE *simple_get_asn1(const char *url, BIO *bio, BIO *rbio,
@@ -111,66 +111,50 @@ X509 *X509_load_http(const char *url, BIO *bio, BIO *rbio, int timeout)
 
 int X509_REQ_sign(X509_REQ *x, EVP_PKEY *pkey, const EVP_MD *md)
 {
-    int ret;
-
     if (x == NULL) {
         ERR_raise(ERR_LIB_X509, ERR_R_PASSED_NULL_PARAMETER);
         return 0;
     }
-    ret = ASN1_item_sign_ex(ASN1_ITEM_rptr(X509_REQ_INFO), &x->sig_alg, NULL,
-                            x->signature, &x->req_info, NULL,
-                            pkey, md, x->libctx, x->propq);
-    if (ret > 0)
-        x->req_info.enc.modified = 1;
-    return ret;
+    x->req_info.enc.modified = 1;
+    return ASN1_item_sign_ex(ASN1_ITEM_rptr(X509_REQ_INFO), &x->sig_alg, NULL,
+                             x->signature, &x->req_info, NULL,
+                             pkey, md, x->libctx, x->propq);
 }
 
 int X509_REQ_sign_ctx(X509_REQ *x, EVP_MD_CTX *ctx)
 {
-    int ret;
-
     if (x == NULL) {
         ERR_raise(ERR_LIB_X509, ERR_R_PASSED_NULL_PARAMETER);
         return 0;
     }
-    ret = ASN1_item_sign_ctx(ASN1_ITEM_rptr(X509_REQ_INFO),
-                             &x->sig_alg, NULL, x->signature, &x->req_info,
-                             ctx);
-    if (ret > 0)
-        x->req_info.enc.modified = 1;
-    return ret;
+    x->req_info.enc.modified = 1;
+    return ASN1_item_sign_ctx(ASN1_ITEM_rptr(X509_REQ_INFO),
+                              &x->sig_alg, NULL, x->signature, &x->req_info,
+                              ctx);
 }
 
 int X509_CRL_sign(X509_CRL *x, EVP_PKEY *pkey, const EVP_MD *md)
 {
-    int ret;
-
     if (x == NULL) {
         ERR_raise(ERR_LIB_X509, ERR_R_PASSED_NULL_PARAMETER);
         return 0;
     }
-    ret = ASN1_item_sign_ex(ASN1_ITEM_rptr(X509_CRL_INFO), &x->crl.sig_alg,
-                            &x->sig_alg, &x->signature, &x->crl, NULL,
-                            pkey, md, x->libctx, x->propq);
-    if (ret > 0)
-        x->crl.enc.modified = 1;
-    return ret;
+    x->crl.enc.modified = 1;
+    return ASN1_item_sign_ex(ASN1_ITEM_rptr(X509_CRL_INFO), &x->crl.sig_alg,
+                             &x->sig_alg, &x->signature, &x->crl, NULL,
+                             pkey, md, x->libctx, x->propq);
 }
 
 int X509_CRL_sign_ctx(X509_CRL *x, EVP_MD_CTX *ctx)
 {
-    int ret;
-
     if (x == NULL) {
         ERR_raise(ERR_LIB_X509, ERR_R_PASSED_NULL_PARAMETER);
         return 0;
     }
-    ret = ASN1_item_sign_ctx(ASN1_ITEM_rptr(X509_CRL_INFO),
-                             &x->crl.sig_alg, &x->sig_alg, &x->signature,
-                             &x->crl, ctx);
-    if (ret > 0)
-        x->crl.enc.modified = 1;
-    return ret;
+    x->crl.enc.modified = 1;
+    return ASN1_item_sign_ctx(ASN1_ITEM_rptr(X509_CRL_INFO),
+                              &x->crl.sig_alg, &x->sig_alg, &x->signature,
+                              &x->crl, ctx);
 }
 
 X509_CRL *X509_CRL_load_http(const char *url, BIO *bio, BIO *rbio, int timeout)


### PR DESCRIPTION
…call was successful"

This reverts commit 9249a34b076df9a9d55ab74ab465d336980cae6a. Fixes #19388

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
