### PR TITLE
rand_lib: RAND_poll: Reseed in non-"no-deprecated" builds.

### DIFF
--- a/crypto/rand/rand_lib.c
+++ b/crypto/rand/rand_lib.c
@@ -121,6 +121,8 @@ void RAND_keep_random_devices_open(int keep)
  */
 int RAND_poll(void)
 {
+    static const char salt[] = "polling";
+
 # ifndef OPENSSL_NO_DEPRECATED_3_0
     const RAND_METHOD *meth = RAND_get_rand_method();
     int ret = meth == RAND_OpenSSL();
@@ -149,14 +151,12 @@ int RAND_poll(void)
         ret = 1;
      err:
         ossl_rand_pool_free(pool);
+        return ret;
     }
-    return ret;
-# else
-    static const char salt[] = "polling";
+# endif
 
     RAND_seed(salt, sizeof(salt));
     return 1;
-# endif
 }
 
 # ifndef OPENSSL_NO_DEPRECATED_3_0


### PR DESCRIPTION
I recently discovered that with a default non-"no-deprecated" libcrypto build (i.e., the one that ships with Ubuntu 22.04 LTS), calls to RAND_poll don't reseed the DRBGs the way that calls to RAND_seed or RAND_add do.

I'm aware that the DRBGs will request and add entropy automatically, so manual reseeding isn't necessary.  However for applications that have reason (or requirement) to reseed during application-specific events, this brings RAND_poll in-line with the behavior of RAND_seed and RAND_add.