### PR TITLE
Fix BN_nnmod and BN_mod_inverse incorrect result

### DIFF
--- a/crypto/bn/bn_exp.c
+++ b/crypto/bn/bn_exp.c
@@ -1362,6 +1362,22 @@ int BN_mod_exp_simple(BIGNUM *r, const BIGNUM *a, const BIGNUM *p,
     wstart = bits - 1;          /* The top bit of the window */
     wend = 0;                   /* The bottom bit of the window */
 
+    if (r == m) {
+        BIGNUM *m_dup = BN_CTX_get(ctx);
+
+        if (m_dup == NULL || BN_copy(m_dup, r) == NULL)
+            goto err;
+        m = m_dup;
+    }
+
+    if (r == p) {
+        BIGNUM *p_dup = BN_CTX_get(ctx);
+
+        if (p_dup == NULL || BN_copy(p_dup, p) == NULL)
+            goto err;
+        p = p_dup;
+    }
+
     if (!BN_one(r))
         goto err;
 

--- a/crypto/bn/bn_mod.c
+++ b/crypto/bn/bn_mod.c
@@ -195,6 +195,17 @@ int bn_mod_sub_fixed_top(BIGNUM *r, const BIGNUM *a, const BIGNUM *b,
 int BN_mod_sub_quick(BIGNUM *r, const BIGNUM *a, const BIGNUM *b,
                      const BIGNUM *m)
 {
+    if (r == m) {
+        BIGNUM *m_dup = BN_dup(m);
+        int ret;
+
+        if (m_dup == NULL)
+            return 0;
+        ret = BN_mod_sub_quick(r, a, b, m_dup);
+        BN_free(m_dup);
+        return ret;
+    }
+
     if (!BN_sub(r, a, b))
         return 0;
     if (r->neg)

--- a/crypto/bn/bn_mod.c
+++ b/crypto/bn/bn_mod.c
@@ -12,6 +12,17 @@
 
 int BN_nnmod(BIGNUM *r, const BIGNUM *m, const BIGNUM *d, BN_CTX *ctx)
 {
+    if (r == d) {
+        BIGNUM *d_dup = BN_dup(d);
+        int ret;
+
+        if (d_dup == NULL)
+            return 0;
+        ret = BN_nnmod(r, m, d_dup, ctx);
+        BN_free(d_dup);
+        return ret;
+    }
+
     /*
      * like BN_mod, but returns non-negative remainder (i.e., 0 <= r < |d|
      * always holds)

--- a/test/bntest.c
+++ b/test/bntest.c
@@ -3193,6 +3193,38 @@ err:
     return res;
 }
 
+static int test_mod_exp_simple(void)
+{
+    int res = 0;
+    char *str = NULL;
+    BIGNUM* a = NULL;
+    BIGNUM* b = NULL;
+    BIGNUM* c = NULL;
+
+    if (!TEST_true(BN_dec2bn(&a, "3")))
+        goto err;
+    if (!TEST_true(BN_dec2bn(&b, "1")))
+        goto err;
+    if (!TEST_true(BN_dec2bn(&c, "11")))
+        goto err;
+    /* Note that this aliases the result with the modulus. */
+    if (!TEST_int_eq(BN_mod_exp_simple(c, a, b, c, ctx), 1))
+        goto err;
+    if (!TEST_ptr_ne(str = BN_bn2dec(c), NULL))
+        goto err;
+    if (!TEST_int_eq(strcmp(str, "3"), 0))
+        goto err;
+
+    res = 1;
+
+err:
+    BN_free(a);
+    BN_free(b);
+    BN_free(c);
+    OPENSSL_free(str);
+    return res;
+}
+
 static int file_test_run(STANZA *s)
 {
     static const FILETEST filetests[] = {
@@ -3340,6 +3372,7 @@ int setup_tests(void)
         ADD_ALL_TESTS(test_mod_exp_consttime, (int)OSSL_NELEM(ModExpTests));
         ADD_TEST(test_mod_exp2_mont);
         ADD_TEST(test_mod_inverse);
+        ADD_TEST(test_mod_exp_simple);
         if (stochastic)
             ADD_TEST(test_rand_range);
     } else {

--- a/test/bntest.c
+++ b/test/bntest.c
@@ -3176,6 +3176,7 @@ static int test_mod_inverse(void)
         goto err;
     if (!TEST_true(BN_dec2bn(&b, "3259122431")))
         goto err;
+    /* Note that this aliases the result with the modulus. */
     if (!TEST_ptr_eq(BN_mod_inverse(b, a, b, ctx), b))
         goto err;
     if (!TEST_ptr_ne(str = BN_bn2dec(b), NULL))

--- a/test/bntest.c
+++ b/test/bntest.c
@@ -3165,6 +3165,33 @@ err:
     return res;
 }
 
+static int test_mod_inverse(void)
+{
+    int res = 0;
+    char *str = NULL;
+    BIGNUM* a = NULL;
+    BIGNUM* b = NULL;
+
+    if (!TEST_true(BN_dec2bn(&a, "5193817943")))
+        goto err;
+    if (!TEST_true(BN_dec2bn(&b, "3259122431")))
+        goto err;
+    if (!TEST_ptr_eq(BN_mod_inverse(b, a, b, ctx), b))
+        goto err;
+    if (!TEST_ptr_ne(str = BN_bn2dec(b), NULL))
+        goto err;
+    if (!TEST_int_eq(strcmp(str, "2609653924"), 0))
+        goto err;
+
+    res = 1;
+
+err:
+    BN_free(a);
+    BN_free(b);
+    OPENSSL_free(str);
+    return res;
+}
+
 static int file_test_run(STANZA *s)
 {
     static const FILETEST filetests[] = {
@@ -3311,6 +3338,7 @@ int setup_tests(void)
         ADD_ALL_TESTS(test_mod_exp, (int)OSSL_NELEM(ModExpTests));
         ADD_ALL_TESTS(test_mod_exp_consttime, (int)OSSL_NELEM(ModExpTests));
         ADD_TEST(test_mod_exp2_mont);
+        ADD_TEST(test_mod_inverse);
         if (stochastic)
             ADD_TEST(test_rand_range);
     } else {


### PR DESCRIPTION
When r aliases d the result may be wrong, since d is overwritten by BN_mod but it may still be used later.

Fixes #21110

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
