### PR TITLE
Add support for --version and synonyms

### DIFF
--- a/apps/openssl.c
+++ b/apps/openssl.c
@@ -232,6 +232,7 @@ static void setup_trace(const char *str)
 #endif /* OPENSSL_NO_TRACE */
 
 static char *help_argv[] = { "help", NULL };
+static char *version_argv[] = { "version", NULL };
 
 int main(int argc, char *argv[])
 {
@@ -241,6 +242,7 @@ int main(int argc, char *argv[])
     const char *fname;
     ARGS arg;
     int global_help = 0;
+    int global_version = 0;
     int ret = 0;
 
     arg.argv = NULL;
@@ -285,17 +287,24 @@ int main(int argc, char *argv[])
         global_help = argc > 1
             && (strcmp(argv[1], "-help") == 0 || strcmp(argv[1], "--help") == 0
                 || strcmp(argv[1], "-h") == 0 || strcmp(argv[1], "--h") == 0);
+        global_version = argc > 1
+            && (strcmp(argv[1], "-version") == 0 || strcmp(argv[1], "--version") == 0
+                || strcmp(argv[1], "-v") == 0 || strcmp(argv[1], "--v") == 0);
+
         argc--;
         argv++;
-        opt_appname(argc == 1 || global_help ? "help" : argv[0]);
+        opt_appname(argc == 1 || global_help ? "help" : global_version ? "version" : argv[0]);
     } else {
         argv[0] = pname;
     }
 
-    /* If there's a command, run with that, otherwise "help". */
-    ret = argc == 0 || global_help
-        ? do_cmd(prog, 1, help_argv)
-        : do_cmd(prog, argc, argv);
+    /* If there's no command, assume "help". If there's an override for help
+    or version run those, otherwise run the command given. */
+    ret =  (argc == 0) || global_help 
+            ? do_cmd(prog, 1, help_argv)
+            : global_version 
+                ? do_cmd(prog, 1, version_argv)
+                : do_cmd(prog, argc, argv);
 
  end:
     OPENSSL_free(default_config_file);
@@ -325,7 +334,6 @@ const OPTIONS help_options[] = {
     {"command", 0, 0, "Name of command to display help (optional)"},
     {NULL}
 };
-
 
 int help_main(int argc, char **argv)
 {

--- a/apps/openssl.c
+++ b/apps/openssl.c
@@ -298,8 +298,10 @@ int main(int argc, char *argv[])
         argv[0] = pname;
     }
 
-    /* If there's no command, assume "help". If there's an override for help
-    or version run those, otherwise run the command given. */
+    /*
+     * If there's no command, assume "help". If there's an override for help
+     * or version run those, otherwise run the command given.
+     */
     ret =  (argc == 0) || global_help 
             ? do_cmd(prog, 1, help_argv)
             : global_version 

--- a/doc/man1/openssl.pod
+++ b/doc/man1/openssl.pod
@@ -34,20 +34,6 @@ It can be used for
  o  Handling of S/MIME signed or encrypted mail
  o  Timestamp requests, generation and verification
 
-=head2 Program Options
-
-=over 4
-
-=item B<-help> | B<--help>
-
-Provides a terse summary of all B<openssl> program options. For more detailed information, each command supports a B<-help> option.
-
-=item B<-version> | B<--version>
-
-Provides a terse summary of the B<openssl> program version. For more detailed information see L<openssl-version(1)>.
-
-=back
-
 =head1 COMMAND SUMMARY
 
 The B<openssl> program provides a rich variety of commands (I<command> in
@@ -519,10 +505,16 @@ This section describes some common options with common behavior.
 
 =over 4
 
-=item B<-help>
+=item B<-help> | B<--help>
 
 Provides a terse summary of all options.
 If an option takes an argument, the "type" of argument is also given.
+For more detailed information, each command supports a B<-help> option.
+
+=item B<-version> | B<--version>
+
+Provides a terse summary of the B<openssl> program version.
+For more detailed information see L<openssl-version(1)>.
 
 =item B<-->
 

--- a/doc/man1/openssl.pod
+++ b/doc/man1/openssl.pod
@@ -501,14 +501,16 @@ SM4 Cipher
 Details of which options are available depend on the specific command.
 This section describes some common options with common behavior.
 
-=head2 Common Options
+=head2 Program Options
+
+These options can be specified without a command specified to get help
+or version information.
 
 =over 4
 
 =item B<-help>
 
 Provides a terse summary of all options.
-If an option takes an argument, the "type" of argument is also given.
 For more detailed information, each command supports a B<-help> option.
 Accepts B<--help> as well.
 
@@ -517,6 +519,16 @@ Accepts B<--help> as well.
 Provides a terse summary of the B<openssl> program version.
 For more detailed information see L<openssl-version(1)>.
 Accepts B<--version> as well.
+
+=back
+
+=head2 Common Options
+
+=over 4
+
+=item B<-help>
+
+If an option takes an argument, the "type" of argument is also given.
 
 =item B<-->
 

--- a/doc/man1/openssl.pod
+++ b/doc/man1/openssl.pod
@@ -13,7 +13,7 @@ I<command>
 
 B<openssl> B<no->I<XXX> [ I<options> ]
 
-B<openssl> B<-help> | B<--help> | B<-version> | B<--version>
+B<openssl> B<-help> | B<-version>
 
 =head1 DESCRIPTION
 
@@ -505,16 +505,18 @@ This section describes some common options with common behavior.
 
 =over 4
 
-=item B<-help> | B<--help>
+=item B<-help>
 
 Provides a terse summary of all options.
 If an option takes an argument, the "type" of argument is also given.
 For more detailed information, each command supports a B<-help> option.
+Accepts B<--help> as well.
 
-=item B<-version> | B<--version>
+=item B<-version>
 
 Provides a terse summary of the B<openssl> program version.
 For more detailed information see L<openssl-version(1)>.
+Accepts B<--version> as well.
 
 =item B<-->
 

--- a/doc/man1/openssl.pod
+++ b/doc/man1/openssl.pod
@@ -13,6 +13,8 @@ I<command>
 
 B<openssl> B<no->I<XXX> [ I<options> ]
 
+B<openssl> B<-help> | B<--help> | B<-version> | B<--version>
+
 =head1 DESCRIPTION
 
 OpenSSL is a cryptography toolkit implementing the Secure Sockets Layer (SSL)
@@ -31,6 +33,20 @@ It can be used for
  o  SSL/TLS Client and Server Tests
  o  Handling of S/MIME signed or encrypted mail
  o  Timestamp requests, generation and verification
+
+=head2 Program Options
+
+=over 4
+
+=item B<-help> | B<--help>
+
+Provides a terse summary of all B<openssl> program options. For more detailed information, each command supports a B<-help> option.
+
+=item B<-version> | B<--version>
+
+Provides a terse summary of the B<openssl> program version. For more detailed information see L<openssl-version(1)>.
+
+=back
 
 =head1 COMMAND SUMMARY
 

--- a/test/recipes/20-test_app.t
+++ b/test/recipes/20-test_app.t
@@ -13,7 +13,7 @@ use OpenSSL::Test;
 
 setup("test_app");
 
-plan tests => 5;
+plan tests => 7;
 
 ok(run(app(["openssl"])),
    "Run openssl app with no args");
@@ -29,3 +29,9 @@ ok(run(app(["openssl", "-help"])),
 
 ok(run(app(["openssl", "--help"])),
    "Run openssl app with --help");
+
+ok(run(app(["openssl", "-version"])),
+   "Run openssl app with -version");
+
+ok(run(app(["openssl", "--version"])),
+   "Run openssl app with --version");


### PR DESCRIPTION
Just like --help is explicitly supported, we should support --version. This will greatly ease people adopting openssl.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
