### PR TITLE
Special case SM2 when decoding PEM file

### DIFF
--- a/crypto/encode_decode/decoder_pkey.c
+++ b/crypto/encode_decode/decoder_pkey.c
@@ -314,7 +314,8 @@ int ossl_decoder_ctx_setup_for_pkey(OSSL_DECODER_CTX *ctx,
 
     if (keytype != NULL
             && (strcmp(keytype, "id-ecPublicKey") == 0
-                || strcmp(keytype, "1.2.840.10045.2.1") == 0))
+                || strcmp(keytype, "1.2.840.10045.2.1") == 0
+                || strcmp(keytype, "EC") == 0))
         isecoid = 1;
 
     OSSL_TRACE_BEGIN(DECODER) {


### PR DESCRIPTION
fix: https://github.com/openssl/openssl/issues/20420

It is different that the SM2 private key PEM files generated by the version 1.1 and the version after 3.0, which the file generated by 1.1 is BEGIN as  "-----BEGIN EC PRIVATE KEY-----". To enable the version after 3.0 to support SM2 PEM private key file generated by 1.1 version, we have to special case SM2 when we encounter the EC type.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
