### PR TITLE
OpenSSL::paramnames: Use less magic perl

### DIFF
--- a/util/perl/OpenSSL/paramnames.pm
+++ b/util/perl/OpenSSL/paramnames.pm
@@ -576,12 +576,12 @@ sub generate_trie {
                 }
 
                 if (not defined $$cursor{$c}) {
-                    $$cursor{$c} = {};
+                    $cursor->{$c} = {};
                     $nodes++;
                 }
-                $cursor = %$cursor{$c};
+                $cursor = $cursor->{$c};
             }
-            $$cursor{'val'} = $name;
+            $cursor->{'val'} = $name;
         }
     }
     #print "\n\n/* $nodes nodes for $chars letters*/\n\n";


### PR DESCRIPTION
Constructions like `$$cursor{whatever}` and `%$cursor{whatever}` were ambiguous
in some perl versions, and it's still better to use the arrow syntax for the
way we use them, i.e. they can both be replaced with `$cursor->{whatever}`.

Fixes #21152
Fixes #21172
