### PR TITLE
Fix `--strict-warnings` build on djgpp (3.1)

### DIFF
--- a/crypto/asn1/x_int64.c
+++ b/crypto/asn1/x_int64.c
@@ -224,8 +224,8 @@ static int uint32_print(BIO *out, const ASN1_VALUE **pval, const ASN1_ITEM *it,
                         int indent, const ASN1_PCTX *pctx)
 {
     if ((it->size & INTxx_FLAG_SIGNED) == INTxx_FLAG_SIGNED)
-        return BIO_printf(out, "%d\n", **(int32_t **)pval);
-    return BIO_printf(out, "%u\n", **(uint32_t **)pval);
+        return BIO_printf(out, "%d\n", (int)**(int32_t **)pval);
+    return BIO_printf(out, "%u\n", (unsigned int)**(uint32_t **)pval);
 }
 
 

--- a/crypto/bio/bss_dgram.c
+++ b/crypto/bio/bss_dgram.c
@@ -218,7 +218,7 @@ static void dgram_adjust_rcv_timeout(BIO *b)
                        &(data->socket_timeout), &sz) < 0) {
             perror("getsockopt");
         } else
-            OPENSSL_assert(sz <= sizeof(data->socket_timeout));
+            OPENSSL_assert((size_t)sz <= sizeof(data->socket_timeout));
 #  endif
 
         /* Get current time */
@@ -623,7 +623,7 @@ static long dgram_ctrl(BIO *b, int cmd, long num, void *ptr)
                 perror("getsockopt");
                 ret = -1;
             } else {
-                OPENSSL_assert(sz <= sizeof(struct timeval));
+                OPENSSL_assert((size_t)sz <= sizeof(struct timeval));
                 ret = (int)sz;
             }
 #  endif
@@ -674,7 +674,7 @@ static long dgram_ctrl(BIO *b, int cmd, long num, void *ptr)
                 perror("getsockopt");
                 ret = -1;
             } else {
-                OPENSSL_assert(sz <= sizeof(struct timeval));
+                OPENSSL_assert((size_t)sz <= sizeof(struct timeval));
                 ret = (int)sz;
             }
 #  endif

--- a/crypto/bio/bss_dgram.c
+++ b/crypto/bio/bss_dgram.c
@@ -393,7 +393,9 @@ static long dgram_ctrl(BIO *b, int cmd, long num, void *ptr)
     long ret = 1;
     int *ip;
     bio_dgram_data *data = NULL;
+# ifndef __DJGPP__
     int sockopt_val = 0;
+# endif
     int d_errno;
 # if defined(OPENSSL_SYS_LINUX) && (defined(IP_MTU_DISCOVER) || defined(IP_MTU))
     socklen_t sockopt_len;      /* assume that system supporting IP_MTU is
@@ -705,24 +707,24 @@ static long dgram_ctrl(BIO *b, int cmd, long num, void *ptr)
         break;
 # endif
     case BIO_CTRL_DGRAM_SET_DONT_FRAG:
-        sockopt_val = num ? 1 : 0;
-
         switch (data->peer.sa.sa_family) {
         case AF_INET:
 # if defined(IP_DONTFRAG)
+            sockopt_val = num ? 1 : 0;
             if ((ret = setsockopt(b->num, IPPROTO_IP, IP_DONTFRAG,
                                   &sockopt_val, sizeof(sockopt_val))) < 0) {
                 perror("setsockopt");
                 ret = -1;
             }
 # elif defined(OPENSSL_SYS_LINUX) && defined(IP_MTU_DISCOVER) && defined (IP_PMTUDISC_PROBE)
-            if ((sockopt_val = num ? IP_PMTUDISC_PROBE : IP_PMTUDISC_DONT),
-                (ret = setsockopt(b->num, IPPROTO_IP, IP_MTU_DISCOVER,
+            sockopt_val = num ? IP_PMTUDISC_PROBE : IP_PMTUDISC_DONT;
+            if ((ret = setsockopt(b->num, IPPROTO_IP, IP_MTU_DISCOVER,
                                   &sockopt_val, sizeof(sockopt_val))) < 0) {
                 perror("setsockopt");
                 ret = -1;
             }
 # elif defined(OPENSSL_SYS_WINDOWS) && defined(IP_DONTFRAGMENT)
+            sockopt_val = num ? 1 : 0;
             if ((ret = setsockopt(b->num, IPPROTO_IP, IP_DONTFRAGMENT,
                                   (const char *)&sockopt_val,
                                   sizeof(sockopt_val))) < 0) {
@@ -736,6 +738,7 @@ static long dgram_ctrl(BIO *b, int cmd, long num, void *ptr)
 # if OPENSSL_USE_IPV6
         case AF_INET6:
 #  if defined(IPV6_DONTFRAG)
+            sockopt_val = num ? 1 : 0;
             if ((ret = setsockopt(b->num, IPPROTO_IPV6, IPV6_DONTFRAG,
                                   (const void *)&sockopt_val,
                                   sizeof(sockopt_val))) < 0) {
@@ -743,8 +746,8 @@ static long dgram_ctrl(BIO *b, int cmd, long num, void *ptr)
                 ret = -1;
             }
 #  elif defined(OPENSSL_SYS_LINUX) && defined(IPV6_MTUDISCOVER)
-            if ((sockopt_val = num ? IP_PMTUDISC_PROBE : IP_PMTUDISC_DONT),
-                (ret = setsockopt(b->num, IPPROTO_IPV6, IPV6_MTU_DISCOVER,
+            sockopt_val = num ? IP_PMTUDISC_PROBE : IP_PMTUDISC_DONT;
+            if ((ret = setsockopt(b->num, IPPROTO_IPV6, IPV6_MTU_DISCOVER,
                                   &sockopt_val, sizeof(sockopt_val))) < 0) {
                 perror("setsockopt");
                 ret = -1;

--- a/crypto/threads_lib.c
+++ b/crypto/threads_lib.c
@@ -8,7 +8,8 @@
  */
 #include <openssl/crypto.h>
 
-#ifndef OPENSSL_NO_DEPRECATED_3_0
+#ifdef OPENSSL_SYS_UNIX
+# ifndef OPENSSL_NO_DEPRECATED_3_0
 
 void OPENSSL_fork_prepare(void)
 {
@@ -22,4 +23,5 @@ void OPENSSL_fork_child(void)
 {
 }
 
+# endif
 #endif

--- a/ssl/ssl_ciph.c
+++ b/ssl/ssl_ciph.c
@@ -819,8 +819,9 @@ static void ssl_cipher_apply_rule(uint32_t cipher_id, uint32_t alg_mkey,
     OSSL_TRACE_BEGIN(TLS_CIPHER){
         BIO_printf(trc_out,
                    "Applying rule %d with %08x/%08x/%08x/%08x/%08x %08x (%d)\n",
-                   rule, alg_mkey, alg_auth, alg_enc, alg_mac, min_tls,
-                   algo_strength, strength_bits);
+                   rule, (unsigned int)alg_mkey, (unsigned int)alg_auth,
+                   (unsigned int)alg_enc, (unsigned int)alg_mac, min_tls,
+                   (unsigned int)algo_strength, (int)strength_bits);
     }
 
     if (rule == CIPHER_DEL || rule == CIPHER_BUMP)
@@ -864,9 +865,13 @@ static void ssl_cipher_apply_rule(uint32_t cipher_id, uint32_t alg_mkey,
                 BIO_printf(trc_out,
                            "\nName: %s:"
                            "\nAlgo = %08x/%08x/%08x/%08x/%08x Algo_strength = %08x\n",
-                           cp->name, cp->algorithm_mkey, cp->algorithm_auth,
-                           cp->algorithm_enc, cp->algorithm_mac, cp->min_tls,
-                           cp->algo_strength);
+                           cp->name,
+                           (unsigned int)cp->algorithm_mkey,
+                           (unsigned int)cp->algorithm_auth,
+                           (unsigned int)cp->algorithm_enc,
+                           (unsigned int)cp->algorithm_mac,
+                           cp->min_tls,
+                           (unsigned int)cp->algo_strength);
             }
             if (cipher_id != 0 && (cipher_id != cp->id))
                 continue;

--- a/ssl/ssl_sess.c
+++ b/ssl/ssl_sess.c
@@ -59,9 +59,11 @@ __owur static int timeoutcmp(SSL_SESSION *a, SSL_SESSION *b)
  */
 void ssl_session_calculate_timeout(SSL_SESSION *ss)
 {
+#ifndef __DJGPP__ /* time_t is unsigned on djgpp */
     /* Force positive timeout */
     if (ss->timeout < 0)
         ss->timeout = 0;
+#endif
     ss->calc_timeout = ss->time + ss->timeout;
     /*
      * |timeout| is always zero or positive, so the check for
@@ -70,7 +72,7 @@ void ssl_session_calculate_timeout(SSL_SESSION *ss)
     ss->timeout_ovf = ss->time > 0 && ss->calc_timeout < ss->time;
     /*
      * N.B. Realistic overflow can only occur in our lifetimes on a
-     *      32-bit machine in January 2038.
+     *      32-bit machine with signed time_t, in January 2038.
      *      However, There are no controls to limit the |timeout|
      *      value, except to keep it positive.
      */

--- a/ssl/ssl_txt.c
+++ b/ssl/ssl_txt.c
@@ -151,7 +151,7 @@ int SSL_SESSION_print(BIO *bp, const SSL_SESSION *x)
 
     if (istls13) {
         if (BIO_printf(bp, "    Max Early Data: %u\n",
-                       x->ext.max_early_data) <= 0)
+                       (unsigned int)x->ext.max_early_data) <= 0)
             goto err;
     }
 

--- a/ssl/statem/extensions_srvr.c
+++ b/ssl/statem/extensions_srvr.c
@@ -1147,7 +1147,7 @@ int tls_parse_ctos_psk(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
              * rounding errors.
              */
             if (id == 0
-                    && sess->timeout >= (long)agesec
+                    && sess->timeout >= (time_t)agesec
                     && agems / (uint32_t)1000 == agesec
                     && ticket_age <= agems + 1000
                     && ticket_age + TICKET_AGE_ALLOWANCE >= agems + 1000) {

--- a/ssl/t1_trce.c
+++ b/ssl/t1_trce.c
@@ -884,7 +884,7 @@ static int ssl_print_extension(BIO *bio, int indent, int server,
                          | ((unsigned int)ext[2] << 8)
                          | (unsigned int)ext[3];
         BIO_indent(bio, indent + 2, 80);
-        BIO_printf(bio, "max_early_data=%u\n", max_early_data);
+        BIO_printf(bio, "max_early_data=%u\n", (unsigned int)max_early_data);
         break;
 
     default:

--- a/test/ssl_cert_table_internal_test.c
+++ b/test/ssl_cert_table_internal_test.c
@@ -35,7 +35,8 @@ static int do_test_cert_table(int nid, uint32_t amask, size_t idx,
         TEST_note("Expected %s, got %s\n", OBJ_nid2sn(nid),
                   OBJ_nid2sn(clu->nid));
     if (clu->amask != amask)
-        TEST_note("Expected auth mask 0x%x, got 0x%x\n", amask, clu->amask);
+        TEST_note("Expected auth mask 0x%x, got 0x%x\n",
+                  (unsigned int)amask, (unsigned int)clu->amask);
     return 0;
 }
 


### PR DESCRIPTION
Similar to #19322, but for the 3.1 branch.