### PR TITLE
Fix dlts_get_max_record_overhead()

### DIFF
--- a/ssl/record/methods/recmethod_local.h
+++ b/ssl/record/methods/recmethod_local.h
@@ -148,6 +148,7 @@ struct ossl_record_layer_st
     int role;
     int direction;
     int level;
+    const EVP_MD *md;
     /* DTLS only */
     uint16_t epoch;
 

--- a/ssl/record/methods/tls13_meth.c
+++ b/ssl/record/methods/tls13_meth.c
@@ -39,8 +39,6 @@ static int tls13_set_crypto_state(OSSL_RECORD_LAYER *rl, int level,
         return OSSL_RECORD_RETURN_FATAL;
     }
 
-    rl->taglen = taglen;
-
     mode = EVP_CIPHER_get_mode(ciph);
 
     if (EVP_CipherInit_ex(ciph_ctx, ciph, NULL, NULL, NULL, enc) <= 0

--- a/ssl/record/methods/tls_common.c
+++ b/ssl/record/methods/tls_common.c
@@ -1249,6 +1249,8 @@ tls_int_new_record_layer(OSSL_LIB_CTX *libctx, const char *propq, int vers,
     rl->role = role;
     rl->direction = direction;
     rl->level = level;
+    rl->taglen = taglen;
+    rl->md = md;
 
     rl->alert = SSL_AD_NO_ALERT;
 


### PR DESCRIPTION
The calculation of the maximum DTLS record overhead was incorrect which means that we could exceed the MTU in some situations. We fix the calculation to take account of more sources of record overhead. We ignore potential overheads due to expansion after compression. At the time we make the calculation we don't know how long the record will be yet. However we can't accurately calculate the expansion without knowing that length. Just using a fallback expansion value for the worst case scenario doesn't help because that value is too high and is bigger than our fallback MTU size.

Testing this was tricky. The best solution I've come up with is to add an assert into statem_dtls.c to verify that we never exceed the MTU. Without the fix in dtls_get_max_record_overhead() this causes the existing test suite to fail. With the fix the test suite still passes.

While investigating this problem I spotted and fixed a different but related problem in tls_common.c. We calculates the maximum amount of growth we might expect to see during an encryption operation and reserve that many bytes in the WPACKET. Unfortunately the calculation was wrong which means that the encryption can overflow the amount of bytes reserved for it. In practice this isn't really an issue because the underlying buffer is still sufficiently large. 
