### PR TITLE
Do not check definition of a macro and use it in a single condition

### DIFF
--- a/crypto/mem_sec.c
+++ b/crypto/mem_sec.c
@@ -24,8 +24,8 @@
 #ifndef OPENSSL_NO_SECURE_MEMORY
 # if defined(_WIN32)
 #  include <windows.h>
-#  if defined(WINAPI_FAMILY_PARTITION) \
-     && !WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP | WINAPI_PARTITION_SYSTEM)
+#  if defined(WINAPI_FAMILY_PARTITION)
+#   if !WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP | WINAPI_PARTITION_SYSTEM)
 /*
  * While VirtualLock is available under the app partition (e.g. UWP),
  * the headers do not define the API. Define it ourselves instead.
@@ -37,6 +37,7 @@ VirtualLock(
     _In_ LPVOID lpAddress,
     _In_ SIZE_T dwSize
     );
+#   endif
 #  endif
 # endif
 # include <stdlib.h>


### PR DESCRIPTION
The condition evaluation in #if conditions does not tolerate this if the macro is not defined.

Fixes #19628
