### PR TITLE
Put EdDSA back into the FIPS provider

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -220,7 +220,8 @@ OpenSSL 3.1
    backward compatibility purposes and the "fips=yes" property query
    must be used for all algorithm fetches to ensure FIPS compliance.
 
-   The algorithms that are included but not approved are Triple DES and EdDSA.
+   The algorithms that are included but not approved are Triple DES ECB
+   and Triple DES CBC.
 
    *Paul Dale*
 

--- a/doc/man7/OSSL_PROVIDER-FIPS.pod
+++ b/doc/man7/OSSL_PROVIDER-FIPS.pod
@@ -398,9 +398,9 @@ want to operate in a FIPS approved manner.  The algorithms are:
 
 =over 4
 
-=item Triple DES
+=item Triple DES ECB
 
-=item EdDSA
+=item Triple DES CBC
 
 =back
 

--- a/doc/man7/fips_module.pod
+++ b/doc/man7/fips_module.pod
@@ -476,9 +476,9 @@ want to operate in a FIPS approved manner.  The algorithms are:
 
 =over 4
 
-=item Triple DES
+=item Triple DES ECB
 
-=item EdDSA
+=item Triple DES CBC
 
 =back
 

--- a/doc/man7/migration_guide.pod
+++ b/doc/man7/migration_guide.pod
@@ -26,7 +26,9 @@ want to operate in a FIPS approved manner.  The algorithms are:
 
 =over 4
 
-=item Triple DES
+=item Triple DES ECB
+
+=item Triple DES CBC
 
 =item EdDSA
 

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -393,9 +393,9 @@ static const OSSL_ALGORITHM fips_signature[] = {
 #endif
     { PROV_NAMES_RSA, FIPS_DEFAULT_PROPERTIES, ossl_rsa_signature_functions },
 #ifndef OPENSSL_NO_EC
-    { PROV_NAMES_ED25519, FIPS_UNAPPROVED_PROPERTIES,
+    { PROV_NAMES_ED25519, FIPS_DEFAULT_PROPERTIES,
       ossl_ed25519_signature_functions },
-    { PROV_NAMES_ED448, FIPS_UNAPPROVED_PROPERTIES, ossl_ed448_signature_functions },
+    { PROV_NAMES_ED448, FIPS_DEFAULT_PROPERTIES, ossl_ed448_signature_functions },
     { PROV_NAMES_ECDSA, FIPS_DEFAULT_PROPERTIES, ossl_ecdsa_signature_functions },
 #endif
     { PROV_NAMES_HMAC, FIPS_DEFAULT_PROPERTIES,
@@ -439,9 +439,9 @@ static const OSSL_ALGORITHM fips_keymgmt[] = {
       PROV_DESCS_X25519 },
     { PROV_NAMES_X448, FIPS_DEFAULT_PROPERTIES, ossl_x448_keymgmt_functions,
       PROV_DESCS_X448 },
-    { PROV_NAMES_ED25519, FIPS_UNAPPROVED_PROPERTIES, ossl_ed25519_keymgmt_functions,
+    { PROV_NAMES_ED25519, FIPS_DEFAULT_PROPERTIES, ossl_ed25519_keymgmt_functions,
       PROV_DESCS_ED25519 },
-    { PROV_NAMES_ED448, FIPS_UNAPPROVED_PROPERTIES, ossl_ed448_keymgmt_functions,
+    { PROV_NAMES_ED448, FIPS_DEFAULT_PROPERTIES, ossl_ed448_keymgmt_functions,
       PROV_DESCS_ED448 },
 #endif
     { PROV_NAMES_TLS1_PRF, FIPS_DEFAULT_PROPERTIES, ossl_kdf_keymgmt_functions,


### PR DESCRIPTION
With the final publication of [FIPS 186-5](https://csrc.nist.gov/publications/detail/fips/186/5/final), EdDSA can be validated and will be included in our upcoming FIPS 140-3 validation.

- [x] documentation is added or updated
- [ ] tests are added or updated
