### PR TITLE
Modify API X509_STORE_CTX_get_current_cert() in document text

### DIFF
--- a/doc/man3/X509_STORE_CTX_get_error.pod
+++ b/doc/man3/X509_STORE_CTX_get_error.pod
@@ -49,8 +49,10 @@ X509_STORE_CTX_set_error_depth() sets the error I<depth>.
 This can be used in combination with X509_STORE_CTX_set_error() to set the
 depth at which an error condition was detected.
 
-X509_STORE_CTX_get_current_cert() returns the certificate in I<ctx> which
-caused the error or NULL if no certificate is relevant.
+X509_STORE_CTX_get_current_cert() returns the current certificate in
+I<ctx>. If an error occurred, the current certificate will be the one
+that is most closely related to the error, or possibly NULL if no such
+certificate is relevant.
 
 X509_STORE_CTX_set_current_cert() sets the certificate I<x> in I<ctx> which
 caused the error.


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

Modify the documentation text of X509_STORE_CTX_get_current_cert(), the previous text is misleading and vague.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
