### PR TITLE
Fix `no-ec enable-ktls` build

### DIFF
--- a/.github/workflows/run-checker-ci.yml
+++ b/.github/workflows/run-checker-ci.yml
@@ -40,6 +40,7 @@ jobs:
           enable-trace enable-fips,
           no-ts,
           no-ui,
+          enable-ktls no-ec,
         ]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/run-checker-ci.yml
+++ b/.github/workflows/run-checker-ci.yml
@@ -40,7 +40,6 @@ jobs:
           enable-trace enable-fips,
           no-ts,
           no-ui,
-          enable-ktls no-ec,
         ]
     runs-on: ubuntu-latest
     steps:

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -1450,7 +1450,9 @@ static struct ktls_test_cipher {
     { TLS1_2_VERSION, "AES256-GCM-SHA384"},
 #  endif
 #  ifdef OPENSSL_KTLS_CHACHA20_POLY1305
+#    ifndef OPENSSL_NO_EC
     { TLS1_2_VERSION, "ECDHE-RSA-CHACHA20-POLY1305"},
+#    endif
 #  endif
 # endif
 # if !defined(OSSL_NO_USABLE_TLS1_3)


### PR DESCRIPTION
The KTLS test uses a TLSv1.2 cipher that uses ECDHE

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [X] tests are added or updated
