### PR TITLE
Adding Control Flow guard to Windows Builds

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1475,10 +1475,10 @@ my %targets = (
                                 "UNICODE", "_UNICODE",
                                 "_CRT_SECURE_NO_DEPRECATE",
                                 "_WINSOCK_DEPRECATED_NO_WARNINGS"),
-        lib_cflags       => add("/Zi /Fdossl_static.pdb"),
+        lib_cflags       => add("/guard:cf /Zi /Fdossl_static.pdb"),
         lib_defines      => add("L_ENDIAN"),
-        dso_cflags       => "/Zi /Fddso.pdb",
-        bin_cflags       => "/Zi /Fdapp.pdb",
+        dso_cflags       => "/guard:cf /Zi /Fddso.pdb",
+        bin_cflags       => "/guard:cf /Zi /Fdapp.pdb",
         # def_flag made to empty string so a .def file gets generated
         shared_defflag   => '',
         shared_ldflag    => "/dll",


### PR DESCRIPTION
Control flow guard is a code security implementation: https://learn.microsoft.com/en-us/windows/win32/secbp/control-flow-guard 

We identified it with BlackDuck security scan utility 
CLA: trivial
