### PR TITLE
Use <openssl/e_os2.h> rather than <stdint.h>

### DIFF
--- a/fuzz/fuzzer.h
+++ b/fuzz/fuzzer.h
@@ -8,8 +8,8 @@
  * or in the file LICENSE in the source distribution.
  */
 
-#include <stdint.h>     /* for uint8_t */
-#include <stddef.h>     /* for size_t */
+#include <stddef.h>              /* for size_t */
+#include <openssl/e_os2.h>       /* for uint8_t */
 
 int FuzzerTestOneInput(const uint8_t *buf, size_t len);
 int FuzzerInitialize(int *argc, char ***argv);


### PR DESCRIPTION
<stdint.h> is C99, which means that on older compiler, it can't be included.
We have code in <openssl/e_os2.h> that compensates.
