### PR TITLE
Fix broken cherry-pick of rsaz_exp_x2.c bug fix [3.0]

### DIFF
--- a/crypto/bn/rsaz_exp_x2.c
+++ b/crypto/bn/rsaz_exp_x2.c
@@ -23,6 +23,14 @@ NON_EMPTY_TRANSLATION_UNIT
 # include <assert.h>
 # include <string.h>
 
+# if defined(__GNUC__)
+#  define ALIGN64 __attribute__((aligned(64)))
+# elif defined(_MSC_VER)
+#  define ALIGN64 __declspec(align(64))
+# else
+#  define ALIGN64
+# endif
+
 # define ALIGN_OF(ptr, boundary) \
     ((unsigned char *)(ptr) + (boundary - (((size_t)(ptr)) & (boundary - 1))))
 

--- a/crypto/bn/rsaz_exp_x2.c
+++ b/crypto/bn/rsaz_exp_x2.c
@@ -42,8 +42,6 @@ NON_EMPTY_TRANSLATION_UNIT
 # define BITS2WORD8_SIZE(x)  (((x) + 7) >> 3)
 # define BITS2WORD64_SIZE(x) (((x) + 63) >> 6)
 
-typedef uint64_t ALIGN1 uint64_t_align1;
-
 static ossl_inline uint64_t get_digit52(const uint8_t *in, int in_len);
 static ossl_inline void put_digit52(uint8_t *out, int out_len, uint64_t digit);
 static void to_words52(BN_ULONG *out, int out_len, const BN_ULONG *in,


### PR DESCRIPTION
Unfortunately the rsaz_exp_x2.c is slightly different in 3.0 in that it still needs the ALIGN64 macro.

This fixes CI failure on 3.0 so it is urgent.
