### PR TITLE
Ensure that SIZE_MAX is defined where OSSL_SSIZE_MAX is used.

### DIFF
--- a/include/internal/e_os.h
+++ b/include/internal/e_os.h
@@ -16,6 +16,7 @@
 # include <openssl/e_os2.h>
 # include <openssl/crypto.h>
 # include "internal/nelem.h"
+# include "internal/numbers.h"   /* Ensure the definition of SIZE_MAX */
 
 /*
  * <openssl/e_os2.h> contains what we can justify to make visible to the


### PR DESCRIPTION
`include/openssl/e_os2.h` defines `OSSL_SSIZE_MAX` in terms of `SIZE_MAX` as a fallback.  This doesn't work well on platforms where `SIZE_MAX` isn't defined, so we must ensure that it's defined by including `"internal/numbers.h"`.
Since this is compensating for operating system discrepancies, it's reasonable to make this change in `include/internal/e_os.h`.

-----

This should fix current VMS build failures
