### PR TITLE
QUIC Multi-Stream Multi-Thread (MSMT)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,7 +202,7 @@ jobs:
     - name: modprobe tls
       run: sudo modprobe tls
     - name: config
-      run: ./config --banner=Configured --strict-warnings no-ec enable-ssl-trace enable-zlib enable-zlib-dynamic enable-crypto-mdebug enable-crypto-mdebug-backtrace enable-egd enable-ktls enable-fips enable-quic && perl configdata.pm --dump
+      run: ./config --banner=Configured --strict-warnings no-ec enable-ssl-trace enable-zlib enable-zlib-dynamic enable-crypto-mdebug enable-crypto-mdebug-backtrace enable-egd enable-ktls enable-fips enable-quic no-threads && perl configdata.pm --dump
     - name: make
       run: make -s -j4
     - name: make test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,11 +187,11 @@ jobs:
     - name: checkout fuzz/corpora submodule
       run: git submodule update --init --depth 1 fuzz/corpora
     - name: config
-      run: CC=clang ./config --banner=Configured no-fips --strict-warnings -fsanitize=thread && perl configdata.pm --dump
+      run: CC=clang ./config --banner=Configured no-fips --strict-warnings -fsanitize=thread enable-quic && perl configdata.pm --dump
     - name: make
       run: make -s -j4
     - name: make test
-      run: make V=1 TESTS="test_threads test_internal_provider test_provfetch test_provider test_pbe test_evp_kdf test_pkcs12 test_store test_evp" test HARNESS_JOBS=${HARNESS_JOBS:-4}
+      run: make V=1 TESTS="test_threads test_internal_provider test_provfetch test_provider test_pbe test_evp_kdf test_pkcs12 test_store test_evp test_quic*" test HARNESS_JOBS=${HARNESS_JOBS:-4}
 
   enable_non-default_options:
     runs-on: ubuntu-latest

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -101,7 +101,7 @@ jobs:
     - name: config
       working-directory: _build
       run: |
-        perl ..\Configure --banner=Configured no-makedepend no-bulk no-deprecated no-fips no-asm -DOPENSSL_SMALL_FOOTPRINT
+        perl ..\Configure --banner=Configured no-makedepend no-bulk no-deprecated no-fips no-asm no-threads enable-quic -DOPENSSL_SMALL_FOOTPRINT
         perl configdata.pm --dump
     - name: build
       working-directory: _build

--- a/crypto/threads_none.c
+++ b/crypto/threads_none.c
@@ -148,6 +148,13 @@ int CRYPTO_atomic_load(uint64_t *val, uint64_t *ret, CRYPTO_RWLOCK *lock)
     return 1;
 }
 
+int CRYPTO_atomic_load_int(int *val, int *ret, CRYPTO_RWLOCK *lock)
+{
+    *ret = *val;
+
+    return 1;
+}
+
 int openssl_init_fork_handlers(void)
 {
     return 0;

--- a/crypto/threads_pthread.c
+++ b/crypto/threads_pthread.c
@@ -270,6 +270,30 @@ int CRYPTO_atomic_load(uint64_t *val, uint64_t *ret, CRYPTO_RWLOCK *lock)
 
     return 1;
 }
+
+int CRYPTO_atomic_load_int(int *val, int *ret, CRYPTO_RWLOCK *lock)
+{
+# if defined(__GNUC__) && defined(__ATOMIC_ACQUIRE) && !defined(BROKEN_CLANG_ATOMICS)
+    if (__atomic_is_lock_free(sizeof(*val), val)) {
+        __atomic_load(val, ret, __ATOMIC_ACQUIRE);
+        return 1;
+    }
+# elif defined(__sun) && (defined(__SunOS_5_10) || defined(__SunOS_5_11))
+    /* This will work for all future Solaris versions. */
+    if (ret != NULL) {
+        *ret = (int *)atomic_or_uint_nv((unsigned int *)val, 0);
+        return 1;
+    }
+# endif
+    if (lock == NULL || !CRYPTO_THREAD_read_lock(lock))
+        return 0;
+    *ret  = *val;
+    if (!CRYPTO_THREAD_unlock(lock))
+        return 0;
+
+    return 1;
+}
+
 # ifndef FIPS_MODULE
 int openssl_init_fork_handlers(void)
 {

--- a/crypto/threads_win.c
+++ b/crypto/threads_win.c
@@ -251,6 +251,22 @@ int CRYPTO_atomic_load(uint64_t *val, uint64_t *ret, CRYPTO_RWLOCK *lock)
 #endif
 }
 
+int CRYPTO_atomic_load_int(int *val, int *ret, CRYPTO_RWLOCK *lock)
+{
+#if (defined(NO_INTERLOCKEDOR64))
+    if (lock == NULL || !CRYPTO_THREAD_read_lock(lock))
+        return 0;
+    *ret = *val;
+    if (!CRYPTO_THREAD_unlock(lock))
+        return 0;
+
+    return 1;
+#else
+    *ret = (int)InterlockedOr((LONG volatile *)val, 0);
+    return 1;
+#endif
+}
+
 int openssl_init_fork_handlers(void)
 {
     return 0;

--- a/crypto/threads_win.c
+++ b/crypto/threads_win.c
@@ -262,6 +262,7 @@ int CRYPTO_atomic_load_int(int *val, int *ret, CRYPTO_RWLOCK *lock)
 
     return 1;
 #else
+    /* On Windows, LONG is always the same size as int. */
     *ret = (int)InterlockedOr((LONG volatile *)val, 0);
     return 1;
 #endif

--- a/doc/designs/quic-design/glossary.md
+++ b/doc/designs/quic-design/glossary.md
@@ -129,6 +129,10 @@ usage in which API calls must not be made concurrently.
 **QCSO:** QUIC Connection SSL Object. This is an SSL object created using
 `SSL_new` using a QUIC method.
 
+**QCTX**: QUIC Context. This is a utility object defined within the QUIC APL
+which helps to unwrap a SSL object pointer (a QCSO or QSSO) into the relevant
+structure pointers such as `QUIC_CONNECTION` or `QUIC_XSO`.
+
 **QRL:** QUIC record layer. Refers collectively to the QRX and QTX.
 
 **QRX:** QUIC Record Layer RX. Receives incoming datagrams and decrypts the

--- a/doc/man3/CRYPTO_THREAD_run_once.pod
+++ b/doc/man3/CRYPTO_THREAD_run_once.pod
@@ -6,6 +6,7 @@ CRYPTO_THREAD_run_once,
 CRYPTO_THREAD_lock_new, CRYPTO_THREAD_read_lock, CRYPTO_THREAD_write_lock,
 CRYPTO_THREAD_unlock, CRYPTO_THREAD_lock_free,
 CRYPTO_atomic_add, CRYPTO_atomic_or, CRYPTO_atomic_load,
+CRYPTO_atomic_load_int,
 OSSL_set_max_threads, OSSL_get_max_threads,
 OSSL_get_thread_support_flags - OpenSSL thread support
 
@@ -26,6 +27,7 @@ OSSL_get_thread_support_flags - OpenSSL thread support
  int CRYPTO_atomic_or(uint64_t *val, uint64_t op, uint64_t *ret,
                       CRYPTO_RWLOCK *lock);
  int CRYPTO_atomic_load(uint64_t *val, uint64_t *ret, CRYPTO_RWLOCK *lock);
+ int CRYPTO_atomic_load_int(int *val, int *ret, CRYPTO_RWLOCK *lock);
 
  int OSSL_set_max_threads(OSSL_LIB_CTX *ctx, uint64_t max_threads);
  uint64_t OSSL_get_max_threads(OSSL_LIB_CTX *ctx);
@@ -103,6 +105,11 @@ platform. Because of this, if a variable is modified by CRYPTO_atomic_or() or
 read by CRYPTO_atomic_load() then CRYPTO_atomic_load() must be the only way that
 the variable is read. If atomic operations are not supported and I<lock> is
 NULL, then the function will fail.
+
+=item *
+
+CRYPTO_atomic_load_int() works identically to CRYPTO_atomic_load() but operates
+on an I<int> value instead of a I<uint64_t> value.
 
 =item *
 

--- a/include/internal/cryptlib.h
+++ b/include/internal/cryptlib.h
@@ -159,4 +159,5 @@ char *ossl_ipaddr_to_asc(unsigned char *p, int len);
 char *ossl_buf2hexstr_sep(const unsigned char *buf, long buflen, char sep);
 unsigned char *ossl_hexstr2buf_sep(const char *str, long *buflen,
                                    const char sep);
+
 #endif

--- a/include/internal/quic_stream_map.h
+++ b/include/internal/quic_stream_map.h
@@ -255,6 +255,7 @@ typedef struct quic_stream_map_st {
     void                    *get_stream_limit_cb_arg;
     QUIC_RXFC               *max_streams_bidi_rxfc;
     QUIC_RXFC               *max_streams_uni_rxfc;
+    int                     is_server;
 } QUIC_STREAM_MAP;
 
 /*
@@ -274,7 +275,8 @@ int ossl_quic_stream_map_init(QUIC_STREAM_MAP *qsm,
                               uint64_t (*get_stream_limit_cb)(int uni, void *arg),
                               void *get_stream_limit_cb_arg,
                               QUIC_RXFC *max_streams_bidi_rxfc,
-                              QUIC_RXFC *max_streams_uni_rxfc);
+                              QUIC_RXFC *max_streams_uni_rxfc,
+                              int is_server);
 
 /*
  * Any streams still in the map will be released as though

--- a/include/internal/quic_tserver.h
+++ b/include/internal/quic_tserver.h
@@ -150,6 +150,13 @@ int ossl_quic_tserver_stream_has_peer_reset_stream(QUIC_TSERVER *srv,
  */
 int ossl_quic_tserver_set_new_local_cid(QUIC_TSERVER *srv,
                                         const QUIC_CONN_ID *conn_id);
+
+/*
+ * Returns the stream ID of the next incoming stream, or UINT64_MAX if there
+ * currently is none.
+ */
+uint64_t ossl_quic_tserver_pop_incoming_stream(QUIC_TSERVER *srv);
+
 # endif
 
 #endif

--- a/include/internal/refcount.h
+++ b/include/internal/refcount.h
@@ -197,7 +197,7 @@ typedef int CRYPTO_REF_COUNT;
 
 # define CRYPTO_UP_REF(val, ret, lock) CRYPTO_atomic_add(val, 1, ret, lock)
 # define CRYPTO_DOWN_REF(val, ret, lock) CRYPTO_atomic_add(val, -1, ret, lock)
-# define CRYPTO_GET_REF(val, ret, lock) CRYPTO_atomic_load(val, ret, lock)
+# define CRYPTO_GET_REF(val, ret, lock) CRYPTO_atomic_load_int(val, ret, lock)
 
 # endif
 

--- a/include/internal/ring_buf.h
+++ b/include/internal/ring_buf.h
@@ -102,18 +102,16 @@ static ossl_inline size_t ring_buf_push(struct ring_buf *r,
                                         const unsigned char *buf,
                                         size_t buf_len)
 {
-    size_t pushed = 0, avail, idx, l, i;
+    size_t pushed = 0, avail, idx, l;
     unsigned char *start = r->start;
 
-    for (i = 0;; ++i) {
+    for (;;) {
         avail = ring_buf_avail(r);
         if (buf_len > avail)
             buf_len = avail;
 
         if (buf_len == 0)
             break;
-
-        assert(i < 2);
 
         idx = r->head_offset % r->alloc;
         l = r->alloc - idx;

--- a/include/openssl/crypto.h.in
+++ b/include/openssl/crypto.h.in
@@ -89,6 +89,7 @@ int CRYPTO_atomic_add(int *val, int amount, int *ret, CRYPTO_RWLOCK *lock);
 int CRYPTO_atomic_or(uint64_t *val, uint64_t op, uint64_t *ret,
                      CRYPTO_RWLOCK *lock);
 int CRYPTO_atomic_load(uint64_t *val, uint64_t *ret, CRYPTO_RWLOCK *lock);
+int CRYPTO_atomic_load_int(int *val, int *ret, CRYPTO_RWLOCK *lock);
 
 /* No longer needed, so this is a no-op */
 #define OPENSSL_malloc_init() while(0) continue

--- a/ssl/quic/quic_channel.c
+++ b/ssl/quic/quic_channel.c
@@ -186,7 +186,8 @@ static int ch_init(QUIC_CHANNEL *ch)
 
     if (!ossl_quic_stream_map_init(&ch->qsm, get_stream_limit, ch,
                                    &ch->max_streams_bidi_rxfc,
-                                   &ch->max_streams_uni_rxfc))
+                                   &ch->max_streams_uni_rxfc,
+                                   ch->is_server))
         goto err;
 
     ch->have_qsm = 1;
@@ -2425,7 +2426,6 @@ QUIC_STREAM *ossl_quic_channel_new_stream_local(QUIC_CHANNEL *ch, int is_uni)
     /* Locally-initiated stream, so we always want a send buffer. */
     if (!ch_init_new_stream(ch, qs, /*can_send=*/1, /*can_recv=*/!is_uni))
         goto err;
-
 
     ++*p_next_ordinal;
     return qs;

--- a/ssl/quic/quic_fc.c
+++ b/ssl/quic/quic_fc.c
@@ -341,7 +341,7 @@ int ossl_quic_rxfc_on_retire(QUIC_RXFC *rxfc,
                              uint64_t num_bytes,
                              OSSL_TIME rtt)
 {
-    if (rxfc->parent == NULL)
+    if (rxfc->parent == NULL && !rxfc->stream_count_mode)
         return 0;
 
     if (num_bytes == 0)
@@ -352,7 +352,10 @@ int ossl_quic_rxfc_on_retire(QUIC_RXFC *rxfc,
         return 0;
 
     rxfc_on_retire(rxfc, num_bytes, 0, rtt);
-    rxfc_on_retire(rxfc->parent, num_bytes, rxfc->cur_window_size, rtt);
+
+    if (!rxfc->stream_count_mode)
+        rxfc_on_retire(rxfc->parent, num_bytes, rxfc->cur_window_size, rtt);
+
     return 1;
 }
 

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -444,8 +444,9 @@ void ossl_quic_free(SSL *s)
     /* Note: SSL_free calls OPENSSL_free(qc) for us */
 
     SSL_free(ctx.qc->tls);
+    quic_unlock(ctx.qc); /* tsan doesn't like freeing locked mutexes */
 #if defined(OPENSSL_THREADS)
-    ossl_crypto_mutex_free(&ctx.qc->mutex); /* freed while still locked */
+    ossl_crypto_mutex_free(&ctx.qc->mutex);
 #endif
 }
 

--- a/ssl/quic/quic_local.h
+++ b/ssl/quic/quic_local.h
@@ -84,6 +84,13 @@ struct quic_xso_st {
 
     /* SSL_set_mode */
     uint32_t                        ssl_mode;
+
+    /*
+     * Last 'normal' error during an app-level I/O operation, used by
+     * SSL_get_error(); used to track data-path errors like SSL_ERROR_WANT_READ
+     * and SSL_ERROR_WANT_WRITE.
+     */
+    int                             last_error;
 };
 
 struct quic_conn_st {

--- a/ssl/quic/quic_reactor.c
+++ b/ssl/quic/quic_reactor.c
@@ -175,7 +175,7 @@ static int poll_two_fds(int rfd, int rfd_want_read,
         /* Do not block forever; should not happen. */
         return 0;
 
-# if !defined(OPENSSL_THREADS)
+# if defined(OPENSSL_THREADS)
     if (mutex != NULL)
         ossl_crypto_mutex_unlock(mutex);
 # endif

--- a/ssl/quic/quic_reactor.c
+++ b/ssl/quic/quic_reactor.c
@@ -175,8 +175,10 @@ static int poll_two_fds(int rfd, int rfd_want_read,
         /* Do not block forever; should not happen. */
         return 0;
 
+# if !defined(OPENSSL_THREADS)
     if (mutex != NULL)
         ossl_crypto_mutex_unlock(mutex);
+# endif
 
     do {
         /*
@@ -200,8 +202,10 @@ static int poll_two_fds(int rfd, int rfd_want_read,
         pres = select(maxfd + 1, &rfd_set, &wfd_set, &efd_set, ptv);
     } while (pres == -1 && get_last_socket_error_is_eintr());
 
+# if defined(OPENSSL_THREADS)
     if (mutex != NULL)
         ossl_crypto_mutex_lock(mutex);
+# endif
 
     return pres < 0 ? 0 : 1;
 #else
@@ -232,8 +236,10 @@ static int poll_two_fds(int rfd, int rfd_want_read,
         /* Do not block forever; should not happen. */
         return 0;
 
+# if defined(OPENSSL_THREADS)
     if (mutex != NULL)
         ossl_crypto_mutex_unlock(mutex);
+# endif
 
     do {
         if (ossl_time_is_infinite(deadline)) {
@@ -247,8 +253,10 @@ static int poll_two_fds(int rfd, int rfd_want_read,
         pres = poll(pfds, npfd, timeout_ms);
     } while (pres == -1 && get_last_socket_error_is_eintr());
 
+# if defined(OPENSSL_THREADS)
     if (mutex != NULL)
         ossl_crypto_mutex_lock(mutex);
+# endif
 
     return pres < 0 ? 0 : 1;
 #endif

--- a/ssl/quic/quic_stream_map.c
+++ b/ssl/quic/quic_stream_map.c
@@ -280,8 +280,8 @@ void ossl_quic_stream_map_update_state(QUIC_STREAM_MAP *qsm, QUIC_STREAM *s)
     int should_be_active, allowed_by_stream_limit = 1;
 
     if (qsm->get_stream_limit_cb != NULL
-        && (s->type & QUIC_STREAM_INITIATOR_CLIENT) != 0) {
-        int uni = ((s->type & QUIC_STREAM_DIR_UNI) != 0);
+        && ossl_quic_stream_is_server_init(s) == qsm->is_server) {
+        int uni = !ossl_quic_stream_is_bidi(s);
         uint64_t stream_limit, stream_ordinal = s->id >> 2;
 
         stream_limit

--- a/ssl/quic/quic_stream_map.c
+++ b/ssl/quic/quic_stream_map.c
@@ -89,7 +89,8 @@ int ossl_quic_stream_map_init(QUIC_STREAM_MAP *qsm,
                               uint64_t (*get_stream_limit_cb)(int uni, void *arg),
                               void *get_stream_limit_cb_arg,
                               QUIC_RXFC *max_streams_bidi_rxfc,
-                              QUIC_RXFC *max_streams_uni_rxfc)
+                              QUIC_RXFC *max_streams_uni_rxfc,
+                              int is_server)
 {
     qsm->map = lh_QUIC_STREAM_new(hash_stream, cmp_stream);
     qsm->active_list.prev = qsm->active_list.next = &qsm->active_list;
@@ -105,6 +106,7 @@ int ossl_quic_stream_map_init(QUIC_STREAM_MAP *qsm,
     qsm->get_stream_limit_cb_arg    = get_stream_limit_cb_arg;
     qsm->max_streams_bidi_rxfc      = max_streams_bidi_rxfc;
     qsm->max_streams_uni_rxfc       = max_streams_uni_rxfc;
+    qsm->is_server                  = is_server;
     return 1;
 }
 

--- a/ssl/quic/quic_tserver.c
+++ b/ssl/quic/quic_tserver.c
@@ -67,8 +67,10 @@ QUIC_TSERVER *ossl_quic_tserver_new(const QUIC_TSERVER_ARGS *args,
 
     srv->args = *args;
 
+#if defined(OPENSSL_THREADS)
     if ((srv->mutex = ossl_crypto_mutex_new()) == NULL)
         goto err;
+#endif
 
     srv->ctx = SSL_CTX_new_ex(srv->args.libctx, srv->args.propq, TLS_method());
     if (srv->ctx == NULL)
@@ -106,7 +108,9 @@ QUIC_TSERVER *ossl_quic_tserver_new(const QUIC_TSERVER_ARGS *args,
 err:
     if (srv != NULL) {
         ossl_quic_channel_free(srv->ch);
+#if defined(OPENSSL_THREADS)
         ossl_crypto_mutex_free(&srv->mutex);
+#endif
     }
 
     OPENSSL_free(srv);
@@ -123,7 +127,9 @@ void ossl_quic_tserver_free(QUIC_TSERVER *srv)
     BIO_free(srv->args.net_wbio);
     SSL_free(srv->tls);
     SSL_CTX_free(srv->ctx);
+#if defined(OPENSSL_THREADS)
     ossl_crypto_mutex_free(&srv->mutex);
+#endif
     OPENSSL_free(srv);
 }
 

--- a/ssl/quic/quic_tserver.c
+++ b/ssl/quic/quic_tserver.c
@@ -404,3 +404,16 @@ int ossl_quic_tserver_set_new_local_cid(QUIC_TSERVER *srv,
     /* Replace existing local connection ID in the QUIC_CHANNEL */
     return ossl_quic_channel_replace_local_cid(srv->ch, conn_id);
 }
+
+uint64_t ossl_quic_tserver_pop_incoming_stream(QUIC_TSERVER *srv)
+{
+    QUIC_STREAM_MAP *qsm = ossl_quic_channel_get_qsm(srv->ch);
+    QUIC_STREAM *qs = ossl_quic_stream_map_peek_accept_queue(qsm);
+
+    if (qs == NULL)
+        return UINT64_MAX;
+
+    ossl_quic_stream_map_remove_from_accept_queue(qsm, qs, ossl_time_zero());
+
+    return qs->id;
+}

--- a/test/quic_multistream_test.c
+++ b/test/quic_multistream_test.c
@@ -625,11 +625,11 @@ static int run_script_worker(struct helper *h, const struct script_op *script,
                 s_stream_id = UINT64_MAX;
         }
 
-        if (thread_idx < 0) {
+        if (thread_idx < 0)
             ossl_quic_tserver_tick(h->s);
-            if (connect_started)
-                SSL_tick(h->c_conn);
-        }
+
+        if (thread_idx >= 0 || connect_started)
+            SSL_tick(h->c_conn);
 
         if (thread_idx >= 0) {
             /* Only allow certain opcodes on child threads. */

--- a/test/quic_multistream_test.c
+++ b/test/quic_multistream_test.c
@@ -1473,6 +1473,81 @@ static const struct script_op script_10[] = {
     OP_END
 };
 
+/* 11. Many threads accepting on the same client connection */
+static const struct script_op script_11_child[] = {
+    OP_C_ACCEPT_STREAM_WAIT (a)
+    OP_C_READ_EXPECT        (a, "foo", 3)
+    OP_C_EXPECT_FIN         (a)
+
+    OP_END
+};
+
+static const struct script_op script_11[] = {
+    OP_C_SET_ALPN           ("ossltest")
+    OP_C_CONNECT_WAIT       ()
+    OP_C_SET_DEFAULT_STREAM_MODE(SSL_DEFAULT_STREAM_MODE_NONE)
+
+    OP_S_NEW_STREAM_BIDI    (a, S_BIDI_ID(0))
+    OP_S_WRITE              (a, "foo", 3)
+    OP_S_CONCLUDE           (a)
+
+    OP_S_NEW_STREAM_BIDI    (b, S_BIDI_ID(1))
+    OP_S_WRITE              (b, "foo", 3)
+    OP_S_CONCLUDE           (b)
+
+    OP_S_NEW_STREAM_BIDI    (c, S_BIDI_ID(2))
+    OP_S_WRITE              (c, "foo", 3)
+    OP_S_CONCLUDE           (c)
+
+    OP_S_NEW_STREAM_BIDI    (d, S_BIDI_ID(3))
+    OP_S_WRITE              (d, "foo", 3)
+    OP_S_CONCLUDE           (d)
+
+    OP_S_NEW_STREAM_BIDI    (e, S_BIDI_ID(4))
+    OP_S_WRITE              (e, "foo", 3)
+    OP_S_CONCLUDE           (e)
+
+    OP_NEW_THREAD           (5, script_11_child)
+
+    OP_END
+};
+
+/* 12. Many threads initiating on the same client connection */
+static const struct script_op script_12_child[] = {
+    OP_C_NEW_STREAM_BIDI    (a, ANY_ID)
+    OP_C_WRITE              (a, "foo", 3)
+    OP_C_CONCLUDE           (a)
+    OP_C_FREE_STREAM        (a)
+
+    OP_END
+};
+
+static const struct script_op script_12[] = {
+    OP_C_SET_ALPN           ("ossltest")
+    OP_C_CONNECT_WAIT       ()
+    OP_C_SET_DEFAULT_STREAM_MODE(SSL_DEFAULT_STREAM_MODE_NONE)
+
+    OP_NEW_THREAD           (5, script_12_child)
+
+    OP_S_BIND_STREAM_ID     (a, C_BIDI_ID(0))
+    OP_S_READ_EXPECT        (a, "foo", 3)
+    OP_S_EXPECT_FIN         (a)
+    OP_S_BIND_STREAM_ID     (b, C_BIDI_ID(1))
+    OP_S_READ_EXPECT        (b, "foo", 3)
+    OP_S_EXPECT_FIN         (b)
+    OP_S_BIND_STREAM_ID     (c, C_BIDI_ID(2))
+    OP_S_READ_EXPECT        (c, "foo", 3)
+    OP_S_EXPECT_FIN         (c)
+    OP_S_BIND_STREAM_ID     (d, C_BIDI_ID(3))
+    OP_S_READ_EXPECT        (d, "foo", 3)
+    OP_S_EXPECT_FIN         (d)
+    OP_S_BIND_STREAM_ID     (e, C_BIDI_ID(4))
+    OP_S_READ_EXPECT        (e, "foo", 3)
+    OP_S_EXPECT_FIN         (e)
+
+    OP_END
+};
+
 static const struct script_op *const scripts[] = {
     script_1,
     script_2,
@@ -1484,6 +1559,8 @@ static const struct script_op *const scripts[] = {
     script_8,
     script_9,
     script_10,
+    script_11,
+    script_12,
 };
 
 static int test_script(int idx)

--- a/test/quic_tserver_test.c
+++ b/test/quic_tserver_test.c
@@ -64,7 +64,6 @@ static int do_test(int use_thread_assist, int use_fake_time, int use_inject)
     union BIO_sock_info_u s_info = {0};
     SSL_CTX *c_ctx = NULL;
     SSL *c_ssl = NULL;
-    short port = 8186;
     int c_connected = 0, c_write_done = 0, c_begin_read = 0, s_read_done = 0;
     int c_wait_eos = 0, c_done_eos = 0;
     int c_start_idle_test = 0, c_done_idle_test = 0;
@@ -89,8 +88,7 @@ static int do_test(int use_thread_assist, int use_fake_time, int use_inject)
     if (!TEST_ptr(s_addr_ = BIO_ADDR_new()))
         goto err;
 
-    if (!TEST_true(BIO_ADDR_rawmake(s_addr_, AF_INET, &ina, sizeof(ina),
-                                    htons(port))))
+    if (!TEST_true(BIO_ADDR_rawmake(s_addr_, AF_INET, &ina, sizeof(ina), 0)))
         goto err;
 
     if (!TEST_true(BIO_bind(s_fd, s_addr_, 0)))

--- a/test/quic_tserver_test.c
+++ b/test/quic_tserver_test.c
@@ -12,6 +12,7 @@
 #include "internal/common.h"
 #include "internal/sockets.h"
 #include "internal/quic_tserver.h"
+#include "internal/quic_thread_assist.h"
 #include "internal/quic_ssl.h"
 #include "internal/time.h"
 #include "testutil.h"
@@ -74,6 +75,13 @@ static int do_test(int use_thread_assist, int use_fake_time, int use_inject)
     unsigned char alpn[] = { 8, 'o', 's', 's', 'l', 't', 'e', 's', 't' };
     OSSL_TIME (*now_cb)(void *arg) = use_fake_time ? fake_now : real_now;
     size_t limit_ms = 1000;
+
+#if defined(OPENSSL_NO_QUIC_THREAD_ASSIST)
+    if (use_thread_assist) {
+        TEST_skip("thread assisted mode not enabled");
+        return 1;
+    }
+#endif
 
     ina.s_addr = htonl(0x7f000001UL);
 

--- a/test/quic_txp_test.c
+++ b/test/quic_txp_test.c
@@ -176,7 +176,8 @@ static int helper_init(struct helper *h)
 
     if (!TEST_true(ossl_quic_stream_map_init(&h->qsm, NULL, NULL,
                                              &h->max_streams_bidi_rxfc,
-                                             &h->max_streams_uni_rxfc)))
+                                             &h->max_streams_uni_rxfc,
+                                             /*is_server=*/0)))
         goto err;
 
     h->have_qsm = 1;

--- a/test/testutil/basic_output.c
+++ b/test/testutil/basic_output.c
@@ -76,14 +76,14 @@ void test_close_streams(void)
 #endif
 }
 
-static ossl_inline void lock(void)
+static ossl_inline void test_io_lock(void)
 {
 #if defined(OPENSSL_THREADS)
     OPENSSL_assert(CRYPTO_THREAD_write_lock(io_lock) > 0);
 #endif
 }
 
-static ossl_inline void unlock(void)
+static ossl_inline void test_io_unlock(void)
 {
 #if defined(OPENSSL_THREADS)
     CRYPTO_THREAD_unlock(io_lock);
@@ -94,9 +94,9 @@ int test_vprintf_stdout(const char *fmt, va_list ap)
 {
     int r;
 
-    lock();
+    test_io_lock();
     r = BIO_vprintf(bio_out, fmt, ap);
-    unlock();
+    test_io_unlock();
 
     return r;
 }
@@ -105,9 +105,9 @@ int test_vprintf_stderr(const char *fmt, va_list ap)
 {
     int r;
 
-    lock();
+    test_io_lock();
     r = BIO_vprintf(bio_err, fmt, ap);
-    unlock();
+    test_io_unlock();
 
     return r;
 }
@@ -116,9 +116,9 @@ int test_flush_stdout(void)
 {
     int r;
 
-    lock();
+    test_io_lock();
     r = BIO_flush(bio_out);
-    unlock();
+    test_io_unlock();
 
     return r;
 }
@@ -127,9 +127,9 @@ int test_flush_stderr(void)
 {
     int r;
 
-    lock();
+    test_io_lock();
     r = BIO_flush(bio_err);
-    unlock();
+    test_io_unlock();
 
     return r;
 }
@@ -138,9 +138,9 @@ int test_vprintf_tapout(const char *fmt, va_list ap)
 {
     int r;
 
-    lock();
+    test_io_lock();
     r = BIO_vprintf(tap_out, fmt, ap);
-    unlock();
+    test_io_unlock();
 
     return r;
 }
@@ -149,9 +149,9 @@ int test_vprintf_taperr(const char *fmt, va_list ap)
 {
     int r;
 
-    lock();
+    test_io_lock();
     r = BIO_vprintf(tap_err, fmt, ap);
-    unlock();
+    test_io_unlock();
 
     return r;
 }
@@ -160,9 +160,9 @@ int test_flush_tapout(void)
 {
     int r;
 
-    lock();
+    test_io_lock();
     r = BIO_flush(tap_out);
-    unlock();
+    test_io_unlock();
 
     return r;
 }
@@ -171,9 +171,9 @@ int test_flush_taperr(void)
 {
     int r;
 
-    lock();
+    test_io_lock();
     r = BIO_flush(tap_err);
-    unlock();
+    test_io_unlock();
 
     return r;
 }

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5517,3 +5517,4 @@ EC_GROUP_to_params                      ?	3_2_0	EXIST::FUNCTION:EC
 X509_STORE_CTX_init_rpk                 ?	3_2_0	EXIST::FUNCTION:
 X509_STORE_CTX_get0_rpk                 ?	3_2_0	EXIST::FUNCTION:
 X509_STORE_CTX_set0_rpk                 ?	3_2_0	EXIST::FUNCTION:
+CRYPTO_atomic_load_int                  ?	3_2_0	EXIST::FUNCTION:


### PR DESCRIPTION
New commits on top of MSST:

```
5014f02b9a QUIC APL: Make SSL_get_error per-stream, error raising refactor
b1f760f05c QUIC MSMT TESTS: Add tests to exercise MAX_STREAMS
5dceb7c5c4 QUIC RXDP: Ensure all stream-related frames autocreate a stream
d00bd10318 QUIC FC: Correct operation of stream count mode
ea38c5fcd5 QUIC QSM: Correct the logic for determining stream count limits
9f0f6e2f30 QUIC QSM: Allow QSM to know if we are in the server role
51fddf2e2b QUIC MSMT: Stress tests, support for repeating test opoerations
0c2e71375e QUIC MSMT: Add a basic multithreading test
35410e9cd7 QUIC MSMT: Revise tests to support multithreading
df54063991 QUIC TSERVER: Allow detection of new incoming streams
```

Since the thread-assisted PR already resulted in adding locking everywhere, surprisingly little was needed to get MT working. This is mostly tests, though we do have to be careful with how we handle `SSL_get_error`.