### PR TITLE
Fix a typo in DTLSv1_listen()

### DIFF
--- a/ssl/d1_lib.c
+++ b/ssl/d1_lib.c
@@ -454,7 +454,7 @@ int DTLSv1_listen(SSL *ssl, BIO_ADDR *client)
     if (buf == NULL)
         return -1;
     wbuf = OPENSSL_malloc(DTLS1_RT_HEADER_LENGTH + SSL3_RT_MAX_PLAIN_LENGTH);
-    if (buf == NULL)
+    if (wbuf == NULL)
         return -1;
 
     do {


### PR DESCRIPTION
Due to a typo we were checking the wrong buffer for NULL.

Fixes coverity issue 1516101.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
