### PR TITLE
Use libctx when generating DH parameters

### DIFF
--- a/crypto/dh/dh_gen.c
+++ b/crypto/dh/dh_gen.c
@@ -170,7 +170,7 @@ static int dh_builtin_genparams(DH *ret, int prime_len, int generator,
         return 0;
     }
 
-    ctx = BN_CTX_new();
+    ctx = BN_CTX_new_ex(ret->libctx);
     if (ctx == NULL)
         goto err;
     BN_CTX_start(ctx);
@@ -214,7 +214,7 @@ static int dh_builtin_genparams(DH *ret, int prime_len, int generator,
         g = generator;
     }
 
-    if (!BN_generate_prime_ex(ret->params.p, prime_len, 1, t1, t2, cb))
+    if (!BN_generate_prime_ex2(ret->params.p, prime_len, 1, t1, t2, cb, ctx))
         goto err;
     if (!BN_GENCB_call(cb, 3, 0))
         goto err;

--- a/test/evp_extra_test2.c
+++ b/test/evp_extra_test2.c
@@ -356,6 +356,30 @@ static int test_dh_tofrom_data_select(void)
     EVP_PKEY_CTX_free(gctx);
     return ret;
 }
+
+static int test_dh_paramgen(void)
+{
+    int ret;
+    OSSL_PARAM params[3];
+    EVP_PKEY *pkey = NULL;
+    EVP_PKEY_CTX *gctx = NULL;
+    unsigned int pbits = 512; /* minimum allowed for speed */
+
+    params[0] = OSSL_PARAM_construct_uint(OSSL_PKEY_PARAM_FFC_PBITS, &pbits);
+    params[1] = OSSL_PARAM_construct_utf8_string(OSSL_PKEY_PARAM_FFC_TYPE,
+                                                 "generator", 0);
+    params[2] = OSSL_PARAM_construct_end();
+
+    ret = TEST_ptr(gctx = EVP_PKEY_CTX_new_from_name(mainctx, "DH", NULL))
+          && TEST_int_gt(EVP_PKEY_paramgen_init(gctx), 0)
+          && TEST_true(EVP_PKEY_CTX_set_params(gctx, params))
+          && TEST_true(EVP_PKEY_paramgen(gctx, &pkey))
+          && TEST_ptr(pkey);
+
+    EVP_PKEY_CTX_free(gctx);
+    EVP_PKEY_free(pkey);
+    return ret;
+}
 #endif
 
 #ifndef OPENSSL_NO_EC
@@ -1156,6 +1180,7 @@ int setup_tests(void)
 #endif
 #ifndef OPENSSL_NO_DH
     ADD_TEST(test_dh_tofrom_data_select);
+    ADD_TEST(test_dh_paramgen);
 #endif
     ADD_TEST(test_rsa_tofrom_data_select);
 


### PR DESCRIPTION
We did not use libctx when generating the safe prime DH parameters.

It needs to be passed via BN_CTX.
