### PR TITLE
Added key management im(ex)portable params

### DIFF
--- a/crypto/evp/keymgmt_meth.c
+++ b/crypto/evp/keymgmt_meth.c
@@ -486,6 +486,12 @@ const OSSL_PARAM *evp_keymgmt_import_types(const EVP_KEYMGMT *keymgmt,
     return keymgmt->import_types(selection);
 }
 
+const OSSL_PARAM *EVP_KEYMGMT_importable_params(const EVP_KEYMGMT *keymgmt,
+                                                int selection)
+{
+    return evp_keymgmt_import_types(keymgmt, selection);
+}
+
 int evp_keymgmt_export(const EVP_KEYMGMT *keymgmt, void *keydata,
                        int selection, OSSL_CALLBACK *param_cb, void *cbarg)
 {
@@ -504,6 +510,12 @@ const OSSL_PARAM *evp_keymgmt_export_types(const EVP_KEYMGMT *keymgmt,
     if (keymgmt->export_types == NULL)
         return NULL;
     return keymgmt->export_types(selection);
+}
+
+const OSSL_PARAM *EVP_KEYMGMT_exportable_params(const EVP_KEYMGMT *keymgmt,
+                                                int selection)
+{
+    return evp_keymgmt_export_types(keymgmt, selection);
 }
 
 void *evp_keymgmt_dup(const EVP_KEYMGMT *keymgmt, const void *keydata_from,

--- a/doc/man3/EVP_KEYMGMT.pod
+++ b/doc/man3/EVP_KEYMGMT.pod
@@ -14,7 +14,9 @@ EVP_KEYMGMT_do_all_provided,
 EVP_KEYMGMT_names_do_all,
 EVP_KEYMGMT_gettable_params,
 EVP_KEYMGMT_settable_params,
-EVP_KEYMGMT_gen_settable_params
+EVP_KEYMGMT_gen_settable_params,
+EVP_KEYMGMT_importable_params,
+EVP_KEYMGMT_exportable_params,
 - EVP key management routines
 
 =head1 SYNOPSIS
@@ -41,6 +43,10 @@ EVP_KEYMGMT_gen_settable_params
  const OSSL_PARAM *EVP_KEYMGMT_gettable_params(const EVP_KEYMGMT *keymgmt);
  const OSSL_PARAM *EVP_KEYMGMT_settable_params(const EVP_KEYMGMT *keymgmt);
  const OSSL_PARAM *EVP_KEYMGMT_gen_settable_params(const EVP_KEYMGMT *keymgmt);
+ const OSSL_PARAM *EVP_KEYMGMT_importable_params(const EVP_KEYMGMT *keymgmt,
+                                                 int selection);
+ const OSSL_PARAM *EVP_KEYMGMT_exportable_params(const EVP_KEYMGMT *keymgmt,
+                                                 int selection);
 
 =head1 DESCRIPTION
 
@@ -92,6 +98,10 @@ constant L<OSSL_PARAM(3)> array that describes the names and types of key
 parameters that can be retrieved or set.
 EVP_KEYMGMT_gettable_params() is used by L<EVP_PKEY_gettable_params(3)>.
 
+EVP_KEYMGMT_importable_params() and EVP_KEYMGMT_exportable_params() return a
+constant L<OSSL_PARAM(3)> array that describes the names and types of key
+parameters that can be imported or exported for this key management.
+
 EVP_KEYMGMT_gen_settable_params() returns a constant L<OSSL_PARAM(3)> array that
 describes the names and types of key generation parameters that can be set via
 L<EVP_PKEY_CTX_set_params(3)>.
@@ -126,7 +136,8 @@ EVP_KEYMGMT_get0_name() returns the algorithm name, or NULL on error.
 EVP_KEYMGMT_get0_description() returns a pointer to a description, or NULL if
 there isn't one.
 
-EVP_KEYMGMT_gettable_params(), EVP_KEYMGMT_settable_params() and
+EVP_KEYMGMT_gettable_params(), EVP_KEYMGMT_settable_params(), 
+EVP_KEYMGMT_importable_params(), EVP_KEYMGMT_exportable_params(), and
 EVP_KEYMGMT_gen_settable_params() return a constant L<OSSL_PARAM(3)> array or
 NULL on error.
 

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -1774,6 +1774,10 @@ int EVP_KEYMGMT_names_do_all(const EVP_KEYMGMT *keymgmt,
 const OSSL_PARAM *EVP_KEYMGMT_gettable_params(const EVP_KEYMGMT *keymgmt);
 const OSSL_PARAM *EVP_KEYMGMT_settable_params(const EVP_KEYMGMT *keymgmt);
 const OSSL_PARAM *EVP_KEYMGMT_gen_settable_params(const EVP_KEYMGMT *keymgmt);
+const OSSL_PARAM *EVP_KEYMGMT_importable_params(const EVP_KEYMGMT *keymgmt,
+                                                int selection);
+const OSSL_PARAM *EVP_KEYMGMT_exportable_params(const EVP_KEYMGMT *keymgmt,
+                                                int selection);
 
 EVP_PKEY_CTX *EVP_PKEY_CTX_new(EVP_PKEY *pkey, ENGINE *e);
 EVP_PKEY_CTX *EVP_PKEY_CTX_new_id(int id, ENGINE *e);


### PR DESCRIPTION
CLA: trivial
Added 2 method to get importable and exportable params from key management:
```
EVP_KEYMGMT_importable_params
EVP_KEYMGMT_exportable_params
```
These 2 methods can be used to get im(ex)ported types from another key management
which comes handy if you are going to make decisions based on feasibility of importing
or exporting some parameter in the key management interface.
 
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
