### PR TITLE
Ensure that the key share group is allowed for our protocol version (3.0)

### DIFF
--- a/ssl/statem/extensions_clnt.c
+++ b/ssl/statem/extensions_clnt.c
@@ -679,6 +679,10 @@ EXT_RETURN tls_construct_ctos_key_share(SSL *s, WPACKET *pkt,
             if (!tls_group_allowed(s, pgroups[i], SSL_SECOP_CURVE_SUPPORTED))
                 continue;
 
+            if (!tls_valid_group(s, pgroups[i], TLS1_3_VERSION, TLS1_3_VERSION,
+                                 0, NULL))
+                continue;
+
             curve_id = pgroups[i];
             break;
         }
@@ -1775,7 +1779,9 @@ int tls_parse_stoc_key_share(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
                 break;
         }
         if (i >= num_groups
-                || !tls_group_allowed(s, group_id, SSL_SECOP_CURVE_SUPPORTED)) {
+                || !tls_group_allowed(s, group_id, SSL_SECOP_CURVE_SUPPORTED)
+                || !tls_valid_group(s, group_id, TLS1_3_VERSION, TLS1_3_VERSION,
+                                    0, NULL)) {
             SSLfatal(s, SSL_AD_ILLEGAL_PARAMETER, SSL_R_BAD_KEY_SHARE);
             return 0;
         }

--- a/ssl/statem/extensions_srvr.c
+++ b/ssl/statem/extensions_srvr.c
@@ -648,7 +648,14 @@ int tls_parse_ctos_key_share(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
         }
 
         /* Check if this share is for a group we can use */
-        if (!check_in_list(s, group_id, srvrgroups, srvr_num_groups, 1)) {
+        if (!check_in_list(s, group_id, srvrgroups, srvr_num_groups, 1)
+                || !tls_group_allowed(s, group_id, SSL_SECOP_CURVE_SUPPORTED)
+                   /*
+                    * We tolerate but ignore a group id that we don't think is
+                    * suitable for TLSv1.3
+                    */
+                || !tls_valid_group(s, group_id, TLS1_3_VERSION, TLS1_3_VERSION,
+                                    0, NULL)) {
             /* Share not suitable */
             continue;
         }

--- a/test/recipes/70-test_key_share.t
+++ b/test/recipes/70-test_key_share.t
@@ -25,7 +25,8 @@ use constant {
     ZERO_LEN_KEX_DATA => 9,
     TRAILING_DATA => 10,
     SELECT_X25519 => 11,
-    NO_KEY_SHARES_IN_HRR => 12
+    NO_KEY_SHARES_IN_HRR => 12,
+    NON_TLS1_3_KEY_SHARE => 13
 };
 
 use constant {
@@ -85,7 +86,7 @@ if (disabled("ec")) {
     $proxy->serverflags("-groups P-256");
 }
 $proxy->start() or plan skip_all => "Unable to start up Proxy for tests";
-plan tests => 22;
+plan tests => 23;
 ok(TLSProxy::Message->success(), "Success after HRR");
 
 #Test 2: The server sending an HRR requesting a group the client already sent
@@ -290,11 +291,27 @@ if (disabled("ec")) {
 $proxy->start();
 ok(TLSProxy::Message->fail(), "Server sends HRR with no key_shares");
 
+SKIP: {
+    skip "No EC support in this OpenSSL build", 1 if disabled("ec");
+    #Test 23: Trailing data on key_share in ServerHello should fail
+    $proxy->clear();
+    $direction = CLIENT_TO_SERVER;
+    $proxy->clientflags("-groups secp192r1:P-256:X25519");
+    $proxy->ciphers("AES128-SHA:\@SECLEVEL=0");
+    $testtype = NON_TLS1_3_KEY_SHARE;
+    $proxy->start();
+    my $ishrr = defined ${$proxy->message_list}[2]
+                &&(${$proxy->message_list}[0]->mt == TLSProxy::Message::MT_CLIENT_HELLO)
+                && (${$proxy->message_list}[2]->mt == TLSProxy::Message::MT_CLIENT_HELLO);
+    ok(TLSProxy::Message->success() && $ishrr,
+       "Client sends a key_share for a Non TLSv1.3 group");
+}
+
 sub modify_key_shares_filter
 {
     my $proxy = shift;
 
-    # We're only interested in the initial ClientHello
+    # We're only interested in the initial ClientHello/SererHello/HRR
     if (($direction == CLIENT_TO_SERVER && $proxy->flight != 0
                 && ($proxy->flight != 1 || $testtype != NO_KEY_SHARES_IN_HRR))
             || ($direction == SERVER_TO_CLIENT && $proxy->flight != 1)) {
@@ -307,12 +324,19 @@ sub modify_key_shares_filter
             my $ext;
             my $suppgroups;
 
-            #Setup supported groups to include some unrecognised groups
-            $suppgroups = pack "C8",
-                0x00, 0x06, #List Length
-                0xff, 0xfe, #Non existing group 1
-                0xff, 0xff, #Non existing group 2
-                0x00, 0x1d; #x25519
+            if ($testtype != NON_TLS1_3_KEY_SHARE) {
+                #Setup supported groups to include some unrecognised groups
+                $suppgroups = pack "C8",
+                    0x00, 0x06, #List Length
+                    0xff, 0xfe, #Non existing group 1
+                    0xff, 0xff, #Non existing group 2
+                    0x00, 0x1d; #x25519
+            } else {
+                $suppgroups = pack "C6",
+                    0x00, 0x04, #List Length
+                    0x00, 0x13,
+                    0x00, 0x1d; #x25519
+            }
 
             if ($testtype == EMPTY_EXTENSION) {
                 $ext = pack "C2",
@@ -376,6 +400,13 @@ sub modify_key_shares_filter
                     0x00, 0x17, #P-256
                     0x00, 0x01, #key_exchange data length
                     0xff;       #Dummy key_share data
+            } elsif ($testtype == NON_TLS1_3_KEY_SHARE) {
+                $ext = pack "C6H98",
+                    0x00, 0x35, #List Length
+                    0x00, 0x13, #P-192
+                    0x00, 0x31, #key_exchange data length
+                    "04EE3B38D1CB800A1A2B702FC8423599F2AC7161E175C865F8".
+                    "3DAF78BCBAE561464E8144359BE70CB7989D28A2F43F8F2C";  #key_exchange data
             }
 
             if ($testtype != EMPTY_EXTENSION
@@ -383,7 +414,6 @@ sub modify_key_shares_filter
                 $message->set_extension(
                     TLSProxy::Message::EXT_SUPPORTED_GROUPS, $suppgroups);
             }
-
             if ($testtype == MISSING_EXTENSION) {
                 $message->delete_extension(
                     TLSProxy::Message::EXT_KEY_SHARE);

--- a/test/ssl-tests/14-curves.cnf
+++ b/test/ssl-tests/14-curves.cnf
@@ -1,6 +1,6 @@
 # Generated with generate_ssl_tests.pl
 
-num_tests = 55
+num_tests = 80
 
 test-0 = 0-curve-prime256v1
 test-1 = 1-curve-secp384r1
@@ -32,31 +32,56 @@ test-26 = 26-curve-secp256k1
 test-27 = 27-curve-brainpoolP256r1
 test-28 = 28-curve-brainpoolP384r1
 test-29 = 29-curve-brainpoolP512r1
-test-30 = 30-curve-sect233k1-tls13
-test-31 = 31-curve-sect233r1-tls13
-test-32 = 32-curve-sect283k1-tls13
-test-33 = 33-curve-sect283r1-tls13
-test-34 = 34-curve-sect409k1-tls13
-test-35 = 35-curve-sect409r1-tls13
-test-36 = 36-curve-sect571k1-tls13
-test-37 = 37-curve-sect571r1-tls13
-test-38 = 38-curve-secp224r1-tls13
-test-39 = 39-curve-sect163k1-tls13
-test-40 = 40-curve-sect163r2-tls13
-test-41 = 41-curve-prime192v1-tls13
-test-42 = 42-curve-sect163r1-tls13
-test-43 = 43-curve-sect193r1-tls13
-test-44 = 44-curve-sect193r2-tls13
-test-45 = 45-curve-sect239k1-tls13
-test-46 = 46-curve-secp160k1-tls13
-test-47 = 47-curve-secp160r1-tls13
-test-48 = 48-curve-secp160r2-tls13
-test-49 = 49-curve-secp192k1-tls13
-test-50 = 50-curve-secp224k1-tls13
-test-51 = 51-curve-secp256k1-tls13
-test-52 = 52-curve-brainpoolP256r1-tls13
-test-53 = 53-curve-brainpoolP384r1-tls13
-test-54 = 54-curve-brainpoolP512r1-tls13
+test-30 = 30-curve-sect233k1-tls12-in-tls13
+test-31 = 31-curve-sect233r1-tls12-in-tls13
+test-32 = 32-curve-sect283k1-tls12-in-tls13
+test-33 = 33-curve-sect283r1-tls12-in-tls13
+test-34 = 34-curve-sect409k1-tls12-in-tls13
+test-35 = 35-curve-sect409r1-tls12-in-tls13
+test-36 = 36-curve-sect571k1-tls12-in-tls13
+test-37 = 37-curve-sect571r1-tls12-in-tls13
+test-38 = 38-curve-secp224r1-tls12-in-tls13
+test-39 = 39-curve-sect163k1-tls12-in-tls13
+test-40 = 40-curve-sect163r2-tls12-in-tls13
+test-41 = 41-curve-prime192v1-tls12-in-tls13
+test-42 = 42-curve-sect163r1-tls12-in-tls13
+test-43 = 43-curve-sect193r1-tls12-in-tls13
+test-44 = 44-curve-sect193r2-tls12-in-tls13
+test-45 = 45-curve-sect239k1-tls12-in-tls13
+test-46 = 46-curve-secp160k1-tls12-in-tls13
+test-47 = 47-curve-secp160r1-tls12-in-tls13
+test-48 = 48-curve-secp160r2-tls12-in-tls13
+test-49 = 49-curve-secp192k1-tls12-in-tls13
+test-50 = 50-curve-secp224k1-tls12-in-tls13
+test-51 = 51-curve-secp256k1-tls12-in-tls13
+test-52 = 52-curve-brainpoolP256r1-tls12-in-tls13
+test-53 = 53-curve-brainpoolP384r1-tls12-in-tls13
+test-54 = 54-curve-brainpoolP512r1-tls12-in-tls13
+test-55 = 55-curve-sect233k1-tls13
+test-56 = 56-curve-sect233r1-tls13
+test-57 = 57-curve-sect283k1-tls13
+test-58 = 58-curve-sect283r1-tls13
+test-59 = 59-curve-sect409k1-tls13
+test-60 = 60-curve-sect409r1-tls13
+test-61 = 61-curve-sect571k1-tls13
+test-62 = 62-curve-sect571r1-tls13
+test-63 = 63-curve-secp224r1-tls13
+test-64 = 64-curve-sect163k1-tls13
+test-65 = 65-curve-sect163r2-tls13
+test-66 = 66-curve-prime192v1-tls13
+test-67 = 67-curve-sect163r1-tls13
+test-68 = 68-curve-sect193r1-tls13
+test-69 = 69-curve-sect193r2-tls13
+test-70 = 70-curve-sect239k1-tls13
+test-71 = 71-curve-secp160k1-tls13
+test-72 = 72-curve-secp160r1-tls13
+test-73 = 73-curve-secp160r2-tls13
+test-74 = 74-curve-secp192k1-tls13
+test-75 = 75-curve-secp224k1-tls13
+test-76 = 76-curve-secp256k1-tls13
+test-77 = 77-curve-brainpoolP256r1-tls13
+test-78 = 78-curve-brainpoolP384r1-tls13
+test-79 = 79-curve-brainpoolP512r1-tls13
 # ===========================================================
 
 [0-curve-prime256v1]
@@ -929,676 +954,1426 @@ ExpectedTmpKeyType = brainpoolP512r1
 
 # ===========================================================
 
-[30-curve-sect233k1-tls13]
-ssl_conf = 30-curve-sect233k1-tls13-ssl
+[30-curve-sect233k1-tls12-in-tls13]
+ssl_conf = 30-curve-sect233k1-tls12-in-tls13-ssl
 
-[30-curve-sect233k1-tls13-ssl]
-server = 30-curve-sect233k1-tls13-server
-client = 30-curve-sect233k1-tls13-client
+[30-curve-sect233k1-tls12-in-tls13-ssl]
+server = 30-curve-sect233k1-tls12-in-tls13-server
+client = 30-curve-sect233k1-tls12-in-tls13-client
 
-[30-curve-sect233k1-tls13-server]
+[30-curve-sect233k1-tls12-in-tls13-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-Curves = sect233k1
+CipherString = DEFAULT@SECLEVEL=1
+Curves = sect233k1:P-256
 MaxProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[30-curve-sect233k1-tls13-client]
-CipherString = ECDHE
-Curves = sect233k1
+[30-curve-sect233k1-tls12-in-tls13-client]
+CipherString = ECDHE@SECLEVEL=1
+Curves = sect233k1:P-256
+MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-30]
-ExpectedResult = ClientFail
+ExpectedProtocol = TLSv1.3
+ExpectedResult = Success
+ExpectedTmpKeyType = P-256
 
 
 # ===========================================================
 
-[31-curve-sect233r1-tls13]
-ssl_conf = 31-curve-sect233r1-tls13-ssl
+[31-curve-sect233r1-tls12-in-tls13]
+ssl_conf = 31-curve-sect233r1-tls12-in-tls13-ssl
 
-[31-curve-sect233r1-tls13-ssl]
-server = 31-curve-sect233r1-tls13-server
-client = 31-curve-sect233r1-tls13-client
+[31-curve-sect233r1-tls12-in-tls13-ssl]
+server = 31-curve-sect233r1-tls12-in-tls13-server
+client = 31-curve-sect233r1-tls12-in-tls13-client
 
-[31-curve-sect233r1-tls13-server]
+[31-curve-sect233r1-tls12-in-tls13-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-Curves = sect233r1
+CipherString = DEFAULT@SECLEVEL=1
+Curves = sect233r1:P-256
 MaxProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[31-curve-sect233r1-tls13-client]
-CipherString = ECDHE
-Curves = sect233r1
+[31-curve-sect233r1-tls12-in-tls13-client]
+CipherString = ECDHE@SECLEVEL=1
+Curves = sect233r1:P-256
+MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-31]
-ExpectedResult = ClientFail
+ExpectedProtocol = TLSv1.3
+ExpectedResult = Success
+ExpectedTmpKeyType = P-256
 
 
 # ===========================================================
 
-[32-curve-sect283k1-tls13]
-ssl_conf = 32-curve-sect283k1-tls13-ssl
+[32-curve-sect283k1-tls12-in-tls13]
+ssl_conf = 32-curve-sect283k1-tls12-in-tls13-ssl
 
-[32-curve-sect283k1-tls13-ssl]
-server = 32-curve-sect283k1-tls13-server
-client = 32-curve-sect283k1-tls13-client
+[32-curve-sect283k1-tls12-in-tls13-ssl]
+server = 32-curve-sect283k1-tls12-in-tls13-server
+client = 32-curve-sect283k1-tls12-in-tls13-client
 
-[32-curve-sect283k1-tls13-server]
+[32-curve-sect283k1-tls12-in-tls13-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-Curves = sect283k1
+CipherString = DEFAULT@SECLEVEL=1
+Curves = sect283k1:P-256
 MaxProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[32-curve-sect283k1-tls13-client]
-CipherString = ECDHE
-Curves = sect283k1
+[32-curve-sect283k1-tls12-in-tls13-client]
+CipherString = ECDHE@SECLEVEL=1
+Curves = sect283k1:P-256
+MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-32]
-ExpectedResult = ClientFail
+ExpectedProtocol = TLSv1.3
+ExpectedResult = Success
+ExpectedTmpKeyType = P-256
 
 
 # ===========================================================
 
-[33-curve-sect283r1-tls13]
-ssl_conf = 33-curve-sect283r1-tls13-ssl
+[33-curve-sect283r1-tls12-in-tls13]
+ssl_conf = 33-curve-sect283r1-tls12-in-tls13-ssl
 
-[33-curve-sect283r1-tls13-ssl]
-server = 33-curve-sect283r1-tls13-server
-client = 33-curve-sect283r1-tls13-client
+[33-curve-sect283r1-tls12-in-tls13-ssl]
+server = 33-curve-sect283r1-tls12-in-tls13-server
+client = 33-curve-sect283r1-tls12-in-tls13-client
 
-[33-curve-sect283r1-tls13-server]
+[33-curve-sect283r1-tls12-in-tls13-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-Curves = sect283r1
+CipherString = DEFAULT@SECLEVEL=1
+Curves = sect283r1:P-256
 MaxProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[33-curve-sect283r1-tls13-client]
-CipherString = ECDHE
-Curves = sect283r1
+[33-curve-sect283r1-tls12-in-tls13-client]
+CipherString = ECDHE@SECLEVEL=1
+Curves = sect283r1:P-256
+MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-33]
-ExpectedResult = ClientFail
+ExpectedProtocol = TLSv1.3
+ExpectedResult = Success
+ExpectedTmpKeyType = P-256
 
 
 # ===========================================================
 
-[34-curve-sect409k1-tls13]
-ssl_conf = 34-curve-sect409k1-tls13-ssl
+[34-curve-sect409k1-tls12-in-tls13]
+ssl_conf = 34-curve-sect409k1-tls12-in-tls13-ssl
 
-[34-curve-sect409k1-tls13-ssl]
-server = 34-curve-sect409k1-tls13-server
-client = 34-curve-sect409k1-tls13-client
+[34-curve-sect409k1-tls12-in-tls13-ssl]
+server = 34-curve-sect409k1-tls12-in-tls13-server
+client = 34-curve-sect409k1-tls12-in-tls13-client
 
-[34-curve-sect409k1-tls13-server]
+[34-curve-sect409k1-tls12-in-tls13-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-Curves = sect409k1
+CipherString = DEFAULT@SECLEVEL=1
+Curves = sect409k1:P-256
 MaxProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[34-curve-sect409k1-tls13-client]
-CipherString = ECDHE
-Curves = sect409k1
+[34-curve-sect409k1-tls12-in-tls13-client]
+CipherString = ECDHE@SECLEVEL=1
+Curves = sect409k1:P-256
+MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-34]
-ExpectedResult = ClientFail
+ExpectedProtocol = TLSv1.3
+ExpectedResult = Success
+ExpectedTmpKeyType = P-256
 
 
 # ===========================================================
 
-[35-curve-sect409r1-tls13]
-ssl_conf = 35-curve-sect409r1-tls13-ssl
+[35-curve-sect409r1-tls12-in-tls13]
+ssl_conf = 35-curve-sect409r1-tls12-in-tls13-ssl
 
-[35-curve-sect409r1-tls13-ssl]
-server = 35-curve-sect409r1-tls13-server
-client = 35-curve-sect409r1-tls13-client
+[35-curve-sect409r1-tls12-in-tls13-ssl]
+server = 35-curve-sect409r1-tls12-in-tls13-server
+client = 35-curve-sect409r1-tls12-in-tls13-client
 
-[35-curve-sect409r1-tls13-server]
+[35-curve-sect409r1-tls12-in-tls13-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-Curves = sect409r1
+CipherString = DEFAULT@SECLEVEL=1
+Curves = sect409r1:P-256
 MaxProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[35-curve-sect409r1-tls13-client]
-CipherString = ECDHE
-Curves = sect409r1
+[35-curve-sect409r1-tls12-in-tls13-client]
+CipherString = ECDHE@SECLEVEL=1
+Curves = sect409r1:P-256
+MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-35]
-ExpectedResult = ClientFail
+ExpectedProtocol = TLSv1.3
+ExpectedResult = Success
+ExpectedTmpKeyType = P-256
 
 
 # ===========================================================
 
-[36-curve-sect571k1-tls13]
-ssl_conf = 36-curve-sect571k1-tls13-ssl
+[36-curve-sect571k1-tls12-in-tls13]
+ssl_conf = 36-curve-sect571k1-tls12-in-tls13-ssl
 
-[36-curve-sect571k1-tls13-ssl]
-server = 36-curve-sect571k1-tls13-server
-client = 36-curve-sect571k1-tls13-client
+[36-curve-sect571k1-tls12-in-tls13-ssl]
+server = 36-curve-sect571k1-tls12-in-tls13-server
+client = 36-curve-sect571k1-tls12-in-tls13-client
 
-[36-curve-sect571k1-tls13-server]
+[36-curve-sect571k1-tls12-in-tls13-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-Curves = sect571k1
+CipherString = DEFAULT@SECLEVEL=1
+Curves = sect571k1:P-256
 MaxProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[36-curve-sect571k1-tls13-client]
-CipherString = ECDHE
-Curves = sect571k1
+[36-curve-sect571k1-tls12-in-tls13-client]
+CipherString = ECDHE@SECLEVEL=1
+Curves = sect571k1:P-256
+MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-36]
-ExpectedResult = ClientFail
+ExpectedProtocol = TLSv1.3
+ExpectedResult = Success
+ExpectedTmpKeyType = P-256
 
 
 # ===========================================================
 
-[37-curve-sect571r1-tls13]
-ssl_conf = 37-curve-sect571r1-tls13-ssl
+[37-curve-sect571r1-tls12-in-tls13]
+ssl_conf = 37-curve-sect571r1-tls12-in-tls13-ssl
 
-[37-curve-sect571r1-tls13-ssl]
-server = 37-curve-sect571r1-tls13-server
-client = 37-curve-sect571r1-tls13-client
+[37-curve-sect571r1-tls12-in-tls13-ssl]
+server = 37-curve-sect571r1-tls12-in-tls13-server
+client = 37-curve-sect571r1-tls12-in-tls13-client
 
-[37-curve-sect571r1-tls13-server]
+[37-curve-sect571r1-tls12-in-tls13-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-Curves = sect571r1
+CipherString = DEFAULT@SECLEVEL=1
+Curves = sect571r1:P-256
 MaxProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[37-curve-sect571r1-tls13-client]
-CipherString = ECDHE
-Curves = sect571r1
+[37-curve-sect571r1-tls12-in-tls13-client]
+CipherString = ECDHE@SECLEVEL=1
+Curves = sect571r1:P-256
+MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-37]
-ExpectedResult = ClientFail
+ExpectedProtocol = TLSv1.3
+ExpectedResult = Success
+ExpectedTmpKeyType = P-256
 
 
 # ===========================================================
 
-[38-curve-secp224r1-tls13]
-ssl_conf = 38-curve-secp224r1-tls13-ssl
+[38-curve-secp224r1-tls12-in-tls13]
+ssl_conf = 38-curve-secp224r1-tls12-in-tls13-ssl
 
-[38-curve-secp224r1-tls13-ssl]
-server = 38-curve-secp224r1-tls13-server
-client = 38-curve-secp224r1-tls13-client
+[38-curve-secp224r1-tls12-in-tls13-ssl]
+server = 38-curve-secp224r1-tls12-in-tls13-server
+client = 38-curve-secp224r1-tls12-in-tls13-client
 
-[38-curve-secp224r1-tls13-server]
+[38-curve-secp224r1-tls12-in-tls13-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-Curves = secp224r1
+CipherString = DEFAULT@SECLEVEL=1
+Curves = secp224r1:P-256
 MaxProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[38-curve-secp224r1-tls13-client]
-CipherString = ECDHE
-Curves = secp224r1
+[38-curve-secp224r1-tls12-in-tls13-client]
+CipherString = ECDHE@SECLEVEL=1
+Curves = secp224r1:P-256
+MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-38]
-ExpectedResult = ClientFail
+ExpectedProtocol = TLSv1.3
+ExpectedResult = Success
+ExpectedTmpKeyType = P-256
 
 
 # ===========================================================
 
-[39-curve-sect163k1-tls13]
-ssl_conf = 39-curve-sect163k1-tls13-ssl
+[39-curve-sect163k1-tls12-in-tls13]
+ssl_conf = 39-curve-sect163k1-tls12-in-tls13-ssl
 
-[39-curve-sect163k1-tls13-ssl]
-server = 39-curve-sect163k1-tls13-server
-client = 39-curve-sect163k1-tls13-client
+[39-curve-sect163k1-tls12-in-tls13-ssl]
+server = 39-curve-sect163k1-tls12-in-tls13-server
+client = 39-curve-sect163k1-tls12-in-tls13-client
 
-[39-curve-sect163k1-tls13-server]
+[39-curve-sect163k1-tls12-in-tls13-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-Curves = sect163k1
+CipherString = DEFAULT@SECLEVEL=1
+Curves = sect163k1:P-256
 MaxProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[39-curve-sect163k1-tls13-client]
-CipherString = ECDHE
-Curves = sect163k1
+[39-curve-sect163k1-tls12-in-tls13-client]
+CipherString = ECDHE@SECLEVEL=1
+Curves = sect163k1:P-256
+MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-39]
-ExpectedResult = ClientFail
+ExpectedProtocol = TLSv1.3
+ExpectedResult = Success
+ExpectedTmpKeyType = P-256
 
 
 # ===========================================================
 
-[40-curve-sect163r2-tls13]
-ssl_conf = 40-curve-sect163r2-tls13-ssl
+[40-curve-sect163r2-tls12-in-tls13]
+ssl_conf = 40-curve-sect163r2-tls12-in-tls13-ssl
 
-[40-curve-sect163r2-tls13-ssl]
-server = 40-curve-sect163r2-tls13-server
-client = 40-curve-sect163r2-tls13-client
+[40-curve-sect163r2-tls12-in-tls13-ssl]
+server = 40-curve-sect163r2-tls12-in-tls13-server
+client = 40-curve-sect163r2-tls12-in-tls13-client
 
-[40-curve-sect163r2-tls13-server]
+[40-curve-sect163r2-tls12-in-tls13-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-Curves = sect163r2
+CipherString = DEFAULT@SECLEVEL=1
+Curves = sect163r2:P-256
 MaxProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[40-curve-sect163r2-tls13-client]
-CipherString = ECDHE
-Curves = sect163r2
+[40-curve-sect163r2-tls12-in-tls13-client]
+CipherString = ECDHE@SECLEVEL=1
+Curves = sect163r2:P-256
+MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-40]
-ExpectedResult = ClientFail
+ExpectedProtocol = TLSv1.3
+ExpectedResult = Success
+ExpectedTmpKeyType = P-256
 
 
 # ===========================================================
 
-[41-curve-prime192v1-tls13]
-ssl_conf = 41-curve-prime192v1-tls13-ssl
+[41-curve-prime192v1-tls12-in-tls13]
+ssl_conf = 41-curve-prime192v1-tls12-in-tls13-ssl
 
-[41-curve-prime192v1-tls13-ssl]
-server = 41-curve-prime192v1-tls13-server
-client = 41-curve-prime192v1-tls13-client
+[41-curve-prime192v1-tls12-in-tls13-ssl]
+server = 41-curve-prime192v1-tls12-in-tls13-server
+client = 41-curve-prime192v1-tls12-in-tls13-client
 
-[41-curve-prime192v1-tls13-server]
+[41-curve-prime192v1-tls12-in-tls13-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-Curves = prime192v1
+CipherString = DEFAULT@SECLEVEL=1
+Curves = prime192v1:P-256
 MaxProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[41-curve-prime192v1-tls13-client]
-CipherString = ECDHE
-Curves = prime192v1
+[41-curve-prime192v1-tls12-in-tls13-client]
+CipherString = ECDHE@SECLEVEL=1
+Curves = prime192v1:P-256
+MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-41]
-ExpectedResult = ClientFail
+ExpectedProtocol = TLSv1.3
+ExpectedResult = Success
+ExpectedTmpKeyType = P-256
 
 
 # ===========================================================
 
-[42-curve-sect163r1-tls13]
-ssl_conf = 42-curve-sect163r1-tls13-ssl
+[42-curve-sect163r1-tls12-in-tls13]
+ssl_conf = 42-curve-sect163r1-tls12-in-tls13-ssl
 
-[42-curve-sect163r1-tls13-ssl]
-server = 42-curve-sect163r1-tls13-server
-client = 42-curve-sect163r1-tls13-client
+[42-curve-sect163r1-tls12-in-tls13-ssl]
+server = 42-curve-sect163r1-tls12-in-tls13-server
+client = 42-curve-sect163r1-tls12-in-tls13-client
 
-[42-curve-sect163r1-tls13-server]
+[42-curve-sect163r1-tls12-in-tls13-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-Curves = sect163r1
+CipherString = DEFAULT@SECLEVEL=1
+Curves = sect163r1:P-256
 MaxProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[42-curve-sect163r1-tls13-client]
-CipherString = ECDHE
-Curves = sect163r1
+[42-curve-sect163r1-tls12-in-tls13-client]
+CipherString = ECDHE@SECLEVEL=1
+Curves = sect163r1:P-256
+MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-42]
-ExpectedResult = ClientFail
+ExpectedProtocol = TLSv1.3
+ExpectedResult = Success
+ExpectedTmpKeyType = P-256
 
 
 # ===========================================================
 
-[43-curve-sect193r1-tls13]
-ssl_conf = 43-curve-sect193r1-tls13-ssl
+[43-curve-sect193r1-tls12-in-tls13]
+ssl_conf = 43-curve-sect193r1-tls12-in-tls13-ssl
 
-[43-curve-sect193r1-tls13-ssl]
-server = 43-curve-sect193r1-tls13-server
-client = 43-curve-sect193r1-tls13-client
+[43-curve-sect193r1-tls12-in-tls13-ssl]
+server = 43-curve-sect193r1-tls12-in-tls13-server
+client = 43-curve-sect193r1-tls12-in-tls13-client
 
-[43-curve-sect193r1-tls13-server]
+[43-curve-sect193r1-tls12-in-tls13-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-Curves = sect193r1
+CipherString = DEFAULT@SECLEVEL=1
+Curves = sect193r1:P-256
 MaxProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[43-curve-sect193r1-tls13-client]
-CipherString = ECDHE
-Curves = sect193r1
+[43-curve-sect193r1-tls12-in-tls13-client]
+CipherString = ECDHE@SECLEVEL=1
+Curves = sect193r1:P-256
+MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-43]
-ExpectedResult = ClientFail
+ExpectedProtocol = TLSv1.3
+ExpectedResult = Success
+ExpectedTmpKeyType = P-256
 
 
 # ===========================================================
 
-[44-curve-sect193r2-tls13]
-ssl_conf = 44-curve-sect193r2-tls13-ssl
+[44-curve-sect193r2-tls12-in-tls13]
+ssl_conf = 44-curve-sect193r2-tls12-in-tls13-ssl
 
-[44-curve-sect193r2-tls13-ssl]
-server = 44-curve-sect193r2-tls13-server
-client = 44-curve-sect193r2-tls13-client
+[44-curve-sect193r2-tls12-in-tls13-ssl]
+server = 44-curve-sect193r2-tls12-in-tls13-server
+client = 44-curve-sect193r2-tls12-in-tls13-client
 
-[44-curve-sect193r2-tls13-server]
+[44-curve-sect193r2-tls12-in-tls13-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-Curves = sect193r2
+CipherString = DEFAULT@SECLEVEL=1
+Curves = sect193r2:P-256
 MaxProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[44-curve-sect193r2-tls13-client]
-CipherString = ECDHE
-Curves = sect193r2
+[44-curve-sect193r2-tls12-in-tls13-client]
+CipherString = ECDHE@SECLEVEL=1
+Curves = sect193r2:P-256
+MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-44]
-ExpectedResult = ClientFail
+ExpectedProtocol = TLSv1.3
+ExpectedResult = Success
+ExpectedTmpKeyType = P-256
 
 
 # ===========================================================
 
-[45-curve-sect239k1-tls13]
-ssl_conf = 45-curve-sect239k1-tls13-ssl
+[45-curve-sect239k1-tls12-in-tls13]
+ssl_conf = 45-curve-sect239k1-tls12-in-tls13-ssl
 
-[45-curve-sect239k1-tls13-ssl]
-server = 45-curve-sect239k1-tls13-server
-client = 45-curve-sect239k1-tls13-client
+[45-curve-sect239k1-tls12-in-tls13-ssl]
+server = 45-curve-sect239k1-tls12-in-tls13-server
+client = 45-curve-sect239k1-tls12-in-tls13-client
 
-[45-curve-sect239k1-tls13-server]
+[45-curve-sect239k1-tls12-in-tls13-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-Curves = sect239k1
+CipherString = DEFAULT@SECLEVEL=1
+Curves = sect239k1:P-256
 MaxProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[45-curve-sect239k1-tls13-client]
-CipherString = ECDHE
-Curves = sect239k1
+[45-curve-sect239k1-tls12-in-tls13-client]
+CipherString = ECDHE@SECLEVEL=1
+Curves = sect239k1:P-256
+MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-45]
-ExpectedResult = ClientFail
+ExpectedProtocol = TLSv1.3
+ExpectedResult = Success
+ExpectedTmpKeyType = P-256
 
 
 # ===========================================================
 
-[46-curve-secp160k1-tls13]
-ssl_conf = 46-curve-secp160k1-tls13-ssl
+[46-curve-secp160k1-tls12-in-tls13]
+ssl_conf = 46-curve-secp160k1-tls12-in-tls13-ssl
 
-[46-curve-secp160k1-tls13-ssl]
-server = 46-curve-secp160k1-tls13-server
-client = 46-curve-secp160k1-tls13-client
+[46-curve-secp160k1-tls12-in-tls13-ssl]
+server = 46-curve-secp160k1-tls12-in-tls13-server
+client = 46-curve-secp160k1-tls12-in-tls13-client
 
-[46-curve-secp160k1-tls13-server]
+[46-curve-secp160k1-tls12-in-tls13-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-Curves = secp160k1
+CipherString = DEFAULT@SECLEVEL=1
+Curves = secp160k1:P-256
 MaxProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[46-curve-secp160k1-tls13-client]
-CipherString = ECDHE
-Curves = secp160k1
+[46-curve-secp160k1-tls12-in-tls13-client]
+CipherString = ECDHE@SECLEVEL=1
+Curves = secp160k1:P-256
+MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-46]
-ExpectedResult = ClientFail
+ExpectedProtocol = TLSv1.3
+ExpectedResult = Success
+ExpectedTmpKeyType = P-256
 
 
 # ===========================================================
 
-[47-curve-secp160r1-tls13]
-ssl_conf = 47-curve-secp160r1-tls13-ssl
+[47-curve-secp160r1-tls12-in-tls13]
+ssl_conf = 47-curve-secp160r1-tls12-in-tls13-ssl
 
-[47-curve-secp160r1-tls13-ssl]
-server = 47-curve-secp160r1-tls13-server
-client = 47-curve-secp160r1-tls13-client
+[47-curve-secp160r1-tls12-in-tls13-ssl]
+server = 47-curve-secp160r1-tls12-in-tls13-server
+client = 47-curve-secp160r1-tls12-in-tls13-client
 
-[47-curve-secp160r1-tls13-server]
+[47-curve-secp160r1-tls12-in-tls13-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-Curves = secp160r1
+CipherString = DEFAULT@SECLEVEL=1
+Curves = secp160r1:P-256
 MaxProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[47-curve-secp160r1-tls13-client]
-CipherString = ECDHE
-Curves = secp160r1
+[47-curve-secp160r1-tls12-in-tls13-client]
+CipherString = ECDHE@SECLEVEL=1
+Curves = secp160r1:P-256
+MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-47]
-ExpectedResult = ClientFail
+ExpectedProtocol = TLSv1.3
+ExpectedResult = Success
+ExpectedTmpKeyType = P-256
 
 
 # ===========================================================
 
-[48-curve-secp160r2-tls13]
-ssl_conf = 48-curve-secp160r2-tls13-ssl
+[48-curve-secp160r2-tls12-in-tls13]
+ssl_conf = 48-curve-secp160r2-tls12-in-tls13-ssl
 
-[48-curve-secp160r2-tls13-ssl]
-server = 48-curve-secp160r2-tls13-server
-client = 48-curve-secp160r2-tls13-client
+[48-curve-secp160r2-tls12-in-tls13-ssl]
+server = 48-curve-secp160r2-tls12-in-tls13-server
+client = 48-curve-secp160r2-tls12-in-tls13-client
 
-[48-curve-secp160r2-tls13-server]
+[48-curve-secp160r2-tls12-in-tls13-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-Curves = secp160r2
+CipherString = DEFAULT@SECLEVEL=1
+Curves = secp160r2:P-256
 MaxProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[48-curve-secp160r2-tls13-client]
-CipherString = ECDHE
-Curves = secp160r2
+[48-curve-secp160r2-tls12-in-tls13-client]
+CipherString = ECDHE@SECLEVEL=1
+Curves = secp160r2:P-256
+MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-48]
-ExpectedResult = ClientFail
+ExpectedProtocol = TLSv1.3
+ExpectedResult = Success
+ExpectedTmpKeyType = P-256
 
 
 # ===========================================================
 
-[49-curve-secp192k1-tls13]
-ssl_conf = 49-curve-secp192k1-tls13-ssl
+[49-curve-secp192k1-tls12-in-tls13]
+ssl_conf = 49-curve-secp192k1-tls12-in-tls13-ssl
 
-[49-curve-secp192k1-tls13-ssl]
-server = 49-curve-secp192k1-tls13-server
-client = 49-curve-secp192k1-tls13-client
+[49-curve-secp192k1-tls12-in-tls13-ssl]
+server = 49-curve-secp192k1-tls12-in-tls13-server
+client = 49-curve-secp192k1-tls12-in-tls13-client
 
-[49-curve-secp192k1-tls13-server]
+[49-curve-secp192k1-tls12-in-tls13-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-Curves = secp192k1
+CipherString = DEFAULT@SECLEVEL=1
+Curves = secp192k1:P-256
 MaxProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[49-curve-secp192k1-tls13-client]
-CipherString = ECDHE
-Curves = secp192k1
+[49-curve-secp192k1-tls12-in-tls13-client]
+CipherString = ECDHE@SECLEVEL=1
+Curves = secp192k1:P-256
+MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-49]
-ExpectedResult = ClientFail
+ExpectedProtocol = TLSv1.3
+ExpectedResult = Success
+ExpectedTmpKeyType = P-256
 
 
 # ===========================================================
 
-[50-curve-secp224k1-tls13]
-ssl_conf = 50-curve-secp224k1-tls13-ssl
+[50-curve-secp224k1-tls12-in-tls13]
+ssl_conf = 50-curve-secp224k1-tls12-in-tls13-ssl
 
-[50-curve-secp224k1-tls13-ssl]
-server = 50-curve-secp224k1-tls13-server
-client = 50-curve-secp224k1-tls13-client
+[50-curve-secp224k1-tls12-in-tls13-ssl]
+server = 50-curve-secp224k1-tls12-in-tls13-server
+client = 50-curve-secp224k1-tls12-in-tls13-client
 
-[50-curve-secp224k1-tls13-server]
+[50-curve-secp224k1-tls12-in-tls13-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-Curves = secp224k1
+CipherString = DEFAULT@SECLEVEL=1
+Curves = secp224k1:P-256
 MaxProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[50-curve-secp224k1-tls13-client]
-CipherString = ECDHE
-Curves = secp224k1
+[50-curve-secp224k1-tls12-in-tls13-client]
+CipherString = ECDHE@SECLEVEL=1
+Curves = secp224k1:P-256
+MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-50]
-ExpectedResult = ClientFail
+ExpectedProtocol = TLSv1.3
+ExpectedResult = Success
+ExpectedTmpKeyType = P-256
 
 
 # ===========================================================
 
-[51-curve-secp256k1-tls13]
-ssl_conf = 51-curve-secp256k1-tls13-ssl
+[51-curve-secp256k1-tls12-in-tls13]
+ssl_conf = 51-curve-secp256k1-tls12-in-tls13-ssl
 
-[51-curve-secp256k1-tls13-ssl]
-server = 51-curve-secp256k1-tls13-server
-client = 51-curve-secp256k1-tls13-client
+[51-curve-secp256k1-tls12-in-tls13-ssl]
+server = 51-curve-secp256k1-tls12-in-tls13-server
+client = 51-curve-secp256k1-tls12-in-tls13-client
 
-[51-curve-secp256k1-tls13-server]
+[51-curve-secp256k1-tls12-in-tls13-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-Curves = secp256k1
+CipherString = DEFAULT@SECLEVEL=1
+Curves = secp256k1:P-256
 MaxProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[51-curve-secp256k1-tls13-client]
-CipherString = ECDHE
-Curves = secp256k1
+[51-curve-secp256k1-tls12-in-tls13-client]
+CipherString = ECDHE@SECLEVEL=1
+Curves = secp256k1:P-256
+MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-51]
-ExpectedResult = ClientFail
+ExpectedProtocol = TLSv1.3
+ExpectedResult = Success
+ExpectedTmpKeyType = P-256
 
 
 # ===========================================================
 
-[52-curve-brainpoolP256r1-tls13]
-ssl_conf = 52-curve-brainpoolP256r1-tls13-ssl
+[52-curve-brainpoolP256r1-tls12-in-tls13]
+ssl_conf = 52-curve-brainpoolP256r1-tls12-in-tls13-ssl
 
-[52-curve-brainpoolP256r1-tls13-ssl]
-server = 52-curve-brainpoolP256r1-tls13-server
-client = 52-curve-brainpoolP256r1-tls13-client
+[52-curve-brainpoolP256r1-tls12-in-tls13-ssl]
+server = 52-curve-brainpoolP256r1-tls12-in-tls13-server
+client = 52-curve-brainpoolP256r1-tls12-in-tls13-client
 
-[52-curve-brainpoolP256r1-tls13-server]
+[52-curve-brainpoolP256r1-tls12-in-tls13-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-Curves = brainpoolP256r1
+CipherString = DEFAULT@SECLEVEL=1
+Curves = brainpoolP256r1:P-256
 MaxProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[52-curve-brainpoolP256r1-tls13-client]
-CipherString = ECDHE
-Curves = brainpoolP256r1
+[52-curve-brainpoolP256r1-tls12-in-tls13-client]
+CipherString = ECDHE@SECLEVEL=1
+Curves = brainpoolP256r1:P-256
+MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-52]
-ExpectedResult = ClientFail
+ExpectedProtocol = TLSv1.3
+ExpectedResult = Success
+ExpectedTmpKeyType = P-256
 
 
 # ===========================================================
 
-[53-curve-brainpoolP384r1-tls13]
-ssl_conf = 53-curve-brainpoolP384r1-tls13-ssl
+[53-curve-brainpoolP384r1-tls12-in-tls13]
+ssl_conf = 53-curve-brainpoolP384r1-tls12-in-tls13-ssl
 
-[53-curve-brainpoolP384r1-tls13-ssl]
-server = 53-curve-brainpoolP384r1-tls13-server
-client = 53-curve-brainpoolP384r1-tls13-client
+[53-curve-brainpoolP384r1-tls12-in-tls13-ssl]
+server = 53-curve-brainpoolP384r1-tls12-in-tls13-server
+client = 53-curve-brainpoolP384r1-tls12-in-tls13-client
 
-[53-curve-brainpoolP384r1-tls13-server]
+[53-curve-brainpoolP384r1-tls12-in-tls13-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
-CipherString = DEFAULT
-Curves = brainpoolP384r1
+CipherString = DEFAULT@SECLEVEL=1
+Curves = brainpoolP384r1:P-256
 MaxProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[53-curve-brainpoolP384r1-tls13-client]
-CipherString = ECDHE
-Curves = brainpoolP384r1
+[53-curve-brainpoolP384r1-tls12-in-tls13-client]
+CipherString = ECDHE@SECLEVEL=1
+Curves = brainpoolP384r1:P-256
+MaxProtocol = TLSv1.3
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
 [test-53]
+ExpectedProtocol = TLSv1.3
+ExpectedResult = Success
+ExpectedTmpKeyType = P-256
+
+
+# ===========================================================
+
+[54-curve-brainpoolP512r1-tls12-in-tls13]
+ssl_conf = 54-curve-brainpoolP512r1-tls12-in-tls13-ssl
+
+[54-curve-brainpoolP512r1-tls12-in-tls13-ssl]
+server = 54-curve-brainpoolP512r1-tls12-in-tls13-server
+client = 54-curve-brainpoolP512r1-tls12-in-tls13-client
+
+[54-curve-brainpoolP512r1-tls12-in-tls13-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT@SECLEVEL=1
+Curves = brainpoolP512r1:P-256
+MaxProtocol = TLSv1.3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[54-curve-brainpoolP512r1-tls12-in-tls13-client]
+CipherString = ECDHE@SECLEVEL=1
+Curves = brainpoolP512r1:P-256
+MaxProtocol = TLSv1.3
+MinProtocol = TLSv1.3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-54]
+ExpectedProtocol = TLSv1.3
+ExpectedResult = Success
+ExpectedTmpKeyType = P-256
+
+
+# ===========================================================
+
+[55-curve-sect233k1-tls13]
+ssl_conf = 55-curve-sect233k1-tls13-ssl
+
+[55-curve-sect233k1-tls13-ssl]
+server = 55-curve-sect233k1-tls13-server
+client = 55-curve-sect233k1-tls13-client
+
+[55-curve-sect233k1-tls13-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+Curves = sect233k1
+MaxProtocol = TLSv1.3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[55-curve-sect233k1-tls13-client]
+CipherString = ECDHE
+Curves = sect233k1
+MinProtocol = TLSv1.3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-55]
 ExpectedResult = ClientFail
 
 
 # ===========================================================
 
-[54-curve-brainpoolP512r1-tls13]
-ssl_conf = 54-curve-brainpoolP512r1-tls13-ssl
+[56-curve-sect233r1-tls13]
+ssl_conf = 56-curve-sect233r1-tls13-ssl
 
-[54-curve-brainpoolP512r1-tls13-ssl]
-server = 54-curve-brainpoolP512r1-tls13-server
-client = 54-curve-brainpoolP512r1-tls13-client
+[56-curve-sect233r1-tls13-ssl]
+server = 56-curve-sect233r1-tls13-server
+client = 56-curve-sect233r1-tls13-client
 
-[54-curve-brainpoolP512r1-tls13-server]
+[56-curve-sect233r1-tls13-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+Curves = sect233r1
+MaxProtocol = TLSv1.3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[56-curve-sect233r1-tls13-client]
+CipherString = ECDHE
+Curves = sect233r1
+MinProtocol = TLSv1.3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-56]
+ExpectedResult = ClientFail
+
+
+# ===========================================================
+
+[57-curve-sect283k1-tls13]
+ssl_conf = 57-curve-sect283k1-tls13-ssl
+
+[57-curve-sect283k1-tls13-ssl]
+server = 57-curve-sect283k1-tls13-server
+client = 57-curve-sect283k1-tls13-client
+
+[57-curve-sect283k1-tls13-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+Curves = sect283k1
+MaxProtocol = TLSv1.3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[57-curve-sect283k1-tls13-client]
+CipherString = ECDHE
+Curves = sect283k1
+MinProtocol = TLSv1.3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-57]
+ExpectedResult = ClientFail
+
+
+# ===========================================================
+
+[58-curve-sect283r1-tls13]
+ssl_conf = 58-curve-sect283r1-tls13-ssl
+
+[58-curve-sect283r1-tls13-ssl]
+server = 58-curve-sect283r1-tls13-server
+client = 58-curve-sect283r1-tls13-client
+
+[58-curve-sect283r1-tls13-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+Curves = sect283r1
+MaxProtocol = TLSv1.3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[58-curve-sect283r1-tls13-client]
+CipherString = ECDHE
+Curves = sect283r1
+MinProtocol = TLSv1.3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-58]
+ExpectedResult = ClientFail
+
+
+# ===========================================================
+
+[59-curve-sect409k1-tls13]
+ssl_conf = 59-curve-sect409k1-tls13-ssl
+
+[59-curve-sect409k1-tls13-ssl]
+server = 59-curve-sect409k1-tls13-server
+client = 59-curve-sect409k1-tls13-client
+
+[59-curve-sect409k1-tls13-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+Curves = sect409k1
+MaxProtocol = TLSv1.3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[59-curve-sect409k1-tls13-client]
+CipherString = ECDHE
+Curves = sect409k1
+MinProtocol = TLSv1.3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-59]
+ExpectedResult = ClientFail
+
+
+# ===========================================================
+
+[60-curve-sect409r1-tls13]
+ssl_conf = 60-curve-sect409r1-tls13-ssl
+
+[60-curve-sect409r1-tls13-ssl]
+server = 60-curve-sect409r1-tls13-server
+client = 60-curve-sect409r1-tls13-client
+
+[60-curve-sect409r1-tls13-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+Curves = sect409r1
+MaxProtocol = TLSv1.3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[60-curve-sect409r1-tls13-client]
+CipherString = ECDHE
+Curves = sect409r1
+MinProtocol = TLSv1.3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-60]
+ExpectedResult = ClientFail
+
+
+# ===========================================================
+
+[61-curve-sect571k1-tls13]
+ssl_conf = 61-curve-sect571k1-tls13-ssl
+
+[61-curve-sect571k1-tls13-ssl]
+server = 61-curve-sect571k1-tls13-server
+client = 61-curve-sect571k1-tls13-client
+
+[61-curve-sect571k1-tls13-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+Curves = sect571k1
+MaxProtocol = TLSv1.3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[61-curve-sect571k1-tls13-client]
+CipherString = ECDHE
+Curves = sect571k1
+MinProtocol = TLSv1.3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-61]
+ExpectedResult = ClientFail
+
+
+# ===========================================================
+
+[62-curve-sect571r1-tls13]
+ssl_conf = 62-curve-sect571r1-tls13-ssl
+
+[62-curve-sect571r1-tls13-ssl]
+server = 62-curve-sect571r1-tls13-server
+client = 62-curve-sect571r1-tls13-client
+
+[62-curve-sect571r1-tls13-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+Curves = sect571r1
+MaxProtocol = TLSv1.3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[62-curve-sect571r1-tls13-client]
+CipherString = ECDHE
+Curves = sect571r1
+MinProtocol = TLSv1.3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-62]
+ExpectedResult = ClientFail
+
+
+# ===========================================================
+
+[63-curve-secp224r1-tls13]
+ssl_conf = 63-curve-secp224r1-tls13-ssl
+
+[63-curve-secp224r1-tls13-ssl]
+server = 63-curve-secp224r1-tls13-server
+client = 63-curve-secp224r1-tls13-client
+
+[63-curve-secp224r1-tls13-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+Curves = secp224r1
+MaxProtocol = TLSv1.3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[63-curve-secp224r1-tls13-client]
+CipherString = ECDHE
+Curves = secp224r1
+MinProtocol = TLSv1.3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-63]
+ExpectedResult = ClientFail
+
+
+# ===========================================================
+
+[64-curve-sect163k1-tls13]
+ssl_conf = 64-curve-sect163k1-tls13-ssl
+
+[64-curve-sect163k1-tls13-ssl]
+server = 64-curve-sect163k1-tls13-server
+client = 64-curve-sect163k1-tls13-client
+
+[64-curve-sect163k1-tls13-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+Curves = sect163k1
+MaxProtocol = TLSv1.3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[64-curve-sect163k1-tls13-client]
+CipherString = ECDHE
+Curves = sect163k1
+MinProtocol = TLSv1.3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-64]
+ExpectedResult = ClientFail
+
+
+# ===========================================================
+
+[65-curve-sect163r2-tls13]
+ssl_conf = 65-curve-sect163r2-tls13-ssl
+
+[65-curve-sect163r2-tls13-ssl]
+server = 65-curve-sect163r2-tls13-server
+client = 65-curve-sect163r2-tls13-client
+
+[65-curve-sect163r2-tls13-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+Curves = sect163r2
+MaxProtocol = TLSv1.3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[65-curve-sect163r2-tls13-client]
+CipherString = ECDHE
+Curves = sect163r2
+MinProtocol = TLSv1.3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-65]
+ExpectedResult = ClientFail
+
+
+# ===========================================================
+
+[66-curve-prime192v1-tls13]
+ssl_conf = 66-curve-prime192v1-tls13-ssl
+
+[66-curve-prime192v1-tls13-ssl]
+server = 66-curve-prime192v1-tls13-server
+client = 66-curve-prime192v1-tls13-client
+
+[66-curve-prime192v1-tls13-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+Curves = prime192v1
+MaxProtocol = TLSv1.3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[66-curve-prime192v1-tls13-client]
+CipherString = ECDHE
+Curves = prime192v1
+MinProtocol = TLSv1.3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-66]
+ExpectedResult = ClientFail
+
+
+# ===========================================================
+
+[67-curve-sect163r1-tls13]
+ssl_conf = 67-curve-sect163r1-tls13-ssl
+
+[67-curve-sect163r1-tls13-ssl]
+server = 67-curve-sect163r1-tls13-server
+client = 67-curve-sect163r1-tls13-client
+
+[67-curve-sect163r1-tls13-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+Curves = sect163r1
+MaxProtocol = TLSv1.3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[67-curve-sect163r1-tls13-client]
+CipherString = ECDHE
+Curves = sect163r1
+MinProtocol = TLSv1.3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-67]
+ExpectedResult = ClientFail
+
+
+# ===========================================================
+
+[68-curve-sect193r1-tls13]
+ssl_conf = 68-curve-sect193r1-tls13-ssl
+
+[68-curve-sect193r1-tls13-ssl]
+server = 68-curve-sect193r1-tls13-server
+client = 68-curve-sect193r1-tls13-client
+
+[68-curve-sect193r1-tls13-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+Curves = sect193r1
+MaxProtocol = TLSv1.3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[68-curve-sect193r1-tls13-client]
+CipherString = ECDHE
+Curves = sect193r1
+MinProtocol = TLSv1.3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-68]
+ExpectedResult = ClientFail
+
+
+# ===========================================================
+
+[69-curve-sect193r2-tls13]
+ssl_conf = 69-curve-sect193r2-tls13-ssl
+
+[69-curve-sect193r2-tls13-ssl]
+server = 69-curve-sect193r2-tls13-server
+client = 69-curve-sect193r2-tls13-client
+
+[69-curve-sect193r2-tls13-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+Curves = sect193r2
+MaxProtocol = TLSv1.3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[69-curve-sect193r2-tls13-client]
+CipherString = ECDHE
+Curves = sect193r2
+MinProtocol = TLSv1.3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-69]
+ExpectedResult = ClientFail
+
+
+# ===========================================================
+
+[70-curve-sect239k1-tls13]
+ssl_conf = 70-curve-sect239k1-tls13-ssl
+
+[70-curve-sect239k1-tls13-ssl]
+server = 70-curve-sect239k1-tls13-server
+client = 70-curve-sect239k1-tls13-client
+
+[70-curve-sect239k1-tls13-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+Curves = sect239k1
+MaxProtocol = TLSv1.3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[70-curve-sect239k1-tls13-client]
+CipherString = ECDHE
+Curves = sect239k1
+MinProtocol = TLSv1.3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-70]
+ExpectedResult = ClientFail
+
+
+# ===========================================================
+
+[71-curve-secp160k1-tls13]
+ssl_conf = 71-curve-secp160k1-tls13-ssl
+
+[71-curve-secp160k1-tls13-ssl]
+server = 71-curve-secp160k1-tls13-server
+client = 71-curve-secp160k1-tls13-client
+
+[71-curve-secp160k1-tls13-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+Curves = secp160k1
+MaxProtocol = TLSv1.3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[71-curve-secp160k1-tls13-client]
+CipherString = ECDHE
+Curves = secp160k1
+MinProtocol = TLSv1.3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-71]
+ExpectedResult = ClientFail
+
+
+# ===========================================================
+
+[72-curve-secp160r1-tls13]
+ssl_conf = 72-curve-secp160r1-tls13-ssl
+
+[72-curve-secp160r1-tls13-ssl]
+server = 72-curve-secp160r1-tls13-server
+client = 72-curve-secp160r1-tls13-client
+
+[72-curve-secp160r1-tls13-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+Curves = secp160r1
+MaxProtocol = TLSv1.3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[72-curve-secp160r1-tls13-client]
+CipherString = ECDHE
+Curves = secp160r1
+MinProtocol = TLSv1.3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-72]
+ExpectedResult = ClientFail
+
+
+# ===========================================================
+
+[73-curve-secp160r2-tls13]
+ssl_conf = 73-curve-secp160r2-tls13-ssl
+
+[73-curve-secp160r2-tls13-ssl]
+server = 73-curve-secp160r2-tls13-server
+client = 73-curve-secp160r2-tls13-client
+
+[73-curve-secp160r2-tls13-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+Curves = secp160r2
+MaxProtocol = TLSv1.3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[73-curve-secp160r2-tls13-client]
+CipherString = ECDHE
+Curves = secp160r2
+MinProtocol = TLSv1.3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-73]
+ExpectedResult = ClientFail
+
+
+# ===========================================================
+
+[74-curve-secp192k1-tls13]
+ssl_conf = 74-curve-secp192k1-tls13-ssl
+
+[74-curve-secp192k1-tls13-ssl]
+server = 74-curve-secp192k1-tls13-server
+client = 74-curve-secp192k1-tls13-client
+
+[74-curve-secp192k1-tls13-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+Curves = secp192k1
+MaxProtocol = TLSv1.3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[74-curve-secp192k1-tls13-client]
+CipherString = ECDHE
+Curves = secp192k1
+MinProtocol = TLSv1.3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-74]
+ExpectedResult = ClientFail
+
+
+# ===========================================================
+
+[75-curve-secp224k1-tls13]
+ssl_conf = 75-curve-secp224k1-tls13-ssl
+
+[75-curve-secp224k1-tls13-ssl]
+server = 75-curve-secp224k1-tls13-server
+client = 75-curve-secp224k1-tls13-client
+
+[75-curve-secp224k1-tls13-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+Curves = secp224k1
+MaxProtocol = TLSv1.3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[75-curve-secp224k1-tls13-client]
+CipherString = ECDHE
+Curves = secp224k1
+MinProtocol = TLSv1.3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-75]
+ExpectedResult = ClientFail
+
+
+# ===========================================================
+
+[76-curve-secp256k1-tls13]
+ssl_conf = 76-curve-secp256k1-tls13-ssl
+
+[76-curve-secp256k1-tls13-ssl]
+server = 76-curve-secp256k1-tls13-server
+client = 76-curve-secp256k1-tls13-client
+
+[76-curve-secp256k1-tls13-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+Curves = secp256k1
+MaxProtocol = TLSv1.3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[76-curve-secp256k1-tls13-client]
+CipherString = ECDHE
+Curves = secp256k1
+MinProtocol = TLSv1.3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-76]
+ExpectedResult = ClientFail
+
+
+# ===========================================================
+
+[77-curve-brainpoolP256r1-tls13]
+ssl_conf = 77-curve-brainpoolP256r1-tls13-ssl
+
+[77-curve-brainpoolP256r1-tls13-ssl]
+server = 77-curve-brainpoolP256r1-tls13-server
+client = 77-curve-brainpoolP256r1-tls13-client
+
+[77-curve-brainpoolP256r1-tls13-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+Curves = brainpoolP256r1
+MaxProtocol = TLSv1.3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[77-curve-brainpoolP256r1-tls13-client]
+CipherString = ECDHE
+Curves = brainpoolP256r1
+MinProtocol = TLSv1.3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-77]
+ExpectedResult = ClientFail
+
+
+# ===========================================================
+
+[78-curve-brainpoolP384r1-tls13]
+ssl_conf = 78-curve-brainpoolP384r1-tls13-ssl
+
+[78-curve-brainpoolP384r1-tls13-ssl]
+server = 78-curve-brainpoolP384r1-tls13-server
+client = 78-curve-brainpoolP384r1-tls13-client
+
+[78-curve-brainpoolP384r1-tls13-server]
+Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
+CipherString = DEFAULT
+Curves = brainpoolP384r1
+MaxProtocol = TLSv1.3
+PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
+
+[78-curve-brainpoolP384r1-tls13-client]
+CipherString = ECDHE
+Curves = brainpoolP384r1
+MinProtocol = TLSv1.3
+VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
+VerifyMode = Peer
+
+[test-78]
+ExpectedResult = ClientFail
+
+
+# ===========================================================
+
+[79-curve-brainpoolP512r1-tls13]
+ssl_conf = 79-curve-brainpoolP512r1-tls13-ssl
+
+[79-curve-brainpoolP512r1-tls13-ssl]
+server = 79-curve-brainpoolP512r1-tls13-server
+client = 79-curve-brainpoolP512r1-tls13-client
+
+[79-curve-brainpoolP512r1-tls13-server]
 Certificate = ${ENV::TEST_CERTS_DIR}/servercert.pem
 CipherString = DEFAULT
 Curves = brainpoolP512r1
 MaxProtocol = TLSv1.3
 PrivateKey = ${ENV::TEST_CERTS_DIR}/serverkey.pem
 
-[54-curve-brainpoolP512r1-tls13-client]
+[79-curve-brainpoolP512r1-tls13-client]
 CipherString = ECDHE
 Curves = brainpoolP512r1
 MinProtocol = TLSv1.3
 VerifyCAFile = ${ENV::TEST_CERTS_DIR}/rootcert.pem
 VerifyMode = Peer
 
-[test-54]
+[test-79]
 ExpectedResult = ClientFail
 
 

--- a/test/ssl-tests/14-curves.cnf.in
+++ b/test/ssl-tests/14-curves.cnf.in
@@ -73,6 +73,30 @@ sub generate_tests() {
     foreach (0..$#curves_tls_1_2) {
         my $curve = $curves_tls_1_2[$_];
         push @tests, {
+            name => "curve-${curve}-tls12-in-tls13",
+            server => {
+                "Curves" => "$curve:P-256",
+                "CipherString" => 'DEFAULT@SECLEVEL=1',
+                "MaxProtocol" => "TLSv1.3"
+            },
+            client => {
+                "CipherString" => 'ECDHE@SECLEVEL=1',
+                "MaxProtocol" => "TLSv1.3",
+                "MinProtocol" => "TLSv1.3",
+                "Curves" => "$curve:P-256"
+            },
+            test   => {
+                #This curve is not allowed in a TLSv1.3 key_share. We should
+                #succeed but fallback to P-256
+                "ExpectedTmpKeyType" => "P-256",
+                "ExpectedProtocol" => "TLSv1.3",
+                "ExpectedResult" => "Success"
+            },
+        };
+    }
+    foreach (0..$#curves_tls_1_2) {
+        my $curve = $curves_tls_1_2[$_];
+        push @tests, {
             name => "curve-${curve}-tls13",
             server => {
                 "Curves" => $curve,


### PR DESCRIPTION
This is a backport of #19317 but for the 3.0 branch. It is essentially the same. There are differences in the 14-curves.cnf file - but this is an auto-generated file.
