### PR TITLE
Replace __attribute__((malloc)) with __attribute__((__malloc__)) in macros.h

### DIFF
--- a/include/openssl/macros.h
+++ b/include/openssl/macros.h
@@ -315,7 +315,7 @@
 
 # ifndef OSSL_CRYPTO_ALLOC
 #  if defined(__GNUC__)
-#   define OSSL_CRYPTO_ALLOC __attribute__((malloc))
+#   define OSSL_CRYPTO_ALLOC __attribute__((__malloc__))
 #  elif defined(_MSC_VER)
 #   define OSSL_CRYPTO_ALLOC __declspec(restrict)
 #  else


### PR DESCRIPTION

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already
This PR fixes issue #20776 by replacing __attribute__((malloc)) with __attribute__((__malloc__)) in the include/openssl/macros.h file, as recommended by GCC documentation.


If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
