### PR TITLE
CI: add Clang 16

### DIFF
--- a/.github/workflows/compiler-zoo.yml
+++ b/.github/workflows/compiler-zoo.yml
@@ -67,6 +67,10 @@ jobs:
             cc: clang-15,
             distro: ubuntu-22.04,
             llvm-ppa-name: jammy
+          }, {
+            cc: clang-16,
+            distro: ubuntu-22.04,
+            llvm-ppa-name: jammy
           }
         ]
     # We set per-compiler now to allow testing with both older and newer sets


### PR DESCRIPTION
It's that time of (half-)year again, so hello!

Clang 16 will be released shortly (beginning of March).
