### PR TITLE
Create a tutorial for writing a simple blocking QUIC client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,6 +132,7 @@ providers/common/include/prov/der_sm2.h
 /tools/c_rehash.pl
 /util/shlib_wrap.sh
 /util/wrap.pl
+/util/quicserver
 /tags
 /TAGS
 *.map

--- a/demos/guide/Makefile
+++ b/demos/guide/Makefile
@@ -1,5 +1,7 @@
 #
-# To run the demos when linked with a shared library (default):
+# To run the demos when linked with a shared library (default) ensure that
+# libcrypto and libssl are on the library path. For example to run the
+# tls-client-block demo:
 #
 #    LD_LIBRARY_PATH=../.. ./tls-client-block
 
@@ -7,10 +9,13 @@ CFLAGS = -I../../include -g
 LDFLAGS = -L../..
 LDLIBS = -lcrypto -lssl
 
-all: tls-client-block
+all: tls-client-block quic-client-block
 
 tls-client-block: tls-client-block.c
 	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $< $(LDLIBS)
 
+quic-client-block: quic-client-block.c
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $< $(LDLIBS)
+
 clean:
-	$(RM) *.o tls-client-block
+	$(RM) *.o tls-client-block quic-client-block

--- a/demos/guide/quic-client-block.c
+++ b/demos/guide/quic-client-block.c
@@ -106,9 +106,13 @@ static BIO *create_socket_bio(const char *hostname, const char *port,
     return bio;
 }
 
-/* Server hostname and port details */
-#define HOSTNAME "www.example.com"
-#define PORT     "443"
+/* Server hostname and port details. Must be in quotes */
+#ifndef HOSTNAME
+# define HOSTNAME "www.example.com"
+#endif
+#ifndef PORT
+# define PORT     "443"
+#endif
 
 /*
  * Simple application to send a basic HTTP/1.0 request to a server and

--- a/demos/guide/quic-client-block.c
+++ b/demos/guide/quic-client-block.c
@@ -116,7 +116,9 @@ static BIO *create_socket_bio(const char *hostname, const char *port,
 
 /*
  * Simple application to send a basic HTTP/1.0 request to a server and
- * print the response on the screen.
+ * print the response on the screen. Note that HTTP/1.0 over QUIC is
+ * non-standard and will not typically be supported by real world servers. This
+ * is for demonstration purposes only.
  */
 int main(void)
 {
@@ -165,7 +167,7 @@ int main(void)
 
     /*
      * Create the underlying transport socket/BIO and associate it with the
-     * connection
+     * connection.
      */
     bio = create_socket_bio(HOSTNAME, PORT, &peer_addr);
     if (bio == NULL) {
@@ -248,7 +250,7 @@ int main(void)
     if (SSL_get_error(ssl, 0) != SSL_ERROR_ZERO_RETURN) {
         /*
          * Some error occurred other than a graceful close down by the
-         * peer
+         * peer.
          */
         printf ("Failed reading remaining data\n");
         goto end;

--- a/demos/guide/quic-client-block.c
+++ b/demos/guide/quic-client-block.c
@@ -1,0 +1,285 @@
+/*
+ *  Copyright 2023 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ *  Licensed under the Apache License 2.0 (the "License").  You may not use
+ *  this file except in compliance with the License.  You can obtain a copy
+ *  in the file LICENSE in the source distribution or at
+ *  https://www.openssl.org/source/license.html
+ */
+
+/*
+ * NB: Changes to this file should also be reflected in
+ * doc/man7/ossl-guide-quic-client-block.pod
+ */
+
+#include <string.h>
+
+/* Include the appropriate header file for SOCK_DGRAM */
+#ifdef _WIN32 /* Windows */
+# include <winsock2.h>
+#else /* Linux/Unix */
+# include <sys/socket.h>
+#endif
+
+#include <openssl/bio.h>
+#include <openssl/ssl.h>
+#include <openssl/err.h>
+
+/* Helper function to create a BIO connected to the server */
+static BIO *create_socket_bio(const char *hostname, const char *port,
+                              BIO_ADDR **peer_addr)
+{
+    int sock = -1;
+    BIO_ADDRINFO *res;
+    const BIO_ADDRINFO *ai = NULL;
+    BIO *bio;
+
+    /*
+     * Lookup IP address info for the server.
+     */
+    if (!BIO_lookup_ex(hostname, port, BIO_LOOKUP_CLIENT, 0, SOCK_DGRAM, 0,
+                       &res))
+        return NULL;
+
+    /*
+     * Loop through all the possible addresses for the server and find one
+     * we can connect to.
+     */
+    for (ai = res; ai != NULL; ai = BIO_ADDRINFO_next(ai)) {
+        /*
+         * Create a TCP socket. We could equally use non-OpenSSL calls such
+         * as "socket" here for this and the subsequent connect and close
+         * functions. But for portability reasons and also so that we get
+         * errors on the OpenSSL stack in the event of a failure we use
+         * OpenSSL's versions of these functions.
+         */
+        sock = BIO_socket(BIO_ADDRINFO_family(ai), SOCK_DGRAM, 0, 0);
+        if (sock == -1)
+            continue;
+
+        /* Connect the socket to the server's address */
+        if (!BIO_connect(sock, BIO_ADDRINFO_address(ai), 0)) {
+            BIO_closesocket(sock);
+            sock = -1;
+            continue;
+        }
+
+        /* Set to nonblocking mode */
+        if (!BIO_socket_nbio(sock, 1)) {
+            sock = -1;
+            continue;
+        }
+
+        break;
+    }
+
+    if (sock != -1) {
+        *peer_addr = BIO_ADDR_dup(BIO_ADDRINFO_address(ai));
+        if (*peer_addr == NULL) {
+            BIO_closesocket(sock);
+            return NULL;
+        }
+    }
+
+
+    /* Free the address information resources we allocated earlier */
+    BIO_ADDRINFO_free(res);
+
+    /* If sock is -1 then we've been unable to connect to the server */
+    if (sock == -1)
+        return NULL;
+
+    /* Create a BIO to wrap the socket*/
+    bio = BIO_new(BIO_s_datagram());
+    if (bio == NULL)
+        BIO_closesocket(sock);
+
+    /*
+     * Associate the newly created BIO with the underlying socket. By
+     * passing BIO_CLOSE here the socket will be automatically closed when
+     * the BIO is freed. Alternatively you can use BIO_NOCLOSE, in which
+     * case you must close the socket explicitly when it is no longer
+     * needed.
+     */
+    BIO_set_fd(bio, sock, BIO_CLOSE);
+
+    return bio;
+}
+
+/* Server hostname and port details */
+#define HOSTNAME "www.example.com"
+#define PORT     "443"
+
+/*
+ * Simple application to send a basic HTTP/1.0 request to a server and
+ * print the response on the screen.
+ */
+int main(void)
+{
+    SSL_CTX *ctx = NULL;
+    SSL *ssl;
+    BIO *bio = NULL;
+    int res = EXIT_FAILURE;
+    int ret;
+    unsigned char alpn[] = { 8, 'h', 't', 't', 'p', '/', '1', '.', '0' };
+    const char *request =
+        "GET / HTTP/1.0\r\nConnection: close\r\nHost: "HOSTNAME"\r\n\r\n";
+    size_t written, readbytes;
+    char buf[160];
+    BIO_ADDR *peer_addr = NULL;
+
+    /*
+     * Create an SSL_CTX which we can use to create SSL objects from. We
+     * want an SSL_CTX for creating clients so we use
+     * OSSL_QUIC_client_method() here.
+     */
+    ctx = SSL_CTX_new(OSSL_QUIC_client_method());
+    if (ctx == NULL) {
+        printf("Failed to create the SSL_CTX\n");
+        goto end;
+    }
+
+    /*
+     * Configure the client to abort the handshake if certificate
+     * verification fails. Virtually all clients should do this unless you
+     * really know what you are doing.
+     */
+    SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER, NULL);
+
+    /* Use the default trusted certificate store */
+    if (!SSL_CTX_set_default_verify_paths(ctx)) {
+        printf("Failed to set the default trusted certificate store\n");
+        goto end;
+    }
+
+    /* Create an SSL object to represent the TLS connection */
+    ssl = SSL_new(ctx);
+    if (ssl == NULL) {
+        printf("Failed to create the SSL object\n");
+        goto end;
+    }
+
+    /*
+     * Create the underlying transport socket/BIO and associate it with the
+     * connection
+     */
+    bio = create_socket_bio(HOSTNAME, PORT, &peer_addr);
+    if (bio == NULL) {
+        printf("Failed to crete the BIO\n");
+        goto end;
+    }
+    SSL_set_bio(ssl, bio, bio);
+
+    /*
+     * Tell the server during the handshake which hostname we are attempting
+     * to connect to in case the server supports multiple hosts.
+     */
+    if (!SSL_set_tlsext_host_name(ssl, HOSTNAME)) {
+        printf("Failed to set the SNI hostname\n");
+        goto end;
+    }
+
+    /*
+     * Ensure we check during certificate verification that the server has
+     * supplied a certificate for the hostname that we were expecting.
+     * Virtually all clients should do this unless you really know what you
+     * are doing.
+     */
+    if (!SSL_set1_host(ssl, HOSTNAME)) {
+        printf("Failed to set the certificate verification hostname");
+        goto end;
+    }
+
+    /* SSL_set_alpn_protos returns 0 for success! */
+    if (SSL_set_alpn_protos(ssl, alpn, sizeof(alpn)) != 0) {
+        printf("Failed to set the ALPN for the connection\n");
+        goto end;
+    }
+
+    if (!SSL_set_initial_peer_addr(ssl, peer_addr)) {
+        printf("Failed to set the inital peer address\n");
+        goto end;
+    }
+
+    if ((ret = SSL_connect(ssl)) < 1) {
+        /*
+         * If the failure is due to a verification error we can get more
+         * information about it from SSL_get_verify_result().
+         */
+        if (SSL_get_verify_result(ssl) != X509_V_OK)
+            printf("Verify error: %s\n",
+                X509_verify_cert_error_string(SSL_get_verify_result(ssl)));
+        goto end;
+    }
+
+    /* Write an HTTP GET request to the peer */
+    if (!SSL_write_ex(ssl, request, strlen(request), &written)) {
+        printf("Failed to write HTTP request\n");
+        goto end;
+    }
+
+    /*
+     * Get up to sizeof(buf) bytes of the response. We keep reading until the
+     * server closes the connection.
+     */
+    while (SSL_read_ex(ssl, buf, sizeof(buf), &readbytes)) {
+        /*
+        * OpenSSL does not guarantee that the returned data is a string or
+        * that it is NUL terminated so we use fwrite() to write the exact
+        * number of bytes that we read. The data could be non-printable or
+        * have NUL characters in the middle of it. For this simple example
+        * we're going to print it to stdout anyway.
+        */
+        fwrite(buf, 1, readbytes, stdout);
+    }
+    /* In case the response didn't finish with a newline we add one now */
+    printf("\n");
+
+    /*
+     * Check whether we finished the while loop above normally or as the
+     * result of an error. The 0 argument to SSL_get_error() is the return
+     * code we received from the SSL_read_ex() call. It must be 0 in order
+     * to get here. Normal completion is indicated by SSL_ERROR_ZERO_RETURN.
+     */
+    if (SSL_get_error(ssl, 0) != SSL_ERROR_ZERO_RETURN) {
+        /*
+         * Some error occurred other than a graceful close down by the
+         * peer
+         */
+        printf ("Failed reading remaining data\n");
+        goto end;
+    }
+
+    /*
+     * Repeatedly call SSL_shutdown() until the connection is fully
+     * closed.
+     */
+    do {
+        ret = SSL_shutdown(ssl);
+        if (ret < 0) {
+            printf("Error shuting down: %d\n", ret);
+            goto end;
+        }
+    } while (ret != 1);
+
+    /* Success! */
+    res = EXIT_SUCCESS;
+ end:
+    /*
+     * If something bad happened then we will dump the contents of the
+     * OpenSSL error stack to stderr. There might be some useful diagnostic
+     * information there.
+     */
+    if (res == EXIT_FAILURE)
+        ERR_print_errors_fp(stderr);
+
+    /*
+     * Free the resources we allocated. We do not free the BIO object here
+     * because ownership of it was immediately transferred to the SSL object
+     * via SSL_set_bio(). The BIO will be freed when we free the SSL object.
+     */
+    SSL_free(ssl);
+    SSL_CTX_free(ctx);
+    BIO_ADDR_free(peer_addr);
+    return res;
+}

--- a/demos/guide/tls-client-block.c
+++ b/demos/guide/tls-client-block.c
@@ -91,9 +91,13 @@ static BIO *create_socket_bio(const char *hostname, const char *port)
     return bio;
 }
 
-/* Server hostname and port details */
-#define HOSTNAME "www.example.com"
-#define PORT     "443"
+/* Server hostname and port details. Must be in quotes */
+#ifndef HOSTNAME
+# define HOSTNAME "www.example.com"
+#endif
+#ifndef PORT
+# define PORT     "443"
+#endif
 
 /*
  * Simple application to send a basic HTTP/1.0 request to a server and

--- a/demos/guide/tls-client-block.c
+++ b/demos/guide/tls-client-block.c
@@ -157,7 +157,7 @@ int main(void)
 
     /*
      * Create the underlying transport socket/BIO and associate it with the
-     * connection
+     * connection.
      */
     bio = create_socket_bio(HOSTNAME, PORT);
     if (bio == NULL) {
@@ -231,7 +231,7 @@ int main(void)
     if (SSL_get_error(ssl, 0) != SSL_ERROR_ZERO_RETURN) {
         /*
          * Some error occurred other than a graceful close down by the
-         * peer
+         * peer.
          */
         printf ("Failed reading remaining data\n");
         goto end;

--- a/doc/build.info
+++ b/doc/build.info
@@ -4757,6 +4757,14 @@ DEPEND[man/man7/openssl_user_macros.7]=man7/openssl_user_macros.pod
 GENERATE[man/man7/openssl_user_macros.7]=man7/openssl_user_macros.pod
 DEPEND[man7/openssl_user_macros.pod]{pod}=man7/openssl_user_macros.pod.in
 GENERATE[man7/openssl_user_macros.pod]=man7/openssl_user_macros.pod.in
+DEPEND[html/man7/ossl-guide-quic-client-block.html]=man7/ossl-guide-quic-client-block.pod
+GENERATE[html/man7/ossl-guide-quic-client-block.html]=man7/ossl-guide-quic-client-block.pod
+DEPEND[man/man7/ossl-guide-quic-client-block.7]=man7/ossl-guide-quic-client-block.pod
+GENERATE[man/man7/ossl-guide-quic-client-block.7]=man7/ossl-guide-quic-client-block.pod
+DEPEND[html/man7/ossl-guide-quic-introduction.html]=man7/ossl-guide-quic-introduction.pod
+GENERATE[html/man7/ossl-guide-quic-introduction.html]=man7/ossl-guide-quic-introduction.pod
+DEPEND[man/man7/ossl-guide-quic-introduction.7]=man7/ossl-guide-quic-introduction.pod
+GENERATE[man/man7/ossl-guide-quic-introduction.7]=man7/ossl-guide-quic-introduction.pod
 DEPEND[html/man7/ossl-guide-tls-client-block.html]=man7/ossl-guide-tls-client-block.pod
 GENERATE[html/man7/ossl-guide-tls-client-block.html]=man7/ossl-guide-tls-client-block.pod
 DEPEND[man/man7/ossl-guide-tls-client-block.7]=man7/ossl-guide-tls-client-block.pod
@@ -4973,6 +4981,8 @@ html/man7/openssl-glossary.html \
 html/man7/openssl-quic.html \
 html/man7/openssl-threads.html \
 html/man7/openssl_user_macros.html \
+html/man7/ossl-guide-quic-client-block.html \
+html/man7/ossl-guide-quic-introduction.html \
 html/man7/ossl-guide-tls-client-block.html \
 html/man7/ossl-guide-tls-introduction.html \
 html/man7/ossl_store-file.html \
@@ -5108,6 +5118,8 @@ man/man7/openssl-glossary.7 \
 man/man7/openssl-quic.7 \
 man/man7/openssl-threads.7 \
 man/man7/openssl_user_macros.7 \
+man/man7/ossl-guide-quic-client-block.7 \
+man/man7/ossl-guide-quic-introduction.7 \
 man/man7/ossl-guide-tls-client-block.7 \
 man/man7/ossl-guide-tls-introduction.7 \
 man/man7/ossl_store-file.7 \

--- a/doc/man7/ossl-guide-quic-client-block.pod
+++ b/doc/man7/ossl-guide-quic-client-block.pod
@@ -1,0 +1,292 @@
+=pod
+
+=begin comment
+
+NB: Changes to the source code samples in this file should also be reflected in
+demos/guide/quic-client-block.c
+
+=end comment
+
+=head1 NAME
+
+ossl-guide-quic-client-block
+- OpenSSL Guide: Writing a simple blocking QUIC client
+
+=head1 SIMPLE BLOCKING QUIC CLIENT EXAMPLE
+
+This page will present various source code samples demonstrating how to write
+a simple blocking QUIC client application which connects to a server, sends an
+HTTP/1.0 request to it, and reads back the response.
+
+We assume that you already have OpenSSL installed on your system; that you
+already have some fundamental understanding of OpenSSL concepts, TLS and QUIC
+(see L<crypto(7)>, L<ossl-guide-tls-introduction(7)> and
+L<ossl-guide-quic-introduction(7)>); and that you know how to
+write and build C code and link it against the libcrypto and libssl libraries
+that are provided by OpenSSL. It also assumes that you have a basic
+understanding of UDP/IP and sockets. The example code that we build in this
+tutorial will amend the blocking TLS client example that is covered in
+L<ossl-guide-tls-client-block(7)>. Only the differences between that client and
+this one will be discussed so we also assume that you have run through and
+understand that tutorial.
+
+For this tutorial our client will be using a single QUIC stream. A subsequent
+tutorial will discuss how to write a multi-stream client.
+
+The complete source code for this example blocking QUIC client is available in
+the B<demos/guide> directory of the OpenSSL source distribution in the file
+B<quic-client-block.c>. It is also available online at
+L<https://github.com/openssl/openssl/blob/master/demos/guide/quic-client-block.c>.
+
+=head2 Creating the SSL_CTX and SSL objects
+
+In the TLS tutorial (L<ossl-guide-tls-client-block(7)>) we created an B<SSL_CTX>
+object for our client and used it to create an B<SSL> object to represent the
+TLS connection. A QUIC connection works in exactly the same way. We first create
+an B<SSL_CTX> object and then use it to create an B<SSL> object to represent the
+QUIC connection.
+
+As in the TLS example the first step is to create an B<SSL_CTX> object for our
+client. This is done in the same way as before except that we use a different
+"method". OpenSSL offers two different QUIC client methods, i.e.
+L<OSSL_QUIC_client_method(3)> and L<OSSL_QUIC_client_thread_method(3)>.
+
+The first one is the equivalent of L<TLS_client_method(3)> but for the QUIC
+protocol. The second one is the same, but it will additionally create a
+background thread for handling time based events (known as "thread assisted
+mode", see L<ossl-guide-quic-introduction(7)>). For this tutorial we will be
+using L<OSSL_QUIC_client_method(3)> because we will not be leaving the QUIC
+connection idle in our application and so thread assisted mode is not needed.
+
+    /*
+     * Create an SSL_CTX which we can use to create SSL objects from. We
+     * want an SSL_CTX for creating clients so we use OSSL_QUIC_client_method()
+     * here.
+     */
+    ctx = SSL_CTX_new(OSSL_QUIC_client_method());
+    if (ctx == NULL) {
+        printf("Failed to create the SSL_CTX\n");
+        goto end;
+    }
+
+The other setup steps that we applied to the B<SSL_CTX> for TLS also apply to
+QUIC except for restricting the TLS versions that we are willing to accept. The
+QUIC protocol implementation in OpenSSL currently only supports TLSv1.3. There
+is no need to call L<SSL_CTX_set_min_proto_version(3)> or
+L<SSL_CTX_set_max_proto_version(3)> in an OpenSSL QUIC application, and any such
+call will be ignored.
+
+Once the B<SSL_CTX> is created, the B<SSL> object is constructed in exactly the
+same way as for the TLS application.
+
+=head2 Creating the socket and BIO
+
+A major different between TLS and QUIC is the underlying transport protocol. TLS
+uses TCP while QUIC uses UDP. The way that the QUIC socket is created in our
+example code is much the same as for TLS. We use the L<BIO_lookup_ex(3)> and
+L<BIO_socket(3)> helper functions as we did in the previous tutorial except that
+we pass B<SOCK_DGRAM> as an argument to indicate UDP (instead of B<SOCK_STREAM>
+for TCP).
+
+    /*
+     * Lookup IP address info for the server.
+     */
+    if (!BIO_lookup_ex(hostname, port, BIO_LOOKUP_CLIENT, 0, SOCK_DGRAM, 0,
+                       &res))
+        return NULL;
+
+    /*
+     * Loop through all the possible addresses for the server and find one
+     * we can connect to.
+     */
+    for (ai = res; ai != NULL; ai = BIO_ADDRINFO_next(ai)) {
+        /*
+         * Create a TCP socket. We could equally use non-OpenSSL calls such
+         * as "socket" here for this and the subsequent connect and close
+         * functions. But for portability reasons and also so that we get
+         * errors on the OpenSSL stack in the event of a failure we use
+         * OpenSSL's versions of these functions.
+         */
+        sock = BIO_socket(BIO_ADDRINFO_family(ai), SOCK_DGRAM, 0, 0);
+        if (sock == -1)
+            continue;
+
+        /* Connect the socket to the server's address */
+        if (!BIO_connect(sock, BIO_ADDRINFO_address(ai), 0)) {
+            BIO_closesocket(sock);
+            sock = -1;
+            continue;
+        }
+
+        /* Set to nonblocking mode */
+        if (!BIO_socket_nbio(sock, 1)) {
+            sock = -1;
+            continue;
+        }
+
+        break;
+    }
+
+    if (sock != -1) {
+        *peer_addr = BIO_ADDR_dup(BIO_ADDRINFO_address(ai));
+        if (*peer_addr == NULL) {
+            BIO_closesocket(sock);
+            return NULL;
+        }
+    }
+
+    /* Free the address information resources we allocated earlier */
+    BIO_ADDRINFO_free(res);
+
+You may notice a couple of other differences between this code and the version
+that we used for TLS.
+
+Firstly, we set the socket into nonblocking mode. This must always be done for
+an OpenSSL QUIC application. This may be surprising considering that we are
+trying to write a blocking client. Despite this the B<SSL> object will still
+have blocking behaviour. See L<ossl-guide-quic-introduction(7)> for further
+information on this.
+
+Secondly, we take note of the IP address of the peer that we are connecting to.
+We store that information away. We will need it later.
+
+See L<BIO_lookup_ex(3)>, L<BIO_socket(3)>, L<BIO_connect(3)>,
+L<BIO_closesocket(3)>, L<BIO_ADDRINFO_next(3)>, L<BIO_ADDRINFO_address(3)>,
+L<BIO_ADDRINFO_free(3)> and L<BIO_ADDR_dup(3)> for further information on the
+functions used here. In the above example code the B<hostname> and B<port>
+variables are strings, e.g. "www.example.com" and "443".
+
+As for our TLS client, once the socket has been created and connected we need to
+associate it with a BIO object:
+
+    BIO *bio;
+
+    /* Create a BIO to wrap the socket*/
+    bio = BIO_new(BIO_s_datagram());
+    if (bio == NULL)
+        BIO_closesocket(sock);
+
+    /*
+     * Associate the newly created BIO with the underlying socket. By
+     * passing BIO_CLOSE here the socket will be automatically closed when
+     * the BIO is freed. Alternatively you can use BIO_NOCLOSE, in which
+     * case you must close the socket explicitly when it is no longer
+     * needed.
+     */
+    BIO_set_fd(bio, sock, BIO_CLOSE);
+
+Note the use of L<BIO_s_datagram(3)> here as opposed to L<BIO_s_socket(3)> that
+we used for our TLS client. This is again due to the fact that QUIC uses UDP
+instead of TCP for its transport layer. See L<BIO_new(3)>, L<BIO_s_datagram(3)>
+and L<BIO_set_fd(3)> for further information on these functions.
+
+=head2 Setting the server's hostname
+
+As in the TLS tutorial we need to set the server's hostname both for SNI (Server
+Name Indication) and for certificate validation purposes. The steps for this are
+identical to the TLS tutorial and won't be repeated here.
+
+=head2 Setting the ALPN
+
+ALPN (Application-Layer Protocol Negotiation) is a feature of TLS that enables
+the application to negotiate which protocol will be used over the connection.
+For example, if you intend to use HTTP/3 over the connection then the ALPN value
+for that is "h3" (see
+L<https://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xml#alpn-protocol-ids>).
+OpenSSL provides the ability for a client to specify the ALPN to use via the
+L<SSL_set_alpn_protos(3)> function. This is optional for a TLS client and so our
+simple client that we developed in L<ossl-guide-tls-client-block(7)> did not use
+it. However QUIC mandates that the TLS handshake used in establishing a QUIC
+connection must use ALPN.
+
+    unsigned char alpn[] = { 8, 'h', 't', 't', 'p', '/', '1', '.', '0' };
+
+    /* SSL_set_alpn_protos returns 0 for success! */
+    if (SSL_set_alpn_protos(ssl, alpn, sizeof(alpn)) != 0) {
+        printf("Failed to set the ALPN for the connection\n");
+        goto end;
+    }
+
+The ALPN is specified using a length prefixed array of unsigned chars (it is not
+a NUL terminated string). Our original TLS blocking client demo was using
+HTTP/1.0. We will use the same for this example. Unlike most OpenSSL functions
+L<SSL_set_alpn_protos(3)> returns zero for success and nonzero for failure.
+
+=head2 Setting the peer address
+
+An OpenSSL QUIC application must specify the target address of the server that
+is being connected to. In L</Creating the socket and BIO> above we saved that
+address away for future use. Now we need to use it via the
+L<SSL_set_initial_peer_addr(3)> function.
+
+    if (!SSL_set_initial_peer_addr(ssl, peer_addr)) {
+        printf("Failed to set the inital peer address\n");
+        goto end;
+    }
+
+Note that we will need to free the B<peer_addr> value that we allocated via
+L<BIO_ADDR_dup(3)> earlier:
+
+    BIO_ADDR_free(peer_addr);
+
+=head2 The handshake and application data transfer
+
+Once initial setup of the B<SSL> object is complete then we perform the
+handshake via L<SSL_connect(3)> in exactly the same way as we did for the TLS
+client, so we won't repeat it here.
+
+We can also perform data transfer using a default QUIC stream that is
+automatically associated with the B<SSL> object for us. We can transmit data
+using L<SSL_write_ex(3)>, and receive data using L<SSL_read_ex(3)> in exactly
+the same way as for TLS. Again, we won't repeat it here.
+
+=head2 Shutting down the connection
+
+As in the TLS tutorial, once we have finished reading data from the server then
+we are ready to close the connection down. As before we do this via the
+L<SSL_shutdown(3)> function. This example for QUIC is very similar to the TLS
+version. However the L<SSL_shutdown(3)> function may need to be called more than
+once:
+
+    /*
+     * Repeatedly call SSL_shutdown() until the connection is fully
+     * closed.
+     */
+    do {
+        ret = SSL_shutdown(ssl);
+        if (ret < 0) {
+            printf("Error shuting down: %d\n", ret);
+            goto end;
+        }
+    } while (ret != 1);
+
+The shutdown process is in two stages. First we gracefully shutdown the
+connection for sending and secondly we shutdown the connection for receiving.
+L<SSL_shutdown(3)> returns 0 once the first stage has been completed, and 1 once
+the second stage is finished. This two stage process applies to TLS as well.
+However in our blocking TLS client example code we knew that the peer had
+already partially closed down due to the B<SSL_ERROR_ZERO_RETURN> that we had
+obtained via L<SSL_get_error(3)> after the final L<SSL_read_ex(3)> call. Due to
+that return value we knew that the connection was already closed down for
+receiving data and hence L<SSL_shutdown(3)> should only need to be called once.
+
+However, with QUIC, the B<SSL_ERROR_ZERO_RETURN> value only tells us that the
+stream (not the connection) is partially closed down. Therefore we need to call
+L<SSL_shutdown(3)> more than once to ensure that we progress through both stages
+of the shutdown process.
+
+=head1 SEE ALSO
+
+L<crypto(7)>, L<ossl-guide-tls-introduction(7)>,
+L<ossl-guide-tls-client-block(7)>, L<ossl-guide-quic-introduction(7)>
+
+=head1 COPYRIGHT
+
+Copyright 2023 The OpenSSL Project Authors. All Rights Reserved.
+
+Licensed under the Apache License 2.0 (the "License").  You may not use
+this file except in compliance with the License.  You can obtain a copy
+in the file LICENSE in the source distribution or at
+L<https://www.openssl.org/source/license.html>.
+
+=cut

--- a/doc/man7/ossl-guide-quic-client-block.pod
+++ b/doc/man7/ossl-guide-quic-client-block.pod
@@ -34,8 +34,8 @@ For this tutorial our client will be using a single QUIC stream. A subsequent
 tutorial will discuss how to write a multi-stream client.
 
 The complete source code for this example blocking QUIC client is available in
-the B<demos/guide> directory of the OpenSSL source distribution in the file
-B<quic-client-block.c>. It is also available online at
+the C<demos/guide> directory of the OpenSSL source distribution in the file
+C<quic-client-block.c>. It is also available online at
 L<https://github.com/openssl/openssl/blob/master/demos/guide/quic-client-block.c>.
 
 =head2 Creating the SSL_CTX and SSL objects
@@ -81,8 +81,8 @@ same way as for the TLS application.
 
 =head2 Creating the socket and BIO
 
-A major different between TLS and QUIC is the underlying transport protocol. TLS
-uses TCP while QUIC uses UDP. The way that the QUIC socket is created in our
+A major difference between TLS and QUIC is the underlying transport protocol.
+TLS uses TCP while QUIC uses UDP. The way that the QUIC socket is created in our
 example code is much the same as for TLS. We use the L<BIO_lookup_ex(3)> and
 L<BIO_socket(3)> helper functions as we did in the previous tutorial except that
 we pass B<SOCK_DGRAM> as an argument to indicate UDP (instead of B<SOCK_STREAM>

--- a/doc/man7/ossl-guide-quic-client-block.pod
+++ b/doc/man7/ossl-guide-quic-client-block.pod
@@ -16,7 +16,9 @@ ossl-guide-quic-client-block
 
 This page will present various source code samples demonstrating how to write
 a simple blocking QUIC client application which connects to a server, sends an
-HTTP/1.0 request to it, and reads back the response.
+HTTP/1.0 request to it, and reads back the response. Note that HTTP/1.0 over
+QUIC is non-standard and will not typically be supported by real world servers.
+This is for demonstration purposes only.
 
 We assume that you already have OpenSSL installed on your system; that you
 already have some fundamental understanding of OpenSSL concepts, TLS and QUIC

--- a/doc/man7/ossl-guide-quic-introduction.pod
+++ b/doc/man7/ossl-guide-quic-introduction.pod
@@ -18,7 +18,7 @@ L<ossl-guide-tls-introduction(7)>).
 QUIC is a general purpose protocol for enabling applications to securely
 communicate over a network. It is defined in RFC9000 (see
 L<https://datatracker.ietf.org/doc/rfc9000/>). QUIC integrates parts of the
-TLS protocol for connection establishment but independetenly protects packets.
+TLS protocol for connection establishment but independently protects packets.
 It provides similar security guarantees to TLS such as confidentiality,
 integrity and authentication (see L<ossl-guide-tls-introduction(7)>). It
 additionally provides multiplexing capabilities through the use of "streams"
@@ -102,7 +102,7 @@ See L<bio(7)> for an introduction to OpenSSL's B<BIO> concept.
 A significant difference between OpenSSL TLS applications and OpenSSL QUIC
 applications is the way that blocking is implemented. In TLS if your application
 expects blocking behaviour then you configure the underlying socket for
-blocking. Conversely if your application want nonblocking behaviour then the
+blocking. Conversely if your application wants nonblocking behaviour then the
 underlying socket is configured to be nonblocking.
 
 With an OpenSSL QUIC application the underlying socket must always be configured

--- a/doc/man7/ossl-guide-quic-introduction.pod
+++ b/doc/man7/ossl-guide-quic-introduction.pod
@@ -72,7 +72,7 @@ to both TLS and QUIC.
 QUIC introduces the concept of "streams". A stream provides a reliable
 mechanism for sending and receiving application data between the endpoints. The
 bytes transmitted are guaranteed to be received in the same order they were sent
-in without any loss of data or reordering of the bytes. A TLS application
+without any loss of data or reordering of the bytes. A TLS application
 effectively has one bi-directional stream available to it per TLS connection. A
 QUIC application can have multiple uni-directional or bi-directional streams
 available to it for each connection.

--- a/doc/man7/ossl-guide-quic-introduction.pod
+++ b/doc/man7/ossl-guide-quic-introduction.pod
@@ -63,7 +63,7 @@ This relationship between QUIC and TLS means that many of the API functions in
 OpenSSL that apply to TLS connections also apply to QUIC connections and
 applications can use them in exactly the same way. Some functions do not apply
 to QUIC at all, and others have altered semantics. You should refer to the
-documenation pages for each function for information on how it applies to QUIC.
+documentation pages for each function for information on how it applies to QUIC.
 Typically if QUIC is not mentioned in the manual pages then the functions apply
 to both TLS and QUIC.
 

--- a/doc/man7/ossl-guide-quic-introduction.pod
+++ b/doc/man7/ossl-guide-quic-introduction.pod
@@ -1,0 +1,135 @@
+=pod
+
+=head1 NAME
+
+ossl-guide-quic-introduction
+- OpenSSL Guide: An introduction to QUIC in OpenSSL
+
+=head1 INTRODUCTION
+
+This page will provide an introduction to some basic QUIC concepts and
+background and how it is used within OpenSSL. It assumes that you have a basic
+understanding of UDP/IP and sockets. It also assumes that you are familiar with
+some OpenSSL and TLS fundamentals (see L<crypto(7)> and
+L<ossl-guide-tls-introduction(7)>).
+
+=head1 WHAT IS QUIC?
+
+QUIC is a general purpose protocol for enabling applications to securely
+communicate over a network. It is defined in RFC9000 (see
+L<https://datatracker.ietf.org/doc/rfc9000/>). QUIC integrates parts of the
+TLS protocol for connection establishment but independetenly protects packets.
+It provides similar security guarantees to TLS such as confidentiality,
+integrity and authentication (see L<ossl-guide-tls-introduction(7)>). It
+additionally provides multiplexing capabilities through the use of "streams"
+(see L</QUIC STREAMS> below).
+
+=head1 QUIC TIME BASED EVENTS
+
+A key difference between the TLS implementation and the QUIC implementation in
+OpenSSL is how time is handled. The QUIC protocol requires various actions to be
+performed on a regular basis regardless of whether application data is being
+transmitted or received.
+
+OpenSSL introduces a new function L<SSL_handle_events(3)> that will
+automatically process any outstanding time based events that must be handled.
+Alternatively calling any I/O function such as L<SSL_read_ex(3)> or
+L<SSL_write_ex(3)> will also process these events. There is also
+L<SSL_get_event_timeout(3)> which tells an application the amount of time that
+remains until L<SSL_handle_events(3)> (or any I/O function) must be called.
+
+Fortunately a blocking application that does not leave the QUIC connection idle,
+and is regularly calling I/O functions does not typically need to worry about
+this. However if you are developing a nonblocking application or one that may
+leave the QUIC connection idle for a period of time then you will need to
+arrange to call these functions.
+
+OpenSSL provides an optional "thread assisted mode" that will automatically
+create a background thread and will regularly call L<SSL_handle_events(3)> in a
+thread safe manner. This provides a simple way for an application to satisfy the
+QUIC requirements for time based events without having to implement special
+logic to accomplish it.
+
+=head1 QUIC AND TLS
+
+QUIC reuses parts of the TLS protocol in its implementation. Specifically the
+TLS handshake also exists in QUIC. The TLS handshake messages are wrapped up in
+QUIC protocol messages in order to send them to the peer. Once the TLS handshake
+is complete all application data is sent entirely using QUIC protocol messages
+without using TLS - although some TLS handshake messages may still be sent in
+some circumstances.
+
+This relationship between QUIC and TLS means that many of the API functions in
+OpenSSL that apply to TLS connections also apply to QUIC connections and
+applications can use them in exactly the same way. Some functions do not apply
+to QUIC at all, and others have altered semantics. You should refer to the
+documenation pages for each function for information on how it applies to QUIC.
+Typically if QUIC is not mentioned in the manual pages then the functions apply
+to both TLS and QUIC.
+
+=head1 QUIC STREAMS
+
+QUIC introduces the concept of "streams". A stream provides a reliable
+mechanism for sending and receiving application data between the endpoints. The
+bytes transmitted are guaranteed to be received in the same order they were sent
+in without any loss of data or reordering of the bytes. A TLS application
+effectively has one bi-directional stream available to it per TLS connection. A
+QUIC application can have multiple uni-directional or bi-directional streams
+available to it for each connection.
+
+In OpenSSL an B<SSL> object is used to represent both connections and streams.
+A QUIC application creates an initial B<SSL> object to represent the connection
+(known as the connection B<SSL> object). Once the connection is complete
+additional B<SSL> objects can be created to represent streams (known as stream
+B<SSL> objects). Unless configured otherwise, a "default" stream is also
+associated with the connection B<SSL> object so you can still write data and
+read data to/from it. Some OpenSSL API functions can only be used with
+connection B<SSL> objects, and some can only be used with stream B<SSL> objects.
+Check the documentation for each function to confirm what type of B<SSL> object
+can be used in any particular context. A connection B<SSL> object that has a
+default stream attached to it can be used in contexts that require a connection
+B<SSL> object or in contexts that require a stream B<SSL> object.
+
+=head1 SOCKETS AND BLOCKING
+
+TLS assumes "stream" type semantics for its underlying transport layer protocol
+(usually achieved by using TCP). However QUIC assumes "datagram" type semantics
+by using UDP. An OpenSSL application using QUIC is responsible for creating a
+BIO to represent the underlying transport layer. This BIO must support datagrams
+and is typically L<BIO_s_datagram(3)>, but other B<BIO> choices are available.
+See L<bio(7)> for an introduction to OpenSSL's B<BIO> concept.
+
+A significant difference between OpenSSL TLS applications and OpenSSL QUIC
+applications is the way that blocking is implemented. In TLS if your application
+expects blocking behaviour then you configure the underlying socket for
+blocking. Conversely if your application want nonblocking behaviour then the
+underlying socket is configured to be nonblocking.
+
+With an OpenSSL QUIC application the underlying socket must always be configured
+to be nonblocking. Howevever the B<SSL> object will, by default, still operate
+in blocking mode. So, from an application's perspective, calls to functions such
+as L<SSL_read_ex(3)>, L<SSL_write_ex(3)> and other I/O functions will still
+block. OpenSSL itself provides that blocking capability for QUIC instead of the
+socket. If nonblocking behaviour is desired then the application must call
+L<SSL_set_blocking_mode(3)>.
+
+=head1 FURTHER READING
+
+See L<ossl-guide-quic-client-block(7)> to see an example of applying these
+concepts in order to write a simple blocking QUIC client.
+
+=head1 SEE ALSO
+
+L<crypto(7)>, L<bio(7)>, L<ossl-guide-tls-introduction(7)>,
+L<ossl-guide-tls-client-block(7)>, L<ossl-guide-quic-client-block(7)>
+
+=head1 COPYRIGHT
+
+Copyright 2023 The OpenSSL Project Authors. All Rights Reserved.
+
+Licensed under the Apache License 2.0 (the "License").  You may not use
+this file except in compliance with the License.  You can obtain a copy
+in the file LICENSE in the source distribution or at
+L<https://www.openssl.org/source/license.html>.
+
+=cut

--- a/doc/man7/ossl-guide-tls-client-block.pod
+++ b/doc/man7/ossl-guide-tls-client-block.pod
@@ -135,7 +135,7 @@ to create an IPv4 TCP socket:
 
     int sock;
 
-    sock = socket(AF_INET, SOCK_STEAM, 0);
+    sock = socket(AF_INET, SOCK_STREAM, 0);
     if (sock == -1)
         return NULL;
 
@@ -542,6 +542,11 @@ that we have been unable to find the issuer of the server's certificate (or one
 of its intermediate CA certificates) in our trusted certificate store (e.g.
 because the trusted certificate store is misconfigured, or there are missing
 intermediate CAs, or the issuer is simply unrecognised).
+
+=head1 FURTHER READING
+
+See L<ossl-guide-quic-client-block(7)> to read a tutorial on how to modify the
+client developed on this page to support QUIC instead of TLS.
 
 =head1 SEE ALSO
 

--- a/doc/man7/ossl-guide-tls-introduction.pod
+++ b/doc/man7/ossl-guide-tls-introduction.pod
@@ -297,10 +297,12 @@ object.
 
 See L<ossl-guide-tls-client-block(7)> to see an example of applying these
 concepts in order to write a simple TLS client based on a blocking socket.
+See L<ossl-guide-quic-introduction(7)> for an introduction to QUIC in OpenSSL.
 
 =head1 SEE ALSO
 
-L<crypto(7)>, L<ossl-guide-tls-client-block(7)>
+L<crypto(7)>, L<ossl-guide-tls-client-block(7)>,
+L<ossl-guide-quic-introduction(7)>
 
 =head1 COPYRIGHT
 

--- a/include/internal/quic_tserver.h
+++ b/include/internal/quic_tserver.h
@@ -15,6 +15,7 @@
 # include "internal/quic_stream.h"
 # include "internal/quic_channel.h"
 # include "internal/statem.h"
+# include "internal/time.h"
 
 # ifndef OPENSSL_NO_QUIC
 
@@ -39,6 +40,8 @@ typedef struct quic_tserver_args_st {
     BIO *net_rbio, *net_wbio;
     OSSL_TIME (*now_cb)(void *arg);
     void *now_cb_arg;
+    const unsigned char *alpn;
+    size_t alpnlen;
 } QUIC_TSERVER_ARGS;
 
 QUIC_TSERVER *ossl_quic_tserver_new(const QUIC_TSERVER_ARGS *args,
@@ -156,6 +159,27 @@ int ossl_quic_tserver_set_new_local_cid(QUIC_TSERVER *srv,
  * currently is none.
  */
 uint64_t ossl_quic_tserver_pop_incoming_stream(QUIC_TSERVER *srv);
+
+/*
+ * Returns 1 if all data sent on the given stream_id has been acked by the peer.
+ */
+int ossl_quic_tserver_is_stream_totally_acked(QUIC_TSERVER *srv,
+                                              uint64_t stream_id);
+
+/* Returns 1 if we are currently interested in reading data from the network */
+int ossl_quic_tserver_get_net_read_desired(QUIC_TSERVER *srv);
+
+/* Returns 1 if we are currently interested in writing data to the network */
+int ossl_quic_tserver_get_net_write_desired(QUIC_TSERVER *srv);
+
+/* Returns the next event deadline */
+OSSL_TIME ossl_quic_tserver_get_deadline(QUIC_TSERVER *srv);
+
+/*
+ * Shutdown the QUIC connection. Returns 1 if the connection is terminated and
+ * 0 otherwise.
+ */
+int ossl_quic_tserver_shutdown(QUIC_TSERVER *srv);
 
 # endif
 

--- a/ssl/quic/cc_newreno.c
+++ b/ssl/quic/cc_newreno.c
@@ -296,11 +296,16 @@ static uint64_t newreno_get_tx_allowance(OSSL_CC_DATA *cc)
 
 static OSSL_TIME newreno_get_wakeup_deadline(OSSL_CC_DATA *cc)
 {
-    /*
-     * The NewReno congestion controller does not vary its state in time, only
-     * in response to stimulus.
-     */
-    return ossl_time_infinite();
+    if (newreno_get_tx_allowance(cc) > 0) {
+        /* We have TX allowance now so wakeup immediately */
+        return ossl_time_zero();
+    } else {
+        /*
+        * The NewReno congestion controller does not vary its state in time,
+        * only in response to stimulus.
+        */
+        return ossl_time_infinite();
+    }
 }
 
 static int newreno_on_data_sent(OSSL_CC_DATA *cc, uint64_t num_bytes)

--- a/ssl/quic/cc_newreno.c
+++ b/ssl/quic/cc_newreno.c
@@ -301,9 +301,9 @@ static OSSL_TIME newreno_get_wakeup_deadline(OSSL_CC_DATA *cc)
         return ossl_time_zero();
     } else {
         /*
-        * The NewReno congestion controller does not vary its state in time,
-        * only in response to stimulus.
-        */
+         * The NewReno congestion controller does not vary its state in time,
+         * only in response to stimulus.
+         */
         return ossl_time_infinite();
     }
 }

--- a/ssl/quic/quic_channel.c
+++ b/ssl/quic/quic_channel.c
@@ -135,6 +135,8 @@ static int ch_init(QUIC_CHANNEL *ch)
     qtx_args.mdpl = QUIC_MIN_INITIAL_DGRAM_LEN;
     ch->rx_max_udp_payload_size = qtx_args.mdpl;
 
+    ch->ping_deadline = ossl_time_infinite();
+
     ch->qtx = ossl_qtx_new(&qtx_args);
     if (ch->qtx == NULL)
         goto err;

--- a/ssl/quic/quic_impl.c
+++ b/ssl/quic/quic_impl.c
@@ -339,6 +339,7 @@ SSL *ossl_quic_new(SSL_CTX *ctx)
     qc->default_stream_mode     = SSL_DEFAULT_STREAM_MODE_AUTO_BIDI;
     qc->default_ssl_mode        = qc->ssl.ctx->mode;
     qc->default_blocking        = 1;
+    qc->blocking                = 1;
     qc->incoming_stream_policy  = SSL_INCOMING_STREAM_POLICY_AUTO;
     qc->last_error              = SSL_ERROR_NONE;
 

--- a/test/helpers/quictestlib.c
+++ b/test/helpers/quictestlib.c
@@ -156,6 +156,7 @@ int qtest_create_quic_objects(OSSL_LIB_CTX *libctx, SSL_CTX *clientctx,
     tserver_args.libctx = libctx;
     tserver_args.net_rbio = sbio;
     tserver_args.net_wbio = fisbio;
+    tserver_args.alpn = NULL;
 
     if (!TEST_ptr(*qtserv = ossl_quic_tserver_new(&tserver_args, certfile,
                                                   keyfile)))

--- a/test/quic_cc_test.c
+++ b/test/quic_cc_test.c
@@ -515,11 +515,8 @@ static int test_sanity(void)
     if (!TEST_uint64_t_ge(allowance = ccm->get_tx_allowance(cc), 1472))
         goto err;
 
-    /*
-     * No wakeups should be scheduled currently as we don't currently implement
-     * pacing.
-     */
-    if (!TEST_true(ossl_time_is_infinite(ccm->get_wakeup_deadline(cc))))
+    /* There is TX allowance so wakeup should be immediate */
+    if (!TEST_true(ossl_time_is_zero(ccm->get_wakeup_deadline(cc))))
         goto err;
 
     /* No bytes should currently be in flight. */

--- a/test/quic_multistream_test.c
+++ b/test/quic_multistream_test.c
@@ -489,6 +489,7 @@ static int helper_init(struct helper *h, int free_order)
 
     s_args.net_rbio     = h->s_net_bio;
     s_args.net_wbio     = h->s_net_bio;
+    s_args.alpn         = NULL;
     s_args.now_cb       = get_time;
     s_args.now_cb_arg   = h;
 

--- a/test/quic_tserver_test.c
+++ b/test/quic_tserver_test.c
@@ -119,6 +119,7 @@ static int do_test(int use_thread_assist, int use_fake_time, int use_inject)
 
     tserver_args.net_rbio = s_net_bio;
     tserver_args.net_wbio = s_net_bio;
+    tserver_args.alpn = NULL;
     if (use_fake_time)
         tserver_args.now_cb = fake_now;
 

--- a/test/recipes/75-test_quicapi_data/ssltraceref.txt
+++ b/test/recipes/75-test_quicapi_data/ssltraceref.txt
@@ -234,7 +234,7 @@ YeeuLO02zToHhnQ6KbPXOrQAqcL1kngO4g+j/ru+4AZThFkdkGnltvk=
         No extensions
 
 Received Datagram
-  Length: 256
+  Length: 234
 Received Packet
   Packet Type: Handshake
   Version: 0x00000001
@@ -267,8 +267,6 @@ Header:
     Finished, Length=32
       verify_data (len=32): ????????????????????????????????????????????????????????????????
 
-
-Received Frame: Ping
 Sent Frame: Ack  (without ECN)
     Largest acked: 1
     Ack delay (raw) 0
@@ -284,11 +282,5 @@ Sent Packet
   Source Conn Id: <zero length id>
   Payload length: 60
   Packet Number: 0x00000000
-Sent Frame: Ack  (without ECN)
-    Largest acked: 0
-    Ack delay (raw) 0
-    Ack range count: 0
-    First ack range: 0
-
 Sent Datagram
-  Length: 115
+  Length: 81

--- a/util/build.info
+++ b/util/build.info
@@ -1,7 +1,14 @@
 IF[{- $target{build_scheme}->[1] eq "unix" -}]
- SCRIPTS{noinst}=shlib_wrap.sh
- SOURCE[shlib_wrap.sh]=shlib_wrap.sh.in
+  SCRIPTS{noinst}=shlib_wrap.sh
+  SOURCE[shlib_wrap.sh]=shlib_wrap.sh.in
 ENDIF
 SCRIPTS{noinst}=wrap.pl
 SOURCE[wrap.pl]=wrap.pl.in
 DEPEND[wrap.pl]=../configdata.pm
+
+IF[{- !$disabled{quic} -}]
+  PROGRAMS{noinst}=quicserver
+  SOURCE[quicserver]=quicserver.c
+INCLUDE[quicserver]=../include ../apps/include
+DEPEND[quicserver]=../libcrypto.a ../libssl.a
+ENDIF

--- a/util/quicserver.c
+++ b/util/quicserver.c
@@ -15,6 +15,7 @@
 #include <openssl/bio.h>
 #include <openssl/ssl.h>
 #include <openssl/err.h>
+#include "internal/e_os.h"
 #include "internal/sockets.h"
 #include "internal/quic_tserver.h"
 #include "internal/time.h"

--- a/util/quicserver.c
+++ b/util/quicserver.c
@@ -1,0 +1,252 @@
+/*
+ * Copyright 2023 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+/*
+ * This is a temporary test server for QUIC. It will eventually be replaced
+ * by s_server and removed once we have full QUIC server support.
+ */
+
+#include <openssl/bio.h>
+#include <openssl/ssl.h>
+#include <openssl/err.h>
+#include "internal/sockets.h"
+#include "internal/quic_tserver.h"
+#include "internal/time.h"
+
+static void wait_for_activity(QUIC_TSERVER *qtserv)
+{
+    fd_set readfds, writefds;
+    fd_set *readfdsp = NULL, *writefdsp = NULL;
+    struct timeval timeout, *timeoutp = NULL;
+    int width;
+    int sock;
+    BIO *bio = ossl_quic_tserver_get0_rbio(qtserv);
+    OSSL_TIME deadline;
+
+    BIO_get_fd(bio, &sock);
+
+    if (ossl_quic_tserver_get_net_read_desired(qtserv)) {
+        readfdsp = &readfds;
+        FD_ZERO(readfdsp);
+        openssl_fdset(sock, readfdsp);
+    }
+
+    if (ossl_quic_tserver_get_net_write_desired(qtserv)) {
+        writefdsp = &writefds;
+        FD_ZERO(writefdsp);
+        openssl_fdset(sock, writefdsp);
+    }
+
+    deadline = ossl_quic_tserver_get_deadline(qtserv);
+
+    if (!ossl_time_is_infinite(deadline)) {
+        timeout = ossl_time_to_timeval(ossl_time_subtract(deadline,
+                                                          ossl_time_now()));
+        timeoutp = &timeout;
+    }
+
+    width = sock + 1;
+
+    if (readfdsp == NULL && writefdsp == NULL && timeoutp == NULL)
+        return;
+
+    select(width, readfdsp, writefdsp, NULL, timeoutp);
+}
+
+/* Helper function to create a BIO connected to the server */
+static BIO *create_dgram_bio(int family, const char *hostname, const char *port)
+{
+    int sock = -1;
+    BIO_ADDRINFO *res;
+    const BIO_ADDRINFO *ai = NULL;
+    BIO *bio;
+
+    if (BIO_sock_init() != 1)
+        return NULL;
+
+    /*
+     * Lookup IP address info for the server.
+     */
+    if (!BIO_lookup_ex(hostname, port, BIO_LOOKUP_SERVER, family, SOCK_DGRAM,
+                       0, &res))
+        return NULL;
+
+    /*
+     * Loop through all the possible addresses for the server and find one
+     * we can create and start listening on
+     */
+    for (ai = res; ai != NULL; ai = BIO_ADDRINFO_next(ai)) {
+        /* Create the UDP socket */
+        sock = BIO_socket(BIO_ADDRINFO_family(ai), SOCK_DGRAM, 0, 0);
+        if (sock == -1)
+            continue;
+
+        /* Start listening on the socket */
+        if (!BIO_listen(sock, BIO_ADDRINFO_address(ai), 0)) {
+            BIO_closesocket(sock);
+            sock = -1;
+            continue;
+        }
+
+        /* Set to non-blocking mode */
+        if (!BIO_socket_nbio(sock, 1)) {
+            BIO_closesocket(sock);
+            sock = -1;
+            continue;
+        }
+    }
+
+    /* Free the address information resources we allocated earlier */
+    BIO_ADDRINFO_free(res);
+
+    /* If sock is -1 then we've been unable to connect to the server */
+    if (sock == -1)
+        return NULL;
+
+    /* Create a BIO to wrap the socket*/
+    bio = BIO_new(BIO_s_datagram());
+    if (bio == NULL)
+        BIO_closesocket(sock);
+
+    /*
+     * Associate the newly created BIO with the underlying socket. By
+     * passing BIO_CLOSE here the socket will be automatically closed when
+     * the BIO is freed. Alternatively you can use BIO_NOCLOSE, in which
+     * case you must close the socket explicitly when it is no longer
+     * needed.
+     */
+    BIO_set_fd(bio, sock, BIO_CLOSE);
+
+    return bio;
+}
+
+static void usage(void)
+{
+    printf("quicserver [-6] hostname port certfile keyfile\n");
+}
+
+int main(int argc, char *argv[])
+{
+    QUIC_TSERVER_ARGS tserver_args = {0};
+    QUIC_TSERVER *qtserv = NULL;
+    int ipv6 = 0;
+    int argnext = 1;
+    BIO *bio = NULL;
+    char *hostname, *port, *certfile, *keyfile;
+    int ret = EXIT_FAILURE;
+    unsigned char reqbuf[1024];
+    size_t numbytes, reqbytes = 0;
+    const char reqterm[] = {
+        '\r', '\n', '\r', '\n'
+    };
+    const char *msg = "Hello world\n";
+    unsigned char alpn[] = { 8, 'h', 't', 't', 'p', '/', '1', '.', '0' };
+    int first = 1;
+
+    if (argc == 0)
+        return EXIT_FAILURE;
+
+    while (argnext < argc) {
+        if (argv[argnext][0] != '-')
+            break;
+        if (strcmp(argv[argnext], "-6") == 0) {
+            ipv6 = 1;
+        } else {
+            printf("Unrecognised argument %s\n", argv[argnext]);
+            usage();
+            return EXIT_FAILURE;
+        }
+        argnext++;
+    }
+
+    if (argc - argnext != 4) {
+        usage();
+        return EXIT_FAILURE;
+    }
+    hostname = argv[argnext++];
+    port = argv[argnext++];
+    certfile = argv[argnext++];
+    keyfile = argv[argnext++];
+
+    bio = create_dgram_bio(ipv6 ? AF_INET6 : AF_INET, hostname, port);
+    if (bio == NULL || !BIO_up_ref(bio)) {
+        BIO_free(bio);
+        printf("Unable to create server socket\n");
+        return EXIT_FAILURE;
+    }
+
+    tserver_args.libctx = NULL;
+    tserver_args.net_rbio = bio;
+    tserver_args.net_wbio = bio;
+    tserver_args.alpn = alpn;
+    tserver_args.alpnlen = sizeof(alpn);
+
+    qtserv = ossl_quic_tserver_new(&tserver_args, certfile, keyfile);
+    if (qtserv == NULL) {
+        printf("Failed to create the QUIC_TSERVER\n");
+        goto end;
+    }
+
+    printf("Starting quicserver\n");
+    printf("Note that this utility will be removed in a future OpenSSL version\n");
+    printf("For test purposes only. Not for use in a production environment\n");
+
+    /* Ownership of the BIO is passed to qtserv */
+    bio = NULL;
+
+    /* Read the request */
+    do {
+        if (first)
+            first = 0;
+        else
+            wait_for_activity(qtserv);
+
+        ossl_quic_tserver_tick(qtserv);
+
+        if (ossl_quic_tserver_read(qtserv, 0, reqbuf, sizeof(reqbuf),
+                                    &numbytes)) {
+            if (numbytes > 0) {
+                fwrite(reqbuf, 1, numbytes, stdout);
+            }
+            reqbytes += numbytes;
+        }
+    } while (reqbytes < sizeof(reqterm)
+             || memcmp(reqbuf + reqbytes - sizeof(reqterm), reqterm,
+                       sizeof(reqterm)) != 0);
+
+    /* Send the response */
+
+    ossl_quic_tserver_tick(qtserv);
+    if (!ossl_quic_tserver_write(qtserv, 0, (unsigned char *)msg, strlen(msg),
+                                 &numbytes))
+        goto end;
+
+    if (!ossl_quic_tserver_conclude(qtserv, 0))
+        goto end;
+
+    /* Wait until all data we have sent has been acked */
+    while (!ossl_quic_tserver_is_terminated(qtserv)
+           && !ossl_quic_tserver_is_stream_totally_acked(qtserv, 0)) {
+        ossl_quic_tserver_tick(qtserv);
+        wait_for_activity(qtserv);
+    }
+
+    while (!ossl_quic_tserver_shutdown(qtserv))
+        wait_for_activity(qtserv);
+
+    /* Close down here */
+
+    ret = EXIT_SUCCESS;
+ end:
+    /* Free twice because we did an up-ref */
+    BIO_free(bio);
+    BIO_free(bio);
+    ossl_quic_tserver_free(qtserv);
+    return ret;
+}


### PR DESCRIPTION
This tutorial only covers a single stream client at this stage. A future
PR will cover adding multi-stream support.

As well as the tutorial I've also added a QUIC server utility. This is not intended for installation and is a temporary test tool until we add s_server support in a later release.

I encountered some bugs in our QUIC implementation while I got this working, so those are also fixed:

- SSL_connect did not block (patch courtesy of @hlandau)
- Busy loop entered in the server because the ping deadline was defaulting to zero
- 1 second delay in the handshake because although we had stuff available to send the CC had TX allowance, we were still waiting until the next CC wakeup deadline (which is infinite for new reno).
