### PR TITLE
optimize param lookup in ossl_gcm_(get/set)_ctx_params

### DIFF
--- a/crypto/params.c
+++ b/crypto/params.c
@@ -1529,3 +1529,29 @@ int OSSL_PARAM_get_octet_string_ptr(const OSSL_PARAM *p, const void **val,
     return rv || get_string_ptr_internal(p, val, used_len,
                                          OSSL_PARAM_OCTET_STRING);
 }
+
+OSSL_PARAM *OSSL_PARAM_next(OSSL_PARAM *p)
+{
+    if (p != NULL && p->key != NULL)
+        return p + 1;
+    return NULL;
+}
+
+const OSSL_PARAM *OSSL_PARAM_next_const(const OSSL_PARAM *p)
+{
+    if (p != NULL && p->key != NULL)
+        return p + 1;
+    return NULL;
+}
+
+int OSSL_PARAM_equals(const OSSL_PARAM *p, const char *key)
+{
+    if (p != NULL && key != NULL && p->key != NULL)
+        return strcmp(key, p->key) == 0;
+    return 0;
+}
+
+int OSSL_PARAM_is_end(const OSSL_PARAM *p)
+{
+    return p == NULL || p->key == NULL;
+}

--- a/include/openssl/params.h
+++ b/include/openssl/params.h
@@ -154,7 +154,6 @@ OSSL_PARAM *OSSL_PARAM_dup(const OSSL_PARAM *p);
 OSSL_PARAM *OSSL_PARAM_merge(const OSSL_PARAM *p1, const OSSL_PARAM *p2);
 void OSSL_PARAM_free(OSSL_PARAM *p);
 
-const OSSL_PARAM *OSSL_PARAM_locate_const(const OSSL_PARAM *p, const char *key);
 OSSL_PARAM *OSSL_PARAM_next(OSSL_PARAM *p);
 const OSSL_PARAM *OSSL_PARAM_next_const(const OSSL_PARAM *p);
 int OSSL_PARAM_equals(const OSSL_PARAM *p, const char *key);

--- a/include/openssl/params.h
+++ b/include/openssl/params.h
@@ -154,6 +154,12 @@ OSSL_PARAM *OSSL_PARAM_dup(const OSSL_PARAM *p);
 OSSL_PARAM *OSSL_PARAM_merge(const OSSL_PARAM *p1, const OSSL_PARAM *p2);
 void OSSL_PARAM_free(OSSL_PARAM *p);
 
+const OSSL_PARAM *OSSL_PARAM_locate_const(const OSSL_PARAM *p, const char *key);
+OSSL_PARAM *OSSL_PARAM_next(OSSL_PARAM *p);
+const OSSL_PARAM *OSSL_PARAM_next_const(const OSSL_PARAM *p);
+int OSSL_PARAM_equals(const OSSL_PARAM *p, const char *key);
+int OSSL_PARAM_is_end(const OSSL_PARAM *p);
+
 # ifdef  __cplusplus
 }
 # endif

--- a/providers/implementations/ciphers/ciphercommon_gcm.c
+++ b/providers/implementations/ciphers/ciphercommon_gcm.c
@@ -172,64 +172,65 @@ int ossl_gcm_get_ctx_params(void *vctx, OSSL_PARAM params[])
             }
             break;
         case 'k':
-                if (OSSL_PARAM_equals(p, OSSL_CIPHER_PARAM_KEYLEN)) {
-                    if (!OSSL_PARAM_set_size_t(p, ctx->keylen)) {
-                        ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
-                        return 0;
-                    }
+            if (OSSL_PARAM_equals(p, OSSL_CIPHER_PARAM_KEYLEN)) {
+                if (!OSSL_PARAM_set_size_t(p, ctx->keylen)) {
+                    ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
+                    return 0;
                 }
-                break;
+            }
+            break;
         case 't':
-                if (OSSL_PARAM_equals(p, OSSL_CIPHER_PARAM_AEAD_TAG)) {
-                    sz = p->data_size;
-                    if (sz == 0
-                        || sz > EVP_GCM_TLS_TAG_LEN
-                        || !ctx->enc
-                        || ctx->taglen == UNINITIALISED_SIZET) {
-                        ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_TAG);
-                        return 0;
-                    }
-                    if (!OSSL_PARAM_set_octet_string(p, ctx->buf, sz)) {
-                        ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
-                        return 0;
-                    }
+            if (OSSL_PARAM_equals(p, OSSL_CIPHER_PARAM_AEAD_TAG)) {
+                sz = p->data_size;
+                if (sz == 0
+                    || sz > EVP_GCM_TLS_TAG_LEN
+                    || !ctx->enc
+                    || ctx->taglen == UNINITIALISED_SIZET) {
+                    ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_TAG);
+                    return 0;
                 }
-                else if (OSSL_PARAM_equals(p, OSSL_CIPHER_PARAM_AEAD_TAGLEN)) {
-                    size_t taglen = (ctx->taglen != UNINITIALISED_SIZET) ? ctx->taglen :
-                        GCM_TAG_MAX_SIZE;
+                if (!OSSL_PARAM_set_octet_string(p, ctx->buf, sz)) {
+                    ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
+                    return 0;
+                }
+            }
+            else if (OSSL_PARAM_equals(p, OSSL_CIPHER_PARAM_AEAD_TAGLEN)) {
+                size_t taglen = (ctx->taglen != UNINITIALISED_SIZET) ? ctx->taglen :
+                    GCM_TAG_MAX_SIZE;
 
-                    if (!OSSL_PARAM_set_size_t(p, taglen)) {
-                        ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
-                        return 0;
-                    }
+                if (!OSSL_PARAM_set_size_t(p, taglen)) {
+                    ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
+                    return 0;
                 }
-                else if (OSSL_PARAM_equals(p, OSSL_CIPHER_PARAM_AEAD_TLS1_AAD_PAD)) {
-                    if (!OSSL_PARAM_set_size_t(p, ctx->tls_aad_pad_sz)) {
-                        ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
-                        return 0;
-                    }
+            }
+            else if (OSSL_PARAM_equals(p, OSSL_CIPHER_PARAM_AEAD_TLS1_AAD_PAD)) {
+                if (!OSSL_PARAM_set_size_t(p, ctx->tls_aad_pad_sz)) {
+                    ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
+                    return 0;
                 }
-                else if (OSSL_PARAM_equals(p, OSSL_CIPHER_PARAM_AEAD_TLS1_GET_IV_GEN)) {
-                    if (p->data == NULL
-                        || p->data_type != OSSL_PARAM_OCTET_STRING
-                        || !getivgen(ctx, p->data, p->data_size))
-                        return 0;
-                }
+            }
+            else if (OSSL_PARAM_equals(p, OSSL_CIPHER_PARAM_AEAD_TLS1_GET_IV_GEN)) {
+                if (p->data == NULL
+                    || p->data_type != OSSL_PARAM_OCTET_STRING
+                    || !getivgen(ctx, p->data, p->data_size))
+                    return 0;
+            }
+            break;
         case 'u':
-                if (OSSL_PARAM_equals(p, OSSL_CIPHER_PARAM_UPDATED_IV)) {
-                    if (ctx->iv_state == IV_STATE_UNINITIALISED)
-                        return 0;
-                    if (ctx->ivlen > p->data_size) {
-                        ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_IV_LENGTH);
-                        return 0;
-                    }
-                    if (!OSSL_PARAM_set_octet_string(p, ctx->iv, ctx->ivlen)
-                        && !OSSL_PARAM_set_octet_ptr(p, &ctx->iv, ctx->ivlen)) {
-                        ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
-                        return 0;
-                    }
+            if (OSSL_PARAM_equals(p, OSSL_CIPHER_PARAM_UPDATED_IV)) {
+                if (ctx->iv_state == IV_STATE_UNINITIALISED)
+                    return 0;
+                if (ctx->ivlen > p->data_size) {
+                    ERR_raise(ERR_LIB_PROV, PROV_R_INVALID_IV_LENGTH);
+                    return 0;
                 }
-                break;
+                if (!OSSL_PARAM_set_octet_string(p, ctx->iv, ctx->ivlen)
+                    && !OSSL_PARAM_set_octet_ptr(p, &ctx->iv, ctx->ivlen)) {
+                    ERR_raise(ERR_LIB_PROV, PROV_R_FAILED_TO_SET_PARAMETER);
+                    return 0;
+                }
+            }
+            break;
         }
         p = OSSL_PARAM_next(p);
     }

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5517,3 +5517,7 @@ EC_GROUP_to_params                      ?	3_2_0	EXIST::FUNCTION:EC
 X509_STORE_CTX_init_rpk                 ?	3_2_0	EXIST::FUNCTION:
 X509_STORE_CTX_get0_rpk                 ?	3_2_0	EXIST::FUNCTION:
 X509_STORE_CTX_set0_rpk                 ?	3_2_0	EXIST::FUNCTION:
+OSSL_PARAM_next                         ?	3_2_0	EXIST::FUNCTION:
+OSSL_PARAM_next_const                   ?	3_2_0	EXIST::FUNCTION:
+OSSL_PARAM_equals                       ?	3_2_0	EXIST::FUNCTION:
+OSSL_PARAM_is_end                       ?	3_2_0	EXIST::FUNCTION:


### PR DESCRIPTION
potential fix for #20625 #20171

This PR changes the order of the iteration loops, and instead of trying checking all potential parameters types, it iterates over the input parameter array. It also checks the first letter of the parameter name to allow more efficient lookup.

