### PR TITLE
util/mkdef.pl: Take shlib_variant into account

### DIFF
--- a/util/mkdef.pl
+++ b/util/mkdef.pl
@@ -197,6 +197,7 @@ foreach (@ARGV, split(/ /, $config{options}))
 	}
 $libname = $unified_info{sharednames}->{libcrypto} if $do_crypto;
 $libname = $unified_info{sharednames}->{libssl} if $do_ssl;
+$libname .= $target{shlib_variant} || "";
 
 if (!$libname) {
 	if ($do_ssl) {


### PR DESCRIPTION
For platforms using import libraries, the lack of this causes a
disjoint between the name of the DLL that's produced, and the
corresponding import library.

Fixes #20942 (follows up #20732)
