### PR TITLE
`cmp_vfy_test.c`: fix name `OSSL_CMP_CTX_set0_trusted{,Store}`

### DIFF
--- a/doc/man3/OSSL_CMP_validate_msg.pod
+++ b/doc/man3/OSSL_CMP_validate_msg.pod
@@ -66,7 +66,7 @@ return 1 on success, 0 on error or validation failed.
 
 L<OSSL_CMP_CTX_new(3)>, L<OSSL_CMP_exec_certreq(3)>,
 L<OSSL_CMP_CTX_set1_secretValue(3)>, L<OSSL_CMP_CTX_set1_srvCert(3)>,
-L<OSSL_CMP_CTX_set1_untrusted(3)>, L<OSSL_CMP_CTX_set0_trusted(3)>
+L<OSSL_CMP_CTX_set1_untrusted(3)>, L<OSSL_CMP_CTX_set0_trustedStore(3)>
 
 =head1 HISTORY
 

--- a/test/cmp_vfy_test.c
+++ b/test/cmp_vfy_test.c
@@ -153,7 +153,7 @@ static int test_validate_msg_mac_alg_protection(int miss, int wrong)
     SETUP_TEST_FIXTURE(CMP_VFY_TEST_FIXTURE, set_up);
 
     fixture->expected = !miss && !wrong;
-    if (!TEST_true(miss ? OSSL_CMP_CTX_set0_trusted(fixture->cmp_ctx, NULL)
+    if (!TEST_true(miss ? OSSL_CMP_CTX_set0_trustedStore(fixture->cmp_ctx, NULL)
                    : OSSL_CMP_CTX_set1_secretValue(fixture->cmp_ctx, sec_1,
                                                    wrong ? 4 : sizeof(sec_1)))
             || !TEST_ptr(fixture->msg = load_pkimsg(ip_waiting_f, libctx))) {


### PR DESCRIPTION
This fixes name mismatch on cherry-picking #19729 to 3.0.
If needed to do this way, should be urgent.