### PR TITLE
Fix CertificateCompressionAlgorithm to be read as 2-octet-wide

### DIFF
--- a/ssl/statem/extensions.c
+++ b/ssl/statem/extensions.c
@@ -1860,7 +1860,7 @@ int tls_parse_compress_certificate(SSL_CONNECTION *sc, PACKET *pkt, unsigned int
      * The array is 0 (i.e. "none") terminated
      * The preference list only contains supported algorithms
      */
-    while (PACKET_get_1(&supported_comp_algs, &comp)) {
+    while (PACKET_get_net_2(&supported_comp_algs, &comp)) {
         if (tls_comp_in_pref(sc, comp) && !already_set[comp]) {
             sc->ext.compress_certificate_from_peer[j++] = comp;
             already_set[comp] = 1;


### PR DESCRIPTION
[RFC8879](https://datatracker.ietf.org/doc/html/rfc8879)
defines `CertificateCompressionAlgorithm` as a two-octet-wide enum:
```
       enum {
           zlib(1),
           brotli(2),
           zstd(3),
           (65535)
       } CertificateCompressionAlgorithm;
```

OpenSSL is reading them as one-octet-wide values though,
so that yet-unallocated values like 770 (0x302) or 16385 (0x4001)
are considered valid algorithms and result in compression negotiated and used.

@tmshort, please also double-check the width in other places,
I only gave it a cursory look.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
