### PR TITLE
Fix a compilation failure in bio_comp_test.c

### DIFF
--- a/test/bio_comp_test.c
+++ b/test/bio_comp_test.c
@@ -25,8 +25,8 @@
 static int sizes[NUM_SIZES] = { 64, 512, 2048, 16 * 1024 };
 
 /* using global buffers */
-unsigned char *original = NULL;
-unsigned char *result = NULL;
+static unsigned char *original = NULL;
+static unsigned char *result = NULL;
 
 /*
  * For compression:


### PR DESCRIPTION
Compiling with clang, --strict-warnings and enable-zlib-dynamic resulted in a compilation failure. This fixes it.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
