### PR TITLE
documentation: Options -no_ssl3, -no_tls1, -no_tls1_1, -no_tls1_2, -no_tls1_3, not recognised #19014

### DIFF
--- a/doc/man1/openssl.pod
+++ b/doc/man1/openssl.pod
@@ -584,6 +584,8 @@ When a specific TLS version is required, only that version will be offered or
 accepted.
 Only one specific protocol can be given and it cannot be combined with any of
 the B<no_> options.
+The B<no_*> options do not work with B<s_time>, B<ciphers> commands but work with
+B<s_client> and B<s_server> commands.
 
 =item B<-dtls>, B<-dtls1>, B<-dtls1_2>
 

--- a/doc/man1/openssl.pod
+++ b/doc/man1/openssl.pod
@@ -584,7 +584,7 @@ When a specific TLS version is required, only that version will be offered or
 accepted.
 Only one specific protocol can be given and it cannot be combined with any of
 the B<no_> options.
-The B<no_*> options do not work with B<s_time>, B<ciphers> commands but work with
+The B<no_*> options do not work with B<s_time> and B<ciphers> commands but work with
 B<s_client> and B<s_server> commands.
 
 =item B<-dtls>, B<-dtls1>, B<-dtls1_2>


### PR DESCRIPTION
Fixes: #19014 

Added clarification for `no-*` options for where it can or cannot be used https://github.com/openssl/openssl/issues/19014#issuecomment-1217864612.

CLA: trivial