### PR TITLE
CMP app: fix server info to be just the host (not port/URL)

### DIFF
--- a/apps/cmp.c
+++ b/apps/cmp.c
@@ -1919,12 +1919,15 @@ static int setup_client_ctx(OSSL_CMP_CTX *ctx, ENGINE *engine)
         if ((info = OPENSSL_zalloc(sizeof(*info))) == NULL)
             goto err;
         (void)OSSL_CMP_CTX_set_http_cb_arg(ctx, info);
+        info->ssl_ctx = setup_ssl_ctx(ctx, host, engine);
         info->server = host;
-        info->port = server_port;
+        host = NULL; /* prevent deallocation */
+        if (server_port != NULL
+                && (info->port = OPENSSL_strdup(server_port)) == NULL)
+            goto err;
         /* workaround for callback design flaw, see #17088: */
         info->use_proxy = proxy_host != NULL;
         info->timeout = OSSL_CMP_CTX_get_option(ctx, OSSL_CMP_OPT_MSG_TIMEOUT);
-        info->ssl_ctx = setup_ssl_ctx(ctx, host, engine);
 
         if (info->ssl_ctx == NULL)
             goto err;
@@ -3063,7 +3066,11 @@ int cmp_main(int argc, char **argv)
         /* cannot free info already here, as it may be used indirectly by: */
         OSSL_CMP_CTX_free(cmp_ctx);
 #ifndef OPENSSL_NO_SOCK
-        APP_HTTP_TLS_INFO_free(info);
+        if (info != NULL) {
+            OPENSSL_free((char *)info->server);
+            OPENSSL_free((char *)info->port);
+            APP_HTTP_TLS_INFO_free(info);
+        }
 #endif
     }
     X509_VERIFY_PARAM_free(vpm);

--- a/apps/cmp.c
+++ b/apps/cmp.c
@@ -1919,7 +1919,7 @@ static int setup_client_ctx(OSSL_CMP_CTX *ctx, ENGINE *engine)
         if ((info = OPENSSL_zalloc(sizeof(*info))) == NULL)
             goto err;
         (void)OSSL_CMP_CTX_set_http_cb_arg(ctx, info);
-        info->server = opt_server;
+        info->server = host;
         info->port = server_port;
         /* workaround for callback design flaw, see #17088: */
         info->use_proxy = proxy_host != NULL;

--- a/apps/cmp.c
+++ b/apps/cmp.c
@@ -1922,8 +1922,7 @@ static int setup_client_ctx(OSSL_CMP_CTX *ctx, ENGINE *engine)
         info->ssl_ctx = setup_ssl_ctx(ctx, host, engine);
         info->server = host;
         host = NULL; /* prevent deallocation */
-        if (server_port != NULL
-                && (info->port = OPENSSL_strdup(server_port)) == NULL)
+        if ((info->port = OPENSSL_strdup(server_port)) == NULL)
             goto err;
         /* workaround for callback design flaw, see #17088: */
         info->use_proxy = proxy_host != NULL;

--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -2519,6 +2519,10 @@ BIO *app_http_tls_cb(BIO *bio, void *arg, int connect, int detail)
     if (connect) {
         SSL *ssl;
         BIO *sbio = NULL;
+        X509_STORE *ts = SSL_CTX_get_cert_store(ssl_ctx);
+        X509_VERIFY_PARAM *vpm = X509_STORE_get0_param(ts);
+        const char *host = vpm == NULL ? NULL :
+            X509_VERIFY_PARAM_get0_host(vpm, 0 /* first hostname */);
 
         /* adapt after fixing callback design flaw, see #17088 */
         if ((info->use_proxy
@@ -2533,8 +2537,8 @@ BIO *app_http_tls_cb(BIO *bio, void *arg, int connect, int detail)
             return NULL;
         }
 
-        /* adapt after fixing callback design flaw, see #17088 */
-        SSL_set_tlsext_host_name(ssl, info->server); /* not critical to do */
+        if (vpm != NULL)
+            SSL_set_tlsext_host_name(ssl, host /* may be NULL */);
 
         SSL_set_connect_state(ssl);
         BIO_set_ssl(sbio, ssl, BIO_CLOSE);


### PR DESCRIPTION
Fixes #20031, in the way correctly suggested here.
