### PR TITLE
Do not build P10-specific AES-GCM assembler on macOS

### DIFF
--- a/crypto/chacha/build.info
+++ b/crypto/chacha/build.info
@@ -13,7 +13,7 @@ IF[{- !$disabled{asm} -}]
   $CHACHAASM_aarch64=chacha-armv8.S chacha-armv8-sve.S
 
   $CHACHAASM_ppc32=chacha_ppc.c chacha-ppc.s
-  IF[{- $target{sys_id} ne "AIX" -}]
+  IF[{- $target{sys_id} ne "AIX" && $target{sys_id} ne "MACOSX" -}]
     $CHACHAASM_ppc32=chacha_ppc.c chacha-ppc.s chachap10-ppc.s
   ENDIF
   $CHACHAASM_ppc64=$CHACHAASM_ppc32

--- a/crypto/chacha/chacha_ppc.c
+++ b/crypto/chacha/chacha_ppc.c
@@ -30,7 +30,7 @@ void ChaCha20_ctr32(unsigned char *out, const unsigned char *inp,
                     size_t len, const unsigned int key[8],
                     const unsigned int counter[4])
 {
-#ifndef OPENSSL_SYS_AIX
+#if !defined(OPENSSL_SYS_AIX) && !defined(OPENSSL_SYS_MACOSX)
     OPENSSL_ppccap_P & PPC_BRD31
         ? ChaCha20_ctr32_vsx_p10(out, inp, len, key, counter) :
 #endif

--- a/crypto/modes/build.info
+++ b/crypto/modes/build.info
@@ -33,7 +33,7 @@ IF[{- !$disabled{asm} -}]
   $MODESDEF_parisc20_64=$MODESDEF_parisc11
 
   $MODESASM_ppc32=ghashp8-ppc.s
-  IF[{- $target{sys_id} ne "AIX" -}]
+  IF[{- $target{sys_id} ne "AIX" && $target{sys_id} ne "MACOSX" -}]
     $MODESASM_ppc32=ghashp8-ppc.s aes-gcm-ppc.s
   ENDIF
   $MODESDEF_ppc32=

--- a/include/crypto/aes_platform.h
+++ b/include/crypto/aes_platform.h
@@ -74,7 +74,7 @@ void AES_xts_decrypt(const unsigned char *inp, unsigned char *out, size_t len,
 #   define HWAES_ctr32_encrypt_blocks aes_p8_ctr32_encrypt_blocks
 #   define HWAES_xts_encrypt aes_p8_xts_encrypt
 #   define HWAES_xts_decrypt aes_p8_xts_decrypt
-#   ifndef OPENSSL_SYS_AIX
+#   if !defined(OPENSSL_SYS_AIX) && !defined(OPENSSL_SYS_MACOSX)
 #    define PPC_AES_GCM_CAPABLE (OPENSSL_ppccap_P & PPC_MADD300)
 #    define AES_GCM_ENC_BYTES 128
 #    define AES_GCM_DEC_BYTES 128
@@ -87,7 +87,7 @@ size_t ppc_aes_gcm_decrypt(const unsigned char *in, unsigned char *out,
 #    define AES_GCM_ASM_PPC(gctx) ((gctx)->ctr==aes_p8_ctr32_encrypt_blocks && \
                                    (gctx)->gcm.funcs.ghash==gcm_ghash_p8)
 void gcm_ghash_p8(u64 Xi[2],const u128 Htable[16],const u8 *inp, size_t len);
-#   endif /* OPENSSL_SYS_AIX */
+#   endif /* OPENSSL_SYS_AIX || OPENSSL_SYS_MACOSX */
 #  endif /* PPC */
 
 #  if (defined(__arm__) || defined(__arm) || defined(__aarch64__))


### PR DESCRIPTION
Legacy PowerPC machines running Mac OS X 10.5 and earlier are unable to build OpenSSL 3.1 due to the inclusion of new PPC assembler code that is incompatible with the OS X assembler. Exclude the P10-specific AES-GCM and ChaCha assembler code from being built on OS X systems.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
