### PR TITLE
Revert "win-onecore: Build with /APPCONTAINER for UWP compat"

### DIFF
--- a/Configurations/50-win-onecore.conf
+++ b/Configurations/50-win-onecore.conf
@@ -36,14 +36,13 @@ my %targets = (
         # /NODEFAULTLIB:kernel32.lib is needed, because MSVCRT.LIB has
         # hidden reference to kernel32.lib, but we don't actually want
         # it in "onecore" build.
-        # /APPCONTAINER is needed for Universal Windows Platform compat
-        lflags          => add("/NODEFAULTLIB:kernel32.lib /APPCONTAINER"),
+        lflags          => add("/NODEFAULTLIB:kernel32.lib"),
         defines         => add("OPENSSL_SYS_WIN_CORE"),
         ex_libs         => "onecore.lib",
     },
     "VC-WIN64A-ONECORE" => {
         inherit_from    => [ "VC-WIN64A" ],
-        lflags          => add("/NODEFAULTLIB:kernel32.lib /APPCONTAINER"),
+        lflags          => add("/NODEFAULTLIB:kernel32.lib"),
         defines         => add("OPENSSL_SYS_WIN_CORE"),
         ex_libs         => "onecore.lib",
     },
@@ -69,7 +68,7 @@ my %targets = (
         defines         => add("_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE",
                                "OPENSSL_SYS_WIN_CORE"),
         bn_ops          => "BN_LLONG RC4_CHAR",
-        lflags          => add("/NODEFAULTLIB:kernel32.lib /APPCONTAINER"),
+        lflags          => add("/NODEFAULTLIB:kernel32.lib"),
         ex_libs         => "onecore.lib",
         multilib        => "-arm",
     },
@@ -78,7 +77,7 @@ my %targets = (
         defines         => add("_ARM_WINAPI_PARTITION_DESKTOP_SDK_AVAILABLE",
                                "OPENSSL_SYS_WIN_CORE"),
         bn_ops          => "SIXTY_FOUR_BIT RC4_CHAR",
-        lflags          => add("/NODEFAULTLIB:kernel32.lib /APPCONTAINER"),
+        lflags          => add("/NODEFAULTLIB:kernel32.lib"),
         ex_libs         => "onecore.lib",
         multilib        => "-arm64",
     },


### PR DESCRIPTION
This reverts commit 2c61a670ebf2f1923a3bd2ef0ee4b2fa6261eaeb.

Not all OneCore based SKUs (or editions) of Windows (Server, XBOX, etc) require /APPCONTAINER. The /APPCONTAINER link option is only relevant for Universal Windows Platform (UWP) apps for which there are already dedicated configurations (VC-WIN32-UWP, VC-WIN64A-UWP, etc) where the /APPCONTAINER link option is added.