### PR TITLE
crypto/init.c: gcc build warning fix

### DIFF
--- a/crypto/init.c
+++ b/crypto/init.c
@@ -760,7 +760,7 @@ int OPENSSL_atexit(void (*handler)(void))
         union {
             void *sym;
             void (*func)(void);
-        } handlersym;
+        } handlersym = { 0 };
 
         handlersym.func = handler;
 # if defined(DSO_WIN32) && !defined(_WIN32_WCE)


### PR DESCRIPTION
Fix the gcc build warning from crypto/init.c:
variable handlersym set but not used [-Wunused-but-set-variable]

Signed-off-by: Gang Chen <gang.c.chen@intel.com>