### PR TITLE
openssl pkcs12 -export: Ignore the fetch error when a legacy algorithm is found

### DIFF
--- a/crypto/evp/p5_crpt2.c
+++ b/crypto/evp/p5_crpt2.c
@@ -231,13 +231,16 @@ int PKCS5_v2_PBKDF2_keyivgen_ex(EVP_CIPHER_CTX *ctx, const char *pass,
         goto err;
     }
 
+    (void)ERR_set_mark();
     prfmd = prfmd_fetch = EVP_MD_fetch(libctx, OBJ_nid2sn(hmac_md_nid), propq);
     if (prfmd == NULL)
         prfmd = EVP_get_digestbynid(hmac_md_nid);
     if (prfmd == NULL) {
+        (void)ERR_clear_last_mark();
         ERR_raise(ERR_LIB_EVP, EVP_R_UNSUPPORTED_PRF);
         goto err;
     }
+    (void)ERR_pop_to_mark();
 
     if (kdf->salt->type != V_ASN1_OCTET_STRING) {
         ERR_raise(ERR_LIB_EVP, EVP_R_UNSUPPORTED_SALT_TYPE);

--- a/crypto/pkcs12/p12_mutl.c
+++ b/crypto/pkcs12/p12_mutl.c
@@ -108,15 +108,20 @@ static int pkcs12_gen_mac(PKCS12 *p12, const char *pass, int passlen,
     X509_ALGOR_get0(&macoid, NULL, NULL, macalg);
     if (OBJ_obj2txt(md_name, sizeof(md_name), macoid, 0) < 0)
         return 0;
+
+    (void)ERR_set_mark();
     md = md_fetch = EVP_MD_fetch(p12->authsafes->ctx.libctx, md_name,
                                  p12->authsafes->ctx.propq);
     if (md == NULL)
         md = EVP_get_digestbynid(OBJ_obj2nid(macoid));
 
     if (md == NULL) {
+        (void)ERR_clear_last_mark();
         ERR_raise(ERR_LIB_PKCS12, PKCS12_R_UNKNOWN_DIGEST_ALGORITHM);
         return 0;
     }
+    (void)ERR_pop_to_mark();
+
     md_size = EVP_MD_get_size(md);
     md_nid = EVP_MD_get_type(md);
     if (md_size < 0)


### PR DESCRIPTION
```
openssl pkcs12 -engine gost -export -inkey seckey.pem -in cert.pem -out user.pfx -keypbe gost89 -certpbe gost89 -macalg md_gost12_256
Engine "gost" set.
Enter Export Password:
Verifying - Enter Export Password:
00040D4CB27F0000:error:0308010C:digital envelope routines:inner_evp_generic_fetch:unsupported:../../../../openssl/crypto/evp/evp_fetch.c:373:Global default library context, Algorithm (md_gost12_512 : 107), Properties (<null>)
00040D4CB27F0000:error:0308010C:digital envelope routines:inner_evp_generic_fetch:unsupported:../../../../openssl/crypto/evp/evp_fetch.c:373:Global default library context, Algorithm (md_gost12_512 : 107), Properties (<null>)
00040D4CB27F0000:error:0308010C:digital envelope routines:inner_evp_generic_fetch:unsupported:../../../../openssl/crypto/evp/evp_fetch.c:373:Global default library context, Algorithm (GOST R 34.11-2012 with 256 bit hash : 101), Properties (<null>)
0
```