### PR TITLE
When using PEM_read_bio_PrivateKey_ex() the public key is optional

### DIFF
--- a/crypto/pem/pem_pkey.c
+++ b/crypto/pem/pem_pkey.c
@@ -76,7 +76,7 @@ static EVP_PKEY *pem_read_bio_key_decoder(BIO *bp, EVP_PKEY **x,
     ERR_pop_to_mark();
 
     /* if we were asked for private key, the public key is optional */
-    if (selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY)
+    if ((selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) != 0)
         selection = selection & ~OSSL_KEYMGMT_SELECT_PUBLIC_KEY;
 
     if (!evp_keymgmt_util_has(pkey, selection)) {
@@ -110,7 +110,7 @@ static EVP_PKEY *pem_read_bio_key_legacy(BIO *bp, EVP_PKEY **x,
     EVP_PKEY *ret = NULL;
 
     ERR_set_mark();  /* not interested in PEM read errors */
-    if (selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) {
+    if ((selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) != 0) {
         if (!PEM_bytes_read_bio_secmem(&data, &len, &nm,
                                        PEM_STRING_EVP_PKEY,
                                        bp, cb, u)) {
@@ -120,7 +120,7 @@ static EVP_PKEY *pem_read_bio_key_legacy(BIO *bp, EVP_PKEY **x,
     } else {
         const char *pem_string = PEM_STRING_PARAMETERS;
 
-        if (selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY)
+        if ((selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY) != 0)
             pem_string = PEM_STRING_PUBLIC;
         if (!PEM_bytes_read_bio(&data, &len, &nm,
                                 pem_string,
@@ -178,11 +178,11 @@ static EVP_PKEY *pem_read_bio_key_legacy(BIO *bp, EVP_PKEY **x,
             goto p8err;
         ret = ossl_d2i_PrivateKey_legacy(ameth->pkey_id, x, &p, len, libctx,
                                          propq);
-    } else if (!(selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY)
-               && (selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY)) {
+    } else if ((selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY) == 0
+               && (selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY) != 0) {
         /* Trying legacy PUBKEY decoding only if we do not want private key. */
         ret = ossl_d2i_PUBKEY_legacy(x, &p, len);
-    } else if (!(selection & EVP_PKEY_KEYPAIR)
+    } else if ((selection & EVP_PKEY_KEYPAIR) == 0
                && (slen = ossl_pem_check_suffix(nm, "PARAMETERS")) > 0) {
         /* Trying legacy params decoding only if we do not want a key. */
         ret = EVP_PKEY_new();

--- a/crypto/pem/pem_pkey.c
+++ b/crypto/pem/pem_pkey.c
@@ -180,9 +180,11 @@ static EVP_PKEY *pem_read_bio_key_legacy(BIO *bp, EVP_PKEY **x,
                                          propq);
     } else if (!(selection & OSSL_KEYMGMT_SELECT_PRIVATE_KEY)
                && (selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY)) {
+        /* Trying legacy PUBKEY decoding only if we do not want private key. */
         ret = ossl_d2i_PUBKEY_legacy(x, &p, len);
-    } else if (!(selection & OSSL_KEYMGMT_SELECT_PUBLIC_KEY)
+    } else if (!(selection & EVP_PKEY_KEYPAIR)
                && (slen = ossl_pem_check_suffix(nm, "PARAMETERS")) > 0) {
+        /* Trying legacy params decoding only if we do not want a key. */
         ret = EVP_PKEY_new();
         if (ret == NULL)
             goto err;

--- a/crypto/pem/pem_pkey.c
+++ b/crypto/pem/pem_pkey.c
@@ -300,7 +300,7 @@ EVP_PKEY *PEM_read_bio_PrivateKey_ex(BIO *bp, EVP_PKEY **x,
                                      OSSL_LIB_CTX *libctx, const char *propq)
 {
     return pem_read_bio_key(bp, x, cb, u, libctx, propq,
-                            /* we want the public key, if available */
+                            /* we want also the public key, if available */
                             EVP_PKEY_KEYPAIR);
 }
 

--- a/crypto/pem/pem_pkey.c
+++ b/crypto/pem/pem_pkey.c
@@ -300,7 +300,7 @@ EVP_PKEY *PEM_read_bio_PrivateKey_ex(BIO *bp, EVP_PKEY **x,
                                      OSSL_LIB_CTX *libctx, const char *propq)
 {
     return pem_read_bio_key(bp, x, cb, u, libctx, propq,
-                            /* we want also the public key, if available */
+                            /* we also want the public key, if available */
                             EVP_PKEY_KEYPAIR);
 }
 


### PR DESCRIPTION
Fixes #19498

However the private key part is not optional which was mishandled by the legacy routine.

It would be nice to have a test for this however this needs an algorithm where the public key part is not there in the PKCS#8 file and is not autocomputed on import as done for EC keys.

oqsprovider tests will test it in future.
