### PR TITLE
Extended SSL_SESSION functions using time_t datatype

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,12 @@ OpenSSL 3.3
 
 ### Changes between 3.2 and 3.3 [xx XXX xxxx]
 
+ * Added API functions SSL_SESSION_get_time_ex(), SSL_SESSION_set_time_ex()
+   using time_t which is Y2038 safe on 32 bit systems when 64 bit time
+   is enabled (e.g via setting glibc macro _TIME_BITS=64).
+
+   *Ijtaba Hussain*
+
  * The EVP_PKEY_fromdata function has been augmented to allow for the derivation
    of CRT (Chinese Remainder Theorem) parameters when requested.  See the
    OSSL_PKEY_PARAM_RSA_DERIVE_FROM_PQ param in the EVP_PKEY-RSA documentation.

--- a/doc/man3/SSL_SESSION_get_time.pod
+++ b/doc/man3/SSL_SESSION_get_time.pod
@@ -3,7 +3,7 @@
 =head1 NAME
 
 SSL_SESSION_get_time, SSL_SESSION_set_time, SSL_SESSION_get_timeout,
-SSL_SESSION_set_timeout,
+SSL_SESSION_set_timeout, SSL_SESSION_get_time_ex, SSL_SESSION_set_time_ex,
 SSL_get_time, SSL_set_time, SSL_get_timeout, SSL_set_timeout
 - retrieve and manipulate session time and timeout settings
 
@@ -21,6 +21,9 @@ SSL_get_time, SSL_set_time, SSL_get_timeout, SSL_set_timeout
  long SSL_get_timeout(const SSL_SESSION *s);
  long SSL_set_timeout(SSL_SESSION *s, long tm);
 
+ time_t SSL_SESSION_get_time_ex(const SSL_SESSION *s);
+ time_t SSL_SESSION_set_time_ex(SSL_SESSION *s, time_t tm);
+
 =head1 DESCRIPTION
 
 SSL_SESSION_get_time() returns the time at which the session B<s> was
@@ -35,6 +38,10 @@ in seconds.
 
 SSL_SESSION_set_timeout() sets the timeout value for session B<s> in seconds
 to B<tm>.
+
+SSL_SESSION_get_time_ex() and SSL_SESSION_set_time_ex() extended functions use
+the time_t datatype instead of long to fix the Y2038 problem on systems with 
+64 bit time_t type.
 
 The SSL_get_time(), SSL_set_time(), SSL_get_timeout(), and SSL_set_timeout()
 functions are synonyms for the SSL_SESSION_*() counterparts.
@@ -58,6 +65,12 @@ SSL_SESSION_set_time() and SSL_SESSION_set_timeout() return 1 on success.
 If any of the function is passed the NULL pointer for the session B<s>,
 0 is returned.
 
+=head1 BUGS
+
+The data type long is typically 32 bits on many systems, hence the old
+functions SSL_SESSION_get_time() and SSL_SESSION_set_time() are not always
+Y2038 safe.
+
 =head1 SEE ALSO
 
 L<ssl(7)>,
@@ -66,7 +79,7 @@ L<SSL_get_default_timeout(3)>
 
 =head1 COPYRIGHT
 
-Copyright 2001-2016 The OpenSSL Project Authors. All Rights Reserved.
+Copyright 2001-2023 The OpenSSL Project Authors. All Rights Reserved.
 
 Licensed under the Apache License 2.0 (the "License").  You may not use
 this file except in compliance with the License.  You can obtain a copy

--- a/include/openssl/ssl.h.in
+++ b/include/openssl/ssl.h.in
@@ -1691,6 +1691,9 @@ __owur long SSL_SESSION_set_timeout(SSL_SESSION *s, long t);
 __owur int SSL_SESSION_get_protocol_version(const SSL_SESSION *s);
 __owur int SSL_SESSION_set_protocol_version(SSL_SESSION *s, int version);
 
+__owur time_t SSL_SESSION_get_time_ex(const SSL_SESSION *s);
+__owur time_t SSL_SESSION_set_time_ex(SSL_SESSION *s, time_t t);
+
 __owur const char *SSL_SESSION_get0_hostname(const SSL_SESSION *s);
 __owur int SSL_SESSION_set1_hostname(SSL_SESSION *s, const char *hostname);
 void SSL_SESSION_get0_alpn_selected(const SSL_SESSION *s,

--- a/ssl/ssl_sess.c
+++ b/ssl/ssl_sess.c
@@ -919,14 +919,19 @@ long SSL_SESSION_get_timeout(const SSL_SESSION *s)
 
 long SSL_SESSION_get_time(const SSL_SESSION *s)
 {
-    if (s == NULL)
-        return 0;
-    return (long)ossl_time_to_time_t(s->time);
+    return (long) SSL_SESSION_get_time_ex(s);
 }
 
-long SSL_SESSION_set_time(SSL_SESSION *s, long t)
+time_t SSL_SESSION_get_time_ex(const SSL_SESSION *s)
 {
-    OSSL_TIME new_time = ossl_time_from_time_t((time_t)t);
+    if (s == NULL)
+        return 0;
+    return ossl_time_to_time_t(s->time);
+}
+
+time_t SSL_SESSION_set_time_ex(SSL_SESSION *s, time_t t)
+{
+    OSSL_TIME new_time = ossl_time_from_time_t(t);
 
     if (s == NULL)
         return 0;
@@ -942,6 +947,11 @@ long SSL_SESSION_set_time(SSL_SESSION *s, long t)
         ssl_session_calculate_timeout(s);
     }
     return t;
+}
+
+long SSL_SESSION_set_time(SSL_SESSION *s, long t)
+{
+    return (long) SSL_SESSION_set_time_ex(s, (time_t) t);
 }
 
 int SSL_SESSION_get_protocol_version(const SSL_SESSION *s)

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -3389,7 +3389,7 @@ static int ed_gen_cb(SSL *s, void *arg)
         return 1;
     artificial_ticket_time--;
 
-    if (SSL_SESSION_set_time(sess, SSL_SESSION_get_time(sess) - 10) == 0)
+    if (SSL_SESSION_set_time_ex(sess, SSL_SESSION_get_time_ex(sess) - 10) == 0)
         return 0;
 
     return 1;
@@ -3492,8 +3492,8 @@ static int setupearly_data_test(SSL_CTX **cctx, SSL_CTX **sctx, SSL **clientssl,
      * gave it on the server side
      */
     if (artificial
-            && !TEST_long_gt(SSL_SESSION_set_time(*sess,
-                                                  SSL_SESSION_get_time(*sess) - 10), 0))
+            && !TEST_time_t_gt(SSL_SESSION_set_time_ex(*sess,
+                                     SSL_SESSION_get_time_ex(*sess) - 10), 0))
         return 0;
 
     if (!TEST_true(create_ssl_objects(*sctx, *cctx, serverssl,

--- a/util/libssl.num
+++ b/util/libssl.num
@@ -581,3 +581,5 @@ SSL_write_ex2                           ?	3_3_0	EXIST::FUNCTION:
 SSL_get_value_uint                      ?	3_3_0	EXIST::FUNCTION:
 SSL_set_value_uint                      ?	3_3_0	EXIST::FUNCTION:
 SSL_poll                                ?	3_3_0	EXIST::FUNCTION:
+SSL_SESSION_get_time_ex                 ?	3_3_0	EXIST::FUNCTION:
+SSL_SESSION_set_time_ex                 ?	3_3_0	EXIST::FUNCTION:


### PR DESCRIPTION
Hi Team,

Would really appreciate a review of this draft PR for #16726 (Y2038 overflow problem in API functions taking / returning long values)

There may be more functions and parts of openssl affected by the same issue. Instead of adding new tests, I've updated one existing test as well as modified the existing functions to call the new extended ones so we have better test coverage / less redundancy. Whilst this approach feels a bit "hacky", I figured this was cleaner than duplicating existing tests.

In terms of discovering other parts of openssl affected by Y2038, these are the only approaches I can think of:

1) Run openssl tests with a post Y2038 date in a 32 bit environment (pending)
2) Run tests for other openssl dependant software libraries with a post Y2038 date in a 32 bit environment

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [x] tests are added or updated
