### PR TITLE
Fix test_tls13_encryption()

### DIFF
--- a/ssl/record/methods/tls_common.c
+++ b/ssl/record/methods/tls_common.c
@@ -1398,6 +1398,9 @@ int tls_free(OSSL_RECORD_LAYER *rl)
     size_t left, written;
     int ret = 1;
 
+    if (rl == NULL)
+        return 1;
+
     rbuf = &rl->rbuf;
 
     left = SSL3_BUFFER_get_left(rbuf);

--- a/test/tls13encryptiontest.c
+++ b/test/tls13encryptiontest.c
@@ -305,17 +305,14 @@ static int test_record(SSL3_RECORD *rec, RECORD_DATA *recd, int enc)
 
 static int test_tls13_encryption(void)
 {
-    SSL_CTX *ctx = NULL;
-    SSL *ssl = NULL;
     SSL3_RECORD rec;
     unsigned char *key = NULL;
     const EVP_CIPHER *ciph = EVP_aes_128_gcm();
     int ret = 0;
     size_t ivlen, ctr;
-    SSL_CONNECTION *s;
     unsigned char seqbuf[SEQ_NUM_SIZE];
     unsigned char iv[EVP_MAX_IV_LENGTH];
-    OSSL_RECORD_LAYER *rl;
+    OSSL_RECORD_LAYER *rrl = NULL, *wrl = NULL;
 
     /*
      * Encrypted TLSv1.3 records always have an outer content type of
@@ -325,32 +322,6 @@ static int test_tls13_encryption(void)
     rec.type = SSL3_RT_APPLICATION_DATA;
     rec.rec_version = TLS1_2_VERSION;
 
-    ctx = SSL_CTX_new(TLS_method());
-    if (!TEST_ptr(ctx)) {
-        TEST_info("Failed creating SSL_CTX");
-        goto err;
-    }
-
-    ssl = SSL_new(ctx);
-    if (!TEST_ptr(ssl) || !TEST_ptr(s = SSL_CONNECTION_FROM_SSL_ONLY(ssl))) {
-        TEST_info("Failed creating SSL");
-        goto err;
-    }
-
-    s->enc_read_ctx = EVP_CIPHER_CTX_new();
-    if (!TEST_ptr(s->enc_read_ctx))
-        goto err;
-
-    s->enc_write_ctx = EVP_CIPHER_CTX_new();
-    if (!TEST_ptr(s->enc_write_ctx))
-        goto err;
-
-    s->s3.tmp.new_cipher = SSL_CIPHER_find(ssl, TLS13_AES_128_GCM_SHA256_BYTES);
-    if (!TEST_ptr(s->s3.tmp.new_cipher)) {
-        TEST_info("Failed to find cipher");
-        goto err;
-    }
-
     for (ctr = 0; ctr < OSSL_NELEM(refdata); ctr++) {
         /* Load the record */
         ivlen = EVP_CIPHER_get_iv_length(ciph);
@@ -359,55 +330,53 @@ static int test_tls13_encryption(void)
             goto err;
         }
 
-        /* Set up the read/write sequences */
-#if 0
-        /* TODO(RECLAYER): Fix me */
-        memcpy(RECORD_LAYER_get_write_sequence(&s->rlayer), seqbuf, sizeof(seqbuf));
-#endif
-        memcpy(s->write_iv, iv, ivlen);
-
-        /* Load the key into the EVP_CIPHER_CTXs */
-        if (EVP_CipherInit_ex(s->enc_write_ctx, ciph, NULL, key, NULL, 1) <= 0
-                || EVP_CipherInit_ex(s->enc_read_ctx, ciph, NULL, key, NULL, 0)
-                   <= 0) {
-            TEST_error("Failed loading key into EVP_CIPHER_CTX\n");
+        /* Set up the write record layer */
+        if (!TEST_true(ossl_tls_record_method.new_record_layer(
+                          NULL, NULL, TLS1_3_VERSION, OSSL_RECORD_ROLE_SERVER,
+                          OSSL_RECORD_DIRECTION_WRITE,
+                          OSSL_RECORD_PROTECTION_LEVEL_APPLICATION, 0, key, 16,
+                          iv, ivlen, NULL, 0, EVP_aes_128_gcm(),
+                          EVP_GCM_TLS_TAG_LEN, 0, NULL, NULL, NULL, NULL, NULL,
+                          NULL, NULL, NULL, NULL, NULL, NULL, &wrl)))
             goto err;
-        }
+        memcpy(wrl->sequence, seqbuf, sizeof(seqbuf));
 
         /* Encrypt it */
-#if 0
-        /* TODO(RECLAYER): Fix me */
-        if (!TEST_size_t_eq(tls13_enc(s, &rec, 1, 1, NULL, 0), 1)) {
+        if (!TEST_size_t_eq(wrl->funcs->cipher(wrl, &rec, 1, 1, NULL, 0), 1)) {
             TEST_info("Failed to encrypt record %zu", ctr);
             goto err;
         }
-#endif
+
         if (!TEST_true(test_record(&rec, &refdata[ctr], 1))) {
             TEST_info("Record %zu encryption test failed", ctr);
             goto err;
         }
 
+        /* Set up the read record layer */
         if (!TEST_true(ossl_tls_record_method.new_record_layer(
                           NULL, NULL, TLS1_3_VERSION, OSSL_RECORD_ROLE_SERVER,
                           OSSL_RECORD_DIRECTION_READ,
                           OSSL_RECORD_PROTECTION_LEVEL_APPLICATION, 0, key, 16,
                           iv, ivlen, NULL, 0, EVP_aes_128_gcm(),
                           EVP_GCM_TLS_TAG_LEN, 0, NULL, NULL, NULL, NULL, NULL,
-                          NULL, NULL, NULL, NULL, NULL, NULL, &rl))) {
+                          NULL, NULL, NULL, NULL, NULL, NULL, &rrl)))
             goto err;
-        }
-        memcpy(rl->sequence, seqbuf, sizeof(seqbuf));
+        memcpy(rrl->sequence, seqbuf, sizeof(seqbuf));
+
         /* Decrypt it */
-        if (!TEST_int_eq(rl->funcs->cipher(rl, &rec, 1, 0, NULL, 0), 1)) {
+        if (!TEST_int_eq(wrl->funcs->cipher(rrl, &rec, 1, 0, NULL, 0), 1)) {
             TEST_info("Failed to decrypt record %zu", ctr);
             goto err;
         }
+
         if (!TEST_true(test_record(&rec, &refdata[ctr], 0))) {
             TEST_info("Record %zu decryption test failed", ctr);
             goto err;
         }
 
-        ossl_tls_record_method.free(rl);
+        ossl_tls_record_method.free(rrl);
+        ossl_tls_record_method.free(wrl);
+        rrl = wrl = NULL;
         OPENSSL_free(rec.data);
         OPENSSL_free(key);
         rec.data = NULL;
@@ -418,18 +387,15 @@ static int test_tls13_encryption(void)
     ret = 1;
 
  err:
+    ossl_tls_record_method.free(rrl);
+    ossl_tls_record_method.free(wrl);
     OPENSSL_free(rec.data);
     OPENSSL_free(key);
-    SSL_free(ssl);
-    SSL_CTX_free(ctx);
     return ret;
 }
 
 int setup_tests(void)
 {
-    if (0) {
-        /* TODO(RECLAYER): This test needs fixing for the new record layer */
-        ADD_TEST(test_tls13_encryption);
-    }
+    ADD_TEST(test_tls13_encryption);
     return 1;
 }


### PR DESCRIPTION
This test was disabled during the record write record layer refactor. We can now enable it again.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
