### PR TITLE
Add QUIC support to s_client

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,13 @@ OpenSSL 3.2
 
 ### Changes between 3.1 and 3.2 [xx XXX xxxx]
 
+ * Added the "-quic" option to s_client to enable connectivity to QUIC servers.
+   QUIC requires the use of ALPN, so this must be specified via the "-alpn"
+   option. Use of the "advanced" s_client command command via the "-adv" option
+   is recommended.
+
+   *Matt Caswell*
+
  * Reworked the Fix for the Timing Oracle in RSA Decryption ([CVE-2022-4304]).
    The previous fix for this timing side channel turned out to cause
    a severe 2-3x performance regression in the typical use case

--- a/apps/include/s_apps.h
+++ b/apps/include/s_apps.h
@@ -36,7 +36,7 @@ int ssl_print_groups(BIO *out, SSL *s, int noshared);
 int ssl_print_tmp_key(BIO *out, SSL *s);
 int init_client(int *sock, const char *host, const char *port,
                 const char *bindhost, const char *bindport,
-                int family, int type, int protocol, int tfo,
+                int family, int type, int protocol, int tfo, int doconn,
                 BIO_ADDR **ba_ret);
 int should_retry(int i);
 void do_ssl_shutdown(SSL *ssl);

--- a/apps/lib/s_socket.c
+++ b/apps/lib/s_socket.c
@@ -65,7 +65,8 @@ BIO_ADDR *ourpeer = NULL;
  * @type: socket type, must be SOCK_STREAM or SOCK_DGRAM
  * @protocol: socket protocol, e.g. IPPROTO_TCP or IPPROTO_UDP (or 0 for any)
  * @tfo: flag to enable TCP Fast Open
- * @ba_ret: BIO_ADDR that was connected to for TFO, to be freed by caller
+ * @doconn: whether we should call BIO_connect() on the socket
+ * @ba_ret: BIO_ADDR for the remote peer, to be freed by caller
  *
  * This will create a socket and use it to connect to a host:port, or if
  * family == AF_UNIX, to the path found in host.
@@ -78,7 +79,7 @@ BIO_ADDR *ourpeer = NULL;
  */
 int init_client(int *sock, const char *host, const char *port,
                 const char *bindhost, const char *bindport,
-                int family, int type, int protocol, int tfo,
+                int family, int type, int protocol, int tfo, int doconn,
                 BIO_ADDR **ba_ret)
 {
     BIO_ADDRINFO *res = NULL;
@@ -173,14 +174,14 @@ int init_client(int *sock, const char *host, const char *port,
                 options |= BIO_SOCK_TFO;
         }
 
-        if (!BIO_connect(*sock, BIO_ADDRINFO_address(ai), options)) {
+        if (doconn && !BIO_connect(*sock, BIO_ADDRINFO_address(ai), options)) {
             BIO_closesocket(*sock);
             *sock = INVALID_SOCKET;
             continue;
         }
 
         /* Save the address */
-        if (tfo && ba_ret != NULL)
+        if (tfo || !doconn)
             *ba_ret = BIO_ADDR_dup(BIO_ADDRINFO_address(ai));
 
         /* Success, don't try any more addresses */

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -2173,6 +2173,10 @@ int s_client_main(int argc, char **argv)
         BIO_printf(bio_err, "%s: QUIC does not support the -tfo option\n", prog);
         goto end;
     }
+    if (isquic && alpn_in == NULL) {
+        BIO_printf(bio_err, "%s: QUIC requires ALPN to be specified (e.g. \"h3\" for HTTP/3) via the -alpn option\n", prog);
+        goto end;
+    }
 #endif
 
     if (tfo)

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -107,12 +107,6 @@ static BIO *bio_c_out = NULL;
 static int c_quiet = 0;
 static char *sess_out = NULL;
 static SSL_SESSION *psksess = NULL;
-/*
- * TODO(QUIC): This needs to be global so we can query it easily. It would be
- *             better if there was an SSL_is_quic() function like there is
- *             an SSL_is_dtls()
- */
-static int isquic = 0;
 
 static void print_stuff(BIO *berr, SSL *con, int full);
 #ifndef OPENSSL_NO_OCSP
@@ -949,7 +943,7 @@ int s_client_main(int argc, char **argv)
 #endif
     BIO *bio_c_msg = NULL;
     const char *keylog_file = NULL, *early_data_file = NULL;
-    int isdtls = 0;
+    int isdtls = 0, isquic = 0;
     char *psksessf = NULL;
     int enable_pha = 0;
     int enable_client_rpk = 0;
@@ -1375,9 +1369,8 @@ int s_client_main(int argc, char **argv)
         case OPT_QUIC:
 #ifndef OPENSSL_NO_QUIC
             meth = OSSL_QUIC_client_method();
-            /* TODO(QUIC): What should these values be for QUIC? */
-            min_version = TLS1_3_VERSION;
-            max_version = TLS1_3_VERSION;
+            min_version = 0;
+            max_version = 0;
             socket_type = SOCK_DGRAM;
 # ifndef OPENSSL_NO_DTLS
             isdtls = 0;

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -3839,7 +3839,7 @@ static int user_data_execute(struct user_data_st *user_data, int cmd, char *arg)
         BIO_printf(bio_err, "  {help}: Get this help text\n");
         BIO_printf(bio_err, "  {quit}: Close the connection to the peer\n");
         BIO_printf(bio_err, "  {reconnect}: Reconnect to the peer\n");
-        if (isquic) {
+        if (SSL_is_quic(user_data->con)) {
             BIO_printf(bio_err, "  {fin}: Send FIN on the stream. No further writing is possible\n");
         } else if(SSL_version(user_data->con) == TLS1_3_VERSION) {
             BIO_printf(bio_err, "  {keyup:req|noreq}: Send a Key Update message\n");
@@ -3987,7 +3987,7 @@ static int user_data_process(struct user_data_st *user_data, size_t *len,
                 cmd = USER_COMMAND_QUIT;
             } else if (OPENSSL_strcasecmp(cmd_start, "reconnect") == 0) {
                 cmd = USER_COMMAND_RECONNECT;
-            } else if(isquic) {
+            } else if(SSL_is_quic(user_data->con)) {
                 if (OPENSSL_strcasecmp(cmd_start, "fin") == 0)
                     cmd = USER_COMMAND_FIN;
             } if (SSL_version(user_data->con) == TLS1_3_VERSION) {

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -86,6 +86,9 @@ struct user_data_st {
 
     /* The mode we are using for processing commands */
     int mode;
+
+    /* Whether FIN has ben sent on the stream */
+    int isfin;
 };
 
 static void user_data_init(struct user_data_st *user_data, SSL *con, char *buf,
@@ -104,6 +107,12 @@ static BIO *bio_c_out = NULL;
 static int c_quiet = 0;
 static char *sess_out = NULL;
 static SSL_SESSION *psksess = NULL;
+/*
+ * TODO(QUIC): This needs to be global so we can query it easily. It would be
+ *             better if there was an SSL_is_quic() function like there is
+ *             an SSL_is_dtls()
+ */
+static int isquic = 0;
 
 static void print_stuff(BIO *berr, SSL *con, int full);
 #ifndef OPENSSL_NO_OCSP
@@ -941,7 +950,6 @@ int s_client_main(int argc, char **argv)
     BIO *bio_c_msg = NULL;
     const char *keylog_file = NULL, *early_data_file = NULL;
     int isdtls = 0;
-    int isquic = 0;
     char *psksessf = NULL;
     int enable_pha = 0;
     int enable_client_rpk = 0;
@@ -3801,6 +3809,7 @@ static void user_data_init(struct user_data_st *user_data, SSL *con, char *buf,
     user_data->buflen = 0;
     user_data->bufoff = 0;
     user_data->mode = mode;
+    user_data->isfin = 0;
 }
 
 static int user_data_add(struct user_data_st *user_data, size_t i)
@@ -3819,6 +3828,7 @@ static int user_data_add(struct user_data_st *user_data, size_t i)
 #define USER_COMMAND_RECONNECT   2
 #define USER_COMMAND_RENEGOTIATE 3
 #define USER_COMMAND_KEY_UPDATE  4
+#define USER_COMMAND_FIN         5
 
 static int user_data_execute(struct user_data_st *user_data, int cmd, char *arg)
 {
@@ -3832,7 +3842,9 @@ static int user_data_execute(struct user_data_st *user_data, int cmd, char *arg)
         BIO_printf(bio_err, "  {help}: Get this help text\n");
         BIO_printf(bio_err, "  {quit}: Close the connection to the peer\n");
         BIO_printf(bio_err, "  {reconnect}: Reconnect to the peer\n");
-        if (SSL_version(user_data->con) == TLS1_3_VERSION) {
+        if (isquic) {
+            BIO_printf(bio_err, "  {fin}: Send FIN on the stream. No further writing is possible\n");
+        } else if(SSL_version(user_data->con) == TLS1_3_VERSION) {
             BIO_printf(bio_err, "  {keyup:req|noreq}: Send a Key Update message\n");
             BIO_printf(bio_err, "                     Arguments:\n");
             BIO_printf(bio_err, "                     req   = peer update requested (default)\n");
@@ -3874,6 +3886,13 @@ static int user_data_execute(struct user_data_st *user_data, int cmd, char *arg)
                 break;
             return USER_DATA_PROCESS_CONTINUE;
         }
+
+    case USER_COMMAND_FIN:
+        if (!SSL_stream_conclude(user_data->con, 0))
+            break;
+        user_data->isfin = 1;
+        return USER_DATA_PROCESS_NO_DATA;
+
     default:
         break;
     }
@@ -3971,7 +3990,10 @@ static int user_data_process(struct user_data_st *user_data, size_t *len,
                 cmd = USER_COMMAND_QUIT;
             } else if (OPENSSL_strcasecmp(cmd_start, "reconnect") == 0) {
                 cmd = USER_COMMAND_RECONNECT;
-            } else if (SSL_version(user_data->con) == TLS1_3_VERSION) {
+            } else if(isquic) {
+                if (OPENSSL_strcasecmp(cmd_start, "fin") == 0)
+                    cmd = USER_COMMAND_FIN;
+            } if (SSL_version(user_data->con) == TLS1_3_VERSION) {
                 if (OPENSSL_strcasecmp(cmd_start, "keyup") == 0) {
                     cmd = USER_COMMAND_KEY_UPDATE;
                     if (arg_start == NULL)
@@ -4016,6 +4038,11 @@ static int user_data_process(struct user_data_st *user_data, size_t *len,
              */
             outlen = cmd_start - buf_start;
         }
+    }
+
+    if (user_data->isfin) {
+        user_data->buflen = user_data->bufoff = *len = *off = 0;
+        return USER_DATA_PROCESS_NO_DATA;
     }
 
 #ifdef CHARSET_EBCDIC

--- a/doc/man1/openssl-s_client.pod.in
+++ b/doc/man1/openssl-s_client.pod.in
@@ -20,6 +20,7 @@ B<openssl> B<s_client>
 [B<-unix> I<path>]
 [B<-4>]
 [B<-6>]
+[B<-quic>]
 [B<-servername> I<name>]
 [B<-noservername>]
 [B<-verify> I<depth>]
@@ -213,6 +214,11 @@ Use IPv4 only.
 =item B<-6>
 
 Use IPv6 only.
+
+=item B<-quic>
+
+Connect using the QUIC protocol. If specified then the B<-alpn> option must also
+be provided.
 
 =item B<-servername> I<name>
 
@@ -939,6 +945,11 @@ to update its keys. The default is "req".
 =item B<reneg>
 
 Initiate a renegotiation with the server. (D)TLSv1.2 or below only.
+
+=item B<fin>
+
+Indicate FIN on the current stream. QUIC only. Once FIN has been sent any
+further text entered for this stream is ignored.
 
 =back
 


### PR DESCRIPTION
This PR adds support to s_client for creating QUIC connections through the new flag "-quic". It also adds a new command for signalling FIN on a stream.

It is built on top of #20566 and includes the commits from there. Only the last 2 commits are relevant to this PR.