### PR TITLE
QUIC API Overview Design Document

### DIFF
--- a/doc/designs/quic-design/quic-api-ssl-funcs.md
+++ b/doc/designs/quic-design/quic-api-ssl-funcs.md
@@ -87,6 +87,9 @@ Notes:
 - †9: QUIC always uses AES-128-GCM initially. We need to determine when and
   what ciphers we report as being in use.
 - †10: Not supporting async for now.
+- †11: Since these functions only configure cipher suite lists used for TLSv1.2,
+  which is never used for QUIC, they do not require changes, and we can allow
+  applications to configure these lists freely, as they will be ignored.
 
 | API Item | Cat. | Sema. | Appl. | Impl. Req. | Status |
 |----------|----------|-----------|---------------|----------------|--------|
@@ -140,7 +143,7 @@ Notes:
 | `SSL_CTX_up_ref` | Object | 🟩U | 🟩A | 🟩NC | 🟢Done |
 | `SSL_CTX_free` | Object | 🟩U | 🟩A | 🟩NC | 🟢Done |
 | `SSL_new` | Object | 🟩U | 🟩A | 🟧QSI | 🟢Done |
-| `SSL_dup` | Object | 🟩U | 🟩A | 🟧QSI | 🟠Design TBD |
+| `SSL_dup` | Object | 🟩U | 🟩A | 🟥FC | 🟢Done |
 | `SSL_up_ref` | Object | 🟩U | 🟩A | 🟩NC | 🟢Done |
 | `SSL_free` | Object | 🟩U | 🟩A | 🟧QSI | 🟢Done |
 | `SSL_is_dtls` | Object | 🟩U | 🟩A | 🟩NC | 🟢Done |
@@ -153,28 +156,27 @@ Notes:
 | **⇒ Method Manipulation** | |
 | `SSL_CTX_get_ssl_method` | Object | 🟩U | 🟩A | 🟩NC | 🟢Done |
 | `SSL_get_ssl_method` | Object | 🟩U | 🟩A | 🟩NC | 🟢Done |
-| `SSL_CTX_set_ssl_method` | Object | 🟥TBD | 🟩A | 🟧QSI | 🟠Design TBD |
-| `SSL_set_ssl_method` | Object | 🟥TBD | 🟩A | 🟧QSI | 🟠Design TBD |
+| `SSL_set_ssl_method` | Object | 🟥TBD | 🟩A | 🟧QSI | 🟢Done |
 | **⇒ SRTP** | |
-| `SSL_get_selected_srtp_profile` | HL | 🟩U | 🟥FC | 🟨C\* | 🟡TODO |
-| `SSL_get_srtp_profiles` | HL | 🟩U | 🟥FC | 🟨C\* | 🟡TODO |
-| `SSL_CTX_set_tlsext_use_srtp` | HL | 🟩U | 🟥FC | 🟨C\* | 🟡TODO |
-| `SSL_set_tlsext_use_srtp` | HL | 🟩U | 🟥FC | 🟨C\* | 🟡TODO |
+| `SSL_get_selected_srtp_profile` | HL | 🟩U | 🟧NO | 🟨C\* | 🟢Done |
+| `SSL_get_srtp_profiles` | HL | 🟩U | 🟧NO | 🟨C\* | 🟢Done |
+| `SSL_CTX_set_tlsext_use_srtp` | HL | 🟩U | 🟥FC | 🟨C\* | 🟢Done |
+| `SSL_set_tlsext_use_srtp` | HL | 🟩U | 🟥FC | 🟩NC\* | 🟢Done |
 | **⇒ Ciphersuite Configuration** | |
-| `SSL_CTX_set_cipher_list` | HL | 🟩U | 🟩A | 🟨C\* †1 | 🟡TODO |
-| `SSL_CTX_set_ciphersuites` | HL | 🟩U | 🟩A | 🟨C\* †1 | 🟡TODO |
-| `SSL_CTX_get_ciphers` | HL | 🟩U | 🟩A | 🟨C\* †1 | 🟡TODO |
-| `SSL_set_ciphersuites` | HL | 🟩U | 🟩A | 🟨C\* †1 | 🟡TODO |
-| `SSL_get1_supported_ciphers` | HL | 🟩U | 🟩A | 🟨C\* †1 | 🟡TODO |
-| `SSL_bytes_to_cipher_list` | HL | 🟩U | 🟩A | 🟨C\* †1 | 🟡TODO |
-| `SSL_get_ciphers` | HL | 🟩U | 🟩A | 🟨C\* †1 | 🟡TODO |
-| `SSL_get_cipher_list` | HL | 🟩U | 🟩A | 🟨C\* †1 | 🟡TODO |
-| `SSL_set_cipher_list` | HL | 🟩U | 🟩A | 🟨C\* †1 | 🟡TODO |
+| `SSL_CTX_set_cipher_list` | HL | 🟩U | 🟩A | 🟩NC\* †11 | 🟢Done |
+| `SSL_CTX_set_ciphersuites` | HL | 🟩U | 🟩A | 🟨C\* †1 | 🟢Done |
+| `SSL_CTX_get_ciphers` | HL | 🟩U | 🟩A |🟩NC\* | 🟢Done |
+| `SSL_set_ciphersuites` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_get1_supported_ciphers` | HL | 🟩U | 🟩A | 🟨C\* †1 | 🟢Done |
+| `SSL_bytes_to_cipher_list` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_get_ciphers` | HL | 🟩U | 🟩A |  🟩NC\* | 🟢Done |
+| `SSL_get_cipher_list` | HL | 🟩U | 🟩A | 🟩NC\* †11 | 🟢Done |
+| `SSL_set_cipher_list` | HL | 🟩U | 🟩A | 🟩NC\* †11 | 🟢Done |
 | **⇒ Negotiated Ciphersuite Queries** | |
-| `SSL_get_current_cipher` | HL | 🟩U | 🟩A | 🟨C\* †9 | 🟠Design TBD |
-| `SSL_get_pending_cipher` | HL | 🟩U | 🟩A | 🟨C\* †9 | 🟠Design TBD |
-| `SSL_get_shared_ciphers` | HL | 🟩U | 🟩A | 🟨C\* †9 | 🟠Design TBD |
-| `SSL_get_client_ciphers` | HL | 🟩U | 🟩A | 🟨C\* †9 | 🟠Design TBD |
+| `SSL_get_current_cipher` | HL | 🟩U | 🟩A |🟩NC\* †9 | 🟢Done |
+| `SSL_get_pending_cipher` | HL | 🟩U | 🟩A | 🟩NC\* †9 | 🟢Done |
+| `SSL_get_shared_ciphers` | HL | 🟩U | 🟩A | 🟩NC\* †9 | 🟢Done |
+| `SSL_get_client_ciphers` | HL | 🟩U | 🟩A | 🟩NC\* †9 | 🟢Done |
 | `SSL_get_current_compression` | HL | 🟩U | 🟩A | 🟩HLNC | 🟢Done |
 | `SSL_get_current_expansion` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
 | `SSL_get_shared_sigalgs` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
@@ -191,9 +193,9 @@ Notes:
 | `SSL_get0_alpn_selected` | HL | 🟩U | 🟩A | 🟨C\* †2 | 🟡TODO |
 | `SSL_CTX_set_alpn_protos` | HL | 🟩U | 🟩A | 🟨C\* †2 | 🟡TODO |
 | **⇒ NPN** | †3 |
-| `SSL_CTX_set_next_proto_select_cb` | HL | 🟩U | 🟥FC | 🟨C\* †3 | 🟡TODO |
-| `SSL_CTX_set_next_protos_advertised_cb` | HL | 🟩U | 🟥FC | 🟨C\* †3 | 🟡TODO |
-| `SSL_get0_next_proto_negotiated` | HL | 🟩U | 🟥FC | 🟨C\* †3 | 🟡TODO |
+| `SSL_CTX_set_next_proto_select_cb` | HL | 🟩U | 🟥FC | 🟨C\* †3 | 🟢Done |
+| `SSL_CTX_set_next_protos_advertised_cb` | HL | 🟩U | 🟥FC | 🟨C\* †3 | 🟢Done |
+| `SSL_get0_next_proto_negotiated` | HL | 🟩U | 🟥FC | 🟩NC\* †3 | 🟢Done |
 | **⇒ Narrow Waist Interface** | †4 |
 | `SSL_CTX_ctrl` | Object | 🟩U | 🟩A | 🟩NC\* †4 | 🟢Done |
 | `SSL_ctrl` | Object | 🟩U | 🟩A | 🟩NC\* †4 | 🟢Done |
@@ -394,11 +396,11 @@ Notes:
 | `SSL_renegotiate_abbreviated` | HL | 🟩U | 🟥FC | 🟩NC\* †5 | 🟢Done |
 | `SSL_renegotiate_pending` | HL | 🟩U | 🟧NO | 🟩NC\* †5 | 🟢Done |
 | **⇒ Options** | |
-| `SSL_CTX_clear_options` | HL | 🟩U | 🟩A | 🟨C\* | 🟠Design TBD |
-| `SSL_CTX_set_options` | HL | 🟩U | 🟩A | 🟨C\* | 🟠Design TBD |
+| `SSL_CTX_clear_options` | HL | 🟩U | 🟩A | 🟨C\* | 🟢Done |
+| `SSL_CTX_set_options` | HL | 🟩U | 🟩A | 🟨C\* | 🟢Done |
 | `SSL_CTX_get_options` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
-| `SSL_clear_options` | HL | 🟩U | 🟩A | 🟨C\* | 🟠Design TBD |
-| `SSL_set_options` | HL | 🟩U | 🟩A | 🟨C\* | 🟠Design TBD |
+| `SSL_clear_options` | HL | 🟩U | 🟩A | 🟨C\* | 🟢Done |
+| `SSL_set_options` | HL | 🟩U | 🟩A | 🟨C\* | 🟢Done |
 | `SSL_get_options` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
 | **⇒ Configuration** | |
 | `SSL_CONF_CTX_new` | Global | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
@@ -519,7 +521,7 @@ Notes:
 | `SSL_set_num_tickets` | HL | 🟩U | 🟩A | 🟩NC\* †7 | 🟢Done |
 | `SSL_CTX_get_num_tickets` | HL | 🟩U | 🟩A | 🟩NC\* †7 | 🟢Done |
 | `SSL_CTX_set_num_tickets` | HL | 🟩U | 🟩A | 🟩NC\* †7 | 🟢Done |
-| `SSL_new_session_ticket` | HL | 🟩U | 🟩A | 🟨C\* | 🟡TODO |
+| `SSL_new_session_ticket` | HL | 🟩U | 🟩A | 🟩NC\* †7 | 🟢Done |
 | `SSL_set_session_ticket_ext` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
 | `SSL_set_session_ticket_ext_cb` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
 | `SSL_CTX_set_tlsext_ticket_key_evp_cb` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
@@ -559,9 +561,9 @@ Notes:
 | `SSL_CTX_use_serverinfo_ex` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
 | `SSL_CTX_use_serverinfo_file` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
 | **⇒ Post-Handshake Authentication** | |
-| `SSL_verify_client_post_handshake` | HL | 🟩U | 🟥FC | 🟨C* †8 | 🟡TODO |
-| `SSL_CTX_set_post_handshake_auth` | HL | 🟩U | 🟥FC | 🟨C* †8 | 🟡TODO |
-| `SSL_set_post_handshake_auth` | HL | 🟩U | 🟥FC | 🟨C* †8 | 🟡TODO |
+| `SSL_verify_client_post_handshake` | HL | 🟩U | 🟥FC | 🟨C* †8 | 🟢Done |
+| `SSL_CTX_set_post_handshake_auth` | HL | 🟩U | 🟥FC | 🟨C* †8 | 🟢Done |
+| `SSL_set_post_handshake_auth` | HL | 🟩U | 🟥FC | 🟨C* †8 | 🟢Done |
 | **⇒ DH Parameters** | |
 | `SSL_CTX_set_dh_auto` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
 | `SSL_set_dh_auto` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
@@ -576,23 +578,23 @@ Notes:
 | `SSL_in_before` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
 | `SSL_is_init_finished` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
 | `SSL_get_state` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
-| `SSL_rstate_string` | HL | 🟩U | 🟩A | 🟧QSI | 🟠Design TBD |
-| `SSL_rstate_string_long` | HL | 🟩U | 🟩A | 🟧QSI | 🟠Design TBD |
-| `SSL_state_string` | HL | 🟩U | 🟩A | 🟧QSI | 🟠Design TBD |
-| `SSL_state_string_long` | HL | 🟩U | 🟩A | 🟧QSI | 🟠Design TBD |
+| `SSL_rstate_string` | HL | 🟩U | 🟩A | 🟧QSI | 🟢Done |
+| `SSL_rstate_string_long` | HL | 🟩U | 🟩A | 🟧QSI | 🟢Done |
+| `SSL_state_string` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_state_string_long` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
 | **⇒ Data Path and CSSM** | |
 | `SSL_set_connect_state` | CSSM | 🟩U | 🟩A | 🟧QSI | 🟢Done |
 | `SSL_set_accept_state` | CSSM | 🟩U | 🟩A | 🟧QSI | 🟢Done |
-| `SSL_is_server` | CSSM | 🟩U | 🟩A | 🟧QSI | 🟡TODO |
+| `SSL_is_server` | CSSM | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
 | `SSL_peek` | ADP | 🟩U | 🟩A | 🟧QSI | 🟢Done |
 | `SSL_peek_ex` | ADP | 🟩U | 🟩A | 🟧QSI | 🟢Done |
 | `SSL_read` | ADP | 🟩U | 🟩A | 🟧QSI | 🟢Done |
 | `SSL_read_ex` | ADP | 🟩U | 🟩A | 🟧QSI | 🟢Done |
 | `SSL_write` | ADP | 🟩U | 🟩A | 🟧QSI | 🟢Done |
 | `SSL_write_ex` | ADP | 🟩U | 🟩A | 🟧QSI | 🟢Done |
-| `SSL_sendfile` | ADP | 🟩U | 🟩A | 🟧QSI | 🟠Design TBD |
-| `SSL_pending` | ADP | 🟩U | 🟩A | 🟧QSI | 🟠Design TBD |
-| `SSL_has_pending` | ADP | TBD | 🟩A | 🟧QSI | 🟠Design TBD |
+| `SSL_sendfile` | ADP | 🟩U | 🟥FC | 🟩NC\* | 🟢Done |
+| `SSL_pending` | ADP | 🟩U | 🟩A | 🟧QSI | 🟢Done |
+| `SSL_has_pending` | ADP | TBD | 🟩A | 🟧QSI | 🟢Done |
 | `SSL_accept` | CSSM | 🟩U | 🟩A | 🟧QSI | 🟢Done |
 | `SSL_connect` | CSSM | 🟩U | 🟩A | 🟧QSI | 🟢Done |
 | `SSL_do_handshake` | CSSM | 🟩U | 🟩A | 🟧QSI | 🟢Done |
@@ -605,15 +607,15 @@ Notes:
 | `SSL_get_rfd` | NDP | 🟩U | 🟩A | 🟩NC | 🟢Done |
 | `SSL_get_wfd` | NDP | 🟩U | 🟩A | 🟩NC | 🟢Done |
 | `SSL_get_fd` | NDP | 🟩U | 🟩A | 🟩NC | 🟢Done |
-| `SSL_set_rfd` | NDP | 🟧C | 🟩A | 🟧QSI | 🟡TODO |
-| `SSL_set_wfd` | NDP | 🟧C | 🟩A | 🟧QSI | 🟡TODO |
-| `SSL_set_fd` | NDP | 🟩U | 🟩A | 🟧QSI | 🟡TODO |
-| `SSL_key_update` | RL | 🟩U | 🟩A | 🟧QSI | 🟠Design TBD |
-| `SSL_get_key_update_type` | RL | 🟩U | 🟩A | 🟧QSI | 🟠Design TBD |
-| `SSL_clear`  (connection) | CSSM | TBD | 🟩A | 🟧QSI | 🟡TODO |
+| `SSL_set_rfd` | NDP | 🟧C | 🟩A | 🟧QSI | 🟢Done |
+| `SSL_set_wfd` | NDP | 🟧C | 🟩A | 🟧QSI | 🟢Done |
+| `SSL_set_fd` | NDP | 🟩U | 🟩A | 🟧QSI | 🟢Done |
+| `SSL_key_update` | RL | 🟩U | 🟩A | 🟧QSI | 🟢Done |
+| `SSL_get_key_update_type` | RL | 🟩U | 🟩A | 🟧QSI | 🟢Done |
+| `SSL_clear`  (connection) | CSSM | TBD | 🟩A | 🟥FC | 🟢Done |
 | `SSL_clear`  (stream) | CSSM | TBD | 🟩A | 🟧QSI | 🟠Design TBD |
 | `SSL_shutdown` | CSSM | 🟧C | 🟩A | 🟧QSI | 🟡TODO |
-| `SSL_want` | ADP | 🟧C | 🟩A | 🟧QSI | 🟡TODO |
+| `SSL_want` | ADP | 🟧C | 🟩A | 🟧QSI | 🟢Done |
 | `BIO_new_ssl_connect` | Global | 🟩U | 🟩A | 🟧QSI | 🟡TODO |
 | `BIO_new_buffer_ssl_connect` | Global | 🟩U | 🟦U | 🟧QSI | 🟡TODO |
 | `SSL_get_shutdown` | CSSM | 🟩U | 🟩A | 🟧QSI | 🟠Design TBD |
@@ -635,14 +637,25 @@ Notes:
 | `SSL_get_stream_state` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟡TODO |
 | `SSL_get_stream_error_code` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟡TODO |
 | `SSL_get_conn_close_info` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟡TODO |
+| **⇒ New APIs for Multi-Stream** | |
+| `SSL_get0_connection` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟡TODO |
+| `SSL_is_connection` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟡TODO |
+| `SSL_get_stream_id` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟡TODO |
+| `SSL_get_stream_type` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟡TODO |
+| `SSL_new_stream` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟡TODO |
+| `SSL_accept_stream` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟡TODO |
+| `SSL_get_accept_stream_queue_len` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟡TODO |
+| `SSL_set_default_stream_type` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟡TODO |
+| `SSL_detach_stream` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟡TODO |
+| `SSL_attach_stream` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟡TODO |
 | **⇒ Currently Not Supported** | |
-| `SSL_copy_session_id` | Special | 🟩U | 🟥FC | 🟨C* | 🟡TODO |
-| `BIO_ssl_copy_session_id` | Special | 🟩U | 🟥FC | 🟨C* | 🟡TODO |
-| `SSL_CTX_set_quiet_shutdown` | CSSM | 🟩U | 🟥FC | 🟨C* | 🟡TODO |
-| `SSL_CTX_get_quiet_shutdown` | CSSM | 🟩U | 🟧NO | 🟨C* | 🟡TODO |
-| `SSL_set_quiet_shutdown` | CSSM | 🟩U | 🟥FC | 🟨C* | 🟡TODO |
-| `SSL_get_quiet_shutdown` | CSSM | 🟩U | 🟧NO | 🟨C* | 🟡TODO |
-| `SSL_CTX_set_ssl_version` | HL | 🟩U | 🟥FC | 🟨C* | 🟡TODO |
+| `SSL_copy_session_id` | Special | 🟩U | 🟥FC | 🟨C* | 🟢Done |
+| `BIO_ssl_copy_session_id` | Special | 🟩U | 🟥FC | 🟨C* | 🟢Done |
+| `SSL_CTX_set_quiet_shutdown` | CSSM | 🟩U | 🟦U | 🟩NC | 🟢Done |
+| `SSL_CTX_get_quiet_shutdown` | CSSM | 🟩U | 🟦U | 🟩NC | 🟢Done |
+| `SSL_set_quiet_shutdown` | CSSM | 🟩U | 🟥FC | 🟨C | 🟢Done |
+| `SSL_get_quiet_shutdown` | CSSM | 🟩U | 🟧NO | 🟨C | 🟢Done |
+| `SSL_CTX_set_ssl_version` | HL | 🟩U | 🟥FC | 🟨C | 🟢Done |
 | **⇒ Async** | |
 | `SSL_CTX_set_async_callback` | Async | 🟩U | 🟧NO | 🟩NC* †10 | 🟢Done |
 | `SSL_set_async_callback` | Async | 🟩U | 🟧NO | 🟩NC* †10 | 🟢Done |
@@ -653,67 +666,67 @@ Notes:
 | `SSL_get_all_async_fds` | Async | 🟩U | 🟧NO | 🟩NC* †10 | 🟢Done |
 | `SSL_get_changed_async_fds` | Async | 🟩U | 🟧NO | 🟩NC* †10 | 🟢Done |
 | **⇒ Readahead** | |
-| `SSL_CTX_get_default_read_ahead` | RL | 🟩U | 🟧NO | 🟨C* | 🟡TODO |
-| `SSL_CTX_get_read_ahead` | RL | 🟩U | 🟧NO | 🟨C* | 🟡TODO |
-| `SSL_CTX_set_read_ahead` | RL | 🟩U | 🟧NO | 🟨C* | 🟡TODO |
-| `SSL_get_read_ahead` | RL | 🟩U | 🟧NO | 🟨C* | 🟡TODO |
-| `SSL_set_read_ahead` | RL | 🟩U | 🟧NO | 🟨C* | 🟡TODO |
-| `SSL_CTX_set_default_read_buffer_len` | RL | 🟩U | 🟧NO | 🟨C* | 🟡TODO |
-| `SSL_set_default_read_buffer_len` | RL | 🟩U | 🟧NO | 🟨C* | 🟡TODO |
+| `SSL_CTX_get_default_read_ahead` | RL | 🟩U | 🟧NO | 🟩NC* | 🟢Done |
+| `SSL_CTX_get_read_ahead` | RL | 🟩U | 🟧NO | 🟩NC* |🟢Done  |
+| `SSL_CTX_set_read_ahead` | RL | 🟩U | 🟧NO | 🟨C* |🟢Done  |
+| `SSL_get_read_ahead` | RL | 🟩U | 🟧NO | 🟨C* |🟢Done |
+| `SSL_set_read_ahead` | RL | 🟩U | 🟧NO | 🟨C* | 🟢Done |
+| `SSL_CTX_set_default_read_buffer_len` | RL | 🟩U | 🟧NO | 🟩NC* | 🟢Done |
+| `SSL_set_default_read_buffer_len` | RL | 🟩U | 🟧NO | 🟨C* | 🟢Done |
 | **⇒ Record Padding and Fragmentation** | |
-| `SSL_CTX_set_record_padding_callback` | RL | 🟩U | 🟥FC | 🟨C* | 🟡TODO |
-| `SSL_set_record_padding_callback` | RL | 🟩U | 🟥FC | 🟨C* | 🟡TODO |
-| `SSL_CTX_get_record_padding_callback_arg` | RL | 🟩U | 🟥FC | 🟨C* | 🟡TODO |
-| `SSL_CTX_set_record_padding_callback_arg` | RL | 🟩U | 🟥FC | 🟨C* | 🟡TODO |
-| `SSL_get_record_padding_callback_arg` | RL | 🟩U | 🟥FC | 🟨C* | 🟡TODO |
-| `SSL_set_record_padding_callback_arg` | RL | 🟩U | 🟥FC | 🟨C* | 🟡TODO |
-| `SSL_CTX_set_block_padding` | RL | 🟩U | 🟥FC | 🟨C* | 🟡TODO |
-| `SSL_set_block_padding` | RL | 🟩U | 🟥FC | 🟨C* | 🟡TODO |
-| `SSL_CTX_set_tlsext_max_fragment_length` | RL | 🟩U | 🟥FC | 🟨C* | 🟡TODO |
-| `SSL_set_tlsext_max_fragment_length` | RL | 🟩U | 🟥FC | 🟨C* | 🟡TODO |
+| `SSL_CTX_set_record_padding_callback` | RL | 🟩U | 🟥FC | 🟩NC* | 🟢Done |
+| `SSL_set_record_padding_callback` | RL | 🟩U | 🟥FC | 🟨C* | 🟢Done |
+| `SSL_CTX_get_record_padding_callback_arg` | RL | 🟩U | 🟥FC | 🟩NC* | 🟢Done |
+| `SSL_CTX_set_record_padding_callback_arg` | RL | 🟩U | 🟥FC | 🟩NC* | 🟢Done |
+| `SSL_get_record_padding_callback_arg` | RL | 🟩U | 🟥FC | 🟩NC* | 🟢Done |
+| `SSL_set_record_padding_callback_arg` | RL | 🟩U | 🟥FC |🟩NC* | 🟢Done |
+| `SSL_CTX_set_block_padding` | RL | 🟩U | 🟥FC | 🟩NC* | 🟢Done |
+| `SSL_set_block_padding` | RL | 🟩U | 🟥FC | 🟨C* | 🟢Done |
+| `SSL_CTX_set_tlsext_max_fragment_length` | RL | 🟩U | 🟥FC | 🟩NC* | 🟢Done |
+| `SSL_set_tlsext_max_fragment_length` | RL | 🟩U | 🟥FC | 🟨C* | 🟢Done |
 | **⇒ Stateless/HelloRetryRequest** | |
-| `SSL_stateless` | RL | 🟩U | 🟥FC | 🟨C* | 🟡TODO |
-| `SSL_CTX_set_stateless_cookie_generate_cb` | RL | 🟩U | 🟥FC | 🟨C* | 🟡TODO |
-| `SSL_CTX_set_stateless_cookie_verify_cb` | RL | 🟩U | 🟥FC | 🟨C* | 🟡TODO |
+| `SSL_stateless` | RL | 🟩U | 🟥FC | 🟨C* | 🟢Done |
+| `SSL_CTX_set_stateless_cookie_generate_cb` | RL | 🟩U | 🟥FC | 🟩NC* | 🟢Done |
+| `SSL_CTX_set_stateless_cookie_verify_cb` | RL | 🟩U | 🟥FC | 🟩NC* | 🟢Done |
 | **⇒ Early Data/0-RTT** | |
-| `SSL_CTX_set_allow_early_data_cb` | 0-RTT | 🟩U | 🟥FC | 🟨C* | 🟡TODO |
-| `SSL_set_allow_early_data_cb` | 0-RTT | 🟩U | 🟥FC | 🟨C* | 🟡TODO |
-| `SSL_CTX_get_recv_max_early_data` | 0-RTT | 🟩U | 🟥FC | 🟨C* | 🟡TODO |
-| `SSL_CTX_set_recv_max_early_data` | 0-RTT | 🟩U | 🟥FC | 🟨C* | 🟡TODO |
-| `SSL_get_recv_max_early_data` | 0-RTT | 🟩U | 🟥FC | 🟨C* | 🟡TODO |
-| `SSL_set_recv_max_early_data` | 0-RTT | 🟩U | 🟥FC | 🟨C* | 🟡TODO |
-| `SSL_CTX_get_max_early_data` | 0-RTT | 🟩U | 🟥FC | 🟨C* | 🟡TODO |
-| `SSL_CTX_set_max_early_data` | 0-RTT | 🟩U | 🟥FC | 🟨C* | 🟡TODO |
-| `SSL_get_max_early_data` | 0-RTT | 🟩U | 🟥FC | 🟨C* | 🟡TODO |
-| `SSL_set_max_early_data` | 0-RTT | 🟩U | 🟥FC | 🟨C* | 🟡TODO |
-| `SSL_read_early_data` | 0-RTT | 🟩U | 🟥FC | 🟨C* | 🟡TODO |
-| `SSL_write_early_data` | 0-RTT | 🟩U | 🟥FC | 🟨C* | 🟡TODO |
-| `SSL_get_early_data_status` | 0-RTT | 🟩U | 🟥FC | 🟨C* | 🟡TODO |
+| `SSL_CTX_set_allow_early_data_cb` | 0-RTT | 🟩U | 🟥FC | 🟩NC* | 🟢Done |
+| `SSL_set_allow_early_data_cb` | 0-RTT | 🟩U | 🟥FC | 🟨C* |🟢Done  |
+| `SSL_CTX_get_recv_max_early_data` | 0-RTT | 🟩U | 🟥FC | 🟩NC* | 🟢Done |
+| `SSL_CTX_set_recv_max_early_data` | 0-RTT | 🟩U | 🟥FC | 🟩NC* | 🟢Done |
+| `SSL_get_recv_max_early_data` | 0-RTT | 🟩U | 🟥FC | 🟩NC* | 🟢Done |
+| `SSL_set_recv_max_early_data` | 0-RTT | 🟩U | 🟥FC | 🟨C* | 🟢Done |
+| `SSL_CTX_get_max_early_data` | 0-RTT | 🟩U | 🟥FC | 🟩NC* | 🟢Done  |
+| `SSL_CTX_set_max_early_data` | 0-RTT | 🟩U | 🟥FC | 🟩NC* | 🟢Done |
+| `SSL_get_max_early_data` | 0-RTT | 🟩U | 🟥FC | 🟩NC* | 🟢Done |
+| `SSL_set_max_early_data` | 0-RTT | 🟩U | 🟥FC | 🟨C* | 🟢Done  |
+| `SSL_read_early_data` | 0-RTT | 🟩U | 🟥FC | 🟨C* | 🟢Done |
+| `SSL_write_early_data` | 0-RTT | 🟩U | 🟥FC | 🟨C* | 🟢Done |
+| `SSL_get_early_data_status` | 0-RTT | 🟩U | 🟥FC | 🟩NC* | 🟢Done |
 | **⇒ Miscellaneous** | |
 | `DTLSv1_listen` | RL | 🟩U | 🟦U | 🟩NC | 🟢Done |
 | `DTLS_set_timer_cb` | NDP | 🟩U | 🟦U | 🟩NC | 🟢Done |
 | `DTLS_get_data_mtu` | NDP | 🟩U | 🟦U | 🟩NC | 🟢Done |
 | `SSL_get_ex_data_X509_STORE_CTX_idx` | Global | 🟩U | 🟦U | 🟩NC | 🟢Done |
 | `BIO_ssl_shutdown` | Global | 🟩U | 🟩A | 🟩NC | 🟢Done |
-| `SSL_alloc_buffers` | HL | 🟩U | 🟩A | 🟨C\* | 🟠Design TBD |
-| `SSL_free_buffers` | HL | 🟩U | 🟩A | 🟨C\* | 🟠Design TBD |
+| `SSL_alloc_buffers` | HL | 🟩U | 🟩A | 🟨C\* | 🟢Done |
+| `SSL_free_buffers` | HL | 🟩U | 🟩A | 🟨C\* | 🟢Done |
 | `SSL_trace` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
 | `SSL_set_debug` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
 | **⇒ Controls** | |
-| `SSL_CTRL_MODE` | Special | 🟩U | 🟩A | 🟧QSI | 🟡TODO |
-| `SSL_CTRL_CLEAR_MODE` | Special | 🟩U | 🟩A | 🟧QSI | 🟡TODO |
+| `SSL_CTRL_MODE` | Special | 🟩U | 🟩A | 🟧QSI | 🟢Done |
+| `SSL_CTRL_CLEAR_MODE` | Special | 🟩U | 🟩A | 🟧QSI | 🟢Done |
 | `SSL_CTRL_CLEAR_NUM_RENEGOTIATIONS` | HL | 🟩U | 🟧NO | 🟩NC* | 🟢Done |
 | `SSL_CTRL_GET_NUM_RENEGOTIATIONS` | HL | 🟩U | 🟧NO | 🟩NC* | 🟢Done |
 | `SSL_CTRL_GET_TOTAL_RENEGOTIATIONS` | HL | 🟩U | 🟧NO | 🟩NC* | 🟢Done |
 | `SSL_CTRL_GET_RI_SUPPORT` | HL | 🟩U | 🟧NO | 🟩NC* | 🟢Done |
 | `SSL_CTRL_GET_READ_AHEAD` | HL | 🟩U | 🟧NO | 🟩NC* | 🟢Done |
-| `SSL_CTRL_SET_READ_AHEAD` | HL | 🟩U | 🟥FC | 🟨C* | 🟡TODO |
-| `SSL_CTRL_SET_MAX_PIPELINES` | RL | 🟩U | 🟥FC | 🟨C* | 🟡TODO |
-| `SSL_CTRL_SET_MAX_SEND_FRAGMENT` | RL | 🟩U | 🟥FC | 🟨C* | 🟡TODO |
-| `SSL_CTRL_SET_SPLIT_SEND_FRAGMENT` | RL | 🟩U | 🟥FC | 🟨C* | 🟡TODO |
+| `SSL_CTRL_SET_READ_AHEAD` | HL | 🟩U | 🟥FC | 🟨C* |🟢Done |
+| `SSL_CTRL_SET_MAX_PIPELINES` | RL | 🟩U | 🟥FC | 🟨C* | 🟢Done |
+| `SSL_CTRL_SET_MAX_SEND_FRAGMENT` | RL | 🟩U | 🟥FC | 🟨C* | 🟢Done |
+| `SSL_CTRL_SET_SPLIT_SEND_FRAGMENT` | RL | 🟩U | 🟥FC | 🟨C* | 🟢Done |
 | `SSL_CTRL_SET_MTU` | RL | 🟩U | 🟥FC | 🟩NC* | 🟢Done |
-| `SSL_CTRL_SET_MAX_PROTO_VERSION` | HL | 🟩U | 🟩A | 🟨C* | 🟡TODO |
-| `SSL_CTRL_SET_MIN_PROTO_VERSION` | HL | 🟩U | 🟩A | 🟨C* | 🟡TODO |
+| `SSL_CTRL_SET_MAX_PROTO_VERSION` | HL | 🟩U | 🟩A | 🟨C* | 🟢Done |
+| `SSL_CTRL_SET_MIN_PROTO_VERSION` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
 | `SSL_CTRL_GET_MAX_PROTO_VERSION` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
 | `SSL_CTRL_GET_MIN_PROTO_VERSION` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
 | `SSL_CTRL_BUILD_CERT_CHAIN` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
@@ -810,5 +823,170 @@ Notes:
 | `SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER` | ADP | 🟩U | 🟩A | 🟧QSI | 🟢Done |
 | `SSL_MODE_RELEASE_BUFFERS` | ADP | 🟩U | 🟧NO | 🟩NC | 🟢Done |
 | `SSL_MODE_ASYNC` | ADP | 🟩U | 🟧NO | 🟩NC | 🟢Done |
-| `SSL_MODE_AUTO_RETRY` | ADP | TBD | TBD | TBD | 🔴Pending Triage |
-| `SSL_MODE_SEND_FALLBACK_SCSV` | HL | 🟩U | 🟩A | 🟨C\* | 🟡TODO |
+| `SSL_MODE_AUTO_RETRY` | ADP | 🟩U | 🟧NO | 🟩NC | 🟢Done |
+| `SSL_MODE_SEND_FALLBACK_SCSV` | HL | 🟩U | 🟩U | 🟩NC | 🟢Done |
+
+Q&A For TLS-Related Calls
+-------------------------
+
+### What should `SSL_get_current_cipher`, `SSL_get_pending_cipher`, etc. do?
+
+QUIC always uses AES-128-GCM for Initial packets. At this time the handshake
+layer has not negotiated a ciphersuite so it has no “current” cipher. We could
+return AES-128-GCM here, but it seems reasonable to just return NULL as the
+encryption is mostly for protection against accidential modification and not
+“real” encryption. From the perspective of the Handshake layer encryption is not
+active yet. An application using QUIC can always interpret NULL as meaning
+AES-128-GCM is being used if needed as this is implied by using QUIC.
+
+### What should `SSL_CTX_set_cipher_list` do?
+
+Since this function configures the cipher list for TLSv1.2 and below only, there
+is no need to restrict it as TLSv1.3 is required for QUIC. For the sake of
+application compatibility, applications can still configure the TLSv1.2 cipher
+list; it will always be ignored.
+
+### What should `SSL_get_current_cipher` and similar do?
+
+QUIC always uses AES-128-GCM encryption initially, so we could either return
+AES-128-GCM where the handshake has not yet negotiated another algorithm or
+return NULL here.
+
+A. We return NULL here, because it allows applications to detect if a
+ciphersuite has been negotiated and NULL can be used to infer that Initial
+encryption is still being used. This also minimises the changes needed to the
+implementation.
+
+### What SSL options should be supported?
+
+Options we explicitly want to support:
+
+- `SSL_OP_CIPHER_SERVER_PREFERENCE`
+- `SSL_OP_DISABLE_TLSEXT_CA_NAMES`
+- `SSL_OP_NO_TX_CERTIFICATE_COMPRESSION`
+- `SSL_OP_NO_RX_CERTIFICATE_COMPRESSION`
+- `SSL_OP_PRIORITIZE_CHACHA`
+- `SSL_OP_NO_TICKET`
+
+Options we do not yet support but could support in the future, currently no-ops:
+
+- `SSL_OP_CLEANSE_PLAINTEXT`
+- `SSL_OP_NO_QUERY_MTU`
+- `SSL_OP_NO_ANTI_REPLAY`
+
+The following options must be explicitly forbidden:
+
+- `SSL_OP_NO_TLSv1_3` — TLSv1.3 is required for QUIC
+- `SSL_OP_ENABLE_MIDDLEBOX_COMPAT` — forbidden by QUIC RFCs
+- `SSL_OP_ENABLE_KTLS` — not currently supported for QUIC
+- `SSL_OP_SAFARI_ECDHE_ECDSA_BUG`
+- `SSL_OP_TLSEXT_PADDING`
+- `SSL_OP_TLS_ROLLBACK_BUG`
+- `SSL_OP_IGNORE_UNEXPECTED_EOF`
+- `SSL_OP_ALLOW_NO_DHE_KEX`
+
+The following options are ignored for TLSv1.3 or otherwise not applicable and
+may therefore be settable but ignored. We take this approach on the grounds
+that it is harmless and applications might want to see that options have been
+correctly set for protocols unrelated to QUIC.
+
+- `SSL_OP_CRYPTOPRO_TLSEXT_BUG`
+- `SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS`
+- `SSL_OP_ALLOW_CLIENT_RENEGOTIATION`
+- `SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION`
+- `SSL_OP_CISCO_ANYCONNECT`
+- `SSL_OP_COOKIE_EXCHANGE`
+- `SSL_OP_LEGACY_SERVER_CONNECT`
+- `SSL_OP_NO_COMPRESSION`
+- `SSL_OP_NO_ENCRYPT_THEN_MAC`
+- `SSL_OP_NO_EXTENDED_MASTER_SECRET`
+- `SSL_OP_NO_RENEGOTIATION`
+- `SSL_OP_NO_RESSION_RESUMPTION_ON_NEGOTIATION`
+- `SSL_OP_NO_SSLv3`
+- `SSL_OP_NO_TLSv1`
+- `SSL_OP_NO_TLSv1_1`
+- `SSL_OP_NO_TLSv1_2`
+- `SSL_OP_NO_DTLSv1`
+- `SSL_OP_NO_DTLSv1_2`
+
+### What should `SSL_rstate_string` and `SSL_state_string` do?
+
+SSL_state_string is highly handshake layer specific, so it makes sense to just
+forward to the handshake layer.
+
+SSL_rstate_string is record layer specific. A cursory evaluation of usage via
+GitHub code search did not appear to identify much usage of this function other
+than for debug output; i.e., there seems to be little usage of this in a way
+that depends on the output for the purposes of control flow. Since there is not
+really any direct correspondence to the QUIC record layer, we conservatively
+define the output of this function as "unknown".
+
+TODO: forbid NPN
+TODO: enforce TLSv1.3
+TODO: forbid PHA            - DONE
+TODO: forbid middlebox compat mode in a deeper way?
+TODO: new_session_ticket doesn't need modifying as such, but ticket machinery
+      will
+
+### What should `SSL_pending` and `SSL_has_pending` do?
+
+`SSL_pending` traditionally yields the number of bytes buffered inside a SSL
+object available for immediate reading. For QUIC, we can just make this report
+the current size of the receive stream buffer.
+
+`SSL_has_pending` returns a boolean value indicating whether there is processed
+or unprocessed incoming data pending. There is no direct correspondence to
+QUIC, so there are various implementation options:
+
+- `SSL_pending() > 0`
+- `SSL_pending() > 0 || pending URXEs or RXEs exist`
+
+The latter can probably be viewed as more of a direct correspondence to the
+design intent of the API, so we go with this.
+
+### What should `SSL_alloc_buffers` and `SSL_free_buffers` do?
+
+These do not really correspond to our internal architecture for QUIC. Since
+internal buffers are always available, `SSL_alloc_buffers` can simply always
+return 1. `SSL_free_buffers` can always return 0, as though the buffers are in
+use, which they generally will be.
+
+### What should `SSL_key_update` and `SSL_get_key_update_type`?
+
+`SSL_key_update` can trigger a TX record layer key update, which will cause the
+peer to respond with a key update in turn. The update occurs asynchronously
+at next transmission, not immediately.
+
+`SSL_get_key_update_type` returns an enumerated value which is only relevant to
+the TLSv1.3 protocol; for QUIC, it will always return `SSL_KEY_UPDATE_NONE`.
+
+### What should `SSL_MODE_AUTO_RETRY` do?
+
+The absence of `SSL_MODE_AUTO_RETRY` causes `SSL_read`/`SSL_write` on a normal
+TLS connection to potentially return due to internal handshake message
+processing. This does not really make sense for our QUIC implementation,
+therefore we always act as though `SSL_MODE_AUTO_RETRY` is on, and this mode is
+ignored.
+
+### What should `SSL_MODE_SEND_FALLBACK_SCSV` do?
+
+This is not relevant to QUIC because this functionality relates to protocol
+version downgrade attack protection and QUIC only supports TLSv1.3. Thus,
+it is ignored.
+
+### What should `SSL_CTX_set_ssl_version` do?
+
+This is a deprecated function, so it needn't be supported for QUIC. Fail closed.
+
+### What should `SSL_set_ssl_method` do?
+
+For now we can avoid supporting this for QUIC. Supporting this would be rather
+hairy.
+
+### What should `SSL_set_shutdown` do?
+
+TBD.
+
+### What should `SSL_dup` and `SSL_clear` do?
+
+These may be tricky to support. Currently they are blocked.

--- a/doc/designs/quic-design/quic-api-ssl-funcs.md
+++ b/doc/designs/quic-design/quic-api-ssl-funcs.md
@@ -622,7 +622,6 @@ Notes:
 | `SSL_tick` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟢Done |
 | `SSL_get_tick_timeout` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟢Done |
 | `SSL_get_blocking_mode` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟢Done |
-| `SSL_get_blocking_mode` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟢Done |
 | `SSL_set_blocking_mode` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟢Done |
 | `SSL_get_rpoll_descriptor` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟢Done |
 | `SSL_get_wpoll_descriptor` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟢Done |

--- a/doc/designs/quic-design/quic-api-ssl-funcs.md
+++ b/doc/designs/quic-design/quic-api-ssl-funcs.md
@@ -842,23 +842,18 @@ encryption is mostly for protection against accidential modification and not
 active yet. An application using QUIC can always interpret NULL as meaning
 AES-128-GCM is being used if needed as this is implied by using QUIC.
 
+A. We return NULL here, because it allows applications to detect if a
+ciphersuite has been negotiated and NULL can be used to infer that Initial
+encryption is still being used. This also minimises the changes needed to the
+implementation.
+
 ### What should `SSL_CTX_set_cipher_list` do?
 
 Since this function configures the cipher list for TLSv1.2 and below only, there
 is no need to restrict it as TLSv1.3 is required for QUIC. For the sake of
 application compatibility, applications can still configure the TLSv1.2 cipher
-list; it will always be ignored.
-
-### What should `SSL_get_current_cipher` and similar do?
-
-QUIC always uses AES-128-GCM encryption initially, so we could either return
-AES-128-GCM where the handshake has not yet negotiated another algorithm or
-return NULL here.
-
-A. We return NULL here, because it allows applications to detect if a
-ciphersuite has been negotiated and NULL can be used to infer that Initial
-encryption is still being used. This also minimises the changes needed to the
-implementation.
+list; it will always be ignored. This function can still be used to set the
+SECLEVEL; no changes are needed to facilitate this.
 
 ### What SSL options should be supported?
 
@@ -870,10 +865,10 @@ Options we explicitly want to support:
 - `SSL_OP_NO_RX_CERTIFICATE_COMPRESSION`
 - `SSL_OP_PRIORITIZE_CHACHA`
 - `SSL_OP_NO_TICKET`
+- `SSL_OP_CLEANSE_PLAINTEXT`
 
 Options we do not yet support but could support in the future, currently no-ops:
 
-- `SSL_OP_CLEANSE_PLAINTEXT`
 - `SSL_OP_NO_QUERY_MTU`
 - `SSL_OP_NO_ANTI_REPLAY`
 

--- a/doc/designs/quic-design/quic-api-ssl-funcs.md
+++ b/doc/designs/quic-design/quic-api-ssl-funcs.md
@@ -133,7 +133,7 @@ Notes:
 | `DTLSv1_2_client_method` | Global | 🟩U | 🟦U | 🟩NC | 🟢Done |
 | `DTLSv1_2_server_method` | Global | 🟩U | 🟦U | 🟩NC | 🟢Done |
 | `OSSL_QUIC_client_method` | Global | 🟩U | 🟦U | 🟥QSA | 🟢Done |
-| `OSSL_QUIC_client_thread_method` | Global | 🟩U | 🟦U | 🟥QSA | 🟠Design TBD |
+| `OSSL_QUIC_client_thread_method` | Global | 🟩U | 🟦U | 🟥QSA | 🟢Done |
 | `OSSL_QUIC_server_method` | Global | 🟩U | 🟦U | 🟥QSA | 🟠Design TBD |
 | **⇒ Instantiation** | |
 | `BIO_f_ssl` | Object | 🟩U | 🟩A | 🟩NC | 🟢Done |
@@ -189,9 +189,9 @@ Notes:
 | `SSL_SESSION_set1_alpn_selected` | HL | 🟩U | 🟩A | 🟨C\* †2 | 🟡TODO |
 | `SSL_SESSION_get0_alpn_selected` | HL | 🟩U | 🟩A | 🟨C\* †2 | 🟡TODO |
 | `SSL_CTX_set_alpn_select_cb` | HL | 🟩U | 🟩A | 🟨C\* †2 | 🟡TODO |
-| `SSL_set_alpn_protos` | HL | 🟩U | 🟩A | 🟨C\* †2 | 🟡TODO |
-| `SSL_get0_alpn_selected` | HL | 🟩U | 🟩A | 🟨C\* †2 | 🟡TODO |
-| `SSL_CTX_set_alpn_protos` | HL | 🟩U | 🟩A | 🟨C\* †2 | 🟡TODO |
+| `SSL_set_alpn_protos` | HL | 🟩U | 🟩A | 🟨C\* †2 | 🟢Done |
+| `SSL_get0_alpn_selected` | HL | 🟩U | 🟩A | 🟨C\* †2 | 🟢Done |
+| `SSL_CTX_set_alpn_protos` | HL | 🟩U | 🟩A | 🟨C\* †2 | 🟢Done |
 | **⇒ NPN** | †3 |
 | `SSL_CTX_set_next_proto_select_cb` | HL | 🟩U | 🟥FC | 🟨C\* †3 | 🟢Done |
 | `SSL_CTX_set_next_protos_advertised_cb` | HL | 🟩U | 🟥FC | 🟨C\* †3 | 🟢Done |
@@ -976,12 +976,11 @@ This is a deprecated function, so it needn't be supported for QUIC. Fail closed.
 
 ### What should `SSL_set_ssl_method` do?
 
-For now we can avoid supporting this for QUIC. Supporting this would be rather
-hairy.
+We do not currently support this for QUIC.
 
 ### What should `SSL_set_shutdown` do?
 
-TBD.
+This is not supported and is a no-op for QUIC.
 
 ### What should `SSL_dup` and `SSL_clear` do?
 

--- a/doc/designs/quic-design/quic-api-ssl-funcs.md
+++ b/doc/designs/quic-design/quic-api-ssl-funcs.md
@@ -648,9 +648,7 @@ Notes:
 | `SSL_accept_stream` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟡TODO |
 | `SSL_get_accept_stream_queue_len` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟡TODO |
 | `SSL_set_default_stream_mode` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟡TODO |
-| `SSL_set_incoming_stream_reject_policy` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟡TODO |
-| `SSL_detach_stream` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟡TODO |
-| `SSL_attach_stream` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟡TODO |
+| `SSL_set_incoming_stream_policy` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟡TODO |
 | **⇒ Currently Not Supported** | |
 | `SSL_copy_session_id` | Special | 🟩U | 🟥FC | 🟨C* | 🟢Done |
 | `BIO_ssl_copy_session_id` | Special | 🟩U | 🟥FC | 🟨C* | 🟢Done |

--- a/doc/designs/quic-design/quic-api-ssl-funcs.md
+++ b/doc/designs/quic-design/quic-api-ssl-funcs.md
@@ -1,0 +1,815 @@
+Behaviour of SSL functions on QUIC SSL objects
+==============================================
+
+This document is a companion to the [QUIC API Overview](./quic-api.md) which
+lists all SSL functions and controls and notes their behaviour with QUIC SSL
+objects.
+
+The Category column is as follows:
+
+- **Global**:
+  These API items do not relate to SSL objects. They may be stateless or may
+  relate only to global state.
+
+  Can also be used for APIs implemented only in terms of other public libssl APIs.
+- **Object**:
+  Object management APIs. Some of these may require QUIC-specific implementation.
+- **HL**: Handshake layer API.
+
+  These calls should generally be dispatched to the handshake layer, unless
+  they are not applicable to QUIC. Modifications inside the handshake layer
+  for the QUIC case may or may not be required.
+- **CSSM**: Connection/Stream State Machine. API related to lifecycle of a
+  connection or stream. Needs QUIC-specific implementation.
+- **ADP**: App Data Path. Application-side data path API. QUIC-specific
+  implementation.
+- **NDP**: Net Data Path. Network-side data path control API. Also includes I/O
+  ticking and timeout handling.
+- **RL**: Record layer related API. If these API items only relate to the TLS
+  record layer, they must be disabled for QUIC; if they are also relevant to the
+  QUIC record layer, they will require QUIC-specific implementation.
+- **Async**: Relates to the async functionality.
+- **0-RTT**: Relates to early data/0-RTT functionality.
+- **Special**: Other calls which defy classification.
+
+The Semantics column is as follows:
+
+- **🟩U**: Unchanged. The semantics of the API are not changed for QUIC.
+- **🟧C**: Changed. The semantics of the API are changed for QUIC.
+- **🟦N**: New. The API is new for QUIC.
+- **🟥TBD**: Yet to be determined if semantic changes will be required.
+
+The Applicability column is as follows:
+
+- **🟦U**: Unrelated. Not applicable to QUIC — fully unrelated (e.g. functions for
+  other SSL methods).
+- **🟥FC**: Not applicable to QUIC (or not currently supported) — fail closed.
+- **🟧NO**: Not applicable to QUIC (nor not currently supported) — no-op.
+- **🟩A**: Applicable.
+
+The Implementation Requirements column is as follows:
+
+- **🟩NC**: No changes are expected to be needed (where marked **\***, dispatch
+  to handshake layer).
+
+  **Note**: Where this value is used with an applicability of **FC** or **NO**,
+  this means that the desired behaviour is already an emergent consequence of the
+  existing code.
+- **🟨C**: Modifications are expected to be needed (where marked **\***,
+  dispatch to handshake layer with changes inside the handshake layer).
+- **🟧QSI**: QUIC specific implementation.
+- **🟥QSA**: QUIC specific API.
+
+The Status column is as follows:
+
+- **🔴Pending Triage**: Have not determined the classification of this API item yet.
+- **🟠Design TBD**: It has not yet been determined how this API item will work for
+  QUIC.
+- **🟡TODO**: It has been determined how this API item should work for QUIC but it
+  has not yet been implemented.
+- **🟢Done**: No further work is anticipated to be needed for this API item.
+
+Notes:
+
+- †1: Must restrict which ciphers can be used with QUIC; otherwise, no changes.
+- †2: ALPN usage must be mandated; otherwise, no changes.
+- †3: NPN usage should be forced off as it should never be used with QUIC;
+  otherwise, no changes.
+- †4: Controls needing changes are listed separately.
+- †5: TLS compression and renegotiation must not be used with QUIC, but these
+  features are already forbidden in
+  TLS 1.3, which is a requirement for QUIC, thus no changes should be needed.
+- †6: Callback specified is called for handshake layer messages (TLSv1.3).
+- †7: Tickets are issued using `NEW_TOKEN` frames in QUIC and this will
+  require handshake layer changes. However these APIs as such do not require
+  changes.
+- †8: Use of post-handshake authentication is prohibited by QUIC.
+- †9: QUIC always uses AES-128-GCM initially. We need to determine when and
+  what ciphers we report as being in use.
+- †10: Not supporting async for now.
+
+| API Item | Cat. | Sema. | Appl. | Impl. Req. | Status |
+|----------|----------|-----------|---------------|----------------|--------|
+| **⇒ Global Information and Functions** | |
+| `OSSL_default_cipher_list` | Global | 🟩U | 🟦U | 🟩NC | 🟢Done |
+| `OSSL_default_ciphersuites` | Global | 🟩U | 🟦U | 🟩NC | 🟢Done |
+| `ERR_load_SSL_strings` | Global | 🟩U | 🟦U | 🟩NC | 🟢Done |
+| `OPENSSL_init_ssl` | Global | 🟩U | 🟦U | 🟩NC | 🟢Done |
+| `OPENSSL_cipher_name` | Global | 🟩U | 🟦U | 🟩NC | 🟢Done |
+| `SSL_alert_desc_string` | Global | 🟩U | 🟦U | 🟩NC | 🟢Done |
+| `SSL_alert_desc_string_long` | Global | 🟩U | 🟦U | 🟩NC | 🟢Done |
+| `SSL_alert_type_string` | Global | 🟩U | 🟦U | 🟩NC | 🟢Done |
+| `SSL_alert_type_string_long` | Global | 🟩U | 🟦U | 🟩NC | 🟢Done |
+| `SSL_extension_supported` | Global | 🟩U | 🟦U | 🟩NC | 🟢Done |
+| `SSL_add_ssl_module` | Global | 🟩U | 🟦U | 🟩NC | 🟢Done |
+| `SSL_test_functions` | Global | 🟩U | 🟦U | 🟩NC | 🟢Done |
+| `SSL_select_next_proto` | Global | 🟩U | 🟦U | 🟩NC | 🟢Done |
+| **⇒ Methods** | |
+| `SSLv3_method` | Global | 🟩U | 🟦U | 🟩NC | 🟢Done |
+| `SSLv3_client_method` | Global | 🟩U | 🟦U | 🟩NC | 🟢Done |
+| `SSLv3_server_method` | Global | 🟩U | 🟦U | 🟩NC | 🟢Done |
+| `TLS_method` | Global | 🟩U | 🟦U | 🟩NC | 🟢Done |
+| `TLS_client_method` | Global | 🟩U | 🟦U | 🟩NC | 🟢Done |
+| `TLS_server_method` | Global | 🟩U | 🟦U | 🟩NC | 🟢Done |
+| `TLSv1_method` | Global | 🟩U | 🟦U | 🟩NC | 🟢Done |
+| `TLSv1_client_method` | Global | 🟩U | 🟦U | 🟩NC | 🟢Done |
+| `TLSv1_server_method` | Global | 🟩U | 🟦U | 🟩NC | 🟢Done |
+| `TLSv1_1_method` | Global | 🟩U | 🟦U | 🟩NC | 🟢Done |
+| `TLSv1_1_client_method` | Global | 🟩U | 🟦U | 🟩NC | 🟢Done |
+| `TLSv1_1_server_method` | Global | 🟩U | 🟦U | 🟩NC | 🟢Done |
+| `TLSv1_2_client_method` | Global | 🟩U | 🟦U | 🟩NC | 🟢Done |
+| `TLSv1_2_server_method` | Global | 🟩U | 🟦U | 🟩NC | 🟢Done |
+| `TLSv1_2_method` | Global | 🟩U | 🟦U | 🟩NC | 🟢Done |
+| `DTLS_method` | Global | 🟩U | 🟦U | 🟩NC | 🟢Done |
+| `DTLS_client_method` | Global | 🟩U | 🟦U | 🟩NC | 🟢Done |
+| `DTLS_server_method` | Global | 🟩U | 🟦U | 🟩NC | 🟢Done |
+| `DTLSv1_client_method` | Global | 🟩U | 🟦U | 🟩NC | 🟢Done |
+| `DTLSv1_server_method` | Global | 🟩U | 🟦U | 🟩NC | 🟢Done |
+| `DTLSv1_method` | Global | 🟩U | 🟦U | 🟩NC | 🟢Done |
+| `DTLSv1_2_method` | Global | 🟩U | 🟦U | 🟩NC | 🟢Done |
+| `DTLSv1_2_client_method` | Global | 🟩U | 🟦U | 🟩NC | 🟢Done |
+| `DTLSv1_2_server_method` | Global | 🟩U | 🟦U | 🟩NC | 🟢Done |
+| `OSSL_QUIC_client_method` | Global | 🟩U | 🟦U | 🟥QSA | 🟢Done |
+| `OSSL_QUIC_client_thread_method` | Global | 🟩U | 🟦U | 🟥QSA | 🟠Design TBD |
+| `OSSL_QUIC_server_method` | Global | 🟩U | 🟦U | 🟥QSA | 🟠Design TBD |
+| **⇒ Instantiation** | |
+| `BIO_f_ssl` | Object | 🟩U | 🟩A | 🟩NC | 🟢Done |
+| `BIO_new_ssl` | Object | 🟩U | 🟩A | 🟩NC | 🟢Done |
+| `SSL_CTX_new` | Object | 🟩U | 🟩A | 🟩NC | 🟢Done |
+| `SSL_CTX_new_ex` | Object | 🟩U | 🟩A | 🟩NC | 🟢Done |
+| `SSL_CTX_up_ref` | Object | 🟩U | 🟩A | 🟩NC | 🟢Done |
+| `SSL_CTX_free` | Object | 🟩U | 🟩A | 🟩NC | 🟢Done |
+| `SSL_new` | Object | 🟩U | 🟩A | 🟧QSI | 🟢Done |
+| `SSL_dup` | Object | 🟩U | 🟩A | 🟧QSI | 🟠Design TBD |
+| `SSL_up_ref` | Object | 🟩U | 🟩A | 🟩NC | 🟢Done |
+| `SSL_free` | Object | 🟩U | 🟩A | 🟧QSI | 🟢Done |
+| `SSL_is_dtls` | Object | 🟩U | 🟩A | 🟩NC | 🟢Done |
+| `SSL_CTX_get_ex_data` | Object | 🟩U | 🟩A | 🟩NC | 🟢Done |
+| `SSL_CTX_set_ex_data` | Object | 🟩U | 🟩A | 🟩NC | 🟢Done |
+| `SSL_get_ex_data` | Object | 🟩U | 🟩A | 🟩NC | 🟢Done |
+| `SSL_set_ex_data` | Object | 🟩U | 🟩A | 🟩NC | 🟢Done |
+| `SSL_get_SSL_CTX` | Object | 🟩U | 🟩A | 🟩NC | 🟢Done |
+| `SSL_set_SSL_CTX` | Object | 🟩U | 🟩A | 🟩NC | 🟢Done |
+| **⇒ Method Manipulation** | |
+| `SSL_CTX_get_ssl_method` | Object | 🟩U | 🟩A | 🟩NC | 🟢Done |
+| `SSL_get_ssl_method` | Object | 🟩U | 🟩A | 🟩NC | 🟢Done |
+| `SSL_CTX_set_ssl_method` | Object | 🟥TBD | 🟩A | 🟧QSI | 🟠Design TBD |
+| `SSL_set_ssl_method` | Object | 🟥TBD | 🟩A | 🟧QSI | 🟠Design TBD |
+| **⇒ SRTP** | |
+| `SSL_get_selected_srtp_profile` | HL | 🟩U | 🟥FC | 🟨C\* | 🟡TODO |
+| `SSL_get_srtp_profiles` | HL | 🟩U | 🟥FC | 🟨C\* | 🟡TODO |
+| `SSL_CTX_set_tlsext_use_srtp` | HL | 🟩U | 🟥FC | 🟨C\* | 🟡TODO |
+| `SSL_set_tlsext_use_srtp` | HL | 🟩U | 🟥FC | 🟨C\* | 🟡TODO |
+| **⇒ Ciphersuite Configuration** | |
+| `SSL_CTX_set_cipher_list` | HL | 🟩U | 🟩A | 🟨C\* †1 | 🟡TODO |
+| `SSL_CTX_set_ciphersuites` | HL | 🟩U | 🟩A | 🟨C\* †1 | 🟡TODO |
+| `SSL_CTX_get_ciphers` | HL | 🟩U | 🟩A | 🟨C\* †1 | 🟡TODO |
+| `SSL_set_ciphersuites` | HL | 🟩U | 🟩A | 🟨C\* †1 | 🟡TODO |
+| `SSL_get1_supported_ciphers` | HL | 🟩U | 🟩A | 🟨C\* †1 | 🟡TODO |
+| `SSL_bytes_to_cipher_list` | HL | 🟩U | 🟩A | 🟨C\* †1 | 🟡TODO |
+| `SSL_get_ciphers` | HL | 🟩U | 🟩A | 🟨C\* †1 | 🟡TODO |
+| `SSL_get_cipher_list` | HL | 🟩U | 🟩A | 🟨C\* †1 | 🟡TODO |
+| `SSL_set_cipher_list` | HL | 🟩U | 🟩A | 🟨C\* †1 | 🟡TODO |
+| **⇒ Negotiated Ciphersuite Queries** | |
+| `SSL_get_current_cipher` | HL | 🟩U | 🟩A | 🟨C\* †9 | 🟠Design TBD |
+| `SSL_get_pending_cipher` | HL | 🟩U | 🟩A | 🟨C\* †9 | 🟠Design TBD |
+| `SSL_get_shared_ciphers` | HL | 🟩U | 🟩A | 🟨C\* †9 | 🟠Design TBD |
+| `SSL_get_client_ciphers` | HL | 🟩U | 🟩A | 🟨C\* †9 | 🟠Design TBD |
+| `SSL_get_current_compression` | HL | 🟩U | 🟩A | 🟩HLNC | 🟢Done |
+| `SSL_get_current_expansion` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_get_shared_sigalgs` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_get_sigalgs` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_get_peer_signature_nid` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_get_peer_signature_type_nid` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_get_signature_nid` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_get_signature_type_nid` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| **⇒ ALPN** | †2 |
+| `SSL_SESSION_set1_alpn_selected` | HL | 🟩U | 🟩A | 🟨C\* †2 | 🟡TODO |
+| `SSL_SESSION_get0_alpn_selected` | HL | 🟩U | 🟩A | 🟨C\* †2 | 🟡TODO |
+| `SSL_CTX_set_alpn_select_cb` | HL | 🟩U | 🟩A | 🟨C\* †2 | 🟡TODO |
+| `SSL_set_alpn_protos` | HL | 🟩U | 🟩A | 🟨C\* †2 | 🟡TODO |
+| `SSL_get0_alpn_selected` | HL | 🟩U | 🟩A | 🟨C\* †2 | 🟡TODO |
+| `SSL_CTX_set_alpn_protos` | HL | 🟩U | 🟩A | 🟨C\* †2 | 🟡TODO |
+| **⇒ NPN** | †3 |
+| `SSL_CTX_set_next_proto_select_cb` | HL | 🟩U | 🟥FC | 🟨C\* †3 | 🟡TODO |
+| `SSL_CTX_set_next_protos_advertised_cb` | HL | 🟩U | 🟥FC | 🟨C\* †3 | 🟡TODO |
+| `SSL_get0_next_proto_negotiated` | HL | 🟩U | 🟥FC | 🟨C\* †3 | 🟡TODO |
+| **⇒ Narrow Waist Interface** | †4 |
+| `SSL_CTX_ctrl` | Object | 🟩U | 🟩A | 🟩NC\* †4 | 🟢Done |
+| `SSL_ctrl` | Object | 🟩U | 🟩A | 🟩NC\* †4 | 🟢Done |
+| `SSL_CTX_callback_ctrl` | Object | 🟩U | 🟩A | 🟩NC\* †4 | 🟢Done |
+| `SSL_callback_ctrl` | Object | 🟩U | 🟩A | 🟩NC\* †4 | 🟢Done |
+| **⇒ Miscellaneous Accessors** | |
+| `SSL_get_server_random` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_get_client_random` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_get_finished` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_get_peer_finished` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| **⇒ Ciphersuite Information** | |
+| `SSL_CIPHER_description` | Global | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CIPHER_find` | Global | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CIPHER_get_auth_nid` | Global | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CIPHER_get_bits` | Global | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CIPHER_get_cipher_nid` | Global | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CIPHER_get_digest_nid` | Global | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CIPHER_get_handshake_digest` | Global | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CIPHER_get_id` | Global | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CIPHER_get_kx_nid` | Global | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CIPHER_get_name` | Global | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CIPHER_get_protocol_id` | Global | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CIPHER_get_version` | Global | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CIPHER_is_aead` | Global | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CIPHER_standard_name` | Global | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_group_to_name` | Global | 🟩U | 🟦U | 🟩NC\* | 🟢Done |
+| **⇒ Version Queries** | |
+| `SSL_get_version` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_version` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_client_version` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| **⇒ Certificate Chain Management** | |
+| `SSL_get_certificate` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_use_certificate` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_use_certificate_chain_file` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_use_certificate_chain_file` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_use_certificate_file` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_load_verify_file` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_load_verify_dir` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_load_verify_store` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_load_verify_locations` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `CertSSL_use_cert_and_key` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_use_certificate_ASN1` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_use_PrivateKey` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_use_PrivateKey_ASN1` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_use_PrivateKey_file` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_use_RSAPrivateKey` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_use_RSAPrivateKey_ASN1` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_use_RSAPrivateKey_file` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_set_default_verify_dir` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_set_default_verify_file` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_set_default_verify_paths` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_set_default_verify_store` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_use_cert_and_key` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_use_certificate` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_use_certificate_ASN1` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_use_certificate_file` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_use_PrivateKey` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_use_PrivateKey_ASN1` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_use_PrivateKey_file` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_use_RSAPrivateKey` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_use_RSAPrivateKey_ASN1` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_use_RSAPrivateKey_file` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_check_chain` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_check_private_key` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_check_private_key` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_add_client_CA` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_add1_to_CA_list` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_add_dir_cert_subjects_to_stack` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_add_file_cert_subjects_to_stack` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_add_store_cert_subjects_to_stack` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_load_client_CA_file` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_load_client_CA_file_ex` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_dup_CA_list` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_set0_CA_list` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_get0_CA_list` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_set_client_CA_list` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_add_client_CA` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_get0_CA_list` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_get0_certificate` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_get0_privatekey` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_get_cert_store` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_set1_cert_store` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_get_client_CA_list` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_add1_to_CA_list` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_set0_CA_list` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_get_client_cert_cb` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_get_default_passwd_cb` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_get_default_passwd_cb_userdata` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_get_client_CA_list` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_get_privatekey` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| **⇒ Certificate Compression** | |
+| `SSL_CTX_set1_cert_comp_preference` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_set1_cert_comp_preference` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_compress_certs` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_compress_certs` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_set1_compressed_cert` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_set1_compressed_cert` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_get1_compressed_cert` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_get1_compressed_cert` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| **⇒ Certificate Verification** | |
+| `SSL_set1_host` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_add1_host` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_set_hostflags` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_set_verify` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_set_verify` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_set_verify_depth` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_set_verify_result` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_get_verify_callback` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_get_verify_depth` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_get_verify_mode` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_get_verify_result` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_get0_peer_CA_list` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_get0_peer_certificate` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_get0_verified_chain` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_get1_peer_certificate` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_get_peer_cert_chain` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_get_peer_certificate` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_certs_clear` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_get0_param` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_get0_param` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_get_verify_mode` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_get_verify_depth` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_set_verify_depth` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_get0_peername` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_set1_param` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_set1_param` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_get0_param` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_get0_param` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_set_purpose` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_set_purpose` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_set_trust` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_set_trust` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| **⇒ PSK** | |
+| `SSL_use_psk_identity_hint` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_use_psk_identity_hint` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_set_psk_client_callback` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_set_psk_find_session_callback` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_set_psk_server_callback` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_set_psk_use_session_callback` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_get_psk_identity` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_get_psk_identity_hint` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| **⇒ SRP** | |
+| `SSL_SRP_CTX_init` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_SRP_CTX_init` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_SRP_CTX_free` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_SRP_CTX_free` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_set_srp_client_pwd_callback` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_set_srp_password` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_get_srp_g` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_set_srp_cb_arg` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_get_srp_N` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_set_srp_username_callback` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_get_srp_username` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_set_srp_server_param` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_get_srp_userinfo` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_srp_server_param_with_username` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_set_srp_strength` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_set_srp_verify_param_callback` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_set_srp_server_param_pw` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_set_srp_username` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SRP_Calc_A_param` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| **⇒ DANE** | |
+| `SSL_CTX_dane_enable` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_get0_dane_tlsa` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_dane_set_flags` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_dane_set_flags` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_dane_clear_flags` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_dane_clear_flags` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_get0_dane` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_dane_enable` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_get0_dane_authority` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_dane_mtype_set` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_dane_tlsa_add` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| **⇒ Certificate Transparency** | |
+| `SSL_CTX_enable_ct` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_ct_is_enabled` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_set_ctlog_list_file` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_set_default_ctlog_list_file` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_set_ct_validation_callback` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_set0_ctlog_store` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_get0_ctlog_store` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_enable_ct` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_ct_is_enabled` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_get0_peer_scts` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_set_ct_validation_callback` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| **⇒ Compression** | |
+| `SSL_COMP_add_compression_method` | HL | 🟩U | 🟩A | 🟩NC\* †5 | 🟢Done |
+| `SSL_COMP_get0_name` | HL | 🟩U | 🟩A | 🟩NC\* †5 | 🟢Done |
+| `SSL_COMP_get_compression_methods` | HL | 🟩U | 🟩A | 🟩NC\* †5 | 🟢Done |
+| `SSL_COMP_get_id` | HL | 🟩U | 🟩A | 🟩NC\* †5 | 🟢Done |
+| `SSL_COMP_get_name` | HL | 🟩U | 🟩A | 🟩NC\* †5 | 🟢Done |
+| `SSL_COMP_set0_compression_methods` | HL | 🟩U | 🟩A | 🟩NC\* †5 | 🟢Done |
+| **⇒ Exporters** | |
+| `SSL_export_keying_material` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_export_keying_material_early` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| **⇒ Renegotiation** | |
+| `SSL_renegotiate` | HL | 🟩U | 🟥FC | 🟩NC\* †5 | 🟢Done |
+| `SSL_renegotiate_abbreviated` | HL | 🟩U | 🟥FC | 🟩NC\* †5 | 🟢Done |
+| `SSL_renegotiate_pending` | HL | 🟩U | 🟧NO | 🟩NC\* †5 | 🟢Done |
+| **⇒ Options** | |
+| `SSL_CTX_clear_options` | HL | 🟩U | 🟩A | 🟨C\* | 🟠Design TBD |
+| `SSL_CTX_set_options` | HL | 🟩U | 🟩A | 🟨C\* | 🟠Design TBD |
+| `SSL_CTX_get_options` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_clear_options` | HL | 🟩U | 🟩A | 🟨C\* | 🟠Design TBD |
+| `SSL_set_options` | HL | 🟩U | 🟩A | 🟨C\* | 🟠Design TBD |
+| `SSL_get_options` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| **⇒ Configuration** | |
+| `SSL_CONF_CTX_new` | Global | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CONF_CTX_free` | Global | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CONF_CTX_set_ssl` | Global | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CONF_CTX_set_ssl_ctx` | Global | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CONF_CTX_set1_prefix` | Global | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CONF_CTX_set_flags` | Global | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CONF_CTX_clear_flags` | Global | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CONF_CTX_finish` | Global | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CONF_cmd` | Global | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CONF_cmd_argv` | Global | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CONF_cmd_value_type` | Global | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_config` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_config` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| **⇒ Callbacks** | |
+| `SSL_CTX_set_cert_cb` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_set_cert_store` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_set_cert_verify_callback` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_set_client_CA_list` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_set_client_cert_cb` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_set_client_cert_engine` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_set_client_hello_cb` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_set_cookie_generate_cb` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_set_cookie_verify_cb` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_set_default_passwd_cb` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_set_default_passwd_cb_userdata` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_set_default_read_buffer_len` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_get_info_callback` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_set_info_callback` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_get_info_callback` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_set_info_callback` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_set_msg_callback` | HL | 🟩U | 🟩A | 🟩NC\* †6 | 🟢Done |
+| `SSL_set_cert_cb` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_set_default_passwd_cb` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_set_default_passwd_cb_userdata` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_get_default_passwd_cb` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_get_default_passwd_cb_userdata` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_set_keylog_callback` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_get_keylog_callback` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_set_psk_client_callback` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_set_psk_find_session_callback` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_set_psk_server_callback` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_set_psk_use_session_callback` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_get_verify_callback` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_set_not_resumable_session_callback` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_set_not_resumable_session_callback` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_set_session_secret_cb` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| **⇒ Session Management** | |
+| `d2i_SSL_SESSION` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `i2d_SSL_SESSION` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `PEM_read_bio_SSL_SESSION` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `PEM_read_SSL_SESSION` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `PEM_write_bio_SSL_SESSION` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `PEM_write_SSL_SESSION` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_SESSION_new` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_SESSION_up_ref` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_SESSION_dup` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_SESSION_free` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_SESSION_print` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_SESSION_print_fp` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_SESSION_print_keylog` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_SESSION_get0_cipher` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_SESSION_set_cipher` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_SESSION_get0_hostname` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_SESSION_set1_hostname` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_SESSION_get0_id_context` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_SESSION_set1_id_context` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_SESSION_get0_peer` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_SESSION_get0_ticket` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_SESSION_get0_ticket_appdata` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_SESSION_set1_ticket_appdata` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_SESSION_has_ticket` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_SESSION_get_protocol_version` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_SESSION_set_protocol_version` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_SESSION_get_compress_id` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_SESSION_get_id` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_SESSION_set1_id` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_SESSION_get_time` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_SESSION_set_time` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_SESSION_get_timeout` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_SESSION_set_timeout` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_SESSION_get_ex_data` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_SESSION_set_ex_data` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_SESSION_get0_hostname` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_SESSION_set1_hostname` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_SESSION_get_master_key` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_SESSION_get_master_key` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_SESSION_is_resumable` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_SESSION_get_max_early_data` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_SESSION_get_max_early_data` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_SESSION_get_max_fragment_length` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_SESSION_get_ticket_lifetime_hint` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_add_session` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_remove_session` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_get1_session` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_get_session` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_set_session` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_sess_get_get_cb` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_sess_set_get_cb` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_sess_get_new_cb` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_sess_set_new_cb` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_sess_get_remove_cb` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_sess_set_remove_cb` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_set_session_id_context` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_set_session_id_context` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_set_generate_session_id` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_set_generate_session_id` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_has_matching_session_id` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_flush_sessions` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_session_reused` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_get_timeout` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_set_timeout` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_get_default_timeout` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_sessions` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| **⇒ Session Ticket Management** | |
+| `SSL_get_num_tickets` | HL | 🟩U | 🟩A | 🟩NC\* †7 | 🟢Done |
+| `SSL_set_num_tickets` | HL | 🟩U | 🟩A | 🟩NC\* †7 | 🟢Done |
+| `SSL_CTX_get_num_tickets` | HL | 🟩U | 🟩A | 🟩NC\* †7 | 🟢Done |
+| `SSL_CTX_set_num_tickets` | HL | 🟩U | 🟩A | 🟩NC\* †7 | 🟢Done |
+| `SSL_new_session_ticket` | HL | 🟩U | 🟩A | 🟨C\* | 🟡TODO |
+| `SSL_set_session_ticket_ext` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_set_session_ticket_ext_cb` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_set_tlsext_ticket_key_evp_cb` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| **⇒ Security Levels** | |
+| `SSL_CTX_get_security_level` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_set_security_level` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_get_security_level` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_set_security_level` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_get_security_callback` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_set_security_callback` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SS_get_security_callback` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SS_set_security_callback` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_get0_security_ex_data` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_set0_security_ex_data` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_get0_security_ex_data` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_set0_security_ex_data` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| **⇒ Custom Extensions** | |
+| `SSL_CTX_add_custom_ext` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_add_client_custom_ext` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_add_server_custom_ext` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_has_client_custom_ext` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| **⇒ Early ClientHello Processing** | |
+| `SSL_client_hello_get_extension_order` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_client_hello_get0_ciphers` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_client_hello_get0_compression_methods` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_client_hello_get0_ext` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_client_hello_get0_legacy_version` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_client_hello_get0_random` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_client_hello_get0_session_id` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_client_hello_get1_extensions_present` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_client_hello_isv2` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| **⇒ SNI** | |
+| `SSL_get_servername` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_get_servername_type` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| **⇒ Server Info** | |
+| `SSL_CTX_use_serverinfo` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_use_serverinfo_ex` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_use_serverinfo_file` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| **⇒ Post-Handshake Authentication** | |
+| `SSL_verify_client_post_handshake` | HL | 🟩U | 🟥FC | 🟨C* †8 | 🟡TODO |
+| `SSL_CTX_set_post_handshake_auth` | HL | 🟩U | 🟥FC | 🟨C* †8 | 🟡TODO |
+| `SSL_set_post_handshake_auth` | HL | 🟩U | 🟥FC | 🟨C* †8 | 🟡TODO |
+| **⇒ DH Parameters** | |
+| `SSL_CTX_set_dh_auto` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_set_dh_auto` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_set0_tmp_dh_pkey` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_set0_tmp_dh_pkey` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_set_tmp_dh_callback` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_set_tmp_dh_callback` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_CTX_set_tmp_dh` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_set_tmp_dh` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| **⇒ State Queries** | |
+| `SSL_in_init` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_in_before` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_is_init_finished` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_get_state` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_rstate_string` | HL | 🟩U | 🟩A | 🟧QSI | 🟠Design TBD |
+| `SSL_rstate_string_long` | HL | 🟩U | 🟩A | 🟧QSI | 🟠Design TBD |
+| `SSL_state_string` | HL | 🟩U | 🟩A | 🟧QSI | 🟠Design TBD |
+| `SSL_state_string_long` | HL | 🟩U | 🟩A | 🟧QSI | 🟠Design TBD |
+| **⇒ Data Path and CSSM** | |
+| `SSL_set_connect_state` | CSSM | 🟩U | 🟩A | 🟧QSI | 🟢Done |
+| `SSL_set_accept_state` | CSSM | 🟩U | 🟩A | 🟧QSI | 🟢Done |
+| `SSL_is_server` | CSSM | 🟩U | 🟩A | 🟧QSI | 🟡TODO |
+| `SSL_peek` | ADP | 🟩U | 🟩A | 🟧QSI | 🟢Done |
+| `SSL_peek_ex` | ADP | 🟩U | 🟩A | 🟧QSI | 🟢Done |
+| `SSL_read` | ADP | 🟩U | 🟩A | 🟧QSI | 🟢Done |
+| `SSL_read_ex` | ADP | 🟩U | 🟩A | 🟧QSI | 🟢Done |
+| `SSL_write` | ADP | 🟩U | 🟩A | 🟧QSI | 🟢Done |
+| `SSL_write_ex` | ADP | 🟩U | 🟩A | 🟧QSI | 🟢Done |
+| `SSL_sendfile` | ADP | 🟩U | 🟩A | 🟧QSI | 🟠Design TBD |
+| `SSL_pending` | ADP | 🟩U | 🟩A | 🟧QSI | 🟠Design TBD |
+| `SSL_has_pending` | ADP | TBD | 🟩A | 🟧QSI | 🟠Design TBD |
+| `SSL_accept` | CSSM | 🟩U | 🟩A | 🟧QSI | 🟢Done |
+| `SSL_connect` | CSSM | 🟩U | 🟩A | 🟧QSI | 🟢Done |
+| `SSL_do_handshake` | CSSM | 🟩U | 🟩A | 🟧QSI | 🟢Done |
+| `SSL_set0_wbio` | NDP | 🟩U | 🟩A | 🟧QSI | 🟢Done |
+| `SSL_set0_rbio` | NDP | 🟧C | 🟩A | 🟧QSI | 🟢Done |
+| `SSL_set_bio` | NDP | 🟧C | 🟩A | 🟧QSI | 🟢Done |
+| `SSL_get_wbio` | NDP | 🟧C | 🟩A | 🟧QSI | 🟢Done |
+| `SSL_get_rbio` | NDP | 🟧C | 🟩A | 🟧QSI | 🟢Done |
+| `SSL_get_error` | NDP | 🟩U | 🟩A | 🟧QSI | Done — needs review |
+| `SSL_get_rfd` | NDP | 🟩U | 🟩A | 🟩NC | 🟢Done |
+| `SSL_get_wfd` | NDP | 🟩U | 🟩A | 🟩NC | 🟢Done |
+| `SSL_get_fd` | NDP | 🟩U | 🟩A | 🟩NC | 🟢Done |
+| `SSL_set_rfd` | NDP | 🟧C | 🟩A | 🟧QSI | 🟡TODO |
+| `SSL_set_wfd` | NDP | 🟧C | 🟩A | 🟧QSI | 🟡TODO |
+| `SSL_set_fd` | NDP | 🟩U | 🟩A | 🟧QSI | 🟡TODO |
+| `SSL_key_update` | RL | 🟩U | 🟩A | 🟧QSI | 🟠Design TBD |
+| `SSL_get_key_update_type` | RL | 🟩U | 🟩A | 🟧QSI | 🟠Design TBD |
+| `SSL_clear`  (connection) | CSSM | TBD | 🟩A | 🟧QSI | 🟡TODO |
+| `SSL_clear`  (stream) | CSSM | TBD | 🟩A | 🟧QSI | 🟠Design TBD |
+| `SSL_shutdown` | CSSM | 🟧C | 🟩A | 🟧QSI | 🟡TODO |
+| `SSL_want` | ADP | 🟧C | 🟩A | 🟧QSI | 🟡TODO |
+| `BIO_new_ssl_connect` | Global | 🟩U | 🟩A | 🟧QSI | 🟡TODO |
+| `BIO_new_buffer_ssl_connect` | Global | 🟩U | 🟦U | 🟧QSI | 🟡TODO |
+| `SSL_get_shutdown` | CSSM | 🟩U | 🟩A | 🟧QSI | 🟠Design TBD |
+| `SSL_set_shutdown` | CSSM | 🟩U | 🟩A | 🟧QSI | 🟠Design TBD |
+| **⇒ New APIs** | |
+| `SSL_tick` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟢Done |
+| `SSL_get_tick_timeout` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟢Done |
+| `SSL_get_blocking_mode` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟢Done |
+| `SSL_get_blocking_mode` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟢Done |
+| `SSL_set_blocking_mode` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟢Done |
+| `SSL_get_rpoll_descriptor` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟢Done |
+| `SSL_get_wpoll_descriptor` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟢Done |
+| `SSL_want_net_read` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟢Done |
+| `SSL_want_net_write` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟢Done |
+| `SSL_get_initial_peer_addr` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟢Done |
+| `SSL_set_initial_peer_addr` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟢Done |
+| `SSL_shutdown_ex` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟡TODO |
+| `SSL_stream_conclude` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟡TODO |
+| `SSL_stream_reset` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟡TODO |
+| `SSL_get_stream_state` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟡TODO |
+| `SSL_get_stream_error_code` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟡TODO |
+| `SSL_get_conn_close_info` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟡TODO |
+| **⇒ Currently Not Supported** | |
+| `SSL_copy_session_id` | Special | 🟩U | 🟥FC | 🟨C* | 🟡TODO |
+| `BIO_ssl_copy_session_id` | Special | 🟩U | 🟥FC | 🟨C* | 🟡TODO |
+| `SSL_CTX_set_quiet_shutdown` | CSSM | 🟩U | 🟥FC | 🟨C* | 🟡TODO |
+| `SSL_CTX_get_quiet_shutdown` | CSSM | 🟩U | 🟧NO | 🟨C* | 🟡TODO |
+| `SSL_set_quiet_shutdown` | CSSM | 🟩U | 🟥FC | 🟨C* | 🟡TODO |
+| `SSL_get_quiet_shutdown` | CSSM | 🟩U | 🟧NO | 🟨C* | 🟡TODO |
+| `SSL_CTX_set_ssl_version` | HL | 🟩U | 🟥FC | 🟨C* | 🟡TODO |
+| **⇒ Async** | |
+| `SSL_CTX_set_async_callback` | Async | 🟩U | 🟧NO | 🟩NC* †10 | 🟢Done |
+| `SSL_set_async_callback` | Async | 🟩U | 🟧NO | 🟩NC* †10 | 🟢Done |
+| `SSL_CTX_set_async_callback_arg` | Async | 🟩U | 🟧NO | 🟩NC* †10 | 🟢Done |
+| `SSL_set_async_callback_arg` | Async | 🟩U | 🟧NO | 🟩NC* †10 | 🟢Done |
+| `SSL_waiting_for_async` | Async | 🟩U | 🟧NO | 🟩NC* †10 | 🟢Done |
+| `SSL_get_async_status` | Async | 🟩U | 🟧NO | 🟩NC* †10 | 🟢Done |
+| `SSL_get_all_async_fds` | Async | 🟩U | 🟧NO | 🟩NC* †10 | 🟢Done |
+| `SSL_get_changed_async_fds` | Async | 🟩U | 🟧NO | 🟩NC* †10 | 🟢Done |
+| **⇒ Readahead** | |
+| `SSL_CTX_get_default_read_ahead` | RL | 🟩U | 🟧NO | 🟨C* | 🟡TODO |
+| `SSL_CTX_get_read_ahead` | RL | 🟩U | 🟧NO | 🟨C* | 🟡TODO |
+| `SSL_CTX_set_read_ahead` | RL | 🟩U | 🟧NO | 🟨C* | 🟡TODO |
+| `SSL_get_read_ahead` | RL | 🟩U | 🟧NO | 🟨C* | 🟡TODO |
+| `SSL_set_read_ahead` | RL | 🟩U | 🟧NO | 🟨C* | 🟡TODO |
+| `SSL_CTX_set_default_read_buffer_len` | RL | 🟩U | 🟧NO | 🟨C* | 🟡TODO |
+| `SSL_set_default_read_buffer_len` | RL | 🟩U | 🟧NO | 🟨C* | 🟡TODO |
+| **⇒ Record Padding and Fragmentation** | |
+| `SSL_CTX_set_record_padding_callback` | RL | 🟩U | 🟥FC | 🟨C* | 🟡TODO |
+| `SSL_set_record_padding_callback` | RL | 🟩U | 🟥FC | 🟨C* | 🟡TODO |
+| `SSL_CTX_get_record_padding_callback_arg` | RL | 🟩U | 🟥FC | 🟨C* | 🟡TODO |
+| `SSL_CTX_set_record_padding_callback_arg` | RL | 🟩U | 🟥FC | 🟨C* | 🟡TODO |
+| `SSL_get_record_padding_callback_arg` | RL | 🟩U | 🟥FC | 🟨C* | 🟡TODO |
+| `SSL_set_record_padding_callback_arg` | RL | 🟩U | 🟥FC | 🟨C* | 🟡TODO |
+| `SSL_CTX_set_block_padding` | RL | 🟩U | 🟥FC | 🟨C* | 🟡TODO |
+| `SSL_set_block_padding` | RL | 🟩U | 🟥FC | 🟨C* | 🟡TODO |
+| `SSL_CTX_set_tlsext_max_fragment_length` | RL | 🟩U | 🟥FC | 🟨C* | 🟡TODO |
+| `SSL_set_tlsext_max_fragment_length` | RL | 🟩U | 🟥FC | 🟨C* | 🟡TODO |
+| **⇒ Stateless/HelloRetryRequest** | |
+| `SSL_stateless` | RL | 🟩U | 🟥FC | 🟨C* | 🟡TODO |
+| `SSL_CTX_set_stateless_cookie_generate_cb` | RL | 🟩U | 🟥FC | 🟨C* | 🟡TODO |
+| `SSL_CTX_set_stateless_cookie_verify_cb` | RL | 🟩U | 🟥FC | 🟨C* | 🟡TODO |
+| **⇒ Early Data/0-RTT** | |
+| `SSL_CTX_set_allow_early_data_cb` | 0-RTT | 🟩U | 🟥FC | 🟨C* | 🟡TODO |
+| `SSL_set_allow_early_data_cb` | 0-RTT | 🟩U | 🟥FC | 🟨C* | 🟡TODO |
+| `SSL_CTX_get_recv_max_early_data` | 0-RTT | 🟩U | 🟥FC | 🟨C* | 🟡TODO |
+| `SSL_CTX_set_recv_max_early_data` | 0-RTT | 🟩U | 🟥FC | 🟨C* | 🟡TODO |
+| `SSL_get_recv_max_early_data` | 0-RTT | 🟩U | 🟥FC | 🟨C* | 🟡TODO |
+| `SSL_set_recv_max_early_data` | 0-RTT | 🟩U | 🟥FC | 🟨C* | 🟡TODO |
+| `SSL_CTX_get_max_early_data` | 0-RTT | 🟩U | 🟥FC | 🟨C* | 🟡TODO |
+| `SSL_CTX_set_max_early_data` | 0-RTT | 🟩U | 🟥FC | 🟨C* | 🟡TODO |
+| `SSL_get_max_early_data` | 0-RTT | 🟩U | 🟥FC | 🟨C* | 🟡TODO |
+| `SSL_set_max_early_data` | 0-RTT | 🟩U | 🟥FC | 🟨C* | 🟡TODO |
+| `SSL_read_early_data` | 0-RTT | 🟩U | 🟥FC | 🟨C* | 🟡TODO |
+| `SSL_write_early_data` | 0-RTT | 🟩U | 🟥FC | 🟨C* | 🟡TODO |
+| `SSL_get_early_data_status` | 0-RTT | 🟩U | 🟥FC | 🟨C* | 🟡TODO |
+| **⇒ Miscellaneous** | |
+| `DTLSv1_listen` | RL | 🟩U | 🟦U | 🟩NC | 🟢Done |
+| `DTLS_set_timer_cb` | NDP | 🟩U | 🟦U | 🟩NC | 🟢Done |
+| `DTLS_get_data_mtu` | NDP | 🟩U | 🟦U | 🟩NC | 🟢Done |
+| `SSL_get_ex_data_X509_STORE_CTX_idx` | Global | 🟩U | 🟦U | 🟩NC | 🟢Done |
+| `BIO_ssl_shutdown` | Global | 🟩U | 🟩A | 🟩NC | 🟢Done |
+| `SSL_alloc_buffers` | HL | 🟩U | 🟩A | 🟨C\* | 🟠Design TBD |
+| `SSL_free_buffers` | HL | 🟩U | 🟩A | 🟨C\* | 🟠Design TBD |
+| `SSL_trace` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| `SSL_set_debug` | HL | 🟩U | 🟩A | 🟩NC\* | 🟢Done |
+| **⇒ Controls** | |
+| `SSL_CTRL_MODE` | Special | 🟩U | 🟩A | 🟧QSI | 🟡TODO |
+| `SSL_CTRL_CLEAR_MODE` | Special | 🟩U | 🟩A | 🟧QSI | 🟡TODO |
+| `SSL_CTRL_CLEAR_NUM_RENEGOTIATIONS` | HL | 🟩U | 🟧NO | 🟩NC* | 🟢Done |
+| `SSL_CTRL_GET_NUM_RENEGOTIATIONS` | HL | 🟩U | 🟧NO | 🟩NC* | 🟢Done |
+| `SSL_CTRL_GET_TOTAL_RENEGOTIATIONS` | HL | 🟩U | 🟧NO | 🟩NC* | 🟢Done |
+| `SSL_CTRL_GET_RI_SUPPORT` | HL | 🟩U | 🟧NO | 🟩NC* | 🟢Done |
+| `SSL_CTRL_GET_READ_AHEAD` | HL | 🟩U | 🟧NO | 🟩NC* | 🟢Done |
+| `SSL_CTRL_SET_READ_AHEAD` | HL | 🟩U | 🟥FC | 🟨C* | 🟡TODO |
+| `SSL_CTRL_SET_MAX_PIPELINES` | RL | 🟩U | 🟥FC | 🟨C* | 🟡TODO |
+| `SSL_CTRL_SET_MAX_SEND_FRAGMENT` | RL | 🟩U | 🟥FC | 🟨C* | 🟡TODO |
+| `SSL_CTRL_SET_SPLIT_SEND_FRAGMENT` | RL | 🟩U | 🟥FC | 🟨C* | 🟡TODO |
+| `SSL_CTRL_SET_MTU` | RL | 🟩U | 🟥FC | 🟩NC* | 🟢Done |
+| `SSL_CTRL_SET_MAX_PROTO_VERSION` | HL | 🟩U | 🟩A | 🟨C* | 🟡TODO |
+| `SSL_CTRL_SET_MIN_PROTO_VERSION` | HL | 🟩U | 🟩A | 🟨C* | 🟡TODO |
+| `SSL_CTRL_GET_MAX_PROTO_VERSION` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_GET_MIN_PROTO_VERSION` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_BUILD_CERT_CHAIN` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_CERT_FLAGS` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_CHAIN` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_CHAIN_CERT` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_CLEAR_CERT_FLAGS` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_CLEAR_EXTRA_CHAIN_CERTS` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_EXTRA_CHAIN_CERT` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_GET_CHAIN_CERTS` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_GET_CHAIN_CERT_STORE` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_GET_CLIENT_CERT_REQUEST` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_GET_CLIENT_CERT_TYPES` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_GET_EC_POINT_FORMATS` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_GET_EXTMS_SUPPORT` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_GET_EXTRA_CHAIN_CERTS` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_GET_FLAGS` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_GET_GROUPS` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_GET_IANA_GROUPS` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_GET_MAX_CERT_LIST` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_GET_NEGOTIATED_GROUP` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_GET_PEER_SIGNATURE_NID` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_GET_PEER_TMP_KEY` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_GET_RAW_CIPHERLIST` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_GET_SESS_CACHE_MODE` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_GET_SESS_CACHE_SIZE` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_GET_SHARED_GROUP` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_GET_SIGNATURE_NID` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_GET_TLSEXT_STATUS_REQ_CB` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_GET_TLSEXT_STATUS_REQ_CB_ARG` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_GET_TLSEXT_STATUS_REQ_EXTS` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_GET_TLSEXT_STATUS_REQ_IDS` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_GET_TLSEXT_STATUS_REQ_OCSP_RESP` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_GET_TLSEXT_STATUS_REQ_TYPE` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_GET_TLSEXT_TICKET_KEYS` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_GET_TMP_KEY` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_GET_VERIFY_CERT_STORE` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_SELECT_CURRENT_CERT` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_SESS_ACCEPT` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_SESS_ACCEPT_GOOD` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_SESS_ACCEPT_RENEGOTIATE` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_SESS_CACHE_FULL` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_SESS_CB_HIT` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_SESS_CONNECT` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_SESS_CONNECT_GOOD` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_SESS_CONNECT_RENEGOTIATE` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_SESS_HIT` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_SESS_MISSES` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_SESS_NUMBER` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_SESS_TIMEOUTS` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_SET_CHAIN_CERT_STORE` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_SET_CLIENT_CERT_TYPES` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_SET_CLIENT_SIGALGS` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_SET_CLIENT_SIGALGS_LIST` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_SET_CURRENT_CERT` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_SET_DH_AUTO` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_SET_GROUPS` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_SET_GROUPS_LIST` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_SET_MAX_CERT_LIST` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_SET_MSG_CALLBACK` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_SET_MSG_CALLBACK_ARG` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_SET_NOT_RESUMABLE_SESS_CB` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_SET_RETRY_VERIFY` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_SET_SESS_CACHE_MODE` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_SET_SESS_CACHE_SIZE` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_SET_SIGALGS` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_SET_SIGALGS_LIST` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_SET_SRP_ARG` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_SET_SRP_GIVE_CLIENT_PWD_CB` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_SET_SRP_VERIFY_PARAM_CB` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_SET_TLSEXT_DEBUG_ARG` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_SET_TLSEXT_DEBUG_CB` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_SET_TLSEXT_HOSTNAME` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_SET_TLSEXT_SERVERNAME_ARG` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_SET_TLSEXT_SERVERNAME_CB` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_SET_TLS_EXT_SRP_PASSWORD` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_SET_TLS_EXT_SRP_STRENGTH` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_SET_TLS_EXT_SRP_USERNAME` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_SET_TLS_EXT_SRP_USERNAME_CB` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_SET_TLSEXT_STATUS_REQ_CB` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_SET_TLSEXT_STATUS_REQ_CB_ARG` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_SET_TLSEXT_STATUS_REQ_EXTS` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_SET_TLSEXT_STATUS_REQ_IDS` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_SET_TLSEXT_STATUS_REQ_OCSP_RESP` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_SET_TLSEXT_STATUS_REQ_TYPE` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_SET_TLSEXT_TICKET_KEY_CB` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_SET_TLSEXT_TICKET_KEYS` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_SET_TMP_DH` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_SET_TMP_DH_CB` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_SET_TMP_ECDH` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| `SSL_CTRL_SET_VERIFY_CERT_STORE` | HL | 🟩U | 🟩A | 🟩NC* | 🟢Done |
+| **⇒ SSL Modes** | |
+| `SSL_MODE_ENABLE_PARTIAL_WRITE` | ADP | 🟩U | 🟩A | 🟧QSI | 🟢Done |
+| `SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER` | ADP | 🟩U | 🟩A | 🟧QSI | 🟢Done |
+| `SSL_MODE_RELEASE_BUFFERS` | ADP | 🟩U | 🟧NO | 🟩NC | 🟢Done |
+| `SSL_MODE_ASYNC` | ADP | 🟩U | 🟧NO | 🟩NC | 🟢Done |
+| `SSL_MODE_AUTO_RETRY` | ADP | TBD | TBD | TBD | 🔴Pending Triage |
+| `SSL_MODE_SEND_FALLBACK_SCSV` | HL | 🟩U | 🟩A | 🟨C\* | 🟡TODO |

--- a/doc/designs/quic-design/quic-api-ssl-funcs.md
+++ b/doc/designs/quic-design/quic-api-ssl-funcs.md
@@ -634,8 +634,10 @@ Notes:
 | `SSL_shutdown_ex` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟡TODO |
 | `SSL_stream_conclude` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟡TODO |
 | `SSL_stream_reset` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟡TODO |
-| `SSL_get_stream_state` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟡TODO |
-| `SSL_get_stream_error_code` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟡TODO |
+| `SSL_get_stream_read_state` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟡TODO |
+| `SSL_get_stream_write_state` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟡TODO |
+| `SSL_get_stream_read_error_code` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟡TODO |
+| `SSL_get_stream_write_error_code` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟡TODO |
 | `SSL_get_conn_close_info` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟡TODO |
 | **⇒ New APIs for Multi-Stream** | |
 | `SSL_get0_connection` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟡TODO |
@@ -645,7 +647,8 @@ Notes:
 | `SSL_new_stream` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟡TODO |
 | `SSL_accept_stream` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟡TODO |
 | `SSL_get_accept_stream_queue_len` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟡TODO |
-| `SSL_set_default_stream_type` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟡TODO |
+| `SSL_set_default_stream_mode` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟡TODO |
+| `SSL_set_incoming_stream_reject_policy` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟡TODO |
 | `SSL_detach_stream` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟡TODO |
 | `SSL_attach_stream` | CSSM | 🟦N | 🟩A | 🟥QSA | 🟡TODO |
 | **⇒ Currently Not Supported** | |

--- a/doc/designs/quic-design/quic-api.md
+++ b/doc/designs/quic-design/quic-api.md
@@ -228,7 +228,7 @@ error occurs.
 
 We have to implement all of the following modes:
 
-- `SSL_ENABLE_PARTIAL_WRITE` on or off
+- `SSL_MODE_ENABLE_PARTIAL_WRITE` on or off
 - `SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER` on or off
 - Blocking mode on or off
 
@@ -613,11 +613,12 @@ for a duration it chooses.
 
 If `SSL_SHUTDOWN_FLAG_RAPID` is specified in `flags`, a rapid shutdown is
 performed, otherwise an RFC-compliant shutdown is performed. The principal
-effect of this flag is to disable blocking behaviour in blocking mode, and the
-QUIC implementation will still attempt to implement the Terminating state
-semantics if the application happens to tick it, until it reaches the Terminated
-state or is freed. An application can change its mind about performing a rapid
-shutdown by making a subsequent call to `SSL_shutdown_ex` without the flag set.
+effect of this flag is to partially disable blocking behaviour in blocking mode,
+and the QUIC implementation will still attempt to implement the Terminating
+state semantics if the application happens to tick it, until it reaches the
+Terminated state or is freed. An application can change its mind about
+performing a rapid shutdown by making a subsequent call to `SSL_shutdown_ex`
+without the flag set.
 
 Calling `SSL_shutdown_ex` on a QUIC stream SSL object is not valid; such a call
 will fail and has no effect. The rationale for this is that an application may
@@ -721,7 +722,7 @@ no-ops. This is considered a success case.
  * e.g. Non-QUIC SSL object, or QUIC connection SSL object without a default
  * stream.
  */
-#define SSL_STREAM_STATE_NONE           0
+#define SSL_STREAM_STATE_NONE                   0
 /*
  * The read or write part of the stream has been finished in a normal manner.
  *
@@ -733,12 +734,17 @@ no-ops. This is considered a success case.
  * already indicated the end of the stream by calling SSL_stream_conclude,
  * and that future calls to SSL_write will fail.
  */
-#define SSL_STREAM_STATE_FINISHED       1
+#define SSL_STREAM_STATE_FINISHED               1
 
 /*
- * The stream was reset by the local or remote party.
+ * The stream was reset by the local party.
  */
-#define SSL_STREAM_STATE_RESET          2
+#define SSL_STREAM_STATE_RESET_LOCAL            2
+
+/*
+ * The stream was reset by the remote party.
+ */
+#define SSL_STREAM_STATE_RESET_REMOTE           3
 
 /*
  * The underlying connection supporting the stream has closed or otherwise
@@ -751,7 +757,7 @@ no-ops. This is considered a success case.
  * For SSL_get_stream_write_state, this means that attempts to write to the
  * stream will fail.
  */
-#define SSL_STREAM_STATE_CONN_CLOSED    3
+#define SSL_STREAM_STATE_CONN_CLOSED            4
 
 int SSL_get_stream_read_state(SSL *ssl);
 int SSL_get_stream_write_state(SSL *ssl);
@@ -1113,8 +1119,8 @@ side, since multiple connections will share the same socket, which will
 presumably be associated with some kind of enduring listener object. Thus when
 server support is implemented in the future connection teardown could be handled
 internally by maintaining the state of connections undergoing termination inside
-the listener object. However, similar caveats to those discussed here when the
-listener object itself is to be town down. (It is also possible we could
+the listener object. However, similar caveats to those discussed here arise when
+the listener object itself is to be town down. (It is also possible we could
 optionally allow use of the server-style API to make multiple outgoing client
 connections with a non-zero-length client-side CID on the same underlying
 network BIO.)

--- a/doc/designs/quic-design/quic-api.md
+++ b/doc/designs/quic-design/quic-api.md
@@ -394,7 +394,8 @@ Should not require any changes.
 
 - `SSL_MODE_ENABLE_PARTIAL_WRITE`: Implemented. If this mode is set during a
   non-partial-write `SSL_write` operation spanning multiple `SSL_write` calls,
-  this operation is aborted and partial write mode begins immediately.
+  this mode does not take effect until the non-partial write operation is
+  completed.
 
 - `SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER`: Implemented.
 
@@ -423,9 +424,6 @@ TBD: Should any of these be implemented as ctrls rather than actual functions?
 Advances the QUIC state machine to the extent feasible, potentially performing
 network I/O. Also compatible with DTLSv1 and supercedes `DTLSv1_handle_timeout`
 for all use cases.
-
-TBD: Should we just map this to DTLS_CTRL_HANDLE_TIMEOUT internally (and maybe
-alias the CTRL #define)?
 
 TBD: Deprecate `DTLSv1_get_timeout`?
 TBD: Deprecate `DTLSv1_handle_timeout`?
@@ -1185,3 +1183,12 @@ Where connection closure is initiated remotely rather than locally, only the
 draining state is relevant. Since we conclude above that we do not need to
 implement the draining state on the client side, this means that connection
 closure can be completed immediately in the case of a remote closure.
+
+**Q. Should we just map `SSL_tick` to `DTLS_CTRL_HANDLE_TIMEOUT` internally?**
+
+A. No, since the infinite time representation is different between the two
+calls.
+
+**Q. How should `STOP_SENDING` be supported?**
+
+TODO: Determine how `STOP_SENDING` should be supported.

--- a/doc/designs/quic-design/quic-api.md
+++ b/doc/designs/quic-design/quic-api.md
@@ -5,6 +5,97 @@ This document sets out the objectives of the QUIC API design process, describes
 the new and changed APIs, and the design constraints motivating those API
 designs and the relevant design decisions.
 
+- [QUIC API Overview](#quic-api-overview)
+  * [Overview and Implementation Status](#overview-and-implementation-status)
+  * [Objectives](#objectives)
+  * [SSL Objects](#ssl-objects)
+    + [Structure of Documentation](#structure-of-documentation)
+    + [Existing APIs](#existing-apis)
+      - [`SSL_set_connect_state`](#-ssl-set-connect-state-)
+      - [`SSL_set_accept_state`](#-ssl-set-accept-state-)
+      - [`SSL_is_server`](#-ssl-is-server-)
+      - [`SSL_connect`](#-ssl-connect-)
+      - [`SSL_accept`](#-ssl-accept-)
+      - [`SSL_do_handshake`](#-ssl-do-handshake-)
+      - [`SSL_read`, `SSL_read_ex`, `SSL_peek`, `SSL_peek_ex`](#-ssl-read----ssl-read-ex----ssl-peek----ssl-peek-ex-)
+      - [`SSL_write`, `SSL_write_ex`](#-ssl-write----ssl-write-ex-)
+      - [`SSL_pending`](#-ssl-pending-)
+      - [`SSL_has_pending`](#-ssl-has-pending-)
+      - [`SSL_shutdown`](#-ssl-shutdown-)
+      - [`SSL_clear`](#-ssl-clear-)
+      - [`SSL_free`](#-ssl-free-)
+      - [`SSL_set0_rbio`, `SSL_set0_wbio`, `SSL_set_bio`](#-ssl-set0-rbio----ssl-set0-wbio----ssl-set-bio-)
+      - [`SSL_set_[rw]fd`](#-ssl-set--rw-fd-)
+      - [`SSL_get_[rw]fd`](#-ssl-get--rw-fd-)
+      - [`SSL_CTRL_MODE`, `SSL_CTRL_CLEAR_MODE`](#-ssl-ctrl-mode----ssl-ctrl-clear-mode-)
+      - [SSL Modes](#ssl-modes)
+    + [New APIs](#new-apis)
+      - [`SSL_tick`](#-ssl-tick-)
+      - [`SSL_get_tick_timeout`](#-ssl-get-tick-timeout-)
+      - [`SSL_set_blocking_mode`, `SSL_get_blocking_mode`](#-ssl-set-blocking-mode----ssl-get-blocking-mode-)
+      - [`SSL_get_rpoll_descriptor`, `SSL_get_wpoll_descriptor`](#-ssl-get-rpoll-descriptor----ssl-get-wpoll-descriptor-)
+      - [`SSL_want_net_read`, `SSL_want_net_write`](#-ssl-want-net-read----ssl-want-net-write-)
+      - [`SSL_want`, `SSL_want_read`, `SSL_want_write`](#-ssl-want----ssl-want-read----ssl-want-write-)
+      - [`SSL_set_initial_peer_addr`, `SSL_get_initial_peer_addr`](#-ssl-set-initial-peer-addr----ssl-get-initial-peer-addr-)
+      - [`SSL_shutdown_ex`](#-ssl-shutdown-ex-)
+      - [`SSL_stream_conclude`](#-ssl-stream-conclude-)
+      - [`SSL_stream_reset`](#-ssl-stream-reset-)
+      - [`SSL_get_stream_state`](#-ssl-get-stream-state-)
+      - [`SSL_get_stream_error_code`](#-ssl-get-stream-error-code-)
+      - [`SSL_get_conn_close_info`](#-ssl-get-conn-close-info-)
+    + [Future APIs](#future-apis)
+  * [BIO Objects](#bio-objects)
+    + [Existing APIs](#existing-apis-1)
+      - [`BIO_s_connect`, `BIO_new_ssl_connect`, `BIO_set_conn_hostname`](#-bio-s-connect----bio-new-ssl-connect----bio-set-conn-hostname-)
+      - [`BIO_new_bio_pair`](#-bio-new-bio-pair-)
+      - [Interactions with `BIO_f_buffer`](#interactions-with--bio-f-buffer-)
+      - [MTU Signalling](#mtu-signalling)
+    + [New APIs](#new-apis-1)
+      - [`BIO_sendmmsg` and `BIO_recvmmsg`](#-bio-sendmmsg--and--bio-recvmmsg-)
+      - [Truncation Mode](#truncation-mode)
+      - [Capability Negotiation](#capability-negotiation)
+      - [Local Address Support](#local-address-support)
+      - [`BIO_s_dgram_pair`](#-bio-s-dgram-pair-)
+      - [`BIO_POLL_DESCRIPTOR`](#-bio-poll-descriptor-)
+      - [`BIO_s_dgram_mem`](#-bio-s-dgram-mem-)
+      - [`BIO_err_is_non_fatal`](#-bio-err-is-non-fatal-)
+  * [Q & A](#q---a)
+  * [Implementation Status](#implementation-status)
+
+Overview and Implementation Status
+----------------------------------
+
+A listing of all SSL object APIs and their implications for QUIC, including
+current implementation status, can be found in
+[quic-api-ssl-funcs.md](./quic-api-ssl-funcs.md).
+
+Non-SSL object APIs which are new or changed, or otherwise discussed in this
+document are listed below, along with their implementation status. SSL object
+APIs are not listed here; see [quic-api-ssl-funcs.md](./quic-api-ssl-funcs.md)
+for details on SSL object APIs.
+
+| Semantics | API                             | Status |
+|-----------|---------------------------------|--------|
+| TBD       | `BIO_s_connect`                 | TODO  |
+| TBD       | `BIO_set_conn_hostname`         | TODO   |
+| TBD       | `BIO_new_bio_pair`              | TODO   |
+| New       | `BIO_s_dgram_pair`              | Done   |
+| Unchanged | `BIO_dgram_get_mtu`             | Done   |
+| Unchanged | `BIO_dgram_set_mtu`             | Done   |
+| New       | `BIO_sendmmsg`                  | Done   |
+| New       | `BIO_recvmmsg`                  | Done   |
+| New       | `BIO_dgram_set_no_trunc`        | Done   |
+| New       | `BIO_dgram_get_no_trunc`        | Done   |
+| New       | `BIO_dgram_set_caps`            | Done   |
+| New       | `BIO_dgram_get_caps`            | Done   |
+| New       | `BIO_dgram_get_effective_caps`  | Done   |
+| New       | `BIO_dgram_get_local_addr_cap`  | Done   |
+| New       | `BIO_dgram_set_local_addr_enable` | Done  |
+| New       | `BIO_dgram_get_local_addr_enable` | Done  |
+| New       | `BIO_get_rpoll_descriptor`      | Done   |
+| New       | `BIO_get_wpoll_descriptor`      | Done   |
+| New       | `BIO_err_is_non_fatal`          | Done   |
+
 Objectives
 ----------
 

--- a/doc/designs/quic-design/quic-api.md
+++ b/doc/designs/quic-design/quic-api.md
@@ -846,9 +846,9 @@ eventually be MSMT-safe.
 
 The blocking mode can be configured on each SSL object individually. When a QUIC
 stream SSL object is created it inherits its blocking state from the currently
-configured blocking state of the QUIC connection SSL object at the  time the
+configured blocking state of the QUIC connection SSL object at the time the
 stream is created. This can be changed independently. For example, a QUIC
-connection SSL object can be in blokcing mode to allow for blocking
+connection SSL object can be in blocking mode to allow for blocking
 `SSL_accept_stream` calls, yet have some or all QUIC stream SSL objects be in
 non-blocking mode concurrently.
 
@@ -931,15 +931,15 @@ __owur uint64_t SSL_get_stream_id(SSL *ssl);
  *
  * For QUIC:
  *   Creates a new stream. Must be called only on a QUIC connection SSL object.
- *   Can be used on client or server. If the SSL_FLAG_UNI flag is set, the
- *   created stream is unidirectional, otherwise it is bidirectional.
+ *   Can be used on client or server. If the SSL_STREAM_FLAG_UNI flag is set,
+ *   the created stream is unidirectional, otherwise it is bidirectional.
  *
  *   To be MSMT-safe.
  *
  * For TLS and DTLS SSL objects:
  *   Always fails.
  */
-#define SSL_FLAG_UNI    1
+#define SSL_STREAM_FLAG_UNI    1
 
 SSL *SSL_new_stream(SSL *ssl, uint64_t flags);
 ```
@@ -948,7 +948,7 @@ SSL *SSL_new_stream(SSL *ssl, uint64_t flags);
 
 ```c
 /*
- * Create a new SSL object representing an additional stream which has created
+ * Create a new SSL object representing an additional stream which was created
  * by the peer.
  *
  * There is no need to call SSL_accept on the resulting object, and
@@ -958,7 +958,8 @@ SSL *SSL_new_stream(SSL *ssl, uint64_t flags);
  *   Must be called only on a QUIC connection SSL object. Fails if called on a
  *   stream object. Checks if a new stream has been created by the peer. If it
  *   has, creates a new SSL object to represent it and returns it. Otherwise,
- *   returns NULL.
+ *   returns NULL. If multiple streams are available to be accepted, the oldest
+ *   stream (that is, the stream with the lowest stream ID) is accepted.
  *
  * For all other methods:
  *   Returns NULL.
@@ -980,9 +981,9 @@ SSL *SSL_accept_stream(SSL *ssl, uint64_t flags);
 ```c
 /*
  * Determine the number of streams waiting to be returned on a subsequent call
- * to SSL_accept_stream. If this returns a non-zero value, SSL_accept_stream is
- * guaranteed to work. Returns 0 for non-QUIC objects, or for QUIC stream
- * objects.
+ * to SSL_accept_stream. If this returns a non-zero value, the next call to
+ * SSL_accept_stream (on any thread) is guaranteed to work. Returns 0 for
+ * non-QUIC objects, or for QUIC stream objects.
  *
  * To be MSMT-safe.
  */

--- a/doc/designs/quic-design/quic-api.md
+++ b/doc/designs/quic-design/quic-api.md
@@ -1,0 +1,617 @@
+QUIC API Overview
+=================
+
+This document sets out the objectives of the QUIC API design process, describes
+the new and changed APIs, and the design constraints motivating those API
+designs and the relevant design decisions.
+
+Objectives
+----------
+
+The objectives of the QUIC API design are:
+
+- to provide an API suitable for use with QUIC, now and in the future;
+
+- to reuse the existing libssl APIs to the extent feasible;
+
+- to enable existing applications to adapt to using QUIC with only
+  minimal API changes.
+
+SSL Objects
+-----------
+
+### Structure of Documentation
+
+Each API listed below has an information table with the following fields:
+
+- **Semantics**: This can be one of:
+
+    - **Unchanged**: The semantics of this existing libssl API call are
+      unchanged.
+    - **Changed**: The semantics are changed for QUIC.
+    - **New**: The API is new for QUIC.
+
+- `SSL_get_error`: Can this API, when used with QUIC, change the
+  state returned by `SSL_get_error`? This can be any combination of:
+
+    - **Never**: Does not interact with `SSL_get_error`.
+    - **Error**: Non-`WANT_READ`/`WANT_WRITE` errors can be raised.
+    - **Want**: `WANT_READ`/`WANT_WRITE` can be raised.
+
+- **Can Tick?**: Whether this function is allowed to tick the QUIC state
+  machine and potentially perform network I/O.
+
+- **CSHL:** Connection/Stream/Handshake Layer classification.
+  This can be one of:
+
+    - **HL:** This is a handshake layer related call. It should be supported
+      on a QUIC connection SSL object, forwarding to the handshake layer
+      SSL object.
+
+      Whether we allow QUIC stream SSL objects to have these calls forwarded is
+      TBD.
+
+    - **HL-Forbidden:** This is a handshake layer related call, but it is
+      inapplicable to QUIC, so it is not supported.
+
+    - **C:** Not handshake-layer related. QUIC connection SSL object usage only.
+      Fails on a QUIC stream SSL object.
+
+    - **CS:** Not handshake-layer related. Can be used on any QUIC SSL object.
+
+### Existing APIs
+
+#### `SSL_set_connect_state`
+
+| Semantics | `SSL_get_error` | Can Tick? | CSHL          |
+| --------- | ------------- | --------- | ------------- |
+| Unchanged | Never         | No        | HL            |
+
+#### `SSL_set_accept_state`
+
+| Semantics | `SSL_get_error` | Can Tick? | CSHL          |
+| --------- | ------------- | --------- | ------------- |
+| Unchanged | Never         | No        | HL            |
+
+**Note:** Attempting to proceed in this state will not function for now because
+we do not implement server support at this time. However, the semantics of this
+function as such are unchanged.
+
+#### `SSL_is_server`
+
+| Semantics | `SSL_get_error` | Can Tick? | CSHL          |
+| --------- | ------------- | --------- | ------------- |
+| Unchanged | Never         | No        | HL            |
+
+#### `SSL_connect`
+
+| Semantics | `SSL_get_error` | Can Tick? | CSHL          |
+| --------- | ------------- | --------- | ------------- |
+| Unchanged | Error/Want    | Yes       | HL            |
+
+Simple composition of `SSL_set_connect_state` and `SSL_do_handshake`.
+
+#### `SSL_accept`
+
+| Semantics | `SSL_get_error` | Can Tick? | CSHL          |
+| --------- | ------------- | --------- | ------------- |
+| Unchanged | Error/Want    | Yes       | HL            |
+
+Simple composition of `SSL_set_accept_state` and `SSL_do_handshake`.
+
+#### `SSL_do_handshake`
+
+| Semantics | `SSL_get_error` | Can Tick? | CSHL          |
+| --------- | ------------- | --------- | ------------- |
+| Unchanged | Error/Want    | Yes       | HL            |
+
+**Note:** Idempotent if handshake already completed.
+
+**Blocking Considerations:** Blocks until handshake completed if in blocking
+mode.
+
+**TBD:** Should this wait until handshake is completed or until it is confirmed?
+
+#### `SSL_read`, `SSL_read_ex`, `SSL_peek`, `SSL_peek_ex`
+
+| Semantics | `SSL_get_error` | Can Tick? | CSHL          |
+| --------- | ------------- | --------- | ------------- |
+| Unchanged | Error/Want    | Yes       | CS            |
+
+**Blocking Considerations:** Blocks until at least one byte is available or an
+error occurs if in blocking mode (including the peek functions).
+
+#### `SSL_write`, `SSL_write_ex`
+
+| Semantics | `SSL_get_error` | Can Tick? | CSHL          |
+| --------- | ------------- | --------- | ------------- |
+| Unchanged | Error/Want    | Yes       | CS            |
+
+We have to implement all of the following modes:
+
+- `SSL_ENABLE_PARTIAL_WRITE` on or off
+- `SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER` on or off
+- Blocking mode on or off
+
+**Blocking Considerations:** Blocks until all data is written or an error occurs
+if in blocking mode.
+
+TBD: Does SSL_ENABLE_PARTIAL_WRITE interact with blocking mode?
+
+#### `SSL_pending`
+
+| Semantics | `SSL_get_error` | Can Tick? | CSHL          |
+| --------- | ------------- | --------- | ------------- |
+| Unchanged | Never         | No        | CS            |
+
+#### `SSL_has_pending`
+
+| Semantics | `SSL_get_error` | Can Tick? | CSHL          |
+| --------- | ------------- | --------- | ------------- |
+| Unchanged | Never         | No        | CS            |
+
+**TBD.** Options:
+
+  - Semantics unchanged or approximated (essentially, `SSL_pending() || any RXE
+    queued || any URXE queued`).
+  - Change semantics to only determine the return value based on if there is
+    data in the stream receive buffer.
+
+#### `SSL_shutdown`
+
+| Semantics | `SSL_get_error` | Can Tick? | CSHL          |
+| --------- | ------------- | --------- | ------------- |
+| Unchanged | Error/Want    | Yes       | CS            |
+
+Semantics unchanged on QUIC Connection SSL objects.
+
+Probable implementation:
+
+  - If the peer did not yet close the connection, send CONNECTION_CLOSE once
+    (best effort, tick), return 0.
+  - Otherwise, if teardown is complete, return 1.
+
+Semantics for future QUIC Stream SSL objects TBD, but:
+
+  - We should have a way for `SSL_shutdown` to only affect the stream object
+    and not the entire connection, so that applications can pass SSL objects for
+    an individual stream to parts of themselves which expect something
+    resembling traditional TCP stream and then call `SSL_shutdown`.
+
+    A reasonable design here would be to have `SSL_shutdown` on a QUIC stream
+    SSL object only shut down that stream. However this would mean
+    `SSL_shutdown` behaves differently on the default stream (i.e., the QUIC
+    connection SSL object) to other streams. Thus a new API should probably be
+    added explicitly for QUIC stream shutdown. `SSL_shutdown` on a QUIC stream
+    object will redirect to this function, or it can be used explicitly on the
+    QUIC connection object if it has a default stream bound.
+
+#### `SSL_clear`
+
+There are potential implementation hazards:
+
+>SSL_clear() resets the SSL object to allow for another connection. The reset
+>operation however keeps several settings of the last sessions (some of these
+>settings were made automatically during the last handshake). It only makes sense
+>for a new connection with the exact same peer that shares these settings, and
+>may fail if that peer changes its settings between connections.
+
+**TBD:** How should `SSL_clear` be implemented? Either:
+
+  - Modernised implementation which resets everything, handshake layer
+    re-instantiated (safer);
+  - Preserve `SSL_clear` semantics at the handshake layer, reset all QUIC state
+    (`QUIC_CHANNEL` torn down, CSM reset).
+
+#### `SSL_set0_rbio`, `SSL_set0_wbio`, `SSL_set_bio`
+
+| Semantics | `SSL_get_error` | Can Tick? | CSHL          |
+| --------- | ------------- | --------- | ------------- |
+| Changed   | Never         | No        | C             |
+
+Sets network-side BIO.
+
+The changes to the semantics of these calls are as follows:
+
+  - The BIO MUST be a BIO with datagram semantics.
+
+  - If the BIO is non-pollable (see below), application-level blocking mode will
+    be forced off.
+
+#### `SSL_set_[rw]fd`
+
+| Semantics | `SSL_get_error` | Can Tick? | CSHL          |
+| --------- | ------------- | --------- | ------------- |
+| Changed   | Never         | No        | C             |
+
+Sets network-side socket FD.
+
+Existing behaviour: Instantiates a `BIO_s_socket`, sets an FD on it, and sets it
+as the BIO.
+
+New proposed behaviour:
+
+- Instantiate a `BIO_s_dgram` instead for a QUIC connection SSL object.
+- Fails (no-op) for a QUIC stream SSL object.
+
+#### `SSL_get_[rw]fd`
+
+| Semantics | `SSL_get_error` | Can Tick? | CSHL          |
+| --------- | ------------- | --------- | ------------- |
+| Unchanged | Never         | No        | C             |
+
+Should not require any changes.
+
+#### `SSL_CTRL_MODE`, `SSL_CTRL_CLEAR_MODE`
+
+| Semantics | `SSL_get_error` | Can Tick? | CSHL          |
+| --------- | ------------- | --------- | ------------- |
+| Unchanged | Never         | No        | CS            |
+
+#### SSL Modes
+
+- `SSL_MODE_ENABLE_PARTIAL_WRITE`: Implemented. If this mode is set during a
+  non-partial-write `SSL_write` operation spanning multiple `SSL_write` calls,
+  this operation is aborted and partial write mode begins immediately.
+
+- `SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER`: Implemented.
+
+- `SSL_MODE_AUTO_RETRY`: TBD.
+
+- `SSL_MODE_RELEASE_BUFFERS`: Ignored. This is an optimization and if it has
+  any sensible semantic correspondence to QUIC, this can be considered later.
+
+- `SSL_MODE_SEND_FALLBACK_SCSV`: TBD: Either ignore or fail if the client
+  attempts to set this prior to handshake. The latter is probably safer.
+
+  TBD: What if the client attempts to set this post handshake? Ignore it?
+
+- `SSL_MODE_ASYNC`: TBD.
+
+### New APIs
+
+TBD: Should any of these be implemented as ctrls rather than actual functions?
+
+#### `SSL_tick`
+
+| Semantics | `SSL_get_error` | Can Tick? | CSHL          |
+| --------- | ------------- | --------- | ------------- |
+| New       | Never         | Yes       | CS            |
+
+Advances the QUIC state machine to the extent feasible, potentially performing
+network I/O. Also compatible with DTLSv1 and supercedes `DTLSv1_handle_timeout`
+for all use cases.
+
+TBD: Should we just map this to DTLS_CTRL_HANDLE_TIMEOUT internally (and maybe
+alias the CTRL #define)?
+
+#### `SSL_get_tick_timeout`
+
+| Semantics | `SSL_get_error` | Can Tick? | CSHL          |
+| --------- | ------------- | --------- | ------------- |
+| New       | Never         | No        | CS            |
+
+Gets the time until the QUIC state machine next wants to receive a timeout
+event, if any.
+
+This is similar to the existing `DTLSv1_get_timeout` function, but it is not
+specific to DTLSv1. It is also usable for DTLSv1 and can become a
+protocol-agnostic API for this purpose, superceding `DTLSv1_get_timeout` for all
+use cases.
+
+The design is similar to that of `DTLSv1_get_timeout` and uses a `struct
+timeval`. However, this function represents an infinite timeout (i.e., no
+timeout) using `tv_sec == -1`, whereas `DTLSv1_get_timeout` represents an
+infinite timeout using a 0 return value, which does not allow a failure
+condition to be distinguished.
+
+TBD: Should we just map this to DTLS_CTRL_GET_TIMEOUT internally (and maybe
+alias the CTRL #define)?
+
+#### `SSL_set_blocking_mode`, `SSL_get_blocking_mode`
+
+| Semantics | `SSL_get_error` | Can Tick? | CSHL          |
+| --------- | ------------- | --------- | ------------- |
+| New       | Never         | No        | CS            |
+
+Turns blocking mode on or off. This is necessary because up until now libssl has
+operated in blocking or non-blocking mode automatically as an emergent
+consequence of whether the underlying network socket is blocking. Since we are
+proposing to use only non-blocking I/O internally, use of blocking semantics at
+the application level must be explicitly configured.
+
+Use on stream objects: It may be feasible to implement this such that different
+QUIC stream SSL objects can have different settings for this option.
+
+Not supported for non-QUIC SSL objects.
+
+#### `SSL_get_rpoll_descriptor`, `SSL_get_wpoll_descriptor`
+
+| Semantics | `SSL_get_error` | Can Tick? | CSHL          |
+| --------- | ------------- | --------- | ------------- |
+| New       | Never         | No        | CS            |
+
+These functions output poll descriptors which can be used to determine
+when the QUIC state machine should next be ticked. `SSL_get_rpoll_descriptor` is
+relevant if `SSL_want_net_read` returns 1, and `SSL_get_wpoll_descriptor` is
+relevant if `SSL_want_net_write` returns 1.
+
+The implementation of these functions is a simple forward to
+`BIO_get_rpoll_descriptor` and `BIO_get_wpoll_descriptor` on the underlying
+network BIOs.
+
+#### `SSL_want_net_read`, `SSL_want_net_write`
+
+| Semantics | `SSL_get_error` | Can Tick? | CSHL          |
+| --------- | ------------- | --------- | ------------- |
+| New       | Never         | No        | CS            |
+
+These calls return 1 if the QUIC state machine is interested in receiving
+further data from the network, or writing to the network, respectively. The
+return values of these calls should be used to determine which wakeup events
+should cause an application to call `SSL_tick`. These functions do not mutate
+any state, and their return values may change after a call to any SSL function
+other than `SSL_want_net_read`, `SSL_want_net_write`,
+`SSL_get_rpoll_descriptor`, `SSL_get_wpoll_descriptor` and
+`SSL_get_tick_timeout`.
+
+#### `SSL_want`, `SSL_want_read`, `SSL_want_write`
+
+The existing API `SSL_want`, and the macros defined in terms of it, are
+traditionally used to determine if the SSL state machine has exited in
+non-blocking mode due to a desire to read from or write to the underlying
+network BIO. However, this API is unsuitable for use with QUIC because the
+return value of `SSL_want` can only express one I/O direction at a time (read or
+write), not both. This call will not be implemented for QUIC (e.g. always
+returns `SSL_NOTHING`) and `SSL_want_net_read` and `SSL_want_net_write` will be
+used instead.
+
+TBD: Should these be implemented for non-QUIC SSL objects?
+
+#### `SSL_set_initial_peer_addr`, `SSL_get_initial_peer_addr`
+
+| Semantics | `SSL_get_error` | Can Tick? | CSHL          |
+| --------- | ------------- | --------- | ------------- |
+| New       | Never         | No        | CS            |
+
+`SSL_set_initial_peer_addr` sets the initial L4 UDP peer address for an outgoing
+QUIC connection.
+
+The initial peer address may be autodetected if no peer address has already been
+set explicitly and the QUIC connection SSL object is provided with a
+`BIO_s_dgram` with a peer set.
+
+`SSL_set_initial_peer_addr` cannot be called after a connection is established.
+
+### Future APIs
+
+A custom poller interface may be provided in the future. For more information,
+see the QUIC I/O Architecture design document.
+
+BIO Objects
+-----------
+
+### Existing APIs
+
+#### `BIO_s_connect`, `BIO_new_ssl_connect`, `BIO_set_conn_hostname`
+
+We are aiming to support use of the existing `BIO_new_ssl_connect` API with only
+minimal changes. This will require internal changes to `BIO_s_connect`, which
+should automatically detect when it is being used with a QUIC `SSL_CTX` and act
+accordingly.
+
+#### `BIO_new_bio_pair`
+
+Unsuitable for use with QUIC on the network side; instead, applications can
+make use of the new `BIO_s_dgram_pair` which provides equivalent functionality
+with datagram semantics.
+
+#### Interactions with `BIO_f_buffer`
+
+Existing applications sometimes combine a network socket BIO with a
+`BIO_f_buffer`. This is problematic because the datagram semantics of writes are
+not preserved, therefore the BIO provided to libssl is, as provided, unusable
+for the purposes of implementing QUIC. Moreover, output buffering is not a
+relevant or desirable performance optimisation for the transmission of UDP
+datagrams and will actually undermine QUIC performance by causing incorrect
+calculation of ACK delays and consequently inaccurate RTT calculation.
+
+Options:
+
+  - Require applications to be changed to not use QUIC with a `BIO_f_buffer`.
+  - Detect when a `BIO_f_buffer` is part of a BIO stack and bypass it
+    (yucky and surprising).
+
+#### MTU Signalling
+
+**See also:**
+[BIO_s_dgram_pair(3)](https://www.openssl.org/docs/manmaster/man3/BIO_s_dgram_pair.html)
+
+`BIO_dgram_get_mtu` (`BIO_CTRL_DGRAM_GET_MTU`) and `BIO_dgram_set_mtu`
+(`BIO_CTRL_DGRAM_SET_MTU`) already exist for `BIO_s_dgram` and are implemented
+on a `BIO_s_dgram_pair` to allow the MTU to be determined and configured. One
+side of a pair can configure the MTU to allow the other side to detect it.
+
+`BIO_s_dgram` also has pre-existing support for getting the correct MTU value
+from the OS using `BIO_CTRL_DGRAM_QUERY_MTU`.
+
+### New APIs
+
+#### `BIO_sendmmsg` and `BIO_recvmmsg`
+
+**See also:**
+[BIO_sendmmsg(3)](https://www.openssl.org/docs/manmaster/man3/BIO_sendmmsg.html)
+
+The BIO interface features a new high-performance API for the execution of
+multiple read or write operations in a single system call, on supported OSes. On
+other OSes, a compatible fallback implementation is used.
+
+Unlike all other BIO APIs, this API is intended for concurrent threaded use and
+as such operates in a stateless fashion with regards to a BIO. This means, for
+example, that retry indications are made using explicit API inputs and outputs
+rather than setting an internal flag on the BIO.
+
+This new BIO API includes:
+
+- Local address support (getting the destination address of an incoming
+  packet; setting the source address of an outgoing packet), where support
+  for this is available;
+- Peer address support (setting the destination address of an outgoing
+  packet; getting the source address of an incoming packet), where support
+  for this is available.
+
+The following functionality was intentionally left out of this design because
+not all OSes can provide support:
+
+- Iovecs (which have also been determined not to be necessary for a
+  performant QUIC implementation);
+- Features such as `MSG_DONTWAIT`, etc.
+
+This BIO API is intended to be extensible. For more information on this API, see
+BIO_sendmmsg(3) and BIO_recvmmsg(3).
+
+Custom BIO implementers may set their own implementation of these APIs via
+corresponding `BIO_meth` getter/setter functions.
+
+#### Truncation Mode
+
+**See also:**
+[BIO_s_dgram_pair(3)](https://www.openssl.org/docs/manmaster/man3/BIO_s_dgram_pair.html)
+
+The controls `BIO_dgram_get_no_trunc` (`BIO_CTRL_DGRAM_GET_NO_TRUNC`) and
+`BIO_dgram_get_no_trunc` (`BIO_CTRL_DGRAM_GET_NO_TRUNC`) are introduced. This is
+a boolean value which may be implemented by BIOs with datagram semantics. When
+enabled, attempting to receive a datagram such that the datagram would
+ordinarily be truncated (as per the design of the Berkeley sockets API) instead
+results in a failure. This is intended for implementation by `BIO_s_dgram_pair`.
+For compatibility, the default behaviour is off.
+
+#### Capability Negotiation
+
+**See also:**
+[BIO_s_dgram_pair(3)](https://www.openssl.org/docs/manmaster/man3/BIO_s_dgram_pair.html)
+
+Where a `BIO_s_dgram_pair` is used, there is the potential for such a memory BIO
+to be used by existing application code which is being adapted for use with
+QUIC. A problem arises whereby one end of a `BIO_s_dgram_pair` (for example, the
+side being used by OpenSSL's QUIC implementation) may assume that the other end
+supports certain capabilities (for example, specifying a peer address), when in
+actual fact the opposite end of the `BIO_s_dgram_pair` does not.
+
+A capability signalling mechanism is introduced which allows one end of a
+`BIO_s_dgram_pair` to indicate to the user of the opposite BIO the following
+capabilities and related information:
+
+- Whether source addresses the peer specifies will be processed.
+- Whether destination addresses the peer specifies will be processed.
+- Whether source addresses will be provided to the opposite BIO when it
+  receives datagrams.
+- Whether destination addresses will be provided to the opposite BIO
+  when it receives datagrams.
+
+The usage is as follows:
+
+- One side of a BIO pair calls `BIO_dgram_set_caps` with zero or
+  more of the following flags to advertise its capabilities:
+  - `BIO_DGRAM_CAP_HANDLES_SRC_ADDR`
+  - `BIO_DGRAM_CAP_HANDLES_DST_ADDR`
+  - `BIO_DGRAM_CAP_PROVIDES_SRC_ADDR`
+  - `BIO_DGRAM_CAP_PROVIDES_DST_ADDR`
+- The other side of the BIO pair calls `BIO_dgram_get_effective_caps`
+  to learn the effective capabilities of the BIO. These are the capabilities set
+  by the opposite BIO.
+- The above process can also be repeated in the opposite direction.
+
+#### Local Address Support
+
+**See also:**
+[BIO_s_dgram_pair(3)](https://www.openssl.org/docs/manmaster/man3/BIO_s_dgram_pair.html)
+
+Support for local addressing (the reception of destination addresses for
+incoming packets, and the specification of source addresses for outgoing
+packets) varies by OS. Thus, it may not be available in all circumstances. A
+feature negotiation mechanism is introduced to facilitate this.
+
+`BIO_dgram_get_local_addr_cap` (`BIO_CTRL_DGRAM_GET_LOCAL_ADDR_CAP`) determines
+if a BIO is potentially capable of supporting local addressing on the current
+platform. If it determines that support is available, local addressing support
+must then be explicitly enabled via `BIO_dgram_set_local_addr_enable`
+(`BIO_CTRL_DGRAM_SET_LOCAL_ADDR_ENABLE`). If local addressing support has not
+been enabled, attempts to use local addressing (for example via `BIO_sendmmsg`
+or `BIO_recvmmsg` with a `BIO_MSG` with a non-NULL `local` field) fails.
+
+An explicit enablement call is required because setting up local addressing
+support requires system calls on most operating systems prior to sending or
+receiving packets and we do not wish to do this automatically inside the
+`BIO_sendmmsg`/`BIO_recvmmsg` fastpaths, particularly since the process of
+enabling support could fail due to lack of OS support, etc.
+
+`BIO_dgram_get_local_addr_enable` (`BIO_CTRL_DGRAM_GET_LOCAL_ADDR_ENABLE`) is
+also available.
+
+It is important to note that `BIO_dgram_get_local_addr_cap` is entirely distinct
+from the application capability negotiation mechanism discussed above. Whereas
+the capability negotiation mechanism discussed above allows *applications* to
+signal what they are capable of handling in their usage of a given BIO,
+`BIO_dgram_local_addr_cap` allows a *BIO implementation* to indicate to the
+users of that BIO whether it is able to support local addressing (where
+enabled).
+
+#### `BIO_s_dgram_pair`
+
+**See also:**
+[BIO_s_dgram_pair(3)](https://www.openssl.org/docs/manmaster/man3/BIO_s_dgram_pair.html)
+
+A new BIO implementation, `BIO_s_dgram_pair`, is provided. This is similar to
+the existing BIO pair but provides datagram semantics. It provides full support
+for the new APIs `BIO_sendmmsg`, `BIO_recvmmsg`, the capability negotiation
+mechanism described above, local address support and the MTU signalling
+mechanism described above.
+
+It can be instantiated using the new API `BIO_new_dgram_pair`.
+
+#### `BIO_POLL_DESCRIPTOR`
+
+The concept of *poll descriptors* are introduced. A poll descriptor is a tagged
+union structure which represents an abstraction over some unspecified kind of OS
+descriptor which can be used for synchronization and waiting.
+
+The most commonly used kind of poll descriptor is one which describes a network
+socket (i.e., on POSIX-like platforms, a file descriptor), however other kinds
+of poll descriptor may be defined.
+
+A BIO may be queried for whether it has a poll descriptor for read or write
+operations respectively:
+
+- Where `BIO_get_rpoll_descriptor` (`BIO_CTRL_GET_RPOLL_DESCRIPTOR`) is called,
+  the BIO should output a poll descriptor which describes a resource which can
+  be used to determine when the BIO will next become readable via a call to
+  `BIO_read` or, if supported by the BIO, `BIO_recvmmsg`.
+- Where
+  `BIO_get_wpoll_descriptor` (`BIO_CTRL_GET_WPOLL_DESCRIPTOR`) is called, the
+  BIO should output a poll descriptor which describes a resource which can be
+  used to determine when the BIO will next become writeable via a call to
+  `BIO_write` or, if supported by the BIO, `BIO_sendmmsg`.
+
+A BIO may not necessarily be able to provide a poll descriptor. For example,
+memory-based BIOs such as `BIO_s_dgram_pair` do not correspond to any OS
+synchronisation resource, and thus the `BIO_get_rpoll_descriptor` and
+`BIO_get_wpoll_descriptor` calls are not supported for such BIOs.
+
+A BIO which supports these functions is known as pollable, and a BIO which does
+not is known as non-pollable. `BIO_s_dgram` supports these functions.
+
+The implementation of these functions for a `BIO_f_ssl` forwards to
+`SSL_get_rpoll_descriptor` and `SSL_get_wpoll_descriptor` respectively. The
+
+#### `BIO_s_dgram_mem`
+
+This is a basic memory buffer BIO with datagram semantics. Unlike
+`BIO_s_dgram_pair`, it is unidirectional and does not support peer addressing or
+local addressing.
+
+#### `BIO_err_is_non_fatal`
+
+A new predicate function `BIO_err_is_non_fatal` is defined which determines if
+an error code represents a non-fatal or transient error. For details, see
+[BIO_sendmmsg(3)](https://www.openssl.org/docs/manmaster/man3/BIO_sendmmsg.html).


### PR DESCRIPTION
This document, rather needed and until now missing, sets out our overall approach to the QUIC-related API effort. It both discusses evolution and semantics of existing APIs and what new ones are added.

Feedback welcomed.

See also #19770.