### PR TITLE
replace BIO_free(bio_err) as BIO_free_all(bio_err)

### DIFF
--- a/apps/openssl.c
+++ b/apps/openssl.c
@@ -307,7 +307,7 @@ int main(int argc, char *argv[])
     BIO_free(bio_in);
     BIO_free_all(bio_out);
     apps_shutdown();
-    BIO_free(bio_err);
+    BIO_free_all(bio_err);
     EXIT(ret);
 }
 


### PR DESCRIPTION
Because dup_bio_err() can return a BIO chain when 'OPENSSL_SYS_VMS' is defined, it is better to use BIO_free_all() to release rather BIO_free().