### PR TITLE
crypto/sha/asm/sha512-ia64.pl: When checking assembler file names, ignore case

### DIFF
--- a/crypto/sha/asm/sha512-ia64.pl
+++ b/crypto/sha/asm/sha512-ia64.pl
@@ -78,7 +78,7 @@
 # $output is the last argument if it looks like a file (it has an extension)
 $output = $#ARGV >= 0 && $ARGV[$#ARGV] =~ m|\.\w+$| ? pop : undef;
 
-if ($output =~ /512.*\.[s|asm]/) {
+if ($output =~ /512.*\.[s|asm]/i) {
 	$SZ=8;
 	$BITS=8*$SZ;
 	$LDW="ld8";
@@ -92,7 +92,7 @@ if ($output =~ /512.*\.[s|asm]/) {
 	@sigma0=(1,  8, 7);
 	@sigma1=(19,61, 6);
 	$rounds=80;
-} elsif ($output =~ /256.*\.[s|asm]/) {
+} elsif ($output =~ /256.*\.[s|asm]/i) {
 	$SZ=4;
 	$BITS=8*$SZ;
 	$LDW="ld4";


### PR DESCRIPTION
The use case is that uppercase .ASM extension may be used on some platforms,
and we were only testing for the lowercase extension.
