### PR TITLE
Do not use stitched AES-GCM implementation on PPC32

### DIFF
--- a/crypto/modes/build.info
+++ b/crypto/modes/build.info
@@ -33,11 +33,11 @@ IF[{- !$disabled{asm} -}]
   $MODESDEF_parisc20_64=$MODESDEF_parisc11
 
   $MODESASM_ppc32=ghashp8-ppc.s
-  IF[{- $target{sys_id} ne "AIX" && $target{sys_id} ne "MACOSX" -}]
-    $MODESASM_ppc32=ghashp8-ppc.s aes-gcm-ppc.s
-  ENDIF
   $MODESDEF_ppc32=
   $MODESASM_ppc64=$MODESASM_ppc32
+  IF[{- $target{sys_id} ne "AIX" && $target{sys_id} ne "MACOSX" -}]
+    $MODESASM_ppc64=$MODESASM_ppc32 aes-gcm-ppc.s
+  ENDIF
   $MODESDEF_ppc64=$MODESDEF_ppc32
 
   $MODESASM_c64xplus=ghash-c64xplus.s

--- a/providers/implementations/ciphers/cipher_aes_gcm_hw.c
+++ b/providers/implementations/ciphers/cipher_aes_gcm_hw.c
@@ -141,7 +141,7 @@ static const PROV_GCM_HW aes_gcm = {
 # include "cipher_aes_gcm_hw_t4.inc"
 #elif defined(AES_PMULL_CAPABLE) && defined(AES_GCM_ASM)
 # include "cipher_aes_gcm_hw_armv8.inc"
-#elif defined(PPC_AES_GCM_CAPABLE)
+#elif defined(PPC_AES_GCM_CAPABLE) && defined(_ARCH_PPC64)
 # include "cipher_aes_gcm_hw_ppc.inc"
 #elif defined(RV64I_ZKND_ZKNE_CAPABLE)
 # include "cipher_aes_gcm_hw_rv64i_zknd_zkne.inc"


### PR DESCRIPTION
The implementation is not usable there at all.
Fixes #21301
