### PR TITLE
Avoid taking a write lock in RAND_get_rand_method()

### DIFF
--- a/crypto/rand/rand_lib.c
+++ b/crypto/rand/rand_lib.c
@@ -189,6 +189,13 @@ const RAND_METHOD *RAND_get_rand_method(void)
     if (!RUN_ONCE(&rand_init, do_rand_init))
         return NULL;
 
+    if (!CRYPTO_THREAD_read_lock(rand_meth_lock))
+        return NULL;
+    tmp_meth = default_RAND_meth;
+    CRYPTO_THREAD_unlock(rand_meth_lock);
+    if (tmp_meth != NULL)
+        return tmp_meth;
+
     if (!CRYPTO_THREAD_write_lock(rand_meth_lock))
         return NULL;
     if (default_RAND_meth == NULL) {


### PR DESCRIPTION
The function RAND_get_rand_method() is called every time RAND_bytes() or RAND_priv_bytes() is called. We were obtaining a write lock in order to find the default random method - even though we rarely write. We change this to a read lock and only fallback to a write lock if we need to.

Partial fix for #20286
