### PR TITLE
timing_load_creds requires POSIX1.2001 due to rusage

### DIFF
--- a/test/timing_load_creds.c
+++ b/test/timing_load_creds.c
@@ -12,7 +12,7 @@
 
 #include <openssl/e_os2.h>
 
-#ifdef OPENSSL_SYS_UNIX
+#if defined OPENSSL_SYS_UNIX
 # include <sys/stat.h>
 # include <sys/resource.h>
 # include <openssl/pem.h>
@@ -20,6 +20,7 @@
 # include <openssl/err.h>
 # include <openssl/bio.h>
 # include "internal/e_os.h"
+# if defined(_POSIX_VERSION) && _POSIX_VERSION >= 200112L
 
 static char *prog;
 
@@ -76,11 +77,12 @@ static void usage(void)
     fprintf(stderr, "          p for private key\n");
     exit(EXIT_FAILURE);
 }
+# endif
 #endif
 
 int main(int ac, char **av)
 {
-#ifdef OPENSSL_SYS_UNIX
+#if defined(_POSIX_VERSION) && _POSIX_VERSION >= 200112L
     int i, debug = 0, count = 100, what = 'c';
     struct stat sb;
     FILE *fp;

--- a/test/timing_load_creds.c
+++ b/test/timing_load_creds.c
@@ -12,7 +12,7 @@
 
 #include <openssl/e_os2.h>
 
-#if defined OPENSSL_SYS_UNIX
+#ifdef OPENSSL_SYS_UNIX
 # include <sys/stat.h>
 # include <sys/resource.h>
 # include <openssl/pem.h>

--- a/test/timing_load_creds.c
+++ b/test/timing_load_creds.c
@@ -199,7 +199,8 @@ int main(int ac, char **av)
 # elif defined(OPENSSL_SYS_VMS)
     fprintf(stderr, "This tool is not supported on VMS\n");
 # else
-    fprintf(stderr, "This tool is not supported on this platform\n");
+    fprintf(stderr,
+            "This tool is not supported on this platform for lack of POSIX1.2001 support\n");
 # endif
     exit(EXIT_FAILURE);
 #endif

--- a/test/timing_load_creds.c
+++ b/test/timing_load_creds.c
@@ -194,14 +194,8 @@ int main(int ac, char **av)
     OPENSSL_free(contents);
     return EXIT_SUCCESS;
 #else
-# if defined(OPENSSL_SYS_WINDOWS)
-    fprintf(stderr, "This tool is not supported on Windows\n");
-# elif defined(OPENSSL_SYS_VMS)
-    fprintf(stderr, "This tool is not supported on VMS\n");
-# else
     fprintf(stderr,
             "This tool is not supported on this platform for lack of POSIX1.2001 support\n");
-# endif
     exit(EXIT_FAILURE);
 #endif
 }


### PR DESCRIPTION
Fixes #19838

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
