### PR TITLE
`X509_V_ERR_INVALID_PURPOSE`: fix misleading text; fix doc omission

### DIFF
--- a/crypto/x509/x509_txt.c
+++ b/crypto/x509/x509_txt.c
@@ -74,7 +74,7 @@ const char *X509_verify_cert_error_string(long n)
     case X509_V_ERR_PATH_LENGTH_EXCEEDED:
         return "path length constraint exceeded";
     case X509_V_ERR_INVALID_PURPOSE:
-        return "unsupported certificate purpose";
+        return "unsuitable certificate purpose";
     case X509_V_ERR_CERT_UNTRUSTED:
         return "certificate not trusted";
     case X509_V_ERR_CERT_REJECTED:

--- a/doc/man3/X509_STORE_CTX_get_error.pod
+++ b/doc/man3/X509_STORE_CTX_get_error.pod
@@ -227,7 +227,7 @@ consistent with the supplied purpose.
 
 The basicConstraints path-length parameter has been exceeded.
 
-=item B<X509_V_ERR_INVALID_PURPOSE: unsupported certificate purpose>
+=item B<X509_V_ERR_INVALID_PURPOSE: unsuitable certificate purpose>
 
 The target certificate cannot be used for the specified purpose.
 

--- a/doc/man3/X509_VERIFY_PARAM_set_flags.pod
+++ b/doc/man3/X509_VERIFY_PARAM_set_flags.pod
@@ -90,6 +90,7 @@ X509_VERIFY_PARAM_clear_flags() clears the flags B<flags> in B<param>.
 X509_VERIFY_PARAM_set_purpose() sets the verification purpose in B<param>
 to B<purpose>. This determines the acceptable purpose of the certificate
 chain, for example B<X509_PURPOSE_SSL_CLIENT>.
+The purpose requirement is cleared if B<purpose> is 0.
 
 X509_VERIFY_PARAM_set_trust() sets the trust setting in B<param> to
 B<trust>.


### PR DESCRIPTION
Fix misleading text for `X509_V_ERR_INVALID_PURPOSE`
and an omission in doc of `X509_VERIFY_PARAM_clear_flags()`.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
