### PR TITLE
unbuffer stdin before get passwd from stdin

### DIFF
--- a/apps/apps.c
+++ b/apps/apps.c
@@ -430,6 +430,7 @@ static char *app_get_pass(const char *arg, int keepbio)
             pwdbio = BIO_push(btmp, pwdbio);
 #endif
         } else if (strcmp(arg, "stdin") == 0) {
+            unbuffer(stdin);
             pwdbio = dup_bio_in(FORMAT_TEXT);
             if (!pwdbio) {
                 BIO_printf(bio_err, "Can't open BIO for stdin\n");


### PR DESCRIPTION
commond ` LD_LIBRARY_PATH= openssl rsa -aes256 -passout stdin <<< "xxxxxx”` will get pass(fun` app_get_pass()`) from stdin first, and then load key(fun `load_key()`). but it unbuffer stdin before load key, this will cause the load key to fail. 

now unbuffer stdin before get pass, this will solve https://github.com/openssl/openssl/issues/19835