### PR TITLE
CI fixes and workarounds for the recent CI failures

### DIFF
--- a/.github/workflows/cross-compiles.yml
+++ b/.github/workflows/cross-compiles.yml
@@ -58,7 +58,7 @@ jobs:
           }, {
             arch: m68k-linux-gnu,
             libs: libc6-dev-m68k-cross,
-            target: -static -m68040 linux-latomic,
+            target: -static -m68040 linux-latomic -Wno-stringop-overflow,
             fips: no,
             tests: -test_includes -test_store -test_x509_store
           }, {
@@ -91,7 +91,7 @@ jobs:
           }, {
             arch: s390x-linux-gnu,
             libs: libc6-dev-s390x-cross,
-            target: linux64-s390x
+            target: linux64-s390x -Wno-stringop-overflow
           }, {
             arch: sh4-linux-gnu,
             libs: libc6-dev-sh4-cross,
@@ -110,7 +110,7 @@ jobs:
           }, {
             arch: m68k-linux-gnu,
             libs: libc6-dev-m68k-cross,
-            target: -mcfv4e linux-latomic,
+            target: -mcfv4e linux-latomic -Wno-stringop-overflow,
             tests: none
           }, {
             arch: mips-linux-gnu,

--- a/.github/workflows/fuzz-checker.yml
+++ b/.github/workflows/fuzz-checker.yml
@@ -26,7 +26,7 @@ jobs:
           }, {
             name: libFuzzer,
             config: enable-fuzz-libfuzzer enable-asan enable-ubsan,
-            libs: --with-fuzzer-lib=/usr/lib/llvm-12/lib/libFuzzer.a --with-fuzzer-include=/usr/lib/llvm-12/build/lib/clang/12.0.0/include/fuzzer,
+            libs: --with-fuzzer-lib=/usr/lib/llvm-12/lib/libFuzzer.a --with-fuzzer-include=/usr/include/clang/12/include/fuzzer,
             install: libfuzzer-12-dev,
             cc: clang-12,
             linker: clang++-12,
@@ -34,7 +34,7 @@ jobs:
           }, {
             name: libFuzzer+,
             config: enable-fuzz-libfuzzer enable-asan enable-ubsan -fsanitize-coverage=trace-cmp -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION,
-            libs: --with-fuzzer-lib=/usr/lib/llvm-12/lib/libFuzzer.a --with-fuzzer-include=/usr/lib/llvm-12/build/lib/clang/12.0.0/include/fuzzer,
+            libs: --with-fuzzer-lib=/usr/lib/llvm-12/lib/libFuzzer.a --with-fuzzer-include=/usr/include/clang/12/include/fuzzer,
             extra: enable-fips enable-ec_nistp_64_gcc_128 -fno-sanitize=alignment enable-tls1_3 enable-weak-ssl-ciphers enable-rc5 enable-md2 enable-ssl3 enable-ssl3-method enable-nextprotoneg,
             install: libfuzzer-12-dev,
             cc: clang-12,

--- a/.github/workflows/run-checker-merge.yml
+++ b/.github/workflows/run-checker-merge.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         opt: [
-          enable-asan no-shared no-asm -DOPENSSL_SMALL_FOOTPRINT,
+          enable-asan no-modules no-asm -DOPENSSL_SMALL_FOOTPRINT,
           no-dgram,
           no-dso,
           no-dynamic-engine,


### PR DESCRIPTION
Fuzz checker CI: Use more generic include dir for fuzzer includes.

Cross compiles CI: Disable stringop-overflow warning on s390x and m68k

Run-checker merge CI: Replace no-shared with no-modules
