### PR TITLE
Fix more VMS inclusions

### DIFF
--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -240,8 +240,6 @@
       # includes "../ssl_local.h".  Adding "./quic" as an inclusion directory
       # helps making this sort of header from these directories.
       push @{$unified_info{includes_extra}->{$obj}}, qw(./quic);
-      use Data::Dumper;
-      print STDERR Dumper($unified_info{includes_extra});
   }
   foreach (grep /\[\.ssl\.(?:record|statem)\].*?\.o$/, keys %{$unified_info{sources}}) {
       my $obj = platform->obj($_);

--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -229,11 +229,19 @@
   }
   foreach (grep /\[\.ssl\].*?\.o$/, keys %{$unified_info{sources}}) {
       my $obj = platform->obj($_);
-      # Most of the files in [.ssl.record.methods] include "ssl_local.h"
-      # which includes things like "record/record.h".  Adding "./" as an
-      # inclusion directory helps making this sort of header from these
-      # directories.
+      # Most of the files in [.ssl] include "ssl_local.h" which includes things
+      # like "record/record.h".  Adding "./" as an inclusion directory helps
+      # making this sort of header from these directories.
       push @{$unified_info{includes_extra}->{$obj}}, qw(./);
+  }
+  foreach (grep /\[\.ssl\].*?ssl_lib\.o$/, keys %{$unified_info{sources}}) {
+      my $obj = platform->obj($_);
+      # Some files in [.ssl] include "quic/quic_local.h", which in turn
+      # includes "../ssl_local.h".  Adding "./quic" as an inclusion directory
+      # helps making this sort of header from these directories.
+      push @{$unified_info{includes_extra}->{$obj}}, qw(./quic);
+      use Data::Dumper;
+      print STDERR Dumper($unified_info{includes_extra});
   }
   foreach (grep /\[\.ssl\.(?:record|statem)\].*?\.o$/, keys %{$unified_info{sources}}) {
       my $obj = platform->obj($_);


### PR DESCRIPTION
inclusing quic/quic_local.h from ssl/ssl_lib.c presented another challenge
for the current VMS C.  Since ssl/quic/quic_local.h in turn includes
../ssl_local.h, we compensated for with the usual whack-a-mole in
Configurations/descrip.mms.tmpl.

As far as my personal tests go, this seems to be the last fix of this sort,
so far.
