### PR TITLE
Have all numeric OSSL_PARAM_get_xxx() check that data and data_size are set

### DIFF
--- a/crypto/params.c
+++ b/crypto/params.c
@@ -283,7 +283,7 @@ int OSSL_PARAM_set_int(OSSL_PARAM *p, int val)
     }
 #endif
 
-    if (val == NULL || p == NULL) {
+    if (p == NULL) {
         err_null_argument;
         return 0;
     }
@@ -332,7 +332,7 @@ int OSSL_PARAM_set_uint(OSSL_PARAM *p, unsigned int val)
     }
 #endif
 
-    if (val == NULL || p == NULL) {
+    if (p == NULL) {
         err_null_argument;
         return 0;
     }
@@ -382,7 +382,7 @@ int OSSL_PARAM_set_long(OSSL_PARAM *p, long int val)
     }
 #endif
 
-    if (val == NULL || p == NULL) {
+    if (p == NULL) {
         err_null_argument;
         return 0;
     }
@@ -431,7 +431,7 @@ int OSSL_PARAM_set_ulong(OSSL_PARAM *p, unsigned long int val)
     }
 #endif
 
-    if (val == NULL || p == NULL) {
+    if (p == NULL) {
         err_null_argument;
         return 0;
     }

--- a/crypto/params.c
+++ b/crypto/params.c
@@ -36,7 +36,7 @@
 #define err_unsupported_real  \
     ERR_raise(ERR_LIB_CRYPTO, CRYPTO_R_PARAM_UNSUPPORTED_FLOATING_POINT_FORMAT)
 #define err_invalid_argument  \
-   ERR_raise(ERR_LIB_CRYPTO, ERR_R_PASSED_INVALID_ARGUMENT) 
+    ERR_raise(ERR_LIB_CRYPTO, ERR_R_PASSED_INVALID_ARGUMENT)
 
 /*
  * Return the number of bits in the mantissa of a double.  This is used to

--- a/crypto/params.c
+++ b/crypto/params.c
@@ -35,6 +35,8 @@
     ERR_raise(ERR_LIB_CRYPTO, ERR_R_PASSED_NULL_PARAMETER)
 #define err_unsupported_real  \
     ERR_raise(ERR_LIB_CRYPTO, CRYPTO_R_PARAM_UNSUPPORTED_FLOATING_POINT_FORMAT)
+#define err_invalid_argument  \
+   ERR_raise(ERR_LIB_CRYPTO, ERR_R_PASSED_INVALID_ARGUMENT) 
 
 /*
  * Return the number of bits in the mantissa of a double.  This is used to
@@ -382,6 +384,10 @@ int OSSL_PARAM_get_int32(const OSSL_PARAM *p, int32_t *val)
         err_null_argument;
         return 0;
     }
+    if (p->data_size == 0 ||  p->data == NULL) {
+        err_invalid_argument;
+        return 0;
+    }
 
     if (p->data_type == OSSL_PARAM_INTEGER) {
 #ifndef OPENSSL_SMALL_FOOTPRINT
@@ -525,6 +531,10 @@ int OSSL_PARAM_get_uint32(const OSSL_PARAM *p, uint32_t *val)
 
     if (val == NULL || p == NULL) {
         err_null_argument;
+        return 0;
+    }
+    if (p->data_size == 0 ||  p->data == NULL) {
+        err_invalid_argument;
         return 0;
     }
 
@@ -674,6 +684,10 @@ int OSSL_PARAM_get_int64(const OSSL_PARAM *p, int64_t *val)
         err_null_argument;
         return 0;
     }
+    if (p->data_size == 0 ||  p->data == NULL) {
+        err_invalid_argument;
+        return 0;
+    }
 
     if (p->data_type == OSSL_PARAM_INTEGER) {
 #ifndef OPENSSL_SMALL_FOOTPRINT
@@ -812,6 +826,10 @@ int OSSL_PARAM_get_uint64(const OSSL_PARAM *p, uint64_t *val)
 
     if (val == NULL || p == NULL) {
         err_null_argument;
+        return 0;
+    }
+    if (p->data_size == 0 ||  p->data == NULL) {
+        err_invalid_argument;
         return 0;
     }
 
@@ -1024,6 +1042,10 @@ int OSSL_PARAM_get_BN(const OSSL_PARAM *p, BIGNUM **val)
         err_null_argument;
         return 0;
     }
+    if (p->data_size == 0 ||  p->data == NULL) {
+        err_invalid_argument;
+        return 0;
+    }
 
     switch (p->data_type) {
     case OSSL_PARAM_UNSIGNED_INTEGER:
@@ -1113,6 +1135,10 @@ int OSSL_PARAM_get_double(const OSSL_PARAM *p, double *val)
 
     if (val == NULL || p == NULL) {
         err_null_argument;
+        return 0;
+    }
+    if (p->data_size == 0 ||  p->data == NULL) {
+        err_invalid_argument;
         return 0;
     }
 

--- a/crypto/params.c
+++ b/crypto/params.c
@@ -260,6 +260,15 @@ int OSSL_PARAM_get_int(const OSSL_PARAM *p, int *val)
         return OSSL_PARAM_get_int64(p, (int64_t *)val);
     }
 #endif
+
+    if (val == NULL || p == NULL) {
+        err_null_argument;
+        return 0;
+    }
+    if (p->data_size == 0 ||  p->data == NULL) {
+        err_invalid_argument;
+        return 0;
+    }
     return general_get_int(p, val, sizeof(*val));
 }
 
@@ -273,6 +282,15 @@ int OSSL_PARAM_set_int(OSSL_PARAM *p, int val)
         return OSSL_PARAM_set_int64(p, (int64_t)val);
     }
 #endif
+
+    if (val == NULL || p == NULL) {
+        err_null_argument;
+        return 0;
+    }
+    if (p->data_size == 0 ||  p->data == NULL) {
+        err_invalid_argument;
+        return 0;
+    }
     return general_set_int(p, &val, sizeof(val));
 }
 
@@ -291,6 +309,15 @@ int OSSL_PARAM_get_uint(const OSSL_PARAM *p, unsigned int *val)
         return OSSL_PARAM_get_uint64(p, (uint64_t *)val);
     }
 #endif
+
+    if (val == NULL || p == NULL) {
+        err_null_argument;
+        return 0;
+    }
+    if (p->data_size == 0 ||  p->data == NULL) {
+        err_invalid_argument;
+        return 0;
+    }
     return general_get_uint(p, val, sizeof(*val));
 }
 
@@ -304,6 +331,15 @@ int OSSL_PARAM_set_uint(OSSL_PARAM *p, unsigned int val)
         return OSSL_PARAM_set_uint64(p, (uint64_t)val);
     }
 #endif
+
+    if (val == NULL || p == NULL) {
+        err_null_argument;
+        return 0;
+    }
+    if (p->data_size == 0 ||  p->data == NULL) {
+        err_invalid_argument;
+        return 0;
+    }
     return general_set_uint(p, &val, sizeof(val));
 }
 
@@ -323,6 +359,15 @@ int OSSL_PARAM_get_long(const OSSL_PARAM *p, long int *val)
         return OSSL_PARAM_get_int64(p, (int64_t *)val);
     }
 #endif
+
+    if (val == NULL || p == NULL) {
+        err_null_argument;
+        return 0;
+    }
+    if (p->data_size == 0 ||  p->data == NULL) {
+        err_invalid_argument;
+        return 0;
+    }
     return general_get_int(p, val, sizeof(*val));
 }
 
@@ -336,6 +381,15 @@ int OSSL_PARAM_set_long(OSSL_PARAM *p, long int val)
         return OSSL_PARAM_set_int64(p, (int64_t)val);
     }
 #endif
+
+    if (val == NULL || p == NULL) {
+        err_null_argument;
+        return 0;
+    }
+    if (p->data_size == 0 ||  p->data == NULL) {
+        err_invalid_argument;
+        return 0;
+    }
     return general_set_int(p, &val, sizeof(val));
 }
 
@@ -354,6 +408,15 @@ int OSSL_PARAM_get_ulong(const OSSL_PARAM *p, unsigned long int *val)
         return OSSL_PARAM_get_uint64(p, (uint64_t *)val);
     }
 #endif
+
+    if (val == NULL || p == NULL) {
+        err_null_argument;
+        return 0;
+    }
+    if (p->data_size == 0 ||  p->data == NULL) {
+        err_invalid_argument;
+        return 0;
+    }
     return general_get_uint(p, val, sizeof(*val));
 }
 
@@ -367,6 +430,15 @@ int OSSL_PARAM_set_ulong(OSSL_PARAM *p, unsigned long int val)
         return OSSL_PARAM_set_uint64(p, (uint64_t)val);
     }
 #endif
+
+    if (val == NULL || p == NULL) {
+        err_null_argument;
+        return 0;
+    }
+    if (p->data_size == 0 ||  p->data == NULL) {
+        err_invalid_argument;
+        return 0;
+    }
     return general_set_uint(p, &val, sizeof(val));
 }
 
@@ -981,6 +1053,15 @@ int OSSL_PARAM_get_size_t(const OSSL_PARAM *p, size_t *val)
         return OSSL_PARAM_get_uint64(p, (uint64_t *)val);
     }
 #endif
+
+    if (val == NULL || p == NULL) {
+        err_null_argument;
+        return 0;
+    }
+    if (p->data_size == 0 ||  p->data == NULL) {
+        err_invalid_argument;
+        return 0;
+    }
     return general_get_uint(p, val, sizeof(*val));
 }
 
@@ -1013,6 +1094,15 @@ int OSSL_PARAM_get_time_t(const OSSL_PARAM *p, time_t *val)
         return OSSL_PARAM_get_int64(p, (int64_t *)val);
     }
 #endif
+
+    if (val == NULL || p == NULL) {
+        err_null_argument;
+        return 0;
+    }
+    if (p->data_size == 0 ||  p->data == NULL) {
+        err_invalid_argument;
+        return 0;
+    }
     return general_get_int(p, val, sizeof(*val));
 }
 


### PR DESCRIPTION
If the OSSL_PARAM fields |data| or |data_size| are not set (data == NULL
or data_size == 0), it's not a valid number.
