### PR TITLE
Address session ownership

### DIFF
--- a/doc/man3/SSL_SESSION_free.pod
+++ b/doc/man3/SSL_SESSION_free.pod
@@ -21,8 +21,8 @@ SSL_SESSION_free - create, free and manage SSL_SESSION structures
 SSL_SESSION_new() creates a new SSL_SESSION structure and returns a pointer to
 it.
 
-SSL_SESSION_dup() copies the contents of the SSL_SESSION structure in B<src>
-and returns a pointer to it.
+SSL_SESSION_dup() creates a new SSL_SESSION structure that is a copy of B<src>.
+The copy is not owned by any cache that B<src> may have been in.
 
 SSL_SESSION_up_ref() increments the reference count on the given SSL_SESSION
 structure.
@@ -61,6 +61,8 @@ incorrect reference counts and therefore program failures.
 
 SSL_SESSION_new returns a pointer to the newly allocated SSL_SESSION structure
 or NULL on error.
+
+SSL_SESSION_dup returns a pointer to the new copy or NULL on error.
 
 SSL_SESSION_up_ref returns 1 on success or 0 on error.
 

--- a/ssl/ssl_sess.c
+++ b/ssl/ssl_sess.c
@@ -169,9 +169,10 @@ SSL_SESSION *ssl_session_dup(const SSL_SESSION *src, int ticket)
     dest->ticket_appdata = NULL;
     memset(&dest->ex_data, 0, sizeof(dest->ex_data));
 
-    /* We deliberately don't copy the prev and next pointers */
+    /* As the copy is not in the cache, we remove the associated pointers */
     dest->prev = NULL;
     dest->next = NULL;
+    dest->owner = NULL;
 
     dest->references = 1;
 

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -2285,7 +2285,9 @@ static int execute_test_session(int maxprot, int use_int_cache,
          */
         if (use_int_cache && maxprot != TLS1_3_VERSION) {
             if (!TEST_ptr(tmp = SSL_SESSION_dup(sess2))
-                    || !TEST_true(SSL_CTX_remove_session(sctx, sess2)))
+                || !TEST_true(sess2->owner != NULL)
+                || !TEST_true(tmp->owner == NULL)
+                || !TEST_true(SSL_CTX_remove_session(sctx, sess2)))
                 goto end;
             SSL_SESSION_free(sess2);
         }


### PR DESCRIPTION
This commit resolves an issue with corruption of session cache lists. There is an undocumented invariant maintained by SSL_SESSION_list_add and SSL_SESSION_list_remove that either a session has an owner and is in the linked list of that owning session, or is not. However duplication did not clear the owner.

Timeout management added in https://github.com/openssl/openssl/pull/8687 uses the owner pointer to update the list order, however if the session is a copy of the one in the cache, this logic is incorrect and leads to corruption of the list structures. The solution is to ensure duplicates have owner unset.

I also took the liberty of updating the documentation while I was at it.

##### Checklist

- [x] documentation is added or updated
- [x] tests are added or updated
