### PR TITLE
Fix a HPKE API to put libctx, propq as last (optional parameters).

### DIFF
--- a/crypto/hpke/hpke.c
+++ b/crypto/hpke/hpke.c
@@ -1334,13 +1334,11 @@ int OSSL_HPKE_suite_check(OSSL_HPKE_SUITE suite)
     return hpke_suite_check(suite, NULL, NULL, NULL);
 }
 
-int OSSL_HPKE_get_grease_value(OSSL_LIB_CTX *libctx, const char *propq,
-                               const OSSL_HPKE_SUITE *suite_in,
+int OSSL_HPKE_get_grease_value(const OSSL_HPKE_SUITE *suite_in,
                                OSSL_HPKE_SUITE *suite,
-                               unsigned char *enc,
-                               size_t *enclen,
-                               unsigned char *ct,
-                               size_t ctlen)
+                               unsigned char *enc, size_t *enclen,
+                               unsigned char *ct, size_t ctlen,
+                               OSSL_LIB_CTX *libctx, const char *propq)
 {
     OSSL_HPKE_SUITE chosen;
     size_t plen = 0;

--- a/doc/man3/OSSL_HPKE_CTX_new.pod
+++ b/doc/man3/OSSL_HPKE_CTX_new.pod
@@ -68,11 +68,11 @@ OSSL_HPKE_CTX_get_seq, OSSL_HPKE_CTX_set_seq
                              const unsigned char *ikme, size_t ikmelen);
 
  int OSSL_HPKE_suite_check(OSSL_HPKE_SUITE suite);
- int OSSL_HPKE_get_grease_value(OSSL_LIB_CTX *libctx, const char *propq,
-                                const OSSL_HPKE_SUITE *suite_in,
+ int OSSL_HPKE_get_grease_value(const OSSL_HPKE_SUITE *suite_in,
                                 OSSL_HPKE_SUITE *suite,
                                 unsigned char *enc, size_t *enclen,
-                                unsigned char *ct, size_t ctlen);
+                                unsigned char *ct, size_t ctlen,
+                                OSSL_LIB_CTX *libctx, const char *propq);
 
  int OSSL_HPKE_str2suite(const char *str, OSSL_HPKE_SUITE *suite);
  size_t OSSL_HPKE_get_ciphertext_size(OSSL_HPKE_SUITE suite, size_t clearlen);

--- a/include/openssl/hpke.h
+++ b/include/openssl/hpke.h
@@ -138,11 +138,11 @@ int OSSL_HPKE_CTX_set_seq(OSSL_HPKE_CTX *ctx, uint64_t seq);
 int OSSL_HPKE_CTX_get_seq(OSSL_HPKE_CTX *ctx, uint64_t *seq);
 
 int OSSL_HPKE_suite_check(OSSL_HPKE_SUITE suite);
-int OSSL_HPKE_get_grease_value(OSSL_LIB_CTX *libctx, const char *propq,
-                               const OSSL_HPKE_SUITE *suite_in,
+int OSSL_HPKE_get_grease_value(const OSSL_HPKE_SUITE *suite_in,
                                OSSL_HPKE_SUITE *suite,
                                unsigned char *enc, size_t *enclen,
-                               unsigned char *ct, size_t ctlen);
+                               unsigned char *ct, size_t ctlen,
+                               OSSL_LIB_CTX *libctx, const char *propq);
 int OSSL_HPKE_str2suite(const char *str, OSSL_HPKE_SUITE *suite);
 size_t OSSL_HPKE_get_ciphertext_size(OSSL_HPKE_SUITE suite, size_t clearlen);
 size_t OSSL_HPKE_get_public_encap_size(OSSL_HPKE_SUITE suite);

--- a/test/hpke_test.c
+++ b/test/hpke_test.c
@@ -1260,16 +1260,18 @@ static int test_hpke_grease(void)
     /* GREASEing */
     /* check too short for public value */
     g_pub_len = 10;
-    if (TEST_false(OSSL_HPKE_get_grease_value(testctx, NULL, NULL, &g_suite,
+    if (TEST_false(OSSL_HPKE_get_grease_value(NULL, &g_suite,
                                               g_pub, &g_pub_len,
-                                              g_cipher, g_cipher_len)) != 1) {
+                                              g_cipher, g_cipher_len,
+                                              testctx, NULL)) != 1) {
         overallresult = 0;
     }
     /* reset to work */
     g_pub_len = OSSL_HPKE_TSTSIZE;
-    if (TEST_true(OSSL_HPKE_get_grease_value(testctx, NULL, NULL, &g_suite,
+    if (TEST_true(OSSL_HPKE_get_grease_value(NULL, &g_suite,
                                              g_pub, &g_pub_len,
-                                             g_cipher, g_cipher_len)) != 1) {
+                                             g_cipher, g_cipher_len,
+                                             testctx, NULL)) != 1) {
         overallresult = 0;
     }
     /* expansion */
@@ -1630,36 +1632,41 @@ static int test_hpke_random_suites(void)
     size_t ctlen = sizeof(ct);
 
     /* test with NULL/0 inputs */
-    if (!TEST_false(OSSL_HPKE_get_grease_value(testctx, NULL, NULL, NULL,
-                                               NULL, NULL, NULL, 0)))
+    if (!TEST_false(OSSL_HPKE_get_grease_value(NULL, NULL,
+                                               NULL, NULL, NULL, 0,
+                                               testctx, NULL)))
         return 0;
     enclen = 10;
-    if (!TEST_false(OSSL_HPKE_get_grease_value(testctx, NULL, &def_suite,
-                                               &suite2, enc, &enclen,
-                                               ct, ctlen)))
+    if (!TEST_false(OSSL_HPKE_get_grease_value(&def_suite, &suite2,
+                                               enc, &enclen, ct, ctlen,
+                                               testctx, NULL)))
         return 0;
 
     enclen = sizeof(enc); /* reset, 'cause get_grease() will have set */
     /* test with a should-be-good suite */
-    if (!TEST_true(OSSL_HPKE_get_grease_value(testctx, NULL, &def_suite,
-                                              &suite2, enc, &enclen,
-                                              ct, ctlen)))
+    if (!TEST_true(OSSL_HPKE_get_grease_value(&def_suite, &suite2,
+                                              enc, &enclen, ct, ctlen,
+                                              testctx, NULL)))
         return 0;
     /* no suggested suite */
     enclen = sizeof(enc); /* reset, 'cause get_grease() will have set */
-    if (!TEST_true(OSSL_HPKE_get_grease_value(testctx, NULL, NULL, &suite2,
-                                              enc, &enclen, ct, ctlen)))
+    if (!TEST_true(OSSL_HPKE_get_grease_value(NULL, &suite2,
+                                              enc, &enclen,
+                                              ct, ctlen,
+                                              testctx, NULL)))
         return 0;
     /* suggested suite with P-521, just to be sure we hit long values */
     enclen = sizeof(enc); /* reset, 'cause get_grease() will have set */
     suite.kem_id = OSSL_HPKE_KEM_ID_P521;
-    if (!TEST_true(OSSL_HPKE_get_grease_value(testctx, NULL, &suite, &suite2,
-                                              enc, &enclen, ct, ctlen)))
+    if (!TEST_true(OSSL_HPKE_get_grease_value(&suite, &suite2,
+                                              enc, &enclen, ct, ctlen,
+                                              testctx, NULL)))
         return 0;
     enclen = sizeof(enc);
     ctlen = 2; /* too-short cttext (can't fit an aead tag) */
-    if (!TEST_false(OSSL_HPKE_get_grease_value(testctx, NULL, NULL, &suite2,
-                                               enc, &enclen, ct, ctlen)))
+    if (!TEST_false(OSSL_HPKE_get_grease_value(NULL, &suite2,
+                                               enc, &enclen, ct, ctlen,
+                                               testctx, NULL)))
         return 0;
 
     ctlen = sizeof(ct);
@@ -1667,20 +1674,23 @@ static int test_hpke_random_suites(void)
 
     suite.kem_id = OSSL_HPKE_KEM_ID_X25519; /* back to default */
     suite.aead_id = 0x1234; /* bad aead */
-    if (!TEST_false(OSSL_HPKE_get_grease_value(testctx, NULL, &suite, &suite2,
-                                               enc, &enclen, ct, ctlen)))
+    if (!TEST_false(OSSL_HPKE_get_grease_value(&suite, &suite2,
+                                               enc, &enclen, ct, ctlen,
+                                               testctx, NULL)))
         return 0;
     enclen = sizeof(enc);
     suite.aead_id = def_suite.aead_id; /* good aead */
     suite.kdf_id = 0x3451; /* bad kdf */
-    if (!TEST_false(OSSL_HPKE_get_grease_value(testctx, NULL, &suite, &suite2,
-                                               enc, &enclen, ct, ctlen)))
+    if (!TEST_false(OSSL_HPKE_get_grease_value(&suite, &suite2,
+                                               enc, &enclen, ct, ctlen,
+                                               testctx, NULL)))
         return 0;
     enclen = sizeof(enc);
     suite.kdf_id = def_suite.kdf_id; /* good kdf */
     suite.kem_id = 0x4517; /* bad kem */
-    if (!TEST_false(OSSL_HPKE_get_grease_value(testctx, NULL, &suite, &suite2,
-                                               enc, &enclen, ct, ctlen)))
+    if (!TEST_false(OSSL_HPKE_get_grease_value(&suite, &suite2,
+                                               enc, &enclen, ct, ctlen,
+                                               testctx, NULL)))
         return 0;
     return 1;
 }


### PR DESCRIPTION
This keeps the interface consistent with other HPKE API's.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
