### PR TITLE
Do not send the empty renegotiation info SCSV in QUIC

### DIFF
--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -747,8 +747,10 @@ SSL *ossl_ssl_connection_new_int(SSL_CTX *ctx, const SSL_METHOD *method)
 
     s->options = ctx->options;
     s->dane.flags = ctx->dane.flags;
-    s->min_proto_version = ctx->min_proto_version;
-    s->max_proto_version = ctx->max_proto_version;
+    if (method->version == ctx->method->version) {
+        s->min_proto_version = ctx->min_proto_version;
+        s->max_proto_version = ctx->max_proto_version;
+    }
     s->mode = ctx->mode;
     s->max_cert_list = ctx->max_cert_list;
     s->max_early_data = ctx->max_early_data;
@@ -2862,7 +2864,11 @@ long SSL_ctrl(SSL *s, int cmd, long larg, void *parg)
     long l;
     SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL(s);
 
-    /* TODO(QUIC): Special handling for some ctrls will be needed */
+    /*
+     * TODO(QUIC): Special handling for some ctrls will be needed
+     * For example SSL_CTRL_SET/GET_MIN/MAX_PROTO_VERSION should
+     * be handled within the QUIC connection, not the inner TLS.
+     */
     if (sc == NULL)
         return 0;
 

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -2864,11 +2864,7 @@ long SSL_ctrl(SSL *s, int cmd, long larg, void *parg)
     long l;
     SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL(s);
 
-    /*
-     * TODO(QUIC): Special handling for some ctrls will be needed
-     * For example SSL_CTRL_SET/GET_MIN/MAX_PROTO_VERSION should
-     * be handled within the QUIC connection, not the inner TLS.
-     */
+    /* TODO(QUIC): Special handling for some ctrls will be needed */
     if (sc == NULL)
         return 0;
 

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -4027,7 +4027,9 @@ int ssl_cipher_list_to_bytes(SSL_CONNECTION *s, STACK_OF(SSL_CIPHER) *sk,
 {
     int i;
     size_t totlen = 0, len, maxlen, maxverok = 0;
-    int empty_reneg_info_scsv = !s->renegotiate;
+    int empty_reneg_info_scsv = !s->renegotiate
+                                && (SSL_CONNECTION_IS_DTLS(s)
+                                    || s->min_proto_version < TLS1_3_VERSION);
     SSL *ssl = SSL_CONNECTION_GET_SSL(s);
 
     /* Set disabled masks for this session */


### PR DESCRIPTION
There is no point in sending that when min_proto_version is >= TLS1_3_VERSION. So we set that during SSL_CTX initialization and skip adding the SCSV.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
