### PR TITLE
Exclude IPv6 code using OPENSSL_USE_IPV6 instead of AF_INET6

### DIFF
--- a/crypto/bio/b_addr.c
+++ b/crypto/bio/b_addr.c
@@ -73,7 +73,7 @@ int BIO_ADDR_make(BIO_ADDR *ap, const struct sockaddr *sa)
         memcpy(&(ap->s_in), sa, sizeof(struct sockaddr_in));
         return 1;
     }
-#ifdef AF_INET6
+#if OPENSSL_USE_IPV6
     if (sa->sa_family == AF_INET6) {
         memcpy(&(ap->s_in6), sa, sizeof(struct sockaddr_in6));
         return 1;
@@ -112,7 +112,7 @@ int BIO_ADDR_rawmake(BIO_ADDR *ap, int family,
         ap->s_in.sin_addr = *(struct in_addr *)where;
         return 1;
     }
-#ifdef AF_INET6
+#if OPENSSL_USE_IPV6
     if (family == AF_INET6) {
         if (wherelen != sizeof(struct in6_addr))
             return 0;
@@ -141,7 +141,7 @@ int BIO_ADDR_rawaddress(const BIO_ADDR *ap, void *p, size_t *l)
         len = sizeof(ap->s_in.sin_addr);
         addrptr = &ap->s_in.sin_addr;
     }
-#ifdef AF_INET6
+#if OPENSSL_USE_IPV6
     else if (ap->sa.sa_family == AF_INET6) {
         len = sizeof(ap->s_in6.sin6_addr);
         addrptr = &ap->s_in6.sin6_addr;
@@ -170,7 +170,7 @@ unsigned short BIO_ADDR_rawport(const BIO_ADDR *ap)
 {
     if (ap->sa.sa_family == AF_INET)
         return ap->s_in.sin_port;
-#ifdef AF_INET6
+#if OPENSSL_USE_IPV6
     if (ap->sa.sa_family == AF_INET6)
         return ap->s_in6.sin6_port;
 #endif
@@ -325,7 +325,7 @@ socklen_t BIO_ADDR_sockaddr_size(const BIO_ADDR *ap)
 {
     if (ap->sa.sa_family == AF_INET)
         return sizeof(ap->s_in);
-#ifdef AF_INET6
+#if OPENSSL_USE_IPV6
     if (ap->sa.sa_family == AF_INET6)
         return sizeof(ap->s_in6);
 #endif
@@ -649,7 +649,7 @@ int BIO_lookup_ex(const char *host, const char *service, int lookup_type,
 
     switch(family) {
     case AF_INET:
-#ifdef AF_INET6
+#if OPENSSL_USE_IPV6
     case AF_INET6:
 #endif
 #ifdef AF_UNIX

--- a/crypto/bio/bio_local.h
+++ b/crypto/bio/bio_local.h
@@ -74,7 +74,7 @@ struct bio_addrinfo_st {
 
 union bio_addr_st {
     struct sockaddr sa;
-# ifdef AF_INET6
+# if OPENSSL_USE_IPV6
     struct sockaddr_in6 s_in6;
 # endif
     struct sockaddr_in s_in;

--- a/crypto/bio/bss_acpt.c
+++ b/crypto/bio/bss_acpt.c
@@ -188,7 +188,7 @@ static int acpt_state(BIO *b, BIO_ACCEPT *c)
                               * at least the "else" part will always be
                               * compiled.
                               */
-#ifdef AF_INET6
+#if OPENSSL_USE_IPV6
                         family = AF_INET6;
                     } else {
 #endif
@@ -490,7 +490,7 @@ static long acpt_ctrl(BIO *b, int cmd, long num, void *ptr)
                 *pp = data->cache_peer_serv;
             } else if (num == 4) {
                 switch (BIO_ADDRINFO_family(data->addr_iter)) {
-#ifdef AF_INET6
+#if OPENSSL_USE_IPV6
                 case AF_INET6:
                     ret = BIO_FAMILY_IPV6;
                     break;

--- a/crypto/bio/bss_conn.c
+++ b/crypto/bio/bss_conn.c
@@ -103,7 +103,7 @@ static int conn_state(BIO *b, BIO_CONNECT *c)
                               * at least the "else" part will always be
                               * compiled.
                               */
-#ifdef AF_INET6
+#if OPENSSL_USE_IPV6
                         family = AF_INET6;
                     } else {
 #endif
@@ -391,7 +391,7 @@ static long conn_ctrl(BIO *b, int cmd, long num, void *ptr)
                 *pptr = (const char *)BIO_ADDRINFO_address(data->addr_iter);
             } else if (num == 3) {
                 switch (BIO_ADDRINFO_family(data->addr_iter)) {
-# ifdef AF_INET6
+# if OPENSSL_USE_IPV6
                 case AF_INET6:
                     ret = BIO_FAMILY_IPV6;
                     break;


### PR DESCRIPTION
#18250 was marked for openssl 1.1.1, but was never backported, since the filename change. This PR backports this change. Other than the filename change the changes are the same.