### PR TITLE
Add missing assignment to EVP_get_digestbynid()

### DIFF
--- a/crypto/evp/evp_pbe.c
+++ b/crypto/evp/evp_pbe.c
@@ -143,7 +143,7 @@ int EVP_PBE_CipherInit_ex(ASN1_OBJECT *pbe_obj, const char *pass, int passlen,
         md = md_fetch = EVP_MD_fetch(libctx, OBJ_nid2sn(md_nid), propq);
         /* Fallback to legacy method */
         if (md == NULL)
-            EVP_get_digestbynid(md_nid);
+            md = EVP_get_digestbynid(md_nid);
 
         if (md == NULL) {
             (void)ERR_clear_last_mark();


### PR DESCRIPTION
The assignment of the result of EVP_get_digestbynid() did not happen which made the fallback not actually perform the fallback.

CLA: trivial

Please note that I found this using a static analysis tool I am developing at the moment. It could therefore be a false positive bug. I manually reviewed the case to be extra sure that it is a real bug.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
