### PR TITLE
DOCS: EVP_PKEY_get_default_digest_{name,nid}() - add params description

### DIFF
--- a/doc/man3/EVP_PKEY_get_default_digest_nid.pod
+++ b/doc/man3/EVP_PKEY_get_default_digest_nid.pod
@@ -32,32 +32,9 @@ similar.
 
 =head1 PARAMETERS
 
-EVP_PKEY_get_default_digest_name() uses these <OSSL_PARAM(3)> key to ask the
-provider for the values it seeks:
-
-=over 4
-
-=item "mandatory-digest" (B<OSSL_PKEY_PARAM_MANDATORY_DIGEST>) <UTF8 string>
-
-When the providers responds to this, the return value from
-EVP_PKEY_get_default_digest_name() will be 2.
-
-If the value from the provider is C<""> or C<"UNDEF">,
-EVP_PKEY_get_default_digest_name() will place the string C<"UNDEF"> into
-I<mdname>.  This means that no digest should be used with the signature
-operation.
-
-=item "default-digest" (B<OSSL_PKEY_PARAM_DEFAULT_DIGEST>) <UTF8 string>
-
-When the providers responds to this, the return value from
-EVP_PKEY_get_default_digest_name() will be 1.
-
-If the value from the provider is C<""> or C<"UNDEF">,
-EVP_PKEY_get_default_digest_name() will place the string C<"UNDEF"> into
-I<mdname>.  This means that no digest has to be used with the signature
-operation.
-
-=back
+EVP_PKEY_get_default_digest_name() uses <OSSL_PARAM(3)> parameters key to
+ask the provider for the values it seeks,
+see L<provider-keymgmt(7)/Common Information Parameters>.
 
 =head1 CONTROLS
 

--- a/doc/man3/EVP_PKEY_get_default_digest_nid.pod
+++ b/doc/man3/EVP_PKEY_get_default_digest_nid.pod
@@ -30,6 +30,50 @@ are keys with a B<EVP_PKEY_ASN1_METHOD>; these keys have typically
 been loaded from engines, or created with L<EVP_PKEY_assign_RSA(3)> or
 similar.
 
+=head1 PARAMETERS
+
+EVP_PKEY_get_default_digest_name() uses these <OSSL_PARAM(3)> key to ask the
+provider for the values it seeks:
+
+=over 4
+
+=item "mandatory-digest" (B<OSSL_PKEY_PARAM_MANDATORY_DIGEST>) <UTF8 string>
+
+When the providers responds to this, the return value from
+EVP_PKEY_get_default_digest_name() will be 2.
+
+If the value from the provider is C<""> or C<"UNDEF">,
+EVP_PKEY_get_default_digest_name() will place the string C<"UNDEF"> into
+I<mdname>.  This means that no digest should be used with the signature
+operation.
+
+=item "default-digest" (B<OSSL_PKEY_PARAM_DEFAULT_DIGEST>) <UTF8 string>
+
+When the providers responds to this, the return value from
+EVP_PKEY_get_default_digest_name() will be 1.
+
+If the value from the provider is C<""> or C<"UNDEF">,
+EVP_PKEY_get_default_digest_name() will place the string C<"UNDEF"> into
+I<mdname>.  This means that no digest has to be used with the signature
+operation.
+
+=back
+
+=head1 CONTROLS
+
+EVP_PKEY_get_default_digest_nid() uses the following control to query for
+the mandatory / default digest NID for the signature operation:
+
+=over 4
+
+=item ASN1_PKEY_CTRL_DEFAULT_MD_NID
+
+=back
+
+The L<EVP_PKEY_ASN1_METHOD(3)> pkey_ctrl() method receives I<pnid> and is
+fully responsible for filling that in with the correct NID, as well as
+returning the value that EVP_PKEY_get_default_digest_nid() should return.
+
 =head1 NOTES
 
 For all current standard OpenSSL public key algorithms SHA256 is returned.

--- a/doc/man3/EVP_PKEY_get_default_digest_nid.pod
+++ b/doc/man3/EVP_PKEY_get_default_digest_nid.pod
@@ -30,27 +30,6 @@ are keys with a B<EVP_PKEY_ASN1_METHOD>; these keys have typically
 been loaded from engines, or created with L<EVP_PKEY_assign_RSA(3)> or
 similar.
 
-=head1 PARAMETERS
-
-EVP_PKEY_get_default_digest_name() uses <OSSL_PARAM(3)> parameters key to
-ask the provider for the values it seeks,
-see L<provider-keymgmt(7)/Common Information Parameters>.
-
-=head1 CONTROLS
-
-EVP_PKEY_get_default_digest_nid() uses the following control to query for
-the mandatory / default digest NID for the signature operation:
-
-=over 4
-
-=item ASN1_PKEY_CTRL_DEFAULT_MD_NID
-
-=back
-
-The L<EVP_PKEY_ASN1_METHOD(3)> pkey_ctrl() method receives I<pnid> and is
-fully responsible for filling that in with the correct NID, as well as
-returning the value that EVP_PKEY_get_default_digest_nid() should return.
-
 =head1 NOTES
 
 For all current standard OpenSSL public key algorithms SHA256 is returned.

--- a/doc/man7/EVP_PKEY-EC.pod
+++ b/doc/man7/EVP_PKEY-EC.pod
@@ -142,7 +142,7 @@ Used for getting the EC public key X component.
 
 Used for getting the EC public key Y component.
 
-=item (B<OSSL_PKEY_PARAM_DEFAULT_DIGEST>) <UTF8 string>
+=item "default-digest" (B<OSSL_PKEY_PARAM_DEFAULT_DIGEST>) <UTF8 string>
 
 Getter that returns the default digest name.
 (Currently returns "SHA256" as of OpenSSL 3.0).

--- a/doc/man7/provider-keymgmt.pod
+++ b/doc/man7/provider-keymgmt.pod
@@ -396,7 +396,7 @@ If there is a mandatory digest for performing a signature operation with
 keys from this keymgmt, this parameter should get its name as value.
 
 When EVP_PKEY_get_default_digest_name() queries this parameter and it's
-filled in by the implementation, its return value from will be 2.
+filled in by the implementation, its return value will be 2.
 
 If the keymgmt implementation fills in the value C<""> or C<"UNDEF">,
 L<EVP_PKEY_get_default_digest_name(3)> will place the string C<"UNDEF"> into
@@ -409,8 +409,8 @@ If there is a default digest for performing a signature operation with
 keys from this keymgmt, this parameter should get its name as value.
 
 When L<EVP_PKEY_get_default_digest_name(3)> queries this parameter and it's
-filled in by the implementation, its return value from will be 1.  Note that
-if B<OSSL_PKEY_PARAM_MANDATORY_DIGEST> is responded to as well,
+filled in by the implementation, its return value will be 1.  Note that if
+B<OSSL_PKEY_PARAM_MANDATORY_DIGEST> is responded to as well,
 L<EVP_PKEY_get_default_digest_name(3)> ignores the response to this
 parameter.
 

--- a/doc/man7/provider-keymgmt.pod
+++ b/doc/man7/provider-keymgmt.pod
@@ -390,6 +390,36 @@ dimensions handled in the rest of the same provider.
 The value should be the number of security bits of the given key.
 Bits of security is defined in SP800-57.
 
+=item "mandatory-digest" (B<OSSL_PKEY_PARAM_MANDATORY_DIGEST>) <UTF8 string>
+
+If there is a mandatory digest for performing a signature operation with
+keys from this keymgmt, this parameter should get its name as value.
+
+When EVP_PKEY_get_default_digest_name() queries this parameter and it's
+filled in by the implementation, its return value from will be 2.
+
+If the keymgmt implementation fills in the value C<""> or C<"UNDEF">,
+L<EVP_PKEY_get_default_digest_name(3)> will place the string C<"UNDEF"> into
+its argument I<mdname>.  This signifies that no digest should be specified
+with the corresponding signature operation.
+
+=item "default-digest" (B<OSSL_PKEY_PARAM_DEFAULT_DIGEST>) <UTF8 string>
+
+If there is a default digest for performing a signature operation with
+keys from this keymgmt, this parameter should get its name as value.
+
+When L<EVP_PKEY_get_default_digest_name(3)> queries this parameter and it's
+filled in by the implementation, its return value from will be 1.  Note that
+if B<OSSL_PKEY_PARAM_MANDATORY_DIGEST> is responded to as well,
+L<EVP_PKEY_get_default_digest_name(3)> ignores the response to this
+parameter.
+
+If the keymgmt implementation fills in the value C<""> or C<"UNDEF">,
+L<EVP_PKEY_get_default_digest_name(3)> will place the string C<"UNDEF"> into
+its argument I<mdname>.  This signifies that no digest has to be specified
+with the corresponding signature operation, but may be specified as an
+option.
+
 =back
 
 =head1 RETURN VALUES


### PR DESCRIPTION
This includes both OSSL_PARAM(3) parameter keys and legacy pkey_ctrl()
control commands.

Fixes #20428
