### PR TITLE
Avoid taking a write lock in ossl_provider_doall_activated()

### DIFF
--- a/crypto/provider_core.c
+++ b/crypto/provider_core.c
@@ -148,7 +148,7 @@ struct ossl_provider_st {
 
     /* OpenSSL library side data */
     CRYPTO_REF_COUNT refcnt;
-    CRYPTO_RWLOCK *refcnt_lock;  /* For the ref and activatecnt counters */
+    CRYPTO_RWLOCK *refcnt_lock;  /* For the refcnt and activatecnt counters */
     CRYPTO_REF_COUNT activatecnt;
     char *name;
     char *path;


### PR DESCRIPTION
We refactor ossl_provider_doall_activated() so that we only need to take a read lock instead of a write lock for the flag_lock. This should improve performance by avoiding the lock contention. We achieve this by protecting the activatecnt via atomics rather than via a lock and by avoiding the full provider activation/deactivation procedure where it is not needed.

Partial fix for #20286

