### PR TITLE
return from ossl_namemap_doall_names() immediately if namemap is NULL

### DIFF
--- a/crypto/core_namemap.c
+++ b/crypto/core_namemap.c
@@ -137,9 +137,8 @@ int ossl_namemap_doall_names(const OSSL_NAMEMAP *namemap, int number,
     cbdata.number = number;
     cbdata.found = 0;
 
-    if (namemap == NULL) {
+    if (namemap == NULL)
         return 0;
-    }
 
     /*
      * We collect all the names first under a read lock. Subsequently we call

--- a/crypto/core_namemap.c
+++ b/crypto/core_namemap.c
@@ -137,6 +137,10 @@ int ossl_namemap_doall_names(const OSSL_NAMEMAP *namemap, int number,
     cbdata.number = number;
     cbdata.found = 0;
 
+    if (namemap == NULL) {
+        return 0;
+    }
+
     /*
      * We collect all the names first under a read lock. Subsequently we call
      * the user function, so that we're not holding the read lock when in user


### PR DESCRIPTION
When `ossl_namemap_stored()` returns NULL in
https://github.com/openssl/openssl/blob/6c0ecc2bce64cc86948a51f80f832b5e48a9ebea/crypto/evp/evp_fetch.c#L621-L629 then `ossl_namemap_doall_names()` will attempt to dereference it. This trivial change fixes that. I am fixing this because this actually lead to a crash in my environment.