### PR TITLE
adding provider_unload functions for cmp_ tests

### DIFF
--- a/test/cmp_client_test.c
+++ b/test/cmp_client_test.c
@@ -449,6 +449,8 @@ void cleanup_tests(void)
     EVP_PKEY_free(server_key);
     X509_free(client_cert);
     EVP_PKEY_free(client_key);
+    OSSL_PROVIDER_unload(default_null_provider);
+    OSSL_PROVIDER_unload(provider);
     OSSL_LIB_CTX_free(libctx);
     return;
 }

--- a/test/cmp_msg_test.c
+++ b/test/cmp_msg_test.c
@@ -539,6 +539,8 @@ void cleanup_tests(void)
 {
     EVP_PKEY_free(newkey);
     X509_free(cert);
+    OSSL_PROVIDER_unload(default_null_provider);
+    OSSL_PROVIDER_unload(provider);
     OSSL_LIB_CTX_free(libctx);
 }
 

--- a/test/cmp_protect_test.c
+++ b/test/cmp_protect_test.c
@@ -527,6 +527,8 @@ void cleanup_tests(void)
     X509_free(intermediate);
     OSSL_CMP_MSG_free(ir_protected);
     OSSL_CMP_MSG_free(ir_unprotected);
+    OSSL_PROVIDER_unload(default_null_provider);
+    OSSL_PROVIDER_unload(provider);
     OSSL_LIB_CTX_free(libctx);
 }
 

--- a/test/cmp_vfy_test.c
+++ b/test/cmp_vfy_test.c
@@ -585,6 +585,8 @@ void cleanup_tests(void)
     X509_free(instaca_cert);
     OSSL_CMP_MSG_free(ir_unprotected);
     OSSL_CMP_MSG_free(ir_rmprotection);
+    OSSL_PROVIDER_unload(default_null_provider);
+    OSSL_PROVIDER_unload(provider);
     OSSL_LIB_CTX_free(libctx);
     return;
 }


### PR DESCRIPTION
CLA: trivial

Fixes #20716

Fix is to add provider unload functions to cleanup_tests(), more information is in issue description. Memory leaks in cmp_ tests were verified by running them directly in valgrind, e.g.

```
valgrind --leak-check=full --show-leak-kinds=all test/cmp_msg_test test/recipes/65-test_cmp_msg_data/new.key test/recipes/65-test_cmp_msg_data/server.crt test/recipes/65-test_cmp_msg_data/pkcs10.der default test/default.cnf
```

The issue description also mentions a memory leak in cmp_ctx_test. This was incorrect; this was an issue in 3.0.5 but is currently fixed in master.