### PR TITLE
Fix cmactest for the check-ansi CI

### DIFF
--- a/test/cmactest.c
+++ b/test/cmactest.c
@@ -31,6 +31,13 @@ static const char xtskey[32] = {
     0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f
 };
 
+#ifdef __GNUC__
+# pragma GCC diagnostic ignored "-Woverlength-strings"
+#endif
+#ifdef __clang__
+# pragma clang diagnostic ignored "-Woverlength-strings"
+#endif
+
 static struct test_st {
     const char key[32];
     int key_len;


### PR DESCRIPTION
Add pragmas to ignore overlength-string issues.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
