### PR TITLE
Add support for rstream get/release record in the QUIC TLS layer

### DIFF
--- a/include/internal/quic_tls.h
+++ b/include/internal/quic_tls.h
@@ -32,9 +32,18 @@ typedef struct quic_tls_args_st {
     int (*crypto_send_cb)(const unsigned char *buf, size_t buf_len,
                           size_t *consumed, void *arg);
     void *crypto_send_cb_arg;
-    int (*crypto_recv_cb)(unsigned char *buf, size_t buf_len,
-                          size_t *bytes_read, void *arg);
-    void *crypto_recv_cb_arg;
+
+    /*
+     * Call to receive crypto stream data. A pointer to the underlying buffer
+     * is provided, and subsequently released to avoid unnecessary copying of
+     * data.
+     */
+    int (*crypto_recv_rcd_cb)(const unsigned char **buf, size_t *bytes_read,
+                              void *arg);
+    void *crypto_recv_rcd_cb_arg;
+    int (*crypto_release_rcd_cb)(size_t bytes_read, void *arg);
+    void *crypto_release_rcd_cb_arg;
+
 
     /* Called when a traffic secret is available for a given encryption level. */
     int (*yield_secret_cb)(uint32_t enc_level, int direction /* 0=RX, 1=TX */,

--- a/include/internal/recordmethod.h
+++ b/include/internal/recordmethod.h
@@ -225,7 +225,8 @@ struct ossl_record_method_st {
      * filled in with the epoch and sequence number from the record.
      * An opaque record layer handle for the record is returned in |*rechandle|
      * which is used in a subsequent call to |release_record|. The buffer must
-     * remain available until release_record is called.
+     * remain available until all the bytes from record are released via one or
+     * more release_record calls.
      *
      * Internally the the OSSL_RECORD_METHOD the implementation may read/process
      * multiple records in one go and buffer them.
@@ -234,11 +235,12 @@ struct ossl_record_method_st {
                       int *type, const unsigned char **data, size_t *datalen,
                       uint16_t *epoch, unsigned char *seq_num);
     /*
-     * Release a buffer associated with a record previously read with
-     * read_record. Records are guaranteed to be released in the order that they
-     * are read.
+     * Release length bytes from a buffer associated with a record previously
+     * read with read_record. Once all the bytes from a record are released, the
+     * whole record and its associated buffer is released. Records are
+     * guaranteed to be released in the order that they are read.
      */
-    int (*release_record)(OSSL_RECORD_LAYER *rl, void *rechandle);
+    int (*release_record)(OSSL_RECORD_LAYER *rl, void *rechandle, size_t length);
 
     /*
      * In the event that a fatal error is returned from the functions above then

--- a/include/internal/recordmethod.h
+++ b/include/internal/recordmethod.h
@@ -231,7 +231,7 @@ struct ossl_record_method_st {
      * multiple records in one go and buffer them.
      */
     int (*read_record)(OSSL_RECORD_LAYER *rl, void **rechandle, int *rversion,
-                      int *type, unsigned char **data, size_t *datalen,
+                      int *type, const unsigned char **data, size_t *datalen,
                       uint16_t *epoch, unsigned char *seq_num);
     /*
      * Release a buffer associated with a record previously read with

--- a/ssl/quic/quic_channel.c
+++ b/ssl/quic/quic_channel.c
@@ -50,8 +50,9 @@ static int ch_on_handshake_yield_secret(uint32_t enc_level, int direction,
                                         const unsigned char *secret,
                                         size_t secret_len,
                                         void *arg);
-static int ch_on_crypto_recv(unsigned char *buf, size_t buf_len,
-                             size_t *bytes_read, void *arg);
+static int ch_on_crypto_recv_record(const unsigned char **buf,
+                                    size_t *bytes_read, void *arg);
+static int ch_on_crypto_release_record(size_t bytes_read, void *arg);
 static int crypto_ensure_empty(QUIC_RSTREAM *rstream);
 static int ch_on_crypto_send(const unsigned char *buf, size_t buf_len,
                              size_t *consumed, void *arg);
@@ -237,8 +238,10 @@ static int ch_init(QUIC_CHANNEL *ch)
     tls_args.s                          = ch->tls;
     tls_args.crypto_send_cb             = ch_on_crypto_send;
     tls_args.crypto_send_cb_arg         = ch;
-    tls_args.crypto_recv_cb             = ch_on_crypto_recv;
-    tls_args.crypto_recv_cb_arg         = ch;
+    tls_args.crypto_recv_rcd_cb         = ch_on_crypto_recv_record;
+    tls_args.crypto_recv_rcd_cb_arg     = ch;
+    tls_args.crypto_release_rcd_cb      = ch_on_crypto_release_record;
+    tls_args.crypto_release_rcd_cb_arg  = ch;
     tls_args.yield_secret_cb            = ch_on_handshake_yield_secret;
     tls_args.yield_secret_cb_arg        = ch;
     tls_args.got_transport_params_cb    = ch_on_transport_params;
@@ -504,8 +507,8 @@ static int crypto_ensure_empty(QUIC_RSTREAM *rstream)
     return avail == 0;
 }
 
-static int ch_on_crypto_recv(unsigned char *buf, size_t buf_len,
-                             size_t *bytes_read, void *arg)
+static int ch_on_crypto_recv_record(const unsigned char **buf,
+                                    size_t *bytes_read, void *arg)
 {
     QUIC_CHANNEL *ch = arg;
     QUIC_RSTREAM *rstream;
@@ -539,8 +542,20 @@ static int ch_on_crypto_recv(unsigned char *buf, size_t buf_len,
     if (rstream == NULL)
         return 0;
 
-    return ossl_quic_rstream_read(rstream, buf, buf_len, bytes_read,
-                                  &is_fin);
+    return ossl_quic_rstream_get_record(rstream, buf, bytes_read,
+                                        &is_fin);
+}
+
+static int ch_on_crypto_release_record(size_t bytes_read, void *arg)
+{
+    QUIC_CHANNEL *ch = arg;
+    QUIC_RSTREAM *rstream;
+
+    rstream = ch->crypto_recv[ossl_quic_enc_level_to_pn_space(ch->rx_enc_level)];
+    if (rstream == NULL)
+        return 0;
+
+    return ossl_quic_rstream_release_record(rstream, bytes_read);
 }
 
 static int ch_on_handshake_yield_secret(uint32_t enc_level, int direction,

--- a/ssl/quic/quic_tls.c
+++ b/ssl/quic/quic_tls.c
@@ -54,18 +54,12 @@ struct ossl_record_layer_st {
     OSSL_RECORD_TEMPLATE template;
 
     /*
-     * Temp buffer for storing received data (copied from the stream receive
-     * buffer)
-     */
-    unsigned char recbuf[SSL3_RT_MAX_PLAIN_LENGTH];
-
-    /*
      * If we hit an error, what alert code should be used
      */
     int alert;
 
-    /* Set if recbuf is populated with data */
-    unsigned int recread : 1;
+    /* Amount of crypto stream data we have received but not yet released  */
+    size_t recread;
 
     /* Callbacks */
     OSSL_FUNC_rlayer_msg_callback_fn *msg_callback;
@@ -348,11 +342,11 @@ static int quic_read_record(OSSL_RECORD_LAYER *rl, void **rechandle,
     BIO_clear_retry_flags(rl->dummybio);
 
     /*
-     * TODO(QUIC): There seems to be an unnecessary copy here. It would be
-     *             better to send back a ref direct to the underlying buffer
+     * TODO(QUIC): Cast data to const, which should be safe....can read_record
+     * be modified to pass this as const to start with?
      */
-    if (!rl->qtls->args.crypto_recv_cb(rl->recbuf, sizeof(rl->recbuf), datalen,
-                                       rl->qtls->args.crypto_recv_cb_arg)) {
+    if (!rl->qtls->args.crypto_recv_rcd_cb((const unsigned char **)data, datalen,
+                                           rl->qtls->args.crypto_recv_rcd_cb_arg)) {
         QUIC_TLS_FATAL(rl, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
         return OSSL_RECORD_RETURN_FATAL;
     }
@@ -365,8 +359,7 @@ static int quic_read_record(OSSL_RECORD_LAYER *rl, void **rechandle,
     *rechandle = rl;
     *rversion = TLS1_3_VERSION;
     *type = SSL3_RT_HANDSHAKE;
-    *data = rl->recbuf;
-    rl->recread = 1;
+    rl->recread = *datalen;
     /* epoch/seq_num are not relevant for TLS */
 
     if (rl->msg_callback != NULL) {
@@ -399,10 +392,17 @@ static int quic_read_record(OSSL_RECORD_LAYER *rl, void **rechandle,
 
 static int quic_release_record(OSSL_RECORD_LAYER *rl, void *rechandle)
 {
-    if (!ossl_assert(rl->recread == 1) || !ossl_assert(rl == rechandle)) {
+    if (!ossl_assert(rl->recread > 0) || !ossl_assert(rl == rechandle)) {
         QUIC_TLS_FATAL(rl, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
         return 0;
     }
+
+    if (!rl->qtls->args.crypto_release_rcd_cb(rl->recread,
+                                              rl->qtls->args.crypto_release_rcd_cb_arg)) {
+        QUIC_TLS_FATAL(rl, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
+        return OSSL_RECORD_RETURN_FATAL;
+    }
+
 
     rl->recread = 0;
     return 1;
@@ -602,7 +602,8 @@ QUIC_TLS *ossl_quic_tls_new(const QUIC_TLS_ARGS *args)
     QUIC_TLS *qtls;
 
     if (args->crypto_send_cb == NULL
-        || args->crypto_recv_cb == NULL) {
+        || args->crypto_recv_rcd_cb == NULL
+        || args->crypto_release_rcd_cb == NULL) {
         ERR_raise(ERR_LIB_SSL, ERR_R_PASSED_NULL_PARAMETER);
         return NULL;
     }

--- a/ssl/quic/quic_tls.c
+++ b/ssl/quic/quic_tls.c
@@ -332,7 +332,7 @@ static int quic_retry_write_records(OSSL_RECORD_LAYER *rl)
 }
 
 static int quic_read_record(OSSL_RECORD_LAYER *rl, void **rechandle,
-                            int *rversion, int *type, unsigned char **data,
+                            int *rversion, int *type, const unsigned char **data,
                             size_t *datalen, uint16_t *epoch,
                             unsigned char *seq_num)
 {
@@ -341,11 +341,7 @@ static int quic_read_record(OSSL_RECORD_LAYER *rl, void **rechandle,
 
     BIO_clear_retry_flags(rl->dummybio);
 
-    /*
-     * TODO(QUIC): Cast data to const, which should be safe....can read_record
-     * be modified to pass this as const to start with?
-     */
-    if (!rl->qtls->args.crypto_recv_rcd_cb((const unsigned char **)data, datalen,
+    if (!rl->qtls->args.crypto_recv_rcd_cb(data, datalen,
                                            rl->qtls->args.crypto_recv_rcd_cb_arg)) {
         QUIC_TLS_FATAL(rl, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
         return OSSL_RECORD_RETURN_FATAL;

--- a/ssl/record/methods/recmethod_local.h
+++ b/ssl/record/methods/recmethod_local.h
@@ -459,7 +459,7 @@ int tls_retry_write_records(OSSL_RECORD_LAYER *rl);
 int tls_get_alert_code(OSSL_RECORD_LAYER *rl);
 int tls_set1_bio(OSSL_RECORD_LAYER *rl, BIO *bio);
 int tls_read_record(OSSL_RECORD_LAYER *rl, void **rechandle, int *rversion,
-                    int *type, unsigned char **data, size_t *datalen,
+                    int *type, const unsigned char **data, size_t *datalen,
                     uint16_t *epoch, unsigned char *seq_num);
 int tls_release_record(OSSL_RECORD_LAYER *rl, void *rechandle);
 int tls_default_set_protocol_version(OSSL_RECORD_LAYER *rl, int version);

--- a/ssl/record/methods/recmethod_local.h
+++ b/ssl/record/methods/recmethod_local.h
@@ -461,7 +461,7 @@ int tls_set1_bio(OSSL_RECORD_LAYER *rl, BIO *bio);
 int tls_read_record(OSSL_RECORD_LAYER *rl, void **rechandle, int *rversion,
                     int *type, const unsigned char **data, size_t *datalen,
                     uint16_t *epoch, unsigned char *seq_num);
-int tls_release_record(OSSL_RECORD_LAYER *rl, void *rechandle);
+int tls_release_record(OSSL_RECORD_LAYER *rl, void *rechandle, size_t length);
 int tls_default_set_protocol_version(OSSL_RECORD_LAYER *rl, int version);
 int tls_set_protocol_version(OSSL_RECORD_LAYER *rl, int version);
 void tls_set_plain_alerts(OSSL_RECORD_LAYER *rl, int allow);

--- a/ssl/record/methods/tls_common.c
+++ b/ssl/record/methods/tls_common.c
@@ -1088,7 +1088,7 @@ int tls13_common_post_process_record(OSSL_RECORD_LAYER *rl, TLS_RL_RECORD *rec)
 }
 
 int tls_read_record(OSSL_RECORD_LAYER *rl, void **rechandle, int *rversion,
-                    int *type, unsigned char **data, size_t *datalen,
+                    int *type, const unsigned char **data, size_t *datalen,
                     uint16_t *epoch, unsigned char *seq_num)
 {
     TLS_RL_RECORD *rec;

--- a/ssl/record/methods/tls_common.c
+++ b/ssl/record/methods/tls_common.c
@@ -1132,14 +1132,31 @@ int tls_read_record(OSSL_RECORD_LAYER *rl, void **rechandle, int *rversion,
     return OSSL_RECORD_RETURN_SUCCESS;
 }
 
-int tls_release_record(OSSL_RECORD_LAYER *rl, void *rechandle)
+int tls_release_record(OSSL_RECORD_LAYER *rl, void *rechandle, size_t length)
 {
+    TLS_RL_RECORD *rec = &rl->rrec[rl->num_released];
+
     if (!ossl_assert(rl->num_released < rl->curr_rec)
-            || !ossl_assert(rechandle == &rl->rrec[rl->num_released])) {
+            || !ossl_assert(rechandle == rec)) {
         /* Should not happen */
         RLAYERfatal(rl, SSL_AD_INTERNAL_ERROR, SSL_R_INVALID_RECORD);
         return OSSL_RECORD_RETURN_FATAL;
     }
+
+    if (rec->length < length) {
+        /* Should not happen */
+        RLAYERfatal(rl, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
+        return OSSL_RECORD_RETURN_FATAL;
+    }
+
+    if ((rl->options & SSL_OP_CLEANSE_PLAINTEXT) != 0)
+        OPENSSL_cleanse(rec->data + rec->off, length);
+
+    rec->off += length;
+    rec->length -= length;
+
+    if (rec->length > 0)
+        return OSSL_RECORD_RETURN_SUCCESS;
 
     rl->num_released++;
 

--- a/ssl/record/rec_layer_d1.c
+++ b/ssl/record/rec_layer_d1.c
@@ -58,9 +58,10 @@ void DTLS_RECORD_LAYER_clear(RECORD_LAYER *rl)
 
     while ((item = pqueue_pop(d->buffered_app_data.q)) != NULL) {
         rec = (TLS_RECORD *)item->data;
+
         if (rl->s->options & SSL_OP_CLEANSE_PLAINTEXT)
-            OPENSSL_cleanse(rec->data, rec->length);
-        OPENSSL_free(rec->data);
+            OPENSSL_cleanse(rec->allocdata, rec->length);
+        OPENSSL_free(rec->allocdata);
         OPENSSL_free(item->data);
         pitem_free(item);
     }
@@ -99,7 +100,7 @@ static int dtls_buffer_record(SSL_CONNECTION *s, TLS_RECORD *rec)
      * now. Copying data isn't good - but this should be infrequent so we
      * accept it here.
      */
-    rdata->data = OPENSSL_memdup(rec->data, rec->length);
+    rdata->data = rdata->allocdata = OPENSSL_memdup(rec->data, rec->length);
     if (rdata->data == NULL) {
         OPENSSL_free(rdata);
         pitem_free(item);
@@ -126,7 +127,7 @@ static int dtls_buffer_record(SSL_CONNECTION *s, TLS_RECORD *rec)
 
     if (pqueue_insert(queue->q, item) == NULL) {
         /* Must be a duplicate so ignore it */
-        OPENSSL_free(rdata->data);
+        OPENSSL_free(rdata->allocdata);
         OPENSSL_free(rdata);
         pitem_free(item);
     }
@@ -349,8 +350,9 @@ int dtls1_read_bytes(SSL *s, int type, int *recvd_type, unsigned char *buf,
             if (rr->length == 0)
                 ssl_release_record(sc, rr);
         } else {
+            /* TODO(RECLAYER): Casting away the const is wrong! FIX ME */
             if (sc->options & SSL_OP_CLEANSE_PLAINTEXT)
-                OPENSSL_cleanse(&(rr->data[rr->off]), n);
+                OPENSSL_cleanse((unsigned char *)&(rr->data[rr->off]), n);
             rr->length -= n;
             rr->off += n;
             if (rr->length == 0)
@@ -380,7 +382,7 @@ int dtls1_read_bytes(SSL *s, int type, int *recvd_type, unsigned char *buf,
 
     if (rr->type == SSL3_RT_ALERT) {
         unsigned int alert_level, alert_descr;
-        unsigned char *alert_bytes = rr->data + rr->off;
+        const unsigned char *alert_bytes = rr->data + rr->off;
         PACKET alert;
 
         if (!PACKET_buf_init(&alert, alert_bytes, rr->length)

--- a/ssl/record/record.h
+++ b/ssl/record/record.h
@@ -24,7 +24,12 @@ typedef struct tls_record_st {
     int version;
     int type;
     /* The data buffer containing bytes from the record */
-    unsigned char *data;
+    const unsigned char *data;
+    /*
+     * Buffer that we allocated to store data. If non NULL always the same as
+     * data (but non-const)
+     */
+    unsigned char *allocdata;
     /* Number of remaining to be read in the data buffer */
     size_t length;
     /* Offset into the data buffer where to start reading */

--- a/ssl/record/record.h
+++ b/ssl/record/record.h
@@ -165,7 +165,7 @@ __owur int dtls1_write_bytes(SSL_CONNECTION *s, int type, const void *buf,
 int do_dtls1_write(SSL_CONNECTION *s, int type, const unsigned char *buf,
                    size_t len, size_t *written);
 void dtls1_increment_epoch(SSL_CONNECTION *s, int rw);
-void ssl_release_record(SSL_CONNECTION *s, TLS_RECORD *rr);
+int ssl_release_record(SSL_CONNECTION *s, TLS_RECORD *rr, size_t length);
 
 # define HANDLE_RLAYER_READ_RETURN(s, ret) \
     ossl_tls_handle_rlayer_return(s, 0, ret, OPENSSL_FILE, OPENSSL_LINE)

--- a/ssl/ssl_local.h
+++ b/ssl/ssl_local.h
@@ -2602,7 +2602,7 @@ __owur int dtls1_get_queue_priority(unsigned short seq, int is_ccs);
 int dtls1_retransmit_buffered_messages(SSL_CONNECTION *s);
 void dtls1_clear_received_buffer(SSL_CONNECTION *s);
 void dtls1_clear_sent_buffer(SSL_CONNECTION *s);
-void dtls1_get_message_header(unsigned char *data,
+void dtls1_get_message_header(const unsigned char *data,
                               struct hm_header_st *msg_hdr);
 __owur OSSL_TIME dtls1_default_timeout(void);
 __owur OSSL_TIME *dtls1_get_timeout(SSL_CONNECTION *s, OSSL_TIME *timeleft);

--- a/ssl/statem/statem_dtls.c
+++ b/ssl/statem/statem_dtls.c
@@ -1301,7 +1301,8 @@ static unsigned char *dtls1_write_message_header(SSL_CONNECTION *s,
     return p;
 }
 
-void dtls1_get_message_header(unsigned char *data, struct hm_header_st *msg_hdr)
+void dtls1_get_message_header(const unsigned char *data, struct
+                              hm_header_st *msg_hdr)
 {
     memset(msg_hdr, 0, sizeof(*msg_hdr));
     msg_hdr->type = *(data++);

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -1701,7 +1701,7 @@ static int execute_cleanse_plaintext(const SSL_METHOD *smeth,
     SSL_CTX *cctx = NULL, *sctx = NULL;
     SSL *clientssl = NULL, *serverssl = NULL;
     int testresult = 0;
-    void *zbuf;
+    const unsigned char *zbuf;
     SSL_CONNECTION *serversc;
     TLS_RECORD *rr;
 


### PR DESCRIPTION
The QUIC TLS layer was taking an internal copy of rstream data while reading. The QUIC rstream code has recently been extended to enable a get/release model which avoids the need for this internal copy, so we use that instead.

We also make the "data" field of the TLS record layer "get_record" function "const". This improves consistency with the QUIC rstream implementation - and improves the abstraction between the TLS implementation and the abstract record layer. We should not expect that the TLS implementation should be able to change the underlying buffer. Future record layers may not expect that.

This is built on the commits in #19794, and is therefore draft until that PR has been merged.