### PR TITLE
Add two new build targets to enable the possibility of using clang-cl as an assembler for Windows on Arm

### DIFF
--- a/Configurations/50-win-clang-cl.conf
+++ b/Configurations/50-win-clang-cl.conf
@@ -1,0 +1,35 @@
+## -*- mode: perl; -*-
+# Windows on Arm clang-cl targets.
+#
+
+my %targets = (
+    "VC-WIN64-CLANGASM-ARM" => {
+        inherit_from    => [ "VC-noCE-common" ],
+        defines         => add("_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE",
+                               "OPENSSL_SYS_WIN_CORE"),
+        bn_ops          => "SIXTY_FOUR_BIT RC4_CHAR",
+        multilib        => "-arm64",
+        asm_arch        => "aarch64",
+        AS        => "clang-cl.exe",
+        ASFLAGS   => "/nologo /Zi",
+        asflags   => "/c",
+        asoutflag => "/Fo",
+        perlasm_scheme => "win64",
+        uplink_arch      => 'armv8',
+    },
+    "VC-CLANG-WIN64-CLANGASM-ARM" => {
+        CC => "clang-cl",
+        inherit_from    => [ "VC-noCE-common" ],
+        defines         => add("_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE",
+                               "OPENSSL_SYS_WIN_CORE"),
+        bn_ops          => "SIXTY_FOUR_BIT RC4_CHAR",
+        multilib        => "-arm64",
+        asm_arch        => "aarch64",
+        AS        => "clang-cl.exe",
+        ASFLAGS   => "/nologo /Zi",
+        asflags   => "/c",
+        asoutflag => "/Fo",
+        perlasm_scheme => "win64",
+        uplink_arch      => 'armv8',
+    },
+);

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -780,7 +780,7 @@ EOF
           }
           return <<"EOF";
 $target: "$gen0" $deps
-	\$(CPP) $incs $cppflags $defs "$gen0" > \$@.i
+	\$(CPP) /D__ASSEMBLER__ $incs $cppflags $defs "$gen0" > \$@.i
 	move /Y \$@.i \$@
 EOF
       } elsif ($gen0 =~ m|^.*\.in$|) {

--- a/crypto/armcap.c
+++ b/crypto/armcap.c
@@ -17,15 +17,36 @@
 #include <sys/sysctl.h>
 #endif
 #include "internal/cryptlib.h"
+#ifndef _WIN32
 #include <unistd.h>
-
+#else
+#include <windows.h>
+#endif
 #include "arm_arch.h"
 
 unsigned int OPENSSL_armcap_P = 0;
 unsigned int OPENSSL_arm_midr = 0;
 unsigned int OPENSSL_armv8_rsa_neonized = 0;
 
-#if __ARM_MAX_ARCH__<7
+#ifdef _WIN32
+void OPENSSL_cpuid_setup(void)
+{
+    OPENSSL_armcap_P |= ARMV7_NEON;
+    OPENSSL_armv8_rsa_neonized = 1;
+    if (IsProcessorFeaturePresent(PF_ARM_V8_CRYPTO_INSTRUCTIONS_AVAILABLE)) {
+        // These are all covered by one call in Windows
+        OPENSSL_armcap_P |= ARMV8_AES;
+        OPENSSL_armcap_P |= ARMV8_PMULL;
+        OPENSSL_armcap_P |= ARMV8_SHA1;
+        OPENSSL_armcap_P |= ARMV8_SHA256;
+    }
+}
+
+uint32_t OPENSSL_rdtsc(void)
+{
+    return 0;
+}
+#elif __ARM_MAX_ARCH__<7
 void OPENSSL_cpuid_setup(void)
 {
 }

--- a/crypto/perlasm/arm-xlate.pl
+++ b/crypto/perlasm/arm-xlate.pl
@@ -22,6 +22,7 @@ my $dotinlocallabels=($flavour=~/linux/)?1:0;
 ################################################################
 my $arch = sub {
     if ($flavour =~ /linux/)	{ ".arch\t".join(',',@_); }
+    elsif ($flavour =~ /win64/) { ".arch\t".join(',',@_); }
     else			{ ""; }
 };
 my $fpu = sub {
@@ -37,6 +38,7 @@ my $rodata = sub {
 };
 my $hidden = sub {
     if ($flavour =~ /ios/)	{ ".private_extern\t".join(',',@_); }
+    elsif ($flavour =~ /win64/) { ""; }
     else			{ ".hidden\t".join(',',@_); }
 };
 my $comm = sub {
@@ -85,6 +87,15 @@ my $type = sub {
 					"#endif";
 				  }
 			        }
+    elsif ($flavour =~ /win64/) { if (join(',',@_) =~ /(\w+),%function/) {
+                # See https://sourceware.org/binutils/docs/as/Pseudo-Ops.html
+                # Per https://docs.microsoft.com/en-us/windows/win32/debug/pe-format#coff-symbol-table,
+                # the type for functions is 0x20, or 32.
+                ".def $1\n".
+                "   .type 32\n".
+                ".endef";
+            }
+        }
     else			{ ""; }
 };
 my $size = sub {


### PR DESCRIPTION
Currently it is not possible to use the assembler files for Windows on Arm as there is no NASM for aarch64. This patch makes the appropriate changes to use `clang-cl` as an assembler along with the possibility of also using it as a compiler. Forcibly adding `__ASSEMBLER__` was required as cl does not add it by itself.