### PR TITLE
check the inverted range bound for X509v3_addr_add_range

### DIFF
--- a/crypto/x509/v3_addr.c
+++ b/crypto/x509/v3_addr.c
@@ -629,6 +629,8 @@ int X509v3_addr_add_range(IPAddrBlocks *addr,
 
     if (aors == NULL)
         return 0;
+    if (memcmp(min, max, length) > 0)
+        return 0;
     if (!make_addressRange(&aor, min, max, length))
         return 0;
     if (sk_IPAddressOrRange_push(aors, aor))


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->
Fixes #18527 

<!-- Remove items that do not apply. For completed items, change [ ] to [x].
##### Checklist
- [ ] documentation is added or updated
- [ ] tests are added or updated  -->
