### PR TITLE
Typo fixes

### DIFF
--- a/crypto/ctype.c
+++ b/crypto/ctype.c
@@ -258,7 +258,7 @@ int ossl_ctype_check(int c, unsigned int mask)
 }
 
 /*
- * Implement some of the simplier functions directly to avoid the overhead of
+ * Implement some of the simpler functions directly to avoid the overhead of
  * accessing memory via ctype_char_map[].
  */
 

--- a/doc/designs/quic-design/record-layer.md
+++ b/doc/designs/quic-design/record-layer.md
@@ -564,7 +564,7 @@ struct ossl_record_method_st {
                       const char **longstr);
 
     /*
-     * Set new options or modify ones that were originaly specified in the
+     * Set new options or modify ones that were originally specified in the
      * new_record_layer call.
      */
     int (*set_options)(OSSL_RECORD_LAYER *rl, const OSSL_PARAM *options);

--- a/doc/internal/man3/OSSL_EVENT.pod
+++ b/doc/internal/man3/OSSL_EVENT.pod
@@ -99,7 +99,7 @@ Once populated, the event type, the references to event context, and the
 reference to the destructor function are considered immutable, up until the
 event structure is destroyed.
 
-The reference to the auxilliary identifying material or to the payload,
+The reference to the auxiliary identifying material or to the payload,
 however, are considered mutable.  Any event handler may "steal" them and
 replace the reference to them in the event structure with NULL.  Stealing
 must be done with much care.

--- a/doc/man3/BIO_sendmmsg.pod
+++ b/doc/man3/BIO_sendmmsg.pod
@@ -32,7 +32,7 @@ BIO_err_is_non_fatal - send and receive multiple datagrams in a single call
 =head1 DESCRIPTION
 
 BIO_sendmmsg() and BIO_recvmmsg() functions can be used to send and receive
-multiple messages in a single call to a BIO. They are analagous to sendmmsg(2)
+multiple messages in a single call to a BIO. They are analogous to sendmmsg(2)
 and recvmmsg(2) on operating systems which provide those functions.
 
 The B<BIO_MSG> structure provides a subset of the functionality of the B<struct

--- a/doc/man3/OSSL_CMP_CTX_new.pod
+++ b/doc/man3/OSSL_CMP_CTX_new.pod
@@ -640,7 +640,7 @@ OSSL_CMP_CTX_set_certConf_cb_arg(), or NULL if unset.
 
 OSSL_CMP_CTX_get_status() returns for client contexts the PKIstatus from
 the last received CertRepMessage or Revocation Response or error message:
-=item B<OSSL_CMP_PKISTATUS_accepted> on sucessful receipt of a GENP message:
+=item B<OSSL_CMP_PKISTATUS_accepted> on successful receipt of a GENP message:
 
 =over 4
 

--- a/doc/man3/OSSL_HPKE_CTX_new.pod
+++ b/doc/man3/OSSL_HPKE_CTX_new.pod
@@ -521,7 +521,7 @@ This example demonstrates a minimal round-trip using HPKE.
         if (OSSL_HPKE_seal(sctx, ct, &ctlen, aad, aadlen, pt, ptlen) != 1)
             goto err;
 
-        /* receiver's actions - decrypt data using the recievers private key */
+        /* receiver's actions - decrypt data using the receivers private key */
         if ((rctx = OSSL_HPKE_CTX_new(hpke_mode, hpke_suite,
                                       OSSL_HPKE_ROLE_RECEIVER,
                                       NULL, NULL)) == NULL)

--- a/doc/man7/provider-asym_cipher.pod
+++ b/doc/man7/provider-asym_cipher.pod
@@ -240,7 +240,7 @@ The negotiated TLS protocol version.
 Gets of sets the use of the implicit rejection mechanism for RSA PKCS#1 v1.5
 decryption. When set (non zero value), the decryption API will return
 a deterministically random value if the PKCS#1 v1.5 padding check fails.
-This makes explotation of the Bleichenbacher significantly harder, even
+This makes exploitation of the Bleichenbacher significantly harder, even
 if the code using the RSA decryption API is not implemented in side-channel
 free manner. Set by default.
 

--- a/ssl/record/recordmethod.h
+++ b/ssl/record/recordmethod.h
@@ -286,7 +286,7 @@ struct ossl_record_method_st {
                       const char **longstr);
 
     /*
-     * Set new options or modify ones that were originaly specified in the
+     * Set new options or modify ones that were originally specified in the
      * new_record_layer call.
      */
     int (*set_options)(OSSL_RECORD_LAYER *rl, const OSSL_PARAM *options);

--- a/test/recipes/30-test_evp_data/evppkey_rsa_common.txt
+++ b/test/recipes/30-test_evp_data/evppkey_rsa_common.txt
@@ -489,7 +489,7 @@ Output = 1f037dd717b07d3e7f7359
 
 # The old FIPS provider doesn't include the workaround (#13817)
 FIPSversion = >=3.2.0
-# negative test with otherwise valid padding but a zero byte at the eigth
+# negative test with otherwise valid padding but a zero byte at the eighth
 # byte of padding
 Decrypt = RSA-2048-2
 Input = a7a340675a82c30e22219a55bc07cdf36d47d01834c1834f917f18b517419ce9de2a96460e745024436470ed85e94297b283537d52189c406a3f533cb405cc6a9dba46b482ce98b6e3dd52d8fce2237425617e38c11fbc46b61897ef200d01e4f25f5f6c4c5b38cd0de38ba11908b86595a8036a08a42a3d05b79600a97ac18ba368a08d6cf6ccb624f6e8002afc75599fba4de3d4f3ba7d208391ebe8d21f8282b18e2c10869eb2702e68f9176b42b0ddc9d763f0c86ba0ff92c957aaeab76d9ab8da52ea297ec11d92d770146faa1b300e0f91ef969b53e7d2907ffc984e9a9c9d11fb7d6cba91972059b46506b035efec6575c46d7114a6b935864858445f

--- a/test/recipes/80-test_cms.t
+++ b/test/recipes/80-test_cms.t
@@ -655,7 +655,7 @@ my @smime_cms_param_tests_autodigestmax = (
         "-keyopt", "rsa_padding_mode:pss", "-keyopt", "rsa_pss_saltlen:auto-digestmax",
         "-out", "{output}.cms" ],
       # digest is SHA-512, which produces 64, bytes of output, but an RSA-PSS
-      # signature with a 1024 bit RSA key can only accomodate 62
+      # signature with a 1024 bit RSA key can only accommodate 62
       sub { my %opts = @_; rsapssSaltlen("$opts{output}.cms") == 62; },
       [ "{cmd2}", @defaultprov, "-verify", "-in", "{output}.cms", "-inform", "PEM",
         "-CAfile", $smroot, "-out", "{output}.txt" ],


### PR DESCRIPTION
Fixed typos:
accomodate -> accommodate
analagous -> analogous
auxilliary -> auxiliary
eigth -> eighth
explotation -> exploitation
originaly -> originally
simplier -> simpler
sucessful -> successful
recievers -> receivers

Found with: https://github.com/ss18/grep-typos


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
