### PR TITLE
Workaround egd rand source deficiencies

### DIFF
--- a/test/drbgtest.c
+++ b/test/drbgtest.c
@@ -277,7 +277,7 @@ static int test_drbg_reseed(int expect_success,
 }
 
 
-#if defined(OPENSSL_SYS_UNIX)
+#if defined(OPENSSL_SYS_UNIX) && !defined(OPENSSL_RAND_SEED_EGD)
 /* number of children to fork */
 #define DRBG_FORK_COUNT 9
 /* two results per child, two for the parent */
@@ -895,7 +895,7 @@ err:
 int setup_tests(void)
 {
     ADD_TEST(test_rand_reseed);
-#if defined(OPENSSL_SYS_UNIX)
+#if defined(OPENSSL_SYS_UNIX) && !defined(OPENSSL_RAND_SEED_EGD)
     ADD_ALL_TESTS(test_rand_fork_safety, RANDOM_SIZE);
 #endif
     ADD_TEST(test_rand_prediction_resistance);


### PR DESCRIPTION
With egd as the rand source the reseed after fork confuses the egd.

Fixes #19396

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
