### PR TITLE
Fix new typos found by codespell

### DIFF
--- a/apps/cmp.c
+++ b/apps/cmp.c
@@ -2864,7 +2864,7 @@ static int do_genm(OSSL_CMP_CTX *ctx)
         if (cacerts == NULL) {
             CMP_warn("no CA certificates provided by server");
         } else if (save_free_certs(cacerts, opt_cacertsout, "CA") < 0) {
-            CMP_err1("Failed to store CA certficates from genp in %s",
+            CMP_err1("Failed to store CA certificates from genp in %s",
                      opt_cacertsout);
             return 0;
         }

--- a/demos/guide/tls-client-block.c
+++ b/demos/guide/tls-client-block.c
@@ -137,7 +137,7 @@ int main(void)
 
     /*
      * TLSv1.1 or earlier are deprecated by IETF and are generally to be
-     * avoided if possible. We require a mimimum TLS version of TLSv1.2.
+     * avoided if possible. We require a minimum TLS version of TLSv1.2.
      */
     if (!SSL_CTX_set_min_proto_version(ctx, TLS1_2_VERSION)) {
         printf("Failed to set the minimum TLS protocol version\n");
@@ -245,7 +245,7 @@ int main(void)
          * for one back". But we already know we got one from the peer
          * because of the SSL_ERROR_ZERO_RETURN above.
          */
-        printf("Error shuting down\n");
+        printf("Error shutting down\n");
         goto end;
     }
 

--- a/doc/designs/quic-design/error-handling.md
+++ b/doc/designs/quic-design/error-handling.md
@@ -63,7 +63,7 @@ depend on the error stack contents.
 Intermittent errors are handled within the library and cleared from the
 error stack before returning to the user.
 
-Permanent errors happenning within the assist thread, within SSL_tick()
+Permanent errors happening within the assist thread, within SSL_tick()
 processing, or when calling SSL_read()/SSL_write() on a stream need to be
 replicated for SSL_read()/SSL_write() calls on other streams.
 

--- a/ssl/quic/quic_trace.c
+++ b/ssl/quic/quic_trace.c
@@ -562,7 +562,7 @@ int ossl_quic_trace(int write_p, int version, int content_type,
     case SSL3_RT_QUIC_DATAGRAM:
         BIO_puts(bio, write_p ? "Sent" : "Received");
         /*
-         * Unfortunately there is no way of receiving auxilliary information
+         * Unfortunately there is no way of receiving auxiliary information
          * about the datagram through the msg_callback API such as the peer
          * address
          */

--- a/test/cmactest.c
+++ b/test/cmactest.c
@@ -77,7 +77,7 @@ static struct test_st {
             0x0b, 0x0c, 0x0d, 0x0e, 0x0f
         },
         16,
-        /* fulfill data to 3072 bytes with below string */
+        /* repeat the string below until filling 3072 bytes */
         "#abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789#",
         3072,
         "35da8a02a7afce90e5b711308cee2dee"
@@ -90,7 +90,7 @@ static struct test_st {
             0x16, 0x17
         },
         24,
-        /* fulfill data to 4095 bytes with below string */
+        /* repeat the string below until filling 4095 bytes */
         "#abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789#",
         4095,
         "59053f4e81f3593610f987adb547c5b2"
@@ -103,7 +103,7 @@ static struct test_st {
             0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f
         },
         32,
-        /* fulfill data to 2560 bytes with below string */
+        /* repeat the string below until filling 2560 bytes */
         "#abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789#",
         2560,
         "9c6cf85f7f4baca99725764a0df973a9"
@@ -116,7 +116,7 @@ static struct test_st {
             0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f
         },
         24,
-        /* fulfill data to 2048 bytes with below string */
+        /* repeat the string below until filling 2048 bytes */
         "#abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789#",
         2048,
         "2c2fccc7fcc5d98a"
@@ -128,7 +128,7 @@ static struct test_st {
             0x0b, 0x0c, 0x0d, 0x0e, 0x0f
         },
         16,
-        /* fulfill data to 2049 bytes with below string */
+        /* repeat the string below until filling 2049 bytes */
         "#abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789#",
         2049,
         "c9a9cbc82a3b2d96074e386fce1216f2"
@@ -177,19 +177,19 @@ static int test_cmac_run(void)
 
     ctx = CMAC_CTX_new();
 
-    /* Construct input data, fulfill data to match data length */
+    /* Construct input data, fill repeatedly until reaching data length */
     for (case_idx = 0; case_idx < OSSL_NELEM(test); case_idx++) {
         size_t str_len = strlen((char *)test[case_idx].data);
-        size_t fulfill_len = test[case_idx].data_len - str_len;
-        size_t fulfill_idx = str_len;
-        while (fulfill_len > 0) {
-            if (fulfill_len > str_len) {
-                memcpy(&test[case_idx].data[fulfill_idx], test[case_idx].data, str_len);
-                fulfill_len -= str_len;
-                fulfill_idx += str_len;
+        size_t fill_len = test[case_idx].data_len - str_len;
+        size_t fill_idx = str_len;
+        while (fill_len > 0) {
+            if (fill_len > str_len) {
+                memcpy(&test[case_idx].data[fill_idx], test[case_idx].data, str_len);
+                fill_len -= str_len;
+                fill_idx += str_len;
             } else {
-                memcpy(&test[case_idx].data[fulfill_idx], test[case_idx].data, fulfill_len);
-                fulfill_len = 0;
+                memcpy(&test[case_idx].data[fill_idx], test[case_idx].data, fill_len);
+                fill_len = 0;
             }
         }
     }

--- a/test/cmactest.c
+++ b/test/cmactest.c
@@ -77,7 +77,7 @@ static struct test_st {
             0x0b, 0x0c, 0x0d, 0x0e, 0x0f
         },
         16,
-        /* fullfill data to 3072 bytes with below string */
+        /* fulfill data to 3072 bytes with below string */
         "#abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789#",
         3072,
         "35da8a02a7afce90e5b711308cee2dee"
@@ -90,7 +90,7 @@ static struct test_st {
             0x16, 0x17
         },
         24,
-        /* fullfill data to 4095 bytes with below string */
+        /* fulfill data to 4095 bytes with below string */
         "#abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789#",
         4095,
         "59053f4e81f3593610f987adb547c5b2"
@@ -103,7 +103,7 @@ static struct test_st {
             0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f
         },
         32,
-        /* fullfill data to 2560 bytes with below string */
+        /* fulfill data to 2560 bytes with below string */
         "#abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789#",
         2560,
         "9c6cf85f7f4baca99725764a0df973a9"
@@ -116,7 +116,7 @@ static struct test_st {
             0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f
         },
         24,
-        /* fullfill data to 2048 bytes with below string */
+        /* fulfill data to 2048 bytes with below string */
         "#abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789#",
         2048,
         "2c2fccc7fcc5d98a"
@@ -128,7 +128,7 @@ static struct test_st {
             0x0b, 0x0c, 0x0d, 0x0e, 0x0f
         },
         16,
-        /* fullfill data to 2049 bytes with below string */
+        /* fulfill data to 2049 bytes with below string */
         "#abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789#",
         2049,
         "c9a9cbc82a3b2d96074e386fce1216f2"
@@ -177,19 +177,19 @@ static int test_cmac_run(void)
 
     ctx = CMAC_CTX_new();
 
-    /* Construct input data, fullfill data to match data length */
+    /* Construct input data, fulfill data to match data length */
     for (case_idx = 0; case_idx < OSSL_NELEM(test); case_idx++) {
         size_t str_len = strlen((char *)test[case_idx].data);
-        size_t fullfill_len = test[case_idx].data_len - str_len;
-        size_t fullfill_idx = str_len;
-        while (fullfill_len > 0) {
-            if (fullfill_len > str_len) {
-                memcpy(&test[case_idx].data[fullfill_idx], test[case_idx].data, str_len);
-                fullfill_len -= str_len;
-                fullfill_idx += str_len;
+        size_t fulfill_len = test[case_idx].data_len - str_len;
+        size_t fulfill_idx = str_len;
+        while (fulfill_len > 0) {
+            if (fulfill_len > str_len) {
+                memcpy(&test[case_idx].data[fulfill_idx], test[case_idx].data, str_len);
+                fulfill_len -= str_len;
+                fulfill_idx += str_len;
             } else {
-                memcpy(&test[case_idx].data[fullfill_idx], test[case_idx].data, fullfill_len);
-                fullfill_len = 0;
+                memcpy(&test[case_idx].data[fulfill_idx], test[case_idx].data, fulfill_len);
+                fulfill_len = 0;
             }
         }
     }

--- a/util/ctags.sh
+++ b/util/ctags.sh
@@ -53,14 +53,14 @@ fi
 
 {
     # At the first pass, ctags should not be affected by personal
-    # configration files. So --options=NONE is passed.
+    # configuration files. So --options=NONE is passed.
     #
     # However, if the option is passed, ctags doesn't load the project
-    # default configration files under $project/.ctags.d. So we load
-    # the project default configration files, add-dir.ctags and
+    # default configuration files under $project/.ctags.d. So we load
+    # the project default configuration files, add-dir.ctags and
     # exclude.ctags, explicitly.
     #
-    # openssl-stage1 contains a configration file specialized to
+    # openssl-stage1 contains a configuration file specialized to
     # extract macro definitions. It should not be used in normal ctags
     # usage.
     $CTAGS --quiet --options=NONE \


### PR DESCRIPTION
I have two commits, because the second one is debatable and changes a local variable name. I can squash it if you agree.

Definition of _fulfill_ in some dictionaries:
* [Oxford Learner's Dictionary](https://www.oxfordlearnersdictionaries.com/definition/english/fulfil)
* [Cambridge Dictionary](https://dictionary.cambridge.org/dictionary/english/fulfill)
* [Merriam-Webster](https://www.merriam-webster.com/dictionary/fulfill)
* [Collins](https://www.collinsdictionary.com/dictionary/english/fulfill)

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
