### PR TITLE
Don't set cancel state/type on Android

### DIFF
--- a/crypto/thread/arch/thread_posix.c
+++ b/crypto/thread/arch/thread_posix.c
@@ -22,9 +22,6 @@ static void *thread_start_thunk(void *vthread)
 
     thread = (CRYPTO_THREAD *)vthread;
 
-    pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL);
-    pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS, NULL);
-
     ret = thread->routine(thread->data);
     ossl_crypto_mutex_lock(thread->statelock);
     CRYPTO_THREAD_SET_STATE(thread, CRYPTO_THREAD_FINISHED);


### PR DESCRIPTION
`pthread_cancel()` and associated functions are not supported on Android. Therefore we do not call any of these functions when compiling for Android targets.

Fixes #19559

I've tested that this compiles using my local Android NDK - but I don't have a way of running the tests on Android in my local set up.

It's actually unclear why we need to call `pthread_setcancelstate()` or `pthread_setcanceltype()` at all since we never call `pthread_cancel()` anyway. An alternative fix might be simply to delete these lines altogether. Perhaps @ckalina has a view on that.
