### PR TITLE
rsa: fix version of rsa implicit rejection introduction

### DIFF
--- a/doc/man3/EVP_PKEY_CTX_ctrl.pod
+++ b/doc/man3/EVP_PKEY_CTX_ctrl.pod
@@ -394,7 +394,7 @@ OSSL_ASYM_CIPHER_PARAM_TLS_NEGOTIATED_VERSION should be set to the actual
 negotiated protocol version. Otherwise it should be left unset.
 
 Similarly to the B<RSA_PKCS1_WITH_TLS_PADDING> above, since OpenSSL version
-3.1.0, the use of B<RSA_PKCS1_PADDING> will return a randomly generated message
+3.2.0, the use of B<RSA_PKCS1_PADDING> will return a randomly generated message
 instead of padding errors in case padding checks fail. Applications that
 want to remain secure while using earlier versions of OpenSSL, still need to
 handle both the error code from the RSA decryption operation and the

--- a/doc/man3/EVP_PKEY_decrypt.pod
+++ b/doc/man3/EVP_PKEY_decrypt.pod
@@ -53,12 +53,12 @@ algorithm.
 
 =head1 WARNINGS
 
-In OpenSSL versions before 3.1.0, when used in PKCS#1 v1.5 padding,
+In OpenSSL versions before 3.2.0, when used in PKCS#1 v1.5 padding,
 both the return value from the EVP_PKEY_decrypt() and the B<outlen> provided
 information useful in mounting a Bleichenbacher attack against the
 used private key. They had to processed in a side-channel free way.
 
-Since version 3.1.0, the EVP_PKEY_decrypt() method when used with PKCS#1
+Since version 3.2.0, the EVP_PKEY_decrypt() method when used with PKCS#1
 v1.5 padding doesn't return an error in case it detects an error in padding,
 instead it returns a pseudo-randomly generated message, removing the need
 of side-channel secure code from applications using OpenSSL.

--- a/doc/man3/RSA_public_encrypt.pod
+++ b/doc/man3/RSA_public_encrypt.pod
@@ -92,9 +92,9 @@ which can potentially be used to mount a Bleichenbacher padding oracle
 attack. This is an inherent weakness in the PKCS #1 v1.5 padding
 design. Prefer RSA_PKCS1_OAEP_PADDING.
 
-In OpenSSL before version 3.1.0, both the return value and the length of
+In OpenSSL before version 3.2.0, both the return value and the length of
 returned value could be used to mount the Bleichenbacher attack.
-Since version 3.1.0, OpenSSL does not return an error in case of padding
+Since version 3.2.0, OpenSSL does not return an error in case of padding
 checks failed. Instead it generates a random message based on used private
 key and provided ciphertext so that application code doesn't have to implement
 a side-channel secure error handling.


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

Since the RSA implicit rejection isn't [planned for backporting to 3.1.0](https://github.com/openssl/openssl/pull/13817#issuecomment-1346665250), the man pages are incorrect. Update them to state that implicit rejection was added in 3.2.0.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated