### PR TITLE
rsaz_exp_x2.c: Avoid potential undefined behavior with strict aliasing

### DIFF
--- a/crypto/bn/rsaz_exp_x2.c
+++ b/crypto/bn/rsaz_exp_x2.c
@@ -557,9 +557,13 @@ static void to_words52(BN_ULONG *out, int out_len,
     in_str = (uint8_t *)in;
 
     for (; in_bitsize >= (2 * DIGIT_SIZE); in_bitsize -= (2 * DIGIT_SIZE), out += 2) {
-        out[0] = (*(uint64_t *)in_str) & DIGIT_MASK;
+        uint64_t digit;
+
+        memcpy(&digit, in_str, sizeof(digit));
+        out[0] = digit & DIGIT_MASK;
         in_str += 6;
-        out[1] = ((*(uint64_t *)in_str) >> 4) & DIGIT_MASK;
+        memcpy(&digit, in_str, sizeof(digit));
+        out[1] = (digit >> 4) & DIGIT_MASK;
         in_str += 7;
         out_len -= 2;
     }
@@ -618,9 +622,13 @@ static void from_words52(BN_ULONG *out, int out_bitsize, const BN_ULONG *in)
 
         for (; out_bitsize >= (2 * DIGIT_SIZE);
                out_bitsize -= (2 * DIGIT_SIZE), in += 2) {
-            (*(uint64_t *)out_str) = in[0];
+            uint64_t digit;
+
+            digit = in[0];
+            memcpy(out_str, &digit, sizeof(digit));
             out_str += 6;
-            (*(uint64_t *)out_str) ^= in[1] << 4;
+            digit = digit >> 48 | in[1] << 4;
+            memcpy(out_str, &digit, sizeof(digit));
             out_str += 7;
         }
 

--- a/crypto/bn/rsaz_exp_x2.c
+++ b/crypto/bn/rsaz_exp_x2.c
@@ -24,14 +24,6 @@ NON_EMPTY_TRANSLATION_UNIT
 # include <assert.h>
 # include <string.h>
 
-# if defined(__GNUC__)
-#  define ALIGN64 __attribute__((aligned(64)))
-# elif defined(_MSC_VER)
-#  define ALIGN64 __declspec(align(64))
-# else
-#  define ALIGN64
-# endif
-
 # define ALIGN_OF(ptr, boundary) \
     ((unsigned char *)(ptr) + (boundary - (((size_t)(ptr)) & (boundary - 1))))
 

--- a/crypto/bn/rsaz_exp_x2.c
+++ b/crypto/bn/rsaz_exp_x2.c
@@ -25,11 +25,11 @@ NON_EMPTY_TRANSLATION_UNIT
 # include <string.h>
 
 # if defined(__GNUC__)
-#  define ALIGN1  __attribute__((aligned(1)))
+#  define ALIGN64 __attribute__((aligned(64)))
 # elif defined(_MSC_VER)
-#  define ALIGN1  __declspec(align(1))
+#  define ALIGN64 __declspec(align(64))
 # else
-#  define ALIGN1
+#  define ALIGN64
 # endif
 
 # define ALIGN_OF(ptr, boundary) \
@@ -46,8 +46,6 @@ NON_EMPTY_TRANSLATION_UNIT
 /* Number of registers required to hold |digits_num| amount of qword digits */
 # define NUMBER_OF_REGISTERS(digits_num, register_size)            \
     (((digits_num) * 64 + (register_size) - 1) / (register_size))
-
-typedef uint64_t ALIGN1 uint64_t_align1;
 
 static ossl_inline uint64_t get_digit(const uint8_t *in, int in_len);
 static ossl_inline void put_digit(uint8_t *out, int out_len, uint64_t digit);
@@ -559,9 +557,9 @@ static void to_words52(BN_ULONG *out, int out_len,
     in_str = (uint8_t *)in;
 
     for (; in_bitsize >= (2 * DIGIT_SIZE); in_bitsize -= (2 * DIGIT_SIZE), out += 2) {
-        out[0] = (*(uint64_t_align1 *)in_str) & DIGIT_MASK;
+        out[0] = (*(uint64_t *)in_str) & DIGIT_MASK;
         in_str += 6;
-        out[1] = ((*(uint64_t_align1 *)in_str) >> 4) & DIGIT_MASK;
+        out[1] = ((*(uint64_t *)in_str) >> 4) & DIGIT_MASK;
         in_str += 7;
         out_len -= 2;
     }
@@ -620,9 +618,9 @@ static void from_words52(BN_ULONG *out, int out_bitsize, const BN_ULONG *in)
 
         for (; out_bitsize >= (2 * DIGIT_SIZE);
                out_bitsize -= (2 * DIGIT_SIZE), in += 2) {
-            (*(uint64_t_align1 *)out_str) = in[0];
+            (*(uint64_t *)out_str) = in[0];
             out_str += 6;
-            (*(uint64_t_align1 *)out_str) ^= in[1] << 4;
+            (*(uint64_t *)out_str) ^= in[1] << 4;
             out_str += 7;
         }
 


### PR DESCRIPTION
Fixes #19584
