### PR TITLE
Drop a spurious printf in evp_test.c

### DIFF
--- a/test/evp_test.c
+++ b/test/evp_test.c
@@ -426,7 +426,6 @@ static int digest_test_run(EVP_TEST *t)
     int xof = 0;
     OSSL_PARAM params[2];
 
-    printf("test %s (%d %d)\n", t->name, t->s.start, t->s.curr);
     t->err = "TEST_FAILURE";
     if (!TEST_ptr(mctx = EVP_MD_CTX_new()))
         goto err;


### PR DESCRIPTION
A spurious printf was added to evp_test.c - probably for debugging purposes. This actually causes runtime errors in some cases because the name being printed can be NULL.

Fixes #19814

