### PR TITLE
pkey: Imply public check if -pubin is specified

### DIFF
--- a/apps/pkey.c
+++ b/apps/pkey.c
@@ -248,7 +248,7 @@ int pkey_main(int argc, char **argv)
             goto end;
         }
 
-        if (check)
+        if (check && !pubin)
             r = EVP_PKEY_check(ctx);
         else
             r = EVP_PKEY_public_check(ctx);


### PR DESCRIPTION
Trivial fix to openssl pkey to imply using public check if -pubin is specified.
