### PR TITLE
Remove redundant assignment in felem_mul_ref in p521

### DIFF
--- a/crypto/ec/ecp_nistp521.c
+++ b/crypto/ec/ecp_nistp521.c
@@ -782,7 +782,6 @@ static void felem_inv(felem out, const felem in)
     felem_reduce(ftmp3, tmp);   /* 2^7 - 2^3 */
     felem_square(tmp, ftmp3);
     felem_reduce(ftmp3, tmp);   /* 2^8 - 2^4 */
-    felem_assign(ftmp4, ftmp3);
     felem_mul(tmp, ftmp3, ftmp);
     felem_reduce(ftmp4, tmp);   /* 2^8 - 2^1 */
     felem_square(tmp, ftmp4);


### PR DESCRIPTION
ftmp4 is assigned immediately before receiving the reduced output of the multiplication of ftmp and ftmp3, without being read inbetween these assignments. Remove redundant assignment.