### PR TITLE
VC++ 2010 x86 compilers do not have InterlockedOr64

### DIFF
--- a/crypto/threads_win.c
+++ b/crypto/threads_win.c
@@ -22,7 +22,7 @@
  * only VC++ 2008 or earlier x86 compilers.
  */
 
-#if (defined(_MSC_VER) && defined(_M_IX86) && _MSC_VER <= 1500)
+#if (defined(_MSC_VER) && defined(_M_IX86) && _MSC_VER <= 1600)
 # define NO_INTERLOCKEDOR64
 #endif
 


### PR DESCRIPTION
The changes from the following commit should also apply to Visual Studio 2010
https://github.com/openssl/openssl/commit/2d46a44ff24173d2cf5ea2196360cb79470d49c7#r104867505

Fixes build errors: undefined symbol InterlockedOr64 on Windows 2003, Visual Studio 2010 for x86 target.

@mattcaswell @dnobori @paulidale @t8m 