### PR TITLE
Fix a lock in provider_remove_store_methods()

### DIFF
--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -1208,7 +1208,7 @@ static int provider_remove_store_methods(OSSL_PROVIDER *prov)
     if (!freeing) {
         int acc;
 
-        if (!CRYPTO_THREAD_read_lock(prov->opbits_lock))
+        if (!CRYPTO_THREAD_write_lock(prov->opbits_lock))
             return 0;
         OPENSSL_free(prov->operation_bits);
         prov->operation_bits = NULL;


### PR DESCRIPTION
We were taking a read lock. It should have been a write lock.

Fixes #19474

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
