### PR TITLE
`check-format.pl`: fixes on false positives and statistics

### DIFF
--- a/util/check-format.pl
+++ b/util/check-format.pl
@@ -225,14 +225,14 @@ sub report_flexibly {
     my $line = shift;
     my $msg = shift;
     my $contents = shift;
-    my $report_SPC = $msg =~ /space/;
+    my $report_SPC = $msg =~ /space|blank/;
     return if $report_SPC && $sloppy_SPC;
 
     print "$ARGV:$line:$msg:$contents" unless $self_test;
     $num_reports_line++;
     $num_reports++;
-    $num_indent_reports++ if $msg =~ m/indent/;
-    $num_nesting_issues++ if $msg =~ m/directive nesting/;
+    $num_indent_reports++ if $msg =~ m/:indent /;
+    $num_nesting_issues++ if $msg =~ m/ nesting indent /;
     $num_syntax_issues++  if $msg =~ m/unclosed|unexpected/;
     $num_SPC_reports++    if $report_SPC;
     $num_length_reports++ if $msg =~ m/length/;

--- a/util/check-format.pl
+++ b/util/check-format.pl
@@ -150,8 +150,8 @@ my $count_before;          # number of leading whitespace characters (except lin
 my $has_label;             # current line contains label
 my $local_offset;          # current extra indent due to label, switch case/default, or leading closing brace(s)
 my $line_body_start;       # number of line where last function body started, or 0
-my $line_function_start;   # number of line where last function definition started, used if $line_body_start != 0
-my $last_function_header;  # header containing name of last function defined, used if $line_function_start != 0
+my $line_function_start;   # number of line where last function definition started, used for $line_body_start
+my $last_function_header;  # header containing name of last function defined, used if $line_body_start != 0
 my $line_opening_brace;    # number of previous line with opening brace after do/while/for, optionally for if/else
 
 my $keyword_opening_brace; # name of previous keyword, used if $line_opening_brace != 0
@@ -1033,8 +1033,8 @@ while (<>) { # loop over all lines of all input files
             if ($outermost_level) {
                 if (!$assignment_start && !$bak_in_expr) {
                     # at end of function definition header (or stmt or var definition)
-                    report("'{' not at beginning") if $head ne "";
-                    $line_body_start = $contents =~ m/LONG BODY/ ? 0 : $line;
+                    report("'{' not at line start") if length($head) != $preproc_offset && $head =~ m/\)\s*/; # at end of function definition header
+                    $line_body_start = $contents =~ m/LONG BODY/ ? 0 : $line if $line_function_start != 0;
                 }
             } else {
                 $line_opening_brace = $line if $keyword_opening_brace =~ m/do|while|for/;


### PR DESCRIPTION
This is a backport of (the relevant portions of) #19796 to 3.0 and 3.1, as suggested by https://github.com/openssl/openssl/pull/19796#issuecomment-1422780074.
