### PR TITLE
Skip current directory and parent directory symbols when reading files in a directory

### DIFF
--- a/ssl/ssl_cert.c
+++ b/ssl/ssl_cert.c
@@ -24,6 +24,16 @@
 #include "ssl_local.h"
 #include "ssl_cert_table.h"
 #include "internal/thread_once.h"
+#ifndef OPENSSL_NO_POSIX_IO
+# include <sys/stat.h>
+# ifdef _WIN32
+#  define stat _stat
+# endif
+#endif
+
+#ifndef S_ISDIR
+# define S_ISDIR(a) (((a) & S_IFMT) == S_IFDIR)
+#endif
 
 static int ssl_security_default_callback(const SSL *s, const SSL_CTX *ctx,
                                          int op, int bits, int nid, void *other,
@@ -808,6 +818,7 @@ int SSL_add_dir_cert_subjects_to_stack(STACK_OF(X509_NAME) *stack,
     while ((filename = OPENSSL_DIR_read(&d, dir))) {
         char buf[1024];
         int r;
+        struct stat st;
 
         if (strlen(dir) + strlen(filename) + 2 > sizeof(buf)) {
             ERR_raise(ERR_LIB_SSL, SSL_R_PATH_TOO_LONG);
@@ -818,6 +829,9 @@ int SSL_add_dir_cert_subjects_to_stack(STACK_OF(X509_NAME) *stack,
 #else
         r = BIO_snprintf(buf, sizeof(buf), "%s/%s", dir, filename);
 #endif
+        /* Skip subdirectories */
+        if (!stat(buf, &st) && S_ISDIR(st.st_mode))
+            continue;
         if (r <= 0 || r >= (int)sizeof(buf))
             goto err;
         if (!SSL_add_file_cert_subjects_to_stack(stack, buf))


### PR DESCRIPTION
`SSL_add_dir_cert_subjects_to_stack()` function always fails on Windows.
`SSL_add_file_cert_subjects_to_stack()` function fails on Windows when trying to open a directory as a file :
[https://github.com/openssl/openssl/blob/7e5505107aacdf58a4d0c00da90af4b7407c8d65/ssl/ssl_cert.c#L767-L768](https://github.com/openssl/openssl/blob/7e5505107aacdf58a4d0c00da90af4b7407c8d65/ssl/ssl_cert.c#L767-L768)

The following code shows this error. This PoC works in Linux but not Windows:
```c
#include <openssl/x509.h>
#include <openssl/ssl.h>
#include <openssl/safestack.h>

int main(int argc, char **argv) {
    int n, i;
    STACK_OF(X509_NAME) *ca_dn=sk_X509_NAME_new_null();
    (void)argc;
    SSL_add_dir_cert_subjects_to_stack(ca_dn, argv[1]);
    if((n=sk_X509_NAME_num(ca_dn))==0) {
        printf("No trusted certificates found\n");
        sk_X509_NAME_pop_free(ca_dn, X509_NAME_free);
        return 1; /* FAILED */
    }
    for(i=0; i<n; i++) {
        char *ca_name=X509_NAME_oneline(sk_X509_NAME_value(ca_dn, i), NULL, 0);
        printf("CA #%d: %s\n", i, ca_name);
        OPENSSL_free(ca_name);
    }
    sk_X509_NAME_pop_free(ca_dn, X509_NAME_free);
    return 0; /* OK */
}
```
My improved PR fixes this by skipping current, parent and other subdirectories in `SSL_add_dir_cert_subjects_to_stack()`.