### PR TITLE
Wrong output of public key for fips module

### DIFF
--- a/crypto/ec/curve25519.c
+++ b/crypto/ec/curve25519.c
@@ -5646,6 +5646,7 @@ err:
     return res;
 }
 
+#if !defined(FIPS_MODULE)
 int
 ossl_ed25519_public_from_private(OSSL_LIB_CTX *ctx, uint8_t out_public_key[32],
                                  const uint8_t private_key[32],
@@ -5676,6 +5677,7 @@ ossl_ed25519_public_from_private(OSSL_LIB_CTX *ctx, uint8_t out_public_key[32],
     OPENSSL_cleanse(az, sizeof(az));
     return 1;
 }
+#endif
 
 int
 ossl_x25519(uint8_t out_shared_key[32], const uint8_t private_key[32],
@@ -5687,6 +5689,7 @@ ossl_x25519(uint8_t out_shared_key[32], const uint8_t private_key[32],
     return CRYPTO_memcmp(kZeros, out_shared_key, 32) != 0;
 }
 
+#if !defined(FIPS_MODULE)
 void
 ossl_x25519_public_from_private(uint8_t out_public_value[32],
                                 const uint8_t private_key[32])
@@ -5715,3 +5718,4 @@ ossl_x25519_public_from_private(uint8_t out_public_value[32],
 
     OPENSSL_cleanse(e, sizeof(e));
 }
+#endif

--- a/crypto/ec/ecx_backend.c
+++ b/crypto/ec/ecx_backend.c
@@ -28,6 +28,7 @@
 int ossl_ecx_public_from_private(ECX_KEY *key)
 {
     switch (key->type) {
+#ifndef FIPS_MODULE
     case ECX_KEY_TYPE_X25519:
         ossl_x25519_public_from_private(key->pubkey, key->privkey);
         break;
@@ -38,6 +39,7 @@ int ossl_ecx_public_from_private(ECX_KEY *key)
             return 0;
         }
         break;
+#endif
     case ECX_KEY_TYPE_X448:
         ossl_x448_public_from_private(key->pubkey, key->privkey);
         break;


### PR DESCRIPTION
Fixes: #20758 

Public key happens only for Fips provider in ed25519 and x25519