### PR TITLE
`OSSL_CMP_SRV_process_request()`: fix recipNonce in error cases, etc.

### DIFF
--- a/apps/cmp.c
+++ b/apps/cmp.c
@@ -1109,7 +1109,7 @@ static OSSL_CMP_SRV_CTX *setup_srv_ctx(ENGINE *engine)
         goto err;
 
     if (opt_send_error)
-        (void)ossl_cmp_mock_srv_set_send_error(srv_ctx, 1);
+        (void)ossl_cmp_mock_srv_set_sendError(srv_ctx, 1);
 
     if (opt_send_unprotected)
         (void)OSSL_CMP_CTX_set_option(ctx, OSSL_CMP_OPT_UNPROTECTED_SEND, 1);

--- a/apps/include/cmp_mock_srv.h
+++ b/apps/include/cmp_mock_srv.h
@@ -28,7 +28,7 @@ int ossl_cmp_mock_srv_set1_caPubsOut(OSSL_CMP_SRV_CTX *srv_ctx,
                                      STACK_OF(X509) *caPubs);
 int ossl_cmp_mock_srv_set_statusInfo(OSSL_CMP_SRV_CTX *srv_ctx, int status,
                                      int fail_info, const char *text);
-int ossl_cmp_mock_srv_set_send_error(OSSL_CMP_SRV_CTX *srv_ctx, int val);
+int ossl_cmp_mock_srv_set_sendError(OSSL_CMP_SRV_CTX *srv_ctx, int bodytype);
 int ossl_cmp_mock_srv_set_pollCount(OSSL_CMP_SRV_CTX *srv_ctx, int count);
 int ossl_cmp_mock_srv_set_checkAfterTime(OSSL_CMP_SRV_CTX *srv_ctx, int sec);
 

--- a/apps/lib/cmp_mock_srv.c
+++ b/apps/lib/cmp_mock_srv.c
@@ -23,7 +23,7 @@ typedef struct
     STACK_OF(X509) *chainOut;  /* chain of certOut to add to extraCerts field */
     STACK_OF(X509) *caPubsOut; /* certs to return in caPubs field of ip msg */
     OSSL_CMP_PKISI *statusOut; /* status for ip/cp/kup/rp msg unless polling */
-    int sendError;             /* send error response also on valid requests */
+    int sendError;             /* send error response on given request type */
     OSSL_CMP_MSG *certReq;     /* ir/cr/p10cr/kur remembered while polling */
     int certReqId;             /* id of last ir/cr/kur, used for polling */
     int pollCount;             /* number of polls before actual cert response */
@@ -56,6 +56,7 @@ static mock_srv_ctx *mock_srv_ctx_new(void)
     if ((ctx->statusOut = OSSL_CMP_PKISI_new()) == NULL)
         goto err;
 
+    ctx->sendError = -1;
     ctx->certReqId = -1;
 
     /* all other elements are initialized to 0 or NULL, respectively */
@@ -148,7 +149,7 @@ int ossl_cmp_mock_srv_set_statusInfo(OSSL_CMP_SRV_CTX *srv_ctx, int status,
     return 1;
 }
 
-int ossl_cmp_mock_srv_set_send_error(OSSL_CMP_SRV_CTX *srv_ctx, int val)
+int ossl_cmp_mock_srv_set_sendError(OSSL_CMP_SRV_CTX *srv_ctx, int bodytype)
 {
     mock_srv_ctx *ctx = OSSL_CMP_SRV_CTX_get0_custom_ctx(srv_ctx);
 
@@ -156,7 +157,8 @@ int ossl_cmp_mock_srv_set_send_error(OSSL_CMP_SRV_CTX *srv_ctx, int val)
         ERR_raise(ERR_LIB_CMP, CMP_R_NULL_ARGUMENT);
         return 0;
     }
-    ctx->sendError = val != 0;
+    /* might check bodytype, but this would require exporting all body types */
+    ctx->sendError = bodytype;
     return 1;
 }
 
@@ -220,7 +222,8 @@ static OSSL_CMP_PKISI *process_cert_request(OSSL_CMP_SRV_CTX *srv_ctx,
         ERR_raise(ERR_LIB_CMP, CMP_R_NULL_ARGUMENT);
         return NULL;
     }
-    if (ctx->sendError) {
+    if (ctx->sendError == 1
+            || ctx->sendError == OSSL_CMP_MSG_get_bodytype(cert_req)) {
         ERR_raise(ERR_LIB_CMP, CMP_R_ERROR_PROCESSING_MESSAGE);
         return NULL;
     }
@@ -298,7 +301,8 @@ static OSSL_CMP_PKISI *process_rr(OSSL_CMP_SRV_CTX *srv_ctx,
         ERR_raise(ERR_LIB_CMP, CMP_R_NULL_ARGUMENT);
         return NULL;
     }
-    if (ctx->sendError) {
+    if (ctx->sendError == 1
+            || ctx->sendError == OSSL_CMP_MSG_get_bodytype(rr)) {
         ERR_raise(ERR_LIB_CMP, CMP_R_ERROR_PROCESSING_MESSAGE);
         return NULL;
     }
@@ -325,7 +329,9 @@ static int process_genm(OSSL_CMP_SRV_CTX *srv_ctx,
         ERR_raise(ERR_LIB_CMP, CMP_R_NULL_ARGUMENT);
         return 0;
     }
-    if (sk_OSSL_CMP_ITAV_num(in) > 1 || ctx->sendError) {
+    if (ctx->sendError == 1
+            || ctx->sendError == OSSL_CMP_MSG_get_bodytype(genm)
+            || sk_OSSL_CMP_ITAV_num(in) > 1) {
         ERR_raise(ERR_LIB_CMP, CMP_R_ERROR_PROCESSING_MESSAGE);
         return 0;
     }
@@ -392,7 +398,9 @@ static int process_certConf(OSSL_CMP_SRV_CTX *srv_ctx,
         ERR_raise(ERR_LIB_CMP, CMP_R_NULL_ARGUMENT);
         return 0;
     }
-    if (ctx->sendError || ctx->certOut == NULL) {
+    if (ctx->sendError == 1
+            || ctx->sendError == OSSL_CMP_MSG_get_bodytype(certConf)
+            || ctx->certOut == NULL) {
         ERR_raise(ERR_LIB_CMP, CMP_R_ERROR_PROCESSING_MESSAGE);
         return 0;
     }
@@ -425,7 +433,8 @@ static int process_pollReq(OSSL_CMP_SRV_CTX *srv_ctx,
         ERR_raise(ERR_LIB_CMP, CMP_R_NULL_ARGUMENT);
         return 0;
     }
-    if (ctx->sendError) {
+    if (ctx->sendError == 1
+            || ctx->sendError == OSSL_CMP_MSG_get_bodytype(pollReq)) {
         *certReq = NULL;
         ERR_raise(ERR_LIB_CMP, CMP_R_ERROR_PROCESSING_MESSAGE);
         return 0;

--- a/crypto/cmp/cmp_client.c
+++ b/crypto/cmp/cmp_client.c
@@ -630,6 +630,7 @@ static int cert_response(OSSL_CMP_CTX *ctx, int sleep, int rid,
         ERR_raise_data(ERR_LIB_CMP, CMP_R_CERTIFICATE_NOT_ACCEPTED,
                        "rejecting newly enrolled cert with subject: %s; %s",
                        subj, txt);
+        ctx->status = OSSL_CMP_PKISTATUS_rejection;
         ret = 0;
     }
     OPENSSL_free(subj);

--- a/crypto/cmp/cmp_ctx.c
+++ b/crypto/cmp/cmp_ctx.c
@@ -602,13 +602,13 @@ DEFINE_OSSL_set1_up_ref(ossl_cmp_ctx, validatedSrvCert, X509)
  */
 DEFINE_OSSL_set1_up_ref(OSSL_CMP_CTX, srvCert, X509)
 
-/* Set the X509 name of the recipient. Set in the PKIHeader */
+/* Set the X509 name of the recipient to be placed in the PKIHeader */
 DEFINE_OSSL_CMP_CTX_set1(recipient, X509_NAME)
 
 /* Store the X509 name of the expected sender in the PKIHeader of responses */
 DEFINE_OSSL_CMP_CTX_set1(expected_sender, X509_NAME)
 
-/* Set the X509 name of the issuer. Set in the PKIHeader */
+/* Set the X509 name of the issuer to be placed in the certTemplate */
 DEFINE_OSSL_CMP_CTX_set1(issuer, X509_NAME)
 
 /*

--- a/crypto/cmp/cmp_vfy.c
+++ b/crypto/cmp/cmp_vfy.c
@@ -651,7 +651,7 @@ static int check_transactionID_or_nonce(ASN1_OCTET_STRING *expected,
 
         expected_str = i2s_ASN1_OCTET_STRING(NULL, expected);
         actual_str = actual == NULL ? NULL: i2s_ASN1_OCTET_STRING(NULL, actual);
-        ERR_raise_data(ERR_LIB_CMP, CMP_R_TRANSACTIONID_UNMATCHED,
+        ERR_raise_data(ERR_LIB_CMP, reason,
                        "expected = %s, actual = %s",
                        expected_str == NULL ? "?" : expected_str,
                        actual == NULL ? "(none)" :

--- a/crypto/cmp/cmp_vfy.c
+++ b/crypto/cmp/cmp_vfy.c
@@ -775,6 +775,11 @@ int ossl_cmp_msg_check_update(OSSL_CMP_CTX *ctx, const OSSL_CMP_MSG *msg,
                                       CMP_R_RECIPNONCE_UNMATCHED))
         return 0;
 
+    /* if not yet present, learn transactionID */
+    if (ctx->transactionID == NULL
+        && !OSSL_CMP_CTX_set1_transactionID(ctx, hdr->transactionID))
+        return 0;
+
     /*
      * RFC 4210 section 5.1.1 states: the recipNonce is copied from
      * the senderNonce of the previous message in the transaction.
@@ -782,11 +787,6 @@ int ossl_cmp_msg_check_update(OSSL_CMP_CTX *ctx, const OSSL_CMP_MSG *msg,
      */
     if (!ossl_cmp_ctx_set1_recipNonce(ctx, hdr->senderNonce))
         return 0;
-
-    /* if not yet present, learn transactionID */
-    if (ctx->transactionID == NULL
-        && !OSSL_CMP_CTX_set1_transactionID(ctx, hdr->transactionID))
-        return -1;
 
     /*
      * Store any provided extraCerts in ctx for future use,
@@ -798,7 +798,7 @@ int ossl_cmp_msg_check_update(OSSL_CMP_CTX *ctx, const OSSL_CMP_MSG *msg,
                         /* this allows self-signed certs */
                         X509_ADD_FLAG_UP_REF | X509_ADD_FLAG_NO_DUP
                         | X509_ADD_FLAG_PREPEND))
-        return -1;
+        return 0;
 
     if (ossl_cmp_hdr_get_protection_nid(hdr) == NID_id_PasswordBasedMAC) {
         /*

--- a/doc/internal/man3/ossl_cmp_mock_srv_new.pod
+++ b/doc/internal/man3/ossl_cmp_mock_srv_new.pod
@@ -41,30 +41,29 @@ I<propq>, both of which may be NULL to select the defaults.
 
 ossl_cmp_mock_srv_free() deallocates the contexts for the CMP mock server.
 
-OSSL_CMP_SRV_CTX_set1_refCert() sets the reference certificate to be expected
+ossl_cmp_mock_srv_set1_refCert() sets the reference certificate to be expected
 for rr messages and for any oldCertID included in kur messages.
 
-OSSL_CMP_SRV_CTX_set1_certOut() sets the certificate to be returned in
+ossl_cmp_mock_srv_set1_certOut() sets the certificate to be returned in
 cp/ip/kup.
 Note that on each certificate request the mock server does not produce
 a fresh certificate but just returns the same pre-existing certificate.
 
-OSSL_CMP_SRV_CTX_set1_chainOut() sets the certificate chain to be added to
+ossl_cmp_mock_srv_set1_chainOut() sets the certificate chain to be added to
 the extraCerts in a cp/ip/kup.
 It should be useful for the validation of the certificate given via
-OSSL_CMP_SRV_CTX_set1_certOut().
+ossl_cmp_mock_srv_set1_certOut().
 
-OSSL_CMP_SRV_CTX_set1_caPubsOut() sets the caPubs to be returned in an ip.
+ossl_cmp_mock_srv_set1_caPubsOut() sets the caPubs to be returned in an ip.
 
-OSSL_CMP_SRV_CTX_set_statusInfo() sets the status info to be returned.
+ossl_cmp_mock_srv_set_statusInfo() sets the status info to be returned.
 
-OSSL_CMP_SRV_CTX_set_send_error() enables enforcement of error responses.
+ossl_cmp_mock_srv_set_send_error() enables enforcement of error responses.
 
-OSSL_CMP_SRV_CTX_set_pollCount() sets the number of polls before cert response.
+ossl_cmp_mock_srv_set_pollCount() sets the number of polls before cert response.
 
-OSSL_CMP_SRV_CTX_set_checkAfterTime() sets the number of seconds
+ossl_cmp_mock_srv_set_checkAfterTime() sets the number of seconds
 the client should wait for the next poll.
-
 
 =head1 NOTES
 

--- a/doc/internal/man3/ossl_cmp_mock_srv_new.pod
+++ b/doc/internal/man3/ossl_cmp_mock_srv_new.pod
@@ -9,7 +9,7 @@ ossl_cmp_mock_srv_set1_certOut,
 ossl_cmp_mock_srv_set1_chainOut,
 ossl_cmp_mock_srv_set1_caPubsOut,
 ossl_cmp_mock_srv_set_statusInfo,
-ossl_cmp_mock_srv_set_send_error,
+ossl_cmp_mock_srv_set_sendError,
 ossl_cmp_mock_srv_set_pollCount,
 ossl_cmp_mock_srv_set_checkAfterTime
 - functions used for testing with CMP mock server
@@ -29,7 +29,7 @@ ossl_cmp_mock_srv_set_checkAfterTime
                                       STACK_OF(X509) *caPubs);
  int ossl_cmp_mock_srv_set_statusInfo(OSSL_CMP_SRV_CTX *srv_ctx, int status,
                                       int fail_info, const char *text);
- int ossl_cmp_mock_srv_set_send_error(OSSL_CMP_SRV_CTX *srv_ctx, int val);
+ int ossl_cmp_mock_srv_set_sendError(OSSL_CMP_SRV_CTX *srv_ctx, int bodytype);
  int ossl_cmp_mock_srv_set_pollCount(OSSL_CMP_SRV_CTX *srv_ctx, int count);
  int ossl_cmp_mock_srv_set_checkAfterTime(OSSL_CMP_SRV_CTX *srv_ctx, int sec);
 
@@ -58,7 +58,9 @@ ossl_cmp_mock_srv_set1_caPubsOut() sets the caPubs to be returned in an ip.
 
 ossl_cmp_mock_srv_set_statusInfo() sets the status info to be returned.
 
-ossl_cmp_mock_srv_set_send_error() enables enforcement of error responses.
+ossl_cmp_mock_srv_set_sendError() enables enforcement of error responses
+for requests of the given I<bodytype>, or for all requests if I<bodytype> is 1.
+A I<bodytype> of -1 can be used to disable this feature, which is the default.
 
 ossl_cmp_mock_srv_set_pollCount() sets the number of polls before cert response.
 

--- a/test/cmp_client_test.c
+++ b/test/cmp_client_test.c
@@ -126,6 +126,7 @@ static int execute_exec_certrequest_ses_test(CMP_SES_TEST_FIXTURE *fixture)
     X509 *res = OSSL_CMP_exec_certreq(ctx, fixture->req_type, NULL);
     int status = OSSL_CMP_CTX_get_status(ctx);
 
+    OSSL_CMP_CTX_print_errors(ctx);
     if (!TEST_int_eq(status, fixture->expected)
         && !(fixture->expected == OSSL_CMP_PKISTATUS_waiting
              && TEST_int_eq(status, OSSL_CMP_PKISTATUS_trans)))
@@ -173,7 +174,7 @@ static int test_exec_RR_ses_receive_error(void)
                                      OSSL_CMP_PKISTATUS_rejection,
                                      OSSL_CMP_CTX_FAILINFO_signerNotTrusted,
                                      "test string");
-    ossl_cmp_mock_srv_set_send_error(fixture->srv_ctx, 1);
+    ossl_cmp_mock_srv_set_sendError(fixture->srv_ctx, OSSL_CMP_PKIBODY_RR);
     fixture->expected = OSSL_CMP_PKISTATUS_rejection;
     EXECUTE_TEST(execute_exec_RR_ses_test, tear_down);
     return result;
@@ -224,27 +225,31 @@ static int test_exec_IR_ses_poll_total_timeout(void)
                                  OSSL_CMP_PKISTATUS_waiting);
 }
 
-static int test_exec_CR_ses(int implicit_confirm, int granted)
+static int test_exec_CR_ses(int implicit_confirm, int granted, int reject)
 {
     SETUP_TEST_FIXTURE(CMP_SES_TEST_FIXTURE, set_up);
     fixture->req_type = OSSL_CMP_CR;
-    fixture->expected = OSSL_CMP_PKISTATUS_accepted;
     OSSL_CMP_CTX_set_option(fixture->cmp_ctx,
                             OSSL_CMP_OPT_IMPLICIT_CONFIRM, implicit_confirm);
     OSSL_CMP_SRV_CTX_set_grant_implicit_confirm(fixture->srv_ctx, granted);
+    ossl_cmp_mock_srv_set_sendError(fixture->srv_ctx,
+                                    reject ? OSSL_CMP_PKIBODY_CERTCONF : -1);
+    fixture->expected = reject ? OSSL_CMP_PKISTATUS_rejection
+        : OSSL_CMP_PKISTATUS_accepted;
     EXECUTE_TEST(execute_exec_certrequest_ses_test, tear_down);
     return result;
 }
 
 static int test_exec_CR_ses_explicit_confirm(void)
 {
-    return test_exec_CR_ses(0, 0);
+    return test_exec_CR_ses(0, 0, 0)
+        && test_exec_CR_ses(0, 0, 1 /* reject */);
 }
 
 static int test_exec_CR_ses_implicit_confirm(void)
 {
-    return test_exec_CR_ses(1, 0)
-        && test_exec_CR_ses(1, 1);
+    return test_exec_CR_ses(1, 0, 0)
+        && test_exec_CR_ses(1, 1 /* granted */, 0);
 }
 
 static int test_exec_KUR_ses(int transfer_error)
@@ -269,21 +274,48 @@ static int test_exec_KUR_ses_transfer_error(void)
     return test_exec_KUR_ses(1);
 }
 
-static int test_exec_P10CR_ses(void)
+static int test_certConf_cb(OSSL_CMP_CTX *ctx, X509 *cert, int fail_info,
+                            const char **txt)
 {
-    X509_REQ *req = NULL;
+    int *reject = OSSL_CMP_CTX_get_certConf_cb_arg(ctx);
+
+    if (*reject) {
+        *txt = "not to my taste";
+        fail_info = OSSL_CMP_PKIFAILUREINFO_badCertTemplate;
+    }
+    return fail_info;
+}
+
+static int test_exec_P10CR_ses(int reject)
+{
+    OSSL_CMP_CTX *ctx;
+    X509_REQ *csr = NULL;
 
     SETUP_TEST_FIXTURE(CMP_SES_TEST_FIXTURE, set_up);
     fixture->req_type = OSSL_CMP_P10CR;
-    fixture->expected = OSSL_CMP_PKISTATUS_accepted;
-    if (!TEST_ptr(req = load_csr_der(pkcs10_f, libctx))
-            || !TEST_true(OSSL_CMP_CTX_set1_p10CSR(fixture->cmp_ctx, req))) {
+    fixture->expected = reject ? OSSL_CMP_PKISTATUS_rejection
+        : OSSL_CMP_PKISTATUS_accepted;
+    ctx = fixture->cmp_ctx;
+    if (!TEST_ptr(csr = load_csr_der(pkcs10_f, libctx))
+        || !TEST_true(OSSL_CMP_CTX_set1_p10CSR(ctx, csr))
+        || !TEST_true(OSSL_CMP_CTX_set_certConf_cb(ctx, test_certConf_cb))
+        || !TEST_true(OSSL_CMP_CTX_set_certConf_cb_arg(ctx, &reject))) {
         tear_down(fixture);
         fixture = NULL;
     }
-    X509_REQ_free(req);
+    X509_REQ_free(csr);
     EXECUTE_TEST(execute_exec_certrequest_ses_test, tear_down);
     return result;
+}
+
+static int test_exec_P10CR_ses_ok(void)
+{
+    return test_exec_P10CR_ses(0);
+}
+
+static int test_exec_P10CR_ses_reject(void)
+{
+    return test_exec_P10CR_ses(1);
 }
 
 static int execute_try_certreq_poll_test(CMP_SES_TEST_FIXTURE *fixture)
@@ -319,7 +351,7 @@ static int execute_try_certreq_poll_abort_test(CMP_SES_TEST_FIXTURE *fixture)
 {
     OSSL_CMP_CTX *ctx = fixture->cmp_ctx;
     int check_after;
-    const int CHECK_AFTER = INT_MAX;
+    const int CHECK_AFTER = 99;
     const int TYPE = OSSL_CMP_CR;
 
     ossl_cmp_mock_srv_set_pollCount(fixture->srv_ctx, 3);
@@ -328,7 +360,7 @@ static int execute_try_certreq_poll_abort_test(CMP_SES_TEST_FIXTURE *fixture)
         && check_after == CHECK_AFTER
         && TEST_ptr_eq(OSSL_CMP_CTX_get0_newCert(ctx), NULL)
         && TEST_int_eq(fixture->expected,
-                       OSSL_CMP_try_certreq(ctx, -1, NULL, NULL))
+                       OSSL_CMP_try_certreq(ctx, -1 /* abort */, NULL, NULL))
         && TEST_ptr_eq(OSSL_CMP_CTX_get0_newCert(fixture->cmp_ctx), NULL);
 }
 
@@ -463,7 +495,8 @@ int setup_tests(void)
     ADD_TEST(test_exec_IR_ses_poll_total_timeout);
     ADD_TEST(test_exec_KUR_ses_ok);
     ADD_TEST(test_exec_KUR_ses_transfer_error);
-    ADD_TEST(test_exec_P10CR_ses);
+    ADD_TEST(test_exec_P10CR_ses_ok);
+    ADD_TEST(test_exec_P10CR_ses_reject);
     ADD_TEST(test_try_certreq_poll);
     ADD_TEST(test_try_certreq_poll_abort);
     ADD_TEST(test_exec_GENM_ses_ok);

--- a/test/testutil/provider.c
+++ b/test/testutil/provider.c
@@ -38,7 +38,7 @@ int test_get_libctx(OSSL_LIB_CTX **libctx, OSSL_PROVIDER **default_null_prov,
         goto err;
     }
 
-    if (module_name != NULL
+    if (provider != NULL && module_name != NULL
             && (*provider = OSSL_PROVIDER_load(new_libctx, module_name)) == NULL) {
         opt_printf_stderr("Failed to load provider %s\n", module_name);
         goto err;


### PR DESCRIPTION
With more thorough testing I found several bugs in CMP error situations, fixed here.
To add test cases I had to generalize the internal error injection function `ossl_cmp_mock_srv_set_send_error()`,
which I renamed for consistency with related functions to `ossl_cmp_mock_srv_set_sendError()`.

In this occasion, also fix glitches in the internal documentation of these functions,
two mistakes in related code comments in `cmp_ctx.c`, 
and a potential crash in `test_get_libctx()`, which I noticed while 
preparing #20187, which came up while extending the tests.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
