### PR TITLE
Fix bss_dgram related issues

### DIFF
--- a/crypto/bio/bss_dgram.c
+++ b/crypto/bio/bss_dgram.c
@@ -1423,8 +1423,8 @@ static int dgram_sendmmsg(BIO *b, BIO_MSG *msg, size_t stride,
                  msg[0].data_len,
 #  endif
                  sysflags,
-                 msg[0].peer != NULL ? &msg[0].peer->sa : NULL,
-                 msg[0].peer != NULL ? sizeof(*msg[0].peer) : 0);
+                 msg[0].peer != NULL ? BIO_ADDR_sockaddr(msg[0].peer) : NULL,
+                 msg[0].peer != NULL ? BIO_ADDR_sockaddr_size(msg[0].peer) : 0);
     if (ret <= 0) {
         ERR_raise(ERR_LIB_SYS, get_last_socket_error());
         *num_processed = 0;

--- a/test/bio_dgram_test.c
+++ b/test/bio_dgram_test.c
@@ -175,11 +175,11 @@ static int test_bio_dgram_impl(int af, int use_local)
     if (!TEST_int_ge(fd2, 0))
         goto err;
 
-    if (!TEST_int_gt(BIO_bind(fd1, addr1, 0), 0))
+    if (BIO_bind(fd1, addr1, 0) <= 0
+        || BIO_bind(fd2, addr2, 0) <= 0) {
+        testresult = TEST_skip("BIO_bind() failed - assuming it's an unavailable address family");
         goto err;
-
-    if (!TEST_int_gt(BIO_bind(fd2, addr2, 0), 0))
-        goto err;
+    }
 
     info1.addr = addr1;
     if (!TEST_int_gt(BIO_sock_info(fd1, BIO_SOCK_INFO_ADDRESS, &info1), 0))


### PR DESCRIPTION
This fixes two issues:

1.  in `crypto/bio/bss_dgram.c`, the `BIO_ADDR` fields were used directly in
    the call to `sendto()`.  Especially using `sizeof(addr)` to determine
    the size of the applicable sockaddr is fragile, as there are `sendto()`
    implementations that are very picky that the size match the indicated
    address family.
    
    It's better to use `BIO_ADDR_sockaddr()` and `BIO_ADDR_sockaddr_size()`,
    to ensure that the correct data is used.
2.  `test/bio_dgram_test.c` fails when an address family isn't supported on
    the platform it's run on.  Typically, there are still platform without
    IPv6 support.
    This is fixed by modifying the test so it's skipped when `BIO_bind()`
    fails.  Since `test/bio_dgram_test.c` isn't designed to test `BIO_bind()`
    specifically, this is sensible enough.
