### PR TITLE
X509_NAME_cmp fix for empty name

### DIFF
--- a/crypto/x509/x509_cmp.c
+++ b/crypto/x509/x509_cmp.c
@@ -277,11 +277,11 @@ int X509_NAME_cmp(const X509_NAME *a, const X509_NAME *b)
     if (ret == 0 && a->canon_enclen == 0)
         return 0;
 
-    if (a->canon_enc == NULL || b->canon_enc == NULL)
-        return -2;
-
-    if (ret == 0)
+    if (ret == 0) {
+        if (a->canon_enc == NULL || b->canon_enc == NULL)
+            return -2;
         ret = memcmp(a->canon_enc, b->canon_enc, a->canon_enclen);
+    }
 
     return ret < 0 ? -1 : ret > 0;
 }


### PR DESCRIPTION
The leaf certificate in our certificate chain currently has an empty subject.
This was verifying fine always until we updated alpine linux to version with OpenSSL 3.0.8 (from 1.1.1q).
It is also still validating fine on debian linux with OpenSSL 3.0.8.

Root cause analysis indicated that following commit caused the issue: https://github.com/openssl/openssl/commit/72ded6f2a93085f536b4a820ab42b2da26fecf1c

Reason is the empty subject is now always seen as an issue and returns -2.  In both cases when empty subject is a or b.  Which of course invalidates the compare invariant: `"" < "anything"` and `"anything" < ""`.

We have a certificate chain that exactly triggers issue on alpine linux qsort that the correct certificate is not found anymore in verification.

##### Checklist
- [ ] tests are added or updated
