### PR TITLE
params_api_test.c: Fix mistake in backported test fix

### DIFF
--- a/test/params_api_test.c
+++ b/test/params_api_test.c
@@ -431,7 +431,7 @@ static int test_param_bignum(int n)
 
     if (!TEST_true(OSSL_PARAM_set_BN(&param, b)))
         goto err;
-    le_copy(buf, bnbuf, len);
+    le_copy(buf, bnbuf, sizeof(bnbuf));
     if (!TEST_mem_eq(raw_values[n].value, len, buf, len))
         goto err;
     param.data_size = param.return_size;


### PR DESCRIPTION
Fixup for e8f1d76b50204d87a0ef7f6879eb1dd507a54368.

Fixes on-push CI failure on 3.1 branch. Marking urgent.
