### PR TITLE
Added some null pointer checks for provider alg

### DIFF
--- a/crypto/encode_decode/decoder_meth.c
+++ b/crypto/encode_decode/decoder_meth.c
@@ -206,7 +206,7 @@ void *ossl_decoder_from_algorithm(int id, const OSSL_ALGORITHM *algodef,
     const OSSL_DISPATCH *fns = algodef->implementation;
     OSSL_LIB_CTX *libctx = ossl_provider_libctx(prov);
 
-    if ((decoder = ossl_decoder_new()) == NULL)
+    if (fns == NULL || ((decoder = ossl_decoder_new()) == NULL))
         return NULL;
     decoder->base.id = id;
     if ((decoder->base.name = ossl_algorithm_get1_first_name(algodef)) == NULL) {

--- a/crypto/encode_decode/encoder_meth.c
+++ b/crypto/encode_decode/encoder_meth.c
@@ -206,7 +206,7 @@ static void *encoder_from_algorithm(int id, const OSSL_ALGORITHM *algodef,
     const OSSL_DISPATCH *fns = algodef->implementation;
     OSSL_LIB_CTX *libctx = ossl_provider_libctx(prov);
 
-    if ((encoder = ossl_encoder_new()) == NULL)
+    if (fns == NULL || ((encoder = ossl_encoder_new()) == NULL))
         return NULL;
     encoder->base.id = id;
     if ((encoder->base.name = ossl_algorithm_get1_first_name(algodef)) == NULL) {

--- a/crypto/evp/asymcipher.c
+++ b/crypto/evp/asymcipher.c
@@ -328,7 +328,7 @@ static void *evp_asym_cipher_from_algorithm(int name_id,
     int ctxfncnt = 0, encfncnt = 0, decfncnt = 0;
     int gparamfncnt = 0, sparamfncnt = 0;
 
-    if ((cipher = evp_asym_cipher_new(prov)) == NULL) {
+    if (fns == NULL || ((cipher = evp_asym_cipher_new(prov)) == NULL)) {
         ERR_raise(ERR_LIB_EVP, ERR_R_EVP_LIB);
         goto err;
     }

--- a/crypto/evp/digest.c
+++ b/crypto/evp/digest.c
@@ -979,7 +979,7 @@ static void *evp_md_from_algorithm(int name_id,
     int fncnt = 0;
 
     /* EVP_MD_fetch() will set the legacy NID if available */
-    if ((md = evp_md_new()) == NULL) {
+    if (fns == NULL || ((md = evp_md_new()) == NULL)) {
         ERR_raise(ERR_LIB_EVP, ERR_R_EVP_LIB);
         return NULL;
     }

--- a/crypto/evp/evp_enc.c
+++ b/crypto/evp/evp_enc.c
@@ -1525,7 +1525,7 @@ static void *evp_cipher_from_algorithm(const int name_id,
     EVP_CIPHER *cipher = NULL;
     int fnciphcnt = 0, fnctxcnt = 0;
 
-    if ((cipher = evp_cipher_new()) == NULL) {
+    if (fns == NULL || ((cipher = evp_cipher_new()) == NULL)) {
         ERR_raise(ERR_LIB_EVP, ERR_R_EVP_LIB);
         return NULL;
     }

--- a/crypto/evp/evp_rand.c
+++ b/crypto/evp/evp_rand.c
@@ -123,7 +123,7 @@ static void *evp_rand_from_algorithm(int name_id,
     int fnzeroizecnt = 0;
 #endif
 
-    if ((rand = evp_rand_new()) == NULL) {
+    if (fns == NULL || ((rand = evp_rand_new()) == NULL)) {
         ERR_raise(ERR_LIB_EVP, ERR_R_EVP_LIB);
         return NULL;
     }

--- a/crypto/evp/exchange.c
+++ b/crypto/evp/exchange.c
@@ -46,7 +46,7 @@ static void *evp_keyexch_from_algorithm(int name_id,
     EVP_KEYEXCH *exchange = NULL;
     int fncnt = 0, sparamfncnt = 0, gparamfncnt = 0;
 
-    if ((exchange = evp_keyexch_new(prov)) == NULL) {
+    if (fns == NULL || ((exchange = evp_keyexch_new(prov)) == NULL)) {
         ERR_raise(ERR_LIB_EVP, ERR_R_EVP_LIB);
         goto err;
     }

--- a/crypto/evp/kdf_meth.c
+++ b/crypto/evp/kdf_meth.c
@@ -64,7 +64,7 @@ static void *evp_kdf_from_algorithm(int name_id,
     EVP_KDF *kdf = NULL;
     int fnkdfcnt = 0, fnctxcnt = 0;
 
-    if ((kdf = evp_kdf_new()) == NULL) {
+    if (fns == NULL || ((kdf = evp_kdf_new()) == NULL)) {
         ERR_raise(ERR_LIB_EVP, ERR_R_EVP_LIB);
         return NULL;
     }

--- a/crypto/evp/kem.c
+++ b/crypto/evp/kem.c
@@ -299,7 +299,7 @@ static void *evp_kem_from_algorithm(int name_id, const OSSL_ALGORITHM *algodef,
     int ctxfncnt = 0, encfncnt = 0, decfncnt = 0;
     int gparamfncnt = 0, sparamfncnt = 0;
 
-    if ((kem = evp_kem_new(prov)) == NULL) {
+    if (fns == NULL || ((kem = evp_kem_new(prov)) == NULL)) {
         ERR_raise(ERR_LIB_EVP, ERR_R_EVP_LIB);
         goto err;
     }

--- a/crypto/evp/keymgmt_meth.c
+++ b/crypto/evp/keymgmt_meth.c
@@ -45,7 +45,7 @@ static void *keymgmt_from_algorithm(int name_id,
     int importfncnt = 0, exportfncnt = 0;
     int importtypesfncnt = 0, exporttypesfncnt = 0;
 
-    if ((keymgmt = keymgmt_new()) == NULL)
+    if (fns == NULL || ((keymgmt = keymgmt_new()) == NULL))
         return NULL;
 
     keymgmt->name_id = name_id;

--- a/crypto/evp/mac_meth.c
+++ b/crypto/evp/mac_meth.c
@@ -65,7 +65,7 @@ static void *evp_mac_from_algorithm(int name_id,
     EVP_MAC *mac = NULL;
     int fnmaccnt = 0, fnctxcnt = 0;
 
-    if ((mac = evp_mac_new()) == NULL) {
+    if (fns == NULL || ((mac = evp_mac_new()) == NULL)) {
         ERR_raise(ERR_LIB_EVP, ERR_R_EVP_LIB);
         return NULL;
     }

--- a/crypto/evp/signature.c
+++ b/crypto/evp/signature.c
@@ -48,7 +48,7 @@ static void *evp_signature_from_algorithm(int name_id,
     int digsignfncnt = 0, digverifyfncnt = 0;
     int gparamfncnt = 0, sparamfncnt = 0, gmdparamfncnt = 0, smdparamfncnt = 0;
 
-    if ((signature = evp_signature_new(prov)) == NULL) {
+    if (fns == NULL || ((signature = evp_signature_new(prov)) == NULL)) {
         ERR_raise(ERR_LIB_EVP, ERR_R_EVP_LIB);
         goto err;
     }

--- a/crypto/store/store_meth.c
+++ b/crypto/store/store_meth.c
@@ -179,7 +179,7 @@ static void *loader_from_algorithm(int scheme_id, const OSSL_ALGORITHM *algodef,
     OSSL_STORE_LOADER *loader = NULL;
     const OSSL_DISPATCH *fns = algodef->implementation;
 
-    if ((loader = new_loader(prov)) == NULL)
+    if (fns == NULL || ((loader = new_loader(prov)) == NULL))
         return NULL;
     loader->scheme_id = scheme_id;
     loader->propdef = algodef->property_definition;


### PR DESCRIPTION
CLA: trivial
Previously, if the implemention of an algorithms was `NULL`, we were getting a segmentation fault. I added some checks to fail fetching algorithms if the implementation is `NULL`.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
