### PR TITLE
parse_value(): Don't apply any precondition for parsing an unquoted string

### DIFF
--- a/crypto/property/property_parse.c
+++ b/crypto/property/property_parse.c
@@ -246,8 +246,9 @@ static int parse_value(OSSL_LIB_CTX *ctx, const char *t[],
         r = parse_oct(&s, res);
     } else if (ossl_isdigit(*s)) {
         return parse_number(t, res);
-    } else if (ossl_isalpha(*s))
+    } else {
         return parse_unquoted(ctx, t, res, create);
+    }
     if (r)
         *t = s;
     return r;

--- a/test/property_test.c
+++ b/test/property_test.c
@@ -141,6 +141,9 @@ static const struct {
     { "n=0x0", "n=0", 1 },
     { "n=0, sky=blue", "?n=0, sky=blue", 2 },
     { "n=1, sky=blue", "?n=0, sky=blue", 1 },
+    /* Try less obvious names and values too */
+    { "x.strange=something!, n=1", "?n=0, x.strange=something!", 1 },
+    { "x.strange=@something!, n=1", "?n=0, x.strange=@something!", 1 },
 };
 
 static int test_property_parse(int n)
@@ -151,7 +154,7 @@ static int test_property_parse(int n)
 
     if (TEST_ptr(store = ossl_method_store_new(NULL))
         && add_property_names("sky", "groan", "cold", "today", "tomorrow", "n",
-                              NULL)
+                              "x.strange", NULL)
         && TEST_ptr(p = ossl_parse_property(NULL, parser_tests[n].defn))
         && TEST_ptr(q = ossl_parse_query(NULL, parser_tests[n].query, 0))
         && TEST_int_eq(ossl_property_match_count(q, p), parser_tests[n].e))


### PR DESCRIPTION
There was a check that the unquoted property value would start with an
alphabetic character.  This goes against the spec in property(7), which
says this:

    UnquotedString ::= [^{space},]+

The fix is to simply remove that precondition and leave it to parse_unquoted()
to do its job.
