### PR TITLE
Fix typo in Ordinals.pm from PR #14074

### DIFF
--- a/util/perl/OpenSSL/Ordinals.pm
+++ b/util/perl/OpenSSL/Ordinals.pm
@@ -349,7 +349,7 @@ sub _putback {
         croak "Duplicate entries for ".$items[0]->name()." from ".
             $items[0]->source()." and ".$items[1]->source()."\n"
             if $items[0]->name() eq $items[1]->name()
-            && $items[0]->type() eq $items[2]->type()
+            && $items[0]->type() eq $items[1]->type()
             && $items[0]->platforms() eq $items[1]->platforms();
 
         # Check that all platforms exist in both items, and have opposite values


### PR DESCRIPTION
Commit 50ccc176da8644be079eccc4523c261e34f7b293 (PR #14074) broke reporting of duplicate prototypes due to an overlooked typo.