### PR TITLE
Drop incorrect skipping of some evp_test testcases with no-gost

### DIFF
--- a/test/recipes/30-test_evp.t
+++ b/test/recipes/30-test_evp.t
@@ -26,7 +26,6 @@ my $no_des = disabled("des");
 my $no_dh = disabled("dh");
 my $no_dsa = disabled("dsa");
 my $no_ec = disabled("ec");
-my $no_gost = disabled("gost");
 my $no_sm2 = disabled("sm2");
 my $no_siv = disabled("siv");
 
@@ -78,7 +77,7 @@ push @files, qw(
                 evppkey_ecdsa.txt
                 evppkey_kas.txt
                 evppkey_mismatch.txt
-               ) unless $no_ec || $no_gost;
+               ) unless $no_ec;
 
 # A list of tests that only run with the default provider
 # (i.e. The algorithms are not present in the fips provider)


### PR DESCRIPTION
Not sure why it was there but certainly it is not needed. With 3.0 and above `no-gost` just disables the GOST support in libssl.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests are added or updated
