### PR TITLE
Fix a memory leak in rsa_priv_encode

### DIFF
--- a/crypto/rsa/rsa_ameth.c
+++ b/crypto/rsa/rsa_ameth.c
@@ -172,6 +172,7 @@ static int rsa_priv_encode(PKCS8_PRIV_KEY_INFO *p8, const EVP_PKEY *pkey)
                          strtype, str, rk, rklen)) {
         RSAerr(RSA_F_RSA_PRIV_ENCODE, ERR_R_MALLOC_FAILURE);
         ASN1_STRING_free(str);
+        OPENSSL_clear_free(rk, rklen);
         return 0;
     }
 


### PR DESCRIPTION
If PKCS8_pkey_set0 fails, the memory in rk need to be clear freed otherwise it is owned by the PKCS8_PRIV_KEY_INFO.

This was found by my error injection patch #18355 together with the new asn1 corpora #19669
see https://github.com/openssl/openssl/pull/19669#issuecomment-1316365655

this was already fixed in master/3.0 some 6 months ago.