### PR TITLE
Allowing load-balancing among multiple matching algorithm implementations

### DIFF
--- a/crypto/context.c
+++ b/crypto/context.c
@@ -48,6 +48,7 @@ struct ossl_lib_ctx_st {
 #endif
 
     unsigned int ischild:1;
+    unsigned int isloadbalancer:1;
 };
 
 int ossl_lib_ctx_write_lock(OSSL_LIB_CTX *ctx)
@@ -72,6 +73,15 @@ int ossl_lib_ctx_is_child(OSSL_LIB_CTX *ctx)
     if (ctx == NULL)
         return 0;
     return ctx->ischild;
+}
+
+int ossl_lib_ctx_is_load_balancer(OSSL_LIB_CTX *ctx)
+{
+    ctx = ossl_lib_ctx_get_concrete(ctx);
+
+    if (ctx == NULL)
+        return 0;
+    return ctx->isloadbalancer;
 }
 
 static void context_deinit_objs(OSSL_LIB_CTX *ctx);
@@ -436,6 +446,24 @@ OSSL_LIB_CTX *OSSL_LIB_CTX_new_child(const OSSL_CORE_HANDLE *handle,
         return NULL;
     }
     ctx->ischild = 1;
+
+    return ctx;
+}
+
+OSSL_LIB_CTX *OSSL_LIB_CTX_new_load_balancer(const OSSL_CORE_HANDLE *handle,
+                                             const OSSL_DISPATCH *in,
+                                             int strategy)
+{
+    OSSL_LIB_CTX *ctx = OSSL_LIB_CTX_new_child(handle, in);
+
+    if (ctx == NULL)
+        return NULL;
+
+    if (!ossl_load_balancer_init(ctx, strategy)) {
+        OSSL_LIB_CTX_free(ctx);
+        return NULL;
+    }
+    ctx->isloadbalancer = 1;
 
     return ctx;
 }

--- a/crypto/context.c
+++ b/crypto/context.c
@@ -32,6 +32,7 @@ struct ossl_lib_ctx_st {
     void *provider_conf;
     void *bio_core;
     void *child_provider;
+    void *lb_strategy;
     OSSL_METHOD_STORE *decoder_store;
     OSSL_METHOD_STORE *encoder_store;
     OSSL_METHOD_STORE *store_loader_store;
@@ -185,6 +186,9 @@ static int context_init(OSSL_LIB_CTX *ctx)
     ctx->child_provider = ossl_child_prov_ctx_new(ctx);
     if (ctx->child_provider == NULL)
         goto err;
+    ctx->lb_strategy = ossl_lb_strategy_ctx_new(ctx);
+    if (ctx->lb_strategy == NULL)
+        goto err;
 #endif
 
     /* Everything depends on properties, so we also pre-initialise that */
@@ -320,6 +324,10 @@ static void context_deinit_objs(OSSL_LIB_CTX *ctx)
     if (ctx->child_provider != NULL) {
         ossl_child_prov_ctx_free(ctx->child_provider);
         ctx->child_provider = NULL;
+    }
+    if (ctx->lb_strategy != NULL) {
+        ossl_lb_strategy_ctx_free(ctx->lb_strategy);
+        ctx->lb_strategy = NULL;
     }
 #endif
 }
@@ -550,6 +558,8 @@ void *ossl_lib_ctx_get_data(OSSL_LIB_CTX *ctx, int index)
         return ctx->store_loader_store;
     case OSSL_LIB_CTX_SELF_TEST_CB_INDEX:
         return ctx->self_test_cb;
+    case OSSL_LIB_CTX_LB_STRATEGY_INDEX:
+        return ctx->lb_strategy;
 #endif
 #ifndef OPENSSL_NO_THREAD_POOL
     case OSSL_LIB_CTX_THREAD_INDEX:

--- a/crypto/evp/digest.c
+++ b/crypto/evp/digest.c
@@ -300,7 +300,20 @@ static int evp_md_init_internal(EVP_MD_CTX *ctx, const EVP_MD *type,
         }
         type = lbmd;
         EVP_MD_free(ctx->fetched_digest);
+        /*
+         * copying to fetched_digest so it laterly can be free'd
+         * by EVP_MD_CTX_free()
+         */
         ctx->fetched_digest = lbmd;
+        /*
+         * the incoming type (reqdigest) is from a dummy method by 'lbprov'.
+         * it can not provide proper response to function calls such as:
+         * EVP_MD_get_size(EVP_MD_CTX_get0_md(ctx)),
+         * EVP_MD_get0_name(EVP_MD_CTX_get0_md(ctx)),
+         * EVP_MD_get0_description(EVP_MD_CTX_get0_md(ctx)))
+         *
+         * set reqdigest to the actual fetched method to fix this.
+         */
         ctx->reqdigest = type;
     }
 #endif

--- a/crypto/evp/evp_fetch.c
+++ b/crypto/evp/evp_fetch.c
@@ -117,6 +117,14 @@ static uint32_t evp_method_id(int name_id, unsigned int operation_id)
             | (operation_id & METHOD_ID_OPERATION_MASK));
 }
 
+/*
+ * a function to return name_id from method_id
+ */
+int evp_method_id_to_name_id(uint32_t method_id)
+{
+    return (method_id >> METHOD_ID_NAME_OFFSET);
+}
+
 static void *get_evp_method_from_store(void *store, const OSSL_PROVIDER **prov,
                                        void *data)
 {

--- a/crypto/property/property.c
+++ b/crypto/property/property.c
@@ -789,6 +789,34 @@ static void ossl_method_cache_flush_some(OSSL_METHOD_STORE *store)
         tsan_add(&global_seed, state.seed);
 }
 
+int ossl_load_balancer_init(OSSL_LIB_CTX *ctx, int strategy)
+{
+    LB_GLOBAL *lgbl;
+    void *status;
+
+    /* initialize strategy */
+    lgbl = ossl_lib_ctx_get_data(ctx, OSSL_LIB_CTX_LB_STRATEGY_INDEX);
+    if (lgbl == NULL)
+        return 0;
+
+    lgbl->strategy = strategy;
+    switch (lgbl->strategy) {
+    case LB_STRATEGY_ROUND_ROBIN:
+        if ((status = lb_sched_round_robin_new_status()) == NULL)
+            return 0;
+        lgbl->strategy_status = status;
+        return 1;
+    #if 0  /* to-be-added */
+    case LB_STRATEGY_PRIORITY:
+    case LB_STRATEGY_FREE_BANDWIDTH:
+    case LB_STRATEGY_PACKET_SIZE:
+    #endif
+    default:
+        return 0;
+    }
+    return 0;
+}
+
 int ossl_method_store_cache_get(OSSL_METHOD_STORE *store, OSSL_PROVIDER *prov,
                                 int nid, const char *prop_query, void **method)
 {

--- a/crypto/provider_predefined.c
+++ b/crypto/provider_predefined.c
@@ -14,6 +14,7 @@ OSSL_provider_init_fn ossl_default_provider_init;
 OSSL_provider_init_fn ossl_base_provider_init;
 OSSL_provider_init_fn ossl_null_provider_init;
 OSSL_provider_init_fn ossl_fips_intern_provider_init;
+OSSL_provider_init_fn ossl_lb_provider_init;
 #ifdef STATIC_LEGACY
 OSSL_provider_init_fn ossl_legacy_provider_init;
 #endif
@@ -26,6 +27,7 @@ const OSSL_PROVIDER_INFO ossl_predefined_providers[] = {
     { "legacy", NULL, ossl_legacy_provider_init, NULL, 0 },
 # endif
     { "base", NULL, ossl_base_provider_init, NULL, 0 },
+    { "loadbalance", NULL, ossl_lb_provider_init, NULL, 0 },
     { "null", NULL, ossl_null_provider_init, NULL, 0 },
 #endif
     { NULL, NULL, NULL, NULL, 0 }

--- a/doc/man3/OSSL_LIB_CTX.pod
+++ b/doc/man3/OSSL_LIB_CTX.pod
@@ -3,7 +3,8 @@
 =head1 NAME
 
 OSSL_LIB_CTX, OSSL_LIB_CTX_new, OSSL_LIB_CTX_new_from_dispatch,
-OSSL_LIB_CTX_new_child, OSSL_LIB_CTX_free, OSSL_LIB_CTX_load_config,
+OSSL_LIB_CTX_new_child, OSSL_LIB_CTX_new_load_balancer,
+OSSL_LIB_CTX_free, OSSL_LIB_CTX_load_config,
 OSSL_LIB_CTX_get0_global_default, OSSL_LIB_CTX_set0_default
 - OpenSSL library context
 
@@ -18,6 +19,9 @@ OSSL_LIB_CTX_get0_global_default, OSSL_LIB_CTX_set0_default
                                               const OSSL_DISPATCH *in);
  OSSL_LIB_CTX *OSSL_LIB_CTX_new_child(const OSSL_CORE_HANDLE *handle,
                                       const OSSL_DISPATCH *in);
+ OSSL_LIB_CTX *OSSL_LIB_CTX_new_load_balancer(const OSSL_CORE_HANDLE *handle,
+                                              const OSSL_DISPATCH *in,
+                                              int strategy);
  int OSSL_LIB_CTX_load_config(OSSL_LIB_CTX *ctx, const char *config_file);
  void OSSL_LIB_CTX_free(OSSL_LIB_CTX *ctx);
  OSSL_LIB_CTX *OSSL_LIB_CTX_get0_global_default(void);
@@ -82,6 +86,15 @@ yet be available in the newly constructed child library context. As soon as the
 B<OSSL_provider_init> function returns then the new provider is available in the
 application's library context and will be similarly mirrored in the child
 library context.
+
+OSSL_LIB_CTX_new_load_balancer() is based on OSSL_LIB_CTX_new_child() except
+that it doesn't mirror the "loadbalancer" provider self into the child libctx's
+provider store. This function accepts a I<strategy> input, which indicates what
+type of load balancing strategy the user wants to use.
+
+Available types of strategy is defined in <openssl/cryto.h>. With this input,
+a strategy related status is allocated and a scheduler function is bounded to
+the new libctx.
 
 OSSL_LIB_CTX_load_config() loads a configuration file using the given I<ctx>.
 This can be used to associate a library context with providers that are loaded

--- a/include/crypto/context.h
+++ b/include/crypto/context.h
@@ -26,6 +26,7 @@ void *ossl_fips_prov_ossl_ctx_new(OSSL_LIB_CTX *);
 #if defined(OPENSSL_THREADS)
 void *ossl_threads_ctx_new(OSSL_LIB_CTX *);
 #endif
+void *ossl_lb_strategy_ctx_new(OSSL_LIB_CTX *);
 
 void ossl_provider_store_free(void *);
 void ossl_property_string_data_free(void *);
@@ -45,3 +46,4 @@ void ossl_release_default_drbg_ctx(void);
 #if defined(OPENSSL_THREADS)
 void ossl_threads_ctx_free(void *);
 #endif
+void ossl_lb_strategy_ctx_free(void *);

--- a/include/crypto/evp.h
+++ b/include/crypto/evp.h
@@ -951,4 +951,7 @@ int evp_md_get_number(const EVP_MD *md);
 int evp_rand_get_number(const EVP_RAND *rand);
 int evp_signature_get_number(const EVP_SIGNATURE *signature);
 
+/* get name_id from method_id */
+int evp_method_id_to_name_id(uint32_t method_id);
+
 #endif /* OSSL_CRYPTO_EVP_H */

--- a/include/internal/core.h
+++ b/include/internal/core.h
@@ -68,4 +68,5 @@ __owur int ossl_lib_ctx_write_lock(OSSL_LIB_CTX *ctx);
 __owur int ossl_lib_ctx_read_lock(OSSL_LIB_CTX *ctx);
 int ossl_lib_ctx_unlock(OSSL_LIB_CTX *ctx);
 int ossl_lib_ctx_is_child(OSSL_LIB_CTX *ctx);
+int ossl_lib_ctx_is_load_balancer(OSSL_LIB_CTX *ctx);
 #endif

--- a/include/internal/cryptlib.h
+++ b/include/internal/cryptlib.h
@@ -117,7 +117,8 @@ typedef struct ossl_ex_data_global_st {
 # define OSSL_LIB_CTX_BIO_CORE_INDEX                17
 # define OSSL_LIB_CTX_CHILD_PROVIDER_INDEX          18
 # define OSSL_LIB_CTX_THREAD_INDEX                  19
-# define OSSL_LIB_CTX_MAX_INDEXES                   20
+# define OSSL_LIB_CTX_LB_STRATEGY_INDEX             20
+# define OSSL_LIB_CTX_MAX_INDEXES                   21
 
 OSSL_LIB_CTX *ossl_lib_ctx_get_concrete(OSSL_LIB_CTX *ctx);
 int ossl_lib_ctx_is_default(OSSL_LIB_CTX *ctx);

--- a/include/internal/property.h
+++ b/include/internal/property.h
@@ -96,4 +96,5 @@ size_t ossl_property_list_to_string(OSSL_LIB_CTX *ctx,
 int ossl_global_properties_no_mirrored(OSSL_LIB_CTX *libctx);
 void ossl_global_properties_stop_mirroring(OSSL_LIB_CTX *libctx);
 
+int ossl_load_balancer_init(OSSL_LIB_CTX *ctx, int strategy);
 #endif

--- a/include/internal/provider.h
+++ b/include/internal/provider.h
@@ -77,6 +77,7 @@ const char *ossl_provider_module_path(const OSSL_PROVIDER *prov);
 void *ossl_provider_prov_ctx(const OSSL_PROVIDER *prov);
 const OSSL_DISPATCH *ossl_provider_get0_dispatch(const OSSL_PROVIDER *prov);
 OSSL_LIB_CTX *ossl_provider_libctx(const OSSL_PROVIDER *prov);
+int ossl_provider_is_load_balancer(const OSSL_PROVIDER *prov);
 
 /* Thin wrappers around calls to the provider */
 void ossl_provider_teardown(const OSSL_PROVIDER *prov);

--- a/include/openssl/core_dispatch.h
+++ b/include/openssl/core_dispatch.h
@@ -205,6 +205,8 @@ OSSL_CORE_MAKE_FUNC(void, cleanup_nonce, (const OSSL_CORE_HANDLE *handle,
 #define OSSL_FUNC_PROVIDER_GET0_DISPATCH       109
 #define OSSL_FUNC_PROVIDER_UP_REF              110
 #define OSSL_FUNC_PROVIDER_FREE                111
+#define OSSL_FUNC_PROVIDER_SET_LOAD_BALANCER   112
+#define OSSL_FUNC_PROVIDER_IS_LOAD_BALANCER    113
 
 OSSL_CORE_MAKE_FUNC(int, provider_register_child_cb,
                     (const OSSL_CORE_HANDLE *handle,
@@ -224,6 +226,10 @@ OSSL_CORE_MAKE_FUNC(int, provider_up_ref,
                     (const OSSL_CORE_HANDLE *prov, int activate))
 OSSL_CORE_MAKE_FUNC(int, provider_free,
                     (const OSSL_CORE_HANDLE *prov, int deactivate))
+OSSL_CORE_MAKE_FUNC(int, provider_set_load_balancer,
+                    (const OSSL_CORE_HANDLE *prov))
+OSSL_CORE_MAKE_FUNC(int, provider_is_load_balancer,
+                    (const OSSL_CORE_HANDLE *prov))
 
 /* Functions provided by the provider to the Core, reserved numbers 1024-1535 */
 # define OSSL_FUNC_PROVIDER_TEARDOWN           1024

--- a/include/openssl/crypto.h.in
+++ b/include/openssl/crypto.h.in
@@ -540,6 +540,14 @@ void OSSL_sleep(uint64_t millis);
 #define LB_STRATEGY_PACKET_SIZE         4
 #define LB_STRATEGY_MAX                 5
 
+/*
+ * a struct to hold query information about free_bandwidths from providers
+ */
+typedef struct {
+    const char *name;           /* name of a method */
+    int free_bandwidth;         /* to be returned by provider upon this query */
+} FREE_BANDWIDTH_QUERY;
+
 # ifdef  __cplusplus
 }
 # endif

--- a/include/openssl/crypto.h.in
+++ b/include/openssl/crypto.h.in
@@ -531,6 +531,11 @@ OSSL_LIB_CTX *OSSL_LIB_CTX_set0_default(OSSL_LIB_CTX *libctx);
 
 void OSSL_sleep(uint64_t millis);
 
+#define LB_STRATEGY_ROUND_ROBIN         1
+#define LB_STRATEGY_PRIORITY            2
+#define LB_STRATEGY_FREE_BANDWIDTH      3
+#define LB_STRATEGY_PACKET_SIZE         4
+
 # ifdef  __cplusplus
 }
 # endif

--- a/include/openssl/crypto.h.in
+++ b/include/openssl/crypto.h.in
@@ -538,6 +538,7 @@ void OSSL_sleep(uint64_t millis);
 #define LB_STRATEGY_PRIORITY            2
 #define LB_STRATEGY_FREE_BANDWIDTH      3
 #define LB_STRATEGY_PACKET_SIZE         4
+#define LB_STRATEGY_MAX                 5
 
 # ifdef  __cplusplus
 }

--- a/include/openssl/crypto.h.in
+++ b/include/openssl/crypto.h.in
@@ -524,6 +524,9 @@ OSSL_LIB_CTX *OSSL_LIB_CTX_new_from_dispatch(const OSSL_CORE_HANDLE *handle,
                                              const OSSL_DISPATCH *in);
 OSSL_LIB_CTX *OSSL_LIB_CTX_new_child(const OSSL_CORE_HANDLE *handle,
                                      const OSSL_DISPATCH *in);
+OSSL_LIB_CTX *OSSL_LIB_CTX_new_load_balancer(const OSSL_CORE_HANDLE *handle,
+                                             const OSSL_DISPATCH *in,
+                                             int strategy);
 int OSSL_LIB_CTX_load_config(OSSL_LIB_CTX *ctx, const char *config_file);
 void OSSL_LIB_CTX_free(OSSL_LIB_CTX *);
 OSSL_LIB_CTX *OSSL_LIB_CTX_get0_global_default(void);

--- a/providers/build.info
+++ b/providers/build.info
@@ -67,6 +67,17 @@ DEPEND[$LIBLEGACY]=$LIBCOMMON
 DEPEND[$LIBDEFAULT]=$LIBCOMMON
 
 #
+# load-balance provider stuff
+#
+# Currently, load-balance provider is built in, it means that libcrypto must
+# include all the object files that are needed (we do that indirectly,
+# by using the appropriate libraries as source).  Note that for shared
+# libraries, SOURCEd libraries are considered as if they were specified
+# with DEPEND.
+$LBGOAL=../libcrypto
+SOURCE[$LBGOAL]=lbprov.c
+
+#
 # Default provider stuff
 #
 # Because the default provider is built in, it means that libcrypto must

--- a/providers/lbprov.c
+++ b/providers/lbprov.c
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2022 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+
+#include <openssl/core.h>
+#include <openssl/core_dispatch.h>
+#include <openssl/core_names.h>
+#include <openssl/crypto.h>
+#include <openssl/params.h>
+#include "prov/names.h"
+#include "prov/providercommon.h"
+#include "prov/digestcommon.h"
+#include "prov/provider_ctx.h"
+
+/*
+ * Forward declarations to ensure that interface functions are correctly
+ * defined.
+ */
+static OSSL_FUNC_provider_teardown_fn lbprov_teardown;
+static OSSL_FUNC_provider_gettable_params_fn lbprov_gettable_params;
+static OSSL_FUNC_provider_get_params_fn lbprov_get_params;
+static OSSL_FUNC_provider_query_operation_fn lbprov_query;
+
+#define ALG(NAMES, FUNC) { NAMES, "provider=loadbalance", FUNC , "dummy implementation by lbprov" }
+
+/* Parameters we provide to the core */
+static const OSSL_PARAM lbprov_param_types[] = {
+    OSSL_PARAM_DEFN(OSSL_PROV_PARAM_NAME, OSSL_PARAM_UTF8_PTR, NULL, 0),
+    OSSL_PARAM_DEFN(OSSL_PROV_PARAM_VERSION, OSSL_PARAM_UTF8_PTR, NULL, 0),
+    OSSL_PARAM_DEFN(OSSL_PROV_PARAM_BUILDINFO, OSSL_PARAM_UTF8_PTR, NULL, 0),
+    OSSL_PARAM_DEFN(OSSL_PROV_PARAM_STATUS, OSSL_PARAM_INTEGER, NULL, 0),
+    OSSL_PARAM_END
+};
+
+static const OSSL_PARAM *lbprov_gettable_params(void *provctx)
+{
+    return lbprov_param_types;
+}
+
+static int lbprov_get_params(void *provctx, OSSL_PARAM params[])
+{
+    OSSL_PARAM *p;
+
+    p = OSSL_PARAM_locate(params, OSSL_PROV_PARAM_NAME);
+    if (p != NULL && !OSSL_PARAM_set_utf8_ptr(p, "a built-in loadbalance provider"))
+        return 0;
+    p = OSSL_PARAM_locate(params, OSSL_PROV_PARAM_VERSION);
+    if (p != NULL && !OSSL_PARAM_set_utf8_ptr(p, "0.1"))
+        return 0;
+    p = OSSL_PARAM_locate(params, OSSL_PROV_PARAM_BUILDINFO);
+    if (p != NULL && !OSSL_PARAM_set_utf8_ptr(p, "rc0"))
+        return 0;
+    p = OSSL_PARAM_locate(params, OSSL_PROV_PARAM_STATUS);
+    if (p != NULL && !OSSL_PARAM_set_int(p, ossl_prov_is_running()))
+        return 0;
+    return 1;
+}
+
+/* dummy functions
+ * Actual computing should never happen in this provider itself. Actual
+ * computing should be delegated to the child providers.
+ *
+ * Return: NULL or 0 on error
+ */
+static int dummy_int_ret_err(void)
+{
+    return 0;
+}
+
+static int dummy_int_ret_succ(void)
+{
+    return 1;
+}
+
+static void *dummy_ptr_ret(void)
+{
+    return NULL;
+}
+
+static const OSSL_DISPATCH lbprov_dummy_md5_functions[] = {
+    { OSSL_FUNC_DIGEST_NEWCTX,  (void (*)(void))dummy_ptr_ret },
+    { OSSL_FUNC_DIGEST_UPDATE,  (void (*)(void))dummy_int_ret_err },
+    { OSSL_FUNC_DIGEST_FINAL,   (void (*)(void))dummy_int_ret_err },
+    { OSSL_FUNC_DIGEST_FREECTX, (void (*)(void))dummy_ptr_ret },
+    { OSSL_FUNC_DIGEST_DUPCTX,  (void (*)(void))dummy_ptr_ret },
+    { OSSL_FUNC_DIGEST_INIT,    (void (*)(void))dummy_int_ret_err },
+    /*
+     * OSSL_FUNC_DIGEST_GET_PARAMS must return 1 success.
+     * Otherwise ossl_method_construct() fails at evp_md_cache_constants()
+     */
+    { OSSL_FUNC_DIGEST_GET_PARAMS, (void (*)(void))dummy_int_ret_succ },
+    { 0, NULL }
+};
+
+static const OSSL_ALGORITHM lbprov_digests[] = {
+    ALG(PROV_NAMES_MD5, lbprov_dummy_md5_functions),
+    { NULL, NULL, NULL }
+};
+
+static const OSSL_ALGORITHM lbprov_ciphers[] = {
+    { NULL, NULL, NULL }
+};
+
+static const OSSL_ALGORITHM lbprov_kdfs[] = {
+    { NULL, NULL, NULL }
+};
+
+static const OSSL_ALGORITHM *lbprov_query(void *provctx, int operation_id,
+                                          int *no_cache)
+{
+    *no_cache = 0;
+    switch (operation_id) {
+    case OSSL_OP_DIGEST:
+        return lbprov_digests;
+    case OSSL_OP_CIPHER:
+        return lbprov_ciphers;
+    case OSSL_OP_KDF:
+        return lbprov_kdfs;
+    }
+    return NULL;
+}
+
+static void lbprov_teardown(void *provctx)
+{
+    OSSL_LIB_CTX_free(PROV_LIBCTX_OF(provctx));
+    ossl_prov_ctx_free(provctx);
+}
+
+/* The base dispatch table */
+static const OSSL_DISPATCH lbprov_dispatch_table[] = {
+    { OSSL_FUNC_PROVIDER_TEARDOWN, (void (*)(void))lbprov_teardown },
+    { OSSL_FUNC_PROVIDER_QUERY_OPERATION, (void (*)(void))lbprov_query },
+    { OSSL_FUNC_PROVIDER_GETTABLE_PARAMS, (void (*)(void))lbprov_gettable_params },
+    { OSSL_FUNC_PROVIDER_GET_PARAMS, (void (*)(void))lbprov_get_params },
+    { 0, NULL }
+};
+
+OSSL_provider_init_fn ossl_lb_provider_init;
+
+int ossl_lb_provider_init(const OSSL_CORE_HANDLE *handle,
+                          const OSSL_DISPATCH *in,
+                          const OSSL_DISPATCH **out,
+                          void **provctx)
+{
+    OSSL_LIB_CTX *libctx = NULL;
+    const OSSL_DISPATCH *tmp = in;
+    OSSL_FUNC_provider_set_load_balancer_fn *c_set_load_balancer = NULL;
+
+    for (; in->function_id != 0; in++) {
+        switch (in->function_id) {
+        case OSSL_FUNC_PROVIDER_SET_LOAD_BALANCER:
+            c_set_load_balancer = OSSL_FUNC_provider_set_load_balancer(in);
+            break;
+        default:
+            /* Just ignore anything we don't understand */
+            break;
+        }
+    }
+
+    /* mark self as a loadbalancer provider */
+    if ((c_set_load_balancer == NULL) || (c_set_load_balancer(handle) == 0))
+        return 0;
+
+    /* create load_balancer libctx */
+    if ((*provctx = ossl_prov_ctx_new()) == NULL
+        || (libctx = OSSL_LIB_CTX_new_load_balancer(handle, tmp,
+                                                    LB_STRATEGY_ROUND_ROBIN)) == NULL) {
+        OSSL_LIB_CTX_free(libctx);
+        goto err;
+    }
+
+    /* set up provctx */
+    ossl_prov_ctx_set0_libctx(*provctx, libctx);
+    ossl_prov_ctx_set0_handle(*provctx, handle);
+
+    *out = lbprov_dispatch_table;
+    return 1;
+
+err:
+    lbprov_teardown(*provctx);
+    *provctx = NULL;
+    return 0;
+}

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5512,3 +5512,4 @@ BIO_get_wpoll_descriptor                ?	3_2_0	EXIST::FUNCTION:
 ASN1_item_unpack_ex                     ?	3_2_0	EXIST::FUNCTION:
 PKCS12_SAFEBAG_get1_cert_ex             ?	3_2_0	EXIST::FUNCTION:
 PKCS12_SAFEBAG_get1_crl_ex              ?	3_2_0	EXIST::FUNCTION:
+OSSL_LIB_CTX_new_load_balancer          ?	3_2_0	EXIST::FUNCTION:


### PR DESCRIPTION
This patchset defined a new type of built-in provider with the name "loadbalance". The original idea was discussed in https://github.com/openssl/openssl/issues/19228. Here I'm proposing a draft, calling for your comments. Appreciate any type of feedbacks.

With this patchset, a user can specify what type of load balancing strategy to use when loading the 'loadbalance' provider. By default, it is round-robin. With this strategy (an integer number), the "loadbalance" provider creates a load_balancer libctx, which bases on child libctx, but without mirroring the “loadbalance” provider self into the child’s provider store. Inside the load_balancer libctx, a strategy related status is allocated and a scheduler function is bound.

The user can keep loading other providers which he wants to balance the work loads with into the parent libctx. As expected, these providers will be mirrored to the load_balancer libctx as child providers.

Suppose a dummy implementation of algorithm (eg. MD5) exists in both the “loadbalance” provider and the other providers, the user can now start a fetch with the property string “provider=loadbalance", and it will return the dummy implementation from the “loadbalance” provider.
`	md5 = EVP_MD_fetch(parent_libctx, "MD5", "provider=loadbalance");
`

Then at the init stage, i.e. digest init, the evp code will detect that this method comes from loadbalancer provider, so, it will go down one level, ie. check through the load_balancer libctx’s method store or cache, call previously bounded scheduler function to fetch a proper implementation from child providers, then set the new fetched method into context ctx.
`	EVP_DigestInit_ex(ctx, md5, NULL);
`

Moving onward, calculations will happen with the new method. 

When another thread calls the fetch/Init, with the help of the strategy specific scheduler function, it will be load-balanced to the next proper implementation, which may come from the same or not the same provider.

Some design notes, which I want to receive your comments :
1. I put the strategy specific scheduler functions in crypto/property/property.c, together with other method stores routines, and related struct types. I don’t want to export these structures and routines through OSSL_DISPATCH core_dispatch[].
2. Need to add more wrapper (dummy) algorithm implementations into the “loadbalance” provider. So we can load balance over them.
3. This feature is wrapped by #ifndef FIPS_MODULE. Because it relies on the child libctx.

This patchset include 7 patches:
Patch 1: Add load-balance strategy field into OSSL_LIB_CTX
Patch 2: Implement load-balance method fetch framework and add a round-robin strategy
Patch 3: Add a new field isloadbalancer in ossl_provider_st
Patch 4: Add a new load_balancer libctx type
Patch 5: Call load-balance fetch before normal method store and cache fetch
Patch 6: Digest init: fetch a real method from load_balancer libctx
Patch 7: Add a built-in provider loadbalance

Known issue:
1. crypto: function OSSL_LIB_CTX_new_load_balancer(3) undocumented
2. Tests, need to add more tests.

Usage Example:
```
{
    OSSL_LIB_CTX *parent_libctx = NULL;
    OSSL_PROVIDER *lbprov = NULL;
    OSSL_PROVIDER *deflt = NULL;

    lb_libctx = OSSL_LIB_CTX_new();

    /* load loadbalance provider, which by default enables round-robin strategy */
    lbprov = OSSL_PROVIDER_load(parent_libctx, "loadbalance");

    /* load other providers, and they will be mirrored into loadbalance provider's child libctx */
    deflt = OSSL_PROVIDER_load(parent_libctx, "default");

    {
	/*
	 * calculate MD5
	 */
	EVP_MD_CTX *ctx = NULL;
	EVP_MD *md5 = NULL;
	unsigned char *outdigest = NULL;

	/* specify property query sting: loadbalance */
	md5 = EVP_MD_fetch(parent_libctx, "MD5", "provider=loadbalance");

	/* Create a context for the digest operation */
	ctx = EVP_MD_CTX_new();
	/* Initialise the digest operation */
	EVP_DigestInit_ex(ctx, md5, NULL);
	EVP_DigestUpdate(ctx, msg, sizeof(msg));

	/* NOTE: cannot get_size from EVP_MD *md5, because the actual method has been 
	 * modified by EVP_DigestInit_ex(ctx)
	 */
	outdigest = OPENSSL_malloc(EVP_MD_get_size(EVP_MD_CTX_get0_md(ctx)));

	/* Now calculate the digest itself */
	EVP_DigestFinal_ex(ctx, outdigest, &len);
    }
    
    OSSL_PROVIDER_unload(lbprov);
    OSSL_PROVIDER_unload(deflt);
    OSSL_LIB_CTX_free(parent_libctx);
}

```
