### PR TITLE
CONF_modules_load_file_ex(): Do not try to load an empty file name

### DIFF
--- a/crypto/conf/conf_mod.c
+++ b/crypto/conf/conf_mod.c
@@ -184,15 +184,21 @@ int CONF_modules_load_file_ex(OSSL_LIB_CTX *libctx, const char *filename,
     CONF *conf = NULL;
     int ret = 0, diagnostics = 0;
 
+    ERR_set_mark();
+
     if (filename == NULL) {
         file = CONF_get1_default_config_file();
         if (file == NULL)
             goto err;
+        if (*file == '\0') {
+            /* Do not try to load an empty file name but do not error out */
+            ret = 1;
+            goto err;
+        }
     } else {
         file = (char *)filename;
     }
 
-    ERR_set_mark();
     conf = NCONF_new_ex(libctx, NULL);
     if (conf == NULL)
         goto err;


### PR DESCRIPTION
This fixes the below bug in the right way.

Instead of potentially failing weirdly in CONF_modules_load_file_ex() we just return success if the default config file is an empty string.

Fixes #21258
