### PR TITLE
Add RFC8701 GREASE Support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -878,6 +878,13 @@ OpenSSL 3.2
 
    *Richard Levitte*
 
+ * Add support for RFC8701 GREASE. Extra values can be added to known
+   extensions and cipher lists in the ClientHello. Additional extensions can
+   also be added. This is intended for testing unknown values in extensions
+   and cipher lists, and not for implementing custom extensions or ciphers.
+
+   *Todd Short*
+
  * The BLAKE2b hash algorithm supports a configurable output length
    by setting the "size" parameter.
 

--- a/doc/build.info
+++ b/doc/build.info
@@ -2235,6 +2235,10 @@ DEPEND[html/man3/SSL_CTX_add_session.html]=man3/SSL_CTX_add_session.pod
 GENERATE[html/man3/SSL_CTX_add_session.html]=man3/SSL_CTX_add_session.pod
 DEPEND[man/man3/SSL_CTX_add_session.3]=man3/SSL_CTX_add_session.pod
 GENERATE[man/man3/SSL_CTX_add_session.3]=man3/SSL_CTX_add_session.pod
+DEPEND[html/man3/SSL_CTX_clean_grease.html]=man3/SSL_CTX_clean_grease.pod
+GENERATE[html/man3/SSL_CTX_clean_grease.html]=man3/SSL_CTX_clean_grease.pod
+DEPEND[man/man3/SSL_CTX_clean_grease.3]=man3/SSL_CTX_clean_grease.pod
+GENERATE[man/man3/SSL_CTX_clean_grease.3]=man3/SSL_CTX_clean_grease.pod
 DEPEND[html/man3/SSL_CTX_config.html]=man3/SSL_CTX_config.pod
 GENERATE[html/man3/SSL_CTX_config.html]=man3/SSL_CTX_config.pod
 DEPEND[man/man3/SSL_CTX_config.3]=man3/SSL_CTX_config.pod
@@ -3604,6 +3608,7 @@ html/man3/SSL_CONF_cmd_argv.html \
 html/man3/SSL_CTX_add1_chain_cert.html \
 html/man3/SSL_CTX_add_extra_chain_cert.html \
 html/man3/SSL_CTX_add_session.html \
+html/man3/SSL_CTX_clean_grease.html \
 html/man3/SSL_CTX_config.html \
 html/man3/SSL_CTX_ctrl.html \
 html/man3/SSL_CTX_dane_enable.html \
@@ -4276,6 +4281,7 @@ man/man3/SSL_CONF_cmd_argv.3 \
 man/man3/SSL_CTX_add1_chain_cert.3 \
 man/man3/SSL_CTX_add_extra_chain_cert.3 \
 man/man3/SSL_CTX_add_session.3 \
+man/man3/SSL_CTX_clean_grease.3 \
 man/man3/SSL_CTX_config.3 \
 man/man3/SSL_CTX_ctrl.3 \
 man/man3/SSL_CTX_dane_enable.3 \

--- a/doc/man3/SSL_CTX_clean_grease.pod
+++ b/doc/man3/SSL_CTX_clean_grease.pod
@@ -1,0 +1,129 @@
+=pod
+
+=head1 NAME
+
+SSL_CTX_add_grease_to_extension,
+SSL_CTX_add_grease_to_ciphers,
+SSL_CTX_add_grease_extension,
+SSL_CTX_clean_grease - Add GREASE (RFC8701) to the TLS handshake
+
+=head1 SYNOPSIS
+
+ #include <openssl/ssl.h>
+
+ int SSL_CTX_add_grease_to_extension(SSL_CTX *ctx, unsigned int extension,
+                                     unsigned int value);
+ int SSL_CTX_add_grease_to_ciphers(SSL_CTX *ctx, unsigned int value);
+ int SSL_CTX_add_grease_extension(SSL_CTX *ctx, unsigned int extension,
+                                  unsigned char* value, size_t length);
+ void SSL_CTX_clean_grease(SSL_CTX *ctx);
+
+=head1 DESCRIPTION
+
+SSL_CTX_add_grease_to_extension() adds a GREASE value to a known extension.
+If the extension cannot support GREASE values, an error is returned.
+These GREASE values only apply to the ClientHello.
+
+SSL_CTX_add_grease_to_ciphers() adds a 16-bit GREASE value to the list of ciphers.
+These GREASE values only apply to the ClientHello.
+
+SSL_CTX_add_grease_extension() adds a new GREASE extionsion with the given
+payload. If the extension is a known, supported extension, an error is returned.
+
+SSL_CTX_clean_grease() removes GREASE values from the b<ctx>.
+
+=head1 NOTES
+
+GREASE is defined in RFC8701 "Applying Generate Random Extensions And Sustain
+Extensibility" to TLS Extensibility. It is a method of adding unsupported
+values to extensions and other fields to ensure that breakage (in terms of
+protocol or program) does not occur.
+
+These functions store these GREASE values to an SSL_CTX object, which are then
+added to the handshake of any SSL object that refereces the SSL_CTX object.
+
+A set of GREASE values are defined as reserved: two-byte values where the lower
+nibble of each byte is 0xA. These values may not be used by other RFCs.
+This API does not require that only these values are used; any value may be used
+as a GREASE value, as long as it doesn't conflict with an existing extension
+number.
+
+GREASE values are prepended to the normal extension values.
+
+The SSL_CTX_add_grease_to_extension() function supports the following extensions:
+
+=over 4
+
+=item TLSEXT_TYPE_supported_versions
+
+=item TLSEXT_TYPE_signature_algorithms
+
+=item TLSEXT_TYPE_supported_groups
+
+=item TLSEXT_TYPE_compress_certificate
+
+The above extensions support 16-bit GREASE values.
+
+=item TLSEXT_TYPE_psk_kex_modes
+
+The above extension supports 8-bit GREASE values.
+
+=item TLSEXT_TYPE_key_share
+
+The above extension adds a 16-bit GREASE encoded-point type (lower 16-bits of
+b<value>) with the whole contents of b<value> (sizeof(unsigned int)) used as
+the encoded-point value.
+
+=back
+
+The SSL_CTX_add_grease_extension() function will add all configuted GREASE
+extentions to the following handshake messages:
+
+=over 4
+
+=item Client Hello
+
+This applies only to the client.
+
+=item Server Hello
+
+This applies only to the server.
+
+=item Certificate Request
+
+This applies only to the server when doing TLSv1.3.
+
+=back
+
+GREASE values are not (supposed to be) processed by servers and clients. They
+are present to ensure TLS extensibility.
+
+=head1 RETURN VALUES
+
+The SSL_CTX_add_grease_to_extension(), SSL_CTX_add_grease_to_ciphers(),
+and SSL_CTX_add_grease_extension() functions
+return 1 on success and 0 on failure.
+
+Success means that the GREASE value was stored.
+
+=head1 SEE ALSO
+
+L<SSL_CTX_new(3)>, L<SSL_new(3)>
+
+=head1 HISTORY
+
+The SSL_CTX_add_grease_to_extension(),
+SSL_CTX_add_grease_to_ciphers(),
+SSL_CTX_add_grease_extension(), and
+SSL_CTX_clean_grease() functions were added in Openssl 3.6.
+
+=head1 COPYRIGHT
+
+Copyright 2025 The OpenSSL Project Authors. All Rights Reserved.
+
+Licensed under the Apache License 2.0 (the "License").  You may not use
+this file except in compliance with the License.  You can obtain a copy
+in the file LICENSE in the source distribution or at
+L<https://www.openssl.org/source/license.html>.
+
+=cut

--- a/include/openssl/ssl.h.in
+++ b/include/openssl/ssl.h.in
@@ -2880,6 +2880,14 @@ int SSL_set_quic_tls_transport_params(SSL *s,
 
 int SSL_set_quic_tls_early_data_enabled(SSL *s, int enabled);
 
+/* RFC 8701 GREASE support */
+
+int SSL_CTX_add_grease_to_extension(SSL_CTX *ctx, unsigned int extension, unsigned int value);
+int SSL_CTX_add_grease_to_ciphers(SSL_CTX *ctx, unsigned int value);
+int SSL_CTX_add_grease_extension(SSL_CTX *ctx, unsigned int extension, unsigned char *value,
+                                 size_t length);
+void SSL_CTX_clean_grease(SSL_CTX *ctx);
+
 # ifdef  __cplusplus
 }
 # endif

--- a/ssl/ssl_local.h
+++ b/ssl/ssl_local.h
@@ -1216,6 +1216,8 @@ struct ssl_ctx_st {
 # ifndef OPENSSL_NO_QLOG
     char *qlog_title; /* Session title for qlog */
 # endif
+
+    struct ossl_grease_st *grease;
 };
 
 typedef struct ossl_quic_tls_callbacks_st {
@@ -3170,5 +3172,18 @@ long ossl_ctrl_internal(SSL *s, int cmd, long larg, void *parg, int no_quic);
      SSL_DOMAIN_FLAG_THREAD_ASSISTED |          \
      SSL_DOMAIN_FLAG_BLOCKING |                 \
      SSL_DOMAIN_FLAG_LEGACY_BLOCKING)
+
+/* EXTENSION < 0xFFFF is the actual extension value */
+# define OSSL_GREASE_CIPHER 0x10001
+
+struct ossl_grease_st {
+    struct ossl_grease_st *next;
+    unsigned int extension;
+    int new_extension;
+    unsigned int value;
+    unsigned char *data;
+    size_t length;
+};
+typedef struct ossl_grease_st OSSL_GREASE;
 
 #endif

--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -2914,3 +2914,31 @@ MSG_PROCESS_RETURN tls13_process_compressed_certificate(SSL_CONNECTION *sc,
     return ret;
 }
 #endif
+
+int tls_add_grease16_to_packet(SSL_CONNECTION *s, WPACKET *pkt, unsigned int extension)
+{
+    SSL_CTX *ctx = SSL_CONNECTION_GET_CTX(s);
+    OSSL_GREASE *g;
+
+    for (g = ctx->grease; g != NULL; g = g->next) {
+        if (g->extension == extension) {
+            if (!WPACKET_put_bytes_u16(pkt, g->value & 0xFFFF))
+                return 0;
+        }
+    }
+    return 1;
+}
+
+int tls_add_grease8_to_packet(SSL_CONNECTION *s, WPACKET *pkt, unsigned int extension)
+{
+    SSL_CTX *ctx = SSL_CONNECTION_GET_CTX(s);
+    OSSL_GREASE *g;
+
+    for (g = ctx->grease; g != NULL; g = g->next) {
+        if (g->extension == extension) {
+            if (!WPACKET_put_bytes_u8(pkt, g->value & 0xFF))
+                return 0;
+        }
+    }
+    return 1;
+}

--- a/ssl/statem/statem_local.h
+++ b/ssl/statem/statem_local.h
@@ -570,3 +570,5 @@ int tls_parse_ctos_server_cert_type(SSL_CONNECTION *sc, PACKET *pkt,
 int tls_parse_stoc_server_cert_type(SSL_CONNECTION *s, PACKET *pkt,
                                     unsigned int context,
                                     X509 *x, size_t chainidx);
+int tls_add_grease16_to_packet(SSL_CONNECTION *s, WPACKET *pkt, unsigned int extension);
+int tls_add_grease8_to_packet(SSL_CONNECTION *s, WPACKET *pkt, unsigned int extension);

--- a/test/build.info
+++ b/test/build.info
@@ -69,7 +69,8 @@ IF[{- !$disabled{tests} -}]
           ca_internals_test bio_tfo_test membio_test bio_dgram_test list_test \
           fips_version_test x509_test hpke_test pairwise_fail_test \
           nodefltctxtest evp_xof_test x509_load_cert_file_test bio_meth_test \
-          x509_acert_test x509_req_test strtoultest bio_pw_callback_test
+          x509_acert_test x509_req_test strtoultest bio_pw_callback_test \
+          grease_test
 
   IF[{- !$disabled{'rpk'} -}]
     PROGRAMS{noinst}=rpktest
@@ -582,6 +583,10 @@ IF[{- !$disabled{tests} -}]
   SOURCE[rpktest]=rpktest.c helpers/ssltestlib.c
   INCLUDE[rpktest]=../include ../apps/include ..
   DEPEND[rpktest]=../libcrypto ../libssl libtestutil.a
+
+  SOURCE[grease_test]=grease_test.c helpers/ssltestlib.c
+  INCLUDE[grease_test]=../include ../apps/include ..
+  DEPEND[grease_test]=../libcrypto ../libssl libtestutil.a
 
   SOURCE[defltfips_test]=defltfips_test.c
   INCLUDE[defltfips_test]=../include  ../apps/include

--- a/test/cert_comp_test.c
+++ b/test/cert_comp_test.c
@@ -120,6 +120,20 @@ static void cert_comp_info_cb(const SSL *s, int where, int ret)
     }
 }
 
+static int add_grease(SSL_CTX *ctx)
+{
+    uint16_t values[] = { 0x0101, 0x0202, 0x0303, 0x1A1A, 0x2A2A };
+    size_t i;
+
+    for (i = 0; i < OSSL_NELEM(values); i++) {
+        if (!TEST_true(SSL_CTX_add_grease_to_extension(ctx,
+                                                       TLSEXT_TYPE_compress_certificate,
+                                                       values[i])))
+            return 0;
+    }
+    return 1;
+}
+
 static int test_ssl_cert_comp(int test)
 {
     SSL_CTX *cctx = NULL, *sctx = NULL;
@@ -163,6 +177,9 @@ static int test_ssl_cert_comp(int test)
                                        TLS_client_method(),
                                        TLS1_3_VERSION, 0,
                                        &sctx, &cctx, cert, privkey)))
+        goto end;
+
+    if (!add_grease(sctx) || !add_grease(cctx))
         goto end;
     if (test == 3) {
         /* coverity[deadcode] */

--- a/test/grease_test.c
+++ b/test/grease_test.c
@@ -1,0 +1,345 @@
+/*
+ * Copyright 2023 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+#include <openssl/ssl.h>
+
+#include "helpers/ssltestlib.h"
+#include "testutil.h"
+
+#undef OSSL_NO_USABLE_TLS1_3
+#if defined(OPENSSL_NO_TLS1_3) \
+    || (defined(OPENSSL_NO_EC) && defined(OPENSSL_NO_DH))
+/*
+ * If we don't have ec or dh then there are no built-in groups that are usable
+ * with TLSv1.3
+ */
+# define OSSL_NO_USABLE_TLS1_3
+#endif
+
+#define GREASE_SETUP_ALL 0
+#define GREASE_SETUP_KS  1
+
+static char *certsdir = NULL;
+static char *cert = NULL;
+static char *privkey = NULL;
+
+static unsigned char SID_CTX[] = { 'g', 'r', 'e', 'a', 's', 'e'};
+
+static int my_verify_cb(int ok, X509_STORE_CTX *ctx)
+{
+    return 1;
+}
+
+static int setup_cert(SSL *ssl)
+{
+    if (!TEST_int_eq(SSL_use_PrivateKey_file(ssl, privkey, SSL_FILETYPE_PEM), 1)
+            || !TEST_int_eq(SSL_use_certificate_file(ssl, cert, SSL_FILETYPE_PEM), 1)
+            || !TEST_int_eq(SSL_check_private_key(ssl), 1))
+        return 0;
+    return 1;
+}
+
+static unsigned char extension_data[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 };
+static int setup_grease(SSL_CTX *ctx, int gr_set)
+{
+    if (gr_set == GREASE_SETUP_ALL) {
+        if (!TEST_true(SSL_CTX_add_grease_to_ciphers(ctx, 0x5A5A)))
+            return 0;
+        if (!TEST_true(SSL_CTX_add_grease_to_ciphers(ctx, 0x6A6A)))
+            return 0;
+        if (!TEST_true(SSL_CTX_add_grease_to_ciphers(ctx, 0x7A7A)))
+            return 0;
+
+        /* Duplicate */
+        if (!TEST_false(SSL_CTX_add_grease_to_ciphers(ctx, 0x5A5A)))
+            return 0;
+
+        if (!TEST_true(SSL_CTX_add_grease_to_extension(ctx, TLSEXT_TYPE_supported_versions,
+                                                       0x5A5A)))
+            return 0;
+        if (!TEST_true(SSL_CTX_add_grease_to_extension(ctx, TLSEXT_TYPE_signature_algorithms,
+                                                       0x6A6A)))
+            return 0;
+        if (!TEST_true(SSL_CTX_add_grease_to_extension(ctx, TLSEXT_TYPE_signature_algorithms,
+                                                       0x7A7A)))
+            return 0;
+        if (!TEST_true(SSL_CTX_add_grease_to_extension(ctx, TLSEXT_TYPE_supported_groups,
+                                                       0x11118A8A)))
+            return 0;
+        if (!TEST_true(SSL_CTX_add_grease_to_extension(ctx, TLSEXT_TYPE_compress_certificate,
+                                                       0x9A9A)))
+            return 0;
+        if (!TEST_true(SSL_CTX_add_grease_to_extension(ctx, TLSEXT_TYPE_psk_kex_modes, 0x9A)))
+            return 0;
+        if (!TEST_true(SSL_CTX_add_grease_to_extension(ctx, TLSEXT_TYPE_client_cert_type, 0x8A)))
+            return 0;
+        if (!TEST_true(SSL_CTX_add_grease_to_extension(ctx, TLSEXT_TYPE_server_cert_type, 0x7A)))
+            return 0;
+    }
+
+    if (gr_set == GREASE_SETUP_ALL || gr_set == GREASE_SETUP_KS) {
+        /* Fails due to strict key-share checking unless it matches a value in supported_groups */
+        if (!TEST_true(SSL_CTX_add_grease_to_extension(ctx, TLSEXT_TYPE_key_share, 0x11118A8A)))
+            return 0;
+    }
+
+    if (gr_set == GREASE_SETUP_ALL) {
+        /* Duplicate */
+        if (!TEST_false(SSL_CTX_add_grease_to_extension(ctx, TLSEXT_TYPE_supported_versions,
+                                                        0x5A5A)))
+            return 0;
+
+        if (!TEST_true(SSL_CTX_add_grease_extension(ctx, 0x1111, extension_data,
+                                                    sizeof(extension_data))))
+            return 0;
+        if (!TEST_true(SSL_CTX_add_grease_extension(ctx, 0x2222, extension_data,
+                                                    sizeof(extension_data))))
+            return 0;
+
+        /* Duplicate */
+        if (!TEST_false(SSL_CTX_add_grease_extension(ctx, 0x2222, extension_data,
+                                                     sizeof(extension_data))))
+            return 0;
+    }
+
+    return 1;
+}
+
+/*
+ * Test dimensions:
+ *   (2) TLSv1.2 vs TLSv1.3
+ *
+ * Tests:
+ * idx = 0 - is the normal success case, certificate
+ * idx = 1 - add client authentication
+ * idx = 2 - add client authentication (PHA)
+ * idx = 3 - simple resumption
+ * idx = 4 - simple resumption, no ticket
+ * idx = 5 - resumption with client authentication
+ * idx = 6 - resumption with client authentication, no ticket
+ *
+ * 7 * 2 - 1 = 13 tests (-1 because idx=2 is skipped for TLSv1.2)
+ */
+static int test_grease_internal(int idx, int gr_set)
+{
+#define GREASE_TESTS 7
+#define GREASE_DIMS 2
+    SSL_CTX *cctx = NULL, *sctx = NULL;
+    SSL *clientssl = NULL, *serverssl = NULL;
+    int testresult = 0, ret, expected = 1;
+    int tls_version;
+    SSL_SESSION *client_sess = NULL;
+    int idx_prot;
+    int client_auth = 0;
+    int resumption = 0;
+
+    if (!TEST_int_le(idx, GREASE_TESTS * GREASE_DIMS))
+        return 0;
+
+    idx_prot = idx / GREASE_TESTS;
+    idx %= GREASE_TESTS;
+
+    switch (idx_prot) {
+    case 0:
+#ifdef OSSL_NO_USABLE_TLS1_3
+        testresult = TEST_skip("TLSv1.3 disabled");
+        goto end;
+#else
+        tls_version = TLS1_3_VERSION;
+        break;
+#endif
+    case 1:
+#ifdef OPENSSL_NO_TLS1_2
+        testresult = TEST_skip("TLSv1.2 disabled");
+        goto end;
+#else
+        tls_version = TLS1_2_VERSION;
+        break;
+#endif
+    default:
+        goto end;
+    }
+
+    if (idx == 2 && tls_version != TLS1_3_VERSION) {
+        testresult = TEST_skip("PHA requires TLSv1.3");
+        goto end;
+    }
+
+    if (!TEST_true(create_ssl_ctx_pair(NULL,
+                                       TLS_server_method(), TLS_client_method(),
+                                       tls_version, tls_version,
+                                       &sctx, &cctx, NULL, NULL)))
+        goto end;
+
+    /* No Ticket */
+    if (idx == 4 || idx == 6) {
+        SSL_CTX_set_options(sctx, SSL_OP_NO_TICKET);
+        SSL_CTX_set_options(cctx, SSL_OP_NO_TICKET);
+    }
+    if (!TEST_true(SSL_CTX_set_session_id_context(sctx, SID_CTX, sizeof(SID_CTX))))
+        goto end;
+    if (!TEST_true(SSL_CTX_set_session_id_context(cctx, SID_CTX, sizeof(SID_CTX))))
+        goto end;
+
+    /* Configure Grease */
+    if (!TEST_true(setup_grease(sctx, gr_set)) || !TEST_true(setup_grease(cctx, gr_set)))
+        goto end;
+
+    if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
+                                      NULL, NULL)))
+        goto end;
+
+    if (!TEST_true(setup_cert(serverssl)))
+        goto end;
+
+    /* Client Authentication */
+    if (idx == 1 || idx == 2 || idx == 5 || idx == 6) {
+        if (!TEST_true(setup_cert(clientssl)))
+            goto end;
+
+        /* PHA */
+        if (idx == 2) {
+            SSL_set_verify(serverssl,
+                           SSL_VERIFY_PEER
+                           | SSL_VERIFY_FAIL_IF_NO_PEER_CERT
+                           | SSL_VERIFY_POST_HANDSHAKE,
+                           my_verify_cb);
+            SSL_set_post_handshake_auth(clientssl, 1);
+        } else {
+            SSL_set_verify(serverssl,
+                           SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT,
+                           my_verify_cb);
+        }
+        client_auth = 1;
+    }
+
+    /* Resumption */
+    if (idx == 3 || idx == 4 || idx == 5 || idx == 6)
+        resumption = 1;
+
+    /* With strict key-share checking, the connection is expected to fail */
+    if (gr_set == GREASE_SETUP_KS)
+        expected = 0;
+
+    ret = create_ssl_connection(serverssl, clientssl, SSL_ERROR_NONE);
+    if (!TEST_int_eq(expected, ret))
+        goto end;
+
+    if (idx == 2) {
+        /* Make PHA happen... */
+        if (!TEST_true(SSL_verify_client_post_handshake(serverssl)))
+            goto end;
+        if (!TEST_true(SSL_do_handshake(serverssl)))
+            goto end;
+        if (!TEST_int_le(SSL_read(clientssl, NULL, 0), 0))
+            goto end;
+        if (!TEST_int_le(SSL_read(serverssl, NULL, 0), 0))
+            goto end;
+    }
+
+    if (client_auth) {
+        /* only if connection is expected to succeed */
+        if (expected == 1 && !TEST_ptr(SSL_get0_peer_certificate(serverssl)))
+            goto end;
+    }
+
+    if (resumption) {
+        if (!TEST_ptr((client_sess = SSL_get1_session(clientssl))))
+            goto end;
+
+        SSL_shutdown(clientssl);
+        SSL_shutdown(serverssl);
+        SSL_free(clientssl);
+        SSL_free(serverssl);
+        serverssl = clientssl = NULL;
+
+        if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
+                                          NULL, NULL))
+                || !TEST_true(SSL_set_session(clientssl, client_sess)))
+            goto end;
+
+        if (!TEST_true(setup_cert(serverssl)))
+            goto end;
+
+        /* Client Auth */
+        if (idx == 5 || idx == 6) {
+            if (!TEST_true(setup_cert(clientssl)))
+                goto end;
+            SSL_set_verify(serverssl, SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT,
+                           my_verify_cb);
+        }
+
+        ret = create_ssl_connection(serverssl, clientssl, SSL_ERROR_NONE);
+        if (!TEST_int_eq(expected, ret))
+            goto end;
+        if (!TEST_true(SSL_session_reused(clientssl)))
+            goto end;
+    }
+
+    testresult = 1;
+
+ end:
+    SSL_SESSION_free(client_sess);
+    SSL_free(serverssl);
+    SSL_free(clientssl);
+    SSL_CTX_free(sctx);
+    SSL_CTX_free(cctx);
+
+    if (testresult == 0)
+        TEST_info("idx_prot=%d, idx=%d", idx_prot, idx);
+    return testresult;
+}
+
+/* Wrapper for generic tests */
+static int test_grease(int idx)
+{
+    return test_grease_internal(idx, GREASE_SETUP_ALL);
+}
+
+/*
+ * Wrapper for testing key-share grease; when supported_groups is also not set,
+ * the connection should fail
+ */
+static int test_grease_key_share(void)
+{
+    return test_grease_internal(0, GREASE_SETUP_KS);
+}
+
+OPT_TEST_DECLARE_USAGE("certdir\n")
+
+int setup_tests(void)
+{
+    if (!test_skip_common_options()) {
+        TEST_error("Error parsing test options\n");
+        return 0;
+    }
+
+    if (!TEST_ptr(certsdir = test_get_argument(0)))
+        return 0;
+
+    cert = test_mk_file_path(certsdir, "servercert.pem");
+    if (cert == NULL)
+        goto err;
+
+    privkey = test_mk_file_path(certsdir, "serverkey.pem");
+    if (privkey == NULL)
+        goto err;
+
+    ADD_ALL_TESTS(test_grease, GREASE_TESTS * GREASE_DIMS);
+    ADD_TEST(test_grease_key_share);
+    return 1;
+
+ err:
+    return 0;
+}
+
+void cleanup_tests(void)
+{
+    OPENSSL_free(cert);
+    OPENSSL_free(privkey);
+}

--- a/test/recipes/90-test_grease.t
+++ b/test/recipes/90-test_grease.t
@@ -1,0 +1,21 @@
+#! /usr/bin/env perl
+# Copyright 2016-2022 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+use OpenSSL::Test::Utils;
+use OpenSSL::Test qw/:DEFAULT srctop_dir bldtop_dir/;
+
+BEGIN {
+    setup("test_grease");
+}
+
+use lib srctop_dir('Configurations');
+use lib bldtop_dir('.');
+
+plan tests => 1;
+
+ok(run(test(["grease_test", srctop_dir("test", "certs")])), "running grease_test");

--- a/util/libssl.num
+++ b/util/libssl.num
@@ -606,3 +606,7 @@ SSL_CTX_set_domain_flags                ?	3_5_0	EXIST::FUNCTION:
 SSL_CTX_get_domain_flags                ?	3_5_0	EXIST::FUNCTION:
 SSL_get_domain_flags                    ?	3_5_0	EXIST::FUNCTION:
 SSL_CTX_set_new_pending_conn_cb         ?	3_5_0	EXIST::FUNCTION:
+SSL_CTX_add_grease_to_extension         ?	3_5_0	EXIST::FUNCTION:
+SSL_CTX_add_grease_to_ciphers           ?	3_5_0	EXIST::FUNCTION:
+SSL_CTX_add_grease_extension            ?	3_5_0	EXIST::FUNCTION:
+SSL_CTX_clean_grease                    ?	3_5_0	EXIST::FUNCTION:


### PR DESCRIPTION
This adds support for RFC8701, which can be used in testing to ensure TLS extensibility and proper processing. This is different from fuzzing in that this can be done on both the client and the server, and allows the connection to complete.

The API is public to allow end-users to do their own testing with GREASE.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
