### PR TITLE
Enable AES optimisation on Apple Silicon M2-based systems

### DIFF
--- a/crypto/armcap.c
+++ b/crypto/armcap.c
@@ -254,7 +254,8 @@ void OPENSSL_cpuid_setup(void)
             OPENSSL_armcap_P |= ARMV8_SHA3;
             len = sizeof(uarch);
             if ((sysctlbyname("machdep.cpu.brand_string", uarch, &len, NULL, 0) == 0) &&
-                (strncmp(uarch, "Apple M1", 8) == 0))
+               ((strncmp(uarch, "Apple M1", 8) == 0) ||
+                (strncmp(uarch, "Apple M2", 8) == 0)))
                 OPENSSL_armcap_P |= ARMV8_UNROLL8_EOR3;
         }
     }


### PR DESCRIPTION
Gives a performance enhancement of 16-38%, similar to the M1.
