### PR TITLE
QUIC Test Server and Basic Echo Test

### DIFF
--- a/include/internal/quic_record_rx.h
+++ b/include/internal/quic_record_rx.h
@@ -322,6 +322,15 @@ int ossl_qrx_set_early_validation_cb(OSSL_QRX *qrx,
                                      void *cb_arg);
 
 /*
+ * Forcibly injects a URXE which has been issued by the DEMUX into the QRX for
+ * processing. This can be used to pass a received datagram to the QRX if it
+ * would not be correctly routed to the QRX via standard DCID-based routing; for
+ * example, when handling an incoming Initial packet which is attempting to
+ * establish a new connection.
+ */
+void ossl_qrx_inject_urxe(OSSL_QRX *qrx, QUIC_URXE *e);
+
+/*
  * Key Update (RX)
  * ===============
  *

--- a/include/internal/quic_tserver.h
+++ b/include/internal/quic_tserver.h
@@ -60,9 +60,9 @@ int ossl_quic_tserver_read(QUIC_TSERVER *srv,
 
 /*
  * Attempts to write to stream 0. Writes the number of bytes consumed to
- * *consumed and returns 1 on success. If there is no space currently available
- * to write any bytes, 0 is written to *consumed and 1 is returned (this is
- * considered a success case).
+ * *bytes_written and returns 1 on success. If there is no space currently
+ * available to write any bytes, 0 is written to *consumed and 1 is returned
+ * (this is considered a success case).
  *
  * Note that unlike libssl public APIs, this API always works in a 'partial
  * write' mode.

--- a/include/internal/quic_types.h
+++ b/include/internal/quic_types.h
@@ -93,6 +93,8 @@ static ossl_unused ossl_inline int ossl_quic_conn_id_eq(const QUIC_CONN_ID *a,
 /* Arbitrary choice of default idle timeout (not an RFC value). */
 #  define QUIC_DEFAULT_IDLE_TIMEOUT   30000
 
+#  define QUIC_STATELESS_RESET_TOKEN_LEN    16
+
 # endif
 
 #endif

--- a/ssl/quic/build.info
+++ b/ssl/quic/build.info
@@ -11,3 +11,4 @@ SOURCE[$LIBSSL]=quic_sf_list.c quic_rstream.c quic_sstream.c
 SOURCE[$LIBSSL]=quic_dummy_handshake.c
 SOURCE[$LIBSSL]=quic_reactor.c
 SOURCE[$LIBSSL]=quic_channel.c
+SOURCE[$LIBSSL]=quic_tserver.c

--- a/ssl/quic/quic_channel_local.h
+++ b/ssl/quic/quic_channel_local.h
@@ -118,19 +118,29 @@ struct quic_channel_st {
 
     /* Internal state. */
     /*
-     * The DCID used in the first Initial packet we transmit as a client.
+     * Client: The DCID used in the first Initial packet we transmit as a client.
+     * Server: The DCID used in the first Initial packet the client transmitted.
      * Randomly generated and required by RFC to be at least 8 bytes.
      */
     QUIC_CONN_ID                    init_dcid;
 
     /*
-     * The SCID found in the first Initial packet from the server.
+     * Client: The SCID found in the first Initial packet from the server.
+     * Not valid for servers.
      * Valid if have_received_enc_pkt is set.
      */
     QUIC_CONN_ID                    init_scid;
 
-    /* The SCID found in an incoming Retry packet we handled. */
+    /*
+     * Client only: The SCID found in an incoming Retry packet we handled.
+     * Not valid for servers.
+     */
     QUIC_CONN_ID                    retry_scid;
+
+    /* Server only: The DCID we currently use to talk to the peer. */
+    QUIC_CONN_ID                    cur_remote_dcid;
+    /* Server only: The DCID we currently expect the peer to use to talk to us. */
+    QUIC_CONN_ID                    cur_local_dcid;
 
     /* Transport parameter values received from server. */
     uint64_t                        init_max_stream_data_bidi_local;

--- a/ssl/quic/quic_demux.c
+++ b/ssl/quic/quic_demux.c
@@ -501,14 +501,13 @@ static int demux_process_pending_urxe(QUIC_DEMUX *demux, QUIC_URXE *e)
          * handler, pass it to the handler. Otherwise, we will never be able to
          * process this datagram, so get rid of it.
          */
+        ossl_list_urxe_remove(&demux->urx_pending, e);
         if (demux->default_cb != NULL) {
             /* Pass to default handler. */
-            ossl_list_urxe_remove(&demux->urx_pending, e);
             e->demux_state = URXE_DEMUX_STATE_ISSUED;
             demux->default_cb(e, demux->default_cb_arg);
         } else {
             /* Discard. */
-            ossl_list_urxe_remove(&demux->urx_pending, e);
             ossl_list_urxe_insert_tail(&demux->urx_free, e);
             e->demux_state = URXE_DEMUX_STATE_FREE;
         }

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -1131,9 +1131,12 @@ static int quic_read(SSL *s, void *buf, size_t len, size_t *bytes_read, int peek
             else
                 return QUIC_RAISE_NON_NORMAL_ERROR(qc, ERR_R_INTERNAL_ERROR, NULL);
         }
-    }
 
-    return 1;
+        return 1;
+    } else {
+        /* We did not get any bytes and are not in blocking mode. */
+        return QUIC_RAISE_NORMAL_ERROR(qc, SSL_ERROR_WANT_READ);
+    }
 }
 
 int ossl_quic_read(SSL *s, void *buf, size_t len, size_t *bytes_read)

--- a/ssl/quic/quic_record_rx.c
+++ b/ssl/quic/quic_record_rx.c
@@ -217,15 +217,19 @@ void ossl_qrx_free(OSSL_QRX *qrx)
     OPENSSL_free(qrx);
 }
 
-static void qrx_on_rx(QUIC_URXE *urxe, void *arg)
+void ossl_qrx_inject_urxe(OSSL_QRX *qrx, QUIC_URXE *urxe)
 {
-    OSSL_QRX *qrx = arg;
-
     /* Initialize our own fields inside the URXE and add to the pending list. */
     urxe->processed     = 0;
     urxe->hpr_removed   = 0;
     urxe->deferred      = 0;
     ossl_list_urxe_insert_tail(&qrx->urx_pending, urxe);
+}
+
+static void qrx_on_rx(QUIC_URXE *urxe, void *arg)
+{
+    OSSL_QRX *qrx = arg;
+    ossl_qrx_inject_urxe(qrx, urxe);
 }
 
 int ossl_qrx_add_dst_conn_id(OSSL_QRX *qrx,

--- a/ssl/quic/quic_tserver.c
+++ b/ssl/quic/quic_tserver.c
@@ -120,6 +120,7 @@ int ossl_quic_tserver_read(QUIC_TSERVER *srv,
          * the peer).
          */
         OSSL_RTT_INFO rtt_info;
+
         ossl_statm_get_rtt_info(ossl_quic_channel_get_statm(srv->ch), &rtt_info);
 
         if (!ossl_quic_rxfc_on_retire(&srv->stream0->rxfc, *bytes_read,

--- a/ssl/quic/quic_tserver.c
+++ b/ssl/quic/quic_tserver.c
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2022 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include "internal/quic_tserver.h"
+#include "internal/quic_channel.h"
+#include "internal/quic_statm.h"
+#include "internal/common.h"
+
+/*
+ * QUIC Test Server Module
+ * =======================
+ */
+struct quic_tserver_st {
+    QUIC_TSERVER_ARGS   args;
+
+    /*
+     * The QUIC channel providing the core QUIC connection implementation.
+     */
+    QUIC_CHANNEL    *ch;
+
+    /* Our single bidirectional application data stream. */
+    QUIC_STREAM     *stream0;
+
+    /* The current peer L4 address. AF_UNSPEC if we do not have a peer yet. */
+    BIO_ADDR        cur_peer_addr;
+
+    /* Are we connected to a peer? */
+    unsigned int    connected       : 1;
+};
+
+QUIC_TSERVER *ossl_quic_tserver_new(const QUIC_TSERVER_ARGS *args)
+{
+    QUIC_TSERVER *srv = NULL;
+    QUIC_CHANNEL_ARGS ch_args = {0};
+
+    if (args->net_rbio == NULL || args->net_wbio == NULL)
+        goto err;
+
+    if ((srv = OPENSSL_zalloc(sizeof(*srv))) == NULL)
+        goto err;
+
+    srv->args = *args;
+
+    ch_args.libctx      = srv->args.libctx;
+    ch_args.propq       = srv->args.propq;
+    ch_args.is_server   = 1;
+
+    if ((srv->ch = ossl_quic_channel_new(&ch_args)) == NULL)
+        goto err;
+
+    if (!ossl_quic_channel_set_net_rbio(srv->ch, srv->args.net_rbio)
+        || !ossl_quic_channel_set_net_wbio(srv->ch, srv->args.net_wbio))
+        goto err;
+
+    srv->stream0 = ossl_quic_channel_get_stream_by_id(srv->ch, 0);
+    if (srv->stream0 == NULL)
+        goto err;
+
+    return srv;
+
+err:
+    if (srv != NULL)
+        ossl_quic_channel_free(srv->ch);
+
+    OPENSSL_free(srv);
+    return NULL;
+}
+
+void ossl_quic_tserver_free(QUIC_TSERVER *srv)
+{
+    if (srv == NULL)
+        return;
+
+    ossl_quic_channel_free(srv->ch);
+    BIO_free(srv->args.net_rbio);
+    BIO_free(srv->args.net_wbio);
+    OPENSSL_free(srv);
+}
+
+int ossl_quic_tserver_tick(QUIC_TSERVER *srv)
+{
+    ossl_quic_reactor_tick(ossl_quic_channel_get_reactor(srv->ch));
+
+    if (ossl_quic_channel_is_active(srv->ch))
+        srv->connected = 1;
+
+    return 1;
+}
+
+int ossl_quic_tserver_is_connected(QUIC_TSERVER *srv)
+{
+    return ossl_quic_channel_is_active(srv->ch);
+}
+
+int ossl_quic_tserver_read(QUIC_TSERVER *srv,
+                           unsigned char *buf,
+                           size_t buf_len,
+                           size_t *bytes_read)
+{
+    int is_fin = 0; /* TODO(QUIC): Handle FIN in API */
+
+    if (!ossl_quic_channel_is_active(srv->ch))
+        return 0;
+
+    if (!ossl_quic_rstream_read(srv->stream0->rstream, buf, buf_len,
+                                bytes_read, &is_fin))
+        return 0;
+
+    if (*bytes_read > 0) {
+        /*
+         * We have read at least one byte from the stream. Inform stream-level
+         * RXFC of the retirement of controlled bytes. Update the active stream
+         * status (the RXFC may now want to emit a frame granting more credit to
+         * the peer).
+         */
+        OSSL_RTT_INFO rtt_info;
+        ossl_statm_get_rtt_info(ossl_quic_channel_get_statm(srv->ch), &rtt_info);
+
+        if (!ossl_quic_rxfc_on_retire(&srv->stream0->rxfc, *bytes_read,
+                                      rtt_info.smoothed_rtt))
+            return 0;
+    }
+
+    if (is_fin)
+        srv->stream0->recv_fin_retired = 1;
+
+    if (*bytes_read > 0)
+        ossl_quic_stream_map_update_state(ossl_quic_channel_get_qsm(srv->ch),
+                                          srv->stream0);
+
+    return 1;
+}
+
+int ossl_quic_tserver_write(QUIC_TSERVER *srv,
+                            const unsigned char *buf,
+                            size_t buf_len,
+                            size_t *bytes_written)
+{
+    if (!ossl_quic_channel_is_active(srv->ch))
+        return 0;
+
+    if (!ossl_quic_sstream_append(srv->stream0->sstream,
+                                  buf, buf_len, bytes_written))
+        return 0;
+
+    if (*bytes_written > 0)
+        /*
+         * We have appended at least one byte to the stream. Potentially mark
+         * the stream as active, depending on FC.
+         */
+        ossl_quic_stream_map_update_state(ossl_quic_channel_get_qsm(srv->ch),
+                                          srv->stream0);
+
+    /* Try and send. */
+    ossl_quic_tserver_tick(srv);
+    return 1;
+}

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -4411,6 +4411,14 @@ int SSL_get_error(const SSL *s, int i)
     if (i > 0)
         return SSL_ERROR_NONE;
 
+#ifndef OPENSSL_NO_QUIC
+    if (qc != NULL) {
+        reason = ossl_quic_get_error(qc, i);
+        if (reason != SSL_ERROR_NONE)
+            return reason;
+    }
+#endif
+
     if (sc == NULL)
         return SSL_ERROR_SSL;
 
@@ -4424,14 +4432,6 @@ int SSL_get_error(const SSL *s, int i)
         else
             return SSL_ERROR_SSL;
     }
-
-#ifndef OPENSSL_NO_QUIC
-    if (qc != NULL) {
-        reason = ossl_quic_get_error(qc, i);
-        if (reason != SSL_ERROR_NONE)
-            return reason;
-    }
-#endif
 
 #ifndef OPENSSL_NO_QUIC
     if (qc == NULL)

--- a/test/build.info
+++ b/test/build.info
@@ -320,6 +320,10 @@ IF[{- !$disabled{tests} -}]
   INCLUDE[quic_txp_test]=../include ../apps/include
   DEPEND[quic_txp_test]=../libcrypto.a ../libssl.a libtestutil.a
 
+  SOURCE[quic_tserver_test]=quic_tserver_test.c
+  INCLUDE[quic_tserver_test]=../include ../apps/include
+  DEPEND[quic_tserver_test]=../libcrypto.a ../libssl.a libtestutil.a
+
   SOURCE[asynctest]=asynctest.c
   INCLUDE[asynctest]=../include ../apps/include
   DEPEND[asynctest]=../libcrypto
@@ -1053,7 +1057,7 @@ ENDIF
   ENDIF
 
   IF[{- !$disabled{'quic'} -}]
-    PROGRAMS{noinst}=quicapitest quic_wire_test quic_ackm_test quic_record_test quic_fc_test quic_stream_test quic_cfq_test quic_txpim_test quic_fifd_test quic_txp_test
+    PROGRAMS{noinst}=quicapitest quic_wire_test quic_ackm_test quic_record_test quic_fc_test quic_stream_test quic_cfq_test quic_txpim_test quic_fifd_test quic_txp_test quic_tserver_test
   ENDIF
 
   SOURCE[quicapitest]=quicapitest.c helpers/ssltestlib.c

--- a/test/build.info
+++ b/test/build.info
@@ -1057,7 +1057,9 @@ ENDIF
   ENDIF
 
   IF[{- !$disabled{'quic'} -}]
-    PROGRAMS{noinst}=quicapitest quic_wire_test quic_ackm_test quic_record_test quic_fc_test quic_stream_test quic_cfq_test quic_txpim_test quic_fifd_test quic_txp_test quic_tserver_test
+    PROGRAMS{noinst}=quicapitest quic_wire_test quic_ackm_test quic_record_test
+    PROGRAMS{noinst}=quic_fc_test quic_stream_test quic_cfq_test quic_txpim_test
+    PROGRAMS{noinst}=quic_fifd_test quic_txp_test quic_tserver_test
   ENDIF
 
   SOURCE[quicapitest]=quicapitest.c helpers/ssltestlib.c

--- a/test/quic_tserver_test.c
+++ b/test/quic_tserver_test.c
@@ -21,6 +21,7 @@ static char msg2[1024], msg3[1024];
 static int is_want(SSL *s, int ret)
 {
     int ec = SSL_get_error(s, ret);
+
     return ec == SSL_ERROR_WANT_READ || ec == SSL_ERROR_WANT_WRITE;
 }
 

--- a/test/quic_tserver_test.c
+++ b/test/quic_tserver_test.c
@@ -1,0 +1,221 @@
+/*
+ * Copyright 2022 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+#include <openssl/ssl.h>
+#include <openssl/quic.h>
+#include <openssl/bio.h>
+#include "internal/common.h"
+#include "internal/sockets.h"
+#include "internal/quic_tserver.h"
+#include "internal/time.h"
+#include "testutil.h"
+
+static const char msg1[] = "The quick brown fox jumped over the lazy dogs.";
+static char msg2[1024], msg3[1024];
+
+static int is_want(SSL *s, int ret)
+{
+    int ec = SSL_get_error(s, ret);
+    return ec == SSL_ERROR_WANT_READ || ec == SSL_ERROR_WANT_WRITE;
+}
+
+static int test_tserver(void)
+{
+    int testresult = 0, ret;
+    int s_fd = -1, c_fd = -1;
+    BIO *s_net_bio = NULL, *s_net_bio_own = NULL;
+    BIO *c_net_bio = NULL, *c_net_bio_own = NULL;
+    QUIC_TSERVER_ARGS tserver_args = {0};
+    QUIC_TSERVER *tserver = NULL;
+    BIO_ADDR *s_addr_ = NULL;
+    struct in_addr ina = {0};
+    union BIO_sock_info_u s_info = {0};
+    SSL_CTX *c_ctx = NULL;
+    SSL *c_ssl = NULL;
+    short port = 8186;
+    int c_connected = 0, c_write_done = 0, c_begin_read = 0;
+    size_t l = 0, s_total_read = 0, s_total_written = 0, c_total_read = 0;
+    int s_begin_write = 0;
+    OSSL_TIME start_time;
+
+    ina.s_addr = htonl(0x7f000001UL);
+
+    /* Setup test server. */
+    s_fd = BIO_socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP, 0);
+    if (!TEST_int_ge(s_fd, 0))
+        goto err;
+
+    if (!TEST_true(BIO_socket_nbio(s_fd, 1)))
+        goto err;
+
+    if (!TEST_ptr(s_addr_ = BIO_ADDR_new()))
+        goto err;
+
+    if (!TEST_true(BIO_ADDR_rawmake(s_addr_, AF_INET, &ina, sizeof(ina),
+                                    htons(port))))
+        goto err;
+
+    if (!TEST_true(BIO_bind(s_fd, s_addr_, 0)))
+        goto err;
+
+    s_info.addr = s_addr_;
+    if (!TEST_true(BIO_sock_info(s_fd, BIO_SOCK_INFO_ADDRESS, &s_info)))
+        goto err;
+
+    if (!TEST_int_gt(BIO_ADDR_rawport(s_addr_), 0))
+        goto err;
+
+    if (!TEST_ptr(s_net_bio = s_net_bio_own = BIO_new_dgram(s_fd, 0)))
+        goto err;
+
+    if (!BIO_up_ref(s_net_bio))
+        goto err;
+
+    tserver_args.net_rbio = s_net_bio;
+    tserver_args.net_wbio = s_net_bio;
+
+    if (!TEST_ptr(tserver = ossl_quic_tserver_new(&tserver_args))) {
+        BIO_free(s_net_bio);
+        goto err;
+    }
+
+    s_net_bio_own = NULL;
+
+    /* Setup test client. */
+    c_fd = BIO_socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP, 0);
+    if (!TEST_int_ge(c_fd, 0))
+        goto err;
+
+    if (!TEST_true(BIO_socket_nbio(c_fd, 1)))
+        goto err;
+
+    if (!TEST_ptr(c_net_bio = c_net_bio_own = BIO_new_dgram(c_fd, 0)))
+        goto err;
+
+    if (!BIO_dgram_set_peer(c_net_bio, s_addr_))
+        goto err;
+
+    if (!TEST_ptr(c_ctx = SSL_CTX_new(OSSL_QUIC_client_method())))
+        goto err;
+
+    if (!TEST_ptr(c_ssl = SSL_new(c_ctx)))
+        goto err;
+
+    /* Takes ownership of our reference to the BIO. */
+    SSL_set0_rbio(c_ssl, c_net_bio);
+
+    /* Get another reference to be transferred in the SSL_set0_wbio call. */
+    if (!TEST_true(BIO_up_ref(c_net_bio))) {
+        c_net_bio_own = NULL; /* SSL_free will free the first reference. */
+        goto err;
+    }
+
+    SSL_set0_wbio(c_ssl, c_net_bio);
+    c_net_bio_own = NULL;
+
+    if (!TEST_true(SSL_set_blocking_mode(c_ssl, 0)))
+        goto err;
+
+    start_time = ossl_time_now();
+
+    for (;;) {
+        if (ossl_time_compare(ossl_time_subtract(ossl_time_now(), start_time),
+                              ossl_ms2time(1000)) >= 0) {
+            TEST_error("timeout while attempting QUIC server test");
+            goto err;
+        }
+
+        ret = SSL_connect(c_ssl);
+        if (!TEST_true(ret == 1 || is_want(c_ssl, ret)))
+            goto err;
+
+        if (ret == 1)
+            c_connected = 1;
+
+        if (c_connected && !c_write_done) {
+            if (!TEST_int_eq(SSL_write(c_ssl, msg1, sizeof(msg1) - 1),
+                             (int)sizeof(msg1) - 1))
+                goto err;
+
+            c_write_done = 1;
+        }
+
+        if (c_connected && c_write_done && s_total_read < sizeof(msg1) - 1) {
+            if (!TEST_true(ossl_quic_tserver_read(tserver,
+                                                  (unsigned char *)msg2 + s_total_read,
+                                                  sizeof(msg2) - s_total_read, &l)))
+                goto err;
+
+            s_total_read += l;
+            if (s_total_read == sizeof(msg1) - 1) {
+                if (!TEST_mem_eq(msg1, sizeof(msg1) - 1,
+                                 msg2, sizeof(msg1) - 1))
+                    goto err;
+
+                s_begin_write = 1;
+            }
+        }
+
+        if (s_begin_write && s_total_written < sizeof(msg1) - 1) {
+            if (!TEST_true(ossl_quic_tserver_write(tserver,
+                                                   (unsigned char *)msg2 + s_total_written,
+                                                   sizeof(msg1) - 1 - s_total_written, &l)))
+                goto err;
+
+            s_total_written += l;
+
+            if (s_total_written == sizeof(msg1) - 1)
+                c_begin_read = 1;
+        }
+
+        if (c_begin_read && c_total_read < sizeof(msg1) - 1) {
+            ret = SSL_read_ex(c_ssl, msg3 + c_total_read,
+                              sizeof(msg1) - 1 - c_total_read, &l);
+            if (!TEST_true(ret == 1 || is_want(c_ssl, ret)))
+                goto err;
+
+            c_total_read += l;
+
+            if (c_total_read == sizeof(msg1) - 1) {
+                if (!TEST_mem_eq(msg1, sizeof(msg1) - 1,
+                                 msg3, c_total_read))
+                    goto err;
+
+                /* MATCH */
+                break;
+            }
+        }
+
+        /*
+         * This is inefficient because we spin until things work without
+         * blocking but this is just a test.
+         */
+        SSL_tick(c_ssl);
+        ossl_quic_tserver_tick(tserver);
+    }
+
+    testresult = 1;
+err:
+    SSL_free(c_ssl);
+    SSL_CTX_free(c_ctx);
+    ossl_quic_tserver_free(tserver);
+    BIO_ADDR_free(s_addr_);
+    BIO_free(s_net_bio_own);
+    BIO_free(c_net_bio_own);
+    if (s_fd >= 0)
+        BIO_closesocket(s_fd);
+    if (c_fd >= 0)
+        BIO_closesocket(c_fd);
+    return testresult;
+}
+
+int setup_tests(void)
+{
+    ADD_TEST(test_tserver);
+    return 1;
+}

--- a/test/recipes/70-test_quic_tserver.t
+++ b/test/recipes/70-test_quic_tserver.t
@@ -1,0 +1,19 @@
+#! /usr/bin/env perl
+# Copyright 2022 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+use OpenSSL::Test;
+use OpenSSL::Test::Utils;
+
+setup("test_quic_txp");
+
+plan skip_all => "QUIC protocol is not supported by this OpenSSL build"
+    if disabled('quic');
+
+plan tests => 1;
+
+ok(run(test(["quic_tserver_test"])));


### PR DESCRIPTION
This augments the QUIC CSM PR with basic server support for test purposes. This test server code is incomplete because it does not implement address validation, anti-amplification logic or retry, and is therefore not suitable for production use. However, it provides an internal endpoint we can talk to for the purposes of testing our QUIC client.

It also includes a basic in-process echo test. I expect we will want to produce a lot more tests using this framework but let's get this in first.

This builds on the CSM PR, so the new commits are:
```
QUIC Test Server: Basic echo server test
QUIC Test Server Implementation
QUIC CHANNEL: Add basic server support for testing
QUIC CHANNEL: Transport params: Offer reason text and add server support
QUIC TXP: Fix generation of CONNECTION_CLOSE
QUIC Front-End I/O API: Fix WANT_READ signalling for SSL_read
QUIC Front-End I/O API: Fix implementation of SSL_get_error
QUIC QRX: (Server support) Add support for manual URXE injection
QUIC DHS: (Server support) Add server state machine for DHS
QUIC DEMUX: (Server support) Add support for default handler
```