### PR TITLE
Disable policy tree test if preconditions are not right

### DIFF
--- a/test/recipes/80-test_policy_tree.t
+++ b/test/recipes/80-test_policy_tree.t
@@ -18,6 +18,8 @@ use OpenSSL::Glob;
 
 setup("test_policy_tree");
 
+plan skip_all => "No EC support" if disabled("ec");
+
 plan tests => 2;
 
 # The small pathological tree is expected to work


### PR DESCRIPTION
no-ec and no-bulk both break the test.

- [ ] documentation is added or updated
- [x] tests are added or updated
