### PR TITLE
Consistency: "Authors" after "The OpenSSL Project"

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ attempting to develop or distribute cryptographic code.
 Copyright
 =========
 
-Copyright (c) 1998-2023 The OpenSSL Project
+Copyright (c) 1998-2023 The OpenSSL Project Authors
 
 Copyright (c) 1995-1998 Eric A. Young, Tim J. Hudson
 


### PR DESCRIPTION
All source files show "The OpenSSL Project Authors" as the copyright owner.

The alternative would be to change the source files instead of `README.md`.
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

Fixes #21262.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
