### PR TITLE
Have Windows and VMS build files use shlib_variant

### DIFF
--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -47,13 +47,13 @@
       map { (my $x = $_) =~ s/\.a$//; $x }
       @{$unified_info{libraries}};
   our @shlibs =
-      map { $unified_info{sharednames}->{$_} || () }
+      map { $unified_info{sharednames}->{$_}.$shlibvariant || () }
       grep(!/\.a$/, @{$unified_info{libraries}});
   our @install_libs =
       map { (my $x = $_) =~ s/\.a$//; $x }
       @{$unified_info{install}->{libraries}};
   our @install_shlibs =
-      map { $unified_info{sharednames}->{$_} || () }
+      map { $unified_info{sharednames}->{$_}.$shlibvariant || () }
       grep(!/\.a$/, @{$unified_info{install}->{libraries}});
 
   # This is a horrible hack, but is needed because recursive inclusion of files
@@ -695,7 +695,7 @@ reconfigure reconf :
       }
       return map { $_ =~ /\.a$/
                    ? $`.".OLB"
-                   : $unified_info{sharednames}->{$_}.".EXE" } @_;
+                   : $unified_info{sharednames}->{$_}.$shlibvariant.".EXE" } @_;
   }
 
   # Helper function to deal with inclusion directory specs.
@@ -912,7 +912,7 @@ EOF
   sub libobj2shlib {
       my %args = @_;
       my $lib = $args{lib};
-      my $shlib = $args{shlib};
+      my $shlib = $args{shlib}.$shlibvariant;
       my $libd = dirname($lib);
       my $libn = basename($lib);
       my @objs = map { (my $x = $_) =~ s|\.o$|.OBJ|; $x }

--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -13,6 +13,8 @@
   our $sover_dirname = sprintf "%02d%02d", split(/\./, $config{shlib_version_number});
   our $osslver = sprintf "%02d%02d", split(/\./, $config{version});
 
+  our $shlibvariant = $target{shlib_variant} || "";
+
   our $sourcedir = $config{sourcedir};
   our $builddir = $config{builddir};
   sub sourcefile {

--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -9,6 +9,7 @@
  our $exeext = $target{exe_extension} || ".exe";
  our $libext = $target{lib_extension} || ".lib";
  our $shlibext = $target{shared_extension} || ".dll";
+ our $shlibvariant = $target{shlib_variant} || "";
  our $shlibextimport = $target{shared_import_extension} || ".lib";
  our $dsoext = $target{dso_extension} || ".dll";
 
@@ -35,7 +36,7 @@
      my $lib = shift;
      return () if $disabled{shared} || $lib =~ /\.a$/;
      return () unless defined $unified_info{sharednames}->{$lib};
-     return $unified_info{sharednames}->{$lib} . $shlibext;
+     return $unified_info{sharednames}->{$lib} . $shlibvariant . $shlibext;
  }
 
  sub lib {


### PR DESCRIPTION
This is an omission, it should have been in place a long time ago.

Fixes #20732
