### PR TITLE
Add FIPS build instructions

### DIFF
--- a/README-FIPS.md
+++ b/README-FIPS.md
@@ -31,9 +31,13 @@ the `enable-fips` option.
 Installing the FIPS provider
 ============================
 
-You can build the OpenSSL source code with a validated FIPS provider by doing the
-following if you only use the FIPS validated source code. If you want to use a
-validated FIPS provider with the latest release see the next section.
+In order to be FIPS compliant you must only use FIPS validated source code.
+Refer to <https://www.openssl.org/source/> for information related to
+which versions are FIPS validated. The instructions given below build OpenSSL
+just using the FIPS validated source code.
+
+If you want to use a validated FIPS provider, but also want to use the latest
+OpenSSL release to build everything else, then refer to the next section.
 
 The following is only a guide.
 Please read the Security Policy for up to date installation instructions.
@@ -67,11 +71,11 @@ the installation by doing the following two things:
 
 - Runs the FIPS module self tests
 - Generates the so-called FIPS module configuration file containing information
-  about the module such as the self test status, and the module checksum.
+  about the module such as the module checksum (and for OpenSSL 3.0 the self test status).
 
 The FIPS module must have the self tests run, and the FIPS module config file
-output generated on every machine that it is to be used on. You must not copy
-the FIPS module config file output data from one machine to another.
+output generated on every machine that it is to be used on. For OpenSSL 3.0,
+you must not copy the FIPS module config file output data from one machine to another.
 
 On Unix, the `openssl fipsinstall` command will be invoked as follows by default:
 
@@ -79,7 +83,7 @@ On Unix, the `openssl fipsinstall` command will be invoked as follows by default
 
 If you configured OpenSSL to be installed to a different location, the paths will
 vary accordingly. In the rare case that you need to install the fipsmodule.cnf
-to non-standard location, you can execute the `openssl fipsinstall` command manually.
+to a non-standard location, you can execute the `openssl fipsinstall` command manually.
 
 Installing the FIPS provider and using it with the latest release
 =================================================================
@@ -87,7 +91,7 @@ Installing the FIPS provider and using it with the latest release
 This normally requires you to download 2 copies of the OpenSSL source code.
 
 Download and build a validated FIPS provider
---------------------------------------------------
+--------------------------------------------
 
 Refer to <https://www.openssl.org/source/> for information related to
 which versions are FIPS validated. For this example we use OpenSSL 3.0.0.
@@ -111,7 +115,7 @@ We use OpenSSL 3.1.0 here, (but you could also use the latest 3.0.X)
     $ make
 
 Use the OpenSSL FIPS provider for testing
----------------------------------------------
+-----------------------------------------
 
 We do this by replacing the artifact for the OpenSSL 3.1.0 FIPS provider.
 Note that the OpenSSL 3.1.0 FIPS provider has not been validated
@@ -119,6 +123,9 @@ so it must not be used for FIPS purposes.
 
     $ cp ../openssl-3.0.0/providers/fips.so providers/.
     $ cp ../openssl-3.0.0/providers/fipsmodule.cnf providers/.
+    // Note that for OpenSSL 3.0 that the `fipsmodule.cnf` file should not
+    // be copied across multiple machines if it contains an entry for
+    // `install-status`. (Otherwise the self tests would be skipped).
 
     // Validate the output of the following to make sure we are using the
     // OpenSSL 3.0.0 FIPS provider

--- a/README-FIPS.md
+++ b/README-FIPS.md
@@ -2,7 +2,7 @@ OpenSSL FIPS support
 ====================
 
 This release of OpenSSL includes a cryptographic module that can be
-FIPS 140-2 validated. The module is implemented as an OpenSSL provider.
+FIPS validated. The module is implemented as an OpenSSL provider.
 A provider is essentially a dynamically loadable module which implements
 cryptographic algorithms, see the [README-PROVIDERS](README-PROVIDERS.md) file
 for further details.
@@ -31,9 +31,9 @@ the `enable-fips` option.
 Installing the FIPS provider
 ============================
 
-You can build the OpenSSL source code and the FIPS provider by doing the following
-if you only use the FIPS validated source code. If you want to use a validated FIPS
-module with the latest release see the next section.
+You can build the OpenSSL source code with a validated FIPS provider by doing the
+following if you only use the FIPS validated source code. If you want to use a
+validated FIPS provider with the latest release see the next section.
 
 The following is only a guide.
 Please read the Security Policy for up to date installation instructions.
@@ -86,13 +86,11 @@ Installing the FIPS provider and using it with the latest release
 
 This normally requires you to download 2 copies of the OpenSSL source code.
 
-Download and build the (OpenSSL 3.0) FIPS provider
+Download and build a validated FIPS provider
 --------------------------------------------------
 
-OpenSSL 3.0 is the only source that is currently FIPS validated.
-If you use any other source currently it is NOT FIPS valid.
-Please refer to the security guide for guidance related to
-the OpenSSL 3.0  FIPS provider.
+Refer to <https://www.openssl.org/source/> for information related to
+which versions are FIPS validated. For this example we use OpenSSL 3.0.0.
 
     $ wget https://www.openssl.org/source/openssl-3.0.0.tar.gz
     $ tar -xf openssl-3.0.0.tar.gz
@@ -104,40 +102,40 @@ the OpenSSL 3.0  FIPS provider.
 Download and build the latest release of OpenSSL
 ------------------------------------------------
 
-We use OpenSSL 3.1 here, (but you could also use the latest 3.0.X)
+We use OpenSSL 3.1.0 here, (but you could also use the latest 3.0.X)
 
     $ wget https://www.openssl.org/source/openssl-3.1.0.tar.gz
     $ tar -xf openssl-3.1.0.tar.gz
     $ cd openssl-3.1.0
     $ ./Configure enable-fips
-    $ make -j 4
+    $ make
 
-Use the OpenSSL 3.0 FIPS provider for testing
+Use the OpenSSL FIPS provider for testing
 ---------------------------------------------
 
-We do this by replacing the artifact for the OpenSSL 3.1 FIPS provider.
-Note that the OpenSSL 3.1 FIPS provider has not been validated
+We do this by replacing the artifact for the OpenSSL 3.1.0 FIPS provider.
+Note that the OpenSSL 3.1.0 FIPS provider has not been validated
 so it must not be used for FIPS purposes.
 
     $ cp ../openssl-3.0.0/providers/fips.so providers/.
     $ cp ../openssl-3.0.0/providers/fipsmodule.cnf providers/.
 
     // Validate the output of the following to make sure we are using the
-    // OpenSSL 3.0 FIPS provider
+    // OpenSSL 3.0.0 FIPS provider
     $ ./util/wrap.pl -fips apps/openssl list -provider-path providers \
     -provider fips -providers
 
     // Now run the current tests using the OpenSSL 3.0 FIPS provider.
     $ make tests
 
-Copy the FIPS provider artifacts (fips.so & fipsmodule.cnf) to known locations
-------------------------------------------------------------------------------
+Copy the FIPS provider artifacts (`fips.so` & `fipsmodule.cnf`) to known locations
+-------------------------------------------------------------------------------------
 
     $ cd ../openssl-3.0.0
     $ sudo make install_fips
 
-Check that the FIPS provider is being used
-------------------------------------------
+Check that the correct FIPS provider is being used
+--------------------------------------------------
 
     $./util/wrap.pl -fips apps/openssl list -provider-path providers \
     -provider fips -providers

--- a/README-FIPS.md
+++ b/README-FIPS.md
@@ -71,7 +71,8 @@ the installation by doing the following two things:
 
 - Runs the FIPS module self tests
 - Generates the so-called FIPS module configuration file containing information
-  about the module such as the module checksum (and for OpenSSL 3.0 the self test status).
+  about the module such as the module checksum (and for OpenSSL 3.0 the
+  self test status).
 
 The FIPS module must have the self tests run, and the FIPS module config file
 output generated on every machine that it is to be used on. For OpenSSL 3.0,

--- a/doc/man7/fips_module.pod
+++ b/doc/man7/fips_module.pod
@@ -14,6 +14,9 @@ This guide details different ways that OpenSSL can be used in conjunction
 with the FIPS module. Which is the correct approach to use will depend on your
 own specific circumstances and what you are attempting to achieve.
 
+For information related to installing the FIPS module see
+L<https://github.com/openssl/openssl/blob/master/README-FIPS.md>.
+
 Note that the old functions FIPS_mode() and FIPS_mode_set() are no longer
 present so you must remove them from your application if you use them.
 


### PR DESCRIPTION
If you are building the latest release source code with enable-fips configured then the FIPS provider you are using is not likely to be FIPS compliant.

This update demonstrates how to build a FIPS provider that is compliant and use it with the latest source code.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [X] documentation is added or updated
- [ ] tests are added or updated
