### PR TITLE
Make SSL_alloc_buffers() and SSL_free_buffers() work again

### DIFF
--- a/ssl/record/methods/dtls_meth.c
+++ b/ssl/record/methods/dtls_meth.c
@@ -790,5 +790,7 @@ const OSSL_RECORD_METHOD ossl_dtls_record_method = {
     tls_get_compression,
     tls_set_max_frag_len,
     dtls_get_max_record_overhead,
-    tls_increment_sequence_ctr
+    tls_increment_sequence_ctr,
+    tls_alloc_buffers,
+    tls_free_buffers
 };

--- a/ssl/record/methods/dtls_meth.c
+++ b/ssl/record/methods/dtls_meth.c
@@ -771,8 +771,6 @@ const OSSL_RECORD_METHOD ossl_dtls_record_method = {
     tls_unprocessed_read_pending,
     tls_processed_read_pending,
     tls_app_data_pending,
-    tls_write_pending,
-    tls_get_max_record_len,
     tls_get_max_records,
     tls_write_records,
     tls_retry_write_records,

--- a/ssl/record/methods/ktls_meth.c
+++ b/ssl/record/methods/ktls_meth.c
@@ -579,8 +579,6 @@ const OSSL_RECORD_METHOD ossl_ktls_record_method = {
     tls_unprocessed_read_pending,
     tls_processed_read_pending,
     tls_app_data_pending,
-    tls_write_pending,
-    tls_get_max_record_len,
     tls_get_max_records,
     tls_write_records,
     tls_retry_write_records,

--- a/ssl/record/methods/ktls_meth.c
+++ b/ssl/record/methods/ktls_meth.c
@@ -533,6 +533,24 @@ static int ktls_prepare_write_bio(OSSL_RECORD_LAYER *rl, int type)
     return OSSL_RECORD_RETURN_SUCCESS;
 }
 
+static int ktls_alloc_buffers(OSSL_RECORD_LAYER *rl)
+{
+    /* We use the application buffer directly for writing */
+    if (rl->direction == OSSL_RECORD_DIRECTION_WRITE)
+        return 1;
+
+    return tls_alloc_buffers(rl);
+}
+
+static int ktls_free_buffers(OSSL_RECORD_LAYER *rl)
+{
+    /* We use the application buffer directly for writing */
+    if (rl->direction == OSSL_RECORD_DIRECTION_WRITE)
+        return 1;
+
+    return tls_free_buffers(rl);
+}
+
 static struct record_functions_st ossl_ktls_funcs = {
     ktls_set_crypto_state,
     ktls_cipher,
@@ -580,5 +598,7 @@ const OSSL_RECORD_METHOD ossl_ktls_record_method = {
     tls_get_compression,
     tls_set_max_frag_len,
     NULL,
-    tls_increment_sequence_ctr
+    tls_increment_sequence_ctr,
+    ktls_alloc_buffers,
+    ktls_free_buffers
 };

--- a/ssl/record/methods/recmethod_local.h
+++ b/ssl/record/methods/recmethod_local.h
@@ -389,8 +389,6 @@ int tls_reset(OSSL_RECORD_LAYER *rl);
 int tls_unprocessed_read_pending(OSSL_RECORD_LAYER *rl);
 int tls_processed_read_pending(OSSL_RECORD_LAYER *rl);
 size_t tls_app_data_pending(OSSL_RECORD_LAYER *rl);
-int tls_write_pending(OSSL_RECORD_LAYER *rl);
-size_t tls_get_max_record_len(OSSL_RECORD_LAYER *rl);
 size_t tls_get_max_records(OSSL_RECORD_LAYER *rl, int type, size_t len,
                            size_t maxfrag, size_t *preffrag);
 int tls_write_records(OSSL_RECORD_LAYER *rl, OSSL_RECORD_TEMPLATE *templates,

--- a/ssl/record/methods/recmethod_local.h
+++ b/ssl/record/methods/recmethod_local.h
@@ -345,6 +345,8 @@ __owur int ssl3_cbc_digest_record(const EVP_MD *md,
                                   size_t mac_secret_length, char is_sslv3);
 
 int tls_increment_sequence_ctr(OSSL_RECORD_LAYER *rl);
+int tls_alloc_buffers(OSSL_RECORD_LAYER *rl);
+int tls_free_buffers(OSSL_RECORD_LAYER *rl);
 
 int tls_default_read_n(OSSL_RECORD_LAYER *rl, size_t n, size_t max, int extend,
                        int clearold, size_t *readbytes);

--- a/ssl/record/methods/tls_common.c
+++ b/ssl/record/methods/tls_common.c
@@ -1442,16 +1442,6 @@ size_t tls_app_data_pending(OSSL_RECORD_LAYER *rl)
     return num;
 }
 
-int tls_write_pending(OSSL_RECORD_LAYER *rl)
-{
-    return 0;
-}
-
-size_t tls_get_max_record_len(OSSL_RECORD_LAYER *rl)
-{
-    return 0;
-}
-
 size_t tls_get_max_records_default(OSSL_RECORD_LAYER *rl, int type, size_t len,
                                    size_t maxfrag, size_t *preffrag)
 {
@@ -2095,8 +2085,6 @@ const OSSL_RECORD_METHOD ossl_tls_record_method = {
     tls_unprocessed_read_pending,
     tls_processed_read_pending,
     tls_app_data_pending,
-    tls_write_pending,
-    tls_get_max_record_len,
     tls_get_max_records,
     tls_write_records,
     tls_retry_write_records,

--- a/ssl/record/methods/tls_common.c
+++ b/ssl/record/methods/tls_common.c
@@ -2028,6 +2028,66 @@ int tls_increment_sequence_ctr(OSSL_RECORD_LAYER *rl)
     return 1;
 }
 
+int tls_alloc_buffers(OSSL_RECORD_LAYER *rl)
+{
+    if (rl->direction == OSSL_RECORD_DIRECTION_WRITE) {
+        /* If we have a pending write then buffers are already allocated */
+        if (rl->nextwbuf < rl->numwpipes)
+            return 1;
+        /*
+         * We assume 1 pipe with default sized buffer. If what we need ends up
+         * being a different size to that then it will be reallocated on demand.
+         * If we need more than 1 pipe then that will also be allocated on
+         * demand
+         */
+        if (!tls_setup_write_buffer(rl, 1, 0, 0))
+            return 0;
+
+        /*
+         * Normally when we allocate write buffers we immediately write
+         * something into it. In this case we're not doing that so mark the
+         * buffer as empty.
+         */
+        SSL3_BUFFER_set_left(&rl->wbuf[0], 0);
+        return 1;
+    }
+
+    /* Read direction */
+
+    /* If we have pending data to be read then buffers are already allocated */
+    if (rl->curr_rec < rl->num_recs || SSL3_BUFFER_get_left(&rl->rbuf) != 0)
+        return 1;
+    return tls_setup_read_buffer(rl);
+}
+
+int tls_free_buffers(OSSL_RECORD_LAYER *rl)
+{
+    if (rl->direction == OSSL_RECORD_DIRECTION_WRITE) {
+        if (rl->nextwbuf < rl->numwpipes) {
+            /*
+             * We may have pending data. If we've just got one empty buffer
+             * allocated then it has probably just been alloc'd via
+             * tls_alloc_buffers, and it is fine to free it. Otherwise this
+             * looks like real pending data and it is an error.
+             */
+            if (rl->nextwbuf != 0
+                    || rl->numwpipes != 1
+                    || SSL3_BUFFER_get_left(&rl->wbuf[0]) != 0)
+                return 0;
+        }
+        tls_release_write_buffer(rl);
+        return 1;
+    }
+
+    /* Read direction */
+
+    /* If we have pending data to be read then fail */
+    if (rl->curr_rec < rl->num_recs || SSL3_BUFFER_get_left(&rl->rbuf) != 0)
+        return 0;
+
+    return tls_release_read_buffer(rl);
+}
+
 const OSSL_RECORD_METHOD ossl_tls_record_method = {
     tls_new_record_layer,
     tls_free,
@@ -2054,5 +2114,7 @@ const OSSL_RECORD_METHOD ossl_tls_record_method = {
     tls_get_compression,
     tls_set_max_frag_len,
     NULL,
-    tls_increment_sequence_ctr
+    tls_increment_sequence_ctr,
+    tls_alloc_buffers,
+    tls_free_buffers
 };

--- a/ssl/record/rec_layer_s3.c
+++ b/ssl/record/rec_layer_s3.c
@@ -48,14 +48,6 @@ void RECORD_LAYER_clear(RECORD_LAYER *rl)
         DTLS_RECORD_LAYER_clear(rl);
 }
 
-void RECORD_LAYER_release(RECORD_LAYER *rl)
-{
-    /*
-     * TODO(RECLAYER): Need a way to release the write buffers in the record
-     * layer on demand
-     */
-}
-
 /* Checks if we have unprocessed read ahead data pending */
 int RECORD_LAYER_read_pending(const RECORD_LAYER *rl)
 {

--- a/ssl/record/record.h
+++ b/ssl/record/record.h
@@ -202,7 +202,6 @@ typedef struct ssl_mac_buf_st SSL_MAC_BUF;
 
 void RECORD_LAYER_init(RECORD_LAYER *rl, SSL_CONNECTION *s);
 void RECORD_LAYER_clear(RECORD_LAYER *rl);
-void RECORD_LAYER_release(RECORD_LAYER *rl);
 int RECORD_LAYER_read_pending(const RECORD_LAYER *rl);
 int RECORD_LAYER_processed_read_pending(const RECORD_LAYER *rl);
 int RECORD_LAYER_write_pending(const RECORD_LAYER *rl);

--- a/ssl/record/recordmethod.h
+++ b/ssl/record/recordmethod.h
@@ -164,16 +164,6 @@ struct ossl_record_method_st {
      */
     size_t (*app_data_pending)(OSSL_RECORD_LAYER *rl);
 
-    int (*write_pending)(OSSL_RECORD_LAYER *rl);
-
-    /*
-     * Find out the maximum amount of plaintext data that the record layer is
-     * prepared to write in a single record. When calling write_records it is
-     * the caller's responsibility to ensure that no record template exceeds
-     * this maximum when calling write_records.
-     */
-    size_t (*get_max_record_len)(OSSL_RECORD_LAYER *rl);
-
     /*
      * Find out the maximum number of records that the record layer is prepared
      * to process in a single call to write_records. It is the caller's

--- a/ssl/record/recordmethod.h
+++ b/ssl/record/recordmethod.h
@@ -320,6 +320,18 @@ struct ossl_record_method_st {
      * Increment the record sequence number
      */
     int (*increment_sequence_ctr)(OSSL_RECORD_LAYER *rl);
+
+    /*
+     * Allocate read or write buffers. Does nothing if already allocated.
+     * Assumes default buffer length and 1 pipeline.
+     */
+    int (*alloc_buffers)(OSSL_RECORD_LAYER *rl);
+
+    /*
+     * Free read or write buffers. Fails if there is pending read or write
+     * data. Buffers are automatically reallocated on next read/write.
+     */
+    int (*free_buffers)(OSSL_RECORD_LAYER *rl);
 };
 
 

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -6366,22 +6366,22 @@ int SSL_free_buffers(SSL *ssl)
 
     rl = &sc->rlayer;
 
-    if (RECORD_LAYER_read_pending(rl) || RECORD_LAYER_write_pending(rl))
-        return 0;
-
-    RECORD_LAYER_release(rl);
-    return 1;
+    return rl->rrlmethod->free_buffers(rl->rrl)
+           && rl->wrlmethod->free_buffers(rl->wrl);
 }
 
 int SSL_alloc_buffers(SSL *ssl)
 {
+    RECORD_LAYER *rl;
     SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL(ssl);
 
     if (sc == NULL)
         return 0;
 
-    /* TODO(RECLAYER): Need a way to make this happen in the record layer */
-    return 1;
+    rl = &sc->rlayer;
+
+    return rl->rrlmethod->alloc_buffers(rl->rrl)
+           && rl->wrlmethod->alloc_buffers(rl->wrl);
 }
 
 void SSL_CTX_set_keylog_callback(SSL_CTX *ctx, SSL_CTX_keylog_cb_func cb)

--- a/test/sslbuffertest.c
+++ b/test/sslbuffertest.c
@@ -13,6 +13,12 @@
 #include <openssl/bio.h>
 #include <openssl/err.h>
 
+/* We include internal headers so we can check if the buffers are allocated */
+#include "../ssl/ssl_local.h"
+#include "../ssl/record/record_local.h"
+#include "../ssl/record/recordmethod.h"
+#include "../ssl/record/methods/recmethod_local.h"
+
 #include "internal/packet.h"
 
 #include "helpers/ssltestlib.h"
@@ -28,6 +34,17 @@ static SSL_CTX *clientctx = NULL;
 
 #define MAX_ATTEMPTS    100
 
+static int checkbuffers(SSL *s, int isalloced)
+{
+    SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL(s);
+    OSSL_RECORD_LAYER *rrl = sc->rlayer.rrl;
+    OSSL_RECORD_LAYER *wrl = sc->rlayer.wrl;
+
+    if (isalloced)
+        return rrl->rbuf.buf != NULL && wrl->wbuf[0].buf != NULL;
+
+    return rrl->rbuf.buf == NULL && wrl->wbuf[0].buf == NULL;
+}
 
 /*
  * There are 9 passes in the tests
@@ -78,14 +95,18 @@ static int test_func(int test)
         for (ret = -1, i = 0, len = 0; len != sizeof(testdata) && i < 2;
              i++) {
             /* test == 0 mean to free/allocate = control */
-            if (test >= 1 && !TEST_true(SSL_free_buffers(clientssl)))
+            if (test >= 1 && (!TEST_true(SSL_free_buffers(clientssl))
+                              || !TEST_true(checkbuffers(clientssl, 0))))
                 goto end;
-            if (test >= 2 && !TEST_true(SSL_alloc_buffers(clientssl)))
+            if (test >= 2 && (!TEST_true(SSL_alloc_buffers(clientssl))
+                              || !TEST_true(checkbuffers(clientssl, 1))))
                 goto end;
             /* allocate a second time */
-            if (test >= 3 && !TEST_true(SSL_alloc_buffers(clientssl)))
+            if (test >= 3 && (!TEST_true(SSL_alloc_buffers(clientssl))
+                              || !TEST_true(checkbuffers(clientssl, 1))))
                 goto end;
-            if (test >= 4 && !TEST_true(SSL_free_buffers(clientssl)))
+            if (test >= 4 && (!TEST_true(SSL_free_buffers(clientssl))
+                              || !TEST_true(checkbuffers(clientssl, 0))))
                 goto end;
 
             ret = SSL_write(clientssl, testdata + len,
@@ -112,14 +133,18 @@ static int test_func(int test)
         for (ret = -1, i = 0, len = 0; len != sizeof(testdata) &&
                  i < MAX_ATTEMPTS; i++)
         {
-            if (test >= 5 && !TEST_true(SSL_free_buffers(serverssl)))
+            if (test >= 5 && (!TEST_true(SSL_free_buffers(serverssl))
+                              || !TEST_true(checkbuffers(serverssl, 0))))
                 goto end;
             /* free a second time */
-            if (test >= 6 && !TEST_true(SSL_free_buffers(serverssl)))
+            if (test >= 6 && (!TEST_true(SSL_free_buffers(serverssl))
+                              || !TEST_true(checkbuffers(serverssl, 0))))
                 goto end;
-            if (test >= 7 && !TEST_true(SSL_alloc_buffers(serverssl)))
+            if (test >= 7 && (!TEST_true(SSL_alloc_buffers(serverssl))
+                              || !TEST_true(checkbuffers(serverssl, 1))))
                 goto end;
-            if (test >= 8 && !TEST_true(SSL_free_buffers(serverssl)))
+            if (test >= 8 && (!TEST_true(SSL_free_buffers(serverssl))
+                              || !TEST_true(checkbuffers(serverssl, 0))))
                 goto end;
 
             ret = SSL_read(serverssl, buf + len, sizeof(buf) - len);


### PR DESCRIPTION
The recent record layer refactor left SSL_alloc_buffers() and SSL_free_buffers() as no-ops. We make them work again.

While we are making changes to OSSL_RECORD_METHOD functions, we also remove a couple that were no-ops and never called.
