### PR TITLE
add engine param to ciphers command

### DIFF
--- a/apps/ciphers.c
+++ b/apps/ciphers.c
@@ -18,6 +18,7 @@
 
 typedef enum OPTION_choice {
     OPT_COMMON,
+    OPT_ENGINE,
     OPT_STDNAME,
     OPT_CONVERT,
     OPT_SSL3,
@@ -36,6 +37,9 @@ const OPTIONS ciphers_options[] = {
 
     OPT_SECTION("General"),
     {"help", OPT_HELP, '-', "Display this summary"},
+#ifndef OPENSSL_NO_ENGINE
+    {"engine", OPT_ENGINE, 's', "Use engine, possibly a hardware device"},
+#endif
 
     OPT_SECTION("Output"),
     {"v", OPT_V, '-', "Verbose listing of the SSL/TLS ciphers"},
@@ -122,6 +126,9 @@ int ciphers_main(int argc, char **argv)
             break;
         case OPT_UPPER_V:
             verbose = Verbose = 1;
+            break;
+        case OPT_ENGINE:
+            setup_engine(opt_arg(), 0);
             break;
         case OPT_S:
             use_supported = 1;

--- a/apps/dgst.c
+++ b/apps/dgst.c
@@ -53,7 +53,7 @@ const OPTIONS dgst_options[] = {
     {"help", OPT_HELP, '-', "Display this summary"},
     {"list", OPT_LIST, '-', "List digests"},
 #ifndef OPENSSL_NO_ENGINE
-    {"engine", OPT_ENGINE, 's', "Use engine e, possibly a hardware device"},
+    {"engine", OPT_ENGINE, 's', "Use engine, possibly a hardware device"},
     {"engine_impl", OPT_ENGINE_IMPL, '-',
      "Also use engine given by -engine for digest operations"},
 #endif

--- a/doc/man1/openssl-ciphers.pod.in
+++ b/doc/man1/openssl-ciphers.pod.in
@@ -23,7 +23,8 @@ B<openssl> B<ciphers>
 [B<-stdname>]
 [B<-convert> I<name>]
 [B<-ciphersuites> I<val>]
-{- $OpenSSL::safe::opt_provider_synopsis -}
+{- $OpenSSL::safe::opt_engine_synopsis -}{- output_off() if $disabled{"deprecated-3.0"}; ""
+-}{- $OpenSSL::safe::opt_provider_synopsis -}
 [I<cipherlist>]
 
 =head1 DESCRIPTION
@@ -40,6 +41,8 @@ determine the appropriate cipherlist.
 
 Print a usage message.
 
+{- $OpenSSL::safe::opt_engine_item -}
+{- output_off() if $disabled{"deprecated-3.0"}; "" -}
 {- $OpenSSL::safe::opt_provider_item -}
 
 =item B<-s>


### PR DESCRIPTION
You can set -engine parameter for `openssl dgst` and `openssl enc`, you can set -provider parameter for `openssl dgst`, `openssl enc` and `openssl ciphers`, but there is no -engine parameter for `openssl ciphers` command. I suppose this to be an oddity that should be fixed.

CLA: trivial