### PR TITLE
Fix decoders so that they use the passed in propq.

### DIFF
--- a/crypto/encode_decode/encoder_local.h
+++ b/crypto/encode_decode/encoder_local.h
@@ -53,6 +53,7 @@ struct ossl_decoder_st {
     OSSL_FUNC_decoder_does_selection_fn *does_selection;
     OSSL_FUNC_decoder_decode_fn *decode;
     OSSL_FUNC_decoder_export_object_fn *export_object;
+    OSSL_FUNC_decoder_newctx_ex_fn *newctx_ex;
 };
 
 struct ossl_encoder_instance_st {

--- a/crypto/x509/x_pubkey.c
+++ b/crypto/x509/x_pubkey.c
@@ -66,7 +66,8 @@ ASN1_SEQUENCE(X509_PUBKEY_INTERNAL) = {
 } static_ASN1_SEQUENCE_END_name(X509_PUBKEY, X509_PUBKEY_INTERNAL)
 
 X509_PUBKEY *ossl_d2i_X509_PUBKEY_INTERNAL(const unsigned char **pp,
-                                           long len, OSSL_LIB_CTX *libctx)
+                                           long len, OSSL_LIB_CTX *libctx,
+                                           const char *propq)
 {
     X509_PUBKEY *xpub = OPENSSL_zalloc(sizeof(*xpub));
 
@@ -74,7 +75,7 @@ X509_PUBKEY *ossl_d2i_X509_PUBKEY_INTERNAL(const unsigned char **pp,
         return NULL;
     return (X509_PUBKEY *)ASN1_item_d2i_ex((ASN1_VALUE **)&xpub, pp, len,
                                            ASN1_ITEM_rptr(X509_PUBKEY_INTERNAL),
-                                           libctx, NULL);
+                                           libctx, propq);
 }
 
 void ossl_X509_PUBKEY_INTERNAL_free(X509_PUBKEY *xpub)

--- a/doc/man7/provider-decoder.pod
+++ b/doc/man7/provider-decoder.pod
@@ -19,6 +19,7 @@ provider-decoder - The OSSL_DECODER library E<lt>-E<gt> provider functions
  int OSSL_FUNC_decoder_get_params(OSSL_PARAM params[]);
 
  /* Functions to construct / destruct / manipulate the decoder context */
+ void *OSSL_FUNC_decoder_newctx_ex(void *provctx, const char *propq);
  void *OSSL_FUNC_decoder_newctx(void *provctx);
  void OSSL_FUNC_decoder_freectx(void *ctx);
  const OSSL_PARAM *OSSL_FUNC_decoder_settable_ctx_params(void *provctx);
@@ -92,6 +93,7 @@ macros in L<openssl-core_dispatch.h(7)>, as follows:
  OSSL_FUNC_decoder_get_params          OSSL_FUNC_DECODER_GET_PARAMS
  OSSL_FUNC_decoder_gettable_params     OSSL_FUNC_DECODER_GETTABLE_PARAMS
 
+ OSSL_FUNC_decoder_newctx_ex           OSSL_FUNC_DECODER_NEWCTX_EX
  OSSL_FUNC_decoder_newctx              OSSL_FUNC_DECODER_NEWCTX
  OSSL_FUNC_decoder_freectx             OSSL_FUNC_DECODER_FREECTX
  OSSL_FUNC_decoder_set_ctx_params      OSSL_FUNC_DECODER_SET_CTX_PARAMS
@@ -191,11 +193,17 @@ supports any of the combinations given by I<selection>.
 
 =head2 Context functions
 
-OSSL_FUNC_decoder_newctx() returns a context to be used with the rest of
-the functions.
+OSSL_FUNC_decoder_newctx_ex() return a context to be used with the rest of the
+functions.
+OSSL_FUNC_decoder_newctx_ex() passes the optional property query parameter
+I<propq> which may be used by fetches inside OSSL_FUNC_decoder_decode().
+
+OSSL_FUNC_decoder_newctx() is similiar to OSSL_FUNC_decoder_newctx_ex() but
+uses NULL as the property query internally. This function will only be used
+when OSSL_FUNC_decoder_newctx_ex() is not implemented.
 
 OSSL_FUNC_decoder_freectx() frees the given I<ctx> as created by
-OSSL_FUNC_decoder_newctx().
+OSSL_FUNC_decoder_newctx_ex().
 
 OSSL_FUNC_decoder_set_ctx_params() sets context data according to parameters
 from I<params> that it recognises.  Unrecognised parameters should be
@@ -277,8 +285,8 @@ of object it's being prompted for.
 
 =head1 RETURN VALUES
 
-OSSL_FUNC_decoder_newctx() returns a pointer to a context, or NULL on
-failure.
+OSSL_FUNC_decoder_newctx_ex() and OSSL_FUNC_decoder_newctx()
+return a pointer to a context, or NULL on failure.
 
 OSSL_FUNC_decoder_set_ctx_params() returns 1, unless a recognised
 parameter was invalid or caused an error, for which 0 is returned.
@@ -299,6 +307,7 @@ L<provider(7)>
 =head1 HISTORY
 
 The DECODER interface was introduced in OpenSSL 3.0.
+The function OSSL_FUNC_decoder_newctx_ex() was added in OpenSSL 3.0.10
 
 =head1 COPYRIGHT
 

--- a/include/crypto/x509.h
+++ b/include/crypto/x509.h
@@ -336,7 +336,8 @@ int ossl_x509_PUBKEY_get0_libctx(OSSL_LIB_CTX **plibctx, const char **ppropq,
 ASN1_OCTET_STRING *ossl_x509_pubkey_hash(X509_PUBKEY *pubkey);
 
 X509_PUBKEY *ossl_d2i_X509_PUBKEY_INTERNAL(const unsigned char **pp,
-                                           long len, OSSL_LIB_CTX *libctx);
+                                           long len, OSSL_LIB_CTX *libctx,
+                                           const char *propq);
 void ossl_X509_PUBKEY_INTERNAL_free(X509_PUBKEY *xpub);
 
 RSA *ossl_d2i_RSA_PSS_PUBKEY(RSA **a, const unsigned char **pp, long length);

--- a/include/openssl/core_dispatch.h
+++ b/include/openssl/core_dispatch.h
@@ -893,9 +893,12 @@ OSSL_CORE_MAKE_FUNC(void, encoder_free_object, (void *obj))
 # define OSSL_FUNC_DECODER_GETTABLE_PARAMS             4
 # define OSSL_FUNC_DECODER_SET_CTX_PARAMS              5
 # define OSSL_FUNC_DECODER_SETTABLE_CTX_PARAMS         6
+# define OSSL_FUNC_DECODER_NEWCTX_EX                   7
 # define OSSL_FUNC_DECODER_DOES_SELECTION             10
 # define OSSL_FUNC_DECODER_DECODE                     11
 # define OSSL_FUNC_DECODER_EXPORT_OBJECT              20
+
+OSSL_CORE_MAKE_FUNC(void *, decoder_newctx_ex, (void *provctx, const char *propq))
 OSSL_CORE_MAKE_FUNC(void *, decoder_newctx, (void *provctx))
 OSSL_CORE_MAKE_FUNC(void, decoder_freectx, (void *ctx))
 OSSL_CORE_MAKE_FUNC(int, decoder_get_params, (OSSL_PARAM params[]))


### PR DESCRIPTION
Fixes #21198

Inside the decoder fetches were passing propq as NULL. The problem stems from lower level OSSL_DECODER objects only handling the libctx and using NULL as the propq. (This happens because we can normally get the libctx from the provctx, and that is what is passed down). This PR add a newctx_ex() method to the OSSL_DECODER object which passes an extra arg for the propq. It will use this new method if it exists, otherwise it uses the old newctx().
I considered using the set_ctx_params method but it is cleaner when implemented as a new_ex constructor.

This does not attempt to address the encoders passing a propq.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
