### PR TITLE
log actual NID causing the 'unknown message digest algorithm error'

### DIFF
--- a/crypto/asn1/a_verify.c
+++ b/crypto/asn1/a_verify.c
@@ -180,8 +180,9 @@ int ASN1_item_verify_ctx(const ASN1_ITEM *it, const X509_ALGOR *alg,
             if (mdnid != NID_undef) {
                 type = EVP_get_digestbynid(mdnid);
                 if (type == NULL) {
-                    ERR_raise(ERR_LIB_ASN1,
-                              ASN1_R_UNKNOWN_MESSAGE_DIGEST_ALGORITHM);
+                    ERR_raise_data(ERR_LIB_ASN1,
+                                   ASN1_R_UNKNOWN_MESSAGE_DIGEST_ALGORITHM,
+                                   "nid=0x%x", mdnid);
                     goto err;
                 }
             }


### PR DESCRIPTION
This trivial change adds the NID causing X509 signature verification error to error data. In my case I shot myself into the foot by using `no-autoalginit` with static build (so sha256 etc. were absent in the algorithm tables) and this might have helped to debug this and similar problems.