### PR TITLE
stack: Do not add error if pop/shift/value accesses outside of the stack

### DIFF
--- a/crypto/conf/conf_def.c
+++ b/crypto/conf/conf_def.c
@@ -294,7 +294,7 @@ static int def_load_bio(CONF *conf, BIO *in, long *line)
             }
 #endif
             /* no more files in directory, continue with processing parent */
-            if (sk_BIO_num(biosk) < 1 || (parent = sk_BIO_pop(biosk)) == NULL) {
+            if ((parent = sk_BIO_pop(biosk)) == NULL) {
                 /* everything processed get out of the loop */
                 break;
             } else {

--- a/crypto/stack/stack.c
+++ b/crypto/stack/stack.c
@@ -448,11 +448,11 @@ void *OPENSSL_sk_value(const OPENSSL_STACK *st, int i)
 void *OPENSSL_sk_set(OPENSSL_STACK *st, int i, const void *data)
 {
     if (st == NULL) {
-        ERR_raise(ERR_LIB_X509, ERR_R_PASSED_NULL_PARAMETER);
+        ERR_raise(ERR_LIB_CRYPTO, ERR_R_PASSED_NULL_PARAMETER);
         return NULL;
     }
     if (i < 0 || i >= st->num) {
-        ERR_raise_data(ERR_LIB_X509, ERR_R_PASSED_INVALID_ARGUMENT,
+        ERR_raise_data(ERR_LIB_CRYPTO, ERR_R_PASSED_INVALID_ARGUMENT,
                        "i=%d", i);
         return NULL;
     }

--- a/crypto/stack/stack.c
+++ b/crypto/stack/stack.c
@@ -297,6 +297,9 @@ void *OPENSSL_sk_delete_ptr(OPENSSL_STACK *st, const void *p)
 {
     int i;
 
+    if (st == NULL)
+        return NULL;
+
     for (i = 0; i < st->num; i++)
         if (st->data[i] == p)
             return internal_delete(st, i);
@@ -305,15 +308,8 @@ void *OPENSSL_sk_delete_ptr(OPENSSL_STACK *st, const void *p)
 
 void *OPENSSL_sk_delete(OPENSSL_STACK *st, int loc)
 {
-    if (st == NULL) {
-        ERR_raise(ERR_LIB_X509, ERR_R_PASSED_NULL_PARAMETER);
+    if (st == NULL || loc < 0 || loc >= st->num)
         return NULL;
-    }
-    if (loc < 0 || loc >= st->num) {
-        ERR_raise_data(ERR_LIB_X509, ERR_R_PASSED_INVALID_ARGUMENT,
-                       "loc=%d", loc);
-        return NULL;
-    }
 
     return internal_delete(st, loc);
 }

--- a/crypto/stack/stack.c
+++ b/crypto/stack/stack.c
@@ -401,10 +401,8 @@ void *OPENSSL_sk_shift(OPENSSL_STACK *st)
         ERR_raise(ERR_LIB_X509, ERR_R_PASSED_NULL_PARAMETER);
         return NULL;
     }
-    if (st->num == 0) {
-        ERR_raise(ERR_LIB_X509, ERR_R_PASSED_INVALID_ARGUMENT);
+    if (st->num == 0)
         return NULL;
-    }
     return internal_delete(st, 0);
 }
 
@@ -414,10 +412,8 @@ void *OPENSSL_sk_pop(OPENSSL_STACK *st)
         ERR_raise(ERR_LIB_X509, ERR_R_PASSED_NULL_PARAMETER);
         return NULL;
     }
-    if (st->num == 0) {
-        ERR_raise(ERR_LIB_X509, ERR_R_PASSED_INVALID_ARGUMENT);
+    if (st->num == 0)
         return NULL;
-    }
     return internal_delete(st, st->num - 1);
 }
 
@@ -464,11 +460,8 @@ void *OPENSSL_sk_value(const OPENSSL_STACK *st, int i)
         ERR_raise(ERR_LIB_X509, ERR_R_PASSED_NULL_PARAMETER);
         return NULL;
     }
-    if (i < 0 || i >= st->num) {
-        ERR_raise_data(ERR_LIB_X509, ERR_R_PASSED_INVALID_ARGUMENT,
-                       "i=%d", i);
+    if (i < 0 || i >= st->num)
         return NULL;
-    }
     return (void *)st->data[i];
 }
 

--- a/crypto/stack/stack.c
+++ b/crypto/stack/stack.c
@@ -397,33 +397,21 @@ int OPENSSL_sk_unshift(OPENSSL_STACK *st, const void *data)
 
 void *OPENSSL_sk_shift(OPENSSL_STACK *st)
 {
-    if (st == NULL) {
-        ERR_raise(ERR_LIB_X509, ERR_R_PASSED_NULL_PARAMETER);
-        return NULL;
-    }
-    if (st->num == 0)
+    if (st == NULL || st->num == 0)
         return NULL;
     return internal_delete(st, 0);
 }
 
 void *OPENSSL_sk_pop(OPENSSL_STACK *st)
 {
-    if (st == NULL) {
-        ERR_raise(ERR_LIB_X509, ERR_R_PASSED_NULL_PARAMETER);
-        return NULL;
-    }
-    if (st->num == 0)
+    if (st == NULL || st->num == 0)
         return NULL;
     return internal_delete(st, st->num - 1);
 }
 
 void OPENSSL_sk_zero(OPENSSL_STACK *st)
 {
-    if (st == NULL) {
-        ERR_raise(ERR_LIB_X509, ERR_R_PASSED_NULL_PARAMETER);
-        return;
-    }
-    if (st->num == 0)
+    if (st == NULL || st->num == 0)
         return;
     memset(st->data, 0, sizeof(*st->data) * st->num);
     st->num = 0;
@@ -456,11 +444,7 @@ int OPENSSL_sk_num(const OPENSSL_STACK *st)
 
 void *OPENSSL_sk_value(const OPENSSL_STACK *st, int i)
 {
-    if (st == NULL) {
-        ERR_raise(ERR_LIB_X509, ERR_R_PASSED_NULL_PARAMETER);
-        return NULL;
-    }
-    if (i < 0 || i >= st->num)
+    if (st == NULL || i < 0 || i >= st->num)
         return NULL;
     return (void *)st->data[i];
 }

--- a/doc/man3/DEFINE_STACK_OF.pod
+++ b/doc/man3/DEFINE_STACK_OF.pod
@@ -229,6 +229,13 @@ A failed search is indicated by a B<-1> return value.
 STACK_OF(), DEFINE_STACK_OF(), DEFINE_STACK_OF_CONST(), and
 DEFINE_SPECIAL_STACK_OF() are implemented as macros.
 
+It is not an error to call B<sk_I<TYPE>_num>(), B<sk_I<TYPE>_value>(),
+B<sk_I<TYPE>_free>(), B<sk_I<TYPE>_zero>(), B<sk_I<TYPE>_pop_free>(),
+B<sk_I<TYPE>_delete>(), B<sk_I<TYPE>_delete_ptr>(), B<sk_I<TYPE>_pop>(),
+B<sk_I<TYPE>_shift>(), B<sk_I<TYPE>_find>(), B<sk_I<TYPE>_find_ex>(),
+and B<sk_I<TYPE>_find_all>() on a NULL stack, empty stack, or with
+an invalid index. An error is not raised in these conditions.
+
 The underlying utility B<OPENSSL_sk_> API should not be used directly.
 It defines these functions: OPENSSL_sk_deep_copy(),
 OPENSSL_sk_delete(), OPENSSL_sk_delete_ptr(), OPENSSL_sk_dup(),

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -5773,8 +5773,7 @@ static int ct_move_scts(STACK_OF(SCT) **dst, STACK_OF(SCT) *src,
         }
     }
 
-    while (sk_SCT_num(src) > 0) {
-        sct = sk_SCT_pop(src);
+    while ((sct = sk_SCT_pop(src)) != NULL) {
         if (SCT_set_source(sct, origin) != 1)
             goto err;
 

--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -3591,7 +3591,7 @@ MSG_PROCESS_RETURN tls_process_client_certificate(SSL_CONNECTION *s,
     }
 
     X509_free(s->session->peer);
-    s->session->peer = sk_X509_num(sk) == 0 ? NULL: sk_X509_shift(sk);
+    s->session->peer = sk_X509_shift(sk);
     s->session->verify_result = s->verify_result;
 
     OSSL_STACK_OF_X509_free(s->session->peer_chain);

--- a/test/helpers/ssltestlib.c
+++ b/test/helpers/ssltestlib.c
@@ -349,8 +349,7 @@ static int mempacket_test_read(BIO *bio, char *out, int outl)
     unsigned int seq, offset, len, epoch;
 
     BIO_clear_retry_flags(bio);
-    if (sk_MEMPACKET_num(ctx->pkts) <= 0
-        || (thispkt = sk_MEMPACKET_value(ctx->pkts, 0)) == NULL
+    if ((thispkt = sk_MEMPACKET_value(ctx->pkts, 0)) == NULL
         || thispkt->num != ctx->currpkt) {
         /* Probably run out of data */
         BIO_set_retry_read(bio);
@@ -603,9 +602,8 @@ int mempacket_test_inject(BIO *bio, const char *in, int inl, int pktnum,
             ctx->lastpkt++;
             do {
                 i++;
-                if (i < sk_MEMPACKET_num(ctx->pkts)
-                        && (nextpkt = sk_MEMPACKET_value(ctx->pkts, i)) != NULL
-                        && nextpkt->num == ctx->lastpkt)
+                nextpkt = sk_MEMPACKET_value(ctx->pkts, i);
+                if (nextpkt != NULL && nextpkt->num == ctx->lastpkt)
                     ctx->lastpkt++;
                 else
                     return inl;


### PR DESCRIPTION
This partially reverts commit 30eba7f35983a917f1007bce45040c0af3442e42.
This is legitimate use of the stack functions and no error should be reported apart from the NULL return value.

Fixes #19389

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
