### PR TITLE
Expand RISC-V testing

### DIFF
--- a/.github/workflows/cross-compiles.yml
+++ b/.github/workflows/cross-compiles.yml
@@ -94,9 +94,18 @@ jobs:
             # resolves it.
             target: -O2 linux-ppc64le
           }, {
+            # RV64GC
             arch: riscv64-linux-gnu,
             libs: libc6-dev-riscv64-cross,
             target: linux64-riscv64
+          }, {
+            # RV64GC with bitmanip and scalar crypto extensions
+            arch: riscv64-linux-gnu,
+            libs: libc6-dev-riscv64-cross,
+            target: linux64-riscv64,
+            qemucpu: "rv64,zba=true,zbb=true,zbc=true,zbs=true,zbkb=true,zbkc=true,zbkx=true,zknd=true,zkne=true,zknh=true,zksed=true,zksh=true,zkr=true",
+            opensslcapsname: riscvcap, # OPENSSL_riscvcap
+            opensslcaps: "rv64gc_zba_zbb_zbc_zbs_zbkb_zbkc_zbkx_zbknd_zkne_zknh_zksed_zksh_zkr"
           }, {
             arch: s390x-linux-gnu,
             libs: libc6-dev-s390x-cross,

--- a/.github/workflows/cross-compiles.yml
+++ b/.github/workflows/cross-compiles.yml
@@ -30,6 +30,15 @@ jobs:
         #          to never run the tests, otherwise its value is passed to
         #          the "make test" command to allow selective disabling of
         #          tests.
+        #   qemucpu: optional; string that describes CPU properties.
+        #            The string will be used to set the QEMU_CPU variable.
+        #   opensslcapsname: optional; string that describes the postfix of the
+        #                    OpenSSL environment variable that defines CPU
+        #                    capabilities. E.g. "foo" will result in an
+        #                    environment variable with the name OPENSSL_foo.
+        #   opensslcaps: optional; if opensslcapsname (see above) is set, then
+        #                this string will be used as content for the OpenSSL
+        #                capabilities variable.
         platform: [
           {
             arch: aarch64-linux-gnu,
@@ -163,6 +172,15 @@ jobs:
     - name: install qemu
       if: github.event_name == 'push' && matrix.platform.tests != 'none'
       run: sudo apt-get -yq --force-yes install qemu-user
+
+    - name: Set QEMU environment
+      if: github.event_name == 'push' && matrix.platform.qemucpu != ''
+      run: echo "QEMU_CPU=${{ matrix.platform.qemucpu }}" >> $GITHUB_ENV
+
+    - name: Set OpenSSL caps environment
+      if: github.event_name == 'push' && matrix.platform.opensslcapsname != ''
+      run: echo "OPENSSL_${{ matrix.platform.opensslcapsname }}=\
+                 ${{ matrix.platform.opensslcaps }}" >> $GITHUB_ENV
 
     - name: make all tests
       if: github.event_name == 'push' && matrix.platform.tests == ''


### PR DESCRIPTION
RISC-V already has a couple of routines to accelerate cryptographic calculations using ISA extensions. Let's add a cross-compile target that allows the CI to test this code.

The new defined machine is a rv64gc machine with
* all Bitmanip extensions (Zb*)
* all Scalar Crypto extensions (Zk*)

This selection matches the supported RISC-V extensions in OpenSSL.

See also #20091.

Note, that this PR is untested (only GitHub workflow changes).