### PR TITLE
Don't do SIGILL capability detection on Apple Silicon

### DIFF
--- a/crypto/armcap.c
+++ b/crypto/armcap.c
@@ -362,7 +362,7 @@ void OPENSSL_cpuid_setup(void)
         }
 #  endif
     }
-#  ifdef __aarch64__
+#  if defined(__aarch64__) && !defined(__APPLE__)
     if (sigsetjmp(ill_jmp, 1) == 0) {
         _armv8_sve_probe();
         OPENSSL_armcap_P |= ARMV8_SVE;


### PR DESCRIPTION
Fixes #20753

We get the values for Apple Silicon from `sysctl`, so the `sigsetjmp()/probe()` dance isn't necessary there.

This matches what is done a bit higher up at line 344.

A test would require running something under `lldb`, so not providing one (sorry)

##### Checklist

(none apply)