### PR TITLE
Adds a configuration target for arm ios simulators

### DIFF
--- a/Configurations/15-ios.conf
+++ b/Configurations/15-ios.conf
@@ -1,9 +1,10 @@
 #### iPhoneOS/iOS
 #
-# It takes recent enough Xcode to use following two targets. It shouldn't
-# be a problem by now, but if they don't work, original targets below
-# that depend on manual definition of environment variables should still
-# work...
+# `xcrun` targets require an Xcode that can determine the correct C compiler via
+# `xcrun -sdk iphoneos`. This has been standard in Xcode for a while now - any recent
+# Xcode should do.  If the Xcode on the build machine doesn't support this then use
+# the legacy targets at the end of this file. These require manual definition of
+# environment variables.
 #
 my %targets = (
     "ios-common" => {
@@ -33,6 +34,30 @@ my %targets = (
     "iossimulator-xcrun" => {
         inherit_from     => [ "ios-common" ],
         CC               => "xcrun -sdk iphonesimulator cc",
+    },
+    "iossimulator-arm64-xcrun" => {
+        inherit_from     => [ "ios-common" ],
+        CC               => "xcrun -sdk iphonesimulator cc",
+        cflags           => add("-arch arm64 -mios-simulator-version-min=7.0.0 -fno-common"),
+        bn_ops           => "SIXTY_FOUR_BIT_LONG",
+        asm_arch         => 'aarch64',
+        perlasm_scheme   => "ios64",
+    },
+    "iossimulator-i386-xcrun" => {
+        inherit_from     => [ "ios-common" ],
+        CC               => "xcrun -sdk iphonesimulator cc",
+        cflags           => add("-arch i386 -mios-simulator-version-min=7.0.0 -fno-common"),
+        bn_ops           => "BN_LLONG",
+        asm_arch         => 'x86',
+        perlasm_scheme   => "macosx",
+    },
+    "iossimulator-x86_64-xcrun" => {
+        inherit_from     => [ "ios-common" ],
+        CC               => "xcrun -sdk iphonesimulator cc",
+        cflags           => add("-arch x86_64 -mios-simulator-version-min=7.0.0 -fno-common"),
+        bn_ops           => "SIXTY_FOUR_BIT_LONG",
+        asm_arch         => 'x86_64',
+        perlasm_scheme   => "macosx",
     },
 # It takes three prior-set environment variables to make it work:
 #


### PR DESCRIPTION
Adds a build configuration target for iOS arm simulator.

Fixes: https://github.com/openssl/openssl/issues/21287

Probably fixes: 
https://github.com/openssl/openssl/issues/12691
https://github.com/openssl/openssl/issues/8008

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->
