### PR TITLE
`doc/man1/{storeutl,gendsa}`: point out that extra options/arguments are ignored

### DIFF
--- a/doc/man1/openssl-gendsa.pod.in
+++ b/doc/man1/openssl-gendsa.pod.in
@@ -57,6 +57,9 @@ These options encrypt the private key with specified
 cipher before outputting it. A pass phrase is prompted for.
 If none of these options is specified no encryption is used.
 
+Note that all options must be given before the I<paramfile> argument.
+Otherwise they are ignored.
+
 =item B<-verbose>
 
 Print extra details about the operations being performed.

--- a/doc/man1/openssl-storeutl.pod.in
+++ b/doc/man1/openssl-storeutl.pod.in
@@ -28,12 +28,12 @@ B<openssl> B<storeutl>
 [B<-fingerprint> I<arg>]
 [B<-I<digest>>]
 {- $OpenSSL::safe::opt_engine_synopsis -}{- $OpenSSL::safe::opt_provider_synopsis -}
-I<uri> ...
+I<uri>
 
 =head1 DESCRIPTION
 
 This command can be used to display the contents (after
-decryption as the case may be) fetched from the given URIs.
+decryption as the case may be) fetched from the given URI.
 
 =head1 OPTIONS
 
@@ -75,6 +75,9 @@ Fetch objects recursively when possible.
 Only select the certificates, keys or CRLs from the given URI.
 However, if this URI would return a set of names (URIs), those are always
 returned.
+
+Note that all options must be given before the I<uri> argument.
+Otherwise they are ignored.
 
 =item B<-subject> I<arg>
 


### PR DESCRIPTION
... and therefore all options must be given before the final file/URI arg.

This is essentially a backport of the doc portion of #20156 to 3.0 and 3.1, 
where the missing error checking/reporting likely will not be added.

- [x] documentation is added or updated
