### PR TITLE
Fix how mkerr handles SSLv3 Alerts

### DIFF
--- a/util/mkerr.pl
+++ b/util/mkerr.pl
@@ -567,6 +567,10 @@ EOF
                 $rn =~ tr/_[A-Z]/ [a-z]/;
                 $strings{$i} = $rn;
             }
+            # Handle special case of different text in SSLv3 alerts
+            if ( $i =~ /^SSL_R_SSLV3_ALERT_/) {
+                $rn =~ s/^sslv3/ssl\/tls/;
+            }
             my $short = "    {ERR_PACK($pack_lib, 0, $i), \"$rn\"},";
             if ( length($short) <= 80 ) {
                 print OUT "$short\n";


### PR DESCRIPTION
The SSLV3 alert text is not a directly derived from the name of the alert. Instead, the "sslv3" text is replaced with "ssl/tls".

When doing a `make update` with modified/added errors in the ssl directory, that error text reverts to the default, and looks like an unintentional change which needs to be undone before merging.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
