### PR TITLE
Fix documentation where openssl-genrsa is listed as deprecated since OpenSSL 3.0

### DIFF
--- a/doc/man1/openssl-genrsa.pod.in
+++ b/doc/man1/openssl-genrsa.pod.in
@@ -36,9 +36,6 @@ B<openssl> B<genrsa>
 
 =head1 DESCRIPTION
 
-This command has been deprecated.
-The L<openssl-genpkey(1)> command should be used instead.
-
 This command generates an RSA private key.
 
 =head1 OPTIONS
@@ -126,7 +123,7 @@ L<openssl-gendsa(1)>
 
 =head1 HISTORY
 
-This command was deprecated in OpenSSL 3.0.
+This command was erroneously marked as deprecated in OpenSSL 3.0. It is not deprecated.
 
 =head1 COPYRIGHT
 

--- a/doc/man1/openssl-genrsa.pod.in
+++ b/doc/man1/openssl-genrsa.pod.in
@@ -121,10 +121,6 @@ L<openssl(1)>,
 L<openssl-genpkey(1)>,
 L<openssl-gendsa(1)>
 
-=head1 HISTORY
-
-This command was erroneously marked as deprecated in OpenSSL 3.0. It is not deprecated.
-
 =head1 COPYRIGHT
 
 Copyright 2000-2022 The OpenSSL Project Authors. All Rights Reserved.


### PR DESCRIPTION
openssl-genrsa is not deprecated however the OpenSSL documentation states that it is the case from OpenSSL 3.0. This has been fixed in the documentation, specifically in manpage 1.

Fixes #21055

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
