### PR TITLE
Delete unreachable code

### DIFF
--- a/crypto/bio/bio_print.c
+++ b/crypto/bio/bio_print.c
@@ -706,9 +706,7 @@ fmtfp(char **sbuffer,
         fconvert[fplace++] = "0123456789"[fracpart % 10];
         fracpart = (fracpart / 10);
     }
-
-    if (fplace == sizeof(fconvert))
-        fplace--;
+  
     fconvert[fplace] = 0;
 
     /* convert exponent part */

--- a/crypto/bio/bio_print.c
+++ b/crypto/bio/bio_print.c
@@ -706,7 +706,7 @@ fmtfp(char **sbuffer,
         fconvert[fplace++] = "0123456789"[fracpart % 10];
         fracpart = (fracpart / 10);
     }
-  
+
     fconvert[fplace] = 0;
 
     /* convert exponent part */


### PR DESCRIPTION
crypto/bio/bio_print.c 
The purpose of adding the conditional operator on line 710 is to check if the value of the variable 'fplace' exceeds the size of the array 'fconvert', and to reduce the value of 'fplace' by 1, so that later on we can set the value to zero of the array element with the index 'fplace' and not make any calls beyond the array edges. However, the condition on line 710 will always be false, because the size of 'fconvert' is strictly specified at the beginning of the 'fmtfp()' function (line 571), so it is reasonable to remove this conditional operator, as well as the unreachable decrementation code of the variable 'fplace'.

crypto/rsa/rsa_mp.c
After initializing the variable cap, there are no scenarios in the function ossl_rsa_multip_cap() where the value of cap can be greater than 5, so it is reasonable to remove the conditional statement on line 111 as well as the unreachable code on line 112.

CLA: trivial