### PR TITLE
CMP: Extend revocation request with issuer and serial

### DIFF
--- a/crypto/cmp/cmp_client.c
+++ b/crypto/cmp/cmp_client.c
@@ -774,7 +774,8 @@ int OSSL_CMP_exec_RR_ses(OSSL_CMP_CTX *ctx)
         return 0;
     }
     ctx->status = OSSL_CMP_PKISTATUS_request;
-    if (ctx->oldCert == NULL && ctx->p10CSR == NULL) {
+    if (ctx->oldCert == NULL && ctx->p10CSR == NULL
+        && (ctx->serialNumber == NULL || ctx->issuer == NULL)) {
         ERR_raise(ERR_LIB_CMP, CMP_R_MISSING_REFERENCE_CERT);
         return 0;
     }

--- a/crypto/cmp/cmp_ctx.c
+++ b/crypto/cmp/cmp_ctx.c
@@ -226,6 +226,7 @@ void OSSL_CMP_CTX_free(OSSL_CMP_CTX *ctx)
 
     EVP_PKEY_free(ctx->newPkey);
     X509_NAME_free(ctx->issuer);
+    ASN1_INTEGER_free(ctx->serialNumber);
     X509_NAME_free(ctx->subjectName);
     sk_GENERAL_NAME_pop_free(ctx->subjectAltNames, GENERAL_NAME_free);
     X509_EXTENSIONS_free(ctx->reqExtensions);
@@ -611,6 +612,8 @@ DEFINE_OSSL_CMP_CTX_set1(expected_sender, X509_NAME)
 /* Set the X509 name of the issuer to be placed in the certTemplate */
 DEFINE_OSSL_CMP_CTX_set1(issuer, X509_NAME)
 
+/* Set the ASN1_INTEGER serial to be placed in the certTemplate for rr */
+DEFINE_OSSL_CMP_CTX_set1(serialNumber, ASN1_INTEGER)
 /*
  * Set the subject name that will be placed in the certificate
  * request. This will be the subject name on the received certificate.

--- a/crypto/cmp/cmp_local.h
+++ b/crypto/cmp/cmp_local.h
@@ -101,7 +101,8 @@ struct ossl_cmp_ctx_st {
     /* certificate template */
     EVP_PKEY *newPkey; /* explicit new private/public key for cert enrollment */
     int newPkey_priv; /* flag indicating if newPkey contains private key */
-    X509_NAME *issuer; /* issuer name to used in cert template */
+    X509_NAME *issuer; /* issuer name to used in cert template, also in rr */
+    ASN1_INTEGER *serialNumber; /* certificate serial number to use in rr */
     int days; /* Number of days new certificates are asked to be valid for */
     X509_NAME *subjectName; /* subject name to be used in cert template */
     STACK_OF(GENERAL_NAME) *subjectAltNames; /* to add to the cert template */

--- a/crypto/cmp/cmp_msg.c
+++ b/crypto/cmp/cmp_msg.c
@@ -518,27 +518,38 @@ OSSL_CMP_MSG *ossl_cmp_certrep_new(OSSL_CMP_CTX *ctx, int bodytype,
 OSSL_CMP_MSG *ossl_cmp_rr_new(OSSL_CMP_CTX *ctx)
 {
     OSSL_CMP_MSG *msg = NULL;
+    const X509_NAME *issuer = NULL;
+    const X509_NAME *subject = NULL;
+    const ASN1_INTEGER *serialNumber = NULL;
+    EVP_PKEY *pubkey = NULL;
     OSSL_CMP_REVDETAILS *rd;
     int ret;
 
-    if (!ossl_assert(ctx != NULL && (ctx->oldCert != NULL
-                                     || ctx->p10CSR != NULL)))
+    if (!ossl_assert(ctx != NULL
+                     && (ctx->oldCert != NULL || ctx->p10CSR != NULL
+                         || (ctx->serialNumber != NULL && ctx->issuer != NULL))))
         return NULL;
 
     if ((rd = OSSL_CMP_REVDETAILS_new()) == NULL)
         goto err;
 
+    if (ctx->serialNumber != NULL && ctx->issuer != NULL) {
+        issuer = ctx->issuer;
+        serialNumber = ctx->serialNumber;
+    } else if (ctx->oldCert != NULL) {
+        issuer = X509_get_issuer_name(ctx->oldCert);
+        serialNumber = X509_get0_serialNumber(ctx->oldCert);
+    } else if (ctx->p10CSR != NULL) {
+        pubkey = X509_REQ_get0_pubkey(ctx->p10CSR);
+        subject = X509_REQ_get_subject_name(ctx->p10CSR);
+    }
+    else {
+        goto err;
+    }
+
     /* Fill the template from the contents of the certificate to be revoked */
-    ret = ctx->oldCert != NULL
-        ? OSSL_CRMF_CERTTEMPLATE_fill(rd->certDetails,
-                                      NULL /* pubkey would be redundant */,
-                                      NULL /* subject would be redundant */,
-                                      X509_get_issuer_name(ctx->oldCert),
-                                      X509_get0_serialNumber(ctx->oldCert))
-        : OSSL_CRMF_CERTTEMPLATE_fill(rd->certDetails,
-                                      X509_REQ_get0_pubkey(ctx->p10CSR),
-                                      X509_REQ_get_subject_name(ctx->p10CSR),
-                                      NULL, NULL);
+    ret = OSSL_CRMF_CERTTEMPLATE_fill(rd->certDetails, pubkey, subject,
+                                      issuer, serialNumber);
     if (!ret)
         goto err;
 

--- a/doc/man1/openssl-cmp.pod.in
+++ b/doc/man1/openssl-cmp.pod.in
@@ -24,7 +24,6 @@ Certificate enrollment options:
 [B<-newkey> I<filename>|I<uri>]
 [B<-newkeypass> I<arg>]
 [B<-subject> I<name>]
-[B<-issuer> I<name>]
 [B<-days> I<number>]
 [B<-reqexts> I<name>]
 [B<-sans> I<spec>]
@@ -43,6 +42,8 @@ Certificate enrollment options:
 Certificate enrollment and revocation options:
 
 [B<-oldcert> I<filename>|I<uri>]
+[B<-issuer> I<name>]
+[B<-serial> I<number>]
 [B<-revreason> I<number>]
 
 Message transfer options:
@@ -292,18 +293,6 @@ Example:
 
 C</DC=org/DC=OpenSSL/DC=users/UID=123456+CN=John Doe>
 
-=item B<-issuer> I<name>
-
-X.509 Distinguished Name (DN) use as issuer field
-in the requested certificate template in IR/CR/KUR messages.
-If the NULL-DN (C</>) is given then no issuer is placed in the template.
-
-If provided and neither B<-recipient> nor B<-srvcert> is given,
-the issuer DN is used as fallback recipient of outgoing CMP messages.
-
-The argument must be formatted as I</type0=value0/type1=value1/type2=...>.
-For details see the description of the B<-subject> option.
-
 =item B<-days> I<number>
 
 Number of days the new certificate is requested to be valid for, counting from
@@ -421,6 +410,7 @@ The certificate to be updated (i.e., renewed or re-keyed) in Key Update Request
 For KUR the certificate to be updated defaults to B<-cert>,
 and the resulting certificate is called I<reference certificate>.
 For RR the certificate to be revoked can also be specified using B<-csr>.
+B<-oldcert> and B<-csr> is ignored if B<-issuer> and B<-serial> is provided.
 
 The reference certificate, if any, is also used for
 deriving default subject DN and Subject Alternative Names and the
@@ -429,6 +419,23 @@ Its public key is used as a fallback in the template of certification requests.
 Its subject is used as sender of outgoing messages if B<-cert> is not given.
 Its issuer is used as default recipient in CMP message headers
 if neither B<-recipient>, B<-srvcert>, nor B<-issuer> is given.
+
+=item B<-issuer> I<name>
+
+X.509 Distinguished Name (DN) use as issuer field
+in the requested certificate template in IR/CR/KUR/RR messages.
+If the NULL-DN (C</>) is given then no issuer is placed in the template.
+
+If provided and neither B<-recipient> nor B<-srvcert> is given,
+the issuer DN is used as fallback recipient of outgoing CMP messages.
+
+The argument must be formatted as I</type0=value0/type1=value1/type2=...>.
+For details see the description of the B<-subject> option.
+
+=item B<-serial> I<number>
+
+Specify the Serial number of certificate to be revoked in revocation request.
+The serial number can be decimal or hex (if preceded by C<0x>)
 
 =item B<-revreason> I<number>
 

--- a/doc/man3/OSSL_CMP_CTX_new.pod
+++ b/doc/man3/OSSL_CMP_CTX_new.pod
@@ -43,6 +43,7 @@ OSSL_CMP_CTX_set1_extraCertsOut,
 OSSL_CMP_CTX_set0_newPkey,
 OSSL_CMP_CTX_get0_newPkey,
 OSSL_CMP_CTX_set1_issuer,
+OSSL_CMP_CTX_set1_serialNumber,
 OSSL_CMP_CTX_set1_subjectName,
 OSSL_CMP_CTX_push1_subjectAltName,
 OSSL_CMP_CTX_set0_reqExtensions,
@@ -133,6 +134,7 @@ OSSL_CMP_CTX_set1_senderNonce
  int OSSL_CMP_CTX_set0_newPkey(OSSL_CMP_CTX *ctx, int priv, EVP_PKEY *pkey);
  EVP_PKEY *OSSL_CMP_CTX_get0_newPkey(const OSSL_CMP_CTX *ctx, int priv);
  int OSSL_CMP_CTX_set1_issuer(OSSL_CMP_CTX *ctx, const X509_NAME *name);
+ int OSSL_CMP_CTX_set1_serialNumber(OSSL_CMP_CTX *ctx, const ASN1_INTEGER *sn);
  int OSSL_CMP_CTX_set1_subjectName(OSSL_CMP_CTX *ctx, const X509_NAME *name);
  int OSSL_CMP_CTX_push1_subjectAltName(OSSL_CMP_CTX *ctx,
                                        const GENERAL_NAME *name);
@@ -467,7 +469,7 @@ The reference counts of those certificates handled successfully are increased.
 OSSL_CMP_CTX_get0_untrusted() returns a pointer to the
 list of untrusted certs in I<ctx>, which may be empty if unset.
 
-OSSL_CMP_CTX_set1_cert() sets the CMP signer certificate
+OSSL_CMP_CTX_set1_cert() sets the CMP I<signer certificate>
 related to the private key used for CMP message protection.
 Therefore the public key of this I<cert> must correspond to
 the private key set before or thereafter via OSSL_CMP_CTX_set1_pkey().
@@ -556,6 +558,9 @@ private component then NULL is returned.
 OSSL_CMP_CTX_set1_issuer() sets the name of the intended issuer that
 will be set in the CertTemplate, i.e., the X509 name of the CA server.
 
+OSSL_CMP_CTX_set1_serialNumber() sets the serial number optionally used to
+select the certificate to be revoked in Revocation Requests (RR).
+
 OSSL_CMP_CTX_set1_subjectName() sets the subject DN that will be used in
 the CertTemplate structure when requesting a new cert. For Key Update Requests
 (KUR), it defaults to the subject DN of the reference certificate,
@@ -588,17 +593,22 @@ to the X509_EXTENSIONS of the requested certificate template.
 
 OSSL_CMP_CTX_set1_oldCert() sets the old certificate to be updated in
 Key Update Requests (KUR) or to be revoked in Revocation Requests (RR).
-It must be given for RR, else it defaults to the CMP signer certificate.
-The I<reference certificate> determined in this way, if any, is also used for
-deriving default subject DN, public key, Subject Alternative Names, and the
-default issuer entry in the requested certificate template of IR/CR/KUR.
+For RR, this is ignored if an issuer name and a serial number are provided using
+OSSL_CMP_CTX_set1_issuer() and OSSL_CMP_CTX_set1_serialNumber(), respectively.
+For IR/CR/KUR this sets the I<reference certificate>,
+which otherwise defaults to the CMP signer certificate.
+The I<reference certificate> determined this way, if any, is used for providing
+default public key, subject DN, Subject Alternative Names, and issuer DN entries
+in the requested certificate template of IR/CR/KUR messages.
+
 The subject of the reference certificate is used as the sender field value
 in CMP message headers.
 Its issuer is used as default recipient in CMP message headers.
 
 OSSL_CMP_CTX_set1_p10CSR() sets the PKCS#10 CSR to use in P10CR messages.
-If such a CSR is provided, its subject, public key, and extension fields are
-also used as fallback values for the certificate template of IR/CR/KUR messages.
+If such a CSR is provided, its subject and public key fields are also
+used as fallback values for the certificate template of IR/CR/KUR/RR messages,
+and any extensions included are added to the template of IR/CR/KUR messages.
 
 OSSL_CMP_CTX_push0_genm_ITAV() adds I<itav> to the stack in the I<ctx> which
 will be the body of a General Message sent with this context.
@@ -828,6 +838,8 @@ OSSL_CMP_CTX_reset_geninfo_ITAVs() was added in OpenSSL 3.0.8.
 
 OSSL_CMP_CTX_get0_libctx(), OSSL_CMP_CTX_get0_propq(), and
 OSSL_CMP_CTX_get0_validatedSrvCert() were added in OpenSSL 3.2.
+
+OSSL_CMP_CTX_set1_serialNumber() was added in OpenSSL 3.2.
 
 =head1 COPYRIGHT
 

--- a/doc/man3/OSSL_CMP_exec_certreq.pod
+++ b/doc/man3/OSSL_CMP_exec_certreq.pod
@@ -101,7 +101,12 @@ a negative value as the I<req_type> argument then OSSL_CMP_try_certreq()
 aborts the CMP transaction by sending an error message to the server.
 
 OSSL_CMP_exec_RR_ses() requests the revocation of the certificate
-specified in the I<ctx> using L<OSSL_CMP_CTX_set1_oldCert(3)>.
+specified in the I<ctx> using the issuer DN and serial number set by
+OSSL_CMP_CTX_set1_issuer(3) and OSSL_CMP_CTX_set1_serialNumber(3), respectively,
+otherwise the issuer DN and serial number
+of the certificate set by L<OSSL_CMP_CTX_set1_oldCert(3)>,
+otherwise the subject DN and public key
+of the certificate signing request set by L<OSSL_CMP_CTX_set1_p10CSR(3)>.
 RFC 4210 is vague in which PKIStatus should be returned by the server.
 We take "accepted" and "grantedWithMods" as clear success and handle
 "revocationWarning" and "revocationNotification" just as warnings because CAs

--- a/include/openssl/cmp.h.in
+++ b/include/openssl/cmp.h.in
@@ -344,6 +344,7 @@ int OSSL_CMP_CTX_set1_extraCertsOut(OSSL_CMP_CTX *ctx,
 int OSSL_CMP_CTX_set0_newPkey(OSSL_CMP_CTX *ctx, int priv, EVP_PKEY *pkey);
 EVP_PKEY *OSSL_CMP_CTX_get0_newPkey(const OSSL_CMP_CTX *ctx, int priv);
 int OSSL_CMP_CTX_set1_issuer(OSSL_CMP_CTX *ctx, const X509_NAME *name);
+int OSSL_CMP_CTX_set1_serialNumber(OSSL_CMP_CTX *ctx, const ASN1_INTEGER *sn);
 int OSSL_CMP_CTX_set1_subjectName(OSSL_CMP_CTX *ctx, const X509_NAME *name);
 int OSSL_CMP_CTX_push1_subjectAltName(OSSL_CMP_CTX *ctx,
                                       const GENERAL_NAME *name);

--- a/test/recipes/80-test_cmp_http_data/test_commands.csv
+++ b/test/recipes/80-test_cmp_http_data/test_commands.csv
@@ -33,15 +33,23 @@ expected,description, -section,val, -cmd,val,val2, -cacertsout,val,val2, -infoty
 1, --- get certificate for revocation ----, -section,, -cmd,cr,,BLANK,,,BLANK,,,BLANK,,BLANK,
 1,revreason AACompromise, -section,, -cmd,rr,,BLANK,,,BLANK,,, -oldcert,_RESULT_DIR/test.cert.pem, -revreason,10
 1, --- get certificate for revocation ----, -section,, -cmd,cr,,BLANK,,,BLANK,,,BLANK,,BLANK,
-1, --- use csr for revocation ----, -section,, -cmd,rr,,BLANK,,,BLANK,,,BLANK,, -revreason,0, -csr,csr.pem
-1, --- get certificate for revocation ----, -section,, -cmd,cr,,BLANK,,,BLANK,,,BLANK,,BLANK,
-0,without oldcert, -section,, -cmd,rr,,BLANK,,,BLANK,,,BLANK,,BLANK,
-0,oldcert file nonexistent, -section,, -cmd,rr,,BLANK,,,BLANK,,, -oldcert,idontexist,BLANK,
-0,empty oldcert file, -section,, -cmd,rr,,BLANK,,,BLANK,,, -oldcert,empty.txt,BLANK,
-0,oldcert and key do not match, -section,, -cmd,rr,,BLANK,,,BLANK,,, -oldcert,trusted.crt, -revreason,0
 0,revreason 11 (invalid), -section,, -cmd,rr,,BLANK,,,BLANK,,, -oldcert,_RESULT_DIR/test.cert.pem, -revreason,11
 0,revreason string, -section,, -cmd,rr,,BLANK,,,BLANK,,, -oldcert,_RESULT_DIR/test.cert.pem, -revreason,abc
 0,revreason out of integer range, -section,, -cmd,rr,,BLANK,,,BLANK,,, -oldcert,_RESULT_DIR/test.cert.pem, -revreason,010000000000000000000
+1,use csr for revocation, -section,, -cmd,rr,,BLANK,,,BLANK,,,BLANK,, -revreason,0, -csr,csr.pem
+1, --- get certificate for revocation ----, -section,, -cmd,cr,,BLANK,,,BLANK,,,BLANK,,BLANK,
+1,use issuer and serial for revocation, -section,, -cmd,rr,,BLANK,,,BLANK,,,BLANK,, -revreason,-1,BLANK,,, -expect_sender,"""",-issuer,/C=AU/ST=Some-State/O=Internet Widgits Pty Ltd/CN=subinterCA,-serial,0xA44DB0329A714A8D
+1, --- get certificate for revocation ----, -section,, -cmd,cr,,BLANK,,,BLANK,,,BLANK,,BLANK,
+0,use issuer but no serial for revocation, -section,, -cmd,rr,,BLANK,,,BLANK,,,BLANK,, -revreason,-1,BLANK,,, -expect_sender,"""",-issuer,/C=AU/ST=Some-State/O=Internet Widgits Pty Ltd/CN=subinterCA,BLANK,
+0,use serial but no issuer for revocation, -section,, -cmd,rr,,BLANK,,,BLANK,,,BLANK,, -revreason,-1,BLANK,,, -expect_sender,"""", -issuer, """", -serial, 0xA44DB0329A714A8D
+0,wrong issuer for revocation, -section,, -cmd,rr,,BLANK,,,BLANK,,,BLANK,, -revreason,-1,BLANK,,, -expect_sender,"""", -issuer, /C=AU/ST=Some-State/O=Internet Widgits Pty Ltd/CN=wrongCA, -serial, 0xA44DB0329A714A8D
+0,bad issuer DN for revocation, -section,, -cmd,rr,,BLANK,,,BLANK,,,BLANK,, -revreason,-1,BLANK,,, -expect_sender,"""", -issuer, "'XYZ'", -serial, 0xA44DB0329A714A8D
+0,wrong serial for revocation, -section,, -cmd,rr,,BLANK,,,BLANK,,,BLANK,, -revreason,-1,BLANK,,, -expect_sender,"""", -issuer, /C=AU/ST=Some-State/O=Internet Widgits Pty Ltd/CN=subinterCA, -serial, 0xA44DB0329A714A00
+0,bad serial for revocation, -section,, -cmd,rr,,BLANK,,,BLANK,,,BLANK,, -revreason,-1,BLANK,,, -expect_sender,"""", -issuer, /C=AU/ST=Some-State/O=Internet Widgits Pty Ltd/CN=subinterCA, -serial, xyz
+0,rr without oldcert/csr/issuer/serial, -section,, -cmd,rr,,BLANK,,,BLANK,,,BLANK,,BLANK,
+0,rr with oldcert file nonexistent, -section,, -cmd,rr,,BLANK,,,BLANK,,, -oldcert,idontexist,BLANK,
+0,rr with empty oldcert file, -section,, -cmd,rr,,BLANK,,,BLANK,,, -oldcert,empty.txt,BLANK,
+0,rr where oldcert and key do not match, -section,, -cmd,rr,,BLANK,,,BLANK,,, -oldcert,trusted.crt, -revreason,0
 ,,,,,,,,,,,,,,,,,
 1,ir + infotype, -section,, -cmd,ir,,BLANK,,, -infotype,signKeyPairTypes,,BLANK,,BLANK,
 1,genm without -infotype, -section,, -cmd,genm,,BLANK,,, BLANK,,,BLANK,,BLANK,

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5452,6 +5452,7 @@ OSSL_CMP_CTX_get0_libctx                ?	3_2_0	EXIST::FUNCTION:CMP
 OSSL_CMP_CTX_get0_propq                 ?	3_2_0	EXIST::FUNCTION:CMP
 OSSL_CMP_CTX_reset_geninfo_ITAVs        ?	3_0_8	EXIST::FUNCTION:CMP
 OSSL_CMP_CTX_get0_validatedSrvCert      ?	3_2_0	EXIST::FUNCTION:CMP
+OSSL_CMP_CTX_set1_serialNumber          ?	3_2_0	EXIST::FUNCTION:CMP
 OSSL_CMP_MSG_update_recipNonce          ?	3_0_9	EXIST::FUNCTION:CMP
 OSSL_CRMF_CERTTEMPLATE_get0_publicKey   ?	3_2_0	EXIST::FUNCTION:CRMF
 CMS_final_digest                        ?	3_2_0	EXIST::FUNCTION:CMS


### PR DESCRIPTION
CMP: support specifying certificate to be revoked via issuer and serial number

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
