### PR TITLE
ocsp: Add missing test if make_ocsp_response failed

### DIFF
--- a/apps/ocsp.c
+++ b/apps/ocsp.c
@@ -730,6 +730,8 @@ redo_accept:
         make_ocsp_response(bio_err, &resp, req, rdb, rca_cert, rsigner, rkey,
                            rsign_md, rsign_sigopts, rother, rflags, nmin, ndays,
                            badsig, resp_certid_md);
+        if (resp == NULL)
+            goto end;
         if (cbio != NULL)
             send_ocsp_response(cbio, resp);
     } else if (host != NULL) {


### PR DESCRIPTION
Add missing test if make_ocsp_response failed.
This bug exist in openssl-1.* and openssl3.*
CLA: trivial