### PR TITLE
Fix pipelining in 3.1/3.0

### DIFF
--- a/doc/man3/SSL_CTX_set_split_send_fragment.pod
+++ b/doc/man3/SSL_CTX_set_split_send_fragment.pod
@@ -56,7 +56,7 @@ of pipelines that will be used at any one time. This value applies to both
 used (i.e. normal non-parallel operation). The number of pipelines set must be
 in the range 1 - SSL_MAX_PIPELINES (32). Setting this to a value > 1 will also
 automatically turn on "read_ahead" (see L<SSL_CTX_set_read_ahead(3)>). This is
-explained further below. OpenSSL will only every use more than one pipeline if
+explained further below. OpenSSL will only ever use more than one pipeline if
 a cipher suite is negotiated that uses a pipeline capable cipher provided by an
 engine.
 
@@ -96,7 +96,10 @@ into the buffer. Without this set data is read into the read buffer one record
 at a time. The more data that can be read, the more opportunity there is for
 parallelising the processing at the cost of increased memory overhead per
 connection. Setting B<read_ahead> can impact the behaviour of the SSL_pending()
-function (see L<SSL_pending(3)>).
+function (see L<SSL_pending(3)>). In addition the default size of the internal
+read buffer is multiplied by the number of pipelines available to ensure that we
+can read multiple records in one go. This can therefore have a significant
+impact on memory usage.
 
 The SSL_CTX_set_default_read_buffer_len() and SSL_set_default_read_buffer_len()
 functions control the size of the read buffer that will be used. The B<len>

--- a/ssl/record/rec_layer_s3.c
+++ b/ssl/record/rec_layer_s3.c
@@ -608,14 +608,13 @@ int ssl3_write_bytes(SSL *s, int type, const void *buf_, size_t len,
         if (numpipes > maxpipes)
             numpipes = maxpipes;
 
-        if (n / numpipes >= max_send_fragment) {
+        if (n / numpipes >= split_send_fragment) {
             /*
              * We have enough data to completely fill all available
              * pipelines
              */
-            for (j = 0; j < numpipes; j++) {
-                pipelens[j] = max_send_fragment;
-            }
+            for (j = 0; j < numpipes; j++)
+                pipelens[j] = split_send_fragment;
         } else {
             /* We can partially fill all available pipelines */
             tmppipelen = n / numpipes;

--- a/ssl/record/rec_layer_s3.c
+++ b/ssl/record/rec_layer_s3.c
@@ -215,25 +215,7 @@ int ssl3_read_n(SSL *s, size_t n, size_t max, int extend, int clearold,
         /* start with empty packet ... */
         if (left == 0)
             rb->offset = align;
-        else if (align != 0 && left >= SSL3_RT_HEADER_LENGTH) {
-            /*
-             * check if next packet length is large enough to justify payload
-             * alignment...
-             */
-            pkt = rb->buf + rb->offset;
-            if (pkt[0] == SSL3_RT_APPLICATION_DATA
-                && (pkt[3] << 8 | pkt[4]) >= 128) {
-                /*
-                 * Note that even if packet is corrupted and its length field
-                 * is insane, we can only be led to wrong decision about
-                 * whether memmove will occur or not. Header values has no
-                 * effect on memmove arguments and therefore no buffer
-                 * overrun can be triggered.
-                 */
-                memmove(rb->buf + align, pkt, left);
-                rb->offset = align;
-            }
-        }
+
         s->rlayer.packet = rb->buf + rb->offset;
         s->rlayer.packet_length = 0;
         /* ... now we can act as if 'extend' was set */

--- a/ssl/record/ssl3_buffer.c
+++ b/ssl/record/ssl3_buffer.c
@@ -58,6 +58,11 @@ int ssl3_setup_read_buffer(SSL *s)
         if (ssl_allow_compression(s))
             len += SSL3_RT_MAX_COMPRESSED_OVERHEAD;
 #endif
+
+        /* Ensure our buffer is large enough to support all our pipelines */
+        if (s->max_pipelines > 1)
+            len *= s->max_pipelines;
+
         if (b->default_len > len)
             len = b->default_len;
         if ((p = OPENSSL_malloc(len)) == NULL) {

--- a/ssl/record/ssl3_record.c
+++ b/ssl/record/ssl3_record.c
@@ -964,6 +964,7 @@ int tls1_enc(SSL *s, SSL3_RECORD *recs, size_t n_recs, int sending,
     EVP_CIPHER_CTX *ds;
     size_t reclen[SSL_MAX_PIPELINES];
     unsigned char buf[SSL_MAX_PIPELINES][EVP_AEAD_TLS1_AAD_LEN];
+    unsigned char *data[SSL_MAX_PIPELINES];
     int i, pad = 0, tmpr;
     size_t bs, ctr, padnum, loop;
     unsigned char padval;
@@ -1123,8 +1124,6 @@ int tls1_enc(SSL *s, SSL3_RECORD *recs, size_t n_recs, int sending,
             }
         }
         if (n_recs > 1) {
-            unsigned char *data[SSL_MAX_PIPELINES];
-
             /* Set the output buffers */
             for (ctr = 0; ctr < n_recs; ctr++) {
                 data[ctr] = recs[ctr].data;


### PR DESCRIPTION
This PR backports the fixes to a number of pipelining bugs that were resolved in master recently to 3.1/3.0. It also adds a new test for the pipelining code which would have caught these issues.

It is mostly a backport of PR #19456, plus an additional fix which was included in a much larger commit in master (https://github.com/openssl/openssl/commit/c6186792b98e93cf2d5d2a9fb85e4aeab31db890) related to moving the pipelining code into the new record layer that exists there.

Fixes #20197