### PR TITLE
Fix OSSL_PROVIDER_try_load() retain_fallbacks doc

### DIFF
--- a/doc/man3/OSSL_PROVIDER.pod
+++ b/doc/man3/OSSL_PROVIDER.pod
@@ -97,8 +97,8 @@ the environment variable OPENSSL_MODULES if set.
 
 OSSL_PROVIDER_try_load() functions like OSSL_PROVIDER_load(), except that
 it does not disable the fallback providers if the provider cannot be
-loaded and initialized or if I<retain_fallbacks> is zero.
-If the provider loads successfully and I<retain_fallbacks> is nonzero, the
+loaded and initialized or if I<retain_fallbacks> is nonzero.
+If the provider loads successfully and I<retain_fallbacks> is zero, the
 fallback providers are disabled.
 
 OSSL_PROVIDER_unload() unloads the given provider.


### PR DESCRIPTION
CLA: trivial

Fixes the documentation relating to the `retain_fallbacks` parameter of `OSSL_PROVIDER_try_load()`. I think the boolean logic in the documentation is inverted. The fallback providers are retained if `retain_fallbacks` is non-zero.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
~- [ ] documentation is added or updated~
~- [ ] tests are added or updated~
