### PR TITLE
QUIC API FIN support

### DIFF
--- a/doc/build.info
+++ b/doc/build.info
@@ -2671,6 +2671,10 @@ DEPEND[html/man3/SSL_state_string.html]=man3/SSL_state_string.pod
 GENERATE[html/man3/SSL_state_string.html]=man3/SSL_state_string.pod
 DEPEND[man/man3/SSL_state_string.3]=man3/SSL_state_string.pod
 GENERATE[man/man3/SSL_state_string.3]=man3/SSL_state_string.pod
+DEPEND[html/man3/SSL_stream_conclude.html]=man3/SSL_stream_conclude.pod
+GENERATE[html/man3/SSL_stream_conclude.html]=man3/SSL_stream_conclude.pod
+DEPEND[man/man3/SSL_stream_conclude.3]=man3/SSL_stream_conclude.pod
+GENERATE[man/man3/SSL_stream_conclude.3]=man3/SSL_stream_conclude.pod
 DEPEND[html/man3/SSL_tick.html]=man3/SSL_tick.pod
 GENERATE[html/man3/SSL_tick.html]=man3/SSL_tick.pod
 DEPEND[man/man3/SSL_tick.3]=man3/SSL_tick.pod
@@ -3507,6 +3511,7 @@ html/man3/SSL_set_shutdown.html \
 html/man3/SSL_set_verify_result.html \
 html/man3/SSL_shutdown.html \
 html/man3/SSL_state_string.html \
+html/man3/SSL_stream_conclude.html \
 html/man3/SSL_tick.html \
 html/man3/SSL_want.html \
 html/man3/SSL_write.html \
@@ -4129,6 +4134,7 @@ man/man3/SSL_set_shutdown.3 \
 man/man3/SSL_set_verify_result.3 \
 man/man3/SSL_shutdown.3 \
 man/man3/SSL_state_string.3 \
+man/man3/SSL_stream_conclude.3 \
 man/man3/SSL_tick.3 \
 man/man3/SSL_want.3 \
 man/man3/SSL_write.3 \

--- a/doc/man3/SSL_shutdown.pod
+++ b/doc/man3/SSL_shutdown.pod
@@ -2,13 +2,22 @@
 
 =head1 NAME
 
-SSL_shutdown - shut down a TLS/SSL connection
+SSL_shutdown, SSL_shutdown_ex - shut down a TLS/SSL or QUIC connection
 
 =head1 SYNOPSIS
 
  #include <openssl/ssl.h>
 
  int SSL_shutdown(SSL *ssl);
+
+ typedef struct ssl_shutdown_ex_args_st {
+     uint64_t    quic_error_code;
+     const char  *quic_reason;
+ } SSL_SHUTDOWN_EX_ARGS;
+
+ __owur int SSL_shutdown_ex(SSL *ssl, uint64_t flags,
+                            const SSL_SHUTDOWN_EX_ARGS *args,
+                            size_t args_len);
 
 =head1 DESCRIPTION
 
@@ -88,6 +97,36 @@ will result in an error being generated.
 The error can be ignored using the B<SSL_OP_IGNORE_UNEXPECTED_EOF>.
 For more information see L<SSL_CTX_set_options(3)>.
 
+SSL_shutdown_ex() is an extended version of SSL_shutdown(). If non-NULL, I<args>
+must point to a B<SSL_SHUTDOWN_EX_ARGS> structure and I<args_len> must be set to
+I<sizeof(SSL_SHUTDOWN_EX_ARGS)>. The B<SSL_SHUTDOWN_EX_ARGS> structure must be
+zero-initialized. If B<args> is NULL, the behaviour is the same as passing a
+zero-initialised B<SSL_SHUTDOWN_EX_ARGS> structure. When used with a non-QUIC
+SSL object, the arguments are ignored and the call functions identically to
+SSL_shutdown().
+
+=begin comment
+
+TODO(QUIC): Once streams are implemented, revise this text
+
+=end comment
+
+When used with a QUIC connection SSL object, SSL_shutdown_ex() initiates a QUIC
+immediate close. The I<quic_error_code> field can be used to specify a 62-bit
+application error code to be signalled via QUIC. The value specified must be in
+the range [0, 2**62-1], else this call fails. I<quic_reason> may optionally
+specify a zero-terminated reason string to be signalled to the peer. If a reason
+is not specified, a zero-length string is used as the reason. The reason string
+is copied and need not remain allocated after the call to the function returns.
+Reason strings are bounded by the path MTU and may be silently truncated if they
+are too long to fit in a QUIC packet. The arguments are only used on the first
+call to SSL_shutdown_ex() for a given QUIC connection SSL object.
+
+When using QUIC, how an application uses SSL_shutdown() or SSL_shutdown_ex() has
+implications for whether QUIC closes a connection in an RFC-compliant manner.
+For discussion these issues, and for discussion of the I<flags> argument, see
+B<QUIC-SPECIFIC SHUTDOWN CONSIDERATIONS> below.
+
 =head2 First to close the connection
 
 When the application is the first party to send the close_notify
@@ -125,9 +164,69 @@ If successful, SSL_shutdown() will return 1.
 Whether SSL_RECEIVED_SHUTDOWN is already set can be checked using the
 SSL_get_shutdown() (see also L<SSL_set_shutdown(3)> call.
 
+=head1 QUIC-SPECIFIC SHUTDOWN CONSIDERATIONS
+
+When using QUIC, SSL_shutdown() or SSL_shutdown_ex() causes any data written to
+a stream which has not yet been sent to the peer to be written before the
+shutdown process is considered complete. An exception to this is streams which
+terminated in a non-normal fashion, for example due to a stream reset; only
+streams which are non-terminated or which terminated in a normal fashion have
+their pending send buffers flushed in this manner. This behaviour can be skipped
+by setting the B<SSL_SHUTDOWN_FLAG_IMMEDIATE> flag; in this case, data remaining
+in stream send buffers may not be transmitted to the peer. This flag may be used
+when a non-normal application condition has occurred and the delivery of data
+written to streams via L<SSL_write(3)> is no longer relevant.
+
+Aspects of how QUIC handles connection closure must be taken into account by
+applications. Ordinarily, QUIC expects a connection to continue to be serviced
+for a substantial period of time after it is nominally closed. This is necessary
+to ensure that any connection closure notification sent to the peer was
+successfully received. However, a consequence of this is that a fully
+RFC-compliant QUIC connection closure process could take on the order of
+seconds. This may be unsuitable for some applications, such as short-lived
+processes which need to exit immediately after completing an application-layer
+transaction.
+
+As such, there are two shutdown modes available to users of QUIC connection SSL
+objects:
+
+=over 4
+
+=item RFC compliant shutdown mode
+
+This is the default behaviour. The shutdown process may take a period of time up
+to three times the current estimated RTT to the peer. It is possible for the
+closure process to complete much faster in some circumstances but this cannot be
+relied upon.
+
+In blocking mode, the function will return once the closure process is complete.
+In nonblocking mode, SSL_shutdown_ex() should be called until it returns 1,
+indicating the closure process is complete and the connection is now fully shut
+down.
+
+=item Rapid shutdown mode
+
+In this mode, the peer is notified of connection closure on a best effort basis
+by sending a single QUIC packet. If that QUIC packet i slost, the peer will not
+know that the connection has terminated until the negotiated idle timeout (if
+any) expires.
+
+This will generally return 0 on success, indicating that the connection has not
+yet been fully shut down (unless it has already done so, in which case it will
+return 1).
+
+=back
+
+If B<SSL_SHUTDOWN_FLAG_RAPID> is specified in I<flags>, a rapid shutdown is
+performed, otherwise an RFC-compliant shutdown is performed.
+
+If an application calls SSL_shutdown_ex() with B<SSL_SHUTDOWN_FLAG_RAPID>, an
+application can subsequently change its mind about performing a rapid shutdown
+by making a subsequent call to SSL_shutdown_ex() without the flag set.
+
 =head1 RETURN VALUES
 
-The following return values can occur:
+For both SSL_shutdown() and SSL_shutdown_ex() following return values can occur:
 
 =over 4
 
@@ -137,14 +236,19 @@ The shutdown is not yet finished: the close_notify was sent but the peer
 did not send it back yet.
 Call SSL_read() to do a bidirectional shutdown.
 
-Unlike most other function, returning 0 does not indicate an error.
-L<SSL_get_error(3)> should not get called, it may misleadingly
+For QUIC connection SSL objects, a CONNECTION_CLOSE frame may have been sent
+but the connection closure process has not yet completed.
+
+Unlike most other functions, returning 0 does not indicate an error.
+L<SSL_get_error(3)> should not be called; it may misleadingly
 indicate an error even though no error occurred.
 
 =item Z<>1
 
-The shutdown was successfully completed. The close_notify alert was sent
-and the peer's close_notify alert was received.
+The shutdown was successfully completed. For non-QUIC SSL objects, this means
+that the close_notify alert was sent and the peer's close_notify alert was
+received. For QUIC connection SSL objects, this means that the connection
+closure process has completed.
 
 =item E<lt>0
 

--- a/doc/man3/SSL_shutdown.pod
+++ b/doc/man3/SSL_shutdown.pod
@@ -182,7 +182,7 @@ applications. Ordinarily, QUIC expects a connection to continue to be serviced
 for a substantial period of time after it is nominally closed. This is necessary
 to ensure that any connection closure notification sent to the peer was
 successfully received. However, a consequence of this is that a fully
-RFC-compliant QUIC connection closure process could take on the order of
+RFC-compliant QUIC connection closure process could take of the order of
 seconds. This may be unsuitable for some applications, such as short-lived
 processes which need to exit immediately after completing an application-layer
 transaction.
@@ -226,29 +226,33 @@ by making a subsequent call to SSL_shutdown_ex() without the flag set.
 
 =head1 RETURN VALUES
 
-For both SSL_shutdown() and SSL_shutdown_ex() following return values can occur:
+For both SSL_shutdown() and SSL_shutdown_ex() the following return values can occur:
 
 =over 4
 
 =item Z<>0
 
-The shutdown is not yet finished: the close_notify was sent but the peer
-did not send it back yet.
-Call SSL_read() to do a bidirectional shutdown.
+The shutdown process is ongoing and has not yet completed.
 
-For QUIC connection SSL objects, a CONNECTION_CLOSE frame may have been sent
-but the connection closure process has not yet completed.
+For TLS and DTLS, this means that a close_notify alert has been sent but the
+peer has not yet replied in turn with its own close_notify.
+
+For QUIC connection SSL objects, a CONNECTION_CLOSE frame may have been
+sent but the connection closure process has not yet completed.
 
 Unlike most other functions, returning 0 does not indicate an error.
-L<SSL_get_error(3)> should not be called; it may misleadingly
-indicate an error even though no error occurred.
+L<SSL_get_error(3)> should not be called; it may misleadingly indicate an error
+even though no error occurred.
 
 =item Z<>1
 
-The shutdown was successfully completed. For non-QUIC SSL objects, this means
-that the close_notify alert was sent and the peer's close_notify alert was
-received. For QUIC connection SSL objects, this means that the connection
-closure process has completed.
+The shutdown was successfully completed.
+
+For TLS and DTLS, this means that a close_notify alert was sent and the peer's
+close_notify alert was received.
+
+For QUIC connection SSL objects, this means that the connection closure process
+has completed.
 
 =item E<lt>0
 

--- a/doc/man3/SSL_shutdown.pod
+++ b/doc/man3/SSL_shutdown.pod
@@ -99,8 +99,8 @@ For more information see L<SSL_CTX_set_options(3)>.
 
 SSL_shutdown_ex() is an extended version of SSL_shutdown(). If non-NULL, I<args>
 must point to a B<SSL_SHUTDOWN_EX_ARGS> structure and I<args_len> must be set to
-I<sizeof(SSL_SHUTDOWN_EX_ARGS)>. The B<SSL_SHUTDOWN_EX_ARGS> structure must be
-zero-initialized. If B<args> is NULL, the behaviour is the same as passing a
+C<sizeof(SSL_SHUTDOWN_EX_ARGS)>. The B<SSL_SHUTDOWN_EX_ARGS> structure must be
+zero-initialized. If I<args> is NULL, the behaviour is the same as passing a
 zero-initialised B<SSL_SHUTDOWN_EX_ARGS> structure. When used with a non-QUIC
 SSL object, the arguments are ignored and the call functions identically to
 SSL_shutdown().
@@ -124,7 +124,7 @@ call to SSL_shutdown_ex() for a given QUIC connection SSL object.
 
 When using QUIC, how an application uses SSL_shutdown() or SSL_shutdown_ex() has
 implications for whether QUIC closes a connection in an RFC-compliant manner.
-For discussion these issues, and for discussion of the I<flags> argument, see
+For discussion of these issues, and for discussion of the I<flags> argument, see
 B<QUIC-SPECIFIC SHUTDOWN CONSIDERATIONS> below.
 
 =head2 First to close the connection
@@ -172,10 +172,10 @@ shutdown process is considered complete. An exception to this is streams which
 terminated in a non-normal fashion, for example due to a stream reset; only
 streams which are non-terminated or which terminated in a normal fashion have
 their pending send buffers flushed in this manner. This behaviour can be skipped
-by setting the B<SSL_SHUTDOWN_FLAG_IMMEDIATE> flag; in this case, data remaining
-in stream send buffers may not be transmitted to the peer. This flag may be used
-when a non-normal application condition has occurred and the delivery of data
-written to streams via L<SSL_write(3)> is no longer relevant.
+by setting the B<SSL_SHUTDOWN_FLAG_NO_STREAM_FLUSH> flag; in this case, data
+remaining in stream send buffers may not be transmitted to the peer. This flag
+may be used when a non-normal application condition has occurred and the
+delivery of data written to streams via L<SSL_write(3)> is no longer relevant.
 
 Aspects of how QUIC handles connection closure must be taken into account by
 applications. Ordinarily, QUIC expects a connection to continue to be serviced
@@ -207,7 +207,7 @@ down.
 =item Rapid shutdown mode
 
 In this mode, the peer is notified of connection closure on a best effort basis
-by sending a single QUIC packet. If that QUIC packet i slost, the peer will not
+by sending a single QUIC packet. If that QUIC packet is lost, the peer will not
 know that the connection has terminated until the negotiated idle timeout (if
 any) expires.
 
@@ -268,6 +268,10 @@ L<SSL_accept(3)>, L<SSL_set_shutdown(3)>,
 L<SSL_CTX_set_quiet_shutdown(3)>, L<SSL_CTX_set_options(3)>
 L<SSL_clear(3)>, L<SSL_free(3)>,
 L<ssl(7)>, L<bio(7)>
+
+=head1 HISTORY
+
+The SSL_shutdown_ex() function was added in OpenSSL 3.2.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/SSL_stream_conclude.pod
+++ b/doc/man3/SSL_stream_conclude.pod
@@ -27,7 +27,7 @@ When calling this on a stream, the receive part of the stream remains
 unaffected, and the peer may continue to send data until it also signals the end
 of the stream. Thus, SSL_read() can still be used.
 
-B<flags> is reserved and should be set to 0.
+I<flags> is reserved and should be set to 0.
 
 Only the first call to this function has any effect for a given stream;
 subsequent calls are no-ops. This is considered a success case.

--- a/doc/man3/SSL_stream_conclude.pod
+++ b/doc/man3/SSL_stream_conclude.pod
@@ -1,0 +1,62 @@
+=pod
+
+=head1 NAME
+
+SSL_stream_conclude - conclude the sending part of a QUIC stream
+
+=head1 SYNOPSIS
+
+ #include <openssl/ssl.h>
+
+ __owur int SSL_stream_conclude(SSL *s, uint64_t flags);
+
+=head1 DESCRIPTION
+
+SSL_stream_conclude() signals the normal end-of-stream condition for the send
+part of a QUIC stream. If called on a QUIC connection SSL object, it signals the
+end of the single stream to the peer.
+
+Any data already queued for transmission via a call to SSL_write() will still be
+written in a reliable manner before the end-of-stream is signalled, assuming the
+connection remains healthy. This function can be thought of as appending a
+logical end-of-stream marker after any data which has previously been written to
+the stream via calls to SSL_write(). Further attempts to call SSL_write() after
+calling this function will fail.
+
+When calling this on a stream, the receive part of the stream remains
+unaffected, and the peer may continue to send data until it also signals the end
+of the stream. Thus, SSL_read() can still be used.
+
+B<flags> is reserved and should be set to 0.
+
+Only the first call to this function has any effect for a given stream;
+subsequent calls are no-ops. This is considered a success case.
+
+=begin comment
+
+TODO(QUIC): Once streams are implemented, revise this text
+
+=end comment
+
+=head1 RETURN VALUES
+
+Returns 1 on success and 0 on failure.
+
+=head1 SEE ALSO
+
+L<ssl(7)>, L<SSL_shutdown_ex(3)>
+
+=head1 HISTORY
+
+The SSL_stream_conclude() function was added in OpenSSL 3.2.
+
+=head1 COPYRIGHT
+
+Copyright 2022 The OpenSSL Project Authors. All Rights Reserved.
+
+Licensed under the Apache License 2.0 (the "License").  You may not use
+this file except in compliance with the License.  You can obtain a copy
+in the file LICENSE in the source distribution or at
+L<https://www.openssl.org/source/license.html>.
+
+=cut

--- a/doc/man3/SSL_stream_conclude.pod
+++ b/doc/man3/SSL_stream_conclude.pod
@@ -38,9 +38,13 @@ TODO(QUIC): Once streams are implemented, revise this text
 
 =end comment
 
+This function is not supported on non-QUIC SSL objects.
+
 =head1 RETURN VALUES
 
 Returns 1 on success and 0 on failure.
+
+Returns 0 if called on a non-QUIC SSL object.
 
 =head1 SEE ALSO
 

--- a/include/internal/quic_channel.h
+++ b/include/internal/quic_channel.h
@@ -91,7 +91,7 @@ void ossl_quic_channel_free(QUIC_CHANNEL *ch);
 int ossl_quic_channel_start(QUIC_CHANNEL *ch);
 
 /* Start a locally initiated connection shutdown. */
-void ossl_quic_channel_local_close(QUIC_CHANNEL *ch);
+void ossl_quic_channel_local_close(QUIC_CHANNEL *ch, uint64_t app_error_code);
 
 /*
  * Called when the handshake is confirmed.

--- a/include/internal/quic_ssl.h
+++ b/include/internal/quic_ssl.h
@@ -28,7 +28,6 @@ __owur int ossl_quic_connect(SSL *s);
 __owur int ossl_quic_read(SSL *s, void *buf, size_t len, size_t *readbytes);
 __owur int ossl_quic_peek(SSL *s, void *buf, size_t len, size_t *readbytes);
 __owur int ossl_quic_write(SSL *s, const void *buf, size_t len, size_t *written);
-__owur int ossl_quic_shutdown(SSL *s);
 __owur long ossl_quic_ctrl(SSL *s, int cmd, long larg, void *parg);
 __owur long ossl_quic_ctx_ctrl(SSL_CTX *ctx, int cmd, long larg, void *parg);
 __owur long ossl_quic_callback_ctrl(SSL *s, int cmd, void (*fp) (void));
@@ -53,6 +52,10 @@ __owur int ossl_quic_get_net_write_desired(QUIC_CONNECTION *qc);
 __owur int ossl_quic_get_error(const QUIC_CONNECTION *qc, int i);
 __owur int ossl_quic_conn_get_blocking_mode(const QUIC_CONNECTION *qc);
 __owur int ossl_quic_conn_set_blocking_mode(QUIC_CONNECTION *qc, int blocking);
+__owur int ossl_quic_conn_shutdown(QUIC_CONNECTION *qc, uint64_t flags,
+                                   const SSL_SHUTDOWN_EX_ARGS *args,
+                                   size_t args_len);
+__owur int ossl_quic_conn_stream_conclude(QUIC_CONNECTION *qc);
 void ossl_quic_conn_set0_net_rbio(QUIC_CONNECTION *qc, BIO *net_wbio);
 void ossl_quic_conn_set0_net_wbio(QUIC_CONNECTION *qc, BIO *net_wbio);
 BIO *ossl_quic_conn_get_net_rbio(const QUIC_CONNECTION *qc);

--- a/include/internal/quic_stream.h
+++ b/include/internal/quic_stream.h
@@ -248,6 +248,12 @@ int ossl_quic_sstream_append(QUIC_SSTREAM *qss,
 void ossl_quic_sstream_fin(QUIC_SSTREAM *qss);
 
 /*
+ * If the stream has had ossl_quic_sstream_fin() called, returns 1 and writes
+ * the final size to *final_size. Otherwise, returns 0.
+ */
+int ossl_quic_sstream_get_final_size(QUIC_SSTREAM *qss, uint64_t *final_size);
+
+/*
  * Resizes the internal ring buffer. All stream data is preserved safely.
  *
  * This can be used to expand or contract the ring buffer, but not to contract

--- a/include/internal/quic_tserver.h
+++ b/include/internal/quic_tserver.h
@@ -51,12 +51,19 @@ int ossl_quic_tserver_is_connected(QUIC_TSERVER *srv);
  * *bytes_read and returns 1 on success. If no bytes are available, 0 is written
  * to *bytes_read and 1 is returned (this is considered a success case).
  *
- * Returns 0 if connection is not currently active.
+ * Returns 0 if connection is not currently active. If the receive part of
+ * the stream has reached the end of stream condition, returns 0; call
+ * ossl_quic_tserver_has_read_ended() to identify this condition.
  */
 int ossl_quic_tserver_read(QUIC_TSERVER *srv,
                            unsigned char *buf,
                            size_t buf_len,
                            size_t *bytes_read);
+
+/*
+ * Returns 1 if the read part of the stream has ended normally.
+ */
+int ossl_quic_tserver_has_read_ended(QUIC_TSERVER *srv);
 
 /*
  * Attempts to write to stream 0. Writes the number of bytes consumed to
@@ -73,6 +80,11 @@ int ossl_quic_tserver_write(QUIC_TSERVER *srv,
                             const unsigned char *buf,
                             size_t buf_len,
                             size_t *bytes_written);
+
+/*
+ * Signals normal end of the stream.
+ */
+int ossl_quic_tserver_conclude(QUIC_TSERVER *srv);
 
 # endif
 

--- a/include/openssl/ssl.h.in
+++ b/include/openssl/ssl.h.in
@@ -2270,6 +2270,8 @@ __owur int SSL_shutdown_ex(SSL *ssl, uint64_t flags,
                            const SSL_SHUTDOWN_EX_ARGS *args,
                            size_t args_len);
 
+__owur int SSL_stream_conclude(SSL *ssl, uint64_t flags);
+
 # ifndef OPENSSL_NO_DEPRECATED_1_1_0
 #  define SSL_cache_hit(s) SSL_session_reused(s)
 # endif

--- a/include/openssl/ssl.h.in
+++ b/include/openssl/ssl.h.in
@@ -2263,8 +2263,8 @@ typedef struct ssl_shutdown_ex_args_st {
     const char  *quic_reason;
 } SSL_SHUTDOWN_EX_ARGS;
 
-#define SSL_SHUTDOWN_FLAG_RAPID         (1U << 0)
-#define SSL_SHUTDOWN_FLAG_IMMEDIATE     (1U << 1)
+#define SSL_SHUTDOWN_FLAG_RAPID             (1U << 0)
+#define SSL_SHUTDOWN_FLAG_NO_STREAM_FLUSH   (1U << 1)
 
 __owur int SSL_shutdown_ex(SSL *ssl, uint64_t flags,
                            const SSL_SHUTDOWN_EX_ARGS *args,

--- a/include/openssl/ssl.h.in
+++ b/include/openssl/ssl.h.in
@@ -2258,6 +2258,18 @@ __owur int SSL_set_blocking_mode(SSL *s, int blocking);
 __owur int SSL_get_blocking_mode(SSL *s);
 __owur int SSL_set_initial_peer_addr(SSL *s, const BIO_ADDR *peer_addr);
 
+typedef struct ssl_shutdown_ex_args_st {
+    uint64_t    quic_error_code;
+    const char  *quic_reason;
+} SSL_SHUTDOWN_EX_ARGS;
+
+#define SSL_SHUTDOWN_FLAG_RAPID         (1U << 0)
+#define SSL_SHUTDOWN_FLAG_IMMEDIATE     (1U << 1)
+
+__owur int SSL_shutdown_ex(SSL *ssl, uint64_t flags,
+                           const SSL_SHUTDOWN_EX_ARGS *args,
+                           size_t args_len);
+
 # ifndef OPENSSL_NO_DEPRECATED_1_1_0
 #  define SSL_cache_hit(s) SSL_session_reused(s)
 # endif

--- a/ssl/quic/quic_channel.c
+++ b/ssl/quic/quic_channel.c
@@ -1710,14 +1710,15 @@ int ossl_quic_channel_start(QUIC_CHANNEL *ch)
 }
 
 /* Start a locally initiated connection shutdown. */
-void ossl_quic_channel_local_close(QUIC_CHANNEL *ch)
+void ossl_quic_channel_local_close(QUIC_CHANNEL *ch, uint64_t app_error_code)
 {
     QUIC_TERMINATE_CAUSE tcause = {0};
 
     if (ossl_quic_channel_is_term_any(ch))
         return;
 
-    tcause.app = 1;
+    tcause.app          = 1;
+    tcause.error_code   = app_error_code;
     ch_start_terminating(ch, &tcause, 0);
 }
 

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -496,7 +496,7 @@ int ossl_quic_conn_shutdown(QUIC_CONNECTION *qc, uint64_t flags,
     ossl_quic_channel_local_close(qc->ch,
                                   args != NULL ? args->quic_error_code : 0);
 
-    /* TODO(QUIC): !SSL_SHUTDOWN_FLAG_IMMEDIATE */
+    /* TODO(QUIC): !SSL_SHUTDOWN_FLAG_NO_STREAM_FLUSH */
 
     if (ossl_quic_channel_is_terminated(qc->ch))
         return 1;
@@ -748,7 +748,6 @@ int ossl_quic_accept(SSL *s)
  *   (BIO/)SSL_write            => ossl_quic_write
  *         SSL_pending          => ossl_quic_pending
  *         SSL_stream_conclude  => ossl_quic_conn_stream_conclude
- *
  */
 
 /* SSL_get_error */

--- a/ssl/quic/quic_local.h
+++ b/ssl/quic/quic_local.h
@@ -198,7 +198,7 @@ const SSL_METHOD *func_name(void)  \
                 ossl_quic_read, \
                 ossl_quic_peek, \
                 ossl_quic_write, \
-                ossl_quic_shutdown, \
+                NULL /* shutdown */, \
                 NULL /* renegotiate */, \
                 ossl_quic_renegotiate_check, \
                 NULL /* read_bytes */, \

--- a/ssl/quic/quic_sstream.c
+++ b/ssl/quic/quic_sstream.c
@@ -442,6 +442,17 @@ void ossl_quic_sstream_fin(QUIC_SSTREAM *qss)
     qss->have_final_size = 1;
 }
 
+int ossl_quic_sstream_get_final_size(QUIC_SSTREAM *qss, uint64_t *final_size)
+{
+    if (!qss->have_final_size)
+        return 0;
+
+    if (final_size != NULL)
+        *final_size = qss->ring_buf.head_offset;
+
+    return 1;
+}
+
 int ossl_quic_sstream_append(QUIC_SSTREAM *qss,
                              const unsigned char *buf,
                              size_t buf_len,

--- a/ssl/quic/quic_tserver.c
+++ b/ssl/quic/quic_tserver.c
@@ -103,9 +103,12 @@ int ossl_quic_tserver_read(QUIC_TSERVER *srv,
                            size_t buf_len,
                            size_t *bytes_read)
 {
-    int is_fin = 0; /* TODO(QUIC): Handle FIN in API */
+    int is_fin = 0;
 
     if (!ossl_quic_channel_is_active(srv->ch))
+        return 0;
+
+    if (srv->stream0->recv_fin_retired)
         return 0;
 
     if (!ossl_quic_rstream_read(srv->stream0->rstream, buf, buf_len,
@@ -138,6 +141,11 @@ int ossl_quic_tserver_read(QUIC_TSERVER *srv,
     return 1;
 }
 
+int ossl_quic_tserver_has_read_ended(QUIC_TSERVER *srv)
+{
+    return srv->stream0->recv_fin_retired;
+}
+
 int ossl_quic_tserver_write(QUIC_TSERVER *srv,
                             const unsigned char *buf,
                             size_t buf_len,
@@ -159,6 +167,21 @@ int ossl_quic_tserver_write(QUIC_TSERVER *srv,
                                           srv->stream0);
 
     /* Try and send. */
+    ossl_quic_tserver_tick(srv);
+    return 1;
+}
+
+int ossl_quic_tserver_conclude(QUIC_TSERVER *srv)
+{
+    if (!ossl_quic_channel_is_active(srv->ch))
+        return 0;
+
+    if (!ossl_quic_sstream_get_final_size(srv->stream0->sstream, NULL)) {
+        ossl_quic_sstream_fin(srv->stream0->sstream);
+        ossl_quic_stream_map_update_state(ossl_quic_channel_get_qsm(srv->ch),
+                                          srv->stream0);
+    }
+
     ossl_quic_tserver_tick(srv);
     return 1;
 }

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -7196,3 +7196,17 @@ int SSL_shutdown_ex(SSL *ssl, uint64_t flags,
     return SSL_shutdown(ssl);
 #endif
 }
+
+int SSL_stream_conclude(SSL *ssl, uint64_t flags)
+{
+#ifndef OPENSSL_NO_QUIC
+    QUIC_CONNECTION *qc = QUIC_CONNECTION_FROM_SSL(ssl);
+
+    if (qc == NULL)
+        return 0;
+
+    return ossl_quic_conn_stream_conclude(qc);
+#else
+    return 0;
+#endif
+}

--- a/test/quic_tserver_test.c
+++ b/test/quic_tserver_test.c
@@ -206,11 +206,18 @@ static int test_tserver(void)
             if (!TEST_false(ret))
                 goto err;
 
-            if (!TEST_int_eq(SSL_get_error(c_ssl, ret), SSL_ERROR_ZERO_RETURN))
-                goto err;
+            /*
+             * Allow the implementation to take as long as it wants to finally
+             * notice EOS. Account for varied timings in OS networking stacks.
+             */
+            if (SSL_get_error(c_ssl, ret) != SSL_ERROR_WANT_READ) {
+                if (!TEST_int_eq(SSL_get_error(c_ssl, ret),
+                                 SSL_ERROR_ZERO_RETURN))
+                    goto err;
 
-            /* DONE */
-            break;
+                /* DONE */
+                break;
+            }
         }
 
         /*

--- a/test/quic_tserver_test.c
+++ b/test/quic_tserver_test.c
@@ -39,7 +39,8 @@ static int test_tserver(void)
     SSL_CTX *c_ctx = NULL;
     SSL *c_ssl = NULL;
     short port = 8186;
-    int c_connected = 0, c_write_done = 0, c_begin_read = 0;
+    int c_connected = 0, c_write_done = 0, c_begin_read = 0, s_read_done = 0;
+    int c_wait_eos = 0;
     size_t l = 0, s_total_read = 0, s_total_written = 0, c_total_read = 0;
     int s_begin_write = 0;
     OSSL_TIME start_time;
@@ -143,22 +144,27 @@ static int test_tserver(void)
                              (int)sizeof(msg1) - 1))
                 goto err;
 
+            if (!TEST_true(SSL_stream_conclude(c_ssl, 0)))
+                goto err;
+
             c_write_done = 1;
         }
 
-        if (c_connected && c_write_done && s_total_read < sizeof(msg1) - 1) {
-            if (!TEST_true(ossl_quic_tserver_read(tserver,
-                                                  (unsigned char *)msg2 + s_total_read,
-                                                  sizeof(msg2) - s_total_read, &l)))
-                goto err;
+        if (c_connected && c_write_done && !s_read_done) {
+            if (!ossl_quic_tserver_read(tserver,
+                                        (unsigned char *)msg2 + s_total_read,
+                                        sizeof(msg2) - s_total_read, &l)) {
+                if (!TEST_true(ossl_quic_tserver_has_read_ended(tserver)))
+                    goto err;
 
-            s_total_read += l;
-            if (s_total_read == sizeof(msg1) - 1) {
-                if (!TEST_mem_eq(msg1, sizeof(msg1) - 1,
-                                 msg2, sizeof(msg1) - 1))
+                if (!TEST_mem_eq(msg1, sizeof(msg1) - 1, msg2, s_total_read))
                     goto err;
 
                 s_begin_write = 1;
+            } else {
+                s_total_read += l;
+                if (!TEST_size_t_le(s_total_read, sizeof(msg1) - 1))
+                    goto err;
             }
         }
 
@@ -170,8 +176,10 @@ static int test_tserver(void)
 
             s_total_written += l;
 
-            if (s_total_written == sizeof(msg1) - 1)
+            if (s_total_written == sizeof(msg1) - 1) {
+                ossl_quic_tserver_conclude(tserver);
                 c_begin_read = 1;
+            }
         }
 
         if (c_begin_read && c_total_read < sizeof(msg1) - 1) {
@@ -187,9 +195,22 @@ static int test_tserver(void)
                                  msg3, c_total_read))
                     goto err;
 
-                /* MATCH */
-                break;
+                c_wait_eos = 1;
             }
+        }
+
+        if (c_wait_eos) {
+            unsigned char c;
+
+            ret = SSL_read_ex(c_ssl, &c, sizeof(c), &l);
+            if (!TEST_false(ret))
+                goto err;
+
+            if (!TEST_int_eq(SSL_get_error(c_ssl, ret), SSL_ERROR_ZERO_RETURN))
+                goto err;
+
+            /* DONE */
+            break;
         }
 
         /*

--- a/util/libssl.num
+++ b/util/libssl.num
@@ -541,3 +541,4 @@ SSL_get_blocking_mode                   ?	3_2_0	EXIST::FUNCTION:
 SSL_set_initial_peer_addr               ?	3_2_0	EXIST::FUNCTION:
 SSL_net_read_desired                    ?	3_2_0	EXIST::FUNCTION:
 SSL_net_write_desired                   ?	3_2_0	EXIST::FUNCTION:
+SSL_shutdown_ex                         ?	3_2_0	EXIST::FUNCTION:

--- a/util/libssl.num
+++ b/util/libssl.num
@@ -542,3 +542,4 @@ SSL_set_initial_peer_addr               ?	3_2_0	EXIST::FUNCTION:
 SSL_net_read_desired                    ?	3_2_0	EXIST::FUNCTION:
 SSL_net_write_desired                   ?	3_2_0	EXIST::FUNCTION:
 SSL_shutdown_ex                         ?	3_2_0	EXIST::FUNCTION:
+SSL_stream_conclude                     ?	3_2_0	EXIST::FUNCTION:


### PR DESCRIPTION
This is built on top of the test server PR. I've made it a separate PR for now to ease review and let people keep doing review in more manageable chunks. It implements the proposed API for signalling end-of-stream in the API Overview document (`SSL_stream_conclude`) and also has a partial implementation of `SSL_shutdown_ex`.

It also updates the tserver test to exercise this functionality.

The new commits are:

```
94b2b866a4 QUIC Test Server: Exercise end-of-stream condition on read and write
219f21377a QUIC Front End I/O API: Add support for signalling and detecting end-of-stream
9108b3e052 QUIC TXP: Fix handling of FIN stream chunks
0f7c94613a QUIC: Refine SSL_shutdown and begin to implement SSL_shutdown_ex
```