### PR TITLE
Coverity 1520485: logically dead code

### DIFF
--- a/crypto/cmp/cmp_ctx.c
+++ b/crypto/cmp/cmp_ctx.c
@@ -919,12 +919,12 @@ int OSSL_CMP_CTX_set_option(OSSL_CMP_CTX *ctx, int opt, int val)
         ctx->keep_alive = val;
         break;
     case OSSL_CMP_OPT_MSG_TIMEOUT:
-        if (val < 0)
+        if (val <= 0)
             val = 0;
         ctx->msg_timeout = val;
         break;
     case OSSL_CMP_OPT_TOTAL_TIMEOUT:
-        if (val < 0)
+        if (val <= 0)
             val = 0;
         ctx->total_timeout = val;
         break;

--- a/crypto/cmp/cmp_ctx.c
+++ b/crypto/cmp/cmp_ctx.c
@@ -919,13 +919,9 @@ int OSSL_CMP_CTX_set_option(OSSL_CMP_CTX *ctx, int opt, int val)
         ctx->keep_alive = val;
         break;
     case OSSL_CMP_OPT_MSG_TIMEOUT:
-        if (val <= 0)
-            val = 0;
         ctx->msg_timeout = val;
         break;
     case OSSL_CMP_OPT_TOTAL_TIMEOUT:
-        if (val <= 0)
-            val = 0;
         ctx->total_timeout = val;
         break;
     case OSSL_CMP_OPT_PERMIT_TA_IN_EXTRACERTS_FOR_IR:


### PR DESCRIPTION
This is a false positive, but changing the condition so the code appears live seems safer than removing the check.

Fixes Coverity 1520485
