### PR TITLE
rand: remove the ossl_rand_pool_add_additional_data() function.

### DIFF
--- a/providers/implementations/include/prov/seeding.h
+++ b/providers/implementations/include/prov/seeding.h
@@ -15,17 +15,6 @@ size_t ossl_prov_acquire_entropy_from_tsc(RAND_POOL *pool);
 size_t ossl_prov_acquire_entropy_from_cpu(RAND_POOL *pool);
 
 /*
- * Add some platform specific additional data
- *
- * This function is platform specific and adds some random noise to the
- * additional data used for generating random bytes and for reseeding
- * the drbg.
- *
- * Returns 1 on success and 0 on failure.
- */
-int ossl_rand_pool_add_additional_data(RAND_POOL *pool);
-
-/*
  * External seeding functions from the core dispatch table.
  */
 int ossl_prov_seeding_from_dispatch(const OSSL_DISPATCH *fns);

--- a/providers/implementations/rands/seeding/rand_unix.c
+++ b/providers/implementations/rands/seeding/rand_unix.c
@@ -773,31 +773,6 @@ int ossl_pool_add_nonce_data(RAND_POOL *pool)
     return ossl_rand_pool_add(pool, (unsigned char *)&data, sizeof(data), 0);
 }
 
-int ossl_rand_pool_add_additional_data(RAND_POOL *pool)
-{
-    struct {
-        int fork_id;
-        CRYPTO_THREAD_ID tid;
-        uint64_t time;
-    } data;
-
-    /* Erase the entire structure including any padding */
-    memset(&data, 0, sizeof(data));
-
-    /*
-     * Add some noise from the thread id and a high resolution timer.
-     * The fork_id adds some extra fork-safety.
-     * The thread id adds a little randomness if the drbg is accessed
-     * concurrently (which is the case for the <master> drbg).
-     */
-    data.fork_id = openssl_get_fork_id();
-    data.tid = CRYPTO_THREAD_get_current_id();
-    data.time = get_timer_bits();
-
-    return ossl_rand_pool_add(pool, (unsigned char *)&data, sizeof(data), 0);
-}
-
-
 /*
  * Get the current time with the highest possible resolution
  *

--- a/providers/implementations/rands/seeding/rand_vms.c
+++ b/providers/implementations/rands/seeding/rand_vms.c
@@ -575,32 +575,6 @@ size_t ossl_pool_acquire_entropy(RAND_POOL *pool)
     return data_collect_method(pool);
 }
 
-
-int ossl_rand_pool_add_additional_data(RAND_POOL *pool)
-{
-    struct {
-        CRYPTO_THREAD_ID tid;
-        unsigned __int64 time;
-    } data;
-
-    /* Erase the entire structure including any padding */
-    memset(&data, 0, sizeof(data));
-
-    /*
-     * Add some noise from the thread id and a high resolution timer.
-     * The thread id adds a little randomness if the drbg is accessed
-     * concurrently (which is the case for the <master> drbg).
-     */
-    data.tid = CRYPTO_THREAD_get_current_id();
-#if __CRTL_VER >= 80400000
-    sys$gettim_prec(&data.time);
-#else
-    sys$gettim((void*)&data.time);
-#endif
-
-    return ossl_rand_pool_add(pool, (unsigned char *)&data, sizeof(data), 0);
-}
-
 int ossl_rand_pool_init(void)
 {
     return 1;

--- a/providers/implementations/rands/seeding/rand_vxworks.c
+++ b/providers/implementations/rands/seeding/rand_vxworks.c
@@ -76,26 +76,6 @@ void ossl_rand_pool_keep_random_devices_open(int keep)
 {
 }
 
-int ossl_rand_pool_add_additional_data(RAND_POOL *pool)
-{
-    struct {
-        CRYPTO_THREAD_ID tid;
-        uint64_t time;
-    } data;
-
-    memset(&data, 0, sizeof(data));
-
-    /*
-     * Add some noise from the thread id and a high resolution timer.
-     * The thread id adds a little randomness if the drbg is accessed
-     * concurrently (which is the case for the <master> drbg).
-     */
-    data.tid = CRYPTO_THREAD_get_current_id();
-    data.time = get_timer_bits();
-
-    return ossl_rand_pool_add(pool, (unsigned char *)&data, sizeof(data), 0);
-}
-
 int ossl_pool_add_nonce_data(RAND_POOL *pool)
 {
     struct {

--- a/providers/implementations/rands/seeding/rand_win.c
+++ b/providers/implementations/rands/seeding/rand_win.c
@@ -147,26 +147,6 @@ int ossl_pool_add_nonce_data(RAND_POOL *pool)
     return ossl_rand_pool_add(pool, (unsigned char *)&data, sizeof(data), 0);
 }
 
-int ossl_rand_pool_add_additional_data(RAND_POOL *pool)
-{
-    struct {
-        DWORD tid;
-        LARGE_INTEGER time;
-    } data;
-
-    /* Erase the entire structure including any padding */
-    memset(&data, 0, sizeof(data));
-
-    /*
-     * Add some noise from the thread id and a high resolution timer.
-     * The thread id adds a little randomness if the drbg is accessed
-     * concurrently (which is the case for the <master> drbg).
-     */
-    data.tid = GetCurrentThreadId();
-    QueryPerformanceCounter(&data.time);
-    return ossl_rand_pool_add(pool, (unsigned char *)&data, sizeof(data), 0);
-}
-
 int ossl_rand_pool_init(void)
 {
     return 1;


### PR DESCRIPTION
This function isn't called from anywhere and cannot easily be used by the current RNG infrastructure.
