### PR TITLE
s_client: psk_client_cb honor the hint, GH #20785

### DIFF
--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -142,6 +142,7 @@ static unsigned int psk_client_cb(SSL *ssl, const char *hint, char *identity,
     int ret;
     long key_len;
     unsigned char *key;
+    char *used_hint = (char *)hint;
 
     if (c_debug)
         BIO_printf(bio_c_out, "psk_client_cb\n");
@@ -149,7 +150,8 @@ static unsigned int psk_client_cb(SSL *ssl, const char *hint, char *identity,
         /* no ServerKeyExchange message */
         if (c_debug)
             BIO_printf(bio_c_out,
-                       "NULL received PSK identity hint, continuing anyway\n");
+                       "NULL received PSK identity hint, continuing with the default\n");
+        used_hint = psk_identity;
     } else if (c_debug) {
         BIO_printf(bio_c_out, "Received PSK identity hint '%s'\n", hint);
     }
@@ -157,7 +159,7 @@ static unsigned int psk_client_cb(SSL *ssl, const char *hint, char *identity,
     /*
      * lookup PSK identity and PSK key based on the given identity hint here
      */
-    ret = BIO_snprintf(identity, max_identity_len, "%s", psk_identity);
+    ret = BIO_snprintf(identity, max_identity_len, "%s", used_hint);
     if (ret < 0 || (unsigned int)ret > max_identity_len)
         goto out_err;
     if (c_debug)

--- a/test/ssl_old_test.c
+++ b/test/ssl_old_test.c
@@ -1600,7 +1600,7 @@ int main(int argc, char *argv[])
             BIO_printf(bio_err, "setting PSK identity hint to s_ctx\n");
         if (!SSL_CTX_use_psk_identity_hint(s_ctx, "ctx server identity_hint") ||
             !SSL_CTX_use_psk_identity_hint(s_ctx2, "ctx server identity_hint")) {
-            BIO_printf(bio_err, "error setting PSK identity hint to s_ctx\n");
+            BIO_printf(bio_err, "error setting PSK identity hint to s_ctx or s_ctx2\n");
             ERR_print_errors(bio_err);
             goto end;
         }
@@ -2967,7 +2967,8 @@ static unsigned int psk_client_callback(SSL *ssl, const char *hint,
     int ret;
     unsigned int psk_len = 0;
 
-    ret = BIO_snprintf(identity, max_identity_len, "Client_identity");
+    ret = BIO_snprintf(identity, max_identity_len, "%s", hint != NULL
+                       ? hint : "ctx server identity_hint");
     if (ret < 0)
         goto out_err;
     if (debug)
@@ -2987,7 +2988,7 @@ static unsigned int psk_server_callback(SSL *ssl, const char *identity,
 {
     unsigned int psk_len = 0;
 
-    if (strcmp(identity, "Client_identity") != 0) {
+    if (strcmp(identity, "ctx server identity_hint") != 0) {
         BIO_printf(bio_err, "server: PSK error: client identity not found\n");
         return 0;
     }

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -3275,10 +3275,9 @@ static int use_session_cb(SSL *ssl, const EVP_MD *md, const unsigned char **id,
 }
 
 #ifndef OPENSSL_NO_PSK
-static unsigned int psk_client_cb(SSL *ssl, const char *hint, char *id,
-                                  unsigned int max_id_len,
-                                  unsigned char *psk,
-                                  unsigned int max_psk_len)
+static unsigned int psk_client_cb(ossl_unused SSL *ssl, ossl_unused const char *hint,
+                                  char *id, unsigned int max_id_len,
+                                  unsigned char *psk, unsigned int max_psk_len)
 {
     unsigned int psklen = 0;
 


### PR DESCRIPTION
- [x] documentation is added or updated
- [x] tests are added or updated
  only ssl_old_test sets a hint, sslapitest reuses the TLSv1.3 master key
