### PR TITLE
Make error reason for disallowed legacy sigalg more specific

### DIFF
--- a/crypto/err/openssl.txt
+++ b/crypto/err/openssl.txt
@@ -1404,6 +1404,8 @@ SSL_R_INVALID_SESSION_ID:999:invalid session id
 SSL_R_INVALID_SRP_USERNAME:357:invalid srp username
 SSL_R_INVALID_STATUS_RESPONSE:328:invalid status response
 SSL_R_INVALID_TICKET_KEYS_LENGTH:325:invalid ticket keys length
+SSL_R_LEGACY_SIGALG_DISALLOWED_OR_UNSUPPORTED:333:\
+	legacy sigalg disallowed or unsupported
 SSL_R_LENGTH_MISMATCH:159:length mismatch
 SSL_R_LENGTH_TOO_LONG:404:length too long
 SSL_R_LENGTH_TOO_SHORT:160:length too short

--- a/include/openssl/sslerr.h
+++ b/include/openssl/sslerr.h
@@ -153,6 +153,7 @@
 # define SSL_R_INVALID_SRP_USERNAME                       357
 # define SSL_R_INVALID_STATUS_RESPONSE                    328
 # define SSL_R_INVALID_TICKET_KEYS_LENGTH                 325
+# define SSL_R_LEGACY_SIGALG_DISALLOWED_OR_UNSUPPORTED    333
 # define SSL_R_LENGTH_MISMATCH                            159
 # define SSL_R_LENGTH_TOO_LONG                            404
 # define SSL_R_LENGTH_TOO_SHORT                           160

--- a/ssl/ssl_err.c
+++ b/ssl/ssl_err.c
@@ -230,6 +230,8 @@ static const ERR_STRING_DATA SSL_str_reasons[] = {
     "invalid status response"},
     {ERR_PACK(ERR_LIB_SSL, 0, SSL_R_INVALID_TICKET_KEYS_LENGTH),
     "invalid ticket keys length"},
+    {ERR_PACK(ERR_LIB_SSL, 0, SSL_R_LEGACY_SIGALG_DISALLOWED_OR_UNSUPPORTED),
+    "legacy sigalg disallowed or unsupported"},
     {ERR_PACK(ERR_LIB_SSL, 0, SSL_R_LENGTH_MISMATCH), "length mismatch"},
     {ERR_PACK(ERR_LIB_SSL, 0, SSL_R_LENGTH_TOO_LONG), "length too long"},
     {ERR_PACK(ERR_LIB_SSL, 0, SSL_R_LENGTH_TOO_SHORT), "length too short"},

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -2349,7 +2349,8 @@ MSG_PROCESS_RETURN tls_process_key_exchange(SSL_CONNECTION *s, PACKET *pkt)
                 goto err;
             }
         } else if (!tls1_set_peer_legacy_sigalg(s, pkey)) {
-            SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
+            SSLfatal(s, SSL_AD_INTERNAL_ERROR,
+                     SSL_R_LEGACY_SIGALG_DISALLOWED_OR_UNSUPPORTED);
             goto err;
         }
 

--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -442,7 +442,8 @@ MSG_PROCESS_RETURN tls_process_cert_verify(SSL_CONNECTION *s, PACKET *pkt)
             goto err;
         }
     } else if (!tls1_set_peer_legacy_sigalg(s, pkey)) {
-            SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
+            SSLfatal(s, SSL_AD_INTERNAL_ERROR,
+                     SSL_R_LEGACY_SIGALG_DISALLOWED_OR_UNSUPPORTED);
             goto err;
     }
 


### PR DESCRIPTION
The internal error reason is confusing and indicating an error in OpenSSL and not a configuration problem.

Fixes #19867

I am proposing this as a bug fix to be backported to 3.0 because the current error reason is actually causing reports as #19867.
