### PR TITLE
Update min/max proto version APIs

### DIFF
--- a/doc/man3/SSL_CTX_set_min_proto_version.pod
+++ b/doc/man3/SSL_CTX_set_min_proto_version.pod
@@ -42,7 +42,7 @@ Currently supported versions are B<SSL3_VERSION>, B<TLS1_VERSION>,
 B<TLS1_1_VERSION>, B<TLS1_2_VERSION>, B<TLS1_3_VERSION> for TLS and
 B<DTLS1_VERSION>, B<DTLS1_2_VERSION> for DTLS.
 
-In the current version of OpenSSL only QUICv1 is supported in conjuction with
+In the current version of OpenSSL only QUICv1 is supported in conjunction with
 TLSv1.3. Calling these functions on a QUIC object has no effect.
 
 =head1 RETURN VALUES

--- a/doc/man3/SSL_CTX_set_min_proto_version.pod
+++ b/doc/man3/SSL_CTX_set_min_proto_version.pod
@@ -42,6 +42,9 @@ Currently supported versions are B<SSL3_VERSION>, B<TLS1_VERSION>,
 B<TLS1_1_VERSION>, B<TLS1_2_VERSION>, B<TLS1_3_VERSION> for TLS and
 B<DTLS1_VERSION>, B<DTLS1_2_VERSION> for DTLS.
 
+In the current version of OpenSSL only QUICv1 is supported in conjuction with
+TLSv1.3. Calling these functions on a QUIC object has no effect.
+
 =head1 RETURN VALUES
 
 These setter functions return 1 on success and 0 on failure. The getter

--- a/ssl/statem/statem_lib.c
+++ b/ssl/statem/statem_lib.c
@@ -2049,8 +2049,10 @@ int ssl_set_version_bound(int method_version, int version, int *bound)
 
     valid_tls = version >= SSL3_VERSION && version <= TLS_MAX_VERSION_INTERNAL;
     valid_dtls =
-        DTLS_VERSION_LE(version, DTLS_MAX_VERSION_INTERNAL) &&
-        DTLS_VERSION_GE(version, DTLS1_BAD_VER);
+        /* We support client side pre-standardisation version of DTLS */
+        (version == DTLS1_BAD_VER)
+        || (DTLS_VERSION_LE(version, DTLS_MAX_VERSION_INTERNAL)
+            && DTLS_VERSION_GE(version, DTLS1_VERSION));
 
     if (!valid_tls && !valid_dtls)
         return 0;

--- a/test/ssl_ctx_test.c
+++ b/test/ssl_ctx_test.c
@@ -40,14 +40,22 @@ static const version_test version_testdata[] = {
     {PROTO_TLS,  TLS1_2_VERSION,         TLS1_1_VERSION,         1, 1, TLS1_2_VERSION,     TLS1_1_VERSION},
     {PROTO_TLS,  SSL3_VERSION - 1,       TLS1_3_VERSION,         0, 1, 0,                  TLS1_3_VERSION},
     {PROTO_TLS,  SSL3_VERSION,           TLS1_3_VERSION + 1,     1, 0, SSL3_VERSION,       0},
+#ifndef OPENSSL_NO_DTLS
     {PROTO_TLS,  DTLS1_VERSION,          DTLS1_2_VERSION,        1, 1, 0,                  0},
+#endif
     {PROTO_TLS,  OSSL_QUIC1_VERSION,     OSSL_QUIC1_VERSION,     0, 0, 0,                  0},
     {PROTO_TLS,  7,                      42,                     0, 0, 0,                  0},
     {PROTO_DTLS, 0,                      0,                      1, 1, 0,                  0},
     {PROTO_DTLS, DTLS1_VERSION,          DTLS1_2_VERSION,        1, 1, DTLS1_VERSION,      DTLS1_2_VERSION},
+#ifndef OPENSSL_NO_DTLS1_2
     {PROTO_DTLS, DTLS1_2_VERSION,        DTLS1_2_VERSION,        1, 1, DTLS1_2_VERSION,    DTLS1_2_VERSION},
+#endif
+#ifndef OPENSSL_NO_DTLS1
     {PROTO_DTLS, DTLS1_VERSION,          DTLS1_VERSION,          1, 1, DTLS1_VERSION,      DTLS1_VERSION},
+#endif
+#if !defined(OPENSSL_NO_DTLS1) && !defined(OPENSSL_NO_DTLS1_2)
     {PROTO_DTLS, DTLS1_2_VERSION,        DTLS1_VERSION,          1, 1, DTLS1_2_VERSION,    DTLS1_VERSION},
+#endif
     {PROTO_DTLS, DTLS1_VERSION + 1,      DTLS1_2_VERSION,        0, 1, 0,                  DTLS1_2_VERSION},
     {PROTO_DTLS, DTLS1_VERSION,          DTLS1_2_VERSION - 1,    1, 0, DTLS1_VERSION,      0},
     {PROTO_DTLS, TLS1_VERSION,           TLS1_3_VERSION,         1, 1, 0,                  0},
@@ -57,7 +65,9 @@ static const version_test version_testdata[] = {
     {PROTO_QUIC, OSSL_QUIC1_VERSION,     OSSL_QUIC1_VERSION,     0, 0, 0,                  0},
     {PROTO_QUIC, OSSL_QUIC1_VERSION,     OSSL_QUIC1_VERSION + 1, 0, 0, 0,                  0},
     {PROTO_QUIC, TLS1_VERSION,           TLS1_3_VERSION,         1, 1, 0,                  0},
+#ifndef OPENSSL_NO_DTLS
     {PROTO_QUIC, DTLS1_VERSION,          DTLS1_2_VERSION,        1, 1, 0,                  0},
+#endif
 };
 
 static int test_set_min_max_version(int idx_tst)
@@ -73,9 +83,11 @@ static int test_set_min_max_version(int idx_tst)
         meth = TLS_client_method();
         break;
 
+#ifndef OPENSSL_NO_DTLS
     case PROTO_DTLS:
         meth = DTLS_client_method();
         break;
+#endif
 
 #ifndef OPENSSL_NO_QUIC
     case PROTO_QUIC:
@@ -85,7 +97,7 @@ static int test_set_min_max_version(int idx_tst)
     }
 
     if (meth == NULL)
-        return TEST_skip("QUIC not supported");
+        return TEST_skip("Protocol not supported");
 
     ctx = SSL_CTX_new(meth);
     if (ctx == NULL)

--- a/test/ssl_ctx_test.c
+++ b/test/ssl_ctx_test.c
@@ -11,6 +11,7 @@
 #include <openssl/ssl.h>
 
 typedef struct {
+    int proto;
     int min_version;
     int max_version;
     int min_ok;
@@ -19,13 +20,44 @@ typedef struct {
     int expected_max;
 } version_test;
 
+#define PROTO_TLS  0
+#define PROTO_DTLS 1
+#define PROTO_QUIC 2
+
+/*
+ * If a version is valid for *any* protocol then setting the min/max protocol is
+ * expected to return success, even if that version is not valid for *this*
+ * protocol. However it only has an effect if it is valid for *this* protocol -
+ * otherwise it is ignored.
+ */
 static const version_test version_testdata[] = {
-    /* min           max             ok    expected min    expected max */
-    {0,              0,              1, 1, 0,              0},
-    {TLS1_VERSION,   TLS1_2_VERSION, 1, 1, TLS1_VERSION,   TLS1_2_VERSION},
-    {TLS1_2_VERSION, TLS1_2_VERSION, 1, 1, TLS1_2_VERSION, TLS1_2_VERSION},
-    {TLS1_2_VERSION, TLS1_1_VERSION, 1, 1, TLS1_2_VERSION, TLS1_1_VERSION},
-    {7,              42,             0, 0, 0,              0},
+    /* proto     min                     max                     ok    expected min        expected max */
+    {PROTO_TLS,  0,                      0,                      1, 1, 0,                  0},
+    {PROTO_TLS,  SSL3_VERSION,           TLS1_3_VERSION,         1, 1, SSL3_VERSION,       TLS1_3_VERSION},
+    {PROTO_TLS,  TLS1_VERSION,           TLS1_3_VERSION,         1, 1, TLS1_VERSION,       TLS1_3_VERSION},
+    {PROTO_TLS,  TLS1_VERSION,           TLS1_2_VERSION,         1, 1, TLS1_VERSION,       TLS1_2_VERSION},
+    {PROTO_TLS,  TLS1_2_VERSION,         TLS1_2_VERSION,         1, 1, TLS1_2_VERSION,     TLS1_2_VERSION},
+    {PROTO_TLS,  TLS1_2_VERSION,         TLS1_1_VERSION,         1, 1, TLS1_2_VERSION,     TLS1_1_VERSION},
+    {PROTO_TLS,  SSL3_VERSION - 1,       TLS1_3_VERSION,         0, 1, 0,                  TLS1_3_VERSION},
+    {PROTO_TLS,  SSL3_VERSION,           TLS1_3_VERSION + 1,     1, 0, SSL3_VERSION,       0},
+    {PROTO_TLS,  DTLS1_VERSION,          DTLS1_2_VERSION,        1, 1, 0,                  0},
+    {PROTO_TLS,  OSSL_QUIC1_VERSION,     OSSL_QUIC1_VERSION,     0, 0, 0,                  0},
+    {PROTO_TLS,  7,                      42,                     0, 0, 0,                  0},
+    {PROTO_DTLS, 0,                      0,                      1, 1, 0,                  0},
+    {PROTO_DTLS, DTLS1_VERSION,          DTLS1_2_VERSION,        1, 1, DTLS1_VERSION,      DTLS1_2_VERSION},
+    {PROTO_DTLS, DTLS1_2_VERSION,        DTLS1_2_VERSION,        1, 1, DTLS1_2_VERSION,    DTLS1_2_VERSION},
+    {PROTO_DTLS, DTLS1_VERSION,          DTLS1_VERSION,          1, 1, DTLS1_VERSION,      DTLS1_VERSION},
+    {PROTO_DTLS, DTLS1_2_VERSION,        DTLS1_VERSION,          1, 1, DTLS1_2_VERSION,    DTLS1_VERSION},
+    {PROTO_DTLS, DTLS1_VERSION + 1,      DTLS1_2_VERSION,        0, 1, 0,                  DTLS1_2_VERSION},
+    {PROTO_DTLS, DTLS1_VERSION,          DTLS1_2_VERSION - 1,    1, 0, DTLS1_VERSION,      0},
+    {PROTO_DTLS, TLS1_VERSION,           TLS1_3_VERSION,         1, 1, 0,                  0},
+    {PROTO_DTLS, OSSL_QUIC1_VERSION,     OSSL_QUIC1_VERSION,     0, 0, 0,                  0},
+    /* These functions never have an effect when called on a QUIC object */
+    {PROTO_QUIC, 0,                      0,                      1, 1, 0,                  0},
+    {PROTO_QUIC, OSSL_QUIC1_VERSION,     OSSL_QUIC1_VERSION,     0, 0, 0,                  0},
+    {PROTO_QUIC, OSSL_QUIC1_VERSION,     OSSL_QUIC1_VERSION + 1, 0, 0, 0,                  0},
+    {PROTO_QUIC, TLS1_VERSION,           TLS1_3_VERSION,         1, 1, 0,                  0},
+    {PROTO_QUIC, DTLS1_VERSION,          DTLS1_2_VERSION,        1, 1, 0,                  0},
 };
 
 static int test_set_min_max_version(int idx_tst)
@@ -34,8 +66,28 @@ static int test_set_min_max_version(int idx_tst)
     SSL *ssl = NULL;
     int testresult = 0;
     version_test t = version_testdata[idx_tst];
+    const SSL_METHOD *meth = NULL;
 
-    ctx = SSL_CTX_new(TLS_server_method());
+    switch (t.proto) {
+    case PROTO_TLS:
+        meth = TLS_client_method();
+        break;
+
+    case PROTO_DTLS:
+        meth = DTLS_client_method();
+        break;
+
+#ifndef OPENSSL_NO_QUIC
+    case PROTO_QUIC:
+        meth = OSSL_QUIC_client_method();
+        break;
+#endif
+    }
+
+    if (meth == NULL)
+        return TEST_skip("QUIC not supported");
+
+    ctx = SSL_CTX_new(meth);
     if (ctx == NULL)
         goto end;
 


### PR DESCRIPTION
This is a replacement for #20790 and does the following:

- Documents that the min/max proto APIs don't do anything for QUIC objects at the moment
- Fixes an issue also fixed in #20790 where a number of version numbers were incorrectly identified as DTLS version numbers
- Adds the test from #20790 (updated for the newly agreed behaviour)