### PR TITLE
Add additional fips version checking test helper functions

### DIFF
--- a/test/recipes/03-test_fipsinstall.t
+++ b/test/recipes/03-test_fipsinstall.t
@@ -252,7 +252,7 @@ SKIP: {
 
     run(test(["fips_version_test", "-config", $provconf, "<3.1.0"]),
              capture => 1, statusvar => \my $exit);
-    skip "FIPS provider version is too new for KAT DSA signature test", 1
+    skip "FIPS provider version is too new for PCT DSA signature test", 1
         if !$exit;
     ok(!run(app(['openssl', 'fipsinstall', '-out', 'fips.cnf', '-module', $infile,
                 '-provider_name', 'fips', '-mac_name', 'HMAC',

--- a/test/testutil.h
+++ b/test/testutil.h
@@ -257,7 +257,9 @@ void cleanup_tests(void);
 int fips_provider_version_eq(OSSL_LIB_CTX *libctx, int major, int minor, int patch);
 int fips_provider_version_ne(OSSL_LIB_CTX *libctx, int major, int minor, int patch);
 int fips_provider_version_le(OSSL_LIB_CTX *libctx, int major, int minor, int patch);
+int fips_provider_version_lt(OSSL_LIB_CTX *libctx, int major, int minor, int patch);
 int fips_provider_version_gt(OSSL_LIB_CTX *libctx, int major, int minor, int patch);
+int fips_provider_version_ge(OSSL_LIB_CTX *libctx, int major, int minor, int patch);
 
 /*
  * This function matches fips provider version with (potentially multiple)


### PR DESCRIPTION
As for #19665 but for 3.1 and master

- [ ] documentation is added or updated
- [x] tests are added or updated
