### PR TITLE
crypto/params: drop float for UEFI

### DIFF
--- a/crypto/params.c
+++ b/crypto/params.c
@@ -38,6 +38,7 @@
 #define err_unsupported_real  \
     ERR_raise(ERR_LIB_CRYPTO, CRYPTO_R_PARAM_UNSUPPORTED_FLOATING_POINT_FORMAT)
 
+#ifndef OPENSSL_SYS_UEFI
 /*
  * Return the number of bits in the mantissa of a double.  This is used to
  * shift a larger integral value to determine if it will exactly fit into a
@@ -47,6 +48,7 @@ static unsigned int real_shift(void)
 {
     return sizeof(double) == 4 ? 24 : 53;
 }
+#endif
 
 OSSL_PARAM *OSSL_PARAM_locate(OSSL_PARAM *p, const char *key)
 {
@@ -378,8 +380,6 @@ OSSL_PARAM OSSL_PARAM_construct_ulong(const char *key, unsigned long int *buf)
 
 int OSSL_PARAM_get_int32(const OSSL_PARAM *p, int32_t *val)
 {
-    double d;
-
     if (val == NULL || p == NULL) {
         err_null_argument;
         return 0;
@@ -432,6 +432,9 @@ int OSSL_PARAM_get_int32(const OSSL_PARAM *p, int32_t *val)
         return general_get_int(p, val, sizeof(*val));
 
     } else if (p->data_type == OSSL_PARAM_REAL) {
+#ifndef OPENSSL_SYS_UEFI
+        double d;
+
         switch (p->data_size) {
         case sizeof(double):
             d = *(const double *)p->data;
@@ -444,6 +447,7 @@ int OSSL_PARAM_get_int32(const OSSL_PARAM *p, int32_t *val)
         }
         err_unsupported_real;
         return 0;
+#endif
     }
     err_bad_type;
     return 0;
@@ -492,6 +496,7 @@ int OSSL_PARAM_set_int32(OSSL_PARAM *p, int32_t val)
 #endif
         return general_set_int(p, &val, sizeof(val));
     } else if (p->data_type == OSSL_PARAM_REAL) {
+#ifndef OPENSSL_SYS_UEFI
         p->return_size = sizeof(double);
         if (p->data == NULL)
             return 1;
@@ -510,6 +515,7 @@ int OSSL_PARAM_set_int32(OSSL_PARAM *p, int32_t val)
         }
         err_unsupported_real;
         return 0;
+#endif
     }
     err_bad_type;
     return 0;
@@ -523,8 +529,6 @@ OSSL_PARAM OSSL_PARAM_construct_int32(const char *key, int32_t *buf)
 
 int OSSL_PARAM_get_uint32(const OSSL_PARAM *p, uint32_t *val)
 {
-    double d;
-
     if (val == NULL || p == NULL) {
         err_null_argument;
         return 0;
@@ -578,6 +582,9 @@ int OSSL_PARAM_get_uint32(const OSSL_PARAM *p, uint32_t *val)
 #endif
         return general_get_uint(p, val, sizeof(*val));
     } else if (p->data_type == OSSL_PARAM_REAL) {
+#ifndef OPENSSL_SYS_UEFI
+        double d;
+
         switch (p->data_size) {
         case sizeof(double):
             d = *(const double *)p->data;
@@ -590,6 +597,7 @@ int OSSL_PARAM_get_uint32(const OSSL_PARAM *p, uint32_t *val)
         }
         err_unsupported_real;
         return 0;
+#endif
     }
     err_bad_type;
     return 0;
@@ -642,6 +650,7 @@ int OSSL_PARAM_set_uint32(OSSL_PARAM *p, uint32_t val)
 #endif
         return general_set_uint(p, &val, sizeof(val));
     } else if (p->data_type == OSSL_PARAM_REAL) {
+#ifndef OPENSSL_SYS_UEFI
         p->return_size = sizeof(double);
         if (p->data == NULL)
             return 1;
@@ -657,6 +666,7 @@ int OSSL_PARAM_set_uint32(OSSL_PARAM *p, uint32_t val)
         }
         err_unsupported_real;
         return 0;
+#endif
     }
     err_bad_type;
     return 0;
@@ -670,8 +680,6 @@ OSSL_PARAM OSSL_PARAM_construct_uint32(const char *key, uint32_t *buf)
 
 int OSSL_PARAM_get_int64(const OSSL_PARAM *p, int64_t *val)
 {
-    double d;
-
     if (val == NULL || p == NULL) {
         err_null_argument;
         return 0;
@@ -709,6 +717,9 @@ int OSSL_PARAM_get_int64(const OSSL_PARAM *p, int64_t *val)
 #endif
         return general_get_int(p, val, sizeof(*val));
     } else if (p->data_type == OSSL_PARAM_REAL) {
+#ifndef OPENSSL_SYS_UEFI
+        double d;
+
         switch (p->data_size) {
         case sizeof(double):
             d = *(const double *)p->data;
@@ -728,6 +739,7 @@ int OSSL_PARAM_get_int64(const OSSL_PARAM *p, int64_t *val)
         }
         err_unsupported_real;
         return 0;
+#endif
     }
     err_bad_type;
     return 0;
@@ -735,8 +747,6 @@ int OSSL_PARAM_get_int64(const OSSL_PARAM *p, int64_t *val)
 
 int OSSL_PARAM_set_int64(OSSL_PARAM *p, int64_t val)
 {
-    uint64_t u64;
-
     if (p == NULL) {
         err_null_argument;
         return 0;
@@ -783,6 +793,9 @@ int OSSL_PARAM_set_int64(OSSL_PARAM *p, int64_t val)
 #endif
         return general_set_int(p, &val, sizeof(val));
     } else if (p->data_type == OSSL_PARAM_REAL) {
+#ifndef OPENSSL_SYS_UEFI
+        uint64_t u64;
+
         p->return_size = sizeof(double);
         if (p->data == NULL)
             return 1;
@@ -798,6 +811,7 @@ int OSSL_PARAM_set_int64(OSSL_PARAM *p, int64_t val)
         }
         err_unsupported_real;
         return 0;
+#endif
     }
     err_bad_type;
     return 0;
@@ -810,8 +824,6 @@ OSSL_PARAM OSSL_PARAM_construct_int64(const char *key, int64_t *buf)
 
 int OSSL_PARAM_get_uint64(const OSSL_PARAM *p, uint64_t *val)
 {
-    double d;
-
     if (val == NULL || p == NULL) {
         err_null_argument;
         return 0;
@@ -855,6 +867,9 @@ int OSSL_PARAM_get_uint64(const OSSL_PARAM *p, uint64_t *val)
 #endif
         return general_get_uint(p, val, sizeof(*val));
     } else if (p->data_type == OSSL_PARAM_REAL) {
+#ifndef OPENSSL_SYS_UEFI
+        double d;
+
         switch (p->data_size) {
         case sizeof(double):
             d = *(const double *)p->data;
@@ -874,6 +889,7 @@ int OSSL_PARAM_get_uint64(const OSSL_PARAM *p, uint64_t *val)
         }
         err_unsupported_real;
         return 0;
+#endif
     }
     err_bad_type;
     return 0;
@@ -932,6 +948,7 @@ int OSSL_PARAM_set_uint64(OSSL_PARAM *p, uint64_t val)
 #endif
         return general_set_uint(p, &val, sizeof(val));
     } else if (p->data_type == OSSL_PARAM_REAL) {
+#ifndef OPENSSL_SYS_UEFI
         p->return_size = sizeof(double);
         switch (p->data_size) {
         case sizeof(double):
@@ -944,6 +961,7 @@ int OSSL_PARAM_set_uint64(OSSL_PARAM *p, uint64_t val)
         }
         err_unsupported_real;
         return 0;
+#endif
     }
     err_bad_type;
     return 0;
@@ -1108,6 +1126,7 @@ OSSL_PARAM OSSL_PARAM_construct_BN(const char *key, unsigned char *buf,
                                 buf, bsize);
 }
 
+#ifndef OPENSSL_SYS_UEFI
 int OSSL_PARAM_get_double(const OSSL_PARAM *p, double *val)
 {
     int64_t i64;
@@ -1252,6 +1271,7 @@ OSSL_PARAM OSSL_PARAM_construct_double(const char *key, double *buf)
 {
     return ossl_param_construct(key, OSSL_PARAM_REAL, buf, sizeof(double));
 }
+#endif
 
 static int get_string_internal(const OSSL_PARAM *p, void **val,
                                size_t *max_len, size_t *used_len,


### PR DESCRIPTION
Using floating point is not supported in UEFI and can cause build problems, for example due to SSE being disabled and x64 calling convention passing floats in SSE registers.

Avoid those problems by not compiling the related code for floating point numbers.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
