### PR TITLE
Provider compat CI: remove testcase with corrupted RSA ciphertext

### DIFF
--- a/.github/workflows/fips-provider.yml
+++ b/.github/workflows/fips-provider.yml
@@ -92,6 +92,9 @@ jobs:
       - name: copy the provider
         run: |
           cp -a build/providers/fips.so build-3.0/providers/fips.so
+      - name: removing incompatible testcase
+        run: sed -i '/# Corrupted ciphertext/{N;N;N;N;d}' evppkey_rsa_common.txt
+        working-directory: ./source-3.0/test/recipes/30-test_evp_data
       - name: make test 3.0
         run: make test HARNESS_JOBS=${HARNESS_JOBS:-4}
         working-directory: ./build-3.0


### PR DESCRIPTION
This testcase does not work anymore after PR #13817 was merged.
