### PR TITLE
Fix PEM PKEY export leak on error path and avoid segfault if PKEY is NULL

### DIFF
--- a/crypto/pem/pem_pkey.c
+++ b/crypto/pem/pem_pkey.c
@@ -343,6 +343,7 @@ int PEM_write_bio_PrivateKey_traditional(BIO *bp, const EVP_PKEY *x,
 
     if (x->ameth == NULL || x->ameth->old_priv_encode == NULL) {
         ERR_raise(ERR_LIB_PEM, PEM_R_UNSUPPORTED_PUBLIC_KEY_TYPE);
+        EVP_PKEY_free(copy);
         return 0;
     }
     BIO_snprintf(pem_str, 80, "%s PRIVATE KEY", x->ameth->pem_str);

--- a/crypto/pem/pem_pkey.c
+++ b/crypto/pem/pem_pkey.c
@@ -311,7 +311,7 @@ PEM_write_cb_ex_fnsig(PrivateKey, EVP_PKEY, BIO, write_bio)
     IMPLEMENT_PEM_provided_write_body_main(pkey, bio);
 
  legacy:
-    if (x->ameth == NULL || x->ameth->priv_encode != NULL)
+    if (x != NULL && (x->ameth == NULL || x->ameth->priv_encode != NULL))
         return PEM_write_bio_PKCS8PrivateKey(out, x, enc,
                                              (const char *)kstr, klen, cb, u);
     return PEM_write_bio_PrivateKey_traditional(out, x, enc, kstr, klen, cb, u);
@@ -335,6 +335,9 @@ int PEM_write_bio_PrivateKey_traditional(BIO *bp, const EVP_PKEY *x,
     char pem_str[80];
     EVP_PKEY *copy = NULL;
     int ret;
+
+    if (x == NULL)
+        return 0;
 
     if (evp_pkey_is_assigned(x)
         && evp_pkey_is_provided(x)

--- a/test/evp_pkey_provided_test.c
+++ b/test/evp_pkey_provided_test.c
@@ -188,7 +188,12 @@ static int test_print_key_using_pem(const char *alg, const EVP_PKEY *pk)
         /* Unencrypted private key in PEM form */
         || !TEST_true(PEM_write_bio_PrivateKey(membio, pk,
                                                NULL, NULL, 0, NULL, NULL))
-        || !TEST_true(compare_with_file(alg, PRIV_PEM, membio)))
+        || !TEST_true(compare_with_file(alg, PRIV_PEM, membio))
+        /* NULL key */
+        || !TEST_false(PEM_write_bio_PrivateKey(membio, NULL,
+                                               NULL, NULL, 0, NULL, NULL))
+        || !TEST_false(PEM_write_bio_PrivateKey_traditional(membio, NULL,
+                                               NULL, NULL, 0, NULL, NULL)))
         goto err;
 
     ret = 1;


### PR DESCRIPTION
These two patches fix
 - a leak on PEM_write_bio_PrivateKey_traditional error patch (easily detectable with valgrind or address sanitizer).
 - check if EVP_PKEY is NULL and avoids segfault

Found by this (simplified) testcase:
```
#include <openssl/bio.h>
#include <openssl/pem.h>
#include <openssl/evp.h>

int main(int arc, char **argv)
{
	EVP_PKEY *pkey = NULL;
	EVP_PKEY_CTX *genctx = NULL;
	BIO *bio = NULL;

	bio = BIO_new_fp(stdout, BIO_NOCLOSE);
	if (!bio) {
		printf("BIO_new_fp failed\n");
		goto out;
	}

	genctx = EVP_PKEY_CTX_new_from_name(NULL, "ED448", NULL);
	if (!genctx) {
		printf("EVP_PKEY_CTX_new_from_name failed\n");
		goto out;
	}

	if (EVP_PKEY_keygen_init(genctx) != 1) {
		printf("EVP_PKEY_keygen_init failed\n");
		goto out;
	}

	if (EVP_PKEY_generate(genctx, &pkey) != 1) {
		printf("EVP_PKEY_generate failed\n");
		goto out;
	}

	/* Check leak in traditional output */
	PEM_write_bio_PrivateKey(bio, pkey, NULL, NULL, 0, 0, NULL);
	PEM_write_bio_PrivateKey_traditional(bio, pkey, NULL, NULL, 0, 0, NULL);

	/* Try pkey = NULL */
	PEM_write_bio_PrivateKey(bio, NULL, NULL, NULL, 0, 0, NULL);
	PEM_write_bio_PrivateKey_traditional(bio, NULL, NULL, NULL, 0, 0, NULL);

out:
	EVP_PKEY_CTX_free(genctx);
	EVP_PKEY_free(pkey);
	BIO_free_all(bio);

	return 0;
}
```

- [x] tests are added or updated
