### PR TITLE
Finer grained error records for provider load/init failures

### DIFF
--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -901,7 +901,8 @@ static int provider_init(OSSL_PROVIDER *prov)
 
         if (prov->module == NULL) {
             /* DSO has already recorded errors, this is just a tracepoint */
-            ERR_raise(ERR_LIB_CRYPTO, ERR_R_DSO_LIB);
+            ERR_raise_data(ERR_LIB_CRYPTO, ERR_R_DSO_LIB,
+                           "name=%s", prov->name);
             goto end;
         }
 
@@ -913,7 +914,8 @@ static int provider_init(OSSL_PROVIDER *prov)
     /* Check for and call the initialise function for the provider. */
     if (prov->init_function == NULL) {
         ERR_raise_data(ERR_LIB_CRYPTO, ERR_R_UNSUPPORTED,
-                       "name=%s, provider has no provider init function");
+                       "name=%s, provider has no provider init function",
+                       prov->name);
         goto end;
     }
 

--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -899,16 +899,26 @@ static int provider_init(OSSL_PROVIDER *prov)
             OPENSSL_free(allocated_load_dir);
         }
 
-        if (prov->module != NULL)
-            prov->init_function = (OSSL_provider_init_fn *)
-                DSO_bind_func(prov->module, "OSSL_provider_init");
+        if (prov->module == NULL) {
+            /* DSO has already recorded errors, this is just a tracepoint */
+            ERR_raise(ERR_LIB_CRYPTO, ERR_R_DSO_LIB);
+            goto end;
+        }
+
+        prov->init_function = (OSSL_provider_init_fn *)
+            DSO_bind_func(prov->module, "OSSL_provider_init");
 #endif
     }
 
-    /* Call the initialise function for the provider. */
-    if (prov->init_function == NULL
-        || !prov->init_function((OSSL_CORE_HANDLE *)prov, core_dispatch,
-                                &provider_dispatch, &tmp_provctx)) {
+    /* Check for and call the initialise function for the provider. */
+    if (prov->init_function == NULL) {
+        ERR_raise_data(ERR_LIB_CRYPTO, ERR_R_UNSUPPORTED,
+                       "name=%s, provider has no provider init function");
+        goto end;
+    }
+
+    if (!prov->init_function((OSSL_CORE_HANDLE *)prov, core_dispatch,
+                             &provider_dispatch, &tmp_provctx)) {
         ERR_raise_data(ERR_LIB_CRYPTO, ERR_R_INIT_FAIL,
                        "name=%s", prov->name);
         goto end;


### PR DESCRIPTION
Finer grained error records for provider load/init failures

When a provider is activated, these three cases would record that the
provider init function failed (implying that it was called):

-   failure to load the provider module (in case it's a dynamically
    loadable module)
-   the init function not being present (i.e. being NULL)
-   the init function being called and returning an error indication
    (i.e. returning a false value)

This is confusing.

Separating the three cases so that they record different errors will
make it easier to determine causes of failure.
