### PR TITLE
fix possible divide by zero bug

### DIFF
--- a/ssl/record/methods/ssl3_meth.c
+++ b/ssl/record/methods/ssl3_meth.c
@@ -221,7 +221,7 @@ static int ssl3_mac(OSSL_RECORD_LAYER *rl, TLS_RL_RECORD *rec, unsigned char *md
     hash = rl->md_ctx;
 
     t = EVP_MD_CTX_get_size(hash);
-    if (t < 0)
+    if (t <= 0)
         return 0;
     md_size = t;
     npad = (48 / md_size) * md_size;


### PR DESCRIPTION
In the file ssl/record/methods/ssl3_meth.c, the function ssl3_mac has the following code：

```
t = EVP_MD_CTX_get_size(hash);
if (t < 0)
    return 0;
md_size = t;
npad = (48 / md_size) * md_size;
```

The variable md_size is used as a divisor. Since the code explicitly checks whether u is negative, I think it should also avoid the case when md_size=0 to prevent divide by zero bugs.