### PR TITLE
Document remaining obsolete SSL_OP_NETSCAPE_*_BUG

### DIFF
--- a/doc/man3/SSL_CTX_set_options.pod
+++ b/doc/man3/SSL_CTX_set_options.pod
@@ -378,6 +378,10 @@ retained for compatibility purposes:
 
 =item SSL_OP_EPHEMERAL_RSA
 
+=item SSL_OP_NETSCAPE_CA_DN_BUG
+
+=item SSL_OP_NETSCAPE_DEMO_CIPHER_CHANGE_BUG
+
 =back
 
 =head1 SECURE RENEGOTIATION


### PR DESCRIPTION
`SSL_OP_NETSCAPE_CA_DN_BUG` became obsolete in 3c33c6f6b1086435 and support for `SSL_OP_NETSCAPE_DEMO_CIPHER_CHANGE_BUG` was removed by 7a4dadc3a6a487db. The definitions are still listed under "OBSOLETE OPTIONS retained for compatibility" in `ssl.h.in`, so this commit adds them to the list of obsolete options in `doc/man3`.

Refs: https://github.com/nodejs/node/pull/46954

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
