### PR TITLE
`p12_kiss.c`: clean sloppy use of `sk_X509_shift()`

### DIFF
--- a/crypto/ct/ct_oct.c
+++ b/crypto/ct/ct_oct.c
@@ -272,12 +272,10 @@ STACK_OF(SCT) *o2i_SCT_LIST(STACK_OF(SCT) **a, const unsigned char **pp,
         if (sk == NULL)
             return NULL;
     } else {
-        SCT *sct;
-
         /* Use the given stack, but empty it first. */
         sk = *a;
-        while ((sct = sk_SCT_pop(sk)) != NULL)
-            SCT_free(sct);
+        while (sk_SCT_num(sk) > 0)
+            SCT_free(sk_SCT_pop(sk));
     }
 
     while (list_len > 0) {

--- a/crypto/engine/eng_cnf.c
+++ b/crypto/engine/eng_cnf.c
@@ -170,10 +170,8 @@ static int int_engine_module_init(CONF_IMODULE *md, const CONF *cnf)
 
 static void int_engine_module_finish(CONF_IMODULE *md)
 {
-    ENGINE *e;
-
-    while ((e = sk_ENGINE_pop(initialized_engines)))
-        ENGINE_finish(e);
+    while (sk_ENGINE_num(initialized_engines) > 0)
+        ENGINE_finish(sk_ENGINE_pop(initialized_engines));
     sk_ENGINE_free(initialized_engines);
     initialized_engines = NULL;
 }

--- a/crypto/pkcs12/p12_kiss.c
+++ b/crypto/pkcs12/p12_kiss.c
@@ -90,7 +90,8 @@ int PKCS12_parse(PKCS12 *p12, const char *pass, EVP_PKEY **pkey, X509 **cert,
     }
 
     /* Split the certs in ocerts over *cert and *ca as far as requested */
-    while ((x = sk_X509_shift(ocerts)) != NULL) {
+    while (sk_X509_num(ocerts) > 0) {
+        x = sk_X509_shift(ocerts);
         if (pkey != NULL && *pkey != NULL
                 && cert != NULL && *cert == NULL) {
             int match;


### PR DESCRIPTION
After adding error queue entries, an error showed up at this point.

Fixes #19389 in a direct way, alternatively to #19400.

