### PR TITLE
tests: clear error queue before executing a testcase

### DIFF
--- a/test/cmsapitest.c
+++ b/test/cmsapitest.c
@@ -327,8 +327,6 @@ static int test_d2i_CMS_decode(const int idx)
     long buf_len = 0;
     int ret = 0;
 
-    ERR_clear_error();
-
     if (!TEST_ptr(bio = BIO_new_file(derin, "r")))
       goto end;
 

--- a/test/recordlentest.c
+++ b/test/recordlentest.c
@@ -101,8 +101,6 @@ static int test_record_overflow(int idx)
         return 1;
 #endif
 
-    ERR_clear_error();
-
     if (!TEST_true(create_ssl_ctx_pair(NULL, TLS_server_method(),
                                        TLS_client_method(),
                                        TLS1_VERSION, 0,

--- a/test/sslcorrupttest.c
+++ b/test/sslcorrupttest.c
@@ -192,8 +192,6 @@ static int test_ssl_corrupt(int testidx)
 
     docorrupt = 0;
 
-    ERR_clear_error();
-
     TEST_info("Starting #%d, %s", testidx, cipher_list[testidx]);
 
     if (!TEST_true(create_ssl_ctx_pair(NULL, TLS_server_method(),

--- a/test/testutil/driver.c
+++ b/test/testutil/driver.c
@@ -331,6 +331,7 @@ int run_tests(const char *test_prog_name)
             test_flush_tapout();
         } else if (all_tests[i].num == -1) {
             set_test_title(all_tests[i].test_case_name);
+            ERR_clear_error();
             verdict = all_tests[i].test_fn();
             finalize(verdict != 0);
             test_verdict(verdict, "%d - %s", test_case_count + 1, test_title);
@@ -367,6 +368,7 @@ int run_tests(const char *test_prog_name)
                 j = (j + jstep) % all_tests[i].num;
                 if (single_iter != -1 && ((jj + 1) != single_iter))
                     continue;
+                ERR_clear_error();
                 v = all_tests[i].param_test_fn(j);
 
                 if (v == 0) {


### PR DESCRIPTION
There can be errors in the queue from previous tests and we look at it to verify we do not add spurious errors in these testcases.

Fixes #19477

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
