### PR TITLE
Avoid use of _umul128 on Windows ARM64 (VC-WIN64-ARM)

### DIFF
--- a/crypto/bn/rsa_sup_mul.c
+++ b/crypto/bn/rsa_sup_mul.c
@@ -109,7 +109,7 @@ static ossl_inline void _mul_limb(limb_t *hi, limb_t *lo, limb_t a, limb_t b)
     *hi = t >> LIMB_BIT_SIZE;
     *lo = (limb_t)t;
 }
-#elif (BN_BYTES == 8) && (defined _MSC_VER)
+#elif (BN_BYTES == 8) && (defined _MSC_VER) && (defined(_M_AMD64) || defined(_M_X64))
 /* https://learn.microsoft.com/en-us/cpp/intrinsics/umul128?view=msvc-170 */
 #pragma intrinsic(_umul128)
 static ossl_inline void _mul_limb(limb_t *hi, limb_t *lo, limb_t a, limb_t b)


### PR DESCRIPTION
_umul128 is unavailable for ARM64 when building using Visual Studio, causing a linker failure when attempting to build for VC-WIN64-ARM. This limits the use of _umul128 to AMD64 builds.

This applies to both OpenSSL 3.0 and OpenSSL 1.1.1.

CLA: trivial