### PR TITLE
Fix build on NonStop

### DIFF
--- a/apps/speed.c
+++ b/apps/speed.c
@@ -63,8 +63,8 @@ VirtualLock(
     );
 #endif
 
-# if defined(OPENSSL_SYS_UNIX)
-#  include <sys/mman.h>
+#if defined(OPENSSL_SYS_LINUX)
+# include <sys/mman.h>
 #endif
 
 #include <openssl/bn.h>


### PR DESCRIPTION
Fixes #19810

We support `speed -mlock` option on Linux and Windows only, include the sys/mman.h only for Linux.
