### PR TITLE
bin2bn(): When len==0, just return a zero BIGNUM

### DIFF
--- a/crypto/bn/bn_lib.c
+++ b/crypto/bn/bn_lib.c
@@ -440,6 +440,10 @@ static BIGNUM *bin2bn(const unsigned char *s, int len, BIGNUM *ret,
     unsigned int n;
     BIGNUM *bn = NULL;
 
+    /* Negative length is not acceptable */
+    if (len < 0)
+        return NULL;
+
     if (ret == NULL)
         ret = bn = BN_new();
     if (ret == NULL)

--- a/crypto/bn/bn_lib.c
+++ b/crypto/bn/bn_lib.c
@@ -447,6 +447,15 @@ static BIGNUM *bin2bn(const unsigned char *s, int len, BIGNUM *ret,
     bn_check_top(ret);
 
     /*
+     * If the input has no bits, the number is considered zero.
+     * This makes calls with s==NULL and len==0 safe.
+     */
+    if (len == 0) {
+        BN_clear(ret);
+        return ret;
+    }
+
+    /*
      * The loop that does the work iterates from least to most
      * significant BIGNUM chunk, so we adapt parameters to transfer
      * input bytes accordingly.

--- a/test/bntest.c
+++ b/test/bntest.c
@@ -2219,6 +2219,35 @@ static int test_mpi(int i)
     return st;
 }
 
+static int test_bin2zero(void)
+{
+    unsigned char input[] = { '\0' };
+    BIGNUM *zbn = NULL;
+    int ret = 0;
+
+    if (!TEST_ptr(zbn = BN_new()))
+        goto err;
+
+#define zerotest(fn)                           \
+    if (!TEST_ptr(fn(input, 1, zbn))    \
+        || !TEST_true(BN_is_zero(zbn))   \
+        || !TEST_ptr(fn(input, 0, zbn)) \
+        || !TEST_true(BN_is_zero(zbn))   \
+        || !TEST_ptr(fn(NULL, 0, zbn))  \
+        || !TEST_true(BN_is_zero(zbn)))  \
+        goto err
+
+    zerotest(BN_bin2bn);
+    zerotest(BN_signed_bin2bn);
+    zerotest(BN_lebin2bn);
+    zerotest(BN_signed_lebin2bn);
+#undef zerotest
+
+    ret = 1;
+ err:
+    return ret;
+}
+
 static int test_rand(void)
 {
     BIGNUM *bn = NULL;
@@ -3213,6 +3242,7 @@ int setup_tests(void)
         ADD_TEST(test_dec2bn);
         ADD_TEST(test_hex2bn);
         ADD_TEST(test_asc2bn);
+        ADD_TEST(test_bin2zero);
         ADD_ALL_TESTS(test_mpi, (int)OSSL_NELEM(kMPITests));
         ADD_ALL_TESTS(test_bn2signed, (int)OSSL_NELEM(kSignedTests_BE));
         ADD_TEST(test_negzero);

--- a/test/bntest.c
+++ b/test/bntest.c
@@ -2245,6 +2245,7 @@ static int test_bin2zero(void)
 
     ret = 1;
  err:
+    BN_free(zbn);
     return ret;
 }
 

--- a/test/bntest.c
+++ b/test/bntest.c
@@ -2221,7 +2221,7 @@ static int test_mpi(int i)
 
 static int test_bin2zero(void)
 {
-    unsigned char input[] = { '\0' };
+    unsigned char input[] = { 0 };
     BIGNUM *zbn = NULL;
     int ret = 0;
 


### PR DESCRIPTION
This allows calls with s==NULL and len==0 to be safe.  It probably already
was, but address sanitizers could still complain.

This fixes the underlying problem detected in #20011
