### PR TITLE
Fix early_data age calculation

### DIFF
--- a/ssl/statem/extensions_srvr.c
+++ b/ssl/statem/extensions_srvr.c
@@ -1155,16 +1155,18 @@ int tls_parse_ctos_psk(SSL_CONNECTION *s, PACKET *pkt, unsigned int context,
                 continue;
             }
 
-            age = ossl_time_subtract(ossl_seconds2time(ticket_agel),
-                                     ossl_seconds2time(sess->ext.tick_age_add));
+            age = ossl_time_subtract(ossl_ms2time(ticket_agel),
+                                     ossl_ms2time(sess->ext.tick_age_add));
             t = ossl_time_subtract(ossl_time_now(), sess->time);
 
             /*
-             * Beause we use second granuality, it could appear that
-             * the client's ticket age is longer than ours (our ticket
-             * age calculation should always be slightly longer than the
-             * client's due to the network latency).  Therefore we add
-             * 1000ms to our age calculation to adjust for rounding errors.
+             * Although internally we use OSS_TIME which has ns granularity,
+             * when SSL_SESSION structures are serialised/deserialised we use
+             * second granularity for the sess->time field. Therefore it could
+             * appear that the client's ticket age is longer than ours (our
+             * ticket age calculation should always be slightly longer than the
+             * client's due to the network latency). Therefore we add 1000ms to
+             * our age calculation to adjust for rounding errors.
              */
             expire = ossl_time_add(t, ossl_ms2time(1000));
 


### PR DESCRIPTION
While converting libssl in master to use OSSL_TIME we introduced a confusion between ms and seconds. This meant that ticket age was being miscalculated as 1000 times bigger than it actually was - leading to early data never being accepted because the ticket is too old.

We fix that and also clarify a nearby comment which might have been the source of the confusion.

Although we have extensive early_data tests this was never being caught because the tests run so quickly that the ticket age was always coming out as close to zero. 1000 times zero is still zero, so the tickets were still being accepted. We modify some of the tests to introduce some artificial age to exercise the age calculations better.

