### PR TITLE
allow to disable apps building

### DIFF
--- a/.github/workflows/run-checker-daily.yml
+++ b/.github/workflows/run-checker-daily.yml
@@ -22,6 +22,7 @@ jobs:
         opt: [
           386,
           no-afalgeng,
+          no-apps,
           no-aria,
           no-asan,
           no-asm,

--- a/Configure
+++ b/Configure
@@ -408,6 +408,7 @@ my @dtls = qw(dtls1 dtls1_2);
 my @disablables = (
     "acvp-tests",
     "afalgeng",
+    "apps",
     "argon2",
     "aria",
     "asan",

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -583,6 +583,10 @@ access to algorithm internals that are not normally accessible.
 Additional information related to ACVP can be found at
 <https://github.com/usnistgov/ACVP>.
 
+### no-apps
+
+Do not build apps, e.g. the openssl program. This is handy for minimization.
+
 ### no-asm
 
 Do not use assembler code.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -586,6 +586,7 @@ Additional information related to ACVP can be found at
 ### no-apps
 
 Do not build apps, e.g. the openssl program. This is handy for minimization.
+This option also disables tests.
 
 ### no-asm
 


### PR DESCRIPTION
This trivial change allows to disable apps building.  It's handy for minimization.

The option was already there and adhered to by `apps/build.info`, however Configure did not allow to use it directly, only via cascading.