### PR TITLE
Ensure our buffer allocation allows for the Explicit IV

### DIFF
--- a/ssl/record/methods/tls_common.c
+++ b/ssl/record/methods/tls_common.c
@@ -158,11 +158,15 @@ int tls_setup_write_buffer(OSSL_RECORD_LAYER *rl, size_t numwpipes,
 #endif
 
         defltlen = rl->max_frag_len + SSL3_RT_SEND_MAX_ENCRYPTED_OVERHEAD
-                   + headerlen + align;
+                   + headerlen + align + rl->eivlen;
 #ifndef OPENSSL_NO_COMP
         if (tls_allow_compression(rl))
             defltlen += SSL3_RT_MAX_COMPRESSED_OVERHEAD;
 #endif
+        /*
+         * We don't need to add eivlen here since empty fragments only occur
+         * when we don't have an explicit IV
+         */
         if (!(rl->options & SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS))
             defltlen += headerlen + align + SSL3_RT_SEND_MAX_ENCRYPTED_OVERHEAD;
     }

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -1545,7 +1545,7 @@ static int test_large_app_data(int tst)
     SSL_CTX *cctx = NULL, *sctx = NULL;
     SSL *clientssl = NULL, *serverssl = NULL;
     int testresult = 0, prot;
-    unsigned char *msg, *buf;
+    unsigned char *msg, *buf = NULL;
     size_t written, readbytes;
 
     switch (tst >> 2) {

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -1594,6 +1594,9 @@ static int test_large_app_data(int tst)
         return 0;
     }
 
+    if (prot < TLS1_2_VERSION && is_fips)
+        return 1;
+
     /* Maximal sized message of zeros */
     msg = OPENSSL_zalloc(SSL3_RT_MAX_PLAIN_LENGTH);
     if (!TEST_ptr(msg))

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -1550,7 +1550,7 @@ static int test_large_app_data(int tst)
 
     switch (tst >> 2) {
     case 0:
-#ifndef OPENSSL_NO_TLS1_3
+#ifndef OSSL_NO_USABLE_TLS1_3
         prot = TLS1_3_VERSION;
         break;
 #else

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -1547,6 +1547,8 @@ static int test_large_app_data(int tst)
     int testresult = 0, prot;
     unsigned char *msg, *buf = NULL;
     size_t written, readbytes;
+    const SSL_METHOD *smeth = TLS_server_method();
+    const SSL_METHOD *cmeth = TLS_client_method();
 
     switch (tst >> 2) {
     case 0:
@@ -1589,12 +1591,32 @@ static int test_large_app_data(int tst)
         return 1;
 #endif
 
+    case 5:
+#ifndef OPENSSL_NO_DTLS1_2
+        prot = DTLS1_2_VERSION;
+        smeth = DTLS_server_method();
+        cmeth = DTLS_client_method();
+        break;
+#else
+        return 1;
+#endif
+
+    case 6:
+#ifndef OPENSSL_NO_DTLS1
+        prot = DTLS1_VERSION;
+        smeth = DTLS_server_method();
+        cmeth = DTLS_client_method();
+        break;
+#else
+        return 1;
+#endif
+
     default:
         /* Shouldn't happen */
         return 0;
     }
 
-    if (prot < TLS1_2_VERSION && is_fips)
+    if ((prot < TLS1_2_VERSION || prot == DTLS1_VERSION) && is_fips)
         return 1;
 
     /* Maximal sized message of zeros */
@@ -1608,12 +1630,11 @@ static int test_large_app_data(int tst)
     /* Set whole buffer to all bits set */
     memset(buf, 0xff, SSL3_RT_MAX_PLAIN_LENGTH + 1);
 
-    if (!TEST_true(create_ssl_ctx_pair(libctx, TLS_server_method(),
-                                       TLS_client_method(), prot, prot,
+    if (!TEST_true(create_ssl_ctx_pair(libctx, smeth, cmeth, prot, prot,
                                        &sctx, &cctx, cert, privkey)))
         goto end;
 
-    if ((prot < TLS1_2_VERSION)) {
+    if (prot < TLS1_2_VERSION || prot == DTLS1_VERSION) {
         /* Older protocol versions need SECLEVEL=0 due to SHA1 usage */
         if (!TEST_true(SSL_CTX_set_cipher_list(cctx, "DEFAULT:@SECLEVEL=0"))
                 || !TEST_true(SSL_CTX_set_cipher_list(sctx,
@@ -10703,7 +10724,7 @@ int setup_tests(void)
 #ifndef OPENSSL_NO_DTLS
     ADD_TEST(test_large_message_dtls);
 #endif
-    ADD_ALL_TESTS(test_large_app_data, 20);
+    ADD_ALL_TESTS(test_large_app_data, 28);
     ADD_TEST(test_cleanse_plaintext);
 #ifndef OPENSSL_NO_OCSP
     ADD_TEST(test_tlsext_status_type);

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -1532,6 +1532,143 @@ static int test_large_message_dtls(void)
 }
 #endif
 
+/*
+ * Test we can successfully send the maximum amount of application data. We
+ * test each protocol version individually, each with and without EtM enabled.
+ * TLSv1.3 doesn't use EtM so technically it is redundant to test both but it is
+ * simpler this way. We also test all combinations with and without the
+ * SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS option which affects the size of the
+ * underlying buffer.
+ */
+static int test_large_app_data(int tst)
+{
+    SSL_CTX *cctx = NULL, *sctx = NULL;
+    SSL *clientssl = NULL, *serverssl = NULL;
+    int testresult = 0, prot;
+    unsigned char *msg, *buf;
+    size_t written, readbytes;
+
+    switch (tst >> 2) {
+    case 0:
+#ifndef OPENSSL_NO_TLS1_3
+        prot = TLS1_3_VERSION;
+        break;
+#else
+        return 1;
+#endif
+
+    case 1:
+#ifndef OPENSSL_NO_TLS1_2
+        prot = TLS1_2_VERSION;
+        break;
+#else
+        return 1;
+#endif
+
+    case 2:
+#ifndef OPENSSL_NO_TLS1_1
+        prot = TLS1_1_VERSION;
+        break;
+#else
+        return 1;
+#endif
+
+    case 3:
+#ifndef OPENSSL_NO_TLS1
+        prot = TLS1_VERSION;
+        break;
+#else
+        return 1;
+#endif
+
+    case 4:
+#ifndef OPENSSL_NO_SSL3
+        prot = SSL3_VERSION;
+        break;
+#else
+        return 1;
+#endif
+
+    default:
+        /* Shouldn't happen */
+        return 0;
+    }
+
+    /* Maximal sized message of zeros */
+    msg = OPENSSL_zalloc(SSL3_RT_MAX_PLAIN_LENGTH);
+    if (!TEST_ptr(msg))
+        goto end;
+
+    buf = OPENSSL_malloc(SSL3_RT_MAX_PLAIN_LENGTH + 1);
+    if (!TEST_ptr(buf))
+        goto end;
+    /* Set whole buffer to all bits set */
+    memset(buf, 0xff, SSL3_RT_MAX_PLAIN_LENGTH + 1);
+
+    if (!TEST_true(create_ssl_ctx_pair(libctx, TLS_server_method(),
+                                       TLS_client_method(), prot, prot,
+                                       &sctx, &cctx, cert, privkey)))
+        goto end;
+
+    if ((prot < TLS1_2_VERSION)) {
+        /* Older protocol versions need SECLEVEL=0 due to SHA1 usage */
+        if (!TEST_true(SSL_CTX_set_cipher_list(cctx, "DEFAULT:@SECLEVEL=0"))
+                || !TEST_true(SSL_CTX_set_cipher_list(sctx,
+                                                      "DEFAULT:@SECLEVEL=0")))
+        goto end;
+    }
+
+    if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl,
+                                      &clientssl, NULL, NULL)))
+        goto end;
+
+    if ((tst & 1) != 0) {
+        /* Setting this option gives us a minimally sized underlying buffer */
+        if (!TEST_true(SSL_set_options(serverssl,
+                                       SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS))
+                || !TEST_true(SSL_set_options(clientssl,
+                                              SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS)))
+            goto end;
+    }
+
+    if ((tst & 2) != 0) {
+        /*
+         * Setting this option means the MAC is added before encryption
+         * giving us a larger record for the encryption process
+         */
+        if (!TEST_true(SSL_set_options(serverssl, SSL_OP_NO_ENCRYPT_THEN_MAC))
+                || !TEST_true(SSL_set_options(clientssl,
+                                              SSL_OP_NO_ENCRYPT_THEN_MAC)))
+            goto end;
+    }
+
+    if (!TEST_true(create_ssl_connection(serverssl, clientssl, SSL_ERROR_NONE)))
+        goto end;
+
+    if (!TEST_true(SSL_write_ex(clientssl, msg, SSL3_RT_MAX_PLAIN_LENGTH,
+                                &written))
+            || !TEST_size_t_eq(written, SSL3_RT_MAX_PLAIN_LENGTH))
+        goto end;
+
+    /* We provide a buffer slightly larger than what we are actually expecting */
+    if (!TEST_true(SSL_read_ex(serverssl, buf, SSL3_RT_MAX_PLAIN_LENGTH + 1,
+                               &readbytes)))
+        goto end;
+
+    if (!TEST_mem_eq(msg, written, buf, readbytes))
+        goto end;
+
+    testresult = 1;
+end:
+    OPENSSL_free(msg);
+    OPENSSL_free(buf);
+    SSL_free(serverssl);
+    SSL_free(clientssl);
+    SSL_CTX_free(sctx);
+    SSL_CTX_free(cctx);
+    return testresult;
+}
+
 static int execute_cleanse_plaintext(const SSL_METHOD *smeth,
                                      const SSL_METHOD *cmeth,
                                      int min_version, int max_version)
@@ -10563,6 +10700,7 @@ int setup_tests(void)
 #ifndef OPENSSL_NO_DTLS
     ADD_TEST(test_large_message_dtls);
 #endif
+    ADD_ALL_TESTS(test_large_app_data, 20);
     ADD_TEST(test_cleanse_plaintext);
 #ifndef OPENSSL_NO_OCSP
     ADD_TEST(test_tlsext_status_type);


### PR DESCRIPTION
Some ciphers/protocol versions have an explicit IV. We need to make sure we
have sufficient room for it in the underlying buffer.

This fixes a regression introduced during the record layer refactor.
