### PR TITLE
Fix openssl storeutl to allow serial + issuer

### DIFF
--- a/apps/storeutl.c
+++ b/apps/storeutl.c
@@ -165,8 +165,7 @@ int storeutl_main(int argc, char *argv[])
             break;
         case OPT_CRITERION_ISSUER:
             if (criterion != 0
-                || (criterion == OSSL_STORE_SEARCH_BY_ISSUER_SERIAL
-                    && issuer != NULL)) {
+                && criterion != OSSL_STORE_SEARCH_BY_ISSUER_SERIAL) {
                 BIO_printf(bio_err, "%s: criterion already given.\n",
                            prog);
                 goto end;
@@ -183,8 +182,7 @@ int storeutl_main(int argc, char *argv[])
             break;
         case OPT_CRITERION_SERIAL:
             if (criterion != 0
-                || (criterion == OSSL_STORE_SEARCH_BY_ISSUER_SERIAL
-                    && serial != NULL)) {
+                && criterion != OSSL_STORE_SEARCH_BY_ISSUER_SERIAL) {
                 BIO_printf(bio_err, "%s: criterion already given.\n",
                            prog);
                 goto end;


### PR DESCRIPTION
storeutl wants to enforce the use of issuer and serial together, however the current code prevents to use them together and returns an error if only one of them is specified.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
