### PR TITLE
PKCS8: Allow Password based KDF Saltlen to be specified when writing an encrypted private key

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,13 @@ OpenSSL 3.2
 
 ### Changes between 3.1 and 3.2 [xx XXX xxxx]
 
+ * The openssl "pkcs8" commandline application has changed the default
+   PBE salt length to 16 bytes. Prior to the change it used 8 bytes,
+   which is not an acceptable value for FIPS algorithms (PBKDF2).
+   An additional "saltlen" option has also been added.
+
+   *Shane Lontis*
+
  * Added client side support for QUIC
 
    *Hugo Landau, Matt Caswell, Paul Dale, Tomáš Mráz, Richard Levitte*

--- a/apps/pkcs8.c
+++ b/apps/pkcs8.c
@@ -17,6 +17,10 @@
 #include <openssl/evp.h>
 #include <openssl/pkcs12.h>
 
+#define PBE_SALT_LEN_DEFAULT 16
+#define STR(a) XSTR(a)
+#define XSTR(a) #a
+
 typedef enum OPTION_choice {
     OPT_COMMON,
     OPT_INFORM, OPT_OUTFORM, OPT_ENGINE, OPT_IN, OPT_OUT,
@@ -54,7 +58,8 @@ const OPTIONS pkcs8_options[] = {
     {"traditional", OPT_TRADITIONAL, '-', "use traditional format private key"},
     {"iter", OPT_ITER, 'p', "Specify the iteration count"},
     {"noiter", OPT_NOITER, '-', "Use 1 as iteration count"},
-    {"saltlen", OPT_SALTLEN, 'p', "Specify the salt length"},
+    {"saltlen", OPT_SALTLEN, 'p', "Specify the salt length (in bytes)"},
+    {OPT_MORE_STR, 0, 0, "Default: " STR(PBE_SALT_LEN_DEFAULT)},
 
 #ifndef OPENSSL_NO_SCRYPT
     OPT_SECTION("Scrypt"),
@@ -87,7 +92,7 @@ int pkcs8_main(int argc, char **argv)
     int nocrypt = 0, ret = 1, iter = PKCS12_DEFAULT_ITER;
     int informat = FORMAT_UNDEF, outformat = FORMAT_PEM, topk8 = 0, pbe_nid = -1;
     int private = 0, traditional = 0;
-    int saltlen = 0;
+    int saltlen = PBE_SALT_LEN_DEFAULT;
 #ifndef OPENSSL_NO_SCRYPT
     long scrypt_N = 0, scrypt_r = 0, scrypt_p = 0;
 #endif

--- a/doc/man1/openssl-pkcs8.pod.in
+++ b/doc/man1/openssl-pkcs8.pod.in
@@ -283,7 +283,7 @@ The B<-iter> option was added in OpenSSL 1.1.0.
 The B<-engine> option was deprecated in OpenSSL 3.0.
 
 The B<-saltlen> option was added in OpenSSL 3.2. Prior to this change
-the default value used internally was 8 bytes. It now uses a default\
+the default value used internally was 8 bytes. It now uses a default
 of 16 bytes.
 
 =head1 COPYRIGHT

--- a/doc/man1/openssl-pkcs8.pod.in
+++ b/doc/man1/openssl-pkcs8.pod.in
@@ -27,6 +27,7 @@ B<openssl> B<pkcs8>
 [B<-scrypt_N> I<N>]
 [B<-scrypt_r> I<r>]
 [B<-scrypt_p> I<p>]
+[B<-saltlen> I<size>]
 {- $OpenSSL::safe::opt_r_synopsis -}
 {- $OpenSSL::safe::opt_engine_synopsis -}{- $OpenSSL::safe::opt_provider_synopsis -}
 
@@ -154,6 +155,11 @@ Sets the scrypt I<N>, I<r> or I<p> parameters.
 
 {- $OpenSSL::safe::opt_provider_item -}
 
+=item B<-saltlen>
+
+Sets the length (in bytes) of the salt to use for the PBE algorithm.
+If this value is not specified, the default is 16 (128 bits).
+
 =back
 
 =head1 NOTES
@@ -275,6 +281,10 @@ L<openssl-gendsa(1)>
 The B<-iter> option was added in OpenSSL 1.1.0.
 
 The B<-engine> option was deprecated in OpenSSL 3.0.
+
+The B<-saltlen> option was added in OpenSSL 3.2. Prior to this change
+the default value used internally was 8 bytes. It now uses a default\
+of 16 bytes.
 
 =head1 COPYRIGHT
 


### PR DESCRIPTION
It you write out a RSA private key using
````
openssl pkcs8 -topk8 -in rsapriv.pem -out priv.pem
````
It will set the saltlen used by PBKDF2 to a default of 64 bits and there is no way to change this.
NIST requires 128 bits.

The code inside the FIPS provider gets around this issue by setting a flag that ignores the lower bound check when PKCS5 is used. This however will not interop nicely with other FIPS compliant toolkits that assume that 128 bits are being used.


NOTE: This also does not address 'genrsa' which calls PEM_write_bio_PrivateKey().
This function uses the encoders which currently have no mechanism for passing the saltlen.
Currently you would have to use this pkcs8 app (with the change in this PR) to get around the issue,, 

This PR now sets the default salt length to 128 bits within the PKCS8 application.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
