### PR TITLE
Fix typos newly found by codespell in branch 3.0

### DIFF
--- a/doc/man1/openssl-genpkey.pod.in
+++ b/doc/man1/openssl-genpkey.pod.in
@@ -333,7 +333,7 @@ The B<algorithm> option must be B<"DH">.
 =item "default"
 
 Selects a default type based on the B<algorithm>. This is used by the
-OpenSSL default provider to set the type for backwards compatability.
+OpenSSL default provider to set the type for backwards compatibility.
 If B<algorithm> is B<"DH"> then B<"generator"> is used.
 If B<algorithm> is B<"DHX"> then B<"fips186_2"> is used.
 

--- a/doc/man1/openssl-verification-options.pod
+++ b/doc/man1/openssl-verification-options.pod
@@ -92,7 +92,7 @@ It does not have a negative trust attribute rejecting the given use.
 =item *
 
 It has a positive trust attribute accepting the given use
-or (by default) one of the following compatibilty conditions apply:
+or (by default) one of the following compatibility conditions apply:
 It is self-signed or the B<-partial_chain> option is given
 (which corresponds to the B<X509_V_FLAG_PARTIAL_CHAIN> flag being set).
 


### PR DESCRIPTION
Fix only typos in `doc/man*` for inclusion in branch 3.0.

CLA: trivial

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
