### PR TITLE
Fix a logic flaw in test_mod_exp_zero

### DIFF
--- a/test/exptest.c
+++ b/test/exptest.c
@@ -49,7 +49,7 @@ static int test_mod_exp_zero(void)
     BIGNUM *r = NULL;
     BN_ULONG one_word = 1;
     BN_CTX *ctx = BN_CTX_new();
-    int ret = 1, failed = 0;
+    int ret = 0, failed = 0;
     BN_MONT_CTX *mont = NULL;
 
     if (!TEST_ptr(m = BN_new())


### PR DESCRIPTION
Due to the logic flaw, possible test failures
in this test case might be ignored.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
