### PR TITLE
check the return of BIO_new_fp() in dup_bio_out() & dup_bio_err()

### DIFF
--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -2911,6 +2911,9 @@ BIO *dup_bio_out(int format)
                         BIO_NOCLOSE | (FMT_istext(format) ? BIO_FP_TEXT : 0));
     void *prefix = NULL;
 
+    if (b == NULL)
+        return NULL;
+
 #ifdef OPENSSL_SYS_VMS
     if (FMT_istext(format))
         b = BIO_push(BIO_new(BIO_f_linebuffer()), b);
@@ -2931,7 +2934,7 @@ BIO *dup_bio_err(int format)
                         BIO_NOCLOSE | (FMT_istext(format) ? BIO_FP_TEXT : 0));
 
 #ifdef OPENSSL_SYS_VMS
-    if (FMT_istext(format))
+    if (b != NULL && FMT_istext(format))
         b = BIO_push(BIO_new(BIO_f_linebuffer()), b);
 #endif
     return b;


### PR DESCRIPTION
In dup_bio_out() & dup_bio_err(), if BIO_new_fp() fails, we should just return NULL and do not need to further create other filter BIOs.