### PR TITLE
Make sure we can query the SSL object for version info when using QUIC

### DIFF
--- a/doc/man3/SSL_get_version.pod
+++ b/doc/man3/SSL_get_version.pod
@@ -2,8 +2,8 @@
 
 =head1 NAME
 
-SSL_client_version, SSL_get_version, SSL_is_dtls, SSL_version - get the
-protocol information of a connection
+SSL_client_version, SSL_get_version, SSL_is_dtls, SSL_is_tls, SSL_is_quic,
+SSL_version - get the protocol information of a connection
 
 =head1 SYNOPSIS
 
@@ -14,6 +14,8 @@ protocol information of a connection
  const char *SSL_get_version(const SSL *ssl);
 
  int SSL_is_dtls(const SSL *ssl);
+ int SSL_is_tls(const SSL *ssl);
+ int SSL_is_quic(const SSL *ssl);
 
  int SSL_version(const SSL *s);
 
@@ -28,7 +30,11 @@ the numeric protocol version used for the connection. They should only be called
 after the initial handshake has been completed. Prior to that the results
 returned from these functions may be unreliable.
 
-SSL_is_dtls() returns one if the connection is using DTLS, zero if not.
+SSL_is_dtls() returns 1 if the connection is using DTLS or 0 if not.
+
+SSL_is_tls() returns 1 if the connection is using SSL/TLS or 0 if not.
+
+SSL_is_quic() returns 1 if the connection is using QUIC or 0 if not.
 
 =head1 RETURN VALUES
 
@@ -56,6 +62,22 @@ The connection uses the TLSv1.2 protocol.
 =item TLSv1.3
 
 The connection uses the TLSv1.3 protocol.
+
+=item DTLSv0.9
+
+The connection uses an obsolete pre-standardisation DTLS protocol
+
+=item DTLSv1
+
+The connection uses the DTLSv1 protocol
+
+=item DTLSv1.2
+
+The connection uses the DTLSv1.2 protocol
+
+=item QUICv1
+
+The connection uses the QUICv1 protocol.
 
 =item unknown
 
@@ -89,6 +111,23 @@ The connection uses the TLSv1.2 protocol.
 The connection uses the TLSv1.3 protocol (never returned for
 SSL_client_version()).
 
+=item  DTLS1_BAD_VER
+
+The connection uses an obsolete pre-standardisation DTLS protocol
+
+=item DTLS1_VERSION
+
+The connection uses the DTLSv1 protocol
+
+=item DTLS1_2_VERSION
+
+The connection uses the DTLSv1.2 protocol
+
+=item OSSL_QUIC1_VERSION
+
+The connection uses the QUICv1 protocol (never returned for
+SSL_client_version()).
+
 =back
 
 =head1 SEE ALSO
@@ -97,7 +136,8 @@ L<ssl(7)>
 
 =head1 HISTORY
 
-The SSL_is_dtls() function was added in OpenSSL 1.1.0.
+The SSL_is_dtls() function was added in OpenSSL 1.1.0. The SSL_is_tls() and
+SSL_is_quic() functions were added in OpenSSL 3.2.
 
 =head1 COPYRIGHT
 

--- a/include/openssl/prov_ssl.h
+++ b/include/openssl/prov_ssl.h
@@ -19,6 +19,7 @@ extern "C" {
 
 # define SSL_MAX_MASTER_KEY_LENGTH 48
 
+/* SSL/TLS uses a 2 byte unsigned version number */
 # define SSL3_VERSION                    0x0300
 # define TLS1_VERSION                    0x0301
 # define TLS1_1_VERSION                  0x0302
@@ -27,6 +28,9 @@ extern "C" {
 # define DTLS1_VERSION                   0xFEFF
 # define DTLS1_2_VERSION                 0xFEFD
 # define DTLS1_BAD_VER                   0x0100
+
+/* QUIC uses a 4 byte unsigned version number */
+# define OSSL_QUIC1_VERSION              0x0000001
 
 # ifdef __cplusplus
 }

--- a/include/openssl/ssl.h.in
+++ b/include/openssl/ssl.h.in
@@ -1798,6 +1798,8 @@ __owur int SSL_CTX_set_session_id_context(SSL_CTX *ctx,
 SSL *SSL_new(SSL_CTX *ctx);
 int SSL_up_ref(SSL *s);
 int SSL_is_dtls(const SSL *s);
+int SSL_is_tls(const SSL *s);
+int SSL_is_quic(const SSL *s);
 __owur int SSL_set_session_id_context(SSL *ssl, const unsigned char *sid_ctx,
                                       unsigned int sid_ctx_len);
 

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -928,10 +928,39 @@ int SSL_is_dtls(const SSL *s)
 {
     SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL(s);
 
+#ifndef OPENSSL_NO_QUIC
+    if (s->type == SSL_TYPE_QUIC_CONNECTION || s->type == SSL_TYPE_QUIC_STREAM)
+        return 0;
+#endif
+
     if (sc == NULL)
         return 0;
 
     return SSL_CONNECTION_IS_DTLS(sc) ? 1 : 0;
+}
+
+int SSL_is_tls(const SSL *s)
+{
+    SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL(s);
+
+#ifndef OPENSSL_NO_QUIC
+    if (s->type == SSL_TYPE_QUIC_CONNECTION || s->type == SSL_TYPE_QUIC_STREAM)
+        return 0;
+#endif
+
+    if (sc == NULL)
+        return 0;
+
+    return SSL_CONNECTION_IS_DTLS(sc) ? 0 : 1;
+}
+
+int SSL_is_quic(const SSL *s)
+{
+#ifndef OPENSSL_NO_QUIC
+    if (s->type == SSL_TYPE_QUIC_CONNECTION || s->type == SSL_TYPE_QUIC_STREAM)
+        return 1;
+#endif
+    return 0;
 }
 
 int SSL_up_ref(SSL *s)
@@ -4741,6 +4770,12 @@ const char *SSL_get_version(const SSL *s)
 {
     const SSL_CONNECTION *sc = SSL_CONNECTION_FROM_CONST_SSL(s);
 
+#ifndef OPENSSL_NO_QUIC
+    /* We only support QUICv1 - so if its QUIC its QUICv1 */
+    if (s->type == SSL_TYPE_QUIC_CONNECTION || s->type == SSL_TYPE_QUIC_STREAM)
+        return "QUICv1";
+#endif
+
     if (sc == NULL)
         return NULL;
 
@@ -5077,6 +5112,11 @@ int SSL_version(const SSL *s)
 {
     const SSL_CONNECTION *sc = SSL_CONNECTION_FROM_CONST_SSL(s);
 
+#ifndef OPENSSL_NO_QUIC
+    /* We only support QUICv1 - so if its QUIC its QUICv1 */
+    if (s->type == SSL_TYPE_QUIC_CONNECTION || s->type == SSL_TYPE_QUIC_STREAM)
+        return OSSL_QUIC1_VERSION;
+#endif
     /* TODO(QUIC): Do we want to report QUIC version this way instead? */
     if (sc == NULL)
         return 0;

--- a/test/quicapitest.c
+++ b/test/quicapitest.c
@@ -154,6 +154,45 @@ static int test_ciphersuites(void)
     return testresult;
 }
 
+/*
+ * Test that SSL_version, SSL_get_version, SSL_is_quic, SSL_is_tls and
+ * SSL_is_dtls return the expected results for a QUIC connection. Compare with
+ * test_version() in sslapitest.c which does the same thing for TLS/DTLS
+ * connections.
+ */
+static int test_version(void)
+{
+    SSL_CTX *cctx = SSL_CTX_new_ex(libctx, NULL, OSSL_QUIC_client_method());
+    SSL *clientquic = NULL;
+    QUIC_TSERVER *qtserv = NULL;
+    int testresult = 0;
+
+    if (!TEST_ptr(cctx)
+            || !TEST_true(qtest_create_quic_objects(libctx, cctx, cert, privkey,
+                                                    0, &qtserv, &clientquic,
+                                                    NULL))
+            || !TEST_true(qtest_create_quic_connection(qtserv, clientquic)))
+        goto err;
+
+    if (!TEST_int_eq(SSL_version(clientquic), OSSL_QUIC1_VERSION)
+            || !TEST_str_eq(SSL_get_version(clientquic), "QUICv1"))
+        goto err;
+
+    if (!TEST_true(SSL_is_quic(clientquic))
+            || !TEST_false(SSL_is_tls(clientquic))
+            || !TEST_false(SSL_is_dtls(clientquic)))
+        goto err;
+
+
+    testresult = 1;
+ err:
+    ossl_quic_tserver_free(qtserv);
+    SSL_free(clientquic);
+    SSL_CTX_free(cctx);
+
+    return testresult;
+}
+
 OPT_TEST_DECLARE_USAGE("provider config\n")
 
 int setup_tests(void)
@@ -210,6 +249,7 @@ int setup_tests(void)
 
     ADD_ALL_TESTS(test_quic_write_read, 2);
     ADD_TEST(test_ciphersuites);
+    ADD_TEST(test_version);
 
     return 1;
  err:

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -10825,6 +10825,147 @@ end:
 }
 #endif /* !defined(OPENSSL_NO_TLS1_2) && !defined(OPENSSL_NO_DYNAMIC_ENGINE) */
 
+static int check_version_string(SSL *s, int version)
+{
+    const char *verstr = NULL;
+
+    switch (version) {
+    case SSL3_VERSION:
+        verstr = "SSLv3";
+        break;
+    case TLS1_VERSION:
+        verstr = "TLSv1";
+        break;
+    case TLS1_1_VERSION:
+        verstr = "TLSv1.1";
+        break;
+    case TLS1_2_VERSION:
+        verstr = "TLSv1.2";
+        break;
+    case TLS1_3_VERSION:
+        verstr = "TLSv1.3";
+        break;
+    case DTLS1_VERSION:
+        verstr = "DTLSv1";
+        break;
+    case DTLS1_2_VERSION:
+        verstr = "DTLSv1.2";
+    }
+
+    return TEST_str_eq(verstr, SSL_get_version(s));
+}
+
+/*
+ * Test that SSL_version, SSL_get_version, SSL_is_quic, SSL_is_tls and
+ * SSL_is_dtls return the expected results for a (D)TLS connection. Compare with
+ * test_version() in quicapitest.c which does the same thing for QUIC
+ * connections.
+ */
+static int test_version(int idx)
+{
+    SSL_CTX *cctx = NULL, *sctx = NULL;
+    SSL *clientssl = NULL, *serverssl = NULL;
+    int testresult = 0, version;
+    const SSL_METHOD *servmeth = TLS_server_method();
+    const SSL_METHOD *clientmeth = TLS_client_method();
+
+    switch (idx) {
+#if !defined(OPENSSL_NO_SSL3)
+    case 0:
+        version = SSL3_VERSION;
+        break;
+#endif
+#if !defined(OPENSSL_NO_TLS1)
+    case 1:
+        version = TLS1_VERSION;
+        break;
+#endif
+#if !defined(OPENSSL_NO_TLS1_2)
+    case 2:
+        version = TLS1_2_VERSION;
+        break;
+#endif
+#if !defined(OSSL_NO_USABLE_TLS1_3)
+    case 3:
+        version = TLS1_3_VERSION;
+        break;
+#endif
+#if !defined(OPENSSL_NO_DTLS1)
+    case 4:
+        version = DTLS1_VERSION;
+        break;
+#endif
+#if !defined(OPENSSL_NO_DTLS1_2)
+    case 5:
+        version = DTLS1_2_VERSION;
+        break;
+#endif
+    /*
+     * NB we do not support QUIC in this test. That is covered by quicapitest.c
+     * We also don't support DTLS1_BAD_VER since we have no server support for
+     * that.
+     */
+    default:
+        TEST_skip("Unsupported protocol version");
+        return 1;
+    }
+
+#if !defined(OPENSSL_NO_DTLS)
+    if (version == DTLS1_VERSION || version == DTLS1_2_VERSION) {
+        servmeth = DTLS_server_method();
+        clientmeth = DTLS_client_method();
+    }
+#endif
+
+    if (!TEST_true(create_ssl_ctx_pair(libctx, servmeth, clientmeth, version,
+                                       version, &sctx, &cctx, cert, privkey)))
+        goto end;
+
+    if (!TEST_true(SSL_CTX_set_cipher_list(sctx, "DEFAULT:@SECLEVEL=0"))
+            || !TEST_true(SSL_CTX_set_cipher_list(cctx,
+                                                "DEFAULT:@SECLEVEL=0")))
+        goto end;
+
+    if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl,
+                                      &clientssl, NULL, NULL)))
+        goto end;
+
+    if (!TEST_true(create_ssl_connection(serverssl, clientssl, SSL_ERROR_NONE)))
+        goto end;
+
+    if (!TEST_int_eq(SSL_version(serverssl), version)
+            || !TEST_int_eq(SSL_version(clientssl), version)
+            || !TEST_true(check_version_string(serverssl, version))
+            || !TEST_true(check_version_string(clientssl, version)))
+        goto end;
+
+    if (version == DTLS1_VERSION || version == DTLS1_2_VERSION) {
+        if (!TEST_true(SSL_is_dtls(serverssl))
+                || !TEST_true(SSL_is_dtls(clientssl))
+                || !TEST_false(SSL_is_tls(serverssl))
+                || !TEST_false(SSL_is_tls(clientssl))
+                || !TEST_false(SSL_is_quic(serverssl))
+                || !TEST_false(SSL_is_quic(clientssl)))
+        goto end;
+    } else {
+        if (!TEST_true(SSL_is_tls(serverssl))
+                || !TEST_true(SSL_is_tls(clientssl))
+                || !TEST_false(SSL_is_dtls(serverssl))
+                || !TEST_false(SSL_is_dtls(clientssl))
+                || !TEST_false(SSL_is_quic(serverssl))
+                || !TEST_false(SSL_is_quic(clientssl)))
+        goto end;
+    }
+
+    testresult = 1;
+end:
+    SSL_free(serverssl);
+    SSL_free(clientssl);
+    SSL_CTX_free(sctx);
+    SSL_CTX_free(cctx);
+    return testresult;
+}
+
 OPT_TEST_DECLARE_USAGE("certfile privkeyfile srpvfile tmpfile provider config dhfile\n")
 
 int setup_tests(void)
@@ -11128,6 +11269,7 @@ int setup_tests(void)
 #if !defined(OPENSSL_NO_TLS1_2) && !defined(OPENSSL_NO_DYNAMIC_ENGINE)
     ADD_ALL_TESTS(test_pipelining, 6);
 #endif
+    ADD_ALL_TESTS(test_version, 6);
     return 1;
 
  err:

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -10910,6 +10910,14 @@ static int test_version(int idx)
         return 1;
     }
 
+    if (is_fips
+            && (version == SSL3_VERSION
+                || version == TLS1_VERSION
+                || version == DTLS1_VERSION)) {
+        TEST_skip("Protocol version not supported with FIPS");
+        return 1;
+    }
+
 #if !defined(OPENSSL_NO_DTLS)
     if (version == DTLS1_VERSION || version == DTLS1_2_VERSION) {
         servmeth = DTLS_server_method();

--- a/util/libssl.num
+++ b/util/libssl.num
@@ -558,3 +558,5 @@ SSL_get_negotiated_client_cert_type     ?	3_2_0	EXIST::FUNCTION:
 SSL_get_negotiated_server_cert_type     ?	3_2_0	EXIST::FUNCTION:
 SSL_add_expected_rpk                    ?	3_2_0	EXIST::FUNCTION:
 d2i_SSL_SESSION_ex                      ?	3_2_0	EXIST::FUNCTION:
+SSL_is_tls                              ?	3_2_0	EXIST::FUNCTION:
+SSL_is_quic                             ?	3_2_0	EXIST::FUNCTION:


### PR DESCRIPTION
We have the existing functions SSL_version(), SSL_get_version() and
SSL_is_dtls(). We extend the first two to return something sensible when
using QUIC. We additionally provide the new functions SSL_is_tls() and
SSL_is_quic() to provide a mechanism to figure out what protocol we are
using.
