### PR TITLE
Disable atomic refcounts with `no-threads`

### DIFF
--- a/include/internal/refcount.h
+++ b/include/internal/refcount.h
@@ -13,7 +13,7 @@
 # include <openssl/e_os2.h>
 # include <openssl/trace.h>
 
-# ifndef OPENSSL_DEV_NO_ATOMICS
+# if defined(OPENSSL_THREADS) && !defined(OPENSSL_DEV_NO_ATOMICS)
 #  if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L \
       && !defined(__STDC_NO_ATOMICS__)
 #   include <stdatomic.h>


### PR DESCRIPTION
This is needed for building with `-march=i386 no-threads`, on platforms where libatomic is not available (djgpp, specifically).  The implementation now falls back to `CRYPTO_atomic_add()`, which performs plain lock-free addition in a `no-threads` build.

Needed for: #19307

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->
