### PR TITLE
doc: update FIPS provider version information

### DIFF
--- a/doc/man7/OSSL_PROVIDER-FIPS.pod
+++ b/doc/man7/OSSL_PROVIDER-FIPS.pod
@@ -430,13 +430,12 @@ L<OSSL_SELF_TEST_new(3)>,
 L<OSSL_PARAM(3)>,
 L<openssl-core.h(7)>,
 L<openssl-core_dispatch.h(7)>,
-L<provider(7)>
+L<provider(7)>,
+L<https://www.openssl.org/source/>
 
 =head1 HISTORY
 
 This functionality was added in OpenSSL 3.0.
-
-OpenSSL 3.0.0 and OpenSSL 3.0.8 include a FIPS 140-2 approved FIPS provider.
 
 =head1 COPYRIGHT
 

--- a/doc/man7/OSSL_PROVIDER-FIPS.pod
+++ b/doc/man7/OSSL_PROVIDER-FIPS.pod
@@ -408,6 +408,19 @@ A simple self test callback is shown below for illustrative purposes.
     return ret;
   }
 
+=head1 NOTES
+
+Some released versions of OpenSSL do not include a validated
+FIPS provider.  To determine which versions have undergone
+the validation process, please refer to the
+L<OpenSSL Downloads page|https://www.openssl.org/source/>.  If you
+require FIPS-approved functionality, it is essential to build your FIPS
+provider using one of the validated versions listed there.  Normally,
+it is possible to utilize a FIPS provider constructed from one of the
+validated versions alongside F<libcrypto> and F<libssl> compiled from any
+release within the same major release series.  This flexibility enables
+you to address bug fixes and CVEs that fall outside the FIPS boundary.
+
 =head1 SEE ALSO
 
 L<openssl-fipsinstall(1)>,
@@ -422,6 +435,8 @@ L<provider(7)>
 =head1 HISTORY
 
 This functionality was added in OpenSSL 3.0.
+
+OpenSSL 3.0.0 and OpenSSL 3.0.8 include a FIPS 140-2 approved FIPS provider.
 
 =head1 COPYRIGHT
 

--- a/doc/man7/fips_module.pod
+++ b/doc/man7/fips_module.pod
@@ -456,6 +456,19 @@ use L<EVP_MD_get0_provider(3)>.
 To extract the name from the B<OSSL_PROVIDER>, use
 L<OSSL_PROVIDER_get0_name(3)>.
 
+=head1 NOTES
+
+Some released versions of OpenSSL do not include a validated
+FIPS provider.  To determine which versions have undergone
+the validation process, please refer to the
+L<OpenSSL Downloads page|https://www.openssl.org/source/>.  If you
+require FIPS-approved functionality, it is essential to build your FIPS
+provider using one of the validated versions listed there.  Normally,
+it is possible to utilize a FIPS provider constructed from one of the
+validated versions alongside F<libcrypto> and F<libssl> compiled from any
+release within the same major release series.  This flexibility enables
+you to address bug fixes and CVEs that fall outside the FIPS boundary.
+
 =head1 SEE ALSO
 
 L<migration_guide(7)>, L<crypto(7)>, L<fips_config(5)>
@@ -464,6 +477,8 @@ L<migration_guide(7)>, L<crypto(7)>, L<fips_config(5)>
 
 The FIPS module guide was created for use with the new FIPS provider
 in OpenSSL 3.0.
+
+OpenSSL 3.0.0 and OpenSSL 3.0.8 include a FIPS 140-2 approved FIPS provider.
 
 =head1 COPYRIGHT
 

--- a/doc/man7/fips_module.pod
+++ b/doc/man7/fips_module.pod
@@ -471,14 +471,13 @@ you to address bug fixes and CVEs that fall outside the FIPS boundary.
 
 =head1 SEE ALSO
 
-L<migration_guide(7)>, L<crypto(7)>, L<fips_config(5)>
+L<migration_guide(7)>, L<crypto(7)>, L<fips_config(5)>,
+L<https://www.openssl.org/source/>
 
 =head1 HISTORY
 
 The FIPS module guide was created for use with the new FIPS provider
 in OpenSSL 3.0.
-
-OpenSSL 3.0.0 and OpenSSL 3.0.8 include a FIPS 140-2 approved FIPS provider.
 
 =head1 COPYRIGHT
 


### PR DESCRIPTION
With 3.0.8 validated, we need to note this in the documentation.

Counterpart of #21049 for 3.0.x

- [x] documentation is added or updated
- [ ] tests are added or updated
