### PR TITLE
Fix an occasional CI failure due to unaligned access [3.0]

### DIFF
--- a/crypto/bn/rsaz_exp_x2.c
+++ b/crypto/bn/rsaz_exp_x2.c
@@ -31,6 +31,14 @@ NON_EMPTY_TRANSLATION_UNIT
 #  define ALIGN64
 # endif
 
+# if defined(__GNUC__)
+#  define ALIGN1  __attribute__((aligned(1)))
+# elif defined(_MSC_VER)
+#  define ALIGN1  __declspec(align(1))
+# else
+#  define ALIGN1
+# endif
+
 # define ALIGN_OF(ptr, boundary) \
     ((unsigned char *)(ptr) + (boundary - (((size_t)(ptr)) & (boundary - 1))))
 
@@ -41,6 +49,8 @@ NON_EMPTY_TRANSLATION_UNIT
 
 # define BITS2WORD8_SIZE(x)  (((x) + 7) >> 3)
 # define BITS2WORD64_SIZE(x) (((x) + 63) >> 6)
+
+typedef uint64_t ALIGN1 uint64_t_align1;
 
 static ossl_inline uint64_t get_digit52(const uint8_t *in, int in_len);
 static ossl_inline void put_digit52(uint8_t *out, int out_len, uint64_t digit);
@@ -468,9 +478,9 @@ static void to_words52(BN_ULONG *out, int out_len,
     in_str = (uint8_t *)in;
 
     for (; in_bitsize >= (2 * DIGIT_SIZE); in_bitsize -= (2 * DIGIT_SIZE), out += 2) {
-        out[0] = (*(uint64_t *)in_str) & DIGIT_MASK;
+        out[0] = (*(uint64_t_align1 *)in_str) & DIGIT_MASK;
         in_str += 6;
-        out[1] = ((*(uint64_t *)in_str) >> 4) & DIGIT_MASK;
+        out[1] = ((*(uint64_t_align1 *)in_str) >> 4) & DIGIT_MASK;
         in_str += 7;
         out_len -= 2;
     }
@@ -527,9 +537,9 @@ static void from_words52(BN_ULONG *out, int out_bitsize, const BN_ULONG *in)
         uint8_t *out_str = (uint8_t *)out;
 
         for (; out_bitsize >= (2 * DIGIT_SIZE); out_bitsize -= (2 * DIGIT_SIZE), in += 2) {
-            (*(uint64_t *)out_str) = in[0];
+            (*(uint64_t_align1 *)out_str) = in[0];
             out_str += 6;
-            (*(uint64_t *)out_str) ^= in[1] << 4;
+            (*(uint64_t_align1 *)out_str) ^= in[1] << 4;
             out_str += 7;
         }
 


### PR DESCRIPTION
This happens rarely, but only because very few CI runs use the exotic CPU type that is necessary to execute anything within rsaz_exp_x2.c and enable UBSAN at the same time.

crypto/bn/rsaz_exp_x2.c:562:20: runtime error: load of misaligned address 0x612000022cc6 for type 'uint64_t' (aka 'unsigned long'), which requires 8 byte alignment 0x612000022cc6: note: pointer points here
 84 a3 78 e0 8e 8d  4a a5 51 9c 57 d0 d6 41  f3 26 d1 4e e1 98 42 b5  3a 9f 04 f1 73 d2 1d bf  73 44
             ^
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior crypto/bn/rsaz_exp_x2.c:562:20 in ../../util/wrap.pl ../../fuzz/server-test ../../fuzz/corpora/server => 1 not ok 2 - Fuzzing server

This is for 3.0