### PR TITLE
Added ability to pass additional ASFLAGS to Configure

### DIFF
--- a/Configure
+++ b/Configure
@@ -741,6 +741,7 @@ my @user_crossable = qw ( AR AS CC CXX CPP LD MT RANLIB RC );
 # input, as opposed to the VAR=string option that override the corresponding
 # config target attributes
 my %useradd = (
+    ASFLAGS     => [],
     CPPDEFINES  => [],
     CPPINCLUDES => [],
     CPPFLAGS    => [],


### PR DESCRIPTION
This allows additional command line options to be passed to the assembler. For example: 
Configure VC-WIN64A ASFLAGS=--reproducible