### PR TITLE
Fix documentation for OFB/OCB in the FIPS provider

### DIFF
--- a/doc/man7/EVP_CIPHER-AES.pod
+++ b/doc/man7/EVP_CIPHER-AES.pod
@@ -27,7 +27,7 @@ default provider:
 
 =item "AES-128-ECB", "AES-192-ECB" and "AES-256-ECB"
 
-=item "AES-192-OCB", "AES-128-OCB" and "AES-256-OCB"
+=item "AES-192-OFB", "AES-128-OFB" and "AES-256-OFB"
 
 =item "AES-128-SIV", "AES-192-SIV" and "AES-256-SIV"
 
@@ -52,7 +52,7 @@ FIPS provider:
 
 =over 4
 
-=item "AES-128-OFB", "AES-192-OFB" and "AES-256-OFB"
+=item "AES-128-OCB", "AES-192-OCB" and "AES-256-OCB"
 
 =back
 


### PR DESCRIPTION
The documentation currently says that OCB is available in the FIPS provider and OFB is not. However, according to the code at https://github.com/openssl/openssl/blob/master/providers/fips/fipsprov.c#L278-L280, it should be the other way around:
```
    ALG(PROV_NAMES_AES_256_OFB, ossl_aes256ofb_functions),
    ALG(PROV_NAMES_AES_192_OFB, ossl_aes192ofb_functions),
    ALG(PROV_NAMES_AES_128_OFB, ossl_aes128ofb_functions),
```

##### Checklist
- [x] documentation is added or updated
