### PR TITLE
An overflow in ssl/ssl_lib.c SSL_get_shared_ciphers()

### DIFF
--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -3347,20 +3347,18 @@ char *SSL_get_shared_ciphers(const SSL *s, char *buf, int size)
         return NULL;
 
     for (i = 0; i < sk_SSL_CIPHER_num(clntsk); i++) {
-        int n;
-
         c = sk_SSL_CIPHER_value(clntsk, i);
         if (sk_SSL_CIPHER_find(srvrsk, c) < 0)
             continue;
 
-        n = strlen(c->name);
+        int n = strlen(c->name);
         if (n + 1 > size) {
             if (p != buf)
                 --p;
             *p = '\0';
             return buf;
         }
-        strcpy(p, c->name);
+        strncpy(p, c->name,n);
         p += n;
         *(p++) = ':';
         size -= n + 1;


### PR DESCRIPTION
Fixes #19837

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
