### PR TITLE
Avoid duplicating symbols in legacy.a with some build options

### DIFF
--- a/crypto/bf/build.info
+++ b/crypto/bf/build.info
@@ -17,7 +17,7 @@ SOURCE[../../libcrypto]=$ALL
 
 # When all deprecated symbols are removed, libcrypto doesn't export the
 # blowfish functions, so we must include them directly in liblegacy.a
-IF[{- $disabled{'deprecated-3.0'} -}]
+IF[{- $disabled{'deprecated-3.0'} && !$disabled{module} && !$disabled{shared} -}]
   SOURCE[../../providers/liblegacy.a]=$ALL
 ENDIF
 

--- a/crypto/bn/build.info
+++ b/crypto/bn/build.info
@@ -116,11 +116,6 @@ IF[{- !$disabled{'deprecated-3.0'} -}]
 ENDIF
 SOURCE[../../providers/libfips.a]=$COMMON $BNASM
 DEFINE[../../providers/libfips.a]=$BNDEF
-# Because some CPUID implementations use some BN assembler (!!!), we
-# must include assembler code into the legacy provider under the same
-# conditions as CPUID code is included.  See ../build.info
-SOURCE[../../providers/liblegacy.a]=$BNASM
-DEFINE[../../providers/liblegacy.a]=$BNDEF
 # Implementations are now spread across several libraries, so the defines
 # need to be applied to all affected libraries and modules.
 DEFINE[../../providers/libcommon.a]=$BNDEF

--- a/crypto/build.info
+++ b/crypto/build.info
@@ -102,7 +102,9 @@ $UTIL_COMMON=\
         param_build_set.c der_writer.c threads_lib.c params_dup.c \
         quic_vlint.c time.c
 
-SOURCE[../libssl]=sparse_array.c
+IF[{- !$disabled{shared} -}]
+  SOURCE[../libssl]=sparse_array.c
+ENDIF
 
 SOURCE[../libcrypto]=$UTIL_COMMON \
         mem.c mem_sec.c \

--- a/crypto/cast/build.info
+++ b/crypto/cast/build.info
@@ -18,7 +18,7 @@ SOURCE[../../libcrypto]=$ALL
 
 # When all deprecated symbols are removed, libcrypto doesn't export the
 # cast functions, so we must include them directly in liblegacy.a
-IF[{- $disabled{'deprecated-3.0'} -}]
+IF[{- $disabled{'deprecated-3.0'} && !$disabled{module} && !$disabled{shared} -}]
   SOURCE[../../providers/liblegacy.a]=$ALL
 ENDIF
 

--- a/crypto/des/build.info
+++ b/crypto/des/build.info
@@ -23,11 +23,12 @@ $ALL=$COMMON\
 
 SOURCE[../../libcrypto]=$ALL $DESASM
 SOURCE[../../providers/libfips.a]=$COMMON $DESASM
-SOURCE[../../providers/liblegacy.a]=$DESASM
+IF[{- !$disabled{module} && !$disabled{shared} -}]
+  SOURCE[../../providers/liblegacy.a]=$DESASM
+ENDIF
 
 DEFINE[../../libcrypto]=$DESDEF
 DEFINE[../../providers/libfips.a]=$DESDEF
-DEFINE[../../providers/liblegacy.a]=$DESDEF
 
 # When all deprecated symbols are removed, libcrypto doesn't export the
 # DES functions, so we must include them directly in liblegacy.a

--- a/crypto/idea/build.info
+++ b/crypto/idea/build.info
@@ -5,6 +5,6 @@ SOURCE[../../libcrypto]=$ALL
 
 # When all deprecated symbols are removed, libcrypto doesn't export the
 # idea functions, so we must include them directly in liblegacy.a
-IF[{- $disabled{'deprecated-3.0'} -}]
+IF[{- $disabled{'deprecated-3.0'} && !$disabled{module} && !$disabled{shared} -}]
   SOURCE[../../providers/liblegacy.a]=$ALL
 ENDIF

--- a/crypto/md2/build.info
+++ b/crypto/md2/build.info
@@ -4,6 +4,6 @@ SOURCE[../../libcrypto]=md2_dgst.c md2_one.c
 
 # When all deprecated symbols are removed, libcrypto doesn't export the
 # MD2 functions, so we must include them directly in liblegacy.a
-IF[{- $disabled{'deprecated-3.0'} -}]
+IF[{- $disabled{'deprecated-3.0'} && !$disabled{module} && !$disabled{shared} -}]
   SOURCE[../../providers/liblegacy.a]=md2_dgst.c md2_one.c
 ENDIF

--- a/crypto/md4/build.info
+++ b/crypto/md4/build.info
@@ -4,6 +4,6 @@ SOURCE[../../libcrypto]=md4_dgst.c md4_one.c
 
 # When all deprecated symbols are removed, libcrypto doesn't export the
 # MD4 functions, so we must include them directly in liblegacy.a
-IF[{- $disabled{'deprecated-3.0'} -}]
+IF[{- $disabled{'deprecated-3.0'} && !$disabled{module} && !$disabled{shared} -}]
   SOURCE[../../providers/liblegacy.a]=md4_dgst.c md4_one.c
 ENDIF

--- a/crypto/md5/build.info
+++ b/crypto/md5/build.info
@@ -24,7 +24,7 @@ SOURCE[../../libcrypto]=$COMMON
 # default provider.  A no-deprecated build removes the external definition from
 # libcrypto and this means that the code needs to be in liblegacy.  However,
 # when building without 'dso', liblegacy is included in libcrypto.
-IF[{- !$disabled{dso} -}]
+IF[{- !$disabled{module} && !$disabled{shared} -}]
   SOURCE[../../providers/liblegacy.a]=$COMMON
 ENDIF
 

--- a/crypto/mdc2/build.info
+++ b/crypto/mdc2/build.info
@@ -4,6 +4,6 @@ SOURCE[../../libcrypto]=mdc2dgst.c mdc2_one.c
 
 # When all deprecated symbols are removed, libcrypto doesn't export the
 # MDC2 functions, so we must include them directly in liblegacy.a
-IF[{- $disabled{'deprecated-3.0'} -}]
+IF[{- $disabled{'deprecated-3.0'} && !$disabled{module} && !$disabled{shared} -}]
   SOURCE[../../providers/liblegacy.a]=mdc2dgst.c mdc2_one.c
 ENDIF

--- a/crypto/rc2/build.info
+++ b/crypto/rc2/build.info
@@ -6,6 +6,6 @@ SOURCE[../../libcrypto]=$ALL
 
 # When all deprecated symbols are removed, libcrypto doesn't export the
 # rc2 functions, so we must include them directly in liblegacy.a
-IF[{- $disabled{'deprecated-3.0'} -}]
+IF[{- $disabled{'deprecated-3.0'} && !$disabled{module} && !$disabled{shared} -}]
   SOURCE[../../providers/liblegacy.a]=$ALL
 ENDIF

--- a/crypto/rc4/build.info
+++ b/crypto/rc4/build.info
@@ -21,7 +21,7 @@ SOURCE[../../libcrypto]=$RC4ASM
 
 # When all deprecated symbols are removed, libcrypto doesn't export the
 # rc4 functions, so we must include them directly in liblegacy.a
-IF[{- $disabled{'deprecated-3.0'} -}]
+IF[{- $disabled{'deprecated-3.0'} && !$disabled{module} && !$disabled{shared} -}]
   SOURCE[../../providers/liblegacy.a]=$RC4ASM
 ENDIF
 

--- a/crypto/rc5/build.info
+++ b/crypto/rc5/build.info
@@ -18,7 +18,7 @@ SOURCE[../../libcrypto]=$ALL
 
 # When all deprecated symbols are removed, libcrypto doesn't export the
 # rc5 functions, so we must include them directly in liblegacy.a
-IF[{- $disabled{'deprecated-3.0'} -}]
+IF[{- $disabled{'deprecated-3.0'} && !$disabled{module} && !$disabled{shared} -}]
   SOURCE[../../providers/liblegacy.a]=$ALL
 ENDIF
 

--- a/crypto/ripemd/build.info
+++ b/crypto/ripemd/build.info
@@ -20,7 +20,7 @@ DEFINE[../../libcrypto]=$RMD160DEF
 
 # When all deprecated symbols are removed, libcrypto doesn't export the
 # RIPEMD160 functions, so we must include them directly in liblegacy.a
-IF[{- $disabled{'deprecated-3.0'} && !$disabled{'module'} -}]
+IF[{- $disabled{'deprecated-3.0'} && !$disabled{module} && !$disabled{shared} -}]
   SOURCE[../../providers/liblegacy.a]=rmd_dgst.c rmd_one.c $RMD160ASM
   DEFINE[../../providers/liblegacy.a]=$RMD160DEF
 ENDIF

--- a/crypto/seed/build.info
+++ b/crypto/seed/build.info
@@ -5,6 +5,6 @@ SOURCE[../../libcrypto]=$ALL
 
 # When all deprecated symbols are removed, libcrypto doesn't export the
 # seed functions, so we must include them directly in liblegacy.a
-IF[{- $disabled{'deprecated-3.0'} -}]
+IF[{- $disabled{'deprecated-3.0'} && !$disabled{module} && !$disabled{shared} -}]
   SOURCE[../../providers/liblegacy.a]=$ALL
 ENDIF

--- a/crypto/whrlpool/build.info
+++ b/crypto/whrlpool/build.info
@@ -22,7 +22,7 @@ DEFINE[../../libcrypto]=$WPDEF
 
 # When all deprecated symbols are removed, libcrypto doesn't export the
 # WHIRLPOOL functions, so we must include them directly in liblegacy.a
-IF[{- $disabled{'deprecated-3.0'} -}]
+IF[{- $disabled{'deprecated-3.0'} && !$disabled{module} && !$disabled{shared} -}]
   SOURCE[../../providers/liblegacy.a]=wp_dgst.c $WPASM
   DEFINE[../../providers/liblegacy.a]=$WPDEF
 ENDIF


### PR DESCRIPTION
If no-module or no-shared is used, the symbols from libcrypto should not be duplicated in legacy.a

Also the BIGNUM functions are currently not needed in legacy.a at all.

Fixes #20124
