### PR TITLE
Prevent a fuzzing timeout in the conf fuzzer

### DIFF
--- a/crypto/conf/conf_def.c
+++ b/crypto/conf/conf_def.c
@@ -448,7 +448,7 @@ static int def_load_bio(CONF *conf, BIO *in, long *line)
                  * includes - with a large amount of time spent in
                  * OPENSSL_strlcat/OPENSSL_strcpy. This is not a security
                  * concern because config files should never come from untrusted
-                 * sources. We just set an aribtrary limit on the allowed
+                 * sources. We just set an arbitrary limit on the allowed
                  * number of includes when fuzzing to prevent this timeout.
                  */
                 if (numincludes++ > 10)

--- a/crypto/conf/conf_def.c
+++ b/crypto/conf/conf_def.c
@@ -226,6 +226,9 @@ static int def_load_bio(CONF *conf, BIO *in, long *line)
     char *dirpath = NULL;
     OPENSSL_DIR_CTX *dirctx = NULL;
 #endif
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+    int numincludes = 0;
+#endif
 
     if ((buff = BUF_MEM_new()) == NULL) {
         ERR_raise(ERR_LIB_CONF, ERR_R_BUF_LIB);
@@ -437,6 +440,20 @@ static int def_load_bio(CONF *conf, BIO *in, long *line)
                 BIO *next;
                 const char *include_dir = ossl_safe_getenv("OPENSSL_CONF_INCLUDE");
                 char *include_path = NULL;
+
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+                /*
+                 * The include processing below can cause the "conf" fuzzer to
+                 * timeout due to the fuzzer inserting large and complicated
+                 * includes - with a large amount of time spent in
+                 * OPENSSL_strlcat/OPENSSL_strcpy. This is not a security
+                 * concern because config files should never come from untrusted
+                 * sources. We just set an aribtrary limit on the allowed
+                 * number of includes when fuzzing to prevent this timeout.
+                 */
+                if (numincludes++ > 10)
+                    goto err;
+#endif
 
                 if (include_dir == NULL)
                     include_dir = conf->includedir;


### PR DESCRIPTION
The fuzzer was creating a config file with large numbers of includes which are expensive to process. However this should not cause a security issue, and should never happen in normal operation so we can ignore it.

Fixes ossfuzz issue 57718.

