### PR TITLE
Fix pkcs12 CLI macsaltlen parameter

### DIFF
--- a/apps/pkcs12.c
+++ b/apps/pkcs12.c
@@ -152,7 +152,7 @@ const OPTIONS pkcs12_options[] = {
     {"noiter", OPT_NOITER, '-', "Don't use encryption iteration"},
     {"nomaciter", OPT_NOMACITER, '-', "Don't use MAC iteration)"},
     {"maciter", OPT_MACITER, '-', "Unused, kept for backwards compatibility"},
-    {"macsaltlen", OPT_MACSALTLEN, '-', "Specify the salt len for MAC"},
+    {"macsaltlen", OPT_MACSALTLEN, 'p', "Specify the salt len for MAC"},
     {"nomac", OPT_NOMAC, '-', "Don't generate MAC"},
     {NULL}
 };


### PR DESCRIPTION
Fix pkcs12 cli by changing macsaltlen parameter from non-argument type to positive integer type. Issue #20969 

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
