### PR TITLE
Fix possible UB in init_info_strings

### DIFF
--- a/crypto/info.c
+++ b/crypto/info.c
@@ -45,10 +45,10 @@ DEFINE_RUN_ONCE_STATIC(init_info_strings)
 
     BIO_snprintf(ossl_cpu_info_str, sizeof(ossl_cpu_info_str),
                  CPUINFO_PREFIX "OPENSSL_ia32cap=0x%llx:0x%llx",
-                 (long long)OPENSSL_ia32cap_P[0] |
-                 (long long)OPENSSL_ia32cap_P[1] << 32,
-                 (long long)OPENSSL_ia32cap_P[2] |
-                 (long long)OPENSSL_ia32cap_P[3] << 32);
+                 (unsigned long long)OPENSSL_ia32cap_P[0] |
+                 (unsigned long long)OPENSSL_ia32cap_P[1] << 32,
+                 (unsigned long long)OPENSSL_ia32cap_P[2] |
+                 (unsigned long long)OPENSSL_ia32cap_P[3] << 32);
     if ((env = getenv("OPENSSL_ia32cap")) != NULL)
         BIO_snprintf(ossl_cpu_info_str + strlen(ossl_cpu_info_str),
                      sizeof(ossl_cpu_info_str) - strlen(ossl_cpu_info_str),


### PR DESCRIPTION
"openssl version -c" may create undefined behavior in the shift:

`crypto/info.c:42:50: runtime error: left shift of 4275712515 by 32 places cannot be represented in type 'long long int'`
