### PR TITLE
Do not fail if ctx dup does not succeed

### DIFF
--- a/crypto/evp/p_sign.c
+++ b/crypto/evp/p_sign.c
@@ -39,6 +39,8 @@ int EVP_SignFinal_ex(EVP_MD_CTX *ctx, unsigned char *sigret,
         rv = EVP_MD_CTX_copy_ex(tmp_ctx, ctx);
         if (rv)
             rv = EVP_DigestFinal_ex(tmp_ctx, m, &m_len);
+        else
+            rv = EVP_DigestFinal_ex(ctx, m, &m_len);
         EVP_MD_CTX_free(tmp_ctx);
         if (!rv)
             return 0;

--- a/crypto/evp/p_verify.c
+++ b/crypto/evp/p_verify.c
@@ -37,6 +37,8 @@ int EVP_VerifyFinal_ex(EVP_MD_CTX *ctx, const unsigned char *sigbuf,
         rv = EVP_MD_CTX_copy_ex(tmp_ctx, ctx);
         if (rv)
             rv = EVP_DigestFinal_ex(tmp_ctx, m, &m_len);
+        else
+            rv = EVP_DigestFinal_ex(ctx, m, &m_len);
         EVP_MD_CTX_free(tmp_ctx);
         if (!rv)
             return 0;

--- a/doc/man3/EVP_DigestSignInit.pod
+++ b/doc/man3/EVP_DigestSignInit.pod
@@ -166,6 +166,10 @@ external circumstances (see L<RAND(7)>), the operation will fail.
 The call to EVP_DigestSignFinal() internally finalizes a copy of the digest
 context. This means that calls to EVP_DigestSignUpdate() and
 EVP_DigestSignFinal() can be called later to digest and sign additional data.
+Note that not all providers allow for continuation, in case the selected
+provider does not allow to duplicate contexts EVP_DigestSignFinal() will
+finalize the digest context and attempting to process additional data via
+EVP_DigestSignUpdate() will result in an error.
 
 EVP_DigestSignInit() and EVP_DigestSignInit_ex() functions can be called
 multiple times on a context and the parameters set by previous calls should be

--- a/doc/man3/EVP_DigestSignInit.pod
+++ b/doc/man3/EVP_DigestSignInit.pod
@@ -166,7 +166,10 @@ external circumstances (see L<RAND(7)>), the operation will fail.
 The call to EVP_DigestSignFinal() internally finalizes a copy of the digest
 context. This means that calls to EVP_DigestSignUpdate() and
 EVP_DigestSignFinal() can be called later to digest and sign additional data.
-Note that not all providers allow for continuation, in case the selected
+Applications may disable this behavior by setting the EVP_MD_CTX_FLAG_FINALISE
+context flag via L<EVP_MD_CTX_set_flags(3)>.
+
+Note that not all providers support continuation, in case the selected
 provider does not allow to duplicate contexts EVP_DigestSignFinal() will
 finalize the digest context and attempting to process additional data via
 EVP_DigestSignUpdate() will result in an error.

--- a/doc/man3/EVP_DigestVerifyInit.pod
+++ b/doc/man3/EVP_DigestVerifyInit.pod
@@ -155,6 +155,10 @@ external circumstances (see L<RAND(7)>), the operation will fail.
 The call to EVP_DigestVerifyFinal() internally finalizes a copy of the digest
 context. This means that EVP_VerifyUpdate() and EVP_VerifyFinal() can
 be called later to digest and verify additional data.
+Note that not all providers allow for continuation, in case the selected
+provider does not allow to duplicate contexts EVP_DigestVerifyFinal() will
+finalize the digest context and attempting to process additional data via
+EVP_DigestVerifyUpdate() will result in an error.
 
 EVP_DigestVerifyInit() and EVP_DigestVerifyInit_ex() functions can be called
 multiple times on a context and the parameters set by previous calls should be

--- a/doc/man3/EVP_DigestVerifyInit.pod
+++ b/doc/man3/EVP_DigestVerifyInit.pod
@@ -154,8 +154,11 @@ external circumstances (see L<RAND(7)>), the operation will fail.
 
 The call to EVP_DigestVerifyFinal() internally finalizes a copy of the digest
 context. This means that EVP_VerifyUpdate() and EVP_VerifyFinal() can
-be called later to digest and verify additional data.
-Note that not all providers allow for continuation, in case the selected
+be called later to digest and verify additional data. Applications may disable
+this behavior by setting the EVP_MD_CTX_FLAG_FINALISE context flag via
+L<EVP_MD_CTX_set_flags(3)>.
+
+Note that not all providers support continuation, in case the selected
 provider does not allow to duplicate contexts EVP_DigestVerifyFinal() will
 finalize the digest context and attempting to process additional data via
 EVP_DigestVerifyUpdate() will result in an error.

--- a/doc/man3/EVP_SignInit.pod
+++ b/doc/man3/EVP_SignInit.pod
@@ -72,6 +72,11 @@ Since only a copy of the digest context is ever finalized the context must
 be cleaned up after use by calling EVP_MD_CTX_free() or a memory leak
 will occur.
 
+Note that not all providers allow for continuation, in case the selected
+provider does not allow to duplicate contexts EVP_SignFinal() will
+finalize the digest context and attempting to process additional data via
+EVP_SignUpdate() will result in an error.
+
 =head1 BUGS
 
 Older versions of this documentation wrongly stated that calls to

--- a/doc/man3/EVP_SignInit.pod
+++ b/doc/man3/EVP_SignInit.pod
@@ -66,13 +66,15 @@ due to external circumstances (see L<RAND(7)>), the operation will fail.
 
 The call to EVP_SignFinal() internally finalizes a copy of the digest context.
 This means that calls to EVP_SignUpdate() and EVP_SignFinal() can be called
-later to digest and sign additional data.
+later to digest and sign additional data.cApplications may disable this
+behavior by setting the EVP_MD_CTX_FLAG_FINALISE context flag via
+L<EVP_MD_CTX_set_flags(3)>.
 
 Since only a copy of the digest context is ever finalized the context must
 be cleaned up after use by calling EVP_MD_CTX_free() or a memory leak
 will occur.
 
-Note that not all providers allow for continuation, in case the selected
+Note that not all providers support continuation, in case the selected
 provider does not allow to duplicate contexts EVP_SignFinal() will
 finalize the digest context and attempting to process additional data via
 EVP_SignUpdate() will result in an error.

--- a/doc/man3/EVP_VerifyInit.pod
+++ b/doc/man3/EVP_VerifyInit.pod
@@ -62,13 +62,15 @@ transparent to the algorithm used and much more flexible.
 
 The call to EVP_VerifyFinal() internally finalizes a copy of the digest context.
 This means that calls to EVP_VerifyUpdate() and EVP_VerifyFinal() can be called
-later to digest and verify additional data.
+later to digest and verify additional data. Applications may disable this
+behavior by setting the EVP_MD_CTX_FLAG_FINALISE context flag via
+L<EVP_MD_CTX_set_flags(3)>.
 
 Since only a copy of the digest context is ever finalized the context must
 be cleaned up after use by calling EVP_MD_CTX_free() or a memory leak
 will occur.
 
-Note that not all providers allow for continuation, in case the selected
+Note that not all providers support continuation, in case the selected
 provider does not allow to duplicate contexts EVP_VerifyFinal() will
 finalize the digest context and attempting to process additional data via
 EVP_VerifyUpdate() will result in an error.

--- a/doc/man3/EVP_VerifyInit.pod
+++ b/doc/man3/EVP_VerifyInit.pod
@@ -68,6 +68,11 @@ Since only a copy of the digest context is ever finalized the context must
 be cleaned up after use by calling EVP_MD_CTX_free() or a memory leak
 will occur.
 
+Note that not all providers allow for continuation, in case the selected
+provider does not allow to duplicate contexts EVP_VerifyFinal() will
+finalize the digest context and attempting to process additional data via
+EVP_VerifyUpdate() will result in an error.
+
 =head1 BUGS
 
 Older versions of this documentation wrongly stated that calls to

--- a/include/crypto/evp.h
+++ b/include/crypto/evp.h
@@ -21,6 +21,7 @@
  * values in evp.h
  */
 #define EVP_MD_CTX_FLAG_KEEP_PKEY_CTX   0x0400
+#define EVP_MD_CTX_FLAG_FINALISED       0x0800
 
 #define evp_pkey_ctx_is_legacy(ctx)                             \
     ((ctx)->keymgmt == NULL)

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -226,7 +226,8 @@ int (*EVP_MD_meth_get_ctrl(const EVP_MD *md))(EVP_MD_CTX *ctx, int cmd,
  * if the following flag is set.
  */
 # define EVP_MD_CTX_FLAG_FINALISE        0x0200
-/* NOTE: 0x0400 is reserved for internal usage */
+/* NOTE: 0x0400 and 0x0800 are reserved for internal usage */
+
 # ifndef OPENSSL_NO_DEPRECATED_3_0
 OSSL_DEPRECATEDIN_3_0
 EVP_CIPHER *EVP_CIPHER_meth_new(int cipher_type, int block_size, int key_len);

--- a/test/build.info
+++ b/test/build.info
@@ -180,7 +180,7 @@ IF[{- !$disabled{tests} -}]
     DEFINE[evp_test]=NO_LEGACY_MODULE
   ENDIF
 
-  SOURCE[evp_extra_test]=evp_extra_test.c
+  SOURCE[evp_extra_test]=evp_extra_test.c fake_rsaprov.c
   INCLUDE[evp_extra_test]=../include ../apps/include
   DEPEND[evp_extra_test]=../libcrypto.a libtestutil.a
 


### PR DESCRIPTION
If the ctx was *really* needed we'll probably fail later with an error anyway, so no point in failing immediately.

In most cases users will actually not follow-up with additional requests, so by failing later we will allow more use cases when a provider can't support duplication.

Fixes #20364 

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
