### PR TITLE
Don't call OPENSSL_init_crypto from inside a RUN_ONCE

### DIFF
--- a/crypto/objects/obj_dat.c
+++ b/crypto/objects/obj_dat.c
@@ -65,9 +65,6 @@ static ossl_inline void objs_free_locks(void)
 
 DEFINE_RUN_ONCE_STATIC(obj_lock_initialise)
 {
-    /* Make sure we've loaded config before checking for any "added" objects */
-    OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CONFIG, NULL);
-
     ossl_obj_lock = CRYPTO_THREAD_lock_new();
     if (ossl_obj_lock == NULL)
         return 0;
@@ -84,6 +81,8 @@ DEFINE_RUN_ONCE_STATIC(obj_lock_initialise)
 
 static ossl_inline int ossl_init_added_lock(void)
 {
+    /* Make sure we've loaded config before checking for any "added" objects */
+    OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CONFIG, NULL);
     return RUN_ONCE(&ossl_obj_lock_init, obj_lock_initialise);
 }
 


### PR DESCRIPTION
Calling OPENSSL_init_crypto from inside a RUN_ONCE seems like a bad idea. This is especially bad if OPENSSL_init_crypto can recursively end up attempting to call the RUN_ONCE that we're already inside.

The initialisation in OPENSSL_init_crypto is already "run once" protected. There is no need to protect it "twice".

Fixes #20653

(I created this against the 3.1 branch so that @mouse07410 can easily try it out. It would need to be cherry-picked to master and 3.0)
