### PR TITLE
doc: update FIPS provider version information

### DIFF
--- a/doc/man7/OSSL_PROVIDER-FIPS.pod
+++ b/doc/man7/OSSL_PROVIDER-FIPS.pod
@@ -426,6 +426,17 @@ A simple self test callback is shown below for illustrative purposes.
 
 =head1 NOTES
 
+Some released versions of OpenSSL do not include a validated
+FIPS provider.  To determine which versions have undergone
+the validation process, please refer to the
+L<OpenSSL Downloads page|https://www.openssl.org/source/>.  If you
+require FIPS-approved functionality, it is essential to build your FIPS
+provider using one of the validated versions listed there.  Normally,
+it is possible to utilize a FIPS provider constructed from one of the
+validated versions alongside F<libcrypto> and F<libssl> compiled from any
+release within the same major release series.  This flexibility enables
+you to address bug fixes and CVEs that fall outside the FIPS boundary.
+
 The FIPS provider in OpenSSL 3.1 includes some non-FIPS validated algorithms,
 consequently the property query C<fips=yes> is mandatory for applications that
 want to operate in a FIPS approved manner.  The algorithms are:
@@ -455,9 +466,9 @@ L<provider(7)>
 
 This functionality was added in OpenSSL 3.0.
 
-OpenSSL 3.0 includes a FIPS 140-2 approved FIPS provider.
+OpenSSL 3.0.0 and OpenSSL 3.0.8 include a FIPS 140-2 approved FIPS provider.
 
-OpenSSL 3.1 includes a FIPS 140-3 approved FIPS provider.
+OpenSSL 3.1 will include a FIPS 140-3 approved FIPS provider.
 
 =head1 COPYRIGHT
 

--- a/doc/man7/OSSL_PROVIDER-FIPS.pod
+++ b/doc/man7/OSSL_PROVIDER-FIPS.pod
@@ -460,15 +460,12 @@ L<OSSL_SELF_TEST_new(3)>,
 L<OSSL_PARAM(3)>,
 L<openssl-core.h(7)>,
 L<openssl-core_dispatch.h(7)>,
-L<provider(7)>
+L<provider(7)>,
+L<https://www.openssl.org/source/>
 
 =head1 HISTORY
 
 This functionality was added in OpenSSL 3.0.
-
-OpenSSL 3.0.0 and OpenSSL 3.0.8 include a FIPS 140-2 approved FIPS provider.
-
-OpenSSL 3.1 will include a FIPS 140-3 approved FIPS provider.
 
 =head1 COPYRIGHT
 

--- a/doc/man7/fips_module.pod
+++ b/doc/man7/fips_module.pod
@@ -470,6 +470,17 @@ L<OSSL_PROVIDER_get0_name(3)>.
 
 =head1 NOTES
 
+Some released versions of OpenSSL do not include a validated
+FIPS provider.  To determine which versions have undergone
+the validation process, please refer to the
+L<OpenSSL Downloads page|https://www.openssl.org/source/>.  If you
+require FIPS-approved functionality, it is essential to build your FIPS
+provider using one of the validated versions listed there.  Normally,
+it is possible to utilize a FIPS provider constructed from one of the
+validated versions alongside F<libcrypto> and F<libssl> compiled from any
+release within the same major release series.  This flexibility enables
+you to address bug fixes and CVEs that fall outside the FIPS boundary.
+
 The FIPS provider in OpenSSL 3.1 includes some non-FIPS validated algorithms,
 consequently the property query C<fips=yes> is mandatory for applications that
 want to operate in a FIPS approved manner.  The algorithms are:
@@ -486,16 +497,13 @@ want to operate in a FIPS approved manner.  The algorithms are:
 
 =head1 SEE ALSO
 
-L<migration_guide(7)>, L<crypto(7)>, L<fips_config(5)>
+L<migration_guide(7)>, L<crypto(7)>, L<fips_config(5)>,
+L<https://www.openssl.org/source/>
 
 =head1 HISTORY
 
 The FIPS module guide was created for use with the new FIPS provider
 in OpenSSL 3.0.
-
-OpenSSL 3.0 includes a FIPS 140-2 approved FIPS provider.
-
-OpenSSL 3.1 includes a FIPS 140-3 approved FIPS provider.
 
 =head1 COPYRIGHT
 


### PR DESCRIPTION
With 3.0.8 validated, we need to note this in the documentation.

- [x] documentation is added or updated
- [ ] tests are added or updated
