### PR TITLE
Fix a typo found by codespell in a variable name

### DIFF
--- a/crypto/bn/bn_lib.c
+++ b/crypto/bn/bn_lib.c
@@ -426,11 +426,11 @@ int BN_set_word(BIGNUM *a, BN_ULONG w)
     return 1;
 }
 
-typedef enum {BIG, LITTLE} endianess_t;
+typedef enum {BIG, LITTLE} endianness_t;
 typedef enum {SIGNED, UNSIGNED} signedness_t;
 
 static BIGNUM *bin2bn(const unsigned char *s, int len, BIGNUM *ret,
-                      endianess_t endianess, signedness_t signedness)
+                      endianness_t endianness, signedness_t signedness)
 {
     int inc;
     const unsigned char *s2;
@@ -464,7 +464,7 @@ static BIGNUM *bin2bn(const unsigned char *s, int len, BIGNUM *ret,
      * significant BIGNUM chunk, so we adapt parameters to transfer
      * input bytes accordingly.
      */
-    if (endianess == LITTLE) {
+    if (endianness == LITTLE) {
         s2 = s + len - 1;
         inc2 = -1;
         inc = 1;
@@ -542,7 +542,7 @@ BIGNUM *BN_signed_bin2bn(const unsigned char *s, int len, BIGNUM *ret)
 }
 
 static int bn2binpad(const BIGNUM *a, unsigned char *to, int tolen,
-                     endianess_t endianess, signedness_t signedness)
+                     endianness_t endianness, signedness_t signedness)
 {
     int inc;
     int n, n8;
@@ -599,7 +599,7 @@ static int bn2binpad(const BIGNUM *a, unsigned char *to, int tolen,
      * to most significant BIGNUM limb, so we adapt parameters to
      * transfer output bytes accordingly.
      */
-    if (endianess == LITTLE) {
+    if (endianness == LITTLE) {
         inc = 1;
     } else {
         inc = -1;


### PR DESCRIPTION
The change is limited to a single C file.

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
