### PR TITLE
Fix PRE_PARAMS_TO_CTRL translation

### DIFF
--- a/crypto/evp/ctrl_params_translate.c
+++ b/crypto/evp/ctrl_params_translate.c
@@ -631,7 +631,7 @@ static int default_fixup_args(enum state state,
                     return 1;
                 case OSSL_PARAM_UTF8_STRING:
                     return OSSL_PARAM_get_utf8_string(ctx->params,
-                                                      &ctx->p2, ctx->sz);
+                                                      (char **)&ctx->p2, ctx->sz);
                 case OSSL_PARAM_OCTET_STRING:
                     return OSSL_PARAM_get_octet_string(ctx->params,
                                                        ctx->p2, ctx->sz,

--- a/crypto/evp/ctrl_params_translate.c
+++ b/crypto/evp/ctrl_params_translate.c
@@ -631,7 +631,7 @@ static int default_fixup_args(enum state state,
                     return 1;
                 case OSSL_PARAM_UTF8_STRING:
                     return OSSL_PARAM_get_utf8_string(ctx->params,
-                                                      ctx->p2, ctx->sz);
+                                                      &ctx->p2, ctx->sz);
                 case OSSL_PARAM_OCTET_STRING:
                     return OSSL_PARAM_get_octet_string(ctx->params,
                                                        ctx->p2, ctx->sz,
@@ -1155,6 +1155,8 @@ static int fix_ec_paramgen_curve_nid(enum state state,
         ctx->p1 = OBJ_sn2nid(ctx->p2);
         ctx->p2 = NULL;
     }
+
+    ctx->ctrl_cmd = EVP_PKEY_CTRL_EC_PARAMGEN_CURVE_NID;
 
     return ret;
 }


### PR DESCRIPTION
This PR fixes #20161.

It does that by addressing the following issues:
- `ctx->p2` is `NULL` and is passed by value instead of by address to `OSSL_PARAM_get_utf8_string`. As a result, `get_string_internal` returns `0`, leading to failure. By passing `ctx->p2` by address, `get_string_internal` will allocate the needed string and make `ctx->p2` point to it. Also, worth noting that the next call to `OBJ_sn2nid` in `fix_ec_paramgen_curve_nid` expects a `const char *` as argument, which means that `ctx->p2` is expected to be a `char *`.
- `ctx->ctrl_cmd` is `0` in `evp_pkey_ctx_setget_params_to_ctrl`, As a result, the next call to `EVP_PKEY_CTX_ctrl` will fail: it calls `pkey_ec_ctrl`, and since `ctx->ctrl_cmd` is `0`, it fails with `-2` and raises `EVP_R_COMMAND_NOT_SUPPORTED`. By setting it to `EVP_PKEY_CTRL_EC_PARAMGEN_CURVE_NID` in `fix_ec_paramgen_curve_nid`, the call to `EVP_PKEY_CTX_ctrl` will succeed as expected.