### PR TITLE
Fix check for private key existence before eddsa sign functions

### DIFF
--- a/providers/implementations/signature/eddsa_sig.c
+++ b/providers/implementations/signature/eddsa_sig.c
@@ -161,6 +161,10 @@ int ed25519_digest_sign(void *vpeddsactx, unsigned char *sigret,
         ERR_raise(ERR_LIB_PROV, PROV_R_OUTPUT_BUFFER_TOO_SMALL);
         return 0;
     }
+    if (edkey->privkey == NULL) {
+        ERR_raise(ERR_LIB_PROV, PROV_R_NOT_A_PRIVATE_KEY);
+        return 0;
+    }
 #ifdef S390X_EC_ASM
     if (S390X_CAN_SIGN(ED25519)) {
 	    if (s390x_ed25519_digestsign(edkey, sigret, tbs, tbslen) == 0) {
@@ -196,6 +200,10 @@ int ed448_digest_sign(void *vpeddsactx, unsigned char *sigret,
     }
     if (sigsize < ED448_SIGSIZE) {
         ERR_raise(ERR_LIB_PROV, PROV_R_OUTPUT_BUFFER_TOO_SMALL);
+        return 0;
+    }
+    if (edkey->privkey == NULL) {
+        ERR_raise(ERR_LIB_PROV, PROV_R_NOT_A_PRIVATE_KEY);
         return 0;
     }
 #ifdef S390X_EC_ASM

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -4650,6 +4650,7 @@ const OPTIONS *test_get_options(void)
     return options;
 }
 
+#ifndef OPENSSL_NO_EC
 /* Test that trying to sign with a public key errors out gracefully */
 static int test_ecx_not_private_key(int tst)
 {
@@ -4714,6 +4715,7 @@ static int test_ecx_not_private_key(int tst)
 
     return testresult;
 }
+#endif /* OPENSSL_NO_EC */
 
 int setup_tests(void)
 {

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -4620,14 +4620,24 @@ static int test_ecx_short_keys(int tst)
 {
     unsigned char ecxkeydata = 1;
     EVP_PKEY *pkey;
+    OSSL_PROVIDER* deflprov;
+    int testresult = 1;
 
+
+    deflprov = OSSL_PROVIDER_load(NULL, "default");
+
+    if (!TEST_ptr(deflprov))
+        return 0;
 
     pkey = EVP_PKEY_new_raw_private_key(ecxnids[tst], NULL, &ecxkeydata, 1);
     if (!TEST_ptr_null(pkey)) {
         EVP_PKEY_free(pkey);
-        return 0;
+        testresult = 0;
     }
-    return 1;
+
+    OSSL_PROVIDER_unload(deflprov);
+
+    return testresult;
 }
 
 typedef enum OPTION_choice {
@@ -4663,6 +4673,7 @@ static int test_ecx_not_private_key(int tst)
     int ret;
     unsigned char *pubkey;
     size_t pubkeylen;
+    OSSL_PROVIDER* deflprov;
 
 
     switch (keys[tst].type) {
@@ -4675,6 +4686,11 @@ static int test_ecx_not_private_key(int tst)
     /* Check if this algorithm supports public keys */
     if (keys[tst].pub == NULL)
         return 1;
+
+    deflprov = OSSL_PROVIDER_load(NULL, "default");
+
+    if (!TEST_ptr(deflprov))
+        return 0;
 
     pubkey = (unsigned char *)keys[tst].pub,
     pubkeylen = strlen(keys[tst].pub);
@@ -4709,6 +4725,7 @@ static int test_ecx_not_private_key(int tst)
     EVP_MD_CTX_free(ctx);
     OPENSSL_free(mac);
     EVP_PKEY_free(pkey);
+    OSSL_PROVIDER_unload(deflprov);
 
     return testresult;
 #endif

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -4665,9 +4665,9 @@ static int test_ecx_not_private_key(int tst)
     size_t pubkeylen;
 
     switch (keys[tst].type) {
-        case NID_X25519:
-        case NID_X448:
-            return TEST_skip("signing not supported for X25519/X448");
+    case NID_X25519:
+    case NID_X448:
+        return TEST_skip("signing not supported for X25519/X448");
     }
 
     /* Check if this algorithm supports public keys */

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -4620,13 +4620,13 @@ static int test_ecx_short_keys(int tst)
 {
     unsigned char ecxkeydata = 1;
     EVP_PKEY *pkey;
-    OSSL_PROVIDER* deflprov;
+    OSSL_PROVIDER* default_provider;
     int testresult = 1;
 
 
-    deflprov = OSSL_PROVIDER_load(NULL, "default");
+    default_provider = OSSL_PROVIDER_load(NULL, "default");
 
-    if (!TEST_ptr(deflprov))
+    if (!TEST_ptr(default_provider))
         return 0;
 
     pkey = EVP_PKEY_new_raw_private_key(ecxnids[tst], NULL, &ecxkeydata, 1);
@@ -4635,7 +4635,7 @@ static int test_ecx_short_keys(int tst)
         testresult = 0;
     }
 
-    OSSL_PROVIDER_unload(deflprov);
+    OSSL_PROVIDER_unload(default_provider);
 
     return testresult;
 }


### PR DESCRIPTION
Fix #19524.

Looks like there's no test for cases of RSA and EC, please advice if I need to add test for this patch. Thanks.

A similar fix is also needed for 1.1.1, please let me know if this one looks good so I can backport.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
