### PR TITLE
Only call OPENSSL_init_crypto on fetch if using the default libctx

### DIFF
--- a/crypto/property/property.c
+++ b/crypto/property/property.c
@@ -502,13 +502,14 @@ int ossl_method_store_fetch(OSSL_METHOD_STORE *store,
     int ret = 0;
     int j, best = -1, score, optional;
 
-#ifndef FIPS_MODULE
-    if (!OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CONFIG, NULL))
-        return 0;
-#endif
-
     if (nid <= 0 || method == NULL || store == NULL)
         return 0;
+
+#ifndef FIPS_MODULE
+    if (ossl_lib_ctx_is_default(store->ctx)
+            && !OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CONFIG, NULL))
+        return 0;
+#endif
 
     /* This only needs to be a read lock, because the query won't create anything */
     if (!ossl_property_read_lock(store))

--- a/test/build.info
+++ b/test/build.info
@@ -64,7 +64,7 @@ IF[{- !$disabled{tests} -}]
           bio_readbuffer_test user_property_test pkcs7_test upcallstest \
           provfetchtest prov_config_test rand_test ca_internals_test \
           bio_tfo_test membio_test bio_dgram_test list_test fips_version_test \
-          x509_test hpke_test pairwise_fail_test
+          x509_test hpke_test pairwise_fail_test nodefltctxtest
 
   IF[{- !$disabled{'deprecated-3.0'} -}]
     PROGRAMS{noinst}=enginetest
@@ -231,6 +231,10 @@ IF[{- !$disabled{tests} -}]
   SOURCE[pairwise_fail_test]=pairwise_fail_test.c
   INCLUDE[pairwise_fail_test]=../include ../apps/include
   DEPEND[pairwise_fail_test]=../libcrypto.a libtestutil.a
+
+  SOURCE[nodefltctxtest]=nodefltctxtest.c
+  INCLUDE[nodefltctxtest]=../include ../apps/include
+  DEPEND[nodefltctxtest]=../libcrypto.a libtestutil.a
 
   SOURCE[evp_pkey_dhkem_test]=evp_pkey_dhkem_test.c
   INCLUDE[evp_pkey_dhkem_test]=../include ../apps/include

--- a/test/nodefltctxtest.c
+++ b/test/nodefltctxtest.c
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2023 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <openssl/evp.h>
+#include "testutil.h"
+
+/*
+ * Test that the default libctx does not get initialised when using a custom
+ * libctx. We assume that this test application has been executed such that the
+ * null provider is loaded via the config file.
+ */
+static int test_no_deflt_ctx_init(void)
+{
+    int testresult = 0;
+    EVP_MD *md = NULL;
+    OSSL_LIB_CTX *ctx = OSSL_LIB_CTX_new();
+
+    if (!TEST_ptr(ctx))
+        return 0;
+
+    md = EVP_MD_fetch(ctx, "SHA2-256", NULL);
+    if (!TEST_ptr(md))
+        goto err;
+
+    /*
+     * Since we're using a non-default libctx above, the default libctx should
+     * not have been initialised via config file, and so it is not too late to
+     * use OPENSSL_INIT_NO_LOAD_CONFIG.
+     */
+    OPENSSL_init_crypto(OPENSSL_INIT_NO_LOAD_CONFIG, NULL);
+
+    /*
+     * If the config file was incorrectly loaded then the null provider will
+     * have been initialised and the default provider loading will have been
+     * blocked. If the config file was NOT loaded (as we expect) then the
+     * default provider should be available.
+     */
+    if (!TEST_true(OSSL_PROVIDER_available(NULL, "default")))
+        goto err;
+    if (!TEST_false(OSSL_PROVIDER_available(NULL, "null")))
+        goto err;
+
+    testresult = 1;
+ err:
+    EVP_MD_free(md);
+    OSSL_LIB_CTX_free(ctx);
+    return testresult;
+}
+
+int setup_tests(void)
+{
+    ADD_TEST(test_no_deflt_ctx_init);
+    return 1;
+}

--- a/test/null.cnf
+++ b/test/null.cnf
@@ -1,0 +1,13 @@
+openssl_conf = openssl_init
+
+# Comment out the next line to ignore configuration errors
+config_diagnostics = 1
+
+[openssl_init]
+providers = provider_sect
+
+[provider_sect]
+null = null_sect
+
+[null_sect]
+activate = 1

--- a/test/recipes/04-test_nodefltctx.t
+++ b/test/recipes/04-test_nodefltctx.t
@@ -1,0 +1,19 @@
+#! /usr/bin/env perl
+# Copyright 2023The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+use strict;
+use OpenSSL::Test::Simple;
+use OpenSSL::Test qw/:DEFAULT srctop_file/;
+use Cwd qw(abs_path);
+
+setup("test_nodefltctx");
+
+# Load the null provider by default into the default libctx
+$ENV{OPENSSL_CONF} = abs_path(srctop_file("test", "null.cnf"));
+
+simple_test("test_nodefltctx", "nodefltctxtest");


### PR DESCRIPTION
There is no point in calling OPENSSL_init_crypto() unless we are actually going to be using the default libctx.

Fixes #20315