### PR TITLE
bio fix: pass flags on BIO_ctrl to make flush retriable

### DIFF
--- a/crypto/bio/bf_buff.c
+++ b/crypto/bio/bf_buff.c
@@ -360,6 +360,7 @@ static long buffer_ctrl(BIO *b, int cmd, long num, void *ptr)
             return 0;
         if (ctx->obuf_len <= 0) {
             ret = BIO_ctrl(b->next_bio, cmd, num, ptr);
+            BIO_copy_next_retry(b);
             break;
         }
 
@@ -380,6 +381,7 @@ static long buffer_ctrl(BIO *b, int cmd, long num, void *ptr)
             }
         }
         ret = BIO_ctrl(b->next_bio, cmd, num, ptr);
+        BIO_copy_next_retry(b);
         break;
     case BIO_CTRL_DUP:
         dbio = (BIO *)ptr;

--- a/crypto/bio/bf_lbuf.c
+++ b/crypto/bio/bf_lbuf.c
@@ -259,6 +259,7 @@ static long linebuffer_ctrl(BIO *b, int cmd, long num, void *ptr)
             return 0;
         if (ctx->obuf_len <= 0) {
             ret = BIO_ctrl(b->next_bio, cmd, num, ptr);
+            BIO_copy_next_retry(b);
             break;
         }
 
@@ -278,6 +279,7 @@ static long linebuffer_ctrl(BIO *b, int cmd, long num, void *ptr)
             }
         }
         ret = BIO_ctrl(b->next_bio, cmd, num, ptr);
+        BIO_copy_next_retry(b);
         break;
     case BIO_CTRL_DUP:
         dbio = (BIO *)ptr;

--- a/crypto/comp/c_brotli.c
+++ b/crypto/comp/c_brotli.c
@@ -716,8 +716,10 @@ static long bio_brotli_ctrl(BIO *b, int cmd, long num, void *ptr)
 
     case BIO_CTRL_FLUSH:
         ret = bio_brotli_flush(b);
-        if (ret > 0)
+        if (ret > 0) {
             ret = BIO_flush(next);
+            BIO_copy_next_retry(b);
+        }
         break;
 
     case BIO_C_SET_BUFF_SIZE:

--- a/crypto/comp/c_zlib.c
+++ b/crypto/comp/c_zlib.c
@@ -640,8 +640,10 @@ static long bio_zlib_ctrl(BIO *b, int cmd, long num, void *ptr)
 
     case BIO_CTRL_FLUSH:
         ret = bio_zlib_flush(b);
-        if (ret > 0)
+        if (ret > 0) {
             ret = BIO_flush(next);
+            BIO_copy_next_retry(b);
+        }
         break;
 
     case BIO_C_SET_BUFF_SIZE:

--- a/crypto/comp/c_zstd.c
+++ b/crypto/comp/c_zstd.c
@@ -762,8 +762,10 @@ static long bio_zstd_ctrl(BIO *b, int cmd, long num, void *ptr)
 
     case BIO_CTRL_FLUSH:
         ret = bio_zstd_flush(b);
-        if (ret > 0)
+        if (ret > 0) {
             ret = BIO_flush(next);
+            BIO_copy_next_retry(b);
+        }
         break;
 
     case BIO_C_SET_BUFF_SIZE:

--- a/crypto/evp/bio_b64.c
+++ b/crypto/evp/bio_b64.c
@@ -496,6 +496,7 @@ static long b64_ctrl(BIO *b, int cmd, long num, void *ptr)
         }
         /* Finally flush the underlying BIO */
         ret = BIO_ctrl(next, cmd, num, ptr);
+        BIO_copy_next_retry(b);
         break;
 
     case BIO_C_DO_STATE_MACHINE:

--- a/crypto/evp/bio_enc.c
+++ b/crypto/evp/bio_enc.c
@@ -360,6 +360,7 @@ static long enc_ctrl(BIO *b, int cmd, long num, void *ptr)
 
         /* Finally flush the underlying BIO */
         ret = BIO_ctrl(next, cmd, num, ptr);
+        BIO_copy_next_retry(b);
         break;
     case BIO_C_GET_CIPHER_STATUS:
         ret = (long)ctx->ok;

--- a/crypto/evp/bio_ok.c
+++ b/crypto/evp/bio_ok.c
@@ -372,6 +372,7 @@ static long ok_ctrl(BIO *b, int cmd, long num, void *ptr)
 
         /* Finally flush the underlying BIO */
         ret = BIO_ctrl(next, cmd, num, ptr);
+        BIO_copy_next_retry(b);
         break;
     case BIO_C_DO_STATE_MACHINE:
         BIO_clear_retry_flags(b);


### PR DESCRIPTION
This PR fixed a wrong wbio pointer usage on SSL_get_error.
The bug will cause `SSL_get_error` to return `SSL_ERROR_SYSCALL` even after `BIO_set_retry_write` in some cases such as `BIO_CTRL_FLUSH`. Without this fix, when `BIO_CTRL_FLUSH`, if BIO writer gets a `WOULD_BLOCK` error, it calls `BIO_set_retry_write` and returns 0, it will not work and openssl will return a failure.

Previous review is in #20919 , I reopened this PR to trigger CLA checking.