### PR TITLE
Fix sctp compile errors

### DIFF
--- a/.github/workflows/run-checker-daily.yml
+++ b/.github/workflows/run-checker-daily.yml
@@ -140,7 +140,7 @@ jobs:
     - name: Install Dependencies for sctp option
       run:  |
         sudo apt-get update
-        sudo apt-get -yq install libsctp-dev
+        sudo apt-get -yq install lksctp-tools libsctp-dev
         sudo sysctl -w net.sctp.auth_enable=1
       if: matrix.opt == 'enable-sctp'
     - name: config

--- a/.github/workflows/run-checker-daily.yml
+++ b/.github/workflows/run-checker-daily.yml
@@ -98,7 +98,7 @@ jobs:
           no-ripemd,
           no-rmd160,
           no-scrypt,
-          no-sctp,
+          enable-sctp,
           no-secure-memory,
           no-seed,
           no-shared,
@@ -137,6 +137,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - name: Install Dependencies for sctp option
+      run:  |
+        sudo apt-get update
+        sudo apt-get -yq install libsctp-dev
+        sudo sysctl -w net.sctp.auth_enable=1
+      if: matrix.opt == 'enable-sctp'
     - name: config
       run: CC=clang ./config --banner=Configured --strict-warnings ${{ matrix.opt }}
     - name: config dump

--- a/ssl/record/rec_layer_d1.c
+++ b/ssl/record/rec_layer_d1.c
@@ -178,14 +178,10 @@ static void dtls_unbuffer_record(SSL_CONNECTION *s)
         s->rlayer.curr_rec = 0;
 
 #ifndef OPENSSL_NO_SCTP
-        {
-            BIO *rbio = SSL_get_rbio(SSL_CONNECTION_GET_SSL(s));
-
-            /* Restore bio_dgram_sctp_rcvinfo struct */
-            if (BIO_dgram_is_sctp(rbio)) {
-                BIO_ctrl(rbio, BIO_CTRL_DGRAM_SCTP_SET_RCVINFO,
-                         sizeof(rdata->recordinfo), &rdata->recordinfo);
-            }
+        /* Restore bio_dgram_sctp_rcvinfo struct */
+        if (BIO_dgram_is_sctp(s->rbio)) {
+            BIO_ctrl(s->rbio, BIO_CTRL_DGRAM_SCTP_SET_RCVINFO,
+                     sizeof(rdata->recordinfo), &rdata->recordinfo);
         }
 #endif
 

--- a/ssl/record/rec_layer_d1.c
+++ b/ssl/record/rec_layer_d1.c
@@ -136,12 +136,16 @@ int dtls_buffer_record(SSL_CONNECTION *s, TLS_RECORD *rec)
     item->data = rdata;
 
 #ifndef OPENSSL_NO_SCTP
-    /* Store bio_dgram_sctp_rcvinfo struct */
-    if (BIO_dgram_is_sctp(SSL_get_rbio(ssl)) &&
-        (SSL_get_state(ssl) == TLS_ST_SR_FINISHED
-         || SSL_get_state(ssl) == TLS_ST_CR_FINISHED)) {
-        BIO_ctrl(SSL_get_rbio(ssl), BIO_CTRL_DGRAM_SCTP_GET_RCVINFO,
-                 sizeof(rdata->recordinfo), &rdata->recordinfo);
+    {
+        SSL *ssl = SSL_CONNECTION_GET_SSL(s);
+
+        /* Store bio_dgram_sctp_rcvinfo struct */
+        if (BIO_dgram_is_sctp(SSL_get_rbio(ssl)) &&
+            (SSL_get_state(ssl) == TLS_ST_SR_FINISHED
+             || SSL_get_state(ssl) == TLS_ST_CR_FINISHED)) {
+            BIO_ctrl(SSL_get_rbio(ssl), BIO_CTRL_DGRAM_SCTP_GET_RCVINFO,
+                     sizeof(rdata->recordinfo), &rdata->recordinfo);
+        }
     }
 #endif
 
@@ -174,10 +178,14 @@ static void dtls_unbuffer_record(SSL_CONNECTION *s)
         s->rlayer.curr_rec = 0;
 
 #ifndef OPENSSL_NO_SCTP
-        /* Restore bio_dgram_sctp_rcvinfo struct */
-        if (BIO_dgram_is_sctp(SSL_get_rbio(s))) {
-            BIO_ctrl(SSL_get_rbio(s), BIO_CTRL_DGRAM_SCTP_SET_RCVINFO,
-                        sizeof(rdata->recordinfo), &rdata->recordinfo);
+        {
+            BIO *rbio = SSL_get_rbio(SSL_CONNECTION_GET_SSL(s));
+
+            /* Restore bio_dgram_sctp_rcvinfo struct */
+            if (BIO_dgram_is_sctp(rbio)) {
+                BIO_ctrl(rbio, BIO_CTRL_DGRAM_SCTP_SET_RCVINFO,
+                         sizeof(rdata->recordinfo), &rdata->recordinfo);
+            }
         }
 #endif
 

--- a/ssl/record/rec_layer_d1.c
+++ b/ssl/record/rec_layer_d1.c
@@ -136,16 +136,12 @@ int dtls_buffer_record(SSL_CONNECTION *s, TLS_RECORD *rec)
     item->data = rdata;
 
 #ifndef OPENSSL_NO_SCTP
-    {
-        SSL *ssl = SSL_CONNECTION_GET_SSL(s);
-
-        /* Store bio_dgram_sctp_rcvinfo struct */
-        if (BIO_dgram_is_sctp(SSL_get_rbio(ssl)) &&
-            (SSL_get_state(ssl) == TLS_ST_SR_FINISHED
-             || SSL_get_state(ssl) == TLS_ST_CR_FINISHED)) {
-            BIO_ctrl(SSL_get_rbio(ssl), BIO_CTRL_DGRAM_SCTP_GET_RCVINFO,
-                     sizeof(rdata->recordinfo), &rdata->recordinfo);
-        }
+    /* Store bio_dgram_sctp_rcvinfo struct */
+    if (BIO_dgram_is_sctp(s->rbio) &&
+        (ossl_statem_get_state(s) == TLS_ST_SR_FINISHED
+         || ossl_statem_get_state(s) == TLS_ST_CR_FINISHED)) {
+        BIO_ctrl(s->rbio, BIO_CTRL_DGRAM_SCTP_GET_RCVINFO,
+                 sizeof(rdata->recordinfo), &rdata->recordinfo);
     }
 #endif
 

--- a/ssl/statem/statem.c
+++ b/ssl/statem/statem.c
@@ -116,6 +116,11 @@ int SSL_in_before(const SSL *s)
         && (sc->statem.state == MSG_FLOW_UNINITED);
 }
 
+OSSL_HANDSHAKE_STATE ossl_statem_get_state(SSL_CONNECTION *s)
+{
+    return s != NULL ? s->statem.hand_state : TLS_ST_BEFORE;
+}
+
 /*
  * Clear the state machine state and reset back to MSG_FLOW_UNINITED
  */

--- a/ssl/statem/statem.h
+++ b/ssl/statem/statem.h
@@ -128,6 +128,7 @@ typedef struct ossl_statem_st OSSL_STATEM;
 
 __owur int ossl_statem_accept(SSL *s);
 __owur int ossl_statem_connect(SSL *s);
+OSSL_HANDSHAKE_STATE ossl_statem_get_state(SSL_CONNECTION *s);
 void ossl_statem_clear(SSL_CONNECTION *s);
 void ossl_statem_set_renegotiate(SSL_CONNECTION *s);
 void ossl_statem_send_fatal(SSL_CONNECTION *s, int al);

--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -3411,7 +3411,7 @@ WORK_STATE tls_post_process_client_key_exchange(SSL_CONNECTION *s,
                 return WORK_ERROR;
             }
 
-            BIO_ctrl(SSL_get_wbio(SSL_CONNECTION_GET_SSL(s)), BIO_CTRL_DGRAM_SCTP_ADD_AUTH_KEY,
+            BIO_ctrl(s->wbio, BIO_CTRL_DGRAM_SCTP_ADD_AUTH_KEY,
                      sizeof(sctpauthkey), sctpauthkey);
         }
     }

--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -3411,7 +3411,7 @@ WORK_STATE tls_post_process_client_key_exchange(SSL_CONNECTION *s,
                 return WORK_ERROR;
             }
 
-            BIO_ctrl(SSL_get_wbio(s), BIO_CTRL_DGRAM_SCTP_ADD_AUTH_KEY,
+            BIO_ctrl(SSL_get_wbio(SSL_CONNECTION_GET_SSL(s)), BIO_CTRL_DGRAM_SCTP_ADD_AUTH_KEY,
                      sizeof(sctpauthkey), sctpauthkey);
         }
     }


### PR DESCRIPTION
Fixes #19371

running config with 'enable-sctp' gave compiler errors.