### PR TITLE
Fixes #20145: free memory of certStatus before goto err

### DIFF
--- a/crypto/cmp/cmp_msg.c
+++ b/crypto/cmp/cmp_msg.c
@@ -817,8 +817,13 @@ OSSL_CMP_MSG *ossl_cmp_certConf_new(OSSL_CMP_CTX *ctx, int fail_info,
     if ((certStatus = OSSL_CMP_CERTSTATUS_new()) == NULL)
         goto err;
     /* consume certStatus into msg right away so it gets deallocated with msg */
-    if (!sk_OSSL_CMP_CERTSTATUS_push(msg->body->value.certConf, certStatus))
+    if (sk_OSSL_CMP_CERTSTATUS_push(msg->body->value.certConf, certStatus) < 1) {
+    /*
+     * It hasn't been consumed by the msg at this point of time,
+     * so we should free certStatus */
+        OSSL_CMP_CERTSTATUS_free(certStatus);
         goto err;
+    }
     /* set the ID of the certReq */
     if (!ASN1_INTEGER_set(certStatus->certReqId, OSSL_CMP_CERTREQID))
         goto err;


### PR DESCRIPTION
I have fix the issue #20145 with freeing memory of certStatus and changed the condition as asked in the issue.
I changed :
```cpp
/* consume certStatus into msg right away so it gets deallocated with msg */ 
if (!sk_OSSL_CMP_CERTSTATUS_push(msg->body->value.certConf, certStatus)) 
    goto err; 
```
Into : 
```cpp
/* consume certStatus into msg right away so it gets deallocated with msg */ 
if (sk_OSSL_CMP_CERTSTATUS_push(msg->body->value.certConf, certStatus) < 1) {
/*
 * It hasn't been consumed by the msg at this point of time,
 * so we should free certStatus */
    OSSL_CMP_CERTSTATUS_free(certStatus);
    goto err;
}

```