### PR TITLE
Fix decoders so that they use the passed in propq.

### DIFF
--- a/crypto/encode_decode/decoder_pkey.c
+++ b/crypto/encode_decode/decoder_pkey.c
@@ -455,6 +455,7 @@ static int ossl_decoder_ctx_setup_for_pkey(OSSL_DECODER_CTX *ctx,
                    "(ctx %p) Got %d decoders producing keys\n",
                    (void *)ctx, collect_data.total);
     } OSSL_TRACE_END(DECODER);
+
     /*
      * Finish initializing the decoder context. If one or more decoders matched
      * above then the number of decoders attached to the OSSL_DECODER_CTX will

--- a/crypto/encode_decode/decoder_pkey.c
+++ b/crypto/encode_decode/decoder_pkey.c
@@ -455,7 +455,6 @@ static int ossl_decoder_ctx_setup_for_pkey(OSSL_DECODER_CTX *ctx,
                    "(ctx %p) Got %d decoders producing keys\n",
                    (void *)ctx, collect_data.total);
     } OSSL_TRACE_END(DECODER);
-
     /*
      * Finish initializing the decoder context. If one or more decoders matched
      * above then the number of decoders attached to the OSSL_DECODER_CTX will
@@ -746,6 +745,10 @@ OSSL_DECODER_CTX_new_for_pkey(EVP_PKEY **pkey,
                               OSSL_LIB_CTX *libctx, const char *propquery)
 {
     OSSL_DECODER_CTX *ctx = NULL;
+    OSSL_PARAM decoder_params[] = {
+        OSSL_PARAM_END,
+        OSSL_PARAM_END
+    };
     DECODER_CACHE *cache
         = ossl_lib_ctx_get_data(libctx, OSSL_LIB_CTX_DECODER_CACHE_INDEX);
     DECODER_CACHE_ENTRY cacheent, *res, *newcache = NULL;
@@ -754,6 +757,9 @@ OSSL_DECODER_CTX_new_for_pkey(EVP_PKEY **pkey,
         ERR_raise(ERR_LIB_OSSL_DECODER, ERR_R_OSSL_DECODER_LIB);
         return NULL;
     }
+    if (propquery != NULL)
+        decoder_params[0] = OSSL_PARAM_construct_utf8_string(OSSL_DECODER_PARAM_PROPERTIES,
+                                                             (char *)propquery, 0);
 
     /* It is safe to cast away the const here */
     cacheent.input_type = (char *)input_type;
@@ -795,7 +801,9 @@ OSSL_DECODER_CTX_new_for_pkey(EVP_PKEY **pkey,
             && OSSL_DECODER_CTX_set_input_structure(ctx, input_structure)
             && OSSL_DECODER_CTX_set_selection(ctx, selection)
             && ossl_decoder_ctx_setup_for_pkey(ctx, keytype, libctx, propquery)
-            && OSSL_DECODER_CTX_add_extra(ctx, libctx, propquery)) {
+            && OSSL_DECODER_CTX_add_extra(ctx, libctx, propquery)
+            && (propquery == NULL
+                || OSSL_DECODER_CTX_set_params(ctx, decoder_params))) {
             OSSL_TRACE_BEGIN(DECODER) {
                 BIO_printf(trc_out, "(ctx %p) Got %d decoders\n",
                         (void *)ctx, OSSL_DECODER_CTX_get_num_decoders(ctx));

--- a/crypto/x509/x_pubkey.c
+++ b/crypto/x509/x_pubkey.c
@@ -66,7 +66,8 @@ ASN1_SEQUENCE(X509_PUBKEY_INTERNAL) = {
 } static_ASN1_SEQUENCE_END_name(X509_PUBKEY, X509_PUBKEY_INTERNAL)
 
 X509_PUBKEY *ossl_d2i_X509_PUBKEY_INTERNAL(const unsigned char **pp,
-                                           long len, OSSL_LIB_CTX *libctx)
+                                           long len, OSSL_LIB_CTX *libctx,
+                                           const char *propq)
 {
     X509_PUBKEY *xpub = OPENSSL_zalloc(sizeof(*xpub));
 
@@ -74,7 +75,7 @@ X509_PUBKEY *ossl_d2i_X509_PUBKEY_INTERNAL(const unsigned char **pp,
         return NULL;
     return (X509_PUBKEY *)ASN1_item_d2i_ex((ASN1_VALUE **)&xpub, pp, len,
                                            ASN1_ITEM_rptr(X509_PUBKEY_INTERNAL),
-                                           libctx, NULL);
+                                           libctx, propq);
 }
 
 void ossl_X509_PUBKEY_INTERNAL_free(X509_PUBKEY *xpub)

--- a/include/crypto/x509.h
+++ b/include/crypto/x509.h
@@ -336,7 +336,8 @@ int ossl_x509_PUBKEY_get0_libctx(OSSL_LIB_CTX **plibctx, const char **ppropq,
 ASN1_OCTET_STRING *ossl_x509_pubkey_hash(X509_PUBKEY *pubkey);
 
 X509_PUBKEY *ossl_d2i_X509_PUBKEY_INTERNAL(const unsigned char **pp,
-                                           long len, OSSL_LIB_CTX *libctx);
+                                           long len, OSSL_LIB_CTX *libctx,
+                                           const char *propq);
 void ossl_X509_PUBKEY_INTERNAL_free(X509_PUBKEY *xpub);
 
 RSA *ossl_d2i_RSA_PSS_PUBKEY(RSA **a, const unsigned char **pp, long length);

--- a/providers/implementations/encode_decode/decode_der2key.c
+++ b/providers/implementations/encode_decode/decode_der2key.c
@@ -89,6 +89,7 @@ struct keytype_desc_st {
  */
 struct der2key_ctx_st {
     PROV_CTX *provctx;
+    char *propq;
     const struct keytype_desc_st *desc;
     /* The selection that is passed to der2key_decode() */
     int selection;
@@ -109,7 +110,7 @@ static void *der2key_decode_p8(const unsigned char **input_der,
     if ((p8inf = d2i_PKCS8_PRIV_KEY_INFO(NULL, input_der, input_der_len)) != NULL
         && PKCS8_pkey_get0(NULL, NULL, NULL, &alg, p8inf)
         && OBJ_obj2nid(alg->algorithm) == ctx->desc->evp_type)
-        key = key_from_pkcs8(p8inf, PROV_LIBCTX_OF(ctx->provctx), NULL);
+        key = key_from_pkcs8(p8inf, PROV_LIBCTX_OF(ctx->provctx), ctx->propq);
     PKCS8_PRIV_KEY_INFO_free(p8inf);
 
     return key;
@@ -120,6 +121,8 @@ static void *der2key_decode_p8(const unsigned char **input_der,
 static OSSL_FUNC_decoder_freectx_fn der2key_freectx;
 static OSSL_FUNC_decoder_decode_fn der2key_decode;
 static OSSL_FUNC_decoder_export_object_fn der2key_export_object;
+static OSSL_FUNC_decoder_settable_ctx_params_fn der2key_settable_ctx_params;
+static OSSL_FUNC_decoder_set_ctx_params_fn der2key_set_ctx_params;
 
 static struct der2key_ctx_st *
 der2key_newctx(void *provctx, const struct keytype_desc_st *desc)
@@ -133,10 +136,34 @@ der2key_newctx(void *provctx, const struct keytype_desc_st *desc)
     return ctx;
 }
 
+static const OSSL_PARAM *der2key_settable_ctx_params(ossl_unused void *provctx)
+{
+    static const OSSL_PARAM settables[] = {
+        OSSL_PARAM_utf8_string(OSSL_DECODER_PARAM_PROPERTIES, NULL, 0),
+        OSSL_PARAM_END,
+    };
+    return settables;
+}
+
+static int der2key_set_ctx_params(void *vctx, const OSSL_PARAM params[])
+{
+    struct der2key_ctx_st *ctx = vctx;
+    const OSSL_PARAM *p;
+
+    p = OSSL_PARAM_locate_const(params, OSSL_DECODER_PARAM_PROPERTIES);
+    if (p != NULL && !OSSL_PARAM_get_utf8_string(p, &ctx->propq,
+                                                 OSSL_MAX_PROPQUERY_SIZE))
+        return 0;
+
+    return 1;
+}
+
 static void der2key_freectx(void *vctx)
 {
     struct der2key_ctx_st *ctx = vctx;
 
+    if (ctx != NULL)
+        OPENSSL_free(ctx->propq);
     OPENSSL_free(ctx);
 }
 
@@ -755,6 +782,10 @@ static void rsa_adjust(void *key, struct der2key_ctx_st *ctx)
           (void (*)(void))der2key_decode },                             \
         { OSSL_FUNC_DECODER_EXPORT_OBJECT,                              \
           (void (*)(void))der2key_export_object },                      \
+        { OSSL_FUNC_DECODER_SETTABLE_CTX_PARAMS,                        \
+          (void (*)(void))der2key_settable_ctx_params },                \
+        { OSSL_FUNC_DECODER_SET_CTX_PARAMS,                             \
+          (void (*)(void))der2key_set_ctx_params },                     \
         OSSL_DISPATCH_END                                               \
     }
 

--- a/providers/implementations/encode_decode/decode_der2key.c
+++ b/providers/implementations/encode_decode/decode_der2key.c
@@ -89,7 +89,7 @@ struct keytype_desc_st {
  */
 struct der2key_ctx_st {
     PROV_CTX *provctx;
-    char *propq;
+    char propq[OSSL_MAX_PROPQUERY_SIZE];
     const struct keytype_desc_st *desc;
     /* The selection that is passed to der2key_decode() */
     int selection;
@@ -140,7 +140,7 @@ static const OSSL_PARAM *der2key_settable_ctx_params(ossl_unused void *provctx)
 {
     static const OSSL_PARAM settables[] = {
         OSSL_PARAM_utf8_string(OSSL_DECODER_PARAM_PROPERTIES, NULL, 0),
-        OSSL_PARAM_END,
+        OSSL_PARAM_END
     };
     return settables;
 }
@@ -149,10 +149,10 @@ static int der2key_set_ctx_params(void *vctx, const OSSL_PARAM params[])
 {
     struct der2key_ctx_st *ctx = vctx;
     const OSSL_PARAM *p;
+    char *str = ctx->propq;
 
     p = OSSL_PARAM_locate_const(params, OSSL_DECODER_PARAM_PROPERTIES);
-    if (p != NULL && !OSSL_PARAM_get_utf8_string(p, &ctx->propq,
-                                                 OSSL_MAX_PROPQUERY_SIZE))
+    if (p != NULL && !OSSL_PARAM_get_utf8_string(p, &str, sizeof(ctx->propq)))
         return 0;
 
     return 1;
@@ -162,8 +162,6 @@ static void der2key_freectx(void *vctx)
 {
     struct der2key_ctx_st *ctx = vctx;
 
-    if (ctx != NULL)
-        OPENSSL_free(ctx->propq);
     OPENSSL_free(ctx);
 }
 

--- a/providers/implementations/encode_decode/decode_epki2pki.c
+++ b/providers/implementations/encode_decode/decode_epki2pki.c
@@ -26,12 +26,15 @@
 static OSSL_FUNC_decoder_newctx_fn epki2pki_newctx;
 static OSSL_FUNC_decoder_freectx_fn epki2pki_freectx;
 static OSSL_FUNC_decoder_decode_fn epki2pki_decode;
+static OSSL_FUNC_decoder_settable_ctx_params_fn epki2pki_settable_ctx_params;
+static OSSL_FUNC_decoder_set_ctx_params_fn epki2pki_set_ctx_params;
 
 /*
  * Context used for EncryptedPrivateKeyInfo to PrivateKeyInfo decoding.
  */
 struct epki2pki_ctx_st {
     PROV_CTX *provctx;
+    char *propq;
 };
 
 static void *epki2pki_newctx(void *provctx)
@@ -47,7 +50,31 @@ static void epki2pki_freectx(void *vctx)
 {
     struct epki2pki_ctx_st *ctx = vctx;
 
+    if (ctx != NULL)
+        OPENSSL_free(ctx->propq);
     OPENSSL_free(ctx);
+}
+
+static const OSSL_PARAM *epki2pki_settable_ctx_params(ossl_unused void *provctx)
+{
+    static const OSSL_PARAM settables[] = {
+        OSSL_PARAM_utf8_string(OSSL_DECODER_PARAM_PROPERTIES, NULL, 0),
+        OSSL_PARAM_END,
+    };
+    return settables;
+}
+
+static int epki2pki_set_ctx_params(void *vctx, const OSSL_PARAM params[])
+{
+    struct epki2pki_ctx_st *ctx = vctx;
+    const OSSL_PARAM *p;
+
+    p = OSSL_PARAM_locate_const(params, OSSL_DECODER_PARAM_PROPERTIES);
+    if (p != NULL && !OSSL_PARAM_get_utf8_string(p, &ctx->propq,
+                                                 OSSL_MAX_PROPQUERY_SIZE))
+        return 0;
+
+    return 1;
 }
 
 /*
@@ -104,7 +131,8 @@ static int epki2pki_decode(void *vctx, OSSL_CORE_BIO *cin, int selection,
             if (!PKCS12_pbe_crypt_ex(alg, pbuf, plen,
                                      oct->data, oct->length,
                                      &new_der, &new_der_len, 0,
-                                     PROV_LIBCTX_OF(ctx->provctx), NULL)) {
+                                     PROV_LIBCTX_OF(ctx->provctx),
+                                     ctx->propq)) {
                 ok = 0;
             } else {
                 OPENSSL_free(der);
@@ -154,5 +182,9 @@ const OSSL_DISPATCH ossl_EncryptedPrivateKeyInfo_der_to_der_decoder_functions[] 
     { OSSL_FUNC_DECODER_NEWCTX, (void (*)(void))epki2pki_newctx },
     { OSSL_FUNC_DECODER_FREECTX, (void (*)(void))epki2pki_freectx },
     { OSSL_FUNC_DECODER_DECODE, (void (*)(void))epki2pki_decode },
+    { OSSL_FUNC_DECODER_SETTABLE_CTX_PARAMS,
+      (void (*)(void))epki2pki_settable_ctx_params },
+    { OSSL_FUNC_DECODER_SET_CTX_PARAMS,
+      (void (*)(void))epki2pki_set_ctx_params },
     OSSL_DISPATCH_END
 };

--- a/providers/implementations/encode_decode/decode_epki2pki.c
+++ b/providers/implementations/encode_decode/decode_epki2pki.c
@@ -34,7 +34,7 @@ static OSSL_FUNC_decoder_set_ctx_params_fn epki2pki_set_ctx_params;
  */
 struct epki2pki_ctx_st {
     PROV_CTX *provctx;
-    char *propq;
+    char propq[OSSL_MAX_PROPQUERY_SIZE];
 };
 
 static void *epki2pki_newctx(void *provctx)
@@ -50,8 +50,6 @@ static void epki2pki_freectx(void *vctx)
 {
     struct epki2pki_ctx_st *ctx = vctx;
 
-    if (ctx != NULL)
-        OPENSSL_free(ctx->propq);
     OPENSSL_free(ctx);
 }
 
@@ -59,7 +57,7 @@ static const OSSL_PARAM *epki2pki_settable_ctx_params(ossl_unused void *provctx)
 {
     static const OSSL_PARAM settables[] = {
         OSSL_PARAM_utf8_string(OSSL_DECODER_PARAM_PROPERTIES, NULL, 0),
-        OSSL_PARAM_END,
+        OSSL_PARAM_END
     };
     return settables;
 }
@@ -68,10 +66,10 @@ static int epki2pki_set_ctx_params(void *vctx, const OSSL_PARAM params[])
 {
     struct epki2pki_ctx_st *ctx = vctx;
     const OSSL_PARAM *p;
+    char *str = ctx->propq;
 
     p = OSSL_PARAM_locate_const(params, OSSL_DECODER_PARAM_PROPERTIES);
-    if (p != NULL && !OSSL_PARAM_get_utf8_string(p, &ctx->propq,
-                                                 OSSL_MAX_PROPQUERY_SIZE))
+    if (p != NULL && !OSSL_PARAM_get_utf8_string(p, &str, sizeof(ctx->propq)))
         return 0;
 
     return 1;

--- a/providers/implementations/encode_decode/decode_pvk2key.c
+++ b/providers/implementations/encode_decode/decode_pvk2key.c
@@ -24,6 +24,7 @@
 #include <openssl/pem.h>         /* For public PVK functions */
 #include <openssl/x509.h>
 #include "internal/passphrase.h"
+#include "internal/sizes.h"
 #include "crypto/pem.h"          /* For internal PVK and "blob" headers */
 #include "crypto/rsa.h"
 #include "prov/bio.h"
@@ -49,12 +50,15 @@ struct keytype_desc_st {
 static OSSL_FUNC_decoder_freectx_fn pvk2key_freectx;
 static OSSL_FUNC_decoder_decode_fn pvk2key_decode;
 static OSSL_FUNC_decoder_export_object_fn pvk2key_export_object;
+static OSSL_FUNC_decoder_settable_ctx_params_fn pvk2key_settable_ctx_params;
+static OSSL_FUNC_decoder_set_ctx_params_fn pvk2key_set_ctx_params;
 
 /*
  * Context used for DER to key decoding.
  */
 struct pvk2key_ctx_st {
     PROV_CTX *provctx;
+    char *propq;
     const struct keytype_desc_st *desc;
     /* The selection that is passed to der2key_decode() */
     int selection;
@@ -76,7 +80,31 @@ static void pvk2key_freectx(void *vctx)
 {
     struct pvk2key_ctx_st *ctx = vctx;
 
+    if (ctx != NULL)
+        OPENSSL_free(ctx->propq);
     OPENSSL_free(ctx);
+}
+
+static const OSSL_PARAM *pvk2key_settable_ctx_params(ossl_unused void *provctx)
+{
+    static const OSSL_PARAM settables[] = {
+        OSSL_PARAM_utf8_string(OSSL_DECODER_PARAM_PROPERTIES, NULL, 0),
+        OSSL_PARAM_END,
+    };
+    return settables;
+}
+
+static int pvk2key_set_ctx_params(void *vctx, const OSSL_PARAM params[])
+{
+    struct pvk2key_ctx_st *ctx = vctx;
+    const OSSL_PARAM *p;
+
+    p = OSSL_PARAM_locate_const(params, OSSL_DECODER_PARAM_PROPERTIES);
+    if (p != NULL && !OSSL_PARAM_get_utf8_string(p, &ctx->propq,
+                                                 OSSL_MAX_PROPQUERY_SIZE))
+        return 0;
+
+    return 1;
 }
 
 static int pvk2key_does_selection(void *provctx, int selection)
@@ -115,7 +143,8 @@ static int pvk2key_decode(void *vctx, OSSL_CORE_BIO *cin, int selection,
             goto end;
 
         key = ctx->desc->read_private_key(in, ossl_pw_pvk_password, &pwdata,
-                                          PROV_LIBCTX_OF(ctx->provctx), NULL);
+                                          PROV_LIBCTX_OF(ctx->provctx),
+                                          ctx->propq);
 
         /*
          * Because the PVK API doesn't have a separate decrypt call, we need
@@ -247,6 +276,10 @@ static void rsa_adjust(void *key, struct pvk2key_ctx_st *ctx)
           (void (*)(void))pvk2key_decode },                             \
         { OSSL_FUNC_DECODER_EXPORT_OBJECT,                              \
           (void (*)(void))pvk2key_export_object },                      \
+        { OSSL_FUNC_DECODER_SETTABLE_CTX_PARAMS,                        \
+          (void (*)(void))pvk2key_settable_ctx_params },                \
+        { OSSL_FUNC_DECODER_SET_CTX_PARAMS,                             \
+          (void (*)(void))pvk2key_set_ctx_params },                     \
         OSSL_DISPATCH_END                                               \
     }
 

--- a/providers/implementations/encode_decode/decode_pvk2key.c
+++ b/providers/implementations/encode_decode/decode_pvk2key.c
@@ -58,7 +58,7 @@ static OSSL_FUNC_decoder_set_ctx_params_fn pvk2key_set_ctx_params;
  */
 struct pvk2key_ctx_st {
     PROV_CTX *provctx;
-    char *propq;
+    char propq[OSSL_MAX_PROPQUERY_SIZE];
     const struct keytype_desc_st *desc;
     /* The selection that is passed to der2key_decode() */
     int selection;
@@ -80,8 +80,6 @@ static void pvk2key_freectx(void *vctx)
 {
     struct pvk2key_ctx_st *ctx = vctx;
 
-    if (ctx != NULL)
-        OPENSSL_free(ctx->propq);
     OPENSSL_free(ctx);
 }
 
@@ -98,10 +96,10 @@ static int pvk2key_set_ctx_params(void *vctx, const OSSL_PARAM params[])
 {
     struct pvk2key_ctx_st *ctx = vctx;
     const OSSL_PARAM *p;
+    char *str = ctx->propq;
 
     p = OSSL_PARAM_locate_const(params, OSSL_DECODER_PARAM_PROPERTIES);
-    if (p != NULL && !OSSL_PARAM_get_utf8_string(p, &ctx->propq,
-                                                 OSSL_MAX_PROPQUERY_SIZE))
+    if (p != NULL && !OSSL_PARAM_get_utf8_string(p, &str, sizeof(ctx->propq)))
         return 0;
 
     return 1;

--- a/test/build.info
+++ b/test/build.info
@@ -1071,6 +1071,11 @@ IF[{- !$disabled{tests} -}]
     DEPEND[endecoder_legacy_test]=../libcrypto.a libtestutil.a
   ENDIF
 
+  PROGRAMS{noinst}=decoder_propq_test
+  SOURCE[decoder_propq_test]=decoder_propq_test.c
+  INCLUDE[decoder_propq_test]=.. ../include ../apps/include
+  DEPEND[decoder_propq_test]=../libcrypto.a libtestutil.a
+
   PROGRAMS{noinst}=namemap_internal_test
   SOURCE[namemap_internal_test]=namemap_internal_test.c
   INCLUDE[namemap_internal_test]=.. ../include ../apps/include

--- a/test/decoder_propq_test.c
+++ b/test/decoder_propq_test.c
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2023 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <openssl/pem.h>
+#include <openssl/evp.h>
+#include "testutil.h"
+
+static OSSL_LIB_CTX *libctx = NULL;
+static OSSL_PROVIDER *nullprov = NULL;
+static OSSL_PROVIDER *libprov = NULL;
+static const char *filename = NULL;
+static pem_password_cb passcb;
+
+typedef enum OPTION_choice {
+    OPT_ERR = -1,
+    OPT_EOF = 0,
+    OPT_CONFIG_FILE,
+    OPT_PROVIDER_NAME,
+    OPT_TEST_ENUM
+} OPTION_CHOICE;
+
+const OPTIONS *test_get_options(void)
+{
+    static const OPTIONS test_options[] = {
+        OPT_TEST_OPTIONS_WITH_EXTRA_USAGE("file\n"),
+        { "config", OPT_CONFIG_FILE, '<',
+          "The configuration file to use for the libctx" },
+        { "provider", OPT_PROVIDER_NAME, 's',
+          "The provider to load (The default value is 'default')" },
+        { OPT_HELP_STR, 1, '-', "file\tFile to decode.\n" },
+        { NULL }
+    };
+    return test_options;
+}
+
+static int passcb(char *buf, int size, int rwflag, void *userdata)
+{
+    strcpy(buf, "pass");
+    return strlen(buf);
+}
+
+static int test_decode_nonfipsalg(void)
+{
+    int ret = 0;
+    EVP_PKEY *privkey = NULL;
+    BIO *bio = NULL;
+
+    /*
+     * Apply the "fips=true" property to all fetches for the libctx.
+     * We do this to test that we are using the propq override
+     */
+    EVP_default_properties_enable_fips(libctx, 1);
+
+    if (!TEST_ptr(bio = BIO_new_file(filename, "r")))
+        goto err;
+
+    /*
+     * If NULL is passed as the propq here it uses the global property "fips=true",
+     * Which we expect to fail if the decode uses a non FIPS algorithm
+     */
+    if (!TEST_ptr_null(PEM_read_bio_PrivateKey_ex(bio, &privkey, &passcb, NULL, libctx, NULL)))
+        goto err;
+
+    /*
+     * Pass if we override the libctx global prop query to optionally use fips=true
+     * This assumes that the libctx contains the default provider
+     */
+    if (!TEST_ptr_null(PEM_read_bio_PrivateKey_ex(bio, &privkey, &passcb, NULL, libctx, "?fips=true")))
+        goto err;
+
+    ret = 1;
+err:
+    BIO_free(bio);
+    EVP_PKEY_free(privkey);
+    return ret;
+}
+
+int setup_tests(void)
+{
+    const char *prov_name = "default";
+    char *config_file = NULL;
+    OPTION_CHOICE o;
+
+    while ((o = opt_next()) != OPT_EOF) {
+        switch (o) {
+        case OPT_PROVIDER_NAME:
+            prov_name = opt_arg();
+            break;
+        case OPT_CONFIG_FILE:
+            config_file = opt_arg();
+            break;
+        case OPT_TEST_CASES:
+           break;
+        default:
+        case OPT_ERR:
+            return 0;
+        }
+    }
+
+    filename = test_get_argument(0);
+    if (!test_get_libctx(&libctx, &nullprov, config_file, &libprov, prov_name))
+        return 0;
+
+    ADD_TEST(test_decode_nonfipsalg);
+    return 1;
+}
+
+void cleanup_tests(void)
+{
+    OSSL_PROVIDER_unload(libprov);
+    OSSL_LIB_CTX_free(libctx);
+    OSSL_PROVIDER_unload(nullprov);
+}


### PR DESCRIPTION
Fixes #21198

decoder objects were setting propq as NULL.
Added a set_ctx/settable_ctx to all decoders that should supply a property query parameter to internal functions.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [x] tests are added or updated
