### PR TITLE
test: don't check for FIPS provider if it isn't being built

### DIFF
--- a/test/drbgtest.c
+++ b/test/drbgtest.c
@@ -137,6 +137,7 @@ static time_t reseed_time(EVP_RAND_CTX *drbg)
  */
 static int using_fips_rng(void)
 {
+#ifdef FIPS_MODULE
     EVP_RAND_CTX *primary = RAND_get0_primary(NULL);
     const OSSL_PROVIDER *prov;
     const char *name;
@@ -149,6 +150,9 @@ static int using_fips_rng(void)
         return 0;
     name = OSSL_PROVIDER_get0_name(prov);
     return strcmp(name, "OpenSSL FIPS Provider") == 0;
+#else  /* FIPS_MODULE */
+    return 0;
+#endif /* FIPS_MODULE */
 }
 
  /*


### PR DESCRIPTION
Fixes #19396

- [ ] documentation is added or updated
- [x] tests are added or updated
