### PR TITLE
Fix new typos found by codespell

### DIFF
--- a/doc/man3/OSSL_CMP_CTX_new.pod
+++ b/doc/man3/OSSL_CMP_CTX_new.pod
@@ -627,7 +627,7 @@ OSSL_CMP_CTX_set_certConf_cb_arg(), or NULL if unset.
 
 OSSL_CMP_CTX_get_status() returns for client contexts the PKIstatus from
 the last received CertRepMessage or Revocation Response or error message:
-=item B<OSSL_CMP_PKISTATUS_accepted> on sucessful receipt of a GENP message:
+=item B<OSSL_CMP_PKISTATUS_accepted> on successful receipt of a GENP message:
 
 =over 4
 

--- a/doc/man7/EVP_PKEY-RSA.pod
+++ b/doc/man7/EVP_PKEY-RSA.pod
@@ -189,7 +189,7 @@ both return 1 unconditionally.
 
 For RSA keys, L<EVP_PKEY_public_check(3)> conforms to the SP800-56Br1 I<public key
 check> when the OpenSSL FIPS provider is used. The OpenSSL default provider
-performs similiar tests but relaxes the keysize restrictions for backwards
+performs similar tests but relaxes the keysize restrictions for backwards
 compatibility.
 
 For RSA keys, L<EVP_PKEY_public_check_quick(3)> is the same as


### PR DESCRIPTION
Fix only typos in `doc/man*` for inclusion in 3.* branches.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
