### PR TITLE
Fixup demo exit status magic numbers

### DIFF
--- a/demos/bio/client-arg.c
+++ b/demos/bio/client-arg.c
@@ -22,6 +22,7 @@ int main(int argc, char **argv)
     char **args = argv + 1;
     const char *connect_str = "localhost:4433";
     int nargs = argc - 1;
+    int ret = EXIT_FAILURE;
 
     ctx = SSL_CTX_new(TLS_client_method());
     cctx = SSL_CONF_CTX_new();
@@ -100,9 +101,10 @@ int main(int argc, char **argv)
             break;
         BIO_write(out, tmpbuf, len);
     }
+    ret = EXIT_SUCCESS;
  end:
     SSL_CONF_CTX_free(cctx);
     BIO_free_all(sbio);
     BIO_free(out);
-    return 0;
+    return ret;
 }

--- a/demos/bio/client-conf.c
+++ b/demos/bio/client-conf.c
@@ -25,6 +25,7 @@ int main(int argc, char **argv)
     CONF_VALUE *cnf;
     const char *connect_str = "localhost:4433";
     long errline = -1;
+    int ret = EXIT_FAILURE;
 
     conf = NCONF_new(NULL);
 
@@ -108,10 +109,12 @@ int main(int argc, char **argv)
             break;
         BIO_write(out, tmpbuf, len);
     }
+    ret = EXIT_SUCCESS;
+
  end:
     SSL_CONF_CTX_free(cctx);
     BIO_free_all(sbio);
     BIO_free(out);
     NCONF_free(conf);
-    return 0;
+    return ret;
 }

--- a/demos/cipher/aesccm.c
+++ b/demos/cipher/aesccm.c
@@ -229,10 +229,10 @@ err:
 int main(int argc, char **argv)
 {
     if (!aes_ccm_encrypt())
-        return 1;
+        return EXIT_FAILURE;
 
     if (!aes_ccm_decrypt())
-        return 1;
+        return EXIT_FAILURE;
 
-    return 0;
+    return EXIT_SUCCESS;
 }

--- a/demos/cipher/aesgcm.c
+++ b/demos/cipher/aesgcm.c
@@ -219,10 +219,10 @@ err:
 int main(int argc, char **argv)
 {
     if (!aes_gcm_encrypt())
-        return 1;
+        return EXIT_FAILURE;
 
     if (!aes_gcm_decrypt())
-        return 1;
+        return EXIT_FAILURE;
 
-    return 0;
+    return EXIT_SUCCESS;
 }

--- a/demos/cipher/aeskeywrap.c
+++ b/demos/cipher/aeskeywrap.c
@@ -171,11 +171,10 @@ err:
 int main(int argc, char **argv)
 {
     if (!aes_wrap_encrypt())
-       return 1;
+       return EXIT_FAILURE;
 
     if (!aes_wrap_decrypt())
-        return 1;
+        return EXIT_FAILURE;
 
-    return 0;
+    return EXIT_SUCCESS;
 }
-

--- a/demos/cipher/ariacbc.c
+++ b/demos/cipher/ariacbc.c
@@ -169,10 +169,10 @@ err:
 int main(int argc, char **argv)
 {
     if (!aria_cbc_encrypt())
-       return 1;
+        return EXIT_FAILURE;
 
     if (!aria_cbc_decrypt())
-        return 1;
+        return EXIT_FAILURE;
 
-    return 0;
+    return EXIT_SUCCESS;
 }

--- a/demos/cms/cms_comp.c
+++ b/demos/cms/cms_comp.c
@@ -16,7 +16,7 @@ int main(int argc, char **argv)
 {
     BIO *in = NULL, *out = NULL;
     CMS_ContentInfo *cms = NULL;
-    int ret = 1;
+    int ret = EXIT_FAILURE;
 
     /*
      * On OpenSSL 1.0.0+ only:
@@ -48,11 +48,11 @@ int main(int argc, char **argv)
     if (!SMIME_write_CMS(out, cms, in, flags))
         goto err;
 
-    ret = 0;
+    ret = EXIT_SUCCESS;
 
  err:
 
-    if (ret) {
+    if (ret == EXIT_FAILURE) {
         fprintf(stderr, "Error Compressing Data\n");
         ERR_print_errors_fp(stderr);
     }

--- a/demos/cms/cms_ddec.c
+++ b/demos/cms/cms_ddec.c
@@ -21,7 +21,7 @@ int main(int argc, char **argv)
     X509 *rcert = NULL;
     EVP_PKEY *rkey = NULL;
     CMS_ContentInfo *cms = NULL;
-    int ret = 1;
+    int ret = EXIT_FAILURE;
 
     OpenSSL_add_all_algorithms();
     ERR_load_crypto_strings();
@@ -68,11 +68,11 @@ int main(int argc, char **argv)
     if (!CMS_decrypt(cms, rkey, rcert, dcont, out, 0))
         goto err;
 
-    ret = 0;
+    ret = EXIT_SUCCESS;
 
  err:
 
-    if (ret) {
+    if (ret == EXIT_FAILURE) {
         fprintf(stderr, "Error Decrypting Data\n");
         ERR_print_errors_fp(stderr);
     }

--- a/demos/cms/cms_dec.c
+++ b/demos/cms/cms_dec.c
@@ -18,7 +18,7 @@ int main(int argc, char **argv)
     X509 *rcert = NULL;
     EVP_PKEY *rkey = NULL;
     CMS_ContentInfo *cms = NULL;
-    int ret = 1;
+    int ret = EXIT_FAILURE;
 
     OpenSSL_add_all_algorithms();
     ERR_load_crypto_strings();
@@ -59,11 +59,10 @@ int main(int argc, char **argv)
     if (!CMS_decrypt(cms, rkey, rcert, NULL, out, 0))
         goto err;
 
-    ret = 0;
+    ret = EXIT_SUCCESS;
 
  err:
-
-    if (ret) {
+    if (ret == EXIT_FAILURE) {
         fprintf(stderr, "Error Decrypting Data\n");
         ERR_print_errors_fp(stderr);
     }

--- a/demos/cms/cms_denc.c
+++ b/demos/cms/cms_denc.c
@@ -21,7 +21,7 @@ int main(int argc, char **argv)
     X509 *rcert = NULL;
     STACK_OF(X509) *recips = NULL;
     CMS_ContentInfo *cms = NULL;
-    int ret = 1;
+    int ret = EXIT_FAILURE;
 
     int flags = CMS_STREAM | CMS_DETACHED;
 
@@ -77,11 +77,9 @@ int main(int argc, char **argv)
     if (!PEM_write_bio_CMS(out, cms))
         goto err;
 
-    ret = 0;
-
+    ret = EXIT_SUCCESS;
  err:
-
-    if (ret) {
+    if (ret == EXIT_FAILURE) {
         fprintf(stderr, "Error Encrypting Data\n");
         ERR_print_errors_fp(stderr);
     }

--- a/demos/cms/cms_enc.c
+++ b/demos/cms/cms_enc.c
@@ -18,7 +18,7 @@ int main(int argc, char **argv)
     X509 *rcert = NULL;
     STACK_OF(X509) *recips = NULL;
     CMS_ContentInfo *cms = NULL;
-    int ret = 1;
+    int ret = EXIT_FAILURE;
 
     /*
      * On OpenSSL 1.0.0 and later only:
@@ -73,11 +73,9 @@ int main(int argc, char **argv)
     if (!SMIME_write_CMS(out, cms, in, flags))
         goto err;
 
-    ret = 0;
-
+    ret = EXIT_SUCCESS;
  err:
-
-    if (ret) {
+    if (ret == EXIT_FAILURE) {
         fprintf(stderr, "Error Encrypting Data\n");
         ERR_print_errors_fp(stderr);
     }

--- a/demos/cms/cms_sign.c
+++ b/demos/cms/cms_sign.c
@@ -18,7 +18,7 @@ int main(int argc, char **argv)
     X509 *scert = NULL;
     EVP_PKEY *skey = NULL;
     CMS_ContentInfo *cms = NULL;
-    int ret = 1;
+    int ret = EXIT_FAILURE;
 
     /*
      * For simple S/MIME signing use CMS_DETACHED. On OpenSSL 1.0.0 only: for
@@ -69,11 +69,9 @@ int main(int argc, char **argv)
     if (!SMIME_write_CMS(out, cms, in, flags))
         goto err;
 
-    ret = 0;
-
+    ret = EXIT_SUCCESS;
  err:
-
-    if (ret) {
+    if (ret == EXIT_FAILURE) {
         fprintf(stderr, "Error Signing Data\n");
         ERR_print_errors_fp(stderr);
     }

--- a/demos/cms/cms_sign2.c
+++ b/demos/cms/cms_sign2.c
@@ -18,7 +18,7 @@ int main(int argc, char **argv)
     X509 *scert = NULL, *scert2 = NULL;
     EVP_PKEY *skey = NULL, *skey2 = NULL;
     CMS_ContentInfo *cms = NULL;
-    int ret = 1;
+    int ret = EXIT_FAILURE;
 
     OpenSSL_add_all_algorithms();
     ERR_load_crypto_strings();
@@ -77,11 +77,9 @@ int main(int argc, char **argv)
     if (!SMIME_write_CMS(out, cms, in, CMS_STREAM))
         goto err;
 
-    ret = 0;
-
+    ret = EXIT_SUCCESS;
  err:
-
-    if (ret) {
+    if (ret == EXIT_FAILURE) {
         fprintf(stderr, "Error Signing Data\n");
         ERR_print_errors_fp(stderr);
     }

--- a/demos/cms/cms_uncomp.c
+++ b/demos/cms/cms_uncomp.c
@@ -16,7 +16,7 @@ int main(int argc, char **argv)
 {
     BIO *in = NULL, *out = NULL;
     CMS_ContentInfo *cms = NULL;
-    int ret = 1;
+    int ret = EXIT_FAILURE;
 
     OpenSSL_add_all_algorithms();
     ERR_load_crypto_strings();
@@ -42,11 +42,9 @@ int main(int argc, char **argv)
     if (!CMS_uncompress(cms, out, NULL, 0))
         goto err;
 
-    ret = 0;
-
+    ret = EXIT_SUCCESS;
  err:
-
-    if (ret) {
+    if (ret == EXIT_FAILURE) {
         fprintf(stderr, "Error Uncompressing Data\n");
         ERR_print_errors_fp(stderr);
     }

--- a/demos/cms/cms_ver.c
+++ b/demos/cms/cms_ver.c
@@ -18,8 +18,7 @@ int main(int argc, char **argv)
     X509_STORE *st = NULL;
     X509 *cacert = NULL;
     CMS_ContentInfo *cms = NULL;
-
-    int ret = 1;
+    int ret = EXIT_FAILURE;
 
     OpenSSL_add_all_algorithms();
     ERR_load_crypto_strings();
@@ -69,11 +68,9 @@ int main(int argc, char **argv)
 
     fprintf(stderr, "Verification Successful\n");
 
-    ret = 0;
-
+    ret = EXIT_SUCCESS;
  err:
-
-    if (ret) {
+    if (ret == EXIT_FAILURE) {
         fprintf(stderr, "Error Verifying Data\n");
         ERR_print_errors_fp(stderr);
     }

--- a/demos/digest/BIO_f_md.c
+++ b/demos/digest/BIO_f_md.c
@@ -36,7 +36,7 @@
 
 int main(int argc, char * argv[])
 {
-    int result = 1;
+    int result = EXIT_FAILURE;
     OSSL_LIB_CTX *library_context = NULL;
     BIO *input = NULL;
     BIO *bio_digest = NULL;
@@ -106,10 +106,10 @@ int main(int argc, char * argv[])
         fprintf(stdout, "%02x", (unsigned char)digest_value[j]);
     }
     fprintf(stdout, "\n");
-    result = 0;
+    result = EXIT_SUCCESS;
 
 cleanup:
-    if (result != 0) 
+    if (result == EXIT_FAILURE)
         ERR_print_errors_fp(stderr);
 
     OPENSSL_free(digest_value);

--- a/demos/digest/EVP_MD_demo.c
+++ b/demos/digest/EVP_MD_demo.c
@@ -179,5 +179,5 @@ cleanup:
 
 int main(void)
 {
-    return demonstrate_digest() == 0;
+    return demonstrate_digest() ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/demos/digest/EVP_MD_stdin.c
+++ b/demos/digest/EVP_MD_stdin.c
@@ -123,12 +123,14 @@ cleanup:
 
 int main(void)
 {
-    int result = 1;
+    int result = EXIT_FAILURE;
     BIO *input = BIO_new_fd(fileno(stdin), 1);
 
     if (input != NULL) {
-        result = demonstrate_digest(input);
+        result = (demonstrate_digest(input) ? EXIT_SUCCESS : EXIT_FAILURE);
         BIO_free(input);
     }
+    if (result == EXIT_FAILURE)
+        ERR_print_errors_fp(stderr);
     return result;
 }

--- a/demos/digest/EVP_MD_xof.c
+++ b/demos/digest/EVP_MD_xof.c
@@ -43,7 +43,7 @@ static const char *propq = NULL;
 
 int main(int argc, char **argv)
 {
-    int rv = 1;
+    int rv = EXIT_FAILURE;
     OSSL_LIB_CTX *libctx = NULL;
     EVP_MD *md = NULL;
     EVP_MD_CTX *ctx = NULL;
@@ -122,7 +122,7 @@ int main(int argc, char **argv)
         }
     }
 
-    rv = 0;
+    rv = EXIT_SUCCESS;
 end:
     OPENSSL_free(digest);
     EVP_MD_CTX_free(ctx);

--- a/demos/encode/ec_encode.c
+++ b/demos/encode/ec_encode.c
@@ -173,7 +173,7 @@ cleanup:
 
 int main(int argc, char **argv)
 {
-    int rv = 1;
+    int rv = EXIT_FAILURE;
     OSSL_LIB_CTX *libctx = NULL;
     EVP_PKEY *pkey = NULL;
     const char *passphrase_in = NULL, *passphrase_out = NULL;
@@ -197,7 +197,7 @@ int main(int argc, char **argv)
         goto cleanup;
     }
 
-    rv = 0;
+    rv = EXIT_SUCCESS;
 cleanup:
     EVP_PKEY_free(pkey);
     OSSL_LIB_CTX_free(libctx);

--- a/demos/encode/rsa_encode.c
+++ b/demos/encode/rsa_encode.c
@@ -170,7 +170,7 @@ cleanup:
 
 int main(int argc, char **argv)
 {
-    int rv = 1;
+    int rv = EXIT_FAILURE;
     OSSL_LIB_CTX *libctx = NULL;
     EVP_PKEY *pkey = NULL;
     const char *passphrase_in = NULL, *passphrase_out = NULL;
@@ -194,7 +194,7 @@ int main(int argc, char **argv)
         goto cleanup;
     }
 
-    rv = 0;
+    rv = EXIT_SUCCESS;
 cleanup:
     EVP_PKEY_free(pkey);
     OSSL_LIB_CTX_free(libctx);

--- a/demos/kdf/hkdf.c
+++ b/demos/kdf/hkdf.c
@@ -43,7 +43,7 @@ static unsigned char hkdf_okm[] = {
 
 int main(int argc, char **argv)
 {
-    int rv = 1;
+    int rv = EXIT_FAILURE;
     EVP_KDF *kdf = NULL;
     EVP_KDF_CTX *kctx = NULL;
     unsigned char out[42];
@@ -95,7 +95,7 @@ int main(int argc, char **argv)
         goto end;
     }
 
-    rv = 0;
+    rv = EXIT_SUCCESS;
 end:
     EVP_KDF_CTX_free(kctx);
     EVP_KDF_free(kdf);

--- a/demos/kdf/pbkdf2.c
+++ b/demos/kdf/pbkdf2.c
@@ -57,7 +57,7 @@ static const unsigned char expected_output[] = {
 
 int main(int argc, char **argv)
 {
-    int rv = 1;
+    int rv = EXIT_FAILURE;
     EVP_KDF *kdf = NULL;
     EVP_KDF_CTX *kctx = NULL;
     unsigned char out[64];
@@ -108,7 +108,7 @@ int main(int argc, char **argv)
         goto end;
     }
 
-    rv = 0;
+    rv = EXIT_SUCCESS;
 end:
     EVP_KDF_CTX_free(kctx);
     EVP_KDF_free(kdf);

--- a/demos/kdf/scrypt.c
+++ b/demos/kdf/scrypt.c
@@ -59,7 +59,7 @@ static const unsigned char expected_output[] = {
 
 int main(int argc, char **argv)
 {
-    int rv = 1;
+    int rv = EXIT_FAILURE;
     EVP_KDF *kdf = NULL;
     EVP_KDF_CTX *kctx = NULL;
     unsigned char out[64];
@@ -111,7 +111,7 @@ int main(int argc, char **argv)
         goto end;
     }
 
-    rv = 0;
+    rv = EXIT_SUCCESS;
 end:
     EVP_KDF_CTX_free(kctx);
     EVP_KDF_free(kdf);

--- a/demos/keyexch/x25519.c
+++ b/demos/keyexch/x25519.c
@@ -267,12 +267,12 @@ int main(int argc, char **argv)
     /* Test X25519 key exchange with known result. */
     printf("Key exchange using known answer (deterministic):\n");
     if (keyexch_x25519(1) == 0)
-        return 1;
+        return EXIT_FAILURE;
 
     /* Test X25519 key exchange with random keys. */
     printf("Key exchange using random keys:\n");
     if (keyexch_x25519(0) == 0)
-        return 1;
+        return EXIT_FAILURE;
 
-    return 0;
+    return EXIT_SUCCESS;
 }

--- a/demos/pkcs12/pkwrite.c
+++ b/demos/pkcs12/pkwrite.c
@@ -23,13 +23,13 @@ int main(int argc, char **argv)
     PKCS12 *p12;
     if (argc != 5) {
         fprintf(stderr, "Usage: pkwrite infile password name p12file\n");
-        exit(1);
+        exit(EXIT_FAILURE);
     }
     OpenSSL_add_all_algorithms();
     ERR_load_crypto_strings();
     if ((fp = fopen(argv[1], "r")) == NULL) {
         fprintf(stderr, "Error opening file %s\n", argv[1]);
-        exit(1);
+        exit(EXIT_FAILURE);
     }
     cert = PEM_read_X509(fp, NULL, NULL, NULL);
     rewind(fp);
@@ -44,10 +44,10 @@ int main(int argc, char **argv)
     if ((fp = fopen(argv[4], "wb")) == NULL) {
         fprintf(stderr, "Error opening file %s\n", argv[4]);
         ERR_print_errors_fp(stderr);
-        exit(1);
+        exit(EXIT_FAILURE);
     }
     i2d_PKCS12_fp(fp, p12);
     PKCS12_free(p12);
     fclose(fp);
-    return 0;
+    return EXIT_SUCCESS;
 }

--- a/demos/pkey/EVP_PKEY_EC_keygen.c
+++ b/demos/pkey/EVP_PKEY_EC_keygen.c
@@ -131,7 +131,7 @@ cleanup:
 
 int main(void)
 {
-    int result = 0;
+    int ret = EXIT_FAILURE;
     EVP_PKEY *pkey;
 
     pkey = do_ec_keygen();
@@ -145,11 +145,11 @@ int main(void)
      * At this point we can write out the generated key using
      * i2d_PrivateKey() and i2d_PublicKey() if required.
      */
-    result = 1;
+    ret = EXIT_SUCCESS;
 cleanup:
-    if (result != 1)
+    if (ret == EXIT_FAILURE)
         ERR_print_errors_fp(stderr);
 
     EVP_PKEY_free(pkey);
-    return result == 0;
+    return ret;
 }

--- a/demos/pkey/EVP_PKEY_RSA_keygen.c
+++ b/demos/pkey/EVP_PKEY_RSA_keygen.c
@@ -239,7 +239,7 @@ cleanup:
 
 int main(int argc, char **argv)
 {
-    int rv = 1;
+    int rv = EXIT_FAILURE;
     OSSL_LIB_CTX *libctx = NULL;
     EVP_PKEY *pkey = NULL;
     unsigned int bits = 4096;
@@ -256,7 +256,7 @@ int main(int argc, char **argv)
         bits_i = atoi(argv[1]);
         if (bits < 512) {
             fprintf(stderr, "Invalid RSA key size\n");
-            return 1;
+            return EXIT_FAILURE;
         }
 
         bits = (unsigned int)bits_i;
@@ -281,7 +281,7 @@ int main(int argc, char **argv)
         goto cleanup;
     }
 
-    rv = 0;
+    rv = EXIT_SUCCESS;
 cleanup:
     EVP_PKEY_free(pkey);
     OSSL_LIB_CTX_free(libctx);

--- a/demos/signature/EVP_DSA_Signature_demo.c
+++ b/demos/signature/EVP_DSA_Signature_demo.c
@@ -268,7 +268,7 @@ end:
 
 int main(void)
 {
-    int result = 0;
+    int result = EXIT_FAILURE;
     OSSL_LIB_CTX *libctx = NULL;
     EVP_PKEY *params = NULL;
     EVP_PKEY *pkey = NULL;
@@ -301,9 +301,9 @@ int main(void)
     if (demo_verify(libctx, sig_len, sig_value, public_key) != 1)
         goto end;
 
-    result = 1;
+    result = EXIT_SUCCESS;
 end:
-    if (result != 1)
+    if (result == EXIT_FAILURE)
         ERR_print_errors_fp(stderr);
 
     OPENSSL_free(sig_value);
@@ -313,5 +313,5 @@ end:
     OSSL_PARAM_free(keypair);
     OSSL_LIB_CTX_free(libctx);
 
-    return result ? 0 : 1;
+    return result;
 }

--- a/demos/signature/EVP_EC_Signature_demo.c
+++ b/demos/signature/EVP_EC_Signature_demo.c
@@ -208,7 +208,7 @@ int main(void)
     const char *sig_name = "SHA3-512";
     size_t sig_len = 0;
     unsigned char *sig_value = NULL;
-    int result = 0;
+    int result = EXIT_FAILURE;
 
     libctx = OSSL_LIB_CTX_new();
     if (libctx == NULL) {
@@ -223,13 +223,13 @@ int main(void)
         fprintf(stderr, "demo_verify failed.\n");
         goto cleanup;
     }
-    result = 1;
+    result = EXIT_SUCCESS;
 
 cleanup:
-    if (result != 1)
+    if (result == EXIT_FAILURE)
         ERR_print_errors_fp(stderr);
     /* OpenSSL free functions will ignore NULL arguments */
     OSSL_LIB_CTX_free(libctx);
     OPENSSL_free(sig_value);
-    return result == 0;
+    return result;
 }

--- a/demos/signature/rsa_pss_direct.c
+++ b/demos/signature/rsa_pss_direct.c
@@ -185,7 +185,7 @@ end:
 
 int main(int argc, char **argv)
 {
-    int rv = 1;
+    int rv = EXIT_FAILURE;
     OSSL_LIB_CTX *libctx = NULL;
     unsigned char *sig = NULL;
     size_t sig_len = 0;
@@ -196,7 +196,7 @@ int main(int argc, char **argv)
     if (verify(libctx, sig, sig_len) == 0)
         goto end;
 
-    rv = 0;
+    rv = EXIT_SUCCESS;
 end:
     OPENSSL_free(sig);
     OSSL_LIB_CTX_free(libctx);

--- a/demos/signature/rsa_pss_hash.c
+++ b/demos/signature/rsa_pss_hash.c
@@ -170,7 +170,7 @@ end:
 
 int main(int argc, char **argv)
 {
-    int rv = 1;
+    int rv = EXIT_FAILURE;
     OSSL_LIB_CTX *libctx = NULL;
     unsigned char *sig = NULL;
     size_t sig_len = 0;
@@ -181,7 +181,7 @@ int main(int argc, char **argv)
     if (verify(libctx, sig, sig_len) == 0)
         goto end;
 
-    rv = 0;
+    rv = EXIT_SUCCESS;
 end:
     OPENSSL_free(sig);
     OSSL_LIB_CTX_free(libctx);

--- a/demos/smime/smdec.c
+++ b/demos/smime/smdec.c
@@ -18,7 +18,7 @@ int main(int argc, char **argv)
     X509 *rcert = NULL;
     EVP_PKEY *rkey = NULL;
     PKCS7 *p7 = NULL;
-    int ret = 1;
+    int ret = EXIT_FAILURE;
 
     OpenSSL_add_all_algorithms();
     ERR_load_crypto_strings();
@@ -59,10 +59,10 @@ int main(int argc, char **argv)
     if (!PKCS7_decrypt(p7, rkey, rcert, out, 0))
         goto err;
 
-    ret = 0;
+    ret = EXIT_SUCCESS;
 
  err:
-    if (ret) {
+    if (ret == EXIT_FAILURE) {
         fprintf(stderr, "Error Signing Data\n");
         ERR_print_errors_fp(stderr);
     }

--- a/demos/smime/smenc.c
+++ b/demos/smime/smenc.c
@@ -18,7 +18,7 @@ int main(int argc, char **argv)
     X509 *rcert = NULL;
     STACK_OF(X509) *recips = NULL;
     PKCS7 *p7 = NULL;
-    int ret = 1;
+    int ret = EXIT_FAILURE;
 
     /*
      * On OpenSSL 0.9.9 only:
@@ -73,10 +73,10 @@ int main(int argc, char **argv)
     if (!SMIME_write_PKCS7(out, p7, in, flags))
         goto err;
 
-    ret = 0;
+    ret = EXIT_SUCCESS;
 
  err:
-    if (ret) {
+    if (ret == EXIT_FAILURE) {
         fprintf(stderr, "Error Encrypting Data\n");
         ERR_print_errors_fp(stderr);
     }

--- a/demos/smime/smsign.c
+++ b/demos/smime/smsign.c
@@ -18,7 +18,7 @@ int main(int argc, char **argv)
     X509 *scert = NULL;
     EVP_PKEY *skey = NULL;
     PKCS7 *p7 = NULL;
-    int ret = 1;
+    int ret = EXIT_FAILURE;
 
     /*
      * For simple S/MIME signing use PKCS7_DETACHED. On OpenSSL 0.9.9 only:
@@ -69,10 +69,10 @@ int main(int argc, char **argv)
     if (!SMIME_write_PKCS7(out, p7, in, flags))
         goto err;
 
-    ret = 0;
+    ret = EXIT_SUCCESS;
 
  err:
-    if (ret) {
+    if (ret == EXIT_FAILURE) {
         fprintf(stderr, "Error Signing Data\n");
         ERR_print_errors_fp(stderr);
     }

--- a/demos/smime/smsign2.c
+++ b/demos/smime/smsign2.c
@@ -18,7 +18,7 @@ int main(int argc, char **argv)
     X509 *scert = NULL, *scert2 = NULL;
     EVP_PKEY *skey = NULL, *skey2 = NULL;
     PKCS7 *p7 = NULL;
-    int ret = 1;
+    int ret = EXIT_FAILURE;
 
     OpenSSL_add_all_algorithms();
     ERR_load_crypto_strings();
@@ -77,10 +77,10 @@ int main(int argc, char **argv)
     if (!SMIME_write_PKCS7(out, p7, in, PKCS7_STREAM))
         goto err;
 
-    ret = 0;
+    ret = EXIT_SUCCESS;
 
  err:
-    if (ret) {
+    if (ret == EXIT_FAILURE) {
         fprintf(stderr, "Error Signing Data\n");
         ERR_print_errors_fp(stderr);
     }

--- a/demos/smime/smver.c
+++ b/demos/smime/smver.c
@@ -18,8 +18,7 @@ int main(int argc, char **argv)
     X509_STORE *st = NULL;
     X509 *cacert = NULL;
     PKCS7 *p7 = NULL;
-
-    int ret = 1;
+    int ret = EXIT_FAILURE;
 
     OpenSSL_add_all_algorithms();
     ERR_load_crypto_strings();
@@ -69,10 +68,10 @@ int main(int argc, char **argv)
 
     fprintf(stderr, "Verification Successful\n");
 
-    ret = 0;
+    ret = EXIT_SUCCESS;
 
  err:
-    if (ret) {
+    if (ret == EXIT_FAILURE) {
         fprintf(stderr, "Error Verifying Data\n");
         ERR_print_errors_fp(stderr);
     }

--- a/demos/sslecho/main.c
+++ b/demos/sslecho/main.c
@@ -123,7 +123,7 @@ void usage()
     printf("       --or--\n");
     printf("       sslecho c ip\n");
     printf("       c=client, s=server, ip=dotted ip of server\n");
-    exit(1);
+    exit(EXIT_FAILURE);
 }
 
 int main(int argc, char **argv)
@@ -340,5 +340,5 @@ int main(int argc, char **argv)
 
     printf("sslecho exiting\n");
 
-    return 0;
+    return EXIT_SUCCESS;
 }


### PR DESCRIPTION
The demo code is quite often block copied for new demos, so this PR changes demos to use EXIT_SUCCESS & EXIT_FAILURE instead of 0 and 1.
Internal functions use the normal notation of 0 = error, 1 = success, but the value returned by main() must use EXIT_SUCCESS and EXIT_FAILURE.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
