### PR TITLE
Document limits on static and dynamic linking for HPE NonStop platforms.

### DIFF
--- a/NOTES-NONSTOP.md
+++ b/NOTES-NONSTOP.md
@@ -44,6 +44,20 @@ instead of `nsx` in the set above.
 You cannot build for TNS/E for FIPS, so you must specify the `no-fips`
 option to `./Configure`.
 
+Linking and Loading Considerations
+----------------------------------
+
+Because of how the NonStop Common Runtime Environment (CRE) works, there are
+restrictions on how programs can link and load with OpenSSL libraries.
+On current NonStop platforms, programs cannot both statically link OpenSSL
+libraries and dynamically load OpenSSL shared libraries concurrently. If this
+is done, there is a high probability of encountering a SIGSEGV condition
+relating to `atexit()` processing when a shared library is unloaded and when
+the program terminates. This limitation applies to all OpenSSL shared library
+components.
+
+A resolution to this situation is under investigation.
+
 About Prefix and OpenSSLDir
 ---------------------------
 


### PR DESCRIPTION
Documentation is necessary as static and dynamic linking cause SIGSEGV during atexit() processing on the platform.

Fixes: #19951

Signed-off-by: Randall S. Becker <randall.becker@nexbridge.ca>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
