### PR TITLE
Fix documentation of X509_VERIFY_PARAM_add0_policy() [1.1.1]

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,11 @@
 
  Changes between 1.1.1t and 1.1.1u [xx XXX xxxx]
 
+  *) Corrected documentation of X509_VERIFY_PARAM_add0_policy() to mention
+     that it does not enable policy checking. Thanks to
+     David Benjamin for discovering this issue. (CVE-2023-0466)
+     [Tomas Mraz]
+
   *) Limited the number of nodes created in a policy tree to mitigate
      against CVE-2023-0464.  The default limit is set to 1000 nodes, which
      should be sufficient for most installations.  If required, the limit

--- a/NEWS
+++ b/NEWS
@@ -7,7 +7,7 @@
 
   Major changes between OpenSSL 1.1.1t and OpenSSL 1.1.1u [under development]
 
-      o
+      o Fixed documentation of X509_VERIFY_PARAM_add0_policy() (CVE-2023-0466)
 
   Major changes between OpenSSL 1.1.1s and OpenSSL 1.1.1t [7 Feb 2023]
 

--- a/doc/man3/X509_VERIFY_PARAM_set_flags.pod
+++ b/doc/man3/X509_VERIFY_PARAM_set_flags.pod
@@ -92,8 +92,9 @@ B<trust>.
 X509_VERIFY_PARAM_set_time() sets the verification time in B<param> to
 B<t>. Normally the current time is used.
 
-X509_VERIFY_PARAM_add0_policy() enables policy checking (it is disabled
-by default) and adds B<policy> to the acceptable policy set.
+X509_VERIFY_PARAM_add0_policy() adds B<policy> to the acceptable policy set.
+Contrary to preexisting documentation of this function it does not enable
+policy checking.
 
 X509_VERIFY_PARAM_set1_policies() enables policy checking (it is disabled
 by default) and sets the acceptable policy set to B<policies>. Any existing
@@ -376,6 +377,10 @@ The flag B<X509_V_FLAG_CB_ISSUER_CHECK> was deprecated in OpenSSL 1.1.0
 and has no effect.
 
 The X509_VERIFY_PARAM_get_hostflags() function was added in OpenSSL 1.1.0i.
+
+The function X509_VERIFY_PARAM_add0_policy() was historically documented as
+enabling policy checking however the implementation has never done this.
+The documentation was changed to align with the implementation.
 
 =head1 COPYRIGHT
 


### PR DESCRIPTION
The function was incorrectly documented as enabling policy checking.

Fixes: CVE-2023-0466

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
