### PR TITLE
Fix the check of several APIs

### DIFF
--- a/crypto/evp/evp_enc.c
+++ b/crypto/evp/evp_enc.c
@@ -1059,7 +1059,7 @@ int EVP_CIPHER_CTX_set_padding(EVP_CIPHER_CTX *ctx, int pad)
     params[0] = OSSL_PARAM_construct_uint(OSSL_CIPHER_PARAM_PADDING, &pd);
     ok = evp_do_ciph_ctx_setparams(ctx->cipher, ctx->algctx, params);
 
-    return ok != 0;
+    return ok > 0;
 }
 
 int EVP_CIPHER_CTX_ctrl(EVP_CIPHER_CTX *ctx, int type, int arg, void *ptr)

--- a/crypto/evp/evp_lib.c
+++ b/crypto/evp/evp_lib.c
@@ -640,9 +640,9 @@ int EVP_CIPHER_CTX_set_num(EVP_CIPHER_CTX *ctx, int num)
     params[0] = OSSL_PARAM_construct_uint(OSSL_CIPHER_PARAM_NUM, &n);
     ok = evp_do_ciph_ctx_setparams(ctx->cipher, ctx->algctx, params);
 
-    if (ok != 0)
+    if (ok > 0)
         ctx->num = (int)n;
-    return ok != 0;
+    return ok > 0;
 }
 
 int EVP_CIPHER_get_key_length(const EVP_CIPHER *cipher)

--- a/crypto/x509/x509_vfy.c
+++ b/crypto/x509/x509_vfy.c
@@ -3456,7 +3456,7 @@ static int check_curve(X509 *cert)
         EVP_PKEY_get_int_param(pkey,
                                OSSL_PKEY_PARAM_EC_DECODED_FROM_EXPLICIT_PARAMS,
                                &val);
-    return ret < 0 ? ret : !val;
+    return ret == 0 ? -1 : !val;
 }
 
 /*-

--- a/test/aesgcmtest.c
+++ b/test/aesgcmtest.c
@@ -58,7 +58,7 @@ static int do_encrypt(unsigned char *iv_gen, unsigned char *ct, int *ct_len,
           && TEST_true(EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_AEAD_GET_TAG, 16,
                                            tag) > 0)
           && TEST_true(iv_gen == NULL
-                  || EVP_CIPHER_CTX_get_original_iv(ctx, iv_gen, 12));
+                  || EVP_CIPHER_CTX_get_original_iv(ctx, iv_gen, 12) > 0);
     EVP_CIPHER_CTX_free(ctx);
     return ret;
 }

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -3213,8 +3213,8 @@ static int test_evp_iv_aes(int idx)
             || !TEST_true(EVP_EncryptInit_ex(ctx, type, NULL, key, init_iv))
             || !TEST_true(EVP_EncryptUpdate(ctx, ciphertext, &len, msg,
                           (int)sizeof(msg)))
-            || !TEST_true(EVP_CIPHER_CTX_get_original_iv(ctx, oiv, sizeof(oiv)))
-            || !TEST_true(EVP_CIPHER_CTX_get_updated_iv(ctx, iv, sizeof(iv)))
+            || !TEST_int_gt(EVP_CIPHER_CTX_get_original_iv(ctx, oiv, sizeof(oiv)), 0)
+            || !TEST_int_gt(EVP_CIPHER_CTX_get_updated_iv(ctx, iv, sizeof(iv)), 0)
             || !TEST_true(EVP_EncryptFinal_ex(ctx, ciphertext, &len)))
         goto err;
     ivlen = EVP_CIPHER_CTX_get_iv_length(ctx);
@@ -3224,7 +3224,7 @@ static int test_evp_iv_aes(int idx)
 
     /* CBC, OFB, and CFB modes: the updated iv must be reset after reinit */
     if (!TEST_true(EVP_EncryptInit_ex(ctx, NULL, NULL, NULL, NULL))
-        || !TEST_true(EVP_CIPHER_CTX_get_updated_iv(ctx, iv, sizeof(iv))))
+        || !TEST_int_gt(EVP_CIPHER_CTX_get_updated_iv(ctx, iv, sizeof(iv)), 0))
         goto err;
     if (iv_reset) {
         if (!TEST_mem_eq(init_iv, ivlen, iv, ivlen))
@@ -3324,8 +3324,8 @@ static int test_evp_iv_des(int idx)
             || !TEST_true(EVP_EncryptInit_ex(ctx, type, NULL, key, init_iv))
             || !TEST_true(EVP_EncryptUpdate(ctx, ciphertext, &len, msg,
                           (int)sizeof(msg)))
-            || !TEST_true(EVP_CIPHER_CTX_get_original_iv(ctx, oiv, sizeof(oiv)))
-            || !TEST_true(EVP_CIPHER_CTX_get_updated_iv(ctx, iv, sizeof(iv)))
+            || !TEST_int_gt(EVP_CIPHER_CTX_get_original_iv(ctx, oiv, sizeof(oiv)), 0)
+            || !TEST_int_gt(EVP_CIPHER_CTX_get_updated_iv(ctx, iv, sizeof(iv)), 0)
             || !TEST_true(EVP_EncryptFinal_ex(ctx, ciphertext, &len)))
         goto err;
     ivlen = EVP_CIPHER_CTX_get_iv_length(ctx);
@@ -3334,7 +3334,7 @@ static int test_evp_iv_des(int idx)
         goto err;
 
     if (!TEST_true(EVP_EncryptInit_ex(ctx, NULL, NULL, NULL, NULL))
-        || !TEST_true(EVP_CIPHER_CTX_get_updated_iv(ctx, iv, sizeof(iv))))
+        || !TEST_int_gt(EVP_CIPHER_CTX_get_updated_iv(ctx, iv, sizeof(iv)), 0))
         goto err;
     if (!TEST_mem_eq(init_iv, ivlen, iv, ivlen))
         goto err;
@@ -3877,7 +3877,7 @@ static int test_evp_updated_iv(int idx)
         errmsg = "CIPHER_UPDATE";
         goto err;
     }
-    if (!TEST_true(EVP_CIPHER_CTX_get_updated_iv(ctx, updated_iv, sizeof(updated_iv)))) {
+    if (!TEST_int_gt(EVP_CIPHER_CTX_get_updated_iv(ctx, updated_iv, sizeof(updated_iv)), 0)) {
         errmsg = "CIPHER_CTX_GET_UPDATED_IV";
         goto err;
     }

--- a/test/evp_test.c
+++ b/test/evp_test.c
@@ -834,7 +834,7 @@ static int cipher_test_enc(EVP_TEST *t, int enc,
     if (expected->iv != NULL) {
         /* Some (e.g., GCM) tests use IVs longer than EVP_MAX_IV_LENGTH. */
         unsigned char iv[128];
-        if (!TEST_true(EVP_CIPHER_CTX_get_updated_iv(ctx_base, iv, sizeof(iv)))
+        if (!TEST_int_gt(EVP_CIPHER_CTX_get_updated_iv(ctx_base, iv, sizeof(iv)), 0)
             || ((EVP_CIPHER_get_flags(expected->cipher) & EVP_CIPH_CUSTOM_IV) == 0
                 && !TEST_mem_eq(expected->iv, expected->iv_len, iv,
                                 expected->iv_len))) {
@@ -1027,7 +1027,7 @@ static int cipher_test_enc(EVP_TEST *t, int enc,
     if (expected->next_iv != NULL) {
         /* Some (e.g., GCM) tests use IVs longer than EVP_MAX_IV_LENGTH. */
         unsigned char iv[128];
-        if (!TEST_true(EVP_CIPHER_CTX_get_updated_iv(ctx, iv, sizeof(iv)))
+        if (!TEST_int_gt(EVP_CIPHER_CTX_get_updated_iv(ctx, iv, sizeof(iv)), 0)
             || ((EVP_CIPHER_get_flags(expected->cipher) & EVP_CIPH_CUSTOM_IV) == 0
                 && !TEST_mem_eq(expected->next_iv, expected->iv_len, iv,
                                 expected->iv_len))) {


### PR DESCRIPTION
`evp_do_ciph_ctx_setparams` can return negative values.
`EVP_PKEY_get_int_param` does not have negative return values.
`EVP_CIPHER_CTX_get_original_iv` and `EVP_CIPHER_CTX_get_updated_iv` have negative reutrn values.

Thanks for taking time to review.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
