### PR TITLE
ci: don't test the master FIPS provider against a 3.0 build

### DIFF
--- a/.github/workflows/fips-provider.yml
+++ b/.github/workflows/fips-provider.yml
@@ -54,44 +54,48 @@ jobs:
         run: make test HARNESS_JOBS=${HARNESS_JOBS:-4}
         working-directory: ./build
 
-  fips-provider-master:
-    runs-on: ubuntu-latest
-    steps:
-      - name: create build dirs
-        run: |
-          mkdir ./build
-          mkdir ./build-3.0
-          mkdir ./source
-          mkdir ./source-3.0
-      - uses: actions/checkout@v3
-        with:
-          repository: openssl/openssl
-          ref: openssl-3.0
-          path: source-3.0
-      - name: config 3.0
-        run: ../source-3.0/config enable-shared enable-fips
-        working-directory: ./build-3.0
-      - name: config 3.0 dump
-        run: ./configdata.pm --dump
-        working-directory: ./build-3.0
-      - name: make 3.0
-        run: make -s -j4
-        working-directory: ./build-3.0
-      - uses: actions/checkout@v3
-        with:
-          path: source
-      - name: config current
-        run: ../source/config enable-shared enable-fips
-        working-directory: ./build
-      - name: config dump
-        run: ./configdata.pm --dump
-        working-directory: ./build
-      - name: make fips provider
-        run: make -s -j4 build_modules
-        working-directory: ./build
-      - name: copy the provider
-        run: |
-          cp -a build/providers/fips.so build-3.0/providers/fips.so
-      - name: make test 3.0
-        run: make test HARNESS_JOBS=${HARNESS_JOBS:-4}
-        working-directory: ./build-3.0
+# With the removal of triple DES, this doesn't work anymore and modifying
+# 3.0 to make it work isn't a bug fix.  This problem will be amplified once
+# PKCS #1 v1.5 padding is no longer supported.
+# The interum fix is to not run this half of the test.
+#  fips-provider-master:
+#    runs-on: ubuntu-latest
+#    steps:
+#      - name: create build dirs
+#        run: |
+#          mkdir ./build
+#          mkdir ./build-3.0
+#          mkdir ./source
+#          mkdir ./source-3.0
+#      - uses: actions/checkout@v3
+#        with:
+#          repository: openssl/openssl
+#          ref: openssl-3.0
+#          path: source-3.0
+#      - name: config 3.0
+#        run: ../source-3.0/config enable-shared enable-fips
+#        working-directory: ./build-3.0
+#      - name: config 3.0 dump
+#        run: ./configdata.pm --dump
+#        working-directory: ./build-3.0
+#      - name: make 3.0
+#        run: make -s -j4
+#        working-directory: ./build-3.0
+#      - uses: actions/checkout@v3
+#        with:
+#          path: source
+#      - name: config current
+#        run: ../source/config enable-shared enable-fips
+#        working-directory: ./build
+#      - name: config dump
+#        run: ./configdata.pm --dump
+#        working-directory: ./build
+#      - name: make fips provider
+#        run: make -s -j4 build_modules
+#        working-directory: ./build
+#      - name: copy the provider
+#        run: |
+#          cp -a build/providers/fips.so build-3.0/providers/fips.so
+#      - name: make test 3.0
+#        run: make test HARNESS_JOBS=${HARNESS_JOBS:-4}
+#        working-directory: ./build-3.0


### PR DESCRIPTION
The FIPS provider in master & 3.1 cannot pass the tests present in a 3.0 build.

This is a result of the removal of triple DES from the provider. The future removal of PKCS #1 v1.5 padding will exacerbate the failures further.

Fixes #19601

- [ ] documentation is added or updated
- [x] tests are added or updated
