### PR TITLE
Calculate TLS RTT and allow its retreival

### DIFF
--- a/include/openssl/ssl.h.in
+++ b/include/openssl/ssl.h.in
@@ -1134,6 +1134,7 @@ size_t SSL_get_peer_finished(const SSL *s, void *buf, size_t count);
                 SSL_CIPHER_get_version(SSL_get_current_cipher(s))
 # define SSL_get_cipher_name(s) \
                 SSL_CIPHER_get_name(SSL_get_current_cipher(s))
+# define SSL_get_rtt(a)          SSL_SESSION_get_rtt(a)
 # define SSL_get_time(a)         SSL_SESSION_get_time(a)
 # define SSL_set_time(a,b)       SSL_SESSION_set_time((a),(b))
 # define SSL_get_timeout(a)      SSL_SESSION_get_timeout(a)
@@ -1674,6 +1675,7 @@ __owur const char *SSL_state_string(const SSL *s);
 __owur const char *SSL_rstate_string(const SSL *s);
 __owur const char *SSL_state_string_long(const SSL *s);
 __owur const char *SSL_rstate_string_long(const SSL *s);
+__owur long SSL_SESSION_get_rtt(const SSL_SESSION *s);
 __owur long SSL_SESSION_get_time(const SSL_SESSION *s);
 __owur long SSL_SESSION_set_time(SSL_SESSION *s, long t);
 __owur long SSL_SESSION_get_timeout(const SSL_SESSION *s);

--- a/ssl/ssl_local.h
+++ b/ssl/ssl_local.h
@@ -603,6 +603,7 @@ struct ssl_session_st {
     CRYPTO_REF_COUNT references;
     OSSL_TIME timeout;
     OSSL_TIME time;
+    OSSL_TIME rtt;
     OSSL_TIME calc_timeout;
     unsigned int compress_meth; /* Need to lookup the method */
     const SSL_CIPHER *cipher;

--- a/ssl/ssl_sess.c
+++ b/ssl/ssl_sess.c
@@ -916,6 +916,13 @@ long SSL_SESSION_get_time(const SSL_SESSION *s)
     return (long)ossl_time_to_time_t(s->time);
 }
 
+long SSL_SESSION_get_rtt(const SSL_SESSION *s) // return rtt in microseconds. Matches the units of nginx's $tcpinfo_rtt
+{
+    if (s == NULL)
+        return 0;
+    return (long)ossl_time2us(s->rtt);
+}
+
 long SSL_SESSION_set_time(SSL_SESSION *s, long t)
 {
     OSSL_TIME new_time = ossl_time_from_time_t((time_t)t);


### PR DESCRIPTION
Calculate TLS round trip time finding the difference between two times recorded in the handshake
Save TLS RTT in Session Object
Facilitate retrieval of TLS RTT through `SESSION_get_rtt` function