### PR TITLE
Ensure that the SSL_rstate_string*() API works as they used to

### DIFF
--- a/doc/man3/SSL_rstate_string.pod
+++ b/doc/man3/SSL_rstate_string.pod
@@ -42,10 +42,6 @@ The header of the record is being evaluated.
 
 The body of the record is being evaluated.
 
-=item "RD"/"read done"
-
-The record has been completely processed.
-
 =item "unknown"/"unknown"
 
 The read state is unknown. This should never happen.

--- a/ssl/quic/quic_tls.c
+++ b/ssl/quic/quic_tls.c
@@ -451,9 +451,9 @@ static void quic_get_state(OSSL_RECORD_LAYER *rl, const char **shortstr,
 {
     /*
      * According to the docs, valid read state strings are: "RH"/"read header",
-     * "RB"/"read body", "RD"/"read done" and "unknown"/"unknown". We don't
-     * read records in quite that way, so we report every "normal" state as
-     * "read done". In the event of error then we report "unknown".
+     * "RB"/"read body", and "unknown"/"unknown". We don't read records in quite
+     * that way, so we report every "normal" state as "read header". In the
+     * event of error then we report "unknown".
      */
 
     if (rl->qtls->inerror) {
@@ -463,9 +463,9 @@ static void quic_get_state(OSSL_RECORD_LAYER *rl, const char **shortstr,
             *longstr = "unknown";
     } else {
         if (shortstr != NULL)
-            *shortstr = "RD";
+            *shortstr = "RH";
         if (longstr != NULL)
-            *longstr = "read done";
+            *longstr = "read header";
     }
 }
 

--- a/ssl/record/methods/tls_common.c
+++ b/ssl/record/methods/tls_common.c
@@ -1296,6 +1296,7 @@ tls_int_new_record_layer(OSSL_LIB_CTX *libctx, const char *propq, int vers,
     rl->md = md;
 
     rl->alert = SSL_AD_NO_ALERT;
+    rl->rstate = SSL_ST_READ_HEADER;
 
     if (level == OSSL_RECORD_PROTECTION_LEVEL_NONE)
         rl->is_first_record = 1;


### PR DESCRIPTION
We initialise the record layer rstate variable to ensure the
SSL_rstate_string*() APIs return values that are consistent with
previous versions.

Fixes https://github.com/openssl/openssl/issues/20808

While I was at it I realised that the docs mentioned that "RD"/"read done" was a valid response from these functions - but in reality that never happens (and doesn't in 3.1 either). So I updated the docs to match reality, and also tweaked the QUIC implementation to more closely match what the TLS implementation does.
