### PR TITLE
fips: setup the FIPS provider in pendantic mode for testing

### DIFF
--- a/test/helpers/ssl_test_ctx.c
+++ b/test/helpers/ssl_test_ctx.c
@@ -652,6 +652,9 @@ IMPLEMENT_SSL_TEST_BOOL_OPTION(SSL_TEST_CLIENT_CONF, client, enable_pha)
 IMPLEMENT_SSL_TEST_BOOL_OPTION(SSL_TEST_SERVER_CONF, server, force_pha)
 IMPLEMENT_SSL_TEST_BOOL_OPTION(SSL_TEST_CLIENT_CONF, client, no_extms_on_reneg)
 
+/* FIPS provider version limiting */
+IMPLEMENT_SSL_TEST_STRING_OPTION(SSL_TEST_CTX, test, fips_version)
+
 /* Known test options and their corresponding parse methods. */
 
 /* Top-level options. */
@@ -692,6 +695,7 @@ static const ssl_test_ctx_option ssl_test_ctx_options[] = {
     { "EnableServerSCTPLabelBug", &parse_test_enable_server_sctp_label_bug },
     { "ExpectedCipher", &parse_test_expected_cipher },
     { "ExpectedSessionTicketAppData", &parse_test_expected_session_ticket_app_data },
+    { "FIPSversion", &parse_test_fips_version },
 };
 
 /* Nested client options. */
@@ -781,6 +785,7 @@ void SSL_TEST_CTX_free(SSL_TEST_CTX *ctx)
     sk_X509_NAME_pop_free(ctx->expected_server_ca_names, X509_NAME_free);
     sk_X509_NAME_pop_free(ctx->expected_client_ca_names, X509_NAME_free);
     OPENSSL_free(ctx->expected_cipher);
+    OPENSSL_free(ctx->fips_version);
     OPENSSL_free(ctx);
 }
 

--- a/test/helpers/ssl_test_ctx.h
+++ b/test/helpers/ssl_test_ctx.h
@@ -231,6 +231,9 @@ typedef struct {
     char *expected_session_ticket_app_data;
 
     OSSL_LIB_CTX *libctx;
+
+    /* FIPS version string to check for compatibility */
+    char *fips_version;
 } SSL_TEST_CTX;
 
 const char *ssl_test_result_name(ssl_test_result_t result);

--- a/test/recipes/00-prep_fipsmodule_cnf.t
+++ b/test/recipes/00-prep_fipsmodule_cnf.t
@@ -30,7 +30,7 @@ my $fipsmoduleconf = bldtop_file('test', 'fipsmodule.cnf');
 plan tests => 1;
 
 # Create the $fipsmoduleconf file
-ok(run(app(['openssl', 'fipsinstall',
+ok(run(app(['openssl', 'fipsinstall', '-pedantic',
             '-module', $fipsmodule, '-provider_name', 'fips',
             '-section_name', 'fips_sect', '-out', $fipsmoduleconf])),
    "fips install");

--- a/test/recipes/30-test_evp_data/evpkdf_tls12_prf.txt
+++ b/test/recipes/30-test_evp_data/evpkdf_tls12_prf.txt
@@ -13,6 +13,7 @@
 
 Title = TLS12 PRF tests (from NIST test vectors)
 
+FIPSversion = <=3.1.0
 KDF = TLS1-PRF
 Ctrl.digest = digest:SHA256
 Ctrl.Secret = hexsecret:f8938ecc9edebc5030c0c6a441e213cd24e6f770a50dda07876f8d55da062bcadb386b411fd4fe4313a604fce6c17fbc
@@ -21,6 +22,7 @@ Ctrl.client_random = hexseed:36c129d01a3200894b9179faac589d9835d58775f9b5ea3587c
 Ctrl.server_random = hexseed:f6c9575ed7ddd73e1f7d16eca115415812a43c2b747daaaae043abfb50053fce
 Output = 202c88c00f84a17a20027079604787461176455539e705be730890602c289a5001e34eeb3a043e5d52a65e66125188bf
 
+FIPSversion = <=3.1.0
 KDF = TLS1-PRF
 Ctrl.digest = digest:SHA256
 Ctrl.Secret = hexsecret:202c88c00f84a17a20027079604787461176455539e705be730890602c289a5001e34eeb3a043e5d52a65e66125188bf
@@ -30,6 +32,7 @@ Ctrl.client_random = hexseed:62e1fd91f23f558a605f28478c58cf72637b89784d959df7e94
 Output = d06139889fffac1e3a71865f504aa5d0d2a2e89506c6f2279b670c3e1b74f531016a2530c51a3a0f7e1d6590d0f0566b2f387f8d11fd4f731cdd572d2eae927f6f2f81410b25e6960be68985add6c38445ad9f8c64bf8068bf9a6679485d966f1ad6f68b43495b10a683755ea2b858d70ccac7ec8b053c6bd41ca299d4e51928
 
 # As above but use long name for KDF
+FIPSversion = <=3.1.0
 KDF = tls1-prf
 Ctrl.digest = digest:SHA256
 Ctrl.Secret = hexsecret:202c88c00f84a17a20027079604787461176455539e705be730890602c289a5001e34eeb3a043e5d52a65e66125188bf

--- a/test/recipes/90-test_sslapi.t
+++ b/test/recipes/90-test_sslapi.t
@@ -19,7 +19,7 @@ use lib bldtop_dir('.');
 
 my $no_fips = disabled('fips') || ($ENV{NO_FIPS} // 0);
 my $fipsmodcfg_filename = "fipsmodule.cnf";
-my $fipsmodcfg = bldtop_file("providers", $fipsmodcfg_filename);
+my $fipsmodcfg = bldtop_file("test", $fipsmodcfg_filename);
 
 my $provconf = srctop_file("test", "fips-and-base.cnf");
 

--- a/test/ssl-tests/30-extended-master-secret.cnf
+++ b/test/ssl-tests/30-extended-master-secret.cnf
@@ -32,6 +32,7 @@ VerifyMode = Peer
 
 [test-0]
 ExpectedResult = Success
+FIPSversion = <=3.1.0
 
 
 # ===========================================================
@@ -57,6 +58,7 @@ VerifyMode = Peer
 
 [test-1]
 ExpectedResult = Success
+FIPSversion = <=3.1.0
 
 
 # ===========================================================
@@ -83,6 +85,7 @@ VerifyMode = Peer
 
 [test-2]
 ExpectedResult = Success
+FIPSversion = <=3.1.0
 
 
 # ===========================================================
@@ -122,6 +125,7 @@ VerifyMode = Peer
 
 [test-3]
 ExpectedResult = Success
+FIPSversion = <=3.1.0
 HandshakeMode = Resume
 
 
@@ -148,6 +152,7 @@ VerifyMode = Peer
 
 [test-4]
 ExpectedResult = Success
+FIPSversion = <=3.1.0
 
 
 # ===========================================================
@@ -173,6 +178,7 @@ VerifyMode = Peer
 
 [test-5]
 ExpectedResult = Success
+FIPSversion = <=3.1.0
 
 
 # ===========================================================
@@ -199,5 +205,6 @@ VerifyMode = Peer
 
 [test-6]
 ExpectedResult = Success
+FIPSversion = <=3.1.0
 
 

--- a/test/ssl-tests/30-extended-master-secret.cnf.in
+++ b/test/ssl-tests/30-extended-master-secret.cnf.in
@@ -27,6 +27,7 @@ my @tests_tls1_2 = (
         },
         test   => {
           "ExpectedResult" => "Success",
+          "FIPSversion" => "<=3.1.0",
         },
     },
     {
@@ -40,6 +41,7 @@ my @tests_tls1_2 = (
         },
         test   => {
           "ExpectedResult" => "Success",
+          "FIPSversion" => "<=3.1.0",
         },
     },
     {
@@ -54,6 +56,7 @@ my @tests_tls1_2 = (
         },
         test   => {
           "ExpectedResult" => "Success",
+          "FIPSversion" => "<=3.1.0",
         },
     },
     {
@@ -75,6 +78,7 @@ my @tests_tls1_2 = (
         test   => {
 	  "HandshakeMode" => "Resume",
           "ExpectedResult" => "Success",
+          "FIPSversion" => "<=3.1.0",
         },
     },
     {
@@ -88,6 +92,7 @@ my @tests_tls1_2 = (
         },
         test   => {
           "ExpectedResult" => "Success",
+          "FIPSversion" => "<=3.1.0",
         },
     },
     {
@@ -101,6 +106,7 @@ my @tests_tls1_2 = (
         },
         test   => {
           "ExpectedResult" => "Success",
+          "FIPSversion" => "<=3.1.0",
         },
     },
     {
@@ -115,6 +121,7 @@ my @tests_tls1_2 = (
         },
         test   => {
           "ExpectedResult" => "Success",
+          "FIPSversion" => "<=3.1.0",
         },
     },
 );

--- a/test/ssl_test.c
+++ b/test/ssl_test.c
@@ -409,6 +409,13 @@ static int test_handshake(int idx)
     if (!TEST_ptr(test_ctx))
         goto err;
 
+    /* Verify that the FIPS provider supports this test */
+    if (test_ctx->fips_version != NULL
+                && !fips_provider_version_match(libctx, test_ctx->fips_version)) {
+            ret = TEST_skip("FIPS provider unable to run this test");
+            goto err;
+    }
+
 #ifndef OPENSSL_NO_DTLS
     if (test_ctx->method == SSL_TEST_METHOD_DTLS) {
         server_ctx = SSL_CTX_new_ex(libctx, NULL, DTLS_server_method());

--- a/util/mk-fipsmodule-cnf.pl
+++ b/util/mk-fipsmodule-cnf.pl
@@ -8,9 +8,14 @@
 
 use Getopt::Long;
 
-my $activate = 1;
+# Module options for pedantic FIPS mode
+# self_test_onload happens if install_mac isn't included, don't add it below
 my $conditional_errors = 1;
 my $security_checks = 1;
+my $ems_check = 0;
+my $drgb_no_trunc_dgst = 0;
+
+my $activate = 1;
 my $mac_key;
 my $module_name;
 my $section_name = "fips_sect";
@@ -40,5 +45,7 @@ print <<_____;
 activate = $activate
 conditional-errors = $conditional_errors
 security-checks = $security_checks
+ems_check = $ems_check
+drgb_no_trunc_dgst = $drgb_no_trunc_dgst
 module-mac = $module_mac
 _____


### PR DESCRIPTION
Add options so that the FIPS provider is set to pedantic mode for testing purposes.

Kind of related to and branched from #20752 but not related to installation.

- [ ] documentation is added or updated
- [x] tests are added or updated
