### PR TITLE
Remove unused internal functions evp_pkey_ctx_get1_id_prov and evp_pkey_ctx_get1_id_len_prov

### DIFF
--- a/crypto/evp/pmeth_lib.c
+++ b/crypto/evp/pmeth_lib.c
@@ -1264,16 +1264,6 @@ static int get1_id_data(EVP_PKEY_CTX *ctx, void *id, size_t *id_len)
     return ret;
 }
 
-int evp_pkey_ctx_get1_id_prov(EVP_PKEY_CTX *ctx, void *id)
-{
-    return get1_id_data(ctx, id, NULL);
-}
-
-int evp_pkey_ctx_get1_id_len_prov(EVP_PKEY_CTX *ctx, size_t *id_len)
-{
-    return get1_id_data(ctx, NULL, id_len);
-}
-
 int EVP_PKEY_CTX_get1_id(EVP_PKEY_CTX *ctx, void *id)
 {
     return EVP_PKEY_CTX_ctrl(ctx, -1, -1, EVP_PKEY_CTRL_GET1_ID, 0, (void*)id);

--- a/crypto/evp/pmeth_lib.c
+++ b/crypto/evp/pmeth_lib.c
@@ -1234,36 +1234,6 @@ int EVP_PKEY_CTX_set1_id(EVP_PKEY_CTX *ctx, const void *id, int len)
                              EVP_PKEY_CTRL_SET1_ID, (int)len, (void*)(id));
 }
 
-static int get1_id_data(EVP_PKEY_CTX *ctx, void *id, size_t *id_len)
-{
-    int ret;
-    void *tmp_id = NULL;
-    OSSL_PARAM params[2], *p = params;
-
-    if (!EVP_PKEY_CTX_IS_SIGNATURE_OP(ctx)) {
-        ERR_raise(ERR_LIB_EVP, EVP_R_COMMAND_NOT_SUPPORTED);
-        /* Uses the same return values as EVP_PKEY_CTX_ctrl */
-        return -2;
-    }
-
-    *p++ = OSSL_PARAM_construct_octet_ptr(OSSL_PKEY_PARAM_DIST_ID,
-                                          &tmp_id, 0);
-    *p++ = OSSL_PARAM_construct_end();
-
-    ret = evp_pkey_ctx_get_params_strict(ctx, params);
-    if (ret == -2) {
-        ERR_raise(ERR_LIB_EVP, EVP_R_COMMAND_NOT_SUPPORTED);
-    } else if (ret > 0) {
-        size_t tmp_id_len = params[0].return_size;
-
-        if (id != NULL)
-            memcpy(id, tmp_id, tmp_id_len);
-        if (id_len != NULL)
-            *id_len = tmp_id_len;
-    }
-    return ret;
-}
-
 int EVP_PKEY_CTX_get1_id(EVP_PKEY_CTX *ctx, void *id)
 {
     return EVP_PKEY_CTX_ctrl(ctx, -1, -1, EVP_PKEY_CTRL_GET1_ID, 0, (void*)id);

--- a/crypto/evp/pmeth_lib.c
+++ b/crypto/evp/pmeth_lib.c
@@ -1203,31 +1203,6 @@ int EVP_PKEY_CTX_set_kem_op(EVP_PKEY_CTX *ctx, const char *op)
     return EVP_PKEY_CTX_set_params(ctx, params);
 }
 
-int evp_pkey_ctx_set1_id_prov(EVP_PKEY_CTX *ctx, const void *id, int len)
-{
-    OSSL_PARAM params[2], *p = params;
-    int ret;
-
-    if (!EVP_PKEY_CTX_IS_SIGNATURE_OP(ctx)) {
-        ERR_raise(ERR_LIB_EVP, EVP_R_COMMAND_NOT_SUPPORTED);
-        /* Uses the same return values as EVP_PKEY_CTX_ctrl */
-        return -2;
-    }
-
-    *p++ = OSSL_PARAM_construct_octet_string(OSSL_PKEY_PARAM_DIST_ID,
-                                             /*
-                                              * Cast away the const. This is
-                                              * read only so should be safe
-                                              */
-                                             (void *)id, (size_t)len);
-    *p++ = OSSL_PARAM_construct_end();
-
-    ret = evp_pkey_ctx_set_params_strict(ctx, params);
-    if (ret == -2)
-        ERR_raise(ERR_LIB_EVP, EVP_R_COMMAND_NOT_SUPPORTED);
-    return ret;
-}
-
 int EVP_PKEY_CTX_set1_id(EVP_PKEY_CTX *ctx, const void *id, int len)
 {
     return EVP_PKEY_CTX_ctrl(ctx, -1, -1,

--- a/include/crypto/evp.h
+++ b/include/crypto/evp.h
@@ -895,8 +895,6 @@ EVP_MD_CTX *evp_md_ctx_new_ex(EVP_PKEY *pkey, const ASN1_OCTET_STRING *id,
 int evp_pkey_name2type(const char *name);
 const char *evp_pkey_type2name(int type);
 
-int evp_pkey_ctx_set1_id_prov(EVP_PKEY_CTX *ctx, const void *id, int len);
-
 int evp_pkey_ctx_use_cached_data(EVP_PKEY_CTX *ctx);
 # endif /* !defined(FIPS_MODULE) */
 

--- a/include/crypto/evp.h
+++ b/include/crypto/evp.h
@@ -896,8 +896,6 @@ int evp_pkey_name2type(const char *name);
 const char *evp_pkey_type2name(int type);
 
 int evp_pkey_ctx_set1_id_prov(EVP_PKEY_CTX *ctx, const void *id, int len);
-int evp_pkey_ctx_get1_id_prov(EVP_PKEY_CTX *ctx, void *id);
-int evp_pkey_ctx_get1_id_len_prov(EVP_PKEY_CTX *ctx, size_t *id_len);
 
 int evp_pkey_ctx_use_cached_data(EVP_PKEY_CTX *ctx);
 # endif /* !defined(FIPS_MODULE) */


### PR DESCRIPTION
Fixes #20701 
Remove unused internal functions evp_pkey_ctx_get1_id_prov and evp_pkey_ctx_get1_id_len_prov
