### PR TITLE
Fix accumulated index comments in felem_inv for p521

### DIFF
--- a/crypto/ec/ecp_nistp521.c
+++ b/crypto/ec/ecp_nistp521.c
@@ -843,9 +843,9 @@ static void felem_inv(felem out, const felem in)
         felem_reduce(ftmp3, tmp); /* 2^521 - 2^9 */
     }
     felem_mul(tmp, ftmp3, ftmp4);
-    felem_reduce(ftmp3, tmp);   /* 2^512 - 2^2 */
+    felem_reduce(ftmp3, tmp);   /* 2^521 - 2^2 */
     felem_mul(tmp, ftmp3, in);
-    felem_reduce(out, tmp);     /* 2^512 - 3 */
+    felem_reduce(out, tmp);     /* 2^521 - 3 */
 }
 
 /* This is 2^521-1, expressed as an felem */


### PR DESCRIPTION
Comments in felem_inv refer to the logarithm with respect to in of the element that has just been computed. The last two such annotations are incorrect. By Fermat's last theorem, we hope to compute in^(p-2) in GF(2^521-1), as such we expect the final index we reach to be 2^521-3.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->
