### PR TITLE
add dependabot to keep actions versions up-to-date

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
While working on #19439 I noticed that there were multiple deprecation warnings for various out of date github actions. This dependabot job will automatically bump actions versions when new tags are created for the actions you consume.