### PR TITLE
Cherry-pick uefi float related changes to openssl-3.1

### DIFF
--- a/crypto/params.c
+++ b/crypto/params.c
@@ -36,6 +36,7 @@
 #define err_unsupported_real  \
     ERR_raise(ERR_LIB_CRYPTO, CRYPTO_R_PARAM_UNSUPPORTED_FLOATING_POINT_FORMAT)
 
+#ifndef OPENSSL_SYS_UEFI
 /*
  * Return the number of bits in the mantissa of a double.  This is used to
  * shift a larger integral value to determine if it will exactly fit into a
@@ -45,6 +46,7 @@ static unsigned int real_shift(void)
 {
     return sizeof(double) == 4 ? 24 : 53;
 }
+#endif
 
 OSSL_PARAM *OSSL_PARAM_locate(OSSL_PARAM *p, const char *key)
 {
@@ -376,8 +378,6 @@ OSSL_PARAM OSSL_PARAM_construct_ulong(const char *key, unsigned long int *buf)
 
 int OSSL_PARAM_get_int32(const OSSL_PARAM *p, int32_t *val)
 {
-    double d;
-
     if (val == NULL || p == NULL) {
         err_null_argument;
         return 0;
@@ -430,6 +430,9 @@ int OSSL_PARAM_get_int32(const OSSL_PARAM *p, int32_t *val)
         return general_get_int(p, val, sizeof(*val));
 
     } else if (p->data_type == OSSL_PARAM_REAL) {
+#ifndef OPENSSL_SYS_UEFI
+        double d;
+
         switch (p->data_size) {
         case sizeof(double):
             d = *(const double *)p->data;
@@ -442,6 +445,7 @@ int OSSL_PARAM_get_int32(const OSSL_PARAM *p, int32_t *val)
         }
         err_unsupported_real;
         return 0;
+#endif
     }
     err_bad_type;
     return 0;
@@ -490,6 +494,7 @@ int OSSL_PARAM_set_int32(OSSL_PARAM *p, int32_t val)
 #endif
         return general_set_int(p, &val, sizeof(val));
     } else if (p->data_type == OSSL_PARAM_REAL) {
+#ifndef OPENSSL_SYS_UEFI
         p->return_size = sizeof(double);
         if (p->data == NULL)
             return 1;
@@ -508,6 +513,7 @@ int OSSL_PARAM_set_int32(OSSL_PARAM *p, int32_t val)
         }
         err_unsupported_real;
         return 0;
+#endif
     }
     err_bad_type;
     return 0;
@@ -521,8 +527,6 @@ OSSL_PARAM OSSL_PARAM_construct_int32(const char *key, int32_t *buf)
 
 int OSSL_PARAM_get_uint32(const OSSL_PARAM *p, uint32_t *val)
 {
-    double d;
-
     if (val == NULL || p == NULL) {
         err_null_argument;
         return 0;
@@ -576,6 +580,9 @@ int OSSL_PARAM_get_uint32(const OSSL_PARAM *p, uint32_t *val)
 #endif
         return general_get_uint(p, val, sizeof(*val));
     } else if (p->data_type == OSSL_PARAM_REAL) {
+#ifndef OPENSSL_SYS_UEFI
+        double d;
+
         switch (p->data_size) {
         case sizeof(double):
             d = *(const double *)p->data;
@@ -588,6 +595,7 @@ int OSSL_PARAM_get_uint32(const OSSL_PARAM *p, uint32_t *val)
         }
         err_unsupported_real;
         return 0;
+#endif
     }
     err_bad_type;
     return 0;
@@ -640,6 +648,7 @@ int OSSL_PARAM_set_uint32(OSSL_PARAM *p, uint32_t val)
 #endif
         return general_set_uint(p, &val, sizeof(val));
     } else if (p->data_type == OSSL_PARAM_REAL) {
+#ifndef OPENSSL_SYS_UEFI
         p->return_size = sizeof(double);
         if (p->data == NULL)
             return 1;
@@ -655,6 +664,7 @@ int OSSL_PARAM_set_uint32(OSSL_PARAM *p, uint32_t val)
         }
         err_unsupported_real;
         return 0;
+#endif
     }
     err_bad_type;
     return 0;
@@ -668,8 +678,6 @@ OSSL_PARAM OSSL_PARAM_construct_uint32(const char *key, uint32_t *buf)
 
 int OSSL_PARAM_get_int64(const OSSL_PARAM *p, int64_t *val)
 {
-    double d;
-
     if (val == NULL || p == NULL) {
         err_null_argument;
         return 0;
@@ -707,6 +715,9 @@ int OSSL_PARAM_get_int64(const OSSL_PARAM *p, int64_t *val)
 #endif
         return general_get_int(p, val, sizeof(*val));
     } else if (p->data_type == OSSL_PARAM_REAL) {
+#ifndef OPENSSL_SYS_UEFI
+        double d;
+
         switch (p->data_size) {
         case sizeof(double):
             d = *(const double *)p->data;
@@ -726,6 +737,7 @@ int OSSL_PARAM_get_int64(const OSSL_PARAM *p, int64_t *val)
         }
         err_unsupported_real;
         return 0;
+#endif
     }
     err_bad_type;
     return 0;
@@ -733,8 +745,6 @@ int OSSL_PARAM_get_int64(const OSSL_PARAM *p, int64_t *val)
 
 int OSSL_PARAM_set_int64(OSSL_PARAM *p, int64_t val)
 {
-    uint64_t u64;
-
     if (p == NULL) {
         err_null_argument;
         return 0;
@@ -781,6 +791,9 @@ int OSSL_PARAM_set_int64(OSSL_PARAM *p, int64_t val)
 #endif
         return general_set_int(p, &val, sizeof(val));
     } else if (p->data_type == OSSL_PARAM_REAL) {
+#ifndef OPENSSL_SYS_UEFI
+        uint64_t u64;
+
         p->return_size = sizeof(double);
         if (p->data == NULL)
             return 1;
@@ -796,6 +809,7 @@ int OSSL_PARAM_set_int64(OSSL_PARAM *p, int64_t val)
         }
         err_unsupported_real;
         return 0;
+#endif
     }
     err_bad_type;
     return 0;
@@ -808,8 +822,6 @@ OSSL_PARAM OSSL_PARAM_construct_int64(const char *key, int64_t *buf)
 
 int OSSL_PARAM_get_uint64(const OSSL_PARAM *p, uint64_t *val)
 {
-    double d;
-
     if (val == NULL || p == NULL) {
         err_null_argument;
         return 0;
@@ -853,6 +865,9 @@ int OSSL_PARAM_get_uint64(const OSSL_PARAM *p, uint64_t *val)
 #endif
         return general_get_uint(p, val, sizeof(*val));
     } else if (p->data_type == OSSL_PARAM_REAL) {
+#ifndef OPENSSL_SYS_UEFI
+        double d;
+
         switch (p->data_size) {
         case sizeof(double):
             d = *(const double *)p->data;
@@ -872,6 +887,7 @@ int OSSL_PARAM_get_uint64(const OSSL_PARAM *p, uint64_t *val)
         }
         err_unsupported_real;
         return 0;
+#endif
     }
     err_bad_type;
     return 0;
@@ -930,6 +946,7 @@ int OSSL_PARAM_set_uint64(OSSL_PARAM *p, uint64_t val)
 #endif
         return general_set_uint(p, &val, sizeof(val));
     } else if (p->data_type == OSSL_PARAM_REAL) {
+#ifndef OPENSSL_SYS_UEFI
         p->return_size = sizeof(double);
         switch (p->data_size) {
         case sizeof(double):
@@ -942,6 +959,7 @@ int OSSL_PARAM_set_uint64(OSSL_PARAM *p, uint64_t val)
         }
         err_unsupported_real;
         return 0;
+#endif
     }
     err_bad_type;
     return 0;
@@ -1088,6 +1106,7 @@ OSSL_PARAM OSSL_PARAM_construct_BN(const char *key, unsigned char *buf,
                                 buf, bsize);
 }
 
+#ifndef OPENSSL_SYS_UEFI
 int OSSL_PARAM_get_double(const OSSL_PARAM *p, double *val)
 {
     int64_t i64;
@@ -1232,6 +1251,7 @@ OSSL_PARAM OSSL_PARAM_construct_double(const char *key, double *buf)
 {
     return ossl_param_construct(key, OSSL_PARAM_REAL, buf, sizeof(double));
 }
+#endif
 
 static int get_string_internal(const OSSL_PARAM *p, void **val,
                                size_t *max_len, size_t *used_len,


### PR DESCRIPTION
UEFI can only use the release version of openssl, lets cherry-pick these changes to openssl-3.0 and openssl-3.1branch.

cherry-pick from master branch.
https://github.com/openssl/openssl/commit/2c500578fc68871eca7fabc7ee36b4027891671b

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
