### PR TITLE
conf/conf_sap.c: correct return of ossl_config_int() in UEFI system

### DIFF
--- a/crypto/conf/conf_sap.c
+++ b/crypto/conf/conf_sap.c
@@ -66,6 +66,8 @@ int ossl_config_int(const OPENSSL_INIT_SETTINGS *settings)
 
 #ifndef OPENSSL_SYS_UEFI
     ret = CONF_modules_load_file(filename, appname, flags);
+#else
+    ret = 1;
 #endif
     openssl_configured = 1;
     return ret;


### PR DESCRIPTION
FIX: https://github.com/openssl/openssl/issues/21299

ret in ossl_config_int() only used to check return value of CONF_modules_load_file(), should set it to 1 if in UEFI system.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
