### PR TITLE
Make the min/max proto functions do something sensible for QUIC

### DIFF
--- a/doc/man3/SSL_CONF_cmd.pod
+++ b/doc/man3/SSL_CONF_cmd.pod
@@ -416,24 +416,26 @@ This is a synonym for the "Groups" command.
 This sets the minimum supported SSL, TLS or DTLS version.
 
 Currently supported protocol values are B<SSLv3>, B<TLSv1>, B<TLSv1.1>,
-B<TLSv1.2>, B<TLSv1.3>, B<DTLSv1> and B<DTLSv1.2>.
-The SSL and TLS bounds apply only to TLS-based contexts, while the DTLS bounds
-apply only to DTLS-based contexts.
-The command can be repeated with one instance setting a TLS bound, and the
-other setting a DTLS bound.
-The value B<None> applies to both types of contexts and disables the limits.
+B<TLSv1.2>, B<TLSv1.3>, B<DTLSv1>, B<DTLSv1.2> and B<QUICv1>.
+The SSL and TLS bounds apply only to TLS-based contexts. The DTLS bounds
+apply only to DTLS-based contexts.The QUIC bounds apply only to QUIC-based
+contexts.
+The command can be repeated with one instance setting a TLS bound, another
+setting a DTLS bound and another setting a QUIC bound.
+The value B<None> applies to all types of contexts and disables the limits.
 
 =item B<MaxProtocol>
 
 This sets the maximum supported SSL, TLS or DTLS version.
 
 Currently supported protocol values are B<SSLv3>, B<TLSv1>, B<TLSv1.1>,
-B<TLSv1.2>, B<TLSv1.3>, B<DTLSv1> and B<DTLSv1.2>.
-The SSL and TLS bounds apply only to TLS-based contexts, while the DTLS bounds
-apply only to DTLS-based contexts.
-The command can be repeated with one instance setting a TLS bound, and the
-other setting a DTLS bound.
-The value B<None> applies to both types of contexts and disables the limits.
+B<TLSv1.2>, B<TLSv1.3>, B<DTLSv1>, B<DTLSv1.2> and B<QUICv1>.
+The SSL and TLS bounds apply only to TLS-based contexts. The DTLS bounds
+apply only to DTLS-based contexts.The QUIC bounds apply only to QUIC-based
+contexts.
+The command can be repeated with one instance setting a TLS bound, another
+setting a DTLS bound and another setting a QUIC bound.
+The value B<None> applies to all types of contexts and disables the limits.
 
 =item B<Protocol>
 
@@ -775,8 +777,8 @@ B<AllowNoDHEKEX> and B<PrioritizeChaCha> were added in OpenSSL 1.1.1.
 The B<UnsafeLegacyServerConnect> option is no longer set by default from
 OpenSSL 3.0.
 
-The B<TxCertificateCompression> and B<RxCertificateCompression> options were
-added in OpenSSL 3.2.
+The B<TxCertificateCompression> and B<RxCertificateCompression> options and QUIC
+support were added in OpenSSL 3.2.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/SSL_CONF_cmd.pod
+++ b/doc/man3/SSL_CONF_cmd.pod
@@ -418,7 +418,7 @@ This sets the minimum supported SSL, TLS or DTLS version.
 Currently supported protocol values are B<SSLv3>, B<TLSv1>, B<TLSv1.1>,
 B<TLSv1.2>, B<TLSv1.3>, B<DTLSv1>, B<DTLSv1.2> and B<QUICv1>.
 The SSL and TLS bounds apply only to TLS-based contexts. The DTLS bounds
-apply only to DTLS-based contexts.The QUIC bounds apply only to QUIC-based
+apply only to DTLS-based contexts. The QUIC bounds apply only to QUIC-based
 contexts.
 The command can be repeated with one instance setting a TLS bound, another
 setting a DTLS bound and another setting a QUIC bound.
@@ -431,7 +431,7 @@ This sets the maximum supported SSL, TLS or DTLS version.
 Currently supported protocol values are B<SSLv3>, B<TLSv1>, B<TLSv1.1>,
 B<TLSv1.2>, B<TLSv1.3>, B<DTLSv1>, B<DTLSv1.2> and B<QUICv1>.
 The SSL and TLS bounds apply only to TLS-based contexts. The DTLS bounds
-apply only to DTLS-based contexts.The QUIC bounds apply only to QUIC-based
+apply only to DTLS-based contexts. The QUIC bounds apply only to QUIC-based
 contexts.
 The command can be repeated with one instance setting a TLS bound, another
 setting a DTLS bound and another setting a QUIC bound.

--- a/doc/man3/SSL_CTX_set_min_proto_version.pod
+++ b/doc/man3/SSL_CTX_set_min_proto_version.pod
@@ -39,8 +39,9 @@ Getters return 0 in case B<ctx> or B<ssl> have been configured to
 automatically use the lowest or highest version supported by the library.
 
 Currently supported versions are B<SSL3_VERSION>, B<TLS1_VERSION>,
-B<TLS1_1_VERSION>, B<TLS1_2_VERSION>, B<TLS1_3_VERSION> for TLS and
-B<DTLS1_VERSION>, B<DTLS1_2_VERSION> for DTLS.
+B<TLS1_1_VERSION>, B<TLS1_2_VERSION>, B<TLS1_3_VERSION> for TLS,
+B<DTLS1_VERSION>, B<DTLS1_2_VERSION> for DTLS and B<OSSL_QUIC1_VERSION> for
+QUIC.
 
 =head1 RETURN VALUES
 
@@ -60,7 +61,7 @@ L<SSL_CTX_set_options(3)>, L<SSL_CONF_cmd(3)>
 =head1 HISTORY
 
 The setter functions were added in OpenSSL 1.1.0. The getter functions
-were added in OpenSSL 1.1.1.
+were added in OpenSSL 1.1.1. QUIC support was added in OpenSSL 3.2.
 
 =head1 COPYRIGHT
 

--- a/ssl/ssl_conf.c
+++ b/ssl/ssl_conf.c
@@ -318,7 +318,8 @@ static int protocol_from_string(const char *value)
         {"TLSv1.2", TLS1_2_VERSION},
         {"TLSv1.3", TLS1_3_VERSION},
         {"DTLSv1", DTLS1_VERSION},
-        {"DTLSv1.2", DTLS1_2_VERSION}
+        {"DTLSv1.2", DTLS1_2_VERSION},
+        {"QUICv1", OSSL_QUIC1_VERSION}
     };
     size_t i;
     size_t n = OSSL_NELEM(versions);

--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -2049,6 +2049,7 @@ int ssl_set_version_bound(int method_version, int version, int *bound)
 
     valid_tls = version >= SSL3_VERSION && version <= TLS_MAX_VERSION_INTERNAL;
     valid_dtls =
+        /* We support client side pre-standardisation version of DTLS */
         (version == DTLS1_BAD_VER)
         || (DTLS_VERSION_LE(version, DTLS_MAX_VERSION_INTERNAL)
             && DTLS_VERSION_GE(version, DTLS1_VERSION));

--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -2049,10 +2049,11 @@ int ssl_set_version_bound(int method_version, int version, int *bound)
 
     valid_tls = version >= SSL3_VERSION && version <= TLS_MAX_VERSION_INTERNAL;
     valid_dtls =
-        DTLS_VERSION_LE(version, DTLS_MAX_VERSION_INTERNAL) &&
-        DTLS_VERSION_GE(version, DTLS1_BAD_VER);
+        (version == DTLS1_BAD_VER)
+        || (DTLS_VERSION_LE(version, DTLS_MAX_VERSION_INTERNAL)
+            && DTLS_VERSION_GE(version, DTLS1_VERSION));
 
-    if (!valid_tls && !valid_dtls)
+    if (!valid_tls && !valid_dtls && version != OSSL_QUIC1_VERSION)
         return 0;
 
     /*-
@@ -2082,7 +2083,15 @@ int ssl_set_version_bound(int method_version, int version, int *bound)
         if (valid_dtls)
             *bound = version;
         break;
+
+#ifndef OPENSSL_NO_QUIC
+    case OSSL_QUIC_ANY_VERSION:
+        if (version == OSSL_QUIC1_VERSION)
+            *bound = version;
+        break;
+#endif
     }
+
     return 1;
 }
 


### PR DESCRIPTION
Ensure we can set OSSL_QUICV1_VERSION via the min/man protocol API functions. This also applies to the config file equivalents.