### PR TITLE
crypto/err: expand on error code generation

### DIFF
--- a/crypto/err/README.md
+++ b/crypto/err/README.md
@@ -42,3 +42,14 @@ The generated C error code file `xxx_err.c` will load the header
 files `stdio.h`, `openssl/err.h` and `openssl/xxx.h` so the
 header file must load any additional header files containing any
 definitions it uses.
+
+Adding new error codes
+======================
+
+Instead of manually adding error codes into `crypto/err/openssl.txt`,
+it is recommended to leverage `make update` for error code generation.
+The target will process relevant sources and generate error codes for
+any *used* error codes.
+
+If an error code is added manually into `crypto/err/openssl.txt`,
+subsequent `make update` has no effect.


### PR DESCRIPTION
##### Checklist
- [x] documentation is added or updated

When adding error codes for Argon2, I hit a snag with `make errors`. Turns out I falsely assumed that the perl script will generate `include/openssl/proverr.h` and `providers/common/provider_err.c` for all entries in `crypto/err/openssl.txt`. By filling in values manually I broke the process and couldn't get the other files to update.

This PR updates `crypto/err/README.md` and documents what I assume to be the recommended approach:
```
Adding new error codes
======================

Instead of manually adding error codes into `crypto/err/openssl.txt`,
it is recommemded to leverage `make update` for error code generation.
The target will process relevant sources and generate error codes for
any *used* error codes.

If an error code is added manually into `crypto/err/openssl.txt`,
subsequent `make update` has no effect and the whole process must be
completed manually.
```

If this is obvious and not useful, feel free to close this PR. Any rewording is welcome.