### PR TITLE
Update hkdf.c to avoid potentially vulnerable code pattern

### DIFF
--- a/providers/implementations/kdfs/hkdf.c
+++ b/providers/implementations/kdfs/hkdf.c
@@ -531,7 +531,7 @@ static int HKDF_Expand(const EVP_MD *evp_md,
         if (!HMAC_Final(hmac, prev, NULL))
             goto err;
 
-        copy_len = (done_len + dig_len > okm_len) ?
+        copy_len = (dig_len > okm_len - done_len) ?
                        okm_len - done_len :
                        dig_len;
 


### PR DESCRIPTION
The expression `if (a+b>c) a=c-b` is incorrect if `a+b` overflows. It should be replaced by `if (a>c-b) a=c-b`, which avoids the potential overflow and is much easier to understand. This pattern is the root cause of [CVE-2022-37454](https://github.com/advisories/GHSA-6w4m-2xhg-2658), a buffer overflow vulnerability in the "official" SHA-3 implementation.

It has been confirmed that the addition in [hkdf.c:534](https://github.com/openssl/openssl/blob/master/providers/implementations/kdfs/hkdf.c#L534) cannot overflow. So this is only a minor proposed change to avoid potentially vulnerable code patterns and to improve readability. More information: https://github.com/github/codeql/pull/12036#issuecomment-1466056959