### PR TITLE
Fix snprintf missing, fix two typos

### DIFF
--- a/apps/cmp.c
+++ b/apps/cmp.c
@@ -2048,7 +2048,7 @@ static int save_cert_or_delete(X509 *cert, const char *file, const char *desc)
     if (cert == NULL) {
         char desc_cert[80];
 
-        snprintf(desc_cert, sizeof(desc_cert), "%s certificate", desc);
+        BIO_snprintf(desc_cert, sizeof(desc_cert), "%s certificate", desc);
         return delete_file(file, desc_cert);
     } else {
         STACK_OF(X509) *certs = sk_X509_new_null();

--- a/apps/lib/http_server.c
+++ b/apps/lib/http_server.c
@@ -506,12 +506,12 @@ int http_server_send_asn1_resp(const char *prog, BIO *cbio, int keep_alive,
                                const ASN1_ITEM *it, const ASN1_VALUE *resp)
 {
     char buf[200], *p;
-    int ret = snprintf(buf, sizeof(buf), HTTP_1_0" 200 OK\r\n%s"
-                       "Content-type: %s\r\n"
-                       "Content-Length: %d\r\n",
-                       keep_alive ? "Connection: keep-alive\r\n" : "",
-                       content_type,
-                       ASN1_item_i2d(resp, NULL, it));
+    int ret = BIO_snprintf(buf, sizeof(buf), HTTP_1_0" 200 OK\r\n%s"
+                           "Content-type: %s\r\n"
+                           "Content-Length: %d\r\n",
+                           keep_alive ? "Connection: keep-alive\r\n" : "",
+                           content_type,
+                           ASN1_item_i2d(resp, NULL, it));
 
     if (ret < 0 || (size_t)ret >= sizeof(buf))
         return 0;
@@ -532,9 +532,9 @@ int http_server_send_status(const char *prog, BIO *cbio,
                             int status, const char *reason)
 {
     char buf[200];
-    int ret = snprintf(buf, sizeof(buf), HTTP_1_0" %d %s\r\n\r\n",
-                       /* This implicitly cancels keep-alive */
-                       status, reason);
+    int ret = BIO_snprintf(buf, sizeof(buf), HTTP_1_0" %d %s\r\n\r\n",
+                           /* This implicitly cancels keep-alive */
+                           status, reason);
 
     if (ret < 0 || (size_t)ret >= sizeof(buf))
         return 0;

--- a/apps/lib/log.c
+++ b/apps/lib/log.c
@@ -46,7 +46,7 @@ static void log_with_prefix(const char *prog, const char *fmt, va_list ap)
     char prefix[80];
     BIO *bio, *pre = BIO_new(BIO_f_prefix());
 
-    (void)snprintf(prefix, sizeof(prefix), "%s: ", prog);
+    (void)BIO_snprintf(prefix, sizeof(prefix), "%s: ", prog);
     (void)BIO_set_prefix(pre, prefix);
     bio = BIO_push(pre, bio_err);
     (void)BIO_vprintf(bio, fmt, ap);

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -1963,7 +1963,7 @@ int s_client_main(int argc, char **argv)
 
     /*
      * In TLSv1.3 NewSessionTicket messages arrive after the handshake and can
-     * come at any time. Therefore we use a callback to write out the session
+     * come at any time. Therefore, we use a callback to write out the session
      * when we know about it. This approach works for < TLSv1.3 as well.
      */
     SSL_CTX_set_session_cache_mode(ctx, SSL_SESS_CACHE_CLIENT
@@ -2849,7 +2849,7 @@ int s_client_main(int argc, char **argv)
 #if defined(OPENSSL_SYS_WINDOWS) || defined(OPENSSL_SYS_MSDOS)
             /*
              * Under Windows/DOS we make the assumption that we can always
-             * write to the tty: therefore if we need to write to the tty we
+             * write to the tty: therefore, if we need to write to the tty we
              * just fall through. Otherwise we timeout the select every
              * second and see if there are any keypresses. Note: this is a
              * hack, in a proper Windows application we wouldn't do this.
@@ -3394,7 +3394,7 @@ static void print_stuff(BIO *bio, SSL *s, int full)
         /*
          * We also print the verify results when we dump session information,
          * but in TLSv1.3 we may not get that right away (or at all) depending
-         * on when we get a NewSessionTicket. Therefore we print it now as well.
+         * on when we get a NewSessionTicket. Therefore, we print it now as well.
          */
         verify_result = SSL_get_verify_result(s);
         BIO_printf(bio, "Verify return code: %ld (%s)\n", verify_result,

--- a/doc/man3/EVP_PKEY_decapsulate.pod
+++ b/doc/man3/EVP_PKEY_decapsulate.pod
@@ -22,7 +22,7 @@ The EVP_PKEY_decapsulate_init() function initializes a private key algorithm
 context I<ctx> for a decapsulation operation and then sets the I<params>
 on the context in the same way as calling L<EVP_PKEY_CTX_set_params(3)>.
 
-The EVP_PKEY_auth_decapsulate_init() function is similiar to
+The EVP_PKEY_auth_decapsulate_init() function is similar to
 EVP_PKEY_decapsulate_init() but also passes an I<authpub> authentication public
 key that is used during decapsulation.
 

--- a/doc/man3/EVP_PKEY_encapsulate.pod
+++ b/doc/man3/EVP_PKEY_encapsulate.pod
@@ -22,7 +22,7 @@ The EVP_PKEY_encapsulate_init() function initializes a public key algorithm
 context I<ctx> for an encapsulation operation and then sets the I<params>
 on the context in the same way as calling L<EVP_PKEY_CTX_set_params(3)>.
 
-The EVP_PKEY_auth_encapsulate_init() function is similiar to
+The EVP_PKEY_auth_encapsulate_init() function is similar to
 EVP_PKEY_encapsulate_init() but also passes an I<authpriv> authentication private
 key that is used during encapsulation.
 

--- a/doc/man7/EVP_KDF-HMAC-DRBG.pod
+++ b/doc/man7/EVP_KDF-HMAC-DRBG.pod
@@ -7,7 +7,7 @@ EVP_KDF-HMAC-DRBG
 
 =head1 DESCRIPTION
 
-Support for a deterministic HMAC DRBG using the B<EVP_KDF> API. This is similiar
+Support for a deterministic HMAC DRBG using the B<EVP_KDF> API. This is similar
 to L<EVP_RAND-HMAC-DRBG(7)>, but uses fixed values for its entropy and nonce
 values. This is used to generate deterministic nonce value required by ECDSA
 and DSA (as defined in RFC 6979).

--- a/doc/man7/EVP_PKEY-RSA.pod
+++ b/doc/man7/EVP_PKEY-RSA.pod
@@ -186,7 +186,7 @@ both return 1 unconditionally.
 
 For RSA keys, L<EVP_PKEY_public_check(3)> conforms to the SP800-56Br1 I<public key
 check> when the OpenSSL FIPS provider is used. The OpenSSL default provider
-performs similiar tests but relaxes the keysize restrictions for backwards
+performs similar tests but relaxes the keysize restrictions for backwards
 compatibility.
 
 For RSA keys, L<EVP_PKEY_public_check_quick(3)> is the same as

--- a/doc/man7/provider-kem.pod
+++ b/doc/man7/provider-kem.pod
@@ -137,7 +137,7 @@ The key object should have been previously generated, loaded or imported into
 the provider using the key management (OSSL_OP_KEYMGMT) operation (see
 provider-keymgmt(7)>.
 
-OSSL_FUNC_kem_auth_encapsulate_init() is similiar to
+OSSL_FUNC_kem_auth_encapsulate_init() is similar to
 OSSL_FUNC_kem_encapsulate_init(), but also passes an additional authentication
 key I<provauthkey> which cannot be NULL.
 
@@ -165,7 +165,7 @@ The key object should have been previously generated, loaded or imported into
 the provider using the key management (OSSL_OP_KEYMGMT) operation (see
 provider-keymgmt(7)>.
 
-OSSL_FUNC_kem_auth_decapsulate_init() is similiar to
+OSSL_FUNC_kem_auth_decapsulate_init() is similar to
 OSSL_FUNC_kem_decapsulate_init(), but also passes an additional authentication
 key I<provauthkey> which cannot be NULL.
 

--- a/providers/implementations/kdfs/x942kdf.c
+++ b/providers/implementations/kdfs/x942kdf.c
@@ -239,7 +239,7 @@ x942_encode_otherinfo(size_t keylen,
         goto err;
     /*
      * Since we allocated the exact size required, the buffer should point to the
-     * start of the alllocated buffer at this point.
+     * start of the allocated buffer at this point.
      */
     if (WPACKET_get_curr(&pkt) != der_buf)
         goto err;

--- a/test/hpke_test.c
+++ b/test/hpke_test.c
@@ -1204,8 +1204,8 @@ static int test_hpke_suite_strs(void)
     for (kemind = 0; kemind != OSSL_NELEM(kem_str_list); kemind++) {
         for (kdfind = 0; kdfind != OSSL_NELEM(kdf_str_list); kdfind++) {
             for (aeadind = 0; aeadind != OSSL_NELEM(aead_str_list); aeadind++) {
-                snprintf(sstr, 128, "%s,%s,%s", kem_str_list[kemind],
-                         kdf_str_list[kdfind], aead_str_list[aeadind]);
+                BIO_snprintf(sstr, 128, "%s,%s,%s", kem_str_list[kemind],
+                             kdf_str_list[kdfind], aead_str_list[aeadind]);
                 if (TEST_true(OSSL_HPKE_str2suite(sstr, &stirred)) != 1) {
                     if (verbose)
                         TEST_note("Unexpected str2suite fail for :%s",


### PR DESCRIPTION
Current master don't link in my old VS config, it complains for missing `sprintf` definition.

Fix two typos



##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
