### PR TITLE
Use $config{build_file} instead of $target{build_file} [1.1.1]

### DIFF
--- a/Configure
+++ b/Configure
@@ -1215,7 +1215,7 @@ $target{build_scheme} = [ $target{build_scheme} ]
 my ($builder, $builder_platform, @builder_opts) =
     @{$target{build_scheme}};
 
-foreach my $checker (($builder_platform."-".$target{build_file}."-checker.pm",
+foreach my $checker (($builder_platform."-".$config{build_file}."-checker.pm",
                       $builder_platform."-checker.pm")) {
     my $checker_path = catfile($srcdir, "Configurations", $checker);
     if (-f $checker_path) {
@@ -1712,8 +1712,8 @@ if ($builder eq "unified") {
     # Store the name of the template file we will build the build file from
     # in %config.  This may be useful for the build file itself.
     my @build_file_template_names =
-        ( $builder_platform."-".$target{build_file}.".tmpl",
-          $target{build_file}.".tmpl" );
+        ( $builder_platform."-".$config{build_file}.".tmpl",
+          $config{build_file}.".tmpl" );
     my @build_file_templates = ();
 
     # First, look in the user provided directory, if given
@@ -1937,8 +1937,8 @@ if ($builder eq "unified") {
                     }
                     next if @skip && $skip[$#skip] <= 0;
                     push @rawlines,  $_
-                        if ($target_kind eq $target{build_file}
-                            || $target_kind eq $target{build_file}."(".$builder_platform.")");
+                        if ($target_kind eq $config{build_file}
+                            || $target_kind eq $config{build_file}."(".$builder_platform.")");
                 }
             },
             qr/^\s*(?:#.*)?$/ => sub { },
@@ -2813,8 +2813,8 @@ if ($builder_platform eq 'unix') {
 
 my %builders = (
     unified => sub {
-        print 'Creating ',$target{build_file},"\n";
-        run_dofile(catfile($blddir, $target{build_file}),
+        print 'Creating ',$config{build_file},"\n";
+        run_dofile(catfile($blddir, $config{build_file}),
                    @{$config{build_file_templates}});
     },
     );
@@ -2868,7 +2868,7 @@ exit(0);
 #
 sub death_handler {
     die @_ if $^S;              # To prevent the added message in eval blocks
-    my $build_file = $target{build_file} // "build file";
+    my $build_file = $config{build_file} // "build file";
     my @message = ( <<"_____", @_ );
 
 Failure!  $build_file wasn't produced.


### PR DESCRIPTION
If the user specifies an alternative build file than the default, this alternative is recorded in $config{build_file}, not $target{build_file}. Therefore, the former should be used, leaving the latter as a mere default.

This is a bug.

-----

This is #20173 backported to 1.1.1