### PR TITLE
`ParseC.pm`: gracefully handle DOS-style end-of-line in source files

### DIFF
--- a/util/perl/OpenSSL/ParseC.pm
+++ b/util/perl/OpenSSL/ParseC.pm
@@ -816,14 +816,13 @@ sub parse {
 
     foreach my $line (@_) {
         # split tries to be smart when a string ends with the thing we split on
-        $line =~ s/\r\n/\n/; # gracefully handle DOS-style end-of-line
         $line .= "\n" unless $line =~ m|\R$|;
         $line .= "#";
 
         # We use ¦undef¦ as a marker for a new line from the file.
         # Since we convert one line to several and unshift that into @lines,
         # that's the only safe way we have to track the original lines
-        my @lines = map { ( undef, $_ ) } split $/, $line;
+        my @lines = map { ( undef, $_ ) } split m|\R|, $line;
 
         # Remember that extra # we added above?  Now we remove it
         pop @lines;

--- a/util/perl/OpenSSL/ParseC.pm
+++ b/util/perl/OpenSSL/ParseC.pm
@@ -816,6 +816,7 @@ sub parse {
 
     foreach my $line (@_) {
         # split tries to be smart when a string ends with the thing we split on
+        $line =~ s/\r\n/\n/; # gracefully handle DOS-style end-of-line
         $line .= "\n" unless $line =~ m|\R$|;
         $line .= "#";
 


### PR DESCRIPTION
Prevent weird hick-ups like:
```
Unmatched parentheses at include/openssl/asn1.h line 520

make[1]: *** [Makefile:4757: util/libcrypto.num] Error 255
make[1]: *** Waiting for unfinished jobs....
make: *** [Makefile:3387: build_sw] Error 2
```
during builds in case header files in `include/openss/` happen to have `\r\n` at line ends, 
which can happen when a `git clone` or `git checkout` gets the line end conversion wrong,
which can happen easily (by default?) on Windows Subsystem for Linux (WSL).

The issue can reproduced easily also on 'real' Linux by
```
unix2dos include/openssl/asn1.h.in
make -s -j
```

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
