### PR TITLE
`OSSL_CMP_SRV_process_request()`: fix recipNonce in error cases, etc. -backport #20190 to 3.0 and 3.1

### DIFF
--- a/apps/cmp.c
+++ b/apps/cmp.c
@@ -1121,7 +1121,7 @@ static OSSL_CMP_SRV_CTX *setup_srv_ctx(ENGINE *engine)
         goto err;
 
     if (opt_send_error)
-        (void)ossl_cmp_mock_srv_set_send_error(srv_ctx, 1);
+        (void)ossl_cmp_mock_srv_set_sendError(srv_ctx, 1);
 
     if (opt_send_unprotected)
         (void)OSSL_CMP_CTX_set_option(ctx, OSSL_CMP_OPT_UNPROTECTED_SEND, 1);

--- a/apps/include/cmp_mock_srv.h
+++ b/apps/include/cmp_mock_srv.h
@@ -27,7 +27,7 @@ int ossl_cmp_mock_srv_set1_caPubsOut(OSSL_CMP_SRV_CTX *srv_ctx,
                                      STACK_OF(X509) *caPubs);
 int ossl_cmp_mock_srv_set_statusInfo(OSSL_CMP_SRV_CTX *srv_ctx, int status,
                                      int fail_info, const char *text);
-int ossl_cmp_mock_srv_set_send_error(OSSL_CMP_SRV_CTX *srv_ctx, int val);
+int ossl_cmp_mock_srv_set_sendError(OSSL_CMP_SRV_CTX *srv_ctx, int bodytype);
 int ossl_cmp_mock_srv_set_pollCount(OSSL_CMP_SRV_CTX *srv_ctx, int count);
 int ossl_cmp_mock_srv_set_checkAfterTime(OSSL_CMP_SRV_CTX *srv_ctx, int sec);
 

--- a/crypto/cmp/cmp_client.c
+++ b/crypto/cmp/cmp_client.c
@@ -630,6 +630,7 @@ static int cert_response(OSSL_CMP_CTX *ctx, int sleep, int rid,
         ERR_raise_data(ERR_LIB_CMP, CMP_R_CERTIFICATE_NOT_ACCEPTED,
                        "rejecting newly enrolled cert with subject: %s; %s",
                        subj, txt);
+        ctx->status = OSSL_CMP_PKISTATUS_rejection;
         ret = 0;
     }
     OPENSSL_free(subj);

--- a/crypto/cmp/cmp_ctx.c
+++ b/crypto/cmp/cmp_ctx.c
@@ -669,13 +669,13 @@ int OSSL_CMP_CTX_set1_##FIELD(OSSL_CMP_CTX *ctx, TYPE *val) \
  */
 DEFINE_OSSL_CMP_CTX_set1_up_ref(srvCert, X509)
 
-/* Set the X509 name of the recipient. Set in the PKIHeader */
+/* Set the X509 name of the recipient to be placed in the PKIHeader */
 DEFINE_OSSL_CMP_CTX_set1(recipient, X509_NAME)
 
 /* Store the X509 name of the expected sender in the PKIHeader of responses */
 DEFINE_OSSL_CMP_CTX_set1(expected_sender, X509_NAME)
 
-/* Set the X509 name of the issuer. Set in the PKIHeader */
+/* Set the X509 name of the issuer to be placed in the certTemplate */
 DEFINE_OSSL_CMP_CTX_set1(issuer, X509_NAME)
 
 /*

--- a/crypto/cmp/cmp_server.c
+++ b/crypto/cmp/cmp_server.c
@@ -446,7 +446,7 @@ OSSL_CMP_MSG *OSSL_CMP_SRV_process_request(OSSL_CMP_SRV_CTX *srv_ctx,
     ASN1_OCTET_STRING *backup_secret;
     OSSL_CMP_PKIHEADER *hdr;
     int req_type, rsp_type;
-    int res;
+    int req_verified = 0;
     OSSL_CMP_MSG *rsp = NULL;
 
     if (srv_ctx == NULL || srv_ctx->ctx == NULL
@@ -506,12 +506,12 @@ OSSL_CMP_MSG *OSSL_CMP_SRV_process_request(OSSL_CMP_SRV_CTX *srv_ctx,
         }
     }
 
-    res = ossl_cmp_msg_check_update(ctx, req, unprotected_exception,
-                                    srv_ctx->acceptUnprotected);
+    req_verified = ossl_cmp_msg_check_update(ctx, req, unprotected_exception,
+                                             srv_ctx->acceptUnprotected);
     if (ctx->secretValue != NULL && ctx->pkey != NULL
             && ossl_cmp_hdr_get_protection_nid(hdr) != NID_id_PasswordBasedMAC)
         ctx->secretValue = NULL; /* use MSG_SIG_ALG when protecting rsp */
-    if (!res)
+    if (!req_verified)
         goto err;
 
     switch (req_type) {
@@ -568,9 +568,15 @@ OSSL_CMP_MSG *OSSL_CMP_SRV_process_request(OSSL_CMP_SRV_CTX *srv_ctx,
         int fail_info = 1 << OSSL_CMP_PKIFAILUREINFO_badRequest;
         OSSL_CMP_PKISI *si = NULL;
 
-        if (ctx->transactionID == NULL) {
-            /* ignore any (extra) error in next two function calls: */
-            (void)OSSL_CMP_CTX_set1_transactionID(ctx, hdr->transactionID);
+        if (!req_verified) {
+            /*
+             * Above ossl_cmp_msg_check_update() was not successfully executed,
+             * which normally would set ctx->transactionID and ctx->recipNonce.
+             * So anyway try to provide the right transactionID and recipNonce,
+             * while ignoring any (extra) error in next two function calls.
+             */
+            if (ctx->transactionID == NULL)
+                (void)OSSL_CMP_CTX_set1_transactionID(ctx, hdr->transactionID);
             (void)ossl_cmp_ctx_set1_recipNonce(ctx, hdr->senderNonce);
         }
 

--- a/crypto/cmp/cmp_vfy.c
+++ b/crypto/cmp/cmp_vfy.c
@@ -642,7 +642,6 @@ int OSSL_CMP_validate_msg(OSSL_CMP_CTX *ctx, const OSSL_CMP_MSG *msg)
     return 0;
 }
 
-
 /*-
  * Check received message (i.e., response by server or request from client)
  * Any msg->extraCerts are prepended to ctx->untrusted.

--- a/crypto/cmp/cmp_vfy.c
+++ b/crypto/cmp/cmp_vfy.c
@@ -765,6 +765,11 @@ int ossl_cmp_msg_check_update(OSSL_CMP_CTX *ctx, const OSSL_CMP_MSG *msg,
 #endif
     }
 
+    /* if not yet present, learn transactionID */
+    if (ctx->transactionID == NULL
+        && !OSSL_CMP_CTX_set1_transactionID(ctx, hdr->transactionID))
+        return 0;
+
     /*
      * RFC 4210 section 5.1.1 states: the recipNonce is copied from
      * the senderNonce of the previous message in the transaction.
@@ -772,11 +777,6 @@ int ossl_cmp_msg_check_update(OSSL_CMP_CTX *ctx, const OSSL_CMP_MSG *msg,
      */
     if (!ossl_cmp_ctx_set1_recipNonce(ctx, hdr->senderNonce))
         return 0;
-
-    /* if not yet present, learn transactionID */
-    if (ctx->transactionID == NULL
-        && !OSSL_CMP_CTX_set1_transactionID(ctx, hdr->transactionID))
-        return -1;
 
     /*
      * Store any provided extraCerts in ctx for future use,
@@ -788,7 +788,7 @@ int ossl_cmp_msg_check_update(OSSL_CMP_CTX *ctx, const OSSL_CMP_MSG *msg,
                         /* this allows self-signed certs */
                         X509_ADD_FLAG_UP_REF | X509_ADD_FLAG_NO_DUP
                         | X509_ADD_FLAG_PREPEND))
-        return -1;
+        return 0;
 
     if (ossl_cmp_hdr_get_protection_nid(hdr) == NID_id_PasswordBasedMAC) {
         /*

--- a/doc/internal/man3/ossl_cmp_mock_srv_new.pod
+++ b/doc/internal/man3/ossl_cmp_mock_srv_new.pod
@@ -8,7 +8,7 @@ ossl_cmp_mock_srv_set1_certOut,
 ossl_cmp_mock_srv_set1_chainOut,
 ossl_cmp_mock_srv_set1_caPubsOut,
 ossl_cmp_mock_srv_set_statusInfo,
-ossl_cmp_mock_srv_set_send_error,
+ossl_cmp_mock_srv_set_sendError,
 ossl_cmp_mock_srv_set_pollCount,
 ossl_cmp_mock_srv_set_checkAfterTime
 - functions used for testing with CMP mock server
@@ -27,7 +27,7 @@ ossl_cmp_mock_srv_set_checkAfterTime
                                       STACK_OF(X509) *caPubs);
  int ossl_cmp_mock_srv_set_statusInfo(OSSL_CMP_SRV_CTX *srv_ctx, int status,
                                       int fail_info, const char *text);
- int ossl_cmp_mock_srv_set_send_error(OSSL_CMP_SRV_CTX *srv_ctx, int val);
+ int ossl_cmp_mock_srv_set_sendError(OSSL_CMP_SRV_CTX *srv_ctx, int bodytype);
  int ossl_cmp_mock_srv_set_pollCount(OSSL_CMP_SRV_CTX *srv_ctx, int count);
  int ossl_cmp_mock_srv_set_checkAfterTime(OSSL_CMP_SRV_CTX *srv_ctx, int sec);
 
@@ -51,7 +51,9 @@ ossl_cmp_mock_srv_set1_caPubsOut() sets the caPubs to be returned in an ip.
 
 ossl_cmp_mock_srv_set_statusInfo() sets the status info to be returned.
 
-ossl_cmp_mock_srv_set_send_error() enables enforcement of error responses.
+ossl_cmp_mock_srv_set_sendError() enables enforcement of error responses
+for requests of the given I<bodytype>, or for all requests if I<bodytype> is 1.
+A I<bodytype> of -1 can be used to disable this feature, which is the default.
 
 ossl_cmp_mock_srv_set_pollCount() sets the number of polls before cert response.
 

--- a/doc/internal/man3/ossl_cmp_mock_srv_new.pod
+++ b/doc/internal/man3/ossl_cmp_mock_srv_new.pod
@@ -39,24 +39,24 @@ I<propq>, both of which may be NULL to select the defaults.
 
 ossl_cmp_mock_srv_free() deallocates the contexts for the CMP mock server.
 
-OSSL_CMP_SRV_CTX_set1_certOut() sets the certificate to be returned in
+ossl_cmp_mock_srv_set1_certOut() sets the certificate to be returned in
 cp/ip/kup.
 
-OSSL_CMP_SRV_CTX_set1_chainOut() sets the certificate chain to be added to
+ossl_cmp_mock_srv_set1_chainOut() sets the certificate chain to be added to
 the extraCerts in a cp/ip/kup.
-It should to useful to validate B<certOut>.
+It should be useful for the validation of the certificate given via
+ossl_cmp_mock_srv_set1_certOut().
 
-OSSL_CMP_SRV_CTX_set1_caPubsOut() sets the caPubs to be returned in an ip.
+ossl_cmp_mock_srv_set1_caPubsOut() sets the caPubs to be returned in an ip.
 
-OSSL_CMP_SRV_CTX_set_statusInfo() sets the status info to be returned.
+ossl_cmp_mock_srv_set_statusInfo() sets the status info to be returned.
 
-OSSL_CMP_SRV_CTX_set_send_error() enables enforcement of error responses.
+ossl_cmp_mock_srv_set_send_error() enables enforcement of error responses.
 
-OSSL_CMP_SRV_CTX_set_pollCount() sets the number of polls before cert response.
+ossl_cmp_mock_srv_set_pollCount() sets the number of polls before cert response.
 
-OSSL_CMP_SRV_CTX_set_checkAfterTime() sets the number of seconds
+ossl_cmp_mock_srv_set_checkAfterTime() sets the number of seconds
 the client should wait for the next poll.
-
 
 =head1 NOTES
 

--- a/test/testutil/provider.c
+++ b/test/testutil/provider.c
@@ -38,7 +38,7 @@ int test_get_libctx(OSSL_LIB_CTX **libctx, OSSL_PROVIDER **default_null_prov,
         goto err;
     }
 
-    if (module_name != NULL
+    if (provider != NULL && module_name != NULL
             && (*provider = OSSL_PROVIDER_load(new_libctx, module_name)) == NULL) {
         opt_printf_stderr("Failed to load provider %s\n", module_name);
         goto err;


### PR DESCRIPTION
This backports #20190 to 3.0 and 3.1, where it did not merge cleanly.
