### PR TITLE
S390X: Fix Ed448ph

### DIFF
--- a/providers/implementations/signature/eddsa_sig.c
+++ b/providers/implementations/signature/eddsa_sig.c
@@ -343,10 +343,11 @@ int ed448_digest_sign(void *vpeddsactx, unsigned char *sigret,
         return 0;
     }
 #ifdef S390X_EC_ASM
-    /* s390x_ed448_digestsign() does not yet support context-strings.
-       fall back to non-accelerated sign if a context-string is provided. */
+    /* s390x_ed448_digestsign() does not yet support context-strings or pre-hashing.
+       fall back to non-accelerated sign if a context-string or pre-hasing is provided. */
     if (S390X_CAN_SIGN(ED448)
-            && peddsactx->context_string_len == 0) {
+            && peddsactx->context_string_len == 0
+            && peddsactx->prehash_flag == 0) {
         if (s390x_ed448_digestsign(edkey, sigret, tbs, tbslen) == 0) {
             ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SIGN);
             return 0;
@@ -424,10 +425,11 @@ int ed448_digest_verify(void *vpeddsactx, const unsigned char *sig,
         return 0;
 
 #ifdef S390X_EC_ASM
-    /* s390x_ed448_digestverify() does not yet support context-strings.
-       fall back to non-accelerated verify if a context-string is provided. */
+    /* s390x_ed448_digestverify() does not yet support context-strings or pre-hashing.
+       fall back to non-accelerated verify if a context-string or pre-hasing is provided. */
     if (S390X_CAN_SIGN(ED448)
-            && peddsactx->context_string_len == 0) {
+            && peddsactx->context_string_len == 0
+            && peddsactx->prehash_flag == 0) {
         return s390x_ed448_digestverify(edkey, sig, tbs, tbslen);
     }
 #endif /* S390X_EC_ASM */


### PR DESCRIPTION
CPACF does not support pre-hashing.  This was considered correctly for Ed25519ph, but not for Ed448ph which lead to errors in the test_evp suite (test vector 20 - pre-hashing without context string).  Fix this by using the non-accelerated version of Ed448 also if no context string is provided, but pre-hashing is performed.

Signed-off-by: Juergen Christ <jchrist@linux.ibm.com>

No new tests needed since this fixes a bug discovered by existing test cases (test_evp vector 20).

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->
