### PR TITLE
Replace "a RSA" with "an RSA"

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19449,7 +19449,7 @@ ndif
    *Ralf S. Engelschall*
 
  * Incorporated the popular no-RSA/DSA-only patches
-   which allow to compile a RSA-free SSLeay.
+   which allow to compile an RSA-free SSLeay.
 
    *Andrew Cooke / Interrader Ldt., Ralf S. Engelschall*
 

--- a/crypto/rsa/rsa_mp.c
+++ b/crypto/rsa/rsa_mp.c
@@ -21,7 +21,7 @@ void ossl_rsa_multip_info_free_ex(RSA_PRIME_INFO *pinfo)
 
 void ossl_rsa_multip_info_free(RSA_PRIME_INFO *pinfo)
 {
-    /* free a RSA_PRIME_INFO structure */
+    /* free an RSA_PRIME_INFO structure */
     BN_clear_free(pinfo->r);
     BN_clear_free(pinfo->d);
     BN_clear_free(pinfo->t);
@@ -32,7 +32,7 @@ RSA_PRIME_INFO *ossl_rsa_multip_info_new(void)
 {
     RSA_PRIME_INFO *pinfo;
 
-    /* create a RSA_PRIME_INFO structure */
+    /* create an RSA_PRIME_INFO structure */
     if ((pinfo = OPENSSL_zalloc(sizeof(RSA_PRIME_INFO))) == NULL)
         return NULL;
     if ((pinfo->r = BN_secure_new()) == NULL)

--- a/demos/encode/rsa_encode.c
+++ b/demos/encode/rsa_encode.c
@@ -93,7 +93,7 @@ cleanup:
 }
 
 /*
- * Store a RSA public or private key to a file using PEM encoding.
+ * Store an RSA public or private key to a file using PEM encoding.
  *
  * If a passphrase is supplied, the file is encrypted, otherwise
  * it is unencrypted.

--- a/doc/HOWTO/certificates.txt
+++ b/doc/HOWTO/certificates.txt
@@ -30,7 +30,7 @@ keys, so before you create a certificate or a certificate request, you
 need to create a private key.
 
 Private keys are generated with 'openssl genrsa -out privkey.pem' if
-you want a RSA private key, or if you want a DSA private key:
+you want an RSA private key, or if you want a DSA private key:
 'openssl dsaparam -out dsaparam.pem 2048; openssl gendsa -out privkey.pem dsaparam.pem'.
 
 The private keys created by these commands are not passphrase protected;

--- a/doc/HOWTO/keys.txt
+++ b/doc/HOWTO/keys.txt
@@ -14,9 +14,9 @@ algorithms.  The most popular ones associated with certificates are
 RSA and DSA, and this HOWTO will show how to generate each of them.
 
 
-2. To generate a RSA key
+2. To generate an RSA key
 
-A RSA key can be used both for encryption and for signing.
+An RSA key can be used both for encryption and for signing.
 
 Generating a key for the RSA algorithm is quite easy, all you have to
 do is the following:

--- a/doc/man3/SSL_CTX_set_cipher_list.pod
+++ b/doc/man3/SSL_CTX_set_cipher_list.pod
@@ -80,7 +80,7 @@ additional restrictions apply. All ciphers have additional requirements.
 ADH ciphers don't need a certificate, but DH-parameters must have been set.
 All other ciphers need a corresponding certificate and key.
 
-A RSA cipher can only be chosen, when a RSA certificate is available.
+An RSA cipher can only be chosen, when an RSA certificate is available.
 RSA ciphers using DHE need a certificate and key and additional DH-parameters
 (see L<SSL_CTX_set_tmp_dh_callback(3)>).
 

--- a/doc/man3/SSL_CTX_use_certificate.pod
+++ b/doc/man3/SSL_CTX_use_certificate.pod
@@ -130,7 +130,7 @@ RSA key found to B<ssl>.
 SSL_CTX_check_private_key() checks the consistency of a private key with
 the corresponding certificate loaded into B<ctx>. If more than one
 key/certificate pair (RSA/DSA) is installed, the last item installed will
-be checked. If e.g. the last item was a RSA certificate or key, the RSA
+be checked. If e.g. the last item was an RSA certificate or key, the RSA
 key/certificate pair will be checked. SSL_check_private_key() performs
 the same check for B<ssl>. If no key/certificate was explicitly added for
 this B<ssl>, the last item added into B<ctx> will be checked.

--- a/doc/man3/SSL_CTX_use_serverinfo.pod
+++ b/doc/man3/SSL_CTX_use_serverinfo.pod
@@ -59,7 +59,7 @@ SSL_SERVERINFOV2 data or "BEGIN SERVERINFO FOR " for SSL_SERVERINFOV1 data.
 
 If more than one certificate (RSA/DSA) is installed using
 SSL_CTX_use_certificate(), the serverinfo extension will be loaded into the
-last certificate installed.  If e.g. the last item was a RSA certificate, the
+last certificate installed.  If e.g. the last item was an RSA certificate, the
 loaded serverinfo extension data will be loaded for that certificate.  To
 use the serverinfo extension for multiple certificates,
 SSL_CTX_use_serverinfo() needs to be called multiple times, once B<after>

--- a/test/keymgmt_internal_test.c
+++ b/test/keymgmt_internal_test.c
@@ -227,7 +227,7 @@ static int test_pass_rsa(FIXTURE *fixture)
     while (dup_pk == NULL) {
         ret = 0;
         km = km3;
-        /* Check that we can't export an RSA key into a RSA-PSS keymanager */
+        /* Check that we can't export an RSA key into an RSA-PSS keymanager */
         if (!TEST_ptr_null(provkey2 = evp_pkey_export_to_provider(pk, NULL,
                                                                   &km,
                                                                   NULL)))

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -401,7 +401,7 @@ static int test_keylog(void)
      * Now we want to test that our output data was vaguely sensible. We
      * do that by using strtok and confirming that we have more or less the
      * data we expect. For both client and server, we expect to see one master
-     * secret. The client should also see a RSA key exchange.
+     * secret. The client should also see an RSA key exchange.
      */
     expected.rsa_key_exchange_count = 1;
     expected.master_secret_count = 1;


### PR DESCRIPTION
It looks there are other less important places with "a RSA".

Fixes openssl#19771

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
