### PR TITLE
Improve the performance of EVP_PKCS82PKEY_ex

### DIFF
--- a/crypto/evp/evp_pkey.c
+++ b/crypto/evp/evp_pkey.c
@@ -75,9 +75,12 @@ EVP_PKEY *EVP_PKCS82PKEY_ex(const PKCS8_PRIV_KEY_INFO *p8, OSSL_LIB_CTX *libctx,
     OSSL_DECODER_CTX *dctx = NULL;
     const ASN1_OBJECT *algoid = NULL;
     const char *keytype = NULL;
+    char keytypebuf[80];
 
-    if (PKCS8_pkey_get0(&algoid, NULL, NULL, NULL, p8))
-        keytype = OBJ_nid2sn(OBJ_obj2nid(algoid));
+    if (PKCS8_pkey_get0(&algoid, NULL, NULL, NULL, p8)) {
+        if (OBJ_obj2txt(keytypebuf, sizeof(keytypebuf), algoid, 0))
+            keytype = keytypebuf;
+    }
     /*
      * else we don't know the OID...carry on anyway to see if we may have a
      * decoder that can handle it anyway

--- a/crypto/evp/evp_pkey.c
+++ b/crypto/evp/evp_pkey.c
@@ -91,8 +91,7 @@ EVP_PKEY *EVP_PKCS82PKEY_ex(const PKCS8_PRIV_KEY_INFO *p8, OSSL_LIB_CTX *libctx,
     dctx = OSSL_DECODER_CTX_new_for_pkey(&pkey, "DER", "PrivateKeyInfo",
                                          keytype, selection, libctx, propq);
 
-    /* OSSL_DECODER_CTX_get_num_decoders() correctly handles a NULL argument */
-    if (OSSL_DECODER_CTX_get_num_decoders(dctx) == 0) {
+    if (dctx != NULL && OSSL_DECODER_CTX_get_num_decoders(dctx) == 0) {
         OSSL_DECODER_CTX_free(dctx);
 
         /*

--- a/crypto/evp/evp_pkey.c
+++ b/crypto/evp/evp_pkey.c
@@ -77,7 +77,8 @@ EVP_PKEY *EVP_PKCS82PKEY_ex(const PKCS8_PRIV_KEY_INFO *p8, OSSL_LIB_CTX *libctx,
     const ASN1_OBJECT *algoid = NULL;
     char keytype[OSSL_MAX_NAME_SIZE];
 
-    if (!PKCS8_pkey_get0(&algoid, NULL, NULL, NULL, p8)
+    if (p8 == NULL
+            || !PKCS8_pkey_get0(&algoid, NULL, NULL, NULL, p8)
             || !OBJ_obj2txt(keytype, sizeof(keytype), algoid, 0))
         return NULL;
 


### PR DESCRIPTION
We can easily find out the keytype which should significantly improve the performance of this function because we don't have to try every loaded decoder.

Partial fix for #20399
