### PR TITLE
Change FIPS provider certificate state in documentation

### DIFF
--- a/doc/man7/fips_module.pod
+++ b/doc/man7/fips_module.pod
@@ -495,7 +495,7 @@ in OpenSSL 3.0.
 
 OpenSSL 3.0 includes a FIPS 140-2 approved FIPS provider.
 
-OpenSSL 3.1 includes a FIPS 140-3 approved FIPS provider.
+OpenSSL 3.1 includes a FIPS 140-3 compliant FIPS provider.
 
 =head1 COPYRIGHT
 


### PR DESCRIPTION
To my knowledge FIPS provider hasn't been certified as FIPS 140-3 (and on [NIST site](https://csrc.nist.gov/projects/cryptographic-module-validation-program/validated-modules/search) I can only find 140-2 certification), so this documentation is probably misleading. 