### PR TITLE
Changes entry for Ripemd160 in 3.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,10 +24,6 @@ OpenSSL 3.2
 
 ### Changes between 3.0 and 3.2 [xx XXX xxxx]
 
- * Added RIPEMD160 to the default provider.
-
-   *Paul Dale*
-
  * Add support for certificate compression (RFC8879), including
    library support for Brotli and Zstandard compression.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -227,6 +227,12 @@ breaking changes, and mappings for the large list of deprecated functions.
 
 [Migration guide]: https://github.com/openssl/openssl/tree/master/doc/man7/migration_guide.pod
 
+### Changes between 3.0.6 and 3.0.7 [?? ??? ????]
+
+ * Added RIPEMD160 to the default provider.
+
+   *Paul Dale*
+
 ### Changes between 3.0.5 and 3.0.6 [11 Oct 2022]
 
  * OpenSSL supports creating a custom cipher via the legacy

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -223,7 +223,7 @@ breaking changes, and mappings for the large list of deprecated functions.
 
 [Migration guide]: https://github.com/openssl/openssl/tree/master/doc/man7/migration_guide.pod
 
-### Changes between 3.0.6 and 3.0.7 [?? ??? ????]
+### Changes between 3.0.6 and 3.0.7 [xx XXX xxxx]
 
  * Added RIPEMD160 to the default provider.
 


### PR DESCRIPTION
The second commit belongs only to master branch. The first can be cherry picked to 3.0 (possibly with trivial conflict fixup).
