### PR TITLE
providers/common/der/oids_to_c.pm: Remove use of Data::Dumper

### DIFF
--- a/providers/common/der/oids_to_c.pm
+++ b/providers/common/der/oids_to_c.pm
@@ -23,8 +23,6 @@ my $OID_def_re = qr/
                        \s* ${OID_value_re}
                    /x;
 
-use Data::Dumper;
-
 sub filter_to_H {
     my ($name, $comment) = @{ shift() };
     my @oid_nums = @_;


### PR DESCRIPTION
This is a development remnant, which should have been remove when finalized.

Fixes #19546
