### PR TITLE
tags: fix `make tags' target for out of tree builds

### DIFF
--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -1381,7 +1381,7 @@ test_ordinals:
 
 tags TAGS: FORCE
 	rm -f TAGS tags
-	-util/ctags.sh
+	-( cd $(SRCDIR); util/ctags.sh )
 	-etags `find . -name '*.[ch]' -o -name '*.pm'`
 
 providers/fips.checksum.new: providers/fips.module.sources.new


### PR DESCRIPTION

- [ ] documentation is added or updated
- [ ] tests are added or updated
