### PR TITLE
Fix various instances of unsafe sk_find usage

### DIFF
--- a/crypto/asn1/a_strnid.c
+++ b/crypto/asn1/a_strnid.c
@@ -29,8 +29,11 @@ DEFINE_RUN_ONCE_STATIC(do_stable_lock_init)
         return 0;
 
     if (stable == NULL
-        && (stable = sk_ASN1_STRING_TABLE_new(sk_table_cmp)) == NULL)
+        && (stable = sk_ASN1_STRING_TABLE_new(sk_table_cmp)) == NULL) {
+        CRYPTO_THREAD_lock_free(stable_lock);
+        stable_lock = NULL;
         return 0;
+    }
 
     return 1;
 }
@@ -259,10 +262,8 @@ void ASN1_STRING_TABLE_cleanup(void)
         sk_ASN1_STRING_TABLE_pop_free(tmp, st_free);
     }
 
-    if (stable_lock != NULL) {
-        CRYPTO_THREAD_lock_free(stable_lock);
-        stable_lock = NULL;
-    }
+    CRYPTO_THREAD_lock_free(stable_lock);
+    stable_lock = NULL;
 }
 
 static void st_free(ASN1_STRING_TABLE *tbl)

--- a/crypto/asn1/a_strnid.c
+++ b/crypto/asn1/a_strnid.c
@@ -38,7 +38,7 @@ DEFINE_RUN_ONCE_STATIC(do_stable_lock_init)
     return 1;
 }
 
-static int ensure_init(void)
+static int ensure_stable_init(void)
 {
     if (!RUN_ONCE(&stable_lock_init, do_stable_lock_init))
         return 0;
@@ -114,7 +114,7 @@ ASN1_STRING *ASN1_STRING_set_by_NID(ASN1_STRING **out,
     unsigned long mask;
     int ret;
 
-    if (!ensure_init())
+    if (!ensure_stable_init())
         return NULL;
 
     if (!CRYPTO_THREAD_write_lock(stable_lock))
@@ -191,7 +191,7 @@ static ASN1_STRING_TABLE *stable_get(int nid)
     ASN1_STRING_TABLE *tmp, *rv = NULL, *res = NULL;
 
     /* Always need a string table so allocate one if NULL */
-    if (!ensure_init())
+    if (!ensure_stable_init())
         return NULL;
 
     if (!CRYPTO_THREAD_write_lock(stable_lock))

--- a/crypto/asn1/a_strnid.c
+++ b/crypto/asn1/a_strnid.c
@@ -13,7 +13,7 @@
 #include <openssl/asn1.h>
 #include <openssl/objects.h>
 
-static  CRYPTO_ONCE stable_lock_init = CRYPTO_ONCE_STATIC_INIT;
+static CRYPTO_ONCE stable_lock_init = CRYPTO_ONCE_STATIC_INIT;
 static CRYPTO_RWLOCK *stable_lock = NULL;
 /* protected by stable_lock */
 static STACK_OF(ASN1_STRING_TABLE) *stable = NULL;

--- a/crypto/asn1/ameth_lib.c
+++ b/crypto/asn1/ameth_lib.c
@@ -56,7 +56,7 @@ DEFINE_RUN_ONCE_STATIC(do_app_methods_lock_init)
     return 1;
 }
 
-static int ensure_init(void)
+static int ensure_app_methods_init(void)
 {
     if (!RUN_ONCE(&app_methods_lock_init, do_app_methods_lock_init))
         return 0;
@@ -77,7 +77,7 @@ int EVP_PKEY_asn1_get_count(void)
 {
     int num = OSSL_NELEM(standard_methods);
 
-    if (ensure_init()
+    if (ensure_app_methods_init()
         && CRYPTO_THREAD_read_lock(app_methods_lock)) {
         num += sk_EVP_PKEY_ASN1_METHOD_num(app_methods);
         CRYPTO_THREAD_unlock(app_methods_lock);
@@ -96,7 +96,7 @@ const EVP_PKEY_ASN1_METHOD *EVP_PKEY_asn1_get0(int idx)
     if (idx < num)
         return standard_methods[idx];
     idx -= num;
-    if (!ensure_init()
+    if (!ensure_app_methods_init()
         || !CRYPTO_THREAD_read_lock(app_methods_lock))
         return NULL;
     m = sk_EVP_PKEY_ASN1_METHOD_value(app_methods, idx);
@@ -133,7 +133,7 @@ const EVP_PKEY_ASN1_METHOD *EVP_PKEY_asn1_find(ENGINE **pe, int type)
 {
     const EVP_PKEY_ASN1_METHOD *t;
 
-    if (!ensure_init()
+    if (!ensure_app_methods_init()
         || !CRYPTO_THREAD_read_lock(app_methods_lock))
         return NULL;
 
@@ -217,7 +217,7 @@ int EVP_PKEY_asn1_add0(const EVP_PKEY_ASN1_METHOD *ameth)
         return 0;
     }
 
-    if (!ensure_init()
+    if (!ensure_app_methods_init()
         || !CRYPTO_THREAD_write_lock(app_methods_lock))
         return 0;
 

--- a/crypto/evp/evp_pbe.c
+++ b/crypto/evp/evp_pbe.c
@@ -54,7 +54,7 @@ DEFINE_RUN_ONCE_STATIC(do_pbe_algs_lock_init)
     return 1;
 }
 
-static int ensure_init(void)
+static int ensure_pbe_algs_init(void)
 {
     if (!RUN_ONCE(&pbe_algs_lock_init, do_pbe_algs_lock_init))
         return 0;
@@ -231,7 +231,7 @@ int EVP_PBE_alg_add_type(int pbe_type, int pbe_nid, int cipher_nid,
 {
     EVP_PBE_CTL *pbe_tmp = NULL;
 
-    if (!ensure_init()) {
+    if (!ensure_pbe_algs_init()) {
         ERR_raise(ERR_LIB_EVP, ERR_R_CRYPTO_LIB);
         goto err;
     }
@@ -291,7 +291,7 @@ int EVP_PBE_find_ex(int type, int pbe_nid, int *pcnid, int *pmnid,
     pbelu.pbe_type = type;
     pbelu.pbe_nid = pbe_nid;
 
-    if (ensure_init()) {
+    if (ensure_pbe_algs_init()) {
         if (!CRYPTO_THREAD_write_lock(pbe_algs_lock))
             return 0;
 

--- a/crypto/init.c
+++ b/crypto/init.c
@@ -32,6 +32,7 @@
 #include "crypto/store.h"
 #include <openssl/cmp_util.h> /* for OSSL_CMP_log_close() */
 #include <openssl/trace.h>
+#include <openssl/x509v3.h>
 #include "crypto/ctype.h"
 
 static int stopped = 0;
@@ -454,6 +455,24 @@ void OPENSSL_cleanup(void)
 
     OSSL_TRACE(INIT, "OPENSSL_cleanup: ossl_trace_cleanup()\n");
     ossl_trace_cleanup();
+
+    OSSL_TRACE(INIT, "OPENSSL_cleanup: X509_VERIFY_PARAM_table_cleanup()\n");
+    X509_VERIFY_PARAM_table_cleanup();
+
+    OSSL_TRACE(INIT, "OPENSSL_cleanup: X509_TRUST_cleanup()\n");
+    X509_TRUST_cleanup();
+
+    OSSL_TRACE(INIT, "OPENSSL_cleanup: X509_PURPOSE_cleanup()\n");
+    X509_PURPOSE_cleanup();
+
+    OSSL_TRACE(INIT, "OPENSSL_cleanup: X509V3_EXT_cleanup()\n");
+    X509V3_EXT_cleanup();
+
+    OSSL_TRACE(INIT, "OPENSSL_cleanup: ossl_app_methods_cleanup()\n");
+    ossl_app_methods_cleanup();
+
+    OSSL_TRACE(INIT, "OPENSSL_cleanup: ASN1_STRING_TABLE_cleanup()\n");
+    ASN1_STRING_TABLE_cleanup();
 
     base_inited = 0;
 }

--- a/crypto/x509/v3_lib.c
+++ b/crypto/x509/v3_lib.c
@@ -42,7 +42,7 @@ DEFINE_RUN_ONCE_STATIC(do_ext_list_lock_init)
     return 1;
 }
 
-static int ensure_init(void)
+static int ensure_ext_list_init(void)
 {
     if (!RUN_ONCE(&ext_list_lock_init, do_ext_list_lock_init))
         return 0;
@@ -52,7 +52,7 @@ static int ensure_init(void)
 
 int X509V3_EXT_add(X509V3_EXT_METHOD *ext)
 {
-    if (!ensure_init()
+    if (!ensure_ext_list_init()
         || !CRYPTO_THREAD_write_lock(ext_list_lock) ) {
         ERR_raise(ERR_LIB_X509V3, ERR_R_CRYPTO_LIB);
         return 0;
@@ -96,7 +96,7 @@ const X509V3_EXT_METHOD *X509V3_EXT_get_nid(int nid)
     if (!ext_list)
         return NULL;
 
-    if (!ensure_init()
+    if (!ensure_ext_list_init()
         || CRYPTO_THREAD_write_lock(ext_list_lock))
         return NULL;
 

--- a/crypto/x509/v3_purp.c
+++ b/crypto/x509/v3_purp.c
@@ -97,7 +97,7 @@ DEFINE_RUN_ONCE_STATIC(do_xptable_lock_init)
     return 1;
 }
 
-static int ensure_init(void)
+static int ensure_xptable_init(void)
 {
     if (!RUN_ONCE(&xptable_lock_init, do_xptable_lock_init))
         return 0;
@@ -148,7 +148,7 @@ int X509_PURPOSE_get_count(void)
 {
     int ret;
 
-    if (!ensure_init()
+    if (!ensure_xptable_init()
         || !CRYPTO_THREAD_read_lock(xptable_lock))
         return X509_PURPOSE_COUNT;
 
@@ -176,7 +176,7 @@ X509_PURPOSE *X509_PURPOSE_get0(int idx)
         return NULL;
     if (idx < (int)X509_PURPOSE_COUNT)
         return xstandard + idx;
-    if (!ensure_init()
+    if (!ensure_xptable_init()
         || !CRYPTO_THREAD_read_lock(xptable_lock))
         return NULL;
     p = get_entry(idx);
@@ -189,7 +189,7 @@ int X509_PURPOSE_get_by_sname(const char *sname)
     int i, count;
     X509_PURPOSE *xptmp;
 
-    if (!ensure_init()
+    if (!ensure_xptable_init()
         || !CRYPTO_THREAD_read_lock(xptable_lock))
         return -1;
 
@@ -213,7 +213,7 @@ int X509_PURPOSE_get_by_id(int purpose)
 
     if (purpose >= X509_PURPOSE_MIN && purpose <= X509_PURPOSE_MAX)
         return purpose - X509_PURPOSE_MIN;
-    if (!ensure_init()
+    if (!ensure_xptable_init()
         || !CRYPTO_THREAD_write_lock(xptable_lock))
         return -1;
     tmp.purpose = purpose;
@@ -268,7 +268,7 @@ int X509_PURPOSE_add(int id, int trust, int flags,
 
     /* If its a new entry manage the dynamic table */
     if (idx == -1) {
-        if (!ensure_init()
+        if (!ensure_xptable_init()
             || !CRYPTO_THREAD_write_lock(xptable_lock)) {
             ERR_raise(ERR_LIB_X509V3, ERR_R_CRYPTO_LIB);
             goto err;

--- a/crypto/x509/x509_trust.c
+++ b/crypto/x509/x509_trust.c
@@ -74,7 +74,7 @@ DEFINE_RUN_ONCE_STATIC(do_trtable_lock_init)
     return 1;
 }
 
-static int ensure_init(void)
+static int ensure_trtable_init(void)
 {
     if (!RUN_ONCE(&trtable_lock_init, do_trtable_lock_init))
         return 0;
@@ -111,7 +111,7 @@ int X509_TRUST_get_count(void)
 {
     int r;
 
-    if (!ensure_init()
+    if (!ensure_trtable_init()
         || !CRYPTO_THREAD_read_lock(trtable_lock))
         return X509_TRUST_COUNT;
 
@@ -128,7 +128,7 @@ X509_TRUST *X509_TRUST_get0(int idx)
         return NULL;
     if (idx < (int)X509_TRUST_COUNT)
         return trstandard + idx;
-    if (!ensure_init()
+    if (!ensure_trtable_init()
         || !CRYPTO_THREAD_read_lock(trtable_lock))
         return NULL;
     p = sk_X509_TRUST_value(trtable, idx - X509_TRUST_COUNT);
@@ -143,7 +143,7 @@ int X509_TRUST_get_by_id(int id)
 
     if ((id >= X509_TRUST_MIN) && (id <= X509_TRUST_MAX))
         return id - X509_TRUST_MIN;
-    if (!ensure_init()
+    if (!ensure_trtable_init()
         || !CRYPTO_THREAD_write_lock(trtable_lock))
         return -1;
     tmp.trust = id;
@@ -203,7 +203,7 @@ int X509_TRUST_add(int id, int flags, int (*ck) (X509_TRUST *, X509 *, int),
 
     /* If its a new entry manage the dynamic table */
     if (idx < 0) {
-        if (!ensure_init()
+        if (!ensure_trtable_init()
             || CRYPTO_THREAD_write_lock(trtable_lock)) {
             ERR_raise(ERR_LIB_X509, ERR_R_CRYPTO_LIB);
             goto err;

--- a/crypto/x509/x509_trust.c
+++ b/crypto/x509/x509_trust.c
@@ -65,8 +65,11 @@ DEFINE_RUN_ONCE_STATIC(do_trtable_lock_init)
         return 0;
 
     if (trtable == NULL
-        && (trtable = sk_X509_TRUST_new(tr_cmp)) == NULL)
+        && (trtable = sk_X509_TRUST_new(tr_cmp)) == NULL) {
+        CRYPTO_THREAD_lock_free(trtable_lock);
+        trtable_lock = NULL;
         return 0;
+    }
 
     return 1;
 }

--- a/crypto/x509/x509_vpm.c
+++ b/crypto/x509/x509_vpm.c
@@ -608,7 +608,7 @@ DEFINE_RUN_ONCE_STATIC(do_param_table_lock_init)
     return 1;
 }
 
-static int ensure_init(void)
+static int ensuure_param_table_init(void)
 {
     if (!RUN_ONCE(&param_table_lock_init, do_param_table_lock_init))
         return 0;
@@ -624,7 +624,7 @@ int X509_VERIFY_PARAM_add0_table(X509_VERIFY_PARAM *param)
     int idx, r;
     X509_VERIFY_PARAM *ptmp;
 
-    if (!ensure_init()
+    if (!ensuure_param_table_init()
         || !CRYPTO_THREAD_write_lock(param_table_lock))
         return 0;
 
@@ -643,7 +643,7 @@ int X509_VERIFY_PARAM_get_count(void)
 {
     int num = OSSL_NELEM(default_table);
 
-    if (ensure_init()
+    if (ensuure_param_table_init()
         && CRYPTO_THREAD_read_lock(param_table_lock)) {
         num += sk_X509_VERIFY_PARAM_num(param_table);
         CRYPTO_THREAD_unlock(param_table_lock);
@@ -660,7 +660,7 @@ const X509_VERIFY_PARAM *X509_VERIFY_PARAM_get0(int id)
     if (id < num)
         return default_table + id;
 
-    if (!ensure_init()
+    if (!ensuure_param_table_init()
         || !CRYPTO_THREAD_read_lock(param_table_lock))
         return NULL;
 
@@ -676,7 +676,7 @@ const X509_VERIFY_PARAM *X509_VERIFY_PARAM_lookup(const char *name)
     const X509_VERIFY_PARAM *p;
 
     pm.name = (char *)name;
-    if (ensure_init()
+    if (ensuure_param_table_init()
         && CRYPTO_THREAD_write_lock(param_table_lock)) {
         /* Needs write lock as sk_find may sort the stack. */
         idx = sk_X509_VERIFY_PARAM_find(param_table, &pm);

--- a/include/crypto/asn1.h
+++ b/include/crypto/asn1.h
@@ -150,4 +150,6 @@ X509_ALGOR *ossl_X509_ALGOR_from_nid(int nid, int ptype, void *pval);
 time_t ossl_asn1_string_to_time_t(const char *asn1_string);
 void ossl_asn1_string_set_bits_left(ASN1_STRING *str, unsigned int num);
 
+void ossl_app_methods_cleanup(void);
+
 #endif /* ndef OSSL_CRYPTO_ASN1_H */

--- a/include/crypto/x509.h
+++ b/include/crypto/x509.h
@@ -365,4 +365,5 @@ int ossl_x509_check_private_key(const EVP_PKEY *k, const EVP_PKEY *pkey);
 
 int x509v3_add_len_value_uchar(const char *name, const unsigned char *value,
                                size_t vallen, STACK_OF(CONF_VALUE) **extlist);
+
 #endif  /* OSSL_CRYPTO_X509_H */

--- a/include/internal/cryptlib.h
+++ b/include/internal/cryptlib.h
@@ -159,4 +159,5 @@ char *ossl_ipaddr_to_asc(unsigned char *p, int len);
 char *ossl_buf2hexstr_sep(const unsigned char *buf, long buflen, char sep);
 unsigned char *ossl_hexstr2buf_sep(const char *str, long *buflen,
                                    const char sep);
+
 #endif


### PR DESCRIPTION
This adds locking to various global OSSL_STACK instances which are used unsafely with sk_find (and really, probably in  a quite non-thread-safe way in general).

This may be too conservative from a performance perspective, as it needs to obtain a global write lock to access some fairly infrequently changing data. It is likely we can relax some of the write locks into read locks via ensuring everything is sorted... something to think about. Though even with read locks we have had cache contention issues in the past. It would also be nice to measure the effect of this code once we have performance measurement infrastructure.