### PR TITLE
Fix incorrect ERR_raise() calls

### DIFF
--- a/crypto/x509/v3_purp.c
+++ b/crypto/x509/v3_purp.c
@@ -441,7 +441,7 @@ int ossl_x509v3_cache_extensions(X509 *x)
              * in case ctx->param->flags & X509_V_FLAG_X509_STRICT
              */
             if (bs->pathlen->type == V_ASN1_NEG_INTEGER) {
-                ERR_raise(ERR_LIB_X509, X509V3_R_NEGATIVE_PATHLEN);
+                ERR_raise(ERR_LIB_X509V3, X509V3_R_NEGATIVE_PATHLEN);
                 x->ex_flags |= EXFLAG_INVALID;
             } else {
                 x->ex_pathlen = ASN1_INTEGER_get(bs->pathlen);
@@ -482,7 +482,7 @@ int ossl_x509v3_cache_extensions(X509 *x)
         ASN1_BIT_STRING_free(usage);
         /* Check for empty key usage according to RFC 5280 section 4.2.1.3 */
         if (x->ex_kusage == 0) {
-            ERR_raise(ERR_LIB_X509, X509V3_R_EMPTY_KEY_USAGE);
+            ERR_raise(ERR_LIB_X509V3, X509V3_R_EMPTY_KEY_USAGE);
             x->ex_flags |= EXFLAG_INVALID;
         }
     } else if (i != -1) {
@@ -634,7 +634,7 @@ int ossl_x509v3_cache_extensions(X509 *x)
         return 1;
     }
     CRYPTO_THREAD_unlock(x->lock);
-    ERR_raise(ERR_LIB_X509, X509V3_R_INVALID_CERTIFICATE);
+    ERR_raise(ERR_LIB_X509V3, X509V3_R_INVALID_CERTIFICATE);
     return 0;
 }
 


### PR DESCRIPTION
A few ERR_raise() calls in v3_purp.c use the wrong library. For example, in OpenSSL 3.1.1 we get

00000000:error:0580009E:x509 certificate routines:ossl_x509v3_cache_extensions:reason(158):crypto/x509/v3_purp.c:635:

instead of

00000000:error:1100009E:X509 V3 routines:ossl_x509v3_cache_extensions:invalid certificate:crypto/x509/v3_purp.c:635: