### PR TITLE
fips: implement 140-3 IG D.R

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -250,6 +250,13 @@ OpenSSL 3.1
 
 ### Changes between 3.1.0 and 3.1.1 [xx XXX xxxx]
 
+ * Add FIPS provider configuration option to disallow the use of
+   truncated digests with Hash and HMAC DRBGs (q.v. FIPS 140-3 IG D.R.).
+   The option '-no_drbg_truncated_digests' can optionally be
+   supplied to 'openssl fipsinstall'.
+
+   *Paul Dale*
+
  * Corrected documentation of X509_VERIFY_PARAM_add0_policy() to mention
    that it does not enable policy checking. Thanks to David Benjamin for
    discovering this issue.

--- a/apps/fipsinstall.c
+++ b/apps/fipsinstall.c
@@ -39,6 +39,7 @@ typedef enum OPTION_choice {
     OPT_NO_CONDITIONAL_ERRORS,
     OPT_NO_SECURITY_CHECKS,
     OPT_TLS_PRF_EMS_CHECK,
+    OPT_DISALLOW_DRGB_TRUNC_DIGEST,
     OPT_SELF_TEST_ONLOAD, OPT_SELF_TEST_ONINSTALL
 } OPTION_CHOICE;
 
@@ -62,14 +63,16 @@ const OPTIONS fipsinstall_options[] = {
      "Forces self tests to run once on module installation"},
     {"ems_check", OPT_TLS_PRF_EMS_CHECK, '-',
      "Enable the run-time FIPS check for EMS during TLS1_PRF"},
+    {"no_drbg_truncated_digests", OPT_DISALLOW_DRGB_TRUNC_DIGEST, '-',
+     "Disallow truncated digests with Hash and HMAC DRBGs"},
     OPT_SECTION("Input"),
     {"in", OPT_IN, '<', "Input config file, used when verifying"},
 
     OPT_SECTION("Output"),
     {"out", OPT_OUT, '>', "Output config file, used when generating"},
     {"mac_name", OPT_MAC_NAME, 's', "MAC name"},
-    {"macopt", OPT_MACOPT, 's', "MAC algorithm parameters in n:v form. "
-                                "See 'PARAMETER NAMES' in the EVP_MAC_ docs"},
+    {"macopt", OPT_MACOPT, 's', "MAC algorithm parameters in n:v form."},
+    {OPT_MORE_STR, 0, 0, "See 'PARAMETER NAMES' in the EVP_MAC_ docs"},
     {"noout", OPT_NO_LOG, '-', "Disable logging of self test events"},
     {"corrupt_desc", OPT_CORRUPT_DESC, 's', "Corrupt a self test by description"},
     {"corrupt_type", OPT_CORRUPT_TYPE, 's', "Corrupt a self test by type"},
@@ -175,6 +178,7 @@ static int write_config_fips_section(BIO *out, const char *section,
                                      int conditional_errors,
                                      int security_checks,
                                      int ems_check,
+                                     int drgb_no_trunc_dgst,
                                      unsigned char *install_mac,
                                      size_t install_mac_len)
 {
@@ -190,6 +194,8 @@ static int write_config_fips_section(BIO *out, const char *section,
                       security_checks ? "1" : "0") <= 0
         || BIO_printf(out, "%s = %s\n", OSSL_PROV_FIPS_PARAM_TLS1_PRF_EMS_CHECK,
                       ems_check ? "1" : "0") <= 0
+        || BIO_printf(out, "%s = %s\n", OSSL_PROV_PARAM_DRBG_TRUNC_DIGEST,
+                      drgb_no_trunc_dgst ? "1" : "0") <= 0
         || !print_mac(out, OSSL_PROV_FIPS_PARAM_MODULE_MAC, module_mac,
                       module_mac_len))
         goto end;
@@ -212,7 +218,8 @@ static CONF *generate_config_and_load(const char *prov_name,
                                       size_t module_mac_len,
                                       int conditional_errors,
                                       int security_checks,
-                                      int ems_check)
+                                      int ems_check,
+                                      int drgb_no_trunc_dgst)
 {
     BIO *mem_bio = NULL;
     CONF *conf = NULL;
@@ -226,6 +233,7 @@ static CONF *generate_config_and_load(const char *prov_name,
                                        conditional_errors,
                                        security_checks,
                                        ems_check,
+                                       drgb_no_trunc_dgst,
                                        NULL, 0))
         goto end;
 
@@ -323,7 +331,8 @@ int fipsinstall_main(int argc, char **argv)
 {
     int ret = 1, verify = 0, gotkey = 0, gotdigest = 0, self_test_onload = 1;
     int enable_conditional_errors = 1, enable_security_checks = 1;
-    int enable_tls_prf_ems_check = 0; /* This is off by default */
+    int enable_tls_prf_ems_check = 0;   /* This is off by default */
+    int enable_drgb_no_trunc_dgst = 0;  /* This is off by default */
     const char *section_name = "fips_sect";
     const char *mac_name = "HMAC";
     const char *prov_name = "fips";
@@ -371,6 +380,9 @@ opthelp:
             break;
         case OPT_TLS_PRF_EMS_CHECK:
             enable_tls_prf_ems_check = 1;
+            break;
+        case OPT_DISALLOW_DRGB_TRUNC_DIGEST:
+            enable_drgb_no_trunc_dgst = 1;
             break;
         case OPT_QUIET:
             quiet = 1;
@@ -536,7 +548,8 @@ opthelp:
                                         module_mac_len,
                                         enable_conditional_errors,
                                         enable_security_checks,
-                                        enable_tls_prf_ems_check);
+                                        enable_tls_prf_ems_check,
+                                        enable_drgb_no_trunc_dgst);
         if (conf == NULL)
             goto end;
         if (!load_fips_prov_and_run_self_test(prov_name))
@@ -554,6 +567,7 @@ opthelp:
                                        enable_conditional_errors,
                                        enable_security_checks,
                                        enable_tls_prf_ems_check,
+                                       enable_drgb_no_trunc_dgst,
                                        install_mac, install_mac_len))
             goto end;
         if (!quiet)

--- a/doc/man1/openssl-fipsinstall.pod.in
+++ b/doc/man1/openssl-fipsinstall.pod.in
@@ -22,6 +22,7 @@ B<openssl fipsinstall>
 [B<-no_conditional_errors>]
 [B<-no_security_checks>]
 [B<-ems_check>]
+[B<-no_drbg_truncated_digests>]
 [B<-self_test_onload>]
 [B<-self_test_oninstall>]
 [B<-corrupt_desc> I<selftest_description>]
@@ -174,6 +175,11 @@ turn off the check at compile time.
 Configure the module to enable a run-time Extended Master Secret (EMS) check
 when using the TLS1_PRF KDF algorithm. This check is disabled by default.
 See RFC 7627 for information related to EMS.
+
+=item B<-no_drbg_truncated_digests>
+
+Configure the module to not allow truncated digests to be used with Hash and
+HMAC DRBGs.  See FIPS 140-3 IG D.R for details.
 
 =item B<-self_test_onload>
 

--- a/doc/man7/EVP_RAND-HASH-DRBG.pod
+++ b/doc/man7/EVP_RAND-HASH-DRBG.pod
@@ -54,6 +54,24 @@ These parameters work as described in L<EVP_RAND(3)/PARAMETERS>.
 
 =head1 NOTES
 
+When the FIPS provider is installed using the B<-no_drbg_truncated_digests>
+option to fipsinstall, only these digests are permitted (as per
+L<FIPS 140-3 IG D.R|https://csrc.nist.gov/CSRC/media/Projects/cryptographic-module-validation-program/documents/fips%20140-3/FIPS%20140-3%20IG.pdf>):
+
+=over 4
+
+=item SHA-1
+
+=item SHA2-256
+
+=item SHA2-512
+
+=item SHA3-256
+
+=item SHA3-512
+
+=back
+
 A context for HASH DRBG can be obtained by calling:
 
  EVP_RAND *rand = EVP_RAND_fetch(NULL, "HASH-DRBG", NULL);
@@ -86,7 +104,15 @@ NIST SP 800-90A and SP 800-90B
 =head1 SEE ALSO
 
 L<EVP_RAND(3)>,
-L<EVP_RAND(3)/PARAMETERS>
+L<EVP_RAND(3)/PARAMETERS>,
+L<openssl-fipsinstall(1)>
+
+=head1 HISTORY
+
+OpenSSL 3.1.1 introduced the B<-no_drbg_truncated_digests> option to
+fipsinstall which restricts the permitted digests when using the FIPS
+provider in a complaint manner.  For details refer to
+L<FIPS 140-3 IG D.R|https://csrc.nist.gov/CSRC/media/Projects/cryptographic-module-validation-program/documents/fips%20140-3/FIPS%20140-3%20IG.pdf>.
 
 =head1 COPYRIGHT
 

--- a/doc/man7/EVP_RAND-HMAC-DRBG.pod
+++ b/doc/man7/EVP_RAND-HMAC-DRBG.pod
@@ -56,6 +56,23 @@ These parameters work as described in L<EVP_RAND(3)/PARAMETERS>.
 
 =head1 NOTES
 
+When using the FIPS provider, only these digests are permitted (as per
+L<FIPS 140-3 IG D.R|https://csrc.nist.gov/CSRC/media/Projects/cryptographic-module-validation-program/documents/fips%20140-3/FIPS%20140-3%20IG.pdf>):
+
+=over 4
+
+=item SHA-1
+
+=item SHA2-256
+
+=item SHA2-512
+
+=item SHA3-256
+
+=item SHA3-512
+
+=back
+
 A context for HMAC DRBG can be obtained by calling:
 
  EVP_RAND *rand = EVP_RAND_fetch(NULL, "HMAC-DRBG", NULL);
@@ -89,7 +106,16 @@ NIST SP 800-90A and SP 800-90B
 =head1 SEE ALSO
 
 L<EVP_RAND(3)>,
-L<EVP_RAND(3)/PARAMETERS>
+L<EVP_RAND(3)/PARAMETERS>,
+L<openssl-fipsinstall(1)>
+
+
+=head1 HISTORY
+
+OpenSSL 3.1.1 introduced the B<-no_drbg_truncated_digests> option to
+fipsinstall which restricts the permitted digests when using the FIPS
+provider in a complaint manner.  For details refer to
+L<FIPS 140-3 IG D.R|https://csrc.nist.gov/CSRC/media/Projects/cryptographic-module-validation-program/documents/fips%20140-3/FIPS%20140-3%20IG.pdf>).
 
 =head1 COPYRIGHT
 

--- a/include/openssl/core_names.h
+++ b/include/openssl/core_names.h
@@ -27,6 +27,7 @@ extern "C" {
 #define OSSL_PROV_PARAM_STATUS             "status"              /* uint */
 #define OSSL_PROV_PARAM_SECURITY_CHECKS    "security-checks"     /* uint */
 #define OSSL_PROV_PARAM_TLS1_PRF_EMS_CHECK "tls1-prf-ems-check"  /* uint */
+#define OSSL_PROV_PARAM_DRBG_TRUNC_DIGEST  "drbg-no-trunc-md"    /* uint */
 
 /* Self test callback parameters */
 #define OSSL_PROV_PARAM_SELF_TEST_PHASE  "st-phase" /* utf8_string */

--- a/include/openssl/fips_names.h
+++ b/include/openssl/fips_names.h
@@ -49,6 +49,7 @@ extern "C" {
 
 /*
  * A boolean that determines if the runtime FIPS security checks are performed.
+ * This is enabled by default.
  * Type: OSSL_PARAM_UTF8_STRING
  */
 # define OSSL_PROV_FIPS_PARAM_SECURITY_CHECKS "security-checks"
@@ -56,10 +57,18 @@ extern "C" {
 /*
  * A boolean that determines if the runtime FIPS check for TLS1_PRF EMS is performed.
  * This is disabled by default.
- *
  * Type: OSSL_PARAM_UTF8_STRING
  */
 # define OSSL_PROV_FIPS_PARAM_TLS1_PRF_EMS_CHECK "tls1-prf-ems-check"
+
+/*
+ * A boolean that determines if truncated digests can be used with Hash and HMAC
+ * DRBGs.  FIPS 140-3 IG D.R disallows such use for efficiency rather than
+ * security reasons.
+ * This is disabled by default.
+ * Type: OSSL_PARAM_UTF8_STRING
+ */
+# define OSSL_PROV_FIPS_PARAM_DRBG_TRUNC_DIGEST  "drbg-no-trunc-md"
 
 # ifdef __cplusplus
 }

--- a/providers/common/include/prov/fipscommon.h
+++ b/providers/common/include/prov/fipscommon.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2023 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#ifdef FIPS_MODULE
+# include <openssl/types.h>
+
+int FIPS_security_check_enabled(OSSL_LIB_CTX *libctx);
+int FIPS_tls_prf_ems_check(OSSL_LIB_CTX *libctx);
+int FIPS_restricted_drbg_digests_enabled(OSSL_LIB_CTX *libctx);
+
+#endif

--- a/providers/common/securitycheck_fips.c
+++ b/providers/common/securitycheck_fips.c
@@ -18,9 +18,7 @@
 #include <openssl/core_names.h>
 #include <openssl/obj_mac.h>
 #include "prov/securitycheck.h"
-
-int FIPS_security_check_enabled(OSSL_LIB_CTX *libctx);
-int FIPS_tls_prf_ems_check(OSSL_LIB_CTX *libctx);
+#include "prov/fipscommon.h"
 
 int ossl_securitycheck_enabled(OSSL_LIB_CTX *libctx)
 {

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -21,6 +21,7 @@
 #include "prov/providercommon.h"
 #include "prov/provider_util.h"
 #include "prov/seeding.h"
+#include "prov/fipscommon.h"
 #include "internal/nelem.h"
 #include "self_test.h"
 #include "crypto/context.h"
@@ -932,7 +933,6 @@ int BIO_snprintf(char *buf, size_t n, const char *format, ...)
 }
 
 #define FIPS_FEATURE_CHECK(fname, field)                                    \
-    int fname(OSSL_LIB_CTX *libctx);                                        \
     int fname(OSSL_LIB_CTX *libctx)                                         \
     {                                                                       \
         FIPS_GLOBAL *fgbl =                                                 \

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -46,8 +46,6 @@ static OSSL_FUNC_provider_query_operation_fn fips_query;
 #define UNAPPROVED_ALG(NAMES, FUNC) UNAPPROVED_ALGC(NAMES, FUNC, NULL)
 
 extern OSSL_FUNC_core_thread_start_fn *c_thread_start;
-int FIPS_security_check_enabled(OSSL_LIB_CTX *libctx);
-int FIPS_tls_prf_ems_check(OSSL_LIB_CTX *libctx);
 
 /*
  * Should these function pointers be stored in the provider side provctx? Could
@@ -79,14 +77,24 @@ static OSSL_FUNC_BIO_vsnprintf_fn *c_BIO_vsnprintf;
 static OSSL_FUNC_self_test_cb_fn *c_stcbfn = NULL;
 static OSSL_FUNC_core_get_libctx_fn *c_get_libctx = NULL;
 
+typedef struct {
+    const char *option;
+    unsigned char enabled;
+} FIPS_OPTION;
+
 typedef struct fips_global_st {
     const OSSL_CORE_HANDLE *handle;
     SELF_TEST_POST_PARAMS selftest_params;
-    int fips_security_checks;
-    int fips_tls1_prf_ems_check;
-    const char *fips_security_check_option;
-    const char *fips_tls1_prf_ems_check_option;
+    FIPS_OPTION fips_security_checks;
+    FIPS_OPTION fips_tls1_prf_ems_check;
+    FIPS_OPTION fips_restricted_drgb_digests;
 } FIPS_GLOBAL;
+
+static void init_fips_option(FIPS_OPTION *opt, int enabled)
+{
+    opt->enabled = enabled;
+    opt->option = enabled ? "1" : "0";
+}
 
 void *ossl_fips_prov_ossl_ctx_new(OSSL_LIB_CTX *libctx)
 {
@@ -94,12 +102,9 @@ void *ossl_fips_prov_ossl_ctx_new(OSSL_LIB_CTX *libctx)
 
     if (fgbl == NULL)
         return NULL;
-    fgbl->fips_security_checks = 1;
-    fgbl->fips_security_check_option = "1";
-
-    fgbl->fips_tls1_prf_ems_check = 0; /* Disabled by default */
-    fgbl->fips_tls1_prf_ems_check_option = "0";
-
+    init_fips_option(&fgbl->fips_security_checks, 1);
+    init_fips_option(&fgbl->fips_tls1_prf_ems_check, 0); /* Disabled by default */
+    init_fips_option(&fgbl->fips_restricted_drgb_digests, 0);
     return fgbl;
 }
 
@@ -116,6 +121,7 @@ static const OSSL_PARAM fips_param_types[] = {
     OSSL_PARAM_DEFN(OSSL_PROV_PARAM_STATUS, OSSL_PARAM_INTEGER, NULL, 0),
     OSSL_PARAM_DEFN(OSSL_PROV_PARAM_SECURITY_CHECKS, OSSL_PARAM_INTEGER, NULL, 0),
     OSSL_PARAM_DEFN(OSSL_PROV_PARAM_TLS1_PRF_EMS_CHECK, OSSL_PARAM_INTEGER, NULL, 0),
+    OSSL_PARAM_DEFN(OSSL_PROV_PARAM_DRBG_TRUNC_DIGEST, OSSL_PARAM_INTEGER, NULL, 0),
     OSSL_PARAM_END
 };
 
@@ -129,7 +135,7 @@ static int fips_get_params_from_core(FIPS_GLOBAL *fgbl)
     * OSSL_PROV_FIPS_PARAM_SECURITY_CHECKS and
     * OSSL_PROV_FIPS_PARAM_TLS1_PRF_EMS_CHECK are not self test parameters.
     */
-    OSSL_PARAM core_params[9], *p = core_params;
+    OSSL_PARAM core_params[10], *p = core_params;
 
     *p++ = OSSL_PARAM_construct_utf8_ptr(
             OSSL_PROV_PARAM_CORE_MODULE_FILENAME,
@@ -155,14 +161,21 @@ static int fips_get_params_from_core(FIPS_GLOBAL *fgbl)
             OSSL_PROV_FIPS_PARAM_CONDITIONAL_ERRORS,
             (char **)&fgbl->selftest_params.conditional_error_check,
             sizeof(fgbl->selftest_params.conditional_error_check));
-    *p++ = OSSL_PARAM_construct_utf8_ptr(
-            OSSL_PROV_FIPS_PARAM_SECURITY_CHECKS,
-            (char **)&fgbl->fips_security_check_option,
-            sizeof(fgbl->fips_security_check_option));
-    *p++ = OSSL_PARAM_construct_utf8_ptr(
-            OSSL_PROV_FIPS_PARAM_TLS1_PRF_EMS_CHECK,
-            (char **)&fgbl->fips_tls1_prf_ems_check_option,
-            sizeof(fgbl->fips_tls1_prf_ems_check_option));
+
+/* FIPS features can be enabled or disabled independently */
+#define FIPS_FEATURE_OPTION(fgbl, pname, field)                         \
+    *p++ = OSSL_PARAM_construct_utf8_ptr(                               \
+            pname, (char **)&fgbl->field.option,                        \
+            sizeof(fgbl->field.option))
+
+    FIPS_FEATURE_OPTION(fgbl, OSSL_PROV_FIPS_PARAM_SECURITY_CHECKS,
+                        fips_security_checks);
+    FIPS_FEATURE_OPTION(fgbl, OSSL_PROV_FIPS_PARAM_TLS1_PRF_EMS_CHECK,
+                        fips_tls1_prf_ems_check);
+    FIPS_FEATURE_OPTION(fgbl, OSSL_PROV_FIPS_PARAM_DRBG_TRUNC_DIGEST,
+                        fips_restricted_drgb_digests);
+#undef FIPS_FEATURE_OPTION
+
     *p = OSSL_PARAM_construct_end();
 
     if (!c_get_params(fgbl->handle, core_params)) {
@@ -196,12 +209,19 @@ static int fips_get_params(void *provctx, OSSL_PARAM params[])
     p = OSSL_PARAM_locate(params, OSSL_PROV_PARAM_STATUS);
     if (p != NULL && !OSSL_PARAM_set_int(p, ossl_prov_is_running()))
         return 0;
-    p = OSSL_PARAM_locate(params, OSSL_PROV_PARAM_SECURITY_CHECKS);
-    if (p != NULL && !OSSL_PARAM_set_int(p, fgbl->fips_security_checks))
-        return 0;
-    p = OSSL_PARAM_locate(params, OSSL_PROV_PARAM_TLS1_PRF_EMS_CHECK);
-    if (p != NULL && !OSSL_PARAM_set_int(p, fgbl->fips_tls1_prf_ems_check))
-        return 0;
+
+#define FIPS_FEATURE_GET(fgbl, pname, field)                            \
+    p = OSSL_PARAM_locate(params, pname);                               \
+    if (p != NULL && !OSSL_PARAM_set_int(p, fgbl->field.enabled))       \
+        return 0
+
+    FIPS_FEATURE_GET(fgbl, OSSL_PROV_PARAM_SECURITY_CHECKS,
+                     fips_security_checks);
+    FIPS_FEATURE_GET(fgbl, OSSL_PROV_PARAM_TLS1_PRF_EMS_CHECK,
+                     fips_tls1_prf_ems_check);
+    FIPS_FEATURE_GET(fgbl, OSSL_PROV_PARAM_DRBG_TRUNC_DIGEST,
+                     fips_restricted_drgb_digests);
+#undef FIPS_FEATURE_GET
     return 1;
 }
 
@@ -708,15 +728,21 @@ int OSSL_provider_init_int(const OSSL_CORE_HANDLE *handle,
         && strcmp(fgbl->selftest_params.conditional_error_check, "0") == 0)
         SELF_TEST_disable_conditional_error_state();
 
-    /* Disable the security check if it's disabled in the fips config file. */
-    if (fgbl->fips_security_check_option != NULL
-        && strcmp(fgbl->fips_security_check_option, "0") == 0)
-        fgbl->fips_security_checks = 0;
+    /* Enable or disable FIPS provider options */
+#define FIPS_SET_OPTION(fgbl, field)                                            \
+    if (fgbl->field.option != NULL) {                                       \
+        if (strcmp(fgbl->field.option, "1") == 0)                           \
+            fgbl->field.enabled = 1;                                        \
+        else if (strcmp(fgbl->field.option, "0") == 0)                      \
+            fgbl->field.enabled = 0;                                        \
+        else                                                                \
+            goto err;                                                       \
+    }
 
-    /* Enable the ems check if it's enabled in the fips config file. */
-    if (fgbl->fips_tls1_prf_ems_check_option != NULL
-        && strcmp(fgbl->fips_tls1_prf_ems_check_option, "1") == 0)
-        fgbl->fips_tls1_prf_ems_check = 1;
+    FIPS_SET_OPTION(fgbl, fips_security_checks);
+    FIPS_SET_OPTION(fgbl, fips_tls1_prf_ems_check);
+    FIPS_SET_OPTION(fgbl, fips_restricted_drgb_digests);
+#undef FIPS_SET_OPTION
 
     ossl_prov_cache_exported_algorithms(fips_ciphers, exported_fips_ciphers);
 
@@ -905,21 +931,20 @@ int BIO_snprintf(char *buf, size_t n, const char *format, ...)
     return ret;
 }
 
-int FIPS_security_check_enabled(OSSL_LIB_CTX *libctx)
-{
-    FIPS_GLOBAL *fgbl = ossl_lib_ctx_get_data(libctx,
-                                              OSSL_LIB_CTX_FIPS_PROV_INDEX);
+#define FIPS_FEATURE_CHECK(fname, field)                                    \
+    int fname(OSSL_LIB_CTX *libctx);                                        \
+    int fname(OSSL_LIB_CTX *libctx)                                         \
+    {                                                                       \
+        FIPS_GLOBAL *fgbl =                                                 \
+            ossl_lib_ctx_get_data(libctx, OSSL_LIB_CTX_FIPS_PROV_INDEX);    \
+        return fgbl->field.enabled;                                         \
+    }
 
-    return fgbl->fips_security_checks;
-}
-
-int FIPS_tls_prf_ems_check(OSSL_LIB_CTX *libctx)
-{
-    FIPS_GLOBAL *fgbl = ossl_lib_ctx_get_data(libctx,
-                                              OSSL_LIB_CTX_FIPS_PROV_INDEX);
-
-    return fgbl->fips_tls1_prf_ems_check;
-}
+FIPS_FEATURE_CHECK(FIPS_security_check_enabled, fips_security_checks)
+FIPS_FEATURE_CHECK(FIPS_tls_prf_ems_check, fips_tls1_prf_ems_check)
+FIPS_FEATURE_CHECK(FIPS_restricted_drbg_digests_enabled,
+                   fips_restricted_drgb_digests)
+#undef FIPS_FEATURE_CHECK
 
 void OSSL_SELF_TEST_get_callback(OSSL_LIB_CTX *libctx, OSSL_CALLBACK **cb,
                                  void **cbarg)

--- a/providers/implementations/rands/drbg.c
+++ b/providers/implementations/rands/drbg.c
@@ -21,6 +21,7 @@
 #include "crypto/rand_pool.h"
 #include "prov/provider_ctx.h"
 #include "prov/providercommon.h"
+#include "prov/fipscommon.h"
 #include "crypto/context.h"
 
 /*
@@ -934,7 +935,6 @@ int ossl_drbg_verify_digest(ossl_unused OSSL_LIB_CTX *libctx, const EVP_MD *md)
         "SHA3-256", "SHA3-512",     /* non-truncated SHA3 allowed */
     };
     size_t i;
-    extern int FIPS_restricted_drbg_digests_enabled(OSSL_LIB_CTX *libctx);
 
     if (FIPS_restricted_drbg_digests_enabled(libctx)) {
         for (i = 0; i < OSSL_NELEM(allowed_digests); i++)

--- a/providers/implementations/rands/drbg.c
+++ b/providers/implementations/rands/drbg.c
@@ -922,3 +922,32 @@ int ossl_drbg_set_ctx_params(PROV_DRBG *drbg, const OSSL_PARAM params[])
         return 0;
     return 1;
 }
+
+/* Confirm digest is allowed to be used with a DRBG */
+int ossl_drbg_verify_digest(ossl_unused OSSL_LIB_CTX *libctx, const EVP_MD *md)
+{
+#ifdef FIPS_MODULE
+    /* FIPS 140-3 IG D.R limited DRBG digests to a specific set */
+    static const char *const allowed_digests[] = {
+        "SHA1",                     /* SHA 1 allowed */
+        "SHA2-256", "SHA2-512",     /* non-truncated SHA2 allowed */
+        "SHA3-256", "SHA3-512",     /* non-truncated SHA3 allowed */
+    };
+    size_t i;
+    extern int FIPS_restricted_drbg_digests_enabled(OSSL_LIB_CTX *libctx);
+
+    if (FIPS_restricted_drbg_digests_enabled(libctx)) {
+        for (i = 0; i < OSSL_NELEM(allowed_digests); i++)
+            if (EVP_MD_is_a(md, allowed_digests[i]))
+                return 1;
+        ERR_raise(ERR_LIB_PROV, PROV_R_DIGEST_NOT_ALLOWED);
+        return 0;
+    }
+#endif
+    /* Outside of FIPS, any digests that are not XOF are allowed */
+    if ((EVP_MD_get_flags(md) & EVP_MD_FLAG_XOF) != 0) {
+        ERR_raise(ERR_LIB_PROV, PROV_R_XOF_DIGESTS_NOT_ALLOWED);
+        return 0;
+    }
+    return 1;
+}

--- a/providers/implementations/rands/drbg_hash.c
+++ b/providers/implementations/rands/drbg_hash.c
@@ -466,10 +466,8 @@ static int drbg_hash_set_ctx_params(void *vctx, const OSSL_PARAM params[])
 
     md = ossl_prov_digest_md(&hash->digest);
     if (md != NULL) {
-        if ((EVP_MD_get_flags(md) & EVP_MD_FLAG_XOF) != 0) {
-            ERR_raise(ERR_LIB_PROV, PROV_R_XOF_DIGESTS_NOT_ALLOWED);
-            return 0;
-        }
+        if (!ossl_drbg_verify_digest(libctx, md))
+            return 0;   /* Error already raised for us */
 
         /* These are taken from SP 800-90 10.1 Table 2 */
         hash->blocklen = EVP_MD_get_size(md);

--- a/providers/implementations/rands/drbg_hmac.c
+++ b/providers/implementations/rands/drbg_hmac.c
@@ -366,22 +366,15 @@ static int drbg_hmac_set_ctx_params(void *vctx, const OSSL_PARAM params[])
     if (!ossl_prov_digest_load_from_params(&hmac->digest, params, libctx))
         return 0;
 
-    /*
-     * Confirm digest is allowed. We allow all digests that are not XOF
-     * (such as SHAKE).  In FIPS mode, the fetch will fail for non-approved
-     * digests.
-     */
     md = ossl_prov_digest_md(&hmac->digest);
-    if (md != NULL && (EVP_MD_get_flags(md) & EVP_MD_FLAG_XOF) != 0) {
-        ERR_raise(ERR_LIB_PROV, PROV_R_XOF_DIGESTS_NOT_ALLOWED);
-        return 0;
-    }
+    if (md != NULL && !ossl_drbg_verify_digest(libctx, md))
+        return 0;   /* Error already raised for us */
 
     if (!ossl_prov_macctx_load_from_params(&hmac->ctx, params,
                                            NULL, NULL, NULL, libctx))
         return 0;
 
-    if (hmac->ctx != NULL) {
+    if (md != NULL && hmac->ctx != NULL) {
         /* These are taken from SP 800-90 10.1 Table 2 */
         hmac->blocklen = EVP_MD_get_size(md);
         /* See SP800-57 Part1 Rev4 5.6.1 Table 3 */

--- a/providers/implementations/rands/drbg_local.h
+++ b/providers/implementations/rands/drbg_local.h
@@ -251,4 +251,7 @@ size_t ossl_crngt_get_entropy(PROV_DRBG *drbg,
 void ossl_crngt_cleanup_entropy(PROV_DRBG *drbg,
                                 unsigned char *out, size_t outlen);
 
+/* Confirm digest is allowed to be used with a DRBG */
+int ossl_drbg_verify_digest(ossl_unused OSSL_LIB_CTX *libctx, const EVP_MD *md);
+
 #endif


### PR DESCRIPTION
This limits the available digests that can be used by the Hash and HMAC DRBGs.
Outside of FIPS, there remains no restriction.

Refer to [FIPS 140-3 IG D.R](https://csrc.nist.gov/CSRC/media/Projects/cryptographic-module-validation-program/documents/fips%20140-3/FIPS%20140-3%20IG.pdf#%5B%7B%22num%22%3A359%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C697%2C0%5D).

- [x] documentation is added or updated
- [x] tests are added or updated
