### PR TITLE
Create v3name_fuzzer.c, fuzzer for GENERAL_NAME which discovers cve-2023-0286

### DIFF
--- a/fuzz/v3name_fuzzer.c
+++ b/fuzz/v3name_fuzzer.c
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2012-2023 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <string.h>
+#include <openssl/e_os2.h>
+#include <openssl/x509.h>
+#include <openssl/x509v3.h>
+#include "internal/nelem.h"
+#include "fuzzer.h"
+
+int FuzzerInitialize(int *argc, char ***argv)
+{
+    return 1;
+}
+
+int FuzzerTestOneInput(const uint8_t* data, size_t size){
+
+     size_t i, j;
+    GENERAL_NAME *namesa = OPENSSL_malloc(size);
+    GENERAL_NAME *namesb = OPENSSL_malloc(size);
+    
+    if (namesa == NULL || namesb == NULL)
+        return 0;
+
+    const unsigned char *derp = data;
+
+        /*
+         * We create two versions of each GENERAL_NAME so that we ensure when
+         * we compare them they are always different pointers.
+         */
+        namesa = d2i_GENERAL_NAME(NULL, &derp, size);
+        derp = data;
+        namesb = d2i_GENERAL_NAME(NULL, &derp, size);        
+        GENERAL_NAME_cmp(namesa, namesb);
+        if (namesa != NULL)
+            GENERAL_NAME_free(namesa);
+        if (namesb != NULL)
+            GENERAL_NAME_free(namesb);
+    return 0;
+}
+
+void FuzzerCleanup(void)
+{
+}
+


### PR DESCRIPTION
fuzzer for v3name, cve-2023-0286

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- adding fuzzer for GENERAL_NAME
i am using mac so not able to test this code. i have tested a normal build with libfuzzer 
