### PR TITLE
crypto/conf: gcc build warning fix

### DIFF
--- a/crypto/conf/conf_sap.c
+++ b/crypto/conf/conf_sap.c
@@ -43,16 +43,19 @@ void OPENSSL_config(const char *appname)
 int openssl_config_int(const OPENSSL_INIT_SETTINGS *settings)
 {
     int ret = 0;
+#if defined(OPENSSL_INIT_DEBUG) || !defined(OPENSSL_SYS_UEFI)
     const char *filename;
     const char *appname;
     unsigned long flags;
+#endif
 
     if (openssl_configured)
         return 1;
-
+#if defined(OPENSSL_INIT_DEBUG) || !defined(OPENSSL_SYS_UEFI)
     filename = settings ? settings->filename : NULL;
     appname = settings ? settings->appname : NULL;
     flags = settings ? settings->flags : DEFAULT_CONF_MFLAGS;
+#endif
 
 #ifdef OPENSSL_INIT_DEBUG
     fprintf(stderr, "OPENSSL_INIT: openssl_config_int(%s, %s, %lu)\n",


### PR DESCRIPTION
Fix the gcc build warning from conf_sap.c:
variable flags set but not used [-Wunused-but-set-variable] variable appname set but not used [-Wunused-but-set-variable] variable filename set but not used [-Wunused-but-set-variable]

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
