### PR TITLE
Use of sparse_array.c only in the shared libssl

### DIFF
--- a/crypto/build.info
+++ b/crypto/build.info
@@ -102,9 +102,7 @@ $UTIL_COMMON=\
         param_build_set.c der_writer.c threads_lib.c params_dup.c \
         quic_vlint.c time.c
 
-IF[{- !$disabled{shared} -}]
-  SOURCE[../libssl]=sparse_array.c
-ENDIF
+SHARED_SOURCE[../libssl]=sparse_array.c
 
 SOURCE[../libcrypto]=$UTIL_COMMON \
         mem.c mem_sec.c \


### PR DESCRIPTION
Conditioning it on $disabled{shared} isn't right, it will still end up
in the static variant of the library.  It's better to use SHARED_SOURCE
for these sorts of things.

Fixes #20238
