### PR TITLE
c_rehash: Fix file extension matching

### DIFF
--- a/tools/c_rehash.in
+++ b/tools/c_rehash.in
@@ -143,7 +143,7 @@ sub hash_dir {
             }
         }
     }
-    FILE: foreach $fname (grep {/\.(pem)|(crt)|(cer)|(crl)$/} @flist) {
+    FILE: foreach $fname (grep {/\.(pem|crt|cer|crl)$/} @flist) {
         # Check to see if certificates and/or CRLs present.
         my ($cert, $crl) = check_file($fname);
         if (!$cert && !$crl) {


### PR DESCRIPTION
For some reason, parenthesis were added 8 years ago in commit a787c2590e468585a1a19738e0c7f481ec91b762. This essentially removed the \. and $ constructs from the middle branches. Hence a file called e.g. cert.key would accidentally match the (cer) rule.

CLA: trivial