### PR TITLE
Fix stack corruption in ui_read

### DIFF
--- a/crypto/evp/evp_key.c
+++ b/crypto/evp/evp_key.c
@@ -55,12 +55,16 @@ int EVP_read_pw_string_min(char *buf, int min, int len, const char *prompt,
     int ret = -1;
     char buff[BUFSIZ];
     UI *ui;
+    const UI_METHOD *ui_method = NULL;
 
     if ((prompt == NULL) && (prompt_string[0] != '\0'))
         prompt = prompt_string;
     ui = UI_new();
     if (ui == NULL)
         return ret;
+    ui_method = UI_get_method(ui);
+    if (ui_method == NULL || ui_method == UI_null())
+        goto end;
     if (UI_add_input_string(ui, prompt, 0, buf, min,
                             (len >= BUFSIZ) ? BUFSIZ - 1 : len) < 0
         || (verify

--- a/crypto/pem/pem_lib.c
+++ b/crypto/pem/pem_lib.c
@@ -63,7 +63,7 @@ int PEM_def_callback(char *buf, int num, int rwflag, void *userdata)
         memset(buf, 0, (unsigned int)num);
         return -1;
     }
-    return strlen(buf);
+    return OPENSSL_strnlen(buf, (size_t)num);
 }
 
 void PEM_proc_type(char *buf, int type)

--- a/crypto/ui/ui_util.c
+++ b/crypto/ui/ui_util.c
@@ -107,7 +107,7 @@ static int ui_read(UI *ui, UI_STRING *uis)
     switch (UI_get_string_type(uis)) {
     case UIT_PROMPT:
         {
-            char result[PEM_BUFSIZE + 1];
+            char result[PEM_BUFSIZE + 1] = { 0, };
             const struct pem_password_cb_data *data =
                 UI_method_get_ex_data(UI_get_method(ui), ui_method_data_index);
             int maxsize = UI_get_result_maxsize(uis);

--- a/test/evp_extra_test2.c
+++ b/test/evp_extra_test2.c
@@ -23,6 +23,7 @@
 #include <openssl/rsa.h>
 #include <openssl/dh.h>
 #include <openssl/core_names.h>
+#include <openssl/ui.h>
 
 #include "testutil.h"
 #include "internal/nelem.h"
@@ -753,6 +754,52 @@ static int test_PEM_read_bio_negative(int testid)
     return ok;
 }
 
+static int test_PEM_read_bio_negative_wrong_password(int testid)
+{
+    int ok = 0;
+    OSSL_PROVIDER *provider = OSSL_PROVIDER_load(NULL, "default");
+    EVP_PKEY *read_pkey = NULL;
+    EVP_PKEY *write_pkey = EVP_RSA_gen(1024);
+    BIO *key_bio = BIO_new(BIO_s_mem());
+    const UI_METHOD *undo_ui_method = NULL;
+    const UI_METHOD *ui_method = NULL;
+    if (testid > 0)
+        ui_method = UI_null();
+
+    if (!TEST_ptr(provider))
+        goto err;
+    if (!TEST_ptr(key_bio))
+        goto err;
+    if (!TEST_ptr(write_pkey))
+        goto err;
+    undo_ui_method = UI_get_default_method();
+    UI_set_default_method(ui_method);
+
+    if (/* Output Encrypted private key in PEM form */
+        !TEST_true(PEM_write_bio_PrivateKey(key_bio, write_pkey, EVP_aes_256_cbc(),
+                                           NULL, 0, NULL, "pass")))
+        goto err;
+
+    ERR_clear_error();
+    read_pkey = PEM_read_bio_PrivateKey(key_bio, NULL, NULL, NULL);
+    if (!TEST_ptr_null(read_pkey))
+        goto err;
+
+    if (!TEST_int_eq(ERR_GET_REASON(ERR_get_error()), PEM_R_PROBLEMS_GETTING_PASSWORD))
+        goto err;
+    ok = 1;
+
+ err:
+    test_openssl_errors();
+    EVP_PKEY_free(read_pkey);
+    EVP_PKEY_free(write_pkey);
+    BIO_free(key_bio);
+    OSSL_PROVIDER_unload(provider);
+    UI_set_default_method(undo_ui_method);
+
+    return ok;
+}
+
 static int do_fromdata_key_is_equal(const OSSL_PARAM params[],
                                     const EVP_PKEY *expected, const char *type)
 {
@@ -1313,6 +1360,7 @@ int setup_tests(void)
     ADD_TEST(test_pkcs8key_nid_bio);
 #endif
     ADD_ALL_TESTS(test_PEM_read_bio_negative, OSSL_NELEM(keydata));
+    ADD_ALL_TESTS(test_PEM_read_bio_negative_wrong_password, 2);
     ADD_TEST(test_rsa_pss_sign);
     ADD_TEST(test_evp_md_ctx_dup);
     ADD_TEST(test_evp_md_ctx_copy);


### PR DESCRIPTION
There is a possible stack corruption in case, when data->cb() returns len > 1024
I've faced it on windows x64 build.
I suppose, it is possible on others platforms.

Sequence:
1) ui_read creates buffer, doesn't call memset()
2) data->cb() calls PEM_def_callback()
3) PEM_def_callback() calls EVP_read_pw_string_min(), which doesn't fill buffer with any data.
4) PEM_def_callback() returns strlen() of uninitialized buffer (without null terminator). It is dangerous and can lead to the crash. Or it can return invalid size, which will be greater than buffer size.
5) In ui_read we tries to add a null terminator to the data out of our buffer.

Decided to initialize buffer in ui_read() and replace dangerous strlen with OPENSSL_strnlen().

I'm not such familiar with code, maybe EVP_read_pw_string_min should be updated, because EVP_read_pw_string_min returns 0, but doesn't set any data to the input buffer.
If someone point me to the better fix, I will appreciate.

Code to reproduce this issue
```

    std::string filename = "test.pem";
    std::string password = "password";
    {
        std::unique_ptr<EVP_PKEY, decltype(&::EVP_PKEY_free)> key(EVP_RSA_gen(2048), ::EVP_PKEY_free);

        std::unique_ptr<BIO, decltype(&::BIO_free)> out(BIO_new(BIO_s_file()), ::BIO_free);
        if (out != nullptr) {
            if (BIO_write_filename(out.get(), const_cast<char*>(filename.c_str())) > 0) {
                int size = PEM_write_bio_PrivateKey(out.get(), key.get(), EVP_aes_256_cbc(), nullptr, 0,
                    nullptr, const_cast<char*>(password.data()));
                std::cout << size << std::endl;
            }
        }
    }
    {
        // read with null password
        std::unique_ptr<BIO, decltype(&::BIO_free)> in(BIO_new(BIO_s_file()), ::BIO_free);
        if (in != nullptr) {
            if (BIO_read_filename(in.get(), filename.c_str()) > 0) {
                EVP_PKEY* pkey = PEM_read_bio_PrivateKey(in.get(), nullptr, nullptr, nullptr);
                std::cout << (pkey == nullptr) << std::endl;
            }
        }
    }
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
