### PR TITLE
QUIC Multi-Stream Single-Thread (MSST) Implementation

### DIFF
--- a/crypto/err/openssl.txt
+++ b/crypto/err/openssl.txt
@@ -1463,6 +1463,7 @@ SSL_R_NO_SHARED_CIPHER:193:no shared cipher
 SSL_R_NO_SHARED_GROUPS:410:no shared groups
 SSL_R_NO_SHARED_SIGNATURE_ALGORITHMS:376:no shared signature algorithms
 SSL_R_NO_SRTP_PROFILES:359:no srtp profiles
+SSL_R_NO_STREAM:355:no stream
 SSL_R_NO_SUITABLE_DIGEST_ALGORITHM:297:no suitable digest algorithm
 SSL_R_NO_SUITABLE_GROUPS:295:no suitable groups
 SSL_R_NO_SUITABLE_KEY_SHARE:101:no suitable key share

--- a/crypto/err/openssl.txt
+++ b/crypto/err/openssl.txt
@@ -1340,6 +1340,7 @@ SSL_R_COMPRESSION_ID_NOT_WITHIN_PRIVATE_RANGE:307:\
 	compression id not within private range
 SSL_R_COMPRESSION_LIBRARY_ERROR:142:compression library error
 SSL_R_CONNECTION_TYPE_NOT_SET:144:connection type not set
+SSL_R_CONN_USE_ONLY:356:conn use only
 SSL_R_CONTEXT_NOT_DANE_ENABLED:167:context not dane enabled
 SSL_R_COOKIE_GEN_CALLBACK_FAILURE:400:cookie gen callback failure
 SSL_R_COOKIE_MISMATCH:308:cookie mismatch

--- a/doc/build.info
+++ b/doc/build.info
@@ -2459,10 +2459,6 @@ DEPEND[html/man3/SSL_alloc_buffers.html]=man3/SSL_alloc_buffers.pod
 GENERATE[html/man3/SSL_alloc_buffers.html]=man3/SSL_alloc_buffers.pod
 DEPEND[man/man3/SSL_alloc_buffers.3]=man3/SSL_alloc_buffers.pod
 GENERATE[man/man3/SSL_alloc_buffers.3]=man3/SSL_alloc_buffers.pod
-DEPEND[html/man3/SSL_attach_stream.html]=man3/SSL_attach_stream.pod
-GENERATE[html/man3/SSL_attach_stream.html]=man3/SSL_attach_stream.pod
-DEPEND[man/man3/SSL_attach_stream.3]=man3/SSL_attach_stream.pod
-GENERATE[man/man3/SSL_attach_stream.3]=man3/SSL_attach_stream.pod
 DEPEND[html/man3/SSL_check_chain.html]=man3/SSL_check_chain.pod
 GENERATE[html/man3/SSL_check_chain.html]=man3/SSL_check_chain.pod
 DEPEND[man/man3/SSL_check_chain.3]=man3/SSL_check_chain.pod
@@ -2679,6 +2675,10 @@ DEPEND[html/man3/SSL_set_connect_state.html]=man3/SSL_set_connect_state.pod
 GENERATE[html/man3/SSL_set_connect_state.html]=man3/SSL_set_connect_state.pod
 DEPEND[man/man3/SSL_set_connect_state.3]=man3/SSL_set_connect_state.pod
 GENERATE[man/man3/SSL_set_connect_state.3]=man3/SSL_set_connect_state.pod
+DEPEND[html/man3/SSL_set_default_stream_mode.html]=man3/SSL_set_default_stream_mode.pod
+GENERATE[html/man3/SSL_set_default_stream_mode.html]=man3/SSL_set_default_stream_mode.pod
+DEPEND[man/man3/SSL_set_default_stream_mode.3]=man3/SSL_set_default_stream_mode.pod
+GENERATE[man/man3/SSL_set_default_stream_mode.3]=man3/SSL_set_default_stream_mode.pod
 DEPEND[html/man3/SSL_set_fd.html]=man3/SSL_set_fd.pod
 GENERATE[html/man3/SSL_set_fd.html]=man3/SSL_set_fd.pod
 DEPEND[man/man3/SSL_set_fd.3]=man3/SSL_set_fd.pod
@@ -3506,7 +3506,6 @@ html/man3/SSL_accept.html \
 html/man3/SSL_accept_stream.html \
 html/man3/SSL_alert_type_string.html \
 html/man3/SSL_alloc_buffers.html \
-html/man3/SSL_attach_stream.html \
 html/man3/SSL_check_chain.html \
 html/man3/SSL_clear.html \
 html/man3/SSL_connect.html \
@@ -3561,6 +3560,7 @@ html/man3/SSL_set_async_callback.html \
 html/man3/SSL_set_bio.html \
 html/man3/SSL_set_blocking_mode.html \
 html/man3/SSL_set_connect_state.html \
+html/man3/SSL_set_default_stream_mode.html \
 html/man3/SSL_set_fd.html \
 html/man3/SSL_set_incoming_stream_policy.html \
 html/man3/SSL_set_initial_peer_addr.html \
@@ -4141,7 +4141,6 @@ man/man3/SSL_accept.3 \
 man/man3/SSL_accept_stream.3 \
 man/man3/SSL_alert_type_string.3 \
 man/man3/SSL_alloc_buffers.3 \
-man/man3/SSL_attach_stream.3 \
 man/man3/SSL_check_chain.3 \
 man/man3/SSL_clear.3 \
 man/man3/SSL_connect.3 \
@@ -4196,6 +4195,7 @@ man/man3/SSL_set_async_callback.3 \
 man/man3/SSL_set_bio.3 \
 man/man3/SSL_set_blocking_mode.3 \
 man/man3/SSL_set_connect_state.3 \
+man/man3/SSL_set_default_stream_mode.3 \
 man/man3/SSL_set_fd.3 \
 man/man3/SSL_set_incoming_stream_policy.3 \
 man/man3/SSL_set_initial_peer_addr.3 \

--- a/doc/build.info
+++ b/doc/build.info
@@ -2447,6 +2447,10 @@ DEPEND[html/man3/SSL_accept.html]=man3/SSL_accept.pod
 GENERATE[html/man3/SSL_accept.html]=man3/SSL_accept.pod
 DEPEND[man/man3/SSL_accept.3]=man3/SSL_accept.pod
 GENERATE[man/man3/SSL_accept.3]=man3/SSL_accept.pod
+DEPEND[html/man3/SSL_accept_stream.html]=man3/SSL_accept_stream.pod
+GENERATE[html/man3/SSL_accept_stream.html]=man3/SSL_accept_stream.pod
+DEPEND[man/man3/SSL_accept_stream.3]=man3/SSL_accept_stream.pod
+GENERATE[man/man3/SSL_accept_stream.3]=man3/SSL_accept_stream.pod
 DEPEND[html/man3/SSL_alert_type_string.html]=man3/SSL_alert_type_string.pod
 GENERATE[html/man3/SSL_alert_type_string.html]=man3/SSL_alert_type_string.pod
 DEPEND[man/man3/SSL_alert_type_string.3]=man3/SSL_alert_type_string.pod
@@ -2455,6 +2459,10 @@ DEPEND[html/man3/SSL_alloc_buffers.html]=man3/SSL_alloc_buffers.pod
 GENERATE[html/man3/SSL_alloc_buffers.html]=man3/SSL_alloc_buffers.pod
 DEPEND[man/man3/SSL_alloc_buffers.3]=man3/SSL_alloc_buffers.pod
 GENERATE[man/man3/SSL_alloc_buffers.3]=man3/SSL_alloc_buffers.pod
+DEPEND[html/man3/SSL_attach_stream.html]=man3/SSL_attach_stream.pod
+GENERATE[html/man3/SSL_attach_stream.html]=man3/SSL_attach_stream.pod
+DEPEND[man/man3/SSL_attach_stream.3]=man3/SSL_attach_stream.pod
+GENERATE[man/man3/SSL_attach_stream.3]=man3/SSL_attach_stream.pod
 DEPEND[html/man3/SSL_check_chain.html]=man3/SSL_check_chain.pod
 GENERATE[html/man3/SSL_check_chain.html]=man3/SSL_check_chain.pod
 DEPEND[man/man3/SSL_check_chain.3]=man3/SSL_check_chain.pod
@@ -2483,6 +2491,10 @@ DEPEND[html/man3/SSL_free.html]=man3/SSL_free.pod
 GENERATE[html/man3/SSL_free.html]=man3/SSL_free.pod
 DEPEND[man/man3/SSL_free.3]=man3/SSL_free.pod
 GENERATE[man/man3/SSL_free.3]=man3/SSL_free.pod
+DEPEND[html/man3/SSL_get0_connection.html]=man3/SSL_get0_connection.pod
+GENERATE[html/man3/SSL_get0_connection.html]=man3/SSL_get0_connection.pod
+DEPEND[man/man3/SSL_get0_connection.3]=man3/SSL_get0_connection.pod
+GENERATE[man/man3/SSL_get0_connection.3]=man3/SSL_get0_connection.pod
 DEPEND[html/man3/SSL_get0_peer_rpk.html]=man3/SSL_get0_peer_rpk.pod
 GENERATE[html/man3/SSL_get0_peer_rpk.html]=man3/SSL_get0_peer_rpk.pod
 DEPEND[man/man3/SSL_get0_peer_rpk.3]=man3/SSL_get0_peer_rpk.pod
@@ -2511,6 +2523,10 @@ DEPEND[html/man3/SSL_get_client_random.html]=man3/SSL_get_client_random.pod
 GENERATE[html/man3/SSL_get_client_random.html]=man3/SSL_get_client_random.pod
 DEPEND[man/man3/SSL_get_client_random.3]=man3/SSL_get_client_random.pod
 GENERATE[man/man3/SSL_get_client_random.3]=man3/SSL_get_client_random.pod
+DEPEND[html/man3/SSL_get_conn_close_info.html]=man3/SSL_get_conn_close_info.pod
+GENERATE[html/man3/SSL_get_conn_close_info.html]=man3/SSL_get_conn_close_info.pod
+DEPEND[man/man3/SSL_get_conn_close_info.3]=man3/SSL_get_conn_close_info.pod
+GENERATE[man/man3/SSL_get_conn_close_info.3]=man3/SSL_get_conn_close_info.pod
 DEPEND[html/man3/SSL_get_current_cipher.html]=man3/SSL_get_current_cipher.pod
 GENERATE[html/man3/SSL_get_current_cipher.html]=man3/SSL_get_current_cipher.pod
 DEPEND[man/man3/SSL_get_current_cipher.3]=man3/SSL_get_current_cipher.pod
@@ -2567,6 +2583,14 @@ DEPEND[html/man3/SSL_get_shared_sigalgs.html]=man3/SSL_get_shared_sigalgs.pod
 GENERATE[html/man3/SSL_get_shared_sigalgs.html]=man3/SSL_get_shared_sigalgs.pod
 DEPEND[man/man3/SSL_get_shared_sigalgs.3]=man3/SSL_get_shared_sigalgs.pod
 GENERATE[man/man3/SSL_get_shared_sigalgs.3]=man3/SSL_get_shared_sigalgs.pod
+DEPEND[html/man3/SSL_get_stream_id.html]=man3/SSL_get_stream_id.pod
+GENERATE[html/man3/SSL_get_stream_id.html]=man3/SSL_get_stream_id.pod
+DEPEND[man/man3/SSL_get_stream_id.3]=man3/SSL_get_stream_id.pod
+GENERATE[man/man3/SSL_get_stream_id.3]=man3/SSL_get_stream_id.pod
+DEPEND[html/man3/SSL_get_stream_read_state.html]=man3/SSL_get_stream_read_state.pod
+GENERATE[html/man3/SSL_get_stream_read_state.html]=man3/SSL_get_stream_read_state.pod
+DEPEND[man/man3/SSL_get_stream_read_state.3]=man3/SSL_get_stream_read_state.pod
+GENERATE[man/man3/SSL_get_stream_read_state.3]=man3/SSL_get_stream_read_state.pod
 DEPEND[html/man3/SSL_get_tick_timeout.html]=man3/SSL_get_tick_timeout.pod
 GENERATE[html/man3/SSL_get_tick_timeout.html]=man3/SSL_get_tick_timeout.pod
 DEPEND[man/man3/SSL_get_tick_timeout.3]=man3/SSL_get_tick_timeout.pod
@@ -2607,6 +2631,10 @@ DEPEND[html/man3/SSL_new.html]=man3/SSL_new.pod
 GENERATE[html/man3/SSL_new.html]=man3/SSL_new.pod
 DEPEND[man/man3/SSL_new.3]=man3/SSL_new.pod
 GENERATE[man/man3/SSL_new.3]=man3/SSL_new.pod
+DEPEND[html/man3/SSL_new_stream.html]=man3/SSL_new_stream.pod
+GENERATE[html/man3/SSL_new_stream.html]=man3/SSL_new_stream.pod
+DEPEND[man/man3/SSL_new_stream.3]=man3/SSL_new_stream.pod
+GENERATE[man/man3/SSL_new_stream.3]=man3/SSL_new_stream.pod
 DEPEND[html/man3/SSL_pending.html]=man3/SSL_pending.pod
 GENERATE[html/man3/SSL_pending.html]=man3/SSL_pending.pod
 DEPEND[man/man3/SSL_pending.3]=man3/SSL_pending.pod
@@ -2655,6 +2683,10 @@ DEPEND[html/man3/SSL_set_fd.html]=man3/SSL_set_fd.pod
 GENERATE[html/man3/SSL_set_fd.html]=man3/SSL_set_fd.pod
 DEPEND[man/man3/SSL_set_fd.3]=man3/SSL_set_fd.pod
 GENERATE[man/man3/SSL_set_fd.3]=man3/SSL_set_fd.pod
+DEPEND[html/man3/SSL_set_incoming_stream_reject_policy.html]=man3/SSL_set_incoming_stream_reject_policy.pod
+GENERATE[html/man3/SSL_set_incoming_stream_reject_policy.html]=man3/SSL_set_incoming_stream_reject_policy.pod
+DEPEND[man/man3/SSL_set_incoming_stream_reject_policy.3]=man3/SSL_set_incoming_stream_reject_policy.pod
+GENERATE[man/man3/SSL_set_incoming_stream_reject_policy.3]=man3/SSL_set_incoming_stream_reject_policy.pod
 DEPEND[html/man3/SSL_set_initial_peer_addr.html]=man3/SSL_set_initial_peer_addr.pod
 GENERATE[html/man3/SSL_set_initial_peer_addr.html]=man3/SSL_set_initial_peer_addr.pod
 DEPEND[man/man3/SSL_set_initial_peer_addr.3]=man3/SSL_set_initial_peer_addr.pod
@@ -2687,6 +2719,10 @@ DEPEND[html/man3/SSL_stream_conclude.html]=man3/SSL_stream_conclude.pod
 GENERATE[html/man3/SSL_stream_conclude.html]=man3/SSL_stream_conclude.pod
 DEPEND[man/man3/SSL_stream_conclude.3]=man3/SSL_stream_conclude.pod
 GENERATE[man/man3/SSL_stream_conclude.3]=man3/SSL_stream_conclude.pod
+DEPEND[html/man3/SSL_stream_reset.html]=man3/SSL_stream_reset.pod
+GENERATE[html/man3/SSL_stream_reset.html]=man3/SSL_stream_reset.pod
+DEPEND[man/man3/SSL_stream_reset.3]=man3/SSL_stream_reset.pod
+GENERATE[man/man3/SSL_stream_reset.3]=man3/SSL_stream_reset.pod
 DEPEND[html/man3/SSL_tick.html]=man3/SSL_tick.pod
 GENERATE[html/man3/SSL_tick.html]=man3/SSL_tick.pod
 DEPEND[man/man3/SSL_tick.3]=man3/SSL_tick.pod
@@ -3467,8 +3503,10 @@ html/man3/SSL_SESSION_is_resumable.html \
 html/man3/SSL_SESSION_print.html \
 html/man3/SSL_SESSION_set1_id.html \
 html/man3/SSL_accept.html \
+html/man3/SSL_accept_stream.html \
 html/man3/SSL_alert_type_string.html \
 html/man3/SSL_alloc_buffers.html \
+html/man3/SSL_attach_stream.html \
 html/man3/SSL_check_chain.html \
 html/man3/SSL_clear.html \
 html/man3/SSL_connect.html \
@@ -3476,6 +3514,7 @@ html/man3/SSL_do_handshake.html \
 html/man3/SSL_export_keying_material.html \
 html/man3/SSL_extension_supported.html \
 html/man3/SSL_free.html \
+html/man3/SSL_get0_connection.html \
 html/man3/SSL_get0_peer_rpk.html \
 html/man3/SSL_get0_peer_scts.html \
 html/man3/SSL_get_SSL_CTX.html \
@@ -3483,6 +3522,7 @@ html/man3/SSL_get_all_async_fds.html \
 html/man3/SSL_get_certificate.html \
 html/man3/SSL_get_ciphers.html \
 html/man3/SSL_get_client_random.html \
+html/man3/SSL_get_conn_close_info.html \
 html/man3/SSL_get_current_cipher.html \
 html/man3/SSL_get_default_timeout.html \
 html/man3/SSL_get_error.html \
@@ -3497,6 +3537,8 @@ html/man3/SSL_get_rbio.html \
 html/man3/SSL_get_rpoll_descriptor.html \
 html/man3/SSL_get_session.html \
 html/man3/SSL_get_shared_sigalgs.html \
+html/man3/SSL_get_stream_id.html \
+html/man3/SSL_get_stream_read_state.html \
 html/man3/SSL_get_tick_timeout.html \
 html/man3/SSL_get_verify_result.html \
 html/man3/SSL_get_version.html \
@@ -3507,6 +3549,7 @@ html/man3/SSL_key_update.html \
 html/man3/SSL_library_init.html \
 html/man3/SSL_load_client_CA_file.html \
 html/man3/SSL_new.html \
+html/man3/SSL_new_stream.html \
 html/man3/SSL_pending.html \
 html/man3/SSL_read.html \
 html/man3/SSL_read_early_data.html \
@@ -3519,6 +3562,7 @@ html/man3/SSL_set_bio.html \
 html/man3/SSL_set_blocking_mode.html \
 html/man3/SSL_set_connect_state.html \
 html/man3/SSL_set_fd.html \
+html/man3/SSL_set_incoming_stream_reject_policy.html \
 html/man3/SSL_set_initial_peer_addr.html \
 html/man3/SSL_set_retry_verify.html \
 html/man3/SSL_set_session.html \
@@ -3527,6 +3571,7 @@ html/man3/SSL_set_verify_result.html \
 html/man3/SSL_shutdown.html \
 html/man3/SSL_state_string.html \
 html/man3/SSL_stream_conclude.html \
+html/man3/SSL_stream_reset.html \
 html/man3/SSL_tick.html \
 html/man3/SSL_want.html \
 html/man3/SSL_write.html \
@@ -4093,8 +4138,10 @@ man/man3/SSL_SESSION_is_resumable.3 \
 man/man3/SSL_SESSION_print.3 \
 man/man3/SSL_SESSION_set1_id.3 \
 man/man3/SSL_accept.3 \
+man/man3/SSL_accept_stream.3 \
 man/man3/SSL_alert_type_string.3 \
 man/man3/SSL_alloc_buffers.3 \
+man/man3/SSL_attach_stream.3 \
 man/man3/SSL_check_chain.3 \
 man/man3/SSL_clear.3 \
 man/man3/SSL_connect.3 \
@@ -4102,6 +4149,7 @@ man/man3/SSL_do_handshake.3 \
 man/man3/SSL_export_keying_material.3 \
 man/man3/SSL_extension_supported.3 \
 man/man3/SSL_free.3 \
+man/man3/SSL_get0_connection.3 \
 man/man3/SSL_get0_peer_rpk.3 \
 man/man3/SSL_get0_peer_scts.3 \
 man/man3/SSL_get_SSL_CTX.3 \
@@ -4109,6 +4157,7 @@ man/man3/SSL_get_all_async_fds.3 \
 man/man3/SSL_get_certificate.3 \
 man/man3/SSL_get_ciphers.3 \
 man/man3/SSL_get_client_random.3 \
+man/man3/SSL_get_conn_close_info.3 \
 man/man3/SSL_get_current_cipher.3 \
 man/man3/SSL_get_default_timeout.3 \
 man/man3/SSL_get_error.3 \
@@ -4123,6 +4172,8 @@ man/man3/SSL_get_rbio.3 \
 man/man3/SSL_get_rpoll_descriptor.3 \
 man/man3/SSL_get_session.3 \
 man/man3/SSL_get_shared_sigalgs.3 \
+man/man3/SSL_get_stream_id.3 \
+man/man3/SSL_get_stream_read_state.3 \
 man/man3/SSL_get_tick_timeout.3 \
 man/man3/SSL_get_verify_result.3 \
 man/man3/SSL_get_version.3 \
@@ -4133,6 +4184,7 @@ man/man3/SSL_key_update.3 \
 man/man3/SSL_library_init.3 \
 man/man3/SSL_load_client_CA_file.3 \
 man/man3/SSL_new.3 \
+man/man3/SSL_new_stream.3 \
 man/man3/SSL_pending.3 \
 man/man3/SSL_read.3 \
 man/man3/SSL_read_early_data.3 \
@@ -4145,6 +4197,7 @@ man/man3/SSL_set_bio.3 \
 man/man3/SSL_set_blocking_mode.3 \
 man/man3/SSL_set_connect_state.3 \
 man/man3/SSL_set_fd.3 \
+man/man3/SSL_set_incoming_stream_reject_policy.3 \
 man/man3/SSL_set_initial_peer_addr.3 \
 man/man3/SSL_set_retry_verify.3 \
 man/man3/SSL_set_session.3 \
@@ -4153,6 +4206,7 @@ man/man3/SSL_set_verify_result.3 \
 man/man3/SSL_shutdown.3 \
 man/man3/SSL_state_string.3 \
 man/man3/SSL_stream_conclude.3 \
+man/man3/SSL_stream_reset.3 \
 man/man3/SSL_tick.3 \
 man/man3/SSL_want.3 \
 man/man3/SSL_write.3 \

--- a/doc/build.info
+++ b/doc/build.info
@@ -2683,10 +2683,10 @@ DEPEND[html/man3/SSL_set_fd.html]=man3/SSL_set_fd.pod
 GENERATE[html/man3/SSL_set_fd.html]=man3/SSL_set_fd.pod
 DEPEND[man/man3/SSL_set_fd.3]=man3/SSL_set_fd.pod
 GENERATE[man/man3/SSL_set_fd.3]=man3/SSL_set_fd.pod
-DEPEND[html/man3/SSL_set_incoming_stream_reject_policy.html]=man3/SSL_set_incoming_stream_reject_policy.pod
-GENERATE[html/man3/SSL_set_incoming_stream_reject_policy.html]=man3/SSL_set_incoming_stream_reject_policy.pod
-DEPEND[man/man3/SSL_set_incoming_stream_reject_policy.3]=man3/SSL_set_incoming_stream_reject_policy.pod
-GENERATE[man/man3/SSL_set_incoming_stream_reject_policy.3]=man3/SSL_set_incoming_stream_reject_policy.pod
+DEPEND[html/man3/SSL_set_incoming_stream_policy.html]=man3/SSL_set_incoming_stream_policy.pod
+GENERATE[html/man3/SSL_set_incoming_stream_policy.html]=man3/SSL_set_incoming_stream_policy.pod
+DEPEND[man/man3/SSL_set_incoming_stream_policy.3]=man3/SSL_set_incoming_stream_policy.pod
+GENERATE[man/man3/SSL_set_incoming_stream_policy.3]=man3/SSL_set_incoming_stream_policy.pod
 DEPEND[html/man3/SSL_set_initial_peer_addr.html]=man3/SSL_set_initial_peer_addr.pod
 GENERATE[html/man3/SSL_set_initial_peer_addr.html]=man3/SSL_set_initial_peer_addr.pod
 DEPEND[man/man3/SSL_set_initial_peer_addr.3]=man3/SSL_set_initial_peer_addr.pod
@@ -3562,7 +3562,7 @@ html/man3/SSL_set_bio.html \
 html/man3/SSL_set_blocking_mode.html \
 html/man3/SSL_set_connect_state.html \
 html/man3/SSL_set_fd.html \
-html/man3/SSL_set_incoming_stream_reject_policy.html \
+html/man3/SSL_set_incoming_stream_policy.html \
 html/man3/SSL_set_initial_peer_addr.html \
 html/man3/SSL_set_retry_verify.html \
 html/man3/SSL_set_session.html \
@@ -4197,7 +4197,7 @@ man/man3/SSL_set_bio.3 \
 man/man3/SSL_set_blocking_mode.3 \
 man/man3/SSL_set_connect_state.3 \
 man/man3/SSL_set_fd.3 \
-man/man3/SSL_set_incoming_stream_reject_policy.3 \
+man/man3/SSL_set_incoming_stream_policy.3 \
 man/man3/SSL_set_initial_peer_addr.3 \
 man/man3/SSL_set_retry_verify.3 \
 man/man3/SSL_set_session.3 \

--- a/doc/man3/SSL_accept_stream.pod
+++ b/doc/man3/SSL_accept_stream.pod
@@ -27,9 +27,7 @@ function may still return NULL in blocking mode, for example if the underlying
 connection is terminated.
 
 The caller is responsible for managing the lifetime of the returned QUIC stream
-SSL object. The lifespan of the parent QUIC connection SSL object must exceed
-that of the QUIC stream SSL object; that is, the stream object must be freed
-first, using L<SSL_free(3)>.
+SSL object; for more information, see L<SSL_free(3)>.
 
 This function will block if the QUIC connection SSL object is configured in
 blocking mode (see L<SSL_set_blocking_mode(3)>), but this may be bypassed by

--- a/doc/man3/SSL_accept_stream.pod
+++ b/doc/man3/SSL_accept_stream.pod
@@ -44,8 +44,8 @@ TODO(QUIC): Revise in MSMT PR to mention threading considerations.
 =end comment
 
 Depending on whether default stream functionality is being used, it may be
-necessary to explicitly configure the incoming stream rejection policy before
-streams can be accepted; see L<SSL_set_incoming_stream_reject_policy(3)>.
+necessary to explicitly configure the incoming stream policy before streams can
+be accepted; see L<SSL_set_incoming_stream_policy(3)>.
 
 =begin comment
 

--- a/doc/man3/SSL_accept_stream.pod
+++ b/doc/man3/SSL_accept_stream.pod
@@ -31,7 +31,7 @@ SSL object; for more information, see L<SSL_free(3)>.
 
 This function will block if the QUIC connection SSL object is configured in
 blocking mode (see L<SSL_set_blocking_mode(3)>), but this may be bypassed by
-passing the flag B<SSL_ACCEPT_STREAM_NO_BLOCK> in B<flags>. If this flag is set,
+passing the flag B<SSL_ACCEPT_STREAM_NO_BLOCK> in I<flags>. If this flag is set,
 this function never blocks.
 
 SSL_get_accept_stream_queue_len() returns the number of incoming streams
@@ -59,6 +59,7 @@ man(7) pages are merged
 SSL_accept_stream() returns a newly allocated QUIC stream SSL object, or NULL if
 no new incoming streams are available, or if the connection has been terminated,
 or if called on a SSL object other than a QUIC connection SSL object.
+L<SSL_get_error(3)> can be used to obtain further information in this case.
 
 SSL_get_accept_stream_queue_len() returns the number of incoming streams
 currently waiting in the accept queue, or 0 if called on a SSL object other than

--- a/doc/man3/SSL_accept_stream.pod
+++ b/doc/man3/SSL_accept_stream.pod
@@ -1,0 +1,74 @@
+=pod
+
+=head1 NAME
+
+SSL_accept_stream, SSL_get_accept_stream_queue_len, SSL_ACCEPT_STREAM_NO_BLOCK -
+accept an incoming QUIC stream from a QUIC peer
+
+=head1 SYNOPSIS
+
+ #include <openssl/ssl.h>
+
+ #define SSL_ACCEPT_STREAM_NO_BLOCK
+
+ SSL *SSL_accept_stream(SSL *ssl, uint64_t flags);
+
+ size_t SSL_get_accept_stream_queue_len(SSL *ssl);
+
+=head1 DESCRIPTION
+
+The SSL_accept_stream() function attempts to dequeue an incoming stream from the
+given QUIC connection SSL object and returns the newly allocated QUIC stream SSL
+object.
+
+If the queue of incoming streams is empty, this function returns NULL (in
+nonblocking mode) or waits for an incoming stream (in blocking mode). This
+function may still return NULL in blocking mode, for example if the underlying
+connection is terminated.
+
+The caller is responsible for managing the lifetime of the returned QUIC stream
+SSL object. The lifespan of the parent QUIC connection SSL object must exceed
+that of the QUIC stream SSL object; that is, the stream object must be freed
+first, using L<SSL_free(3)>.
+
+This function will block if the QUIC connection SSL object is configured in
+blocking mode (see L<SSL_set_blocking_mode(3)>), but this may be bypassed by
+passing the flag B<SSL_ACCEPT_STREAM_NO_BLOCK> in B<flags>. If this flag is set,
+this function never blocks.
+
+SSL_accept_stream_queue_len() returns the number of incoming streams currently
+waiting in the accept queue. It is intended for informational use only, as this
+number may change between a call to it and a subsequent call to
+SSL_accept_stream(), due to SSL_accept_stream() calls by other threads.
+
+Depending on whether default stream functionality is being used, it may be
+necessary to explicitly configure the incoming stream rejection policy before
+streams can be accepted; see L<SSL_set_incoming_stream_reject_policy(3)>.
+
+=head1 RETURN VALUES
+
+SSL_accept_stream() returns a newly allocated QUIC stream SSL object, or NULL if
+no new incoming streams are available, or if the connection has been terminated.
+
+SSL_get_accept_stream_queue_len() returns the number of incoming streams
+currently waiting in the accept queue.
+
+=head1 SEE ALSO
+
+L<SSL_new_stream(3)>, L<SSL_set_blocking_mode(3)>, L<SSL_free(3)>
+
+=head1 HISTORY
+
+SSL_accept_stream() and SSL_get_accept_stream_queue_len() were added in OpenSSL
+3.2.
+
+=head1 COPYRIGHT
+
+Copyright 2002-2023 The OpenSSL Project Authors. All Rights Reserved.
+
+Licensed under the Apache License 2.0 (the "License").  You may not use
+this file except in compliance with the License.  You can obtain a copy
+in the file LICENSE in the source distribution or at
+L<https://www.openssl.org/source/license.html>.
+
+=cut

--- a/doc/man3/SSL_accept_stream.pod
+++ b/doc/man3/SSL_accept_stream.pod
@@ -36,22 +36,35 @@ blocking mode (see L<SSL_set_blocking_mode(3)>), but this may be bypassed by
 passing the flag B<SSL_ACCEPT_STREAM_NO_BLOCK> in B<flags>. If this flag is set,
 this function never blocks.
 
-SSL_accept_stream_queue_len() returns the number of incoming streams currently
-waiting in the accept queue. It is intended for informational use only, as this
-number may change between a call to it and a subsequent call to
-SSL_accept_stream(), due to SSL_accept_stream() calls by other threads.
+SSL_get_accept_stream_queue_len() returns the number of incoming streams
+currently waiting in the accept queue.
+
+=begin comment
+
+TODO(QUIC): Revise in MSMT PR to mention threading considerations.
+
+=end comment
 
 Depending on whether default stream functionality is being used, it may be
 necessary to explicitly configure the incoming stream rejection policy before
 streams can be accepted; see L<SSL_set_incoming_stream_reject_policy(3)>.
 
+=begin comment
+
+TODO(QUIC): Update the above to refer to default stream man(7) page once
+man(7) pages are merged
+
+=end comment
+
 =head1 RETURN VALUES
 
 SSL_accept_stream() returns a newly allocated QUIC stream SSL object, or NULL if
-no new incoming streams are available, or if the connection has been terminated.
+no new incoming streams are available, or if the connection has been terminated,
+or if called on a SSL object other than a QUIC connection SSL object.
 
 SSL_get_accept_stream_queue_len() returns the number of incoming streams
-currently waiting in the accept queue.
+currently waiting in the accept queue, or 0 if called on a SSL object other than
+a QUIC connection SSL object.
 
 =head1 SEE ALSO
 

--- a/doc/man3/SSL_attach_stream.pod
+++ b/doc/man3/SSL_attach_stream.pod
@@ -1,0 +1,160 @@
+=pod
+
+=head1 NAME
+
+SSL_attach_stream, SSL_detach_stream, SSL_set_default_stream_mode,
+SSL_DEFAULT_STREAM_MODE_NONE, SSL_DEFAULT_STREAM_MODE_AUTO_BIDI,
+SSL_DEFAULT_STREAM_MODE_AUTO_UNI - manage the default stream for a QUIC
+connection
+
+=head1 SYNOPSIS
+
+ #include <openssl/ssl.h>
+
+ int SSL_attach_stream(SSL *conn, SSL *stream);
+ SSL *SSL_detach_stream(SSL *conn);
+
+ #define SSL_DEFAULT_STREAM_MODE_NONE
+ #define SSL_DEFAULT_STREAM_MODE_AUTO_BIDI
+ #define SSL_DEFAULT_STREAM_MODE_AUTO_UNI
+
+ int SSL_set_default_stream_mode(SSL *conn, uint32_t mode);
+
+=head1 DESCRIPTION
+
+A QUIC connection SSL object may have a default stream attached to it. A default
+stream is a QUIC stream to which calls to L<SSL_read(3)> and L<SSL_write(3)>
+made on a QUIC connection SSL object are redirected. Default stream handling
+allows legacy applications to use QUIC similarly to a traditional TLS
+connection.
+
+When not disabled, a default stream is automatically created on an outgoing
+connection once L<SSL_read(3)> or L<SSL_write(3)> is called.
+
+A QUIC stream must be explicitly designated as client-initiated or
+server-initiated up front. This broadly corresponds to whether an application
+protocol involves the client transmitting first, or the server transmitting
+first. As such, if L<SSL_read(3)> is called first (before any call to
+L<SSL_write(3)>)  after establishing a connection, OpenSSL will wait for the
+server to open the first server-initiated stream, and then bind this as the
+default stream. Conversely, if L<SSL_write(3)> is called before any call to
+L<SSL_read(3)>, OpenSSL assumes the client wishes to transmit first, creates a
+client-initiated stream, and binds this as the default stream.
+
+By default, the default stream created is bidirectional. If a unidirectional
+stream is desired, or if the application wishes to disable default stream
+functionality, SSL_set_default_stream_mode() (discussed below) can be used to
+accomplish this.
+
+If a default stream is currently bound to a QUIC connection SSL object, it can
+be detached from that QUIC connection SSL object and used explicitly by calling
+SSL_detach_stream(), which detaches the default stream and returns it as an
+explicit QUIC stream SSL object.
+
+Once detached, the caller is responsible for managing the lifetime of the QUIC
+stream SSL object and must free it by calling L<SSL_free(3)>. The lifetime of a
+QUIC connection SSL object must exceed that of any subsidiary QUIC stream SSL
+objects; in other words, QUIC stream SSL objects must be freed before the parent
+QUIC connection SSL object is freed.
+
+When a QUIC connection SSL object has no default stream currently associated
+with it, for example because the default stream was detached or because default
+stream functionality was disabled, calls to functions which require a stream on
+the QUIC connection SSL object will fail.
+
+The act of detaching a stream from a QUIC connection SSL object can be reversed
+by calling SSL_attach_stream(). This can also be used to designate a stream
+obtained via L<SSL_new_stream(3)> or L<SSL_accept_stream(3)> as the default
+stream. SSL_attach_stream() cannot be used if there is already a default stream
+associated with the QUIC connection SSL object; therefore, you may need to call
+SSL_detach_stream() first.
+
+It is recommended that new applications and applications which rely on multiple
+streams forego use of the default stream functionality, which is intended for
+legacy applications.
+
+SSL_set_default_stream_mode() can be used to configure or disable default stream
+handling. It can only be called on a QUIC connection SSL object prior to any
+default stream being created. If used, it is recommended to call it immediately
+after calling L<SSL_new(3)>, prior to initiating a connection. The argument
+B<mode> may be one of the following options:
+
+=over 4
+
+=item SSL_DEFAULT_STREAM_MODE_AUTO_BIDI
+
+This is the default setting. If L<SSL_write(3)> is called prior to any call to
+L<SSL_read(3)>, a bidirectional client-initiated stream is created and bound as
+the default stream. If L<SSL_read(3)> is called prior to any call to
+L<SSL_write(3)>, OpenSSL waits for an incoming stream from the peer (causing
+L<SSL_read(3)> to block if the connection is in blocking mode), and then binds
+that stream as the default stream. Note that this incoming stream may be either
+bidirectional or unidirectional; thus, this setting does not guarantee presence
+of a bidirectional stream when L<SSL_read(3)> is called first. To determine the
+type of a stream after a call to L<SSL_read(3)>, use L<SSL_get_stream_type(3)>.
+
+=item SSL_DEFAULT_STREAM_MODE_AUTO_UNI
+
+In this mode, if L<SSL_write(3)> is called prior to any call to L<SSL_read(3)>,
+a unidirectional client-initiated stream is created and bound as the default
+stream. The behaviour is otherwise identical to that of
+B<SSL_DEFAULT_STREAM_MODE_AUTO_BIDI>. The behaviour when L<SSL_read(3)> is
+called prior to any call to L<SSL_write(3)> is unchanged.
+
+=item SSL_DEFAULT_STREAM_MODE_NONE
+
+Default stream creation is inhibited. This is the recommended mode of operation.
+L<SSL_read(3)> and L<SSL_write(3)> calls cannot be made on the QUIC connection
+SSL object directly. You must obtain streams using L<SSL_new_stream(3)> or
+L<SSL_accept_stream(3)> in order to communicate with the peer.
+
+It is still possible to explicitly attach a stream as the default stream using
+SSL_attach_stream().
+
+=back
+
+A default stream will not be automatically created on a QUIC connection SSL
+object if the default stream mode is set to B<SSL_DEFAULT_STREAM_MODE_NONE>, or
+if the QUIC connection SSL object previously had a default stream which was
+detached using SSL_detach_stream().
+
+L<SSL_set_incoming_stream_reject_policy(3)> interacts significantly with the
+default stream functionality.
+
+=head1 RETURN VALUES
+
+SSL_detach_stream() returns a QUIC stream SSL object, or NULL if there is no
+default stream currently attached.
+
+SSL_attach_stream() returns 1 on success and 0 on failure.
+
+SSL_attach_stream() fails if a default stream is already attached to the QUIC
+connection SSL object.
+
+SSL_set_default_stream_mode() returns 1 on success and 0 on failure.
+
+SSL_set_default_stream_mode() fails if it is called after a default stream has
+already been established.
+
+These functions fail if called on a QUIC stream SSL object or on a non-QUIC SSL
+object.
+
+=head1 SEE ALSO
+
+L<SSL_new_stream(3)>, L<SSL_accept_stream(3)>, L<SSL_free(3)>,
+L<SSL_set_incoming_stream_reject_policy(3)>
+
+=head1 HISTORY
+
+These functions were added in OpenSSL 3.2.
+
+=head1 COPYRIGHT
+
+Copyright 2002-2023 The OpenSSL Project Authors. All Rights Reserved.
+
+Licensed under the Apache License 2.0 (the "License").  You may not use
+this file except in compliance with the License.  You can obtain a copy
+in the file LICENSE in the source distribution or at
+L<https://www.openssl.org/source/license.html>.
+
+=cut

--- a/doc/man3/SSL_attach_stream.pod
+++ b/doc/man3/SSL_attach_stream.pod
@@ -129,8 +129,8 @@ object if the default stream mode is set to B<SSL_DEFAULT_STREAM_MODE_NONE>, or
 if the QUIC connection SSL object previously had a default stream which was
 detached using SSL_detach_stream().
 
-L<SSL_set_incoming_stream_reject_policy(3)> interacts significantly with the
-default stream functionality.
+L<SSL_set_incoming_stream_policy(3)> interacts significantly with the default
+stream functionality.
 
 =head1 RETURN VALUES
 
@@ -153,7 +153,7 @@ object.
 =head1 SEE ALSO
 
 L<SSL_new_stream(3)>, L<SSL_accept_stream(3)>, L<SSL_free(3)>,
-L<SSL_set_incoming_stream_reject_policy(3)>
+L<SSL_set_incoming_stream_policy(3)>
 
 =head1 HISTORY
 

--- a/doc/man3/SSL_attach_stream.pod
+++ b/doc/man3/SSL_attach_stream.pod
@@ -52,10 +52,10 @@ SSL_detach_stream(), which detaches the default stream and returns it as an
 explicit QUIC stream SSL object.
 
 Once detached, the caller is responsible for managing the lifetime of the QUIC
-stream SSL object and must free it by calling L<SSL_free(3)>. The lifetime of a
-QUIC connection SSL object must exceed that of any subsidiary QUIC stream SSL
-objects; in other words, QUIC stream SSL objects must be freed before the parent
-QUIC connection SSL object is freed.
+stream SSL object and must free it by calling L<SSL_free(3)>. A QUIC stream SSL
+object maintains a reference to a QUIC connection SSL object, therefore a QUIC
+connection SSL object and its child stream objects may be freed in either order;
+for details, see L<SSL_free(3)>.
 
 When a QUIC connection SSL object has no default stream currently associated
 with it, for example because the default stream was detached or because default
@@ -75,7 +75,9 @@ SSL_attach_stream(), the QUIC connection SSL object becomes responsible for
 managing its lifetime. Calling SSL_free() on the QUIC connection SSL object will
 free the stream automatically. Moreover, once the call to SSL_attach_stream()
 succeeds, the application must make no further use of the QUIC stream SSL object
-pointer that it passed to SSL_attach_stream().
+pointer that it passed to SSL_attach_stream(). An application must not call
+SSL_attach_stream() with a QUIC stream SSL object that has more than one
+reference to it.
 
 It is recommended that new applications and applications which rely on multiple
 streams forego use of the default stream functionality, which is intended for

--- a/doc/man3/SSL_attach_stream.pod
+++ b/doc/man3/SSL_attach_stream.pod
@@ -60,7 +60,8 @@ QUIC connection SSL object is freed.
 When a QUIC connection SSL object has no default stream currently associated
 with it, for example because the default stream was detached or because default
 stream functionality was disabled, calls to functions which require a stream on
-the QUIC connection SSL object will fail.
+the QUIC connection SSL object (for example, L<SSL_read(3)> and L<SSL_write(3)>)
+will fail.
 
 The act of detaching a stream from a QUIC connection SSL object can be reversed
 by calling SSL_attach_stream(). This can also be used to designate a stream
@@ -68,6 +69,13 @@ obtained via L<SSL_new_stream(3)> or L<SSL_accept_stream(3)> as the default
 stream. SSL_attach_stream() cannot be used if there is already a default stream
 associated with the QUIC connection SSL object; therefore, you may need to call
 SSL_detach_stream() first.
+
+If a stream is successfully attached to a QUIC connection SSL object using
+SSL_attach_stream(), the QUIC connection SSL object becomes responsible for
+managing its lifetime. Calling SSL_free() on the QUIC connection SSL object will
+free the stream automatically. Moreover, once the call to SSL_attach_stream()
+succeeds, the application must make no further use of the QUIC stream SSL object
+pointer that it passed to SSL_attach_stream().
 
 It is recommended that new applications and applications which rely on multiple
 streams forego use of the default stream functionality, which is intended for
@@ -89,9 +97,10 @@ the default stream. If L<SSL_read(3)> is called prior to any call to
 L<SSL_write(3)>, OpenSSL waits for an incoming stream from the peer (causing
 L<SSL_read(3)> to block if the connection is in blocking mode), and then binds
 that stream as the default stream. Note that this incoming stream may be either
-bidirectional or unidirectional; thus, this setting does not guarantee presence
-of a bidirectional stream when L<SSL_read(3)> is called first. To determine the
-type of a stream after a call to L<SSL_read(3)>, use L<SSL_get_stream_type(3)>.
+bidirectional or unidirectional; thus, this setting does not guarantee the
+presence of a bidirectional stream when L<SSL_read(3)> is called first. To
+determine the type of a stream after a call to L<SSL_read(3)>, use
+L<SSL_get_stream_type(3)>.
 
 =item SSL_DEFAULT_STREAM_MODE_AUTO_UNI
 

--- a/doc/man3/SSL_attach_stream.pod
+++ b/doc/man3/SSL_attach_stream.pod
@@ -87,7 +87,7 @@ SSL_set_default_stream_mode() can be used to configure or disable default stream
 handling. It can only be called on a QUIC connection SSL object prior to any
 default stream being created. If used, it is recommended to call it immediately
 after calling L<SSL_new(3)>, prior to initiating a connection. The argument
-B<mode> may be one of the following options:
+I<mode> may be one of the following options:
 
 =over 4
 

--- a/doc/man3/SSL_free.pod
+++ b/doc/man3/SSL_free.pod
@@ -34,6 +34,34 @@ and L<SSL_set_shutdown(3)> was not used to set the
 SSL_SENT_SHUTDOWN state, the session will also be removed
 from the session cache as required by RFC2246.
 
+When used to free a QUIC stream SSL object, the respective sending and receiving
+parts of the stream are reset unless those parts have already been concluded
+normally:
+
+=over 4
+
+=item
+
+If the stream has a sending part (in other words, if it is bidirectional or a
+locally-initiated unidirectional stream) and that part has not been concluded
+via a call to L<SSL_stream_conclude(3)> or L<SSL_stream_reset(3)> on the QUIC
+stream SSL object, a call to SSL_free() automatically resets the sending part of
+the stream as though L<SSL_stream_reset(3)> were called with a QUIC application
+error code of 0.
+
+=item
+
+If the stream has a receiving part (in other words, if it is bidirectional or a
+remotely-initiated unidirectional stream), and the peer has not yet concluded
+that part of the stream normally (such as via a call to
+L<SSL_stream_conclude(3)> on its own end), a call to SSL_free() automatically
+requests the reset of the receiving part of the stream using a QUIC STOP_SENDING
+frame with a QUIC application error code of 0. Note that as per the QUIC
+protocol, this will automatically cause the peer to reset that part of the
+stream in turn (which is its sending part).
+
+=back
+
 =head1 RETURN VALUES
 
 SSL_free() does not provide diagnostic information.

--- a/doc/man3/SSL_free.pod
+++ b/doc/man3/SSL_free.pod
@@ -62,6 +62,10 @@ stream in turn (which is its sending part).
 
 =back
 
+A QUIC stream SSL object maintains a reference to a QUIC connection SSL object
+internally, therefore a QUIC stream SSL object and its parent QUIC connection
+SSL object can be freed in either order.
+
 =head1 RETURN VALUES
 
 SSL_free() does not provide diagnostic information.

--- a/doc/man3/SSL_get0_connection.pod
+++ b/doc/man3/SSL_get0_connection.pod
@@ -1,0 +1,54 @@
+=pod
+
+=head1 NAME
+
+SSL_get0_connection, SSL_is_connection - get a QUIC connection SSL object from a
+QUIC stream SSL object
+
+=head1 SYNOPSIS
+
+ #include <openssl/ssl.h>
+
+ SSL *SSL_get0_connection(SSL *ssl);
+ int SSL_is_connection(SSL *ssl);
+
+=head1 DESCRIPTION
+
+The SSL_get0_connection() function, when called on a QUIC stream SSL object,
+returns the QUIC connection SSL object which the QUIC stream SSL object belongs
+to.
+
+When called on a QUIC connection SSL object, it returns the same object.
+
+When called on a non-QUIC object, it returns the same object it was passed.
+
+SSL_is_connection() returns 1 for QUIC connection SSL objects and for non-QUIC
+SSL objects, but returns 0 for QUIC stream SSL objects.
+
+=head1 RETURN VALUES
+
+SSL_get0_connection() returns the QUIC connection SSL object (for a QUIC stream
+SSL object) and otherwise returns the same SSL object passed. It always returns
+non-NULL.
+
+SSL_is_connection() returns 1 if the SSL object is not a QUIC stream SSL object
+and 0 otherwise.
+
+=head1 SEE ALSO
+
+L<SSL_new(3)>, L<SSL_new_stream(3)>, L<SSL_accept_stream(3)>
+
+=head1 HISTORY
+
+These functions were added in OpenSSL 3.2.
+
+=head1 COPYRIGHT
+
+Copyright 2002-2023 The OpenSSL Project Authors. All Rights Reserved.
+
+Licensed under the Apache License 2.0 (the "License").  You may not use
+this file except in compliance with the License.  You can obtain a copy
+in the file LICENSE in the source distribution or at
+L<https://www.openssl.org/source/license.html>.
+
+=cut

--- a/doc/man3/SSL_get_conn_close_info.pod
+++ b/doc/man3/SSL_get_conn_close_info.pod
@@ -12,8 +12,8 @@ SSL_get_conn_close_info - get information about why a QUIC connection was closed
      uint64_t error_code;
      char     *reason;
      size_t   reason_len;
-     char     is_local;
-     char     is_transport;
+     int      is_local;
+     int      is_transport;
  } SSL_CONN_CLOSE_INFO;
 
  int SSL_get_conn_close_info(SSL *ssl, SSL_CONN_CLOSE_INFO *info,

--- a/doc/man3/SSL_get_conn_close_info.pod
+++ b/doc/man3/SSL_get_conn_close_info.pod
@@ -1,0 +1,93 @@
+=pod
+
+=head1 NAME
+
+SSL_get_conn_close_info - get information about why a QUIC connection was closed
+
+=head1 SYNOPSIS
+
+ #include <openssl/ssl.h>
+
+ typedef struct ssl_conn_close_info_st {
+     uint64_t error_code;
+     char     *reason;
+     size_t   reason_len;
+     char     is_local;
+     char     is_transport;
+ } SSL_CONN_CLOSE_INFO;
+
+ int SSL_get_conn_close_info(SSL *ssl, SSL_CONN_CLOSE_INFO *info,
+                             size_t info_len);
+
+=head1 DESCRIPTION
+
+The SSL_get_conn_close_info() function provides information about why and how a
+QUIC connection was closed.
+
+Connection closure information is written to B<*info>, which must be non-NULL.
+B<info_len> must be set to B<sizeof(*info)>.
+
+The following fields are set:
+
+=over 4
+
+=item B<error_code>
+
+This is a 62-bit QUIC error code. It is either a 62-bit application error code
+(if B<is_transport> is 0) or a  62-bit standard QUIC transport error code (if
+B<is_transport> is 1).
+
+=item B<reason>
+
+If non-NULL, this is intended to be a UTF-8 textual string briefly describing
+the reason for connection closure. The length of the reason string in bytes is
+given in B<reason_len>. While, if non-NULL, OpenSSL guarantees that this string
+will be zero terminated, consider that this buffer may originate from the
+(untrusted) peer and thus may also contain zero bytes elsewhere. Therefore, use
+of B<reason_len> is recommended.
+
+While it is intended as per the QUIC protocol that this be a UTF-8 string, there
+is no guarantee that this is the case for strings received from the peer.
+
+=item B<is_local>
+
+If 1, connection closure was locally triggered. This could be due to an
+application request (e.g. if B<is_transport> is 0), or (if B<is_transport> is 1)
+due to logic internal to the QUIC implementation (for example, if the peer
+engages in a protocol violation, or an idle timeout occurs).
+
+If 0, connection closure was remotely triggered.
+
+=item B<is_transport>
+
+If 1, connection closure was triggered for QUIC protocol reasons.
+
+If 0, connection closure was triggered by the local or remote application.
+
+=back
+
+=head1 RETURN VALUES
+
+SSL_get_conn_close_info() returns 1 on success and 0 on failure. This function
+fails if called on a QUIC connection SSL object which has not yet been
+terminated. It also fails if called on a QUIC stream SSL object or a non-QUIC
+SSL object.
+
+=head1 SEE ALSO
+
+L<SSL_shutdown_ex(3)>
+
+=head1 HISTORY
+
+This function was added in OpenSSL 3.2.
+
+=head1 COPYRIGHT
+
+Copyright 2002-2023 The OpenSSL Project Authors. All Rights Reserved.
+
+Licensed under the Apache License 2.0 (the "License").  You may not use
+this file except in compliance with the License.  You can obtain a copy
+in the file LICENSE in the source distribution or at
+L<https://www.openssl.org/source/license.html>.
+
+=cut

--- a/doc/man3/SSL_get_conn_close_info.pod
+++ b/doc/man3/SSL_get_conn_close_info.pod
@@ -24,41 +24,41 @@ SSL_get_conn_close_info - get information about why a QUIC connection was closed
 The SSL_get_conn_close_info() function provides information about why and how a
 QUIC connection was closed.
 
-Connection closure information is written to B<*info>, which must be non-NULL.
-B<info_len> must be set to B<sizeof(*info)>.
+Connection closure information is written to I<*info>, which must be non-NULL.
+I<info_len> must be set to C<sizeof(*info)>.
 
 The following fields are set:
 
 =over 4
 
-=item B<error_code>
+=item I<error_code>
 
 This is a 62-bit QUIC error code. It is either a 62-bit application error code
-(if B<is_transport> is 0) or a  62-bit standard QUIC transport error code (if
-B<is_transport> is 1).
+(if I<is_transport> is 0) or a  62-bit standard QUIC transport error code (if
+I<is_transport> is 1).
 
-=item B<reason>
+=item I<reason>
 
 If non-NULL, this is intended to be a UTF-8 textual string briefly describing
 the reason for connection closure. The length of the reason string in bytes is
-given in B<reason_len>. While, if non-NULL, OpenSSL guarantees that this string
+given in I<reason_len>. While, if non-NULL, OpenSSL guarantees that this string
 will be zero terminated, consider that this buffer may originate from the
 (untrusted) peer and thus may also contain zero bytes elsewhere. Therefore, use
-of B<reason_len> is recommended.
+of I<reason_len> is recommended.
 
 While it is intended as per the QUIC protocol that this be a UTF-8 string, there
 is no guarantee that this is the case for strings received from the peer.
 
-=item B<is_local>
+=item I<is_local>
 
 If 1, connection closure was locally triggered. This could be due to an
-application request (e.g. if B<is_transport> is 0), or (if B<is_transport> is 1)
+application request (e.g. if I<is_transport> is 0), or (if I<is_transport> is 1)
 due to logic internal to the QUIC implementation (for example, if the peer
 engages in a protocol violation, or an idle timeout occurs).
 
 If 0, connection closure was remotely triggered.
 
-=item B<is_transport>
+=item I<is_transport>
 
 If 1, connection closure was triggered for QUIC protocol reasons.
 

--- a/doc/man3/SSL_get_stream_id.pod
+++ b/doc/man3/SSL_get_stream_id.pod
@@ -31,13 +31,14 @@ on the stream, and returns one of the following values:
 
 =item B<SSL_STREAM_TYPE_NONE>
 
-The SSL object is a non-QUIC SSL object, or is a QUIC connection SSL object
-without a default stream attached (see L<SSL_attach_stream(3)>).
+The SSL object is a QUIC connection SSL object without a default stream attached
+(see L<SSL_attach_stream(3)>).
 
 =item B<SSL_STREAM_TYPE_BIDI>
 
-The SSL object is a QUIC stream object (or QUIC connection SSL object with a
-default stream attached), and that stream is a bidirectional QUIC stream.
+The SSL object is a non-QUIC SSL object, or is a QUIC stream object (or QUIC
+connection SSL object with a default stream attached), and that stream is a
+bidirectional QUIC stream.
 
 =item B<SSL_STREAM_TYPE_READ>
 

--- a/doc/man3/SSL_get_stream_id.pod
+++ b/doc/man3/SSL_get_stream_id.pod
@@ -1,0 +1,98 @@
+=pod
+
+=head1 NAME
+
+SSL_get_stream_id, SSL_get_stream_type, SSL_STREAM_TYPE_NONE,
+SSL_STREAM_TYPE_READ, SSL_STREAM_TYPE_WRITE, SSL_STREAM_TYPE_BIDI - get QUIC
+stream ID and stream type information
+
+=head1 SYNOPSIS
+
+ #include <openssl/ssl.h>
+
+ uint64_t SSL_get_stream_id(SSL *ssl);
+
+ #define SSL_STREAM_TYPE_NONE
+ #define SSL_STREAM_TYPE_BIDI
+ #define SSL_STREAM_TYPE_READ
+ #define SSL_STREAM_TYPE_WRITE
+ int SSL_get_stream_type(SSL *ssl);
+
+=head1 DESCRIPTION
+
+The SSL_get_stream_id() function returns the QUIC stream ID for a QUIC stream
+SSL object, or for a QUIC connection SSL object which has a default stream
+attached.
+
+The SSL_get_stream_type() function identifies what operations can be performed
+on the stream, and returns one of the following values:
+
+=over 4
+
+=item B<SSL_STREAM_TYPE_NONE>
+
+The SSL object is a non-QUIC SSL object, or is a QUIC connection SSL object
+without a default stream attached (see L<SSL_attach_stream(3)>).
+
+=item B<SSL_STREAM_TYPE_BIDI>
+
+The SSL object is a QUIC stream object (or QUIC connection SSL object with a
+default stream attached), and that stream is a bidirectional QUIC stream.
+
+=item B<SSL_STREAM_TYPE_READ>
+
+The SSL object is a QUIC stream object (or QUIC connection SSL object with a
+default stream attached), and that stream is a unidirectional QUIC stream which
+was initiated by the remote peer; thus, it can be read from, but not written to.
+
+=item B<SSL_STREAM_TYPE_WRITE>
+
+The SSL object is a QUIC stream object (or QUIC connection SSL object with a
+default stream attached), and that stream is a unidirectional QUIC stream which
+was initiated by the local application; thus, it can be written to, but not read
+from.
+
+=back
+
+=head1 NOTES
+
+While QUICv1 assigns specific meaning to the low two bits of a QUIC stream ID,
+QUIC stream IDs in future versions of QUIC are not required to have the same
+semantics. Do not determine stream properties using these bits. Instead, use
+SSL_get_stream_type() to determine the stream type.
+
+The SSL_get_stream_type() identifies the type of a QUIC stream based on its
+identity, and does not indicate whether an operation can currently be
+successfully performed on a stream. For example, you might locally initiate a
+unidirectional stream, write to it, and then conclude the stream using
+L<SSL_stream_conclude(3)>, meaning that it can no longer be written to, but
+SSL_get_stream_type() would still return B<SSL_STREAM_TYPE_WRITE>. The value
+returned by SSL_get_stream_type() does not vary over the lifespan of a stream.
+
+=head1 RETURN VALUES
+
+SSL_get_stream_id() returns a QUIC stream ID, or B<UINT64_MAX> if called on an
+SSL object which is not a QUIC SSL object, or if called on a QUIC connection SSL
+object without a default stream attached. Note that valid QUIC stream IDs are
+always below 2**62.
+
+SSL_get_stream_type() returns one of the B<SSL_STREAM_TYPE> values.
+
+=head1 SEE ALSO
+
+L<SSL_attach_stream(3)>, L<SSL_new_stream(3)>, L<SSL_accept_stream(3)>
+
+=head1 HISTORY
+
+These functions were added in OpenSSL 3.2.
+
+=head1 COPYRIGHT
+
+Copyright 2002-2023 The OpenSSL Project Authors. All Rights Reserved.
+
+Licensed under the Apache License 2.0 (the "License").  You may not use
+this file except in compliance with the License.  You can obtain a copy
+in the file LICENSE in the source distribution or at
+L<https://www.openssl.org/source/license.html>.
+
+=cut

--- a/doc/man3/SSL_get_stream_id.pod
+++ b/doc/man3/SSL_get_stream_id.pod
@@ -31,8 +31,8 @@ on the stream, and returns one of the following values:
 
 =item B<SSL_STREAM_TYPE_NONE>
 
-The SSL object is a QUIC connection SSL object without a default stream attached
-(see L<SSL_attach_stream(3)>).
+The SSL object is a QUIC connection SSL object without a default stream
+attached.
 
 =item B<SSL_STREAM_TYPE_BIDI>
 
@@ -81,7 +81,7 @@ SSL_get_stream_type() returns one of the B<SSL_STREAM_TYPE> values.
 
 =head1 SEE ALSO
 
-L<SSL_attach_stream(3)>, L<SSL_new_stream(3)>, L<SSL_accept_stream(3)>
+L<SSL_new_stream(3)>, L<SSL_accept_stream(3)>
 
 =head1 HISTORY
 

--- a/doc/man3/SSL_get_stream_read_state.pod
+++ b/doc/man3/SSL_get_stream_read_state.pod
@@ -1,0 +1,162 @@
+=pod
+
+=head1 NAME
+
+SSL_get_stream_read_state, SSL_get_stream_write_state,
+SSL_get_stream_read_error_code, SSL_get_stream_write_error_code,
+SSL_STREAM_STATE_NONE, SSL_STREAM_STATE_OK, SSL_STREAM_STATE_WRONG_DIR,
+SSL_STREAM_STATE_FINISHED, SSL_STREAM_STATE_RESET_LOCAL,
+SSL_STREAM_STATE_RESET_REMOTE, SSL_STREAM_STATE_CONN_CLOSED - get QUIC stream
+state
+
+=head1 SYNOPSIS
+
+ #include <openssl/ssl.h>
+
+ #define SSL_STREAM_STATE_NONE
+ #define SSL_STREAM_STATE_OK
+ #define SSL_STREAM_STATE_WRONG_DIR
+ #define SSL_STREAM_STATE_FINISHED
+ #define SSL_STREAM_STATE_RESET_LOCAL
+ #define SSL_STREAM_STATE_RESET_REMOTE
+ #define SSL_STREAM_STATE_CONN_CLOSED
+
+ int SSL_get_stream_read_state(SSL *ssl);
+ int SSL_get_stream_write_state(SSL *ssl);
+
+ int SSL_get_stream_read_error_code(SSL *ssl, uint64_t *app_error_code);
+ int SSL_get_stream_write_error_code(SSL *ssl, uint64_t *app_error_code);
+
+=head1 DESCRIPTION
+
+SSL_get_stream_read_state() and SSL_get_stream_write_state() retrieve the
+overall state of the receiving and sending parts of a QUIC stream, respectively.
+
+They both return one of the following values:
+
+=over 4
+
+=item SSL_STREAM_STATE_NONE
+
+This value is returned if called on a non-QUIC SSL object, or on a QUIC
+connection SSL object without a default stream attached.
+
+=item SSL_STREAM_STATE_OK
+
+This value is returned on a stream which has not been concluded and remains
+healthy.
+
+=item SSL_STREAM_STATE_WRONG_DIR
+
+This value is returned if SSL_get_stream_read_state() is called on a
+locally-initiated (and thus send-only) unidirectional stream, or, conversely, if
+SSL_get_stream_write_state() is called on a remotely-initiated (and thus
+receive-only) unidirectional stream.
+
+=item SSL_STREAM_STATE_FINISHED
+
+For SSL_get_stream_read_state(), this value is returned when the remote peer has
+signalled the end of the receiving part of the stream. Note that there may still
+be residual data available to read via L<SSL_read(3)> when this state is
+returned.
+
+For SSL_get_stream_write_state(), this value is returned when the local
+application has concluded the stream using L<SSL_stream_conclude(3)>. Future
+L<SSL_write(3)> calls will not succeed.
+
+=item SSL_STREAM_STATE_RESET_LOCAL
+
+This value is returned when the applicable stream part was reset by the local
+application.
+
+For SSL_get_stream_read_state(), this means that the receiving part of the
+stream was aborted using a locally transmitted QUIC B<STOP_SENDING> frame. It
+may or may not still be possible to obtain any residual data which remains to be
+read by calling L<SSL_read(3)>.
+
+For SSL_get_stream_write_state(), this means that the sending part of the stream
+was aborted, for example because the application called L<SSL_stream_reset(3)>,
+or because a QUIC stream SSL object with an un-concluded sending part was freed
+using L<SSL_free(3)>. Calls to L<SSL_write(3)> will fail.
+
+When this value is returned, the application error code which was signalled can
+be obtained by calling SSL_get_stream_read_error_code() or
+SSL_get_stream_write_error_code() as appropriate.
+
+=item SSL_STREAM_STATE_RESET_REMOTE
+
+This value is returned when the applicable stream part was reset by the remote
+peer.
+
+For SSL_get_stream_read_state(), this means that the peer sent a QUIC
+B<RESET_STREAM> frame for the receiving part of the stream; the receiving part
+of the stream was logically aborted by the peer.
+
+For SSL_get_stream_write_state(), this means that the peer sent a QUIC
+B<STOP_SENDING> frame for the sending part of the stream; the peer has indicated
+that it does not wish to receive further data on the sending part of the stream.
+Calls to L<SSL_write(3)> will fail.
+
+When this value is returned, the application error code which was signalled can
+be obtained by calling SSL_get_stream_read_error_code() or
+SSL_get_stream_write_error_code() as appropriate.
+
+=item SSL_STREAM_STATE_CONN_CLOSED
+
+The QUIC connection to which the stream belongs was closed. You can obtain
+information about the circumstances of this closure using
+L<SSL_get_conn_close_info(3)>. There may still be residual data available to
+read via L<SSL_read(3)> when this state is returned. Calls to L<SSL_write(3)>
+will fail. SSL_get_stream_read_state() will return this state if and only if
+SSL_get_stream_write_state() will also return this state.
+
+=back
+
+SSL_get_stream_read_error_code() and SSL_get_stream_write_error_code() provide
+the application error code which was signalled during non-normal termination of
+the receiving or sending parts of a stream, respectively. On success, the
+application error code is written to B<*app_error_code>.
+
+=head1 NOTES
+
+If a QUIC connection is closed, the stream state for all streams transitions to
+B<SSL_STREAM_STATE_CONN_CLOSED>, but no application error code can be retrieved
+using SSL_get_stream_read_error_code() or SSL_get_stream_write_error_code(), as
+the QUIC connection closure process does not cause an application error code to
+be associated with each individual stream still existing at the time of
+connection closure. However, you can obtain the overall error code associated
+with the connection closure using L<SSL_get_conn_close_info(3)>.
+
+=head1 RETURN VALUES
+
+SSL_get_stream_read_state() and SSL_get_stream_write_state() return one of the
+B<SSL_STREAM_STATE> values. If called on a non-QUIC SSL object, or a QUIC
+connection SSL object without a default stream, B<SSL_STREAM_STATE_NONE> is
+returned.
+
+SSL_get_stream_read_error_code() and SSL_get_stream_write_error_code() return 1
+on success and 0 if the stream was terminated normally. They return -1 on error,
+for example if the stream is still healthy, was still healthy at the time of
+connection closure, if called on a stream for which the respective stream part
+does not exist (e.g. on a unidirectional stream), or if called on a non-QUIC
+object or a QUIC connection SSL object without a default stream attached.
+
+=head1 SEE ALSO
+
+L<SSL_stream_conclude(3)>, L<SSL_stream_reset(3)>, L<SSL_new_stream(3)>,
+L<SSL_accept_stream(3)>, L<SSL_get_conn_close_info(3)>
+
+=head1 HISTORY
+
+These functions were added in OpenSSL 3.2.
+
+=head1 COPYRIGHT
+
+Copyright 2002-2023 The OpenSSL Project Authors. All Rights Reserved.
+
+Licensed under the Apache License 2.0 (the "License").  You may not use
+this file except in compliance with the License.  You can obtain a copy
+in the file LICENSE in the source distribution or at
+L<https://www.openssl.org/source/license.html>.
+
+=cut

--- a/doc/man3/SSL_get_stream_read_state.pod
+++ b/doc/man3/SSL_get_stream_read_state.pod
@@ -36,24 +36,24 @@ They both return one of the following values:
 
 =over 4
 
-=item SSL_STREAM_STATE_NONE
+=item B<SSL_STREAM_STATE_NONE>
 
 This value is returned if called on a non-QUIC SSL object, or on a QUIC
 connection SSL object without a default stream attached.
 
-=item SSL_STREAM_STATE_OK
+=item B<SSL_STREAM_STATE_OK>
 
 This value is returned on a stream which has not been concluded and remains
 healthy.
 
-=item SSL_STREAM_STATE_WRONG_DIR
+=item B<SSL_STREAM_STATE_WRONG_DIR>
 
 This value is returned if SSL_get_stream_read_state() is called on a
 locally-initiated (and thus send-only) unidirectional stream, or, conversely, if
 SSL_get_stream_write_state() is called on a remotely-initiated (and thus
 receive-only) unidirectional stream.
 
-=item SSL_STREAM_STATE_FINISHED
+=item B<SSL_STREAM_STATE_FINISHED>
 
 For SSL_get_stream_read_state(), this value is returned when the remote peer has
 signalled the end of the receiving part of the stream. Note that there may still
@@ -64,7 +64,7 @@ For SSL_get_stream_write_state(), this value is returned when the local
 application has concluded the stream using L<SSL_stream_conclude(3)>. Future
 L<SSL_write(3)> calls will not succeed.
 
-=item SSL_STREAM_STATE_RESET_LOCAL
+=item B<SSL_STREAM_STATE_RESET_LOCAL>
 
 This value is returned when the applicable stream part was reset by the local
 application.
@@ -83,7 +83,7 @@ When this value is returned, the application error code which was signalled can
 be obtained by calling SSL_get_stream_read_error_code() or
 SSL_get_stream_write_error_code() as appropriate.
 
-=item SSL_STREAM_STATE_RESET_REMOTE
+=item B<SSL_STREAM_STATE_RESET_REMOTE>
 
 This value is returned when the applicable stream part was reset by the remote
 peer.
@@ -101,7 +101,7 @@ When this value is returned, the application error code which was signalled can
 be obtained by calling SSL_get_stream_read_error_code() or
 SSL_get_stream_write_error_code() as appropriate.
 
-=item SSL_STREAM_STATE_CONN_CLOSED
+=item B<SSL_STREAM_STATE_CONN_CLOSED>
 
 The QUIC connection to which the stream belongs was closed. You can obtain
 information about the circumstances of this closure using
@@ -115,7 +115,7 @@ SSL_get_stream_write_state() will also return this state.
 SSL_get_stream_read_error_code() and SSL_get_stream_write_error_code() provide
 the application error code which was signalled during non-normal termination of
 the receiving or sending parts of a stream, respectively. On success, the
-application error code is written to B<*app_error_code>.
+application error code is written to I<*app_error_code>.
 
 =head1 NOTES
 

--- a/doc/man3/SSL_new_stream.pod
+++ b/doc/man3/SSL_new_stream.pod
@@ -1,0 +1,62 @@
+=pod
+
+=head1 NAME
+
+SSL_new_stream, SSL_STREAM_FLAG_UNI - create a new locally-initiated QUIC stream
+
+=head1 SYNOPSIS
+
+ #include <openssl/ssl.h>
+
+ #define SSL_STREAM_FLAG_UNI     (1U << 0)
+ SSL *SSL_new_stream(SSL *ssl, uint64_t flags);
+
+=head1 DESCRIPTION
+
+The SSL_new_stream() function, when passed a QUIC connection SSL object, creates
+a new locally-initiated bidirectional or unidirectional QUIC stream and returns
+the newly created QUIC stream SSL object.
+
+If the B<SSL_STREAM_FLAG_UNI> flag is passed, a unidirectional stream is
+created; else a bidirectional stream is created.
+
+To retrieve the stream ID of the newly created stream, use
+L<SSL_get_stream_id(3)>.
+
+It is the caller's responsibility to free the QUIC stream SSL object using
+L<SSL_free(3)>. The lifetime of the QUIC connection SSL object must exceed that
+of the QUIC stream SSL object; in other words, the QUIC stream SSL object must
+be freed first.
+
+Once a stream has been created using SSL_new_stream(), it may be used in the
+normal way using L<SSL_read(3)> and L<SSL_write(3)>.
+
+This function can only be used to create stream objects for locally-initiated
+streams. To accept incoming streams initiated by a peer, use
+L<SSL_accept_stream(3)>.
+
+=head1 RETURN VALUES
+
+SSL_new_stream() returns a new stream object, or NULL on error.
+
+This function fails if called on a QUIC stream SSL object or on a non-QUIC SSL
+object.
+
+=head1 SEE ALSO
+
+L<SSL_accept_stream(3)>, L<SSL_free(3)>
+
+=head1 HISTORY
+
+SSL_new_stream() was added in OpenSSL 3.2.
+
+=head1 COPYRIGHT
+
+Copyright 2002-2023 The OpenSSL Project Authors. All Rights Reserved.
+
+Licensed under the Apache License 2.0 (the "License").  You may not use
+this file except in compliance with the License.  You can obtain a copy
+in the file LICENSE in the source distribution or at
+L<https://www.openssl.org/source/license.html>.
+
+=cut

--- a/doc/man3/SSL_set_default_stream_mode.pod
+++ b/doc/man3/SSL_set_default_stream_mode.pod
@@ -2,7 +2,7 @@
 
 =head1 NAME
 
-SSL_attach_stream, SSL_detach_stream, SSL_set_default_stream_mode,
+SSL_set_default_stream_mode,
 SSL_DEFAULT_STREAM_MODE_NONE, SSL_DEFAULT_STREAM_MODE_AUTO_BIDI,
 SSL_DEFAULT_STREAM_MODE_AUTO_UNI - manage the default stream for a QUIC
 connection
@@ -10,9 +10,6 @@ connection
 =head1 SYNOPSIS
 
  #include <openssl/ssl.h>
-
- int SSL_attach_stream(SSL *conn, SSL *stream);
- SSL *SSL_detach_stream(SSL *conn);
 
  #define SSL_DEFAULT_STREAM_MODE_NONE
  #define SSL_DEFAULT_STREAM_MODE_AUTO_BIDI
@@ -46,38 +43,10 @@ stream is desired, or if the application wishes to disable default stream
 functionality, SSL_set_default_stream_mode() (discussed below) can be used to
 accomplish this.
 
-If a default stream is currently bound to a QUIC connection SSL object, it can
-be detached from that QUIC connection SSL object and used explicitly by calling
-SSL_detach_stream(), which detaches the default stream and returns it as an
-explicit QUIC stream SSL object.
-
-Once detached, the caller is responsible for managing the lifetime of the QUIC
-stream SSL object and must free it by calling L<SSL_free(3)>. A QUIC stream SSL
-object maintains a reference to a QUIC connection SSL object, therefore a QUIC
-connection SSL object and its child stream objects may be freed in either order;
-for details, see L<SSL_free(3)>.
-
 When a QUIC connection SSL object has no default stream currently associated
-with it, for example because the default stream was detached or because default
-stream functionality was disabled, calls to functions which require a stream on
-the QUIC connection SSL object (for example, L<SSL_read(3)> and L<SSL_write(3)>)
-will fail.
-
-The act of detaching a stream from a QUIC connection SSL object can be reversed
-by calling SSL_attach_stream(). This can also be used to designate a stream
-obtained via L<SSL_new_stream(3)> or L<SSL_accept_stream(3)> as the default
-stream. SSL_attach_stream() cannot be used if there is already a default stream
-associated with the QUIC connection SSL object; therefore, you may need to call
-SSL_detach_stream() first.
-
-If a stream is successfully attached to a QUIC connection SSL object using
-SSL_attach_stream(), the QUIC connection SSL object becomes responsible for
-managing its lifetime. Calling SSL_free() on the QUIC connection SSL object will
-free the stream automatically. Moreover, once the call to SSL_attach_stream()
-succeeds, the application must make no further use of the QUIC stream SSL object
-pointer that it passed to SSL_attach_stream(). An application must not call
-SSL_attach_stream() with a QUIC stream SSL object that has more than one
-reference to it.
+with it, for example because default stream functionality was disabled, calls to
+functions which require a stream on the QUIC connection SSL object (for example,
+L<SSL_read(3)> and L<SSL_write(3)>) will fail.
 
 It is recommended that new applications and applications which rely on multiple
 streams forego use of the default stream functionality, which is intended for
@@ -119,28 +88,15 @@ L<SSL_read(3)> and L<SSL_write(3)> calls cannot be made on the QUIC connection
 SSL object directly. You must obtain streams using L<SSL_new_stream(3)> or
 L<SSL_accept_stream(3)> in order to communicate with the peer.
 
-It is still possible to explicitly attach a stream as the default stream using
-SSL_attach_stream().
-
 =back
 
 A default stream will not be automatically created on a QUIC connection SSL
-object if the default stream mode is set to B<SSL_DEFAULT_STREAM_MODE_NONE>, or
-if the QUIC connection SSL object previously had a default stream which was
-detached using SSL_detach_stream().
+object if the default stream mode is set to B<SSL_DEFAULT_STREAM_MODE_NONE>.
 
 L<SSL_set_incoming_stream_policy(3)> interacts significantly with the default
 stream functionality.
 
 =head1 RETURN VALUES
-
-SSL_detach_stream() returns a QUIC stream SSL object, or NULL if there is no
-default stream currently attached.
-
-SSL_attach_stream() returns 1 on success and 0 on failure.
-
-SSL_attach_stream() fails if a default stream is already attached to the QUIC
-connection SSL object.
 
 SSL_set_default_stream_mode() returns 1 on success and 0 on failure.
 

--- a/doc/man3/SSL_set_incoming_stream_policy.pod
+++ b/doc/man3/SSL_set_incoming_stream_policy.pod
@@ -45,15 +45,8 @@ following rules:
 
 =item *
 
-An incoming stream is accepted if L<SSL_detach_stream(3)> has ever been called
-on a QUIC connection SSL object, as the application is assumed to be
-stream-aware in this case.
-
-=item *
-
-Otherwise, if the default stream mode (configured using
-L<SSL_set_default_stream_mode(3)>) is set to
-B<SSL_DEFAULT_STREAM_MODE_AUTO_BIDI> (the default) or
+If the default stream mode (configured using L<SSL_set_default_stream_mode(3)>)
+is set to B<SSL_DEFAULT_STREAM_MODE_AUTO_BIDI> (the default) or
 B<SSL_DEFAULT_STREAM_MODE_AUTO_UNI>, the incoming stream is rejected.
 
 =item *
@@ -89,7 +82,6 @@ object.
 
 =head1 SEE ALSO
 
-L<SSL_attach_stream(3)>, L<SSL_detach_stream(3)>,
 L<SSL_set_default_stream_mode(3)>, L<SSL_accept_stream(3)>
 
 =head1 HISTORY

--- a/doc/man3/SSL_set_incoming_stream_policy.pod
+++ b/doc/man3/SSL_set_incoming_stream_policy.pod
@@ -2,25 +2,25 @@
 
 =head1 NAME
 
-SSL_set_incoming_stream_reject_policy, SSL_INCOMING_STREAM_REJECT_POLICY_AUTO,
-SSL_INCOMING_STREAM_REJECT_POLICY_ACCEPT,
-SSL_INCOMING_STREAM_REJECT_POLICY_REJECT - manage the QUIC incoming stream
+SSL_set_incoming_stream_policy, SSL_INCOMING_STREAM_POLICY_AUTO,
+SSL_INCOMING_STREAM_POLICY_ACCEPT,
+SSL_INCOMING_STREAM_POLICY_REJECT - manage the QUIC incoming stream
 rejection policy
 
 =head1 SYNOPSIS
 
  #include <openssl/ssl.h>
 
- #define SSL_INCOMING_STREAM_REJECT_POLICY_AUTO
- #define SSL_INCOMING_STREAM_REJECT_POLICY_ACCEPT
- #define SSL_INCOMING_STREAM_REJECT_POLICY_REJECT
+ #define SSL_INCOMING_STREAM_POLICY_AUTO
+ #define SSL_INCOMING_STREAM_POLICY_ACCEPT
+ #define SSL_INCOMING_STREAM_POLICY_REJECT
 
- int SSL_set_incoming_stream_reject_policy(SSL *conn, int policy,
+ int SSL_set_incoming_stream_policy(SSL *conn, int policy,
                                            uint64_t app_error_code);
 
 =head1 DESCRIPTION
 
-SSL_set_incoming_stream_reject_policy() policy changes the incoming stream
+SSL_set_incoming_stream_policy() policy changes the incoming stream
 rejection policy for a QUIC connection. Depending on the policy configured,
 OpenSSL QUIC may automatically reject incoming streams initiated by the peer.
 This is intended to ensure that legacy applications using single-stream
@@ -36,7 +36,7 @@ The valid values for I<policy> are:
 
 =over 4
 
-=item SSL_INCOMING_STREAM_REJECT_POLICY_AUTO
+=item SSL_INCOMING_STREAM_POLICY_AUTO
 
 This is the default setting. Incoming streams are accepted according to the
 following rules:
@@ -64,12 +64,12 @@ accepted.
 
 =back
 
-=item SSL_INCOMING_STREAM_REJECT_POLICY_ACCEPT
+=item SSL_INCOMING_STREAM_POLICY_ACCEPT
 
 Always accept incoming streams, allowing them to be dequeued using
 L<SSL_accept_stream(3)>.
 
-=item SSL_INCOMING_STREAM_REJECT_POLICY_REJECT
+=item SSL_INCOMING_STREAM_POLICY_REJECT
 
 Always reject incoming streams.
 
@@ -94,7 +94,7 @@ L<SSL_set_default_stream_mode(3)>, L<SSL_accept_stream(3)>
 
 =head1 HISTORY
 
-SSL_set_incoming_stream_reject_policy() was added in OpenSSL 3.2.
+SSL_set_incoming_stream_policy() was added in OpenSSL 3.2.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/SSL_set_incoming_stream_policy.pod
+++ b/doc/man3/SSL_set_incoming_stream_policy.pod
@@ -5,7 +5,7 @@
 SSL_set_incoming_stream_policy, SSL_INCOMING_STREAM_POLICY_AUTO,
 SSL_INCOMING_STREAM_POLICY_ACCEPT,
 SSL_INCOMING_STREAM_POLICY_REJECT - manage the QUIC incoming stream
-rejection policy
+policy
 
 =head1 SYNOPSIS
 
@@ -20,17 +20,16 @@ rejection policy
 
 =head1 DESCRIPTION
 
-SSL_set_incoming_stream_policy() policy changes the incoming stream
-rejection policy for a QUIC connection. Depending on the policy configured,
-OpenSSL QUIC may automatically reject incoming streams initiated by the peer.
-This is intended to ensure that legacy applications using single-stream
-operation with a default stream on a QUIC connection SSL object are not passed
-remotely-initiated streams by a peer which those applications are not prepared
-to handle.
+SSL_set_incoming_stream_policy() policy changes the incoming stream policy for a
+QUIC connection. Depending on the policy configured, OpenSSL QUIC may
+automatically reject incoming streams initiated by the peer. This is intended to
+ensure that legacy applications using single-stream operation with a default
+stream on a QUIC connection SSL object are not passed remotely-initiated streams
+by a peer which those applications are not prepared to handle.
 
 I<app_error_code> is an application error code which will be used in any QUIC
-B<STOP_SENDING> or B<RESET_STREAM> frames generated to implement the rejection
-policy. The default application error code is 0.
+B<STOP_SENDING> or B<RESET_STREAM> frames generated to implement the policy. The
+default application error code is 0.
 
 The valid values for I<policy> are:
 

--- a/doc/man3/SSL_set_incoming_stream_reject_policy.pod
+++ b/doc/man3/SSL_set_incoming_stream_reject_policy.pod
@@ -1,0 +1,108 @@
+=pod
+
+=head1 NAME
+
+SSL_set_incoming_stream_reject_policy, SSL_INCOMING_STREAM_REJECT_POLICY_AUTO,
+SSL_INCOMING_STREAM_REJECT_POLICY_ACCEPT,
+SSL_INCOMING_STREAM_REJECT_POLICY_REJECT - manage the QUIC incoming stream
+rejection policy
+
+=head1 SYNOPSIS
+
+ #include <openssl/ssl.h>
+
+ #define SSL_INCOMING_STREAM_REJECT_POLICY_AUTO
+ #define SSL_INCOMING_STREAM_REJECT_POLICY_ACCEPT
+ #define SSL_INCOMING_STREAM_REJECT_POLICY_REJECT
+
+ int SSL_set_incoming_stream_reject_policy(SSL *conn, int policy,
+                                           uint64_t app_error_code);
+
+=head1 DESCRIPTION
+
+SSL_set_incoming_stream_reject_policy() policy changes the incoming stream
+rejection policy for a QUIC connection. Depending on the policy configured,
+OpenSSL QUIC may automatically reject incoming streams initiated by the peer.
+This is intended to ensure that legacy applications using single-stream
+operation with a default stream on a QUIC connection SSL object are not passed
+remotely-initiated streams by a peer which those applications are not prepared
+to handle.
+
+B<app_error_code> is an application error code which will be used in any QUIC
+B<STOP_SENDING> or B<RESET_STREAM> frames generated to implement the rejection
+policy. The default application error code is 0.
+
+The valid values for B<policy> are:
+
+=over 4
+
+=item SSL_INCOMING_STREAM_REJECT_POLICY_AUTO
+
+This is the default setting. Incoming streams are accepted according to the
+following rules:
+
+=over 4
+
+=item *
+
+An incoming stream is accepted if L<SSL_detach_stream(3)> has ever been called
+on a QUIC connection SSL object, as the application is assumed to be
+stream-aware in this case.
+
+=item *
+
+Otherwise, if the default stream mode (configured using
+L<SSL_set_default_stream_mode(3)>) is set to
+B<SSL_DEFAULT_STREAM_MODE_AUTO_BIDI> (the default) or
+B<SSL_DEFAULT_STREAM_MODE_AUTO_UNI>, the incoming stream is rejected.
+
+=item *
+
+Otherwise (where the default stream mode is B<SSL_DEFAULT_STREAM_MODE_NONE>),
+the application is assumed to be stream aware, and the incoming stream is
+accepted.
+
+=back
+
+=item SSL_INCOMING_STREAM_REJECT_POLICY_ACCEPT
+
+Always accept incoming streams, allowing them to be dequeued using
+L<SSL_accept_stream(3)>.
+
+=item SSL_INCOMING_STREAM_REJECT_POLICY_REJECT
+
+Always reject incoming streams.
+
+=back
+
+Where an incoming stream is rejected, it is rejected immediately and it is not
+possible to gain access to the stream using L<SSL_accept_stream(3)>. The stream
+is rejected using QUIC B<STOP_SENDING> and B<RESET_STREAM> frames as
+appropriate.
+
+=head1 RETURN VALUES
+
+Returns 1 on success and 0 on failure.
+
+This function fails if called on a QUIC stream SSL object, or on a non-QUIC SSL
+object.
+
+=head1 SEE ALSO
+
+L<SSL_attach_stream(3)>, L<SSL_detach_stream(3)>,
+L<SSL_set_default_stream_mode(3)>, L<SSL_accept_stream(3)>
+
+=head1 HISTORY
+
+SSL_set_incoming_stream_reject_policy() was added in OpenSSL 3.2.
+
+=head1 COPYRIGHT
+
+Copyright 2002-2023 The OpenSSL Project Authors. All Rights Reserved.
+
+Licensed under the Apache License 2.0 (the "License").  You may not use
+this file except in compliance with the License.  You can obtain a copy
+in the file LICENSE in the source distribution or at
+L<https://www.openssl.org/source/license.html>.
+
+=cut

--- a/doc/man3/SSL_set_incoming_stream_reject_policy.pod
+++ b/doc/man3/SSL_set_incoming_stream_reject_policy.pod
@@ -28,11 +28,11 @@ operation with a default stream on a QUIC connection SSL object are not passed
 remotely-initiated streams by a peer which those applications are not prepared
 to handle.
 
-B<app_error_code> is an application error code which will be used in any QUIC
+I<app_error_code> is an application error code which will be used in any QUIC
 B<STOP_SENDING> or B<RESET_STREAM> frames generated to implement the rejection
 policy. The default application error code is 0.
 
-The valid values for B<policy> are:
+The valid values for I<policy> are:
 
 =over 4
 

--- a/doc/man3/SSL_stream_reset.pod
+++ b/doc/man3/SSL_stream_reset.pod
@@ -1,0 +1,79 @@
+=pod
+
+=head1 NAME
+
+SSL_stream_reset - reset a QUIC stream
+
+=head1 SYNOPSIS
+
+ #include <openssl/ssl.h>
+
+ typedef struct ssl_stream_reset_args_st {
+     uint64_t quic_error_code;
+ } SSL_STREAM_RESET_ARGS;
+
+ int SSL_stream_reset(SSL *ssl,
+                      const SSL_STREAM_RESET_ARGS *args,
+                      size_t args_len);
+
+=head1 DESCRIPTION
+
+The SSL_stream_reset() function resets the send part of a QUIC stream when
+called on a QUIC stream SSL object, or on a QUIC connection SSL object with  a
+default stream attached.
+
+If B<args> is non-NULL, B<args_len> must be set to B<sizeof(*args)>.
+
+B<quic_error_code> is an application-specified error code, which must be in the
+range [0, 2**62-1]. If B<args> is NULL, a value of 0 is used.
+
+Resetting a stream indicates to an application that the sending part of the
+stream is terminating abnormally. When a stream is reset, the implementation
+does not guarantee that any data already passed to L<SSL_write(3)> will be
+received by the peer, and data already passed to L<SSL_write(3)> but not yet
+transmitted may or may not be discarded. As such, you should only reset
+a stream when the information transmitted on the stream no longer matters, for
+example due to an error condition.
+
+This function cannot be called on a unidirectional stream initiated by the peer,
+as only the sending side of a stream can initiate a stream reset.
+
+It is also possible to trigger a stream reset by calling L<SSL_free(3)>; see the
+documentation for L<SSL_free(3)> for details.
+
+The receiving part of the stream (for bidirectional streams) continues to
+function normally.
+
+=head1 NOTES
+
+This function corresponds to the QUIC B<RESET_STREAM> frame.
+
+=head1 RETURN VALUES
+
+Returns 1 on success and 0 on failure.
+
+This function fails if called on a QUIC connection SSL object without a default
+stream attached, or on a non-QUIC SSL object.
+
+After the first call to this function succeeds for a given stream,
+subsequent calls succeed but are ignored. The application error code
+used is that passed to the first successful call to this function.
+
+=head1 SEE ALSO
+
+L<SSL_free(3)>
+
+=head1 HISTORY
+
+SSL_stream_reset() was added in OpenSSL 3.2.
+
+=head1 COPYRIGHT
+
+Copyright 2002-2023 The OpenSSL Project Authors. All Rights Reserved.
+
+Licensed under the Apache License 2.0 (the "License").  You may not use
+this file except in compliance with the License.  You can obtain a copy
+in the file LICENSE in the source distribution or at
+L<https://www.openssl.org/source/license.html>.
+
+=cut

--- a/doc/man3/SSL_stream_reset.pod
+++ b/doc/man3/SSL_stream_reset.pod
@@ -22,10 +22,10 @@ The SSL_stream_reset() function resets the send part of a QUIC stream when
 called on a QUIC stream SSL object, or on a QUIC connection SSL object with  a
 default stream attached.
 
-If B<args> is non-NULL, B<args_len> must be set to B<sizeof(*args)>.
+If I<args> is non-NULL, I<args_len> must be set to C<sizeof(*args)>.
 
-B<quic_error_code> is an application-specified error code, which must be in the
-range [0, 2**62-1]. If B<args> is NULL, a value of 0 is used.
+I<quic_error_code> is an application-specified error code, which must be in the
+range [0, 2**62-1]. If I<args> is NULL, a value of 0 is used.
 
 Resetting a stream indicates to an application that the sending part of the
 stream is terminating abnormally. When a stream is reset, the implementation

--- a/include/internal/quic_channel.h
+++ b/include/internal/quic_channel.h
@@ -84,6 +84,19 @@
  */
 #  define QUIC_TAKES_LOCK
 
+/*
+ * The function acquires the channel mutex and leaves it acquired
+ * when returning success.
+ *
+ * Any function tagged with this has the following precondition and
+ * postcondition:
+ *
+ *   Precondition: must not hold channel mutex (unchecked)
+ *   Postcondition: channel mutex is held by calling thread
+ *      or function returned failure
+ */
+#  define QUIC_ACQUIRES_LOCK
+
 #  define QUIC_TODO_LOCK
 
 #  define QUIC_CHANNEL_STATE_IDLE                        0

--- a/include/internal/quic_channel.h
+++ b/include/internal/quic_channel.h
@@ -299,6 +299,23 @@ QUIC_STREAM *ossl_quic_channel_new_stream_local(QUIC_CHANNEL *ch, int is_uni);
 QUIC_STREAM *ossl_quic_channel_new_stream_remote(QUIC_CHANNEL *ch,
                                                  uint64_t stream_id);
 
+/*
+ * Configures incoming stream auto-reject. If enabled, incoming streams have
+ * both their sending and receiving parts automatically rejected using
+ * STOP_SENDING and STREAM_RESET frames. aec is the application error
+ * code to be used for those frames.
+ */
+void ossl_quic_channel_set_incoming_stream_auto_reject(QUIC_CHANNEL *ch,
+                                                       int enable,
+                                                       uint64_t aec);
+
+/*
+ * Causes the channel to reject the sending and receiving parts of a stream,
+ * as though autorejected. Can be used if a stream has already been
+ * accepted.
+ */
+void ossl_quic_channel_reject_stream(QUIC_CHANNEL *ch, QUIC_STREAM *qs);
+
 # endif
 
 #endif

--- a/include/internal/quic_channel.h
+++ b/include/internal/quic_channel.h
@@ -257,7 +257,8 @@ QUIC_STREAM *ossl_quic_channel_get_stream_by_id(QUIC_CHANNEL *ch,
 
 /* Returns 1 if channel is terminating or terminated. */
 int ossl_quic_channel_is_term_any(const QUIC_CHANNEL *ch);
-QUIC_TERMINATE_CAUSE ossl_quic_channel_get_terminate_cause(const QUIC_CHANNEL *ch);
+const QUIC_TERMINATE_CAUSE *
+ossl_quic_channel_get_terminate_cause(const QUIC_CHANNEL *ch);
 int ossl_quic_channel_is_terminating(const QUIC_CHANNEL *ch);
 int ossl_quic_channel_is_terminated(const QUIC_CHANNEL *ch);
 int ossl_quic_channel_is_active(const QUIC_CHANNEL *ch);

--- a/include/internal/quic_channel.h
+++ b/include/internal/quic_channel.h
@@ -273,9 +273,18 @@ CRYPTO_MUTEX *ossl_quic_channel_get_mutex(QUIC_CHANNEL *ch);
 /*
  * Creates a new locally-initiated stream in the stream mapper, choosing an
  * appropriate stream ID. If is_uni is 1, creates a unidirectional stream, else
- * creates a bidirectional stream.
+ * creates a bidirectional stream. Returns NULL on failure.
  */
-QUIC_STREAM *ossl_quic_channel_new_stream(QUIC_CHANNEL *ch, int is_uni);
+QUIC_STREAM *ossl_quic_channel_new_stream_local(QUIC_CHANNEL *ch, int is_uni);
+
+/*
+ * Creates a new remotely-initiated stream in the stream mapper. The stream ID
+ * is used to confirm the initiator and determine the stream type. The stream is
+ * automatically added to the QSM's accept queue. A pointer to the stream is
+ * also returned. Returns NULL on failure.
+ */
+QUIC_STREAM *ossl_quic_channel_new_stream_remote(QUIC_CHANNEL *ch,
+                                                 uint64_t stream_id);
 
 # endif
 

--- a/include/internal/quic_channel.h
+++ b/include/internal/quic_channel.h
@@ -270,6 +270,13 @@ SSL *ossl_quic_channel_get0_ssl(QUIC_CHANNEL *ch);
  */
 CRYPTO_MUTEX *ossl_quic_channel_get_mutex(QUIC_CHANNEL *ch);
 
+/*
+ * Creates a new locally-initiated stream in the stream mapper, choosing an
+ * appropriate stream ID. If is_uni is 1, creates a unidirectional stream, else
+ * creates a bidirectional stream.
+ */
+QUIC_STREAM *ossl_quic_channel_new_stream(QUIC_CHANNEL *ch, int is_uni);
+
 # endif
 
 #endif

--- a/include/internal/quic_fc.h
+++ b/include/internal/quic_fc.h
@@ -137,7 +137,7 @@ struct quic_rxfc_st {
     OSSL_TIME       (*now)(void *arg);
     void            *now_arg;
     QUIC_RXFC       *parent;
-    unsigned char   error_code, has_cwm_changed, is_fin;
+    unsigned char   error_code, has_cwm_changed, is_fin, stream_count_mode;
 };
 
 /*
@@ -147,12 +147,23 @@ struct quic_rxfc_st {
  * and absolute maximum window sizes, respectively. Window size values are
  * expressed in bytes and determine how much credit the RXFC extends to the peer
  * to transmit more data at a time.
+ *
+ * If stream_count_mode is 1, this RXFC is for use tracking maximum stream count
+ * enforcement. In this case conn_rxfc must be NULL.
  */
 int ossl_quic_rxfc_init(QUIC_RXFC *rxfc, QUIC_RXFC *conn_rxfc,
                         uint64_t initial_window_size,
                         uint64_t max_window_size,
                         OSSL_TIME (*now)(void *arg),
                         void *now_arg);
+
+/*
+ * Initialises an RX flow controller for stream count enforcement.
+ */
+int ossl_quic_rxfc_init_for_stream_count(QUIC_RXFC *rxfc,
+                                         uint64_t initial_window_size,
+                                         OSSL_TIME (*now)(void *arg),
+                                         void *now_arg);
 
 /*
  * Gets the parent (i.e., connection-level) RXFC. Returns NULL if called on a

--- a/include/internal/quic_fc.h
+++ b/include/internal/quic_fc.h
@@ -147,9 +147,6 @@ struct quic_rxfc_st {
  * and absolute maximum window sizes, respectively. Window size values are
  * expressed in bytes and determine how much credit the RXFC extends to the peer
  * to transmit more data at a time.
- *
- * If stream_count_mode is 1, this RXFC is for use tracking maximum stream count
- * enforcement. In this case conn_rxfc must be NULL.
  */
 int ossl_quic_rxfc_init(QUIC_RXFC *rxfc, QUIC_RXFC *conn_rxfc,
                         uint64_t initial_window_size,

--- a/include/internal/quic_fifd.h
+++ b/include/internal/quic_fifd.h
@@ -37,6 +37,11 @@ struct quic_fifd_st {
                                  QUIC_TXPIM_PKT *pkt,
                                  void *arg);
     void           *regen_frame_arg;
+    void          (*confirm_frame)(uint64_t frame_type,
+                                   uint64_t stream_id,
+                                   QUIC_TXPIM_PKT *pkt,
+                                   void *arg);
+    void           *confirm_frame_arg;
     void          (*sstream_updated)(uint64_t stream_id,
                                    void *arg);
     void           *sstream_updated_arg;
@@ -57,6 +62,11 @@ int ossl_quic_fifd_init(QUIC_FIFD *fifd,
                                             QUIC_TXPIM_PKT *pkt,
                                             void *arg),
                         void *regen_frame_arg,
+                        void (*confirm_frame)(uint64_t frame_type,
+                                             uint64_t stream_id,
+                                             QUIC_TXPIM_PKT *pkt,
+                                             void *arg),
+                        void *confirm_frame_arg,
                         void (*sstream_updated)(uint64_t stream_id,
                                                 void *arg),
                         void *sstream_updated_arg);

--- a/include/internal/quic_fifd.h
+++ b/include/internal/quic_fifd.h
@@ -37,6 +37,9 @@ struct quic_fifd_st {
                                  QUIC_TXPIM_PKT *pkt,
                                  void *arg);
     void           *regen_frame_arg;
+    void          (*sstream_updated)(uint64_t stream_id,
+                                   void *arg);
+    void           *sstream_updated_arg;
 };
 
 int ossl_quic_fifd_init(QUIC_FIFD *fifd,
@@ -53,7 +56,10 @@ int ossl_quic_fifd_init(QUIC_FIFD *fifd,
                                             uint64_t stream_id,
                                             QUIC_TXPIM_PKT *pkt,
                                             void *arg),
-                        void *regen_frame_arg);
+                        void *regen_frame_arg,
+                        void (*sstream_updated)(uint64_t stream_id,
+                                                void *arg),
+                        void *sstream_updated_arg);
 
 void ossl_quic_fifd_cleanup(QUIC_FIFD *fifd); /* (no-op) */
 

--- a/include/internal/quic_ssl.h
+++ b/include/internal/quic_ssl.h
@@ -66,6 +66,7 @@ BIO *ossl_quic_conn_get_net_wbio(const SSL *s);
 __owur int ossl_quic_conn_set_initial_peer_addr(SSL *s,
                                                 const BIO_ADDR *peer_addr);
 __owur SSL *ossl_quic_conn_stream_new(SSL *s, uint64_t flags);
+__owur SSL *ossl_quic_get0_connection(SSL *s);
 
 /*
  * Used to override ossl_time_now() for debug purposes. Must be called before

--- a/include/internal/quic_ssl.h
+++ b/include/internal/quic_ssl.h
@@ -72,6 +72,8 @@ __owur uint64_t ossl_quic_get_stream_id(SSL *s);
 __owur int ossl_quic_set_default_stream_mode(SSL *s, uint32_t mode);
 __owur SSL *ossl_quic_detach_stream(SSL *s);
 __owur int ossl_quic_attach_stream(SSL *conn, SSL *stream);
+__owur int ossl_quic_set_incoming_stream_reject_policy(SSL *s, int policy,
+                                                       uint64_t aec);
 
 /*
  * Used to override ossl_time_now() for debug purposes. Must be called before

--- a/include/internal/quic_ssl.h
+++ b/include/internal/quic_ssl.h
@@ -72,8 +72,8 @@ __owur uint64_t ossl_quic_get_stream_id(SSL *s);
 __owur int ossl_quic_set_default_stream_mode(SSL *s, uint32_t mode);
 __owur SSL *ossl_quic_detach_stream(SSL *s);
 __owur int ossl_quic_attach_stream(SSL *conn, SSL *stream);
-__owur int ossl_quic_set_incoming_stream_reject_policy(SSL *s, int policy,
-                                                       uint64_t aec);
+__owur int ossl_quic_set_incoming_stream_policy(SSL *s, int policy,
+                                                uint64_t aec);
 __owur SSL *ossl_quic_accept_stream(SSL *s, uint64_t flags);
 __owur size_t ossl_quic_get_accept_stream_queue_len(SSL *s);
 

--- a/include/internal/quic_ssl.h
+++ b/include/internal/quic_ssl.h
@@ -69,6 +69,9 @@ __owur SSL *ossl_quic_conn_stream_new(SSL *s, uint64_t flags);
 __owur SSL *ossl_quic_get0_connection(SSL *s);
 __owur int ossl_quic_get_stream_type(SSL *s);
 __owur uint64_t ossl_quic_get_stream_id(SSL *s);
+__owur int ossl_quic_set_default_stream_mode(SSL *s, uint32_t mode);
+__owur SSL *ossl_quic_detach_stream(SSL *s);
+__owur int ossl_quic_attach_stream(SSL *conn, SSL *stream);
 
 /*
  * Used to override ossl_time_now() for debug purposes. Must be called before

--- a/include/internal/quic_ssl.h
+++ b/include/internal/quic_ssl.h
@@ -65,6 +65,7 @@ BIO *ossl_quic_conn_get_net_rbio(const SSL *s);
 BIO *ossl_quic_conn_get_net_wbio(const SSL *s);
 __owur int ossl_quic_conn_set_initial_peer_addr(SSL *s,
                                                 const BIO_ADDR *peer_addr);
+__owur SSL *ossl_quic_conn_stream_new(SSL *s, uint64_t flags);
 
 /*
  * Used to override ossl_time_now() for debug purposes. Must be called before

--- a/include/internal/quic_ssl.h
+++ b/include/internal/quic_ssl.h
@@ -77,6 +77,20 @@ __owur int ossl_quic_set_incoming_stream_reject_policy(SSL *s, int policy,
 __owur SSL *ossl_quic_accept_stream(SSL *s, uint64_t flags);
 __owur size_t ossl_quic_get_accept_stream_queue_len(SSL *s);
 
+__owur int ossl_quic_stream_reset(SSL *ssl,
+                                  const SSL_STREAM_RESET_ARGS *args,
+                                  size_t args_len);
+
+__owur int ossl_quic_get_stream_read_state(SSL *ssl);
+__owur int ossl_quic_get_stream_write_state(SSL *ssl);
+__owur int ossl_quic_get_stream_read_error_code(SSL *ssl,
+                                                uint64_t *app_error_code);
+__owur int ossl_quic_get_stream_write_error_code(SSL *ssl,
+                                                 uint64_t *app_error_code);
+__owur int ossl_quic_get_conn_close_info(SSL *ssl,
+                                         SSL_CONN_CLOSE_INFO *info,
+                                         size_t info_len);
+
 /*
  * Used to override ossl_time_now() for debug purposes. Must be called before
  * connecting.

--- a/include/internal/quic_ssl.h
+++ b/include/internal/quic_ssl.h
@@ -74,6 +74,8 @@ __owur SSL *ossl_quic_detach_stream(SSL *s);
 __owur int ossl_quic_attach_stream(SSL *conn, SSL *stream);
 __owur int ossl_quic_set_incoming_stream_reject_policy(SSL *s, int policy,
                                                        uint64_t aec);
+__owur SSL *ossl_quic_accept_stream(SSL *s, uint64_t flags);
+__owur size_t ossl_quic_get_accept_stream_queue_len(SSL *s);
 
 /*
  * Used to override ossl_time_now() for debug purposes. Must be called before

--- a/include/internal/quic_ssl.h
+++ b/include/internal/quic_ssl.h
@@ -68,6 +68,7 @@ __owur int ossl_quic_conn_set_initial_peer_addr(SSL *s,
 __owur SSL *ossl_quic_conn_stream_new(SSL *s, uint64_t flags);
 __owur SSL *ossl_quic_get0_connection(SSL *s);
 __owur int ossl_quic_get_stream_type(SSL *s);
+__owur uint64_t ossl_quic_get_stream_id(SSL *s);
 
 /*
  * Used to override ossl_time_now() for debug purposes. Must be called before

--- a/include/internal/quic_ssl.h
+++ b/include/internal/quic_ssl.h
@@ -40,30 +40,30 @@ int ossl_quic_renegotiate_check(SSL *ssl, int initok);
 typedef struct quic_conn_st QUIC_CONNECTION;
 typedef struct quic_xso_st QUIC_XSO;
 
-int ossl_quic_do_handshake(QUIC_CONNECTION *qc);
-void ossl_quic_set_connect_state(QUIC_CONNECTION *qc);
-void ossl_quic_set_accept_state(QUIC_CONNECTION *qc);
+int ossl_quic_do_handshake(SSL *s);
+void ossl_quic_set_connect_state(SSL *s);
+void ossl_quic_set_accept_state(SSL *s);
 
-__owur int ossl_quic_has_pending(const QUIC_CONNECTION *qc);
-__owur int ossl_quic_tick(QUIC_CONNECTION *qc);
-__owur int ossl_quic_get_tick_timeout(QUIC_CONNECTION *qc, struct timeval *tv);
-OSSL_TIME ossl_quic_get_tick_deadline(QUIC_CONNECTION *qc);
-__owur int ossl_quic_get_rpoll_descriptor(QUIC_CONNECTION *qc, BIO_POLL_DESCRIPTOR *d);
-__owur int ossl_quic_get_wpoll_descriptor(QUIC_CONNECTION *qc, BIO_POLL_DESCRIPTOR *d);
-__owur int ossl_quic_get_net_read_desired(QUIC_CONNECTION *qc);
-__owur int ossl_quic_get_net_write_desired(QUIC_CONNECTION *qc);
-__owur int ossl_quic_get_error(const QUIC_CONNECTION *qc, int i);
-__owur int ossl_quic_conn_get_blocking_mode(const QUIC_CONNECTION *qc);
-__owur int ossl_quic_conn_set_blocking_mode(QUIC_CONNECTION *qc, int blocking);
-__owur int ossl_quic_conn_shutdown(QUIC_CONNECTION *qc, uint64_t flags,
+__owur int ossl_quic_has_pending(const SSL *s);
+__owur int ossl_quic_tick(SSL *s);
+__owur int ossl_quic_get_tick_timeout(SSL *s, struct timeval *tv);
+OSSL_TIME ossl_quic_get_tick_deadline(SSL *s);
+__owur int ossl_quic_get_rpoll_descriptor(SSL *s, BIO_POLL_DESCRIPTOR *d);
+__owur int ossl_quic_get_wpoll_descriptor(SSL *s, BIO_POLL_DESCRIPTOR *d);
+__owur int ossl_quic_get_net_read_desired(SSL *s);
+__owur int ossl_quic_get_net_write_desired(SSL *s);
+__owur int ossl_quic_get_error(const SSL *s, int i);
+__owur int ossl_quic_conn_get_blocking_mode(const SSL *s);
+__owur int ossl_quic_conn_set_blocking_mode(SSL *s, int blocking);
+__owur int ossl_quic_conn_shutdown(SSL *s, uint64_t flags,
                                    const SSL_SHUTDOWN_EX_ARGS *args,
                                    size_t args_len);
-__owur int ossl_quic_conn_stream_conclude(QUIC_CONNECTION *qc);
-void ossl_quic_conn_set0_net_rbio(QUIC_CONNECTION *qc, BIO *net_wbio);
-void ossl_quic_conn_set0_net_wbio(QUIC_CONNECTION *qc, BIO *net_wbio);
-BIO *ossl_quic_conn_get_net_rbio(const QUIC_CONNECTION *qc);
-BIO *ossl_quic_conn_get_net_wbio(const QUIC_CONNECTION *qc);
-__owur int ossl_quic_conn_set_initial_peer_addr(QUIC_CONNECTION *qc,
+__owur int ossl_quic_conn_stream_conclude(SSL *s);
+void ossl_quic_conn_set0_net_rbio(SSL *s, BIO *net_wbio);
+void ossl_quic_conn_set0_net_wbio(SSL *s, BIO *net_wbio);
+BIO *ossl_quic_conn_get_net_rbio(const SSL *s);
+BIO *ossl_quic_conn_get_net_wbio(const SSL *s);
+__owur int ossl_quic_conn_set_initial_peer_addr(SSL *s,
                                                 const BIO_ADDR *peer_addr);
 
 /*

--- a/include/internal/quic_ssl.h
+++ b/include/internal/quic_ssl.h
@@ -67,6 +67,7 @@ __owur int ossl_quic_conn_set_initial_peer_addr(SSL *s,
                                                 const BIO_ADDR *peer_addr);
 __owur SSL *ossl_quic_conn_stream_new(SSL *s, uint64_t flags);
 __owur SSL *ossl_quic_get0_connection(SSL *s);
+__owur int ossl_quic_get_stream_type(SSL *s);
 
 /*
  * Used to override ossl_time_now() for debug purposes. Must be called before

--- a/include/internal/quic_stream.h
+++ b/include/internal/quic_stream.h
@@ -254,6 +254,12 @@ void ossl_quic_sstream_fin(QUIC_SSTREAM *qss);
 int ossl_quic_sstream_get_final_size(QUIC_SSTREAM *qss, uint64_t *final_size);
 
 /*
+ * Returns 1 iff all bytes (and any FIN, if any) which have been appended to the
+ * QUIC_SSTREAM so far, and any FIN (if any), have been both sent and acked.
+ */
+int ossl_quic_sstream_is_totally_acked(QUIC_SSTREAM *qss);
+
+/*
  * Resizes the internal ring buffer. All stream data is preserved safely.
  *
  * This can be used to expand or contract the ring buffer, but not to contract

--- a/include/internal/quic_stream_map.h
+++ b/include/internal/quic_stream_map.h
@@ -69,7 +69,7 @@ struct quic_stream_st {
 
     /*
      * Application Error Code (AEC) for incoming RESET_STREAM frame.
-     * This  is only valid if peer_reset_stream is 1.
+     * This is only valid if peer_reset_stream is 1.
      */
     uint64_t        peer_reset_stream_aec;
 

--- a/include/internal/quic_stream_map.h
+++ b/include/internal/quic_stream_map.h
@@ -166,6 +166,16 @@ void ossl_quic_stream_map_cleanup(QUIC_STREAM_MAP *qsm);
 #define QUIC_STREAM_DIR_UNI                 2
 #define QUIC_STREAM_DIR_MASK                2
 
+static ossl_inline ossl_unused int ossl_quic_stream_is_server_init(QUIC_STREAM *s)
+{
+    return (s->type & QUIC_STREAM_INITIATOR_MASK) == QUIC_STREAM_INITIATOR_SERVER;
+}
+
+static ossl_inline ossl_unused int ossl_quic_stream_is_bidi(QUIC_STREAM *s)
+{
+    return (s->type & QUIC_STREAM_DIR_MASK) == QUIC_STREAM_DIR_BIDI;
+}
+
 /*
  * Allocate a new stream. type is a combination of one QUIC_STREAM_INITIATOR_*
  * value and one QUIC_STREAM_DIR_* value. Note that clients can e.g. allocate

--- a/include/internal/quic_stream_map.h
+++ b/include/internal/quic_stream_map.h
@@ -138,6 +138,8 @@ typedef struct quic_stream_map_st {
     QUIC_STREAM             *rr_cur;
     uint64_t                (*get_stream_limit_cb)(int uni, void *arg);
     void                    *get_stream_limit_cb_arg;
+    QUIC_RXFC               *max_streams_bidi_rxfc;
+    QUIC_RXFC               *max_streams_uni_rxfc;
 } QUIC_STREAM_MAP;
 
 /*
@@ -155,7 +157,9 @@ typedef struct quic_stream_map_st {
  */
 int ossl_quic_stream_map_init(QUIC_STREAM_MAP *qsm,
                               uint64_t (*get_stream_limit_cb)(int uni, void *arg),
-                              void *get_stream_limit_cb_arg);
+                              void *get_stream_limit_cb_arg,
+                              QUIC_RXFC *max_streams_bidi_rxfc,
+                              QUIC_RXFC *max_streams_uni_rxfc);
 
 /*
  * Any streams still in the map will be released as though
@@ -246,12 +250,14 @@ void ossl_quic_stream_map_push_accept_queue(QUIC_STREAM_MAP *qsm,
 QUIC_STREAM *ossl_quic_stream_map_peek_accept_queue(QUIC_STREAM_MAP *qsm);
 
 /*
- * Removes a stream from the accept queue.
+ * Removes a stream from the accept queue. rtt is the estimated connection RTT.
+ * The stream is retired for the purposes of MAX_STREAMS RXFC.
  *
  * Precondition: s is in the accept queue.
  */
 void ossl_quic_stream_map_remove_from_accept_queue(QUIC_STREAM_MAP *qsm,
-                                                   QUIC_STREAM *s);
+                                                   QUIC_STREAM *s,
+                                                   OSSL_TIME rtt);
 
 /* Returns the length of the accept queue. */
 size_t ossl_quic_stream_map_get_accept_queue_len(QUIC_STREAM_MAP *qsm);

--- a/include/internal/quic_stream_map.h
+++ b/include/internal/quic_stream_map.h
@@ -238,6 +238,13 @@ void ossl_quic_stream_map_update_state(QUIC_STREAM_MAP *qsm, QUIC_STREAM *s);
 void ossl_quic_stream_map_set_rr_stepping(QUIC_STREAM_MAP *qsm, size_t stepping);
 
 /*
+ * Resets the sending part of a stream.
+ */
+void ossl_quic_stream_map_reset_stream_send_part(QUIC_STREAM_MAP *qsm,
+                                                 QUIC_STREAM *qs,
+                                                 uint64_t aec);
+
+/*
  * Adds a stream to the accept queue.
  */
 void ossl_quic_stream_map_push_accept_queue(QUIC_STREAM_MAP *qsm,

--- a/include/internal/quic_stream_map.h
+++ b/include/internal/quic_stream_map.h
@@ -60,6 +60,18 @@ struct quic_stream_st {
      */
     uint64_t        reset_stream_aec;
 
+    /*
+     * Application Error Code (AEC) for incoming STOP_SENDING frame.
+     * This is only valid if peer_stop_sending is 1.
+     */
+    uint64_t        peer_stop_sending_aec;
+
+    /*
+     * Application Error Code (AEC) for incoming RESET_STREAM frame.
+     * This  is only valid if peer_reset_stream is 1.
+     */
+    uint64_t        peer_reset_stream_aec;
+
     /* Temporary value used by TXP. */
     uint64_t        txp_txfc_new_credit_consumed;
 

--- a/include/internal/quic_stream_map.h
+++ b/include/internal/quic_stream_map.h
@@ -107,18 +107,6 @@ struct quic_stream_st {
     unsigned int    deleted                 : 1;
 };
 
-/*
- * Marks a stream for STOP_SENDING. aec is the application error code (AEC).
- * This can only fail if it has already been called.
- */
-int ossl_quic_stream_stop_sending(QUIC_STREAM *s, uint64_t aec);
-
-/*
- * Marks a stream for reset. aec is the application error code (AEC).
- * This can only fail if it has already been called.
- */
-int ossl_quic_stream_reset(QUIC_STREAM *s, uint64_t aec);
-
 /* 
  * QUIC Stream Map
  * ===============
@@ -239,10 +227,24 @@ void ossl_quic_stream_map_set_rr_stepping(QUIC_STREAM_MAP *qsm, size_t stepping)
 
 /*
  * Resets the sending part of a stream.
+ *
+ * Returns 1 if the sending part of a stream was not already reset.
+ * Returns 0 otherwise, which need not be considered an error.
  */
-void ossl_quic_stream_map_reset_stream_send_part(QUIC_STREAM_MAP *qsm,
-                                                 QUIC_STREAM *qs,
-                                                 uint64_t aec);
+int ossl_quic_stream_map_reset_stream_send_part(QUIC_STREAM_MAP *qsm,
+                                                QUIC_STREAM *qs,
+                                                uint64_t aec);
+
+/*
+ * Marks the receiving part of a stream for STOP_SENDING.
+ *
+ * Returns  1 if the receiving part of a stream was not already marked for
+ * STOP_SENDING.
+ * Returns 0 otherwise, which need not be considered an error.
+ */
+int ossl_quic_stream_map_stop_sending_recv_part(QUIC_STREAM_MAP *qsm,
+                                                QUIC_STREAM *qs,
+                                                uint64_t aec);
 
 /*
  * Adds a stream to the accept queue.

--- a/include/internal/quic_stream_map.h
+++ b/include/internal/quic_stream_map.h
@@ -101,6 +101,9 @@ struct quic_stream_st {
 
     /* A FIN has been retired from the rstream buffer. */
     unsigned int    recv_fin_retired        : 1;
+
+    /* The stream's XSO has been deleted. Pending GC. */
+    unsigned int    deleted                 : 1;
 };
 
 /*

--- a/include/internal/quic_stream_map.h
+++ b/include/internal/quic_stream_map.h
@@ -112,6 +112,10 @@ struct quic_stream_st {
     unsigned int    want_stop_sending       : 1; /* used for gen or regen */
     unsigned int    want_reset_stream       : 1; /* used for gen or regen */
 
+    /* Flags set when frames *we* sent were acknowledged. */
+    unsigned int    acked_stop_sending      : 1;
+    unsigned int    acked_reset_stream      : 1;
+
     /* A FIN has been retired from the rstream buffer. */
     unsigned int    recv_fin_retired        : 1;
 

--- a/include/internal/quic_stream_map.h
+++ b/include/internal/quic_stream_map.h
@@ -129,7 +129,7 @@ struct quic_stream_st {
      *     queue nor has an associated XSO. This condition occurs when and only
      *     when deleted is true.
      *
-     *   - Once there is the case (i.e., no user-facing API object exposing the
+     *   - Once this is the case (i.e., no user-facing API object exposing the
      *     stream), we can delete the stream once we determine that all of our
      *     protocol obligations requiring us to keep the QUIC_STREAM around have
      *     been met.

--- a/include/internal/quic_tserver.h
+++ b/include/internal/quic_tserver.h
@@ -98,7 +98,7 @@ int ossl_quic_tserver_read(QUIC_TSERVER *srv,
 int ossl_quic_tserver_has_read_ended(QUIC_TSERVER *srv, uint64_t stream_id);
 
 /*
- * Attempts to write to stream 0. Writes the number of bytes consumed to
+ * Attempts to write to the given stream. Writes the number of bytes consumed to
  * *bytes_written and returns 1 on success. If there is no space currently
  * available to write any bytes, 0 is written to *consumed and 1 is returned
  * (this is considered a success case).

--- a/include/internal/quic_tserver.h
+++ b/include/internal/quic_tserver.h
@@ -71,7 +71,8 @@ int ossl_quic_tserver_is_handshake_confirmed(const QUIC_TSERVER *srv);
 /* Returns 1 if the server is in any terminating or terminated state */
 int ossl_quic_tserver_is_term_any(const QUIC_TSERVER *srv);
 
-QUIC_TERMINATE_CAUSE ossl_quic_tserver_get_terminate_cause(const QUIC_TSERVER *srv);
+const QUIC_TERMINATE_CAUSE *
+ossl_quic_tserver_get_terminate_cause(const QUIC_TSERVER *srv);
 
 /* Returns 1 if the server is in a terminated state */
 int ossl_quic_tserver_is_terminated(const QUIC_TSERVER *srv);

--- a/include/internal/quic_tserver.h
+++ b/include/internal/quic_tserver.h
@@ -86,6 +86,7 @@ int ossl_quic_tserver_is_terminated(const QUIC_TSERVER *srv);
  * ossl_quic_tserver_has_read_ended() to identify this condition.
  */
 int ossl_quic_tserver_read(QUIC_TSERVER *srv,
+                           uint64_t stream_id,
                            unsigned char *buf,
                            size_t buf_len,
                            size_t *bytes_read);
@@ -93,7 +94,7 @@ int ossl_quic_tserver_read(QUIC_TSERVER *srv,
 /*
  * Returns 1 if the read part of the stream has ended normally.
  */
-int ossl_quic_tserver_has_read_ended(QUIC_TSERVER *srv);
+int ossl_quic_tserver_has_read_ended(QUIC_TSERVER *srv, uint64_t stream_id);
 
 /*
  * Attempts to write to stream 0. Writes the number of bytes consumed to
@@ -107,6 +108,7 @@ int ossl_quic_tserver_has_read_ended(QUIC_TSERVER *srv);
  * Returns 0 if connection is not currently active.
  */
 int ossl_quic_tserver_write(QUIC_TSERVER *srv,
+                            uint64_t stream_id,
                             const unsigned char *buf,
                             size_t buf_len,
                             size_t *bytes_written);
@@ -114,7 +116,15 @@ int ossl_quic_tserver_write(QUIC_TSERVER *srv,
 /*
  * Signals normal end of the stream.
  */
-int ossl_quic_tserver_conclude(QUIC_TSERVER *srv);
+int ossl_quic_tserver_conclude(QUIC_TSERVER *srv, uint64_t stream_id);
+
+/*
+ * Create a server-initiated stream. The stream ID of the newly
+ * created stream is written to *stream_id.
+ */
+int ossl_quic_tserver_stream_new(QUIC_TSERVER *srv,
+                                 int is_uni,
+                                 uint64_t *stream_id);
 
 BIO *ossl_quic_tserver_get0_rbio(QUIC_TSERVER *srv);
 

--- a/include/internal/quic_tserver.h
+++ b/include/internal/quic_tserver.h
@@ -129,6 +129,22 @@ int ossl_quic_tserver_stream_new(QUIC_TSERVER *srv,
 
 BIO *ossl_quic_tserver_get0_rbio(QUIC_TSERVER *srv);
 
+/*
+ * Returns 1 if the peer has sent a STOP_SENDING frame for a stream.
+ * app_error_code is written if this returns 1.
+ */
+int ossl_quic_tserver_stream_has_peer_stop_sending(QUIC_TSERVER *srv,
+                                                   uint64_t stream_id,
+                                                   uint64_t *app_error_code);
+
+/*
+ * Returns 1 if the peer has sent a RESET_STREAM frame for a stream.
+ * app_error_code is written if this returns 1.
+ */
+int ossl_quic_tserver_stream_has_peer_reset_stream(QUIC_TSERVER *srv,
+                                                   uint64_t stream_id,
+                                                   uint64_t *app_error_code);
+
 # endif
 
 #endif

--- a/include/internal/quic_txp.h
+++ b/include/internal/quic_txp.h
@@ -42,6 +42,8 @@ typedef struct ossl_quic_tx_packetiser_args_st {
     QUIC_STREAM_MAP *qsm;       /* QUIC Streams Map */
     QUIC_TXFC       *conn_txfc; /* QUIC Connection-Level TX Flow Controller */
     QUIC_RXFC       *conn_rxfc; /* QUIC Connection-Level RX Flow Controller */
+    QUIC_RXFC       *max_streams_bidi_rxfc; /* QUIC RXFC for MAX_STREAMS generation */
+    QUIC_RXFC       *max_streams_uni_rxfc;
     const OSSL_CC_METHOD *cc_method; /* QUIC Congestion Controller */
     OSSL_CC_DATA    *cc_data;   /* QUIC Congestion Controller Instance */
     OSSL_TIME       (*now)(void *arg);  /* Callback to get current time. */

--- a/include/internal/refcount.h
+++ b/include/internal/refcount.h
@@ -197,6 +197,7 @@ typedef int CRYPTO_REF_COUNT;
 
 # define CRYPTO_UP_REF(val, ret, lock) CRYPTO_atomic_add(val, 1, ret, lock)
 # define CRYPTO_DOWN_REF(val, ret, lock) CRYPTO_atomic_add(val, -1, ret, lock)
+# define CRYPTO_GET_REF(val, ret, lock) CRYPTO_atomic_load(val, ret, lock)
 
 # endif
 

--- a/include/openssl/ssl.h.in
+++ b/include/openssl/ssl.h.in
@@ -2266,6 +2266,7 @@ __owur int SSL_net_write_desired(SSL *s);
 __owur int SSL_set_blocking_mode(SSL *s, int blocking);
 __owur int SSL_get_blocking_mode(SSL *s);
 __owur int SSL_set_initial_peer_addr(SSL *s, const BIO_ADDR *peer_addr);
+__owur SSL *SSL_get0_connection(SSL *s);
 
 #define SSL_STREAM_FLAG_UNI     (1U << 0)
 __owur SSL *SSL_new_stream(SSL *s, uint64_t flags);

--- a/include/openssl/ssl.h.in
+++ b/include/openssl/ssl.h.in
@@ -2270,8 +2270,8 @@ __owur SSL *SSL_get0_connection(SSL *s);
 __owur int SSL_is_connection(SSL *s);
 
 #define SSL_STREAM_TYPE_NONE        0
-#define SSL_STREAM_TYPE_READ        1
-#define SSL_STREAM_TYPE_WRITE       2
+#define SSL_STREAM_TYPE_READ        (1U << 0)
+#define SSL_STREAM_TYPE_WRITE       (1U << 1)
 #define SSL_STREAM_TYPE_BIDI        (SSL_STREAM_TYPE_READ | SSL_STREAM_TYPE_WRITE)
 __owur int SSL_get_stream_type(SSL *s);
 

--- a/include/openssl/ssl.h.in
+++ b/include/openssl/ssl.h.in
@@ -2275,6 +2275,8 @@ __owur int SSL_is_connection(SSL *s);
 #define SSL_STREAM_TYPE_BIDI        (SSL_STREAM_TYPE_READ | SSL_STREAM_TYPE_WRITE)
 __owur int SSL_get_stream_type(SSL *s);
 
+__owur uint64_t SSL_get_stream_id(SSL *s);
+
 #define SSL_STREAM_FLAG_UNI     (1U << 0)
 __owur SSL *SSL_new_stream(SSL *s, uint64_t flags);
 

--- a/include/openssl/ssl.h.in
+++ b/include/openssl/ssl.h.in
@@ -2288,6 +2288,11 @@ __owur int SSL_attach_stream(SSL *conn, SSL *stream);
 #define SSL_STREAM_FLAG_UNI     (1U << 0)
 __owur SSL *SSL_new_stream(SSL *s, uint64_t flags);
 
+#define SSL_INCOMING_STREAM_REJECT_POLICY_AUTO      0
+#define SSL_INCOMING_STREAM_REJECT_POLICY_ACCEPT    1
+#define SSL_INCOMING_STREAM_REJECT_POLICY_REJECT    2
+__owur int SSL_set_incoming_stream_reject_policy(SSL *s, int policy, uint64_t aec);
+
 # ifndef OPENSSL_NO_QUIC
 __owur int SSL_inject_net_dgram(SSL *s, const unsigned char *buf,
                                 size_t buf_len,

--- a/include/openssl/ssl.h.in
+++ b/include/openssl/ssl.h.in
@@ -2343,7 +2343,7 @@ typedef struct ssl_conn_close_info_st {
     uint64_t error_code;
     char     *reason;
     size_t    reason_len;
-    char      is_local, is_transport;
+    int       is_local, is_transport;
 } SSL_CONN_CLOSE_INFO;
 
 __owur int SSL_get_conn_close_info(SSL *ssl,

--- a/include/openssl/ssl.h.in
+++ b/include/openssl/ssl.h.in
@@ -2318,6 +2318,38 @@ __owur int SSL_shutdown_ex(SSL *ssl, uint64_t flags,
 
 __owur int SSL_stream_conclude(SSL *ssl, uint64_t flags);
 
+typedef struct ssl_stream_reset_args_st {
+    uint64_t quic_error_code;
+} SSL_STREAM_RESET_ARGS;
+
+__owur int SSL_stream_reset(SSL *ssl,
+                            const SSL_STREAM_RESET_ARGS *args,
+                            size_t args_len);
+
+#define SSL_STREAM_STATE_NONE           0
+#define SSL_STREAM_STATE_OK             1
+#define SSL_STREAM_STATE_WRONG_DIR      2
+#define SSL_STREAM_STATE_FINISHED       3
+#define SSL_STREAM_STATE_RESET_LOCAL    4
+#define SSL_STREAM_STATE_RESET_REMOTE   5
+#define SSL_STREAM_STATE_CONN_CLOSED    6
+__owur int SSL_get_stream_read_state(SSL *ssl);
+__owur int SSL_get_stream_write_state(SSL *ssl);
+
+__owur int SSL_get_stream_read_error_code(SSL *ssl, uint64_t *app_error_code);
+__owur int SSL_get_stream_write_error_code(SSL *ssl, uint64_t *app_error_code);
+
+typedef struct ssl_conn_close_info_st {
+    uint64_t error_code;
+    char     *reason;
+    size_t    reason_len;
+    char      is_local, is_transport;
+} SSL_CONN_CLOSE_INFO;
+
+__owur int SSL_get_conn_close_info(SSL *ssl,
+                                   SSL_CONN_CLOSE_INFO *info,
+                                   size_t info_len);
+
 # ifndef OPENSSL_NO_DEPRECATED_1_1_0
 #  define SSL_cache_hit(s) SSL_session_reused(s)
 # endif

--- a/include/openssl/ssl.h.in
+++ b/include/openssl/ssl.h.in
@@ -2269,6 +2269,12 @@ __owur int SSL_set_initial_peer_addr(SSL *s, const BIO_ADDR *peer_addr);
 __owur SSL *SSL_get0_connection(SSL *s);
 __owur int SSL_is_connection(SSL *s);
 
+#define SSL_STREAM_TYPE_NONE        0
+#define SSL_STREAM_TYPE_READ        1
+#define SSL_STREAM_TYPE_WRITE       2
+#define SSL_STREAM_TYPE_BIDI        (SSL_STREAM_TYPE_READ | SSL_STREAM_TYPE_WRITE)
+__owur int SSL_get_stream_type(SSL *s);
+
 #define SSL_STREAM_FLAG_UNI     (1U << 0)
 __owur SSL *SSL_new_stream(SSL *s, uint64_t flags);
 

--- a/include/openssl/ssl.h.in
+++ b/include/openssl/ssl.h.in
@@ -2293,6 +2293,10 @@ __owur SSL *SSL_new_stream(SSL *s, uint64_t flags);
 #define SSL_INCOMING_STREAM_REJECT_POLICY_REJECT    2
 __owur int SSL_set_incoming_stream_reject_policy(SSL *s, int policy, uint64_t aec);
 
+#define SSL_ACCEPT_STREAM_NO_BLOCK      (1U << 0)
+__owur SSL *SSL_accept_stream(SSL *s, uint64_t flags);
+__owur size_t SSL_get_accept_stream_queue_len(SSL *s);
+
 # ifndef OPENSSL_NO_QUIC
 __owur int SSL_inject_net_dgram(SSL *s, const unsigned char *buf,
                                 size_t buf_len,

--- a/include/openssl/ssl.h.in
+++ b/include/openssl/ssl.h.in
@@ -2267,6 +2267,7 @@ __owur int SSL_set_blocking_mode(SSL *s, int blocking);
 __owur int SSL_get_blocking_mode(SSL *s);
 __owur int SSL_set_initial_peer_addr(SSL *s, const BIO_ADDR *peer_addr);
 __owur SSL *SSL_get0_connection(SSL *s);
+__owur int SSL_is_connection(SSL *s);
 
 #define SSL_STREAM_FLAG_UNI     (1U << 0)
 __owur SSL *SSL_new_stream(SSL *s, uint64_t flags);

--- a/include/openssl/ssl.h.in
+++ b/include/openssl/ssl.h.in
@@ -2282,9 +2282,6 @@ __owur uint64_t SSL_get_stream_id(SSL *s);
 #define SSL_DEFAULT_STREAM_MODE_AUTO_UNI    2
 __owur int SSL_set_default_stream_mode(SSL *s, uint32_t mode);
 
-__owur SSL *SSL_detach_stream(SSL *s);
-__owur int SSL_attach_stream(SSL *conn, SSL *stream);
-
 #define SSL_STREAM_FLAG_UNI     (1U << 0)
 __owur SSL *SSL_new_stream(SSL *s, uint64_t flags);
 

--- a/include/openssl/ssl.h.in
+++ b/include/openssl/ssl.h.in
@@ -2277,6 +2277,14 @@ __owur int SSL_get_stream_type(SSL *s);
 
 __owur uint64_t SSL_get_stream_id(SSL *s);
 
+#define SSL_DEFAULT_STREAM_MODE_NONE        0
+#define SSL_DEFAULT_STREAM_MODE_AUTO_BIDI   1
+#define SSL_DEFAULT_STREAM_MODE_AUTO_UNI    2
+__owur int SSL_set_default_stream_mode(SSL *s, uint32_t mode);
+
+__owur SSL *SSL_detach_stream(SSL *s);
+__owur int SSL_attach_stream(SSL *conn, SSL *stream);
+
 #define SSL_STREAM_FLAG_UNI     (1U << 0)
 __owur SSL *SSL_new_stream(SSL *s, uint64_t flags);
 

--- a/include/openssl/ssl.h.in
+++ b/include/openssl/ssl.h.in
@@ -2288,10 +2288,10 @@ __owur int SSL_attach_stream(SSL *conn, SSL *stream);
 #define SSL_STREAM_FLAG_UNI     (1U << 0)
 __owur SSL *SSL_new_stream(SSL *s, uint64_t flags);
 
-#define SSL_INCOMING_STREAM_REJECT_POLICY_AUTO      0
-#define SSL_INCOMING_STREAM_REJECT_POLICY_ACCEPT    1
-#define SSL_INCOMING_STREAM_REJECT_POLICY_REJECT    2
-__owur int SSL_set_incoming_stream_reject_policy(SSL *s, int policy, uint64_t aec);
+#define SSL_INCOMING_STREAM_POLICY_AUTO      0
+#define SSL_INCOMING_STREAM_POLICY_ACCEPT    1
+#define SSL_INCOMING_STREAM_POLICY_REJECT    2
+__owur int SSL_set_incoming_stream_policy(SSL *s, int policy, uint64_t aec);
 
 #define SSL_ACCEPT_STREAM_NO_BLOCK      (1U << 0)
 __owur SSL *SSL_accept_stream(SSL *s, uint64_t flags);

--- a/include/openssl/ssl.h.in
+++ b/include/openssl/ssl.h.in
@@ -2266,6 +2266,10 @@ __owur int SSL_net_write_desired(SSL *s);
 __owur int SSL_set_blocking_mode(SSL *s, int blocking);
 __owur int SSL_get_blocking_mode(SSL *s);
 __owur int SSL_set_initial_peer_addr(SSL *s, const BIO_ADDR *peer_addr);
+
+#define SSL_STREAM_FLAG_UNI     (1U << 0)
+__owur SSL *SSL_new_stream(SSL *s, uint64_t flags);
+
 # ifndef OPENSSL_NO_QUIC
 __owur int SSL_inject_net_dgram(SSL *s, const unsigned char *buf,
                                 size_t buf_len,

--- a/include/openssl/sslerr.h
+++ b/include/openssl/sslerr.h
@@ -84,6 +84,7 @@
 # define SSL_R_COMPRESSION_ID_NOT_WITHIN_PRIVATE_RANGE    307
 # define SSL_R_COMPRESSION_LIBRARY_ERROR                  142
 # define SSL_R_CONNECTION_TYPE_NOT_SET                    144
+# define SSL_R_CONN_USE_ONLY                              356
 # define SSL_R_CONTEXT_NOT_DANE_ENABLED                   167
 # define SSL_R_COOKIE_GEN_CALLBACK_FAILURE                400
 # define SSL_R_COOKIE_MISMATCH                            308
@@ -354,6 +355,5 @@
 # define SSL_R_WRONG_VERSION_NUMBER                       267
 # define SSL_R_X509_LIB                                   268
 # define SSL_R_X509_VERIFICATION_SETUP_PROBLEMS           269
-# define SSL_R_CONN_USE_ONLY                              411
 
 #endif

--- a/include/openssl/sslerr.h
+++ b/include/openssl/sslerr.h
@@ -202,6 +202,7 @@
 # define SSL_R_NO_SHARED_GROUPS                           410
 # define SSL_R_NO_SHARED_SIGNATURE_ALGORITHMS             376
 # define SSL_R_NO_SRTP_PROFILES                           359
+# define SSL_R_NO_STREAM                                  355
 # define SSL_R_NO_SUITABLE_DIGEST_ALGORITHM               297
 # define SSL_R_NO_SUITABLE_GROUPS                         295
 # define SSL_R_NO_SUITABLE_KEY_SHARE                      101
@@ -353,5 +354,6 @@
 # define SSL_R_WRONG_VERSION_NUMBER                       267
 # define SSL_R_X509_LIB                                   268
 # define SSL_R_X509_VERIFICATION_SETUP_PROBLEMS           269
+# define SSL_R_CONN_USE_ONLY                              411
 
 #endif

--- a/ssl/quic/quic_channel.c
+++ b/ssl/quic/quic_channel.c
@@ -1372,6 +1372,9 @@ static void ch_tick(QUIC_TICK_RESULT *res, void *arg, uint32_t flags)
     /* Write any data to the network due to be sent. */
     ch_tx(ch);
 
+    /* Do stream GC. */
+    ossl_quic_stream_map_gc(&ch->qsm);
+
     /* Determine the time at which we should next be ticked. */
     res->tick_deadline = ch_determine_next_tick_deadline(ch);
 

--- a/ssl/quic/quic_channel.c
+++ b/ssl/quic/quic_channel.c
@@ -845,7 +845,7 @@ static int ch_on_transport_params(const unsigned char *params,
              * This is correct; the BIDI_LOCAL TP governs streams created by
              * the endpoint which sends the TP, i.e., our peer.
              */
-            ch->init_max_stream_data_bidi_remote = v;
+            ch->rx_init_max_stream_data_bidi_remote = v;
             got_initial_max_stream_data_bidi_local = 1;
             break;
 
@@ -865,7 +865,7 @@ static int ch_on_transport_params(const unsigned char *params,
              * This is correct; the BIDI_REMOTE TP governs streams created
              * by the endpoint which receives the TP, i.e., us.
              */
-            ch->init_max_stream_data_bidi_local = v;
+            ch->rx_init_max_stream_data_bidi_local = v;
 
             /* Apply to stream 0. */
             ossl_quic_txfc_bump_cwm(&ch->stream0->txfc, v);
@@ -884,7 +884,7 @@ static int ch_on_transport_params(const unsigned char *params,
                 goto malformed;
             }
 
-            ch->init_max_stream_data_uni_remote = v;
+            ch->rx_init_max_stream_data_uni_remote = v;
             got_initial_max_stream_data_uni = 1;
             break;
 

--- a/ssl/quic/quic_channel.c
+++ b/ssl/quic/quic_channel.c
@@ -225,26 +225,6 @@ static int ch_init(QUIC_CHANNEL *ch)
             goto err;
     }
 
-    if ((ch->stream0 = ossl_quic_stream_map_alloc(&ch->qsm, 0,
-                                                  QUIC_STREAM_INITIATOR_CLIENT
-                                                  | QUIC_STREAM_DIR_BIDI)) == NULL)
-        goto err;
-
-    if ((ch->stream0->sstream = ossl_quic_sstream_new(INIT_APP_BUF_LEN)) == NULL)
-        goto err;
-
-    if ((ch->stream0->rstream = ossl_quic_rstream_new(NULL, NULL, 0)) == NULL)
-        goto err;
-
-    if (!ossl_quic_txfc_init(&ch->stream0->txfc, &ch->conn_txfc))
-        goto err;
-
-    if (!ossl_quic_rxfc_init(&ch->stream0->rxfc, &ch->conn_rxfc,
-                             1 * 1024 * 1024,
-                             5 * 1024 * 1024,
-                             get_time, ch))
-        goto err;
-
     /* Plug in the TLS handshake layer. */
     tls_args.s                          = ch->tls;
     tls_args.crypto_send_cb             = ch_on_crypto_send;
@@ -310,11 +290,6 @@ static void ch_cleanup(QUIC_CHANNEL *ch)
     if (ch->have_statm)
         ossl_statm_destroy(&ch->statm);
     ossl_ackm_free(ch->ackm);
-
-    if (ch->stream0 != NULL) {
-        assert(ch->have_qsm);
-        ossl_quic_stream_map_release(&ch->qsm, ch->stream0); /* frees sstream */
-    }
 
     if (ch->have_qsm)
         ossl_quic_stream_map_cleanup(&ch->qsm);

--- a/ssl/quic/quic_channel.c
+++ b/ssl/quic/quic_channel.c
@@ -2301,11 +2301,11 @@ err:
 QUIC_STREAM *ossl_quic_channel_new_stream_local(QUIC_CHANNEL *ch, int is_uni)
 {
     QUIC_STREAM *qs;
-    int type = 0;
+    int type;
     uint64_t stream_id, *p_next_ordinal;
 
-    type |= ch->is_server ? QUIC_STREAM_INITIATOR_SERVER
-                          : QUIC_STREAM_INITIATOR_CLIENT;
+    type = ch->is_server ? QUIC_STREAM_INITIATOR_SERVER
+                         : QUIC_STREAM_INITIATOR_CLIENT;
 
     if (is_uni) {
         p_next_ordinal = &ch->next_local_stream_ordinal_uni;

--- a/ssl/quic/quic_channel.c
+++ b/ssl/quic/quic_channel.c
@@ -2380,9 +2380,11 @@ void ossl_quic_channel_set_incoming_stream_auto_reject(QUIC_CHANNEL *ch,
 
 void ossl_quic_channel_reject_stream(QUIC_CHANNEL *ch, QUIC_STREAM *qs)
 {
-    ossl_quic_stream_stop_sending(qs, ch->incoming_stream_auto_reject_aec);
-    ossl_quic_stream_reset(qs, ch->incoming_stream_auto_reject_aec);
+    ossl_quic_stream_map_stop_sending_recv_part(&ch->qsm, qs,
+                                                ch->incoming_stream_auto_reject_aec);
 
+    ossl_quic_stream_map_reset_stream_send_part(&ch->qsm, qs,
+                                                ch->incoming_stream_auto_reject_aec);
     qs->deleted = 1;
 
     ossl_quic_stream_map_update_state(&ch->qsm, qs);

--- a/ssl/quic/quic_channel.c
+++ b/ssl/quic/quic_channel.c
@@ -445,9 +445,10 @@ int ossl_quic_channel_is_term_any(const QUIC_CHANNEL *ch)
         || ossl_quic_channel_is_terminated(ch);
 }
 
-QUIC_TERMINATE_CAUSE ossl_quic_channel_get_terminate_cause(const QUIC_CHANNEL *ch)
+const QUIC_TERMINATE_CAUSE *
+ossl_quic_channel_get_terminate_cause(const QUIC_CHANNEL *ch)
 {
-    return ch->terminate_cause;
+    return ossl_quic_channel_is_term_any(ch) ? &ch->terminate_cause : NULL;
 }
 
 int ossl_quic_channel_is_handshake_complete(const QUIC_CHANNEL *ch)

--- a/ssl/quic/quic_channel_local.h
+++ b/ssl/quic/quic_channel_local.h
@@ -167,6 +167,12 @@ struct quic_channel_st {
     uint64_t                        next_local_stream_ordinal_bidi;
     uint64_t                        next_local_stream_ordinal_uni;
 
+    /*
+     * Application error code to be used for STOP_SENDING/RESET_STREAM frames
+     * used to autoreject incoming streams.
+     */
+    uint64_t                        incoming_stream_auto_reject_aec;
+
     /* Valid if we are in the TERMINATING or TERMINATED states. */
     QUIC_TERMINATE_CAUSE            terminate_cause;
 
@@ -290,6 +296,9 @@ struct quic_channel_st {
      * 10.1).
      */
     unsigned int                    have_sent_ack_eliciting_since_rx    : 1;
+
+    /* Should incoming streams automatically be rejected? */
+    unsigned int                    incoming_stream_auto_reject         : 1;
 };
 
 # endif

--- a/ssl/quic/quic_channel_local.h
+++ b/ssl/quic/quic_channel_local.h
@@ -69,9 +69,13 @@ struct quic_channel_st {
     OSSL_QUIC_TX_PACKETISER         *txp;
     QUIC_TXPIM                      *txpim;
     QUIC_CFQ                        *cfq;
-    /* Connection level FC. */
+    /*
+     * Connection level FC. The stream_count RXFCs is used to manage
+     * MAX_STREAMS signalling.
+     */
     QUIC_TXFC                       conn_txfc;
     QUIC_RXFC                       conn_rxfc;
+    QUIC_RXFC                       max_streams_bidi_rxfc, max_streams_uni_rxfc;
     QUIC_STREAM_MAP                 qsm;
     OSSL_STATM                      statm;
     OSSL_CC_DATA                    *cc_data;

--- a/ssl/quic/quic_channel_local.h
+++ b/ssl/quic/quic_channel_local.h
@@ -124,9 +124,9 @@ struct quic_channel_st {
     QUIC_CONN_ID                    cur_local_dcid;
 
     /* Transport parameter values received from server. */
-    uint64_t                        init_max_stream_data_bidi_local;
-    uint64_t                        init_max_stream_data_bidi_remote;
-    uint64_t                        init_max_stream_data_uni_remote;
+    uint64_t                        rx_init_max_stream_data_bidi_local;
+    uint64_t                        rx_init_max_stream_data_bidi_remote;
+    uint64_t                        rx_init_max_stream_data_uni_remote;
     uint64_t                        rx_max_ack_delay; /* ms */
     unsigned char                   rx_ack_delay_exp;
 

--- a/ssl/quic/quic_channel_local.h
+++ b/ssl/quic/quic_channel_local.h
@@ -159,6 +159,14 @@ struct quic_channel_st {
     /* Maximum active CID limit, as negotiated by transport parameters. */
     uint64_t                        rx_active_conn_id_limit;
 
+    /*
+     * Used to allocate stream IDs. This is a stream ordinal, i.e., a stream ID
+     * without the low two bits designating type and initiator. Shift and or in
+     * the type bits to convert to a stream ID.
+     */
+    uint64_t                        next_local_stream_ordinal_bidi;
+    uint64_t                        next_local_stream_ordinal_uni;
+
     /* Valid if we are in the TERMINATING or TERMINATED states. */
     QUIC_TERMINATE_CAUSE            terminate_cause;
 

--- a/ssl/quic/quic_channel_local.h
+++ b/ssl/quic/quic_channel_local.h
@@ -131,7 +131,7 @@ struct quic_channel_st {
     /* Transport parameter values received from server. */
     uint64_t                        rx_init_max_stream_data_bidi_local;
     uint64_t                        rx_init_max_stream_data_bidi_remote;
-    uint64_t                        rx_init_max_stream_data_uni_remote;
+    uint64_t                        rx_init_max_stream_data_uni;
     uint64_t                        rx_max_ack_delay; /* ms */
     unsigned char                   rx_ack_delay_exp;
 

--- a/ssl/quic/quic_channel_local.h
+++ b/ssl/quic/quic_channel_local.h
@@ -97,12 +97,6 @@ struct quic_channel_st {
     QUIC_SSTREAM                    *crypto_send[QUIC_PN_SPACE_NUM];
     QUIC_RSTREAM                    *crypto_recv[QUIC_PN_SPACE_NUM];
 
-    /*
-     * Our (currently only) application data stream. This is a bidirectional
-     * client-initiated stream and thus (in QUICv1) always has a stream ID of 0.
-     */
-    QUIC_STREAM                     *stream0;
-
     /* Internal state. */
     /*
      * Client: The DCID used in the first Initial packet we transmit as a client.

--- a/ssl/quic/quic_channel_local.h
+++ b/ssl/quic/quic_channel_local.h
@@ -168,6 +168,15 @@ struct quic_channel_st {
     uint64_t                        next_local_stream_ordinal_uni;
 
     /*
+     * Used to track which stream ordinals within a given stream type have been
+     * used by the remote peer. This is an optimisation used to determine
+     * which streams should be implicitly created due to usage of a higher
+     * stream ordinal.
+     */
+    uint64_t                        next_remote_stream_ordinal_bidi;
+    uint64_t                        next_remote_stream_ordinal_uni;
+
+    /*
      * Application error code to be used for STOP_SENDING/RESET_STREAM frames
      * used to autoreject incoming streams.
      */

--- a/ssl/quic/quic_channel_local.h
+++ b/ssl/quic/quic_channel_local.h
@@ -123,6 +123,11 @@ struct quic_channel_st {
     /* Server only: The DCID we currently expect the peer to use to talk to us. */
     QUIC_CONN_ID                    cur_local_dcid;
 
+    /* Transport parameter values we send to our peer. */
+    uint64_t                        tx_init_max_stream_data_bidi_local;
+    uint64_t                        tx_init_max_stream_data_bidi_remote;
+    uint64_t                        tx_init_max_stream_data_uni;
+
     /* Transport parameter values received from server. */
     uint64_t                        rx_init_max_stream_data_bidi_local;
     uint64_t                        rx_init_max_stream_data_bidi_remote;

--- a/ssl/quic/quic_fc.c
+++ b/ssl/quic/quic_fc.c
@@ -146,6 +146,21 @@ int ossl_quic_rxfc_init(QUIC_RXFC *rxfc, QUIC_RXFC *conn_rxfc,
     rxfc->now               = now;
     rxfc->now_arg           = now_arg;
     rxfc->is_fin            = 0;
+    rxfc->stream_count_mode = 0;
+    return 1;
+}
+
+int ossl_quic_rxfc_init_for_stream_count(QUIC_RXFC *rxfc,
+                                         uint64_t initial_window_size,
+                                         OSSL_TIME (*now)(void *arg),
+                                         void *now_arg)
+{
+    if (!ossl_quic_rxfc_init(rxfc, NULL,
+                             initial_window_size, initial_window_size,
+                             now, now_arg))
+        return 0;
+
+    rxfc->stream_count_mode = 1;
     return 1;
 }
 
@@ -185,7 +200,7 @@ int ossl_quic_rxfc_on_rx_stream_frame(QUIC_RXFC *rxfc, uint64_t end, int is_fin)
 {
     uint64_t delta;
 
-    if (rxfc->parent == NULL)
+    if (!rxfc->stream_count_mode && rxfc->parent == NULL)
         return 0;
 
     if (rxfc->is_fin && ((is_fin && rxfc->hwm != end) || end > rxfc->hwm)) {
@@ -201,8 +216,9 @@ int ossl_quic_rxfc_on_rx_stream_frame(QUIC_RXFC *rxfc, uint64_t end, int is_fin)
         delta = end - rxfc->hwm;
         rxfc->hwm = end;
 
-        on_rx_controlled_bytes(rxfc, delta);           /* result ignored */
-        on_rx_controlled_bytes(rxfc->parent, delta);   /* result ignored */
+        on_rx_controlled_bytes(rxfc, delta);             /* result ignored */
+        if (rxfc->parent != NULL)
+            on_rx_controlled_bytes(rxfc->parent, delta); /* result ignored */
     } else if (end < rxfc->hwm && is_fin) {
         rxfc->error_code = QUIC_ERR_FINAL_SIZE_ERROR;
         return 1; /* not a caller error */

--- a/ssl/quic/quic_fifd.c
+++ b/ssl/quic/quic_fifd.c
@@ -26,7 +26,10 @@ int ossl_quic_fifd_init(QUIC_FIFD *fifd,
                                             uint64_t stream_id,
                                             QUIC_TXPIM_PKT *pkt,
                                             void *arg),
-                        void *regen_frame_arg)
+                        void *regen_frame_arg,
+                        void (*sstream_updated)(uint64_t stream_id,
+                                                void *arg),
+                        void *sstream_updated_arg)
 {
     if (cfq == NULL || ackm == NULL || txpim == NULL
         || get_sstream_by_id == NULL || regen_frame == NULL)
@@ -39,6 +42,8 @@ int ossl_quic_fifd_init(QUIC_FIFD *fifd,
     fifd->get_sstream_by_id_arg = get_sstream_by_id_arg;
     fifd->regen_frame           = regen_frame;
     fifd->regen_frame_arg       = regen_frame_arg;
+    fifd->sstream_updated       = sstream_updated;
+    fifd->sstream_updated_arg   = sstream_updated_arg;
     return 1;
 }
 
@@ -89,6 +94,7 @@ static void on_lost(void *arg)
     size_t i, num_chunks = ossl_quic_txpim_pkt_get_num_chunks(pkt);
     QUIC_SSTREAM *sstream;
     QUIC_CFQ_ITEM *cfq_item, *cfq_item_next;
+    int sstream_updated;
 
     /* STREAM and CRYPTO stream chunks, FIN and stream FC frames */
     for (i = 0; i < num_chunks; ++i) {
@@ -98,12 +104,18 @@ static void on_lost(void *arg)
         if (sstream == NULL)
             continue;
 
-        if (chunks[i].end >= chunks[i].start)
+        sstream_updated = 0;
+
+        if (chunks[i].end >= chunks[i].start) {
             ossl_quic_sstream_mark_lost(sstream,
                                         chunks[i].start, chunks[i].end);
+            sstream_updated = 1;
+        }
 
-        if (chunks[i].has_fin && chunks[i].stream_id != UINT64_MAX)
+        if (chunks[i].has_fin && chunks[i].stream_id != UINT64_MAX) {
             ossl_quic_sstream_mark_lost_fin(sstream);
+            sstream_updated = 1;
+        }
 
         if (chunks[i].has_stop_sending && chunks[i].stream_id != UINT64_MAX)
             fifd->regen_frame(OSSL_QUIC_FRAME_TYPE_STOP_SENDING,
@@ -129,6 +141,10 @@ static void on_lost(void *arg)
                           chunks[i].stream_id,
                           pkt,
                           fifd->regen_frame_arg);
+
+        if (sstream_updated && chunks[i].stream_id != UINT64_MAX)
+            fifd->sstream_updated(chunks[i].stream_id,
+                                  fifd->sstream_updated_arg);
     }
 
     /* GCR */

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -1225,7 +1225,11 @@ static int quic_wait_for_stream(void *arg)
     }
 
     args->qs = ossl_quic_stream_map_get_by_id(ossl_quic_channel_get_qsm(args->qc->ch),
-                                              args->expect_id);
+                                              args->expect_id | QUIC_STREAM_DIR_BIDI);
+    if (args->qs == NULL)
+        args->qs = ossl_quic_stream_map_get_by_id(ossl_quic_channel_get_qsm(args->qc->ch),
+                                                  args->expect_id | QUIC_STREAM_DIR_UNI);
+
     if (args->qs != NULL)
         return 1; /* stream now exists */
 
@@ -1259,12 +1263,12 @@ static int qc_wait_for_default_xso_for_read(QUIC_CONNECTION *qc)
         ? QUIC_STREAM_INITIATOR_CLIENT
         : QUIC_STREAM_INITIATOR_SERVER;
 
-    expect_id |= (qc->default_stream_mode == SSL_DEFAULT_STREAM_MODE_AUTO_UNI)
-        ? QUIC_STREAM_DIR_UNI
-        : QUIC_STREAM_DIR_BIDI;
-
     qs = ossl_quic_stream_map_get_by_id(ossl_quic_channel_get_qsm(qc->ch),
-                                        expect_id);
+                                        expect_id | QUIC_STREAM_DIR_BIDI);
+    if (qs == NULL)
+        qs = ossl_quic_stream_map_get_by_id(ossl_quic_channel_get_qsm(qc->ch),
+                                            expect_id | QUIC_STREAM_DIR_UNI);
+
     if (qs == NULL) {
         ossl_quic_reactor_tick(ossl_quic_channel_get_reactor(qc->ch), 0);
 

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -1868,6 +1868,20 @@ int ossl_quic_get_stream_type(SSL *s)
 }
 
 /*
+ * SSL_get_stream_id
+ * -----------------
+ */
+uint64_t ossl_quic_get_stream_id(SSL *s)
+{
+    QCTX ctx;
+
+    if (!expect_quic_with_stream(s, /*remote_init=*/-1, &ctx))
+        return UINT64_MAX;
+
+    return ctx.xso->stream->id;
+}
+
+/*
  * QUIC Front-End I/O API: SSL_CTX Management
  * ==========================================
  */

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -1822,6 +1822,20 @@ int SSL_inject_net_dgram(SSL *s, const unsigned char *buf,
 }
 
 /*
+ * SSL_get0_connection
+ * -------------------
+ */
+SSL *ossl_quic_get0_connection(SSL *s)
+{
+    QCTX ctx;
+
+    if (!expect_quic(s, &ctx))
+        return NULL;
+
+    return &ctx.qc->ssl;
+}
+
+/*
  * QUIC Front-End I/O API: SSL_CTX Management
  * ==========================================
  */

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -520,7 +520,13 @@ static void qc_set_default_xso_keep_ref(QUIC_CONNECTION *qc, QUIC_XSO *xso,
              * Changing from not having a default XSO to having one. The new XSO
              * will have had a reference to the QC we need to drop to avoid a
              * circular reference.
+             *
+             * Currently we never change directly from one default XSO to
+             * another, though this function would also still be correct if this
+             * weren't the case.
              */
+            assert(*old_xso == NULL);
+
             CRYPTO_DOWN_REF(&qc->ssl.references, &refs, &qc->ssl.lock);
             assert(refs > 0);
         }

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -1966,7 +1966,7 @@ QUIC_TAKES_LOCK
 static size_t ossl_quic_pending_int(const SSL *s)
 {
     QCTX ctx;
-    size_t avail;
+    size_t avail = 0;
     int fin = 0;
 
     if (!expect_quic_with_stream_lock(s, /*remote_init=*/-1, &ctx))

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -2231,6 +2231,7 @@ SSL *ossl_quic_accept_stream(SSL *s, uint64_t flags)
     QUIC_STREAM_MAP *qsm;
     QUIC_STREAM *qs;
     QUIC_XSO *xso;
+    OSSL_RTT_INFO rtt_info;
 
     if (!expect_quic_conn_only(s, &ctx))
         return NULL;
@@ -2270,7 +2271,9 @@ SSL *ossl_quic_accept_stream(SSL *s, uint64_t flags)
     if (xso == NULL)
         goto out;
 
-    ossl_quic_stream_map_remove_from_accept_queue(qsm, qs);
+    ossl_statm_get_rtt_info(ossl_quic_channel_get_statm(ctx.qc->ch), &rtt_info);
+    ossl_quic_stream_map_remove_from_accept_queue(qsm, qs,
+                                                  rtt_info.smoothed_rtt);
     new_s = &xso->ssl;
 
     /* Calling this function inhibits default XSO autocreation. */

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -247,6 +247,9 @@ SSL *ossl_quic_new(SSL_CTX *ctx)
     qc->is_thread_assisted
         = (ssl_base->method == OSSL_QUIC_client_thread_method());
 
+    qc->as_server       = 0; /* TODO(QUIC): server support */
+    qc->as_server_state = qc->as_server;
+
     /* Channel is not created yet. */
     qc->ssl_mode   = qc->ssl.ctx->mode;
     qc->last_error = SSL_ERROR_NONE;
@@ -803,7 +806,7 @@ void ossl_quic_set_connect_state(SSL *s)
     if (ctx.qc->started)
         return;
 
-    ctx.qc->as_server = 0;
+    ctx.qc->as_server_state = 0;
 }
 
 /* SSL_set_accept_state */
@@ -818,7 +821,7 @@ void ossl_quic_set_accept_state(SSL *s)
     if (ctx.qc->started)
         return;
 
-    ctx.qc->as_server = 1;
+    ctx.qc->as_server_state = 1;
 }
 
 /* SSL_do_handshake */
@@ -926,7 +929,7 @@ static int quic_do_handshake(QUIC_CONNECTION *qc)
         return -1; /* Non-protocol error */
     }
 
-    if (qc->as_server) {
+    if (qc->as_server != qc->as_server_state) {
         /* TODO(QUIC): Server mode not currently supported */
         QUIC_RAISE_NON_NORMAL_ERROR(qc, ERR_R_PASSED_INVALID_ARGUMENT, NULL);
         return -1; /* Non-protocol error */

--- a/ssl/quic/quic_local.h
+++ b/ssl/quic/quic_local.h
@@ -169,6 +169,9 @@ struct quic_conn_st {
     /* Do newly created streams start in blocking mode? Inherited by new XSOs. */
     unsigned int                    default_blocking        : 1;
 
+    /* Have we created a default XSO yet? */
+    unsigned int                    default_xso_created     : 1;
+
     /* SSL_set_mode. This is not used directly but inherited by new XSOs. */
     uint32_t                        default_ssl_mode;
 

--- a/ssl/quic/quic_local.h
+++ b/ssl/quic/quic_local.h
@@ -27,7 +27,7 @@
 # ifndef OPENSSL_NO_QUIC
 
 /*
- * QUIC stream SSL object (QCSO) type. This implements the API personality layer
+ * QUIC stream SSL object (QSSO) type. This implements the API personality layer
  * for QSSO objects, wrapping the QUIC-native QUIC_STREAM object and tracking
  * state required by the libssl API personality.
  */

--- a/ssl/quic/quic_local.h
+++ b/ssl/quic/quic_local.h
@@ -178,6 +178,10 @@ struct quic_conn_st {
     /* SSL_set_mode. This is not used directly but inherited by new XSOs. */
     uint32_t                        default_ssl_mode;
 
+    /* SSL_set_incoming_stream_reject_policy. */
+    int                             incoming_stream_reject_policy;
+    uint64_t                        incoming_stream_reject_aec;
+
     /*
      * Last 'normal' error during an app-level I/O operation, used by
      * SSL_get_error(); used to track data-path errors like SSL_ERROR_WANT_READ

--- a/ssl/quic/quic_local.h
+++ b/ssl/quic/quic_local.h
@@ -178,9 +178,9 @@ struct quic_conn_st {
     /* SSL_set_mode. This is not used directly but inherited by new XSOs. */
     uint32_t                        default_ssl_mode;
 
-    /* SSL_set_incoming_stream_reject_policy. */
-    int                             incoming_stream_reject_policy;
-    uint64_t                        incoming_stream_reject_aec;
+    /* SSL_set_incoming_stream_policy. */
+    int                             incoming_stream_policy;
+    uint64_t                        incoming_stream_aec;
 
     /*
      * Last 'normal' error during an app-level I/O operation, used by

--- a/ssl/quic/quic_local.h
+++ b/ssl/quic/quic_local.h
@@ -86,10 +86,16 @@ struct quic_conn_st {
     unsigned int                    can_poll_net_wbio       : 1;
 
     /*
-     * Has the application called SSL_set_accept_state? We do not support this
-     * but track it here so we can reject a subsequent handshake call.
+     * This is 1 if we were instantiated using a QUIC server method
+     * (for future use).
      */
     unsigned int                    as_server               : 1;
+
+    /*
+     * Has the application called SSL_set_accept_state? We require this to be
+     * congruent with the value of as_server.
+     */
+    unsigned int                    as_server_state         : 1;
 
     /* Are we using thread assisted mode? Never changes after init. */
     unsigned int                    is_thread_assisted      : 1;

--- a/ssl/quic/quic_local.h
+++ b/ssl/quic/quic_local.h
@@ -138,6 +138,9 @@ struct quic_conn_st {
     OSSL_TIME                       (*override_now_cb)(void *arg);
     void                            *override_now_cb_arg;
 
+    /* Number of XSOs allocated. Includes the default XSO, if any. */
+    size_t                          num_xso;
+
     /* Have we started? */
     unsigned int                    started                 : 1;
 

--- a/ssl/quic/quic_local.h
+++ b/ssl/quic/quic_local.h
@@ -179,10 +179,15 @@ void ossl_quic_conn_on_remote_conn_close(QUIC_CONNECTION *qc,
       : ((ssl)->type == SSL_TYPE_QUIC_CONNECTION                 \
          ? (c SSL_CONNECTION *)((c QUIC_CONNECTION *)(ssl))->tls \
          : NULL))
+
+#  define IS_QUIC(ssl) ((ssl) != NULL                                   \
+                        && ((ssl)->type == SSL_TYPE_QUIC_CONNECTION     \
+                            || (ssl)->type == SSL_TYPE_QUIC_XSO))
 # else
 #  define QUIC_CONNECTION_FROM_SSL_int(ssl, c) NULL
 #  define QUIC_XSO_FROM_SSL_int(ssl, c) NULL
 #  define SSL_CONNECTION_FROM_QUIC_SSL_int(ssl, c) NULL
+#  define IS_QUIC(ssl) 0
 # endif
 
 # define QUIC_CONNECTION_FROM_SSL(ssl) \

--- a/ssl/quic/quic_local.h
+++ b/ssl/quic/quic_local.h
@@ -172,6 +172,9 @@ struct quic_conn_st {
     /* Have we created a default XSO yet? */
     unsigned int                    default_xso_created     : 1;
 
+    /* Default stream type. Defaults to SSL_DEFAULT_STREAM_MODE_AUTO_BIDI. */
+    uint32_t                        default_stream_mode;
+
     /* SSL_set_mode. This is not used directly but inherited by new XSOs. */
     uint32_t                        default_ssl_mode;
 

--- a/ssl/quic/quic_record_rx.c
+++ b/ssl/quic/quic_record_rx.c
@@ -190,6 +190,7 @@ static void qrx_cleanup_urxl(OSSL_QRX *qrx, QUIC_URXE_LIST *l)
 
     for (e = ossl_list_urxe_head(l); e != NULL; e = enext) {
         enext = ossl_list_urxe_next(e);
+        ossl_list_urxe_remove(l, e);
         ossl_quic_demux_release_urxe(qrx->demux, e);
     }
 }

--- a/ssl/quic/quic_rx_depack.c
+++ b/ssl/quic/quic_rx_depack.c
@@ -172,7 +172,14 @@ static int depack_do_frame_stop_sending(PACKET *pkt,
     }
 
     stream->peer_stop_sending = 1;
-    ossl_quic_stream_map_update_state(&ch->qsm, stream);
+
+    /*
+     * RFC 9000 s. 3.5: Receiving a STOP_SENDING frame means we must respond in
+     * turn with a RESET_STREAM frame for the same part of the stream. The other
+     * part is unaffected.
+     */
+    ossl_quic_stream_map_reset_stream_send_part(&ch->qsm, stream,
+                                                frame_data.app_error_code);
     return 1;
 }
 

--- a/ssl/quic/quic_rx_depack.c
+++ b/ssl/quic/quic_rx_depack.c
@@ -129,7 +129,9 @@ static int depack_do_frame_reset_stream(PACKET *pkt,
         return 0;
     }
 
-    stream->peer_reset_stream = 1;
+    stream->peer_reset_stream       = 1;
+    stream->peer_reset_stream_aec   = frame_data.app_error_code;
+
     ossl_quic_stream_map_update_state(&ch->qsm, stream);
     return 1;
 }
@@ -171,7 +173,8 @@ static int depack_do_frame_stop_sending(PACKET *pkt,
         return 0;
     }
 
-    stream->peer_stop_sending = 1;
+    stream->peer_stop_sending       = 1;
+    stream->peer_stop_sending_aec   = frame_data.app_error_code;
 
     /*
      * RFC 9000 s. 3.5: Receiving a STOP_SENDING frame means we must respond in

--- a/ssl/quic/quic_tserver.c
+++ b/ssl/quic/quic_tserver.c
@@ -363,3 +363,37 @@ BIO *ossl_quic_tserver_get0_rbio(QUIC_TSERVER *srv)
 {
     return srv->args.net_rbio;
 }
+
+int ossl_quic_tserver_stream_has_peer_stop_sending(QUIC_TSERVER *srv,
+                                                   uint64_t stream_id,
+                                                   uint64_t *app_error_code)
+{
+    QUIC_STREAM *qs;
+
+    qs = ossl_quic_stream_map_get_by_id(ossl_quic_channel_get_qsm(srv->ch),
+                                        stream_id);
+    if (qs == NULL)
+        return 0;
+
+    if (qs->peer_stop_sending && app_error_code != NULL)
+        *app_error_code = qs->peer_stop_sending_aec;
+
+    return qs->peer_stop_sending;
+}
+
+int ossl_quic_tserver_stream_has_peer_reset_stream(QUIC_TSERVER *srv,
+                                                   uint64_t stream_id,
+                                                   uint64_t  *app_error_code)
+{
+    QUIC_STREAM *qs;
+
+    qs = ossl_quic_stream_map_get_by_id(ossl_quic_channel_get_qsm(srv->ch),
+                                        stream_id);
+    if (qs == NULL)
+        return 0;
+
+    if (qs->peer_reset_stream && app_error_code != NULL)
+        *app_error_code = qs->peer_reset_stream_aec;
+
+    return qs->peer_reset_stream;
+}

--- a/ssl/quic/quic_tserver.c
+++ b/ssl/quic/quic_tserver.c
@@ -169,7 +169,8 @@ int ossl_quic_tserver_is_term_any(const QUIC_TSERVER *srv)
     return ossl_quic_channel_is_term_any(srv->ch);
 }
 
-QUIC_TERMINATE_CAUSE ossl_quic_tserver_get_terminate_cause(const QUIC_TSERVER *srv)
+const QUIC_TERMINATE_CAUSE *
+ossl_quic_tserver_get_terminate_cause(const QUIC_TSERVER *srv)
 {
     return ossl_quic_channel_get_terminate_cause(srv->ch);
 }

--- a/ssl/ssl_err.c
+++ b/ssl/ssl_err.c
@@ -311,6 +311,7 @@ static const ERR_STRING_DATA SSL_str_reasons[] = {
     {ERR_PACK(ERR_LIB_SSL, 0, SSL_R_NO_SHARED_SIGNATURE_ALGORITHMS),
     "no shared signature algorithms"},
     {ERR_PACK(ERR_LIB_SSL, 0, SSL_R_NO_SRTP_PROFILES), "no srtp profiles"},
+    {ERR_PACK(ERR_LIB_SSL, 0, SSL_R_NO_STREAM), "no stream"},
     {ERR_PACK(ERR_LIB_SSL, 0, SSL_R_NO_SUITABLE_DIGEST_ALGORITHM),
     "no suitable digest algorithm"},
     {ERR_PACK(ERR_LIB_SSL, 0, SSL_R_NO_SUITABLE_GROUPS), "no suitable groups"},

--- a/ssl/ssl_err.c
+++ b/ssl/ssl_err.c
@@ -104,6 +104,7 @@ static const ERR_STRING_DATA SSL_str_reasons[] = {
     "compression library error"},
     {ERR_PACK(ERR_LIB_SSL, 0, SSL_R_CONNECTION_TYPE_NOT_SET),
     "connection type not set"},
+    {ERR_PACK(ERR_LIB_SSL, 0, SSL_R_CONN_USE_ONLY), "conn use only"},
     {ERR_PACK(ERR_LIB_SSL, 0, SSL_R_CONTEXT_NOT_DANE_ENABLED),
     "context not dane enabled"},
     {ERR_PACK(ERR_LIB_SSL, 0, SSL_R_COOKIE_GEN_CALLBACK_FAILURE),

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -7328,6 +7328,18 @@ int SSL_is_connection(SSL *s)
     return SSL_get0_connection(s) == s;
 }
 
+int SSL_get_stream_type(SSL *s)
+{
+#ifndef OPENSSL_NO_QUIC
+    if (!IS_QUIC(s))
+        return SSL_STREAM_TYPE_BIDI;
+
+    return ossl_quic_get_stream_type(s);
+#else
+    return SSL_STREAM_TYPE_BIDI;
+#endif
+}
+
 int SSL_add_expected_rpk(SSL *s, EVP_PKEY *rpk)
 {
     unsigned char *data = NULL;

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -7400,6 +7400,30 @@ int SSL_set_incoming_stream_reject_policy(SSL *s, int policy, uint64_t aec)
 #endif
 }
 
+SSL *SSL_accept_stream(SSL *s, uint64_t flags)
+{
+#ifndef OPENSSL_NO_QUIC
+    if (!IS_QUIC(s))
+        return NULL;
+
+    return ossl_quic_accept_stream(s, flags);
+#else
+    return NULL;
+#endif
+}
+
+size_t SSL_get_accept_stream_queue_len(SSL *s)
+{
+#ifndef OPENSSL_NO_QUIC
+    if (!IS_QUIC(s))
+        return 0;
+
+    return ossl_quic_get_accept_stream_queue_len(s);
+#else
+    return 0;
+#endif
+}
+
 int SSL_add_expected_rpk(SSL *s, EVP_PKEY *rpk)
 {
     unsigned char *data = NULL;

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -7311,6 +7311,18 @@ SSL *SSL_new_stream(SSL *s, uint64_t flags)
 #endif
 }
 
+SSL *SSL_get0_connection(SSL *s)
+{
+#ifndef OPENSSL_NO_QUIC
+    if (!IS_QUIC(s))
+        return s;
+
+    return ossl_quic_get0_connection(s);
+#else
+    return s;
+#endif
+}
+
 int SSL_add_expected_rpk(SSL *s, EVP_PKEY *rpk)
 {
     unsigned char *data = NULL;

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -7385,13 +7385,13 @@ int SSL_attach_stream(SSL *conn, SSL *stream)
 #endif
 }
 
-int SSL_set_incoming_stream_reject_policy(SSL *s, int policy, uint64_t aec)
+int SSL_set_incoming_stream_policy(SSL *s, int policy, uint64_t aec)
 {
 #ifndef OPENSSL_NO_QUIC
     if (!IS_QUIC(s))
         return 0;
 
-    return ossl_quic_set_incoming_stream_reject_policy(s, policy, aec);
+    return ossl_quic_set_incoming_stream_policy(s, policy, aec);
 #else
     return 0;
 #endif

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -7388,6 +7388,18 @@ int SSL_attach_stream(SSL *conn, SSL *stream)
 #endif
 }
 
+int SSL_set_incoming_stream_reject_policy(SSL *s, int policy, uint64_t aec)
+{
+#ifndef OPENSSL_NO_QUIC
+    if (!IS_QUIC(s))
+        return 0;
+
+    return ossl_quic_set_incoming_stream_reject_policy(s, policy, aec);
+#else
+    return 0;
+#endif
+}
+
 int SSL_add_expected_rpk(SSL *s, EVP_PKEY *rpk)
 {
     unsigned char *data = NULL;

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -7340,6 +7340,18 @@ int SSL_get_stream_type(SSL *s)
 #endif
 }
 
+uint64_t SSL_get_stream_id(SSL *s)
+{
+#ifndef OPENSSL_NO_QUIC
+    if (!IS_QUIC(s))
+        return UINT64_MAX;
+
+    return ossl_quic_get_stream_id(s);
+#else
+    return UINT64_MAX;
+#endif
+}
+
 int SSL_add_expected_rpk(SSL *s, EVP_PKEY *rpk)
 {
     unsigned char *data = NULL;

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -7424,6 +7424,81 @@ size_t SSL_get_accept_stream_queue_len(SSL *s)
 #endif
 }
 
+int SSL_stream_reset(SSL *s,
+                     const SSL_STREAM_RESET_ARGS *args,
+                     size_t args_len)
+{
+#ifndef OPENSSL_NO_QUIC
+    if (!IS_QUIC(s))
+        return 0;
+
+    return ossl_quic_stream_reset(s, args, args_len);
+#else
+    return 0;
+#endif
+}
+
+int SSL_get_stream_read_state(SSL *s)
+{
+#ifndef OPENSSL_NO_QUIC
+    if (!IS_QUIC(s))
+        return SSL_STREAM_STATE_NONE;
+
+    return ossl_quic_get_stream_read_state(s);
+#else
+    return SSL_STREAM_STATE_NONE;
+#endif
+}
+
+int SSL_get_stream_write_state(SSL *s)
+{
+#ifndef OPENSSL_NO_QUIC
+    if (!IS_QUIC(s))
+        return SSL_STREAM_STATE_NONE;
+
+    return ossl_quic_get_stream_write_state(s);
+#else
+    return SSL_STREAM_STATE_NONE;
+#endif
+}
+
+int SSL_get_stream_read_error_code(SSL *s, uint64_t *app_error_code)
+{
+#ifndef OPENSSL_NO_QUIC
+    if (!IS_QUIC(s))
+        return -1;
+
+    return ossl_quic_get_stream_read_error_code(s, app_error_code);
+#else
+    return -1;
+#endif
+}
+
+int SSL_get_stream_write_error_code(SSL *s, uint64_t *app_error_code)
+{
+#ifndef OPENSSL_NO_QUIC
+    if (!IS_QUIC(s))
+        return -1;
+
+    return ossl_quic_get_stream_write_error_code(s, app_error_code);
+#else
+    return -1;
+#endif
+}
+
+int SSL_get_conn_close_info(SSL *s, SSL_CONN_CLOSE_INFO *info,
+                            size_t info_len)
+{
+#ifndef OPENSSL_NO_QUIC
+    if (!IS_QUIC(s))
+        return -1;
+
+    return ossl_quic_get_conn_close_info(s, info, info_len);
+#else
+    return -1;
+#endif
+}
+
 int SSL_add_expected_rpk(SSL *s, EVP_PKEY *rpk)
 {
     unsigned char *data = NULL;

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -7384,7 +7384,7 @@ int SSL_attach_stream(SSL *conn, SSL *stream)
 
     return ossl_quic_attach_stream(conn, stream);
 #else
-    return NULL;
+    return 0;
 #endif
 }
 

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -7361,30 +7361,6 @@ int SSL_set_default_stream_mode(SSL *s, uint32_t mode)
 #endif
 }
 
-SSL *SSL_detach_stream(SSL *s)
-{
-#ifndef OPENSSL_NO_QUIC
-    if (!IS_QUIC(s))
-        return NULL;
-
-    return ossl_quic_detach_stream(s);
-#else
-    return NULL;
-#endif
-}
-
-int SSL_attach_stream(SSL *conn, SSL *stream)
-{
-#ifndef OPENSSL_NO_QUIC
-    if (!IS_QUIC(conn))
-        return 0;
-
-    return ossl_quic_attach_stream(conn, stream);
-#else
-    return 0;
-#endif
-}
-
 int SSL_set_incoming_stream_policy(SSL *s, int policy, uint64_t aec)
 {
 #ifndef OPENSSL_NO_QUIC

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -7323,6 +7323,11 @@ SSL *SSL_get0_connection(SSL *s)
 #endif
 }
 
+int SSL_is_connection(SSL *s)
+{
+    return SSL_get0_connection(s) == s;
+}
+
 int SSL_add_expected_rpk(SSL *s, EVP_PKEY *rpk)
 {
     unsigned char *data = NULL;

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -7352,6 +7352,42 @@ uint64_t SSL_get_stream_id(SSL *s)
 #endif
 }
 
+int SSL_set_default_stream_mode(SSL *s, uint32_t mode)
+{
+#ifndef OPENSSL_NO_QUIC
+    if (!IS_QUIC(s))
+        return 0;
+
+    return ossl_quic_set_default_stream_mode(s, mode);
+#else
+    return 0;
+#endif
+}
+
+SSL *SSL_detach_stream(SSL *s)
+{
+#ifndef OPENSSL_NO_QUIC
+    if (!IS_QUIC(s))
+        return NULL;
+
+    return ossl_quic_detach_stream(s);
+#else
+    return NULL;
+#endif
+}
+
+int SSL_attach_stream(SSL *conn, SSL *stream)
+{
+#ifndef OPENSSL_NO_QUIC
+    if (!IS_QUIC(conn))
+        return 0;
+
+    return ossl_quic_attach_stream(conn, stream);
+#else
+    return NULL;
+#endif
+}
+
 int SSL_add_expected_rpk(SSL *s, EVP_PKEY *rpk)
 {
     unsigned char *data = NULL;

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -1874,13 +1874,11 @@ int SSL_has_pending(const SSL *s)
      * the records for some reason.
      */
     const SSL_CONNECTION *sc;
-#ifndef OPENSSL_NO_QUIC
-    const QUIC_CONNECTION *qc = QUIC_CONNECTION_FROM_CONST_SSL(s);
 
-    if (qc != NULL)
+#ifndef OPENSSL_NO_QUIC
+    if (IS_QUIC(s))
         return ossl_quic_has_pending(s);
 #endif
-
 
     sc = SSL_CONNECTION_FROM_CONST_SSL(s);
 
@@ -2692,10 +2690,9 @@ int SSL_shutdown(SSL *s)
      * (see ssl3_shutdown).
      */
     SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL(s);
-#ifndef OPENSSL_NO_QUIC
-    QUIC_CONNECTION *qc = QUIC_CONNECTION_FROM_SSL(s);
 
-    if (qc != NULL)
+#ifndef OPENSSL_NO_QUIC
+    if (IS_QUIC(s))
         return ossl_quic_conn_shutdown(s, 0, NULL, 0);
 #endif
 

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -7299,6 +7299,18 @@ int SSL_stream_conclude(SSL *ssl, uint64_t flags)
 #endif
 }
 
+SSL *SSL_new_stream(SSL *s, uint64_t flags)
+{
+#ifndef OPENSSL_NO_QUIC
+    if (!IS_QUIC(s))
+        return NULL;
+
+    return ossl_quic_conn_stream_new(s, flags);
+#else
+    return NULL;
+#endif
+}
+
 int SSL_add_expected_rpk(SSL *s, EVP_PKEY *rpk)
 {
     unsigned char *data = NULL;

--- a/test/build.info
+++ b/test/build.info
@@ -340,6 +340,10 @@ IF[{- !$disabled{tests} -}]
   INCLUDE[quic_client_test]=../include ../apps/include
   DEPEND[quic_client_test]=../libcrypto.a ../libssl.a libtestutil.a
 
+  SOURCE[quic_multistream_test]=quic_multistream_test.c
+  INCLUDE[quic_multistream_test]=../include ../apps/include
+  DEPEND[quic_multistream_test]=../libcrypto.a ../libssl.a libtestutil.a
+
   SOURCE[asynctest]=asynctest.c
   INCLUDE[asynctest]=../include ../apps/include
   DEPEND[asynctest]=../libcrypto
@@ -1095,7 +1099,7 @@ ENDIF
     PROGRAMS{noinst}=quic_wire_test quic_ackm_test quic_record_test
     PROGRAMS{noinst}=quic_fc_test quic_stream_test quic_cfq_test quic_txpim_test
     PROGRAMS{noinst}=quic_fifd_test quic_txp_test quic_tserver_test
-    PROGRAMS{noinst}=quic_client_test quic_cc_test
+    PROGRAMS{noinst}=quic_client_test quic_cc_test quic_multistream_test
   ENDIF
 
   SOURCE[quic_ackm_test]=quic_ackm_test.c cc_dummy.c

--- a/test/helpers/quictestlib.c
+++ b/test/helpers/quictestlib.c
@@ -312,7 +312,7 @@ int qtest_shutdown(QUIC_TSERVER *qtserv, SSL *clientssl)
 
 int qtest_check_server_transport_err(QUIC_TSERVER *qtserv, uint64_t code)
 {
-    QUIC_TERMINATE_CAUSE cause;
+    const QUIC_TERMINATE_CAUSE *cause;
 
     ossl_quic_tserver_tick(qtserv);
 
@@ -323,8 +323,9 @@ int qtest_check_server_transport_err(QUIC_TSERVER *qtserv, uint64_t code)
         return 0;
 
     cause = ossl_quic_tserver_get_terminate_cause(qtserv);
-    if  (!TEST_true(cause.remote)
-            || !TEST_uint64_t_eq(cause.error_code, code))
+    if  (!TEST_ptr(cause)
+            || !TEST_true(cause->remote)
+            || !TEST_uint64_t_eq(cause->error_code, code))
         return 0;
 
     return 1;

--- a/test/quic_fifd_test.c
+++ b/test/quic_fifd_test.c
@@ -40,6 +40,9 @@ static void regen_frame(uint64_t frame_type, uint64_t stream_id,
     regen_frame_p(frame_type, stream_id, pkt, arg);
 }
 
+static void sstream_updated(uint64_t stream_id, void *arg)
+{}
+
 typedef struct info_st {
     QUIC_FIFD fifd;
     OSSL_ACKM *ackm;
@@ -329,7 +332,8 @@ static int test_fifd(int idx)
         || !TEST_true(ossl_quic_fifd_init(&info.fifd, info.cfq, info.ackm,
                                           info.txpim,
                                           get_sstream_by_id, NULL,
-                                          regen_frame, NULL)))
+                                          regen_frame, NULL,
+                                          sstream_updated, NULL)))
         goto err;
 
     for (i = 0; i < OSSL_NELEM(info.sstream); ++i)

--- a/test/quic_fifd_test.c
+++ b/test/quic_fifd_test.c
@@ -40,6 +40,10 @@ static void regen_frame(uint64_t frame_type, uint64_t stream_id,
     regen_frame_p(frame_type, stream_id, pkt, arg);
 }
 
+static void confirm_frame(uint64_t frame_type, uint64_t stream_id,
+                          QUIC_TXPIM_PKT *pkt, void *arg)
+{}
+
 static void sstream_updated(uint64_t stream_id, void *arg)
 {}
 
@@ -333,6 +337,7 @@ static int test_fifd(int idx)
                                           info.txpim,
                                           get_sstream_by_id, NULL,
                                           regen_frame, NULL,
+                                          confirm_frame, NULL,
                                           sstream_updated, NULL)))
         goto err;
 

--- a/test/quic_multistream_test.c
+++ b/test/quic_multistream_test.c
@@ -1,0 +1,1203 @@
+/*
+ * Copyright 2023 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+#include <openssl/ssl.h>
+#include <openssl/quic.h>
+#include <openssl/bio.h>
+#include <openssl/lhash.h>
+#include "internal/quic_tserver.h"
+#include "testutil.h"
+
+static const char *certfile, *keyfile;
+
+typedef struct stream_info {
+    const char      *name;
+    SSL             *c_stream;
+    uint64_t        s_stream_id;
+} STREAM_INFO;
+
+DEFINE_LHASH_OF_EX(STREAM_INFO);
+
+struct helper {
+    int                     s_fd;
+    BIO                     *s_net_bio, *s_net_bio_own;
+    BIO_ADDR                *s_net_bio_addr;
+    QUIC_TSERVER            *s;
+    LHASH_OF(STREAM_INFO)   *s_streams;
+
+    int                     c_fd;
+    BIO                     *c_net_bio, *c_net_bio_own;
+    SSL_CTX                 *c_ctx;
+    SSL                     *c_conn;
+    LHASH_OF(STREAM_INFO)   *c_streams;
+
+    OSSL_TIME       start_time;
+    int             init, blocking;
+};
+
+struct script_op {
+    uint32_t        op;
+    const void      *arg0;
+    size_t          arg1;
+    int             (*check_func)(struct helper *h, const struct script_op *op);
+    const char      *stream_name;
+    uint64_t        arg2;
+};
+
+#define OPK_END                                     0
+#define OPK_CHECK                                   1
+#define OPK_C_SET_ALPN                              2
+#define OPK_C_CONNECT_WAIT                          3
+#define OPK_C_WRITE                                 4
+#define OPK_S_WRITE                                 5
+#define OPK_C_READ_EXPECT                           6
+#define OPK_S_READ_EXPECT                           7
+#define OPK_C_EXPECT_FIN                            8
+#define OPK_S_EXPECT_FIN                            9
+#define OPK_C_CONCLUDE                              10
+#define OPK_S_CONCLUDE                              11
+#define OPK_C_DETACH                                12
+#define OPK_C_ATTACH                                13
+#define OPK_C_NEW_STREAM                            14
+#define OPK_S_NEW_STREAM                            15
+#define OPK_C_ACCEPT_STREAM                         16
+#define OPK_C_ACCEPT_STREAM_NONE                    17
+#define OPK_C_FREE_STREAM                           18
+#define OPK_C_SET_DEFAULT_STREAM_MODE               19
+#define OPK_C_SET_INCOMING_STREAM_REJECT_POLICY     20
+#define OPK_C_SHUTDOWN                              21
+#define OPK_C_EXPECT_CONN_CLOSE_INFO                22
+#define OPK_S_EXPECT_CONN_CLOSE_INFO                23
+#define OPK_S_BIND_STREAM_ID                        24
+#define OPK_C_WAIT_FOR_DATA                         25
+#define OPK_C_WRITE_FAIL                            26
+#define OPK_S_WRITE_FAIL                            27
+#define OPK_C_READ_FAIL                             28
+#define OPK_C_STREAM_RESET                          29
+
+#define EXPECT_CONN_CLOSE_APP       (1U << 0)
+#define EXPECT_CONN_CLOSE_REMOTE    (1U << 1)
+
+#define C_BIDI_ID(ordinal) \
+    (((ordinal) << 2) | QUIC_STREAM_INITIATOR_CLIENT | QUIC_STREAM_DIR_BIDI)
+#define S_BIDI_ID(ordinal) \
+    (((ordinal) << 2) | QUIC_STREAM_INITIATOR_SERVER | QUIC_STREAM_DIR_BIDI)
+#define C_UNI_ID(ordinal) \
+    (((ordinal) << 2) | QUIC_STREAM_INITIATOR_CLIENT | QUIC_STREAM_DIR_UNI)
+#define S_UNI_ID(ordinal) \
+    (((ordinal) << 2) | QUIC_STREAM_INITIATOR_SERVER | QUIC_STREAM_DIR_UNI)
+
+#define OP_END  \
+    {OPK_END}
+#define OP_CHECK(func, arg2)  \
+    {OPK_CHECK, NULL, 0, (func), NULL, (arg2)},
+#define OP_C_SET_ALPN(alpn) \
+    {OPK_C_SET_ALPN, (alpn), 0, NULL, NULL},
+#define OP_C_CONNECT_WAIT() \
+    {OPK_C_CONNECT_WAIT, NULL, 0, NULL, NULL},
+#define OP_C_WRITE(stream_name, buf, buf_len)   \
+    {OPK_C_WRITE, (buf), (buf_len), NULL, #stream_name},
+#define OP_S_WRITE(stream_name, buf, buf_len)   \
+    {OPK_S_WRITE, (buf), (buf_len), NULL, #stream_name},
+#define OP_C_READ_EXPECT(stream_name, buf, buf_len)   \
+    {OPK_C_READ_EXPECT, (buf), (buf_len), NULL, #stream_name},
+#define OP_S_READ_EXPECT(stream_name, buf, buf_len)   \
+    {OPK_S_READ_EXPECT, (buf), (buf_len), NULL, #stream_name},
+#define OP_C_EXPECT_FIN(stream_name) \
+    {OPK_C_EXPECT_FIN, NULL, 0, NULL, #stream_name},
+#define OP_S_EXPECT_FIN(stream_name) \
+    {OPK_S_EXPECT_FIN, NULL, 0, NULL, #stream_name},
+#define OP_C_CONCLUDE(stream_name) \
+    {OPK_C_CONCLUDE, NULL, 0, NULL, #stream_name},
+#define OP_S_CONCLUDE(stream_name) \
+    {OPK_S_CONCLUDE, NULL, 0, NULL, #stream_name},
+#define OP_C_DETACH(stream_name) \
+    {OPK_C_DETACH, NULL, 0, NULL, #stream_name},
+#define OP_C_ATTACH(stream_name) \
+    {OPK_C_ATTACH, NULL, 0, NULL, #stream_name},
+#define OP_C_NEW_STREAM_BIDI(stream_name, expect_id) \
+    {OPK_C_NEW_STREAM, NULL, 0, NULL, #stream_name, (expect_id)},
+#define OP_C_NEW_STREAM_UNI(stream_name, expect_id) \
+    {OPK_C_NEW_STREAM, NULL, 1, NULL, #stream_name, (expect_id)},
+#define OP_S_NEW_STREAM_BIDI(stream_name, expect_id) \
+    {OPK_S_NEW_STREAM, NULL, 0, NULL, #stream_name, (expect_id)},
+#define OP_S_NEW_STREAM_UNI(stream_name, expect_id) \
+    {OPK_S_NEW_STREAM, NULL, 1, NULL, #stream_name, (expect_id)},
+#define OP_C_ACCEPT_STREAM(stream_name) \
+    {OPK_C_ACCEPT_STREAM, NULL, 0, NULL, #stream_name},
+#define OP_C_ACCEPT_STREAM_NONE() \
+    {OPK_C_ACCEPT_STREAM_NONE, NULL, 0, NULL, NULL},
+#define OP_C_FREE_STREAM(stream_name) \
+    {OPK_C_FREE_STREAM, NULL, 0, NULL, #stream_name},
+#define OP_C_SET_DEFAULT_STREAM_MODE(mode) \
+    {OPK_C_SET_DEFAULT_STREAM_MODE, NULL, (mode), NULL, NULL},
+#define OP_C_SET_INCOMING_STREAM_REJECT_POLICY(policy) \
+    {OPK_C_SET_INCOMING_STREAM_REJECT_POLICY, NULL, (policy), NULL, NULL},
+#define OP_C_SHUTDOWN() \
+    {OPK_C_SHUTDOWN, NULL, 0, NULL, NULL},
+#define OP_C_EXPECT_CONN_CLOSE_INFO(ec, app, remote)                \
+    {OPK_C_EXPECT_CONN_CLOSE_INFO, NULL,                            \
+        ((app) ? EXPECT_CONN_CLOSE_APP : 0) |                       \
+        ((remote) ? EXPECT_CONN_CLOSE_REMOTE : 0),                  \
+        NULL, NULL, (ec)},
+#define OP_S_EXPECT_CONN_CLOSE_INFO(ec, app, remote) \
+    {OPK_S_EXPECT_CONN_CLOSE_INFO, NULL,            \
+        ((app) ? EXPECT_CONN_CLOSE_APP : 0) |       \
+        ((remote) ? EXPECT_CONN_CLOSE_REMOTE : 0),  \
+        NULL, NULL, (ec)},
+#define OP_S_BIND_STREAM_ID(stream_name, stream_id) \
+    {OPK_S_BIND_STREAM_ID, NULL, 0, NULL, #stream_name, (stream_id)},
+#define OP_C_WAIT_FOR_DATA(stream_name) \
+    {OPK_C_WAIT_FOR_DATA, NULL, 0, NULL, #stream_name},
+#define OP_C_WRITE_FAIL(stream_name)  \
+    {OPK_C_WRITE_FAIL, NULL, 0, NULL, #stream_name},
+#define OP_S_WRITE_FAIL(stream_name)  \
+    {OPK_S_WRITE_FAIL, NULL, 0, NULL, #stream_name},
+#define OP_C_READ_FAIL(stream_name)  \
+    {OPK_C_READ_FAIL, NULL, 0, NULL, #stream_name},
+#define OP_C_STREAM_RESET(stream_name, aec)  \
+    {OPK_C_STREAM_RESET, NULL, 0, NULL, #stream_name, (aec)},
+
+static int check_rejected(struct helper *h, const struct script_op *op)
+{
+    uint64_t stream_id = op->arg2;
+
+    if (!TEST_true(ossl_quic_tserver_stream_has_peer_stop_sending(h->s, stream_id, NULL))
+        || !TEST_true(ossl_quic_tserver_stream_has_peer_reset_stream(h->s, stream_id, NULL)))
+        return 0;
+
+    return 1;
+}
+
+static int check_stream_reset(struct helper *h, const struct script_op *op)
+{
+    uint64_t stream_id = op->arg2, aec = 0;
+
+    return TEST_true(ossl_quic_tserver_stream_has_peer_reset_stream(h->s, stream_id,
+                                                                    &aec))
+        && TEST_uint64_t_eq(aec, 42);
+}
+
+static int check_stream_stopped(struct helper *h, const struct script_op *op)
+{
+    uint64_t stream_id = op->arg2;
+
+    return TEST_true(ossl_quic_tserver_stream_has_peer_stop_sending(h->s, stream_id,
+                                                                    NULL));
+}
+
+static unsigned long stream_info_hash(const STREAM_INFO *info)
+{
+    return OPENSSL_LH_strhash(info->name);
+}
+
+static int stream_info_cmp(const STREAM_INFO *a, const STREAM_INFO *b)
+{
+    return strcmp(a->name, b->name);
+}
+
+static void cleanup_stream(STREAM_INFO *info)
+{
+    SSL_free(info->c_stream);
+    OPENSSL_free(info);
+}
+
+static void helper_cleanup_streams(LHASH_OF(STREAM_INFO) **lh)
+{
+    if (*lh == NULL)
+        return;
+
+    lh_STREAM_INFO_doall(*lh, cleanup_stream);
+    lh_STREAM_INFO_free(*lh);
+    *lh = NULL;
+}
+
+static void helper_cleanup(struct helper *h)
+{
+    helper_cleanup_streams(&h->s_streams);
+    helper_cleanup_streams(&h->c_streams);
+
+    SSL_free(h->c_conn);
+    h->c_conn = NULL;
+
+    ossl_quic_tserver_free(h->s);
+    h->s = NULL;
+
+    BIO_free(h->s_net_bio_own);
+    h->s_net_bio_own = NULL;
+
+    BIO_free(h->c_net_bio_own);
+    h->c_net_bio_own = NULL;
+
+    if (h->s_fd >= 0) {
+        BIO_closesocket(h->s_fd);
+        h->s_fd = -1;
+    }
+
+    if (h->c_fd >= 0) {
+        BIO_closesocket(h->c_fd);
+        h->c_fd = -1;
+    }
+
+    BIO_ADDR_free(h->s_net_bio_addr);
+    h->s_net_bio_addr = NULL;
+
+    SSL_CTX_free(h->c_ctx);
+    h->c_ctx = NULL;
+}
+
+static int helper_init(struct helper *h)
+{
+    short port = 8186;
+    struct in_addr ina = {0};
+    QUIC_TSERVER_ARGS s_args = {0};
+
+    memset(h, 0, sizeof(*h));
+    h->c_fd = -1;
+    h->s_fd = -1;
+
+    if (!TEST_ptr(h->s_streams = lh_STREAM_INFO_new(stream_info_hash,
+                                                    stream_info_cmp)))
+        goto err;
+
+    if (!TEST_ptr(h->c_streams = lh_STREAM_INFO_new(stream_info_hash,
+                                                    stream_info_cmp)))
+        goto err;
+
+    ina.s_addr = htonl(0x7f000001UL);
+
+    h->s_fd = BIO_socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP, 0);
+    if (!TEST_int_ge(h->s_fd, 0))
+        goto err;
+
+    if (!TEST_true(BIO_socket_nbio(h->s_fd, 1)))
+        goto err;
+
+    if (!TEST_ptr(h->s_net_bio_addr = BIO_ADDR_new()))
+        goto err;
+
+    if (!TEST_true(BIO_ADDR_rawmake(h->s_net_bio_addr, AF_INET, &ina, sizeof(ina),
+                                    htons(port))))
+        goto err;
+
+    if (!TEST_true(BIO_bind(h->s_fd, h->s_net_bio_addr, 0)))
+        goto err;
+
+    if (!TEST_int_gt(BIO_ADDR_rawport(h->s_net_bio_addr), 0))
+        goto err;
+
+    if  (!TEST_ptr(h->s_net_bio = h->s_net_bio_own = BIO_new_dgram(h->s_fd, 0)))
+        goto err;
+
+    if (!BIO_up_ref(h->s_net_bio))
+        goto err;
+
+    s_args.net_rbio = h->s_net_bio;
+    s_args.net_wbio = h->s_net_bio;
+    //s_args.now_cb = ...;
+
+    if (!TEST_ptr(h->s = ossl_quic_tserver_new(&s_args, certfile, keyfile)))
+        goto err;
+
+    h->s_net_bio_own = NULL;
+
+    h->c_fd = BIO_socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP, 0);
+    if (!TEST_int_ge(h->c_fd, 0))
+        goto err;
+
+    if (!TEST_true(BIO_socket_nbio(h->c_fd, 1)))
+        goto err;
+
+    if (!TEST_ptr(h->c_net_bio = h->c_net_bio_own = BIO_new_dgram(h->c_fd, 0)))
+        goto err;
+
+    if (!TEST_true(BIO_dgram_set_peer(h->c_net_bio, h->s_net_bio_addr)))
+        goto err;
+
+
+    if (!TEST_ptr(h->c_ctx = SSL_CTX_new(OSSL_QUIC_client_method())))
+        goto err;
+
+    if (!TEST_ptr(h->c_conn = SSL_new(h->c_ctx)))
+        goto err;
+
+    /* Takes ownership of our reference to the BIO. */
+    SSL_set0_rbio(h->c_conn, h->c_net_bio);
+    h->c_net_bio_own = NULL;
+
+    if (!TEST_true(BIO_up_ref(h->c_net_bio)))
+        goto err;
+
+    SSL_set0_wbio(h->c_conn, h->c_net_bio);
+
+    if (!TEST_true(SSL_set_blocking_mode(h->c_conn, 0)))
+        goto err;
+
+    h->start_time   = ossl_time_now();
+    h->init         = 1;
+    return 1;
+
+err:
+    helper_cleanup(h);
+    return 0;
+}
+
+static STREAM_INFO *get_stream_info(LHASH_OF(STREAM_INFO) *lh,
+                                    const char *stream_name)
+{
+    STREAM_INFO key, *info;
+
+    if (!TEST_ptr(stream_name))
+        return NULL;
+
+    if (!strcmp(stream_name, "DEFAULT"))
+        return NULL;
+
+    key.name = stream_name;
+    info = lh_STREAM_INFO_retrieve(lh, &key);
+    if (info == NULL) {
+        info = OPENSSL_zalloc(sizeof(*info));
+        if (info == NULL)
+            return NULL;
+
+        info->name          = stream_name;
+        info->s_stream_id   = UINT64_MAX;
+        lh_STREAM_INFO_insert(lh, info);
+    }
+
+    return info;
+}
+
+static int helper_set_c_stream(struct helper *h, const char *stream_name,
+                               SSL *c_stream)
+{
+    STREAM_INFO *info = get_stream_info(h->c_streams, stream_name);
+
+    if (info == NULL)
+        return 0;
+
+    info->c_stream      = c_stream;
+    info->s_stream_id   = UINT64_MAX;
+    return 1;
+}
+
+static SSL *helper_get_c_stream(struct helper *h, const char *stream_name)
+{
+    STREAM_INFO *info;
+
+    if (!strcmp(stream_name, "DEFAULT"))
+        return h->c_conn;
+
+    info = get_stream_info(h->c_streams, stream_name);
+    if (info == NULL)
+        return NULL;
+
+    return info->c_stream;
+}
+
+static int
+helper_set_s_stream(struct helper *h, const char *stream_name,
+                    uint64_t s_stream_id)
+{
+    STREAM_INFO *info;
+
+    if (!strcmp(stream_name, "DEFAULT"))
+        return 0;
+
+    info = get_stream_info(h->s_streams, stream_name);
+    if (info == NULL)
+        return 0;
+
+    info->c_stream      = NULL;
+    info->s_stream_id   = s_stream_id;
+    return 1;
+}
+
+static uint64_t helper_get_s_stream(struct helper *h, const char *stream_name)
+{
+    STREAM_INFO *info;
+
+    if (!strcmp(stream_name, "DEFAULT"))
+        return UINT64_MAX;
+
+    info = get_stream_info(h->s_streams, stream_name);
+    if (info == NULL)
+        return UINT64_MAX;
+
+    return info->s_stream_id;
+}
+
+static int is_want(SSL *s, int ret)
+{
+    int ec = SSL_get_error(s, ret);
+
+    return ec == SSL_ERROR_WANT_READ || ec == SSL_ERROR_WANT_WRITE;
+}
+
+static int run_script(const struct script_op *script)
+{
+    size_t op_idx = 0;
+    int testresult = 0;
+    int no_advance = 0;
+    const struct script_op *op = NULL;
+    struct helper h;
+    unsigned char *tmp_buf = NULL;
+    int connect_started = 0;
+
+    if (!TEST_true(helper_init(&h)))
+        goto out;
+
+#define SPIN_AGAIN() do { no_advance = 1; continue; } while (0)
+
+    for (;; no_advance ? (void)(no_advance = 0) : (void)++op_idx) {
+        SSL *c_tgt              = h.c_conn;
+        uint64_t s_stream_id    = UINT64_MAX;
+
+        op = &script[op_idx];
+
+        if (op->stream_name != NULL) {
+            c_tgt       = helper_get_c_stream(&h, op->stream_name);
+            s_stream_id = helper_get_s_stream(&h, op->stream_name);
+        }
+
+        ossl_quic_tserver_tick(h.s);
+        if (connect_started)
+            SSL_tick(h.c_conn);
+
+        switch (op->op) {
+        case OPK_END:
+            testresult = 1;
+            goto out;
+
+        case OPK_CHECK:
+            if (!TEST_true(op->check_func(&h, op)))
+                goto out;
+
+            break;
+
+        case OPK_C_SET_ALPN:
+            {
+                const char *alpn = op->arg0;
+                size_t alpn_len = strlen(alpn);
+
+                if (!TEST_size_t_le(alpn_len, UINT8_MAX)
+                    || !TEST_ptr(tmp_buf = (unsigned char *)OPENSSL_malloc(alpn_len + 1)))
+                    goto out;
+
+                memcpy(tmp_buf + 1, alpn, alpn_len);
+                tmp_buf[0] = (unsigned char)alpn_len;
+
+                /* 0 is the success case for SSL_set_alpn_protos(). */
+                if (!TEST_false(SSL_set_alpn_protos(h.c_conn, tmp_buf,
+                                                    alpn_len + 1)))
+                    goto out;
+
+                OPENSSL_free(tmp_buf);
+                tmp_buf = NULL;
+            }
+            break;
+
+        case OPK_C_CONNECT_WAIT:
+            {
+                int ret;
+
+                connect_started = 1;
+
+                ret = SSL_connect(h.c_conn);
+                if (!TEST_true(ret == 1
+                               || (!h.blocking && is_want(h.c_conn, ret))))
+                    goto out;
+
+                if (!h.blocking && ret != 1)
+                    SPIN_AGAIN();
+            }
+            break;
+
+        case OPK_C_WRITE:
+            {
+                size_t bytes_written = 0;
+
+                if (!TEST_ptr(c_tgt))
+                    goto out;
+
+                if (!TEST_true(SSL_write_ex(c_tgt, op->arg0, op->arg1,
+                                            &bytes_written))
+                    || !TEST_size_t_eq(bytes_written, op->arg1))
+                    goto out;
+            }
+            break;
+
+        case OPK_S_WRITE:
+            {
+                size_t bytes_written = 0;
+
+                if (!TEST_uint64_t_ne(s_stream_id, UINT64_MAX))
+                    goto out;
+
+                if (!TEST_true(ossl_quic_tserver_write(h.s, s_stream_id,
+                                                       op->arg0, op->arg1,
+                                                       &bytes_written))
+                    || !TEST_size_t_eq(bytes_written, op->arg1))
+                    goto out;
+            }
+            break;
+
+        case OPK_C_CONCLUDE:
+            {
+                if (!TEST_true(SSL_stream_conclude(c_tgt, 0)))
+                    goto out;
+            }
+            break;
+
+        case OPK_S_CONCLUDE:
+            {
+                if (!TEST_uint64_t_ne(s_stream_id, UINT64_MAX))
+                    goto out;
+
+                ossl_quic_tserver_conclude(h.s, s_stream_id);
+            }
+            break;
+
+        case OPK_C_WAIT_FOR_DATA:
+            {
+                char buf[1];
+                size_t bytes_read = 0;
+
+                if (!TEST_ptr(c_tgt))
+                    goto out;
+
+                if (!SSL_peek_ex(c_tgt, buf, sizeof(buf), &bytes_read)
+                    || bytes_read == 0)
+                    SPIN_AGAIN();
+            }
+            break;
+
+        case OPK_C_READ_EXPECT:
+            {
+                size_t bytes_read = 0;
+
+                if (!TEST_ptr(tmp_buf = OPENSSL_malloc(op->arg1)))
+                    goto out;
+
+                if (!TEST_true(SSL_read_ex(c_tgt, tmp_buf, op->arg1,
+                                            &bytes_read))
+                    || !TEST_size_t_eq(bytes_read, op->arg1))
+                    goto out;
+
+                if (!TEST_mem_eq(tmp_buf, op->arg1, op->arg0, op->arg1))
+                    goto out;
+
+                OPENSSL_free(tmp_buf);
+                tmp_buf = NULL;
+            }
+            break;
+
+        case OPK_S_READ_EXPECT:
+            {
+                size_t bytes_read = 0;
+
+                if (!TEST_uint64_t_ne(s_stream_id, UINT64_MAX))
+                    goto out;
+
+                if (op->arg1 > 0
+                    && !TEST_ptr(tmp_buf = OPENSSL_malloc(op->arg1)))
+                    goto out;
+
+                if (!TEST_true(ossl_quic_tserver_read(h.s, s_stream_id,
+                                                      tmp_buf, op->arg1,
+                                                      &bytes_read))
+                    || !TEST_size_t_eq(bytes_read, op->arg1))
+                    goto out;
+
+                if (op->arg1 > 0
+                    && !TEST_mem_eq(tmp_buf, op->arg1, op->arg0, op->arg1))
+                    goto out;
+
+                OPENSSL_free(tmp_buf);
+                tmp_buf = NULL;
+            }
+            break;
+
+        case OPK_C_EXPECT_FIN:
+            {
+                char buf[1];
+                size_t bytes_read = 0;
+
+                if (!TEST_false(SSL_read_ex(c_tgt, buf, sizeof(buf),
+                                            &bytes_read))
+                    || !TEST_size_t_eq(bytes_read, 0)
+                    || !TEST_int_eq(SSL_get_error(c_tgt, 0),
+                                    SSL_ERROR_ZERO_RETURN))
+                    goto  out;
+            }
+            break;
+
+        case OPK_S_EXPECT_FIN:
+            {
+                if (!TEST_uint64_t_ne(s_stream_id, UINT64_MAX)
+                    || !TEST_true(ossl_quic_tserver_has_read_ended(h.s,
+                                                                   s_stream_id)))
+                    goto out;
+            }
+            break;
+
+        case OPK_C_DETACH:
+            {
+                SSL *c_stream;
+
+                if (!TEST_ptr_null(c_tgt))
+                    goto out; /* don't overwrite existing stream with same name */
+
+                if (!TEST_ptr(c_stream = SSL_detach_stream(h.c_conn)))
+                    goto out;
+
+                if (!TEST_true(helper_set_c_stream(&h, op->stream_name, c_stream)))
+                    goto out;
+            }
+            break;
+
+        case OPK_C_ATTACH:
+            {
+                if (!TEST_ptr(c_tgt))
+                    goto out;
+
+                if (!TEST_true(SSL_attach_stream(h.c_conn, c_tgt)))
+                    goto out;
+
+                if (!TEST_true(helper_set_c_stream(&h, op->stream_name, NULL)))
+                    goto out;
+            }
+            break;
+
+        case OPK_C_NEW_STREAM:
+            {
+                SSL *c_stream;
+                uint64_t flags = 0;
+
+                if (!TEST_ptr_null(c_tgt))
+                    goto out; /* don't overwrite existing stream with same name */
+
+                if (op->arg1 != 0)
+                    flags |= SSL_STREAM_FLAG_UNI;
+
+                if (!TEST_ptr(c_stream = SSL_new_stream(h.c_conn, flags)))
+                    goto out;
+
+                if (op->arg2 != UINT64_MAX
+                    && !TEST_uint64_t_eq(SSL_get_stream_id(c_stream),
+                                         op->arg2))
+                    goto out;
+
+                if (!TEST_true(helper_set_c_stream(&h, op->stream_name, c_stream)))
+                    goto out;
+            }
+            break;
+
+        case OPK_S_NEW_STREAM:
+            {
+                uint64_t stream_id = UINT64_MAX;
+
+                if (!TEST_uint64_t_eq(s_stream_id, UINT64_MAX))
+                    goto out; /* don't overwrite existing stream with same name */
+
+                if (!TEST_true(ossl_quic_tserver_stream_new(h.s,
+                                                            op->arg1 > 0,
+                                                            &stream_id)))
+                    goto out;
+
+                if (op->arg2 != UINT64_MAX
+                    && !TEST_uint64_t_eq(stream_id, op->arg2))
+                    goto out;
+
+                if (!TEST_true(helper_set_s_stream(&h, op->stream_name,
+                                                   stream_id)))
+                    goto out;
+            }
+            break;
+
+        case OPK_C_ACCEPT_STREAM:
+            {
+                SSL *c_stream;
+
+                if (!TEST_ptr_null(c_tgt))
+                    goto out; /* don't overwrite existing stream with same name */
+
+                if (!TEST_ptr(c_stream = SSL_accept_stream(h.c_conn, 0)))
+                    goto out;
+
+                if (!TEST_true(helper_set_c_stream(&h, op->stream_name,
+                                                   c_stream)))
+                    goto out;
+            }
+            break;
+
+        case OPK_C_ACCEPT_STREAM_NONE:
+            {
+                SSL *c_stream;
+
+                if (!TEST_ptr_null(c_stream = SSL_accept_stream(h.c_conn, 0))) {
+                    SSL_free(c_stream);
+                    goto out;
+                }
+            }
+            break;
+
+        case OPK_C_FREE_STREAM:
+            {
+                if (!TEST_ptr(c_tgt)
+                    || !TEST_true(!SSL_is_connection(c_tgt)))
+                    goto out;
+
+                if (!TEST_true(helper_set_c_stream(&h, op->stream_name, NULL)))
+                    goto out;
+
+                SSL_free(c_tgt);
+                c_tgt = NULL;
+            }
+            break;
+
+        case OPK_C_SET_DEFAULT_STREAM_MODE:
+            {
+                if (!TEST_ptr(c_tgt))
+                    goto out;
+
+                if (!TEST_true(SSL_set_default_stream_mode(c_tgt, op->arg1)))
+                    goto out;
+            }
+            break;
+
+        case OPK_C_SET_INCOMING_STREAM_REJECT_POLICY:
+            {
+                if (!TEST_ptr(c_tgt))
+                    goto out;
+
+                if (!TEST_true(SSL_set_incoming_stream_reject_policy(c_tgt,
+                                                                     op->arg1, 0)))
+                    goto out;
+            }
+            break;
+
+        case OPK_C_SHUTDOWN:
+            {
+                int ret;
+
+                if (!TEST_ptr(c_tgt))
+                    goto out;
+
+                ret = SSL_shutdown_ex(c_tgt, 0, NULL, 0);
+                if (!TEST_int_ge(ret, 0))
+                    goto out;
+
+            }
+            break;
+
+        case OPK_C_EXPECT_CONN_CLOSE_INFO:
+            {
+                SSL_CONN_CLOSE_INFO cc_info = {0};
+                int expect_app = (op->arg1 & EXPECT_CONN_CLOSE_APP) != 0;
+                int expect_remote = (op->arg1 & EXPECT_CONN_CLOSE_REMOTE) != 0;
+                uint64_t error_code = op->arg2;
+
+                if (!TEST_ptr(c_tgt))
+                    goto out;
+
+                if (!TEST_true(SSL_get_conn_close_info(c_tgt, &cc_info,
+                                                       sizeof(cc_info))))
+                    goto out;
+
+                if (!TEST_int_eq(expect_app, !cc_info.is_transport)
+                    || !TEST_int_eq(expect_remote, !cc_info.is_local)
+                    || !TEST_uint64_t_eq(error_code, cc_info.error_code))
+                    goto out;
+            }
+            break;
+
+        case OPK_S_EXPECT_CONN_CLOSE_INFO:
+            {
+                const QUIC_TERMINATE_CAUSE *tc;
+                int expect_app = (op->arg1 & EXPECT_CONN_CLOSE_APP) != 0;
+                int expect_remote = (op->arg1 & EXPECT_CONN_CLOSE_REMOTE) != 0;
+                uint64_t error_code = op->arg2;
+
+                if (!TEST_true(ossl_quic_tserver_is_term_any(h.s)))
+                    goto out;
+
+                if (!TEST_ptr(tc = ossl_quic_tserver_get_terminate_cause(h.s)))
+                    goto out;
+
+                if (!TEST_uint64_t_eq(error_code, tc->error_code)
+                    || !TEST_int_eq(expect_app, tc->app)
+                    || !TEST_int_eq(expect_remote, tc->remote))
+                    goto out;
+            }
+            break;
+
+        case OPK_S_BIND_STREAM_ID:
+            {
+                if (!TEST_uint64_t_eq(s_stream_id, UINT64_MAX))
+                    goto out;
+
+                if (!TEST_true(helper_set_s_stream(&h, op->stream_name, op->arg2)))
+                    goto out;
+            }
+            break;
+
+        case OPK_C_WRITE_FAIL:
+            {
+                uint64_t bytes_written = 0;
+
+                if (!TEST_ptr(c_tgt))
+                    goto out;
+
+                if (!TEST_false(SSL_write_ex(c_tgt, "apple", 5, &bytes_written)))
+                    goto out;
+            }
+            break;
+
+        case OPK_S_WRITE_FAIL:
+            {
+                size_t bytes_written = 0;
+
+                if (!TEST_uint64_t_ne(s_stream_id, UINT64_MAX))
+                    goto out;
+
+                if (!TEST_false(ossl_quic_tserver_write(h.s, s_stream_id,
+                                                       (const unsigned char *)"apple", 5,
+                                                       &bytes_written)))
+                    goto out;
+            }
+            break;
+
+        case OPK_C_READ_FAIL:
+            {
+                uint64_t bytes_read = 0;
+                char buf[1];
+
+                if (!TEST_ptr(c_tgt))
+                    goto out;
+
+                if (!TEST_false(SSL_read_ex(c_tgt, buf, sizeof(buf), &bytes_read)))
+                    goto out;
+            }
+            break;
+
+        case OPK_C_STREAM_RESET:
+            {
+                SSL_STREAM_RESET_ARGS args = {0};
+
+                if (!TEST_ptr(c_tgt))
+                    goto out;
+
+                args.quic_error_code = op->arg2;
+
+                if (!TEST_true(SSL_stream_reset(c_tgt, &args, sizeof(args))))
+                    goto out;
+            }
+            break;
+
+        default:
+            TEST_error("unknown op");
+            goto out;
+        }
+    }
+
+out:
+    if (!testresult)
+        TEST_error("failed at script op %zu\n", op_idx + 1);
+
+    OPENSSL_free(tmp_buf);
+    helper_cleanup(&h);
+    return testresult;
+}
+
+/* 1. Simple single-stream test */
+static const struct script_op script_1[] = {
+    OP_C_SET_ALPN           ("ossltest")
+    OP_C_CONNECT_WAIT       ()
+    OP_C_WRITE              (DEFAULT, "apple", 5)
+    OP_C_CONCLUDE           (DEFAULT)
+    OP_S_BIND_STREAM_ID     (a, C_BIDI_ID(0))
+    OP_S_READ_EXPECT        (a, "apple", 5)
+    OP_S_EXPECT_FIN         (a)
+    OP_S_WRITE              (a, "orange", 6)
+    OP_S_CONCLUDE           (a)
+    OP_C_READ_EXPECT        (DEFAULT, "orange", 6)
+    OP_C_EXPECT_FIN         (DEFAULT)
+    OP_END
+};
+
+/* 2. Multi-stream test */
+static const struct script_op script_2[] = {
+    OP_C_SET_ALPN           ("ossltest")
+    OP_C_CONNECT_WAIT       ()
+    OP_C_SET_INCOMING_STREAM_REJECT_POLICY(SSL_INCOMING_STREAM_REJECT_POLICY_ACCEPT)
+    OP_C_WRITE              (DEFAULT,  "apple", 5)
+    OP_S_BIND_STREAM_ID     (a, C_BIDI_ID(0))
+    OP_S_READ_EXPECT        (a, "apple", 5)
+    OP_S_WRITE              (a, "orange", 6)
+    OP_C_READ_EXPECT        (DEFAULT, "orange", 6)
+
+    OP_C_NEW_STREAM_BIDI    (b, C_BIDI_ID(1))
+    OP_C_WRITE              (b, "flamingo", 8)
+    OP_C_CONCLUDE           (b)
+    OP_S_BIND_STREAM_ID     (b, C_BIDI_ID(1))
+    OP_S_READ_EXPECT        (b, "flamingo", 8)
+    OP_S_EXPECT_FIN         (b)
+    OP_S_WRITE              (b, "gargoyle", 8)
+    OP_S_CONCLUDE           (b)
+    OP_C_READ_EXPECT        (b, "gargoyle", 8)
+    OP_C_EXPECT_FIN         (b)
+
+    OP_C_NEW_STREAM_UNI     (c, C_UNI_ID(0))
+    OP_C_WRITE              (c, "elephant", 8)
+    OP_C_CONCLUDE           (c)
+    OP_S_BIND_STREAM_ID     (c, C_UNI_ID(0))
+    OP_S_READ_EXPECT        (c, "elephant", 8)
+    OP_S_EXPECT_FIN         (c)
+    OP_S_WRITE_FAIL         (c)
+
+    OP_C_ACCEPT_STREAM_NONE ()
+
+    OP_S_NEW_STREAM_BIDI    (d, S_BIDI_ID(0))
+    OP_S_WRITE              (d, "frog", 4)
+    OP_S_CONCLUDE           (d)
+
+    OP_C_ACCEPT_STREAM      (d)
+    OP_C_ACCEPT_STREAM_NONE ()
+    OP_C_READ_EXPECT        (d, "frog", 4)
+    OP_C_EXPECT_FIN         (d)
+
+    OP_S_NEW_STREAM_BIDI    (e, S_BIDI_ID(1))
+    OP_S_WRITE              (e, "mixture", 7)
+    OP_S_CONCLUDE           (e)
+
+    OP_C_ACCEPT_STREAM      (e)
+    OP_C_READ_EXPECT        (e, "mixture", 7)
+    OP_C_EXPECT_FIN         (e)
+    OP_C_WRITE              (e, "ramble", 6)
+    OP_S_READ_EXPECT        (e, "ramble", 6)
+    OP_C_CONCLUDE           (e)
+    OP_S_EXPECT_FIN         (e)
+
+    OP_S_NEW_STREAM_UNI     (f, S_UNI_ID(0))
+    OP_S_WRITE              (f, "yonder", 6)
+    OP_S_CONCLUDE           (f)
+
+    OP_C_ACCEPT_STREAM      (f)
+    OP_C_ACCEPT_STREAM_NONE ()
+    OP_C_READ_EXPECT        (f, "yonder", 6)
+    OP_C_EXPECT_FIN         (f)
+    OP_C_WRITE_FAIL         (f)
+
+    OP_C_SET_INCOMING_STREAM_REJECT_POLICY(SSL_INCOMING_STREAM_REJECT_POLICY_REJECT)
+    OP_S_NEW_STREAM_BIDI    (g, S_BIDI_ID(2))
+    OP_S_WRITE              (g, "unseen", 6)
+    OP_S_CONCLUDE           (g)
+
+    OP_C_ACCEPT_STREAM_NONE ()
+
+    OP_C_SET_INCOMING_STREAM_REJECT_POLICY(SSL_INCOMING_STREAM_REJECT_POLICY_AUTO)
+    OP_S_NEW_STREAM_BIDI    (h, S_BIDI_ID(3))
+    OP_S_WRITE              (h, "UNSEEN", 6)
+    OP_S_CONCLUDE           (h)
+
+    OP_C_ACCEPT_STREAM_NONE ()
+
+    /*
+     * Streams g, h should have been rejected, so server should have got
+     * STOP_SENDING/RESET_STREAM.
+     */
+    OP_CHECK                (check_rejected, S_BIDI_ID(2))
+    OP_CHECK                (check_rejected, S_BIDI_ID(3))
+
+    OP_END
+};
+
+/* 3. Default stream detach/reattach test */
+static const struct script_op script_3[] = {
+    OP_C_SET_ALPN           ("ossltest")
+    OP_C_CONNECT_WAIT       ()
+
+    OP_C_WRITE              (DEFAULT, "apple", 5)
+    OP_C_DETACH             (a)             /* DEFAULT becomes stream 'a' */
+    OP_C_WRITE_FAIL         (DEFAULT)
+
+    OP_C_WRITE              (a, "by", 2)
+
+    OP_S_BIND_STREAM_ID     (a, C_BIDI_ID(0))
+    OP_S_READ_EXPECT        (a, "appleby", 7)
+
+    OP_S_WRITE              (a, "hello", 5)
+    OP_C_READ_EXPECT        (a, "hello", 5)
+
+    OP_C_WRITE_FAIL         (DEFAULT)
+    OP_C_ATTACH             (a)
+    OP_C_WRITE              (DEFAULT, "is here", 7)
+    OP_S_READ_EXPECT        (a, "is here", 7)
+
+    OP_C_DETACH             (a)
+    OP_C_CONCLUDE           (a)
+    OP_S_EXPECT_FIN         (a)
+
+    OP_END
+};
+
+/* 4. Default stream mode test */
+static const struct script_op script_4[] = {
+    OP_C_SET_ALPN           ("ossltest")
+    OP_C_CONNECT_WAIT       ()
+
+    OP_C_SET_DEFAULT_STREAM_MODE(SSL_DEFAULT_STREAM_MODE_NONE)
+    OP_C_WRITE_FAIL         (DEFAULT)
+
+    OP_S_NEW_STREAM_BIDI    (a, S_BIDI_ID(0))
+    OP_S_WRITE              (a, "apple", 5)
+
+    OP_C_READ_FAIL          (DEFAULT)
+
+    OP_C_ACCEPT_STREAM      (a)
+    OP_C_READ_EXPECT        (a, "apple", 5)
+
+    OP_C_ATTACH             (a)
+    OP_C_WRITE              (DEFAULT, "orange", 6)
+    OP_S_READ_EXPECT        (a, "orange", 6)
+
+    OP_END
+};
+
+/* 5. Test stream reset functionality */
+static const struct script_op script_5[] = {
+    OP_C_SET_ALPN           ("ossltest")
+    OP_C_CONNECT_WAIT       ()
+
+    OP_C_SET_DEFAULT_STREAM_MODE(SSL_DEFAULT_STREAM_MODE_NONE)
+    OP_C_NEW_STREAM_BIDI    (a, C_BIDI_ID(0))
+
+    OP_C_WRITE              (a, "apple", 5)
+    OP_C_STREAM_RESET       (a, 42)
+
+    OP_S_BIND_STREAM_ID     (a, C_BIDI_ID(0))
+    OP_S_READ_EXPECT        (a, "apple", 5)
+    OP_CHECK                (check_stream_reset, C_BIDI_ID(0))
+
+    OP_END
+};
+
+/* 6. Test STOP_SENDING functionality */
+static const struct script_op script_6[] = {
+    OP_C_SET_ALPN           ("ossltest")
+    OP_C_CONNECT_WAIT       ()
+
+    OP_C_SET_DEFAULT_STREAM_MODE(SSL_DEFAULT_STREAM_MODE_NONE)
+    OP_S_NEW_STREAM_BIDI    (a, S_BIDI_ID(0))
+    OP_S_WRITE              (a, "apple", 5)
+
+    OP_C_ACCEPT_STREAM      (a)
+    OP_C_FREE_STREAM        (a)
+    OP_C_ACCEPT_STREAM_NONE ()
+
+    OP_CHECK                (check_stream_stopped, S_BIDI_ID(0))
+
+    OP_END
+};
+
+/* 7. Unidirectional default stream mode test (client sends first) */
+static const struct script_op script_7[] = {
+    OP_C_SET_ALPN           ("ossltest")
+    OP_C_CONNECT_WAIT       ()
+
+    OP_C_SET_DEFAULT_STREAM_MODE(SSL_DEFAULT_STREAM_MODE_AUTO_UNI)
+    OP_C_WRITE              (DEFAULT, "apple", 5)
+
+    OP_S_BIND_STREAM_ID     (a, C_UNI_ID(0))
+    OP_S_READ_EXPECT        (a, "apple", 5)
+    OP_S_WRITE_FAIL         (a)
+
+    OP_END
+};
+
+/* 8. Unidirectional default stream mode test (server sends first) */
+static const struct script_op script_8[] = {
+    OP_C_SET_ALPN           ("ossltest")
+    OP_C_CONNECT_WAIT       ()
+
+    OP_C_SET_DEFAULT_STREAM_MODE(SSL_DEFAULT_STREAM_MODE_AUTO_UNI)
+    OP_S_NEW_STREAM_UNI     (a, S_UNI_ID(0))
+    OP_S_WRITE              (a, "apple", 5)
+    OP_C_READ_EXPECT        (DEFAULT, "apple", 5)
+    OP_C_WRITE_FAIL         (DEFAULT)
+
+    OP_END
+};
+
+/* 9. Unidirectional default stream mode test (server sends first on bidi) */
+static const struct script_op script_9[] = {
+    OP_C_SET_ALPN           ("ossltest")
+    OP_C_CONNECT_WAIT       ()
+
+    OP_C_SET_DEFAULT_STREAM_MODE(SSL_DEFAULT_STREAM_MODE_AUTO_UNI)
+    OP_S_NEW_STREAM_BIDI    (a, S_BIDI_ID(0))
+    OP_S_WRITE              (a, "apple", 5)
+    OP_C_READ_EXPECT        (DEFAULT, "apple", 5)
+    OP_C_WRITE              (DEFAULT, "orange", 6)
+    OP_S_READ_EXPECT        (a, "orange", 6)
+
+    OP_END
+};
+
+/* 10. Shutdown */
+static const struct script_op script_10[] = {
+    OP_C_SET_ALPN           ("ossltest")
+    OP_C_CONNECT_WAIT       ()
+
+    OP_C_WRITE              (DEFAULT, "apple", 5)
+    OP_S_BIND_STREAM_ID     (a, C_BIDI_ID(0))
+    OP_S_READ_EXPECT        (a, "apple", 5)
+
+    OP_C_SHUTDOWN           ()
+    OP_C_EXPECT_CONN_CLOSE_INFO(0, 1, 0)
+    OP_S_EXPECT_CONN_CLOSE_INFO(0, 1, 1)
+
+    OP_END
+};
+
+static const struct script_op *const scripts[] = {
+    script_1,
+    script_2,
+    script_3,
+    script_4,
+    script_5,
+    script_6,
+    script_7,
+    script_8,
+    script_9,
+    script_10,
+};
+
+static int test_script(int idx)
+{
+    TEST_info("Running script %d", idx + 1);
+    return run_script(scripts[idx]);
+}
+
+OPT_TEST_DECLARE_USAGE("certfile privkeyfile\n")
+
+int setup_tests(void)
+{
+    if (!test_skip_common_options()) {
+        TEST_error("Error parsing test options\n");
+        return 0;
+    }
+
+    if (!TEST_ptr(certfile = test_get_argument(0))
+        || !TEST_ptr(keyfile = test_get_argument(1)))
+        return 0;
+
+    ADD_ALL_TESTS(test_script, OSSL_NELEM(scripts));
+    return 1;
+}

--- a/test/quic_multistream_test.c
+++ b/test/quic_multistream_test.c
@@ -299,7 +299,6 @@ static int helper_init(struct helper *h)
 
     s_args.net_rbio = h->s_net_bio;
     s_args.net_wbio = h->s_net_bio;
-    //s_args.now_cb = ...;
 
     if (!TEST_ptr(h->s = ossl_quic_tserver_new(&s_args, certfile, keyfile)))
         goto err;
@@ -849,7 +848,7 @@ static int run_script(const struct script_op *script)
 
         case OPK_C_WRITE_FAIL:
             {
-                uint64_t bytes_written = 0;
+                size_t bytes_written = 0;
 
                 if (!TEST_ptr(c_tgt))
                     goto out;
@@ -875,7 +874,7 @@ static int run_script(const struct script_op *script)
 
         case OPK_C_READ_FAIL:
             {
-                uint64_t bytes_read = 0;
+                size_t bytes_read = 0;
                 char buf[1];
 
                 if (!TEST_ptr(c_tgt))

--- a/test/quic_multistream_test.c
+++ b/test/quic_multistream_test.c
@@ -486,6 +486,7 @@ static int run_script(const struct script_op *script, int free_order)
                 ++op_idx;
 
             first           = 0;
+            offset          = 0;
             op_start_time   = ossl_time_now();
             op_deadline     = ossl_time_add(op_start_time, ossl_ms2time(2000));
         }

--- a/test/quic_multistream_test.c
+++ b/test/quic_multistream_test.c
@@ -11,6 +11,7 @@
 #include <openssl/bio.h>
 #include <openssl/lhash.h>
 #include "internal/quic_tserver.h"
+#include "internal/quic_ssl.h"
 #include "testutil.h"
 
 static const char *certfile, *keyfile;
@@ -715,7 +716,7 @@ static int run_script(const struct script_op *script, int free_order)
                 if (!TEST_ptr_null(c_tgt))
                     goto out; /* don't overwrite existing stream with same name */
 
-                if (!TEST_ptr(c_stream = SSL_detach_stream(h.c_conn)))
+                if (!TEST_ptr(c_stream = ossl_quic_detach_stream(h.c_conn)))
                     goto out;
 
                 if (!TEST_true(helper_set_c_stream(&h, op->stream_name, c_stream)))
@@ -728,7 +729,7 @@ static int run_script(const struct script_op *script, int free_order)
                 if (!TEST_ptr(c_tgt))
                     goto out;
 
-                if (!TEST_true(SSL_attach_stream(h.c_conn, c_tgt)))
+                if (!TEST_true(ossl_quic_attach_stream(h.c_conn, c_tgt)))
                     goto out;
 
                 if (!TEST_true(helper_set_c_stream(&h, op->stream_name, NULL)))

--- a/test/quic_multistream_test.c
+++ b/test/quic_multistream_test.c
@@ -70,7 +70,7 @@ struct script_op {
 #define OPK_C_ACCEPT_STREAM_NONE                    17
 #define OPK_C_FREE_STREAM                           18
 #define OPK_C_SET_DEFAULT_STREAM_MODE               19
-#define OPK_C_SET_INCOMING_STREAM_REJECT_POLICY     20
+#define OPK_C_SET_INCOMING_STREAM_POLICY            20
 #define OPK_C_SHUTDOWN                              21
 #define OPK_C_EXPECT_CONN_CLOSE_INFO                22
 #define OPK_S_EXPECT_CONN_CLOSE_INFO                23
@@ -137,8 +137,8 @@ struct script_op {
     {OPK_C_FREE_STREAM, NULL, 0, NULL, #stream_name},
 #define OP_C_SET_DEFAULT_STREAM_MODE(mode) \
     {OPK_C_SET_DEFAULT_STREAM_MODE, NULL, (mode), NULL, NULL},
-#define OP_C_SET_INCOMING_STREAM_REJECT_POLICY(policy) \
-    {OPK_C_SET_INCOMING_STREAM_REJECT_POLICY, NULL, (policy), NULL, NULL},
+#define OP_C_SET_INCOMING_STREAM_POLICY(policy) \
+    {OPK_C_SET_INCOMING_STREAM_POLICY, NULL, (policy), NULL, NULL},
 #define OP_C_SHUTDOWN() \
     {OPK_C_SHUTDOWN, NULL, 0, NULL, NULL},
 #define OP_C_EXPECT_CONN_CLOSE_INFO(ec, app, remote)                \
@@ -833,13 +833,13 @@ static int run_script(const struct script_op *script, int free_order)
             }
             break;
 
-        case OPK_C_SET_INCOMING_STREAM_REJECT_POLICY:
+        case OPK_C_SET_INCOMING_STREAM_POLICY:
             {
                 if (!TEST_ptr(c_tgt))
                     goto out;
 
-                if (!TEST_true(SSL_set_incoming_stream_reject_policy(c_tgt,
-                                                                     op->arg1, 0)))
+                if (!TEST_true(SSL_set_incoming_stream_policy(c_tgt,
+                                                              op->arg1, 0)))
                     goto out;
             }
             break;
@@ -996,7 +996,7 @@ static const struct script_op script_1[] = {
 static const struct script_op script_2[] = {
     OP_C_SET_ALPN           ("ossltest")
     OP_C_CONNECT_WAIT       ()
-    OP_C_SET_INCOMING_STREAM_REJECT_POLICY(SSL_INCOMING_STREAM_REJECT_POLICY_ACCEPT)
+    OP_C_SET_INCOMING_STREAM_POLICY(SSL_INCOMING_STREAM_POLICY_ACCEPT)
     OP_C_WRITE              (DEFAULT,  "apple", 5)
     OP_S_BIND_STREAM_ID     (a, C_BIDI_ID(0))
     OP_S_READ_EXPECT        (a, "apple", 5)
@@ -1055,14 +1055,14 @@ static const struct script_op script_2[] = {
     OP_C_EXPECT_FIN         (f)
     OP_C_WRITE_FAIL         (f)
 
-    OP_C_SET_INCOMING_STREAM_REJECT_POLICY(SSL_INCOMING_STREAM_REJECT_POLICY_REJECT)
+    OP_C_SET_INCOMING_STREAM_POLICY(SSL_INCOMING_STREAM_POLICY_REJECT)
     OP_S_NEW_STREAM_BIDI    (g, S_BIDI_ID(2))
     OP_S_WRITE              (g, "unseen", 6)
     OP_S_CONCLUDE           (g)
 
     OP_C_ACCEPT_STREAM_NONE ()
 
-    OP_C_SET_INCOMING_STREAM_REJECT_POLICY(SSL_INCOMING_STREAM_REJECT_POLICY_AUTO)
+    OP_C_SET_INCOMING_STREAM_POLICY(SSL_INCOMING_STREAM_POLICY_AUTO)
     OP_S_NEW_STREAM_BIDI    (h, S_BIDI_ID(3))
     OP_S_WRITE              (h, "UNSEEN", 6)
     OP_S_CONCLUDE           (h)

--- a/test/quic_tserver_test.c
+++ b/test/quic_tserver_test.c
@@ -215,16 +215,17 @@ static int do_test(int use_thread_assist, int use_fake_time, int use_inject)
         }
 
         if (c_connected && c_write_done && !s_read_done) {
-            if (!ossl_quic_tserver_read(tserver,
+            if (!ossl_quic_tserver_read(tserver, 0,
                                         (unsigned char *)msg2 + s_total_read,
                                         sizeof(msg2) - s_total_read, &l)) {
-                if (!TEST_true(ossl_quic_tserver_has_read_ended(tserver)))
+                if (!TEST_true(ossl_quic_tserver_has_read_ended(tserver, 0)))
                     goto err;
 
                 if (!TEST_mem_eq(msg1, sizeof(msg1) - 1, msg2, s_total_read))
                     goto err;
 
                 s_begin_write = 1;
+                s_read_done   = 1;
             } else {
                 s_total_read += l;
                 if (!TEST_size_t_le(s_total_read, sizeof(msg1) - 1))
@@ -233,7 +234,7 @@ static int do_test(int use_thread_assist, int use_fake_time, int use_inject)
         }
 
         if (s_begin_write && s_total_written < sizeof(msg1) - 1) {
-            if (!TEST_true(ossl_quic_tserver_write(tserver,
+            if (!TEST_true(ossl_quic_tserver_write(tserver, 0,
                                                    (unsigned char *)msg2 + s_total_written,
                                                    sizeof(msg1) - 1 - s_total_written, &l)))
                 goto err;
@@ -241,7 +242,7 @@ static int do_test(int use_thread_assist, int use_fake_time, int use_inject)
             s_total_written += l;
 
             if (s_total_written == sizeof(msg1) - 1) {
-                ossl_quic_tserver_conclude(tserver);
+                ossl_quic_tserver_conclude(tserver, 0);
                 c_begin_read = 1;
             }
         }

--- a/test/quic_txp_test.c
+++ b/test/quic_txp_test.c
@@ -1470,7 +1470,8 @@ static int run_script(const struct script_op *script)
                                                                  op->arg0)))
                     goto err;
 
-                if (!TEST_true(ossl_quic_stream_stop_sending(s, op->arg1)))
+                if (!TEST_true(ossl_quic_stream_map_stop_sending_recv_part(h.args.qsm,
+                                                                           s, op->arg1)))
                     goto err;
 
                 ossl_quic_stream_map_update_state(h.args.qsm, s);
@@ -1487,7 +1488,8 @@ static int run_script(const struct script_op *script)
                                                                  op->arg0)))
                     goto err;
 
-                if (!TEST_true(ossl_quic_stream_reset(s, op->arg1)))
+                if (!TEST_true(ossl_quic_stream_map_reset_stream_send_part(h.args.qsm,
+                                                                           s, op->arg1)))
                     goto err;
 
                 ossl_quic_stream_map_update_state(h.args.qsm, s);

--- a/test/quic_txp_test.c
+++ b/test/quic_txp_test.c
@@ -174,7 +174,9 @@ static int helper_init(struct helper *h)
                                                h->cc_data)))
         goto err;
 
-    if (!TEST_true(ossl_quic_stream_map_init(&h->qsm, NULL, NULL)))
+    if (!TEST_true(ossl_quic_stream_map_init(&h->qsm, NULL, NULL,
+                                             &h->max_streams_bidi_rxfc,
+                                             &h->max_streams_uni_rxfc)))
         goto err;
 
     h->have_qsm = 1;

--- a/test/quic_txp_test.c
+++ b/test/quic_txp_test.c
@@ -47,6 +47,7 @@ struct helper {
     BIO                             *bio1, *bio2;
     QUIC_TXFC                       conn_txfc;
     QUIC_RXFC                       conn_rxfc, stream_rxfc;
+    QUIC_RXFC                       max_streams_bidi_rxfc, max_streams_uni_rxfc;
     OSSL_STATM                      statm;
     OSSL_CC_DATA                    *cc_data;
     const OSSL_CC_METHOD            *cc_method;
@@ -147,6 +148,17 @@ static int helper_init(struct helper *h)
                                        NULL)))
         goto err;
 
+    if (!TEST_true(ossl_quic_rxfc_init(&h->max_streams_bidi_rxfc, NULL,
+                                       100, 100,
+                                       fake_now,
+                                       NULL)))
+        goto err;
+
+    if (!TEST_true(ossl_quic_rxfc_init(&h->max_streams_uni_rxfc, NULL,
+                                       100, 100,
+                                       fake_now,
+                                       NULL)))
+
     if (!TEST_true(ossl_statm_init(&h->statm)))
         goto err;
 
@@ -171,14 +183,16 @@ static int helper_init(struct helper *h)
         if (!TEST_ptr(h->args.crypto[i] = ossl_quic_sstream_new(4096)))
             goto err;
 
-    h->args.cur_scid   = scid_1;
-    h->args.cur_dcid   = dcid_1;
-    h->args.qsm        = &h->qsm;
-    h->args.conn_txfc  = &h->conn_txfc;
-    h->args.conn_rxfc  = &h->conn_rxfc;
-    h->args.cc_method  = h->cc_method;
-    h->args.cc_data    = h->cc_data;
-    h->args.now        = fake_now;
+    h->args.cur_scid                = scid_1;
+    h->args.cur_dcid                = dcid_1;
+    h->args.qsm                     = &h->qsm;
+    h->args.conn_txfc               = &h->conn_txfc;
+    h->args.conn_rxfc               = &h->conn_rxfc;
+    h->args.max_streams_bidi_rxfc   = &h->max_streams_bidi_rxfc;
+    h->args.max_streams_uni_rxfc    = &h->max_streams_uni_rxfc;
+    h->args.cc_method               = h->cc_method;
+    h->args.cc_data                 = h->cc_data;
+    h->args.now                     = fake_now;
 
     if (!TEST_ptr(h->txp = ossl_quic_tx_packetiser_new(&h->args)))
         goto err;

--- a/test/quicapitest.c
+++ b/test/quicapitest.c
@@ -62,13 +62,12 @@ static int test_quic_write_read(int idx)
             goto end;
     }
 
-    if (!TEST_true(ossl_quic_tserver_stream_new(qtserv, /*is_uni=*/0, &sid))
-        || !TEST_uint64_t_eq(sid, 1)) /* server-initiated, so first SID is 1 */
-        goto end;
+    sid = 0; /* client-initiated bidirectional stream */
 
     for (j = 0; j < 2; j++) {
         /* Check that sending and receiving app data is ok */
-        if (!TEST_true(SSL_write_ex(clientquic, msg, msglen, &numbytes)))
+        if (!TEST_true(SSL_write_ex(clientquic, msg, msglen, &numbytes))
+            || !TEST_size_t_eq(numbytes, msglen))
             goto end;
         if (idx == 1) {
             do {
@@ -86,6 +85,7 @@ static int test_quic_write_read(int idx)
                 goto end;
         }
 
+        ossl_quic_tserver_tick(qtserv);
         if (!TEST_true(ossl_quic_tserver_write(qtserv, sid, (unsigned char *)msg,
                                                msglen, &numbytes)))
             goto end;

--- a/test/quicfaultstest.c
+++ b/test/quicfaultstest.c
@@ -99,6 +99,7 @@ static int test_unknown_frame(void)
     unsigned char buf[80];
     size_t byteswritten;
     QTEST_FAULT *fault = NULL;
+    uint64_t sid = UINT64_MAX;
 
     if (!TEST_ptr(cctx))
         goto err;
@@ -119,7 +120,11 @@ static int test_unknown_frame(void)
                                                          NULL)))
         goto err;
 
-    if (!TEST_true(ossl_quic_tserver_write(qtserv, 0, (unsigned char *)msg, msglen,
+    if (!TEST_true(ossl_quic_tserver_stream_new(qtserv, /*is_uni=*/0, &sid))
+        || !TEST_uint64_t_eq(sid, 1))
+        goto err;
+
+    if (!TEST_true(ossl_quic_tserver_write(qtserv, sid, (unsigned char *)msg, msglen,
                                            &byteswritten)))
         goto err;
 
@@ -263,6 +268,7 @@ static int test_corrupted_data(int idx)
     size_t msglen = strlen(msg);
     unsigned char buf[80];
     size_t bytesread, byteswritten;
+    uint64_t sid = UINT64_MAX;
 
     if (!TEST_ptr(cctx))
         goto err;
@@ -290,11 +296,15 @@ static int test_corrupted_data(int idx)
     /* Corrupt the next server packet*/
     docorrupt = 1;
 
+    if (!TEST_true(ossl_quic_tserver_stream_new(qtserv, /*is_uni=*/0, &sid))
+        || !TEST_uint64_t_eq(sid, 1))
+        goto err;
+
     /*
      * Send first 5 bytes of message. This will get corrupted and is treated as
      * "lost"
      */
-    if (!TEST_true(ossl_quic_tserver_write(qtserv, 0, (unsigned char *)msg, 5,
+    if (!TEST_true(ossl_quic_tserver_write(qtserv, sid, (unsigned char *)msg, 5,
                                            &byteswritten)))
         goto err;
 
@@ -317,7 +327,7 @@ static int test_corrupted_data(int idx)
     OSSL_sleep(100);
 
     /* Send rest of message */
-    if (!TEST_true(ossl_quic_tserver_write(qtserv, 0, (unsigned char *)msg + 5,
+    if (!TEST_true(ossl_quic_tserver_write(qtserv, sid, (unsigned char *)msg + 5,
                                            msglen - 5, &byteswritten)))
         goto err;
 

--- a/test/quicfaultstest.c
+++ b/test/quicfaultstest.c
@@ -45,7 +45,7 @@ static int test_basic(void)
         goto err;
 
     ossl_quic_tserver_tick(qtserv);
-    if (!TEST_true(ossl_quic_tserver_read(qtserv, buf, sizeof(buf), &bytesread)))
+    if (!TEST_true(ossl_quic_tserver_read(qtserv, 0, buf, sizeof(buf), &bytesread)))
         goto err;
 
     /*
@@ -119,7 +119,7 @@ static int test_unknown_frame(void)
                                                          NULL)))
         goto err;
 
-    if (!TEST_true(ossl_quic_tserver_write(qtserv, (unsigned char *)msg, msglen,
+    if (!TEST_true(ossl_quic_tserver_write(qtserv, 0, (unsigned char *)msg, msglen,
                                            &byteswritten)))
         goto err;
 
@@ -294,7 +294,7 @@ static int test_corrupted_data(int idx)
      * Send first 5 bytes of message. This will get corrupted and is treated as
      * "lost"
      */
-    if (!TEST_true(ossl_quic_tserver_write(qtserv, (unsigned char *)msg, 5,
+    if (!TEST_true(ossl_quic_tserver_write(qtserv, 0, (unsigned char *)msg, 5,
                                            &byteswritten)))
         goto err;
 
@@ -317,7 +317,7 @@ static int test_corrupted_data(int idx)
     OSSL_sleep(100);
 
     /* Send rest of message */
-    if (!TEST_true(ossl_quic_tserver_write(qtserv, (unsigned char *)msg + 5,
+    if (!TEST_true(ossl_quic_tserver_write(qtserv, 0, (unsigned char *)msg + 5,
                                            msglen - 5, &byteswritten)))
         goto err;
 

--- a/test/recipes/70-test_quic_multistream.t
+++ b/test/recipes/70-test_quic_multistream.t
@@ -1,0 +1,21 @@
+#! /usr/bin/env perl
+# Copyright 2022 The OpenSSL Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution or at
+# https://www.openssl.org/source/license.html
+
+use OpenSSL::Test qw/:DEFAULT srctop_file/;
+use OpenSSL::Test::Utils;
+
+setup("test_quic_multistream");
+
+plan skip_all => "QUIC protocol is not supported by this OpenSSL build"
+    if disabled('quic');
+
+plan tests => 1;
+
+ok(run(test(["quic_multistream_test",
+             srctop_file("test", "certs", "servercert.pem"),
+             srctop_file("test", "certs", "serverkey.pem")])));

--- a/util/libssl.num
+++ b/util/libssl.num
@@ -561,3 +561,4 @@ d2i_SSL_SESSION_ex                      ?	3_2_0	EXIST::FUNCTION:
 SSL_is_tls                              ?	3_2_0	EXIST::FUNCTION:
 SSL_is_quic                             ?	3_2_0	EXIST::FUNCTION:
 SSL_new_stream                          ?	3_2_0	EXIST::FUNCTION:
+SSL_get0_connection                     ?	3_2_0	EXIST::FUNCTION:

--- a/util/libssl.num
+++ b/util/libssl.num
@@ -568,3 +568,4 @@ SSL_get_stream_id                       ?	3_2_0	EXIST::FUNCTION:
 SSL_set_default_stream_mode             ?	3_2_0	EXIST::FUNCTION:
 SSL_detach_stream                       ?	3_2_0	EXIST::FUNCTION:
 SSL_attach_stream                       ?	3_2_0	EXIST::FUNCTION:
+SSL_set_incoming_stream_reject_policy   ?	3_2_0	EXIST::FUNCTION:

--- a/util/libssl.num
+++ b/util/libssl.num
@@ -566,8 +566,6 @@ SSL_is_connection                       ?	3_2_0	EXIST::FUNCTION:
 SSL_get_stream_type                     ?	3_2_0	EXIST::FUNCTION:
 SSL_get_stream_id                       ?	3_2_0	EXIST::FUNCTION:
 SSL_set_default_stream_mode             ?	3_2_0	EXIST::FUNCTION:
-SSL_detach_stream                       ?	3_2_0	EXIST::FUNCTION:
-SSL_attach_stream                       ?	3_2_0	EXIST::FUNCTION:
 SSL_accept_stream                       ?	3_2_0	EXIST::FUNCTION:
 SSL_get_accept_stream_queue_len         ?	3_2_0	EXIST::FUNCTION:
 SSL_stream_reset                        ?	3_2_0	EXIST::FUNCTION:

--- a/util/libssl.num
+++ b/util/libssl.num
@@ -568,7 +568,6 @@ SSL_get_stream_id                       ?	3_2_0	EXIST::FUNCTION:
 SSL_set_default_stream_mode             ?	3_2_0	EXIST::FUNCTION:
 SSL_detach_stream                       ?	3_2_0	EXIST::FUNCTION:
 SSL_attach_stream                       ?	3_2_0	EXIST::FUNCTION:
-SSL_set_incoming_stream_reject_policy   ?	3_2_0	EXIST::FUNCTION:
 SSL_accept_stream                       ?	3_2_0	EXIST::FUNCTION:
 SSL_get_accept_stream_queue_len         ?	3_2_0	EXIST::FUNCTION:
 SSL_stream_reset                        ?	3_2_0	EXIST::FUNCTION:
@@ -577,3 +576,4 @@ SSL_get_stream_write_state              ?	3_2_0	EXIST::FUNCTION:
 SSL_get_stream_read_error_code          ?	3_2_0	EXIST::FUNCTION:
 SSL_get_stream_write_error_code         ?	3_2_0	EXIST::FUNCTION:
 SSL_get_conn_close_info                 ?	3_2_0	EXIST::FUNCTION:
+SSL_set_incoming_stream_policy          ?	3_2_0	EXIST::FUNCTION:

--- a/util/libssl.num
+++ b/util/libssl.num
@@ -560,3 +560,4 @@ SSL_add_expected_rpk                    ?	3_2_0	EXIST::FUNCTION:
 d2i_SSL_SESSION_ex                      ?	3_2_0	EXIST::FUNCTION:
 SSL_is_tls                              ?	3_2_0	EXIST::FUNCTION:
 SSL_is_quic                             ?	3_2_0	EXIST::FUNCTION:
+SSL_new_stream                          ?	3_2_0	EXIST::FUNCTION:

--- a/util/libssl.num
+++ b/util/libssl.num
@@ -571,3 +571,9 @@ SSL_attach_stream                       ?	3_2_0	EXIST::FUNCTION:
 SSL_set_incoming_stream_reject_policy   ?	3_2_0	EXIST::FUNCTION:
 SSL_accept_stream                       ?	3_2_0	EXIST::FUNCTION:
 SSL_get_accept_stream_queue_len         ?	3_2_0	EXIST::FUNCTION:
+SSL_stream_reset                        ?	3_2_0	EXIST::FUNCTION:
+SSL_get_stream_read_state               ?	3_2_0	EXIST::FUNCTION:
+SSL_get_stream_write_state              ?	3_2_0	EXIST::FUNCTION:
+SSL_get_stream_read_error_code          ?	3_2_0	EXIST::FUNCTION:
+SSL_get_stream_write_error_code         ?	3_2_0	EXIST::FUNCTION:
+SSL_get_conn_close_info                 ?	3_2_0	EXIST::FUNCTION:

--- a/util/libssl.num
+++ b/util/libssl.num
@@ -569,3 +569,5 @@ SSL_set_default_stream_mode             ?	3_2_0	EXIST::FUNCTION:
 SSL_detach_stream                       ?	3_2_0	EXIST::FUNCTION:
 SSL_attach_stream                       ?	3_2_0	EXIST::FUNCTION:
 SSL_set_incoming_stream_reject_policy   ?	3_2_0	EXIST::FUNCTION:
+SSL_accept_stream                       ?	3_2_0	EXIST::FUNCTION:
+SSL_get_accept_stream_queue_len         ?	3_2_0	EXIST::FUNCTION:

--- a/util/libssl.num
+++ b/util/libssl.num
@@ -562,3 +562,5 @@ SSL_is_tls                              ?	3_2_0	EXIST::FUNCTION:
 SSL_is_quic                             ?	3_2_0	EXIST::FUNCTION:
 SSL_new_stream                          ?	3_2_0	EXIST::FUNCTION:
 SSL_get0_connection                     ?	3_2_0	EXIST::FUNCTION:
+SSL_is_connection                       ?	3_2_0	EXIST::FUNCTION:
+SSL_get_stream_type                     ?	3_2_0	EXIST::FUNCTION:

--- a/util/libssl.num
+++ b/util/libssl.num
@@ -564,3 +564,7 @@ SSL_new_stream                          ?	3_2_0	EXIST::FUNCTION:
 SSL_get0_connection                     ?	3_2_0	EXIST::FUNCTION:
 SSL_is_connection                       ?	3_2_0	EXIST::FUNCTION:
 SSL_get_stream_type                     ?	3_2_0	EXIST::FUNCTION:
+SSL_get_stream_id                       ?	3_2_0	EXIST::FUNCTION:
+SSL_set_default_stream_mode             ?	3_2_0	EXIST::FUNCTION:
+SSL_detach_stream                       ?	3_2_0	EXIST::FUNCTION:
+SSL_attach_stream                       ?	3_2_0	EXIST::FUNCTION:

--- a/util/other.syms
+++ b/util/other.syms
@@ -646,6 +646,25 @@ SSL_want_x509_lookup                    define
 SSLv23_client_method                    define
 SSLv23_method                           define
 SSLv23_server_method                    define
+SSL_STREAM_FLAG_UNI                     define
+SSL_STREAM_TYPE_NONE                    define
+SSL_STREAM_TYPE_READ                    define
+SSL_STREAM_TYPE_WRITE                   define
+SSL_STREAM_TYPE_BIDI                    define
+SSL_STREAM_STATE_NONE                   define
+SSL_STREAM_STATE_WRONG_DIR              define
+SSL_STREAM_STATE_OK                     define
+SSL_STREAM_STATE_FINISHED               define
+SSL_STREAM_STATE_RESET_LOCAL            define
+SSL_STREAM_STATE_RESET_REMOTE           define
+SSL_STREAM_STATE_CONN_CLOSED            define
+SSL_ACCEPT_STREAM_NO_BLOCK              define
+SSL_DEFAULT_STREAM_MODE_AUTO_BIDI       define
+SSL_DEFAULT_STREAM_MODE_AUTO_UNI        define
+SSL_DEFAULT_STREAM_MODE_NONE            define
+SSL_INCOMING_STREAM_REJECT_POLICY_ACCEPT define
+SSL_INCOMING_STREAM_REJECT_POLICY_AUTO  define
+SSL_INCOMING_STREAM_REJECT_POLICY_REJECT define
 TLS_DEFAULT_CIPHERSUITES                define deprecated 3.0.0
 X509_CRL_http_nbio                      define deprecated 3.0.0
 X509_http_nbio                          define deprecated 3.0.0

--- a/util/other.syms
+++ b/util/other.syms
@@ -662,9 +662,9 @@ SSL_ACCEPT_STREAM_NO_BLOCK              define
 SSL_DEFAULT_STREAM_MODE_AUTO_BIDI       define
 SSL_DEFAULT_STREAM_MODE_AUTO_UNI        define
 SSL_DEFAULT_STREAM_MODE_NONE            define
-SSL_INCOMING_STREAM_REJECT_POLICY_ACCEPT define
-SSL_INCOMING_STREAM_REJECT_POLICY_AUTO  define
-SSL_INCOMING_STREAM_REJECT_POLICY_REJECT define
+SSL_INCOMING_STREAM_POLICY_ACCEPT       define
+SSL_INCOMING_STREAM_POLICY_AUTO         define
+SSL_INCOMING_STREAM_POLICY_REJECT       define
 TLS_DEFAULT_CIPHERSUITES                define deprecated 3.0.0
 X509_CRL_http_nbio                      define deprecated 3.0.0
 X509_http_nbio                          define deprecated 3.0.0


### PR DESCRIPTION
Worth noting that some commits have useful commit messages.

New commits:
```
087bd44f1c QUIC MSST: Tests
b6b7df3596 QUIC APL: Fix a bug where incoming unidirectional streams weren't detected
71a455c6c4 QUIC TSERVER: Allow STOP_SENDING/RESET_STREAM to be queried
8236b3b85e QUIC TSERVER: Handle FINs correctly if ossl_quic_tserver_read is not called first
5a95cc8394 QUIC QSM: Minor bugfixes
f793b89423 QUIC MSST: make update
5fe26d7489 QUIC MSST: Add documentation for new APIs
3ab63c47dd QUIC APL: Send STOP_SENDING/RESET_STREAM when XSO is freed
9b80b44979 QUIC QSM: Stream garbage collection
35c20302f5 QUIC FIFD: Add support for callback on frame ACK
9ec518c54c QUIC DISPATCH/APL: Add SSL_stream_reset and status query APIs
9dc18e2ae1 QUIC RXDP: Record STOP_SENDING/RESET_STREAM event AEC codes consistently
3ddc02290b QUIC QSM: Clean up SEND_STREAM/RECV_STREAM handling
ced1d2cb77 QUIC CHANNEL: Do not copy terminate cause as it is not modified after termination
c5779ec848 QUIC QSM: Handle STOP_SENDING correctly
33b7c080ca QUIC RXDP/QSM: Enforce MAX_STREAMS
72ad9c296f QUIC TXP/CHANNEL: Generate MAX_STREAMS using RXFC
b6985a3d53 QUIC FC: Modify RXFC to support use for enforcing MAX_STREAMS
cb468dfdc6 QUIC CHANNEL: Incoming streams implicitly create lower-numbered streams
5ef0d69e37 QUIC: Update faults test to use streams correctly
2fb9556d4a QUIC FIFD: Ensure QUIC_STREAM is updated after QUIC_SSTREAM loss
7690000e6d QUIC APL: Fix locking in XSO code and fix tests
0af0a197e3 QUIC CHANNEL, APL: Reject policy handling
c98f149fde QUIC DISPATCH/APL: SSL_accept_stream, SSL_get_accept_queue_len
830ce9eeca QUIC DISPATCH/APL: Add SSL_set_incoming_stream_reject_policy (unwired)
68d8ecd9f9 QUIC DISPATCH/APL: Implement SSL_set_default_stream_mode, default XSO refactor
5f0b368c06 QUIC DISPATCH/APL: Implement SSL_get_stream_id
dbc7748f4c QUIC DISPATCH/APL: Implement SSL_get_stream_type
312a956589 QUIC DISPATCH/APL: Implement SSL_is_connection
bbc0c1b28a QUIC DISPATCH/APL: Implement SSL_get0_connection
8d5c0f50e2 QUIC APL: Defer default XSO creation
0bbb2cd745 QUIC TSERVER: Add support for multiple streams
1edeac03e1 QUIC CHANNEL: Initialise state, FC credit for new streams correctly
c31e916e7a QUIC CHANNEL: Handle incoming remotely-created streams
5e81fa31dd QUIC APL: Add stream creation APIs
b12faab644 QUIC APL: Refactor stream-related code into QUIC_XSO object
4c2f22d2c2 QUIC CHANNEL: Handle any number of streams
85f3367ab9 QUIC CHANNEL: Store TPs for initial flow control in TX direction
7fe293726f QUIC CHANNEL: Clarify role of RX TPs in preparation of storing TX TPs
a1e5be1e66 QUIC CHANNEL: Remove stream 0-specific code
3245541e38 QUIC APL: Create QUIC CHANNEL up front rather than deferring creation
448a421c9b QUIC CHANNEL: Fix bug where get_time arg wasn't passed
411c06fcba QUIC: Base client/server identity on SSL method, not SSL_set_connect/accept_state
3f28f8a17c QUIC Dispatch: Update ssl_lib.c frontend to use new dispatch style
65c2f030f7 QUIC Dispatch: Add simple way to determine if SSL object is QUIC-related
5f0951fed9 QUIC Dispatch: Refactor APL interface to use SSL pointers not QC pointers
b23391d46f QUIC Dispatch: Introduce the QUIC_XSO object
dacfa7a122 QUIC Dispatch: Enhance SSL object unwrapping functions (core)
```