### PR TITLE
Fix the padlock engine

### DIFF
--- a/engines/e_padlock.c
+++ b/engines/e_padlock.c
@@ -146,6 +146,19 @@ static int padlock_init(ENGINE *e)
     return (padlock_use_rng || padlock_use_ace);
 }
 
+#  ifndef AES_ASM
+static int padlock_aes_set_encrypt_key(const unsigned char *userKey,
+                                       const int bits,
+                                       AES_KEY *key);
+static int padlock_aes_set_decrypt_key(const unsigned char *userKey,
+                                       const int bits,
+                                       AES_KEY *key);
+#   define AES_ASM
+#   define AES_set_encrypt_key padlock_aes_set_encrypt_key
+#   define AES_set_decrypt_key padlock_aes_set_decrypt_key
+#   include "../crypto/aes/aes_core.c"
+#  endif
+
 /*
  * This stuff is needed if this ENGINE is being compiled into a
  * self-contained shared-library.
@@ -646,12 +659,10 @@ padlock_aes_init_key(EVP_CIPHER_CTX *ctx, const unsigned char *key,
             AES_set_decrypt_key(key, key_len, &cdata->ks);
         else
             AES_set_encrypt_key(key, key_len, &cdata->ks);
-#  ifndef AES_ASM
         /*
          * OpenSSL C functions use byte-swapped extended key.
          */
         padlock_key_bswap(&cdata->ks);
-#  endif
         cdata->cword.b.keygen = 1;
         break;
 


### PR DESCRIPTION
... after it was broken for almost 5 years,
since the first 1.1.1 release.
Note: The last working version was 1.1.0l release.

Fixes #20073

This is for master/3.1/3.0 branches,
1.1.1 will need an extra PR due to whitespace merge conflicts.
Manual tests on @ValdikSS 's padlock hardware were successful.