### PR TITLE
Replace non-standard pointer bit-fiddling with standard ANSI C

### DIFF
--- a/crypto/bn/bn_local.h
+++ b/crypto/bn/bn_local.h
@@ -367,24 +367,6 @@ struct bn_gencb_st {
 # define BN_MUL_LOW_RECURSIVE_SIZE_NORMAL        (32)/* 32 */
 # define BN_MONT_CTX_SET_SIZE_WORD               (64)/* 32 */
 
-/*
- * 2011-02-22 SMS. In various places, a size_t variable or a type cast to
- * size_t was used to perform integer-only operations on pointers.  This
- * failed on VMS with 64-bit pointers (CC /POINTER_SIZE = 64) because size_t
- * is still only 32 bits.  What's needed in these cases is an integer type
- * with the same size as a pointer, which size_t is not certain to be. The
- * only fix here is VMS-specific.
- */
-# if defined(OPENSSL_SYS_VMS)
-#  if __INITIAL_POINTER_SIZE == 64
-#   define PTR_SIZE_INT long long
-#  else                         /* __INITIAL_POINTER_SIZE == 64 */
-#   define PTR_SIZE_INT int
-#  endif                        /* __INITIAL_POINTER_SIZE == 64 [else] */
-# elif !defined(PTR_SIZE_INT)   /* defined(OPENSSL_SYS_VMS) */
-#  define PTR_SIZE_INT size_t
-# endif                         /* defined(OPENSSL_SYS_VMS) [else] */
-
 # if !defined(OPENSSL_NO_ASM) && !defined(OPENSSL_NO_INLINE_ASM) && !defined(PEDANTIC)
 /*
  * BN_UMULT_HIGH section.

--- a/crypto/bn/bn_nist.c
+++ b/crypto/bn/bn_nist.c
@@ -338,7 +338,6 @@ int BN_nist_mod_192(BIGNUM *r, const BIGNUM *a, const BIGNUM *field,
                         sizeof(unsigned int)];
     } buf;
     BN_ULONG c_d[BN_NIST_192_TOP], *res;
-    PTR_SIZE_INT mask;
     static const BIGNUM ossl_bignum_nist_p_192_sqr = {
         (BN_ULONG *)_nist_p_192_sqr,
         OSSL_NELEM(_nist_p_192_sqr),
@@ -439,13 +438,9 @@ int BN_nist_mod_192(BIGNUM *r, const BIGNUM *a, const BIGNUM *field,
      * 'tmp=result-modulus; if (!carry || !borrow) result=tmp;'
      * this is what happens below, but without explicit if:-) a.
      */
-    mask =
-        0 - (PTR_SIZE_INT) bn_sub_words(c_d, r_d, _nist_p_192[0],
-                                        BN_NIST_192_TOP);
-    mask &= 0 - (PTR_SIZE_INT) carry;
-    res = c_d;
-    res = (BN_ULONG *)
-        (((PTR_SIZE_INT) res & ~mask) | ((PTR_SIZE_INT) r_d & mask));
+    res = (bn_sub_words(c_d, r_d, _nist_p_192[0], BN_NIST_192_TOP) && carry)
+        ? r_d
+        : c_d;
     nist_cp_bn(r_d, res, BN_NIST_192_TOP);
     r->top = BN_NIST_192_TOP;
     bn_correct_top(r);
@@ -479,7 +474,6 @@ int BN_nist_mod_224(BIGNUM *r, const BIGNUM *a, const BIGNUM *field,
                         sizeof(unsigned int)];
     } buf;
     BN_ULONG c_d[BN_NIST_224_TOP], *res;
-    PTR_SIZE_INT mask;
     union {
         bn_addsub_f f;
         PTR_SIZE_INT p;
@@ -616,19 +610,14 @@ int BN_nist_mod_224(BIGNUM *r, const BIGNUM *a, const BIGNUM *field,
         carry =
             (int)bn_add_words(r_d, r_d, _nist_p_224[-carry - 1],
                               BN_NIST_224_TOP);
-        mask = 0 - (PTR_SIZE_INT) carry;
-        u.p = ((PTR_SIZE_INT) bn_sub_words & mask) |
-            ((PTR_SIZE_INT) bn_add_words & ~mask);
+        u.f = carry ? bn_sub_words : bn_add_words;
     } else
         carry = 1;
 
     /* otherwise it's effectively same as in BN_nist_mod_192... */
-    mask =
-        0 - (PTR_SIZE_INT) (*u.f) (c_d, r_d, _nist_p_224[0], BN_NIST_224_TOP);
-    mask &= 0 - (PTR_SIZE_INT) carry;
-    res = c_d;
-    res = (BN_ULONG *)(((PTR_SIZE_INT) res & ~mask) |
-                       ((PTR_SIZE_INT) r_d & mask));
+    res = ((*u.f) (c_d, r_d, _nist_p_224[0], BN_NIST_224_TOP) && carry)
+        ? r_d
+        : c_d;
     nist_cp_bn(r_d, res, BN_NIST_224_TOP);
     r->top = BN_NIST_224_TOP;
     bn_correct_top(r);
@@ -660,7 +649,6 @@ int BN_nist_mod_256(BIGNUM *r, const BIGNUM *a, const BIGNUM *field,
                         sizeof(unsigned int)];
     } buf;
     BN_ULONG c_d[BN_NIST_256_TOP], *res;
-    PTR_SIZE_INT mask;
     union {
         bn_addsub_f f;
         PTR_SIZE_INT p;
@@ -859,18 +847,13 @@ int BN_nist_mod_256(BIGNUM *r, const BIGNUM *a, const BIGNUM *field,
         carry =
             (int)bn_add_words(r_d, r_d, _nist_p_256[-carry - 1],
                               BN_NIST_256_TOP);
-        mask = 0 - (PTR_SIZE_INT) carry;
-        u.p = ((PTR_SIZE_INT) bn_sub_words & mask) |
-            ((PTR_SIZE_INT) bn_add_words & ~mask);
+        u.f = carry ? bn_sub_words : bn_add_words;
     } else
         carry = 1;
 
-    mask =
-        0 - (PTR_SIZE_INT) (*u.f) (c_d, r_d, _nist_p_256[0], BN_NIST_256_TOP);
-    mask &= 0 - (PTR_SIZE_INT) carry;
-    res = c_d;
-    res = (BN_ULONG *)(((PTR_SIZE_INT) res & ~mask) |
-                       ((PTR_SIZE_INT) r_d & mask));
+    res = ((*u.f) (c_d, r_d, _nist_p_256[0], BN_NIST_256_TOP) && carry)
+        ? r_d
+        : c_d;
     nist_cp_bn(r_d, res, BN_NIST_256_TOP);
     r->top = BN_NIST_256_TOP;
     bn_correct_top(r);
@@ -906,7 +889,6 @@ int BN_nist_mod_384(BIGNUM *r, const BIGNUM *a, const BIGNUM *field,
                         sizeof(unsigned int)];
     } buf;
     BN_ULONG c_d[BN_NIST_384_TOP], *res;
-    PTR_SIZE_INT mask;
     union {
         bn_addsub_f f;
         PTR_SIZE_INT p;
@@ -1140,18 +1122,13 @@ int BN_nist_mod_384(BIGNUM *r, const BIGNUM *a, const BIGNUM *field,
         carry =
             (int)bn_add_words(r_d, r_d, _nist_p_384[-carry - 1],
                               BN_NIST_384_TOP);
-        mask = 0 - (PTR_SIZE_INT) carry;
-        u.p = ((PTR_SIZE_INT) bn_sub_words & mask) |
-            ((PTR_SIZE_INT) bn_add_words & ~mask);
+        u.f = carry ? bn_sub_words : bn_add_words;
     } else
         carry = 1;
 
-    mask =
-        0 - (PTR_SIZE_INT) (*u.f) (c_d, r_d, _nist_p_384[0], BN_NIST_384_TOP);
-    mask &= 0 - (PTR_SIZE_INT) carry;
-    res = c_d;
-    res = (BN_ULONG *)(((PTR_SIZE_INT) res & ~mask) |
-                       ((PTR_SIZE_INT) r_d & mask));
+    res = ((*u.f) (c_d, r_d, _nist_p_384[0], BN_NIST_384_TOP) && carry)
+        ? r_d
+        : c_d;
     nist_cp_bn(r_d, res, BN_NIST_384_TOP);
     r->top = BN_NIST_384_TOP;
     bn_correct_top(r);
@@ -1168,7 +1145,6 @@ int BN_nist_mod_521(BIGNUM *r, const BIGNUM *a, const BIGNUM *field,
 {
     int top = a->top, i;
     BN_ULONG *r_d, *a_d = a->d, t_d[BN_NIST_521_TOP], val, tmp, *res;
-    PTR_SIZE_INT mask;
     static const BIGNUM ossl_bignum_nist_p_521_sqr = {
         (BN_ULONG *)_nist_p_521_sqr,
         OSSL_NELEM(_nist_p_521_sqr),
@@ -1221,12 +1197,10 @@ int BN_nist_mod_521(BIGNUM *r, const BIGNUM *a, const BIGNUM *field,
     r_d[i] &= BN_NIST_521_TOP_MASK;
 
     bn_add_words(r_d, r_d, t_d, BN_NIST_521_TOP);
-    mask =
-        0 - (PTR_SIZE_INT) bn_sub_words(t_d, r_d, _nist_p_521,
-                                        BN_NIST_521_TOP);
-    res = t_d;
-    res = (BN_ULONG *)(((PTR_SIZE_INT) res & ~mask) |
-                       ((PTR_SIZE_INT) r_d & mask));
+    res = bn_sub_words(t_d, r_d, _nist_p_521,
+                       BN_NIST_521_TOP)
+        ? r_d
+        : t_d;
     nist_cp_bn(r_d, res, BN_NIST_521_TOP);
     r->top = BN_NIST_521_TOP;
     bn_correct_top(r);

--- a/crypto/bn/bn_nist.c
+++ b/crypto/bn/bn_nist.c
@@ -474,10 +474,7 @@ int BN_nist_mod_224(BIGNUM *r, const BIGNUM *a, const BIGNUM *field,
                         sizeof(unsigned int)];
     } buf;
     BN_ULONG c_d[BN_NIST_224_TOP], *res;
-    union {
-        bn_addsub_f f;
-        PTR_SIZE_INT p;
-    } u;
+    bn_addsub_f adjust;
     static const BIGNUM ossl_bignum_nist_p_224_sqr = {
         (BN_ULONG *)_nist_p_224_sqr,
         OSSL_NELEM(_nist_p_224_sqr),
@@ -591,7 +588,7 @@ int BN_nist_mod_224(BIGNUM *r, const BIGNUM *a, const BIGNUM *field,
 # endif
     }
 #endif
-    u.f = bn_sub_words;
+    adjust = bn_sub_words;
     if (carry > 0) {
         carry =
             (int)bn_sub_words(r_d, r_d, _nist_p_224[carry - 1],
@@ -610,12 +607,12 @@ int BN_nist_mod_224(BIGNUM *r, const BIGNUM *a, const BIGNUM *field,
         carry =
             (int)bn_add_words(r_d, r_d, _nist_p_224[-carry - 1],
                               BN_NIST_224_TOP);
-        u.f = carry ? bn_sub_words : bn_add_words;
+        adjust = carry ? bn_sub_words : bn_add_words;
     } else
         carry = 1;
 
     /* otherwise it's effectively same as in BN_nist_mod_192... */
-    res = ((*u.f) (c_d, r_d, _nist_p_224[0], BN_NIST_224_TOP) && carry)
+    res = ((*adjust) (c_d, r_d, _nist_p_224[0], BN_NIST_224_TOP) && carry)
         ? r_d
         : c_d;
     nist_cp_bn(r_d, res, BN_NIST_224_TOP);
@@ -649,10 +646,7 @@ int BN_nist_mod_256(BIGNUM *r, const BIGNUM *a, const BIGNUM *field,
                         sizeof(unsigned int)];
     } buf;
     BN_ULONG c_d[BN_NIST_256_TOP], *res;
-    union {
-        bn_addsub_f f;
-        PTR_SIZE_INT p;
-    } u;
+    bn_addsub_f adjust;
     static const BIGNUM ossl_bignum_nist_p_256_sqr = {
         (BN_ULONG *)_nist_p_256_sqr,
         OSSL_NELEM(_nist_p_256_sqr),
@@ -838,7 +832,7 @@ int BN_nist_mod_256(BIGNUM *r, const BIGNUM *a, const BIGNUM *field,
     }
 #endif
     /* see BN_nist_mod_224 for explanation */
-    u.f = bn_sub_words;
+    adjust = bn_sub_words;
     if (carry > 0)
         carry =
             (int)bn_sub_words(r_d, r_d, _nist_p_256[carry - 1],
@@ -847,11 +841,11 @@ int BN_nist_mod_256(BIGNUM *r, const BIGNUM *a, const BIGNUM *field,
         carry =
             (int)bn_add_words(r_d, r_d, _nist_p_256[-carry - 1],
                               BN_NIST_256_TOP);
-        u.f = carry ? bn_sub_words : bn_add_words;
+        adjust = carry ? bn_sub_words : bn_add_words;
     } else
         carry = 1;
 
-    res = ((*u.f) (c_d, r_d, _nist_p_256[0], BN_NIST_256_TOP) && carry)
+    res = ((*adjust) (c_d, r_d, _nist_p_256[0], BN_NIST_256_TOP) && carry)
         ? r_d
         : c_d;
     nist_cp_bn(r_d, res, BN_NIST_256_TOP);
@@ -889,10 +883,7 @@ int BN_nist_mod_384(BIGNUM *r, const BIGNUM *a, const BIGNUM *field,
                         sizeof(unsigned int)];
     } buf;
     BN_ULONG c_d[BN_NIST_384_TOP], *res;
-    union {
-        bn_addsub_f f;
-        PTR_SIZE_INT p;
-    } u;
+    bn_addsub_f adjust;
     static const BIGNUM ossl_bignum_nist_p_384_sqr = {
         (BN_ULONG *)_nist_p_384_sqr,
         OSSL_NELEM(_nist_p_384_sqr),
@@ -1113,7 +1104,7 @@ int BN_nist_mod_384(BIGNUM *r, const BIGNUM *a, const BIGNUM *field,
     }
 #endif
     /* see BN_nist_mod_224 for explanation */
-    u.f = bn_sub_words;
+    adjust = bn_sub_words;
     if (carry > 0)
         carry =
             (int)bn_sub_words(r_d, r_d, _nist_p_384[carry - 1],
@@ -1122,11 +1113,11 @@ int BN_nist_mod_384(BIGNUM *r, const BIGNUM *a, const BIGNUM *field,
         carry =
             (int)bn_add_words(r_d, r_d, _nist_p_384[-carry - 1],
                               BN_NIST_384_TOP);
-        u.f = carry ? bn_sub_words : bn_add_words;
+        adjust = carry ? bn_sub_words : bn_add_words;
     } else
         carry = 1;
 
-    res = ((*u.f) (c_d, r_d, _nist_p_384[0], BN_NIST_384_TOP) && carry)
+    res = ((*adjust) (c_d, r_d, _nist_p_384[0], BN_NIST_384_TOP) && carry)
         ? r_d
         : c_d;
     nist_cp_bn(r_d, res, BN_NIST_384_TOP);


### PR DESCRIPTION
Replaces the non-standard C pointer bit-fiddling in `bn_nist.c` with the ternary conditional operator. As this is the only place `#define PTR_SIZE_INT` is used, we can then remove it from `crypto/bn/bn_local.h`.

### Benefits

#### Converts implementation defined behavior to standard ANSI C

Bit-fiddling pointers is technically implementation defined behavior in the C specification so the following code is not supported in all platforms:

```c
    PTR_SIZE_INT mask;
    void * a, b, c;
    int boolean_flag;

    mask = 0 - boolean_flag;
    /* Not guaranteed to be a valid ptr to a or b on all platforms  */
    a = (void *)
        ((((PTR_SIZE_INT) b & ~mask) | (((PTR_SIZE_INT)) c & mask)));
```

For example, without these patches, the current code doesn't compile for [ARM's experimental Morello platform](https://www.arm.com/architecture/cpu/morello).

In fact, any integer to pointer casting is implementation defined behavior in the ASNI C specification (see http://port70.net/~nsz/c/c89/c89-draft.html#3.3.4).

This also allows us to remove the `#define PTR_SIZE_INT size_t`, which is great, as there are a couple of esoteric platforms where `size_t != uintptr_t`.

Using a ternary conditional operator is supported on all platforms (i.e. `a = boolean_flag ? b : c;`).

#### Performance

On most modern compilers/CPUs, this will be faster, since it will get converted to a CMOV instruction. (the compiler doesn't know that the return value from `bn_sub_words`/`bn_add_words` is a boolean, so it currently can't optimize this to a CMOV).

### Potential downsides

In some cases (e.g. older compilers or simpler CPUs), this code will get compiled into branching code. Most simpler CPUs usually have short pipelines, so even if there is a branch misprediction, this shouldn't have too much of a performance impact.

I don't think this will result in any potential timing attacks, since these functions already have a bunch of `if()` conditionals.

(If there is a risk of timing attacks, we should probably instead make some new functions in `include/internal/constant_time.h` called `constant_time_select_ptr` and `constant_time_select_func_ptr` (since in C, function pointers aren't necessarily the same size as object pointers).)

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

---

##### Checklist

There's not an easy way to test for this implementation defined behavior, other than to add a CI job that compiles for a platform that doesn't support bit-fiddling pointers, but that seems like a lot of wasted computation for a platform that very few people will use.