### PR TITLE
providers/implementations/kdfs/argon2.c: Don't use UINT64_C

### DIFF
--- a/providers/implementations/kdfs/argon2.c
+++ b/providers/implementations/kdfs/argon2.c
@@ -307,7 +307,7 @@ static ossl_inline uint64_t rotr64(const uint64_t w, const unsigned int c)
 
 static ossl_inline uint64_t mul_lower(uint64_t x, uint64_t y)
 {
-    const uint64_t m = UINT64_C(0xFFFFFFFF);
+    const uint64_t m = 0xFFFFFFFFUL;
     return (x & m) * (y & m);
 }
 


### PR DESCRIPTION
With less than C99 compilers, this macro isn't guaranteed to exist, and
the value passed to it is 32 bits, so explicitly ending it with 'UL' is
correct in all cases.  We simply leave it to the compiler to extend it
appropriately for uint64_t.
