### PR TITLE
doc: Fix incorrect pairing of functions

### DIFF
--- a/doc/man7/provider-signature.pod
+++ b/doc/man7/provider-signature.pod
@@ -155,7 +155,7 @@ set of "signature" functions, i.e. at least one of:
 
 =item OSSL_FUNC_signature_verify_init and OSSL_FUNC_signature_verify
 
-=item OSSL_FUNC_signature_verify_recover_init and OSSL_FUNC_signature_verify_init
+=item OSSL_FUNC_signature_verify_recover_init and OSSL_FUNC_signature_verify_recover
 
 =item OSSL_FUNC_signature_digest_sign_init, OSSL_FUNC_signature_digest_sign_update and OSSL_FUNC_signature_digest_sign_final
 


### PR DESCRIPTION
CLA: trivial

The functions that should be implemented together are `OSSL_FUNC_signature_verify_recover_init` and `OSSL_FUNC_signature_verify_recover` and not  `OSSL_FUNC_signature_verify_recover_init` with ` OSSL_FUNC_signature_verify_init`
