### PR TITLE
Fix `OSSL_trace_set_channel` mem management and doc

### DIFF
--- a/crypto/trace.c
+++ b/crypto/trace.c
@@ -304,8 +304,8 @@ static int set_trace_data(int category, int type, BIO **channel,
         trace_channels[category].type = type;
         trace_channels[category].bio = *channel;
         /*
-         * must not be done before setting prefix/suffix, as those may fail,
-         * an then the caller is mislead to free *channel
+         * This must not be done before setting prefix/suffix,
+         * as those may fail, and then the caller is mislead to free *channel.
          */
     }
 

--- a/crypto/trace.c
+++ b/crypto/trace.c
@@ -288,11 +288,6 @@ static int set_trace_data(int category, int type, BIO **channel,
     }
 
     /* Before running callbacks are done, set new data where appropriate */
-    if (channel != NULL && *channel != NULL) {
-        trace_channels[category].type = type;
-        trace_channels[category].bio = *channel;
-    }
-
     if (prefix != NULL && *prefix != NULL) {
         if ((curr_prefix = OPENSSL_strdup(*prefix)) == NULL)
             return 0;
@@ -303,6 +298,15 @@ static int set_trace_data(int category, int type, BIO **channel,
         if ((curr_suffix = OPENSSL_strdup(*suffix)) == NULL)
             return 0;
         trace_channels[category].suffix = curr_suffix;
+    }
+
+    if (channel != NULL && *channel != NULL) {
+        trace_channels[category].type = type;
+        trace_channels[category].bio = *channel;
+        /*
+         * must not be done before setting prefix/suffix, as those may fail,
+         * an then the caller is mislead to free *channel
+         */
     }
 
     /* Finally, run the attach callback on the new data */

--- a/doc/man3/OSSL_trace_set_channel.pod
+++ b/doc/man3/OSSL_trace_set_channel.pod
@@ -47,6 +47,8 @@ can be used for producing free-text trace output.
 
 OSSL_trace_set_channel() is used to enable the given trace C<category>
 by attaching the B<BIO> I<bio> object as (simple) trace channel.
+On success the ownership of the BIO is transferred to the channel,
+so the caller must not free it directly.
 
 OSSL_trace_set_prefix() and OSSL_trace_set_suffix() can be used to add
 an extra line for each channel, to be output before and after group of


### PR DESCRIPTION
Adding tests to #18704,
* I found a bug, which can lead to double free, in the internal function used to implement `OSSL_trace_set_channel()`, fixed here.
* I also found a severe omission in the related documentation, and fixed it here by stating that 
on success `OSSL_trace_set_channel()` it takes ownership of the `bio` parameter.


