### PR TITLE
Fix PACKET_equal test with BUF_LEN+1 on -Wstringop-overread

### DIFF
--- a/test/packettest.c
+++ b/test/packettest.c
@@ -12,13 +12,13 @@
 
 #define BUF_LEN 255
 
-static unsigned char smbuf[BUF_LEN];
+static unsigned char smbuf[BUF_LEN + 1];
 
 static int test_PACKET_remaining(void)
 {
     PACKET pkt;
 
-    if (!TEST_true(PACKET_buf_init(&pkt, smbuf, sizeof(smbuf)))
+    if (!TEST_true(PACKET_buf_init(&pkt, smbuf, BUF_LEN))
             || !TEST_size_t_eq(PACKET_remaining(&pkt), BUF_LEN)
             || !TEST_true(PACKET_forward(&pkt, BUF_LEN - 1))
             || !TEST_size_t_eq(PACKET_remaining(&pkt), 1)
@@ -33,7 +33,7 @@ static int test_PACKET_end(void)
 {
     PACKET pkt;
 
-    if (!TEST_true(PACKET_buf_init(&pkt, smbuf, sizeof(smbuf)))
+    if (!TEST_true(PACKET_buf_init(&pkt, smbuf, BUF_LEN))
             || !TEST_size_t_eq(PACKET_remaining(&pkt), BUF_LEN)
             || !TEST_ptr_eq(PACKET_end(&pkt), smbuf + BUF_LEN)
             || !TEST_true(PACKET_forward(&pkt, BUF_LEN - 1))


### PR DESCRIPTION
Detected with -Werror.
Now the build and all tests pass through with asan, ubsan, -O2 and -Werror on gcc-11 and gcc-12.

Then we could add -Werror on all known compilers.

##### Checklist
- [x] tests are added or updated
