### PR TITLE
evp: manually update type field in EVP_MD

### DIFF
--- a/crypto/evp/digest.c
+++ b/crypto/evp/digest.c
@@ -1112,6 +1112,11 @@ EVP_MD *EVP_MD_fetch(OSSL_LIB_CTX *ctx, const char *algorithm,
         evp_generic_fetch(ctx, OSSL_OP_DIGEST, algorithm, properties,
                           evp_md_from_algorithm, evp_md_up_ref, evp_md_free);
 
+    /*  The value of 'type' will be lost if using EVP_MD_fetch() to retrieve EVP_MD
+        when building with OPENSSL_NO_AUTOALGINIT. Manually add it back here. */
+#ifdef OPENSSL_NO_AUTOALGINIT
+        md->type = OBJ_txt2nid(algorithm);
+#endif
     return md;
 }
 


### PR DESCRIPTION
FIX: https://github.com/openssl/openssl/issues/20221

The value of 'type' will be lost if using EVP_MD_fetch() to retrieve EVP_MD when building with OPENSSL_NO_AUTOALGINIT.
Manually add it back here.

Background:
Compared with 1.1.1, the output size of openssl 3.0 has almost doubled, so we tried to enable OPENSSL_NO_AUTOALGINIT to reduce the size to meet the memory limit of the old platform.
OPENSSL_NO_AUTOALGINIT will reduce binary size up to ~50KB based on different configuration (original size is 1578KB).

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
