### PR TITLE
Update documentation for ChaCha20-poly1305 relating to setting the IV

### DIFF
--- a/doc/man3/EVP_EncryptInit.pod
+++ b/doc/man3/EVP_EncryptInit.pod
@@ -448,6 +448,8 @@ If not called a default nonce length of 12 (i.e. 96 bits) is used. The maximum
 nonce length is 12 bytes (i.e. 96-bits). If a nonce of less than 12 bytes is set
 then the nonce is automatically padded with leading 0 bytes to make it 12 bytes
 in length.
+Warning: Setting the length to values less than 12 will produce an error in OpenSSL
+version 3.0 and later. For secure operation it is not recommended to set this value.
 
 =item EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_AEAD_GET_TAG, taglen, tag)
 


### PR DESCRIPTION
length.

It is not recommended to set the value to less than 12 bytes. In OpenSSL 3.0 and later setting the value will result in an error.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
