### PR TITLE
[doc] Sync documentation now that 3.0 honors OSSL_PKEY_PARAM_EC_POINT_CONVERSION_FORMAT

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -213,20 +213,6 @@ OpenSSL 3.1
 
    *Shane Lontis*
 
- * Our provider implementations of `OSSL_FUNC_KEYMGMT_EXPORT` and
-   `OSSL_FUNC_KEYMGMT_GET_PARAMS` for EC and SM2 keys now honor
-   `OSSL_PKEY_PARAM_EC_POINT_CONVERSION_FORMAT` as set (and
-   default to `POINT_CONVERSION_UNCOMPRESSED`) when exporting
-   `OSSL_PKEY_PARAM_PUB_KEY`, instead of unconditionally using
-   `POINT_CONVERSION_COMPRESSED` as in previous 3.x releases.
-   For symmetry, our implementation of `EVP_PKEY_ASN1_METHOD->export_to`
-   for legacy EC and SM2 keys is also changed similarly to honor the
-   equivalent conversion format flag as specified in the underlying
-   `EC_KEY` object being exported to a provider, when this function is
-   called through `EVP_PKEY_export()`.
-
-   *Nicola Tuveri*
-
  * RNDR and RNDRRS support in provider functions to provide
    random number generation for Arm CPUs (aarch64).
 
@@ -292,6 +278,22 @@ The migration guide contains more detailed information related to new features,
 breaking changes, and mappings for the large list of deprecated functions.
 
 [Migration guide]: https://github.com/openssl/openssl/tree/master/doc/man7/migration_guide.pod
+
+### Changes between 3.0.7 and 3.0.8 [xx XXX xxxx]
+
+ * Our provider implementations of `OSSL_FUNC_KEYMGMT_EXPORT` and
+   `OSSL_FUNC_KEYMGMT_GET_PARAMS` for EC and SM2 keys now honor
+   `OSSL_PKEY_PARAM_EC_POINT_CONVERSION_FORMAT` as set (and
+   default to `POINT_CONVERSION_UNCOMPRESSED`) when exporting
+   `OSSL_PKEY_PARAM_PUB_KEY`, instead of unconditionally using
+   `POINT_CONVERSION_COMPRESSED` as in previous 3.x releases.
+   For symmetry, our implementation of `EVP_PKEY_ASN1_METHOD->export_to`
+   for legacy EC and SM2 keys is also changed similarly to honor the
+   equivalent conversion format flag as specified in the underlying
+   `EC_KEY` object being exported to a provider, when this function is
+   called through `EVP_PKEY_export()`.
+
+   *Nicola Tuveri*
 
 ### Changes between 3.0.6 and 3.0.7 [1 Nov 2022]
 

--- a/doc/man7/EVP_PKEY-EC.pod
+++ b/doc/man7/EVP_PKEY-EC.pod
@@ -118,9 +118,9 @@ EVP_PKEY_fromdata() and EVP_PKEY_todata() functions.
 Note, in particular, that the choice of point compression format used for
 encoding the exported value via EVP_PKEY_todata() depends on the underlying
 provider implementation.
-Before OpenSSL 3.1, the implementation of providers included with OpenSSL always
+Before OpenSSL 3.0.8, the implementation of providers included with OpenSSL always
 opted for an encoding in compressed format, unconditionally.
-Since OpenSSL 3.1, the implementation has been changed to honor the
+Since OpenSSL 3.0.8, the implementation has been changed to honor the
 B<OSSL_PKEY_PARAM_EC_POINT_CONVERSION_FORMAT> parameter, if set, or to default
 to uncompressed format.
 


### PR DESCRIPTION
https://github.com/openssl/openssl/pull/19901 backported the "Honor `OSSL_PKEY_PARAM_EC_POINT_CONVERSION_FORMAT` as set and default to `UNCOMPRESSED`" changeset to 3.0.

As [requested](https://github.com/openssl/openssl/pull/19901#issuecomment-1362595839), this PR (targeting `master`) updates:

- the HISTORY notes of the relevant documentation to mark the change happened since 3.0.8.
- the `CHANGES.md file` to sync up with the tip of the `openssl-3.0` branch

The PR is organized in 2 commits, with the second marked as `squash!`: upon the rebase for merging this, the bullet point in the commit message of the latter commit should be added to the message of the first commit.
I organized it in 2 commits to make it easier to cherry-pick for 3.1, as the CHANGES.md commit might require trivial changes.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] `tests:exempted` as this PR only syncs documentation with the stable branch
