### PR TITLE
ec_kmgmt.c: check the return of BN_CTX_get() in time.

### DIFF
--- a/providers/implementations/keymgmt/ec_kmgmt.c
+++ b/providers/implementations/keymgmt/ec_kmgmt.c
@@ -161,6 +161,8 @@ int key_to_params(const EC_KEY *eckey, OSSL_PARAM_BLD *tmpl,
                 x = BN_CTX_get(bnctx);
             if (py != NULL)
                 y = BN_CTX_get(bnctx);
+            if (x == NULL && y == NULL)
+                goto err;
 
             if (!EC_POINT_get_affine_coordinates(ecg, pub_point, x, y, bnctx))
                 goto err;

--- a/providers/implementations/keymgmt/ec_kmgmt.c
+++ b/providers/implementations/keymgmt/ec_kmgmt.c
@@ -157,12 +157,16 @@ int key_to_params(const EC_KEY *eckey, OSSL_PARAM_BLD *tmpl,
                 goto err;
         }
         if (px != NULL || py != NULL) {
-            if (px != NULL)
+            if (px != NULL) {
                 x = BN_CTX_get(bnctx);
-            if (py != NULL)
+                if (x == NULL)
+                    goto err;
+            }
+            if (py != NULL) {
                 y = BN_CTX_get(bnctx);
-            if (x == NULL && y == NULL)
-                goto err;
+                if (y == NULL)
+                    goto err;
+            }
 
             if (!EC_POINT_get_affine_coordinates(ecg, pub_point, x, y, bnctx))
                 goto err;


### PR DESCRIPTION
If x and y are all NULL, then it is unnecessary to do subsequent operations.
Therefore, this PR adds two checks for the return of BN_CTX_get() in time.