### PR TITLE
Introduce [HAVE_/NO_]MADVISE defines

### DIFF
--- a/crypto/mem_sec.c
+++ b/crypto/mem_sec.c
@@ -66,6 +66,18 @@ VirtualLock(
 # include <sys/stat.h>
 # include <fcntl.h>
 #endif
+#ifndef HAVE_MADVISE
+# if defined(MADV_DONTDUMP)
+#  define HAVE_MADVISE 1
+# else
+#  define HAVE_MADVISE 0
+# endif
+#endif
+#if HAVE_MADVISE
+# undef NO_MADVISE
+#else
+# define NO_MADVISE
+#endif
 
 #define CLEAR(p, s) OPENSSL_cleanse(p, s)
 #ifndef PAGE_SIZE
@@ -567,7 +579,7 @@ static int sh_init(size_t size, size_t minsize)
     if (mlock(sh.arena, sh.arena_size) < 0)
         ret = 2;
 #endif
-#ifdef MADV_DONTDUMP
+#ifndef NO_MADVISE
     if (madvise(sh.arena, sh.arena_size, MADV_DONTDUMP) < 0)
         ret = 2;
 #endif


### PR DESCRIPTION
Toolchains that target a non-MMU architecture may not have the `madvise` function available, even if the `sys/mman.h` header provides a define for `MADV_DONTDUMP` (e.g. when targeting ARMv7-M with uClibc). The following tweaks the implementation to use `HAVE_MADVISE`/`NO_MADVISE` defines to help indicate when to attempt to use `madvise`. This change operates in the same manner as the original implementation (i.e. relies on `MADV_DONTDUMP` to indicate if `madvise` can be used); however, this change now allows a builder to override the internal detection by explicitly providing the `HAVE_MADVISE` define at compile time. This should give flexibility for environments which do not have `madvise` when there is no easy logic to set `NO_MADVISE`.

See also: https://github.com/openssl/openssl/pull/8089