### PR TITLE
link the pyca tests against the correct openssl

### DIFF
--- a/test/recipes/95-test_external_pyca_data/cryptography.sh
+++ b/test/recipes/95-test_external_pyca_data/cryptography.sh
@@ -42,19 +42,22 @@ python -m venv venv-cryptography
 
 cd pyca-cryptography
 
-pip install .[test]
+echo "------------------------------------------------------------------"
+echo "Building cryptography and installing test requirements"
+echo "------------------------------------------------------------------"
+LDFLAGS="-L$O_LIB" CFLAGS="-I$O_BINC -I$O_SINC " pip install .[test]
 pip install -e vectors
 
 echo "------------------------------------------------------------------"
-echo "Building cryptography"
+echo "Print linked libraries"
 echo "------------------------------------------------------------------"
-CFLAGS="-I$O_BINC -I$O_SINC -L$O_LIB" pip install .
+ldd ../venv-cryptography/lib/python*/site-packages/cryptography/hazmat/bindings/_openssl*
+
 
 echo "------------------------------------------------------------------"
 echo "Running tests"
 echo "------------------------------------------------------------------"
-
-CFLAGS="-I$O_BINC -I$O_SINC -L$O_LIB" pytest -n auto tests --wycheproof-root=../wycheproof
+pytest -n auto tests --wycheproof-root=../wycheproof
 
 cd ../
 deactivate

--- a/test/recipes/95-test_external_pyca_data/cryptography.sh
+++ b/test/recipes/95-test_external_pyca_data/cryptography.sh
@@ -39,6 +39,8 @@ cd $SRCTOP
 rm -rf venv-cryptography
 python -m venv venv-cryptography
 . ./venv-cryptography/bin/activate
+# Upgrade pip to always have latest
+pip install -U pip
 
 cd pyca-cryptography
 
@@ -51,7 +53,7 @@ pip install -e vectors
 echo "------------------------------------------------------------------"
 echo "Print linked libraries"
 echo "------------------------------------------------------------------"
-ldd ../venv-cryptography/lib/python*/site-packages/cryptography/hazmat/bindings/_openssl*
+ldd ../venv-cryptography/lib/python*/site-packages/cryptography/hazmat/bindings/_openssl*.so
 
 
 echo "------------------------------------------------------------------"

--- a/test/recipes/95-test_external_pyca_data/cryptography.sh
+++ b/test/recipes/95-test_external_pyca_data/cryptography.sh
@@ -53,7 +53,7 @@ pip install -e vectors
 echo "------------------------------------------------------------------"
 echo "Print linked libraries"
 echo "------------------------------------------------------------------"
-ldd ../venv-cryptography/lib/python*/site-packages/cryptography/hazmat/bindings/_openssl*.so
+ldd $(find ../venv-cryptography/lib/ -iname '*.so')
 
 
 echo "------------------------------------------------------------------"


### PR DESCRIPTION
Links OpenSSL properly for the pyca test suite and prints more verbose information about the shared objects if people need to debug it again in the future.