### PR TITLE
Fix daily CI failure for no-chacha and no-poly1305 builds plus some HPKE refactoring

### DIFF
--- a/crypto/hpke/hpke_util.c
+++ b/crypto/hpke/hpke_util.c
@@ -393,6 +393,10 @@ EVP_KDF_CTX *ossl_kdf_ctx_create(const char *kdfname, const char *mdname,
     EVP_KDF_CTX *kctx = NULL;
 
     kdf = EVP_KDF_fetch(libctx, kdfname, propq);
+    if (kdf == NULL) {
+        ERR_raise(ERR_LIB_CRYPTO, ERR_R_FETCH_FAILED);
+        return NULL;
+    }
     kctx = EVP_KDF_CTX_new(kdf);
     EVP_KDF_free(kdf);
     if (kctx != NULL && mdname != NULL) {

--- a/crypto/hpke/hpke_util.c
+++ b/crypto/hpke/hpke_util.c
@@ -86,13 +86,11 @@ static const OSSL_HPKE_AEAD_INFO hpke_aead_tab[] = {
       OSSL_HPKE_MAX_NONCELEN },
     { OSSL_HPKE_AEAD_ID_AES_GCM_256, LN_aes_256_gcm, 16, 32,
       OSSL_HPKE_MAX_NONCELEN },
-#ifndef OPENSSL_NO_CHACHA20
-# ifndef OPENSSL_NO_POLY1305
+#if !defined(OPENSSL_NO_CHACHA) && !defined(OPENSSL_NO_POLY1305)
     { OSSL_HPKE_AEAD_ID_CHACHA_POLY1305, LN_chacha20_poly1305, 16, 32,
       OSSL_HPKE_MAX_NONCELEN },
-# endif
-    { OSSL_HPKE_AEAD_ID_EXPORTONLY, NULL, 0, 0, 0 }
 #endif
+    { OSSL_HPKE_AEAD_ID_EXPORTONLY, NULL, 0, 0, 0 }
 };
 
 /*

--- a/test/hpke_test.c
+++ b/test/hpke_test.c
@@ -1342,13 +1342,6 @@ static int test_hpke_oddcalls(void)
     if (!TEST_false(OSSL_HPKE_CTX_set1_psk(NULL, NULL, NULL, 0)))
         goto end;
 
-    /* make/break ctx */
-    if (!TEST_ptr(ctx = OSSL_HPKE_CTX_new(hpke_mode, hpke_suite,
-                                          testctx, "foo")))
-        goto end;
-    OSSL_HPKE_CTX_free(ctx);
-    ctx = NULL;
-
     /* bad suite calls */
     hpke_suite.aead_id = 0xbad;
     if (!TEST_false(OSSL_HPKE_suite_check(hpke_suite)))

--- a/test/hpke_test.c
+++ b/test/hpke_test.c
@@ -797,7 +797,9 @@ static uint16_t hpke_kdf_list[] = {
 static uint16_t hpke_aead_list[] = {
     OSSL_HPKE_AEAD_ID_AES_GCM_128,
     OSSL_HPKE_AEAD_ID_AES_GCM_256,
+#if !defined(OPENSSL_NO_CHACHA) && !defined(OPENSSL_NO_POLY1305)
     OSSL_HPKE_AEAD_ID_CHACHA_POLY1305
+#endif
 };
 
 /*


### PR DESCRIPTION
When investigating daily CI failure for no-chacha and no-poly1305 builds I've realized there is some inefficiency in the HPKE seal/open functions.
