### PR TITLE
Allow 3.1 FIPS provider to pass 3.0 test suite

### DIFF
--- a/test/recipes/03-test_fipsinstall.t
+++ b/test/recipes/03-test_fipsinstall.t
@@ -28,6 +28,7 @@ plan tests => 29;
 
 my $infile = bldtop_file('providers', platform->dso('fips'));
 my $fipskey = $ENV{FIPSKEY} // config('FIPSKEY') // '00';
+my $provconf = srctop_file("test", "fips-and-base.cnf");
 
 # Read in a text $infile and replace the regular expression in $srch with the
 # value in $repl and output to a new file $outfile.
@@ -230,6 +231,12 @@ SKIP: {
 SKIP: {
     skip "Skipping Signature DSA corruption test because of no dsa in this build", 1
         if disabled("dsa");
+
+    run(test(["fips_version_test", "-config", $provconf, "<3.1.0"]),
+             capture => 1, statusvar => \my $exit);
+    skip "FIPS provider version is too new for PCT DSA signature test", 1
+        if !$exit;
+
     ok(!run(app(['openssl', 'fipsinstall', '-out', 'fips.cnf', '-module', $infile,
                 '-provider_name', 'fips', '-mac_name', 'HMAC',
                 '-macopt', 'digest:SHA256', '-macopt', "hexkey:$fipskey",

--- a/test/testutil.h
+++ b/test/testutil.h
@@ -256,7 +256,9 @@ void cleanup_tests(void);
 int fips_provider_version_eq(OSSL_LIB_CTX *libctx, int major, int minor, int patch);
 int fips_provider_version_ne(OSSL_LIB_CTX *libctx, int major, int minor, int patch);
 int fips_provider_version_le(OSSL_LIB_CTX *libctx, int major, int minor, int patch);
+int fips_provider_version_lt(OSSL_LIB_CTX *libctx, int major, int minor, int patch);
 int fips_provider_version_gt(OSSL_LIB_CTX *libctx, int major, int minor, int patch);
+int fips_provider_version_ge(OSSL_LIB_CTX *libctx, int major, int minor, int patch);
 
 /*
  * This function matches fips provider version with (potentially multiple)


### PR DESCRIPTION
Fixes #19601

- [ ] documentation is added or updated
- [x] tests are added or updated
