### PR TITLE
Partially revert #18070 (Add support for Windows CA certificate store)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -229,24 +229,13 @@ OpenSSL 3.2
 
    *Hugo Landau*
 
- * The `SSL_CERT_PATH` and `SSL_CERT_URI` environment variables are introduced.
-   `SSL_CERT_URI` can be used to specify a URI for a root certificate store. The
-   `SSL_CERT_PATH` environment variable specifies a delimiter-separated list of
-   paths which are searched for root certificates.
-
-   The existing `SSL_CERT_DIR` environment variable is deprecated.
-   `SSL_CERT_DIR` was previously used to specify either a delimiter-separated
-   list of paths or an URI, which is ambiguous. Setting `SSL_CERT_PATH` causes
-   `SSL_CERT_DIR` to be ignored for the purposes of determining root certificate
-   directories, and setting `SSL_CERT_URI` causes `SSL_CERT_DIR` to be ignored
-   for the purposes of determining root certificate stores.
-
-   *Hugo Landau*
-
  * Support for loading root certificates from the Windows certificate store
    has been added. The support is in the form of a store which recognises the
-   URI string of `org.openssl.winstore://`. This store is enabled by default and
-   can be disabled using the new compile-time option `no-winstore`.
+   URI string of `org.openssl.winstore://`. This URI scheme currently takes no
+   arguments. This store is built by default and can be disabled using the new
+   compile-time option `no-winstore`. This store is not currently used by
+   default and must be loaded explicitly using the above store URI. It is
+   expected to be loaded by default in the next minor release of OpenSSL.
 
    *Hugo Landau*
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -235,7 +235,7 @@ OpenSSL 3.2
    arguments. This store is built by default and can be disabled using the new
    compile-time option `no-winstore`. This store is not currently used by
    default and must be loaded explicitly using the above store URI. It is
-   expected to be loaded by default in the next minor release of OpenSSL.
+   expected to be loaded by default in the future.
 
    *Hugo Landau*
 

--- a/crypto/x509/by_dir.c
+++ b/crypto/x509/by_dir.c
@@ -88,18 +88,13 @@ static int dir_ctrl(X509_LOOKUP *ctx, int cmd, const char *argp, long argl,
     switch (cmd) {
     case X509_L_ADD_DIR:
         if (argl == X509_FILETYPE_DEFAULT) {
-            /* If SSL_CERT_PATH is provided and non-empty, use that. */
-            const char *dir = ossl_safe_getenv(X509_get_default_cert_path_env());
+            const char *dir = ossl_safe_getenv(X509_get_default_cert_dir_env());
 
-            /* Fallback to SSL_CERT_DIR. */
-            if (dir == NULL)
-                dir = ossl_safe_getenv(X509_get_default_cert_dir_env());
-
-            /* Fallback to built-in default. */
-            if (dir == NULL)
-                dir = X509_get_default_cert_dir();
-
-            ret = add_cert_dir(ld, dir, X509_FILETYPE_PEM);
+            if (dir)
+                ret = add_cert_dir(ld, dir, X509_FILETYPE_PEM);
+            else
+                ret = add_cert_dir(ld, X509_get_default_cert_dir(),
+                                   X509_FILETYPE_PEM);
             if (!ret) {
                 ERR_raise(ERR_LIB_X509, X509_R_LOADING_CERT_DIR);
             }

--- a/crypto/x509/by_store.c
+++ b/crypto/x509/by_store.c
@@ -111,21 +111,12 @@ static int by_store_ctrl_ex(X509_LOOKUP *ctx, int cmd, const char *argp,
 {
     switch (cmd) {
     case X509_L_ADD_STORE:
-        /* First try the newer default cert URI envvar. */
-        if (argp == NULL)
-            argp = ossl_safe_getenv(X509_get_default_cert_uri_env());
-
-        /* If not set, see if we have a URI in the older cert dir envvar. */
+        /* If no URI is given, use the default cert dir as default URI */
         if (argp == NULL)
             argp = ossl_safe_getenv(X509_get_default_cert_dir_env());
 
-        /* Fallback to default store URI. */
         if (argp == NULL)
-            argp = X509_get_default_cert_uri();
-
-        /* No point adding an empty URI. */
-        if (!*argp)
-            return 1;
+            argp = X509_get_default_cert_dir();
 
         {
             STACK_OF(OPENSSL_STRING) *uris = X509_LOOKUP_get_method_data(ctx);

--- a/crypto/x509/x509_def.c
+++ b/crypto/x509/x509_def.c
@@ -22,11 +22,6 @@ const char *X509_get_default_cert_area(void)
     return X509_CERT_AREA;
 }
 
-const char *X509_get_default_cert_uri(void)
-{
-    return X509_CERT_URI;
-}
-
 const char *X509_get_default_cert_dir(void)
 {
     return X509_CERT_DIR;
@@ -35,16 +30,6 @@ const char *X509_get_default_cert_dir(void)
 const char *X509_get_default_cert_file(void)
 {
     return X509_CERT_FILE;
-}
-
-const char *X509_get_default_cert_uri_env(void)
-{
-    return X509_CERT_URI_EVP;
-}
-
-const char *X509_get_default_cert_path_env(void)
-{
-    return X509_CERT_PATH_EVP;
 }
 
 const char *X509_get_default_cert_dir_env(void)

--- a/doc/man3/X509_get_default_cert_file.pod
+++ b/doc/man3/X509_get_default_cert_file.pod
@@ -49,14 +49,14 @@ variable can also be a store URI (but see BUGS below).
 
 By default (for example, when L<X509_STORE_set_default_paths(3)> is used), the
 environment variable name returned by X509_get_default_cert_dir_env() is
-interpreted both as a delimiter-separated list of paths, and as a store URI by
-default. This is ambiguous. For example, specifying a value of
-B<"file:///etc/certs"> would cause instantiation of the "file" store provided as
-part of the default provider, but would also cause an L<X509_LOOKUP_hash_dir(3)>
-instance to look for certificates in the directory B<"file"> (relative to the
-current working directory) and the directory B<"///etc/certs">. This can be
-avoided by avoiding use of the environment variable mechanism and using other
-methods to construct X509_LOOKUP instances.
+interpreted both as a delimiter-separated list of paths, and as a store URI.
+This is ambiguous. For example, specifying a value of B<"file:///etc/certs">
+would cause instantiation of the "file" store provided as part of the default
+provider, but would also cause an L<X509_LOOKUP_hash_dir(3)> instance to look
+for certificates in the directory B<"file"> (relative to the current working
+directory) and the directory B<"///etc/certs">. This can be avoided by avoiding
+use of the environment variable mechanism and using other methods to construct
+X509_LOOKUP instances.
 
 =head1 RETURN VALUES
 
@@ -76,7 +76,7 @@ L<SSL_CTX_load_verify_locations(3)>
 
 =head1 COPYRIGHT
 
-Copyright 2023 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2022-2023 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/doc/man3/X509_get_default_cert_file.pod
+++ b/doc/man3/X509_get_default_cert_file.pod
@@ -3,9 +3,7 @@
 =head1 NAME
 
 X509_get_default_cert_file, X509_get_default_cert_file_env,
-X509_get_default_cert_path_env,
-X509_get_default_cert_dir, X509_get_default_cert_dir_env,
-X509_get_default_cert_uri, X509_get_default_cert_uri_env -
+X509_get_default_cert_dir, X509_get_default_cert_dir_env -
 retrieve default locations for trusted CA certificates
 
 =head1 SYNOPSIS
@@ -14,12 +12,9 @@ retrieve default locations for trusted CA certificates
 
  const char *X509_get_default_cert_file(void);
  const char *X509_get_default_cert_dir(void);
- const char *X509_get_default_cert_uri(void);
 
  const char *X509_get_default_cert_file_env(void);
- const char *X509_get_default_cert_path_env(void);
  const char *X509_get_default_cert_dir_env(void);
- const char *X509_get_default_cert_uri_env(void);
 
 =head1 DESCRIPTION
 
@@ -37,48 +32,31 @@ specified. If a given directory in the list exists, OpenSSL attempts to lookup
 CA certificates in this directory by calculating a filename based on a hash of
 the certificate's subject name.
 
-The X509_get_default_cert_uri() function returns the default URI for a
-certificate store accessed programmatically via an OpenSSL provider. If there is
-no default store applicable to the system for which OpenSSL was compiled, this
-returns an empty string.
-
-X509_get_default_cert_file_env() and X509_get_default_cert_uri_env() return
-environment variable names which are recommended to specify nondefault values to
-be used instead of the values returned by X509_get_default_cert_file() and
-X509_get_default_cert_uri() respectively. The values returned by the latter
-functions are not affected by these environment variables; you must check for
-these environment variables yourself, using these functions to retrieve the
-correct environment variable names. If an environment variable is not set, the
-value returned by the corresponding function above should be used.
-
-X509_get_default_cert_path_env() returns the environment variable name which is
+X509_get_default_cert_file_env() returns an environment variable name which is
 recommended to specify a nondefault value to be used instead of the value
-returned by X509_get_default_cert_dir(). This environment variable supersedes
-the deprecated environment variable whose name is returned by
-X509_get_default_cert_dir_env(). This environment variable was deprecated as its
-contents can be interpreted ambiguously; see NOTES.
+returned by X509_get_default_cert_file(). The value returned by the latter
+function is not affected by these environment variables; you must check for this
+environment variable yourself, using this function to retrieve the correct
+environment variable name. If an environment variable is not set, the value
+returned by the X509_get_default_cert_file() should be used.
 
-By default, OpenSSL uses the path list specified in the environment variable
-whose name is returned by X509_get_default_cert_path_env() if it is set;
-otherwise, it uses the path list specified in the environment variable whose
-name is returned by X509_get_default_cert_dir_env() if it is set; otherwise, it
-uses the value returned by X509_get_default_cert_dir()).
+X509_get_default_cert_dir_env() returns the environment variable name which is
+recommended to specify a nondefault value to be used instead of the value
+returned by X509_get_default_cert_dir(). The value specified by this environment
+variable can also be a store URI (but see BUGS below).
 
-=head1 NOTES
+=head1 BUGS
 
-X509_get_default_cert_uri(), X509_get_default_cert_uri_env() and
-X509_get_default_cert_path_env() were introduced in OpenSSL 3.2. Prior to this
-release, store URIs were expressed via the environment variable returned by
-X509_get_default_cert_dir_env(); this environment variable could be used to
-specify either a list of directories or a store URI. This creates an ambiguity
-in which the environment variable returned by X509_get_default_cert_dir_env() is
-interpreted both as a list of directories and as a store URI.
-
-This usage and the environment variable returned by
-X509_get_default_cert_dir_env() are now deprecated; to specify a store URI, use
-the environment variable returned by X509_get_default_cert_uri_env(), and to
-specify a list of directories, use the environment variable returned by
-X509_get_default_cert_path_env().
+By default (for example, when L<X509_STORE_set_default_paths(3)> is used), the
+environment variable name returned by X509_get_default_cert_dir_env() is
+interpreted both as a delimiter-separated list of paths, and as a store URI by
+default. This is ambiguous. For example, specifying a value of
+B<"file:///etc/certs"> would cause instantiation of the "file" store provided as
+part of the default provider, but would also cause an L<X509_LOOKUP_hash_dir(3)>
+instance to look for certificates in the directory B<"file"> (relative to the
+current working directory) and the directory B<"///etc/certs">. This can be
+avoided by avoiding use of the environment variable mechanism and using other
+methods to construct X509_LOOKUP instances.
 
 =head1 RETURN VALUES
 
@@ -96,14 +74,9 @@ L<SSL_CTX_load_verify_dir(3)>,
 L<SSL_CTX_load_verify_store(3)>,
 L<SSL_CTX_load_verify_locations(3)>
 
-=head1 HISTORY
-
-X509_get_default_cert_uri(), X509_get_default_cert_path_env() and
-X509_get_default_cert_uri_env() were introduced in OpenSSL 3.2.
-
 =head1 COPYRIGHT
 
-Copyright 2022 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2023 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/include/internal/common.h
+++ b/include/internal/common.h
@@ -75,14 +75,6 @@ __owur static ossl_inline int ossl_assert_int(int expr, const char *exprstr,
 #  define CTLOG_FILE              "OSSL$DATAROOT:[000000]ct_log_list.cnf"
 # endif
 
-#ifndef OPENSSL_NO_WINSTORE
-# define X509_CERT_URI            "org.openssl.winstore://"
-#else
-# define X509_CERT_URI            ""
-#endif
-
-# define X509_CERT_URI_EVP        "SSL_CERT_URI"
-# define X509_CERT_PATH_EVP       "SSL_CERT_PATH"
 # define X509_CERT_DIR_EVP        "SSL_CERT_DIR"
 # define X509_CERT_FILE_EVP       "SSL_CERT_FILE"
 # define CTLOG_FILE_EVP           "CTLOG_FILE"

--- a/include/openssl/x509.h.in
+++ b/include/openssl/x509.h.in
@@ -495,11 +495,8 @@ ASN1_TIME *X509_time_adj_ex(ASN1_TIME *s,
 ASN1_TIME *X509_gmtime_adj(ASN1_TIME *s, long adj);
 
 const char *X509_get_default_cert_area(void);
-const char *X509_get_default_cert_uri(void);
 const char *X509_get_default_cert_dir(void);
 const char *X509_get_default_cert_file(void);
-const char *X509_get_default_cert_uri_env(void);
-const char *X509_get_default_cert_path_env(void);
 const char *X509_get_default_cert_dir_env(void);
 const char *X509_get_default_cert_file_env(void);
 const char *X509_get_default_private_dir(void);

--- a/util/libcrypto.num
+++ b/util/libcrypto.num
@@ -5468,9 +5468,6 @@ BIO_meth_get_sendmmsg                   ?	3_2_0	EXIST::FUNCTION:
 BIO_meth_set_recvmmsg                   ?	3_2_0	EXIST::FUNCTION:
 BIO_meth_get_recvmmsg                   ?	3_2_0	EXIST::FUNCTION:
 BIO_err_is_non_fatal                    ?	3_2_0	EXIST::FUNCTION:SOCK
-X509_get_default_cert_uri               ?	3_2_0	EXIST::FUNCTION:
-X509_get_default_cert_uri_env           ?	3_2_0	EXIST::FUNCTION:
-X509_get_default_cert_path_env          ?	3_2_0	EXIST::FUNCTION:
 BIO_s_dgram_pair                        ?	3_2_0	EXIST::FUNCTION:DGRAM
 BIO_new_bio_dgram_pair                  ?	3_2_0	EXIST::FUNCTION:DGRAM
 EVP_PKEY_auth_encapsulate_init          ?	3_2_0	EXIST::FUNCTION:


### PR DESCRIPTION
As discussed at OTC. Blocker for 3.2. I kept and tweaked the documentation and the store itself.