### PR TITLE
doc: Fix misleading stucture info

### DIFF
--- a/doc/man7/provider-signature.pod
+++ b/doc/man7/provider-signature.pod
@@ -420,7 +420,7 @@ respectively.
 =head1 RETURN VALUES
 
 OSSL_FUNC_signature_newctx() and OSSL_FUNC_signature_dupctx() should return the newly created
-provider side signature, or NULL on failure.
+provider side signature context, or NULL on failure.
 
 OSSL_FUNC_signature_gettable_ctx_params(), OSSL_FUNC_signature_settable_ctx_params(),
 OSSL_FUNC_signature_gettable_md_ctx_params() and OSSL_FUNC_signature_settable_md_ctx_params(),


### PR DESCRIPTION
CLA: trivial

The thing created by `OSSL_FUNC_signature_newctx()` and `OSSL_FUNC_signature_dupctx()` is a signature context, not a signature. It's in the name of the function and surrounding documentation.