### PR TITLE
Second attempt at the Run-checker merge CI fix

### DIFF
--- a/.github/workflows/run-checker-merge.yml
+++ b/.github/workflows/run-checker-merge.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         opt: [
-          enable-asan no-modules no-asm -DOPENSSL_SMALL_FOOTPRINT,
+          enable-asan no-shared no-asm -DOPENSSL_SMALL_FOOTPRINT,
           no-dgram,
           no-dso,
           no-dynamic-engine,

--- a/.github/workflows/run-checker-merge.yml
+++ b/.github/workflows/run-checker-merge.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         opt: [
-          enable-asan no-shared no-asm -DOPENSSL_SMALL_FOOTPRINT,
+          enable-asan enable-ubsan no-shared no-asm -DOPENSSL_SMALL_FOOTPRINT,
           no-dgram,
           no-dso,
           no-dynamic-engine,


### PR DESCRIPTION
The previous fix was incorrect because we have module as disablable and not modules. Besides even no-module instead of no-shared does not really fix the issue.

The correct fix is to enable-ubsan along the asan otherwise the leak is not detected with the current clang version present in the CI images.