### PR TITLE
Don't force DRBG reseed on parent reseed

### DIFF
--- a/doc/man7/EVP_RAND.pod
+++ b/doc/man7/EVP_RAND.pod
@@ -201,15 +201,12 @@ entropy from a live entropy source (section 5.5.2 of [NIST SP 800-90C]).
 It is up to the user to ensure that a live entropy source is configured
 and is being used.
 
-For the three shared DRBGs (and only for these) there is another way to
-reseed them manually:
-If L<RAND_add(3)> is called with a positive I<randomness> argument
-(or L<RAND_seed(3)>), then this will immediately reseed the <primary> DRBG.
-The <public> and <private> DRBG will detect this on their next generate
-call and reseed, pulling randomness from <primary>.
-
-The last feature has been added to support the common practice used with
-previous OpenSSL versions to call RAND_add() before calling RAND_bytes().
+For the <primary> DRBG, calling L<RAND_add(3)> (or L<RAND_seed(3)>) will
+immediately reseed the DRBG.
+The <public> and <private> DRBGs will pick up the new randomness on
+their next reseeding.
+This supports the common practice, used with previous OpenSSL versions,
+to call L<RAND_add(3)> before calling L<RAND_bytes(3)> for the first time.
 
 
 =head2 Entropy Input and Additional Data

--- a/doc/man7/EVP_RAND.pod
+++ b/doc/man7/EVP_RAND.pod
@@ -205,8 +205,14 @@ For the <primary> DRBG, calling L<RAND_add(3)> (or L<RAND_seed(3)>) will
 immediately reseed the DRBG.
 The <public> and <private> DRBGs will pick up the new randomness on
 their next reseeding.
-This supports the common practice, used with previous OpenSSL versions,
-to call L<RAND_add(3)> before calling L<RAND_bytes(3)> for the first time.
+This supports the common practice, used with previous OpenSSL versions, to
+call L<RAND_add(3)> before calling L<RAND_bytes(3)> for the first time.
+Note however, that contrary to the behaviour before version 3.0.9,
+a L<RAND_add(3)> call I<after> DRBG instantiation will not have an
+immediate effect on the output of the following L<RAND_bytes(3)> call.
+Consequently, it is best to call L<RAND_add(3)> as early as possible
+during application startup.
+
 
 
 =head2 Entropy Input and Additional Data

--- a/providers/implementations/rands/drbg.c
+++ b/providers/implementations/rands/drbg.c
@@ -658,9 +658,6 @@ int ossl_prov_drbg_generate(PROV_DRBG *drbg, unsigned char *out, size_t outlen,
             || now - drbg->reseed_time >= drbg->reseed_time_interval)
             reseed_required = 1;
     }
-    if (drbg->parent != NULL
-            && get_parent_reseed_count(drbg) != drbg->parent_reseed_counter)
-        reseed_required = 1;
 
     if (reseed_required || prediction_resistance) {
         if (!ossl_prov_drbg_reseed(drbg, prediction_resistance, NULL, 0,

--- a/providers/implementations/rands/drbg_local.h
+++ b/providers/implementations/rands/drbg_local.h
@@ -14,7 +14,6 @@
 # include <openssl/core_dispatch.h>
 # include <openssl/core_names.h>
 # include <openssl/params.h>
-# include "internal/tsan_assist.h"
 # include "internal/nelem.h"
 # include "internal/numbers.h"
 # include "prov/provider_ctx.h"
@@ -145,19 +144,6 @@ struct prov_drbg_st {
      * This value is ignored if it is zero.
      */
     time_t reseed_time_interval;
-    /*
-     * Counts the number of reseeds since instantiation.
-     * This value is ignored if it is zero.
-     *
-     * This counter is used only for seed propagation from the <master> DRBG
-     * to its two children, the <public> and <private> DRBG. This feature is
-     * very special and its sole purpose is to ensure that any randomness which
-     * is added by PROV_add() or PROV_seed() will have an immediate effect on
-     * the output of PROV_bytes() resp. PROV_priv_bytes().
-     */
-    TSAN_QUALIFIER unsigned int reseed_counter;
-    unsigned int reseed_next_counter;
-    unsigned int parent_reseed_counter;
 
     size_t seedlen;
     DRBG_STATUS state;

--- a/test/drbgtest.c
+++ b/test/drbgtest.c
@@ -727,6 +727,10 @@ static int test_rand_prediction_resistance(void)
         || !TEST_true(EVP_RAND_instantiate(z, 0, 0, NULL, 0, NULL)))
         goto err;
 
+    /* Fill the first buffer with random bytes */
+    if (!TEST_true(EVP_RAND_generate(z, buf1, sizeof(buf1), 0, 0, NULL, 0)))
+        goto err;
+
     /*
      * When prediction resistance is requested, the request should be
      * propagated to the primary, so that the entire DRBG chain reseeds.

--- a/test/drbgtest.c
+++ b/test/drbgtest.c
@@ -245,17 +245,13 @@ static int test_drbg_reseed(int expect_success,
 
     if (expect_public_reseed >= 0) {
         /* Test whether public DRBG was reseeded as expected */
-        if (!TEST_int_ge(reseed_counter(public), public_reseed)
-                || !TEST_uint_ge(reseed_counter(public),
-                                 reseed_counter(primary)))
+        if (!TEST_int_ge(reseed_counter(public), public_reseed))
             return 0;
     }
 
     if (expect_private_reseed >= 0) {
-        /* Test whether public DRBG was reseeded as expected */
-        if (!TEST_int_ge(reseed_counter(private), private_reseed)
-                || !TEST_uint_ge(reseed_counter(private),
-                                 reseed_counter(primary)))
+        /* Test whether private DRBG was reseeded as expected */
+        if (!TEST_int_ge(reseed_counter(private), private_reseed))
             return 0;
     }
 
@@ -850,7 +846,8 @@ static int test_rand_prediction_resistance(void)
         goto err;
 
     /*
-     * During a normal generate, only the last DRBG should be reseed */
+     * During a normal generate, none of the DRBGs should be reseed
+     */
     inc_reseed_counter(y);
     xreseed = reseed_counter(x);
     yreseed = reseed_counter(y);
@@ -858,7 +855,7 @@ static int test_rand_prediction_resistance(void)
     if (!TEST_true(EVP_RAND_generate(z, buf1, sizeof(buf1), 0, 0, NULL, 0))
         || !TEST_int_eq(reseed_counter(x), xreseed)
         || !TEST_int_eq(reseed_counter(y), yreseed)
-        || !TEST_int_gt(reseed_counter(z), zreseed))
+        || !TEST_int_eq(reseed_counter(z), zreseed))
         goto err;
 
     /*


### PR DESCRIPTION
The existing code forces all child DRBGs to reseed if their parent reseeds.  This means that a prediction resistant request (which reseeds the chain up to the primary DRBG) causes all public and private DRBGs to also reseed which is very inefficient (these two exist per thread after all).

This change avoids the forced reseed on parent reseed.  DRBGs will still reseed based on usage and time.

Fixes #20414

- [x] documentation is added or updated
- [x] tests are added or updated
