### PR TITLE
ec: Use .machine "any" explicitly in ecp_nistp521-ppc64

### DIFF
--- a/crypto/ec/asm/ecp_nistp521-ppc64.pl
+++ b/crypto/ec/asm/ecp_nistp521-ppc64.pl
@@ -140,6 +140,7 @@ ___
 }
 
 $code.=<<___;
+.machine	"any"
 .text
 
 ___


### PR DESCRIPTION
Since GCC commit e154242724b084380e3221df7c08fcdbd8460674 the flag "-many" is sometimes not passed to the assembler. Use .machine "any" just like ecp_nistz256-ppc64 to prevent compile errors when built with some configurations of GCC.
