### PR TITLE
Fix BIO_do_connect return value documentation

### DIFF
--- a/doc/man3/BIO_s_connect.pod
+++ b/doc/man3/BIO_s_connect.pod
@@ -28,7 +28,7 @@ BIO_set_nbio, BIO_do_connect - connect BIO
 
  long BIO_set_nbio(BIO *b, long n);
 
- int BIO_do_connect(BIO *b);
+ long BIO_do_connect(BIO *b);
 
 =head1 DESCRIPTION
 


### PR DESCRIPTION
Fixes wrong return type in BIO_do_connect man page. Current man page indicates the function returns an int while it returns a long. 

Fixes #20096.

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated

