### PR TITLE
explain zlib-dynamic usage for RPM based distributions

### DIFF
--- a/Configure
+++ b/Configure
@@ -93,6 +93,7 @@ EOF
 # [no-]zlib     [don't] compile support for zlib compression.
 # zlib-dynamic  Like "zlib", but the zlib library is expected to be a shared
 #               library and will be loaded at run-time by the OpenSSL library.
+#               This option is not suggested for RPM based distributions.
 # sctp          include SCTP support
 # enable-quic   include QUIC support (currently just for developers as the
 #               implementation is by no means complete and usable)

--- a/Configure
+++ b/Configure
@@ -91,9 +91,10 @@ EOF
 # no-asm        do not use assembler
 # no-egd        do not compile support for the entropy-gathering daemon APIs
 # [no-]zlib     [don't] compile support for zlib compression.
-# zlib-dynamic  Like "zlib", but the zlib library is expected to be a shared
-#               library and will be loaded at run-time by the OpenSSL library.
-#               This option is not suggested for RPM based distributions.
+# zlib-dynamic  Instead of linking the libcrypto to zlib library libcrypto
+#               will dynamically load the shared zlib library at run-time.
+#               This option requires the unversioned zlib shared library file
+#               to be present on the system.
 # sctp          include SCTP support
 # enable-quic   include QUIC support (currently just for developers as the
 #               implementation is by no means complete and usable)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -440,6 +440,13 @@ then this flag is optional and defaults to `ZLIB1` if not provided.
 This flag is optional and if not provided then `GNV$LIBZSHR`, `GNV$LIBZSHR32`
 or `GNV$LIBZSHR64` is used by default depending on the pointer size chosen.
 
+**RPM based distributions:** this option is not suggested to use, as internal
+DSO will try to load `libz.so`, which in most cases is a symlink to real
+shared object library with soname, and is distributed separately as a
+development RPM package.
+
+Please use `zlib` instead.
+
 ### with-zstd-include
 
     --with-zstd-include=DIR
@@ -1039,6 +1046,13 @@ Like the zlib option, but has OpenSSL load the zlib library dynamically
 when needed.
 
 This is only supported on systems where loading of shared libraries is supported.
+
+**RPM based distributions:** this option is not suggested to use, as internal
+DSO will try to load `libz.so`, which in most cases is a symlink to real
+shared object library with soname, and is distributed separately as a
+development RPM package.
+
+Please use `zlib` instead.
 
 ### enable-zstd
 


### PR DESCRIPTION
Hi,

this is documentation update for RPM based distributions about usage of `zlib-dynamic `and that it may cause issues like https://github.com/openssl/openssl/issues/19539

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [] tests are added or updated
