### PR TITLE
add note about retrieving error stack to SSL_get_verify_result(3)

### DIFF
--- a/doc/man3/SSL_get_verify_result.pod
+++ b/doc/man3/SSL_get_verify_result.pod
@@ -22,6 +22,13 @@ of a certificate can fail because of many reasons at the same time. Only
 the last verification error that occurred during the processing is available
 from SSL_get_verify_result().
 
+Sometimes there can be a sequence of errors leading to the verification
+failure as reported by SSL_get_verify_result().
+To get the errors, it is necessary to setup a verify callback via
+L<SSL_CTX_set_verify(3)> or L<SSL_set_verify(3)> and retrieve the errors
+from the error stack there, because once L<SSL_connect(3)> returns,
+these errors mey no longer be available.
+
 The verification result is part of the established session and is restored
 when a session is reused.
 

--- a/doc/man3/SSL_get_verify_result.pod
+++ b/doc/man3/SSL_get_verify_result.pod
@@ -27,7 +27,7 @@ failure as reported by SSL_get_verify_result().
 To get the errors, it is necessary to setup a verify callback via
 L<SSL_CTX_set_verify(3)> or L<SSL_set_verify(3)> and retrieve the errors
 from the error stack there, because once L<SSL_connect(3)> returns,
-these errors mey no longer be available.
+these errors may no longer be available.
 
 The verification result is part of the established session and is restored
 when a session is reused.


### PR DESCRIPTION
This change augments the SSL_get_verify_result(3) man page with a note about retrieving error stack. This would have helped me when diagnosing a subtle certificate verification error.