### PR TITLE
Remove ossl_rsa_pss_params_30_set_maskgenalg().

### DIFF
--- a/crypto/rsa/rsa_pss.c
+++ b/crypto/rsa/rsa_pss.c
@@ -334,15 +334,6 @@ int ossl_rsa_pss_params_30_set_hashalg(RSA_PSS_PARAMS_30 *rsa_pss_params,
     return 1;
 }
 
-int ossl_rsa_pss_params_30_set_maskgenalg(RSA_PSS_PARAMS_30 *rsa_pss_params,
-                                          int maskgenalg_nid)
-{
-    if (rsa_pss_params == NULL)
-        return 0;
-    rsa_pss_params->mask_gen.algorithm_nid = maskgenalg_nid;
-    return 1;
-}
-
 int ossl_rsa_pss_params_30_set_maskgenhashalg(RSA_PSS_PARAMS_30 *rsa_pss_params,
                                               int maskgenhashalg_nid)
 {

--- a/include/crypto/rsa.h
+++ b/include/crypto/rsa.h
@@ -34,8 +34,6 @@ int ossl_rsa_pss_params_30_copy(RSA_PSS_PARAMS_30 *to,
 int ossl_rsa_pss_params_30_is_unrestricted(const RSA_PSS_PARAMS_30 *rsa_pss_params);
 int ossl_rsa_pss_params_30_set_hashalg(RSA_PSS_PARAMS_30 *rsa_pss_params,
                                        int hashalg_nid);
-int ossl_rsa_pss_params_30_set_maskgenalg(RSA_PSS_PARAMS_30 *rsa_pss_params,
-                                          int maskgenalg_nid);
 int ossl_rsa_pss_params_30_set_maskgenhashalg(RSA_PSS_PARAMS_30 *rsa_pss_params,
                                               int maskgenhashalg_nid);
 int ossl_rsa_pss_params_30_set_saltlen(RSA_PSS_PARAMS_30 *rsa_pss_params,


### PR DESCRIPTION
This is an unused internal function. It should be added back
in if there is a need to set this value to something other than
NID_mgf1 (which is not likely).

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
