### PR TITLE
Optimise some X509_STORE related locking

### DIFF
--- a/crypto/x509/by_dir.c
+++ b/crypto/x509/by_dir.c
@@ -352,11 +352,15 @@ static int get_cert_by_subject_ex(X509_LOOKUP *xl, X509_LOOKUP_TYPE type,
          * Note: quadratic time find here since the objects won't generally be
          *       sorted and sorting the would result in O(n^2 log n) complexity.
          */
-        X509_STORE_lock(xl->store_ctx);
-        j = sk_X509_OBJECT_find(xl->store_ctx->objs, &stmp);
-        tmp = sk_X509_OBJECT_value(xl->store_ctx->objs, j);
-        X509_STORE_unlock(xl->store_ctx);
-
+        if (k > 0) {
+            X509_STORE_lock(xl->store_ctx);
+            j = sk_X509_OBJECT_find(xl->store_ctx->objs, &stmp);
+            tmp = sk_X509_OBJECT_value(xl->store_ctx->objs, j);
+            X509_STORE_unlock(xl->store_ctx);
+        } else {
+            j = -1;
+            tmp = NULL;
+        }
         /*
          * If a CRL, update the last file suffix added for this.
          * We don't need to add an entry if k is 0 as this is the initial value.

--- a/crypto/x509/x509_lu.c
+++ b/crypto/x509/x509_lu.c
@@ -338,7 +338,8 @@ static int ossl_x509_store_ctx_get_by_subject(const X509_STORE_CTX *ctx,
         X509_STORE_unlock(store);
         /* Take a write lock instead of a read lock */
         X509_STORE_lock(store);
-        sk_X509_OBJECT_sort(store->objs);
+        if (!sk_X509_OBJECT_is_sorted(store->objs))
+            sk_X509_OBJECT_sort(store->objs);
     }
     tmp = X509_OBJECT_retrieve_by_subject(store->objs, type, name);
     X509_STORE_unlock(store);


### PR DESCRIPTION
`ossl_x509_store_ctx_get_by_subject()` was taking a write lock for the store, but was only (usually) retrieving a value from the stack of objects. We take a read lock instead.

We also avoid an unnecessary lock in a common case in `get_cert_by_subject_ex`