### PR TITLE
Fix an overflow in SSL_get_shared_ciphers().

### DIFF
--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -3220,14 +3220,14 @@ char *SSL_get_shared_ciphers(const SSL *s, char *buf, int size)
         return NULL;
 
     for (i = 0; i < sk_SSL_CIPHER_num(clntsk); i++) {
-        int n;
+        unsigned int n;
 
         c = sk_SSL_CIPHER_value(clntsk, i);
         if (sk_SSL_CIPHER_find(srvrsk, c) < 0)
             continue;
 
         n = strlen(c->name);
-        if (n + 1 > size) {
+        if (n >= size) {
             if (p != buf)
                 --p;
             *p = '\0';


### PR DESCRIPTION
Fixes an overflow in SSL_get_shared_ciphers().
The return type of strlen() is size_of. If the length of c->name is over 2^31, the strcpy() in Ln.3236 will trigger a overflow. Furthermore, SSL_get_shared_ciphers is an exported functions. This represents a security issue for end user code that calls this function directly.

