### PR TITLE
The FIPS provider will not support AES SIV mode ciphers

### DIFF
--- a/doc/man7/EVP_CIPHER-AES.pod
+++ b/doc/man7/EVP_CIPHER-AES.pod
@@ -29,8 +29,6 @@ default provider:
 
 =item "AES-192-OFB", "AES-128-OFB" and "AES-256-OFB"
 
-=item "AES-128-GCM-SIV", "AES-192-GCM-SIV" and "AES-256-GCM-SIV"
-
 =item "AES-128-XTS" and "AES-256-XTS"
 
 =item "AES-128-CCM", "AES-192-CCM" and "AES-256-CCM"
@@ -55,6 +53,8 @@ FIPS provider:
 =item "AES-128-OCB", "AES-192-OCB" and "AES-256-OCB"
 
 =item "AES-128-SIV", "AES-192-SIV" and "AES-256-SIV"
+
+=item "AES-128-GCM-SIV", "AES-192-GCM-SIV" and "AES-256-GCM-SIV"
 
 =back
 

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -297,11 +297,6 @@ static const OSSL_ALGORITHM_CAPABLE fips_ciphers[] = {
     ALG(PROV_NAMES_AES_128_CTR, ossl_aes128ctr_functions),
     ALG(PROV_NAMES_AES_256_XTS, ossl_aes256xts_functions),
     ALG(PROV_NAMES_AES_128_XTS, ossl_aes128xts_functions),
-#ifndef OPENSSL_NO_SIV
-    ALG(PROV_NAMES_AES_128_GCM_SIV, ossl_aes128gcm_siv_functions),
-    ALG(PROV_NAMES_AES_192_GCM_SIV, ossl_aes192gcm_siv_functions),
-    ALG(PROV_NAMES_AES_256_GCM_SIV, ossl_aes256gcm_siv_functions),
-#endif /* OPENSSL_NO_SIV */
     ALG(PROV_NAMES_AES_256_GCM, ossl_aes256gcm_functions),
     ALG(PROV_NAMES_AES_192_GCM, ossl_aes192gcm_functions),
     ALG(PROV_NAMES_AES_128_GCM, ossl_aes128gcm_functions),

--- a/providers/implementations/ciphers/build.info
+++ b/providers/implementations/ciphers/build.info
@@ -25,7 +25,7 @@ $SM4_GOAL=../../libdefault.a
 $CHACHA_GOAL=../../libdefault.a
 $CHACHAPOLY_GOAL=../../libdefault.a
 $SIV_GOAL=../../libdefault.a
-$SIV_GCM_GOAL=../../libdefault.a ../../libfips.a
+$SIV_GCM_GOAL=../../libdefault.a
 
 IF[{- !$disabled{asm} -}]
   $GHASHDEF_x86=GHASH_ASM

--- a/test/recipes/30-test_evp.t
+++ b/test/recipes/30-test_evp.t
@@ -80,7 +80,6 @@ push @files, qw(
                 evppkey_kas.txt
                 evppkey_mismatch.txt
                ) unless $no_ec;
-push @files, qw(evpciph_aes_gcm_siv.txt) unless $no_siv;
 
 # A list of tests that only run with the default provider
 # (i.e. The algorithms are not present in the fips provider)
@@ -125,6 +124,7 @@ push @defltfiles, qw(evppkey_brainpool.txt) unless $no_ec;
 push @defltfiles, qw(evppkey_ecdsa_rfc6979.txt) unless $no_ec;
 push @defltfiles, qw(evppkey_dsa_rfc6979.txt) unless $no_dsa;
 push @defltfiles, qw(evppkey_sm2.txt) unless $no_sm2;
+push @defltfiles, qw(evpciph_aes_gcm_siv.txt) unless $no_siv;
 push @defltfiles, qw(evpciph_aes_siv.txt) unless $no_siv;
 
 plan tests =>


### PR DESCRIPTION

- [x] documentation is added or updated
- [x] tests are added or updated
