### PR TITLE
CMP: add API functions `OSSL_CMP_CTX_get0_{libctx,propq}`

### DIFF
--- a/crypto/cmp/cmp_ctx.c
+++ b/crypto/cmp/cmp_ctx.c
@@ -58,6 +58,9 @@ int PREFIX##_set0##_##NAME(OSSL_CMP_CTX *ctx, TYPE *val) \
  */
 DEFINE_OSSL_set0_NAME(OSSL_CMP_CTX, trusted, trusted, X509_STORE)
 
+DEFINE_OSSL_CMP_CTX_get0(libctx, OSSL_LIB_CTX)
+DEFINE_OSSL_CMP_CTX_get0(propq, const char)
+
 /* Get current list of non-trusted intermediate certs */
 DEFINE_OSSL_CMP_CTX_get0(untrusted, STACK_OF(X509))
 

--- a/doc/man3/OSSL_CMP_CTX_new.pod
+++ b/doc/man3/OSSL_CMP_CTX_new.pod
@@ -5,6 +5,7 @@
 OSSL_CMP_CTX_new,
 OSSL_CMP_CTX_free,
 OSSL_CMP_CTX_reinit,
+OSSL_CMP_CTX_get0_libctx, OSSL_CMP_CTX_get0_propq,
 OSSL_CMP_CTX_set_option,
 OSSL_CMP_CTX_get_option,
 OSSL_CMP_CTX_set_log_cb,
@@ -73,6 +74,8 @@ OSSL_CMP_CTX_set1_senderNonce
  OSSL_CMP_CTX *OSSL_CMP_CTX_new(OSSL_LIB_CTX *libctx, const char *propq);
  void OSSL_CMP_CTX_free(OSSL_CMP_CTX *ctx);
  int OSSL_CMP_CTX_reinit(OSSL_CMP_CTX *ctx);
+ OSSL_LIB_CTX *OSSL_CMP_CTX_get0_libctx(const OSSL_CMP_CTX *ctx);
+ const char *OSSL_CMP_CTX_get0_propq(const OSSL_CMP_CTX *ctx);
  int OSSL_CMP_CTX_set_option(OSSL_CMP_CTX *ctx, int opt, int val);
  int OSSL_CMP_CTX_get_option(const OSSL_CMP_CTX *ctx, int opt);
 
@@ -186,6 +189,12 @@ clearing the internal CMP transaction (aka session) status, PKIStatusInfo,
 and any previous results (newCert, newChain, caPubs, and extraCertsIn)
 from the last executed transaction.
 All other field values (i.e., CMP options) are retained for potential re-use.
+
+OSSL_CMP_CTX_get0_libctx() returns the I<libctx> argument that was used
+when constructing I<ctx> with OSSL_CMP_CTX_new(), which may be NULL.
+
+OSSL_CMP_CTX_get0_propq() returns the I<propq> argument that was used
+when constructing I<ctx> with OSSL_CMP_CTX_new(), which may be NULL.
 
 OSSL_CMP_CTX_set_option() sets the given value for the given option
 (e.g., OSSL_CMP_OPT_IMPLICIT_CONFIRM) in the given OSSL_CMP_CTX structure.
@@ -448,8 +457,8 @@ certificate, for the TLS client certificate (if any), when verifying
 the CMP server certificate, and when verifying newly enrolled certificates.
 The reference counts of those certificates handled successfully are increased.
 
-OSSL_CMP_CTX_get0_untrusted(OSSL_CMP_CTX *ctx) returns a pointer to the
-list of untrusted certs, which may be empty if unset.
+OSSL_CMP_CTX_get0_untrusted() returns a pointer to the
+list of untrusted certs in I<ctx>, which may be empty if unset.
 
 OSSL_CMP_CTX_set1_cert() sets the certificate related to the client's private key
 used for CMP message protection.
@@ -676,6 +685,7 @@ CMP is defined in RFC 4210 (and CRMF in RFC 4211).
 OSSL_CMP_CTX_free() and OSSL_CMP_CTX_print_errors() do not return anything.
 
 OSSL_CMP_CTX_new(),
+OSSL_CMP_CTX_get0_libctx(), OSSL_CMP_CTX_get0_propq(),
 OSSL_CMP_CTX_get_http_cb_arg(),
 OSSL_CMP_CTX_get_transfer_cb_arg(),
 OSSL_CMP_CTX_get0_trusted(),
@@ -780,7 +790,8 @@ OSSL_CMP_CTX_set0_trustedStore() was renamed to OSSL_CMP_CTX_set0_trusted(),
 using macros, while keeping the old names for backward compatibility,
 in OpenSSL 3.2.
 
-OSSL_CMP_CTX_get0_validatedSrvCert() was added in OpenSSL 3.2.
+OSSL_CMP_CTX_get0_libctx(), OSSL_CMP_CTX_get0_propq(), and
+OSSL_CMP_CTX_get0_validatedSrvCert() were added in OpenSSL 3.2.
 
 =head1 COPYRIGHT
 

--- a/include/openssl/cmp.h.in
+++ b/include/openssl/cmp.h.in
@@ -264,6 +264,8 @@ void OSSL_CMP_MSG_free(OSSL_CMP_MSG *msg);
 OSSL_CMP_CTX *OSSL_CMP_CTX_new(OSSL_LIB_CTX *libctx, const char *propq);
 void OSSL_CMP_CTX_free(OSSL_CMP_CTX *ctx);
 int OSSL_CMP_CTX_reinit(OSSL_CMP_CTX *ctx);
+OSSL_LIB_CTX *OSSL_CMP_CTX_get0_libctx(const OSSL_CMP_CTX *ctx);
+const char *OSSL_CMP_CTX_get0_propq(const OSSL_CMP_CTX *ctx);
 /* CMP general options: */
 #  define OSSL_CMP_OPT_LOG_VERBOSITY 0
 /* CMP transfer options: */

--- a/test/cmp_ctx_test.c
+++ b/test/cmp_ctx_test.c
@@ -108,6 +108,21 @@ static int execute_CTX_reinit_test(OSSL_CMP_CTX_TEST_FIXTURE *fixture)
     return res;
 }
 
+static int test_CTX_libctx_propq(void)
+{
+    OSSL_LIB_CTX *libctx = OSSL_LIB_CTX_new();
+    const char *propq = "?provider=legacy";
+    OSSL_CMP_CTX *cmpctx = OSSL_CMP_CTX_new(libctx, propq);
+    int res = TEST_ptr(libctx)
+        && TEST_ptr(cmpctx)
+        && TEST_ptr_eq(libctx, OSSL_CMP_CTX_get0_libctx(cmpctx))
+        && TEST_str_eq(propq, OSSL_CMP_CTX_get0_propq(cmpctx));
+
+    OSSL_CMP_CTX_free(cmpctx);
+    OSSL_LIB_CTX_free(libctx);
+    return res;
+}
+
 static int test_CTX_reinit(void)
 {
     SETUP_TEST_FIXTURE(OSSL_CMP_CTX_TEST_FIXTURE, set_up);
@@ -794,8 +809,8 @@ int setup_tests(void)
         return 0;
     }
 
-    /* OSSL_CMP_CTX_new() is tested by set_up() */
-    /* OSSL_CMP_CTX_free() is tested by tear_down() */
+    /* also tests OSSL_CMP_CTX_new() and OSSL_CMP_CTX_free(): */
+    ADD_TEST(test_CTX_libctx_propq);
     ADD_TEST(test_CTX_reinit);
 
     /* various CMP options: */

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5443,6 +5443,8 @@ BN_signed_bn2native                     ?	3_2_0	EXIST::FUNCTION:
 ASYNC_set_mem_functions                 ?	3_2_0	EXIST::FUNCTION:
 ASYNC_get_mem_functions                 ?	3_2_0	EXIST::FUNCTION:
 BIO_ADDR_dup                            ?	3_2_0	EXIST::FUNCTION:SOCK
+OSSL_CMP_CTX_get0_libctx                ?	3_2_0	EXIST::FUNCTION:CMP
+OSSL_CMP_CTX_get0_propq                 ?	3_2_0	EXIST::FUNCTION:CMP
 OSSL_CMP_CTX_get0_validatedSrvCert      ?	3_2_0	EXIST::FUNCTION:CMP
 OSSL_CRMF_CERTTEMPLATE_get0_publicKey   ?	3_2_0	EXIST::FUNCTION:CRMF
 CMS_final_digest                        ?	3_2_0	EXIST::FUNCTION:CMS


### PR DESCRIPTION
It turns out that these two getter functions were missing from the `OSSL_CMP_CTX` API.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
