### PR TITLE
fips: document that the ECX curves are not-validated

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -209,6 +209,14 @@ OpenSSL 3.1
 
 ### Changes between 3.0 and 3.1.0 [xx XXX xxxx]
 
+ * The FIPS provider includes a few non-approved algorithms for
+   backward compatibility purposes and the "fips=yes" property query
+   must be used for all algorithm fetches to ensure FIPS compliance.
+
+   The algorithms that are included but not approved are Triple DES and EdDSA.
+
+   *Paul Dale*
+
  * Added support for KMAC in KBKDF.
 
    *Shane Lontis*

--- a/doc/man7/OSSL_PROVIDER-FIPS.pod
+++ b/doc/man7/OSSL_PROVIDER-FIPS.pod
@@ -392,15 +392,15 @@ A simple self test callback is shown below for illustrative purposes.
 
 =head1 NOTES
 
-The FIPS provider in OpenSSL 3.1 includes some non-FIPS validated elliptic curves,
+The FIPS provider in OpenSSL 3.1 includes some non-FIPS validated algorithms,
 consequently the property query C<fips=yes> is mandatory for applications that
-want to operate in a FIPS approved manner.  The curves are:
+want to operate in a FIPS approved manner.  The algoriths are:
 
 =over 4
 
-=item Ed25519
+=item Triple DES
 
-=item Ed448
+=item EdDSA
 
 =back
 

--- a/doc/man7/OSSL_PROVIDER-FIPS.pod
+++ b/doc/man7/OSSL_PROVIDER-FIPS.pod
@@ -394,7 +394,7 @@ A simple self test callback is shown below for illustrative purposes.
 
 The FIPS provider in OpenSSL 3.1 includes some non-FIPS validated algorithms,
 consequently the property query C<fips=yes> is mandatory for applications that
-want to operate in a FIPS approved manner.  The algoriths are:
+want to operate in a FIPS approved manner.  The algorithms are:
 
 =over 4
 

--- a/doc/man7/OSSL_PROVIDER-FIPS.pod
+++ b/doc/man7/OSSL_PROVIDER-FIPS.pod
@@ -7,7 +7,7 @@ OSSL_PROVIDER-FIPS - OpenSSL FIPS provider
 =head1 DESCRIPTION
 
 The OpenSSL FIPS provider is a special provider that conforms to the Federal
-Information Processing Standards (FIPS) specified in FIPS 140-2. This 'module'
+Information Processing Standards (FIPS) specified in FIPS 140-3. This 'module'
 contains an approved set of cryptographic algorithms that is validated by an
 accredited testing laboratory.
 
@@ -32,7 +32,7 @@ L<EVP_PKEY_CTX_new_from_name(3)>.
 It isn't mandatory to query for any of these properties, except to
 make sure to get implementations of this provider and none other.
 
-The "fips=yes" property can be use to make sure only FIPS approved
+The C<fips=yes> property can be use to make sure only FIPS approved
 implementations are used for crypto operations.  This may also include
 other non-crypto support operations that are not in the FIPS provider,
 such as asymmetric key encoders,
@@ -390,6 +390,20 @@ A simple self test callback is shown below for illustrative purposes.
     return ret;
   }
 
+=head1 NOTES
+
+The FIPS provider in OpenSSL 3.1 includes some non-FIPS validated elliptic curves,
+consequently the property query C<fips=yes> is mandatory for applications that
+want to operate in a FIPS approved manner.  The curves are:
+
+=over 4
+
+=item Ed25519
+
+=item Ed448
+
+=back
+
 =head1 SEE ALSO
 
 L<openssl-fipsinstall(1)>,
@@ -404,6 +418,10 @@ L<provider(7)>
 =head1 HISTORY
 
 This functionality was added in OpenSSL 3.0.
+
+OpenSSL 3.0 includes a FIPS 140-2 approved FIPS provider.
+
+OpenSSL 3.1 includes a FIPS 140-3 approved FIPS provider.
 
 =head1 COPYRIGHT
 

--- a/doc/man7/fips_module.pod
+++ b/doc/man7/fips_module.pod
@@ -472,7 +472,7 @@ L<OSSL_PROVIDER_get0_name(3)>.
 
 The FIPS provider in OpenSSL 3.1 includes some non-FIPS validated algorithms,
 consequently the property query C<fips=yes> is mandatory for applications that
-want to operate in a FIPS approved manner.  The algoriths are:
+want to operate in a FIPS approved manner.  The algorithms are:
 
 =over 4
 

--- a/doc/man7/fips_module.pod
+++ b/doc/man7/fips_module.pod
@@ -80,6 +80,7 @@ Edit the config file to add the following lines near the beginning:
 
     [openssl_init]
     providers = provider_sect
+    alg_section = algorithm_sect
 
     [provider_sect]
     fips = fips_sect
@@ -87,6 +88,9 @@ Edit the config file to add the following lines near the beginning:
 
     [base_sect]
     activate = 1
+
+    [algorithm_sect]
+    default_properties = fips=yes
 
 Obviously the include file location above should match the path and name of the
 FIPS module config file that you installed earlier.
@@ -341,7 +345,7 @@ base providers. The other library context will just use the default provider.
     /* As an example get some digests */
 
     /* Get a FIPS validated digest */
-    fipssha256 = EVP_MD_fetch(fips_libctx, "SHA2-256", NULL);
+    fipssha256 = EVP_MD_fetch(fips_libctx, "SHA2-256", "fips=yes");
     if (fipssha256 == NULL)
         goto err;
 
@@ -419,7 +423,7 @@ contexts.
      * We assume that a nondefault library context with the FIPS
      * provider loaded has been created called fips_libctx.
      */
-    SSL_CTX *fips_ssl_ctx = SSL_CTX_new_ex(fips_libctx, NULL, TLS_method());
+    SSL_CTX *fips_ssl_ctx = SSL_CTX_new_ex(fips_libctx, "fips=yes", TLS_method());
     /*
      * We assume that a nondefault library context with the default
      * provider loaded has been created called non_fips_libctx.
@@ -456,6 +460,20 @@ use L<EVP_MD_get0_provider(3)>.
 To extract the name from the B<OSSL_PROVIDER>, use
 L<OSSL_PROVIDER_get0_name(3)>.
 
+=head1 NOTES
+
+The FIPS provider in OpenSSL 3.1 includes some non-FIPS validated elliptic curves,
+consequently the property query C<fips=yes> is mandatory for applications that
+want to operate in a FIPS approved manner.  The curves are:
+
+=over 4
+
+=item Ed25519
+
+=item Ed448
+
+=back
+
 =head1 SEE ALSO
 
 L<migration_guide(7)>, L<crypto(7)>, L<fips_config(5)>
@@ -464,6 +482,10 @@ L<migration_guide(7)>, L<crypto(7)>, L<fips_config(5)>
 
 The FIPS module guide was created for use with the new FIPS provider
 in OpenSSL 3.0.
+
+OpenSSL 3.0 includes a FIPS 140-2 approved FIPS provider.
+
+OpenSSL 3.1 includes a FIPS 140-3 approved FIPS provider.
 
 =head1 COPYRIGHT
 

--- a/doc/man7/fips_module.pod
+++ b/doc/man7/fips_module.pod
@@ -462,15 +462,15 @@ L<OSSL_PROVIDER_get0_name(3)>.
 
 =head1 NOTES
 
-The FIPS provider in OpenSSL 3.1 includes some non-FIPS validated elliptic curves,
+The FIPS provider in OpenSSL 3.1 includes some non-FIPS validated algorithms,
 consequently the property query C<fips=yes> is mandatory for applications that
-want to operate in a FIPS approved manner.  The curves are:
+want to operate in a FIPS approved manner.  The algoriths are:
 
 =over 4
 
-=item Ed25519
+=item Triple DES
 
-=item Ed448
+=item EdDSA
 
 =back
 

--- a/doc/man7/fips_module.pod
+++ b/doc/man7/fips_module.pod
@@ -335,6 +335,14 @@ base providers. The other library context will just use the default provider.
         goto err;
 
     /*
+     * Set the default property query on the FIPS library context to
+     * ensure that only FIPS algorithms can be used.  There are a few non-FIPS
+     * approved algorithms in the FIPS provider for backward compatibility reasons.
+     */
+    if (!EVP_set_default_properties(fips_libctx, "fips=yes"))
+        goto err;
+
+    /*
      * We don't need to do anything special to load the default
      * provider into nonfips_libctx. This happens automatically if no
      * other providers are loaded.
@@ -345,7 +353,7 @@ base providers. The other library context will just use the default provider.
     /* As an example get some digests */
 
     /* Get a FIPS validated digest */
-    fipssha256 = EVP_MD_fetch(fips_libctx, "SHA2-256", "fips=yes");
+    fipssha256 = EVP_MD_fetch(fips_libctx, "SHA2-256", NULL);
     if (fipssha256 == NULL)
         goto err;
 

--- a/doc/man7/migration_guide.pod
+++ b/doc/man7/migration_guide.pod
@@ -22,7 +22,7 @@ L<crypto(7)>.
 
 The FIPS provider in OpenSSL 3.1 includes some non-FIPS validated algorithms,
 consequently the property query C<fips=yes> is mandatory for applications that
-want to operate in a FIPS approved manner.  The algoriths are:
+want to operate in a FIPS approved manner.  The algorithms are:
 
 =over 4
 

--- a/doc/man7/migration_guide.pod
+++ b/doc/man7/migration_guide.pod
@@ -20,7 +20,19 @@ L<crypto(7)>.
 
 =head2 Main Changes from OpenSSL 3.0
 
-There are no changes requiring additional migration measures since OpenSSL 3.0.
+The FIPS provider in OpenSSL 3.1 includes some non-FIPS validated elliptic curves,
+consequently the property query C<fips=yes> is mandatory for applications that
+want to operate in a FIPS approved manner.  The curves are:
+
+=over 4
+
+=item Ed25519
+
+=item Ed448
+
+=back
+
+There are no other changes requiring additional migration measures since OpenSSL 3.0.
 
 =head1 OPENSSL 3.0
 

--- a/doc/man7/migration_guide.pod
+++ b/doc/man7/migration_guide.pod
@@ -20,15 +20,15 @@ L<crypto(7)>.
 
 =head2 Main Changes from OpenSSL 3.0
 
-The FIPS provider in OpenSSL 3.1 includes some non-FIPS validated elliptic curves,
+The FIPS provider in OpenSSL 3.1 includes some non-FIPS validated algorithms,
 consequently the property query C<fips=yes> is mandatory for applications that
-want to operate in a FIPS approved manner.  The curves are:
+want to operate in a FIPS approved manner.  The algoriths are:
 
 =over 4
 
-=item Ed25519
+=item Triple DES
 
-=item Ed448
+=item EdDSA
 
 =back
 

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -378,8 +378,8 @@ static const OSSL_ALGORITHM fips_keyexch[] = {
 #endif
 #ifndef OPENSSL_NO_EC
     { PROV_NAMES_ECDH, FIPS_DEFAULT_PROPERTIES, ossl_ecdh_keyexch_functions },
-    { PROV_NAMES_X25519, FIPS_UNAPPROVED_PROPERTIES, ossl_x25519_keyexch_functions },
-    { PROV_NAMES_X448, FIPS_UNAPPROVED_PROPERTIES, ossl_x448_keyexch_functions },
+    { PROV_NAMES_X25519, FIPS_DEFAULT_PROPERTIES, ossl_x25519_keyexch_functions },
+    { PROV_NAMES_X448, FIPS_DEFAULT_PROPERTIES, ossl_x448_keyexch_functions },
 #endif
     { PROV_NAMES_TLS1_PRF, FIPS_DEFAULT_PROPERTIES,
       ossl_kdf_tls1_prf_keyexch_functions },
@@ -435,9 +435,9 @@ static const OSSL_ALGORITHM fips_keymgmt[] = {
 #ifndef OPENSSL_NO_EC
     { PROV_NAMES_EC, FIPS_DEFAULT_PROPERTIES, ossl_ec_keymgmt_functions,
       PROV_DESCS_EC },
-    { PROV_NAMES_X25519, FIPS_UNAPPROVED_PROPERTIES, ossl_x25519_keymgmt_functions,
+    { PROV_NAMES_X25519, FIPS_DEFAULT_PROPERTIES, ossl_x25519_keymgmt_functions,
       PROV_DESCS_X25519 },
-    { PROV_NAMES_X448, FIPS_UNAPPROVED_PROPERTIES, ossl_x448_keymgmt_functions,
+    { PROV_NAMES_X448, FIPS_DEFAULT_PROPERTIES, ossl_x448_keymgmt_functions,
       PROV_DESCS_X448 },
     { PROV_NAMES_ED25519, FIPS_UNAPPROVED_PROPERTIES, ossl_ed25519_keymgmt_functions,
       PROV_DESCS_ED25519 },

--- a/test/fips-and-base.cnf
+++ b/test/fips-and-base.cnf
@@ -7,6 +7,12 @@ config_diagnostics = 1
 
 [openssl_init]
 providers = provider_sect
+# You MUST uncomment the following line to operate in a FIPS approved manner,
+# It is commented out here purely for testing purposes.
+#alg_section = evp_properties
+
+[evp_properties]
+default_properties = "fips=yes"
 
 [provider_sect]
 fips = fips_sect


### PR DESCRIPTION
Ed25519, Ed448, X25519 and X448 are included in the FIPS 140-3 provider for compatibility purposes but are flagged as "fips=no" to prevent their accidental use.  This therefore requires that applications always specify the "fips=yes" property query to enforce FIPS correctness.


- [x] documentation is added or updated
- [ ] tests are added or updated
