### PR TITLE
SSL_conf_cmd: add support for IgnoreUnexpectedEOF

### DIFF
--- a/doc/man3/SSL_CONF_cmd.pod
+++ b/doc/man3/SSL_CONF_cmd.pod
@@ -569,6 +569,11 @@ B<SSL_OP_ENABLE_KTLS_TX_ZEROCOPY_SENDFILE>. This option only applies to Linux.
 KTLS sendfile on FreeBSD doesn't offer an option to disable zerocopy and
 always runs in this mode.
 
+B<IgnoreUnexpectedEOF>: Equivalent to B<SSL_OP_IGNORE_UNEXPECTED_EOF>.
+You should only enable this option if the protocol running over TLS can detect
+a truncation attack itself, and that the application is checking for that
+truncation attack.
+
 =item B<VerifyMode>
 
 The B<value> argument is a comma separated list of flags to set.

--- a/ssl/ssl_conf.c
+++ b/ssl/ssl_conf.c
@@ -401,6 +401,7 @@ static int cmd_Options(SSL_CONF_CTX *cctx, const char *value)
         SSL_FLAG_TBL_INV("TxCertificateCompression", SSL_OP_NO_TX_CERTIFICATE_COMPRESSION),
         SSL_FLAG_TBL_INV("RxCertificateCompression", SSL_OP_NO_RX_CERTIFICATE_COMPRESSION),
         SSL_FLAG_TBL("KTLSTxZerocopySendfile", SSL_OP_ENABLE_KTLS_TX_ZEROCOPY_SENDFILE),
+        SSL_FLAG_TBL("IgnoreUnexpectedEOF", SSL_OP_IGNORE_UNEXPECTED_EOF),
     };
     if (value == NULL)
         return -3;


### PR DESCRIPTION
- [x] documentation is added or updated
(Trivial addition to existing array (not even compile tested, but should do))