### PR TITLE
Fix Configure test for -mips in CFLAGS

### DIFF
--- a/Configure
+++ b/Configure
@@ -1244,7 +1244,7 @@ if ($target =~ /^mingw/ && `$config{CC} --target-help 2>&1` =~ m/-mno-cygwin/m)
         }
 
 if ($target =~ /linux.*-mips/ && !$disabled{asm}
-        && !grep { $_ !~ /-m(ips|arch=)/ } (@{$config{CFLAGS}})) {
+        && !grep { $_ =~ /-m(ips|arch=)/ } (@{$config{CFLAGS}})) {
         # minimally required architecture flags for assembly modules
         my $value;
         $value = '-mips2' if ($target =~ /mips32/);


### PR DESCRIPTION
We want to add -mips2 or -mips3 only if the user hasn't already specified a mips version in CFLAGS. The existing test was a double-negative.

CLA: trivial

Fixes: https://github.com/openssl/openssl/issues/20214