### PR TITLE
build_wincrypt_test.c: Fix compilation with MSVC

### DIFF
--- a/test/build_wincrypt_test.c
+++ b/test/build_wincrypt_test.c
@@ -22,7 +22,11 @@
 # include <wincrypt.h>
 # ifndef X509_NAME
 #  ifndef PEDANTIC
-#   warning "wincrypt.h no longer defining X509_NAME before OpenSSL headers"
+#    ifdef _MSC_VER
+#      pragma message("wincrypt.h no longer defining X509_NAME before OpenSSL headers")
+#    else
+#      warning "wincrypt.h no longer defining X509_NAME before OpenSSL headers"
+#    endif
 #  endif
 # endif
 #endif


### PR DESCRIPTION
uses #pragma message instead of #warning with MSVC
Fixes issue https://github.com/openssl/openssl/issues/20805
