### PR TITLE
QUIC TXP: Fix missing OSSL_NELEM include (URGENT)

### DIFF
--- a/ssl/quic/quic_stream_map.c
+++ b/ssl/quic/quic_stream_map.c
@@ -8,6 +8,7 @@
 */
 
 #include "internal/quic_stream_map.h"
+#include "internal/nelem.h"
 
 /* QUIC Stream
  * ===========


### PR DESCRIPTION
The `OSSL_NELEM` changes merged recently broke the QUIC TXP PR. Since the CI had already run for QUIC TXP, this was not caught.

Urgent to fix build breakage.