### PR TITLE
Added `CERTIFICATE_VERIFY_MAX_LENGTH` constant

### DIFF
--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -1020,7 +1020,7 @@ size_t ossl_statem_client_max_message_size(SSL_CONNECTION *s)
         return s->max_cert_list;
 
     case TLS_ST_CR_CERT_VRFY:
-        return SSL3_RT_MAX_PLAIN_LENGTH;
+        return CERTIFICATE_VERIFY_MAX_LENGTH;
 
     case TLS_ST_CR_CERT_STATUS:
         return SSL3_RT_MAX_PLAIN_LENGTH;

--- a/ssl/statem/statem_local.h
+++ b/ssl/statem/statem_local.h
@@ -31,6 +31,9 @@
 /* Max ServerHello size permitted by RFC 8446 */
 #define SERVER_HELLO_MAX_LENGTH         65607
 
+/* Max CertificateVerify size permitted by RFC 8446 */
+#define CERTIFICATE_VERIFY_MAX_LENGTH   65538
+
 /* Max should actually be 36 but we are generous */
 #define FINISHED_MAX_LENGTH             64
 

--- a/ssl/statem/statem_local.h
+++ b/ssl/statem/statem_local.h
@@ -32,7 +32,7 @@
 #define SERVER_HELLO_MAX_LENGTH         65607
 
 /* Max CertificateVerify size permitted by RFC 8446 */
-#define CERTIFICATE_VERIFY_MAX_LENGTH   65538
+#define CERTIFICATE_VERIFY_MAX_LENGTH   65539
 
 /* Max should actually be 36 but we are generous */
 #define FINISHED_MAX_LENGTH             64

--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -1223,7 +1223,7 @@ size_t ossl_statem_server_max_message_size(SSL_CONNECTION *s)
         return CLIENT_KEY_EXCH_MAX_LENGTH;
 
     case TLS_ST_SR_CERT_VRFY:
-        return SSL3_RT_MAX_PLAIN_LENGTH;
+        return CERTIFICATE_VERIFY_MAX_LENGTH;
 
 #ifndef OPENSSL_NO_NEXTPROTONEG
     case TLS_ST_SR_NEXT_PROTO:


### PR DESCRIPTION
- Set `CERTIFICATE_VERIFY_MAX_LENGTH` to `65539 = 2^16 - 1 + 2 + 2`
- Changed `SSL3_RT_MAX_PLAIN_LENGTH` to `CERTIFICATE_VERIFY_MAX_LENGTH`  in `case TLS_ST_CR_CERT_VRFY` in the function `ossl_statem_client_max_message_size` of `statem_clnt.c` and in the function `ossl_statem_server_max_message_size` of `statem_srvr.c`
- Addresses [#20478](https://github.com/openssl/openssl/issues/20478)