### PR TITLE
`check-format.pl`: three fixes on false positives and statistics

### DIFF
--- a/util/check-format.pl
+++ b/util/check-format.pl
@@ -301,14 +301,14 @@ sub report_flexibly {
     my $line = shift;
     my $msg = shift;
     my $contents = shift;
-    my $report_SPC = $msg =~ /space/;
+    my $report_SPC = $msg =~ /space|blank/;
     return if $report_SPC && $sloppy_SPC;
 
     print "$ARGV:$line:$msg:$contents" unless $self_test;
     $num_reports_line++;
     $num_reports++;
-    $num_indent_reports++ if $msg =~ m/indent/;
-    $num_nesting_issues++ if $msg =~ m/#if nesting/;
+    $num_indent_reports++ if $msg =~ m/:indent /;
+    $num_nesting_issues++ if $msg =~ m/ nesting indent /;
     $num_syntax_issues++  if $msg =~ m/unclosed|unexpected/;
     $num_SPC_reports++    if $report_SPC;
     $num_length_reports++ if $msg =~ m/length/;

--- a/util/check-format.pl
+++ b/util/check-format.pl
@@ -165,8 +165,8 @@ my $count_before;          # number of leading whitespace characters (except lin
 my $has_label;             # current line contains label
 my $local_offset;          # current extra indent due to label, switch case/default, or leading closing brace(s)
 my $line_body_start;       # number of line where last function body started, or 0
-my $line_function_start;   # number of line where last function definition started, used if $line_body_start != 0
-my $last_function_header;  # header containing name of last function defined, used if $line_function_start != 0
+my $line_function_start;   # number of line where last function definition started, used for $line_body_start
+my $last_function_header;  # header containing name of last function defined, used if $line_body_start != 0
 my $line_opening_brace;    # number of previous line with opening brace after do/while/for, optionally for if/else
 
 my $keyword_opening_brace; # name of previous keyword, used if $line_opening_brace != 0
@@ -1129,7 +1129,7 @@ while (<>) { # loop over all lines of all input files
                 if (!$assignment_start && !$local_in_expr) {
                     # at end of function definition header (or stmt or var definition)
                     report("'{' not at line start") if length($head) != $preproc_offset && $head =~ m/\)\s*/; # at end of function definition header
-                    $line_body_start = $contents =~ m/LONG BODY/ ? 0 : $line;
+                    $line_body_start = $contents =~ m/LONG BODY/ ? 0 : $line if $line_function_start != 0;
                 }
             } else {
                 $line_opening_brace = $line if $keyword_opening_brace =~ m/do|while|for/;

--- a/util/check-format.pl
+++ b/util/check-format.pl
@@ -715,7 +715,7 @@ while (<>) { # loop over all lines of all input files
         my $space_count = length($space); # maybe could also use indentation before '#'
         report("'#if' nesting indent = $space_count != $preproc_if_nesting") if $space_count != $preproc_if_nesting;
         $preproc_if_nesting++ if $preproc_directive =~ m/^(if|ifdef|ifndef|else|elif)$/;
-        $ifdef__cplusplus = $preproc_directive eq "ifdef2" && m/\s+__cplusplus\s*$/;
+        $ifdef__cplusplus = $preproc_directive eq "ifdef" && m/\s+__cplusplus\s*$/;
 
         # handle indentation of preprocessor directive independently of surrounding normal code
         $count = -1; # do not check indentation of first line of preprocessor directive


### PR DESCRIPTION
* fix detection of function body start
* detection of `#ifdef __cplusplus` used in header files
* fix statistics on whitespace and nesting issues

