### PR TITLE
thread: remove remnants of ossl_crypto_mem_barrier

### DIFF
--- a/crypto/thread/arch/thread_none.c
+++ b/crypto/thread/arch/thread_none.c
@@ -70,8 +70,4 @@ void ossl_crypto_condvar_free(CRYPTO_CONDVAR **cv)
 {
 }
 
-void ossl_crypto_mem_barrier(void)
-{
-}
-
 #endif

--- a/crypto/thread/arch/thread_win.c
+++ b/crypto/thread/arch/thread_win.c
@@ -179,9 +179,4 @@ void ossl_crypto_condvar_free(CRYPTO_CONDVAR **cv)
     *cv_p = NULL;
 }
 
-void ossl_crypto_mem_barrier(void)
-{
-    MemoryBarrier();
-}
-
 #endif

--- a/include/internal/thread_arch.h
+++ b/include/internal/thread_arch.h
@@ -117,6 +117,4 @@ int ossl_crypto_thread_native_exit(void);
 int ossl_crypto_thread_native_is_self(CRYPTO_THREAD *thread);
 int ossl_crypto_thread_native_clean(CRYPTO_THREAD *thread);
 
-void ossl_crypto_mem_barrier(void);
-
 #endif /* OSSL_INTERNAL_THREAD_ARCH_H */


### PR DESCRIPTION
Commit ac21c1780a63a8d9a3a6217eb52fe0d188fa7655 VMS knows POSIX threads too! removed ossl_crypto_mem_barrier for POSIX systems.

Remove it for Win32 and other architectures as well.

Resolves issue #19506 Unable to build under bcc32c environment (Embarcadero clang compiler).

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated

ossl_crypto_mem_barrier is internal, not included in docs.

- [x] tests are added or updated

not tested, N/A.

Adding @levitte to CC as it relates to https://github.com/openssl/openssl/commit/ac21c1780a63a8d9a3a6217eb52fe0d188fa7655