### PR TITLE
Avoid undefined behaviour with the <ctype.h> functions.

### DIFF
--- a/apps/cmp.c
+++ b/apps/cmp.c
@@ -2118,7 +2118,7 @@ static const char *prev_item(const char *opt, const char *end)
     beg = end;
     while (beg > opt) {
         --beg;
-        if (beg[0] == ',' || isspace(beg[0])) {
+        if (beg[0] == ',' || isspace((unsigned char)beg[0])) {
             ++beg;
             break;
         }
@@ -2133,7 +2133,7 @@ static const char *prev_item(const char *opt, const char *end)
     opt_item[len] = '\0';
     while (beg > opt) {
         --beg;
-        if (beg[0] != ',' && !isspace(beg[0])) {
+        if (beg[0] != ',' && !isspace((unsigned char)beg[0])) {
             ++beg;
             break;
         }

--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -664,13 +664,13 @@ void *app_malloc(size_t sz, const char *what)
 char *next_item(char *opt) /* in list separated by comma and/or space */
 {
     /* advance to separator (comma or whitespace), if any */
-    while (*opt != ',' && !isspace(*opt) && *opt != '\0')
+    while (*opt != ',' && !isspace((unsigned char)*opt) && *opt != '\0')
         opt++;
     if (*opt != '\0') {
         /* terminate current item */
         *opt++ = '\0';
         /* skip over any whitespace after separator */
-        while (isspace(*opt))
+        while (isspace((unsigned char)*opt))
             opt++;
     }
     return *opt == '\0' ? NULL : opt; /* NULL indicates end of input */

--- a/apps/req.c
+++ b/apps/req.c
@@ -198,7 +198,7 @@ static int duplicated(LHASH_OF(OPENSSL_STRING) *addexts, char *kv)
 
     /* Check syntax. */
     /* Skip leading whitespace, make a copy. */
-    while (isspace(*kv))
+    while (isspace((unsigned char)*kv))
         kv++;
     if ((p = strchr(kv, '=')) == NULL) {
         BIO_printf(bio_err, "Parse error on -addext: missing '='\n");
@@ -210,7 +210,7 @@ static int duplicated(LHASH_OF(OPENSSL_STRING) *addexts, char *kv)
 
     /* Skip trailing space before the equal sign. */
     for (p = kv + off; p > kv; --p)
-        if (!isspace(p[-1]))
+        if (!isspace((unsigned char)p[-1]))
             break;
     if (p == kv) {
         BIO_printf(bio_err, "Parse error on -addext: missing key\n");

--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -2342,7 +2342,7 @@ int s_client_main(int argc, char **argv)
             do {
                 mbuf_len = BIO_gets(fbio, mbuf, BUFSIZZ);
             }
-            while (mbuf_len > 3 && (!isdigit(mbuf[0]) || !isdigit(mbuf[1]) || !isdigit(mbuf[2]) || mbuf[3] != ' '));
+            while (mbuf_len > 3 && (!isdigit((unsigned char)mbuf[0]) || !isdigit((unsigned char)mbuf[1]) || !isdigit((unsigned char)mbuf[2]) || mbuf[3] != ' '));
             (void)BIO_flush(fbio);
             BIO_pop(fbio);
             BIO_free(fbio);

--- a/crypto/LPdir_unix.c
+++ b/crypto/LPdir_unix.c
@@ -137,7 +137,7 @@ const char *LP_find_file(LP_DIR_CTX **ctx, const char *directory)
     if ((*ctx)->expect_file_generations) {
         char *p = (*ctx)->entry_name + strlen((*ctx)->entry_name);
 
-        while (p > (*ctx)->entry_name && isdigit(p[-1]))
+        while (p > (*ctx)->entry_name && isdigit((unsigned char)p[-1]))
             p--;
         if (p > (*ctx)->entry_name && p[-1] == ';')
             p[-1] = '\0';

--- a/crypto/riscvcap.c
+++ b/crypto/riscvcap.c
@@ -38,7 +38,7 @@ size_t OPENSSL_instrument_bus2(unsigned int *out, size_t cnt, size_t max)
 static void strtoupper(char *str)
 {
     for (char *x = str; *x; ++x)
-        *x = toupper(*x);
+        *x = toupper((unsigned char)*x);
 }
 
 /* parse_env() parses a RISC-V architecture string. An example of such a string

--- a/engines/e_loader_attic.c
+++ b/engines/e_loader_attic.c
@@ -983,7 +983,7 @@ static OSSL_STORE_LOADER_CTX *file_open_ex
 #ifdef _WIN32
         /* Windows "file:" URIs with a drive letter start with a '/' */
         if (p[0] == '/' && p[2] == ':' && p[3] == '/') {
-            char c = tolower(p[1]);
+            char c = tolower((unsigned char)p[1]);
 
             if (c >= 'a' && c <= 'z') {
                 p++;
@@ -1470,9 +1470,9 @@ static int file_name_check(OSSL_STORE_LOADER_CTX *ctx, const char *name)
      * Last, check that the rest of the extension is a decimal number, at
      * least one digit long.
      */
-    if (!isdigit(*p))
+    if (!isdigit((unsigned char)*p))
         return 0;
-    while (isdigit(*p))
+    while (isdigit((unsigned char)*p))
         p++;
 
 #ifdef __VMS

--- a/providers/implementations/encode_decode/encode_key2text.c
+++ b/providers/implementations/encode_decode/encode_key2text.c
@@ -112,7 +112,8 @@ static int print_labeled_bignum(BIO *out, const char *label, const BIGNUM *bn)
             use_sep = 0; /* The first byte on the next line doesnt have a : */
         }
         if (BIO_printf(out, "%s%c%c", use_sep ? ":" : "",
-                       tolower(p[0]), tolower(p[1])) <= 0)
+                       tolower((unsigned char)p[0]),
+                       tolower((unsigned char)p[1])) <= 0)
             goto err;
         ++bytes;
         p += 2;

--- a/providers/implementations/storemgmt/file_store.c
+++ b/providers/implementations/storemgmt/file_store.c
@@ -236,7 +236,7 @@ static void *file_open(void *provctx, const char *uri)
 #ifdef _WIN32
         /* Windows "file:" URIs with a drive letter start with a '/' */
         if (p[0] == '/' && p[2] == ':' && p[3] == '/') {
-            char c = tolower(p[1]);
+            char c = tolower((unsigned char)p[1]);
 
             if (c >= 'a' && c <= 'z') {
                 p++;
@@ -608,9 +608,9 @@ static int file_name_check(struct file_ctx_st *ctx, const char *name)
      * Last, check that the rest of the extension is a decimal number, at
      * least one digit long.
      */
-    if (!isdigit(*p))
+    if (!isdigit((unsigned char)*p))
         return 0;
-    while (isdigit(*p))
+    while (isdigit((unsigned char)*p))
         p++;
 
 #ifdef __VMS

--- a/test/evp_test.c
+++ b/test/evp_test.c
@@ -3811,11 +3811,11 @@ static int prov_available(char *providers)
     int more = 1;
 
     while (more) {
-        for (; isspace(*providers); providers++)
+        for (; isspace((unsigned char)*providers); providers++)
             continue;
         if (*providers == '\0')
             break;               /* End of the road */
-        for (p = providers; *p != '\0' && !isspace(*p); p++)
+        for (p = providers; *p != '\0' && !isspace((unsigned char)*p); p++)
             continue;
         if (*p == '\0')
             more = 0;

--- a/test/testutil/provider.c
+++ b/test/testutil/provider.c
@@ -177,11 +177,13 @@ int fips_provider_version_match(OSSL_LIB_CTX *libctx, const char *versions)
     } mode;
 
     while (*versions != '\0') {
-        for (; isspace(*versions); versions++)
+        for (; isspace((unsigned char)*versions); versions++)
             continue;
         if (*versions == '\0')
             break;
-        for (p = versions; *versions != '\0' && !isspace(*versions); versions++)
+        for (p = versions;
+             *versions != '\0' && !isspace((unsigned char)*versions);
+             versions++)
             continue;
         if (*p == '!') {
             mode = MODE_NE;
@@ -201,7 +203,7 @@ int fips_provider_version_match(OSSL_LIB_CTX *libctx, const char *versions)
         } else if (*p == '>') {
             mode = MODE_GT;
             p++;
-        } else if (isdigit(*p)) {
+        } else if (isdigit((unsigned char)*p)) {
             mode = MODE_EQ;
         } else {
             TEST_info("Error matching FIPS version: mode %s\n", p);


### PR DESCRIPTION
As defined in the C standard:

> In all cases the argument is an int, the value of which shall be representable as an unsigned char or shall equal the value of the macro EOF.  If the argument has any other value, the behavior is undefined.

This is because they're designed to work with the int values returned by getc or fgetc; they need extra work to handle a char value.

If EOF is -1 (as it almost always is), with 8-bit bytes, the allowed inputs to the ctype.h functions are:

    {-1, 0, 1, 2, 3, ..., 255}.

However, on platforms where char is signed, such as x86 with the usual ABI, code like

    char *p = ...;
    ... isspace(*p) ...

may pass in values in the range:

    {-128, -127, -126, ..., -2, -1, 0, 1, ..., 127}.

This has two problems:

1. Inputs in the set {-128, -127, -126, ..., -2} are forbidden.

2. The non-EOF byte 0xff is conflated with the value EOF = -1, so even though the input is not forbidden, it may give the wrong answer.

Casting char inputs to unsigned char first works around this, by mapping the (non-EOF character) range {-128, -127, ..., -1} to {128, 129, ..., 255}, leaving no collisions with EOF.  So the above fragment needs to be:

    char *p = ...;
    ... isspace((unsigned char)*p) ...

This patch inserts unsigned char casts where necessary.  Most of the cases I changed, I compile-tested using -Wchar-subscripts -Werror on NetBSD, which defines the ctype.h functions as macros so that they trigger the warning when the argument has type char.  The exceptions are under #ifdef __VMS or #ifdef _WIN32.  I left alone calls where the input is int where the cast would obviously be wrong; and I left alone calls where the input is already unsigned char so the cast is unnecessary.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
