### PR TITLE
Fix the return checks of some APIs

### DIFF
--- a/apps/rsautl.c
+++ b/apps/rsautl.c
@@ -242,25 +242,25 @@ int rsautl_main(int argc, char **argv)
 
     switch (rsa_mode) {
     case RSA_VERIFY:
-        rv = EVP_PKEY_verify_recover_init(ctx)
-            && EVP_PKEY_CTX_set_rsa_padding(ctx, pad)
+        rv = EVP_PKEY_verify_recover_init(ctx) > 0
+            && EVP_PKEY_CTX_set_rsa_padding(ctx, pad) > 0
             && EVP_PKEY_verify_recover(ctx, rsa_out, &rsa_outlen,
-                                       rsa_in, rsa_inlen);
+                                       rsa_in, rsa_inlen) > 0;
         break;
     case RSA_SIGN:
-        rv = EVP_PKEY_sign_init(ctx)
-            && EVP_PKEY_CTX_set_rsa_padding(ctx, pad)
-            && EVP_PKEY_sign(ctx, rsa_out, &rsa_outlen, rsa_in, rsa_inlen);
+        rv = EVP_PKEY_sign_init(ctx) > 0
+            && EVP_PKEY_CTX_set_rsa_padding(ctx, pad) > 0
+            && EVP_PKEY_sign(ctx, rsa_out, &rsa_outlen, rsa_in, rsa_inlen) > 0;
         break;
     case RSA_ENCRYPT:
-        rv = EVP_PKEY_encrypt_init(ctx)
-            && EVP_PKEY_CTX_set_rsa_padding(ctx, pad)
-            && EVP_PKEY_encrypt(ctx, rsa_out, &rsa_outlen, rsa_in, rsa_inlen);
+        rv = EVP_PKEY_encrypt_init(ctx) > 0
+            && EVP_PKEY_CTX_set_rsa_padding(ctx, pad) > 0
+            && EVP_PKEY_encrypt(ctx, rsa_out, &rsa_outlen, rsa_in, rsa_inlen) > 0;
         break;
     case RSA_DECRYPT:
-        rv = EVP_PKEY_decrypt_init(ctx)
-            && EVP_PKEY_CTX_set_rsa_padding(ctx, pad)
-            && EVP_PKEY_decrypt(ctx, rsa_out, &rsa_outlen, rsa_in, rsa_inlen);
+        rv = EVP_PKEY_decrypt_init(ctx) > 0
+            && EVP_PKEY_CTX_set_rsa_padding(ctx, pad) > 0
+            && EVP_PKEY_decrypt(ctx, rsa_out, &rsa_outlen, rsa_in, rsa_inlen) > 0;
         break;
     }
 

--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -3131,7 +3131,7 @@ static int www_body(int s, int stype, int prot, unsigned char *context)
     }
 
     /* lets make the output buffer a reasonable size */
-    if (!BIO_set_write_buffer_size(io, bufsize))
+    if (BIO_set_write_buffer_size(io, bufsize) <= 0)
         goto err;
 
     if ((con = SSL_new(ctx)) == NULL)
@@ -3560,7 +3560,7 @@ static int rev_body(int s, int stype, int prot, unsigned char *context)
         goto err;
 
     /* lets make the output buffer a reasonable size */
-    if (!BIO_set_write_buffer_size(io, bufsize))
+    if (BIO_set_write_buffer_size(io, bufsize) <= 0)
         goto err;
 
     if ((con = SSL_new(ctx)) == NULL)

--- a/crypto/bio/bf_buff.c
+++ b/crypto/bio/bf_buff.c
@@ -383,8 +383,8 @@ static long buffer_ctrl(BIO *b, int cmd, long num, void *ptr)
         break;
     case BIO_CTRL_DUP:
         dbio = (BIO *)ptr;
-        if (!BIO_set_read_buffer_size(dbio, ctx->ibuf_size) ||
-            !BIO_set_write_buffer_size(dbio, ctx->obuf_size))
+        if (BIO_set_read_buffer_size(dbio, ctx->ibuf_size) <= 0 ||
+            BIO_set_write_buffer_size(dbio, ctx->obuf_size) <= 0)
             ret = 0;
         break;
     case BIO_CTRL_PEEK:

--- a/crypto/bio/bf_lbuf.c
+++ b/crypto/bio/bf_lbuf.c
@@ -281,7 +281,7 @@ static long linebuffer_ctrl(BIO *b, int cmd, long num, void *ptr)
         break;
     case BIO_CTRL_DUP:
         dbio = (BIO *)ptr;
-        if (!BIO_set_write_buffer_size(dbio, ctx->obuf_size))
+        if (BIO_set_write_buffer_size(dbio, ctx->obuf_size) <= 0)
             ret = 0;
         break;
     default:

--- a/crypto/crmf/crmf_lib.c
+++ b/crypto/crmf/crmf_lib.c
@@ -653,7 +653,7 @@ X509
     cikeysize = EVP_CIPHER_get_key_length(cipher);
     /* first the symmetric key needs to be decrypted */
     pkctx = EVP_PKEY_CTX_new_from_pkey(libctx, pkey, propq);
-    if (pkctx != NULL && EVP_PKEY_decrypt_init(pkctx)) {
+    if (pkctx != NULL && EVP_PKEY_decrypt_init(pkctx) > 0) {
         ASN1_BIT_STRING *encKey = ecert->encSymmKey;
         size_t failure;
         int retval;

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -4816,7 +4816,7 @@ int ssl_init_wbio_buffer(SSL_CONNECTION *s)
     }
 
     bbio = BIO_new(BIO_f_buffer());
-    if (bbio == NULL || !BIO_set_read_buffer_size(bbio, 1)) {
+    if (bbio == NULL || BIO_set_read_buffer_size(bbio, 1) <= 0) {
         BIO_free(bbio);
         ERR_raise(ERR_LIB_SSL, ERR_R_BUF_LIB);
         return 0;

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -2040,7 +2040,7 @@ static int test_EVP_SM2(void)
                                         sizeof(kMsg))))
             goto done;
 
-        if (!TEST_true(EVP_PKEY_decrypt_init(cctx)))
+        if (!TEST_int_gt(EVP_PKEY_decrypt_init(cctx), 0))
             goto done;
 
         if (!TEST_true(EVP_PKEY_CTX_set_params(cctx, sparams)))


### PR DESCRIPTION
It seems these APIs have negative return values and should not be checked by the unary operator.

Thank you for taking time to review.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
