### PR TITLE
Fix coverity 1516093 tainted scalar

### DIFF
--- a/ssl/t1_trce.c
+++ b/ssl/t1_trce.c
@@ -1345,7 +1345,8 @@ static int ssl_print_compressed_certificates(BIO *bio, const SSL_CONNECTION *sc,
     if (!ossl_comp_has_alg(alg))
         return 0;
 
-    if (uclen == 0 || (ucdata = OPENSSL_malloc(uclen)) == NULL)
+    /* Check against certificate maximum size (coverity) */
+    if (uclen == 0 || uclen > 0xFFFFFF || (ucdata = OPENSSL_malloc(uclen)) == NULL)
         return 0;
 
     switch (alg) {


### PR DESCRIPTION
|uclen| is created from three byte values, so this seems a bit redundant, but if it makes coverity happy

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
