### PR TITLE
Fix checking return code of EVP_PKEY_get_int_param at check_curve

### DIFF
--- a/crypto/x509/x509_vfy.c
+++ b/crypto/x509/x509_vfy.c
@@ -3642,7 +3642,7 @@ static int check_curve(X509 *cert)
         EVP_PKEY_get_int_param(pkey,
                                OSSL_PKEY_PARAM_EC_DECODED_FROM_EXPLICIT_PARAMS,
                                &val);
-    return ret < 0 ? ret : !val;
+    return ret == 1 ? !val : -1;
 }
 
 /*-


### PR DESCRIPTION
According to docs, EVP_PKEY_get_int_param should return 1 on Success, and 0 on Failure. So, fix checking of this return value at check_curve

CLA: trivial