### PR TITLE
apps.c: check the return of EVP_MD_CTX_new

### DIFF
--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -2180,8 +2180,6 @@ static int do_sign_init(EVP_MD_CTX *ctx, EVP_PKEY *pkey,
     EVP_PKEY_CTX *pkctx = NULL;
     char def_md[80];
 
-    if (ctx == NULL)
-        return 0;
     /*
      * EVP_PKEY_get_default_digest_name() returns 2 if the digest is mandatory
      * for this algorithm.

--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -2277,7 +2277,7 @@ int do_X509_REQ_sign(X509_REQ *x, EVP_PKEY *pkey, const char *md,
     int rv = 0;
     EVP_MD_CTX *mctx = EVP_MD_CTX_new();
 
-    if (do_sign_init(mctx, pkey, md, sigopts) > 0)
+    if (mctx != NULL && do_sign_init(mctx, pkey, md, sigopts) > 0)
         rv = (X509_REQ_sign_ctx(x, mctx) > 0);
     EVP_MD_CTX_free(mctx);
     return rv;
@@ -2290,7 +2290,7 @@ int do_X509_CRL_sign(X509_CRL *x, EVP_PKEY *pkey, const char *md,
     int rv = 0;
     EVP_MD_CTX *mctx = EVP_MD_CTX_new();
 
-    if (do_sign_init(mctx, pkey, md, sigopts) > 0)
+    if (mctx != NULL && do_sign_init(mctx, pkey, md, sigopts) > 0)
         rv = (X509_CRL_sign_ctx(x, mctx) > 0);
     EVP_MD_CTX_free(mctx);
     return rv;


### PR DESCRIPTION
apps.c: check the return of EVP_MD_CTX_new in time to avoid unnecessary call and other further validations.