### PR TITLE
Fix a bug where the result of rehash is unstable

### DIFF
--- a/apps/rehash.c
+++ b/apps/rehash.c
@@ -340,6 +340,11 @@ static int ends_with_dirsep(const char *path)
     return *path == '/';
 }
 
+static int sk_strcmp(const char * const *a, const char * const *b)
+{
+    return strcmp(*a, *b);
+}
+
 /*
  * Process a directory; return number of errors found.
  */
@@ -369,7 +374,7 @@ static int do_dir(const char *dirname, enum Hash h)
     if (verbose)
         BIO_printf(bio_out, "Doing %s\n", dirname);
 
-    if ((files = sk_OPENSSL_STRING_new_null()) == NULL) {
+    if ((files = sk_OPENSSL_STRING_new(sk_strcmp)) == NULL) {
         BIO_printf(bio_err, "Skipping %s, out of memory\n", dirname);
         errs = 1;
         goto err;


### PR DESCRIPTION
Fixes #21028 

The root cause is that the file entries targeted for rehash are not actually sorted.
Sort was skipped because the compare function was null.
So a compare function has been implemented to allow file entries to be sorted.

[Build]
Success

[Test]
_test file list_
- certA-1.pem
- certA-2.pem (same as certA-1.pem)
- certB-1.pem
- certB-2.pem (same as certB-1.pem)

_rehash results : before patch_
**(The result is from my local system. It will change depending on OS file system.)**
- 0a775a30.0 -> certA-1.pem
- 1001acf7.0 -> certB-**2**.pem

_rehash results : after patch_
- 0a775a30.0 -> certA-1.pem
- 1001acf7.0 -> certB-1.pem

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
