### PR TITLE
SM4 AESE optimization for ARMv8

### DIFF
--- a/crypto/sm4/asm/sm4-armv8.pl
+++ b/crypto/sm4/asm/sm4-armv8.pl
@@ -32,7 +32,7 @@ sub rev32() {
 my $dst = shift;
 my $src = shift;
 $code.=<<___;
-#ifndef __ARMEB__
+#ifndef __AARCH64EB__
 	rev32	$dst.16b,$src.16b
 #endif
 ___

--- a/crypto/sm4/asm/vpsm4_ex-armv8.pl
+++ b/crypto/sm4/asm/vpsm4_ex-armv8.pl
@@ -1,5 +1,5 @@
 #! /usr/bin/env perl
-# Copyright 2020-2022 The OpenSSL Project Authors. All Rights Reserved.
+# Copyright 2022 The OpenSSL Project Authors. All Rights Reserved.
 #
 # Licensed under the Apache License 2.0 (the "License").  You may not use
 # this file except in compliance with the License.  You can obtain a copy
@@ -7,9 +7,9 @@
 # https://www.openssl.org/source/license.html
 
 #
-# This module implements SM4 with ASIMD on aarch64
+# This module implements SM4 with ASIMD and AESE on AARCH64
 #
-# Feb 2022
+# Dec 2022
 #
 
 # $output is the last argument if it looks like a file (it has an extension)
@@ -23,19 +23,24 @@ $0 =~ m/(.*[\/\\])[^\/\\]+$/; $dir=$1;
 die "can't locate arm-xlate.pl";
 
 open OUT,"| \"$^X\" $xlate $flavour \"$output\""
-    or die "can't call $xlate: $!";
+	or die "can't call $xlate: $!";
 *STDOUT=*OUT;
 
-$prefix="vpsm4";
+$prefix="vpsm4_ex";
 my @vtmp=map("v$_",(0..3));
+my @qtmp=map("q$_",(0..3));
 my @data=map("v$_",(4..7));
 my @datax=map("v$_",(8..11));
 my ($rk0,$rk1)=("v12","v13");
 my ($rka,$rkb)=("v14","v15");
 my @vtmpx=map("v$_",(12..15));
-my @sbox=map("v$_",(16..31));
+my ($vtmp4,$vtmp5)=("v24","v25");
+my ($MaskV,$TAHMatV,$TALMatV,$ATAHMatV,$ATALMatV,$ANDMaskV)=("v26","v27","v28","v29","v30","v31");
+my ($MaskQ,$TAHMatQ,$TALMatQ,$ATAHMatQ,$ATALMatQ,$ANDMaskQ)=("q26","q27","q28","q29","q30","q31");
+
 my ($inp,$outp,$blocks,$rks)=("x0","x1","w2","x3");
 my ($tmpw,$tmp,$wtmp0,$wtmp1,$wtmp2)=("w6","x6","w7","w8","w9");
+my ($xtmp1,$xtmp2)=("x8","x9");
 my ($ptr,$counter)=("x10","w11");
 my ($word0,$word1,$word2,$word3)=("w12","w13","w14","w15");
 
@@ -60,6 +65,51 @@ ___
 	}
 }
 
+sub rev32_armeb() {
+	my $dst = shift;
+	my $src = shift;
+
+	if ($src and ("$src" ne "$dst")) {
+$code.=<<___;
+#ifdef __AARCH64EB__
+	rev32	$dst.16b,$src.16b
+#else
+	mov	$dst.16b,$src.16b
+#endif
+___
+	} else {
+$code.=<<___;
+#ifdef __AARCH64EB__
+	rev32	$dst.16b,$dst.16b
+#endif
+___
+	}
+}
+
+sub rbit() {
+	my $dst = shift;
+	my $src = shift;
+	my $std = shift;
+
+	if ($src and ("$src" ne "$dst")) {
+		if ($std eq "_gb") {
+$code.=<<___;
+			rbit $dst.16b,$src.16b
+___
+		} else {
+$code.=<<___;
+			mov $dst.16b,$src.16b
+___
+		}
+	} else {
+		if ($std eq "_gb") {
+$code.=<<___;
+			rbit $dst.16b,$src.16b
+___
+		}
+	}
+}
+
 sub transpose() {
 	my ($dat0,$dat1,$dat2,$dat3,$vt0,$vt1,$vt2,$vt3) = @_;
 
@@ -75,37 +125,52 @@ $code.=<<___;
 ___
 }
 
+# matrix multiplication Mat*x = (lowerMat*x) ^ (higherMat*x)
+sub mul_matrix() {
+	my $x = shift;
+	my $higherMat = shift;
+	my $lowerMat = shift;
+	my $tmp = shift;
+$code.=<<___;
+	ushr	$tmp.16b, $x.16b, 4
+	and		$x.16b, $x.16b, $ANDMaskV.16b
+	tbl		$x.16b, {$lowerMat.16b}, $x.16b
+	tbl		$tmp.16b, {$higherMat.16b}, $tmp.16b
+	eor		$x.16b, $x.16b, $tmp.16b
+___
+}
+
 # sbox operations for 4-lane of words
+# sbox operation for 4-lane of words
 sub sbox() {
 	my $dat = shift;
 
 $code.=<<___;
-	movi	@vtmp[0].16b,#64
-	movi	@vtmp[1].16b,#128
-	movi	@vtmp[2].16b,#192
-	sub	@vtmp[0].16b,$dat.16b,@vtmp[0].16b
-	sub	@vtmp[1].16b,$dat.16b,@vtmp[1].16b
-	sub	@vtmp[2].16b,$dat.16b,@vtmp[2].16b
-	tbl	$dat.16b,{@sbox[0].16b,@sbox[1].16b,@sbox[2].16b,@sbox[3].16b},$dat.16b
-	tbl	@vtmp[0].16b,{@sbox[4].16b,@sbox[5].16b,@sbox[6].16b,@sbox[7].16b},@vtmp[0].16b
-	tbl	@vtmp[1].16b,{@sbox[8].16b,@sbox[9].16b,@sbox[10].16b,@sbox[11].16b},@vtmp[1].16b
-	tbl	@vtmp[2].16b,{@sbox[12].16b,@sbox[13].16b,@sbox[14].16b,@sbox[15].16b},@vtmp[2].16b
-	add	@vtmp[0].2d,@vtmp[0].2d,@vtmp[1].2d
-	add	@vtmp[2].2d,@vtmp[2].2d,$dat.2d
-	add	$dat.2d,@vtmp[0].2d,@vtmp[2].2d
+	// optimize sbox using AESE instruction
+	tbl	@vtmp[0].16b, {$dat.16b}, $MaskV.16b
+___
+	&mul_matrix(@vtmp[0], $TAHMatV, $TALMatV, $vtmp4);
+$code.=<<___;
+	eor @vtmp[1].16b, @vtmp[1].16b, @vtmp[1].16b
+	aese @vtmp[0].16b,@vtmp[1].16b
+___
+	&mul_matrix(@vtmp[0], $ATAHMatV, $ATALMatV, $vtmp4);
+$code.=<<___;
+	mov	$dat.16b,@vtmp[0].16b
 
+	// linear transformation
 	ushr	@vtmp[0].4s,$dat.4s,32-2
+	ushr	@vtmp[1].4s,$dat.4s,32-10
+	ushr	@vtmp[2].4s,$dat.4s,32-18
+	ushr	@vtmp[3].4s,$dat.4s,32-24
 	sli	@vtmp[0].4s,$dat.4s,2
-	ushr	@vtmp[2].4s,$dat.4s,32-10
-	eor	@vtmp[1].16b,@vtmp[0].16b,$dat.16b
-	sli	@vtmp[2].4s,$dat.4s,10
-	eor	@vtmp[1].16b,@vtmp[2].16b,$vtmp[1].16b
-	ushr	@vtmp[0].4s,$dat.4s,32-18
-	sli	@vtmp[0].4s,$dat.4s,18
-	ushr	@vtmp[2].4s,$dat.4s,32-24
-	eor	@vtmp[1].16b,@vtmp[0].16b,$vtmp[1].16b
-	sli	@vtmp[2].4s,$dat.4s,24
-	eor	$dat.16b,@vtmp[2].16b,@vtmp[1].16b
+	sli	@vtmp[1].4s,$dat.4s,10
+	sli	@vtmp[2].4s,$dat.4s,18
+	sli	@vtmp[3].4s,$dat.4s,24
+	eor	$vtmp4.16b,@vtmp[0].16b,$dat.16b
+	eor	$vtmp4.16b,$vtmp4.16b,$vtmp[1].16b
+	eor	$dat.16b,@vtmp[2].16b,@vtmp[3].16b
+	eor	$dat.16b,$dat.16b,$vtmp4.16b
 ___
 }
 
@@ -115,56 +180,48 @@ sub sbox_double() {
 	my $datx = shift;
 
 $code.=<<___;
-	movi	@vtmp[3].16b,#64
-	sub	@vtmp[0].16b,$dat.16b,@vtmp[3].16b
-	sub	@vtmp[1].16b,@vtmp[0].16b,@vtmp[3].16b
-	sub	@vtmp[2].16b,@vtmp[1].16b,@vtmp[3].16b
-	tbl	$dat.16b,{@sbox[0].16b,@sbox[1].16b,@sbox[2].16b,@sbox[3].16b},$dat.16b
-	tbl	@vtmp[0].16b,{@sbox[4].16b,@sbox[5].16b,@sbox[6].16b,@sbox[7].16b},@vtmp[0].16b
-	tbl	@vtmp[1].16b,{@sbox[8].16b,@sbox[9].16b,@sbox[10].16b,@sbox[11].16b},@vtmp[1].16b
-	tbl	@vtmp[2].16b,{@sbox[12].16b,@sbox[13].16b,@sbox[14].16b,@sbox[15].16b},@vtmp[2].16b
-	add	@vtmp[1].2d,@vtmp[0].2d,@vtmp[1].2d
-	add	$dat.2d,@vtmp[2].2d,$dat.2d
-	add	$dat.2d,@vtmp[1].2d,$dat.2d
+	// optimize sbox using AESE instruction
+	tbl	@vtmp[0].16b, {$dat.16b}, $MaskV.16b
+	tbl	@vtmp[1].16b, {$datx.16b}, $MaskV.16b
+___
+	&mul_matrix(@vtmp[0], $TAHMatV, $TALMatV, $vtmp4);
+	&mul_matrix(@vtmp[1], $TAHMatV, $TALMatV, $vtmp4);
+$code.=<<___;
+	eor $vtmp5.16b, $vtmp5.16b, $vtmp5.16b
+	aese @vtmp[0].16b,$vtmp5.16b
+	aese @vtmp[1].16b,$vtmp5.16b
+___
+	&mul_matrix(@vtmp[0], $ATAHMatV, $ATALMatV,$vtmp4);
+	&mul_matrix(@vtmp[1], $ATAHMatV, $ATALMatV,$vtmp4);
+$code.=<<___;
+	mov	$dat.16b,@vtmp[0].16b
+	mov	$datx.16b,@vtmp[1].16b
 
-	sub	@vtmp[0].16b,$datx.16b,@vtmp[3].16b
-	sub	@vtmp[1].16b,@vtmp[0].16b,@vtmp[3].16b
-	sub	@vtmp[2].16b,@vtmp[1].16b,@vtmp[3].16b
-	tbl	$datx.16b,{@sbox[0].16b,@sbox[1].16b,@sbox[2].16b,@sbox[3].16b},$datx.16b
-	tbl	@vtmp[0].16b,{@sbox[4].16b,@sbox[5].16b,@sbox[6].16b,@sbox[7].16b},@vtmp[0].16b
-	tbl	@vtmp[1].16b,{@sbox[8].16b,@sbox[9].16b,@sbox[10].16b,@sbox[11].16b},@vtmp[1].16b
-	tbl	@vtmp[2].16b,{@sbox[12].16b,@sbox[13].16b,@sbox[14].16b,@sbox[15].16b},@vtmp[2].16b
-	add	@vtmp[1].2d,@vtmp[0].2d,@vtmp[1].2d
-	add	$datx.2d,@vtmp[2].2d,$datx.2d
-	add	$datx.2d,@vtmp[1].2d,$datx.2d
-
+	// linear transformation
 	ushr	@vtmp[0].4s,$dat.4s,32-2
+	ushr	$vtmp5.4s,$datx.4s,32-2
+	ushr	@vtmp[1].4s,$dat.4s,32-10
+	ushr	@vtmp[2].4s,$dat.4s,32-18
+	ushr	@vtmp[3].4s,$dat.4s,32-24
 	sli	@vtmp[0].4s,$dat.4s,2
-	ushr	@vtmp[2].4s,$datx.4s,32-2
-	eor	@vtmp[1].16b,@vtmp[0].16b,$dat.16b
-	sli	@vtmp[2].4s,$datx.4s,2
-
-	ushr	@vtmp[0].4s,$dat.4s,32-10
-	eor	@vtmp[3].16b,@vtmp[2].16b,$datx.16b
-	sli	@vtmp[0].4s,$dat.4s,10
-	ushr	@vtmp[2].4s,$datx.4s,32-10
-	eor	@vtmp[1].16b,@vtmp[0].16b,$vtmp[1].16b
-	sli	@vtmp[2].4s,$datx.4s,10
-
-	ushr	@vtmp[0].4s,$dat.4s,32-18
-	eor	@vtmp[3].16b,@vtmp[2].16b,$vtmp[3].16b
-	sli	@vtmp[0].4s,$dat.4s,18
+	sli	$vtmp5.4s,$datx.4s,2
+	sli	@vtmp[1].4s,$dat.4s,10
+	sli	@vtmp[2].4s,$dat.4s,18
+	sli	@vtmp[3].4s,$dat.4s,24
+	eor	$vtmp4.16b,@vtmp[0].16b,$dat.16b
+	eor	$vtmp4.16b,$vtmp4.16b,@vtmp[1].16b
+	eor	$dat.16b,@vtmp[2].16b,@vtmp[3].16b
+	eor	$dat.16b,$dat.16b,$vtmp4.16b
+	ushr	@vtmp[1].4s,$datx.4s,32-10
 	ushr	@vtmp[2].4s,$datx.4s,32-18
-	eor	@vtmp[1].16b,@vtmp[0].16b,$vtmp[1].16b
+	ushr	@vtmp[3].4s,$datx.4s,32-24
+	sli	@vtmp[1].4s,$datx.4s,10
 	sli	@vtmp[2].4s,$datx.4s,18
-
-	ushr	@vtmp[0].4s,$dat.4s,32-24
-	eor	@vtmp[3].16b,@vtmp[2].16b,$vtmp[3].16b
-	sli	@vtmp[0].4s,$dat.4s,24
-	ushr	@vtmp[2].4s,$datx.4s,32-24
-	eor	$dat.16b,@vtmp[0].16b,@vtmp[1].16b
-	sli	@vtmp[2].4s,$datx.4s,24
+	sli	@vtmp[3].4s,$datx.4s,24
+	eor	$vtmp4.16b,$vtmp5.16b,$datx.16b
+	eor	$vtmp4.16b,$vtmp4.16b,@vtmp[1].16b
 	eor	$datx.16b,@vtmp[2].16b,@vtmp[3].16b
+	eor	$datx.16b,$datx.16b,$vtmp4.16b
 ___
 }
 
@@ -173,28 +230,19 @@ sub sbox_1word () {
 	my $word = shift;
 
 $code.=<<___;
-	movi	@vtmp[1].16b,#64
-	movi	@vtmp[2].16b,#128
-	movi	@vtmp[3].16b,#192
-	mov	@vtmp[0].s[0],$word
+	mov	@vtmp[3].s[0],$word
+	// optimize sbox using AESE instruction
+	tbl	@vtmp[0].16b, {@vtmp[3].16b}, $MaskV.16b
+___
+	&mul_matrix(@vtmp[0], $TAHMatV, $TALMatV, @vtmp[2]);
+$code.=<<___;
+	eor @vtmp[1].16b, @vtmp[1].16b, @vtmp[1].16b
+	aese @vtmp[0].16b,@vtmp[1].16b
+___
+	&mul_matrix(@vtmp[0], $ATAHMatV, $ATALMatV, @vtmp[2]);
+$code.=<<___;
 
-	sub	@vtmp[1].16b,@vtmp[0].16b,@vtmp[1].16b
-	sub	@vtmp[2].16b,@vtmp[0].16b,@vtmp[2].16b
-	sub	@vtmp[3].16b,@vtmp[0].16b,@vtmp[3].16b
-
-	tbl	@vtmp[0].16b,{@sbox[0].16b,@sbox[1].16b,@sbox[2].16b,@sbox[3].16b},@vtmp[0].16b
-	tbl	@vtmp[1].16b,{@sbox[4].16b,@sbox[5].16b,@sbox[6].16b,@sbox[7].16b},@vtmp[1].16b
-	tbl	@vtmp[2].16b,{@sbox[8].16b,@sbox[9].16b,@sbox[10].16b,@sbox[11].16b},@vtmp[2].16b
-	tbl	@vtmp[3].16b,{@sbox[12].16b,@sbox[13].16b,@sbox[14].16b,@sbox[15].16b},@vtmp[3].16b
-
-	mov	$word,@vtmp[0].s[0]
-	mov	$wtmp0,@vtmp[1].s[0]
-	mov	$wtmp2,@vtmp[2].s[0]
-	add	$wtmp0,$word,$wtmp0
-	mov	$word,@vtmp[3].s[0]
-	add	$wtmp0,$wtmp0,$wtmp2
-	add	$wtmp0,$wtmp0,$word
-
+	mov	$wtmp0,@vtmp[0].s[0]
 	eor	$word,$wtmp0,$wtmp0,ror #32-2
 	eor	$word,$word,$wtmp0,ror #32-10
 	eor	$word,$word,$wtmp0,ror #32-18
@@ -427,39 +475,74 @@ sub load_sbox () {
 	my $data = shift;
 
 $code.=<<___;
-	adr	$ptr,.Lsbox
-	ld1	{@sbox[0].16b,@sbox[1].16b,@sbox[2].16b,@sbox[3].16b},[$ptr],#64
-	ld1	{@sbox[4].16b,@sbox[5].16b,@sbox[6].16b,@sbox[7].16b},[$ptr],#64
-	ld1	{@sbox[8].16b,@sbox[9].16b,@sbox[10].16b,@sbox[11].16b},[$ptr],#64
-	ld1	{@sbox[12].16b,@sbox[13].16b,@sbox[14].16b,@sbox[15].16b},[$ptr]
+	ldr $MaskQ,	   =0x0306090c0f0205080b0e0104070a0d00
+	ldr $TAHMatQ,	=0x22581a6002783a4062185a2042387a00
+	ldr $TALMatQ,	=0xc10bb67c4a803df715df62a89e54e923
+	ldr $ATAHMatQ,   =0x1407c6d56c7fbeadb9aa6b78c1d21300
+	ldr $ATALMatQ,   =0xe383c1a1fe9edcbc6404462679195b3b
+	ldr $ANDMaskQ,	=0x0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f
 ___
+}
+
+sub mov_reg_to_vec() {
+	my $src0 = shift;
+	my $src1 = shift;
+	my $desv = shift;
+$code.=<<___;
+	mov $desv.d[0],$src0
+	mov $desv.d[1],$src1
+___
+	&rev32_armeb($desv,$desv);
+}
+
+sub mov_vec_to_reg() {
+	my $srcv = shift;
+	my $des0 = shift;
+	my $des1 = shift;
+$code.=<<___;
+	mov $des0,$srcv.d[0]
+	mov $des1,$srcv.d[1]
+___
+}
+
+sub compute_tweak() {
+	my $src0 = shift;
+	my $src1 = shift;
+	my $des0 = shift;
+	my $des1 = shift;
+$code.=<<___;
+	mov $wtmp0,0x87
+	extr	$xtmp2,$src1,$src1,#32
+	extr	$des1,$src1,$src0,#63
+	and	$wtmp1,$wtmp0,$wtmp2,asr#31
+	eor	$des0,$xtmp1,$src0,lsl#1
+___
+}
+
+sub compute_tweak_vec() {
+	my $src = shift;
+	my $des = shift;
+	my $std = shift;
+	&rbit(@vtmp[2],$src,$std);
+$code.=<<___;
+	ldr  @qtmp[0], =0x01010101010101010101010101010187
+	shl  $des.16b, @vtmp[2].16b, #1
+	ext  @vtmp[1].16b, @vtmp[2].16b, @vtmp[2].16b,#15
+	ushr @vtmp[1].16b, @vtmp[1].16b, #7
+	mul  @vtmp[1].16b, @vtmp[1].16b, @vtmp[0].16b
+	eor  $des.16b, $des.16b, @vtmp[1].16b
+___
+	&rbit($des,$des,$std);
 }
 
 $code=<<___;
 #include "arm_arch.h"
-.arch	armv8-a
+.arch	armv8-a+crypto
 .text
 
-.type	_vpsm4_consts,%object
+.type	_${prefix}_consts,%object
 .align	7
-_vpsm4_consts:
-.Lsbox:
-	.byte 0xD6,0x90,0xE9,0xFE,0xCC,0xE1,0x3D,0xB7,0x16,0xB6,0x14,0xC2,0x28,0xFB,0x2C,0x05
-	.byte 0x2B,0x67,0x9A,0x76,0x2A,0xBE,0x04,0xC3,0xAA,0x44,0x13,0x26,0x49,0x86,0x06,0x99
-	.byte 0x9C,0x42,0x50,0xF4,0x91,0xEF,0x98,0x7A,0x33,0x54,0x0B,0x43,0xED,0xCF,0xAC,0x62
-	.byte 0xE4,0xB3,0x1C,0xA9,0xC9,0x08,0xE8,0x95,0x80,0xDF,0x94,0xFA,0x75,0x8F,0x3F,0xA6
-	.byte 0x47,0x07,0xA7,0xFC,0xF3,0x73,0x17,0xBA,0x83,0x59,0x3C,0x19,0xE6,0x85,0x4F,0xA8
-	.byte 0x68,0x6B,0x81,0xB2,0x71,0x64,0xDA,0x8B,0xF8,0xEB,0x0F,0x4B,0x70,0x56,0x9D,0x35
-	.byte 0x1E,0x24,0x0E,0x5E,0x63,0x58,0xD1,0xA2,0x25,0x22,0x7C,0x3B,0x01,0x21,0x78,0x87
-	.byte 0xD4,0x00,0x46,0x57,0x9F,0xD3,0x27,0x52,0x4C,0x36,0x02,0xE7,0xA0,0xC4,0xC8,0x9E
-	.byte 0xEA,0xBF,0x8A,0xD2,0x40,0xC7,0x38,0xB5,0xA3,0xF7,0xF2,0xCE,0xF9,0x61,0x15,0xA1
-	.byte 0xE0,0xAE,0x5D,0xA4,0x9B,0x34,0x1A,0x55,0xAD,0x93,0x32,0x30,0xF5,0x8C,0xB1,0xE3
-	.byte 0x1D,0xF6,0xE2,0x2E,0x82,0x66,0xCA,0x60,0xC0,0x29,0x23,0xAB,0x0D,0x53,0x4E,0x6F
-	.byte 0xD5,0xDB,0x37,0x45,0xDE,0xFD,0x8E,0x2F,0x03,0xFF,0x6A,0x72,0x6D,0x6C,0x5B,0x51
-	.byte 0x8D,0x1B,0xAF,0x92,0xBB,0xDD,0xBC,0x7F,0x11,0xD9,0x5C,0x41,0x1F,0x10,0x5A,0xD8
-	.byte 0x0A,0xC1,0x31,0x88,0xA5,0xCD,0x7B,0xBD,0x2D,0x74,0xD0,0x12,0xB8,0xE5,0xB4,0xB0
-	.byte 0x89,0x69,0x97,0x4A,0x0C,0x96,0x77,0x7E,0x65,0xB9,0xF1,0x09,0xC5,0x6E,0xC6,0x84
-	.byte 0x18,0xF0,0x7D,0xEC,0x3A,0xDC,0x4D,0x20,0x79,0xEE,0x5F,0x3E,0xD7,0xCB,0x39,0x48
+_${prefix}_consts:
 .Lck:
 	.long 0x00070E15, 0x1C232A31, 0x383F464D, 0x545B6269
 	.long 0x70777E85, 0x8C939AA1, 0xA8AFB6BD, 0xC4CBD2D9
@@ -474,7 +557,7 @@ _vpsm4_consts:
 .Lshuffles:
 	.dword 0x0B0A090807060504,0x030201000F0E0D0C
 
-.size	_vpsm4_consts,.-_vpsm4_consts
+.size	_${prefix}_consts,.-_${prefix}_consts
 ___
 
 {{{
@@ -482,9 +565,9 @@ my ($key,$keys,$enc)=("x0","x1","w2");
 my ($pointer,$schedules,$wtmp,$roundkey)=("x5","x6","w7","w8");
 my ($vkey,$vfk,$vmap)=("v5","v6","v7");
 $code.=<<___;
-.type	_vpsm4_set_key,%function
+.type	_${prefix}_set_key,%function
 .align	4
-_vpsm4_set_key:
+_${prefix}_set_key:
 	AARCH64_VALID_CALL_TARGET
 	ld1	{$vkey.4s},[$key]
 ___
@@ -509,16 +592,18 @@ $code.=<<___;
 	eor	$roundkey,$roundkey,$wtmp
 	mov	$wtmp,$vkey.s[3]
 	eor	$roundkey,$roundkey,$wtmp
-	// sbox lookup
+	// optimize sbox using AESE instruction
 	mov	@data[0].s[0],$roundkey
-	tbl	@vtmp[1].16b,{@sbox[0].16b,@sbox[1].16b,@sbox[2].16b,@sbox[3].16b},@data[0].16b
-	sub	@data[0].16b,@data[0].16b,@vtmp[0].16b
-	tbx	@vtmp[1].16b,{@sbox[4].16b,@sbox[5].16b,@sbox[6].16b,@sbox[7].16b},@data[0].16b
-	sub	@data[0].16b,@data[0].16b,@vtmp[0].16b
-	tbx	@vtmp[1].16b,{@sbox[8].16b,@sbox[9].16b,@sbox[10].16b,@sbox[11].16b},@data[0].16b
-	sub	@data[0].16b,@data[0].16b,@vtmp[0].16b
-	tbx	@vtmp[1].16b,{@sbox[12].16b,@sbox[13].16b,@sbox[14].16b,@sbox[15].16b},@data[0].16b
-	mov	$wtmp,@vtmp[1].s[0]
+	tbl	@vtmp[0].16b, {@data[0].16b}, $MaskV.16b
+___
+	&mul_matrix(@vtmp[0], $TAHMatV, $TALMatV, @vtmp[2]);
+$code.=<<___;
+	eor @vtmp[1].16b, @vtmp[1].16b, @vtmp[1].16b
+	aese @vtmp[0].16b,@vtmp[1].16b
+___
+	&mul_matrix(@vtmp[0], $ATAHMatV, $ATALMatV, @vtmp[2]);
+$code.=<<___;
+	mov	$wtmp,@vtmp[0].s[0]
 	eor	$roundkey,$wtmp,$wtmp,ror #19
 	eor	$roundkey,$roundkey,$wtmp,ror #9
 	mov	$wtmp,$vkey.s[0]
@@ -534,36 +619,36 @@ $code.=<<___;
 	subs	$schedules,$schedules,#1
 	b.ne	1b
 	ret
-.size	_vpsm4_set_key,.-_vpsm4_set_key
+.size	_${prefix}_set_key,.-_${prefix}_set_key
 ___
 }}}
 
 
 {{{
 $code.=<<___;
-.type	_vpsm4_enc_4blks,%function
+.type	_${prefix}_enc_4blks,%function
 .align	4
-_vpsm4_enc_4blks:
+_${prefix}_enc_4blks:
 	AARCH64_VALID_CALL_TARGET
 ___
 	&encrypt_4blks();
 $code.=<<___;
 	ret
-.size	_vpsm4_enc_4blks,.-_vpsm4_enc_4blks
+.size	_${prefix}_enc_4blks,.-_${prefix}_enc_4blks
 ___
 }}}
 
 {{{
 $code.=<<___;
-.type	_vpsm4_enc_8blks,%function
+.type	_${prefix}_enc_8blks,%function
 .align	4
-_vpsm4_enc_8blks:
+_${prefix}_enc_8blks:
 	AARCH64_VALID_CALL_TARGET
 ___
 	&encrypt_8blks();
 $code.=<<___;
 	ret
-.size	_vpsm4_enc_8blks,.-_vpsm4_enc_8blks
+.size	_${prefix}_enc_8blks,.-_${prefix}_enc_8blks
 ___
 }}}
 
@@ -578,7 +663,7 @@ ${prefix}_set_encrypt_key:
 	AARCH64_SIGN_LINK_REGISTER
 	stp	x29,x30,[sp,#-16]!
 	mov	w2,1
-	bl	_vpsm4_set_key
+	bl	_${prefix}_set_key
 	ldp	x29,x30,[sp],#16
 	AARCH64_VALIDATE_LINK_REGISTER
 	ret
@@ -596,7 +681,7 @@ ${prefix}_set_decrypt_key:
 	AARCH64_SIGN_LINK_REGISTER
 	stp	x29,x30,[sp,#-16]!
 	mov	w2,0
-	bl	_vpsm4_set_key
+	bl	_${prefix}_set_key
 	ldp	x29,x30,[sp],#16
 	AARCH64_VALIDATE_LINK_REGISTER
 	ret
@@ -620,7 +705,7 @@ ___
 	&load_sbox();
 	&rev32(@data[0],@data[0]);
 $code.=<<___;
-	mov	$rks,x2
+	mov	$rks,$rk
 ___
 	&encrypt_1blk(@data[0]);
 $code.=<<___;
@@ -634,9 +719,6 @@ ___
 }}}
 
 {{{
-my ($enc) = ("w4");
-my @dat=map("v$_",(16..23));
-
 $code.=<<___;
 .globl	${prefix}_ecb_encrypt
 .type	${prefix}_ecb_encrypt,%function
@@ -668,7 +750,7 @@ ___
 	&rev32(@datax[2],@datax[2]);
 	&rev32(@datax[3],@datax[3]);
 $code.=<<___;
-	bl	_vpsm4_enc_8blks
+	bl	_${prefix}_enc_8blks
 	st4	{@vtmp[0].4s,@vtmp[1].4s,@vtmp[2].4s,@vtmp[3].4s},[$outp],#64
 	st4	{@data[0].4s,@data[1].4s,@data[2].4s,@data[3].4s},[$outp],#64
 	subs	$blocks,$blocks,#8
@@ -684,7 +766,7 @@ ___
 	&rev32(@data[2],@data[2]);
 	&rev32(@data[3],@data[3]);
 $code.=<<___;
-	bl	_vpsm4_enc_4blks
+	bl	_${prefix}_enc_4blks
 	st4	{@vtmp[0].4s,@vtmp[1].4s,@vtmp[2].4s,@vtmp[3].4s},[$outp],#64
 	sub	$blocks,$blocks,#4
 1:
@@ -710,7 +792,7 @@ ___
 	&rev32(@data[2],@data[2]);
 	&rev32(@data[3],@data[3]);
 $code.=<<___;
-	bl	_vpsm4_enc_4blks
+	bl	_${prefix}_enc_4blks
 	st4	{@vtmp[0].s-@vtmp[3].s}[0],[$outp],#16
 	st4	{@vtmp[0].s-@vtmp[3].s}[1],[$outp]
 	b	100f
@@ -722,7 +804,7 @@ ___
 	&rev32(@data[2],@data[2]);
 	&rev32(@data[3],@data[3]);
 $code.=<<___;
-	bl	_vpsm4_enc_4blks
+	bl	_${prefix}_enc_4blks
 	st4	{@vtmp[0].s-@vtmp[3].s}[0],[$outp],#16
 	st4	{@vtmp[0].s-@vtmp[3].s}[1],[$outp],#16
 	st4	{@vtmp[0].s-@vtmp[3].s}[2],[$outp]
@@ -829,7 +911,7 @@ ___
 	&rev32(@datax[2],@datax[2]);
 	&rev32(@datax[3],$datax[3]);
 $code.=<<___;
-	bl	_vpsm4_enc_8blks
+	bl	_${prefix}_enc_8blks
 ___
 	&transpose(@vtmp,@datax);
 	&transpose(@data,@datax);
@@ -866,7 +948,7 @@ ___
 	&rev32(@data[2],@data[2]);
 	&rev32(@data[3],$data[3]);
 $code.=<<___;
-	bl	_vpsm4_enc_4blks
+	bl	_${prefix}_enc_4blks
 	ld1	{@data[0].4s,@data[1].4s,@data[2].4s,@data[3].4s},[$inp],#64
 ___
 	&transpose(@vtmp,@datax);
@@ -908,7 +990,7 @@ ___
 	&rev32(@data[2],@data[2]);
 	&rev32(@data[3],@data[3]);
 $code.=<<___;
-	bl	_vpsm4_enc_4blks
+	bl	_${prefix}_enc_4blks
 	ld1	{@data[0].4s,@data[1].4s},[$inp],#32
 ___
 	&transpose(@vtmp,@datax);
@@ -927,7 +1009,7 @@ ___
 	&rev32(@data[2],@data[2]);
 	&rev32(@data[3],@data[3]);
 $code.=<<___;
-	bl	_vpsm4_enc_4blks
+	bl	_${prefix}_enc_4blks
 	ld1	{@data[0].4s,@data[1].4s,@data[2].4s},[$inp],#48
 ___
 	&transpose(@vtmp,@datax);
@@ -1004,7 +1086,7 @@ $code.=<<___;
 	add	$ctr,$ctr,#1
 	cmp	$blocks,#8
 	b.ge	.Lctr32_8_blocks_process
-	bl	_vpsm4_enc_4blks
+	bl	_${prefix}_enc_4blks
 	ld4	{@vtmpx[0].4s,@vtmpx[1].4s,@vtmpx[2].4s,@vtmpx[3].4s},[$inp],#64
 	eor	@vtmp[0].16b,@vtmp[0].16b,@vtmpx[0].16b
 	eor	@vtmp[1].16b,@vtmp[1].16b,@vtmpx[1].16b
@@ -1026,7 +1108,7 @@ $code.=<<___;
 	add	$ctr,$ctr,#1
 	mov	@datax[3].s[3],$ctr
 	add	$ctr,$ctr,#1
-	bl	_vpsm4_enc_8blks
+	bl	_${prefix}_enc_8blks
 	ld4	{@vtmpx[0].4s,@vtmpx[1].4s,@vtmpx[2].4s,@vtmpx[3].4s},[$inp],#64
 	ld4	{@datax[0].4s,@datax[1].4s,@datax[2].4s,@datax[3].4s},[$inp],#64
 	eor	@vtmp[0].16b,@vtmp[0].16b,@vtmpx[0].16b
@@ -1066,7 +1148,7 @@ $code.=<<___;
 	mov	@data[3].s[1],$ctr
 	subs	$blocks,$blocks,#1
 	b.ne	1f
-	bl	_vpsm4_enc_4blks
+	bl	_${prefix}_enc_4blks
 	ld4	{@vtmpx[0].s,@vtmpx[1].s,@vtmpx[2].s,@vtmpx[3].s}[0],[$inp],#16
 	ld4	{@vtmpx[0].s,@vtmpx[1].s,@vtmpx[2].s,@vtmpx[3].s}[1],[$inp],#16
 	eor	@vtmp[0].16b,@vtmp[0].16b,@vtmpx[0].16b
@@ -1079,7 +1161,7 @@ $code.=<<___;
 1:	// last 3 blocks processing
 	add	$ctr,$ctr,#1
 	mov	@data[3].s[2],$ctr
-	bl	_vpsm4_enc_4blks
+	bl	_${prefix}_enc_4blks
 	ld4	{@vtmpx[0].s,@vtmpx[1].s,@vtmpx[2].s,@vtmpx[3].s}[0],[$inp],#16
 	ld4	{@vtmpx[0].s,@vtmpx[1].s,@vtmpx[2].s,@vtmpx[3].s}[1],[$inp],#16
 	ld4	{@vtmpx[0].s,@vtmpx[1].s,@vtmpx[2].s,@vtmpx[3].s}[2],[$inp],#16
@@ -1101,12 +1183,356 @@ $code.=<<___;
 .size	${prefix}_ctr32_encrypt_blocks,.-${prefix}_ctr32_encrypt_blocks
 ___
 }}}
+
+
+{{{
+my ($blocks,$len)=("x2","x2");
+my $ivp=("x5");
+my @twx=map("x$_",(12..27));
+my ($rks1,$rks2)=("x26","x27");
+my $lastBlk=("x26");
+my $enc=("w28");
+my $remain=("x29");
+
+my @tweak=map("v$_",(16..23));
+my $lastTweak=("v25");
+
+sub gen_xts_cipher() {
+	my $std = shift;
+$code.=<<___;
+.globl	${prefix}_xts_encrypt${std}
+.type	${prefix}_xts_encrypt${std},%function
+.align	5
+${prefix}_xts_encrypt${std}:
+	AARCH64_SIGN_LINK_REGISTER
+	stp	x15, x16, [sp, #-0x10]!
+	stp	x17, x18, [sp, #-0x10]!
+	stp	x19, x20, [sp, #-0x10]!
+	stp	x21, x22, [sp, #-0x10]!
+	stp	x23, x24, [sp, #-0x10]!
+	stp	x25, x26, [sp, #-0x10]!
+	stp	x27, x28, [sp, #-0x10]!
+	stp	x29, x30, [sp, #-0x10]!
+	stp	d8, d9, [sp, #-0x10]!
+	stp	d10, d11, [sp, #-0x10]!
+	stp	d12, d13, [sp, #-0x10]!
+	stp	d14, d15, [sp, #-0x10]!
+	mov	$rks1,x3
+	mov	$rks2,x4
+	mov	$enc,w6
+	ld1	{@tweak[0].4s}, [$ivp]
+	mov	$rks,$rks2
+___
+	&load_sbox();
+	&rev32(@tweak[0],@tweak[0]);
+	&encrypt_1blk(@tweak[0]);
+$code.=<<___;
+	mov	$rks,$rks1
+	and	$remain,$len,#0x0F
+	// convert length into blocks
+	lsr	$blocks,$len,4
+	cmp	$blocks,#1
+	b.lt .return${std}
+
+	cmp $remain,0
+	// If the encryption/decryption Length is N times of 16,
+	// the all blocks are encrypted/decrypted in .xts_encrypt_blocks${std}
+	b.eq .xts_encrypt_blocks${std}
+
+	// If the encryption/decryption length is not N times of 16,
+	// the last two blocks are encrypted/decrypted in .last_2blks_tweak${std} or .only_2blks_tweak${std}
+	// the other blocks are encrypted/decrypted in .xts_encrypt_blocks${std}
+	subs $blocks,$blocks,#1
+	b.eq .only_2blks_tweak${std}
+.xts_encrypt_blocks${std}:
+___
+	&rbit(@tweak[0],@tweak[0],$std);
+	&rev32_armeb(@tweak[0],@tweak[0]);
+	&mov_vec_to_reg(@tweak[0],@twx[0],@twx[1]);
+	&compute_tweak(@twx[0],@twx[1],@twx[2],@twx[3]);
+	&compute_tweak(@twx[2],@twx[3],@twx[4],@twx[5]);
+	&compute_tweak(@twx[4],@twx[5],@twx[6],@twx[7]);
+	&compute_tweak(@twx[6],@twx[7],@twx[8],@twx[9]);
+	&compute_tweak(@twx[8],@twx[9],@twx[10],@twx[11]);
+	&compute_tweak(@twx[10],@twx[11],@twx[12],@twx[13]);
+	&compute_tweak(@twx[12],@twx[13],@twx[14],@twx[15]);
+$code.=<<___;
+.Lxts_8_blocks_process${std}:
+	cmp	$blocks,#8
+___
+	&mov_reg_to_vec(@twx[0],@twx[1],@tweak[0]);
+	&compute_tweak(@twx[14],@twx[15],@twx[0],@twx[1]);
+	&mov_reg_to_vec(@twx[2],@twx[3],@tweak[1]);
+	&compute_tweak(@twx[0],@twx[1],@twx[2],@twx[3]);
+	&mov_reg_to_vec(@twx[4],@twx[5],@tweak[2]);
+	&compute_tweak(@twx[2],@twx[3],@twx[4],@twx[5]);
+	&mov_reg_to_vec(@twx[6],@twx[7],@tweak[3]);
+	&compute_tweak(@twx[4],@twx[5],@twx[6],@twx[7]);
+	&mov_reg_to_vec(@twx[8],@twx[9],@tweak[4]);
+	&compute_tweak(@twx[6],@twx[7],@twx[8],@twx[9]);
+	&mov_reg_to_vec(@twx[10],@twx[11],@tweak[5]);
+	&compute_tweak(@twx[8],@twx[9],@twx[10],@twx[11]);
+	&mov_reg_to_vec(@twx[12],@twx[13],@tweak[6]);
+	&compute_tweak(@twx[10],@twx[11],@twx[12],@twx[13]);
+	&mov_reg_to_vec(@twx[14],@twx[15],@tweak[7]);
+	&compute_tweak(@twx[12],@twx[13],@twx[14],@twx[15]);
+$code.=<<___;
+	b.lt	.Lxts_4_blocks_process${std}
+	ld1 {@data[0].4s,@data[1].4s,@data[2].4s,@data[3].4s},[$inp],#64
+___
+	&rbit(@tweak[0],@tweak[0],$std);
+	&rbit(@tweak[1],@tweak[1],$std);
+	&rbit(@tweak[2],@tweak[2],$std);
+	&rbit(@tweak[3],@tweak[3],$std);
+$code.=<<___;
+	eor @data[0].16b, @data[0].16b, @tweak[0].16b
+	eor @data[1].16b, @data[1].16b, @tweak[1].16b
+	eor @data[2].16b, @data[2].16b, @tweak[2].16b
+	eor @data[3].16b, @data[3].16b, @tweak[3].16b
+	ld1	{@datax[0].4s,$datax[1].4s,@datax[2].4s,@datax[3].4s},[$inp],#64
+___
+	&rbit(@tweak[4],@tweak[4],$std);
+	&rbit(@tweak[5],@tweak[5],$std);
+	&rbit(@tweak[6],@tweak[6],$std);
+	&rbit(@tweak[7],@tweak[7],$std);
+$code.=<<___;
+	eor @datax[0].16b, @datax[0].16b, @tweak[4].16b
+	eor @datax[1].16b, @datax[1].16b, @tweak[5].16b
+	eor @datax[2].16b, @datax[2].16b, @tweak[6].16b
+	eor @datax[3].16b, @datax[3].16b, @tweak[7].16b
+___
+	&rev32(@data[0],@data[0]);
+	&rev32(@data[1],@data[1]);
+	&rev32(@data[2],@data[2]);
+	&rev32(@data[3],@data[3]);
+	&rev32(@datax[0],@datax[0]);
+	&rev32(@datax[1],@datax[1]);
+	&rev32(@datax[2],@datax[2]);
+	&rev32(@datax[3],@datax[3]);
+	&transpose(@data,@vtmp);
+	&transpose(@datax,@vtmp);
+$code.=<<___;
+	bl	_${prefix}_enc_8blks
+___
+	&transpose(@vtmp,@datax);
+	&transpose(@data,@datax);
+$code.=<<___;
+	eor @vtmp[0].16b, @vtmp[0].16b, @tweak[0].16b
+	eor @vtmp[1].16b, @vtmp[1].16b, @tweak[1].16b
+	eor @vtmp[2].16b, @vtmp[2].16b, @tweak[2].16b
+	eor @vtmp[3].16b, @vtmp[3].16b, @tweak[3].16b
+	eor @data[0].16b, @data[0].16b, @tweak[4].16b
+	eor @data[1].16b, @data[1].16b, @tweak[5].16b
+	eor @data[2].16b, @data[2].16b, @tweak[6].16b
+	eor @data[3].16b, @data[3].16b, @tweak[7].16b
+
+	// save the last tweak
+	mov $lastTweak.16b,@tweak[7].16b
+	st1	{@vtmp[0].4s,@vtmp[1].4s,@vtmp[2].4s,@vtmp[3].4s},[$outp],#64
+	st1	{@data[0].4s,@data[1].4s,@data[2].4s,@data[3].4s},[$outp],#64
+	subs	$blocks,$blocks,#8
+	b.gt	.Lxts_8_blocks_process${std}
+	b	100f
+.Lxts_4_blocks_process${std}:
+	cmp	$blocks,#4
+	b.lt	1f
+	ld1	{@data[0].4s,@data[1].4s,@data[2].4s,@data[3].4s},[$inp],#64
+___
+	&rbit(@tweak[0],@tweak[0],$std);
+	&rbit(@tweak[1],@tweak[1],$std);
+	&rbit(@tweak[2],@tweak[2],$std);
+	&rbit(@tweak[3],@tweak[3],$std);
+$code.=<<___;
+	eor @data[0].16b, @data[0].16b, @tweak[0].16b
+	eor @data[1].16b, @data[1].16b, @tweak[1].16b
+	eor @data[2].16b, @data[2].16b, @tweak[2].16b
+	eor @data[3].16b, @data[3].16b, @tweak[3].16b
+___
+	&rev32(@data[0],@data[0]);
+	&rev32(@data[1],@data[1]);
+	&rev32(@data[2],@data[2]);
+	&rev32(@data[3],@data[3]);
+	&transpose(@data,@vtmp);
+$code.=<<___;
+	bl	_${prefix}_enc_4blks
+___
+	&transpose(@vtmp,@data);
+$code.=<<___;
+	eor @vtmp[0].16b, @vtmp[0].16b, @tweak[0].16b
+	eor @vtmp[1].16b, @vtmp[1].16b, @tweak[1].16b
+	eor @vtmp[2].16b, @vtmp[2].16b, @tweak[2].16b
+	eor @vtmp[3].16b, @vtmp[3].16b, @tweak[3].16b
+	st1	{@vtmp[0].4s,@vtmp[1].4s,@vtmp[2].4s,@vtmp[3].4s},[$outp],#64
+	sub	$blocks,$blocks,#4
+	mov @tweak[0].16b,@tweak[4].16b
+	mov @tweak[1].16b,@tweak[5].16b
+	mov @tweak[2].16b,@tweak[6].16b
+	// save the last tweak
+	mov $lastTweak.16b,@tweak[3].16b
+1:
+	// process last block
+	cmp	$blocks,#1
+	b.lt	100f
+	b.gt	1f
+	ld1	{@data[0].4s},[$inp],#16
+___
+	&rbit(@tweak[0],@tweak[0],$std);
+$code.=<<___;
+	eor @data[0].16b, @data[0].16b, @tweak[0].16b
+___
+	&rev32(@data[0],@data[0]);
+	&encrypt_1blk(@data[0]);
+$code.=<<___;
+	eor @data[0].16b, @data[0].16b, @tweak[0].16b
+	st1	{@data[0].4s},[$outp],#16
+	// save the last tweak
+	mov $lastTweak.16b,@tweak[0].16b
+	b	100f
+1:  // process last 2 blocks
+	cmp	$blocks,#2
+	b.gt	1f
+	ld1	{@data[0].4s,@data[1].4s},[$inp],#32
+___
+	&rbit(@tweak[0],@tweak[0],$std);
+	&rbit(@tweak[1],@tweak[1],$std);
+$code.=<<___;
+	eor @data[0].16b, @data[0].16b, @tweak[0].16b
+	eor @data[1].16b, @data[1].16b, @tweak[1].16b
+___
+	&rev32(@data[0],@data[0]);
+	&rev32(@data[1],@data[1]);
+	&transpose(@data,@vtmp);
+$code.=<<___;
+	bl	_${prefix}_enc_4blks
+___
+	&transpose(@vtmp,@data);
+$code.=<<___;
+	eor @vtmp[0].16b, @vtmp[0].16b, @tweak[0].16b
+	eor @vtmp[1].16b, @vtmp[1].16b, @tweak[1].16b
+	st1	{@vtmp[0].4s,@vtmp[1].4s},[$outp],#32
+	// save the last tweak
+	mov $lastTweak.16b,@tweak[1].16b
+	b	100f
+1:  // process last 3 blocks
+	ld1	{@data[0].4s,@data[1].4s,@data[2].4s},[$inp],#48
+___
+	&rbit(@tweak[0],@tweak[0],$std);
+	&rbit(@tweak[1],@tweak[1],$std);
+	&rbit(@tweak[2],@tweak[2],$std);
+$code.=<<___;
+	eor @data[0].16b, @data[0].16b, @tweak[0].16b
+	eor @data[1].16b, @data[1].16b, @tweak[1].16b
+	eor @data[2].16b, @data[2].16b, @tweak[2].16b
+___
+	&rev32(@data[0],@data[0]);
+	&rev32(@data[1],@data[1]);
+	&rev32(@data[2],@data[2]);
+	&transpose(@data,@vtmp);
+$code.=<<___;
+	bl	_${prefix}_enc_4blks
+___
+	&transpose(@vtmp,@data);
+$code.=<<___;
+	eor @vtmp[0].16b, @vtmp[0].16b, @tweak[0].16b
+	eor @vtmp[1].16b, @vtmp[1].16b, @tweak[1].16b
+	eor @vtmp[2].16b, @vtmp[2].16b, @tweak[2].16b
+	st1	{@vtmp[0].4s,@vtmp[1].4s,@vtmp[2].4s},[$outp],#48
+	// save the last tweak
+	mov $lastTweak.16b,@tweak[2].16b
+100:
+	cmp $remain,0
+	b.eq .return${std}
+
+// This brance calculates the last two tweaks, 
+// while the encryption/decryption length is larger than 32
+.last_2blks_tweak${std}:
+___
+	&rev32_armeb($lastTweak,$lastTweak);
+	&compute_tweak_vec($lastTweak,@tweak[1],$std);
+	&compute_tweak_vec(@tweak[1],@tweak[2],$std);
+$code.=<<___;
+	b .check_dec${std}
+
+
+// This brance calculates the last two tweaks, 
+// while the encryption/decryption length is equal to 32, who only need two tweaks
+.only_2blks_tweak${std}:
+	mov @tweak[1].16b,@tweak[0].16b
+___
+	&rev32_armeb(@tweak[1],@tweak[1]);
+	&compute_tweak_vec(@tweak[1],@tweak[2]);
+$code.=<<___;
+	b .check_dec${std}
+
+
+// Determine whether encryption or decryption is required.
+// The last two tweaks need to be swapped for decryption.
+.check_dec${std}:
+	// encryption:1 decryption:0
+	cmp $enc,1
+	b.eq .prcess_last_2blks${std}
+	mov @vtmp[0].16B,@tweak[1].16b
+	mov @tweak[1].16B,@tweak[2].16b
+	mov @tweak[2].16B,@vtmp[0].16b
+
+.prcess_last_2blks${std}:
+___
+	&rev32_armeb(@tweak[1],@tweak[1]);
+	&rev32_armeb(@tweak[2],@tweak[2]);
+$code.=<<___;
+	ld1	{@data[0].4s},[$inp],#16
+	eor @data[0].16b, @data[0].16b, @tweak[1].16b
+___
+	&rev32(@data[0],@data[0]);
+	&encrypt_1blk(@data[0]);
+$code.=<<___;
+	eor @data[0].16b, @data[0].16b, @tweak[1].16b
+	st1	{@data[0].4s},[$outp],#16
+
+	sub $lastBlk,$outp,16
+	.loop${std}:
+		subs $remain,$remain,1
+		ldrb	$wtmp0,[$lastBlk,$remain]
+		ldrb	$wtmp1,[$inp,$remain]
+		strb	$wtmp1,[$lastBlk,$remain]
+		strb	$wtmp0,[$outp,$remain]
+	b.gt .loop${std}
+	ld1		{@data[0].4s}, [$lastBlk]	
+	eor @data[0].16b, @data[0].16b, @tweak[2].16b
+___
+	&rev32(@data[0],@data[0]);
+	&encrypt_1blk(@data[0]);
+$code.=<<___;
+	eor @data[0].16b, @data[0].16b, @tweak[2].16b
+	st1		{@data[0].4s}, [$lastBlk]
+.return${std}:
+	ldp		d14, d15, [sp], #0x10
+	ldp		d12, d13, [sp], #0x10
+	ldp		d10, d11, [sp], #0x10
+	ldp		d8, d9, [sp], #0x10
+	ldp		x29, x30, [sp], #0x10
+	ldp		x27, x28, [sp], #0x10
+	ldp		x25, x26, [sp], #0x10
+	ldp		x23, x24, [sp], #0x10
+	ldp		x21, x22, [sp], #0x10
+	ldp		x19, x20, [sp], #0x10
+	ldp		x17, x18, [sp], #0x10
+	ldp		x15, x16, [sp], #0x10
+	AARCH64_VALIDATE_LINK_REGISTER
+	ret
+.size	${prefix}_xts_encrypt${standard},.-${prefix}_xts_encrypt${standard}
+___
+} # end of gen_xts_cipher
+&gen_xts_cipher("_gb");
+&gen_xts_cipher("");
+}}}
+
 ########################################
 open SELF,$0;
 while(<SELF>) {
-        next if (/^#!/);
-        last if (!s/^#/\/\// and !/^$/);
-        print;
+		next if (/^#!/);
+		last if (!s/^#/\/\// and !/^$/);
+		print;
 }
 close SELF;
 

--- a/crypto/sm4/build.info
+++ b/crypto/sm4/build.info
@@ -2,7 +2,7 @@ LIBS=../../libcrypto
 
 IF[{- !$disabled{asm} -}]
   $SM4DEF_aarch64=SM4_ASM VPSM4_ASM
-  $SM4ASM_aarch64=sm4-armv8.S vpsm4-armv8.S
+  $SM4ASM_aarch64=sm4-armv8.S vpsm4-armv8.S vpsm4_ex-armv8.S
 
   # Now that we have defined all the arch specific variables, use the
   # appropriate one, and define the appropriate macros
@@ -30,5 +30,7 @@ ENDIF
 
 GENERATE[sm4-armv8.S]=asm/sm4-armv8.pl
 GENERATE[vpsm4-armv8.S]=asm/vpsm4-armv8.pl
+GENERATE[vpsm4_ex-armv8.S]=asm/vpsm4_ex-armv8.pl
 INCLUDE[sm4-armv8.o]=..
 INCLUDE[vpsm4-armv8.o]=..
+INCLUDE[vpsm4_ex-armv8.o]=..

--- a/include/crypto/sm4_platform.h
+++ b/include/crypto/sm4_platform.h
@@ -25,6 +25,7 @@ static inline int vpsm4_capable(void)
 }
 #    if defined(VPSM4_ASM)
 #     define VPSM4_CAPABLE vpsm4_capable()
+#     define VPSM4_EX_CAPABLE (vpsm4_capable() && (OPENSSL_armcap_P & ARMV8_AES))
 #    endif
 #    define HWSM4_CAPABLE (OPENSSL_armcap_P & ARMV8_SM4)
 #    define HWSM4_set_encrypt_key sm4_v8_set_encrypt_key
@@ -56,7 +57,7 @@ void HWSM4_ctr32_encrypt_blocks(const unsigned char *in, unsigned char *out,
                                 const unsigned char ivec[16]);
 # endif /* HWSM4_CAPABLE */
 
-#ifdef VPSM4_CAPABLE
+# ifdef VPSM4_CAPABLE
 int vpsm4_set_encrypt_key(const unsigned char *userKey, SM4_KEY *key);
 int vpsm4_set_decrypt_key(const unsigned char *userKey, SM4_KEY *key);
 void vpsm4_encrypt(const unsigned char *in, unsigned char *out,
@@ -74,5 +75,28 @@ void vpsm4_ctr32_encrypt_blocks(const unsigned char *in, unsigned char *out,
                                 const unsigned char ivec[16]);
 # endif /* VPSM4_CAPABLE */
 
+# ifdef VPSM4_EX_CAPABLE
+int vpsm4_ex_set_encrypt_key(const unsigned char *userKey, SM4_KEY *key);
+int vpsm4_ex_set_decrypt_key(const unsigned char *userKey, SM4_KEY *key);
+void vpsm4_ex_encrypt(const unsigned char *in, unsigned char *out,
+                      const SM4_KEY *key);
+void vpsm4_ex_decrypt(const unsigned char *in, unsigned char *out,
+                      const SM4_KEY *key);
+void vpsm4_ex_cbc_encrypt(const unsigned char *in, unsigned char *out,
+                          size_t length, const SM4_KEY *key,
+                          unsigned char *ivec, const int enc);
+void vpsm4_ex_ecb_encrypt(const unsigned char *in, unsigned char *out,
+                          size_t length, const SM4_KEY *key,
+                          const int enc);
+void vpsm4_ex_ctr32_encrypt_blocks(const unsigned char *in, unsigned char *out,
+                                   size_t len, const void *key,
+                                   const unsigned char ivec[16]);
+void vpsm4_ex_xts_encrypt(const unsigned char *in, unsigned char *out,
+                          size_t len, const SM4_KEY *key1, const SM4_KEY *key2,
+                          const unsigned char ivec[16], const int enc);
+void vpsm4_ex_xts_encrypt_gb(const unsigned char *in, unsigned char *out,
+                          size_t len, const SM4_KEY *key1, const SM4_KEY *key2,
+                          const unsigned char ivec[16], const int enc);
+# endif /* VPSM4_EX_CAPABLE */
 
 #endif /* OSSL_SM4_PLATFORM_H */

--- a/providers/implementations/ciphers/cipher_sm4_hw.c
+++ b/providers/implementations/ciphers/cipher_sm4_hw.c
@@ -42,6 +42,19 @@ static int cipher_hw_sm4_initkey(PROV_CIPHER_CTX *ctx,
             (void)0;            /* terminate potentially open 'else' */
         } else
 #endif
+#ifdef VPSM4_EX_CAPABLE
+        if (VPSM4_EX_CAPABLE) {
+            vpsm4_ex_set_encrypt_key(key, ks);
+            ctx->block = (block128_f)vpsm4_ex_encrypt;
+            ctx->stream.cbc = NULL;
+            if (ctx->mode == EVP_CIPH_CBC_MODE)
+                ctx->stream.cbc = (cbc128_f)vpsm4_ex_cbc_encrypt;
+            else if (ctx->mode == EVP_CIPH_ECB_MODE)
+                ctx->stream.ecb = (ecb128_f)vpsm4_ex_ecb_encrypt;
+            else if (ctx->mode == EVP_CIPH_CTR_MODE)
+                ctx->stream.ctr = (ctr128_f)vpsm4_ex_ctr32_encrypt_blocks;
+        } else
+#endif
 #ifdef VPSM4_CAPABLE
         if (VPSM4_CAPABLE) {
             vpsm4_set_encrypt_key(key, ks);
@@ -73,6 +86,17 @@ static int cipher_hw_sm4_initkey(PROV_CIPHER_CTX *ctx,
             if (ctx->mode == EVP_CIPH_ECB_MODE)
                 ctx->stream.ecb = (ecb128_f)HWSM4_ecb_encrypt;
 #endif
+        } else
+#endif
+#ifdef VPSM4_EX_CAPABLE
+        if (VPSM4_EX_CAPABLE) {
+            vpsm4_ex_set_decrypt_key(key, ks);
+            ctx->block = (block128_f)vpsm4_ex_decrypt;
+            ctx->stream.cbc = NULL;
+            if (ctx->mode == EVP_CIPH_CBC_MODE)
+                ctx->stream.cbc = (cbc128_f)vpsm4_ex_cbc_encrypt;
+        else if (ctx->mode == EVP_CIPH_ECB_MODE)
+                ctx->stream.ecb = (ecb128_f)vpsm4_ex_ecb_encrypt;
         } else
 #endif
 #ifdef VPSM4_CAPABLE

--- a/providers/implementations/ciphers/cipher_sm4_xts.c
+++ b/providers/implementations/ciphers/cipher_sm4_xts.c
@@ -145,14 +145,14 @@ static int sm4_xts_cipher(void *vctx, unsigned char *out, size_t *outl,
     if (ctx->xts_standard) {
         if (ctx->stream != NULL)
             (*ctx->stream)(in, out, inl, ctx->xts.key1, ctx->xts.key2,
-                           ctx->base.iv);
+                           ctx->base.iv, ctx->base.enc);
         else if (CRYPTO_xts128_encrypt(&ctx->xts, ctx->base.iv, in, out, inl,
                                        ctx->base.enc))
             return 0;
     } else {
         if (ctx->stream_gb != NULL)
             (*ctx->stream_gb)(in, out, inl, ctx->xts.key1, ctx->xts.key2,
-                              ctx->base.iv);
+                              ctx->base.iv, ctx->base.enc);
         else if (ossl_crypto_xts128gb_encrypt(&ctx->xts, ctx->base.iv, in, out,
                                               inl, ctx->base.enc))
             return 0;

--- a/providers/implementations/ciphers/cipher_sm4_xts.h
+++ b/providers/implementations/ciphers/cipher_sm4_xts.h
@@ -14,7 +14,7 @@
 PROV_CIPHER_FUNC(void, xts_stream,
                  (const unsigned char *in, unsigned char *out, size_t len,
                   const SM4_KEY *key1, const SM4_KEY *key2,
-                  const unsigned char iv[16]));
+                  const unsigned char iv[16], const int enc));
 
 typedef struct prov_sm4_xts_ctx_st {
     /* Must be first */


### PR DESCRIPTION
This patch optimizes SM4 for ARM processor using ASIMD and AES HW instruction, which is an optional feature of
crypto extension for ARMv8-A.

This optimization is based on existing ASIMD implementation (i.e., vpsm4-armv8.pl). Similarly, it also improve performance if both of following conditions are met:
1) Input data equal to or more than 4 blocks;
2) Cipher mode allows parallelism, including ECB, CTR, GCM or CBC decryption

For more details about the theory, see [sm4ni](https://github.com/mjosaarinen/sm4ni). The constants used in subroutine `load_sbox` are from [this blog](https://www.cnblogs.com/kentle/p/15826075.html). We've done some further optimizations so the constants don't look the same.

The performance data on Kunpeng-920 2.6GHz hardware is as follows. The vpsm4_ex-armv8.pl is improved by about 16% compared with vpsm4-armv8.pl and 140%~160% compared with sm4.c. As for single block input data, performance could drop about 50%.

sm4.c
 type             16 bytes     64 bytes    256 bytes   1024 bytes   8192 bytes  16384 bytes
SM4-ECB          80407.14k    85300.06k    85868.24k    86763.97k    86715.05k    86775.13k
SM4-CBC          77752.78k    80713.71k    81698.56k    82142.27k    82004.65k    82056.53k
SM4-CBC          76679.58k    82742.53k    84521.56k    85360.16k    85281.45k    85536.54k
SM4-CTR          75415.10k    78762.37k    79654.66k    80073.03k    79943.00k    80210.37k
SM4-XTS          39961.43k    64757.93k    76031.74k    79360.34k    80618.60k    80303.45k
SM4-CFB          77561.46k    80984.51k    81551.03k    81826.47k    82374.81k    82029.59k
SM4-OFB          77704.14k    81598.04k    82886.89k    82812.59k    83613.38k    82935.81k

vpsm4-armv8.pl
 type             16 bytes     64 bytes    256 bytes   1024 bytes   8192 bytes  16384 bytes
SM4-ECB          35425.95k   122996.12k   175135.34k   177286.49k   178211.50k   178266.72k
SM4-CBC          35538.75k    36535.89k    36425.55k    36748.93k    36541.78k    36484.64k
SM4-CBC          35657.63k   122078.85k   174190.76k   176717.06k   176949.93k   177308.85k
SM4-CTR          35683.95k   120279.59k   176395.86k   177032.08k   177991.06k   177629.87k
SM4-XTS          17801.13k    28802.15k    33827.48k    35345.12k    35919.19k    35935.57k
SM4-CFB          35478.46k    35681.64k    36060.73k    35748.18k    35806.44k    35655.75k
SM4-OFB          35562.41k    35804.29k    35923.59k    36177.24k    36324.26k    36164.95k

vpsm4_ex-armv8.pl
 type             16 bytes     64 bytes    256 bytes   1024 bytes   8192 bytes  16384 bytes
SM4-ECB          32092.50k   116268.76k   205334.59k   207700.42k   207833.77k   208569.96k
SM4-CBC          32175.81k    32750.21k    32736.51k    32762.88k    32863.89k    32619.55k
SM4-CBC          31912.62k   115407.54k   202925.74k   205583.36k   207293.22k   206684.16k
SM4-CTR          32049.50k   114071.89k   205088.28k   206120.62k   206561.28k   207457.61k
SM4-XTS          15978.03k    60165.70k   147150.85k   188738.22k   205923.32k   206597.31k
SM4-CFB          31816.47k    32057.11k    32239.30k    32148.48k    32288.54k    32178.18k
SM4-OFB          31876.35k    32269.23k    32510.29k    32431.10k    32456.70k    32565.25k

Signed-off-by: Xu Yizhou <xuyizhou1@huawei.com>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
