### PR TITLE
Fix function signatures in aes-gcm-armv8 comments.

### DIFF
--- a/crypto/modes/asm/aes-gcm-armv8-unroll8_64.pl
+++ b/crypto/modes/asm/aes-gcm-armv8-unroll8_64.pl
@@ -249,12 +249,12 @@ my $rk4v="v27";
 
 
 #########################################################################################
-# size_t unroll8_eor3_aes_gcm_enc_128_kernel(const unsigned char *in,
-#                               size_t len,
-#                               unsigned char *out,
-#                               const void *key,
-#                               unsigned char ivec[16],
-#                               u64 *Xi);
+# size_t unroll8_eor3_aes_gcm_enc_128_kernel(const uint8_t * plaintext,
+#                                            uint64_t plaintext_length,
+#                                            uint8_t * ciphertext,
+#                                            uint64_t *Xi,
+#                                            unsigned char ivec[16],
+#                                            const void *key);
 #
 $code.=<<___;
 .global unroll8_eor3_aes_gcm_enc_128_kernel
@@ -1348,12 +1348,12 @@ unroll8_eor3_aes_gcm_enc_128_kernel:
 ___
 
 #########################################################################################
-# size_t unroll8_eor3_aes_gcm_dec_128_kernel(const unsigned char *in,
-#                               size_t len,
-#                               unsigned char *out,
-#                               u64 *Xi,
-#                               unsigned char ivec[16],
-#                               const void *key);
+# size_t unroll8_eor3_aes_gcm_dec_128_kernel(const uint8_t * ciphertext,
+#                                            uint64_t plaintext_length,
+#                                            uint8_t * plaintext,
+#                                            uint64_t *Xi,
+#                                            unsigned char ivec[16],
+#                                            const void *key);
 #
 $code.=<<___;
 .global unroll8_eor3_aes_gcm_dec_128_kernel
@@ -2502,12 +2502,12 @@ my $rk3q1="v26.1q";
 my $rk4v="v27";
 
 #########################################################################################
-# size_t unroll8_eor3_aes_gcm_enc_192_kernel(const unsigned char *in,
-#                               size_t len,
-#                               unsigned char *out,
-#                               const void *key,
-#                               unsigned char ivec[16],
-#                               u64 *Xi);
+# size_t unroll8_eor3_aes_gcm_enc_192_kernel(const uint8_t * plaintext,
+#                                            uint64_t plaintext_length,
+#                                            uint8_t * ciphertext,
+#                                            uint64_t *Xi,
+#                                            unsigned char ivec[16],
+#                                            const void *key);
 #
 $code.=<<___;
 .global unroll8_eor3_aes_gcm_enc_192_kernel
@@ -3664,12 +3664,12 @@ unroll8_eor3_aes_gcm_enc_192_kernel:
 ___
 
 #########################################################################################
-# size_t unroll8_eor3_aes_gcm_dec_192_kernel(const unsigned char *in,
-#                               size_t len,
-#                               unsigned char *out,
-#                               const void *key,
-#                               unsigned char ivec[16],
-#                               u64 *Xi);
+# size_t unroll8_eor3_aes_gcm_dec_192_kernel(const uint8_t * ciphertext,
+#                                            uint64_t plaintext_length,
+#                                            uint8_t * plaintext,
+#                                            uint64_t *Xi,
+#                                            unsigned char ivec[16],
+#                                            const void *key);
 #
 $code.=<<___;
 .global unroll8_eor3_aes_gcm_dec_192_kernel
@@ -4879,12 +4879,12 @@ my $rk2q1="v28.1q";
 my $rk3q1="v26.1q";
 my $rk4v="v27";
 #########################################################################################
-# size_t unroll8_eor3_aes_gcm_enc_256_kernel(const unsigned char *in,
-#                               size_t len,
-#                               unsigned char *out,
-#                               const void *key,
-#                               unsigned char ivec[16],
-#                               u64 *Xi);
+# size_t unroll8_eor3_aes_gcm_enc_256_kernel(const uint8_t * plaintext,
+#                                            uint64_t plaintext_length,
+#                                            uint8_t * ciphertext,
+#                                            uint64_t *Xi,
+#                                            unsigned char ivec[16],
+#                                            const void *key);
 #
 $code.=<<___;
 .global unroll8_eor3_aes_gcm_enc_256_kernel
@@ -6110,12 +6110,12 @@ ___
 
 {
 #########################################################################################
-# size_t unroll8_eor3_aes_gcm_dec_256_kernel(const unsigned char *in,
-#                               size_t len,
-#                               unsigned char *out,
-#                               const void *key,
-#                               unsigned char ivec[16],
-#                               u64 *Xi);
+# size_t unroll8_eor3_aes_gcm_dec_256_kernel(const uint8_t * ciphertext,
+#                                            uint64_t plaintext_length,
+#                                            uint8_t * plaintext,
+#                                            uint64_t *Xi,
+#                                            unsigned char ivec[16],
+#                                            const void *key);
 #
 $code.=<<___;
 .global unroll8_eor3_aes_gcm_dec_256_kernel

--- a/crypto/modes/asm/aes-gcm-armv8_64.pl
+++ b/crypto/modes/asm/aes-gcm-armv8_64.pl
@@ -245,12 +245,12 @@ $code.=<<___                    if ($flavour !~ /64/);
 ___
 
 #########################################################################################
-# size_t aes_gcm_enc_128_kernel(const unsigned char *in,
-#                               size_t len,
-#                               unsigned char *out,
-#                               const void *key,
+# size_t aes_gcm_enc_128_kernel(const uint8_t * plaintext,
+#                               uint64_t plaintext_length,
+#                               uint8_t * ciphertext,
+#                               uint64_t *Xi,
 #                               unsigned char ivec[16],
-#                               u64 *Xi);
+#                               const void *key);
 #
 $code.=<<___;
 .global aes_gcm_enc_128_kernel
@@ -1131,12 +1131,12 @@ aes_gcm_enc_128_kernel:
 ___
 
 #########################################################################################
-# size_t aes_gcm_dec_128_kernel(const unsigned char *in,
-#                               size_t len,
-#                               unsigned char *out,
-#                               const void *key,
+# size_t aes_gcm_dec_128_kernel(const uint8_t * ciphertext,
+#                               uint64_t plaintext_length,
+#                               uint8_t * plaintext,
+#                               uint64_t *Xi,
 #                               unsigned char ivec[16],
-#                               u64 *Xi);
+#                               const void *key);
 #
 $code.=<<___;
 .global aes_gcm_dec_128_kernel
@@ -2089,12 +2089,12 @@ my $rk4v="v22";
 my $rk4d="d22";
 
 #########################################################################################
-# size_t aes_gcm_enc_192_kernel(const unsigned char *in,
-#                               size_t len,
-#                               unsigned char *out,
-#                               const void *key,
+# size_t aes_gcm_enc_192_kernel(const uint8_t * plaintext,
+#                               uint64_t plaintext_length,
+#                               uint8_t * ciphertext,
+#                               uint64_t *Xi,
 #                               unsigned char ivec[16],
-#                               u64 *Xi);
+#                               const void *key);
 #
 $code.=<<___;
 .global aes_gcm_enc_192_kernel
@@ -3026,12 +3026,12 @@ aes_gcm_enc_192_kernel:
 ___
 
 #########################################################################################
-# size_t aes_gcm_dec_192_kernel(const unsigned char *in,
-#                               size_t len,
-#                               unsigned char *out,
-#                               const void *key,
+# size_t aes_gcm_dec_192_kernel(const uint8_t * ciphertext,
+#                               uint64_t plaintext_length,
+#                               uint8_t * plaintext,
+#                               uint64_t *Xi,
 #                               unsigned char ivec[16],
-#                               u64 *Xi);
+#                               const void *key);
 #
 $code.=<<___;
 .global aes_gcm_dec_192_kernel
@@ -4034,12 +4034,12 @@ my $rk4v="v22";
 my $rk4d="d22";
 
 #########################################################################################
-# size_t aes_gcm_enc_256_kernel(const unsigned char *in,
-#                               size_t len,
-#                               unsigned char *out,
-#                               const void *key,
+# size_t aes_gcm_enc_256_kernel(const uint8_t * plaintext,
+#                               uint64_t plaintext_length,
+#                               uint8_t * ciphertext,
+#                               uint64_t *Xi,
 #                               unsigned char ivec[16],
-#                               u64 *Xi);
+#                               const void *key);
 #
 $code.=<<___;
 .global aes_gcm_enc_256_kernel
@@ -5019,12 +5019,12 @@ my $t8d="d4";
 my $t9="v6";
 my $t9d="d6";
 #########################################################################################
-# size_t aes_gcm_dec_256_kernel(const unsigned char *in,
-#                               size_t len,
-#                               unsigned char *out,
-#                               const void *key,
+# size_t aes_gcm_dec_256_kernel(const uint8_t * ciphertext,
+#                               uint64_t plaintext_length,
+#                               uint8_t * plaintext,
+#                               uint64_t *Xi,
 #                               unsigned char ivec[16],
-#                               u64 *Xi);
+#                               const void *key);
 #
 $code.=<<___;
 .global aes_gcm_dec_256_kernel


### PR DESCRIPTION
Comments of aes-gcm-armv8_64.pl and aes-gcm-armv8-unroll8_64.pl are inconsistent with aes_platform.h. Fix it.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
