### PR TITLE
Fix incorrect error branch in ossl_bn_rsa_fips186_4_derive_prime()

### DIFF
--- a/crypto/bn/bn_rsa_fips186_4.c
+++ b/crypto/bn/bn_rsa_fips186_4.c
@@ -357,7 +357,7 @@ int ossl_bn_rsa_fips186_4_derive_prime(BIGNUM *Y, BIGNUM *X, const BIGNUM *Xin,
              *    sqrt(2) * 2^(nlen/2-1) <= Random X <= (2^(nlen/2)) - 1.
              */
             if (!BN_priv_rand_range_ex(X, range, 0, ctx) || !BN_add(X, X, base))
-                goto end;
+                goto err;
         }
         /* (Step 4) Y = X + ((R - X) mod 2r1r2) */
         if (!BN_mod_sub(Y, R, X, r1r2x2, ctx) || !BN_add(Y, Y, X))


### PR DESCRIPTION
BN_priv_rand_range_ex() and BN_add() both return a 0 on failure and a 1 on success. In case of failure, the algorithm should fail. However, the branch that it goes through on failure is "goto end", not "goto err". Therefore, the algorithm will return 1 which indicates success instead of 0 for failure, leading to potential problems for the callers. Fix it by changing the goto to "goto err" instead of "goto end".

CLA: trivial

Please note that I found this using a static analysis tool I am developing at the moment. It could therefore be a false positive bug. I manually reviewed the case to be extra sure that it is a real bug.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
