### PR TITLE
OBJ_nid2obj(): Return UNDEF object instead of NULL for NID_undef

### DIFF
--- a/crypto/objects/obj_dat.c
+++ b/crypto/objects/obj_dat.c
@@ -299,9 +299,8 @@ ASN1_OBJECT *OBJ_nid2obj(int n)
     ADDED_OBJ ad, *adp = NULL;
     ASN1_OBJECT ob;
 
-    if (n == NID_undef)
-        return NULL;
-    if (n >= 0 && n < NUM_NID && nid_objs[n].nid != NID_undef)
+    if (n >= 0 && n < NUM_NID
+        && (n == NID_undef || nid_objs[n].nid != NID_undef))
         return (ASN1_OBJECT *)&(nid_objs[n]);
 
     ad.type = ADDED_NID;

--- a/test/asn1_internal_test.c
+++ b/test/asn1_internal_test.c
@@ -254,6 +254,16 @@ static int test_obj_create(void)
     return 1;
 }
 
+static int test_obj_nid_undef(void)
+{
+    if (!TEST_ptr(OBJ_nid2obj(NID_undef))
+        || !TEST_ptr(OBJ_nid2sn(NID_undef))
+        || !TEST_ptr(OBJ_nid2ln(NID_undef)))
+        return 0;
+
+    return 1;
+}
+
 int setup_tests(void)
 {
     ADD_TEST(test_tbl_standard);
@@ -261,5 +271,6 @@ int setup_tests(void)
     ADD_TEST(test_empty_nonoptional_content);
     ADD_TEST(test_unicode_range);
     ADD_TEST(test_obj_create);
+    ADD_TEST(test_obj_nid_undef);
     return 1;
 }


### PR DESCRIPTION
Fixes a regression from 3.0 from the obj creation refactoring.

Fixes #20555
