### PR TITLE
Consistent copyright start year

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ attempting to develop or distribute cryptographic code.
 Copyright
 =========
 
-Copyright (c) 1998-2023 The OpenSSL Project Authors
+Copyright (c) 1995-2023 The OpenSSL Project Authors
 
 Copyright (c) 1995-1998 Eric A. Young, Tim J. Hudson
 


### PR DESCRIPTION
I count 495 files in the repository that contain 1995 as the start year:
```
$ grep -Re ' Copyright 1995-.... The OpenSSL Project Authors.' | wc -l
495
$ 
```

If the copyright in README.md has a global scope, which it should have according to #20496, then it should be consistent with these 495 files.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
