### PR TITLE
Set RC4 defines on libcrypto/liblegacy

### DIFF
--- a/crypto/rc4/build.info
+++ b/crypto/rc4/build.info
@@ -21,9 +21,14 @@ SOURCE[../../libcrypto]=$RC4ASM
 
 # When all deprecated symbols are removed, libcrypto doesn't export the
 # rc4 functions, so we must include them directly in liblegacy.a
-IF[{- $disabled{'deprecated-3.0'} && !$disabled{module} && !$disabled{shared} -}]
+IF[{- !$disabled{module} && !$disabled{shared} -}]
   SOURCE[../../providers/liblegacy.a]=$RC4ASM
 ENDIF
+
+# Implementations are now spread across several libraries, so the defines
+# need to be applied to all affected libraries and modules.
+DEFINE[../../libcrypto]=$RC4DEF
+DEFINE[../../providers/liblegacy.a]=$RC4DEF
 
 GENERATE[rc4-586.S]=asm/rc4-586.pl
 DEPEND[rc4-586.S]=../perlasm/x86asm.pl

--- a/providers/implementations/ciphers/cipher_rc4_hmac_md5.h
+++ b/providers/implementations/ciphers/cipher_rc4_hmac_md5.h
@@ -31,3 +31,6 @@ typedef struct prov_cipher_hw_rc4_hmac_md5_st {
 } PROV_CIPHER_HW_RC4_HMAC_MD5;
 
 const PROV_CIPHER_HW *ossl_prov_cipher_hw_rc4_hmac_md5(size_t keybits);
+
+void rc4_md5_enc(RC4_KEY *key, const void *in0, void *out,
+                 MD5_CTX *ctx, const void *inp, size_t blocks);


### PR DESCRIPTION
Also add missing prototype for rc4_md5_enc.

Fixes #21150 