### PR TITLE
Cleanse data in send stream buffers if SSL_OP_CLEANSE_PLAINTEXT is set

### DIFF
--- a/doc/man3/SSL_CTX_set_options.pod
+++ b/doc/man3/SSL_CTX_set_options.pod
@@ -141,6 +141,11 @@ responsible for cleansing all other buffers. Most notably, this
 applies to buffers passed to functions like L<SSL_read(3)>,
 L<SSL_peek(3)> but also like L<SSL_write(3)>.
 
+This option can be set differently on individual QUIC stream objects.
+Because the data to send is buffered by OpenSSL until it is acknowledged
+by the peer this option when set will cause also cleansing the buffered
+sent data once it is acknowledged by the peer.
+
 =item SSL_OP_COOKIE_EXCHANGE
 
 Turn on Cookie Exchange as described in RFC4347 Section 4.2.1. Only affects

--- a/doc/man3/SSL_CTX_set_options.pod
+++ b/doc/man3/SSL_CTX_set_options.pod
@@ -129,7 +129,7 @@ connection. Only available when using the deprecated DTLSv1_client_method() API.
 
 =item SSL_OP_CLEANSE_PLAINTEXT
 
-By default TLS connections keep a copy of received plaintext
+By default TLS and QUIC SSL objects keep a copy of received plaintext
 application data in a static buffer until it is overwritten by the
 next portion of data. When enabling SSL_OP_CLEANSE_PLAINTEXT
 deciphered application data is cleansed by calling OPENSSL_cleanse(3)
@@ -141,10 +141,13 @@ responsible for cleansing all other buffers. Most notably, this
 applies to buffers passed to functions like L<SSL_read(3)>,
 L<SSL_peek(3)> but also like L<SSL_write(3)>.
 
-This option can be set differently on individual QUIC stream objects.
-Because the data to send is buffered by OpenSSL until it is acknowledged
-by the peer this option when set will cause also cleansing the buffered
-sent data once it is acknowledged by the peer.
+TLS connections do not buffer data to be sent in plaintext. QUIC stream
+objects do buffer plaintext data to be sent and this option will also cause
+that data to be cleansed when it is discarded.
+
+This option can be set differently on individual QUIC stream objects and
+has no effect on QUIC connection objects (except where a default stream is
+being used).
 
 =item SSL_OP_COOKIE_EXCHANGE
 

--- a/include/internal/quic_stream.h
+++ b/include/internal/quic_stream.h
@@ -296,6 +296,11 @@ void ossl_quic_sstream_adjust_iov(size_t len,
                                   size_t num_iov);
 
 /*
+ * Sets flag to cleanse the buffered data when it is acked.
+ */
+void ossl_quic_sstream_set_cleanse(QUIC_SSTREAM *qss, int cleanse);
+
+/*
  * QUIC Receive Stream Manager
  * ===========================
  *

--- a/include/internal/ring_buf.h
+++ b/include/internal/ring_buf.h
@@ -47,9 +47,12 @@ static ossl_inline int ring_buf_init(struct ring_buf *r)
     return 1;
 }
 
-static ossl_inline void ring_buf_destroy(struct ring_buf *r)
+static ossl_inline void ring_buf_destroy(struct ring_buf *r, int cleanse)
 {
-    OPENSSL_free(r->start);
+    if (cleanse)
+        OPENSSL_clear_free(r->start, r->alloc);
+    else
+        OPENSSL_free(r->start);
     r->start = NULL;
     r->alloc = 0;
 }
@@ -213,7 +216,8 @@ static ossl_inline void ring_buf_cpop_range(struct ring_buf *r,
         r->head_offset = r->ctail_offset;
 }
 
-static ossl_inline int ring_buf_resize(struct ring_buf *r, size_t num_bytes)
+static ossl_inline int ring_buf_resize(struct ring_buf *r, size_t num_bytes,
+                                       int cleanse)
 {
     struct ring_buf rnew = {0};
     const unsigned char *src = NULL;
@@ -251,9 +255,9 @@ static ossl_inline int ring_buf_resize(struct ring_buf *r, size_t num_bytes)
     }
 
     assert(rnew.head_offset == r->head_offset);
-    rnew.ctail_offset   = r->ctail_offset;
+    rnew.ctail_offset = r->ctail_offset;
 
-    OPENSSL_free(r->start);
+    ring_buf_destroy(r, cleanse);
     memcpy(r, &rnew, sizeof(*r));
     return 1;
 }

--- a/ssl/quic/quic_channel.c
+++ b/ssl/quic/quic_channel.c
@@ -2694,16 +2694,18 @@ static int ch_init_new_stream(QUIC_CHANNEL *ch, QUIC_STREAM *qs,
     int server_init = ossl_quic_stream_is_server_init(qs);
     int local_init = (ch->is_server == server_init);
     int is_uni = !ossl_quic_stream_is_bidi(qs);
+    int cleanse = (ch->tls->ctx->options & SSL_OP_CLEANSE_PLAINTEXT) != 0;
 
-    if (can_send && (qs->sstream = ossl_quic_sstream_new(INIT_APP_BUF_LEN)) == NULL)
-        goto err;
+    if (can_send) {
+        if ((qs->sstream = ossl_quic_sstream_new(INIT_APP_BUF_LEN)) == NULL)
+            goto err;
+        ossl_quic_sstream_set_cleanse(qs->sstream, cleanse);
+    }
 
     if (can_recv) {
         if ((qs->rstream = ossl_quic_rstream_new(NULL, NULL, 0)) == NULL)
             goto err;
-        ossl_quic_rstream_set_cleanse(qs->rstream,
-                                      (ch->tls->ctx->options
-                                       & SSL_OP_CLEANSE_PLAINTEXT) != 0);
+        ossl_quic_rstream_set_cleanse(qs->rstream, cleanse);
     }
 
     /* TXFC */

--- a/ssl/quic/quic_rstream.c
+++ b/ssl/quic/quic_rstream.c
@@ -30,7 +30,7 @@ QUIC_RSTREAM *ossl_quic_rstream_new(QUIC_RXFC *rxfc,
         return NULL;
 
     ring_buf_init(&ret->rbuf);
-    if (!ring_buf_resize(&ret->rbuf, rbuf_size)) {
+    if (!ring_buf_resize(&ret->rbuf, rbuf_size, 0)) {
         OPENSSL_free(ret);
         return NULL;
     }
@@ -43,11 +43,14 @@ QUIC_RSTREAM *ossl_quic_rstream_new(QUIC_RXFC *rxfc,
 
 void ossl_quic_rstream_free(QUIC_RSTREAM *qrs)
 {
+    int cleanse;
+
     if (qrs == NULL)
         return;
 
+    cleanse = qrs->fl.cleanse;
     ossl_sframe_list_destroy(&qrs->fl);
-    ring_buf_destroy(&qrs->rbuf);
+    ring_buf_destroy(&qrs->rbuf, cleanse);
     OPENSSL_free(qrs);
 }
 
@@ -281,7 +284,7 @@ int ossl_quic_rstream_resize_rbuf(QUIC_RSTREAM *qrs, size_t rbuf_size)
     if (ossl_sframe_list_is_head_locked(&qrs->fl))
         return 0;
 
-    if (!ring_buf_resize(&qrs->rbuf, rbuf_size))
+    if (!ring_buf_resize(&qrs->rbuf, rbuf_size, qrs->fl.cleanse))
         return 0;
 
     return 1;

--- a/ssl/quic/quic_sstream.c
+++ b/ssl/quic/quic_sstream.c
@@ -52,6 +52,7 @@ struct quic_sstream_st {
     unsigned int    have_final_size     : 1;
     unsigned int    sent_final_size     : 1;
     unsigned int    acked_final_size    : 1;
+    unsigned int    cleanse             : 1;
 };
 
 static void qss_cull(QUIC_SSTREAM *qss);
@@ -349,7 +350,8 @@ static void qss_cull(QUIC_SSTREAM *qss)
      * can only cull contiguous areas at the start of the ring buffer anyway.
      */
     if (h != NULL)
-        ring_buf_cpop_range(&qss->ring_buf, h->range.start, h->range.end, 0);
+        ring_buf_cpop_range(&qss->ring_buf, h->range.start, h->range.end,
+                            qss->cleanse);
 }
 
 int ossl_quic_sstream_set_buffer_size(QUIC_SSTREAM *qss, size_t num_bytes)
@@ -409,4 +411,9 @@ void ossl_quic_sstream_adjust_iov(size_t len,
 
         running += iovlen;
     }
+}
+
+void ossl_quic_sstream_set_cleanse(QUIC_SSTREAM *qss, int cleanse)
+{
+    qss->cleanse = cleanse;
 }

--- a/ssl/quic/quic_sstream.c
+++ b/ssl/quic/quic_sstream.c
@@ -66,8 +66,8 @@ QUIC_SSTREAM *ossl_quic_sstream_new(size_t init_buf_size)
         return NULL;
 
     ring_buf_init(&qss->ring_buf);
-    if (!ring_buf_resize(&qss->ring_buf, init_buf_size)) {
-        ring_buf_destroy(&qss->ring_buf);
+    if (!ring_buf_resize(&qss->ring_buf, init_buf_size, 0)) {
+        ring_buf_destroy(&qss->ring_buf, 0);
         OPENSSL_free(qss);
         return NULL;
     }
@@ -84,7 +84,7 @@ void ossl_quic_sstream_free(QUIC_SSTREAM *qss)
 
     ossl_uint_set_destroy(&qss->new_set);
     ossl_uint_set_destroy(&qss->acked_set);
-    ring_buf_destroy(&qss->ring_buf);
+    ring_buf_destroy(&qss->ring_buf, qss->cleanse);
     OPENSSL_free(qss);
 }
 
@@ -356,7 +356,7 @@ static void qss_cull(QUIC_SSTREAM *qss)
 
 int ossl_quic_sstream_set_buffer_size(QUIC_SSTREAM *qss, size_t num_bytes)
 {
-    return ring_buf_resize(&qss->ring_buf, num_bytes);
+    return ring_buf_resize(&qss->ring_buf, num_bytes, qss->cleanse);
 }
 
 size_t ossl_quic_sstream_get_buffer_size(QUIC_SSTREAM *qss)


### PR DESCRIPTION
This is different from TLS where the encryption is done in place and so there is no need to cleanse the data to be sent.

Also cleanse the ring buffer in send and receive streams on release if the cleanse flag is set.