### PR TITLE
Fix documented names and return types for some functions and signatures

### DIFF
--- a/doc/man7/provider-decoder.pod
+++ b/doc/man7/provider-decoder.pod
@@ -34,7 +34,7 @@ provider-decoder - The OSSL_DECODER library E<lt>-E<gt> provider functions
                               OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg);
 
  /* Functions to export a decoded object */
- void *OSSL_FUNC_decoder_export_object(void *ctx,
+ int OSSL_FUNC_decoder_export_object(void *ctx,
                                        const void *objref, size_t objref_sz,
                                        OSSL_CALLBACK *export_cb,
                                        void *export_cbarg);
@@ -83,7 +83,7 @@ For example, the "function" OSSL_FUNC_decoder_decode() has these:
                                    int selection,
                                    OSSL_CALLBACK *data_cb, void *data_cbarg,
                                    OSSL_PASSPHRASE_CALLBACK *cb, void *cbarg);
- static ossl_inline OSSL_FUNC_decoder_decode_fn
+ static ossl_inline OSSL_FUNC_decoder_decode_fn*
      OSSL_FUNC_decoder_decode(const OSSL_DISPATCH *opf);
 
 L<OSSL_DISPATCH(3)> arrays are indexed by numbers that are provided as


### PR DESCRIPTION
The macro OSSL_CORE_MAKE_FUNC in core_dispatch.h generates a function, and a corresponding function signature typedef with name ending in "_fn". The typedefed signature is unrelated to the signature of the function. However, provider-decoder.pod describes typedefed signatures generated by the macro, but uses the names of the functions (lacking "_fn") instead of the typedefed signatures, which is a mismatch.

Also, the documented return type of OSSL_FUNC_decoder_export_object_fn is wrong; the correct type is int, due to the following line in core_dispatch.h: OSSL_CORE_MAKE_FUNC(int, decoder_export_object,

Fixes #19543

The documented claim (prior to applying this patch) about OSSL_FUNC_decoder_export_object, etc that "None of these are actual functions" is contradicted by the fact that the code actually calls those functions, and calls them specifically by those names. E.g. in decoder_meth.c:
                decoder->export_object = OSSL_FUNC_decoder_export_object(fns);

The functions are generated by OSSL_CORE_MAKE_FUNC.

The paragraph "None of these are actual functions"... should be replaced by something more like "These function signatures, generated by the OSSL_CORE_MAKE_FUNC macro, are for functions that are offered as function pointers in OSSL_DISPATCH arrays." Somebody else can choose suitable phrasing; this patch only fixes the names and signatures.

Trivial due to just appending "_fn" to documented names, changing a void to an int, and fixing two asterisks.

CLA: trivial

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
