### PR TITLE
QUIC: Rename SSL_tick, SSL_get_tick_timeout

### DIFF
--- a/doc/build.info
+++ b/doc/build.info
@@ -2535,6 +2535,10 @@ DEPEND[html/man3/SSL_get_error.html]=man3/SSL_get_error.pod
 GENERATE[html/man3/SSL_get_error.html]=man3/SSL_get_error.pod
 DEPEND[man/man3/SSL_get_error.3]=man3/SSL_get_error.pod
 GENERATE[man/man3/SSL_get_error.3]=man3/SSL_get_error.pod
+DEPEND[html/man3/SSL_get_event_timeout.html]=man3/SSL_get_event_timeout.pod
+GENERATE[html/man3/SSL_get_event_timeout.html]=man3/SSL_get_event_timeout.pod
+DEPEND[man/man3/SSL_get_event_timeout.3]=man3/SSL_get_event_timeout.pod
+GENERATE[man/man3/SSL_get_event_timeout.3]=man3/SSL_get_event_timeout.pod
 DEPEND[html/man3/SSL_get_extms_support.html]=man3/SSL_get_extms_support.pod
 GENERATE[html/man3/SSL_get_extms_support.html]=man3/SSL_get_extms_support.pod
 DEPEND[man/man3/SSL_get_extms_support.3]=man3/SSL_get_extms_support.pod
@@ -2587,10 +2591,6 @@ DEPEND[html/man3/SSL_get_stream_read_state.html]=man3/SSL_get_stream_read_state.
 GENERATE[html/man3/SSL_get_stream_read_state.html]=man3/SSL_get_stream_read_state.pod
 DEPEND[man/man3/SSL_get_stream_read_state.3]=man3/SSL_get_stream_read_state.pod
 GENERATE[man/man3/SSL_get_stream_read_state.3]=man3/SSL_get_stream_read_state.pod
-DEPEND[html/man3/SSL_get_tick_timeout.html]=man3/SSL_get_tick_timeout.pod
-GENERATE[html/man3/SSL_get_tick_timeout.html]=man3/SSL_get_tick_timeout.pod
-DEPEND[man/man3/SSL_get_tick_timeout.3]=man3/SSL_get_tick_timeout.pod
-GENERATE[man/man3/SSL_get_tick_timeout.3]=man3/SSL_get_tick_timeout.pod
 DEPEND[html/man3/SSL_get_verify_result.html]=man3/SSL_get_verify_result.pod
 GENERATE[html/man3/SSL_get_verify_result.html]=man3/SSL_get_verify_result.pod
 DEPEND[man/man3/SSL_get_verify_result.3]=man3/SSL_get_verify_result.pod
@@ -2603,6 +2603,10 @@ DEPEND[html/man3/SSL_group_to_name.html]=man3/SSL_group_to_name.pod
 GENERATE[html/man3/SSL_group_to_name.html]=man3/SSL_group_to_name.pod
 DEPEND[man/man3/SSL_group_to_name.3]=man3/SSL_group_to_name.pod
 GENERATE[man/man3/SSL_group_to_name.3]=man3/SSL_group_to_name.pod
+DEPEND[html/man3/SSL_handle_events.html]=man3/SSL_handle_events.pod
+GENERATE[html/man3/SSL_handle_events.html]=man3/SSL_handle_events.pod
+DEPEND[man/man3/SSL_handle_events.3]=man3/SSL_handle_events.pod
+GENERATE[man/man3/SSL_handle_events.3]=man3/SSL_handle_events.pod
 DEPEND[html/man3/SSL_in_init.html]=man3/SSL_in_init.pod
 GENERATE[html/man3/SSL_in_init.html]=man3/SSL_in_init.pod
 DEPEND[man/man3/SSL_in_init.3]=man3/SSL_in_init.pod
@@ -2723,10 +2727,6 @@ DEPEND[html/man3/SSL_stream_reset.html]=man3/SSL_stream_reset.pod
 GENERATE[html/man3/SSL_stream_reset.html]=man3/SSL_stream_reset.pod
 DEPEND[man/man3/SSL_stream_reset.3]=man3/SSL_stream_reset.pod
 GENERATE[man/man3/SSL_stream_reset.3]=man3/SSL_stream_reset.pod
-DEPEND[html/man3/SSL_tick.html]=man3/SSL_tick.pod
-GENERATE[html/man3/SSL_tick.html]=man3/SSL_tick.pod
-DEPEND[man/man3/SSL_tick.3]=man3/SSL_tick.pod
-GENERATE[man/man3/SSL_tick.3]=man3/SSL_tick.pod
 DEPEND[html/man3/SSL_want.html]=man3/SSL_want.pod
 GENERATE[html/man3/SSL_want.html]=man3/SSL_want.pod
 DEPEND[man/man3/SSL_want.3]=man3/SSL_want.pod
@@ -3525,6 +3525,7 @@ html/man3/SSL_get_conn_close_info.html \
 html/man3/SSL_get_current_cipher.html \
 html/man3/SSL_get_default_timeout.html \
 html/man3/SSL_get_error.html \
+html/man3/SSL_get_event_timeout.html \
 html/man3/SSL_get_extms_support.html \
 html/man3/SSL_get_fd.html \
 html/man3/SSL_get_peer_cert_chain.html \
@@ -3538,10 +3539,10 @@ html/man3/SSL_get_session.html \
 html/man3/SSL_get_shared_sigalgs.html \
 html/man3/SSL_get_stream_id.html \
 html/man3/SSL_get_stream_read_state.html \
-html/man3/SSL_get_tick_timeout.html \
 html/man3/SSL_get_verify_result.html \
 html/man3/SSL_get_version.html \
 html/man3/SSL_group_to_name.html \
+html/man3/SSL_handle_events.html \
 html/man3/SSL_in_init.html \
 html/man3/SSL_inject_net_dgram.html \
 html/man3/SSL_key_update.html \
@@ -3572,7 +3573,6 @@ html/man3/SSL_shutdown.html \
 html/man3/SSL_state_string.html \
 html/man3/SSL_stream_conclude.html \
 html/man3/SSL_stream_reset.html \
-html/man3/SSL_tick.html \
 html/man3/SSL_want.html \
 html/man3/SSL_write.html \
 html/man3/TS_RESP_CTX_new.html \
@@ -4160,6 +4160,7 @@ man/man3/SSL_get_conn_close_info.3 \
 man/man3/SSL_get_current_cipher.3 \
 man/man3/SSL_get_default_timeout.3 \
 man/man3/SSL_get_error.3 \
+man/man3/SSL_get_event_timeout.3 \
 man/man3/SSL_get_extms_support.3 \
 man/man3/SSL_get_fd.3 \
 man/man3/SSL_get_peer_cert_chain.3 \
@@ -4173,10 +4174,10 @@ man/man3/SSL_get_session.3 \
 man/man3/SSL_get_shared_sigalgs.3 \
 man/man3/SSL_get_stream_id.3 \
 man/man3/SSL_get_stream_read_state.3 \
-man/man3/SSL_get_tick_timeout.3 \
 man/man3/SSL_get_verify_result.3 \
 man/man3/SSL_get_version.3 \
 man/man3/SSL_group_to_name.3 \
+man/man3/SSL_handle_events.3 \
 man/man3/SSL_in_init.3 \
 man/man3/SSL_inject_net_dgram.3 \
 man/man3/SSL_key_update.3 \
@@ -4207,7 +4208,6 @@ man/man3/SSL_shutdown.3 \
 man/man3/SSL_state_string.3 \
 man/man3/SSL_stream_conclude.3 \
 man/man3/SSL_stream_reset.3 \
-man/man3/SSL_tick.3 \
 man/man3/SSL_want.3 \
 man/man3/SSL_write.3 \
 man/man3/TS_RESP_CTX_new.3 \

--- a/doc/man3/BIO_get_rpoll_descriptor.pod
+++ b/doc/man3/BIO_get_rpoll_descriptor.pod
@@ -92,7 +92,7 @@ not pollable for readability or writeability respectively.
 
 =head1 SEE ALSO
 
-L<SSL_tick(3)>, L<SSL_get_tick_timeout(3)>, L<SSL_get_rpoll_descriptor(3)>,
+L<SSL_handle_events(3)>, L<SSL_get_event_timeout(3)>, L<SSL_get_rpoll_descriptor(3)>,
 L<SSL_get_wpoll_descriptor(3)>, L<bio(7)>
 
 =head1 HISTORY

--- a/doc/man3/DTLSv1_get_timeout.pod
+++ b/doc/man3/DTLSv1_get_timeout.pod
@@ -2,8 +2,8 @@
 
 =head1 NAME
 
-DTLSv1_get_timeout - determine when a DTLS SSL object next needs a timeout
-event to be handled
+DTLSv1_get_timeout - determine when a DTLS or QUIC SSL object next needs a
+timeout event to be handled
 
 =head1 SYNOPSIS
 
@@ -13,8 +13,9 @@ event to be handled
 
 =head1 DESCRIPTION
 
-DTLSv1_get_timeout() can be used on a DTLS SSL object to determine when the
-SSL object next needs to perform internal processing due to the passage of time.
+DTLSv1_get_timeout() can be used on a DTLS or QUIC SSL object to determine when
+the SSL object next needs to perform internal processing due to the passage of
+time.
 
 Calling DTLSv1_get_timeout() results in I<*tv> being written with an amount of
 time left before the SSL object needs have DTLSv1_handle_timeout() called on it.
@@ -22,7 +23,7 @@ If the SSL object needs to be ticked immediately, I<*tv> is zeroed and the
 function succeeds, returning 1. If no timeout is currently active, this function
 returns 0.
 
-This function is only applicable to DTLS objects. It fails if called on
+This function is only applicable to DTLS and QUIC objects. It fails if called on
 any other kind of SSL object.
 
 Note that the value output by a call to DTLSv1_get_timeout() may change as a

--- a/doc/man3/DTLSv1_get_timeout.pod
+++ b/doc/man3/DTLSv1_get_timeout.pod
@@ -32,7 +32,7 @@ Once the timeout expires, DTLSv1_handle_timeout() should be called to handle any
 internal processing which is due; for more information, see
 L<DTLSv1_handle_timeout(3)>.
 
-L<SSL_get_tick_timeout(3)> supersedes all use cases for this this function and
+L<SSL_get_event_timeout(3)> supersedes all use cases for this this function and
 may be used instead of it.
 
 =head1 RETURN VALUES
@@ -43,7 +43,7 @@ Returns 0 on failure, or if no timeout is currently active.
 
 =head1 SEE ALSO
 
-L<DTLSv1_handle_timeout(3)>, L<SSL_get_tick_timeout(3)>, L<ssl(7)>
+L<DTLSv1_handle_timeout(3)>, L<SSL_get_event_timeout(3)>, L<ssl(7)>
 
 =head1 COPYRIGHT
 

--- a/doc/man3/DTLSv1_handle_timeout.pod
+++ b/doc/man3/DTLSv1_handle_timeout.pod
@@ -2,7 +2,8 @@
 
 =head1 NAME
 
-DTLSv1_handle_timeout - handle a pending timeout event for a DTLS SSL object
+DTLSv1_handle_timeout - handle a pending timeout event for a DTLS or QUIC SSL
+object
 
 =head1 SYNOPSIS
 
@@ -13,13 +14,13 @@ DTLSv1_handle_timeout - handle a pending timeout event for a DTLS SSL object
 =head1 DESCRIPTION
 
 DTLSv1_handle_timeout() handles any timeout events which have become pending
-on a DTLS SSL object.
+on a DTLS or QUIC SSL object.
 
 Use L<DTLSv1_get_timeout(3)> or L<SSL_get_event_timeout(3)> to determine
 when to call DTLSv1_handle_timeout().
 
-This function is only applicable to DTLS objects. It returns 0 if called on
-any other kind of SSL object.
+This function is only applicable to DTLS or QUIC SSL objects. It returns 0 if
+called on any other kind of SSL object.
 
 L<SSL_handle_events(3)> supersedes all use cases for this this function and may
 be used instead of it.
@@ -29,7 +30,7 @@ be used instead of it.
 Returns 1 if there was a pending timeout event and it was handled successfully.
 
 Returns 0 if there was no pending timeout event, or if the SSL object is not a
-DTLS object.
+DTLS or QUIC object.
 
 Returns -1 if there was a pending timeout event but it could not be handled
 successfully.

--- a/doc/man3/DTLSv1_handle_timeout.pod
+++ b/doc/man3/DTLSv1_handle_timeout.pod
@@ -15,14 +15,14 @@ DTLSv1_handle_timeout - handle a pending timeout event for a DTLS SSL object
 DTLSv1_handle_timeout() handles any timeout events which have become pending
 on a DTLS SSL object.
 
-Use L<DTLSv1_get_timeout(3)> or L<SSL_get_tick_timeout(3)> to determine
+Use L<DTLSv1_get_timeout(3)> or L<SSL_get_event_timeout(3)> to determine
 when to call DTLSv1_handle_timeout().
 
 This function is only applicable to DTLS objects. It returns 0 if called on
 any other kind of SSL object.
 
-L<SSL_tick(3)> supersedes all use cases for this this function and may be used
-instead of it.
+L<SSL_handle_events(3)> supersedes all use cases for this this function and may
+be used instead of it.
 
 =head1 RETURN VALUES
 
@@ -36,7 +36,7 @@ successfully.
 
 =head1 SEE ALSO
 
-L<DTLSv1_get_timeout(3)>, L<SSL_tick(3)>, L<ssl(7)>
+L<DTLSv1_get_timeout(3)>, L<SSL_handle_events(3)>, L<ssl(7)>
 
 =head1 COPYRIGHT
 

--- a/doc/man3/DTLSv1_handle_timeout.pod
+++ b/doc/man3/DTLSv1_handle_timeout.pod
@@ -22,7 +22,7 @@ when to call DTLSv1_handle_timeout().
 This function is only applicable to DTLS or QUIC SSL objects. It returns 0 if
 called on any other kind of SSL object.
 
-L<SSL_handle_events(3)> supersedes all use cases for this this function and may
+L<SSL_handle_events(3)> supersedes all use cases for this function and may
 be used instead of it.
 
 =head1 RETURN VALUES

--- a/doc/man3/SSL_get_event_timeout.pod
+++ b/doc/man3/SSL_get_event_timeout.pod
@@ -2,20 +2,20 @@
 
 =head1 NAME
 
-SSL_get_tick_timeout - determine when an SSL object next needs to be ticked
+SSL_get_event_timeout - determine when an SSL object next needs to be ticked
 
 =head1 SYNOPSIS
 
  #include <openssl/ssl.h>
 
- int SSL_get_tick_timeout(SSL *s, struct timeval *tv);
+ int SSL_get_event_timeout(SSL *s, struct timeval *tv);
 
 =head1 DESCRIPTION
 
-SSL_get_tick_timeout() determines when the SSL object next needs to perform
+SSL_get_event_timeout() determines when the SSL object next needs to perform
 internal processing due to the passage of time.
 
-Calling SSL_get_tick_timeout() results in I<*tv> being written with an amount of
+Calling SSL_get_event_timeout() results in I<*tv> being written with an amount of
 time left before the SSL object needs to be ticked. If the SSL object needs to
 be ticked immediately, it is set to zero; if the SSL object currently does not
 need to be ticked at any point in the future, I<tv->tv_sec> is set to -1,
@@ -30,13 +30,14 @@ L<DTLSv1_get_timeout(3)> function. Note that this function differs from
 L<DTLSv1_get_timeout(3)> in that the case where no timeout is active is
 considered a success condition.
 
-Note that the value output by a call to SSL_get_tick_timeout() may change as a
+Note that the value output by a call to SSL_get_event_timeout() may change as a
 result of other calls to the SSL object.
 
-Once the timeout expires, SSL_tick() should be called to handle any internal
-processing which is due; for more information, see L<SSL_tick(3)>.
+Once the timeout expires, SSL_handle_events() should be called to handle any
+internal processing which is due; for more information, see
+L<SSL_handle_events(3)>.
 
-Note that SSL_get_tick_timeout() supersedes the older L<DTLSv1_get_timeout(3)>
+Note that SSL_get_event_timeout() supersedes the older L<DTLSv1_get_timeout(3)>
 function for all use cases.
 
 =head1 RETURN VALUES
@@ -45,11 +46,11 @@ Returns 1 on success and 0 on failure.
 
 =head1 SEE ALSO
 
-L<SSL_tick(3)>, L<DTLSv1_get_timeout(3)>, L<ssl(7)>
+L<SSL_handle_events(3)>, L<DTLSv1_get_timeout(3)>, L<ssl(7)>
 
 =head1 HISTORY
 
-The SSL_get_tick_timeout() function was added in OpenSSL 3.2.
+The SSL_get_event_timeout() function was added in OpenSSL 3.2.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/SSL_get_event_timeout.pod
+++ b/doc/man3/SSL_get_event_timeout.pod
@@ -8,18 +8,38 @@ SSL_get_event_timeout - determine when an SSL object next needs to be ticked
 
  #include <openssl/ssl.h>
 
- int SSL_get_event_timeout(SSL *s, struct timeval *tv);
+ int SSL_get_event_timeout(SSL *s, struct timeval *tv, int *is_infinite);
 
 =head1 DESCRIPTION
 
 SSL_get_event_timeout() determines when the SSL object next needs to perform
 internal processing due to the passage of time.
 
-Calling SSL_get_event_timeout() results in I<*tv> being written with an amount of
-time left before the SSL object needs to be ticked. If the SSL object needs to
-be ticked immediately, it is set to zero; if the SSL object currently does not
-need to be ticked at any point in the future, I<tv->tv_sec> is set to -1,
-representing infinity.
+All arguments are required; I<tv> and I<is_infinite> must be non-NULL.
+
+Upon the successful return of SSL_get_event_timeout(), one of the following
+cases applies:
+
+=over 4
+
+=item
+
+The SSL object has events which need to be handled immediately; I<*tv> is set to
+zero and I<*is_infinite> is set to 0.
+
+=item
+
+The SSL object has events which need to be handled after some amount of time
+(relative to the time at which SSL_get_event_timeout() was called). I<*tv> is
+set to the amount of time after which L<SSL_handle_events(3)> should be called
+and I<*is_infinite> is set to 0.
+
+=item
+
+There are currently no timer events which require handling in the future. The
+value of I<*tv> is unspecified and I<*is_infinite> is set to 1.
+
+=back
 
 This function is currently applicable only to DTLS and QUIC connection SSL
 objects. If it is called on any other kind of SSL object, it always outputs
@@ -39,6 +59,9 @@ L<SSL_handle_events(3)>.
 
 Note that SSL_get_event_timeout() supersedes the older L<DTLSv1_get_timeout(3)>
 function for all use cases.
+
+If the call to SSL_get_event_timeout() fails, the values of I<*tv> and
+I<*is_infinite> may still be changed and their values become unspecified.
 
 =head1 RETURN VALUES
 

--- a/doc/man3/SSL_get_event_timeout.pod
+++ b/doc/man3/SSL_get_event_timeout.pod
@@ -2,7 +2,8 @@
 
 =head1 NAME
 
-SSL_get_event_timeout - determine when an SSL object next needs to be ticked
+SSL_get_event_timeout - determine when an SSL object next needs to have events
+handled
 
 =head1 SYNOPSIS
 
@@ -24,8 +25,8 @@ cases applies:
 
 =item
 
-The SSL object has events which need to be handled immediately; I<*tv> is set to
-zero and I<*is_infinite> is set to 0.
+The SSL object has events which need to be handled immediately; The fields of
+I<*tv> are set to 0 and I<*is_infinite> is set to 0.
 
 =item
 
@@ -53,7 +54,7 @@ considered a success condition.
 Note that the value output by a call to SSL_get_event_timeout() may change as a
 result of other calls to the SSL object.
 
-Once the timeout expires, SSL_handle_events() should be called to handle any
+Once the timeout expires, L<SSL_handle_events(3)> should be called to handle any
 internal processing which is due; for more information, see
 L<SSL_handle_events(3)>.
 

--- a/doc/man3/SSL_get_rpoll_descriptor.pod
+++ b/doc/man3/SSL_get_rpoll_descriptor.pod
@@ -20,7 +20,7 @@ network I/O can be performed
 The functions SSL_get_rpoll_descriptor() and SSL_get_wpoll_descriptor() can be
 used to determine when an SSL object which represents a QUIC connection can
 perform useful network I/O, so that an application using a QUIC connection SSL
-object in nonblocking mode can determine when it should call SSL_tick().
+object in nonblocking mode can determine when it should call SSL_handle_events().
 
 On success, these functions output poll descriptors. For more information on
 poll descriptors, see L<BIO_get_rpoll_descriptor(3)>.
@@ -34,9 +34,9 @@ not interested in writing data to the network at the current time,
 SSL_net_write_desired() will return 0.
 
 The intention is that an application using QUIC in nonblocking mode can use
-these calls, in conjunction with L<SSL_get_tick_timeout(3)> to wait for network
+these calls, in conjunction with L<SSL_get_event_timeout(3)> to wait for network
 I/O conditions which allow the SSL object to perform useful work. When such a
-condition arises, L<SSL_tick(3)> should be called.
+condition arises, L<SSL_handle_events(3)> should be called.
 
 In particular, the expected usage is as follows:
 
@@ -44,18 +44,18 @@ In particular, the expected usage is as follows:
 
 =item *
 
-SSL_tick() should be called whenever the timeout returned by
-SSL_get_tick_timeout(3) (if any) expires
+SSL_handle_events() should be called whenever the timeout returned by
+SSL_get_event_timeout(3) (if any) expires
 
 =item *
 
-If the last call to SSL_net_read_desired() returned 1, SSL_tick() should be called
+If the last call to SSL_net_read_desired() returned 1, SSL_handle_events() should be called
 whenever the poll descriptor output by SSL_get_rpoll_descriptor() becomes
 readable.
 
 =item *
 
-If the last call to SSL_net_write_desired() returned 1, SSL_tick() should be called
+If the last call to SSL_net_write_desired() returned 1, SSL_handle_events() should be called
 whenever the poll descriptor output by SSL_get_wpoll_descriptor() becomes
 writable.
 
@@ -64,7 +64,7 @@ writable.
 The return values of the SSL_net_read_desired() and SSL_net_write_desired() functions
 may change in response to any call to the SSL object other than
 SSL_net_read_desired(), SSL_net_write_desired(), SSL_get_rpoll_descriptor(),
-SSL_get_wpoll_descriptor() and SSL_get_tick_timeout().
+SSL_get_wpoll_descriptor() and SSL_get_event_timeout().
 
 These functions are not supported on non-QUIC SSL objects.
 
@@ -74,7 +74,7 @@ These functions return 1 on success and 0 on failure.
 
 =head1 SEE ALSO
 
-L<SSL_tick(3)>, L<SSL_get_tick_timeout(3)>, L<ssl(7)>
+L<SSL_handle_events(3)>, L<SSL_get_event_timeout(3)>, L<ssl(7)>
 
 =head1 HISTORY
 

--- a/doc/man3/SSL_handle_events.pod
+++ b/doc/man3/SSL_handle_events.pod
@@ -38,10 +38,10 @@ cases of L<DTLSv1_handle_timeout(3)>, it should be preferred for new
 applications which do not require support for OpenSSL 3.1 or older.
 
 When using DTLS, an application must call SSL_handle_events() as indicated by
-calls to L<SSL_get_event_timeout(3)>; ticking is not performed automatically by
-calls to other SSL functions such as L<SSL_read(3)> or L<SSL_write(3)>. Note
-that this is different to QUIC which also performs ticking implicitly; see
-below.
+calls to L<SSL_get_event_timeout(3)>; event handling is not performed
+automatically by calls to other SSL functions such as L<SSL_read(3)> or
+L<SSL_write(3)>. Note that this is different to QUIC which also performs event
+handling implicitly; see below.
 
 =item QUIC connection SSL objects
 

--- a/doc/man3/SSL_handle_events.pod
+++ b/doc/man3/SSL_handle_events.pod
@@ -2,66 +2,67 @@
 
 =head1 NAME
 
-SSL_tick - advance asynchronous state machine and perform network I/O
+SSL_handle_events - advance asynchronous state machine and perform network I/O
 
 =head1 SYNOPSIS
 
  #include <openssl/ssl.h>
 
- int SSL_tick(SSL *ssl);
+ int SSL_handle_events(SSL *ssl);
 
 =head1 DESCRIPTION
 
-SSL_tick() performs any internal processing which is due on a SSL object. The
-exact operations performed by SSL_tick() vary depending on what kind of protocol
-is being used with the given SSL object. For example, SSL_tick() may handle
+SSL_handle_events() performs any internal processing which is due on a SSL object. The
+exact operations performed by SSL_handle_events() vary depending on what kind of protocol
+is being used with the given SSL object. For example, SSL_handle_events() may handle
 timeout events which have become due, or may attempt, to the extent currently
 possible, to perform network I/O operations on one of the BIOs underlying the
 SSL object.
 
-The primary use case for SSL_tick() is to allow an application which uses
+The primary use case for SSL_handle_events() is to allow an application which uses
 OpenSSL in nonblocking mode to give OpenSSL an opportunity to handle timer
 events, or to respond to the availability of new data to be read from an
 underlying BIO, or to respond to the opportunity to write pending data to an
 underlying BIO.
 
-SSL_tick() can be used only with the following types of SSL object:
+SSL_handle_events() can be used only with the following types of SSL object:
 
 =over 4
 
 =item DTLS SSL objects
 
-Using SSL_tick() on an SSL object being used with a DTLS method allows timeout
+Using SSL_handle_events() on an SSL object being used with a DTLS method allows timeout
 events to be handled properly. This is equivalent to a call to
-L<DTLSv1_handle_timeout(3)>. Since SSL_tick() handles a superset of the use
+L<DTLSv1_handle_timeout(3)>. Since SSL_handle_events() handles a superset of the use
 cases of L<DTLSv1_handle_timeout(3)>, it should be preferred for new
 applications which do not require support for OpenSSL 3.1 or older.
 
-When using DTLS, an application must call SSL_tick() as indicated by calls to
-L<SSL_get_tick_timeout(3)>; ticking is not performed automatically by calls to
-other SSL functions such as L<SSL_read(3)> or L<SSL_write(3)>. Note that this is
-different to QUIC which also performs ticking implicitly; see below.
+When using DTLS, an application must call SSL_handle_events() as indicated by
+calls to L<SSL_get_event_timeout(3)>; ticking is not performed automatically by
+calls to other SSL functions such as L<SSL_read(3)> or L<SSL_write(3)>. Note
+that this is different to QUIC which also performs ticking implicitly; see
+below.
 
 =item QUIC connection SSL objects
 
-Using SSL_tick() on an SSL object which represents a QUIC connection allows
+Using SSL_handle_events() on an SSL object which represents a QUIC connection allows
 timeout events to be handled properly, as well as incoming network data to be
 processed, and queued outgoing network data to be written, if the underlying BIO
 has the capacity to accept it.
 
 Ordinarily, when an application uses an SSL object in blocking mode, it does not
-need to call SSL_tick() because OpenSSL performs ticking internally on an
+need to call SSL_handle_events() because OpenSSL performs ticking internally on an
 automatic basis. However, if an application uses a QUIC connection in
-nonblocking mode, it must at a minimum ensure that SSL_tick() is called
+nonblocking mode, it must at a minimum ensure that SSL_handle_events() is called
 periodically to allow timeout events to be handled. An application can find out
-when it next needs to call SSL_tick() for this purpose (if at all) by calling
-L<SSL_get_tick_timeout(3)>.
+when it next needs to call SSL_handle_events() for this purpose (if at all) by calling
+L<SSL_get_event_timeout(3)>.
 
-Calling SSL_tick() on a QUIC connection SSL object being used in blocking mode
+Calling SSL_handle_events() on a QUIC connection SSL object being used in blocking mode
 is not necessary unless no I/O calls (such as L<SSL_read(3)> or L<SSL_write(3)>)
 will be made to the object for a substantial period of time. So long as at least
 one call to the SSL object is blocking, no such call is needed. However,
-SSL_tick() may optionally be used on a QUIC connection object if desired.
+SSL_handle_events() may optionally be used on a QUIC connection object if desired.
 
 =begin comment
 
@@ -71,10 +72,10 @@ TODO(QUIC): Update the above paragraph once we support thread assisted mode.
 
 =back
 
-Calling SSL_tick() on any other kind of SSL object is a no-op. This is
+Calling SSL_handle_events() on any other kind of SSL object is a no-op. This is
 considered a success case.
 
-Note that SSL_tick() supersedes the older L<DTLSv1_handle_timeout(3)> function
+Note that SSL_handle_events() supersedes the older L<DTLSv1_handle_timeout(3)> function
 for all use cases.
 
 =head1 RETURN VALUES
@@ -83,11 +84,11 @@ Returns 1 on success and 0 on failure.
 
 =head1 SEE ALSO
 
-L<SSL_get_tick_timeout(3)>, L<DTLSv1_handle_timeout(3)>, L<ssl(7)>
+L<SSL_get_event_timeout(3)>, L<DTLSv1_handle_timeout(3)>, L<ssl(7)>
 
 =head1 HISTORY
 
-The SSL_tick() function was added in OpenSSL 3.2.
+The SSL_handle_events() function was added in OpenSSL 3.2.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/SSL_inject_net_dgram.pod
+++ b/doc/man3/SSL_inject_net_dgram.pod
@@ -37,7 +37,7 @@ on a SSL object which is not a QUIC connection SSL object.
 
 =head1 SEE ALSO
 
-L<OSSL_QUIC_client_method(3)>, L<SSL_tick(3)>, L<SSL_set_blocking_mode(3)>
+L<OSSL_QUIC_client_method(3)>, L<SSL_handle_events(3)>, L<SSL_set_blocking_mode(3)>
 
 =head1 HISTORY
 

--- a/doc/man3/SSL_set_blocking_mode.pod
+++ b/doc/man3/SSL_set_blocking_mode.pod
@@ -37,7 +37,7 @@ provided to the SSL object are themselves configured in nonblocking mode.
 
 Where a QUIC connection SSL object is used in nonblocking mode, an application
 is responsible for ensuring that the SSL object is ticked regularly; see
-L<SSL_tick(3)>.
+L<SSL_handle_events(3)>.
 
 Blocking mode is disabled automatically if the application provides a QUIC
 connection SSL object with a network BIO which cannot support blocking mode. To
@@ -55,7 +55,7 @@ SSL_get_blocking_mode() returns 1 if blocking is currently enabled. It returns
 
 =head1 SEE ALSO
 
-L<SSL_tick(3)>, L<ssl(7)>
+L<SSL_handle_events(3)>, L<ssl(7)>
 
 =head1 HISTORY
 

--- a/doc/man7/openssl-quic.pod
+++ b/doc/man7/openssl-quic.pod
@@ -401,23 +401,23 @@ it must add a call to L<SSL_set_blocking_mode(3)> to disable blocking mode.
 
 If your application does not choose to use thread assisted mode, it must ensure
 that it calls an I/O function on the SSL object (for example, L<SSL_read(3)> or
-L<SSL_write(3)>), or the new function L<SSL_tick(3)>, regularly. If the SSL
-object is used in blocking mode, an ongoing blocking call to an I/O function
+L<SSL_write(3)>), or the new function L<SSL_handle_events(3)>, regularly. If the
+SSL object is used in blocking mode, an ongoing blocking call to an I/O function
 satisfies this requirement. This is required to ensure that timer events
 required by QUIC are handled in a timely fashion.
 
 Most applications will service the SSL object by calling L<SSL_read(3)> or
 L<SSL_write(3)> regularly. If an application does not do this, it should ensure
-that L<SSL_tick(3)> is called regularly.
+that L<SSL_handle_events(3)> is called regularly.
 
-L<SSL_get_tick_timeout(3)> can be used to determine when L<SSL_tick(3)> must
-next be called.
+L<SSL_get_event_timeout(3)> can be used to determine when
+L<SSL_handle_events(3)> must next be called.
 
 If the SSL object is being used with an underlying network BIO which is pollable
 (such as L<BIO_s_datagram(3)>), the application can use
 L<SSL_get_rpoll_descriptor(3)>, L<SSL_get_wpoll_descriptor(3)> to obtain
-resources which can be used to determine when L<SSL_tick(3)> should be called
-due to network I/O.
+resources which can be used to determine when L<SSL_handle_events(3)> should be
+called due to network I/O.
 
 Applications which use thread assisted mode do not need to be concerned
 with this requirement, as the QUIC implementation ensures timeout events
@@ -494,24 +494,24 @@ The following SSL APIs are new but relevant to both QUIC and DTLS:
 
 =over 4
 
-=item L<SSL_get_tick_timeout(3)>
+=item L<SSL_get_event_timeout(3)>
 
 Determines when the QUIC implementation should next be woken up via a call to
-L<SSL_tick(3)> (or another I/O function such as L<SSL_read(3)> or
+L<SSL_handle_events(3)> (or another I/O function such as L<SSL_read(3)> or
 L<SSL_write(3)>), if ever.
 
 This can also be used with DTLS and supersedes L<DTLSv1_get_timeout(3)> for new
 usage.
 
-=item L<SSL_tick(3)>
+=item L<SSL_handle_events(3)>
 
 This is a non-specific I/O operation which makes a best effort attempt to
 perform any pending I/O or timeout processing. It can be used to advance the
 QUIC state machine by processing incoming network traffic, generating outgoing
 network traffic and handling any expired timeout events. Most other I/O
 functions on an SSL object, such as L<SSL_read(3)> and L<SSL_write(3)>
-implicitly perform ticking of the SSL object, so calling this function is only
-needed if no other I/O function is to be called.
+implicitly perform event handling on the SSL object, so calling this function is
+only needed if no other I/O function is to be called.
 
 This can also be used with DTLS and supersedes L<DTLSv1_handle_timeout(3)> for
 new usage.
@@ -535,8 +535,8 @@ These functions facilitate operation in nonblocking mode.
 When an SSL object is being used with an underlying network read BIO which
 supports polling, L<SSL_get_rpoll_descriptor(3)> outputs an OS resource which
 can be used to synchronise on network readability events which should result in
-a call to L<SSL_tick(3)>. L<SSL_get_wpoll_descriptor(3)> works in an analogous
-fashion for the underlying network write BIO.
+a call to L<SSL_handle_events(3)>. L<SSL_get_wpoll_descriptor(3)> works in an
+analogous fashion for the underlying network write BIO.
 
 The poll descriptors provided by these functions need only be used when
 L<SSL_net_read_desired(3)> and L<SSL_net_write_desired(3)> return 1, respectively.
@@ -770,7 +770,7 @@ synchronisation.
 It should call L<SSL_net_read_desired(3)> and L<SSL_net_write_desired(3)> to determine
 whether the QUIC implementation is currently interested in readability and
 writability events on the underlying network BIO which was provided, and call
-L<SSL_get_tick_timeout(3)> to determine if any timeout event will become
+L<SSL_get_event_timeout(3)> to determine if any timeout event will become
 applicable in the future.
 
 =item
@@ -791,11 +791,11 @@ The poll descriptor returned by L<SSL_get_wpoll_descriptor(3)> becomes writable
 
 =item
 
-The timeout returned by L<SSL_get_tick_timeout(3)> (if any) expires.
+The timeout returned by L<SSL_get_event_timeout(3)> (if any) expires.
 
 =back
 
-Once any of these events occurs, L<SSL_tick(3)> should be called.
+Once any of these events occurs, L<SSL_handle_events(3)> should be called.
 
 =back
 
@@ -803,31 +803,32 @@ Once any of these events occurs, L<SSL_tick(3)> should be called.
 
 If the network read and write BIOs provided were not pollable (for example, in
 the case of L<BIO_s_dgram_pair(3)>), the application is responsible for managing
-and synchronising network I/O. It should call L<SSL_tick(3)> after it writes
-data to a L<BIO_s_dgram_pair(3)> or otherwise takes action so that the QUIC
-implementation can read new datagrams via a call to L<BIO_recvmmsg(3)> on the
-underlying network BIO. The QUIC implementation may output datagrams via a call
-to L<BIO_sendmmsg(3)> and the application is responsible for ensuring these are
-transmitted.
+and synchronising network I/O. It should call L<SSL_handle_events(3)> after it
+writes data to a L<BIO_s_dgram_pair(3)> or otherwise takes action so that the
+QUIC implementation can read new datagrams via a call to L<BIO_recvmmsg(3)> on
+the underlying network BIO. The QUIC implementation may output datagrams via a
+call to L<BIO_sendmmsg(3)> and the application is responsible for ensuring these
+are transmitted.
 
-The application must call L<SSL_get_tick_timeout(3)> after every call to
-L<SSL_tick(3)> (or another I/O function on the SSL object), and ensure that a
-call to L<SSL_tick(3)> is performed after the specified timeout (if any).
+The application must call L<SSL_get_event_timeout(3)> after every call to
+L<SSL_handle_events(3)> (or another I/O function on the SSL object), and ensure
+that a call to L<SSL_handle_events(3)> is performed after the specified timeout
+(if any).
 
 =back
 
 =head1 SEE ALSO
 
-L<SSL_tick(3)>, L<SSL_get_tick_timeout(3)>, L<SSL_net_read_desired(3)>,
-L<SSL_net_write_desired(3)>, L<SSL_get_rpoll_descriptor(3)>,
-L<SSL_get_wpoll_descriptor(3)>, L<SSL_set_blocking_mode(3)>,
-L<SSL_shutdown_ex(3)>, L<SSL_set_initial_peer_addr(3)>,
-L<SSL_stream_conclude(3)>, L<SSL_stream_reset(3)>,
-L<SSL_get_stream_read_state(3)>, L<SSL_get_stream_read_error_code(3)>,
-L<SSL_get_conn_close_info(3)>, L<SSL_get0_connection(3)>,
-L<SSL_get_stream_type(3)>, L<SSL_get_stream_id(3)>, L<SSL_new_stream(3)>,
-L<SSL_accept_stream(3)>, L<SSL_set_incoming_stream_policy(3)>,
-L<SSL_set_default_stream_mode(3)>
+L<SSL_handle_events(3)>, L<SSL_get_event_timeout(3)>,
+L<SSL_net_read_desired(3)>, L<SSL_net_write_desired(3)>,
+L<SSL_get_rpoll_descriptor(3)>, L<SSL_get_wpoll_descriptor(3)>,
+L<SSL_set_blocking_mode(3)>, L<SSL_shutdown_ex(3)>,
+L<SSL_set_initial_peer_addr(3)>, L<SSL_stream_conclude(3)>,
+L<SSL_stream_reset(3)>, L<SSL_get_stream_read_state(3)>,
+L<SSL_get_stream_read_error_code(3)>, L<SSL_get_conn_close_info(3)>,
+L<SSL_get0_connection(3)>, L<SSL_get_stream_type(3)>, L<SSL_get_stream_id(3)>,
+L<SSL_new_stream(3)>, L<SSL_accept_stream(3)>,
+L<SSL_set_incoming_stream_policy(3)>, L<SSL_set_default_stream_mode(3)>
 
 =head1 COPYRIGHT
 

--- a/include/internal/quic_ssl.h
+++ b/include/internal/quic_ssl.h
@@ -45,9 +45,9 @@ void ossl_quic_set_connect_state(SSL *s);
 void ossl_quic_set_accept_state(SSL *s);
 
 __owur int ossl_quic_has_pending(const SSL *s);
-__owur int ossl_quic_tick(SSL *s);
-__owur int ossl_quic_get_tick_timeout(SSL *s, struct timeval *tv);
-OSSL_TIME ossl_quic_get_tick_deadline(SSL *s);
+__owur int ossl_quic_handle_events(SSL *s);
+__owur int ossl_quic_get_event_timeout(SSL *s, struct timeval *tv);
+OSSL_TIME ossl_quic_get_event_deadline(SSL *s);
 __owur int ossl_quic_get_rpoll_descriptor(SSL *s, BIO_POLL_DESCRIPTOR *d);
 __owur int ossl_quic_get_wpoll_descriptor(SSL *s, BIO_POLL_DESCRIPTOR *d);
 __owur int ossl_quic_get_net_read_desired(SSL *s);

--- a/include/internal/quic_ssl.h
+++ b/include/internal/quic_ssl.h
@@ -46,7 +46,8 @@ void ossl_quic_set_accept_state(SSL *s);
 
 __owur int ossl_quic_has_pending(const SSL *s);
 __owur int ossl_quic_handle_events(SSL *s);
-__owur int ossl_quic_get_event_timeout(SSL *s, struct timeval *tv);
+__owur int ossl_quic_get_event_timeout(SSL *s, struct timeval *tv,
+                                       int *is_infinite);
 OSSL_TIME ossl_quic_get_event_deadline(SSL *s);
 __owur int ossl_quic_get_rpoll_descriptor(SSL *s, BIO_POLL_DESCRIPTOR *d);
 __owur int ossl_quic_get_wpoll_descriptor(SSL *s, BIO_POLL_DESCRIPTOR *d);

--- a/include/openssl/ssl.h.in
+++ b/include/openssl/ssl.h.in
@@ -2257,8 +2257,8 @@ int SSL_CTX_set_num_tickets(SSL_CTX *ctx, size_t num_tickets);
 size_t SSL_CTX_get_num_tickets(const SSL_CTX *ctx);
 
 /* QUIC support */
-int SSL_tick(SSL *s);
-__owur int SSL_get_tick_timeout(SSL *s, struct timeval *tv);
+int SSL_handle_events(SSL *s);
+__owur int SSL_get_event_timeout(SSL *s, struct timeval *tv);
 __owur int SSL_get_rpoll_descriptor(SSL *s, BIO_POLL_DESCRIPTOR *desc);
 __owur int SSL_get_wpoll_descriptor(SSL *s, BIO_POLL_DESCRIPTOR *desc);
 __owur int SSL_net_read_desired(SSL *s);

--- a/include/openssl/ssl.h.in
+++ b/include/openssl/ssl.h.in
@@ -2258,7 +2258,7 @@ size_t SSL_CTX_get_num_tickets(const SSL_CTX *ctx);
 
 /* QUIC support */
 int SSL_handle_events(SSL *s);
-__owur int SSL_get_event_timeout(SSL *s, struct timeval *tv);
+__owur int SSL_get_event_timeout(SSL *s, struct timeval *tv, int *is_infinite);
 __owur int SSL_get_rpoll_descriptor(SSL *s, BIO_POLL_DESCRIPTOR *desc);
 __owur int SSL_get_wpoll_descriptor(SSL *s, BIO_POLL_DESCRIPTOR *desc);
 __owur int SSL_net_read_desired(SSL *s);

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -1057,6 +1057,18 @@ long ossl_quic_ctrl(SSL *s, int cmd, long larg, void *parg)
         /* This ctrl also needs to be passed to the internal SSL object */
         return SSL_ctrl(ctx.qc->tls, cmd, larg, parg);
 
+    case DTLS_CTRL_GET_TIMEOUT: /* DTLSv1_get_timeout */
+        {
+            int is_infinite;
+
+            if (!ossl_quic_get_event_timeout(s, parg, &is_infinite))
+                return 0;
+
+            return !is_infinite;
+        }
+    case DTLS_CTRL_HANDLE_TIMEOUT: /* DTLSv1_handle_timeout */
+        /* For legacy compatibility with DTLS calls. */
+        return ossl_quic_handle_events(s) == 1 ? 1 : -1;
     default:
         /* Probably a TLS related ctrl. Defer to our internal SSL object */
         return SSL_ctrl(ctx.qc->tls, cmd, larg, parg);

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -839,7 +839,7 @@ static int xso_blocking_mode(const QUIC_XSO *xso)
         && xso->conn->can_poll_net_wbio;
 }
 
-/* SSL_handle_events; handles events by ticking the reactor. */
+/* SSL_handle_events; performs QUIC I/O and timeout processing. */
 QUIC_TAKES_LOCK
 int ossl_quic_handle_events(SSL *s)
 {
@@ -856,9 +856,10 @@ int ossl_quic_handle_events(SSL *s)
 
 /*
  * SSL_get_event_timeout. Get the time in milliseconds until the SSL object
- * should be ticked by the application by calling SSL_handle_events(). tv is set
- * to 0 if the object should be ticked immediately. If no timeout is currently
- * active, *is_infinite is set to 1 and the value of *tv is undefined.
+ * should next have events handled by the application by calling
+ * SSL_handle_events(). tv is set to 0 if the object should have events handled
+ * immediately. If no timeout is currently active, *is_infinite is set to 1 and
+ * the value of *tv is undefined.
  */
 QUIC_TAKES_LOCK
 int ossl_quic_get_event_timeout(SSL *s, struct timeval *tv, int *is_infinite)

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -820,8 +820,8 @@ int ossl_quic_conn_set_initial_peer_addr(SSL *s,
  * QUIC Front-End I/O API: Asynchronous I/O Management
  * ===================================================
  *
- *   (BIO/)SSL_tick                 => ossl_quic_tick
- *   (BIO/)SSL_get_tick_timeout     => ossl_quic_get_tick_timeout
+ *   (BIO/)SSL_handle_events        => ossl_quic_handle_events
+ *   (BIO/)SSL_get_event_timeout    => ossl_quic_get_event_timeout
  *   (BIO/)SSL_get_poll_fd          => ossl_quic_get_poll_fd
  *
  */
@@ -839,9 +839,9 @@ static int xso_blocking_mode(const QUIC_XSO *xso)
         && xso->conn->can_poll_net_wbio;
 }
 
-/* SSL_tick; ticks the reactor. */
+/* SSL_handle_events; handles events by ticking the reactor. */
 QUIC_TAKES_LOCK
-int ossl_quic_tick(SSL *s)
+int ossl_quic_handle_events(SSL *s)
 {
     QCTX ctx;
 
@@ -855,13 +855,13 @@ int ossl_quic_tick(SSL *s)
 }
 
 /*
- * SSL_get_tick_timeout. Get the time in milliseconds until the SSL object
- * should be ticked by the application by calling SSL_tick(). tv is set to 0 if
- * the object should be ticked immediately and tv->tv_sec is set to -1 if no
- * timeout is currently active.
+ * SSL_get_event_timeout. Get the time in milliseconds until the SSL object
+ * should be ticked by the application by calling SSL_handle_events(). tv is set
+ * to 0 if the object should be ticked immediately and tv->tv_sec is set to -1
+ * if no timeout is currently active.
  */
 QUIC_TAKES_LOCK
-int ossl_quic_get_tick_timeout(SSL *s, struct timeval *tv)
+int ossl_quic_get_event_timeout(SSL *s, struct timeval *tv)
 {
     QCTX ctx;
     OSSL_TIME deadline = ossl_time_infinite();

--- a/ssl/quic/quic_reactor.c
+++ b/ssl/quic/quic_reactor.c
@@ -347,8 +347,9 @@ int ossl_quic_reactor_block_until_pred(QUIC_REACTOR *rtor,
              * the poll call. However this might be difficult because it
              * requires we do the call to poll(2) or equivalent syscall
              * ourselves, whereas in the general case the application does the
-             * polling and just calls SSL_tick(). Implementing this optimisation
-             * in the future will probably therefore require API changes.
+             * polling and just calls SSL_handle_events(). Implementing this
+             * optimisation in the future will probably therefore require API
+             * changes.
              */
             return 0;
     }

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -7148,22 +7148,25 @@ int SSL_handle_events(SSL *s)
     return 1;
 }
 
-int SSL_get_event_timeout(SSL *s, struct timeval *tv)
+int SSL_get_event_timeout(SSL *s, struct timeval *tv, int *is_infinite)
 {
     SSL_CONNECTION *sc;
 
 #ifndef OPENSSL_NO_QUIC
     if (IS_QUIC(s))
-        return ossl_quic_get_event_timeout(s, tv);
+        return ossl_quic_get_event_timeout(s, tv, is_infinite);
 #endif
 
     sc = SSL_CONNECTION_FROM_SSL_ONLY(s);
     if (sc != NULL && SSL_CONNECTION_IS_DTLS(sc)
-        && DTLSv1_get_timeout(s, tv))
+        && DTLSv1_get_timeout(s, tv)) {
+        *is_infinite = 0;
         return 1;
+    }
 
-    tv->tv_sec  = -1;
+    tv->tv_sec  = 1000000;
     tv->tv_usec = 0;
+    *is_infinite = 1;
     return 1;
 }
 

--- a/ssl/ssl_lib.c
+++ b/ssl/ssl_lib.c
@@ -7124,13 +7124,13 @@ int SSL_CTX_set0_tmp_dh_pkey(SSL_CTX *ctx, EVP_PKEY *dhpkey)
 }
 
 /* QUIC-specific methods which are supported on QUIC connections only. */
-int SSL_tick(SSL *s)
+int SSL_handle_events(SSL *s)
 {
     SSL_CONNECTION *sc;
 
 #ifndef OPENSSL_NO_QUIC
     if (IS_QUIC(s))
-        return ossl_quic_tick(s);
+        return ossl_quic_handle_events(s);
 #endif
 
     sc = SSL_CONNECTION_FROM_SSL_ONLY(s);
@@ -7148,13 +7148,13 @@ int SSL_tick(SSL *s)
     return 1;
 }
 
-int SSL_get_tick_timeout(SSL *s, struct timeval *tv)
+int SSL_get_event_timeout(SSL *s, struct timeval *tv)
 {
     SSL_CONNECTION *sc;
 
 #ifndef OPENSSL_NO_QUIC
     if (IS_QUIC(s))
-        return ossl_quic_get_tick_timeout(s, tv);
+        return ossl_quic_get_event_timeout(s, tv);
 #endif
 
     sc = SSL_CONNECTION_FROM_SSL_ONLY(s);

--- a/test/helpers/quictestlib.c
+++ b/test/helpers/quictestlib.c
@@ -268,7 +268,7 @@ int qtest_create_quic_connection(QUIC_TSERVER *qtserv, SSL *clientssl)
          * be done in a real application.
          */
         if (!clienterr && retc <= 0)
-            SSL_tick(clientssl);
+            SSL_handle_events(clientssl);
         if (!servererr && rets <= 0) {
             ossl_quic_tserver_tick(qtserv);
             servererr = ossl_quic_tserver_is_term_any(qtserv);

--- a/test/quic_client_test.c
+++ b/test/quic_client_test.c
@@ -148,7 +148,7 @@ static int test_quic_client(void)
          * blocking but this is just a test.
          */
         OSSL_sleep(0);
-        SSL_tick(c_ssl);
+        SSL_handle_events(c_ssl);
     }
 
     testresult = 1;

--- a/test/quic_multistream_test.c
+++ b/test/quic_multistream_test.c
@@ -632,7 +632,7 @@ static int run_script_worker(struct helper *h, const struct script_op *script,
             ossl_quic_tserver_tick(h->s);
 
         if (thread_idx >= 0 || connect_started)
-            SSL_tick(h->c_conn);
+            SSL_handle_events(h->c_conn);
 
         if (thread_idx >= 0) {
             /* Only allow certain opcodes on child threads. */

--- a/test/quic_newcid_test.c
+++ b/test/quic_newcid_test.c
@@ -112,7 +112,7 @@ static int test_ncid_frame(int fail)
         goto err;
 
     ossl_quic_tserver_tick(qtserv);
-    if (!TEST_true(SSL_tick(cssl)))
+    if (!TEST_true(SSL_handle_events(cssl)))
         goto err;
 
     if (!TEST_int_eq(SSL_read(cssl, buf, sizeof(buf)), msglen))

--- a/test/quic_tserver_test.c
+++ b/test/quic_tserver_test.c
@@ -333,7 +333,7 @@ static int do_test(int use_thread_assist, int use_fake_time, int use_inject)
          */
         if (!c_start_idle_test || c_done_idle_test) {
             /* Inhibit manual ticking during idle test to test TA mode. */
-            SSL_tick(c_ssl);
+            SSL_handle_events(c_ssl);
         }
 
         ossl_quic_tserver_tick(tserver);

--- a/test/quicapitest.c
+++ b/test/quicapitest.c
@@ -91,7 +91,7 @@ static int test_quic_write_read(int idx)
                                                msglen, &numbytes)))
             goto end;
         ossl_quic_tserver_tick(qtserv);
-        SSL_tick(clientquic);
+        SSL_handle_events(clientquic);
         /*
          * In blocking mode the SSL_read_ex call will block until the socket is
          * readable and has our data. In non-blocking mode we're doing everything

--- a/test/quicfaultstest.c
+++ b/test/quicfaultstest.c
@@ -132,7 +132,7 @@ static int test_unknown_frame(void)
         goto err;
 
     ossl_quic_tserver_tick(qtserv);
-    if (!TEST_true(SSL_tick(cssl)))
+    if (!TEST_true(SSL_handle_events(cssl)))
         goto err;
 
     if (!TEST_int_le(ret = SSL_read(cssl, buf, sizeof(buf)), 0))
@@ -145,10 +145,10 @@ static int test_unknown_frame(void)
     /*
      * TODO(QUIC): We should expect an error on the queue after this - but we
      * don't have it yet.
-     * Note, just raising the error in the obvious place causes SSL_tick() to
-     * succeed, but leave a suprious error on the stack. We need to either
-     * allow SSL_tick() to fail, or somehow delay the raising of the error
-     * until the SSL_read() call.
+     * Note, just raising the error in the obvious place causes
+     * SSL_handle_events() to succeed, but leave a suprious error on the stack.
+     * We need to either allow SSL_handle_events() to fail, or somehow delay the
+     * raising of the error until the SSL_read() call.
      */
     if (!TEST_int_eq(ERR_GET_REASON(ERR_peek_error()),
                      SSL_R_UNKNOWN_FRAME_TYPE_RECEIVED))
@@ -339,7 +339,7 @@ static int test_corrupted_data(int idx)
      * "lost". We also process the second packet which should be decrypted
      * successfully. Therefore we ack the frames in it
      */
-    if (!TEST_true(SSL_tick(cssl)))
+    if (!TEST_true(SSL_handle_events(cssl)))
         goto err;
 
     /*
@@ -349,7 +349,7 @@ static int test_corrupted_data(int idx)
     ossl_quic_tserver_tick(qtserv);
 
     /* Receive and process the newly arrived message data resend */
-    if (!TEST_true(SSL_tick(cssl)))
+    if (!TEST_true(SSL_handle_events(cssl)))
         goto err;
 
     /* The whole message should now have arrived */

--- a/util/libssl.num
+++ b/util/libssl.num
@@ -532,8 +532,6 @@ SSL_CTX_set1_compressed_cert            ?	3_2_0	EXIST::FUNCTION:
 SSL_set1_compressed_cert                ?	3_2_0	EXIST::FUNCTION:
 SSL_CTX_get1_compressed_cert            ?	3_2_0	EXIST::FUNCTION:
 SSL_get1_compressed_cert                ?	3_2_0	EXIST::FUNCTION:
-SSL_tick                                ?	3_2_0	EXIST::FUNCTION:
-SSL_get_tick_timeout                    ?	3_2_0	EXIST::FUNCTION:
 SSL_get_rpoll_descriptor                ?	3_2_0	EXIST::FUNCTION:
 SSL_get_wpoll_descriptor                ?	3_2_0	EXIST::FUNCTION:
 SSL_set_blocking_mode                   ?	3_2_0	EXIST::FUNCTION:
@@ -575,3 +573,5 @@ SSL_get_stream_read_error_code          ?	3_2_0	EXIST::FUNCTION:
 SSL_get_stream_write_error_code         ?	3_2_0	EXIST::FUNCTION:
 SSL_get_conn_close_info                 ?	3_2_0	EXIST::FUNCTION:
 SSL_set_incoming_stream_policy          ?	3_2_0	EXIST::FUNCTION:
+SSL_handle_events                       ?	3_2_0	EXIST::FUNCTION:
+SSL_get_event_timeout                   ?	3_2_0	EXIST::FUNCTION:


### PR DESCRIPTION
Built on top of MSMT PR.

```
9a3f93ddfb QUIC: Update documentation to reflect compatibility of DTLS APIs
12e12b4ec4 QUIC APL: Allow DTLSv1 APIs to be used for compatibility
3d1142a376 QUIC: Update documentation for SSL_get_event_timeout
5dfa5ae60e QUIC APL: Change SSL_get_event_timeout API design
b4976d91bb QUIC: Rename SSL_tick, SSL_get_tick_timeout
8ec61607a8 QUIC Documentation: Rename SSL_tick, SSL_get_tick_timeout
```

Fixes #20867, #20868.