### PR TITLE
Add SM2 support for EVP_PKEY_Q_keygen

### DIFF
--- a/crypto/evp/evp_lib.c
+++ b/crypto/evp/evp_lib.c
@@ -1215,7 +1215,8 @@ EVP_PKEY *EVP_PKEY_Q_keygen(OSSL_LIB_CTX *libctx, const char *propq,
     } else if (OPENSSL_strcasecmp(type, "ED25519") != 0
                && OPENSSL_strcasecmp(type, "X25519") != 0
                && OPENSSL_strcasecmp(type, "ED448") != 0
-               && OPENSSL_strcasecmp(type, "X448") != 0) {
+               && OPENSSL_strcasecmp(type, "X448") != 0
+               && OPENSSL_strcasecmp(type, "SM2") != 0) {
         ERR_raise(ERR_LIB_EVP, ERR_R_PASSED_INVALID_ARGUMENT);
         goto end;
     }

--- a/doc/man3/EVP_PKEY_keygen.pod
+++ b/doc/man3/EVP_PKEY_keygen.pod
@@ -100,7 +100,7 @@ If I<type> is C<RSA>,
 a B<size_t> parameter must be given to specify the size of the RSA key.
 If I<type> is C<EC>,
 a string parameter must be given to specify the name of the EC curve.
-If I<type> is C<X25519>, C<X448>, C<ED25519>, or C<ED448>
+If I<type> is C<X25519>, C<X448>, C<ED25519>, C<ED448>, or C<SM2>
 no further parameter is needed.
 
 =head1 RETURN VALUES


### PR DESCRIPTION
There is no reason preventing this API to support SM2, which gives us a simple method to do SM2 key gen.


<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
