### PR TITLE
openssl-3.1#20290: Fixed typo in "config" man page

### DIFF
--- a/doc/man5/config.pod
+++ b/doc/man5/config.pod
@@ -73,7 +73,7 @@ done with the following directive:
 The default behavior, where the B<value> is B<false> or B<off>, is to treat
 the dollarsign as indicating a variable name; C<foo$bar> is interpreted as
 C<foo> followed by the expansion of the variable C<bar>. If B<value> is
-B<true> or B<on>, then C<foo$bar> is a single seven-character name nad
+B<true> or B<on>, then C<foo$bar> is a single seven-character name and
 variable expansions must be specified using braces or parentheses.
 
  .pragma [=] includedir:value


### PR DESCRIPTION
CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
