### PR TITLE
restrict rsaBITS algorithm name check in speed

### DIFF
--- a/apps/speed.c
+++ b/apps/speed.c
@@ -3576,8 +3576,8 @@ skip_hmac:
             }
 
             if (kem_type == KEM_RSA) {
-                params[0] = OSSL_PARAM_construct_size_t(OSSL_PKEY_PARAM_RSA_BITS,
-                                                        (size_t *)&bits);
+                params[0] = OSSL_PARAM_construct_uint(OSSL_PKEY_PARAM_RSA_BITS,
+                                                      &bits);
                 use_params = 1;
             } else if (kem_type == KEM_EC) {
                 name = (char *)(kem_name + 2);
@@ -3757,8 +3757,8 @@ skip_hmac:
             /* no string after rsa<bitcnt> permitted: */
             if (strlen(sig_name) < MAX_ALGNAME_SUFFIX + 4 /* rsa+digit */
                 && sscanf(sig_name, "rsa%u%s", &bits, sfx) == 1) {
-                params[0] = OSSL_PARAM_construct_size_t(OSSL_PKEY_PARAM_RSA_BITS,
-                                                        (size_t *)&bits);
+                params[0] = OSSL_PARAM_construct_uint(OSSL_PKEY_PARAM_RSA_BITS,
+                                                      &bits);
                 use_params = 1;
             }
 

--- a/apps/speed.c
+++ b/apps/speed.c
@@ -3555,6 +3555,7 @@ skip_hmac:
             int use_params = 0;
             enum kem_type_t { KEM_RSA = 1, KEM_EC, KEM_X25519, KEM_X448 } kem_type;
 
+            /* no string after rsa<bitcnt> permitted: */
             if (sscanf(kem_name, "rsa%u%s", &bits, sfx) == 1)
                 kem_type = KEM_RSA;
             else if (strncmp(kem_name, "EC", 2) == 0)
@@ -3750,6 +3751,7 @@ skip_hmac:
                 ERR_print_errors(bio_err);
             }
 
+            /* no string after rsa<bitcnt> permitted: */
             if (sscanf(sig_name, "rsa%u%s", &bits, sfx) == 1) {
                 params[0] = OSSL_PARAM_construct_size_t(OSSL_PKEY_PARAM_RSA_BITS,
                                                         (size_t *)&bits);

--- a/apps/speed.c
+++ b/apps/speed.c
@@ -3548,14 +3548,14 @@ skip_hmac:
             size_t send_secret_len, out_len;
             size_t rcv_secret_len;
             unsigned char *out = NULL, *send_secret = NULL, *rcv_secret;
-            size_t bits;
+            unsigned int bits;
             char *name;
             char sfx[100];
             OSSL_PARAM params[] = { OSSL_PARAM_END, OSSL_PARAM_END };
             int use_params = 0;
             enum kem_type_t { KEM_RSA = 1, KEM_EC, KEM_X25519, KEM_X448 } kem_type;
 
-            if (sscanf(kem_name, "rsa%ld%s", &bits, sfx) == 1)
+            if (sscanf(kem_name, "rsa%u%s", &bits, sfx) == 1)
                 kem_type = KEM_RSA;
             else if (strncmp(kem_name, "EC", 2) == 0)
                 kem_type = KEM_EC;
@@ -3573,7 +3573,7 @@ skip_hmac:
 
             if (kem_type == KEM_RSA) {
                 params[0] = OSSL_PARAM_construct_size_t(OSSL_PKEY_PARAM_RSA_BITS,
-                                                        &bits);
+                                                        (size_t *)&bits);
                 use_params = 1;
             } else if (kem_type == KEM_EC) {
                 name = (char *)(kem_name + 2);
@@ -3737,7 +3737,7 @@ skip_hmac:
             char sfx[100];
             size_t md_len = SHA256_DIGEST_LENGTH;
             size_t max_sig_len, sig_len;
-            size_t bits;
+            unsigned int bits;
             OSSL_PARAM params[] = { OSSL_PARAM_END, OSSL_PARAM_END };
             int use_params = 0;
 
@@ -3750,9 +3750,9 @@ skip_hmac:
                 ERR_print_errors(bio_err);
             }
 
-            if (sscanf(sig_name, "rsa%ld%s", &bits, sfx) == 1) {
+            if (sscanf(sig_name, "rsa%u%s", &bits, sfx) == 1) {
                 params[0] = OSSL_PARAM_construct_size_t(OSSL_PKEY_PARAM_RSA_BITS,
-                                                        &bits);
+                                                        (size_t *)&bits);
                 use_params = 1;
             }
 

--- a/apps/speed.c
+++ b/apps/speed.c
@@ -3550,11 +3550,12 @@ skip_hmac:
             unsigned char *out = NULL, *send_secret = NULL, *rcv_secret;
             size_t bits;
             char *name;
+            char sfx[100];
             OSSL_PARAM params[] = { OSSL_PARAM_END, OSSL_PARAM_END };
             int use_params = 0;
             enum kem_type_t { KEM_RSA = 1, KEM_EC, KEM_X25519, KEM_X448 } kem_type;
 
-            if (strncmp(kem_name, "rsa", 3) == 0)
+            if (sscanf(kem_name, "rsa%ld%s", &bits, sfx) == 1)
                 kem_type = KEM_RSA;
             else if (strncmp(kem_name, "EC", 2) == 0)
                 kem_type = KEM_EC;
@@ -3571,7 +3572,6 @@ skip_hmac:
             }
 
             if (kem_type == KEM_RSA) {
-                bits = atoi(kem_name + 3);
                 params[0] = OSSL_PARAM_construct_size_t(OSSL_PKEY_PARAM_RSA_BITS,
                                                         &bits);
                 use_params = 1;
@@ -3734,6 +3734,7 @@ skip_hmac:
             EVP_PKEY_CTX *sig_verify_ctx = NULL;
             unsigned char md[SHA256_DIGEST_LENGTH];
             unsigned char *sig;
+            char sfx[100];
             size_t md_len = SHA256_DIGEST_LENGTH;
             size_t max_sig_len, sig_len;
             size_t bits;
@@ -3749,8 +3750,7 @@ skip_hmac:
                 ERR_print_errors(bio_err);
             }
 
-            if (strncmp(sig_name, "rsa", 3) == 0) {
-                bits = atoi(sig_name + 3);
+            if (sscanf(sig_name, "rsa%ld%s", &bits, sfx) == 1) {
                 params[0] = OSSL_PARAM_construct_size_t(OSSL_PKEY_PARAM_RSA_BITS,
                                                         &bits);
                 use_params = 1;
@@ -3774,7 +3774,7 @@ skip_hmac:
 
             if (sig_gen_ctx == NULL)
                 sig_gen_ctx = EVP_PKEY_CTX_new_from_name(app_get0_libctx(),
-                                      (strncmp(sig_name, "rsa", 3) == 0) ? "RSA" : sig_name,
+                                      use_params == 1 ? "RSA" : sig_name,
                                       app_get0_propq());
 
             if (!sig_gen_ctx || EVP_PKEY_keygen_init(sig_gen_ctx) <= 0
@@ -3796,7 +3796,7 @@ skip_hmac:
                                                       app_get0_propq());
             if (sig_sign_ctx == NULL
                 || EVP_PKEY_sign_init(sig_sign_ctx) <= 0
-                || (strncmp(sig_name, "rsa", 3) == 0
+                || (use_params == 1
                     && (EVP_PKEY_CTX_set_rsa_padding(sig_sign_ctx,
                                                      RSA_PKCS1_PADDING) <= 0))
                 || EVP_PKEY_sign(sig_sign_ctx, NULL, &max_sig_len,
@@ -3822,7 +3822,7 @@ skip_hmac:
                                                         app_get0_propq());
             if (sig_verify_ctx == NULL
                 || EVP_PKEY_verify_init(sig_verify_ctx) <= 0
-                || (strncmp(sig_name, "rsa", 3) == 0
+                || (use_params == 1
                   && (EVP_PKEY_CTX_set_rsa_padding(sig_verify_ctx,
                                                    RSA_PKCS1_PADDING) <= 0))) {
                 BIO_printf(bio_err,

--- a/apps/speed.c
+++ b/apps/speed.c
@@ -22,6 +22,8 @@
 #define KEM_SECONDS     PKEY_SECONDS
 #define SIG_SECONDS     PKEY_SECONDS
 
+#define MAX_ALGNAME_SUFFIX 100
+
 /* We need to use some deprecated APIs */
 #define OPENSSL_SUPPRESS_DEPRECATED
 
@@ -3550,13 +3552,14 @@ skip_hmac:
             unsigned char *out = NULL, *send_secret = NULL, *rcv_secret;
             unsigned int bits;
             char *name;
-            char sfx[100];
+            char sfx[MAX_ALGNAME_SUFFIX];
             OSSL_PARAM params[] = { OSSL_PARAM_END, OSSL_PARAM_END };
             int use_params = 0;
             enum kem_type_t { KEM_RSA = 1, KEM_EC, KEM_X25519, KEM_X448 } kem_type;
 
             /* no string after rsa<bitcnt> permitted: */
-            if (sscanf(kem_name, "rsa%u%s", &bits, sfx) == 1)
+            if (strlen(kem_name) < MAX_ALGNAME_SUFFIX + 4 /* rsa+digit */
+                && sscanf(kem_name, "rsa%u%s", &bits, sfx) == 1)
                 kem_type = KEM_RSA;
             else if (strncmp(kem_name, "EC", 2) == 0)
                 kem_type = KEM_EC;
@@ -3735,7 +3738,7 @@ skip_hmac:
             EVP_PKEY_CTX *sig_verify_ctx = NULL;
             unsigned char md[SHA256_DIGEST_LENGTH];
             unsigned char *sig;
-            char sfx[100];
+            char sfx[MAX_ALGNAME_SUFFIX];
             size_t md_len = SHA256_DIGEST_LENGTH;
             size_t max_sig_len, sig_len;
             unsigned int bits;
@@ -3752,7 +3755,8 @@ skip_hmac:
             }
 
             /* no string after rsa<bitcnt> permitted: */
-            if (sscanf(sig_name, "rsa%u%s", &bits, sfx) == 1) {
+            if (strlen(sig_name) < MAX_ALGNAME_SUFFIX + 4 /* rsa+digit */
+                && sscanf(sig_name, "rsa%u%s", &bits, sfx) == 1) {
                 params[0] = OSSL_PARAM_construct_size_t(OSSL_PKEY_PARAM_RSA_BITS,
                                                         (size_t *)&bits);
                 use_params = 1;


### PR DESCRIPTION
This PR ties down overly lax algorithm name checks in https://github.com/openssl/openssl/pull/19968 : Without this PR, algorithm names of classic/PQ hybrid algorithms like "rsa3072_dilithium2" would be incorrectly considered pure RSA algorithms.
