### PR TITLE
Change how providers are selected with pkey operations

### DIFF
--- a/crypto/evp/asymcipher.c
+++ b/crypto/evp/asymcipher.c
@@ -68,10 +68,10 @@ static int evp_pkey_asym_cipher_init(EVP_PKEY_CTX *ctx, int operation,
     /*
      * We perform two iterations:
      *
-     * 1.  Do the normal asym cipher fetch, using the fetching data given by
-     *     the EVP_PKEY_CTX.
-     * 2.  Do the provider specific asym cipher fetch, from the same provider
+     * 1.  Do the provider specific asym cipher fetch, from the same provider
      *     as |ctx->keymgmt|
+     * 2.  Do the normal asym cipher fetch, using the fetching data given by
+     *     the EVP_PKEY_CTX.
      *
      * We then try to fetch the keymgmt from the same provider as the
      * asym cipher, and try to export |ctx->pkey| to that keymgmt (when
@@ -95,18 +95,17 @@ static int evp_pkey_asym_cipher_init(EVP_PKEY_CTX *ctx, int operation,
 
         switch (iter) {
         case 1:
-            cipher = EVP_ASYM_CIPHER_fetch(ctx->libctx, supported_ciph,
-                                           ctx->propquery);
-            if (cipher != NULL)
-                tmp_prov = EVP_ASYM_CIPHER_get0_provider(cipher);
-            break;
-        case 2:
             tmp_prov = EVP_KEYMGMT_get0_provider(ctx->keymgmt);
             cipher =
                 evp_asym_cipher_fetch_from_prov((OSSL_PROVIDER *)tmp_prov,
                                                 supported_ciph, ctx->propquery);
+            break;
+        case 2:
+            cipher = EVP_ASYM_CIPHER_fetch(ctx->libctx, supported_ciph,
+                                           ctx->propquery);
             if (cipher == NULL)
                 goto legacy;
+            tmp_prov = EVP_ASYM_CIPHER_get0_provider(cipher);
             break;
         }
         if (cipher == NULL)

--- a/crypto/evp/exchange.c
+++ b/crypto/evp/exchange.c
@@ -257,10 +257,10 @@ int EVP_PKEY_derive_init_ex(EVP_PKEY_CTX *ctx, const OSSL_PARAM params[])
     /*
      * We perform two iterations:
      *
-     * 1.  Do the normal exchange fetch, using the fetching data given by
-     *     the EVP_PKEY_CTX.
-     * 2.  Do the provider specific exchange fetch, from the same provider
+     * 1.  Do the provider specific exchange fetch, from the same provider
      *     as |ctx->keymgmt|
+     * 2.  Do the normal exchange fetch, using the fetching data given by
+     *     the EVP_PKEY_CTX.
      *
      * We then try to fetch the keymgmt from the same provider as the
      * exchange, and try to export |ctx->pkey| to that keymgmt (when
@@ -284,18 +284,17 @@ int EVP_PKEY_derive_init_ex(EVP_PKEY_CTX *ctx, const OSSL_PARAM params[])
 
         switch (iter) {
         case 1:
-            exchange =
-                EVP_KEYEXCH_fetch(ctx->libctx, supported_exch, ctx->propquery);
-            if (exchange != NULL)
-                tmp_prov = EVP_KEYEXCH_get0_provider(exchange);
-            break;
-        case 2:
             tmp_prov = EVP_KEYMGMT_get0_provider(ctx->keymgmt);
             exchange =
                 evp_keyexch_fetch_from_prov((OSSL_PROVIDER *)tmp_prov,
                                               supported_exch, ctx->propquery);
+            break;
+        case 2:
+            exchange =
+                EVP_KEYEXCH_fetch(ctx->libctx, supported_exch, ctx->propquery);
             if (exchange == NULL)
                 goto legacy;
+            tmp_prov = EVP_KEYEXCH_get0_provider(exchange);
             break;
         }
         if (exchange == NULL)

--- a/crypto/evp/kem.c
+++ b/crypto/evp/kem.c
@@ -64,10 +64,10 @@ static int evp_kem_init(EVP_PKEY_CTX *ctx, int operation,
      * checking if kem is already there.
      * We perform two iterations:
      *
-     * 1.  Do the normal kem fetch, using the fetching data given by
-     *     the EVP_PKEY_CTX.
-     * 2.  Do the provider specific kem fetch, from the same provider
+     * 1.  Do the provider specific kem fetch, from the same provider
      *     as |ctx->keymgmt|
+     * 2.  Do the normal kem fetch, using the fetching data given by
+     *     the EVP_PKEY_CTX.
      *
      * We then try to fetch the keymgmt from the same provider as the
      * kem, and try to export |ctx->pkey| to that keymgmt (when this
@@ -91,16 +91,15 @@ static int evp_kem_init(EVP_PKEY_CTX *ctx, int operation,
 
         switch (iter) {
         case 1:
-            kem = EVP_KEM_fetch(ctx->libctx, supported_kem, ctx->propquery);
-            if (kem != NULL)
-                tmp_prov = EVP_KEM_get0_provider(kem);
-            break;
-        case 2:
             tmp_prov = EVP_KEYMGMT_get0_provider(ctx->keymgmt);
             kem = evp_kem_fetch_from_prov((OSSL_PROVIDER *)tmp_prov,
                                           supported_kem, ctx->propquery);
-
-            if (kem == NULL) {
+            break;
+        case 2:
+            kem = EVP_KEM_fetch(ctx->libctx, supported_kem, ctx->propquery);
+            if (kem != NULL)
+                tmp_prov = EVP_KEM_get0_provider(kem);
+            else {
                 ERR_raise(ERR_LIB_EVP,
                           EVP_R_OPERATION_NOT_SUPPORTED_FOR_THIS_KEYTYPE);
                 ret = -2;

--- a/crypto/evp/m_sigver.c
+++ b/crypto/evp/m_sigver.c
@@ -116,10 +116,10 @@ static int do_sigver_init(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx,
     /*
      * We perform two iterations:
      *
-     * 1.  Do the normal signature fetch, using the fetching data given by
-     *     the EVP_PKEY_CTX.
-     * 2.  Do the provider specific signature fetch, from the same provider
+     * 1.  Do the provider specific signature fetch, from the same provider
      *     as |ctx->keymgmt|
+     * 2.  Do the normal signature fetch, using the fetching data given by
+     *     the EVP_PKEY_CTX.
      *
      * We then try to fetch the keymgmt from the same provider as the
      * signature, and try to export |ctx->pkey| to that keymgmt (when
@@ -143,18 +143,17 @@ static int do_sigver_init(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx,
 
         switch (iter) {
         case 1:
-            signature = EVP_SIGNATURE_fetch(locpctx->libctx, supported_sig,
-                                            locpctx->propquery);
-            if (signature != NULL)
-                tmp_prov = EVP_SIGNATURE_get0_provider(signature);
-            break;
-        case 2:
             tmp_prov = EVP_KEYMGMT_get0_provider(locpctx->keymgmt);
             signature =
                 evp_signature_fetch_from_prov((OSSL_PROVIDER *)tmp_prov,
                                               supported_sig, locpctx->propquery);
+            break;
+        case 2:
+            signature = EVP_SIGNATURE_fetch(locpctx->libctx, supported_sig,
+                                            locpctx->propquery);
             if (signature == NULL)
                 goto legacy;
+            tmp_prov = EVP_SIGNATURE_get0_provider(signature);
             break;
         }
         if (signature == NULL)

--- a/crypto/evp/signature.c
+++ b/crypto/evp/signature.c
@@ -439,10 +439,10 @@ static int evp_pkey_signature_init(EVP_PKEY_CTX *ctx, int operation,
     /*
      * We perform two iterations:
      *
-     * 1.  Do the normal signature fetch, using the fetching data given by
-     *     the EVP_PKEY_CTX.
-     * 2.  Do the provider specific signature fetch, from the same provider
+     * 1.  Do the provider specific signature fetch, from the same provider
      *     as |ctx->keymgmt|
+     * 2.  Do the normal signature fetch, using the fetching data given by
+     *     the EVP_PKEY_CTX.
      *
      * We then try to fetch the keymgmt from the same provider as the
      * signature, and try to export |ctx->pkey| to that keymgmt (when
@@ -466,18 +466,17 @@ static int evp_pkey_signature_init(EVP_PKEY_CTX *ctx, int operation,
 
         switch (iter) {
         case 1:
-            signature =
-                EVP_SIGNATURE_fetch(ctx->libctx, supported_sig, ctx->propquery);
-            if (signature != NULL)
-                tmp_prov = EVP_SIGNATURE_get0_provider(signature);
-            break;
-        case 2:
             tmp_prov = EVP_KEYMGMT_get0_provider(ctx->keymgmt);
             signature =
                 evp_signature_fetch_from_prov((OSSL_PROVIDER *)tmp_prov,
                                               supported_sig, ctx->propquery);
+            break;
+        case 2:
+            signature =
+                EVP_SIGNATURE_fetch(ctx->libctx, supported_sig, ctx->propquery);
             if (signature == NULL)
                 goto legacy;
+            tmp_prov = EVP_SIGNATURE_get0_provider(signature);
             break;
         }
         if (signature == NULL)


### PR DESCRIPTION
This PR changes the selection logic for finding the correct provider when initializing operations that use pkeys.

The TL;DR is: OpenSSL should prefer to use the same provider that was used to fetch the keys when selecting an operation handler. And fallback to searching more generic providers only if that provider cannot handle the requested operation.

I ran through this issues as I am writing this provider:
https://github.com/latchset/pkcs11-provider

A peculiar thing with pkcs11 providers is that it is always very obvious that keys come from a pkcs11 token because you need to use a pkcs11: URI to source them, and that selects automatically the pkcs11 provider store functions which will give back a pkcs11 provider specific key.
This means that by just passing a URI into openssl commands without specifying a provider or propq strings you end up using the pkcs11-provider and obtain a valid key handler.

However after obtaining a key I found out, earlier in development, that all operations were failing with odd errors due to key export issues (private keys cannot be exported from a pkcs11 token).
Not knowing any better I initially worked around this problem by returning keys that had a special data_type (for example "PKCS11-RSA" instead of "RSA") and exporting from keymgmt and other operations under both the standard and the special name ...
I now have a PR to rectify the situation depending on this PR, which I have tested with:
https://github.com/latchset/pkcs11-provider/pull/67

Why change selection ?

In general I think it makes more sense to stick to the provider that gave you keys by default, it just seem to make more sense. However there are actual practical benefits in terms of applications.

Having to always pass a "provider=whatever" property to *all* EVP_PKEY_something() calls is somewhat burdensome for existing applications ported over from the OpenSSL 1.1 days, it would definitely be simpler to just change those calls that fetch keys, and then assume that if you got a key from provider X, whenever you do an operation on that key, that provider X is being used by default.

For example, an application wanting to use FIPS where possible, but ok to make exception where not (as stop gap to compliance) would want to avoid setting the provider=fips selection in the configuration file and rather do it in code where needed.

Without the current PR it would have the daunting tasks to change all invocations and carefully manually set the propq everywhere. Because at every turn the current code will always select the 'default' provider in preference, regardless of which provider's keymgmt functions were used to source or generate the keys.


Another case is where an application load keys directly but then uses libraries that themselves use openssl. With this PR the application can make sure the key is loaded with a provider of choice (for example a provider that uses a hw accelerator), and then not need to change the 3rd party library to have it use the "preferred" provider by default. This is especially important when the acceleration engine offers only part of the functionality. In that case the desired behavior is to use the acceleration provider where possible, but fallback to the 'default' provider otherwise.


Finally I could not find a reason to not select the "closest" provider first, and only later fallback to a generic one, that doesn't mean a reason does not exist, I just couldn't find one.