### PR TITLE
Avoid erroneous diagnostics in speed measuring

### DIFF
--- a/apps/speed.c
+++ b/apps/speed.c
@@ -774,7 +774,7 @@ static int EVP_Update_loop(void *args)
     else
         rc = EVP_EncryptFinal_ex(ctx, buf, &outl);
 
-    if (rc <= 1)
+    if (rc == 0)
         BIO_printf(bio_err, "Error finalizing cipher loop\n");
     return count;
 }
@@ -816,7 +816,7 @@ static int EVP_Update_loop_ccm(void *args)
     else
         final = EVP_EncryptFinal_ex(ctx, buf, &outl);
 
-    if (final <= 1)
+    if (final == 0)
         BIO_printf(bio_err, "Error finalizing ccm loop\n");
     return realcount;
 }


### PR DESCRIPTION
Fixes #20291 
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
