### PR TITLE
Fix incomplete error check on RSA_public_decrypt()

### DIFF
--- a/providers/implementations/signature/rsa_sig.c
+++ b/providers/implementations/signature/rsa_sig.c
@@ -838,7 +838,7 @@ static int rsa_verify(void *vprsactx, const unsigned char *sig, size_t siglen,
             return 0;
         rslen = RSA_public_decrypt(siglen, sig, prsactx->tbuf, prsactx->rsa,
                                    prsactx->pad_mode);
-        if (rslen == 0) {
+        if (rslen <= 0) {
             ERR_raise(ERR_LIB_PROV, ERR_R_RSA_LIB);
             return 0;
         }


### PR DESCRIPTION
According to the documentation and my analysis tool RSA_public_decrypt() can return -1 on error, but this is not checked. Fix it by changing the error condition.

CLA: trivial

Please note that I found this using a static analysis tool I am developing at the moment. It could therefore be a false positive bug. I manually reviewed the case to be extra sure that it is a real bug.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
