### PR TITLE
Do not duplicate OPENSSL_armcap_P on 32 bit ARM

### DIFF
--- a/crypto/armcap.c
+++ b/crypto/armcap.c
@@ -25,7 +25,9 @@
 #endif
 #include "arm_arch.h"
 
+#ifdef __aarch64__
 unsigned int OPENSSL_armcap_P = 0;
+#endif
 unsigned int OPENSSL_arm_midr = 0;
 unsigned int OPENSSL_armv8_rsa_neonized = 0;
 

--- a/test/recipes/01-test_symbol_presence.t
+++ b/test/recipes/01-test_symbol_presence.t
@@ -168,6 +168,10 @@ foreach (sort keys %stlibname) {
     }
 }
 my @duplicates = sort grep { $symbols{$_} > 1 } keys %symbols;
+if (@duplicates) {
+    note "Duplicates:";
+    note join('\n', @duplicates);
+}
 ok(scalar @duplicates == 0, "checking no duplicate symbols in static libraries");
 
 ######################################################################


### PR DESCRIPTION
The declaration in armcap.c was duplicate.

This resolves CI failures on cross-compile builds on ARM.