### PR TITLE
Update X509 fuzzer to verify a chain

### DIFF
--- a/fuzz/build.info
+++ b/fuzz/build.info
@@ -9,7 +9,7 @@
 -}
 
 IF[{- !$disabled{"fuzz-afl"} || !$disabled{"fuzz-libfuzzer"} -}]
-  PROGRAMS{noinst}=asn1 asn1parse bignum bndiv client conf crl server smime x509
+  PROGRAMS{noinst}=asn1 asn1parse bignum bndiv client conf crl server smime
   PROGRAMS{noinst}=punycode pem decoder
   PROGRAMS{noinst}=v3name
 
@@ -23,6 +23,10 @@ IF[{- !$disabled{"fuzz-afl"} || !$disabled{"fuzz-libfuzzer"} -}]
 
   IF[{- !$disabled{"ct"} -}]
     PROGRAMS{noinst}=ct
+  ENDIF
+
+  IF[{- !$disabled{"ocsp"} -}]
+    PROGRAMS{noinst}=x509
   ENDIF
 
   SOURCE[asn1]=asn1.c driver.c fuzz_rand.c
@@ -95,7 +99,7 @@ IF[{- !$disabled{"fuzz-afl"} || !$disabled{"fuzz-libfuzzer"} -}]
 ENDIF
 
 IF[{- !$disabled{tests} -}]
-  PROGRAMS{noinst}=asn1-test asn1parse-test bignum-test bndiv-test client-test conf-test crl-test server-test smime-test x509-test
+  PROGRAMS{noinst}=asn1-test asn1parse-test bignum-test bndiv-test client-test conf-test crl-test server-test smime-test
   PROGRAMS{noinst}=punycode-test pem-test decoder-test
   PROGRAMS{noinst}=v3name-test
 
@@ -109,6 +113,10 @@ IF[{- !$disabled{tests} -}]
 
   IF[{- !$disabled{"ct"} -}]
     PROGRAMS{noinst}=ct-test
+  ENDIF
+
+  IF[{- !$disabled{"ocsp"} -}]
+    PROGRAMS{noinst}=x509-test
   ENDIF
 
   SOURCE[asn1-test]=asn1.c test-corpus.c fuzz_rand.c

--- a/fuzz/x509.c
+++ b/fuzz/x509.c
@@ -9,6 +9,7 @@
  */
 
 #include <openssl/x509.h>
+#include <openssl/ocsp.h>
 #include <openssl/bio.h>
 #include <openssl/err.h>
 #include <openssl/rand.h>
@@ -17,31 +18,131 @@
 int FuzzerInitialize(int *argc, char ***argv)
 {
     FuzzerSetRand();
-    OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CRYPTO_STRINGS, NULL);
+    OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CRYPTO_STRINGS
+       | OPENSSL_INIT_ADD_ALL_CIPHERS | OPENSSL_INIT_ADD_ALL_DIGESTS, NULL);
     ERR_clear_error();
     CRYPTO_free_ex_index(0, -1);
+    return 1;
+}
+
+static int cb(int ok, X509_STORE_CTX *ctx)
+{
     return 1;
 }
 
 int FuzzerTestOneInput(const uint8_t *buf, size_t len)
 {
     const unsigned char *p = buf;
+    size_t orig_len = len;
     unsigned char *der = NULL;
+    BIO *bio = NULL;
+    X509 *x509_1 = NULL, *x509_2 = NULL;
+    X509_STORE *store = NULL;
+    X509_VERIFY_PARAM *param = NULL;
+    X509_STORE_CTX *ctx = NULL;
+    X509_CRL *crl = NULL;
+    STACK_OF(X509_CRL) *crls = NULL;
+    STACK_OF(X509) *certs = NULL;
+    OCSP_RESPONSE *resp = NULL;
+    OCSP_BASICRESP *bs = NULL;
+    OCSP_CERTID *id = NULL;
 
-    X509 *x509 = d2i_X509(NULL, &p, len);
-    if (x509 != NULL) {
-        BIO *bio = BIO_new(BIO_s_null());
-        /* This will load and print the public key as well as extensions */
-        X509_print(bio, x509);
-        BIO_free(bio);
+    x509_1 = d2i_X509(NULL, &p, len);
+    if (x509_1 == NULL)
+        goto err;
 
-        X509_issuer_and_serial_hash(x509);
+    bio = BIO_new(BIO_s_null());
+    if (bio == NULL)
+        goto err;
 
-        i2d_X509(x509, &der);
-        OPENSSL_free(der);
+    /* This will load and print the public key as well as extensions */
+    X509_print(bio, x509_1);
+    BIO_free(bio);
 
-        X509_free(x509);
+    X509_issuer_and_serial_hash(x509_1);
+
+    i2d_X509(x509_1, &der);
+    OPENSSL_free(der);
+
+    len = orig_len - (p - buf);
+    x509_2 = d2i_X509(NULL, &p, len);
+    if (x509_2 == NULL)
+        goto err;
+
+    len = orig_len - (p - buf);
+    crl = d2i_X509_CRL(NULL, &p, len);
+    if (crl == NULL)
+        goto err;
+
+    len = orig_len - (p - buf);
+    resp = d2i_OCSP_RESPONSE(NULL, &p, len);
+
+    store = X509_STORE_new();
+    X509_STORE_add_cert(store, x509_2);
+
+    param = X509_VERIFY_PARAM_new();
+    X509_VERIFY_PARAM_set_flags(param, X509_V_FLAG_NO_CHECK_TIME);
+    X509_VERIFY_PARAM_set_flags(param, X509_V_FLAG_X509_STRICT);
+    X509_VERIFY_PARAM_set_flags(param, X509_V_FLAG_PARTIAL_CHAIN);
+    X509_VERIFY_PARAM_set_flags(param, X509_V_FLAG_CRL_CHECK);
+
+    X509_STORE_set1_param(store, param);
+
+    X509_STORE_set_verify_cb(store, cb);
+
+    ctx = X509_STORE_CTX_new();
+    if (ctx == NULL)
+        goto err;
+
+    X509_STORE_CTX_init(ctx, store, x509_1, NULL);
+
+    if (crl != NULL) {
+        crls = sk_X509_CRL_new_null();
+        if (crls == NULL)
+            goto err;
+
+        sk_X509_CRL_push(crls, crl);
+        X509_STORE_CTX_set0_crls(ctx, crls);
     }
+
+    X509_verify_cert(ctx);
+
+    if (resp != NULL)
+        bs = OCSP_response_get1_basic(resp);
+
+    if (bs != NULL) {
+        int status, reason;
+        ASN1_GENERALIZEDTIME *revtime, *thisupd, *nextupd;
+
+        certs = sk_X509_new_null();
+        if (certs == NULL)
+            goto err;
+
+        sk_X509_push(certs, x509_1);
+        sk_X509_push(certs, x509_2);
+
+        OCSP_basic_verify(bs, certs, store, OCSP_PARTIAL_CHAIN);
+
+        id = OCSP_cert_to_id(NULL, x509_1, x509_2);
+        if (id == NULL)
+            goto err;
+        OCSP_resp_find_status(bs, id, &status, &reason, &revtime, &thisupd,
+                              &nextupd);
+    }
+
+err:
+    X509_STORE_CTX_free(ctx);
+    X509_VERIFY_PARAM_free(param);
+    X509_STORE_free(store);
+    X509_free(x509_1);
+    X509_free(x509_2);
+    X509_CRL_free(crl);
+    OCSP_CERTID_free(id);
+    OCSP_BASICRESP_free(bs);
+    OCSP_RESPONSE_free(resp);
+    sk_X509_CRL_free(crls);
+    sk_X509_free(certs);
+
     ERR_clear_error();
     return 0;
 }

--- a/test/recipes/99-test_fuzz_x509.t
+++ b/test/recipes/99-test_fuzz_x509.t
@@ -15,6 +15,9 @@ use OpenSSL::Test::Utils;
 my $fuzzer = "x509";
 setup("test_fuzz_${fuzzer}");
 
+plan skip_all => "This test requires ocsp support"
+    if disabled("ocsp");
+
 plan tests => 2; # one more due to below require_ok(...)
 
 require_ok(srctop_file('test','recipes','fuzz.pl'));


### PR DESCRIPTION
It add supports for verifying that it's been signed by a CA, and checks the CRL and OCSP status

Can find CVE-2022-4203 and CVE-2023-0286
