### PR TITLE
Fix int_ctx_new() error when use 1.1.1n sm2 key and ec method engine

### DIFF
--- a/crypto/evp/p_lib.c
+++ b/crypto/evp/p_lib.c
@@ -722,6 +722,7 @@ static void detect_foreign_key(EVP_PKEY *pkey)
         break;
 #  ifndef OPENSSL_NO_EC
     case EVP_PKEY_SM2:
+        break;
     case EVP_PKEY_EC:
         pkey->foreign = pkey->pkey.ec != NULL
                         && ossl_ec_key_is_foreign(pkey->pkey.ec);


### PR DESCRIPTION
Fix #21169 
