### PR TITLE
Add documentation for CPUID bit #64+17

### DIFF
--- a/doc/man3/OPENSSL_ia32cap.pod
+++ b/doc/man3/OPENSSL_ia32cap.pod
@@ -97,6 +97,8 @@ and RORX;
 
 =item bit #64+16 denoting availability of AVX512F extension;
 
+=item bit #64+17 denoting availability of AVX512DQ extension;
+
 =item bit #64+18 denoting availability of RDSEED instruction;
 
 =item bit #64+19 denoting availability of ADCX and ADOX instructions;


### PR DESCRIPTION
CLA: trivial

- [x] documentation is added or updated

I'm not sure why bit # 64+17 was not documented, considering it is used in the code (e.g. https://github.com/openssl/openssl/blob/master/crypto/modes/asm/aes-gcm-avx512.pl#L81 and https://github.com/openssl/openssl/blob/master/crypto/bn/asm/rsaz-2k-avx512.pl).

On the other hand, it is omitted in other parts of the code:
* https://github.com/openssl/openssl/blob/master/crypto/x86_64cpuid.pl#L203
* https://github.com/openssl/openssl/blob/master/crypto/x86_64cpuid.pl#L217
* https://github.com/openssl/openssl/blob/master/crypto/x86_64cpuid.pl#L228

Perhaps those files will need to be updated? 