### PR TITLE
Fix the ceiling on how much encryption growth we can have

### DIFF
--- a/ssl/record/rec_layer_s3.c
+++ b/ssl/record/rec_layer_s3.c
@@ -16,6 +16,7 @@
 #include <openssl/rand.h>
 #include "record_local.h"
 #include "internal/packet.h"
+#include "internal/cryptlib.h"
 
 #if     defined(OPENSSL_SMALL_FOOTPRINT) || \
         !(      defined(AES_ASM) &&     ( \
@@ -676,6 +677,14 @@ int ssl3_write_bytes(SSL *s, int type, const void *buf_, size_t len,
     }
 }
 
+/*
+ * Encryption growth may result from padding in CBC ciphersuites (never more
+ * than SSL_RT_MAX_CIPHER_BLOCK_SIZE bytes), or from an AEAD tag (never more
+ * than EVP_MAX_MD_SIZE bytes). In the case of stitched ciphersuites growth can
+ * come from both of these.
+ */
+#define MAX_ENCRYPTION_GROWTH (EVP_MAX_MD_SIZE + SSL_RT_MAX_CIPHER_BLOCK_SIZE)
+
 int do_ssl3_write(SSL *s, int type, const unsigned char *buf,
                   size_t *pipelens, size_t numpipes,
                   int create_empty_fragment, size_t *written)
@@ -1014,15 +1023,9 @@ int do_ssl3_write(SSL *s, int type, const unsigned char *buf,
             }
         }
 
-        /*
-         * Reserve some bytes for any growth that may occur during encryption.
-         * This will be at most one cipher block or the tag length if using
-         * AEAD. SSL_RT_MAX_CIPHER_BLOCK_SIZE covers either case.
-         */
+        /* Reserve some bytes for any growth that may occur during encryption. */
         if (!BIO_get_ktls_send(s->wbio)) {
-            if (!WPACKET_reserve_bytes(thispkt,
-                                        SSL_RT_MAX_CIPHER_BLOCK_SIZE,
-                                        NULL)
+            if (!WPACKET_reserve_bytes(thispkt, MAX_ENCRYPTION_GROWTH, NULL)
                 /*
                  * We also need next the amount of bytes written to this
                  * sub-packet
@@ -1074,6 +1077,9 @@ int do_ssl3_write(SSL *s, int type, const unsigned char *buf,
 
         /* Allocate bytes for the encryption overhead */
         if (!WPACKET_get_length(thispkt, &origlen)
+                   /* Check we allowed enough room for the encryption growth */
+                || !ossl_assert(origlen + MAX_ENCRYPTION_GROWTH
+                                >= thiswr->length)
                    /* Encryption should never shrink the data! */
                 || origlen > thiswr->length
                 || (thiswr->length > origlen


### PR DESCRIPTION
Stitched ciphersuites can grow by more during encryption than the code allowed for. We fix the calculation and add an assert to check we go it right.

Note that this is not a security issue. Even though we can overflow the amount of bytes reserved in the WPACKET for the encryption, the underlying buffer is still big enough.

Testing this is difficult. I would argue that the addition of the ossl_assert is sufficient for this. Adding a similar assert to 3.1 HEAD, but without the fix is enough to make the existing test suite fail.

This is a backport to 3.1/3.0 of one of the commits from #19516
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
