### PR TITLE
Fix SSL3_ALIGN_PAYLOAD=0

### DIFF
--- a/.github/workflows/run-checker-daily.yml
+++ b/.github/workflows/run-checker-daily.yml
@@ -130,6 +130,7 @@ jobs:
           no-zlib,
           enable-zlib-dynamic,
           no-zlib-dynamic,
+          -DSSL3_ALIGN_PAYLOAD=0,
         ]
     runs-on: ubuntu-latest
     steps:

--- a/ssl/d1_lib.c
+++ b/ssl/d1_lib.c
@@ -487,8 +487,7 @@ int DTLSv1_listen(SSL *s, BIO_ADDR *client)
     }
     buf = RECORD_LAYER_get_rbuf(&s->rlayer)->buf;
     wbuf = RECORD_LAYER_get_wbuf(&s->rlayer)[0].buf;
-#if defined(SSL3_ALIGN_PAYLOAD)
-# if SSL3_ALIGN_PAYLOAD != 0
+#if SSL3_ALIGN_PAYLOAD != 0
     /*
      * Using SSL3_RT_HEADER_LENGTH here instead of DTLS1_RT_HEADER_LENGTH for
      * consistency with ssl3_read_n. In practice it should make no difference
@@ -497,7 +496,6 @@ int DTLSv1_listen(SSL *s, BIO_ADDR *client)
      */
     align = (size_t)buf + SSL3_RT_HEADER_LENGTH;
     align = SSL3_ALIGN_PAYLOAD - 1 - ((align - 1) % SSL3_ALIGN_PAYLOAD);
-# endif
 #endif
     buf += align;
 

--- a/ssl/record/ssl3_buffer.c
+++ b/ssl/record/ssl3_buffer.c
@@ -47,7 +47,7 @@ int ssl3_setup_read_buffer(SSL *s)
     else
         headerlen = SSL3_RT_HEADER_LENGTH;
 
-#if defined(SSL3_ALIGN_PAYLOAD) && SSL3_ALIGN_PAYLOAD!=0
+#if SSL3_ALIGN_PAYLOAD != 0
     align = (-SSL3_RT_HEADER_LENGTH) & (SSL3_ALIGN_PAYLOAD - 1);
 #endif
 
@@ -91,7 +91,7 @@ int ssl3_setup_write_buffer(SSL *s, size_t numwpipes, size_t len)
         else
             headerlen = SSL3_RT_HEADER_LENGTH;
 
-#if defined(SSL3_ALIGN_PAYLOAD) && SSL3_ALIGN_PAYLOAD!=0
+#if SSL3_ALIGN_PAYLOAD != 0
         align = SSL3_ALIGN_PAYLOAD - 1;
 #endif
 

--- a/test/recordlentest.c
+++ b/test/recordlentest.c
@@ -74,6 +74,13 @@ static int fail_due_to_record_overflow(int enc)
             && ERR_GET_REASON(err) == reason)
         return 1;
 
+#if SSL3_ALIGN_PAYLOAD < 2
+    if (ERR_GET_LIB(err) == ERR_LIB_SSL
+            && ERR_GET_REASON(err) == SSL_R_PACKET_LENGTH_TOO_LONG
+            && reason == SSL_R_ENCRYPTED_LENGTH_TOO_LONG)
+        return 1;
+#endif
+
     return 0;
 }
 


### PR DESCRIPTION
"./config -DSSL3_ALIGN_PAYLOAD=0" used to work
before 1.1.1 but is now broken.
This patch fixes it again.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
