### PR TITLE
Allow to pass a passprase callback at store open

### DIFF
--- a/crypto/store/store_local.h
+++ b/crypto/store/store_local.h
@@ -113,6 +113,7 @@ struct ossl_store_loader_st {
     OSSL_FUNC_store_close_fn *p_close;
     OSSL_FUNC_store_export_object_fn *p_export_object;
     OSSL_FUNC_store_delete_fn *p_delete;
+    OSSL_FUNC_store_open_ex_fn *p_open_ex;
 };
 DEFINE_LHASH_OF_EX(OSSL_STORE_LOADER);
 

--- a/crypto/store/store_meth.c
+++ b/crypto/store/store_meth.c
@@ -223,6 +223,10 @@ static void *loader_from_algorithm(int scheme_id, const OSSL_ALGORITHM *algodef,
             if (loader->p_delete == NULL)
                 loader->p_delete = OSSL_FUNC_store_delete(fns);
             break;
+        case OSSL_FUNC_STORE_OPEN_EX:
+            if (loader->p_open_ex == NULL)
+                loader->p_open_ex = OSSL_FUNC_store_open_ex(fns);
+            break;
         }
     }
 

--- a/doc/man7/provider-storemgmt.pod
+++ b/doc/man7/provider-storemgmt.pod
@@ -27,6 +27,10 @@ provider-storemgmt - The OSSL_STORE library E<lt>-E<gt> provider functions
  int OSSL_FUNC_store_export_object
      (void *loaderctx, const void *objref, size_t objref_sz,
       OSSL_CALLBACK *export_cb, void *export_cbarg);
+ void *OSSL_FUNC_store_open_ex(void *provctx, const char *uri,
+                               const OSSL_PARAM params[],
+                               OSSL_PASSPHRASE_CALLBACK *pw_cb,
+                               void *pw_cbarg);
 
  int OSSL_FUNC_store_delete(void *provctx, const char *uri,
                     const OSSL_PARAM params[],
@@ -75,6 +79,7 @@ in L<openssl-core_dispatch.h(7)>, as follows:
  OSSL_FUNC_store_close                OSSL_FUNC_STORE_CLOSE
  OSSL_FUNC_store_export_object        OSSL_FUNC_STORE_EXPORT_OBJECT
  OSSL_FUNC_store_delete               OSSL_FUNC_STORE_DELETE
+ OSSL_FUNC_store_open_ex              OSSL_FUNC_STORE_OPEN_EX
 
 =head2 Functions
 
@@ -123,6 +128,13 @@ OSSL_FUNC_store_delete() deletes the object identified by the I<uri>. The
 implementation is entirely responsible for the interpretation of the URI.  In
 case a passphrase needs to be prompted to remove an object, I<pw_cb> should be
 called.
+
+OSSL_FUNC_store_open_ex() is an extended variant of OSSL_FUNC_store_open(). If
+the provider does not implement this function the code internally falls back to
+use the original OSSL_FUNC_store_open().
+This variant additionally accepts an L<OSSL_PARAM(3)> object and a I<pw_cb>
+callback that can be used to request a passphrase in cases where the whole
+store needs to be unlocked before performing any load operation.
 
 =head2 Load Parameters
 

--- a/include/openssl/core_dispatch.h
+++ b/include/openssl/core_dispatch.h
@@ -937,6 +937,7 @@ OSSL_CORE_MAKE_FUNC(int, decoder_export_object,
 #define OSSL_FUNC_STORE_CLOSE                       7
 #define OSSL_FUNC_STORE_EXPORT_OBJECT               8
 #define OSSL_FUNC_STORE_DELETE                      9
+#define OSSL_FUNC_STORE_OPEN_EX                     10
 OSSL_CORE_MAKE_FUNC(void *, store_open, (void *provctx, const char *uri))
 OSSL_CORE_MAKE_FUNC(void *, store_attach, (void *provctx, OSSL_CORE_BIO *in))
 OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, store_settable_ctx_params,
@@ -953,6 +954,9 @@ OSSL_CORE_MAKE_FUNC(int, store_export_object,
                     (void *loaderctx, const void *objref, size_t objref_sz,
                      OSSL_CALLBACK *export_cb, void *export_cbarg))
 OSSL_CORE_MAKE_FUNC(int, store_delete,
+                    (void *provctx, const char *uri, const OSSL_PARAM params[],
+                     OSSL_PASSPHRASE_CALLBACK *pw_cb, void *pw_cbarg))
+OSSL_CORE_MAKE_FUNC(void *, store_open_ex,
                     (void *provctx, const char *uri, const OSSL_PARAM params[],
                      OSSL_PASSPHRASE_CALLBACK *pw_cb, void *pw_cbarg))
 

--- a/test/fake_rsaprov.h
+++ b/test/fake_rsaprov.h
@@ -9,6 +9,8 @@
 
 #include <openssl/core_dispatch.h>
 
+#define FAKE_PASSPHRASE "Passphrase Testing"
+
 /* Fake RSA provider implementation */
 OSSL_PROVIDER *fake_rsa_start(OSSL_LIB_CTX *libctx);
 void fake_rsa_finish(OSSL_PROVIDER *p);


### PR DESCRIPTION
Some PKCS11 modules require authentication early on to be able to preload objects, which we want to do to avoid costly roundtrips when the HSM is actually reached over a network (Cloud HSM).

Unfortunately at open time we can't interact with the user becaue the callbacks are only passed at load time.

This patch corrects this issue by providing a more feature rich open call for providers.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
