### PR TITLE
fix non-fetchable hashes in openssl dgst -list

### DIFF
--- a/apps/dgst.c
+++ b/apps/dgst.c
@@ -488,8 +488,7 @@ static void show_digests(const OBJ_NAME *name, void *arg)
 
     /* Filter out message digests that we cannot use */
     md = EVP_MD_fetch(app_get0_libctx(), name->name, app_get0_propq());
-    if (md == NULL)
-    {
+    if (md == NULL) {
         md = EVP_get_digestbyname(name->name);
         if (md == NULL)
             return;

--- a/apps/dgst.c
+++ b/apps/dgst.c
@@ -489,7 +489,11 @@ static void show_digests(const OBJ_NAME *name, void *arg)
     /* Filter out message digests that we cannot use */
     md = EVP_MD_fetch(app_get0_libctx(), name->name, app_get0_propq());
     if (md == NULL)
-        return;
+    {
+        md = EVP_get_digestbyname(name->name);
+        if (md == NULL)
+            return;
+    }
 
     BIO_printf(dec->bio, "-%-25s", name->name);
     if (++dec->n == 3) {


### PR DESCRIPTION
`openssl dgst -engine gost -list` doesn't show hashes added by gost-engine because they are not supported by EVP_MD_fetch and EVP_get_digestbyname should be used instead. Another example of this issue has been fixed in https://github.com/openssl/openssl/pull/12689
By the way, `openssl enc -engine gost -list` works correctly.

CLA: trivial
