### PR TITLE
VMS knows POSIX threads too!

### DIFF
--- a/crypto/thread/arch/thread_posix.c
+++ b/crypto/thread/arch/thread_posix.c
@@ -193,42 +193,4 @@ void ossl_crypto_condvar_free(CRYPTO_CONDVAR **cv)
     *cv_p = NULL;
 }
 
-# if 0                           /* We don't use this anywhere */
-void ossl_crypto_mem_barrier(void)
-{
-# if defined(__clang__) || defined(__GNUC__)
-    __sync_synchronize();
-# elif !defined(OPENSSL_NO_ASM)
-#  if defined(__alpha__) /* Alpha */
-    __asm__ volatile("mb" : : : "memory");
-#  elif defined(__amd64__) || defined(__i386__) || defined(__i486__) \
-    || defined(__i586__)  || defined(__i686__) || defined(__i386) /* x86 */
-    __asm__ volatile("mfence" : : : "memory");
-#  elif defined(__arm__) || defined(__aarch64__) /* ARMv7, ARMv8 */
-    __asm__ volatile("dmb ish" : : : "memory");
-#  elif defined(__hppa__) /* PARISC */
-    __asm__ volatile("" : : : "memory");
-#  elif defined(__mips__) /* MIPS */
-    __asm__ volatile("sync" : : : "memory");
-#  elif defined(__powerpc__) || defined(__powerpc64__) /* power, ppc64, ppc64le */
-    __asm__ volatile("sync" : : : "memory");
-#  elif defined(__sparc__)
-    __asm__ volatile("ba,pt	%%xcc, 1f\n\t" \
-                     " membar	#Sync\n"   \
-                     "1:\n"                \
-                     : : : "memory");
-#  elif defined(__s390__) || defined(__s390x__) /* z */
-    __asm__ volatile("bcr 15,0" : : : "memory");
-#  elif defined(__riscv) || defined(__riscv__) /* riscv */
-    __asm__ volatile("fence iorw,iorw" : : : "memory");
-#  else /* others, compiler only */
-    __asm__ volatile("" : : : "memory");
-#  endif
-# else
-    /* compiler only barrier */
-    __asm__ volatile("" : : : "memory");
-# endif
-}
-# endif
-
 #endif

--- a/crypto/thread/arch/thread_posix.c
+++ b/crypto/thread/arch/thread_posix.c
@@ -193,6 +193,7 @@ void ossl_crypto_condvar_free(CRYPTO_CONDVAR **cv)
     *cv_p = NULL;
 }
 
+# if 0                           /* We don't use this anywhere */
 void ossl_crypto_mem_barrier(void)
 {
 # if defined(__clang__) || defined(__GNUC__)
@@ -228,5 +229,6 @@ void ossl_crypto_mem_barrier(void)
     __asm__ volatile("" : : : "memory");
 # endif
 }
+# endif
 
 #endif

--- a/include/internal/thread_arch.h
+++ b/include/internal/thread_arch.h
@@ -18,6 +18,8 @@
 
 # if defined(OPENSSL_THREADS) && defined(OPENSSL_SYS_UNIX)
 #  define OPENSSL_THREADS_POSIX
+# elif defined(OPENSSL_THREADS) && defined(OPENSSL_SYS_VMS)
+#  define OPENSSL_THREADS_POSIX
 # elif defined(OPENSSL_THREADS) && defined(OPENSSL_SYS_WINDOWS) && \
     defined(_WIN32_WINNT)
 #  if _WIN32_WINNT >= 0x0600


### PR DESCRIPTION
`include/internal/thread_arch.h  didn't indicate this, now it does.

This also invalidates `ossl_crypto_mem_barrier()`, which we isn't used
anywhere.  Reason for invalidation: it doesn't build with compilers
that don't support the GNU extension `__asm__`.
