### PR TITLE
`cmp_client_test.c`: add tests for `OSSL_CMP_CTX_get_status`

### DIFF
--- a/test/cmp_client_test.c
+++ b/test/cmp_client_test.c
@@ -88,24 +88,29 @@ static CMP_SES_TEST_FIXTURE *set_up(const char *const test_case_name)
     return NULL;
 }
 
-static int execute_exec_RR_ses_test(CMP_SES_TEST_FIXTURE *fixture)
+static int execute_exec_RR_ses_test(CMP_SES_TEST_FIXTURE *fixt)
 {
-    return TEST_int_eq(fixture->expected,
-                       OSSL_CMP_exec_RR_ses(fixture->cmp_ctx) == 1);
+    return TEST_int_eq(OSSL_CMP_CTX_get_status(fixt->cmp_ctx),
+                       OSSL_CMP_PKISTATUS_unspecified)
+        && TEST_int_eq(OSSL_CMP_exec_RR_ses(fixt->cmp_ctx),
+                       fixt->expected == OSSL_CMP_PKISTATUS_accepted)
+        && TEST_int_eq(OSSL_CMP_CTX_get_status(fixt->cmp_ctx), fixt->expected);
 }
 
 static int execute_exec_GENM_ses_test_single(CMP_SES_TEST_FIXTURE *fixture)
 {
+    OSSL_CMP_CTX *ctx = fixture->cmp_ctx;
     ASN1_OBJECT *type = OBJ_txt2obj("1.3.6.1.5.5.7.4.2", 1);
     OSSL_CMP_ITAV *itav = OSSL_CMP_ITAV_create(type, NULL);
     STACK_OF(OSSL_CMP_ITAV) *itavs;
 
-    OSSL_CMP_CTX_push0_genm_ITAV(fixture->cmp_ctx, itav);
+    OSSL_CMP_CTX_push0_genm_ITAV(ctx, itav);
+    itavs = OSSL_CMP_exec_GENM_ses(ctx);
 
-    if (!TEST_ptr(itavs = OSSL_CMP_exec_GENM_ses(fixture->cmp_ctx)))
-        return 0;
     sk_OSSL_CMP_ITAV_pop_free(itavs, OSSL_CMP_ITAV_free);
-    return 1;
+    return TEST_int_eq(OSSL_CMP_CTX_get_status(ctx), fixture->expected)
+        && fixture->expected == OSSL_CMP_PKISTATUS_accepted ?
+        TEST_ptr(itavs) : TEST_ptr_null(itavs);
 }
 
 static int execute_exec_GENM_ses_test(CMP_SES_TEST_FIXTURE *fixture)
@@ -117,10 +122,15 @@ static int execute_exec_GENM_ses_test(CMP_SES_TEST_FIXTURE *fixture)
 
 static int execute_exec_certrequest_ses_test(CMP_SES_TEST_FIXTURE *fixture)
 {
-    X509 *res = OSSL_CMP_exec_certreq(fixture->cmp_ctx,
-                                      fixture->req_type, NULL);
+    OSSL_CMP_CTX *ctx = fixture->cmp_ctx;
+    X509 *res = OSSL_CMP_exec_certreq(ctx, fixture->req_type, NULL);
+    int status = OSSL_CMP_CTX_get_status(ctx);
 
-    if (fixture->expected == 0)
+    if (!TEST_int_eq(status, fixture->expected)
+        && !(fixture->expected == OSSL_CMP_PKISTATUS_waiting
+             && TEST_int_eq(status, OSSL_CMP_PKISTATUS_trans)))
+        return 0;
+    if (fixture->expected != OSSL_CMP_PKISTATUS_accepted)
         return TEST_ptr_null(res);
 
     if (!TEST_ptr(res) || !TEST_int_eq(X509_cmp(res, client_cert), 0))
@@ -135,12 +145,25 @@ static int execute_exec_certrequest_ses_test(CMP_SES_TEST_FIXTURE *fixture)
     return 1;
 }
 
-static int test_exec_RR_ses(void)
+static int test_exec_RR_ses(int request_error)
 {
     SETUP_TEST_FIXTURE(CMP_SES_TEST_FIXTURE, set_up);
-    fixture->expected = 1;
+    if (request_error)
+        OSSL_CMP_CTX_set1_oldCert(fixture->cmp_ctx, NULL);
+    fixture->expected = request_error ? OSSL_CMP_PKISTATUS_request
+        : OSSL_CMP_PKISTATUS_accepted;
     EXECUTE_TEST(execute_exec_RR_ses_test, tear_down);
     return result;
+}
+
+static int test_exec_RR_ses_ok(void)
+{
+    return test_exec_RR_ses(0);
+}
+
+static int test_exec_RR_ses_request_error(void)
+{
+    return test_exec_RR_ses(1);
 }
 
 static int test_exec_RR_ses_receive_error(void)
@@ -151,7 +174,7 @@ static int test_exec_RR_ses_receive_error(void)
                                      OSSL_CMP_CTX_FAILINFO_signerNotTrusted,
                                      "test string");
     ossl_cmp_mock_srv_set_send_error(fixture->srv_ctx, 1);
-    fixture->expected = 0;
+    fixture->expected = OSSL_CMP_PKISTATUS_rejection;
     EXECUTE_TEST(execute_exec_RR_ses_test, tear_down);
     return result;
 }
@@ -160,7 +183,7 @@ static int test_exec_IR_ses(void)
 {
     SETUP_TEST_FIXTURE(CMP_SES_TEST_FIXTURE, set_up);
     fixture->req_type = OSSL_CMP_IR;
-    fixture->expected = 1;
+    fixture->expected = OSSL_CMP_PKISTATUS_accepted;
     fixture->caPubs = sk_X509_new_null();
     sk_X509_push(fixture->caPubs, server_cert);
     sk_X509_push(fixture->caPubs, server_cert);
@@ -169,61 +192,81 @@ static int test_exec_IR_ses(void)
     return result;
 }
 
-static const int checkAfter = 1;
-static int test_exec_IR_ses_poll(void)
+static int test_exec_IR_ses_poll(int check_after, int poll_count,
+                                 int total_timeout, int expect)
 {
     SETUP_TEST_FIXTURE(CMP_SES_TEST_FIXTURE, set_up);
     fixture->req_type = OSSL_CMP_IR;
-    fixture->expected = 1;
-    ossl_cmp_mock_srv_set_pollCount(fixture->srv_ctx, 2);
-    ossl_cmp_mock_srv_set_checkAfterTime(fixture->srv_ctx, checkAfter);
+    fixture->expected = expect;
+    ossl_cmp_mock_srv_set_checkAfterTime(fixture->srv_ctx, check_after);
+    ossl_cmp_mock_srv_set_pollCount(fixture->srv_ctx, poll_count);
+    OSSL_CMP_CTX_set_option(fixture->cmp_ctx,
+                            OSSL_CMP_OPT_TOTAL_TIMEOUT, total_timeout);
     EXECUTE_TEST(execute_exec_certrequest_ses_test, tear_down);
     return result;
 }
 
-static int test_exec_IR_ses_poll_timeout(void)
+static int checkAfter = 1;
+static int test_exec_IR_ses_poll_ok(void)
 {
-    const int pollCount = 3;
-    const int tout = pollCount * checkAfter;
-
-    SETUP_TEST_FIXTURE(CMP_SES_TEST_FIXTURE, set_up);
-    fixture->req_type = OSSL_CMP_IR;
-    fixture->expected = 0;
-    ossl_cmp_mock_srv_set_pollCount(fixture->srv_ctx, pollCount + 1);
-    ossl_cmp_mock_srv_set_checkAfterTime(fixture->srv_ctx, checkAfter);
-    OSSL_CMP_CTX_set_option(fixture->cmp_ctx, OSSL_CMP_OPT_TOTAL_TIMEOUT, tout);
-    EXECUTE_TEST(execute_exec_certrequest_ses_test, tear_down);
-    return result;
+    return test_exec_IR_ses_poll(checkAfter, 2, 0, OSSL_CMP_PKISTATUS_accepted);
 }
 
-static int test_exec_CR_ses(void)
+static int test_exec_IR_ses_poll_no_timeout(void)
+{
+    return test_exec_IR_ses_poll(checkAfter, 1 /* pollCount */, checkAfter + 1,
+                                 OSSL_CMP_PKISTATUS_accepted);
+}
+
+static int test_exec_IR_ses_poll_total_timeout(void)
+{
+    return test_exec_IR_ses_poll(checkAfter + 1, 2 /* pollCount */, checkAfter,
+                                 OSSL_CMP_PKISTATUS_waiting);
+}
+
+static int test_exec_CR_ses(int implicit_confirm, int granted)
 {
     SETUP_TEST_FIXTURE(CMP_SES_TEST_FIXTURE, set_up);
     fixture->req_type = OSSL_CMP_CR;
-    fixture->expected = 1;
+    fixture->expected = OSSL_CMP_PKISTATUS_accepted;
+    OSSL_CMP_CTX_set_option(fixture->cmp_ctx,
+                            OSSL_CMP_OPT_IMPLICIT_CONFIRM, implicit_confirm);
+    OSSL_CMP_SRV_CTX_set_grant_implicit_confirm(fixture->srv_ctx, granted);
     EXECUTE_TEST(execute_exec_certrequest_ses_test, tear_down);
     return result;
+}
+
+static int test_exec_CR_ses_explicit_confirm(void)
+{
+    return test_exec_CR_ses(0, 0);
 }
 
 static int test_exec_CR_ses_implicit_confirm(void)
 {
+    return test_exec_CR_ses(1, 0)
+        && test_exec_CR_ses(1, 1);
+}
+
+static int test_exec_KUR_ses(int transfer_error)
+{
     SETUP_TEST_FIXTURE(CMP_SES_TEST_FIXTURE, set_up);
-    fixture->req_type = OSSL_CMP_CR;
-    fixture->expected = 1;
-    OSSL_CMP_CTX_set_option(fixture->cmp_ctx,
-                            OSSL_CMP_OPT_IMPLICIT_CONFIRM, 1);
-    OSSL_CMP_SRV_CTX_set_grant_implicit_confirm(fixture->srv_ctx, 1);
+    fixture->req_type = OSSL_CMP_KUR;
+    if (transfer_error)
+        OSSL_CMP_CTX_set_transfer_cb_arg(fixture->cmp_ctx, NULL);
+    fixture->expected = transfer_error ? OSSL_CMP_PKISTATUS_trans
+        : OSSL_CMP_PKISTATUS_accepted;
     EXECUTE_TEST(execute_exec_certrequest_ses_test, tear_down);
     return result;
 }
 
-static int test_exec_KUR_ses(void)
+static int test_exec_KUR_ses_ok(void)
 {
-    SETUP_TEST_FIXTURE(CMP_SES_TEST_FIXTURE, set_up);
-    fixture->req_type = OSSL_CMP_KUR;
-    fixture->expected = 1;
-    EXECUTE_TEST(execute_exec_certrequest_ses_test, tear_down);
-    return result;
+    return test_exec_KUR_ses(0);
+}
+
+static int test_exec_KUR_ses_transfer_error(void)
+{
+    return test_exec_KUR_ses(1);
 }
 
 static int test_exec_P10CR_ses(void)
@@ -232,7 +275,7 @@ static int test_exec_P10CR_ses(void)
 
     SETUP_TEST_FIXTURE(CMP_SES_TEST_FIXTURE, set_up);
     fixture->req_type = OSSL_CMP_P10CR;
-    fixture->expected = 1;
+    fixture->expected = OSSL_CMP_PKISTATUS_accepted;
     if (!TEST_ptr(req = load_csr_der(pkcs10_f, libctx))
             || !TEST_true(OSSL_CMP_CTX_set1_p10CSR(fixture->cmp_ctx, req))) {
         tear_down(fixture);
@@ -297,11 +340,25 @@ static int test_try_certreq_poll_abort(void)
     return result;
 }
 
-static int test_exec_GENM_ses(void)
+static int test_exec_GENM_ses(int transfer_error)
 {
     SETUP_TEST_FIXTURE(CMP_SES_TEST_FIXTURE, set_up);
+    if (transfer_error)
+        OSSL_CMP_CTX_set_transfer_cb_arg(fixture->cmp_ctx, NULL);
+    fixture->expected = transfer_error ? OSSL_CMP_PKISTATUS_trans
+        : OSSL_CMP_PKISTATUS_accepted;
     EXECUTE_TEST(execute_exec_GENM_ses_test, tear_down);
     return result;
+}
+
+static int test_exec_GENM_ses_ok(void)
+{
+    return test_exec_GENM_ses(0);
+}
+
+static int test_exec_GENM_ses_error(void)
+{
+    return test_exec_GENM_ses(1);
 }
 
 static int execute_exchange_certConf_test(CMP_SES_TEST_FIXTURE *fixture)
@@ -386,18 +443,22 @@ int setup_tests(void)
         return 0;
     }
 
-    ADD_TEST(test_exec_RR_ses);
+    ADD_TEST(test_exec_RR_ses_ok);
+    ADD_TEST(test_exec_RR_ses_request_error);
     ADD_TEST(test_exec_RR_ses_receive_error);
-    ADD_TEST(test_exec_CR_ses);
+    ADD_TEST(test_exec_CR_ses_explicit_confirm);
     ADD_TEST(test_exec_CR_ses_implicit_confirm);
     ADD_TEST(test_exec_IR_ses);
-    ADD_TEST(test_exec_IR_ses_poll);
-    ADD_TEST(test_exec_IR_ses_poll_timeout);
-    ADD_TEST(test_exec_KUR_ses);
+    ADD_TEST(test_exec_IR_ses_poll_ok);
+    ADD_TEST(test_exec_IR_ses_poll_no_timeout);
+    ADD_TEST(test_exec_IR_ses_poll_total_timeout);
+    ADD_TEST(test_exec_KUR_ses_ok);
+    ADD_TEST(test_exec_KUR_ses_transfer_error);
     ADD_TEST(test_exec_P10CR_ses);
     ADD_TEST(test_try_certreq_poll);
     ADD_TEST(test_try_certreq_poll_abort);
-    ADD_TEST(test_exec_GENM_ses);
+    ADD_TEST(test_exec_GENM_ses_ok);
+    ADD_TEST(test_exec_GENM_ses_error);
     ADD_TEST(test_exchange_certConf);
     ADD_TEST(test_exchange_error);
     return 1;


### PR DESCRIPTION
This is a follow-up of #19205, adding test cases as requested.

