### PR TITLE
Fix incomplete check on CMS_SharedInfo_encode

### DIFF
--- a/crypto/cms/cms_ec.c
+++ b/crypto/cms/cms_ec.c
@@ -346,7 +346,7 @@ static int ecdh_cms_encrypt(CMS_RecipientInfo *ri)
 
     penclen = CMS_SharedInfo_encode(&penc, wrap_alg, ukm, keylen);
 
-    if (penclen == 0)
+    if (penclen <= 0)
         goto err;
 
     if (EVP_PKEY_CTX_set0_ecdh_kdf_ukm(pctx, penc, penclen) <= 0)


### PR DESCRIPTION
CMS_SharedInfo_encode() can also return a negative error value, but this is not checked in the current check, only the zero error return value is covered. A previous PR [1] fixed the other caller's check of CMS_SharedInfo_encode in this file, but it seems like this place was missed. Fix it by changing the check to <= 0.

[1] https://github.com/openssl/openssl/pull/12628/commits/a752fc4da5e1dfd5b3a730d95272c2e2b0c48f1a

CLA: trivial

Please note that I found this using a static analysis tool I am developing at the moment. It could therefore be a false positive bug. I manually reviewed the case to be extra sure that it is a real bug.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
