### PR TITLE
`OSSL_CRMF_CERTTEMPLATE_get0_publicKey()`: fix return type and doc

### DIFF
--- a/crypto/crmf/crmf_lib.c
+++ b/crypto/crmf/crmf_lib.c
@@ -541,7 +541,7 @@ int OSSL_CRMF_MSGS_verify_popo(const OSSL_CRMF_MSGS *reqs,
     return 1;
 }
 
-const X509_PUBKEY
+X509_PUBKEY
 *OSSL_CRMF_CERTTEMPLATE_get0_publicKey(const OSSL_CRMF_CERTTEMPLATE *tmpl)
 {
     return tmpl != NULL ? tmpl->publicKey : NULL;

--- a/crypto/crmf/crmf_lib.c
+++ b/crypto/crmf/crmf_lib.c
@@ -547,7 +547,6 @@ X509_PUBKEY
     return tmpl != NULL ? tmpl->publicKey : NULL;
 }
 
-/* retrieves the serialNumber of the given cert template or NULL on error */
 const ASN1_INTEGER
 *OSSL_CRMF_CERTTEMPLATE_get0_serialNumber(const OSSL_CRMF_CERTTEMPLATE *tmpl)
 {
@@ -560,7 +559,6 @@ const X509_NAME
     return tmpl != NULL ? tmpl->subject : NULL;
 }
 
-/* retrieves the issuer name of the given cert template or NULL on error */
 const X509_NAME
 *OSSL_CRMF_CERTTEMPLATE_get0_issuer(const OSSL_CRMF_CERTTEMPLATE *tmpl)
 {
@@ -573,14 +571,12 @@ X509_EXTENSIONS
     return tmpl != NULL ? tmpl->extensions : NULL;
 }
 
-/* retrieves the issuer name of the given CertId or NULL on error */
 const X509_NAME *OSSL_CRMF_CERTID_get0_issuer(const OSSL_CRMF_CERTID *cid)
 {
     return cid != NULL && cid->issuer->type == GEN_DIRNAME ?
         cid->issuer->d.directoryName : NULL;
 }
 
-/* retrieves the serialNumber of the given CertId or NULL on error */
 const ASN1_INTEGER *OSSL_CRMF_CERTID_get0_serialNumber(const OSSL_CRMF_CERTID
                                                        *cid)
 {
@@ -588,8 +584,8 @@ const ASN1_INTEGER *OSSL_CRMF_CERTID_get0_serialNumber(const OSSL_CRMF_CERTID
 }
 
 /*-
- * fill in certificate template.
- * Any value argument that is NULL will leave the respective field unchanged.
+ * Fill in the certificate template |tmpl|.
+ * Any other NULL argument will leave the respective field unchanged.
  */
 int OSSL_CRMF_CERTTEMPLATE_fill(OSSL_CRMF_CERTTEMPLATE *tmpl,
                                 EVP_PKEY *pubkey,

--- a/doc/man3/OSSL_CRMF_MSG_get0_tmpl.pod
+++ b/doc/man3/OSSL_CRMF_MSG_get0_tmpl.pod
@@ -19,7 +19,7 @@ OSSL_CRMF_MSG_get_certReqId
  #include <openssl/crmf.h>
 
  OSSL_CRMF_CERTTEMPLATE *OSSL_CRMF_MSG_get0_tmpl(const OSSL_CRMF_MSG *crm);
- const X509_PUBKEY
+ X509_PUBKEY
  *OSSL_CRMF_CERTTEMPLATE_get0_publicKey(const OSSL_CRMF_CERTTEMPLATE *tmpl);
  const X509_NAME
  *OSSL_CRMF_CERTTEMPLATE_get0_subject(const OSSL_CRMF_CERTTEMPLATE *tmpl);
@@ -90,6 +90,8 @@ RFC 4211
 =head1 HISTORY
 
 The OpenSSL CRMF support was added in OpenSSL 3.0.
+
+OSSL_CRMF_CERTTEMPLATE_get0_publicKey() was added in OpenSSL 3.2.
 
 =head1 COPYRIGHT
 

--- a/include/openssl/crmf.h.in
+++ b/include/openssl/crmf.h.in
@@ -151,7 +151,7 @@ int OSSL_CRMF_MSGS_verify_popo(const OSSL_CRMF_MSGS *reqs,
                                int rid, int acceptRAVerified,
                                OSSL_LIB_CTX *libctx, const char *propq);
 OSSL_CRMF_CERTTEMPLATE *OSSL_CRMF_MSG_get0_tmpl(const OSSL_CRMF_MSG *crm);
-const X509_PUBKEY
+X509_PUBKEY
 *OSSL_CRMF_CERTTEMPLATE_get0_publicKey(const OSSL_CRMF_CERTTEMPLATE *tmpl);
 const X509_NAME
 *OSSL_CRMF_CERTTEMPLATE_get0_subject(const OSSL_CRMF_CERTTEMPLATE *tmpl);


### PR DESCRIPTION
This is a fixup of #18930.

Preparing CMP support for central key generation,
I found that the return type of `OSSL_CRMF_CERTTEMPLATE_get0_publicKey()`
was not flexible enough - it should not be `const`,
and it does not need to be according to the structure decl in `crmf_local.h`:
```
struct ossl_crmf_certtemplate_st {
    [...]
    const X509_NAME *issuer;
    OSSL_CRMF_OPTIONALVALIDITY *validity;
    const X509_NAME *subject;
    X509_PUBKEY *publicKey;
    [...]
} /* OSSL_CRMF_CERTTEMPLATE */;
```

Luckily, this can still be fixed without an API break because the new function has not been released yet.

On this occasion, also added the missing related HISTORY entry in `OSSL_CRMF_MSG_get0_tmpl.pod`.
