### PR TITLE
Fix treatment of BUILD_METADATA

### DIFF
--- a/NOTES-NONSTOP.md
+++ b/NOTES-NONSTOP.md
@@ -186,6 +186,9 @@ following variables:
         if [ -n "$PRE_RELEASE_TAG" ]; then
             PRE_RELEASE_TAG="-$PRE_RELEASE_TAG"
         fi
+        if [ -n "$BUILD_METADATA" ]; then
+            BUILD_METADATA="+$BUILD_METADATA"
+        fi
         echo "$MAJOR.$MINOR.$PATCH$PRE_RELEASE_TAG$BUILD_METADATA" |\
             sed -e 's/[-.+]/_/g'
         )

--- a/dev/release-aux/release-version-fn.sh
+++ b/dev/release-aux/release-version-fn.sh
@@ -54,6 +54,9 @@ get_version () {
                          -e 's|^dev$|0|' \
                          -e 's|^alpha([0-9]+)(-(dev))?$|\1|' \
                          -e 's|^beta([0-9]+)(-(dev))?$|\1|' )
+    _BUILD_METADATA=''
+    if [ -n "$PRE_RELEASE_TAG" ]; then _PRE_RELEASE_TAG="-${PRE_RELEASE_TAG}"; fi
+    if [ -n "$BUILD_METADATA" ]; then _BUILD_METADATA="+${BUILD_METADATA}"; fi
 }
 
 # $1 is one of "alpha", "beta", "final", "", or "minor"
@@ -102,6 +105,7 @@ set_version () {
             PRE_RELEASE_TAG="$PRE_LABEL$PRE_NUM"
             ;;
     esac
+    if [ -n "$PRE_RELEASE_TAG" ]; then _PRE_RELEASE_TAG="+${PRE_RELEASE_TAG}"; fi
     cat > "$SOURCEDIR/VERSION.dat" <<EOF
 MAJOR=$MAJOR
 MINOR=$MINOR

--- a/dev/release-aux/release-version-fn.sh
+++ b/dev/release-aux/release-version-fn.sh
@@ -105,7 +105,7 @@ set_version () {
             PRE_RELEASE_TAG="$PRE_LABEL$PRE_NUM"
             ;;
     esac
-    if [ -n "$PRE_RELEASE_TAG" ]; then _PRE_RELEASE_TAG="+${PRE_RELEASE_TAG}"; fi
+    if [ -n "$PRE_RELEASE_TAG" ]; then _PRE_RELEASE_TAG="-${PRE_RELEASE_TAG}"; fi
     cat > "$SOURCEDIR/VERSION.dat" <<EOF
 MAJOR=$MAJOR
 MINOR=$MINOR

--- a/dev/release.sh
+++ b/dev/release.sh
@@ -354,11 +354,11 @@ fi
 set_version
 
 if [ -n "$PRE_LABEL" ]; then
-    release="$VERSION-$PRE_RELEASE_TAG$BUILD_METADATA"
-    release_text="$SERIES$BUILD_METADATA $PRE_LABEL $PRE_NUM"
+    release="$VERSION$_PRE_RELEASE_TAG$_BUILD_METADATA"
+    release_text="$SERIES$_BUILD_METADATA $PRE_LABEL $PRE_NUM"
     announce_template=openssl-announce-pre-release.tmpl
 else
-    release="$VERSION$BUILD_METADATA"
+    release="$VERSION$_BUILD_METADATA"
     release_text="$release"
     announce_template=openssl-announce-release.tmpl
 fi
@@ -458,10 +458,10 @@ prev_release_date="$RELEASE_DATE"
 next_release_state "$next_method2"
 set_version
 
-release="$VERSION-$PRE_RELEASE_TAG$BUILD_METADATA"
-release_text="$VERSION$BUILD_METADATA"
+release="$VERSION$_PRE_RELEASE_TAG$_BUILD_METADATA"
+release_text="$VERSION$_BUILD_METADATA"
 if [ -n "$PRE_LABEL" ]; then
-    release_text="$SERIES$BUILD_METADATA $PRE_LABEL $PRE_NUM"
+    release_text="$SERIES$_BUILD_METADATA $PRE_LABEL $PRE_NUM"
 fi
 $VERBOSE "== Updated version information to $release"
 
@@ -494,8 +494,8 @@ if $do_branch; then
     next_release_state "minor"
     set_version
 
-    release="$VERSION-$PRE_RELEASE_TAG$BUILD_METADATA"
-    release_text="$SERIES$BUILD_METADATA"
+    release="$VERSION$_PRE_RELEASE_TAG$_BUILD_METADATA"
+    release_text="$SERIES$_BUILD_METADATA"
     $VERBOSE "== Updated version information to $release"
 
     $VERBOSE "== Updating files for $release :"
@@ -802,6 +802,10 @@ This is normally not seen in the git workspace, but should always be what's
 found in the tar file of a regular release.
 
 =back
+
+=item B<BUILD_METADATA>
+
+Extra build metadata to be used by anyone for their own purposes.
 
 =item B<RELEASE_DATE>
 

--- a/util/mktar.sh
+++ b/util/mktar.sh
@@ -12,6 +12,7 @@ HERE=`dirname $0`
 . $HERE/../VERSION.dat
 
 if [ -n "$PRE_RELEASE_TAG" ]; then PRE_RELEASE_TAG=-$PRE_RELEASE_TAG; fi
+if [ -n "$BUILD_METADATA" ]; then BUILD_METADATA=+$BUILD_METADATA; fi
 version=$MAJOR.$MINOR.$PATCH$PRE_RELEASE_TAG$BUILD_METADATA
 basename=openssl
 


### PR DESCRIPTION
According to documentation [^1], the BUILD_METADATA from VERSION.dat should
be prefixed with a plus sign when used.  It is given this treatment in
Configure, but not in all other scripts that use VERSION.dat directly.
This change fixes that.
