### PR TITLE
WIP: Enable access to the curves and certificate type

### DIFF
--- a/doc/man3/SSL_get_used_group_id.pod
+++ b/doc/man3/SSL_get_used_group_id.pod
@@ -1,0 +1,46 @@
+=pod
+
+=head1 NAME
+
+SSL_get_used_group_id, SSL_get_used_group_nid, SSL_get_used_sigalg_nid - get information
+about the curve that was used for the key agreement of the current TLS session establishment
+and about the signature algorithm that was used to sign the certificate of the peer.
+
+=head1 SYNOPSIS
+
+ #include <openssl/ssl.h>
+
+ long SSL_get_used_group_id(SSL *ssl);
+ long SSL_get_used_group_nid(SSL *ssl);
+ long SSL_get_used_sigalg_nid(SSL *ssl);
+
+=head1 DESCRIPTION
+
+SSL_get_used_group_id() returns the ID of the group of the curve that was used for the key agreement of the current TLS session establishment.
+
+SSL_get_used_group_nid() returns the name of the group of the curve that was used for the key agreement of the current TLS session establishment.
+
+SSL_get_used_sigalg_nid() returns the name of the signature algorithm (and hash if applicable) that was used to sign the certificate of the peer.
+
+=head1 RETURN VALUES
+
+All these functions return ids on success and 0 otherwise.
+
+=head1 NOTES
+
+This function is implemented as a macro.
+
+=head1 SEE ALSO
+
+L<ssl(7)>
+
+=head1 COPYRIGHT
+
+Copyright 2017-2018 The OpenSSL Project Authors. All Rights Reserved.
+
+Licensed under the OpenSSL license (the "License").  You may not use
+this file except in compliance with the License.  You can obtain a copy
+in the file LICENSE in the source distribution or at
+L<https://www.openssl.org/source/license.html>.
+
+=cut

--- a/include/openssl/ssl.h.in
+++ b/include/openssl/ssl.h.in
@@ -1332,6 +1332,9 @@ DECLARE_PEM_rw(SSL_SESSION, SSL_SESSION)
 # define SSL_CTRL_SET_RETRY_VERIFY               136
 # define SSL_CTRL_GET_VERIFY_CERT_STORE          137
 # define SSL_CTRL_GET_CHAIN_CERT_STORE           138
+# define SSL_CTRL_GET_USED_GROUP_ID              139
+# define SSL_CTRL_GET_USED_GROUP_NID             140
+# define SSL_CTRL_GET_USED_SIGALG_NID            141
 # define SSL_CERT_SET_FIRST                      1
 # define SSL_CERT_SET_NEXT                       2
 # define SSL_CERT_SET_SERVER                     3
@@ -1499,6 +1502,14 @@ DECLARE_PEM_rw(SSL_SESSION, SSL_SESSION)
         SSL_ctrl(s, SSL_CTRL_GET_MIN_PROTO_VERSION, 0, NULL)
 # define SSL_get_max_proto_version(s) \
         SSL_ctrl(s, SSL_CTRL_GET_MAX_PROTO_VERSION, 0, NULL)
+#define SSL_get_oqs_kem_curve_id(s) \
+        SSL_ctrl(s, SSL_CTRL_GET_OQS_KEM_CURVE_ID, 0, NULL)
+#define SSL_get_used_group_id(s) \
+        SSL_ctrl(s, SSL_CTRL_GET_USED_GROUP_ID, 0, NULL)
+#define SSL_get_used_group_nid(s) \
+        SSL_ctrl(s, SSL_CTRL_GET_USED_GROUP_NID, 0, NULL)
+#define SSL_get_used_sigalg_nid(s) \
+        SSL_ctrl(s, SSL_CTRL_GET_USED_SIGALG_NID, 0, NULL)
 
 const char *SSL_group_to_name(SSL *s, int id);
 
@@ -1519,6 +1530,8 @@ int SSL_CTX_set0_tmp_dh_pkey(SSL_CTX *ctx, EVP_PKEY *dhpkey);
 # define SSL_CTRL_SET_CURVES           SSL_CTRL_SET_GROUPS
 # define SSL_CTRL_SET_CURVES_LIST      SSL_CTRL_SET_GROUPS_LIST
 # define SSL_CTRL_GET_SHARED_CURVE     SSL_CTRL_GET_SHARED_GROUP
+# define SSL_CTRL_GET_USED_CURVE_ID    SSL_CTRL_GET_USED_GROUP_ID
+# define SSL_CTRL_GET_USED_CURVE_NID   SSL_CTRL_GET_USED_GROUP_NID
 
 # define SSL_get1_curves               SSL_get1_groups
 # define SSL_CTX_set1_curves           SSL_CTX_set1_groups
@@ -1526,7 +1539,8 @@ int SSL_CTX_set0_tmp_dh_pkey(SSL_CTX *ctx, EVP_PKEY *dhpkey);
 # define SSL_set1_curves               SSL_set1_groups
 # define SSL_set1_curves_list          SSL_set1_groups_list
 # define SSL_get_shared_curve          SSL_get_shared_group
-
+# define SSL_get_used_curve_id         SSL_get_used_group_id
+# define SSL_get_used_curve_nid        SSL_get_used_group_nid
 
 # ifndef OPENSSL_NO_DEPRECATED_1_1_0
 /* Provide some compatibility macros for removed functionality. */

--- a/include/openssl/ssl.h.in
+++ b/include/openssl/ssl.h.in
@@ -1502,13 +1502,11 @@ DECLARE_PEM_rw(SSL_SESSION, SSL_SESSION)
         SSL_ctrl(s, SSL_CTRL_GET_MIN_PROTO_VERSION, 0, NULL)
 # define SSL_get_max_proto_version(s) \
         SSL_ctrl(s, SSL_CTRL_GET_MAX_PROTO_VERSION, 0, NULL)
-#define SSL_get_oqs_kem_curve_id(s) \
-        SSL_ctrl(s, SSL_CTRL_GET_OQS_KEM_CURVE_ID, 0, NULL)
-#define SSL_get_used_group_id(s) \
+# define SSL_get_used_group_id(s) \
         SSL_ctrl(s, SSL_CTRL_GET_USED_GROUP_ID, 0, NULL)
-#define SSL_get_used_group_nid(s) \
+# define SSL_get_used_group_nid(s) \
         SSL_ctrl(s, SSL_CTRL_GET_USED_GROUP_NID, 0, NULL)
-#define SSL_get_used_sigalg_nid(s) \
+# define SSL_get_used_sigalg_nid(s) \
         SSL_ctrl(s, SSL_CTRL_GET_USED_SIGALG_NID, 0, NULL)
 
 const char *SSL_group_to_name(SSL *s, int id);
@@ -1541,6 +1539,7 @@ int SSL_CTX_set0_tmp_dh_pkey(SSL_CTX *ctx, EVP_PKEY *dhpkey);
 # define SSL_get_shared_curve          SSL_get_shared_group
 # define SSL_get_used_curve_id         SSL_get_used_group_id
 # define SSL_get_used_curve_nid        SSL_get_used_group_nid
+
 
 # ifndef OPENSSL_NO_DEPRECATED_1_1_0
 /* Provide some compatibility macros for removed functionality. */

--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -3760,27 +3760,26 @@ long ssl3_ctrl(SSL *s, int cmd, long larg, void *parg)
         }
     case SSL_CTRL_GET_USED_GROUP_ID:
         {
-          if (s == NULL || s->s3 == NULL) return 0;
-          if (s->server == 0|| s->session == NULL) return 0;
-          return s->s3->tmp.oqs_kem_curve_id ? s->s3->tmp.oqs_kem_curve_id : s->s3->group_id;
+            if (sc == NULL) return 0;
+            if (sc->server == 0|| sc->session == NULL) return 0;
+            return sc->s3.group_id;
         }
     case SSL_CTRL_GET_USED_GROUP_NID:
         {
-          if (s == NULL || s->s3 == NULL) return 0;
-          if (s->server == 0|| s->session == NULL) return 0;
-          const TLS_GROUP_INFO *tls_group_info =
-            tls1_group_id_lookup(s->s3->tmp.oqs_kem_curve_id ?
-                                 s->s3->tmp.oqs_kem_curve_id : s->s3->group_id);
-          return tls_group_info == NULL ? 0 : tls_group_info->nid;
+            if (sc == NULL) return 0;
+            if (sc->server == 0|| sc->session == NULL) return 0;
+            const TLS_GROUP_INFO *tls_group_info =
+                    tls1_group_id_lookup(s->ctx, sc->s3.group_id);
+            return tls_group_info == NULL ? 0 : tls_group_info->group_id;
         }
     case SSL_CTRL_GET_USED_SIGALG_NID:
         {
-          if (s == NULL || s->s3 == NULL) return 0;
-          if (s->session == NULL) return 0;
-          if (s->s3->tmp.peer_sigalg == NULL) return 0;
-          if (s->s3->tmp.peer_sigalg->sig == EVP_PKEY_EC)
-             return s->s3->tmp.peer_sigalg->sigandhash;
-          return s->s3->tmp.peer_sigalg->sig;
+            if (sc == NULL) return 0;
+            if (sc->session == NULL) return 0;
+            if (sc->s3.tmp.peer_sigalg == NULL) return 0;
+            if (sc->s3.tmp.peer_sigalg->sig == EVP_PKEY_EC)
+                return sc->s3.tmp.peer_sigalg->sigandhash;
+            return sc->s3.tmp.peer_sigalg->sig;
         }
 
     default:

--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -3770,7 +3770,8 @@ long ssl3_ctrl(SSL *s, int cmd, long larg, void *parg)
             if (sc->server == 0|| sc->session == NULL) return 0;
             const TLS_GROUP_INFO *tls_group_info =
                     tls1_group_id_lookup(s->ctx, sc->s3.group_id);
-            return tls_group_info == NULL ? 0 : tls_group_info->group_id;
+            if (tls_group_info == NULL) return 0;
+            return tls1_group_id2nid(tls_group_info->group_id, 0);
         }
     case SSL_CTRL_GET_USED_SIGALG_NID:
         {

--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -3761,14 +3761,14 @@ long ssl3_ctrl(SSL *s, int cmd, long larg, void *parg)
     case SSL_CTRL_GET_USED_GROUP_ID:
         {
           if (s == NULL || s->s3 == NULL) return 0;
-          if (s->server || s->session == NULL) return 0;
+          if (s->server == 0|| s->session == NULL) return 0;
           return s->s3->tmp.oqs_kem_curve_id ? s->s3->tmp.oqs_kem_curve_id : s->s3->group_id;
         }
     case SSL_CTRL_GET_USED_GROUP_NID:
         {
           if (s == NULL || s->s3 == NULL) return 0;
-          if (s->server || s->session == NULL) return 0;
-          TLS_GROUP_INFO *tls_group_info =
+          if (s->server == 0|| s->session == NULL) return 0;
+          const TLS_GROUP_INFO *tls_group_info =
             tls1_group_id_lookup(s->s3->tmp.oqs_kem_curve_id ?
                                  s->s3->tmp.oqs_kem_curve_id : s->s3->group_id);
           return tls_group_info == NULL ? 0 : tls_group_info->nid;
@@ -3776,7 +3776,8 @@ long ssl3_ctrl(SSL *s, int cmd, long larg, void *parg)
     case SSL_CTRL_GET_USED_SIGALG_NID:
         {
           if (s == NULL || s->s3 == NULL) return 0;
-          if (s->server || s->session == NULL) return 0;
+          if (s->session == NULL) return 0;
+          if (s->s3->tmp.peer_sigalg == NULL) return 0;
           if (s->s3->tmp.peer_sigalg->sig == EVP_PKEY_EC)
              return s->s3->tmp.peer_sigalg->sigandhash;
           return s->s3->tmp.peer_sigalg->sig;

--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -3758,6 +3758,29 @@ long ssl3_ctrl(SSL *s, int cmd, long larg, void *parg)
             }
             return (int)sc->ext.peer_supportedgroups_len;
         }
+    case SSL_CTRL_GET_USED_GROUP_ID:
+        {
+          if (s == NULL || s->s3 == NULL) return 0;
+          if (s->server || s->session == NULL) return 0;
+          return s->s3->tmp.oqs_kem_curve_id ? s->s3->tmp.oqs_kem_curve_id : s->s3->group_id;
+        }
+    case SSL_CTRL_GET_USED_GROUP_NID:
+        {
+          if (s == NULL || s->s3 == NULL) return 0;
+          if (s->server || s->session == NULL) return 0;
+          TLS_GROUP_INFO *tls_group_info =
+            tls1_group_id_lookup(s->s3->tmp.oqs_kem_curve_id ?
+                                 s->s3->tmp.oqs_kem_curve_id : s->s3->group_id);
+          return tls_group_info == NULL ? 0 : tls_group_info->nid;
+        }
+    case SSL_CTRL_GET_USED_SIGALG_NID:
+        {
+          if (s == NULL || s->s3 == NULL) return 0;
+          if (s->server || s->session == NULL) return 0;
+          if (s->s3->tmp.peer_sigalg->sig == EVP_PKEY_EC)
+             return s->s3->tmp.peer_sigalg->sigandhash;
+          return s->s3->tmp.peer_sigalg->sig;
+        }
 
     default:
         break;

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -37,6 +37,7 @@
 
 #include "helpers/ssltestlib.h"
 #include "testutil.h"
+#include "testutil/output.h"
 #include "internal/nelem.h"
 #include "internal/ktls.h"
 #include "../ssl/ssl_local.h"
@@ -7796,7 +7797,7 @@ static int test_ssl_get_used_group(int tst)
     SSL *clientssl = NULL, *serverssl = NULL;
     int testresult = 0;
 
-    if (!TEST_true(create_ssl_ctx_pair(TLS_server_method(),
+    if (!TEST_true(create_ssl_ctx_pair(libctx, TLS_server_method(),
                                        TLS_client_method(),
                                        TLS1_VERSION,
                                        TLS_MAX_VERSION,
@@ -7807,11 +7808,11 @@ static int test_ssl_get_used_group(int tst)
             || !TEST_true(SSL_CTX_set_ciphersuites(cctx, "TLS_AES_256_GCM_SHA384"))
             || !TEST_true(SSL_CTX_set_cipher_list(sctx, "AES256-SHA"))
             || !TEST_true(SSL_CTX_set_ciphersuites(sctx, "TLS_AES_256_GCM_SHA384")))
-         goto end;
+        goto end;
 
 
     if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
-                                             NULL, NULL))
+                                      NULL, NULL))
             || !TEST_true(create_ssl_connection(serverssl, clientssl,
                                                 SSL_ERROR_NONE)))
         goto end;


### PR DESCRIPTION
This PR changes enable access to the curves and certificate type used in TLSv1.3 handshakes.

This equivalent to access to the ciphers used in the TLS session. The benefit is that monitoring/logging can not only report the protocol and ciphers, but also the curve and certificate type used for a TLSv1.3 connection on the client side. In particular, an user can verify that a quantum-safe-crypto curve and certificate was used.

##### Checklist
- [x] documentation is added or updated
- [x] tests are added or updated

This PR was adapted from an open PR by my co-worker @akihikokuroda against the Open Quantum Safe fork of OpenSSL 1.1.1 https://github.com/open-quantum-safe/openssl/pull/426 which

Co-authored-by: akihikokuroda <akuroda@us.ibm.com>