### PR TITLE
s390xcap.c: Avoid copying structure on initialization

### DIFF
--- a/crypto/s390xcap.c
+++ b/crypto/s390xcap.c
@@ -48,13 +48,15 @@
             cap->NAME[1] = ~cap->NAME[1];                               \
     }
 
-#define TOK_CPU(NAME)                                                   \
+#define TOK_CPU_ALIAS(NAME, STRUCT_NAME)                                \
     (sscanf(tok_begin,                                                  \
             " %" STR(LEN) "s %" STR(LEN) "s ",                          \
             tok[0], tok[1]) == 1                                        \
      && !strcmp(tok[0], #NAME)) {                                       \
-            memcpy(cap, &NAME, sizeof(*cap));                           \
+            memcpy(cap, &STRUCT_NAME, sizeof(*cap));                    \
     }
+
+#define TOK_CPU(NAME) TOK_CPU_ALIAS(NAME, NAME)
 
 #ifndef OSSL_IMPLEMENT_GETAUXVAL
 static sigjmp_buf ill_jmp;
@@ -672,9 +674,8 @@ static int parse_env(struct OPENSSL_s390xcap_st *cap)
 
     /*-
      * z16 (2022) - z/Architecture POP
-     * Implements MSA and MSA1-9 (same as z15).
+     * Implements MSA and MSA1-9 (same as z15, no need to repeat).
      */
-    static const struct OPENSSL_s390xcap_st z16 = z15;
 
     char *tok_begin, *tok_end, *buff, tok[S390X_STFLE_MAX][LEN + 1];
     int rc, off, i, n;
@@ -730,7 +731,7 @@ static int parse_env(struct OPENSSL_s390xcap_st *cap)
         else if TOK_CPU(z13)
         else if TOK_CPU(z14)
         else if TOK_CPU(z15)
-        else if TOK_CPU(z16)
+        else if TOK_CPU_ALIAS(z16, z15)
 
         /* whitespace(ignored) or invalid tokens */
         else {


### PR DESCRIPTION
This is problematic on old compilers. It also avoids duplicating the read-only data.
