### PR TITLE
Drop the last reference of SHLIB_EXT

### DIFF
--- a/Configurations/descrip.mms.tmpl
+++ b/Configurations/descrip.mms.tmpl
@@ -465,7 +465,7 @@ NODEBUG=@
         $(NODEBUG) ! Set up logical names for the libraries, so LINK and
         $(NODEBUG) ! running programs can use them.
         $(NODEBUG) !
-        $(NODEBUG) {- join("\n\t\$(NODEBUG) ", map { "DEFINE ".uc($_)." 'F\$ENV(\"DEFAULT\")'".uc($_)."\$(SHLIB_EXT)" } @shlibs) || "!" -}
+        $(NODEBUG) {- join("\n\t\$(NODEBUG) ", map { "DEFINE ".uc($_)." 'F\$ENV(\"DEFAULT\")'".uc($_).".EXE" } @shlibs) || "!" -}
 
 .LAST :
         $(NODEBUG) {- join("\n\t\$(NODEBUG) ", map { "DEASSIGN ".uc($_) } @shlibs) || "!" -}


### PR DESCRIPTION
SHLIB_EXT is a variable that exists on OpenSSL build file templates before
version 3.0, for which much of the logic for figuring out file names and
such was moved to the 'platform' set of routines.

But, it seems that one (now useless) reference remained on the VMS specific
descrip.mms.tmpl.  We replace it with an explicit '.EXE', which is the
default extension for shared libraries on VMS.
