### PR TITLE
Add verifying if fdopen returns NULL

### DIFF
--- a/apps/speed.c
+++ b/apps/speed.c
@@ -3508,7 +3508,7 @@ static int do_multi(int multi, int size_num)
         char buf[1024];
         char *p;
 
-        if ((f = fdopen(fds[n], "r")) == NULL){
+        if ((f = fdopen(fds[n], "r")) == NULL) {
             BIO_printf(bio_err, "fdopen failure with 0x%x\n",
                            errno);
             return 1;

--- a/apps/speed.c
+++ b/apps/speed.c
@@ -3508,7 +3508,11 @@ static int do_multi(int multi, int size_num)
         char buf[1024];
         char *p;
 
-        f = fdopen(fds[n], "r");
+        if ((f = fdopen(fds[n], "r")) == NULL){
+            BIO_printf(bio_err, "fdopen failure with 0x%x\n",
+                           errno);
+            return 1;
+        }
         while (fgets(buf, sizeof(buf), f)) {
             p = strchr(buf, '\n');
             if (p)

--- a/apps/speed.c
+++ b/apps/speed.c
@@ -3510,7 +3510,7 @@ static int do_multi(int multi, int size_num)
 
         if ((f = fdopen(fds[n], "r")) == NULL) {
             BIO_printf(bio_err, "fdopen failure with 0x%x\n",
-                           errno);
+                       errno);
             return 1;
         }
         while (fgets(buf, sizeof(buf), f)) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->
There were no verification if fdopen returns NULL because it failed and then the FILE pointer was passed to fgets even though it could be NULL.
Fixes #19542

