### PR TITLE
Configurations/*.tmpl: overhaul assembler make rules.

### DIFF
--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -1000,7 +1000,8 @@ EOF
 $target : $gen0 $deps $mkdef
 	\$(PERL) $mkdef$ord_ver --type $args{intent} --ordinals $gen0 --name $ord_name "--OS" "VMS"$case_insensitive > $target
 EOF
-      } elsif (platform->isasm($args{src})) {
+      } elsif (platform->isasm($args{src})
+               || platform->iscppasm($args{src})) {
           #
           # Assembler generator
           #
@@ -1010,7 +1011,9 @@ EOF
                 dso => "$dso_cflags $dso_cppflags",
                 bin => "$bin_cflags $bin_cppflags" } -> {$args{intent}};
           my $defs = join("", map { ",".$_ } @{$args{defs}});
-          my $target = platform->asm($args{src});
+          my $target = platform->isasm($args{src})
+                       ? platform->asm($args{src})
+                       : $args{src};
 
           my $generator;
           if ($gen0 =~ /\.pl$/) {
@@ -1023,21 +1026,6 @@ EOF
           }
 
           if (defined($generator)) {
-              # If the target is named foo.S in build.info, we want to
-              # end up generating foo.s in two steps.
-              if ($args{src} =~ /\.S$/) {
-                   return <<"EOF";
-$target : $gen0 $deps
-	$generator \$\@-S
-        \@ extradefines = "$defs"
-	PIPE \$(CPP) $cppflags \$\@-S | -
-             \$(PERL) -ne "/^#(\\s*line)?\\s*[0-9]+\\s+""/ or print" > \$\@-i
-        \@ DELETE/SYMBOL/LOCAL extradefines
-        RENAME \$\@-i \$\@
-        DELETE \$\@-S;
-EOF
-              }
-              # Otherwise....
               return <<"EOF";
 $target : $gen0 $deps
         \@ extradefines = "$defs"

--- a/Configurations/platform/BASE.pm
+++ b/Configurations/platform/BASE.pm
@@ -42,7 +42,7 @@ sub def         { return __base($_[1], '.ld') . $_[0]->defext() }
 sub obj         { return __base($_[1], '.o') . $_[0]->objext() }
 sub res         { return __base($_[1], '.res') . $_[0]->resext() }
 sub dep         { return __base($_[1], '.o') . $_[0]->depext() } # <- objname
-sub asm         { return __base($_[1], '.S', '.s') . $_[0]->asmext() }
+sub asm         { return __base($_[1], '.s') . $_[0]->asmext() }
 
 # Another set of convenience functions for standard checks of certain
 # internal extensions and conversion from internal to platform specific
@@ -51,7 +51,8 @@ sub asm         { return __base($_[1], '.S', '.s') . $_[0]->asmext() }
 sub isdef       { return $_[1] =~ m|\.ld$|;   }
 sub isobj       { return $_[1] =~ m|\.o$|;    }
 sub isres       { return $_[1] =~ m|\.res$|;  }
-sub isasm       { return $_[1] =~ m|\.[Ss]$|; }
+sub isasm       { return $_[1] =~ m|\.s$|;    }
+sub iscppasm    { return $_[1] =~ m|\.S$|;    }
 sub isstaticlib { return $_[1] =~ m|\.a$|;    }
 sub convertext {
     if ($_[0]->isdef($_[1]))        { return $_[0]->def($_[1]); }

--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -1576,7 +1576,8 @@ EOF
 $target: $gen0 $deps \$(SRCDIR)/util/mkdef.pl
 	\$(PERL) \$(SRCDIR)/util/mkdef.pl$ord_ver --type $args{intent} --ordinals $gen0  --name $ord_name --OS $mkdef_os > $target
 EOF
-      } elsif (platform->isasm($args{src})) {
+      } elsif (platform->isasm($args{src})
+               || platform->iscppasm($args{src})) {
           #
           # Assembler generator
           #

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -747,7 +747,8 @@ EOF
 $target: $gen0 $deps $mkdef
 	"\$(PERL)" "$mkdef"$ord_ver --type $args{intent} --ordinals $gen0 --name $ord_name --OS windows > $target
 EOF
-      } elsif (platform->isasm($args{src})) {
+      } elsif (platform->isasm($args{src})
+               || platform->iscppasm($args{src})) {
           #
           # Assembler generator
           #
@@ -757,7 +758,9 @@ EOF
               dso => '$(DSO_CFLAGS) $(DSO_CPPFLAGS)',
               bin => '$(BIN_CFLAGS) $(BIN_CPPFLAGS)'
           } -> {$args{intent}};
-          my $target = platform->asm($args{src});
+          my $target = platform->isasm($args{src})
+                       ? platform->asm($args{src})
+                       : $args{src};
 
           my $generator;
           if ($gen0 =~ /\.pl$/) {
@@ -770,18 +773,6 @@ EOF
           }
 
           if (defined($generator)) {
-              # If the target is named foo.S in build.info, we want to
-              # end up generating foo.s in two steps.
-              if ($args{src} =~ /\.S$/) {
-                   return <<"EOF";
-$target: "$gen0" $deps
-	cmd /C "set "ASM=\$(AS)" & $generator \$@.S"
-	\$(CPP) $incs $cppflags $defs \$@.S > \$@.i
-	move /Y \$@.i \$@
-        del /Q \$@.S
-EOF
-              }
-              # Otherwise....
               return <<"EOF";
 $target: "$gen0" $deps
 	cmd /C "set "ASM=\$(AS)" & $generator \$@"


### PR DESCRIPTION
NOTE: Not Configurations/unix-Makefile.tmpl, as that was done 4 years
ago, in commit a23f03166e0ec49ac09b3671e7ab4ba4fa57d42a.

So far assembly modules were intended to be built as .pl->.S->.{asmext}
followed by .{asmext}->.o.  This posed a problem in build_all_generated
rule if it was executed on another computer, and also turned out to be
buggy, as .S was also translated to .{asmext} on Windows and VMS.
Both issues are fixed by changing the rule sequence to .pl->.S and then
.S->.s->.o, with the added benefit that the Windows and VMS build file
templates are more in sync with unix-Makefile.tmpl and slightly simpler.

Fixes #19594
