### PR TITLE
Document that the RSA e value is mandatory when importing.

### DIFF
--- a/doc/man7/EVP_PKEY-RSA.pod
+++ b/doc/man7/EVP_PKEY-RSA.pod
@@ -23,15 +23,18 @@ supports the following.
 
 =item "n" (B<OSSL_PKEY_PARAM_RSA_N>) <unsigned integer>
 
-The RSA "n" value.
+The RSA modulus "n" value.
 
 =item "e" (B<OSSL_PKEY_PARAM_RSA_E>) <unsigned integer>
 
-The RSA "e" value.
+The RSA public exponent "e" value.
+This value must always be set when creating a raw key using L<EVP_PKEY_fromdata(3)>.
+Note that when a decryption operation is performed, that this value is used for
+blinding purposes to prevent timing attacks.
 
 =item "d" (B<OSSL_PKEY_PARAM_RSA_D>) <unsigned integer>
 
-The RSA "d" value.
+The RSA private exponent "d" value.
 
 =item "rsa-factor1" (B<OSSL_PKEY_PARAM_RSA_FACTOR1>) <unsigned integer>
 


### PR DESCRIPTION
The lab tried doing a RSA decryption primitive using just n (using p, q) and d.

This failed for 2 reasons:
(1) e is required when importing
(2) Internally e is used for blinding.

Note n and e can be calculated using:
n = pq
e = (1/d) mod (p-1)(q-1)

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
