### PR TITLE
Document return value of OSSL_DECODER_from_data

### DIFF
--- a/doc/man3/OSSL_DECODER_from_bio.pod
+++ b/doc/man3/OSSL_DECODER_from_bio.pod
@@ -42,8 +42,8 @@ except that the input is coming from the B<FILE> I<fp>.
 
 =head1 RETURN VALUES
 
-OSSL_DECODER_from_bio() and OSSL_DECODER_from_fp() return 1 on success, or 0
-on failure.
+OSSL_DECODER_from_bio(), OSSL_DECODER_from_data() and OSSL_DECODER_from_fp()
+return 1 on success, or 0 on failure.
 
 =head1 EXAMPLES
 


### PR DESCRIPTION
The return value of `OSSL_DECODER_from_data()` was not documented.

CLA: trivial

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
