### PR TITLE
openssl req -verify output to stderr instead of stdout

### DIFF
--- a/apps/req.c
+++ b/apps/req.c
@@ -937,7 +937,7 @@ int req_main(int argc, char **argv)
         if (i == 0)
             BIO_printf(bio_err, "Certificate request self-signature verify failure\n");
         else /* i > 0 */
-            BIO_printf(out, "Certificate request self-signature verify OK\n");
+            BIO_printf(bio_out, "Certificate request self-signature verify OK\n");
     }
 
     if (noout && !text && !modulus && !subject && !pubkey) {

--- a/apps/req.c
+++ b/apps/req.c
@@ -937,7 +937,7 @@ int req_main(int argc, char **argv)
         if (i == 0)
             BIO_printf(bio_err, "Certificate request self-signature verify failure\n");
         else /* i > 0 */
-            BIO_printf(bio_err, "Certificate request self-signature verify OK\n");
+            BIO_printf(out, "Certificate request self-signature verify OK\n");
     }
 
     if (noout && !text && !modulus && !subject && !pubkey) {


### PR DESCRIPTION
Fixes: #20728 

Changed the uniformization of output to stdout in case of success instead of stderr as mentioned in https://github.com/openssl/openssl/issues/20728#issue-1666338260