### PR TITLE
s390x: Fix keccak xofs via CPACF

### DIFF
--- a/providers/implementations/digests/sha3_prov.c
+++ b/providers/implementations/digests/sha3_prov.c
@@ -182,6 +182,8 @@ static int s390x_keccakc_final(unsigned char *md, void *vctx, int padding)
     KECCAK1600_CTX *ctx = vctx;
     size_t bsz = ctx->block_size;
     size_t num = ctx->bufsz;
+    size_t needed = ctx->md_size;
+    static const unsigned char empty[KECCAK1600_WIDTH / 8] = {0};
 
     if (!ossl_prov_is_running())
         return 0;
@@ -191,7 +193,14 @@ static int s390x_keccakc_final(unsigned char *md, void *vctx, int padding)
     ctx->buf[num] = padding;
     ctx->buf[bsz - 1] |= 0x80;
     s390x_kimd(ctx->buf, bsz, ctx->pad, ctx->A);
-    memcpy(md, ctx->A, ctx->md_size);
+    while (needed > bsz) {
+        memcpy(md, ctx->A, bsz);
+        needed -= bsz;
+        md += bsz;
+        s390x_kimd(empty, bsz, ctx->pad, ctx->A);
+    }
+    memcpy(md, ctx->A, needed);
+    
     return 1;
 }
 


### PR DESCRIPTION
CPACF does not directly support xofs.  Emulate this by using single block operations on an empty input block.

Fixes: affc070aabc9 ("s390x: Optimize kmac")

Signed-off-by: Juergen Christ <jchrist@linux.ibm.com>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist

