### PR TITLE
crypto: thread: remove ossl_crypto_thread_native_terminate

### DIFF
--- a/crypto/thread/arch.c
+++ b/crypto/thread/arch.c
@@ -54,15 +54,9 @@ int ossl_crypto_thread_native_join(CRYPTO_THREAD *thread, CRYPTO_THREAD_RETVAL *
         return 0;
 
     ossl_crypto_mutex_lock(thread->statelock);
-    req_state_mask = CRYPTO_THREAD_TERMINATED | CRYPTO_THREAD_FINISHED \
-                     | CRYPTO_THREAD_JOINED;
+    req_state_mask = CRYPTO_THREAD_FINISHED | CRYPTO_THREAD_JOINED;
     while (!CRYPTO_THREAD_GET_STATE(thread, req_state_mask))
         ossl_crypto_condvar_wait(thread->condvar, thread->statelock);
-
-    if (CRYPTO_THREAD_GET_STATE(thread, CRYPTO_THREAD_TERMINATED)) {
-        ossl_crypto_mutex_unlock(thread->statelock);
-        return 0;
-    }
 
     if (CRYPTO_THREAD_GET_STATE(thread, CRYPTO_THREAD_JOINED))
         goto pass;
@@ -121,7 +115,6 @@ int ossl_crypto_thread_native_clean(CRYPTO_THREAD *handle)
 
     req_state_mask = 0;
     req_state_mask |= CRYPTO_THREAD_FINISHED;
-    req_state_mask |= CRYPTO_THREAD_TERMINATED;
     req_state_mask |= CRYPTO_THREAD_JOINED;
 
     ossl_crypto_mutex_lock(handle->statelock);

--- a/crypto/thread/arch/thread_none.c
+++ b/crypto/thread/arch/thread_none.c
@@ -21,11 +21,6 @@ int ossl_crypto_thread_native_perform_join(CRYPTO_THREAD *thread, CRYPTO_THREAD_
     return 0;
 }
 
-int ossl_crypto_thread_native_terminate(CRYPTO_THREAD *thread)
-{
-    return 0;
-}
-
 int ossl_crypto_thread_native_exit(void)
 {
     return 0;

--- a/include/internal/thread_arch.h
+++ b/include/internal/thread_arch.h
@@ -55,7 +55,6 @@ typedef CRYPTO_THREAD_RETVAL (*CRYPTO_THREAD_ROUTINE_CB)(void *,
 # define CRYPTO_THREAD_FINISHED   (1UL << 0)
 # define CRYPTO_THREAD_JOIN_AWAIT (1UL << 1)
 # define CRYPTO_THREAD_JOINED     (1UL << 2)
-# define CRYPTO_THREAD_TERMINATED (1UL << 3)
 
 # define CRYPTO_THREAD_GET_STATE(THREAD, FLAG) ((THREAD)->state & (FLAG))
 # define CRYPTO_THREAD_GET_ERROR(THREAD, FLAG) (((THREAD)->state >> 16) & (FLAG))
@@ -112,7 +111,6 @@ int ossl_crypto_thread_native_join(CRYPTO_THREAD *thread,
                               CRYPTO_THREAD_RETVAL *retval);
 int ossl_crypto_thread_native_perform_join(CRYPTO_THREAD *thread,
                                            CRYPTO_THREAD_RETVAL *retval);
-int ossl_crypto_thread_native_terminate(CRYPTO_THREAD *thread);
 int ossl_crypto_thread_native_exit(void);
 int ossl_crypto_thread_native_is_self(CRYPTO_THREAD *thread);
 int ossl_crypto_thread_native_clean(CRYPTO_THREAD *thread);

--- a/test/threadstest.c
+++ b/test/threadstest.c
@@ -784,19 +784,6 @@ static uint32_t test_thread_native_fn(void *data)
     *ldata = *ldata + 1;
     return *ldata - 1;
 }
-
-static uint32_t test_thread_noreturn(void *data)
-{
-    while (1) {
-	OSSL_sleep(1000);
-    }
-
-    /* unreachable */
-    OPENSSL_die("test_thread_noreturn", __FILE__, __LINE__);
-
-    return 0;
-}
-
 /* Tests of native threads */
 
 static int test_thread_native(void)
@@ -805,7 +792,7 @@ static int test_thread_native(void)
     uint32_t local;
     CRYPTO_THREAD *t;
 
-    /* thread spawn, join and termination */
+    /* thread spawn, join */
 
     local = 1;
     t = ossl_crypto_thread_native_start(test_thread_native_fn, &local, 1);
@@ -826,29 +813,11 @@ static int test_thread_native(void)
     if (!TEST_int_eq(retval, 1) || !TEST_int_eq(local, 2))
         return 0;
 
-    if (!TEST_int_eq(ossl_crypto_thread_native_terminate(t), 1))
-        return 0;
-    if (!TEST_int_eq(ossl_crypto_thread_native_terminate(t), 1))
-        return 0;
-
-    if (!TEST_int_eq(ossl_crypto_thread_native_join(t, &retval), 0))
-        return 0;
-
     if (!TEST_int_eq(ossl_crypto_thread_native_clean(t), 1))
         return 0;
     t = NULL;
 
     if (!TEST_int_eq(ossl_crypto_thread_native_clean(t), 0))
-        return 0;
-
-    /* termination of a long running thread */
-
-    t = ossl_crypto_thread_native_start(test_thread_noreturn, NULL, 1);
-    if (!TEST_ptr(t))
-        return 0;
-    if (!TEST_int_eq(ossl_crypto_thread_native_terminate(t), 1))
-        return 0;
-    if (!TEST_int_eq(ossl_crypto_thread_native_clean(t), 1))
         return 0;
 
     return 1;


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated

Currently `ossl_crypto_thread_native_terminate` is not required (neither for Argon2), remove it.