### PR TITLE
Fix compilation error when using clang-cl 16 or higher

### DIFF
--- a/crypto/thread/arch/thread_win.c
+++ b/crypto/thread/arch/thread_win.c
@@ -13,7 +13,7 @@
 # include <process.h>
 # include <windows.h>
 
-static DWORD __stdcall thread_start_thunk(LPVOID vthread)
+static unsigned __stdcall thread_start_thunk(LPVOID vthread)
 {
     CRYPTO_THREAD *thread;
     CRYPTO_THREAD_RETVAL ret;


### PR DESCRIPTION
Fixes a "Incompatible function pointer types" error.

In prior versions, this was a warning, but is now an error.

The correct type for the function was taken from: https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/beginthread-beginthreadex

##### Checklist
n/a
