### PR TITLE
Prevent double free for `CMS_add1_cert()` and fix doc - backport to 3.0 and 3.1

### DIFF
--- a/crypto/cms/cms_lib.c
+++ b/crypto/cms/cms_lib.c
@@ -615,11 +615,12 @@ int CMS_add0_crl(CMS_ContentInfo *cms, X509_CRL *crl)
 
 int CMS_add1_crl(CMS_ContentInfo *cms, X509_CRL *crl)
 {
-    int r;
-    r = CMS_add0_crl(cms, crl);
-    if (r > 0)
-        X509_CRL_up_ref(crl);
-    return r;
+    if (!X509_CRL_up_ref(crl))
+        return 0;
+    if (CMS_add0_crl(cms, crl))
+        return 1;
+    X509_CRL_free(crl);
+    return 0;
 }
 
 STACK_OF(X509) *CMS_get1_certs(CMS_ContentInfo *cms)

--- a/doc/man3/CMS_add0_cert.pod
+++ b/doc/man3/CMS_add0_cert.pod
@@ -20,6 +20,8 @@ CMS_add0_cert, CMS_add1_cert, CMS_get1_certs, CMS_add0_crl, CMS_add1_crl, CMS_ge
 =head1 DESCRIPTION
 
 CMS_add0_cert() and CMS_add1_cert() add certificate I<cert> to I<cms>.
+This is used by L<CMS_sign_ex()> and L<CMS_sign()> and may be used before
+calling L<CMS_verify()> to help chain building in certificate validation.
 I<cms> must be of type signed data or (authenticated) enveloped data.
 For signed data, such a certificate can be used when signing or verifying
 to fill in the signer certificate or to provide an extra CA certificate
@@ -29,7 +31,8 @@ CMS_get1_certs() returns all certificates in I<cms>.
 
 CMS_add0_crl() and CMS_add1_crl() add CRL I<crl> to I<cms>.
 I<cms> must be of type signed data or (authenticated) enveloped data.
-For signed data, such a CRL may be used in certificate validation.
+For signed data, such a CRL may be used in certificate validation
+with L<CMS_verify()>.
 It may be given both for inclusion when signing a CMS message
 and when verifying a signed CMS message.
 
@@ -48,8 +51,7 @@ As the I<0> implies CMS_add0_cert() adds I<cert> internally to I<cms> and it
 must not be freed up after the call as opposed to CMS_add1_cert() where I<cert>
 must be freed up.
 
-The same certificate or CRL must not be added to the same cms structure more
-than once.
+The same certificate must not be added to the same cms structure more than once.
 
 =head1 RETURN VALUES
 
@@ -63,7 +65,7 @@ in practice is if the I<cms> type is invalid.
 =head1 SEE ALSO
 
 L<ERR_get_error(3)>,
-L<CMS_sign(3)>,
+L<CMS_sign(3)>, L<CMS_sign_ex(3)>, L<CMS_verify(3)>,
 L<CMS_encrypt(3)>
 
 =head1 COPYRIGHT


### PR DESCRIPTION
Backport the parts of #19199 containing fixes for `CMS_add1_cert()`.

