### PR TITLE
doc: fix copy/paste error

### DIFF
--- a/doc/man3/OPENSSL_init_crypto.pod
+++ b/doc/man3/OPENSSL_init_crypto.pod
@@ -82,7 +82,7 @@ B<OPENSSL_INIT_NO_ADD_ALL_CIPHERS> will be ignored.
 With this option the library will automatically load and make available all
 libcrypto digests. This option is a default option. Once selected subsequent
 calls to OPENSSL_init_crypto() with the option
-B<OPENSSL_INIT_NO_ADD_ALL_CIPHERS> will be ignored.
+B<OPENSSL_INIT_NO_ADD_ALL_DIGESTS> will be ignored.
 
 =item OPENSSL_INIT_NO_ADD_ALL_CIPHERS
 


### PR DESCRIPTION
This isn't a security fix but should be safe in 1.1.1.  If a reviewer disagrees, please remove the label.  I'm fine either way.

Fixes #19460


- [x] documentation is added or updated
- [ ] tests are added or updated
