### PR TITLE
Update VMS configurations

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -2079,5 +2079,9 @@ my %targets = (
         cflags           => add("/POINTER_SIZE=64=ARGV"),
         pointer_size     => "64",
     },
-
+    "vms-x86_64" => {
+        inherit_from     => [ "vms-generic" ],
+        bn_ops           => "SIXTY_FOUR_BIT",
+        pointer_size     => "",
+    }
 );

--- a/Configurations/50-vms-x86_64.conf
+++ b/Configurations/50-vms-x86_64.conf
@@ -1,16 +1,10 @@
 ## -*- mode: perl; -*-
 
-# OpenVMS for x86_64 is currently out on a field test.  A native C compiler
-# is currently not available, but there are cross-compilation tools for
-# OpenVMS for Itanium.  This configuration file holds the necessary target(s)
-# to make that useful.
-#
-# The assumption is that *building* is done on Itanium, and then the source
-# tree and build tree are transferred to x86_64, where tests can be performed,
-# and installation can be done.
+# OpenVMS cross compilation of x86_64 binaries on Itanium.  This doesn't
+# fit the usual cross compilation parameters that are used on Unixly machines
 
 (
- 'vms-x86_64' => {
+ 'vms-x86_64-cross-ia64' => {
      inherit_from   => [ 'vms-generic' ],
      CC             => 'XCC',
      bn_ops         => 'SIXTY_FOUR_BIT',

--- a/NOTES-VMS.md
+++ b/NOTES-VMS.md
@@ -83,6 +83,23 @@ When done, we recommend that you turn that flag back off:
 
     $ set image /flag=nocall_debug [.test]evp_test.exe
 
+About assembler acceleration
+----------------------------
+
+OpenSSL has assembler acceleration for a number of BIGNUM and crypto
+routines.  The VMS config targets tries to look for a selection of
+assemblers and will use what they find.  If none of the assemblers are
+found, OpenSSL will be built as if `no-asm` was configured.
+
+### For Itanium / IA64 / I64
+
+-   There is only one assembler, a port of Intel's `ias`, found in the
+    HP Open Source Tools CD, available through [DECUSlib](http://www.decuslib.com).
+    It's assumed to be set up as per the instructions, where `disk` and
+    `dir` are expected to be adapted to local conditions:
+
+        $ ias :== $disk:[dir]iasi64.exe
+
 Checking the distribution
 -------------------------
 

--- a/util/perl/OpenSSL/config.pm
+++ b/util/perl/OpenSSL/config.pm
@@ -354,8 +354,12 @@ sub determine_compiler_settings {
         if ( $SYSTEM eq 'OpenVMS' ) {
             my $v = `CC/VERSION NLA0:`;
             if ($? == 0) {
+                # The normal releases have a version number prefixed with a V.
+                # However, other letters have been seen as well (for example X),
+                # and it's documented that HP (now VSI) reserve the letter W, X,
+                # Y and Z for their own uses.
                 my ($vendor, $version) =
-                    ( $v =~ m/^([A-Z]+) C V([0-9\.-]+) on / );
+                    ( $v =~ m/^([A-Z]+) C [VWXYZ]([0-9\.-]+)(:? +\(.*?\))? on / );
                 my ($major, $minor, $patch) =
                     ( $version =~ m/^([0-9]+)\.([0-9]+)-0*?(0|[1-9][0-9]*)$/ );
                 $CC = 'CC';


### PR DESCRIPTION
The x86_64 port has been moving forward, there is now a C compiler
available (released in mid-February this year).

Furthermore, OpenSSL has had support for using the OpenVMS port of
Intel's `ias` for years, but not had any actual information about it.
It's about time that it's mentioned.
