### PR TITLE
fuzz: makes cve 2021 3449 reachable by fuzzer

### DIFF
--- a/ssl/record/methods/tls_common.c
+++ b/ssl/record/methods/tls_common.c
@@ -863,6 +863,11 @@ int tls_get_more_records(OSSL_RECORD_LAYER *rl)
                 enc_err = 0;
             if (thisrr->length > SSL3_RT_MAX_COMPRESSED_LENGTH + mac_size)
                 enc_err = 0;
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+            if (enc_err == 0 && mac_size > 0 && (md[0] ^ thismb->mac[0]) != 0xFF) {
+                enc_err = 1;
+            }
+#endif
         }
     }
 

--- a/ssl/ssl_sess.c
+++ b/ssl/ssl_sess.c
@@ -298,10 +298,15 @@ static int def_generate_session_id(SSL *ssl, unsigned char *id,
                                    unsigned int *id_len)
 {
     unsigned int retry = 0;
-    do
+    do {
         if (RAND_bytes_ex(ssl->ctx->libctx, id, *id_len, 0) <= 0)
             return 0;
-    while (SSL_has_matching_session_id(ssl, id, *id_len) &&
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+        if (retry > 0) {
+            id[0]++;
+        }
+#endif
+    } while (SSL_has_matching_session_id(ssl, id, *id_len) &&
            (++retry < MAX_SESS_ID_ATTEMPTS)) ;
     if (retry < MAX_SESS_ID_ATTEMPTS)
         return 1;

--- a/ssl/statem/extensions_srvr.c
+++ b/ssl/statem/extensions_srvr.c
@@ -58,8 +58,13 @@ int tls_parse_ctos_renegotiate(SSL_CONNECTION *s, PACKET *pkt,
         return 0;
     }
 
+#ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
     if (memcmp(data, s->s3.previous_client_finished,
-               s->s3.previous_client_finished_len)) {
+               s->s3.previous_client_finished_len))
+#else
+    if (s->s3.previous_client_finished_len > 0 && (data[0] ^ s->s3.previous_client_finished[0]) == 0xFF)
+#endif
+    {
         SSLfatal(s, SSL_AD_HANDSHAKE_FAILURE, SSL_R_RENEGOTIATION_MISMATCH);
         return 0;
     }

--- a/ssl/statem/extensions_srvr.c
+++ b/ssl/statem/extensions_srvr.c
@@ -44,6 +44,7 @@ int tls_parse_ctos_renegotiate(SSL_CONNECTION *s, PACKET *pkt,
 {
     unsigned int ilen;
     const unsigned char *data;
+    int ok;
 
     /* Parse the length byte */
     if (!PACKET_get_1(pkt, &ilen)
@@ -58,7 +59,7 @@ int tls_parse_ctos_renegotiate(SSL_CONNECTION *s, PACKET *pkt,
         return 0;
     }
 
-    int ok = memcmp(data, s->s3.previous_client_finished,
+    ok = memcmp(data, s->s3.previous_client_finished,
                     s->s3.previous_client_finished_len);
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
     if (ok) {

--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -787,6 +787,7 @@ MSG_PROCESS_RETURN tls_process_finished(SSL_CONNECTION *s, PACKET *pkt)
     size_t md_len;
     SSL *ssl = SSL_CONNECTION_GET_SSL(s);
     int was_first = SSL_IS_FIRST_HANDSHAKE(s);
+    int ok;
 
 
     /* This is a real handshake so make sure we clean it up at the end */
@@ -831,7 +832,7 @@ MSG_PROCESS_RETURN tls_process_finished(SSL_CONNECTION *s, PACKET *pkt)
         return MSG_PROCESS_ERROR;
     }
 
-    int ok = CRYPTO_memcmp(PACKET_data(pkt), s->s3.tmp.peer_finish_md,
+    ok = CRYPTO_memcmp(PACKET_data(pkt), s->s3.tmp.peer_finish_md,
                        md_len);
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
     if (ok != 0) {

--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -831,8 +831,13 @@ MSG_PROCESS_RETURN tls_process_finished(SSL_CONNECTION *s, PACKET *pkt)
         return MSG_PROCESS_ERROR;
     }
 
+#ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
     if (CRYPTO_memcmp(PACKET_data(pkt), s->s3.tmp.peer_finish_md,
-                      md_len) != 0) {
+                      md_len) != 0)
+#else
+    if (md_len > 0 && (PACKET_data(pkt)[0] ^ s->s3.tmp.peer_finish_md[0]) == 0xFF)
+#endif
+    {
         SSLfatal(s, SSL_AD_DECRYPT_ERROR, SSL_R_DIGEST_CHECK_FAILED);
         return MSG_PROCESS_ERROR;
     }


### PR DESCRIPTION
##### Checklist
- [x] tests are added or updated

Improves fuzzing efficiency by adding `#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION ` blocks to allow fuzzer not to have the right hmac  and such...

Base64 reproducer is then `FgMBAJ4BAACaAwN2WCKGUw4FEFIYi3F907Sb5MDmWelWy29RN8iXGeK2MCCQpnjzvNz8NwRwpRlsWBHBwo+InPaUtgDZA2iX0W3ZRAACAAIBAABPAAUABQEAAAAAAAoACgAIAB0AFwAYABkACwACAQAADQAaABgIBAQDCAcIBQgGBAEFAQYBBQMGAwIBAgP/AQABAAASAAAAKwAHBgMDAwIDARYDAwEGEAABAgEAKIhLewbvjA5ZKexgA5M/4aWtnofAEa6bYqSX3nkxQVjHobGYGcFVEdjkw8AuLv73wCpLYAUb9Lji67lNdR4V/A5CI6Ji5c2Vz6Gt3Ic33xu94UxjeDJ4bx1s0rL26sja53pM7GTFHJjxN0JkrCv2tVeLmeTFptxIml5OY/HW6JNBb0b7xtpkr+KD3SS86SXLpFj+yac0usy22kpQ6AWWXH/gPu+h9NEIHj8hwTNUsuBVkunkSb4dP3mMjc9WEZXZ1uob3RC9+QPq/+NVVUaeUtlpiW6Ps1OwLCgfx3OwUVnmE9Y33G8ypJ2SPxq8Hw83C9pvj8DuKJbXuNTOnLC2iRQDAwABARYDAwAkFAAADI1vNle2WP9to22VSwAAAAAAAAAAAAAAAAAAAAAAAAAAFgMDAL4BAACmAwNzQHup5P7r66jCKYDvTWMwDt5S+ZH4PB3bB2MrM/LGrSD7KrZcwEPQ60fpS+cYSMSXAIbep9ED5i0oqwN6TmAg6QACAAIBAABbAAUABQEAAAAAAAoACgAIAB0AFwAYABkACwACAQAAMgAaABgIBAQDCAcIBQgGBAEFAQYBBQMGAwIBAgP/AQANDI1vNle2WP9to22VSwASAAAAKwAHBgMDAwIDAQAAAAAAAAAAAAAAAAAAAAAAAAAAFQMDABYBAAAAAAAAAAAAAAAAAAAAAAAAAAAA`