### PR TITLE
Add a test for TLS pipelining

### DIFF
--- a/doc/man3/SSL_CTX_set_split_send_fragment.pod
+++ b/doc/man3/SSL_CTX_set_split_send_fragment.pod
@@ -56,7 +56,7 @@ of pipelines that will be used at any one time. This value applies to both
 used (i.e. normal non-parallel operation). The number of pipelines set must be
 in the range 1 - SSL_MAX_PIPELINES (32). Setting this to a value > 1 will also
 automatically turn on "read_ahead" (see L<SSL_CTX_set_read_ahead(3)>). This is
-explained further below. OpenSSL will only every use more than one pipeline if
+explained further below. OpenSSL will only ever use more than one pipeline if
 a cipher suite is negotiated that uses a pipeline capable cipher provided by an
 engine.
 
@@ -96,7 +96,10 @@ into the buffer. Without this set data is read into the read buffer one record
 at a time. The more data that can be read, the more opportunity there is for
 parallelising the processing at the cost of increased memory overhead per
 connection. Setting B<read_ahead> can impact the behaviour of the SSL_pending()
-function (see L<SSL_pending(3)>).
+function (see L<SSL_pending(3)>). In addition the default size of the internal
+read buffer is multiplied by the number of pipelines available to ensure that we
+can read multiple records in one go. This can therefore have a signficiant
+impact on memory usage.
 
 The SSL_CTX_set_default_read_buffer_len() and SSL_set_default_read_buffer_len()
 functions control the size of the read buffer that will be used. The B<len>

--- a/doc/man3/SSL_CTX_set_split_send_fragment.pod
+++ b/doc/man3/SSL_CTX_set_split_send_fragment.pod
@@ -98,7 +98,7 @@ parallelising the processing at the cost of increased memory overhead per
 connection. Setting B<read_ahead> can impact the behaviour of the SSL_pending()
 function (see L<SSL_pending(3)>). In addition the default size of the internal
 read buffer is multiplied by the number of pipelines available to ensure that we
-can read multiple records in one go. This can therefore have a signficiant
+can read multiple records in one go. This can therefore have a significant
 impact on memory usage.
 
 The SSL_CTX_set_default_read_buffer_len() and SSL_set_default_read_buffer_len()

--- a/ssl/record/methods/tls1_meth.c
+++ b/ssl/record/methods/tls1_meth.c
@@ -162,6 +162,7 @@ static int tls1_cipher(OSSL_RECORD_LAYER *rl, SSL3_RECORD *recs, size_t n_recs,
     EVP_CIPHER_CTX *ds;
     size_t reclen[SSL_MAX_PIPELINES];
     unsigned char buf[SSL_MAX_PIPELINES][EVP_AEAD_TLS1_AAD_LEN];
+    unsigned char *data[SSL_MAX_PIPELINES];
     int pad = 0, tmpr, provided;
     size_t bs, ctr, padnum, loop;
     unsigned char padval;
@@ -298,8 +299,6 @@ static int tls1_cipher(OSSL_RECORD_LAYER *rl, SSL3_RECORD *recs, size_t n_recs,
         }
     }
     if (n_recs > 1) {
-        unsigned char *data[SSL_MAX_PIPELINES];
-
         /* Set the output buffers */
         for (ctr = 0; ctr < n_recs; ctr++)
             data[ctr] = recs[ctr].data;

--- a/ssl/record/methods/tls_common.c
+++ b/ssl/record/methods/tls_common.c
@@ -290,9 +290,9 @@ int tls_default_read_n(OSSL_RECORD_LAYER *rl, size_t n, size_t max, int extend,
 
     if (!extend) {
         /* start with empty packet ... */
-        if (left == 0) {
+        if (left == 0)
             rb->offset = align;
-        }
+
         rl->packet = rb->buf + rb->offset;
         rl->packet_length = 0;
         /* ... now we can act as if 'extend' was set */

--- a/ssl/record/methods/tls_common.c
+++ b/ssl/record/methods/tls_common.c
@@ -1456,10 +1456,6 @@ size_t tls_get_max_records_default(OSSL_RECORD_LAYER *rl, int type, size_t len,
                                    size_t maxfrag, size_t *preffrag)
 {
     /*
-     * TODO(RECLAYER): There is no test for the pipelining code. We should add
-     *                 one.
-     */
-    /*
      * If we have a pipeline capable cipher, and we have been configured to use
      * it, then return the preferred number of pipelines.
      */

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -10233,7 +10233,7 @@ static int test_pipelining(int idx)
 
     /*
      * If the pipelining code worked, then we expect all 5 pipelines to have
-     * been used - expect in test 3 where only 4 pipelines will be used. This
+     * been used - except in test 3 where only 4 pipelines will be used. This
      * will result in 5 records (4 for test 3) having been sent to peerb.
      * Since peerb is not using read_ahead we expect this to be read in 5 or 4
      * separate SSL_read_ex calls
@@ -10266,7 +10266,7 @@ static int test_pipelining(int idx)
 
     /*
      * The data was written in 5 separate chunks. If the pipelining is working
-     * the we expect peera to read all 5 and process them in parallel, giving
+     * then we expect peera to read all 5 and process them in parallel, giving
      * back the complete result in a single call to SSL_read_ex
      */
     if (!TEST_true(SSL_read_ex(peera, buf, sizeof(buf) - 1, &readbytes)))

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -10175,7 +10175,7 @@ static int test_pipelining(int idx)
     int testresult = 0, numreads;
     /* A 55 byte message */
     unsigned char *msg = (unsigned char *)
-        "0123456789012345678901234567890123456789012345678901234";
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz123";
     size_t written, readbytes, offset, msglen, fragsize = 10, numpipes = 5;
     size_t expectedreads;
     unsigned char *buf = NULL;
@@ -10217,7 +10217,7 @@ static int test_pipelining(int idx)
 
     if (idx == 5) {
         numpipes = 2;
-        /* Maxium allowed fragment size */
+        /* Maximum allowed fragment size */
         fragsize = SSL3_RT_MAX_PLAIN_LENGTH;
         msglen = fragsize * numpipes;
         msg = OPENSSL_malloc(msglen);


### PR DESCRIPTION
TLS pipelining provides the ability for libssl to read or write multiple records in parallel. It requires special ciphers to do this, and there are currently no built-in ciphers that provide this capability. However, the dasync engine does have such a cipher, so we add a test for this capability using that engine.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
