### PR TITLE
Fix SSL3_ALIGN_PAYLOAD=0 (1.1.1)

### DIFF
--- a/.github/workflows/run-checker-daily.yml
+++ b/.github/workflows/run-checker-daily.yml
@@ -114,6 +114,7 @@ jobs:
           no-zlib,
           enable-zlib-dynamic,
           no-zlib-dynamic,
+          -DSSL3_ALIGN_PAYLOAD=0,
         ]
     runs-on: ubuntu-latest
     steps:

--- a/ssl/d1_lib.c
+++ b/ssl/d1_lib.c
@@ -493,8 +493,7 @@ int DTLSv1_listen(SSL *s, BIO_ADDR *client)
     }
     buf = RECORD_LAYER_get_rbuf(&s->rlayer)->buf;
     wbuf = RECORD_LAYER_get_wbuf(&s->rlayer)[0].buf;
-#if defined(SSL3_ALIGN_PAYLOAD)
-# if SSL3_ALIGN_PAYLOAD != 0
+#if SSL3_ALIGN_PAYLOAD != 0
     /*
      * Using SSL3_RT_HEADER_LENGTH here instead of DTLS1_RT_HEADER_LENGTH for
      * consistency with ssl3_read_n. In practice it should make no difference
@@ -503,7 +502,6 @@ int DTLSv1_listen(SSL *s, BIO_ADDR *client)
      */
     align = (size_t)buf + SSL3_RT_HEADER_LENGTH;
     align = SSL3_ALIGN_PAYLOAD - 1 - ((align - 1) % SSL3_ALIGN_PAYLOAD);
-# endif
 #endif
     buf += align;
 

--- a/ssl/record/rec_layer_s3.c
+++ b/ssl/record/rec_layer_s3.c
@@ -206,7 +206,7 @@ int ssl3_read_n(SSL *s, size_t n, size_t max, int extend, int clearold,
         }
 
     left = rb->left;
-#if defined(SSL3_ALIGN_PAYLOAD) && SSL3_ALIGN_PAYLOAD!=0
+#if SSL3_ALIGN_PAYLOAD != 0
     align = (size_t)rb->buf + SSL3_RT_HEADER_LENGTH;
     align = SSL3_ALIGN_PAYLOAD - 1 - ((align - 1) % SSL3_ALIGN_PAYLOAD);
 #endif
@@ -766,7 +766,7 @@ int do_ssl3_write(SSL *s, int type, const unsigned char *buf,
 
     if (create_empty_fragment) {
         wb = &s->rlayer.wbuf[0];
-#if defined(SSL3_ALIGN_PAYLOAD) && SSL3_ALIGN_PAYLOAD!=0
+#if SSL3_ALIGN_PAYLOAD != 0
         /*
          * extra fragment would be couple of cipher blocks, which would be
          * multiple of SSL3_ALIGN_PAYLOAD, so if we want to align the real
@@ -778,7 +778,8 @@ int do_ssl3_write(SSL *s, int type, const unsigned char *buf,
         SSL3_BUFFER_set_offset(wb, align);
         if (!WPACKET_init_static_len(&pkt[0], SSL3_BUFFER_get_buf(wb),
                                      SSL3_BUFFER_get_len(wb), 0)
-                || !WPACKET_allocate_bytes(&pkt[0], align, NULL)) {
+                || (align != 0
+                    && !WPACKET_allocate_bytes(&pkt[0], align, NULL))) {
             SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_DO_SSL3_WRITE,
                      ERR_R_INTERNAL_ERROR);
             goto err;
@@ -801,14 +802,15 @@ int do_ssl3_write(SSL *s, int type, const unsigned char *buf,
             thispkt = &pkt[j];
 
             wb = &s->rlayer.wbuf[j];
-#if defined(SSL3_ALIGN_PAYLOAD) && SSL3_ALIGN_PAYLOAD != 0
+#if SSL3_ALIGN_PAYLOAD != 0
             align = (size_t)SSL3_BUFFER_get_buf(wb) + SSL3_RT_HEADER_LENGTH;
             align = SSL3_ALIGN_PAYLOAD - 1 - ((align - 1) % SSL3_ALIGN_PAYLOAD);
 #endif
             SSL3_BUFFER_set_offset(wb, align);
             if (!WPACKET_init_static_len(thispkt, SSL3_BUFFER_get_buf(wb),
                                          SSL3_BUFFER_get_len(wb), 0)
-                    || !WPACKET_allocate_bytes(thispkt, align, NULL)) {
+                    || (align != 0
+                        && !WPACKET_allocate_bytes(thispkt, align, NULL))) {
                 SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_DO_SSL3_WRITE,
                          ERR_R_INTERNAL_ERROR);
                 goto err;

--- a/ssl/record/ssl3_buffer.c
+++ b/ssl/record/ssl3_buffer.c
@@ -47,7 +47,7 @@ int ssl3_setup_read_buffer(SSL *s)
     else
         headerlen = SSL3_RT_HEADER_LENGTH;
 
-#if defined(SSL3_ALIGN_PAYLOAD) && SSL3_ALIGN_PAYLOAD!=0
+#if SSL3_ALIGN_PAYLOAD != 0
     align = (-SSL3_RT_HEADER_LENGTH) & (SSL3_ALIGN_PAYLOAD - 1);
 #endif
 
@@ -92,7 +92,7 @@ int ssl3_setup_write_buffer(SSL *s, size_t numwpipes, size_t len)
         else
             headerlen = SSL3_RT_HEADER_LENGTH;
 
-#if defined(SSL3_ALIGN_PAYLOAD) && SSL3_ALIGN_PAYLOAD!=0
+#if SSL3_ALIGN_PAYLOAD != 0
         align = SSL3_ALIGN_PAYLOAD - 1;
 #endif
 

--- a/test/recordlentest.c
+++ b/test/recordlentest.c
@@ -74,6 +74,13 @@ static int fail_due_to_record_overflow(int enc)
             && ERR_GET_REASON(err) == reason)
         return 1;
 
+#if SSL3_ALIGN_PAYLOAD < 2
+    if (ERR_GET_LIB(err) == ERR_LIB_SSL
+            && ERR_GET_REASON(err) == SSL_R_PACKET_LENGTH_TOO_LONG
+            && reason == SSL_R_ENCRYPTED_LENGTH_TOO_LONG)
+        return 1;
+#endif
+
     return 0;
 }
 


### PR DESCRIPTION
"./config -DSSL3_ALIGN_PAYLOAD=0" used to work
before 1.1.1 but is now broken.
This patch fixes it again.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated