### PR TITLE
Add zlib oneshot compression

### DIFF
--- a/doc/man3/COMP_CTX_new.pod
+++ b/doc/man3/COMP_CTX_new.pod
@@ -11,6 +11,7 @@ COMP_CTX_free,
 COMP_compress_block,
 COMP_expand_block,
 COMP_zlib,
+COMP_zlib_oneshot,
 COMP_brotli,
 COMP_brotli_oneshot,
 COMP_zstd,
@@ -37,6 +38,7 @@ BIO_f_zstd
                        unsigned char *in, int ilen);
 
  COMP_METHOD *COMP_zlib(void);
+ COMP_METHOD *COMP_zlib_oneshot(void);
  COMP_METHOD *COMP_brotli(void);
  COMP_METHOD *COMP_brotli_oneshot(void);
  COMP_METHOD *COMP_zstd(void);
@@ -75,6 +77,10 @@ into the OpenSSL library. In such a case, NULL will be returned.
 =item *
 
 COMP_zlib() returns a B<COMP_METHOD> for stream-based ZLIB compression.
+
+=item *
+
+COMP_zlib_oneshot() returns a B<COMP_METHOD> for one-shot ZLIB compression.
 
 =item *
 
@@ -130,7 +136,7 @@ COMP_zlib(), COMP_brotli() and COMP_zstd() are stream-based compression methods.
 Internal state (including compression dictionary) is maintained between calls.
 If an error is returned, the stream is corrupted, and should be closed.
 
-COMP_brotli_oneshot() and COMP_zstd_oneshot() are not stream-based. These
+COMP_zlib_oneshot(), COMP_brotli_oneshot() and COMP_zstd_oneshot() are not stream-based. These
 methods do not maintain state between calls. An error in one call does not affect
 future calls.
 
@@ -138,7 +144,7 @@ future calls.
 
 COMP_CTX_new() returns a B<COMP_CTX> on success, or NULL on failure.
 
-COMP_CTX_get_method(), COMP_zlib(), COMP_brotli(), COMP_brotli_oneshot(),
+COMP_CTX_get_method(), COMP_zlib(), COMP_zlib_oneshot(), COMP_brotli(), COMP_brotli_oneshot(),
 COMP_zstd(), and COMP_zstd_oneshot() return a B<COMP_METHOD> on success,
 or NULL on failure.
 

--- a/include/openssl/comp.h
+++ b/include/openssl/comp.h
@@ -40,6 +40,7 @@ int COMP_expand_block(COMP_CTX *ctx, unsigned char *out, int olen,
                       unsigned char *in, int ilen);
 
 COMP_METHOD *COMP_zlib(void);
+COMP_METHOD *COMP_zlib_oneshot(void);
 COMP_METHOD *COMP_brotli(void);
 COMP_METHOD *COMP_brotli_oneshot(void);
 COMP_METHOD *COMP_zstd(void);

--- a/ssl/ssl_cert_comp.c
+++ b/ssl/ssl_cert_comp.c
@@ -101,7 +101,7 @@ __owur static OSSL_COMP_CERT *OSSL_COMP_CERT_from_uncompressed_data(unsigned cha
         method = COMP_brotli_oneshot();
         break;
     case TLSEXT_comp_cert_zlib:
-        method = COMP_zlib();
+        method = COMP_zlib_oneshot();
         break;
     case TLSEXT_comp_cert_zstd:
         method = COMP_zstd_oneshot();

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -3689,7 +3689,7 @@ CON_FUNC_RETURN tls_construct_client_compressed_certificate(SSL_CONNECTION *sc,
 
     switch (alg) {
     case TLSEXT_comp_cert_zlib:
-        method = COMP_zlib();
+        method = COMP_zlib_oneshot();
         break;
     case TLSEXT_comp_cert_brotli:
         method = COMP_brotli_oneshot();

--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -2520,7 +2520,7 @@ MSG_PROCESS_RETURN tls13_process_compressed_certificate(SSL_CONNECTION *sc,
     }
     switch (comp_alg) {
     case TLSEXT_comp_cert_zlib:
-        method = COMP_zlib();
+        method = COMP_zlib_oneshot();
         break;
     case TLSEXT_comp_cert_brotli:
         method = COMP_brotli_oneshot();

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5480,3 +5480,4 @@ COMP_zstd_oneshot                       ?	3_2_0	EXIST::FUNCTION:COMP
 BIO_f_zstd                              ?	3_2_0	EXIST::FUNCTION:COMP
 d2i_PUBKEY_ex_fp                        ?	3_2_0	EXIST::FUNCTION:STDIO
 d2i_PUBKEY_ex_bio                       ?	3_2_0	EXIST::FUNCTION:
+COMP_zlib_oneshot                       ?	3_2_0	EXIST::FUNCTION:COMP


### PR DESCRIPTION
Fixes #19520

The existing stream-based ZLIB compression does not close out the stream properly. This is incompatible with RFC1950.
Add a one-shot ZLIB compression method (as used with Brotli and Zstd) to do certificate compression.

This was found by tlsfuzzer.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
