### PR TITLE
OSSL_PARAM and BIGNUM; ensure at least one byte is allocated

### DIFF
--- a/crypto/param_build.c
+++ b/crypto/param_build.c
@@ -218,6 +218,10 @@ static int push_BN(OSSL_PARAM_BLD *bld, const char *key,
         }
         if (BN_get_flags(bn, BN_FLG_SECURE) == BN_FLG_SECURE)
             secure = 1;
+
+        /* The BIGNUM is zero, we must transfer at least one byte */
+        if (sz == 0)
+            sz++;
     }
     pd = param_push(bld, key, sz, sz, type, secure);
     if (pd == NULL)

--- a/crypto/params.c
+++ b/crypto/params.c
@@ -1068,6 +1068,9 @@ int OSSL_PARAM_set_BN(OSSL_PARAM *p, const BIGNUM *val)
     /* We add 1 byte for signed numbers, to make space for a sign extension */
     if (p->data_type == OSSL_PARAM_INTEGER)
         bytes++;
+    /* We make sure that at least one byte is used, so zero is properly set */
+    if (bytes == 0)
+        bytes++;
 
     p->return_size = bytes;
     if (p->data == NULL)

--- a/test/param_build_test.c
+++ b/test/param_build_test.c
@@ -219,6 +219,8 @@ err:
     OSSL_PARAM_free(params_blt);
     OSSL_PARAM_BLD_free(bld);
     OPENSSL_free(utf);
+    BN_free(zbn);
+    BN_free(zbn_res);
     BN_free(pbn);
     BN_free(pbn_res);
     BN_free(nbn);
@@ -381,6 +383,8 @@ err:
     OSSL_PARAM_BLD_free(bld);
     OPENSSL_secure_free(data1);
     OPENSSL_secure_free(data2);
+    BN_free(zbn);
+    BN_free(zbn_res);
     BN_free(pbn);
     BN_free(pbn_res);
     BN_free(nbn);

--- a/test/param_build_test.c
+++ b/test/param_build_test.c
@@ -16,10 +16,77 @@
 
 static const OSSL_PARAM params_empty[] = { OSSL_PARAM_END };
 
+static int template_public_single_zero_test(void)
+{
+    OSSL_PARAM_BLD *bld = NULL;
+    OSSL_PARAM *params = NULL, *params_blt = NULL, *p;
+    BIGNUM *zbn = NULL, *zbn_res = NULL;
+    int res = 0;
+
+    if (!TEST_ptr(bld = OSSL_PARAM_BLD_new())
+        || !TEST_ptr(zbn = BN_new())
+        || !TEST_true(OSSL_PARAM_BLD_push_BN(bld, "zeronumber", zbn))
+        || !TEST_ptr(params_blt = OSSL_PARAM_BLD_to_param(bld)))
+        goto err;
+
+    params = params_blt;
+    /* Check BN (zero BN becomes unsigned integer) */
+    if (!TEST_ptr(p = OSSL_PARAM_locate(params, "zeronumber"))
+        || !TEST_str_eq(p->key, "zeronumber")
+        || !TEST_uint_eq(p->data_type, OSSL_PARAM_UNSIGNED_INTEGER)
+        || !TEST_true(OSSL_PARAM_get_BN(p, &zbn_res))
+        || !TEST_BN_eq(zbn_res, zbn))
+        goto err;
+    res = 1;
+err:
+    if (params != params_blt)
+        OPENSSL_free(params);
+    OSSL_PARAM_free(params_blt);
+    OSSL_PARAM_BLD_free(bld);
+    BN_free(zbn);
+    BN_free(zbn_res);
+    return res;
+}
+
+static int template_private_single_zero_test(void)
+{
+    OSSL_PARAM_BLD *bld = NULL;
+    OSSL_PARAM *params = NULL, *params_blt = NULL, *p;
+    BIGNUM *zbn = NULL, *zbn_res = NULL;
+    int res = 0;
+
+    if (!TEST_ptr(bld = OSSL_PARAM_BLD_new())
+        || !TEST_ptr(zbn = BN_secure_new())
+        || !TEST_true(OSSL_PARAM_BLD_push_BN(bld, "zeronumber", zbn))
+        || !TEST_ptr(params_blt = OSSL_PARAM_BLD_to_param(bld)))
+        goto err;
+
+    params = params_blt;
+    /* Check BN (zero BN becomes unsigned integer) */
+    if (!TEST_ptr(p = OSSL_PARAM_locate(params, "zeronumber"))
+        || !TEST_true(CRYPTO_secure_allocated(p->data))
+        || !TEST_str_eq(p->key, "zeronumber")
+        || !TEST_uint_eq(p->data_type, OSSL_PARAM_UNSIGNED_INTEGER)
+        || !TEST_true(OSSL_PARAM_get_BN(p, &zbn_res))
+        || !TEST_int_eq(BN_get_flags(zbn, BN_FLG_SECURE), BN_FLG_SECURE)
+        || !TEST_BN_eq(zbn_res, zbn))
+        goto err;
+    res = 1;
+err:
+    if (params != params_blt)
+        OPENSSL_free(params);
+    OSSL_PARAM_free(params_blt);
+    OSSL_PARAM_BLD_free(bld);
+    BN_free(zbn);
+    BN_free(zbn_res);
+    return res;
+}
+
 static int template_public_test(int tstid)
 {
     OSSL_PARAM_BLD *bld = OSSL_PARAM_BLD_new();
     OSSL_PARAM *params = NULL, *params_blt = NULL, *p1 = NULL, *p;
+    BIGNUM *zbn = NULL, *zbn_res = NULL;
     BIGNUM *pbn = NULL, *pbn_res = NULL;
     BIGNUM *nbn = NULL, *nbn_res = NULL;
     int i;
@@ -38,6 +105,8 @@ static int template_public_test(int tstid)
         || !TEST_true(OSSL_PARAM_BLD_push_int64(bld, "i64", -9999999))
         || !TEST_true(OSSL_PARAM_BLD_push_time_t(bld, "t", 11224))
         || !TEST_true(OSSL_PARAM_BLD_push_double(bld, "d", 1.61803398875))
+        || !TEST_ptr(zbn = BN_new())
+        || !TEST_true(OSSL_PARAM_BLD_push_BN(bld, "zeronumber", zbn))
         || !TEST_ptr(pbn = BN_new())
         || !TEST_true(BN_set_word(pbn, 1729))
         || !TEST_true(OSSL_PARAM_BLD_push_BN(bld, "bignumber", pbn))
@@ -123,6 +192,12 @@ static int template_public_test(int tstid)
         || !TEST_ptr(p = OSSL_PARAM_locate(params, "utf8_p"))
         || !TEST_true(OSSL_PARAM_get_utf8_ptr(p, &cutf))
         || !TEST_str_eq(cutf, "bar-boom")
+        /* Check BN (zero BN becomes unsigned integer) */
+        || !TEST_ptr(p = OSSL_PARAM_locate(params, "zeronumber"))
+        || !TEST_str_eq(p->key, "zeronumber")
+        || !TEST_uint_eq(p->data_type, OSSL_PARAM_UNSIGNED_INTEGER)
+        || !TEST_true(OSSL_PARAM_get_BN(p, &zbn_res))
+        || !TEST_BN_eq(zbn_res, zbn)
         /* Check BN (positive BN becomes unsigned integer) */
         || !TEST_ptr(p = OSSL_PARAM_locate(params, "bignumber"))
         || !TEST_str_eq(p->key, "bignumber")
@@ -165,6 +240,7 @@ static int template_private_test(int tstid)
     uint32_t i32;
     uint64_t i64;
     size_t st;
+    BIGNUM *zbn = NULL, *zbn_res = NULL;
     BIGNUM *pbn = NULL, *pbn_res = NULL;
     BIGNUM *nbn = NULL, *nbn_res = NULL;
     int res = 0;
@@ -184,6 +260,8 @@ static int template_private_test(int tstid)
         || !TEST_true(OSSL_PARAM_BLD_push_uint32(bld, "i32", 1532))
         || !TEST_true(OSSL_PARAM_BLD_push_uint64(bld, "i64", 9999999))
         || !TEST_true(OSSL_PARAM_BLD_push_size_t(bld, "st", 65537))
+        || !TEST_ptr(zbn = BN_secure_new())
+        || !TEST_true(OSSL_PARAM_BLD_push_BN(bld, "zeronumber", zbn))
         || !TEST_ptr(pbn = BN_secure_new())
         || !TEST_true(BN_set_word(pbn, 1729))
         || !TEST_true(OSSL_PARAM_BLD_push_BN(bld, "bignumber", pbn))
@@ -269,6 +347,14 @@ static int template_private_test(int tstid)
         || !TEST_str_eq(p->key, "oct_p")
         || !TEST_uint_eq(p->data_type, OSSL_PARAM_OCTET_PTR)
         || !TEST_mem_eq(*(void **)p->data, p->data_size, data2, data2_size)
+        /* Check BN (zero BN becomes unsigned integer) */
+        || !TEST_ptr(p = OSSL_PARAM_locate(params, "zeronumber"))
+        || !TEST_true(CRYPTO_secure_allocated(p->data))
+        || !TEST_str_eq(p->key, "zeronumber")
+        || !TEST_uint_eq(p->data_type, OSSL_PARAM_UNSIGNED_INTEGER)
+        || !TEST_true(OSSL_PARAM_get_BN(p, &zbn_res))
+        || !TEST_int_eq(BN_get_flags(pbn, BN_FLG_SECURE), BN_FLG_SECURE)
+        || !TEST_BN_eq(zbn_res, zbn)
         /* Check BN (positive BN becomes unsigned integer) */
         || !TEST_ptr(p = OSSL_PARAM_locate(params, "bignumber"))
         || !TEST_true(CRYPTO_secure_allocated(p->data))
@@ -460,10 +546,13 @@ err:
 
 int setup_tests(void)
 {
+    ADD_TEST(template_public_single_zero_test);
     ADD_ALL_TESTS(template_public_test, 5);
     /* Only run the secure memory testing if we have secure memory available */
-    if (CRYPTO_secure_malloc_init(1<<16, 16))
+    if (CRYPTO_secure_malloc_init(1<<16, 16)) {
+        ADD_TEST(template_private_single_zero_test);
         ADD_ALL_TESTS(template_private_test, 5);
+    }
     ADD_TEST(builder_limit_test);
     ADD_TEST(builder_merge_test);
     return 1;


### PR DESCRIPTION
A zero BIGNUM contains zero bytes, while OSSL_PARAMs with an INTEGER (or
UNSIGNED INTEGER) data type are expected to have at least one data byte
allocated, containing a zero.  This wasn't handled correctly.

Fixes #20011
