### PR TITLE
APPS: remove spurious errors when certain config file entries are not provided - backport

### DIFF
--- a/apps/ca.c
+++ b/apps/ca.c
@@ -628,6 +628,8 @@ end_of_options:
 
     f = NCONF_get_string(conf, section, ENV_NAMEOPT);
 
+    if (f == NULL)
+        ERR_clear_error();
     if (f != NULL) {
         if (!set_nameopt(f)) {
             BIO_printf(bio_err, "Invalid name options: \"%s\"\n", f);
@@ -785,8 +787,10 @@ end_of_options:
         /* We can have sections in the ext file */
         if (extensions == NULL) {
             extensions = NCONF_get_string(extfile_conf, "default", "extensions");
-            if (extensions == NULL)
+            if (extensions == NULL) {
+                ERR_clear_error();
                 extensions = "default";
+            }
         }
     }
 
@@ -824,6 +828,8 @@ end_of_options:
             char *tmp_email_dn = NULL;
 
             tmp_email_dn = NCONF_get_string(conf, section, ENV_DEFAULT_EMAIL_DN);
+            if (tmp_email_dn == NULL)
+                ERR_clear_error();
             if (tmp_email_dn != NULL && strcmp(tmp_email_dn, "no") == 0)
                 email_dn = 0;
         }
@@ -839,6 +845,7 @@ end_of_options:
         if (NCONF_get_string(conf, section, ENV_RAND_SERIAL) != NULL) {
             rand_ser = 1;
         } else {
+            ERR_clear_error();
             serialfile = lookup_conf(conf, section, ENV_SERIAL);
             if (serialfile == NULL)
                 goto end;
@@ -908,8 +915,10 @@ end_of_options:
         }
 
         if (days == 0) {
-            if (!NCONF_get_number(conf, section, ENV_DEFAULT_DAYS, &days))
+            if (!NCONF_get_number(conf, section, ENV_DEFAULT_DAYS, &days)) {
+                ERR_clear_error();
                 days = 0;
+            }
         }
         if (enddate == NULL && days == 0) {
             BIO_printf(bio_err, "cannot lookup how many days to certify for\n");
@@ -1161,22 +1170,28 @@ end_of_options:
             }
         }
 
-        if ((crlnumberfile = NCONF_get_string(conf, section, ENV_CRLNUMBER))
-            != NULL)
+        crlnumberfile = NCONF_get_string(conf, section, ENV_CRLNUMBER);
+        if (crlnumberfile != NULL) {
             if ((crlnumber = load_serial(crlnumberfile, NULL, 0, NULL))
                 == NULL) {
                 BIO_printf(bio_err, "error while loading CRL number\n");
                 goto end;
             }
+        } else {
+            ERR_clear_error();
+        }
 
         if (!crldays && !crlhours && !crlsec) {
             if (!NCONF_get_number(conf, section,
-                                  ENV_DEFAULT_CRL_DAYS, &crldays))
+                                  ENV_DEFAULT_CRL_DAYS, &crldays)) {
+                ERR_clear_error();
                 crldays = 0;
+            }
             if (!NCONF_get_number(conf, section,
-                                  ENV_DEFAULT_CRL_HOURS, &crlhours))
+                                  ENV_DEFAULT_CRL_HOURS, &crlhours)) {
+                ERR_clear_error();
                 crlhours = 0;
-            ERR_clear_error();
+            }
         }
         if ((crl_nextupdate == NULL) &&
                 (crldays == 0) && (crlhours == 0) && (crlsec == 0)) {

--- a/apps/cmp.c
+++ b/apps/cmp.c
@@ -2148,6 +2148,7 @@ static char *conf_get_string(const CONF *src_conf, const char *groups,
     while ((end = prev_item(groups, end)) != NULL) {
         if ((res = NCONF_get_string(src_conf, opt_item, name)) != NULL)
             return res;
+        ERR_clear_error();
     }
     return res;
 }

--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -1679,7 +1679,10 @@ CA_DB *load_index(const char *dbfile, DB_ATTR *db_attr)
         char *p = NCONF_get_string(dbattr_conf, NULL, "unique_subject");
         if (p) {
             retdb->attributes.unique_subject = parse_yesno(p, 1);
+        } else {
+            ERR_clear_error();
         }
+
     }
 
     retdb->dbfname = OPENSSL_strdup(dbfile);

--- a/apps/req.c
+++ b/apps/req.c
@@ -635,8 +635,10 @@ int req_main(int argc, char **argv)
     if (newreq && pkey == NULL) {
         app_RAND_load_conf(req_conf, section);
 
-        if (!NCONF_get_number(req_conf, section, BITS, &newkey_len))
+        if (!NCONF_get_number(req_conf, section, BITS, &newkey_len)) {
+            ERR_clear_error();
             newkey_len = DEFAULT_KEY_LENGTH;
+        }
 
         genctx = set_keygen_ctx(keyalg, &keyalgstr, &newkey_len, gen_eng);
         if (genctx == NULL)


### PR DESCRIPTION
This backports the functional essence of #20971 to 3.0 and 3.1,
at least for all cases that I am aware of.


