### PR TITLE
crypto: thread: serialize concurrent joins

### DIFF
--- a/crypto/thread/arch/thread_none.c
+++ b/crypto/thread/arch/thread_none.c
@@ -16,7 +16,7 @@ int ossl_crypto_thread_native_spawn(CRYPTO_THREAD *thread)
     return 0;
 }
 
-int ossl_crypto_thread_native_join(CRYPTO_THREAD *thread, CRYPTO_THREAD_RETVAL *retval)
+int ossl_crypto_thread_native_perform_join(CRYPTO_THREAD *thread, CRYPTO_THREAD_RETVAL *retval)
 {
     return 0;
 }

--- a/include/internal/thread_arch.h
+++ b/include/internal/thread_arch.h
@@ -52,7 +52,8 @@ typedef CRYPTO_THREAD_RETVAL (*CRYPTO_THREAD_ROUTINE_CB)(void *,
                                                          void **);
 
 # define CRYPTO_THREAD_NO_STATE   0UL
-# define CRYPTO_THREAD_FINISHED   (1UL << 1)
+# define CRYPTO_THREAD_FINISHED   (1UL << 0)
+# define CRYPTO_THREAD_JOIN_AWAIT (1UL << 1)
 # define CRYPTO_THREAD_JOINED     (1UL << 2)
 # define CRYPTO_THREAD_TERMINATED (1UL << 3)
 
@@ -109,6 +110,8 @@ CRYPTO_THREAD * ossl_crypto_thread_native_start(CRYPTO_THREAD_ROUTINE routine,
 int ossl_crypto_thread_native_spawn(CRYPTO_THREAD *thread);
 int ossl_crypto_thread_native_join(CRYPTO_THREAD *thread,
                               CRYPTO_THREAD_RETVAL *retval);
+int ossl_crypto_thread_native_perform_join(CRYPTO_THREAD *thread,
+                                           CRYPTO_THREAD_RETVAL *retval);
 int ossl_crypto_thread_native_terminate(CRYPTO_THREAD *thread);
 int ossl_crypto_thread_native_exit(void);
 int ossl_crypto_thread_native_is_self(CRYPTO_THREAD *thread);

--- a/test/threadstest.c
+++ b/test/threadstest.c
@@ -833,7 +833,7 @@ static int test_thread_native(void)
     if (!TEST_int_eq(ossl_crypto_thread_native_terminate(t), 1))
         return 0;
 
-    if (!TEST_int_eq(ossl_crypto_thread_native_join(t, &retval), 1))
+    if (!TEST_int_eq(ossl_crypto_thread_native_join(t, &retval), 0))
         return 0;
 
     if (!TEST_int_eq(ossl_crypto_thread_native_clean(t), 1))


### PR DESCRIPTION
Multiple concurrent joins with a running thread suffer from a race condition that allows concurrent join calls to perform concurrent arch specific join calls, which is UB on POSIX, or to concurrently execute join and terminate calls.

As soon as a thread T1 exists, one of the threads that joins with T1 is selected to perform the join, the remaining ones await completion. Once completed, the remaining calls immediately return. If the join failed, another thread is selected to attempt the join operation.

Forcefully terminating a thread that is in the process of joining another thread is not supported.

Common code from thread_posix and thread_win was refactored to use common wrapper that handles synchronization.

This should fix the timeout encountered while executing threads test (likely due to test_thread_native_multiple_joins).

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
