### PR TITLE
Fix arm64 asm code back compatible issue with gcc 4.9.4

### DIFF
--- a/crypto/modes/asm/aes-gcm-armv8-unroll8_64.pl
+++ b/crypto/modes/asm/aes-gcm-armv8-unroll8_64.pl
@@ -174,7 +174,7 @@ $code=<<___;
 
 #if __ARM_MAX_ARCH__>=8
 ___
-$code.=".arch   armv8.2-a+crypto\n.text\n";
+$code.=".arch   armv8-a+crypto\n.text\n";
 
 $input_ptr="x0";  #argument block
 $bit_length="x1";

--- a/crypto/sm3/asm/sm3-armv8.pl
+++ b/crypto/sm3/asm/sm3-armv8.pl
@@ -109,7 +109,6 @@ ___
 
 $code=<<___;
 #include "arm_arch.h"
-.arch	armv8.2-a
 .text
 ___
 


### PR DESCRIPTION
Fix: #20963

There are arm crypto related architecture declarations in the files crypto/modes/asm/aes-gcm-armv8-unroll8_64.pl and crypto/sm3/asm/sm3-armv8.pl,  and they will cause compile failure in older gcc compiler such as gcc4.9.4.
Change to fix the issue.
