### PR TITLE
sleep.c: Limit the sleep time instead of sleeping for days or even years

### DIFF
--- a/crypto/sleep.c
+++ b/crypto/sleep.c
@@ -48,11 +48,11 @@ void OSSL_sleep(uint64_t millis)
      * Windows' Sleep() takes a DWORD argument, which is smaller than
      * a uint64_t, so we need to limit it to 49 days, which should be enough.
      */
-    DWORD milliseconds = (DWORD)-1;
+    DWORD limited_millis = (DWORD)-1;
 
-    if (millis < milliseconds)
-        milliseconds = (DWORD)millis;
-    Sleep(milliseconds);
+    if (millis < limited_millis)
+        limited_millis = (DWORD)millis;
+    Sleep(limited_millis);
 }
 
 #else
@@ -66,11 +66,11 @@ static void ossl_sleep_secs(uint64_t secs)
      * a uint64_t, so it needs to be limited to 136 years which
      * should be enough even for Sleeping Beauty.
      */
-    unsigned int seconds = UINT_MAX;
+    unsigned int limited_secs = UINT_MAX;
 
-    if (secs < seconds)
-        seconds = (unsigned int)secs;
-    sleep(seconds);
+    if (secs < limited_secs)
+        limited_secs = (unsigned int)secs;
+    sleep(limited_secs);
 }
 
 static void ossl_sleep_millis(uint64_t millis)

--- a/doc/man3/OSSL_sleep.pod
+++ b/doc/man3/OSSL_sleep.pod
@@ -14,8 +14,13 @@ OSSL_sleep - delay execution for a specified number of milliseconds
 
 OSSL_sleep() is a convenience function to delay execution of the calling
 thread for (at least) I<millis> milliseconds.  The delay is not guaranteed;
-it may be affected by system activity, by the time spent processing the call
-or by system timer granularity.
+it may be affected by system activity, by the time spent processing the call,
+limitation on the underlying system call parameter size or by system timer
+granularity.
+
+In particular on Windows the maximum amount of time it will sleep is
+49 days and on systems where the regular sleep(3) is used as the underlying
+system call the maximum sleep time is about 136 years.
 
 =head1 RETURN VALUES
 

--- a/test/build.info
+++ b/test/build.info
@@ -92,7 +92,7 @@ IF[{- !$disabled{tests} -}]
 
   SOURCE[sanitytest]=sanitytest.c
   INCLUDE[sanitytest]=../include ../apps/include
-  DEPEND[sanitytest]=../libcrypto libtestutil.a
+  DEPEND[sanitytest]=../libcrypto.a libtestutil.a
 
   SOURCE[rand_test]=rand_test.c
   INCLUDE[rand_test]=../include ../apps/include

--- a/test/sanitytest.c
+++ b/test/sanitytest.c
@@ -11,6 +11,7 @@
 #include <openssl/types.h>
 #include "testutil.h"
 #include "internal/numbers.h"
+#include "internal/time.h"
 
 static int test_sanity_null_zero(void)
 {
@@ -129,6 +130,25 @@ static int test_sanity_memcmp(void)
     return CRYPTO_memcmp("ab", "cd", 2);
 }
 
+static int test_sanity_sleep(void)
+{
+    OSSL_TIME start = ossl_time_now();
+    uint64_t seconds;
+
+    /*
+     * On any reasonable system this must sleep at least one second
+     * but not more than 20.
+     * Assuming there is no interruption.
+     */
+    OSSL_sleep(1000);
+
+    seconds = ossl_time2seconds(ossl_time_subtract(ossl_time_now(), start));
+
+    if (!TEST_uint64_t_ge(seconds, 1) || !TEST_uint64_t_le(seconds, 20))
+       return 0;
+    return 1;
+}
+
 int setup_tests(void)
 {
     ADD_TEST(test_sanity_null_zero);
@@ -138,6 +158,6 @@ int setup_tests(void)
     ADD_TEST(test_sanity_unsigned_conversion);
     ADD_TEST(test_sanity_range);
     ADD_TEST(test_sanity_memcmp);
+    ADD_TEST(test_sanity_sleep);
     return 1;
 }
-


### PR DESCRIPTION
As the sleep() call is interruptible, it is not even a good idea to call it in a loop if the caller uses some ridiculously large value as an infinity just waiting for an interrupt.

Alternative to #20530 