### PR TITLE
Add tests for BN API's (bn_print.c and bn_const.c)

### DIFF
--- a/test/bntest.c
+++ b/test/bntest.c
@@ -3233,9 +3233,9 @@ static int test_dh_named_primes(void)
     int ret;
     BIGNUM *bn1 = NULL, *bn2 = NULL, *bn3 = NULL;
 
-    ret = TEST_ptr(bn1 = BN_get_rfc2409_prime_768(bn1))
-          && TEST_ptr(bn2 = BN_get_rfc3526_prime_1536())
-          && TEST_ptr(bn3 = BN_get_rfc3526_prime_6144());
+    ret = TEST_ptr(bn1 = BN_get_rfc2409_prime_768(NULL))
+          && TEST_ptr(bn2 = BN_get_rfc3526_prime_1536(NULL))
+          && TEST_ptr(bn3 = BN_get_rfc3526_prime_6144(NULL));
     BN_free(bn1);
     BN_free(bn2);
     BN_free(bn3);


### PR DESCRIPTION
Add Tests for bn_print.c functions BN_print_fp(), BN_options(). Add Tests for bn_const.c BN_get_rfc2409_prime_768(), BN_get_rfc3526_prime_1536() & BN_get_rfc3526_prime_6144() (Note that the other getters are accessed via TLS tests).

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
