### PR TITLE
Improve HTTP-based test framework

### DIFF
--- a/test/recipes/80-test_cmp_http_data/Mock/test.cnf
+++ b/test/recipes/80-test_cmp_http_data/Mock/test.cnf
@@ -12,13 +12,12 @@ policies = certificatePolicies
 #policy_oids_critical = 1
 #verbosity = 7
 
-############################# server configurations
+############################# server-dependent configurations
 
 [Mock] # the built-in OpenSSL CMP mock server
 no_check_time = 1
 server_host = 127.0.0.1 # localhost
-# server_port = 0 means that the port is determined by the server
-server_port = 0
+server_port = 0 # 0 means that the port is determined by the server
 server_tls = $server_port
 server_cert = server.crt
 server = $server_host:$server_port


### PR DESCRIPTION
When adding various test cases to `test/recipes/80-test_cmp_http_data/`
I found some issues that are improved here:

* `80-test_cmp_http.t`: fix server port and confusion client vs. server config
* `apps/lib/http_server.c`: improve diagnostics, e.g., on port number already in use

I'm not sure if this should be backported, yet tentatively added the respective tags.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
