### PR TITLE
crypto/sleep.c: Have the fallback ossl_sleep_secs() sleep all the seconds

### DIFF
--- a/crypto/sleep.c
+++ b/crypto/sleep.c
@@ -81,6 +81,7 @@ static void ossl_sleep_secs(uint64_t secs)
     unsigned int i;
 
     uint_times = (unsigned int)(secs >> (8 * sizeof(unsigned int)));
+    secs &= (unsigned int)-1;
     if (uint_times > 0) {
         for (i = uint_times; i-- > 0;)
             sleep((unsigned int)-1);
@@ -91,6 +92,9 @@ static void ossl_sleep_secs(uint64_t secs)
          */
         sleep(uint_times);
     }
+
+    /* Now, sleep the remaining seconds */
+    sleep((unsigned int)secs);
 }
 
 static void ossl_sleep_millis(uint64_t millis)


### PR DESCRIPTION
In the internal `ossl_sleep_secs()`, we have a lot of machination to ensure
that we compensate for the fact that `sleep()` takes an `unsigned int`, not a
`uint64_t`, by sleeping the appropriate amount of chunks of seconds that can't
fit in an `unsigned int`.  We did forget to sleep the remaining seconds (the
remaining amount that does fit in an `unsigned int`), though, which means that
a simple call like `OSSL_sleep(2000)` wouldn't sleep at all.

Fixes #20524
