### PR TITLE
aes/asm/bsaes-armv7.pl: Replace adrl with add

### DIFF
--- a/crypto/aes/asm/bsaes-armv7.pl
+++ b/crypto/aes/asm/bsaes-armv7.pl
@@ -1447,7 +1447,7 @@ ossl_bsaes_ctr32_encrypt_blocks:
 .align	2
 0:	add	r12, $key, #248
 	vld1.8	{@XMM[0]}, [$ctr]		@ load counter
-	adrl	$ctr, .LREVM0SR			@ borrow $ctr
+	add	$ctr, $const, #.LREVM0SR-.LM0	@ borrow $ctr
 	vldmia	r12, {@XMM[4]}			@ load round0 key
 	sub	sp, #0x10			@ place for adjusted round0 key
 #endif


### PR DESCRIPTION
"adrl" is a pseudo-instruction used to calculate an address relative to PC. It's not recognized by clang resulting in a compilation error. I've stumbled upon it when trying to integrate the bsaes-armv7 assmebly logic into FreeBSD kernel, which uses clang as it's default compiler. Note that this affect the build only if BSAES_ASM_EXTENDED_KEY is defined, which is not the default option in OpenSSL.

The solution here is to replace it with an add instruction. This mimics what has already been done in !BSAES_ASM_EXTENDED_KEY logic. Because of that I've marked this as trivial CLA.