### PR TITLE
Padlock: fix byte swapping assembly for AES-192 and 256

### DIFF
--- a/engines/asm/e_padlock-x86.pl
+++ b/engines/asm/e_padlock-x86.pl
@@ -115,6 +115,8 @@ $chunk="ebx";
 &function_begin_B("padlock_key_bswap");
 	&mov	("edx",&wparam(0));
 	&mov	("ecx",&DWP(240,"edx"));
+	&inc	("ecx");
+	&shl	("ecx",2);
 &set_label("bswap_loop");
 	&mov	("eax",&DWP(0,"edx"));
 	&bswap	("eax");

--- a/engines/asm/e_padlock-x86_64.pl
+++ b/engines/asm/e_padlock-x86_64.pl
@@ -94,6 +94,8 @@ padlock_capability:
 .align	16
 padlock_key_bswap:
 	mov	240($arg1),%edx
+	inc	%edx
+	shl	\$2,%edx
 .Lbswap_loop:
 	mov	($arg1),%eax
 	bswap	%eax


### PR DESCRIPTION
Byte swapping code incorrectly uses the number of AES rounds to swap expanded AES key, while swapping only a single dword in a loop, resulting in swapped key and partially swapped expanded keys, breaking AES encryption and decryption on VIA Padlock hardware.

This commit correctly sets the number of swapping loops to be done.

Fixes #20073

CLA: trivial
