### PR TITLE
crypto/bio: fix build on UEFI

### DIFF
--- a/crypto/bio/b_print.c
+++ b/crypto/bio/b_print.c
@@ -13,6 +13,7 @@
 #include "crypto/ctype.h"
 #include "internal/numbers.h"
 #include <openssl/bio.h>
+#include <openssl/opensslconf.h>
 
 /*
  * Copyright Patrick Powell 1995
@@ -31,8 +32,10 @@ static int fmtstr(char **, char **, size_t *, size_t *,
                   const char *, int, int, int);
 static int fmtint(char **, char **, size_t *, size_t *,
                   int64_t, int, int, int, int);
+#ifndef OPENSSL_SYS_UEFI
 static int fmtfp(char **, char **, size_t *, size_t *,
                  LDOUBLE, int, int, int, int);
+#endif
 static int doapr_outch(char **, char **, size_t *, size_t *, int);
 static int _dopr(char **sbuffer, char **buffer,
                  size_t *maxlen, size_t *retlen, int *truncated,
@@ -88,7 +91,9 @@ _dopr(char **sbuffer,
 {
     char ch;
     int64_t value;
+#ifndef OPENSSL_SYS_UEFI
     LDOUBLE fvalue;
+#endif
     char *strvalue;
     int min;
     int max;
@@ -259,6 +264,7 @@ _dopr(char **sbuffer,
                             min, max, flags))
                     return 0;
                 break;
+#ifndef OPENSSL_SYS_UEFI
             case 'f':
                 if (cflags == DP_C_LDOUBLE)
                     fvalue = va_arg(args, LDOUBLE);
@@ -292,6 +298,16 @@ _dopr(char **sbuffer,
                            flags, G_FORMAT))
                     return 0;
                 break;
+#else
+            case 'f':
+            case 'E':
+            case 'e':
+            case 'G':
+            case 'g':
+                /* not implemented for UEFI */
+                ERR_raise(ERR_LIB_BIO, ERR_R_UNSUPPORTED);
+                return 0;
+#endif
             case 'c':
                 if (!doapr_outch(sbuffer, buffer, &currlen, maxlen,
                                  va_arg(args, int)))
@@ -511,6 +527,8 @@ fmtint(char **sbuffer,
     }
     return 1;
 }
+
+#ifndef OPENSSL_SYS_UEFI
 
 static LDOUBLE abs_val(LDOUBLE value)
 {
@@ -802,6 +820,8 @@ fmtfp(char **sbuffer,
     }
     return 1;
 }
+
+#endif /* OPENSSL_SYS_UEFI */
 
 #define BUFFER_INC  1024
 


### PR DESCRIPTION
Cherry-pick from: https://github.com/openssl/openssl/pull/17547

When compiling openssl for tianocore compiling abs_val() and pow_10()
fails with the following error because SSE support is disabled:

crypto/bio/bio_print.c:587:46: error: SSE register return with SSE disabled

Fix that by using EFIAPI calling convention when compiling for UEFI.

EDK2 not support openssl-3.0, need fix it in openssl-1.1.1 also.