### PR TITLE
Introduced a new macro `OSSL_DISPATCH_END` which refers to the end of `OSSL_DISPATCH` arrays.

### DIFF
--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -2160,6 +2160,6 @@ static const OSSL_DISPATCH core_dispatch_[] = {
     { OSSL_FUNC_CORE_OBJ_ADD_SIGID, (void (*)(void))core_obj_add_sigid },
     { OSSL_FUNC_CORE_OBJ_CREATE, (void (*)(void))core_obj_create },
 #endif
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };
 static const OSSL_DISPATCH *core_dispatch = core_dispatch_;

--- a/doc/man3/OSSL_DISPATCH.pod
+++ b/doc/man3/OSSL_DISPATCH.pod
@@ -2,7 +2,7 @@
 
 =head1 NAME
 
-OSSL_DISPATCH - OpenSSL Core type to define a dispatchable function table
+OSSL_DISPATCH, OSSL_DISPATCH_END - OpenSSL Core type to define a dispatchable function table
 
 =head1 SYNOPSIS
 
@@ -14,14 +14,15 @@ OSSL_DISPATCH - OpenSSL Core type to define a dispatchable function table
      void (*function)(void);
  };
 
+ #define OSSL_DISPATCH_END
+
 =head1 DESCRIPTION
 
 This type is a tuple of function identity and function pointer.
 Arrays of this type are passed between the OpenSSL libraries and the
 providers to describe what functionality one side provides to the other.
 
-Arrays of this type must be terminated with a tuple having function identity
-zero and function pointer NULL.
+Arrays of this type must be terminated with the OSSL_DISPATCH_END macro.
 
 =head2 B<OSSL_DISPATCH> fields
 

--- a/doc/man7/provider-base.pod
+++ b/doc/man7/provider-base.pod
@@ -751,7 +751,7 @@ operation C<BAR>.
 
  static const OSSL_ITEM reasons[] = {
      { E_MALLOC, "memory allocation failure" }.
-     { 0, NULL } /* Termination */
+     OSSL_DISPATCH_END
  };
 
  /*
@@ -831,7 +831,7 @@ operation C<BAR>.
      { OSSL_FUNC_BAR_INIT, (void (*)(void))foo_init },
      { OSSL_FUNC_BAR_UPDATE, (void (*)(void))foo_update },
      { OSSL_FUNC_BAR_FINAL, (void (*)(void))foo_final },
-     { 0, NULL }
+     OSSL_DISPATCH_END
  };
 
  static const OSSL_ALGORITHM bars[] = {
@@ -863,7 +863,7 @@ operation C<BAR>.
      { OSSL_FUNC_PROVIDER_TEARDOWN, (void (*)(void))p_teardown },
      { OSSL_FUNC_PROVIDER_QUERY_OPERATION, (void (*)(void))p_query },
      { OSSL_FUNC_PROVIDER_GET_REASON_STRINGS, (void (*)(void))p_reasons },
-     { 0, NULL }
+     OSSL_DISPATCH_END
  };
 
  int OSSL_provider_init(const OSSL_CORE_HANDLE *handle,

--- a/fuzz/fuzz_rand.c
+++ b/fuzz/fuzz_rand.c
@@ -114,7 +114,7 @@ static const OSSL_DISPATCH fuzz_rand_functions[] = {
     { OSSL_FUNC_RAND_GETTABLE_CTX_PARAMS,
       (void(*)(void))fuzz_rand_gettable_ctx_params },
     { OSSL_FUNC_RAND_GET_CTX_PARAMS, (void(*)(void))fuzz_rand_get_ctx_params },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };
 
 static const OSSL_ALGORITHM fuzz_rand_rand[] = {
@@ -138,7 +138,7 @@ static const OSSL_ALGORITHM *fuzz_rand_query(void *provctx,
 static const OSSL_DISPATCH fuzz_rand_method[] = {
     { OSSL_FUNC_PROVIDER_TEARDOWN, (void (*)(void))OSSL_LIB_CTX_free },
     { OSSL_FUNC_PROVIDER_QUERY_OPERATION, (void (*)(void))fuzz_rand_query },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };
 
 static int fuzz_rand_provider_init(const OSSL_CORE_HANDLE *handle,

--- a/include/openssl/core.h
+++ b/include/openssl/core.h
@@ -42,6 +42,9 @@ struct ossl_dispatch_st {
     void (*function)(void);
 };
 
+# define OSSL_DISPATCH_END \
+    { 0, NULL }
+
 /*
  * Other items, essentially an int<->pointer map element.
  *

--- a/providers/baseprov.c
+++ b/providers/baseprov.c
@@ -118,7 +118,7 @@ static const OSSL_DISPATCH base_dispatch_table[] = {
       (void (*)(void))base_gettable_params },
     { OSSL_FUNC_PROVIDER_GET_PARAMS, (void (*)(void))base_get_params },
     { OSSL_FUNC_PROVIDER_QUERY_OPERATION, (void (*)(void))base_query },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };
 
 OSSL_provider_init_fn ossl_base_provider_init;

--- a/providers/defltprov.c
+++ b/providers/defltprov.c
@@ -557,7 +557,7 @@ static const OSSL_DISPATCH deflt_dispatch_table[] = {
     { OSSL_FUNC_PROVIDER_QUERY_OPERATION, (void (*)(void))deflt_query },
     { OSSL_FUNC_PROVIDER_GET_CAPABILITIES,
       (void (*)(void))ossl_prov_get_capabilities },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };
 
 OSSL_provider_init_fn ossl_default_provider_init;

--- a/providers/fips/fipsprov.c
+++ b/providers/fips/fipsprov.c
@@ -545,14 +545,14 @@ static const OSSL_DISPATCH fips_dispatch_table[] = {
     { OSSL_FUNC_PROVIDER_GET_CAPABILITIES,
       (void (*)(void))ossl_prov_get_capabilities },
     { OSSL_FUNC_PROVIDER_SELF_TEST, (void (*)(void))fips_self_test },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };
 
 /* Functions we provide to ourself */
 static const OSSL_DISPATCH intern_dispatch_table[] = {
     { OSSL_FUNC_PROVIDER_TEARDOWN, (void (*)(void))fips_intern_teardown },
     { OSSL_FUNC_PROVIDER_QUERY_OPERATION, (void (*)(void))fips_query },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };
 
 /*

--- a/providers/implementations/asymciphers/rsa_enc.c
+++ b/providers/implementations/asymciphers/rsa_enc.c
@@ -602,5 +602,5 @@ const OSSL_DISPATCH ossl_rsa_asym_cipher_functions[] = {
       (void (*)(void))rsa_set_ctx_params },
     { OSSL_FUNC_ASYM_CIPHER_SETTABLE_CTX_PARAMS,
       (void (*)(void))rsa_settable_ctx_params },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };

--- a/providers/implementations/asymciphers/sm2_enc.c
+++ b/providers/implementations/asymciphers/sm2_enc.c
@@ -229,5 +229,5 @@ const OSSL_DISPATCH ossl_sm2_asym_cipher_functions[] = {
       (void (*)(void))sm2_set_ctx_params },
     { OSSL_FUNC_ASYM_CIPHER_SETTABLE_CTX_PARAMS,
       (void (*)(void))sm2_settable_ctx_params },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };

--- a/providers/implementations/ciphers/cipher_aes_cbc_hmac_sha.c
+++ b/providers/implementations/ciphers/cipher_aes_cbc_hmac_sha.c
@@ -26,7 +26,7 @@
 #ifndef AES_CBC_HMAC_SHA_CAPABLE
 # define IMPLEMENT_CIPHER(nm, sub, kbits, blkbits, ivbits, flags)              \
 const OSSL_DISPATCH ossl_##nm##kbits##sub##_functions[] = {                    \
-    { 0, NULL }                                                                \
+    OSSL_DISPATCH_END                                                              \
 };
 #else
 
@@ -403,7 +403,7 @@ const OSSL_DISPATCH ossl_##nm##kbits##sub##_functions[] = {                    \
         (void (*)(void))nm##_set_ctx_params },                                 \
     { OSSL_FUNC_CIPHER_SETTABLE_CTX_PARAMS,                                    \
         (void (*)(void))nm##_settable_ctx_params },                            \
-    { 0, NULL }                                                                \
+    OSSL_DISPATCH_END                                                          \
 };
 
 #endif /* AES_CBC_HMAC_SHA_CAPABLE */

--- a/providers/implementations/ciphers/cipher_aes_gcm_siv.c
+++ b/providers/implementations/ciphers/cipher_aes_gcm_siv.c
@@ -315,7 +315,7 @@ const OSSL_DISPATCH ossl_##alg##kbits##lc##_functions[] = {                     
     { OSSL_FUNC_CIPHER_GETTABLE_CTX_PARAMS, (void (*)(void))ossl_##alg##_##lc##_gettable_ctx_params },  \
     { OSSL_FUNC_CIPHER_SET_CTX_PARAMS,      (void (*)(void))ossl_##alg##_##lc##_set_ctx_params },       \
     { OSSL_FUNC_CIPHER_SETTABLE_CTX_PARAMS, (void (*)(void))ossl_##alg##_##lc##_settable_ctx_params },  \
-    { 0, NULL }                                                                                         \
+    OSSL_DISPATCH_END                                                                                   \
 }
 
 IMPLEMENT_cipher(aes, gcm_siv, GCM_SIV, AEAD_FLAGS, 128, 8, 96);

--- a/providers/implementations/ciphers/cipher_aes_ocb.c
+++ b/providers/implementations/ciphers/cipher_aes_ocb.c
@@ -549,7 +549,7 @@ const OSSL_DISPATCH ossl_##aes##kbits##mode##_functions[] = {                  \
         (void (*)(void))cipher_ocb_gettable_ctx_params },                      \
     { OSSL_FUNC_CIPHER_SETTABLE_CTX_PARAMS,                                    \
         (void (*)(void))cipher_ocb_settable_ctx_params },                      \
-    { 0, NULL }                                                                \
+    OSSL_DISPATCH_END                                                          \
 }
 
 IMPLEMENT_cipher(ocb, OCB, AES_OCB_FLAGS, 256, 128, OCB_DEFAULT_IV_LEN * 8);

--- a/providers/implementations/ciphers/cipher_aes_siv.c
+++ b/providers/implementations/ciphers/cipher_aes_siv.c
@@ -293,7 +293,7 @@ const OSSL_DISPATCH ossl_##alg##kbits##lc##_functions[] = {                    \
       (void (*)(void)) alg##_##lc##_set_ctx_params },                          \
     { OSSL_FUNC_CIPHER_SETTABLE_CTX_PARAMS,                                    \
       (void (*)(void)) alg##_##lc##_settable_ctx_params },                     \
-    { 0, NULL }                                                                \
+    OSSL_DISPATCH_END                                                          \
 };
 
 IMPLEMENT_cipher(aes, siv, SIV, SIV_FLAGS, 128, 8, 0)

--- a/providers/implementations/ciphers/cipher_aes_wrp.c
+++ b/providers/implementations/ciphers/cipher_aes_wrp.c
@@ -293,7 +293,7 @@ static int aes_wrap_set_ctx_params(void *vctx, const OSSL_PARAM params[])
             (void (*)(void))ossl_cipher_generic_gettable_ctx_params },         \
         { OSSL_FUNC_CIPHER_SETTABLE_CTX_PARAMS,                                \
             (void (*)(void))ossl_cipher_generic_settable_ctx_params },         \
-        { 0, NULL }                                                            \
+        OSSL_DISPATCH_END                                                      \
     }
 
 IMPLEMENT_cipher(wrap, wrap, WRAP, WRAP_FLAGS, 256, 64, AES_WRAP_NOPAD_IVLEN * 8);

--- a/providers/implementations/ciphers/cipher_aes_xts.c
+++ b/providers/implementations/ciphers/cipher_aes_xts.c
@@ -285,7 +285,7 @@ const OSSL_DISPATCH ossl_aes##kbits##xts_functions[] = {                       \
       (void (*)(void))aes_xts_set_ctx_params },                                \
     { OSSL_FUNC_CIPHER_SETTABLE_CTX_PARAMS,                                    \
      (void (*)(void))aes_xts_settable_ctx_params },                            \
-    { 0, NULL }                                                                \
+    OSSL_DISPATCH_END                                                          \
 }
 
 IMPLEMENT_cipher(xts, XTS, 256, AES_XTS_FLAGS);

--- a/providers/implementations/ciphers/cipher_chacha20.c
+++ b/providers/implementations/ciphers/cipher_chacha20.c
@@ -200,6 +200,6 @@ const OSSL_DISPATCH ossl_chacha20_functions[] = {
     { OSSL_FUNC_CIPHER_SET_CTX_PARAMS, (void (*)(void))chacha20_set_ctx_params },
     { OSSL_FUNC_CIPHER_SETTABLE_CTX_PARAMS,
         (void (*)(void))chacha20_settable_ctx_params },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };
 

--- a/providers/implementations/ciphers/cipher_chacha20_poly1305.c
+++ b/providers/implementations/ciphers/cipher_chacha20_poly1305.c
@@ -327,6 +327,6 @@ const OSSL_DISPATCH ossl_chacha20_ossl_poly1305_functions[] = {
         (void (*)(void))chacha20_poly1305_set_ctx_params },
     { OSSL_FUNC_CIPHER_SETTABLE_CTX_PARAMS,
         (void (*)(void))chacha20_poly1305_settable_ctx_params },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };
 

--- a/providers/implementations/ciphers/cipher_cts.h
+++ b/providers/implementations/ciphers/cipher_cts.h
@@ -42,7 +42,7 @@ const OSSL_DISPATCH ossl_##alg##kbits##lcmode##_cts_functions[] = {            \
       (void (*)(void)) alg##_cbc_cts_gettable_ctx_params },                    \
     { OSSL_FUNC_CIPHER_SETTABLE_CTX_PARAMS,                                    \
      (void (*)(void)) alg##_cbc_cts_settable_ctx_params },                     \
-    { 0, NULL }                                                                \
+    OSSL_DISPATCH_END                                                          \
 };
 
 OSSL_FUNC_cipher_update_fn ossl_cipher_cbc_cts_block_update;

--- a/providers/implementations/ciphers/cipher_des.c
+++ b/providers/implementations/ciphers/cipher_des.c
@@ -183,7 +183,7 @@ const OSSL_DISPATCH ossl_##des_##lcmode##_functions[] = {                      \
      (void (*)(void))ossl_cipher_generic_set_ctx_params },                     \
     { OSSL_FUNC_CIPHER_SETTABLE_CTX_PARAMS,                                    \
      (void (*)(void))ossl_cipher_generic_settable_ctx_params },                \
-    { 0, NULL }                                                                \
+    OSSL_DISPATCH_END                                                          \
 }
 
 /* ossl_des_ecb_functions */

--- a/providers/implementations/ciphers/cipher_null.c
+++ b/providers/implementations/ciphers/cipher_null.c
@@ -193,5 +193,5 @@ const OSSL_DISPATCH ossl_null_functions[] = {
     { OSSL_FUNC_CIPHER_SET_CTX_PARAMS, (void (*)(void))null_set_ctx_params },
     { OSSL_FUNC_CIPHER_SETTABLE_CTX_PARAMS,
       (void (*)(void))null_settable_ctx_params },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };

--- a/providers/implementations/ciphers/cipher_rc2.c
+++ b/providers/implementations/ciphers/cipher_rc2.c
@@ -263,7 +263,7 @@ const OSSL_DISPATCH ossl_##alg##kbits##lcmode##_functions[] = {                \
       (void (*)(void))rc2_set_ctx_params },                                    \
     { OSSL_FUNC_CIPHER_SETTABLE_CTX_PARAMS,                                    \
      (void (*)(void))rc2_settable_ctx_params },                                \
-    { 0, NULL }                                                                \
+    OSSL_DISPATCH_END                                                          \
 };
 
 /* ossl_rc2128ecb_functions */

--- a/providers/implementations/ciphers/cipher_rc4.c
+++ b/providers/implementations/ciphers/cipher_rc4.c
@@ -110,7 +110,7 @@ const OSSL_DISPATCH ossl_##alg##kbits##_functions[] = {                        \
       (void (*)(void))ossl_cipher_generic_gettable_ctx_params },               \
     { OSSL_FUNC_CIPHER_SETTABLE_CTX_PARAMS,                                    \
      (void (*)(void))ossl_cipher_var_keylen_settable_ctx_params },             \
-    { 0, NULL }                                                                \
+    OSSL_DISPATCH_END                                                          \
 };
 
 /* ossl_rc440_functions */

--- a/providers/implementations/ciphers/cipher_rc4_hmac_md5.c
+++ b/providers/implementations/ciphers/cipher_rc4_hmac_md5.c
@@ -230,5 +230,5 @@ const OSSL_DISPATCH ossl_rc4_hmac_ossl_md5_functions[] = {
         (void (*)(void))rc4_hmac_md5_set_ctx_params },
     { OSSL_FUNC_CIPHER_SETTABLE_CTX_PARAMS,
         (void (*)(void))rc4_hmac_md5_settable_ctx_params },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };

--- a/providers/implementations/ciphers/cipher_rc5.c
+++ b/providers/implementations/ciphers/cipher_rc5.c
@@ -173,7 +173,7 @@ const OSSL_DISPATCH ossl_##alg##kbits##lcmode##_functions[] = {                \
       (void (*)(void))rc5_set_ctx_params },                                    \
     { OSSL_FUNC_CIPHER_SETTABLE_CTX_PARAMS,                                    \
      (void (*)(void))rc5_settable_ctx_params },                                \
-    { 0, NULL }                                                                \
+    OSSL_DISPATCH_END                                                          \
 };
 
 /* ossl_rc5128ecb_functions */

--- a/providers/implementations/ciphers/cipher_sm4_xts.c
+++ b/providers/implementations/ciphers/cipher_sm4_xts.c
@@ -275,7 +275,7 @@ const OSSL_DISPATCH ossl_sm4##kbits##xts_functions[] = {                       \
       (void (*)(void))sm4_xts_set_ctx_params },                                \
     { OSSL_FUNC_CIPHER_SETTABLE_CTX_PARAMS,                                    \
      (void (*)(void))sm4_xts_settable_ctx_params },                            \
-    { 0, NULL }                                                                \
+    OSSL_DISPATCH_END                                                          \
 }
 /* ossl_sm4128xts_functions */
 IMPLEMENT_cipher(xts, XTS, 128, SM4_XTS_FLAGS);

--- a/providers/implementations/ciphers/cipher_tdes.h
+++ b/providers/implementations/ciphers/cipher_tdes.h
@@ -67,7 +67,7 @@ const OSSL_DISPATCH ossl_tdes_##type##_##lcmode##_functions[] = {              \
      (void (*)(void))ossl_cipher_generic_set_ctx_params },                     \
     { OSSL_FUNC_CIPHER_SETTABLE_CTX_PARAMS,                                    \
      (void (*)(void))ossl_cipher_generic_settable_ctx_params },                \
-    { 0, NULL }                                                                \
+    OSSL_DISPATCH_END                                                          \
 }
 
 void *ossl_tdes_newctx(void *provctx, int mode, size_t kbits, size_t blkbits,

--- a/providers/implementations/ciphers/cipher_tdes_wrap.c
+++ b/providers/implementations/ciphers/cipher_tdes_wrap.c
@@ -203,7 +203,7 @@ const OSSL_DISPATCH ossl_tdes_wrap_cbc_functions[] =                           \
       (void (*)(void))ossl_cipher_generic_set_ctx_params },                    \
     { OSSL_FUNC_CIPHER_SETTABLE_CTX_PARAMS,                                    \
       (void (*)(void))ossl_cipher_generic_settable_ctx_params },               \
-    { 0, NULL }                                                                \
+    OSSL_DISPATCH_END                                                          \
 }
 
 /* ossl_tdes_wrap_cbc_functions */

--- a/providers/implementations/encode_decode/decode_der2key.c
+++ b/providers/implementations/encode_decode/decode_der2key.c
@@ -749,7 +749,7 @@ static void rsa_adjust(void *key, struct der2key_ctx_st *ctx)
           (void (*)(void))der2key_decode },                             \
         { OSSL_FUNC_DECODER_EXPORT_OBJECT,                              \
           (void (*)(void))der2key_export_object },                      \
-        { 0, NULL }                                                     \
+        OSSL_DISPATCH_END                                               \
     }
 
 #ifndef OPENSSL_NO_DH

--- a/providers/implementations/encode_decode/decode_epki2pki.c
+++ b/providers/implementations/encode_decode/decode_epki2pki.c
@@ -154,5 +154,5 @@ const OSSL_DISPATCH ossl_EncryptedPrivateKeyInfo_der_to_der_decoder_functions[] 
     { OSSL_FUNC_DECODER_NEWCTX, (void (*)(void))epki2pki_newctx },
     { OSSL_FUNC_DECODER_FREECTX, (void (*)(void))epki2pki_freectx },
     { OSSL_FUNC_DECODER_DECODE, (void (*)(void))epki2pki_decode },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };

--- a/providers/implementations/encode_decode/decode_msblob2key.c
+++ b/providers/implementations/encode_decode/decode_msblob2key.c
@@ -262,7 +262,7 @@ static void rsa_adjust(void *key, struct msblob2key_ctx_st *ctx)
           (void (*)(void))msblob2key_decode },                          \
         { OSSL_FUNC_DECODER_EXPORT_OBJECT,                              \
           (void (*)(void))msblob2key_export_object },                   \
-        { 0, NULL }                                                     \
+        OSSL_DISPATCH_END                                               \
     }
 
 #ifndef OPENSSL_NO_DSA

--- a/providers/implementations/encode_decode/decode_pem2der.c
+++ b/providers/implementations/encode_decode/decode_pem2der.c
@@ -216,5 +216,5 @@ const OSSL_DISPATCH ossl_pem_to_der_decoder_functions[] = {
     { OSSL_FUNC_DECODER_NEWCTX, (void (*)(void))pem2der_newctx },
     { OSSL_FUNC_DECODER_FREECTX, (void (*)(void))pem2der_freectx },
     { OSSL_FUNC_DECODER_DECODE, (void (*)(void))pem2der_decode },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };

--- a/providers/implementations/encode_decode/decode_pvk2key.c
+++ b/providers/implementations/encode_decode/decode_pvk2key.c
@@ -230,7 +230,7 @@ static void rsa_adjust(void *key, struct pvk2key_ctx_st *ctx)
           (void (*)(void))pvk2key_decode },                             \
         { OSSL_FUNC_DECODER_EXPORT_OBJECT,                              \
           (void (*)(void))pvk2key_export_object },                      \
-        { 0, NULL }                                                     \
+        OSSL_DISPATCH_END                                               \
     }
 
 #ifndef OPENSSL_NO_DSA

--- a/providers/implementations/encode_decode/decode_spki2typespki.c
+++ b/providers/implementations/encode_decode/decode_spki2typespki.c
@@ -120,5 +120,5 @@ const OSSL_DISPATCH ossl_SubjectPublicKeyInfo_der_to_der_decoder_functions[] = {
     { OSSL_FUNC_DECODER_NEWCTX, (void (*)(void))spki2typespki_newctx },
     { OSSL_FUNC_DECODER_FREECTX, (void (*)(void))spki2typespki_freectx },
     { OSSL_FUNC_DECODER_DECODE, (void (*)(void))spki2typespki_decode },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };

--- a/providers/implementations/encode_decode/encode_key2any.c
+++ b/providers/implementations/encode_decode/encode_key2any.c
@@ -1293,7 +1293,7 @@ static int key2any_encode(struct key2any_ctx_st *ctx, OSSL_CORE_BIO *cout,
           (void (*)(void))impl##_to_##kind##_##output##_free_object },      \
         { OSSL_FUNC_ENCODER_ENCODE,                                         \
           (void (*)(void))impl##_to_##kind##_##output##_encode },           \
-        { 0, NULL }                                                         \
+        OSSL_DISPATCH_END                                                   \
     }
 
 /*

--- a/providers/implementations/encode_decode/encode_key2blob.c
+++ b/providers/implementations/encode_decode/encode_key2blob.c
@@ -168,7 +168,7 @@ static int key2blob_encode(void *vctx, const void *key, int selection,
           (void (*)(void))impl##2blob_free_object },                    \
         { OSSL_FUNC_ENCODER_ENCODE,                                     \
           (void (*)(void))impl##2blob_encode },                         \
-        { 0, NULL }                                                     \
+        OSSL_DISPATCH_END                                               \
     }
 
 #ifndef OPENSSL_NO_EC

--- a/providers/implementations/encode_decode/encode_key2ms.c
+++ b/providers/implementations/encode_decode/encode_key2ms.c
@@ -222,7 +222,7 @@ static int key2pvk_encode(void *vctx, const void *key, int selection,
           (void (*)(void))impl##2##output##_free_object },                    \
         { OSSL_FUNC_ENCODER_ENCODE,                                           \
           (void (*)(void))impl##2##output##_encode },                         \
-        { 0, NULL }                                                           \
+        OSSL_DISPATCH_END                                                     \
     }
 
 #ifndef OPENSSL_NO_DSA

--- a/providers/implementations/encode_decode/encode_key2text.c
+++ b/providers/implementations/encode_decode/encode_key2text.c
@@ -867,7 +867,7 @@ static int key2text_encode(void *vctx, const void *key, int selection,
           (void (*)(void))impl##2text_free_object },                    \
         { OSSL_FUNC_ENCODER_ENCODE,                                     \
           (void (*)(void))impl##2text_encode },                         \
-        { 0, NULL }                                                     \
+        OSSL_DISPATCH_END                                               \
     }
 
 #ifndef OPENSSL_NO_DH

--- a/providers/implementations/exchange/dh_exch.c
+++ b/providers/implementations/exchange/dh_exch.c
@@ -507,5 +507,5 @@ const OSSL_DISPATCH ossl_dh_keyexch_functions[] = {
     { OSSL_FUNC_KEYEXCH_GET_CTX_PARAMS, (void (*)(void))dh_get_ctx_params },
     { OSSL_FUNC_KEYEXCH_GETTABLE_CTX_PARAMS,
       (void (*)(void))dh_gettable_ctx_params },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };

--- a/providers/implementations/exchange/ecdh_exch.c
+++ b/providers/implementations/exchange/ecdh_exch.c
@@ -575,5 +575,5 @@ const OSSL_DISPATCH ossl_ecdh_keyexch_functions[] = {
     { OSSL_FUNC_KEYEXCH_GET_CTX_PARAMS, (void (*)(void))ecdh_get_ctx_params },
     { OSSL_FUNC_KEYEXCH_GETTABLE_CTX_PARAMS,
       (void (*)(void))ecdh_gettable_ctx_params },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };

--- a/providers/implementations/exchange/ecx_exch.c
+++ b/providers/implementations/exchange/ecx_exch.c
@@ -165,7 +165,7 @@ const OSSL_DISPATCH ossl_x25519_keyexch_functions[] = {
     { OSSL_FUNC_KEYEXCH_SET_PEER, (void (*)(void))ecx_set_peer },
     { OSSL_FUNC_KEYEXCH_FREECTX, (void (*)(void))ecx_freectx },
     { OSSL_FUNC_KEYEXCH_DUPCTX, (void (*)(void))ecx_dupctx },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };
 
 const OSSL_DISPATCH ossl_x448_keyexch_functions[] = {
@@ -175,5 +175,5 @@ const OSSL_DISPATCH ossl_x448_keyexch_functions[] = {
     { OSSL_FUNC_KEYEXCH_SET_PEER, (void (*)(void))ecx_set_peer },
     { OSSL_FUNC_KEYEXCH_FREECTX, (void (*)(void))ecx_freectx },
     { OSSL_FUNC_KEYEXCH_DUPCTX, (void (*)(void))ecx_dupctx },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };

--- a/providers/implementations/exchange/kdf_exch.c
+++ b/providers/implementations/exchange/kdf_exch.c
@@ -207,7 +207,7 @@ KDF_SETTABLE_CTX_PARAMS(scrypt, "SCRYPT")
         { OSSL_FUNC_KEYEXCH_SET_CTX_PARAMS, (void (*)(void))kdf_set_ctx_params }, \
         { OSSL_FUNC_KEYEXCH_SETTABLE_CTX_PARAMS, \
         (void (*)(void))kdf_##funcname##_settable_ctx_params }, \
-        { 0, NULL } \
+        OSSL_DISPATCH_END \
     };
 
 KDF_KEYEXCH_FUNCTIONS(tls1_prf)

--- a/providers/implementations/include/prov/ciphercommon.h
+++ b/providers/implementations/include/prov/ciphercommon.h
@@ -154,7 +154,7 @@ const OSSL_DISPATCH ossl_##alg##kbits##lcmode##_functions[] = {                \
       (void (*)(void))ossl_cipher_generic_gettable_ctx_params },               \
     { OSSL_FUNC_CIPHER_SETTABLE_CTX_PARAMS,                                    \
      (void (*)(void))ossl_cipher_generic_settable_ctx_params },                \
-    { 0, NULL }                                                                \
+    OSSL_DISPATCH_END                                                          \
 };
 
 # define IMPLEMENT_var_keylen_cipher_func(alg, UCALG, lcmode, UCMODE, flags,    \
@@ -181,7 +181,7 @@ const OSSL_DISPATCH ossl_##alg##kbits##lcmode##_functions[] = {                \
       (void (*)(void))ossl_cipher_generic_gettable_ctx_params },               \
     { OSSL_FUNC_CIPHER_SETTABLE_CTX_PARAMS,                                    \
      (void (*)(void))ossl_cipher_var_keylen_settable_ctx_params },             \
-    { 0, NULL }                                                                \
+    OSSL_DISPATCH_END                                                          \
 };
 
 

--- a/providers/implementations/include/prov/ciphercommon_aead.h
+++ b/providers/implementations/include/prov/ciphercommon_aead.h
@@ -47,7 +47,7 @@ const OSSL_DISPATCH ossl_##alg##kbits##lc##_functions[] = {                    \
       (void (*)(void))ossl_cipher_aead_gettable_ctx_params },                  \
     { OSSL_FUNC_CIPHER_SETTABLE_CTX_PARAMS,                                    \
       (void (*)(void))ossl_cipher_aead_settable_ctx_params },                  \
-    { 0, NULL }                                                                \
+    OSSL_DISPATCH_END                                                          \
 }
 
 #endif

--- a/providers/implementations/kdfs/argon2.c
+++ b/providers/implementations/kdfs/argon2.c
@@ -1549,7 +1549,7 @@ const OSSL_DISPATCH ossl_kdf_argon2i_functions[] = {
     { OSSL_FUNC_KDF_GETTABLE_CTX_PARAMS,
       (void(*)(void))kdf_argon2_gettable_ctx_params },
     { OSSL_FUNC_KDF_GET_CTX_PARAMS, (void(*)(void))kdf_argon2_get_ctx_params },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };
 
 const OSSL_DISPATCH ossl_kdf_argon2d_functions[] = {
@@ -1563,7 +1563,7 @@ const OSSL_DISPATCH ossl_kdf_argon2d_functions[] = {
     { OSSL_FUNC_KDF_GETTABLE_CTX_PARAMS,
       (void(*)(void))kdf_argon2_gettable_ctx_params },
     { OSSL_FUNC_KDF_GET_CTX_PARAMS, (void(*)(void))kdf_argon2_get_ctx_params },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };
 
 const OSSL_DISPATCH ossl_kdf_argon2id_functions[] = {
@@ -1577,7 +1577,7 @@ const OSSL_DISPATCH ossl_kdf_argon2id_functions[] = {
     { OSSL_FUNC_KDF_GETTABLE_CTX_PARAMS,
       (void(*)(void))kdf_argon2_gettable_ctx_params },
     { OSSL_FUNC_KDF_GET_CTX_PARAMS, (void(*)(void))kdf_argon2_get_ctx_params },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };
 
 #endif

--- a/providers/implementations/kdfs/hkdf.c
+++ b/providers/implementations/kdfs/hkdf.c
@@ -394,7 +394,7 @@ const OSSL_DISPATCH ossl_kdf_hkdf_functions[] = {
     { OSSL_FUNC_KDF_GETTABLE_CTX_PARAMS,
       (void(*)(void))kdf_hkdf_gettable_ctx_params },
     { OSSL_FUNC_KDF_GET_CTX_PARAMS, (void(*)(void))kdf_hkdf_get_ctx_params },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };
 
 /*
@@ -810,5 +810,5 @@ const OSSL_DISPATCH ossl_kdf_tls1_3_kdf_functions[] = {
     { OSSL_FUNC_KDF_GETTABLE_CTX_PARAMS,
       (void(*)(void))kdf_hkdf_gettable_ctx_params },
     { OSSL_FUNC_KDF_GET_CTX_PARAMS, (void(*)(void))kdf_hkdf_get_ctx_params },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };

--- a/providers/implementations/kdfs/hmacdrbg_kdf.c
+++ b/providers/implementations/kdfs/hmacdrbg_kdf.c
@@ -255,5 +255,5 @@ const OSSL_DISPATCH ossl_kdf_hmac_drbg_functions[] = {
       (void(*)(void))hmac_drbg_kdf_gettable_ctx_params },
     { OSSL_FUNC_KDF_GET_CTX_PARAMS,
       (void(*)(void))hmac_drbg_kdf_get_ctx_params },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };

--- a/providers/implementations/kdfs/kbkdf.c
+++ b/providers/implementations/kdfs/kbkdf.c
@@ -488,5 +488,5 @@ const OSSL_DISPATCH ossl_kdf_kbkdf_functions[] = {
     { OSSL_FUNC_KDF_GETTABLE_CTX_PARAMS,
       (void(*)(void))kbkdf_gettable_ctx_params },
     { OSSL_FUNC_KDF_GET_CTX_PARAMS, (void(*)(void))kbkdf_get_ctx_params },
-    { 0, NULL },
+    OSSL_DISPATCH_END,
 };

--- a/providers/implementations/kdfs/krb5kdf.c
+++ b/providers/implementations/kdfs/krb5kdf.c
@@ -230,7 +230,7 @@ const OSSL_DISPATCH ossl_kdf_krb5kdf_functions[] = {
       (void(*)(void))krb5kdf_gettable_ctx_params },
     { OSSL_FUNC_KDF_GET_CTX_PARAMS,
       (void(*)(void))krb5kdf_get_ctx_params },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };
 
 #ifndef OPENSSL_NO_DES

--- a/providers/implementations/kdfs/pbkdf1.c
+++ b/providers/implementations/kdfs/pbkdf1.c
@@ -260,5 +260,5 @@ const OSSL_DISPATCH ossl_kdf_pbkdf1_functions[] = {
     { OSSL_FUNC_KDF_GETTABLE_CTX_PARAMS,
       (void(*)(void))kdf_pbkdf1_gettable_ctx_params },
     { OSSL_FUNC_KDF_GET_CTX_PARAMS, (void(*)(void))kdf_pbkdf1_get_ctx_params },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };

--- a/providers/implementations/kdfs/pbkdf2.c
+++ b/providers/implementations/kdfs/pbkdf2.c
@@ -288,7 +288,7 @@ const OSSL_DISPATCH ossl_kdf_pbkdf2_functions[] = {
     { OSSL_FUNC_KDF_GETTABLE_CTX_PARAMS,
       (void(*)(void))kdf_pbkdf2_gettable_ctx_params },
     { OSSL_FUNC_KDF_GET_CTX_PARAMS, (void(*)(void))kdf_pbkdf2_get_ctx_params },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };
 
 /*

--- a/providers/implementations/kdfs/pkcs12kdf.c
+++ b/providers/implementations/kdfs/pkcs12kdf.c
@@ -315,5 +315,5 @@ const OSSL_DISPATCH ossl_kdf_pkcs12_functions[] = {
     { OSSL_FUNC_KDF_GETTABLE_CTX_PARAMS,
       (void(*)(void))kdf_pkcs12_gettable_ctx_params },
     { OSSL_FUNC_KDF_GET_CTX_PARAMS, (void(*)(void))kdf_pkcs12_get_ctx_params },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };

--- a/providers/implementations/kdfs/pvkkdf.c
+++ b/providers/implementations/kdfs/pvkkdf.c
@@ -244,5 +244,5 @@ const OSSL_DISPATCH ossl_kdf_pvk_functions[] = {
     { OSSL_FUNC_KDF_GETTABLE_CTX_PARAMS,
       (void(*)(void))kdf_pvk_gettable_ctx_params },
     { OSSL_FUNC_KDF_GET_CTX_PARAMS, (void(*)(void))kdf_pvk_get_ctx_params },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };

--- a/providers/implementations/kdfs/scrypt.c
+++ b/providers/implementations/kdfs/scrypt.c
@@ -317,7 +317,7 @@ const OSSL_DISPATCH ossl_kdf_scrypt_functions[] = {
     { OSSL_FUNC_KDF_GETTABLE_CTX_PARAMS,
       (void(*)(void))kdf_scrypt_gettable_ctx_params },
     { OSSL_FUNC_KDF_GET_CTX_PARAMS, (void(*)(void))kdf_scrypt_get_ctx_params },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };
 
 #define R(a,b) (((a) << (b)) | ((a) >> (32 - (b))))

--- a/providers/implementations/kdfs/sshkdf.c
+++ b/providers/implementations/kdfs/sshkdf.c
@@ -245,7 +245,7 @@ const OSSL_DISPATCH ossl_kdf_sshkdf_functions[] = {
     { OSSL_FUNC_KDF_GETTABLE_CTX_PARAMS,
       (void(*)(void))kdf_sshkdf_gettable_ctx_params },
     { OSSL_FUNC_KDF_GET_CTX_PARAMS, (void(*)(void))kdf_sshkdf_get_ctx_params },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };
 
 static int SSHKDF(const EVP_MD *evp_md,

--- a/providers/implementations/kdfs/sskdf.c
+++ b/providers/implementations/kdfs/sskdf.c
@@ -570,7 +570,7 @@ const OSSL_DISPATCH ossl_kdf_sskdf_functions[] = {
     { OSSL_FUNC_KDF_GETTABLE_CTX_PARAMS,
       (void(*)(void))sskdf_gettable_ctx_params },
     { OSSL_FUNC_KDF_GET_CTX_PARAMS, (void(*)(void))sskdf_get_ctx_params },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };
 
 const OSSL_DISPATCH ossl_kdf_x963_kdf_functions[] = {
@@ -585,5 +585,5 @@ const OSSL_DISPATCH ossl_kdf_x963_kdf_functions[] = {
     { OSSL_FUNC_KDF_GETTABLE_CTX_PARAMS,
       (void(*)(void))sskdf_gettable_ctx_params },
     { OSSL_FUNC_KDF_GET_CTX_PARAMS, (void(*)(void))sskdf_get_ctx_params },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };

--- a/providers/implementations/kdfs/tls1_prf.c
+++ b/providers/implementations/kdfs/tls1_prf.c
@@ -311,7 +311,7 @@ const OSSL_DISPATCH ossl_kdf_tls1_prf_functions[] = {
       (void(*)(void))kdf_tls1_prf_gettable_ctx_params },
     { OSSL_FUNC_KDF_GET_CTX_PARAMS,
       (void(*)(void))kdf_tls1_prf_get_ctx_params },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };
 
 /*

--- a/providers/implementations/kdfs/x942kdf.c
+++ b/providers/implementations/kdfs/x942kdf.c
@@ -626,5 +626,5 @@ const OSSL_DISPATCH ossl_kdf_x942_kdf_functions[] = {
     { OSSL_FUNC_KDF_GETTABLE_CTX_PARAMS,
       (void(*)(void))x942kdf_gettable_ctx_params },
     { OSSL_FUNC_KDF_GET_CTX_PARAMS, (void(*)(void))x942kdf_get_ctx_params },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };

--- a/providers/implementations/kem/ec_kem.c
+++ b/providers/implementations/kem/ec_kem.c
@@ -810,5 +810,5 @@ const OSSL_DISPATCH ossl_ec_asym_kem_functions[] = {
       (void (*)(void))eckem_auth_encapsulate_init },
     { OSSL_FUNC_KEM_AUTH_DECAPSULATE_INIT,
       (void (*)(void))eckem_auth_decapsulate_init },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };

--- a/providers/implementations/kem/ecx_kem.c
+++ b/providers/implementations/kem/ecx_kem.c
@@ -700,5 +700,5 @@ const OSSL_DISPATCH ossl_ecx_asym_kem_functions[] = {
       (void (*)(void))ecxkem_auth_encapsulate_init },
     { OSSL_FUNC_KEM_AUTH_DECAPSULATE_INIT,
       (void (*)(void))ecxkem_auth_decapsulate_init },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };

--- a/providers/implementations/kem/rsa_kem.c
+++ b/providers/implementations/kem/rsa_kem.c
@@ -361,5 +361,5 @@ const OSSL_DISPATCH ossl_rsa_asym_kem_functions[] = {
       (void (*)(void))rsakem_set_ctx_params },
     { OSSL_FUNC_KEM_SETTABLE_CTX_PARAMS,
       (void (*)(void))rsakem_settable_ctx_params },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };

--- a/providers/implementations/keymgmt/dh_kmgmt.c
+++ b/providers/implementations/keymgmt/dh_kmgmt.c
@@ -841,7 +841,7 @@ const OSSL_DISPATCH ossl_dh_keymgmt_functions[] = {
     { OSSL_FUNC_KEYMGMT_EXPORT, (void (*)(void))dh_export },
     { OSSL_FUNC_KEYMGMT_EXPORT_TYPES, (void (*)(void))dh_export_types },
     { OSSL_FUNC_KEYMGMT_DUP, (void (*)(void))dh_dup },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };
 
 /* For any DH key, we use the "DH" algorithms regardless of sub-type. */
@@ -875,5 +875,5 @@ const OSSL_DISPATCH ossl_dhx_keymgmt_functions[] = {
     { OSSL_FUNC_KEYMGMT_QUERY_OPERATION_NAME,
       (void (*)(void))dhx_query_operation_name },
     { OSSL_FUNC_KEYMGMT_DUP, (void (*)(void))dh_dup },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };

--- a/providers/implementations/keymgmt/dsa_kmgmt.c
+++ b/providers/implementations/keymgmt/dsa_kmgmt.c
@@ -672,5 +672,5 @@ const OSSL_DISPATCH ossl_dsa_keymgmt_functions[] = {
     { OSSL_FUNC_KEYMGMT_EXPORT, (void (*)(void))dsa_export },
     { OSSL_FUNC_KEYMGMT_EXPORT_TYPES, (void (*)(void))dsa_export_types },
     { OSSL_FUNC_KEYMGMT_DUP, (void (*)(void))dsa_dup },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };

--- a/providers/implementations/keymgmt/ec_kmgmt.c
+++ b/providers/implementations/keymgmt/ec_kmgmt.c
@@ -1444,7 +1444,7 @@ const OSSL_DISPATCH ossl_ec_keymgmt_functions[] = {
     { OSSL_FUNC_KEYMGMT_QUERY_OPERATION_NAME,
       (void (*)(void))ec_query_operation_name },
     { OSSL_FUNC_KEYMGMT_DUP, (void (*)(void))ec_dup },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };
 
 #ifndef FIPS_MODULE
@@ -1475,7 +1475,7 @@ const OSSL_DISPATCH ossl_sm2_keymgmt_functions[] = {
     { OSSL_FUNC_KEYMGMT_QUERY_OPERATION_NAME,
       (void (*)(void))sm2_query_operation_name },
     { OSSL_FUNC_KEYMGMT_DUP, (void (*)(void))ec_dup },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };
 # endif
 #endif

--- a/providers/implementations/keymgmt/ecx_kmgmt.c
+++ b/providers/implementations/keymgmt/ecx_kmgmt.c
@@ -840,7 +840,7 @@ static int ed448_validate(const void *keydata, int selection, int checktype)
         { OSSL_FUNC_KEYMGMT_GEN_CLEANUP, (void (*)(void))ecx_gen_cleanup }, \
         { OSSL_FUNC_KEYMGMT_LOAD, (void (*)(void))ecx_load }, \
         { OSSL_FUNC_KEYMGMT_DUP, (void (*)(void))ecx_dup }, \
-        { 0, NULL } \
+        OSSL_DISPATCH_END \
     };
 
 MAKE_KEYMGMT_FUNCTIONS(x25519)

--- a/providers/implementations/keymgmt/kdf_legacy_kmgmt.c
+++ b/providers/implementations/keymgmt/kdf_legacy_kmgmt.c
@@ -100,5 +100,5 @@ const OSSL_DISPATCH ossl_kdf_keymgmt_functions[] = {
     { OSSL_FUNC_KEYMGMT_NEW, (void (*)(void))kdf_newdata },
     { OSSL_FUNC_KEYMGMT_FREE, (void (*)(void))kdf_freedata },
     { OSSL_FUNC_KEYMGMT_HAS, (void (*)(void))kdf_has },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };

--- a/providers/implementations/keymgmt/mac_legacy_kmgmt.c
+++ b/providers/implementations/keymgmt/mac_legacy_kmgmt.c
@@ -542,7 +542,7 @@ const OSSL_DISPATCH ossl_mac_legacy_keymgmt_functions[] = {
         (void (*)(void))mac_gen_settable_params },
     { OSSL_FUNC_KEYMGMT_GEN, (void (*)(void))mac_gen },
     { OSSL_FUNC_KEYMGMT_GEN_CLEANUP, (void (*)(void))mac_gen_cleanup },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };
 
 const OSSL_DISPATCH ossl_cmac_legacy_keymgmt_functions[] = {
@@ -564,6 +564,6 @@ const OSSL_DISPATCH ossl_cmac_legacy_keymgmt_functions[] = {
         (void (*)(void))cmac_gen_settable_params },
     { OSSL_FUNC_KEYMGMT_GEN, (void (*)(void))mac_gen },
     { OSSL_FUNC_KEYMGMT_GEN_CLEANUP, (void (*)(void))mac_gen_cleanup },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };
 

--- a/providers/implementations/keymgmt/rsa_kmgmt.c
+++ b/providers/implementations/keymgmt/rsa_kmgmt.c
@@ -715,7 +715,7 @@ const OSSL_DISPATCH ossl_rsa_keymgmt_functions[] = {
     { OSSL_FUNC_KEYMGMT_EXPORT, (void (*)(void))rsa_export },
     { OSSL_FUNC_KEYMGMT_EXPORT_TYPES, (void (*)(void))rsa_export_types },
     { OSSL_FUNC_KEYMGMT_DUP, (void (*)(void))rsa_dup },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };
 
 const OSSL_DISPATCH ossl_rsapss_keymgmt_functions[] = {
@@ -740,5 +740,5 @@ const OSSL_DISPATCH ossl_rsapss_keymgmt_functions[] = {
     { OSSL_FUNC_KEYMGMT_QUERY_OPERATION_NAME,
       (void (*)(void))rsa_query_operation_name },
     { OSSL_FUNC_KEYMGMT_DUP, (void (*)(void))rsa_dup },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };

--- a/providers/implementations/macs/blake2_mac_impl.c
+++ b/providers/implementations/macs/blake2_mac_impl.c
@@ -250,5 +250,5 @@ const OSSL_DISPATCH BLAKE2_FUNCTIONS[] = {
     { OSSL_FUNC_MAC_SETTABLE_CTX_PARAMS,
       (void (*)(void))blake2_mac_settable_ctx_params },
     { OSSL_FUNC_MAC_SET_CTX_PARAMS, (void (*)(void))blake2_mac_set_ctx_params },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };

--- a/providers/implementations/macs/cmac_prov.c
+++ b/providers/implementations/macs/cmac_prov.c
@@ -229,5 +229,5 @@ const OSSL_DISPATCH ossl_cmac_functions[] = {
     { OSSL_FUNC_MAC_SETTABLE_CTX_PARAMS,
       (void (*)(void))cmac_settable_ctx_params },
     { OSSL_FUNC_MAC_SET_CTX_PARAMS, (void (*)(void))cmac_set_ctx_params },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };

--- a/providers/implementations/macs/gmac_prov.c
+++ b/providers/implementations/macs/gmac_prov.c
@@ -255,5 +255,5 @@ const OSSL_DISPATCH ossl_gmac_functions[] = {
     { OSSL_FUNC_MAC_SETTABLE_CTX_PARAMS,
       (void (*)(void))gmac_settable_ctx_params },
     { OSSL_FUNC_MAC_SET_CTX_PARAMS, (void (*)(void))gmac_set_ctx_params },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };

--- a/providers/implementations/macs/hmac_prov.c
+++ b/providers/implementations/macs/hmac_prov.c
@@ -344,5 +344,5 @@ const OSSL_DISPATCH ossl_hmac_functions[] = {
     { OSSL_FUNC_MAC_SETTABLE_CTX_PARAMS,
       (void (*)(void))hmac_settable_ctx_params },
     { OSSL_FUNC_MAC_SET_CTX_PARAMS, (void (*)(void))hmac_set_ctx_params },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };

--- a/providers/implementations/macs/kmac_prov.c
+++ b/providers/implementations/macs/kmac_prov.c
@@ -605,7 +605,7 @@ const OSSL_DISPATCH ossl_kmac128_functions[] = {
     { OSSL_FUNC_MAC_SETTABLE_CTX_PARAMS,
       (void (*)(void))kmac_settable_ctx_params },
     { OSSL_FUNC_MAC_SET_CTX_PARAMS, (void (*)(void))kmac_set_ctx_params },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };
 
 const OSSL_DISPATCH ossl_kmac256_functions[] = {
@@ -621,5 +621,5 @@ const OSSL_DISPATCH ossl_kmac256_functions[] = {
     { OSSL_FUNC_MAC_SETTABLE_CTX_PARAMS,
       (void (*)(void))kmac_settable_ctx_params },
     { OSSL_FUNC_MAC_SET_CTX_PARAMS, (void (*)(void))kmac_set_ctx_params },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };

--- a/providers/implementations/macs/poly1305_prov.c
+++ b/providers/implementations/macs/poly1305_prov.c
@@ -183,5 +183,5 @@ const OSSL_DISPATCH ossl_poly1305_functions[] = {
     { OSSL_FUNC_MAC_SETTABLE_CTX_PARAMS,
       (void (*)(void))poly1305_settable_ctx_params },
     { OSSL_FUNC_MAC_SET_CTX_PARAMS, (void (*)(void))poly1305_set_ctx_params },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };

--- a/providers/implementations/macs/siphash_prov.c
+++ b/providers/implementations/macs/siphash_prov.c
@@ -233,5 +233,5 @@ const OSSL_DISPATCH ossl_siphash_functions[] = {
     { OSSL_FUNC_MAC_SETTABLE_CTX_PARAMS,
       (void (*)(void))siphash_settable_ctx_params },
     { OSSL_FUNC_MAC_SET_CTX_PARAMS, (void (*)(void))siphash_set_params },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };

--- a/providers/implementations/rands/drbg_ctr.c
+++ b/providers/implementations/rands/drbg_ctr.c
@@ -747,5 +747,5 @@ const OSSL_DISPATCH ossl_drbg_ctr_functions[] = {
       (void(*)(void))drbg_ctr_verify_zeroization },
     { OSSL_FUNC_RAND_GET_SEED, (void(*)(void))ossl_drbg_get_seed },
     { OSSL_FUNC_RAND_CLEAR_SEED, (void(*)(void))ossl_drbg_clear_seed },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };

--- a/providers/implementations/rands/drbg_hash.c
+++ b/providers/implementations/rands/drbg_hash.c
@@ -521,5 +521,5 @@ const OSSL_DISPATCH ossl_drbg_hash_functions[] = {
       (void(*)(void))drbg_hash_verify_zeroization },
     { OSSL_FUNC_RAND_GET_SEED, (void(*)(void))ossl_drbg_get_seed },
     { OSSL_FUNC_RAND_CLEAR_SEED, (void(*)(void))ossl_drbg_clear_seed },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };

--- a/providers/implementations/rands/drbg_hmac.c
+++ b/providers/implementations/rands/drbg_hmac.c
@@ -424,5 +424,5 @@ const OSSL_DISPATCH ossl_drbg_ossl_hmac_functions[] = {
       (void(*)(void))drbg_hmac_verify_zeroization },
     { OSSL_FUNC_RAND_GET_SEED, (void(*)(void))ossl_drbg_get_seed },
     { OSSL_FUNC_RAND_CLEAR_SEED, (void(*)(void))ossl_drbg_clear_seed },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };

--- a/providers/implementations/rands/seed_src.c
+++ b/providers/implementations/rands/seed_src.c
@@ -245,5 +245,5 @@ const OSSL_DISPATCH ossl_seed_src_functions[] = {
       (void(*)(void))seed_src_verify_zeroization },
     { OSSL_FUNC_RAND_GET_SEED, (void(*)(void))seed_get_seed },
     { OSSL_FUNC_RAND_CLEAR_SEED, (void(*)(void))seed_clear_seed },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };

--- a/providers/implementations/rands/test_rng.c
+++ b/providers/implementations/rands/test_rng.c
@@ -292,5 +292,5 @@ const OSSL_DISPATCH ossl_test_rng_functions[] = {
     { OSSL_FUNC_RAND_VERIFY_ZEROIZATION,
       (void(*)(void))test_rng_verify_zeroization },
     { OSSL_FUNC_RAND_GET_SEED, (void(*)(void))test_rng_get_seed },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };

--- a/providers/implementations/signature/dsa_sig.c
+++ b/providers/implementations/signature/dsa_sig.c
@@ -610,5 +610,5 @@ const OSSL_DISPATCH ossl_dsa_signature_functions[] = {
       (void (*)(void))dsa_set_ctx_md_params },
     { OSSL_FUNC_SIGNATURE_SETTABLE_CTX_MD_PARAMS,
       (void (*)(void))dsa_settable_ctx_md_params },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };

--- a/providers/implementations/signature/ecdsa_sig.c
+++ b/providers/implementations/signature/ecdsa_sig.c
@@ -635,5 +635,5 @@ const OSSL_DISPATCH ossl_ecdsa_signature_functions[] = {
       (void (*)(void))ecdsa_set_ctx_md_params },
     { OSSL_FUNC_SIGNATURE_SETTABLE_CTX_MD_PARAMS,
       (void (*)(void))ecdsa_settable_ctx_md_params },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };

--- a/providers/implementations/signature/eddsa_sig.c
+++ b/providers/implementations/signature/eddsa_sig.c
@@ -607,7 +607,7 @@ const OSSL_DISPATCH ossl_ed25519_signature_functions[] = {
     { OSSL_FUNC_SIGNATURE_SET_CTX_PARAMS, (void (*)(void))eddsa_set_ctx_params },
     { OSSL_FUNC_SIGNATURE_SETTABLE_CTX_PARAMS,
       (void (*)(void))eddsa_settable_ctx_params },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };
 
 const OSSL_DISPATCH ossl_ed448_signature_functions[] = {
@@ -628,7 +628,7 @@ const OSSL_DISPATCH ossl_ed448_signature_functions[] = {
     { OSSL_FUNC_SIGNATURE_SET_CTX_PARAMS, (void (*)(void))eddsa_set_ctx_params },
     { OSSL_FUNC_SIGNATURE_SETTABLE_CTX_PARAMS,
       (void (*)(void))eddsa_settable_ctx_params },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };
 
 #ifdef S390X_EC_ASM

--- a/providers/implementations/signature/mac_legacy_sig.c
+++ b/providers/implementations/signature/mac_legacy_sig.c
@@ -256,7 +256,7 @@ MAC_SETTABLE_CTX_PARAMS(cmac, "CMAC")
           (void (*)(void))mac_set_ctx_params }, \
         { OSSL_FUNC_SIGNATURE_SETTABLE_CTX_PARAMS, \
           (void (*)(void))mac_##funcname##_settable_ctx_params }, \
-        { 0, NULL } \
+        OSSL_DISPATCH_END \
     };
 
 MAC_SIGNATURE_FUNCTIONS(hmac)

--- a/providers/implementations/signature/rsa_sig.c
+++ b/providers/implementations/signature/rsa_sig.c
@@ -1488,5 +1488,5 @@ const OSSL_DISPATCH ossl_rsa_signature_functions[] = {
       (void (*)(void))rsa_set_ctx_md_params },
     { OSSL_FUNC_SIGNATURE_SETTABLE_CTX_MD_PARAMS,
       (void (*)(void))rsa_settable_ctx_md_params },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };

--- a/providers/implementations/signature/sm2_sig.c
+++ b/providers/implementations/signature/sm2_sig.c
@@ -559,5 +559,5 @@ const OSSL_DISPATCH ossl_sm2_signature_functions[] = {
       (void (*)(void))sm2sig_set_ctx_md_params },
     { OSSL_FUNC_SIGNATURE_SETTABLE_CTX_MD_PARAMS,
       (void (*)(void))sm2sig_settable_ctx_md_params },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };

--- a/providers/implementations/storemgmt/file_store.c
+++ b/providers/implementations/storemgmt/file_store.c
@@ -782,5 +782,5 @@ const OSSL_DISPATCH ossl_file_store_functions[] = {
     { OSSL_FUNC_STORE_LOAD, (void (*)(void))file_load },
     { OSSL_FUNC_STORE_EOF, (void (*)(void))file_eof },
     { OSSL_FUNC_STORE_CLOSE, (void (*)(void))file_close },
-    { 0, NULL },
+    OSSL_DISPATCH_END,
 };

--- a/providers/implementations/storemgmt/file_store_any2obj.c
+++ b/providers/implementations/storemgmt/file_store_any2obj.c
@@ -246,7 +246,7 @@ static int pvk2obj_decode(void *provctx, OSSL_CORE_BIO *cin, int selection,
         { OSSL_FUNC_DECODER_NEWCTX, (void (*)(void))any2obj_newctx },        \
         { OSSL_FUNC_DECODER_FREECTX, (void (*)(void))any2obj_freectx },      \
         { OSSL_FUNC_DECODER_DECODE, (void (*)(void))fromtype##2obj_decode }, \
-        { 0, NULL }                                                          \
+        OSSL_DISPATCH_END                                                    \
     }
 
 MAKE_DECODER(der, OSSL_OBJECT_UNKNOWN);

--- a/providers/implementations/storemgmt/winstore_store.c
+++ b/providers/implementations/storemgmt/winstore_store.c
@@ -323,5 +323,5 @@ const OSSL_DISPATCH ossl_winstore_store_functions[] = {
     { OSSL_FUNC_STORE_LOAD, (void (*)(void))winstore_load },
     { OSSL_FUNC_STORE_EOF, (void (*)(void))winstore_eof },
     { OSSL_FUNC_STORE_CLOSE, (void (*)(void))winstore_close },
-    { 0, NULL },
+    OSSL_DISPATCH_END,
 };

--- a/providers/legacyprov.c
+++ b/providers/legacyprov.c
@@ -193,7 +193,7 @@ static const OSSL_DISPATCH legacy_dispatch_table[] = {
     { OSSL_FUNC_PROVIDER_GETTABLE_PARAMS, (void (*)(void))legacy_gettable_params },
     { OSSL_FUNC_PROVIDER_GET_PARAMS, (void (*)(void))legacy_get_params },
     { OSSL_FUNC_PROVIDER_QUERY_OPERATION, (void (*)(void))legacy_query },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };
 
 int OSSL_provider_init(const OSSL_CORE_HANDLE *handle,

--- a/providers/nullprov.c
+++ b/providers/nullprov.c
@@ -64,7 +64,7 @@ static const OSSL_DISPATCH null_dispatch_table[] = {
     { OSSL_FUNC_PROVIDER_GETTABLE_PARAMS, (void (*)(void))null_gettable_params },
     { OSSL_FUNC_PROVIDER_GET_PARAMS, (void (*)(void))null_get_params },
     { OSSL_FUNC_PROVIDER_QUERY_OPERATION, (void (*)(void))null_query },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };
 
 int ossl_null_provider_init(const OSSL_CORE_HANDLE *handle,

--- a/ssl/record/rec_layer_s3.c
+++ b/ssl/record/rec_layer_s3.c
@@ -1103,7 +1103,7 @@ static const OSSL_DISPATCH rlayer_dispatch[] = {
     { OSSL_FUNC_RLAYER_MSG_CALLBACK, (void (*)(void))rlayer_msg_callback_wrapper },
     { OSSL_FUNC_RLAYER_SECURITY, (void (*)(void))rlayer_security_wrapper },
     { OSSL_FUNC_RLAYER_PADDING, (void (*)(void))rlayer_padding_wrapper },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };
 
 void ossl_ssl_set_custom_record_layer(SSL_CONNECTION *s,

--- a/test/bio_core_test.c
+++ b/test/bio_core_test.c
@@ -61,7 +61,7 @@ static const OSSL_DISPATCH biocbs[] = {
     { OSSL_FUNC_BIO_CTRL, (void (*)(void))tst_bio_core_ctrl },
     { OSSL_FUNC_BIO_UP_REF, (void (*)(void))tst_bio_core_up_ref },
     { OSSL_FUNC_BIO_FREE, (void (*)(void))tst_bio_core_free },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };
 
 static int test_bio_core(void)

--- a/test/fake_rsaprov.c
+++ b/test/fake_rsaprov.c
@@ -277,7 +277,7 @@ static const OSSL_DISPATCH fake_rsa_keymgmt_funcs[] = {
     { OSSL_FUNC_KEYMGMT_GEN_INIT, (void (*)(void))fake_rsa_gen_init },
     { OSSL_FUNC_KEYMGMT_GEN, (void (*)(void))fake_rsa_gen },
     { OSSL_FUNC_KEYMGMT_GEN_CLEANUP, (void (*)(void))fake_rsa_gen_cleanup },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };
 
 static const OSSL_ALGORITHM fake_rsa_keymgmt_algs[] = {
@@ -510,7 +510,7 @@ static const OSSL_DISPATCH fake_rsa_sig_funcs[] = {
         (void (*)(void))fake_rsa_dgstvfy_final },
     { OSSL_FUNC_SIGNATURE_DIGEST_VERIFY,
         (void (*)(void))fake_rsa_dgstvfy },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };
 
 static const OSSL_ALGORITHM fake_rsa_sig_algs[] = {
@@ -629,7 +629,7 @@ static const OSSL_DISPATCH fake_rsa_store_funcs[] = {
     { OSSL_FUNC_STORE_LOAD, (void (*)(void))fake_rsa_st_load },
     { OSSL_FUNC_STORE_EOF, (void (*)(void))fake_rsa_st_eof },
     { OSSL_FUNC_STORE_CLOSE, (void (*)(void))fake_rsa_st_close },
-    { 0, NULL },
+    OSSL_DISPATCH_END,
 };
 
 static const OSSL_ALGORITHM fake_rsa_store_algs[] = {
@@ -659,7 +659,7 @@ static const OSSL_ALGORITHM *fake_rsa_query(void *provctx,
 static const OSSL_DISPATCH fake_rsa_method[] = {
     { OSSL_FUNC_PROVIDER_TEARDOWN, (void (*)(void))OSSL_LIB_CTX_free },
     { OSSL_FUNC_PROVIDER_QUERY_OPERATION, (void (*)(void))fake_rsa_query },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };
 
 static int fake_rsa_provider_init(const OSSL_CORE_HANDLE *handle,

--- a/test/filterprov.c
+++ b/test/filterprov.c
@@ -128,7 +128,7 @@ static const OSSL_DISPATCH filter_dispatch_table[] = {
     { OSSL_FUNC_PROVIDER_UNQUERY_OPERATION, (void (*)(void))filter_unquery },
     { OSSL_FUNC_PROVIDER_GET_CAPABILITIES, (void (*)(void))filter_get_capabilities },
     { OSSL_FUNC_PROVIDER_TEARDOWN, (void (*)(void))filter_teardown },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };
 
 int filter_provider_init(const OSSL_CORE_HANDLE *handle,

--- a/test/p_test.c
+++ b/test/p_test.c
@@ -222,7 +222,7 @@ static const OSSL_DISPATCH p_test_table[] = {
     { OSSL_FUNC_PROVIDER_GET_REASON_STRINGS,
         (void (*)(void))p_get_reason_strings},
     { OSSL_FUNC_PROVIDER_TEARDOWN, (void (*)(void))p_teardown },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };
 
 int OSSL_provider_init(const OSSL_CORE_HANDLE *handle,

--- a/test/provfetchtest.c
+++ b/test/provfetchtest.c
@@ -25,7 +25,7 @@ static int dummy_decoder_decode(void *ctx, OSSL_CORE_BIO *cin, int selection,
 
 static const OSSL_DISPATCH dummy_decoder_functions[] = {
     { OSSL_FUNC_DECODER_DECODE, (void (*)(void))dummy_decoder_decode },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };
 
 static const OSSL_ALGORITHM dummy_decoders[] = {
@@ -43,7 +43,7 @@ static int dummy_encoder_encode(void *ctx, OSSL_CORE_BIO *out,
 
 static const OSSL_DISPATCH dummy_encoder_functions[] = {
     { OSSL_FUNC_DECODER_DECODE, (void (*)(void))dummy_encoder_encode },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };
 
 static const OSSL_ALGORITHM dummy_encoders[] = {
@@ -78,7 +78,7 @@ static const OSSL_DISPATCH dummy_store_functions[] = {
     { OSSL_FUNC_STORE_LOAD, (void (*)(void))dummy_store_load },
     { OSSL_FUNC_STORE_EOF, (void (*)(void))dumm_store_eof },
     { OSSL_FUNC_STORE_CLOSE, (void (*)(void))dummy_store_close },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };
 
 static const OSSL_ALGORITHM dummy_store[] = {
@@ -167,7 +167,7 @@ static const OSSL_DISPATCH dummy_rand_functions[] = {
     { OSSL_FUNC_RAND_ENABLE_LOCKING, (void(*)(void))dummy_rand_enable_locking },
     { OSSL_FUNC_RAND_LOCK, (void(*)(void))dummy_rand_lock },
     { OSSL_FUNC_RAND_UNLOCK, (void(*)(void))dummy_rand_unlock },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };
 
 static const OSSL_ALGORITHM dummy_rand[] = {
@@ -195,7 +195,7 @@ static const OSSL_ALGORITHM *dummy_query(void *provctx, int operation_id,
 static const OSSL_DISPATCH dummy_dispatch_table[] = {
     { OSSL_FUNC_PROVIDER_QUERY_OPERATION, (void (*)(void))dummy_query },
     { OSSL_FUNC_PROVIDER_TEARDOWN, (void (*)(void))OSSL_LIB_CTX_free },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };
 
 static int dummy_provider_init(const OSSL_CORE_HANDLE *handle,

--- a/test/testutil/fake_random.c
+++ b/test/testutil/fake_random.c
@@ -134,7 +134,7 @@ static const OSSL_DISPATCH fake_rand_functions[] = {
     { OSSL_FUNC_RAND_GETTABLE_CTX_PARAMS,
       (void(*)(void))fake_rand_gettable_ctx_params },
     { OSSL_FUNC_RAND_GET_CTX_PARAMS, (void(*)(void))fake_rand_get_ctx_params },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };
 
 static const OSSL_ALGORITHM fake_rand_rand[] = {
@@ -158,7 +158,7 @@ static const OSSL_ALGORITHM *fake_rand_query(void *provctx,
 static const OSSL_DISPATCH fake_rand_method[] = {
     { OSSL_FUNC_PROVIDER_TEARDOWN, (void (*)(void))OSSL_LIB_CTX_free },
     { OSSL_FUNC_PROVIDER_QUERY_OPERATION, (void (*)(void))fake_rand_query },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };
 
 static int fake_rand_provider_init(const OSSL_CORE_HANDLE *handle,

--- a/test/tls-provider.c
+++ b/test/tls-provider.c
@@ -538,7 +538,7 @@ static const OSSL_DISPATCH xor_keyexch_functions[] = {
     { OSSL_FUNC_KEYEXCH_SET_PEER, (void (*)(void))xor_set_peer },
     { OSSL_FUNC_KEYEXCH_FREECTX, (void (*)(void))xor_freectx },
     { OSSL_FUNC_KEYEXCH_DUPCTX, (void (*)(void))xor_dupctx },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };
 
 static const OSSL_ALGORITHM tls_prov_keyexch[] = {
@@ -667,7 +667,7 @@ static const OSSL_DISPATCH xor_kem_functions[] = {
     { OSSL_FUNC_KEM_ENCAPSULATE, (void (*)(void))xor_encapsulate },
     { OSSL_FUNC_KEM_DECAPSULATE_INIT, (void (*)(void))xor_init },
     { OSSL_FUNC_KEM_DECAPSULATE, (void (*)(void))xor_decapsulate },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };
 
 static const OSSL_ALGORITHM tls_prov_kem[] = {
@@ -1110,7 +1110,7 @@ static const OSSL_DISPATCH xor_keymgmt_functions[] = {
     { OSSL_FUNC_KEYMGMT_EXPORT, (void (*)(void))xor_export },
     { OSSL_FUNC_KEYMGMT_EXPORT_TYPES, (void (*)(void))xor_export_types },
     { OSSL_FUNC_KEYMGMT_EXPORT_TYPES_EX, (void (*)(void))xor_export_types_ex },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };
 
 /* We're re-using most XOR keymgmt functions also for signature operations: */
@@ -1164,7 +1164,7 @@ static const OSSL_DISPATCH xor_xorhmacsig_keymgmt_functions[] = {
     { OSSL_FUNC_KEYMGMT_EXPORT_TYPES, (void (*)(void))xor_export_types },
     { OSSL_FUNC_KEYMGMT_LOAD, (void (*)(void))xor_load },
     { OSSL_FUNC_KEYMGMT_MATCH, (void (*)(void))xor_match },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };
 
 static const OSSL_DISPATCH xor_xorhmacsha2sig_keymgmt_functions[] = {
@@ -1188,7 +1188,7 @@ static const OSSL_DISPATCH xor_xorhmacsha2sig_keymgmt_functions[] = {
     { OSSL_FUNC_KEYMGMT_EXPORT_TYPES, (void (*)(void))xor_export_types },
     { OSSL_FUNC_KEYMGMT_LOAD, (void (*)(void))xor_load },
     { OSSL_FUNC_KEYMGMT_MATCH, (void (*)(void))xor_match },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };
 
 typedef enum {
@@ -2009,7 +2009,7 @@ static int key2any_encode(struct key2any_ctx_st *ctx, OSSL_CORE_BIO *cout,
           (void (*)(void))impl##_to_##kind##_##output##_free_object },      \
         { OSSL_FUNC_ENCODER_ENCODE,                                         \
           (void (*)(void))impl##_to_##kind##_##output##_encode },           \
-        { 0, NULL }                                                         \
+        OSSL_DISPATCH_END                                                   \
     }
 
 /*
@@ -2544,7 +2544,7 @@ static void xorx_key_adjust(void *key, struct der2key_ctx_st *ctx)
           (void (*)(void))xor_der2key_decode },                         \
         { OSSL_FUNC_DECODER_EXPORT_OBJECT,                              \
           (void (*)(void))der2key_export_object },                      \
-        { 0, NULL }                                                     \
+        OSSL_DISPATCH_END                                               \
     }
 
 MAKE_DECODER(XORSIGALG_NAME, xorhmacsig, xor, PrivateKeyInfo);
@@ -3111,7 +3111,7 @@ static const OSSL_DISPATCH xor_signature_functions[] = {
       (void (*)(void))xor_sig_set_ctx_md_params },
     { OSSL_FUNC_SIGNATURE_SETTABLE_CTX_MD_PARAMS,
       (void (*)(void))xor_sig_settable_ctx_md_params },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };
 
 static const OSSL_ALGORITHM tls_prov_signature[] = {
@@ -3169,7 +3169,7 @@ static const OSSL_DISPATCH tls_prov_dispatch_table[] = {
     { OSSL_FUNC_PROVIDER_TEARDOWN, (void (*)(void))tls_prov_teardown },
     { OSSL_FUNC_PROVIDER_QUERY_OPERATION, (void (*)(void))tls_prov_query },
     { OSSL_FUNC_PROVIDER_GET_CAPABILITIES, (void (*)(void))tls_prov_get_capabilities },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };
 
 static

--- a/test/upcallstest.c
+++ b/test/upcallstest.c
@@ -21,7 +21,7 @@ static const OSSL_ALGORITHM *obj_query(void *provctx, int operation_id,
 
 static const OSSL_DISPATCH obj_dispatch_table[] = {
     { OSSL_FUNC_PROVIDER_QUERY_OPERATION, (void (*)(void))obj_query },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };
 
 static OSSL_FUNC_core_obj_add_sigid_fn *c_obj_add_sigid = NULL;

--- a/test/user_property_test.c
+++ b/test/user_property_test.c
@@ -45,7 +45,7 @@ static int tmpmd_digest(void *provctx, const unsigned char *in, size_t inl,
 static const OSSL_DISPATCH testprovmd_functions[] = {
     { OSSL_FUNC_DIGEST_GET_PARAMS, (void (*)(void))tmpmd_get_params },
     { OSSL_FUNC_DIGEST_DIGEST, (void (*)(void))tmpmd_digest },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };
 
 static const OSSL_ALGORITHM testprov_digests[] = {
@@ -63,7 +63,7 @@ static const OSSL_ALGORITHM *testprov_query(void *provctx,
 
 static const OSSL_DISPATCH testprov_dispatch_table[] = {
     { OSSL_FUNC_PROVIDER_QUERY_OPERATION, (void (*)(void))testprov_query },
-    { 0, NULL }
+    OSSL_DISPATCH_END
 };
 
 static int testprov_provider_init(const OSSL_CORE_HANDLE *handle,

--- a/util/other.syms
+++ b/util/other.syms
@@ -468,6 +468,7 @@ OSSL_PARAM_construct_TYPE               generic
 OSSL_PARAM_utf8_string                  define
 OSSL_PARAM_get_TYPE                     generic
 OSSL_PARAM_END                          define
+OSSL_DISPATCH_END                       define
 OSSL_PARAM_set_TYPE                     generic
 OSSL_ENCODER_PUBKEY_TO_DER_PQ           define
 OSSL_ENCODER_PrivateKey_TO_DER_PQ       define


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
