### PR TITLE
x509: Fix possible use-after-free when OOM

### DIFF
--- a/crypto/x509/pcy_node.c
+++ b/crypto/x509/pcy_node.c
@@ -98,11 +98,11 @@ X509_POLICY_NODE *ossl_policy_level_add_node(X509_POLICY_LEVEL *level,
             tree->extra_data = sk_X509_POLICY_DATA_new_null();
         if (tree->extra_data == NULL) {
             ERR_raise(ERR_LIB_X509V3, ERR_R_CRYPTO_LIB);
-            goto node_error;
+            goto extra_data_error;
         }
         if (!sk_X509_POLICY_DATA_push(tree->extra_data, data)) {
             ERR_raise(ERR_LIB_X509V3, ERR_R_CRYPTO_LIB);
-            goto node_error;
+            goto extra_data_error;
         }
     }
 
@@ -111,6 +111,14 @@ X509_POLICY_NODE *ossl_policy_level_add_node(X509_POLICY_LEVEL *level,
         parent->nchild++;
 
     return node;
+
+ extra_data_error:
+    if (level != NULL) {
+        if (level->anyPolicy == node)
+            level->anyPolicy = NULL;
+        else
+            (void) sk_X509_POLICY_NODE_pop(level->nodes);
+    }
 
  node_error:
     ossl_policy_node_free(node);


### PR DESCRIPTION
`ossl_policy_level_add_node()` first adds the new node to the `level->nodes` stack, and then attempts to add extra data if `extra_data` is true. If memory allocation or adding the extra data to `tree->extra_data` fails, the allocated node (that has already been added to the `level->nodes` stack) is freed using `ossl_policy_node_free()`, which leads to a potential use after free.

Additionally, the tree's node count and the parent's child count would not be updated, despite the new node being added.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] ~~documentation is added or updated~~
- [ ] ~~tests are added or updated~~
