### PR TITLE
Fix BIO_set_indent() check

### DIFF
--- a/crypto/asn1/asn1_parse.c
+++ b/crypto/asn1/asn1_parse.c
@@ -50,7 +50,7 @@ static int asn1_print_info(BIO *bp, long offset, int depth, int hl, long len,
             pop_f_prefix = 1;
         }
         saved_indent = BIO_get_indent(bp);
-        if (BIO_set_prefix(bp, str) <= 0 || BIO_set_indent(bp, indent) < 0)
+        if (BIO_set_prefix(bp, str) <= 0 || BIO_set_indent(bp, indent) <= 0)
             goto err;
     }
 


### PR DESCRIPTION
This macro returns an errorcode <= 0 according to the documentation and my tool, but only < 0 is checked. Other callers that check the return value perform this check correctly. Fix it by changing the check to <= 0.

CLA: trivial

Please note that I found this using a static analysis tool I am developing at the moment. It could therefore be a false positive bug. I manually reviewed the case to be extra sure that it is a real bug.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
