### PR TITLE
Remove old RSA CRT names.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -31,6 +31,16 @@ OpenSSL 4.1
   * API calls `CRYPTO_atomic_load_ptr`, `CRYPTO_atomic_store_ptr`, and
     `CRYPTO_atomic_cmp_exch_ptr` have been added.
 
+ * Remove the constants OSSL_PKEY_PARAM_RSA_FACTOR, OSSL_PKEY_PARAM_RSA_EXPONENT,
+   and OSSL_PKEY_PARAM_RSA_COEFFICIENT. These values were not intended to be used
+   as OSSL_PARAM key names. Using these key names previously as params passed
+   into EVP_PKEY_fromdata() resulted in the values being ignored, which is not
+   the desired result if the user intended to use CRT values. Please use the
+   names such as OSSL_PKEY_PARAM_RSA_FACTOR1 instead.
+   See doc/man7/EVP_PKEY-RSA.pod for more information.
+
+   *Shane Lontis*
+
 OpenSSL 4.0
 -----------
 

--- a/util/perl/OpenSSL/paramnames.pm
+++ b/util/perl/OpenSSL/paramnames.pm
@@ -385,9 +385,9 @@ my %params = (
 # n, e, d are the usual public and private key components
 #
 # rsa-num is the number of factors, including p and q
-# rsa-factor is used for each factor: p, q, r_i (i = 3, ...)
-# rsa-exponent is used for each exponent: dP, dQ, d_i (i = 3, ...)
-# rsa-coefficient is used for each coefficient: qInv, t_i (i = 3, ...)
+# rsa-factorX is used for each factor: p, q, r_i (i = 3, ...)
+# rsa-exponentX is used for each exponent: dP, dQ, d_i (i = 3, ...)
+# rsa-coefficientX is used for each coefficient: qInv, t_i (i = 3, ...)
 #
 # The number of rsa-factor items must be equal to the number of rsa-exponent
 # items, and the number of rsa-coefficients must be one less.
@@ -397,9 +397,6 @@ my %params = (
     'OSSL_PKEY_PARAM_RSA_N' =>           "n",
     'OSSL_PKEY_PARAM_RSA_E' =>           "e",
     'OSSL_PKEY_PARAM_RSA_D' =>           "d",
-    'OSSL_PKEY_PARAM_RSA_FACTOR' =>      "rsa-factor",
-    'OSSL_PKEY_PARAM_RSA_EXPONENT' =>    "rsa-exponent",
-    'OSSL_PKEY_PARAM_RSA_COEFFICIENT' => "rsa-coefficient",
     'OSSL_PKEY_PARAM_RSA_FACTOR1' =>      "rsa-factor1",
     'OSSL_PKEY_PARAM_RSA_FACTOR2' =>      "rsa-factor2",
     'OSSL_PKEY_PARAM_RSA_FACTOR3' =>      "rsa-factor3",


### PR DESCRIPTION
Fixes #19488

The constants OSSL_PKEY_PARAM_RSA_FACTOR, OSSL_PKEY_PARAM_RSA_EXPONENT, and OSSL_PKEY_PARAM_RSA_COEFFICIENT are not valid OSSL_PARAMS keys. Using them results in the parameters being ignored if they are passed to fromdata. The result of this is that it would use just n, e and d when performing operations, instead of CRT related operations (such as rsa_mod_exp)

The correct values include an index such as OSSL_PKEY_PARAM_RSA_FACTOR1, OSSL_PKEY_PARAM_RSA_EXPONENT1 and OSSL_PKEY_PARAM_RSA_COEFFICIENT1.

The data driven self tests have been updated to use the correct values.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
