### PR TITLE
RISC-V: GCM: Implement .ghash()

### DIFF
--- a/crypto/modes/asm/ghash-riscv64.pl
+++ b/crypto/modes/asm/ghash-riscv64.pl
@@ -26,225 +26,221 @@ my $code=<<___;
 ___
 
 ################################################################################
-# gcm_init_clmul_rv64i_zbb_zbc(u128 Htable[16], const u64 Xi[2])
-# Initialization function for clmul-based implementation of GMULT
-# This function is used in tandem with gcm_gmult_clmul_rv64i_zbb_zbc
-################################################################################
+# void gcm_init_rv64i_zbc(u128 Htable[16], const u64 H[2]);
+# void gcm_init_rv64i_zbc__zbb(u128 Htable[16], const u64 H[2]);
+# void gcm_init_rv64i_zbc__zbkb(u128 Htable[16], const u64 H[2]);
+#
+# input:  H: 128-bit H - secret parameter E(K, 0^128)
+# output: Htable: Preprocessed key data for gcm_gmult_rv64i_zbc* and
+#                 gcm_ghash_rv64i_zbc*
+#
+# All callers of this function revert the byte-order unconditionally
+# on little-endian machines. So we need to revert the byte-order back.
+# Additionally we reverse the bits of each byte.
+
 {
-my ($Haddr,$Xi,$TEMP) = ("a0","a1","a2");
+my ($Htable,$H,$VAL0,$VAL1,$TMP0,$TMP1,$TMP2) = ("a0","a1","a2","a3","t0","t1","t2");
 
 $code .= <<___;
-.balign 16
-.globl gcm_init_clmul_rv64i_zbb_zbc
-.type gcm_init_clmul_rv64i_zbb_zbc,\@function
-# Initialize clmul-based implementation of galois field multiplication routine.
-# gcm_init_clmul_rv64i_zbb_zbc(ctx->Htable, ctx->H.u)
-gcm_init_clmul_rv64i_zbb_zbc:
-    # argument 0 = ctx->Htable (store H here)
-    # argument 1 = H.u[] (2x 64-bit words) [H_high64, H_low64]
-
-    # Simply store [H_high64, H_low64] for later
-    ld      $TEMP,0($Xi)
-    sd      $TEMP,0($Haddr)
-    ld      $TEMP,8($Xi)
-    sd      $TEMP,8($Haddr)
-
+.p2align 3
+.globl gcm_init_rv64i_zbc
+.type gcm_init_rv64i_zbc,\@function
+gcm_init_rv64i_zbc:
+    ld      $VAL0,0($H)
+    ld      $VAL1,8($H)
+    @{[brev8_rv64i   $VAL0, $TMP0, $TMP1, $TMP2]}
+    @{[brev8_rv64i   $VAL1, $TMP0, $TMP1, $TMP2]}
+    @{[sd_rev8_rv64i $VAL0, $Htable, 0, $TMP0]}
+    @{[sd_rev8_rv64i $VAL1, $Htable, 8, $TMP0]}
     ret
-
+.size gcm_init_rv64i_zbc,.-gcm_init_rv64i_zbc
 ___
+}
 
+{
+my ($Htable,$H,$VAL0,$VAL1,$TMP0,$TMP1,$TMP2) = ("a0","a1","a2","a3","t0","t1","t2");
+
+$code .= <<___;
+.p2align 3
+.globl gcm_init_rv64i_zbc__zbb
+.type gcm_init_rv64i_zbc__zbb,\@function
+gcm_init_rv64i_zbc__zbb:
+    ld      $VAL0,0($H)
+    ld      $VAL1,8($H)
+    @{[brev8_rv64i $VAL0, $TMP0, $TMP1, $TMP2]}
+    @{[brev8_rv64i $VAL1, $TMP0, $TMP1, $TMP2]}
+    @{[rev8 $VAL0, $VAL0]}
+    @{[rev8 $VAL1, $VAL1]}
+    sd      $VAL0,0($Htable)
+    sd      $VAL1,8($Htable)
+    ret
+.size gcm_init_rv64i_zbc__zbb,.-gcm_init_rv64i_zbc__zbb
+___
+}
+
+{
+my ($Htable,$H,$TMP0,$TMP1) = ("a0","a1","t0","t1");
+
+$code .= <<___;
+.p2align 3
+.globl gcm_init_rv64i_zbc__zbkb
+.type gcm_init_rv64i_zbc__zbkb,\@function
+gcm_init_rv64i_zbc__zbkb:
+    ld      $TMP0,0($H)
+    ld      $TMP1,8($H)
+    @{[brev8 $TMP0, $TMP0]}
+    @{[brev8 $TMP1, $TMP1]}
+    @{[rev8 $TMP0, $TMP0]}
+    @{[rev8 $TMP1, $TMP1]}
+    sd      $TMP0,0($Htable)
+    sd      $TMP1,8($Htable)
+    ret
+.size gcm_init_rv64i_zbc__zbkb,.-gcm_init_rv64i_zbc__zbkb
+___
 }
 
 ################################################################################
-# gcm_gmult_clmul_rv64i_zbb_zbc(u64 Xi[2], const u128 Htable[16])
-# Compute GMULT (X*H mod f) using the Zbc (clmul) and Zbb (basic bit manip)
-# extensions, and the Modified Barrett Reduction technique
-################################################################################
+# void gcm_gmult_rv64i_zbc(u64 Xi[2], const u128 Htable[16]);
+# void gcm_gmult_rv64i_zbc__zbkb(u64 Xi[2], const u128 Htable[16]);
+#
+# input:  Xi: current hash value
+#         Htable: copy of H
+# output: Xi: next hash value Xi
+#
+# Compute GMULT (Xi*H mod f) using the Zbc (clmul) and Zbb (basic bit manip)
+# extensions. Using the no-Karatsuba approach and clmul for the final reduction.
+# This results in an implementation with minimized number of instructions.
+# HW with clmul latencies higher than 2 cycles might observe a performance
+# improvement with Karatsuba. HW with clmul latencies higher than 6 cycles
+# might observe a performance improvement with additionally converting the
+# reduction to shift&xor. For a full discussion of this estimates see
+# https://github.com/riscv/riscv-crypto/blob/master/doc/supp/gcm-mode-cmul.adoc
 {
-my ($Xi,$Haddr,$A1,$A0,$B1,$B0,$C1,$C0,$D1,$D0,$E1,$E0,$TEMP,$TEMP2,$qp_low) =
- ("a0","a1","a2","a3","a4","a5","a6","a7","t0","t1","t2","t3","t4","t5","t6");
+my ($Xi,$Htable,$x0,$x1,$y0,$y1) = ("a0","a1","a4","a5","a6","a7");
+my ($z0,$z1,$z2,$z3,$t0,$t1,$polymod) = ("t0","t1","t2","t3","t4","t5","t6");
 
 $code .= <<___;
-.balign 16
-.globl gcm_gmult_clmul_rv64i_zbb_zbc
-.type gcm_gmult_clmul_rv64i_zbb_zbc,\@function
-# static void gcm_gmult_clmul_rv64i_zbb_zbc(u64 Xi[2], const u128 Htable[16])
-# Computes product of X*H mod f
-gcm_gmult_clmul_rv64i_zbb_zbc:
+.p2align 3
+.globl gcm_gmult_rv64i_zbc
+.type gcm_gmult_rv64i_zbc,\@function
+gcm_gmult_rv64i_zbc:
+    # Load Xi and bit-reverse it
+    ld        $x0, 0($Xi)
+    ld        $x1, 8($Xi)
+    @{[brev8_rv64i $x0, $z0, $z1, $z2]}
+    @{[brev8_rv64i $x1, $z0, $z1, $z2]}
 
-    # Load X and H (H is saved previously in gcm_init_clmul_rv64i_zbb_zbc)
-    ld              $A1,0($Xi)
-    ld              $A0,8($Xi)
+    # Load the key (already bit-reversed)
+    ld        $y0, 0($Htable)
+    ld        $y1, 8($Htable)
 
-    ld              $B1,0($Haddr)
-    ld              $B0,8($Haddr)
+    # Load the reduction constant
+    la        $polymod, Lpolymod
+    lbu       $polymod, 0($polymod)
 
-    li              $qp_low,0xe100000000000000
+    # Multiplication (without Karatsuba)
+    @{[clmulh $z3, $x1, $y1]}
+    @{[clmul  $z2, $x1, $y1]}
+    @{[clmulh $t1, $x0, $y1]}
+    @{[clmul  $z1, $x0, $y1]}
+    xor       $z2, $z2, $t1
+    @{[clmulh $t1, $x1, $y0]}
+    @{[clmul  $t0, $x1, $y0]}
+    xor       $z2, $z2, $t1
+    xor       $z1, $z1, $t0
+    @{[clmulh $t1, $x0, $y0]}
+    @{[clmul  $z0, $x0, $y0]}
+    xor       $z1, $z1, $t1
 
-    # Perform Katratsuba Multiplication to generate a 255-bit intermediate
-    # A = [A1:A0]
-    # B = [B1:B0]
-    # Let:
-    # [C1:C0] = A1*B1
-    # [D1:D0] = A0*B0
-    # [E1:E0] = (A0+A1)*(B0+B1)
-    # Then:
-    # A*B = [C1:C0+C1+D1+E1:D1+C0+D0+E0:D0]
+    # Reduction with clmul
+    @{[clmulh $t1, $z3, $polymod]}
+    @{[clmul  $t0, $z3, $polymod]}
+    xor       $z2, $z2, $t1
+    xor       $z1, $z1, $t0
+    @{[clmulh $t1, $z2, $polymod]}
+    @{[clmul  $t0, $z2, $polymod]}
+    xor       $x1, $z1, $t1
+    xor       $x0, $z0, $t0
 
-    @{[rev8         $A1, $A1]}
-    @{[clmul        $C0,$A1,$B1]}
-    @{[clmulh       $C1,$A1,$B1]}
-
-    @{[rev8         $A0,$A0]}
-    @{[clmul        $D0,$A0,$B0]}
-    @{[clmulh       $D1,$A0,$B0]}
-
-    xor             $TEMP,$A0,$A1
-    xor             $TEMP2,$B0,$B1
-
-    @{[clmul        $E0,$TEMP,$TEMP2]}
-    @{[clmulh       $E1,$TEMP,$TEMP2]}
-
-    # 0th term is just C1
-
-    # Construct term 1 in E1 (E1 only appears in dword 1)
-    xor             $E1,$E1,$D1
-    xor             $E1,$E1,$C1
-    xor             $E1,$E1,$C0
-
-    # Term 1 is E1
-
-    # Construct term 2 in E0 (E0 only appears in dword 2)
-    xor             $E0,$E0,$D0
-    xor             $E0,$E0,$C0
-    xor             $E0,$E0,$D1
-
-    # Term 2 is E0
-
-    # final term is just D0
-
-    # X*H is now stored in [C1,E1,E0,D0]
-
-    # Left-justify
-    slli            $C1,$C1,1
-    # Or in the high bit of E1
-    srli            $TEMP,$E1,63
-    or              $C1,$C1,$TEMP
-
-    slli            $E1,$E1,1
-    # Or in the high bit of E0
-    srli            $TEMP2,$E0,63
-    or              $E1,$E1,$TEMP2
-
-    slli            $E0,$E0,1
-    # Or in the high bit of D0
-    srli            $TEMP,$D0,63
-    or              $E0,$E0,$TEMP
-
-    slli            $D0,$D0,1
-
-    # Barrett Reduction
-    # c = [E0, D0]
-    # We want the top 128 bits of the result of c*f
-    # We'll get this by computing the low-half (most significant 128 bits in
-    # the reflected domain) of clmul(c,fs)<<1 first, then
-    # xor in c to complete the calculation
-
-    # AA = [AA1:AA0] = [E0,D0] = c
-    # BB = [BB1:BB0] = [qp_low,0]
-    # [CC1:CC0] = AA1*BB1
-    # [DD1:DD0] = AA0*BB0
-    # [EE1:EE0] = (AA0+AA1)*(BB0+BB1)
-    # Then:
-    # AA*BB = [CC1:CC0+CC1+DD1+EE1:DD1+CC0+DD0+EE0:DD0]
-    # We only need CC0,DD1,DD0,EE0 to compute the low 128 bits of c * qp_low
-___
-
-my ($CC0,$EE0,$AA1,$AA0,$BB1) = ($A0,$B1,$E0,$D0,$qp_low);
-
-$code .= <<___;
-
-    @{[clmul        $CC0,$AA1,$BB1]}
-    #clmul          DD0,AA0,BB0     # BB0 is 0, so DD0 = 0
-    #clmulh         DD1,AA0,BB0     # BB0 is 0, so DD1 = 0
-    xor             $TEMP,$AA0,$AA1
-    #xor            TEMP2,BB0,BB1   # TEMP2 = BB1 = qp_low
-    @{[clmul        $EE0,$TEMP,$BB1]}
-
-    # Result is [N/A:N/A:DD1+CC0+DD0+EE0:DD0]
-    # Simplifying: [CC0+EE0:0]
-    xor             $TEMP2,$CC0,$EE0
-    # Shift left by 1 to correct for bit reflection
-    slli            $TEMP2,$TEMP2,1
-
-    # xor into c = [E0,D0]
-    # Note that only E0 is affected
-    xor             $E0,$E0,$TEMP2
-
-    # Now, q = [E0,D0]
-
-    # The final step is to compute clmul(q,[qp_low:0])<<1
-    # The leftmost 128 bits are the reduced result.
-    # Once again, we use Karatsuba multiplication, but many of the terms
-    # simplify or cancel out.
-    # AA = [AA1:AA0] = [E0,D0] = c
-    # BB = [BB1:BB0] = [qp_low,0]
-    # [CC1:CC0] = AA1*BB1
-    # [DD1:DD0] = AA0*BB0
-    # [EE1:EE0] = (AA0+AA1)*(BB0+BB1)
-    # Then:
-    # AA*BB = [CC1:CC0+CC1+DD1+EE1:DD1+CC0+DD0+EE0:DD0]
-    # We need CC1,CC0,DD0,DD1,EE1,EE0 to compute the leftmost 128 bits of AA*BB
-
-___
-
-my ($AA1,$AA0,$BB1,$CC1,$CC0,$EE1,$EE0) = ($E0,$D0,$qp_low,$A0,$A1,$C0,$B0);
-
-$code .= <<___;
-
-    @{[clmul        $CC0,$AA1,$BB1]}
-    @{[clmulh       $CC1,$AA1,$BB1]}
-
-    #clmul          DD0,AA0,BB0   # BB0 = 0 so DD0 = 0
-    #clmulh         DD1,AA0,BB0   # BB0 = 0 so DD1 = 0
-
-    xor             $TEMP,$AA0,$AA1
-    #xor            TEMP2,BB0,BB1 # BB0 = 0 to TEMP2 == BB1 == qp_low
-
-    @{[clmul        $EE0,$TEMP,$BB1]}
-    @{[clmulh       $EE1,$TEMP,$BB1]}
-
-    # Need the DD1+CC0+DD0+EE0 term to shift its leftmost bit into the
-    # intermediate result.
-    # This is just CC0+EE0, store it in TEMP
-    xor             $TEMP,$CC0,$EE0
-
-    # Result is [CC1:CC0+CC1+EE1:(a single bit)]<<1
-    # Combine into [CC1:CC0]
-    xor             $CC0,$CC0,$CC1
-    xor             $CC0,$CC0,$EE1
-
-    # Shift 128-bit quantity, xor in [C1,E1] and store
-    slli            $CC1,$CC1,1
-    srli            $TEMP2,$CC0,63
-    or              $CC1,$CC1,$TEMP2
-    # xor in C1
-    xor             $CC1,$CC1,$C1
-    @{[rev8         $CC1,$CC1]}
-
-    slli            $CC0,$CC0,1
-    srli            $TEMP,$TEMP,63
-    or              $CC0,$CC0,$TEMP
-    # xor in E1
-    xor             $CC0,$CC0,$E1
-    @{[rev8         $CC0,$CC0]}
-    sd              $CC1,0(a0)
-    sd              $CC0,8(a0)
-
+    # Bit-reverse Xi back and store it
+    @{[brev8_rv64i $x0, $z0, $z1, $z2]}
+    @{[brev8_rv64i $x1, $z0, $z1, $z2]}
+    sd        $x0, 0($Xi)
+    sd        $x1, 8($Xi)
     ret
+.size gcm_gmult_rv64i_zbc,.-gcm_gmult_rv64i_zbc
 ___
-
 }
+
+{
+my ($Xi,$Htable,$x0,$x1,$y0,$y1) = ("a0","a1","a4","a5","a6","a7");
+my ($z0,$z1,$z2,$z3,$t0,$t1,$polymod) = ("t0","t1","t2","t3","t4","t5","t6");
+
+$code .= <<___;
+.p2align 3
+.globl gcm_gmult_rv64i_zbc__zbkb
+.type gcm_gmult_rv64i_zbc__zbkb,\@function
+gcm_gmult_rv64i_zbc__zbkb:
+    # Load Xi and bit-reverse it
+    ld        $x0, 0($Xi)
+    ld        $x1, 8($Xi)
+    @{[brev8  $x0, $x0]}
+    @{[brev8  $x1, $x1]}
+
+    # Load the key (already bit-reversed)
+    ld        $y0, 0($Htable)
+    ld        $y1, 8($Htable)
+
+    # Load the reduction constant
+    la        $polymod, Lpolymod
+    lbu       $polymod, 0($polymod)
+
+    # Multiplication (without Karatsuba)
+    @{[clmulh $z3, $x1, $y1]}
+    @{[clmul  $z2, $x1, $y1]}
+    @{[clmulh $t1, $x0, $y1]}
+    @{[clmul  $z1, $x0, $y1]}
+    xor       $z2, $z2, $t1
+    @{[clmulh $t1, $x1, $y0]}
+    @{[clmul  $t0, $x1, $y0]}
+    xor       $z2, $z2, $t1
+    xor       $z1, $z1, $t0
+    @{[clmulh $t1, $x0, $y0]}
+    @{[clmul  $z0, $x0, $y0]}
+    xor       $z1, $z1, $t1
+
+    # Reduction with clmul
+    @{[clmulh $t1, $z3, $polymod]}
+    @{[clmul  $t0, $z3, $polymod]}
+    xor       $z2, $z2, $t1
+    xor       $z1, $z1, $t0
+    @{[clmulh $t1, $z2, $polymod]}
+    @{[clmul  $t0, $z2, $polymod]}
+    xor       $x1, $z1, $t1
+    xor       $x0, $z0, $t0
+
+    # Bit-reverse Xi back and store it
+    @{[brev8  $x0, $x0]}
+    @{[brev8  $x1, $x1]}
+    sd        $x0, 0($Xi)
+    sd        $x1, 8($Xi)
+    ret
+.size gcm_gmult_rv64i_zbc__zbkb,.-gcm_gmult_rv64i_zbc__zbkb
+___
+}
+
+$code .= <<___;
+.p2align 3
+Lbrev8_const:
+    .dword  0xAAAAAAAAAAAAAAAA
+    .dword  0xCCCCCCCCCCCCCCCC
+    .dword  0xF0F0F0F0F0F0F0F0
+.size Lbrev8_const,.-Lbrev8_const
+
+Lpolymod:
+    .byte 0x87
+.size Lpolymod,.-Lpolymod
+___
 
 print $code;
 

--- a/crypto/modes/gcm128.c
+++ b/crypto/modes/gcm128.c
@@ -27,9 +27,10 @@ typedef size_t size_t_aX;
 # define PUTU32(p,v)     *(u32 *)(p) = BSWAP4(v)
 #endif
 
-/* RISC-V uses C implementation of gmult as a fallback. */
+/* RISC-V uses C implementation as a fallback. */
 #if defined(__riscv)
 # define INCLUDE_C_GMULT_4BIT
+# define INCLUDE_C_GHASH_4BIT
 #endif
 
 #define PACK(s)         ((size_t)(s)<<(sizeof(size_t)*8-16))
@@ -232,7 +233,7 @@ static void gcm_gmult_4bit(u64 Xi[2], const u128 Htable[16])
 
 # endif
 
-# if !defined(GHASH_ASM)
+# if !defined(GHASH_ASM) || defined(INCLUDE_C_GHASH_4BIT)
 #  if !defined(OPENSSL_SMALL_FOOTPRINT)
 /*
  * Streamed gcm_mult_4bit, see CRYPTO_gcm128_[en|de]crypt for
@@ -401,14 +402,17 @@ void gcm_ghash_p8(u64 Xi[2], const u128 Htable[16], const u8 *inp,
                   size_t len);
 # elif defined(OPENSSL_CPUID_OBJ) && defined(__riscv) && __riscv_xlen == 64
 #  include "crypto/riscv_arch.h"
-#  define GHASH_ASM_RISCV
-#  undef  GHASH
+#  define GHASH_ASM_RV64I
 /* Zbc/Zbkc (scalar crypto with clmul) based routines. */
 void gcm_init_rv64i_zbc(u128 Htable[16], const u64 Xi[2]);
 void gcm_init_rv64i_zbc__zbb(u128 Htable[16], const u64 Xi[2]);
 void gcm_init_rv64i_zbc__zbkb(u128 Htable[16], const u64 Xi[2]);
 void gcm_gmult_rv64i_zbc(u64 Xi[2], const u128 Htable[16]);
 void gcm_gmult_rv64i_zbc__zbkb(u64 Xi[2], const u128 Htable[16]);
+void gcm_ghash_rv64i_zbc(u64 Xi[2], const u128 Htable[16],
+                         const u8 *inp, size_t len);
+void gcm_ghash_rv64i_zbc__zbkb(u64 Xi[2], const u128 Htable[16],
+                               const u8 *inp, size_t len);
 # endif
 #endif
 
@@ -416,7 +420,7 @@ static void gcm_get_funcs(struct gcm_funcs_st *ctx)
 {
     /* set defaults -- overridden below as needed */
     ctx->ginit = gcm_init_4bit;
-#if !defined(GHASH_ASM) || defined(INCLUDE_C_GMULT_4BIT)
+#if !defined(GHASH_ASM)
     ctx->gmult = gcm_gmult_4bit;
 #else
     ctx->gmult = NULL;
@@ -503,19 +507,24 @@ static void gcm_get_funcs(struct gcm_funcs_st *ctx)
         ctx->ghash = gcm_ghash_p8;
     }
     return;
-#elif defined(GHASH_ASM_RISCV) && __riscv_xlen == 64
-    /* RISCV defaults; gmult already set above */
-    ctx->ghash = NULL;
+#elif defined(GHASH_ASM_RV64I)
+    /* RISCV defaults */
+    ctx->gmult = gcm_gmult_4bit;
+    ctx->ghash = gcm_ghash_4bit;
+
     if (RISCV_HAS_ZBC()) {
         if (RISCV_HAS_ZBKB()) {
             ctx->ginit = gcm_init_rv64i_zbc__zbkb;
             ctx->gmult = gcm_gmult_rv64i_zbc__zbkb;
+            ctx->ghash = gcm_ghash_rv64i_zbc__zbkb;
         } else if (RISCV_HAS_ZBB()) {
             ctx->ginit = gcm_init_rv64i_zbc__zbb;
             ctx->gmult = gcm_gmult_rv64i_zbc;
+            ctx->ghash = gcm_ghash_rv64i_zbc;
         } else {
             ctx->ginit = gcm_init_rv64i_zbc;
             ctx->gmult = gcm_gmult_rv64i_zbc;
+            ctx->ghash = gcm_ghash_rv64i_zbc;
         }
     }
     return;

--- a/crypto/modes/gcm128.c
+++ b/crypto/modes/gcm128.c
@@ -502,7 +502,7 @@ static void gcm_get_funcs(struct gcm_funcs_st *ctx)
 #elif defined(GHASH_ASM_RISCV) && __riscv_xlen == 64
     /* RISCV defaults; gmult already set above */
     ctx->ghash = NULL;
-    if (RISCV_HAS_ZBB() && RISCV_HAS_ZBC()) {
+    if (RISCV_HAS_ZBB_AND_ZBC()) {
         ctx->ginit = gcm_init_clmul_rv64i_zbb_zbc;
         ctx->gmult = gcm_gmult_clmul_rv64i_zbb_zbc;
     }

--- a/crypto/perlasm/riscv.pm
+++ b/crypto/perlasm/riscv.pm
@@ -120,4 +120,33 @@ sub aes64ks2 {
     return ".word ".($template | ($rs2 << 20) | ($rs1 << 15) | ($rd << 7));
 }
 
+sub clmul {
+    # Encoding for clmul rd, rs1, rs2 instruction on RV64
+    #                XXXXXXX_ rs2 _ rs1 _XXX_ rd  _XXXXXXX
+    my $template = 0b0000101_00000_00000_001_00000_0110011;
+    my $rd = read_reg shift;
+    my $rs1 = read_reg shift;
+    my $rs2 = read_reg shift;
+    return ".word ".($template | ($rs2 << 20) | ($rs1 << 15) | ($rd << 7));
+}
+
+sub clmulh {
+    # Encoding for clmulh rd, rs1, rs2 instruction on RV64
+    #                XXXXXXX_ rs2 _ rs1 _XXX_ rd  _XXXXXXX
+    my $template = 0b0000101_00000_00000_011_00000_0110011;
+    my $rd = read_reg shift;
+    my $rs1 = read_reg shift;
+    my $rs2 = read_reg shift;
+    return ".word ".($template | ($rs2 << 20) | ($rs1 << 15) | ($rd << 7));
+}
+
+sub rev8 {
+    # Encoding for rev8 rd, rs instruction on RV64
+    #               XXXXXXXXXXXXX_ rs  _XXX_ rd  _XXXXXXX
+    my $template = 0b011010111000_00000_101_00000_0010011;
+    my $rd = read_reg shift;
+    my $rs = read_reg shift;
+    return ".word ".($template | ($rs << 15) | ($rd << 7));
+}
+
 1;

--- a/crypto/perlasm/riscv.pm
+++ b/crypto/perlasm/riscv.pm
@@ -1,0 +1,101 @@
+#! /usr/bin/env perl
+# Copyright 2023 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+use strict;
+use warnings;
+
+my @regs = map("x$_",(0..31));
+my %reglookup;
+@reglookup{@regs} = @regs;
+
+# Takes a register name, possibly an alias, and converts it to a register index
+# from 0 to 31
+sub read_reg {
+    my $reg = lc shift;
+    if (!exists($reglookup{$reg})) {
+        die("Unknown register ".$reg);
+    }
+    my $regstr = $reglookup{$reg};
+    if (!($regstr =~ /^x([0-9]+)$/)) {
+        die("Could not process register ".$reg);
+    }
+    return $1;
+}
+
+# Scalar crypto instructions
+
+sub aes64ds {
+    # Encoding for aes64ds rd, rs1, rs2 instruction on RV64
+    #                XXXXXXX_ rs2 _ rs1 _XXX_ rd  _XXXXXXX
+    my $template = 0b0011101_00000_00000_000_00000_0110011;
+    my $rd = read_reg shift;
+    my $rs1 = read_reg shift;
+    my $rs2 = read_reg shift;
+    return ".word ".($template | ($rs2 << 20) | ($rs1 << 15) | ($rd << 7));
+}
+
+sub aes64dsm {
+    # Encoding for aes64dsm rd, rs1, rs2 instruction on RV64
+    #                XXXXXXX_ rs2 _ rs1 _XXX_ rd  _XXXXXXX
+    my $template = 0b0011111_00000_00000_000_00000_0110011;
+    my $rd = read_reg shift;
+    my $rs1 = read_reg shift;
+    my $rs2 = read_reg shift;
+    return ".word ".($template | ($rs2 << 20) | ($rs1 << 15) | ($rd << 7));
+}
+
+sub aes64es {
+    # Encoding for aes64es rd, rs1, rs2 instruction on RV64
+    #                XXXXXXX_ rs2 _ rs1 _XXX_ rd  _XXXXXXX
+    my $template = 0b0011001_00000_00000_000_00000_0110011;
+    my $rd = read_reg shift;
+    my $rs1 = read_reg shift;
+    my $rs2 = read_reg shift;
+    return ".word ".($template | ($rs2 << 20) | ($rs1 << 15) | ($rd << 7));
+}
+
+sub aes64esm {
+    # Encoding for aes64esm rd, rs1, rs2 instruction on RV64
+    #                XXXXXXX_ rs2 _ rs1 _XXX_ rd  _XXXXXXX
+    my $template = 0b0011011_00000_00000_000_00000_0110011;
+    my $rd = read_reg shift;
+    my $rs1 = read_reg shift;
+    my $rs2 = read_reg shift;
+    return ".word ".($template | ($rs2 << 20) | ($rs1 << 15) | ($rd << 7));
+}
+
+sub aes64im {
+    # Encoding for aes64im rd, rs1 instruction on RV64
+    #                XXXXXXXXXXXX_ rs1 _XXX_ rd  _XXXXXXX
+    my $template = 0b001100000000_00000_001_00000_0010011;
+    my $rd = read_reg shift;
+    my $rs1 = read_reg shift;
+    return ".word ".($template | ($rs1 << 15) | ($rd << 7));
+}
+
+sub aes64ks1i {
+    # Encoding for aes64ks1i rd, rs1, rnum instruction on RV64
+    #                XXXXXXXX_rnum_ rs1 _XXX_ rd  _XXXXXXX
+    my $template = 0b00110001_0000_00000_001_00000_0010011;
+    my $rd = read_reg shift;
+    my $rs1 = read_reg shift;
+    my $rnum = shift;
+    return ".word ".($template | ($rnum << 20) | ($rs1 << 15) | ($rd << 7));
+}
+
+sub aes64ks2 {
+    # Encoding for aes64ks2 rd, rs1, rs2 instruction on RV64
+    #                XXXXXXX_ rs2 _ rs1 _XXX_ rd  _XXXXXXX
+    my $template = 0b0111111_00000_00000_000_00000_0110011;
+    my $rd = read_reg shift;
+    my $rs1 = read_reg shift;
+    my $rs2 = read_reg shift;
+    return ".word ".($template | ($rs2 << 20) | ($rs1 << 15) | ($rd << 7));
+}
+
+1;

--- a/include/crypto/aes_platform.h
+++ b/include/crypto/aes_platform.h
@@ -434,7 +434,6 @@ void aes256_t4_xts_decrypt(const unsigned char *in, unsigned char *out,
 # elif defined(OPENSSL_CPUID_OBJ) && defined(__riscv) && __riscv_xlen == 64
 /* RISC-V 64 support */
 #  include "riscv_arch.h"
-#  define RV64I_ZKND_ZKNE_CAPABLE   (RISCV_HAS_ZKND() && RISCV_HAS_ZKNE())
 
 int rv64i_zkne_set_encrypt_key(const unsigned char *userKey, const int bits,
                           AES_KEY *key);
@@ -447,8 +446,6 @@ void rv64i_zknd_decrypt(const unsigned char *in, unsigned char *out,
 # elif defined(OPENSSL_CPUID_OBJ) && defined(__riscv) && __riscv_xlen == 32
 /* RISC-V 32 support */
 #  include "riscv_arch.h"
-#  define RV32I_ZKND_ZKNE_CAPABLE   (RISCV_HAS_ZKND() && RISCV_HAS_ZKNE())
-#  define RV32I_ZBKB_ZKND_ZKNE_CAPABLE   (RV32I_ZKND_ZKNE_CAPABLE && RISCV_HAS_ZBKB())
 
 int rv32i_zkne_set_encrypt_key(const unsigned char *userKey, const int bits,
                                AES_KEY *key);

--- a/include/crypto/riscv_arch.h
+++ b/include/crypto/riscv_arch.h
@@ -56,4 +56,9 @@ static const size_t kRISCVNumCaps =
 # include "riscv_arch.def"
 ;
 
+/* Extension combination tests. */
+#define RISCV_HAS_ZBB_AND_ZBC() (RISCV_HAS_ZBB() && RISCV_HAS_ZBC())
+#define RISCV_HAS_ZBKB_AND_ZKND_AND_ZKNE() (RISCV_HAS_ZBKB() && RISCV_HAS_ZKND() && RISCV_HAS_ZKNE())
+#define RISCV_HAS_ZKND_AND_ZKNE() (RISCV_HAS_ZKND() && RISCV_HAS_ZKNE())
+
 #endif

--- a/providers/implementations/ciphers/cipher_aes_ccm_hw.c
+++ b/providers/implementations/ciphers/cipher_aes_ccm_hw.c
@@ -61,10 +61,10 @@ static const PROV_CCM_HW aes_ccm = {
 # include "cipher_aes_ccm_hw_aesni.inc"
 #elif defined(SPARC_AES_CAPABLE)
 # include "cipher_aes_ccm_hw_t4.inc"
-#elif defined(RV64I_ZKND_ZKNE_CAPABLE)
-# include "cipher_aes_ccm_hw_rv64i_zknd_zkne.inc"
-#elif defined(RV32I_ZBKB_ZKND_ZKNE_CAPABLE) && defined(RV32I_ZKND_ZKNE_CAPABLE)
-# include "cipher_aes_ccm_hw_rv32i_zknd_zkne.inc"
+#elif defined(__riscv) && __riscv_xlen == 64
+# include "cipher_aes_ccm_hw_rv64i.inc"
+#elif defined(__riscv) && __riscv_xlen == 32
+# include "cipher_aes_ccm_hw_rv32i.inc"
 #else
 const PROV_CCM_HW *ossl_prov_aes_hw_ccm(size_t keybits)
 {

--- a/providers/implementations/ciphers/cipher_aes_ccm_hw_rv32i.inc
+++ b/providers/implementations/ciphers/cipher_aes_ccm_hw_rv32i.inc
@@ -52,9 +52,9 @@ static const PROV_CCM_HW rv32i_zbkb_zknd_zkne_ccm = {
 
 const PROV_CCM_HW *ossl_prov_aes_hw_ccm(size_t keybits)
 {
-    if (RV32I_ZBKB_ZKND_ZKNE_CAPABLE)
+    if (RISCV_HAS_ZBKB_AND_ZKND_AND_ZKNE())
         return &rv32i_zbkb_zknd_zkne_ccm;
-    if (RV32I_ZKND_ZKNE_CAPABLE)
+    if (RISCV_HAS_ZKND_AND_ZKNE())
         return &rv32i_zknd_zkne_ccm;
     return &aes_ccm;
 }

--- a/providers/implementations/ciphers/cipher_aes_ccm_hw_rv64i.inc
+++ b/providers/implementations/ciphers/cipher_aes_ccm_hw_rv64i.inc
@@ -33,5 +33,5 @@ static const PROV_CCM_HW rv64i_zknd_zkne_ccm = {
 
 const PROV_CCM_HW *ossl_prov_aes_hw_ccm(size_t keybits)
 {
-    return RV64I_ZKND_ZKNE_CAPABLE ? &rv64i_zknd_zkne_ccm : &aes_ccm;
+    return RISCV_HAS_ZKND_AND_ZKNE() ? &rv64i_zknd_zkne_ccm : &aes_ccm;
 }

--- a/providers/implementations/ciphers/cipher_aes_gcm_hw.c
+++ b/providers/implementations/ciphers/cipher_aes_gcm_hw.c
@@ -143,10 +143,10 @@ static const PROV_GCM_HW aes_gcm = {
 # include "cipher_aes_gcm_hw_armv8.inc"
 #elif defined(PPC_AES_GCM_CAPABLE)
 # include "cipher_aes_gcm_hw_ppc.inc"
-#elif defined(RV64I_ZKND_ZKNE_CAPABLE)
-# include "cipher_aes_gcm_hw_rv64i_zknd_zkne.inc"
-#elif defined(RV32I_ZBKB_ZKND_ZKNE_CAPABLE) && defined(RV32I_ZKND_ZKNE_CAPABLE)
-# include "cipher_aes_gcm_hw_rv32i_zknd_zkne.inc"
+#elif defined(__riscv) && __riscv_xlen == 64
+# include "cipher_aes_gcm_hw_rv64i.inc"
+#elif defined(__riscv) && __riscv_xlen == 32
+# include "cipher_aes_gcm_hw_rv32i.inc"
 #else
 const PROV_GCM_HW *ossl_prov_aes_hw_gcm(size_t keybits)
 {

--- a/providers/implementations/ciphers/cipher_aes_gcm_hw_rv32i.inc
+++ b/providers/implementations/ciphers/cipher_aes_gcm_hw_rv32i.inc
@@ -55,9 +55,9 @@ static const PROV_GCM_HW rv32i_zbkb_zknd_zkne_gcm = {
 
 const PROV_GCM_HW *ossl_prov_aes_hw_gcm(size_t keybits)
 {
-    if (RV32I_ZBKB_ZKND_ZKNE_CAPABLE)
+    if (RISCV_HAS_ZBKB_AND_ZKND_AND_ZKNE())
         return &rv32i_zbkb_zknd_zkne_gcm;
-    if (RV32I_ZKND_ZKNE_CAPABLE)
+    if (RISCV_HAS_ZKND_AND_ZKNE())
         return &rv32i_zknd_zkne_gcm;
     return &aes_gcm;
 }

--- a/providers/implementations/ciphers/cipher_aes_gcm_hw_rv64i.inc
+++ b/providers/implementations/ciphers/cipher_aes_gcm_hw_rv64i.inc
@@ -33,7 +33,7 @@ static const PROV_GCM_HW rv64i_zknd_zkne_gcm = {
 
 const PROV_GCM_HW *ossl_prov_aes_hw_gcm(size_t keybits)
 {
-    if (RV64I_ZKND_ZKNE_CAPABLE)
+    if (RISCV_HAS_ZKND_AND_ZKNE())
         return &rv64i_zknd_zkne_gcm;
     else
         return &aes_gcm;

--- a/providers/implementations/ciphers/cipher_aes_hw.c
+++ b/providers/implementations/ciphers/cipher_aes_hw.c
@@ -142,10 +142,10 @@ const PROV_CIPHER_HW *ossl_prov_cipher_hw_aes_##mode(size_t keybits)           \
 # include "cipher_aes_hw_t4.inc"
 #elif defined(S390X_aes_128_CAPABLE)
 # include "cipher_aes_hw_s390x.inc"
-#elif defined(RV64I_ZKND_ZKNE_CAPABLE)
-# include "cipher_aes_hw_rv64i_zknd_zkne.inc"
-#elif defined(RV32I_ZBKB_ZKND_ZKNE_CAPABLE) && defined(RV32I_ZKND_ZKNE_CAPABLE)
-# include "cipher_aes_hw_rv32i_zknd_zkne.inc"
+#elif defined(__riscv) && __riscv_xlen == 64
+# include "cipher_aes_hw_rv64i.inc"
+#elif defined(__riscv) && __riscv_xlen == 32
+# include "cipher_aes_hw_rv32i.inc"
 #else
 /* The generic case */
 # define PROV_CIPHER_HW_declare(mode)

--- a/providers/implementations/ciphers/cipher_aes_hw_rv32i.inc
+++ b/providers/implementations/ciphers/cipher_aes_hw_rv32i.inc
@@ -96,7 +96,7 @@ static const PROV_CIPHER_HW rv32i_zbkb_zknd_zkne_##mode = {                    \
     cipher_hw_aes_copyctx                                                      \
 };
 #define PROV_CIPHER_HW_select(mode)                                            \
-if (RV32I_ZBKB_ZKND_ZKNE_CAPABLE)                                              \
+if (RISCV_HAS_ZBKB_AND_ZKND_AND_ZKNE())                                        \
     return &rv32i_zbkb_zknd_zkne_##mode;                                       \
-if (RV32I_ZKND_ZKNE_CAPABLE)                                                   \
+if (RISCV_HAS_ZKND_AND_ZKNE())                                                 \
     return &rv32i_zknd_zkne_##mode;

--- a/providers/implementations/ciphers/cipher_aes_hw_rv64i.inc
+++ b/providers/implementations/ciphers/cipher_aes_hw_rv64i.inc
@@ -55,5 +55,5 @@ static const PROV_CIPHER_HW rv64i_zknd_zkne_##mode = {                         \
     cipher_hw_aes_copyctx                                                      \
 };
 #define PROV_CIPHER_HW_select(mode)                                            \
-if (RV64I_ZKND_ZKNE_CAPABLE)                                                   \
+if (RISCV_HAS_ZKND_AND_ZKNE())                                                 \
     return &rv64i_zknd_zkne_##mode;

--- a/providers/implementations/ciphers/cipher_aes_ocb_hw.c
+++ b/providers/implementations/ciphers/cipher_aes_ocb_hw.c
@@ -103,7 +103,8 @@ static const PROV_CIPHER_HW aes_t4_ocb = {                                     \
 # define PROV_CIPHER_HW_select()                                               \
     if (SPARC_AES_CAPABLE)                                                     \
         return &aes_t4_ocb;
-#elif defined(RV64I_ZKND_ZKNE_CAPABLE)
+
+#elif defined(__riscv) && __riscv_xlen == 64
 
 static int cipher_hw_aes_ocb_rv64i_zknd_zkne_initkey(PROV_CIPHER_CTX *vctx,
                                                      const unsigned char *key,
@@ -122,9 +123,10 @@ static const PROV_CIPHER_HW aes_rv64i_zknd_zkne_ocb = {                        \
     NULL                                                                       \
 };
 # define PROV_CIPHER_HW_select()                                               \
-    if (RV64I_ZKND_ZKNE_CAPABLE)                                               \
+    if (RISCV_HAS_ZKND_AND_ZKNE())                                             \
         return &aes_rv64i_zknd_zkne_ocb;
-#elif defined(RV32I_ZBKB_ZKND_ZKNE_CAPABLE) && defined(RV32I_ZKND_ZKNE_CAPABLE)
+
+#elif defined(__riscv) && __riscv_xlen == 32
 
 static int cipher_hw_aes_ocb_rv32i_zknd_zkne_initkey(PROV_CIPHER_CTX *vctx,
                                                      const unsigned char *key,
@@ -158,9 +160,9 @@ static const PROV_CIPHER_HW aes_rv32i_zbkb_zknd_zkne_ocb = {                   \
     NULL                                                                       \
 };
 # define PROV_CIPHER_HW_select()                                               \
-    if (RV32I_ZBKB_ZKND_ZKNE_CAPABLE)                                          \
+    if (RISCV_HAS_ZBKB_AND_ZKND_AND_ZKNE())                                    \
         return &aes_rv32i_zbkb_zknd_zkne_ocb;                                  \
-    if (RV32I_ZKND_ZKNE_CAPABLE)                                               \
+    if (RISCV_HAS_ZKND_AND_ZKNE())                                             \
         return &aes_rv32i_zknd_zkne_ocb;
 #else
 # define PROV_CIPHER_HW_declare()

--- a/providers/implementations/ciphers/cipher_aes_xts_hw.c
+++ b/providers/implementations/ciphers/cipher_aes_xts_hw.c
@@ -158,7 +158,8 @@ static const PROV_CIPHER_HW aes_xts_t4 = {                                     \
 # define PROV_CIPHER_HW_select_xts()                                           \
 if (SPARC_AES_CAPABLE)                                                         \
     return &aes_xts_t4;
-#elif defined(RV64I_ZKND_ZKNE_CAPABLE)
+
+#elif defined(__riscv) && __riscv_xlen == 64
 
 static int cipher_hw_aes_xts_rv64i_zknd_zkne_initkey(PROV_CIPHER_CTX *ctx,
                                                      const unsigned char *key,
@@ -181,9 +182,10 @@ static const PROV_CIPHER_HW aes_xts_rv64i_zknd_zkne = {                        \
     cipher_hw_aes_xts_copyctx                                                  \
 };
 # define PROV_CIPHER_HW_select_xts()                                           \
-if (RV64I_ZKND_ZKNE_CAPABLE)                                                   \
+if (RISCV_HAS_ZKND_AND_ZKNE())                                                 \
     return &aes_xts_rv64i_zknd_zkne;
-#elif defined(RV32I_ZBKB_ZKND_ZKNE_CAPABLE) && defined(RV32I_ZKND_ZKNE_CAPABLE)
+
+#elif defined(__riscv) && __riscv_xlen == 32
 
 static int cipher_hw_aes_xts_rv32i_zknd_zkne_initkey(PROV_CIPHER_CTX *ctx,
                                                      const unsigned char *key,
@@ -221,9 +223,9 @@ static const PROV_CIPHER_HW aes_xts_rv32i_zbkb_zknd_zkne = {                   \
     cipher_hw_aes_xts_copyctx                                                  \
 };
 # define PROV_CIPHER_HW_select_xts()                                           \
-if (RV32I_ZBKB_ZKND_ZKNE_CAPABLE)                                              \
+if (RISCV_HAS_ZBKB_AND_ZKND_AND_ZKNE())                                        \
     return &aes_xts_rv32i_zbkb_zknd_zkne;                                      \
-if (RV32I_ZKND_ZKNE_CAPABLE)                                                   \
+if (RISCV_HAS_ZKND_ZKNE())                                                     \
     return &aes_xts_rv32i_zknd_zkne;
 # else
 /* The generic case */


### PR DESCRIPTION
The current RISC-V GCM implementation does not include a `.ghash()` callback. This is an issue for future improvements (i.e. adding new GCM implementations for the upcoming vector crypto ISA extensions). Therefore, this PR adds this missing piece.

Unfortunately, this was a bit more work than expected because the current implementation needed to be replaced by an improved `.gmult()` code sequence to free up registers so the loop in `.ghash()` could be realized without stack utilization.

During testing, it was observed that no test calls `.ghash()` with more than 1 block (i.e. 16 bytes) of data. Therefore, I wrote a new one. Plus, yet another one which also triggers another code path in `gcm128.c` (running into the `GHASH_CHUNK` limitation).

During the work it was observed that the RISC-V extension test macros deserve some clean-ups to make them easier to read (e.g. extension tests are only relevant for run-time decisions) and extend. The related changes are included in this series.

The `.ghash()` implementation itself is straightforward. It just includes the XOR-loop into the `gmult()` sequence.

All code has been tested using upstream QEMU.

Test instructions:
```
OPENSSL_riscvcap_base="rv64gc"
OPENSSL_riscvcap_zbc="rv64gc_zbc"
OPENSSL_riscvcap_zbc_zbb="rv64gc_zbc_zbb"
OPENSSL_riscvcap_zbc_zbkb="rv64gc_zbc_zbkb"

QEMU_CPU_BASE="rv64"
QEMU_CPU_ZBC="rv64,zbc=true"
QEMU_CPU_ZBC_ZBB="rv64,zbc=true,zbb=true"
QEMU_CPU_ZBC_ZBKB="rv64,zbc=true,zbkb=true"

# Must succeed
OPENSSL_riscvcap=$OPENSSL_riscvcap_base QEMU_CPU=$QEMU_CPU_BASE ../build.sh test build noclean
OPENSSL_riscvcap=$OPENSSL_riscvcap_zbc QEMU_CPU=$QEMU_CPU_ZBC ../build.sh test build noclean
OPENSSL_riscvcap=$OPENSSL_riscvcap_zbc_zbb QEMU_CPU=$QEMU_CPU_ZBC_ZBB ../build.sh test build noclean
OPENSSL_riscvcap=$OPENSSL_riscvcap_zbc_zbkb QEMU_CPU=$QEMU_CPU_ZBC_ZBKB ../build.sh test build noclean

# Must fail (illegal instr)
OPENSSL_riscvcap=$OPENSSL_riscvcap_zbc QEMU_CPU=$QEMU_CPU_BASE ../build.sh test build noclean
OPENSSL_riscvcap=$OPENSSL_riscvcap_zbc_zbb QEMU_CPU=$QEMU_CPU_ZBC ../build.sh test build noclean
OPENSSL_riscvcap=$OPENSSL_riscvcap_zbc_zbkb QEMU_CPU=$QEMU_CPU_ZBC ../build.sh test build noclean
```