### PR TITLE
`CMS_ContentInfo_free()`: fix mem leak on encrypted content key

### DIFF
--- a/crypto/asn1/asn_mime.c
+++ b/crypto/asn1/asn_mime.c
@@ -516,6 +516,12 @@ int SMIME_crlf_copy(BIO *in, BIO *out, int flags)
     int len;
     char linebuf[MAX_SMLEN];
     int ret;
+
+    if (in == NULL || out == NULL) {
+        ERR_raise(ERR_LIB_ASN1, ERR_R_PASSED_NULL_PARAMETER);
+        return 0;
+    }
+
     /*
      * Buffer output so we don't write one line at a time. This is useful
      * when streaming as we don't end up with one OCTET STRING per line.

--- a/crypto/cms/cms_env.c
+++ b/crypto/cms/cms_env.c
@@ -142,10 +142,12 @@ CMS_EncryptedContentInfo *ossl_cms_get0_env_enc_content(const CMS_ContentInfo *c
 {
     switch (cms_get_enveloped_type(cms)) {
     case CMS_ENVELOPED_STANDARD:
-        return cms->d.envelopedData->encryptedContentInfo;
+        return cms->d.envelopedData == NULL ? NULL
+            : cms->d.envelopedData->encryptedContentInfo;
 
     case CMS_ENVELOPED_AUTH:
-        return cms->d.authEnvelopedData->authEncryptedContentInfo;
+        return cms->d.authEnvelopedData == NULL ? NULL
+            : cms->d.authEnvelopedData->authEncryptedContentInfo;
 
     default:
         return NULL;

--- a/crypto/cms/cms_lib.c
+++ b/crypto/cms/cms_lib.c
@@ -74,6 +74,10 @@ CMS_ContentInfo *CMS_ContentInfo_new(void)
 void CMS_ContentInfo_free(CMS_ContentInfo *cms)
 {
     if (cms != NULL) {
+        CMS_EncryptedContentInfo *ec = ossl_cms_get0_env_enc_content(cms);
+
+        if (ec != NULL)
+            OPENSSL_clear_free(ec->key, ec->keylen);
         OPENSSL_free(cms->ctx.propq);
         ASN1_item_free((ASN1_VALUE *)cms, ASN1_ITEM_rptr(CMS_ContentInfo));
     }


### PR DESCRIPTION
Also check for NULL pointer arguments in `SMIME_crlf_copy()`.

Fixes #21026