### PR TITLE
CMP app: tweak user guidance and comments; increase robustness

### DIFF
--- a/apps/cmp.c
+++ b/apps/cmp.c
@@ -1976,6 +1976,7 @@ static int setup_client_ctx(OSSL_CMP_CTX *ctx, ENGINE *engine)
 
         if ((info = OPENSSL_zalloc(sizeof(*info))) == NULL)
             goto err;
+        APP_HTTP_TLS_INFO_free(OSSL_CMP_CTX_get_http_cb_arg(ctx));
         (void)OSSL_CMP_CTX_set_http_cb_arg(ctx, info);
         info->ssl_ctx = setup_ssl_ctx(ctx, host, engine);
         info->server = host;
@@ -3120,6 +3121,7 @@ int cmp_main(int argc, char **argv)
 #ifndef OPENSSL_NO_SOCK
         APP_HTTP_TLS_INFO *info = OSSL_CMP_CTX_get_http_cb_arg(cmp_ctx);
 
+        (void)OSSL_CMP_CTX_set_http_cb_arg(cmp_ctx, NULL);
 #endif
         ossl_cmp_mock_srv_free(OSSL_CMP_CTX_get_transfer_cb_arg(cmp_ctx));
         X509_STORE_free(OSSL_CMP_CTX_get_certConf_cb_arg(cmp_ctx));

--- a/apps/cmp.c
+++ b/apps/cmp.c
@@ -1560,7 +1560,7 @@ static int setup_request_ctx(OSSL_CMP_CTX *ctx, ENGINE *engine)
                 if (!set_name(opt_subject, OSSL_CMP_CTX_set1_subjectName, ctx, "subject"))
                     return 0;
             } else {
-                CMP_warn1("-subject %s since -ref or -cert is given", msg);
+                CMP_warn1("-subject %s since sender is taken from -ref or -cert", msg);
             }
         }
         if (opt_issuer != NULL)
@@ -1575,6 +1575,16 @@ static int setup_request_ctx(OSSL_CMP_CTX *ctx, ENGINE *engine)
             CMP_warn1("-policies %s", msg);
         if (opt_policy_oids != NULL)
             CMP_warn1("-policy_oids %s", msg);
+        if (opt_cmd != CMP_P10CR) {
+            if (opt_implicit_confirm)
+                CMP_warn1("-implicit_confirm %s, and 'p10cr'", msg);
+            if (opt_disable_confirm)
+                CMP_warn1("-disable_confirm %s, and 'p10cr'", msg);
+            if (opt_certout != NULL)
+                CMP_warn1("-certout %s, and 'p10cr'", msg);
+            if (opt_chainout != NULL)
+                CMP_warn1("-chainout %s, and 'p10cr'", msg);
+        }
     }
     if (opt_cmd == CMP_KUR) {
         char *ref_cert = opt_oldcert != NULL ? opt_oldcert : opt_cert;
@@ -1656,7 +1666,7 @@ static int setup_request_ctx(OSSL_CMP_CTX *ctx, ENGINE *engine)
 
     if (opt_csr != NULL) {
         if (opt_cmd == CMP_GENM) {
-            CMP_warn("-csr option is ignored for command 'genm'");
+            CMP_warn("-csr option is ignored for 'genm' command");
         } else {
             csr = load_csr_autofmt(opt_csr, FORMAT_UNDEF, NULL, "PKCS#10 CSR");
             if (csr == NULL)
@@ -1736,7 +1746,7 @@ static int setup_request_ctx(OSSL_CMP_CTX *ctx, ENGINE *engine)
 
     if (opt_oldcert != NULL) {
         if (opt_cmd == CMP_GENM) {
-            CMP_warn("-oldcert option is ignored for command 'genm'");
+            CMP_warn("-oldcert option is ignored for 'genm' command");
         } else {
             X509 *oldcert = load_cert_pwd(opt_oldcert, opt_keypass,
                                           opt_cmd == CMP_KUR ?

--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -2349,6 +2349,7 @@ int do_X509_sign(X509 *cert, int force_v1, EVP_PKEY *pkey, const char *md,
                              "keyid, issuer", !self_sign))
             goto end;
     }
+    /* May add further measures for ensuring RFC 5280 compliance, see #19805 */
 
     if (mctx != NULL && do_sign_init(mctx, pkey, md, sigopts) > 0)
         rv = (X509_sign_ctx(cert, mctx) > 0);

--- a/apps/lib/cmp_mock_srv.c
+++ b/apps/lib/cmp_mock_srv.c
@@ -264,7 +264,7 @@ static OSSL_CMP_PKISI *process_cert_request(OSSL_CMP_SRV_CTX *srv_ctx,
 
     if (ctx->certOut != NULL
             && (*certOut = X509_dup(ctx->certOut)) == NULL)
-        /* Should better return a cert produced from data in request template */
+        /* Should return a cert produced from request template, see FR #16054 */
         goto err;
     if (ctx->chainOut != NULL
             && (*chainOut = X509_chain_up_ref(ctx->chainOut)) == NULL)

--- a/crypto/cmp/cmp_client.c
+++ b/crypto/cmp/cmp_client.c
@@ -31,7 +31,7 @@
 static int unprotected_exception(const OSSL_CMP_CTX *ctx,
                                  const OSSL_CMP_MSG *rep,
                                  int invalid_protection,
-                                 int expected_type /* ignored here */)
+                                 ossl_unused int expected_type)
 {
     int rcvd_type = OSSL_CMP_MSG_get_bodytype(rep /* may be NULL */);
     const char *msg_type = NULL;
@@ -556,7 +556,8 @@ int OSSL_CMP_certConf_cb(OSSL_CMP_CTX *ctx, X509 *cert, int fail_info,
  */
 static int cert_response(OSSL_CMP_CTX *ctx, int sleep, int rid,
                          OSSL_CMP_MSG **resp, int *checkAfter,
-                         int req_type, int expected_type)
+                         ossl_unused int req_type,
+                         ossl_unused int expected_type)
 {
     EVP_PKEY *rkey = ossl_cmp_ctx_get0_newPubkey(ctx);
     int fail_info = 0; /* no failure */
@@ -646,6 +647,10 @@ static int cert_response(OSSL_CMP_CTX *ctx, int sleep, int rid,
     if (fail_info != 0) /* immediately log error before any certConf exchange */
         ossl_cmp_log1(ERROR, ctx,
                       "rejecting newly enrolled cert with subject: %s", subj);
+    /*
+     * certConf exchange should better be moved to do_certreq_seq() such that
+     * also more low-level errors with CertReqMessages get reported to server
+     */
     if (!ctx->disableConfirm
             && !ossl_cmp_hdr_has_implicitConfirm((*resp)->header)) {
         if (!ossl_cmp_exchange_certConf(ctx, rid, fail_info, txt))

--- a/doc/man1/openssl-cmp.pod.in
+++ b/doc/man1/openssl-cmp.pod.in
@@ -270,8 +270,8 @@ L<openssl-passphrase-options(1)>.
 
 =item B<-subject> I<name>
 
-X509 Distinguished Name (DN) of subject to use in the requested certificate
-template.
+X.509 Distinguished Name (DN) to use as subject field
+in the requested certificate template in IR/CR/KUR messages.
 If the NULL-DN (C</>) is given then no subject is placed in the template.
 Default is the subject DN of any PKCS#10 CSR given with the B<-csr> option.
 For KUR, a further fallback is the subject DN
@@ -293,8 +293,8 @@ C</DC=org/DC=OpenSSL/DC=users/UID=123456+CN=John Doe>
 
 =item B<-issuer> I<name>
 
-X509 issuer Distinguished Name (DN) of the CA server
-to place in the requested certificate template in IR/CR/KUR.
+X.509 Distinguished Name (DN) use as issuer field
+in the requested certificate template in IR/CR/KUR messages.
 If the NULL-DN (C</>) is given then no issuer is placed in the template.
 
 If provided and neither B<-recipient> nor B<-srvcert> is given,
@@ -512,11 +512,13 @@ Defaults to any path given with B<-server>, else C<"/">.
 
 =item B<-keep_alive> I<value>
 
-If the given value is 0 then HTTP connections are not kept open
-after receiving a response, which is the default behavior for HTTP 1.0.
-If the value is 1 or 2 then persistent connections are requested.
-If the value is 2 then persistent connections are required,
-i.e., in case the server does not grant them an error occurs.
+If the given value is 0 then HTTP connections are closed after each response
+(which would be the default behavior of HTTP 1.0)
+even if a CMP transaction needs more than one round trip.
+If the value is 1 or 2
+then for each transaction a persistent connection is requested.
+If the value is 2 then a persistent connection is required,
+i.e., an error occurs if the server does not grant it.
 The default value is 1, which means preferring to keep the connection open.
 
 =item B<-msg_timeout> I<seconds>
@@ -570,7 +572,8 @@ as well as for chain building
 when validating server certificates (checking signature-based
 CMP message protection) and when validating newly enrolled certificates.
 
-Multiple filenames or URLs may be given, separated by commas and/or whitespace.
+Multiple sources may be given, separated by commas and/or whitespace
+(where in the latter case the whole argument must be enclosed in "...").
 Each source may contain multiple certificates.
 
 =item B<-srvcert> I<filename>|I<uri>


### PR DESCRIPTION
This handles some loose ends with the CMP implementation, documentation, and code comments.
 * `apps/cmp.c: improve warnings on option use`
* `apps/cmp.c:` make management of `http_cb_arg` pointer more robust
* `apps.c`: add comment to `do_X509_sign()` referring to question # 19805
* `openssl-cmp.pod.in`: tweak doc of `-subject`, `-issuer`, `-keep_alive`, and `-untrusted` options
* `cmp_mock_srv.c`: improve comment on cert to be produced from request template
* `cmp_client.c`: add comment on certConf and add `ossl_unused` to two functions