### PR TITLE
demo: Fix makefile target

### DIFF
--- a/demos/encrypt/Makefile
+++ b/demos/encrypt/Makefile
@@ -12,7 +12,7 @@ all: rsa_encrypt
 %.o: %.c
 	$(CC) $(CFLAGS) -c $<
 
-rsa_encrypt_ec: rsa_encrypt.o
+rsa_encrypt: rsa_encrypt.o
 
 test: ;
 


### PR DESCRIPTION
The makefile target was incorrect and wouldn't build the rsa_encrypt demo.


- [ ] documentation is added or updated
- [ ] tests are added or updated
