### PR TITLE
Fix a typo found by codespell in a Makefile variable

### DIFF
--- a/Configurations/windows-makefile.tmpl
+++ b/Configurations/windows-makefile.tmpl
@@ -765,7 +765,7 @@ EOF
           my $generator;
           if ($gen0 =~ /\.pl$/) {
               $generator = '"$(PERL)"'.$gen_incs.' "'.$gen0.'"'.$gen_args
-                  .' "$(PERLASM_SCHEME)"'.$incs.' '.$cppflags.$defs.' $(PROCESSSOR)';
+                  .' "$(PERLASM_SCHEME)"'.$incs.' '.$cppflags.$defs.' $(PROCESSOR)';
           } elsif ($gen0 =~ /\.S$/) {
               $generator = undef;
           } else {


### PR DESCRIPTION
I have no experience with building on Windows, so I don't know the effect of fixing this typo. I guess that this will fix a bug at worst.

Extracted from https://github.com/openssl/openssl/pull/20910.

CLA: trivial

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
