### PR TITLE
Check for 0 modulus in BN_RECP_CTX_set.

### DIFF
--- a/crypto/bn/bn_recp.c
+++ b/crypto/bn/bn_recp.c
@@ -42,7 +42,7 @@ void BN_RECP_CTX_free(BN_RECP_CTX *recp)
 
 int BN_RECP_CTX_set(BN_RECP_CTX *recp, const BIGNUM *d, BN_CTX *ctx)
 {
-    if (!BN_copy(&(recp->N), d))
+    if (BN_is_zero(d) || !BN_copy(&(recp->N), d))
         return 0;
     BN_zero(&(recp->Nr));
     recp->num_bits = BN_num_bits(d);


### PR DESCRIPTION
The function BN_RECP_CTX_set did not check whether arg d is zero, in which case an early failure should be returned to the invoker. This is a similar fix to the cognate defect of CVE-2015-1794.

Fixes #21111

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
