### PR TITLE
Erase temporary buffer in EVP_PKEY_get_bn_param()

### DIFF
--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -2176,12 +2176,11 @@ int EVP_PKEY_get_bn_param(const EVP_PKEY *pkey, const char *key_name,
         goto err;
     ret = OSSL_PARAM_get_BN(params, bn);
 err:
-    if (buf) {
-        if (OSSL_PARAM_modified(params)) {
+    if (buf != NULL) {
+        if (OSSL_PARAM_modified(params))
             OPENSSL_clear_free(buf, buf_sz);
-        } else {
+        else
             OPENSSL_free(buf);
-        }
     } else if (OSSL_PARAM_modified(params)) {
         OPENSSL_cleanse(buffer, params[0].data_size);
     }

--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -2176,7 +2176,15 @@ int EVP_PKEY_get_bn_param(const EVP_PKEY *pkey, const char *key_name,
         goto err;
     ret = OSSL_PARAM_get_BN(params, bn);
 err:
-    OPENSSL_free(buf);
+    if (buf) {
+        if (OSSL_PARAM_modified(params)) {
+            OPENSSL_clear_free(buf, buf_sz);
+        } else {
+            OPENSSL_free(buf);
+        }
+    } else if (OSSL_PARAM_modified(params)) {
+        OPENSSL_cleanse(buffer, params[0].data_size);
+    }
     return ret;
 }
 


### PR DESCRIPTION
Function EVP_PKEY_get_bn_param() uses temporary buffer (on stack or heap allocated) to store serialized bignum, but after deserializing it into BIGNUM*, the buffer is not erased and may contain sensitive data.

This change makes sure the buffer is erased if it was successfully filled before. Unfortunately, it does not distinguish between public and private key components, and will always erase the buffer.

Fixes https://github.com/openssl/openssl/issues/20626