### PR TITLE
Fix SSL3_ALIGN_PAYLOAD=0

### DIFF
--- a/.github/workflows/run-checker-daily.yml
+++ b/.github/workflows/run-checker-daily.yml
@@ -131,6 +131,7 @@ jobs:
           no-zlib,
           enable-zlib-dynamic,
           no-zlib-dynamic,
+          -DSSL3_ALIGN_PAYLOAD=0,
           -DOPENSSL_NO_BUILTIN_OVERFLOW_CHECKING
         ]
     runs-on: ubuntu-latest

--- a/ssl/record/methods/tls1_meth.c
+++ b/ssl/record/methods/tls1_meth.c
@@ -539,7 +539,7 @@ static int tls1_mac(OSSL_RECORD_LAYER *rl, TLS_RL_RECORD *rec, unsigned char *md
     return ret;
 }
 
-#if defined(SSL3_ALIGN_PAYLOAD) && SSL3_ALIGN_PAYLOAD != 0
+#if SSL3_ALIGN_PAYLOAD != 0
 # ifndef OPENSSL_NO_COMP
 #  define MAX_PREFIX_LEN ((SSL3_ALIGN_PAYLOAD - 1) \
                            + SSL3_RT_SEND_MAX_ENCRYPTED_OVERHEAD \
@@ -612,7 +612,7 @@ int tls1_initialise_write_packets(OSSL_RECORD_LAYER *rl,
 
         wb = &bufs[0];
 
-#if defined(SSL3_ALIGN_PAYLOAD) && SSL3_ALIGN_PAYLOAD != 0
+#if SSL3_ALIGN_PAYLOAD != 0
         align = (size_t)TLS_BUFFER_get_buf(wb) + SSL3_RT_HEADER_LENGTH;
         align = SSL3_ALIGN_PAYLOAD - 1
                 - ((align - 1) % SSL3_ALIGN_PAYLOAD);
@@ -625,7 +625,7 @@ int tls1_initialise_write_packets(OSSL_RECORD_LAYER *rl,
             return 0;
         }
         *wpinited = 1;
-        if (!WPACKET_allocate_bytes(&pkt[0], align, NULL)) {
+        if (align != 0 && !WPACKET_allocate_bytes(&pkt[0], align, NULL)) {
             RLAYERfatal(rl, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
             return 0;
         }

--- a/ssl/record/methods/tls_common.c
+++ b/ssl/record/methods/tls_common.c
@@ -153,7 +153,7 @@ int tls_setup_write_buffer(OSSL_RECORD_LAYER *rl, size_t numwpipes,
         else
             headerlen = SSL3_RT_HEADER_LENGTH;
 
-#if defined(SSL3_ALIGN_PAYLOAD) && SSL3_ALIGN_PAYLOAD != 0
+#if SSL3_ALIGN_PAYLOAD != 0
         align = SSL3_ALIGN_PAYLOAD - 1;
 #endif
 
@@ -228,7 +228,7 @@ int tls_setup_read_buffer(OSSL_RECORD_LAYER *rl)
     else
         headerlen = SSL3_RT_HEADER_LENGTH;
 
-#if defined(SSL3_ALIGN_PAYLOAD) && SSL3_ALIGN_PAYLOAD != 0
+#if SSL3_ALIGN_PAYLOAD != 0
     align = (-SSL3_RT_HEADER_LENGTH) & (SSL3_ALIGN_PAYLOAD - 1);
 #endif
 
@@ -299,7 +299,7 @@ int tls_default_read_n(OSSL_RECORD_LAYER *rl, size_t n, size_t max, int extend,
 
     rb = &rl->rbuf;
     left = rb->left;
-#if defined(SSL3_ALIGN_PAYLOAD) && SSL3_ALIGN_PAYLOAD != 0
+#if SSL3_ALIGN_PAYLOAD != 0
     align = (size_t)rb->buf + SSL3_RT_HEADER_LENGTH;
     align = SSL3_ALIGN_PAYLOAD - 1 - ((align - 1) % SSL3_ALIGN_PAYLOAD);
 #endif
@@ -1503,7 +1503,7 @@ int tls_initialise_write_packets_default(OSSL_RECORD_LAYER *rl,
                                          size_t *wpinited)
 {
     WPACKET *thispkt;
-    size_t j, align;
+    size_t j, align = 0;
     TLS_BUFFER *wb;
 
     for (j = 0; j < numtempl; j++) {
@@ -1512,7 +1512,7 @@ int tls_initialise_write_packets_default(OSSL_RECORD_LAYER *rl,
 
         wb->type = templates[j].type;
 
-#if defined(SSL3_ALIGN_PAYLOAD) && SSL3_ALIGN_PAYLOAD != 0
+#if SSL3_ALIGN_PAYLOAD != 0
         align = (size_t)TLS_BUFFER_get_buf(wb);
         align += rl->isdtls ? DTLS1_RT_HEADER_LENGTH : SSL3_RT_HEADER_LENGTH;
         align = SSL3_ALIGN_PAYLOAD - 1
@@ -1526,7 +1526,7 @@ int tls_initialise_write_packets_default(OSSL_RECORD_LAYER *rl,
             return 0;
         }
         (*wpinited)++;
-        if (!WPACKET_allocate_bytes(thispkt, align, NULL)) {
+        if (align != 0 && !WPACKET_allocate_bytes(thispkt, align, NULL)) {
             RLAYERfatal(rl, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
             return 0;
         }

--- a/test/recordlentest.c
+++ b/test/recordlentest.c
@@ -74,6 +74,13 @@ static int fail_due_to_record_overflow(int enc)
             && ERR_GET_REASON(err) == reason)
         return 1;
 
+#if SSL3_ALIGN_PAYLOAD < 2
+    if (ERR_GET_LIB(err) == ERR_LIB_SSL
+            && ERR_GET_REASON(err) == SSL_R_PACKET_LENGTH_TOO_LONG
+            && reason == SSL_R_ENCRYPTED_LENGTH_TOO_LONG)
+        return 1;
+#endif
+
     return 0;
 }
 


### PR DESCRIPTION
"./config -DSSL3_ALIGN_PAYLOAD=0" used to work
before 1.1.1 but is now broken.
This patch fixes it again.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
