### PR TITLE
Fix aarch64 signed bit shift issue found by UBSAN

### DIFF
--- a/crypto/aes/asm/bsaes-armv8.pl
+++ b/crypto/aes/asm/bsaes-armv8.pl
@@ -1019,13 +1019,9 @@ _bsaes_key_convert:
 //   No output registers, usual AAPCS64 register preservation
 ossl_bsaes_cbc_encrypt:
         cmp     x2, #128
-#ifdef __APPLE__
         bhs     .Lcbc_do_bsaes
         b       AES_cbc_encrypt
 .Lcbc_do_bsaes:
-#else
-        blo     AES_cbc_encrypt
-#endif
 
         // it is up to the caller to make sure we are called with enc == 0
 


### PR DESCRIPTION
OpenSSL 3.1.0 will be released soon so I tried to build it on all architectures and noticed build failure on aarch64.

```
[  208s] 	providers/libdefault.a providers/libcommon.a  -lz -ldl -pthread
[  208s] crypto/aes/libcrypto-shlib-bsaes-armv8.o: in function `ossl_bsaes_cbc_encrypt':
[  208s] /home/abuild/rpmbuild/BUILD/openssl-3.1/crypto/aes/bsaes-armv8.S:993:(.text+0xdd4): relocation truncated to fit: R_AARCH64_CONDBR19 against symbol `AES_cbc_encrypt' defined in .text section in /tmp/ccVvtSGQ.ltrans0.ltrans.o
[  208s] collect2: error: ld returned 1 exit status
[  208s] make[1]: *** [Makefile:5340: libcrypto.so.3] Error 1
```

It's same issue as reported #18813 and after applying patch 1efd8533e1c the build succeeds.

Above commit was backported into 3.0 branch but only partially (3f348a0f6c3). First hunk is missing and this is causing this failure in openssl-3.1.0-beta1 and also in openssl-3.1 so I cherry-picked missing part.

@mattcaswell would it be possible to merge it before OpenSSL 3.1.0 release date?