### PR TITLE
Create hierarchical demo Makefile.

### DIFF
--- a/demos/Makefile
+++ b/demos/Makefile
@@ -1,4 +1,4 @@
-MODULES=bio digest encode encrypt kdf keyexch mac pkcs12 pkey signature sslecho
+MODULES=bio digest encode encrypt kdf keyexch mac pkey signature sslecho
 
 all:
 	@set -e; for i in $(MODULES); do \

--- a/demos/Makefile
+++ b/demos/Makefile
@@ -1,16 +1,14 @@
-MODULES= bio digest encode encrypt kdf keyexch mac pkcs12 pkey signature sslecho
+MODULES=bio digest encode encrypt kdf keyexch mac pkcs12 pkey signature sslecho
+
 all:
-	@ : 
 	@set -e; for i in $(MODULES); do \
-		( cd $$i; ${MAKE} all); \
+		${MAKE} -C $$i all; \
 	done
 clean:
-	@ : 
 	@set -e; for i in $(MODULES); do \
-		( cd $$i; ${MAKE} clean); \
+		${MAKE} -C $$i clean; \
 	done
 test:
-	@ : 
 	@set -e; for i in $(MODULES); do \
-		( cd $$i; ${MAKE} test); \
+		${MAKE} -C $$i test; \
 	done

--- a/demos/Makefile
+++ b/demos/Makefile
@@ -1,0 +1,16 @@
+MODULES= bio digest encode encrypt kdf keyexch mac pkcs12 pkey signature sslecho
+all:
+	@ : 
+	@set -e; for i in $(MODULES); do \
+		( cd $$i; ${MAKE} all); \
+	done
+clean:
+	@ : 
+	@set -e; for i in $(MODULES); do \
+		( cd $$i; ${MAKE} clean); \
+	done
+test:
+	@ : 
+	@set -e; for i in $(MODULES); do \
+		( cd $$i; ${MAKE} test); \
+	done

--- a/demos/bio/Makefile
+++ b/demos/bio/Makefile
@@ -17,6 +17,7 @@ CFLAGS = $(OPENSSL_INCS_LOCATION)
 LDFLAGS = $(OPENSSL_LIBS_LOCATION) -lssl -lcrypto $(EX_LIBS)
 
 all: client-arg client-conf saccept sconnect server-arg server-cmod server-conf
+test: client-arg client-conf saccept sconnect server-arg server-cmod server-conf
 
 client-arg: client-arg.o
 client-conf: client-conf.o

--- a/demos/bio/Makefile
+++ b/demos/bio/Makefile
@@ -17,7 +17,8 @@ CFLAGS = $(OPENSSL_INCS_LOCATION)
 LDFLAGS = $(OPENSSL_LIBS_LOCATION) -lssl -lcrypto $(EX_LIBS)
 
 all: client-arg client-conf saccept sconnect server-arg server-cmod server-conf
-test: client-arg client-conf saccept sconnect server-arg server-cmod server-conf
+
+test:
 
 client-arg: client-arg.o
 client-conf: client-conf.o

--- a/demos/cipher/Makefile
+++ b/demos/cipher/Makefile
@@ -31,7 +31,6 @@ clean:
 .PHONY: test
 test: all
 	@echo "\nCipher tests:"
-	@ : 
 	@set -e; for tst in $(TESTS); do \
 		echo "\n"$$tst; \
 		./$$tst; \

--- a/demos/cipher/Makefile
+++ b/demos/cipher/Makefile
@@ -33,5 +33,5 @@ test: all
 	@echo "\nCipher tests:"
 	@set -e; for tst in $(TESTS); do \
 		echo "\n"$$tst; \
-		./$$tst; \
+		LD_LIBRARY_PATH=../.. ./$$tst; \
 	done

--- a/demos/cipher/Makefile
+++ b/demos/cipher/Makefile
@@ -13,7 +13,9 @@
 CFLAGS = $(OPENSSL_INCS_LOCATION)
 LDFLAGS = $(OPENSSL_LIBS_LOCATION) -lssl -lcrypto
 
-all: aesccm aesgcm aeskeywrap ariacbc
+TESTS=aesccm aesgcm aeskeywrap ariacbc
+
+all: $(TESTS)
 
 aesccm: aesccm.o
 aesgcm: aesgcm.o
@@ -25,3 +27,12 @@ aesccm aesgcm aeskeywrap ariacbc:
 
 clean:
 	$(RM) aesccm aesgcm aeskeywrap ariacbc *.o
+
+.PHONY: test
+test: all
+	@echo "\nCipher tests:"
+	@ : 
+	@set -e; for tst in $(TESTS); do \
+		echo "\n"$$tst; \
+		./$$tst; \
+	done

--- a/demos/digest/Makefile
+++ b/demos/digest/Makefile
@@ -23,9 +23,8 @@ BIO_f_md: BIO_f_md.o
 # Since some of these tests use stdin we use the source file as stdin when running the exes
 test: all
 	@echo "\nDigest tests:"
-	@ : 
 	@set -e; for tst in $(TESTS); do \
-		echo "\n"$$tst;  \
+		echo "\n"$$tst; \
 		cat $$tst.c | ./$$tst; \
 	done
 

--- a/demos/digest/Makefile
+++ b/demos/digest/Makefile
@@ -7,7 +7,9 @@ CFLAGS = -I../../include -g -Wall
 LDFLAGS = -L../..
 LDLIBS = -lcrypto
 
-all: EVP_MD_demo EVP_MD_stdin EVP_MD_xof BIO_f_md
+TESTS=EVP_MD_demo EVP_MD_stdin EVP_MD_xof BIO_f_md
+
+all: $(TESTS)
 
 %.o: %.c
 	$(CC) $(CFLAGS) -c $<
@@ -17,7 +19,15 @@ EVP_MD_stdin: EVP_MD_stdin.o
 EVP_MD_xof: EVP_MD_xof.o
 BIO_f_md: BIO_f_md.o
 
-test: ;
+.PHONY: test
+# Since some of these tests use stdin we use the source file as stdin when running the exes
+test: all
+	@echo "\nDigest tests:"
+	@ : 
+	@set -e; for tst in $(TESTS); do \
+		echo "\n"$$tst;  \
+		cat $$tst.c | ./$$tst; \
+	done
 
 clean:
-	$(RM) *.o EVP_MD_demo EVP_MD_stdin EVP_MD_xof BIO_f_md
+	$(RM) *.o $(TESTS)

--- a/demos/encode/Makefile
+++ b/demos/encode/Makefile
@@ -7,7 +7,9 @@ CFLAGS = -I../../include -g -Wall
 LDFLAGS = -L../..
 LDLIBS = -lcrypto
 
-all: ec_encode rsa_encode
+TESTS=ec_encode rsa_encode
+
+all: $(TESTS)
 
 %.o: %.c
 	$(CC) $(CFLAGS) -c $<
@@ -17,4 +19,4 @@ all: ec_encode rsa_encode
 test: ;
 
 clean:
-	$(RM) *.o rsa_encode ec_encode
+	$(RM) *.o $(TESTS)

--- a/demos/encode/Makefile
+++ b/demos/encode/Makefile
@@ -16,7 +16,7 @@ all: $(TESTS)
 
 %_encode: %_encode.o
 
-test: ;
+test:
 
 clean:
 	$(RM) *.o $(TESTS)

--- a/demos/encrypt/Makefile
+++ b/demos/encrypt/Makefile
@@ -7,14 +7,23 @@ CFLAGS = -I../../include -g
 LDFLAGS = -L../..
 LDLIBS = -lcrypto
 
-all: rsa_encrypt
+TESTS=rsa_encrypt
+
+all: $(TESTS)
 
 %.o: %.c
 	$(CC) $(CFLAGS) -c $<
 
 rsa_encrypt: rsa_encrypt.o
 
-test: ;
-
 clean:
-	$(RM) *.o rsa_encrypt
+	$(RM) *.o $(TESTS)
+
+.PHONY: test
+test: all
+	@echo "\nEncrypt tests:"
+	@ : 
+	@set -e; for tst in $(TESTS); do \
+		echo "\n"$$tst;  \
+		./$$tst; \
+	done

--- a/demos/encrypt/Makefile
+++ b/demos/encrypt/Makefile
@@ -24,5 +24,5 @@ test: all
 	@echo "\nEncrypt tests:"
 	@set -e; for tst in $(TESTS); do \
 		echo "\n"$$tst; \
-		./$$tst; \
+		LD_LIBRARY_PATH=../.. ./$$tst; \
 	done

--- a/demos/encrypt/Makefile
+++ b/demos/encrypt/Makefile
@@ -22,8 +22,7 @@ clean:
 .PHONY: test
 test: all
 	@echo "\nEncrypt tests:"
-	@ : 
 	@set -e; for tst in $(TESTS); do \
-		echo "\n"$$tst;  \
+		echo "\n"$$tst; \
 		./$$tst; \
 	done

--- a/demos/kdf/Makefile
+++ b/demos/kdf/Makefile
@@ -25,8 +25,7 @@ clean:
 .PHONY: test
 test: all
 	@echo "\nKDF tests:"
-	@ : 
 	@set -e; for tst in $(TESTS); do \
-		echo "\n"$$tst;  \
+		echo "\n"$$tst; \
 		./$$tst; \
 	done

--- a/demos/kdf/Makefile
+++ b/demos/kdf/Makefile
@@ -7,7 +7,9 @@ CFLAGS = -I../../include -g
 LDFLAGS = -L../..
 LDLIBS = -lcrypto
 
-all: hkdf pbkdf2 scrypt argon2
+TESTS=hkdf pbkdf2 scrypt argon2
+
+all: $(TESTS)
 
 %.o: %.c
 	$(CC) $(CFLAGS) -c $<
@@ -15,8 +17,16 @@ all: hkdf pbkdf2 scrypt argon2
 hkdf: hkdf.o
 pbkdf2: pbkdf2.o
 scrypt: scrypt.o
-
-test: ;
+argon2: argon2.o
 
 clean:
-	$(RM) *.o hkdf pbkdf2 scrypt argon2
+	$(RM) *.o $(TESTS)
+
+.PHONY: test
+test: all
+	@echo "\nKDF tests:"
+	@ : 
+	@set -e; for tst in $(TESTS); do \
+		echo "\n"$$tst;  \
+		./$$tst; \
+	done

--- a/demos/keyexch/Makefile
+++ b/demos/keyexch/Makefile
@@ -1,31 +1,28 @@
 #
 # To run the demos when linked with a shared library (default):
 #
-#    LD_LIBRARY_PATH=../.. ./hkdf
+#    LD_LIBRARY_PATH=../.. ./x25519
 
-CFLAGS = -I../../include -g
+CFLAGS = -I../../include -g -Wall
 LDFLAGS = -L../..
 LDLIBS = -lcrypto
 
-TESTS=hkdf pbkdf2 scrypt argon2
+TESTS=x25519
 
 all: $(TESTS)
 
 %.o: %.c
 	$(CC) $(CFLAGS) -c $<
 
-hkdf: hkdf.o
-pbkdf2: pbkdf2.o
-scrypt: scrypt.o
-argon2: argon2.o
-
-clean:
-	$(RM) *.o $(TESTS)
+%x25519: %x25519.o
 
 .PHONY: test
 test: all
-	@echo "\nKDF tests:"
+	@echo "\nKeyExchange tests:"
 	@set -e; for tst in $(TESTS); do \
 		echo "\n"$$tst; \
 		LD_LIBRARY_PATH=../.. ./$$tst; \
 	done
+
+clean:
+	$(RM) *.o $(TESTS)

--- a/demos/mac/Makefile
+++ b/demos/mac/Makefile
@@ -11,7 +11,9 @@
 CFLAGS = $(OPENSSL_INCS_LOCATION) -Wall
 LDFLAGS = $(OPENSSL_LIBS_LOCATION) -lssl -lcrypto
 
-all: gmac hmac-sha512 cmac-aes256 poly1305
+TESTS=gmac hmac-sha512 cmac-aes256 poly1305
+
+all: $(TESTS)
 
 gmac: gmac.o
 hmac-sha512: hmac-sha512.o
@@ -22,4 +24,13 @@ gmac hmac-sha512 cmac-aes256 poly1305:
 	$(CC) $(CFLAGS) -o $@ $< $(LDFLAGS)
 
 clean:
-	$(RM) gmac hmac-sha512 cmac-aes256 poly1305 *.o
+	$(RM) *.o $(TESTS)
+
+.PHONY: test
+test: all
+	@echo "\nMAC tests:"
+	@ : 
+	@set -e; for tst in $(TESTS); do \
+		echo "\n"$$tst;  \
+		./$$tst; \
+	done

--- a/demos/mac/Makefile
+++ b/demos/mac/Makefile
@@ -31,5 +31,5 @@ test: all
 	@echo "\nMAC tests:"
 	@set -e; for tst in $(TESTS); do \
 		echo "\n"$$tst; \
-		./$$tst; \
+		LD_LIBRARY_PATH=../.. ./$$tst; \
 	done

--- a/demos/mac/Makefile
+++ b/demos/mac/Makefile
@@ -29,8 +29,7 @@ clean:
 .PHONY: test
 test: all
 	@echo "\nMAC tests:"
-	@ : 
 	@set -e; for tst in $(TESTS); do \
-		echo "\n"$$tst;  \
+		echo "\n"$$tst; \
 		./$$tst; \
 	done

--- a/demos/pkey/Makefile
+++ b/demos/pkey/Makefile
@@ -38,8 +38,7 @@ clean:
 .PHONY: test
 test: all
 	@echo "\nPKEY tests:"
-	@ : 
 	@set -e; for tst in $(TESTS); do \
-		echo "\n"$$tst;  \
+		echo "\n"$$tst; \
 		./$$tst; \
 	done

--- a/demos/pkey/Makefile
+++ b/demos/pkey/Makefile
@@ -12,8 +12,10 @@ CFLAGS = -I../../include -g -Wall
 LDFLAGS = -L../..
 LDLIBS = -lcrypto
 
-all: EVP_PKEY_EC_keygen EVP_PKEY_RSA_keygen EVP_PKEY_DSA_keygen \
-	 EVP_PKEY_DSA_paramgen EVP_PKEY_DSA_paramvalidate EVP_PKEY_DSA_paramfromdata \
+TESTS=EVP_PKEY_EC_keygen EVP_PKEY_RSA_keygen EVP_PKEY_DSA_keygen \
+EVP_PKEY_DSA_paramgen EVP_PKEY_DSA_paramvalidate EVP_PKEY_DSA_paramfromdata
+
+all: $(TESTS)
 
 %.o: %.c dsa.inc
 	$(CC) $(CFLAGS) -c $<
@@ -30,8 +32,14 @@ EVP_PKEY_DSA_paramvalidate: EVP_PKEY_DSA_paramvalidate.o
 
 EVP_PKEY_DSA_paramfromdata: EVP_PKEY_DSA_paramfromdata.o
 
-test: ;
-
 clean:
-	$(RM) *.o EVP_PKEY_EC_keygen EVP_PKEY_RSA_keygen EVP_PKEY_DSA_keygen \
-	      EVP_PKEY_DSA_paramgen EVP_PKEY_DSA_paramfromdata EVP_PKEY_DSA_paramvalidate
+	$(RM) *.o $(TESTS)
+
+.PHONY: test
+test: all
+	@echo "\nPKEY tests:"
+	@ : 
+	@set -e; for tst in $(TESTS); do \
+		echo "\n"$$tst;  \
+		./$$tst; \
+	done

--- a/demos/pkey/Makefile
+++ b/demos/pkey/Makefile
@@ -40,5 +40,5 @@ test: all
 	@echo "\nPKEY tests:"
 	@set -e; for tst in $(TESTS); do \
 		echo "\n"$$tst; \
-		./$$tst; \
+		LD_LIBRARY_PATH=../.. ./$$tst; \
 	done

--- a/demos/signature/Makefile
+++ b/demos/signature/Makefile
@@ -30,8 +30,7 @@ clean:
 .PHONY: test
 test: all
 	@echo "\nSignature tests:"
-	@ : 
 	@set -e; for tst in $(TESTS); do \
-		echo "\n"$$tst;  \
+		echo "\n"$$tst; \
 		./$$tst; \
 	done

--- a/demos/signature/Makefile
+++ b/demos/signature/Makefile
@@ -11,7 +11,9 @@ CFLAGS = -I../../include -g -Wall
 LDFLAGS = -L../..
 LDLIBS = -lcrypto
 
-all: EVP_EC_Signature_demo EVP_DSA_Signature_demo EVP_ED_Signature_demo rsa_pss_direct rsa_pss_hash
+TESTS=EVP_EC_Signature_demo EVP_DSA_Signature_demo EVP_ED_Signature_demo rsa_pss_direct rsa_pss_hash
+
+all: $(TESTS)
 
 %.o: %.c
 	$(CC) $(CFLAGS) -c $<
@@ -22,7 +24,14 @@ EVP_ED_Signature_demo: EVP_ED_Signature_demo.o
 rsa_pss_direct: rsa_pss_direct.o
 rsa_pss_hash: rsa_pss_hash.o
 
-test: ;
-
 clean:
-	$(RM) *.o EVP_EC_Signature_demo EVP_DSA_Signature_demo EVP_ED_Signature_demo rsa_pss_direct rsa_pss_hash
+	$(RM) *.o $(TESTS)
+
+.PHONY: test
+test: all
+	@echo "\nSignature tests:"
+	@ : 
+	@set -e; for tst in $(TESTS); do \
+		echo "\n"$$tst;  \
+		./$$tst; \
+	done

--- a/demos/signature/Makefile
+++ b/demos/signature/Makefile
@@ -32,5 +32,5 @@ test: all
 	@echo "\nSignature tests:"
 	@set -e; for tst in $(TESTS); do \
 		echo "\n"$$tst; \
-		./$$tst; \
+		LD_LIBRARY_PATH=../.. ./$$tst; \
 	done

--- a/demos/sslecho/makefile
+++ b/demos/sslecho/makefile
@@ -8,7 +8,7 @@ $(PROG): main.c
 
 	$(CC) -O0 -g3 -W -Wall -I../../include -L../../ -o $(PROG) main.c -lssl -lcrypto
 
-test: ;
+test:
 
 clean:
 	rm -rf $(PROG) *.o *.obj

--- a/demos/sslecho/makefile
+++ b/demos/sslecho/makefile
@@ -8,5 +8,7 @@ $(PROG): main.c
 
 	$(CC) -O0 -g3 -W -Wall -I../../include -L../../ -o $(PROG) main.c -lssl -lcrypto
 
+test: ;
+
 clean:
 	rm -rf $(PROG) *.o *.obj


### PR DESCRIPTION
This add a Makefile with all, clean, and test targets. This has only been added for demos that already contain Makefiles. For problematic tests that require inputs, the test target does nothing.

(Note: Demos should be self contained and not require unknown external inputs. This PR does not attempt to fix this.)

Depends on #20545 (One of the demos, exit status were incorrect).

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
