### PR TITLE
Fix links in `cms_add0_cert.pod` and improve `find-doc-nits` error msg

### DIFF
--- a/doc/man3/CMS_add0_cert.pod
+++ b/doc/man3/CMS_add0_cert.pod
@@ -22,8 +22,8 @@ CMS_add0_crl, CMS_add1_crl, CMS_get1_crls
 
 CMS_add0_cert() and CMS_add1_cert() add certificate I<cert> to I<cms>
 unless it is already present.
-This is used by L<CMS_sign_ex()> and L<CMS_sign()> and may be used before
-calling L<CMS_verify()> to help chain building in certificate validation.
+This is used by L<CMS_sign_ex(3)> and L<CMS_sign(3)> and may be used before
+calling L<CMS_verify(3)> to help chain building in certificate validation.
 As the 0 implies, CMS_add0_cert() adds I<cert> internally to I<cms>
 and on success it must not be freed up by the caller.
 In contrast, the caller of CMS_add1_cert() must free I<cert>.
@@ -37,7 +37,7 @@ CMS_get1_certs() returns all certificates in I<cms>.
 CMS_add0_crl() and CMS_add1_crl() add CRL I<crl> to I<cms>.
 I<cms> must be of type signed data or (authenticated) enveloped data.
 For signed data, such a CRL may be used in certificate validation
-with L<CMS_verify()>.
+with L<CMS_verify(3)>.
 It may be given both for inclusion when signing a CMS message
 and when verifying a signed CMS message.
 

--- a/util/find-doc-nits
+++ b/util/find-doc-nits
@@ -701,17 +701,21 @@ sub check {
     my $dirname = basename(dirname($filename));
     my $contents = $podinfo{contents};
 
+    # Find what section this page is in; presume 3.
+    my $mansect = 3;
+    $mansect = $1 if $filename =~ /man([1-9])/;
+
     my $id = "${filename}:1:";
     check_head_style($id, $contents);
 
     # Check ordering of some sections in man3
-    if ( $filename =~ m|man3/| ) {
+    if ( $mansect == 3 ) {
         check_section_location($id, $contents, "RETURN VALUES", "EXAMPLES");
         check_section_location($id, $contents, "SEE ALSO", "HISTORY");
         check_section_location($id, $contents, "EXAMPLES", "SEE ALSO");
     }
 
-    # Make sure every link has a section.
+    # Make sure every link has a man section number.
     while ( $contents =~ /$markup_re/msg ) {
         my $target = $1;
         next unless $target =~ /^L<(.*)>$/;     # Skip if not L<...>
@@ -722,7 +726,7 @@ sub check {
         next if $target =~ /::/;                #   links to a Perl module, or
         next if $target =~ /^https?:/;          #   is a URL link, or
         next if $target =~ /\([1357]\)$/;       #   it has a section
-        err($id, "Section missing in $target")
+        err($id, "Missing man section number (likely, $mansect) in L<$target>")
     }
     # Check for proper links to commands.
     while ( $contents =~ /L<([^>]*)\(1\)(?:\/.*)?>/g ) {
@@ -741,10 +745,10 @@ sub check {
     }
 
     unless ( $contents =~ /^=for openssl generic/ms ) {
-        if ( $filename =~ m|man3/| ) {
+        if ( $mansect == 3 ) {
             name_synopsis($id, $filename, $contents);
             functionname_check($id, $filename, $contents);
-        } elsif ( $filename =~ m|man1/| ) {
+        } elsif ( $mansect == 1 ) {
             option_check($id, $filename, $contents)
         }
     }
@@ -808,7 +812,7 @@ sub check {
     close $OUT;
     unlink $temp || warn "Can't remove $temp, $!";
 
-    # Find what section this page is in; assume 3.
+    # Find what section this page is in; presume 3.
     my $section = 3;
     $section = $1 if $dirname =~ /man([1-9])/;
 


### PR DESCRIPTION
It turns out that my recently merged changes to  `cms_add0_cert.pod` made `find-doc-nits` unhappy.
Sorry that this went unnoticed and now causes unrelated CI failures in newly pushed PRs.
For this reason, I propose making the fix given here urgent.

As the error messages by `make doc-nits`:
```
/usr/bin/perl ./util/find-doc-nits -c -n -l -e
doc/man3/CMS_add0_cert.pod:1: Section missing in CMS_sign_ex()
doc/man3/CMS_add0_cert.pod:1: Section missing in CMS_sign()
doc/man3/CMS_add0_cert.pod:1: Section missing in CMS_verify()
doc/man3/CMS_add0_cert.pod:1: Section missing in CMS_verify()
```
are unclear and even misleading, such that it took me a while to understand what went wrong,
I propose the improvement of  `find-doc-nits`  given in the 2nd commit.
The error given will then read, e.g.,:
```
doc/man3/CMS_add0_cert.pod:1: Missing man section number (likely, 3) in L<CMS_verify()>
```

