### PR TITLE
kbkdf: Fix kbkdf_dup function pointer type

### DIFF
--- a/providers/implementations/kdfs/kbkdf.c
+++ b/providers/implementations/kdfs/kbkdf.c
@@ -76,7 +76,7 @@ typedef struct {
 
 /* Definitions needed for typechecking. */
 static OSSL_FUNC_kdf_newctx_fn kbkdf_new;
-static OSSL_FUNC_kdf_newctx_fn kbkdf_dup;
+static OSSL_FUNC_kdf_dupctx_fn kbkdf_dup;
 static OSSL_FUNC_kdf_freectx_fn kbkdf_free;
 static OSSL_FUNC_kdf_reset_fn kbkdf_reset;
 static OSSL_FUNC_kdf_derive_fn kbkdf_derive;


### PR DESCRIPTION
kbkdf_dup should use the appropriate type OSSL_FUNC_kdf_dupctx_fn.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- ~documentation is added or updated~
- ~tests are added or updated~
