### PR TITLE
Don't get a write lock when querying the parent reseed_count or strength

### DIFF
--- a/doc/man7/provider-rand.pod
+++ b/doc/man7/provider-rand.pod
@@ -50,6 +50,7 @@ functions
  /* Context Locking */
  int OSSL_FUNC_rand_enable_locking(void *ctx);
  int OSSL_FUNC_rand_lock(void *ctx);
+ int OSSL_FUNC_rand_lock_ex(void *ctx, int read);
  void OSSL_FUNC_rand_unlock(void *ctx);
 
  /* RAND parameter descriptors */
@@ -144,8 +145,13 @@ OSSL_FUNC_rand_enable_locking() allows locking to be turned on for a DRBG and al
 its parent DRBGs.  From this call onwards, the DRBG can be used in a thread
 safe manner.
 
-OSSL_FUNC_rand_lock() is used to lock a DRBG.  Once locked, exclusive access
-is guaranteed.
+OSSL_FUNC_rand_lock() and OSSL_FUNC_rand_lock_ex() are used to lock a DRBG.
+Where possible it is preferred that a DRBG implement OSSL_FUNC_rand_lock_ex()
+in preference to OSSL_FUNC_rand_lock(). Once locked, exclusive access
+is guaranteed. OSSL_FUNC_rand_lock_ex() takes an additional "read" parameter
+which indicates whether a lock should be a read lock or a write lock. A "read"
+lock is assumed to be sufficient for OSSL_FUNC_rand_get_ctx_params() and
+OSSL_FUNC_rand_verify_zeroization() calls.
 
 OSSL_FUNC_rand_unlock() is used to unlock a DRBG.
 

--- a/include/openssl/core_dispatch.h
+++ b/include/openssl/core_dispatch.h
@@ -453,6 +453,7 @@ OSSL_CORE_MAKE_FUNC(int, kdf_set_ctx_params,
 # define OSSL_FUNC_RAND_VERIFY_ZEROIZATION           17
 # define OSSL_FUNC_RAND_GET_SEED                     18
 # define OSSL_FUNC_RAND_CLEAR_SEED                   19
+# define OSSL_FUNC_RAND_LOCK_EX                      20
 
 OSSL_CORE_MAKE_FUNC(void *,rand_newctx,
                     (void *provctx, void *parent,
@@ -477,6 +478,7 @@ OSSL_CORE_MAKE_FUNC(size_t,rand_nonce,
                      size_t min_noncelen, size_t max_noncelen))
 OSSL_CORE_MAKE_FUNC(int,rand_enable_locking, (void *vctx))
 OSSL_CORE_MAKE_FUNC(int,rand_lock, (void *vctx))
+OSSL_CORE_MAKE_FUNC(int,rand_lock_ex, (void *vctx, int read))
 OSSL_CORE_MAKE_FUNC(void,rand_unlock, (void *vctx))
 OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *,rand_gettable_params, (void *provctx))
 OSSL_CORE_MAKE_FUNC(const OSSL_PARAM *,rand_gettable_ctx_params,

--- a/providers/implementations/rands/drbg_ctr.c
+++ b/providers/implementations/rands/drbg_ctr.c
@@ -735,6 +735,7 @@ const OSSL_DISPATCH ossl_drbg_ctr_functions[] = {
     { OSSL_FUNC_RAND_GENERATE, (void(*)(void))drbg_ctr_generate_wrapper },
     { OSSL_FUNC_RAND_RESEED, (void(*)(void))drbg_ctr_reseed_wrapper },
     { OSSL_FUNC_RAND_ENABLE_LOCKING, (void(*)(void))ossl_drbg_enable_locking },
+    { OSSL_FUNC_RAND_LOCK, (void(*)(void))ossl_drbg_lock },
     { OSSL_FUNC_RAND_LOCK_EX, (void(*)(void))ossl_drbg_lock_ex },
     { OSSL_FUNC_RAND_UNLOCK, (void(*)(void))ossl_drbg_unlock },
     { OSSL_FUNC_RAND_SETTABLE_CTX_PARAMS,

--- a/providers/implementations/rands/drbg_ctr.c
+++ b/providers/implementations/rands/drbg_ctr.c
@@ -735,7 +735,7 @@ const OSSL_DISPATCH ossl_drbg_ctr_functions[] = {
     { OSSL_FUNC_RAND_GENERATE, (void(*)(void))drbg_ctr_generate_wrapper },
     { OSSL_FUNC_RAND_RESEED, (void(*)(void))drbg_ctr_reseed_wrapper },
     { OSSL_FUNC_RAND_ENABLE_LOCKING, (void(*)(void))ossl_drbg_enable_locking },
-    { OSSL_FUNC_RAND_LOCK, (void(*)(void))ossl_drbg_lock },
+    { OSSL_FUNC_RAND_LOCK_EX, (void(*)(void))ossl_drbg_lock_ex },
     { OSSL_FUNC_RAND_UNLOCK, (void(*)(void))ossl_drbg_unlock },
     { OSSL_FUNC_RAND_SETTABLE_CTX_PARAMS,
       (void(*)(void))drbg_ctr_settable_ctx_params },

--- a/providers/implementations/rands/drbg_hash.c
+++ b/providers/implementations/rands/drbg_hash.c
@@ -509,6 +509,7 @@ const OSSL_DISPATCH ossl_drbg_hash_functions[] = {
     { OSSL_FUNC_RAND_GENERATE, (void(*)(void))drbg_hash_generate_wrapper },
     { OSSL_FUNC_RAND_RESEED, (void(*)(void))drbg_hash_reseed_wrapper },
     { OSSL_FUNC_RAND_ENABLE_LOCKING, (void(*)(void))ossl_drbg_enable_locking },
+    { OSSL_FUNC_RAND_LOCK, (void(*)(void))ossl_drbg_lock },
     { OSSL_FUNC_RAND_LOCK_EX, (void(*)(void))ossl_drbg_lock_ex },
     { OSSL_FUNC_RAND_UNLOCK, (void(*)(void))ossl_drbg_unlock },
     { OSSL_FUNC_RAND_SETTABLE_CTX_PARAMS,

--- a/providers/implementations/rands/drbg_hash.c
+++ b/providers/implementations/rands/drbg_hash.c
@@ -509,7 +509,7 @@ const OSSL_DISPATCH ossl_drbg_hash_functions[] = {
     { OSSL_FUNC_RAND_GENERATE, (void(*)(void))drbg_hash_generate_wrapper },
     { OSSL_FUNC_RAND_RESEED, (void(*)(void))drbg_hash_reseed_wrapper },
     { OSSL_FUNC_RAND_ENABLE_LOCKING, (void(*)(void))ossl_drbg_enable_locking },
-    { OSSL_FUNC_RAND_LOCK, (void(*)(void))ossl_drbg_lock },
+    { OSSL_FUNC_RAND_LOCK_EX, (void(*)(void))ossl_drbg_lock_ex },
     { OSSL_FUNC_RAND_UNLOCK, (void(*)(void))ossl_drbg_unlock },
     { OSSL_FUNC_RAND_SETTABLE_CTX_PARAMS,
       (void(*)(void))drbg_hash_settable_ctx_params },

--- a/providers/implementations/rands/drbg_hmac.c
+++ b/providers/implementations/rands/drbg_hmac.c
@@ -412,7 +412,7 @@ const OSSL_DISPATCH ossl_drbg_ossl_hmac_functions[] = {
     { OSSL_FUNC_RAND_GENERATE, (void(*)(void))drbg_hmac_generate_wrapper },
     { OSSL_FUNC_RAND_RESEED, (void(*)(void))drbg_hmac_reseed_wrapper },
     { OSSL_FUNC_RAND_ENABLE_LOCKING, (void(*)(void))ossl_drbg_enable_locking },
-    { OSSL_FUNC_RAND_LOCK, (void(*)(void))ossl_drbg_lock },
+    { OSSL_FUNC_RAND_LOCK_EX, (void(*)(void))ossl_drbg_lock_ex },
     { OSSL_FUNC_RAND_UNLOCK, (void(*)(void))ossl_drbg_unlock },
     { OSSL_FUNC_RAND_SETTABLE_CTX_PARAMS,
       (void(*)(void))drbg_hmac_settable_ctx_params },

--- a/providers/implementations/rands/drbg_hmac.c
+++ b/providers/implementations/rands/drbg_hmac.c
@@ -412,6 +412,7 @@ const OSSL_DISPATCH ossl_drbg_ossl_hmac_functions[] = {
     { OSSL_FUNC_RAND_GENERATE, (void(*)(void))drbg_hmac_generate_wrapper },
     { OSSL_FUNC_RAND_RESEED, (void(*)(void))drbg_hmac_reseed_wrapper },
     { OSSL_FUNC_RAND_ENABLE_LOCKING, (void(*)(void))ossl_drbg_enable_locking },
+    { OSSL_FUNC_RAND_LOCK, (void(*)(void))ossl_drbg_lock },
     { OSSL_FUNC_RAND_LOCK_EX, (void(*)(void))ossl_drbg_lock_ex },
     { OSSL_FUNC_RAND_UNLOCK, (void(*)(void))ossl_drbg_unlock },
     { OSSL_FUNC_RAND_SETTABLE_CTX_PARAMS,

--- a/providers/implementations/rands/drbg_local.h
+++ b/providers/implementations/rands/drbg_local.h
@@ -218,6 +218,7 @@ OSSL_FUNC_rand_clear_seed_fn ossl_drbg_clear_seed;
 
 /* locking api */
 OSSL_FUNC_rand_enable_locking_fn ossl_drbg_enable_locking;
+OSSL_FUNC_rand_lock_fn ossl_drbg_lock;
 OSSL_FUNC_rand_lock_ex_fn ossl_drbg_lock_ex;
 OSSL_FUNC_rand_unlock_fn ossl_drbg_unlock;
 

--- a/providers/implementations/rands/drbg_local.h
+++ b/providers/implementations/rands/drbg_local.h
@@ -84,6 +84,7 @@ struct prov_drbg_st {
     void *parent;
     OSSL_FUNC_rand_enable_locking_fn *parent_enable_locking;
     OSSL_FUNC_rand_lock_fn *parent_lock;
+    OSSL_FUNC_rand_lock_ex_fn *parent_lock_ex;
     OSSL_FUNC_rand_unlock_fn *parent_unlock;
     OSSL_FUNC_rand_get_ctx_params_fn *parent_get_ctx_params;
     OSSL_FUNC_rand_nonce_fn *parent_nonce;
@@ -217,7 +218,7 @@ OSSL_FUNC_rand_clear_seed_fn ossl_drbg_clear_seed;
 
 /* locking api */
 OSSL_FUNC_rand_enable_locking_fn ossl_drbg_enable_locking;
-OSSL_FUNC_rand_lock_fn ossl_drbg_lock;
+OSSL_FUNC_rand_lock_ex_fn ossl_drbg_lock_ex;
 OSSL_FUNC_rand_unlock_fn ossl_drbg_unlock;
 
 /* Common parameters for all of our DRBGs */

--- a/providers/implementations/rands/seed_src.c
+++ b/providers/implementations/rands/seed_src.c
@@ -32,7 +32,7 @@ static OSSL_FUNC_rand_gettable_ctx_params_fn seed_src_gettable_ctx_params;
 static OSSL_FUNC_rand_get_ctx_params_fn seed_src_get_ctx_params;
 static OSSL_FUNC_rand_verify_zeroization_fn seed_src_verify_zeroization;
 static OSSL_FUNC_rand_enable_locking_fn seed_src_enable_locking;
-static OSSL_FUNC_rand_lock_fn seed_src_lock;
+static OSSL_FUNC_rand_lock_ex_fn seed_src_lock_ex;
 static OSSL_FUNC_rand_unlock_fn seed_src_unlock;
 static OSSL_FUNC_rand_get_seed_fn seed_get_seed;
 static OSSL_FUNC_rand_clear_seed_fn seed_clear_seed;
@@ -217,7 +217,7 @@ static int seed_src_enable_locking(ossl_unused void *vseed)
     return 1;
 }
 
-int seed_src_lock(ossl_unused void *vctx)
+int seed_src_lock_ex(ossl_unused void *vctx, int read)
 {
     return 1;
 }
@@ -236,7 +236,7 @@ const OSSL_DISPATCH ossl_seed_src_functions[] = {
     { OSSL_FUNC_RAND_GENERATE, (void(*)(void))seed_src_generate },
     { OSSL_FUNC_RAND_RESEED, (void(*)(void))seed_src_reseed },
     { OSSL_FUNC_RAND_ENABLE_LOCKING, (void(*)(void))seed_src_enable_locking },
-    { OSSL_FUNC_RAND_LOCK, (void(*)(void))seed_src_lock },
+    { OSSL_FUNC_RAND_LOCK, (void(*)(void))seed_src_lock_ex },
     { OSSL_FUNC_RAND_UNLOCK, (void(*)(void))seed_src_unlock },
     { OSSL_FUNC_RAND_GETTABLE_CTX_PARAMS,
       (void(*)(void))seed_src_gettable_ctx_params },

--- a/providers/implementations/rands/test_rng.c
+++ b/providers/implementations/rands/test_rng.c
@@ -33,7 +33,7 @@ static OSSL_FUNC_rand_gettable_ctx_params_fn test_rng_gettable_ctx_params;
 static OSSL_FUNC_rand_get_ctx_params_fn test_rng_get_ctx_params;
 static OSSL_FUNC_rand_verify_zeroization_fn test_rng_verify_zeroization;
 static OSSL_FUNC_rand_enable_locking_fn test_rng_enable_locking;
-static OSSL_FUNC_rand_lock_fn test_rng_lock;
+static OSSL_FUNC_rand_lock_ex_fn test_rng_lock_ex;
 static OSSL_FUNC_rand_unlock_fn test_rng_unlock;
 static OSSL_FUNC_rand_get_seed_fn test_rng_get_seed;
 
@@ -253,12 +253,16 @@ static int test_rng_enable_locking(void *vtest)
     return 1;
 }
 
-static int test_rng_lock(void *vtest)
+static int test_rng_lock_ex(void *vtest, int read)
 {
     PROV_TEST_RNG *t = (PROV_TEST_RNG *)vtest;
 
     if (t == NULL || t->lock == NULL)
         return 1;
+
+    if (read)
+        return CRYPTO_THREAD_read_lock(t->lock);
+
     return CRYPTO_THREAD_write_lock(t->lock);
 }
 
@@ -281,7 +285,7 @@ const OSSL_DISPATCH ossl_test_rng_functions[] = {
     { OSSL_FUNC_RAND_RESEED, (void(*)(void))test_rng_reseed },
     { OSSL_FUNC_RAND_NONCE, (void(*)(void))test_rng_nonce },
     { OSSL_FUNC_RAND_ENABLE_LOCKING, (void(*)(void))test_rng_enable_locking },
-    { OSSL_FUNC_RAND_LOCK, (void(*)(void))test_rng_lock },
+    { OSSL_FUNC_RAND_LOCK_EX, (void(*)(void))test_rng_lock_ex },
     { OSSL_FUNC_RAND_UNLOCK, (void(*)(void))test_rng_unlock },
     { OSSL_FUNC_RAND_SETTABLE_CTX_PARAMS,
       (void(*)(void))test_rng_settable_ctx_params },

--- a/test/provfetchtest.c
+++ b/test/provfetchtest.c
@@ -146,7 +146,7 @@ static int dummy_rand_enable_locking(void *vtest)
     return 1;
 }
 
-static int dummy_rand_lock(void *vtest)
+static int dummy_rand_lock_ex(void *vtest, int read)
 {
     return 1;
 }
@@ -165,7 +165,7 @@ static const OSSL_DISPATCH dummy_rand_functions[] = {
       (void(*)(void))dummy_rand_gettable_ctx_params },
     { OSSL_FUNC_RAND_GET_CTX_PARAMS, (void(*)(void))dummy_rand_get_ctx_params },
     { OSSL_FUNC_RAND_ENABLE_LOCKING, (void(*)(void))dummy_rand_enable_locking },
-    { OSSL_FUNC_RAND_LOCK, (void(*)(void))dummy_rand_lock },
+    { OSSL_FUNC_RAND_LOCK_EX, (void(*)(void))dummy_rand_lock_ex },
     { OSSL_FUNC_RAND_UNLOCK, (void(*)(void))dummy_rand_unlock },
     OSSL_DISPATCH_END
 };


### PR DESCRIPTION
A read lock should be sufficient when all we are doing is querying the parent DRBG reseed_count or strength.

Partially fixes #20286

I've marked this for master/3.1/3.0 although it is unclear to what extent this is backportable since it adds new API in the fetchable DRBG interface.
