### PR TITLE
fix bug with `armv7_tick` probing

### DIFF
--- a/crypto/armcap.c
+++ b/crypto/armcap.c
@@ -237,11 +237,11 @@ void OPENSSL_cpuid_setup(void)
     }
 # endif
 
-    /* Things that getauxval didn't tell us */
-    if (sigsetjmp(ill_jmp, 1) == 0) {
-        _armv7_tick();
-        OPENSSL_armcap_P |= ARMV7_TICK;
-    }
+    /*
+     * Probing for ARMV7_TICK is known to produce unreliable results,
+     * so we will only use the feature when the user explicitly enables
+     * it with OPENSSL_armcap.
+     */
 
     sigaction(SIGILL, &ill_oact, NULL);
     sigprocmask(SIG_SETMASK, &oset, NULL);


### PR DESCRIPTION
Should fix 
- https://github.com/openssl/openssl/issues/14838
- https://github.com/openssl/openssl/issues/17465

This is a backport of an OpenSSL 3.x fix https://github.com/openssl/openssl/commit/6c3728c72a8263a201352f6d118f9fc94bdbc6fb

I currently have this issue on a Samsung Galaxy A6 (model `SM-A600FN`), equipped with a big.LITTLE CPU.
