### PR TITLE
Fix documentation of X509_VERIFY_PARAM_add0_policy() [3.1]

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,13 @@ OpenSSL 3.1
 
 ### Changes between 3.1.0 and 3.1.1 [xx XXX xxxx]
 
+ * Corrected documentation of X509_VERIFY_PARAM_add0_policy() to mention
+   that it does not enable policy checking. Thanks to David Benjamin for
+   discovering this issue.
+   ([CVE-2023-0466])
+
+   *Tomáš Mráz*
+
  * Limited the number of nodes created in a policy tree to mitigate
    against CVE-2023-0464.  The default limit is set to 1000 nodes, which
    should be sufficient for most installations.  If required, the limit
@@ -19689,6 +19696,7 @@ ndif
 
 <!-- Links -->
 
+[CVE-2023-0466]: https://www.openssl.org/news/vulnerabilities.html#CVE-2023-0466
 [CVE-2023-0401]: https://www.openssl.org/news/vulnerabilities.html#CVE-2023-0401
 [CVE-2023-0286]: https://www.openssl.org/news/vulnerabilities.html#CVE-2023-0286
 [CVE-2023-0217]: https://www.openssl.org/news/vulnerabilities.html#CVE-2023-0217

--- a/NEWS.md
+++ b/NEWS.md
@@ -21,7 +21,7 @@ OpenSSL 3.1
 
 ### Major changes between OpenSSL 3.1.0 and OpenSSL 3.1.1 [under development]
 
-  * none
+  * Fixed documentation of X509_VERIFY_PARAM_add0_policy() ([CVE-2023-0466])
 
 ### Major changes between OpenSSL 3.0 and OpenSSL 3.1.0 [14 Mar 2023]
 
@@ -1446,6 +1446,7 @@ OpenSSL 0.9.x
   * Support for various new platforms
 
 <!-- Links -->
+[CVE-2023-0466]: https://www.openssl.org/news/vulnerabilities.html#CVE-2023-0466
 [CVE-2023-0401]: https://www.openssl.org/news/vulnerabilities.html#CVE-2023-0401
 [CVE-2023-0286]: https://www.openssl.org/news/vulnerabilities.html#CVE-2023-0286
 [CVE-2023-0217]: https://www.openssl.org/news/vulnerabilities.html#CVE-2023-0217

--- a/doc/man3/X509_VERIFY_PARAM_set_flags.pod
+++ b/doc/man3/X509_VERIFY_PARAM_set_flags.pod
@@ -98,8 +98,9 @@ B<trust>.
 X509_VERIFY_PARAM_set_time() sets the verification time in B<param> to
 B<t>. Normally the current time is used.
 
-X509_VERIFY_PARAM_add0_policy() enables policy checking (it is disabled
-by default) and adds B<policy> to the acceptable policy set.
+X509_VERIFY_PARAM_add0_policy() adds B<policy> to the acceptable policy set.
+Contrary to preexisting documentation of this function it does not enable
+policy checking.
 
 X509_VERIFY_PARAM_set1_policies() enables policy checking (it is disabled
 by default) and sets the acceptable policy set to B<policies>. Any existing
@@ -399,6 +400,10 @@ The X509_VERIFY_PARAM_get_hostflags() function was added in OpenSSL 1.1.0i.
 
 The X509_VERIFY_PARAM_get0_host(), X509_VERIFY_PARAM_get0_email(),
 and X509_VERIFY_PARAM_get1_ip_asc() functions were added in OpenSSL 3.0.
+
+The function X509_VERIFY_PARAM_add0_policy() was historically documented as
+enabling policy checking however the implementation has never done this.
+The documentation was changed to align with the implementation.
 
 =head1 COPYRIGHT
 


### PR DESCRIPTION
The function was incorrectly documented as enabling policy checking.

Fixes: CVE-2023-0466

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
