### PR TITLE
Cast the argument to unsigned char when calling isspace()

### DIFF
--- a/apps/cmp.c
+++ b/apps/cmp.c
@@ -2174,7 +2174,7 @@ static const char *prev_item(const char *opt, const char *end)
     beg = end;
     while (beg > opt) {
         --beg;
-        if (beg[0] == ',' || isspace(beg[0])) {
+        if (beg[0] == ',' || isspace(_UC(beg[0]))) {
             ++beg;
             break;
         }
@@ -2189,7 +2189,7 @@ static const char *prev_item(const char *opt, const char *end)
     opt_item[len] = '\0';
     while (beg > opt) {
         --beg;
-        if (beg[0] != ',' && !isspace(beg[0])) {
+        if (beg[0] != ',' && !isspace(_UC(beg[0]))) {
             ++beg;
             break;
         }

--- a/apps/lib/apps.c
+++ b/apps/lib/apps.c
@@ -690,13 +690,13 @@ void *app_malloc(size_t sz, const char *what)
 char *next_item(char *opt) /* in list separated by comma and/or space */
 {
     /* advance to separator (comma or whitespace), if any */
-    while (*opt != ',' && !isspace(*opt) && *opt != '\0')
+    while (*opt != ',' && !isspace(_UC(*opt)) && *opt != '\0')
         opt++;
     if (*opt != '\0') {
         /* terminate current item */
         *opt++ = '\0';
         /* skip over any whitespace after separator */
-        while (isspace(*opt))
+        while (isspace(_UC(*opt)))
             opt++;
     }
     return *opt == '\0' ? NULL : opt; /* NULL indicates end of input */

--- a/apps/req.c
+++ b/apps/req.c
@@ -198,7 +198,7 @@ static int duplicated(LHASH_OF(OPENSSL_STRING) *addexts, char *kv)
 
     /* Check syntax. */
     /* Skip leading whitespace, make a copy. */
-    while (isspace(*kv))
+    while (isspace(_UC(*kv)))
         kv++;
     if ((p = strchr(kv, '=')) == NULL) {
         BIO_printf(bio_err, "Parse error on -addext: missing '='\n");
@@ -210,7 +210,7 @@ static int duplicated(LHASH_OF(OPENSSL_STRING) *addexts, char *kv)
 
     /* Skip trailing space before the equal sign. */
     for (p = kv + off; p > kv; --p)
-        if (!isspace(p[-1]))
+        if (!isspace(_UC(p[-1])))
             break;
     if (p == kv) {
         BIO_printf(bio_err, "Parse error on -addext: missing key\n");

--- a/test/evp_test.c
+++ b/test/evp_test.c
@@ -3811,11 +3811,11 @@ static int prov_available(char *providers)
     int more = 1;
 
     while (more) {
-        for (; isspace(*providers); providers++)
+        for (; isspace((unsigned char)(*providers)); providers++)
             continue;
         if (*providers == '\0')
             break;               /* End of the road */
-        for (p = providers; *p != '\0' && !isspace(*p); p++)
+        for (p = providers; *p != '\0' && !isspace((unsigned char)(*p)); p++)
             continue;
         if (*p == '\0')
             more = 0;

--- a/test/testutil/provider.c
+++ b/test/testutil/provider.c
@@ -177,11 +177,11 @@ int fips_provider_version_match(OSSL_LIB_CTX *libctx, const char *versions)
     } mode;
 
     while (*versions != '\0') {
-        for (; isspace(*versions); versions++)
+        for (; isspace((unsigned char)(*versions)); versions++)
             continue;
         if (*versions == '\0')
             break;
-        for (p = versions; *versions != '\0' && !isspace(*versions); versions++)
+        for (p = versions; *versions != '\0' && !isspace((unsigned char)(*versions)); versions++)
             continue;
         if (*p == '!') {
             mode = MODE_NE;


### PR DESCRIPTION
Fixes further build issues for "strict" checks in `cygwin` (see https://github.com/openssl/openssl/pull/21006#issuecomment-1581836982).
