### PR TITLE
Fix incomplete check on EVP_CIPHER_param_to_asn1()

### DIFF
--- a/crypto/pkcs7/pk7_doit.c
+++ b/crypto/pkcs7/pk7_doit.c
@@ -331,7 +331,7 @@ BIO *PKCS7_dataInit(PKCS7 *p7, BIO *bio)
                 if (xalg->parameter == NULL)
                     goto err;
             }
-            if (EVP_CIPHER_param_to_asn1(ctx, xalg->parameter) < 0)
+            if (EVP_CIPHER_param_to_asn1(ctx, xalg->parameter) <= 0)
                 goto err;
         }
 


### PR DESCRIPTION
That function is a wrapper around evp_cipher_param_to_asn1_ex() which can return 0 as an error value via its ret <= 0 check [1]. Furthermore, all other callers of this function check against <= 0 instead of < 0 and this is also in line with what the documentation tells us. Fix the incomplete check by changing it to <= 0 as well.

CLA: trivial

[1] https://github.com/openssl/openssl/blob/114d99b46bfb212ffc510865df317ca2c1542623/crypto/evp/evp_lib.c#L164-L165

Please note that I found this using a static analysis tool I am developing at the moment. It could therefore be a false positive bug. I manually reviewed the case to be extra sure that it is a real bug.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
