### PR TITLE
aesv8-armx.pl: Avoid buffer overrread in AES-XTS decryption

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -270,6 +270,15 @@ OpenSSL 3.1
 
 ### Changes between 3.1.0 and 3.1.1 [xx XXX xxxx]
 
+ * Fixed buffer overread in AES-XTS decryption on ARM 64 bit platforms which
+   happens if the buffer size is 4 mod 5. This can trigger a crash of an
+   application using AES-XTS decryption if the memory just after the buffer
+   being decrypted is not mapped.
+   Thanks to Anton Romanov (Amazon) for discovering the issue.
+   ([CVE-2023-1255])
+
+   *Nevine Ebeid*
+
  * Add FIPS provider configuration option to disallow the use of
    truncated digests with Hash and HMAC DRBGs (q.v. FIPS 140-3 IG D.R.).
    The option '-no_drbg_truncated_digests' can optionally be
@@ -19943,6 +19952,7 @@ ndif
 
 <!-- Links -->
 
+[CVE-2023-1255]: https://www.openssl.org/news/vulnerabilities.html#CVE-2023-1255
 [CVE-2023-0466]: https://www.openssl.org/news/vulnerabilities.html#CVE-2023-0466
 [CVE-2023-0465]: https://www.openssl.org/news/vulnerabilities.html#CVE-2023-0465
 [CVE-2023-0464]: https://www.openssl.org/news/vulnerabilities.html#CVE-2023-0464

--- a/NEWS.md
+++ b/NEWS.md
@@ -38,6 +38,8 @@ OpenSSL 3.1
 
 ### Major changes between OpenSSL 3.1.0 and OpenSSL 3.1.1 [under development]
 
+  * Fixed buffer overread in AES-XTS decryption on ARM 64 bit platforms
+    ([CVE-2023-1255])
   * Fixed documentation of X509_VERIFY_PARAM_add0_policy() ([CVE-2023-0466])
   * Fixed handling of invalid certificate policies in leaf certificates
     ([CVE-2023-0465])
@@ -1466,6 +1468,7 @@ OpenSSL 0.9.x
   * Support for various new platforms
 
 <!-- Links -->
+[CVE-2023-1255]: https://www.openssl.org/news/vulnerabilities.html#CVE-2023-1255
 [CVE-2023-0466]: https://www.openssl.org/news/vulnerabilities.html#CVE-2023-0466
 [CVE-2023-0465]: https://www.openssl.org/news/vulnerabilities.html#CVE-2023-0465
 [CVE-2023-0464]: https://www.openssl.org/news/vulnerabilities.html#CVE-2023-0464

--- a/crypto/aes/asm/aesv8-armx.pl
+++ b/crypto/aes/asm/aesv8-armx.pl
@@ -3367,7 +3367,7 @@ $code.=<<___	if ($flavour =~ /64/);
 .align	4
 .Lxts_dec_tail4x:
 	add	$inp,$inp,#16
-	vld1.32	{$dat0},[$inp],#16
+	tst	$tailcnt,#0xf
 	veor	$tmp1,$dat1,$tmp0
 	vst1.8	{$tmp1},[$out],#16
 	veor	$tmp2,$dat2,$tmp2
@@ -3376,6 +3376,8 @@ $code.=<<___	if ($flavour =~ /64/);
 	veor	$tmp4,$dat4,$tmp4
 	vst1.8	{$tmp3-$tmp4},[$out],#32
 
+	b.eq	.Lxts_dec_abort
+	vld1.32	{$dat0},[$inp],#16
 	b	.Lxts_done
 .align	4
 .Lxts_outer_dec_tail:


### PR DESCRIPTION
Original author: Nevine Ebeid (Amazon)
Fixes: CVE-2023-1255

The buffer overread happens on decrypts of 4 mod 5 sizes. Unless the memory just after the buffer is unmapped this is harmless.
