### PR TITLE
doc: update copyright year in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ attempting to develop or distribute cryptographic code.
 Copyright
 =========
 
-Copyright (c) 1998-2022 The OpenSSL Project
+Copyright (c) 1998-2023 The OpenSSL Project
 
 Copyright (c) 1995-1998 Eric A. Young, Tim J. Hudson
 


### PR DESCRIPTION
Updated the end copyright year in README.md to 2023

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ x] documentation is added or updated

 CLA: trivial 


