### PR TITLE
fixing up EVP_PKEY_get_id for providers

### DIFF
--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -982,7 +982,7 @@ int EVP_PKEY_type(int type)
 
 int EVP_PKEY_get_id(const EVP_PKEY *pkey)
 {
-    return pkey->type > 0 ? pkey->type : NID_undef;
+    return pkey->type;
 }
 
 int EVP_PKEY_get_base_id(const EVP_PKEY *pkey)

--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -982,7 +982,7 @@ int EVP_PKEY_type(int type)
 
 int EVP_PKEY_get_id(const EVP_PKEY *pkey)
 {
-    return pkey->type;
+    return pkey->type > 0 ? pkey->type : NID_undef;
 }
 
 int EVP_PKEY_get_base_id(const EVP_PKEY *pkey)

--- a/doc/man3/EVP_PKEY_set1_RSA.pod
+++ b/doc/man3/EVP_PKEY_set1_RSA.pod
@@ -63,7 +63,7 @@ EVP_PKEY_get_base_id() returns the type of I<pkey>. For example
 an RSA key will return B<EVP_PKEY_RSA>.
 
 EVP_PKEY_get_id() returns the actual NID associated with I<pkey>
-if I<pkey> is (also) implemented outside of a L<provider(7)>.
+only if the I<pkey> type isn't implemented just in a L<provider(7)>.
 Historically keys using the same algorithm could use different NIDs.
 For example an RSA key could use the NIDs corresponding to
 the NIDs B<NID_rsaEncryption> (equivalent to B<EVP_PKEY_RSA>) or

--- a/doc/man3/EVP_PKEY_set1_RSA.pod
+++ b/doc/man3/EVP_PKEY_set1_RSA.pod
@@ -146,8 +146,7 @@ EVP_PKEY_get_id(), EVP_PKEY_get_base_id(), EVP_PKEY_type()
 For EVP_PKEY key type checking purposes, L<EVP_PKEY_is_a(3)> is more generic.
 
 For purposes of retrieving the name of the B<EVP_PKEY> the function
-L<EVP_PKEY_get0_type_name(3)> is more generally useful, particularly if
-the PKEY is implemented in a L<provider(7)>.
+L<EVP_PKEY_get0_type_name(3)> is more generally useful.
 
 The keys returned from the functions EVP_PKEY_get0_RSA(), EVP_PKEY_get0_DSA(),
 EVP_PKEY_get0_DH() and EVP_PKEY_get0_EC_KEY() were changed to have a "const"

--- a/doc/man3/EVP_PKEY_set1_RSA.pod
+++ b/doc/man3/EVP_PKEY_set1_RSA.pod
@@ -62,12 +62,12 @@ see L<openssl_user_macros(7)>:
 EVP_PKEY_get_base_id() returns the type of I<pkey>. For example
 an RSA key will return B<EVP_PKEY_RSA>.
 
-EVP_PKEY_get_id() returns the actual OID associated with I<pkey>.
-Historically keys using the same algorithm could use different OIDs.
-For example an RSA key could use the OIDs corresponding to
+EVP_PKEY_get_id() returns the actual NID associated with I<pkey>.
+Historically keys using the same algorithm could use different NIDs.
+For example an RSA key could use the NIDs corresponding to
 the NIDs B<NID_rsaEncryption> (equivalent to B<EVP_PKEY_RSA>) or
 B<NID_rsa> (equivalent to B<EVP_PKEY_RSA2>). The use of
-alternative non-standard OIDs is now rare so B<EVP_PKEY_RSA2> et al are not
+alternative non-standard NIDs is now rare so B<EVP_PKEY_RSA2> et al are not
 often seen in practice.
 
 EVP_PKEY_type() returns the underlying type of the NID I<type>. For example
@@ -141,6 +141,10 @@ been assigned an internal key with EVP_PKEY_assign_*():
 EVP_PKEY_get_id(), EVP_PKEY_get_base_id(), EVP_PKEY_type()
 
 For EVP_PKEY key type checking purposes, L<EVP_PKEY_is_a(3)> is more generic.
+
+For purposes of retrieving the name of the B<EVP_PKEY> the function
+L<EVP_PKEY_get0_type_name(3)> is more generally useful, particularly if
+the PKEY is implemented in a provider.
 
 The keys returned from the functions EVP_PKEY_get0_RSA(), EVP_PKEY_get0_DSA(),
 EVP_PKEY_get0_DH() and EVP_PKEY_get0_EC_KEY() were changed to have a "const"

--- a/doc/man3/EVP_PKEY_set1_RSA.pod
+++ b/doc/man3/EVP_PKEY_set1_RSA.pod
@@ -63,14 +63,14 @@ EVP_PKEY_get_base_id() returns the type of I<pkey>. For example
 an RSA key will return B<EVP_PKEY_RSA>.
 
 EVP_PKEY_get_id() returns the actual NID associated with I<pkey>
-if I<pkey> is implemented outside of a L<provider(7)>.
+if I<pkey> is (also) implemented outside of a L<provider(7)>.
 Historically keys using the same algorithm could use different NIDs.
 For example an RSA key could use the NIDs corresponding to
 the NIDs B<NID_rsaEncryption> (equivalent to B<EVP_PKEY_RSA>) or
 B<NID_rsa> (equivalent to B<EVP_PKEY_RSA2>). The use of
 alternative non-standard NIDs is now rare so B<EVP_PKEY_RSA2> et al are not
 often seen in practice.
-EVP_PKEY_get_id() returns -1 (EVP_PKEY_KEYMGMT) if the I<pkey> is
+EVP_PKEY_get_id() returns -1 (B<EVP_PKEY_KEYMGMT>) if the I<pkey> is
 only implemented in a L<provider(7)>.
 
 EVP_PKEY_type() returns the underlying type of the NID I<type>. For example

--- a/doc/man3/EVP_PKEY_set1_RSA.pod
+++ b/doc/man3/EVP_PKEY_set1_RSA.pod
@@ -62,13 +62,16 @@ see L<openssl_user_macros(7)>:
 EVP_PKEY_get_base_id() returns the type of I<pkey>. For example
 an RSA key will return B<EVP_PKEY_RSA>.
 
-EVP_PKEY_get_id() returns the actual NID associated with I<pkey>.
+EVP_PKEY_get_id() returns the actual NID associated with I<pkey>
+if I<pkey> is not implemented in an external L<provider(7)>.
 Historically keys using the same algorithm could use different NIDs.
 For example an RSA key could use the NIDs corresponding to
 the NIDs B<NID_rsaEncryption> (equivalent to B<EVP_PKEY_RSA>) or
 B<NID_rsa> (equivalent to B<EVP_PKEY_RSA2>). The use of
 alternative non-standard NIDs is now rare so B<EVP_PKEY_RSA2> et al are not
 often seen in practice.
+EVP_PKEY_get_id() returns -1 (EVP_PKEY_KEYMGMT) if the I<pkey> is
+implemented in an external L<provider(7)>.
 
 EVP_PKEY_type() returns the underlying type of the NID I<type>. For example
 EVP_PKEY_type(EVP_PKEY_RSA2) will return B<EVP_PKEY_RSA>.
@@ -144,7 +147,7 @@ For EVP_PKEY key type checking purposes, L<EVP_PKEY_is_a(3)> is more generic.
 
 For purposes of retrieving the name of the B<EVP_PKEY> the function
 L<EVP_PKEY_get0_type_name(3)> is more generally useful, particularly if
-the PKEY is implemented in a provider.
+the PKEY is implemented in a L<provider(7)>.
 
 The keys returned from the functions EVP_PKEY_get0_RSA(), EVP_PKEY_get0_DSA(),
 EVP_PKEY_get0_DH() and EVP_PKEY_get0_EC_KEY() were changed to have a "const"

--- a/doc/man3/EVP_PKEY_set1_RSA.pod
+++ b/doc/man3/EVP_PKEY_set1_RSA.pod
@@ -63,7 +63,7 @@ EVP_PKEY_get_base_id() returns the type of I<pkey>. For example
 an RSA key will return B<EVP_PKEY_RSA>.
 
 EVP_PKEY_get_id() returns the actual NID associated with I<pkey>
-if I<pkey> is not implemented in an external L<provider(7)>.
+if I<pkey> is implemented outside of a L<provider(7)>.
 Historically keys using the same algorithm could use different NIDs.
 For example an RSA key could use the NIDs corresponding to
 the NIDs B<NID_rsaEncryption> (equivalent to B<EVP_PKEY_RSA>) or
@@ -71,7 +71,7 @@ B<NID_rsa> (equivalent to B<EVP_PKEY_RSA2>). The use of
 alternative non-standard NIDs is now rare so B<EVP_PKEY_RSA2> et al are not
 often seen in practice.
 EVP_PKEY_get_id() returns -1 (EVP_PKEY_KEYMGMT) if the I<pkey> is
-implemented in an external L<provider(7)>.
+only implemented in a L<provider(7)>.
 
 EVP_PKEY_type() returns the underlying type of the NID I<type>. For example
 EVP_PKEY_type(EVP_PKEY_RSA2) will return B<EVP_PKEY_RSA>.

--- a/doc/man7/migration_guide.pod
+++ b/doc/man7/migration_guide.pod
@@ -1813,6 +1813,19 @@ See L</Deprecated low-level key object getters and setters>
 
 =item *
 
+EVP_PKEY_id()
+
+This function was previously used to reliably return the NID of
+an EVP_PKEY object, e.g., to look up the name of the algorithm of
+such EVP_PKEY by calling L<OBJ_nid2sn(3)>. With the introduction
+of L<provider(7)>s EVP_PKEY_id() or its new equivalent
+L<EVP_PKEY_get_id(3)> might now also return the value -1 indicating
+the use of a provider to implement the EVP_PKEY object.
+Therefore, the use of L<EVP_PKEY_get0_type_name(3)> is recommended
+for retrieving the name of the EVP_PKEY algorithm.
+
+=item *
+
 EVP_PKEY_set1_tls_encodedpoint() EVP_PKEY_get1_tls_encodedpoint()
 
 These functions were previously used by libssl to set or get an encoded public

--- a/doc/man7/migration_guide.pod
+++ b/doc/man7/migration_guide.pod
@@ -2256,10 +2256,11 @@ This function was previously used to reliably return the NID of
 an EVP_PKEY object, e.g., to look up the name of the algorithm of
 such EVP_PKEY by calling L<OBJ_nid2sn(3)>. With the introduction
 of L<provider(7)>s EVP_PKEY_id() or its new equivalent
-L<EVP_PKEY_get_id(3)> might now also return the value -1 indicating
-the use of a provider to implement the EVP_PKEY object.
-Therefore, the use of L<EVP_PKEY_get0_type_name(3)> is recommended
-for retrieving the name of the EVP_PKEY algorithm.
+L<EVP_PKEY_get_id(3)> might now also return the value -1
+(B<EVP_PKEY_KEYMGMT>) indicating the use of a provider to
+implement the EVP_PKEY object. Therefore, the use of
+L<EVP_PKEY_get0_type_name(3)> is recommended for retrieving
+the name of the EVP_PKEY algorithm.
 
 =back
 

--- a/doc/man7/migration_guide.pod
+++ b/doc/man7/migration_guide.pod
@@ -1813,19 +1813,6 @@ See L</Deprecated low-level key object getters and setters>
 
 =item *
 
-EVP_PKEY_id()
-
-This function was previously used to reliably return the NID of
-an EVP_PKEY object, e.g., to look up the name of the algorithm of
-such EVP_PKEY by calling L<OBJ_nid2sn(3)>. With the introduction
-of L<provider(7)>s EVP_PKEY_id() or its new equivalent
-L<EVP_PKEY_get_id(3)> might now also return the value -1 indicating
-the use of a provider to implement the EVP_PKEY object.
-Therefore, the use of L<EVP_PKEY_get0_type_name(3)> is recommended
-for retrieving the name of the EVP_PKEY algorithm.
-
-=item *
-
 EVP_PKEY_set1_tls_encodedpoint() EVP_PKEY_get1_tls_encodedpoint()
 
 These functions were previously used by libssl to set or get an encoded public
@@ -2252,6 +2239,27 @@ and L<X509_get0_signature(3)> instead.
 X509_http_nbio(), X509_CRL_http_nbio()
 
 Use L<X509_load_http(3)> and L<X509_CRL_load_http(3)> instead.
+
+=back
+
+=head3 NID handling for provided keys and algorithms
+
+The following functions for NID (numeric id) handling have changed semantics.
+
+=over 4
+
+=item *
+
+EVP_PKEY_id(), EVP_PKEY_get_id()
+
+This function was previously used to reliably return the NID of
+an EVP_PKEY object, e.g., to look up the name of the algorithm of
+such EVP_PKEY by calling L<OBJ_nid2sn(3)>. With the introduction
+of L<provider(7)>s EVP_PKEY_id() or its new equivalent
+L<EVP_PKEY_get_id(3)> might now also return the value -1 indicating
+the use of a provider to implement the EVP_PKEY object.
+Therefore, the use of L<EVP_PKEY_get0_type_name(3)> is recommended
+for retrieving the name of the EVP_PKEY algorithm.
 
 =back
 

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -1854,7 +1854,7 @@ int tls12_check_peer_sigalg(SSL_CONNECTION *s, uint16_t sig, EVP_PKEY *pkey)
     }
     lu = tls1_lookup_sigalg(s, sig);
     /* if this sigalg is loaded, set so far unknown pkeyid to its sig NID */
-    if ((pkeyid == 0) && (lu != NULL))
+    if ((pkeyid == EVP_PKEY_KEYMGMT) && (lu != NULL))
         pkeyid = lu->sig;
 
     /* Should never happen */

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -1854,7 +1854,7 @@ int tls12_check_peer_sigalg(SSL_CONNECTION *s, uint16_t sig, EVP_PKEY *pkey)
     }
     lu = tls1_lookup_sigalg(s, sig);
     /* if this sigalg is loaded, set so far unknown pkeyid to its sig NID */
-    if ((pkeyid == -1) && (lu != NULL))
+    if ((pkeyid == 0) && (lu != NULL))
         pkeyid = lu->sig;
 
     /* Should never happen */


### PR DESCRIPTION
Fixes #20497 .

If merged, this PR should also be backported to 3.0 as this aligns the long-standing documentation for (the return value of) `EVP_PKEY(_get)_id` with its implementation (in the presence of provider-based EVP_PKEY algorithms). 
