### PR TITLE
`X509_STORE_CTX_get_error.pod`: make order consistent, add some missing entries

### DIFF
--- a/crypto/x509/x509_txt.c
+++ b/crypto/x509/x509_txt.c
@@ -179,7 +179,7 @@ const char *X509_verify_cert_error_string(long n)
     case X509_V_ERR_SIGNATURE_ALGORITHM_MISMATCH:
         return "subject signature algorithm and issuer public key algorithm mismatch";
     case X509_V_ERR_SIGNATURE_ALGORITHM_INCONSISTENCY:
-        return "cert info siganature and signature algorithm mismatch";
+        return "cert info signature and signature algorithm mismatch";
     case X509_V_ERR_INVALID_CA:
         return "invalid CA certificate";
     case X509_V_ERR_PATHLEN_INVALID_FOR_NON_CA:
@@ -212,6 +212,11 @@ const char *X509_verify_cert_error_string(long n)
         return "Using cert extension requires at least X509v3";
     case X509_V_ERR_EC_KEY_EXPLICIT_PARAMS:
         return "Certificate public key has explicit ECC parameters";
+
+        /*
+         * Entries must be kept consistent with include/openssl/x509_vfy.h.in
+         * and with doc/man3/X509_STORE_CTX_get_error.pod
+         */
 
     default:
         /* Printing an error number into a static buffer is not thread-safe */

--- a/doc/man3/X509_STORE_CTX_get_error.pod
+++ b/doc/man3/X509_STORE_CTX_get_error.pod
@@ -220,10 +220,10 @@ The certificate chain length is greater than the supplied maximum depth.
 
 The certificate has been revoked.
 
-=item B<X509_V_ERR_INVALID_CA: invalid CA certificate>
+=item B<X509_V_ERR_NO_ISSUER_PUBLIC_KEY:
+ issuer certificate doesn't have a public key>
 
-A CA certificate is invalid. Either it is not a CA or its extensions are not
-consistent with the supplied purpose.
+The issuer certificate does not have a public key.
 
 =item B<X509_V_ERR_PATH_LENGTH_EXCEEDED: path length constraint exceeded>
 
@@ -266,6 +266,44 @@ key usage does not include certificate signing>
 The current candidate issuer certificate was rejected because its C<keyUsage>
 extension does not permit certificate signing.
 
+=item B<X509_V_ERR_UNABLE_TO_GET_CRL_ISSUER:
+unable to get CRL issuer certificate>
+
+Unable to get CRL issuer certificate.
+
+=item B<X509_V_ERR_UNHANDLED_CRITICAL_EXTENSION: unhandled critical extension>
+
+Unhandled critical extension.
+
+=item B<X509_V_ERR_KEYUSAGE_NO_CRL_SIGN: key usage does not include CRL signing>
+
+Key usage does not include CRL signing.
+
+=item B<X509_V_ERR_UNHANDLED_CRITICAL_CRL_EXTENSION: unhandled critical CRL extension>
+
+Unhandled critical CRL extension.
+
+=item B<X509_V_ERR_INVALID_NON_CA: invalid non-CA certificate (has CA markings)>
+
+Invalid non-CA certificate has CA markings.
+
+=item B<X509_V_ERR_PROXY_PATH_LENGTH_EXCEEDED:
+proxy path length constraint exceeded>
+
+Proxy path length constraint exceeded.
+
+=item B<X509_V_ERR_KEYUSAGE_NO_DIGITAL_SIGNATURE:
+key usage does not include digital signature>
+
+Key usage does not include digital signature, and therefore cannot sign
+certificates.
+
+=item B<X509_V_ERR_PROXY_CERTIFICATES_NOT_ALLOWED:
+ proxy certificates not allowed, please set the appropriate flag>
+
+Proxy certificates not allowed unless the B<X509_V_FLAG_ALLOW_PROXY_CERTS> flag
+is set.
+
 =item B<X509_V_ERR_INVALID_EXTENSION:
 invalid or inconsistent certificate extension>
 
@@ -288,9 +326,13 @@ present.
 
 The only CRLs that could be found did not match the scope of the certificate.
 
-=item B<X509_V_ERR_UNSUPPORTED_EXTENSION_FEATURE: Unsupported extension feature>
+=item B<X509_V_ERR_UNSUPPORTED_EXTENSION_FEATURE: unsupported extension feature>
 
 Some feature of a certificate extension is not supported. Unused.
+
+=item B<X509_V_ERR_UNNESTED_RESOURCE: RFC 3779 resource not subset of parent's resources>
+
+See RFC 3779 for details.
 
 =item B<X509_V_ERR_PERMITTED_VIOLATION: permitted subtree violation>
 
@@ -306,6 +348,11 @@ name constraints minimum and maximum not supported>
 A certificate name constraints extension included a minimum or maximum field:
 this is not supported.
 
+=item B<X509_V_ERR_APPLICATION_VERIFICATION: application verification failure>
+
+An application specific error. This will never be returned unless explicitly
+set by an application callback.
+
 =item B<X509_V_ERR_UNSUPPORTED_CONSTRAINT_TYPE:
 unsupported name constraint type>
 
@@ -319,57 +366,14 @@ The format of the name constraint is not recognised: for example an email
 address format of a form not mentioned in RFC3280. This could be caused by
 a garbage extension or some new feature not currently supported.
 
+=item B<X509_V_ERR_UNSUPPORTED_NAME_SYNTAX: unsupported or invalid name syntax>
+
+Unsupported or invalid name syntax.
+
 =item B<X509_V_ERR_CRL_PATH_VALIDATION_ERROR: CRL path validation error>
 
 An error occurred when attempting to verify the CRL path. This error can only
 happen if extended CRL checking is enabled.
-
-=item B<X509_V_ERR_APPLICATION_VERIFICATION: application verification failure>
-
-An application specific error. This will never be returned unless explicitly
-set by an application callback.
-
-=item B<X509_V_ERR_UNABLE_TO_GET_CRL_ISSUER: unable to get CRL issuer certificate>
-
-Unable to get CRL issuer certificate.
-
-=item B<X509_V_ERR_UNHANDLED_CRITICAL_EXTENSION: unhandled critical extension>
-
-Unhandled critical extension.
-
-=item B<X509_V_ERR_KEYUSAGE_NO_CRL_SIGN: key usage does not include CRL signing>
-
-Key usage does not include CRL signing.
-
-=item B<X509_V_ERR_UNHANDLED_CRITICAL_CRL_EXTENSION: unhandled critical CRL extension>
-
-Unhandled critical CRL extension.
-
-=item B<X509_V_ERR_INVALID_NON_CA: invalid non-CA certificate (has CA markings)>
-
-Invalid non-CA certificate has CA markings.
-
-=item B<X509_V_ERR_PROXY_PATH_LENGTH_EXCEEDED: proxy path length constraint exceeded>
-
-Proxy path length constraint exceeded.
-
-=item B<X509_V_ERR_KEYUSAGE_NO_DIGITAL_SIGNATURE: key usage does not include digital signature>
-
-Key usage does not include digital signature, and therefore cannot sign
-certificates.
-
-=item B<X509_V_ERR_PROXY_CERTIFICATES_NOT_ALLOWED: proxy certificates not allowed, please set the appropriate flag>
-
-Proxy certificates not allowed unless the B<X509_V_FLAG_ALLOW_PROXY_CERTS> flag
-is set.
-
-=item B<X509_V_ERR_UNNESTED_RESOURCE: RFC 3779 resource not subset of parent's resources>
-
-See RFC 3779 for details.
-
-=item B<X509_V_ERR_UNSUPPORTED_NAME_SYNTAX: unsupported or invalid name syntax>
-
-Unsupported or invalid name syntax.
 
 =item B<X509_V_ERR_PATH_LOOP: path loop>
 
@@ -434,14 +438,27 @@ Returned by the verify callback to indicate OCSP verification failed.
 Returned by the verify callback to indicate that the certificate is not
 recognized by the OCSP responder.
 
-=item B<X509_V_ERR_NO_ISSUER_PUBLIC_KEY: issuer certificate doesn't have a public key>
+=item B<X509_V_ERR_UNSUPPORTED_SIGNATURE_ALGORITHM:
+unsupported signature algorithm>
 
-The issuer certificate does not have a public key.
+Cannot find certificate signature algorithm.
 
-=item B<X509_V_ERR_SIGNATURE_ALGORITHM_MISMATCH: subject signature algorithm and issuer public key algorithm mismatch>
+=item B<X509_V_ERR_SIGNATURE_ALGORITHM_MISMATCH:
+subject signature algorithm and issuer public key algorithm mismatch>
 
 The issuer's public key is not of the type required by the signature in
 the subject's certificate.
+
+=item B<X509_V_ERR_SIGNATURE_ALGORITHM_INCONSISTENCY:
+cert info signature and signature algorithm mismatch>
+
+The algorithm given in the certificate info is inconsistent
+ with the one used for the certificate signature.
+
+=item B<X509_V_ERR_INVALID_CA: invalid CA certificate>
+
+A CA certificate is invalid. Either it is not a CA or its extensions are not
+consistent with the supplied purpose.
 
 =back
 


### PR DESCRIPTION
This is a spin-off from #14218, making the X509 verification error doc more complete and consistent with `x509_vfy.h.in` and `x509_txt.c`.

Also add a respective comment to `x509_txt.c` as a reminder:
```
        /*
         * Entries must be kept consistent with include/openssl/x509_vfy.h.in
         * and with doc/man3/X509_STORE_CTX_get_error.pod
         */
```