### PR TITLE
Give every printf like function __restrict for the format value

### DIFF
--- a/apps/include/apps.h
+++ b/apps/include/apps.h
@@ -224,7 +224,7 @@ typedef struct ca_db_st {
 
 extern int do_updatedb(CA_DB *db, time_t *now);
 
-void app_bail_out(char *fmt, ...);
+void app_bail_out(char *__restrict fmt, ...);
 void *app_malloc(size_t sz, const char *what);
 
 /* load_serial, save_serial, and rotate_serial are also used for CRL numbers */

--- a/apps/include/log.h
+++ b/apps/include/log.h
@@ -45,6 +45,6 @@ int log_get_verbosity(void);
  * returns nothing
  */
 void trace_log_message(int category,
-                       const char *prog, int level, const char *fmt, ...);
+                       const char *prog, int level, const char *__restrict fmt, ...);
 
 #endif /* OSSL_APPS_LOG_H */

--- a/apps/include/opt.h
+++ b/apps/include/opt.h
@@ -395,7 +395,7 @@ int opt_uintmax(const char *arg, ossl_uintmax_t *result);
 int opt_isdir(const char *name);
 int opt_format(const char *s, unsigned long flags, int *result);
 void print_format_error(int format, unsigned long flags);
-int opt_printf_stderr(const char *fmt, ...);
+int opt_printf_stderr(const char *__restrict fmt, ...);
 int opt_string(const char *name, const char **options);
 int opt_pair(const char *arg, const OPT_PAIR * pairs, int *result);
 

--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -641,7 +641,7 @@ EVP_PKEY *load_keyparams(const char *uri, int format, int maybe_stdin,
     return load_keyparams_suppress(uri, format, maybe_stdin, keytype, desc, 0);
 }
 
-void app_bail_out(char *fmt, ...)
+void app_bail_out(char *__restrict fmt, ...)
 {
     va_list args;
 

--- a/apps/lib/apps_opt_printf.c
+++ b/apps/lib/apps_opt_printf.c
@@ -12,7 +12,7 @@
 #include "apps_ui.h"
 
 /* This function is defined here due to visibility of bio_err */
-int opt_printf_stderr(const char *fmt, ...)
+int opt_printf_stderr(const char *__restrict fmt, ...)
 {
     va_list ap;
     int ret;

--- a/apps/lib/log.c
+++ b/apps/lib/log.c
@@ -41,7 +41,7 @@ static int print_syslog(const char *str, size_t len, void *levPtr)
 }
 #endif
 
-static void log_with_prefix(const char *prog, const char *fmt, va_list ap)
+static void log_with_prefix(const char *prog, const char *__restrict fmt, va_list ap)
 {
     char prefix[80];
     BIO *bio, *pre = BIO_new(BIO_f_prefix());
@@ -69,7 +69,7 @@ static void log_with_prefix(const char *prog, const char *fmt, va_list ap)
 #endif
 
 void trace_log_message(int category,
-                       const char *prog, int level, const char *fmt, ...)
+                       const char *prog, int level, const char *__restrict fmt, ...)
 {
     va_list ap;
     va_start(ap, fmt);

--- a/apps/storeutl.c
+++ b/apps/storeutl.c
@@ -335,7 +335,7 @@ int storeutl_main(int argc, char *argv[])
     return ret;
 }
 
-static int indent_printf(int indent, BIO *bio, const char *format, ...)
+static int indent_printf(int indent, BIO *bio, const char *__restrict format, ...)
 {
     va_list args;
     int ret;

--- a/crypto/bio/bio_print.c
+++ b/crypto/bio/bio_print.c
@@ -39,7 +39,7 @@ static int fmtfp(char **, char **, size_t *, size_t *,
 static int doapr_outch(char **, char **, size_t *, size_t *, int);
 static int _dopr(char **sbuffer, char **buffer,
                  size_t *maxlen, size_t *retlen, int *truncated,
-                 const char *format, va_list args);
+                 const char *__restrict format, va_list args);
 
 /* format read states */
 #define DP_S_DEFAULT    0
@@ -87,7 +87,7 @@ static int
 _dopr(char **sbuffer,
       char **buffer,
       size_t *maxlen,
-      size_t *retlen, int *truncated, const char *format, va_list args)
+      size_t *retlen, int *truncated, const char *__restrict format, va_list args)
 {
     char ch;
     int64_t value;
@@ -877,7 +877,7 @@ doapr_outch(char **sbuffer,
 
 /***************************************************************************/
 
-int BIO_printf(BIO *bio, const char *format, ...)
+int BIO_printf(BIO *bio, const char *__restrict format, ...)
 {
     va_list args;
     int ret;
@@ -890,7 +890,7 @@ int BIO_printf(BIO *bio, const char *format, ...)
     return ret;
 }
 
-int BIO_vprintf(BIO *bio, const char *format, va_list args)
+int BIO_vprintf(BIO *bio, const char *__restrict format, va_list args)
 {
     int ret;
     size_t retlen;
@@ -923,7 +923,7 @@ int BIO_vprintf(BIO *bio, const char *format, va_list args)
  * closely related to BIO_printf, and we need *some* name prefix ... (XXX the
  * function should be renamed, but to what?)
  */
-int BIO_snprintf(char *buf, size_t n, const char *format, ...)
+int BIO_snprintf(char *buf, size_t n, const char *__restrict format, ...)
 {
     va_list args;
     int ret;
@@ -936,7 +936,7 @@ int BIO_snprintf(char *buf, size_t n, const char *format, ...)
     return ret;
 }
 
-int BIO_vsnprintf(char *buf, size_t n, const char *format, va_list args)
+int BIO_vsnprintf(char *buf, size_t n, const char *__restrict format, va_list args)
 {
     size_t retlen;
     int truncated;

--- a/crypto/bio/ossl_core_bio.c
+++ b/crypto/bio/ossl_core_bio.c
@@ -118,7 +118,7 @@ long ossl_core_bio_ctrl(OSSL_CORE_BIO *cb, int cmd, long larg, void *parg)
     return BIO_ctrl(cb->bio, cmd, larg, parg);
 }
 
-int ossl_core_bio_vprintf(OSSL_CORE_BIO *cb, const char *format, va_list args)
+int ossl_core_bio_vprintf(OSSL_CORE_BIO *cb, const char *__restrict format, va_list args)
 {
     return BIO_vprintf(cb->bio, format, args);
 }

--- a/crypto/cmp/cmp_ctx.c
+++ b/crypto/cmp/cmp_ctx.c
@@ -333,7 +333,7 @@ static size_t ossl_cmp_log_trace_cb(const char *buf, size_t cnt,
 /* Print CMP log messages (i.e., diagnostic info) via the log cb of the ctx */
 int ossl_cmp_print_log(OSSL_CMP_severity level, const OSSL_CMP_CTX *ctx,
                        const char *func, const char *file, int line,
-                       const char *level_str, const char *format, ...)
+                       const char *level_str, const char *__restrict format, ...)
 {
     va_list args;
     char hugebuf[1024 * 2];

--- a/crypto/cmp/cmp_local.h
+++ b/crypto/cmp/cmp_local.h
@@ -755,7 +755,7 @@ int ossl_cmp_asn1_octet_string_set1_bytes(ASN1_OCTET_STRING **tgt,
 /* from cmp_ctx.c */
 int ossl_cmp_print_log(OSSL_CMP_severity level, const OSSL_CMP_CTX *ctx,
                        const char *func, const char *file, int line,
-                       const char *level_str, const char *format, ...);
+                       const char *level_str, const char *__restrict format, ...);
 # define ossl_cmp_log(level, ctx, msg) \
     ossl_cmp_print_log(OSSL_CMP_LOG_##level, ctx, OPENSSL_FUNC, OPENSSL_FILE, \
                        OPENSSL_LINE, #level, "%s", msg)

--- a/crypto/err/err_blocks.c
+++ b/crypto/err/err_blocks.c
@@ -37,7 +37,7 @@ void ERR_set_debug(const char *file, int line, const char *func)
     err_set_debug(es, es->top, file, line, func);
 }
 
-void ERR_set_error(int lib, int reason, const char *fmt, ...)
+void ERR_set_error(int lib, int reason, const char *__restrict fmt, ...)
 {
     va_list args;
 
@@ -46,7 +46,7 @@ void ERR_set_error(int lib, int reason, const char *fmt, ...)
     va_end(args);
 }
 
-void ERR_vset_error(int lib, int reason, const char *fmt, va_list args)
+void ERR_vset_error(int lib, int reason, const char *__restrict fmt, va_list args)
 {
     ERR_STATE *es;
     char *buf = NULL;

--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -1976,7 +1976,7 @@ static void core_set_error_debug(const OSSL_CORE_HANDLE *handle,
 }
 
 static void core_vset_error(const OSSL_CORE_HANDLE *handle,
-                            uint32_t reason, const char *fmt, va_list args)
+                            uint32_t reason, const char *__restrict fmt, va_list args)
 {
     /*
      * We created this object originally and we know it is actually an

--- a/doc/internal/man3/ossl_cmp_print_log.pod
+++ b/doc/internal/man3/ossl_cmp_print_log.pod
@@ -24,7 +24,7 @@ ossl_cmp_add_error_line
 
  int ossl_cmp_print_log(OSSL_CMP_severity level, const OSSL_CMP_CTX *ctx,
                         const char *func, const char *file, int line,
-                        const char *level_str, const char *format, ...);
+                        const char *level_str, const char *__restrict format, ...);
  #define ossl_cmp_alert(ctx, msg)
  #define ossl_cmp_err(ctx, msg)
  #define ossl_cmp_warn(ctx, msg)

--- a/doc/man3/BIO_printf.pod
+++ b/doc/man3/BIO_printf.pod
@@ -9,11 +9,11 @@ BIO_printf, BIO_vprintf, BIO_snprintf, BIO_vsnprintf
 
  #include <openssl/bio.h>
 
- int BIO_printf(BIO *bio, const char *format, ...);
- int BIO_vprintf(BIO *bio, const char *format, va_list args);
+ int BIO_printf(BIO *bio, const char *__restrict format, ...);
+ int BIO_vprintf(BIO *bio, const char *__restrict format, va_list args);
 
- int BIO_snprintf(char *buf, size_t n, const char *format, ...);
- int BIO_vsnprintf(char *buf, size_t n, const char *format, va_list args);
+ int BIO_snprintf(char *buf, size_t n, const char *__restrict format, ...);
+ int BIO_vsnprintf(char *buf, size_t n, const char *__restrict format, va_list args);
 
 =head1 DESCRIPTION
 

--- a/doc/man3/ERR_new.pod
+++ b/doc/man3/ERR_new.pod
@@ -11,8 +11,8 @@ ERR_new, ERR_set_debug, ERR_set_error, ERR_vset_error
 
  void ERR_new(void);
  void ERR_set_debug(const char *file, int line, const char *func);
- void ERR_set_error(int lib, int reason, const char *fmt, ...);
- void ERR_vset_error(int lib, int reason, const char *fmt, va_list args);
+ void ERR_set_error(int lib, int reason, const char *__restrict fmt, ...);
+ void ERR_vset_error(int lib, int reason, const char *__restrict fmt, va_list args);
 
 =head1 DESCRIPTION
 

--- a/doc/man3/ERR_put_error.pod
+++ b/doc/man3/ERR_put_error.pod
@@ -14,7 +14,7 @@ ERR_add_error_txt, ERR_add_error_mem_bio
  #include <openssl/err.h>
 
  void ERR_raise(int lib, int reason);
- void ERR_raise_data(int lib, int reason, const char *fmt, ...);
+ void ERR_raise_data(int lib, int reason, const char *__restrict fmt, ...);
 
  void ERR_add_error_data(int num, ...);
  void ERR_add_error_vdata(int num, va_list arg);

--- a/doc/man3/OSSL_DECODER_from_bio.pod
+++ b/doc/man3/OSSL_DECODER_from_bio.pod
@@ -51,7 +51,7 @@ To decode an RSA key encoded with PEM from a bio:
 
  OSSL_DECODER_CTX *dctx;
  EVP_PKEY *pkey = NULL;
- const char *format = "PEM";   /* NULL for any format */
+ const char *__restrict format = "PEM";   /* NULL for any format */
  const char *structure = NULL; /* any structure */
  const char *keytype = "RSA";  /* NULL for any key */
  const unsigned char *pass = "my password";
@@ -76,7 +76,7 @@ To decode an EC key encoded with DER from a buffer:
 
  OSSL_DECODER_CTX *dctx;
  EVP_PKEY *pkey = NULL;
- const char *format = "DER";   /* NULL for any format */
+ const char *__restrict format = "DER";   /* NULL for any format */
  const char *structure = NULL; /* any structure */
  const char *keytype = "EC";   /* NULL for any key */
  const unsigned char *pass = NULL

--- a/doc/man3/OSSL_ENCODER_to_bio.pod
+++ b/doc/man3/OSSL_ENCODER_to_bio.pod
@@ -60,7 +60,7 @@ return 1 on success, or 0 on failure.
 To encode a pkey as PKCS#8 with PEM format into a bio:
 
  OSSL_ENCODER_CTX *ectx;
- const char *format = "PEM";
+ const char *__restrict format = "PEM";
  const char *structure = "PrivateKeyInfo"; /* PKCS#8 structure */
  const unsigned char *pass = "my password";
 
@@ -85,7 +85,7 @@ To encode a pkey as PKCS#8 with DER format encrypted with
 AES-256-CBC into a buffer:
 
  OSSL_ENCODER_CTX *ectx;
- const char *format = "DER";
+ const char *__restrict format = "DER";
  const char *structure = "PrivateKeyInfo"; /* PKCS#8 structure */
  const unsigned char *pass = "my password";
  unsigned char *data = NULL;

--- a/doc/man7/provider-base.pod
+++ b/doc/man7/provider-base.pod
@@ -29,7 +29,7 @@ provider-base
  void core_set_error_debug(const OSSL_CORE_HANDLE *handle,
                            const char *file, int line, const char *func);
  void core_vset_error(const OSSL_CORE_HANDLE *handle,
-                      uint32_t reason, const char *fmt, va_list args);
+                      uint32_t reason, const char *__restrict fmt, va_list args);
 
  int core_obj_add_sigid(const OSSL_CORE_HANDLE *prov, const char  *sign_name,
                         const char *digest_name, const char *pkey_name);
@@ -67,8 +67,8 @@ provider-base
                   size_t *written);
  int BIO_up_ref(OSSL_CORE_BIO *bio);
  int BIO_free(OSSL_CORE_BIO *bio);
- int BIO_vprintf(OSSL_CORE_BIO *bio, const char *format, va_list args);
- int BIO_vsnprintf(char *buf, size_t n, const char *fmt, va_list args);
+ int BIO_vprintf(OSSL_CORE_BIO *bio, const char *__restrict format, va_list args);
+ int BIO_vsnprintf(char *buf, size_t n, const char *__restrict fmt, va_list args);
 
  void OSSL_SELF_TEST_set_callback(OSSL_LIB_CTX *libctx, OSSL_CALLBACK *cb,
                                   void *cbarg);

--- a/engines/e_capi.c
+++ b/engines/e_capi.c
@@ -111,7 +111,7 @@ typedef struct CAPI_KEY_st CAPI_KEY;
 static void capi_addlasterror(void);
 static void capi_adderror(DWORD err);
 
-static void CAPI_trace(CAPI_CTX *ctx, char *format, ...);
+static void CAPI_trace(CAPI_CTX *ctx, char *__restrict format, ...);
 
 static int capi_list_providers(CAPI_CTX *ctx, BIO *out);
 static int capi_list_containers(CAPI_CTX *ctx, BIO *out);
@@ -1096,7 +1096,7 @@ static int capi_dsa_free(DSA *dsa)
 }
 # endif
 
-static void capi_vtrace(CAPI_CTX *ctx, int level, char *format,
+static void capi_vtrace(CAPI_CTX *ctx, int level, char *__restrict format,
                         va_list argptr)
 {
     BIO *out;
@@ -1112,7 +1112,7 @@ static void capi_vtrace(CAPI_CTX *ctx, int level, char *format,
     BIO_free(out);
 }
 
-static void CAPI_trace(CAPI_CTX *ctx, char *format, ...)
+static void CAPI_trace(CAPI_CTX *ctx, char *__restrict format, ...)
 {
     va_list args;
     va_start(args, format);

--- a/include/internal/bio.h
+++ b/include/internal/bio.h
@@ -94,7 +94,7 @@ int ossl_core_bio_puts(OSSL_CORE_BIO *cb, const char *buf);
 long ossl_core_bio_ctrl(OSSL_CORE_BIO *cb, int cmd, long larg, void *parg);
 int ossl_core_bio_up_ref(OSSL_CORE_BIO *cb);
 int ossl_core_bio_free(OSSL_CORE_BIO *cb);
-int ossl_core_bio_vprintf(OSSL_CORE_BIO *cb, const char *format, va_list args);
+int ossl_core_bio_vprintf(OSSL_CORE_BIO *cb, const char *__restrict format, va_list args);
 
 int ossl_bio_init_core(OSSL_LIB_CTX *libctx, const OSSL_DISPATCH *fns);
 

--- a/include/openssl/bio.h.in
+++ b/include/openssl/bio.h.in
@@ -891,13 +891,13 @@ void BIO_copy_next_retry(BIO *b);
 #   endif
 #  endif
 # endif
-int BIO_printf(BIO *bio, const char *format, ...)
+int BIO_printf(BIO *bio, const char *__restrict format, ...)
 ossl_bio__attr__((__format__(ossl_bio__printf__, 2, 3)));
-int BIO_vprintf(BIO *bio, const char *format, va_list args)
+int BIO_vprintf(BIO *bio, const char *__restrict format, va_list args)
 ossl_bio__attr__((__format__(ossl_bio__printf__, 2, 0)));
-int BIO_snprintf(char *buf, size_t n, const char *format, ...)
+int BIO_snprintf(char *buf, size_t n, const char *__restrict format, ...)
 ossl_bio__attr__((__format__(ossl_bio__printf__, 3, 4)));
-int BIO_vsnprintf(char *buf, size_t n, const char *format, va_list args)
+int BIO_vsnprintf(char *buf, size_t n, const char *__restrict format, va_list args)
 ossl_bio__attr__((__format__(ossl_bio__printf__, 3, 0)));
 # undef ossl_bio__attr__
 # undef ossl_bio__printf__

--- a/include/openssl/core_dispatch.h
+++ b/include/openssl/core_dispatch.h
@@ -82,7 +82,7 @@ OSSL_CORE_MAKE_FUNC(void,core_set_error_debug,
 # define OSSL_FUNC_CORE_VSET_ERROR             7
 OSSL_CORE_MAKE_FUNC(void,core_vset_error,
                     (const OSSL_CORE_HANDLE *prov,
-                     uint32_t reason, const char *fmt, va_list args))
+                     uint32_t reason, const char *__restrict fmt, va_list args))
 # define OSSL_FUNC_CORE_SET_ERROR_MARK         8
 OSSL_CORE_MAKE_FUNC(int, core_set_error_mark, (const OSSL_CORE_HANDLE *prov))
 # define OSSL_FUNC_CORE_CLEAR_LAST_ERROR_MARK  9
@@ -169,10 +169,10 @@ OSSL_CORE_MAKE_FUNC(int, BIO_gets, (OSSL_CORE_BIO *bio, char *buf, int size))
 OSSL_CORE_MAKE_FUNC(int, BIO_puts, (OSSL_CORE_BIO *bio, const char *str))
 OSSL_CORE_MAKE_FUNC(int, BIO_up_ref, (OSSL_CORE_BIO *bio))
 OSSL_CORE_MAKE_FUNC(int, BIO_free, (OSSL_CORE_BIO *bio))
-OSSL_CORE_MAKE_FUNC(int, BIO_vprintf, (OSSL_CORE_BIO *bio, const char *format,
+OSSL_CORE_MAKE_FUNC(int, BIO_vprintf, (OSSL_CORE_BIO *bio, const char *__restrict format,
                                        va_list args))
 OSSL_CORE_MAKE_FUNC(int, BIO_vsnprintf,
-                   (char *buf, size_t n, const char *fmt, va_list args))
+                   (char *buf, size_t n, const char *__restrict fmt, va_list args))
 OSSL_CORE_MAKE_FUNC(int, BIO_ctrl, (OSSL_CORE_BIO *bio,
                                     int cmd, long num, void *ptr))
 

--- a/include/openssl/err.h.in
+++ b/include/openssl/err.h.in
@@ -383,8 +383,8 @@ typedef struct ERR_string_data_st {
 /* Building blocks */
 void ERR_new(void);
 void ERR_set_debug(const char *file, int line, const char *func);
-void ERR_set_error(int lib, int reason, const char *fmt, ...);
-void ERR_vset_error(int lib, int reason, const char *fmt, va_list args);
+void ERR_set_error(int lib, int reason, const char *__restrict fmt, ...);
+void ERR_vset_error(int lib, int reason, const char *__restrict fmt, va_list args);
 
 /* Main error raising functions */
 # define ERR_raise(lib, reason) ERR_raise_data((lib),(reason),NULL)

--- a/providers/common/bio_prov.c
+++ b/providers/common/bio_prov.c
@@ -138,14 +138,14 @@ int ossl_prov_bio_free(OSSL_CORE_BIO *bio)
     return c_bio_free(bio);
 }
 
-int ossl_prov_bio_vprintf(OSSL_CORE_BIO *bio, const char *format, va_list ap)
+int ossl_prov_bio_vprintf(OSSL_CORE_BIO *bio, const char *__restrict format, va_list ap)
 {
     if (c_bio_vprintf == NULL)
         return -1;
     return c_bio_vprintf(bio, format, ap);
 }
 
-int ossl_prov_bio_printf(OSSL_CORE_BIO *bio, const char *format, ...)
+int ossl_prov_bio_printf(OSSL_CORE_BIO *bio, const char *__restrict format, ...)
 {
     va_list ap;
     int ret;

--- a/providers/common/include/prov/bio.h
+++ b/providers/common/include/prov/bio.h
@@ -25,8 +25,8 @@ int ossl_prov_bio_puts(OSSL_CORE_BIO *bio, const char *str);
 int ossl_prov_bio_ctrl(OSSL_CORE_BIO *bio, int cmd, long num, void *ptr);
 int ossl_prov_bio_up_ref(OSSL_CORE_BIO *bio);
 int ossl_prov_bio_free(OSSL_CORE_BIO *bio);
-int ossl_prov_bio_vprintf(OSSL_CORE_BIO *bio, const char *format, va_list ap);
-int ossl_prov_bio_printf(OSSL_CORE_BIO *bio, const char *format, ...);
+int ossl_prov_bio_vprintf(OSSL_CORE_BIO *bio, const char *__restrict format, va_list ap);
+int ossl_prov_bio_printf(OSSL_CORE_BIO *bio, const char *__restrict format, ...);
 
 BIO_METHOD *ossl_bio_prov_init_bio_method(void);
 BIO *ossl_bio_new_from_core_bio(PROV_CTX *provctx, OSSL_CORE_BIO *corebio);

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -770,7 +770,7 @@ void ERR_set_debug(const char *file, int line, const char *func)
     c_set_error_debug(NULL, file, line, func);
 }
 
-void ERR_set_error(int lib, int reason, const char *fmt, ...)
+void ERR_set_error(int lib, int reason, const char *__restrict fmt, ...)
 {
     va_list args;
 
@@ -779,7 +779,7 @@ void ERR_set_error(int lib, int reason, const char *fmt, ...)
     va_end(args);
 }
 
-void ERR_vset_error(int lib, int reason, const char *fmt, va_list args)
+void ERR_vset_error(int lib, int reason, const char *__restrict fmt, va_list args)
 {
     c_vset_error(NULL, ERR_PACK(lib, 0, reason), fmt, args);
 }
@@ -873,7 +873,7 @@ int CRYPTO_secure_allocated(const void *ptr)
     return c_CRYPTO_secure_allocated(ptr);
 }
 
-int BIO_snprintf(char *buf, size_t n, const char *format, ...)
+int BIO_snprintf(char *buf, size_t n, const char *__restrict format, ...)
 {
     va_list args;
     int ret;

--- a/providers/legacyprov.c
+++ b/providers/legacyprov.c
@@ -273,7 +273,7 @@ void ERR_set_debug(const char *file, int line, const char *func)
     c_set_error_debug(NULL, file, line, func);
 }
 
-void ERR_set_error(int lib, int reason, const char *fmt, ...)
+void ERR_set_error(int lib, int reason, const char *__restrict fmt, ...)
 {
     va_list args;
 
@@ -282,7 +282,7 @@ void ERR_set_error(int lib, int reason, const char *fmt, ...)
     va_end(args);
 }
 
-void ERR_vset_error(int lib, int reason, const char *fmt, va_list args)
+void ERR_vset_error(int lib, int reason, const char *__restrict fmt, va_list args)
 {
     c_vset_error(NULL, ERR_PACK(lib, 0, reason), fmt, args);
 }

--- a/ssl/quic/quic_rx_depack.c
+++ b/ssl/quic/quic_rx_depack.c
@@ -127,7 +127,7 @@ static int ssl_close_connection(QUIC_CONNECTION *connection)
 #ifndef QUICfatal
 
 static void ossl_quic_fatal(QUIC_CONNECTION *c, int al, int reason,
-                            const char *fmt, ...)
+                            const char *__restrict fmt, ...)
 {
     va_list args;
 

--- a/ssl/record/methods/recmethod_local.h
+++ b/ssl/record/methods/recmethod_local.h
@@ -387,7 +387,7 @@ extern struct record_functions_st dtls_1_funcs;
 extern struct record_functions_st dtls_any_funcs;
 
 void ossl_rlayer_fatal(OSSL_RECORD_LAYER *rl, int al, int reason,
-                       const char *fmt, ...);
+                       const char *__restrict fmt, ...);
 
 #define RLAYERfatal(rl, al, r) RLAYERfatal_data((rl), (al), (r), NULL)
 #define RLAYERfatal_data                                           \

--- a/ssl/record/methods/tls_common.c
+++ b/ssl/record/methods/tls_common.c
@@ -45,7 +45,7 @@ void ossl_tls_rl_record_set_seq_num(TLS_RL_RECORD *r,
 }
 
 void ossl_rlayer_fatal(OSSL_RECORD_LAYER *rl, int al, int reason,
-                       const char *fmt, ...)
+                       const char *__restrict fmt, ...)
 {
     va_list args;
 

--- a/ssl/ssl_ciph.c
+++ b/ssl/ssl_ciph.c
@@ -1705,7 +1705,7 @@ char *SSL_CIPHER_description(const SSL_CIPHER *cipher, char *buf, int len)
     const char *ver;
     const char *kx, *au, *enc, *mac;
     uint32_t alg_mkey, alg_auth, alg_enc, alg_mac;
-    static const char *format = "%-30s %-7s Kx=%-8s Au=%-5s Enc=%-22s Mac=%-4s\n";
+    static const char *__restrict format = "%-30s %-7s Kx=%-8s Au=%-5s Enc=%-22s Mac=%-4s\n";
 
     if (buf == NULL) {
         len = 128;

--- a/ssl/statem/statem.c
+++ b/ssl/statem/statem.c
@@ -159,7 +159,7 @@ void ossl_statem_send_fatal(SSL_CONNECTION *s, int al)
  * This is a permanent error for the current connection.
  */
 void ossl_statem_fatal(SSL_CONNECTION *s, int al, int reason,
-                       const char *fmt, ...)
+                       const char *__restrict fmt, ...)
 {
     va_list args;
 

--- a/ssl/statem/statem.h
+++ b/ssl/statem/statem.h
@@ -123,7 +123,7 @@ void ossl_statem_clear(SSL_CONNECTION *s);
 void ossl_statem_set_renegotiate(SSL_CONNECTION *s);
 void ossl_statem_send_fatal(SSL_CONNECTION *s, int al);
 void ossl_statem_fatal(SSL_CONNECTION *s, int al, int reason,
-                       const char *fmt, ...);
+                       const char *__restrict fmt, ...);
 # define SSLfatal_alert(s, al) ossl_statem_send_fatal((s), (al))
 # define SSLfatal(s, al, r) SSLfatal_data((s), (al), (r), NULL)
 # define SSLfatal_data                                          \

--- a/test/bio_prefix_text.c
+++ b/test/bio_prefix_text.c
@@ -58,7 +58,7 @@ static const OPTIONS options[] = {
     { NULL }
 };
 
-int opt_printf_stderr(const char *fmt, ...)
+int opt_printf_stderr(const char *__restrict fmt, ...)
 {
     va_list ap;
     int ret;

--- a/test/bioprinttest.c
+++ b/test/bioprinttest.c
@@ -320,12 +320,12 @@ void test_close_streams(void)
  * But we are caller's caller, and test_str_eq is the only one called,
  * and it uses only "%s", which is not "fancy"...
  */
-int test_vprintf_stdout(const char *fmt, va_list ap)
+int test_vprintf_stdout(const char *__restrict fmt, va_list ap)
 {
     return fprintf(stdout, "%*s# ", tap_level, "") + vfprintf(stdout, fmt, ap);
 }
 
-int test_vprintf_stderr(const char *fmt, va_list ap)
+int test_vprintf_stderr(const char *__restrict fmt, va_list ap)
 {
     return fprintf(stderr, "%*s# ", tap_level, "") + vfprintf(stderr, fmt, ap);
 }
@@ -340,12 +340,12 @@ int test_flush_stderr(void)
     return fflush(stderr);
 }
 
-int test_vprintf_tapout(const char *fmt, va_list ap)
+int test_vprintf_tapout(const char *__restrict fmt, va_list ap)
 {
     return fprintf(stdout, "%*s", tap_level, "") + vfprintf(stdout, fmt, ap);
 }
 
-int test_vprintf_taperr(const char *fmt, va_list ap)
+int test_vprintf_taperr(const char *__restrict fmt, va_list ap)
 {
     return fprintf(stderr, "%*s", tap_level, "") + vfprintf(stderr, fmt, ap);
 }

--- a/test/p_test.c
+++ b/test/p_test.c
@@ -61,7 +61,7 @@ static OSSL_FUNC_provider_get_reason_strings_fn p_get_reason_strings;
 static OSSL_FUNC_provider_teardown_fn p_teardown;
 
 static void p_set_error(int lib, int reason, const char *file, int line,
-                        const char *func, const char *fmt, ...)
+                        const char *func, const char *__restrict fmt, ...)
 {
     va_list ap;
 

--- a/test/testutil/basic_output.c
+++ b/test/testutil/basic_output.c
@@ -61,12 +61,12 @@ void test_close_streams(void)
     BIO_free_all(tap_err);
 }
 
-int test_vprintf_stdout(const char *fmt, va_list ap)
+int test_vprintf_stdout(const char *__restrict fmt, va_list ap)
 {
     return BIO_vprintf(bio_out, fmt, ap);
 }
 
-int test_vprintf_stderr(const char *fmt, va_list ap)
+int test_vprintf_stderr(const char *__restrict fmt, va_list ap)
 {
     return BIO_vprintf(bio_err, fmt, ap);
 }
@@ -81,12 +81,12 @@ int test_flush_stderr(void)
     return BIO_flush(bio_err);
 }
 
-int test_vprintf_tapout(const char *fmt, va_list ap)
+int test_vprintf_tapout(const char *__restrict fmt, va_list ap)
 {
     return BIO_vprintf(tap_out, fmt, ap);
 }
 
-int test_vprintf_taperr(const char *fmt, va_list ap)
+int test_vprintf_taperr(const char *__restrict fmt, va_list ap)
 {
     return BIO_vprintf(tap_err, fmt, ap);
 }

--- a/test/testutil/options.c
+++ b/test/testutil/options.c
@@ -66,7 +66,7 @@ void opt_check_usage(void)
         test_printf_stderr("Warning arguments %d and later unchecked\n", i);
 }
 
-int opt_printf_stderr(const char *fmt, ...)
+int opt_printf_stderr(const char *__restrict fmt, ...)
 {
     va_list ap;
     int ret;

--- a/test/testutil/output.c
+++ b/test/testutil/output.c
@@ -9,7 +9,7 @@
 
 #include "output.h"
 
-int test_printf_stdout(const char *fmt, ...)
+int test_printf_stdout(const char *__restrict fmt, ...)
 {
     va_list ap;
     int ret;
@@ -21,7 +21,7 @@ int test_printf_stdout(const char *fmt, ...)
     return ret;
 }
 
-int test_printf_stderr(const char *fmt, ...)
+int test_printf_stderr(const char *__restrict fmt, ...)
 {
     va_list ap;
     int ret;
@@ -33,7 +33,7 @@ int test_printf_stderr(const char *fmt, ...)
     return ret;
 }
 
-int test_printf_tapout(const char *fmt, ...)
+int test_printf_tapout(const char *__restrict fmt, ...)
 {
     va_list ap;
     int ret;
@@ -45,7 +45,7 @@ int test_printf_tapout(const char *fmt, ...)
     return ret;
 }
 
-int test_printf_taperr(const char *fmt, ...)
+int test_printf_taperr(const char *__restrict fmt, ...)
 {
     va_list ap;
     int ret;

--- a/test/testutil/output.h
+++ b/test/testutil/output.h
@@ -38,13 +38,13 @@ void test_open_streams(void);
 void test_close_streams(void);
 void test_adjust_streams_tap_level(int level);
 /* The following ALL return the number of characters written */
-int test_vprintf_stdout(const char *fmt, va_list ap)
+int test_vprintf_stdout(const char *__restrict fmt, va_list ap)
     ossl_test__attr__((__format__(ossl_test__printf__, 1, 0)));
-int test_vprintf_tapout(const char *fmt, va_list ap)
+int test_vprintf_tapout(const char *__restrict fmt, va_list ap)
     ossl_test__attr__((__format__(ossl_test__printf__, 1, 0)));
-int test_vprintf_stderr(const char *fmt, va_list ap)
+int test_vprintf_stderr(const char *__restrict fmt, va_list ap)
     ossl_test__attr__((__format__(ossl_test__printf__, 1, 0)));
-int test_vprintf_taperr(const char *fmt, va_list ap)
+int test_vprintf_taperr(const char *__restrict fmt, va_list ap)
     ossl_test__attr__((__format__(ossl_test__printf__, 1, 0)));
 /* These return failure or success */
 int test_flush_stdout(void);
@@ -53,13 +53,13 @@ int test_flush_stderr(void);
 int test_flush_taperr(void);
 
 /* Commodity functions.  There's no need to override these */
-int test_printf_stdout(const char *fmt, ...)
+int test_printf_stdout(const char *__restrict fmt, ...)
     ossl_test__attr__((__format__(ossl_test__printf__, 1, 2)));
-int test_printf_tapout(const char *fmt, ...)
+int test_printf_tapout(const char *__restrict fmt, ...)
     ossl_test__attr__((__format__(ossl_test__printf__, 1, 2)));
-int test_printf_stderr(const char *fmt, ...)
+int test_printf_stderr(const char *__restrict fmt, ...)
     ossl_test__attr__((__format__(ossl_test__printf__, 1, 2)));
-int test_printf_taperr(const char *fmt, ...)
+int test_printf_taperr(const char *__restrict fmt, ...)
     ossl_test__attr__((__format__(ossl_test__printf__, 1, 2)));
 
 # undef ossl_test__printf__

--- a/test/testutil/tests.c
+++ b/test/testutil/tests.c
@@ -68,13 +68,13 @@ void test_fail_message_prefix(const char *prefix, const char *file,
 static void test_fail_message(const char *prefix, const char *file, int line,
                               const char *type, const char *left,
                               const char *right, const char *op,
-                              const char *fmt, ...)
+                              const char *__restrict fmt, ...)
             PRINTF_FORMAT(8, 9);
 
 static void test_fail_message_va(const char *prefix, const char *file,
                                  int line, const char *type,
                                  const char *left, const char *right,
-                                 const char *op, const char *fmt, va_list ap)
+                                 const char *op, const char *__restrict fmt, va_list ap)
 {
     test_fail_message_prefix(prefix, file, line, type, left, right, op);
     if (fmt != NULL) {
@@ -87,7 +87,7 @@ static void test_fail_message_va(const char *prefix, const char *file,
 static void test_fail_message(const char *prefix, const char *file,
                               int line, const char *type,
                               const char *left, const char *right,
-                              const char *op, const char *fmt, ...)
+                              const char *op, const char *__restrict fmt, ...)
 {
     va_list ap;
 
@@ -143,7 +143,7 @@ void test_perror(const char *s)
     TEST_error("%s: %s", s, strerror(errno));
 }
 
-void test_note(const char *fmt, ...)
+void test_note(const char *__restrict fmt, ...)
 {
     if (fmt != NULL) {
         va_list ap;

--- a/test/tls13secretstest.c
+++ b/test/tls13secretstest.c
@@ -195,7 +195,7 @@ void ossl_statem_send_fatal(SSL_CONNECTION *s, int al)
 }
 
 void ossl_statem_fatal(SSL_CONNECTION *s, int al, int reason,
-                       const char *fmt, ...)
+                       const char *__restrict fmt, ...)
 {
 }
 


### PR DESCRIPTION
The format value has to be a string literal, every time. Otherwise, you are not using these functions correctly. To reinforce this fact, I put __restrict over every non-contrib example of this I could find.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
