### PR TITLE
Revert: "Put EdDSA back as approved algorithms."

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -225,8 +225,8 @@ OpenSSL 3.1
    backward compatibility purposes and the "fips=yes" property query
    must be used for all algorithm fetches to ensure FIPS compliance.
 
-   The algorithms that are included but not approved are Triple DES ECB
-   and Triple DES CBC.
+   The algorithms that are included but not approved are Triple DES ECB,
+   Triple DES CBC and EdDSA.
 
    *Paul Dale*
 

--- a/doc/man7/OSSL_PROVIDER-FIPS.pod
+++ b/doc/man7/OSSL_PROVIDER-FIPS.pod
@@ -402,6 +402,8 @@ want to operate in a FIPS approved manner.  The algorithms are:
 
 =item Triple DES CBC
 
+=item EdDSA
+
 =back
 
 =head1 SEE ALSO

--- a/doc/man7/fips_module.pod
+++ b/doc/man7/fips_module.pod
@@ -480,6 +480,8 @@ want to operate in a FIPS approved manner.  The algorithms are:
 
 =item Triple DES CBC
 
+=item EdDSA
+
 =back
 
 =head1 SEE ALSO

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -393,9 +393,9 @@ static const OSSL_ALGORITHM fips_signature[] = {
 #endif
     { PROV_NAMES_RSA, FIPS_DEFAULT_PROPERTIES, ossl_rsa_signature_functions },
 #ifndef OPENSSL_NO_EC
-    { PROV_NAMES_ED25519, FIPS_DEFAULT_PROPERTIES,
+    { PROV_NAMES_ED25519, FIPS_UNAPPROVED_PROPERTIES,
       ossl_ed25519_signature_functions },
-    { PROV_NAMES_ED448, FIPS_DEFAULT_PROPERTIES, ossl_ed448_signature_functions },
+    { PROV_NAMES_ED448, FIPS_UNAPPROVED_PROPERTIES, ossl_ed448_signature_functions },
     { PROV_NAMES_ECDSA, FIPS_DEFAULT_PROPERTIES, ossl_ecdsa_signature_functions },
 #endif
     { PROV_NAMES_HMAC, FIPS_DEFAULT_PROPERTIES,
@@ -439,9 +439,9 @@ static const OSSL_ALGORITHM fips_keymgmt[] = {
       PROV_DESCS_X25519 },
     { PROV_NAMES_X448, FIPS_DEFAULT_PROPERTIES, ossl_x448_keymgmt_functions,
       PROV_DESCS_X448 },
-    { PROV_NAMES_ED25519, FIPS_DEFAULT_PROPERTIES, ossl_ed25519_keymgmt_functions,
+    { PROV_NAMES_ED25519, FIPS_UNAPPROVED_PROPERTIES, ossl_ed25519_keymgmt_functions,
       PROV_DESCS_ED25519 },
-    { PROV_NAMES_ED448, FIPS_DEFAULT_PROPERTIES, ossl_ed448_keymgmt_functions,
+    { PROV_NAMES_ED448, FIPS_UNAPPROVED_PROPERTIES, ossl_ed448_keymgmt_functions,
       PROV_DESCS_ED448 },
 #endif
     { PROV_NAMES_TLS1_PRF, FIPS_DEFAULT_PROPERTIES, ossl_kdf_keymgmt_functions,


### PR DESCRIPTION
NIST isn't allowing EdDSA at this stage after all, so make it non-FIPS in the FIPS provider.  Guidance for FIPS 140-3 is expected later this month:

> The use of EdDSA still remains non-approved.
>
> Before the FIPS 186-5 and SP 800-186 algorithms / curves can be used in the approved mode, the CMVP will need to do (at least) the following:
>
> - Incorporate FIPS 186-5 and SP 800-186 into SP 800-140C/D;
> - Update IG 10.3.A to incorporate self-test requirements for the new algorithms/curves.
> - Write a new IG on this transition to clarify the issues raised in this thread and elsewhere and provide a clear transition schedule.
>
> The CMVP is working on all three of these items and hope to have drafts public by the end of March.
>
> Since security relevant changes are not permitted for new 140-2 submissions, and under the assumption that this transition away from FIPS 186-4 algorithms will be 'soft' and not move modules to the historical list, we do not plan on writing 140-2 guidance for this transition.

It seems unlikely that all of these requirements will be completed before we submit.

- [x] documentation is added or updated
- [ ] tests are added or updated
