### PR TITLE
gcm_get_funcs(): Add missing fallback for ghash on x86_64

### DIFF
--- a/crypto/modes/gcm128.c
+++ b/crypto/modes/gcm128.c
@@ -457,6 +457,11 @@ static void gcm_get_funcs(struct gcm_funcs_st *ctx)
     ctx->gmult = gcm_gmult_4bit_x86;
     ctx->ghash = gcm_ghash_4bit_x86;
     return;
+# else
+    /* x86_64 fallback defaults */
+    ctx->gmult = gcm_gmult_4bit;
+    ctx->ghash = gcm_ghash_4bit;
+    return;
 # endif
 #elif defined(GHASH_ASM_ARM)
     /* ARM defaults */


### PR DESCRIPTION
Fixes #19673

