### PR TITLE
Fix typos in doc/man3/EVP_EncryptInit.pod

### DIFF
--- a/doc/man3/EVP_EncryptInit.pod
+++ b/doc/man3/EVP_EncryptInit.pod
@@ -1657,9 +1657,9 @@ Encryption using AES-CBC with a 256-bit key with "CS1" ciphertext stealing.
          goto err;
 
      /* NOTE: CTS mode does not support multiple calls to EVP_CipherUpdate() */
-     if (!EVP_CipherUpdate(ctx, encrypted, &outlen, msg, msglen))
+     if (!EVP_CipherUpdate(ctx, out, &outlen, msg, msg_len))
          goto err;
-      if (!EVP_CipherFinal_ex(ctx, encrypted + outlen, &len))
+      if (!EVP_CipherFinal_ex(ctx, out + outlen, &len))
          goto err;
      ret = 1;
  err:


### PR DESCRIPTION
Fix typos in doc/man3/EVP_EncryptInit.pod
Fixes #19728 

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
