### PR TITLE
CI: backport improvements to openssl-3.0 branch

### DIFF
--- a/.github/workflows/compiler-zoo.yml
+++ b/.github/workflows/compiler-zoo.yml
@@ -63,6 +63,10 @@ jobs:
           }, {
             cc: clang-14,
             distro: ubuntu-22.04
+          }, {
+            cc: clang-15,
+            distro: ubuntu-22.04,
+            llvm-ppa-name: jammy
           }
         ]
     # We set per-compiler now to allow testing with both older and newer sets
@@ -72,8 +76,29 @@ jobs:
     steps:
     - name: install packages
       run: |
+        llvm_ppa_name="${{ matrix.zoo.llvm-ppa-name }}"
+
+        # In the Matrix above, we set llvm-ppa-name if an LLVM version isn't
+        # part of the Ubuntu version we're using. See https://apt.llvm.org/.
+        if [[ -n ${llvm_ppa_name} ]] ; then
+            wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key |\
+                gpg --dearmor |\
+                sudo tee /usr/share/keyrings/llvm-snapshot.gpg.key > /dev/null
+
+            clang_version="${{ matrix.zoo.cc }}"
+            clang_version="${clang_version/clang-}"
+
+            echo "deb [signed-by=/usr/share/keyrings/llvm-snapshot.gpg.key] http://apt.llvm.org/${{ matrix.zoo.llvm-ppa-name }}/ llvm-toolchain-${{ matrix.zoo.llvm-ppa-name }}-${clang_version} main" \
+                | sudo tee /etc/apt/sources.list.d/llvm.list
+            echo "deb-src [signed-by=/usr/share/keyrings/llvm-snapshot.gpg.key] http://apt.llvm.org/${{ matrix.zoo.llvm-ppa-name }}/ llvm-toolchain-${{ matrix.zoo.llvm-ppa-name }}-${clang_version} main" \
+                | sudo tee -a /etc/apt/sources.list.d/llvm.list
+
+            cat /etc/apt/sources.list.d/llvm.list
+        fi
+
         sudo apt-get update
-        sudo apt-get -yq --force-yes install ${{ matrix.zoo.cc }}
+        sudo apt-get -y install ${{ matrix.zoo.cc }}
+
     - uses: actions/checkout@v2
 
     - name: config

--- a/.github/workflows/compiler-zoo.yml
+++ b/.github/workflows/compiler-zoo.yml
@@ -19,41 +19,59 @@ jobs:
       matrix:
         zoo: [
           {
-            cc: gcc-7
+            cc: gcc-7,
+            distro: ubuntu-20.04
           }, {
-            cc: gcc-8
+            cc: gcc-8,
+            distro: ubuntu-20.04
           }, {
-            cc: gcc-9
+            cc: gcc-9,
+            distro: ubuntu-20.04
           }, {
-            cc: gcc-10
+            cc: gcc-10,
+            distro: ubuntu-20.04
           }, {
-            cc: gcc-11
+            cc: gcc-11,
+            distro: ubuntu-22.04
           }, {
-            cc: clang-6.0
+            cc: gcc-12,
+            distro: ubuntu-22.04
           }, {
-            cc: clang-7
+            cc: clang-6.0,
+            distro: ubuntu-20.04
           }, {
-            cc: clang-8
+            cc: clang-7,
+            distro: ubuntu-20.04
           }, {
-            cc: clang-9
+            cc: clang-8,
+            distro: ubuntu-20.04
           }, {
-            cc: clang-10
+            cc: clang-9,
+            distro: ubuntu-20.04
           }, {
-            cc: clang-11
+            cc: clang-10,
+            distro: ubuntu-20.04
           }, {
-            cc: clang-12
+            cc: clang-11,
+            distro: ubuntu-20.04
+          }, {
+            cc: clang-12,
+            distro: ubuntu-20.04
+          }, {
+            cc: clang-13,
+            distro: ubuntu-22.04
+          }, {
+            cc: clang-14,
+            distro: ubuntu-22.04
           }
         ]
-    runs-on: ubuntu-latest
+    # We set per-compiler now to allow testing with both older and newer sets
+    # Often, the full range of oldest->newest compilers we want aren't available
+    # in a single version of Ubuntu.
+    runs-on: ${{ matrix.zoo.distro }}
     steps:
     - name: install packages
       run: |
-        echo "deb https://ppa.launchpadcontent.net/ubuntu-toolchain-r/ppa/ubuntu focal main" | sudo tee /etc/apt/sources.list.d/gcc.list
-        echo "deb-src https://ppa.launchpadcontent.net/ubuntu-toolchain-r/ppa/ubuntu focal main" | sudo tee /etc/apt/sources.list.d/gcc.list
-
-        # From https://launchpad.net/~ubuntu-toolchain-r/+archive/ubuntu/ppa
-        sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 60C317803A41BA51845E371A1E9377A2BA9EF27F
-
         sudo apt-get update
         sudo apt-get -yq --force-yes install ${{ matrix.zoo.cc }}
     - uses: actions/checkout@v2

--- a/.github/workflows/compiler-zoo.yml
+++ b/.github/workflows/compiler-zoo.yml
@@ -27,6 +27,8 @@ jobs:
           }, {
             cc: gcc-10
           }, {
+            cc: gcc-11
+          }, {
             cc: clang-6.0
           }, {
             cc: clang-7
@@ -46,6 +48,12 @@ jobs:
     steps:
     - name: install packages
       run: |
+        echo "deb https://ppa.launchpadcontent.net/ubuntu-toolchain-r/ppa/ubuntu focal main" | sudo tee /etc/apt/sources.list.d/gcc.list
+        echo "deb-src https://ppa.launchpadcontent.net/ubuntu-toolchain-r/ppa/ubuntu focal main" | sudo tee /etc/apt/sources.list.d/gcc.list
+
+        # From https://launchpad.net/~ubuntu-toolchain-r/+archive/ubuntu/ppa
+        sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 60C317803A41BA51845E371A1E9377A2BA9EF27F
+
         sudo apt-get update
         sudo apt-get -yq --force-yes install ${{ matrix.zoo.cc }}
     - uses: actions/checkout@v2

--- a/crypto/pem/pem_lib.c
+++ b/crypto/pem/pem_lib.c
@@ -810,7 +810,7 @@ static int get_header_and_data(BIO *bp, BIO **header, BIO **data, char *name,
 {
     BIO *tmp = *header;
     char *linebuf, *p;
-    int len, line, ret = 0, end = 0, prev_partial_line_read = 0, partial_line_read = 0;
+    int len, ret = 0, end = 0, prev_partial_line_read = 0, partial_line_read = 0;
     /* 0 if not seen (yet), 1 if reading header, 2 if finished header */
     enum header_status got_header = MAYBE_HEADER;
     unsigned int flags_mask;
@@ -824,7 +824,7 @@ static int get_header_and_data(BIO *bp, BIO **header, BIO **data, char *name,
         return 0;
     }
 
-    for (line = 0; ; line++) {
+    while(1) {
         flags_mask = ~0u;
         len = BIO_gets(bp, linebuf, LINESIZE);
         if (len <= 0) {

--- a/crypto/txt_db/txt_db.c
+++ b/crypto/txt_db/txt_db.c
@@ -21,7 +21,6 @@ TXT_DB *TXT_DB_read(BIO *in, int num)
 {
     TXT_DB *ret = NULL;
     int esc = 0;
-    long ln = 0;
     int i, add, n;
     int size = BUFSIZE;
     int offset = 0;
@@ -61,7 +60,6 @@ TXT_DB *TXT_DB_read(BIO *in, int num)
         }
         buf->data[offset] = '\0';
         BIO_gets(in, &(buf->data[offset]), size - offset);
-        ln++;
         if (buf->data[offset] == '\0')
             break;
         if ((offset == 0) && (buf->data[0] == '#'))

--- a/crypto/x509/x_name.c
+++ b/crypto/x509/x_name.c
@@ -499,9 +499,7 @@ int X509_NAME_set(X509_NAME **xn, const X509_NAME *name)
 int X509_NAME_print(BIO *bp, const X509_NAME *name, int obase)
 {
     char *s, *c, *b;
-    int l, i;
-
-    l = 80 - 2 - obase;
+    int i;
 
     b = X509_NAME_oneline(name, NULL, 0);
     if (b == NULL)
@@ -527,12 +525,10 @@ int X509_NAME_print(BIO *bp, const X509_NAME *name, int obase)
                 if (BIO_write(bp, ", ", 2) != 2)
                     goto err;
             }
-            l--;
         }
         if (*s == '\0')
             break;
         s++;
-        l--;
     }
 
     OPENSSL_free(b);

--- a/test/testutil/driver.c
+++ b/test/testutil/driver.c
@@ -338,8 +338,6 @@ int run_tests(const char *test_prog_name)
                 num_failed++;
             test_case_count++;
         } else {
-            int num_failed_inner = 0;
-
             verdict = TEST_SKIP_CODE;
             set_test_title(all_tests[i].test_case_name);
             if (all_tests[i].subtest) {
@@ -370,7 +368,6 @@ int run_tests(const char *test_prog_name)
                 v = all_tests[i].param_test_fn(j);
 
                 if (v == 0) {
-                    ++num_failed_inner;
                     verdict = 0;
                 } else if (v != TEST_SKIP_CODE && verdict != 0) {
                     verdict = 1;


### PR DESCRIPTION
This backports #18639 and #19450 to the openssl-3.0 branch.

If it's fine with you folks, I'd like to do the same to 1.1.1 too, as ultimately these compilers are being used by distros, so we want to know if something breaks.