### PR TITLE
Add OSSL_FUNC_keymgmt_im/export_types function that gets the provider context

### DIFF
--- a/crypto/evp/evp_local.h
+++ b/crypto/evp/evp_local.h
@@ -128,8 +128,10 @@ struct evp_keymgmt_st {
     /* Import and export routines */
     OSSL_FUNC_keymgmt_import_fn *import;
     OSSL_FUNC_keymgmt_import_types_fn *import_types;
+    OSSL_FUNC_keymgmt_import_types_ex_fn *import_types_ex;
     OSSL_FUNC_keymgmt_export_fn *export;
     OSSL_FUNC_keymgmt_export_types_fn *export_types;
+    OSSL_FUNC_keymgmt_export_types_ex_fn *export_types_ex;
     OSSL_FUNC_keymgmt_dup_fn *dup;
 } /* EVP_KEYMGMT */ ;
 

--- a/crypto/evp/keymgmt_meth.c
+++ b/crypto/evp/keymgmt_meth.c
@@ -43,6 +43,7 @@ static void *keymgmt_from_algorithm(int name_id,
     int setparamfncnt = 0, getparamfncnt = 0;
     int setgenparamfncnt = 0;
     int importfncnt = 0, exportfncnt = 0;
+    int importtypesfncnt = 0, exporttypesfncnt = 0;
 
     if ((keymgmt = keymgmt_new()) == NULL)
         return NULL;
@@ -154,8 +155,18 @@ static void *keymgmt_from_algorithm(int name_id,
             break;
         case OSSL_FUNC_KEYMGMT_IMPORT_TYPES:
             if (keymgmt->import_types == NULL) {
-                importfncnt++;
+                if (importtypesfncnt == 0)
+                    importfncnt++;
+                importtypesfncnt++;
                 keymgmt->import_types = OSSL_FUNC_keymgmt_import_types(fns);
+            }
+            break;
+        case OSSL_FUNC_KEYMGMT_IMPORT_TYPES_EX:
+            if (keymgmt->import_types_ex == NULL) {
+                if (importtypesfncnt == 0)
+                    importfncnt++;
+                importtypesfncnt++;
+                keymgmt->import_types_ex = OSSL_FUNC_keymgmt_import_types_ex(fns);
             }
             break;
         case OSSL_FUNC_KEYMGMT_EXPORT:
@@ -166,8 +177,18 @@ static void *keymgmt_from_algorithm(int name_id,
             break;
         case OSSL_FUNC_KEYMGMT_EXPORT_TYPES:
             if (keymgmt->export_types == NULL) {
-                exportfncnt++;
+                if (exporttypesfncnt == 0)
+                    exportfncnt++;
+                exporttypesfncnt++;
                 keymgmt->export_types = OSSL_FUNC_keymgmt_export_types(fns);
+            }
+            break;
+        case OSSL_FUNC_KEYMGMT_EXPORT_TYPES_EX:
+            if (keymgmt->export_types_ex == NULL) {
+                if (exporttypesfncnt == 0)
+                    exportfncnt++;
+                exporttypesfncnt++;
+                keymgmt->export_types_ex = OSSL_FUNC_keymgmt_export_types_ex(fns);
             }
             break;
         }
@@ -456,6 +477,10 @@ int evp_keymgmt_import(const EVP_KEYMGMT *keymgmt, void *keydata,
 const OSSL_PARAM *evp_keymgmt_import_types(const EVP_KEYMGMT *keymgmt,
                                            int selection)
 {
+    void *provctx = ossl_provider_ctx(EVP_KEYMGMT_get0_provider(keymgmt));
+
+    if (keymgmt->import_types_ex != NULL)
+        return keymgmt->import_types_ex(provctx, selection);
     if (keymgmt->import_types == NULL)
         return NULL;
     return keymgmt->import_types(selection);
@@ -472,6 +497,10 @@ int evp_keymgmt_export(const EVP_KEYMGMT *keymgmt, void *keydata,
 const OSSL_PARAM *evp_keymgmt_export_types(const EVP_KEYMGMT *keymgmt,
                                            int selection)
 {
+    void *provctx = ossl_provider_ctx(EVP_KEYMGMT_get0_provider(keymgmt));
+
+    if (keymgmt->export_types_ex != NULL)
+        return keymgmt->export_types_ex(provctx, selection);
     if (keymgmt->export_types == NULL)
         return NULL;
     return keymgmt->export_types(selection);

--- a/doc/man7/provider-keymgmt.pod
+++ b/doc/man7/provider-keymgmt.pod
@@ -48,9 +48,11 @@ provider-keymgmt - The KEYMGMT library E<lt>-E<gt> provider functions
  /* Key object import and export functions */
  int OSSL_FUNC_keymgmt_import(void *keydata, int selection, const OSSL_PARAM params[]);
  const OSSL_PARAM *OSSL_FUNC_keymgmt_import_types(int selection);
+ const OSSL_PARAM *OSSL_FUNC_keymgmt_import_types_ex(void *provctx, int selection);
  int OSSL_FUNC_keymgmt_export(void *keydata, int selection,
                               OSSL_CALLBACK *param_cb, void *cbarg);
  const OSSL_PARAM *OSSL_FUNC_keymgmt_export_types(int selection);
+ const OSSL_PARAM *OSSL_FUNC_keymgmt_export_types_ex(void *provctx, int selection);
 
  /* Key object duplication, a constructor */
  void *OSSL_FUNC_keymgmt_dup(const void *keydata_from, int selection);
@@ -115,8 +117,10 @@ macros in L<openssl-core_dispatch.h(7)>, as follows:
 
  OSSL_FUNC_keymgmt_import               OSSL_FUNC_KEYMGMT_IMPORT
  OSSL_FUNC_keymgmt_import_types         OSSL_FUNC_KEYMGMT_IMPORT_TYPES
+ OSSL_FUNC_keymgmt_import_types_ex      OSSL_FUNC_KEYMGMT_IMPORT_TYPES_EX
  OSSL_FUNC_keymgmt_export               OSSL_FUNC_KEYMGMT_EXPORT
  OSSL_FUNC_keymgmt_export_types         OSSL_FUNC_KEYMGMT_EXPORT_TYPES
+ OSSL_FUNC_keymgmt_export_types_ex      OSSL_FUNC_KEYMGMT_EXPORT_TYPES_EX
 
  OSSL_FUNC_keymgmt_dup                  OSSL_FUNC_KEYMGMT_DUP
 
@@ -329,13 +333,25 @@ OSSL_FUNC_keymgmt_export() should extract values indicated by I<selection>
 from I<keydata>, create an L<OSSL_PARAM(3)> array with them and call
 I<param_cb> with that array as well as the given I<cbarg>.
 
-OSSL_FUNC_keymgmt_import_types() should return a constant array of descriptor
+OSSL_FUNC_keymgmt_import_types() and OSSL_FUNC_keymgmt_import_types_ex()
+should return a constant array of descriptor
 L<OSSL_PARAM(3)> for data indicated by I<selection>, for parameters that
 OSSL_FUNC_keymgmt_import() can handle.
+Either OSSL_FUNC_keymgmt_import_types() or OSSL_FUNC_keymgmt_import_types_ex(),
+must be implemented, if OSSL_FUNC_keymgmt_import_types_ex() is implemented, then
+it is preferred over OSSL_FUNC_keymgmt_import_types().
+Providers that are supposed to be backward compatible with OpenSSL 3.0 or 3.1
+must continue to implement OSSL_FUNC_keymgmt_import_types().
 
-OSSL_FUNC_keymgmt_export_types() should return a constant array of descriptor
+OSSL_FUNC_keymgmt_export_types() and OSSL_FUNC_keymgmt_export_types_ex()
+should return a constant array of descriptor
 L<OSSL_PARAM(3)> for data indicated by I<selection>, that the
 OSSL_FUNC_keymgmt_export() callback can expect to receive.
+Either OSSL_FUNC_keymgmt_export_types() or OSSL_FUNC_keymgmt_export_types_ex(),
+must be implemented, if OSSL_FUNC_keymgmt_export_types_ex() is implemented, then
+it is preferred over OSSL_FUNC_keymgmt_export_types().
+Providers that are supposed to be backward compatible with OpenSSL 3.0 or 3.1
+must continue to implement OSSL_FUNC_keymgmt_export_types().
 
 OSSL_FUNC_keymgmt_dup() should duplicate data subsets indicated by
 I<selection> or the whole key data I<keydata_from> and create a new
@@ -395,7 +411,8 @@ the requested operation, or NULL if the same name used to fetch the keymgmt
 applies.
 
 OSSL_FUNC_keymgmt_gettable_params() and OSSL_FUNC_keymgmt_settable_params()
-OSSL_FUNC_keymgmt_import_types(), OSSL_FUNC_keymgmt_export_types()
+OSSL_FUNC_keymgmt_import_types(), OSSL_FUNC_keymgmt_import_types_ex(),
+OSSL_FUNC_keymgmt_export_types(), OSSL_FUNC_keymgmt_export_types_ex()
 should
 always return a constant L<OSSL_PARAM(3)> array.
 
@@ -409,6 +426,9 @@ L<EVP_PKEY-DSA(7)>, L<EVP_PKEY-DH(7)>
 =head1 HISTORY
 
 The KEYMGMT interface was introduced in OpenSSL 3.0.
+
+Functions OSSL_FUNC_keymgmt_import_types_ex(), and OSSL_FUNC_keymgmt_export_types_ex()
+were added with OpenSSL 3.2.
 
 =head1 COPYRIGHT
 

--- a/include/openssl/core_dispatch.h
+++ b/include/openssl/core_dispatch.h
@@ -644,6 +644,14 @@ OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, keymgmt_export_types,
 OSSL_CORE_MAKE_FUNC(void *, keymgmt_dup,
                     (const void *keydata_from, int selection))
 
+/* Extended import and export functions */
+# define OSSL_FUNC_KEYMGMT_IMPORT_TYPES_EX            45
+# define OSSL_FUNC_KEYMGMT_EXPORT_TYPES_EX            46
+OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, keymgmt_import_types_ex,
+                    (void *provctx, int selection))
+OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *, keymgmt_export_types_ex,
+                    (void *provctx, int selection))
+
 /* Key Exchange */
 
 # define OSSL_FUNC_KEYEXCH_NEWCTX                      1

--- a/test/tls-provider.c
+++ b/test/tls-provider.c
@@ -18,8 +18,10 @@
 
 static OSSL_FUNC_keymgmt_import_fn xor_import;
 static OSSL_FUNC_keymgmt_import_types_fn xor_import_types;
+static OSSL_FUNC_keymgmt_import_types_ex_fn xor_import_types_ex;
 static OSSL_FUNC_keymgmt_export_fn xor_export;
 static OSSL_FUNC_keymgmt_export_types_fn xor_export_types;
+static OSSL_FUNC_keymgmt_export_types_ex_fn xor_export_types_ex;
 
 int tls_provider_init(const OSSL_CORE_HANDLE *handle,
                       const OSSL_DISPATCH *in,
@@ -724,9 +726,25 @@ static const OSSL_PARAM *xor_import_types(int select)
     return (select & OSSL_KEYMGMT_SELECT_KEYPAIR) != 0 ? xor_key_types : NULL;
 }
 
+static const OSSL_PARAM *xor_import_types_ex(void *provctx, int select)
+{
+    if (provctx == NULL)
+        return NULL;
+
+    return xor_import_types(select);
+}
+
 static const OSSL_PARAM *xor_export_types(int select)
 {
     return (select & OSSL_KEYMGMT_SELECT_KEYPAIR) != 0 ? xor_key_types : NULL;
+}
+
+static const OSSL_PARAM *xor_export_types_ex(void *provctx, int select)
+{
+    if (provctx == NULL)
+        return NULL;
+
+    return xor_export_types(select);
 }
 
 static void xor_gen_cleanup(void *genctx)
@@ -751,8 +769,10 @@ static const OSSL_DISPATCH xor_keymgmt_functions[] = {
     { OSSL_FUNC_KEYMGMT_FREE, (void (*)(void))xor_freedata },
     { OSSL_FUNC_KEYMGMT_IMPORT, (void (*)(void))xor_import },
     { OSSL_FUNC_KEYMGMT_IMPORT_TYPES, (void (*)(void))xor_import_types },
+    { OSSL_FUNC_KEYMGMT_IMPORT_TYPES_EX, (void (*)(void))xor_import_types_ex },
     { OSSL_FUNC_KEYMGMT_EXPORT, (void (*)(void))xor_export },
     { OSSL_FUNC_KEYMGMT_EXPORT_TYPES, (void (*)(void))xor_export_types },
+    { OSSL_FUNC_KEYMGMT_EXPORT_TYPES_EX, (void (*)(void))xor_export_types_ex },
     { 0, NULL }
 };
 


### PR DESCRIPTION
The provider functions `OSSL_FUNC_keymgmt_import_types()` and `OSSL_FUNC_keymgmt_export_types()` do not get the provider context passed. This makes it difficult for providers to implement these functions unless its a static implementation returning a truly constant `OSSL_PARAM` array. Some providers may have a need to return an `OSSL_PARAM` array that is dependent on the provider configuration, or anything else that is contained in its provider context.

Add version 2 variants of these functions that get the provider context passed. The functions should still return a static and constant `OSSL_PARAM` array, but may use the provider context to select the array to return dependent on its context. The returned array must be constant at least until the provider is unloaded.

Providers can implement only the version 1 functions, or only the version 2 functions, or both. Implementing at least one of those functions is required if also the respective `OSSL_FUNC_keymgmt_import()` or `OSSL_FUNC_keymgmt_export()` function is implemented. If a version 2 function is available, it is called by `evp_keymgmt_import_types()` or `evp_keymgmt_export_types()`, otherwise the version 1 function is called.

This makes the code backward compatible. Existing providers will only implement the version 1 functions, so these functions will continued to be called. Newer providers can choose to implement the version 2 functions, and thus can benefit from the provider context being passed to the implementation.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated

I did intentionally not update the default or fips providers, to make clear that no update is required for existing providers and to test that they still work unchanged. I did add the version 2 functions to the tls-provider for the sslapitest.