### PR TITLE
Don't ask for an invalid group in an HRR

### DIFF
--- a/ssl/statem/extensions.c
+++ b/ssl/statem/extensions.c
@@ -1449,7 +1449,11 @@ static int final_key_share(SSL_CONNECTION *s, unsigned int context, int sent)
                     group_id = pgroups[i];
 
                     if (check_in_list(s, group_id, clntgroups, clnt_num_groups,
-                                      1))
+                                      1)
+                            && tls_group_allowed(s, group_id,
+                                                 SSL_SECOP_CURVE_SUPPORTED)
+                            && tls_valid_group(s, group_id, TLS1_3_VERSION,
+                                               TLS1_3_VERSION, 0, NULL))
                         break;
                 }
 

--- a/test/recipes/70-test_tls13hrr.t
+++ b/test/recipes/70-test_tls13hrr.t
@@ -86,7 +86,8 @@ ok($fatal_alert, "Server duplicated HRR");
 #        TLSv1.3. We expect the server to select X25519 in the HRR and the
 #        handshake to complete successfully
 SKIP: {
-    skip "EC is disabled in this build", 1 if disabled("ec");
+    skip "EC/TLSv1.2 is disabled in this build", 1
+        if disabled("ec") || disabled("tls1_2");
 
     $proxy->clear();
     $proxy->clientflags("-groups P-256:brainpoolP512r1:X25519");

--- a/test/recipes/70-test_tls13hrr.t
+++ b/test/recipes/70-test_tls13hrr.t
@@ -161,7 +161,7 @@ sub hrr_filter
         my @ciphersuites = (TLSProxy::Message::CIPHER_TLS13_AES_128_GCM_SHA256);
         $ch1->ciphersuite_len(2 * scalar @ciphersuites);
         $ch1->ciphersuites(\@ciphersuites);
-    } else {
+    } elsif ($testtype == INVALID_GROUP) {
         # INVALID_GROUP
         my $ext = pack "C7",
             0x00, 0x05, #List Length

--- a/test/recipes/70-test_tls13hrr.t
+++ b/test/recipes/70-test_tls13hrr.t
@@ -36,7 +36,8 @@ my $proxy = TLSProxy::Proxy->new(
 use constant {
     CHANGE_HRR_CIPHERSUITE => 0,
     CHANGE_CH1_CIPHERSUITE => 1,
-    DUPLICATE_HRR => 2
+    DUPLICATE_HRR => 2,
+    INVALID_GROUP => 3
 };
 
 #Test 1: A client should fail if the server changes the ciphersuite between the
@@ -49,7 +50,7 @@ if (disabled("ec")) {
 }
 my $testtype = CHANGE_HRR_CIPHERSUITE;
 $proxy->start() or plan skip_all => "Unable to start up Proxy for tests";
-plan tests => 3;
+plan tests => 4;
 ok(TLSProxy::Message->fail(), "Server ciphersuite changes");
 
 #Test 2: It is an error if the client changes the offered ciphersuites so that
@@ -77,6 +78,23 @@ if (disabled("ec")) {
 $testtype = DUPLICATE_HRR;
 $proxy->start();
 ok($fatal_alert, "Server duplicated HRR");
+
+#Test 4: If the client sends a group that is in the supported_groups list but
+#        otherwise not valid (e.g. not suitable for TLSv1.3) we should reject it
+#        and not consider it when sending the HRR. We send brainpoolP512r1 in
+#        the ClientHello, which is acceptable to the server but is not valid in
+#        TLSv1.3. We expect the server to select X25519 in the HRR and the
+#        handshake to complete successfully
+SKIP: {
+    skip "EC is disabled in this build", 1 if disabled("ec");
+
+    $proxy->clear();
+    $proxy->clientflags("-groups P-256:brainpoolP512r1:X25519");
+    $proxy->serverflags("-groups brainpoolP512r1:X25519");
+    $testtype = INVALID_GROUP;
+    $proxy->start();
+    ok(TLSProxy::Message->success(), "Invalid group with HRR");
+}
 
 sub hrr_filter
 {
@@ -131,16 +149,25 @@ sub hrr_filter
         return;
     }
 
-    # CHANGE_CH1_CIPHERSUITE
     if ($proxy->flight != 0) {
         return;
     }
 
     my $ch1 = ${$proxy->message_list}[0];
 
-    # The server will always pick TLS_AES_256_GCM_SHA384
-    my @ciphersuites = (TLSProxy::Message::CIPHER_TLS13_AES_128_GCM_SHA256);
-    $ch1->ciphersuite_len(2 * scalar @ciphersuites);
-    $ch1->ciphersuites(\@ciphersuites);
+    if ($testtype == CHANGE_CH1_CIPHERSUITE) {
+        # The server will always pick TLS_AES_256_GCM_SHA384
+        my @ciphersuites = (TLSProxy::Message::CIPHER_TLS13_AES_128_GCM_SHA256);
+        $ch1->ciphersuite_len(2 * scalar @ciphersuites);
+        $ch1->ciphersuites(\@ciphersuites);
+    } else {
+        # INVALID_GROUP
+        my $ext = pack "C7",
+            0x00, 0x05, #List Length
+            0x00, 0x1c, #brainpoolP512r1 (not compatible with TLSv1.3)
+            0x00, 0x01, 0xff; #key_exchange data
+        $ch1->set_extension(
+            TLSProxy::Message::EXT_KEY_SHARE, $ext);
+    }
     $ch1->repack();
 }


### PR DESCRIPTION
If the client sends us a group in a key_share that is in our
supported_groups list but is otherwise not suitable (e.g. not compatible
with TLSv1.3) we reject it. We should not ask for that same group again
in a subsequent HRR.

Fixes https://github.com/openssl/openssl/issues/21157
