### PR TITLE
Fix a potential memory leak in apps/s_server.c

### DIFF
--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -229,6 +229,7 @@ static int psk_find_session_cb(SSL *ssl, const unsigned char *identity,
             || !SSL_SESSION_set_cipher(tmpsess, cipher)
             || !SSL_SESSION_set_protocol_version(tmpsess, SSL_version(ssl))) {
         OPENSSL_free(key);
+        SSL_SESSION_free(tmpsess);
         return 0;
     }
     OPENSSL_free(key);


### PR DESCRIPTION
Allocate memory for a new SSL session.
If any of these steps fail,
free the key memory and the tmpsess object
before returning 0 to prevent a memory leak.

Fixes: #20110

CLA: trivial