### PR TITLE
Coverity 1521557: Error handling issues

### DIFF
--- a/crypto/dsa/dsa_backend.c
+++ b/crypto/dsa/dsa_backend.c
@@ -173,7 +173,10 @@ DSA *ossl_dsa_key_from_pkcs8(const PKCS8_PRIV_KEY_INFO *p8inf,
         ERR_raise(ERR_LIB_DSA, DSA_R_BN_ERROR);
         goto dsaerr;
     }
-    DSA_set0_key(dsa, dsa_pubkey, dsa_privkey);
+    if (!DSA_set0_key(dsa, dsa_pubkey, dsa_privkey)) {
+        ERR_raise(ERR_LIB_DSA, ERR_R_BN_LIB);
+        goto dsaerr;
+    }
 
     goto done;
 

--- a/crypto/dsa/dsa_backend.c
+++ b/crypto/dsa/dsa_backend.c
@@ -174,7 +174,7 @@ DSA *ossl_dsa_key_from_pkcs8(const PKCS8_PRIV_KEY_INFO *p8inf,
         goto dsaerr;
     }
     if (!DSA_set0_key(dsa, dsa_pubkey, dsa_privkey)) {
-        ERR_raise(ERR_LIB_DSA, ERR_R_BN_LIB);
+        ERR_raise(ERR_LIB_DSA, ERR_R_INTERNAL_ERROR);
         goto dsaerr;
     }
 


### PR DESCRIPTION
Check the return from DSA_set0_key and generate an error on failure.
Technically a false positive since the function always returns success.

- [ ] documentation is added or updated
- [ ] tests are added or updated
