### PR TITLE
doc/fingerprints.txt: Add the OpenSSL OMC PGP key fingerprint

### DIFF
--- a/doc/fingerprints.txt
+++ b/doc/fingerprints.txt
@@ -12,6 +12,9 @@ in the file named openssl-1.0.1h.tar.gz.asc.
 The following is the list of fingerprints for the keys that are
 currently in use to sign OpenSSL distributions:
 
+OpenSSL OMC:
+EFC0 A467 D613 CB83 C7ED 6D30 D894 E2CE 8B3D 79F5
+
 Richard Levitte:
 7953 AC1F BC3D C8B3 B292 393E D5E9 E43F 7DF9 EE8C
 


### PR DESCRIPTION
We want to move to using this key for tarball and announcement signatures.
It won't happen immediately, though, as we must have it specified in the
latest update of each release branch, so people can verify properly.
