### PR TITLE
3.0 PEM reading perf cherry picks: PR 17881, 18354 and 17921

### DIFF
--- a/crypto/bio/bss_core.c
+++ b/crypto/bio/bss_core.c
@@ -10,6 +10,7 @@
 #include <openssl/core_dispatch.h>
 #include "bio_local.h"
 #include "internal/cryptlib.h"
+#include "crypto/context.h"
 
 typedef struct {
     OSSL_FUNC_BIO_read_ex_fn *c_bio_read_ex;
@@ -21,26 +22,19 @@ typedef struct {
     OSSL_FUNC_BIO_free_fn *c_bio_free;
 } BIO_CORE_GLOBALS;
 
-static void bio_core_globals_free(void *vbcg)
+void ossl_bio_core_globals_free(void *vbcg)
 {
     OPENSSL_free(vbcg);
 }
 
-static void *bio_core_globals_new(OSSL_LIB_CTX *ctx)
+void *ossl_bio_core_globals_new(OSSL_LIB_CTX *ctx)
 {
     return OPENSSL_zalloc(sizeof(BIO_CORE_GLOBALS));
 }
 
-static const OSSL_LIB_CTX_METHOD bio_core_globals_method = {
-    OSSL_LIB_CTX_METHOD_DEFAULT_PRIORITY,
-    bio_core_globals_new,
-    bio_core_globals_free,
-};
-
 static ossl_inline BIO_CORE_GLOBALS *get_globals(OSSL_LIB_CTX *libctx)
 {
-    return ossl_lib_ctx_get_data(libctx, OSSL_LIB_CTX_BIO_CORE_INDEX,
-                                 &bio_core_globals_method);
+    return ossl_lib_ctx_get_data(libctx, OSSL_LIB_CTX_BIO_CORE_INDEX);
 }
 
 static int bio_core_read_ex(BIO *bio, char *data, size_t data_len,

--- a/crypto/core_namemap.c
+++ b/crypto/core_namemap.c
@@ -12,6 +12,7 @@
 #include "crypto/lhash.h"      /* ossl_lh_strcasehash */
 #include "internal/tsan_assist.h"
 #include "internal/sizes.h"
+#include "crypto/context.h"
 
 /*-
  * The namenum entry
@@ -60,7 +61,7 @@ static void namenum_free(NAMENUM_ENTRY *n)
 
 /* OSSL_LIB_CTX_METHOD functions for a namemap stored in a library context */
 
-static void *stored_namemap_new(OSSL_LIB_CTX *libctx)
+void *ossl_stored_namemap_new(OSSL_LIB_CTX *libctx)
 {
     OSSL_NAMEMAP *namemap = ossl_namemap_new();
 
@@ -70,7 +71,7 @@ static void *stored_namemap_new(OSSL_LIB_CTX *libctx)
     return namemap;
 }
 
-static void stored_namemap_free(void *vnamemap)
+void ossl_stored_namemap_free(void *vnamemap)
 {
     OSSL_NAMEMAP *namemap = vnamemap;
 
@@ -80,12 +81,6 @@ static void stored_namemap_free(void *vnamemap)
         ossl_namemap_free(namemap);
     }
 }
-
-static const OSSL_LIB_CTX_METHOD stored_namemap_method = {
-    OSSL_LIB_CTX_METHOD_DEFAULT_PRIORITY,
-    stored_namemap_new,
-    stored_namemap_free,
-};
 
 /*-
  * API functions
@@ -468,8 +463,7 @@ OSSL_NAMEMAP *ossl_namemap_stored(OSSL_LIB_CTX *libctx)
     int nms;
 #endif
     OSSL_NAMEMAP *namemap =
-        ossl_lib_ctx_get_data(libctx, OSSL_LIB_CTX_NAMEMAP_INDEX,
-                              &stored_namemap_method);
+        ossl_lib_ctx_get_data(libctx, OSSL_LIB_CTX_NAMEMAP_INDEX);
 
     if (namemap == NULL)
         return NULL;

--- a/crypto/encode_decode/decoder_meth.c
+++ b/crypto/encode_decode/decoder_meth.c
@@ -17,6 +17,7 @@
 #include "internal/provider.h"
 #include "crypto/decoder.h"
 #include "encoder_local.h"
+#include "crypto/context.h"
 
 /*
  * Decoder can have multiple names, separated with colons in a name string
@@ -65,25 +66,6 @@ void OSSL_DECODER_free(OSSL_DECODER *decoder)
     OPENSSL_free(decoder);
 }
 
-/* Permanent decoder method store, constructor and destructor */
-static void decoder_store_free(void *vstore)
-{
-    ossl_method_store_free(vstore);
-}
-
-static void *decoder_store_new(OSSL_LIB_CTX *ctx)
-{
-    return ossl_method_store_new(ctx);
-}
-
-
-static const OSSL_LIB_CTX_METHOD decoder_store_method = {
-    /* We want decoder_store to be cleaned up before the provider store */
-    OSSL_LIB_CTX_METHOD_PRIORITY_2,
-    decoder_store_new,
-    decoder_store_free,
-};
-
 /* Data to be passed through ossl_method_construct() */
 struct decoder_data_st {
     OSSL_LIB_CTX *libctx;
@@ -120,8 +102,7 @@ static void dealloc_tmp_decoder_store(void *store)
 /* Get the permanent decoder store */
 static OSSL_METHOD_STORE *get_decoder_store(OSSL_LIB_CTX *libctx)
 {
-    return ossl_lib_ctx_get_data(libctx, OSSL_LIB_CTX_DECODER_STORE_INDEX,
-                                 &decoder_store_method);
+    return ossl_lib_ctx_get_data(libctx, OSSL_LIB_CTX_DECODER_STORE_INDEX);
 }
 
 static int reserve_decoder_store(void *store, void *data)

--- a/crypto/encode_decode/decoder_meth.c
+++ b/crypto/encode_decode/decoder_meth.c
@@ -539,6 +539,24 @@ int OSSL_DECODER_is_a(const OSSL_DECODER *decoder, const char *name)
     return 0;
 }
 
+static int resolve_name(OSSL_DECODER *decoder, const char *name)
+{
+    OSSL_LIB_CTX *libctx = ossl_provider_libctx(decoder->base.prov);
+    OSSL_NAMEMAP *namemap = ossl_namemap_stored(libctx);
+
+    return ossl_namemap_name2num(namemap, name);
+}
+
+int ossl_decoder_fast_is_a(OSSL_DECODER *decoder, const char *name, int *id_cache)
+{
+    int id = *id_cache;
+
+    if (id <= 0)
+        *id_cache = id = resolve_name(decoder, name);
+
+    return id > 0 && ossl_decoder_get_number(decoder) == id;
+}
+
 struct do_one_data_st {
     void (*user_fn)(OSSL_DECODER *decoder, void *arg);
     void *user_arg;

--- a/crypto/encode_decode/encoder_local.h
+++ b/crypto/encode_decode/encoder_local.h
@@ -108,6 +108,7 @@ struct ossl_decoder_instance_st {
     void *decoderctx;            /* Never NULL */
     const char *input_type;      /* Never NULL */
     const char *input_structure; /* May be NULL */
+    int input_type_id;
 
     unsigned int flag_input_structure_was_set : 1;
 };
@@ -162,3 +163,6 @@ const OSSL_PROPERTY_LIST *
 ossl_decoder_parsed_properties(const OSSL_DECODER *decoder);
 const OSSL_PROPERTY_LIST *
 ossl_encoder_parsed_properties(const OSSL_ENCODER *encoder);
+
+int ossl_decoder_fast_is_a(OSSL_DECODER *decoder,
+                           const char *name, int *id_cache);

--- a/crypto/encode_decode/encoder_meth.c
+++ b/crypto/encode_decode/encoder_meth.c
@@ -17,6 +17,7 @@
 #include "internal/provider.h"
 #include "crypto/encoder.h"
 #include "encoder_local.h"
+#include "crypto/context.h"
 
 /*
  * Encoder can have multiple names, separated with colons in a name string
@@ -65,25 +66,6 @@ void OSSL_ENCODER_free(OSSL_ENCODER *encoder)
     OPENSSL_free(encoder);
 }
 
-/* Permanent encoder method store, constructor and destructor */
-static void encoder_store_free(void *vstore)
-{
-    ossl_method_store_free(vstore);
-}
-
-static void *encoder_store_new(OSSL_LIB_CTX *ctx)
-{
-    return ossl_method_store_new(ctx);
-}
-
-
-static const OSSL_LIB_CTX_METHOD encoder_store_method = {
-    /* We want encoder_store to be cleaned up before the provider store */
-    OSSL_LIB_CTX_METHOD_PRIORITY_2,
-    encoder_store_new,
-    encoder_store_free,
-};
-
 /* Data to be passed through ossl_method_construct() */
 struct encoder_data_st {
     OSSL_LIB_CTX *libctx;
@@ -120,8 +102,7 @@ static void dealloc_tmp_encoder_store(void *store)
 /* Get the permanent encoder store */
 static OSSL_METHOD_STORE *get_encoder_store(OSSL_LIB_CTX *libctx)
 {
-    return ossl_lib_ctx_get_data(libctx, OSSL_LIB_CTX_ENCODER_STORE_INDEX,
-                                 &encoder_store_method);
+    return ossl_lib_ctx_get_data(libctx, OSSL_LIB_CTX_ENCODER_STORE_INDEX);
 }
 
 static int reserve_encoder_store(void *store, void *data)

--- a/crypto/evp/evp_fetch.c
+++ b/crypto/evp/evp_fetch.c
@@ -23,24 +23,6 @@
 
 #define NAME_SEPARATOR ':'
 
-static void evp_method_store_free(void *vstore)
-{
-    ossl_method_store_free(vstore);
-}
-
-static void *evp_method_store_new(OSSL_LIB_CTX *ctx)
-{
-    return ossl_method_store_new(ctx);
-}
-
-
-static const OSSL_LIB_CTX_METHOD evp_method_store_method = {
-    /* We want evp_method_store to be cleaned up before the provider store */
-    OSSL_LIB_CTX_METHOD_PRIORITY_2,
-    evp_method_store_new,
-    evp_method_store_free,
-};
-
 /* Data to be passed through ossl_method_construct() */
 struct evp_method_data_st {
     OSSL_LIB_CTX *libctx;
@@ -79,8 +61,7 @@ static void *get_tmp_evp_method_store(void *data)
 
 static OSSL_METHOD_STORE *get_evp_method_store(OSSL_LIB_CTX *libctx)
 {
-    return ossl_lib_ctx_get_data(libctx, OSSL_LIB_CTX_EVP_METHOD_STORE_INDEX,
-                                 &evp_method_store_method);
+    return ossl_lib_ctx_get_data(libctx, OSSL_LIB_CTX_EVP_METHOD_STORE_INDEX);
 }
 
 static int reserve_evp_method_store(void *store, void *data)

--- a/crypto/lhash/lhash.c
+++ b/crypto/lhash/lhash.c
@@ -344,18 +344,37 @@ unsigned long OPENSSL_LH_strhash(const char *c)
     return (ret >> 16) ^ ret;
 }
 
+/*
+ * Case insensitive string hashing.
+ *
+ * The lower/upper case bit is masked out (forcing all letters to be capitals).
+ * The major side effect on non-alpha characters is mapping the symbols and
+ * digits into the control character range (which should be harmless).
+ * The duplication (with respect to the hash value) of printable characters
+ * are that '`', '{', '|', '}' and '~' map to '@', '[', '\', ']' and '^'
+ * respectively (which seems tolerable).
+ *
+ * For EBCDIC, the alpha mapping is to lower case, most symbols go to control
+ * characters.  The only duplication is '0' mapping to '^', which is better
+ * than for ASCII.
+ */
 unsigned long ossl_lh_strcasehash(const char *c)
 {
     unsigned long ret = 0;
     long n;
     unsigned long v;
     int r;
+#if defined(CHARSET_EBCDIC) && !defined(CHARSET_EBCDIC_TEST)
+    const long int case_adjust = ~0x40;
+#else
+    const long int case_adjust = ~0x20;
+#endif
 
     if (c == NULL || *c == '\0')
         return ret;
 
     for (n = 0x100; *c != '\0'; n += 0x100) {
-        v = n | ossl_tolower(*c);
+        v = n | (case_adjust & *c);
         r = (int)((v >> 2) ^ v) & 0x0f;
         /* cast to uint64_t to avoid 32 bit shift of 32 bit value */
         ret = (ret << r) | (unsigned long)((uint64_t)ret >> (32 - r));

--- a/crypto/property/defn_cache.c
+++ b/crypto/property/defn_cache.c
@@ -15,6 +15,7 @@
 #include "internal/property.h"
 #include "internal/core.h"
 #include "property_local.h"
+#include "crypto/context.h"
 
 /*
  * Implement a property definition cache.
@@ -47,7 +48,7 @@ static void property_defn_free(PROPERTY_DEFN_ELEM *elem)
     OPENSSL_free(elem);
 }
 
-static void property_defns_free(void *vproperty_defns)
+void ossl_property_defns_free(void *vproperty_defns)
 {
     LHASH_OF(PROPERTY_DEFN_ELEM) *property_defns = vproperty_defns;
 
@@ -58,15 +59,9 @@ static void property_defns_free(void *vproperty_defns)
     }
 }
 
-static void *property_defns_new(OSSL_LIB_CTX *ctx) {
+void *ossl_property_defns_new(OSSL_LIB_CTX *ctx) {
     return lh_PROPERTY_DEFN_ELEM_new(&property_defn_hash, &property_defn_cmp);
 }
-
-static const OSSL_LIB_CTX_METHOD property_defns_method = {
-    OSSL_LIB_CTX_METHOD_DEFAULT_PRIORITY,
-    property_defns_new,
-    property_defns_free,
-};
 
 OSSL_PROPERTY_LIST *ossl_prop_defn_get(OSSL_LIB_CTX *ctx, const char *prop)
 {
@@ -74,8 +69,7 @@ OSSL_PROPERTY_LIST *ossl_prop_defn_get(OSSL_LIB_CTX *ctx, const char *prop)
     LHASH_OF(PROPERTY_DEFN_ELEM) *property_defns;
 
     property_defns = ossl_lib_ctx_get_data(ctx,
-                                           OSSL_LIB_CTX_PROPERTY_DEFN_INDEX,
-                                           &property_defns_method);
+                                           OSSL_LIB_CTX_PROPERTY_DEFN_INDEX);
     if (property_defns == NULL || !ossl_lib_ctx_read_lock(ctx))
         return NULL;
 
@@ -101,8 +95,7 @@ int ossl_prop_defn_set(OSSL_LIB_CTX *ctx, const char *prop,
     int res = 1;
 
     property_defns = ossl_lib_ctx_get_data(ctx,
-                                           OSSL_LIB_CTX_PROPERTY_DEFN_INDEX,
-                                           &property_defns_method);
+                                           OSSL_LIB_CTX_PROPERTY_DEFN_INDEX);
     if (property_defns == NULL)
         return 0;
 

--- a/crypto/property/property.c
+++ b/crypto/property/property.c
@@ -23,6 +23,7 @@
 #include "crypto/lhash.h"
 #include "crypto/sparse_array.h"
 #include "property_local.h"
+#include "crypto/context.h"
 
 /*
  * The number of elements in the query cache before we initiate a flush.
@@ -107,7 +108,7 @@ static void ossl_method_cache_flush_alg(OSSL_METHOD_STORE *store,
 static void ossl_method_cache_flush(OSSL_METHOD_STORE *store, int nid);
 
 /* Global properties are stored per library context */
-static void ossl_ctx_global_properties_free(void *vglobp)
+void ossl_ctx_global_properties_free(void *vglobp)
 {
     OSSL_GLOBAL_PROPERTIES *globp = vglobp;
 
@@ -117,16 +118,10 @@ static void ossl_ctx_global_properties_free(void *vglobp)
     }
 }
 
-static void *ossl_ctx_global_properties_new(OSSL_LIB_CTX *ctx)
+void *ossl_ctx_global_properties_new(OSSL_LIB_CTX *ctx)
 {
     return OPENSSL_zalloc(sizeof(OSSL_GLOBAL_PROPERTIES));
 }
-
-static const OSSL_LIB_CTX_METHOD ossl_ctx_global_properties_method = {
-    OSSL_LIB_CTX_METHOD_DEFAULT_PRIORITY,
-    ossl_ctx_global_properties_new,
-    ossl_ctx_global_properties_free,
-};
 
 OSSL_PROPERTY_LIST **ossl_ctx_global_properties(OSSL_LIB_CTX *libctx,
                                                 int loadconfig)
@@ -137,8 +132,7 @@ OSSL_PROPERTY_LIST **ossl_ctx_global_properties(OSSL_LIB_CTX *libctx,
     if (loadconfig && !OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CONFIG, NULL))
         return NULL;
 #endif
-    globp = ossl_lib_ctx_get_data(libctx, OSSL_LIB_CTX_GLOBAL_PROPERTIES,
-                                  &ossl_ctx_global_properties_method);
+    globp = ossl_lib_ctx_get_data(libctx, OSSL_LIB_CTX_GLOBAL_PROPERTIES);
 
     return globp != NULL ? &globp->list : NULL;
 }
@@ -147,8 +141,7 @@ OSSL_PROPERTY_LIST **ossl_ctx_global_properties(OSSL_LIB_CTX *libctx,
 int ossl_global_properties_no_mirrored(OSSL_LIB_CTX *libctx)
 {
     OSSL_GLOBAL_PROPERTIES *globp
-        = ossl_lib_ctx_get_data(libctx, OSSL_LIB_CTX_GLOBAL_PROPERTIES,
-                                &ossl_ctx_global_properties_method);
+        = ossl_lib_ctx_get_data(libctx, OSSL_LIB_CTX_GLOBAL_PROPERTIES);
 
     return globp != NULL && globp->no_mirrored ? 1 : 0;
 }
@@ -156,8 +149,7 @@ int ossl_global_properties_no_mirrored(OSSL_LIB_CTX *libctx)
 void ossl_global_properties_stop_mirroring(OSSL_LIB_CTX *libctx)
 {
     OSSL_GLOBAL_PROPERTIES *globp
-        = ossl_lib_ctx_get_data(libctx, OSSL_LIB_CTX_GLOBAL_PROPERTIES,
-                                &ossl_ctx_global_properties_method);
+        = ossl_lib_ctx_get_data(libctx, OSSL_LIB_CTX_GLOBAL_PROPERTIES);
 
     if (globp != NULL)
         globp->no_mirrored = 1;

--- a/crypto/property/property_string.c
+++ b/crypto/property/property_string.c
@@ -13,6 +13,7 @@
 #include <openssl/lhash.h>
 #include "crypto/lhash.h"
 #include "property_local.h"
+#include "crypto/context.h"
 
 /*
  * Property strings are a consolidation of all strings seen by the property
@@ -68,7 +69,7 @@ static void property_table_free(PROP_TABLE **pt)
     }
 }
 
-static void property_string_data_free(void *vpropdata)
+void ossl_property_string_data_free(void *vpropdata)
 {
     PROPERTY_STRING_DATA *propdata = vpropdata;
 
@@ -83,7 +84,7 @@ static void property_string_data_free(void *vpropdata)
     OPENSSL_free(propdata);
 }
 
-static void *property_string_data_new(OSSL_LIB_CTX *ctx) {
+void *ossl_property_string_data_new(OSSL_LIB_CTX *ctx) {
     PROPERTY_STRING_DATA *propdata = OPENSSL_zalloc(sizeof(*propdata));
 
     if (propdata == NULL)
@@ -106,15 +107,9 @@ static void *property_string_data_new(OSSL_LIB_CTX *ctx) {
     return propdata;
 
 err:
-    property_string_data_free(propdata);
+    ossl_property_string_data_free(propdata);
     return NULL;
 }
-
-static const OSSL_LIB_CTX_METHOD property_string_data_method = {
-    OSSL_LIB_CTX_METHOD_DEFAULT_PRIORITY,
-    property_string_data_new,
-    property_string_data_free,
-};
 
 static PROPERTY_STRING *new_property_string(const char *s,
                                             OSSL_PROPERTY_IDX *pidx)
@@ -186,8 +181,7 @@ static const char *ossl_property_str(int name, OSSL_LIB_CTX *ctx,
 {
     struct find_str_st findstr;
     PROPERTY_STRING_DATA *propdata
-        = ossl_lib_ctx_get_data(ctx, OSSL_LIB_CTX_PROPERTY_STRING_INDEX,
-                                &property_string_data_method);
+        = ossl_lib_ctx_get_data(ctx, OSSL_LIB_CTX_PROPERTY_STRING_INDEX);
 
     if (propdata == NULL)
         return NULL;
@@ -211,8 +205,7 @@ OSSL_PROPERTY_IDX ossl_property_name(OSSL_LIB_CTX *ctx, const char *s,
                                      int create)
 {
     PROPERTY_STRING_DATA *propdata
-        = ossl_lib_ctx_get_data(ctx, OSSL_LIB_CTX_PROPERTY_STRING_INDEX,
-                                &property_string_data_method);
+        = ossl_lib_ctx_get_data(ctx, OSSL_LIB_CTX_PROPERTY_STRING_INDEX);
 
     if (propdata == NULL)
         return 0;
@@ -230,8 +223,7 @@ OSSL_PROPERTY_IDX ossl_property_value(OSSL_LIB_CTX *ctx, const char *s,
                                       int create)
 {
     PROPERTY_STRING_DATA *propdata
-        = ossl_lib_ctx_get_data(ctx, OSSL_LIB_CTX_PROPERTY_STRING_INDEX,
-                                &property_string_data_method);
+        = ossl_lib_ctx_get_data(ctx, OSSL_LIB_CTX_PROPERTY_STRING_INDEX);
 
     if (propdata == NULL)
         return 0;

--- a/crypto/provider_child.c
+++ b/crypto/provider_child.c
@@ -16,6 +16,7 @@
 #include "internal/provider.h"
 #include "internal/cryptlib.h"
 #include "crypto/evp.h"
+#include "crypto/context.h"
 
 DEFINE_STACK_OF(OSSL_PROVIDER)
 
@@ -33,24 +34,18 @@ struct child_prov_globals {
     OSSL_FUNC_provider_free_fn *c_prov_free;
 };
 
-static void *child_prov_ossl_ctx_new(OSSL_LIB_CTX *libctx)
+void *ossl_child_prov_ctx_new(OSSL_LIB_CTX *libctx)
 {
     return OPENSSL_zalloc(sizeof(struct child_prov_globals));
 }
 
-static void child_prov_ossl_ctx_free(void *vgbl)
+void ossl_child_prov_ctx_free(void *vgbl)
 {
     struct child_prov_globals *gbl = vgbl;
 
     CRYPTO_THREAD_lock_free(gbl->lock);
     OPENSSL_free(gbl);
 }
-
-static const OSSL_LIB_CTX_METHOD child_prov_ossl_ctx_method = {
-    OSSL_LIB_CTX_METHOD_LOW_PRIORITY,
-    child_prov_ossl_ctx_new,
-    child_prov_ossl_ctx_free,
-};
 
 static OSSL_provider_init_fn ossl_child_provider_init;
 
@@ -84,8 +79,7 @@ static int ossl_child_provider_init(const OSSL_CORE_HANDLE *handle,
      */
     ctx = (OSSL_LIB_CTX *)c_get_libctx(handle);
 
-    gbl = ossl_lib_ctx_get_data(ctx, OSSL_LIB_CTX_CHILD_PROVIDER_INDEX,
-                                &child_prov_ossl_ctx_method);
+    gbl = ossl_lib_ctx_get_data(ctx, OSSL_LIB_CTX_CHILD_PROVIDER_INDEX);
     if (gbl == NULL)
         return 0;
 
@@ -103,8 +97,7 @@ static int provider_create_child_cb(const OSSL_CORE_HANDLE *prov, void *cbdata)
     OSSL_PROVIDER *cprov;
     int ret = 0;
 
-    gbl = ossl_lib_ctx_get_data(ctx, OSSL_LIB_CTX_CHILD_PROVIDER_INDEX,
-                                &child_prov_ossl_ctx_method);
+    gbl = ossl_lib_ctx_get_data(ctx, OSSL_LIB_CTX_CHILD_PROVIDER_INDEX);
     if (gbl == NULL)
         return 0;
 
@@ -168,8 +161,7 @@ static int provider_remove_child_cb(const OSSL_CORE_HANDLE *prov, void *cbdata)
     const char *provname;
     OSSL_PROVIDER *cprov;
 
-    gbl = ossl_lib_ctx_get_data(ctx, OSSL_LIB_CTX_CHILD_PROVIDER_INDEX,
-                                &child_prov_ossl_ctx_method);
+    gbl = ossl_lib_ctx_get_data(ctx, OSSL_LIB_CTX_CHILD_PROVIDER_INDEX);
     if (gbl == NULL)
         return 0;
 
@@ -205,8 +197,7 @@ int ossl_provider_init_as_child(OSSL_LIB_CTX *ctx,
     if (ctx == NULL)
         return 0;
 
-    gbl = ossl_lib_ctx_get_data(ctx, OSSL_LIB_CTX_CHILD_PROVIDER_INDEX,
-                                &child_prov_ossl_ctx_method);
+    gbl = ossl_lib_ctx_get_data(ctx, OSSL_LIB_CTX_CHILD_PROVIDER_INDEX);
     if (gbl == NULL)
         return 0;
 
@@ -273,8 +264,7 @@ int ossl_provider_init_as_child(OSSL_LIB_CTX *ctx,
 void ossl_provider_deinit_child(OSSL_LIB_CTX *ctx)
 {
     struct child_prov_globals *gbl
-        = ossl_lib_ctx_get_data(ctx, OSSL_LIB_CTX_CHILD_PROVIDER_INDEX,
-                                &child_prov_ossl_ctx_method);
+        = ossl_lib_ctx_get_data(ctx, OSSL_LIB_CTX_CHILD_PROVIDER_INDEX);
     if (gbl == NULL)
         return;
 
@@ -299,8 +289,7 @@ int ossl_provider_up_ref_parent(OSSL_PROVIDER *prov, int activate)
     const OSSL_CORE_HANDLE *parent_handle;
 
     gbl = ossl_lib_ctx_get_data(ossl_provider_libctx(prov),
-                                OSSL_LIB_CTX_CHILD_PROVIDER_INDEX,
-                                &child_prov_ossl_ctx_method);
+                                OSSL_LIB_CTX_CHILD_PROVIDER_INDEX);
     if (gbl == NULL)
         return 0;
 
@@ -316,8 +305,7 @@ int ossl_provider_free_parent(OSSL_PROVIDER *prov, int deactivate)
     const OSSL_CORE_HANDLE *parent_handle;
 
     gbl = ossl_lib_ctx_get_data(ossl_provider_libctx(prov),
-                                OSSL_LIB_CTX_CHILD_PROVIDER_INDEX,
-                                &child_prov_ossl_ctx_method);
+                                OSSL_LIB_CTX_CHILD_PROVIDER_INDEX);
     if (gbl == NULL)
         return 0;
 

--- a/crypto/provider_conf.c
+++ b/crypto/provider_conf.c
@@ -16,6 +16,7 @@
 #include "internal/provider.h"
 #include "internal/cryptlib.h"
 #include "provider_local.h"
+#include "crypto/context.h"
 
 DEFINE_STACK_OF(OSSL_PROVIDER)
 
@@ -26,7 +27,7 @@ typedef struct {
     STACK_OF(OSSL_PROVIDER) *activated_providers;
 } PROVIDER_CONF_GLOBAL;
 
-static void *prov_conf_ossl_ctx_new(OSSL_LIB_CTX *libctx)
+void *ossl_prov_conf_ctx_new(OSSL_LIB_CTX *libctx)
 {
     PROVIDER_CONF_GLOBAL *pcgbl = OPENSSL_zalloc(sizeof(*pcgbl));
 
@@ -42,7 +43,7 @@ static void *prov_conf_ossl_ctx_new(OSSL_LIB_CTX *libctx)
     return pcgbl;
 }
 
-static void prov_conf_ossl_ctx_free(void *vpcgbl)
+void ossl_prov_conf_ctx_free(void *vpcgbl)
 {
     PROVIDER_CONF_GLOBAL *pcgbl = vpcgbl;
 
@@ -53,13 +54,6 @@ static void prov_conf_ossl_ctx_free(void *vpcgbl)
     CRYPTO_THREAD_lock_free(pcgbl->lock);
     OPENSSL_free(pcgbl);
 }
-
-static const OSSL_LIB_CTX_METHOD provider_conf_ossl_ctx_method = {
-    /* Must be freed before the provider store is freed */
-    OSSL_LIB_CTX_METHOD_PRIORITY_2,
-    prov_conf_ossl_ctx_new,
-    prov_conf_ossl_ctx_free,
-};
 
 static const char *skip_dot(const char *name)
 {
@@ -142,6 +136,8 @@ static int provider_conf_load(OSSL_LIB_CTX *libctx, const char *name,
     int i;
     STACK_OF(CONF_VALUE) *ecmds;
     int soft = 0;
+    PROVIDER_CONF_GLOBAL *pcgbl
+        = ossl_lib_ctx_get_data(libctx, OSSL_LIB_CTX_PROVIDER_CONF_INDEX);
     OSSL_PROVIDER *prov = NULL, *actual = NULL;
     const char *path = NULL;
     long activate = 0;
@@ -183,8 +179,7 @@ static int provider_conf_load(OSSL_LIB_CTX *libctx, const char *name,
 
     if (activate) {
         PROVIDER_CONF_GLOBAL *pcgbl
-            = ossl_lib_ctx_get_data(libctx, OSSL_LIB_CTX_PROVIDER_CONF_INDEX,
-                                    &provider_conf_ossl_ctx_method);
+            = ossl_lib_ctx_get_data(libctx, OSSL_LIB_CTX_PROVIDER_CONF_INDEX);
 
         if (pcgbl == NULL || !CRYPTO_THREAD_write_lock(pcgbl->lock)) {
             ERR_raise(ERR_LIB_CRYPTO, ERR_R_INTERNAL_ERROR);

--- a/crypto/rand/rand_lib.c
+++ b/crypto/rand/rand_lib.c
@@ -18,6 +18,7 @@
 #include "crypto/rand.h"
 #include "crypto/cryptlib.h"
 #include "rand_local.h"
+#include "crypto/context.h"
 
 #ifndef FIPS_MODULE
 # include <stdio.h>
@@ -435,7 +436,7 @@ typedef struct rand_global_st {
  * Initialize the OSSL_LIB_CTX global DRBGs on first use.
  * Returns the allocated global data on success or NULL on failure.
  */
-static void *rand_ossl_ctx_new(OSSL_LIB_CTX *libctx)
+void *ossl_rand_ctx_new(OSSL_LIB_CTX *libctx)
 {
     RAND_GLOBAL *dgbl = OPENSSL_zalloc(sizeof(*dgbl));
 
@@ -492,16 +493,9 @@ void ossl_rand_ctx_free(void *vdgbl)
     OPENSSL_free(dgbl);
 }
 
-static const OSSL_LIB_CTX_METHOD rand_drbg_ossl_ctx_method = {
-    OSSL_LIB_CTX_METHOD_PRIORITY_2,
-    rand_ossl_ctx_new,
-    ossl_rand_ctx_free,
-};
-
 static RAND_GLOBAL *rand_get_global(OSSL_LIB_CTX *libctx)
 {
-    return ossl_lib_ctx_get_data(libctx, OSSL_LIB_CTX_DRBG_INDEX,
-                                 &rand_drbg_ossl_ctx_method);
+    return ossl_lib_ctx_get_data(libctx, OSSL_LIB_CTX_DRBG_INDEX);
 }
 
 static void rand_delete_thread_state(void *arg)

--- a/crypto/self_test_core.c
+++ b/crypto/self_test_core.c
@@ -11,6 +11,7 @@
 #include <openssl/core_names.h>
 #include <openssl/params.h>
 #include "internal/cryptlib.h"
+#include "crypto/context.h"
 
 typedef struct self_test_cb_st
 {
@@ -32,7 +33,7 @@ struct ossl_self_test_st
 };
 
 #ifndef FIPS_MODULE
-static void *self_test_set_callback_new(OSSL_LIB_CTX *ctx)
+void *ossl_self_test_set_callback_new(OSSL_LIB_CTX *ctx)
 {
     SELF_TEST_CB *stcb;
 
@@ -40,21 +41,14 @@ static void *self_test_set_callback_new(OSSL_LIB_CTX *ctx)
     return stcb;
 }
 
-static void self_test_set_callback_free(void *stcb)
+void ossl_self_test_set_callback_free(void *stcb)
 {
     OPENSSL_free(stcb);
 }
 
-static const OSSL_LIB_CTX_METHOD self_test_set_callback_method = {
-    OSSL_LIB_CTX_METHOD_DEFAULT_PRIORITY,
-    self_test_set_callback_new,
-    self_test_set_callback_free,
-};
-
 static SELF_TEST_CB *get_self_test_callback(OSSL_LIB_CTX *libctx)
 {
-    return ossl_lib_ctx_get_data(libctx, OSSL_LIB_CTX_SELF_TEST_CB_INDEX,
-                                 &self_test_set_callback_method);
+    return ossl_lib_ctx_get_data(libctx, OSSL_LIB_CTX_SELF_TEST_CB_INDEX);
 }
 
 void OSSL_SELF_TEST_set_callback(OSSL_LIB_CTX *libctx, OSSL_CALLBACK *cb,

--- a/crypto/store/store_meth.c
+++ b/crypto/store/store_meth.c
@@ -14,6 +14,7 @@
 #include "internal/property.h"
 #include "internal/provider.h"
 #include "store_local.h"
+#include "crypto/context.h"
 
 int OSSL_STORE_LOADER_up_ref(OSSL_STORE_LOADER *loader)
 {
@@ -68,25 +69,6 @@ static void free_loader(void *method)
     OSSL_STORE_LOADER_free(method);
 }
 
-/* Permanent loader method store, constructor and destructor */
-static void loader_store_free(void *vstore)
-{
-    ossl_method_store_free(vstore);
-}
-
-static void *loader_store_new(OSSL_LIB_CTX *ctx)
-{
-    return ossl_method_store_new(ctx);
-}
-
-
-static const OSSL_LIB_CTX_METHOD loader_store_method = {
-    /* We want loader_store to be cleaned up before the provider store */
-    OSSL_LIB_CTX_METHOD_PRIORITY_2,
-    loader_store_new,
-    loader_store_free,
-};
-
 /* Data to be passed through ossl_method_construct() */
 struct loader_data_st {
     OSSL_LIB_CTX *libctx;
@@ -123,8 +105,7 @@ static void *get_tmp_loader_store(void *data)
 /* Get the permanent loader store */
 static OSSL_METHOD_STORE *get_loader_store(OSSL_LIB_CTX *libctx)
 {
-    return ossl_lib_ctx_get_data(libctx, OSSL_LIB_CTX_STORE_LOADER_STORE_INDEX,
-                                &loader_store_method);
+    return ossl_lib_ctx_get_data(libctx, OSSL_LIB_CTX_STORE_LOADER_STORE_INDEX);
 }
 
 static int reserve_loader_store(void *store, void *data)

--- a/doc/internal/man3/ossl_lib_ctx_get_data.pod
+++ b/doc/internal/man3/ossl_lib_ctx_get_data.pod
@@ -11,14 +11,7 @@ ossl_lib_ctx_is_child
  #include <openssl/types.h>
  #include "internal/cryptlib.h"
 
- typedef struct ossl_lib_ctx_method {
-     int priority;
-     void *(*new_func)(OSSL_LIB_CTX *ctx);
-     void (*free_func)(void *);
- } OSSL_LIB_CTX_METHOD;
-
- void *ossl_lib_ctx_get_data(OSSL_LIB_CTX *ctx, int index,
-                             const OSSL_LIB_CTX_METHOD *meth);
+ void *ossl_lib_ctx_get_data(OSSL_LIB_CTX *ctx, int index);
 
  int ossl_lib_ctx_run_once(OSSL_LIB_CTX *ctx, unsigned int idx,
                            ossl_lib_ctx_run_once_fn run_once_fn);
@@ -28,37 +21,23 @@ ossl_lib_ctx_is_child
 
 =head1 DESCRIPTION
 
-Internally, the OpenSSL library context B<OSSL_LIB_CTX> is implemented
-as a B<CRYPTO_EX_DATA>, which allows data from diverse parts of the
-library to be added and removed dynamically.
-Each such data item must have a corresponding CRYPTO_EX_DATA index
-associated with it. Unlike normal CRYPTO_EX_DATA objects we use static indexes
-to identify data items. These are mapped transparently to CRYPTO_EX_DATA dynamic
-indexes internally to the implementation.
-See the example further down to see how that's done.
-
-ossl_lib_ctx_get_data() is used to retrieve a pointer to the data in
-the library context I<ctx> associated with the given I<index>. An
-OSSL_LIB_CTX_METHOD must be defined and given in the I<meth> parameter. The index
-for it should be defined in cryptlib.h. The functions through the method are
-used to create or free items that are stored at that index whenever a library
-context is created or freed, meaning that the code that use a data item of that
-index doesn't have to worry about that, just use the data available.
-
-Deallocation of an index happens automatically when the library
-context is freed.
-
-ossl_lib_ctx_run_once is used to run some initialisation routine I<run_once_fn>
+ossl_lib_ctx_run_once() is used to run some initialisation routine I<run_once_fn>
 exactly once per library context I<ctx> object. Each initialisation routine
 should be allocate a unique run once index in cryptlib.h.
 
 Any resources allocated via a run once initialisation routine can be cleaned up
-using ossl_lib_ctx_onfree. This associates an "on free" routine I<onfreefn> with
+using ossl_lib_ctx_onfree(). This associates an "on free" routine I<onfreefn> with
 the library context I<ctx>. When I<ctx> is freed all associated "on free"
 routines are called.
 
 ossl_lib_ctx_is_child() returns 1 if this library context is a child and 0
 otherwise.
+
+ossl_lib_ctx_get_data() allows different parts of the library to retrieve
+pointers to structures used in diverse parts of the library. The lifetime of
+these structures is managed by B<OSSL_LIB_CTX>. The different objects which can
+be retrieved are specified with the given argument I<index>. The valid values of
+I<index> are specified in cryptlib.h.
 
 =head1 RETURN VALUES
 
@@ -67,51 +46,15 @@ failure.
 
 =head1 EXAMPLES
 
-=head2 Initialization
-
-For a type C<FOO> that should end up in the OpenSSL library context, a
-small bit of initialization is needed, i.e. to associate a constructor
-and a destructor to an index.
-
- typedef struct foo_st {
-     int i;
-     void *data;
- } FOO;
-
- static void *foo_new(OSSL_LIB_CTX *ctx)
- {
-     FOO *ptr = OPENSSL_zalloc(sizeof(*foo));
-     if (ptr != NULL)
-         ptr->i = 42;
-     return ptr;
- }
- static void foo_free(void *ptr)
- {
-     OPENSSL_free(ptr);
- }
-
- /*
-  * Include a reference to this in the methods table in context.c
-  * OSSL_LIB_CTX_FOO_INDEX should be added to internal/cryptlib.h
-  * Priorities can be OSSL_LIB_CTX_METHOD_DEFAULT_PRIORITY,
-  * OSSL_LIB_CTX_METHOD_PRIORITY_1, OSSL_LIB_CTX_METHOD_PRIORITY_2, etc.
-  * Default priority is low (0). The higher the priority the earlier the
-  * method's destructor will be called when the library context is cleaned up.
-  */
- const OSSL_LIB_CTX_METHOD foo_method = {
-     OSSL_LIB_CTX_METHOD_DEFAULT_PRIORITY,
-     foo_new,
-     foo_free
- };
-
 =head2 Usage
 
-To get and use the data stored in the library context, simply do this:
+To obtain a pointer for an object managed by the library context, simply do
+this:
 
  /*
   * ctx is received from a caller,
   */
- FOO *data = ossl_lib_ctx_get_data(ctx, OSSL_LIB_CTX_FOO_INDEX, &foo_method);
+ FOO *data = ossl_lib_ctx_get_data(ctx, OSSL_LIB_CTX_FOO_INDEX);
 
 =head2 Run Once
 

--- a/include/crypto/context.h
+++ b/include/crypto/context.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <openssl/core.h>
+
+void *ossl_provider_store_new(OSSL_LIB_CTX *);
+void *ossl_property_string_data_new(OSSL_LIB_CTX *);
+void *ossl_stored_namemap_new(OSSL_LIB_CTX *);
+void *ossl_property_defns_new(OSSL_LIB_CTX *);
+void *ossl_ctx_global_properties_new(OSSL_LIB_CTX *);
+void *ossl_rand_ctx_new(OSSL_LIB_CTX *);
+void *ossl_prov_conf_ctx_new(OSSL_LIB_CTX *);
+void *ossl_bio_core_globals_new(OSSL_LIB_CTX *);
+void *ossl_child_prov_ctx_new(OSSL_LIB_CTX *);
+void *ossl_prov_drbg_nonce_ctx_new(OSSL_LIB_CTX *);
+void *ossl_self_test_set_callback_new(OSSL_LIB_CTX *);
+void *ossl_rand_crng_ctx_new(OSSL_LIB_CTX *);
+void *ossl_thread_event_ctx_new(OSSL_LIB_CTX *);
+void *ossl_fips_prov_ossl_ctx_new(OSSL_LIB_CTX *);
+
+void ossl_provider_store_free(void *);
+void ossl_property_string_data_free(void *);
+void ossl_stored_namemap_free(void *);
+void ossl_property_defns_free(void *);
+void ossl_ctx_global_properties_free(void *);
+void ossl_rand_ctx_free(void *);
+void ossl_prov_conf_ctx_free(void *);
+void ossl_bio_core_globals_free(void *);
+void ossl_child_prov_ctx_free(void *);
+void ossl_prov_drbg_nonce_ctx_free(void *);
+void ossl_self_test_set_callback_free(void *);
+void ossl_rand_crng_ctx_free(void *);
+void ossl_thread_event_ctx_free(void *);
+void ossl_fips_prov_ossl_ctx_free(void *);

--- a/include/internal/cryptlib.h
+++ b/include/internal/cryptlib.h
@@ -170,24 +170,12 @@ typedef struct ossl_ex_data_global_st {
 # define OSSL_LIB_CTX_CHILD_PROVIDER_INDEX          18
 # define OSSL_LIB_CTX_MAX_INDEXES                   19
 
-# define OSSL_LIB_CTX_METHOD_LOW_PRIORITY          -1
-# define OSSL_LIB_CTX_METHOD_DEFAULT_PRIORITY       0
-# define OSSL_LIB_CTX_METHOD_PRIORITY_1             1
-# define OSSL_LIB_CTX_METHOD_PRIORITY_2             2
-
-typedef struct ossl_lib_ctx_method {
-    int priority;
-    void *(*new_func)(OSSL_LIB_CTX *ctx);
-    void (*free_func)(void *);
-} OSSL_LIB_CTX_METHOD;
-
 OSSL_LIB_CTX *ossl_lib_ctx_get_concrete(OSSL_LIB_CTX *ctx);
 int ossl_lib_ctx_is_default(OSSL_LIB_CTX *ctx);
 int ossl_lib_ctx_is_global_default(OSSL_LIB_CTX *ctx);
 
 /* Functions to retrieve pointers to data by index */
-void *ossl_lib_ctx_get_data(OSSL_LIB_CTX *, int /* index */,
-                            const OSSL_LIB_CTX_METHOD * ctx);
+void *ossl_lib_ctx_get_data(OSSL_LIB_CTX *, int /* index */);
 
 void ossl_lib_ctx_default_deinit(void);
 OSSL_EX_DATA_GLOBAL *ossl_lib_ctx_get_ex_data_global(OSSL_LIB_CTX *ctx);

--- a/providers/implementations/rands/crngt.c
+++ b/providers/implementations/rands/crngt.c
@@ -23,6 +23,7 @@
 #include "crypto/rand_pool.h"
 #include "drbg_local.h"
 #include "prov/seeding.h"
+#include "crypto/context.h"
 
 typedef struct crng_test_global_st {
     unsigned char crngt_prev[EVP_MAX_MD_SIZE];
@@ -52,7 +53,7 @@ static int crngt_get_entropy(PROV_CTX *provctx, const EVP_MD *digest,
     return 0;
 }
 
-static void rand_crng_ossl_ctx_free(void *vcrngt_glob)
+void ossl_rand_crng_ctx_free(void *vcrngt_glob)
 {
     CRNG_TEST_GLOBAL *crngt_glob = vcrngt_glob;
 
@@ -61,7 +62,7 @@ static void rand_crng_ossl_ctx_free(void *vcrngt_glob)
     OPENSSL_free(crngt_glob);
 }
 
-static void *rand_crng_ossl_ctx_new(OSSL_LIB_CTX *ctx)
+void *ossl_rand_crng_ctx_new(OSSL_LIB_CTX *ctx)
 {
     CRNG_TEST_GLOBAL *crngt_glob = OPENSSL_zalloc(sizeof(*crngt_glob));
 
@@ -81,12 +82,6 @@ static void *rand_crng_ossl_ctx_new(OSSL_LIB_CTX *ctx)
 
     return crngt_glob;
 }
-
-static const OSSL_LIB_CTX_METHOD rand_crng_ossl_ctx_method = {
-    OSSL_LIB_CTX_METHOD_DEFAULT_PRIORITY,
-    rand_crng_ossl_ctx_new,
-    rand_crng_ossl_ctx_free,
-};
 
 static int prov_crngt_compare_previous(const unsigned char *prev,
                                        const unsigned char *cur,
@@ -113,8 +108,7 @@ size_t ossl_crngt_get_entropy(PROV_DRBG *drbg,
     int crng_test_pass = 1;
     OSSL_LIB_CTX *libctx = ossl_prov_ctx_get0_libctx(drbg->provctx);
     CRNG_TEST_GLOBAL *crngt_glob
-        = ossl_lib_ctx_get_data(libctx, OSSL_LIB_CTX_RAND_CRNGT_INDEX,
-                                &rand_crng_ossl_ctx_method);
+        = ossl_lib_ctx_get_data(libctx, OSSL_LIB_CTX_RAND_CRNGT_INDEX);
     OSSL_CALLBACK *stcb = NULL;
     void *stcbarg = NULL;
     OSSL_SELF_TEST *st = NULL;

--- a/providers/implementations/rands/drbg.c
+++ b/providers/implementations/rands/drbg.c
@@ -21,6 +21,7 @@
 #include "crypto/rand_pool.h"
 #include "prov/provider_ctx.h"
 #include "prov/providercommon.h"
+#include "crypto/context.h"
 
 /*
  * Support framework for NIST SP 800-90A DRBG
@@ -274,7 +275,7 @@ typedef struct prov_drbg_nonce_global_st {
  * to be in a different global data object. Otherwise we will go into an
  * infinite recursion loop.
  */
-static void *prov_drbg_nonce_ossl_ctx_new(OSSL_LIB_CTX *libctx)
+void *ossl_prov_drbg_nonce_ctx_new(OSSL_LIB_CTX *libctx)
 {
     PROV_DRBG_NONCE_GLOBAL *dngbl = OPENSSL_zalloc(sizeof(*dngbl));
 
@@ -290,7 +291,7 @@ static void *prov_drbg_nonce_ossl_ctx_new(OSSL_LIB_CTX *libctx)
     return dngbl;
 }
 
-static void prov_drbg_nonce_ossl_ctx_free(void *vdngbl)
+void ossl_prov_drbg_nonce_ctx_free(void *vdngbl)
 {
     PROV_DRBG_NONCE_GLOBAL *dngbl = vdngbl;
 
@@ -302,12 +303,6 @@ static void prov_drbg_nonce_ossl_ctx_free(void *vdngbl)
     OPENSSL_free(dngbl);
 }
 
-static const OSSL_LIB_CTX_METHOD drbg_nonce_ossl_ctx_method = {
-    OSSL_LIB_CTX_METHOD_DEFAULT_PRIORITY,
-    prov_drbg_nonce_ossl_ctx_new,
-    prov_drbg_nonce_ossl_ctx_free,
-};
-
 /* Get a nonce from the operating system */
 static size_t prov_drbg_get_nonce(PROV_DRBG *drbg, unsigned char **pout,
                                   size_t min_len, size_t max_len)
@@ -316,8 +311,7 @@ static size_t prov_drbg_get_nonce(PROV_DRBG *drbg, unsigned char **pout,
     unsigned char *buf = NULL;
     OSSL_LIB_CTX *libctx = ossl_prov_ctx_get0_libctx(drbg->provctx);
     PROV_DRBG_NONCE_GLOBAL *dngbl
-        = ossl_lib_ctx_get_data(libctx, OSSL_LIB_CTX_DRBG_NONCE_INDEX,
-                                &drbg_nonce_ossl_ctx_method);
+        = ossl_lib_ctx_get_data(libctx, OSSL_LIB_CTX_DRBG_NONCE_INDEX);
     struct {
         void *drbg;
         int count;

--- a/test/context_internal_test.c
+++ b/test/context_internal_test.c
@@ -12,103 +12,25 @@
 #include "internal/cryptlib.h"
 #include "testutil.h"
 
-/*
- * Everything between BEGIN EXAMPLE and END EXAMPLE is copied from
- * doc/internal/man3/ossl_lib_ctx_get_data.pod
- */
-
-/*
- * ======================================================================
- * BEGIN EXAMPLE
- */
-
-typedef struct foo_st {
-    int i;
-    void *data;
-} FOO;
-
-static void *foo_new(OSSL_LIB_CTX *ctx)
-{
-    FOO *ptr = OPENSSL_zalloc(sizeof(*ptr));
-    if (ptr != NULL)
-        ptr->i = 42;
-    return ptr;
-}
-static void foo_free(void *ptr)
-{
-    OPENSSL_free(ptr);
-}
-static const OSSL_LIB_CTX_METHOD foo_method = {
-    OSSL_LIB_CTX_METHOD_DEFAULT_PRIORITY,
-    foo_new,
-    foo_free
-};
-
-/*
- * END EXAMPLE
- * ======================================================================
- */
-
-static int test_context(OSSL_LIB_CTX *ctx)
-{
-    FOO *data = NULL;
-
-    return TEST_ptr(data = ossl_lib_ctx_get_data(ctx, 0, &foo_method))
-        /* OPENSSL_zalloc in foo_new() initialized it to zero */
-        && TEST_int_eq(data->i, 42);
-}
-
-static int test_app_context(void)
-{
-    OSSL_LIB_CTX *ctx = NULL;
-    int result =
-        TEST_ptr(ctx = OSSL_LIB_CTX_new())
-        && test_context(ctx);
-
-    OSSL_LIB_CTX_free(ctx);
-    return result;
-}
-
-static int test_def_context(void)
-{
-    return test_context(NULL);
-}
-
 static int test_set0_default(void)
 {
     OSSL_LIB_CTX *global = OSSL_LIB_CTX_get0_global_default();
     OSSL_LIB_CTX *local = OSSL_LIB_CTX_new();
     OSSL_LIB_CTX *prev;
     int testresult = 0;
-    FOO *data = NULL;
 
     if (!TEST_ptr(global)
             || !TEST_ptr(local)
-            || !TEST_ptr_eq(global, OSSL_LIB_CTX_set0_default(NULL))
-            || !TEST_ptr(data = ossl_lib_ctx_get_data(local, 0, &foo_method)))
-        goto err;
-
-    /* Set local "i" value to 43. Global "i" should be 42 */
-    data->i++;
-    if (!TEST_int_eq(data->i, 43))
-        goto err;
-
-    /* The default context should still be the "global" default */
-    if (!TEST_ptr(data = ossl_lib_ctx_get_data(NULL, 0, &foo_method))
-            || !TEST_int_eq(data->i, 42))
+            || !TEST_ptr_eq(global, OSSL_LIB_CTX_set0_default(NULL)))
         goto err;
 
     /* Check we can change the local default context */
     if (!TEST_ptr(prev = OSSL_LIB_CTX_set0_default(local))
-            || !TEST_ptr_eq(global, prev)
-            || !TEST_ptr(data = ossl_lib_ctx_get_data(NULL, 0, &foo_method))
-            || !TEST_int_eq(data->i, 43))
+            || !TEST_ptr_eq(global, prev))
         goto err;
 
     /* Calling OSSL_LIB_CTX_set0_default() with a NULL should be a no-op */
-    if (!TEST_ptr_eq(local, OSSL_LIB_CTX_set0_default(NULL))
-            || !TEST_ptr(data = ossl_lib_ctx_get_data(NULL, 0, &foo_method))
-            || !TEST_int_eq(data->i, 43))
+    if (!TEST_ptr_eq(local, OSSL_LIB_CTX_set0_default(NULL)))
         goto err;
 
     /* Global default should be unchanged */
@@ -116,10 +38,8 @@ static int test_set0_default(void)
         goto err;
 
     /* Check we can swap back to the global default */
-   if (!TEST_ptr(prev = OSSL_LIB_CTX_set0_default(global))
-            || !TEST_ptr_eq(local, prev)
-            || !TEST_ptr(data = ossl_lib_ctx_get_data(NULL, 0, &foo_method))
-            || !TEST_int_eq(data->i, 42))
+    if (!TEST_ptr(prev = OSSL_LIB_CTX_set0_default(global))
+            || !TEST_ptr_eq(local, prev))
         goto err;
 
     testresult = 1;
@@ -130,8 +50,6 @@ static int test_set0_default(void)
 
 int setup_tests(void)
 {
-    ADD_TEST(test_app_context);
-    ADD_TEST(test_def_context);
     ADD_TEST(test_set0_default);
     return 1;
 }


### PR DESCRIPTION
This PR cherry picks 3 performance improvements, removing lock contention while reading PEM files, improving `ossl_lh_strcasehash` and decoder resolution speed:


1. https://github.com/openssl/openssl/commit/927d0566ded0dff9d6c5abc8a40bb84068446b76 from https://github.com/openssl/openssl/pull/17881
2. https://github.com/openssl/openssl/commit/a4e21d18d5b7cb4fef66c10f13b1b3b55945439f from https://github.com/openssl/openssl/pull/18354
3. https://github.com/openssl/openssl/commit/4a1108eb5906cd3cf47a3f70bd58722dbe2023a4 from https://github.com/openssl/openssl/pull/17921

