### PR TITLE
Revert "CI: cross-compile: riscv: Add RV64 machine with Zb* and Zk*"

### DIFF
--- a/.github/workflows/cross-compiles.yml
+++ b/.github/workflows/cross-compiles.yml
@@ -94,18 +94,9 @@ jobs:
             # resolves it.
             target: -O2 linux-ppc64le
           }, {
-            # RV64GC
             arch: riscv64-linux-gnu,
             libs: libc6-dev-riscv64-cross,
             target: linux64-riscv64
-          }, {
-            # RV64GC with bitmanip and scalar crypto extensions
-            arch: riscv64-linux-gnu,
-            libs: libc6-dev-riscv64-cross,
-            target: linux64-riscv64,
-            qemucpu: "rv64,zba=true,zbb=true,zbc=true,zbs=true,zbkb=true,zbkc=true,zbkx=true,zknd=true,zkne=true,zknh=true,zksed=true,zksh=true,zkr=true",
-            opensslcapsname: riscvcap, # OPENSSL_riscvcap
-            opensslcaps: "rv64gc_zba_zbb_zbc_zbs_zbkb_zbkc_zbkx_zbknd_zkne_zknh_zksed_zksh_zkr"
           }, {
             arch: s390x-linux-gnu,
             libs: libc6-dev-s390x-cross,


### PR DESCRIPTION
This reverts commit e787c57c538d0922004e49a10be0d403af773272.

The current CI host system is Ubuntu 22.04, which ships with QEMU 6.2. This QEMU release is too old for the required RISC-V extensions. We would need at least QEMU 7.1 (Aug 2022) for this patch.

Let's revert the patch.

See https://github.com/openssl/openssl/pull/20107

CC: @t8m 