### PR TITLE
QUIC User Datagram Injection

### DIFF
--- a/doc/build.info
+++ b/doc/build.info
@@ -2583,6 +2583,10 @@ DEPEND[html/man3/SSL_in_init.html]=man3/SSL_in_init.pod
 GENERATE[html/man3/SSL_in_init.html]=man3/SSL_in_init.pod
 DEPEND[man/man3/SSL_in_init.3]=man3/SSL_in_init.pod
 GENERATE[man/man3/SSL_in_init.3]=man3/SSL_in_init.pod
+DEPEND[html/man3/SSL_inject_net_dgram.html]=man3/SSL_inject_net_dgram.pod
+GENERATE[html/man3/SSL_inject_net_dgram.html]=man3/SSL_inject_net_dgram.pod
+DEPEND[man/man3/SSL_inject_net_dgram.3]=man3/SSL_inject_net_dgram.pod
+GENERATE[man/man3/SSL_inject_net_dgram.3]=man3/SSL_inject_net_dgram.pod
 DEPEND[html/man3/SSL_key_update.html]=man3/SSL_key_update.pod
 GENERATE[html/man3/SSL_key_update.html]=man3/SSL_key_update.pod
 DEPEND[man/man3/SSL_key_update.3]=man3/SSL_key_update.pod
@@ -3489,6 +3493,7 @@ html/man3/SSL_get_verify_result.html \
 html/man3/SSL_get_version.html \
 html/man3/SSL_group_to_name.html \
 html/man3/SSL_in_init.html \
+html/man3/SSL_inject_net_dgram.html \
 html/man3/SSL_key_update.html \
 html/man3/SSL_library_init.html \
 html/man3/SSL_load_client_CA_file.html \
@@ -4112,6 +4117,7 @@ man/man3/SSL_get_verify_result.3 \
 man/man3/SSL_get_version.3 \
 man/man3/SSL_group_to_name.3 \
 man/man3/SSL_in_init.3 \
+man/man3/SSL_inject_net_dgram.3 \
 man/man3/SSL_key_update.3 \
 man/man3/SSL_library_init.3 \
 man/man3/SSL_load_client_CA_file.3 \

--- a/doc/man3/SSL_inject_net_dgram.pod
+++ b/doc/man3/SSL_inject_net_dgram.pod
@@ -39,9 +39,13 @@ on a SSL object which is not a QUIC connection SSL object.
 
 L<OSSL_QUIC_client_method(3)>, L<SSL_tick(3)>, L<SSL_set_blocking_mode(3)>
 
+=head1 HISTORY
+
+The function SSL_inject_net_dgram() was added in OpenSSL 3.2.
+
 =head1 COPYRIGHT
 
-Copyright 2000-2023 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2023 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/doc/man3/SSL_inject_net_dgram.pod
+++ b/doc/man3/SSL_inject_net_dgram.pod
@@ -1,0 +1,51 @@
+=pod
+
+=head1 NAME
+
+SSL_inject_net_dgram - inject a datagram as though received from the network
+
+=head1 SYNOPSIS
+
+ #include <openssl/ssl.h>
+
+ int SSL_inject_net_dgram(SSL *s, const unsigned char *buf,
+                          size_t buf_len,
+                          const BIO_ADDR *peer,
+                          const BIO_ADDR *local);
+
+=head1 DESCRIPTION
+
+This function can be used to inject a datagram payload to a QUIC connection SSL
+object. The payload is processed as though it was received from the network.
+This function can be used for debugging purposes or to allow datagrams to be fed
+to QUIC from alternative sources.
+
+I<buf> is required and must point to a datagram payload to inject. I<buf_len> is
+the length of the buffer in bytes. The buffer is copied and need not remain
+valid after this function returns.
+
+I<peer> and I<local> are optional values pointing to B<BIO_ADDR> structures
+describing the remote and local UDP endpoint addresses for the packet. Though
+the injected packet was not actually received from the network directly by
+OpenSSL, the packet will be processed as though the received datagram had the
+given addresses.
+
+=head1 RETURN VALUES
+
+Returns 1 on success or 0 on failure. This function always fails if called
+on a SSL object which is not a QUIC connection SSL object.
+
+=head1 SEE ALSO
+
+L<OSSL_QUIC_client_method(3)>, L<SSL_tick(3)>, L<SSL_set_blocking_mode(3)>
+
+=head1 COPYRIGHT
+
+Copyright 2000-2023 The OpenSSL Project Authors. All Rights Reserved.
+
+Licensed under the Apache License 2.0 (the "License").  You may not use
+this file except in compliance with the License.  You can obtain a copy
+in the file LICENSE in the source distribution or at
+L<https://www.openssl.org/source/license.html>.
+
+=cut

--- a/include/internal/quic_channel.h
+++ b/include/internal/quic_channel.h
@@ -194,6 +194,8 @@ int ossl_quic_channel_is_active(const QUIC_CHANNEL *ch);
 int ossl_quic_channel_is_handshake_complete(const QUIC_CHANNEL *ch);
 int ossl_quic_channel_is_handshake_confirmed(const QUIC_CHANNEL *ch);
 
+QUIC_DEMUX *ossl_quic_channel_get0_demux(QUIC_CHANNEL *ch);
+
 SSL *ossl_quic_channel_get0_ssl(QUIC_CHANNEL *ch);
 
 # endif

--- a/include/openssl/ssl.h.in
+++ b/include/openssl/ssl.h.in
@@ -2257,6 +2257,12 @@ __owur int SSL_net_write_desired(SSL *s);
 __owur int SSL_set_blocking_mode(SSL *s, int blocking);
 __owur int SSL_get_blocking_mode(SSL *s);
 __owur int SSL_set_initial_peer_addr(SSL *s, const BIO_ADDR *peer_addr);
+# ifndef OPENSSL_NO_QUIC
+__owur int SSL_inject_net_dgram(SSL *s, const unsigned char *buf,
+                                size_t buf_len,
+                                const BIO_ADDR *peer,
+                                const BIO_ADDR *local);
+# endif
 
 typedef struct ssl_shutdown_ex_args_st {
     uint64_t    quic_error_code;

--- a/ssl/quic/quic_channel.c
+++ b/ssl/quic/quic_channel.c
@@ -436,6 +436,11 @@ int ossl_quic_channel_is_handshake_confirmed(const QUIC_CHANNEL *ch)
     return ch->handshake_confirmed;
 }
 
+QUIC_DEMUX *ossl_quic_channel_get0_demux(QUIC_CHANNEL *ch)
+{
+    return ch->demux;
+}
+
 /*
  * QUIC Channel: Callbacks from Miscellaneous Subsidiary Components
  * ================================================================

--- a/ssl/quic/quic_demux.c
+++ b/ssl/quic/quic_demux.c
@@ -600,6 +600,9 @@ int ossl_quic_demux_inject(QUIC_DEMUX *demux,
     else
         BIO_ADDR_clear(&urxe->local);
 
+    urxe->time
+        = demux->now != NULL ? demux->now(demux->now_arg) : ossl_time_zero();
+
     /* Move from free list to pending list. */
     ossl_list_urxe_remove(&demux->urx_free, urxe);
     ossl_list_urxe_insert_tail(&demux->urx_pending, urxe);

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -1233,6 +1233,29 @@ int ossl_quic_conn_stream_conclude(QUIC_CONNECTION *qc)
 }
 
 /*
+ * SSL_inject_net_dgram
+ * --------------------
+ */
+int SSL_inject_net_dgram(SSL *s, const unsigned char *buf,
+                         size_t buf_len,
+                         const BIO_ADDR *peer,
+                         const BIO_ADDR *local)
+{
+    QUIC_CONNECTION *qc = QUIC_CONNECTION_FROM_SSL(s);
+    QUIC_DEMUX *demux;
+
+    if (!expect_quic_conn(qc))
+        return 0;
+
+    if (qc->ch == NULL)
+        return QUIC_RAISE_NON_NORMAL_ERROR(qc, ERR_R_SHOULD_NOT_HAVE_BEEN_CALLED,
+                                           NULL);
+
+    demux = ossl_quic_channel_get0_demux(qc->ch);
+    return ossl_quic_demux_inject(demux, buf, buf_len, peer, local);
+}
+
+/*
  * QUIC Front-End I/O API: SSL_CTX Management
  * ==========================================
  */

--- a/test/quic_tserver_test.c
+++ b/test/quic_tserver_test.c
@@ -104,7 +104,7 @@ static int test_tserver(int test_kind)
          * In inject mode we create a dgram pair to feed to the QUIC client on
          * the read side. We don't feed anything to this, it is just a
          * placeholder to give the client something which never returns any
-         * datagrams..
+         * datagrams.
          */
         if (!TEST_true(BIO_new_bio_dgram_pair(&c_pair_own, 5000,
                                               &s_pair_own, 5000)))

--- a/util/libssl.num
+++ b/util/libssl.num
@@ -543,3 +543,4 @@ SSL_net_read_desired                    ?	3_2_0	EXIST::FUNCTION:
 SSL_net_write_desired                   ?	3_2_0	EXIST::FUNCTION:
 SSL_shutdown_ex                         ?	3_2_0	EXIST::FUNCTION:
 SSL_stream_conclude                     ?	3_2_0	EXIST::FUNCTION:
+SSL_inject_net_dgram                    ?	3_2_0	EXIST::FUNCTION:QUIC


### PR DESCRIPTION
This adds a function which can be used to inject datagrams manually into a QUIC connection as though they were received from the network.

cc @t-j-h 