### PR TITLE
Use $config{build_file} instead of $target{build_file}

### DIFF
--- a/Configure
+++ b/Configure
@@ -1446,7 +1446,7 @@ $target{build_scheme} = [ $target{build_scheme} ]
 my ($builder, $builder_platform, @builder_opts) =
     @{$target{build_scheme}};
 
-foreach my $checker (($builder_platform."-".$target{build_file}."-checker.pm",
+foreach my $checker (($builder_platform."-".$config{build_file}."-checker.pm",
                       $builder_platform."-checker.pm")) {
     my $checker_path = catfile($srcdir, "Configurations", $checker);
     if (-f $checker_path) {
@@ -1912,8 +1912,8 @@ if ($builder eq "unified") {
     # Store the name of the template file we will build the build file from
     # in %config.  This may be useful for the build file itself.
     my @build_file_template_names =
-        ( $builder_platform."-".$target{build_file}.".tmpl",
-          $target{build_file}.".tmpl" );
+        ( $builder_platform."-".$config{build_file}.".tmpl",
+          $config{build_file}.".tmpl" );
     my @build_file_templates = ();
 
     # First, look in the user provided directory, if given
@@ -2930,7 +2930,7 @@ exit(0);
 #
 sub death_handler {
     die @_ if $^S;              # To prevent the added message in eval blocks
-    my $build_file = $target{build_file} // "build file";
+    my $build_file = $config{build_file} // "build file";
     my @message = ( <<"_____", @_ );
 
 Failure!  $build_file wasn't produced.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1304,6 +1304,14 @@ and `descrip.mms` on OpenVMS) from a suitable template in `Configurations/`,
 and defines various macros in `include/openssl/configuration.h` (generated
 from `include/openssl/configuration.h.in`.
 
+If none of the generated build files suit your purpose, it's possible to
+write your own build file template and give its name through the environment
+variable `BUILDFILE`.  For example, Ninja build files could be supported by
+writing `Configurations/build.ninja.tmpl` and the configure with `BUILDFILE`
+set like this (Unix syntax shown, you'll have to adapt for other platforms):
+
+    $ BUILDFILE=build.ninja perl Configure [options...]
+
 ### Out of Tree Builds
 
 OpenSSL can be configured to build in a build directory separate from the

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1307,7 +1307,7 @@ from `include/openssl/configuration.h.in`.
 If none of the generated build files suit your purpose, it's possible to
 write your own build file template and give its name through the environment
 variable `BUILDFILE`.  For example, Ninja build files could be supported by
-writing `Configurations/build.ninja.tmpl` and the configure with `BUILDFILE`
+writing `Configurations/build.ninja.tmpl` and then configure with `BUILDFILE`
 set like this (Unix syntax shown, you'll have to adapt for other platforms):
 
     $ BUILDFILE=build.ninja perl Configure [options...]

--- a/configdata.pm.in
+++ b/configdata.pm.in
@@ -91,7 +91,7 @@ unless (caller) {
         # We do that in two steps, where the first step emits perl
         # snippets.
 
-        my $buildfile = $target{build_file};
+        my $buildfile = $config{build_file};
         my $buildfile_template = "$buildfile.in";
         my @autowarntext = (
             'WARNING: do not edit!',


### PR DESCRIPTION
If the user specifies an alternative build file than the default, this
alternative is recorded in $config{build_file}, not $target{build_file}.
Therefore, the former should be used, leaving the latter as a mere default.

This is a bug.  While fixing it, document it better too.
