### PR TITLE
Fix BIO_f_cipher flushing and other BIO related fixes

### DIFF
--- a/crypto/asn1/asn_mime.c
+++ b/crypto/asn1/asn_mime.c
@@ -515,6 +515,7 @@ int SMIME_crlf_copy(BIO *in, BIO *out, int flags)
     char eol;
     int len;
     char linebuf[MAX_SMLEN];
+    int ret;
     /*
      * Buffer output so we don't write one line at a time. This is useful
      * when streaming as we don't end up with one OCTET STRING per line.
@@ -552,9 +553,12 @@ int SMIME_crlf_copy(BIO *in, BIO *out, int flags)
             }
         }
     }
-    (void)BIO_flush(out);
+    ret = BIO_flush(out);
     BIO_pop(out);
     BIO_free(bf);
+    if (ret <= 0)
+        return 0;
+
     return 1;
 }
 

--- a/crypto/asn1/bio_asn1.c
+++ b/crypto/asn1/bio_asn1.c
@@ -172,7 +172,7 @@ static int asn1_bio_write(BIO *b, const char *in, int inl)
         case ASN1_STATE_START:
             if (!asn1_bio_setup_ex(b, ctx, ctx->prefix,
                                    ASN1_STATE_PRE_COPY, ASN1_STATE_HEADER))
-                return 0;
+                return -1;
             break;
 
             /* Copy any pre data first */
@@ -189,7 +189,7 @@ static int asn1_bio_write(BIO *b, const char *in, int inl)
         case ASN1_STATE_HEADER:
             ctx->buflen = ASN1_object_size(0, inl, ctx->asn1_tag) - inl;
             if (!ossl_assert(ctx->buflen <= ctx->bufsize))
-                return 0;
+                return -1;
             p = ctx->buf;
             ASN1_put_object(&p, 0, inl, ctx->asn1_tag, ctx->asn1_class);
             ctx->copylen = inl;

--- a/crypto/cms/cms_enc.c
+++ b/crypto/cms/cms_enc.c
@@ -81,6 +81,10 @@ BIO *ossl_cms_EncryptedContent_init_bio(CMS_EncryptedContentInfo *ec,
 
     if (enc) {
         calg->algorithm = OBJ_nid2obj(EVP_CIPHER_CTX_get_type(ctx));
+        if (calg->algorithm == NULL) {
+            ERR_raise(ERR_LIB_CMS, CMS_R_UNSUPPORTED_CONTENT_ENCRYPTION_ALGORITHM);
+            goto err;
+        }
         /* Generate a random IV if we need one */
         ivlen = EVP_CIPHER_CTX_get_iv_length(ctx);
         if (ivlen < 0) {

--- a/crypto/cms/cms_err.c
+++ b/crypto/cms/cms_err.c
@@ -140,6 +140,8 @@ static const ERR_STRING_DATA CMS_str_reasons[] = {
     {ERR_PACK(ERR_LIB_CMS, 0, CMS_R_UNKNOWN_ID), "unknown id"},
     {ERR_PACK(ERR_LIB_CMS, 0, CMS_R_UNSUPPORTED_COMPRESSION_ALGORITHM),
     "unsupported compression algorithm"},
+    {ERR_PACK(ERR_LIB_CMS, 0, CMS_R_UNSUPPORTED_CONTENT_ENCRYPTION_ALGORITHM),
+    "unsupported content encryption algorithm"},
     {ERR_PACK(ERR_LIB_CMS, 0, CMS_R_UNSUPPORTED_CONTENT_TYPE),
     "unsupported content type"},
     {ERR_PACK(ERR_LIB_CMS, 0, CMS_R_UNSUPPORTED_ENCRYPTION_TYPE),

--- a/crypto/err/openssl.txt
+++ b/crypto/err/openssl.txt
@@ -371,6 +371,8 @@ CMS_R_UNKNOWN_CIPHER:148:unknown cipher
 CMS_R_UNKNOWN_DIGEST_ALGORITHM:149:unknown digest algorithm
 CMS_R_UNKNOWN_ID:150:unknown id
 CMS_R_UNSUPPORTED_COMPRESSION_ALGORITHM:151:unsupported compression algorithm
+CMS_R_UNSUPPORTED_CONTENT_ENCRYPTION_ALGORITHM:194:\
+	unsupported content encryption algorithm
 CMS_R_UNSUPPORTED_CONTENT_TYPE:152:unsupported content type
 CMS_R_UNSUPPORTED_ENCRYPTION_TYPE:192:unsupported encryption type
 CMS_R_UNSUPPORTED_KEK_ALGORITHM:153:unsupported kek algorithm

--- a/crypto/evp/bio_enc.c
+++ b/crypto/evp/bio_enc.c
@@ -297,6 +297,7 @@ static long enc_ctrl(BIO *b, int cmd, long num, void *ptr)
     int i;
     EVP_CIPHER_CTX **c_ctx;
     BIO *next;
+    int pend;
 
     ctx = BIO_get_data(b);
     next = BIO_next(b);
@@ -332,8 +333,14 @@ static long enc_ctrl(BIO *b, int cmd, long num, void *ptr)
         /* do a final write */
  again:
         while (ctx->buf_len != ctx->buf_off) {
+            pend = ctx->buf_len - ctx->buf_off;
             i = enc_write(b, NULL, 0);
-            if (i < 0)
+            /*
+             * i should never be > 0 here because we didn't ask to write any
+             * new data. We stop if we get an error or we failed to make any
+             * progress writing pending data.
+             */
+            if (i < 0 || (ctx->buf_len - ctx->buf_off) == pend)
                 return i;
         }
 

--- a/include/openssl/cmserr.h
+++ b/include/openssl/cmserr.h
@@ -106,6 +106,7 @@
 #  define CMS_R_UNKNOWN_DIGEST_ALGORITHM                   149
 #  define CMS_R_UNKNOWN_ID                                 150
 #  define CMS_R_UNSUPPORTED_COMPRESSION_ALGORITHM          151
+#  define CMS_R_UNSUPPORTED_CONTENT_ENCRYPTION_ALGORITHM   194
 #  define CMS_R_UNSUPPORTED_CONTENT_TYPE                   152
 #  define CMS_R_UNSUPPORTED_ENCRYPTION_TYPE                192
 #  define CMS_R_UNSUPPORTED_KEK_ALGORITHM                  153

--- a/test/bio_memleak_test.c
+++ b/test/bio_memleak_test.c
@@ -261,13 +261,9 @@ static int test_bio_i2d_ASN1_mime(void)
 
     error_callback_fired = 0;
 
-    /*
-     * The call succeeds even if the input stream ends unexpectedly as
-     * there is no handling for this case in SMIME_crlf_copy().
-     */
-    if (!TEST_true(i2d_ASN1_bio_stream(out, (ASN1_VALUE*) p7, bio,
-                                       SMIME_STREAM | SMIME_BINARY,
-                                       ASN1_ITEM_rptr(PKCS7))))
+    if (!TEST_false(i2d_ASN1_bio_stream(out, (ASN1_VALUE*) p7, bio,
+                                        SMIME_STREAM | SMIME_BINARY,
+                                        ASN1_ITEM_rptr(PKCS7))))
         goto finish;
 
     if (!TEST_int_eq(error_callback_fired, 1))

--- a/test/recipes/80-test_cms.t
+++ b/test/recipes/80-test_cms.t
@@ -887,6 +887,24 @@ subtest "CMS Check that bad attributes fail when verifying signers\n" => sub {
     }
 };
 
+subtest "CMS Check that bad encryption algorithm fails\n" => sub {
+    plan tests => 1;
+
+    SKIP: {
+        skip "DES or Legacy isn't supported in this build", 1
+            if disabled("des") || disabled("legacy");
+
+        my $out = "smtst.txt";
+
+        ok(!run(app(["openssl", "cms", @legacyprov, "-encrypt",
+                    "-in", $smcont,
+                    "-stream", "-recip", $smrsa1,
+                    "-des-ede3",
+                    "-out", $out ])),
+           "Decrypt message from OpenSSL 1.1.1");
+    }
+};
+
 subtest "CMS Decrypt message encrypted with OpenSSL 1.1.1\n" => sub {
     plan tests => 1;
 

--- a/test/recipes/80-test_cms.t
+++ b/test/recipes/80-test_cms.t
@@ -50,7 +50,7 @@ my ($no_des, $no_dh, $no_dsa, $no_ec, $no_ec2m, $no_rc2, $no_zlib)
 
 $no_rc2 = 1 if disabled("legacy");
 
-plan tests => 16;
+plan tests => 17;
 
 ok(run(test(["pkcs7_test"])), "test pkcs7");
 


### PR DESCRIPTION
If an error occurs during a flush on a BIO_f_cipher() then in some cases
we could get into an infinite loop. We add a check to make sure we are
making progress during flush and exit if not.

This issue was reported by Octavio Galland who also demonstrated an
infinite loop in CMS encryption as a result of this bug.

The security team has assessed this issue as not a CVE. This occurs on
*encryption* only which is typically processing trusted data. We are not
aware of a way to trigger this with untrusted data.