### PR TITLE
Update ppccap.c

### DIFF
--- a/crypto/ppccap.c
+++ b/crypto/ppccap.c
@@ -21,6 +21,10 @@
 # if !defined(__power_set)
 #  define __power_set(a) (_system_configuration.implementation & (a))
 # endif
+/* Adding below if condition as __power_set is causing core dump with allow_vmx=0 */
+# if defined(__power_set)
+# undef __power_set
+# endif
 #endif
 #if defined(__APPLE__) && defined(__MACH__)
 # include <sys/types.h>


### PR DESCRIPTION
Unsetting the __power_set macro as this would cause core-dump if hardware acceleration(incore-crypto) is not enabled on AIX operating system.

Here are the logs -

```
# schedo -o allow_vmx
allow_vmx = 0

# openssl version
OpenSSL 3.0.7 1 Nov 2022 (Library: OpenSSL 3.0.7 1 Nov 2022)

# openssl speed -evp aes-256-gcm
Doing AES-256-GCM for 3s on 16 size blocks: Illegal instruction(coredump)

# dbx /usr/bin/openssl core
Type 'help' for help.
[using memory image in core]
reading symbolic information ...warning: no source compiled with -g


Illegal instruction (illegal opcode) in aes_p8_set_encrypt_key at 0xd3c417f0 ($t1)
0xd3c417f0 (aes_p8_set_encrypt_key+0x50) 7c2018ce            lvx   vr1,r0,r3
(dbx) where
aes_p8_set_encrypt_key(??, ??, ??) at 0xd3c417f0
evp_do_ciph_ctx_getparams(0x2005c948, 0xd4002560, 0x20) at 0xd3ca6ee4
cipher_generic_init_internal(0x2005c948, 0xd4002560, 0x20, 0x0, 0x0, 0x0, 0x1) at 0xd3ee0da4
ossl_cipher_generic_einit(0x2005c948, 0xd4002560, 0x20, 0x0, 0x0, 0x0) at 0xd3ee0e60
evp_cipher_init_internal(0x2005c8a8, 0x20037c48, 0x0, 0xd4002560, 0x0, 0x1, 0x0) at 0xd3ca8f8c
EVP_CipherInit_ex(0x2005c8a8, 0x20037c48, 0x0, 0xd4002560, 0x0, 0x1) at 0xd3ca9720
drbg_ctr_init(0x2005c178) at 0xd3e54474
drbg_ctr_set_ctx_params(0x2005c178, 0x2ff22020) at 0xd3e548a4
drbg_ctr_instantiate_wrapper(0x2005c178, 0x0, 0x0, 0x0, 0x0, 0x2ff22020) at 0xd3e54964
evp_rand_instantiate_locked(0x2005c078, 0x0, 0x0, 0x0, 0x0, 0x2ff22020) at 0xd3cb0f1c
EVP_RAND_instantiate(0x2005c078, 0x0, 0x0, 0x0, 0x0, 0x2ff22020) at 0xd3cb0fd4
rand_new_drbg(0xf158c1a8, 0x2005bf28, 0x100, 0xe10) at 0xd3cad5a0
RAND_get0_primary(0xf158c1a8) at 0xd3cad990
RAND_get0_private(0xf158c1a8) at 0xd3cadd2c
RAND_priv_bytes_ex(0xf158c1a8, 0x20051aa8, 0x20, 0x0) at 0xd3cade20
EVP_CIPHER_CTX_rand_key(0x2005a858, 0x20051aa8) at 0xd3cabdd4
speed_main(0x0, 0x2ff229f0) at 0x1007c5b0
do_cmd(0x20030258, 0x3, 0x2ff229e4) at 0x10000980
main(0x3, 0x2ff229e4) at 0x100011c8
(dbx)

````

If I unset the __power_set macro, above issue was not seen.

How to recreate this issue ?

1. Check for incore crypto.
     _schedo -o allow_vmx_
2. If allow_vmx's value is set to 1, disable it by setting it to 0.
     _schedo -ro allow_vmx=0_
3. Run openssl speed command to exploit hardware acceleration capabilities.
     _openssl speed -evp aes-256-gcm_
4. You will see coredump.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
