### PR TITLE
APPS {`storeutl`,`gendsa`}: give error on extra arguments, improve doc

### DIFF
--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -1071,7 +1071,9 @@ int load_key_certs_crls(const char *uri, int format, int maybe_stdin,
     if (failed == NULL) {
         failed = FAIL_NAME;
         if (failed != NULL)
-            BIO_printf(bio_err, "Could not read");
+            BIO_printf(bio_err, "Could not find");
+    } else {
+        BIO_printf(bio_err, "Could not read");
     }
     if (failed != NULL) {
         unsigned long err = ERR_peek_last_error();

--- a/apps/lib/opt.c
+++ b/apps/lib/opt.c
@@ -1054,8 +1054,13 @@ int opt_check_rest_arg(const char *expected)
         opt_printf_stderr("%s: Missing argument: %s\n", prog, expected);
         return 0;
     }
-    if (expected != NULL)
-        return 1;
+    if (expected != NULL) {
+        opt = argv[opt_index + 1];
+        if (opt == NULL || *opt == '\0')
+            return 1;
+        opt_printf_stderr("%s: Extra argument after %s: \"%s\"\n", prog, expected, opt);
+        return 0;
+    }
     if (opt_unknown() == NULL)
         opt_printf_stderr("%s: Extra option: \"%s\"\n", prog, opt);
     else

--- a/doc/man1/openssl-gendsa.pod.in
+++ b/doc/man1/openssl-gendsa.pod.in
@@ -58,6 +58,8 @@ These options encrypt the private key with specified
 cipher before outputting it. A pass phrase is prompted for.
 If none of these options is specified no encryption is used.
 
+Note that all options must be given before the I<paramfile> argument.
+
 =item B<-verbose>
 
 Print extra details about the operations being performed.

--- a/doc/man1/openssl-storeutl.pod.in
+++ b/doc/man1/openssl-storeutl.pod.in
@@ -28,12 +28,12 @@ B<openssl> B<storeutl>
 [B<-fingerprint> I<arg>]
 [B<-I<digest>>]
 {- $OpenSSL::safe::opt_engine_synopsis -}{- $OpenSSL::safe::opt_provider_synopsis -}
-I<uri> ...
+I<uri>
 
 =head1 DESCRIPTION
 
 This command can be used to display the contents (after
-decryption as the case may be) fetched from the given URIs.
+decryption as the case may be) fetched from the given URI.
 
 =head1 OPTIONS
 
@@ -75,6 +75,8 @@ Fetch objects recursively when possible.
 Only select the certificates, keys or CRLs from the given URI.
 However, if this URI would return a set of names (URIs), those are always
 returned.
+
+Note that all options must be given before the I<uri> argument.
 
 =item B<-subject> I<arg>
 

--- a/test/recipes/15-test_gendsa.t
+++ b/test/recipes/15-test_gendsa.t
@@ -28,7 +28,7 @@ my $no_fips = disabled('fips') || ($ENV{NO_FIPS} // 0);
 
 plan tests =>
     ($no_fips ? 0 : 2)          # FIPS related tests
-    + 11;
+    + 13;
 
 ok(run(app([ 'openssl', 'genpkey', '-genparam',
              '-algorithm', 'DSA',
@@ -106,6 +106,14 @@ ok(run(app([ 'openssl', 'genpkey',
 ok(!run(app([ 'openssl', 'genpkey',
               '-algorithm', 'DSA'])),
    "genpkey DSA with no params should fail");
+
+ok(run(app(["openssl", "gendsa", "-verbose",
+            'dsagen.pem'])),
+    "gendsa with -verbose option and dsagen parameter");
+
+ok(!run(app(["openssl", "gendsa",
+             'dsagen.pem', "-verbose"])),
+   "gendsa with extra parameter (at end) should fail");
 
 unless ($no_fips) {
     my $provconf = srctop_file("test", "fips-and-base.cnf");

--- a/test/recipes/90-test_store.t
+++ b/test/recipes/90-test_store.t
@@ -106,7 +106,7 @@ push @methods, [ @prov_method ];
 push @methods, [qw(-engine loader_attic)]
     unless disabled('loadereng');
 
-my $n = scalar @methods
+my $n = 2 + scalar @methods
     * ( (3 * scalar @noexist_files)
         + (6 * scalar @src_files)
         + (2 * scalar @data_files)
@@ -130,6 +130,14 @@ if ($do_test_ossltest_store) {
 plan skip_all => "No plan" if $n == 0;
 
 plan tests => $n;
+
+my $test_x509 = srctop_file('test', 'testx509.pem');
+
+ok(run(app(["openssl", "storeutl",  "-crls", $test_x509])),
+   "storeutil with -crls option");
+
+ok(!run(app(["openssl", "storeutl", $test_x509, "-crls"])),
+   "storeutil with extra parameter (at end) should fail");
 
 indir "store_$$" => sub {
     if ($do_test_ossltest_store) {


### PR DESCRIPTION
Point out that CLI options must be given before the final file/URI arg.
So far, they were silently ignored, as well as any extra args.
Also fix in the `storeutl` doc that there is only one URI arg. 

On this occasion, also improve APPS `load_key_certs_crls()` diagnostics on not finding expected types of contents.

Fixes #20144.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
