### PR TITLE
Make `BN_nist_mod_*` family of functions (in `bn_nist.c`) constant-time

### DIFF
--- a/crypto/bn/bn_nist.c
+++ b/crypto/bn/bn_nist.c
@@ -450,7 +450,11 @@ int BN_nist_mod_192(BIGNUM *r, const BIGNUM *a, const BIGNUM *field,
      * 'tmp=result-modulus; if (!carry || !borrow) result=tmp;'
      * this is what happens below, but without explicit if:-) a.
      */
-    carry = bn_sub_words(c_d, r_d, _nist_p_192[0], BN_NIST_192_TOP) && carry;
+    {
+        int sub_carry = bn_sub_words(c_d, r_d, _nist_p_192[0], BN_NIST_192_TOP);
+        carry = constant_time_select_int(constant_time_is_zero(sub_carry),
+                                         0, carry);
+    }
     constant_time_cond_swap_bn(
         constant_time_is_zero_8(carry),
         r_d, c_d, BN_NIST_192_TOP);
@@ -640,7 +644,7 @@ int BN_nist_mod_224(BIGNUM *r, const BIGNUM *a, const BIGNUM *field,
      */
     {
         BN_ULONG add_res[BN_NIST_224_TOP];
-        int add_carry, sub_carry;
+        int add_carry, sub_carry, adjust_carry;
 
         sub_carry = bn_sub_words(c_d, r_d, _nist_p_224[0], BN_NIST_224_TOP);
         add_carry = bn_add_words(add_res, r_d, _nist_p_224[0], BN_NIST_224_TOP);
@@ -651,10 +655,13 @@ int BN_nist_mod_224(BIGNUM *r, const BIGNUM *a, const BIGNUM *field,
             BN_NIST_224_TOP
         );
 
-        carry = constant_time_select_int(
+        adjust_carry = constant_time_select_int(
             constant_time_eq_int(adjust, ADJUST_WITH_ADD),
             add_carry, sub_carry
-        ) && carry;
+        );
+        /* carry = adjust_carry && carry */
+        carry = constant_time_select_int(constant_time_is_zero(adjust_carry),
+                                         0, carry);
     }
     /* otherwise it's effectively same as in BN_nist_mod_192... */
     constant_time_cond_swap_bn(
@@ -898,7 +905,7 @@ int BN_nist_mod_256(BIGNUM *r, const BIGNUM *a, const BIGNUM *field,
 
     {
         BN_ULONG add_res[BN_NIST_256_TOP];
-        int add_carry, sub_carry;
+        int add_carry, sub_carry, adjust_carry;
 
         sub_carry = bn_sub_words(c_d, r_d, _nist_p_256[0], BN_NIST_256_TOP);
         add_carry = bn_add_words(add_res, r_d, _nist_p_256[0], BN_NIST_256_TOP);
@@ -909,10 +916,13 @@ int BN_nist_mod_256(BIGNUM *r, const BIGNUM *a, const BIGNUM *field,
             BN_NIST_256_TOP
         );
 
-        carry = constant_time_select_int(
+        adjust_carry = constant_time_select_int(
             constant_time_eq_int(adjust, ADJUST_WITH_ADD),
             add_carry, sub_carry
-        ) && carry;
+        );
+        /* carry = adjust_carry && carry */
+        carry = constant_time_select_int(constant_time_is_zero(adjust_carry),
+                                         0, carry);
     }
     constant_time_cond_swap_bn(
         constant_time_is_zero_8(carry),
@@ -1194,7 +1204,7 @@ int BN_nist_mod_384(BIGNUM *r, const BIGNUM *a, const BIGNUM *field,
 
     {
         BN_ULONG add_res[BN_NIST_384_TOP];
-        int add_carry, sub_carry;
+        int add_carry, sub_carry, adjust_carry;
 
         sub_carry = bn_sub_words(c_d, r_d, _nist_p_384[0], BN_NIST_384_TOP);
         add_carry = bn_add_words(add_res, r_d, _nist_p_384[0], BN_NIST_384_TOP);
@@ -1205,10 +1215,13 @@ int BN_nist_mod_384(BIGNUM *r, const BIGNUM *a, const BIGNUM *field,
             BN_NIST_384_TOP
         );
 
-        carry = constant_time_select_int(
+        adjust_carry = constant_time_select_int(
             constant_time_eq_int(adjust, ADJUST_WITH_ADD),
             add_carry, sub_carry
-        ) && carry;
+        );
+        /* carry = adjust_carry && carry */
+        carry = constant_time_select_int(constant_time_is_zero(adjust_carry),
+                                         0, carry);
     }
     constant_time_cond_swap_bn(
         constant_time_is_zero_8(carry),

--- a/crypto/bn/bn_nist.c
+++ b/crypto/bn/bn_nist.c
@@ -479,9 +479,6 @@ int BN_nist_mod_192(BIGNUM *r, const BIGNUM *a, const BIGNUM *field,
     return 1;
 }
 
-typedef BN_ULONG (*bn_addsub_f) (BN_ULONG *, const BN_ULONG *,
-                                 const BN_ULONG *, int);
-
 #define nist_set_224(to, from, a1, a2, a3, a4, a5, a6, a7) \
         { \
         bn_cp_32(to, 0, from, (a7) - 7) \


### PR DESCRIPTION
Makes the `BN_nist_mod_*` family of functions constant time, assuming that:
  - `r != a` or `r == a` (aka the output BIGNUM is either always separate from the input BIGNUM, or the same as the input BIGNUM)
  - `field < a < (field * field)` (where field is the NIST prime)

Fixes https://github.com/openssl/openssl/issues/20761

### Implementation details

I've tried to split up the changes into separate commits to make things easier to review, but it might be better to squash them before merging:
  - [test/bntest.c: add BN_nist_mod_* regression tests](https://github.com/openssl/openssl/commit/aa31789ddf011e95b0067e0547e026a3bd4b8876)
    - Adds regression tests.
  - [bn_nist: make a conditional constant time](https://github.com/openssl/openssl/commit/277fff9c46bc3da4951c2a79b7c32b51291b4c11)
    - Makes the `res = carry ? r_d : c_d;` ternary operator constant time
  - [bn_nist: make function ptr conditional constant](https://github.com/openssl/openssl/commit/894f88ca9f87d2996c8f933e8e150e8a5175d898)
    - Removes the `function_ptr = a ? function_1 : function_2;` ternary operator.
  - [bn_nist: replace `&&` with constant time code](https://github.com/openssl/openssl/commit/f79c67eadc0783c204e00ae2ef254bf69f347ebd)
  - [bn_nist: make BN_nist_mod_* funcs constant time](https://github.com/openssl/openssl/commit/cf046855af4fd9c4093ed8751bfbc2bf384156b8)
    - Removes the `if (carry < 0) {...} else if (carry > 0) {...} else {}` code block.
    - Replace the array lookups with `constant_time_lookup()`

### Benchmarks

I've done some basic benchmarks and here are the results (tested with the input data having a bit-width that's 1.9x the NIST-prime bit-width). It looks like the slowdown for the `BN_mod_nist_224`/`BN_mod_nist_256`/`BM_BN_mod_nist_384` is pretty heavy (~15-30% slowdown), since the logic for those functions was a bit difficult to make into constant time.

To be honest, **it might even be worth just replacing the `_224`/`_256`/`_384` functions with a call to the generic `BN_nnmod()`, since at least according to my benchmark on a x86_64-bit CPU, the performance impact isn't too much worse**, and the code would be much more maintainable.

<details>
  <summary> Benchmark Code </summary>
  
```c++
/**
 * Compiling instructions.
 * 
 * Install google/benchmark: `sudo apt install libbenchmark-dev`
 *
 * Compile with:
 *
 * g++ ./benchmark_nist_functions.cc -lbenchmark -lpthread -lssl -lcrypto -o benchmark_nist_functions
 * 
 * Test with:
 * ./benchmark_nist_functions (for system OpenSSL libs)
 * LD_LIBRARY_PATH="$(pwd)" ./benchmark_nist_functions (for local OpenSSL libs)
 * 
 */
#include <benchmark/benchmark.h>
#include <stdexcept>
#include <memory>

extern "C" {
    #include <openssl/ssl.h>
}

typedef int (*BN_mod_function) (BIGNUM *r, const BIGNUM *a,
                                const BIGNUM *field, BN_CTX *ctx);

static inline void BM_BN_mod(benchmark::State& state, bool use_nist) {
    BIGNUM *input, *nist_res;
    const BIGNUM * nist_prime;
    int bits = state.range(0);

    switch (bits) {
        case 192:
            nist_prime = BN_get0_nist_prime_192();
            break;
        case 224:
            nist_prime = BN_get0_nist_prime_224();
            break;
        case 256:
            nist_prime = BN_get0_nist_prime_256();
            break;
        case 384:
            nist_prime = BN_get0_nist_prime_384();
            break;
        case 521:
            nist_prime = BN_get0_nist_prime_521();
            break;
        default:
            throw std::invalid_argument("Invalid bit val");
    }

    auto BN_nist_mod_func_val = use_nist ? BN_nist_mod_func(nist_prime) : BN_nnmod;

    input = BN_new();
    nist_res = BN_new();
    BN_CTX * ctx = BN_CTX_new();

    if (input == nullptr || nist_res == nullptr || ctx == nullptr) {
        throw new std::runtime_error("error");
    }
    for (auto _ : state) {
        // setup
        state.PauseTiming();
        if (!BN_rand(input, state.range(1), BN_RAND_TOP_ANY, BN_RAND_BOTTOM_ANY)) {
            throw std::runtime_error("error");
        };
        state.ResumeTiming();

        if (!BN_nist_mod_func_val(nist_res, input, nist_prime, ctx)) {
            throw std::runtime_error("error");
        };
    }
    BN_free(input);
    BN_free(nist_res);

    BN_CTX_free(ctx);
}

static void BM_BN_mod_nist(benchmark::State& state) {
    return BM_BN_mod(state, true);
}

static void BM_BN_nnmod(benchmark::State& state) {
    return BM_BN_mod(state, false);
}

static void TestNistArgs(benchmark::internal::Benchmark* b) {
  for (auto nist_prime_bits: {192, 224, 256, 384, 521}) {
    int input_bits = static_cast<int>(nist_prime_bits * 1.9);
    b->Args({nist_prime_bits, input_bits});
  }
}

BENCHMARK(BM_BN_nnmod)->Apply(TestNistArgs);

BENCHMARK(BM_BN_mod_nist)->Apply(TestNistArgs);

int main(int argc, char** argv) {
    printf("%s", OpenSSL_version(OPENSSL_VERSION));
    benchmark::Initialize(&argc, argv);
    if (benchmark::ReportUnrecognizedArguments(argc, argv)) return 1;
    benchmark::RunSpecifiedBenchmarks();
    benchmark::Shutdown();
    return 0;
}
```
</details>

<details>
  <summary> Before benchmark results </summary>
  
(Run on commit 1adc45b1ded7072d1566addeab227efa81b6c947)

```
Run on (16 X 3600 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x8)
  L1 Instruction 32 KiB (x8)
  L2 Unified 512 KiB (x8)
  L3 Unified 16384 KiB (x2)
***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead.
-----------------------------------------------------------------
Benchmark                       Time             CPU   Iterations
-----------------------------------------------------------------
BM_BN_nnmod/192/364           426 ns          421 ns      1683866
BM_BN_nnmod/224/425           439 ns          435 ns      1602958
BM_BN_nnmod/256/486           444 ns          438 ns      1593315
BM_BN_nnmod/384/729           550 ns          543 ns      1280457
BM_BN_nnmod/521/989           643 ns          637 ns      1116602
BM_BN_mod_nist/192/364        289 ns          282 ns      2467992
BM_BN_mod_nist/224/425        293 ns          286 ns      2399081
BM_BN_mod_nist/256/486        296 ns          288 ns      2481888
BM_BN_mod_nist/384/729        303 ns          293 ns      2375221
BM_BN_mod_nist/521/989        302 ns          292 ns      2393257
```

</details>

<details>
  <summary> After benchmark results </summary>
  
(Run on commit e3277085c4a238e86321a9de87126f2c3b5e5662)

```
***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead.
-----------------------------------------------------------------
Benchmark                       Time             CPU   Iterations
-----------------------------------------------------------------
BM_BN_nnmod/192/364           420 ns          414 ns      1688120
BM_BN_nnmod/224/425           442 ns          435 ns      1622101
BM_BN_nnmod/256/486           447 ns          440 ns      1597521
BM_BN_nnmod/384/729           564 ns          557 ns      1257666
BM_BN_nnmod/521/989           637 ns          631 ns      1110108
BM_BN_mod_nist/192/364        317 ns          308 ns      2233960
BM_BN_mod_nist/224/425        346 ns          338 ns      2065222
BM_BN_mod_nist/256/486        406 ns          398 ns      1774933
BM_BN_mod_nist/384/729        433 ns          424 ns      1636938
BM_BN_mod_nist/521/989        295 ns          288 ns      2433044
```

</details>

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
  - **Is there anywhere I should document the constant time conditions of these functions?**
    As far as I'm aware, there's no man-page for these functions, so I can only think of documenting them as a comment in https://github.com/openssl/openssl/blob/c04e78f0c69201226430fed14c291c281da47f2d/include/openssl/bn.h#L539-L541 or in the `bn_nist.c` source file.
  - Is it worth me making a `CHANGES.md` entry?
- [x] tests are added or updated
