### PR TITLE
Fixed the issue where memory allocated to the ID was not being freed

### DIFF
--- a/apps/s_server.c
+++ b/apps/s_server.c
@@ -533,7 +533,6 @@ static int get_ocsp_resp_from_responder(SSL *s, tlsextstatusctx *srctx,
         goto err;
     if (!OCSP_request_add0_id(req, id))
         goto err;
-    id = NULL;
     /* Add any extensions to the request */
     SSL_get_tlsext_status_exts(s, &exts);
     for (i = 0; i < sk_X509_EXTENSION_num(exts); i++) {


### PR DESCRIPTION
This is a very minor modification.
When OpenSSL is running in ```s_server``` mode, the memory allocated for the ```id``` is not properly freed.

##### Checklist
- [ ] documentation is added or updated
- [ ] tests are added or updated
