### PR TITLE
Fix incomplete error check on ASN1_item_i2d()

### DIFF
--- a/crypto/asn1/asn_pack.c
+++ b/crypto/asn1/asn_pack.c
@@ -28,7 +28,7 @@ ASN1_STRING *ASN1_item_pack(void *obj, const ASN1_ITEM *it, ASN1_STRING **oct)
 
     ASN1_STRING_set0(octmp, NULL, 0);
 
-    if ((octmp->length = ASN1_item_i2d(obj, &octmp->data, it)) == 0) {
+    if ((octmp->length = ASN1_item_i2d(obj, &octmp->data, it)) <= 0) {
         ERR_raise(ERR_LIB_ASN1, ASN1_R_ENCODE_ERROR);
         goto err;
     }


### PR DESCRIPTION
According to the documentation and my analysis tool ASN1_item_i2d() can return a negative value on error, but this is not checked. Fix it by changing the error check condition.

CLA: trivial

Please note that I found this using a static analysis tool I am developing at the moment. It could therefore be a false positive bug. I manually reviewed the case to be extra sure that it is a real bug.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
