### PR TITLE
Fix UEFI support on win32

### DIFF
--- a/crypto/cryptlib.c
+++ b/crypto/cryptlib.c
@@ -12,7 +12,7 @@
 #include "crypto/cryptlib.h"
 #include <openssl/safestack.h>
 
-#if defined(_WIN32)
+#if defined(_WIN32) && !defined(OPENSSL_SYS_UEFI)
 # include <tchar.h>
 # include <signal.h>
 # ifdef __WATCOMC__
@@ -256,7 +256,7 @@ void OPENSSL_die(const char *message, const char *file, int line)
 {
     OPENSSL_showfatal("%s:%d: OpenSSL internal error: %s\n",
                       file, line, message);
-#if !defined(_WIN32)
+#if !defined(_WIN32) || defined(OPENSSL_SYS_UEFI)
     abort();
 #else
     /*

--- a/crypto/sleep.c
+++ b/crypto/sleep.c
@@ -39,7 +39,7 @@ void OSSL_sleep(uint64_t millis)
     usleep(millis * 1000);
 # endif
 }
-#elif defined(_WIN32)
+#elif defined(_WIN32) && !defined(OPENSSL_SYS_UEFI)
 # include <windows.h>
 
 void OSSL_sleep(uint64_t millis)

--- a/crypto/time.c
+++ b/crypto/time.c
@@ -15,7 +15,7 @@ OSSL_TIME ossl_time_now(void)
 {
     OSSL_TIME r;
 
-#if defined(_WIN32)
+#if defined(_WIN32) && !defined(OPENSSL_SYS_UEFI)
     SYSTEMTIME st;
     union {
         unsigned __int64 ul;


### PR DESCRIPTION
These changes fix building OpenSSL v3.x on win32 hosts targeting UEFI.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->