### PR TITLE
Fix incorrect error return value in i2r_ADMISSION_SYNTAX()

### DIFF
--- a/crypto/x509/v3_admis.c
+++ b/crypto/x509/v3_admis.c
@@ -199,7 +199,7 @@ static int i2r_ADMISSION_SYNTAX(const struct v3_ext_method *method, void *in,
     return 1;
 
 err:
-    return -1;
+    return 0;
 }
 
 const ASN1_OBJECT *NAMING_AUTHORITY_get0_authorityId(const NAMING_AUTHORITY *n)


### PR DESCRIPTION
The other implementations of i2r return 0 in case of an error, but i2r_ADMISSION_SYNTAX() returns -1. That means the check on i2r does not catch the error. Change it to return 0 like the others do.

Fixes: #20066

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
