### PR TITLE
install provider archives when no-shared is in effect

### DIFF
--- a/providers/build.info
+++ b/providers/build.info
@@ -40,7 +40,11 @@ $LIBCOMMON=libcommon.a
 $LIBFIPS=libfips.a
 $LIBLEGACY=liblegacy.a
 $LIBDEFAULT=libdefault.a
-LIBS{noinst}=$LIBDEFAULT $LIBCOMMON
+IF[{- $disabled{shared} -}]
+    LIBS=$LIBDEFAULT $LIBCOMMON
+ELSE
+    LIBS{noinst}=$LIBDEFAULT $LIBCOMMON
+ENDIF
 
 # Enough of our implementations include prov/ciphercommon.h (present in
 # providers/implementations/include), which includes crypto/*_platform.h


### PR DESCRIPTION
This change installs `libcommon.a` and `libdefault.a` when building in `no-shared` mode. Without these the `libssl.a` and `libcrypto.a` archives are not particularly useful.