### PR TITLE
/dev/crypto: Suppress warning when open /dev/crypto fails with ENXIO.

### DIFF
--- a/engines/e_devcrypto.c
+++ b/engines/e_devcrypto.c
@@ -1228,7 +1228,7 @@ static int open_devcrypto(void)
 
     if ((fd = open("/dev/crypto", O_RDWR, 0)) < 0) {
 #ifndef ENGINE_DEVCRYPTO_DEBUG
-        if (errno != ENOENT)
+        if (errno != ENOENT && errno != ENXIO)
 #endif
             fprintf(stderr, "Could not open /dev/crypto: %s\n", strerror(errno));
         return 0;


### PR DESCRIPTION
On NetBSD the device node is essentially always present, but these days it's mostly not useful except for testing the kernel crypto stack since the cost of CPU crypto has gone down much faster than the cost of I/O to external crypto engines.  So on most systems it is disabled in a way that makes open fail with ENXIO.  NetBSD has had this warning for ENXIO patched away for years.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
