### PR TITLE
Allow OSSL_SIGNATURE_PARAM_NONCE_TYPE to be retrieved

### DIFF
--- a/doc/man7/EVP_SIGNATURE-DSA.pod
+++ b/doc/man7/EVP_SIGNATURE-DSA.pod
@@ -37,6 +37,8 @@ EVP_PKEY_CTX_get_params().
 
 =item "digest" (B<OSSL_SIGNATURE_PARAM_DIGEST>) <UTF8 string>
 
+=item "nonce-type" (B<OSSL_SIGNATURE_PARAM_NONCE_TYPE>) <unsigned integer>
+
 The gettable parameters are described in L<provider-signature(7)>.
 
 =back

--- a/doc/man7/EVP_SIGNATURE-ECDSA.pod
+++ b/doc/man7/EVP_SIGNATURE-ECDSA.pod
@@ -36,6 +36,8 @@ EVP_PKEY_CTX_get_params().
 
 =item "digest" (B<OSSL_SIGNATURE_PARAM_DIGEST>) <UTF8 string>
 
+=item "nonce-type" (B<OSSL_SIGNATURE_PARAM_NONCE_TYPE>) <unsigned integer>
+
 The parameters are described in L<provider-signature(7)>.
 
 =back

--- a/providers/implementations/signature/dsa_sig.c
+++ b/providers/implementations/signature/dsa_sig.c
@@ -461,12 +461,17 @@ static int dsa_get_ctx_params(void *vpdsactx, OSSL_PARAM *params)
     if (p != NULL && !OSSL_PARAM_set_utf8_string(p, pdsactx->mdname))
         return 0;
 
+    p = OSSL_PARAM_locate(params, OSSL_SIGNATURE_PARAM_NONCE_TYPE);
+    if (p != NULL && !OSSL_PARAM_set_uint(p, pdsactx->nonce_type))
+        return 0;
+
     return 1;
 }
 
 static const OSSL_PARAM known_gettable_ctx_params[] = {
     OSSL_PARAM_octet_string(OSSL_SIGNATURE_PARAM_ALGORITHM_ID, NULL, 0),
     OSSL_PARAM_utf8_string(OSSL_SIGNATURE_PARAM_DIGEST, NULL, 0),
+    OSSL_PARAM_uint(OSSL_SIGNATURE_PARAM_NONCE_TYPE, NULL),
     OSSL_PARAM_END
 };
 

--- a/providers/implementations/signature/ecdsa_sig.c
+++ b/providers/implementations/signature/ecdsa_sig.c
@@ -467,6 +467,10 @@ static int ecdsa_get_ctx_params(void *vctx, OSSL_PARAM *params)
                                                     : EVP_MD_get0_name(ctx->md)))
         return 0;
 
+    p = OSSL_PARAM_locate(params, OSSL_SIGNATURE_PARAM_NONCE_TYPE);
+    if (p != NULL && !OSSL_PARAM_set_uint(p, ctx->nonce_type))
+        return 0;
+
     return 1;
 }
 
@@ -474,6 +478,7 @@ static const OSSL_PARAM known_gettable_ctx_params[] = {
     OSSL_PARAM_octet_string(OSSL_SIGNATURE_PARAM_ALGORITHM_ID, NULL, 0),
     OSSL_PARAM_size_t(OSSL_SIGNATURE_PARAM_DIGEST_SIZE, NULL),
     OSSL_PARAM_utf8_string(OSSL_SIGNATURE_PARAM_DIGEST, NULL, 0),
+    OSSL_PARAM_uint(OSSL_SIGNATURE_PARAM_NONCE_TYPE, NULL),
     OSSL_PARAM_END
 };
 

--- a/test/evp_test.c
+++ b/test/evp_test.c
@@ -3341,6 +3341,12 @@ static int digestsigver_test_parse(EVP_TEST *t,
             params[1] = OSSL_PARAM_construct_end();
             if (!EVP_PKEY_CTX_set_params(mdata->pctx, params))
                 t->err = "EVP_PKEY_CTX_set_params_ERROR";
+            else if (!EVP_PKEY_CTX_get_params(mdata->pctx, params))
+                t->err = "EVP_PKEY_CTX_get_params_ERROR";
+            else if (!OSSL_PARAM_modified(&params[0]))
+                t->err = "nonce_type_not_modified_ERROR";
+            else if (nonce_type != 1)
+                t->err = "nonce_type_value_ERROR";
         }
         return 1;
     }


### PR DESCRIPTION
Context parameter OSSL_SIGNATURE_PARAM_NONCE_TYPE can now also be retrieved for ECDSA and DSA.

Fixes: https://github.com/openssl/openssl/issues/20069

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated


