### PR TITLE
Enable access to group name

### DIFF
--- a/doc/build.info
+++ b/doc/build.info
@@ -2491,6 +2491,10 @@ DEPEND[html/man3/SSL_get0_connection.html]=man3/SSL_get0_connection.pod
 GENERATE[html/man3/SSL_get0_connection.html]=man3/SSL_get0_connection.pod
 DEPEND[man/man3/SSL_get0_connection.3]=man3/SSL_get0_connection.pod
 GENERATE[man/man3/SSL_get0_connection.3]=man3/SSL_get0_connection.pod
+DEPEND[html/man3/SSL_get0_group_name.html]=man3/SSL_get0_group_name.pod
+GENERATE[html/man3/SSL_get0_group_name.html]=man3/SSL_get0_group_name.pod
+DEPEND[man/man3/SSL_get0_group_name.3]=man3/SSL_get0_group_name.pod
+GENERATE[man/man3/SSL_get0_group_name.3]=man3/SSL_get0_group_name.pod
 DEPEND[html/man3/SSL_get0_peer_rpk.html]=man3/SSL_get0_peer_rpk.pod
 GENERATE[html/man3/SSL_get0_peer_rpk.html]=man3/SSL_get0_peer_rpk.pod
 DEPEND[man/man3/SSL_get0_peer_rpk.3]=man3/SSL_get0_peer_rpk.pod
@@ -2527,10 +2531,6 @@ DEPEND[html/man3/SSL_get_current_cipher.html]=man3/SSL_get_current_cipher.pod
 GENERATE[html/man3/SSL_get_current_cipher.html]=man3/SSL_get_current_cipher.pod
 DEPEND[man/man3/SSL_get_current_cipher.3]=man3/SSL_get_current_cipher.pod
 GENERATE[man/man3/SSL_get_current_cipher.3]=man3/SSL_get_current_cipher.pod
-DEPEND[html/man3/SSL_get_curve_name.html]=man3/SSL_get_curve_name.pod
-GENERATE[html/man3/SSL_get_curve_name.html]=man3/SSL_get_curve_name.pod
-DEPEND[man/man3/SSL_get_curve_name.3]=man3/SSL_get_curve_name.pod
-GENERATE[man/man3/SSL_get_curve_name.3]=man3/SSL_get_curve_name.pod
 DEPEND[html/man3/SSL_get_default_timeout.html]=man3/SSL_get_default_timeout.pod
 GENERATE[html/man3/SSL_get_default_timeout.html]=man3/SSL_get_default_timeout.pod
 DEPEND[man/man3/SSL_get_default_timeout.3]=man3/SSL_get_default_timeout.pod
@@ -3518,6 +3518,7 @@ html/man3/SSL_export_keying_material.html \
 html/man3/SSL_extension_supported.html \
 html/man3/SSL_free.html \
 html/man3/SSL_get0_connection.html \
+html/man3/SSL_get0_group_name.html \
 html/man3/SSL_get0_peer_rpk.html \
 html/man3/SSL_get0_peer_scts.html \
 html/man3/SSL_get_SSL_CTX.html \
@@ -3527,7 +3528,6 @@ html/man3/SSL_get_ciphers.html \
 html/man3/SSL_get_client_random.html \
 html/man3/SSL_get_conn_close_info.html \
 html/man3/SSL_get_current_cipher.html \
-html/man3/SSL_get_curve_name.html \
 html/man3/SSL_get_default_timeout.html \
 html/man3/SSL_get_error.html \
 html/man3/SSL_get_event_timeout.html \
@@ -4154,6 +4154,7 @@ man/man3/SSL_export_keying_material.3 \
 man/man3/SSL_extension_supported.3 \
 man/man3/SSL_free.3 \
 man/man3/SSL_get0_connection.3 \
+man/man3/SSL_get0_group_name.3 \
 man/man3/SSL_get0_peer_rpk.3 \
 man/man3/SSL_get0_peer_scts.3 \
 man/man3/SSL_get_SSL_CTX.3 \
@@ -4163,7 +4164,6 @@ man/man3/SSL_get_ciphers.3 \
 man/man3/SSL_get_client_random.3 \
 man/man3/SSL_get_conn_close_info.3 \
 man/man3/SSL_get_current_cipher.3 \
-man/man3/SSL_get_curve_name.3 \
 man/man3/SSL_get_default_timeout.3 \
 man/man3/SSL_get_error.3 \
 man/man3/SSL_get_event_timeout.3 \

--- a/doc/build.info
+++ b/doc/build.info
@@ -2527,6 +2527,10 @@ DEPEND[html/man3/SSL_get_current_cipher.html]=man3/SSL_get_current_cipher.pod
 GENERATE[html/man3/SSL_get_current_cipher.html]=man3/SSL_get_current_cipher.pod
 DEPEND[man/man3/SSL_get_current_cipher.3]=man3/SSL_get_current_cipher.pod
 GENERATE[man/man3/SSL_get_current_cipher.3]=man3/SSL_get_current_cipher.pod
+DEPEND[html/man3/SSL_get_curve_name.html]=man3/SSL_get_curve_name.pod
+GENERATE[html/man3/SSL_get_curve_name.html]=man3/SSL_get_curve_name.pod
+DEPEND[man/man3/SSL_get_curve_name.3]=man3/SSL_get_curve_name.pod
+GENERATE[man/man3/SSL_get_curve_name.3]=man3/SSL_get_curve_name.pod
 DEPEND[html/man3/SSL_get_default_timeout.html]=man3/SSL_get_default_timeout.pod
 GENERATE[html/man3/SSL_get_default_timeout.html]=man3/SSL_get_default_timeout.pod
 DEPEND[man/man3/SSL_get_default_timeout.3]=man3/SSL_get_default_timeout.pod
@@ -3523,6 +3527,7 @@ html/man3/SSL_get_ciphers.html \
 html/man3/SSL_get_client_random.html \
 html/man3/SSL_get_conn_close_info.html \
 html/man3/SSL_get_current_cipher.html \
+html/man3/SSL_get_curve_name.html \
 html/man3/SSL_get_default_timeout.html \
 html/man3/SSL_get_error.html \
 html/man3/SSL_get_event_timeout.html \
@@ -4158,6 +4163,7 @@ man/man3/SSL_get_ciphers.3 \
 man/man3/SSL_get_client_random.3 \
 man/man3/SSL_get_conn_close_info.3 \
 man/man3/SSL_get_current_cipher.3 \
+man/man3/SSL_get_curve_name.3 \
 man/man3/SSL_get_default_timeout.3 \
 man/man3/SSL_get_error.3 \
 man/man3/SSL_get_event_timeout.3 \

--- a/doc/man3/SSL_get0_group_name.pod
+++ b/doc/man3/SSL_get0_group_name.pod
@@ -2,26 +2,26 @@
 
 =head1 NAME
 
-SSL_get_curve_name - get name of the curve that was used for the key
+SSL_get0_group_name - get name of the group that was used for the key
 agreement of the current TLS session establishment
 
 =head1 SYNOPSIS
 
  #include <openssl/ssl.h>
 
- const char *SSL_get_curve_name(SSL *s);
+ const char *SSL_get0_group_name(SSL *s);
 
 =head1 DESCRIPTION
 
-SSL_get_curve_name() returns the name of the curve that was used for
+SSL_get0_group_name() returns the name of the group that was used for
 the key agreement of the current TLS session establishment.
 
 
 =head1 RETURN VALUES
 
-If non-NULL, SSL_get_curve_name() returns the name of the curve that was used for
+If non-NULL, SSL_get0_group_name() returns the name of the group that was used for
 the key agreement of the current TLS session establishment.
-If SSL_get_curve_name() returns NULL, an error occurred; possibly no TLS session
+If SSL_get0_group_name() returns NULL, an error occurred; possibly no TLS session
 has been established.
 
 Note that the return value is valid only during the lifetime of the

--- a/doc/man3/SSL_get_curve_name.pod
+++ b/doc/man3/SSL_get_curve_name.pod
@@ -1,0 +1,43 @@
+=pod
+
+=head1 NAME
+
+SSL_get_curve_name - get name of the curve that was used for the key
+agreement of the current TLS session establishment
+
+=head1 SYNOPSIS
+
+ #include <openssl/ssl.h>
+
+ const char *SSL_get_curve_name(SSL *s);
+
+=head1 DESCRIPTION
+
+SSL_get_curve_name() returns the name of the curve that was used for
+the key agreement of the current TLS session establishment.
+
+
+=head1 RETURN VALUES
+
+If non-NULL, SSL_get_curve_name() returns the name of the curve that was used for
+the key agreement of the current TLS session establishment.
+If SSL_get_curve_name() returns NULL, an error occurred; possibly no TLS session
+has been established.
+
+Note that the return value is valid only during the lifetime of the
+SSL object I<ssl>.
+
+=head1 SEE ALSO
+
+L<ssl(7)>
+
+=head1 COPYRIGHT
+
+Copyright 2023 The OpenSSL Project Authors. All Rights Reserved.
+
+Licensed under the Apache License 2.0 (the "License").  You may not use
+this file except in compliance with the License.  You can obtain a copy
+in the file LICENSE in the source distribution or at
+L<https://www.openssl.org/source/license.html>.
+
+=cut

--- a/include/openssl/ssl.h.in
+++ b/include/openssl/ssl.h.in
@@ -1504,7 +1504,7 @@ DECLARE_PEM_rw(SSL_SESSION, SSL_SESSION)
 # define SSL_get_max_proto_version(s) \
         SSL_ctrl(s, SSL_CTRL_GET_MAX_PROTO_VERSION, 0, NULL)
 
-const char *SSL_get_curve_name(SSL *s);
+const char *SSL_get0_group_name(SSL *s);
 const char *SSL_group_to_name(SSL *s, int id);
 
 /* Backwards compatibility, original 1.1.0 names */

--- a/include/openssl/ssl.h.in
+++ b/include/openssl/ssl.h.in
@@ -1504,6 +1504,7 @@ DECLARE_PEM_rw(SSL_SESSION, SSL_SESSION)
 # define SSL_get_max_proto_version(s) \
         SSL_ctrl(s, SSL_CTRL_GET_MAX_PROTO_VERSION, 0, NULL)
 
+const char *SSL_get_curve_name(SSL *s);
 const char *SSL_group_to_name(SSL *s, int id);
 
 /* Backwards compatibility, original 1.1.0 names */

--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -5022,6 +5022,22 @@ int ssl_encapsulate(SSL_CONNECTION *s, EVP_PKEY *pubkey,
     return rv;
 }
 
+const char *SSL_get_curve_name(SSL *s)
+{
+    SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL(s);
+    unsigned int id;
+
+    if (sc == NULL)
+        return NULL;
+
+    if (SSL_CONNECTION_IS_TLS13(sc) && sc->s3.did_kex)
+        id = sc->s3.group_id;
+    else
+        id = sc->session->kex_group;
+
+    return tls1_group_id2name(s->ctx, id);
+}
+
 const char *SSL_group_to_name(SSL *s, int nid) {
     int group_id = 0;
     const TLS_GROUP_INFO *cinf = NULL;

--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -5022,7 +5022,7 @@ int ssl_encapsulate(SSL_CONNECTION *s, EVP_PKEY *pubkey,
     return rv;
 }
 
-const char *SSL_get_curve_name(SSL *s)
+const char *SSL_get0_group_name(SSL *s)
 {
     SSL_CONNECTION *sc = SSL_CONNECTION_FROM_SSL(s);
     unsigned int id;

--- a/ssl/ssl_local.h
+++ b/ssl/ssl_local.h
@@ -2764,6 +2764,7 @@ __owur int ssl_check_srvr_ecc_cert_and_alg(X509 *x, SSL_CONNECTION *s);
 SSL_COMP *ssl3_comp_find(STACK_OF(SSL_COMP) *sk, int n);
 
 __owur const TLS_GROUP_INFO *tls1_group_id_lookup(SSL_CTX *ctx, uint16_t curve_id);
+__owur const char *tls1_group_id2name(SSL_CTX *ctx, uint16_t group_id);
 __owur int tls1_group_id2nid(uint16_t group_id, int include_unknown);
 __owur uint16_t tls1_nid2group_id(int nid);
 __owur int tls1_check_group_id(SSL_CONNECTION *s, uint16_t group_id,

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -755,6 +755,16 @@ const TLS_GROUP_INFO *tls1_group_id_lookup(SSL_CTX *ctx, uint16_t group_id)
     return NULL;
 }
 
+const char *tls1_group_id2name(SSL_CTX *ctx, uint16_t group_id)
+{
+    const TLS_GROUP_INFO *tls_group_info = tls1_group_id_lookup(ctx, group_id);
+
+    if (tls_group_info == NULL)
+        return NULL;
+
+    return tls_group_info->tlsname;
+}
+
 int tls1_group_id2nid(uint16_t group_id, int include_unknown)
 {
     size_t i;

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -5037,8 +5037,8 @@ static int test_key_exchange(int idx)
 
     /* We don't implement RFC 7919 named groups for TLS 1.2. */
     if (idx != 13) {
-        if (!TEST_str_eq(SSL_get_curve_name(serverssl), kexch_name0)
-            || !TEST_str_eq(SSL_get_curve_name(clientssl), kexch_name0))
+        if (!TEST_str_eq(SSL_get0_group_name(serverssl), kexch_name0)
+            || !TEST_str_eq(SSL_get0_group_name(clientssl), kexch_name0))
             goto end;
         if (!TEST_int_eq(SSL_get_negotiated_group(serverssl), kexch_groups[0]))
             goto end;
@@ -9498,8 +9498,8 @@ static int test_pluggable_group(int idx)
                      SSL_group_to_name(serverssl, SSL_get_shared_group(serverssl, 0))))
         goto end;
 
-    if (!TEST_str_eq(group_name, SSL_get_curve_name(serverssl))
-        || !TEST_str_eq(group_name, SSL_get_curve_name(clientssl)))
+    if (!TEST_str_eq(group_name, SSL_get0_group_name(serverssl))
+        || !TEST_str_eq(group_name, SSL_get0_group_name(clientssl)))
         goto end;
 
     testresult = 1;

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -5037,6 +5037,9 @@ static int test_key_exchange(int idx)
 
     /* We don't implement RFC 7919 named groups for TLS 1.2. */
     if (idx != 13) {
+        if (!TEST_str_eq(SSL_get_curve_name(serverssl), kexch_name0)
+            || !TEST_str_eq(SSL_get_curve_name(clientssl), kexch_name0))
+            goto end;
         if (!TEST_int_eq(SSL_get_negotiated_group(serverssl), kexch_groups[0]))
             goto end;
         if (!TEST_int_eq(SSL_get_negotiated_group(clientssl), kexch_groups[0]))
@@ -9493,6 +9496,10 @@ static int test_pluggable_group(int idx)
 
     if (!TEST_str_eq(group_name,
                      SSL_group_to_name(serverssl, SSL_get_shared_group(serverssl, 0))))
+        goto end;
+
+    if (!TEST_str_eq(group_name, SSL_get_curve_name(serverssl))
+        || !TEST_str_eq(group_name, SSL_get_curve_name(clientssl)))
         goto end;
 
     testresult = 1;

--- a/util/libssl.num
+++ b/util/libssl.num
@@ -575,5 +575,4 @@ SSL_get_conn_close_info                 ?	3_2_0	EXIST::FUNCTION:
 SSL_set_incoming_stream_policy          ?	3_2_0	EXIST::FUNCTION:
 SSL_handle_events                       ?	3_2_0	EXIST::FUNCTION:
 SSL_get_event_timeout                   ?	3_2_0	EXIST::FUNCTION:
-SSL_get_curve_name                      ?	3_2_0	EXIST::FUNCTION:
 SSL_get0_group_name                     ?	3_2_0	EXIST::FUNCTION:

--- a/util/libssl.num
+++ b/util/libssl.num
@@ -575,3 +575,4 @@ SSL_get_conn_close_info                 ?	3_2_0	EXIST::FUNCTION:
 SSL_set_incoming_stream_policy          ?	3_2_0	EXIST::FUNCTION:
 SSL_handle_events                       ?	3_2_0	EXIST::FUNCTION:
 SSL_get_event_timeout                   ?	3_2_0	EXIST::FUNCTION:
+SSL_get_curve_name                      ?	3_2_0	EXIST::FUNCTION:

--- a/util/libssl.num
+++ b/util/libssl.num
@@ -576,3 +576,4 @@ SSL_set_incoming_stream_policy          ?	3_2_0	EXIST::FUNCTION:
 SSL_handle_events                       ?	3_2_0	EXIST::FUNCTION:
 SSL_get_event_timeout                   ?	3_2_0	EXIST::FUNCTION:
 SSL_get_curve_name                      ?	3_2_0	EXIST::FUNCTION:
+SSL_get0_group_name                     ?	3_2_0	EXIST::FUNCTION:


### PR DESCRIPTION
Adds two functions `tls1_group_id2name` which returns the `tlsname` for a given `group_id` and `SSL_get0_group_name` which surfaces that name to the "user" 

This is a follow up to my previously rejected PR #20318 and the resulting discussion. It is related to #20594 but I am unsure if it addresses that issue at its core.

Since I am new to this project I would appreciate direction on if I went about surfacing the `tlsname` the correct way here, how I should document this new functionality, and how/where to test it.

I am aware I will need to submit a ICLA and a CCLA (If IBM hasn't submitted one already) before this can be merged.

##### Checklist
- [x] documentation is added or updated
- [x] tests are added or updated
